### PR TITLE
rib: drop NewAddr/DelAddr debug tracing lines

### DIFF
--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -825,7 +825,6 @@ impl Rib {
                 self.link_delete(link);
             }
             FibMessage::NewAddr(addr) => {
-                tracing::info!("NewAddr {:?}", addr);
                 // Kernel netlink path: from_config=false. If a configured
                 // LinkAddr is already present for this address, the merge in
                 // link_addr_update will flip its `fib` flag to true.
@@ -843,8 +842,6 @@ impl Rib {
                 self.router_id_update();
             }
             FibMessage::DelAddr(addr) => {
-                tracing::info!("DelAddr {:?}", addr);
-
                 // If the deleted address is still in config, push it
                 // back to the kernel rather than tearing down state.
                 // Recovery may be suppressed (Step 7 hold-down) — in


### PR DESCRIPTION
## Summary

Tiny follow-up to PR #377. Removes two `tracing::info!("NewAddr/DelAddr {:?}", addr)` lines that were development-time aids during the address recovery feature work. The `addr_recover_*` helpers and `DEBUG_ADDR`-gated logs cover the diagnostic surface now; leaving these at info-level was noisy in production.

The cleanup was originally on the `feature/rib-addr-recovery` branch as commit 37ff2c4, but GitHub had already locked the merge head to the previous commit (1a10640) by the time the push synced, so it didn't make it into main.

## Test plan

- [x] `cargo build --release` clean

Generated with [Claude Code](https://claude.com/claude-code)