### PR TITLE
feat(isis): allocate End SID + emit SRv6 Locators TLV

### DIFF
--- a/crates/isis-packet/src/sub/mod.rs
+++ b/crates/isis-packet/src/sub/mod.rs
@@ -32,9 +32,9 @@ pub mod neigh_disp;
 
 pub mod prefix;
 pub use prefix::{
-    IsisSub2Tlv, IsisSubPrefixSid, IsisTlvExtIpReach, IsisTlvExtIpReachEntry, IsisTlvIpv6Reach,
-    IsisTlvIpv6ReachEntry, IsisTlvMtIpReach, IsisTlvMtIpv6Reach, IsisTlvMultiTopology, IsisTlvSrv6,
-    MultiTopologyId, PrefixSidFlags,
+    IsisSub2Tlv, IsisSubPrefixSid, IsisSubSrv6EndSid, IsisTlvExtIpReach, IsisTlvExtIpReachEntry,
+    IsisTlvIpv6Reach, IsisTlvIpv6ReachEntry, IsisTlvMtIpReach, IsisTlvMtIpv6Reach,
+    IsisTlvMultiTopology, IsisTlvSrv6, MultiTopologyId, PrefixSidFlags, Srv6Locator,
 };
 pub mod prefix_code;
 pub use prefix_code::{IsisPrefixCode, IsisSrv6SidSub2Code};

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -17,7 +17,10 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 // / sr_srv6_enabled flags on IsisConfig.)
 
 use crate::isis_event_trace;
-use crate::rib::{Block, DEFAULT_BLOCK_NAME, Locator, RibSrRx};
+use crate::rib::{
+    Block, DEFAULT_BLOCK_NAME, Locator, RibSrRx, Sid, SidAllocationType, SidBehavior, SidContext,
+    SidOwner,
+};
 
 use crate::config::{DisplayRequest, ShowChannel};
 use crate::isis::link::Afi;
@@ -91,6 +94,12 @@ pub struct Isis {
     /// names. None means the watched name doesn't exist (or no watch).
     pub sr_block: Option<Block>,
     pub sr_locator: Option<Locator>,
+
+    /// End (Node) SID currently registered with the RIB SID registry.
+    /// Tracked separately from the locator so we can issue a SidDel for
+    /// the previous address before allocating a new one when the
+    /// locator's prefix changes underneath us.
+    pub sr_end_sid: Option<std::net::Ipv6Addr>,
 }
 
 pub struct IsisTop<'a> {
@@ -117,6 +126,7 @@ pub struct IsisTop<'a> {
     /// Capability / SRv6 sub-TLVs.
     pub sr_block: &'a Option<Block>,
     pub sr_locator: &'a Option<Locator>,
+    pub sr_end_sid: &'a Option<std::net::Ipv6Addr>,
 }
 
 impl Isis {
@@ -168,6 +178,7 @@ impl Isis {
             watched_locator: None,
             sr_block: None,
             sr_locator: None,
+            sr_end_sid: None,
         };
         isis.callback_build();
         isis.show_build();
@@ -489,6 +500,7 @@ impl Isis {
             spf_result: &mut self.spf_result,
             sr_block: &self.sr_block,
             sr_locator: &self.sr_locator,
+            sr_end_sid: &self.sr_end_sid,
         }
     }
 
@@ -559,6 +571,10 @@ impl Isis {
                 name: prev,
             });
             self.sr_locator = None;
+            // Locator gone -> Node SID has nothing to attach to. Drop
+            // the registration before we leave the helper so the show
+            // table doesn't keep advertising a SID with no locator.
+            self.update_end_sid();
         }
         if let Some(next) = desired {
             let _ = self.rib_tx.send(rib::Message::SrLocatorWatch {
@@ -566,6 +582,36 @@ impl Isis {
                 name: next.clone(),
             });
             self.watched_locator = Some(next);
+        }
+    }
+
+    /// Reconcile the End (Node) SID registration with the current
+    /// locator snapshot. The End SID is the locator's first address
+    /// (RFC 8986 §4.1 — End behavior). On any transition (locator
+    /// resolved/disappeared, prefix changed, locator name swapped) we
+    /// withdraw the previous SID before adding the new one so the
+    /// registry is never double-booked at the same address.
+    fn update_end_sid(&mut self) {
+        let desired = self.sr_locator.as_ref().and_then(|loc| loc.node_sid_addr());
+        if desired == self.sr_end_sid {
+            return;
+        }
+        if let Some(prev) = self.sr_end_sid.take() {
+            let _ = self.rib_tx.send(rib::Message::SidDel { addr: prev });
+        }
+        if let Some(addr) = desired
+            && let Some(loc_name) = self.watched_locator.clone()
+        {
+            let sid = Sid {
+                addr,
+                behavior: SidBehavior::End,
+                context: SidContext::None,
+                owner: SidOwner::new("isis", 0),
+                locator: loc_name,
+                allocation_type: SidAllocationType::Dynamic,
+            };
+            let _ = self.rib_tx.send(rib::Message::SidAdd { sid });
+            self.sr_end_sid = Some(addr);
         }
     }
 
@@ -585,6 +631,10 @@ impl Isis {
                     return;
                 }
                 self.sr_locator = locator;
+                // Allocate / withdraw the Node SID against the new
+                // snapshot before flooding so the LSP carries the
+                // correct value on the very first emission.
+                self.update_end_sid();
             }
         }
         // Re-originate both levels so the new SR snapshot is reflected in
@@ -834,6 +884,36 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
         }
 
         lsp.tlvs.push(cap.into());
