### PR TITLE
chore: remove per-file SPDX / copyright headers

### DIFF
--- a/bdd/src/lib.rs
+++ b/bdd/src/lib.rs
@@ -1,4 +1,1 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod netns;

--- a/bdd/src/main.rs
+++ b/bdd/src/main.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod netns;
 
 #[tokio::main]

--- a/bdd/src/netns.rs
+++ b/bdd/src/netns.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use anyhow::{Context, Result, bail};
 use std::process::Stdio;
 use tokio::process::Command;

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fs;
 
 use bdd::netns;

--- a/crates/bgp-macros/src/lib.rs
+++ b/crates/bgp-macros/src/lib.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{ItemFn, Token, parse_macro_input};

--- a/crates/bgp-packet/src/afi.rs
+++ b/crates/bgp-packet/src/afi.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 
 use nom::IResult;

--- a/crates/bgp-packet/src/attrs/aggregator.rs
+++ b/crates/bgp-packet/src/attrs/aggregator.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bytes::{BufMut, BytesMut};

--- a/crates/bgp-packet/src/attrs/aigp.rs
+++ b/crates/bgp-packet/src/attrs/aigp.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bytes::{BufMut, BytesMut};

--- a/crates/bgp-packet/src/attrs/aspath.rs
+++ b/crates/bgp-packet/src/attrs/aspath.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bytes::{BufMut, BytesMut};
 use nom::IResult;
 use nom::multi::count;

