### PR TITLE
chore(clippy): collapse nested ifs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,6 @@ clap = { version = "4", features = ["derive"] }
 # and explicit-over-implicit choices in packet parsers). Other clippy
 # lints remain at their default level so genuine issues still surface.
 [workspace.lints.clippy]
-# Style — explicit-over-implicit
-collapsible_if = "allow"
-
 # Style — references and casts
 clone_on_copy = "allow"
 needless_borrow = "allow"

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -92,30 +92,27 @@ fn clear_peer_listener_auth(bgp: &mut Bgp, addr: &IpAddr) {
         .get(addr)
         .and_then(|p| p.config.transport.md5_password.as_ref())
         .is_some();
-    if had_md5 {
-        if let Err(e) = super::auth::set_tcp_md5_key(fd, *addr, &[]) {
-            tracing::warn!(
-                peer = %addr,
-                error = %e,
-                "TCP MD5 del on listener failed during peer cleanup"
-            );
-        }
+    if had_md5 && let Err(e) = super::auth::set_tcp_md5_key(fd, *addr, &[]) {
+        tracing::warn!(
+            peer = %addr,
+            error = %e,
+            "TCP MD5 del on listener failed during peer cleanup"
+        );
     }
 
     // TCP-AO: needs the exact (send_id, recv_id) used at install
     // time, remembered on the peer.
     if let Some(peer) = bgp.peers.get_mut(addr)
         && let Some((send_id, recv_id)) = peer.last_ao_installed.take()
+        && let Err(e) = super::auth::del_tcp_ao_key(fd, *addr, send_id, recv_id)
     {
-        if let Err(e) = super::auth::del_tcp_ao_key(fd, *addr, send_id, recv_id) {
-            tracing::warn!(
-                peer = %addr,
-                send_id,
-                recv_id,
-                error = %e,
-                "TCP-AO del on listener failed during peer cleanup"
-            );
-        }
+        tracing::warn!(
+            peer = %addr,
+            send_id,
+            recv_id,
+            error = %e,
+            "TCP-AO del on listener failed during peer cleanup"
+        );
     }
 }
 
@@ -466,14 +463,14 @@ fn config_peer_tcp_md5_password(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
         IpAddr::V4(_) => bgp.listen_fd_v4,
         IpAddr::V6(_) => bgp.listen_fd_v6,
     };
-    if let Some(fd) = listen_fd {
-        if let Err(e) = super::auth::set_tcp_md5_key(fd, addr, &password_bytes) {
-            tracing::warn!(
-                peer = %addr,
-                error = %e,
-                "TCP MD5 setsockopt on listener failed; incoming SYNs from this peer will be dropped"
-            );
-        }
+    if let Some(fd) = listen_fd
+        && let Err(e) = super::auth::set_tcp_md5_key(fd, addr, &password_bytes)
+    {
+        tracing::warn!(
+            peer = %addr,
+            error = %e,
+            "TCP MD5 setsockopt on listener failed; incoming SYNs from this peer will be dropped"
+        );
     }
 
     Some(())

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -427,10 +427,11 @@ impl Peer {
 
     pub fn is_afi_safi(&self, afi: Afi, safi: Safi) -> bool {
         let afi = CapMultiProtocol::new(&afi, &safi);
-        if let Some(cap) = self.cap_map.entries.get(&afi) {
-            if cap.send && cap.recv {
-                return true;
-            }
+        if let Some(cap) = self.cap_map.entries.get(&afi)
+            && cap.send
+            && cap.recv
+        {
+            return true;
         }
         false
     }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -622,27 +622,27 @@ pub fn route_ipv4_update(
         // RFC 4456: Drop update if ORIGINATOR_ID matches local router ID. This
         // prevents routing loops in route reflection scenarios. This happens before
         // the route store in AdjRibIn.
-        if let Some(ref originator_id) = attr.originator_id {
-            if originator_id.id == *bgp.router_id {
-                eprintln!(
-                    "Dropping update for {} from peer {} - ORIGINATOR_ID {} matches local router ID",
-                    nlri.prefix, peer.address, originator_id.id
-                );
-                return;
-            }
+        if let Some(ref originator_id) = attr.originator_id
+            && originator_id.id == *bgp.router_id
+        {
+            eprintln!(
+                "Dropping update for {} from peer {} - ORIGINATOR_ID {} matches local router ID",
+                nlri.prefix, peer.address, originator_id.id
+            );
+            return;
         }
 
         // RFC 4456: Drop update if local router ID is in CLUSTER_LIST. This
         // prevents routing loops in route reflection scenarios when the route
         // has already passed through this route reflector.
-        if let Some(ref cluster_list) = attr.cluster_list {
-            if cluster_list.list.contains(&bgp.router_id) {
-                eprintln!(
-                    "Dropping update for {} from peer {} - local router ID {} found in CLUSTER_LIST",
-                    nlri.prefix, peer.address, bgp.router_id
-                );
-                return;
-            }
+        if let Some(ref cluster_list) = attr.cluster_list
+            && cluster_list.list.contains(&bgp.router_id)
+        {
+            eprintln!(
+                "Dropping update for {} from peer {} - local router ID {} found in CLUSTER_LIST",
+                nlri.prefix, peer.address, bgp.router_id
+            );
+            return;
         }
 
         // Identify peer_type
@@ -738,31 +738,30 @@ fn route_advertise_to_addpath(
     for peer_addr in peer_addrs {
         let peer = peers.get_mut(&peer_addr).expect("peer exists");
 
-        if let Some((nlri, attr)) = route_update_ipv4(peer, &prefix, rib, bgp, true) {
-            if let Some(attr) = route_apply_policy_out(peer, &nlri, attr) {
-                // RTC match.
-                if let Some(_rd) = rd {
-                    if !peer.rtcv4.is_empty() {
-                        if !rtc_match(&peer.rtcv4, &attr.ecom) {
-                            continue;
-                        }
-                    }
-                }
-                let attr = bgp.attr_store.intern(attr);
-                let mut rib = rib.clone();
-                rib.attr = attr.clone();
+        if let Some((nlri, attr)) = route_update_ipv4(peer, &prefix, rib, bgp, true)
+            && let Some(attr) = route_apply_policy_out(peer, &nlri, attr)
+        {
+            // RTC match.
+            if let Some(_rd) = rd
+                && !peer.rtcv4.is_empty()
+                && !rtc_match(&peer.rtcv4, &attr.ecom)
+            {
+                continue;
+            }
+            let attr = bgp.attr_store.intern(attr);
+            let mut rib = rib.clone();
+            rib.attr = attr.clone();
 
-                peer.adj_out.add(rd, nlri.prefix, rib);
-                if let Some(ref rd) = rd {
-                    let vpnv4_nlri = Vpnv4Nlri {
-                        label: Label::default(),
-                        rd: rd.clone(),
-                        nlri,
-                    };
-                    peer.send_vpnv4(vpnv4_nlri, attr, true);
-                } else {
-                    peer.send_ipv4(nlri, attr, true);
-                }
+            peer.adj_out.add(rd, nlri.prefix, rib);
+            if let Some(ref rd) = rd {
+                let vpnv4_nlri = Vpnv4Nlri {
+                    label: Label::default(),
+                    rd: rd.clone(),
+                    nlri,
+                };
+                peer.send_vpnv4(vpnv4_nlri, attr, true);
+            } else {
+                peer.send_ipv4(nlri, attr, true);
             }
         }
     }
@@ -859,10 +858,8 @@ fn route_advertise_to_peers(
             (Some(nlri), Some(attr)) => {
                 if let Some(_rd) = rd {
                     // RTC match.
-                    if !peer.rtcv4.is_empty() {
-                        if !rtc_match(&peer.rtcv4, &attr.ecom) {
-                            continue;
-                        }
+                    if !peer.rtcv4.is_empty() && !rtc_match(&peer.rtcv4, &attr.ecom) {
+                        continue;
                     }
                 }
                 // Send update
@@ -1598,11 +1595,11 @@ pub fn route_update_ipv4(
     // 1. Origin.  Pass through
 
     // 2. AS_PATH
-    if peer.is_ebgp() {
-        if let Some(ref mut aspath) = attrs.aspath {
-            let local_as_path = As4Path::from(vec![peer.local_as]);
-            aspath.prepend_mut(local_as_path.clone());
-        }
+    if peer.is_ebgp()
+        && let Some(ref mut aspath) = attrs.aspath
+    {
+        let local_as_path = As4Path::from(vec![peer.local_as]);
+        aspath.prepend_mut(local_as_path.clone());
     }
 
     // 3. NEXT_HOP
@@ -1620,23 +1617,22 @@ pub fn route_update_ipv4(
     // 4. MED - Pass through.
 
     // 5. Local Preference (for IBGP only)
-    if peer.is_ibgp() {
-        if attrs.local_pref.is_none() {
-            attrs.local_pref = Some(LocalPref::default());
-        }
+    if peer.is_ibgp() && attrs.local_pref.is_none() {
+        attrs.local_pref = Some(LocalPref::default());
     }
 
     // 6. Originator ID (for IBGP route reflection)
     // RFC 4456: A route reflector SHOULD NOT create an ORIGINATOR_ID if one already
     // exists. ORIGINATOR_ID is set only once by the first route reflector and preserved
     // thereafter to identify the original route source within the AS.
-    if peer.peer_type == PeerType::IBGP && rib.typ == BgpRibType::IBGP {
-        if attrs.originator_id.is_none() {
-            // Set ORIGINATOR_ID to the router ID of the peer that originated this route
-            attrs.originator_id = Some(OriginatorId::new(rib.router_id));
-        }
-        // If ORIGINATOR_ID already exists, preserve it (don't overwrite)
+    if peer.peer_type == PeerType::IBGP
+        && rib.typ == BgpRibType::IBGP
+        && attrs.originator_id.is_none()
+    {
+        // Set ORIGINATOR_ID to the router ID of the peer that originated this route
+        attrs.originator_id = Some(OriginatorId::new(rib.router_id));
     }
+    // If ORIGINATOR_ID already exists, preserve it (don't overwrite)
 
     // 7. Cluster List (for IBGP route reflection)
     // RFC 4456: When a route reflector reflects a route, it must prepend the local
@@ -1658,10 +1654,10 @@ pub fn route_update_ipv4(
 
 impl Peer {
     pub fn send_packet(&self, bytes: BytesMut) {
-        if let Some(ref packet_tx) = self.packet_tx {
-            if let Err(e) = packet_tx.send(bytes) {
-                eprintln!("Failed to send BGP packet to {}: {}", self.address, e);
-            }
+        if let Some(ref packet_tx) = self.packet_tx
+            && let Err(e) = packet_tx.send(bytes)
+        {
+            eprintln!("Failed to send BGP packet to {}: {}", self.address, e);
         }
     }
 
@@ -1678,12 +1674,12 @@ impl Peer {
 
     pub fn cache_remove_ipv4(&mut self, prefix: Ipv4Net, id: u32) {
         let nlri = Ipv4Nlri { id, prefix };
-        if let Some(attr) = self.cache_ipv4_rev.remove(&nlri) {
-            if let Some(set) = self.cache_ipv4.get_mut(&attr) {
-                set.remove(&nlri);
-                if set.is_empty() {
-                    self.cache_ipv4.remove(&attr);
-                }
+        if let Some(attr) = self.cache_ipv4_rev.remove(&nlri)
+            && let Some(set) = self.cache_ipv4.get_mut(&attr)
+        {
+            set.remove(&nlri);
+            if set.is_empty() {
+                self.cache_ipv4.remove(&attr);
             }
         }
     }
@@ -1723,12 +1719,12 @@ impl Peer {
             rd,
             nlri: Ipv4Nlri { id, prefix },
         };
-        if let Some(attr) = self.cache_vpnv4_rev.remove(&nlri) {
-            if let Some(set) = self.cache_vpnv4.get_mut(&attr) {
-                set.remove(&nlri);
-                if set.is_empty() {
-                    self.cache_vpnv4.remove(&attr);
-                }
+        if let Some(attr) = self.cache_vpnv4_rev.remove(&nlri)
+            && let Some(set) = self.cache_vpnv4.get_mut(&attr)
+        {
+            set.remove(&nlri);
+            if set.is_empty() {
+                self.cache_vpnv4.remove(&attr);
             }
         }
     }
@@ -1887,10 +1883,8 @@ pub fn route_sync_vpnv4(peer: &mut Peer, bgp: &mut BgpTop) {
             };
 
             // RTC
-            if !peer.rtcv4.is_empty() {
-                if !rtc_match(&peer.rtcv4, &attr.ecom) {
-                    continue;
-                }
+            if !peer.rtcv4.is_empty() && !rtc_match(&peer.rtcv4, &attr.ecom) {
+                continue;
             }
 
             // Register to AdjOut.

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -714,10 +714,10 @@ fn show_bgp_vpnv4_route(
                 writeln!(out, "    {}", attr_parts.join(", "))?;
 
                 // Display AS path if present
-                if let Some(aspath) = &rib.attr.aspath {
-                    if !aspath.segs.is_empty() {
-                        writeln!(out, "    AS path: {}", aspath)?;
-                    }
+                if let Some(aspath) = &rib.attr.aspath
+                    && !aspath.segs.is_empty()
+                {
+                    writeln!(out, "    AS path: {}", aspath)?;
                 }
 
                 // Display route reflection attributes if present (RFC 4456)
@@ -813,10 +813,10 @@ fn show_bgp_route_entry(
             writeln!(out, "    {}", attr_parts.join(", "))?;
 
             // Display AS path if present
-            if let Some(aspath) = &rib.attr.aspath {
-                if !aspath.segs.is_empty() {
-                    writeln!(out, "    AS path: {}", aspath)?;
-                }
+            if let Some(aspath) = &rib.attr.aspath
+                && !aspath.segs.is_empty()
+            {
+                writeln!(out, "    AS path: {}", aspath)?;
             }
 
             // Display route reflection attributes if present (RFC 4456)
@@ -1319,34 +1319,34 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
         }
 
         let afi = CapMultiProtocol::new(&Afi::Ip, &Safi::Unicast);
-        if let Some(cap) = neighbor.cap_map.entries.get(&afi) {
-            if cap.send || cap.recv {
-                writeln!(out, "    IPv4 Unicast: {}", cap.desc())?;
-            }
+        if let Some(cap) = neighbor.cap_map.entries.get(&afi)
+            && (cap.send || cap.recv)
+        {
+            writeln!(out, "    IPv4 Unicast: {}", cap.desc())?;
         }
         let afi = CapMultiProtocol::new(&Afi::Ip6, &Safi::Unicast);
-        if let Some(cap) = neighbor.cap_map.entries.get(&afi) {
-            if cap.send || cap.recv {
-                writeln!(out, "    IPv6 Unicast: {}", cap.desc())?;
-            }
+        if let Some(cap) = neighbor.cap_map.entries.get(&afi)
+            && (cap.send || cap.recv)
+        {
+            writeln!(out, "    IPv6 Unicast: {}", cap.desc())?;
         }
         let afi = CapMultiProtocol::new(&Afi::Ip, &Safi::MplsVpn);
-        if let Some(cap) = neighbor.cap_map.entries.get(&afi) {
-            if cap.send || cap.recv {
-                writeln!(out, "    IPv4 MPLS VPN: {}", cap.desc())?;
-            }
+        if let Some(cap) = neighbor.cap_map.entries.get(&afi)
+            && (cap.send || cap.recv)
+        {
+            writeln!(out, "    IPv4 MPLS VPN: {}", cap.desc())?;
         }
         let afi = CapMultiProtocol::new(&Afi::L2vpn, &Safi::Evpn);
-        if let Some(cap) = neighbor.cap_map.entries.get(&afi) {
-            if cap.send || cap.recv {
-                writeln!(out, "    L2VPN EVPN: {}", cap.desc())?;
-            }
+        if let Some(cap) = neighbor.cap_map.entries.get(&afi)
+            && (cap.send || cap.recv)
+        {
+            writeln!(out, "    L2VPN EVPN: {}", cap.desc())?;
         }
         let afi = CapMultiProtocol::new(&Afi::Ip, &Safi::Rtc);
-        if let Some(cap) = neighbor.cap_map.entries.get(&afi) {
-            if cap.send || cap.recv {
-                writeln!(out, "    IPv4 RTC: {}", cap.desc())?;
-            }
+        if let Some(cap) = neighbor.cap_map.entries.get(&afi)
+            && (cap.send || cap.recv)
+        {
+            writeln!(out, "    IPv4 RTC: {}", cap.desc())?;
         }
 
         if !neighbor.cap_send.addpath.is_empty() || !neighbor.cap_recv.addpath.is_empty() {

--- a/zebra-rs/src/config/comps.rs
+++ b/zebra-rs/src/config/comps.rs
@@ -223,11 +223,11 @@ pub fn comps_add_all(
                 for subent in entry.dir.borrow().iter() {
                     if &subent.name == key {
                         comps_as_leaf(comps, subent);
-                        if let Some(dynamic) = subent.extension.get("ext:dynamic") {
-                            if let Some(candidates) = s.dynamic.get(dynamic) {
-                                for cand in candidates.iter() {
-                                    comps.push(Completion::new_name(cand));
-                                }
+                        if let Some(dynamic) = subent.extension.get("ext:dynamic")
+                            && let Some(candidates) = s.dynamic.get(dynamic)
+                        {
+                            for cand in candidates.iter() {
+                                comps.push(Completion::new_name(cand));
                             }
                         }
                         if subent.name == "if-name-brief" {
@@ -245,11 +245,11 @@ pub fn comps_add_all(
         }
         _ => {
             comps_as_leaf(comps, entry);
-            if let Some(dynamic) = entry.extension.get("ext:dynamic") {
-                if let Some(candidates) = s.dynamic.get(dynamic) {
-                    for cand in candidates.iter() {
-                        comps.push(Completion::new_name(cand));
-                    }
+            if let Some(dynamic) = entry.extension.get("ext:dynamic")
+                && let Some(candidates) = s.dynamic.get(dynamic)
+            {
+                for cand in candidates.iter() {
+                    comps.push(Completion::new_name(cand));
                 }
             }
         }

--- a/zebra-rs/src/config/ip.rs
+++ b/zebra-rs/src/config/ip.rs
@@ -236,10 +236,10 @@ pub fn match_ipv6_prefix(s: &str, prefix: bool) -> (MatchType, usize) {
         if nums > 11 || colons > 7 {
             return (MatchType::None, i);
         }
-        if let Some(&curr) = bytes.get(i) {
-            if curr == b' ' {
-                break;
-            }
+        if let Some(&curr) = bytes.get(i)
+            && curr == b' '
+        {
+            break;
         }
         i += 1;
     }

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -340,11 +340,11 @@ fn entry_match_type(entry: &Rc<Entry>, input: &str, m: &mut Match, s: &mut State
 
     // Handle choice case logic
     if let Some((choice_name, case_name)) = is_choice_case(entry) {
-        if let Some(active_case) = s.get_active_choice_case(&choice_name) {
-            if active_case != &case_name {
-                // Different case is active, clear it
-                s.clear_choice_case(&choice_name);
-            }
+        if let Some(active_case) = s.get_active_choice_case(&choice_name)
+            && active_case != &case_name
+        {
+            // Different case is active, clear it
+            s.clear_choice_case(&choice_name);
         }
         // Set this case as active
         s.set_active_choice_case(&choice_name, &case_name);
@@ -366,11 +366,11 @@ fn entry_match_type(entry: &Rc<Entry>, input: &str, m: &mut Match, s: &mut State
         }
     }
 
-    if let Some(dynamics) = entry.extension.get("ext:dynamic") {
-        if let Some(candidates) = s.dynamic.get(dynamics) {
-            for candidate in candidates.iter() {
-                m.match_keyword(entry, input, candidate);
-            }
+    if let Some(dynamics) = entry.extension.get("ext:dynamic")
+        && let Some(candidates) = s.dynamic.get(dynamics)
+    {
+        for candidate in candidates.iter() {
+            m.match_keyword(entry, input, candidate);
         }
     }
 
@@ -384,10 +384,10 @@ fn entry_match_dir(entry: &Rc<Entry>, str: &str, m: &mut Match, state: &State) {
         // Check if this entry is part of a choice
         if let Some((choice_name, case_name)) = is_choice_case(entry) {
             // Only include if this case is active or no case is active yet
-            if let Some(active_case) = state.get_active_choice_case(&choice_name) {
-                if active_case != &case_name {
-                    continue; // Skip inactive choice case
-                }
+            if let Some(active_case) = state.get_active_choice_case(&choice_name)
+                && active_case != &case_name
+            {
+                continue; // Skip inactive choice case
             }
         }
         m.match_entry(entry, str);
@@ -463,12 +463,11 @@ pub fn ymatch_complete(ymatch: YangMatch, list_presence: bool, is_delete: bool) 
 }
 
 fn matched_enumeration(mx: &Match) -> Option<String> {
-    if let Some(type_node) = &mx.matched_entry.type_node {
-        if type_node.kind == YangType::Enumeration {
-            if let Some(last_match) = &mx.last_match {
-                return Some(last_match.clone());
-            }
-        }
+    if let Some(type_node) = &mx.matched_entry.type_node
+        && type_node.kind == YangType::Enumeration
+        && let Some(last_match) = &mx.last_match
+    {
+        return Some(last_match.clone());
     }
     None
 }

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -53,14 +53,14 @@ fn kernel_supports_nhid() -> bool {
         if parts.len() >= 3 && parts[0] == "Linux" && parts[1] == "version" {
             let version_str = parts[2];
             let version_parts: Vec<&str> = version_str.split('.').collect();
-            if version_parts.len() >= 2 {
-                if let (Ok(major), Ok(minor)) = (
+            if version_parts.len() >= 2
+                && let (Ok(major), Ok(minor)) = (
                     version_parts[0].parse::<u32>(),
                     version_parts[1].parse::<u32>(),
-                ) {
-                    // Nexthop table introduced in kernel 5.3
-                    return major > 5 || (major == 5 && minor >= 3);
-                }
+                )
+            {
+                // Nexthop table introduced in kernel 5.3
+                return major > 5 || (major == 5 && minor >= 3);
             }
         }
     }
@@ -1249,11 +1249,11 @@ impl FibHandle {
 
         // Phase 4D: ESI received and stored. Kernel multi-homing via NDA_NH_ID
         // will be wired in Phase 5 when ECMP nexthop groups are supported.
-        if let Some(esi_val) = esi {
-            if esi_val != [0u8; 10] {
-                // ESI[0] is the ESI type. ESI[1..9] is the type-specific value.
-                eprintln!("mac_add: ESI type {} for MAC {}", esi_val[0], mac);
-            }
+        if let Some(esi_val) = esi
+            && esi_val != [0u8; 10]
+        {
+            // ESI[0] is the ESI type. ESI[1..9] is the type-specific value.
+            eprintln!("mac_add: ESI type {} for MAC {}", esi_val[0], mac);
         }
 
         // Build netlink request

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -73,12 +73,12 @@ pub fn hello_generate(link: &LinkTop, level: Level) -> IsisHello {
 
     let mut neighbors = Vec::new();
     for (_, nbr) in link.state.nbrs.get(&level).iter() {
-        if nbr.state == NfsmState::Init || nbr.state == NfsmState::Up {
-            if let Some(mac) = nbr.mac {
-                neighbors.push(NeighborAddr {
-                    octets: mac.octets(),
-                })
-            }
+        if (nbr.state == NfsmState::Init || nbr.state == NfsmState::Up)
+            && let Some(mac) = nbr.mac
+        {
+            neighbors.push(NeighborAddr {
+                octets: mac.octets(),
+            })
         }
     }
     hello.tlvs.push(IsisTlvIsNeighbor { neighbors }.into());
@@ -409,12 +409,12 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
             }
             DisStatus::Other => {
                 use IfsmEvent::*;
-                if link.state.adj.get(&level).is_none() {
-                    if let Some(lan_id) = lan_id {
-                        *link.state.adj.get_mut(&level) = Some((lan_id.clone(), None));
-                        link.lsdb.get_mut(&level).adj_set(link.ifindex);
-                        link.event(Message::Ifsm(HelloOriginate, link.ifindex, Some(level)));
-                    }
+                if link.state.adj.get(&level).is_none()
+                    && let Some(lan_id) = lan_id
+                {
+                    *link.state.adj.get_mut(&level) = Some((lan_id.clone(), None));
+                    link.lsdb.get_mut(&level).adj_set(link.ifindex);
+                    link.event(Message::Ifsm(HelloOriginate, link.ifindex, Some(level)));
                 }
             }
         }
@@ -431,10 +431,8 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
         link.event(Message::LspOriginate(level));
 
         // CSNP timer for when DIS is me.
-        if new_status == DisStatus::Myself {
-            if link.timer.csnp.get(&level).is_none() {
-                *link.timer.csnp.get_mut(&level) = Some(csnp_timer(link, level));
-            }
+        if new_status == DisStatus::Myself && link.timer.csnp.get(&level).is_none() {
+            *link.timer.csnp.get_mut(&level) = Some(csnp_timer(link, level));
         }
 
         // Record changes.

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -669,11 +669,11 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
     }
 
     // TE Router ID. Prefer configured value, fall back to RIB-derived.
-    if top.config.segment_routing.is_some() {
-        if let Some(router_id) = top.config.te_router_id.or(top.config.rib_router_id) {
-            let te_router_id = IsisTlvTeRouterId { router_id };
-            lsp.tlvs.push(te_router_id.into());
-        }
+    if top.config.segment_routing.is_some()
+        && let Some(router_id) = top.config.te_router_id.or(top.config.rib_router_id)
+    {
+        let te_router_id = IsisTlvTeRouterId { router_id };
+        lsp.tlvs.push(te_router_id.into());
     }
 
     // IS Reachability.
@@ -1206,22 +1206,22 @@ pub fn diff_apply(rib_tx: UnboundedSender<rib::Message>, diff: &DiffResult) {
 }
 
 fn make_ilm_entry(label: u32, ilm: &SpfIlm) -> IlmEntry {
-    if ilm.nhops.len() == 1 {
-        if let Some((&addr, nhop)) = ilm.nhops.iter().next() {
-            let mut uni = NexthopUni {
-                addr: std::net::IpAddr::V4(addr),
-                ifindex: nhop.ifindex,
-                ..Default::default()
-            };
-            if !nhop.adjacency {
-                uni.mpls_label.push(label);
-            }
-            return IlmEntry {
-                rtype: RibType::Isis,
-                ilm_type: ilm.ilm_type.clone(),
-                nexthop: Nexthop::Uni(uni),
-            };
+    if ilm.nhops.len() == 1
+        && let Some((&addr, nhop)) = ilm.nhops.iter().next()
+    {
+        let mut uni = NexthopUni {
+            addr: std::net::IpAddr::V4(addr),
+            ifindex: nhop.ifindex,
+            ..Default::default()
+        };
+        if !nhop.adjacency {
+            uni.mpls_label.push(label);
         }
+        return IlmEntry {
+            rtype: RibType::Isis,
+            ilm_type: ilm.ilm_type.clone(),
+            nexthop: Nexthop::Uni(uni),
+        };
     }
     let mut multi = NexthopMulti::default();
     for (&addr, nhop) in ilm.nhops.iter() {
@@ -1391,19 +1391,19 @@ fn build_rib_from_spf(
         let mut spf_nhops = BTreeMap::new();
         for p in &nhops.nexthops {
             // p.is_empty() means myself
-            if !p.is_empty() {
-                if let Some(nhop_id) = top.lsp_map.get(&level).resolve(p[0]) {
-                    // Find nhop from links
-                    for (ifindex, link) in top.links.iter() {
-                        if let Some(nbr) = link.state.nbrs.get(&level).get(nhop_id) {
-                            for (addr, _) in nbr.addr4.iter() {
-                                let nhop = SpfNexthop {
-                                    ifindex: *ifindex,
-                                    adjacency: p[0] == *node,
-                                    sys_id: Some(nhop_id.clone()),
-                                };
-                                spf_nhops.insert(*addr, nhop);
-                            }
+            if !p.is_empty()
+                && let Some(nhop_id) = top.lsp_map.get(&level).resolve(p[0])
+            {
+                // Find nhop from links
+                for (ifindex, link) in top.links.iter() {
+                    if let Some(nbr) = link.state.nbrs.get(&level).get(nhop_id) {
+                        for (addr, _) in nbr.addr4.iter() {
+                            let nhop = SpfNexthop {
+                                ifindex: *ifindex,
+                                adjacency: p[0] == *node,
+                                sys_id: Some(nhop_id.clone()),
+                            };
+                            spf_nhops.insert(*addr, nhop);
                         }
                     }
                 }

--- a/zebra-rs/src/isis/labelpool.rs
+++ b/zebra-rs/src/isis/labelpool.rs
@@ -26,10 +26,10 @@ impl LabelPool {
             return Some(index + self.begin);
         }
 
-        if let Some(end) = self.end {
-            if self.begin + self.allocated.len() > end {
-                return None;
-            }
+        if let Some(end) = self.end
+            && self.begin + self.allocated.len() > end
+        {
+            return None;
         }
 
         let new_label = self.allocated.len();

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -1211,10 +1211,10 @@ pub fn show_dis_history(
         let mut history = Vec::new();
         for (_, link) in isis.links.iter() {
             if link.config.enabled() {
-                if let Some(ref filter) = interface_filter {
-                    if link.state.name != *filter {
-                        continue;
-                    }
+                if let Some(ref filter) = interface_filter
+                    && link.state.name != *filter
+                {
+                    continue;
                 }
 
                 for level in [Level::L1, Level::L2] {
@@ -1252,10 +1252,10 @@ pub fn show_dis_history(
 
     for (_, link) in isis.links.iter() {
         if link.config.enabled() {
-            if let Some(ref filter) = interface_filter {
-                if link.state.name != *filter {
-                    continue;
-                }
+            if let Some(ref filter) = interface_filter
+                && link.state.name != *filter
+            {
+                continue;
             }
 
             for level in [Level::L1, Level::L2] {

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -164,10 +164,10 @@ pub struct LspCapView<'a> {
 }
 
 fn update_lsp(top: &mut LinkTop, level: Level, key: IsisLspId, lsp: &IsisLsp) {
-    if let Some(prev) = top.lsdb.get(&level).get(&key) {
-        if prev.lsp.tlvs == lsp.tlvs {
-            return;
-        }
+    if let Some(prev) = top.lsdb.get(&level).get(&key)
+        && prev.lsp.tlvs == lsp.tlvs
+    {
+        return;
     }
 
     let lsp = lsp_view(lsp);
@@ -190,10 +190,10 @@ fn update_lsp(top: &mut LinkTop, level: Level, key: IsisLspId, lsp: &IsisLsp) {
                     global: LabelBlock::new(start, cap.range),
                     local: None,
                 };
-                if let Some(lb) = cap_view.lb {
-                    if let SidLabelTlv::Label(start) = lb.sid_label {
-                        label_config.local = Some(LabelBlock::new(start, lb.range));
-                    }
+                if let Some(lb) = cap_view.lb
+                    && let SidLabelTlv::Label(start) = lb.sid_label
+                {
+                    label_config.local = Some(LabelBlock::new(start, lb.range));
                 }
                 top.label_map
                     .get_mut(&level)
@@ -221,16 +221,16 @@ pub fn insert_lsp(top: &mut LinkTop, level: Level, lsp: IsisLsp, bytes: Vec<u8>)
     }
 
     // Check sequence number.
-    if let Some(lsa) = top.lsdb.get(&level).get(&lsp.lsp_id) {
-        if lsp.seq_number <= lsa.lsp.seq_number {
-            isis_database_trace!(
-                top.tracing,
-                Lsdb,
-                &level,
-                "Same or smaller seq_number, no need of updating LSDB"
-            );
-            return None;
-        }
+    if let Some(lsa) = top.lsdb.get(&level).get(&lsp.lsp_id)
+        && lsp.seq_number <= lsa.lsp.seq_number
+    {
+        isis_database_trace!(
+            top.tracing,
+            Lsdb,
+            &level,
+            "Same or smaller seq_number, no need of updating LSDB"
+        );
+        return None;
     }
 
     if key.is_pseudo() {
@@ -286,10 +286,10 @@ pub fn insert_self_originate(
 }
 
 pub fn remove_lsp(top: &mut IsisTop, level: Level, key: IsisLspId) {
-    if let Some(lsa) = top.lsdb.get_mut(&level).remove(&key) {
-        if let Some(_tlv) = lsa.lsp.hostname_tlv() {
-            top.hostname.get_mut(&level).remove(&key.sys_id());
-        }
+    if let Some(lsa) = top.lsdb.get_mut(&level).remove(&key)
+        && let Some(_tlv) = lsa.lsp.hostname_tlv()
+    {
+        top.hostname.get_mut(&level).remove(&key.sys_id());
     }
 }
 

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -208,15 +208,15 @@ fn show_entry(buf: &mut String, top: &Isis, nbr: &Neighbor, level: Level) -> std
     )?;
 
     write!(buf, "    Circuit type: {}, Speaks:", nbr.circuit_type)?;
-    if let Some(proto) = &nbr.proto {
-        if !proto.nlpids.is_empty() {
-            let protocols = proto
-                .nlpids
-                .iter()
-                .map(|&nlpid| IsisProto::from(nlpid))
-                .join(", ");
-            writeln!(buf, " {}", protocols)?;
-        }
+    if let Some(proto) = &nbr.proto
+        && !proto.nlpids.is_empty()
+    {
+        let protocols = proto
+            .nlpids
+            .iter()
+            .map(|&nlpid| IsisProto::from(nlpid))
+            .join(", ");
+        writeln!(buf, " {}", protocols)?;
     }
 
     writeln!(

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -94,10 +94,10 @@ pub fn nbr_hello_interpret(
         let keep = addr4.contains_key(key);
         if !keep {
             // Release the label before removing
-            if let Some(label) = value.label {
-                if let Some(local_pool) = local_pool {
-                    local_pool.release(label as usize);
-                }
+            if let Some(label) = value.label
+                && let Some(local_pool) = local_pool
+            {
+                local_pool.release(label as usize);
             }
         }
         keep
@@ -116,10 +116,10 @@ pub fn nbr_hello_interpret(
         let keep = addr6.contains_key(key);
         if !keep {
             // Release the label before removing
-            if let Some(label) = value.label {
-                if let Some(local_pool) = local_pool {
-                    local_pool.release(label as usize);
-                }
+            if let Some(label) = value.label
+                && let Some(local_pool) = local_pool
+            {
+                local_pool.release(label as usize);
             }
         }
         keep
@@ -240,15 +240,13 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
     // When neighbor is elected as DIS and reports LAN ID in Hello packet,
     // register adjacency if not already set. This handles the case where
     // neighbor reaches Up state before we receive the DIS's LAN ID.
-    if nbr.is_dis() && !nbr.lan_id.is_empty() {
-        if link.state.adj.get_mut(&level).is_none() {
-            // Register adjacency and create SRM/SSN entry in LSDB.
-            *link.state.adj.get_mut(&level) = Some((nbr.lan_id, None));
-            link.lsdb.get_mut(&level).adj_set(link.ifindex);
+    if nbr.is_dis() && !nbr.lan_id.is_empty() && link.state.adj.get_mut(&level).is_none() {
+        // Register adjacency and create SRM/SSN entry in LSDB.
+        *link.state.adj.get_mut(&level) = Some((nbr.lan_id, None));
+        link.lsdb.get_mut(&level).adj_set(link.ifindex);
 
-            nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
-            nbr.event(Message::LspOriginate(level));
-        }
+        nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
+        nbr.event(Message::LspOriginate(level));
     }
 
     // When neighbor state has been changed.
@@ -330,18 +328,16 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
         }
 
         // Fall down from previous.
-        if state == NfsmState::Init {
-            if has_my_sys_id {
-                state = NfsmState::Up;
+        if state == NfsmState::Init && has_my_sys_id {
+            state = NfsmState::Up;
 
-                // Set adjacency.
-                *link.state.adj.get_mut(&level) =
-                    Some((IsisNeighborId::from_sys_id(&nbr.sys_id, 0), nbr.mac));
-                link.lsdb.get_mut(&level).adj_set(nbr.ifindex);
+            // Set adjacency.
+            *link.state.adj.get_mut(&level) =
+                Some((IsisNeighborId::from_sys_id(&nbr.sys_id, 0), nbr.mac));
+            link.lsdb.get_mut(&level).adj_set(nbr.ifindex);
 
-                nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
-                let _ = link.tx.send(Message::AdjacencyUp(level, nbr.ifindex));
-            }
+            nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
+            let _ = link.tx.send(Message::AdjacencyUp(level, nbr.ifindex));
         }
 
         // When neighbor state has been changed.
@@ -522,10 +518,8 @@ pub fn psnp_recv(link: &mut LinkTop, level: Level, pdu: IsisPsnp) {
     // 1 PSNP and this IS is not the level 1 designated IS for the circuit C, or
     // ii. this is a level 2 PSNP and this IS is not the level 2 designated IS
     // for the circuit C, then the IS shall discard the PDU.
-    if link.is_lan() {
-        if *link.state.dis_status.get(&level) != DisStatus::Myself {
-            return;
-        }
+    if link.is_lan() && *link.state.dis_status.get(&level) != DisStatus::Myself {
+        return;
     }
 
     // 7.3.15.2 Action on receipt of a PSNP.

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -83,17 +83,17 @@ fn show_isis_graph(
     let mut graphs = Vec::new();
 
     // Process Level 1 graph
-    if let Some(graph) = isis.graph.get(&Level::L1) {
-        if let Some(graph_json) = format_graph(graph, "L1") {
-            graphs.push(graph_json);
-        }
+    if let Some(graph) = isis.graph.get(&Level::L1)
+        && let Some(graph_json) = format_graph(graph, "L1")
+    {
+        graphs.push(graph_json);
     }
 
     // Process Level 2 graph
-    if let Some(graph) = isis.graph.get(&Level::L2) {
-        if let Some(graph_json) = format_graph(graph, "L2") {
-            graphs.push(graph_json);
-        }
+    if let Some(graph) = isis.graph.get(&Level::L2)
+        && let Some(graph_json) = format_graph(graph, "L2")
+    {
+        graphs.push(graph_json);
     }
 
     if json {

--- a/zebra-rs/src/ospf/flood.rs
+++ b/zebra-rs/src/ospf/flood.rs
@@ -51,17 +51,18 @@ pub fn ospf_ls_request_lookup(nbr: &Neighbor, h: &OspfLsaHeader) -> Option<usize
 // Following the ref/ospfd/ospf_flood.c ospf_flood_through_interface() pattern.
 pub fn ospf_flood_through_interface(_oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) {
     // For neighbors in Exchange or Loading state, check ls_req list.
-    if nbr.state >= NfsmState::Exchange && nbr.state < NfsmState::Full {
-        if let Some(idx) = ospf_ls_request_lookup(nbr, &lsa.h) {
-            // The received LSA is the same or newer than what we requested.
-            // Remove it from ls_req list.
-            nbr.ls_req.remove(idx);
-            tracing::info!(
-                "[Flood] Removed LSA {} from ls_req (remaining: {})",
-                lsa.h.ls_id,
-                nbr.ls_req.len()
-            );
-        }
+    if nbr.state >= NfsmState::Exchange
+        && nbr.state < NfsmState::Full
+        && let Some(idx) = ospf_ls_request_lookup(nbr, &lsa.h)
+    {
+        // The received LSA is the same or newer than what we requested.
+        // Remove it from ls_req list.
+        nbr.ls_req.remove(idx);
+        tracing::info!(
+            "[Flood] Removed LSA {} from ls_req (remaining: {})",
+            lsa.h.ls_id,
+            nbr.ls_req.len()
+        );
     }
 }
 
@@ -107,16 +108,15 @@ pub fn ospf_flood(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) {
     // MinLSArrival check: if the same LSA was installed less than 1 second ago, discard.
     if let Some(install_time) =
         lsdb.lookup_install_time(lsa.h.ls_type, lsa.h.ls_id, lsa.h.adv_router)
+        && install_time.elapsed() < Duration::from_secs(OSPF_MIN_LS_ARRIVAL)
     {
-        if install_time.elapsed() < Duration::from_secs(OSPF_MIN_LS_ARRIVAL) {
-            tracing::info!(
-                "[Flood] MinLSArrival: discarding LSA type={:?} id={} adv={}",
-                lsa.h.ls_type,
-                lsa.h.ls_id,
-                lsa.h.adv_router
-            );
-            return;
-        }
+        tracing::info!(
+            "[Flood] MinLSArrival: discarding LSA type={:?} id={} adv={}",
+            lsa.h.ls_type,
+            lsa.h.ls_id,
+            lsa.h.adv_router
+        );
+        return;
     }
 
     // RFC 2328: Install into LSDB first, then flood.

--- a/zebra-rs/src/ospf/ifsm.rs
+++ b/zebra-rs/src/ospf/ifsm.rs
@@ -253,12 +253,10 @@ pub fn ospf_dr_election_bdr(oi: &mut OspfLink, v: Vec<Identity>) -> Option<Ident
 
 fn ospf_dr_election_dr_change(oi: &mut OspfLink) {
     for (addr, nbr) in oi.nbrs.iter() {
-        if !nbr.ident.router_id.is_unspecified() {
-            if nbr.state >= NfsmState::TwoWay {
-                oi.tx
-                    .send(Message::Nfsm(oi.index, *addr, NfsmEvent::AdjOk))
-                    .unwrap();
-            }
+        if !nbr.ident.router_id.is_unspecified() && nbr.state >= NfsmState::TwoWay {
+            oi.tx
+                .send(Message::Nfsm(oi.index, *addr, NfsmEvent::AdjOk))
+                .unwrap();
         }
     }
 }
@@ -284,10 +282,8 @@ fn ospf_dr_election(oi: &mut OspfLink) -> Option<IfsmState> {
         let bdr = ospf_dr_election_bdr(oi, v.clone());
         let dr = ospf_dr_election_dr(oi, bdr, v);
 
-        if !oi.ident.d_router.is_unspecified() {
-            if bdr == dr {
-                oi.ident.bd_router = Ipv4Addr::UNSPECIFIED;
-            }
+        if !oi.ident.d_router.is_unspecified() && bdr == dr {
+            oi.ident.bd_router = Ipv4Addr::UNSPECIFIED;
         }
         new_state = ospf_ifsm_state(oi);
     }
@@ -377,10 +373,10 @@ pub fn ospf_ifsm(oi: &mut OspfLink, event: IfsmEvent) {
     let next_state = fsm_func(oi).or(fsm_next_state);
 
     // If a state transition occurs, update the state.
-    if let Some(new_state) = next_state {
-        if new_state != oi.state {
-            ospf_ifsm_change_state(oi, new_state);
-        }
+    if let Some(new_state) = next_state
+        && new_state != oi.state
+    {
+        ospf_ifsm_change_state(oi, new_state);
     }
     ospf_ifsm_timer_set(oi);
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -337,16 +337,15 @@ impl Ospf {
             let mut lsa = super::srmpls::router_info_lsa_build(self.router_id);
 
             // Preserve sequence number if re-originating.
-            if let Some(area) = self.areas.get(AREA0) {
-                if let Some(existing) =
+            if let Some(area) = self.areas.get(AREA0)
+                && let Some(existing) =
                     area.lsdb
                         .lookup_by_id(OspfLsType::OpaqueAreaLocal, ls_id, self.router_id)
-                {
-                    lsa.h.ls_seq_number = lsa
-                        .h
-                        .ls_seq_number
-                        .max(existing.h.ls_seq_number.saturating_add(1));
-                }
+            {
+                lsa.h.ls_seq_number = lsa
+                    .h
+                    .ls_seq_number
+                    .max(existing.h.ls_seq_number.saturating_add(1));
             }
             lsa.update();
 
@@ -397,16 +396,15 @@ impl Ospf {
                 super::srmpls::ext_prefix_lsa_build(self.router_id, prefix, &prefix_sid, opaque_id);
 
             // Preserve sequence number if re-originating.
-            if let Some(area) = self.areas.get(AREA0) {
-                if let Some(existing) =
+            if let Some(area) = self.areas.get(AREA0)
+                && let Some(existing) =
                     area.lsdb
                         .lookup_by_id(OspfLsType::OpaqueAreaLocal, ls_id, self.router_id)
-                {
-                    lsa.h.ls_seq_number = lsa
-                        .h
-                        .ls_seq_number
-                        .max(existing.h.ls_seq_number.saturating_add(1));
-                }
+            {
+                lsa.h.ls_seq_number = lsa
+                    .h
+                    .ls_seq_number
+                    .max(existing.h.ls_seq_number.saturating_add(1));
             }
             lsa.update();
 
@@ -466,10 +464,10 @@ impl Ospf {
                 lsdb.lookup_by_id(ls_type, ls_id, adv_router).cloned()
             };
             // Flood the refreshed LSA to all Full neighbors in the area.
-            if let Some(lsa) = refreshed {
-                if let Some(area_id) = area_id {
-                    self.flood_self_originated_lsa(area_id, &lsa);
-                }
+            if let Some(lsa) = refreshed
+                && let Some(area_id) = area_id
+            {
+                self.flood_self_originated_lsa(area_id, &lsa);
             }
             return;
         }
@@ -499,12 +497,10 @@ impl Ospf {
 
         if ev == LsdbEvent::HoldTimerExpire
             && (ls_type == OspfLsType::Router || ls_type == OspfLsType::Network)
+            && let Some(area_id) = area_id
+            && let Some(area) = self.areas.get_mut(area_id)
         {
-            if let Some(area_id) = area_id {
-                if let Some(area) = self.areas.get_mut(area_id) {
-                    Self::ospf_spf_schedule(&self.tx, area);
-                }
-            }
+            Self::ospf_spf_schedule(&self.tx, area);
         }
     }
 
@@ -607,10 +603,10 @@ impl Ospf {
                     };
                     lsdb.flush_lsa(ls_type, ls_id, adv_router, &self.tx, area_id)
                 };
-                if let Some(lsa) = flushed {
-                    if let Some(area_id) = area_id {
-                        self.flood_self_originated_lsa(area_id, &lsa);
-                    }
+                if let Some(lsa) = flushed
+                    && let Some(area_id) = area_id
+                {
+                    self.flood_self_originated_lsa(area_id, &lsa);
                 }
             }
         }
@@ -799,13 +795,14 @@ impl Ospf {
 
             // RFC 2328 Section 13.3 Step 4: For broadcast/NBMA interfaces in
             // state DROther, only flood if we received from DR or BDR.
-            if is_source_iface && link_state == IfsmState::DROther {
-                if let Some((_, src_addr)) = source {
-                    let dr = link.ident.d_router;
-                    let bdr = link.ident.bd_router;
-                    if src_addr != dr && src_addr != bdr {
-                        continue;
-                    }
+            if is_source_iface
+                && link_state == IfsmState::DROther
+                && let Some((_, src_addr)) = source
+            {
+                let dr = link.ident.d_router;
+                let bdr = link.ident.bd_router;
+                if src_addr != dr && src_addr != bdr {
+                    continue;
                 }
             }
 
@@ -816,18 +813,20 @@ impl Ospf {
                 }
 
                 // RFC 2328 Section 13.3 Step 1(c): Skip the source neighbor.
-                if let Some((src_ifindex, src_addr)) = source {
-                    if nbr.ifindex == src_ifindex && nbr.ident.prefix.addr() == src_addr {
-                        continue;
-                    }
+                if let Some((src_ifindex, src_addr)) = source
+                    && nbr.ifindex == src_ifindex
+                    && nbr.ident.prefix.addr() == src_addr
+                {
+                    continue;
                 }
 
                 // RFC 2328 Section 13.3 Step 1(b): For neighbors in
                 // Exchange or Loading state, remove from ls_req if present.
-                if nbr.state >= NfsmState::Exchange && nbr.state < NfsmState::Full {
-                    if let Some(idx) = super::ospf_ls_request_lookup(nbr, &lsa.h) {
-                        nbr.ls_req.remove(idx);
-                    }
+                if nbr.state >= NfsmState::Exchange
+                    && nbr.state < NfsmState::Full
+                    && let Some(idx) = super::ospf_ls_request_lookup(nbr, &lsa.h)
+                {
+                    nbr.ls_req.remove(idx);
                 }
 
                 // RFC 2328 Section 13.3 Step 1(d): Add LSA to retransmit list.
@@ -1449,20 +1448,20 @@ fn build_rib_from_spf(
         let mut spf_nhops = BTreeMap::new();
         for p in &nhops.nexthops {
             // p.is_empty() means myself
-            if !p.is_empty() {
-                if let Some(nhop_id) = top.lsp_map.resolve(p[0]) {
-                    // Find nhop from links
-                    for (ifindex, link) in top.links.iter() {
-                        for (_, nbr) in link.nbrs.iter() {
-                            if *nhop_id == nbr.ident.router_id {
-                                let addr = nbr.ident.prefix.addr();
-                                let nhop = SpfNexthop {
-                                    ifindex: *ifindex,
-                                    adjacency: p[0] == *node,
-                                    router_id: Some(*nhop_id),
-                                };
-                                spf_nhops.insert(addr, nhop);
-                            }
+            if !p.is_empty()
+                && let Some(nhop_id) = top.lsp_map.resolve(p[0])
+            {
+                // Find nhop from links
+                for (ifindex, link) in top.links.iter() {
+                    for (_, nbr) in link.nbrs.iter() {
+                        if *nhop_id == nbr.ident.router_id {
+                            let addr = nbr.ident.prefix.addr();
+                            let nhop = SpfNexthop {
+                                ifindex: *ifindex,
+                                adjacency: p[0] == *node,
+                                router_id: Some(*nhop_id),
+                            };
+                            spf_nhops.insert(addr, nhop);
                         }
                     }
                 }
@@ -1473,53 +1472,52 @@ fn build_rib_from_spf(
         if let Some(lsa) = area
             .lsdb
             .lookup_by_id(OspfLsType::Router, *router_id, *router_id)
+            && let OspfLsp::Router(ref router_lsa) = lsa.lsp
         {
-            if let OspfLsp::Router(ref router_lsa) = lsa.lsp {
-                for link in &router_lsa.links {
-                    match link.link_type {
-                        OspfLinkType::Transit => {
-                            // Transit Network: look up Network-LSA to get the
-                            // network prefix (link_id = dr's interface ip).
-                            for ((_ls_id, _adv), nlsa) in area.lsdb.tables.network.iter() {
-                                if let OspfLsp::Network(ref net) = nlsa.data.lsp {
-                                    if nlsa.data.h.ls_id == link.link_id {
-                                        let mask = u32::from(net.netmask).leading_ones() as u8;
-                                        if let Ok(prefix) = Ipv4Net::new(link.link_id, mask) {
-                                            let prefix = prefix.trunc();
+            for link in &router_lsa.links {
+                match link.link_type {
+                    OspfLinkType::Transit => {
+                        // Transit Network: look up Network-LSA to get the
+                        // network prefix (link_id = dr's interface ip).
+                        for ((_ls_id, _adv), nlsa) in area.lsdb.tables.network.iter() {
+                            if let OspfLsp::Network(ref net) = nlsa.data.lsp
+                                && nlsa.data.h.ls_id == link.link_id
+                            {
+                                let mask = u32::from(net.netmask).leading_ones() as u8;
+                                if let Ok(prefix) = Ipv4Net::new(link.link_id, mask) {
+                                    let prefix = prefix.trunc();
 
-                                            // sid?
-                                            // prefix_sid?
+                                    // sid?
+                                    // prefix_sid?
 
-                                            let spf_route = SpfRoute {
-                                                metric: nhops.cost,
-                                                nhops: spf_nhops.clone(),
-                                                sid: None,
-                                                prefix_sid: None,
-                                            };
-                                            rib_insert(&mut rib, prefix, spf_route);
-                                        }
-                                        break;
-                                    }
+                                    let spf_route = SpfRoute {
+                                        metric: nhops.cost,
+                                        nhops: spf_nhops.clone(),
+                                        sid: None,
+                                        prefix_sid: None,
+                                    };
+                                    rib_insert(&mut rib, prefix, spf_route);
                                 }
+                                break;
                             }
                         }
-                        OspfLinkType::Stub => {
-                            // Stub Network: link_id = network addr,
-                            // link_data = netmask.
-                            let mask = u32::from(link.link_data).leading_ones() as u8;
-                            if let Ok(prefix) = Ipv4Net::new(link.link_id, mask) {
-                                let prefix = prefix.trunc();
-                                let spf_route = SpfRoute {
-                                    metric: nhops.cost,
-                                    nhops: spf_nhops.clone(),
-                                    sid: None,
-                                    prefix_sid: None,
-                                };
-                                rib_insert(&mut rib, prefix, spf_route);
-                            }
-                        }
-                        _ => {}
                     }
+                    OspfLinkType::Stub => {
+                        // Stub Network: link_id = network addr,
+                        // link_data = netmask.
+                        let mask = u32::from(link.link_data).leading_ones() as u8;
+                        if let Ok(prefix) = Ipv4Net::new(link.link_id, mask) {
+                            let prefix = prefix.trunc();
+                            let spf_route = SpfRoute {
+                                metric: nhops.cost,
+                                nhops: spf_nhops.clone(),
+                                sid: None,
+                                prefix_sid: None,
+                            };
+                            rib_insert(&mut rib, prefix, spf_route);
+                        }
+                    }
+                    _ => {}
                 }
             }
         }

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -603,16 +603,14 @@ fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -
 
     // Step 4 special case: MaxAge LSA not in database.
     // If no neighbors in the area are in Exchange or Loading, ack and discard.
-    if lsa.h.ls_age >= OSPF_MAX_AGE && current.is_none() {
-        if oi.exchange_loading_count == 0 {
-            tracing::info!(
-                "[LS Update] MaxAge not in DB, no Exchange/Loading neighbors: type={:?} id={} adv={}",
-                lsa.h.ls_type,
-                lsa.h.ls_id,
-                lsa.h.adv_router
-            );
-            return LsaProcessResult::AckAndDiscard;
-        }
+    if lsa.h.ls_age >= OSPF_MAX_AGE && current.is_none() && oi.exchange_loading_count == 0 {
+        tracing::info!(
+            "[LS Update] MaxAge not in DB, no Exchange/Loading neighbors: type={:?} id={} adv={}",
+            lsa.h.ls_type,
+            lsa.h.ls_id,
+            lsa.h.adv_router
+        );
+        return LsaProcessResult::AckAndDiscard;
     }
 
     // Step 5: Received LSA is newer (or no current copy exists).
@@ -781,12 +779,11 @@ pub fn ospf_ls_ack_recv(
     // Remove acknowledged LSAs from retransmit list.
     for lsah in ls_ack.lsa_headers.iter() {
         let key = (lsah.ls_type, lsah.ls_id, lsah.adv_router);
-        if let Some(rxmt_lsa) = nbr.ls_rxmt.get(&key) {
-            if rxmt_lsa.h.ls_seq_number == lsah.ls_seq_number
-                && rxmt_lsa.h.ls_checksum == lsah.ls_checksum
-            {
-                nbr.ls_rxmt.remove(&key);
-            }
+        if let Some(rxmt_lsa) = nbr.ls_rxmt.get(&key)
+            && rxmt_lsa.h.ls_seq_number == lsah.ls_seq_number
+            && rxmt_lsa.h.ls_checksum == lsah.ls_checksum
+        {
+            nbr.ls_rxmt.remove(&key);
         }
     }
     if nbr.ls_rxmt.is_empty() {

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -311,20 +311,18 @@ fn render_link(out: &mut String, oi: &OspfLink, ospf: &Ospf) {
     }
 
     // Line 9: Network-LSA sequence number (only when DR).
-    if oi.state == IfsmState::DR {
-        if let Some(area) = ospf.areas.get(oi.area_id) {
-            if let Some(lsa) =
-                area.lsdb
-                    .lookup_lsa(OspfLsType::Network, oi.ident.prefix.addr(), ospf.router_id)
-            {
-                writeln!(
-                    out,
-                    "  Saved Network-LSA sequence number 0x{:08x}",
-                    lsa.data.h.ls_seq_number
-                )
-                .unwrap();
-            }
-        }
+    if oi.state == IfsmState::DR
+        && let Some(area) = ospf.areas.get(oi.area_id)
+        && let Some(lsa) =
+            area.lsdb
+                .lookup_lsa(OspfLsType::Network, oi.ident.prefix.addr(), ospf.router_id)
+    {
+        writeln!(
+            out,
+            "  Saved Network-LSA sequence number 0x{:08x}",
+            lsa.data.h.ls_seq_number
+        )
+        .unwrap();
     }
 
     // Line 10: Multicast group memberships.
@@ -1589,10 +1587,10 @@ fn show_ospf_segment_routing(
                 .opaque_area
                 .values()
                 .find_map(|lsa| {
-                    if lsa.data.h.adv_router == *router_id {
-                        if let OspfLsp::OpaqueAreaRouterInfo(ref ri) = lsa.data.lsp {
-                            return Some(format_algo_list(ri));
-                        }
+                    if lsa.data.h.adv_router == *router_id
+                        && let OspfLsp::OpaqueAreaRouterInfo(ref ri) = lsa.data.lsp
+                    {
+                        return Some(format_algo_list(ri));
                     }
                     None
                 })

--- a/zebra-rs/src/policy/community/parser.rs
+++ b/zebra-rs/src/policy/community/parser.rs
@@ -184,12 +184,12 @@ impl FromStr for CommunityMatcher {
 
         if let Some(value_str) = input.strip_prefix("soo:") {
             // Try to parse as exact site of origin (e.g., "soo:100:200")
-            if let Ok(ext_com) = ExtCommunity::from_str(input) {
-                if let Some(first) = ext_com.0.first() {
-                    return Ok(CommunityMatcher::Extended(ExtendedMatcher::Exact(
-                        first.clone(),
-                    )));
-                }
+            if let Ok(ext_com) = ExtCommunity::from_str(input)
+                && let Some(first) = ext_com.0.first()
+            {
+                return Ok(CommunityMatcher::Extended(ExtendedMatcher::Exact(
+                    first.clone(),
+                )));
             }
 
             // If exact parse failed, treat as regex pattern
@@ -295,10 +295,10 @@ pub fn match_community_set(matcher: &CommunityMatcher, bgp_attr: &BgpAttr) -> bo
                             let ext_com_str = ext_com_val.to_string();
                             // Remove the prefix (e.g., "rt:" or "soo:") before matching
                             // The to_string() produces "rt:100:200", but pattern is "^100:.*"
-                            if let Some(value_part) = ext_com_str.split_once(':') {
-                                if compiled.is_match(value_part.1) {
-                                    return true;
-                                }
+                            if let Some(value_part) = ext_com_str.split_once(':')
+                                && compiled.is_match(value_part.1)
+                            {
+                                return true;
                             }
                         }
                     }

--- a/zebra-rs/src/policy/inst.rs
+++ b/zebra-rs/src/policy/inst.rs
@@ -219,16 +219,16 @@ impl Policy {
                         self.watch_prefix.entry(name).or_default().push(watch);
                     }
                     PolicyType::PolicyListIn | PolicyType::PolicyListOut => {
-                        if let Some(policy_list) = self.policy_config.config.get(&name) {
-                            if let Some(tx) = self.clients.get(&proto) {
-                                let msg = PolicyRx::PolicyList {
-                                    name: name.clone(),
-                                    ident,
-                                    policy_type,
-                                    policy_list: Some(policy_list.clone()),
-                                };
-                                let _ = tx.send(msg);
-                            }
+                        if let Some(policy_list) = self.policy_config.config.get(&name)
+                            && let Some(tx) = self.clients.get(&proto)
+                        {
+                            let msg = PolicyRx::PolicyList {
+                                name: name.clone(),
+                                ident,
+                                policy_type,
+                                policy_list: Some(policy_list.clone()),
+                            };
+                            let _ = tx.send(msg);
                         }
                         let watch = PolicyWatch {
                             proto,

--- a/zebra-rs/src/policy/prefix/set.rs
+++ b/zebra-rs/src/policy/prefix/set.rs
@@ -36,24 +36,24 @@ impl PrefixSet {
                 let mut matches = true;
 
                 // Check less-than-or-equal constraint
-                if let Some(le) = entry.le {
-                    if prefix_len > le {
-                        matches = false;
-                    }
+                if let Some(le) = entry.le
+                    && prefix_len > le
+                {
+                    matches = false;
                 }
 
                 // Check equal constraint
-                if let Some(eq) = entry.eq {
-                    if prefix_len != eq {
-                        matches = false;
-                    }
+                if let Some(eq) = entry.eq
+                    && prefix_len != eq
+                {
+                    matches = false;
                 }
 
                 // Check greater-than-or-equal constraint
-                if let Some(ge) = entry.ge {
-                    if prefix_len < ge {
-                        matches = false;
-                    }
+                if let Some(ge) = entry.ge
+                    && prefix_len < ge
+                {
+                    matches = false;
                 }
 
                 if matches {

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -436,10 +436,10 @@ impl Rib {
         esi: Option<[u8; 10]>,
     ) {
         // MAC Mobility: ignore stale duplicates (lower sequence number)
-        if let Some(existing) = self.mac_table.get(&(vni, mac)) {
-            if seq < existing.seq {
-                return; // Ignore stale duplicate
-            }
+        if let Some(existing) = self.mac_table.get(&(vni, mac))
+            && seq < existing.seq
+        {
+            return; // Ignore stale duplicate
         }
 
         let entry = MacEntry {

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -442,10 +442,10 @@ impl Rib {
             self.links.insert(link.index, link.clone());
 
             // Register VXLAN interface with FIB for MAC FDB operations
-            if let Some(vxlan) = self.vxlan.get(&link.name) {
-                if let Some(vni) = vxlan.vni {
-                    self.fib_handle.register_vxlan_ifindex(vni, link.index);
-                }
+            if let Some(vxlan) = self.vxlan.get(&link.name)
+                && let Some(vni) = vxlan.vni
+            {
+                self.fib_handle.register_vxlan_ifindex(vni, link.index);
             }
 
             if !link.is_up() {
@@ -456,10 +456,10 @@ impl Rib {
 
     pub fn link_delete(&mut self, oslink: FibLink) {
         // Unregister VXLAN interface from FIB if applicable
-        if let Some(vxlan) = self.vxlan.get(&oslink.name) {
-            if let Some(vni) = vxlan.vni {
-                self.fib_handle.unregister_vxlan_ifindex(vni);
-            }
+        if let Some(vxlan) = self.vxlan.get(&oslink.name)
+            && let Some(vni) = vxlan.vni
+        {
+            self.fib_handle.unregister_vxlan_ifindex(vni);
         }
         self.links.remove(&oslink.index);
     }
@@ -502,11 +502,11 @@ impl Rib {
         }
 
         // Validate against 0.0.0.0 address for IPv4 - prevents unspecified address on interfaces
-        if let ipnet::IpNet::V4(v4_net) = osaddr.addr {
-            if v4_net.addr().is_unspecified() {
-                println!("FIB: cannot add 0.0.0.0 as interface address");
-                return;
-            }
+        if let ipnet::IpNet::V4(v4_net) = osaddr.addr
+            && v4_net.addr().is_unspecified()
+        {
+            println!("FIB: cannot add 0.0.0.0 as interface address");
+            return;
         }
 
         let mut addr = LinkAddr::from(osaddr);
@@ -657,14 +657,14 @@ pub async fn link_config_exec(
                 if let Some(link) = rib.links.get(&ifindex) {
                     // Check if this IPv4 address already exists on the interface
                     for existing_addr in &link.addr4 {
-                        if let IpNet::V4(existing_v4) = existing_addr.addr {
-                            if existing_v4 == v4addr {
-                                // println!(
-                                //     "IPv4 address {} is already configured on interface {}",
-                                //     v4addr, ifname
-                                // );
-                                return Ok(());
-                            }
+                        if let IpNet::V4(existing_v4) = existing_addr.addr
+                            && existing_v4 == v4addr
+                        {
+                            // println!(
+                            //     "IPv4 address {} is already configured on interface {}",
+                            //     v4addr, ifname
+                            // );
+                            return Ok(());
                         }
                     }
                 }
@@ -722,15 +722,13 @@ pub async fn link_config_exec(
             }
 
             // Validate against loopback address on non-loopback interfaces
-            if v6addr.addr().is_loopback() {
-                if let Some(ifindex) = link_lookup(rib, ifname.to_string()) {
-                    if let Some(link) = rib.links.get(&ifindex) {
-                        if !link.is_loopback() {
-                            println!("Cannot configure loopback address on non-loopback interface");
-                            return Ok(());
-                        }
-                    }
-                }
+            if v6addr.addr().is_loopback()
+                && let Some(ifindex) = link_lookup(rib, ifname.to_string())
+                && let Some(link) = rib.links.get(&ifindex)
+                && !link.is_loopback()
+            {
+                println!("Cannot configure loopback address on non-loopback interface");
+                return Ok(());
             }
 
             // Check if IPv6 address is already configured on the link
@@ -738,14 +736,14 @@ pub async fn link_config_exec(
                 if let Some(link) = rib.links.get(&ifindex) {
                     // Check if this IPv6 address already exists on the interface
                     for existing_addr in &link.addr6 {
-                        if let IpNet::V6(existing_v6) = existing_addr.addr {
-                            if existing_v6 == v6addr {
-                                // println!(
-                                //     "IPv6 address {} is already configured on interface {}",
-                                //     v6addr, ifname
-                                // );
-                                return Ok(());
-                            }
+                        if let IpNet::V6(existing_v6) = existing_addr.addr
+                            && existing_v6 == v6addr
+                        {
+                            // println!(
+                            //     "IPv6 address {} is already configured on interface {}",
+                            //     v6addr, ifname
+                            // );
+                            return Ok(());
                         }
                     }
                 }

--- a/zebra-rs/src/rib/nexthop/map.rs
+++ b/zebra-rs/src/rib/nexthop/map.rs
@@ -139,26 +139,26 @@ impl NexthopMap {
     pub async fn shutdown(&mut self, fib: &FibHandle) {
         for (_, id) in self.set.iter() {
             let entry = self.get(*id);
-            if let Some(grp) = entry {
-                if grp.is_installed() {
-                    fib.nexthop_del(grp).await;
-                }
+            if let Some(grp) = entry
+                && grp.is_installed()
+            {
+                fib.nexthop_del(grp).await;
             }
         }
         for (_, id) in self.map.iter() {
             let entry = self.get(*id);
-            if let Some(grp) = entry {
-                if grp.is_installed() {
-                    fib.nexthop_del(grp).await;
-                }
+            if let Some(grp) = entry
+                && grp.is_installed()
+            {
+                fib.nexthop_del(grp).await;
             }
         }
         for (_, id) in self.mpls.iter() {
             let entry = self.get(*id);
-            if let Some(grp) = entry {
-                if grp.is_installed() {
-                    fib.nexthop_del(grp).await;
-                }
+            if let Some(grp) = entry
+                && grp.is_installed()
+            {
+                fib.nexthop_del(grp).await;
             }
         }
     }

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -456,10 +456,10 @@ pub async fn ipv4_nexthop_sync(
         if let Some(Group::Multi(multi)) = nhop {
             let mut set = BTreeSet::<(usize, u8)>::new();
             for (m, v) in multi.set.iter() {
-                if let Some(Some(group)) = nmap.groups.get(*m) {
-                    if group.is_valid() {
-                        set.insert((*m, *v));
-                    }
+                if let Some(Some(group)) = nmap.groups.get(*m)
+                    && group.is_valid()
+                {
+                    set.insert((*m, *v));
                 }
             }
             multi_cache.insert(idx, set);
@@ -522,13 +522,13 @@ async fn ipv4_entry_selection(
     fib: &FibHandle,
     ifdown: bool,
 ) {
-    if let Some(mut replace) = replace {
-        if replace.is_protocol() {
-            if replace.is_fib() {
-                fib.route_ipv4_del(prefix, &replace).await;
-            }
-            replace.nexthop_unsync(nmap, fib).await;
+    if let Some(mut replace) = replace
+        && replace.is_protocol()
+    {
+        if replace.is_fib() {
+            fib.route_ipv4_del(prefix, &replace).await;
         }
+        replace.nexthop_unsync(nmap, fib).await;
     }
     // Selected.
     let prev = rib_prev(entries);
@@ -868,13 +868,13 @@ async fn ipv6_entry_selection(
         }
     }
 
-    if let Some(mut replace) = replace {
-        if replace.is_protocol() {
-            if replace.is_fib() {
-                fib.route_ipv6_del(prefix, &replace).await;
-            }
-            replace.nexthop_unsync(nmap, fib).await;
+    if let Some(mut replace) = replace
+        && replace.is_protocol()
+    {
+        if replace.is_fib() {
+            fib.route_ipv6_del(prefix, &replace).await;
         }
+        replace.nexthop_unsync(nmap, fib).await;
     }
 
     // Link-local prefixes (fe80::/10) are link-scoped: every interface

--- a/zebra-rs/src/rib/router_id.rs
+++ b/zebra-rs/src/rib/router_id.rs
@@ -26,11 +26,11 @@ fn router_id(links: &BTreeMap<u32, Link>) -> Option<Ipv4Addr> {
 
 impl Rib {
     pub fn router_id_update(&mut self) {
-        if let Some(router_id) = router_id(&self.links) {
-            if self.router_id != router_id {
-                self.router_id = router_id;
-                self.api_router_id_update(router_id);
-            }
+        if let Some(router_id) = router_id(&self.links)
+            && self.router_id != router_id
+        {
+            self.router_id = router_id;
+            self.api_router_id_update(router_id);
         }
     }
 }

--- a/zebra-rs/src/spf/calc.rs
+++ b/zebra-rs/src/spf/calc.rs
@@ -348,10 +348,10 @@ pub fn make_repair_list(pc_inter: &[Intersect], s: usize, d: usize) -> Vec<SrSeg
                 }
                 p_mode = false;
             }
-        } else if let Some(prev_id) = prev_id {
-            if !q_mode {
-                sr_segments.push(SrSegment::AdjSid(prev_id, inter.id));
-            }
+        } else if let Some(prev_id) = prev_id
+            && !q_mode
+        {
+            sr_segments.push(SrSegment::AdjSid(prev_id, inter.id));
         }
 
         if inter.q {
@@ -360,10 +360,8 @@ pub fn make_repair_list(pc_inter: &[Intersect], s: usize, d: usize) -> Vec<SrSeg
         prev_id = Some(inter.id);
     }
 
-    if !q_mode {
-        if let Some(prev_id) = prev_id {
-            sr_segments.push(SrSegment::AdjSid(prev_id, d));
-        }
+    if !q_mode && let Some(prev_id) = prev_id {
+        sr_segments.push(SrSegment::AdjSid(prev_id, d));
     }
 
     sr_segments


### PR DESCRIPTION
## Summary

Re-enable `clippy::collapsible_if` and apply `cargo clippy --fix` across the workspace. The autofixer collapsed all 103 nested-if sites into either combined `&&` conditions or, for the `if let Some(...) = expr { if cond { ... } }` pattern, into Rust 2024 let-chains:

```rust
if let Some(x) = expr
    && x.condition()
{
    body
}
```

`rustfmt` then re-aligned the indentation. Net change: 562 insertions, 597 deletions across 31 files.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace --exclude bdd` — passing
- [x] `cargo fmt --all`

Generated with [Claude Code](https://claude.com/claude-code)