### PR TITLE
isis: defer DIS:Other transition + regenerate Hello on every send

### DIFF
--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -3,6 +3,7 @@ use isis_macros::isis_pdu_handler;
 use isis_packet::*;
 
 use crate::context::Timer;
+use crate::fmt::DisplayOpt;
 use crate::isis::link::DisStatus;
 use crate::isis::network::P2P_ISS;
 use crate::isis_pdu_trace;
@@ -400,19 +401,35 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
             return;
         };
         nbr.is_dis = true;
+
+        // Defer the DisStatus::Other transition until the elected DIS
+        // has published a LAN ID. Without it we can't register the
+        // pseudonode adjacency, so transitioning now would leave us in
+        // Other-with-adj=None — CSNPs would be dropped (packet.rs
+        // csnp_recv guards on adj.is_some()), the self LSP would miss
+        // its pseudonode reach entry, and `show isis adjacency` would
+        // report an inconsistent DIS without a binding. Election
+        // outcome is recorded (`nbr.is_dis = true`); the late-LAN-ID
+        // path in hello_recv re-fires DisSelection once lan_id arrives,
+        // and that run will complete the transition cleanly.
+        if nbr.lan_id.is_empty() {
+            if link.tracing.fsm.nfsm.enabled {
+                tracing::info!(
+                    "[NBR] DIS election: {} elected but LAN ID not yet known, deferring transition",
+                    nbr.sys_id
+                );
+            }
+            return;
+        }
+
         let reason = format!(
             "Neighbor is {} elected (priority: {}, mac: {})",
             nbr.sys_id,
             nbr.priority,
             mac_str(&nbr.mac),
         );
-        let lan_id = if !nbr.lan_id.is_empty() {
-            Some(nbr.lan_id)
-        } else {
-            None
-        };
 
