### PR TITLE
feat(sr): IS-IS subscribes to RIB block/locator + default block

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -204,6 +204,7 @@ fn config_sr_mpls_enable(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<(
         isis.config.sr_mpls_enabled = false;
         isis.config.sr_mpls_block = None;
     }
+    isis.reconcile_block_watch();
     Some(())
 }
 
@@ -214,6 +215,7 @@ fn config_sr_mpls_block(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option
     } else {
         isis.config.sr_mpls_block = None;
     }
+    isis.reconcile_block_watch();
     Some(())
 }
 
@@ -224,6 +226,7 @@ fn config_sr_srv6_enable(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<(
         isis.config.sr_srv6_enabled = false;
         isis.config.sr_srv6_locator = None;
     }
+    isis.reconcile_locator_watch();
     Some(())
 }
 
@@ -234,6 +237,7 @@ fn config_sr_srv6_locator(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Opti
     } else {
         isis.config.sr_srv6_locator = None;
     }
+    isis.reconcile_locator_watch();
     Some(())
 }
 

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -15,7 +15,9 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 // (former SegmentRouting enum import — removed; replaced by sr_mpls_enabled
 // / sr_srv6_enabled flags on IsisConfig.)
+
 use crate::isis_event_trace;
+use crate::rib::{Block, DEFAULT_BLOCK_NAME, Locator, RibSrRx};
 
 use crate::config::{DisplayRequest, ShowChannel};
 use crate::isis::link::Afi;
@@ -74,6 +76,21 @@ pub struct Isis {
     pub local_pool: Option<LabelPool>,
     pub graph: Levels<Option<spf::Graph>>,
     pub spf_result: Levels<Option<BTreeMap<usize, spf::Path>>>,
+
+    /// SR-update return channel from the RIB. Carries the current value of
+    /// the watched block / locator and any subsequent updates.
+    pub sr_rx: UnboundedReceiver<RibSrRx>,
+
+    /// Currently-watched block name on the RIB side. Tracked separately
+    /// from sr_mpls_block so the reconcile helper can compute Watch /
+    /// Unwatch transitions correctly.
+    pub watched_block: Option<String>,
+    pub watched_locator: Option<String>,
+
+    /// Latest applied snapshot received from the RIB for the watched
+    /// names. None means the watched name doesn't exist (or no watch).
+    pub sr_block: Option<Block>,
+    pub sr_locator: Option<Locator>,
 }
 
 pub struct IsisTop<'a> {
@@ -94,6 +111,12 @@ pub struct IsisTop<'a> {
     pub spf_timer: &'a mut Levels<Option<Timer>>,
     pub graph: &'a mut Levels<Option<spf::Graph>>,
     pub spf_result: &'a mut Levels<Option<BTreeMap<usize, spf::Path>>>,
+
+    /// Read-only access to the SR snapshot the IS-IS instance is caching
+    /// from RIB::SrSubscribe. lsp_generate uses these to populate the SR
+    /// Capability / SRv6 sub-TLVs.
+    pub sr_block: &'a Option<Block>,
+    pub sr_locator: &'a Option<Locator>,
 }
 
 impl Isis {
@@ -104,6 +127,15 @@ impl Isis {
             tx: chan.tx.clone(),
         };
         let _ = rib_tx.send(msg);
+
+        // SR config subscription channel. One-time registration with the
+        // RIB; subsequent SrBlockWatch / SrLocatorWatch messages drive
+        // which named entries we receive updates for.
+        let (sr_tx, sr_rx) = mpsc::unbounded_channel::<RibSrRx>();
+        let _ = rib_tx.send(rib::Message::SrSubscribe {
+            proto: "isis".into(),
+            tx: sr_tx,
+        });
 
         let (tx, rx) = mpsc::unbounded_channel();
         let mut isis = Self {
@@ -131,6 +163,11 @@ impl Isis {
             local_pool: Some(LabelPool::new(15000, Some(16000))),
             graph: Levels::<Option<spf::Graph>>::default(),
             spf_result: Levels::<Option<BTreeMap<usize, spf::Path>>>::default(),
+            sr_rx,
+            watched_block: None,
+            watched_locator: None,
+            sr_block: None,
+            sr_locator: None,
         };
         isis.callback_build();
         isis.show_build();
@@ -425,6 +462,9 @@ impl Isis {
                 Some(msg) = self.rx.recv() => {
                     self.process_msg(msg);
                 }
+                Some(msg) = self.sr_rx.recv() => {
+                    self.process_sr_rx(msg);
+                }
             }
         }
     }
