### PR TITLE
fix(rib): sync FIB on interface down/up

### DIFF
--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -821,17 +821,29 @@ impl Rib {
                 // LinkAddr is already present for this address, the merge in
                 // link_addr_update will flip its `fib` flag to true.
                 self.addr_add(addr, false);
-                ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.fib_handle).await;
+                ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.links, &self.fib_handle).await;
                 ipv4_route_sync(&mut self.table, &mut self.nmap, &self.fib_handle, true).await;
-                ipv6_nexthop_sync(&mut self.nmap, &self.table_v6, &self.fib_handle).await;
+                ipv6_nexthop_sync(
+                    &mut self.nmap,
+                    &self.table_v6,
+                    &self.links,
+                    &self.fib_handle,
+                )
+                .await;
                 ipv6_route_sync(&mut self.table_v6, &mut self.nmap, &self.fib_handle).await;
                 self.router_id_update();
             }
             FibMessage::DelAddr(addr) => {
                 self.addr_del(addr);
-                ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.fib_handle).await;
+                ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.links, &self.fib_handle).await;
                 ipv4_route_sync(&mut self.table, &mut self.nmap, &self.fib_handle, true).await;
-                ipv6_nexthop_sync(&mut self.nmap, &self.table_v6, &self.fib_handle).await;
+                ipv6_nexthop_sync(
+                    &mut self.nmap,
+                    &self.table_v6,
+                    &self.links,
+                    &self.fib_handle,
+                )
+                .await;
                 ipv6_route_sync(&mut self.table_v6, &mut self.nmap, &self.fib_handle).await;
                 self.router_id_update();
             }

--- a/zebra-rs/src/rib/nexthop/group.rs
+++ b/zebra-rs/src/rib/nexthop/group.rs
@@ -290,6 +290,7 @@ mod tests {
     fn connected_v6(ifindex: u32) -> RibEntry {
         let mut e = RibEntry::new(RibType::Connected);
         e.ifindex = ifindex;
+        e.set_valid(true);
         e
     }
 
@@ -300,12 +301,14 @@ mod tests {
             ifindex_origin: Some(ifindex),
             ..Default::default()
         });
+        e.set_valid(true);
         e
     }
 
     fn connected_v4(ifindex: u32) -> RibEntry {
         let mut e = RibEntry::new(RibType::Connected);
         e.ifindex = ifindex;
+        e.set_valid(true);
         e
     }
 
@@ -316,6 +319,7 @@ mod tests {
             ifindex_origin: Some(ifindex),
             ..Default::default()
         });
+        e.set_valid(true);
         e
     }
 

--- a/zebra-rs/src/rib/resolve.rs
+++ b/zebra-rs/src/rib/resolve.rs
@@ -99,12 +99,17 @@ fn entry_nexthop_addr(entry: &RibEntry) -> Option<IpAddr> {
 // nexthop lookup. Connected and IGP routes are always trusted; static is
 // trusted up to the depth cap; BGP is excluded because BGP next-hops should
 // resolve over the underlay (IGP / connected), not over BGP itself, and
-// allowing it would risk recursive loops.
+// allowing it would risk recursive loops. The validity check skips entries
+// that are still in the table but no longer reachable — e.g. an IS-IS
+// route whose group went invalid because its egress link is down. Without
+// this filter a recursive static would resolve through the dead route and
+// look reachable when it isn't.
 fn entry_resolvable(entry: &RibEntry) -> bool {
-    matches!(
-        entry.rtype,
-        RibType::Connected | RibType::Static | RibType::Ospf | RibType::Isis
-    )
+    entry.is_valid()
+        && matches!(
+            entry.rtype,
+            RibType::Connected | RibType::Static | RibType::Ospf | RibType::Isis
+        )
 }
 
 pub fn rib_resolve(

--- a/zebra-rs/src/rib/resolve.rs
+++ b/zebra-rs/src/rib/resolve.rs
@@ -220,6 +220,7 @@ mod tests {
     fn connected_v6(ifindex: u32) -> RibEntry {
         let mut e = RibEntry::new(RibType::Connected);
         e.ifindex = ifindex;
+        e.set_valid(true);
         e
     }
 
@@ -230,6 +231,7 @@ mod tests {
             ifindex_origin: Some(ifindex),
             ..Default::default()
         });
+        e.set_valid(true);
         e
     }
 
@@ -240,6 +242,7 @@ mod tests {
             ifindex_origin: None,
             ..Default::default()
         });
