### PR TITLE
feat(srv6): surface SIDs in show ipv6 route and show isis route

### DIFF
--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -443,7 +443,144 @@ fn write_show_isis_route_text(isis: &Isis) -> std::result::Result<String, std::f
     if !wrote_any_level {
         writeln!(buf, "(no SPF result yet)")?;
     }
+
+    write_local_sids(&mut buf, isis)?;
+
     Ok(buf)
+}
+
+/// Append a "Local SRv6 SIDs" section. Pulls the data from existing
+/// IS-IS state — the End/uN SID off `sr_end_sid` (paired with the
+/// locator for behavior + structure) and each per-adjacency End.X/uA
+/// SID off the link's neighbor table — so we don't keep a duplicate
+/// registry on `Isis`. Empty section is suppressed entirely.
+fn write_local_sids(buf: &mut String, isis: &Isis) -> std::fmt::Result {
+    use std::net::Ipv6Addr;
+    let mut rows: Vec<LocalSidRow> = Vec::new();
+
+    // End / uN — at most one entry, derived from the configured locator.
+    if let (Some(addr), Some(locator)) = (isis.sr_end_sid, isis.sr_locator.as_ref()) {
+        let (behavior, prefix_len) = match locator.behavior {
+            Some(crate::rib::LocatorBehavior::Usid) => {
+                let plen = locator
+                    .sid_structure()
+                    .map(|s| s.lb_bits.saturating_add(s.ln_bits))
+                    .unwrap_or(128);
+                ("uN", plen)
+            }
+            None => ("End", 128),
+        };
+        let masked = mask_v6(addr, prefix_len);
+        // End / uN SIDs install on the sr0 dummy in the FIB. IS-IS
+        // doesn't track that device directly, so look it up by name in
+        // the link table — falls back to the dummy's canonical name if
+        // the netlink listener hasn't surfaced it yet.
+        let iface = isis
+            .links
+            .values()
+            .find(|l| l.state.name == crate::rib::inst::SR0_DUMMY_NAME)
+            .map(|l| l.state.name.clone())
+            .unwrap_or_else(|| crate::rib::inst::SR0_DUMMY_NAME.to_string());
+        rows.push(LocalSidRow {
+            prefix: format!("{}/{}", masked, prefix_len),
+            interface: iface,
+            nexthop: "-".to_string(),
+            action: behavior.to_string(),
+            nh6: None,
+        });
+    }
+
+    // End.X / uA — one per Up adjacency that has carved a function.
+    for level in &[Level::L1, Level::L2] {
+        for (ifindex, link) in isis.links.iter() {
+            for (_sys_id, nbr) in link.state.nbrs.get(level).iter() {
+                let Some((_, addr)) = nbr.endx_sid else {
+                    continue;
+                };
+                let behavior = match isis.sr_locator.as_ref().and_then(|l| l.behavior.as_ref()) {
+                    Some(crate::rib::LocatorBehavior::Usid) => "uA",
+                    _ => "End.X",
+                };
+                rows.push(LocalSidRow {
+                    prefix: format!("{}/128", addr),
+                    interface: isis.ifname(*ifindex),
+                    nexthop: nbr
+                        .addr6l
+                        .first()
+                        .map(|a: &Ipv6Addr| a.to_string())
+                        .unwrap_or_else(|| "-".to_string()),
+                    action: behavior.to_string(),
+                    nh6: nbr.addr6l.first().copied(),
+                });
+            }
+        }
+    }
+
+    if rows.is_empty() {
+        return Ok(());
+    }
+
+    const W_PREFIX: usize = 22;
+    const W_INTERFACE: usize = 10;
+    const W_NEXTHOP: usize = 26;
+
+    writeln!(buf)?;
+    writeln!(buf, "Local SRv6 SIDs:")?;
+    writeln!(buf)?;
+    writeln!(
+        buf,
+        " {:<wp$} {:<wi$} {:<wn$} Action",
+        "Prefix",
+        "Interface",
+        "Nexthop",
+        wp = W_PREFIX,
+        wi = W_INTERFACE,
+        wn = W_NEXTHOP,
+    )?;
+    let total = 1 + W_PREFIX + 1 + W_INTERFACE + 1 + W_NEXTHOP + 1 + 6;
+    writeln!(buf, " {}", "-".repeat(total - 2))?;
+
+    for row in rows {
+        let action = if let Some(nh6) = row.nh6 {
+            format!("seg6local {} nh6 {}", row.action, nh6)
+        } else {
+            format!("seg6local {}", row.action)
+        };
+        writeln!(
+            buf,
+            " {:<wp$} {:<wi$} {:<wn$} {}",
+            row.prefix,
+            row.interface,
+            row.nexthop,
+            action,
+            wp = W_PREFIX,
+            wi = W_INTERFACE,
+            wn = W_NEXTHOP,
+        )?;
+    }
+
+    Ok(())
+}
+
+struct LocalSidRow {
+    prefix: String,
+    interface: String,
+    nexthop: String,
+    action: String,
+    nh6: Option<std::net::Ipv6Addr>,
+}
+
+/// Zero the lower (128 - prefix_len) bits of an IPv6 address. Mirrors
+/// the helper in `rib::segment_routing::sid` so this section stays
+/// readable without pulling that helper into the public surface.
+fn mask_v6(addr: std::net::Ipv6Addr, prefix_len: u8) -> std::net::Ipv6Addr {
+    if prefix_len >= 128 {
+        return addr;
+    }
+    let bits = u128::from(addr);
+    let shift = 128 - u32::from(prefix_len);
+    let mask = !0u128 << shift;
+    std::net::Ipv6Addr::from(bits & mask)
 }
 
 /// True when local config has MT 2 (IPv6 unicast) enabled. The IPv6

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -510,7 +510,34 @@ impl Rib {
         let ifindex = sid.ifindex;
         self.fib_handle.route_sid_install(&sid, gid, ifindex).await;
 
+        // Surface the SID in the IPv6 RIB so `show ipv6 route` reflects
+        // it. We index by `Sid::prefix()` so install / uninstall keep
+        // RIB and FIB in lock-step (uN is a /(LB+LN) install; the rest
+        // are /128).
+        self.sid_rib_insert(&sid);
+
         self.sids.insert(sid.addr, sid);
+    }
+
+    /// Insert a `RibEntry` for this SID into `self.table_v6`. Replaces
+    /// any prior entry for the same prefix that was owned by a SID
+    /// (idempotent across re-installs); leaves SPF-installed entries
+    /// alone.
+    fn sid_rib_insert(&mut self, sid: &Sid) {
+        let prefix = sid.prefix();
+        let entry = sid_rib_entry(sid);
+        let entries = self.table_v6.entry(prefix).or_default();
+        entries.retain(|e| !is_seg6local_entry(e));
+        entries.push(entry);
+    }
+
+    /// Remove a previously-inserted SID `RibEntry`. Must match the same
+    /// prefix the install used.
+    fn sid_rib_remove(&mut self, sid: &Sid) {
+        let prefix = sid.prefix();
+        if let Some(entries) = self.table_v6.get_mut(&prefix) {
+            entries.retain(|e| !is_seg6local_entry(e));
+        }
     }
 
     /// Tear down a previously-installed SID. Walks back through the
