### PR TITLE
ci: gate PRs on cargo fmt, clippy, and test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: cargo fmt
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: cargo clippy
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+      - name: Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+  test:
+    name: cargo test
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+      - name: Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Test
+        # The bdd crate's cucumber tests require root + Linux network
+        # namespaces and are not runnable in the GitHub Actions sandbox;
+        # exclude them here. They are intended to be run locally.
+        run: cargo test --workspace --exclude bdd


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow that runs on every push to `main` and on every pull request, with three independent jobs:

- **fmt:** `cargo fmt --all -- --check`
- **clippy:** `cargo clippy --workspace --all-targets -- -D warnings`
- **test:** `cargo test --workspace --exclude bdd`

The `bdd` crate is excluded because its cucumber tests require root and Linux network namespaces and are not runnable in the GitHub Actions sandbox; they're meant to run locally.

This locks in the clean clippy baseline established in #317 and #318 — any future PR that introduces a clippy warning, formatting drift, or test break will fail the check before merge instead of silently accumulating again.

## Test plan

- [x] All three commands pass locally on this branch.
- [ ] After merge, confirm the workflow runs on the next PR.

Generated with [Claude Code](https://claude.com/claude-code)