### PR TITLE
refactor(rib): split nexthop ifindex into origin + resolved

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -238,8 +238,8 @@ impl FibHandle {
                             .push(RouteAttribute::Gateway(RouteAddress::Inet6(ipv6)));
                     }
                 }
-                if uni.ifindex != 0 {
-                    msg.attributes.push(RouteAttribute::Oif(uni.ifindex));
+                if let Some(ifindex) = uni.ifindex() {
+                    msg.attributes.push(RouteAttribute::Oif(ifindex));
                 }
                 let attr = RouteAttribute::Priority(uni.metric);
                 msg.attributes.push(attr);
@@ -253,8 +253,8 @@ impl FibHandle {
                         IpAddr::V6(ipv6) => RouteAttribute::Gateway(RouteAddress::Inet6(ipv6)),
                     };
                     nhop.attributes.push(attr);
-                    if uni.ifindex != 0 {
-                        nhop.attributes.push(RouteAttribute::Oif(uni.ifindex));
+                    if let Some(ifindex) = uni.ifindex() {
+                        nhop.attributes.push(RouteAttribute::Oif(ifindex));
                     }
                     mpath.push(nhop);
                 }
@@ -348,8 +348,8 @@ impl FibHandle {
                             .push(RouteAttribute::Gateway(RouteAddress::Inet6(ipv6)));
                     }
                 }
