### PR TITLE
Add IS-IS multi-topology TLV support (TLV 222, 229)

### DIFF
--- a/crates/isis-packet/src/disp.rs
+++ b/crates/isis-packet/src/disp.rs
@@ -185,6 +185,7 @@ impl Display for IsisTlv {
             Padding(v) => write!(f, "{}", v),
             LspEntries(v) => write!(f, "{}", v),
             ExtIsReach(v) => write!(f, "{}", v),
+            MtIsReach(v) => write!(f, "{}", v),
             Srv6(v) => write!(f, "{}", v),
             ProtoSupported(v) => write!(f, "{}", v),
             Ipv4IfAddr(v) => write!(f, "{}", v),
@@ -196,8 +197,9 @@ impl Display for IsisTlv {
             Ipv6GlobalIfAddr(v) => write!(f, "{}", v),
             Ipv6Reach(v) => write!(f, "{}", v),
             RouterCap(v) => write!(f, "{}", v),
-            MtIpReach(_) => write!(f, ""),
-            MtIpv6Reach(_) => write!(f, ""),
+            MultiTopology(v) => write!(f, "{}", v),
+            MtIpReach(v) => write!(f, "{}", v),
+            MtIpv6Reach(v) => write!(f, "{}", v),
             P2p3Way(v) => write!(f, "{}", v),
             Unknown(v) => {
                 write!(f, "  {:?}", v.typ)

--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -18,7 +18,8 @@ use super::error::{IsisIResult, IsisParseError};
 use super::util::{ParseBe, TlvEmitter, u32_u8_3};
 use super::{
     IsisTlvExtIpReach, IsisTlvExtIsReach, IsisTlvIpv6Reach, IsisTlvMtIpReach, IsisTlvMtIpv6Reach,
-    IsisTlvRouterCap, IsisTlvSrv6, IsisTlvType, IsisType, many0_complete,
+    IsisTlvMtIsReach, IsisTlvMultiTopology, IsisTlvRouterCap, IsisTlvSrv6, IsisTlvType, IsisType,
+    many0_complete,
 };
 
 // IS-IS discriminator.
@@ -523,6 +524,8 @@ pub enum IsisTlv {
     LspEntries(IsisTlvLspEntries),
     #[nom(Selector = "IsisTlvType::ExtIsReach")]
     ExtIsReach(IsisTlvExtIsReach),
+    #[nom(Selector = "IsisTlvType::MtIsReach")]
+    MtIsReach(IsisTlvMtIsReach),
     #[nom(Selector = "IsisTlvType::Srv6")]
     Srv6(IsisTlvSrv6),
     #[nom(Selector = "IsisTlvType::ProtSupported")]
@@ -541,6 +544,8 @@ pub enum IsisTlv {
     Ipv6IfAddr(IsisTlvIpv6IfAddr),
     #[nom(Selector = "IsisTlvType::Ipv6GlobalIfAddr")]
     Ipv6GlobalIfAddr(IsisTlvIpv6GlobalIfAddr),
+    #[nom(Selector = "IsisTlvType::MultiTopology")]
+    MultiTopology(IsisTlvMultiTopology),
     #[nom(Selector = "IsisTlvType::MtIpReach")]
     MtIpReach(IsisTlvMtIpReach),
     #[nom(Selector = "IsisTlvType::Ipv6Reach")]
@@ -564,6 +569,7 @@ impl IsisTlv {
             Padding(v) => v.tlv_emit(buf),
             LspEntries(v) => v.tlv_emit(buf),
             ExtIsReach(v) => v.tlv_emit(buf),
+            MtIsReach(v) => v.tlv_emit(buf),
             Srv6(v) => v.tlv_emit(buf),
             ProtoSupported(v) => v.tlv_emit(buf),
             Ipv4IfAddr(v) => v.tlv_emit(buf),
@@ -573,6 +579,7 @@ impl IsisTlv {
             Ipv6TeRouterId(v) => v.tlv_emit(buf),
             Ipv6IfAddr(v) => v.tlv_emit(buf),
             Ipv6GlobalIfAddr(v) => v.tlv_emit(buf),
+            MultiTopology(v) => v.tlv_emit(buf),
             MtIpReach(v) => v.tlv_emit(buf),
             Ipv6Reach(v) => v.tlv_emit(buf),
             MtIpv6Reach(v) => v.tlv_emit(buf),

--- a/crates/isis-packet/src/sub/mod.rs
+++ b/crates/isis-packet/src/sub/mod.rs
@@ -24,6 +24,7 @@ pub use neigh::{
     AdjSidFlags, IsisSubAdminGrp, IsisSubAsla, IsisSubIpv4IfAddr, IsisSubIpv4NeighAddr,
     IsisSubIpv6IfAddr, IsisSubIpv6NeighAddr, IsisSubLanAdjSid, IsisSubSrv6EndXSid,
     IsisSubSrv6LanEndXSid, IsisSubTeMetric, IsisTlvExtIsReach, IsisTlvExtIsReachEntry,
+    IsisTlvMtIsReach,
 };
 pub mod neigh_code;
 pub use neigh_code::IsisNeighCode;
@@ -32,7 +33,8 @@ pub mod neigh_disp;
 pub mod prefix;
 pub use prefix::{
     IsisSub2Tlv, IsisSubPrefixSid, IsisTlvExtIpReach, IsisTlvExtIpReachEntry, IsisTlvIpv6Reach,
-    IsisTlvIpv6ReachEntry, IsisTlvMtIpReach, IsisTlvMtIpv6Reach, IsisTlvSrv6, PrefixSidFlags,
+    IsisTlvIpv6ReachEntry, IsisTlvMtIpReach, IsisTlvMtIpv6Reach, IsisTlvMultiTopology, IsisTlvSrv6,
+    MultiTopologyId, PrefixSidFlags,
 };
 pub mod prefix_code;
 pub use prefix_code::{IsisPrefixCode, IsisSrv6SidSub2Code};

--- a/crates/isis-packet/src/sub/neigh.rs
+++ b/crates/isis-packet/src/sub/neigh.rs
@@ -3,6 +3,7 @@
 
 use std::net::{Ipv4Addr, Ipv6Addr};
 
+use super::prefix::MultiTopologyId;
 use bitfield_struct::bitfield;
 use bytes::{BufMut, BytesMut};
 use nom::IResult;
@@ -49,6 +50,48 @@ impl TlvEmitter for IsisTlvExtIsReach {
 
     fn emit(&self, buf: &mut BytesMut) {
         self.entries.iter().for_each(|entry| entry.emit(buf));
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisTlvMtIsReach {
+    pub mt: MultiTopologyId,
+    pub entries: Vec<IsisTlvExtIsReachEntry>,
+}
+
+impl ParseBe<IsisTlvMtIsReach> for IsisTlvMtIsReach {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, mt) = be_u16(input)?;
+        let (input, entries) = many0_complete(IsisTlvExtIsReachEntry::parse_be).parse(input)?;
+        Ok((
+            input,
+            Self {
+                mt: mt.into(),
+                entries,
+            },
+        ))
+    }
+}
+
+impl TlvEmitter for IsisTlvMtIsReach {
+    fn typ(&self) -> u8 {
+        IsisTlvType::MtIsReach.into()
+    }
+
+    fn len(&self) -> u8 {
+        let len: u8 = self.entries.iter().map(|entry| entry.len()).sum();
+        len + 2
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u16(self.mt.into());
+        self.entries.iter().for_each(|entry| entry.emit(buf));
+    }
+}
+
+impl From<IsisTlvMtIsReach> for IsisTlv {
+    fn from(tlv: IsisTlvMtIsReach) -> Self {
+        IsisTlv::MtIsReach(tlv)
     }
 }
 

--- a/crates/isis-packet/src/sub/neigh_disp.rs
+++ b/crates/isis-packet/src/sub/neigh_disp.rs
@@ -7,7 +7,7 @@ use super::neigh::{IsisSubAdjSid, IsisSubAdminGrp, IsisSubAsla, IsisSubTlv};
 use super::{
     AdjSidFlags, IsisSubIpv4IfAddr, IsisSubIpv4NeighAddr, IsisSubIpv6IfAddr, IsisSubIpv6NeighAddr,
     IsisSubLanAdjSid, IsisSubSrv6EndXSid, IsisSubSrv6LanEndXSid, IsisSubTeMetric,
-    IsisTlvExtIsReach, IsisTlvExtIsReachEntry,
+    IsisTlvExtIsReach, IsisTlvExtIsReachEntry, IsisTlvMtIsReach,
 };
 
 impl Display for IsisTlvExtIsReach {
@@ -186,6 +186,16 @@ impl Display for IsisSubSrv6LanEndXSid {
         )?;
         for sub2 in &self.sub2s {
             write!(f, "\n      {}", sub2)?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for IsisTlvMtIsReach {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "  MT IS Reachability (MT-ID {}):", self.mt.id())?;
+        for entry in self.entries.iter() {
+            write!(f, "\n{}", entry)?;
         }
         Ok(())
     }

--- a/crates/isis-packet/src/sub/prefix.rs
+++ b/crates/isis-packet/src/sub/prefix.rs
@@ -399,6 +399,44 @@ pub struct MultiTopologyId {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisTlvMultiTopology {
+    pub entries: Vec<MultiTopologyId>,
+}
+
+impl ParseBe<IsisTlvMultiTopology> for IsisTlvMultiTopology {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, entries) = many0_complete(|i| {
+            let (i, mt) = be_u16(i)?;
+            Ok((i, mt.into()))
+        })
+        .parse(input)?;
+        Ok((input, Self { entries }))
+    }
+}
+
+impl TlvEmitter for IsisTlvMultiTopology {
+    fn typ(&self) -> u8 {
+        IsisTlvType::MultiTopology.into()
+    }
+
+    fn len(&self) -> u8 {
+        (self.entries.len() * 2) as u8
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        for entry in &self.entries {
+            buf.put_u16((*entry).into());
+        }
+    }
+}
+
+impl From<IsisTlvMultiTopology> for IsisTlv {
+    fn from(tlv: IsisTlvMultiTopology) -> Self {
+        IsisTlv::MultiTopology(tlv)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IsisTlvMtIpv6Reach {
     pub mt: MultiTopologyId,
     pub entries: Vec<IsisTlvIpv6ReachEntry>,

--- a/crates/isis-packet/src/sub/prefix_disp.rs
+++ b/crates/isis-packet/src/sub/prefix_disp.rs
@@ -8,7 +8,8 @@ use super::prefix::{
 };
 use super::{
     IsisSubPrefixSid, IsisTlvExtIpReach, IsisTlvExtIpReachEntry, IsisTlvIpv6Reach,
-    IsisTlvIpv6ReachEntry,
+    IsisTlvIpv6ReachEntry, IsisTlvMtIpReach, IsisTlvMtIpv6Reach, IsisTlvMultiTopology,
+    MultiTopologyId,
 };
 
 impl Display for IsisTlvExtIpReach {
@@ -130,5 +131,47 @@ impl Display for IsisSub2SidStructure {
             "LB Len: {}, LN Len: {}, Func Len: {}, Arg Len: {}",
             self.lb_len, self.ln_len, self.fun_len, self.arg_len
         )
+    }
+}
+
+impl Display for MultiTopologyId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}", self.id())
+    }
+}
+
+impl Display for IsisTlvMultiTopology {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "  Multi-Topology:")?;
+        for entry in &self.entries {
+            write!(f, " {}", entry)?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for IsisTlvMtIpReach {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "  MT IP Reachability (MT-ID {}):", self.mt.id())?;
+        for (pos, entry) in self.entries.iter().enumerate() {
+            if pos != 0 {
+                writeln!(f)?;
+            }
+            write!(f, "\n{}", entry)?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for IsisTlvMtIpv6Reach {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "  MT IPv6 Reachability (MT-ID {}):", self.mt.id())?;
+        for (pos, entry) in self.entries.iter().enumerate() {
+            if pos != 0 {
+                writeln!(f)?;
+            }
+            write!(f, "\n{}", entry)?;
+        }
+        Ok(())
     }
 }

--- a/crates/isis-packet/src/tlv_type.rs
+++ b/crates/isis-packet/src/tlv_type.rs
@@ -16,6 +16,7 @@ pub enum IsisTlvType {
     Padding = 8,
     LspEntries = 9,
     ExtIsReach = 22,
+    MtIsReach = 222,
     Srv6 = 27,
     ProtSupported = 129,
     Ipv4IfAddr = 132,
@@ -25,6 +26,7 @@ pub enum IsisTlvType {
     Ipv6TeRouterId = 140,
     Ipv6IfAddr = 232,
     Ipv6GlobalIfAddr = 233,
+    MultiTopology = 229,
     MtIpReach = 235,
     Ipv6Reach = 236,
     MtIpv6Reach = 237,
@@ -51,6 +53,7 @@ impl IsisTlvType {
                 | Padding
                 | LspEntries
                 | ExtIsReach
+                | MtIsReach
                 | Srv6
                 | ProtSupported
                 | Ipv4IfAddr
@@ -60,6 +63,7 @@ impl IsisTlvType {
                 | Ipv6TeRouterId
                 | Ipv6IfAddr
                 | Ipv6GlobalIfAddr
+                | MultiTopology
                 | MtIpReach
                 | Ipv6Reach
                 | MtIpv6Reach
@@ -78,6 +82,7 @@ impl From<IsisTlvType> for u8 {
             Padding => 8,
             LspEntries => 9,
             ExtIsReach => 22,
+            MtIsReach => 222,
             Srv6 => 27,
             ProtSupported => 129,
             Ipv4IfAddr => 132,
@@ -87,6 +92,7 @@ impl From<IsisTlvType> for u8 {
             Ipv6TeRouterId => 140,
             Ipv6IfAddr => 232,
             Ipv6GlobalIfAddr => 233,
+            MultiTopology => 229,
             MtIpReach => 235,
             Ipv6Reach => 236,
             MtIpv6Reach => 237,
@@ -106,6 +112,7 @@ impl From<u8> for IsisTlvType {
             8 => Padding,
             9 => LspEntries,
             22 => ExtIsReach,
+            222 => MtIsReach,
             27 => Srv6,
             129 => ProtSupported,
             132 => Ipv4IfAddr,
@@ -115,6 +122,7 @@ impl From<u8> for IsisTlvType {
             140 => Ipv6TeRouterId,
             232 => Ipv6IfAddr,
             233 => Ipv6GlobalIfAddr,
+            229 => MultiTopology,
             235 => MtIpReach,
             236 => Ipv6Reach,
             237 => MtIpv6Reach,


### PR DESCRIPTION
Add TLV 229 (Multi-Topology) and TLV 222 (MT IS Reachability) per RFC 5120. Fix Display implementations for existing TLV 235 (MT IPv4 Reachability) and TLV 237 (MT IPv6 Reachability) which were stubs.