+        e.set_valid(true);
         e
     }
 

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -6,9 +6,9 @@ use prefix_trie::PrefixMap;
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::fib::FibHandle;
-use crate::rib::Nexthop;
 use crate::rib::resolve::{ResolveOpt, rib_resolve, rib_resolve_v6};
 use crate::rib::util::IpNetExt;
+use crate::rib::{Link, LinkFlagsExt, Nexthop};
 
 use super::entry::RibEntry;
 use super::inst::{IlmEntry, Rib};
@@ -109,11 +109,23 @@ impl Rib {
             }
         }
 
-        // Resolve RIB.
-        ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.fib_handle).await;
+        // Resolve RIB. The first sync pass invalidates groups whose
+        // egress link just went down; recursive groups (a static via
+        // an IS-IS route, say) need a *second* pass once those IS-IS
+        // entries have been deselected, otherwise rib_resolve_v6
+        // happily walks the still-present-but-now-invalid entries.
+        // The debounced Resolve scheduled below handles that.
+        ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.links, &self.fib_handle).await;
         ipv4_route_sync(&mut self.table, &mut self.nmap, &self.fib_handle, true).await;
-        ipv6_nexthop_sync(&mut self.nmap, &self.table_v6, &self.fib_handle).await;
+        ipv6_nexthop_sync(
+            &mut self.nmap,
+            &self.table_v6,
+            &self.links,
+            &self.fib_handle,
+        )
+        .await;
         ipv6_route_sync(&mut self.table_v6, &mut self.nmap, &self.fib_handle).await;
+        self.schedule_rib_sync();
     }
 
     pub async fn link_up(&mut self, ifindex: u32) {
@@ -258,10 +270,21 @@ impl Rib {
             }
         }
 
-        ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.fib_handle).await;
+        ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.links, &self.fib_handle).await;
         ipv4_route_sync(&mut self.table, &mut self.nmap, &self.fib_handle, true).await;
-        ipv6_nexthop_sync(&mut self.nmap, &self.table_v6, &self.fib_handle).await;
+        ipv6_nexthop_sync(
+            &mut self.nmap,
+            &self.table_v6,
+            &self.links,
+            &self.fib_handle,
+        )
+        .await;
         ipv6_route_sync(&mut self.table_v6, &mut self.nmap, &self.fib_handle).await;
+        // Mirror link_down: schedule a deferred Resolve so recursive
+        // groups (e.g. a static whose first segment was unreachable
+        // while the link was down) re-evaluate now that the IS-IS
+        // routes are back and selectable.
+        self.schedule_rib_sync();
     }
 
     pub async fn ipv4_route_add(&mut self, prefix: &Ipv4Net, mut entry: RibEntry) {
@@ -376,12 +399,18 @@ impl Rib {
     }
 
     pub async fn ipv6_route_resolve(&mut self) {
-        ipv6_nexthop_sync(&mut self.nmap, &self.table_v6, &self.fib_handle).await;
+        ipv6_nexthop_sync(
+            &mut self.nmap,
+            &self.table_v6,
+            &self.links,
+            &self.fib_handle,
+        )
+        .await;
         ipv6_route_sync(&mut self.table_v6, &mut self.nmap, &self.fib_handle).await;
     }
 
     pub async fn ipv4_route_resolve(&mut self) {
-        ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.fib_handle).await;
+        ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.links, &self.fib_handle).await;
         // `false` = not an ifdown sweep; this resolve cycle is for FIB-update
         // re-resolution, not link-down recovery.
         ipv4_route_sync(&mut self.table, &mut self.nmap, &self.fib_handle, false).await;
