### PR TITLE
feat(fib): install SRv6 SIDs as local seg6local routes via NexthopMap

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -630,6 +630,44 @@ impl FibHandle {
                     );
                 }
 
+                // seg6local nexthops have a different attribute shape:
+                // no Gateway, encap carries the action (and Nh6 for
+                // End.X), Oif identifies the dev. The kernel rejects
+                // this with af=Unspec, so we set Inet6 (SIDs are IPv6).
+                if let Some(action) = uni.seg6local_action {
+                    let nh6 = match uni.addr {
+                        std::net::IpAddr::V6(a) if !a.is_unspecified() => Some(a),
+                        _ => None,
+                    };
+                    let Some((encap, encap_type)) =
+                        super::srv6::build_seg6local_nh_attrs(action, nh6)
+                    else {
+                        tracing::warn!(
+                            "seg6local nexthop encap build skipped for gid {} \
+                             (End.X without IPv6 nexthop)",
+                            uni.gid(),
+                        );
+                        return;
+                    };
+                    msg.header.address_family = AddressFamily::Inet6;
+                    msg.attributes.push(NexthopAttribute::Id(uni.gid() as u32));
+                    msg.attributes.push(NexthopAttribute::Oif(uni.ifindex));
+                    msg.attributes.push(encap_type);
+                    msg.attributes.push(encap);
+
+                    let mut req = NetlinkMessage::from(RouteNetlinkMessage::NewNexthop(msg));
+                    req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE;
+                    let mut response = self.handle.clone().request(req).unwrap();
+                    while let Some(m) = response.next().await {
+                        if let NetlinkPayload::Error(e) = m.payload {
+                            tracing::info!(
+                                "NewNexthop seg6local error: {e} gid: {gid} refcnt: {refcnt}"
+                            );
+                        }
+                    }
+                    return;
+                }
+
                 // Address family follows the gateway address.
                 msg.header.address_family = match uni.addr {
                     std::net::IpAddr::V4(_) => AddressFamily::Inet,
@@ -780,6 +818,82 @@ impl FibHandle {
                     gid = nexthop.gid(),
                     refcnt = nexthop.refcnt()
                 );
+            }
+        }
+    }
+
+    /// Install an SRv6 SID into the FIB as a local /128 host route.
+    /// Uses the nh_id allocated from NexthopMap when the kernel supports
+    /// it, otherwise falls back to embedded seg6local encap on the route
+    /// itself (kernels < 5.3).
+    pub async fn route_sid_install(&self, sid: &crate::rib::Sid, gid: usize, ifindex: u32) {
+        let mut msg = RouteMessage::default();
+        msg.header.address_family = AddressFamily::Inet6;
+        msg.header.destination_prefix_length = 128;
+        msg.header.table = RouteHeader::RT_TABLE_MAIN;
+        msg.header.protocol = RouteProtocol::Isis;
+        msg.header.scope = RouteScope::Universe;
+        // Local routes are processed by the host (the seg6local action
+        // runs on us), not forwarded; the kernel will reject Unicast
+        // here because there's no real "via" target.
+        msg.header.kind = RouteType::Local;
+
+        msg.attributes
+            .push(RouteAttribute::Destination(RouteAddress::Inet6(sid.addr)));
+
+        if self.use_nhid {
+            msg.attributes.push(RouteAttribute::Nhid(gid as u32));
+        } else {
+            // Embedded encap fallback. Set Oif so the kernel knows where
+            // to bind the action; for End we resolved that to loopback,
+            // for End.X to the link.
+            if ifindex != 0 {
+                msg.attributes.push(RouteAttribute::Oif(ifindex));
+            }
+            let Some((encap, encap_type)) =
+                super::srv6::build_seg6local_attrs(sid.behavior, sid.nh6)
+            else {
+                tracing::warn!(
+                    "seg6local route encap build skipped for {} (End.X without IPv6 nexthop)",
+                    sid.addr
+                );
+                return;
+            };
+            msg.attributes.push(encap);
+            msg.attributes.push(encap_type);
+        }
+
+        let mut req = NetlinkMessage::from(RouteNetlinkMessage::NewRoute(msg));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE;
+        let mut response = self.handle.clone().request(req).unwrap();
+        while let Some(m) = response.next().await {
+            if let NetlinkPayload::Error(e) = m.payload {
+                tracing::info!("NewRoute SID install error: addr={} {}", sid.addr, e);
+            }
+        }
+    }
+
+    /// Remove a previously-installed SID host route. Idempotent against
+    /// the kernel — a missing entry surfaces as an error in the trace
+    /// but doesn't propagate.
+    pub async fn route_sid_uninstall(&self, addr: std::net::Ipv6Addr) {
+        let mut msg = RouteMessage::default();
+        msg.header.address_family = AddressFamily::Inet6;
+        msg.header.destination_prefix_length = 128;
+        msg.header.table = RouteHeader::RT_TABLE_MAIN;
+        msg.header.protocol = RouteProtocol::Isis;
+        msg.header.scope = RouteScope::Universe;
+        msg.header.kind = RouteType::Local;
+
+        msg.attributes
+            .push(RouteAttribute::Destination(RouteAddress::Inet6(addr)));
+
+        let mut req = NetlinkMessage::from(RouteNetlinkMessage::DelRoute(msg));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK;
+        let mut response = self.handle.clone().request(req).unwrap();
+        while let Some(m) = response.next().await {
+            if let NetlinkPayload::Error(e) = m.payload {
+                tracing::info!("DelRoute SID uninstall error: addr={addr} {e}");
             }
         }
     }

