### PR TITLE
fix(isis): resolve hostname from OS, skip TLV when unknown

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -11,10 +11,12 @@ use strum_macros::{Display, EnumString};
 use crate::config::{Args, ConfigOp};
 
 use super::Isis;
-use super::inst::Callback;
+use super::inst::{Callback, Message};
 use super::link::Afis;
 use super::tracing::{PacketConfig, PacketDirection};
 use super::{Level, link};
+
+use isis_packet::IsisLspId;
 
 /// IS-IS Multi-Topology identifier (RFC 5120). The wire encoding is a
 /// 12-bit MT ID; we model only the topologies we actually compute SPF
@@ -166,8 +168,18 @@ impl IsisConfig {
         self.is_type.unwrap_or(IsLevel::L1L2)
     }
 
-    pub fn hostname(&self) -> String {
-        self.hostname.clone().unwrap_or("default".into())
+    /// Resolve the hostname to advertise in TLV 137. Configured hostname
+    /// wins; otherwise we fall back to the OS hostname. If neither is
+    /// available we return None and the caller should skip emitting the
+    /// hostname TLV (RFC 5301 leaves the TLV optional).
+    pub fn hostname(&self) -> Option<String> {
+        if let Some(name) = &self.hostname {
+            return Some(name.clone());
+        }
+        hostname::get()
+            .ok()
+            .and_then(|s| s.into_string().ok())
+            .filter(|s| !s.is_empty())
     }
 
     pub fn refresh_time(&self) -> u16 {
@@ -220,12 +232,28 @@ fn config_is_type(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
 fn config_hostname(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     let hostname = args.string()?;
 
+    let prev = isis.config.hostname();
     if op == ConfigOp::Set {
         isis.config.hostname = Some(hostname);
     } else {
         isis.config.hostname = None;
     }
-    // TODO: Re-originate LSP for L1/L2.  That will update hostname map.
+    let curr = isis.config.hostname();
+
+    if prev == curr {
+        return Some(());
+    }
+
+    // Re-originate self LSP at any level that has one so the new
+    // hostname (or its absence) propagates without waiting for the
+    // refresh timer. Levels with no self LSP yet are still pre-NET —
+    // origination will pick the new value naturally on first emission.
+    let key = IsisLspId::new(isis.config.net.sys_id(), 0, 0);
+    for level in [Level::L1, Level::L2] {
+        if isis.lsdb.get(&level).get(&key).is_some() {
+            let _ = isis.tx.send(Message::LspOriginate(level));
+        }
+    }
 
     Some(())
 }

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -882,12 +882,20 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
         lsp.tlvs.push(IsisTlvProtoSupported { nlpids }.into());
     }
 
-    // Hostname.
-    let hostname = top.config.hostname();
-    top.hostname
-        .get_mut(&level)
-        .insert_originate(top.config.net.sys_id(), hostname.clone());
-    lsp.tlvs.push(IsisTlvHostname { hostname }.into());
+    // Hostname (RFC 5301). Configured value wins, then the OS hostname.
+    // If neither is available, skip the TLV entirely and clear any
+    // stale entry from the local hostname map so show output falls
+    // back to the system ID instead of advertising "default".
+    if let Some(hostname) = top.config.hostname() {
+        top.hostname
+            .get_mut(&level)
+            .insert_originate(top.config.net.sys_id(), hostname.clone());
+        lsp.tlvs.push(IsisTlvHostname { hostname }.into());
+    } else {
+        top.hostname
+            .get_mut(&level)
+            .remove(&top.config.net.sys_id());
+    }
 
     // SR Capability.
     if top.config.sr_enabled() {


### PR DESCRIPTION
## Summary

- `IsisConfig::hostname()` now returns `Option<String>`: configured → OS hostname → `None`. The old fallback to the literal `"default"` was the source of bogus `default.NN-00` rows in `show isis database` for peers that hadn't set a hostname.
- `lsp_generate` skips `IsisTlvHostname` when no name is available and clears any stale entry from the local hostname map so show output falls back to the system ID.
- `config_hostname` re-originates the self LSP (per level, only when one exists) on change so updates propagate without waiting for the refresh timer.

## Test plan

- [x] `cargo build --bin zebra-rs`
- [x] `cargo clippy --bin zebra-rs`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --lib --workspace --exclude bdd`
- [ ] Manual: `show isis database` shows hex sys-id (not `default.NN-00`) for peers with no hostname; configured hostname appears immediately after a config change.

Generated with [Claude Code](https://claude.com/claude-code)