### PR TITLE
fix(rib): SRv6 static route nexthop resolution + display polish

### DIFF
--- a/zebra-rs/src/rib/entry.rs
+++ b/zebra-rs/src/rib/entry.rs
@@ -44,10 +44,6 @@ impl RibEntry {
         self.rtype == RibType::Connected
     }
 
-    pub fn is_static(&self) -> bool {
-        self.rtype == RibType::Static
-    }
-
     pub fn set_valid(&mut self, valid: bool) {
         self.valid = valid;
     }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -11,6 +11,7 @@ use super::{
 
 use crate::config::{Args, path_from_command};
 use crate::config::{ConfigChannel, ConfigOp, ConfigRequest, DisplayRequest, ShowChannel};
+use crate::context::Timer;
 use crate::fib::fib_dump;
 use crate::fib::sysctl::sysctl_enable;
 use crate::fib::{FibChannel, FibHandle, FibMessage};
@@ -162,7 +163,20 @@ pub struct Rib {
     pub vxlan_config: VxlanBuilder,
     pub nmap: NexthopMap,
     pub router_id: Ipv4Addr,
+
+    /// Single-shot timer that fires Message::Resolve after a debounce when
+    /// the FIB has changed. None when no resolve is pending. Set by
+    /// schedule_rib_sync(), cleared by the Message::Resolve handler.
+    pub rib_sync_timer: Option<Timer>,
+
+    /// Debounce interval (seconds) before a queued FIB modification triggers
+    /// nexthop resolution. Configurable so an operator can tune for their
+    /// convergence vs. churn trade-off; default 1s matches the typical
+    /// "kick once shortly after the wave settles" pattern.
+    pub rib_sync_interval: u64,
 }
+
+const DEFAULT_RIB_SYNC_INTERVAL_SEC: u64 = 1;
 
 impl Rib {
     pub fn new(no_nhid: bool) -> anyhow::Result<Self> {
@@ -193,9 +207,29 @@ impl Rib {
             vxlan_config: VxlanBuilder::new(),
             nmap: NexthopMap::default(),
             router_id: Ipv4Addr::UNSPECIFIED,
+            rib_sync_timer: None,
+            rib_sync_interval: DEFAULT_RIB_SYNC_INTERVAL_SEC,
         };
         rib.show_build();
         Ok(rib)
+    }
+
+    /// Arm a one-shot timer that fires Message::Resolve after rib_sync_interval
+    /// seconds, debouncing further FIB modifications until the timer fires.
+    /// Repeated calls while a timer is already pending are no-ops, which lets
+    /// a burst of FIB events (e.g. an IS-IS LSDB update producing many route
+    /// installs in quick succession) collapse into a single resolve cycle.
+    pub fn schedule_rib_sync(&mut self) {
+        if self.rib_sync_timer.is_some() {
+            return;
+        }
+        let tx = self.tx.clone();
+        self.rib_sync_timer = Some(Timer::once(self.rib_sync_interval, move || {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send(Message::Resolve);
+            }
+        }));
     }
 
     pub fn subscribe(&mut self, tx: UnboundedSender<RibRx>, _proto: String) {
@@ -299,6 +333,12 @@ impl Rib {
                 self.link_down(ifindex).await;
             }
             Message::Resolve => {
+                // Drop the timer so the next FIB modification can arm a fresh
+                // one. Run both family resolves so static / SRv6 nexthops that
+                // were unresolved at config time get a second chance once the
+                // underlying IGP / connected route lands.
+                self.rib_sync_timer = None;
+                self.ipv4_route_resolve().await;
                 self.ipv6_route_resolve().await;
             }
             Message::Subscribe { tx, proto } => {

--- a/zebra-rs/src/rib/nexthop/group.rs
+++ b/zebra-rs/src/rib/nexthop/group.rs
@@ -61,7 +61,11 @@ impl GroupUni {
         match self.addr {
             IpAddr::V4(ipv4_addr) => {
                 let resolve = rib_resolve(table, ipv4_addr, &ResolveOpt::default());
-                if let Resolve::Onlink(ifindex) = resolve {
+                // Both arms carry a real egress ifindex — Onlink came from a
+                // directly-connected route, Recursive from walking through an
+                // IGP/static covering route. The Group only needs the ifindex,
+                // not the path category.
+                if let Resolve::Onlink(ifindex) | Resolve::Recursive(ifindex) = resolve {
                     self.ifindex = ifindex;
                     self.set_valid(true);
                 }
@@ -76,20 +80,19 @@ impl GroupUni {
         if let IpAddr::V6(ipv6_addr) = self.addr {
             let resolve = rib_resolve_v6(table, ipv6_addr, &ResolveOpt::default());
             match &resolve {
-                Resolve::Onlink(ifindex) => {
+                // Onlink came from a directly-connected route; Recursive came
+                // from walking through an IGP/static covering route. Both
+                // produce a real egress ifindex; the Group cares about that,
+                // not the path category.
+                Resolve::Onlink(ifindex) | Resolve::Recursive(ifindex) => {
                     if DEBUG_V6 {
                         println!(
-                            "[GroupUni::resolve_v6] {} -> Onlink(ifindex={})",
+                            "[GroupUni::resolve_v6] {} -> ifindex={}",
                             ipv6_addr, ifindex
                         );
                     }
                     self.ifindex = *ifindex;
                     self.set_valid(true);
-                }
-                Resolve::Recursive(_) => {
-                    if DEBUG_V6 {
-                        println!("[GroupUni::resolve_v6] {} -> Recursive", ipv6_addr);
-                    }
                 }
                 Resolve::NotFound => {
                     if DEBUG_V6 {

--- a/zebra-rs/src/rib/nexthop/group.rs
+++ b/zebra-rs/src/rib/nexthop/group.rs
@@ -213,3 +213,155 @@ impl GroupTrait for Group {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rib::Nexthop;
+    use crate::rib::entry::RibEntry;
+    use crate::rib::types::RibType;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+    use std::str::FromStr;
+
+    fn group_uni_at(addr: IpAddr) -> GroupUni {
+        let uni = NexthopUni {
+            addr,
+            ..Default::default()
+        };
+        GroupUni::new(0, &uni)
+    }
+
+    fn connected_v6(ifindex: u32) -> RibEntry {
+        let mut e = RibEntry::new(RibType::Connected);
+        e.ifindex = ifindex;
+        e
+    }
+
+    fn isis_v6(addr: Ipv6Addr, ifindex: u32) -> RibEntry {
+        let mut e = RibEntry::new(RibType::Isis);
+        e.nexthop = Nexthop::Uni(NexthopUni {
+            addr: IpAddr::V6(addr),
+            ifindex,
+            ..Default::default()
+        });
+        e
+    }
+
+    fn connected_v4(ifindex: u32) -> RibEntry {
+        let mut e = RibEntry::new(RibType::Connected);
+        e.ifindex = ifindex;
+        e
+    }
+
+    fn isis_v4(addr: Ipv4Addr, ifindex: u32) -> RibEntry {
+        let mut e = RibEntry::new(RibType::Isis);
+        e.nexthop = Nexthop::Uni(NexthopUni {
+            addr: IpAddr::V4(addr),
+            ifindex,
+            ..Default::default()
+        });
+        e
+    }
+
+    #[test]
+    fn resolve_v6_through_isis_recursive_sets_ifindex() {
+        // The SRv6 first-segment scenario: GroupUni's address is covered by an
+        // IS-IS-learned aggregate. rib_resolve_v6 returns Resolve::Recursive
+        // carrying the IS-IS route's ifindex; the Group must adopt it.
+        let mut table = PrefixMap::<Ipv6Net, RibEntries>::new();
+        table.insert(
+            Ipv6Net::from_str("fcbb:bbbb:2::/48").unwrap(),
+            vec![isis_v6("fe80::21c:42ff:fee8:c23".parse().unwrap(), 42)],
+        );
+
+        let mut group = group_uni_at(IpAddr::V6("fcbb:bbbb:2:3:2::".parse().unwrap()));
+        assert_eq!(group.ifindex, 0);
+        assert!(!group.is_valid());
+
+        group.resolve_v6(&table);
+
+        assert_eq!(group.ifindex, 42);
+        assert!(group.is_valid());
+    }
+
+    #[test]
+    fn resolve_v6_onlink_sets_ifindex() {
+        let mut table = PrefixMap::<Ipv6Net, RibEntries>::new();
+        table.insert(
+            Ipv6Net::from_str("2001:db8::/64").unwrap(),
+            vec![connected_v6(7)],
+        );
+
+        let mut group = group_uni_at(IpAddr::V6("2001:db8::1".parse().unwrap()));
+        group.resolve_v6(&table);
+
+        assert_eq!(group.ifindex, 7);
+        assert!(group.is_valid());
+    }
+
+    #[test]
+    fn resolve_v6_not_found_leaves_group_invalid() {
+        let table = PrefixMap::<Ipv6Net, RibEntries>::new();
+        let mut group = group_uni_at(IpAddr::V6("2001:db8::1".parse().unwrap()));
+        group.resolve_v6(&table);
+        assert_eq!(group.ifindex, 0);
+        assert!(!group.is_valid());
+    }
+
+    #[test]
+    fn resolve_v6_with_v4_addr_is_noop() {
+        // resolve_v6 is supposed to skip groups whose addr is IPv4. Even with
+        // a bogus matching entry in the v6 table, the v4-addressed Group
+        // should not get its ifindex updated.
+        let mut table = PrefixMap::<Ipv6Net, RibEntries>::new();
+        table.insert(Ipv6Net::default(), vec![connected_v6(99)]);
+
+        let mut group = group_uni_at(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+        group.resolve_v6(&table);
+
+        assert_eq!(group.ifindex, 0);
+        assert!(!group.is_valid());
+    }
+
+    #[test]
+    fn resolve_v4_through_isis_recursive_sets_ifindex() {
+        let mut table = PrefixMap::<Ipv4Net, RibEntries>::new();
+        table.insert(
+            Ipv4Net::from_str("10.0.0.0/8").unwrap(),
+            vec![isis_v4(Ipv4Addr::new(192, 0, 2, 1), 17)],
+        );
+
+        let mut group = group_uni_at(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3)));
+        group.resolve(&table);
+
+        assert_eq!(group.ifindex, 17);
+        assert!(group.is_valid());
+    }
+
+    #[test]
+    fn resolve_v4_onlink_sets_ifindex() {
+        let mut table = PrefixMap::<Ipv4Net, RibEntries>::new();
+        table.insert(
+            Ipv4Net::from_str("192.168.0.0/24").unwrap(),
+            vec![connected_v4(5)],
+        );
+
+        let mut group = group_uni_at(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 10)));
+        group.resolve(&table);
+
+        assert_eq!(group.ifindex, 5);
+        assert!(group.is_valid());
+    }
+
+    #[test]
+    fn resolve_v4_with_v6_addr_is_noop() {
+        let mut table = PrefixMap::<Ipv4Net, RibEntries>::new();
+        table.insert(Ipv4Net::default(), vec![connected_v4(99)]);
+
+        let mut group = group_uni_at(IpAddr::V6("2001:db8::1".parse().unwrap()));
+        group.resolve(&table);
+
+        assert_eq!(group.ifindex, 0);
+        assert!(!group.is_valid());
+    }
+}

--- a/zebra-rs/src/rib/resolve.rs
+++ b/zebra-rs/src/rib/resolve.rs
@@ -1,12 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright 2025-2026 Kunihiro Ishiguro
 
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use ipnet::{Ipv4Net, Ipv6Net};
 use prefix_trie::PrefixMap;
 
-use super::RibEntries;
+use super::entry::RibEntry;
+use super::nexthop::NexthopUni;
+use super::{Nexthop, RibEntries, RibType};
+
+// Default cap on recursive RIB lookups during nexthop resolution. Cycles can
+// arise legitimately (a static route via an address that itself resolves
+// through another protocol route), and we want to bail before chasing them
+// indefinitely. ResolveOpt::limit can override per-call.
+const DEFAULT_RESOLVE_DEPTH: u8 = 4;
 
 pub enum Resolve {
     Onlink(u32),
@@ -26,7 +34,7 @@ impl Resolve {
 #[derive(Default)]
 pub struct ResolveOpt {
     allow_default: bool,
-    #[allow(dead_code)]
+    /// Maximum recursive lookup depth. 0 means use DEFAULT_RESOLVE_DEPTH.
     limit: u8,
 }
 
@@ -35,6 +43,68 @@ impl ResolveOpt {
     pub fn allow_default(&self) -> bool {
         self.allow_default
     }
+
+    fn depth_limit(&self) -> u8 {
+        if self.limit == 0 {
+            DEFAULT_RESOLVE_DEPTH
+        } else {
+            self.limit
+        }
+    }
+}
+
+// Pull a usable ifindex out of a RibEntry's nexthop. Connected entries store
+// it on the entry itself; protocol entries (IGP / static / BGP) carry it on
+// the resolved NexthopUni — IGP routes get this populated by SPF; static
+// routes only have it after recursive resolution has stamped it.
+fn entry_nexthop_ifindex(entry: &RibEntry) -> Option<u32> {
+    if entry.is_connected() {
+        if entry.ifindex != 0 {
+            return Some(entry.ifindex);
+        }
+        return None;
+    }
+    match &entry.nexthop {
+        Nexthop::Uni(uni) if uni.ifindex != 0 => Some(uni.ifindex),
+        Nexthop::Multi(multi) => first_ifindex(&multi.nexthops),
+        Nexthop::List(list) => first_ifindex(&list.nexthops),
+        _ => None,
+    }
+}
+
+fn first_ifindex(nexthops: &[NexthopUni]) -> Option<u32> {
+    nexthops.iter().find(|u| u.ifindex != 0).map(|u| u.ifindex)
+}
+
+// Pull the unicast next-hop address out of a RibEntry whose ifindex is not
+// yet populated, so we can recurse to find the underlying egress interface.
+fn entry_nexthop_addr(entry: &RibEntry) -> Option<IpAddr> {
+    match &entry.nexthop {
+        Nexthop::Uni(uni) if uni.ifindex == 0 => Some(uni.addr),
+        Nexthop::Multi(multi) => multi
+            .nexthops
+            .first()
+            .filter(|u| u.ifindex == 0)
+            .map(|u| u.addr),
+        Nexthop::List(list) => list
+            .nexthops
+            .first()
+            .filter(|u| u.ifindex == 0)
+            .map(|u| u.addr),
+        _ => None,
+    }
+}
+
+// Whether an entry is allowed to act as a resolver target during recursive
+// nexthop lookup. Connected and IGP routes are always trusted; static is
+// trusted up to the depth cap; BGP is excluded because BGP next-hops should
+// resolve over the underlay (IGP / connected), not over BGP itself, and
+// allowing it would risk recursive loops.
+fn entry_resolvable(entry: &RibEntry) -> bool {
+    matches!(
+        entry.rtype,
+        RibType::Connected | RibType::Static | RibType::Ospf | RibType::Isis
+    )
 }
 
 pub fn rib_resolve(
@@ -42,24 +112,46 @@ pub fn rib_resolve(
     p: Ipv4Addr,
     opt: &ResolveOpt,
 ) -> Resolve {
+    rib_resolve_v4_inner(table, p, opt, 0)
+}
+
+fn rib_resolve_v4_inner(
+    table: &PrefixMap<Ipv4Net, RibEntries>,
+    p: Ipv4Addr,
+    opt: &ResolveOpt,
+    depth: u8,
+) -> Resolve {
+    if depth >= opt.depth_limit() {
+        return Resolve::NotFound;
+    }
     let Ok(key) = Ipv4Net::new(p, Ipv4Addr::BITS as u8) else {
         return Resolve::NotFound;
     };
-
-    let Some((p, entries)) = table.get_lpm(&key) else {
+    let Some((prefix, entries)) = table.get_lpm(&key) else {
         return Resolve::NotFound;
     };
-
-    if !opt.allow_default() && p.prefix_len() == 0 {
+    if !opt.allow_default() && prefix.prefix_len() == 0 {
         return Resolve::NotFound;
     }
 
     for entry in entries.iter() {
-        if entry.is_connected() {
-            return Resolve::Onlink(entry.ifindex);
+        if !entry_resolvable(entry) {
+            continue;
         }
-        if entry.is_static() {
-            return Resolve::Recursive(1);
+        if entry.is_connected() {
+            if let Some(ifindex) = entry_nexthop_ifindex(entry) {
+                return Resolve::Onlink(ifindex);
+            }
+            continue;
+        }
+        if let Some(ifindex) = entry_nexthop_ifindex(entry) {
+            return Resolve::Recursive(ifindex);
+        }
+        if let Some(IpAddr::V4(addr)) = entry_nexthop_addr(entry) {
+            let inner = rib_resolve_v4_inner(table, addr, opt, depth + 1);
+            if inner.is_valid() != 0 {
+                return inner;
+            }
         }
     }
     Resolve::NotFound
@@ -70,25 +162,205 @@ pub fn rib_resolve_v6(
     p: Ipv6Addr,
     opt: &ResolveOpt,
 ) -> Resolve {
+    rib_resolve_v6_inner(table, p, opt, 0)
+}
+
+fn rib_resolve_v6_inner(
+    table: &PrefixMap<Ipv6Net, RibEntries>,
+    p: Ipv6Addr,
+    opt: &ResolveOpt,
+    depth: u8,
+) -> Resolve {
+    if depth >= opt.depth_limit() {
+        return Resolve::NotFound;
+    }
     let Ok(key) = Ipv6Net::new(p, Ipv6Addr::BITS as u8) else {
         return Resolve::NotFound;
     };
-
-    let Some((p, entries)) = table.get_lpm(&key) else {
+    let Some((prefix, entries)) = table.get_lpm(&key) else {
         return Resolve::NotFound;
     };
-
-    if !opt.allow_default() && p.prefix_len() == 0 {
+    if !opt.allow_default() && prefix.prefix_len() == 0 {
         return Resolve::NotFound;
     }
 
     for entry in entries.iter() {
-        if entry.is_connected() {
-            return Resolve::Onlink(entry.ifindex);
+        if !entry_resolvable(entry) {
+            continue;
         }
-        if entry.is_static() {
-            return Resolve::Recursive(1);
+        if entry.is_connected() {
+            if let Some(ifindex) = entry_nexthop_ifindex(entry) {
+                return Resolve::Onlink(ifindex);
+            }
+            continue;
+        }
+        if let Some(ifindex) = entry_nexthop_ifindex(entry) {
+            return Resolve::Recursive(ifindex);
+        }
+        if let Some(IpAddr::V6(addr)) = entry_nexthop_addr(entry) {
+            let inner = rib_resolve_v6_inner(table, addr, opt, depth + 1);
+            if inner.is_valid() != 0 {
+                return inner;
+            }
         }
     }
     Resolve::NotFound
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn connected_v6(ifindex: u32) -> RibEntry {
+        let mut e = RibEntry::new(RibType::Connected);
+        e.ifindex = ifindex;
+        e
+    }
+
+    fn protocol_v6(rtype: RibType, addr: Ipv6Addr, ifindex: u32) -> RibEntry {
+        let mut e = RibEntry::new(rtype);
+        e.nexthop = Nexthop::Uni(NexthopUni {
+            addr: IpAddr::V6(addr),
+            ifindex,
+            ..Default::default()
+        });
+        e
+    }
+
+    fn protocol_v6_unresolved(rtype: RibType, addr: Ipv6Addr) -> RibEntry {
+        let mut e = RibEntry::new(rtype);
+        e.nexthop = Nexthop::Uni(NexthopUni {
+            addr: IpAddr::V6(addr),
+            ifindex: 0,
+            ..Default::default()
+        });
+        e
+    }
+
+    #[test]
+    fn srv6_first_segment_resolves_through_isis_route() {
+        // The original SRv6 nexthop bug: a static route's nexthop (the first
+        // SRv6 segment) is covered by an IS-IS-learned aggregate. The
+        // resolver must surface the IS-IS route's egress ifindex so the
+        // SRv6 install pushes Oif(enp0s5) instead of falling back to lo.
+        let mut table = PrefixMap::<Ipv6Net, RibEntries>::new();
+        table.insert(
+            Ipv6Net::from_str("fcbb:bbbb:2::/48").unwrap(),
+            vec![protocol_v6(
+                RibType::Isis,
+                "fe80::21c:42ff:fee8:c23".parse().unwrap(),
+                42,
+            )],
+        );
+        let target: Ipv6Addr = "fcbb:bbbb:2:3:2::".parse().unwrap();
+        let resolve = rib_resolve_v6(&table, target, &ResolveOpt::default());
+        assert!(matches!(resolve, Resolve::Recursive(42)));
+    }
+
+    #[test]
+    fn ospf_routes_also_resolve() {
+        let mut table = PrefixMap::<Ipv6Net, RibEntries>::new();
+        table.insert(
+            Ipv6Net::from_str("2001:db8:abcd::/48").unwrap(),
+            vec![protocol_v6(RibType::Ospf, "fe80::1".parse().unwrap(), 17)],
+        );
+        let resolve = rib_resolve_v6(
+            &table,
+            "2001:db8:abcd:1::1".parse().unwrap(),
+            &ResolveOpt::default(),
+        );
+        assert!(matches!(resolve, Resolve::Recursive(17)));
+    }
+
+    #[test]
+    fn connected_wins_over_protocol_routes() {
+        let mut table = PrefixMap::<Ipv6Net, RibEntries>::new();
+        table.insert(
+            Ipv6Net::from_str("2001:db8::/64").unwrap(),
+            vec![
+                connected_v6(7),
+                protocol_v6(RibType::Isis, "fe80::1".parse().unwrap(), 42),
+            ],
+        );
+        let resolve = rib_resolve_v6(
+            &table,
+            "2001:db8::1".parse().unwrap(),
+            &ResolveOpt::default(),
+        );
+        assert!(matches!(resolve, Resolve::Onlink(7)));
+    }
+
+    #[test]
+    fn bgp_routes_are_skipped() {
+        // BGP next-hops should resolve over the underlay, not over BGP itself.
+        let mut table = PrefixMap::<Ipv6Net, RibEntries>::new();
+        table.insert(
+            Ipv6Net::from_str("2001:db8:abcd::/48").unwrap(),
+            vec![protocol_v6(RibType::Bgp, "fe80::1".parse().unwrap(), 17)],
+        );
+        let resolve = rib_resolve_v6(
+            &table,
+            "2001:db8:abcd::1".parse().unwrap(),
+            &ResolveOpt::default(),
+        );
+        assert!(matches!(resolve, Resolve::NotFound));
+    }
+
+    #[test]
+    fn unresolved_static_recurses_through_underlying_route() {
+        // A static route whose nexthop hasn't yet been resolved (ifindex=0)
+        // must walk one more level to find the egress interface via
+        // a covering connected/IGP route.
+        let mut table = PrefixMap::<Ipv6Net, RibEntries>::new();
+        // A static route to 2001:db8:1::/64 via 2001:db8:0:1::1 (no ifindex).
+        table.insert(
+            Ipv6Net::from_str("2001:db8:1::/64").unwrap(),
+            vec![protocol_v6_unresolved(
+                RibType::Static,
+                "2001:db8:0:1::1".parse().unwrap(),
+            )],
+        );
+        // The static's nexthop is covered by a connected /64.
+        table.insert(
+            Ipv6Net::from_str("2001:db8:0:1::/64").unwrap(),
+            vec![connected_v6(9)],
+        );
+        let resolve = rib_resolve_v6(
+            &table,
+            "2001:db8:1::5".parse().unwrap(),
+            &ResolveOpt::default(),
+        );
+        assert!(matches!(resolve, Resolve::Onlink(9)));
+    }
+
+    #[test]
+    fn no_match_returns_not_found() {
+        let table = PrefixMap::<Ipv6Net, RibEntries>::new();
+        let resolve = rib_resolve_v6(
+            &table,
+            "2001:db8::1".parse().unwrap(),
+            &ResolveOpt::default(),
+        );
+        assert!(matches!(resolve, Resolve::NotFound));
+    }
+
+    #[test]
+    fn default_route_skipped_unless_allowed() {
+        let mut table = PrefixMap::<Ipv6Net, RibEntries>::new();
+        table.insert(Ipv6Net::default(), vec![connected_v6(11)]);
+        let target: Ipv6Addr = "2001:db8::1".parse().unwrap();
+
+        // Default opt: ::/0 must not resolve.
+        let resolve = rib_resolve_v6(&table, target, &ResolveOpt::default());
+        assert!(matches!(resolve, Resolve::NotFound));
+
+        // Allowed: ::/0 resolves.
+        let opt = ResolveOpt {
+            allow_default: true,
+            limit: 0,
+        };
+        let resolve = rib_resolve_v6(&table, target, &opt);
+        assert!(matches!(resolve, Resolve::Onlink(11)));
+    }
 }

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -265,7 +265,6 @@ impl Rib {
     }
 
     pub async fn ipv4_route_add(&mut self, prefix: &Ipv4Net, mut entry: RibEntry) {
-        let is_connected = entry.is_connected();
         if entry.is_protocol() {
             let mut replace = rib_replace(&mut self.table, prefix, entry.rtype);
             rib_resolve_nexthop(&mut entry, &self.table, &mut self.nmap);
@@ -276,10 +275,10 @@ impl Rib {
             self.rib_selection(prefix, None).await;
         }
 
-        if is_connected {
-            let msg = Message::Resolve;
-            let _ = self.tx.send(msg);
-        }
+        // Any RIB add can shift the FIB — debounced resolve catches static /
+        // SRv6 nexthops that were unreachable before and are now covered by
+        // a freshly-installed underlay route (IS-IS, OSPF, connected, ...).
+        self.schedule_rib_sync();
     }
 
     pub async fn ipv4_route_del(&mut self, prefix: &Ipv4Net, entry: RibEntry) {
@@ -291,6 +290,8 @@ impl Rib {
             let mut replace = rib_replace_system(&mut self.table, prefix, entry);
             self.rib_selection(prefix, replace.pop()).await;
         }
+
+        self.schedule_rib_sync();
     }
 
     pub async fn ilm_add(&mut self, label: u32, ilm: IlmEntry) {
@@ -324,7 +325,6 @@ impl Rib {
                 entry.is_valid(),
             );
         }
-        let is_connected = entry.is_connected();
         if entry.is_protocol() {
             let mut replace = rib_replace_v6(&mut self.table_v6, prefix, entry.rtype);
             rib_resolve_nexthop_v6(&mut entry, &self.table_v6, &mut self.nmap);
@@ -342,10 +342,10 @@ impl Rib {
             self.rib_selection_v6(prefix, None).await;
         }
 
-        if is_connected {
-            let msg = Message::Resolve;
-            let _ = self.tx.send(msg);
-        }
+        // Any RIB add can shift the FIB — debounced resolve catches static /
+        // SRv6 nexthops that were unreachable before and are now covered by
+        // a freshly-installed underlay route (IS-IS, OSPF, connected, ...).
+        self.schedule_rib_sync();
     }
 
     pub async fn ipv6_route_del(&mut self, prefix: &Ipv6Net, entry: RibEntry) {
@@ -357,11 +357,20 @@ impl Rib {
             let mut replace = rib_replace_system_v6(&mut self.table_v6, prefix, entry);
             self.rib_selection_v6(prefix, replace.pop()).await;
         }
+
+        self.schedule_rib_sync();
     }
 
     pub async fn ipv6_route_resolve(&mut self) {
         ipv6_nexthop_sync(&mut self.nmap, &self.table_v6, &self.fib_handle).await;
         ipv6_route_sync(&mut self.table_v6, &mut self.nmap, &self.fib_handle).await;
+    }
+
+    pub async fn ipv4_route_resolve(&mut self) {
+        ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.fib_handle).await;
+        // `false` = not an ifdown sweep; this resolve cycle is for FIB-update
+        // re-resolution, not link-down recovery.
+        ipv4_route_sync(&mut self.table, &mut self.nmap, &self.fib_handle, false).await;
     }
 
     pub async fn rib_selection(&mut self, prefix: &Ipv4Net, replace: Option<RibEntry>) {

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -14,13 +14,27 @@ use super::{Group, Rib, entry::RibEntry, inst::ShowCallback, link::link_show, ne
 use std::fmt::Write;
 
 // "via" word prefix in show output. SRv6-encapsulated nexthops surface as
-// "via seg6 <first-segment>" to match the iproute2 / FRR convention; plain
+// "via seg6 <segments>" to match the iproute2 / FRR convention; plain
 // nexthops keep the bare "via".
 fn via_word(uni: &NexthopUni) -> &'static str {
     if uni.segs.is_empty() {
         "via"
     } else {
         "via seg6"
+    }
+}
+
+// Render the address that follows the "via" word. For SRv6 with a single
+// segment the first (and only) segment IS uni.addr, so the output is just
+// the bare address. With two or more segments we render the full list as
+// "[seg1, seg2, ...]" so the operator can see the policy without dropping
+// to `ip -6 route show`.
+fn via_addr(uni: &NexthopUni) -> String {
+    if uni.segs.len() > 1 {
+        let parts: Vec<String> = uni.segs.iter().map(|s| s.to_string()).collect();
+        format!("[{}]", parts.join(", "))
+    } else {
+        uni.addr.to_string()
     }
 }
 
@@ -348,7 +362,7 @@ pub fn rib_entry_show(
                     buf,
                     " {} {}, {}",
                     via_word(uni),
-                    uni.addr,
+                    via_addr(uni),
                     rib.link_name(ifindex)
                 )
                 .unwrap();
@@ -376,7 +390,7 @@ pub fn rib_entry_show(
                         buf,
                         " {} {}, {}",
                         via_word(uni),
-                        uni.addr,
+                        via_addr(uni),
                         rib.link_name(uni.ifindex),
                     )
                     .unwrap();
@@ -405,7 +419,7 @@ pub fn rib_entry_show(
                         buf,
                         " {} {}, {}, metric {}",
                         via_word(uni),
-                        uni.addr,
+                        via_addr(uni),
                         rib.link_name(uni.ifindex),
                         uni.metric
                     )
@@ -465,7 +479,7 @@ pub fn rib_entry_show_v6(
                     buf,
                     " {} {}, {}",
                     via_word(uni),
-                    uni.addr,
+                    via_addr(uni),
                     rib.link_name(ifindex)
                 )
                 .unwrap();
@@ -493,7 +507,7 @@ pub fn rib_entry_show_v6(
                         buf,
                         " {} {}, {}",
                         via_word(uni),
-                        uni.addr,
+                        via_addr(uni),
                         rib.link_name(uni.ifindex),
                     )
                     .unwrap();
@@ -522,7 +536,7 @@ pub fn rib_entry_show_v6(
                         buf,
                         " {} {}, {}, metric {}",
                         via_word(uni),
-                        uni.addr,
+                        via_addr(uni),
                         rib.link_name(uni.ifindex),
                         uni.metric
                     )
@@ -896,5 +910,71 @@ impl Rib {
         self.show_add("/show/nexthop", nexthop_show);
         self.show_add("/show/mpls/ilm", ilm_show);
         self.show_add("/show/l2/mac/table", mac_show);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv6Addr};
+
+    fn uni_with_segs(segs: Vec<Ipv6Addr>) -> NexthopUni {
+        let addr = segs.first().copied().unwrap_or(Ipv6Addr::UNSPECIFIED);
+        NexthopUni {
+            addr: IpAddr::V6(addr),
+            segs,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn via_word_picks_seg6_only_when_segments_present() {
+        let plain = NexthopUni::default();
+        assert_eq!(via_word(&plain), "via");
+
+        let one = uni_with_segs(vec!["fcbb:bbbb:2:3:2::".parse().unwrap()]);
+        assert_eq!(via_word(&one), "via seg6");
+
+        let two = uni_with_segs(vec![
+            "fcbb:bbbb:2:3:2::".parse().unwrap(),
+            "fcbb:bbbb:2:3:3::".parse().unwrap(),
+        ]);
+        assert_eq!(via_word(&two), "via seg6");
+    }
+
+    #[test]
+    fn via_addr_single_segment_renders_bare_address() {
+        // With a single segment the policy is fully described by the outer
+        // destination (= uni.addr); no need for the [list] form.
+        let one = uni_with_segs(vec!["fcbb:bbbb:2:3:2::".parse().unwrap()]);
+        assert_eq!(via_addr(&one), "fcbb:bbbb:2:3:2::");
+    }
+
+    #[test]
+    fn via_addr_multi_segment_renders_bracketed_list() {
+        let two = uni_with_segs(vec![
+            "fcbb:bbbb:2:3:2::".parse().unwrap(),
+            "fcbb:bbbb:2:3:3::".parse().unwrap(),
+        ]);
+        assert_eq!(via_addr(&two), "[fcbb:bbbb:2:3:2::, fcbb:bbbb:2:3:3::]");
+
+        let three = uni_with_segs(vec![
+            "fcbb:bbbb:2:3:2::".parse().unwrap(),
+            "fcbb:bbbb:2:3:3::".parse().unwrap(),
+            "fcbb:bbbb:2:3:4::".parse().unwrap(),
+        ]);
+        assert_eq!(
+            via_addr(&three),
+            "[fcbb:bbbb:2:3:2::, fcbb:bbbb:2:3:3::, fcbb:bbbb:2:3:4::]"
+        );
+    }
+
+    #[test]
+    fn via_addr_no_segments_renders_underlying_addr() {
+        let plain = NexthopUni {
+            addr: IpAddr::V6("2001:db8::1".parse().unwrap()),
+            ..Default::default()
+        };
+        assert_eq!(via_addr(&plain), "2001:db8::1");
     }
 }

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -24,17 +24,17 @@ fn via_word(uni: &NexthopUni) -> &'static str {
     }
 }
 
-// Render the address that follows the "via" word. For SRv6 with a single
-// segment the first (and only) segment IS uni.addr, so the output is just
-// the bare address. With two or more segments we render the full list as
-// "[seg1, seg2, ...]" so the operator can see the policy without dropping
-// to `ip -6 route show`.
+// Render the address that follows the "via" word. SRv6 nexthops always
+// surface their segment list inside square brackets (matching iproute2's
+// `encap seg6 ... segs N [ ... ]` shape), even for a single segment, so the
+// operator can tell at a glance which routes are policy-encapsulated.
+// Non-SRv6 nexthops render the bare address.
 fn via_addr(uni: &NexthopUni) -> String {
-    if uni.segs.len() > 1 {
+    if uni.segs.is_empty() {
+        uni.addr.to_string()
+    } else {
         let parts: Vec<String> = uni.segs.iter().map(|s| s.to_string()).collect();
         format!("[{}]", parts.join(", "))
-    } else {
-        uni.addr.to_string()
     }
 }
 
@@ -943,11 +943,12 @@ mod tests {
     }
 
     #[test]
-    fn via_addr_single_segment_renders_bare_address() {
-        // With a single segment the policy is fully described by the outer
-        // destination (= uni.addr); no need for the [list] form.
+    fn via_addr_single_segment_renders_bracketed_list() {
+        // Even a single-segment policy is rendered as "[seg]" to match the
+        // iproute2 "segs 1 [ ... ]" convention and stay consistent with the
+        // multi-segment case.
         let one = uni_with_segs(vec!["fcbb:bbbb:2:3:2::".parse().unwrap()]);
-        assert_eq!(via_addr(&one), "fcbb:bbbb:2:3:2::");
+        assert_eq!(via_addr(&one), "[fcbb:bbbb:2:3:2::]");
     }
 
     #[test]

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -7,11 +7,22 @@ use serde_json::Value;
 
 use crate::{
     config::Args,
-    rib::{Label, Nexthop},
+    rib::{Label, Nexthop, nexthop::NexthopUni},
 };
 
 use super::{Group, Rib, entry::RibEntry, inst::ShowCallback, link::link_show, nexthop_show};
 use std::fmt::Write;
+
+// "via" word prefix in show output. SRv6-encapsulated nexthops surface as
+// "via seg6 <first-segment>" to match the iproute2 / FRR convention; plain
+// nexthops keep the bare "via".
+fn via_word(uni: &NexthopUni) -> &'static str {
+    if uni.segs.is_empty() {
+        "via"
+    } else {
+        "via seg6"
+    }
+}
 
 // JSON-serializable structures for route display
 #[derive(Serialize)]
@@ -333,7 +344,14 @@ pub fn rib_entry_show(
                 } else {
                     uni.ifindex
                 };
-                write!(buf, " via {}, {}", uni.addr, rib.link_name(ifindex)).unwrap();
+                write!(
+                    buf,
+                    " {} {}, {}",
+                    via_word(uni),
+                    uni.addr,
+                    rib.link_name(ifindex)
+                )
+                .unwrap();
                 if !uni.mpls.is_empty() {
                     write!(buf, ", label").unwrap();
                     for mpls in uni.mpls.iter() {
@@ -354,7 +372,14 @@ pub fn rib_entry_show(
                     if i != 0 {
                         buf.push_str(&" ".repeat(offset));
                     }
-                    write!(buf, " via {}, {}", uni.addr, rib.link_name(uni.ifindex),).unwrap();
+                    write!(
+                        buf,
+                        " {} {}, {}",
+                        via_word(uni),
+                        uni.addr,
+                        rib.link_name(uni.ifindex),
+                    )
+                    .unwrap();
                     if !uni.mpls.is_empty() {
                         write!(buf, ", label").unwrap();
                         for mpls in uni.mpls.iter() {
@@ -378,7 +403,8 @@ pub fn rib_entry_show(
                     }
                     writeln!(
                         buf,
-                        " via {}, {}, metric {}",
+                        " {} {}, {}, metric {}",
+                        via_word(uni),
                         uni.addr,
                         rib.link_name(uni.ifindex),
                         uni.metric
@@ -435,7 +461,14 @@ pub fn rib_entry_show_v6(
                 } else {
                     uni.ifindex
                 };
-                write!(buf, " via {}, {}", uni.addr, rib.link_name(ifindex)).unwrap();
+                write!(
+                    buf,
+                    " {} {}, {}",
+                    via_word(uni),
+                    uni.addr,
+                    rib.link_name(ifindex)
+                )
+                .unwrap();
                 if !uni.mpls.is_empty() {
                     write!(buf, ", label").unwrap();
                     for mpls in uni.mpls.iter() {
@@ -456,7 +489,14 @@ pub fn rib_entry_show_v6(
                     if i != 0 {
                         buf.push_str(&" ".repeat(offset));
                     }
-                    write!(buf, " via {}, {}", uni.addr, rib.link_name(uni.ifindex),).unwrap();
+                    write!(
+                        buf,
+                        " {} {}, {}",
+                        via_word(uni),
+                        uni.addr,
+                        rib.link_name(uni.ifindex),
+                    )
+                    .unwrap();
                     if !uni.mpls.is_empty() {
                         write!(buf, ", label").unwrap();
                         for mpls in uni.mpls.iter() {
@@ -480,7 +520,8 @@ pub fn rib_entry_show_v6(
                     }
                     writeln!(
                         buf,
-                        " via {}, {}, metric {}",
+                        " {} {}, {}, metric {}",
+                        via_word(uni),
                         uni.addr,
                         rib.link_name(uni.ifindex),
                         uni.metric

--- a/zebra-rs/src/rib/static/route.rs
+++ b/zebra-rs/src/rib/static/route.rs
@@ -82,20 +82,15 @@ impl<F: StaticFamily> StaticRoute<F> {
         let metric = self.metric.unwrap_or(0);
 
         if !self.segs.is_empty() {
-            // SRv6 H.Encap: outer destination is the first segment, kernel
-            // routes the encapsulated packet there. RFC 8986 §5.1 lists
-            // H.Encap as the base behavior, but operators almost always
-            // prefer H.Encap.Red because it omits the redundant first SID
-            // from the SRH (RFC 8986 §5.2). Default to Red when there are
-            // enough segments to do so; fall back to plain H.Encap for a
-            // single-segment policy since Red has no segments left after
-            // dropping the first.
+            // SRv6 H.Encap (RFC 8986 §5.1): outer destination is the first
+            // segment; the SRH carries every configured segment. We default
+            // to plain H.Encap so the FIB reflects the operator's exact
+            // segment list — `ip -6 route show` will report `segs N [...]`
+            // for N configured segments. Operators who want the SRH-reduced
+            // form (H.Encap.Red, RFC 8986 §5.2) can opt in via the explicit
+            // encap-type leaf.
             let first = self.segs[0];
-            let encap_type = self.encap_type.unwrap_or(if self.segs.len() >= 2 {
-                EncapType::HEncapRed
-            } else {
-                EncapType::HEncap
-            });
+            let encap_type = self.encap_type.unwrap_or(EncapType::HEncap);
             let nhop = NexthopUni {
                 addr: IpAddr::V6(first),
                 metric,
@@ -286,24 +281,22 @@ mod tests {
     }
 
     #[test]
-    fn srv6_segs_default_to_h_encap_red_when_unspecified() {
-        // Operator default: with two or more segments, an unspecified
-        // encap-type resolves to H.Encap.Red (RFC 8986 §5.2 reduced
-        // encapsulation, the typical SRv6 deployment choice).
+    fn srv6_segs_default_to_h_encap_when_unspecified() {
+        // Default policy: with no explicit encap-type, install full H.Encap
+        // (RFC 8986 §5.1) so every configured segment lands in the SRH and
+        // the kernel `ip -6 route show` reflects exactly what the operator
+        // configured. H.Encap.Red is opt-in via explicit encap-type.
         let r = StaticRoute::<V4> {
             segs: vec![seg("fd00:c::"), seg("fd00:b::")],
             ..Default::default()
         };
         let entry = r.to_entry().expect("entry built");
         let uni = as_uni(&entry);
-        assert_eq!(uni.encap_type, Some(EncapType::HEncapRed));
+        assert_eq!(uni.encap_type, Some(EncapType::HEncap));
     }
 
     #[test]
-    fn srv6_single_segment_default_falls_back_to_h_encap() {
-        // H.Encap.Red drops the first segment from the SRH, so a
-        // single-segment policy would leave the SRH empty. Fall back
-        // to plain H.Encap rather than producing an invalid policy.
+    fn srv6_single_segment_default_is_h_encap() {
         let r = StaticRoute::<V4> {
             segs: vec![seg("fd00:c::")],
             ..Default::default()


### PR DESCRIPTION
## Summary

A connected series of fixes around SRv6 static-route resolution, FIB install, and `show ip route` rendering — all triggered by an SRv6 static route whose first segment is covered by an IS-IS-learned aggregate landing in the kernel with `dev lo` instead of `dev enp0s5`.

**Resolver / nexthop plumbing**
- `fix(rib): resolve IPv6 nexthops through IGP routes, not just connected` (`292ea04`) — `rib_resolve_v6` (and v4) now walks IS-IS / OSPF / Static covering routes and pulls the egress ifindex off their nexthop. BGP is excluded to avoid recursive loops. `Resolve::Recursive(u32)` now carries a real ifindex; the bogus `(1)` sentinel is gone.
- `fix(rib): GroupUni honors Resolve::Recursive ifindex` (`922bdc1`) — the consumer side: `GroupUni::resolve` / `resolve_v6` was discarding `Recursive` and only honoring `Onlink`, so the resolver fix didn't actually update the Group's ifindex. Now both arms set the ifindex.
- `test(rib): add GroupUni unit tests` (`ed5c0a7`) — pin the recursive/onlink/skip behaviors per family.
- `feat(rib): debounced RIB sync timer` (`e16925d`) — when FIB changes, schedule a 1s `Message::Resolve` (configurable via `Rib::rib_sync_interval`) so static / SRv6 nexthops get re-resolved when their underlay route lands later (e.g., IS-IS comes up after the static was configured). `schedule_rib_sync` is idempotent so a burst of installs collapses into one resolve cycle. Resolve handler now runs both v4 and v6 (was v6-only).

**`show ip route` / `show ipv6 route` polish**
- `feat(rib): show 'via seg6 <addr>'` (`bbcb996`) — surface SRv6 encapsulation in the `via` line.
- `feat(rib): render multi-segment as bracketed list` (`831069e`).
- `feat(rib): always bracket SRv6 segments` (`b5f6a0b`) — single-segment now reads `[seg]` to match iproute2's `segs N [...]` shape regardless of count.

**FIB install policy**
- `fix(static): default SRv6 encap-type to H.Encap` (`16b3a6a`) — flipped from H.Encap.Red so the kernel reports `segs N [...]` for an N-segment configured policy, matching exactly what the operator asked for. H.Encap.Red is still available as an explicit opt-in.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` — 14 new unit tests across `rib::resolve`, `rib::nexthop::group`, `rib::show`, `rib::static::route`.
- [x] Manual: SRv6 static route with first segment covered by an IS-IS /48 now installs to the kernel with the correct `dev <iface>` instead of `dev lo`.
- [x] Manual: configuring N segments produces `ip -6 route show ... encap seg6 mode encap segs N [ ... ]` matching the configured count.
- [x] Manual: `show ipv6 route` renders SRv6 routes as `via seg6 [seg1, seg2, ...], <iface>`.

## Notes

- The default encap-type flip from H.Encap.Red to H.Encap is a deliberate operator-visible change, captured in the project memory note. Operators who want the on-wire byte savings can still opt in via the explicit `encap-type H.Encap.Red` leaf.
- `rib_sync_interval` is configurable on the struct but not yet exposed via YANG — that's a small follow-up.

Generated with [Claude Code](https://claude.com/claude-code)