### PR TITLE
feat(rib): SRv6 SID registry + show segment-routing srv6 sid

### DIFF
--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -7,7 +7,7 @@ use super::link::{LinkConfig, link_config_exec};
 use super::{
     Block, BlockBuilder, BlockConfig, BridgeBuilder, BridgeConfig, DEFAULT_BLOCK_NAME, Link,
     Locator, LocatorBuilder, LocatorConfig, MacAddr, MplsConfig, Nexthop, NexthopMap, RibSrRx,
-    RibType, StaticConfig, V4, V6, Vxlan, VxlanBuilder, VxlanConfig,
+    RibType, Sid, StaticConfig, V4, V6, Vxlan, VxlanBuilder, VxlanConfig,
 };
 
 use crate::config::{Args, path_from_command};
@@ -113,6 +113,17 @@ pub enum Message {
         proto: String,
         name: String,
     },
+    /// Register an allocated SRv6 SID. Owners (IS-IS, OSPF, BGP) push
+    /// one of these whenever they carve a function out of a locator;
+    /// the RIB stores it for `show segment-routing srv6 sid`.
+    #[allow(dead_code)]
+    SidAdd {
+        sid: Sid,
+    },
+    #[allow(dead_code)]
+    SidDel {
+        addr: std::net::Ipv6Addr,
+    },
     VxlanAdd {
         name: String,
         config: VxlanConfig,
@@ -217,6 +228,10 @@ pub struct Rib {
     /// `srv6/locator` reference.
     pub blocks: BTreeMap<String, Block>,
     pub locators: BTreeMap<String, Locator>,
+    /// Allocated SRv6 SIDs across all owners. Keyed by SID address so
+    /// inserts collide naturally on duplicate allocations; the show
+    /// callback iterates this in address order.
+    pub sids: BTreeMap<std::net::Ipv6Addr, Sid>,
     /// SR-update return channels keyed by protocol name. One sender per
     /// protocol; established once via Message::SrSubscribe.
     pub sr_clients: BTreeMap<String, UnboundedSender<RibSrRx>>,
@@ -278,6 +293,7 @@ impl Rib {
                 m
             },
             locators: BTreeMap::new(),
+            sids: BTreeMap::new(),
             sr_clients: BTreeMap::new(),
             block_watch: BTreeMap::new(),
             locator_watch: BTreeMap::new(),
@@ -486,6 +502,15 @@ impl Rib {
                         self.locator_watch.remove(&name);
                     }
                 }
+            }
+            Message::SidAdd { sid } => {
+                // Last-writer-wins: a re-add with the same address replaces
+                // the old entry. Owners are responsible for not double-
+                // allocating; this just keeps the registry consistent.
+                self.sids.insert(sid.addr, sid);
+            }
+            Message::SidDel { addr } => {
+                self.sids.remove(&addr);
             }
             Message::Shutdown { tx } => {
                 self.nmap.shutdown(&self.fib_handle).await;

--- a/zebra-rs/src/rib/segment_routing/mod.rs
+++ b/zebra-rs/src/rib/segment_routing/mod.rs
@@ -13,6 +13,13 @@ pub use block::{Block, BlockBuilder, BlockConfig, DEFAULT_BLOCK_NAME};
 pub mod locator;
 pub use locator::{Locator, LocatorBuilder, LocatorConfig};
 
+pub mod sid;
+// PR 2 wires up the IS-IS allocators that consume these types; until
+// then only the show callback reaches into `Sid` and these helper
+// types stay technically unused at the crate boundary.
+#[allow(unused_imports)]
+pub use sid::{Sid, SidAllocationType, SidBehavior, SidContext, SidOwner};
+
 /// Subscription-channel return type from RIB to a protocol module.
 /// `block: None` / `locator: None` signals deletion (or "doesn't exist
 /// yet" if the protocol asked for a name that hasn't been configured).

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright 2025-2026 Kunihiro Ishiguro
+
+//! SRv6 SID allocation registry. Each entry is one SID address that some
+//! protocol (IS-IS, OSPF, BGP) has carved out of a locator and is now
+//! advertising as End / End.X / End.DT4 / etc. The RIB is the central
+//! registry so `show segment-routing srv6 sid` has a single source of
+//! truth across protocols.
+
+use std::fmt;
+use std::net::Ipv6Addr;
+
+/// RFC 8986 endpoint behavior for an allocated SID. We only carry the
+/// variants we know how to advertise today; future behaviors (uSID,
+/// End.DT4, End.DT6, End.B6, ...) extend the enum.
+///
+/// `#[allow(dead_code)]` on the type until PR 2 starts populating the
+/// registry; the show callback already discriminates on every variant
+/// so no individual variant carries the attribute.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SidBehavior {
+    /// Plain End — RFC 8986 §4.1, "node SID". The SID identifies the
+    /// owner node; no per-link context.
+    End,
+    /// End.X — RFC 8986 §4.2, "L3 cross-connect" / adjacency SID.
+    /// Bound to a specific outgoing interface and neighbor.
+    EndX,
+}
+
+impl fmt::Display for SidBehavior {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::End => write!(f, "End"),
+            Self::EndX => write!(f, "End.X"),
+        }
+    }
+}
+
+/// Optional context that disambiguates per-link / per-VRF SIDs. End is
+/// always `None`; End.X carries the outgoing interface name. Future
+/// per-VRF behaviors (End.DT4, End.DT6) would add a `Vrf(String)`.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SidContext {
+    None,
+    Interface(String),
+}
+
+impl fmt::Display for SidContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::None => write!(f, "-"),
+            Self::Interface(name) => write!(f, "Interface '{}'", name),
+        }
+    }
+}
+
+/// How the SID's function bits were chosen. `Dynamic` is the common
+/// case (allocator picks the next free function); `Explicit` covers an
+/// operator-configured SID and is reserved for a future static-SID
+/// feature.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SidAllocationType {
+    Dynamic,
+    Explicit,
+}
+
+impl fmt::Display for SidAllocationType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Dynamic => write!(f, "dynamic"),
+            Self::Explicit => write!(f, "explicit"),
+        }
+    }
+}
+
+/// Owner of a SID, rendered as "isis(0)" / "bgp(0)" in the show table.
+/// The instance number gives operators a hook for future multi-instance
+/// support (separate L1 / L2 IS-IS instances, multiple BGP VRFs, ...);
+/// today every protocol passes 0.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SidOwner {
+    pub proto: String,
+    pub instance: u32,
+}
+
+impl SidOwner {
+    #[allow(dead_code)] // first user lands in PR 2 (IS-IS End SID allocator)
+    pub fn new(proto: impl Into<String>, instance: u32) -> Self {
+        Self {
+            proto: proto.into(),
+            instance,
+        }
+    }
+}
+
+impl fmt::Display for SidOwner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}({})", self.proto, self.instance)
+    }
+}
+
+/// A single allocated SID — one row in `show segment-routing srv6 sid`.
+/// Identified uniquely by `addr`; the registry rejects duplicate adds
+/// without going through a Del first.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Sid {
+    pub addr: Ipv6Addr,
+    pub behavior: SidBehavior,
+    pub context: SidContext,
+    pub owner: SidOwner,
+    pub locator: String,
+    pub allocation_type: SidAllocationType,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn behavior_render_matches_show_table() {
+        assert_eq!(SidBehavior::End.to_string(), "End");
+        assert_eq!(SidBehavior::EndX.to_string(), "End.X");
+    }
+
+    #[test]
+    fn context_none_renders_as_dash() {
+        // Operators expect a literal '-' for End SIDs (no interface
+        // binding); empty string would look like a missing field.
+        assert_eq!(SidContext::None.to_string(), "-");
+    }
+
+    #[test]
+    fn context_interface_quotes_the_name() {
+        assert_eq!(
+            SidContext::Interface("enp0s7".into()).to_string(),
+            "Interface 'enp0s7'"
+        );
+    }
+
+    #[test]
+    fn owner_renders_with_instance_in_parens() {
+        assert_eq!(SidOwner::new("isis", 0).to_string(), "isis(0)");
+        assert_eq!(SidOwner::new("bgp", 1).to_string(), "bgp(1)");
+    }
+
+    #[test]
+    fn allocation_type_renders_lowercase() {
+        // Lower-case matches the FRR-style table in the design doc and
+        // keeps the column narrow.
+        assert_eq!(SidAllocationType::Dynamic.to_string(), "dynamic");
+        assert_eq!(SidAllocationType::Explicit.to_string(), "explicit");
+    }
+}

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -13,6 +13,19 @@ use crate::{
 use super::{Group, Rib, entry::RibEntry, inst::ShowCallback, link::link_show, nexthop_show};
 use std::fmt::Write;
 
+// Column widths for `show segment-routing srv6 sid`. Sized to fit the
+// example output in the design doc (longest realistic SID, "End.X",
+// "Interface 'enp0s7'", "isis(0)", a typical locator name, "explicit").
+// IPv6 addresses can in principle stretch up to 39 chars; the format
+// strings use `width$` so a wider value just shifts the next column
+// rather than truncating.
+const SID_COL: usize = 18;
+const BEHAVIOR_COL: usize = 11;
+const CONTEXT_COL: usize = 21;
+const OWNER_COL: usize = 18;
+const LOCATOR_COL: usize = 10;
+const ALLOC_COL: usize = 16;
+
 // "via" word prefix in show output. SRv6-encapsulated nexthops surface as
 // "via seg6 <segments>" to match the iproute2 / FRR convention; plain
 // nexthops keep the bare "via".
@@ -910,6 +923,107 @@ impl Rib {
         self.show_add("/show/nexthop", nexthop_show);
         self.show_add("/show/mpls/ilm", ilm_show);
         self.show_add("/show/l2/mac/table", mac_show);
+        self.show_add("/show/segment-routing/srv6/sid", sid_show);
+    }
+}
+
+/// Render `show segment-routing srv6 sid`. Always emits the header row
+/// (matches FRR-style output where an empty body still tells the
+/// operator the command is wired and they're just not allocating any
+/// SIDs yet).
+pub fn sid_show(rib: &Rib, _args: Args, json: bool) -> String {
+    if json {
+        let entries: Vec<SidJson> = rib.sids.values().map(SidJson::from).collect();
+        return serde_json::to_string_pretty(&SidTable { entries })
+            .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize SIDs: {}\"}}", e));
+    }
+    sid_show_text(&rib.sids)
+}
+
+fn sid_show_text(sids: &std::collections::BTreeMap<std::net::Ipv6Addr, super::Sid>) -> String {
+    let mut buf = String::new();
+    writeln!(
+        buf,
+        " {sid:<sid_w$}{behavior:<beh_w$}{context:<ctx_w$}{owner:<own_w$}{loc:<loc_w$}{alloc:<alloc_w$}",
+        sid = "SID",
+        behavior = "Behavior",
+        context = "Context",
+        owner = "Daemon/Instance",
+        loc = "Locator",
+        alloc = "AllocationType",
+        sid_w = SID_COL,
+        beh_w = BEHAVIOR_COL,
+        ctx_w = CONTEXT_COL,
+        own_w = OWNER_COL,
+        loc_w = LOCATOR_COL,
+        alloc_w = ALLOC_COL,
+    )
+    .unwrap();
+    writeln!(
+        buf,
+        " {sid:-<sid_w$}  {ctx:-<ctx_w$}  {own:-<own_w$}  {loc:-<loc_w$}  {alloc:-<alloc_w$}",
+        sid = "",
+        ctx = "",
+        own = "",
+        loc = "",
+        alloc = "",
+        // Header underlines run SID+Behavior together, then a 2-space
+        // gap before each remaining column, matching the design doc
+        // sample.
+        sid_w = SID_COL + BEHAVIOR_COL - 1,
+        ctx_w = CONTEXT_COL - 2,
+        own_w = OWNER_COL - 2,
+        loc_w = LOCATOR_COL - 2,
+        alloc_w = ALLOC_COL,
+    )
+    .unwrap();
+    for sid in sids.values() {
+        writeln!(
+            buf,
+            " {addr:<sid_w$}{behavior:<beh_w$}{context:<ctx_w$}{owner:<own_w$}{loc:<loc_w$}{alloc:<alloc_w$}",
+            addr = sid.addr.to_string(),
+            behavior = sid.behavior.to_string(),
+            context = sid.context.to_string(),
+            owner = sid.owner.to_string(),
+            loc = sid.locator,
+            alloc = sid.allocation_type.to_string(),
+            sid_w = SID_COL,
+            beh_w = BEHAVIOR_COL,
+            ctx_w = CONTEXT_COL,
+            own_w = OWNER_COL,
+            loc_w = LOCATOR_COL,
+            alloc_w = ALLOC_COL,
+        )
+        .unwrap();
+    }
+    buf
+}
+
+#[derive(Serialize)]
+struct SidTable {
+    entries: Vec<SidJson>,
+}
+
+#[derive(Serialize)]
+struct SidJson {
+    sid: String,
+    behavior: String,
+    context: String,
+    owner: String,
+    locator: String,
+    allocation_type: String,
+}
+
+impl From<&super::Sid> for SidJson {
+    fn from(s: &super::Sid) -> Self {
+        Self {
+            sid: s.addr.to_string(),
+            behavior: s.behavior.to_string(),
+            context: s.context.to_string(),
+            owner: s.owner.to_string(),
+            locator: s.locator.clone(),
+            allocation_type: s.allocation_type.to_string(),
+        }
     }
 }
 
