### PR TITLE
chore(clippy): remove cheap mechanical lints from allowlist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,14 +42,10 @@ clap = { version = "4", features = ["derive"] }
 # Style — explicit-over-implicit
 collapsible_if = "allow"
 collapsible_match = "allow"
-field_reassign_with_default = "allow"
-let_and_return = "allow"
 manual_map = "allow"
 needless_bool_assign = "allow"
 needless_return = "allow"
-redundant_closure = "allow"
 redundant_pattern_matching = "allow"
-unused_enumerate_index = "allow"
 unwrap_or_default = "allow"
 
 # Style — references and casts
@@ -62,21 +58,12 @@ unnecessary_cast = "allow"
 for_kv_map = "allow"
 get_first = "allow"
 iter_kv_map = "allow"
-len_zero = "allow"
 manual_range_contains = "allow"
 ptr_arg = "allow"
-unnecessary_get_then_check = "allow"
 unnecessary_map_or = "allow"
 
 # Naming — networking acronyms (TCP, IP, MD5, ...) are fine as-is
 upper_case_acronyms = "allow"
-
-# Print/format — empty/trivial cases
-println_empty_string = "allow"
-writeln_empty_string = "allow"
-
-# Default constructions
-default_constructed_unit_structs = "allow"
 
 # Async — fire-and-forget tasks are intentional in a few places
 let_underscore_future = "allow"

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -968,7 +968,7 @@ pub fn route_rtcv4_sync(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
         return;
     };
     let key = AfiSafi::new(Afi::Ip, Safi::Rtc);
-    if peer.eor.get(&key).is_some() {
+    if peer.eor.contains_key(&key) {
         route_sync_vpnv4(peer, bgp);
     }
     peer.eor.clear();
@@ -1969,7 +1969,7 @@ pub fn route_sync(peer: &mut Peer, bgp: &mut BgpTop) {
     }
     if peer.is_afi_safi(Afi::Ip, Safi::MplsVpn) {
         let key = AfiSafi::new(Afi::Ip, Safi::Rtc);
-        if peer.eor.get(&key).is_none() {
+        if !peer.eor.contains_key(&key) {
             route_sync_vpnv4(peer, bgp);
         }
     }

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -363,7 +363,7 @@ fn show_bgp(bgp: &Bgp, _args: Args, json: bool) -> std::result::Result<String, s
     buf.push_str(SHOW_BGP_HEADER);
 
     for (key, value) in bgp.local_rib.v4.0.iter() {
-        for (_i, rib) in value.iter().enumerate() {
+        for rib in value.iter() {
             let stale = if rib.stale { "S" } else { " " };
             let valid = "*";
             let best = if rib.best_path { ">" } else { " " };
@@ -461,11 +461,11 @@ fn show_bgp_vpnv4(
         "     Network          Next Hop            Metric LocPrf Weight Path"
     );
     for (key, value) in bgp.local_rib.v4vpn.iter() {
-        if value.0.len() > 0 {
+        if !value.0.is_empty() {
             writeln!(buf, "Route Distinguisher: {}", key)?;
         }
         for (k, v) in value.0.iter() {
-            for (_i, rib) in v.iter().enumerate() {
+            for rib in v.iter() {
                 let stale = if rib.stale { "S" } else { " " };
                 let valid = "*";
                 let best = if rib.best_path { ">" } else { " " };
@@ -569,11 +569,11 @@ fn show_adj_rib_routes_vpnv4<D: RibDirection>(
         "     Network          Next Hop            Metric LocPrf Weight Path"
     )?;
     for (key, value) in routes.iter() {
-        if value.0.len() > 0 {
+        if !value.0.is_empty() {
             writeln!(buf, "Route Distinguisher: {}", key)?;
         }
         for (k, v) in value.0.iter() {
-            for (_i, rib) in v.iter().enumerate() {
+            for rib in v.iter() {
                 let stale = if rib.stale { "S" } else { " " };
                 let valid = "*";
                 let best = if rib.best_path { ">" } else { " " };
@@ -1323,7 +1323,7 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
                 }
                 write!(out, " received")?;
             }
-            writeln!(out, "")?;
+            writeln!(out)?;
         }
 
         let afi = CapMultiProtocol::new(&Afi::Ip, &Safi::Unicast);
@@ -1568,7 +1568,7 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
                 }
                 write!(out, " received")?;
             }
-            writeln!(out, "")?;
+            writeln!(out)?;
         }
 
         if neighbor.cap_send.refresh.is_some() || neighbor.cap_recv.refresh.is_some() {
@@ -1581,7 +1581,7 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
                 }
                 write!(out, " received")?;
             }
-            writeln!(out, "")?;
+            writeln!(out)?;
         }
 
         if neighbor.cap_send.enhanced_refresh.is_some()
@@ -1596,7 +1596,7 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
                 }
                 write!(out, " received")?;
             }
-            writeln!(out, "")?;
+            writeln!(out)?;
         }
 
         if neighbor.cap_send.fqdn.is_some() || neighbor.cap_recv.fqdn.is_some() {
@@ -1619,7 +1619,7 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
                     v.domain()
                 )?;
             }
-            writeln!(out, "")?;
+            writeln!(out)?;
         }
 
         if neighbor.cap_send.version.is_some() || neighbor.cap_recv.version.is_some() {
@@ -1632,10 +1632,10 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
                 }
                 write!(out, " received ({})", v.version(),)?;
             }
-            writeln!(out, "")?;
+            writeln!(out)?;
         }
 
