### PR TITLE
feat(isis): add show isis topology command

### DIFF
--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -36,6 +36,7 @@ impl Isis {
         self.show_add("/show/isis/hostname", hostname::show);
         self.show_add("/show/isis/graph", show_isis_graph);
         self.show_add("/show/isis/spf", show_isis_spf);
+        self.show_add("/show/isis/topology", show_isis_topology);
     }
 }
 
@@ -282,6 +283,51 @@ fn show_isis_route(
     } else {
         write_show_isis_route_text(isis)
     }
+}
+
+// `show isis topology` — per-level, per-AFI SPF tree without the RIB
+// tables that `show isis route` adds. PR 2 of the multi-topology
+// series; the renderer is the existing single-topology one. PR 5 will
+// extend it to discriminate per-MT view + add a `<topology-id>` filter.
+fn show_isis_topology(
+    isis: &Isis,
+    _args: Args,
+    _json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let mut buf = String::new();
+    let local_sys_id = isis.config.net.sys_id();
+    writeln!(buf, "Area {}:", format_area_id(&isis.config.net))?;
+
+    let mut wrote_any_level = false;
+    for level in &[Level::L1, Level::L2] {
+        let Some(spf_result) = isis.spf_result.get(level).as_ref() else {
+            continue;
+        };
+        if spf_result.is_empty() {
+            continue;
+        }
+        wrote_any_level = true;
+
+        let level_long = match level {
+            Level::L1 => "level-1",
+            Level::L2 => "level-2",
+        };
+
+        // IPv4 SPF tree.
+        writeln!(buf)?;
+        writeln!(buf, "IS-IS paths to {} routers that speak IP", level_long)?;
+        write_spf_tree(&mut buf, isis, level, &local_sys_id, spf_result, false)?;
+
+        // IPv6 SPF tree (NLPID-gated, RFC 1195 §5).
+        writeln!(buf)?;
+        writeln!(buf, "IS-IS paths to {} routers that speak IPv6", level_long)?;
+        write_spf_tree(&mut buf, isis, level, &local_sys_id, spf_result, true)?;
+    }
+
+    if !wrote_any_level {
+        writeln!(buf, "(no SPF result yet)")?;
+    }
+    Ok(buf)
 }
 
 fn write_show_isis_route_text(isis: &Isis) -> std::result::Result<String, std::fmt::Error> {

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -195,6 +195,10 @@ module exec {
       leaf spf {
         type empty;
       }
+      leaf topology {
+        ext:help "IS-IS SPF tree (per-AFI today; per-MT once multi-topology lands)";
+        type empty;
+      }
       container adjacency {
         ext:help "IS-IS adjacency";
         presence "IS-IS adjacency";


### PR DESCRIPTION
## Summary

PR 2 of the multi-topology series. Adds \`show isis topology\` — per-level, per-AFI SPF tree without the RIB tables that \`show isis route\` already prints. The renderer reuses the existing \`write_spf_tree\` helper, so column layout, NLPID gating, and per-prefix grouping all match what \`show isis route\` already produces; the new command just lets operators see the SPF tree on its own.

PR 5 will extend this command to discriminate the per-MT view and add a \`<topology-id>\` filter once per-topology SPF lands. Today the IPv4 / IPv6 sections still come from the same single-topology SPF run.

## Wire-up

- New \`show_isis_topology\` callback registered at \`/show/isis/topology\`.
- \`topology\` leaf added under the \`isis\` container in \`exec.yang\` so the CLI parser exposes the command.

## Test plan

- [x] \`cargo build --bin zebra-rs\` clean.
- [x] \`cargo clippy --bin zebra-rs\` clean.
- [x] \`cargo test --bin zebra-rs --lib\` 138 passing.
- [ ] In a running zebra-rs, \`show isis topology\` produces the per-level / per-AFI SPF tree:
  - \`Area <addr>:\` header
  - \`IS-IS paths to level-N routers that speak IP\` + tree
  - \`IS-IS paths to level-N routers that speak IPv6\` + tree
- [ ] No RIB tables printed (compare with \`show isis route\` which still has them).

## Open follow-ups (out of scope for this PR)

- The Parent column suffix is hard-coded \`(0)\` (current convention). If the operator-facing target is something else (parent's SPF vertex id, path count), it's a one-line tweak in \`write_spf_tree\`.
- No level filter argument yet (\`show isis topology level-1 / level-2\`); folds in trivially if needed.

Generated with [Claude Code](https://claude.com/claude-code)