### PR TITLE
feat(isis): advertise SRv6 locator prefix in IPv6 Reachability TLV

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1089,6 +1089,23 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
             }
         }
     }
+    // Advertise the configured SRv6 locator as an IPv6 Reachability TLV
+    // (RFC 5308) with metric 0 so receivers learn the locator prefix
+    // purely from their IS-reach metric to us — the originator adds
+    // nothing extra. Gated on the locator having actually resolved in
+    // the RIB; a configured-but-unresolved locator means no prefix yet.
+    if top.config.sr_srv6_enabled
+        && let Some(locator) = top.sr_locator.as_ref()
+        && let Some(prefix) = locator.prefix
+    {
+        let flags = Ipv6ControlInfo::new().with_sub_tlv(false);
+        ipv6_reach.entries.push(IsisTlvIpv6ReachEntry {
+            metric: 0,
+            flags,
+            prefix,
+            subs: Vec::new(),
+        });
+    }
     if !ipv6_reach.entries.is_empty() {
         lsp.tlvs.push(ipv6_reach.into());
     }


### PR DESCRIPTION
## Summary

- Add the configured SRv6 locator prefix to the IPv6 Reachability TLV (RFC 5308, type 236) at metric 0 when SRv6 is enabled and the locator has resolved against the RIB.
- The push is appended to the existing per-link \`ipv6_reach\` entries in \`lsp_generate\`; the trailing \`is_empty()\` push gate stays the same so the TLV is emitted even if no link advertises IPv6 reach but the locator does.
- Independent of the SRv6 Locators TLV (RFC 9352, type 27) already emitted: type 27 carries the SR control-plane info (End SID, algorithm, sub-TLVs); type 236 is what ordinary IPv6 SPF needs to install the prefix in the routing table.

## Gate

- \`top.config.sr_srv6_enabled\` — operator turned on the SRv6 container.
- \`top.sr_locator.is_some()\` — watched locator name resolved.
- \`locator.prefix.is_some()\` — resolved entry actually has a prefix.

These mirror the gates already used by the SRv6 Locators TLV emission.

## Test plan

- [ ] \`cargo build --bin zebra-rs\` is clean.
- [ ] Configure a locator under \`routing isis segment-routing srv6 locator <name>\` and confirm \`show isis database detail\` (and/or Wireshark on the wire) shows the locator prefix in TLV 236 at metric 0, alongside TLV 27.
- [ ] Drop the locator config and confirm the entry disappears from TLV 236 in the next LSP origination.
- [ ] No regression on per-link IPv6 reach entries (still metric 10).

Generated with [Claude Code](https://claude.com/claude-code)