@@ -447,6 +487,8 @@ impl Isis {
             spf_timer: &mut self.spf_timer,
             graph: &mut self.graph,
             spf_result: &mut self.spf_result,
+            sr_block: &self.sr_block,
+            sr_locator: &self.sr_locator,
         }
     }
 
@@ -476,6 +518,108 @@ impl Isis {
             .get(&ifindex)
             .map_or_else(|| "unknown".to_string(), |link| link.state.name.clone())
     }
+
+    /// Compare desired block subscription against the currently-watched
+    /// name and emit Watch / Unwatch messages so they match. Called after
+    /// any config change that could affect `target_block_name`.
+    ///
+    /// On the unwatch transition we also drop the cached snapshot so a
+    /// subsequent re-subscription doesn't show a stale value during the
+    /// gap between Watch and the RIB's reply.
+    pub fn reconcile_block_watch(&mut self) {
+        let desired = target_block_name(&self.config);
+        if desired == self.watched_block {
+            return;
+        }
+        if let Some(prev) = self.watched_block.take() {
+            let _ = self.rib_tx.send(rib::Message::SrBlockUnwatch {
+                proto: "isis".into(),
+                name: prev,
+            });
+            self.sr_block = None;
+        }
+        if let Some(next) = desired {
+            let _ = self.rib_tx.send(rib::Message::SrBlockWatch {
+                proto: "isis".into(),
+                name: next.clone(),
+            });
+            self.watched_block = Some(next);
+        }
+    }
+
+    /// Mirror of `reconcile_block_watch` for the SRv6 locator name.
+    pub fn reconcile_locator_watch(&mut self) {
+        let desired = target_locator_name(&self.config);
+        if desired == self.watched_locator {
+            return;
+        }
+        if let Some(prev) = self.watched_locator.take() {
+            let _ = self.rib_tx.send(rib::Message::SrLocatorUnwatch {
+                proto: "isis".into(),
+                name: prev,
+            });
+            self.sr_locator = None;
+        }
+        if let Some(next) = desired {
+            let _ = self.rib_tx.send(rib::Message::SrLocatorWatch {
+                proto: "isis".into(),
+                name: next.clone(),
+            });
+            self.watched_locator = Some(next);
+        }
+    }
+
+    /// Apply a single update from the RIB SR subscription channel. We only
+    /// store updates for the names we currently watch; messages for stale
+    /// names (e.g. arriving after a switch) are dropped.
+    fn process_sr_rx(&mut self, msg: RibSrRx) {
+        match msg {
+            RibSrRx::Block { name, block } => {
+                if self.watched_block.as_deref() != Some(name.as_str()) {
+                    return;
+                }
+                self.sr_block = block;
+            }
+            RibSrRx::Locator { name, locator } => {
+                if self.watched_locator.as_deref() != Some(name.as_str()) {
+                    return;
+                }
+                self.sr_locator = locator;
+            }
+        }
+        // Re-originate both levels so the new SR snapshot is reflected in
+        // the next LSP without waiting for the refresh timer.
+        let _ = self.tx.send(Message::LspOriginate(Level::L1));
+        let _ = self.tx.send(Message::LspOriginate(Level::L2));
+    }
+}
+
+/// Decide which block this IS-IS instance should subscribe to.
+///
+/// `segment-routing mpls` enabled with no explicit `block` falls back to
+/// the canonical "default" block seeded by the RIB; an explicit name takes
+/// precedence. When SR-MPLS is disabled we want no subscription at all.
+fn target_block_name(cfg: &IsisConfig) -> Option<String> {
+    if !cfg.sr_mpls_enabled {
+        return None;
+    }
+    Some(
+        cfg.sr_mpls_block
+            .clone()
+            .unwrap_or_else(|| DEFAULT_BLOCK_NAME.to_string()),
+    )
+}
+
+/// Decide which locator this IS-IS instance should subscribe to.
+///
+/// SRv6 has no default locator: an enabled `segment-routing srv6` without
+/// a `locator` selection means "no SRv6 SID TLV will be originated", so
+/// no watch is registered.
+fn target_locator_name(cfg: &IsisConfig) -> Option<String> {
+    if !cfg.sr_srv6_enabled {
+        return None;
+    }
+    cfg.sr_srv6_locator.clone()
 }
 
 pub fn dis_generate(top: &mut IsisTop, level: Level, ifindex: u32, base: Option<u32>) -> IsisLsp {
@@ -632,22 +776,26 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
             subs: Vec::new(),
         };
 
