### PR TITLE
fix(config): mark presence containers DirMatched on first match

### DIFF
--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -437,6 +437,17 @@ fn ymatch_next(entry: &Rc<Entry>, ymatch: YangMatch) -> YangMatch {
             if entry.is_directory_entry() {
                 if entry.has_key() {
                     YangMatch::Key
+                } else if entry.presence {
+                    // Presence containers settle into DirMatched right
+                    // here so the CommandPath the caller builds carries
+                    // the correct ymatch — otherwise downstream set()
+                    // can't tell a presence container apart from a
+                    // plain transient Dir on the way to a leaf, and
+                    // the running config tree never marks the node as
+                    // presence. That in turn causes list() to skip the
+                    // node when emitting diffs, so the per-protocol
+                    // handler for the presence path never fires.
+                    YangMatch::DirMatched
                 } else {
                     YangMatch::Dir
                 }
@@ -609,9 +620,9 @@ pub fn parse(
     if s.ymatch == YangMatch::Leaf && mx.matched_entry.is_empty_leaf() {
         s.ymatch = YangMatch::LeafMatched;
     }
-    if s.ymatch == YangMatch::Dir && mx.matched_entry.presence {
-        s.ymatch = YangMatch::DirMatched;
-    }
+    // (presence-container Dir → DirMatched used to live here, but it
+    // was settled too late: the CommandPath was already built with the
+    // wrong ymatch. ymatch_next now handles it directly.)
 
     if path.name == "set" {
         s.set = true;


### PR DESCRIPTION
## Summary

Presence containers (e.g. ``routing/isis``, ``.../srv6``, ``.../mpls``) used to fall through ``ymatch_next`` as plain ``Dir``; a post-check then transitioned ``s.ymatch`` to ``DirMatched`` — but only **after** the ``CommandPath`` was already built with the wrong ymatch. ``set()`` therefore created the Config node with ``presence: false``, ``list()`` skipped it when emitting diff lines, and the per-protocol handler registered at the presence-container path (``/routing/isis/segment-routing/srv6``) never fired on commit.

Net effect: configuring

```
routing isis segment-routing srv6 locator LOC
```

pushed the ``locator`` leaf but never flipped ``sr_srv6_enabled``, so ``target_locator_name`` returned ``None`` and the End-SID allocator stayed inert. After this fix the diff carries both lines:

```
routing isis segment-routing srv6
routing isis segment-routing srv6 locator LOC
```

so ``config_sr_srv6_enable`` and ``config_sr_srv6_locator`` both fire on commit, the SRv6 watch registers, and the End / End.X allocators run as designed.

The fix moves presence detection into ``ymatch_next`` so the ``CommandPath`` carries ``DirMatched`` directly; the now-redundant post-check is removed.

## Test plan

- [x] ``cargo build --bin zebra-rs`` clean
- [x] ``cargo clippy --workspace --all-targets -- -D warnings`` clean
- [x] ``cargo fmt --all -- --check`` clean
- [x] ``cargo test --workspace`` — 138 zebra-rs tests pass, no regressions
- [ ] CI green
- [ ] Manual: load a config with ``routing isis segment-routing srv6 locator LOC`` and verify ``show isis summary`` shows the locator as Up + ``ip -6 route show table local proto isis`` lists the End SID

Generated with [Claude Code](https://claude.com/claude-code)