### PR TITLE
chore(clippy): drop get_first and ptr_arg allows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,6 @@ clap = { version = "4", features = ["derive"] }
 # and explicit-over-implicit choices in packet parsers). Other clippy
 # lints remain at their default level so genuine issues still surface.
 [workspace.lints.clippy]
-# Style — APIs that get used a lot in protocol code
-get_first = "allow"
-ptr_arg = "allow"
-
 # Naming — networking acronyms (TCP, IP, MD5, ...) are fine as-is
 upper_case_acronyms = "allow"
 

--- a/vtyctl/src/clear.rs
+++ b/vtyctl/src/clear.rs
@@ -12,7 +12,7 @@ pub mod vtysh {
     tonic::include_proto!("vtysh");
 }
 
-pub async fn clear(host: &String, command: &String) -> Result<()> {
+pub async fn clear(host: &str, command: &str) -> Result<()> {
     if command.is_empty() {
         eprintln!("vtyctl clear: command argument is required");
         eprintln!("Usage: vtyctl clear <command>");
@@ -31,7 +31,7 @@ pub async fn clear(host: &String, command: &String) -> Result<()> {
         r#type: ExecType::Exec as i32,
         mode: String::from("configure"),
         privilege: 15,
-        line: command.clone(),
+        line: command.to_string(),
         args: Vec::new(),
         ..Default::default()
     };
@@ -47,7 +47,7 @@ pub async fn clear(host: &String, command: &String) -> Result<()> {
     };
 
     let request = ClearRequest {
-        line: command.clone(),
+        line: command.to_string(),
         paths: reply.paths,
     };
 

--- a/vtyctl/src/show.rs
+++ b/vtyctl/src/show.rs
@@ -12,7 +12,7 @@ pub mod vtysh {
     tonic::include_proto!("vtysh");
 }
 
-pub async fn show(host: &String, command: &String, json: bool) -> Result<()> {
+pub async fn show(host: &str, command: &str, json: bool) -> Result<()> {
     if command.is_empty() {
         eprintln!("zctl show: command argument is required");
         eprintln!("Usage: zctl show <command>");
@@ -31,7 +31,7 @@ pub async fn show(host: &String, command: &String, json: bool) -> Result<()> {
         r#type: ExecType::Exec as i32,
         mode: String::from("exec"),
         privilege: 15,
-        line: command.clone(),
+        line: command.to_string(),
         args: Vec::new(),
         ..Default::default()
     };
@@ -47,7 +47,7 @@ pub async fn show(host: &String, command: &String, json: bool) -> Result<()> {
     };
 
     let request = ShowRequest {
-        line: command.clone(),
+        line: command.to_string(),
         json,
         paths: reply.paths,
     };

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -289,9 +289,9 @@ impl ConfigManager {
         std::fs::write(&self.config_path, output).expect("Unable to write file");
     }
 
-    pub fn clear(&self, paths: &Vec<CommandPath>) {
+    pub fn clear(&self, paths: &[CommandPath]) {
         for (_, tx) in self.cm_clients.borrow().iter() {
-            tx.send(ConfigRequest::new(paths.clone(), ConfigOp::Clear))
+            tx.send(ConfigRequest::new(paths.to_vec(), ConfigOp::Clear))
                 .unwrap();
         }
     }
@@ -615,7 +615,7 @@ pub enum ConfigFormat {
     Yaml,
 }
 
-pub fn config_format_type(config_str: &String) -> ConfigFormat {
+pub fn config_format_type(config_str: &str) -> ConfigFormat {
     let first_line = config_str.lines().next().unwrap_or("").trim();
     if first_line.starts_with('{') {
         ConfigFormat::Json

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -50,7 +50,7 @@ impl NeighborAddr6 {
 
 pub fn nbr_hello_interpret(
     nbr: &mut Neighbor,
-    tlvs: &Vec<IsisTlv>,
+    tlvs: &[IsisTlv],
     mac: Option<MacAddr>,
     sys_id: IsisSysId,
     local_pool: &mut Option<LabelPool>,

--- a/zebra-rs/src/policy/inst.rs
+++ b/zebra-rs/src/policy/inst.rs
@@ -67,10 +67,10 @@ impl PolicyRxChannel {
 }
 
 pub trait Syncer {
-    fn prefix_set_update(&self, name: &String, prefix_set: &PrefixSet);
-    fn prefix_set_remove(&self, name: &String);
-    fn policy_list_update(&self, name: &String, policy_list: &PolicyList);
-    fn policy_list_remove(&self, name: &String);
+    fn prefix_set_update(&self, name: &str, prefix_set: &PrefixSet);
+    fn prefix_set_remove(&self, name: &str);
+    fn policy_list_update(&self, name: &str, policy_list: &PolicyList);
+    fn policy_list_remove(&self, name: &str);
 }
 
 pub struct PolicySyncer<'a> {
@@ -79,13 +79,13 @@ pub struct PolicySyncer<'a> {
 }
 
 impl<'a> Syncer for PolicySyncer<'a> {
-    fn prefix_set_update(&self, name: &String, prefix_set: &PrefixSet) {
+    fn prefix_set_update(&self, name: &str, prefix_set: &PrefixSet) {
         // Notify all watchers of this prefix-set update
         if let Some(watches) = self.watch_map.get(name) {
             for watch in watches {
                 if let Some(tx) = self.clients.get(&watch.proto) {
                     let msg = PolicyRx::PrefixSet {
-                        name: name.clone(),
+                        name: name.to_string(),
                         ident: watch.ident,
                         policy_type: watch.policy_type,
                         prefix_set: Some(prefix_set.clone()),
@@ -96,12 +96,12 @@ impl<'a> Syncer for PolicySyncer<'a> {
         }
     }
 
-    fn prefix_set_remove(&self, name: &String) {
+    fn prefix_set_remove(&self, name: &str) {
         if let Some(watches) = self.watch_map.get(name) {
             for watch in watches {
                 if let Some(tx) = self.clients.get(&watch.proto) {
                     let msg = PolicyRx::PrefixSet {
-                        name: name.clone(),
+                        name: name.to_string(),
                         ident: watch.ident,
                         policy_type: watch.policy_type,
                         prefix_set: None,
@@ -112,12 +112,12 @@ impl<'a> Syncer for PolicySyncer<'a> {
         }
     }
 
-    fn policy_list_update(&self, name: &String, policy_list: &PolicyList) {
+    fn policy_list_update(&self, name: &str, policy_list: &PolicyList) {
         if let Some(watches) = self.watch_map.get(name) {
             for watch in watches {
                 if let Some(tx) = self.clients.get(&watch.proto) {
                     let msg = PolicyRx::PolicyList {
-                        name: name.clone(),
+                        name: name.to_string(),
                         ident: watch.ident,
                         policy_type: watch.policy_type,
                         policy_list: Some(policy_list.clone()),
@@ -128,12 +128,12 @@ impl<'a> Syncer for PolicySyncer<'a> {
         }
     }
 
-    fn policy_list_remove(&self, name: &String) {
+    fn policy_list_remove(&self, name: &str) {
         if let Some(watches) = self.watch_map.get(name) {
             for watch in watches {
                 if let Some(tx) = self.clients.get(&watch.proto) {
                     let msg = PolicyRx::PolicyList {
-                        name: name.clone(),
+                        name: name.to_string(),
                         ident: watch.ident,
                         policy_type: watch.policy_type,
                         policy_list: None,

--- a/zebra-rs/src/rib/bridge/builder.rs
+++ b/zebra-rs/src/rib/bridge/builder.rs
@@ -96,8 +96,8 @@ fn cache_lookup<'a>(
     if cache.delete { None } else { Some(cache) }
 }
 
-fn parse_addr_gen_mode(mode: &String) -> Option<AddrGenMode> {
-    match mode.as_str() {
+fn parse_addr_gen_mode(mode: &str) -> Option<AddrGenMode> {
+    match mode {
         "none" => Some(AddrGenMode::None),
         "eui64" => Some(AddrGenMode::Eui64),
         "stable-secret" => Some(AddrGenMode::StableSecret),

--- a/zebra-rs/src/rib/vxlan/builder.rs
+++ b/zebra-rs/src/rib/vxlan/builder.rs
@@ -97,8 +97,8 @@ fn cache_lookup<'a>(
     if cache.delete { None } else { Some(cache) }
 }
 
-fn parse_addr_gen_mode(mode: &String) -> Option<AddrGenMode> {
-    match mode.as_str() {
+fn parse_addr_gen_mode(mode: &str) -> Option<AddrGenMode> {
+    match mode {
         "none" => Some(AddrGenMode::None),
         "eui64" => Some(AddrGenMode::Eui64),
         "stable-secret" => Some(AddrGenMode::StableSecret),

--- a/zebra-rs/src/spf/calc.rs
+++ b/zebra-rs/src/spf/calc.rs
@@ -558,7 +558,7 @@ mod tests {
         };
         assert_eq!(n.cost, 30);
         assert_eq!(n.paths.len(), 2);
-        assert_eq!(*n.paths.get(0).unwrap(), vec![1, 3, 4]);
+        assert_eq!(*n.paths.first().unwrap(), vec![1, 3, 4]);
         assert_eq!(*n.paths.get(1).unwrap(), vec![2, 3, 4]);
 
         // SPF with full path and path max = 1.
@@ -583,7 +583,7 @@ mod tests {
         };
         assert_eq!(n.cost, 20);
         assert_eq!(n.paths.len(), 1);
-        assert_eq!(*n.paths.get(0).unwrap(), vec![1, 3]);
+        assert_eq!(*n.paths.first().unwrap(), vec![1, 3]);
     }
 
     fn tilfa_graph() -> Graph {
@@ -707,7 +707,7 @@ mod tests {
         // PCPath in this example).
         let mut pc_paths = pc_paths(&graph, s, d, x);
         assert_eq!(pc_paths.len(), 1);
-        let pc_path = pc_paths.get(0).unwrap();
+        let pc_path = pc_paths.first().unwrap();
         let mut pc_nodes = Vec::<String>::new();
         for n in pc_path.iter() {
             let name = node_name(&graph, *n);
@@ -776,7 +776,7 @@ mod tests {
             let repair_list = make_repair_list(&pc_inter, s, d);
 
             assert_eq!(repair_list.len(), 3);
-            let first_segment = repair_list.get(0).unwrap();
+            let first_segment = repair_list.first().unwrap();
             let second_segment = repair_list.get(1).unwrap();
             let third_segment = repair_list.get(2).unwrap();
 
@@ -801,10 +801,10 @@ mod tests {
 
         let repair_paths = tilfa(&graph, s, d, x);
         assert_eq!(repair_paths.len(), 1);
-        let repair_list = repair_paths.get(0).unwrap();
+        let repair_list = repair_paths.first().unwrap();
 
         assert_eq!(repair_list.len(), 3);
-        let first_segment = repair_list.get(0).unwrap();
+        let first_segment = repair_list.first().unwrap();
         let second_segment = repair_list.get(1).unwrap();
         let third_segment = repair_list.get(2).unwrap();
 


### PR DESCRIPTION
## Summary

Re-enable `clippy::get_first` and `clippy::ptr_arg`, fix all 17 sites:

- `get_first` (6, autofixed): `vec[0]` → `vec.first().unwrap()` / `vec.first().is_some()` / etc. in `spf::calc` TI-LFA tests.
- `ptr_arg` (11, manual): `&Vec<T>` → `&[T]` and `&String` → `&str` in function signatures. Touched the `Syncer` trait in `policy::inst` (all four methods accept `&str` now), `config::manager::clear` / `config_format_type`, `isis::packet::nbr_hello_interpret`, `parse_addr_gen_mode` helpers in `rib::bridge` / `vxlan::builder`, and `vtyctl::clear` / `show` entry points.

Where bodies previously called `.clone()` on the parameter (returning `String`), switched to `.to_string()`; where they called `mode.as_str()`, removed the redundant call since `mode` is now already `&str`. `paths.clone()` for `Vec` became `paths.to_vec()`.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace --exclude bdd` — passing
- [x] `cargo fmt --all`

Generated with [Claude Code](https://claude.com/claude-code)