### PR TITLE
fix(srv6): Nflen is node width only for uSID install

### DIFF
--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -99,14 +99,16 @@ fn build_seg6local_flavors(
         return None;
     }
     let s = structure?;
-    // Nflen is the combined locator-node + function width — the
-    // "uSID position" the kernel pops on each hop. Lblen is the
-    // shared block portion that stays put.
-    let nflen = s.ln_bits.saturating_add(s.fun_bits);
+    // Nflen is the *node* portion of a uSID — the bits the kernel
+    // shifts on each hop to expose the next uSID identifier. The
+    // function bits belong to the uSID that's being consumed (they
+    // pick the action), not to the next one's position, so they don't
+    // count toward the shift width. Lblen is the shared block portion
+    // that stays put.
     Some(RouteSeg6LocalIpTunnel::Flavors(vec![
         Seg6LocalFlavors::Operation(Seg6LocalFlavorOps::NextCsid),
         Seg6LocalFlavors::Lblen(s.lb_bits),
-        Seg6LocalFlavors::Nflen(nflen),
+        Seg6LocalFlavors::Nflen(s.ln_bits),
     ]))
 }
 


### PR DESCRIPTION
## Summary

\`Nflen\` is the bit-width the kernel shifts the IPv6 destination by on each NEXT-CSID hop — i.e. the *next* uSID's identifier portion (the "node" length). The function bits belong to the uSID being consumed (they pick the action), not to the next one's position, so they don't count toward the shift.

For a \`fcbb:bbbb:1::/48\` uSID locator (lb=32, ln=16, fun=16):

- Was: \`Nflen = ln + fun = 32\`
- Now: \`Nflen = ln = 16\`

## Test plan

- [x] \`cargo build --bin zebra-rs\`
- [x] \`cargo clippy --bin zebra-rs\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test --lib --workspace --exclude bdd\`
- [ ] Manual: \`ip -6 route show table main | grep encap\` shows the End uSID install with \`Lblen(32) Nflen(16)\`.

Generated with [Claude Code](https://claude.com/claude-code)