### PR TITLE
feat(isis): react to interface up/down events

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -267,6 +267,12 @@ impl Isis {
             RibRx::LinkAdd(link) => {
                 self.link_add(link);
             }
+            RibRx::LinkUp(ifindex) => {
+                self.link_state_up(ifindex);
+            }
+            RibRx::LinkDown(ifindex) => {
+                self.link_state_down(ifindex);
+            }
             RibRx::AddrAdd(addr) => {
                 // isis_info!("Isis::AddrAdd {}", addr.addr);
                 self.addr_add(addr);

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -522,8 +522,7 @@ impl Isis {
         // way `nbr_hold_timer_expire` does — keep that path the one
         // place that frees per-adjacency resources.
         for level in [Level::L1, Level::L2] {
-            let nbr_ids: Vec<IsisSysId> =
-                link.state.nbrs.get(&level).keys().copied().collect();
+            let nbr_ids: Vec<IsisSysId> = link.state.nbrs.get(&level).keys().copied().collect();
 
             for sys_id in nbr_ids {
                 if let Some(nbr) = link.state.nbrs.get_mut(&level).get_mut(&sys_id) {

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -486,6 +486,80 @@ impl Isis {
         }
     }
 
+    /// React to a kernel-side link-up event. Mirror the IFF_UP flag
+    /// on our own link record and, if IS-IS is configured on this
+    /// interface, kick the IFSM to re-arm hellos. Adjacencies form
+    /// from scratch via the normal hello / NFSM path; LSP
+    /// re-origination + SPF land naturally on each adjacency Up
+    /// transition.
+    pub fn link_state_up(&mut self, ifindex: u32) {
+        let Some(link) = self.links.get_mut(&ifindex) else {
+            return;
+        };
+        link.flags |= LinkFlags::Up;
+        link.flags |= LinkFlags::LowerUp;
+        if link.config.enabled() {
+            let _ = self.tx.send(Message::Ifsm(IfsmEvent::Start, ifindex, None));
+        }
+    }
+
+    /// React to a kernel-side link-down event. Adjacencies on this
+    /// link can't continue — packets stop flowing the moment IFF_UP
+    /// drops — so tear them down immediately rather than ride out
+    /// the 30s hold timer. Then re-originate the self LSP without
+    /// the dropped peers and schedule SPF for both levels so the
+    /// route table reflects the new topology.
+    pub fn link_state_down(&mut self, ifindex: u32) {
+        let Some(link) = self.links.get_mut(&ifindex) else {
+            return;
+        };
+        link.flags &= !LinkFlags::Up;
+        link.flags &= !LinkFlags::LowerUp;
+        let was_enabled = link.config.enabled();
+
+        // Tear down per-level adjacency state. Each Up neighbor
+        // gets its label / End.X SID returned to the pool the same
+        // way `nbr_hold_timer_expire` does — keep that path the one
+        // place that frees per-adjacency resources.
+        for level in [Level::L1, Level::L2] {
+            let nbr_ids: Vec<IsisSysId> =
+                link.state.nbrs.get(&level).keys().copied().collect();
+
+            for sys_id in nbr_ids {
+                if let Some(nbr) = link.state.nbrs.get_mut(&level).get_mut(&sys_id) {
+                    // Release SR-MPLS adjacency labels.
+                    if let Some(local_pool) = self.local_pool.as_mut() {
+                        for value in nbr.addr4.values_mut() {
+                            if let Some(label) = value.label.take() {
+                                local_pool.release(label as usize);
+                            }
+                        }
+                    }
+                    nbr.release_endx_sid(&mut self.elib, &self.rib_tx);
+                    nbr.state = crate::isis::nfsm::NfsmState::Down;
+                }
+            }
+
+            // Drop adjacency LAN-ID and the per-level CSNP timer.
+            *link.state.adj.get_mut(&level) = None;
+            *link.timer.csnp.get_mut(&level) = None;
+            self.lsdb.get_mut(&level).adj_clear(ifindex);
+        }
+
+        // Stop hello generation on this interface.
+        if was_enabled {
+            let _ = self.tx.send(Message::Ifsm(IfsmEvent::Stop, ifindex, None));
+        }
+
+        // Re-originate the self LSP at both levels (pseudonode peers
+        // dropped, fewer Ext IS Reach entries) and recompute SPF so
+        // the route table no longer shows paths via the down link.
+        let _ = self.tx.send(Message::LspOriginate(Level::L1));
+        let _ = self.tx.send(Message::LspOriginate(Level::L2));
+        let _ = self.tx.send(Message::SpfCalc(Level::L1));
+        let _ = self.tx.send(Message::SpfCalc(Level::L2));
+    }
+
     pub fn addr_add(&mut self, addr: LinkAddr) {
         // println!("ISIS: AddrAdd {} {}", addr.addr, addr.ifindex);
         let Some(link) = self.links.get_mut(&addr.ifindex) else {


### PR DESCRIPTION
## Summary

\`Isis::process_rib_msg\` was ignoring \`RibRx::LinkUp\` / \`RibRx::LinkDown\` (caught by the wildcard arm). When an operator ran \`ifdown enp0s6\`, IS-IS kept the adjacency in \`NfsmState::Up\` until the 30s hold timer fired — so for half a minute the self LSP advertised dropped peers, the route table reported stale paths, and we kept flooding the wrong topology to other peers.

### Wires
- \`Isis::link_state_up(ifindex)\` mirrors IFF_UP / IFF_LOWER_UP on our link record and kicks \`IfsmEvent::Start\` if IS-IS is configured. Adjacencies form via the normal hello / NFSM path; LSP origination + SPF land on each adjacency Up transition.
- \`Isis::link_state_down(ifindex)\` clears those flags, walks the per-level neighbor table, releases SR-MPLS adj labels and End.X SIDs back to their pools (mirroring \`nbr_hold_timer_expire\` so the resource-return path stays in one place), drops the adjacency LAN-ID + CSNP timer, stops hello, then sends \`Message::LspOriginate(L1)\` + \`(L2)\` and \`Message::SpfCalc(L1)\` + \`(L2)\`.

## Test plan

- [x] \`cargo build --bin zebra-rs\`
- [x] \`cargo clippy --bin zebra-rs\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test --lib --workspace --exclude bdd\`
- [ ] Manual: with two peering IS-IS instances, \`ifdown enp0s6\` on one — \`show isis adjacency\`, \`show isis database self\`, and \`show isis route\` reflect the change within a second instead of after 30s. \`ifup enp0s6\` brings the adjacency back the same way.

Generated with [Claude Code](https://claude.com/claude-code)