### PR TITLE
feat(fib): enable per-interface SRv6 (seg6) on link discovery

### DIFF
--- a/zebra-rs/src/fib/netlink/sysctl.rs
+++ b/zebra-rs/src/fib/netlink/sysctl.rs
@@ -26,3 +26,10 @@ pub fn sysctl_mpls_enable(ifname: &String) -> anyhow::Result<()> {
     let _ = ctl.set_value_string("1")?;
     Ok(())
 }
+
+pub fn sysctl_seg6_enable(ifname: &String) -> anyhow::Result<()> {
+    let ctlname = format!("net.ipv6.conf.{}.seg6_enabled", ifname);
+    let ctl = sysctl::Ctl::new(ctlname.as_str())?;
+    let _ = ctl.set_value_string("1")?;
+    Ok(())
+}

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -12,7 +12,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::config::{Args, ConfigOp};
 use crate::fib::message::{FibAddr, FibLink};
 use crate::fib::os_traffic_dump;
-use crate::fib::sysctl::sysctl_mpls_enable;
+use crate::fib::sysctl::{sysctl_mpls_enable, sysctl_seg6_enable};
 
 use super::api::RibRx;
 use super::entry::RibEntry;
@@ -444,6 +444,7 @@ impl Rib {
         } else {
             let link = Link::from(fib_link);
             let _ = sysctl_mpls_enable(&link.name);
+            let _ = sysctl_seg6_enable(&link.name);
             self.api_link_add(&link);
             self.links.insert(link.index, link.clone());
 


### PR DESCRIPTION
## Summary

- Add \`sysctl_seg6_enable(ifname)\` mirroring the existing \`sysctl_mpls_enable\` helper. Writes \`net.ipv6.conf.<ifname>.seg6_enabled=1\`.
- Call it alongside the MPLS hook in the new-link branch of \`Rib::link_add\`, so it fires once per interface as the kernel announces it (initial netlink dump and hot-add).
- The global \`all\`/\`default\` seg6_enabled sysctls in \`CTLNAMES\` already gate the feature globally and seed newly-created interfaces; the per-interface write covers interfaces that existed before zebra-rs started, plus drivers that ignore \`default\`.

## Test plan

- [ ] \`cargo build --bin zebra-rs\` is clean.
- [ ] After running zebra-rs, \`cat /proc/sys/net/ipv6/conf/<iface>/seg6_enabled\` returns \`1\` for every interface, including \`lo\`.
- [ ] Hot-add a dummy interface (\`ip link add dummy0 type dummy\`) and confirm its \`seg6_enabled\` flips to 1 once zebra-rs sees the link.
- [ ] End/End.X SID install still works (no regression vs PR #341/#342 behaviour).

Generated with [Claude Code](https://claude.com/claude-code)