### PR TITLE
feat: SR-MPLS block + SRv6 locator global config

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -27,7 +27,16 @@ impl Isis {
         self.callback_add("/routing/isis/hostname", config_hostname);
         self.callback_add("/routing/isis/timers/hold-time", config_hold_time);
         self.callback_add("/routing/isis/te-router-id", config_te_router_id);
-        self.callback_add("/routing/isis/segment-routing", config_segment_routing);
+        self.callback_add("/routing/isis/segment-routing/mpls", config_sr_mpls_enable);
+        self.callback_add(
+            "/routing/isis/segment-routing/mpls/block",
+            config_sr_mpls_block,
+        );
+        self.callback_add("/routing/isis/segment-routing/srv6", config_sr_srv6_enable);
+        self.callback_add(
+            "/routing/isis/segment-routing/srv6/locator",
+            config_sr_srv6_locator,
+        );
         self.callback_add("/routing/isis/interface/priority", link::config_priority);
         self.tracing_add("/event", config_tracing_event);
         self.tracing_add("/fsm", config_tracing_fsm);
@@ -70,13 +79,6 @@ impl Default for IsisDistribute {
     }
 }
 
-#[derive(Debug, PartialEq, strum_macros::EnumString)]
-#[strum(ascii_case_insensitive)]
-pub enum SegmentRouting {
-    MPLS,
-    SRv6,
-}
-
 #[derive(Default)]
 pub struct IsisConfig {
     pub net: Nsap,
@@ -88,7 +90,25 @@ pub struct IsisConfig {
     pub rib_router_id: Option<Ipv4Addr>,
     pub enable: Afis<usize>,
     pub distribute: IsisDistribute,
-    pub segment_routing: Option<SegmentRouting>,
+
+    /// Set when /routing/isis/segment-routing/mpls is committed (the
+    /// presence-marked YANG container), even if no `block` is selected.
+    /// Drives whether IS-IS originates SR-MPLS Capability sub-TLVs.
+    pub sr_mpls_enabled: bool,
+
+    /// Optional name of a block defined under the global
+    /// /segment-routing/block list. The actual SRGB / SRLB values are
+    /// looked up by name from RIB::blocks; left as a string here so the
+    /// IS-IS config can be staged before the global block is committed.
+    pub sr_mpls_block: Option<String>,
+
+    /// Set when /routing/isis/segment-routing/srv6 is committed.
+    pub sr_srv6_enabled: bool,
+
+    /// Optional name of a locator defined under the global
+    /// /segment-routing/locator list. Same staging-friendly rationale
+    /// as sr_mpls_block.
+    pub sr_srv6_locator: Option<String>,
 }
 
 impl IsisConfig {
@@ -109,6 +129,12 @@ impl IsisConfig {
 
     pub fn hold_time(&self) -> u16 {
         self.hold_time.unwrap_or(Self::DEFAULT_HOLD_TIME)
+    }
+
+    /// True when either SR dataplane is enabled. Used to gate emission
+    /// of the TE Router ID TLV (it's only meaningful in an SR domain).
+    pub fn sr_enabled(&self) -> bool {
+        self.sr_mpls_enabled || self.sr_srv6_enabled
     }
 }
 
@@ -168,12 +194,45 @@ fn config_hold_time(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()>
     Some(())
 }
 
-fn config_segment_routing(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+// Set/cleared by the presence of the YANG container itself, not by any
+// child leaf. libyang invokes the callback at the container path with no
+// extra args when the container is committed (set) or removed (delete).
+fn config_sr_mpls_enable(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
     if op.is_set() {
-        let sr = args.string()?.parse::<SegmentRouting>().ok()?;
-        isis.config.segment_routing = Some(sr);
+        isis.config.sr_mpls_enabled = true;
     } else {
-        isis.config.segment_routing = None;
+        isis.config.sr_mpls_enabled = false;
+        isis.config.sr_mpls_block = None;
+    }
+    Some(())
+}
+
+fn config_sr_mpls_block(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    if op.is_set() {
+        let name = args.string()?;
+        isis.config.sr_mpls_block = Some(name);
+    } else {
+        isis.config.sr_mpls_block = None;
+    }
+    Some(())
+}
+
+fn config_sr_srv6_enable(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
+    if op.is_set() {
+        isis.config.sr_srv6_enabled = true;
+    } else {
+        isis.config.sr_srv6_enabled = false;
+        isis.config.sr_srv6_locator = None;
+    }
+    Some(())
+}
+
+fn config_sr_srv6_locator(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    if op.is_set() {
+        let name = args.string()?;
+        isis.config.sr_srv6_locator = Some(name);
+    } else {
+        isis.config.sr_srv6_locator = None;
     }
     Some(())
 }

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -13,7 +13,8 @@ use isis_packet::*;
 use prefix_trie::PrefixMap;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
-use crate::isis::config::SegmentRouting;
+// (former SegmentRouting enum import — removed; replaced by sr_mpls_enabled
+// / sr_srv6_enabled flags on IsisConfig.)
 use crate::isis_event_trace;
 
 use crate::config::{DisplayRequest, ShowChannel};
@@ -615,7 +616,7 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
     lsp.tlvs.push(IsisTlvHostname { hostname }.into());
 
     // SR Capability.
-    if let Some(sr) = &top.config.segment_routing {
+    if top.config.sr_enabled() {
         // Effective router-id: configured te_router_id wins, else fall back to the
         // RIB-derived id, else 0.0.0.0.
         let router_id: Ipv4Addr = top
@@ -631,54 +632,59 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
             subs: Vec::new(),
         };
 
-        match *sr {
-            SegmentRouting::MPLS => {
-                let mut flags = SegmentRoutingCapFlags::default();
-                flags.set_i_flag(true);
-                flags.set_v_flag(true);
-                let sid_label = SidLabelTlv::Label(16000);
-                let sr_cap = IsisSubSegmentRoutingCap {
-                    flags,
-                    range: 8000,
-                    sid_label,
-                };
-                cap.subs.push(sr_cap.into());
+        // SR-MPLS Capability sub-TLVs.
+        // TODO(srv6-locator-config PR4): the SRGB / SRLB values below are
+        // hardcoded. Replace with a lookup of `top.config.sr_mpls_block`
+        // against RIB::blocks once the IS-IS daemon has access to the
+        // RIB-side block snapshot (probably via a Subscribe-style stream).
+        if top.config.sr_mpls_enabled {
+            let mut flags = SegmentRoutingCapFlags::default();
+            flags.set_i_flag(true);
+            flags.set_v_flag(true);
+            let sid_label = SidLabelTlv::Label(16000);
+            let sr_cap = IsisSubSegmentRoutingCap {
+                flags,
+                range: 8000,
+                sid_label,
+            };
+            cap.subs.push(sr_cap.into());
 
-                // Sub: SR Algorithms
+            // Sub: SR Algorithms
+            let algo = IsisSubSegmentRoutingAlgo {
+                algo: vec![Algo::Spf],
+            };
+            cap.subs.push(algo.into());
+
+            // Sub: SR Local Block
+            let sid_label = SidLabelTlv::Label(15000);
+            let lb = IsisSubSegmentRoutingLB {
+                flags: 0,
+                range: 3000,
+                sid_label,
+            };
+            cap.subs.push(lb.into());
+        }
+
+        // SRv6 Capability sub-TLV.
+        if top.config.sr_srv6_enabled {
+            let srv6 = IsisSubSrv6::default();
+            cap.subs.push(srv6.into());
+
+            // SR-MPLS already pushed Algorithms; for an SRv6-only config
+            // we still need to advertise the algorithm list once.
+            if !top.config.sr_mpls_enabled {
                 let algo = IsisSubSegmentRoutingAlgo {
                     algo: vec![Algo::Spf],
                 };
                 cap.subs.push(algo.into());
-
-                // Sub: SR Local Block
-                let sid_label = SidLabelTlv::Label(15000);
-                let lb = IsisSubSegmentRoutingLB {
-                    flags: 0,
-                    range: 3000,
-                    sid_label,
-                };
-                cap.subs.push(lb.into());
-
-                lsp.tlvs.push(cap.into());
-            }
-            SegmentRouting::SRv6 => {
-                // SRv6 Capability.
-                let srv6 = IsisSubSrv6::default();
-                cap.subs.push(srv6.into());
-
-                // Sub: SR Algorithms
-                let algo = IsisSubSegmentRoutingAlgo {
-                    algo: vec![Algo::Spf],
-                };
-                cap.subs.push(algo.into());
-
-                lsp.tlvs.push(cap.into());
             }
         }
+
+        lsp.tlvs.push(cap.into());
     }
 
     // TE Router ID. Prefer configured value, fall back to RIB-derived.
-    if top.config.segment_routing.is_some()
+    if top.config.sr_enabled()
         && let Some(router_id) = top.config.te_router_id.or(top.config.rib_router_id)
     {
         let te_router_id = IsisTlvTeRouterId { router_id };

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -5,8 +5,9 @@ use super::api::RibRx;
 use super::entry::RibEntry;
 use super::link::{LinkConfig, link_config_exec};
 use super::{
-    BridgeBuilder, BridgeConfig, Link, MacAddr, MplsConfig, Nexthop, NexthopMap, RibType,
-    StaticConfig, V4, V6, Vxlan, VxlanBuilder, VxlanConfig,
+    Block, BlockBuilder, BlockConfig, BridgeBuilder, BridgeConfig, Link, Locator, LocatorBuilder,
+    LocatorConfig, MacAddr, MplsConfig, Nexthop, NexthopMap, RibType, StaticConfig, V4, V6, Vxlan,
+    VxlanBuilder, VxlanConfig,
 };
 
 use crate::config::{Args, path_from_command};
@@ -62,6 +63,20 @@ pub enum Message {
         config: BridgeConfig,
     },
     BridgeDel {
+        name: String,
+    },
+    BlockAdd {
+        name: String,
+        config: BlockConfig,
+    },
+    BlockDel {
+        name: String,
+    },
+    LocatorAdd {
+        name: String,
+        config: LocatorConfig,
+    },
+    LocatorDel {
         name: String,
     },
     VxlanAdd {
@@ -161,6 +176,13 @@ pub struct Rib {
     pub link_config: LinkConfig,
     pub bridge_config: BridgeBuilder,
     pub vxlan_config: VxlanBuilder,
+    pub block_config: BlockBuilder,
+    pub locator_config: LocatorBuilder,
+    /// Applied snapshots, populated by Block/Locator Add/Del messages.
+    /// Other modules read these by name to resolve their `mpls/block` or
+    /// `srv6/locator` reference.
+    pub blocks: BTreeMap<String, Block>,
+    pub locators: BTreeMap<String, Locator>,
     pub nmap: NexthopMap,
     pub router_id: Ipv4Addr,
 
@@ -205,6 +227,10 @@ impl Rib {
             link_config: LinkConfig::new(),
             bridge_config: BridgeBuilder::new(),
             vxlan_config: VxlanBuilder::new(),
+            block_config: BlockBuilder::new(),
+            locator_config: LocatorBuilder::new(),
+            blocks: BTreeMap::new(),
+            locators: BTreeMap::new(),
             nmap: NexthopMap::default(),
             router_id: Ipv4Addr::UNSPECIFIED,
             rib_sync_timer: None,
@@ -308,6 +334,20 @@ impl Rib {
                 };
                 self.vxlan.remove(&name);
                 self.fib_handle.vxlan_del(&vxlan).await;
+            }
+            Message::BlockAdd { name, config } => {
+                let block = config.to_block(&name);
+                self.blocks.insert(name, block);
+            }
+            Message::BlockDel { name } => {
+                self.blocks.remove(&name);
+            }
+            Message::LocatorAdd { name, config } => {
+                let locator = config.to_locator(&name);
+                self.locators.insert(name, locator);
+            }
+            Message::LocatorDel { name } => {
+                self.locators.remove(&name);
             }
             Message::Shutdown { tx } => {
                 self.nmap.shutdown(&self.fib_handle).await;
@@ -439,6 +479,10 @@ impl Rib {
                     let _ = self.bridge_config.exec(path, args, msg.op);
                 } else if path.as_str().starts_with("/vxlan") {
                     let _ = self.vxlan_config.exec(path, args, msg.op);
+                } else if path.as_str().starts_with("/segment-routing/block") {
+                    let _ = self.block_config.exec(path, args, msg.op);
+                } else if path.as_str().starts_with("/segment-routing/locator") {
+                    let _ = self.locator_config.exec(path, args, msg.op);
                 }
             }
             ConfigOp::CommitEnd => {
@@ -448,6 +492,8 @@ impl Rib {
                 self.static_v4.commit(self.tx.clone());
                 self.static_v6.commit(self.tx.clone());
                 self.mpls_config.commit(self.tx.clone());
+                self.block_config.commit(self.tx.clone());
+                self.locator_config.commit(self.tx.clone());
             }
             ConfigOp::Completion => {
                 msg.resp.unwrap().send(self.link_comps()).unwrap();

--- a/zebra-rs/src/rib/mod.rs
+++ b/zebra-rs/src/rib/mod.rs
@@ -56,3 +56,6 @@ pub use vxlan::*;
 
 pub mod addr_gen_mode;
 pub use addr_gen_mode::*;
+
+pub mod segment_routing;
+pub use segment_routing::*;

--- a/zebra-rs/src/rib/segment_routing/block.rs
+++ b/zebra-rs/src/rib/segment_routing/block.rs
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright 2025-2026 Kunihiro Ishiguro
+
+//! SR-MPLS label block (SRGB + SRLB) configuration. Per-protocol modules
+//! (IS-IS, OSPF, BGP-LU) reference a block by name from their
+//! `segment-routing/mpls/block` leaf.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::config::{Args, ConfigOp};
+use crate::rib::Message;
+use crate::spf::label_block::LabelBlock;
+
+/// Applied snapshot of an SR-MPLS block, exported to the rest of the system
+/// once a config commit lands. `global` and `local` are populated only when
+/// both `start` and `range` were configured for the corresponding container.
+///
+/// Fields carry `#[allow(dead_code)]` until the IS-IS-side `mpls/block`
+/// handler (next PR) reads them by name from `Rib::blocks`.
+#[allow(dead_code)]
+#[derive(Debug, Default, Clone)]
+pub struct Block {
+    pub name: String,
+    /// SR Global Block (SRGB) — prefix-SID label range.
+    pub global: Option<LabelBlock>,
+    /// SR Local Block (SRLB) — adjacency-SID label range.
+    pub local: Option<LabelBlock>,
+}
+
+/// In-flight Block configuration, mirroring the YANG list shape:
+///
+/// ```yang
+/// list block {
+///   key "name";
+///   leaf name { type string; }
+///   container global { leaf start; leaf range; }
+///   container local  { leaf start; leaf range; }
+/// }
+/// ```
+///
+/// Each individual leaf can be set/cleared independently during a commit
+/// cycle; conversion to the applied `Block` only emits a `LabelBlock` when
+/// both `start` and `range` are present together.
+#[derive(Debug, Default, Clone)]
+pub struct BlockConfig {
+    pub delete: bool,
+    pub global_start: Option<u32>,
+    pub global_range: Option<u32>,
+    pub local_start: Option<u32>,
+    pub local_range: Option<u32>,
+}
+
+impl BlockConfig {
+    pub fn to_block(&self, name: &str) -> Block {
+        let global = match (self.global_start, self.global_range) {
+            (Some(start), Some(range)) => Some(LabelBlock::new(start, range)),
+            _ => None,
+        };
+        let local = match (self.local_start, self.local_range) {
+            (Some(start), Some(range)) => Some(LabelBlock::new(start, range)),
+            _ => None,
+        };
+        Block {
+            name: name.to_string(),
+            global,
+            local,
+        }
+    }
+}
+
+pub struct BlockBuilder {
+    pub config: BTreeMap<String, BlockConfig>,
+    pub cache: BTreeMap<String, BlockConfig>,
+    builder: ConfigBuilder,
+}
+
+impl BlockBuilder {
+    pub fn new() -> Self {
+        BlockBuilder {
+            config: BTreeMap::new(),
+            cache: BTreeMap::new(),
+            builder: ConfigBuilder::new(),
+        }
+    }
+
+    pub fn exec(&mut self, path: String, mut args: Args, op: ConfigOp) -> Result<()> {
+        const CONFIG_ERR: &str = "missing config handler";
+        const NAME_ERR: &str = "missing block name argument";
+
+        let func = self
+            .builder
+            .map
+            .get(&(path.to_string(), op))
+            .context(CONFIG_ERR)?;
+
+        let name: String = args.string().context(NAME_ERR)?;
+
+        func(&mut self.config, &mut self.cache, &name, &mut args)
+    }
+
+    pub fn commit(&mut self, tx: UnboundedSender<Message>) {
+        while let Some((name, config)) = self.cache.pop_first() {
+            if config.delete {
+                self.config.remove(&name);
+                let _ = tx.send(Message::BlockDel { name });
+            } else {
+                self.config.insert(name.clone(), config.clone());
+                let _ = tx.send(Message::BlockAdd { name, config });
+            }
+        }
+    }
+}
+
+type Handler = fn(
+    config: &mut BTreeMap<String, BlockConfig>,
+    cache: &mut BTreeMap<String, BlockConfig>,
+    name: &String,
+    args: &mut Args,
+) -> Result<()>;
+
+fn config_get(config: &BTreeMap<String, BlockConfig>, name: &String) -> BlockConfig {
+    let Some(entry) = config.get(name) else {
+        return BlockConfig::default();
+    };
+    entry.clone()
+}
+
+fn config_lookup(config: &BTreeMap<String, BlockConfig>, name: &String) -> Option<BlockConfig> {
+    let entry = config.get(name)?;
+    Some(entry.clone())
+}
+
+fn cache_get<'a>(
+    config: &'a BTreeMap<String, BlockConfig>,
+    cache: &'a mut BTreeMap<String, BlockConfig>,
+    name: &'a String,
+) -> Option<&'a mut BlockConfig> {
+    if cache.get(name).is_none() {
+        cache.insert(name.to_string(), config_get(config, name));
+    }
+    cache.get_mut(name)
+}
+
+fn cache_lookup<'a>(
+    config: &'a BTreeMap<String, BlockConfig>,
+    cache: &'a mut BTreeMap<String, BlockConfig>,
+    name: &'a String,
+) -> Option<&'a mut BlockConfig> {
+    if cache.get(name).is_none() {
+        cache.insert(name.clone(), config_lookup(config, name)?);
+    }
+    let cache = cache.get_mut(name)?;
+    if cache.delete { None } else { Some(cache) }
+}
+
+#[derive(Default)]
+struct ConfigBuilder {
+    path: String,
+    map: BTreeMap<(String, ConfigOp), Handler>,
+}
+
+impl ConfigBuilder {
+    pub fn new() -> Self {
+        const CONFIG_ERR: &str = "missing config";
+        const VALUE_ERR: &str = "expected u32";
+
+        ConfigBuilder::default()
+            .path("")
+            .set(|config, cache, name, _args| {
+                let _ = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                if let Some(s) = cache.get_mut(name) {
+                    s.delete = true;
+                } else {
+                    let mut s = config_lookup(config, name).context(CONFIG_ERR)?;
+                    s.delete = true;
+                    cache.insert(name.clone(), s);
+                }
+                Ok(())
+            })
+            .path("/global/start")
+            .set(|config, cache, name, args| {
+                let v = args.u32().context(VALUE_ERR)?;
+                let s = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                s.global_start = Some(v);
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                let s = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                s.global_start = None;
+                Ok(())
+            })
+            .path("/global/range")
+            .set(|config, cache, name, args| {
+                let v = args.u32().context(VALUE_ERR)?;
+                let s = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                s.global_range = Some(v);
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                let s = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                s.global_range = None;
+                Ok(())
+            })
+            .path("/local/start")
+            .set(|config, cache, name, args| {
+                let v = args.u32().context(VALUE_ERR)?;
+                let s = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                s.local_start = Some(v);
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                let s = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                s.local_start = None;
+                Ok(())
+            })
+            .path("/local/range")
+            .set(|config, cache, name, args| {
+                let v = args.u32().context(VALUE_ERR)?;
+                let s = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                s.local_range = Some(v);
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                let s = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                s.local_range = None;
+                Ok(())
+            })
+    }
+
+    pub fn path(mut self, path: &str) -> Self {
+        let prefix = "/segment-routing/block";
+        self.path = format!("{prefix}{path}");
+        self
+    }
+
+    pub fn set(mut self, func: Handler) -> Self {
+        self.map.insert((self.path.clone(), ConfigOp::Set), func);
+        self
+    }
+
+    pub fn del(mut self, func: Handler) -> Self {
+        self.map.insert((self.path.clone(), ConfigOp::Delete), func);
+        self
+    }
+}

--- a/zebra-rs/src/rib/segment_routing/locator.rs
+++ b/zebra-rs/src/rib/segment_routing/locator.rs
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright 2025-2026 Kunihiro Ishiguro
+
+//! SRv6 locator configuration. Per-protocol modules (IS-IS, OSPF, BGP-LU)
+//! reference a locator by name from their `segment-routing/srv6/locator`
+//! leaf.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use ipnet::Ipv6Net;
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::config::{Args, ConfigOp};
+use crate::rib::Message;
+
+/// Locator-wide endpoint behavior. The YANG enum currently lists only
+/// `usid` (RFC 9800 NEXT-C-SID); the variant is `Option<...>` on Locator
+/// because the absence of the leaf means the classic RFC 8986 full SID
+/// layout, not "uSID".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LocatorBehavior {
+    /// RFC 9800 NEXT-C-SID (micro-SID) format.
+    Usid,
+}
+
+impl LocatorBehavior {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "usid" => Some(Self::Usid),
+            _ => None,
+        }
+    }
+}
+
+/// Applied snapshot of an SRv6 locator, exported to the rest of the system
+/// once a config commit lands.
+///
+/// Fields carry `#[allow(dead_code)]` until the IS-IS-side `srv6/locator`
+/// handler (next PR) reads them by name from `Rib::locators`.
+#[allow(dead_code)]
+#[derive(Debug, Default, Clone)]
+pub struct Locator {
+    pub name: String,
+    pub prefix: Option<Ipv6Net>,
+    pub behavior: Option<LocatorBehavior>,
+}
+
+/// In-flight Locator configuration, mirroring the YANG list shape:
+///
+/// ```yang
+/// list locator {
+///   key "name";
+///   leaf name     { type string; }
+///   leaf prefix   { type inet:ipv6-prefix; }
+///   leaf behavior { type enumeration { enum usid; } }
+/// }
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct LocatorConfig {
+    pub delete: bool,
+    pub prefix: Option<Ipv6Net>,
+    pub behavior: Option<LocatorBehavior>,
+}
+
+impl LocatorConfig {
+    pub fn to_locator(&self, name: &str) -> Locator {
+        Locator {
+            name: name.to_string(),
+            prefix: self.prefix,
+            behavior: self.behavior.clone(),
+        }
+    }
+}
+
+pub struct LocatorBuilder {
+    pub config: BTreeMap<String, LocatorConfig>,
+    pub cache: BTreeMap<String, LocatorConfig>,
+    builder: ConfigBuilder,
+}
+
+impl LocatorBuilder {
+    pub fn new() -> Self {
+        LocatorBuilder {
+            config: BTreeMap::new(),
+            cache: BTreeMap::new(),
+            builder: ConfigBuilder::new(),
+        }
+    }
+
+    pub fn exec(&mut self, path: String, mut args: Args, op: ConfigOp) -> Result<()> {
+        const CONFIG_ERR: &str = "missing config handler";
+        const NAME_ERR: &str = "missing locator name argument";
+
+        let func = self
+            .builder
+            .map
+            .get(&(path.to_string(), op))
+            .context(CONFIG_ERR)?;
+
+        let name: String = args.string().context(NAME_ERR)?;
+
+        func(&mut self.config, &mut self.cache, &name, &mut args)
+    }
+
+    pub fn commit(&mut self, tx: UnboundedSender<Message>) {
+        while let Some((name, config)) = self.cache.pop_first() {
+            if config.delete {
+                self.config.remove(&name);
+                let _ = tx.send(Message::LocatorDel { name });
+            } else {
+                self.config.insert(name.clone(), config.clone());
+                let _ = tx.send(Message::LocatorAdd { name, config });
+            }
+        }
+    }
+}
+
+type Handler = fn(
+    config: &mut BTreeMap<String, LocatorConfig>,
+    cache: &mut BTreeMap<String, LocatorConfig>,
+    name: &String,
+    args: &mut Args,
+) -> Result<()>;
+
+fn config_get(config: &BTreeMap<String, LocatorConfig>, name: &String) -> LocatorConfig {
+    let Some(entry) = config.get(name) else {
+        return LocatorConfig::default();
+    };
+    entry.clone()
+}
+
+fn config_lookup(config: &BTreeMap<String, LocatorConfig>, name: &String) -> Option<LocatorConfig> {
+    let entry = config.get(name)?;
+    Some(entry.clone())
+}
+
+fn cache_get<'a>(
+    config: &'a BTreeMap<String, LocatorConfig>,
+    cache: &'a mut BTreeMap<String, LocatorConfig>,
+    name: &'a String,
+) -> Option<&'a mut LocatorConfig> {
+    if cache.get(name).is_none() {
+        cache.insert(name.to_string(), config_get(config, name));
+    }
+    cache.get_mut(name)
+}
+
+fn cache_lookup<'a>(
+    config: &'a BTreeMap<String, LocatorConfig>,
+    cache: &'a mut BTreeMap<String, LocatorConfig>,
+    name: &'a String,
+) -> Option<&'a mut LocatorConfig> {
+    if cache.get(name).is_none() {
+        cache.insert(name.clone(), config_lookup(config, name)?);
+    }
+    let cache = cache.get_mut(name)?;
+    if cache.delete { None } else { Some(cache) }
+}
+
+#[derive(Default)]
+struct ConfigBuilder {
+    path: String,
+    map: BTreeMap<(String, ConfigOp), Handler>,
+}
+
+impl ConfigBuilder {
+    pub fn new() -> Self {
+        const CONFIG_ERR: &str = "missing config";
+        const PREFIX_ERR: &str = "expected ipv6 prefix";
+        const BEHAVIOR_ERR: &str = "unknown locator behavior";
+
+        ConfigBuilder::default()
+            .path("")
+            .set(|config, cache, name, _args| {
+                let _ = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                if let Some(s) = cache.get_mut(name) {
+                    s.delete = true;
+                } else {
+                    let mut s = config_lookup(config, name).context(CONFIG_ERR)?;
+                    s.delete = true;
+                    cache.insert(name.clone(), s);
+                }
+                Ok(())
+            })
+            .path("/prefix")
+            .set(|config, cache, name, args| {
+                let prefix = args.v6net().context(PREFIX_ERR)?;
+                let s = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                s.prefix = Some(prefix);
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                let s = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                s.prefix = None;
+                Ok(())
+            })
+            .path("/behavior")
+            .set(|config, cache, name, args| {
+                let raw = args.string().context(BEHAVIOR_ERR)?;
+                let b = LocatorBehavior::parse(&raw).context(BEHAVIOR_ERR)?;
+                let s = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                s.behavior = Some(b);
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                let s = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                s.behavior = None;
+                Ok(())
+            })
+    }
+
+    pub fn path(mut self, path: &str) -> Self {
+        let prefix = "/segment-routing/locator";
+        self.path = format!("{prefix}{path}");
+        self
+    }
+
+    pub fn set(mut self, func: Handler) -> Self {
+        self.map.insert((self.path.clone(), ConfigOp::Set), func);
+        self
+    }
+
+    pub fn del(mut self, func: Handler) -> Self {
+        self.map.insert((self.path.clone(), ConfigOp::Delete), func);
+        self
+    }
+}

