### PR TITLE
Fix self-originated LSAs flooded without valid checksum

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -277,6 +277,7 @@ impl Ospf {
                 lsa.h.ls_seq_number = lsa.h.ls_seq_number.max(seq.saturating_add(1));
             }
 
+            lsa.update();
             let flood_lsa = lsa.clone();
             area.lsdb.insert_self_originated(lsa, &self.tx, Some(AREA0));
             Self::ospf_spf_schedule(&self.tx, area);
@@ -548,6 +549,7 @@ impl Ospf {
                     lsa.h.ls_seq_number = lsa.h.ls_seq_number.max(seq.saturating_add(1));
                 }
 
+                lsa.update();
                 let flood_lsa = lsa.clone();
                 area.lsdb
                     .insert_self_originated(lsa, &self.tx, Some(area_id));

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -141,6 +141,9 @@ module exec {
             type empty;
           }
         }
+        leaf route {
+          type empty;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Fix Router-LSA and Network-LSA origination to compute checksum/length before cloning for flooding. Previously the flood copy had `ls_checksum=0`, causing neighbors to discard the LSA and never acknowledge, resulting in infinite retransmits.
- Add `route` leaf to OSPF show YANG model

## Test plan
- [ ] Verify retransmit list clears after neighbor acknowledges flooded LSAs
- [ ] Verify `show ip ospf route` YANG path is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)