--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -5,10 +5,13 @@ use std::net::Ipv6Addr;
 
 use anyhow::{Result, bail};
 use isis_packet::srv6::EncapType;
+use netlink_packet_route::nexthop::NexthopAttribute;
 use netlink_packet_route::route::{
     Ipv6SrHdr, RouteAttribute, RouteLwEnCapType, RouteLwTunnelEncap, RouteSeg6IpTunnel,
-    Seg6IpTunnelEncap, Seg6IpTunnelMode, VecIpv6SrHdr,
+    RouteSeg6LocalIpTunnel, Seg6IpTunnelEncap, Seg6IpTunnelMode, Seg6LocalAction, VecIpv6SrHdr,
 };
+
+use crate::rib::SidBehavior;
 
 // Build the seg6 lwtunnel encap for an SRv6 H.Encap policy. Callers wrap the
 // returned encap in either RouteAttribute::Encap (for embedded route-message
@@ -70,5 +73,67 @@ pub fn build_seg6_attrs(
     Ok((
         RouteAttribute::Encap(vec![lwencap]),
         RouteAttribute::EncapType(RouteLwEnCapType::Seg6),
+    ))
+}
+
+// Map a SidBehavior to its kernel SEG6_LOCAL_ACTION_*.
+fn seg6local_action(behavior: SidBehavior) -> Seg6LocalAction {
+    match behavior {
+        SidBehavior::End => Seg6LocalAction::End,
+        SidBehavior::EndX => Seg6LocalAction::EndX,
+    }
+}
+
+// Build the inner Vec<RouteLwTunnelEncap> for a seg6local install.
+//
+// End needs only the Action attribute. End.X also nests Nh6 (the IPv6
+// nexthop). The kernel's required oif rides on the outer route /
+// nexthop message rather than inside the encap, so we don't add it
+// here.
+//
+// Returns None when the operator hasn't supplied the data End.X needs
+// (no IPv6 nexthop) — caller treats that as "skip FIB install for this
+// SID; the registry row stays so the LSP advertisement is unaffected".
+fn build_seg6local_lwtunnel(
+    behavior: SidBehavior,
+    nh6: Option<Ipv6Addr>,
+) -> Option<Vec<RouteLwTunnelEncap>> {
+    let mut attrs: Vec<RouteSeg6LocalIpTunnel> =
+        vec![RouteSeg6LocalIpTunnel::Action(seg6local_action(behavior))];
+    if matches!(behavior, SidBehavior::EndX) {
+        let nh = nh6?;
+        attrs.push(RouteSeg6LocalIpTunnel::Nh6(nh));
+    }
+    Some(
+        attrs
+            .into_iter()
+            .map(RouteLwTunnelEncap::Seg6Local)
+            .collect(),
+    )
+}
+
+// Build seg6local route-attribute pair (Encap + EncapType) for the
+// embedded-encap route install path.
+pub fn build_seg6local_attrs(
+    behavior: SidBehavior,
+    nh6: Option<Ipv6Addr>,
+) -> Option<(RouteAttribute, RouteAttribute)> {
+    let encaps = build_seg6local_lwtunnel(behavior, nh6)?;
+    Some((
+        RouteAttribute::Encap(encaps),
+        RouteAttribute::EncapType(RouteLwEnCapType::Seg6Local),
+    ))
+}
+
+// Build seg6local nexthop-attribute pair (Encap + EncapType) for the
+// nh_id-based install path.
+pub fn build_seg6local_nh_attrs(
+    behavior: SidBehavior,
+    nh6: Option<Ipv6Addr>,
+) -> Option<(NexthopAttribute, NexthopAttribute)> {
+    let encaps = build_seg6local_lwtunnel(behavior, nh6)?;
+    Some((
+        NexthopAttribute::Encap(encaps),
+        NexthopAttribute::EncapType(RouteLwEnCapType::Seg6Local.into()),
     ))
 }

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -636,6 +636,11 @@ impl Isis {
                 owner: SidOwner::new("isis", 0),
                 locator: loc_name,
                 allocation_type: SidAllocationType::Dynamic,
+                // End is local-processing; ifindex=0 lets the RIB
+                // resolve to its loopback link before pushing to the
+                // FIB. nh6 has no meaning for End.
+                ifindex: 0,
+                nh6: None,
             };
             let _ = self.rib_tx.send(rib::Message::SidAdd { sid });
             self.sr_end_sid = Some(addr);

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -130,6 +130,13 @@ impl Neighbor {
             elib.release(function);
             return;
         };