-        writeln!(out, "")?;
+        writeln!(out)?;
     }
     writeln!(
         out,

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -381,7 +381,7 @@ impl Config {
 
     pub fn json(&self, out: &mut String) {
         let keys = self.keys.borrow();
-        if keys.len() > 0 {
+        if !keys.is_empty() {
             out.push('[');
             for (pos, key) in keys.iter().enumerate() {
                 if pos != 0 {

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -474,7 +474,7 @@ fn matched_enumeration(mx: &Match) -> Option<String> {
 }
 
 pub fn is_entry_presence(entry: &Rc<Entry>) -> bool {
-    entry.extension.get("ext:presence").is_some()
+    entry.extension.contains_key("ext:presence")
 }
 
 pub fn parse(

--- a/zebra-rs/src/isis/flood.rs
+++ b/zebra-rs/src/isis/flood.rs
@@ -221,9 +221,7 @@ pub fn ssn_advertise(link: &mut LinkTop, level: Level) {
 
         let total_base_len = packet_len + base_len + tlv_header_len;
 
-        let available_len = mtu - total_base_len;
-
-        available_len
+        mtu - total_base_len
     };
 
     // 16 is IsisLspEntry's length.

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -422,7 +422,7 @@ impl Isis {
         }
     }
     pub fn top(&mut self) -> IsisTop<'_> {
-        let top = IsisTop {
+        IsisTop {
             tx: &self.tx,
             links: &mut self.links,
             config: &self.config,
@@ -438,8 +438,7 @@ impl Isis {
             spf_timer: &mut self.spf_timer,
             graph: &mut self.graph,
             spf_result: &mut self.spf_result,
-        };
-        top
+        }
     }
 
     pub fn link_top<'a>(&'a mut self, ifindex: u32) -> Option<LinkTop<'a>> {
@@ -831,9 +830,7 @@ pub fn csnp_generate(link: &LinkTop, level: Level) -> Vec<IsisCsnp> {
 
         let total_base_len = packet_len + base_len + tlv_header_len;
 
-        let available_len = mtu - total_base_len;
-
-        available_len
+        mtu - total_base_len
     };
     // tracing::info!("[CSNP:Gen] available_len {}", available_len);
 
@@ -1157,11 +1154,15 @@ fn make_rib_entry(route: &SpfRoute) -> rib::entry::RibEntry {
             rib::Nexthop::default()
         }
     } else {
-        let mut multi = rib::NexthopMulti::default();
-        multi.metric = route.metric;
-        for (key, value) in route.nhops.iter() {
-            multi.nexthops.push(nhop_to_nexthop_uni(key, route, value));
-        }
+        let multi = rib::NexthopMulti {
+            metric: route.metric,
+            nexthops: route
+                .nhops
+                .iter()
+                .map(|(key, value)| nhop_to_nexthop_uni(key, route, value))
+                .collect(),
+            ..Default::default()
+        };
         rib::Nexthop::Multi(multi)
     };
 

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -1009,7 +1009,7 @@ pub fn show_detail(
                         writeln!(buf, "    {}", prefix)?;
                     }
                 }
-                writeln!(buf, "")?;
+                writeln!(buf)?;
             }
         }
         Ok(buf)
@@ -1111,8 +1111,8 @@ pub fn show_dis_statistics(
                             current_dis,
                             flap_count: dis_stats.flap_count,
                             is_dampened: dis_stats.is_dampened(),
-                            uptime: dis_stats.uptime.map(|t| format_time_ago(t)),
-                            last_change: dis_stats.last_change.map(|t| format_time_ago(t)),
+                            uptime: dis_stats.uptime.map(format_time_ago),
+                            last_change: dis_stats.last_change.map(format_time_ago),
                             history_count: dis_stats.history.len(),
                         });
                     }

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -246,9 +246,7 @@ pub fn insert_lsp(top: &mut LinkTop, level: Level, lsp: IsisLsp, bytes: Vec<u8>)
     lsa.bytes = bytes;
     lsa.hold_timer = Some(hold_timer(top.tx, level, key, hold_time));
 
