### PR TITLE
feat(srv6): static IPv6 routes with seg6local terminal action

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -44,14 +44,14 @@ use crate::rib::{
 };
 
 // Flip to true to re-enable IPv6 FIB install diagnostic prints.
-const DEBUG_V6: bool = false;
+const DEBUG_V6: bool = true;
 
 // Flip to true to log every SRv6 SID FIB install / uninstall — the
 // pre-send netlink attribute dump for the seg6local route, the
 // nexthop-skip notice, and the rib-side resolution trace. Errors from
 // the kernel are reported regardless. Mirrored by RIB via this same
 // constant (re-exported as `crate::fib::netlink::handle::DEBUG_SID`).
-pub const DEBUG_SID: bool = false;
+pub const DEBUG_SID: bool = true;
 
 /// Mask the lower (128 - prefix_len) bits of an IPv6 address. The
 /// kernel ignores bits past the prefix length on install, but masking

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -115,6 +115,13 @@ fn sid_route_target(
             )
         }
         SidBehavior::UA => (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr),
+        // End.DT4 / End.DT6 are terminal decap+lookup actions. Same
+        // FIB shape as End.X — a /128 host route in table=main with
+        // kind=Unicast, pointed at sr0 by the static route's
+        // ifindex_origin.
+        SidBehavior::EndDT4 | SidBehavior::EndDT6 => {
+            (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr)
+        }
     }
 }
 