-        // SR-MPLS Capability sub-TLVs.
-        // TODO(srv6-locator-config PR4): the SRGB / SRLB values below are
-        // hardcoded. Replace with a lookup of `top.config.sr_mpls_block`
-        // against RIB::blocks once the IS-IS daemon has access to the
-        // RIB-side block snapshot (probably via a Subscribe-style stream).
-        if top.config.sr_mpls_enabled {
-            let mut flags = SegmentRoutingCapFlags::default();
-            flags.set_i_flag(true);
-            flags.set_v_flag(true);
-            let sid_label = SidLabelTlv::Label(16000);
-            let sr_cap = IsisSubSegmentRoutingCap {
-                flags,
-                range: 8000,
-                sid_label,
-            };
-            cap.subs.push(sr_cap.into());
+        // SR-MPLS Capability sub-TLVs. Pulled from the RIB-side block
+        // snapshot (kept fresh via SrSubscribe / SrBlockWatch). When the
+        // configured block name doesn't resolve in the RIB the snapshot
+        // is None and we skip emitting the sub-TLVs entirely — better to
+        // advertise nothing than stale or fabricated values.
+        if top.config.sr_mpls_enabled
+            && let Some(block) = top.sr_block.as_ref()
+        {
+            if let Some(global) = block.global.as_ref() {
+                let mut flags = SegmentRoutingCapFlags::default();
+                flags.set_i_flag(true);
+                flags.set_v_flag(true);
+                let sid_label = SidLabelTlv::Label(global.start);
+                let sr_cap = IsisSubSegmentRoutingCap {
+                    flags,
+                    range: global.end - global.start,
+                    sid_label,
+                };
+                cap.subs.push(sr_cap.into());
+            }
 
             // Sub: SR Algorithms
             let algo = IsisSubSegmentRoutingAlgo {
@@ -656,17 +804,22 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
             cap.subs.push(algo.into());
 
             // Sub: SR Local Block
-            let sid_label = SidLabelTlv::Label(15000);
-            let lb = IsisSubSegmentRoutingLB {
-                flags: 0,
-                range: 3000,
-                sid_label,
-            };
-            cap.subs.push(lb.into());
+            if let Some(local) = block.local.as_ref() {
+                let sid_label = SidLabelTlv::Label(local.start);
+                let lb = IsisSubSegmentRoutingLB {
+                    flags: 0,
+                    range: local.end - local.start,
+                    sid_label,
+                };
+                cap.subs.push(lb.into());
+            }
         }
 
-        // SRv6 Capability sub-TLV.
-        if top.config.sr_srv6_enabled {
+        // SRv6 Capability sub-TLV. Only advertise when the configured
+        // locator actually resolved in the RIB; an `srv6` container with
+        // no usable locator means we have nothing to derive a SID from,
+        // so we don't claim SRv6 capability.
+        if top.config.sr_srv6_enabled && top.sr_locator.is_some() {
             let srv6 = IsisSubSrv6::default();
             cap.subs.push(srv6.into());
 
@@ -1813,5 +1966,73 @@ pub fn mpls_route(rib: &PrefixMap<Ipv4Net, SpfRoute>, ilm: &mut BTreeMap<u32, Sp
             };
             ilm.insert(sid, spf_ilm);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_block_falls_back_to_default_when_unset() {
+        // SR-MPLS enabled but no explicit block configured: should
+        // subscribe to the canonical "default" block.
+        let cfg = IsisConfig {
+            sr_mpls_enabled: true,
+            ..Default::default()
+        };
+        assert_eq!(target_block_name(&cfg), Some("default".to_string()));
+    }
+
+    #[test]
+    fn target_block_uses_explicit_name_when_set() {
+        let cfg = IsisConfig {
+            sr_mpls_enabled: true,
+            sr_mpls_block: Some("custom".into()),
+            ..Default::default()
+        };
+        assert_eq!(target_block_name(&cfg), Some("custom".to_string()));
+    }
+
+    #[test]
+    fn target_block_returns_none_when_mpls_disabled() {
+        // The block name on its own should never produce a watch when
+        // SR-MPLS isn't enabled — otherwise we'd subscribe to stale
+        // config left behind after disabling the container.
+        let cfg = IsisConfig {
+            sr_mpls_block: Some("custom".into()),
+            ..Default::default()
+        };
+        assert_eq!(target_block_name(&cfg), None);
+    }
+
+    #[test]
+    fn target_locator_returns_none_when_unset() {
+        // SRv6 enabled with no locator: no default exists, so we must
+        // not subscribe — IS-IS will not originate the SRv6 SID TLV.
+        let cfg = IsisConfig {
+            sr_srv6_enabled: true,
+            ..Default::default()
+        };
+        assert_eq!(target_locator_name(&cfg), None);
+    }
+
+    #[test]
+    fn target_locator_uses_explicit_name_when_set() {
+        let cfg = IsisConfig {
+            sr_srv6_enabled: true,
+            sr_srv6_locator: Some("loc1".into()),
+            ..Default::default()
+        };
+        assert_eq!(target_locator_name(&cfg), Some("loc1".to_string()));
+    }
+
+    #[test]
+    fn target_locator_returns_none_when_srv6_disabled() {
+        let cfg = IsisConfig {
+            sr_srv6_locator: Some("loc1".into()),
+            ..Default::default()
+        };
+        assert_eq!(target_locator_name(&cfg), None);
     }
 }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -5,9 +5,9 @@ use super::api::RibRx;
 use super::entry::RibEntry;
 use super::link::{LinkConfig, link_config_exec};
 use super::{
-    Block, BlockBuilder, BlockConfig, BridgeBuilder, BridgeConfig, Link, Locator, LocatorBuilder,
-    LocatorConfig, MacAddr, MplsConfig, Nexthop, NexthopMap, RibType, StaticConfig, V4, V6, Vxlan,
-    VxlanBuilder, VxlanConfig,
+    Block, BlockBuilder, BlockConfig, BridgeBuilder, BridgeConfig, DEFAULT_BLOCK_NAME, Link,
+    Locator, LocatorBuilder, LocatorConfig, MacAddr, MplsConfig, Nexthop, NexthopMap, RibSrRx,
+    RibType, StaticConfig, V4, V6, Vxlan, VxlanBuilder, VxlanConfig,
 };
 
 use crate::config::{Args, path_from_command};
@@ -20,7 +20,7 @@ use crate::rib::route::{ipv4_nexthop_sync, ipv4_route_sync, ipv6_nexthop_sync, i
 use crate::rib::{Bridge, RibEntries};
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use prefix_trie::PrefixMap;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::net::{IpAddr, Ipv4Addr};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
@@ -77,6 +77,40 @@ pub enum Message {
         config: LocatorConfig,
     },
     LocatorDel {
+        name: String,
+    },
+    // The Sr* variants below carry #[allow(dead_code)] because they're
+    // produced only by per-protocol subscribers (IS-IS lands in PR 2).
+    // Removed once PR 2 wires the IS-IS sender side.
+    /// One-time per-protocol registration of the SR return channel. The
+    /// channel carries `RibSrRx` updates for any block / locator the
+    /// protocol later watches.
+    #[allow(dead_code)]
+    SrSubscribe {
+        proto: String,
+        tx: UnboundedSender<RibSrRx>,
+    },
+    /// Register interest in a named block. Triggers an immediate push of
+    /// the current `Rib::blocks.get(name)` value (Some or None) and any
+    /// subsequent updates.
+    #[allow(dead_code)]
+    SrBlockWatch {
+        proto: String,
+        name: String,
+    },
+    #[allow(dead_code)]
+    SrBlockUnwatch {
+        proto: String,
+        name: String,
+    },
+    #[allow(dead_code)]
+    SrLocatorWatch {
+        proto: String,
+        name: String,
+    },
+    #[allow(dead_code)]
+    SrLocatorUnwatch {
+        proto: String,
         name: String,
     },
     VxlanAdd {
@@ -183,6 +217,13 @@ pub struct Rib {
     /// `srv6/locator` reference.
     pub blocks: BTreeMap<String, Block>,
     pub locators: BTreeMap<String, Locator>,
+    /// SR-update return channels keyed by protocol name. One sender per
+    /// protocol; established once via Message::SrSubscribe.
+    pub sr_clients: BTreeMap<String, UnboundedSender<RibSrRx>>,
+    /// Per-name block watchers — set of protocol names interested in
+    /// updates to that block.
+    pub block_watch: BTreeMap<String, BTreeSet<String>>,
+    pub locator_watch: BTreeMap<String, BTreeSet<String>>,
     pub nmap: NexthopMap,
     pub router_id: Ipv4Addr,
 
@@ -229,8 +270,17 @@ impl Rib {
             vxlan_config: VxlanBuilder::new(),
             block_config: BlockBuilder::new(),
             locator_config: LocatorBuilder::new(),
-            blocks: BTreeMap::new(),
+            blocks: {
+                // Seed the canonical default block at startup so protocols can
+                // subscribe to "default" without anyone having configured one.
+                let mut m = BTreeMap::new();
+                m.insert(DEFAULT_BLOCK_NAME.to_string(), Block::default_block());
+                m
+            },
             locators: BTreeMap::new(),
+            sr_clients: BTreeMap::new(),
+            block_watch: BTreeMap::new(),
+            locator_watch: BTreeMap::new(),
             nmap: NexthopMap::default(),
             router_id: Ipv4Addr::UNSPECIFIED,
             rib_sync_timer: None,
@@ -256,6 +306,38 @@ impl Rib {
                 let _ = tx.send(Message::Resolve);
             }
         }));
+    }
+
+    /// Push the current value of `blocks[name]` (Some / None) to every
+    /// protocol that has registered a watch on this name.
+    fn notify_block_watchers(&self, name: &str) {
+        let Some(watchers) = self.block_watch.get(name) else {
+            return;
+        };
+        let block = self.blocks.get(name).cloned();
+        for proto in watchers {
+            if let Some(tx) = self.sr_clients.get(proto) {
+                let _ = tx.send(RibSrRx::Block {
+                    name: name.to_string(),
+                    block: block.clone(),
+                });
+            }
+        }
+    }
+
+    fn notify_locator_watchers(&self, name: &str) {
+        let Some(watchers) = self.locator_watch.get(name) else {
+            return;
+        };
+        let locator = self.locators.get(name).cloned();
+        for proto in watchers {
+            if let Some(tx) = self.sr_clients.get(proto) {
+                let _ = tx.send(RibSrRx::Locator {
+                    name: name.to_string(),
+                    locator: locator.clone(),
+                });
+            }
+        }
     }
 
     pub fn subscribe(&mut self, tx: UnboundedSender<RibRx>, _proto: String) {
@@ -337,17 +419,73 @@ impl Rib {
             }
             Message::BlockAdd { name, config } => {
                 let block = config.to_block(&name);
-                self.blocks.insert(name, block);
+                self.blocks.insert(name.clone(), block);
+                self.notify_block_watchers(&name);
             }
             Message::BlockDel { name } => {
                 self.blocks.remove(&name);
+                // The default block is always present — re-seed it so a
+                // delete of `default` reverts to the canonical values
+                // rather than leaving subscribers without a block.
+                if name == DEFAULT_BLOCK_NAME {
+                    self.blocks
+                        .insert(DEFAULT_BLOCK_NAME.to_string(), Block::default_block());
+                }
+                self.notify_block_watchers(&name);
             }
             Message::LocatorAdd { name, config } => {
                 let locator = config.to_locator(&name);
-                self.locators.insert(name, locator);
+                self.locators.insert(name.clone(), locator);
+                self.notify_locator_watchers(&name);
             }
             Message::LocatorDel { name } => {
                 self.locators.remove(&name);
+                self.notify_locator_watchers(&name);
+            }
+            Message::SrSubscribe { proto, tx } => {
+                self.sr_clients.insert(proto, tx);
+            }
+            Message::SrBlockWatch { proto, name } => {
+                self.block_watch
+                    .entry(name.clone())
+                    .or_default()
+                    .insert(proto.clone());
+                // Push the current value so the subscriber doesn't have to
+                // wait for the next change to learn what's there today.
+                if let Some(tx) = self.sr_clients.get(&proto) {
+                    let _ = tx.send(RibSrRx::Block {
+                        name: name.clone(),
+                        block: self.blocks.get(&name).cloned(),
+                    });
+                }
+            }
+            Message::SrBlockUnwatch { proto, name } => {
+                if let Some(set) = self.block_watch.get_mut(&name) {
+                    set.remove(&proto);
+                    if set.is_empty() {
+                        self.block_watch.remove(&name);
+                    }
+                }
+            }
+            Message::SrLocatorWatch { proto, name } => {
+                self.locator_watch
+                    .entry(name.clone())
+                    .or_default()
+                    .insert(proto.clone());
+                if let Some(tx) = self.sr_clients.get(&proto) {
+                    let _ = tx.send(RibSrRx::Locator {
+                        name: name.clone(),
+                        locator: self.locators.get(&name).cloned(),
+                    });
+                }
+            }
+            Message::SrLocatorUnwatch { proto, name } => {
+                if let Some(set) = self.locator_watch.get_mut(&name) {
+                    set.remove(&proto);
+                    if set.is_empty() {
+                        self.locator_watch.remove(&name);
+                    }
+                }
             }
             Message::Shutdown { tx } => {
                 self.nmap.shutdown(&self.fib_handle).await;

--- a/zebra-rs/src/rib/segment_routing/block.rs
+++ b/zebra-rs/src/rib/segment_routing/block.rs
@@ -19,7 +19,7 @@ use crate::spf::label_block::LabelBlock;
 /// both `start` and `range` were configured for the corresponding container.
 ///
 /// Fields carry `#[allow(dead_code)]` until the IS-IS-side `mpls/block`
-/// handler (next PR) reads them by name from `Rib::blocks`.
+/// handler reads them by name from `Rib::blocks`.
 #[allow(dead_code)]
 #[derive(Debug, Default, Clone)]
 pub struct Block {
@@ -28,6 +28,28 @@ pub struct Block {
     pub global: Option<LabelBlock>,
     /// SR Local Block (SRLB) — adjacency-SID label range.
     pub local: Option<LabelBlock>,
+}
+
+/// Canonical name of the default block, always present in `Rib::blocks`.
+/// Operators get this for free without explicit configuration; protocols
+/// that subscribe to "default" without a custom block fall back to it.
+pub const DEFAULT_BLOCK_NAME: &str = "default";
+
+const DEFAULT_GLOBAL_START: u32 = 16000;
+const DEFAULT_GLOBAL_RANGE: u32 = 8000;
+const DEFAULT_LOCAL_START: u32 = 15000;
+const DEFAULT_LOCAL_RANGE: u32 = 100;
+
+impl Block {
+    /// The default block — seeded into `Rib::blocks` at startup and re-seeded
+    /// after a delete of the same name. SRGB 16000..23999 + SRLB 15000..15099.
+    pub fn default_block() -> Self {
+        Self {
+            name: DEFAULT_BLOCK_NAME.to_string(),
+            global: Some(LabelBlock::new(DEFAULT_GLOBAL_START, DEFAULT_GLOBAL_RANGE)),
+            local: Some(LabelBlock::new(DEFAULT_LOCAL_START, DEFAULT_LOCAL_RANGE)),
+        }
+    }
 }
 
 /// In-flight Block configuration, mirroring the YANG list shape:
@@ -247,5 +269,33 @@ impl ConfigBuilder {
     pub fn del(mut self, func: Handler) -> Self {
         self.map.insert((self.path.clone(), ConfigOp::Delete), func);
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_block_has_canonical_values() {
+        let b = Block::default_block();
+        assert_eq!(b.name, DEFAULT_BLOCK_NAME);
+
+        // LabelBlock stores (start, end = start + range), so verify the
+        // pair through that derived shape.
+        let global = b.global.expect("default block has SRGB");
+        assert_eq!(global.start, DEFAULT_GLOBAL_START);
+        assert_eq!(global.end, DEFAULT_GLOBAL_START + DEFAULT_GLOBAL_RANGE);
+
+        let local = b.local.expect("default block has SRLB");
+        assert_eq!(local.start, DEFAULT_LOCAL_START);
+        assert_eq!(local.end, DEFAULT_LOCAL_START + DEFAULT_LOCAL_RANGE);
+    }
+
+    #[test]
+    fn default_block_uses_canonical_name() {
+        // The seeded default lives at the literal name "default" — that's
+        // the name protocols watch when no explicit block is configured.
+        assert_eq!(DEFAULT_BLOCK_NAME, "default");
     }
 }

--- a/zebra-rs/src/rib/segment_routing/mod.rs
+++ b/zebra-rs/src/rib/segment_routing/mod.rs
@@ -8,7 +8,26 @@
 //! that consume them.
 
 pub mod block;
-pub use block::{Block, BlockBuilder, BlockConfig};
+pub use block::{Block, BlockBuilder, BlockConfig, DEFAULT_BLOCK_NAME};
 
 pub mod locator;
 pub use locator::{Locator, LocatorBuilder, LocatorConfig};
+
+/// Subscription-channel return type from RIB to a protocol module.
+/// `block: None` / `locator: None` signals deletion (or "doesn't exist
+/// yet" if the protocol asked for a name that hasn't been configured).
+///
+/// The variants carry `#[allow(dead_code)]` until PR 2 of this branch
+/// wires the IS-IS-side consumer that destructures them.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum RibSrRx {
+    Block {
+        name: String,
+        block: Option<Block>,
+    },
+    Locator {
+        name: String,
+        locator: Option<Locator>,
+    },
+}


### PR DESCRIPTION
## Summary

- **RIB side**: Adds a `SrSubscribe` / `SrBlockWatch` / `SrLocatorWatch`-style subscription channel to push named SR-MPLS block and SRv6 locator snapshots to subscribed protocols. Seeds a canonical `default` block (SRGB 16000+8000, SRLB 15000+100) so operators get useful defaults without explicit config; the default is re-seeded after delete.
- **IS-IS side**: Subscribes on startup; per-config-commit `reconcile_block_watch` / `reconcile_locator_watch` send Watch/Unwatch as the operator changes `segment-routing mpls block` / `srv6 locator`. Snapshot lives in `Isis.sr_block` / `sr_locator` and is consumed by `lsp_generate` to populate the SR-MPLS Capability / SR Local Block sub-TLVs from real values rather than the previously-hardcoded 16000/8000/15000/3000. SRv6 capability is suppressed when the configured locator doesn't resolve in the RIB.
- Default-fallback rule is asymmetric: SR-MPLS without an explicit `block` watches `"default"`; SRv6 has no default — no locator means no SRv6 sub-TLV at all.

## Test plan

- [x] `cargo build --bin zebra-rs` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — all suites pass, including 6 new `target_block_name` / `target_locator_name` unit tests and the 2 new `Block::default_block` tests
- [x] `cargo fmt --all -- --check` clean
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)