### PR TITLE
feat: Add sys_id field to SpfNexthop for neighbor tracking in ILM

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -977,6 +977,7 @@ pub struct SpfRoute {
 pub struct SpfNexthop {
     pub ifindex: u32,
     pub adjacency: bool,
+    pub sys_id: Option<IsisSysId>,
 }
 
 /// Generic result for table diff operations
@@ -1271,6 +1272,7 @@ fn build_adjacency_ilm(
                         let nhop = SpfNexthop {
                             ifindex: *ifindex,
                             adjacency: true,
+                            sys_id: Some(nhop_id.clone()),
                         };
                         nhops.insert(ifaddr.addr, nhop);
                     }
@@ -1278,7 +1280,7 @@ fn build_adjacency_ilm(
             }
         }
 
-        // Adjacency labels start from 24000, so calculate index
+        // Adjacency labels start from 24000, so calculate index.
         let adj_index = if label >= 24000 { label - 24000 + 1 } else { 1 };
         let spf_ilm = SpfIlm {
             nhops,
@@ -1325,6 +1327,7 @@ fn build_rib_from_spf(
                                     let nhop = SpfNexthop {
                                         ifindex: *ifindex,
                                         adjacency: p[0] == *node,
+                                        sys_id: Some(nhop_id.clone()),
                                     };
                                     spf_nhops.insert(ifaddr.addr, nhop);
                                 }
@@ -1335,7 +1338,7 @@ fn build_rib_from_spf(
             }
         }
 
-        // Process reachability entries for this node
+        // Process reachability entries for this node.
         if let Some(entries) = top.reach_map.get(&level).get(&Afi::Ip).get(&sys_id) {
             for entry in entries.iter() {
                 let sid = if let Some(prefix_sid) = entry.prefix_sid() {


### PR DESCRIPTION
## Summary

- Added `sys_id` field to `SpfNexthop` structure to track neighbor's system ID
- Updated `build_adjacency_ilm()` and `build_rib_from_spf()` to populate the new field
- Enables better tracking and debugging of MPLS label operations in ILM

## Changes Made

1. **Modified `SpfNexthop` structure** (`zebra-rs/src/isis/inst.rs:977`)
   - Added `pub sys_id: Option<IsisSysId>` field to store neighbor's system ID

2. **Updated `build_adjacency_ilm()` function** (`zebra-rs/src/isis/inst.rs:1272`)
   - Now populates `sys_id` field with the neighbor's system ID when creating nexthops

3. **Updated `build_rib_from_spf()` function** (`zebra-rs/src/isis/inst.rs:1327`)
   - Also populates `sys_id` field during SPF nexthop calculation

## Benefits

- **Improved visibility**: Can now identify which neighbor a nexthop corresponds to
- **Better debugging**: Easier to troubleshoot MPLS forwarding decisions
- **Enhanced tracking**: System ID information is preserved throughout the ILM processing

## Test plan

- [x] Code compiles successfully
- [x] All existing functionality remains unchanged
- [x] New field is properly populated in both adjacency ILM and RIB SPF calculations
- [ ] Verify MPLS label operations work correctly with the new field
- [ ] Test IS-IS SPF calculations with multiple neighbors

🤖 Generated with [Claude Code](https://claude.ai/code)