### PR TITLE
feat(isis): emit SRv6 SID Structure sub-sub-TLV on End/End.X SIDs

### DIFF
--- a/crates/isis-packet/src/sub/mod.rs
+++ b/crates/isis-packet/src/sub/mod.rs
@@ -32,9 +32,10 @@ pub mod neigh_disp;
 
 pub mod prefix;
 pub use prefix::{
-    IsisSub2Tlv, IsisSubPrefixSid, IsisSubSrv6EndSid, IsisTlvExtIpReach, IsisTlvExtIpReachEntry,
-    IsisTlvIpv6Reach, IsisTlvIpv6ReachEntry, IsisTlvMtIpReach, IsisTlvMtIpv6Reach,
-    IsisTlvMultiTopology, IsisTlvSrv6, MultiTopologyId, PrefixSidFlags, Srv6Locator,
+    IsisSub2SidStructure, IsisSub2Tlv, IsisSubPrefixSid, IsisSubSrv6EndSid, IsisTlvExtIpReach,
+    IsisTlvExtIpReachEntry, IsisTlvIpv6Reach, IsisTlvIpv6ReachEntry, IsisTlvMtIpReach,
+    IsisTlvMtIpv6Reach, IsisTlvMultiTopology, IsisTlvSrv6, MultiTopologyId, PrefixSidFlags,
+    Srv6Locator,
 };
 pub mod prefix_code;
 pub use prefix_code::{IsisPrefixCode, IsisSrv6SidSub2Code};

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -923,6 +923,34 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
         lsp.tlvs.push(cap.into());
     }
 
+    // SRv6 SID Structure sub-sub-TLV (RFC 9352 §9, type 1) — emitted
+    // alongside every End / End.X SID we originate so receivers know
+    // how the SID's bits are partitioned. Computed once per LSP build
+    // because every SID we emit shares the locator and the same fixed
+    // 16-bit function space.
+    //
+    // LB caps at 40, the IPv6 DOC / SR block size typical deployments
+    // use; anything past 40 in the locator goes into LN, the per-node
+    // portion (e.g. /64 → LB=40, LN=24; /48 → LB=40, LN=8). Function is
+    // 16 bits — the width function_addr() places into the SID. Argument
+    // is 0; we don't allocate argument-bearing SIDs.
+    let sid_structure_subs: Vec<IsisSub2Tlv> = top
+        .sr_locator
+        .as_ref()
+        .and_then(|loc| loc.prefix)
+        .map(|prefix| {
+            let plen = prefix.prefix_len();
+            let lb_len = plen.min(40);
+            IsisSub2Tlv::SidStructure(IsisSub2SidStructure {
+                lb_len,
+                ln_len: plen.saturating_sub(lb_len),
+                fun_len: 16,
+                arg_len: 0,
+            })
+        })
+        .into_iter()
+        .collect();
+
     // SRv6 Locators TLV (RFC 9352 §7.1, type 27). One sub-locator per
     // active locator; today we only carry one. The contained End SID
     // sub-TLV (RFC 9352 §7.2) advertises the Node SID we registered
@@ -937,7 +965,7 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
             flags: 0,
             behavior: Behavior::End,
             sid: end_sid,
-            sub2s: Vec::new(),
+            sub2s: sid_structure_subs.clone(),
         };
         let sub_locator = Srv6Locator {
             metric: 0,
@@ -1008,7 +1036,7 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
                         weight: 0,
                         behavior: Behavior::EndX,
                         sid: sid_addr,
-                        sub2s: Vec::new(),
+                        sub2s: sid_structure_subs.clone(),
                     };
                     is_reach.subs.push(neigh::IsisSubTlv::Srv6EndXSid(sub));
                 } else {
@@ -1019,7 +1047,7 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
                         weight: 0,
                         behavior: Behavior::EndX,
                         sid: sid_addr,
-                        sub2s: Vec::new(),
+                        sub2s: sid_structure_subs.clone(),
                     };
                     is_reach.subs.push(neigh::IsisSubTlv::Srv6LanEndXSid(sub));
                 }


### PR DESCRIPTION
## Summary

- Build a single \`IsisSub2SidStructure\` (RFC 9352 §9, type 1) once per LSP from the configured locator's prefix length, then clone it into the \`sub2s\` field of every End / End.X / LAN End.X sub-TLV we emit.
- Receivers now see \`Locator Block Len: ..., Node Len: ..., Func Len: 16, Arg Len: 0\` alongside each SID — matching the format peer LSPs already carry.
- Re-export \`IsisSub2SidStructure\` from \`isis-packet\`'s prefix sub-module so callers using \`use isis_packet::*\` see it (its sibling \`IsisSub2Tlv\` was already re-exported).

## Encoding choices

- **LB caps at 40** — the IPv6 DOC / SR block size typical deployments use. Anything past 40 in the locator goes into LN, the per-node portion. Examples:
  - \`/64\` locator → LB=40, LN=24
  - \`/48\` locator → LB=40, LN=8
- **Fun = 16** — matches the width \`function_addr()\` actually places into the SID.
- **Arg = 0** — we don't allocate argument-bearing SIDs.

If a future per-locator block-size knob lands, this becomes derived from config; for now the convention is hard-coded.

## Test plan

- [ ] \`cargo build --bin zebra-rs\` is clean.
- [ ] With a \`/64\` locator configured, \`show isis database detail\` (and Wireshark on the wire) shows \`Locator Block Len: 40, Node Len: 24, Func Len: 16, Arg Len: 0\` on:
  - the End SID inside the SRv6 Locators TLV
  - the SRv6 End.X SID inside Extended IS Reachability (P2P)
  - the SRv6 LAN End.X SID inside Extended IS Reachability (LAN)
- [ ] No SID structure emitted when the locator is unconfigured / unresolved.

Generated with [Claude Code](https://claude.com/claude-code)