### PR TITLE
fix(isis): bump self LSP seq when peer floods higher copy back

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -250,7 +250,7 @@ fn config_hostname(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> 
     let key = IsisLspId::new(isis.config.net.sys_id(), 0, 0);
     for level in [Level::L1, Level::L2] {
         if isis.lsdb.get(&level).get(&key).is_some() {
-            let _ = isis.tx.send(Message::LspOriginate(level));
+            let _ = isis.tx.send(Message::LspOriginate(level, None));
         }
     }
 

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -471,7 +471,7 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
         }
 
         // LSP Originate.
-        link.event(Message::LspOriginate(level));
+        link.event(Message::LspOriginate(level, None));
 
         // CSNP timer for when DIS is me.
         if new_status == DisStatus::Myself && link.timer.csnp.get(&level).is_none() {

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -311,7 +311,9 @@ impl Isis {
                 &Level::L1,
                 "LSP Originate L1 due to RIB router-id change"
             );
-            self.tx.send(Message::LspOriginate(Level::L1)).unwrap();
+            self.tx
+                .send(Message::LspOriginate(Level::L1, None))
+                .unwrap();
         }
         if self.lsdb.get(&Level::L2).get(&key).is_some() {
             isis_event_trace!(
@@ -320,7 +322,9 @@ impl Isis {
                 &Level::L2,
                 "LSP Originate L2 due to RIB router-id change"
             );
-            self.tx.send(Message::LspOriginate(Level::L2)).unwrap();
+            self.tx
+                .send(Message::LspOriginate(Level::L2, None))
+                .unwrap();
         }
     }
 
@@ -371,8 +375,8 @@ impl Isis {
                 };
                 let _ = process_packet(&mut top, packet, ifindex, mac);
             }
