### PR TITLE
fix(config): canonical entry name for DirMatched paths (sh ip route regression)

### DIFF
--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -594,8 +594,16 @@ pub fn parse(
         .map_or_else(|| 0, |v| v.parse::<i32>().unwrap_or(0));
 
     let path = if ymatch_complete(s.ymatch, mx.matched_entry.presence, s.delete) {
+        // KeyMatched / LeafMatched / LeafListMatched carry the user-
+        // typed value (the list key, the leaf value, ...). DirMatched
+        // for a presence container has no user-typed value — the
+        // "name" must be the canonical entry name so path_from_command
+        // builds e.g. `/show/ip/route` and not `/sh/ip/route` when
+        // the operator typed an abbreviation.
         let sub = if let Some(sub) = matched_enumeration(&mx) {
             sub
+        } else if s.ymatch == YangMatch::DirMatched {
+            mx.matched_entry.name.to_owned()
         } else {
             input[0..mx.pos].to_string()
         };


### PR DESCRIPTION
## Summary

PR #339 (the presence-container fix) made ``ymatch_next`` return ``DirMatched`` eagerly for presence containers. That was correct for the running-tree presence flag, but ``CommandPath`` building treats ``ymatch_complete=true`` as "the user typed a value" and uses ``input[0..mx.pos]`` for ``name``. For KeyMatched / LeafMatched / LeafListMatched that's right (list keys, leaf values are user-typed). For DirMatched there is no user-typed value — the canonical entry name is what should land in the path.

Concrete regression:

```
sh ip route   -> /sh/ip/route   (no handler match, broken)
show ip route -> /show/ip/route (still worked because the substring happened to equal the entry name)
```

Fix: special-case ``DirMatched`` in the path builder to use ``mx.matched_entry.name``. KeyMatched / LeafMatched / LeafListMatched keep the substring path.

## Test plan

- [x] ``cargo build --bin zebra-rs`` clean
- [x] ``cargo clippy --workspace --all-targets -- -D warnings`` clean
- [x] ``cargo fmt --all -- --check`` clean
- [x] ``cargo test --workspace`` — 138 zebra-rs tests pass, no regressions
- [ ] CI green
- [ ] Manual: ``sh ip route`` and ``sh isis summary`` work again; presence-container set behavior from #339 is preserved (still emits two diff lines for ``routing isis segment-routing srv6 locator LOC``)

Generated with [Claude Code](https://claude.com/claude-code)