### PR TITLE
ci: switch deb build workflows to vty overlay flow

### DIFF
--- a/.github/workflows/build-amd64.yaml
+++ b/.github/workflows/build-amd64.yaml
@@ -19,15 +19,12 @@ jobs:
         run: |
           sudo apt update -y
           sudo apt upgrade -y
-          sudo apt install -y protobuf-compiler libnanomsg-dev
-          cd vty
-          ./configure
-          make
+          sudo apt install -y protobuf-compiler libnanomsg-dev bison
+          make -C vty
           echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
           sudo apt update
           sudo apt install nfpm
-          cd ../packaging
-          make amd64
+          make -C packaging amd64
 
       - name: Upload basefs artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-arm64.yaml
+++ b/.github/workflows/build-arm64.yaml
@@ -19,15 +19,12 @@ jobs:
         run: |
           sudo apt update -y
           sudo apt upgrade -y
-          sudo apt install -y protobuf-compiler libnanomsg-dev
-          cd vty
-          ./configure
-          make
+          sudo apt install -y protobuf-compiler libnanomsg-dev bison
+          make -C vty
           echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
           sudo apt update
           sudo apt install nfpm
-          cd ../packaging
-          make arm64
+          make -C packaging arm64
 
       - name: Upload basefs artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

`vty/` no longer ships a `configure` script after the overlay refactor (#373); the new build is `make -C vty`, which fetches `bash-5.2.21.tar.gz`, applies patches, and compiles. Update the deb-build workflows accordingly.

- Replace `cd vty; ./configure; make` → `make -C vty`.
- Add `bison` to the apt install list (needed to regenerate `y.tab.c` from `parse.y`).
- Drop redundant `cd ../packaging` in favor of `make -C packaging <arch>`.

Both `build-amd64.yaml` and `build-arm64.yaml` get the same change.

## Test plan

- [x] Workflow YAML changes are syntactically equivalent to before — same step name, same env, same artifact upload.
- [ ] Post-merge: workflow_dispatch run on amd64 and arm64 to confirm the deb packages still build. (The workflow only fires on push to main, not on PRs, so this can't be validated pre-merge without flipping the trigger.)

Generated with [Claude Code](https://claude.com/claude-code)