-    let lsa = top.lsdb.get_mut(&level).map.insert(key, lsa);
-
-    lsa
+    top.lsdb.get_mut(&level).map.insert(key, lsa)
 }
 
 pub fn insert_self_originate(

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -240,7 +240,7 @@ fn show_entry(buf: &mut String, top: &Isis, nbr: &Neighbor, level: Level) -> std
         if let Some(label) = value.label {
             let _ = write!(buf, " ({})", label);
         }
-        let _ = writeln!(buf, "");
+        let _ = writeln!(buf);
     }
     if !nbr.addr6l.is_empty() {
         writeln!(buf, "    IPv6 Link-Locals")?;
@@ -255,7 +255,7 @@ fn show_entry(buf: &mut String, top: &Isis, nbr: &Neighbor, level: Level) -> std
         writeln!(buf, "      {}", value.addr)?;
     }
 
-    writeln!(buf, "")?;
+    writeln!(buf)?;
     Ok(())
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1583,11 +1583,15 @@ fn make_rib_entry(route: &SpfRoute) -> rib::entry::RibEntry {
             rib::Nexthop::default()
         }
     } else {
-        let mut multi = rib::NexthopMulti::default();
-        multi.metric = route.metric;
-        for (key, value) in route.nhops.iter() {
-            multi.nexthops.push(nhop_to_nexthop_uni(key, route, value));
-        }
+        let multi = rib::NexthopMulti {
+            metric: route.metric,
+            nexthops: route
+                .nhops
+                .iter()
+                .map(|(key, value)| nhop_to_nexthop_uni(key, route, value))
+                .collect(),
+            ..Default::default()
+        };
         rib::Nexthop::Multi(multi)
     };
 

--- a/zebra-rs/src/ospf/network.rs
+++ b/zebra-rs/src/ospf/network.rs
@@ -116,7 +116,7 @@ pub async fn write_packet(sock: Arc<AsyncFd<Socket>>, mut rx: UnboundedReceiver<
                     socket::MsgFlags::empty(),
                     Some(&sockaddr),
                 )
