### PR TITLE
feat: Update nix crate to version 0.30

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -37,7 +37,7 @@ bitflags = "2.6.0"
 sysctl = "0.6"
 nanomsg = "0.7.2"
 socket2 = "0.5.8"
-nix = { version = "0.29", features = ["fs", "net", "socket", "uio", "user"] }
+nix = { version = "0.30", features = ["fs", "net", "socket", "uio", "user"] }
 libc = "0.2.167"
 #bgp-packet = { path = "../../bgp-packet" }
 bgp-packet = { git = "https://github.com/zebra-rs/bgp-packet", branch = "main" }
@@ -65,7 +65,7 @@ futures = "0.3"
 scan_fmt = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-nix = { version = "0.29", features = ["net"] }
+nix = { version = "0.30", features = ["net"] }
 ioctl-rs = "0.2.0"
 net-route = "0.4.2"
 


### PR DESCRIPTION
## Summary
- Update nix crate from v0.29 to v0.30 for both general and macOS-specific dependencies

## Test plan
- [x] Code builds successfully with new nix version
- [x] No compilation errors

🤖 Generated with [Claude Code](https://claude.ai/code)