### PR TITLE
feat(srv6): install uN/uA SIDs in FIB with NEXT-CSID flavor

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -72,9 +72,14 @@ fn mask_v6(addr: std::net::Ipv6Addr, prefix_len: u8) -> std::net::Ipv6Addr {
 ///
 ///   End  : table local, kind=Local,   /128, sid.addr
 ///   End.X: table main,  kind=Unicast, /128, sid.addr
-///   uN   : table main,  kind=Unicast, /(LB+LN), masked sid.addr
+///   uN   : table local, kind=Local,   /(LB+LN), masked sid.addr
 ///          (prefix install — the NEXT-C-SID flavor strips and shifts
-///          at runtime, so any function under the locator hits this)
+///          at runtime, so any function under the locator hits this.
+///          uN reuses End's table/kind because the kernel was silently
+///          dropping installs in table=main with kind=Unicast pointing
+///          at lo; "local prefix routes" are how the kernel normally
+///          treats host-local seg6local actions, and the kind=Local
+///          path is what classic End / End.UN actions hang off.)
 ///   uA   : table main,  kind=Unicast, /128, sid.addr
 ///          (per-adjacency function is unique; longest-prefix match
 ///          picks uA over the wider uN entry)
@@ -95,12 +100,7 @@ fn sid_route_target(
             let plen = structure
                 .map(|s| s.lb_bits.saturating_add(s.ln_bits))
                 .unwrap_or(128);
-            (
-                RouteHeader::RT_TABLE_MAIN,
-                RouteType::Unicast,
-                plen,
-                mask_v6(addr, plen),
-            )
+            (255, RouteType::Local, plen, mask_v6(addr, plen))
         }
         SidBehavior::UA => (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr),
     }
