### PR TITLE
chore(srv6): silence dead_code warnings in locator scaffold

### DIFF
--- a/zebra-rs/src/srv6/locator.rs
+++ b/zebra-rs/src/srv6/locator.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright 2025-2026 Kunihiro Ishiguro
 


### PR DESCRIPTION
## Summary
- Add a file-scoped `#![allow(dead_code)]` to `srv6/locator.rs` so the unused-warning noise from the merged-but-not-yet-wired `Locator` type and uA SID allocator stops leaking into every release build.
- Cleaner than scattering per-item `#[allow]` attributes; the attribute can be removed once IS-IS/SRv6 starts consuming the API.

## Test plan
- [ ] `cargo build --bin zebra-rs --release` no longer prints the five `dead_code` warnings rooted at `srv6/locator.rs`.
- [ ] `cargo test -p zebra-rs srv6::locator` still passes (existing unit tests inside the file).

Generated with [Claude Code](https://claude.com/claude-code)