### PR TITLE
fix(config): match_ipv6_net accepts ::/0 and friends

### DIFF
--- a/zebra-rs/src/config/ip.rs
+++ b/zebra-rs/src/config/ip.rs
@@ -166,8 +166,14 @@ pub fn match_ipv6_prefix(s: &str, prefix: bool) -> (MatchType, usize) {
                     if bytes.get(i + 1) != Some(&b':') {
                         return (MatchType::None, i);
                     }
+                    // Initial `::`. Skip straight to Double so the
+                    // second `:` runs through the double-colon
+                    // transition (which knows how to handle `/`,
+                    // `\0`, and a following hex segment). Going via
+                    // Colon would re-trigger the single-colon
+                    // lookahead and reject `::/0` / `::/128`.
                     colons = colons.saturating_sub(1);
-                    state = Colon;
+                    state = Double;
                 } else {
                     segment_start = Some(i);
                     state = Addr;
@@ -285,4 +291,52 @@ pub fn match_ipv6_addr(src: &str) -> (MatchType, usize) {
 
 pub fn match_ipv6_net(src: &str) -> (MatchType, usize) {
     match_ipv6_prefix(src, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ipv6_net_default_route_is_partial() {
+        // ::/0 used to be rejected because the state machine ran the
+        // second `:` of `::` through the Colon state, whose lookahead
+        // explicitly errors on `/`. Default route is a perfectly valid
+        // input and must complete cleanly.
+        let (m, _) = match_ipv6_net("::/0");
+        assert_eq!(m, MatchType::Partial);
+    }
+
+    #[test]
+    fn ipv6_net_double_colon_with_mask_is_partial() {
+        // Same shape, larger mask values.
+        for input in ["::/64", "::/128"] {
+            let (m, _) = match_ipv6_net(input);
+            assert_eq!(m, MatchType::Partial, "{input} should match");
+        }
+    }
+
+    #[test]
+    fn ipv6_net_double_colon_segment_then_mask_still_works() {
+        // Regression: the standard `2001:db8::/64` and similar shapes
+        // shouldn't have changed.
+        let (m, _) = match_ipv6_net("2001:db8::/64");
+        assert_eq!(m, MatchType::Partial);
+    }
+
+    #[test]
+    fn ipv6_addr_double_colon_only_is_partial() {
+        // Bare `::` (the all-zeros address) parses cleanly in addr
+        // mode.
+        let (m, _) = match_ipv6_addr("::");
+        assert_eq!(m, MatchType::Partial);
+    }
+
+    #[test]
+    fn ipv6_net_single_colon_then_slash_is_still_rejected() {
+        // The old Colon-state guard was meant to reject this pattern
+        // and should keep doing so.
+        let (m, _) = match_ipv6_net("2001:/64");
+        assert_eq!(m, MatchType::None);
+    }
 }

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -869,9 +869,10 @@ impl FibHandle {
         while let Some(msg) = response.next().await {
             if let NetlinkPayload::Error(e) = msg.payload {
                 tracing::info!(
-                    "DelNexthop error: {e} gid: {gid} refcnt: {refcnt}",
+                    "DelNexthop error: {e} gid: {gid} refcnt: {refcnt} nhop: {nexthop:?}",
                     gid = nexthop.gid(),
-                    refcnt = nexthop.refcnt()
+                    refcnt = nexthop.refcnt(),
+                    nexthop = nexthop,
                 );
             }
         }


### PR DESCRIPTION
## Summary

\`match_ipv6_net\` was rejecting \`::/0\` (and \`::/64\`, \`::/128\`, etc.). The state machine ran the second \`:\` of an initial \`::\` through the \`Colon\` state, whose explicit \`Some(&b'/')\` lookahead — meant to reject single-colon-then-slash like \`2001:/64\` — also clobbered the valid \`::/N\` shape.

Skip \`Colon\` and transition straight to \`Double\` when the input begins with \`::\`. The \`Double\` state already handles every following byte correctly (\`\\0\`, \`:\`, \`/\`, hex segment), and the bad single-colon-then-slash pattern still goes through \`Colon\` and is still rejected.

Adds five unit tests in \`zebra-rs/src/config/ip.rs\` — \`::/0\`, \`::/64\`, \`::/128\`, bare \`::\`, and the \`2001:/64\`-still-rejected guard.

Also picks up a small log tweak in \`fib/netlink/handle.rs\` that was sitting in the working tree from earlier SID debugging — \`DelNexthop\` errors now include the nexthop's debug repr so the failing group is identifiable in logs.

## Test plan

- [x] \`cargo test --bin zebra-rs config::ip\` — all five new tests pass
- [x] \`cargo build --bin zebra-rs\`
- [x] \`cargo clippy --bin zebra-rs\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test --lib --workspace --exclude bdd\`
- [ ] Manual: configure a static route with \`route ::/0 ...\` in the CLI; should accept the prefix instead of erroring on the leading \`::\`.

Generated with [Claude Code](https://claude.com/claude-code)