### PR TITLE
Generic YANG choice support + leafref completion groundwork

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -18,7 +18,7 @@ tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
 console-subscriber = "0.4"
-libyang = { git = "https://github.com/zebra-rs/libyang" }
+libyang = { git = "https://github.com/zebra-rs/libyang", rev = "88da815910e20595a99babe8e9d49cdf9ee853c0" }
 #libyang = { path = "../../libyang" }
 regex = "1.10"
 similar = "2"

--- a/zebra-rs/src/config/comps.rs
+++ b/zebra-rs/src/config/comps.rs
@@ -102,6 +102,11 @@ pub fn cleaf(entry: &Rc<Entry>) -> Completion {
             ytype_str(&ytype).to_string()
         } else if let Some(range) = &node.range {
             range.to_string()
+        } else if node.kind == YangType::Leafref {
+            match &node.path {
+                Some(path) => format!("<{} -> {}>", entry.name, path),
+                None => format!("<{}:leafref>", entry.name),
+            }
         } else {
             format!("<{}:{}>", entry.name, ytype_str(&node.kind))
         }

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -320,18 +320,12 @@ pub fn ytype_from_typedef(typedef: &Option<String>) -> Option<YangType> {
 }
 
 fn is_choice_case(entry: &Rc<Entry>) -> Option<(String, String)> {
-    // Check for choice-test subnet choice
-    if entry.name == "prefix-length" || entry.name == "netmask" {
-        return Some(("choice-test-subnet".to_string(), entry.name.clone()));
-    }
-
-    // Add more choice patterns here as needed
-    // Example for routing policy choices:
-    // if entry.name == "protocol-eq" || entry.name == "protocol-neq" {
-    //     return Some(("policy-protocol".to_string(), entry.name.clone()));
-    // }
-
-    None
+    // Choice/case metadata is set by libyang when flattening case
+    // children into the choice's parent `dir` (see libyang's
+    // `choice_entry`). Both must be present.
+    let choice = entry.choice.borrow().clone()?;
+    let case = entry.case.borrow().clone()?;
+    Some((choice, case))
 }
 
 fn entry_match_type(entry: &Rc<Entry>, input: &str, m: &mut Match, s: &mut State) {

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -304,6 +304,13 @@ fn match_builder() -> MatchMap {
         .exec(|m, entry, input, node| {
             m.process(entry, match_string(input, node), cleaf(entry));
         })
+        .kind(YangType::Leafref)
+        .exec(|m, entry, input, node| {
+            // Accept any non-empty word; the target is resolved at
+            // commit time. A future enhancement will enumerate valid
+            // values from the candidate config via `TypeNode.path`.
+            m.process(entry, match_string(input, node), cleaf(entry));
+        })
         .build()
 }
 


### PR DESCRIPTION
## Summary

Consume the libyang changes from zebra-rs/libyang#17 so zebra-rs handles arbitrary YANG `choice` / `case` and leafref-typed leaves generically in the CLI.

- **Generic `choice` / `case` walk**: replace the hardcoded `prefix-length`/`netmask` stub in `is_choice_case` with a read from `entry.choice` / `entry.case` — the metadata libyang now attaches when flattening each case's children into the parent's `dir`. Existing mutual-exclusion state in `State` is unchanged; it now drives any YANG choice, not a single hand-rolled one.
- **Leafref completion hint**: render leafref leaves in the CLI completion as `<name -> /path>` using the newly captured `TypeNode.path`, instead of the opaque `<name:leafref>`.
- **Leafref input acceptance**: add a `YangType::Leafref` arm to `match_builder` so typing a value (e.g. `md5-keychain aaa`) is accepted instead of rejected with "% No such command". Target resolution stays at commit time; enumerating configured values from the candidate config is a separate follow-up.
- **Dependency pin**: update `libyang` to the merged commit 88da815.

## Test plan

- [x] `cargo build -p zebra-rs --bin zebra-rs` — clean.
- [x] libyang `cargo test --test choice_flatten` + `--test leafref_path` — all pass (4/4).
- [x] `./target/debug/zebra-rs --yang-path=./zebra-rs/yang` — YANG parse + augment resolution succeeds; daemon reaches socket bind (port 179 is the only failure, unrelated).
- [ ] Manual CLI walk through `secure-session/options` — the choice cases (`ao-keychain`, `md5-keychain`, `sa`) appear directly under `options` and accept values.

Generated with [Claude Code](https://claude.com/claude-code)