### PR TITLE
feat(isis): add multi-topology config schema (PR 1 of N)

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright 2025-2026 Kunihiro Ishiguro
 
+use std::collections::BTreeSet;
 use std::net::Ipv4Addr;
+use std::str::FromStr;
 
 use isis_packet::{IsLevel, Nsap};
+use strum_macros::{Display, EnumString};
 
 use crate::config::{Args, ConfigOp};
 
@@ -12,6 +15,22 @@ use super::inst::Callback;
 use super::link::Afis;
 use super::tracing::{PacketConfig, PacketDirection};
 use super::{Level, link};
+
+/// IS-IS Multi-Topology identifier (RFC 5120). The wire encoding is a
+/// 12-bit MT ID; we model only the topologies we actually compute SPF
+/// for. Multicast variants (MT 3, MT 4) parse on the wire but don't
+/// surface here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, EnumString, Display)]
+pub enum MtId {
+    /// MT 0 — IPv4 unicast (the legacy "standard" topology). When no
+    /// MT TLV is present in an LSP, RFC 5120 §3.4 says everything
+    /// implicitly belongs here.
+    #[strum(serialize = "standard")]
+    Standard,
+    /// MT 2 — IPv6 unicast.
+    #[strum(serialize = "ipv6-unicast")]
+    Ipv6Unicast,
+}
 
 impl Isis {
     const TRACING: &str = "/routing/isis/tracing";
@@ -36,6 +55,12 @@ impl Isis {
         self.callback_add(
             "/routing/isis/segment-routing/srv6/locator",
             config_sr_srv6_locator,
+        );
+        self.callback_add("/routing/isis/multi-topology", config_mt_enable);
+        self.callback_add("/routing/isis/multi-topology/topology", config_mt_topology);
+        self.callback_add(
+            "/routing/isis/interface/multi-topology/metric",
+            link::config_mt_metric,
         );
         self.callback_add("/routing/isis/interface/priority", link::config_priority);
         self.tracing_add("/event", config_tracing_event);
@@ -109,6 +134,18 @@ pub struct IsisConfig {
     /// /segment-routing/locator list. Same staging-friendly rationale
     /// as sr_mpls_block.
     pub sr_srv6_locator: Option<String>,
+
+    /// Set when /routing/isis/multi-topology is committed (the
+    /// presence-marked YANG container). Drives whether IS-IS
+    /// originates the MT TLV (229) and per-MT reach TLVs in
+    /// follow-up PRs.
+    pub mt_enabled: bool,
+
+    /// MT IDs the operator selected under
+    /// /routing/isis/multi-topology/topology. Empty when MT is on but
+    /// the operator hasn't named any topologies yet — that's a
+    /// no-op-friendly intermediate state during config staging.
+    pub mt_topologies: BTreeSet<MtId>,
 }
 
 impl IsisConfig {
@@ -238,6 +275,33 @@ fn config_sr_srv6_locator(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Opti
         isis.config.sr_srv6_locator = None;
     }
     isis.reconcile_locator_watch();
+    Some(())
+}
+
+// Set/cleared by the presence of the YANG container itself, like
+// segment-routing/srv6 above. Removing the container also drops every
+// configured topology; PR 2 will trigger LSP re-origination from here.
+fn config_mt_enable(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
+    if op.is_set() {
+        isis.config.mt_enabled = true;
+    } else {
+        isis.config.mt_enabled = false;
+        isis.config.mt_topologies.clear();
+    }
+    Some(())
+}
+
+// Per-list-entry callback: the value is the MT id keyword. Add on set,
+// remove on delete. Unknown ids fall through to None — libyang's enum
+// validation should keep them out, but we don't trust the wire.
+fn config_mt_topology(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let id_str = args.string()?;
+    let id = MtId::from_str(&id_str).ok()?;
+    if op.is_set() {
+        isis.config.mt_topologies.insert(id);
+    } else {
+        isis.config.mt_topologies.remove(&id);
+    }
     Some(())
 }
 

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -21,7 +21,7 @@ use crate::isis_event_trace;
 use crate::rib::link::LinkAddr;
 use crate::rib::{Link, MacAddr};
 
-use super::config::IsisConfig;
+use super::config::{IsisConfig, MtId};
 use super::ifsm::{self, has_level};
 use super::inst::{PacketMessage, ReachMap, ReachMapV6};
 use super::neigh::Neighbor;
@@ -200,6 +200,13 @@ pub struct LinkConfig {
     pub csnp_interval: Option<u32>,
 
     pub prefix_sid: Option<SidLabelValue>,
+
+    /// Per-MT metric overrides — populated from
+    /// /routing/isis/interface/<name>/multi-topology/<id>/metric.
+    /// Empty when no per-MT metric is configured; lookup falls back
+    /// to the link's `metric` leaf above. PR 2 reads this when
+    /// emitting MT IS Reach (TLV 222) entries.
+    pub mt_metrics: BTreeMap<MtId, u32>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, EnumString, Display)]
@@ -624,6 +631,27 @@ fn config_afi_enable(isis: &mut Isis, mut args: Args, op: ConfigOp, afi: Afi) ->
 
 pub fn config_ipv4_enable(isis: &mut Isis, args: Args, op: ConfigOp) -> Option<()> {
     config_afi_enable(isis, args, op, Afi::Ip)
+}
+
+// Per-MT, per-link metric override. The path arrives with three
+// values from libyang dispatch: outer interface key (`if-name`), inner
+// list key (MT id keyword), then the leaf value (`metric`). PR 1 just
+// stores it; PR 2 reads it when emitting TLV 222 entries.
+pub fn config_mt_metric(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    use std::str::FromStr;
+
+    let ifname = args.string()?;
+    let id_str = args.string()?;
+    let id = MtId::from_str(&id_str).ok()?;
+
+    let link = isis.links.get_mut_by_name(&ifname)?;
+    if op.is_set() {
+        let metric = args.u32()?;
+        link.config.mt_metrics.insert(id, metric);
+    } else {
+        link.config.mt_metrics.remove(&id);
+    }
+    Some(())
 }
 
 pub fn config_metric(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -298,6 +298,27 @@ module config {
           }
         }
 
+        container multi-topology {
+          // RFC 5120 M-ISIS. Presence enables multi-topology routing;
+          // the inner `topology` list names the topologies the router
+          // participates in. PR 1 lands the config model only — wire
+          // origination, SPF, and routing-install happen in follow-up
+          // PRs.
+          presence "Enable IS-IS multi-topology routing (RFC 5120)";
+          list topology {
+            key "id";
+            // Standard MT IDs we know how to compute SPF for. Multicast
+            // variants (3, 4) parse on the wire but aren't surfaced
+            // here — operators don't enable them via this knob.
+            leaf id {
+              type enumeration {
+                enum standard;       // MT 0 — IPv4 unicast
+                enum ipv6-unicast;   // MT 2 — IPv6 unicast
+              }
+            }
+          }
+        }
+
         leaf te-router-id {
           type inet:ipv4-address;
         }
@@ -370,6 +391,20 @@ module config {
           container ipv6 {
             leaf enable {
               type boolean;
+            }
+          }
+          list multi-topology {
+            // Per-link, per-MT metric override. Absence falls back to
+            // the link's `metric` leaf above.
+            key "id";
+            leaf id {
+              type enumeration {
+                enum standard;
+                enum ipv6-unicast;
+              }
+            }
+            leaf metric {
+              type uint32;
             }
           }
         }


### PR DESCRIPTION
## Summary

YANG schema and config plumbing for RFC 5120 multi-topology IS-IS. Lands the data model only — no LSP origination, SPF, or routing-install behaviour change yet. This is the first of a four-PR sequence:

- **PR 1 (this one)**: YANG + config plumbing.
- **PR 2**: emit MT TLV (229) and MT IS / IPv6 Reach (222 / 237) when \`mt_enabled\` and the topology is in \`mt_topologies\`.
- **PR 3**: per-topology graph and SPF; per-topology RIB install.
- **PR 4**: \`show isis topology\`, MT-aware \`show isis database detail\`, etc.

## Schema additions (config.yang)

\`\`\`yang
/routing/isis/multi-topology              # presence container
/routing/isis/multi-topology/topology     # list keyed by id
                                          #   enums: standard (MT 0),
                                          #          ipv6-unicast (MT 2)
/routing/isis/interface/multi-topology    # per-link, per-MT metric
                                          # override (fallback: link metric)
\`\`\`

## Rust additions

- \`MtId\` enum (\`Standard\` / \`Ipv6Unicast\`). FromStr/Display via strum, Ord for BTreeSet/BTreeMap keys.
- \`IsisConfig.mt_enabled\` — set by the presence container.
- \`IsisConfig.mt_topologies\` (\`BTreeSet<MtId>\`) — entries from the inner list. Cleared when the outer container is removed.
- \`LinkConfig.mt_metrics\` (\`BTreeMap<MtId, u32>\`) — per-link metric overrides per topology.
- Three callbacks: \`config_mt_enable\` (presence), \`config_mt_topology\` (list-entry add/remove), \`link::config_mt_metric\` (per-link metric leaf with three positional args from libyang dispatch).

\`MtId::wire_id\` (the 12-bit on-wire encoding) lands with PR 2 alongside the first consumer to avoid \`dead_code\` warnings.

## Test plan

- [x] \`cargo build --bin zebra-rs\` clean.
- [x] \`cargo clippy\` clean.
- [x] \`cargo test --bin zebra-rs --lib\` 138 passing.
- [ ] Configure \`router isis { multi-topology { topology ipv6-unicast; } }\` and confirm \`mt_enabled=true\`, \`mt_topologies={Ipv6Unicast}\` (state inspection — no behaviour effect yet).
- [ ] Configure \`interface eth0 { multi-topology ipv6-unicast { metric 50; } }\` and confirm \`LinkConfig.mt_metrics\` populated.
- [ ] Drop the outer \`multi-topology\` container; confirm \`mt_topologies\` empties and \`mt_enabled\` flips false.

Generated with [Claude Code](https://claude.com/claude-code)