### PR TITLE
feat(bgp): advertise local hostname via FQDN capability

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -36,6 +36,16 @@ fn config_global_identifier(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
     Some(())
 }
 
+fn config_global_hostname(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let hostname = args.string()?;
+    if op == ConfigOp::Set {
+        bgp.config_set_hostname(Some(hostname));
+    } else {
+        bgp.config_set_hostname(None);
+    }
+    Some(())
+}
+
 fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     if op == ConfigOp::Set {
@@ -45,6 +55,7 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
             bgp.router_id,
             0u32,
             addr,
+            bgp.hostname(),
             bgp.tx.clone(),
         );
         bgp.peers.insert(addr, peer);
@@ -820,6 +831,7 @@ impl Bgp {
     pub fn callback_build(&mut self) {
         self.callback_add("/routing/bgp/global/as", config_global_asn);
         self.callback_add("/routing/bgp/global/identifier", config_global_identifier);
+        self.callback_add("/routing/bgp/global/hostname", config_global_hostname);
         self.callback_peer("", config_peer);
         self.callback_peer("/peer-as", config_peer_as);
         self.callback_peer("/local-identifier", config_local_identifier);

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -56,6 +56,11 @@ pub type ShowCallback = fn(&Bgp, Args, bool) -> std::result::Result<String, std:
 pub struct Bgp {
     pub asn: u32,
     pub router_id: Ipv4Addr,
+    /// Configured hostname for the local BGP speaker. Advertised in
+    /// the FQDN capability (capability code 73). When None, falls back
+    /// to the OS hostname; if that also fails, no FQDN capability is
+    /// emitted. See `Bgp::hostname()` for the resolution order.
+    pub hostname: Option<String>,
     pub peers: PeerMap,
     /// Bounded channel for BGP events (capacity: 8192)
     pub tx: mpsc::Sender<Message>,
@@ -117,6 +122,7 @@ impl Bgp {
         let mut bgp = Self {
             asn: 0,
             router_id: Ipv4Addr::UNSPECIFIED,
+            hostname: None,
             peers: PeerMap::new(),
             tx,
             rx,
@@ -147,6 +153,35 @@ impl Bgp {
 
     pub fn callback_add(&mut self, path: &str, cb: Callback) {
         self.callbacks.insert(path.to_string(), cb);
+    }
+
+    /// Resolve the hostname to advertise in the FQDN capability.
+    /// Configured value wins; otherwise we fall back to the OS
+    /// hostname. None means "skip the FQDN capability entirely".
+    pub fn hostname(&self) -> Option<String> {
+        if let Some(name) = &self.hostname {
+            return Some(name.clone());
+        }
+        hostname::get()
+            .ok()
+            .and_then(|s| s.into_string().ok())
+            .filter(|s| !s.is_empty())
+    }
+
+    /// Update the configured hostname and propagate the resolved
+    /// value to every peer's `local_hostname` snapshot. Existing
+    /// sessions keep using the value they captured at OPEN; the
+    /// next OPEN this peer sends (after a reset / re-establishment)
+    /// will pick up the new one.
+    pub fn config_set_hostname(&mut self, value: Option<String>) {
+        if self.hostname == value {
+            return;
+        }
+        self.hostname = value;
+        let resolved = self.hostname();
+        for (_, peer) in self.peers.iter_mut() {
+            peer.local_hostname = resolved.clone();
+        }
     }
 
     pub fn pcallback_add(&mut self, path: &str, cb: PCallback) {

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -281,6 +281,11 @@ pub struct Peer {
     pub remote_id: Ipv4Addr,
     pub local_as: u32,
     pub peer_as: u32,
+    /// Local BGP speaker's hostname snapshot used to populate the FQDN
+    /// capability in OPEN. Set at peer creation from `Bgp::hostname()`
+    /// and refreshed by the global hostname callback so that re-opened
+    /// sessions advertise the latest value.
+    pub local_hostname: Option<String>,
     pub active: bool,
     pub peer_type: PeerType,
     pub state: State,
@@ -329,6 +334,7 @@ impl Peer {
         router_id: Ipv4Addr,
         peer_as: u32,
         address: IpAddr,
+        local_hostname: Option<String>,
         tx: mpsc::Sender<Message>,
     ) -> Self {
         let mut peer = Self {
@@ -336,6 +342,7 @@ impl Peer {
             router_id,
             local_as,
             peer_as,
+            local_hostname,
             address,
             active: false,
             peer_type: PeerType::IBGP,
@@ -877,6 +884,11 @@ pub fn peer_send_open(peer: &mut Peer) {
     }
     if peer.config.extended_message {
         bgp_cap.extended = Some(CapExtended::default());
+    }
+    if let Some(name) = &peer.local_hostname {
+        // FQDN capability (draft-walton, code 73). Domain name is left
+        // empty for now — operators have only asked for hostname.
+        bgp_cap.fqdn = Some(CapFqdn::new(name, ""));
     }
     for (key, addpath) in peer.config.addpath.iter() {
         bgp_cap.addpath.insert(*key, addpath.clone());

--- a/zebra-rs/src/bgp/peer_map.rs
+++ b/zebra-rs/src/bgp/peer_map.rs
@@ -62,6 +62,19 @@ impl PeerMap {
             .filter_map(move |(addr, &idx)| self.peers[idx].as_ref().map(|peer| (addr, peer)))
     }
 
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&IpAddr, &mut Peer)> {
+        let map = &self.map;
+        self.peers
+            .iter_mut()
+            .enumerate()
+            .filter_map(move |(idx, slot)| {
+                let peer = slot.as_mut()?;
+                map.iter()
+                    .find(|(_, mapped_idx)| **mapped_idx == idx)
+                    .map(|(addr, _)| (addr, peer))
+            })
+    }
+
     pub fn keys(&self) -> impl Iterator<Item = &IpAddr> {
         self.map.iter().filter_map(move |(addr, &idx)| {
             if self.peers[idx].is_some() {

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1904,7 +1904,7 @@ mod summary_tests {
         let mut buf = String::new();
         write_summary_header_row(&mut buf).unwrap();
         let expected = "\
-Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc\n";
+Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Hostname\n";
         assert_eq!(buf, expected);
     }
 

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -70,7 +70,7 @@ fn peer_has_negotiated(peer: &Peer, afi: Afi, safi: Safi) -> bool {
 fn write_summary_header_row(buf: &mut String) -> std::fmt::Result {
     writeln!(
         buf,
-        "{:16}{:>1}{:>11}{:>10}{:>10}{:>9}{:>5}{:>5}{:>9}{:>13}{:>9} Desc",
+        "{:16}{:>1}{:>11}{:>10}{:>10}{:>9}{:>5}{:>5}{:>9}{:>13}{:>9} Hostname",
         "Neighbor",
         "V",
         "AS",
@@ -108,9 +108,16 @@ fn write_summary_peer_row(buf: &mut String, peer: &Peer, afi: Afi, safi: Safi) -
         (pr.to_string(), ps.to_string())
     };
 
+    let hostname = peer
+        .cap_recv
+        .fqdn
+        .as_ref()
+        .map(|f| f.hostname().to_string())
+        .unwrap_or_else(|| "N/A".to_string());
+
     writeln!(
         buf,
-        "{:16}{:>1}{:>11}{:>10}{:>10}{:>9}{:>5}{:>5}{:>9}{:>13}{:>9} N/A",
+        "{:16}{:>1}{:>11}{:>10}{:>10}{:>9}{:>5}{:>5}{:>9}{:>13}{:>9} {}",
         peer.address.to_string(),
         "4",
         peer.peer_as,
@@ -122,6 +129,7 @@ fn write_summary_peer_row(buf: &mut String, peer: &Peer, afi: Afi, safi: Safi) -
         up_down,
         pfx_rcvd_str,
         pfx_sent_str,
+        hostname,
     )
 }
 

--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -310,6 +310,15 @@ module ietf-bgp {
           reference
             "RFC 6286: AS-Wide Unique BGP ID for BGP-4. Section 2.1";
         }
+        leaf hostname {
+          type string;
+          description
+            "Hostname of the local BGP speaker. Advertised to peers
+             via the FQDN capability (draft-walton-bgp-hostname-
+             capability-02, capability code 73). When unset, the OS
+             hostname is used; when neither is available the
+             capability is not sent.";
+        }
         container distance {
           description
             "Administrative distances (or preferences) assigned to


### PR DESCRIPTION
## Summary

- Add \`hostname NAME\` under \`/routing/bgp/global/\`. Configured value wins, then the OS hostname; otherwise the FQDN capability (draft-walton, code 73) is omitted from OPEN.
- Domain name is intentionally left empty for now — operator will revisit later.
- \`Bgp::config_set_hostname\` snapshots the resolved value into every peer's \`local_hostname\` so re-established sessions advertise the latest. Existing OPENed sessions keep their captured value (re-emission would require a session reset, out of scope here).
- \`show ip bgp summary\` replaces the trailing \`N/A\` placeholder with the peer's advertised hostname (column header renamed to \`Hostname\`).

## Test plan

- [x] \`cargo build --bin zebra-rs\`
- [x] \`cargo clippy --bin zebra-rs\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test --lib --workspace --exclude bdd\`
- [ ] Manual: configure \`hostname foo\`, verify peer's \`show ip bgp summary\` shows \`foo\` at the end of the row; without config it shows the OS hostname.

Generated with [Claude Code](https://claude.com/claude-code)