### PR TITLE
fix(isis,rib): MT bit layout, MT TLV display, pseudonode SPF, IGP ifindex

### DIFF
--- a/crates/isis-packet/src/sub/neigh_disp.rs
+++ b/crates/isis-packet/src/sub/neigh_disp.rs
@@ -200,10 +200,25 @@ impl Display for IsisSubSrv6LanEndXSid {
 }
 
 impl Display for IsisTlvMtIsReach {
+    /// One "MT Reachability: <neighbor_id> (Metric: N) <topology>"
+    /// line per entry, mirroring TLV 222's operator-facing reference
+    /// shape. Inlined to avoid the doubled "Neighbor ID:" prefix
+    /// the entry's own Display would otherwise produce; sub-TLVs
+    /// (Adj-SID, SRv6 End.X, etc.) hang off below the main line.
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "  MT IS Reachability (MT-ID {}):", self.mt.id())?;
-        for entry in self.entries.iter() {
-            write!(f, "\n{}", entry)?;
+        let topology = super::prefix_disp::mt_topology_name(self.mt.id());
+        for (pos, entry) in self.entries.iter().enumerate() {
+            if pos != 0 {
+                writeln!(f)?;
+            }
+            write!(
+                f,
+                "  MT Reachability: {} (Metric: {}) {}",
+                entry.neighbor_id, entry.metric, topology,
+            )?;
+            for sub in &entry.subs {
+                write!(f, "\n{sub}")?;
+            }
         }
         Ok(())
     }

--- a/crates/isis-packet/src/sub/prefix.rs
+++ b/crates/isis-packet/src/sub/prefix.rs
@@ -389,13 +389,24 @@ impl From<IsisTlvIpv6Reach> for IsisTlv {
     }
 }
 
