### PR TITLE
chore(clippy): remove tier-2 stylistic lints from allowlist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,20 +41,14 @@ clap = { version = "4", features = ["derive"] }
 [workspace.lints.clippy]
 # Style — explicit-over-implicit
 collapsible_if = "allow"
-needless_bool_assign = "allow"
-needless_return = "allow"
 
 # Style — references and casts
 clone_on_copy = "allow"
 needless_borrow = "allow"
-unnecessary_cast = "allow"
 
 # Style — APIs that get used a lot in protocol code
-for_kv_map = "allow"
 get_first = "allow"
-manual_range_contains = "allow"
 ptr_arg = "allow"
-unnecessary_map_or = "allow"
 
 # Naming — networking acronyms (TCP, IP, MD5, ...) are fine as-is
 upper_case_acronyms = "allow"

--- a/zebra-rs/src/bgp/timer.rs
+++ b/zebra-rs/src/bgp/timer.rs
@@ -107,17 +107,17 @@ fn start_hold_timer(peer: &Peer) -> Timer {
 
 pub fn start_adv_timer_ipv4(peer: &Peer) -> Timer {
     if peer.is_ibgp() {
-        start_timer!(peer, 5 as u64, Event::AdvTimerIpv4Expires)
+        start_timer!(peer, 5_u64, Event::AdvTimerIpv4Expires)
     } else {
-        start_timer!(peer, 30 as u64, Event::AdvTimerIpv4Expires)
+        start_timer!(peer, 30_u64, Event::AdvTimerIpv4Expires)
     }
 }
 
 pub fn start_adv_timer_vpnv4(peer: &Peer) -> Timer {
     if peer.is_ibgp() {
-        start_timer!(peer, 5 as u64, Event::AdvTimerVpnv4Expires)
+        start_timer!(peer, 5_u64, Event::AdvTimerVpnv4Expires)
     } else {
-        start_timer!(peer, 30 as u64, Event::AdvTimerVpnv4Expires)
+        start_timer!(peer, 30_u64, Event::AdvTimerVpnv4Expires)
     }
 }
 

--- a/zebra-rs/src/config/ip.rs
+++ b/zebra-rs/src/config/ip.rs
@@ -205,7 +205,7 @@ pub fn match_ipv6_prefix(s: &str, prefix: bool) -> (MatchType, usize) {
                 let n = i + 1;
                 let seg_start = segment_start.unwrap_or(0);
                 let next = bytes.get(n);
-                if next.map_or(true, |&b| b == b':' || b == b'.' || b == b'/') {
+                if next.is_none_or(|&b| b == b':' || b == b'.' || b == b'/') {
                     if i > seg_start + 4 {
                         return (MatchType::None, i);
                     }

--- a/zebra-rs/src/config/mac.rs
+++ b/zebra-rs/src/config/mac.rs
@@ -12,10 +12,7 @@ pub fn match_mac_addr(src: &str) -> (MatchType, usize) {
     while pos < src.len() {
         let c = src.as_bytes()[pos];
         match c {
-            c if (c >= b'0' && c <= b'9')
-                || (c >= b'a' && c <= b'f')
-                || (c >= b'A' && c <= b'F') =>
-            {
+            c if c.is_ascii_hexdigit() => {
                 id.push(c as char);
                 if id.len() > 2 {
                     return (MatchType::None, pos);

--- a/zebra-rs/src/config/nsap.rs
+++ b/zebra-rs/src/config/nsap.rs
@@ -82,7 +82,7 @@ pub fn match_nsap_addr(src: &str) -> (MatchType, usize) {
     let area_id_bytes = middle_bytes - 6;
 
     // Area ID must be 1-13 octets (per ISO 10589)
-    if area_id_bytes < 1 || area_id_bytes > 13 {
+    if !(1..=13).contains(&area_id_bytes) {
         return (MatchType::None, pos);
     }
 

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -194,18 +194,10 @@ fn config_tracing_event(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option
 
     match ev.as_str() {
         "dis" => {
-            if op.is_set() {
-                isis.tracing.event.dis.enabled = true;
-            } else {
-                isis.tracing.event.dis.enabled = false;
-            }
+            isis.tracing.event.dis.enabled = op.is_set();
         }
         "lsp-originate" => {
-            if op.is_set() {
-                isis.tracing.event.lsp_originate.enabled = true;
-            } else {
-                isis.tracing.event.lsp_originate.enabled = false;
-            }
+            isis.tracing.event.lsp_originate.enabled = op.is_set();
         }
         _ => {
             if op.is_set() {
@@ -224,18 +216,10 @@ fn config_tracing_fsm(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<(
 
     match typ.as_str() {
         "nfsm" => {
-            if op.is_set() {
-                isis.tracing.fsm.nfsm.enabled = true;
-            } else {
-                isis.tracing.fsm.nfsm.enabled = false;
-            }
+            isis.tracing.fsm.nfsm.enabled = op.is_set();
         }
         "ifsm" => {
-            if op.is_set() {
-                isis.tracing.fsm.ifsm.enabled = true;
-            } else {
-                isis.tracing.fsm.ifsm.enabled = false;
-            }
+            isis.tracing.fsm.ifsm.enabled = op.is_set();
         }
         _ => {
             //
@@ -300,11 +284,7 @@ fn config_tracing_database(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Opt
 
     match ev.as_str() {
         "lsdb" => {
-            if op.is_set() {
-                isis.tracing.database.lsdb.enabled = true;
-            } else {
-                isis.tracing.database.lsdb.enabled = false;
-            }
+            isis.tracing.database.lsdb.enabled = op.is_set();
         }
         _ => {
             if op.is_set() {

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -947,12 +947,12 @@ pub struct LspMap {
 impl LspMap {
     pub fn get(&mut self, sys_id: &IsisSysId) -> usize {
         if let Some(index) = self.map.get(&sys_id) {
-            return *index;
+            *index
         } else {
             let index = self.val.len();
             self.map.insert(sys_id.clone(), index);
             self.val.push(sys_id.clone());
-            return index;
+            index
         }
     }
 
@@ -1528,7 +1528,7 @@ pub fn mpls_route(rib: &PrefixMap<Ipv4Net, SpfRoute>, ilm: &mut BTreeMap<u32, Sp
     for (_prefix, route) in rib.iter() {
         if let Some(sid) = route.sid {
             // Calculate prefix index from SID (assuming 16000 is base)
-            let pfx_index = if sid >= 16000 && sid < 24000 {
+            let pfx_index = if (16000..24000).contains(&sid) {
                 sid - 16000
             } else {
                 0

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -94,6 +94,10 @@ impl IsisLinks {
     pub fn iter_mut(&mut self) -> IterMut<'_, u32, IsisLink> {
         self.map.iter_mut()
     }
+
+    pub fn values(&self) -> std::collections::btree_map::Values<'_, u32, IsisLink> {
+        self.map.values()
+    }
 }
 
 #[derive(Debug)]
@@ -237,7 +241,7 @@ impl LinkConfig {
         self.hello_padding.unwrap_or(HelloPaddingPolicy::Always)
     }
     pub fn holddown_count(&self) -> u32 {
-        self.holddown_count.unwrap_or(Self::DEFAULT_HOLDDOWN_COUNT) as u32
+        self.holddown_count.unwrap_or(Self::DEFAULT_HOLDDOWN_COUNT)
     }
 
     pub fn psnp_interval(&self) -> u64 {

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -135,8 +135,8 @@ fn show_mac(mac: Option<MacAddr>) -> String {
 pub fn show(top: &Isis, _args: Args, json: bool) -> std::result::Result<String, std::fmt::Error> {
     let mut nbrs: Vec<NeighborBrief> = vec![];
 
-    for (_, link) in top.links.iter() {
-        for (_key, nbr) in &link.state.nbrs.l1 {
+    for link in top.links.values() {
+        for nbr in link.state.nbrs.l1.values() {
             let rem = nbr.hold_timer.as_ref().map_or(0, |timer| timer.rem_sec());
             let system_id =
                 if let Some((hostname, _)) = top.hostname.get(&Level::L1).get(&nbr.sys_id) {
@@ -153,7 +153,7 @@ pub fn show(top: &Isis, _args: Args, json: bool) -> std::result::Result<String, 
                 snpa: show_mac(nbr.mac),
             });
         }
-        for (_key, nbr) in &link.state.nbrs.l2 {
+        for nbr in link.state.nbrs.l2.values() {
             let rem = nbr.hold_timer.as_ref().map_or(0, |timer| timer.rem_sec());
             let system_id =
                 if let Some((hostname, _)) = top.hostname.get(&Level::L2).get(&nbr.sys_id) {
@@ -235,7 +235,7 @@ fn show_entry(buf: &mut String, top: &Isis, nbr: &Neighbor, level: Level) -> std
     if !nbr.addr4.is_empty() {
         writeln!(buf, "    IP Prefixes")?;
     }
-    for (_key, value) in &nbr.addr4 {
+    for value in nbr.addr4.values() {
         write!(buf, "      {}", value.addr)?;
         if let Some(label) = value.label {
             let _ = write!(buf, " ({})", label);
@@ -251,7 +251,7 @@ fn show_entry(buf: &mut String, top: &Isis, nbr: &Neighbor, level: Level) -> std
     if !nbr.addr6.is_empty() {
         writeln!(buf, "    IPv6 Prefixes")?;
     }
-    for (_, value) in &nbr.addr6 {
+    for value in nbr.addr6.values() {
         writeln!(buf, "      {}", value.addr)?;
     }
 
@@ -320,13 +320,13 @@ pub fn show_detail(
     if json {
         let mut neighbors: Vec<NeighborDetail> = Vec::new();
 
-        for (_, link) in top.links.iter() {
+        for link in top.links.values() {
             // Collect Level-1 neighbors
-            for (_, adj) in &link.state.nbrs.l1 {
+            for adj in link.state.nbrs.l1.values() {
                 neighbors.push(neighbor_to_detail(top, adj, Level::L1));
             }
             // Collect Level-2 neighbors
-            for (_, adj) in &link.state.nbrs.l2 {
+            for adj in link.state.nbrs.l2.values() {
                 neighbors.push(neighbor_to_detail(top, adj, Level::L2));
             }
         }
@@ -341,13 +341,13 @@ pub fn show_detail(
     let estimated_capacity = 512;
     let mut buf = String::with_capacity(estimated_capacity);
 
-    for (_, link) in top.links.iter() {
+    for link in top.links.values() {
         // Show Level-1 neighbors
-        for (_, adj) in &link.state.nbrs.l1 {
+        for adj in link.state.nbrs.l1.values() {
             show_entry(&mut buf, top, adj, Level::L1)?;
         }
         // Show Level-2 neighbors
-        for (_, adj) in &link.state.nbrs.l2 {
+        for adj in link.state.nbrs.l2.values() {
             show_entry(&mut buf, top, adj, Level::L2)?;
         }
     }

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -76,9 +76,9 @@ fn yang_path(arg: &Arg) -> Option<String> {
     }
     let path = Path::new("/etc/zebra-rs/yang");
     if path.exists() {
-        return Some(path.to_string_lossy().to_string());
+        Some(path.to_string_lossy().to_string())
     } else {
-        return None;
+        None
     }
 }
 

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -163,11 +163,7 @@ fn config_ospf_interface_enable(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -
 
     let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
 
-    if op.is_set() && enable {
-        link.config.enable = true;
-    } else {
-        link.config.enable = false;
-    }
+    link.config.enable = op.is_set() && enable;
 
     let (next, next_id) = link_should_enable(link, &ospf.table);
     apply_link_enable_transition(link, next, next_id);
@@ -258,11 +254,7 @@ fn config_ospf_interface_mtu_ignore(ospf: &mut Ospf, mut args: Args, op: ConfigO
     let mtu_ignore = args.boolean()?;
 
     let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
-    if op.is_set() && mtu_ignore {
-        link.config.mtu_ignore = true;
-    } else {
-        link.config.mtu_ignore = false;
-    }
+    link.config.mtu_ignore = op.is_set() && mtu_ignore;
 
     Some(())
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -789,7 +789,7 @@ impl Ospf {
             let link_state = link.state;
 
             // RFC 2328 Section 13.3 Step 2-4: DR/BDR flooding decision.
-            let is_source_iface = source.map_or(false, |(src_if, _)| src_if == ifindex);
+            let is_source_iface = source.is_some_and(|(src_if, _)| src_if == ifindex);
 
             // RFC 2328 Section 13.3 Step 3: If interface state is Backup and
             // LSA was received on this interface, do not flood back out.
@@ -1299,12 +1299,12 @@ pub struct LspMap {
 impl LspMap {
     fn get(&mut self, router_id: Ipv4Addr) -> usize {
         if let Some(index) = self.map.get(&router_id) {
-            return *index;
+            *index
         } else {
             let index = self.val.len();
             self.map.insert(router_id, index);
             self.val.push(router_id);
-            return index;
+            index
         }
     }
 

--- a/zebra-rs/src/rib/entry.rs
+++ b/zebra-rs/src/rib/entry.rs
@@ -87,15 +87,15 @@ impl RibEntry {
 
     pub fn is_valid_nexthop(&self, nmap: &NexthopMap) -> bool {
         match &self.nexthop {
-            Nexthop::Uni(uni) => nmap.get(uni.gid).map_or(false, |group| group.is_valid()),
+            Nexthop::Uni(uni) => nmap.get(uni.gid).is_some_and(|group| group.is_valid()),
             Nexthop::Multi(multi) => multi
                 .nexthops
                 .iter()
-                .any(|nhop| nmap.get(nhop.gid).map_or(false, |group| group.is_valid())),
+                .any(|nhop| nmap.get(nhop.gid).is_some_and(|group| group.is_valid())),
             Nexthop::List(pro) => pro
                 .nexthops
                 .iter()
-                .any(|nhop| nmap.get(nhop.gid).map_or(false, |group| group.is_valid())),
+                .any(|nhop| nmap.get(nhop.gid).is_some_and(|group| group.is_valid())),
             _ => false,
         }
     }

--- a/zebra-rs/src/rib/mpls/route.rs
+++ b/zebra-rs/src/rib/mpls/route.rs
@@ -52,6 +52,6 @@ impl MplsRoute {
             multi.nexthops.push(nhop);
         }
         ilm.nexthop = Nexthop::Multi(multi);
-        return Some(ilm);
+        Some(ilm)
     }
 }

--- a/zebra-rs/src/spf/calc.rs
+++ b/zebra-rs/src/spf/calc.rs
@@ -207,7 +207,7 @@ pub fn spf_calc(
                 }
             } else if opt.full_path {
                 for path in &v.paths {
-                    if opt.path_max.map_or(true, |max| c.paths.len() < max) {
+                    if opt.path_max.is_none_or(|max| c.paths.len() < max) {
                         let mut newpath = path.clone();
                         newpath.push(c.id);
                         c.paths.push(newpath);
@@ -215,7 +215,7 @@ pub fn spf_calc(
                 }
             } else {
                 for nhop in &v.nexthops {
-                    if opt.path_max.map_or(true, |max| c.paths.len() < max) {
+                    if opt.path_max.is_none_or(|max| c.paths.len() < max) {
                         let mut newnhop = nhop.clone();
                         if nhop.is_empty() {
                             newnhop.push(c.id);


### PR DESCRIPTION
## Summary

Re-enable six more clippy lints workspace-wide and fix the 41 sites they surfaced. All readability wins:

- `unnecessary_map_or` (7): `.map_or(false, p)` → `.is_some_and(p)` and `.map_or(true, p)` → `.is_none_or(p)`. More idiomatic since Rust 1.82.
- `for_kv_map` (8): `for (_, v) in map` → `for v in map.values()`. Adds `IsisLinks::values` to expose the underlying `BTreeMap` accessor.
- `needless_return` (7): drop trailing `return` on tail expressions.
- `needless_bool_assign` (7): collapse `if cond { x = true } else { x = false }` to `x = cond` — IS-IS / OSPF tracing toggles.
- `manual_range_contains` (5): `c >= b'0' && c <= b'9'`-style → `c.is_ascii_hexdigit()` or `(a..=b).contains(&x)`.
- `unnecessary_cast` (5): drop `5 as u64` on already-typed literals and `expr as u32` when expr is already `u32`.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace --exclude bdd` — passing
- [x] `cargo fmt --all`

Generated with [Claude Code](https://claude.com/claude-code)