### PR TITLE
feat: Include hostname in 'show isis graph' output with separate fields

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -988,9 +988,9 @@ pub fn graph(
                 }
             }
 
-            // Use hostname if available, otherwise fall back to system ID
+            // Use hostname with system ID if available, otherwise just system ID
             let node_name = if let Some((hostname, _)) = top.hostname.get(&level).get(&sys_id) {
-                hostname.clone()
+                format!("{} ({})", hostname, sys_id)
             } else {
                 sys_id.to_string()
             };

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -988,9 +988,16 @@ pub fn graph(
                 }
             }
 
+            // Use hostname if available, otherwise fall back to system ID
+            let node_name = if let Some((hostname, _)) = top.hostname.get(&level).get(&sys_id) {
+                hostname.clone()
+            } else {
+                sys_id.to_string()
+            };
+
             let mut node = spf::Node {
                 id,
-                name: sys_id.to_string(),
+                name: node_name,
                 olinks: vec![],
                 ilinks: vec![],
                 // is_disabled: false,

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -988,9 +988,9 @@ pub fn graph(
                 }
             }
 
-            // Use hostname with system ID if available, otherwise just system ID
+            // Separate hostname and system ID into distinct fields
             let node_name = if let Some((hostname, _)) = top.hostname.get(&level).get(&sys_id) {
-                format!("{} ({})", hostname, sys_id)
+                hostname.clone()
             } else {
                 sys_id.to_string()
             };
@@ -998,6 +998,7 @@ pub fn graph(
             let mut node = spf::Node {
                 id,
                 name: node_name,
+                sys_id: sys_id.to_string(),
                 olinks: vec![],
                 ilinks: vec![],
                 // is_disabled: false,

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -58,6 +58,7 @@ struct GraphJson {
 struct NodeJson {
     pub id: usize,
     pub name: String,
+    pub sys_id: String,
     pub links: Vec<LinkJson>,
 }
 
@@ -101,7 +102,11 @@ fn show_isis_graph(
             writeln!(buf, "\n{} IS-IS Graph:", graph_data.level)?;
             writeln!(buf, "\nNodes:")?;
             for node in &graph_data.nodes {
-                writeln!(buf, "  {} (id: {})", node.name, node.id)?;
+                if node.name != node.sys_id {
+                    writeln!(buf, "  {} [{}] (id: {})", node.name, node.sys_id, node.id)?;
+                } else {
+                    writeln!(buf, "  {} (id: {})", node.sys_id, node.id)?;
+                }
                 if !node.links.is_empty() {
                     writeln!(buf, "    Links:")?;
                     for link in &node.links {
@@ -142,6 +147,7 @@ fn format_graph(graph: &spf::Graph, level: &str) -> Option<GraphJson> {
         nodes.push(NodeJson {
             id: *id,
             name: node.name.clone(),
+            sys_id: node.sys_id.clone(),
             links: node_links,
         });
     }

--- a/zebra-rs/src/spf/calc.rs
+++ b/zebra-rs/src/spf/calc.rs
@@ -21,6 +21,7 @@ impl SpfOpt {
 pub struct Node {
     pub id: usize,
     pub name: String,
+    pub sys_id: String,
     pub olinks: Vec<Link>,
     pub ilinks: Vec<Link>,
     //pub is_disabled: bool,
@@ -39,6 +40,7 @@ impl Node {
         Self {
             id,
             name: name.into(),
+            sys_id: name.into(), // Default to name for backward compatibility
             olinks: Vec::new(),
             ilinks: Vec::new(),
             // is_disabled: false,


### PR DESCRIPTION
## Summary

This PR enhances the "show isis graph" command to display human-readable hostnames alongside system IDs, with both values provided as separate distinct fields for better identification and API integration.

• **Hostname Integration**: Leverages existing IS-IS Dynamic Hostname TLV (Type 137) data
• **Separate Fields**: Distinguishes hostname and system ID as distinct data fields
• **Enhanced Display**: Improves both text and JSON output formats
• **Backward Compatible**: Maintains existing behavior when hostnames unavailable
• **API-Friendly**: JSON output includes both name and sys_id fields separately

## Implementation Details

**Data Structure Enhancement**:
- Added `sys_id` field to `Node` structure in SPF graph
- Updated JSON serialization to include both name and sys_id
- Enhanced Node constructor for backward compatibility

**Display Formats**:

**Text Output**:
```
L1 IS-IS Graph:

Nodes:
  router-1 [1921.6800.1001.00-00] (id: 0)    # With hostname
    Links:
      -> router-2 (cost: 10)
  1921.6800.3003.00-00 (id: 1)               # Without hostname
```

**JSON Output**:
```json
{
  "level": "L1", 
  "nodes": [
    {
      "id": 0,
      "name": "router-1",
      "sys_id": "1921.6800.1001.00-00",
      "links": [...]
    }
  ]
}
```

## Files Modified

- **zebra-rs/src/spf/calc.rs**: Added sys_id field to Node structure
- **zebra-rs/src/isis/inst.rs**: Enhanced graph building with hostname lookup
- **zebra-rs/src/isis/show.rs**: Updated display logic for separate field presentation

## Key Benefits

1. **Improved Readability**: Network operators can quickly identify routers by meaningful names
2. **Complete Information**: Both logical (hostname) and technical (system ID) identifiers always available
3. **API Integration**: Programmatic access to both identification methods via separate JSON fields
4. **Standards Compliance**: Uses existing IS-IS hostname infrastructure (TLV 137)
5. **Zero Breaking Changes**: Fallback behavior preserved for nodes without hostnames

## Test plan

- [x] Code compiles without errors
- [x] Code formatting applied with `make format`  
- [x] Backward compatibility verified for nodes without hostnames
- [ ] Test hostname display with routers advertising Dynamic Hostname TLV
- [ ] Verify JSON output structure includes both name and sys_id fields
- [ ] Test text display format with mixed hostname/no-hostname scenarios
- [ ] Validate graph topology accuracy with hostname-enabled networks

🤖 Generated with [Claude Code](https://claude.ai/code)