@@ -520,6 +547,11 @@ impl Rib {
         let Some(sid) = self.sids.remove(&addr) else {
             return;
         };
+
+        // Drop the RIB entry first so a concurrent show doesn't see a
+        // dangling row after the kernel install is gone.
+        self.sid_rib_remove(&sid);
+
         if sid.ifindex == 0 {
             // Wasn't installed (no loopback at SidAdd time); nothing to
             // tear down on the kernel side.
@@ -944,6 +976,43 @@ impl Rib {
             }
         }
     }
+}
+
+/// Build a `RibEntry` for an allocated SID. The shape mirrors what
+/// the FIB install path would dump back from the kernel: rtype Isis
+/// (IS-IS is the only allocator today; broaden when OSPF / BGP
+/// follow), distance 115 / metric 0, and a single `Uni` nexthop
+/// carrying `seg6local_action` so the show callback can render
+/// `seg6local <action> [nh6 <addr>]`.
+fn sid_rib_entry(sid: &Sid) -> RibEntry {
+    let mut entry = RibEntry::new(RibType::Isis);
+    entry.distance = 115;
+    entry.metric = 0;
+    entry.set_valid(true);
+    entry.set_selected(true);
+    entry.set_fib(true);
+    entry.ifindex = sid.ifindex;
+
+    let addr = match sid.nh6 {
+        Some(a) => IpAddr::V6(a),
+        None => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+    };
+    entry.nexthop = Nexthop::Uni(NexthopUni {
+        addr,
+        ifindex_origin: (sid.ifindex != 0).then_some(sid.ifindex),
+        seg6local_action: Some(sid.behavior),
+        valid: true,
+        ..Default::default()
+    });
+    entry
+}
+
+/// True when this RibEntry was inserted by `sid_rib_insert` — single
+/// `Uni` nexthop with `seg6local_action` set. Lets `sid_rib_remove`
+/// scrub only its own entries when an install gets replaced or the
+/// SID is withdrawn.
+fn is_seg6local_entry(entry: &RibEntry) -> bool {
+    matches!(&entry.nexthop, Nexthop::Uni(uni) if uni.seg6local_action.is_some())
 }
 
 pub fn serve(mut rib: Rib) {

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -10,6 +10,8 @@
 use std::fmt;
 use std::net::Ipv6Addr;
 
+use ipnet::Ipv6Net;
+
 /// SRv6 endpoint behavior for an allocated SID. RFC 8986 base set plus
 /// the RFC 9800 NEXT-C-SID (uSID) variants we install today; other
 /// behaviors (End.DT4, End.DT6, End.B6, ...) extend the enum.
@@ -152,6 +154,44 @@ pub struct Sid {
     /// Partitioning of the SID's bits. Required for `UN`/`UA`; ignored
     /// for classic `End`/`EndX` (left `None`).
     pub structure: Option<SidStructure>,
+}
+
+impl Sid {
+    /// IPv6 prefix the FIB / RIB indexes this SID under. End / End.X /
+    /// uA install at /128; uN is a *prefix* install (the locator's
+    /// LB+LN portion) so the NEXT-CSID flavor matches every function
+    /// value beneath it. Returns `Ipv6Net::new(addr, 128)` as a
+    /// degenerate-fallback for uN without a SidStructure — that
+    /// shouldn't happen in practice, but a /128 keeps the FIB and RIB
+    /// in lock-step instead of one tracking the locator and the
+    /// other tracking the host address.
+    pub fn prefix(&self) -> Ipv6Net {
+        match self.behavior {
+            SidBehavior::End | SidBehavior::EndX | SidBehavior::UA => {
+                Ipv6Net::new(self.addr, 128).expect("/128 is always valid")
+            }
+            SidBehavior::UN => {
+                let plen = self
+                    .structure
+                    .map(|s| s.lb_bits.saturating_add(s.ln_bits))
+                    .unwrap_or(128);
+                let masked = mask_v6(self.addr, plen);
+                Ipv6Net::new(masked, plen)
+                    .unwrap_or_else(|_| Ipv6Net::new(self.addr, 128).expect("/128 is always valid"))
+            }
+        }
+    }
+}
+
+/// Zero the lower (128 - prefix_len) bits of `addr`.
+fn mask_v6(addr: Ipv6Addr, prefix_len: u8) -> Ipv6Addr {
+    if prefix_len >= 128 {
+        return addr;
+    }
+    let bits = u128::from(addr);
+    let shift = 128 - u32::from(prefix_len);
+    let mask = !0u128 << shift;
+    Ipv6Addr::from(bits & mask)
 }
 
 #[cfg(test)]

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -12,6 +12,7 @@ use crate::{
 
 use super::{Group, Rib, entry::RibEntry, inst::ShowCallback, link::link_show, nexthop_show};
 use std::fmt::Write;
+use std::net::IpAddr;
 use std::time::Duration;
 
 /// Format a route's age the way `show ip route` lines render it:
@@ -513,30 +514,53 @@ pub fn rib_entry_show_v6(
                 } else {
                     uni.ifindex().unwrap_or(0)
                 };
-                write!(
-                    buf,
-                    " {} {}, {}",
-                    via_word(uni),
-                    via_addr(uni),
-                    rib.link_name(ifindex)
-                )
-                .unwrap();
-                if !uni.mpls.is_empty() {
-                    write!(buf, ", label").unwrap();
-                    for mpls in uni.mpls.iter() {
-                        match mpls {
-                            Label::Implicit(label) => {
-                                write!(buf, " {} implicit-null", label).unwrap();
-                            }
-                            Label::Explicit(label) => {
-                                write!(buf, " {}", label).unwrap();
+
+                if let Some(action) = uni.seg6local_action {
+                    // SRv6 SID install. End / uN have no via address —
+                    // they're "directly connected" to the dummy device
+                    // that hosts the seg6local action. End.X / uA also
+                    // print as "directly connected" but trail with the
+                    // adjacency's link-local address as `nh6 ...` and
+                    // repeat the egress link, matching FRR.
+                    let iface = rib.link_name(ifindex);
+                    write!(
+                        buf,
+                        " is directly connected, {}, seg6local {}",
+                        iface, action
+                    )
+                    .unwrap();
+                    if let IpAddr::V6(nh6) = uni.addr
+                        && !nh6.is_unspecified()
+                    {
+                        write!(buf, " nh6 {}, {}", nh6, iface).unwrap();
+                    }
+                    writeln!(buf, ", {}", uptime).unwrap();
+                } else {
+                    write!(
+                        buf,
+                        " {} {}, {}",
+                        via_word(uni),
+                        via_addr(uni),
+                        rib.link_name(ifindex)
+                    )
+                    .unwrap();
+                    if !uni.mpls.is_empty() {
+                        write!(buf, ", label").unwrap();
+                        for mpls in uni.mpls.iter() {
+                            match mpls {
+                                Label::Implicit(label) => {
+                                    write!(buf, " {} implicit-null", label).unwrap();
+                                }
+                                Label::Explicit(label) => {
+                                    write!(buf, " {}", label).unwrap();
+                                }
                             }
                         }
                     }
+                    // Single nexthop — no `weight` column. ECMP prints it
+                    // per leg below.
+                    writeln!(buf, ", {}", uptime).unwrap();
                 }
-                // Single nexthop — no `weight` column. ECMP prints it
-                // per leg below.
-                writeln!(buf, ", {}", uptime).unwrap();
             }
             Nexthop::Multi(multi) => {
                 for (i, uni) in multi.nexthops.iter().enumerate() {


### PR DESCRIPTION
## Summary

Locally-allocated SRv6 SIDs were only visible via \`show segment-routing srv6 sid\`. Mirror what FRR does so they also appear in:

- **\`show ipv6 route\`**: SID-owned rows render \`I>* <prefix> [115/0] is directly connected, <iface>, seg6local <action> [nh6 <addr>, <iface>], <uptime>\`. End / uN show with \`<iface>=sr0\` and no nh6; End.X / uA show with the adjacency's link and trail with \`nh6 <link-local>, <iface>\` (matches the FRR examples in the request).
- **\`show isis route\`**: a "Local SRv6 SIDs" section at the end with prefix / interface / nexthop / action columns. Driven entirely by existing state (\`sr_end_sid\` + per-link \`nbr.endx_sid\`), no duplicate SID registry on \`Isis\`.

### Mechanics

- \`Sid::prefix()\` derives the IPv6Net the FIB/RIB index this SID under — \`/128\` for End/End.X/uA, \`/(LB+LN)\` for uN. Keeps install / uninstall in lock-step without exposing the FIB-internal \`sid_route_target\` helper.
- \`Rib::sid_install\` also pushes a \`RibEntry\` (rtype=Isis, distance=115, metric=0, single Uni nexthop with \`seg6local_action\` + \`nh6\` + ifindex) into \`self.table_v6\`. \`sid_uninstall\` removes it. \`is_seg6local_entry\` discriminates so re-installs scrub only their own row, leaving SPF-installed entries alone.
- \`rib_entry_show_v6\` renders \`seg6local <action> [nh6 <addr>, <iface>]\` when \`uni.seg6local_action.is_some()\`.

## Test plan

- [x] \`cargo build --bin zebra-rs\`
- [x] \`cargo clippy --bin zebra-rs\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test --lib --workspace --exclude bdd\`
- [ ] Manual: with the user's uSID config (locator \`fcbb:bbbb:1::/48\`, IS-IS up on a couple of links), \`show ipv6 route\` shows \`I>* fcbb:bbbb:1::/48 ... seg6local uN\` and one \`I>* <prefix>/128 ... seg6local uA nh6 ...\` per adjacency. \`show isis route\` ends with a "Local SRv6 SIDs" table listing the same.
- [ ] Manual: classic-locator config (no \`behavior usid\`) shows the same with \`End\` / \`End.X\`.

Generated with [Claude Code](https://claude.com/claude-code)