### PR TITLE
chore(fib): disable DEBUG_V6 / DEBUG_SID in main

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -44,14 +44,14 @@ use crate::rib::{
 };
 
 // Flip to true to re-enable IPv6 FIB install diagnostic prints.
-const DEBUG_V6: bool = true;
+const DEBUG_V6: bool = false;
 
 // Flip to true to log every SRv6 SID FIB install / uninstall — the
 // pre-send netlink attribute dump for the seg6local route, the
 // nexthop-skip notice, and the rib-side resolution trace. Errors from
 // the kernel are reported regardless. Mirrored by RIB via this same
 // constant (re-exported as `crate::fib::netlink::handle::DEBUG_SID`).
-pub const DEBUG_SID: bool = true;
+pub const DEBUG_SID: bool = false;
 
 /// Mask the lower (128 - prefix_len) bits of an IPv6 address. The
 /// kernel ignores bits past the prefix length on install, but masking


### PR DESCRIPTION
## Summary

These two compile-time flags slipped into a previous merged commit at \`true\` (caught while merging #363). They're meant to ship as \`false\`; flip them back. Operators who need the SID install / IPv6 FIB tracing can flip locally for one-off investigations.

## Test plan

- [x] \`cargo build --bin zebra-rs\`

Generated with [Claude Code](https://claude.com/claude-code)