### PR TITLE
feat(isis): End.X SID allocation from ELIB pool (0xE000+)

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -100,6 +100,11 @@ pub struct Isis {
     /// the previous address before allocating a new one when the
     /// locator's prefix changes underneath us.
     pub sr_end_sid: Option<std::net::Ipv6Addr>,
+
+    /// ELIB function pool used for End.X (adjacency) SID allocation.
+    /// Reset whenever the watched locator changes so stale function
+    /// reservations don't leak across prefix swaps.
+    pub elib: super::srv6::ElibPool,
 }
 
 pub struct IsisTop<'a> {
@@ -179,6 +184,7 @@ impl Isis {
             sr_block: None,
             sr_locator: None,
             sr_end_sid: None,
+            elib: super::srv6::ElibPool::new(),
         };
         isis.callback_build();
         isis.show_build();
@@ -522,6 +528,10 @@ impl Isis {
             reach_map_v6: &mut self.reach_map_v6,
             label_map: &mut self.label_map,
             spf_timer: &mut self.spf_timer,
+            rib_tx: &self.rib_tx,
+            sr_locator: &self.sr_locator,
+            watched_locator: &self.watched_locator,
+            elib: &mut self.elib,
         })
     }
 
@@ -575,6 +585,7 @@ impl Isis {
             // the registration before we leave the helper so the show
             // table doesn't keep advertising a SID with no locator.
             self.update_end_sid();
+            self.clear_all_endx_sids();
         }
         if let Some(next) = desired {
             let _ = self.rib_tx.send(rib::Message::SrLocatorWatch {
@@ -583,6 +594,22 @@ impl Isis {
             });
             self.watched_locator = Some(next);
         }
+    }
+
+    /// Withdraw every End.X (adjacency) SID and reset the ELIB pool.
+    /// Used whenever the underlying locator changes (prefix swap,
+    /// locator name change, locator removed): every previously-issued
+    /// End.X address is invalidated, so we drop the registry rows and
+    /// let the next Hello re-allocate from a fresh pool.
+    fn clear_all_endx_sids(&mut self) {
+        for link in self.links.values_mut() {
+            for level in [Level::L1, Level::L2] {
+                for nbr in link.state.nbrs.get_mut(&level).values_mut() {
+                    nbr.release_endx_sid(&mut self.elib, &self.rib_tx);
+                }
+            }
+        }
+        self.elib.reset();
     }
 
     /// Reconcile the End (Node) SID registration with the current
@@ -631,6 +658,11 @@ impl Isis {
                     return;
                 }
                 self.sr_locator = locator;
+                // Locator snapshot churned — every End.X address
+                // computed against the previous prefix is now stale.
+                // Drop them all and let the next Hellos re-allocate
+                // from a fresh ELIB pool.
+                self.clear_all_endx_sids();
                 // Allocate / withdraw the Node SID against the new
                 // snapshot before flooding so the LSP carries the
                 // correct value on the very first emission.
@@ -957,6 +989,34 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
                         };
                         is_reach.subs.push(neigh::IsisSubTlv::LanAdjSid(sub));
                     }
+                }
+            }
+
+            // SRv6 End.X (adjacency) sub-TLV — RFC 9352 §8.1 (P2P) /
+            // §8.2 (LAN). One per up adjacency, only when an End.X
+            // SID has been allocated against the resolved locator.
+            if let Some((_, sid_addr)) = nbr.endx_sid {
+                if nbr.link_type.is_p2p() {
+                    let sub = IsisSubSrv6EndXSid {
+                        flags: 0,
+                        algo: Algo::Spf,
+                        weight: 0,
+                        behavior: Behavior::EndX,
+                        sid: sid_addr,
+                        sub2s: Vec::new(),
+                    };
+                    is_reach.subs.push(neigh::IsisSubTlv::Srv6EndXSid(sub));
+                } else {
+                    let sub = IsisSubSrv6LanEndXSid {
+                        system_id: nbr.sys_id,
+                        flags: 0,
+                        algo: Algo::Spf,
+                        weight: 0,
+                        behavior: Behavior::EndX,
+                        sid: sid_addr,
+                        sub2s: Vec::new(),
+                    };
+                    is_reach.subs.push(neigh::IsisSubTlv::Srv6LanEndXSid(sub));
                 }
             }
         }

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -98,6 +98,10 @@ impl IsisLinks {
     pub fn values(&self) -> std::collections::btree_map::Values<'_, u32, IsisLink> {
         self.map.values()
     }
