### PR TITLE
refactor(rib): Generic StaticConfig<F> for IPv4/IPv6

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -1364,11 +1364,11 @@ pub fn route_from_msg(msg: RouteMessage) -> Option<FibRoute> {
                 }
                 builder = builder.nexthop(Nexthop::Multi(multi));
             }
-            RouteAttribute::EncapType(e) => {
-                println!("XXX EncapType {}", e);
+            RouteAttribute::EncapType(_e) => {
+                // println!("XXX EncapType {}", e);
             }
-            RouteAttribute::Encap(e) => {
-                println!("XXX Encap {:?}", e);
+            RouteAttribute::Encap(_e) => {
+                // println!("XXX Encap {:?}", e);
             }
 
             _ => {

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -6,7 +6,7 @@ use super::entry::RibEntry;
 use super::link::{LinkConfig, link_config_exec};
 use super::{
     BridgeBuilder, BridgeConfig, Link, MacAddr, MplsConfig, Nexthop, NexthopMap, RibType,
-    StaticConfig, Vxlan, VxlanBuilder, VxlanConfig,
+    StaticConfig, V4, V6, Vxlan, VxlanBuilder, VxlanConfig,
 };
 
 use crate::config::{Args, path_from_command};
@@ -154,7 +154,8 @@ pub struct Rib {
     pub mac_table: BTreeMap<(u32, MacAddr), MacEntry>,
     pub tx: UnboundedSender<Message>,
     pub rx: UnboundedReceiver<Message>,
-    pub static_config: StaticConfig,
+    pub static_v4: StaticConfig<V4>,
+    pub static_v6: StaticConfig<V6>,
     pub mpls_config: MplsConfig,
     pub link_config: LinkConfig,
     pub bridge_config: BridgeBuilder,
@@ -184,7 +185,8 @@ impl Rib {
             mac_table: BTreeMap::new(),
             tx,
             rx,
-            static_config: StaticConfig::new(),
+            static_v4: StaticConfig::<V4>::new(),
+            static_v6: StaticConfig::<V6>::new(),
             mpls_config: MplsConfig::new(),
             link_config: LinkConfig::new(),
             bridge_config: BridgeBuilder::new(),
@@ -380,7 +382,9 @@ impl Rib {
             ConfigOp::Set | ConfigOp::Delete => {
                 let (path, args) = path_from_command(&msg.paths);
                 if path.as_str().starts_with("/routing/static/ipv4/route") {
-                    let _ = self.static_config.exec(path, args, msg.op);
+                    let _ = self.static_v4.exec(path, args, msg.op);
+                } else if path.as_str().starts_with("/routing/static/ipv6/route") {
+                    let _ = self.static_v6.exec(path, args, msg.op);
                 } else if path.as_str().starts_with("/routing/static/mpls/label") {
                     let _ = self.mpls_config.exec(path, args, msg.op);
                 } else if path.as_str().starts_with("/interface") {
@@ -396,7 +400,8 @@ impl Rib {
                 self.bridge_config.commit(self.tx.clone());
                 self.vxlan_config.commit(self.tx.clone());
                 self.link_config.commit(self.tx.clone());
-                self.static_config.commit(self.tx.clone());
+                self.static_v4.commit(self.tx.clone());
+                self.static_v6.commit(self.tx.clone());
                 self.mpls_config.commit(self.tx.clone());
             }
             ConfigOp::Completion => {

--- a/zebra-rs/src/rib/nexthop/inst.rs
+++ b/zebra-rs/src/rib/nexthop/inst.rs
@@ -23,24 +23,21 @@ pub struct NexthopUni {
 
 impl NexthopUni {
     pub fn new(addr: IpAddr, metric: u32, mpls: Vec<Label>) -> Self {
-        let mut uni = Self {
+        let mpls_label = mpls
+            .iter()
+            .filter_map(|label| match label {
+                Label::Implicit(_) => None,
+                Label::Explicit(label) => Some(*label),
+            })
+            .collect();
+        Self {
             addr,
             metric,
             mpls,
+            mpls_label,
             weight: 1,
             ..Default::default()
-        };
-        for mpls in uni.mpls.iter() {
-            match mpls {
-                Label::Implicit(_) => {
-                    // Implicit null is treated as no label.
-                }
-                Label::Explicit(label) => {
-                    uni.mpls_label.push(label.clone());
-                }
-            }
         }
-        uni
     }
 
     // Backward compatibility method for IPv4

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -339,7 +339,7 @@ pub fn rib_entry_show(
                     for mpls in uni.mpls.iter() {
                         match mpls {
                             Label::Implicit(label) => {
-                                write!(buf, " {}(implicit-null)", label).unwrap();
+                                write!(buf, " {} (implicit-null)", label).unwrap();
                             }
                             Label::Explicit(label) => {
                                 write!(buf, " {}", label).unwrap();

--- a/zebra-rs/src/rib/static/config.rs
+++ b/zebra-rs/src/rib/static/config.rs
@@ -2,9 +2,10 @@
 // Copyright 2025-2026 Kunihiro Ishiguro
 
 use std::collections::BTreeMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use anyhow::{Context, Result};
-use ipnet::Ipv4Net;
+use ipnet::{Ipv4Net, Ipv6Net};
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::config::{Args, ConfigOp};
@@ -13,18 +14,77 @@ use crate::rib::{Message, RibType};
 
 use super::StaticRoute;
 
-pub struct StaticConfig {
-    pub config: BTreeMap<Ipv4Net, StaticRoute>,
-    pub cache: BTreeMap<Ipv4Net, StaticRoute>,
-    builder: ConfigBuilder,
+pub trait StaticFamily: Sized + 'static {
+    type Prefix: Ord + Copy;
+    type Addr: Ord + Copy;
+
+    const FAMILY: &'static str;
+
+    fn parse_prefix(args: &mut Args) -> Option<Self::Prefix>;
+    fn parse_addr(args: &mut Args) -> Option<Self::Addr>;
+    fn to_ip_addr(addr: Self::Addr) -> IpAddr;
+    fn add_msg(prefix: Self::Prefix, rib: RibEntry) -> Message;
+    fn del_msg(prefix: Self::Prefix, rib: RibEntry) -> Message;
 }
 
-impl StaticConfig {
+pub struct V4;
+impl StaticFamily for V4 {
+    type Prefix = Ipv4Net;
+    type Addr = Ipv4Addr;
+    const FAMILY: &'static str = "ipv4";
+
+    fn parse_prefix(args: &mut Args) -> Option<Self::Prefix> {
+        args.v4net()
+    }
+    fn parse_addr(args: &mut Args) -> Option<Self::Addr> {
+        args.v4addr()
+    }
+    fn to_ip_addr(addr: Self::Addr) -> IpAddr {
+        IpAddr::V4(addr)
+    }
+    fn add_msg(prefix: Self::Prefix, rib: RibEntry) -> Message {
+        Message::Ipv4Add { prefix, rib }
+    }
+    fn del_msg(prefix: Self::Prefix, rib: RibEntry) -> Message {
+        Message::Ipv4Del { prefix, rib }
+    }
+}
+
+pub struct V6;
+impl StaticFamily for V6 {
+    type Prefix = Ipv6Net;
+    type Addr = Ipv6Addr;
+    const FAMILY: &'static str = "ipv6";
+
+    fn parse_prefix(args: &mut Args) -> Option<Self::Prefix> {
+        args.v6net()
+    }
+    fn parse_addr(args: &mut Args) -> Option<Self::Addr> {
+        args.v6addr()
+    }
+    fn to_ip_addr(addr: Self::Addr) -> IpAddr {
+        IpAddr::V6(addr)
+    }
+    fn add_msg(prefix: Self::Prefix, rib: RibEntry) -> Message {
+        Message::Ipv6Add { prefix, rib }
+    }
+    fn del_msg(prefix: Self::Prefix, rib: RibEntry) -> Message {
+        Message::Ipv6Del { prefix, rib }
+    }
+}
+
+pub struct StaticConfig<F: StaticFamily> {
+    pub config: BTreeMap<F::Prefix, StaticRoute<F>>,
+    pub cache: BTreeMap<F::Prefix, StaticRoute<F>>,
+    builder: ConfigBuilder<F>,
+}
+
+impl<F: StaticFamily> StaticConfig<F> {
     pub fn new() -> Self {
         Self {
             config: BTreeMap::new(),
             cache: BTreeMap::new(),
-            builder: config_builder(),
+            builder: config_builder::<F>(),
         }
     }
 
@@ -37,7 +97,7 @@ impl StaticConfig {
             .map
             .get(&(path.to_string(), op))
             .context(CONFIG_ERR)?;
-        let prefix: Ipv4Net = args.v4net().context(PREFIX_ERR)?;
+        let prefix = F::parse_prefix(&mut args).context(PREFIX_ERR)?;
 
         func(&mut self.config, &mut self.cache, &prefix, &mut args)
     }
@@ -46,180 +106,198 @@ impl StaticConfig {
         while let Some((p, s)) = self.cache.pop_first() {
             if s.delete {
                 self.config.remove(&p);
-                let msg = Message::Ipv4Del {
-                    prefix: p,
-                    rib: RibEntry::new(RibType::Static),
-                };
-                let _ = tx.send(msg);
+                let _ = tx.send(F::del_msg(p, RibEntry::new(RibType::Static)));
             } else {
                 let entry = s.to_entry();
                 self.config.insert(p, s);
                 if let Some(rib) = entry {
-                    let msg = Message::Ipv4Add { prefix: p, rib };
-                    let _ = tx.send(msg);
+                    let _ = tx.send(F::add_msg(p, rib));
                 }
             }
         }
     }
 }
 
-#[derive(Default)]
-struct ConfigBuilder {
+struct ConfigBuilder<F: StaticFamily> {
     path: String,
-    pub map: BTreeMap<(String, ConfigOp), Handler>,
+    pub map: BTreeMap<(String, ConfigOp), Handler<F>>,
 }
 
-type Handler = fn(
-    config: &mut BTreeMap<Ipv4Net, StaticRoute>,
-    cache: &mut BTreeMap<Ipv4Net, StaticRoute>,
-    prefix: &Ipv4Net,
+impl<F: StaticFamily> Default for ConfigBuilder<F> {
+    fn default() -> Self {
+        Self {
+            path: String::new(),
+            map: BTreeMap::new(),
+        }
+    }
+}
+
+type Handler<F> = fn(
+    config: &mut BTreeMap<<F as StaticFamily>::Prefix, StaticRoute<F>>,
+    cache: &mut BTreeMap<<F as StaticFamily>::Prefix, StaticRoute<F>>,
+    prefix: &<F as StaticFamily>::Prefix,
     args: &mut Args,
 ) -> Result<()>;
 
-impl ConfigBuilder {
+impl<F: StaticFamily> ConfigBuilder<F> {
     pub fn path(mut self, path: &str) -> Self {
         self.path = path.to_string();
         self
     }
 
-    pub fn set(mut self, func: Handler) -> Self {
+    pub fn set(mut self, func: Handler<F>) -> Self {
         self.map.insert((self.path.clone(), ConfigOp::Set), func);
         self
     }
 
-    pub fn del(mut self, func: Handler) -> Self {
+    pub fn del(mut self, func: Handler<F>) -> Self {
         self.map.insert((self.path.clone(), ConfigOp::Delete), func);
         self
     }
 }
 
-fn config_get(config: &BTreeMap<Ipv4Net, StaticRoute>, prefix: &Ipv4Net) -> StaticRoute {
+fn config_get<F: StaticFamily>(
+    config: &BTreeMap<F::Prefix, StaticRoute<F>>,
+    prefix: &F::Prefix,
+) -> StaticRoute<F> {
     let Some(entry) = config.get(prefix) else {
         return StaticRoute::default();
     };
     entry.clone()
 }
 
-fn config_lookup(config: &BTreeMap<Ipv4Net, StaticRoute>, prefix: &Ipv4Net) -> Option<StaticRoute> {
+fn config_lookup<F: StaticFamily>(
+    config: &BTreeMap<F::Prefix, StaticRoute<F>>,
+    prefix: &F::Prefix,
+) -> Option<StaticRoute<F>> {
     let entry = config.get(prefix)?;
     Some(entry.clone())
 }
 
-fn cache_get<'a>(
-    config: &'a BTreeMap<Ipv4Net, StaticRoute>,
-    cache: &'a mut BTreeMap<Ipv4Net, StaticRoute>,
-    prefix: &'a Ipv4Net,
-) -> Option<&'a mut StaticRoute> {
+fn cache_get<'a, F: StaticFamily>(
+    config: &'a BTreeMap<F::Prefix, StaticRoute<F>>,
+    cache: &'a mut BTreeMap<F::Prefix, StaticRoute<F>>,
+    prefix: &'a F::Prefix,
+) -> Option<&'a mut StaticRoute<F>> {
     if cache.get(prefix).is_none() {
-        cache.insert(*prefix, config_get(config, prefix));
+        cache.insert(*prefix, config_get::<F>(config, prefix));
     }
     cache.get_mut(prefix)
 }
 
-fn cache_lookup<'a>(
-    config: &'a BTreeMap<Ipv4Net, StaticRoute>,
-    cache: &'a mut BTreeMap<Ipv4Net, StaticRoute>,
-    prefix: &'a Ipv4Net,
-) -> Option<&'a mut StaticRoute> {
+fn cache_lookup<'a, F: StaticFamily>(
+    config: &'a BTreeMap<F::Prefix, StaticRoute<F>>,
+    cache: &'a mut BTreeMap<F::Prefix, StaticRoute<F>>,
+    prefix: &'a F::Prefix,
+) -> Option<&'a mut StaticRoute<F>> {
     if cache.get(prefix).is_none() {
-        cache.insert(*prefix, config_lookup(config, prefix)?);
+        cache.insert(*prefix, config_lookup::<F>(config, prefix)?);
     }
     let cache = cache.get_mut(prefix)?;
     if cache.delete { None } else { Some(cache) }
 }
 
-fn config_builder() -> ConfigBuilder {
+fn config_builder<F: StaticFamily>() -> ConfigBuilder<F> {
     const CONFIG_ERR: &str = "missing config";
     const NEXTHOP_ERR: &str = "missing nexthop address";
     const METRIC_ERR: &str = "missing metric arg";
     const DISTANCE_ERR: &str = "missing distance arg";
     const WEIGHT_ERR: &str = "missing weight arg";
 
-    ConfigBuilder::default()
-        .path("/routing/static/ipv4/route")
+    ConfigBuilder::<F>::default()
+        .path(&format!("/routing/static/{}/route", F::FAMILY))
         .set(|config, cache, prefix, _args| {
-            let _ = cache_get(config, cache, prefix).context(CONFIG_ERR)?;
+            let _ = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
             Ok(())
         })
         .del(|config, cache, prefix, _args| {
             if let Some(st) = cache.get_mut(prefix) {
                 st.delete = true;
             } else {
-                let mut st = config_lookup(config, prefix).context(CONFIG_ERR)?;
+                let mut st = config_lookup::<F>(config, prefix).context(CONFIG_ERR)?;
                 st.delete = true;
                 cache.insert(*prefix, st);
             }
             Ok(())
         })
-        .path("/routing/static/ipv4/route/metric")
+        .path(&format!("/routing/static/{}/route/metric", F::FAMILY))
         .set(|config, cache, prefix, args| {
-            let s = cache_get(config, cache, prefix).context(CONFIG_ERR)?;
+            let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
             s.metric = Some(args.u32().context(METRIC_ERR)?);
             Ok(())
         })
         .del(|config, cache, prefix, _args| {
-            let s = cache_lookup(config, cache, prefix).context(CONFIG_ERR)?;
+            let s = cache_lookup::<F>(config, cache, prefix).context(CONFIG_ERR)?;
             s.metric = None;
             Ok(())
         })
-        .path("/routing/static/ipv4/route/distance")
+        .path(&format!("/routing/static/{}/route/distance", F::FAMILY))
         .set(|config, cache, prefix, args| {
-            let s = cache_get(config, cache, prefix).context(CONFIG_ERR)?;
+            let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
             s.distance = Some(args.u8().context(DISTANCE_ERR)?);
             Ok(())
         })
         .del(|config, cache, prefix, _args| {
-            let s = cache_lookup(config, cache, prefix).context(CONFIG_ERR)?;
+            let s = cache_lookup::<F>(config, cache, prefix).context(CONFIG_ERR)?;
             s.distance = None;
             Ok(())
         })
-        .path("/routing/static/ipv4/route/nexthop")
+        .path(&format!("/routing/static/{}/route/nexthop", F::FAMILY))
         .set(|config, cache, prefix, args| {
-            let s = cache_get(config, cache, prefix).context(CONFIG_ERR)?;
-            let naddr = args.v4addr().context(NEXTHOP_ERR)?;
+            let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
+            let naddr = F::parse_addr(args).context(NEXTHOP_ERR)?;
             let _ = s.nexthops.entry(naddr).or_default();
             Ok(())
         })
         .del(|config, cache, prefix, args| {
-            let s = cache_lookup(config, cache, prefix).context(CONFIG_ERR)?;
-            let naddr = args.v4addr().context(NEXTHOP_ERR)?;
+            let s = cache_lookup::<F>(config, cache, prefix).context(CONFIG_ERR)?;
+            let naddr = F::parse_addr(args).context(NEXTHOP_ERR)?;
             s.nexthops.remove(&naddr).context(CONFIG_ERR)?;
             Ok(())
         })
-        .path("/routing/static/ipv4/route/nexthop/metric")
+        .path(&format!(
+            "/routing/static/{}/route/nexthop/metric",
+            F::FAMILY
+        ))
         .set(|config, cache, prefix, args| {
-            let s = cache_get(config, cache, prefix).context(CONFIG_ERR)?;
-            let naddr = args.v4addr().context(NEXTHOP_ERR)?;
+            let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
+            let naddr = F::parse_addr(args).context(NEXTHOP_ERR)?;
             let n = s.nexthops.entry(naddr).or_default();
             n.metric = Some(args.u32().context(METRIC_ERR)?);
             Ok(())
         })
         .del(|config, cache, prefix, args| {
-            let s = cache_lookup(config, cache, prefix).context(CONFIG_ERR)?;
-            let naddr = args.v4addr().context(NEXTHOP_ERR)?;
+            let s = cache_lookup::<F>(config, cache, prefix).context(CONFIG_ERR)?;
+            let naddr = F::parse_addr(args).context(NEXTHOP_ERR)?;
             let n = s.nexthops.get_mut(&naddr).context(CONFIG_ERR)?;
             n.metric = None;
             Ok(())
         })
-        .path("/routing/static/ipv4/route/nexthop/weight")
+        .path(&format!(
+            "/routing/static/{}/route/nexthop/weight",
+            F::FAMILY
+        ))
         .set(|config, cache, prefix, args| {
-            let s = cache_get(config, cache, prefix).context(CONFIG_ERR)?;
-            let naddr = args.v4addr().context(NEXTHOP_ERR)?;
+            let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
+            let naddr = F::parse_addr(args).context(NEXTHOP_ERR)?;
             let n = s.nexthops.entry(naddr).or_default();
             n.weight = Some(args.u8().context(WEIGHT_ERR)?);
             Ok(())
         })
         .del(|config, cache, prefix, args| {
-            let s = cache_lookup(config, cache, prefix).context(CONFIG_ERR)?;
-            let naddr = args.v4addr().context(NEXTHOP_ERR)?;
+            let s = cache_lookup::<F>(config, cache, prefix).context(CONFIG_ERR)?;
+            let naddr = F::parse_addr(args).context(NEXTHOP_ERR)?;
             let n = s.nexthops.get_mut(&naddr).context(CONFIG_ERR)?;
             n.weight = None;
             Ok(())
         })
-        .path("/routing/static/ipv4/route/nexthop/label")
+        .path(&format!(
+            "/routing/static/{}/route/nexthop/label",
+            F::FAMILY
+        ))
         .set(|config, cache, prefix, args| {
-            let s = cache_get(config, cache, prefix).context(CONFIG_ERR)?;
-            let naddr = args.v4addr().context(NEXTHOP_ERR)?;
+            let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
+            let naddr = F::parse_addr(args).context(NEXTHOP_ERR)?;
             let n = s.nexthops.entry(naddr).or_default();
             n.labels.clear();
             while let Some(label) = args.u32() {
@@ -228,8 +306,8 @@ fn config_builder() -> ConfigBuilder {
             Ok(())
         })
         .del(|config, cache, prefix, args| {
-            let s = cache_lookup(config, cache, prefix).context(CONFIG_ERR)?;
-            let naddr = args.v4addr().context(NEXTHOP_ERR)?;
+            let s = cache_lookup::<F>(config, cache, prefix).context(CONFIG_ERR)?;
+            let naddr = F::parse_addr(args).context(NEXTHOP_ERR)?;
             let n = s.nexthops.get_mut(&naddr).context(CONFIG_ERR)?;
             n.labels.clear();
             Ok(())

--- a/zebra-rs/src/rib/static/config.rs
+++ b/zebra-rs/src/rib/static/config.rs
@@ -198,11 +198,11 @@ fn cache_lookup<'a, F: StaticFamily>(
 }
 
 fn config_builder<F: StaticFamily>() -> ConfigBuilder<F> {
-    const CONFIG_ERR: &str = "missing config";
-    const NEXTHOP_ERR: &str = "missing nexthop address";
-    const METRIC_ERR: &str = "missing metric arg";
-    const DISTANCE_ERR: &str = "missing distance arg";
-    const WEIGHT_ERR: &str = "missing weight arg";
+    const CONFIG_ERR: &str = "config parse error";
+    const NEXTHOP_ERR: &str = "nexthop address parse error";
+    const METRIC_ERR: &str = "metric arg parse error";
+    const DISTANCE_ERR: &str = "distance arg parse error";
+    const WEIGHT_ERR: &str = "weight arg parse error";
 
     ConfigBuilder::<F>::default()
         .path(&format!("/routing/static/{}/route", F::FAMILY))

--- a/zebra-rs/src/rib/static/route.rs
+++ b/zebra-rs/src/rib/static/route.rs
@@ -2,11 +2,12 @@
 // Copyright 2025-2026 Kunihiro Ishiguro
 
 use std::collections::BTreeMap;
-use std::net::Ipv4Addr;
 
 use crate::rib::entry::RibEntry;
 use crate::rib::nexthop::{Label, NexthopUni};
 use crate::rib::{Nexthop, NexthopList, NexthopMulti, RibType};
+
+use super::config::StaticFamily;
 
 #[derive(Debug, Default, Clone)]
 pub struct StaticNexthop {
@@ -15,15 +16,50 @@ pub struct StaticNexthop {
     pub labels: Vec<u32>,
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct StaticRoute {
+pub struct StaticRoute<F: StaticFamily> {
     pub distance: Option<u8>,
     pub metric: Option<u32>,
-    pub nexthops: BTreeMap<Ipv4Addr, StaticNexthop>,
+    pub nexthops: BTreeMap<F::Addr, StaticNexthop>,
     pub delete: bool,
 }
 
-impl StaticRoute {
+impl<F: StaticFamily> Default for StaticRoute<F> {
+    fn default() -> Self {
+        Self {
+            distance: None,
+            metric: None,
+            nexthops: BTreeMap::new(),
+            delete: false,
+        }
+    }
+}
+
+impl<F: StaticFamily> Clone for StaticRoute<F> {
+    fn clone(&self) -> Self {
+        Self {
+            distance: self.distance,
+            metric: self.metric,
+            nexthops: self.nexthops.clone(),
+            delete: self.delete,
+        }
+    }
+}
+
+impl<F: StaticFamily> std::fmt::Debug for StaticRoute<F>
+where
+    F::Addr: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StaticRoute")
+            .field("distance", &self.distance)
+            .field("metric", &self.metric)
+            .field("nexthops", &self.nexthops)
+            .field("delete", &self.delete)
+            .finish()
+    }
+}
+
+impl<F: StaticFamily> StaticRoute<F> {
     pub fn to_entry(&self) -> Option<RibEntry> {
         if self.nexthops.is_empty() {
             return None;
@@ -37,7 +73,7 @@ impl StaticRoute {
         if self.nexthops.len() == 1 {
             let (p, n) = self.nexthops.iter().next()?;
             let nhop = NexthopUni {
-                addr: std::net::IpAddr::V4(*p),
+                addr: F::to_ip_addr(*p),
                 metric: n.metric.unwrap_or(metric),
                 weight: n.weight.unwrap_or(1),
                 mpls: n.labels.iter().map(|&l| Label::Explicit(l)).collect(),
@@ -49,7 +85,7 @@ impl StaticRoute {
             return Some(entry);
         }
 
-        let mut map: BTreeMap<u32, Vec<(Ipv4Addr, StaticNexthop)>> = BTreeMap::new();
+        let mut map: BTreeMap<u32, Vec<(F::Addr, StaticNexthop)>> = BTreeMap::new();
         for (p, n) in self.nexthops.clone().iter() {
             let metric = n.metric.unwrap_or(metric);
             let e = map.entry(metric).or_default();
@@ -66,7 +102,7 @@ impl StaticRoute {
             };
             for (p, n) in set.iter() {
                 let nhop = NexthopUni {
-                    addr: std::net::IpAddr::V4(*p),
+                    addr: F::to_ip_addr(*p),
                     metric: n.metric.unwrap_or(metric),
                     weight: n.weight.unwrap_or(1),
                     mpls: n.labels.iter().map(|&l| Label::Explicit(l)).collect(),
@@ -84,7 +120,7 @@ impl StaticRoute {
                 }
                 let (p, n) = set.first()?;
                 let nhop = NexthopUni {
-                    addr: std::net::IpAddr::V4(*p),
+                    addr: F::to_ip_addr(*p),
                     metric: *metric,
                     weight: n.weight.unwrap_or(1),
                     mpls: n.labels.iter().map(|&l| Label::Explicit(l)).collect(),
@@ -101,7 +137,9 @@ impl StaticRoute {
 
 #[cfg(test)]
 mod tests {
+    use super::super::config::V4;
     use super::*;
+    use std::net::Ipv4Addr;
 
     fn nh(labels: Vec<u32>, metric: Option<u32>) -> StaticNexthop {
         StaticNexthop {
@@ -127,7 +165,7 @@ mod tests {
 
     #[test]
     fn single_nexthop_with_labels() {
-        let mut r = StaticRoute::default();
+        let mut r = StaticRoute::<V4>::default();
         r.nexthops.insert(
             Ipv4Addr::new(192, 168, 100, 2),
             nh(vec![16200, 16300], None),
@@ -143,7 +181,7 @@ mod tests {
 
     #[test]
     fn ecmp_distinct_stacks_per_leg() {
-        let mut r = StaticRoute::default();
+        let mut r = StaticRoute::<V4>::default();
         r.nexthops
             .insert(Ipv4Addr::new(192, 168, 100, 2), nh(vec![100, 200], None));
         r.nexthops
@@ -167,7 +205,7 @@ mod tests {
 
     #[test]
     fn ecmp_one_leg_labeled_one_bare() {
-        let mut r = StaticRoute::default();
+        let mut r = StaticRoute::<V4>::default();
         r.nexthops
             .insert(Ipv4Addr::new(192, 168, 100, 2), nh(vec![100], None));
         r.nexthops


### PR DESCRIPTION
## Summary
- Introduce `StaticFamily` trait with `V4`/`V6` impls so `StaticConfig`, `StaticRoute`, and the config builder are generic over the address family. Each handler's YANG path is spelled out inline via `format!(\"/routing/static/{}/route/...\", F::FAMILY)` for grep-ability.
- `Rib` now owns separate `static_v4: StaticConfig<V4>` and `static_v6: StaticConfig<V6>`; the config dispatch and `CommitEnd` route to the matching instance.
- Replace the mutable builder loop in `NexthopUni::new` with a `filter_map` iterator chain; drop an unnecessary `clone` on a `Copy` type.
- Minor cleanups: silence debug `println!`s in netlink route parsing and add a space before `(implicit-null)` in the MPLS label display.

## Test plan
- [x] `cargo build --release` clean
- [x] `cargo test --bin zebra-rs rib::r#static::route::tests` — 3/3 pass
- [ ] Exercise CLI `set routing static ipv6 route ... nexthop ...` end-to-end

Generated with [Claude Code](https://claude.com/claude-code)