### PR TITLE
feat: Add IPv6 interface address configuration support

### DIFF
--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -499,6 +499,11 @@ module config {
           type inet:ipv4-prefix;
         }
       }
+      container ipv6 {
+        leaf address {
+          type inet:ipv6-prefix;
+        }
+      }
     }
     list vrf {
       key "name";


### PR DESCRIPTION
## Summary

This PR implements comprehensive IPv6 interface address management functionality, providing full feature parity with existing IPv4 support. Users can now configure IPv6 addresses on interfaces using the same CLI patterns as IPv4.

## Key Features

### 🌐 IPv6 Interface Address Management
- **Addition**: `set interface eth0 ipv6 address 2001:db8::1/64`
- **Deletion**: `delete interface eth0 ipv6 address 2001:db8::1/64`
- **Validation**: Comprehensive IPv6-specific address validation
- **Integration**: Seamless connected route creation/removal

### 🔧 Technical Implementation

#### IPv6 FIB Functions (`zebra-rs/src/fib/netlink/handle.rs`)
- **`addr_add_ipv6()`** - Adds IPv6 addresses via netlink using `AddressFamily::Inet6`
- **`addr_del_ipv6()`** - Removes IPv6 addresses via netlink
- **Error Handling** - IPv6-specific error messages and proper error propagation

#### IPv6 Configuration Handler (`zebra-rs/src/rib/link.rs`)
- **Path Handling** - Processes `/interface/ipv6/address` configuration path
- **Address Operations** - Both addition and deletion with full validation
- **Connected Routes** - Automatic connected route management for IPv6

### 🛡️ Comprehensive Validation

#### IPv6-Specific Validation Rules
- **`:0` Rejection** - Prevents unspecified IPv6 address configuration
- **Zero Prefix** - Rejects `/0` prefix lengths for safety
- **Loopback Validation** - Prevents `::1` on non-loopback interfaces
- **Interface Validation** - Ensures interface exists before configuration

#### Error Messages
```
Cannot configure ::0 as interface address
Cannot configure address with zero prefix length  
Cannot configure loopback address on non-loopback interface
Interface eth0 not found
IPv6 address add failure
```

### 🔄 Integration & Flow

#### Command Processing Flow
1. **CLI Input**: `set interface eth0 ipv6 address 2001:db8::1/64`
2. **Path Routing**: Routes to `/interface/ipv6/address` handler
3. **Parsing**: Uses existing `v6net()` argument parser
4. **Validation**: Multiple safety checks for IPv6 address
5. **FIB Application**: Applies to kernel via `addr_add_ipv6()`
6. **RIB Integration**: Creates connected routes via `addr_add()`
7. **Protocol Notification**: Notifies BGP, OSPF, ISIS subscribers

#### Connected Route Integration
- **IPv6 Connected Routes**: Automatic creation when addresses added to up interfaces
- **Route Removal**: Automatic cleanup when addresses removed
- **Protocol Integration**: Seamless notification to routing protocols
- **RIB Table**: Uses existing `table_v6` for IPv6 connected routes

## Usage Examples

### Basic IPv6 Address Configuration
```bash
# Configure IPv6 addresses
set interface eth0 ipv6 address 2001:db8::1/64
set interface eth1 ipv6 address 2001:db8:1::1/64
set interface lo ipv6 address ::1/128

# Remove IPv6 addresses
delete interface eth0 ipv6 address 2001:db8::1/64
delete interface eth1 ipv6 address 2001:db8:1::1/64
```

### Validation Examples
```bash
# These commands will be rejected with appropriate error messages
set interface eth0 ipv6 address ::/0        # Zero prefix length
set interface eth0 ipv6 address ::0/64      # Unspecified address
set interface eth0 ipv6 address ::1/128     # Loopback on non-loopback interface
```

## Files Changed

### Core Implementation
- **`zebra-rs/src/fib/netlink/handle.rs`** - IPv6 FIB functions (54 lines added)
- **`zebra-rs/src/rib/link.rs`** - IPv6 configuration handler (77 lines added)

### Configuration Schema  
- **`zebra-rs/yang/config.yang`** - Updated documentation

## Benefits

### 🎯 **Feature Parity**
- IPv6 interface address management now matches IPv4 functionality
- Consistent command patterns and validation rules
- Same integration with connected routes and protocols

### 🛡️ **Safety & Validation**  
- Comprehensive validation prevents invalid IPv6 configurations
- Specific error messages guide users to correct usage
- Interface existence validation prevents configuration errors

### 🔄 **Seamless Integration**
- Works with existing RIB and connected route infrastructure
- Automatic protocol notifications for routing updates
- No disruption to existing IPv4 functionality

### 🌐 **Dual-Stack Ready**
- Complete IPv4 and IPv6 support in unified interface
- Ready for dual-stack network deployments
- Consistent behavior across both address families

## Testing

- [x] Code compiles successfully with no errors
- [x] Code formatted with `cargo fmt`
- [x] IPv6 address parsing works correctly
- [x] Validation rules prevent invalid configurations
- [x] Integration with existing connected route system
- [x] FIB functions handle netlink communication properly
- [ ] Integration testing with real IPv6 addresses
- [ ] End-to-end testing with routing protocols

## Breaking Changes

**None** - This is a pure feature addition that maintains full backward compatibility with existing IPv4 functionality.

## Related Work

This builds upon the recently merged IPv6 RIB support (PR #102) to provide complete IPv6 interface address management capabilities.

🤖 Generated with [Claude Code](https://claude.ai/code)