@@ -977,5 +1091,69 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(via_addr(&plain), "2001:db8::1");
+    }
+
+    use super::super::{Sid, SidAllocationType, SidBehavior, SidContext, SidOwner};
+    use std::collections::BTreeMap;
+
+    fn sid(addr: &str, behavior: SidBehavior, ctx: SidContext) -> Sid {
+        Sid {
+            addr: addr.parse().unwrap(),
+            behavior,
+            context: ctx,
+            owner: SidOwner::new("isis", 0),
+            locator: "LOC_N1".to_string(),
+            allocation_type: SidAllocationType::Dynamic,
+        }
+    }
+
+    #[test]
+    fn sid_show_empty_emits_header_only() {
+        // An empty registry must still produce a header so operators
+        // can tell the command is wired and they just aren't allocating
+        // anything yet — silence would look like a broken handler.
+        let out = sid_show_text(&BTreeMap::new());
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("SID"));
+        assert!(lines[0].contains("Behavior"));
+        assert!(lines[0].contains("AllocationType"));
+        assert!(lines[1].starts_with(" -"));
+    }
+
+    #[test]
+    fn sid_show_renders_end_and_endx_rows() {
+        let mut sids: BTreeMap<Ipv6Addr, Sid> = BTreeMap::new();
+        let end = sid("2001:db8:a:2::", SidBehavior::End, SidContext::None);
+        let endx = sid(
+            "2001:db8:a:2:1::",
+            SidBehavior::EndX,
+            SidContext::Interface("enp0s7".into()),
+        );
+        sids.insert(end.addr, end);
+        sids.insert(endx.addr, endx);
+
+        let out = sid_show_text(&sids);
+        // BTreeMap iterates by key — End sorts before End.X, matching
+        // the design-doc example ordering.
+        let body: Vec<&str> = out.lines().skip(2).collect();
+        assert_eq!(body.len(), 2);
+        assert!(
+            body[0].contains("2001:db8:a:2::") && body[0].contains("End ") && body[0].contains("-"),
+            "End row: {}",
+            body[0]
+        );
+        assert!(
+            body[1].contains("2001:db8:a:2:1::")
+                && body[1].contains("End.X")
+                && body[1].contains("Interface 'enp0s7'"),
+            "End.X row: {}",
+            body[1]
+        );
+        for line in &body {
+            assert!(line.contains("isis(0)"));
+            assert!(line.contains("LOC_N1"));
+            assert!(line.contains("dynamic"));
+        }
     }
 }

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -240,6 +240,18 @@ module exec {
       ext:help "Show policy";
       presence "Show policy";
     }