-            Message::LspOriginate(level) => {
-                self.process_lsp_originate(level);
+            Message::LspOriginate(level, floor) => {
+                self.process_lsp_originate(level, floor);
             }
             Message::LspPurge(level, lsp_id) => {
                 self.process_lsp_purge(level, lsp_id);
@@ -387,7 +391,7 @@ impl Isis {
                 self.process_lsdb(ev, level, key);
             }
             Message::AdjacencyUp(level, ifindex) => {
-                self.process_lsp_originate(level);
+                self.process_lsp_originate(level, None);
 
                 let Some(mut link) = self.link_top(ifindex) else {
                     return;
@@ -409,9 +413,9 @@ impl Isis {
         }
     }
 
-    fn process_lsp_originate(&mut self, level: Level) {
+    fn process_lsp_originate(&mut self, level: Level, seq_floor: Option<u32>) {
         let mut top = self.top();
-        let mut lsp = lsp_generate(&mut top, level);
+        let mut lsp = lsp_generate(&mut top, level, seq_floor);
         // tracing::info!("[LSP:Gen] {}", lsp.lsp_id);
         let buf = lsp_emit(&mut lsp, level);
         let lsp_id = lsp.lsp_id;
@@ -757,8 +761,8 @@ impl Isis {
         }
         // Re-originate both levels so the new SR snapshot is reflected in
         // the next LSP without waiting for the refresh timer.
-        let _ = self.tx.send(Message::LspOriginate(Level::L1));
-        let _ = self.tx.send(Message::LspOriginate(Level::L2));
+        let _ = self.tx.send(Message::LspOriginate(Level::L1, None));
+        let _ = self.tx.send(Message::LspOriginate(Level::L2, None));
     }
 }
 
@@ -858,17 +862,21 @@ pub fn dis_generate(top: &mut IsisTop, level: Level, ifindex: u32, base: Option<
     lsp
 }
 
-pub fn lsp_generate(top: &mut IsisTop, level: Level) -> IsisLsp {
+pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> IsisLsp {
     // LSP ID with no pseudo id and no fragmentation.
     let lsp_id = IsisLspId::new(top.config.net.sys_id(), 0, 0);
 
-    // Fetch current sequence number if LSP exists.
-    let seq_number = top
-        .lsdb
-        .get(&level)
-        .get(&lsp_id)
-        .map(|x| x.lsp.seq_number + 1)
-        .unwrap_or(0x0001);
+    // ISO 10589 §7.3.16.4: when a peer floods our own LSP back at us
+    // with `recv_seq > existing_seq`, we have to bump the next
+    // emission past `recv_seq` so the network converges on our
+    // authoritative copy. `seq_floor` carries that signal.
+    let existing = top.lsdb.get(&level).get(&lsp_id).map(|x| x.lsp.seq_number);
+    let seq_number = match (existing, seq_floor) {
+        (Some(e), Some(f)) => e.max(f) + 1,
+        (Some(e), None) => e + 1,
+        (None, Some(f)) => f + 1,
+        (None, None) => 0x0001,
+    };
 
     // Logging.
     isis_event_trace!(
@@ -2135,7 +2143,14 @@ pub enum Message {
     Ifsm(IfsmEvent, u32, Option<Level>),
     Recv(IsisPacket, u32, Option<MacAddr>),
     Lsdb(LsdbEvent, Level, IsisLspId),
-    LspOriginate(Level),
+    /// Re-originate the self LSP at `level`. The optional seq-number
+    /// floor carries §7.3.16.4 semantics: when a peer floods our own
+    /// LSP back at us with a seq higher than what we hold, we must
+    /// bump our next emission to `floor + 1` so the network converges
+    /// on our authoritative copy. `None` means "use the natural
+    /// existing+1" — config edits, RIB router-id changes, link-state
+    /// reactions all pass None.
+    LspOriginate(Level, Option<u32>),
     LspPurge(Level, IsisLspId),
     DisOriginate(Level, u32, Option<u32>),
     SpfCalc(Level),
@@ -2161,7 +2176,9 @@ impl Display for Message {
             Message::Lsdb(lsdb_event, _level, _isis_lsp_id) => {
                 write!(f, "[Message::Lsdb({:?})]", lsdb_event)
             }
-            Message::LspOriginate(level) => write!(f, "[Message::LspOriginate({})]", level),
+            Message::LspOriginate(level, floor) => {
+                write!(f, "[Message::LspOriginate({}, floor={:?})]", level, floor)
+            }
             Message::LspPurge(level, lsp_id) => {
                 write!(f, "[Message::LspPurge({}, {})]", level, lsp_id)
             }

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -566,8 +566,8 @@ impl Isis {
         // Re-originate the self LSP at both levels (pseudonode peers
         // dropped, fewer Ext IS Reach entries) and recompute SPF so
         // the route table no longer shows paths via the down link.
-        let _ = self.tx.send(Message::LspOriginate(Level::L1));
-        let _ = self.tx.send(Message::LspOriginate(Level::L2));
+        let _ = self.tx.send(Message::LspOriginate(Level::L1, None));
+        let _ = self.tx.send(Message::LspOriginate(Level::L2, None));
         let _ = self.tx.send(Message::SpfCalc(Level::L1));
         let _ = self.tx.send(Message::SpfCalc(Level::L2));
     }
@@ -702,7 +702,9 @@ fn config_afi_enable(isis: &mut Isis, mut args: Args, op: ConfigOp, afi: Afi) ->
                 &Level::L1,
                 "LSP Originate L1 due to protocols-supported change"
             );
-            isis.tx.send(Message::LspOriginate(Level::L1)).unwrap();
+            isis.tx
+                .send(Message::LspOriginate(Level::L1, None))
+                .unwrap();
         }
         if isis.lsdb.get(&Level::L2).get(&key).is_some() {
             isis_event_trace!(
@@ -711,7 +713,9 @@ fn config_afi_enable(isis: &mut Isis, mut args: Args, op: ConfigOp, afi: Afi) ->
                 &Level::L2,
                 "LSP Originate L2 due to protocols-supported change"
             );
-            isis.tx.send(Message::LspOriginate(Level::L2)).unwrap();
+            isis.tx
+                .send(Message::LspOriginate(Level::L2, None))
+                .unwrap();
         }
     }
 
@@ -762,7 +766,9 @@ pub fn config_metric(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()
             &Level::L1,
             "LSP Originate L1 due to metric change"
         );
-        isis.tx.send(Message::LspOriginate(Level::L1)).unwrap();
+        isis.tx
+            .send(Message::LspOriginate(Level::L1, None))
+            .unwrap();
     }
 
     // Originate L2 LSP.
@@ -773,7 +779,9 @@ pub fn config_metric(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()
             &Level::L2,
             "LSP Originate L2 due to metric change"
         );
-        isis.tx.send(Message::LspOriginate(Level::L2)).unwrap();
+        isis.tx
+            .send(Message::LspOriginate(Level::L2, None))
+            .unwrap();
     }
 
     Some(())

--- a/zebra-rs/src/isis/nfsm.rs
+++ b/zebra-rs/src/isis/nfsm.rs
@@ -75,7 +75,7 @@ pub fn nbr_hold_timer_expire(link: &mut LinkTop, level: Level, sys_id: IsisSysId
     // Originate Hello and LSP.
     if is_p2p {
         nbr.event(Message::Ifsm(HelloOriginate, ifindex, Some(level)));
-        nbr.event(Message::LspOriginate(level));
+        nbr.event(Message::LspOriginate(level, None));
     } else {
         // DIS election. Run before we drop the entry so the snapshot
         // it operates on still has this neighbor.

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -254,7 +254,7 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
         link.lsdb.get_mut(&level).adj_set(link.ifindex);
 
         nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
-        nbr.event(Message::LspOriginate(level));
+        nbr.event(Message::LspOriginate(level, None));
     }
 
     // When neighbor state has been changed.
@@ -390,6 +390,7 @@ pub fn csnp_recv(link: &mut LinkTop, level: Level, pdu: IsisCsnp) {
     for entry in pdu.tlvs.iter() {
         if let IsisTlv::LspEntries(tlv) = entry {
             for lsp in &tlv.entries {
+                tracing::info!("CSNP LSP ID: {} SEQ {}", lsp.lsp_id, lsp.seq_number);
                 match lsdb
                     .get(&lsp.lsp_id)
                     .map(|seq_number| lsp.seq_number.cmp(seq_number))
@@ -626,6 +627,12 @@ pub fn lsp_recv(link: &mut LinkTop, level: Level, lsp: IsisLsp, bytes: Vec<u8>) 
         return;
     }
 
+    // Detect self-originated LSPs (regular self LSP at pseudo_id 0,
+    // or any pseudonode LSP we originated as DIS — both share our
+    // sys_id). ISO 10589 §7.3.16.4 says we must hold the network on
+    // our authoritative copy, not adopt the peer's view of "ours".
+    let is_self = link.up_config.net.sys_id() == lsp.lsp_id.sys_id();
+
     // 7.3.15.1 Action on receipt of a link state PDU
     match link
         .lsdb
@@ -634,33 +641,54 @@ pub fn lsp_recv(link: &mut LinkTop, level: Level, lsp: IsisLsp, bytes: Vec<u8>) 
         .map(|lsa| lsp.seq_number.cmp(&lsa.lsp.seq_number))
     {
         None | Some(Ordering::Greater) => {
-            // 7.3.15.1 e.1
+            if is_self {
+                // §7.3.16.4: a peer is holding our LSP at a higher
+                // seq than what's in our LSDB (typically because we
+                // restarted and lost the high-water mark, or the LSP
+                // aged out and was re-introduced). Bump the next
+                // emission to `recv_seq + 1` so the network
+                // converges on our authoritative copy. The
+                // `Message::LspOriginate` / `Message::DisOriginate`
+                // handler will run `srm_set_all` on the new LSP, so
+                // the peer naturally gets it back via the normal
+                // flooding path — no `srm_clear` here, that would
+                // suppress the very flood we want.
+                let msg = if lsp.lsp_id.is_pseudo() {
+                    Message::DisOriginate(
+                        level,
+                        lsp.lsp_id.pseudo_id() as u32,
+                        Some(lsp.seq_number),
+                    )
+                } else {
+                    Message::LspOriginate(level, Some(lsp.seq_number))
+                };
+                let _ = link.tx.send(msg);
+            } else {
+                // 7.3.15.1 e.1
+                // 1. Store the new LSP in the database, overwriting the
+                //    existing database LSP for that source (if any) with the
+                //    received LSP.
+                lsdb::insert_lsp(link, level, lsp.clone(), bytes);
 
-            // 1. Store the new LSP in the database, overwriting the
-            //    existing database LSP for that source (if any) with the
-            //    received LSP.
+                // 2. Set SRMflag for that LSP for all circuits other than C.
+                flood::srm_set_other(link, level, &lsp.lsp_id);
 
-            // TODO: We may consider update self originated LSP when it really
-            // overwrite existing one.
-            lsdb::insert_lsp(link, level, lsp.clone(), bytes);
+                // 3. Clear SRMflag for C.
+                flood::srm_clear(link, level, &lsp.lsp_id);
 
-            // 2. Set SRMflag for that LSP for all circuits other than C.
-            flood::srm_set_other(link, level, &lsp.lsp_id);
+                // 4. If C is a non-broadcast circuit, set SSNflag for that LSP for C.
+                if link.is_p2p() {
+                    flood::ssn_set(link, level, &IsisLspEntry::from_lsp(&lsp));
+                }
 
-            // 3. Clear SRMflag for C.
-            flood::srm_clear(link, level, &lsp.lsp_id);
-
-            // 4. If C is a non-broadcast circuit, set SSNflag for that LSP for C.
-            if link.is_p2p() {
-                flood::ssn_set(link, level, &IsisLspEntry::from_lsp(&lsp));
+                // 5. Clear SSNflag for that LSP for the circuits associated
+                //    with a linkage other than C.
+                flood::ssn_clear_other(link, level, &lsp.lsp_id);
             }
-
-            // 5. Clear SSNflag for that LSP for the circuits associated
-            //    with a linkage other than C.
-            flood::ssn_clear_other(link, level, &lsp.lsp_id);
         }
         Some(Ordering::Equal) => {
-            // 7.3.15.1 e.2
+            // 7.3.15.1 e.2 — same for self / non-self: peer mirrors
+            // what we hold, so just ack via SSN on P2P.
 
             // 1. Clear SRMflag for C.
             flood::srm_clear(link, level, &lsp.lsp_id);
@@ -672,7 +700,8 @@ pub fn lsp_recv(link: &mut LinkTop, level: Level, lsp: IsisLsp, bytes: Vec<u8>) 
             }
         }
         Some(Ordering::Less) => {
-            // 7.3.15.1 e.3
+            // 7.3.15.1 e.3 — same for self / non-self: peer holds a
+            // stale copy, set SRM toward C so our copy floods back.
 
             // 1. Set SRMflag for C.
             flood::srm_set(link, level, &lsp.lsp_id);

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -390,7 +390,6 @@ pub fn csnp_recv(link: &mut LinkTop, level: Level, pdu: IsisCsnp) {
     for entry in pdu.tlvs.iter() {
         if let IsisTlv::LspEntries(tlv) = entry {
             for lsp in &tlv.entries {
-                tracing::info!("CSNP LSP ID: {} SEQ {}", lsp.lsp_id, lsp.seq_number);
                 match lsdb
                     .get(&lsp.lsp_id)
                     .map(|seq_number| lsp.seq_number.cmp(seq_number))


### PR DESCRIPTION
## Summary

ISO 10589 §7.3.16.4 says that when a peer floods our own LSP back at us with a seq higher than what's in our LSDB, we have to bump the next emission past their seq so the network converges on our authoritative copy. Today \`lsdb::insert_lsp\` quietly bails on the sys-id match — if the peer's copy was higher (post-restart high-water-mark loss, or an aged-out LSP coming back through CSNP) we never re-originated past it and the network silently held the wrong topology until something else nudged it.

### Wires
- \`Message::LspOriginate(Level)\` becomes \`LspOriginate(Level, Option<u32>)\`. The optional seq floor means "force the next emission to \`max(existing+1, floor+1)\`."
- \`lsp_generate\` honors the floor.
- \`lsp_recv\` detects the sys-id match upfront. For the Greater/None branch (peer's seq ≥ ours) it dispatches the bump-and-re-originate via \`LspOriginate(level, Some(recv_seq))\` for the regular self LSP, or \`DisOriginate(..., Some(recv_seq))\` for a pseudonode LSP we own as DIS. The re-originate's \`srm_set_all\` floods the new copy back to the source naturally — no \`srm_clear\` here, that would suppress the very flood we want.
- Equal / Less branches are correct for self-originated already and stay unchanged.
- The defensive sys-id bail in \`lsdb::insert_lsp\` stays as belt-and-suspenders, but the upfront detection in \`lsp_recv\` means it shouldn't fire any more. The TODO at \`packet.rs:644\` is gone.

## Test plan

- [x] \`cargo build --bin zebra-rs\`
- [x] \`cargo clippy --bin zebra-rs\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test --lib --workspace --exclude bdd\`
- [ ] Manual: bring up an IS-IS peering, flood the self LSP a few times, restart zebra-rs (LSDB starts empty for that LSP). Within one CSNP round, the new LSP should emerge with seq ≥ N+1 instead of starting back at 1.

Generated with [Claude Code](https://claude.com/claude-code)