--- a/zebra-rs/src/rib/segment_routing/mod.rs
+++ b/zebra-rs/src/rib/segment_routing/mod.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright 2025-2026 Kunihiro Ishiguro
+
+//! Segment Routing global configuration. Owns the SRGB/SRLB label blocks
+//! (SR-MPLS) and SRv6 locators that the per-protocol modules (IS-IS, OSPF,
+//! BGP-LU, ...) reference by name. The RIB is the natural owner because it
+//! tracks the install state for both the SID/label space and the routes
+//! that consume them.
+
+pub mod block;
+pub use block::{Block, BlockBuilder, BlockConfig};
+
+pub mod locator;
+pub use locator::{Locator, LocatorBuilder, LocatorConfig};

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -275,10 +275,26 @@ module config {
           }
         }
 
-        leaf segment-routing {
-          type enumeration {
-            enum mpls;
-            enum srv6;
+        container segment-routing {
+          container mpls {
+            presence "Enable Segment Routing over MPLS dataplane";
+            leaf block {
+              // Name of a block defined under the global
+              // /segment-routing/block list. Held as a string (not a
+              // leafref) so an IS-IS config can be staged before the
+              // global block is committed.
+              type string;
+            }
+          }
+          container srv6 {
+            presence "Enable Segment Routing over IPv6 dataplane";
+            leaf locator {
+              // Name of a locator defined under the global
+              // /segment-routing/locator list. Held as a string (not a
+              // leafref) so an IS-IS config can be staged before the
+              // global locator is committed.
+              type string;
+            }
           }
         }
 
@@ -654,6 +670,77 @@ module config {
           }
         }
 
+      }
+    }
+
+    container segment-routing {
+      ext:help "Segment Routing global configuration";
+      description
+        "Global Segment Routing configuration shared across protocols.
+         Blocks (SR-MPLS label ranges) and locators (SRv6 SID prefixes)
+         defined here can be referenced by name from the per-protocol
+         segment-routing sections (e.g. routing/isis/segment-routing/mpls
+         and routing/isis/segment-routing/srv6). Managed by the RIB,
+         which is the natural owner of the SID/label space and the
+         per-block / per-locator install state.";
+
+      list block {
+        key "name";
+        description
+          "SR-MPLS label block. Each block bundles an SR Global Block
+           (SRGB) and an SR Local Block (SRLB) under one name so multiple
+           protocols (IS-IS, OSPF, BGP-LU) can share the same
+           configuration by reference.";
+        leaf name {
+          type string;
+        }
+        container global {
+          description
+            "SR Global Block (SRGB) — prefix-SID label range advertised
+             to the SR domain. Matches the IS-IS SR Capability TLV
+             (RFC 8667 §3.1) <base-label, range> shape.";
+          leaf start {
+            type uint32;
+          }
+          leaf range {
+            type uint32;
+          }
+        }
+        container local {
+          description
+            "SR Local Block (SRLB) — adjacency-SID label range used
+             locally. Same <base-label, range> shape as global.";
+          leaf start {
+            type uint32;
+          }
+          leaf range {
+            type uint32;
+          }
+        }
+      }
+
+      list locator {
+        key "name";
+        description
+          "SRv6 locator. The prefix is the IPv6 range from which SIDs
+           are allocated; behavior selects the SID layout.";
+        leaf name {
+          type string;
+        }
+        leaf prefix {
+          type inet:ipv6-prefix;
+          description
+            "IPv6 prefix from which SIDs are allocated for this locator.";
+        }
+        leaf behavior {
+          type enumeration {
+            enum usid;
+          }
+          description
+            "Locator-wide endpoint behavior. 'usid' selects the
+             RFC 9800 NEXT-C-SID (micro-SID) format; absent means
+             the classic RFC 8986 full-SID layout.";
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Three-commit series introducing two parallel global concepts under a new top-level `/segment-routing/` YANG container:

- **block** — SR-MPLS label range. Each named block bundles SRGB and SRLB.
- **locator** — SRv6 SID prefix. Each named locator pairs an IPv6 prefix with a behavior (currently just `usid` for RFC 9800 NEXT-C-SID).

Per-protocol modules reference these by name. Today only IS-IS is wired:

| # | Commit | Purpose |
|---|---|---|
| 1 | `797d886` | YANG schema for the global block / locator and the IS-IS `segment-routing { mpls, srv6 }` containers. |
| 2 | `4a72e24` | RIB-side handlers: `BlockBuilder` / `LocatorBuilder` + applied-snapshot maps. |
| 3 | `135485b` | IS-IS handlers replacing the old `enum SegmentRouting { MPLS, SRv6 }` with paired (enabled, name) flags; both dataplanes can be enabled simultaneously. |

## YANG shape

```
segment-routing {
  block NAME {
    global { start; range; }
    local  { start; range; }
  }
  locator NAME {
    prefix <ipv6-prefix>
    behavior usid
  }
}

routing { isis {
  segment-routing {
    mpls { block NAME; }      # presence-marked container
    srv6 { locator NAME; }    # presence-marked container
  }
}}
```

CLI surface this produces:

```
set segment-routing block CORE global start 16000
set segment-routing block CORE global range 8000
set segment-routing block CORE local  start 15000
set segment-routing block CORE local  range 100
set segment-routing locator MAIN prefix fcbb:bbbb:2::/48
set segment-routing locator MAIN behavior usid

set routing isis segment-routing mpls
set routing isis segment-routing mpls block CORE
set routing isis segment-routing srv6
set routing isis segment-routing srv6 locator MAIN
```

## Behavioral changes

- The previous `leaf segment-routing { enum mpls; enum srv6; }` is replaced by the container above. Both dataplanes can now be enabled simultaneously (real deployments often run SR-MPLS today and add SRv6 incrementally).
- IS-IS LSP origination emits SR-MPLS Capability sub-TLVs when `sr_mpls_enabled` and the SRv6 sub-TLV when `sr_srv6_enabled`. The Algorithms sub-TLV is emitted exactly once even with both dataplanes configured.
- `IsisConfig::sr_enabled()` (= mpls || srv6) now gates emission of the TE Router ID TLV.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd`
- [x] Manual: each `set segment-routing ...` command parses and the daemon updates its applied snapshot.
- [x] Manual: `set routing isis segment-routing srv6 locator MAIN` flips `sr_srv6_enabled` and stores the locator name; same for the mpls path.

## Known follow-ups (deliberately out of scope here)

- **SRGB/SRLB still hardcoded** in `lsp_generate`. The block name is captured in `IsisConfig::sr_mpls_block` but not yet looked up against `Rib::blocks` — needs a RIB→IS-IS subscription channel for block / locator updates.
- **`show segment-routing`** commands to inspect `Rib::blocks` / `Rib::locators`.
- **BDD scenario** exercising the full config path end-to-end.

## Notes for reviewers

- `block` / `locator` references in IS-IS are held as `type string` (not `leafref`) so an IS-IS config can be staged before the global block / locator is committed — same pattern as `ext:dynamic "rib:interface"`.
- The applied-snapshot fields on `Block` / `Locator` carry `#[allow(dead_code)]` until the IS-IS lookup follow-up reads them; the matching `enum SegmentRouting` from before is removed entirely (no remaining callers).

Generated with [Claude Code](https://claude.com/claude-code)