+    }
+
+    // SRv6 Locators TLV (RFC 9352 §7.1, type 27). One sub-locator per
+    // active locator; today we only carry one. The contained End SID
+    // sub-TLV (RFC 9352 §7.2) advertises the Node SID we registered
+    // with the RIB. Both `sr_locator` and `sr_end_sid` must be set —
+    // sr_end_sid is only populated when the locator's prefix produced
+    // a usable address.
+    if let Some(locator) = top.sr_locator.as_ref()
+        && let Some(end_sid) = *top.sr_end_sid
+        && let Some(prefix) = locator.prefix
+    {
+        let end_sub = IsisSubSrv6EndSid {
+            flags: 0,
+            behavior: Behavior::End,
+            sid: end_sid,
+            sub2s: Vec::new(),
+        };
+        let sub_locator = Srv6Locator {
+            metric: 0,
+            flags: 0,
+            algo: Algo::Spf,
+            locator: prefix,
+            subs: vec![prefix::IsisSubTlv::Srv6EndSid(end_sub)],
+        };
+        let srv6_tlv = IsisTlvSrv6 {
+            flags: Default::default(),
+            locators: vec![sub_locator],
+        };
+        lsp.tlvs.push(IsisTlv::Srv6(srv6_tlv));
     }
 
     // TE Router ID. Prefer configured value, fall back to RIB-derived.

--- a/zebra-rs/src/rib/segment_routing/locator.rs
+++ b/zebra-rs/src/rib/segment_routing/locator.rs
@@ -6,6 +6,7 @@
 //! leaf.
 
 use std::collections::BTreeMap;
+use std::net::Ipv6Addr;
 
 use anyhow::{Context, Result};
 use ipnet::Ipv6Net;
@@ -39,11 +40,23 @@ impl LocatorBehavior {
 /// Fields carry `#[allow(dead_code)]` until the IS-IS-side `srv6/locator`
 /// handler (next PR) reads them by name from `Rib::locators`.
 #[allow(dead_code)]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Locator {
     pub name: String,
     pub prefix: Option<Ipv6Net>,
     pub behavior: Option<LocatorBehavior>,
+}
+
+impl Locator {
+    /// First address of the locator prefix — the canonical Node SID for
+    /// owners that need an End SID. Returns `None` when no prefix is
+    /// configured yet (the locator exists in config but has nothing to
+    /// allocate from). Always uses the network address so a locator
+    /// configured with host bits set still produces the correct Node
+    /// SID.
+    pub fn node_sid_addr(&self) -> Option<Ipv6Addr> {
+        self.prefix.map(|p| p.network())
+    }
 }
 
 /// In-flight Locator configuration, mirroring the YANG list shape:
@@ -227,5 +240,43 @@ impl ConfigBuilder {
     pub fn del(mut self, func: Handler) -> Self {
         self.map.insert((self.path.clone(), ConfigOp::Delete), func);
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_sid_uses_prefix_network_address() {
+        let loc = Locator {
+            name: "loc1".into(),
+            prefix: Some("2001:db8:a:2::/64".parse().unwrap()),
+            behavior: None,
+        };
+        assert_eq!(loc.node_sid_addr(), Some("2001:db8:a:2::".parse().unwrap()));
+    }
+
+    #[test]
+    fn node_sid_zeros_host_bits_when_prefix_has_them_set() {
+        // An operator typo like ".../64 with ::5 host bits" should still
+        // resolve to the canonical first address; protocols rely on
+        // this to advertise a stable Node SID.
+        let loc = Locator {
+            name: "loc1".into(),
+            prefix: Some("2001:db8:a:2::5/64".parse().unwrap()),
+            behavior: None,
+        };
+        assert_eq!(loc.node_sid_addr(), Some("2001:db8:a:2::".parse().unwrap()));
+    }
+
+    #[test]
+    fn node_sid_none_when_prefix_unset() {
+        let loc = Locator {
+            name: "loc1".into(),
+            prefix: None,
+            behavior: None,
+        };
+        assert_eq!(loc.node_sid_addr(), None);
     }
 }


### PR DESCRIPTION
## Summary

PR 2 of 3 toward IS-IS SRv6 SID origination. With the registry from PR 1 in place, IS-IS now actually populates it: every time the watched locator resolves, the End (Node) SID gets allocated at the locator's first address and advertised in the next LSP.

- ``Locator::node_sid_addr()`` returns the locator's network address (RFC 8986 §4.1 End SID), zeroing host bits if any are set in the operator's config.
- ``Isis::sr_end_sid`` tracks the registered SID separately from the locator snapshot so ``update_end_sid()`` can withdraw the previous SID via ``Message::SidDel`` before adding the new one — covers prefix changes, locator name swaps, SRv6 disable, and unwatch transitions in ``reconcile_locator_watch``.
- ``lsp_generate`` emits ``IsisTlvSrv6`` (RFC 9352 §7.1, TLV 27) carrying one ``Srv6Locator { algo: Spf, locator: prefix, subs: [Srv6EndSid { behavior: End, sid }] }`` when both ``sr_locator`` and ``sr_end_sid`` are set.
- Re-exported ``IsisSubSrv6EndSid`` and ``Srv6Locator`` from ``isis-packet``.
- 3 new ``node_sid_addr`` unit tests cover prefix → first address, host-bit zeroing, and unset-prefix returning ``None``.

After this PR, ``show segment-routing srv6 sid`` shows the End row from the design doc on any node with a configured + resolved locator. PR 3 brings the End.X (adjacency) row.

## Test plan

- [x] ``cargo build --bin zebra-rs`` clean
- [x] ``cargo clippy --workspace --all-targets -- -D warnings`` clean
- [x] ``cargo test --workspace`` — 121 zebra-rs tests pass (3 new locator tests), all suites green
- [x] ``cargo fmt --all -- --check`` clean
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)