### PR TITLE
test(isis): add BDD scenarios for multi-topology (MT 2)

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -416,6 +416,35 @@ async fn test_topology_exists(world: &mut BgpWorld) {
         && netns::netns_exists("z2").await.unwrap_or(false);
 }
 
+/// Run a `vtyctl show <command>` inside a namespace and assert the
+/// stdout contains the given substring. Used by the IS-IS multi-
+/// topology feature to verify MT TLVs land in `show isis database
+/// detail`; intentionally generic so other features can reuse it
+/// for LSDB / route-table assertions.
+#[then(expr = "show command {string} in namespace {string} should contain {string}")]
+async fn show_command_contains(
+    _world: &mut BgpWorld,
+    show_cmd: String,
+    namespace: String,
+    needle: String,
+) {
+    let output = netns::exec_in_netns(&namespace, "vtyctl", &["show", &show_cmd])
+        .await
+        .expect("Failed to run show command");
+    assert!(
+        output.contains(&needle),
+        "show '{}' in namespace {} did not contain '{}'\nfull output:\n{}",
+        show_cmd,
+        namespace,
+        needle,
+        output,
+    );
+    println!(
+        "✓ show '{}' in namespace {} contains '{}'",
+        show_cmd, namespace, needle
+    );
+}
+
 #[then("the test environment should be clean")]
 async fn verify_clean_environment(_world: &mut BgpWorld) {
     let z1_exists = netns::netns_exists("z1").await.unwrap_or(false);

--- a/bdd/tests/data/isis_multi_topology/z1-1.yaml
+++ b/bdd/tests/data/isis_multi_topology/z1-1.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::1/128
+- if-name: vz1ns
+  ipv6:
+    address: 2001:db8:1::1/64
+routing:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    multi-topology:
+      topology:
+      - id: ipv6-unicast
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+    - if-name: vz1ns
+      circuit-type: level-2-only
+      ipv6:
+        enable: true

--- a/bdd/tests/data/isis_multi_topology/z2-1.yaml
+++ b/bdd/tests/data/isis_multi_topology/z2-1.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::2/128
+- if-name: vz2ns
+  ipv6:
+    address: 2001:db8:1::2/64
+routing:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    multi-topology:
+      topology:
+      - id: ipv6-unicast
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+    - if-name: vz2ns
+      circuit-type: level-2-only
+      ipv6:
+        enable: true

--- a/bdd/tests/features/isis_multi_topology.feature
+++ b/bdd/tests/features/isis_multi_topology.feature
@@ -1,0 +1,54 @@
+@serial
+@isis_multi_topology
+Feature: IS-IS multi-topology (RFC 5120)
+  As a network operator
+  I want two zebra-rs instances to participate in IS-IS multi-topology
+  routing for IPv6 unicast (MT 2), exchanging TLV 229 / 222 / 237 in
+  their LSPs and installing IPv6 reachability through the per-MT SPF
+  result, so dual-stack networks can run independent IPv4 and IPv6
+  topologies.
+
+  Test Topology (same shape as isis_ipv6 but both sides emit MT TLVs):
+  ```
+  ┌────────────────────────────────────────┐
+  │                  br0                   │
+  └────────────┬───────────────┬───────────┘
+               │               │
+       2001:db8:1::1/64   2001:db8:1::2/64
+            (vz1ns)             (vz2ns)
+          ┌────┴────┐     ┌────┴────┐
+          │   z1    │     │   z2    │
+          │ +MT 2   │     │ +MT 2   │
+          └─────────┘     └─────────┘
+   lo: 2001:db8:0:ffff::1   lo: 2001:db8:0:ffff::2
+              /128                  /128
+  ```
+
+  Both configs add `multi-topology { topology ipv6-unicast; }` under
+  `routing/isis/` so the LSPs carry TLV 229 (capability), TLV 222
+  (MT IS Reach), and TLV 237 (MT IPv6 Reach).
+
+  Scenario: Setup IS-IS L2 with MT 2 over a shared bridge and confirm the link is up
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with loopback and veth interface on the bridge "br0"
+    And I create namespace "z2" with loopback and veth interface on the bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 20 seconds
+    Then ping from "z1" to "2001:db8:1::2" should succeed
+    And ping from "z2" to "2001:db8:1::1" should succeed
+
+  Scenario: MT 2 SPF installs reciprocal IPv6 routes to peer loopbacks
+    Given the test topology exists
+    Then ping from "z1" to "2001:db8:0:ffff::2" should succeed
+    And ping from "z2" to "2001:db8:0:ffff::1" should succeed
+
+  Scenario: LSPs carry the multi-topology TLVs
+    Given the test topology exists
+    Then show command "show isis database detail" in namespace "z1" should contain "Multi-Topology"
+    And show command "show isis database detail" in namespace "z1" should contain "MT IPv6 Reachability (MT-ID 2)"
+    And show command "show isis database detail" in namespace "z2" should contain "Multi-Topology"
+    And show command "show isis database detail" in namespace "z2" should contain "MT IPv6 Reachability (MT-ID 2)"


### PR DESCRIPTION
## Summary

Mirrors the existing \`isis_ipv6\` BDD shape but both nodes carry \`multi-topology { topology ipv6-unicast; }\`. Exercises the full PR1–PR5 pipeline end-to-end on a real two-namespace topology: LSPs originated with TLV 229 / 222 / 237, peer LSPs received into \`mt_membership\` and \`mt2_reach_map_v6\`, MT 2 graph + SPF computed, IPv6 RIB installed via the MT 2 path.

## Scenarios

1. **Setup IS-IS L2 with MT 2 over a shared bridge** — basic L2 ping confirms the adjacency formed despite the new TLVs.
2. **MT 2 SPF installs reciprocal IPv6 routes to peer loopbacks** — loopback ping confirms the v6 RIB build off the MT 2 SPF reaches the peer.
3. **LSPs carry the multi-topology TLVs** — \`show isis database detail\` on each side shows "Multi-Topology" (TLV 229) and "MT IPv6 Reachability (MT-ID 2)" (TLV 237), so we know the adjacency isn't quietly falling back to legacy TLV 236.

## New step

\`show command "<cmd>" in namespace "<ns>" should contain "<needle>"\` — runs \`vtyctl show <cmd>\` inside the namespace and asserts the stdout substring. Intentionally generic so other features can reuse it for LSDB / route-table assertions.

## Out of scope

Strict-mode mismatch scenario (one side MT-enabled, other side legacy → bidirectional connectivity should fail per RFC 5120 §3.4). Deferred — would require a config-swap step that complicates the flow. Negative-path coverage stays a follow-up.

## Test plan

- [x] \`cargo build --tests\` (in \`bdd/\`) clean.
- [x] \`cargo fmt\` clean.
- [ ] Run locally: \`cd bdd && sudo cargo test -- --tags @isis_multi_topology\`. Requires zebra-rs in PATH; namespace ops need sudo. BDD is excluded from CI per existing convention.

Generated with [Claude Code](https://claude.com/claude-code)