### PR TITLE
feat(bgp): add update-source config for IPv4/IPv6 peers

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -392,6 +392,37 @@ fn config_transport_passive(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
     Some(())
 }
 
+fn config_transport_local_address(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let peer_addr = if let Some(addr) = args.v4addr() {
+        IpAddr::V4(addr)
+    } else if let Some(addr) = args.v6addr() {
+        IpAddr::V6(addr)
+    } else {
+        return None;
+    };
+
+    let peer = bgp.peers.get_mut(&peer_addr)?;
+
+    if op == ConfigOp::Set {
+        let source = if let Some(addr) = args.v4addr() {
+            IpAddr::V4(addr)
+        } else if let Some(addr) = args.v6addr() {
+            IpAddr::V6(addr)
+        } else {
+            return None;
+        };
+        // Address family of the source must match the peer.
+        if source.is_ipv4() != peer_addr.is_ipv4() {
+            return None;
+        }
+        peer.config.transport.update_source = Some(source);
+    } else {
+        peer.config.transport.update_source = None;
+    }
+
+    Some(())
+}
+
 fn config_debug_category(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let category = args.string()?;
     let enable = op == ConfigOp::Set;
@@ -443,6 +474,7 @@ impl Bgp {
         self.callback_peer("/peer-as", config_peer_as);
         self.callback_peer("/local-identifier", config_local_identifier);
         self.callback_peer("/transport/passive-mode", config_transport_passive);
+        self.callback_peer("/transport/local-address", config_transport_local_address);
         self.callback_peer("/afi-safi/enabled", config_afi_safi);
         self.callback_peer("/afi-safi/add-path", config_add_path);
         self.callback_peer("/afi-safi/graceful-restart/enabled", config_restart);

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -10,8 +10,8 @@ use std::time::Instant;
 use bytes::BytesMut;
 use serde::Serialize;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpStream;
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::net::{TcpSocket, TcpStream};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use bgp_packet::*;
@@ -117,6 +117,7 @@ pub struct PeerCounter {
 #[derive(Debug, Default, Clone)]
 pub struct PeerTransportConfig {
     pub passive: bool,
+    pub update_source: Option<IpAddr>,
 }
 
 #[derive(Debug, Clone)]
@@ -748,23 +749,50 @@ pub fn peer_start_connection(peer: &mut Peer) -> Task<()> {
     let ident = peer.ident;
     let tx = peer.tx.clone();
     let address = peer.address;
+    let update_source = peer.config.transport.update_source;
     Task::spawn(async move {
         let tx = tx.clone();
-        let addr = match address {
-            IpAddr::V4(addr) => format!("{}:{}", addr, BGP_PORT),
-            IpAddr::V6(addr) => format!("[{}]:{}", addr, BGP_PORT),
+        let remote: SocketAddr = match address {
+            IpAddr::V4(addr) => SocketAddr::new(IpAddr::V4(addr), BGP_PORT),
+            IpAddr::V6(addr) => SocketAddr::new(IpAddr::V6(addr), BGP_PORT),
         };
-        let result = TcpStream::connect(addr).await;
+        let result = peer_connect(remote, update_source).await;
         match result {
             Ok(stream) => {
-                //
                 let _ = tx.try_send(Message::Event(ident, Event::Connected(stream)));
             }
-            Err(err) => {
+            Err(_err) => {
                 let _ = tx.try_send(Message::Event(ident, Event::ConnFail));
             }
         };
     })
+}
+
+async fn peer_connect(
+    remote: SocketAddr,
+    update_source: Option<IpAddr>,
+) -> std::io::Result<TcpStream> {
+    // Address family of the source must match the remote when specified.
+    if let Some(src) = update_source
+        && src.is_ipv4() != remote.is_ipv4()
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "update-source address family does not match peer address",
+        ));
+    }
+
+    let socket = if remote.is_ipv4() {
+        TcpSocket::new_v4()?
+    } else {
+        TcpSocket::new_v6()?
+    };
+
+    if let Some(src) = update_source {
+        socket.bind(SocketAddr::new(src, 0))?;
+    }
+
+    socket.connect(remote).await
 }
 
 pub fn peer_send_open(peer: &mut Peer) {

--- a/zebra-rs/yang/ietf-bgp-common@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-common@2023-07-05.yang
@@ -417,8 +417,8 @@ submodule ietf-bgp-common {
 
     leaf local-address {
       type union {
-        type inet:ip-address;
-        type if:interface-ref;
+        type inet:ipv4-address;
+        type inet:ipv6-address;
       }
       description
         "Set the local IP (either IPv4 or IPv6) address to use for


### PR DESCRIPTION
## Summary
- Adds per-peer `update-source` configuration that binds the local source address of an outgoing BGP TCP connection to a configured IPv4 or IPv6 address (typically a loopback).
- New YANG path: `/routing/bgp/neighbor/<addr>/transport/local-address`. Supports both IPv4 and IPv6; the source address family must match the peer.
- `peer_start_connection()` now creates a `TcpSocket` of the matching family, validates the source family matches the remote, binds to the source when configured, then connects.
- Narrows the IETF BGP YANG `local-address` union to `ipv4-address` / `ipv6-address` (interface-ref is not supported by this implementation).

## Test plan
- [x] `cargo build --bin zebra-rs` succeeds
- [x] `cargo fmt --all` clean
- [ ] Manual: configure `transport/local-address <loopback-v4>` on an IPv4 peer; verify outgoing connection sources from that address (`ss -tnp`)
- [ ] Manual: configure `transport/local-address <loopback-v6>` on an IPv6 peer; verify same
- [ ] Manual: mismatched family (v4 source on v6 peer) is rejected
- [ ] Manual: clearing the config reverts to kernel-chosen source on next connect

Generated with [Claude Code](https://claude.com/claude-code)