-        (DisStatus::Other, Some(nbr.sys_id), lan_id, reason)
+        (DisStatus::Other, Some(nbr.sys_id), Some(nbr.lan_id), reason)
     } else {
         // DIS is myself.
         let sys_id = Some(link.up_config.net.sys_id());
@@ -462,9 +479,19 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
             }
             DisStatus::Other => {
                 use IfsmEvent::*;
+                if link.tracing.fsm.nfsm.enabled {
+                    tracing::info!(
+                        "[NBR] Adjacency {:?} LAN ID {}",
+                        link.state.adj.get(&level),
+                        DisplayOpt(&lan_id)
+                    );
+                }
                 if link.state.adj.get(&level).is_none()
                     && let Some(lan_id) = lan_id
                 {
+                    if link.tracing.fsm.nfsm.enabled {
+                        tracing::info!("[NBR] Adjacency set {}", lan_id);
+                    }
                     *link.state.adj.get_mut(&level) = Some((lan_id, None));
                     link.lsdb.get_mut(&level).adj_set(link.ifindex);
                     link.event(Message::Ifsm(HelloOriginate, link.ifindex, Some(level)));

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use isis_macros::isis_pdu_handler;
 use isis_packet::*;
 
@@ -200,19 +200,39 @@ fn hello_timer(link: &LinkTop, level: Level) -> Timer {
 
 #[isis_pdu_handler(Hello, Send)]
 pub fn hello_send(link: &mut LinkTop, level: Level) -> Result<()> {
-    let hello = link.state.hello.get(&level).as_ref().context("")?;
+    // Regenerate the Hello at every send so the IS Neighbor TLV and
+    // lan_id field always reflect current link state. Caching the
+    // PDU between sends would let an Init→Up transition (or a DIS
+    // election outcome) that didn't fire HelloOriginate at exactly
+    // the right moment leave a stale cached PDU on the wire — which
+    // on broadcast LANs deadlocks the 3-way handshake (peer never
+    // sees us in their IS Neighbor TLV → peer's nbr stays Init →
+    // peer's DIS election never fires → peer's lan_id stays empty
+    // → our deferred DisStatus never recovers).
+    if !has_level(link.state.level(), level) {
+        return Ok(());
+    }
 
-    let (packet, mac) = match hello {
-        IsisPdu::L1Hello(hello) => (
-            IsisPacket::from(IsisType::L1Hello, IsisPdu::L1Hello(hello.clone())),
+    let hello = if link.config.link_type() == LinkType::P2p {
+        IsisPdu::P2pHello(hello_p2p_generate(link, level))
+    } else {
+        match level {
+            Level::L1 => IsisPdu::L1Hello(hello_generate(link, level)),
+            Level::L2 => IsisPdu::L2Hello(hello_generate(link, level)),
+        }
+    };
+
+    let (packet, mac) = match &hello {
+        IsisPdu::L1Hello(h) => (
+            IsisPacket::from(IsisType::L1Hello, IsisPdu::L1Hello(h.clone())),
             None,
         ),
-        IsisPdu::L2Hello(hello) => (
-            IsisPacket::from(IsisType::L2Hello, IsisPdu::L2Hello(hello.clone())),
+        IsisPdu::L2Hello(h) => (
+            IsisPacket::from(IsisType::L2Hello, IsisPdu::L2Hello(h.clone())),
             None,
         ),
-        IsisPdu::P2pHello(hello) => (
-            IsisPacket::from(IsisType::P2pHello, IsisPdu::P2pHello(hello.clone())),
+        IsisPdu::P2pHello(h) => (
+            IsisPacket::from(IsisType::P2pHello, IsisPdu::P2pHello(h.clone())),
             MacAddr::from_vec(P2P_ISS.to_vec()),
         ),
         _ => return Ok(()),
@@ -223,6 +243,12 @@ pub fn hello_send(link: &mut LinkTop, level: Level) -> Result<()> {
     } else {
         isis_pdu_trace!(link, &level, "[P2P Hello:Send] {}", link.state.name);
     }
+
+    // Stash the just-sent PDU for show output and the
+    // "level-active" flag at link.rs (hello_padding reload checks
+    // `link.state.hello.l1.is_some()`); the cache is no longer the
+    // source of truth at send time.
+    *link.state.hello.get_mut(&level) = Some(hello);
 
     let ifindex = link.ifindex;
     let _ = link.ptx.send(PacketMessage::Send(
@@ -243,16 +269,8 @@ pub fn has_level(is_level: IsLevel, level: Level) -> bool {
 
 pub fn hello_originate(link: &mut LinkTop, level: Level) {
     if has_level(link.state.level(), level) {
-        let hello = if link.config.link_type() == LinkType::P2p {
-            IsisPdu::P2pHello(hello_p2p_generate(link, level))
-        } else {
-            match level {
-                Level::L1 => IsisPdu::L1Hello(hello_generate(link, level)),
-                Level::L2 => IsisPdu::L2Hello(hello_generate(link, level)),
-            }
-        };
-
-        *link.state.hello.get_mut(&level) = Some(hello);
+        // hello_send regenerates the PDU itself; we only send one
+        // immediately and (re-)arm the periodic timer here.
         let _ = hello_send(link, level);
         *link.timer.hello.get_mut(&level) = Some(hello_timer(link, level));
     }

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -553,6 +553,9 @@ impl Isis {
             *link.state.adj.get_mut(&level) = None;
             *link.timer.csnp.get_mut(&level) = None;
             self.lsdb.get_mut(&level).adj_clear(ifindex);
+
+            // Reset DIS selection status.
+            *link.state.dis_status.get_mut(&level) = DisStatus::NotSelected;
         }
 
         // Stop hello generation on this interface.

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -272,16 +272,22 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
         }
     }
 
-    // When neighbor is elected as DIS and reports LAN ID in Hello packet,
-    // register adjacency if not already set. This handles the case where
-    // neighbor reaches Up state before we receive the DIS's LAN ID.
-    if nbr.is_dis() && !nbr.lan_id.is_empty() && link.state.adj.get_mut(&level).is_none() {
-        // Register adjacency and create SRM/SSN entry in LSDB.
-        *link.state.adj.get_mut(&level) = Some((nbr.lan_id, None));
-        link.lsdb.get_mut(&level).adj_set(link.ifindex);
-
-        nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
-        nbr.event(Message::LspOriginate(level, None));
+    // Late-LAN-ID arrival: dis_selection deferred the
+    // DisStatus::Other transition because the elected DIS hadn't
+    // published a LAN ID yet. Now that this Hello carries one and we
+    // still have no pseudonode adjacency on this link, re-fire DIS
+    // selection — this time `nbr.lan_id` is non-empty, so the
+    // election will transition to Other and register the adjacency
+    // through the normal path (no inline state mutation here).
+    if nbr.is_dis() && !nbr.lan_id.is_empty() && link.state.adj.get(&level).is_none() {
+        if link.tracing.fsm.nfsm.enabled {
+            tracing::info!(
+                "[NBR] Late LAN ID {} from elected DIS {} - re-running DIS selection",
+                nbr.lan_id,
+                nbr.sys_id
+            );
+        }
+        nbr.event(Message::Ifsm(DisSelection, nbr.ifindex, Some(level)));
     }
 
     // When neighbor state has been changed.
@@ -375,6 +381,9 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
             state = NfsmState::Up;
 
             // Set adjacency.
+            if link.tracing.fsm.nfsm.enabled {
+                tracing::info!("[NBR] Adjacency set {}", nbr.sys_id);
+            }
             *link.state.adj.get_mut(&level) =
                 Some((IsisNeighborId::from_sys_id(&nbr.sys_id, 0), nbr.mac));
             link.lsdb.get_mut(&level).adj_set(nbr.ifindex);


### PR DESCRIPTION
## Summary

Two fixes that together stabilize IS-IS LAN adjacency formation when both peers are bouncing or coming up together.

### 1. Defer `DisStatus::Other` transition until LAN ID is known

When a neighbor wins DIS election but its Hello hasn't yet carried a LAN ID, the previous code transitioned to `DisStatus::Other` anyway with `adj=None`. That left the link in an inconsistent window where `csnp_recv` dropped the DIS's CSNPs (it guards on `adj.is_some()`), the self LSP couldn't include the pseudonode reach, and `show isis adjacency` reported a DIS without a binding.

`dis_selection` now records the election outcome (`nbr.is_dis = true`) but skips the DisStatus transition while `nbr.lan_id` is empty. Once a subsequent Hello carries the LAN ID, `hello_recv` re-fires DisSelection and the second pass transitions cleanly through the normal path — no inline state mutation in the packet handler.

Also reset `dis_status` to `NotSelected` when a link goes down, so a later re-up doesn't leave stale Other/Myself state.

### 2. Regenerate Hello on every send (kill the stale-cache deadlock)

Previously `hello_originate` built an `IsisPdu`, stashed it on `link.state.hello`, and `hello_send` unconditionally read that cached PDU. The cache was only refreshed on state transitions that fired `HelloOriginate` — so any time a transition's `HelloOriginate` event ran before the relevant state mutation became visible to `hello_generate`, the cached PDU got pinned to a stale snapshot. The 3 s hello timer then resent that stale PDU forever.

On a broadcast LAN this deadlocks the 3-way handshake when both sides bounce together: each side's `nbrs` got cleared, neither side's cached Hello has the other's MAC in `IS Neighbor`, neither side's `nbr` ever transitions Init→Up, and neither side ever runs DIS selection again — so peer's `lan_id` stays empty forever and our deferred `DisStatus::Other` transition can't recover via `hello_recv`'s late-LAN-ID re-fire.

`hello_send` now regenerates the PDU at every call. The existing `link.state.hello` field is still updated as a side effect so the show output and the "level was active" check at `link.rs:871` keep working — but the cache is no longer the source of truth at send time. `hello_originate` becomes a thin wrapper that calls `hello_send` and arms the periodic timer.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --bin zebra-rs isis::` — 18 tests pass
- [x] Live test: bounce both peers together; verify peer's first post-bounce Hello with non-empty `lan_id` arrives within ~3 s of the local Init→Up and the late-LAN-ID re-fire completes the transition

Generated with [Claude Code](https://claude.com/claude-code)