### PR TITLE
chore: rename COPYING to LICENSE-AGPL

### DIFF
--- a/LICENSE-AGPL
+++ b/LICENSE-AGPL
@@ -1,3 +1,5 @@
+Copyright (C) 2020-2026 Denver Technologies, Inc.
+
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 


### PR DESCRIPTION
## Summary

- Rename `COPYING` → `LICENSE-AGPL`. GitHub and most tooling pick up `LICENSE*` files as the canonical license, so this improves discoverability.
- Prepend `Copyright (C) 2020-2026 Denver Technologies, Inc.` so the holder is visible at the top of the license file.
- 99% similarity rename — license body unchanged.

## Test plan

- [x] `git diff` confirms rename + 2-line addition only.
- [x] No source files reference the path `COPYING` (verified via grep, excluding the unrelated `vty/` vendored bash docs).

Generated with [Claude Code](https://claude.com/claude-code)