+
+    pub fn values_mut(&mut self) -> std::collections::btree_map::ValuesMut<'_, u32, IsisLink> {
+        self.map.values_mut()
+    }
 }
 
 #[derive(Debug)]
@@ -128,6 +132,15 @@ pub struct LinkTop<'a> {
     pub reach_map_v6: &'a mut Levels<ReachMapV6>,
     pub label_map: &'a mut Levels<IsisLabelMap>,
     pub spf_timer: &'a mut Levels<Option<Timer>>,
+
+    /// SR state needed for End.X (adjacency) SID allocation. Threaded
+    /// through so packet handlers can carve a function from the ELIB
+    /// pool the moment they learn about a new neighbor, without round-
+    /// tripping back through the IS-IS instance.
+    pub rib_tx: &'a tokio::sync::mpsc::UnboundedSender<crate::rib::Message>,
+    pub sr_locator: &'a Option<crate::rib::Locator>,
+    pub watched_locator: &'a Option<String>,
+    pub elib: &'a mut crate::isis::srv6::ElibPool,
 }
 
 impl<'a> LinkTop<'a> {

--- a/zebra-rs/src/isis/mod.rs
+++ b/zebra-rs/src/isis/mod.rs
@@ -33,6 +33,8 @@ pub use level::*;
 
 pub mod srmpls;
 
+pub mod srv6;
+
 pub mod lsdb;
 pub use lsdb::{Lsdb, LsdbEvent};
 

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -12,7 +12,10 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::config::Args;
 use crate::context::Timer;
+use crate::isis::srv6::{ElibPool, function_addr};
+use crate::rib;
 use crate::rib::MacAddr;
+use crate::rib::{Locator, Sid, SidAllocationType, SidBehavior, SidContext, SidOwner};
 
 use super::link::LinkType;
 use super::nfsm::NfsmState;
@@ -43,6 +46,13 @@ pub struct Neighbor {
     //
     pub hold_time: u16,
     pub hold_timer: Option<Timer>,
+
+    /// Allocated End.X (adjacency) SID. Pair carries the ELIB function
+    /// bits (so we can release them on neighbor down) and the full SID
+    /// address (so we know which entry to withdraw from the RIB SID
+    /// registry). `None` until the locator is resolved and the first
+    /// allocator pass picks a function.
+    pub endx_sid: Option<(u16, Ipv6Addr)>,
 }
 
 impl Neighbor {
@@ -72,6 +82,7 @@ impl Neighbor {
             circuit_id: None,
             hold_time: 0,
             link_type,
+            endx_sid: None,
         }
     }
 
@@ -81,6 +92,68 @@ impl Neighbor {
 
     pub fn event(&mut self, message: Message) {
         self.tx.send(message).unwrap();
+    }
+
+    /// Make sure this neighbor has an End.X SID allocated and
+    /// registered with the RIB. Idempotent — if a SID is already
+    /// recorded, returns immediately.
+    ///
+    /// Skipped silently when the locator isn't resolved (no prefix to
+    /// derive a SID from) or when ELIB is exhausted; the next Hello
+    /// re-tries with whatever state has changed since.
+    pub fn ensure_endx_sid(
+        &mut self,
+        ifname: &str,
+        sr_locator: &Option<Locator>,
+        watched_locator: &Option<String>,
+        elib: &mut ElibPool,
+        rib_tx: &UnboundedSender<rib::Message>,
+    ) {
+        if self.endx_sid.is_some() {
+            return;
+        }
+        let Some(locator) = sr_locator.as_ref() else {
+            return;
+        };
+        let Some(prefix) = locator.prefix else {
+            return;
+        };
+        let Some(loc_name) = watched_locator.clone() else {
+            return;
+        };
+        let Some(function) = elib.allocate() else {
+            return;
+        };
+        let Some(addr) = function_addr(prefix, function) else {
+            // Prefix too long for a 16-bit function — release the
+            // function so we don't pin it forever.
+            elib.release(function);
+            return;
+        };
+        let sid = Sid {
+            addr,
+            behavior: SidBehavior::EndX,
+            context: SidContext::Interface(ifname.to_string()),
+            owner: SidOwner::new("isis", 0),
+            locator: loc_name,
+            allocation_type: SidAllocationType::Dynamic,
+        };
+        let _ = rib_tx.send(rib::Message::SidAdd { sid });
+        self.endx_sid = Some((function, addr));
+    }
+
+    /// Release the neighbor's End.X SID, sending a SidDel and freeing
+    /// the function back to the pool. Idempotent — no-op when nothing
+    /// is allocated.
+    pub fn release_endx_sid(
+        &mut self,
+        elib: &mut ElibPool,
+        rib_tx: &UnboundedSender<rib::Message>,
+    ) {
+        if let Some((function, addr)) = self.endx_sid.take() {
+            elib.release(function);
+            let _ = rib_tx.send(rib::Message::SidDel { addr });
+        }
     }
 }
 

--- a/zebra-rs/src/isis/nfsm.rs
+++ b/zebra-rs/src/isis/nfsm.rs
@@ -91,6 +91,10 @@ pub fn nbr_hold_timer_expire(link: &mut LinkTop, level: Level, sys_id: IsisSysId
         }
     }
 
