### PR TITLE
fix(rib): treat IPv6 link-local prefixes as per-link FIB entries

### DIFF
--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -775,6 +775,19 @@ async fn ipv6_entry_selection(
             replace.nexthop_unsync(nmap, fib).await;
         }
     }
+
+    // Link-local prefixes (fe80::/10) are link-scoped: every interface
+    // legitimately holds the same fe80::/64, and best-route selection would
+    // arbitrarily flag only one. Mark every valid entry as selected+FIB.
+    if prefix.addr().is_unicast_link_local() {
+        for entry in entries.iter_mut() {
+            let on = entry.is_valid();
+            entry.set_selected(on);
+            entry.set_fib(on);
+        }
+        return;
+    }
+
     // Selected.
     let prev = rib_prev(entries);
 


### PR DESCRIPTION
## Summary
- Bypass best-route selection for link-local IPv6 prefixes (`fe80::/10`) in `ipv6_entry_selection`. Multiple interfaces legitimately share the same `fe80::/64` prefix bucket; the existing `rib_next` picks one winner per prefix and leaves the rest unflagged.
- Mark every valid entry in a link-local bucket as both `selected` and `fib` so `show ipv6 route` displays `*>` for each interface's `fe80::/64`, matching the expected per-link semantics.
- Uses `prefix.addr().is_unicast_link_local()`, the same helper already used in `isis/link.rs`.

## Test plan
- [ ] Bring up multiple interfaces with IPv6 enabled.
- [ ] Run `show ipv6 route` and confirm every `fe80::/64` row has `*>` flags (selected + FIB).
- [ ] Confirm non-link-local prefixes still go through normal selection (one winner per prefix).

Generated with [Claude Code](https://claude.com/claude-code)