### PR TITLE
feat: Update rustfmt.toml edition to 2024

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-edition = "2021"
+edition = "2024"


### PR DESCRIPTION
## Summary

This PR updates the rustfmt configuration to use Rust edition 2024, completing the migration from edition 2021 to 2024 across the entire project.

## Changes

- **rustfmt.toml**: Updated `edition = "2021"` to `edition = "2024"`

## Context

This follows PR #105 that updated all Cargo.toml files to use edition 2024. The rustfmt.toml file also needs to be updated to ensure that code formatting follows the same edition standards as compilation.

## Why This Matters

The rustfmt.toml file controls how `cargo fmt` formats code. Having it on a different edition than the actual Cargo.toml files could lead to:
- Inconsistent formatting behavior
- Potential formatting that doesn't align with edition 2024 standards
- Confusion about which edition rules are being applied

## Testing ✅

- ✅ `make format` - Formatting works correctly with edition 2024
- ✅ `cargo fmt --all` - All files format without issues
- ✅ No formatting changes were made (indicating consistency)

## Impact

Ensures that rustfmt uses edition 2024 formatting rules, maintaining complete consistency with the project's Rust edition configuration across all workspace members.

## Files Changed
- `rustfmt.toml` - Edition update (1 line change)

This completes the full migration to Rust edition 2024\! 🦀

🤖 Generated with [Claude Code](https://claude.ai/code)