### PR TITLE
chore(clippy): fix collapsible_if regressions from #326

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -446,10 +446,10 @@ impl FibHandle {
 
         let mut response = self.handle.clone().request(req).unwrap();
         while let Some(msg) = response.next().await {
-            if let NetlinkPayload::Error(e) = msg.payload {
-                if DEBUG_ADDR {
-                    tracing::info!("NewRoute IPv6 error: {prefix} {e}");
-                }
+            if let NetlinkPayload::Error(e) = msg.payload
+                && DEBUG_ADDR
+            {
+                tracing::info!("NewRoute IPv6 error: {prefix} {e}");
             }
         }
     }
@@ -551,10 +551,10 @@ impl FibHandle {
 
         let mut response = self.handle.clone().request(req).unwrap();
         while let Some(msg) = response.next().await {
-            if let NetlinkPayload::Error(e) = msg.payload {
-                if DEBUG_ADDR {
-                    tracing::info!("DelRoute IPv6 error: {e} {prefix}");
-                }
+            if let NetlinkPayload::Error(e) = msg.payload
+                && DEBUG_ADDR
+            {
+                tracing::info!("DelRoute IPv6 error: {e} {prefix}");
             }
         }
     }


### PR DESCRIPTION
## Summary
- PR #326 left two `if let NetlinkPayload::Error(e) = msg.payload { if DEBUG_ADDR { ... } }` blocks in the IPv6 NewRoute/DelRoute paths in `fib/netlink/handle.rs`, which trip clippy's `collapsible_if`.
- Fold both into single let-chain form (`if let ... && DEBUG_ADDR { ... }`).
- CI clippy on #326 actually failed but the merge went through anyway — branch protection on `main` is not enforcing required checks.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean locally
- [x] `cargo fmt --all` — no diff
- [ ] CI fmt/clippy/test all green on this PR

Generated with [Claude Code](https://claude.com/claude-code)