### PR TITLE
feat(srv6): install End/uN on sr0 dummy in table main

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -51,7 +51,7 @@ const DEBUG_V6: bool = false;
 // nexthop-skip notice, and the rib-side resolution trace. Errors from
 // the kernel are reported regardless. Mirrored by RIB via this same
 // constant (re-exported as `crate::fib::netlink::handle::DEBUG_SID`).
-pub const DEBUG_SID: bool = false;
+pub const DEBUG_SID: bool = true;
 
 /// Mask the lower (128 - prefix_len) bits of an IPv6 address. The
 /// kernel ignores bits past the prefix length on install, but masking
@@ -74,18 +74,12 @@ fn mask_v6(addr: std::net::Ipv6Addr, prefix_len: u8) -> std::net::Ipv6Addr {
 ///   End  : table main, kind=Unicast, /128, sid.addr
 ///          (`ip -6 route add <SID>/128
 ///           encap seg6local action End dev sr0`)
-///          End used to hang off table=local + kind=Local + dev=lo —
-///          a workaround for the kernel rejecting unicast routes that
-///          point at lo. Routing the seg6local action through a dummy
-///          (sr0) instead gets us back into table=main with kind=Unicast,
-///          which keeps `ip -6 route show` honest and avoids the
-///          host-local route quirks (e.g. ip-rule lookup local).
 ///   End.X: table main, kind=Unicast, /128, sid.addr
-///   uN   : table local, kind=Local,  /(LB+LN), masked sid.addr
+///   uN   : table main, kind=Unicast, /(LB+LN), masked sid.addr
 ///          (prefix install — the NEXT-C-SID flavor strips and shifts
 ///          at runtime, so any function under the locator hits this.
-///          uN keeps the lo + table=local + kind=Local combo for now;
-///          extending the sr0 fix to uSID is a separate change.)
+///          Same dummy-device trick as End: pointing the install at sr0
+///          instead of lo lets us stay in table=main + kind=Unicast.)
 ///   uA   : table main, kind=Unicast, /128, sid.addr
 ///          (per-adjacency function is unique; longest-prefix match
 ///          picks uA over the wider uN entry)
@@ -93,6 +87,13 @@ fn mask_v6(addr: std::net::Ipv6Addr, prefix_len: u8) -> std::net::Ipv6Addr {
 /// uN with no SidStructure falls back to /128 — a degenerate state
 /// (uSID locator without a derived structure shouldn't happen), but
 /// keeps the call total.
+///
+/// Both End and uN previously hung off table=local + kind=Local + dev=lo
+/// to work around the kernel rejecting unicast routes that point at the
+/// loopback. Routing the seg6local action through a dummy (sr0) instead
+/// gets us back into table=main with kind=Unicast across the board, which
+/// keeps `ip -6 route show` honest and avoids the host-local route quirks
+/// (e.g. ip-rule lookup local).
 fn sid_route_target(
     behavior: crate::rib::SidBehavior,
     addr: std::net::Ipv6Addr,
@@ -106,7 +107,12 @@ fn sid_route_target(
             let plen = structure
                 .map(|s| s.lb_bits.saturating_add(s.ln_bits))
                 .unwrap_or(128);
-            (255, RouteType::Local, plen, mask_v6(addr, plen))
+            (
+                RouteHeader::RT_TABLE_MAIN,
+                RouteType::Unicast,
+                plen,
+                mask_v6(addr, plen),
+            )
         }
         SidBehavior::UA => (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr),
     }
@@ -881,20 +887,20 @@ impl FibHandle {
         // four header values, so route_sid_uninstall mirrors the same
         // computation.
         //
-        //   End  : table main,  kind=unicast, /128, sid.addr
+        //   End  : table main, kind=unicast, /128, sid.addr
         //          (`ip -6 route add <SID>/128
         //           encap seg6local action End dev sr0`)
-        //   End.X: table main,  kind=unicast, /128, sid.addr
+        //   End.X: table main, kind=unicast, /128, sid.addr
         //          (`ip -6 route add <SID>/128
         //           encap seg6local action End.X nh6 ... dev ...`)
-        //   uN   : table local, kind=Local,   /(LB+LN), masked addr
-        //          (`ip -6 route add <locator>/<LB+LN> table local
+        //   uN   : table main, kind=unicast, /(LB+LN), masked addr
+        //          (`ip -6 route add <locator>/<LB+LN>
         //           encap seg6local action End flavors next-csid
-        //           lblen <LB> nflen <LN+Fun> dev lo`)
+        //           lblen <LB> nflen <LN+Fun> dev sr0`)
         //          uN is a *prefix* install so any function value
         //          under the locator hits this entry; the kernel's
         //          NEXT-C-SID flavor strips and shifts at runtime.
-        //   uA   : table main,  kind=unicast, /128, sid.addr
+        //   uA   : table main, kind=unicast, /128, sid.addr
         //          Each adjacency function is a unique address;
         //          longest-prefix match picks uA over the wider uN
         //          entry. /128 keeps it simple and matches iproute2.

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -25,6 +25,7 @@ use netlink_packet_route::route::{
 use netlink_packet_route::{AddressFamily, RouteNetlinkMessage};
 use netlink_sys::{AsyncSocket, SocketAddr};
 use rtnetlink::{
+    LinkDummy,
     constants::{
         RTMGRP_IPV4_IFADDR, RTMGRP_IPV4_ROUTE, RTMGRP_IPV6_IFADDR, RTMGRP_IPV6_ROUTE, RTMGRP_LINK,
     },
@@ -70,17 +71,22 @@ fn mask_v6(addr: std::net::Ipv6Addr, prefix_len: u8) -> std::net::Ipv6Addr {
 /// a SID install / uninstall. Behavior-driven so install and uninstall
 /// stay in lock-step:
 ///
-///   End  : table local, kind=Local,   /128, sid.addr
-///   End.X: table main,  kind=Unicast, /128, sid.addr
-///   uN   : table local, kind=Local,   /(LB+LN), masked sid.addr
+///   End  : table main, kind=Unicast, /128, sid.addr
+///          (`ip -6 route add <SID>/128
+///           encap seg6local action End dev sr0`)
+///          End used to hang off table=local + kind=Local + dev=lo —
+///          a workaround for the kernel rejecting unicast routes that
+///          point at lo. Routing the seg6local action through a dummy
+///          (sr0) instead gets us back into table=main with kind=Unicast,
+///          which keeps `ip -6 route show` honest and avoids the
+///          host-local route quirks (e.g. ip-rule lookup local).
+///   End.X: table main, kind=Unicast, /128, sid.addr
+///   uN   : table local, kind=Local,  /(LB+LN), masked sid.addr
 ///          (prefix install — the NEXT-C-SID flavor strips and shifts
 ///          at runtime, so any function under the locator hits this.
-///          uN reuses End's table/kind because the kernel was silently
-///          dropping installs in table=main with kind=Unicast pointing
-///          at lo; "local prefix routes" are how the kernel normally
-///          treats host-local seg6local actions, and the kind=Local
-///          path is what classic End / End.UN actions hang off.)
-///   uA   : table main,  kind=Unicast, /128, sid.addr
+///          uN keeps the lo + table=local + kind=Local combo for now;
+///          extending the sr0 fix to uSID is a separate change.)
+///   uA   : table main, kind=Unicast, /128, sid.addr
 ///          (per-adjacency function is unique; longest-prefix match
 ///          picks uA over the wider uN entry)
 ///
@@ -94,7 +100,7 @@ fn sid_route_target(
 ) -> (u8, RouteType, u8, std::net::Ipv6Addr) {
     use crate::rib::SidBehavior;
     match behavior {
-        SidBehavior::End => (255, RouteType::Local, 128, addr),
+        SidBehavior::End => (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr),
         SidBehavior::EndX => (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr),
         SidBehavior::UN => {
             let plen = structure
@@ -875,14 +881,14 @@ impl FibHandle {
         // four header values, so route_sid_uninstall mirrors the same
         // computation.
         //
-        //   End  : table local, kind=local, /128, sid.addr
-        //          (`ip -6 route add <SID>/128 table local
-        //           encap seg6local action End dev lo`)
+        //   End  : table main,  kind=unicast, /128, sid.addr
+        //          (`ip -6 route add <SID>/128
+        //           encap seg6local action End dev sr0`)
         //   End.X: table main,  kind=unicast, /128, sid.addr
         //          (`ip -6 route add <SID>/128
         //           encap seg6local action End.X nh6 ... dev ...`)
-        //   uN   : table main,  kind=unicast, /(LB+LN), masked addr
-        //          (`ip -6 route add <locator>/<LB+LN>
+        //   uN   : table local, kind=Local,   /(LB+LN), masked addr
+        //          (`ip -6 route add <locator>/<LB+LN> table local
         //           encap seg6local action End flavors next-csid
         //           lblen <LB> nflen <LN+Fun> dev lo`)
         //          uN is a *prefix* install so any function value
@@ -1199,6 +1205,53 @@ impl FibHandle {
             if let NetlinkPayload::Error(e) = msg.payload {
                 tracing::info!("link_set_up error: {}", e);
             }
+        }
+    }
+
+    /// Look up a link's ifindex by name via RTM_GETLINK. Returns None on
+    /// kernel rejection (most often "device not found").
+    pub async fn link_index_by_name(&self, name: &str) -> Option<u32> {
+        use futures::TryStreamExt;
+        let mut stream = self
+            .handle
+            .clone()
+            .link()
+            .get()
+            .match_name(name.to_string())
+            .execute();
+        match stream.try_next().await {
+            Ok(Some(msg)) => Some(msg.header.index),
+            _ => None,
+        }
+    }
+
+    /// Create a dummy link with the given name. Returns the ifindex the
+    /// kernel assigned, or None if creation failed (already exists with a
+    /// conflicting type, etc.). Mirrors `ip link add <name> type dummy`.
+    pub async fn dummy_add(&self, name: &str) -> Option<u32> {
+        let result = self
+            .handle
+            .clone()
+            .link()
+            .add(LinkDummy::new(name).build())
+            .execute()
+            .await;
+        if let Err(e) = result {
+            tracing::warn!("dummy_add({}) error: {}", name, e);
+            return None;
+        }
+        self.link_index_by_name(name).await
+    }
+
+    /// Delete a link by name. Idempotent — missing names log at info but
+    /// don't propagate.
+    pub async fn dummy_del(&self, name: &str) {
+        let Some(ifindex) = self.link_index_by_name(name).await else {
+            tracing::info!("dummy_del({}) skipped — not present", name);
+            return;
+        };
+        if let Err(e) = self.handle.clone().link().del(ifindex).execute().await {
+            tracing::warn!("dummy_del({}) error: {}", name, e);
         }
     }
 

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -51,7 +51,7 @@ const DEBUG_V6: bool = false;
 // nexthop-skip notice, and the rib-side resolution trace. Errors from
 // the kernel are reported regardless. Mirrored by RIB via this same
 // constant (re-exported as `crate::fib::netlink::handle::DEBUG_SID`).
-pub const DEBUG_SID: bool = true;
+pub const DEBUG_SID: bool = false;
 
 /// Mask the lower (128 - prefix_len) bits of an IPv6 address. The
 /// kernel ignores bits past the prefix length on install, but masking

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -275,9 +275,21 @@ fn config_hold_time(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()>
 fn config_sr_mpls_enable(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
     if op.is_set() {
         isis.config.sr_mpls_enabled = true;
+        // Allocate the adjacency-SID label pool so subsequent hellos
+        // can carve labels for `IsisSubLanAdjSid` sub-TLVs. Idempotent:
+        // re-enabling without a prior disable keeps any previously
+        // handed-out labels intact.
+        if isis.local_pool.is_none() {
+            isis.local_pool = Some(super::LabelPool::new(15000, Some(16000)));
+        }
     } else {
         isis.config.sr_mpls_enabled = false;
         isis.config.sr_mpls_block = None;
+        // Drop the pool. Any labels still cached on neighbor addr4
+        // entries become orphaned but stop short of producing fresh
+        // MPLS installs — `nbr_hello_interpret` and `lsp_generate`
+        // both gate on `local_pool`/`value.label` being present.
+        isis.local_pool = None;
     }
     isis.reconcile_block_watch();
     Some(())

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -199,7 +199,12 @@ impl Isis {
             ilm: Levels::<BTreeMap<u32, SpfIlm>>::default(),
             hostname: Levels::<Hostname>::default(),
             spf_timer: Levels::<Option<Timer>>::default(),
-            local_pool: Some(LabelPool::new(15000, Some(16000))),
+            // Adjacency-SID label pool is owned by the SR-MPLS feature.
+            // Stays None until `segment-routing mpls` is configured —
+            // otherwise we'd allocate labels for every hello and emit
+            // LanAdjSid sub-TLVs that turn into MPLS ILM installs the
+            // kernel rejects (EOPNOTSUPP) on hosts without an MPLS path.
+            local_pool: None,
             graph: Levels::<Option<spf::Graph>>::default(),
             spf_result: Levels::<Option<BTreeMap<usize, spf::Path>>>::default(),
             mt2_graph: Levels::<Option<spf::Graph>>::default(),

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -7,7 +7,8 @@ use super::link::{LinkConfig, link_config_exec};
 use super::{
     Block, BlockBuilder, BlockConfig, BridgeBuilder, BridgeConfig, DEFAULT_BLOCK_NAME, GroupTrait,
     Link, Locator, LocatorBuilder, LocatorConfig, MacAddr, MplsConfig, Nexthop, NexthopMap,
-    NexthopUni, RibSrRx, RibType, Sid, StaticConfig, V4, V6, Vxlan, VxlanBuilder, VxlanConfig,
+    NexthopUni, RibSrRx, RibType, Sid, SidBehavior, StaticConfig, V4, V6, Vxlan, VxlanBuilder,
+    VxlanConfig,
 };
 
 use crate::config::{Args, path_from_command};
@@ -252,7 +253,16 @@ pub struct Rib {
     /// convergence vs. churn trade-off; default 1s matches the typical
     /// "kick once shortly after the wave settles" pattern.
     pub rib_sync_interval: u64,
+
+    /// True when the sr0 dummy was created by this process and must
+    /// therefore be cleaned up on Shutdown. False when sr0 already
+    /// existed (operator-managed) — leave it alone on exit.
+    pub sr0_owned: bool,
 }
+
+/// Name of the dummy interface that hosts End-style seg6local routes
+/// (table=main + kind=Unicast). Created at startup if missing.
+pub const SR0_DUMMY_NAME: &str = "sr0";
 
 const DEFAULT_RIB_SYNC_INTERVAL_SEC: u64 = 1;
 
@@ -301,6 +311,7 @@ impl Rib {
             router_id: Ipv4Addr::UNSPECIFIED,
             rib_sync_timer: None,
             rib_sync_interval: DEFAULT_RIB_SYNC_INTERVAL_SEC,
+            sr0_owned: false,
         };
         rib.show_build();
         Ok(rib)
@@ -384,6 +395,51 @@ impl Rib {
             .map(|link| link.index)
     }
 
+    /// Resolve the device the kernel binds the seg6local action to,
+    /// per behavior:
+    ///   - End: sr0 dummy (table=main + kind=Unicast install)
+    ///   - everything else: loopback (table=local + kind=Local)
+    fn resolve_sid_ifindex(&self, behavior: SidBehavior) -> Option<u32> {
+        match behavior {
+            SidBehavior::End => self
+                .links
+                .values()
+                .find(|link| link.name == SR0_DUMMY_NAME)
+                .map(|link| link.index)
+                .or_else(|| self.resolve_lo_ifindex()),
+            _ => self.resolve_lo_ifindex(),
+        }
+    }
+
+    /// Make sure the sr0 dummy interface exists and is up. Called once
+    /// at startup after the initial FIB dump has populated `self.links`,
+    /// so we can detect a pre-existing sr0 and avoid clobbering it.
+    /// Sets `sr0_owned = true` only when this process created the
+    /// device — used by the shutdown path to decide whether to delete it.
+    pub async fn ensure_sr0_dummy(&mut self) {
+        if self.links.values().any(|link| link.name == SR0_DUMMY_NAME) {
+            // Operator (or a prior run) left sr0 in place — assume they
+            // own its lifecycle and just verify it's up.
+            return;
+        }
+        let Some(ifindex) = self.fib_handle.dummy_add(SR0_DUMMY_NAME).await else {
+            tracing::warn!("sr0 dummy create failed — End SID installs will fall back to lo");
+            return;
+        };
+        self.fib_handle.link_set_up(ifindex).await;
+        self.sr0_owned = true;
+        tracing::info!("sr0 dummy created (ifindex={})", ifindex);
+    }
+
+    /// Inverse of `ensure_sr0_dummy` — only deletes when this process
+    /// created the device. Called from the Shutdown message handler.
+    pub async fn cleanup_sr0_dummy(&self) {
+        if !self.sr0_owned {
+            return;
+        }
+        self.fib_handle.dummy_del(SR0_DUMMY_NAME).await;
+    }
+
     /// Install an allocated SID into the FIB: allocate / share a kernel
     /// nhid via NexthopMap, install the route as RouteType::Local with
     /// seg6local action, and record the entry in `self.sids` so the
@@ -391,7 +447,7 @@ impl Rib {
     async fn sid_install(&mut self, mut sid: Sid) {
         let original_ifindex = sid.ifindex;
         if sid.ifindex == 0
-            && let Some(ifindex) = self.resolve_lo_ifindex()
+            && let Some(ifindex) = self.resolve_sid_ifindex(sid.behavior)
         {
             sid.ifindex = ifindex;
         }
@@ -412,7 +468,7 @@ impl Rib {
         // entry so the LSP advertisement and show table are unaffected.
         if sid.ifindex == 0 {
             tracing::warn!(
-                "[sid_install] addr={} skipped — no loopback ifindex resolved yet",
+                "[sid_install] addr={} skipped — no SID device ifindex resolved yet",
                 sid.addr
             );
             self.sids.insert(sid.addr, sid);
@@ -648,6 +704,7 @@ impl Rib {
                 for (_, vxlan) in self.vxlan.iter() {
                     self.fib_handle.vxlan_del(vxlan).await;
                 }
+                self.cleanup_sr0_dummy().await;
                 let _ = tx.send(());
             }
             Message::LinkUp { ifindex } => {
@@ -861,6 +918,10 @@ impl Rib {
         if let Err(_err) = fib_dump(self).await {
             // warn!("FIB dump error {}", err);
         }
+
+        // The fib_dump above populated `self.links`; we can now decide
+        // whether sr0 already exists or needs to be created.
+        self.ensure_sr0_dummy().await;
 
         loop {
             tokio::select! {

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -396,12 +396,13 @@ impl Rib {
     }
 
     /// Resolve the device the kernel binds the seg6local action to,
-    /// per behavior:
-    ///   - End: sr0 dummy (table=main + kind=Unicast install)
-    ///   - everything else: loopback (table=local + kind=Local)
+    /// per behavior. End and uN are local-processing actions; both ride
+    /// on the sr0 dummy so the install can stay in table=main +
+    /// kind=Unicast. End.X and uA already run on the actual outgoing
+    /// interface and never hit this path.
     fn resolve_sid_ifindex(&self, behavior: SidBehavior) -> Option<u32> {
         match behavior {
-            SidBehavior::End => self
+            SidBehavior::End | SidBehavior::UN => self
                 .links
                 .values()
                 .find(|link| link.name == SR0_DUMMY_NAME)


### PR DESCRIPTION
## Summary

- Replace the End SID install workaround (`table=local` + `kind=Local` + `dev=lo`) with `table=main` + `kind=Unicast` + `dev=sr0`. uN gets the same treatment for consistency — it's the locator-prefix install that the kernel's NEXT-CSID flavor matches against, so it benefits from the cleaner FIB shape too.
- Add an sr0 dummy lifecycle: \`Rib::ensure_sr0_dummy\` creates and brings it up at startup if absent (\`sr0_owned = true\`); \`Rib::cleanup_sr0_dummy\` runs from the existing Shutdown handler and deletes only when we own it. Pre-existing sr0 (operator-managed) is left alone on entry and exit.
- Fix a long-standing bug surfaced by SRv6-only configs: the IS-IS adjacency-SID label pool was unconditionally initialized, so every IPv4 hello allocated label 15000+, our LSP emitted \`IsisSubLanAdjSid\`, SPF read it back from our own LSP, and the RIB tried an MPLS \`ilm_add\` that the kernel rejected with EOPNOTSUPP on hosts without an MPLS data path. Pool is now \`None\` until \`segment-routing mpls\` is configured.

## Test plan

- [x] \`cargo build --bin zebra-rs\`
- [x] \`cargo clippy --bin zebra-rs\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test --lib --workspace --exclude bdd\`
- [x] Manual: SRv6-only config (uSID locator) — verified End/uN installed under \`ip -6 route show table main | grep encap\` pointing at sr0; no more \`Operation not supported\` MPLS errors in the log.
- [ ] Manual: classic End locator path — verify End/128 lands on sr0 in table main with \`encap seg6local action End\`.
- [ ] Manual: SR-MPLS-enabled config (\`segment-routing mpls\` in YANG) — verify the adj-SID label pool comes back and adj-SID sub-TLVs / ILM installs resume.

Generated with [Claude Code](https://claude.com/claude-code)