### PR TITLE
feat(isis): IPv6 single-topology support (RFC 1195)

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -20,6 +20,10 @@ rib_static_ipv6:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@rib_static_ipv6"
 
+isis_ipv6:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_ipv6"
+
 generate:
 	rm -rf allure-report
 	allure generate
@@ -39,4 +43,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 generate open docs FORCE

--- a/bdd/docs/isis_ipv6.md
+++ b/bdd/docs/isis_ipv6.md
@@ -1,0 +1,36 @@
+# IS-IS IPv6 single-topology
+
+## Overview
+
+As a network operator
+I want two zebra-rs instances to form an IS-IS L2 adjacency over a
+Using an isolated test topology with two zebra-rs instances connected
+
+## Test Topology
+
+```
+  ┌────────────────────────────────────────┐
+  │                  br0                   │
+  └────────────┬───────────────┬───────────┘
+               │               │
+       2001:db8:1::1/64   2001:db8:1::2/64
+            (vz1ns)             (vz2ns)
+          ┌────┴────┐     ┌────┴────┐
+          │   z1    │     │   z2    │
+          └─────────┘     └─────────┘
+   lo: 2001:db8:0:ffff::1   lo: 2001:db8:0:ffff::2
+              /128                  /128
+```
+
+## Config Files
+
+- z1-1.yaml: z1 interface addresses (lo + vz1ns) + IS-IS L2 with IPv6.
+- z2-1.yaml: z2 interface addresses (lo + vz2ns) + IS-IS L2 with IPv6.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup IS-IS L2 over a shared bridge and confirm the link is up | |
+| IS-IS installs reciprocal IPv6 routes to peer loopbacks | |
+| IS-IS adjacency survives a link bounce and routes recover | |

--- a/bdd/tests/data/isis_ipv6/z1-1.yaml
+++ b/bdd/tests/data/isis_ipv6/z1-1.yaml
@@ -1,0 +1,21 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::1/128
+- if-name: vz1ns
+  ipv6:
+    address: 2001:db8:1::1/64
+routing:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+    - if-name: vz1ns
+      circuit-type: level-2-only
+      ipv6:
+        enable: true

--- a/bdd/tests/data/isis_ipv6/z2-1.yaml
+++ b/bdd/tests/data/isis_ipv6/z2-1.yaml
@@ -1,0 +1,21 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::2/128
+- if-name: vz2ns
+  ipv6:
+    address: 2001:db8:1::2/64
+routing:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+    - if-name: vz2ns
+      circuit-type: level-2-only
+      ipv6:
+        enable: true

--- a/bdd/tests/features/isis_ipv6.feature
+++ b/bdd/tests/features/isis_ipv6.feature
@@ -1,0 +1,57 @@
+@serial
+@isis_ipv6
+Feature: IS-IS IPv6 single-topology
+  As a network operator
+  I want two zebra-rs instances to form an IS-IS L2 adjacency over a
+  shared link, exchange IPv6 reachability via TLV 232 (link-local IIH)
+  and TLV 236 (Ipv6Reach in LSPs), and install reciprocal IPv6 routes
+  to each other's loopback so traffic can flow end-to-end.
+  Using an isolated test topology with two zebra-rs instances connected
+  via a shared bridge.
+
+  Test Topology:
+  ```
+  ┌────────────────────────────────────────┐
+  │                  br0                   │
+  └────────────┬───────────────┬───────────┘
+               │               │
+       2001:db8:1::1/64   2001:db8:1::2/64
+            (vz1ns)             (vz2ns)
+          ┌────┴────┐     ┌────┴────┐
+          │   z1    │     │   z2    │
+          └─────────┘     └─────────┘
+   lo: 2001:db8:0:ffff::1   lo: 2001:db8:0:ffff::2
+              /128                  /128
+  ```
+
+  Config files:
+  - z1-1.yaml: z1 interface addresses (lo + vz1ns) + IS-IS L2 with IPv6.
+  - z2-1.yaml: z2 interface addresses (lo + vz2ns) + IS-IS L2 with IPv6.
+
+  Scenario: Setup IS-IS L2 over a shared bridge and confirm the link is up
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with loopback and veth interface on the bridge "br0"
+    And I create namespace "z2" with loopback and veth interface on the bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 20 seconds
+    Then ping from "z1" to "2001:db8:1::2" should succeed
+    And ping from "z2" to "2001:db8:1::1" should succeed
+
+  Scenario: IS-IS installs reciprocal IPv6 routes to peer loopbacks
+    Given the test topology exists
+    Then ping from "z1" to "2001:db8:0:ffff::2" should succeed
+    And ping from "z2" to "2001:db8:0:ffff::1" should succeed
+
+  Scenario: IS-IS adjacency survives a link bounce and routes recover
+    Given the test topology exists
+    When I make namespace "z1" interface "vz1ns" down
+    And I wait 2 seconds
+    Then ping from "z1" to "2001:db8:0:ffff::2" should fail
+    When I make namespace "z1" interface "vz1ns" up
+    And I wait 30 seconds
+    Then ping from "z1" to "2001:db8:0:ffff::2" should succeed
+    And ping from "z2" to "2001:db8:0:ffff::1" should succeed

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -71,6 +71,28 @@ pub fn hello_generate(link: &LinkTop, level: Level) -> IsisHello {
         );
     }
 
+    // IPv6 Interface Address TLVs (RFC 5308 TLV 232 for link-local; non-standard
+    // TLV 233 for global) — only when IS-IS IPv6 is enabled on this link, so we
+    // don't advertise an IPv6 capability we won't honor.
+    if link.config.enable.v6 {
+        for prefix in &link.state.v6laddr {
+            hello.tlvs.push(
+                IsisTlvIpv6IfAddr {
+                    addr: prefix.addr(),
+                }
+                .into(),
+            );
+        }
+        for prefix in &link.state.v6addr {
+            hello.tlvs.push(
+                IsisTlvIpv6GlobalIfAddr {
+                    addr: prefix.addr(),
+                }
+                .into(),
+            );
+        }
+    }
+
     let mut neighbors = Vec::new();
     for (_, nbr) in link.state.nbrs.get(&level).iter() {
         if (nbr.state == NfsmState::Init || nbr.state == NfsmState::Up)
@@ -118,6 +140,27 @@ pub fn hello_p2p_generate(link: &LinkTop, level: Level) -> IsisP2pHello {
             }
             .into(),
         );
