### PR TITLE
isis: add DIS selection / neighbor tracing with DisplayOpt helper

### DIFF
--- a/zebra-rs/src/fmt.rs
+++ b/zebra-rs/src/fmt.rs
@@ -1,0 +1,12 @@
+use std::fmt;
+
+pub struct DisplayOpt<'a, T>(pub &'a Option<T>);
+
+impl<T: fmt::Display> fmt::Display for DisplayOpt<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Some(v) => v.fmt(f),
+            None => f.write_str("N/A"),
+        }
+    }
+}

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -343,9 +343,6 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
                 })
     }
 
-    // Logging.
-    // tracing::info!("DIS selection start");
-
     // Store current DIS state for tracking
     let old_status = *link.state.dis_status.get(&level);
     // let old_sys_id = *link.state.dis_sys_id.get(&level);
@@ -377,6 +374,15 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
         nbrs_up += 1;
     }
 
+    // Logging.
+    if link.tracing.fsm.nfsm.enabled {
+        tracing::info!(
+            "[NBR] DIS selection on {} up neighbor count {}",
+            link.ifindex,
+            nbrs_up
+        );
+    }
+
     // Update link's neighbors Up count.
     *link.state.nbrs_up.get_mut(&level) = nbrs_up;
 
@@ -395,7 +401,7 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
         };
         nbr.is_dis = true;
         let reason = format!(
-            "Neighbor {} elected (priority: {}, mac: {})",
+            "Neighbor is {} elected (priority: {}, mac: {})",
             nbr.sys_id,
             nbr.priority,
             mac_str(&nbr.mac),
@@ -411,14 +417,21 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
         // DIS is myself.
         let sys_id = Some(link.up_config.net.sys_id());
         let reason = format!(
-            "Self elected (priority: {}, neighbors: {})",
+            "Self is elected (priority: {}, neighbors: {})",
             link.config.priority(),
             nbrs_up
         );
         (DisStatus::Myself, sys_id, None, reason)
     };
 
-    // tracing::info!("DIS selection {:?} {}", new_status, reason);
+    if link.tracing.fsm.nfsm.enabled {
+        tracing::info!(
+            "[NBR] DIS selection {:?} -> {:?} {}",
+            old_status,
+            new_status,
+            reason
+        );
+    }
 
     // Perform DIS change when status or sys_id has been changed.
     if old_status != new_status {

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -50,6 +50,9 @@ pub struct Neighbor {
     /// registry). `None` until the locator is resolved and the first
     /// allocator pass picks a function.
     pub endx_sid: Option<(u16, Ipv6Addr)>,
+
+    // For logging purpose.
+    pub created: bool,
 }
 
 impl Neighbor {
@@ -67,7 +70,6 @@ impl Neighbor {
             lan_id: IsisNeighborId::default(),
             circuit_type: IsLevel::default(),
             ifindex,
-            // prev: NfsmState::Down,
             state: NfsmState::Down,
             addr4: BTreeMap::new(),
             addr6: BTreeMap::new(),
@@ -80,6 +82,7 @@ impl Neighbor {
             hold_time: 0,
             link_type,
             endx_sid: None,
+            created: true,
         }
     }
 

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -6,6 +6,7 @@ use anyhow::Error;
 use isis_macros::isis_pdu_handler;
 use isis_packet::*;
 
+use crate::fmt::DisplayOpt;
 use crate::isis::inst::csnp_generate;
 use crate::isis::link::DisStatus;
 use crate::isis::neigh::Neighbor;
@@ -165,6 +166,26 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
             mac,
         ));
 
+    // Logging.
+    if link.tracing.fsm.nfsm.enabled {
+        if nbr.created {
+            tracing::info!(
+                "[NBR] {} Created on {} state {}",
+                pdu.source_id,
+                DisplayOpt(&mac),
+                nbr.state
+            );
+        } else {
+            // tracing::info!(
+            //     "[NBR] {} Fonud on {} state {}",
+            //     pdu.source_id,
+            //     DisplayOpt(&mac),
+            //     nbr.state
+            // );
+        }
+    }
+    nbr.created = false;
+
     // 8.4.2 Broadcast subnetwork IIH PDUs
     //
     // Level n LAN IIH PDUs contain the transmitting Intermediate system’s ID,
@@ -212,6 +233,9 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
         // system and the source of the PDU (R) is two-way. However R shall be
         // included in future Level n LAN IIH PDUs transmitted by this system.
         state = NfsmState::Init;
+        if link.tracing.fsm.nfsm.enabled {
+            tracing::info!("[NBR] {} Down -> Init", nbr.sys_id);
+        }
         nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
     }
 
@@ -222,6 +246,9 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
         // e) generate an adjacencyStateChange (Up)” event.
         if has_mac {
             state = NfsmState::Up;
+            if link.tracing.fsm.nfsm.enabled {
+                tracing::info!("[NBR] {} Init -> Up", nbr.sys_id);
+            }
             // XXX Adjacency(Up)
             nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
             nbr.event(Message::Ifsm(DisSelection, nbr.ifindex, Some(level)));
@@ -236,6 +263,9 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
         // b) generate an adjacencyStateChange (Down) event.
         if !has_mac {
             state = NfsmState::Init;
+            if link.tracing.fsm.nfsm.enabled {
+                tracing::info!("[NBR] {} {} -> Init", nbr.sys_id, nbr.state);
+            }
             // XXX Adjacency(Down)
             nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
             nbr.event(Message::Ifsm(DisSelection, nbr.ifindex, Some(level)));

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -1,4 +1,5 @@
 mod config;
+mod fmt;
 mod spf;
 mod version;
 use config::{Cli, ConfigManager};


### PR DESCRIPTION
## Summary

Improves observability into IS-IS LAN behavior with nfsm-gated tracing for DIS election outcomes and neighbor lifecycle, and introduces a small reusable `DisplayOpt` formatter for `Option<T: Display>` values inside `tracing::info!` calls.

### Changes

- **`crate::fmt::DisplayOpt`** (new `zebra-rs/src/fmt.rs`): zero-alloc adapter that prints `T` if `Some` else `"N/A"`. Available crate-wide via `mod fmt;` in `main.rs`.
- **DIS-selection tracing** (`isis/ifsm.rs`): logs the up-neighbor count, the elected outcome (self vs. peer), and the old → new transition with reason. All gated on `link.tracing.fsm.nfsm.enabled`.
- **Neighbor lifecycle tracing** (`isis/packet.rs`): logs first-time creation (using a new `created` flag on `Neighbor`) and Down→Init / Init→Up / *→Init transitions on LAN hellos. `DisplayOpt(&mac)` is used to render the source MAC inside the create log.
- **`Neighbor::created`** (`isis/neigh.rs`): per-neighbor flag flipped to `false` after the first hello processes, so subsequent updates don't re-log "Created".

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo fmt --all` clean
- [ ] Run with `tracing.fsm.nfsm.enabled=true` and confirm the new logs fire on neighbor up/down and DIS election events without spamming on steady-state hellos.

Generated with [Claude Code](https://claude.com/claude-code)