### PR TITLE
feat(isis): clear isis spf

### DIFF
--- a/zebra-rs/src/config/commands.rs
+++ b/zebra-rs/src/config/commands.rs
@@ -57,6 +57,7 @@ pub fn configure_mode_create(entry: Rc<Entry>) -> Mode {
     mode.install_func(String::from("/load"), load);
     mode.install_func(String::from("/save"), save);
     mode.install_func(String::from("/clear/ip/bgp/neighbor"), clear_bgp);
+    mode.install_func(String::from("/clear/isis/spf"), clear_isis_spf);
     mode
 }
 
@@ -180,5 +181,10 @@ fn list(config: &ConfigManager) -> (ExecCode, String) {
 
 fn clear_bgp(_config: &ConfigManager) -> (ExecCode, String) {
     let output = String::from("clear ip bgp");
+    (ExecCode::Show, output)
+}
+
+fn clear_isis_spf(_config: &ConfigManager) -> (ExecCode, String) {
+    let output = String::from("clear isis spf");
     (ExecCode::Show, output)
 }

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -228,10 +228,37 @@ impl Isis {
 
     pub fn process_cm_msg(&mut self, msg: ConfigRequest) {
         let (path, args) = path_from_command(&msg.paths);
-        // println!("XX path {} args {:?}", path, args);
+
+        // Clear ops don't go through the YANG callback table — they
+        // map directly to runtime side-effects (kick SPF, drop a
+        // peer, ...) the way `clear ip bgp` works in BGP. Match on
+        // the path explicitly so the rest of the pipeline keeps
+        // treating Set / Delete uniformly.
+        if msg.op == ConfigOp::Clear {
+            match path.as_str() {
+                "/clear/isis/spf" => {
+                    self.clear_spf();
+                }
+                _ => {
+                    //
+                }
+            }
+            return;
+        }
+
         if let Some(f) = self.callbacks.get(&path) {
             f(self, args, msg.op);
         }
+    }
+
+    /// Force-recalculate the IS-IS SPF for both L1 and L2. Mirrors
+    /// FRR's `clear isis spf` — useful when an operator wants to
+    /// re-derive the route table without waiting for the next LSDB
+    /// update or the debounce timer to fire. Levels with no SPF
+    /// state yet are no-ops on the receiver side.
+    fn clear_spf(&mut self) {
+        let _ = self.tx.send(Message::SpfCalc(Level::L1));
+        let _ = self.tx.send(Message::SpfCalc(Level::L2));
     }
 
     pub fn process_rib_msg(&mut self, msg: RibRx) {

--- a/zebra-rs/yang/configure.yang
+++ b/zebra-rs/yang/configure.yang
@@ -117,5 +117,14 @@ module configure {
         }
       }
     }
+    container isis {
+      // Force-recalculate the IS-IS SPF for both L1 and L2 instead
+      // of waiting for the next LSDB update or the debounce timer.
+      // Useful when manual diagnosis suspects a stuck route after
+      // an LSDB-side fix.
+      leaf spf {
+        type empty;
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Mirror \`clear ip bgp\`'s shape so an operator can force an IS-IS SPF recalculation without bouncing the daemon or waiting for the debounce timer. Useful when manual diagnosis suspects a stuck route after an LSDB-side fix.

### Wires
- **YANG** (\`configure.yang\`): \`leaf spf { type empty; }\` under \`/clear/isis/\`, parallel to the existing \`/clear/ip/bgp/\` block.
- **CLI echo** (\`commands.rs\`): \`clear_isis_spf\` registered next to \`clear_bgp\`. The CLI returns early after the Clear broadcast (same as today's BGP path), so the string isn't actually rendered — kept for symmetry.
- **IS-IS dispatch** (\`isis::process_cm_msg\`): an explicit \`ConfigOp::Clear\` branch matches paths the way BGP's does. \`/clear/isis/spf\` lands on a new \`Rib::clear_spf\` that sends \`Message::SpfCalc(L1)\` + \`Message::SpfCalc(L2)\`; the existing event-loop branch picks each up and calls \`perform_spf_calculation\`.

## Test plan

- [x] \`cargo build --bin zebra-rs\`
- [x] \`cargo clippy --bin zebra-rs\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test --lib --workspace --exclude bdd\`
- [ ] Manual: \`clear isis spf\` from the CLI triggers an immediate recompute on both levels (visible via \`show isis route\` ages resetting / log lines from \`perform_spf_calculation\`).

Generated with [Claude Code](https://claude.com/claude-code)