### PR TITLE
feat: Reduce BGP neighbor configuration hierarchy level

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -187,7 +187,7 @@ fn config_debug_category(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<
 
 impl Bgp {
     fn callback_peer(&mut self, path: &str, cb: Callback) {
-        let neighbor_prefix = String::from("/routing/bgp/neighbors/neighbor");
+        let neighbor_prefix = String::from("/routing/bgp/neighbor");
         self.callbacks.insert(neighbor_prefix + path, cb);
     }
 

--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -373,104 +373,100 @@ module ietf-bgp {
         uses state;
       }
 
-      container neighbors {
+      list neighbor {
+        key "remote-address";
         description
-          "Configuration for BGP neighbors.";
-
-        list neighbor {
-          key "remote-address";
-          description
-            "List of BGP neighbors configured on the local system,
+          "List of BGP neighbors configured on the local system,
              uniquely identified by remote IPv[46] address.";
 
-          leaf local-identifier {
-            type inet:ipv4-address;
-            description
-              "When present, this peer has been created
+        leaf local-identifier {
+          type inet:ipv4-address;
+          description
+            "When present, this peer has been created
               dynamically.";
-          }
+        }
 
-          leaf remote-address {
-            type inet:ip-address;
-            description
-              "The remote IP address of this entry's BGP peer.";
-          }
+        leaf remote-address {
+          type inet:ip-address;
+          description
+            "The remote IP address of this entry's BGP peer.";
+        }
 
-          leaf peer-group {
-            type leafref {
-              path "../../../peer-groups/peer-group/name";
-            }
-            description
-              "The peer-group with which this neighbor is
+        leaf peer-group {
+          type leafref {
+            path "../../../peer-groups/peer-group/name";
+          }
+          description
+            "The peer-group with which this neighbor is
                associated.";
-          }
+        }
 
-          leaf local-address {
-            type inet:ip-address;
-            config false;
-            description
-              "The local IP address of this entry's BGP connection.";
-          }
+        leaf local-address {
+          type inet:ip-address;
+          config false;
+          description
+            "The local IP address of this entry's BGP connection.";
+        }
 
-          leaf local-port {
-            type inet:port-number;
-            config false;
-            description
-              "The local port for the TCP connection between
+        leaf local-port {
+          type inet:port-number;
+          config false;
+          description
+            "The local port for the TCP connection between
                the BGP peers.";
-          }
+        }
 
-          leaf remote-port {
-            type inet:port-number;
-            config false;
-            description
-              "The remote port for the TCP connection
+        leaf remote-port {
+          type inet:port-number;
+          config false;
+          description
+            "The remote port for the TCP connection
                between the BGP peers.  Note that the
                objects local-addr, local-port, remote-addr, and
                remote-port provide the appropriate
                reference to the standard MIB TCP
                connection table.";
-          }
+        }
 
-          leaf peer-type {
-            type bt:peer-type;
-            config false;
-            description
-              "The type of peering session associated with this
+        leaf peer-type {
+          type bt:peer-type;
+          config false;
+          description
+            "The type of peering session associated with this
                neighbor.";
-            reference
-              "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
+          reference
+            "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
                          Section 1.1 for iBGP and eBGP.
                RFC 5065: Autonomous System Configuration
                          for Confederation internal and external.";
-          }
+        }
 
-          leaf identifier {
-            type yang:dotted-quad;
-            config false;
-            description
-              "The BGP Identifier of this entry's BGP peer.
+        leaf identifier {
+          type yang:dotted-quad;
+          config false;
+          description
+            "The BGP Identifier of this entry's BGP peer.
                This entry MUST be 0.0.0.0 unless the
                session state is in the openconfirm or the
                established state.";
-            reference
-              "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
+          reference
+            "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
                          Section 4.2, 'BGP Identifier'.";
-          }
+        }
 
-          leaf dynamically-configured {
-            type empty;
-            config false;
-            description
-              "When present, this peer has been created
+        leaf dynamically-configured {
+          type empty;
+          config false;
+          description
+            "When present, this peer has been created
               dynamically.";
-          }
+        }
 
-          leaf enabled {
-            type boolean;
-            default "true";
-            description
-              "Whether the BGP peer is enabled. In cases where the
+        leaf enabled {
+          type boolean;
+          default "true";
+          description
+            "Whether the BGP peer is enabled. In cases where the
                enabled leaf is set to false, the local system should
                not initiate connections to the neighbor, and should
                not respond to TCP connections attempts from the
@@ -486,145 +482,145 @@ module ietf-bgp {
                connections. Care should be used in providing
                write access to this object without adequate
                authentication.";
-            reference
-              "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
+          reference
+            "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
                Section 8.1.2.";
+        }
+
+        uses neighbor-group-config;
+
+        container graceful-restart {
+          if-feature "bt:graceful-restart";
+          description
+            "Parameters relating the graceful restart mechanism for
+               BGP";
+          reference
+            "RFC 4724: Graceful Restart Mechanism for BGP.";
+          uses graceful-restart-config;
+          leaf peer-restart-time {
+            type uint16 {
+              range "0..4096";
+            }
+            config false;
+            description
+              "The period of time (advertised by the peer) that the
+                 peer expects a restart of a BGP session to take.";
           }
 
-          uses neighbor-group-config;
-
-          container graceful-restart {
-            if-feature "bt:graceful-restart";
+          leaf peer-restarting {
+            type boolean;
+            config false;
             description
-              "Parameters relating the graceful restart mechanism for
-               BGP";
-            reference
-              "RFC 4724: Graceful Restart Mechanism for BGP.";
-            uses graceful-restart-config;
-            leaf peer-restart-time {
-              type uint16 {
-                range "0..4096";
-              }
-              config false;
-              description
-                "The period of time (advertised by the peer) that the
-                 peer expects a restart of a BGP session to take.";
-            }
-
-            leaf peer-restarting {
-              type boolean;
-              config false;
-              description
-                "This flag indicates whether the remote neighbor is
+              "This flag indicates whether the remote neighbor is
                  currently in the process of restarting, and hence
                  received routes are currently stale.";
-            }
+          }
 
-            leaf local-restarting {
-              type boolean;
-              config false;
-              description
-                "This flag indicates whether the local neighbor is
+          leaf local-restarting {
+            type boolean;
+            config false;
+            description
+              "This flag indicates whether the local neighbor is
                  currently restarting. The flag is cleared after all
                  NLRI have been advertised to the peer, and the
                  End-of-RIB (EOR) marker has been cleared.";
-            }
+          }
 
-            leaf mode {
-              type enumeration {
-                enum helper-only {
-                  description
-                    "The local router is operating in helper-only
+          leaf mode {
+            type enumeration {
+              enum helper-only {
+                description
+                  "The local router is operating in helper-only
                      mode, and hence will not retain forwarding state
                      during a local session restart, but will do so
                      during a restart of the remote peer";
-                }
-                enum bilateral {
-                  description
-                    "The local router is operating in both helper
+              }
+              enum bilateral {
+                description
+                "The local router is operating in both helper
                      mode, and hence retains forwarding state during
                      a remote restart, and also maintains forwarding
                      state during local session restart";
-                }
-                enum remote-helper {
-                  description
-                    "The local system is able to retain routes during
+              }
+              enum remote-helper {
+                description
+                  "The local system is able to retain routes during
                      restart but the remote system is only able to
                      act as a helper";
-                }
-              }
-              config false;
-              description
-                "This leaf indicates the mode of operation of BGP
-                 graceful restart with the peer";
-            }
-          }
-
-          container prefix-limit {
-            description
-              "Parameters relating to the prefix limit for the
-               AFI-SAFI";
-
-            uses prefix-limit-config-common;
-
-            uses prefix-limit-state-common;
-          }
-
-          container afi-safis {
-            description
-              "Per-address-family configuration parameters associated
-               with the neighbor";
-            uses bgp-neighbor-afi-safi-list;
-          }
-
-          leaf session-state {
-            type enumeration {
-              enum idle {
-                description
-                  "Neighbor is down, and in the Idle state of the
-                   FSM.";
-              }
-              enum connect {
-                description
-                  "Neighbor is down, and the session is waiting for
-                   the underlying transport session to be
-                   established.";
-              }
-              enum active {
-                description
-                  "Neighbor is down, and the local system is awaiting
-                   a connection from the remote peer.";
-              }
-              enum opensent {
-                description
-                  "Neighbor is in the process of being established.
-                   The local system has sent an OPEN message.";
-              }
-              enum openconfirm {
-                description
-                  "Neighbor is in the process of being established.
-                   The local system is awaiting a NOTIFICATION or
-                   KEEPALIVE message.";
-              }
-              enum established {
-                description
-                  "Neighbor is up - the BGP session with the peer is
-                   established.";
               }
             }
-            //  notification does not like a non-config statement.
-            //  config false;
-            description
-              "The BGP peer connection state.";
-            reference
-              "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
-               Section 8.1.2.";
-          }
-          leaf last-established {
-            type yang:date-and-time;
             config false;
             description
-              "This timestamp indicates the time that the BGP session
+              "This leaf indicates the mode of operation of BGP
+                 graceful restart with the peer";
+          }
+        }
+
+        container prefix-limit {
+          description
+            "Parameters relating to the prefix limit for the
+               AFI-SAFI";
+
+          uses prefix-limit-config-common;
+
+          uses prefix-limit-state-common;
+        }
+
+        container afi-safis {
+          description
+            "Per-address-family configuration parameters associated
+               with the neighbor";
+          uses bgp-neighbor-afi-safi-list;
+        }
+
+        leaf session-state {
+          type enumeration {
+            enum idle {
+              description
+              "Neighbor is down, and in the Idle state of the
+                   FSM.";
+            }
+            enum connect {
+              description
+              "Neighbor is down, and the session is waiting for
+                   the underlying transport session to be
+                   established.";
+            }
+            enum active {
+              description
+              "Neighbor is down, and the local system is awaiting
+                   a connection from the remote peer.";
+            }
+            enum opensent {
+              description
+              "Neighbor is in the process of being established.
+                   The local system has sent an OPEN message.";
+            }
+            enum openconfirm {
+              description
+              "Neighbor is in the process of being established.
+                   The local system is awaiting a NOTIFICATION or
+                   KEEPALIVE message.";
+            }
+            enum established {
+              description
+              "Neighbor is up - the BGP session with the peer is
+                   established.";
+            }
+          }
+          //  notification does not like a non-config statement.
+          //  config false;
+          description
+            "The BGP peer connection state.";
+          reference
+            "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
+               Section 8.1.2.";
+        }
+        leaf last-established {
+          type yang:date-and-time;
+          config false;
+          description
+            "This timestamp indicates the time that the BGP session
                last transitioned in or out of the Established state.
                The value is the timestamp in seconds relative to the
                Unix Epoch (Jan 1, 1970 00:00:00 UTC).
@@ -633,324 +629,323 @@ module ietf-bgp {
                the difference between this value and the current time
                in UTC (assuming the session is in the Established
                state, per the session-state leaf).";
-            reference
-              "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
+          reference
+            "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
                Section 8.";
-          }
+        }
 
-          uses bgp-capabilities;
+        uses bgp-capabilities;
 
-          container errors {
-            config false;
-            description
-              "Information about BGP NOTIFICATION messages, sent and
+        container errors {
+          config false;
+          description
+            "Information about BGP NOTIFICATION messages, sent and
                received for this neighbor.";
 
-            container received {
-              description
-                "BGP NOTIFICATION message state received from this
-                 neighbor.";
-              uses bgp-errors-common;
-              uses bgp-encapsulated-errors-common;
-              uses bgp-errors-common-data;
-            }
-            container sent {
-              description
-                "BGP NOTIFICATION message state sent to this
-                 neighbor.";
-              uses bgp-errors-common;
-              uses bgp-encapsulated-errors-common;
-              uses bgp-errors-common-data;
-            }
-          }
-
-          container statistics {
-            config false;
+          container received {
             description
-              "Statistics per neighbor.";
+              "BGP NOTIFICATION message state received from this
+                 neighbor.";
+            uses bgp-errors-common;
+            uses bgp-encapsulated-errors-common;
+            uses bgp-errors-common-data;
+          }
+          container sent {
+            description
+              "BGP NOTIFICATION message state sent to this
+                 neighbor.";
+            uses bgp-errors-common;
+            uses bgp-encapsulated-errors-common;
+            uses bgp-errors-common-data;
+          }
+        }
 
-            leaf established-transitions {
-              type yang:zero-based-counter32;
-              description
-                "Number of transitions to the Established state for
+        container statistics {
+          config false;
+          description
+            "Statistics per neighbor.";
+
+          leaf established-transitions {
+            type yang:zero-based-counter32;
+            description
+              "Number of transitions to the Established state for
                  the neighbor session. This value is analogous to the
                  bgpPeerFsmEstablishedTransitions object from the
                  standard BGP-4 MIB";
-              reference
-                "RFC 4273: Definitions of Managed Objects for
+            reference
+              "RFC 4273: Definitions of Managed Objects for
                  BGP-4, bgpPeerFsmEstablishedTransitions,
                  RFC 4271: A Border Gateway Protocol 4 (BGP-4),
                  Section 8.";
-            }
-            container messages {
-              description
-                "Counters for BGP messages sent and received from the
+          }
+          container messages {
+            description
+              "Counters for BGP messages sent and received from the
                  neighbor";
-              leaf total-received {
-                type yang:zero-based-counter32;
-                description
-                  "Total number of BGP messages received from this
+            leaf total-received {
+              type yang:zero-based-counter32;
+              description
+                "Total number of BGP messages received from this
                    neighbor";
-                reference
-                  "RFC 4273: Definitions of Managed Objects for
+              reference
+                "RFC 4273: Definitions of Managed Objects for
                    BGP-4, bgpPeerInTotalMessages.";
-              }
-              leaf total-sent {
-                type yang:zero-based-counter32;
-                description
-                  "Total number of BGP messages sent do this
+            }
+            leaf total-sent {
+              type yang:zero-based-counter32;
+              description
+                "Total number of BGP messages sent do this
                    neighbor";
-                reference
-                  "RFC 4273: Definitions of Managed Objects for
+              reference
+                "RFC 4273: Definitions of Managed Objects for
                    BGP-4, bgpPeerOutTotalMessages.";
-              }
-              leaf updates-received {
-                type yang:zero-based-counter32;
-                description
-                  "Number of BGP UPDATE messages received from this
+            }
+            leaf updates-received {
+              type yang:zero-based-counter32;
+              description
+                "Number of BGP UPDATE messages received from this
                    neighbor.";
-                reference
-                  "RFC 4273: Definitions of Managed Objects for
+              reference
+                "RFC 4273: Definitions of Managed Objects for
                    BGP-4, bgpPeerInUpdates.";
-              }
-              leaf updates-sent {
-                type yang:zero-based-counter32;
-                description
-                  "Number of BGP UPDATE messages sent to this
+            }
+            leaf updates-sent {
+              type yang:zero-based-counter32;
+              description
+                "Number of BGP UPDATE messages sent to this
                    neighbor";
-                reference
-                  "RFC 4273: Definitions of Managed Objects for
+              reference
+                "RFC 4273: Definitions of Managed Objects for
                    BGP-4, bgpPeerOutUpdates.";
-              }
-              leaf erroneous-updates-withdrawn {
-                type yang:zero-based-counter32;
-                config false;
-                description
-                  "The number of BGP UPDATE messages for which the
+            }
+            leaf erroneous-updates-withdrawn {
+              type yang:zero-based-counter32;
+              config false;
+              description
+                "The number of BGP UPDATE messages for which the
                    treat-as-withdraw mechanism has been applied based
                    on erroneous message contents.";
-                reference
-                  "RFC 7606: Revised Error Handling for BGP UPDATE
+              reference
+                "RFC 7606: Revised Error Handling for BGP UPDATE
                    Messages, Section 2.";
-              }
-              leaf erroneous-updates-attribute-discarded {
-                type yang:zero-based-counter32;
-                config false;
-                description
-                  "The number of BGP UPDATE messages for which the
+            }
+            leaf erroneous-updates-attribute-discarded {
+              type yang:zero-based-counter32;
+              config false;
+              description
+                "The number of BGP UPDATE messages for which the
                    attribute discard mechanism has been applied based
                    on erroneous message contents.";
-                reference
-                  "RFC 7606: Revised Error Handling for BGP UPDATE
+              reference
+                "RFC 7606: Revised Error Handling for BGP UPDATE
                    Messages, Section 2.";
-              }
-              leaf in-update-elapsed-time {
-                type yang:gauge32;
-                units "seconds";
-                description
-                  "Elapsed time (in seconds) since the last BGP
+            }
+            leaf in-update-elapsed-time {
+              type yang:gauge32;
+              units "seconds";
+              description
+                "Elapsed time (in seconds) since the last BGP
                    UPDATE message was received from the peer.
                    Each time in-updates is incremented,
                    the value of this object is set to zero (0).";
-                reference
-                  "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
+              reference
+                "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
                    Section 4.3
                    RFC 4271: A Border Gateway Protocol 4 (BGP-4),
                    Established state.";
-              }
-              leaf notifications-received {
-                type yang:zero-based-counter32;
-                description
-                  "Number of BGP NOTIFICATION messages indicating an
+            }
+            leaf notifications-received {
+              type yang:zero-based-counter32;
+              description
+                "Number of BGP NOTIFICATION messages indicating an
                    error condition has occurred exchanged received
                    from this peer.";
-                reference
-                  "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
+              reference
+                "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
                    Section 4.5.";
-              }
-              leaf notifications-sent {
-                type yang:zero-based-counter32;
-                description
-                  "Number of BGP NOTIFICATION messages indicating an
+            }
+            leaf notifications-sent {
+              type yang:zero-based-counter32;
+              description
+                "Number of BGP NOTIFICATION messages indicating an
                    error condition has occurred exchanged sent to
                    this peer.";
-                reference
-                  "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
+              reference
+                "RFC 4271: A Border Gateway Protocol 4 (BGP-4),
                    Section 4.5.";
-              }
-              leaf route-refreshes-received {
-                type yang:zero-based-counter32;
-                description
-                  "Number of BGP ROUTE-REFRESH messages received from
-                   this peer.";
-                reference
-                  "RFC 2918: Route Refresh Capability for BGP-4.";
-              }
-              leaf route-refreshes-sent {
-                type yang:zero-based-counter32;
-                description
-                  "Number of BGP ROUTE-REFRESH messages sent to
-                   this peer.";
-                reference
-                  "RFC 2918: Route Refresh Capability for BGP-4.";
-              }
             }
-            container queues {
+            leaf route-refreshes-received {
+              type yang:zero-based-counter32;
               description
-                "Counters related to queued messages associated with
+                "Number of BGP ROUTE-REFRESH messages received from
+                   this peer.";
+              reference
+                "RFC 2918: Route Refresh Capability for BGP-4.";
+            }
+            leaf route-refreshes-sent {
+              type yang:zero-based-counter32;
+              description
+                "Number of BGP ROUTE-REFRESH messages sent to
+                   this peer.";
+              reference
+                "RFC 2918: Route Refresh Capability for BGP-4.";
+            }
+          }
+          container queues {
+            description
+              "Counters related to queued messages associated with
                  the BGP neighbor";
-              leaf input {
-                type yang:gauge32;
-                description
-                  "The number of messages received from the peer
-                   currently queued";
-              }
-              leaf output {
-                type yang:gauge32;
-                description
-                  "The number of messages queued to be sent to the
-                   peer";
-              }
-            }
-            action clear {
-              if-feature "bt:clear-statistics";
+            leaf input {
+              type yang:gauge32;
               description
-                "Clear statistics action command.
+                "The number of messages received from the peer
+                   currently queued";
+            }
+            leaf output {
+              type yang:gauge32;
+              description
+                "The number of messages queued to be sent to the
+                   peer";
+            }
+          }
+          action clear {
+            if-feature "bt:clear-statistics";
+            description
+              "Clear statistics action command.
 
                  Execution of this command should result in all the
                  counters to be cleared and set to 0.";
 
-              input {
-                leaf clear-at {
-                  type yang:date-and-time;
-                  description
-                    "Time when the clear action needs to be
+            input {
+              leaf clear-at {
+                type yang:date-and-time;
+                description
+                  "Time when the clear action needs to be
                      executed.";
-                }
               }
-              output {
-                leaf clear-finished-at {
-                  type yang:date-and-time;
-                  description
-                    "Time when the clear action command completed.";
-                }
+            }
+            output {
+              leaf clear-finished-at {
+                type yang:date-and-time;
+                description
+                  "Time when the clear action command completed.";
               }
             }
           }
         }
+      }
 
-        notification established {
-          leaf remote-address {
-            type leafref {
-              path "../../neighbor/remote-address";
-            }
-            description
-              "IP address of the neighbor that went into established
-               state.";
+      notification established {
+        leaf remote-address {
+          type leafref {
+            path "../../neighbor/remote-address";
           }
           description
-            "The established event is generated
-             when the BGP FSM enters the established state.";
+            "IP address of the neighbor that went into established
+               state.";
         }
+        description
+          "The established event is generated
+             when the BGP FSM enters the established state.";
+      }
 
-        notification backward-transition {
-          leaf remote-addr {
-            type leafref {
-              path "../../neighbor/remote-address";
-            }
-            description
-              "IP address of the neighbor that changed its state from
-               established state.";
+      notification backward-transition {
+        leaf remote-addr {
+          type leafref {
+            path "../../neighbor/remote-address";
           }
-          container notification-received {
-            description
-              "If the backwards transition was caused by receiving a
+          description
+            "IP address of the neighbor that changed its state from
+               established state.";
+        }
+        container notification-received {
+          description
+            "If the backwards transition was caused by receiving a
                BGP NOTIFICATION message, this is the information
                received in the NOTIFICATION PDU.";
 
-            uses bgp-errors-common;
-            uses bgp-encapsulated-errors-common;
-          }
-          container notification-sent {
-            description
-              "If the backwards transition was caused by sending a
+          uses bgp-errors-common;
+          uses bgp-encapsulated-errors-common;
+        }
+        container notification-sent {
+          description
+            "If the backwards transition was caused by sending a
                BGP NOTIFICATION message, this is the information
                sent in the NOTIFICATION PDU.";
 
-            uses bgp-errors-common;
-            uses bgp-encapsulated-errors-common;
-          }
-          description
-            "The backward-transition event is
+          uses bgp-errors-common;
+          uses bgp-encapsulated-errors-common;
+        }
+        description
+          "The backward-transition event is
              generated when the BGP FSM moves from a higher
              numbered state to a lower numbered state.";
-        }
-        action clear {
-          if-feature "bt:clear-neighbors";
-          description
-            "Clear neighbors action.";
+      }
+      action clear {
+        if-feature "bt:clear-neighbors";
+        description
+          "Clear neighbors action.";
 
-          input {
-            choice operation {
-              default operation-admin;
-              description
-                "The type of operation for the clear action.";
-              case operation-admin {
-                leaf admin {
-                  type empty;
-                  description
-                    "Closes the Established BGP session with a BGP
+        input {
+          choice operation {
+            default operation-admin;
+            description
+              "The type of operation for the clear action.";
+            case operation-admin {
+              leaf admin {
+                type empty;
+                description
+                  "Closes the Established BGP session with a BGP
                      NOTIFICATION message with the Administrative
                      Reset error subcode.";
-                  reference
-                    "RFC 4486 - Subcodes for BGP Cease Notification
+                reference
+                  "RFC 4486 - Subcodes for BGP Cease Notification
                      Message.";
-                }
               }
-              case operation-hard {
-                leaf hard {
-                  type empty;
-                  description
-                    "Closes the Established BGP session with a BGP
+            }
+            case operation-hard {
+              leaf hard {
+                type empty;
+                description
+                  "Closes the Established BGP session with a BGP
                      NOTIFICATION message with the Hard Reset error
                      subcode.";
-                  reference
-                    "RFC 8538, Section 3 - Notification Message
+                reference
+                  "RFC 8538, Section 3 - Notification Message
                      Support for BGP Graceful Restart.";
-                }
-              }
-              case operation-soft {
-                leaf soft {
-                  type empty;
-                  description
-                    "Re-sends the current Adj-Rib-Out to this
-                     neighbor.";
-                }
-              }
-              case operation-soft-inbound {
-                leaf soft-inbound {
-                  if-feature "bt:route-refresh";
-                  type empty;
-                  description
-                    "Requests the Adj-Rib-In for this neighbor to be
-                     re-sent using the BGP Route Refresh feature.";
-                }
               }
             }
-
-            leaf clear-at {
-              type yang:date-and-time;
-              description
-                "Time when the clear action command needs to be
-                 executed.";
+            case operation-soft {
+              leaf soft {
+                type empty;
+                description
+                  "Re-sends the current Adj-Rib-Out to this
+                     neighbor.";
+              }
+            }
+            case operation-soft-inbound {
+              leaf soft-inbound {
+                if-feature "bt:route-refresh";
+                type empty;
+                description
+                  "Requests the Adj-Rib-In for this neighbor to be
+                     re-sent using the BGP Route Refresh feature.";
+              }
             }
           }
-          output {
-            leaf clear-finished-at {
-              type yang:date-and-time;
-              description
-                "Time when the clear action command completed.";
-            }
+
+          leaf clear-at {
+            type yang:date-and-time;
+            description
+              "Time when the clear action command needs to be
+                 executed.";
+          }
+        }
+        output {
+          leaf clear-finished-at {
+            type yang:date-and-time;
+            description
+              "Time when the clear action command completed.";
           }
         }
       }


### PR DESCRIPTION
## Summary

This PR simplifies the BGP neighbor configuration hierarchy by reducing the nesting level, making the configuration more intuitive and easier to use.

## Changes

- Reduced configuration path from `/routing/bgp/neighbors/neighbor` to `/routing/bgp/neighbor`
- Removed unnecessary `neighbors` container level in the YANG model
- Updated all related configuration callbacks and paths

## Benefits

- Simpler configuration structure
- More intuitive CLI commands
- Reduced typing for operators
- Better alignment with industry-standard CLI interfaces

## Example

Before:
```
routing bgp neighbors neighbor 10.0.0.1
```

After:
```
routing bgp neighbor 10.0.0.1
```

## Test Plan

- [ ] Verify neighbor configuration works with new path
- [ ] Ensure existing configurations can be migrated
- [ ] Test show commands reflect new structure
- [ ] Validate YANG model changes

🤖 Generated with [Claude Code](https://claude.ai/code)