### PR TITLE
feat(rib,fib): IPv6 static route resolution and FIB install

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -41,6 +41,9 @@ use crate::rib::{
     Vxlan, link,
 };
 
+// Flip to true to re-enable IPv6 FIB install diagnostic prints.
+const DEBUG_V6: bool = false;
+
 /// Check if the kernel supports nexthop ID (kernel >= 5.3).
 /// Nexthop table was introduced in Linux kernel 5.3.
 fn kernel_supports_nhid() -> bool {
@@ -327,6 +330,243 @@ impl FibHandle {
         }
     }
 
+    pub async fn route_ipv6_add_uni(&self, prefix: &Ipv6Net, entry: &RibEntry, nexthop: &Nexthop) {
+        if DEBUG_V6 {
+            println!(
+                "[IPv6 route_add_uni] prefix={} prefixlen={} rtype={:?} use_nhid={}",
+                prefix,
+                prefix.prefix_len(),
+                entry.rtype,
+                self.use_nhid,
+            );
+        }
+
+        let mut msg = RouteMessage::default();
+        msg.header.address_family = AddressFamily::Inet6;
+        msg.header.destination_prefix_length = prefix.prefix_len();
+
+        msg.header.table = RouteHeader::RT_TABLE_MAIN;
+        msg.header.protocol = match entry.rtype {
+            RibType::Static => RouteProtocol::Static,
+            RibType::Bgp => RouteProtocol::Bgp,
+            RibType::Ospf => RouteProtocol::Ospf,
+            RibType::Isis => RouteProtocol::Isis,
+            _ => RouteProtocol::Static,
+        };
+
+        msg.header.scope = RouteScope::Universe;
+        msg.header.kind = RouteType::Unicast;
+
+        let attr = RouteAttribute::Destination(RouteAddress::Inet6(prefix.addr()));
+        msg.attributes.push(attr);
+
+        if self.use_nhid {
+            if let Nexthop::Uni(uni) = &nexthop {
+                if DEBUG_V6 {
+                    println!(
+                        "[IPv6 route_add_uni] using nhid: gid={} metric={}",
+                        uni.gid, uni.metric
+                    );
+                }
+                msg.attributes.push(RouteAttribute::Nhid(uni.gid as u32));
+                let attr = RouteAttribute::Priority(uni.metric);
+                msg.attributes.push(attr);
+            }
+            if let Nexthop::Multi(multi) = &nexthop {
+                if DEBUG_V6 {
+                    println!(
+                        "[IPv6 route_add_uni] using nhid (multi): gid={} metric={}",
+                        multi.gid, multi.metric
+                    );
+                }
+                msg.attributes.push(RouteAttribute::Nhid(multi.gid as u32));
+                let attr = RouteAttribute::Priority(multi.metric);
+                msg.attributes.push(attr);
+            }
+        } else {
+            if let Nexthop::Uni(uni) = &nexthop {
+                if DEBUG_V6 {
+                    println!(
+                        "[IPv6 route_add_uni] embed nexthop: addr={} ifindex={} metric={}",
+                        uni.addr, uni.ifindex, uni.metric
+                    );
+                }
+                match uni.addr {
+                    IpAddr::V4(ipv4) => {
+                        msg.attributes
+                            .push(RouteAttribute::Gateway(RouteAddress::Inet(ipv4)));
+                    }
+                    IpAddr::V6(ipv6) => {
+                        msg.attributes
+                            .push(RouteAttribute::Gateway(RouteAddress::Inet6(ipv6)));
+                    }
+                }
+                if uni.ifindex != 0 {
+                    msg.attributes.push(RouteAttribute::Oif(uni.ifindex));
+                }
+                let attr = RouteAttribute::Priority(uni.metric);
+                msg.attributes.push(attr);
+            }
+            if let Nexthop::Multi(multi) = &nexthop {
+                let mut mpath = vec![];
+                for uni in multi.nexthops.iter() {
+                    let mut nhop = RouteNextHop::default();
+                    let attr = match uni.addr {
+                        IpAddr::V4(ipv4) => RouteAttribute::Gateway(RouteAddress::Inet(ipv4)),
+                        IpAddr::V6(ipv6) => RouteAttribute::Gateway(RouteAddress::Inet6(ipv6)),
+                    };
+                    nhop.attributes.push(attr);
+                    if uni.ifindex != 0 {
+                        nhop.attributes.push(RouteAttribute::Oif(uni.ifindex));
+                    }
+                    mpath.push(nhop);
+                }
+                msg.attributes.push(RouteAttribute::MultiPath(mpath));
+                let attr = RouteAttribute::Priority(multi.metric);
+                msg.attributes.push(attr);
+            }
+        }
+
+        if DEBUG_V6 {
+            println!(
+                "[IPv6 route_add_uni] netlink request: af={:?} dest_prefix_len={} attrs={:?}",
+                msg.header.address_family, msg.header.destination_prefix_length, msg.attributes
+            );
+        }
+
+        let mut req = NetlinkMessage::from(RouteNetlinkMessage::NewRoute(msg));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL;
+
+        let mut response = self.handle.clone().request(req).unwrap();
+        while let Some(msg) = response.next().await {
+            if let NetlinkPayload::Error(e) = msg.payload {
+                println!("NewRoute IPv6 error: {prefix} {e}");
+            }
+        }
+    }
+
+    pub async fn route_ipv6_add(&self, prefix: &Ipv6Net, entry: &RibEntry) {
+        if !entry.is_protocol() {
+            return;
+        }
+        match &entry.nexthop {
+            Nexthop::Uni(_) | Nexthop::Multi(_) => {
+                self.route_ipv6_add_uni(prefix, entry, &entry.nexthop).await;
+            }
+            Nexthop::List(pro) => {
+                for uni in pro.nexthops.iter() {
+                    self.route_ipv6_add_uni(prefix, entry, &Nexthop::Uni(uni.clone()))
+                        .await;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub async fn route_ipv6_del_uni(&self, prefix: &Ipv6Net, entry: &RibEntry, nexthop: &Nexthop) {
+        if !entry.is_protocol() {
+            return;
+        }
+        let mut msg = RouteMessage::default();
+        msg.header.address_family = AddressFamily::Inet6;
+        msg.header.destination_prefix_length = prefix.prefix_len();
+
+        msg.header.table = RouteHeader::RT_TABLE_MAIN;
+        msg.header.protocol = match entry.rtype {
+            RibType::Static => RouteProtocol::Static,
+            RibType::Bgp => RouteProtocol::Bgp,
+            RibType::Ospf => RouteProtocol::Ospf,
+            RibType::Isis => RouteProtocol::Isis,
+            _ => RouteProtocol::Static,
+        };
+        msg.header.scope = RouteScope::Universe;
+        msg.header.kind = RouteType::Unicast;
+
+        let attr = RouteAttribute::Destination(RouteAddress::Inet6(prefix.addr()));
+        msg.attributes.push(attr);
+
+        let attr = RouteAttribute::Priority(entry.metric);
+        msg.attributes.push(attr);
+
+        if self.use_nhid {
+            if let Nexthop::Uni(uni) = &nexthop {
+                msg.attributes.push(RouteAttribute::Nhid(uni.gid as u32));
+                let attr = RouteAttribute::Priority(uni.metric);
+                msg.attributes.push(attr);
+            }
+            if let Nexthop::Multi(multi) = &nexthop {
+                msg.attributes.push(RouteAttribute::Nhid(multi.gid as u32));
+                let attr = RouteAttribute::Priority(multi.metric);
+                msg.attributes.push(attr);
+            }
+        } else {
+            if let Nexthop::Uni(uni) = &nexthop {
+                match uni.addr {
+                    IpAddr::V4(ipv4) => {
+                        msg.attributes
+                            .push(RouteAttribute::Gateway(RouteAddress::Inet(ipv4)));
+                    }
+                    IpAddr::V6(ipv6) => {
+                        msg.attributes
+                            .push(RouteAttribute::Gateway(RouteAddress::Inet6(ipv6)));
+                    }
+                }
+                if uni.ifindex != 0 {
+                    msg.attributes.push(RouteAttribute::Oif(uni.ifindex));
+                }
+                let attr = RouteAttribute::Priority(uni.metric);
+                msg.attributes.push(attr);
+            }
+            if let Nexthop::Multi(multi) = &nexthop {
+                let mut mpath = vec![];
+                for uni in multi.nexthops.iter() {
+                    let mut nhop = RouteNextHop::default();
+                    let attr = match uni.addr {
+                        IpAddr::V4(ipv4) => RouteAttribute::Gateway(RouteAddress::Inet(ipv4)),
+                        IpAddr::V6(ipv6) => RouteAttribute::Gateway(RouteAddress::Inet6(ipv6)),
+                    };
+                    nhop.attributes.push(attr);
+                    if uni.ifindex != 0 {
+                        nhop.attributes.push(RouteAttribute::Oif(uni.ifindex));
+                    }
+                    mpath.push(nhop);
+                }
+                msg.attributes.push(RouteAttribute::MultiPath(mpath));
+                let attr = RouteAttribute::Priority(multi.metric);
+                msg.attributes.push(attr);
+            }
+        }
+
+        let mut req = NetlinkMessage::from(RouteNetlinkMessage::DelRoute(msg));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK;
+
+        let mut response = self.handle.clone().request(req).unwrap();
+        while let Some(msg) = response.next().await {
+            if let NetlinkPayload::Error(e) = msg.payload {
+                println!("DelRoute IPv6 error: {e} {prefix}");
+            }
+        }
+    }
+
+    pub async fn route_ipv6_del(&self, prefix: &Ipv6Net, entry: &RibEntry) {
+        if !entry.is_protocol() {
+            return;
+        }
+
+        match &entry.nexthop {
+            Nexthop::Link(_) => {}
+            Nexthop::Uni(_) | Nexthop::Multi(_) => {
+                self.route_ipv6_del_uni(prefix, entry, &entry.nexthop).await;
+            }
+            Nexthop::List(list) => {
+                for uni in &list.nexthops {
+                    self.route_ipv6_del_uni(prefix, entry, &Nexthop::Uni(uni.clone()))
+                        .await;
+                }
+            }
+        }
+    }
+
     pub async fn nexthop_add(&self, nexthop: &Group) {
         // Skip nexthop table management for kernels < 5.3
         if !self.use_nhid {
@@ -348,8 +588,22 @@ impl FibHandle {
                 gid = uni.gid();
                 refcnt = uni.refcnt();
 
-                // IPv4.
-                msg.header.address_family = AddressFamily::Inet;
+                if DEBUG_V6 {
+                    println!(
+                        "[nexthop_add Uni] gid={} addr={} ifindex={} valid={} installed={}",
+                        gid,
+                        uni.addr,
+                        uni.ifindex,
+                        uni.is_valid(),
+                        uni.is_installed(),
+                    );
+                }
+
+                // Address family follows the gateway address.
+                msg.header.address_family = match uni.addr {
+                    std::net::IpAddr::V4(_) => AddressFamily::Inet,
+                    std::net::IpAddr::V6(_) => AddressFamily::Inet6,
+                };
 
                 // Nexthop group ID.
                 let attr = NexthopAttribute::Id(uni.gid() as u32);
@@ -369,6 +623,13 @@ impl FibHandle {
                 // Outgoing if.
                 let attr = NexthopAttribute::Oif(uni.ifindex);
                 msg.attributes.push(attr);
+
+                if DEBUG_V6 {
+                    println!(
+                        "[nexthop_add Uni] netlink: af={:?} attrs={:?}",
+                        msg.header.address_family, msg.attributes
+                    );
+                }
 
                 // MPLS.
                 if !uni.labels.is_empty() {

--- a/zebra-rs/src/rib/nexthop/group.rs
+++ b/zebra-rs/src/rib/nexthop/group.rs
@@ -5,13 +5,16 @@ use std::collections::BTreeSet;
 use std::net::IpAddr;
 
 use Group::*;
-use ipnet::Ipv4Net;
+use ipnet::{Ipv4Net, Ipv6Net};
 use prefix_trie::PrefixMap;
 
 use crate::rib::entry::RibEntries;
-use crate::rib::resolve::{Resolve, ResolveOpt, rib_resolve};
+use crate::rib::resolve::{Resolve, ResolveOpt, rib_resolve, rib_resolve_v6};
 
 use super::NexthopUni;
+
+// Flip to true to re-enable IPv6 nexthop resolution diagnostic prints.
+const DEBUG_V6: bool = false;
 
 #[derive(Debug)]
 pub enum Group {
@@ -63,9 +66,36 @@ impl GroupUni {
                     self.set_valid(true);
                 }
             }
-            IpAddr::V6(_ipv6_addr) => {
-                // TODO: Implement IPv6 resolution when IPv6 table is available
-                // For now, we'll leave IPv6 nexthops unresolved
+            IpAddr::V6(_) => {
+                // IPv6 nexthops resolve against the v6 table via resolve_v6.
+            }
+        }
+    }
+
+    pub fn resolve_v6(&mut self, table: &PrefixMap<Ipv6Net, RibEntries>) {
+        if let IpAddr::V6(ipv6_addr) = self.addr {
+            let resolve = rib_resolve_v6(table, ipv6_addr, &ResolveOpt::default());
+            match &resolve {
+                Resolve::Onlink(ifindex) => {
+                    if DEBUG_V6 {
+                        println!(
+                            "[GroupUni::resolve_v6] {} -> Onlink(ifindex={})",
+                            ipv6_addr, ifindex
+                        );
+                    }
+                    self.ifindex = *ifindex;
+                    self.set_valid(true);
+                }
+                Resolve::Recursive(_) => {
+                    if DEBUG_V6 {
+                        println!("[GroupUni::resolve_v6] {} -> Recursive", ipv6_addr);
+                    }
+                }
+                Resolve::NotFound => {
+                    if DEBUG_V6 {
+                        println!("[GroupUni::resolve_v6] {} -> NotFound", ipv6_addr);
+                    }
+                }
             }
         }
     }

--- a/zebra-rs/src/rib/resolve.rs
+++ b/zebra-rs/src/rib/resolve.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright 2025-2026 Kunihiro Ishiguro
 
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
-use ipnet::Ipv4Net;
+use ipnet::{Ipv4Net, Ipv6Net};
 use prefix_trie::PrefixMap;
 
 use super::RibEntries;
@@ -43,6 +43,34 @@ pub fn rib_resolve(
     opt: &ResolveOpt,
 ) -> Resolve {
     let Ok(key) = Ipv4Net::new(p, Ipv4Addr::BITS as u8) else {
+        return Resolve::NotFound;
+    };
+
+    let Some((p, entries)) = table.get_lpm(&key) else {
+        return Resolve::NotFound;
+    };
+
+    if !opt.allow_default() && p.prefix_len() == 0 {
+        return Resolve::NotFound;
+    }
+
+    for entry in entries.iter() {
+        if entry.is_connected() {
+            return Resolve::Onlink(entry.ifindex);
+        }
+        if entry.is_static() {
+            return Resolve::Recursive(1);
+        }
+    }
+    Resolve::NotFound
+}
+
+pub fn rib_resolve_v6(
+    table: &PrefixMap<Ipv6Net, RibEntries>,
+    p: Ipv6Addr,
+    opt: &ResolveOpt,
+) -> Resolve {
+    let Ok(key) = Ipv6Net::new(p, Ipv6Addr::BITS as u8) else {
         return Resolve::NotFound;
     };
 

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -7,7 +7,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::fib::FibHandle;
 use crate::rib::Nexthop;
-use crate::rib::resolve::{ResolveOpt, rib_resolve};
+use crate::rib::resolve::{ResolveOpt, rib_resolve, rib_resolve_v6};
 use crate::rib::util::IpNetExt;
 
 use super::entry::RibEntry;
@@ -16,6 +16,9 @@ use super::nexthop::NexthopUni;
 use super::{
     Group, GroupTrait, Message, NexthopList, NexthopMap, NexthopMulti, RibEntries, RibType,
 };
+
+// Flip to true to re-enable IPv6 RIB/FIB diagnostic prints.
+const DEBUG_V6: bool = false;
 
 impl Rib {
     pub async fn link_down(&mut self, ifindex: u32) {
@@ -208,10 +211,27 @@ impl Rib {
     }
 
     pub async fn ipv6_route_add(&mut self, prefix: &Ipv6Net, mut entry: RibEntry) {
+        if DEBUG_V6 {
+            println!(
+                "[ipv6_route_add] prefix={} rtype={:?} is_protocol={} is_connected={} valid_in={}",
+                prefix,
+                entry.rtype,
+                entry.is_protocol(),
+                entry.is_connected(),
+                entry.is_valid(),
+            );
+        }
         let is_connected = entry.is_connected();
         if entry.is_protocol() {
             let mut replace = rib_replace_v6(&mut self.table_v6, prefix, entry.rtype);
             rib_resolve_nexthop_v6(&mut entry, &self.table_v6, &mut self.nmap);
+            if DEBUG_V6 {
+                println!(
+                    "[ipv6_route_add] after resolve: entry.valid={} nexthop={:?}",
+                    entry.is_valid(),
+                    entry.nexthop
+                );
+            }
             rib_add_v6(&mut self.table_v6, prefix, entry);
             self.rib_selection_v6(prefix, replace.pop()).await;
         } else {
@@ -726,17 +746,31 @@ fn rib_next(ribs: &RibEntries) -> Option<usize> {
 // IPv6 helper functions
 
 async fn ipv6_entry_selection(
-    _prefix: &Ipv6Net,
+    prefix: &Ipv6Net,
     entries: &mut RibEntries,
     replace: Option<RibEntry>,
     nmap: &mut NexthopMap,
     fib: &FibHandle,
 ) {
+    if DEBUG_V6 {
+        println!(
+            "[ipv6_entry_selection] prefix={} entries={} replace={}",
+            prefix,
+            entries.len(),
+            replace.is_some(),
+        );
+        for (i, e) in entries.iter().enumerate() {
+            println!(
+                "  entry[{}] rtype={:?} valid={} selected={} fib={} distance={} metric={}",
+                i, e.rtype, e.valid, e.selected, e.fib, e.distance, e.metric
+            );
+        }
+    }
+
     if let Some(mut replace) = replace {
         if replace.is_protocol() {
             if replace.is_fib() {
-                // TODO: Add IPv6 route deletion to FibHandle
-                // fib.route_ipv6_del(prefix, &replace).await;
+                fib.route_ipv6_del(prefix, &replace).await;
             }
             replace.nexthop_unsync(nmap, fib).await;
         }
@@ -747,6 +781,10 @@ async fn ipv6_entry_selection(
     // New select.
     let next = rib_next(entries);
 
+    if DEBUG_V6 {
+        println!("[ipv6_entry_selection] prev={:?} next={:?}", prev, next);
+    }
+
     if prev == next {
         return;
     }
@@ -754,8 +792,7 @@ async fn ipv6_entry_selection(
         let prev = entries.get_mut(prev).unwrap();
         prev.set_selected(false);
 
-        // TODO: Add IPv6 route deletion to FibHandle
-        // fib.route_ipv6_del(prefix, prev).await;
+        fib.route_ipv6_del(prefix, prev).await;
         prev.set_fib(false);
     }
     if let Some(next) = next {
@@ -764,8 +801,7 @@ async fn ipv6_entry_selection(
 
         if next.is_protocol() {
             next.nexthop_sync(nmap, fib).await;
-            // TODO: Add IPv6 route installation to FibHandle
-            // fib.route_ipv6_add(prefix, next).await;
+            fib.route_ipv6_add(prefix, next).await;
         }
         next.set_fib(true);
     }
@@ -908,7 +944,7 @@ fn ipv6_entry_resolve(entries: &mut RibEntries, nmap: &NexthopMap) {
 // Function is called when IPv6 rib is added.
 fn rib_resolve_nexthop_v6(
     entry: &mut RibEntry,
-    _table: &PrefixMap<Ipv6Net, RibEntries>,
+    table: &PrefixMap<Ipv6Net, RibEntries>,
     nmap: &mut NexthopMap,
 ) {
     // Only protocol entry.
@@ -916,12 +952,12 @@ fn rib_resolve_nexthop_v6(
         return;
     }
     if let Nexthop::Uni(uni) = &mut entry.nexthop {
-        let _ = resolve_nexthop_uni_v6(uni, nmap);
+        let _ = resolve_nexthop_uni_v6(uni, nmap, table);
     }
     if let Nexthop::Multi(multi) = &mut entry.nexthop {
         let mut set = BTreeSet::<(usize, u8)>::new();
         for uni in multi.nexthops.iter_mut() {
-            let valid = resolve_nexthop_uni_v6(uni, nmap);
+            let valid = resolve_nexthop_uni_v6(uni, nmap, table);
             if valid {
                 set.insert((uni.gid, uni.weight));
             }
@@ -929,33 +965,48 @@ fn rib_resolve_nexthop_v6(
         resolve_nexthop_multi(multi, nmap, set);
     }
     if let Nexthop::List(pro) = &mut entry.nexthop {
-        let mut _pro_valid = false;
         for uni in pro.nexthops.iter_mut() {
-            let valid = resolve_nexthop_uni_v6(uni, nmap);
-            if valid {
-                _pro_valid = true;
-            }
+            let _ = resolve_nexthop_uni_v6(uni, nmap, table);
         }
     }
     // If one of nexthop is valid, the entry is valid.
     entry.set_valid(entry.is_valid_nexthop(nmap));
 }
 
-fn resolve_nexthop_uni_v6(uni: &mut NexthopUni, nmap: &mut NexthopMap) -> bool {
+fn resolve_nexthop_uni_v6(
+    uni: &mut NexthopUni,
+    nmap: &mut NexthopMap,
+    table: &PrefixMap<Ipv6Net, RibEntries>,
+) -> bool {
+    if DEBUG_V6 {
+        println!(
+            "[resolve_nexthop_uni_v6] addr={} gid_before={}",
+            uni.addr, uni.gid
+        );
+    }
     let Some(Group::Uni(group)) = nmap.fetch(&uni) else {
+        if DEBUG_V6 {
+            println!("[resolve_nexthop_uni_v6] nmap.fetch returned None");
+        }
         return false;
     };
+    if DEBUG_V6 {
+        println!(
+            "[resolve_nexthop_uni_v6] fetched group gid={} refcnt={} valid={} ifindex={}",
+            group.gid(),
+            group.refcnt(),
+            group.is_valid(),
+            group.ifindex,
+        );
+    }
     if group.refcnt() == 0 {
-        // TODO: Implement IPv6 resolution when available
-        match uni.addr {
-            std::net::IpAddr::V4(_) => {
-                // For IPv4, we can't resolve without the IPv4 table, but this shouldn't happen
-                group.set_valid(false);
-            }
-            std::net::IpAddr::V6(_) => {
-                // For IPv6, we'll mark as invalid for now until resolution is implemented
-                group.set_valid(false);
-            }
+        group.resolve_v6(table);
+        if DEBUG_V6 {
+            println!(
+                "[resolve_nexthop_uni_v6] after resolve_v6 valid={} ifindex={}",
+                group.is_valid(),
+                group.ifindex,
+            );
         }
     }
     group.refcnt_inc();
@@ -963,29 +1014,67 @@ fn resolve_nexthop_uni_v6(uni: &mut NexthopUni, nmap: &mut NexthopMap) -> bool {
     uni.gid = group.gid();
     uni.ifindex = group.ifindex;
 
-    group.is_valid()
+    let valid = group.is_valid();
+    if DEBUG_V6 {
+        println!(
+            "[resolve_nexthop_uni_v6] returning uni.gid={} uni.ifindex={} valid={}",
+            uni.gid, uni.ifindex, valid
+        );
+    }
+    valid
 }
 
 async fn ipv6_nexthop_sync(
     nmap: &mut NexthopMap,
-    _table: &PrefixMap<Ipv6Net, RibEntries>,
-    _fib: &FibHandle,
+    table: &PrefixMap<Ipv6Net, RibEntries>,
+    fib: &FibHandle,
 ) {
+    if DEBUG_V6 {
+        println!("[ipv6_nexthop_sync] start; v6 table size={}", table.len());
+    }
     for nhop in nmap.groups.iter_mut().flatten() {
         if let Group::Uni(uni) = nhop {
-            match uni.addr {
-                std::net::IpAddr::V4(_) => {
-                    // IPv4 addresses are handled by ipv4_nexthop_sync
-                    continue;
+            if DEBUG_V6 {
+                println!(
+                    "[ipv6_nexthop_sync] visiting uni gid={} addr={} ifindex={} valid={} installed={}",
+                    uni.gid(),
+                    uni.addr,
+                    uni.ifindex,
+                    uni.is_valid(),
+                    uni.is_installed(),
+                );
+            }
+            let resolve = match uni.addr {
+                std::net::IpAddr::V4(_) => continue,
+                std::net::IpAddr::V6(ipv6_addr) => {
+                    rib_resolve_v6(table, ipv6_addr, &ResolveOpt::default())
                 }
-                std::net::IpAddr::V6(_ipv6_addr) => {
-                    // TODO: Implement IPv6 resolution
-                    // For now, we'll mark IPv6 nexthops as invalid
-                    uni.set_valid(false);
+            };
+
+            let ifindex = resolve.is_valid();
+            if DEBUG_V6 {
+                println!(
+                    "[ipv6_nexthop_sync] resolved ifindex={} (0 means unresolved)",
+                    ifindex
+                );
+            }
+            if ifindex == 0 {
+                uni.set_ifindex(ifindex);
+                uni.set_valid(false);
+                if uni.is_installed() {
                     uni.set_installed(false);
-                    uni.set_ifindex(0);
+                }
+            } else {
+                uni.set_ifindex(ifindex);
+                uni.set_valid(true);
+                if !uni.is_installed() {
+                    uni.set_installed(true);
+                    fib.nexthop_add(&Group::Uni(uni.clone())).await;
                 }
             }
         }
+    }
+    if DEBUG_V6 {
+        println!("[ipv6_nexthop_sync] done");
     }
 }


### PR DESCRIPTION
## Summary
- Add `rib_resolve_v6` and `GroupUni::resolve_v6` so an IPv6 nexthop's `ifindex` is found via LPM in the v6 RIB (previous code was a TODO that always returned `valid=false`).
- Thread the v6 table through `rib_resolve_nexthop_v6` / `resolve_nexthop_uni_v6`; rewrite `ipv6_nexthop_sync` to actually install the resolved nexthop via `fib.nexthop_add`.
- Wire `fib.route_ipv6_add` / `route_ipv6_del` calls into `ipv6_entry_selection` (previously commented-out TODOs).
- Add `route_ipv6_add` / `route_ipv6_add_uni` / `route_ipv6_del` / `route_ipv6_del_uni` to the netlink `FibHandle`, mirroring the IPv4 path with `AddressFamily::Inet6` and `RouteAddress::Inet6(prefix.addr())`.
- Fix `nexthop_add` to set the netlink header `address_family` from the nexthop's gateway family. The previous hardcoded `Inet` header with an `Inet6` gateway was rejected by the kernel as `EINVAL`, which also caused the dependent `RTM_NEWROUTE` to fail.
- Diagnostic prints in the install pipeline are gated behind a per-module `DEBUG_V6 = false` const so they can be re-enabled with a single flip.

## Test plan
- [ ] Configure `set routing static ipv6 route 2001:db8:ff00:2::/64 nexthop 2001:db8:ff00:10::2` and confirm `show ipv6 route` shows `S *> ... via <addr>, <ifname>` (selected/FIB flags + resolved interface).
- [ ] Verify `ip -6 route show` on Linux shows the static route installed in the kernel FIB.
- [ ] Verify `ip -6 nexthop show` shows the resolved nexthop group.
- [ ] Delete the static route and confirm both kernel route and nexthop group are removed.
- [ ] Add the static before the connected route exists, then bring up the interface, and confirm `Message::Resolve` triggers re-resolution and FIB install.

Generated with [Claude Code](https://claude.com/claude-code)