-                .map_err(|e| std::io::Error::from(e))?;
+                .map_err(std::io::Error::from)?;
                 Ok(())
             })
             .await;

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -25,13 +25,15 @@ use super::{
 
 pub fn ospf_hello_packet(oi: &OspfLink) -> Option<Ospfv2Packet> {
     let addr = oi.addr.first()?;
-    let mut hello = OspfHello::default();
-    hello.netmask = addr.prefix.netmask();
-    hello.hello_interval = oi.hello_interval();
+    let mut hello = OspfHello {
+        netmask: addr.prefix.netmask(),
+        hello_interval: oi.hello_interval(),
+        priority: oi.priority(),
+        router_dead_interval: oi.dead_interval(),
+        ..Default::default()
+    };
     hello.options.set_external(true);
     hello.options.set_o(true);
-    hello.priority = oi.priority();
-    hello.router_dead_interval = oi.dead_interval();
     for (_, nbr) in oi.nbrs.iter() {
         if nbr.state == NfsmState::Down {
             continue;

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -927,13 +927,13 @@ fn show_ospf_database(
         return Ok(String::from("OSPF router ID is not sepcified"));
     }
 
-    let _ = writeln!(out, "");
+    let _ = writeln!(out);
     writeln!(out, "       OSPF Router with ID ({})", ospf.router_id)?;
-    let _ = writeln!(out, "");
+    let _ = writeln!(out);
 
     if let Some(area) = ospf.areas.get(AREA0) {
         writeln!(out, "Router Link States (Area {})", area.id)?;
-        let _ = writeln!(out, "");
+        let _ = writeln!(out);
 
         let mut header = true;
         for ((lsa_id, adv_router), lsa) in area.lsdb.tables.get(&OspfLsType::Router).iter() {

--- a/zebra-rs/src/rib/logging.rs
+++ b/zebra-rs/src/rib/logging.rs
@@ -261,7 +261,7 @@ pub fn setup_tracing_with_format(output: LoggingOutput, format: LogFormat) -> an
         (LoggingOutput::Stdout, LogFormat::Elasticsearch) => {
             tracing_subscriber::fmt()
                 .with_env_filter(filter)
-                .event_format(ElasticsearchFormatter::default())
+                .event_format(ElasticsearchFormatter)
                 .init();
         }
         (LoggingOutput::Stdout, LogFormat::Terminal) => {
@@ -319,7 +319,7 @@ pub fn setup_tracing_with_format(output: LoggingOutput, format: LogFormat) -> an
                 let syslog_writer = SyslogWriter::new()?;
                 tracing_subscriber::fmt()
                     .with_env_filter(filter)
-                    .event_format(ElasticsearchFormatter::default())
+                    .event_format(ElasticsearchFormatter)
                     .with_writer(Mutex::new(syslog_writer))
                     .init();
             }
@@ -526,7 +526,7 @@ pub fn setup_tracing_with_format(output: LoggingOutput, format: LogFormat) -> an
             let writer = rolling::never(log_dir, log_filename);
             tracing_subscriber::fmt()
                 .with_env_filter(filter)
-                .event_format(ElasticsearchFormatter::default())
+                .event_format(ElasticsearchFormatter)
                 .with_writer(writer)
                 .init();
         }

--- a/zebra-rs/src/rib/nexthop/show.rs
+++ b/zebra-rs/src/rib/nexthop/show.rs
@@ -31,7 +31,7 @@ pub fn nexthop_show(rib: &Rib, _args: Args, _json: bool) -> String {
                 for label in uni.labels.iter() {
                     let _ = write!(buf, " {}", label);
                 }
-                let _ = writeln!(buf, "");
+                let _ = writeln!(buf);
             }
             Group::Multi(multi) => {
                 for (gid, weight) in multi.set.iter() {

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -347,7 +347,7 @@ pub fn rib_entry_show(
                         }
                     }
                 }
-                writeln!(buf, "").unwrap();
+                writeln!(buf).unwrap();
             }
             Nexthop::Multi(multi) => {
                 for (i, uni) in multi.nexthops.iter().enumerate() {
@@ -449,7 +449,7 @@ pub fn rib_entry_show_v6(
                         }
                     }
                 }
-                writeln!(buf, "").unwrap();
+                writeln!(buf).unwrap();
             }
             Nexthop::Multi(multi) => {
                 for (i, uni) in multi.nexthops.iter().enumerate() {

--- a/zebra-rs/src/spf/calc.rs
+++ b/zebra-rs/src/spf/calc.rs
@@ -22,9 +22,10 @@ impl SpfOpt {
     }
 
     pub fn full_path() -> Self {
-        let mut opt = Self::default();
-        opt.full_path = true;
-        opt
+        Self {
+            full_path: true,
+            ..Self::default()
+        }
     }
 }
 
@@ -736,19 +737,19 @@ mod tests {
                 let name = node_name(&graph, i.id);
                 print!(" {}", name);
             }
-            println!("");
+            println!();
 
             print!("P ");
             for i in pc_inter.iter() {
                 print!(" {} ", if i.p { "o" } else { "x" });
             }
-            println!("");
+            println!();
 
             print!("Q ");
             for i in pc_inter.iter() {
                 print!(" {} ", if i.q { "o" } else { "x" });
             }
-            println!("");
+            println!();
 
             // Asssert P(S, N1)
             let mut p_inter = Vec::<String>::new();


### PR DESCRIPTION
## Summary

Re-enable nine clippy lints that were silenced workspace-wide and fix the ~44 sites they surfaced. These are the cleanups that have a single correct mechanical fix and no real downside:

- `writeln_empty_string` / `println_empty_string` — `writeln!(buf, \"\")` → `writeln!(buf)`.
- `field_reassign_with_default` — replace `let mut x = T::default(); x.foo = ...;` with a struct literal using `..Default::default()` for the unspecified fields.
- `let_and_return` — collapse `let x = ...; x` blocks to a tail expression.
- `default_constructed_unit_structs` — drop `::default()` on unit structs (`ElasticsearchFormatter`).
- `unused_enumerate_index` — `for (_i, rib) in v.iter().enumerate()` → `for rib in v.iter()`.
- `redundant_closure` — `|x| f(x)` → `f`.
- `len_zero` — `.len() > 0` → `!.is_empty()`.
- `unnecessary_get_then_check` — `map.get(&k).is_some()` → `map.contains_key(&k)`.

These nine entries are removed from the workspace `[lints.clippy]` allowlist so future regressions are caught.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo build --workspace` — clean.
- [x] `cargo test --workspace --exclude bdd` — all passing.
- [x] `cargo fmt --all`

Generated with [Claude Code](https://claude.com/claude-code)