+    }
+
+    // IPv6 Interface Address TLVs (RFC 5308 TLV 232 for link-local; non-standard
+    // TLV 233 for global) — only when IS-IS IPv6 is enabled on this link.
+    if link.config.enable.v6 {
+        for prefix in &link.state.v6laddr {
+            hello.tlvs.push(
+                IsisTlvIpv6IfAddr {
+                    addr: prefix.addr(),
+                }
+                .into(),
+            );
+        }
+        for prefix in &link.state.v6addr {
+            hello.tlvs.push(
+                IsisTlvIpv6GlobalIfAddr {
+                    addr: prefix.addr(),
+                }
+                .into(),
+            );
+        }
     }
 
     // Three way handshake.

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -63,6 +63,7 @@ pub struct Isis {
     pub lsdb: Levels<Lsdb>,
     pub lsp_map: Levels<LspMap>,
     pub reach_map: Levels<Afis<ReachMap>>,
+    pub reach_map_v6: Levels<ReachMapV6>,
     pub label_map: Levels<IsisLabelMap>,
     pub rib: Levels<PrefixMap<Ipv4Net, SpfRoute>>,
     pub rib_v6: Levels<PrefixMap<Ipv6Net, SpfRouteV6>>,
@@ -82,10 +83,9 @@ pub struct IsisTop<'a> {
     pub lsdb: &'a mut Levels<Lsdb>,
     pub lsp_map: &'a mut Levels<LspMap>,
     pub reach_map: &'a mut Levels<Afis<ReachMap>>,
+    pub reach_map_v6: &'a mut Levels<ReachMapV6>,
     pub label_map: &'a mut Levels<IsisLabelMap>,
     pub rib: &'a mut Levels<PrefixMap<Ipv4Net, SpfRoute>>,
-    // PR 3 (build_rib_from_spf_v6 + diff_apply_v6) wires this through.
-    #[allow(dead_code)]
     pub rib_v6: &'a mut Levels<PrefixMap<Ipv6Net, SpfRouteV6>>,
     pub ilm: &'a mut Levels<BTreeMap<u32, SpfIlm>>,
     pub rib_tx: &'a UnboundedSender<rib::Message>,
@@ -120,6 +120,7 @@ impl Isis {
             lsdb: Levels::<Lsdb>::default(),
             lsp_map: Levels::<LspMap>::default(),
             reach_map: Levels::<Afis<ReachMap>>::default(),
+            reach_map_v6: Levels::<ReachMapV6>::default(),
             label_map: Levels::<IsisLabelMap>::default(),
             rib: Levels::<PrefixMap<Ipv4Net, SpfRoute>>::default(),
             rib_v6: Levels::<PrefixMap<Ipv6Net, SpfRouteV6>>::default(),
@@ -435,6 +436,7 @@ impl Isis {
             lsdb: &mut self.lsdb,
             lsp_map: &mut self.lsp_map,
             reach_map: &mut self.reach_map,
+            reach_map_v6: &mut self.reach_map_v6,
             label_map: &mut self.label_map,
             rib: &mut self.rib,
             rib_v6: &mut self.rib_v6,
@@ -462,6 +464,7 @@ impl Isis {
             local_pool: &mut self.local_pool,
             hostname: &mut self.hostname,
             reach_map: &mut self.reach_map,
+            reach_map_v6: &mut self.reach_map_v6,
             label_map: &mut self.label_map,
             spf_timer: &mut self.spf_timer,
         })
@@ -945,6 +948,25 @@ impl ReachMap {
 }
 
 #[derive(Default)]
+pub struct ReachMapV6 {
+    map: BTreeMap<IsisSysId, Vec<IsisTlvIpv6ReachEntry>>,
+}
+
+impl ReachMapV6 {
+    pub fn get(&self, key: &IsisSysId) -> Option<&Vec<IsisTlvIpv6ReachEntry>> {
+        self.map.get(key)
+    }
+
+    pub fn insert(
+        &mut self,
+        key: IsisSysId,
+        value: Vec<IsisTlvIpv6ReachEntry>,
+    ) -> Option<Vec<IsisTlvIpv6ReachEntry>> {
+        self.map.insert(key, value)
+    }
+}
+
+#[derive(Default)]
 pub struct LspMap {
     map: BTreeMap<IsisSysId, usize>,
     val: Vec<IsisSysId>,
@@ -1152,6 +1174,7 @@ pub struct SpfNexthopV6 {
 }
 
 pub type DiffResult<'a> = spf::TableDiffResult<'a, Ipv4Net, SpfRoute>;
+pub type DiffResultV6<'a> = spf::TableDiffResult<'a, Ipv6Net, SpfRouteV6>;
 pub type DiffIlmResult<'a> = spf::TableDiffResult<'a, u32, SpfIlm>;
 
 fn nhop_to_nexthop_uni(key: &Ipv4Addr, route: &SpfRoute, value: &SpfNexthop) -> rib::NexthopUni {
@@ -1221,6 +1244,85 @@ pub fn diff_apply(rib_tx: UnboundedSender<rib::Message>, diff: &DiffResult) {
         if !route.nhops.is_empty() {
             let rib = make_rib_entry(route);
             let msg = rib::Message::Ipv4Add {
+                prefix: **prefix,
+                rib,
+            };
+            rib_tx.send(msg).unwrap();
+        }
+    }
+}
+
+fn nhop_to_nexthop_uni_v6(
+    key: &Ipv6Addr,
+    route: &SpfRouteV6,
+    value: &SpfNexthopV6,
+) -> rib::NexthopUni {
+    let mut mpls = vec![];
+    if let Some(sid) = route.sid {
+        mpls.push(if value.adjacency {
+            rib::Label::Implicit(sid)
+        } else {
+            rib::Label::Explicit(sid)
+        });
+    }
+    let mut nhop = rib::NexthopUni::new(std::net::IpAddr::V6(*key), route.metric, mpls);
+    // IPv6 link-local nexthops require ifindex for kernel scope resolution.
+    nhop.ifindex = value.ifindex;
+    nhop
+}
+
+fn make_rib_entry_v6(route: &SpfRouteV6) -> rib::entry::RibEntry {
+    let mut rib = rib::entry::RibEntry::new(RibType::Isis);
+    rib.distance = 115;
+    rib.metric = route.metric;
+
+    rib.nexthop = if route.nhops.len() == 1 {
+        if let Some((key, value)) = route.nhops.iter().next() {
+            rib::Nexthop::Uni(nhop_to_nexthop_uni_v6(key, route, value))
+        } else {
+            rib::Nexthop::default()
+        }
+    } else {
+        let multi = rib::NexthopMulti {
+            metric: route.metric,
+            nexthops: route
+                .nhops
+                .iter()
+                .map(|(key, value)| nhop_to_nexthop_uni_v6(key, route, value))
+                .collect(),
+            ..Default::default()
+        };
+        rib::Nexthop::Multi(multi)
+    };
+
+    rib
+}
+
+pub fn diff_apply_v6(rib_tx: UnboundedSender<rib::Message>, diff: &DiffResultV6) {
+    for (prefix, route) in diff.only_curr.iter() {
+        if !route.nhops.is_empty() {
+            let rib = make_rib_entry_v6(route);
+            let msg = rib::Message::Ipv6Del {
+                prefix: **prefix,
+                rib,
+            };
+            rib_tx.send(msg).unwrap();
+        }
+    }
+    for (prefix, _, route) in diff.different.iter() {
+        if !route.nhops.is_empty() {
+            let rib = make_rib_entry_v6(route);
+            let msg = rib::Message::Ipv6Add {
+                prefix: **prefix,
+                rib,
+            };
+            rib_tx.send(msg).unwrap();
+        }
+    }
+    for (prefix, route) in diff.only_next.iter() {
+        if !route.nhops.is_empty() {
+            let rib = make_rib_entry_v6(route);
+            let msg = rib::Message::Ipv6Add {
                 prefix: **prefix,
                 rib,
             };
@@ -1495,11 +1597,85 @@ fn build_rib_from_spf(
     rib
 }
 
+// IPv6 mirror of build_rib_from_spf. Walks the same single-topology SPF tree;
+// nexthops come from the peer's link-local IPv6 advertised in IIH (TLV 232,
+// stored on Neighbor::addr6l). Reachable prefixes come from the per-LSP
+// IsisTlvIpv6Reach indexed in reach_map_v6.
+//
+// Prefix-SID / SR plumbing for IPv6 is intentionally deferred — sid and
+// prefix_sid are left None for now and can be added when SRv6 IS-IS support
+// lands as a follow-up.
+fn build_rib_from_spf_v6(
+    top: &mut IsisTop,
+    level: Level,
+    source: usize,
+    spf_result: &BTreeMap<usize, spf::Path>,
+) -> PrefixMap<Ipv6Net, SpfRouteV6> {
+    let mut rib = PrefixMap::<Ipv6Net, SpfRouteV6>::new();
+
+    for (node, nhops) in spf_result {
+        if *node == source {
+            continue;
+        }
+
+        let Some(sys_id) = top.lsp_map.get(&level).resolve(*node) else {
+            continue;
+        };
+
+        // Build nexthop map keyed by the first-hop neighbor's link-local IPv6.
+        let mut spf_nhops = BTreeMap::new();
+        for p in &nhops.nexthops {
+            if !p.is_empty()
+                && let Some(nhop_id) = top.lsp_map.get(&level).resolve(p[0])
+            {
+                for (ifindex, link) in top.links.iter() {
+                    if let Some(nbr) = link.state.nbrs.get(&level).get(nhop_id) {
+                        for addr in nbr.addr6l.iter() {
+                            let nhop = SpfNexthopV6 {
+                                ifindex: *ifindex,
+                                adjacency: p[0] == *node,
+                                sys_id: Some(*nhop_id),
+                            };
+                            spf_nhops.insert(*addr, nhop);
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Some(entries) = top.reach_map_v6.get(&level).get(sys_id) {
+            for entry in entries.iter() {
+                let route = SpfRouteV6 {
+                    metric: nhops.cost + entry.metric,
+                    nhops: spf_nhops.clone(),
+                    sid: None,
+                    prefix_sid: None,
+                };
+
+                if let Some(curr) = rib.get_mut(&entry.prefix.trunc()) {
+                    if curr.metric > route.metric {
+                        *curr = route;
+                    } else if curr.metric == route.metric {
+                        for (addr, nhop) in route.nhops {
+                            curr.nhops.insert(addr, nhop);
+                        }
+                    }
+                } else {
+                    rib.insert(entry.prefix.trunc(), route);
+                }
+            }
+        }
+    }
+
+    rib
+}
+
 /// Apply routing updates to RIB subsystem
 fn apply_routing_updates(
     top: &mut IsisTop,
     level: Level,
     rib: PrefixMap<Ipv4Net, SpfRoute>,
+    rib_v6: PrefixMap<Ipv6Net, SpfRouteV6>,
     ilm: BTreeMap<u32, SpfIlm>,
 ) {
     // Update MPLS ILM
@@ -1509,12 +1685,19 @@ fn apply_routing_updates(
     }
     *top.ilm.get_mut(&level) = ilm;
 
-    // Update RIB
+    // Update IPv4 RIB
     if top.config.distribute.rib {
         let diff = spf::table_diff(top.rib.get(&level).iter(), rib.iter());
         diff_apply(top.rib_tx.clone(), &diff);
     }
     *top.rib.get_mut(&level) = rib;
+
+    // Update IPv6 RIB
+    if top.config.distribute.rib {
+        let diff = spf::table_diff(top.rib_v6.get(&level).iter(), rib_v6.iter());
+        diff_apply_v6(top.rib_tx.clone(), &diff);
+    }
+    *top.rib_v6.get_mut(&level) = rib_v6;
 }
 
 /// Perform SPF calculation and update routing tables
@@ -1533,8 +1716,9 @@ fn perform_spf_calculation(top: &mut IsisTop, level: Level) {
         // Run SPF algorithm
         let spf_result = spf::spf(&graph, source, &spf::SpfOpt::default());
 
-        // Build RIB from SPF results
+        // Build IPv4 + IPv6 RIBs from the same SPF result (single-topology).
         let rib = build_rib_from_spf(top, level, source, &spf_result);
+        let rib_v6 = build_rib_from_spf_v6(top, level, source, &spf_result);
 
         // Store SPF result in the instance.
         // spf::disp(&spf_result, false);
@@ -1544,7 +1728,7 @@ fn perform_spf_calculation(top: &mut IsisTop, level: Level) {
         mpls_route(&rib, &mut ilm);
 
         // Apply updates to RIB subsystem
-        apply_routing_updates(top, level, rib, ilm);
+        apply_routing_updates(top, level, rib, rib_v6, ilm);
     }
 }
 

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -3,10 +3,10 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Display;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 use bytes::BytesMut;
-use ipnet::Ipv4Net;
+use ipnet::{Ipv4Net, Ipv6Net};
 use isis_packet::neigh::{self, IsisSubAdjSid};
 use isis_packet::prefix::{self, Ipv4ControlInfo, Ipv6ControlInfo};
 use isis_packet::*;
@@ -65,6 +65,7 @@ pub struct Isis {
     pub reach_map: Levels<Afis<ReachMap>>,
     pub label_map: Levels<IsisLabelMap>,
     pub rib: Levels<PrefixMap<Ipv4Net, SpfRoute>>,
+    pub rib_v6: Levels<PrefixMap<Ipv6Net, SpfRouteV6>>,
     pub ilm: Levels<BTreeMap<u32, SpfIlm>>,
     pub hostname: Levels<Hostname>,
     pub spf_timer: Levels<Option<Timer>>,
@@ -83,6 +84,9 @@ pub struct IsisTop<'a> {
     pub reach_map: &'a mut Levels<Afis<ReachMap>>,
     pub label_map: &'a mut Levels<IsisLabelMap>,
     pub rib: &'a mut Levels<PrefixMap<Ipv4Net, SpfRoute>>,
+    // PR 3 (build_rib_from_spf_v6 + diff_apply_v6) wires this through.
+    #[allow(dead_code)]
+    pub rib_v6: &'a mut Levels<PrefixMap<Ipv6Net, SpfRouteV6>>,
     pub ilm: &'a mut Levels<BTreeMap<u32, SpfIlm>>,
     pub rib_tx: &'a UnboundedSender<rib::Message>,
     pub hostname: &'a mut Levels<Hostname>,
@@ -118,6 +122,7 @@ impl Isis {
             reach_map: Levels::<Afis<ReachMap>>::default(),
             label_map: Levels::<IsisLabelMap>::default(),
             rib: Levels::<PrefixMap<Ipv4Net, SpfRoute>>::default(),
+            rib_v6: Levels::<PrefixMap<Ipv6Net, SpfRouteV6>>::default(),
             ilm: Levels::<BTreeMap<u32, SpfIlm>>::default(),
             hostname: Levels::<Hostname>::default(),
             spf_timer: Levels::<Option<Timer>>::default(),
@@ -432,6 +437,7 @@ impl Isis {
             reach_map: &mut self.reach_map,
             label_map: &mut self.label_map,
             rib: &mut self.rib,
+            rib_v6: &mut self.rib_v6,
             ilm: &mut self.ilm,
             rib_tx: &self.rib_tx,
             hostname: &mut self.hostname,
@@ -1122,6 +1128,24 @@ pub struct SpfRoute {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SpfNexthop {
+    pub ifindex: u32,
+    pub adjacency: bool,
+    pub sys_id: Option<IsisSysId>,
+}
+
+// IPv6 single-topology mirror of SpfRoute / SpfNexthop. Nexthop key is the
+// peer's IPv6 link-local address (TLV 232 from IIH); ECMP is supported by
+// keying multiple link-locals into the same SpfRouteV6.
+#[derive(Debug, PartialEq)]
+pub struct SpfRouteV6 {
+    pub metric: u32,
+    pub nhops: BTreeMap<Ipv6Addr, SpfNexthopV6>,
+    pub sid: Option<u32>,
+    pub prefix_sid: Option<(SidLabelValue, LabelConfig)>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpfNexthopV6 {
     pub ifindex: u32,
     pub adjacency: bool,
     pub sys_id: Option<IsisSysId>,

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright 2025-2026 Kunihiro Ishiguro
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::Display;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
@@ -1513,9 +1513,12 @@ fn build_rib_from_spf(
             continue;
         };
 
-        // Build nexthop map
+        // Build nexthop map. SPF runs in full-path mode (see
+        // perform_spf_calculation), so each `p` is the full path
+        // [first_hop, ..., destination]; we still index `p[0]` for the
+        // first-hop semantics the v4 path has always used.
         let mut spf_nhops = BTreeMap::new();
-        for p in &nhops.nexthops {
+        for p in &nhops.paths {
             // p.is_empty() means myself
             if !p.is_empty()
                 && let Some(nhop_id) = top.lsp_map.get(&level).resolve(p[0])
@@ -1602,6 +1605,11 @@ fn build_rib_from_spf(
 // stored on Neighbor::addr6l). Reachable prefixes come from the per-LSP
 // IsisTlvIpv6Reach indexed in reach_map_v6.
 //
+// RFC 1195 §5: in single-topology mode, every transit node along the path to
+// an IPv6 destination must advertise IPv6 NLPID (0x8E) in its
+// Protocols-Supported TLV. Paths that traverse a non-IPv6-capable node are
+// dropped here so we don't black-hole traffic at a v4-only transit.
+//
 // Prefix-SID / SR plumbing for IPv6 is intentionally deferred — sid and
 // prefix_sid are left None for now and can be added when SRv6 IS-IS support
 // lands as a follow-up.
@@ -1613,6 +1621,10 @@ fn build_rib_from_spf_v6(
 ) -> PrefixMap<Ipv6Net, SpfRouteV6> {
     let mut rib = PrefixMap::<Ipv6Net, SpfRouteV6>::new();
 
+    // Precompute the set of SysIds whose LSP advertises IPv6 NLPID, used to
+    // gate every transit node on each candidate path.
+    let ipv6_capable = ipv6_capable_set(top.lsdb.get(&level));
+
     for (node, nhops) in spf_result {
         if *node == source {
             continue;
@@ -1622,28 +1634,57 @@ fn build_rib_from_spf_v6(
             continue;
         };
 
+        // Strict NLPID gating per RFC 1195 §5: if the destination doesn't
+        // advertise IPv6, anything claimed via Ipv6Reach is unreachable.
+        if !ipv6_capable.contains(sys_id) {
+            continue;
+        }
+        // Capture SysId so later borrows of top.lsp_map don't conflict.
+        let dest_sys_id = *sys_id;
+
         // Build nexthop map keyed by the first-hop neighbor's link-local IPv6.
+        // Iterate `paths` (full path from first-hop to destination) so we can
+        // strict-gate every transit node, not just the first hop.
         let mut spf_nhops = BTreeMap::new();
-        for p in &nhops.nexthops {
-            if !p.is_empty()
-                && let Some(nhop_id) = top.lsp_map.get(&level).resolve(p[0])
-            {
-                for (ifindex, link) in top.links.iter() {
-                    if let Some(nbr) = link.state.nbrs.get(&level).get(nhop_id) {
-                        for addr in nbr.addr6l.iter() {
-                            let nhop = SpfNexthopV6 {
-                                ifindex: *ifindex,
-                                adjacency: p[0] == *node,
-                                sys_id: Some(*nhop_id),
-                            };
-                            spf_nhops.insert(*addr, nhop);
-                        }
+        'next_path: for p in &nhops.paths {
+            if p.is_empty() {
+                continue;
+            }
+            // Every node on the path (transit + destination) must advertise IPv6.
+            for &hop in p {
+                let Some(hop_sys_id) = top.lsp_map.get(&level).resolve(hop) else {
+                    continue 'next_path;
+                };
+                if !ipv6_capable.contains(hop_sys_id) {
+                    continue 'next_path;
+                }
+            }
+
+            let Some(nhop_id) = top.lsp_map.get(&level).resolve(p[0]) else {
+                continue;
+            };
+            let nhop_sys_id = *nhop_id;
+            let is_adjacency = p[0] == *node;
+            for (ifindex, link) in top.links.iter() {
+                if let Some(nbr) = link.state.nbrs.get(&level).get(&nhop_sys_id) {
+                    for addr in nbr.addr6l.iter() {
+                        let nhop = SpfNexthopV6 {
+                            ifindex: *ifindex,
+                            adjacency: is_adjacency,
+                            sys_id: Some(nhop_sys_id),
+                        };
+                        spf_nhops.insert(*addr, nhop);
                     }
                 }
             }
         }
 
-        if let Some(entries) = top.reach_map_v6.get(&level).get(sys_id) {
+        // No surviving paths after gating → don't install anything for this dest.
+        if spf_nhops.is_empty() {
+            continue;
+        }
+
+        if let Some(entries) = top.reach_map_v6.get(&level).get(&dest_sys_id) {
             for entry in entries.iter() {
                 let route = SpfRouteV6 {
                     metric: nhops.cost + entry.metric,
@@ -1668,6 +1709,24 @@ fn build_rib_from_spf_v6(
     }
 
     rib
+}
+
+// Walk the LSDB and collect SysIds whose Protocols-Supported TLV (TLV 129)
+// includes the IPv6 NLPID (0x8E). Used by strict NLPID gating in
+// build_rib_from_spf_v6.
+fn ipv6_capable_set(lsdb: &Lsdb) -> BTreeSet<IsisSysId> {
+    let ipv6_proto: u8 = IsisProto::Ipv6.into();
+    let mut set = BTreeSet::new();
+    for (lsp_id, lsa) in lsdb.iter() {
+        for tlv in &lsa.lsp.tlvs {
+            if let IsisTlv::ProtoSupported(ps) = tlv
+                && ps.nlpids.contains(&ipv6_proto)
+            {
+                set.insert(lsp_id.sys_id());
+            }
+        }
+    }
+    set
 }
 
 /// Apply routing updates to RIB subsystem
@@ -1713,8 +1772,9 @@ fn perform_spf_calculation(top: &mut IsisTop, level: Level) {
     let mut ilm = build_adjacency_ilm(top, level, &adjacency_sids);
 
     if let Some(source) = source_node {
-        // Run SPF algorithm
-        let spf_result = spf::spf(&graph, source, &spf::SpfOpt::default());
+        // Run SPF in full-path mode so the IPv6 builder can apply RFC 1195 §5
+        // strict NLPID gating across every transit node, not just the first hop.
+        let spf_result = spf::spf(&graph, source, &spf::SpfOpt::full_path());
 
         // Build IPv4 + IPv6 RIBs from the same SPF result (single-topology).
         let rib = build_rib_from_spf(top, level, source, &spf_result);

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -23,7 +23,7 @@ use crate::rib::{Link, MacAddr};
 
 use super::config::IsisConfig;
 use super::ifsm::{self, has_level};
-use super::inst::{PacketMessage, ReachMap};
+use super::inst::{PacketMessage, ReachMap, ReachMapV6};
 use super::neigh::Neighbor;
 use super::network::{read_packet, write_packet};
 use super::socket::isis_socket;
@@ -125,6 +125,7 @@ pub struct LinkTop<'a> {
     pub local_pool: &'a mut Option<LabelPool>,
     pub hostname: &'a mut Levels<Hostname>,
     pub reach_map: &'a mut Levels<Afis<ReachMap>>,
+    pub reach_map_v6: &'a mut Levels<ReachMapV6>,
     pub label_map: &'a mut Levels<IsisLabelMap>,
     pub spf_timer: &'a mut Levels<Option<Timer>>,
 }

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -104,6 +104,7 @@ pub struct LspView<'a> {
     pub cap: Option<&'a IsisTlvRouterCap>,
     pub hostname: Option<&'a IsisTlvHostname>,
     pub ip_reach: Option<&'a IsisTlvExtIpReach>,
+    pub ipv6_reach: Option<&'a IsisTlvIpv6Reach>,
 }
 
 pub fn lsp_view<'a>(lsp: &'a IsisLsp) -> LspView<'a> {
@@ -118,6 +119,9 @@ pub fn lsp_view<'a>(lsp: &'a IsisLsp) -> LspView<'a> {
             }
             IsisTlv::ExtIpReach(ip_reach) => {
                 view.ip_reach = Some(ip_reach);
+            }
+            IsisTlv::Ipv6Reach(ipv6_reach) => {
+                view.ipv6_reach = Some(ipv6_reach);
             }
             _ => {
                 //
@@ -208,6 +212,12 @@ fn update_lsp(top: &mut LinkTop, level: Level, key: IsisLspId, lsp: &IsisLsp) {
         top.reach_map
             .get_mut(&level)
             .get_mut(&Afi::Ip)
+            .insert(key.sys_id(), tlv.entries.clone());
+    }
+
+    if let Some(tlv) = lsp.ipv6_reach {
+        top.reach_map_v6
+            .get_mut(&level)
             .insert(key.sys_id(), tlv.entries.clone());
     }
 }

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright 2025-2026 Kunihiro Ishiguro
 
+use std::collections::BTreeSet;
 use std::fmt::Write;
 
-//use isis_packet::*;
+use isis_packet::{IsisProto, IsisSysId, IsisTlv, Nsap};
 use serde::Serialize;
 
 use super::{Isis, inst::ShowCallback};
 
 use crate::config::Args;
+use crate::isis::link::Afi;
 use crate::isis::{Level, hostname, link, neigh};
 // use spf_rs as spf;
 use crate::spf;
@@ -237,54 +239,412 @@ fn show_isis_route(
         Ok(serde_json::to_string_pretty(&routes_json)
             .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize routes: {}\"}}", e)))
     } else {
-        // Text output (existing implementation)
-        let mut buf = String::new();
+        write_show_isis_route_text(isis)
+    }
+}
 
-        // Helper closure to format and write out routes for a given level
-        let mut write_routes = |level: &Level| -> std::fmt::Result {
-            for (prefix, route) in isis.rib.get(level).iter() {
-                let mut shown = false;
-                for (addr, nhop) in route.nhops.iter() {
-                    let sid = if let Some(sid) = route.sid {
-                        if nhop.adjacency {
-                            format!(", label {} implicit null", sid)
-                        } else {
-                            format!(", label {}", sid)
-                        }
-                    } else {
-                        String::from("")
-                    };
-                    if !shown {
-                        writeln!(
-                            buf,
-                            "{:<20} [{}] via {}, {}{}",
-                            prefix.to_string(),
-                            route.metric,
-                            addr,
-                            isis.ifname(nhop.ifindex),
-                            sid
-                        )?;
-                        shown = true;
-                    } else {
-                        writeln!(
-                            buf,
-                            "                     [{}] via {}, {}{}",
-                            route.metric,
-                            addr,
-                            isis.ifname(nhop.ifindex),
-                            sid
-                        )?;
-                    }
-                }
-            }
-            Ok(())
+fn write_show_isis_route_text(isis: &Isis) -> std::result::Result<String, std::fmt::Error> {
+    let mut buf = String::new();
+    let local_sys_id = isis.config.net.sys_id();
+    writeln!(buf, "Area {}:", format_area_id(&isis.config.net))?;
+
+    let mut wrote_any_level = false;
+    for level in &[Level::L1, Level::L2] {
+        let Some(spf_result) = isis.spf_result.get(level).as_ref() else {
+            continue;
+        };
+        if spf_result.is_empty() {
+            continue;
+        }
+        wrote_any_level = true;
+
+        let level_long = match level {
+            Level::L1 => "level-1",
+            Level::L2 => "level-2",
+        };
+        let level_short = match level {
+            Level::L1 => "L1",
+            Level::L2 => "L2",
         };
 
-        write_routes(&Level::L1)?;
-        write_routes(&Level::L2)?;
+        // IPv4 SPF tree
+        writeln!(buf)?;
+        writeln!(buf, "IS-IS paths to {} routers that speak IP", level_long)?;
+        write_spf_tree(&mut buf, isis, level, &local_sys_id, spf_result, false)?;
 
-        Ok(buf)
+        // IPv4 RIB
+        writeln!(buf)?;
+        writeln!(buf, "IS-IS {} IPv4 routing table:", level_short)?;
+        writeln!(buf)?;
+        write_rib_v4(&mut buf, isis, level)?;
+
+        // IPv6 SPF tree (only IPv6-capable nodes)
+        writeln!(buf)?;
+        writeln!(buf, "IS-IS paths to {} routers that speak IPv6", level_long)?;
+        write_spf_tree(&mut buf, isis, level, &local_sys_id, spf_result, true)?;
+
+        // IPv6 RIB
+        writeln!(buf)?;
+        writeln!(buf, "IS-IS {} IPv6 routing table:", level_short)?;
+        writeln!(buf)?;
+        write_rib_v6(&mut buf, isis, level)?;
     }
+
+    if !wrote_any_level {
+        writeln!(buf, "(no SPF result yet)")?;
+    }
+    Ok(buf)
+}
+
+fn format_area_id(net: &Nsap) -> String {
+    // Render as <afi>.<area_id_bytes_hex_pairs>, the standard IS-IS area form.
+    let mut s = format!("{:02x}", net.afi);
+    for (i, b) in net.area_id.iter().enumerate() {
+        if i % 2 == 0 {
+            s.push('.');
+        }
+        s.push_str(&format!("{:02x}", b));
+    }
+    s
+}
+
+fn hostname_for(isis: &Isis, level: &Level, sys_id: &IsisSysId) -> String {
+    isis.hostname
+        .get(level)
+        .get(sys_id)
+        .map(|(name, _)| name.clone())
+        .unwrap_or_else(|| sys_id.to_string())
+}
+
+// Find the local interface name for a directly-adjacent SysId at the given
+// level, by walking link state. Returns "-" if no adjacency is found.
+fn ifname_for_neighbor(isis: &Isis, level: &Level, sys_id: &IsisSysId) -> String {
+    for (ifindex, link) in isis.links.iter() {
+        if link.state.nbrs.get(level).get(sys_id).is_some() {
+            return isis.ifname(*ifindex);
+        }
+    }
+    String::from("-")
+}
+
+fn ipv6_capable_set_show(isis: &Isis, level: &Level) -> BTreeSet<IsisSysId> {
+    let ipv6_proto: u8 = IsisProto::Ipv6.into();
+    let mut set = BTreeSet::new();
+    for (lsp_id, lsa) in isis.lsdb.get(level).iter() {
+        for tlv in &lsa.lsp.tlvs {
+            if let IsisTlv::ProtoSupported(ps) = tlv
+                && ps.nlpids.contains(&ipv6_proto)
+            {
+                set.insert(lsp_id.sys_id());
+            }
+        }
+    }
+    set
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_spf_tree(
+    buf: &mut String,
+    isis: &Isis,
+    level: &Level,
+    local_sys_id: &IsisSysId,
+    spf_result: &std::collections::BTreeMap<usize, spf::Path>,
+    ipv6: bool,
+) -> std::fmt::Result {
+    // Column widths chosen to fit the typical reference output.
+    const W_VERTEX: usize = 22;
+    const W_TYPE: usize = 13;
+    const W_METRIC: usize = 7;
+    const W_NEXTHOP: usize = 9;
+    const W_INTERFACE: usize = 10;
+
+    writeln!(
+        buf,
+        " {:<wv$} {:<wt$} {:<wm$} {:<wn$} {:<wi$} Parent",
+        "Vertex",
+        "Type",
+        "Metric",
+        "Next-Hop",
+        "Interface",
+        wv = W_VERTEX,
+        wt = W_TYPE,
+        wm = W_METRIC,
+        wn = W_NEXTHOP,
+        wi = W_INTERFACE,
+    )?;
+    let total = 1 + W_VERTEX + 1 + W_TYPE + 1 + W_METRIC + 1 + W_NEXTHOP + 1 + W_INTERFACE + 1 + 8;
+    writeln!(buf, " {}", "-".repeat(total - 2))?;
+
+    // For IPv6 trees, gate by NLPID-capable set per RFC 1195 §5 — same logic
+    // as build_rib_from_spf_v6 so the tree mirrors what's actually installed.
+    let ipv6_capable = if ipv6 {
+        Some(ipv6_capable_set_show(isis, level))
+    } else {
+        None
+    };
+
+    let mut nodes: Vec<(usize, &spf::Path)> = spf_result.iter().map(|(k, v)| (*k, v)).collect();
+    nodes.sort_by_key(|(_, p)| (p.cost, p.id));
+
+    let local_hostname = hostname_for(isis, level, local_sys_id);
+
+    for (node_id, path) in &nodes {
+        let Some(node_sys_id) = isis.lsp_map.get(level).resolve(*node_id) else {
+            continue;
+        };
+        let node_sys_id = *node_sys_id;
+        let is_self = node_sys_id == *local_sys_id;
+        if let Some(set) = &ipv6_capable
+            && !set.contains(&node_sys_id)
+        {
+            continue;
+        }
+        let node_hostname = hostname_for(isis, level, &node_sys_id);
+
+        // First-hop hostname / interface (blank for self).
+        let (nexthop_str, iface_str, parent_str) = if is_self {
+            (String::new(), String::new(), String::new())
+        } else {
+            // Each path = [first_hop, ..., destination]; take the first as
+            // first-hop and the previous-to-last as parent. For a direct
+            // neighbor (path len 1), parent is the local node.
+            let p = path.paths.first().cloned().unwrap_or_default();
+            if p.is_empty() {
+                (String::new(), String::new(), local_hostname.clone())
+            } else {
+                let first_hop_sys_id = isis
+                    .lsp_map
+                    .get(level)
+                    .resolve(p[0])
+                    .copied()
+                    .unwrap_or(node_sys_id);
+                let parent_sys_id = if p.len() <= 1 {
+                    *local_sys_id
+                } else {
+                    isis.lsp_map
+                        .get(level)
+                        .resolve(p[p.len() - 2])
+                        .copied()
+                        .unwrap_or(*local_sys_id)
+                };
+                (
+                    hostname_for(isis, level, &first_hop_sys_id),
+                    ifname_for_neighbor(isis, level, &first_hop_sys_id),
+                    hostname_for(isis, level, &parent_sys_id),
+                )
+            }
+        };
+
+        // Vertex row for the node itself.
+        if is_self {
+            // Match reference: just the hostname, all other columns blank.
+            writeln!(buf, " {}", node_hostname)?;
+        } else {
+            writeln!(
+                buf,
+                " {:<wv$} {:<wt$} {:<wm$} {:<wn$} {:<wi$} {}(0)",
+                node_hostname,
+                "TE-IS",
+                path.cost,
+                nexthop_str,
+                iface_str,
+                parent_str,
+                wv = W_VERTEX,
+                wt = W_TYPE,
+                wm = W_METRIC,
+                wn = W_NEXTHOP,
+                wi = W_INTERFACE,
+            )?;
+        }
+
+        // Prefix rows hanging off this node.
+        if !ipv6 {
+            if let Some(entries) = isis.reach_map.get(level).get(&Afi::Ip).get(&node_sys_id) {
+                for entry in entries.iter() {
+                    let type_str = if is_self { "IP internal" } else { "IP TE" };
+                    let total_metric = path.cost + entry.metric;
+                    let (nh, iface) = if is_self {
+                        (String::new(), String::new())
+                    } else {
+                        (nexthop_str.clone(), iface_str.clone())
+                    };
+                    writeln!(
+                        buf,
+                        " {:<wv$} {:<wt$} {:<wm$} {:<wn$} {:<wi$} {}(0)",
+                        entry.prefix.trunc().to_string(),
+                        type_str,
+                        total_metric,
+                        nh,
+                        iface,
+                        node_hostname,
+                        wv = W_VERTEX,
+                        wt = W_TYPE,
+                        wm = W_METRIC,
+                        wn = W_NEXTHOP,
+                        wi = W_INTERFACE,
+                    )?;
+                }
+            }
+        } else if let Some(entries) = isis.reach_map_v6.get(level).get(&node_sys_id) {
+            for entry in entries.iter() {
+                let total_metric = path.cost + entry.metric;
+                let (nh, iface) = if is_self {
+                    (String::new(), String::new())
+                } else {
+                    (nexthop_str.clone(), iface_str.clone())
+                };
+                writeln!(
+                    buf,
+                    " {:<wv$} {:<wt$} {:<wm$} {:<wn$} {:<wi$} {}(0)",
+                    entry.prefix.trunc().to_string(),
+                    "IP6 internal",
+                    total_metric,
+                    nh,
+                    iface,
+                    node_hostname,
+                    wv = W_VERTEX,
+                    wt = W_TYPE,
+                    wm = W_METRIC,
+                    wn = W_NEXTHOP,
+                    wi = W_INTERFACE,
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn write_rib_v4(buf: &mut String, isis: &Isis, level: &Level) -> std::fmt::Result {
+    const W_PREFIX: usize = 18;
+    const W_METRIC: usize = 7;
+    const W_INTERFACE: usize = 10;
+    const W_NEXTHOP: usize = 16;
+
+    writeln!(
+        buf,
+        " {:<wp$} {:<wm$} {:<wi$} {:<wn$} Label(s)",
+        "Prefix",
+        "Metric",
+        "Interface",
+        "Nexthop",
+        wp = W_PREFIX,
+        wm = W_METRIC,
+        wi = W_INTERFACE,
+        wn = W_NEXTHOP,
+    )?;
+    let total = 1 + W_PREFIX + 1 + W_METRIC + 1 + W_INTERFACE + 1 + W_NEXTHOP + 1 + 9;
+    writeln!(buf, " {}", "-".repeat(total - 2))?;
+
+    let mut entries: Vec<_> = isis.rib.get(level).iter().collect();
+    entries.sort_by_key(|(p, _)| **p);
+
+    for (prefix, route) in entries {
+        if route.nhops.is_empty() {
+            // Locally connected / no nexthop.
+            let label = route
+                .sid
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "-".into());
+            writeln!(
+                buf,
+                " {:<wp$} {:<wm$} {:<wi$} {:<wn$} {}",
+                prefix.to_string(),
+                route.metric,
+                "-",
+                "-",
+                label,
+                wp = W_PREFIX,
+                wm = W_METRIC,
+                wi = W_INTERFACE,
+                wn = W_NEXTHOP,
+            )?;
+            continue;
+        }
+        for (addr, nhop) in route.nhops.iter() {
+            let label = if let Some(sid) = route.sid {
+                if nhop.adjacency {
+                    format!("{} (impl-null)", sid)
+                } else {
+                    sid.to_string()
+                }
+            } else {
+                "-".into()
+            };
+            writeln!(
+                buf,
+                " {:<wp$} {:<wm$} {:<wi$} {:<wn$} {}",
+                prefix.to_string(),
+                route.metric,
+                isis.ifname(nhop.ifindex),
+                addr,
+                label,
+                wp = W_PREFIX,
+                wm = W_METRIC,
+                wi = W_INTERFACE,
+                wn = W_NEXTHOP,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn write_rib_v6(buf: &mut String, isis: &Isis, level: &Level) -> std::fmt::Result {
+    const W_PREFIX: usize = 22;
+    const W_METRIC: usize = 7;
+    const W_INTERFACE: usize = 10;
+    const W_NEXTHOP: usize = 26;
+
+    writeln!(
+        buf,
+        " {:<wp$} {:<wm$} {:<wi$} {:<wn$} Label(s)",
+        "Prefix",
+        "Metric",
+        "Interface",
+        "Nexthop",
+        wp = W_PREFIX,
+        wm = W_METRIC,
+        wi = W_INTERFACE,
+        wn = W_NEXTHOP,
+    )?;
+    let total = 1 + W_PREFIX + 1 + W_METRIC + 1 + W_INTERFACE + 1 + W_NEXTHOP + 1 + 9;
+    writeln!(buf, " {}", "-".repeat(total - 2))?;
+
+    let mut entries: Vec<_> = isis.rib_v6.get(level).iter().collect();
+    entries.sort_by_key(|(p, _)| **p);
+
+    for (prefix, route) in entries {
+        if route.nhops.is_empty() {
+            writeln!(
+                buf,
+                " {:<wp$} {:<wm$} {:<wi$} {:<wn$} -",
+                prefix.to_string(),
+                route.metric,
+                "-",
+                "-",
+                wp = W_PREFIX,
+                wm = W_METRIC,
+                wi = W_INTERFACE,
+                wn = W_NEXTHOP,
+            )?;
+            continue;
+        }
+        for (addr, nhop) in route.nhops.iter() {
+            writeln!(
+                buf,
+                " {:<wp$} {:<wm$} {:<wi$} {:<wn$} -",
+                prefix.to_string(),
+                route.metric,
+                isis.ifname(nhop.ifindex),
+                addr,
+                wp = W_PREFIX,
+                wm = W_METRIC,
+                wi = W_INTERFACE,
+                wn = W_NEXTHOP,
+            )?;
+        }
+    }
+    Ok(())
 }
 
 // JSON structures for ISIS database


### PR DESCRIPTION
## Summary

End-to-end IS-IS IPv6 single-topology support (RFC 1195 §5). Six commits, each independently mergeable in principle but stacked here as one PR for context.

**1. IIH IPv6 emit** (`11f6f38`)
`hello_generate` / `hello_p2p_generate` emit TLV 232 (link-local IfAddr, RFC 5308) and TLV 233 (global IfAddr, non-standard) when `link.config.enable.v6`. Receive side was already wired (`packet.rs:81-84` populates `Neighbor::addr6l` / `addr6`) — this completes the bidirectional exchange.

**2. SPF data types + RIB v6 storage** (`301d9cc`)
`SpfRouteV6` / `SpfNexthopV6` mirror the v4 types but key on `Ipv6Addr` for ECMP-friendly nexthop maps. `Isis::rib_v6 / IsisTop::rib_v6` per-level storage.

**3. SPF→RIB v6 build** (`287896f`)
- `ReachMapV6` mirrors `ReachMap` for `IsisTlvIpv6ReachEntry`.
- `LspView::ipv6_reach` + lsdb processor inserts into `reach_map_v6`.
- `nhop_to_nexthop_uni_v6` explicitly sets `ifindex` (link-local v6 nexthops are unrouteable without scope).
- `make_rib_entry_v6`, `diff_apply_v6` parallel the v4 helpers.
- `build_rib_from_spf_v6` walks the same SPF tree, uses `Neighbor::addr6l` for nexthops, emits `Message::Ipv6Add/Del`.
- `apply_routing_updates` and `perform_spf_calculation` now produce both v4 and v6 RIBs.

**4. Strict NLPID gating** (`a82157f`)
RFC 1195 §5: every transit node along the path must advertise IPv6 NLPID. Switch SPF to `SpfOpt::full_path()` so paths carry full transit lists; precompute `BTreeSet<IsisSysId>` of IPv6-capable nodes; drop any path containing a non-capable hop.

**5. Show command rewrite** (`36e44f8`)
`show isis route` text path produces a per-(level, AF) FRR-style layout: SPF tree (Vertex / Type / Metric / Next-Hop / Interface / Parent) followed by the installed RIB (Prefix / Metric / Interface / Nexthop / Label(s)). IPv6 SPF tree applies the same NLPID gating as the v6 RIB build. JSON path unchanged.

**6. BDD scenario** (`fc066e6`)
`bdd/tests/features/isis_ipv6.feature`: two zebra-rs in netns, IS-IS L2 over a shared bridge, verifying reciprocal IPv6 routes via end-to-end ping and link-bounce recovery.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd`
- [x] Manual: `show isis adjacency` shows the peer up; `show isis neighbor` reflects peer's link-local + global IPv6.
- [ ] BDD `make isis_ipv6`: setup scenario passes (link-local pings work); reciprocal-route scenarios currently fail — IS-IS-installed v6 routes don't reach the kernel. Diagnostic ongoing; the SRv6 nexthop resolver fix on a separate branch is part of the resolution work.

## Known limitations

- Multi-area inter-area IPv6 leaks not implemented. Single-area only for v1.
- Multi-topology (RFC 5120) is a follow-up — single-topology shares one SPF tree across v4 and v6.
- IPv6 prefix-SID / SRv6-IS-IS not wired in the SPF→RIB v6 path (`SpfRouteV6.sid` / `prefix_sid` left `None`).

Generated with [Claude Code](https://claude.com/claude-code)