### PR TITLE
Implement show ip ospf with SPF timing

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1355,8 +1355,9 @@ fn perform_spf_calculation(top: &mut Ospf, area_id: Ipv4Addr) {
     if let Some(source) = source_node {
         let start = Instant::now();
         let spf_result = spf::spf(&graph, source, &spf::SpfOpt::default());
-        top.spf_duration = Some(start.elapsed());
-        top.spf_last = Some(Instant::now());
+        let end = Instant::now();
+        top.spf_duration = Some(end.duration_since(start));
+        top.spf_last = Some(end);
         // println!("[SPF] area {} nodes: {}", area_id, spf_result.len());
         // for (node_id, path) in &spf_result {
         //     if let Some(node) = graph.get(node_id) {

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::net::Ipv4Addr;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use ipnet::{IpNet, Ipv4Net};
 use ospf_packet::*;
@@ -60,6 +61,8 @@ pub struct Ospf {
     pub spf_result: Option<BTreeMap<usize, Path>>,
     pub rib: PrefixMap<Ipv4Net, SpfRoute>,
     pub tracing: OspfTracing,
+    pub spf_last: Option<Instant>,
+    pub spf_duration: Option<Duration>,
 }
 
 // OSPF inteface structure which points out upper layer struct members.
@@ -173,6 +176,8 @@ impl Ospf {
             spf_result: None,
             rib: PrefixMap::new(),
             tracing: OspfTracing::default(),
+            spf_last: None,
+            spf_duration: None,
             sock,
         };
         ospf.callback_build();
@@ -1348,7 +1353,10 @@ fn perform_spf_calculation(top: &mut Ospf, area_id: Ipv4Addr) {
     let (graph, source_node) = graph(top, area_id);
 
     if let Some(source) = source_node {
+        let start = Instant::now();
         let spf_result = spf::spf(&graph, source, &spf::SpfOpt::default());
+        top.spf_duration = Some(start.elapsed());
+        top.spf_last = Some(Instant::now());
         // println!("[SPF] area {} nodes: {}", area_id, spf_result.len());
         // for (node_id, path) in &spf_result {
         //     if let Some(node) = graph.get(node_id) {

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -175,6 +175,8 @@ impl Ospf {
         self.show_add("/show/ip/ospf/database", show_ospf_database);
         self.show_add("/show/ip/ospf/database/detail", show_ospf_database_detail);
         self.show_add("/show/ip/ospf/route", show_ospf_route);
+        self.show_add("/show/ip/ospf/spf", show_ospf_spf);
+        self.show_add("/show/ip/ospf/graps", show_ospf_graph);
     }
 }
 
@@ -1237,4 +1239,20 @@ fn show_ospf_route(
     }
 
     Ok(buf)
+}
+
+fn show_ospf_spf(
+    ospf: &Ospf,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    Ok(String::new())
+}
+
+fn show_ospf_graph(
+    ospf: &Ospf,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    Ok(String::new())
 }

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 use std::net::Ipv4Addr;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use netlink_packet_route::link::LinkFlags;
 use ospf_packet::*;
@@ -476,11 +476,24 @@ fn show_ospf_interface(
 }
 
 fn show_ospf(
-    _ospf: &Ospf,
+    ospf: &Ospf,
     _args: Args,
     _json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
-    Ok(String::from("show ospf"))
+    let mut buf = String::new();
+    writeln!(buf, " OSPF Routing Process, Router ID: {}", ospf.router_id)?;
+    if let Some(spf_last) = ospf.spf_last {
+        let elapsed = Instant::now().duration_since(spf_last);
+        writeln!(
+            buf,
+            " SPF algorithm last executed {} ago",
+            format_uptime(elapsed)
+        )?;
+    }
+    if let Some(spf_duration) = ospf.spf_duration {
+        writeln!(buf, " Last SPF duration {} usecs", spf_duration.as_micros())?;
+    }
+    Ok(buf)
 }
 
 fn nbr_state_string(

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -144,6 +144,12 @@ module exec {
         leaf route {
           type empty;
         }
+        leaf graph {
+          type empty;
+        }
+        leaf spf {
+          type empty;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Implement `show ip ospf` command displaying Router ID, SPF last-execution time, and SPF duration
- Add `spf_last` and `spf_duration` fields to `Ospf` struct, recorded during SPF calculation
- Add stub handlers for `show ip ospf spf` and `show ip ospf graph` commands with YANG model entries

## Test plan
- [ ] Run `show ip ospf` and verify output shows Router ID, SPF elapsed time, and duration in usecs
- [ ] Verify SPF timing updates after topology changes trigger recalculation
- [ ] Confirm `show ip ospf spf` and `show ip ospf graph` commands are recognized by CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)