### PR TITLE
feat: Show hostname for L1 ISIS neighbors and clean up debug prints

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -150,10 +150,10 @@ impl Bgp {
         match TcpListener::bind("0.0.0.0:179").await {
             Ok(listener) => {
                 ipv4_bound = true;
-                println!("Successfully bound to IPv4 0.0.0.0:179");
+                // println!("Successfully bound to IPv4 0.0.0.0:179");
                 let tx_ipv4 = tx.clone();
                 self.listen_task = Some(Task::spawn(async move {
-                    println!("BGP listening on 0.0.0.0:179");
+                    // println!("BGP listening on 0.0.0.0:179");
                     loop {
                         match listener.accept().await {
                             Ok((socket, sockaddr)) => {
@@ -179,10 +179,10 @@ impl Bgp {
         match create_ipv6_listener() {
             Ok(listener) => {
                 ipv6_bound = true;
-                println!("Successfully bound to IPv6 [::]:179");
+                // println!("Successfully bound to IPv6 [::]:179");
                 let tx_ipv6 = tx_clone;
                 self.listen_task6 = Some(Task::spawn(async move {
-                    println!("BGP listening on [::]:179");
+                    // println!("BGP listening on [::]:179");
                     loop {
                         match listener.accept().await {
                             Ok((socket, sockaddr)) => {

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -211,12 +211,12 @@ impl Bgp {
         }
 
         // Log which protocols are bound
-        match (ipv4_bound, ipv6_bound) {
-            (true, true) => println!("BGP dual-stack: listening on both IPv4 and IPv6"),
-            (true, false) => println!("BGP IPv4-only: listening on 0.0.0.0:179"),
-            (false, true) => println!("BGP IPv6-only: listening on [::]:179"),
-            (false, false) => unreachable!(),
-        }
+        // match (ipv4_bound, ipv6_bound) {
+        //     (true, true) => println!("BGP dual-stack: listening on both IPv4 and IPv6"),
+        //     (true, false) => println!("BGP IPv4-only: listening on 0.0.0.0:179"),
+        //     (false, true) => println!("BGP IPv6-only: listening on [::]:179"),
+        //     (false, false) => unreachable!(),
+        // }
 
         Ok(())
     }

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -470,7 +470,6 @@ impl Isis {
                     self.process_cm_msg(msg);
                 }
                 Some(msg) = self.show.rx.recv() => {
-                    println!("XXX Show {:?}", msg);
                     self.process_show_msg(msg).await;
                 }
                 Some(msg) = self.rx.recv() => {

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -96,7 +96,7 @@ pub fn show(top: &Isis, _args: Args, json: bool) -> String {
         for (_, nbr) in &link.state.nbrs.l1 {
             let rem = nbr.hold_timer.as_ref().map_or(0, |timer| timer.rem_sec());
             let system_id =
-                if let Some((hostname, _)) = top.hostname.get(&Level::L2).get(&nbr.pdu.source_id) {
+                if let Some((hostname, _)) = top.hostname.get(&Level::L1).get(&nbr.pdu.source_id) {
                     hostname.clone()
                 } else {
                     nbr.pdu.source_id.to_string()
@@ -147,13 +147,12 @@ pub fn show(top: &Isis, _args: Args, json: bool) -> String {
     buf
 }
 
-fn show_entry(buf: &mut String, top: &Isis, nbr: &Neighbor) {
-    let system_id =
-        if let Some((hostname, _)) = top.hostname.get(&Level::L2).get(&nbr.pdu.source_id) {
-            hostname.clone()
-        } else {
-            nbr.pdu.source_id.to_string()
-        };
+fn show_entry(buf: &mut String, top: &Isis, nbr: &Neighbor, level: Level) {
+    let system_id = if let Some((hostname, _)) = top.hostname.get(&level).get(&nbr.pdu.source_id) {
+        hostname.clone()
+    } else {
+        nbr.pdu.source_id.to_string()
+    };
     writeln!(buf, " {}", system_id).unwrap();
 
     writeln!(
@@ -225,11 +224,11 @@ pub fn show_detail(top: &Isis, _args: Args, _json: bool) -> String {
     for (_, link) in top.links.iter() {
         // Show Level-1 neighbors
         for (_, adj) in &link.state.nbrs.l1 {
-            show_entry(&mut buf, top, adj);
+            show_entry(&mut buf, top, adj, Level::L1);
         }
         // Show Level-2 neighbors
         for (_, adj) in &link.state.nbrs.l2 {
-            show_entry(&mut buf, top, adj);
+            show_entry(&mut buf, top, adj, Level::L2);
         }
     }
 

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -516,7 +516,7 @@ impl Rib {
                 match addr.addr {
                     IpNet::V4(v4_addr) => {
                         let prefix = v4_addr.apply_mask();
-                        println!("Connected: {:?} - adding to RIB (interface up)", prefix);
+                        // println!("Connected: {:?} - adding to RIB (interface up)", prefix);
                         let mut rib = RibEntry::new(RibType::Connected);
                         rib.ifindex = addr.ifindex;
                         rib.set_valid(true);
@@ -525,10 +525,10 @@ impl Rib {
                     }
                     IpNet::V6(v6_addr) => {
                         let prefix = v6_addr.apply_mask();
-                        println!(
-                            "Connected IPv6: {:?} - adding to RIB (interface up)",
-                            prefix
-                        );
+                        // println!(
+                        //     "Connected IPv6: {:?} - adding to RIB (interface up)",
+                        //     prefix
+                        // );
                         let mut rib = RibEntry::new(RibType::Connected);
                         rib.ifindex = addr.ifindex;
                         rib.set_valid(true);
@@ -550,10 +550,10 @@ impl Rib {
                 match addr.addr {
                     IpNet::V4(v4_addr) => {
                         let prefix = v4_addr.apply_mask();
-                        println!(
-                            "Connected: {:?} - removing from RIB (address deleted)",
-                            prefix
-                        );
+                        // println!(
+                        //     "Connected: {:?} - removing from RIB (address deleted)",
+                        //     prefix
+                        // );
                         let mut rib = RibEntry::new(RibType::Connected);
                         rib.ifindex = addr.ifindex;
                         let msg = Message::Ipv4Del { prefix, rib };
@@ -561,10 +561,10 @@ impl Rib {
                     }
                     IpNet::V6(v6_addr) => {
                         let prefix = v6_addr.apply_mask();
-                        println!(
-                            "Connected IPv6: {:?} - removing from RIB (address deleted)",
-                            prefix
-                        );
+                        // println!(
+                        //     "Connected IPv6: {:?} - removing from RIB (address deleted)",
+                        //     prefix
+                        // );
                         let mut rib = RibEntry::new(RibType::Connected);
                         rib.ifindex = addr.ifindex;
                         let msg = Message::Ipv6Del { prefix, rib };

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -19,13 +19,13 @@ impl Rib {
         let Some(link) = self.links.get(&ifindex) else {
             return;
         };
-        println!("link down: {}", link.name);
+        // println!("link down: {}", link.name);
 
         // Remove connected route.
         for addr4 in link.addr4.iter() {
             if let IpNet::V4(addr) = addr4.addr {
                 let prefix = addr.apply_mask();
-                println!("Connected: {:?} down - removing from RIB", prefix);
+                // println!("Connected: {:?} down - removing from RIB", prefix);
                 let mut rib = RibEntry::new(RibType::Connected);
                 rib.ifindex = ifindex;
                 let msg = Message::Ipv4Del { prefix, rib };
@@ -36,7 +36,7 @@ impl Rib {
         for addr6 in link.addr6.iter() {
             if let IpNet::V6(addr) = addr6.addr {
                 let prefix = addr.apply_mask();
-                println!("Connected IPv6: {:?} down - removing from RIB", prefix);
+                // println!("Connected IPv6: {:?} down - removing from RIB", prefix);
                 let mut rib = RibEntry::new(RibType::Connected);
                 rib.ifindex = ifindex;
                 let msg = Message::Ipv6Del { prefix, rib };
@@ -107,13 +107,13 @@ impl Rib {
         let Some(link) = self.links.get(&ifindex) else {
             return;
         };
-        println!("link up {}", link.name);
+        // println!("link up {}", link.name);
 
         // Add connected IPv4 routes when link comes up
         for addr4 in link.addr4.iter() {
             if let IpNet::V4(addr) = addr4.addr {
                 let prefix = addr.apply_mask();
-                println!("Connected: {:?} up - adding to RIB", prefix);
+                // println!("Connected: {:?} up - adding to RIB", prefix);
                 let mut rib = RibEntry::new(RibType::Connected);
                 rib.ifindex = ifindex;
                 rib.set_valid(true);
@@ -126,7 +126,7 @@ impl Rib {
         for addr6 in link.addr6.iter() {
             if let IpNet::V6(addr) = addr6.addr {
                 let prefix = addr.apply_mask();
-                println!("Connected IPv6: {:?} up - adding to RIB", prefix);
+                // println!("Connected IPv6: {:?} up - adding to RIB", prefix);
                 let mut rib = RibEntry::new(RibType::Connected);
                 rib.ifindex = ifindex;
                 rib.set_valid(true);
@@ -159,7 +159,7 @@ impl Rib {
             let mut replace = rib_replace(&mut self.table, prefix, entry.rtype);
             self.rib_selection(prefix, replace.pop()).await;
         } else {
-            println!("System route remove");
+            // println!("System route remove");
             let mut replace = rib_replace_system(&mut self.table, prefix, entry);
             self.rib_selection(prefix, replace.pop()).await;
         }
@@ -207,7 +207,7 @@ impl Rib {
             let mut replace = rib_replace_v6(&mut self.table_v6, prefix, entry.rtype);
             self.rib_selection_v6(prefix, replace.pop()).await;
         } else {
-            println!("IPv6 System route remove");
+            // println!("IPv6 System route remove");
             let mut replace = rib_replace_system_v6(&mut self.table_v6, prefix, entry);
             self.rib_selection_v6(prefix, replace.pop()).await;
         }
@@ -478,7 +478,7 @@ fn rib_add_system(table: &mut PrefixMap<Ipv4Net, RibEntries>, prefix: &Ipv4Net, 
                     let mut btree = BTreeMap::new();
 
                     for l in list.nexthops.iter() {
-                        println!("");
+                        // println!("");
                         btree.insert(l.metric, l.clone());
                     }
 
@@ -703,7 +703,7 @@ fn rib_add_system_v6(
                     let mut btree = BTreeMap::new();
 
                     for l in list.nexthops.iter() {
-                        println!("");
+                        // println!("");
                         btree.insert(l.metric, l.clone());
                     }
 


### PR DESCRIPTION
## Summary
- Fix ISIS neighbor hostname display for Level-1 neighbors
- Remove debug println\! statements throughout the codebase
- Update show_entry function to accept level parameter for correct hostname lookup

## Problem Fixed
The ISIS neighbor show commands were always looking up hostnames in the Level-2 hostname table, even for Level-1 neighbors. This caused Level-1 neighbors to display system IDs instead of hostnames when available.

## Changes Made

### ISIS Neighbor Display Fix
- Modified `show()` function to use Level-1 hostname table for L1 neighbors: `top.hostname.get(&Level::L1)`
- Updated `show_entry()` function signature to accept a `level: Level` parameter
- Updated all calls to `show_entry()` to pass the appropriate level (L1 or L2)

### Debug Print Cleanup
- Commented out debug `println\!` statements in:
  - `zebra-rs/src/rib/route.rs` - link up/down messages, route add/remove messages
  - `zebra-rs/src/rib/link.rs` - address configuration messages  
  - `zebra-rs/src/bgp/inst.rs` - BGP message processing
  - `zebra-rs/src/isis/inst.rs` - ISIS show command processing

## Test Plan
- [x] Code compiles successfully
- [x] ISIS neighbor display now correctly shows hostnames for both L1 and L2 neighbors
- [x] Debug output has been cleaned up for production use

🤖 Generated with [Claude Code](https://claude.ai/code)