### PR TITLE
feat(isis,yang): SR capability advertisement, router-id propagation, and SRv6 static route scaffold

### DIFF
--- a/crates/isis-packet/src/sub/cap.rs
+++ b/crates/isis-packet/src/sub/cap.rs
@@ -292,7 +292,7 @@ impl ParseBe<Srv6Flags> for Srv6Flags {
     }
 }
 
-#[derive(Debug, NomBE, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Default, NomBE, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IsisSubSrv6 {
     pub flags: Srv6Flags,
 }
@@ -308,6 +308,12 @@ impl TlvEmitter for IsisSubSrv6 {
 
     fn emit(&self, buf: &mut BytesMut) {
         buf.put_u16(self.flags.into());
+    }
+}
+
+impl From<IsisSubSrv6> for IsisSubTlv {
+    fn from(sub: IsisSubSrv6) -> Self {
+        IsisSubTlv::Srv6(sub)
     }
 }
 

--- a/zebra-rs/src/config/comps.rs
+++ b/zebra-rs/src/config/comps.rs
@@ -243,7 +243,16 @@ pub fn comps_add_all(
         YangMatch::LeafMatched => {
             //
         }
-        _ => comps_as_leaf(comps, entry),
+        _ => {
+            comps_as_leaf(comps, entry);
+            if let Some(dynamic) = entry.extension.get("ext:dynamic") {
+                if let Some(candidates) = s.dynamic.get(dynamic) {
+                    for cand in candidates.iter() {
+                        comps.push(Completion::new_name(cand));
+                    }
+                }
+            }
+        }
     }
     comps.sort_by(|a, b| a.name.cmp(&b.name));
 

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -22,7 +22,7 @@ use super::{ApplyCode, Completion, Config, ConfigRequest, DisplayRequest, ExecCo
 use libyang::{Entry, YangStore, to_entry};
 use similar::TextDiff;
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::rc::Rc;
 use tokio::sync::mpsc::{self, Receiver, Sender, UnboundedSender};
@@ -376,7 +376,9 @@ impl ConfigManager {
     ) -> (ExecCode, Vec<Completion>) {
         let mut state = State::new();
         if interactive {
-            if let Some(dynamic) = has_dynamic(input) {
+            let mut dynamics = HashSet::new();
+            collect_dynamics(&mode.entry, &mut dynamics);
+            for dynamic in dynamics {
                 let comps = self.comps_dynamic(dynamic.clone()).await;
                 state.dynamic.insert(dynamic, comps);
             }
@@ -594,13 +596,12 @@ pub async fn event_loop(mut config: ConfigManager) {
     }
 }
 
-fn has_dynamic(input: &str) -> Option<String> {
-    if input.split_whitespace().any(|s| s == "interface") {
-        Some(String::from("rib:interface"))
-    } else if input.split_whitespace().any(|s| s == "neighbors") {
-        Some(String::from("bgp:neighbor"))
-    } else {
-        None
+fn collect_dynamics(entry: &Entry, set: &mut HashSet<String>) {
+    if let Some(d) = entry.extension.get("ext:dynamic") {
+        set.insert(d.clone());
+    }
+    for child in entry.dir.borrow().iter() {
+        collect_dynamics(child, set);
     }
 }
 

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -27,7 +27,7 @@ impl Isis {
         self.callback_add("/routing/isis/hostname", config_hostname);
         self.callback_add("/routing/isis/timers/hold-time", config_hold_time);
         self.callback_add("/routing/isis/te-router-id", config_te_router_id);
-        self.callback_add("/routing/segment-routing", config_segment_routing);
+        self.callback_add("/routing/isis/segment-routing", config_segment_routing);
         self.callback_add("/routing/isis/interface/priority", link::config_priority);
         self.tracing_add("/event", config_tracing_event);
         self.tracing_add("/fsm", config_tracing_fsm);
@@ -70,7 +70,7 @@ impl Default for IsisDistribute {
     }
 }
 
-#[derive(Debug, strum_macros::EnumString)]
+#[derive(Debug, PartialEq, strum_macros::EnumString)]
 #[strum(ascii_case_insensitive)]
 pub enum SegmentRouting {
     MPLS,

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -27,6 +27,7 @@ impl Isis {
         self.callback_add("/routing/isis/hostname", config_hostname);
         self.callback_add("/routing/isis/timers/hold-time", config_hold_time);
         self.callback_add("/routing/isis/te-router-id", config_te_router_id);
+        self.callback_add("/routing/segment-routing", config_segment_routing);
         self.callback_add("/routing/isis/interface/priority", link::config_priority);
         self.tracing_add("/event", config_tracing_event);
         self.tracing_add("/fsm", config_tracing_fsm);
@@ -69,6 +70,13 @@ impl Default for IsisDistribute {
     }
 }
 
+#[derive(Debug, strum_macros::EnumString)]
+#[strum(ascii_case_insensitive)]
+pub enum SegmentRouting {
+    MPLS,
+    SRv6,
+}
+
 #[derive(Default)]
 pub struct IsisConfig {
     pub net: Nsap,
@@ -79,6 +87,7 @@ pub struct IsisConfig {
     pub te_router_id: Option<Ipv4Addr>,
     pub enable: Afis<usize>,
     pub distribute: IsisDistribute,
+    pub segment_routing: Option<SegmentRouting>,
 }
 
 impl IsisConfig {
@@ -154,6 +163,16 @@ fn config_hold_time(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()>
         isis.config.hold_time = Some(hold_time);
     } else {
         isis.config.hold_time = None;
+    }
+    Some(())
+}
+
+fn config_segment_routing(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    if op.is_set() {
+        let sr = args.string()?.parse::<SegmentRouting>().ok()?;
+        isis.config.segment_routing = Some(sr);
+    } else {
+        isis.config.segment_routing = None;
     }
     Some(())
 }

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -85,6 +85,7 @@ pub struct IsisConfig {
     pub refresh_time: Option<u16>,
     pub hold_time: Option<u16>,
     pub te_router_id: Option<Ipv4Addr>,
+    pub rib_router_id: Option<Ipv4Addr>,
     pub enable: Afis<usize>,
     pub distribute: IsisDistribute,
     pub segment_routing: Option<SegmentRouting>,

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -155,9 +155,46 @@ impl Isis {
                 // isis_info!("Isis::AddrDel {}", addr.addr);
                 self.addr_del(addr);
             }
+            RibRx::RouterIdUpdate(router_id) => {
+                self.rib_router_id_update(router_id);
+            }
             _ => {
                 //
             }
+        }
+    }
+
+    fn rib_router_id_update(&mut self, router_id: Ipv4Addr) {
+        let new = (!router_id.is_unspecified()).then_some(router_id);
+        if self.config.rib_router_id == new {
+            return;
+        }
+        self.config.rib_router_id = new;
+
+        // Configured te_router_id wins; nothing to re-originate when the
+        // RIB-derived id changes underneath an explicit override.
+        if self.config.te_router_id.is_some() {
+            return;
+        }
+
+        let key = IsisLspId::new(self.config.net.sys_id(), 0, 0);
+        if self.lsdb.get(&Level::L1).get(&key).is_some() {
+            isis_event_trace!(
+                self.tracing,
+                LspOriginate,
+                &Level::L1,
+                "LSP Originate L1 due to RIB router-id change"
+            );
+            self.tx.send(Message::LspOriginate(Level::L1)).unwrap();
+        }
+        if self.lsdb.get(&Level::L2).get(&key).is_some() {
+            isis_event_trace!(
+                self.tracing,
+                LspOriginate,
+                &Level::L2,
+                "LSP Originate L2 due to RIB router-id change"
+            );
+            self.tx.send(Message::LspOriginate(Level::L2)).unwrap();
         }
     }
 
@@ -568,13 +605,13 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
         .insert_originate(top.config.net.sys_id(), hostname.clone());
     lsp.tlvs.push(IsisTlvHostname { hostname }.into());
 
-    // TODO: Router capability. When TE-Router ID is configured, use the value. If
-    // not when Router ID is configured, use the value. Otherwise system
-    // default Router ID will be used.
-    let router_id: Ipv4Addr = match &top.config.te_router_id {
-        Some(router_id) => *router_id,
-        None => "0.0.0.0".parse().unwrap(),
-    };
+    // Effective router-id: configured te_router_id wins, else fall back to the
+    // RIB-derived id, else 0.0.0.0.
+    let router_id: Ipv4Addr = top
+        .config
+        .te_router_id
+        .or(top.config.rib_router_id)
+        .unwrap_or(Ipv4Addr::UNSPECIFIED);
     let mut cap = IsisTlvRouterCap {
         router_id,
         flags: 0.into(),
@@ -609,8 +646,8 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
     cap.subs.push(lb.into());
     lsp.tlvs.push(cap.into());
 
-    // TE Router ID.
-    if let Some(router_id) = top.config.te_router_id {
+    // TE Router ID. Prefer configured value, fall back to RIB-derived.
+    if let Some(router_id) = top.config.te_router_id.or(top.config.rib_router_id) {
         let te_router_id = IsisTlvTeRouterId { router_id };
         lsp.tlvs.push(te_router_id.into());
     }

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -13,6 +13,7 @@ use isis_packet::*;
 use prefix_trie::PrefixMap;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
+use crate::isis::config::SegmentRouting;
 use crate::isis_event_trace;
 
 use crate::config::{DisplayRequest, ShowChannel};
@@ -605,51 +606,75 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
         .insert_originate(top.config.net.sys_id(), hostname.clone());
     lsp.tlvs.push(IsisTlvHostname { hostname }.into());
 
-    // Effective router-id: configured te_router_id wins, else fall back to the
-    // RIB-derived id, else 0.0.0.0.
-    let router_id: Ipv4Addr = top
-        .config
-        .te_router_id
-        .or(top.config.rib_router_id)
-        .unwrap_or(Ipv4Addr::UNSPECIFIED);
-    let mut cap = IsisTlvRouterCap {
-        router_id,
-        flags: 0.into(),
-        subs: Vec::new(),
-    };
+    // SR Capability.
+    if let Some(sr) = &top.config.segment_routing {
+        // Effective router-id: configured te_router_id wins, else fall back to the
+        // RIB-derived id, else 0.0.0.0.
+        let router_id: Ipv4Addr = top
+            .config
+            .te_router_id
+            .or(top.config.rib_router_id)
+            .unwrap_or(Ipv4Addr::UNSPECIFIED);
 
-    // TODO: SR Capability must be obtained from configuration.
-    let mut flags = SegmentRoutingCapFlags::default();
-    flags.set_i_flag(true);
-    flags.set_v_flag(true);
-    let sid_label = SidLabelTlv::Label(16000);
-    let sr_cap = IsisSubSegmentRoutingCap {
-        flags,
-        range: 8000,
-        sid_label,
-    };
-    cap.subs.push(sr_cap.into());
+        // Router Capability.
+        let mut cap = IsisTlvRouterCap {
+            router_id,
+            flags: 0.into(),
+            subs: Vec::new(),
+        };
 
-    // Sub: SR Algorithms
-    let algo = IsisSubSegmentRoutingAlgo {
-        algo: vec![Algo::Spf],
-    };
-    cap.subs.push(algo.into());
+        match *sr {
+            SegmentRouting::MPLS => {
+                let mut flags = SegmentRoutingCapFlags::default();
+                flags.set_i_flag(true);
+                flags.set_v_flag(true);
+                let sid_label = SidLabelTlv::Label(16000);
+                let sr_cap = IsisSubSegmentRoutingCap {
+                    flags,
+                    range: 8000,
+                    sid_label,
+                };
+                cap.subs.push(sr_cap.into());
 
-    // Sub: SR Local Block
-    let sid_label = SidLabelTlv::Label(15000);
-    let lb = IsisSubSegmentRoutingLB {
-        flags: 0,
-        range: 3000,
-        sid_label,
-    };
-    cap.subs.push(lb.into());
-    lsp.tlvs.push(cap.into());
+                // Sub: SR Algorithms
+                let algo = IsisSubSegmentRoutingAlgo {
+                    algo: vec![Algo::Spf],
+                };
+                cap.subs.push(algo.into());
+
+                // Sub: SR Local Block
+                let sid_label = SidLabelTlv::Label(15000);
+                let lb = IsisSubSegmentRoutingLB {
+                    flags: 0,
+                    range: 3000,
+                    sid_label,
+                };
+                cap.subs.push(lb.into());
+
+                lsp.tlvs.push(cap.into());
+            }
+            SegmentRouting::SRv6 => {
+                // SRv6 Capability.
+                let srv6 = IsisSubSrv6::default();
+                cap.subs.push(srv6.into());
+
+                // Sub: SR Algorithms
+                let algo = IsisSubSegmentRoutingAlgo {
+                    algo: vec![Algo::Spf],
+                };
+                cap.subs.push(algo.into());
+
+                lsp.tlvs.push(cap.into());
+            }
+        }
+    }
 
     // TE Router ID. Prefer configured value, fall back to RIB-derived.
-    if let Some(router_id) = top.config.te_router_id.or(top.config.rib_router_id) {
-        let te_router_id = IsisTlvTeRouterId { router_id };
-        lsp.tlvs.push(te_router_id.into());
+    if top.config.segment_routing.is_some() {
+        if let Some(router_id) = top.config.te_router_id.or(top.config.rib_router_id) {
+            let te_router_id = IsisTlvTeRouterId { router_id };
+            lsp.tlvs.push(te_router_id.into());
+        }
     }
 
     // IS Reachability.

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -543,6 +543,11 @@ fn config_afi_enable(isis: &mut Isis, mut args: Args, op: ConfigOp, afi: Afi) ->
     // Currently IS-IS is enabled on this interface.
     let enabled = link.config.enabled();
 
+    // Capture the global per-AFI count before mutation so we can detect a
+    // zero ↔ non-zero transition, which is what flips the AFI's NLPID in
+    // the Protocols Supported TLV (RFC 1195) of our self-originated LSP.
+    let count_before = *isis.config.enable.get(&afi);
+
     if op.is_set() && enable {
         // Set Enable.
         if !*link.config.enable.get(&afi) {
@@ -557,6 +562,9 @@ fn config_afi_enable(isis: &mut Isis, mut args: Args, op: ConfigOp, afi: Afi) ->
         }
     }
 
+    let count_after = *isis.config.enable.get(&afi);
+    let support_changed = (count_before == 0) != (count_after == 0);
+
     if !enabled {
         if link.config.enabled() {
             // Disable -> Enable.
@@ -568,6 +576,28 @@ fn config_afi_enable(isis: &mut Isis, mut args: Args, op: ConfigOp, afi: Afi) ->
             // Enable -> Disable.
             let msg = Message::Ifsm(IfsmEvent::Stop, link.ifindex, None);
             let _ = isis.tx.send(msg);
+        }
+    }
+
+    if support_changed {
+        let key = IsisLspId::new(isis.config.net.sys_id(), 0, 0);
+        if isis.lsdb.get(&Level::L1).get(&key).is_some() {
+            isis_event_trace!(
+                isis.tracing,
+                LspOriginate,
+                &Level::L1,
+                "LSP Originate L1 due to protocols-supported change"
+            );
+            isis.tx.send(Message::LspOriginate(Level::L1)).unwrap();
+        }
+        if isis.lsdb.get(&Level::L2).get(&key).is_some() {
+            isis_event_trace!(
+                isis.tracing,
+                LspOriginate,
+                &Level::L2,
+                "LSP Originate L2 due to protocols-supported change"
+            );
+            isis.tx.send(Message::LspOriginate(Level::L2)).unwrap();
         }
     }
 

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -58,4 +58,10 @@ impl Rib {
             let _ = tx.send(link);
         }
     }
+
+    pub fn api_router_id_update(&self, router_id: Ipv4Addr) {
+        for tx in self.redists.iter() {
+            let _ = tx.send(RibRx::RouterIdUpdate(router_id));
+        }
+    }
 }

--- a/zebra-rs/src/rib/router_id.rs
+++ b/zebra-rs/src/rib/router_id.rs
@@ -29,6 +29,7 @@ impl Rib {
         if let Some(router_id) = router_id(&self.links) {
             if self.router_id != router_id {
                 self.router_id = router_id;
+                self.api_router_id_update(router_id);
             }
         }
     }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -526,6 +526,15 @@ module config {
               type uint32;
               description "Metric of the route.";
             }
+            container srv6 {
+              leaf-list segments {
+                type inet:ipv6-address;
+              }
+              leaf if-name {
+                ext:dynamic "rib:interface";
+                type string;
+              }
+            }
           }
 
           list arp {


### PR DESCRIPTION
## Summary
- Add `srv6` container to static IPv4 route YANG model (groundwork for SRv6 static routes)
- Advertise SR capability in IS-IS LSPs based on `segment-routing` config; re-originate LSP on changes
- Parse `segment-routing` config via `strum_macros::EnumString`
- Propagate RIB router-id changes to IS-IS so LSP source-id stays in sync
- Re-originate LSP on AFI enable transition between zero and non-zero
- Make `ext:dynamic` CLI completion schema-aware

## Test plan
- [ ] `cargo build --release` succeeds
- [ ] `cargo fmt --all -- --check` passes
- [ ] IS-IS LSP carries SR capability sub-TLV when `segment-routing` is configured
- [ ] Changing `router-id` in RIB updates IS-IS source-id and triggers LSP re-origination
- [ ] Toggling AFI enable from/to zero re-originates the LSP
- [ ] CLI completion for `ext:dynamic` reflects the current schema

Generated with [Claude Code](https://claude.com/claude-code)