### PR TITLE
Remove BGP listener auth entries on peer/chain delete

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -53,6 +53,13 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
             Some(peer) => peer.ident,
             None => return None,
         };
+
+        // Defensively clear any listener auth entries associated with
+        // this peer before removing it, in case the per-leaf delete
+        // callbacks didn't fire (e.g., whole-neighbor delete without
+        // explicit tcp-md5 / tcp-ao deletions first).
+        clear_peer_listener_auth(bgp, &addr);
+
         let mut bgp_ref = BgpTop {
             router_id: &bgp.router_id,
             local_rib: &mut bgp.local_rib,
@@ -64,6 +71,52 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
         bgp.peers.remove(&addr);
     }
     Some(())
+}
+
+/// Remove any TCP MD5 / TCP-AO entries for `addr` from the
+/// appropriate listening socket. Best-effort: logs warnings on
+/// failure but does not propagate them, since the peer is being
+/// torn down either way.
+fn clear_peer_listener_auth(bgp: &mut Bgp, addr: &IpAddr) {
+    let fd = match addr {
+        IpAddr::V4(_) => bgp.listen_fd_v4,
+        IpAddr::V6(_) => bgp.listen_fd_v6,
+    };
+    let Some(fd) = fd else { return };
+
+    // MD5: setsockopt with an empty key removes the entry for this
+    // peer address. Only issue the call if the peer had a password
+    // configured.
+    let had_md5 = bgp
+        .peers
+        .get(addr)
+        .and_then(|p| p.config.transport.md5_password.as_ref())
+        .is_some();
+    if had_md5 {
+        if let Err(e) = super::auth::set_tcp_md5_key(fd, *addr, &[]) {
+            tracing::warn!(
+                peer = %addr,
+                error = %e,
+                "TCP MD5 del on listener failed during peer cleanup"
+            );
+        }
+    }
+
+    // TCP-AO: needs the exact (send_id, recv_id) used at install
+    // time, remembered on the peer.
+    if let Some(peer) = bgp.peers.get_mut(addr)
+        && let Some((send_id, recv_id)) = peer.last_ao_installed.take()
+    {
+        if let Err(e) = super::auth::del_tcp_ao_key(fd, *addr, send_id, recv_id) {
+            tracing::warn!(
+                peer = %addr,
+                send_id,
+                recv_id,
+                error = %e,
+                "TCP-AO del on listener failed during peer cleanup"
+            );
+        }
+    }
 }
 
 fn config_peer_as(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
@@ -489,16 +542,16 @@ fn config_peer_tcp_md5_encoding(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
     Some(())
 }
 
-/// Re-resolve TCP-AO keys for every peer whose `ao_config` is set,
-/// cache the result on the peer's transport config, and install the
-/// resolved key on the appropriate listener (IPv4 or IPv6) via
-/// `setsockopt(TCP_AO_ADD_KEY)`.
+/// Re-resolve TCP-AO keys for every peer whose `ao_config` is set
+/// and reconcile the listener state. If the previously installed
+/// (send_id, recv_id) pair differs from the newly resolved one (or
+/// disappears), the old entry is removed via
+/// `setsockopt(TCP_AO_DEL_KEY)` before the new one is installed —
+/// the kernel keys MKTs by (address, send_id, recv_id) and has no
+/// wildcard delete.
 ///
 /// Called from every TCP-AO callback (peer-side and key-chain-side)
-/// after the change has been absorbed into `Bgp`. Stale listener
-/// keys from previous configurations are not removed in this initial
-/// implementation — a daemon restart clears them; explicit del is a
-/// follow-up.
+/// after the change has been absorbed into `Bgp`.
 fn apply_ao_refresh_all(bgp: &mut Bgp) {
     let fd_v4 = bgp.listen_fd_v4;
     let fd_v6 = bgp.listen_fd_v6;
@@ -511,6 +564,12 @@ fn apply_ao_refresh_all(bgp: &mut Bgp) {
         let Some(peer) = bgp.peers.get_mut(&addr) else {
             continue;
         };
+
+        let fd = match addr {
+            IpAddr::V4(_) => fd_v4,
+            IpAddr::V6(_) => fd_v6,
+        };
+
         let resolved = peer
             .config
             .transport
@@ -519,23 +578,42 @@ fn apply_ao_refresh_all(bgp: &mut Bgp) {
             .and_then(|ao| ao.resolve(&key_chains));
         peer.config.transport.resolved_ao_key = resolved.clone();
 
+        let new_ids = resolved.as_ref().map(|r| (r.send_id, r.recv_id));
+
+        // Remove the stale listener entry if the resolved key now
+        // disappears or uses different SendID/RecvID.
+        if let (Some(prev_ids), Some(fd)) = (peer.last_ao_installed, fd)
+            && new_ids != Some(prev_ids)
+        {
+            if let Err(e) = super::auth::del_tcp_ao_key(fd, addr, prev_ids.0, prev_ids.1) {
+                tracing::warn!(
+                    peer = %addr,
+                    send_id = prev_ids.0,
+                    recv_id = prev_ids.1,
+                    error = %e,
+                    "TCP-AO del on listener failed; entry may be stale",
+                );
+            }
+            peer.last_ao_installed = None;
+        }
+
         let Some(r) = resolved else {
             continue;
         };
-        let fd = match addr {
-            IpAddr::V4(_) => fd_v4,
-            IpAddr::V6(_) => fd_v6,
+        let Some(fd) = fd else {
+            continue;
         };
-        if let Some(fd) = fd {
-            if let Err(e) = super::auth::set_tcp_ao_key(
-                fd,
-                addr,
-                r.alg_name,
-                &r.key_material,
-                r.send_id,
-                r.recv_id,
-                r.include_tcp_options,
-            ) {
+        match super::auth::set_tcp_ao_key(
+            fd,
+            addr,
+            r.alg_name,
+            &r.key_material,
+            r.send_id,
+            r.recv_id,
+            r.include_tcp_options,
+        ) {
+            Ok(()) => peer.last_ao_installed = Some((r.send_id, r.recv_id)),
+            Err(e) => {
                 tracing::warn!(
                     peer = %addr,
                     error = %e,

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -313,6 +313,13 @@ pub struct Peer {
     pub cache_vpnv4_rev: HashMap<Vpnv4Nlri, Arc<BgpAttr>>,
     pub cache_ipv4_timer: Option<Timer>,
     pub cache_vpnv4_timer: Option<Timer>,
+    // Runtime bookkeeping for TCP-AO listener state: the (send_id,
+    // recv_id) pair most recently installed via TCP_AO_ADD_KEY for
+    // this peer. Needed because TCP_AO_DEL_KEY requires the exact
+    // IDs — we can't "wildcard-delete" by address. Cleared after a
+    // successful removal or when no AO key is present for this
+    // peer.
+    pub last_ao_installed: Option<(u8, u8)>,
 }
 
 impl Peer {
@@ -365,6 +372,7 @@ impl Peer {
             cache_vpnv4_rev: HashMap::default(),
             cache_ipv4_timer: None,
             cache_vpnv4_timer: None,
+            last_ao_installed: None,
         };
         peer.config
             .mp


### PR DESCRIPTION
## Summary

Polish item 1 from the #301 follow-up list: stale TCP MD5 / TCP-AO entries no longer persist on the BGP listening socket after the backing neighbor or key chain is removed.

### Peer bookkeeping

- New field `Peer.last_ao_installed: Option<(u8, u8)>` records the (send_id, recv_id) pair most recently installed via \`TCP_AO_ADD_KEY\`. The kernel keys MKTs by (address, send_id, recv_id) and has no wildcard delete, so we need the exact pair to call \`TCP_AO_DEL_KEY\` later.

### `apply_ao_refresh_all` reconciliation

- When the resolved AO key disappears OR changes send/recv ids, the prior entry is removed from the listener first, then the new one (if any) is installed. Success and failure are logged via \`tracing::warn!\` but don't propagate — keeping the daemon running with a stale entry beats panicking.

### Explicit cleanup on neighbor delete

- New \`clear_peer_listener_auth(bgp, addr)\` helper is called from \`config_peer\`'s delete branch. MD5: \`setsockopt(TCP_MD5SIG_EXT)\` with an empty key removes the entry. TCP-AO: reads the peer's \`last_ao_installed\` pair and calls \`del_tcp_ao_key\`. Defensive against the case where per-leaf \`tcp-md5\` / \`tcp-ao\` delete callbacks don't fire before the parent neighbor delete.

### Indirect paths that now clean up

- Deleting a \`key-chain\`, deleting a \`key\` within a chain, or clearing a key's crypto-algorithm / key-string / send-id / recv-id all already route through \`apply_ao_refresh_all\`, so they now trigger per-peer listener cleanup automatically for any peer that was referencing the deleted artifact.

## Test plan

- [x] \`cargo build -p zebra-rs --bin zebra-rs\` — clean.
- [x] \`zebra-rs --yang-path=./zebra-rs/yang\` starts, YANG + augments resolve.
- [ ] End-to-end netns verification via the \`bgp_tcp_md5_auth\` / \`bgp_tcp_ao_auth\` BDD features added in #301 — requires root + \`cap_net_{bind_service,admin}\` and kernel ≥ 6.7 for AO; scenarios for key-change and peer-delete are natural extensions once the baseline scenarios are run.

## Remaining polish

Two of the three follow-ups from #301 still open:
- FSM teardown + reconnect when auth changes on an \`Established\` session.
- Key-chain lifetime-based selection + RNextKeyID in-band rollover.

Generated with [Claude Code](https://claude.com/claude-code)