--- a/crates/bgp-packet/src/attrs/aspath_token.rs
+++ b/crates/bgp-packet/src/attrs/aspath_token.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 #[derive(Debug, PartialEq)]
 pub enum Token {
     As(u32),

--- a/crates/bgp-packet/src/attrs/atomic.rs
+++ b/crates/bgp-packet/src/attrs/atomic.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bytes::BytesMut;

--- a/crates/bgp-packet/src/attrs/attr.rs
+++ b/crates/bgp-packet/src/attrs/attr.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bytes::BytesMut;

--- a/crates/bgp-packet/src/attrs/cluster_list.rs
+++ b/crates/bgp-packet/src/attrs/cluster_list.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 use std::net::Ipv4Addr;
 

--- a/crates/bgp-packet/src/attrs/com.rs
+++ b/crates/bgp-packet/src/attrs/com.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bytes::{BufMut, BytesMut};
 use nom_derive::NomBE;
 use std::collections::{BTreeSet, HashMap};

--- a/crates/bgp-packet/src/attrs/emitter.rs
+++ b/crates/bgp-packet/src/attrs/emitter.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bytes::{BufMut, BytesMut};
 
 use crate::{AttrFlags, AttrType};

--- a/crates/bgp-packet/src/attrs/ext_com.rs
+++ b/crates/bgp-packet/src/attrs/ext_com.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 use std::net::Ipv4Addr;
 use std::str::FromStr;

--- a/crates/bgp-packet/src/attrs/ext_com_token.rs
+++ b/crates/bgp-packet/src/attrs/ext_com_token.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::str::FromStr;
 
 use super::RouteDistinguisher;

--- a/crates/bgp-packet/src/attrs/ext_com_type.rs
+++ b/crates/bgp-packet/src/attrs/ext_com_type.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use strum_macros::{Display, EnumString};
 

--- a/crates/bgp-packet/src/attrs/ext_ipv6_com.rs
+++ b/crates/bgp-packet/src/attrs/ext_ipv6_com.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bytes::{BufMut, BytesMut};
 use nom_derive::NomBE;
 use std::fmt;

--- a/crates/bgp-packet/src/attrs/ext_ipv6_com_token.rs
+++ b/crates/bgp-packet/src/attrs/ext_ipv6_com_token.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::Ipv6Addr;
 
 use regex::Regex;

--- a/crates/bgp-packet/src/attrs/flags.rs
+++ b/crates/bgp-packet/src/attrs/flags.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bitflags::bitflags;
 use serde::Serialize;
 use std::fmt;

--- a/crates/bgp-packet/src/attrs/large_com.rs
+++ b/crates/bgp-packet/src/attrs/large_com.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bytes::{BufMut, BytesMut};
 use nom_derive::NomBE;
 use std::collections::BTreeSet;

--- a/crates/bgp-packet/src/attrs/local_pref.rs
+++ b/crates/bgp-packet/src/attrs/local_pref.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bytes::{BufMut, BytesMut};

--- a/crates/bgp-packet/src/attrs/med.rs
+++ b/crates/bgp-packet/src/attrs/med.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bytes::{BufMut, BytesMut};

--- a/crates/bgp-packet/src/attrs/mod.rs
+++ b/crates/bgp-packet/src/attrs/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod attr;
 pub use attr::*;
 

--- a/crates/bgp-packet/src/attrs/mp_reach.rs
+++ b/crates/bgp-packet/src/attrs/mp_reach.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 

--- a/crates/bgp-packet/src/attrs/mp_unreach.rs
+++ b/crates/bgp-packet/src/attrs/mp_unreach.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bytes::BytesMut;

--- a/crates/bgp-packet/src/attrs/nexthop.rs
+++ b/crates/bgp-packet/src/attrs/nexthop.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 use std::net::Ipv4Addr;
 

--- a/crates/bgp-packet/src/attrs/nlri_evpn.rs
+++ b/crates/bgp-packet/src/attrs/nlri_evpn.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 

--- a/crates/bgp-packet/src/attrs/nlri_ipv4.rs
+++ b/crates/bgp-packet/src/attrs/nlri_ipv4.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::Ipv4Addr;
 
 use ipnet::Ipv4Net;

--- a/crates/bgp-packet/src/attrs/nlri_ipv6.rs
+++ b/crates/bgp-packet/src/attrs/nlri_ipv6.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::Ipv6Addr;
 
 use ipnet::Ipv6Net;

--- a/crates/bgp-packet/src/attrs/nlri_rtcv4.rs
+++ b/crates/bgp-packet/src/attrs/nlri_rtcv4.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::{IpAddr, Ipv4Addr};
 
 use bytes::{BufMut, BytesMut};

--- a/crates/bgp-packet/src/attrs/nlri_vpnv4.rs
+++ b/crates/bgp-packet/src/attrs/nlri_vpnv4.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 use std::net::Ipv4Addr;
 

--- a/crates/bgp-packet/src/attrs/origin.rs
+++ b/crates/bgp-packet/src/attrs/origin.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bytes::{BufMut, BytesMut};

--- a/crates/bgp-packet/src/attrs/originator_id.rs
+++ b/crates/bgp-packet/src/attrs/originator_id.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bytes::{BufMut, BytesMut};

--- a/crates/bgp-packet/src/attrs/pmsi_tunnel.rs
+++ b/crates/bgp-packet/src/attrs/pmsi_tunnel.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 use std::net::Ipv4Addr;
 

--- a/crates/bgp-packet/src/attrs/rd.rs
+++ b/crates/bgp-packet/src/attrs/rd.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use nom_derive::*;
 use std::fmt;
 use std::net::Ipv4Addr;

--- a/crates/bgp-packet/src/bgp_attr.rs
+++ b/crates/bgp-packet/src/bgp_attr.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bytes::BytesMut;

--- a/crates/bgp-packet/src/bgp_cap.rs
+++ b/crates/bgp-packet/src/bgp_cap.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 use std::fmt;
 

--- a/crates/bgp-packet/src/bgp_nexthop.rs
+++ b/crates/bgp-packet/src/bgp_nexthop.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::{IpAddr, Ipv4Addr};
 
 use crate::Vpnv4Nexthop;

--- a/crates/bgp-packet/src/caps/addpath.rs
+++ b/crates/bgp-packet/src/caps/addpath.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bytes::{BufMut, BytesMut};

--- a/crates/bgp-packet/src/caps/as4.rs
+++ b/crates/bgp-packet/src/caps/as4.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bytes::{BufMut, BytesMut};

--- a/crates/bgp-packet/src/caps/dynamic.rs
+++ b/crates/bgp-packet/src/caps/dynamic.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use nom_derive::*;

--- a/crates/bgp-packet/src/caps/emit.rs
+++ b/crates/bgp-packet/src/caps/emit.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bytes::{BufMut, BytesMut};
 
 use super::CapCode;

--- a/crates/bgp-packet/src/caps/extend.rs
+++ b/crates/bgp-packet/src/caps/extend.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use nom_derive::*;

--- a/crates/bgp-packet/src/caps/fqdn.rs
+++ b/crates/bgp-packet/src/caps/fqdn.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::{borrow::Cow, fmt};
 
 use bytes::{BufMut, BytesMut};

--- a/crates/bgp-packet/src/caps/graceful.rs
+++ b/crates/bgp-packet/src/caps/graceful.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bitfield_struct::bitfield;

--- a/crates/bgp-packet/src/caps/llgr.rs
+++ b/crates/bgp-packet/src/caps/llgr.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bitfield_struct::bitfield;

--- a/crates/bgp-packet/src/caps/mod.rs
+++ b/crates/bgp-packet/src/caps/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod typ;
 pub use typ::CapCode;
 

--- a/crates/bgp-packet/src/caps/mp.rs
+++ b/crates/bgp-packet/src/caps/mp.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bytes::{BufMut, BytesMut};

--- a/crates/bgp-packet/src/caps/packet.rs
+++ b/crates/bgp-packet/src/caps/packet.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bytes::BytesMut;

--- a/crates/bgp-packet/src/caps/path_limit.rs
+++ b/crates/bgp-packet/src/caps/path_limit.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bytes::{BufMut, BytesMut};

--- a/crates/bgp-packet/src/caps/refresh.rs
+++ b/crates/bgp-packet/src/caps/refresh.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use nom_derive::*;

--- a/crates/bgp-packet/src/caps/typ.rs
+++ b/crates/bgp-packet/src/caps/typ.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use nom::IResult;
 use nom::number::complete::be_u8;
 use nom_derive::*;

--- a/crates/bgp-packet/src/caps/unknown.rs
+++ b/crates/bgp-packet/src/caps/unknown.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bytes::{BufMut, BytesMut};

--- a/crates/bgp-packet/src/caps/version.rs
+++ b/crates/bgp-packet/src/caps/version.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::{borrow::Cow, fmt};
 
 use bytes::{BufMut, BytesMut};

--- a/crates/bgp-packet/src/error.rs
+++ b/crates/bgp-packet/src/error.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use thiserror::Error;
 
 use crate::AttrType;

--- a/crates/bgp-packet/src/label.rs
+++ b/crates/bgp-packet/src/label.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 // MPLS Label encoding (RFC 3032):
 // 0                   1                   2                   3
 // 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1

--- a/crates/bgp-packet/src/lib.rs
+++ b/crates/bgp-packet/src/lib.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod notification;
 pub mod open;
 pub mod packet;

--- a/crates/bgp-packet/src/notification.rs
+++ b/crates/bgp-packet/src/notification.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt::Display;
 
 use super::{BGP_HEADER_LEN, BgpHeader, BgpType};

--- a/crates/bgp-packet/src/open.rs
+++ b/crates/bgp-packet/src/open.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 use std::net::Ipv4Addr;
 

--- a/crates/bgp-packet/src/packet.rs
+++ b/crates/bgp-packet/src/packet.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bytes::{BufMut, BytesMut};
 use nom_derive::*;
 

--- a/crates/bgp-packet/src/parse_be.rs
+++ b/crates/bgp-packet/src/parse_be.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::Ipv4Addr;
 
 use nom::{IResult, number::complete::be_u32};

--- a/crates/bgp-packet/src/parser.rs
+++ b/crates/bgp-packet/src/parser.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 
 use nom::combinator::peek;

--- a/crates/bgp-packet/src/update.rs
+++ b/crates/bgp-packet/src/update.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 use bytes::{BufMut, BytesMut};

--- a/crates/bgp-packet/src/util.rs
+++ b/crates/bgp-packet/src/util.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub fn u32_u24(value: u32) -> [u8; 3] {
     // Extract the three least significant bytes as big-endian
     [

--- a/crates/bgp-packet/tests/error_test.rs
+++ b/crates/bgp-packet/tests/error_test.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bgp_packet::{BgpPacket, BgpParseError};
 use hex_literal::hex;
 

--- a/crates/bgp-packet/tests/parser.rs
+++ b/crates/bgp-packet/tests/parser.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bgp_packet::*;
 use hex_literal::hex;
 

--- a/crates/fixedbuf/src/lib.rs
+++ b/crates/fixedbuf/src/lib.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use byteorder::{BigEndian, ByteOrder};
 use bytes::{BufMut, BytesMut};
 use thiserror::Error;

--- a/crates/isis-macros/src/lib.rs
+++ b/crates/isis-macros/src/lib.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{ItemFn, Token, parse_macro_input};

--- a/crates/isis-packet/src/checksum.rs
+++ b/crates/isis-packet/src/checksum.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub fn is_valid_checksum(input: &[u8]) -> bool {
     if input.len() < 12 {
         return false;

--- a/crates/isis-packet/src/disp.rs
+++ b/crates/isis-packet/src/disp.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt::{Display, Formatter, Result};
 
 use itertools::Itertools;

--- a/crates/isis-packet/src/error.rs
+++ b/crates/isis-packet/src/error.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use crate::{IsisTlvType, IsisType};
 use nom::{ErrorConvert, error::ParseError};
 use thiserror::Error;

--- a/crates/isis-packet/src/lib.rs
+++ b/crates/isis-packet/src/lib.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 mod checksum;
 mod disp;
 mod error;

--- a/crates/isis-packet/src/nsap.rs
+++ b/crates/isis-packet/src/nsap.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 use std::num::ParseIntError;
 use std::str::FromStr;

--- a/crates/isis-packet/src/padding.rs
+++ b/crates/isis-packet/src/padding.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bytes::BytesMut;
 
 use crate::{

--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use bitfield_struct::bitfield;

--- a/crates/isis-packet/src/sub/cap.rs
+++ b/crates/isis-packet/src/sub/cap.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::Ipv4Addr;
 
 use bitfield_struct::bitfield;

--- a/crates/isis-packet/src/sub/cap_code.rs
+++ b/crates/isis-packet/src/sub/cap_code.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use nom::IResult;
 use nom::number::complete::be_u8;
 use nom_derive::*;

--- a/crates/isis-packet/src/sub/cap_disp.rs
+++ b/crates/isis-packet/src/sub/cap_disp.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt::{Display, Formatter, Result};
 
 use super::cap::{IsisSubSrv6, IsisSubTlv, RouterCapFlags};

--- a/crates/isis-packet/src/sub/mod.rs
+++ b/crates/isis-packet/src/sub/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub use nom_derive::*;
 
 #[derive(NomBE)]

--- a/crates/isis-packet/src/sub/neigh.rs
+++ b/crates/isis-packet/src/sub/neigh.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use super::prefix::MultiTopologyId;

--- a/crates/isis-packet/src/sub/neigh_code.rs
+++ b/crates/isis-packet/src/sub/neigh_code.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use nom::IResult;
 use nom::number::complete::be_u8;
 use nom_derive::*;

--- a/crates/isis-packet/src/sub/neigh_disp.rs
+++ b/crates/isis-packet/src/sub/neigh_disp.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt::{Display, Formatter, Result};
 
 use super::neigh::{IsisSubAdjSid, IsisSubAdminGrp, IsisSubAsla, IsisSubTlv};

--- a/crates/isis-packet/src/sub/prefix.rs
+++ b/crates/isis-packet/src/sub/prefix.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use bitfield_struct::bitfield;

--- a/crates/isis-packet/src/sub/prefix_code.rs
+++ b/crates/isis-packet/src/sub/prefix_code.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use nom::IResult;
 use nom::number::complete::be_u8;
 use nom_derive::*;

--- a/crates/isis-packet/src/sub/prefix_disp.rs
+++ b/crates/isis-packet/src/sub/prefix_disp.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt::{Display, Formatter, Result};
 
 use super::prefix::{

--- a/crates/isis-packet/src/sub/srv6.rs
+++ b/crates/isis-packet/src/sub/srv6.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt::{Display, Formatter, Result};
 use std::str::FromStr;
 

--- a/crates/isis-packet/src/sub/unknown.rs
+++ b/crates/isis-packet/src/sub/unknown.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bytes::{BufMut, BytesMut};
 use nom_derive::*;
 use serde::{Deserialize, Serialize};

--- a/crates/isis-packet/src/tlv_type.rs
+++ b/crates/isis-packet/src/tlv_type.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use nom::IResult;
 use nom::number::complete::be_u8;
 use nom_derive::*;

--- a/crates/isis-packet/src/typ.rs
+++ b/crates/isis-packet/src/typ.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt::Display;
 
 use nom::IResult;

--- a/crates/isis-packet/src/util.rs
+++ b/crates/isis-packet/src/util.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bytes::{BufMut, BytesMut};
 
 pub use packet_utils::{ParseBe, TlvEmitter, u32_u8_3, write_hold_time};

--- a/crates/isis-packet/tests/error.rs
+++ b/crates/isis-packet/tests/error.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use isis_packet::*;
 
 #[test]

--- a/crates/isis-packet/tests/json.rs
+++ b/crates/isis-packet/tests/json.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use isis_packet::*;
 
 #[test]

--- a/crates/isis-packet/tests/padding.rs
+++ b/crates/isis-packet/tests/padding.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bytes::BytesMut;
 use isis_packet::*;
 

--- a/crates/isis-packet/tests/parser.rs
+++ b/crates/isis-packet/tests/parser.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bytes::BytesMut;
 use hex_literal::hex;
 use isis_packet::*;

--- a/crates/ospf-macros/src/lib.rs
+++ b/crates/ospf-macros/src/lib.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{ItemFn, Token, parse_macro_input};

--- a/crates/ospf-packet/src/disp.rs
+++ b/crates/ospf-packet/src/disp.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt::{Display, Formatter, Result};
 
 use super::*;

--- a/crates/ospf-packet/src/lib.rs
+++ b/crates/ospf-packet/src/lib.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 mod disp;
 mod ls_type;
 mod parser;

--- a/crates/ospf-packet/src/ls_type.rs
+++ b/crates/ospf-packet/src/ls_type.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt::Display;
 
 use nom::number::complete::be_u8;

--- a/crates/ospf-packet/src/parser.rs
+++ b/crates/ospf-packet/src/parser.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 use std::net::Ipv4Addr;
 

--- a/crates/ospf-packet/src/typ.rs
+++ b/crates/ospf-packet/src/typ.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt::Display;
 
 use nom::number::complete::be_u8;

--- a/crates/ospf-packet/src/util.rs
+++ b/crates/ospf-packet/src/util.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bytes::BytesMut;
 pub use packet_utils::ParseBe;
 

--- a/crates/ospf-packet/tests/ospfv2.rs
+++ b/crates/ospf-packet/tests/ospfv2.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bytes::BytesMut;
 use hex_literal::hex;
 use nom_derive::Parse;

--- a/crates/packet-utils/src/algo.rs
+++ b/crates/packet-utils/src/algo.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt::{Display, Formatter, Result};
 
 use nom::IResult;

--- a/crates/packet-utils/src/lib.rs
+++ b/crates/packet-utils/src/lib.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 mod algo;
 mod many0;
 mod safe_split_at;

--- a/crates/packet-utils/src/many0.rs
+++ b/crates/packet-utils/src/many0.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use nom::combinator::complete;
 use nom::error::ParseError;
 use nom::multi::many0;

--- a/crates/packet-utils/src/safe_split_at.rs
+++ b/crates/packet-utils/src/safe_split_at.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use nom::{Err, IResult, Needed};
 
 /// Split `input` at position `len`, returning `(remaining, head)` as an `IResult`.

--- a/crates/packet-utils/src/sid_label.rs
+++ b/crates/packet-utils/src/sid_label.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bytes::{BufMut, BytesMut};
 use nom::number::complete::{be_u8, be_u24, be_u32};
 use nom::{Err, IResult, Needed};

--- a/crates/packet-utils/src/util.rs
+++ b/crates/packet-utils/src/util.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use byteorder::{BigEndian, ByteOrder};

--- a/vtyctl/build.rs
+++ b/vtyctl/build.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("../proto/vtysh.proto")?;
     Ok(())

--- a/vtyctl/src/apply.rs
+++ b/vtyctl/src/apply.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use anyhow::Result;
 use std::fs::File;
 use std::io::{BufRead, BufReader};

--- a/vtyctl/src/clear.rs
+++ b/vtyctl/src/clear.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use anyhow::Result;
 use std::process::exit;
 use tonic::Request;

--- a/vtyctl/src/main.rs
+++ b/vtyctl/src/main.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 

--- a/vtyctl/src/mcp/client.rs
+++ b/vtyctl/src/mcp/client.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use anyhow::Result;
 use tokio_stream::StreamExt;
 use tonic::Request;

--- a/vtyctl/src/mcp/mod.rs
+++ b/vtyctl/src/mcp/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod client;
 pub mod server;
 pub mod tools;

--- a/vtyctl/src/mcp/server.rs
+++ b/vtyctl/src/mcp/server.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use anyhow::Result;
 use serde_json::{Value, json};
 use std::collections::HashMap;

--- a/vtyctl/src/mcp/tools/isis.rs
+++ b/vtyctl/src/mcp/tools/isis.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use anyhow::Result;
 use serde_json::{Value, json};
 use std::collections::HashMap;

--- a/vtyctl/src/mcp/tools/mod.rs
+++ b/vtyctl/src/mcp/tools/mod.rs
@@ -1,4 +1,1 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod isis;

--- a/vtyctl/src/show.rs
+++ b/vtyctl/src/show.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use anyhow::Result;
 use std::process::exit;
 use tonic::Request;

--- a/vtyhelper/build.rs
+++ b/vtyhelper/build.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("../proto/vtysh.proto")?;
     Ok(())

--- a/vtyhelper/src/main.rs
+++ b/vtyhelper/src/main.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use anyhow::Result;
 use clap::Parser;
 use std::env;

--- a/zebra-rs/build.rs
+++ b/zebra-rs/build.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::process::Command;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/zebra-rs/src/bgp/adj_rib.rs
+++ b/zebra-rs/src/bgp/adj_rib.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
 

--- a/zebra-rs/src/bgp/cap.rs
+++ b/zebra-rs/src/bgp/cap.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 // Capability for sent and received.
 
 use std::collections::HashMap;

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::{IpAddr, Ipv4Addr};
 
 use bgp_packet::*;

--- a/zebra-rs/src/bgp/constant.rs
+++ b/zebra-rs/src/bgp/constant.rs
@@ -1,5 +1,2 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub const BGP_PORT: u16 = 179;
 // pub const BGP_HOLD_TIME: u16 = 90;

--- a/zebra-rs/src/bgp/debug.rs
+++ b/zebra-rs/src/bgp/debug.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 /// BGP debug configuration flags for selective logging
 use serde::{Deserialize, Serialize};
 

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use super::BgpAttrStore;
 use super::peer::{BgpTop, Event, fsm};
 use super::peer_map::PeerMap;

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod inst;
 pub use inst::{Bgp, Message, serve};
 

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 #![allow(dead_code)]
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};

--- a/zebra-rs/src/bgp/peer_map.rs
+++ b/zebra-rs/src/bgp/peer_map.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 use std::net::IpAddr;
 

--- a/zebra-rs/src/bgp/policy.rs
+++ b/zebra-rs/src/bgp/policy.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use crate::policy::{PolicyList, PrefixSet};
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Write;
 use std::net::{IpAddr, Ipv4Addr};

--- a/zebra-rs/src/bgp/store.rs
+++ b/zebra-rs/src/bgp/store.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::HashMap;
 use std::sync::{Arc, Weak};
 

--- a/zebra-rs/src/bgp/timer.rs
+++ b/zebra-rs/src/bgp/timer.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::cmp::min;
 
 use bgp_packet::{AfiSafi, OpenPacket};

--- a/zebra-rs/src/bgp/tracing.rs
+++ b/zebra-rs/src/bgp/tracing.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 /// BGP-specific tracing macros that automatically include proto="bgp" field
 ///
 /// This module provides convenience macros for BGP protocol logging that automatically

--- a/zebra-rs/src/config/api.rs
+++ b/zebra-rs/src/config/api.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use super::vtysh::CommandPath;
 use super::{ApplyCode, Completion, ExecCode};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};

--- a/zebra-rs/src/config/commands.rs
+++ b/zebra-rs/src/config/commands.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use super::ExecCode;
 use super::manager::ConfigManager;
 use super::util::trim_first_line;

--- a/zebra-rs/src/config/comps.rs
+++ b/zebra-rs/src/config/comps.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use super::Config;
 use super::parse::State;
 use super::parse::{entry_is_key, ymatch_complete, ytype_from_typedef};

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bgp_packet::{Afi, AfiSafi, Safi};
 
 use super::Completion;

--- a/zebra-rs/src/config/files.rs
+++ b/zebra-rs/src/config/files.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use super::token::Token;
 use super::token::tokenizer;
 

--- a/zebra-rs/src/config/ip.rs
+++ b/zebra-rs/src/config/ip.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 // IP address and prefix match include partial match. It is required to perform
 // CLI completion with partial input.
 

--- a/zebra-rs/src/config/isis.rs
+++ b/zebra-rs/src/config/isis.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use crate::context::Context;
 use crate::isis::inst;
 

--- a/zebra-rs/src/config/json.rs
+++ b/zebra-rs/src/config/json.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use libyang::Entry;
 use serde_json::Value;
 use std::rc::Rc;

--- a/zebra-rs/src/config/mac.rs
+++ b/zebra-rs/src/config/mac.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use super::parse::MatchType;
 
 pub fn match_mac_addr(src: &str) -> (MatchType, usize) {

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use crate::config::api::{ClearTxResponse, DeployResponse, DisplayTxResponse};
 
 use super::api::{CompletionResponse, ConfigOp, ExecuteResponse, Message};

--- a/zebra-rs/src/config/mod.rs
+++ b/zebra-rs/src/config/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 mod vtysh {
     tonic::include_proto!("vtysh");
 }

--- a/zebra-rs/src/config/mode.rs
+++ b/zebra-rs/src/config/mode.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use super::manager::ConfigStore;
 use super::ExecCode;
 use libyang::Entry;

--- a/zebra-rs/src/config/nsap.rs
+++ b/zebra-rs/src/config/nsap.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use super::parse::MatchType;
 
 /// Match NSAP address format.

--- a/zebra-rs/src/config/ospf.rs
+++ b/zebra-rs/src/config/ospf.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use crate::context::Context;
 use crate::ospf::inst;
 

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use super::comps::{
     centry, cleaf, cname, comps_add_all, comps_add_config, comps_add_cr, comps_append, crange,
 };

--- a/zebra-rs/src/config/paths.rs
+++ b/zebra-rs/src/config/paths.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::VecDeque;
 
 use super::Args;

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::HashMap;
 use tokio::sync::mpsc::{Sender, UnboundedSender};
 use tokio::sync::{mpsc, oneshot};

--- a/zebra-rs/src/config/token.rs
+++ b/zebra-rs/src/config/token.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::iter::{self, from_fn};
 
 #[derive(Debug, PartialEq)]

--- a/zebra-rs/src/config/util.rs
+++ b/zebra-rs/src/config/util.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 // String utilities.
 
 pub fn is_whitespace(s: &str, pos: usize) -> bool {

--- a/zebra-rs/src/config/yaml.rs
+++ b/zebra-rs/src/config/yaml.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub fn yaml_parse(str: &str) -> String {
     let yaml_value: serde_yaml::Value = serde_yaml::from_str(str).unwrap();
     serde_json::to_string(&yaml_value).unwrap()

--- a/zebra-rs/src/context/inst.rs
+++ b/zebra-rs/src/context/inst.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 // Context has 3 contexts.
 //
 // 1. Socket context

--- a/zebra-rs/src/context/mod.rs
+++ b/zebra-rs/src/context/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod inst;
 pub use inst::Context;
 

--- a/zebra-rs/src/context/task.rs
+++ b/zebra-rs/src/context/task.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::future::Future;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};

--- a/zebra-rs/src/fib/macos.rs
+++ b/zebra-rs/src/fib/macos.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use super::message::{FibAddr, FibLink, FibMessage, FibRoute};
 use crate::rib::entry::RibEntry;
 use crate::rib::link;

--- a/zebra-rs/src/fib/message.rs
+++ b/zebra-rs/src/fib/message.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use ipnet::IpNet;
 use netlink_packet_route::link::LinkFlags;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};

--- a/zebra-rs/src/fib/mod.rs
+++ b/zebra-rs/src/fib/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 #[cfg(target_os = "linux")]
 pub mod netlink;
 #[cfg(target_os = "linux")]

--- a/zebra-rs/src/fib/netlink/disp.rs
+++ b/zebra-rs/src/fib/netlink/disp.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt::{Display, Formatter, Result};
 
 use crate::fib::FibRoute;

--- a/zebra-rs/src/fib/netlink/dump.rs
+++ b/zebra-rs/src/fib/netlink/dump.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use anyhow::Result;

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv4Addr};
 

--- a/zebra-rs/src/fib/netlink/mod.rs
+++ b/zebra-rs/src/fib/netlink/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod disp;
 pub mod dump;
 pub mod handle;

--- a/zebra-rs/src/fib/netlink/safeop.rs
+++ b/zebra-rs/src/fib/netlink/safeop.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 // Not used anymore.
 trait SafeOp {
     fn safe_sub(self, v: u8) -> u8;

--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::Ipv6Addr;
 
 use anyhow::{Result, bail};

--- a/zebra-rs/src/fib/netlink/stats.rs
+++ b/zebra-rs/src/fib/netlink/stats.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::Write;

--- a/zebra-rs/src/fib/netlink/sysctl.rs
+++ b/zebra-rs/src/fib/netlink/sysctl.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use sysctl::Sysctl;
 
 const CTLNAMES: &[(&str, &str)] = &[

--- a/zebra-rs/src/fib/windows.rs
+++ b/zebra-rs/src/fib/windows.rs
@@ -1,2 +1,0 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro

--- a/zebra-rs/src/isis/adj.rs
+++ b/zebra-rs/src/isis/adj.rs
@@ -1,2 +1,1 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
+

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeSet;
 use std::net::Ipv4Addr;
 use std::str::FromStr;

--- a/zebra-rs/src/isis/flood.rs
+++ b/zebra-rs/src/isis/flood.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 
 use bytes::BytesMut;

--- a/zebra-rs/src/isis/hostname.rs
+++ b/zebra-rs/src/isis/hostname.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 use std::fmt::Write;
 

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use anyhow::{Context, Result};
 use isis_macros::isis_pdu_handler;
 use isis_packet::*;

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::Display;
 use std::net::{Ipv4Addr, Ipv6Addr};

--- a/zebra-rs/src/isis/labelpool.rs
+++ b/zebra-rs/src/isis/labelpool.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use bit_vec::BitVec;
 
 pub struct LabelPool {

--- a/zebra-rs/src/isis/level.rs
+++ b/zebra-rs/src/isis/level.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 use std::collections::btree_map::{Iter, IterMut};
 use std::fmt::Write;

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 use std::collections::btree_map::{Iter, Values};
 

--- a/zebra-rs/src/isis/mod.rs
+++ b/zebra-rs/src/isis/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod inst;
 pub use inst::{Isis, Message, MsgSender, Packet, PacketMessage};
 

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::net::{Ipv4Addr, Ipv6Addr};

--- a/zebra-rs/src/isis/network.rs
+++ b/zebra-rs/src/isis/network.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::io::{ErrorKind, IoSlice, IoSliceMut};
 use std::os::fd::AsRawFd;
 use std::sync::Arc;

--- a/zebra-rs/src/isis/nfsm.rs
+++ b/zebra-rs/src/isis/nfsm.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use isis_packet::*;
 use num_enum::IntoPrimitive;
 use strum_macros::{Display, EnumString};

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::net::{Ipv4Addr, Ipv6Addr};

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeSet;
 use std::fmt::Write;
 

--- a/zebra-rs/src/isis/socket.rs
+++ b/zebra-rs/src/isis/socket.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::os::fd::AsRawFd;
 
 use nix::sys::socket::{self, LinkAddr, SockaddrLike};

--- a/zebra-rs/src/isis/srmpls.rs
+++ b/zebra-rs/src/isis/srmpls.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use isis_packet::IsisSysId;
 
 pub use crate::spf::label_block::{LabelBlock, LabelConfig, LabelMap};

--- a/zebra-rs/src/isis/srv6.rs
+++ b/zebra-rs/src/isis/srv6.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 //! IS-IS-side SRv6 helpers — the per-instance ELIB function pool used
 //! to allocate End.X (adjacency) SIDs, and the bit math that turns a
 //! locator prefix + 16-bit function into a full SID address.

--- a/zebra-rs/src/isis/tracing.rs
+++ b/zebra-rs/src/isis/tracing.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 /// ISIS-specific conditional tracing system
 ///
 /// This module provides a comprehensive conditional tracing system for ISIS protocol

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 mod config;
 mod spf;
 mod version;

--- a/zebra-rs/src/ospf/addr.rs
+++ b/zebra-rs/src/ospf/addr.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use ipnet::Ipv4Net;
 
 use crate::rib::link::LinkAddr;

--- a/zebra-rs/src/ospf/area.rs
+++ b/zebra-rs/src/ospf/area.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::Ipv4Addr;
 

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 use std::net::Ipv4Addr;
 

--- a/zebra-rs/src/ospf/flood.rs
+++ b/zebra-rs/src/ospf/flood.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::time::Duration;
 
 use ospf_packet::*;

--- a/zebra-rs/src/ospf/ident.rs
+++ b/zebra-rs/src/ospf/ident.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::Ipv4Addr;
 
 use ipnet::Ipv4Net;

--- a/zebra-rs/src/ospf/ifsm.rs
+++ b/zebra-rs/src/ospf/ifsm.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt::Display;
 use std::net::Ipv4Addr;
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::{BTreeMap, HashMap};
 use std::net::Ipv4Addr;
 use std::str::FromStr;

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt::Display;
 use std::sync::Arc;
 use std::{collections::BTreeMap, net::Ipv4Addr};

--- a/zebra-rs/src/ospf/lsa.rs
+++ b/zebra-rs/src/ospf/lsa.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use ospf_packet::*;
 
 pub fn ospf_ls_rquest_new(lsah: &OspfLsaHeader) -> OspfLsRequestEntry {

--- a/zebra-rs/src/ospf/lsdb.rs
+++ b/zebra-rs/src/ospf/lsdb.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::time::Duration;
 use std::{collections::BTreeMap, net::Ipv4Addr};
 

--- a/zebra-rs/src/ospf/mod.rs
+++ b/zebra-rs/src/ospf/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod inst;
 pub use inst::{Message, Ospf, ShowCallback};
 

--- a/zebra-rs/src/ospf/neigh.rs
+++ b/zebra-rs/src/ospf/neigh.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::net::Ipv4Addr;

--- a/zebra-rs/src/ospf/network.rs
+++ b/zebra-rs/src/ospf/network.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::io::{ErrorKind, IoSlice, IoSliceMut};
 use std::net::Ipv4Addr;
 use std::os::fd::AsRawFd;

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt::Display;
 
 use ospf_packet::*;

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::Ipv4Addr;
 
 use ipnet::Ipv4Net;

--- a/zebra-rs/src/ospf/reach_map.rs
+++ b/zebra-rs/src/ospf/reach_map.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 
 use ipnet::Ipv4Net;

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt::Write;
 use std::net::Ipv4Addr;
 use std::time::{Duration, Instant};

--- a/zebra-rs/src/ospf/socket.rs
+++ b/zebra-rs/src/ospf/socket.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::Ipv4Addr;
 use std::os::fd::AsRawFd;
 use std::os::raw::c_int;

--- a/zebra-rs/src/ospf/srmpls.rs
+++ b/zebra-rs/src/ospf/srmpls.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::Ipv4Addr;
 
 use ipnet::Ipv4Net;

--- a/zebra-rs/src/ospf/task.rs
+++ b/zebra-rs/src/ospf/task.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 #![allow(dead_code)]
 use std::future::Future;
 use std::time::Duration;

--- a/zebra-rs/src/ospf/tracing.rs
+++ b/zebra-rs/src/ospf/tracing.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 // OSPF-specific conditional tracing system
 //
 // This module provides a comprehensive conditional tracing system for OSPF protocol

--- a/zebra-rs/src/policy/action.rs
+++ b/zebra-rs/src/policy/action.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/zebra-rs/src/policy/com_list.rs
+++ b/zebra-rs/src/policy/com_list.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 
 use crate::config::{Args, ConfigOp};

--- a/zebra-rs/src/policy/community/config.rs
+++ b/zebra-rs/src/policy/community/config.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr;
 

--- a/zebra-rs/src/policy/community/mod.rs
+++ b/zebra-rs/src/policy/community/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod config;
 pub use config::CommunitySetConfig;
 

--- a/zebra-rs/src/policy/community/parser.rs
+++ b/zebra-rs/src/policy/community/parser.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 // BGP Community Matcher Implementation
 //
 // This module provides parsing and matching functionality for BGP community-set

--- a/zebra-rs/src/policy/community/set.rs
+++ b/zebra-rs/src/policy/community/set.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 // CommunitySet
 
 use std::collections::BTreeSet;

--- a/zebra-rs/src/policy/community/show.rs
+++ b/zebra-rs/src/policy/community/show.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use anyhow::{Context, Error};
 use std::fmt::Write;
 

--- a/zebra-rs/src/policy/inst.rs
+++ b/zebra-rs/src/policy/inst.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::{BTreeMap, HashMap};
 
 use anyhow::{Error, Result};

--- a/zebra-rs/src/policy/mod.rs
+++ b/zebra-rs/src/policy/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod inst;
 pub use inst::*;
 

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 use std::fmt::Write;
 

--- a/zebra-rs/src/policy/prefix/config.rs
+++ b/zebra-rs/src/policy/prefix/config.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 
 use anyhow::{Context, Result};

--- a/zebra-rs/src/policy/prefix/mod.rs
+++ b/zebra-rs/src/policy/prefix/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod set;
 pub use set::PrefixSet;
 

--- a/zebra-rs/src/policy/prefix/set.rs
+++ b/zebra-rs/src/policy/prefix/set.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 
 use ipnet::IpNet;

--- a/zebra-rs/src/policy/prefix/show.rs
+++ b/zebra-rs/src/policy/prefix/show.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use anyhow::{Context, Error};
 use std::fmt::Write;
 

--- a/zebra-rs/src/policy/regex.rs
+++ b/zebra-rs/src/policy/regex.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 #![allow(dead_code)]
 
 // Character '_' has special meanings. It represents [,{}() ] and the beginning of

--- a/zebra-rs/src/policy/rmap.rs
+++ b/zebra-rs/src/policy/rmap.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 
 use super::Action;

--- a/zebra-rs/src/policy/show.rs
+++ b/zebra-rs/src/policy/show.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use crate::policy::Policy;
 use crate::policy::inst::ShowCallback;
 

--- a/zebra-rs/src/rib/addr_gen_mode.rs
+++ b/zebra-rs/src/rib/addr_gen_mode.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 // Defined in /usr/include/linux/if_link.h
 #[repr(u8)]
 #[derive(Debug, Clone)]

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::Ipv4Addr;
 
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};

--- a/zebra-rs/src/rib/bridge/builder.rs
+++ b/zebra-rs/src/rib/bridge/builder.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 
 use anyhow::{Context, Result};

--- a/zebra-rs/src/rib/bridge/config.rs
+++ b/zebra-rs/src/rib/bridge/config.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use crate::rib::AddrGenMode;
 
 #[derive(Default, Debug, Clone)]

--- a/zebra-rs/src/rib/bridge/mod.rs
+++ b/zebra-rs/src/rib/bridge/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod config;
 pub use config::*;
 

--- a/zebra-rs/src/rib/entry.rs
+++ b/zebra-rs/src/rib/entry.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::cmp::Ordering;
 use std::time::Instant;
 

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use super::api::RibRx;
 use super::entry::RibEntry;
 use super::link::{LinkConfig, link_config_exec};

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use anyhow::{Context, Result};
 
 use ipnet::IpNet;

--- a/zebra-rs/src/rib/link_ext.rs
+++ b/zebra-rs/src/rib/link_ext.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use netlink_packet_route::link::LinkFlags;
 
 pub trait LinkFlagsExt {

--- a/zebra-rs/src/rib/logging.rs
+++ b/zebra-rs/src/rib/logging.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::HashMap;
 use std::io;
 

--- a/zebra-rs/src/rib/mac_addr.rs
+++ b/zebra-rs/src/rib/mac_addr.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use serde::Serialize;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]

--- a/zebra-rs/src/rib/mod.rs
+++ b/zebra-rs/src/rib/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod api;
 pub use api::RibRxChannel;
 

--- a/zebra-rs/src/rib/mpls/config.rs
+++ b/zebra-rs/src/rib/mpls/config.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 
 use anyhow::{Context, Result};

--- a/zebra-rs/src/rib/mpls/mod.rs
+++ b/zebra-rs/src/rib/mpls/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod config;
 pub use config::*;
 

--- a/zebra-rs/src/rib/mpls/route.rs
+++ b/zebra-rs/src/rib/mpls/route.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 use std::net::Ipv4Addr;
 

--- a/zebra-rs/src/rib/nanomsg.rs
+++ b/zebra-rs/src/rib/nanomsg.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::{io::Read, net::Ipv4Addr, thread, time::Duration};
 
 use nanomsg::{Protocol, Socket};

--- a/zebra-rs/src/rib/nexthop/disp.rs
+++ b/zebra-rs/src/rib/nexthop/disp.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt::{Display, Formatter, Result};
 
 use super::{Nexthop, NexthopList, NexthopMulti, NexthopUni};

--- a/zebra-rs/src/rib/nexthop/group.rs
+++ b/zebra-rs/src/rib/nexthop/group.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeSet;
 use std::net::{IpAddr, Ipv6Addr};
 

--- a/zebra-rs/src/rib/nexthop/inst.rs
+++ b/zebra-rs/src/rib/nexthop/inst.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use isis_packet::srv6::EncapType;

--- a/zebra-rs/src/rib/nexthop/map.rs
+++ b/zebra-rs/src/rib/nexthop/map.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::{
     collections::{BTreeMap, BTreeSet},
     net::{IpAddr, Ipv6Addr},

--- a/zebra-rs/src/rib/nexthop/mod.rs
+++ b/zebra-rs/src/rib/nexthop/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod inst;
 pub use inst::*;
 

--- a/zebra-rs/src/rib/nexthop/show.rs
+++ b/zebra-rs/src/rib/nexthop/show.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::fmt::Write;
 
 use crate::rib::nexthop::group::{GroupTrait, GroupUni};

--- a/zebra-rs/src/rib/resolve.rs
+++ b/zebra-rs/src/rib/resolve.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use ipnet::{Ipv4Net, Ipv6Net};

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use prefix_trie::PrefixMap;
 use std::collections::{BTreeMap, BTreeSet};

--- a/zebra-rs/src/rib/router_id.rs
+++ b/zebra-rs/src/rib/router_id.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 use std::net::Ipv4Addr;
 

--- a/zebra-rs/src/rib/segment_routing/block.rs
+++ b/zebra-rs/src/rib/segment_routing/block.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 //! SR-MPLS label block (SRGB + SRLB) configuration. Per-protocol modules
 //! (IS-IS, OSPF, BGP-LU) reference a block by name from their
 //! `segment-routing/mpls/block` leaf.

--- a/zebra-rs/src/rib/segment_routing/locator.rs
+++ b/zebra-rs/src/rib/segment_routing/locator.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 //! SRv6 locator configuration. Per-protocol modules (IS-IS, OSPF, BGP-LU)
 //! reference a locator by name from their `segment-routing/srv6/locator`
 //! leaf.

--- a/zebra-rs/src/rib/segment_routing/mod.rs
+++ b/zebra-rs/src/rib/segment_routing/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 //! Segment Routing global configuration. Owns the SRGB/SRLB label blocks
 //! (SR-MPLS) and SRv6 locators that the per-protocol modules (IS-IS, OSPF,
 //! BGP-LU, ...) reference by name. The RIB is the natural owner because it

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 //! SRv6 SID allocation registry. Each entry is one SID address that some
 //! protocol (IS-IS, OSPF, BGP) has carved out of a locator and is now
 //! advertising as End / End.X / End.DT4 / etc. The RIB is the central

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use ipnet::{Ipv4Net, Ipv6Net};
 use serde::Serialize;
 use serde_json::Value;

--- a/zebra-rs/src/rib/srv6/endpoint.rs
+++ b/zebra-rs/src/rib/srv6/endpoint.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 #![allow(dead_code)]
 
 /// SRv6 endpoint behavior.

--- a/zebra-rs/src/rib/srv6/mod.rs
+++ b/zebra-rs/src/rib/srv6/mod.rs
@@ -1,5 +1,2 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod endpoint;
 pub mod sid;

--- a/zebra-rs/src/rib/srv6/sid.rs
+++ b/zebra-rs/src/rib/srv6/sid.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 #![allow(dead_code)]
 use ipnet::Ipv6Net;
 

--- a/zebra-rs/src/rib/static/config.rs
+++ b/zebra-rs/src/rib/static/config.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 

--- a/zebra-rs/src/rib/static/mod.rs
+++ b/zebra-rs/src/rib/static/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod config;
 pub use config::*;
 pub mod route;

--- a/zebra-rs/src/rib/static/route.rs
+++ b/zebra-rs/src/rib/static/route.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv6Addr};
 

--- a/zebra-rs/src/rib/types.rs
+++ b/zebra-rs/src/rib/types.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 /// RIB types.
 const RIB_KERNEL: u8 = 0;
 const RIB_CONNECTED: u8 = 1;

--- a/zebra-rs/src/rib/util.rs
+++ b/zebra-rs/src/rib/util.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use ipnet::{Ipv4Net, Ipv6Net};

--- a/zebra-rs/src/rib/vxlan/builder.rs
+++ b/zebra-rs/src/rib/vxlan/builder.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 use std::net::IpAddr;
 

--- a/zebra-rs/src/rib/vxlan/config.rs
+++ b/zebra-rs/src/rib/vxlan/config.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::net::IpAddr;
 
 use crate::rib::AddrGenMode;

--- a/zebra-rs/src/rib/vxlan/mod.rs
+++ b/zebra-rs/src/rib/vxlan/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod config;
 pub use config::*;
 

--- a/zebra-rs/src/spf/calc.rs
+++ b/zebra-rs/src/spf/calc.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 #![allow(dead_code)]
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};

--- a/zebra-rs/src/spf/diff.rs
+++ b/zebra-rs/src/spf/diff.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 /// Generic result for table diff operations
 #[derive(Debug)]
 pub struct TableDiffResult<'a, K, V> {

--- a/zebra-rs/src/spf/label_block.rs
+++ b/zebra-rs/src/spf/label_block.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 use std::collections::BTreeMap;
 
 #[derive(Debug, Default, PartialEq, Clone)]

--- a/zebra-rs/src/spf/mod.rs
+++ b/zebra-rs/src/spf/mod.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod calc;
 pub use calc::*;
 

--- a/zebra-rs/src/srv6/locator.rs
+++ b/zebra-rs/src/srv6/locator.rs
@@ -1,6 +1,4 @@
 #![allow(dead_code)]
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
 
 use std::collections::BTreeSet;
 use std::net::Ipv6Addr;

--- a/zebra-rs/src/srv6/mod.rs
+++ b/zebra-rs/src/srv6/mod.rs
@@ -1,5 +1,2 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 pub mod locator;
 // pub use locator::*;

--- a/zebra-rs/src/version.rs
+++ b/zebra-rs/src/version.rs
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 #![allow(dead_code)]
 /// Version information module containing package and git details
 use std::fmt;

--- a/zebra-rs/tracing.rs
+++ b/zebra-rs/tracing.rs
@@ -1,4 +1,1 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// Copyright 2025-2026 Kunihiro Ishiguro
-
 


### PR DESCRIPTION
## Summary

- Remove the leading `// SPDX-License-Identifier: AGPL-3.0-or-later` + `// Copyright 2025-2026 Kunihiro Ishiguro` block from every `.rs` file under `zebra-rs/`. Project-wide licensing is covered by the top-level `COPYING` file, so the per-file headers were redundant and added noise to every diff.
- Net change: 281 files, +1 / -840.
- Two stubs that were just license headers (`fib/windows.rs`, `isis/adj.rs`) become empty placeholders so their parent `mod foo;` lines still compile.
- `srv6/locator.rs` keeps its leading `#![allow(dead_code)]` attribute and only loses the comment block underneath.

## Test plan

- [x] `cargo build --release`
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --lib`

Generated with [Claude Code](https://claude.com/claude-code)