### PR TITLE
feat: Implement per-interface IS-IS read/write sockets

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -50,7 +50,7 @@ pub struct Isis {
     pub ctx: Context,
     pub tx: UnboundedSender<Message>,
     pub rx: UnboundedReceiver<Message>,
-    pub ptx: UnboundedSender<PacketMessage>,
+    // pub ptx: UnboundedSender<PacketMessage>,
     pub cm: ConfigChannel,
     pub callbacks: HashMap<String, Callback>,
     pub rib_tx: UnboundedSender<rib::Message>,
@@ -58,7 +58,7 @@ pub struct Isis {
     pub links: IsisLinks,
     pub show: ShowChannel,
     pub show_cb: HashMap<String, ShowCallback>,
-    pub sock: Arc<AsyncFd<Socket>>,
+    // pub sock: Arc<AsyncFd<Socket>>,
     pub config: IsisConfig,
     pub lsdb: Levels<Lsdb>,
     pub lsp_map: Levels<LspMap>,
@@ -106,15 +106,15 @@ impl Isis {
             tx: chan.tx.clone(),
         };
         let _ = rib_tx.send(msg);
-        let sock = Arc::new(AsyncFd::new(isis_socket().unwrap()).unwrap());
+        // let sock = Arc::new(AsyncFd::new(isis_socket().unwrap()).unwrap());
 
         let (tx, rx) = mpsc::unbounded_channel();
-        let (ptx, prx) = mpsc::unbounded_channel();
+        // let (ptx, prx) = mpsc::unbounded_channel();
         let mut isis = Self {
             ctx,
             tx,
             rx,
-            ptx,
+            // ptx,
             cm: ConfigChannel::new(),
             callbacks: HashMap::new(),
             rib_rx: chan.rx,
@@ -122,7 +122,7 @@ impl Isis {
             links: IsisLinks::default(),
             show: ShowChannel::new(),
             show_cb: HashMap::new(),
-            sock,
+            // sock,
             config: IsisConfig::default(),
             lsdb: Levels::<Lsdb>::default(),
             lsp_map: Levels::<LspMap>::default(),
@@ -140,14 +140,14 @@ impl Isis {
         isis.show_build();
 
         let tx = isis.tx.clone();
-        let sock = isis.sock.clone();
-        tokio::spawn(async move {
-            read_packet(sock, tx).await;
-        });
-        let sock = isis.sock.clone();
-        tokio::spawn(async move {
-            write_packet(sock, prx).await;
-        });
+        // let sock = isis.sock.clone();
+        // tokio::spawn(async move {
+        //     read_packet(sock, tx).await;
+        // });
+        // let sock = isis.sock.clone();
+        // tokio::spawn(async move {
+        //     write_packet(sock, prx).await;
+        // });
         isis
     }
 
@@ -501,7 +501,7 @@ impl Isis {
     pub fn link_top<'a>(&'a mut self, ifindex: u32) -> Option<LinkTop<'a>> {
         self.links.get_mut(&ifindex).map(|link| LinkTop {
             tx: &self.tx,
-            ptx: &self.ptx,
+            ptx: &link.ptx,
             up_config: &self.config,
             lsdb: &self.lsdb,
             flags: &link.flags,

--- a/zebra-rs/src/isis/socket.rs
+++ b/zebra-rs/src/isis/socket.rs
@@ -30,7 +30,7 @@ const fn bpf_filter_block(code: u16, jt: u8, jf: u8, k: u32) -> libc::sock_filte
     libc::sock_filter { code, jt, jf, k }
 }
 
-pub fn isis_socket() -> Result<Socket, std::io::Error> {
+pub fn isis_socket(ifindex: u32) -> Result<Socket, std::io::Error> {
     let socket = Socket::new(
         Domain::PACKET,
         Type::DGRAM,
@@ -39,7 +39,7 @@ pub fn isis_socket() -> Result<Socket, std::io::Error> {
 
     socket.set_nonblocking(true);
 
-    let sockaddr = link_addr(libc::ETH_P_ALL as u16, 0, None);
+    let sockaddr = link_addr(libc::ETH_P_ALL as u16, ifindex, None);
 
     socket::bind(socket.as_raw_fd(), &sockaddr)?;
 


### PR DESCRIPTION
## Summary
Implement per-interface IS-IS sockets to improve packet handling isolation and performance. Each IS-IS interface now has its own dedicated socket instead of sharing a single global socket.

## Motivation
The previous implementation used a single shared socket for all IS-IS interfaces, which could lead to:
- Packet handling contention between interfaces
- Difficulty in implementing interface-specific configurations
- Potential performance bottlenecks in high-traffic scenarios

## Changes Made

### Socket Creation
- Modified `isis_socket()` function to accept `ifindex` parameter
- Socket is now bound to a specific interface using the provided ifindex
- Each interface gets its own dedicated packet socket

### Link Structure Updates
- Added `sock: Arc<AsyncFd<Socket>>` field to `IsisLink` structure
- Socket is wrapped in Arc for safe sharing and AsyncFd for tokio integration
- Prepared imports for async packet read/write operations

### Interface Initialization
- Updated link creation to initialize per-interface socket
- Socket is created when the IS-IS link is established
- Each link maintains its own socket throughout its lifetime

## Technical Details
- Socket type: `AF_PACKET` with `SOCK_DGRAM` for IS-IS protocol handling
- Binding: Per-interface binding using interface index
- Async handling: Uses tokio's AsyncFd for non-blocking I/O operations

## Benefits
1. **Isolation**: Each interface handles its own packets independently
2. **Performance**: No contention between interfaces for socket access
3. **Flexibility**: Easier to implement interface-specific features
4. **Debugging**: Clearer packet flow per interface

## Test Plan
- [x] Code compiles successfully
- [x] Formatting applied with `make format`
- [x] Build test passed
- [ ] IS-IS adjacencies form correctly with per-interface sockets
- [ ] Packet transmission/reception works on multiple interfaces

🤖 Generated with [Claude Code](https://claude.ai/code)