### PR TITLE
refactor(isis): collapse multi-topology to a single enum leaf

### DIFF
--- a/bdd/tests/data/isis_multi_topology/z1-1.yaml
+++ b/bdd/tests/data/isis_multi_topology/z1-1.yaml
@@ -10,9 +10,7 @@ routing:
     net: 49.0001.0000.0000.0001.00
     is-type: level-2-only
     hostname: z1
-    multi-topology:
-      topology:
-      - id: ipv6-unicast
+    multi-topology: ipv6-unicast
     interface:
     - if-name: lo
       circuit-type: level-2-only

--- a/bdd/tests/data/isis_multi_topology/z2-1.yaml
+++ b/bdd/tests/data/isis_multi_topology/z2-1.yaml
@@ -10,9 +10,7 @@ routing:
     net: 49.0001.0000.0000.0002.00
     is-type: level-2-only
     hostname: z2
-    multi-topology:
-      topology:
-      - id: ipv6-unicast
+    multi-topology: ipv6-unicast
     interface:
     - if-name: lo
       circuit-type: level-2-only

--- a/bdd/tests/features/isis_multi_topology.feature
+++ b/bdd/tests/features/isis_multi_topology.feature
@@ -24,9 +24,9 @@ Feature: IS-IS multi-topology (RFC 5120)
               /128                  /128
   ```
 
-  Both configs add `multi-topology { topology ipv6-unicast; }` under
-  `routing/isis/` so the LSPs carry TLV 229 (capability), TLV 222
-  (MT IS Reach), and TLV 237 (MT IPv6 Reach).
+  Both configs add `multi-topology ipv6-unicast;` under `routing/isis/`
+  so the LSPs carry TLV 229 (capability), TLV 222 (MT IS Reach), and
+  TLV 237 (MT IPv6 Reach).
 
   Scenario: Setup IS-IS L2 with MT 2 over a shared bridge and confirm the link is up
     Given a clean test environment

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -68,8 +68,7 @@ impl Isis {
             "/routing/isis/segment-routing/srv6/locator",
             config_sr_srv6_locator,
         );
-        self.callback_add("/routing/isis/multi-topology", config_mt_enable);
-        self.callback_add("/routing/isis/multi-topology/topology", config_mt_topology);
+        self.callback_add("/routing/isis/multi-topology", config_mt);
         self.callback_add(
             "/routing/isis/interface/multi-topology/metric",
             link::config_mt_metric,
@@ -147,16 +146,16 @@ pub struct IsisConfig {
     /// as sr_mpls_block.
     pub sr_srv6_locator: Option<String>,
 
-    /// Set when /routing/isis/multi-topology is committed (the
-    /// presence-marked YANG container). Drives whether IS-IS
-    /// originates the MT TLV (229) and per-MT reach TLVs in
-    /// follow-up PRs.
+    /// True when `/routing/isis/multi-topology` carries an MT id.
+    /// Drives whether IS-IS originates TLV 229 and the per-MT reach
+    /// TLVs.
     pub mt_enabled: bool,
 
-    /// MT IDs the operator selected under
-    /// /routing/isis/multi-topology/topology. Empty when MT is on but
-    /// the operator hasn't named any topologies yet — that's a
-    /// no-op-friendly intermediate state during config staging.
+    /// The MT ids the operator turned on. Today the YANG only allows
+    /// `ipv6-unicast`, so this set is either `{}` (off) or
+    /// `{Ipv6Unicast}` (on); the BTreeSet shape is kept so adding
+    /// future MTs (multicast variants, geo-redundancy, ...) doesn't
+    /// reshape the runtime checks that read it.
     pub mt_topologies: BTreeSet<MtId>,
 }
 
@@ -328,29 +327,22 @@ fn config_sr_srv6_locator(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Opti
     Some(())
 }
 
-// Set/cleared by the presence of the YANG container itself, like
-// segment-routing/srv6 above. Removing the container also drops every
-// configured topology; PR 2 will trigger LSP re-origination from here.
-fn config_mt_enable(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
+// Single-leaf callback. The YANG narrowed `multi-topology` from a
+// container-with-list to a single enum leaf because the only MT every
+// real-world IS-IS deployment turns on is MT 2 (IPv6 unicast); the
+// classic dual-flavour matrix never landed in any operator's running
+// config. Set with `ipv6-unicast` flips MT on for that topology;
+// delete clears both the flag and the set.
+fn config_mt(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     if op.is_set() {
+        let id_str = args.string()?;
+        let id = MtId::from_str(&id_str).ok()?;
         isis.config.mt_enabled = true;
+        isis.config.mt_topologies.clear();
+        isis.config.mt_topologies.insert(id);
     } else {
         isis.config.mt_enabled = false;
         isis.config.mt_topologies.clear();
-    }
-    Some(())
-}
-
-// Per-list-entry callback: the value is the MT id keyword. Add on set,
-// remove on delete. Unknown ids fall through to None — libyang's enum
-// validation should keep them out, but we don't trust the wire.
-fn config_mt_topology(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
-    let id_str = args.string()?;
-    let id = MtId::from_str(&id_str).ok()?;
-    if op.is_set() {
-        isis.config.mt_topologies.insert(id);
-    } else {
-        isis.config.mt_topologies.remove(&id);
     }
     Some(())
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -298,24 +298,12 @@ module config {
           }
         }
 
-        container multi-topology {
-          // RFC 5120 M-ISIS. Presence enables multi-topology routing;
-          // the inner `topology` list names the topologies the router
-          // participates in. PR 1 lands the config model only — wire
-          // origination, SPF, and routing-install happen in follow-up
-          // PRs.
-          presence "Enable IS-IS multi-topology routing (RFC 5120)";
-          list topology {
-            key "id";
-            // Standard MT IDs we know how to compute SPF for. Multicast
-            // variants (3, 4) parse on the wire but aren't surfaced
-            // here — operators don't enable them via this knob.
-            leaf id {
-              type enumeration {
-                enum standard;       // MT 0 — IPv4 unicast
-                enum ipv6-unicast;   // MT 2 — IPv6 unicast
-              }
-            }
+        leaf multi-topology {
+          // RFC 5120 M-ISIS Multi Topology (MT). IPv6 unicast is the
+          // only option used in the industry today, so the enum
+          // carries just that one value.
+          type enumeration {
+            enum ipv6-unicast;   // MT 2 — IPv6 unicast
           }
         }
 


### PR DESCRIPTION
## Summary

The container-with-list shape we shipped earlier (\`multi-topology { topology { id ipv6-unicast } }\`) was paying for flexibility nobody uses — IPv6 unicast is the only MT every real-world deployment turns on. Collapse to a single enum leaf:

\`\`\`
multi-topology ipv6-unicast;
\`\`\`

Wire-side semantics unchanged: \`mt_enabled\` flips and \`mt_topologies\` ends up as \`{Ipv6Unicast}\`. The runtime sites that read \`mt_topologies.contains(&MtId::Ipv6Unicast)\` keep working unchanged. Kept the \`BTreeSet<MtId>\` shape so adding future MTs (multicast variants, geo-redundancy, ...) doesn't reshape any of those checks.

### Wires
- YANG: container-with-list → single enum leaf with one value (\`ipv6-unicast\`).
- \`config.rs\`: two callbacks (\`/multi-topology\` + \`/multi-topology/topology\`) → one (\`config_mt\`) that takes the enum string and updates both flags.
- BDD fixtures \`z1-1.yaml\` / \`z2-1.yaml\` and the feature doc-comment updated to the new shape.

## Test plan

- [x] \`cargo build --bin zebra-rs\`
- [x] \`cargo clippy --bin zebra-rs\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test --lib --workspace --exclude bdd\`
- [ ] BDD: \`cargo test --bin bdd -- isis_multi_topology\` (locally) to confirm the new YAML shape parses and the LSPs still carry TLV 229 / 222 / 237.

Generated with [Claude Code](https://claude.com/claude-code)