+// RFC 5120 §7.2 wire layout for an MT identifier:
+//   bit:  0 1 2 3  4 5 6 7 8 9 10 11 12 13 14 15
+//        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//        |R R R R| MT ID                  |
+//        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// As a big-endian u16, the 4 reserved bits sit in the MSB and the
+// 12-bit MT ID in the LSB. `bitfield(u16)` is LSB-first by default,
+// so the *first* declared field lands at the lowest bit positions —
+// declare `id` first to land at bits 0-11 and `resvd` second at bits
+// 12-15. The previous order produced .id()=0 for an MT 2 LSP because
+// MT ID was being read out of the reserved bits.
 #[bitfield(u16, debug = true)]
 #[derive(Serialize, Deserialize, PartialEq)]
 pub struct MultiTopologyId {
-    #[bits(4)]
-    pub resvd: u8,
     #[bits(12)]
     pub id: u16,
+    #[bits(4)]
+    pub resvd: u8,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/isis-packet/src/sub/prefix_disp.rs
+++ b/crates/isis-packet/src/sub/prefix_disp.rs
@@ -136,41 +136,84 @@ impl Display for IsisSub2SidStructure {
 
 impl Display for MultiTopologyId {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{}", self.id())
+        write!(f, "{}", mt_topology_name(self.id()))
+    }
+}
+
+/// Operator-facing name for a 12-bit MT identifier per RFC 5120 §1.4
+/// and IANA "IS-IS MT IDs". Falls back to a `MT-N` placeholder for
+/// unknown / private-use values so the show output stays useful even
+/// when peers advertise topologies we don't model locally.
+pub fn mt_topology_name(id: u16) -> String {
+    match id {
+        0 => "ipv4-unicast".to_string(),
+        1 => "in-band-management".to_string(),
+        2 => "ipv6-unicast".to_string(),
+        3 => "ipv4-multicast".to_string(),
+        4 => "ipv6-multicast".to_string(),
+        n => format!("MT-{n}"),
     }
 }
 
 impl Display for IsisTlvMultiTopology {
+    /// One "MT Router Info: <name>" line per topology. RFC 5120 §3.1
+    /// — the LSP advertises every MT the router participates in;
+    /// listing them on separate lines mirrors what other IS-IS
+    /// implementations print and matches the operator-facing
+    /// reference output.
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "  Multi-Topology:")?;
-        for entry in &self.entries {
-            write!(f, " {}", entry)?;
+        for (pos, entry) in self.entries.iter().enumerate() {
+            if pos != 0 {
+                writeln!(f)?;
+            }
+            write!(f, "  MT Router Info: {entry}")?;
         }
         Ok(())
     }
 }
 
 impl Display for IsisTlvMtIpReach {
+    /// One "MT IP Reachability: <prefix> (Metric: N) <topology>" line
+    /// per entry, with any sub-TLVs hanging off below. The prefix +
+    /// metric are inlined here rather than delegated to the entry's
+    /// own Display, which prepends "Extended IP Reachability:" and
+    /// would otherwise produce a doubled label.
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "  MT IP Reachability (MT-ID {}):", self.mt.id())?;
+        let topology = mt_topology_name(self.mt.id());
         for (pos, entry) in self.entries.iter().enumerate() {
             if pos != 0 {
                 writeln!(f)?;
             }
-            write!(f, "\n{}", entry)?;
+            write!(
+                f,
+                "  MT IP Reachability: {} (Metric: {}) {}",
+                entry.prefix, entry.metric, topology,
+            )?;
+            for sub in &entry.subs {
+                write!(f, "\n{sub}")?;
+            }
         }
         Ok(())
     }
 }
 
 impl Display for IsisTlvMtIpv6Reach {
+    /// One "MT IPv6 Reachability: <prefix> (Metric: N) <topology>"
+    /// line per entry. Same prefix/metric inlining as IsisTlvMtIpReach.
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "  MT IPv6 Reachability (MT-ID {}):", self.mt.id())?;
+        let topology = mt_topology_name(self.mt.id());
         for (pos, entry) in self.entries.iter().enumerate() {
             if pos != 0 {
                 writeln!(f)?;
             }
-            write!(f, "\n{}", entry)?;
+            write!(
+                f,
+                "  MT IPv6 Reachability: {} (Metric: {}) {}",
+                entry.prefix, entry.metric, topology,
+            )?;
+            for sub in &entry.subs {
+                write!(f, "\n{sub}")?;
+            }
         }
         Ok(())
     }

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1742,21 +1742,56 @@ fn process_neighbor_link_mt2(
     top: &mut IsisTop,
     level: Level,
     from_id: usize,
-    _from_sys_id: &IsisSysId,
+    from_sys_id: &IsisSysId,
     entry: &IsisTlvExtIsReachEntry,
     links: &mut Vec<spf::Link>,
 ) {
     let neighbor_lsp_id: IsisLspId = entry.neighbor_id.into();
 
-    if top.lsdb.get(&level).get(&neighbor_lsp_id).is_none() {
+    let Some(neighbor_lsa) = top.lsdb.get(&level).get(&neighbor_lsp_id) else {
         return;
-    }
+    };
+
     if neighbor_lsp_id.is_pseudo() {
-        // Pseudonode handling for MT 2 would walk MtIsReach entries
-        // on the pseudo-LSP. Deferred — most deployments use P2P
-        // links for MT 2 and pseudonodes mainly hit on LAN segments.
+        // LAN segment. The pseudonode LSP is originated by the DIS
+        // and lists every router attached to the LAN in TLV 22 with
+        // metric 0; pseudonode origination doesn't currently emit
+        // TLV 222, so we walk TLV 22 here and gate each LAN-attached
+        // router on its own MT 2 capability via mt_membership.
+        // Result: from_id reaches every MT-2-capable router on the
+        // LAN at cost = (entry.metric + neighbor_entry.metric).
+        let neighbor_lsp = neighbor_lsa.lsp.clone();
+        for tlv in &neighbor_lsp.tlvs {
+            let IsisTlv::ExtIsReach(ext_reach) = tlv else {
+                continue;
+            };
+            for neighbor_entry in &ext_reach.entries {
+                let to_sys_id = neighbor_entry.neighbor_id.sys_id();
+                if to_sys_id == *from_sys_id {
+                    // Skip back-edge to ourselves.
+                    continue;
+                }
+                let mt2_capable = top
+                    .mt_membership
+                    .get(&level)
+                    .get(&to_sys_id)
+                    .map(|set| set.contains(&MtId::Ipv6Unicast))
+                    .unwrap_or(false);
+                if !mt2_capable {
+                    continue;
+                }
+                let to_id = top.lsp_map.get_mut(&level).get(&to_sys_id);
+                links.push(spf::Link {
+                    from: from_id,
+                    to: to_id,
+                    cost: entry.metric + neighbor_entry.metric,
+                });
+            }
+        }
         return;
     }
+
+    // P2P / direct neighbor.
     let to_sys_id = neighbor_lsp_id.sys_id();
     let mt2_capable = top
         .mt_membership

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -1069,14 +1069,30 @@ fn show_isis_spf(
 ) -> std::result::Result<String, std::fmt::Error> {
     let mut buf = String::new();
 
+    // Legacy single-topology SPF — drives IPv4 RIB always, plus
+    // IPv6 RIB when MT 2 is off. Print L1 then L2.
     if let Some(spf) = isis.spf_result.get(&Level::L1) {
-        let _ = writeln!(buf, "L1 SPF");
+        let _ = writeln!(buf, "L1 SPF (single-topology / MT 0)");
         spf::disp_out(&mut buf, spf, false);
     }
     if let Some(spf) = isis.spf_result.get(&Level::L2) {
-        let _ = writeln!(buf, "L2 SPF");
+        let _ = writeln!(buf, "L2 SPF (single-topology / MT 0)");
         spf::disp_out(&mut buf, spf, false);
     }
+
+    // MT 2 SPF — only computed when local config has MT 2 in
+    // mt_topologies. We print the raw tree from mt2_spf_result here
+    // regardless of whether the legacy SPF is also present so
+    // operators can compare metrics across topologies.
+    if let Some(spf) = isis.mt2_spf_result.get(&Level::L1) {
+        let _ = writeln!(buf, "L1 SPF (MT 2 / IPv6 unicast)");
+        spf::disp_out(&mut buf, spf, false);
+    }
+    if let Some(spf) = isis.mt2_spf_result.get(&Level::L2) {
+        let _ = writeln!(buf, "L2 SPF (MT 2 / IPv6 unicast)");
+        spf::disp_out(&mut buf, spf, false);
+    }
+
     Ok(buf)
 }
 

--- a/zebra-rs/src/rib/nexthop/group.rs
+++ b/zebra-rs/src/rib/nexthop/group.rs
@@ -66,19 +66,25 @@ pub struct GroupUni {
 
 impl GroupUni {
     pub fn new(gid: usize, uni: &NexthopUni) -> Self {
-        // For seg6local nexthops the ifindex is pre-determined by the
-        // caller (loopback for End, the link's ifindex for End.X) and
-        // there's no IGP path to resolve through; for plain unicast we
-        // start at 0 and let `resolve`/`resolve_v6` fill it in.
-        let ifindex = if uni.seg6local_action.is_some() {
-            uni.ifindex
-        } else {
-            0
-        };
+        // Trust `uni.ifindex` when the caller has set it. Three
+        // populators do today:
+        //   - IGP protocols (IS-IS, OSPF) emit nexthops with the
+        //     adjacency's egress link already filled in, since they
+        //     learn the link from the adjacency state machine, not
+        //     from a recursive RIB lookup.
+        //   - seg6local installs (End / End.X) pre-resolve to
+        //     loopback / per-adjacency.
+        //   - Connected/static routes obviously know their oif.
+        // Only ifindex == 0 means "I don't know — please resolve".
+        // Previously this branch was gated on seg6local_action, which
+        // discarded IS-IS / OSPF egress info and forced a v6 table
+        // resolve that picked the wrong link for fe80::/64 (link-
+        // local routes exist on every interface, so longest-prefix
+        // returns whichever connected route lands first).
         Self {
             common: GroupCommon::new(gid),
             addr: uni.addr,
-            ifindex,
+            ifindex: uni.ifindex,
             labels: uni.mpls_label.clone(),
             segs: uni.segs.clone(),
             encap_type: uni.encap_type,
@@ -87,6 +93,15 @@ impl GroupUni {
     }
 
     pub fn resolve(&mut self, table: &PrefixMap<Ipv4Net, RibEntries>) {
+        // Caller already supplied an egress link (IGP / seg6local /
+        // connected). Trust it — the recursive RIB walk would just
+        // re-derive the same answer, and for IGP nexthops it can
+        // outright pick the wrong link when the address is reachable
+        // through multiple covering routes.
+        if self.ifindex != 0 {
+            self.set_valid(true);
+            return;
+        }
         match self.addr {
             IpAddr::V4(ipv4_addr) => {
                 let resolve = rib_resolve(table, ipv4_addr, &ResolveOpt::default());
@@ -106,6 +121,20 @@ impl GroupUni {
     }
 
     pub fn resolve_v6(&mut self, table: &PrefixMap<Ipv6Net, RibEntries>) {
+        // Same short-circuit as `resolve`: caller-supplied ifindex
+        // wins over recursive table resolution. Critical for IPv6
+        // because link-local nexthops can't be disambiguated by
+        // table lookup — every interface advertises fe80::/64.
+        if self.ifindex != 0 {
+            if DEBUG_V6 {
+                println!(
+                    "[GroupUni::resolve_v6] addr={} ifindex={} pre-resolved (skipping table walk)",
+                    self.addr, self.ifindex,
+                );
+            }
+            self.set_valid(true);
+            return;
+        }
         if let IpAddr::V6(ipv6_addr) = self.addr {
             let resolve = rib_resolve_v6(table, ipv6_addr, &ResolveOpt::default());
             match &resolve {
@@ -335,6 +364,51 @@ mod tests {
         group.resolve_v6(&table);
         assert_eq!(group.ifindex, 0);
         assert!(!group.is_valid());
+    }
+
+    #[test]
+    fn group_uni_new_preserves_caller_ifindex_for_plain_unicast() {
+        // IGP protocols (IS-IS, OSPF) populate uni.ifindex from the
+        // adjacency state machine. GroupUni::new used to throw that
+        // away for non-seg6local nexthops, forcing a table-based
+        // re-resolve that picks the wrong link for fe80::/64. Pin
+        // the new behaviour: trust the caller.
+        let uni = NexthopUni {
+            addr: IpAddr::V6("fe80::1".parse().unwrap()),
+            ifindex: 42,
+            ..Default::default()
+        };
+        let group = GroupUni::new(0, &uni);
+        assert_eq!(group.ifindex, 42);
+    }
+
+    #[test]
+    fn resolve_v6_skips_table_walk_when_ifindex_pre_resolved() {
+        // Pre-set ifindex (from an IS-IS adjacency, say) must win
+        // over recursive table resolution. Otherwise multi-link
+        // fe80::/64 routes silently route the IGP nexthop out the
+        // wrong interface.
+        let mut table = PrefixMap::<Ipv6Net, RibEntries>::new();
+        // Two connected fe80::/64 routes — the table walk would pick
+        // ifindex 7 (whichever lands first in PrefixMap iteration).
+        table.insert(
+            Ipv6Net::from_str("fe80::/64").unwrap(),
+            vec![connected_v6(7), connected_v6(99)],
+        );
+
+        let uni = NexthopUni {
+            addr: IpAddr::V6("fe80::21c:42ff:fee8:c23".parse().unwrap()),
+            ifindex: 99, // adjacency knows it's on link 99
+            ..Default::default()
+        };
+        let mut group = GroupUni::new(0, &uni);
+        assert_eq!(group.ifindex, 99);
+
+        group.resolve_v6(&table);
+
+        // Table walk did NOT overwrite our 99.
+        assert_eq!(group.ifindex, 99);
+        assert!(group.is_valid());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Four bug fixes uncovered while validating multi-topology end-to-end on a real lab.

### 1. \`MultiTopologyId\` bit layout (\`cc1e99c\`)

Critical interop bug. \`bitfield-struct\` is LSB-first by default, but the struct declared \`resvd\` (4 bits) before \`id\` (12 bits) — putting \`resvd\` at bits 0-3 and the MT ID at bits 12-15. RFC 5120 §7.2 wants the opposite: reserved bits in the MSB nibble, MT ID in the low 12 bits.

Wire bytes for an MT 2 LSP arrived as \`0x00 0x02\` and were decoded into a \`MultiTopologyId\` whose \`.id()\` returned 0. Effects:

- Display showed \`(MT-ID 0)\` for every MT 2 LSP.
- \`mt_id_from_wire(entry.id())\` mapped peer's MT 2 to \`MtId::Standard\`.
- \`graph_mt2\`'s \`mt_reach.mt.id() == 2\` filter never matched.
- MT 2 SPF saw no peers; IPv6 RIB ran empty in MT 2 mode.

Swapped field order so \`id\` is declared first and lands in LSB.

### 2. MT TLV display refresh (\`cc1e99c\`)

Reworked \`IsisTlvMultiTopology\`, \`IsisTlvMtIsReach\`, \`IsisTlvMtIpReach\`, and \`IsisTlvMtIpv6Reach\` displays to the operator-facing reference shape:

\`\`\`
MT Router Info: ipv6-unicast
MT Reachability: 0000.0000.0008.00 (Metric: 50) ipv6-unicast
MT IPv6 Reachability: fcbb:bbbb:2::/48 (Metric: 0) ipv6-unicast
\`\`\`

\`mt_topology_name(id)\` resolves 0/1/2/3/4 to canonical names with a \`MT-N\` fallback.

### 3. Pseudonode walking in \`graph_mt2\` (\`f594cd4\`)

The previous \`graph_mt2\` returned early when it hit a pseudonode neighbor, leaving any LAN-attached peer unreachable in MT 2 SPF. Mirror what the legacy graph builder already does: walk the pseudonode's TLV 22 entries (pseudonodes don't emit TLV 222 today) and gate each LAN-attached router on its own \`mt_membership\` MT 2 capability. Costs sum \`entry.metric + neighbor_entry.metric\`.

### 4. \`show isis spf\` includes MT 2 SPF (\`7bdfc90\`)

When MT 2 is locally enabled, \`show isis spf\` now prints both legacy and MT 2 SPF trees per level so operators can compare metric profiles.

### 5. RIB trusts IGP-supplied ifindex (\`56d6f70\`)

User reported \`show ipv6 route\` listing IS-IS routes as \`via fe80::21c:42ff:fee8:c23, enp0s5\` even though the only IS-IS adjacency was on \`enp0s6\`. Root cause:

- \`GroupUni::new\` only preserved \`uni.ifindex\` for seg6local nexthops; for plain unicast it set \`ifindex = 0\` and forced a table-based resolve.
- \`resolve_v6\` did longest-prefix on the link-local address. With multiple \`fe80::/64\` connected routes (one per interface), it picked whichever the \`PrefixMap\` visited first.

IGP protocols (IS-IS, OSPF) already populate \`nhop.ifindex\` from the adjacency state machine. Now:

- \`GroupUni::new\` copies \`uni.ifindex\` unconditionally — generalises the seg6local-only branch.
- \`resolve\` / \`resolve_v6\` short-circuit when \`self.ifindex != 0\`: mark valid, skip the table walk.

Connected routes / BGP-with-IPv4-nexthop / other \`ifindex == 0\` callers still resolve through the table.

## Test plan

- [x] \`cargo build --bin zebra-rs\` clean.
- [x] \`cargo clippy --bin zebra-rs\` clean.
- [x] \`cargo test --bin zebra-rs --lib\` 142 passing (140 + 2 new GroupUni tests).
- [ ] User-reported MT lab: \`show isis topology\` MT 2 SPF tree now reaches peers across LAN segments; \`show ipv6 route\` shows IS-IS routes via the correct adjacency interface.

## Out of scope

- \`NexthopMap::fetch_uni\` cache key remains keyed on \`uni.addr\` only. Two routes via the same link-local through different interfaces would collide on one \`GroupUni\`. Doesn't bite the user's case (single adjacency, one egress link); follow-up if BGP next-hops via link-local become a thing.
- \`show isis spf <topology-id>\` filter — needs YANG schema work for the optional arg. Operators can grep for now.
- Pseudonode LSP origination doesn't yet emit TLV 222 for MT 2; \`graph_mt2\` walks TLV 22 on pseudonodes as a pragmatic fallback.

Generated with [Claude Code](https://claude.com/claude-code)