+        // End.X needs an IPv6 nexthop — by convention the neighbor's
+        // link-local from its IPv6 IIH address TLV. If we haven't
+        // heard one yet (IPv4-only deployment, or Hellos arrived
+        // before the IPv6 addr exchange), the SID still registers so
+        // the LSP advertises the capability, but `nh6: None` will
+        // tell the FIB to skip the seg6local install.
+        let nh6 = self.addr6l.first().copied();
         let sid = Sid {
             addr,
             behavior: SidBehavior::EndX,
@@ -137,6 +144,8 @@ impl Neighbor {
             owner: SidOwner::new("isis", 0),
             locator: loc_name,
             allocation_type: SidAllocationType::Dynamic,
+            ifindex: self.ifindex,
+            nh6,
         };
         let _ = rib_tx.send(rib::Message::SidAdd { sid });
         self.endx_sid = Some((function, addr));

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -5,9 +5,9 @@ use super::api::RibRx;
 use super::entry::RibEntry;
 use super::link::{LinkConfig, link_config_exec};
 use super::{
-    Block, BlockBuilder, BlockConfig, BridgeBuilder, BridgeConfig, DEFAULT_BLOCK_NAME, Link,
-    Locator, LocatorBuilder, LocatorConfig, MacAddr, MplsConfig, Nexthop, NexthopMap, RibSrRx,
-    RibType, Sid, StaticConfig, V4, V6, Vxlan, VxlanBuilder, VxlanConfig,
+    Block, BlockBuilder, BlockConfig, BridgeBuilder, BridgeConfig, DEFAULT_BLOCK_NAME, GroupTrait,
+    Link, Locator, LocatorBuilder, LocatorConfig, MacAddr, MplsConfig, Nexthop, NexthopMap,
+    NexthopUni, RibSrRx, RibType, Sid, StaticConfig, V4, V6, Vxlan, VxlanBuilder, VxlanConfig,
 };
 
 use crate::config::{Args, path_from_command};
@@ -21,7 +21,7 @@ use crate::rib::{Bridge, RibEntries};
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use prefix_trie::PrefixMap;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
 
@@ -356,6 +356,101 @@ impl Rib {
         }
     }
 
