### PR TITLE
fix(isis): re-establish adjacency after network-type switch

### DIFF
--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -672,12 +672,17 @@ pub fn config_level_common(inst: IsLevel, link: IsLevel) -> IsLevel {
     }
 }
 
-pub fn config_circuit_type(isis: &mut Isis, mut args: Args, _op: ConfigOp) -> Option<()> {
+pub fn config_circuit_type(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let circuit_type = args.string()?.parse::<IsLevel>().ok()?;
 
     let link = isis.links.get_mut_by_name(&name)?;
-    link.config.circuit_type = Some(circuit_type);
+
+    if op.is_set() {
+        link.config.circuit_type = Some(circuit_type);
+    } else {
+        link.config.circuit_type = None;
+    }
 
     let is_level = config_level_common(isis.config.is_type(), link.config.circuit_type());
     link.state.level = is_level;
@@ -685,13 +690,18 @@ pub fn config_circuit_type(isis: &mut Isis, mut args: Args, _op: ConfigOp) -> Op
     Some(())
 }
 
-pub fn config_link_type(isis: &mut Isis, mut args: Args, _op: ConfigOp) -> Option<()> {
+pub fn config_link_type(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let link_type = args.string()?.parse::<LinkType>().ok()?;
 
     let ifindex = {
         let link = isis.links.get_mut_by_name(&name)?;
-        link.config.link_type = Some(link_type);
+
+        if op.is_set() {
+            link.config.link_type = Some(link_type);
+        } else {
+            link.config.link_type = None;
+        }
         link.ifindex
     };
 
@@ -703,24 +713,25 @@ pub fn config_link_type(isis: &mut Isis, mut args: Args, _op: ConfigOp) -> Optio
     Some(())
 }
 
-pub fn config_hello_padding(isis: &mut Isis, mut args: Args, _op: ConfigOp) -> Option<()> {
+pub fn config_hello_padding(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let hello_padding = args.string()?.parse::<HelloPaddingPolicy>().ok()?;
-
     let link = isis.links.get_mut_by_name(&name)?;
 
-    if link.config.hello_padding != Some(hello_padding.clone()) {
+    if op.is_set() {
         link.config.hello_padding = Some(hello_padding);
+    } else {
+        link.config.hello_padding = None;
+    }
 
-        // Update Hello.
-        if link.state.hello.l1.is_some() {
-            let msg = Message::Ifsm(IfsmEvent::HelloOriginate, link.ifindex, Some(Level::L1));
-            let _ = isis.tx.send(msg);
-        }
-        if link.state.hello.l2.is_some() {
-            let msg = Message::Ifsm(IfsmEvent::HelloOriginate, link.ifindex, Some(Level::L2));
-            let _ = isis.tx.send(msg);
-        }
+    // Update Hello.
+    if link.state.hello.l1.is_some() {
+        let msg = Message::Ifsm(IfsmEvent::HelloOriginate, link.ifindex, Some(Level::L1));
+        let _ = isis.tx.send(msg);
+    }
+    if link.state.hello.l2.is_some() {
+        let msg = Message::Ifsm(IfsmEvent::HelloOriginate, link.ifindex, Some(Level::L2));
+        let _ = isis.tx.send(msg);
     }
 
     Some(())

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -139,13 +139,20 @@ pub fn nbr_hello_interpret(
 pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<MacAddr>) {
     use IfsmEvent::*;
 
+    // Logging.
+    isis_pdu_trace!(link, &level, "[Hello:Recv] {}", link.state.name,);
+
     // Check link capability for the level.
     if !has_level(link.state.level(), level) {
+        isis_pdu_trace!(link, &level, "[Hello:Recv] Link does not have the level");
         return;
     }
 
-    // Logging.
-    isis_pdu_trace!(link, &level, "[Hello:Recv] {}", link.state.name,);
+    // Check link type.
+    if !link.is_lan() {
+        isis_pdu_trace!(link, &level, "[Hello:Recv] Link type is not LAN");
+        return;
+    }
 
     // Find neighbor by system id or create a new one.
     let nbr = link
@@ -264,13 +271,28 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
 
     // Process the Hello for each compatible level
     for level in [Level::L1, Level::L2] {
+        // Logging.
+        isis_pdu_trace!(link, &level, "[P2P Hello:Recv] on link {}", link.state.name);
+
         // Check if both sender and receiver support this level
         if !has_level(link_level, level) || !has_level(pdu_level, level) {
+            isis_pdu_trace!(
+                link,
+                &level,
+                "[P2P Hello:Recv] Link does not have enough level"
+            );
             continue;
         }
 
-        // Logging.
-        isis_pdu_trace!(link, &level, "[P2P Hello:Recv] on link {}", link.state.name);
+        // Check link type.
+        if !link.is_p2p() {
+            isis_pdu_trace!(
+                link,
+                &level,
+                "[P2P Hello:Recv] Link type is not point-to-point"
+            );
+            return;
+        }
 
         // Create or update neighbor for this level
         let nbr = link


### PR DESCRIPTION
## Summary
- Honor `ConfigOp::Unset` in `config_circuit_type`, `config_link_type`, and `config_hello_padding`; the previous code ignored the op and left stale values when an override was deleted.
- Gate inbound Hello processing by link type: reject LAN Hello on a P2P link and P2P Hello on a LAN link, so switching network-type from `point-to-point` back to default broadcast (or vice versa) drops stale state and re-establishes adjacency cleanly.
- Reorder Hello-recv trace logging so the entry log fires before guard returns.

## Test plan
- [ ] Configure two IS-IS routers with `network-type point-to-point`, verify adjacency comes up.
- [ ] Remove `network-type point-to-point` on one side (revert to broadcast); confirm the link config clears to `None` and a new broadcast adjacency is established.
- [ ] Reverse the transition (broadcast → point-to-point) and confirm adjacency re-establishes.
- [ ] Toggle `circuit-type` and `hello-padding` overrides and verify deletion clears the value.

Generated with [Claude Code](https://claude.com/claude-code)