@@ -434,6 +441,41 @@ impl FibHandle {
         let attr = RouteAttribute::Destination(RouteAddress::Inet6(prefix.addr()));
         msg.attributes.push(attr);
 
+        // Seg6local install (operator-configured End.DT6 / End.DT4 /
+        // End / uN on a static IPv6 prefix). The seg6local lwtunnel
+        // encap can't ride in the kernel nexthop table, so we always
+        // embed it on the route — independently of `use_nhid`. The
+        // protocol-allocated SID install path goes through
+        // `route_sid_install`, which has the same shape; this branch
+        // is the static counterpart so user-configured action routes
+        // travel the standard `Message::Ipv6Add` pipeline.
+        if let Nexthop::Uni(uni) = &nexthop
+            && let Some(action) = uni.seg6local_action
+        {
+            if let Some(ifindex) = uni.ifindex() {
+                msg.attributes.push(RouteAttribute::Oif(ifindex));
+            }
+            if let Some((encap, encap_type)) =
+                super::srv6::build_seg6local_attrs(action, None, None)
+            {
+                msg.attributes.push(encap);
+                msg.attributes.push(encap_type);
+            }
+            msg.attributes.push(RouteAttribute::Priority(uni.metric));
+
+            let mut req = NetlinkMessage::from(RouteNetlinkMessage::NewRoute(msg));
+            req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE;
+            let mut response = self.handle.clone().request(req).unwrap();
+            while let Some(m) = response.next().await {
+                if let NetlinkPayload::Error(e) = m.payload {
+                    tracing::warn!(
+                        "NewRoute seg6local install error: prefix={prefix} action={action:?} err={e}"
+                    );
+                }
+            }
+            return;
+        }
+
         if self.use_nhid {
             if let Nexthop::Uni(uni) = &nexthop {
                 if DEBUG_V6 {
@@ -589,6 +631,29 @@ impl FibHandle {
 
         let attr = RouteAttribute::Priority(entry.metric);
         msg.attributes.push(attr);
+
+        // Mirror the seg6local install: when the route was a
+        // seg6local route, the kernel matches del on
+        // {prefix, table, kind} alone — no encap attrs needed in
+        // the del message. Sending the Oif still helps when the
+        // user has stacked multiple actions on the same prefix
+        // (rare, but harmless to include).
+        if let Nexthop::Uni(uni) = &nexthop
+            && uni.seg6local_action.is_some()
+        {
+            if let Some(ifindex) = uni.ifindex() {
+                msg.attributes.push(RouteAttribute::Oif(ifindex));
+            }
+            let mut req = NetlinkMessage::from(RouteNetlinkMessage::DelRoute(msg));
+            req.header.flags = NLM_F_REQUEST | NLM_F_ACK;
+            let mut response = self.handle.clone().request(req).unwrap();
+            while let Some(m) = response.next().await {
+                if let NetlinkPayload::Error(e) = m.payload {
+                    tracing::warn!("DelRoute seg6local error: prefix={prefix} err={e}");
+                }
+            }
+            return;
+        }
 
         if self.use_nhid {
             if let Nexthop::Uni(uni) = &nexthop {

--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -122,12 +122,15 @@ fn build_seg6local_flavors(
 //
 // End / uN needs only the Action attribute (uN additionally carries a
 // Flavors block). End.X / uA also nests Nh6 (the IPv6 nexthop).
-// End.DT4 / End.DT6 nest a VrfTable id — the kernel rejects the
-// install with EINVAL otherwise. We default to RT_TABLE_MAIN since
-// zebra-rs doesn't model VRFs yet; once it does, the operator-set
-// table id flows through here. The kernel's required oif rides on
-// the outer route / nexthop message rather than inside the encap,
-// so we don't add it here.
+// End.DT4 / End.DT6 nest a Table id — `iproute2`'s `table N` keyword,
+// `SEG6_LOCAL_TABLE` on the wire — telling the kernel which IPv4 /
+// IPv6 fib to look up the decapsulated inner packet in. We default
+// to RT_TABLE_MAIN; once zebra-rs grows VRF support, the operator-
+// set table id flows through here. (End.DT46 is the dual-family
+// variant and uses `SEG6_LOCAL_VRFTABLE` instead — not modeled
+// yet.) The kernel's required oif rides on the outer route /
+// nexthop message rather than inside the encap, so we don't add it
+// here.
 //
 // Returns None when the operator hasn't supplied the data End.X / uA
 // needs (no IPv6 nexthop) — caller treats that as "skip FIB install
@@ -145,7 +148,7 @@ fn build_seg6local_lwtunnel(
         attrs.push(RouteSeg6LocalIpTunnel::Nh6(nh));
     }
     if matches!(behavior, SidBehavior::EndDT4 | SidBehavior::EndDT6) {
-        attrs.push(RouteSeg6LocalIpTunnel::VrfTable(
+        attrs.push(RouteSeg6LocalIpTunnel::Table(
             RouteHeader::RT_TABLE_MAIN as u32,
         ));
     }

--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -78,11 +78,17 @@ pub fn build_seg6_attrs(
 
 // Map a SidBehavior to its kernel SEG6_LOCAL_ACTION_*. uSID variants
 // reuse the same kernel actions as their classic counterparts; the
-// NEXT-C-SID flavor rides as a separate Flavors attribute.
+// NEXT-C-SID flavor rides as a separate Flavors attribute. End.DT4 /
+// End.DT6 today install without an explicit table-id arg — the
+// kernel uses the route's own table, which is good enough for
+// statically configured terminals; richer table selection is a
+// follow-up.
 fn seg6local_action(behavior: SidBehavior) -> Seg6LocalAction {
     match behavior {
         SidBehavior::End | SidBehavior::UN => Seg6LocalAction::End,
         SidBehavior::EndX | SidBehavior::UA => Seg6LocalAction::EndX,
+        SidBehavior::EndDT4 => Seg6LocalAction::EndDt4,
+        SidBehavior::EndDT6 => Seg6LocalAction::EndDt6,
     }
 }
 

--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -6,9 +6,9 @@ use std::net::Ipv6Addr;
 use anyhow::{Result, bail};
 use isis_packet::srv6::EncapType;
 use netlink_packet_route::route::{
-    Ipv6SrHdr, RouteAttribute, RouteLwEnCapType, RouteLwTunnelEncap, RouteSeg6IpTunnel,
-    RouteSeg6LocalIpTunnel, Seg6IpTunnelEncap, Seg6IpTunnelMode, Seg6LocalAction,
-    Seg6LocalFlavorOps, Seg6LocalFlavors, VecIpv6SrHdr,
+    Ipv6SrHdr, RouteAttribute, RouteHeader, RouteLwEnCapType, RouteLwTunnelEncap,
+    RouteSeg6IpTunnel, RouteSeg6LocalIpTunnel, Seg6IpTunnelEncap, Seg6IpTunnelMode,
+    Seg6LocalAction, Seg6LocalFlavorOps, Seg6LocalFlavors, VecIpv6SrHdr,
 };
 
 use crate::rib::{SidBehavior, SidStructure};
@@ -121,9 +121,13 @@ fn build_seg6local_flavors(
 // Build the inner Vec<RouteLwTunnelEncap> for a seg6local install.
 //
 // End / uN needs only the Action attribute (uN additionally carries a
-// Flavors block). End.X / uA also nests Nh6 (the IPv6 nexthop). The
-// kernel's required oif rides on the outer route / nexthop message
-// rather than inside the encap, so we don't add it here.
+// Flavors block). End.X / uA also nests Nh6 (the IPv6 nexthop).
+// End.DT4 / End.DT6 nest a VrfTable id — the kernel rejects the
+// install with EINVAL otherwise. We default to RT_TABLE_MAIN since
+// zebra-rs doesn't model VRFs yet; once it does, the operator-set
+// table id flows through here. The kernel's required oif rides on
+// the outer route / nexthop message rather than inside the encap,
+// so we don't add it here.
 //
 // Returns None when the operator hasn't supplied the data End.X / uA
 // needs (no IPv6 nexthop) — caller treats that as "skip FIB install
@@ -139,6 +143,11 @@ fn build_seg6local_lwtunnel(
     if matches!(behavior, SidBehavior::EndX | SidBehavior::UA) {
         let nh = nh6?;
         attrs.push(RouteSeg6LocalIpTunnel::Nh6(nh));
+    }
+    if matches!(behavior, SidBehavior::EndDT4 | SidBehavior::EndDT6) {
+        attrs.push(RouteSeg6LocalIpTunnel::VrfTable(
+            RouteHeader::RT_TABLE_MAIN as u32,
+        ));
     }
     if let Some(flavors) = build_seg6local_flavors(behavior, structure) {
         attrs.push(flavors);

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -399,20 +399,30 @@ impl Rib {
     }
 
     /// Resolve the device the kernel binds the seg6local action to,
-    /// per behavior. End and uN are local-processing actions; both ride
-    /// on the sr0 dummy so the install can stay in table=main +
-    /// kind=Unicast. End.X and uA already run on the actual outgoing
-    /// interface and never hit this path.
-    fn resolve_sid_ifindex(&self, behavior: SidBehavior) -> Option<u32> {
+    /// per behavior. End / uN / End.DT4 / End.DT6 are local-processing
+    /// actions; all four ride on the sr0 dummy so the install can stay
+    /// in table=main + kind=Unicast. End.X / uA already run on the
+    /// actual outgoing interface and never hit this path.
+    pub fn resolve_sid_ifindex(&self, behavior: SidBehavior) -> Option<u32> {
         match behavior {
-            SidBehavior::End | SidBehavior::UN => self
-                .links
-                .values()
-                .find(|link| link.name == SR0_DUMMY_NAME)
-                .map(|link| link.index)
-                .or_else(|| self.resolve_lo_ifindex()),
+            SidBehavior::End | SidBehavior::UN | SidBehavior::EndDT4 | SidBehavior::EndDT6 => {
+                self.resolve_sr0_ifindex()
+            }
             _ => self.resolve_lo_ifindex(),
         }
+    }
+
+    /// Look up the sr0 dummy by name, falling back to lo when sr0 isn't
+    /// in the link table yet (early startup). Pulled out of
+    /// `resolve_sid_ifindex` so the message handlers can reach it
+    /// directly when filling in `ifindex_origin` for static
+    /// seg6local routes.
+    fn resolve_sr0_ifindex(&self) -> Option<u32> {
+        self.links
+            .values()
+            .find(|link| link.name == SR0_DUMMY_NAME)
+            .map(|link| link.index)
+            .or_else(|| self.resolve_lo_ifindex())
     }
 
     /// Make sure the sr0 dummy interface exists and is up. Called once

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -325,6 +325,20 @@ impl Rib {
                 entry.is_valid(),
             );
         }
+
+        // Static seg6local routes (action End.DT6 / End.DT4 / End / uN
+        // configured on a prefix) arrive without an ifindex — the
+        // config callback doesn't have access to the link table. Pin
+        // the install to sr0 here so resolve_v6 short-circuits and
+        // the FIB layer emits the right Oif.
+        if let Nexthop::Uni(uni) = &mut entry.nexthop
+            && let Some(action) = uni.seg6local_action
+            && uni.ifindex_origin.is_none()
+            && let Some(ifindex) = self.resolve_sid_ifindex(action)
+        {
+            uni.ifindex_origin = Some(ifindex);
+        }
+
         if entry.is_protocol() {
             let mut replace = rib_replace_v6(&mut self.table_v6, prefix, entry.rtype);
             rib_resolve_nexthop_v6(&mut entry, &self.table_v6, &mut self.nmap);

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -9,6 +9,7 @@
 
 use std::fmt;
 use std::net::Ipv6Addr;
+use std::str::FromStr;
 
 use ipnet::Ipv6Net;
 
@@ -38,6 +39,14 @@ pub enum SidBehavior {
     /// forwarding as End.X with the additional uSID shift; carries a
     /// [`SidStructure`].
     UA,
+    /// End.DT4 — RFC 8986 §4.6. Decapsulates and looks up the inner
+    /// IPv4 packet in a configured table. Today only operator-
+    /// configured static routes use it; the table-id arg isn't
+    /// modeled yet (always uses the route's table at install time).
+    EndDT4,
+    /// End.DT6 — RFC 8986 §4.7. Decapsulates and looks up the inner
+    /// IPv6 packet in a configured table. Same caveat as End.DT4.
+    EndDT6,
 }
 
 impl fmt::Display for SidBehavior {
@@ -47,9 +56,41 @@ impl fmt::Display for SidBehavior {
             Self::EndX => write!(f, "End.X"),
             Self::UN => write!(f, "uN"),
             Self::UA => write!(f, "uA"),
+            Self::EndDT4 => write!(f, "End.DT4"),
+            Self::EndDT6 => write!(f, "End.DT6"),
         }
     }
 }
+
+impl FromStr for SidBehavior {
+    type Err = SidBehaviorParseError;
+
+    /// Accept the canonical `Display` strings used in the YANG enum.
+    /// Case-sensitive — keep operator config matching the spec
+    /// spelling rather than papering over typos.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "End" => Ok(Self::End),
+            "End.X" => Ok(Self::EndX),
+            "uN" => Ok(Self::UN),
+            "uA" => Ok(Self::UA),
+            "End.DT4" => Ok(Self::EndDT4),
+            "End.DT6" => Ok(Self::EndDT6),
+            other => Err(SidBehaviorParseError(other.to_string())),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SidBehaviorParseError(pub String);
+
+impl fmt::Display for SidBehaviorParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown SRv6 endpoint behavior: {:?}", self.0)
+    }
+}
+
+impl std::error::Error for SidBehaviorParseError {}
 
 /// SRv6 SID Structure (RFC 9352 §9): how the 128-bit SID is partitioned
 /// into Locator-Block / Locator-Node / Function / Argument bits.
@@ -167,9 +208,11 @@ impl Sid {
     /// other tracking the host address.
     pub fn prefix(&self) -> Ipv6Net {
         match self.behavior {
-            SidBehavior::End | SidBehavior::EndX | SidBehavior::UA => {
-                Ipv6Net::new(self.addr, 128).expect("/128 is always valid")
-            }
+            SidBehavior::End
+            | SidBehavior::EndX
+            | SidBehavior::UA
+            | SidBehavior::EndDT4
+            | SidBehavior::EndDT6 => Ipv6Net::new(self.addr, 128).expect("/128 is always valid"),
             SidBehavior::UN => {
                 let plen = self
                     .structure
@@ -202,6 +245,32 @@ mod tests {
     fn behavior_render_matches_show_table() {
         assert_eq!(SidBehavior::End.to_string(), "End");
         assert_eq!(SidBehavior::EndX.to_string(), "End.X");
+        assert_eq!(SidBehavior::EndDT4.to_string(), "End.DT4");
+        assert_eq!(SidBehavior::EndDT6.to_string(), "End.DT6");
+    }
+
+    #[test]
+    fn behavior_round_trips_from_str() {
+        // The static route YANG enum and the Display strings must stay
+        // in sync — every value the YANG accepts must parse back.
+        for variant in [
+            SidBehavior::End,
+            SidBehavior::EndX,
+            SidBehavior::UN,
+            SidBehavior::UA,
+            SidBehavior::EndDT4,
+            SidBehavior::EndDT6,
+        ] {
+            let s = variant.to_string();
+            let parsed: SidBehavior = s.parse().expect("round-trip");
+            assert_eq!(parsed, variant);
+        }
+    }
+
+    #[test]
+    fn behavior_unknown_string_is_error() {
+        assert!("End.DT1".parse::<SidBehavior>().is_err());
+        assert!("end".parse::<SidBehavior>().is_err()); // case-sensitive
     }
 
     #[test]

--- a/zebra-rs/src/rib/static/config.rs
+++ b/zebra-rs/src/rib/static/config.rs
@@ -11,7 +11,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::config::{Args, ConfigOp};
 use crate::rib::entry::RibEntry;
-use crate::rib::{Message, RibType};
+use crate::rib::{Message, RibType, SidBehavior};
 
 use super::StaticRoute;
 
@@ -363,6 +363,19 @@ fn config_builder<F: StaticFamily>() -> ConfigBuilder<F> {
         .del(|config, cache, prefix, _args| {
             let s = cache_lookup::<F>(config, cache, prefix).context(CONFIG_ERR)?;
             s.encap_type = None;
+            Ok(())
+        })
+        .path(&format!("/routing/static/{}/route/action", F::FAMILY))
+        .set(|config, cache, prefix, args| {
+            const ACTION_ERR: &str = "missing seg6local action arg";
+            let s = cache_get::<F>(config, cache, prefix).context(CONFIG_ERR)?;
+            let arg = args.string().context(ACTION_ERR)?;
+            s.seg6local_action = Some(arg.parse::<SidBehavior>()?);
+            Ok(())
+        })
+        .del(|config, cache, prefix, _args| {
+            let s = cache_lookup::<F>(config, cache, prefix).context(CONFIG_ERR)?;
+            s.seg6local_action = None;
             Ok(())
         })
 }

--- a/zebra-rs/src/rib/static/route.rs
+++ b/zebra-rs/src/rib/static/route.rs
@@ -8,7 +8,7 @@ use isis_packet::srv6::EncapType;
 
 use crate::rib::entry::RibEntry;
 use crate::rib::nexthop::{Label, NexthopUni};
-use crate::rib::{Nexthop, NexthopList, NexthopMulti, RibType};
+use crate::rib::{Nexthop, NexthopList, NexthopMulti, RibType, SidBehavior};
 
 use super::config::StaticFamily;
 
@@ -25,6 +25,12 @@ pub struct StaticRoute<F: StaticFamily> {
     pub nexthops: BTreeMap<F::Addr, StaticNexthop>,
     pub segs: Vec<Ipv6Addr>,
     pub encap_type: Option<EncapType>,
+    /// SRv6 terminal action (`seg6local`) bound to this prefix —
+    /// e.g. End.DT6 for an inner-IPv6 decap-and-lookup. Mutually
+    /// exclusive with `segs`/`nexthops`; when set, `to_entry`
+    /// produces a Uni nexthop that the FIB installs as a kernel
+    /// `seg6local` route on the sr0 dummy.
+    pub seg6local_action: Option<SidBehavior>,
     pub delete: bool,
 }
 
@@ -36,6 +42,7 @@ impl<F: StaticFamily> Default for StaticRoute<F> {
             nexthops: BTreeMap::new(),
             segs: Vec::new(),
             encap_type: None,
+            seg6local_action: None,
             delete: false,
         }
     }
@@ -49,6 +56,7 @@ impl<F: StaticFamily> Clone for StaticRoute<F> {
             nexthops: self.nexthops.clone(),
             segs: self.segs.clone(),
             encap_type: self.encap_type,
+            seg6local_action: self.seg6local_action,
             delete: self.delete,
         }
     }
@@ -65,6 +73,7 @@ where
             .field("nexthops", &self.nexthops)
             .field("segs", &self.segs)
             .field("encap_type", &self.encap_type)
+            .field("seg6local_action", &self.seg6local_action)
             .field("delete", &self.delete)
             .finish()
     }
@@ -72,7 +81,7 @@ where
 
 impl<F: StaticFamily> StaticRoute<F> {
     pub fn to_entry(&self) -> Option<RibEntry> {
-        if self.nexthops.is_empty() && self.segs.is_empty() {
+        if self.nexthops.is_empty() && self.segs.is_empty() && self.seg6local_action.is_none() {
             return None;
         }
 
@@ -80,6 +89,33 @@ impl<F: StaticFamily> StaticRoute<F> {
         entry.distance = self.distance.unwrap_or(1);
 
         let metric = self.metric.unwrap_or(0);
+
+        if let Some(action) = self.seg6local_action {
+            // Terminal seg6local action (End.DT6 etc.). The address
+            // doesn't matter for End/uN/EndDT4/EndDT6 — the action
+            // doesn't forward, it just decaps + looks up. End.X /
+            // uA also need a per-adjacency nh6, which the YANG
+            // doesn't model yet; the YANG enum description warns
+            // operators away from those for now.
+            //
+            // ifindex_origin is left None here; the RIB sets it to
+            // the sr0 dummy in `Rib::ipv6_route_add` once the
+            // request lands on the RIB-side processor (which has
+            // access to the link table). Doing it here would need
+            // a separate shared-state reference into the static
+            // commit pipeline, which isn't worth it for a one-line
+            // fill-in.
+            let nhop = NexthopUni {
+                addr: IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+                metric,
+                weight: 1,
+                seg6local_action: Some(action),
+                ..Default::default()
+            };
+            entry.nexthop = Nexthop::Uni(nhop);
+            entry.metric = metric;
+            return Some(entry);
+        }
 
         if !self.segs.is_empty() {
             // SRv6 H.Encap (RFC 8986 §5.1): outer destination is the first
@@ -331,5 +367,36 @@ mod tests {
         let uni = as_uni(&entry);
         assert_eq!(uni.addr, IpAddr::V6(seg("fd00:c::")));
         assert!(!uni.segs.is_empty());
+    }
+
+    #[test]
+    fn seg6local_action_alone_produces_entry() {
+        // No nexthops, no segs — just an action. Must still build a
+        // RibEntry (the FIB will install a kernel seg6local route).
+        let r = StaticRoute::<V4> {
+            seg6local_action: Some(SidBehavior::EndDT6),
+            ..Default::default()
+        };
+        let entry = r.to_entry().expect("entry built");
+        let uni = as_uni(&entry);
+        assert_eq!(uni.seg6local_action, Some(SidBehavior::EndDT6));
+        assert_eq!(uni.addr, IpAddr::V6(Ipv6Addr::UNSPECIFIED));
+        assert!(uni.segs.is_empty());
+        assert_eq!(uni.ifindex_origin, None); // RIB fills sr0 in ipv6_route_add
+    }
+
+    #[test]
+    fn seg6local_action_takes_priority_over_segs() {
+        // If both action and segs are configured, action wins —
+        // they're alternative encap models on the same prefix.
+        let r = StaticRoute::<V4> {
+            seg6local_action: Some(SidBehavior::EndDT6),
+            segs: vec![seg("fd00:c::")],
+            ..Default::default()
+        };
+        let entry = r.to_entry().expect("entry built");
+        let uni = as_uni(&entry);
+        assert_eq!(uni.seg6local_action, Some(SidBehavior::EndDT6));
+        assert!(uni.segs.is_empty());
     }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -702,6 +702,24 @@ module config {
                 enum "H.Encap.Red";
               }
             }
+            leaf action {
+              description
+                "SRv6 endpoint behavior installed as a seg6local
+                 terminal action on this prefix. Mutually exclusive
+                 with `segments` (which configures an outer H.Encap
+                 push). Only the local-action variants — End, uN,
+                 End.DT4, End.DT6 — are usable today; End.X / uA
+                 require a per-adjacency nexthop that this list
+                 doesn't model yet.";
+              type enumeration {
+                enum "End";
+                enum "End.X";
+                enum "uN";
+                enum "uA";
+                enum "End.DT4";
+                enum "End.DT6";
+              }
+            }
           }
         }
 


### PR DESCRIPTION
## Summary

Add support for operator-configured SRv6 terminal actions on static IPv6 routes, matching FRR's CLI shape:

\`\`\`
static {
  ipv6 {
    route fcbb:bbbb:3:fe00::/128 {
      action End.DT6;
    }
  }
}
\`\`\`

The FIB installs as \`ip -6 route add ... encap seg6local action <action> [table | nh6 ...] dev sr0\`. Primary use case is End.DT6 / End.DT4 (decap-and-lookup); the full local-action set (End, uN, End.DT4, End.DT6) is also accepted via the same enum, with End.X / uA explicitly out of scope (need a per-adjacency nh6 the YANG doesn't model yet).

### Wires
- \`SidBehavior\` gains \`EndDT4\` / \`EndDT6\` variants + Display + \`FromStr\` (case-sensitive on the canonical spec spellings).
- FIB seg6local mapper covers the DT variants and \`sid_route_target\` extends to their \`(table=main, kind=Unicast, /128)\` shape.
- New \`leaf action\` under \`/routing/static/{ipv4,ipv6}/route/\` and matching set/del callbacks.
- \`StaticRoute.seg6local_action: Option<SidBehavior>\` populated by the callback; \`to_entry\` builds a Uni nexthop with the action set, takes priority over segs.
- \`Rib::ipv6_route_add\` fills \`ifindex_origin\` from sr0 (via \`resolve_sid_ifindex\`, extended to cover DT4/DT6) when an incoming entry has a seg6local action and no origin yet — bridges the static-config side to the link table.
- \`route_ipv6_add_uni\` / \`route_ipv6_del_uni\` get a seg6local arm that embeds the encap on the route (kernel doesn't accept seg6local in nh_id) regardless of \`use_nhid\`. Protocol-allocated SIDs continue to flow through \`route_sid_install\`.
- End.DT4 / End.DT6 nest \`SEG6_LOCAL_TABLE\` (RT_TABLE_MAIN by default) — without it the kernel rejects with EINVAL. \`SEG6_LOCAL_VRFTABLE\` is the End.DT46 attribute and is left for when zebra-rs grows VRF support.

### Tests
- \`SidBehavior\` round-trips through \`to_string()\` / \`from_str()\` for every variant; unknown strings produce a typed error.
- \`StaticRoute::to_entry\` with action alone produces a valid entry; action-with-segs honors the action.

## Test plan

- [x] \`cargo build --bin zebra-rs\`
- [x] \`cargo clippy --bin zebra-rs\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test --lib --workspace --exclude bdd\`
- [x] Manual: \`set routing static ipv6 route fcbb:bbbb:3:fe10::/128 action End.DT6\` installs in the kernel; \`ip -6 route show fcbb:bbbb:3:fe10::/128\` reports \`encap seg6local action End.DT6 table 254 dev sr0\`.

Generated with [Claude Code](https://claude.com/claude-code)