+    /// Build the seg6local NexthopUni a SID install resolves through
+    /// NexthopMap. The (action, ifindex, nh6) triple is the dedup key —
+    /// two End SIDs end up sharing one nh_id, two End.X SIDs to the
+    /// same neighbor likewise share, distinct adjacencies don't.
+    fn sid_nexthop_uni(sid: &Sid) -> NexthopUni {
+        let addr = match sid.nh6 {
+            Some(a) => IpAddr::V6(a),
+            None => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+        };
+        NexthopUni {
+            addr,
+            ifindex: sid.ifindex,
+            seg6local_action: Some(sid.behavior),
+            valid: true,
+            ..Default::default()
+        }
+    }
+
+    /// Resolve a Sid's `ifindex == 0` to the system's loopback before
+    /// install. End SIDs arrive without an ifindex from IS-IS so the
+    /// daemon stays portable; the FIB needs a real one.
+    fn resolve_lo_ifindex(&self) -> Option<u32> {
+        self.links
+            .values()
+            .find(|link| link.is_loopback())
+            .map(|link| link.index)
+    }
+
+    /// Install an allocated SID into the FIB: allocate / share a kernel
+    /// nhid via NexthopMap, install the route as RouteType::Local with
+    /// seg6local action, and record the entry in `self.sids` so the
+    /// show table reflects it.
+    async fn sid_install(&mut self, mut sid: Sid) {
+        if sid.ifindex == 0
+            && let Some(ifindex) = self.resolve_lo_ifindex()
+        {
+            sid.ifindex = ifindex;
+        }
+        // No usable ifindex → skip FIB install but keep the registry
+        // entry so the LSP advertisement and show table are unaffected.
+        if sid.ifindex == 0 {
+            self.sids.insert(sid.addr, sid);
+            return;
+        }
+
+        let uni = Self::sid_nexthop_uni(&sid);
+        let Some(group) = self.nmap.fetch(&uni) else {
+            self.sids.insert(sid.addr, sid);
+            return;
+        };
+        let gid = group.gid();
+        let need_install = !group.is_installed();
+        group.refcnt_inc();
+
+        if need_install {
+            self.fib_handle.nexthop_add(group).await;
+            if let Some(g) = self.nmap.get_mut(gid) {
+                g.set_installed(true);
+            }
+        }
+        let ifindex = sid.ifindex;
+        self.fib_handle.route_sid_install(&sid, gid, ifindex).await;
+
+        self.sids.insert(sid.addr, sid);
+    }
+
+    /// Tear down a previously-installed SID. Walks back through the
+    /// same NexthopMap entry the install used; the kernel nhid is only
+    /// removed when the last referencing SID drops it.
+    async fn sid_uninstall(&mut self, addr: Ipv6Addr) {
+        let Some(sid) = self.sids.remove(&addr) else {
+            return;
+        };
+        if sid.ifindex == 0 {
+            // Wasn't installed (no loopback at SidAdd time); nothing to
+            // tear down on the kernel side.
+            return;
+        }
+
+        self.fib_handle.route_sid_uninstall(addr).await;
+
+        let uni = Self::sid_nexthop_uni(&sid);
+        let Some(group) = self.nmap.fetch(&uni) else {
+            return;
+        };
+        let gid = group.gid();
+        group.refcnt_dec();
+        if group.refcnt() == 0 {
+            self.fib_handle.nexthop_del(group).await;
+            if let Some(g) = self.nmap.get_mut(gid) {
+                g.set_installed(false);
+            }
+        }
+    }
+
     pub fn subscribe(&mut self, tx: UnboundedSender<RibRx>, _proto: String) {
         // Link dump.
         for (_, link) in self.links.iter() {
@@ -504,13 +599,10 @@ impl Rib {
                 }
             }
             Message::SidAdd { sid } => {
-                // Last-writer-wins: a re-add with the same address replaces
-                // the old entry. Owners are responsible for not double-
-                // allocating; this just keeps the registry consistent.
-                self.sids.insert(sid.addr, sid);
+                self.sid_install(sid).await;
             }
             Message::SidDel { addr } => {
-                self.sids.remove(&addr);
+                self.sid_uninstall(addr).await;
             }
             Message::Shutdown { tx } => {
                 self.nmap.shutdown(&self.fib_handle).await;

--- a/zebra-rs/src/rib/nexthop/group.rs
+++ b/zebra-rs/src/rib/nexthop/group.rs
@@ -57,17 +57,32 @@ pub struct GroupUni {
     /// SRv6 endpoint behavior chosen for this encap (e.g. H.Encap,
     /// H.Encap.Red). None when segs is empty (non-SRv6 nexthop).
     pub encap_type: Option<EncapType>,
+
+    /// SRv6 seg6local action — set when this group represents a local
+    /// SID install (End / End.X). NexthopMap keys these separately from
+    /// plain unicast / encap nexthops via `fetch_seg6local`.
+    pub seg6local_action: Option<crate::rib::SidBehavior>,
 }
 
 impl GroupUni {
     pub fn new(gid: usize, uni: &NexthopUni) -> Self {
+        // For seg6local nexthops the ifindex is pre-determined by the
+        // caller (loopback for End, the link's ifindex for End.X) and
+        // there's no IGP path to resolve through; for plain unicast we
+        // start at 0 and let `resolve`/`resolve_v6` fill it in.
+        let ifindex = if uni.seg6local_action.is_some() {
+            uni.ifindex
+        } else {
+            0
+        };
         Self {
             common: GroupCommon::new(gid),
             addr: uni.addr,
-            ifindex: 0,
+            ifindex,
             labels: uni.mpls_label.clone(),
             segs: uni.segs.clone(),
             encap_type: uni.encap_type,
+            seg6local_action: uni.seg6local_action,
         }
     }
 

--- a/zebra-rs/src/rib/nexthop/inst.rs
+++ b/zebra-rs/src/rib/nexthop/inst.rs
@@ -5,6 +5,8 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use isis_packet::srv6::EncapType;
 
+use crate::rib::SidBehavior;
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub enum Label {
     Implicit(u32),
@@ -27,6 +29,12 @@ pub struct NexthopUni {
     // SRv6 endpoint behavior chosen for the encap (e.g. H.Encap, H.Encap.Red).
     // None when segs is empty.
     pub encap_type: Option<EncapType>,
+
+    // SRv6 seg6local action — set when this nexthop installs a local
+    // SID (End / End.X). For End.X, `addr` carries the IPv6 nexthop and
+    // `ifindex` the outgoing link; for End, `ifindex` is the loopback
+    // and `addr` is unused.
+    pub seg6local_action: Option<SidBehavior>,
 
     // Action.
     pub gid: usize,
@@ -68,6 +76,7 @@ impl Default for NexthopUni {
             mpls_label: vec![],
             segs: vec![],
             encap_type: None,
+            seg6local_action: None,
             gid: 0,
             valid: false,
         }

--- a/zebra-rs/src/rib/nexthop/map.rs
+++ b/zebra-rs/src/rib/nexthop/map.rs
@@ -17,11 +17,18 @@ use super::{Group, GroupMulti, GroupTrait, GroupUni, NexthopUni};
 // so N routes with the same SRv6 policy point at one kernel nhid.
 type Seg6Key = (IpAddr, Vec<Ipv6Addr>, Option<EncapType>);
 
+// Dedupe key for SRv6 seg6local nexthops (End / End.X). Two SID installs
+// pointing at the same {action, oif, nh6} share one nhid — uncommon today
+// (each adjacency has its own End.X) but the structure is the same as
+// every other dedupe table here.
+type Seg6LocalKey = (crate::rib::SidBehavior, u32, Option<std::net::Ipv6Addr>);
+
 pub struct NexthopMap {
     map: BTreeMap<IpAddr, usize>,
     set: BTreeMap<BTreeSet<(usize, u8)>, usize>,
     mpls: BTreeMap<(IpAddr, Vec<u32>), usize>,
     seg6: BTreeMap<Seg6Key, usize>,
+    seg6local: BTreeMap<Seg6LocalKey, usize>,
     pub groups: Vec<Option<Group>>,
 }
 
@@ -38,6 +45,7 @@ impl Default for NexthopMap {
             set: BTreeMap::new(),
             mpls: BTreeMap::new(),
             seg6: BTreeMap::new(),
+            seg6local: BTreeMap::new(),
             groups: Vec::new(),
         };
         nmap.groups.push(None);
@@ -138,12 +146,45 @@ impl NexthopMap {
         self.get_mut(gid)
     }
 
+    /// Fetch (or create) the dedup'd nexthop entry for an SRv6 seg6local
+    /// nexthop (End / End.X). Keyed on (action, oif, nh6) so two SIDs
+    /// pointing at the same install target share one Group.
+    pub fn fetch_seg6local(&mut self, uni: &NexthopUni) -> Option<&mut Group> {
+        let action = uni.seg6local_action?;
+        let nh6 = match uni.addr {
+            IpAddr::V6(a) if !a.is_unspecified() => Some(a),
+            _ => None,
+        };
+        let key: Seg6LocalKey = (action, uni.ifindex, nh6);
+        if let Some(&gid) = self.seg6local.get(&key) {
+            let entry = self.groups.get_mut(gid)?;
+            if entry.is_none() {
+                *entry = Some(Group::from_nexthop_uni(uni, gid));
+            }
+            return self.get_mut(gid);
+        }
+
+        let gid = self.new_gid();
+        let group = Group::from_nexthop_uni(uni, gid);
+
+        self.seg6local.insert(key, gid);
+        self.groups.push(Some(group));
+
+        self.get_mut(gid)
+    }
+
     pub fn fetch(&mut self, uni: &NexthopUni) -> Option<&mut Group> {
-        // SRv6 encap takes priority — the segment list is the dedup
-        // dimension that matters, and we want SRv6 nexthops in their own
-        // table so the FIB nexthop_add path can emit seg6 attributes
-        // without re-inspecting NexthopUni.
-        if !uni.segs.is_empty() {
+        // seg6local takes priority over plain unicast — `addr` for an
+        // End SID is unspecified and would route through fetch_uni
+        // otherwise, collapsing every End SID into a single shared
+        // entry by accident.
+        if uni.seg6local_action.is_some() {
+            self.fetch_seg6local(uni)
+        } else if !uni.segs.is_empty() {
+            // SRv6 encap — the segment list is the dedup dimension,
+            // and we want SRv6 nexthops in their own table so the FIB
+            // nexthop_add path can emit seg6 attributes without
+            // re-inspecting NexthopUni.
             self.fetch_seg6(uni)
         } else if uni.mpls_label.is_empty() {
             self.fetch_uni(uni)
@@ -200,6 +241,14 @@ impl NexthopMap {
             }
         }
         for (_, id) in self.seg6.iter() {
+            let entry = self.get(*id);
+            if let Some(grp) = entry
+                && grp.is_installed()
+            {
+                fib.nexthop_del(grp).await;
+            }
+        }
+        for (_, id) in self.seg6local.iter() {
             let entry = self.get(*id);
             if let Some(grp) = entry
                 && grp.is_installed()
@@ -364,5 +413,76 @@ mod tests {
             EncapType::HEncap,
         ));
         assert_eq!(nmap.seg6.len(), 1);
+    }
+
+    fn end_uni(ifindex: u32) -> NexthopUni {
+        NexthopUni {
+            addr: IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+            ifindex,
+            seg6local_action: Some(crate::rib::SidBehavior::End),
+            ..Default::default()
+        }
+    }
+
+    fn endx_uni(ifindex: u32, nh6: &str) -> NexthopUni {
+        NexthopUni {
+            addr: IpAddr::V6(nh6.parse().unwrap()),
+            ifindex,
+            seg6local_action: Some(crate::rib::SidBehavior::EndX),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn fetch_seg6local_dedupes_identical_install_target() {
+        // Two End SIDs install against the same loopback ifindex; the
+        // dedup table should hand back the same gid both times so we
+        // create only one kernel nhid.
+        let mut nmap = NexthopMap::default();
+        let gid_a = group_gid(nmap.fetch(&end_uni(1)).expect("group"));
+        let gid_b = group_gid(nmap.fetch(&end_uni(1)).expect("group"));
+        assert_eq!(gid_a, gid_b);
+    }
+
+    #[test]
+    fn fetch_seg6local_distinguishes_endx_neighbors() {
+        // Distinct adjacencies (different nh6 link-locals) must NOT
+        // share an nh_id — each End.X install is its own kernel entry.
+        let mut nmap = NexthopMap::default();
+        let gid_a = group_gid(nmap.fetch(&endx_uni(2, "fe80::1")).expect("group"));
+        let gid_b = group_gid(nmap.fetch(&endx_uni(2, "fe80::2")).expect("group"));
+        assert_ne!(gid_a, gid_b);
+    }
+
+    #[test]
+    fn fetch_seg6local_distinguishes_action_kinds() {
+        // End and End.X with otherwise-identical dedup-key fields are
+        // still different actions on the wire — keep them separate so
+        // we don't accidentally emit one kernel encap for both.
+        let mut nmap = NexthopMap::default();
+        let gid_end = group_gid(nmap.fetch(&end_uni(2)).expect("group"));
+        // End.X with empty/unspec nh6 is invalid in practice but the
+        // dedup key must still discriminate by action so a bug-y caller
+        // can't collapse the two.
+        let endx = NexthopUni {
+            addr: IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+            ifindex: 2,
+            seg6local_action: Some(crate::rib::SidBehavior::EndX),
+            ..Default::default()
+        };
+        let gid_endx = group_gid(nmap.fetch(&endx).expect("group"));
+        assert_ne!(gid_end, gid_endx);
+    }
+
+    #[test]
+    fn fetch_dispatches_seg6local_before_seg6_or_uni() {
+        // An End SID has addr=:: and segs=[] — without the seg6local
+        // priority gate it would route through fetch_uni and pollute
+        // the plain-unicast map.
+        let mut nmap = NexthopMap::default();
+        nmap.fetch(&end_uni(1));
+        assert_eq!(nmap.seg6local.len(), 1);
+        assert!(nmap.map.is_empty());
+        assert!(nmap.seg6.is_empty());
     }
 }

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -18,7 +18,7 @@ use std::net::Ipv6Addr;
 /// registry; the show callback already discriminates on every variant
 /// so no individual variant carries the attribute.
 #[allow(dead_code)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
 pub enum SidBehavior {
     /// Plain End — RFC 8986 §4.1, "node SID". The SID identifies the
     /// owner node; no per-link context.
@@ -105,6 +105,13 @@ impl fmt::Display for SidOwner {
 /// A single allocated SID — one row in `show segment-routing srv6 sid`.
 /// Identified uniquely by `addr`; the registry rejects duplicate adds
 /// without going through a Del first.
+///
+/// `ifindex` and `nh6` carry the install hints the FIB needs:
+///   - End: `ifindex` is the loopback (the action is purely local
+///     processing, but the kernel rejects seg6local routes without an
+///     output device); `nh6` is `None`.
+///   - End.X: `ifindex` is the outgoing link, `nh6` is the IPv6 link-
+///     local of the neighbor.
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Sid {
@@ -114,6 +121,8 @@ pub struct Sid {
     pub owner: SidOwner,
     pub locator: String,
     pub allocation_type: SidAllocationType,
+    pub ifindex: u32,
+    pub nh6: Option<Ipv6Addr>,
 }
 
 #[cfg(test)]

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1104,6 +1104,8 @@ mod tests {
             owner: SidOwner::new("isis", 0),
             locator: "LOC_N1".to_string(),
             allocation_type: SidAllocationType::Dynamic,
+            ifindex: 0,
+            nh6: None,
         }
     }
 


### PR DESCRIPTION
## Summary

End-to-end install of allocated SRv6 SIDs into the kernel: ``Message::SidAdd`` now flows through ``NexthopMap`` to allocate a kernel ``nh_id``, then writes the SID as a ``/128`` host route with ``RouteType::Local`` and ``lwtunnel encap seg6local`` action ``End`` / ``End.X``. ``Message::SidDel`` walks the same dedup key and tears down only when the last referencing SID releases the nh_id.

- ``NexthopUni`` gains ``seg6local_action: Option<SidBehavior>``; ``NexthopMap`` gets a new ``seg6local`` table keyed on ``(action, ifindex, nh6)`` and ``fetch`` dispatches to it before the plain-unicast / encap paths so an End SID's unspecified addr can't collapse into the plain map.
- ``Sid`` gains ``ifindex: u32`` (0 = RIB resolves loopback) and ``nh6: Option<Ipv6Addr>``. IS-IS End allocator passes ``ifindex: 0, nh6: None``; End.X passes the link's ifindex and ``addr6l.first()``.
- ``FibHandle::nexthop_add`` Uni branch detects ``seg6local_action`` and emits the seg6local nexthop entry (no Gateway, just Oif + encap). New ``route_sid_install`` / ``route_sid_uninstall`` build the host route, referencing nh_id when ``use_nhid`` and falling back to embedded encap otherwise.
- ``Rib::sid_install`` / ``sid_uninstall`` glue all of it together: resolve loopback, fetch group, refcount, call FIB, persist into the registry.
- Re-exports in the ``zebra-rs/netlink-packet-route`` ``seg6`` branch (separate commit ``a9680d3``) make ``Seg6LocalAction`` etc. nameable from outside the crate. ``cargo update -p netlink-packet-route@0.20.1`` here picks up the new rev.

After this PR a node with a configured locator emits End/End.X SIDs *and* the kernel actually processes them — ``ip -6 route`` shows the local routes, ``ip nexthop`` shows the seg6local nh_ids.

## Test plan

- [x] ``cargo build --bin zebra-rs`` clean
- [x] ``cargo clippy --workspace --all-targets -- -D warnings`` clean
- [x] ``cargo test --workspace`` — 132 zebra-rs tests pass (+4 new ``fetch_seg6local`` tests)
- [x] ``cargo fmt --all -- --check`` clean
- [ ] CI green
- [ ] Manual: ``ip -6 route show table local proto isis`` and ``ip nexthop show`` against a running daemon with locator + adjacency

Generated with [Claude Code](https://claude.com/claude-code)