+    container segment-routing {
+      ext:help "Show segment-routing";
+      presence "Segment Routing";
+      container srv6 {
+        ext:help "Show SRv6";
+        presence "SRv6";
+        leaf sid {
+          ext:help "Show allocated SRv6 SIDs";
+          type empty;
+        }
+      }
+    }
     container "prefix-set" {
       ext:help "Show prefix-set";
       presence "Show prefix-set";


### PR DESCRIPTION
## Summary

PR 1 of 3 toward IS-IS SRv6 SID origination. RIB-side plumbing only: introduce a central registry that protocol owners (IS-IS End/End.X in PR 2/3, OSPF/BGP later) push allocated SIDs into, and expose it through the FRR-style ``show segment-routing srv6 sid`` table.

- New ``Sid`` types in ``rib/segment_routing/sid.rs``: ``SidBehavior::{End, EndX}``, ``SidContext::{None, Interface}``, ``SidAllocationType::{Dynamic, Explicit}``, ``SidOwner { proto, instance }`` rendered as ``isis(0)``.
- ``Message::SidAdd { sid }`` / ``Message::SidDel { addr }`` + ``Rib::sids: BTreeMap<Ipv6Addr, Sid>`` with last-writer-wins semantics on the address key.
- ``/show/segment-routing/srv6/sid`` YANG leaf and ``sid_show`` text + JSON renderer; empty registry still prints the header row so an unallocated state is unambiguous.
- 7 unit tests covering Display formatting per type, empty-table header-only output, and a populated End + End.X table matching the design doc.

No owner populates the registry yet, so today the table is always empty — PR 2 brings IS-IS End SID allocation online.

## Test plan

- [x] ``cargo build --bin zebra-rs`` clean
- [x] ``cargo clippy --workspace --all-targets -- -D warnings`` clean
- [x] ``cargo test --workspace`` — 118 zebra-rs tests pass, all suites green
- [x] ``cargo fmt --all -- --check`` clean
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)