@@ -439,11 +468,35 @@ pub async fn rib_selection_ipv6(
 pub async fn ipv4_nexthop_sync(
     nmap: &mut NexthopMap,
     table: &PrefixMap<Ipv4Net, RibEntries>,
+    links: &BTreeMap<u32, Link>,
     fib: &FibHandle,
 ) {
     // Update Group::Uni first, then check Group::Multi.
     for nhop in nmap.groups.iter_mut().flatten() {
         if let Group::Uni(uni) = nhop {
+            // Origin shortcut: when the source pinned an egress link
+            // (IGP adjacency, seg6local install, connected, configured
+            // static) we trust it as long as that link is still up.
+            // When it goes down the kernel auto-removes the routes
+            // that point at it; sync our view so the next route_sync
+            // pass deselects + drops the FIB entries instead of
+            // happily marking them installed.
+            if let Some(ifindex) = uni.ifindex_origin {
+                let link_up = links
+                    .get(&ifindex)
+                    .is_some_and(|l| l.flags.is_up() && l.flags.is_lower_up());
+                if link_up {
+                    uni.set_valid(true);
+                    if !uni.is_installed() {
+                        uni.set_installed(true);
+                        fib.nexthop_add(&Group::Uni(uni.clone())).await;
+                    }
+                } else {
+                    uni.set_valid(false);
+                    uni.set_installed(false);
+                }
+                continue;
+            }
             let resolve = match uni.addr {
                 std::net::IpAddr::V4(ipv4_addr) => {
                     rib_resolve(table, ipv4_addr, &ResolveOpt::default())
@@ -460,13 +513,6 @@ pub async fn ipv4_nexthop_sync(
                 uni.ifindex_resolved = None;
                 uni.set_valid(false);
                 if uni.is_installed() {
-                    // println!(
-                    //     "UniDel: gid {} {}/{} {}",
-                    //     uni.gid(),
-                    //     uni.addr,
-                    //     uni.ifindex,
-                    //     uni.is_installed()
-                    // );
                     uni.set_installed(false);
                     // XXX fib.nexthop_del(&Group::Uni(uni.clone())).await;
                 }
@@ -474,13 +520,6 @@ pub async fn ipv4_nexthop_sync(
                 uni.ifindex_resolved = Some(ifindex);
                 uni.set_valid(true);
                 if !uni.is_installed() {
-                    // println!(
-                    //     "UniAdd: gid {} {}/{} {}",
-                    //     uni.gid(),
-                    //     uni.addr,
-                    //     uni.ifindex(),
-                    //     uni.is_installed()
-                    // );
                     uni.set_installed(true);
                     fib.nexthop_add(&Group::Uni(uni.clone())).await;
                 }
@@ -1193,6 +1232,7 @@ fn resolve_nexthop_uni_v6(
 pub async fn ipv6_nexthop_sync(
     nmap: &mut NexthopMap,
     table: &PrefixMap<Ipv6Net, RibEntries>,
+    links: &BTreeMap<u32, Link>,
     fib: &FibHandle,
 ) {
     if DEBUG_V6 {
@@ -1210,13 +1250,24 @@ pub async fn ipv6_nexthop_sync(
                     uni.is_installed(),
                 );
             }
-            // Origin wins — skip the table walk entirely if the
-            // caller already supplied the egress link.
-            if uni.ifindex_origin.is_some() {
-                uni.set_valid(true);
-                if !uni.is_installed() {
-                    uni.set_installed(true);
-                    fib.nexthop_add(&Group::Uni(uni.clone())).await;
+            // Origin wins — skip the table walk entirely when the
+            // caller pinned the egress link, but only if that link
+            // is still up. When it isn't, the kernel removed the
+            // route on link-down; mark the group invalid so the
+            // route_sync pass deselects and drops the FIB entry.
+            if let Some(ifindex) = uni.ifindex_origin {
+                let link_up = links
+                    .get(&ifindex)
+                    .is_some_and(|l| l.flags.is_up() && l.flags.is_lower_up());
+                if link_up {
+                    uni.set_valid(true);
+                    if !uni.is_installed() {
+                        uni.set_installed(true);
+                        fib.nexthop_add(&Group::Uni(uni.clone())).await;
+                    }
+                } else {
+                    uni.set_valid(false);
+                    uni.set_installed(false);
                 }
                 continue;
             }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -298,11 +298,24 @@ module config {
           }
         }
 
-        leaf multi-topology {
-          // RFC 5120 M-ISIS Multi Topology (MT). In practice, IPv6 unicast is
-          // only one topology used in the industry.
-          type enumeration {
-            enum ipv6-unicast;   // MT 2 — IPv6 unicast
+        container multi-topology {
+          // RFC 5120 M-ISIS. Presence enables multi-topology routing;
+          // the inner `topology` list names the topologies the router
+          // participates in. PR 1 lands the config model only — wire
+          // origination, SPF, and routing-install happen in follow-up
+          // PRs.
+          presence "Enable IS-IS multi-topology routing (RFC 5120)";
+          list topology {
+            key "id";
+            // Standard MT IDs we know how to compute SPF for. Multicast
+            // variants (3, 4) parse on the wire but aren't surfaced
+            // here — operators don't enable them via this knob.
+            leaf id {
+              type enumeration {
+                enum standard;       // MT 0 — IPv4 unicast
+                enum ipv6-unicast;   // MT 2 — IPv6 unicast
+              }
+            }
           }
         }
 

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -298,24 +298,11 @@ module config {
           }
         }
 
-        container multi-topology {
-          // RFC 5120 M-ISIS. Presence enables multi-topology routing;
-          // the inner `topology` list names the topologies the router
-          // participates in. PR 1 lands the config model only — wire
-          // origination, SPF, and routing-install happen in follow-up
-          // PRs.
-          presence "Enable IS-IS multi-topology routing (RFC 5120)";
-          list topology {
-            key "id";
-            // Standard MT IDs we know how to compute SPF for. Multicast
-            // variants (3, 4) parse on the wire but aren't surfaced
-            // here — operators don't enable them via this knob.
-            leaf id {
-              type enumeration {
-                enum standard;       // MT 0 — IPv4 unicast
-                enum ipv6-unicast;   // MT 2 — IPv6 unicast
-              }
-            }
+        leaf multi-topology {
+          // RFC 5120 M-ISIS Multi Topology (MT). In practice, IPv6 unicast is
+          // only one topology used in the industry.
+          type enumeration {
+            enum ipv6-unicast;   // MT 2 — IPv6 unicast
           }
         }
 


### PR DESCRIPTION
## Summary

\`ifdown enp0s6\` → kernel removed every route pointing at enp0s6, but zebra-rs's RIB kept reporting them \`*>\` (installed). \`ifup enp0s6\` → connected returned, but the IS-IS routes / End.X SID / recursive statics did not re-install.

Root cause: the recent \`ifindex_origin\` / \`ifindex_resolved\` split added an origin shortcut to \`{ipv4,ipv6}_nexthop_sync\` that unconditionally marked groups valid + installed when origin was set — link state never entered the picture.

### Fix

- \`ipv4_nexthop_sync\` / \`ipv6_nexthop_sync\` now take \`&BTreeMap<u32, Link>\`. The origin shortcut checks \`flags.is_up() && flags.is_lower_up()\`. Down → group flips to invalid + uninstalled (matches kernel reality); up → revalidate and re-install the nh_id when not installed (drives the link-up recovery).
- \`entry_resolvable\` filters on \`entry.is_valid()\`. Without this, recursive resolution (a static via an IS-IS route) walked through still-present-but-now-invalid IS-IS entries.
- \`link_down\` and \`link_up\` schedule a deferred \`Message::Resolve\` (via the existing \`schedule_rib_sync\`). The first sync pass invalidates / revives the directly-affected IGP groups; the deferred pass picks up the cascade — recursive statics whose underlay just changed — once those underlay entries have been deselected.

## Test plan

- [x] \`cargo build --bin zebra-rs\`
- [x] \`cargo clippy --bin zebra-rs\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test --lib --workspace --exclude bdd\`
- [x] Manual: with the user's IS-IS + uSID + recursive-static config, \`ifdown enp0s6\` removes every dependent route from both \`sh ipv6 route\` and \`ip -6 route\`; the standalone End/uN SID on sr0 stays. \`ifup enp0s6\` re-installs IS-IS routes, the End.X SID, and the recursive static.

Generated with [Claude Code](https://claude.com/claude-code)