### PR TITLE
feat: Update bitfield-struct crate to version 0.11

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -45,7 +45,7 @@ bgp-packet = { git = "https://github.com/zebra-rs/bgp-packet", branch = "main" }
 ospf-packet = { git = "https://github.com/zebra-rs/ospf-packet", branch = "main" }
 #isis-packet = { path = "../../isis-packet" }
 isis-packet = { git = "https://github.com/zebra-rs/isis-packet", branch = "main" }
-bitfield-struct = "0.9.3"
+bitfield-struct = "0.11"
 rand = "0.9"
 chrono = { version = "0.4", features = ["serde"] }
 hostname = "0.4"


### PR DESCRIPTION
## Summary
- Update bitfield-struct crate from v0.9.3 to v0.11

## Test plan
- [x] Code builds successfully with new bitfield-struct version
- [x] No compilation errors

🤖 Generated with [Claude Code](https://claude.ai/code)