### PR TITLE
Implement RFC 8654 Extended Message Support for BGP

### DIFF
--- a/crates/bgp-packet/src/attrs/mp_reach.rs
+++ b/crates/bgp-packet/src/attrs/mp_reach.rs
@@ -59,10 +59,10 @@ impl MpReachAttr {
         }
     }
 
-    pub fn attr_emit_mut(&mut self, buf: &mut BytesMut) {
+    pub fn attr_emit_mut(&mut self, buf: &mut BytesMut, max_size: usize) {
         match self {
             MpReachAttr::Vpnv4(attr) => {
-                attr.attr_emit_mut(buf);
+                attr.attr_emit_mut(buf, max_size);
             }
             _ => {
                 //

--- a/crates/bgp-packet/src/attrs/nlri_vpnv4.rs
+++ b/crates/bgp-packet/src/attrs/nlri_vpnv4.rs
@@ -151,7 +151,7 @@ impl AttrEmitter for Vpnv4Reach {
 }
 
 impl Vpnv4Reach {
-    pub fn attr_emit_mut(&mut self, buf: &mut BytesMut) {
+    pub fn attr_emit_mut(&mut self, buf: &mut BytesMut, max_size: usize) {
         let flags = self.attr_flags();
         let attr_type = self.attr_type();
         let emit_header = |buf: &mut BytesMut, len: usize, extended: bool| {
@@ -170,11 +170,11 @@ impl Vpnv4Reach {
             // Length is known.
             let extended = len > 255;
             emit_header(buf, len, extended);
-            self.emit_mut(buf);
+            self.emit_mut(buf, max_size);
         } else {
             // Buffer the attribute to determine its length.
             let mut attr_buf = BytesMut::new();
-            self.emit_mut(&mut attr_buf);
+            self.emit_mut(&mut attr_buf, max_size);
             let len = attr_buf.len();
             let extended = len > 255;
             emit_header(buf, len, extended);
@@ -182,7 +182,7 @@ impl Vpnv4Reach {
         }
     }
 
-    fn emit_mut(&mut self, buf: &mut BytesMut) {
+    fn emit_mut(&mut self, buf: &mut BytesMut, max_size: usize) {
         // AFI/SAFI.
         buf.put_u16(u16::from(Afi::Ip));
         buf.put_u8(u8::from(Safi::MplsVpn));
@@ -212,7 +212,7 @@ impl Vpnv4Reach {
             // Prefix.
             nlri_len += nlri_psize(update.nlri.prefix.prefix_len());
 
-            if nlri_len + buf.len() > 4096 {
+            if nlri_len + buf.len() > max_size {
                 self.updates.push(update);
                 return;
             }

--- a/crates/bgp-packet/src/packet.rs
+++ b/crates/bgp-packet/src/packet.rs
@@ -7,6 +7,7 @@ use nom_derive::*;
 use crate::{NotificationPacket, OpenPacket, UpdatePacket};
 
 pub const BGP_PACKET_LEN: usize = 4096;
+pub const BGP_EXTENDED_PACKET_LEN: usize = 65535;
 pub const BGP_HEADER_LEN: u16 = 19;
 
 #[repr(u8)]

--- a/crates/bgp-packet/src/parser.rs
+++ b/crates/bgp-packet/src/parser.rs
@@ -7,8 +7,8 @@ use nom::combinator::peek;
 use nom_derive::*;
 
 use crate::{
-    Afi, AfiSafi, BgpHeader, BgpPacket, BgpParseError, BgpType, NotificationPacket, OpenPacket,
-    Safi, UpdatePacket,
+    Afi, AfiSafi, BGP_EXTENDED_PACKET_LEN, BGP_PACKET_LEN, BgpHeader, BgpPacket, BgpParseError,
+    BgpType, NotificationPacket, OpenPacket, Safi, UpdatePacket,
 };
 
 #[derive(Default, Debug, Clone)]
@@ -23,6 +23,8 @@ pub struct ParseOption {
     pub as4: Direct,
     // AddPath
     pub add_path: BTreeMap<AfiSafi, Direct>,
+    // Extended Message (RFC 8654)
+    pub extended_message: bool,
 }
 
 impl ParseOption {
@@ -40,9 +42,18 @@ impl ParseOption {
         self.add_path.get(&key).is_some_and(|direct| direct.send)
     }
 
+    pub fn max_message_len(&self) -> usize {
+        if self.extended_message {
+            BGP_EXTENDED_PACKET_LEN
+        } else {
+            BGP_PACKET_LEN
+        }
+    }
+
     pub fn clear(&mut self) {
         self.as4 = Direct::default();
         self.add_path.clear();
+        self.extended_message = false;
     }
 }
 

--- a/crates/bgp-packet/src/update.rs
+++ b/crates/bgp-packet/src/update.rs
@@ -9,8 +9,9 @@ use nom::number::complete::be_u16;
 use nom_derive::*;
 
 use crate::{
-    Afi, BGP_HEADER_LEN, BgpAttr, BgpHeader, BgpParseError, BgpType, Ipv4Nlri, MpReachAttr,
-    MpUnreachAttr, ParseOption, Safi, nlri_psize, parse_bgp_nlri_ipv4, parse_bgp_update_attribute,
+    Afi, BGP_HEADER_LEN, BGP_PACKET_LEN, BgpAttr, BgpHeader, BgpParseError, BgpType, Ipv4Nlri,
+    MpReachAttr, MpUnreachAttr, ParseOption, Safi, nlri_psize, parse_bgp_nlri_ipv4,
+    parse_bgp_update_attribute,
 };
 
 #[derive(NomBE)]
@@ -34,6 +35,13 @@ impl UpdatePacket {
     pub fn new() -> Self {
         Self::default()
     }
+
+    pub fn with_max_packet_size(max_packet_size: usize) -> Self {
+        Self {
+            max_packet_size,
+            ..Self::default()
+        }
+    }
 }
 
 impl Default for UpdatePacket {
@@ -45,7 +53,7 @@ impl Default for UpdatePacket {
             ipv4_withdraw: Vec::new(),
             mp_update: None,
             mp_withdraw: None,
-            max_packet_size: 4096,
+            max_packet_size: BGP_PACKET_LEN,
         }
     }
 }
@@ -138,7 +146,7 @@ impl UpdatePacket {
         }
 
         // MP reach.
-        mp_update.attr_emit_mut(&mut buf.get_mut());
+        mp_update.attr_emit_mut(&mut buf.get_mut(), self.max_packet_size);
 
         // Fill in attr length.
         let attr_len: u16 = (buf.len() - attr_len_pos - 2) as u16;

--- a/rfc/bgp/rfc8654.txt
+++ b/rfc/bgp/rfc8654.txt
@@ -1,0 +1,321 @@
+﻿
+
+
+
+Internet Engineering Task Force (IETF)                           R. Bush
+Request for Comments: 8654                                  Arrcus & IIJ
+Updates: 4271                                                   K. Patel
+Category: Standards Track                                   Arrcus, Inc.
+ISSN: 2070-1721                                                  D. Ward
+                                                           Cisco Systems
+                                                            October 2019
+
+
+                    Extended Message Support for BGP
+
+Abstract
+
+   The BGP specification (RFC 4271) mandates a maximum BGP message size
+   of 4,096 octets.  As BGP is extended to support new Address Family
+   Identifiers (AFIs), Subsequent AFIs (SAFIs), and other features,
+   there is a need to extend the maximum message size beyond 4,096
+   octets.  This document updates the BGP specification by extending the
+   maximum message size from 4,096 octets to 65,535 octets for all
+   messages except for OPEN and KEEPALIVE messages.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 7841.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   https://www.rfc-editor.org/info/rfc8654.
+
+Copyright Notice
+
+   Copyright (c) 2019 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction
+     1.1.  Requirements Language
+   2.  BGP Extended Message
+   3.  BGP Extended Message Capability
+   4.  Operation
+   5.  Error Handling
+   6.  Changes to RFC 4271
+   7.  IANA Considerations
+   8.  Security Considerations
+   9.  References
+     9.1.  Normative References
+     9.2.  Informative References
+   Acknowledgments
+   Authors' Addresses
+
+1.  Introduction
+
+   The BGP specification [RFC4271] mandates a maximum BGP message size
+   of 4,096 octets.  As BGP is extended to support new AFIs, SAFIs, and
+   other capabilities (e.g., BGPsec [RFC8205] and BGP - Link State (BGP-
+   LS) [RFC7752]), there is a need to extend the maximum message size
+   beyond 4,096 octets.  This document provides an extension to BGP to
+   extend the message size limit from 4,096 octets to 65,535 octets for
+   all messages except for OPEN and KEEPALIVE messages.
+
+1.1.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in
+   BCP 14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+2.  BGP Extended Message
+
+   A BGP message over 4,096 octets in length is a BGP Extended Message.
+
+   BGP Extended Messages have a maximum message size of 65,535 octets.
+   The smallest message that may be sent is a BGP KEEPALIVE, which
+   consists of 19 octets.
+
+3.  BGP Extended Message Capability
+
+   The BGP Extended Message Capability is a new BGP capability [RFC5492]
+   defined with Capability Code 6 and Capability Length 0.
+
+   To advertise the BGP Extended Message Capability to a peer, a BGP
+   speaker uses BGP Capabilities Advertisement [RFC5492].  By
+   advertising the BGP Extended Message Capability to a peer, a BGP
+   speaker conveys that it is able to receive and properly handle BGP
+   Extended Messages (see Section 4).
+
+   Peers that wish to use the BGP Extended Message Capability MUST
+   support error handling for BGP UPDATE messages per [RFC7606].
+
+4.  Operation
+
+   The BGP Extended Message Capability applies to all messages except
+   for OPEN and KEEPALIVE messages.  These exceptions reduce the
+   complexity of providing backward compatibility.
+
+   A BGP speaker that is capable of receiving BGP Extended Messages
+   SHOULD advertise the BGP Extended Message Capability to its peers
+   using BGP Capabilities Advertisement [RFC5492].  A BGP speaker MAY
+   send BGP Extended Messages to a peer only if the BGP Extended Message
+   Capability was received from that peer.
+
+   An implementation that advertises the BGP Extended Message Capability
+   MUST be capable of receiving a message with a length up to and
+   including 65,535 octets.
+
+   Applications generating information that might be encapsulated within
+   BGP messages MUST limit the size of their payload to take the maximum
+   message size into account.
+
+   If a BGP message with a length greater than 4,096 octets is received
+   by a BGP listener who has not advertised the BGP Extended Message
+   Capability, the listener will generate a NOTIFICATION with the Error
+   Subcode set to Bad Message Length ([RFC4271], Section 6.1).
+
+   A BGP UPDATE will (if allowed by policy, best path, etc.) typically
+   propagate throughout the BGP-speaking Internet and hence to BGP
+   speakers that may not support BGP Extended Messages.  Therefore, an
+   announcement in a BGP Extended Message where the size of the
+   attribute set plus the NLRI is larger than 4,096 octets may cause
+   lack of reachability.
+
+   A BGP speaker that has advertised the BGP Extended Message Capability
+   to its peers may receive an UPDATE from one of its peers that
+   produces an ongoing announcement that is larger than 4,096 octets.
+   When propagating that UPDATE onward to a neighbor that has not
+   advertised the BGP Extended Message Capability, the speaker SHOULD
+   try to reduce the outgoing message size by removing attributes
+   eligible under the "attribute discard" approach of [RFC7606].  If the
+   message is still too big, then it must not be sent to the neighbor
+   ([RFC4271], Section 9.2).  Additionally, if the NLRI was previously
+   advertised to that peer, it must be withdrawn from service
+   ([RFC4271], Section 9.1.3).
+
+   If an Autonomous System (AS) has multiple internal BGP speakers and
+   also has multiple external BGP neighbors, care must be taken to
+   ensure a consistent view within the AS in order to present a
+   consistent external view.  In the context of BGP Extended Messages, a
+   consistent view can only be guaranteed if all the Internal BGP (iBGP)
+   speakers advertise the BGP Extended Message Capability.  If that is
+   not the case, then the operator should consider whether or not the
+   BGP Extended Message Capability should be advertised to external
+   peers.
+
+   During the incremental deployment of BGP Extended Messages and use of
+   the "attribute discard" approach of [RFC7606] in an iBGP mesh or with
+   External BGP (eBGP) peers, the operator should monitor any routes
+   dropped and any discarded attributes.
+
+5.  Error Handling
+
+   A BGP speaker that has the ability to use BGP Extended Messages but
+   has not advertised the BGP Extended Message Capability, presumably
+   due to configuration, MUST NOT accept a BGP Extended Message.  A
+   speaker MUST NOT implement a more liberal policy accepting BGP
+   Extended Messages.
+
+   A BGP speaker that does not advertise the BGP Extended Message
+   Capability might also genuinely not support BGP Extended Messages.
+   Such a speaker will follow the error-handling procedures of [RFC4271]
+   if it receives a BGP Extended Message.  Similarly, any speaker that
+   treats an improper BGP Extended Message as a fatal error MUST follow
+   the error-handling procedures of [RFC4271].
+
+   Error handling for UPDATE messages, as specified in Section 6.3 of
+   [RFC4271], is unchanged.  However, if a NOTIFICATION is to be sent to
+   a BGP speaker that has not advertised the BGP Extended Message
+   Capability, the size of the message MUST NOT exceed 4,096 octets.
+
+   It is RECOMMENDED that BGP protocol developers and implementers are
+   conservative in their application and use of BGP Extended Messages.
+   Future protocol specifications MUST describe how to handle peers that
+   can only accommodate 4,096 octet messages.
+
+6.  Changes to RFC 4271
+
+   [RFC4271] states "The value of the Length field MUST always be at
+   least 19 and no greater than 4096."  This document changes the latter
+   number to 65,535 for all messages except for OPEN and KEEPALIVE
+   messages.
+
+   Section 6.1 of [RFC4271] specifies raising an error if the length of
+   a message is over 4,096 octets.  For all messages except for OPEN and
+   KEEPALIVE messages, if the receiver has advertised the BGP Extended
+   Message Capability, this document raises that limit to 65,535.
+
+7.  IANA Considerations
+
+   IANA has made the following allocation in the "Capability Codes"
+   registry:
+
+   +-------+----------------------+-----------+
+   | Value | Description          | Reference |
+   +=======+======================+===========+
+   | 6     | BGP Extended Message | RFC 8654  |
+   +-------+----------------------+-----------+
+
+     Table 1: Addition to "Capability Codes"
+                     Registry
+
+8.  Security Considerations
+
+   This extension to BGP does not change BGP's underlying security
+   issues [RFC4272].
+
+   Due to increased memory requirements for buffering, there may be
+   increased exposure to resource exhaustion, intentional or
+   unintentional.
+
+   If a remote speaker is able to craft a large BGP Extended Message to
+   send on a path where one or more peers do not support BGP Extended
+   Messages, peers that support BGP Extended Messages may:
+
+   *  act to reduce the outgoing message (see Section 4) and, in doing
+      so, cause an attack by discarding attributes one or more of its
+      peers may be expecting.  The attributes eligible under the
+      "attribute discard" approach must have no effect on route
+      selection or installation [RFC7606].
+
+   *  act to reduce the outgoing message (see Section 4) and, in doing
+      so, allow a downgrade attack.  This would only affect the
+      attacker's message, where 'downgrade' has questionable meaning.
+
+   *  incur resource load (processing, message resizing, etc.) when
+      reformatting the large messages.
+
+9.  References
+
+9.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC4271]  Rekhter, Y., Ed., Li, T., Ed., and S. Hares, Ed., "A
+              Border Gateway Protocol 4 (BGP-4)", RFC 4271,
+              DOI 10.17487/RFC4271, January 2006,
+              <https://www.rfc-editor.org/info/rfc4271>.
+
+   [RFC5492]  Scudder, J. and R. Chandra, "Capabilities Advertisement
+              with BGP-4", RFC 5492, DOI 10.17487/RFC5492, February
+              2009, <https://www.rfc-editor.org/info/rfc5492>.
+
+   [RFC7606]  Chen, E., Ed., Scudder, J., Ed., Mohapatra, P., and K.
+              Patel, "Revised Error Handling for BGP UPDATE Messages",
+              RFC 7606, DOI 10.17487/RFC7606, August 2015,
+              <https://www.rfc-editor.org/info/rfc7606>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+9.2.  Informative References
+
+   [RFC4272]  Murphy, S., "BGP Security Vulnerabilities Analysis",
+              RFC 4272, DOI 10.17487/RFC4272, January 2006,
+              <https://www.rfc-editor.org/info/rfc4272>.
+
+   [RFC7752]  Gredler, H., Ed., Medved, J., Previdi, S., Farrel, A., and
+              S. Ray, "North-Bound Distribution of Link-State and
+              Traffic Engineering (TE) Information Using BGP", RFC 7752,
+              DOI 10.17487/RFC7752, March 2016,
+              <https://www.rfc-editor.org/info/rfc7752>.
+
+   [RFC8205]  Lepinski, M., Ed. and K. Sriram, Ed., "BGPsec Protocol
+              Specification", RFC 8205, DOI 10.17487/RFC8205, September
+              2017, <https://www.rfc-editor.org/info/rfc8205>.
+
+Acknowledgments
+
+   The authors thank Alvaro Retana for an amazing review; Enke Chen,
+   Susan Hares, John Scudder, John Levine, and Job Snijders for their
+   input; and Oliver Borchert and Kyehwan Lee for their implementations
+   and testing.
+
+Authors' Addresses
+
+   Randy Bush
+   Arrcus & IIJ
+   5147 Crystal Springs
+   Bainbridge Island, WA 98110
+   United States of America
+
+   Email: randy@psg.com
+
+
+   Keyur Patel
+   Arrcus, Inc.
+
+   Email: keyur@arrcus.com
+
+
+   Dave Ward
+   Cisco Systems
+   170 W. Tasman Drive
+   San Jose, CA 95134
+   United States of America
+
+   Email: dward@cisco.com

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -123,6 +123,7 @@ pub struct PeerTransportConfig {
 pub struct PeerConfig {
     pub transport: PeerTransportConfig,
     pub four_octet: bool,
+    pub extended_message: bool,
     pub mp: AfiSafis<bool>,
     pub restart: AfiSafis<RestartValue>,
     pub llgr: AfiSafis<LlgrValue>,
@@ -137,6 +138,7 @@ impl Default for PeerConfig {
         Self {
             transport: Default::default(),
             four_octet: Default::default(),
+            extended_message: true,
             mp: Default::default(),
             restart: AfiSafis::new(),
             llgr: AfiSafis::new(),
@@ -357,6 +359,14 @@ impl Peer {
         self.config.transport.passive
     }
 
+    pub fn max_packet_size(&self) -> usize {
+        if self.opt.extended_message {
+            BGP_EXTENDED_PACKET_LEN
+        } else {
+            BGP_PACKET_LEN
+        }
+    }
+
     pub fn start(&mut self) {
         if self.peer_as != 0 && !self.address.is_unspecified() && !self.active {
             timer::update_timers(self);
@@ -566,6 +576,11 @@ pub fn fsm_bgp_open(peer: &mut Peer, packet: OpenPacket) -> State {
     // Register add path caps.
     cap_addpath_recv(&packet.bgp_cap, &mut peer.opt, &peer.config.addpath);
 
+    // Extended message negotiation (RFC 8654).
+    if peer.cap_send.extended.is_some() && packet.bgp_cap.extended.is_some() {
+        peer.opt.extended_message = true;
+    }
+
     // Record received capability.
     peer.cap_recv = packet.bgp_cap;
 
@@ -639,8 +654,10 @@ pub async fn peer_packet_parse(
         Ok((_, p)) => {
             match p {
                 BgpPacket::Open(p) => {
-                    // config.cap_recv = p.bgp_cap.clone();
                     cap_addpath_recv(&p.bgp_cap, opt, &config.addpath);
+                    if config.extended_message && p.bgp_cap.extended.is_some() {
+                        opt.extended_message = true;
+                    }
                     let _ = tx.send(Message::Event(ident, Event::BGPOpen(*p))).await;
                 }
                 BgpPacket::Keepalive(_) => {
@@ -668,7 +685,7 @@ pub async fn peer_read(
     mut config: PeerConfig,
     mut opt: ParseOption,
 ) {
-    let mut buf = BytesMut::with_capacity(BGP_PACKET_LEN * 2);
+    let mut buf = BytesMut::with_capacity(BGP_EXTENDED_PACKET_LEN);
     loop {
         match read_half.read_buf(&mut buf).await {
             Ok(read_len) => {
@@ -679,8 +696,14 @@ pub async fn peer_read(
                 while buf.len() >= BGP_HEADER_LEN as usize && buf.len() >= peek_bgp_length(&buf) {
                     let length = peek_bgp_length(&buf);
 
+                    // Validate message length (RFC 8654).
+                    if length < BGP_HEADER_LEN as usize || length > opt.max_message_len() {
+                        let _ = tx.try_send(Message::Event(ident, Event::ConnFail));
+                        return;
+                    }
+
                     let mut remain = buf.split_off(length);
-                    remain.reserve(BGP_PACKET_LEN * 2);
+                    remain.reserve(BGP_EXTENDED_PACKET_LEN);
 
                     match peer_packet_parse(&buf, ident, tx.clone(), &mut config, &mut opt).await {
                         Ok(_) => {
@@ -768,6 +791,9 @@ pub fn peer_send_open(peer: &mut Peer) {
         let cap = CapRefresh::default();
         bgp_cap.refresh = Some(cap);
     }
+    if peer.config.extended_message {
+        bgp_cap.extended = Some(CapExtended::default());
+    }
     for (key, addpath) in peer.config.addpath.iter() {
         bgp_cap.addpath.insert(key.clone(), addpath.clone());
     }
@@ -801,7 +827,13 @@ pub fn peer_send_notification(peer: &mut Peer, code: NotifyCode, sub_code: u8, d
         return;
     };
     let notification = NotificationPacket::new(code, sub_code, data);
-    let bytes: BytesMut = notification.into();
+    let mut bytes: BytesMut = notification.into();
+    // RFC 8654: NOTIFICATION to non-extended peer MUST NOT exceed 4096.
+    if !peer.opt.extended_message && bytes.len() > BGP_PACKET_LEN {
+        bytes.truncate(BGP_PACKET_LEN);
+        let length = bytes.len() as u16;
+        bytes[16..18].copy_from_slice(&length.to_be_bytes());
+    }
     peer.counter[BgpType::Notification as usize].sent += 1;
     let _ = packet_tx.send(bytes);
 }

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -516,6 +516,7 @@ pub fn open_asn(packet: &OpenPacket) -> u32 {
     }
 }
 
+//
 pub fn fsm_bgp_open(peer: &mut Peer, packet: OpenPacket) -> State {
     peer.counter[BgpType::Open as usize].rcvd += 1;
 
@@ -565,7 +566,7 @@ pub fn fsm_bgp_open(peer: &mut Peer, packet: OpenPacket) -> State {
     // Register add path caps.
     cap_addpath_recv(&packet.bgp_cap, &mut peer.opt, &peer.config.addpath);
 
-    // Register graceful restart.
+    // Record received capability.
     peer.cap_recv = packet.bgp_cap;
 
     State::Established

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -771,7 +771,7 @@ fn route_advertise_to_peers(
 
 // Send BGP withdrawal for a prefix
 fn route_withdraw_ipv4(peer: &mut Peer, rd: Option<RouteDistinguisher>, prefix: Ipv4Net, id: u32) {
-    let mut update = UpdatePacket::new();
+    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
 
     match rd {
         Some(rd) => {
@@ -1215,7 +1215,7 @@ pub fn route_update_ipv4(
 }
 
 pub fn route_send_ipv4(peer: &mut Peer, nlri: Ipv4Nlri, bgp_attr: BgpAttr) {
-    let mut update = UpdatePacket::new();
+    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
     update.bgp_attr = Some(bgp_attr);
     update.ipv4_update.push(nlri);
     peer.send_packet(update.into());
@@ -1256,8 +1256,9 @@ impl Peer {
     // Flush BGP update.
     pub fn flush_ipv4(&mut self) {
         let packet_tx = self.packet_tx.clone();
+        let max_size = self.max_packet_size();
         for (attr, nlris) in self.cache_ipv4.drain() {
-            let mut update = UpdatePacket::new();
+            let mut update = UpdatePacket::with_max_packet_size(max_size);
             update.bgp_attr = Some((*attr).clone());
             update.ipv4_update = nlris.into_iter().collect();
 
@@ -1300,8 +1301,9 @@ impl Peer {
     // Flush BGP update.
     pub fn flush_vpnv4(&mut self) {
         let packet_tx = self.packet_tx.clone();
+        let max_size = self.max_packet_size();
         for (attr, nlris) in self.cache_vpnv4.drain() {
-            let mut update = UpdatePacket::new();
+            let mut update = UpdatePacket::with_max_packet_size(max_size);
 
             if let Some(BgpNexthop::Vpnv4(nhop)) = attr.nexthop.as_ref() {
                 let vpnv4reach = Vpnv4Reach {
@@ -1324,7 +1326,7 @@ impl Peer {
 }
 
 pub fn route_send_vpnv4(peer: &mut Peer, nlri: Vpnv4Nlri, bgp_attr: BgpAttr) {
-    let mut update = UpdatePacket::new();
+    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
     if let Some(BgpNexthop::Vpnv4(nhop)) = bgp_attr.nexthop.as_ref() {
         let nlri = Vpnv4Reach {
             snpa: 0,
@@ -1495,20 +1497,20 @@ pub fn route_sync_vpnv4(peer: &mut Peer, bgp: &mut BgpTop) {
 
 // Send End-of-RIB marker for IPv4 Unicast.
 fn send_eor_ipv4_unicast(peer: &mut Peer) {
-    let update = UpdatePacket::new();
+    let update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
     peer.send_packet(update.into());
 }
 
 // Send End-of-RIB marker for VPNv4 Unicast.
 fn send_eor_vpnv4_unicast(peer: &mut Peer) {
-    let mut update = UpdatePacket::new();
+    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
     update.mp_withdraw = Some(MpUnreachAttr::Vpnv4Eor);
     peer.send_packet(update.into());
 }
 
 // Send wildcard RTCv4.
 fn send_default_rtcv4_unicast(peer: &mut Peer) {
-    let mut update = UpdatePacket::new();
+    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
 
     let mut attrs = BgpAttr::new();
     if peer.is_ibgp() {
@@ -1527,7 +1529,7 @@ fn send_default_rtcv4_unicast(peer: &mut Peer) {
 
 // Send End-of-RIB marker for RTCv4.
 fn send_eor_rtcv4_unicast(peer: &mut Peer) {
-    let mut update = UpdatePacket::new();
+    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
     update.mp_withdraw = Some(MpUnreachAttr::Rtcv4Eor);
     peer.send_packet(update.into());
 }

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1212,7 +1212,8 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
             write!(out, "    4 Octet AS:")?;
             if neighbor.cap_send.as4.is_some() {
                 write!(out, " advertised")?;
-            } else if neighbor.cap_recv.as4.is_some() {
+            }
+            if neighbor.cap_recv.as4.is_some() {
                 if neighbor.cap_send.as4.is_some() {
                     write!(out, " and")?;
                 }

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1457,7 +1457,8 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
             write!(out, "    Extended Message:")?;
             if neighbor.cap_send.extended.is_some() {
                 write!(out, " advertised")?;
-            } else if neighbor.cap_recv.extended.is_some() {
+            }
+            if neighbor.cap_recv.extended.is_some() {
                 if neighbor.cap_send.extended.is_some() {
                     write!(out, " and")?;
                 }


### PR DESCRIPTION
## Summary
- Advertise Extended Message capability (code 6) in BGP OPEN
- Track negotiation result in both reader task and main FSM
- Validate incoming message length (4096 before negotiation, 65535 after)
- Use negotiated max packet size for UPDATE fragmentation across all send paths
- Parameterize hardcoded 4096 in VPNv4 NLRI emit
- Truncate NOTIFICATION to 4096 for non-extended peers (RFC 8654 Section 5)
- Fix show.rs display bug where "advertised and received" was never shown

## Test plan
- [x] `cargo build --bin zebra-rs --release` succeeds
- [x] `cargo fmt --all` clean
- [ ] Manual: establish BGP session, verify Extended Message in OPEN
- [ ] Manual: verify `show ip bgp neighbor` displays capability status

Generated with [Claude Code](https://claude.com/claude-code)