### PR TITLE
feat: Remove nom crate dependency from zebra-rs

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -10,7 +10,7 @@ unused = "allow"
 anyhow = "1.0"
 bytes = "1"
 ipnet = "2.9"
-nom = "7"
+# nom = "7"
 prost = "0.13"
 tokio = { version = "1", features = ["full", "tracing"] }
 tokio-stream = "0.1"

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1,7 +1,6 @@
 use bgp_packet::cap::CapMultiProtocol;
 use bytes::BytesMut;
 use ipnet::Ipv4Net;
-use nom::AsBytes;
 use prefix_trie::PrefixMap;
 use serde::Serialize;
 use std::cmp::min;
@@ -571,15 +570,13 @@ pub async fn peer_read(
                     let _ = tx.send(Message::Event(ident, Event::ConnFail));
                     return;
                 }
-                while buf.len() >= BGP_HEADER_LEN as usize
-                    && buf.len() >= peek_bgp_length(buf.as_bytes())
-                {
-                    let length = peek_bgp_length(buf.as_bytes());
+                while buf.len() >= BGP_HEADER_LEN as usize && buf.len() >= peek_bgp_length(&buf) {
+                    let length = peek_bgp_length(&buf);
 
                     let mut remain = buf.split_off(length);
                     remain.reserve(BGP_PACKET_LEN * 2);
 
-                    match peer_packet_parse(buf.as_bytes(), ident, tx.clone(), &mut config) {
+                    match peer_packet_parse(&buf, ident, tx.clone(), &mut config) {
                         Ok(_) => {
                             buf = remain;
                         }


### PR DESCRIPTION
## Summary
- Remove nom crate dependency from zebra-rs
- Replace nom::AsBytes usage in BGP peer code with BytesMut's built-in conversion
- Comment out nom dependency in Cargo.toml

## Test plan
- [x] Code builds successfully without nom dependency
- [x] BGP peer packet parsing still works correctly
- [x] No compilation errors

🤖 Generated with [Claude Code](https://claude.ai/code)