### PR TITLE
fix(config): tokenizer drops uppercase/underscore; show isis summary SRv6 row

### DIFF
--- a/zebra-rs/src/config/files.rs
+++ b/zebra-rs/src/config/files.rs
@@ -73,6 +73,46 @@ prefix-test {
     }
 
     #[test]
+    fn test_user_segment_routing_round_trip() {
+        // Reproduces a user-reported save/load round-trip bug: after
+        // saving a config containing both /routing/isis/segment-routing
+        // and /segment-routing, the loader is supposed to reproduce
+        // both `set` lines. This test pins the parser output so we can
+        // tell whether the bug is in tokenization (no `set` line emitted)
+        // or downstream in parse / dispatch (line emitted but dropped).
+        let config = r#"
+routing {
+  isis {
+    segment-routing {
+      srv6 {
+        locator LOC;
+      }
+    }
+  }
+}
+segment-routing {
+  locator LOC {
+    prefix 2001:db8:a:1::/64;
+  }
+}
+"#;
+        let cmds = load_config_file(config.to_string());
+        let dump = cmds.join("\n");
+        assert!(
+            cmds.iter()
+                .any(|c| c == "set routing isis segment-routing srv6 locator LOC"),
+            "missing isis srv6 locator set line; got:\n{}",
+            dump
+        );
+        assert!(
+            cmds.iter()
+                .any(|c| c == "set segment-routing locator LOC prefix 2001:db8:a:1::/64"),
+            "missing global locator prefix set line; got:\n{}",
+            dump
+        );
+    }
+
+    #[test]
     fn test_leaf_list_old_format() {
         // Test that old single-line format would have been parsed differently
         let config = r#"

--- a/zebra-rs/src/config/token.rs
+++ b/zebra-rs/src/config/token.rs
@@ -23,12 +23,13 @@ pub fn tokenizer(input: String) -> Vec<Token> {
             ch if ch.is_whitespace() => {
                 continue;
             }
-            'a'..='z' | '0'..='9' => {
+            'a'..='z' | 'A'..='Z' | '0'..='9' => {
                 let s: String = iter::once(ch)
                     .chain(from_fn(|| {
                         chars.by_ref().next_if(|c| {
                             c.is_alphabetic()
                                 || c.is_ascii_digit()
+                                || c == &'_'
                                 || c == &'.'
                                 || c == &'-'
                                 || c == &'/'
@@ -64,6 +65,23 @@ pub fn tokenizer(input: String) -> Vec<Token> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_tokenizer_accepts_uppercase_and_underscore() {
+        // Operator-chosen identifiers like locator names commonly use
+        // uppercase + underscores. Earlier the tokenizer only accepted
+        // lowercase / digit starts, so a key like `LOC_N1` was silently
+        // dropped on the way to load — the bug we're guarding against.
+        let tokens = tokenizer("locator LOC_N1;".to_string());
+        let strings: Vec<String> = tokens
+            .iter()
+            .filter_map(|t| match t {
+                Token::String(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(strings, vec!["locator".to_string(), "LOC_N1".to_string()]);
+    }
 
     #[test]
     fn test_tokenizer() {

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -48,11 +48,52 @@ fn show_isis(
 }
 
 fn show_isis_summary(
-    _isis: &Isis,
+    isis: &Isis,
     _args: Args,
     _json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
-    Ok(String::from("show isis summary"))
+    let mut buf = String::new();
+
+    // SRv6 Locator section. Only present when the operator has
+    // configured a locator name under `segment-routing/srv6/locator`;
+    // an unconfigured node has nothing useful to show here.
+    if let Some(name) = isis.watched_locator.as_ref() {
+        writeln!(buf, "SRv6 Locator:")?;
+        writeln!(
+            buf,
+            "{:<20} {:<24} {:<8} Status",
+            "Name", "Prefix", "Behavior"
+        )?;
+        writeln!(buf, "{:-<20} {:-<24} {:-<8} {:-<7}", "", "", "", "")?;
+        let row = render_locator_row(name, isis.sr_locator.as_ref());
+        writeln!(buf, "{row}")?;
+    }
+
+    Ok(buf)
+}
+
+// Build the single locator row. Pulled out so a future test can pin
+// the column widths without spinning up the full Isis fixture.
+fn render_locator_row(name: &str, locator: Option<&crate::rib::Locator>) -> String {
+    use crate::rib::LocatorBehavior;
+    // The locator is "Up" only when the RIB pushed a snapshot AND that
+    // snapshot has a usable prefix. A name configured under IS-IS but
+    // not yet matched by a global `/segment-routing/locator` entry
+    // shows as Down with empty prefix / behavior.
+    let (prefix, behavior, status) = match locator {
+        Some(loc) => match loc.prefix {
+            Some(p) => {
+                let beh = match loc.behavior {
+                    Some(LocatorBehavior::Usid) => "uSID",
+                    None => "Classic",
+                };
+                (p.to_string(), beh.to_string(), "Up")
+            }
+            None => (String::new(), String::new(), "Down"),
+        },
+        None => (String::new(), String::new(), "Down"),
+    };
+    format!("{name:<20} {prefix:<24} {behavior:<8} {status}")
 }
 
 // JSON structures for ISIS graph
@@ -909,4 +950,61 @@ fn show_isis_spf(
         spf::disp_out(&mut buf, spf, false);
     }
     Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rib::{Locator, LocatorBehavior};
+
+    #[test]
+    fn locator_row_classic_when_resolved_with_no_behavior() {
+        let loc = Locator {
+            name: "LOC_N1".into(),
+            prefix: Some("2001:db8:a:2::/64".parse().unwrap()),
+            behavior: None,
+        };
+        let row = render_locator_row("LOC_N1", Some(&loc));
+        assert!(row.contains("LOC_N1"));
+        assert!(row.contains("2001:db8:a:2::/64"));
+        assert!(row.contains("Classic"));
+        assert!(row.trim_end().ends_with("Up"));
+    }
+
+    #[test]
+    fn locator_row_usid_when_resolved_with_usid_behavior() {
+        let loc = Locator {
+            name: "LOC_N1".into(),
+            prefix: Some("2001:db8:a:2::/64".parse().unwrap()),
+            behavior: Some(LocatorBehavior::Usid),
+        };
+        let row = render_locator_row("LOC_N1", Some(&loc));
+        assert!(row.contains("uSID"));
+        assert!(row.trim_end().ends_with("Up"));
+    }
+
+    #[test]
+    fn locator_row_down_when_unresolved() {
+        // The configured name still shows so operators can tell which
+        // locator they're waiting on; prefix and behavior columns are
+        // blank because the RIB hasn't pushed a snapshot.
+        let row = render_locator_row("LOC_N1", None);
+        assert!(row.starts_with("LOC_N1"));
+        assert!(row.trim_end().ends_with("Down"));
+        assert!(!row.contains("uSID"));
+        assert!(!row.contains("Classic"));
+    }
+
+    #[test]
+    fn locator_row_down_when_resolved_without_prefix() {
+        // Locator entry exists in the global config but has no prefix
+        // leaf yet. Same Down treatment as fully unresolved.
+        let loc = Locator {
+            name: "LOC_N1".into(),
+            prefix: None,
+            behavior: None,
+        };
+        let row = render_locator_row("LOC_N1", Some(&loc));
+        assert!(row.trim_end().ends_with("Down"));
+    }
 }

--- a/zebra-rs/src/rib/segment_routing/mod.rs
+++ b/zebra-rs/src/rib/segment_routing/mod.rs
@@ -11,7 +11,7 @@ pub mod block;
 pub use block::{Block, BlockBuilder, BlockConfig, DEFAULT_BLOCK_NAME};
 
 pub mod locator;
-pub use locator::{Locator, LocatorBuilder, LocatorConfig};
+pub use locator::{Locator, LocatorBehavior, LocatorBuilder, LocatorConfig};
 
 pub mod sid;
 // PR 2 wires up the IS-IS allocators that consume these types; until


### PR DESCRIPTION
## Summary

Two unrelated fixes surfaced while debugging IS-IS SR.

**Tokenizer drops uppercase identifiers** — ``zebra-rs/src/config/token.rs`` only treated ``[a-z0-9]`` as the start of a token, so the catch-all arm silently swallowed any identifier starting with an uppercase letter. With the user's saved config:

```
routing { isis { segment-routing { srv6 { locator LOC; } } } }
segment-routing { locator LOC { prefix 2001:db8:a:1::/64; } }
```

``LOC`` got dropped on save→load, the ``set`` lines emitted from ``load_config_file`` came out missing the key, and both segment-routing branches silently failed to parse. Net effect: every reload after a save quietly stripped the SRv6 config.

Fix: extend the token-start range to ``[A-Z]`` and add ``_`` to the in-token allowed set so identifiers like ``LOC_N1`` survive intact (the inner from_fn already accepted uppercase via ``is_alphabetic``, but stopped at ``_``).

**``show isis summary`` was a stub.** Add an SRv6 Locator section reflecting the watched locator:

```
SRv6 Locator:
Name                 Prefix                   Behavior Status
-------------------- ------------------------ -------- -------
LOC_N1               2001:db8:a:2::/64        Classic  Up
```

- Name + ``Down`` when configured but not resolved.
- Name + prefix + ``Classic``/``uSID`` + ``Up`` when resolved.

## Test plan

- [x] ``cargo build --bin zebra-rs`` clean
- [x] ``cargo clippy --workspace --all-targets -- -D warnings`` clean
- [x] ``cargo fmt --all -- --check`` clean
- [x] New unit tests: tokenizer accepts ``LOC_N1``; load_config_file end-to-end on the user's config emits both expected ``set`` lines; 4 cases for the summary row (Classic Up, uSID Up, Down unresolved, Down resolved-without-prefix).
- [x] ``cargo test --workspace`` — all suites pass
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)