### PR TITLE
fix(isis): drop neighbor entries on link-down + hold-timer expiry

### DIFF
--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -506,9 +506,12 @@ impl Isis {
     /// React to a kernel-side link-down event. Adjacencies on this
     /// link can't continue — packets stop flowing the moment IFF_UP
     /// drops — so tear them down immediately rather than ride out
-    /// the 30s hold timer. Then re-originate the self LSP without
-    /// the dropped peers and schedule SPF for both levels so the
-    /// route table reflects the new topology.
+    /// the 30s hold timer. Drop every neighbor entry so when the
+    /// link comes back up, IFSM starts on a blank slate and NFSM
+    /// transitions through Init / Up via fresh hellos. Then
+    /// re-originate the self LSP without the dropped peers and
+    /// schedule SPF for both levels so the route table reflects the
+    /// new topology.
     pub fn link_state_down(&mut self, ifindex: u32) {
         let Some(link) = self.links.get_mut(&ifindex) else {
             return;
@@ -517,10 +520,15 @@ impl Isis {
         link.flags &= !LinkFlags::LowerUp;
         let was_enabled = link.config.enabled();
 
-        // Tear down per-level adjacency state. Each Up neighbor
-        // gets its label / End.X SID returned to the pool the same
-        // way `nbr_hold_timer_expire` does — keep that path the one
-        // place that frees per-adjacency resources.
+        // Tear down per-level adjacency state. Each neighbor returns
+        // its SR-MPLS label / End.X SID to the pool the same way
+        // `nbr_hold_timer_expire` does — keep that path the one
+        // place that frees per-adjacency resources — and the
+        // neighbor entry itself is dropped so the next hello
+        // creates a fresh one. Otherwise stale `addr4` /
+        // `hold_timer` / `endx_sid` values would survive the link
+        // bounce and the NFSM would re-enter from a half-populated
+        // record.
         for level in [Level::L1, Level::L2] {
             let nbr_ids: Vec<IsisSysId> = link.state.nbrs.get(&level).keys().copied().collect();
 
@@ -535,11 +543,16 @@ impl Isis {
                         }
                     }
                     nbr.release_endx_sid(&mut self.elib, &self.rib_tx);
-                    nbr.state = crate::isis::nfsm::NfsmState::Down;
                 }
+                // Drop the entry. The hold-timer JoinHandle goes
+                // with it; tokio cancels the underlying task on
+                // drop.
+                link.state.nbrs.get_mut(&level).remove(&sys_id);
             }
 
-            // Drop adjacency LAN-ID and the per-level CSNP timer.
+            // Reset per-level Up-neighbor counter and adjacency
+            // bookkeeping.
+            *link.state.nbrs_up.get_mut(&level) = 0;
             *link.state.adj.get_mut(&level) = None;
             *link.timer.csnp.get_mut(&level) = None;
             self.lsdb.get_mut(&level).adj_clear(ifindex);

--- a/zebra-rs/src/isis/nfsm.rs
+++ b/zebra-rs/src/isis/nfsm.rs
@@ -69,15 +69,19 @@ pub fn nbr_hold_timer_expire(link: &mut LinkTop, level: Level, sys_id: IsisSysId
         return;
     };
 
+    let was_up = nbr.state == NfsmState::Up;
+    let ifindex = nbr.ifindex;
+
     // Originate Hello and LSP.
     if is_p2p {
-        nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
+        nbr.event(Message::Ifsm(HelloOriginate, ifindex, Some(level)));
         nbr.event(Message::LspOriginate(level));
     } else {
-        // DIS election.
-        nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
-        if nbr.state == NfsmState::Up {
-            nbr.event(Message::Ifsm(DisSelection, nbr.ifindex, Some(level)));
+        // DIS election. Run before we drop the entry so the snapshot
+        // it operates on still has this neighbor.
+        nbr.event(Message::Ifsm(HelloOriginate, ifindex, Some(level)));
+        if was_up {
+            nbr.event(Message::Ifsm(DisSelection, ifindex, Some(level)));
         }
     }
 
@@ -95,8 +99,21 @@ pub fn nbr_hold_timer_expire(link: &mut LinkTop, level: Level, sys_id: IsisSysId
     // and the registry drops the row before the show table runs again.
     nbr.release_endx_sid(link.elib, link.rib_tx);
 
-    // Neighbor state to be down.
-    nbr.state = NfsmState::Down;
+    // Drop the neighbor entry. Keeping it around with NfsmState::Down
+    // (the previous behaviour) carried stale `addr4` (whose labels we
+    // just released and zeroed), the consumed `endx_sid` slot, and a
+    // newly-armed `hold_timer` from any in-flight hello that still
+    // looked up this entry. When the peer's interface bounces and
+    // hellos resume, `nbr_hello_interpret` would find the lingering
+    // record, retain the existing addr entries with `label=None`
+    // forever (no LSP adj-SID re-emission), and re-enter NFSM from
+    // a half-populated state. Drop the row so the next hello starts
+    // from scratch.
+    link.state.nbrs.get_mut(&level).remove(&sys_id);
+    if was_up {
+        let counter = link.state.nbrs_up.get_mut(&level);
+        *counter = counter.saturating_sub(1);
+    }
 
     spf_schedule(link, level);
 }


### PR DESCRIPTION
## Summary

Both link-down paths kept the neighbor entry alive with state=Down after releasing its SR-MPLS label and End.X SID. The lingering record carried stale \`addr4\` (with \`label=None\` after release), a consumed \`endx_sid\` slot, and an in-flight hello might re-arm the hold timer on the dead row before NFSM ever transitioned through Init. After the link bounced back up the NFSM would re-enter from a half-populated state — labels never re-allocated, no LSP adj-SID re-emission.

Drop the entry outright after the existing resource-return bookkeeping. Tokio cancels the held \`hold_timer\` on drop. Reset the per-level \`nbrs_up\` counter at the same time so \`show isis adjacency\` doesn't keep reporting phantoms.

### Two paths
- **Local side** (\`link_state_down\` in \`link.rs\`): kernel told us the interface went down → walk both levels, release labels + SID, drop each entry.
- **Remote side** (\`nbr_hold_timer_expire\` in \`nfsm.rs\`): no kernel signal, just the 30s hold timer. Run the existing HelloOriginate / DisSelection bookkeeping first (DIS selection still needs the neighbor in its Up snapshot), then drop the entry.

When the peer comes back, \`nbr_hello_interpret\` doesn't find the entry, creates a fresh one with newly-allocated labels and a freshly-armed hold timer, and NFSM runs clean Init → Up.

## Test plan

- [x] \`cargo build --bin zebra-rs\`
- [x] \`cargo clippy --bin zebra-rs\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test --lib --workspace --exclude bdd\`
- [ ] Manual: bounce \`enp0s6\` on one side. \`show isis adjacency\` on **both** sides shows zero neighbors during the down period (after hold-timer on the remote side, immediately on the local side) and a fresh \`Up\` adjacency after the link comes back. No phantom Down rows linger.

Generated with [Claude Code](https://claude.com/claude-code)