### PR TITLE
feat(isis): emit MT TLV + MT IS Reach + MT IPv6 Reach (PR 3 of N)

### DIFF
--- a/crates/isis-packet/src/sub/prefix.rs
+++ b/crates/isis-packet/src/sub/prefix.rs
@@ -472,6 +472,12 @@ impl TlvEmitter for IsisTlvMtIpv6Reach {
     }
 }
 
+impl From<IsisTlvMtIpv6Reach> for IsisTlv {
+    fn from(tlv: IsisTlvMtIpv6Reach) -> Self {
+        IsisTlv::MtIpv6Reach(tlv)
+    }
+}
+
 #[bitfield(u8, debug = true)]
 #[derive(Serialize, Deserialize, PartialEq)]
 pub struct Ipv6ControlInfo {

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -32,6 +32,16 @@ pub enum MtId {
     Ipv6Unicast,
 }
 
+impl MtId {
+    /// 12-bit wire identifier per RFC 5120 §7.2 / §7.3.
+    pub fn wire_id(self) -> u16 {
+        match self {
+            Self::Standard => 0,
+            Self::Ipv6Unicast => 2,
+        }
+    }
+}
+
 impl Isis {
     const TRACING: &str = "/routing/isis/tracing";
 

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -39,7 +39,7 @@ use crate::{
 use crate::context::Timer;
 use crate::spf;
 
-use super::config::IsisConfig;
+use super::config::{IsisConfig, MtId};
 use super::flood;
 use super::ifsm::{csnp_timer, has_level};
 use super::link::{Afis, IsisLinks, LinkTop};
@@ -1008,6 +1008,22 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
         lsp.tlvs.push(IsisTlv::Srv6(srv6_tlv));
     }
 
+    // Multi-Topology TLV (229) — RFC 5120 §7.1. Lists the MT IDs
+    // this router participates in. Receivers use it to decide which
+    // MT-keyed TLVs to expect (TLV 222 / 235 / 237) and which graphs
+    // we belong to. Only emitted when MT is enabled and at least one
+    // topology is configured.
+    if top.config.mt_enabled && !top.config.mt_topologies.is_empty() {
+        let entries: Vec<MultiTopologyId> = top
+            .config
+            .mt_topologies
+            .iter()
+            .map(|id| MultiTopologyId::from(id.wire_id()))
+            .collect();
+        let mt_tlv = IsisTlvMultiTopology { entries };
+        lsp.tlvs.push(mt_tlv.into());
+    }
+
     // TE Router ID. Prefer configured value, fall back to RIB-derived.
     if top.config.sr_enabled()
         && let Some(router_id) = top.config.te_router_id.or(top.config.rib_router_id)
@@ -1086,6 +1102,72 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
         lsp.tlvs.push(ext_is_reach.into());
     }
 
+    // MT IS Reach (TLV 222) for MT 2 — RFC 5120 §7.2. Mirrors the
+    // adjacencies in TLV 22 above, but only for IPv6-enabled links
+    // and only when MT 2 is configured. SRv6 End.X / LAN-End.X SIDs
+    // ride here per RFC 8667 §2 (SR sub-TLVs nest inside the
+    // MT-specific IS Reach for the MT they belong to). The IPv4
+    // SR-MPLS AdjSid stays on TLV 22 only — that's MT 0.
+    if top.config.mt_enabled && top.config.mt_topologies.contains(&MtId::Ipv6Unicast) {
+        let mt2_id = MultiTopologyId::from(MtId::Ipv6Unicast.wire_id());
+        let mut mt2_entries: Vec<IsisTlvExtIsReachEntry> = Vec::new();
+        for (_, link) in top.links.iter() {
+            if !link.config.enable.v6 {
+                continue;
+            }
+            let Some((adj, _)) = &link.state.adj.get(&level) else {
+                continue;
+            };
+            // Per-MT metric override falls back to the link's plain
+            // metric leaf. Future PR can layer per-MT defaults too.
+            let metric = link
+                .config
+                .mt_metrics
+                .get(&MtId::Ipv6Unicast)
+                .copied()
+                .unwrap_or_else(|| link.config.metric());
+            let mut entry = IsisTlvExtIsReachEntry {
+                neighbor_id: *adj,
+                metric,
+                subs: Vec::new(),
+            };
+            for (_, nbr) in link.state.nbrs.get(&level).iter() {
+                if let Some((_, sid_addr)) = nbr.endx_sid {
+                    if nbr.link_type.is_p2p() {
+                        let sub = IsisSubSrv6EndXSid {
+                            flags: 0,
+                            algo: Algo::Spf,
+                            weight: 0,
+                            behavior: endx_behavior,
+                            sid: sid_addr,
+                            sub2s: sid_structure_subs.clone(),
+                        };
+                        entry.subs.push(neigh::IsisSubTlv::Srv6EndXSid(sub));
+                    } else {
+                        let sub = IsisSubSrv6LanEndXSid {
+                            system_id: nbr.sys_id,
+                            flags: 0,
+                            algo: Algo::Spf,
+                            weight: 0,
+                            behavior: endx_behavior,
+                            sid: sid_addr,
+                            sub2s: sid_structure_subs.clone(),
+                        };
+                        entry.subs.push(neigh::IsisSubTlv::Srv6LanEndXSid(sub));
+                    }
+                }
+            }
+            mt2_entries.push(entry);
+        }
+        if !mt2_entries.is_empty() {
+            let mt_is_reach = IsisTlvMtIsReach {
+                mt: mt2_id,
+                entries: mt2_entries,
+            };
+            lsp.tlvs.push(mt_is_reach.into());
+        }
+    }
+
     // IPv4 Reachability.
     let mut ext_ip_reach = IsisTlvExtIpReach::default();
     for (_, link) in top.links.iter() {
@@ -1162,7 +1244,17 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
         });
     }
     if !ipv6_reach.entries.is_empty() {
-        lsp.tlvs.push(ipv6_reach.into());
+        if top.config.mt_enabled && top.config.mt_topologies.contains(&MtId::Ipv6Unicast) {
+            // MT 2 mode: same entries, MT-keyed TLV 237 instead of
+            // TLV 236. RFC 5120 §7.3.
+            let mt_ipv6_reach = IsisTlvMtIpv6Reach {
+                mt: MultiTopologyId::from(MtId::Ipv6Unicast.wire_id()),
+                entries: ipv6_reach.entries,
+            };
+            lsp.tlvs.push(mt_ipv6_reach.into());
+        } else {
+            lsp.tlvs.push(ipv6_reach.into());
+        }
     }
     lsp
 }


