### PR TITLE
Fix make book: mdbook 0.5.x rejects multilingual field; drop duplicate SUMMARY entry

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -2,5 +2,4 @@
 title = "The Zebra Routing Software"
 authors = ["Kunihiro Ishiguro"]
 language = "en"
-multilingual = false
 src = "src"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -14,7 +14,6 @@
 
 - [BGP](ch-02-00-what-is-bgp.md)
   - [Dynamic Neighbors](ch-02-01-dynamic-neighbors.md)
-  - [IPv6 link-local Dynamic Neighbors](ch-02-01-dynamic-neighbors.md)
 
 ## Logging and Monitoring
 


### PR DESCRIPTION
## Summary

Two unrelated errors were both blocking \`make book\` on a current mdbook install (0.5.2):

- **\`book/book.toml\`**: \`multilingual = false\` is no longer a valid [book] field. mdbook 0.5.2 rejects it:

      ERROR Invalid configuration file
          Caused by: TOML parse error at line 5, column 1
      5 | multilingual = false
        | ^^^^^^^^^^^^
      unknown field \`multilingual\`, expected one of \`title\`, \`authors\`, \`description\`, \`src\`, \`language\`, \`text-direction\`

  The field had no effect anyway — single-language is the default. Drop the line.

- **\`book/src/SUMMARY.md\`**: two adjacent list items pointed at the same \`ch-02-01-dynamic-neighbors.md\` file (one titled "Dynamic Neighbors", the other "IPv6 link-local Dynamic Neighbors"). mdbook then fails with:

      ERROR Summary parsing failed for file="book/src/SUMMARY.md"
          Caused by: Duplicate file in SUMMARY.md: "ch-02-01-dynamic-neighbors.md"

  There is no separate \`ch-02-02-*\` file for the IPv6 link-local content, so remove the duplicate entry. When that content is authored, it can be re-added pointing at its own markdown file.

## Test plan

- [x] \`make book\` — now completes with \`HTML book written to /home/kunihiro/zebra-rs/book/book\`.

Generated with [Claude Code](https://claude.com/claude-code)