+    // Release the End.X SID — function bits go back to the ELIB pool
+    // and the registry drops the row before the show table runs again.
+    nbr.release_endx_sid(link.elib, link.rib_tx);
+
     // Neighbor state to be down.
     nbr.state = NfsmState::Down;
 

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -195,7 +195,15 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
     // Interpret TLVs.
     let mac = link.state.mac;
     let sys_id = link.up_config.net.sys_id();
+    let ifname = link.state.name.clone();
     let (has_mac, _) = nbr_hello_interpret(nbr, &pdu.tlvs, mac, sys_id, link.local_pool);
+    nbr.ensure_endx_sid(
+        &ifname,
+        link.sr_locator,
+        link.watched_locator,
+        link.elib,
+        link.rib_tx,
+    );
 
     // Start state transition.
     let mut state = nbr.state;
@@ -316,7 +324,15 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
         // Interpret TLVs.
         let mac = link.state.mac;
         let sys_id = link.up_config.net.sys_id();
+        let ifname = link.state.name.clone();
         let (_, has_my_sys_id) = nbr_hello_interpret(nbr, &pdu.tlvs, mac, sys_id, link.local_pool);
+        nbr.ensure_endx_sid(
+            &ifname,
+            link.sr_locator,
+            link.watched_locator,
+            link.elib,
+            link.rib_tx,
+        );
 
         // Start state transition.
         let mut state = nbr.state;