-                if uni.ifindex != 0 {
-                    msg.attributes.push(RouteAttribute::Oif(uni.ifindex));
+                if let Some(ifindex) = uni.ifindex() {
+                    msg.attributes.push(RouteAttribute::Oif(ifindex));
                 }
                 let attr = RouteAttribute::Priority(uni.metric);
                 msg.attributes.push(attr);
@@ -363,8 +363,8 @@ impl FibHandle {
                         IpAddr::V6(ipv6) => RouteAttribute::Gateway(RouteAddress::Inet6(ipv6)),
                     };
                     nhop.attributes.push(attr);
-                    if uni.ifindex != 0 {
-                        nhop.attributes.push(RouteAttribute::Oif(uni.ifindex));
+                    if let Some(ifindex) = uni.ifindex() {
+                        nhop.attributes.push(RouteAttribute::Oif(ifindex));
                     }
                     mpath.push(nhop);
                 }
@@ -463,9 +463,9 @@ impl FibHandle {
             if let Nexthop::Uni(uni) = &nexthop {
                 if DEBUG_V6 {
                     tracing::info!(
-                        "[IPv6 route_add_uni] embed nexthop: addr={} ifindex={} metric={}",
+                        "[IPv6 route_add_uni] embed nexthop: addr={} ifindex={:?} metric={}",
                         uni.addr,
-                        uni.ifindex,
+                        uni.ifindex(),
                         uni.metric
                     );
                 }
@@ -479,8 +479,8 @@ impl FibHandle {
                             .push(RouteAttribute::Gateway(RouteAddress::Inet6(ipv6)));
                     }
                 }
-                if uni.ifindex != 0 {
-                    msg.attributes.push(RouteAttribute::Oif(uni.ifindex));
+                if let Some(ifindex) = uni.ifindex() {
+                    msg.attributes.push(RouteAttribute::Oif(ifindex));
                 }
                 let attr = RouteAttribute::Priority(uni.metric);
                 msg.attributes.push(attr);
@@ -513,8 +513,8 @@ impl FibHandle {
                         IpAddr::V6(ipv6) => RouteAttribute::Gateway(RouteAddress::Inet6(ipv6)),
                     };
                     nhop.attributes.push(attr);
-                    if uni.ifindex != 0 {
-                        nhop.attributes.push(RouteAttribute::Oif(uni.ifindex));
+                    if let Some(ifindex) = uni.ifindex() {
+                        nhop.attributes.push(RouteAttribute::Oif(ifindex));
                     }
                     mpath.push(nhop);
                 }
@@ -613,8 +613,8 @@ impl FibHandle {
                             .push(RouteAttribute::Gateway(RouteAddress::Inet6(ipv6)));
                     }
                 }
-                if uni.ifindex != 0 {
-                    msg.attributes.push(RouteAttribute::Oif(uni.ifindex));
+                if let Some(ifindex) = uni.ifindex() {
+                    msg.attributes.push(RouteAttribute::Oif(ifindex));
                 }
                 let attr = RouteAttribute::Priority(uni.metric);
                 msg.attributes.push(attr);
@@ -628,8 +628,8 @@ impl FibHandle {
                         IpAddr::V6(ipv6) => RouteAttribute::Gateway(RouteAddress::Inet6(ipv6)),
                     };
                     nhop.attributes.push(attr);
-                    if uni.ifindex != 0 {
-                        nhop.attributes.push(RouteAttribute::Oif(uni.ifindex));
+                    if let Some(ifindex) = uni.ifindex() {
+                        nhop.attributes.push(RouteAttribute::Oif(ifindex));
                     }
                     mpath.push(nhop);
                 }
@@ -694,10 +694,10 @@ impl FibHandle {
 
                 if DEBUG_V6 {
                     tracing::info!(
-                        "[nexthop_add Uni] gid={} addr={} ifindex={} valid={} installed={}",
+                        "[nexthop_add Uni] gid={} addr={} ifindex={:?} valid={} installed={}",
                         gid,
                         uni.addr,
-                        uni.ifindex,
+                        uni.ifindex(),
                         uni.is_valid(),
                         uni.is_installed(),
                     );
@@ -742,8 +742,10 @@ impl FibHandle {
                 };
                 msg.attributes.push(attr);
 
-                // Outgoing if.
-                let attr = NexthopAttribute::Oif(uni.ifindex);
+                // Outgoing if. Origin wins over resolved; fall back to 0
+                // ("no Oif attribute") if neither was filled, which is a
+                // bug case the kernel will reject — we want it loud.
+                let attr = NexthopAttribute::Oif(uni.ifindex().unwrap_or(0));
                 msg.attributes.push(attr);
 
                 if DEBUG_V6 {
@@ -1396,8 +1398,8 @@ impl FibHandle {
                 };
                 msg.attributes.push(attr);
 
-                if uni.ifindex != 0 {
-                    let attr = RouteAttribute::Oif(uni.ifindex);
+                if let Some(ifindex) = uni.ifindex() {
+                    let attr = RouteAttribute::Oif(ifindex);
                     msg.attributes.push(attr);
                 }
 
@@ -1423,8 +1425,8 @@ impl FibHandle {
                     };
                     nhop.attributes.push(attr);
 
-                    if uni.ifindex != 0 {
-                        let attr = RouteAttribute::Oif(uni.ifindex);
+                    if let Some(ifindex) = uni.ifindex() {
+                        let attr = RouteAttribute::Oif(ifindex);
                         nhop.attributes.push(attr);
                     }
 
@@ -1864,7 +1866,11 @@ impl RouteBuilder {
     pub fn build(mut self) -> (IpNet, RibEntry) {
         match &mut self.entry.nexthop {
             Nexthop::Uni(uni) => {
-                uni.ifindex = self.entry.ifindex;
+                // Kernel-dump path: the entry.ifindex is what netlink
+                // reported, so it's an origin (the kernel's source of
+                // truth). 0 means "no Oif attribute on this route" —
+                // record as None rather than fabricate an origin.
+                uni.ifindex_origin = (self.entry.ifindex != 0).then_some(self.entry.ifindex);
                 uni.metric = self.entry.metric;
             }
             _ => {

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1869,7 +1869,13 @@ fn nhop_to_nexthop_uni(key: &Ipv4Addr, route: &SpfRoute, value: &SpfNexthop) -> 
             rib::Label::Explicit(sid)
         });
     }
-    rib::NexthopUni::from(*key, route.metric, mpls)
+    let mut nhop = rib::NexthopUni::from(*key, route.metric, mpls);
+    // IS-IS knows the egress link from the adjacency state machine —
+    // record it as the origin so the RIB resolver doesn't re-derive
+    // (and potentially mis-derive) the link via a recursive table
+    // walk. 0 means "no usable adjacency ifindex"; treat as None.
+    nhop.ifindex_origin = (value.ifindex != 0).then_some(value.ifindex);
+    nhop
 }
 
 fn make_rib_entry(route: &SpfRoute) -> rib::entry::RibEntry {
@@ -1949,8 +1955,10 @@ fn nhop_to_nexthop_uni_v6(
         });
     }
     let mut nhop = rib::NexthopUni::new(std::net::IpAddr::V6(*key), route.metric, mpls);
-    // IPv6 link-local nexthops require ifindex for kernel scope resolution.
-    nhop.ifindex = value.ifindex;
+    // IPv6 link-local nexthops can't be disambiguated by table
+    // lookup — every interface advertises fe80::/64. The adjacency
+    // already pinned the egress link, so record it as the origin.
+    nhop.ifindex_origin = (value.ifindex != 0).then_some(value.ifindex);
     nhop
 }
 
@@ -2020,7 +2028,7 @@ fn make_ilm_entry(label: u32, ilm: &SpfIlm) -> IlmEntry {
     {
         let mut uni = NexthopUni {
             addr: std::net::IpAddr::V4(addr),
-            ifindex: nhop.ifindex,
+            ifindex_origin: (nhop.ifindex != 0).then_some(nhop.ifindex),
             ..Default::default()
         };
         if !nhop.adjacency {
@@ -2036,7 +2044,7 @@ fn make_ilm_entry(label: u32, ilm: &SpfIlm) -> IlmEntry {
     for (&addr, nhop) in ilm.nhops.iter() {
         let mut uni = NexthopUni {
             addr: std::net::IpAddr::V4(addr),
-            ifindex: nhop.ifindex,
+            ifindex_origin: (nhop.ifindex != 0).then_some(nhop.ifindex),
             ..Default::default()
         };
         if !nhop.adjacency {

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1566,7 +1566,13 @@ fn nhop_to_nexthop_uni(key: &Ipv4Addr, route: &SpfRoute, value: &SpfNexthop) -> 
             rib::Label::Explicit(sid)
         });
     }
-    rib::NexthopUni::from(*key, route.metric, mpls)
+    let mut nhop = rib::NexthopUni::from(*key, route.metric, mpls);
+    // OSPF, like IS-IS, learns the egress link from the adjacency
+    // state machine, so record it as the origin and let the RIB
+    // resolver leave it alone. 0 means "no usable adjacency ifindex"
+    // — record as None so callers can detect that case.
+    nhop.ifindex_origin = (value.ifindex != 0).then_some(value.ifindex);
+    nhop
 }
 
 fn make_rib_entry(route: &SpfRoute) -> rib::entry::RibEntry {

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -378,7 +378,10 @@ impl Rib {
         };
         NexthopUni {
             addr,
-            ifindex: sid.ifindex,
+            // SID installs pre-resolve the egress link (sr0 / lo for
+            // End/uN, the per-adjacency link for End.X/uA). Treat it
+            // as an origin so the resolver doesn't second-guess.
+            ifindex_origin: (sid.ifindex != 0).then_some(sid.ifindex),
             seg6local_action: Some(sid.behavior),
             valid: true,
             ..Default::default()

--- a/zebra-rs/src/rib/nexthop/group.rs
+++ b/zebra-rs/src/rib/nexthop/group.rs
@@ -44,7 +44,16 @@ impl GroupCommon {
 pub struct GroupUni {
     common: GroupCommon,
     pub addr: IpAddr,
-    pub ifindex: u32,
+
+    /// What the source said the egress ifindex was — copied verbatim
+    /// from `NexthopUni::ifindex_origin` in `GroupUni::new`. Resolution
+    /// must never overwrite this.
+    pub ifindex_origin: Option<u32>,
+    /// What `resolve` / `resolve_v6` looked up when origin was `None`.
+    /// `None` means resolution hasn't run yet or didn't find a covering
+    /// route.
+    pub ifindex_resolved: Option<u32>,
+
     pub labels: Vec<u32>,
 
     /// SRv6 H.Encap segment list (RFC 8986). Non-empty indicates this is an
@@ -66,25 +75,15 @@ pub struct GroupUni {
 
 impl GroupUni {
     pub fn new(gid: usize, uni: &NexthopUni) -> Self {
-        // Trust `uni.ifindex` when the caller has set it. Three
-        // populators do today:
-        //   - IGP protocols (IS-IS, OSPF) emit nexthops with the
-        //     adjacency's egress link already filled in, since they
-        //     learn the link from the adjacency state machine, not
-        //     from a recursive RIB lookup.
-        //   - seg6local installs (End / End.X) pre-resolve to
-        //     loopback / per-adjacency.
-        //   - Connected/static routes obviously know their oif.
-        // Only ifindex == 0 means "I don't know — please resolve".
-        // Previously this branch was gated on seg6local_action, which
-        // discarded IS-IS / OSPF egress info and forced a v6 table
-        // resolve that picked the wrong link for fe80::/64 (link-
-        // local routes exist on every interface, so longest-prefix
-        // returns whichever connected route lands first).
+        // Carry the source's ifindex_origin straight through — IGP
+        // adjacencies, seg6local installs, connected routes and
+        // interface-pinned static routes all set it. The resolver is
+        // only allowed to fill `ifindex_resolved` when origin is None.
         Self {
             common: GroupCommon::new(gid),
             addr: uni.addr,
-            ifindex: uni.ifindex,
+            ifindex_origin: uni.ifindex_origin,
+            ifindex_resolved: None,
             labels: uni.mpls_label.clone(),
             segs: uni.segs.clone(),
             encap_type: uni.encap_type,
@@ -92,13 +91,17 @@ impl GroupUni {
         }
     }
 
+    /// Egress ifindex to use, with origin winning over resolved.
+    pub fn ifindex(&self) -> Option<u32> {
+        self.ifindex_origin.or(self.ifindex_resolved)
+    }
+
     pub fn resolve(&mut self, table: &PrefixMap<Ipv4Net, RibEntries>) {
-        // Caller already supplied an egress link (IGP / seg6local /
-        // connected). Trust it — the recursive RIB walk would just
-        // re-derive the same answer, and for IGP nexthops it can
-        // outright pick the wrong link when the address is reachable
-        // through multiple covering routes.
-        if self.ifindex != 0 {
+        // Origin wins. The recursive RIB walk would re-derive the
+        // same answer at best, and at worst pick the wrong link
+        // when the address is reachable through multiple covering
+        // routes (classic IGP fe80::/64 scenario).
+        if self.ifindex_origin.is_some() {
             self.set_valid(true);
             return;
         }
@@ -110,7 +113,7 @@ impl GroupUni {
                 // IGP/static covering route. The Group only needs the ifindex,
                 // not the path category.
                 if let Resolve::Onlink(ifindex) | Resolve::Recursive(ifindex) = resolve {
-                    self.ifindex = ifindex;
+                    self.ifindex_resolved = Some(ifindex);
                     self.set_valid(true);
                 }
             }
@@ -121,15 +124,14 @@ impl GroupUni {
     }
 
     pub fn resolve_v6(&mut self, table: &PrefixMap<Ipv6Net, RibEntries>) {
-        // Same short-circuit as `resolve`: caller-supplied ifindex
-        // wins over recursive table resolution. Critical for IPv6
-        // because link-local nexthops can't be disambiguated by
-        // table lookup — every interface advertises fe80::/64.
-        if self.ifindex != 0 {
+        // Origin wins. Critical for IPv6 because link-local nexthops
+        // can't be disambiguated by table lookup — every interface
+        // advertises fe80::/64.
+        if let Some(ifindex) = self.ifindex_origin {
             if DEBUG_V6 {
                 println!(
-                    "[GroupUni::resolve_v6] addr={} ifindex={} pre-resolved (skipping table walk)",
-                    self.addr, self.ifindex,
+                    "[GroupUni::resolve_v6] addr={} ifindex_origin={} (skipping table walk)",
+                    self.addr, ifindex,
                 );
             }
             self.set_valid(true);
@@ -145,11 +147,11 @@ impl GroupUni {
                 Resolve::Onlink(ifindex) | Resolve::Recursive(ifindex) => {
                     if DEBUG_V6 {
                         println!(
-                            "[GroupUni::resolve_v6] {} -> ifindex={}",
+                            "[GroupUni::resolve_v6] {} -> ifindex_resolved={}",
                             ipv6_addr, ifindex
                         );
                     }
-                    self.ifindex = *ifindex;
+                    self.ifindex_resolved = Some(*ifindex);
                     self.set_valid(true);
                 }
                 Resolve::NotFound => {
@@ -159,10 +161,6 @@ impl GroupUni {
                 }
             }
         }
-    }
-
-    pub fn set_ifindex(&mut self, ifindex: u32) {
-        self.ifindex = ifindex
     }
 }
 
@@ -299,7 +297,7 @@ mod tests {
         let mut e = RibEntry::new(RibType::Isis);
         e.nexthop = Nexthop::Uni(NexthopUni {
             addr: IpAddr::V6(addr),
-            ifindex,
+            ifindex_origin: Some(ifindex),
             ..Default::default()
         });
         e
@@ -315,17 +313,18 @@ mod tests {
         let mut e = RibEntry::new(RibType::Isis);
         e.nexthop = Nexthop::Uni(NexthopUni {
             addr: IpAddr::V4(addr),
-            ifindex,
+            ifindex_origin: Some(ifindex),
             ..Default::default()
         });
         e
     }
 
     #[test]
-    fn resolve_v6_through_isis_recursive_sets_ifindex() {
+    fn resolve_v6_through_isis_recursive_lands_in_resolved_field() {
         // The SRv6 first-segment scenario: GroupUni's address is covered by an
         // IS-IS-learned aggregate. rib_resolve_v6 returns Resolve::Recursive
-        // carrying the IS-IS route's ifindex; the Group must adopt it.
+        // carrying the IS-IS route's ifindex; the Group records it as the
+        // *resolved* ifindex (origin stays None).
         let mut table = PrefixMap::<Ipv6Net, RibEntries>::new();
         table.insert(
             Ipv6Net::from_str("fcbb:bbbb:2::/48").unwrap(),
@@ -333,17 +332,19 @@ mod tests {
         );
 
         let mut group = group_uni_at(IpAddr::V6("fcbb:bbbb:2:3:2::".parse().unwrap()));
-        assert_eq!(group.ifindex, 0);
+        assert_eq!(group.ifindex(), None);
         assert!(!group.is_valid());
 
         group.resolve_v6(&table);
 
-        assert_eq!(group.ifindex, 42);
+        assert_eq!(group.ifindex_origin, None);
+        assert_eq!(group.ifindex_resolved, Some(42));
+        assert_eq!(group.ifindex(), Some(42));
         assert!(group.is_valid());
     }
 
     #[test]
-    fn resolve_v6_onlink_sets_ifindex() {
+    fn resolve_v6_onlink_lands_in_resolved_field() {
         let mut table = PrefixMap::<Ipv6Net, RibEntries>::new();
         table.insert(
             Ipv6Net::from_str("2001:db8::/64").unwrap(),
@@ -353,7 +354,8 @@ mod tests {
         let mut group = group_uni_at(IpAddr::V6("2001:db8::1".parse().unwrap()));
         group.resolve_v6(&table);
 
-        assert_eq!(group.ifindex, 7);
+        assert_eq!(group.ifindex_resolved, Some(7));
+        assert_eq!(group.ifindex(), Some(7));
         assert!(group.is_valid());
     }
 
@@ -362,32 +364,32 @@ mod tests {
         let table = PrefixMap::<Ipv6Net, RibEntries>::new();
         let mut group = group_uni_at(IpAddr::V6("2001:db8::1".parse().unwrap()));
         group.resolve_v6(&table);
-        assert_eq!(group.ifindex, 0);
+        assert_eq!(group.ifindex(), None);
         assert!(!group.is_valid());
     }
 
     #[test]
-    fn group_uni_new_preserves_caller_ifindex_for_plain_unicast() {
-        // IGP protocols (IS-IS, OSPF) populate uni.ifindex from the
-        // adjacency state machine. GroupUni::new used to throw that
-        // away for non-seg6local nexthops, forcing a table-based
-        // re-resolve that picks the wrong link for fe80::/64. Pin
-        // the new behaviour: trust the caller.
+    fn group_uni_new_carries_origin_for_plain_unicast() {
+        // IGP protocols (IS-IS, OSPF) populate uni.ifindex_origin from
+        // the adjacency state machine. GroupUni::new must carry it
+        // straight through — discarding it would force a table re-
+        // resolve that picks the wrong link for fe80::/64.
         let uni = NexthopUni {
             addr: IpAddr::V6("fe80::1".parse().unwrap()),
-            ifindex: 42,
+            ifindex_origin: Some(42),
             ..Default::default()
         };
         let group = GroupUni::new(0, &uni);
-        assert_eq!(group.ifindex, 42);
+        assert_eq!(group.ifindex_origin, Some(42));
+        assert_eq!(group.ifindex_resolved, None);
+        assert_eq!(group.ifindex(), Some(42));
     }
 
     #[test]
-    fn resolve_v6_skips_table_walk_when_ifindex_pre_resolved() {
-        // Pre-set ifindex (from an IS-IS adjacency, say) must win
-        // over recursive table resolution. Otherwise multi-link
-        // fe80::/64 routes silently route the IGP nexthop out the
-        // wrong interface.
+    fn resolve_v6_does_not_overwrite_origin() {
+        // Origin (from an IS-IS adjacency) must win over recursive
+        // table resolution. Otherwise multi-link fe80::/64 routes
+        // silently route the IGP nexthop out the wrong interface.
         let mut table = PrefixMap::<Ipv6Net, RibEntries>::new();
         // Two connected fe80::/64 routes — the table walk would pick
         // ifindex 7 (whichever lands first in PrefixMap iteration).
@@ -398,16 +400,19 @@ mod tests {
 
         let uni = NexthopUni {
             addr: IpAddr::V6("fe80::21c:42ff:fee8:c23".parse().unwrap()),
-            ifindex: 99, // adjacency knows it's on link 99
+            ifindex_origin: Some(99), // adjacency knows it's on link 99
             ..Default::default()
         };
         let mut group = GroupUni::new(0, &uni);
-        assert_eq!(group.ifindex, 99);
+        assert_eq!(group.ifindex_origin, Some(99));
+        assert_eq!(group.ifindex_resolved, None);
 
         group.resolve_v6(&table);
 
-        // Table walk did NOT overwrite our 99.
-        assert_eq!(group.ifindex, 99);
+        // Resolved stays None — origin short-circuits the table walk.
+        assert_eq!(group.ifindex_origin, Some(99));
+        assert_eq!(group.ifindex_resolved, None);
+        assert_eq!(group.ifindex(), Some(99));
         assert!(group.is_valid());
     }
 
@@ -422,12 +427,12 @@ mod tests {
         let mut group = group_uni_at(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
         group.resolve_v6(&table);
 
-        assert_eq!(group.ifindex, 0);
+        assert_eq!(group.ifindex(), None);
         assert!(!group.is_valid());
     }
 
     #[test]
-    fn resolve_v4_through_isis_recursive_sets_ifindex() {
+    fn resolve_v4_through_isis_recursive_lands_in_resolved_field() {
         let mut table = PrefixMap::<Ipv4Net, RibEntries>::new();
         table.insert(
             Ipv4Net::from_str("10.0.0.0/8").unwrap(),
@@ -437,12 +442,13 @@ mod tests {
         let mut group = group_uni_at(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3)));
         group.resolve(&table);
 
-        assert_eq!(group.ifindex, 17);
+        assert_eq!(group.ifindex_resolved, Some(17));
+        assert_eq!(group.ifindex(), Some(17));
         assert!(group.is_valid());
     }
 
     #[test]
-    fn resolve_v4_onlink_sets_ifindex() {
+    fn resolve_v4_onlink_lands_in_resolved_field() {
         let mut table = PrefixMap::<Ipv4Net, RibEntries>::new();
         table.insert(
             Ipv4Net::from_str("192.168.0.0/24").unwrap(),
@@ -452,7 +458,8 @@ mod tests {
         let mut group = group_uni_at(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 10)));
         group.resolve(&table);
 
-        assert_eq!(group.ifindex, 5);
+        assert_eq!(group.ifindex_resolved, Some(5));
+        assert_eq!(group.ifindex(), Some(5));
         assert!(group.is_valid());
     }
 
@@ -464,8 +471,30 @@ mod tests {
         let mut group = group_uni_at(IpAddr::V6("2001:db8::1".parse().unwrap()));
         group.resolve(&table);
 
-        assert_eq!(group.ifindex, 0);
+        assert_eq!(group.ifindex(), None);
         assert!(!group.is_valid());
+    }
+
+    #[test]
+    fn nexthopuni_ifindex_prefers_origin_over_resolved() {
+        let uni = NexthopUni {
+            addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            ifindex_origin: Some(42),
+            ifindex_resolved: Some(99),
+            ..Default::default()
+        };
+        assert_eq!(uni.ifindex(), Some(42));
+    }
+
+    #[test]
+    fn nexthopuni_ifindex_falls_back_to_resolved_when_origin_is_none() {
+        let uni = NexthopUni {
+            addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            ifindex_origin: None,
+            ifindex_resolved: Some(99),
+            ..Default::default()
+        };
+        assert_eq!(uni.ifindex(), Some(99));
     }
 
     #[test]

--- a/zebra-rs/src/rib/nexthop/inst.rs
+++ b/zebra-rs/src/rib/nexthop/inst.rs
@@ -18,7 +18,22 @@ pub struct NexthopUni {
     pub addr: IpAddr,
     pub metric: u32,
     pub weight: u8,
-    pub ifindex: u32,
+
+    /// What the source said the egress ifindex was — `Some` for IGP
+    /// adjacencies, kernel dump, connected routes, configured static
+    /// routes that name an interface, seg6local installs that
+    /// pre-resolve to loopback / per-adjacency. `None` means "the
+    /// source didn't know; please resolve via the RIB."
+    ///
+    /// Origin is the source of truth for FIB install and show output;
+    /// the resolver must never overwrite it. Future work will give
+    /// `addr` the same origin/resolved split for static routes that
+    /// recurse through a chain of nexthop addresses.
+    pub ifindex_origin: Option<u32>,
+    /// What the RIB resolver looked up when origin was `None`.
+    /// `None` means "not resolved yet" or "no covering route found."
+    pub ifindex_resolved: Option<u32>,
+
     pub valid: bool,
     pub mpls: Vec<Label>,
     pub mpls_label: Vec<u32>,
@@ -32,12 +47,22 @@ pub struct NexthopUni {
 
     // SRv6 seg6local action — set when this nexthop installs a local
     // SID (End / End.X). For End.X, `addr` carries the IPv6 nexthop and
-    // `ifindex` the outgoing link; for End, `ifindex` is the loopback
-    // and `addr` is unused.
+    // `ifindex_origin` the outgoing link; for End, the ifindex is the
+    // sr0 dummy and `addr` is unused.
     pub seg6local_action: Option<SidBehavior>,
 
     // Action.
     pub gid: usize,
+}
+
+impl NexthopUni {
+    /// Egress ifindex to use, with origin winning over resolved.
+    /// Returns `None` only when neither the source nor the resolver
+    /// produced one — callers that need a u32 (FIB / netlink) should
+    /// `.unwrap_or(0)`.
+    pub fn ifindex(&self) -> Option<u32> {
+        self.ifindex_origin.or(self.ifindex_resolved)
+    }
 }
 
 impl NexthopUni {
@@ -69,7 +94,8 @@ impl Default for NexthopUni {
     fn default() -> Self {
         Self {
             addr: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            ifindex: 0,
+            ifindex_origin: None,
+            ifindex_resolved: None,
             metric: 0,
             weight: 1,
             mpls: vec![],

--- a/zebra-rs/src/rib/nexthop/map.rs
+++ b/zebra-rs/src/rib/nexthop/map.rs
@@ -155,7 +155,7 @@ impl NexthopMap {
             IpAddr::V6(a) if !a.is_unspecified() => Some(a),
             _ => None,
         };
-        let key: Seg6LocalKey = (action, uni.ifindex, nh6);
+        let key: Seg6LocalKey = (action, uni.ifindex().unwrap_or(0), nh6);
         if let Some(&gid) = self.seg6local.get(&key) {
             let entry = self.groups.get_mut(gid)?;
             if entry.is_none() {
@@ -418,7 +418,7 @@ mod tests {
     fn end_uni(ifindex: u32) -> NexthopUni {
         NexthopUni {
             addr: IpAddr::V6(Ipv6Addr::UNSPECIFIED),
-            ifindex,
+            ifindex_origin: Some(ifindex),
             seg6local_action: Some(crate::rib::SidBehavior::End),
             ..Default::default()
         }
@@ -427,7 +427,7 @@ mod tests {
     fn endx_uni(ifindex: u32, nh6: &str) -> NexthopUni {
         NexthopUni {
             addr: IpAddr::V6(nh6.parse().unwrap()),
-            ifindex,
+            ifindex_origin: Some(ifindex),
             seg6local_action: Some(crate::rib::SidBehavior::EndX),
             ..Default::default()
         }
@@ -466,7 +466,7 @@ mod tests {
         // can't collapse the two.
         let endx = NexthopUni {
             addr: IpAddr::V6(Ipv6Addr::UNSPECIFIED),
-            ifindex: 2,
+            ifindex_origin: Some(2),
             seg6local_action: Some(crate::rib::SidBehavior::EndX),
             ..Default::default()
         };

--- a/zebra-rs/src/rib/nexthop/show.rs
+++ b/zebra-rs/src/rib/nexthop/show.rs
@@ -41,7 +41,7 @@ pub fn nexthop_show(rib: &Rib, _args: Args, _json: bool) -> String {
             Group::Uni(uni) => {
                 write!(buf, "  ").unwrap();
                 write_via(&mut buf, uni);
-                write!(buf, ", {}", rib.link_name(uni.ifindex)).unwrap();
+                write!(buf, ", {}", rib.link_name(uni.ifindex().unwrap_or(0))).unwrap();
                 for label in uni.labels.iter() {
                     let _ = write!(buf, " {}", label);
                 }
@@ -52,8 +52,13 @@ pub fn nexthop_show(rib: &Rib, _args: Args, _json: bool) -> String {
                     if let Some(Group::Uni(uni)) = rib.nmap.get(*gid) {
                         write!(buf, "  [{}] ", gid).unwrap();
                         write_via(&mut buf, uni);
-                        writeln!(buf, ", {}, weight: {}", rib.link_name(uni.ifindex), weight)
-                            .unwrap();
+                        writeln!(
+                            buf,
+                            ", {}, weight: {}",
+                            rib.link_name(uni.ifindex().unwrap_or(0)),
+                            weight
+                        )
+                        .unwrap();
                     }
                 }
             }

--- a/zebra-rs/src/rib/resolve.rs
+++ b/zebra-rs/src/rib/resolve.rs
@@ -65,7 +65,7 @@ fn entry_nexthop_ifindex(entry: &RibEntry) -> Option<u32> {
         return None;
     }
     match &entry.nexthop {
-        Nexthop::Uni(uni) if uni.ifindex != 0 => Some(uni.ifindex),
+        Nexthop::Uni(uni) if uni.ifindex().is_some() => uni.ifindex(),
         Nexthop::Multi(multi) => first_ifindex(&multi.nexthops),
         Nexthop::List(list) => first_ifindex(&list.nexthops),
         _ => None,
@@ -73,23 +73,23 @@ fn entry_nexthop_ifindex(entry: &RibEntry) -> Option<u32> {
 }
 
 fn first_ifindex(nexthops: &[NexthopUni]) -> Option<u32> {
-    nexthops.iter().find(|u| u.ifindex != 0).map(|u| u.ifindex)
+    nexthops.iter().find_map(|u| u.ifindex())
 }
 
 // Pull the unicast next-hop address out of a RibEntry whose ifindex is not
 // yet populated, so we can recurse to find the underlying egress interface.
 fn entry_nexthop_addr(entry: &RibEntry) -> Option<IpAddr> {
     match &entry.nexthop {
-        Nexthop::Uni(uni) if uni.ifindex == 0 => Some(uni.addr),
+        Nexthop::Uni(uni) if uni.ifindex().is_none() => Some(uni.addr),
         Nexthop::Multi(multi) => multi
             .nexthops
             .first()
-            .filter(|u| u.ifindex == 0)
+            .filter(|u| u.ifindex().is_none())
             .map(|u| u.addr),
         Nexthop::List(list) => list
             .nexthops
             .first()
-            .filter(|u| u.ifindex == 0)
+            .filter(|u| u.ifindex().is_none())
             .map(|u| u.addr),
         _ => None,
     }
@@ -222,7 +222,7 @@ mod tests {
         let mut e = RibEntry::new(rtype);
         e.nexthop = Nexthop::Uni(NexthopUni {
             addr: IpAddr::V6(addr),
-            ifindex,
+            ifindex_origin: Some(ifindex),
             ..Default::default()
         });
         e
@@ -232,7 +232,7 @@ mod tests {
         let mut e = RibEntry::new(rtype);
         e.nexthop = Nexthop::Uni(NexthopUni {
             addr: IpAddr::V6(addr),
-            ifindex: 0,
+            ifindex_origin: None,
             ..Default::default()
         });
         e

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -62,7 +62,7 @@ impl Rib {
                             //
                         }
                         Nexthop::Uni(uni) => {
-                            if uni.ifindex == ifindex {
+                            if uni.ifindex() == Some(ifindex) {
                                 let msg = Message::Ipv4Del {
                                     prefix: *prefix,
                                     rib: entry.clone(),
@@ -90,7 +90,7 @@ impl Rib {
                             //
                         }
                         Nexthop::Uni(uni) => {
-                            if uni.ifindex == ifindex {
+                            if uni.ifindex() == Some(ifindex) {
                                 let msg = Message::Ipv6Del {
                                     prefix: *prefix,
                                     rib: entry.clone(),
@@ -443,7 +443,7 @@ pub async fn ipv4_nexthop_sync(
             // Update the status of the next hop
             let ifindex = resolve.is_valid();
             if ifindex == 0 {
-                uni.set_ifindex(ifindex);
+                uni.ifindex_resolved = None;
                 uni.set_valid(false);
                 if uni.is_installed() {
                     // println!(
@@ -457,14 +457,14 @@ pub async fn ipv4_nexthop_sync(
                     // XXX fib.nexthop_del(&Group::Uni(uni.clone())).await;
                 }
             } else {
-                uni.set_ifindex(ifindex);
+                uni.ifindex_resolved = Some(ifindex);
                 uni.set_valid(true);
                 if !uni.is_installed() {
                     // println!(
                     //     "UniAdd: gid {} {}/{} {}",
                     //     uni.gid(),
                     //     uni.addr,
-                    //     uni.ifindex,
+                    //     uni.ifindex(),
                     //     uni.is_installed()
                     // );
                     uni.set_installed(true);
@@ -601,7 +601,12 @@ async fn ipv4_entry_selection(
 fn nexthop_uni_resolve(nhop: &mut NexthopUni, nmap: &NexthopMap) {
     if let Some(grp) = nmap.get_uni(nhop.gid) {
         nhop.valid = grp.is_valid();
-        nhop.ifindex = grp.ifindex;
+        // Group carries both halves; copy them through unchanged.
+        // Origin must never be lost — that's the whole point of the
+        // split, so the show path can name the IGP-supplied link
+        // even when the table walk would have picked something else.
+        nhop.ifindex_origin = grp.ifindex_origin;
+        nhop.ifindex_resolved = grp.ifindex_resolved;
     }
 }
 
@@ -660,7 +665,10 @@ fn resolve_nexthop_uni(
     group.refcnt_inc();
 
     uni.gid = group.gid();
-    uni.ifindex = group.ifindex;
+    // Origin came from the caller, must not be overwritten;
+    // resolution may have populated `ifindex_resolved`.
+    uni.ifindex_origin = group.ifindex_origin;
+    uni.ifindex_resolved = group.ifindex_resolved;
 
     group.is_valid()
 }
@@ -1130,33 +1138,39 @@ fn resolve_nexthop_uni_v6(
     };
     if DEBUG_V6 {
         println!(
-            "[resolve_nexthop_uni_v6] fetched group gid={} refcnt={} valid={} ifindex={}",
+            "[resolve_nexthop_uni_v6] fetched group gid={} refcnt={} valid={} ifindex={:?}",
             group.gid(),
             group.refcnt(),
             group.is_valid(),
-            group.ifindex,
+            group.ifindex(),
         );
     }
     if group.refcnt() == 0 {
         group.resolve_v6(table);
         if DEBUG_V6 {
             println!(
-                "[resolve_nexthop_uni_v6] after resolve_v6 valid={} ifindex={}",
+                "[resolve_nexthop_uni_v6] after resolve_v6 valid={} ifindex={:?}",
                 group.is_valid(),
-                group.ifindex,
+                group.ifindex(),
             );
         }
     }
     group.refcnt_inc();
 
     uni.gid = group.gid();
-    uni.ifindex = group.ifindex;
+    // Both halves flow through unchanged. The caller's origin (if
+    // any) was preserved across `fetch` and `resolve_v6`; those
+    // routines may have written `ifindex_resolved`.
+    uni.ifindex_origin = group.ifindex_origin;
+    uni.ifindex_resolved = group.ifindex_resolved;
 
     let valid = group.is_valid();
     if DEBUG_V6 {
         println!(
-            "[resolve_nexthop_uni_v6] returning uni.gid={} uni.ifindex={} valid={}",
-            uni.gid, uni.ifindex, valid
+            "[resolve_nexthop_uni_v6] returning uni.gid={} uni.ifindex={:?} valid={}",
+            uni.gid,
+            uni.ifindex(),
+            valid
         );
     }
     valid
@@ -1174,13 +1188,23 @@ pub async fn ipv6_nexthop_sync(
         if let Group::Uni(uni) = nhop {
             if DEBUG_V6 {
                 println!(
-                    "[ipv6_nexthop_sync] visiting uni gid={} addr={} ifindex={} valid={} installed={}",
+                    "[ipv6_nexthop_sync] visiting uni gid={} addr={} ifindex={:?} valid={} installed={}",
                     uni.gid(),
                     uni.addr,
-                    uni.ifindex,
+                    uni.ifindex(),
                     uni.is_valid(),
                     uni.is_installed(),
                 );
+            }
+            // Origin wins — skip the table walk entirely if the
+            // caller already supplied the egress link.
+            if uni.ifindex_origin.is_some() {
+                uni.set_valid(true);
+                if !uni.is_installed() {
+                    uni.set_installed(true);
+                    fib.nexthop_add(&Group::Uni(uni.clone())).await;
+                }
+                continue;
             }
             let resolve = match uni.addr {
                 std::net::IpAddr::V4(_) => continue,
@@ -1197,13 +1221,13 @@ pub async fn ipv6_nexthop_sync(
                 );
             }
             if ifindex == 0 {
-                uni.set_ifindex(ifindex);
+                uni.ifindex_resolved = None;
                 uni.set_valid(false);
                 if uni.is_installed() {
                     uni.set_installed(false);
                 }
             } else {
-                uni.set_ifindex(ifindex);
+                uni.ifindex_resolved = Some(ifindex);
                 uni.set_valid(true);
                 if !uni.is_installed() {
                     uni.set_installed(true);

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -114,14 +114,13 @@ fn rib_entry_to_json(rib: &Rib, prefix: &Ipv4Net, e: &RibEntry) -> RouteEntry {
         }
         Nexthop::Uni(uni) => {
             let grp = rib.nmap.get(uni.gid);
-            let ifindex: u32 = if let Some(grp) = grp {
-                if let Group::Uni(grp) = grp {
-                    grp.ifindex
-                } else {
-                    0
-                }
+            // Prefer the group's view (post-resolution) but fall back
+            // to the NexthopUni's own accessor when no group is around
+            // — both honor origin over resolved.
+            let ifindex: u32 = if let Some(Group::Uni(grp)) = grp {
+                grp.ifindex().unwrap_or(0)
             } else {
-                uni.ifindex
+                uni.ifindex().unwrap_or(0)
             };
 
             vec![NexthopJson {
@@ -149,7 +148,7 @@ fn rib_entry_to_json(rib: &Rib, prefix: &Ipv4Net, e: &RibEntry) -> RouteEntry {
             .iter()
             .map(|uni| NexthopJson {
                 address: Some(uni.addr.to_string()),
-                interface: rib.link_name(uni.ifindex),
+                interface: rib.link_name(uni.ifindex().unwrap_or(0)),
                 weight: Some(uni.weight),
                 metric: Some(uni.metric),
                 mpls_labels: uni
@@ -172,7 +171,7 @@ fn rib_entry_to_json(rib: &Rib, prefix: &Ipv4Net, e: &RibEntry) -> RouteEntry {
             .iter()
             .map(|uni| NexthopJson {
                 address: Some(uni.addr.to_string()),
-                interface: rib.link_name(uni.ifindex),
+                interface: rib.link_name(uni.ifindex().unwrap_or(0)),
                 weight: Some(uni.weight),
                 metric: Some(uni.metric),
                 mpls_labels: uni
@@ -229,14 +228,13 @@ fn rib_entry_to_json_v6(rib: &Rib, prefix: &Ipv6Net, e: &RibEntry) -> RouteEntry
         }
         Nexthop::Uni(uni) => {
             let grp = rib.nmap.get(uni.gid);
-            let ifindex: u32 = if let Some(grp) = grp {
-                if let Group::Uni(grp) = grp {
-                    grp.ifindex
-                } else {
-                    0
-                }
+            // Prefer the group's view (post-resolution) but fall back
+            // to the NexthopUni's own accessor when no group is around
+            // — both honor origin over resolved.
+            let ifindex: u32 = if let Some(Group::Uni(grp)) = grp {
+                grp.ifindex().unwrap_or(0)
             } else {
-                uni.ifindex
+                uni.ifindex().unwrap_or(0)
             };
 
             vec![NexthopJson {
@@ -264,7 +262,7 @@ fn rib_entry_to_json_v6(rib: &Rib, prefix: &Ipv6Net, e: &RibEntry) -> RouteEntry
             .iter()
             .map(|uni| NexthopJson {
                 address: Some(uni.addr.to_string()),
-                interface: rib.link_name(uni.ifindex),
+                interface: rib.link_name(uni.ifindex().unwrap_or(0)),
                 weight: Some(uni.weight),
                 metric: Some(uni.metric),
                 mpls_labels: uni
@@ -287,7 +285,7 @@ fn rib_entry_to_json_v6(rib: &Rib, prefix: &Ipv6Net, e: &RibEntry) -> RouteEntry
             .iter()
             .map(|uni| NexthopJson {
                 address: Some(uni.addr.to_string()),
-                interface: rib.link_name(uni.ifindex),
+                interface: rib.link_name(uni.ifindex().unwrap_or(0)),
                 weight: Some(uni.weight),
                 metric: Some(uni.metric),
                 mpls_labels: uni
@@ -386,14 +384,10 @@ pub fn rib_entry_show(
             Nexthop::Uni(uni) => {
                 let grp = rib.nmap.get(uni.gid);
 
-                let ifindex: u32 = if let Some(grp) = grp {
-                    if let Group::Uni(grp) = grp {
-                        grp.ifindex
-                    } else {
-                        0
-                    }
+                let ifindex: u32 = if let Some(Group::Uni(grp)) = grp {
+                    grp.ifindex().unwrap_or(0)
                 } else {
-                    uni.ifindex
+                    uni.ifindex().unwrap_or(0)
                 };
                 write!(
                     buf,
@@ -430,7 +424,7 @@ pub fn rib_entry_show(
                         " {} {}, {}",
                         via_word(uni),
                         via_addr(uni),
-                        rib.link_name(uni.ifindex),
+                        rib.link_name(uni.ifindex().unwrap_or(0)),
                     )
                     .unwrap();
                     if !uni.mpls.is_empty() {
@@ -460,7 +454,7 @@ pub fn rib_entry_show(
                         " {} {}, {}, metric {}, {}",
                         via_word(uni),
                         via_addr(uni),
-                        rib.link_name(uni.ifindex),
+                        rib.link_name(uni.ifindex().unwrap_or(0)),
                         uni.metric,
                         uptime,
                     )
@@ -514,14 +508,10 @@ pub fn rib_entry_show_v6(
             Nexthop::Uni(uni) => {
                 let grp = rib.nmap.get(uni.gid);
 
-                let ifindex: u32 = if let Some(grp) = grp {
-                    if let Group::Uni(grp) = grp {
-                        grp.ifindex
-                    } else {
-                        0
-                    }
+                let ifindex: u32 = if let Some(Group::Uni(grp)) = grp {
+                    grp.ifindex().unwrap_or(0)
                 } else {
-                    uni.ifindex
+                    uni.ifindex().unwrap_or(0)
                 };
                 write!(
                     buf,
@@ -558,7 +548,7 @@ pub fn rib_entry_show_v6(
                         " {} {}, {}",
                         via_word(uni),
                         via_addr(uni),
-                        rib.link_name(uni.ifindex),
+                        rib.link_name(uni.ifindex().unwrap_or(0)),
                     )
                     .unwrap();
                     if !uni.mpls.is_empty() {
@@ -587,7 +577,7 @@ pub fn rib_entry_show_v6(
                         " {} {}, {}, metric {}, {}",
                         via_word(uni),
                         via_addr(uni),
-                        rib.link_name(uni.ifindex),
+                        rib.link_name(uni.ifindex().unwrap_or(0)),
                         uni.metric,
                         uptime,
                     )
@@ -737,7 +727,7 @@ fn write_ilm_entry(
     let local_label = format!("{:<6}", label);
 
     // Determine outgoing label
-    let outgoing_label = if uni.addr.is_unspecified() && uni.ifindex == 0 {
+    let outgoing_label = if uni.addr.is_unspecified() && uni.ifindex().is_none() {
         format!("{:<11}", "Aggregate")
     } else if uni.mpls_label.is_empty() {
         format!("{:<11}", "Pop")
@@ -761,10 +751,10 @@ fn write_ilm_entry(
         }
     };
 
-    let interface = if uni.addr.is_unspecified() && uni.ifindex == 0 {
+    let interface = if uni.addr.is_unspecified() && uni.ifindex().is_none() {
         "default".to_string()
     } else {
-        rib.link_name(uni.ifindex)
+        rib.link_name(uni.ifindex().unwrap_or(0))
     };
 
     let next_hop = if uni.addr.is_unspecified() {
@@ -788,7 +778,7 @@ fn ilm_to_json(
     ilm: &super::inst::IlmEntry,
     uni: &super::NexthopUni,
 ) -> IlmJson {
-    let outgoing_label = if uni.addr.is_unspecified() && uni.ifindex == 0 {
+    let outgoing_label = if uni.addr.is_unspecified() && uni.ifindex().is_none() {
         "Aggregate".to_string()
     } else if uni.mpls_label.is_empty() {
         "Pop".to_string()
@@ -810,10 +800,10 @@ fn ilm_to_json(
         }
     };
 
-    let outgoing_interface = if uni.addr.is_unspecified() && uni.ifindex == 0 {
+    let outgoing_interface = if uni.addr.is_unspecified() && uni.ifindex().is_none() {
         "default".to_string()
     } else {
-        rib.link_name(uni.ifindex)
+        rib.link_name(uni.ifindex().unwrap_or(0))
     };
 
     let next_hop = if uni.addr.is_unspecified() {


### PR DESCRIPTION
## Summary

Replace the single \`ifindex: u32\` field on \`NexthopUni\` and \`GroupUni\` with two \`Option<u32>\` fields:

- \`ifindex_origin\` — what the source said (IGP adjacency, kernel dump, seg6local install, configured static).
- \`ifindex_resolved\` — what the recursive RIB walk produced when origin was None.

A new \`.ifindex()\` accessor returns origin then resolved.

The motivation: \`ifindex == 0\` was being used as a sentinel for *both* "the source didn't supply one" and "resolution didn't find one." For IGP routes the protocol always knows the egress link from the adjacency state machine, but the IPv4 path didn't propagate it, so the resolver fell back to a recursive table walk that picked the wrong interface for nexthops reachable through multiple covering routes (the classic fe80::/64 multi-link case). The recent \`efa9479\` papered over the IPv6 case with an \`ifindex != 0\` short-circuit; this commit makes the distinction explicit in the type system so the wrong-link bug can't re-emerge.

### Concretely:
- IS-IS / OSPF v4 + v6 nhop converters now write \`ifindex_origin\`.
- Kernel-dump RibBuilder writes \`ifindex_origin\` from the netlink Oif attribute.
- seg6local SID installs (sr0 / lo for End/uN, per-adjacency for End.X/uA) write \`ifindex_origin\`.
- \`GroupUni::new\` carries origin straight through; \`resolve\` / \`resolve_v6\` short-circuit on \`origin.is_some()\`, otherwise fill \`ifindex_resolved\`.
- \`resolve_nexthop_uni\` / \`_v6\` copy both halves back to the NexthopUni; origin is never overwritten.
- All show paths (text + JSON, Uni / Multi / List, IPv4 / IPv6) call \`.ifindex()\`. FIB netlink uses \`.ifindex().unwrap_or(0)\` only at the kernel boundary.

The same origin/resolved split is set up to extend to the nexthop *address* in a follow-up — multi-lookup static routes need to preserve the configured nexthop address even when recursive resolution turns up a different one.

## Test plan

- [x] \`cargo build --bin zebra-rs\`
- [x] \`cargo clippy --bin zebra-rs\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test --lib --workspace --exclude bdd\` (144 tests in zebra-rs bin pass; 8 \`test result: ok\` lines across the workspace)
- [x] Existing regression tests in \`rib/nexthop/group.rs\` rewritten to assert on the new fields. New tests added: \`group_uni_new_carries_origin_for_plain_unicast\`, \`resolve_v6_does_not_overwrite_origin\`, \`nexthopuni_ifindex_prefers_origin_over_resolved\`, \`nexthopuni_ifindex_falls_back_to_resolved_when_origin_is_none\`.
- [ ] Manual: \`show ipv6 route\` for an IS-IS-installed route with link-local nexthop reachable on multiple interfaces — interface column should match the IS-IS adjacency, not whichever connected route lands first in the table.

Generated with [Claude Code](https://claude.com/claude-code)