### PR TITLE
feat: Update sysctl crate to version 0.6

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -34,7 +34,7 @@ serde_yaml = "0.9"
 clap = { version = "4", features = ["derive"] }
 alphanumeric-sort = "1.5.3"
 bitflags = "2.6.0"
-sysctl = "0.5.5"
+sysctl = "0.6"
 nanomsg = "0.7.2"
 socket2 = "0.5.8"
 nix = { version = "0.29", features = ["fs", "net", "socket", "uio", "user"] }


### PR DESCRIPTION
## Summary
- Update sysctl crate from v0.5.5 to v0.6

## Test plan
- [x] Code builds successfully with new sysctl version
- [x] No compilation errors

🤖 Generated with [Claude Code](https://claude.ai/code)