### PR DESCRIPTION
## Summary

PR 3 of the multi-topology series. When \`mt_enabled\` and the operator has named at least one topology, the LSP now carries:

- **TLV 229 (Multi-Topology)** listing every configured MT id, so receivers know which graphs we belong to (RFC 5120 §7.1).
- **TLV 222 (MT IS Reach)** tagged \`mt=2\` for every IPv6-enabled adjacency, when MT 2 (\`ipv6-unicast\`) is configured. Mirrors TLV 22's neighbour set; SRv6 End.X / LAN-End.X sub-TLVs ride here per RFC 8667 §2 — the IPv4 SR-MPLS AdjSid sub-TLV stays on TLV 22 only (MT 0).
- **TLV 237 (MT IPv6 Reach)** tagged \`mt=2\` instead of TLV 236, when MT 2 is configured. Same entries (link addresses + the SRv6 locator's metric-0 reach from #344), MT-keyed envelope (RFC 5120 §7.3).

Per-MT metric override (\`/routing/isis/interface/<name>/multi-topology/<id>/metric\` from PR 1) is consumed for TLV 222 entries; absence falls back to the link's plain \`metric\` leaf.

**MT 0 advertisement is unchanged** — TLV 22 / 135 keep emitting as today, so legacy peers continue to see the IPv4 view they expect.

## Carrier work

- \`isis-packet\` gains \`From<IsisTlvMtIpv6Reach> for IsisTlv\` so the push path looks the same as the TLV 22 / 236 siblings.
- \`MtId::wire_id()\` reinstated as the first consumer (the helper PR 1 deferred).

## Out of scope (next PRs)

- PR 4: per-topology graph + per-topology SPF + per-topology RIB install.
- PR 5: extend \`show isis topology\` to discriminate per-MT view, add \`<topology-id>\` filter, render MT TLVs in \`show isis database detail\`.

## Test plan

- [x] \`cargo build --bin zebra-rs\` clean.
- [x] \`cargo clippy --bin zebra-rs\` clean.
- [x] \`cargo test --bin zebra-rs --lib\` 138 passing.
- [ ] **No MT config**: LSP looks identical to today (no TLV 229, TLV 22 / 135 / 236 untouched). Verify via Wireshark or \`show isis database detail\`.
- [ ] **\`multi-topology { topology ipv6-unicast; }\`**: LSP carries TLV 229 listing MT 2, TLV 222 with IPv6 adjacencies + End.X sub-TLVs, TLV 237 (not 236) for IPv6 reach.
- [ ] **Per-link \`multi-topology ipv6-unicast { metric 50; }\`**: that link's TLV 222 entry uses metric 50.

Generated with [Claude Code](https://claude.com/claude-code)