--- a/zebra-rs/src/isis/srv6.rs
+++ b/zebra-rs/src/isis/srv6.rs
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright 2025-2026 Kunihiro Ishiguro
+
+//! IS-IS-side SRv6 helpers — the per-instance ELIB function pool used
+//! to allocate End.X (adjacency) SIDs, and the bit math that turns a
+//! locator prefix + 16-bit function into a full SID address.
+
+use std::collections::BTreeSet;
+use std::net::Ipv6Addr;
+
+use ipnet::Ipv6Net;
+
+/// ELIB (Explicit allocation Locator-block Information Block) function
+/// range. RFC 9352 reserves the upper half of the 16-bit function space
+/// for explicit allocations; we start at 0xE000 and grow upward, which
+/// leaves the lower 0x0000-0xDFFF range for static / operator-reserved
+/// SIDs.
+pub const ELIB_FIRST: u16 = 0xE000;
+pub const ELIB_LAST: u16 = 0xFFFF;
+
+/// First-fit allocator over the ELIB function range. Stable across
+/// individual allocs and frees (same function gets reused after a free,
+/// minimizing churn in show output) but not across pool resets — when
+/// the underlying locator's prefix changes we deliberately throw the
+/// pool away and re-seed from ELIB_FIRST.
+#[derive(Debug, Default)]
+pub struct ElibPool {
+    used: BTreeSet<u16>,
+}
+
+impl ElibPool {
+    pub fn new() -> Self {
+        Self {
+            used: BTreeSet::new(),
+        }
+    }
+
+    /// Take the lowest free function. Returns `None` when the entire
+    /// ELIB range is exhausted (8192 entries — well past any realistic
+    /// adjacency count, but bounded so we never spin forever).
+    pub fn allocate(&mut self) -> Option<u16> {
+        let mut candidate = ELIB_FIRST;
+        for &used in self.used.iter() {
+            if used != candidate {
+                break;
+            }
+            if candidate == ELIB_LAST {
+                return None;
+            }
+            candidate += 1;
+        }
+        self.used.insert(candidate);
+        Some(candidate)
+    }
+
+    pub fn release(&mut self, function: u16) {
+        self.used.remove(&function);
+    }
+
+    /// Drop every allocation. Used when the underlying locator changes
+    /// — every previously-issued End.X address is invalidated, so the
+    /// pool starts fresh and waiting Hellos re-allocate.
+    pub fn reset(&mut self) {
+        self.used.clear();
+    }
+
+    #[cfg(test)]
+    pub fn is_used(&self, function: u16) -> bool {
+        self.used.contains(&function)
+    }
+}
+
+/// Build a full SID address by placing the 16-bit function immediately
+/// after the locator's prefix bits. Returns `None` when the prefix is
+/// too long to fit a 16-bit function (prefix length > 112).
+///
+/// The function bits land in the hextet right after the prefix; bits
+/// past the prefix length in the operator's prefix value are zeroed
+/// before the OR, so a stray host bit can't shift the result.
+///
+/// Examples:
+///   2001:db8:a::/48      + 0xE000 → 2001:db8:a:e000::
+///   2001:db8:a:2::/64    + 0xE000 → 2001:db8:a:2:e000::
+///   2001:db8::/32        + 0xE000 → 2001:db8:e000::
+pub fn function_addr(prefix: Ipv6Net, function: u16) -> Option<Ipv6Addr> {
+    let plen = prefix.prefix_len() as u32;
+    if plen + 16 > 128 {
+        return None;
+    }
+    let base: u128 = u128::from(prefix.network());
+    let shift = 128 - plen - 16;
+    Some(Ipv6Addr::from(base | ((function as u128) << shift)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocator_starts_at_elib_first() {
+        let mut pool = ElibPool::new();
+        assert_eq!(pool.allocate(), Some(0xE000));
+    }
+
+    #[test]
+    fn allocator_returns_lowest_free_after_release() {
+        // Releasing the bottom hole should not skip it on the next
+        // alloc — the show table values stay stable across short
+        // up/down churn.
+        let mut pool = ElibPool::new();
+        let a = pool.allocate().unwrap();
+        let b = pool.allocate().unwrap();
+        let c = pool.allocate().unwrap();
+        assert_eq!((a, b, c), (0xE000, 0xE001, 0xE002));
+        pool.release(b);
+        assert_eq!(pool.allocate(), Some(0xE001));
+    }
+
+    #[test]
+    fn allocator_reset_returns_to_elib_first() {
+        let mut pool = ElibPool::new();
+        let _ = pool.allocate();
+        let _ = pool.allocate();
+        pool.reset();
+        assert_eq!(pool.allocate(), Some(0xE000));
+        assert!(!pool.is_used(0xE001));
+    }
+
+    #[test]
+    fn function_addr_places_function_after_48_bit_prefix() {
+        let prefix: Ipv6Net = "2001:db8:a::/48".parse().unwrap();
+        let sid = function_addr(prefix, 0xE000).unwrap();
+        assert_eq!(sid, "2001:db8:a:e000::".parse::<Ipv6Addr>().unwrap());
+    }
+
+    #[test]
+    fn function_addr_places_function_after_64_bit_prefix() {
+        // /64 puts function bits in the 5th hextet, so 0xE000 lands
+        // right where operators expect it for a typical "::E000" SID.
+        let prefix: Ipv6Net = "2001:db8:a:2::/64".parse().unwrap();
+        let sid = function_addr(prefix, 0xE000).unwrap();
+        assert_eq!(sid, "2001:db8:a:2:e000::".parse::<Ipv6Addr>().unwrap());
+    }
+
+    #[test]
+    fn function_addr_zeros_host_bits_in_prefix() {
+        // Even if an operator typoed the prefix with host bits set, the
+        // SID computation should reduce to the network address first.
+        // /48 zeros every hextet from the 4th onward — including the
+        // ":2" the operator wrote — so function 0x0001 lands at the
+        // 4th hextet of the canonical network address.
+        let prefix: Ipv6Net = "2001:db8:a:2::/48".parse().unwrap();
+        let sid = function_addr(prefix, 0x0001).unwrap();
+        assert_eq!(sid, "2001:db8:a:1::".parse::<Ipv6Addr>().unwrap());
+    }
+
+    #[test]
+    fn function_addr_rejects_prefix_too_long_for_function() {
+        let prefix: Ipv6Net = "2001:db8::/120".parse().unwrap();
+        assert_eq!(function_addr(prefix, 0xE000), None);
+    }
+}


### PR DESCRIPTION
## Summary

PR 3 of 3 wraps up IS-IS SRv6 SID origination. Per-adjacency End.X SIDs land in the registry from PR 1 and the LSP from PR 2, completing the design-doc table:

```
SID               Behavior  Context              Daemon/Instance  Locator  AllocationType
2001:db8:a:2::    End       -                    isis(0)          LOC_N1   dynamic
2001:db8:a:2:1::  End.X     Interface 'enp0s7'   isis(0)          LOC_N1   dynamic
```

- New ``isis/srv6.rs``: ``ElibPool`` first-fit allocator over functions ``0xE000..0xFFFF`` (RFC 9352 explicit-allocation range), and ``function_addr(prefix, function)`` placing the 16-bit function immediately after the locator's prefix.
- ``Neighbor::endx_sid: Option<(u16, Ipv6Addr)>`` plus ``ensure_endx_sid`` / ``release_endx_sid`` helpers — idempotent allocator + RIB ``SidAdd`` / ``SidDel``.
- Hello receipt (LAN + P2P) calls ``ensure_endx_sid``; hold-timer expire calls ``release_endx_sid``. ``Isis::clear_all_endx_sids`` walks every level/link/neighbor, releases each SID, resets the pool — fired on locator prefix swap and on locator unwatch so stale addresses can't leak.
- ``LinkTop`` carries ``rib_tx`` / ``sr_locator`` / ``watched_locator`` / ``elib`` (mirroring how ``local_pool`` was already threaded for SR-MPLS labels).
- ``lsp_generate`` IS-Reach loop emits ``IsisSubSrv6EndXSid`` (P2P) or ``IsisSubSrv6LanEndXSid`` (LAN) per up neighbor with an allocated SID.
- 7 new unit tests cover the ELIB allocator (start, release-then-reuse, reset) and the address-bit math (/48, /64, host-bit zeroing, /120 rejection).

## Test plan

- [x] ``cargo build --bin zebra-rs`` clean
- [x] ``cargo clippy --workspace --all-targets -- -D warnings`` clean
- [x] ``cargo test --workspace`` — 128 zebra-rs tests pass (+7 new srv6 tests)
- [x] ``cargo fmt --all -- --check`` clean
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)