### PR TITLE
chore(clippy): remove tier-1 mechanical lints from allowlist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,23 +41,17 @@ clap = { version = "4", features = ["derive"] }
 [workspace.lints.clippy]
 # Style — explicit-over-implicit
 collapsible_if = "allow"
-collapsible_match = "allow"
-manual_map = "allow"
 needless_bool_assign = "allow"
 needless_return = "allow"
-redundant_pattern_matching = "allow"
-unwrap_or_default = "allow"
 
 # Style — references and casts
 clone_on_copy = "allow"
 needless_borrow = "allow"
-needless_borrowed_reference = "allow"
 unnecessary_cast = "allow"
 
 # Style — APIs that get used a lot in protocol code
 for_kv_map = "allow"
 get_first = "allow"
-iter_kv_map = "allow"
 manual_range_contains = "allow"
 ptr_arg = "allow"
 unnecessary_map_or = "allow"

--- a/zebra-rs/src/bgp/auth.rs
+++ b/zebra-rs/src/bgp/auth.rs
@@ -351,10 +351,6 @@ pub struct KeyChain {
 }
 
 impl KeyChain {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Pick the key to use for new connections. For this initial
     /// implementation we take the lowest key-id. Lifetime-based
     /// selection and in-band rollover via RNextKeyID are follow-ups.

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -10,7 +10,7 @@ use crate::config::{Args, ConfigOp};
 use crate::policy;
 use crate::policy::com_list::*;
 
-use super::auth::{AoConfig, CryptoAlgorithm, Key, KeyChain};
+use super::auth::{AoConfig, CryptoAlgorithm, Key};
 use super::peer::BgpTop;
 use super::route_clean;
 use super::{
@@ -651,7 +651,7 @@ fn config_peer_tcp_ao_include_tcp_options(
 fn config_key_chain(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     if op == ConfigOp::Set {
-        bgp.key_chains.entry(name).or_insert_with(KeyChain::new);
+        bgp.key_chains.entry(name).or_default();
     } else {
         bgp.key_chains.remove(&name);
     }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -288,8 +288,8 @@ impl LocalRibTable {
         let incb_neigh_as = incb.attr.neighboring_as();
 
         if cand_neigh_as == incb_neigh_as {
-            let cand_med = cand.attr.med.clone().unwrap_or(Med::default());
-            let incb_med = incb.attr.med.clone().unwrap_or(Med::default());
+            let cand_med = cand.attr.med.clone().unwrap_or_default();
+            let incb_med = incb.attr.med.clone().unwrap_or_default();
             if cand_med != incb_med {
                 return (cand_med < incb_med, Reason::Med);
             }

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -187,19 +187,11 @@ fn show_local_pref(attr: &BgpAttr) -> String {
 }
 
 fn show_med2(attr: &BgpAttr) -> Option<u32> {
-    if let Some(attr) = &attr.med {
-        Some(attr.med)
-    } else {
-        None
-    }
+    attr.med.as_ref().map(|a| a.med)
 }
 
 fn show_local_pref2(attr: &BgpAttr) -> Option<u32> {
-    if let Some(attr) = &attr.local_pref {
-        Some(attr.local_pref)
-    } else {
-        None
-    }
+    attr.local_pref.as_ref().map(|a| a.local_pref)
 }
 
 fn show_aspath(attr: &BgpAttr) -> String {

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -23,12 +23,12 @@ fn format_json_value(value: &str) -> String {
     }
 
     // Check if it's an integer (positive or negative)
-    if let Ok(_) = value.parse::<i64>() {
+    if value.parse::<i64>().is_ok() {
         return value.to_string();
     }
 
     // Check if it's a floating point number
-    if let Ok(_) = value.parse::<f64>() {
+    if value.parse::<f64>().is_ok() {
         return value.to_string();
     }
 

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1416,13 +1416,11 @@ fn build_rib_from_spf(
                 let sid = if let Some(prefix_sid) = entry.prefix_sid() {
                     match prefix_sid.sid {
                         // Prefix SID label.
-                        SidLabelValue::Index(index) => {
-                            if let Some(block) = top.label_map.get(&level).get(&sys_id) {
-                                Some(block.global.start + index)
-                            } else {
-                                None
-                            }
-                        }
+                        SidLabelValue::Index(index) => top
+                            .label_map
+                            .get(&level)
+                            .get(&sys_id)
+                            .map(|block| block.global.start + index),
                         SidLabelValue::Label(label) => Some(label),
                     }
                 } else {

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -278,8 +278,8 @@ fn neighbor_to_detail(top: &Isis, nbr: &Neighbor, level: Level) -> NeighborDetai
 
     let ip_prefixes = nbr
         .addr4
-        .iter()
-        .map(|(_, value)| IpPrefix {
+        .values()
+        .map(|value| IpPrefix {
             address: value.addr.to_string(),
             label: value.label,
         })
@@ -288,8 +288,8 @@ fn neighbor_to_detail(top: &Isis, nbr: &Neighbor, level: Level) -> NeighborDetai
     let ipv6_link_locals = nbr.addr6l.iter().map(|addr| addr.to_string()).collect();
     let ipv6_prefixes = nbr
         .addr6
-        .iter()
-        .map(|(_, value)| IpPrefix {
+        .values()
+        .map(|value| IpPrefix {
             address: value.addr.to_string(),
             label: value.label,
         })

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1171,10 +1171,10 @@ impl Ospf {
                 self.queue_delayed_acks(ifindex, headers);
             }
             Message::SpfSchedule(area_id) => {
-                if let Some(area_id) = area_id {
-                    if let Some(area) = self.areas.get_mut(area_id) {
-                        Self::ospf_spf_schedule(&self.tx, area);
-                    }
+                if let Some(area_id) = area_id
+                    && let Some(area) = self.areas.get_mut(area_id)
+                {
+                    Self::ospf_spf_schedule(&self.tx, area);
                 }
             }
             Message::SpfCalc(area_id) => {

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -570,20 +570,19 @@ enum LsaProcessResult {
 fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -> LsaProcessResult {
     // Step 3: Discard AS-External LSAs in stub/NSSA areas.
     use super::area::AreaType;
-    match lsa.h.ls_type {
-        OspfLsType::AsExternal | OspfLsType::SummaryAsbr => {
-            if oi.area_type != AreaType::Normal {
-                tracing::info!(
-                    "[LS Update] Step 3: Discarding {:?} LSA in {:?} area: id={} adv={}",
-                    lsa.h.ls_type,
-                    oi.area_type,
-                    lsa.h.ls_id,
-                    lsa.h.adv_router
-                );
-                return LsaProcessResult::DiscardNoAck;
-            }
-        }
-        _ => {}
+    if matches!(
+        lsa.h.ls_type,
+        OspfLsType::AsExternal | OspfLsType::SummaryAsbr
+    ) && oi.area_type != AreaType::Normal
+    {
+        tracing::info!(
+            "[LS Update] Step 3: Discarding {:?} LSA in {:?} area: id={} adv={}",
+            lsa.h.ls_type,
+            oi.area_type,
+            lsa.h.ls_id,
+            lsa.h.adv_router
+        );
+        return LsaProcessResult::DiscardNoAck;
     }
 
     // Step 4: Look up current database copy, compute comparison result.

--- a/zebra-rs/src/rib/logging.rs
+++ b/zebra-rs/src/rib/logging.rs
@@ -498,7 +498,7 @@ pub fn setup_tracing_with_format(output: LoggingOutput, format: LogFormat) -> an
                         .unwrap_or_else(|| std::path::Path::new("."));
 
                     // Try to create directory and test write permission
-                    if let Ok(_) = std::fs::create_dir_all(parent) {
+                    if std::fs::create_dir_all(parent).is_ok() {
                         // Test write permission by trying to create a temp file
                         let test_file = parent.join(".zebra_write_test");
                         if std::fs::write(&test_file, "test").is_ok() {
@@ -585,7 +585,7 @@ pub fn setup_tracing_with_format(output: LoggingOutput, format: LogFormat) -> an
                         .unwrap_or_else(|| std::path::Path::new("."));
 
                     // Try to create directory and test write permission
-                    if let Ok(_) = std::fs::create_dir_all(parent) {
+                    if std::fs::create_dir_all(parent).is_ok() {
                         // Test write permission by trying to create a temp file
                         let test_file = parent.join(".zebra_write_test");
                         if std::fs::write(&test_file, "test").is_ok() {
@@ -677,7 +677,7 @@ pub fn setup_tracing_with_format(output: LoggingOutput, format: LogFormat) -> an
                         .unwrap_or_else(|| std::path::Path::new("."));
 
                     // Try to create directory and test write permission
-                    if let Ok(_) = std::fs::create_dir_all(parent) {
+                    if std::fs::create_dir_all(parent).is_ok() {
                         // Test write permission by trying to create a temp file
                         let test_file = parent.join(".zebra_write_test");
                         if std::fs::write(&test_file, "test").is_ok() {

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -763,7 +763,7 @@ fn rib_add_system(table: &mut PrefixMap<Ipv4Net, RibEntries>, prefix: &Ipv4Net, 
 
                     btree.insert(uni.metric, uni);
 
-                    let vec: Vec<_> = btree.iter().map(|(_, &ref value)| value.clone()).collect();
+                    let vec: Vec<_> = btree.values().cloned().collect();
                     let list = NexthopList { nexthops: vec };
 
                     Nexthop::List(list)
@@ -975,7 +975,7 @@ fn rib_add_system_v6(
 
                     btree.insert(uni.metric, uni);
 
-                    let vec: Vec<_> = btree.iter().map(|(_, &ref value)| value.clone()).collect();
+                    let vec: Vec<_> = btree.values().cloned().collect();
                     let list = NexthopList { nexthops: vec };
 
                     Nexthop::List(list)


### PR DESCRIPTION
## Summary

Re-enable six more clippy lints that were silenced workspace-wide and fix the 19 sites they surfaced. All readability wins with a single correct mechanical fix:

- `redundant_pattern_matching` (5): `if let Ok(_) = x` → `x.is_ok()`
- `unwrap_or_default` (3): `.unwrap_or(T::default())` → `.unwrap_or_default()`, and `or_insert_with(KeyChain::new)` → `or_default()`. The now-unused `KeyChain::new()` helper is dropped since `KeyChain` derives `Default`.
- `manual_map` (3): `if let Some(v) = x { Some(f(v)) } else { None }` → `x.map(f)`
- `iter_kv_map` (2): `.iter().map(|(_, v)| ...)` → `.values().map(...)` (and `.values().cloned()` where the closure was just a clone)
- `needless_borrowed_reference` (2): drop `&ref` patterns
- `collapsible_match` (2): flatten `match { x => if cond { ... } }` into a single `if matches!(...) && cond { ... }`

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace --exclude bdd` — passing
- [x] `cargo fmt --all`

Generated with [Claude Code](https://claude.com/claude-code)