### PR TITLE
fix: Correct ISIS IsNeighbor TLV handling

### DIFF
--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -66,18 +66,17 @@ pub fn hello_generate(ltop: &LinkTop, level: Level) -> IsisHello {
         );
     }
 
+    let mut neighbors = Vec::new();
     for (_, nbr) in ltop.state.nbrs.get(&level).iter() {
         if nbr.state == NfsmState::Init || nbr.state == NfsmState::Up {
             if let Some(mac) = nbr.mac {
-                hello.tlvs.push(
-                    IsisTlvIsNeighbor {
-                        octets: mac.octets(),
-                    }
-                    .into(),
-                );
+                neighbors.push(NeighborAddr {
+                    octets: mac.octets(),
+                })
             }
         }
     }
+    hello.tlvs.push(IsisTlvIsNeighbor { neighbors }.into());
     if ltop.config.hello_padding() == HelloPaddingPolicy::Always {
         hello.padding(ltop.state.mtu as usize);
     }

--- a/zebra-rs/src/isis/nfsm.rs
+++ b/zebra-rs/src/isis/nfsm.rs
@@ -95,8 +95,10 @@ fn nfsm_hello_has_mac(pdu: &IsisHello, mac: &Option<MacAddr>) -> bool {
 
     for tlv in &pdu.tlvs {
         if let IsisTlv::IsNeighbor(neigh) = tlv {
-            if addr.octets() == neigh.octets() {
-                return true;
+            for neighbor in neigh.neighbors.iter() {
+                if addr.octets() == neighbor.octets {
+                    return true;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
Fix bug in ISIS neighbor TLV handling where neighbors were incorrectly added as multiple TLVs instead of a single TLV containing all neighbors.

## Problem Fixed
The ISIS protocol specifies that the IS Neighbors TLV should contain a list of neighbor MAC addresses within a single TLV. The previous implementation was incorrectly:
- Creating multiple `IsisTlvIsNeighbor` TLVs, one for each neighbor
- Not properly iterating through the neighbors list when checking for MAC addresses

## Changes Made

### In `hello_generate()` (ifsm.rs):
- Changed to collect all neighbor MAC addresses into a vector first
- Create a single `IsisTlvIsNeighbor` TLV containing all neighbors
- This ensures protocol compliance with ISIS specification

### In `nfsm_hello_has_mac()` (nfsm.rs):
- Fixed to iterate through the `neighbors` vector within the TLV
- Previously was trying to access fields directly on the TLV struct
- Now correctly checks each neighbor in the list for MAC address match

## Technical Details
The `IsisTlvIsNeighbor` structure format:
```rust
IsisTlvIsNeighbor {
    neighbors: Vec<NeighborAddr>
}
```

Where each `NeighborAddr` contains the 6-byte MAC address of a neighbor.

## Test Plan
- [x] Code compiles successfully
- [x] ISIS neighbor detection works correctly
- [x] Hello packets now contain properly formatted IS Neighbors TLV

🤖 Generated with [Claude Code](https://claude.ai/code)