### PR TITLE
chore(clippy): drop clone_on_copy and needless_borrow allows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,6 @@ clap = { version = "4", features = ["derive"] }
 # and explicit-over-implicit choices in packet parsers). Other clippy
 # lints remain at their default level so genuine issues still surface.
 [workspace.lints.clippy]
-# Style — references and casts
-clone_on_copy = "allow"
-needless_borrow = "allow"
-
 # Style — APIs that get used a lot in protocol code
 get_first = "allow"
 ptr_arg = "allow"

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -865,7 +865,7 @@ pub fn peer_send_open(peer: &mut Peer) {
 
     for (afi_safi, _) in peer.config.mp.0.iter() {
         let cap = CapMultiProtocol::new(&afi_safi.afi, &afi_safi.safi);
-        bgp_cap.mp.insert(afi_safi.clone(), cap);
+        bgp_cap.mp.insert(*afi_safi, cap);
     }
     if peer.config.four_octet {
         let cap = CapAs4::new(peer.local_as);
@@ -879,16 +879,16 @@ pub fn peer_send_open(peer: &mut Peer) {
         bgp_cap.extended = Some(CapExtended::default());
     }
     for (key, addpath) in peer.config.addpath.iter() {
-        bgp_cap.addpath.insert(key.clone(), addpath.clone());
+        bgp_cap.addpath.insert(*key, addpath.clone());
     }
     for (key, sub) in peer.config.sub.iter() {
         if let Some(_restart_time) = sub.graceful_restart {
             let restart = RestartValue::new(1, key.afi, key.safi);
-            bgp_cap.restart.insert(key.clone(), restart);
+            bgp_cap.restart.insert(*key, restart);
         }
         if let Some(llgr_time) = sub.llgr {
             let llgr = LlgrValue::new(key.afi, key.safi, llgr_time);
-            bgp_cap.llgr.insert(key.clone(), llgr);
+            bgp_cap.llgr.insert(*key, llgr);
         }
     }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -502,10 +502,7 @@ impl LocalRib {
         rd: &RouteDistinguisher,
         prefix: Ipv4Net,
     ) -> Vec<BgpRib> {
-        self.v4vpn
-            .entry(rd.clone())
-            .or_default()
-            .select_best_path(prefix)
+        self.v4vpn.entry(*rd).or_default().select_best_path(prefix)
     }
 
     // EVPN dispatch ----------------------------------------------------------
@@ -636,7 +633,7 @@ pub fn route_ipv4_update(
         // prevents routing loops in route reflection scenarios when the route
         // has already passed through this route reflector.
         if let Some(ref cluster_list) = attr.cluster_list
-            && cluster_list.list.contains(&bgp.router_id)
+            && cluster_list.list.contains(bgp.router_id)
         {
             eprintln!(
                 "Dropping update for {} from peer {} - local router ID {} found in CLUSTER_LIST",
@@ -756,7 +753,7 @@ fn route_advertise_to_addpath(
             if let Some(ref rd) = rd {
                 let vpnv4_nlri = Vpnv4Nlri {
                     label: Label::default(),
-                    rd: rd.clone(),
+                    rd: *rd,
                     nlri,
                 };
                 peer.send_vpnv4(vpnv4_nlri, attr, true);
@@ -793,7 +790,7 @@ fn route_withdraw_from_addpath(
         let peer = peers.get_mut(&peer_addr).expect("peer exists");
 
         if let Some(ref rd) = rd {
-            peer.cache_remove_vpnv4(rd.clone(), prefix, removed.local_id);
+            peer.cache_remove_vpnv4(*rd, prefix, removed.local_id);
         } else {
             peer.cache_remove_ipv4(prefix, removed.local_id);
         }
@@ -872,7 +869,7 @@ fn route_advertise_to_peers(
                 if let Some(ref rd) = rd {
                     let vpnv4_nlri = Vpnv4Nlri {
                         label: Label::default(),
-                        rd: rd.clone(),
+                        rd: *rd,
                         nlri,
                     };
                     peer.send_vpnv4(vpnv4_nlri, attr, true);
@@ -883,7 +880,7 @@ fn route_advertise_to_peers(
             _ => {
                 // We remove the cache.
                 if let Some(ref rd) = rd {
-                    peer.cache_remove_vpnv4(rd.clone(), prefix, 0);
+                    peer.cache_remove_vpnv4(*rd, prefix, 0);
                 } else {
                     peer.cache_remove_ipv4(prefix, 0);
                 }
@@ -946,7 +943,7 @@ pub fn route_ipv4_withdraw(
         bgp.local_rib.select_best_path(nlri.prefix)
     };
     if !selected.is_empty() || !removed.is_empty() {
-        route_advertise_to_peers(rd.clone(), nlri.prefix, &selected, ident, bgp, peers);
+        route_advertise_to_peers(rd, nlri.prefix, &selected, ident, bgp, peers);
     }
     if let Some(removed) = removed.pop() {
         route_withdraw_from_addpath(rd, nlri.prefix, &removed, ident, bgp, peers);
@@ -1205,7 +1202,7 @@ pub fn route_evpn_update(
             return;
         }
         if let Some(ref cluster_list) = attr.cluster_list
-            && cluster_list.list.contains(&bgp.router_id)
+            && cluster_list.list.contains(bgp.router_id)
         {
             return;
         }
@@ -1300,7 +1297,7 @@ pub fn route_from_peer(
                     route_ipv4_update(
                         peer_id,
                         &update.nlri,
-                        Some(update.rd.clone()),
+                        Some(update.rd),
                         Some(update.label),
                         bgp_attr,
                         Some(nlri.nhop.clone()),
@@ -1336,7 +1333,7 @@ pub fn route_from_peer(
                     route_ipv4_withdraw(
                         peer_id,
                         &withdraw.nlri,
-                        Some(withdraw.rd.clone()),
+                        Some(withdraw.rd),
                         Some(withdraw.label),
                         bgp,
                         peers,
@@ -1390,7 +1387,7 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
         withdrawn
     };
     for withdraw in withdrawn.iter() {
-        route_ipv4_withdraw(peer_id, &withdraw, None, None, bgp, peers, true);
+        route_ipv4_withdraw(peer_id, withdraw, None, None, bgp, peers, true);
     }
     let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
     peer.adj_in.v4.0.clear();
@@ -1447,7 +1444,7 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
                             prefix: *prefix,
                         };
                         updates.push((
-                            rd.clone(),
+                            *rd,
                             nlri,
                             rib.label,
                             (*rib.attr).clone(),
@@ -1483,7 +1480,7 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
                     for rib in ribs.iter() {
                         let withdraw = Vpnv4Nlri {
                             label: rib.label.unwrap_or(Label::default()),
-                            rd: rd.clone(),
+                            rd: *rd,
                             nlri: Ipv4Nlri {
                                 id: rib.remote_id,
                                 prefix: *prefix,
@@ -1499,7 +1496,7 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
             route_ipv4_withdraw(
                 peer_id,
                 &withdraw.nlri,
-                Some(withdraw.rd.clone()),
+                Some(withdraw.rd),
                 Some(withdraw.label),
                 bgp,
                 peers,
@@ -1534,7 +1531,7 @@ pub fn stale_route_withdraw(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMa
                     if rib.stale {
                         let withdraw = Vpnv4Nlri {
                             label: rib.label.unwrap_or(Label::default()),
-                            rd: rd.clone(),
+                            rd: *rd,
                             nlri: Ipv4Nlri {
                                 id: rib.remote_id,
                                 prefix: *prefix,
@@ -1553,7 +1550,7 @@ pub fn stale_route_withdraw(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMa
         route_ipv4_withdraw(
             peer_id,
             &withdraw.nlri,
-            Some(withdraw.rd.clone()),
+            Some(withdraw.rd),
             Some(withdraw.label),
             bgp,
             peers,
@@ -1853,7 +1850,7 @@ pub fn route_sync_vpnv4(peer: &mut Peer, bgp: &mut BgpTop) {
                     .iter()
                     .flat_map(|(prefix, ribs)| ribs.iter().map(move |rib| (*prefix, rib.clone())))
                     .collect();
-                (rd.clone(), routes)
+                (*rd, routes)
             })
             .collect()
     } else {
@@ -1866,7 +1863,7 @@ pub fn route_sync_vpnv4(peer: &mut Peer, bgp: &mut BgpTop) {
                     .iter()
                     .map(|(prefix, rib)| (*prefix, rib.clone()))
                     .collect();
-                (rd.clone(), routes)
+                (*rd, routes)
             })
             .collect()
     };
@@ -1890,11 +1887,11 @@ pub fn route_sync_vpnv4(peer: &mut Peer, bgp: &mut BgpTop) {
             // Register to AdjOut.
             rib.attr = bgp.attr_store.intern(attr);
             let arc_attr = rib.attr.clone();
-            peer.adj_out.add(Some(rd.clone()), nlri.prefix, rib);
+            peer.adj_out.add(Some(rd), nlri.prefix, rib);
 
             let vpnv4_nlri = Vpnv4Nlri {
                 label: Label::default(),
-                rd: rd.clone(),
+                rd,
                 nlri,
             };
 

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -219,8 +219,7 @@ impl ConfigManager {
                 }
                 let paths = paths.unwrap();
                 for (_, tx) in self.cm_clients.borrow().iter() {
-                    tx.send(ConfigRequest::new(paths.clone(), op.clone()))
-                        .unwrap();
+                    tx.send(ConfigRequest::new(paths.clone(), op)).unwrap();
                 }
             }
         }

--- a/zebra-rs/src/isis/flood.rs
+++ b/zebra-rs/src/isis/flood.rs
@@ -101,14 +101,14 @@ impl Lsdb {
 
     pub fn ssn_clear(&mut self, lsp_id: &IsisLspId, ifindex: u32) {
         if let Some(flags) = self.adj.get_mut(&ifindex) {
-            flags.ssn.clear(&lsp_id);
+            flags.ssn.clear(lsp_id);
         }
     }
 
     pub fn ssn_clear_other(&mut self, lsp_id: &IsisLspId, ifindex: u32) {
         for (link, flags) in self.adj.iter_mut() {
             if *link != ifindex {
-                flags.ssn.clear(&lsp_id);
+                flags.ssn.clear(lsp_id);
             }
         }
     }
@@ -143,7 +143,7 @@ pub fn ssn_clear(top: &mut LinkTop, level: Level, lsp_id: &IsisLspId) {
 pub fn ssn_clear_other(top: &mut LinkTop, level: Level, lsp_id: &IsisLspId) {
     top.lsdb
         .get_mut(&level)
-        .ssn_clear_other(&lsp_id, top.ifindex);
+        .ssn_clear_other(lsp_id, top.ifindex);
 }
 
 pub fn srm_advertise(top: &mut LinkTop, level: Level, ifindex: u32) {

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -125,7 +125,7 @@ pub fn hello_p2p_generate(link: &LinkTop, level: Level) -> IsisP2pHello {
         IsisTlvP2p3Way {
             state: nbr.state.into(),
             circuit_id: link.ifindex,
-            neighbor_id: Some(nbr.sys_id.clone()),
+            neighbor_id: Some(nbr.sys_id),
             neighbor_circuit_id: nbr.circuit_id,
         }
     } else {
@@ -254,7 +254,7 @@ pub fn dis_dropping(link: &mut LinkTop, level: Level) {
     };
 
     // Create pseudonode LSP ID from the adjacency
-    let pseudonode_lsp_id = IsisLspId::from_neighbor_id(adj.clone(), 0);
+    let pseudonode_lsp_id = IsisLspId::from_neighbor_id(*adj, 0);
 
     // Send purge message to the main IS-IS instance
     link.tx
@@ -313,7 +313,7 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
     // Reset current status.
     let mut best_sys_id: Option<IsisSysId> = None;
     let mut best_priority = link.config.priority();
-    let mut best_mac = link.state.mac.clone();
+    let mut best_mac = link.state.mac;
 
     // We will check at least one Up state neighbor exists.
     let mut nbrs_up = 0;
@@ -331,8 +331,8 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
 
         if is_better(nbr, best_priority, &best_mac) {
             best_priority = nbr.priority;
-            best_mac = nbr.mac.clone();
-            best_sys_id = Some(sys_id.clone());
+            best_mac = nbr.mac;
+            best_sys_id = Some(*sys_id);
         }
         nbrs_up += 1;
     }
@@ -361,7 +361,7 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
             mac_str(&nbr.mac),
         );
         let lan_id = if !nbr.lan_id.is_empty() {
-            Some(nbr.lan_id.clone())
+            Some(nbr.lan_id)
         } else {
             None
         };
@@ -412,7 +412,7 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
                 if link.state.adj.get(&level).is_none()
                     && let Some(lan_id) = lan_id
                 {
-                    *link.state.adj.get_mut(&level) = Some((lan_id.clone(), None));
+                    *link.state.adj.get_mut(&level) = Some((lan_id, None));
                     link.lsdb.get_mut(&level).adj_set(link.ifindex);
                     link.event(Message::Ifsm(HelloOriginate, link.ifindex, Some(level)));
                 }

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -471,7 +471,7 @@ impl Isis {
 pub fn dis_generate(top: &mut IsisTop, level: Level, ifindex: u32, base: Option<u32>) -> IsisLsp {
     let neighbor_id = if let Some(link) = top.links.get(&ifindex) {
         if let Some((adj, _)) = link.state.adj.get(&level) {
-            adj.clone()
+            *adj
         } else {
             IsisNeighborId::default()
         }
@@ -519,7 +519,7 @@ pub fn dis_generate(top: &mut IsisTop, level: Level, ifindex: u32, base: Option<
     if let Some(link) = top.links.get(&ifindex) {
         for (sys_id, nbr) in link.state.nbrs.get(&level).iter() {
             if nbr.state == NfsmState::Up {
-                let neighbor_id = IsisNeighborId::from_sys_id(&sys_id, 0);
+                let neighbor_id = IsisNeighborId::from_sys_id(sys_id, 0);
                 let entry = IsisTlvExtIsReachEntry {
                     neighbor_id,
                     metric: 0,
@@ -568,7 +568,7 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
             "[LspOriginate] seq number reached maximum, purging LSP"
         );
         // TODO: After age out, we need to originate a new one with seq 1.
-        let _ = top.tx.send(Message::LspPurge(level, lsp_id.clone()));
+        let _ = top.tx.send(Message::LspPurge(level, lsp_id));
         return IsisLsp::default();
     }
 
@@ -685,7 +685,7 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
         // Ext IS Reach.
         let mut ext_is_reach = IsisTlvExtIsReach::default();
         let mut is_reach = IsisTlvExtIsReachEntry {
-            neighbor_id: adj.clone(),
+            neighbor_id: *adj,
             metric: link.config.metric(),
             subs: Vec::new(),
         };
@@ -704,7 +704,7 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
                         let sub = IsisSubLanAdjSid {
                             flags: AdjSidFlags::lan_adj_flag_ipv4(),
                             weight: 0,
-                            system_id: nbr.sys_id.clone(),
+                            system_id: nbr.sys_id,
                             sid: SidLabelValue::Label(label),
                         };
                         is_reach.subs.push(neigh::IsisSubTlv::LanAdjSid(sub));
@@ -768,7 +768,7 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
                     let entry = IsisTlvIpv6ReachEntry {
                         metric: 10,
                         flags,
-                        prefix: v6addr.clone(),
+                        prefix: *v6addr,
                         subs: Vec::new(),
                     };
                     ipv6_reach.entries.push(entry);
@@ -946,12 +946,12 @@ pub struct LspMap {
 
 impl LspMap {
     pub fn get(&mut self, sys_id: &IsisSysId) -> usize {
-        if let Some(index) = self.map.get(&sys_id) {
+        if let Some(index) = self.map.get(sys_id) {
             *index
         } else {
             let index = self.val.len();
-            self.map.insert(sys_id.clone(), index);
-            self.val.push(sys_id.clone());
+            self.map.insert(*sys_id, index);
+            self.val.push(*sys_id);
             index
         }
     }
@@ -974,7 +974,7 @@ pub fn graph(
     let mut nodes_to_process = Vec::new();
     for (_, lsa) in top.lsdb.get(&level).iter() {
         if !lsa.lsp.lsp_id.is_pseudo() {
-            let sys_id = lsa.lsp.lsp_id.sys_id().clone();
+            let sys_id = lsa.lsp.lsp_id.sys_id();
             let is_originated = lsa.originated;
             let lsp = lsa.lsp.clone();
             nodes_to_process.push((sys_id, is_originated, lsp));
@@ -1055,7 +1055,7 @@ fn process_neighbor_link(
     entry: &IsisTlvExtIsReachEntry,
     links: &mut Vec<spf::Link>,
 ) {
-    let neighbor_lsp_id: IsisLspId = entry.neighbor_id.clone().into();
+    let neighbor_lsp_id: IsisLspId = entry.neighbor_id.into();
 
     if let Some(neighbor_lsa) = top.lsdb.get(&level).get(&neighbor_lsp_id) {
         // Look up the neighbor's LSP
@@ -1104,7 +1104,7 @@ fn collect_adjacency_sids(lsp: &IsisLsp, sids: &mut BTreeMap<u32, IsisSysId>) {
                     if let neigh::IsisSubTlv::LanAdjSid(adj_sid) = sub
                         && let SidLabelValue::Label(label) = adj_sid.sid
                     {
-                        sids.insert(label, adj_sid.system_id.clone());
+                        sids.insert(label, adj_sid.system_id);
                     }
                 }
             }
@@ -1347,7 +1347,7 @@ fn build_adjacency_ilm(
                     let nhop = SpfNexthop {
                         ifindex: *ifindex,
                         adjacency: true,
-                        sys_id: Some(nhop_id.clone()),
+                        sys_id: Some(*nhop_id),
                     };
                     nhops.insert(*addr, nhop);
                 }
@@ -1401,7 +1401,7 @@ fn build_rib_from_spf(
                             let nhop = SpfNexthop {
                                 ifindex: *ifindex,
                                 adjacency: p[0] == *node,
-                                sys_id: Some(nhop_id.clone()),
+                                sys_id: Some(*nhop_id),
                             };
                             spf_nhops.insert(*addr, nhop);
                         }
@@ -1411,7 +1411,7 @@ fn build_rib_from_spf(
         }
 
         // Process reachability entries for this node.
-        if let Some(entries) = top.reach_map.get(&level).get(&Afi::Ip).get(&sys_id) {
+        if let Some(entries) = top.reach_map.get(&level).get(&Afi::Ip).get(sys_id) {
             for entry in entries.iter() {
                 let sid = if let Some(prefix_sid) = entry.prefix_sid() {
                     match prefix_sid.sid {
@@ -1419,7 +1419,7 @@ fn build_rib_from_spf(
                         SidLabelValue::Index(index) => top
                             .label_map
                             .get(&level)
-                            .get(&sys_id)
+                            .get(sys_id)
                             .map(|block| block.global.start + index),
                         SidLabelValue::Label(label) => Some(label),
                     }
@@ -1428,7 +1428,7 @@ fn build_rib_from_spf(
                 };
 
                 let prefix_sid = if let Some(prefix_sid) = entry.prefix_sid()
-                    && let Some(block) = top.label_map.get(&level).get(&sys_id)
+                    && let Some(block) = top.label_map.get(&level).get(sys_id)
                 {
                     Some((prefix_sid.sid.clone(), block.clone()))
                 } else {

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -72,7 +72,7 @@ pub struct IsisLinks {
 
 impl IsisLinks {
     pub fn get(&self, key: &u32) -> Option<&IsisLink> {
-        self.map.get(&key)
+        self.map.get(key)
     }
 
     pub fn get_mut(&mut self, key: &u32) -> Option<&mut IsisLink> {

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -213,7 +213,7 @@ fn update_lsp(top: &mut LinkTop, level: Level, key: IsisLspId, lsp: &IsisLsp) {
 }
 
 pub fn insert_lsp(top: &mut LinkTop, level: Level, lsp: IsisLsp, bytes: Vec<u8>) -> Option<Lsa> {
-    let key = lsp.lsp_id.clone();
+    let key = lsp.lsp_id;
 
     if top.up_config.net.sys_id() == key.sys_id() {
         isis_database_trace!(top.tracing, Lsdb, &level, "Self originated LSP?");
@@ -255,7 +255,7 @@ pub fn insert_self_originate(
     lsp: IsisLsp,
     bytes: Option<Vec<u8>>,
 ) -> Option<Lsa> {
-    let key = lsp.lsp_id.clone();
+    let key = lsp.lsp_id;
     let mut lsa = Lsa::new(lsp);
     lsa.originated = true;
 

--- a/zebra-rs/src/isis/nfsm.rs
+++ b/zebra-rs/src/isis/nfsm.rs
@@ -34,11 +34,11 @@ pub enum NfsmEvent {
 
 pub fn nfsm_hold_timer(nbr: &Neighbor, level: Level) -> Timer {
     let tx = nbr.tx.clone();
-    let sys_id = nbr.sys_id.clone();
+    let sys_id = nbr.sys_id;
     let ifindex = nbr.ifindex;
     Timer::once(nbr.hold_time as u64, move || {
         let tx = tx.clone();
-        let sys_id = sys_id.clone();
+        let sys_id = sys_id;
         async move {
             tx.send(Message::Nfsm(
                 NfsmEvent::HoldTimerExpire,

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -367,7 +367,7 @@ pub fn csnp_recv(link: &mut LinkTop, level: Level, pdu: IsisCsnp) {
     // TODO: Need to check CSNP's LSP ID start and end.
     let mut lsdb: BTreeMap<IsisLspId, u32> = BTreeMap::new();
     for (_, lsa) in link.lsdb.get(&level).iter() {
-        lsdb.insert(lsa.lsp.lsp_id.clone(), lsa.lsp.seq_number);
+        lsdb.insert(lsa.lsp.lsp_id, lsa.lsp.seq_number);
     }
 
     // 7.3.15.2 b
@@ -376,7 +376,7 @@ pub fn csnp_recv(link: &mut LinkTop, level: Level, pdu: IsisCsnp) {
             for lsp in &tlv.entries {
                 match lsdb
                     .get(&lsp.lsp_id)
-                    .map(|seq_number| lsp.seq_number.cmp(&seq_number))
+                    .map(|seq_number| lsp.seq_number.cmp(seq_number))
                 {
                     Some(Ordering::Greater) => {
                         // 7.3.15.2 b.4
@@ -461,7 +461,7 @@ pub fn srm_set_for_all_lsp(link: &mut LinkTop, level: Level) {
         .lsdb
         .get(&level)
         .iter()
-        .map(|(lsp_id, _)| lsp_id.clone())
+        .map(|(lsp_id, _)| *lsp_id)
         .collect();
 
     for lsp_id in lsp_ids.iter() {

--- a/zebra-rs/src/ospf/ifsm.rs
+++ b/zebra-rs/src/ospf/ifsm.rs
@@ -183,11 +183,11 @@ fn ospf_dr_election_init(oi: &OspfLink) -> Vec<Identity> {
         .filter(|nbr| nbr.state >= NfsmState::TwoWay)
         .filter(|nbr| !nbr.ident.router_id.is_unspecified())
         .filter(|nbr| nbr.ident.priority != 0)
-        .map(|nbr| nbr.ident.clone())
+        .map(|nbr| nbr.ident)
         .collect();
 
     if oi.flags.hello_sent() && !oi.ident.router_id.is_unspecified() && oi.ident.priority != 0 {
-        v.push(oi.ident.clone());
+        v.push(oi.ident);
     }
     v
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -101,7 +101,7 @@ impl Ospf {
             let link_area = link.area;
             self.areas.get_mut(link_area).and_then(|area| {
                 let area_type = area.area_type;
-                link.nbrs.get_mut(&src).map(|nbr| {
+                link.nbrs.get_mut(src).map(|nbr| {
                     (
                         OspfInterface {
                             tx: &self.tx,

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -229,7 +229,7 @@ pub fn ospf_nfsm_timer_set(nbr: &mut Neighbor) {
 
 pub fn ospf_ls_req_timer(nbr: &Neighbor) -> Timer {
     let tx = nbr.tx.clone();
-    let prefix = nbr.ident.prefix.clone();
+    let prefix = nbr.ident.prefix;
     let ifindex = nbr.ifindex;
     Timer::new(Timer::second(1), TimerType::Once, move || {
         use NfsmEvent::*;
@@ -257,7 +257,7 @@ pub fn ospf_nfsm_ignore(
 
 pub fn ospf_inactivity_timer(nbr: &Neighbor) -> Timer {
     let tx = nbr.tx.clone();
-    let prefix = nbr.ident.prefix.clone();
+    let prefix = nbr.ident.prefix;
     let ifindex = nbr.ifindex;
     Timer::new(Timer::second(40), TimerType::Once, move || {
         use NfsmEvent::*;

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -408,7 +408,7 @@ pub fn ospf_db_desc_recv(
             ospf_db_desc_proc(oi, nbr, dd);
         }
         Exchange => {
-            if is_dd_dup(&dd, &nbr.dd.recv) {
+            if is_dd_dup(dd, &nbr.dd.recv) {
                 if nbr.dd.flags.master() {
                     // Packet dup (Master).
                 } else {

--- a/zebra-rs/src/rib/nexthop/map.rs
+++ b/zebra-rs/src/rib/nexthop/map.rs
@@ -19,7 +19,7 @@ pub struct NexthopMap {
 
 impl Group {
     pub fn from_nexthop_uni(uni: &NexthopUni, gid: usize) -> Self {
-        Group::Uni(GroupUni::new(gid, &uni))
+        Group::Uni(GroupUni::new(gid, uni))
     }
 }
 

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -627,7 +627,7 @@ fn resolve_nexthop_uni(
     nmap: &mut NexthopMap,
     table: &PrefixMap<Ipv4Net, RibEntries>,
 ) -> bool {
-    let Some(Group::Uni(group)) = nmap.fetch(&uni) else {
+    let Some(Group::Uni(group)) = nmap.fetch(uni) else {
         return false;
     };
     if group.refcnt() == 0 {
@@ -1098,7 +1098,7 @@ fn resolve_nexthop_uni_v6(
             uni.addr, uni.gid
         );
     }
-    let Some(Group::Uni(group)) = nmap.fetch(&uni) else {
+    let Some(Group::Uni(group)) = nmap.fetch(uni) else {
         if DEBUG_V6 {
             println!("[resolve_nexthop_uni_v6] nmap.fetch returned None");
         }

--- a/zebra-rs/src/spf/calc.rs
+++ b/zebra-rs/src/spf/calc.rs
@@ -286,7 +286,7 @@ pub fn q_space_nodes(graph: &Graph, d: usize, x: usize) -> HashSet<usize> {
 }
 
 pub fn pc_paths(graph: &Graph, s: usize, d: usize, x: usize) -> Vec<Vec<usize>> {
-    spf_calc(&graph, s, Some(x), &SpfOpt::full_path(), &SpfDirect::Normal)
+    spf_calc(graph, s, Some(x), &SpfOpt::full_path(), &SpfDirect::Normal)
         .remove(&d)
         .map_or_else(Vec::new, |data| data.paths)
 }
@@ -658,13 +658,13 @@ mod tests {
     fn seg_disp(graph: &Graph, seg: &SrSegment) -> String {
         match seg {
             SrSegment::NodeSid(id) => {
-                format!("NodeSid({})", graph.get(&id).map(|n| &n.name).unwrap())
+                format!("NodeSid({})", graph.get(id).map(|n| &n.name).unwrap())
             }
             SrSegment::AdjSid(from, to) => {
                 format!(
                     "AdjSid({}, {})",
-                    graph.get(&from).map(|n| &n.name).unwrap(),
-                    graph.get(&to).map(|n| &n.name).unwrap()
+                    graph.get(from).map(|n| &n.name).unwrap(),
+                    graph.get(to).map(|n| &n.name).unwrap()
                 )
             }
         }


### PR DESCRIPTION
## Summary

Re-enable `clippy::clone_on_copy` and `clippy::needless_borrow` and apply `cargo clippy --fix` across the workspace. The autofixer cleaned up all 75 sites — drops `.clone()` on `Copy` types (`IsisLspId`, `AfiSafi`, `Ipv4Net`, `sys_id`, etc.) and removes spurious `&` borrows that the compiler was already auto-dereferencing.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace --exclude bdd` — passing
- [x] `cargo fmt --all`

Generated with [Claude Code](https://claude.com/claude-code)