### PR TITLE
fix(rib): recover IPv6 connected routes on link state change

### DIFF
--- a/crates/isis-packet/src/sub/neigh_disp.rs
+++ b/crates/isis-packet/src/sub/neigh_disp.rs
@@ -132,7 +132,15 @@ impl Display for IsisSubLanAdjSid {
 
 impl Display for IsisSubSrv6EndXSid {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "    End.X SID: {}", self.sid)
+        write!(
+            f,
+            "    SRv6 End.X SID: {}, Algo: {}, Weight: {}, Behavior {}, Flags: {}",
+            self.sid, self.algo, self.weight, self.behavior, self.flags
+        )?;
+        for sub2 in self.sub2s.iter() {
+            write!(f, "\n     {}", sub2)?;
+        }
+        Ok(())
     }
 }
 

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -109,6 +109,8 @@ impl Rib {
         // Resolve RIB.
         ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.fib_handle).await;
         ipv4_route_sync(&mut self.table, &mut self.nmap, &self.fib_handle, true).await;
+        ipv6_nexthop_sync(&mut self.nmap, &self.table_v6, &self.fib_handle).await;
+        ipv6_route_sync(&mut self.table_v6, &mut self.nmap, &self.fib_handle).await;
     }
 
     pub async fn link_up(&mut self, ifindex: u32) {
@@ -146,19 +148,28 @@ impl Rib {
         }
 
         // Add connected IPv6 routes when link comes up
-        // for addr6 in link.addr6.iter() {
-        //     if let IpNet::V6(addr) = addr6.addr {
-        //         let prefix = addr.apply_mask();
-        //         // println!("Connected IPv6: {:?} up - adding to RIB", prefix);
-        //         let mut rib = RibEntry::new(RibType::Connected);
-        //         rib.ifindex = ifindex;
-        //         rib.set_valid(true);
-        //         let msg = Message::Ipv6Add { prefix, rib };
-        //         let _ = self.tx.send(msg);
-        //     }
-        // }
+        for addr6 in link.addr6.iter() {
+            if let IpNet::V6(addr) = addr6.addr {
+                let prefix = addr.apply_mask();
+                let mut entry = RibEntry::new(RibType::Connected);
+                entry.ifindex = ifindex;
+                entry.set_valid(true);
+
+                rib_add_system_v6(&mut self.table_v6, &prefix, entry);
+                rib_selection_ipv6(
+                    &mut self.table_v6,
+                    &prefix,
+                    None,
+                    &mut self.nmap,
+                    &self.fib_handle,
+                )
+                .await;
+            }
+        }
         ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.fib_handle).await;
         ipv4_route_sync(&mut self.table, &mut self.nmap, &self.fib_handle, true).await;
+        ipv6_nexthop_sync(&mut self.nmap, &self.table_v6, &self.fib_handle).await;
+        ipv6_route_sync(&mut self.table_v6, &mut self.nmap, &self.fib_handle).await;
     }
 
     pub async fn ipv4_route_add(&mut self, prefix: &Ipv4Net, mut entry: RibEntry) {
@@ -295,6 +306,19 @@ pub async fn rib_selection_ipv4(
         return;
     };
     ipv4_entry_selection(prefix, entries, replace, nmap, fib, true).await;
+}
+
+pub async fn rib_selection_ipv6(
+    table: &mut PrefixMap<Ipv6Net, RibEntries>,
+    prefix: &Ipv6Net,
+    replace: Option<RibEntry>,
+    nmap: &mut NexthopMap,
+    fib: &FibHandle,
+) {
+    let Some(entries) = table.get_mut(prefix) else {
+        return;
+    };
+    ipv6_entry_selection(prefix, entries, replace, nmap, fib).await;
 }
 
 pub async fn ipv4_nexthop_sync(


### PR DESCRIPTION
## Summary
- When an interface bounced, IPv6 connected routes (link-local + global) were not restored. Root cause: `link_up()` had its IPv6 add path commented out, and neither `link_up()` nor `link_down()` invoked the IPv6 sync helpers — so v6 protocol nexthops resolving via the bouncing link were never re-evaluated either.
- `link_up()`: re-add connected IPv6 routes via the synchronous `rib_add_system_v6` + `rib_selection_ipv6` pattern, parallel to the existing IPv4 block.
- `link_up()` / `link_down()`: call `ipv6_nexthop_sync` and `ipv6_route_sync` after the IPv4 sync calls so v6 nexthop validity and best-route selection are recomputed on every link state change.
- Add `pub async fn rib_selection_ipv6` next to `rib_selection_ipv4`.
- Drive-by: extend the SRv6 End.X SID sub-TLV display in `show isis database detail` to include Algo, Weight, Behavior, and Flags, and iterate the sub2 sub-TLVs (parity with the End SID display).

## Test plan
- [x] `cargo build -p zebra-rs` clean
- [x] `cargo fmt --all` applied
- [ ] Manual: `ip link set <iface> down` then `ip link set <iface> up` and confirm `show ipv6 route` shows the connected `fe80::/64` and global IPv6 prefixes back as `*>`
- [ ] Manual: with an IPv6 static route resolving via the bounced interface, confirm it is removed on down and re-installed on up

Generated with [Claude Code](https://claude.com/claude-code)