@@ -868,24 +868,6 @@ impl FibHandle {
     /// it, otherwise falls back to embedded seg6local encap on the route
     /// itself (kernels < 5.3).
     pub async fn route_sid_install(&self, sid: &crate::rib::Sid, gid: usize, ifindex: u32) {
-        // Log uSID install attempts at warn level so a kernel rejection
-        // (which fires further down at warn) lands next to the call
-        // that triggered it. Classic End / End.X skip this trace —
-        // those paths are well-trodden.
-        if matches!(
-            sid.behavior,
-            crate::rib::SidBehavior::UN | crate::rib::SidBehavior::UA
-        ) {
-            tracing::warn!(
-                "[route_sid_install] uSID attempt addr={} behavior={:?} \
-                 structure={:?} ifindex={} nh6={:?}",
-                sid.addr,
-                sid.behavior,
-                sid.structure,
-                ifindex,
-                sid.nh6,
-            );
-        }
         let mut msg = RouteMessage::default();
         msg.header.address_family = AddressFamily::Inet6;
         // {table, kind, prefix_length, dest_addr} all derive from the

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -868,6 +868,24 @@ impl FibHandle {
     /// it, otherwise falls back to embedded seg6local encap on the route
     /// itself (kernels < 5.3).
     pub async fn route_sid_install(&self, sid: &crate::rib::Sid, gid: usize, ifindex: u32) {
+        // Log uSID install attempts at warn level so a kernel rejection
+        // (which fires further down at warn) lands next to the call
+        // that triggered it. Classic End / End.X skip this trace —
+        // those paths are well-trodden.
+        if matches!(
+            sid.behavior,
+            crate::rib::SidBehavior::UN | crate::rib::SidBehavior::UA
+        ) {
+            tracing::warn!(
+                "[route_sid_install] uSID attempt addr={} behavior={:?} \
+                 structure={:?} ifindex={} nh6={:?}",
+                sid.addr,
+                sid.behavior,
+                sid.structure,
+                ifindex,
+                sid.nh6,
+            );
+        }
         let mut msg = RouteMessage::default();
         msg.header.address_family = AddressFamily::Inet6;
         // {table, kind, prefix_length, dest_addr} all derive from the
@@ -948,11 +966,18 @@ impl FibHandle {
         let mut response = self.handle.clone().request(req).unwrap();
         while let Some(m) = response.next().await {
             if let NetlinkPayload::Error(e) = m.payload {
-                tracing::info!(
-                    "NewRoute SID install error: addr={} behavior={:?} ifindex={} nh6={:?} \
+                // warn level so kernel rejections show up without
+                // requiring DEBUG_SID — silent failures here are how
+                // a misshaped seg6local install slips through.
+                tracing::warn!(
+                    "NewRoute SID install error: addr={} behavior={:?} \
+                     prefix_len={} table={} kind={:?} ifindex={} nh6={:?} \
                      gid={} use_nhid={} err={}",
                     sid.addr,
                     sid.behavior,
+                    prefix_len,
+                    table,
+                    kind,
                     ifindex,
                     sid.nh6,
                     gid,

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -52,6 +52,60 @@ const DEBUG_V6: bool = false;
 // constant (re-exported as `crate::fib::netlink::handle::DEBUG_SID`).
 pub const DEBUG_SID: bool = false;
 
+/// Mask the lower (128 - prefix_len) bits of an IPv6 address. The
+/// kernel ignores bits past the prefix length on install, but masking
+/// keeps the netlink trace honest and the address shape predictable
+/// for unit tests.
+fn mask_v6(addr: std::net::Ipv6Addr, prefix_len: u8) -> std::net::Ipv6Addr {
+    if prefix_len >= 128 {
+        return addr;
+    }
+    let bits = u128::from(addr);
+    let shift = 128 - u32::from(prefix_len);
+    let mask = !0u128 << shift;
+    std::net::Ipv6Addr::from(bits & mask)
+}
+
+/// Pick the (table, kind, prefix_len, dest_addr) the kernel needs for
+/// a SID install / uninstall. Behavior-driven so install and uninstall
+/// stay in lock-step:
+///
+///   End  : table local, kind=Local,   /128, sid.addr
+///   End.X: table main,  kind=Unicast, /128, sid.addr
+///   uN   : table main,  kind=Unicast, /(LB+LN), masked sid.addr
+///          (prefix install — the NEXT-C-SID flavor strips and shifts
+///          at runtime, so any function under the locator hits this)
+///   uA   : table main,  kind=Unicast, /128, sid.addr
+///          (per-adjacency function is unique; longest-prefix match
+///          picks uA over the wider uN entry)
+///
+/// uN with no SidStructure falls back to /128 — a degenerate state
+/// (uSID locator without a derived structure shouldn't happen), but
+/// keeps the call total.
+fn sid_route_target(
+    behavior: crate::rib::SidBehavior,
+    addr: std::net::Ipv6Addr,
+    structure: Option<crate::rib::SidStructure>,
+) -> (u8, RouteType, u8, std::net::Ipv6Addr) {
+    use crate::rib::SidBehavior;
+    match behavior {
+        SidBehavior::End => (255, RouteType::Local, 128, addr),
+        SidBehavior::EndX => (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr),
+        SidBehavior::UN => {
+            let plen = structure
+                .map(|s| s.lb_bits.saturating_add(s.ln_bits))
+                .unwrap_or(128);
+            (
+                RouteHeader::RT_TABLE_MAIN,
+                RouteType::Unicast,
+                plen,
+                mask_v6(addr, plen),
+            )
+        }
+        SidBehavior::UA => (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr),
+    }
+}
+
 /// Check if the kernel supports nexthop ID (kernel >= 5.3).
 /// Nexthop table was introduced in Linux kernel 5.3.
 fn kernel_supports_nhid() -> bool {
@@ -814,51 +868,57 @@ impl FibHandle {
     /// it, otherwise falls back to embedded seg6local encap on the route
     /// itself (kernels < 5.3).
     pub async fn route_sid_install(&self, sid: &crate::rib::Sid, gid: usize, ifindex: u32) {
-        use crate::rib::SidBehavior;
         let mut msg = RouteMessage::default();
         msg.header.address_family = AddressFamily::Inet6;
-        msg.header.destination_prefix_length = 128;
-        // {table, kind} both split on behavior to match the iproute2
-        // patterns the kernel actually accepts:
-        //   End:    table local, kind=local
-        //           (`ip -6 route add <SID>/128 table local
-        //            encap seg6local action End dev lo`)
-        //   End.X:  table main,  kind=unicast
-        //           (`ip -6 route add <SID>/128
-        //            encap seg6local action End.X nh6 ... dev ...`)
-        // End is host-local termination, so it belongs in table local.
-        // End.X forwards through a remote nexthop after popping the SRH
-        // and is a normal unicast forwarding entry — table main is the
-        // right home for it.
+        // {table, kind, prefix_length, dest_addr} all derive from the
+        // behavior. The kernel matches install + uninstall on these
+        // four header values, so route_sid_uninstall mirrors the same
+        // computation.
+        //
+        //   End  : table local, kind=local, /128, sid.addr
+        //          (`ip -6 route add <SID>/128 table local
+        //           encap seg6local action End dev lo`)
+        //   End.X: table main,  kind=unicast, /128, sid.addr
+        //          (`ip -6 route add <SID>/128
+        //           encap seg6local action End.X nh6 ... dev ...`)
+        //   uN   : table main,  kind=unicast, /(LB+LN), masked addr
+        //          (`ip -6 route add <locator>/<LB+LN>
+        //           encap seg6local action End flavors next-csid
+        //           lblen <LB> nflen <LN+Fun> dev lo`)
+        //          uN is a *prefix* install so any function value
+        //          under the locator hits this entry; the kernel's
+        //          NEXT-C-SID flavor strips and shifts at runtime.
+        //   uA   : table main,  kind=unicast, /128, sid.addr
+        //          Each adjacency function is a unique address;
+        //          longest-prefix match picks uA over the wider uN
+        //          entry. /128 keeps it simple and matches iproute2.
         // RT_TABLE_LOCAL (255) — the fork doesn't expose a named
         // constant for it, so hard-code. See linux/rtnetlink.h.
-        msg.header.table = match sid.behavior {
-            SidBehavior::End => 255,
-            SidBehavior::EndX => RouteHeader::RT_TABLE_MAIN,
-        };
+        let (table, kind, prefix_len, dest_addr) =
+            sid_route_target(sid.behavior, sid.addr, sid.structure);
+        msg.header.table = table;
+        msg.header.destination_prefix_length = prefix_len;
         msg.header.protocol = RouteProtocol::Isis;
         msg.header.scope = RouteScope::Universe;
-        msg.header.kind = match sid.behavior {
-            SidBehavior::End => RouteType::Local,
-            SidBehavior::EndX => RouteType::Unicast,
-        };
+        msg.header.kind = kind;
 
         msg.attributes
-            .push(RouteAttribute::Destination(RouteAddress::Inet6(sid.addr)));
+            .push(RouteAttribute::Destination(RouteAddress::Inet6(dest_addr)));
 
         // seg6local always rides as embedded encap on the route — the
         // kernel nh_id table doesn't accept seg6local lwtunnel encaps
         // even when use_nhid is true for the rest of the FIB. Set Oif
-        // so the kernel knows where to bind the action; for End that's
-        // loopback, for End.X the outgoing link.
+        // so the kernel knows where to bind the action; for End / uN
+        // that's loopback, for End.X / uA the outgoing link.
         let _ = gid;
         if ifindex != 0 {
             msg.attributes.push(RouteAttribute::Oif(ifindex));
         }
-        let Some((encap, encap_type)) = super::srv6::build_seg6local_attrs(sid.behavior, sid.nh6)
+        let Some((encap, encap_type)) =
+            super::srv6::build_seg6local_attrs(sid.behavior, sid.nh6, sid.structure)
         else {
             tracing::warn!(
-                "seg6local route encap build skipped for {} (End.X without IPv6 nexthop)",
+                "seg6local route encap build skipped for {} (End.X / uA without IPv6 nexthop)",
                 sid.addr
             );
             return;
@@ -907,25 +967,21 @@ impl FibHandle {
     /// the kernel — a missing entry surfaces as an error in the trace
     /// but doesn't propagate.
     pub async fn route_sid_uninstall(&self, sid: &crate::rib::Sid) {
-        use crate::rib::SidBehavior;
         let mut msg = RouteMessage::default();
         msg.header.address_family = AddressFamily::Inet6;
-        msg.header.destination_prefix_length = 128;
-        // Same {table, kind} the install used — the kernel matches
-        // RTM_DELROUTE on (table, family, dst, prefixlen, kind).
-        msg.header.table = match sid.behavior {
-            SidBehavior::End => 255,
-            SidBehavior::EndX => RouteHeader::RT_TABLE_MAIN,
-        };
+        // Same {table, kind, prefix_len, dest_addr} the install used
+        // — the kernel matches RTM_DELROUTE on (table, family, dst,
+        // prefixlen, kind).
+        let (table, kind, prefix_len, dest_addr) =
+            sid_route_target(sid.behavior, sid.addr, sid.structure);
+        msg.header.table = table;
+        msg.header.destination_prefix_length = prefix_len;
         msg.header.protocol = RouteProtocol::Isis;
         msg.header.scope = RouteScope::Universe;
-        msg.header.kind = match sid.behavior {
-            SidBehavior::End => RouteType::Local,
-            SidBehavior::EndX => RouteType::Unicast,
-        };
+        msg.header.kind = kind;
 
         msg.attributes
-            .push(RouteAttribute::Destination(RouteAddress::Inet6(sid.addr)));
+            .push(RouteAttribute::Destination(RouteAddress::Inet6(dest_addr)));
 
         let mut req = NetlinkMessage::from(RouteNetlinkMessage::DelRoute(msg));
         req.header.flags = NLM_F_REQUEST | NLM_F_ACK;

--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -7,10 +7,11 @@ use anyhow::{Result, bail};
 use isis_packet::srv6::EncapType;
 use netlink_packet_route::route::{
     Ipv6SrHdr, RouteAttribute, RouteLwEnCapType, RouteLwTunnelEncap, RouteSeg6IpTunnel,
-    RouteSeg6LocalIpTunnel, Seg6IpTunnelEncap, Seg6IpTunnelMode, Seg6LocalAction, VecIpv6SrHdr,
+    RouteSeg6LocalIpTunnel, Seg6IpTunnelEncap, Seg6IpTunnelMode, Seg6LocalAction,
+    Seg6LocalFlavorOps, Seg6LocalFlavors, VecIpv6SrHdr,
 };
 
-use crate::rib::SidBehavior;
+use crate::rib::{SidBehavior, SidStructure};
 
 // Build the seg6 lwtunnel encap for an SRv6 H.Encap policy. Callers wrap the
 // returned encap in either RouteAttribute::Encap (for embedded route-message
@@ -75,33 +76,64 @@ pub fn build_seg6_attrs(
     ))
 }
 
-// Map a SidBehavior to its kernel SEG6_LOCAL_ACTION_*.
+// Map a SidBehavior to its kernel SEG6_LOCAL_ACTION_*. uSID variants
+// reuse the same kernel actions as their classic counterparts; the
+// NEXT-C-SID flavor rides as a separate Flavors attribute.
 fn seg6local_action(behavior: SidBehavior) -> Seg6LocalAction {
     match behavior {
-        SidBehavior::End => Seg6LocalAction::End,
-        SidBehavior::EndX => Seg6LocalAction::EndX,
+        SidBehavior::End | SidBehavior::UN => Seg6LocalAction::End,
+        SidBehavior::EndX | SidBehavior::UA => Seg6LocalAction::EndX,
     }
+}
+
+// Build the Flavors attribute for a uSID install. The kernel needs the
+// NEXT-CSID operation flag plus the lblen / nflen parameters so it
+// knows where to split the destination address when shifting the next
+// uSID into position. Returns None for classic behaviors — they don't
+// need a Flavors attribute at all.
+fn build_seg6local_flavors(
+    behavior: SidBehavior,
+    structure: Option<SidStructure>,
+) -> Option<RouteSeg6LocalIpTunnel> {
+    if !matches!(behavior, SidBehavior::UN | SidBehavior::UA) {
+        return None;
+    }
+    let s = structure?;
+    // Nflen is the combined locator-node + function width — the
+    // "uSID position" the kernel pops on each hop. Lblen is the
+    // shared block portion that stays put.
+    let nflen = s.ln_bits.saturating_add(s.fun_bits);
+    Some(RouteSeg6LocalIpTunnel::Flavors(vec![
+        Seg6LocalFlavors::Operation(Seg6LocalFlavorOps::NextCsid),
+        Seg6LocalFlavors::Lblen(s.lb_bits),
+        Seg6LocalFlavors::Nflen(nflen),
+    ]))
 }
 
 // Build the inner Vec<RouteLwTunnelEncap> for a seg6local install.
 //
-// End needs only the Action attribute. End.X also nests Nh6 (the IPv6
-// nexthop). The kernel's required oif rides on the outer route /
-// nexthop message rather than inside the encap, so we don't add it
-// here.
+// End / uN needs only the Action attribute (uN additionally carries a
+// Flavors block). End.X / uA also nests Nh6 (the IPv6 nexthop). The
+// kernel's required oif rides on the outer route / nexthop message
+// rather than inside the encap, so we don't add it here.
 //
-// Returns None when the operator hasn't supplied the data End.X needs
-// (no IPv6 nexthop) — caller treats that as "skip FIB install for this
-// SID; the registry row stays so the LSP advertisement is unaffected".
+// Returns None when the operator hasn't supplied the data End.X / uA
+// needs (no IPv6 nexthop) — caller treats that as "skip FIB install
+// for this SID; the registry row stays so the LSP advertisement is
+// unaffected".
 fn build_seg6local_lwtunnel(
     behavior: SidBehavior,
     nh6: Option<Ipv6Addr>,
+    structure: Option<SidStructure>,
 ) -> Option<Vec<RouteLwTunnelEncap>> {
     let mut attrs: Vec<RouteSeg6LocalIpTunnel> =
         vec![RouteSeg6LocalIpTunnel::Action(seg6local_action(behavior))];
-    if matches!(behavior, SidBehavior::EndX) {
+    if matches!(behavior, SidBehavior::EndX | SidBehavior::UA) {
         let nh = nh6?;
         attrs.push(RouteSeg6LocalIpTunnel::Nh6(nh));
+    }
+    if let Some(flavors) = build_seg6local_flavors(behavior, structure) {
+        attrs.push(flavors);
     }
     Some(
         attrs
@@ -116,8 +148,9 @@ fn build_seg6local_lwtunnel(
 pub fn build_seg6local_attrs(
     behavior: SidBehavior,
     nh6: Option<Ipv6Addr>,
+    structure: Option<SidStructure>,
 ) -> Option<(RouteAttribute, RouteAttribute)> {
-    let encaps = build_seg6local_lwtunnel(behavior, nh6)?;
+    let encaps = build_seg6local_lwtunnel(behavior, nh6, structure)?;
     Some((
         RouteAttribute::Encap(encaps),
         RouteAttribute::EncapType(RouteLwEnCapType::Seg6Local),

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -614,33 +614,44 @@ impl Isis {
 
     /// Reconcile the End (Node) SID registration with the current
     /// locator snapshot. The End SID is the locator's first address
-    /// (RFC 8986 §4.1 — End behavior). On any transition (locator
-    /// resolved/disappeared, prefix changed, locator name swapped) we
+    /// (RFC 8986 §4.1 — End behavior, or RFC 9800 uN when the locator
+    /// is uSID). On any transition (locator resolved/disappeared,
+    /// prefix changed, behavior flipped, locator name swapped) we
     /// withdraw the previous SID before adding the new one so the
-    /// registry is never double-booked at the same address.
+    /// registry is never double-booked at the same address — and so a
+    /// classic↔uSID flip lands the right behavior + structure in the
+    /// FIB even when the address itself didn't change.
     fn update_end_sid(&mut self) {
-        let desired = self.sr_locator.as_ref().and_then(|loc| loc.node_sid_addr());
-        if desired == self.sr_end_sid {
-            return;
-        }
+        // Always del-then-add on any reconcile call. The address might
+        // be unchanged (classic↔uSID flip preserves it) but the
+        // behavior or structure will differ, and the FIB needs the
+        // updated install. The cost of an unnecessary del+add when
+        // truly nothing changed is one channel round-trip; the cost of
+        // skipping a real change is FIB drift.
         if let Some(prev) = self.sr_end_sid.take() {
             let _ = self.rib_tx.send(rib::Message::SidDel { addr: prev });
         }
-        if let Some(addr) = desired
+        if let Some(locator) = self.sr_locator.as_ref()
+            && let Some(addr) = locator.node_sid_addr()
             && let Some(loc_name) = self.watched_locator.clone()
         {
+            let (behavior, structure) = match locator.behavior {
+                Some(LocatorBehavior::Usid) => (SidBehavior::UN, locator.sid_structure()),
+                None => (SidBehavior::End, None),
+            };
             let sid = Sid {
                 addr,
-                behavior: SidBehavior::End,
+                behavior,
                 context: SidContext::None,
                 owner: SidOwner::new("isis", 0),
                 locator: loc_name,
                 allocation_type: SidAllocationType::Dynamic,
-                // End is local-processing; ifindex=0 lets the RIB
+                // End / uN is local-processing; ifindex=0 lets the RIB
                 // resolve to its loopback link before pushing to the
-                // FIB. nh6 has no meaning for End.
+                // FIB. nh6 has no meaning for End / uN.
                 ifindex: 0,
                 nh6: None,
+                structure,
             };
             let _ = self.rib_tx.send(rib::Message::SidAdd { sid });
             self.sr_end_sid = Some(addr);

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -137,15 +137,20 @@ impl Neighbor {
         // the LSP advertises the capability, but `nh6: None` will
         // tell the FIB to skip the seg6local install.
         let nh6 = self.addr6l.first().copied();
+        let (behavior, structure) = match locator.behavior {
+            Some(crate::rib::LocatorBehavior::Usid) => (SidBehavior::UA, locator.sid_structure()),
+            None => (SidBehavior::EndX, None),
+        };
         let sid = Sid {
             addr,
-            behavior: SidBehavior::EndX,
+            behavior,
             context: SidContext::Interface(ifname.to_string()),
             owner: SidOwner::new("isis", 0),
             locator: loc_name,
             allocation_type: SidAllocationType::Dynamic,
             ifindex: self.ifindex,
             nh6,
+            structure,
         };
         let _ = rib_tx.send(rib::Message::SidAdd { sid });
         self.endx_sid = Some((function, addr));

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -411,24 +411,20 @@ impl Rib {
         // No usable ifindex → skip FIB install but keep the registry
         // entry so the LSP advertisement and show table are unaffected.
         if sid.ifindex == 0 {
-            if crate::fib::netlink::handle::DEBUG_SID {
-                tracing::warn!(
-                    "[sid_install] addr={} skipped — no loopback ifindex resolved yet",
-                    sid.addr
-                );
-            }
+            tracing::warn!(
+                "[sid_install] addr={} skipped — no loopback ifindex resolved yet",
+                sid.addr
+            );
             self.sids.insert(sid.addr, sid);
             return;
         }
 
         let uni = Self::sid_nexthop_uni(&sid);
         let Some(group) = self.nmap.fetch(&uni) else {
-            if crate::fib::netlink::handle::DEBUG_SID {
-                tracing::warn!(
-                    "[sid_install] addr={} NexthopMap::fetch returned None",
-                    sid.addr
-                );
-            }
+            tracing::warn!(
+                "[sid_install] addr={} NexthopMap::fetch returned None",
+                sid.addr
+            );
             self.sids.insert(sid.addr, sid);
             return;
         };

--- a/zebra-rs/src/rib/segment_routing/locator.rs
+++ b/zebra-rs/src/rib/segment_routing/locator.rs
@@ -57,6 +57,30 @@ impl Locator {
     pub fn node_sid_addr(&self) -> Option<Ipv6Addr> {
         self.prefix.map(|p| p.network())
     }
+
+    /// Geometry of SIDs allocated under this locator (RFC 9352 §9 SID
+    /// Structure). Returns `None` when the locator has no prefix yet.
+    ///
+    /// Single source of truth so the IS-IS LSP advertisement and the
+    /// FIB install can't drift on LB/LN/Fun. uSID locators cap LB at
+    /// 32 (the typical uSID block size); classic locators cap at 40
+    /// (IPv6 DOC / SR block convention). Function is fixed at 16 bits
+    /// — the width `function_addr()` actually places into the SID.
+    /// Argument is 0; we don't allocate argument-bearing SIDs.
+    pub fn sid_structure(&self) -> Option<crate::rib::SidStructure> {
+        let prefix = self.prefix?;
+        let plen = prefix.prefix_len();
+        let lb_bits = match self.behavior {
+            Some(LocatorBehavior::Usid) => plen.min(32),
+            None => plen.min(40),
+        };
+        Some(crate::rib::SidStructure {
+            lb_bits,
+            ln_bits: plen.saturating_sub(lb_bits),
+            fun_bits: 16,
+            arg_bits: 0,
+        })
+    }
 }
 
 /// In-flight Locator configuration, mirroring the YANG list shape:

--- a/zebra-rs/src/rib/segment_routing/mod.rs
+++ b/zebra-rs/src/rib/segment_routing/mod.rs
@@ -18,7 +18,7 @@ pub mod sid;
 // then only the show callback reaches into `Sid` and these helper
 // types stay technically unused at the crate boundary.
 #[allow(unused_imports)]
-pub use sid::{Sid, SidAllocationType, SidBehavior, SidContext, SidOwner};
+pub use sid::{Sid, SidAllocationType, SidBehavior, SidContext, SidOwner, SidStructure};
 
 /// Subscription-channel return type from RIB to a protocol module.
 /// `block: None` / `locator: None` signals deletion (or "doesn't exist

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -10,9 +10,9 @@
 use std::fmt;
 use std::net::Ipv6Addr;
 
-/// RFC 8986 endpoint behavior for an allocated SID. We only carry the
-/// variants we know how to advertise today; future behaviors (uSID,
-/// End.DT4, End.DT6, End.B6, ...) extend the enum.
+/// SRv6 endpoint behavior for an allocated SID. RFC 8986 base set plus
+/// the RFC 9800 NEXT-C-SID (uSID) variants we install today; other
+/// behaviors (End.DT4, End.DT6, End.B6, ...) extend the enum.
 ///
 /// `#[allow(dead_code)]` on the type until PR 2 starts populating the
 /// registry; the show callback already discriminates on every variant
@@ -26,6 +26,16 @@ pub enum SidBehavior {
     /// End.X — RFC 8986 §4.2, "L3 cross-connect" / adjacency SID.
     /// Bound to a specific outgoing interface and neighbor.
     EndX,
+    /// uN — RFC 9800 NEXT-C-SID flavor of End. Same host-local
+    /// processing semantics; the kernel additionally shifts the
+    /// destination address by `ln + fun` bits before passing the
+    /// packet on. Carries a [`SidStructure`] so the FIB knows the
+    /// shift width.
+    UN,
+    /// uA — RFC 9800 NEXT-C-SID flavor of End.X. Same per-adjacency
+    /// forwarding as End.X with the additional uSID shift; carries a
+    /// [`SidStructure`].
+    UA,
 }
 
 impl fmt::Display for SidBehavior {
@@ -33,8 +43,24 @@ impl fmt::Display for SidBehavior {
         match self {
             Self::End => write!(f, "End"),
             Self::EndX => write!(f, "End.X"),
+            Self::UN => write!(f, "uN"),
+            Self::UA => write!(f, "uA"),
         }
     }
+}
+
+/// SRv6 SID Structure (RFC 9352 §9): how the 128-bit SID is partitioned
+/// into Locator-Block / Locator-Node / Function / Argument bits.
+/// Required to install a uSID SID into the kernel because the
+/// `seg6local` NEXT-C-SID flavor needs Lblen / Nflen attributes to
+/// know what to shift; classic End / End.X don't carry one.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SidStructure {
+    pub lb_bits: u8,
+    pub ln_bits: u8,
+    pub fun_bits: u8,
+    pub arg_bits: u8,
 }
 
 /// Optional context that disambiguates per-link / per-VRF SIDs. End is
@@ -123,6 +149,9 @@ pub struct Sid {
     pub allocation_type: SidAllocationType,
     pub ifindex: u32,
     pub nh6: Option<Ipv6Addr>,
+    /// Partitioning of the SID's bits. Required for `UN`/`UA`; ignored
+    /// for classic `End`/`EndX` (left `None`).
+    pub structure: Option<SidStructure>,
 }
 
 #[cfg(test)]

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1106,6 +1106,7 @@ mod tests {
             allocation_type: SidAllocationType::Dynamic,
             ifindex: 0,
             nh6: None,
+            structure: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Phase 1+2 of FIB-side uSID support. When a configured locator has \`behavior=Some(Usid)\`, the IS-IS allocator registers the Node SID as \`SidBehavior::UN\` and adjacency SIDs as \`SidBehavior::UA\`, both carrying the SID Structure (LB/LN/Fun bits) the kernel needs to shift uSIDs at runtime.

### Data model
- \`SidBehavior\` gains \`UN\` / \`UA\` variants.
- \`Sid\` gains \`structure: Option<SidStructure>\`. Classic End / End.X stay structure-less; uSID variants always carry one.
- \`Locator::sid_structure()\` is now the single source of truth for LB/LN derivation so the LSP encoding and the FIB install can't drift on geometry. uSID caps LB at 32; classic at 40.

### IS-IS allocators
- \`update_end_sid()\` now always del-then-adds on reconcile so a classic↔uSID flip with same prefix lands the right behavior + structure in the FIB even when the address is unchanged.
- The neighbour End.X allocator picks UA + structure when the locator is uSID.

### FIB install
- \`build_seg6local_lwtunnel\` adds a \`Flavors(NextCsid + Lblen + Nflen)\` attribute for uN/uA. \`Nflen = ln_bits + fun_bits\` (the uSID position the kernel pops).
- \`sid_route_target\` picks (table, kind, prefix_len, dest_addr) per behavior:
  - **End**: \`table local, kind=Local, /128\`
  - **End.X**: \`table main, kind=Unicast, /128\`
  - **uN**: \`table local, kind=Local, /(LB+LN)\` — masks the dest. The kernel was silently dropping installs in \`table=main, kind=Unicast\` pointing at lo; matching the classic End pattern at the wider prefix works cleanly.
  - **uA**: \`table main, kind=Unicast, /128\` — per-adjacency function is unique; longest-prefix match picks uA over the wider uN.

### Diagnostic improvements (kept after debugging this PR)
- Kernel install errors now log at \`warn\` (was \`info\`, hidden by default).
- Loopback / NexthopMap skip warnings ungated from \`DEBUG_SID\` so the silent-failure modes are visible.

## Out of scope
The classic ↔ uSID transition path is unchanged: the existing \`process_sr_rx::Locator\` handler clears every End.X and re-runs \`update_end_sid()\` on any locator-snapshot diff. Combined with the new del-then-add behaviour in \`update_end_sid\`, the FIB transitions cleanly.

## Manual verification

With a uSID \`/48\` locator (\`fcbb:bbbb:1::/48\`, behavior usid):

\`\`\`
$ ip -6 route show table all | grep End
local fcbb:bbbb:1::/48  encap seg6local action End flavors next-csid lblen 32 nflen 32 dev lo table local proto isis ...
fcbb:bbbb:1:e000::       encap seg6local action End.X nh6 fe80::21c:42ff:fee8:c23 flavors next-csid lblen 32 nflen 32 dev enp0s6 proto isis ...
\`\`\`

## Test plan

- [x] \`cargo build --bin zebra-rs\` clean.
- [x] \`cargo test --bin zebra-rs --lib\` 138 passing.
- [x] Configure uSID locator on a /48 prefix; uN installs as a /48 host-local route in table local with NEXT-CSID lblen=32 nflen=32 on lo.
- [x] uA installs as /128 with NEXT-CSID lblen=32 nflen=32 on the adjacency interface.
- [ ] Drop \`behavior usid\` from the locator → confirm next reconcile lands classic End at /128 in table local.

Generated with [Claude Code](https://claude.com/claude-code)