### PR TITLE
feat: Update rand crate to version 0.9

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -46,7 +46,7 @@ ospf-packet = { git = "https://github.com/zebra-rs/ospf-packet", branch = "main"
 #isis-packet = { path = "../../isis-packet" }
 isis-packet = { git = "https://github.com/zebra-rs/isis-packet", branch = "main" }
 bitfield-struct = "0.9.3"
-rand = "0.8.5"
+rand = "0.9"
 chrono = { version = "0.4", features = ["serde"] }
 hostname = "0.4"
 bit-vec = "0.8.0"

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -398,8 +398,8 @@ fn ospf_nfsm_change_state(nbr: &mut Neighbor, state: NfsmState, oident: &Identit
             }
         }
         if nbr.dd.seqnum == 0 {
-            let mut rng = rand::thread_rng();
-            nbr.dd.seqnum = rng.r#gen();
+            let mut rng = rand::rng();
+            nbr.dd.seqnum = rng.random();
         } else {
             nbr.dd.seqnum += 1;
         }


### PR DESCRIPTION
## Summary
Update the rand crate from version 0.8.5 to 0.9 and fix associated deprecation warnings.

## Changes Made

### Dependency Update
- Updated `zebra-rs/Cargo.toml`: `rand = "0.8.5"` → `rand = "0.9"`

### Code Updates
Fixed deprecation warnings in `zebra-rs/src/ospf/nfsm.rs`:
- `rand::thread_rng()` → `rand::rng()` (renamed function)
- `rng.r#gen()` → `rng.random()` (renamed method to avoid conflict with Rust 2024 `gen` keyword)

## Benefits
1. **Latest Features**: Access to performance improvements and new functionality in rand 0.9
2. **Future Compatibility**: Avoids conflicts with Rust 2024 edition keywords
3. **Security**: Latest version includes any security fixes
4. **Ecosystem Alignment**: Keeps dependencies current with the Rust ecosystem

## Breaking Changes Handled
- The `thread_rng()` function was renamed to `rng()` in rand 0.9
- The `gen()` method was renamed to `random()` to avoid conflict with the new `gen` keyword in Rust 2024

## Testing
- [x] Code compiles successfully without warnings
- [x] Build verification passed with `cargo build --bin zebra-rs`
- [x] Code formatting applied with `make format`
- [x] OSPF sequence number generation continues to work as expected

## Impact
This is a low-risk change affecting only the OSPF Database Description sequence number generation. The functionality remains identical - only the API calls have been updated to use the new rand 0.9 interface.

🤖 Generated with [Claude Code](https://claude.ai/code)