### PR TITLE
rib: gate address recovery behind --enable-addr-recovery (off by default)

### DIFF
--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -50,6 +50,12 @@ struct Arg {
         help = "Disable nexthop ID and use embedded nexthop in routes (for kernels < 5.3)"
     )]
     no_nhid: bool,
+
+    #[arg(
+        long,
+        help = "Re-install configured addresses removed by the kernel (cool-down on burst); off by default"
+    )]
+    enable_addr_recovery: bool,
 }
 
 // 1. Option Yang path
@@ -130,7 +136,7 @@ async fn main() -> anyhow::Result<()> {
     }
     let yang_path = yang_path.unwrap();
 
-    let mut rib = Rib::new(arg.no_nhid)?;
+    let mut rib = Rib::new(arg.no_nhid, arg.enable_addr_recovery)?;
 
     let policy = Policy::new();
 

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -265,6 +265,13 @@ pub struct Rib {
     /// `crate::rib::route::RECOVERY_*` if an external actor keeps
     /// fighting us.
     pub addr_recovery: BTreeMap<(u32, IpNet), AddrRecoveryState>,
+
+    /// Master switch for the kernel-driven address recovery feature
+    /// (re-install configured addresses on RTM_DELADDR, plus the link_up
+    /// bulk recovery loop). Set via `--enable-addr-recovery`. Off by
+    /// default — when false, an external delete tears the address down
+    /// the same way it did before the feature existed.
+    pub addr_recovery_enabled: bool,
 }
 
 /// Name of the dummy interface that hosts End-style seg6local routes
@@ -274,7 +281,7 @@ pub const SR0_DUMMY_NAME: &str = "sr0";
 const DEFAULT_RIB_SYNC_INTERVAL_SEC: u64 = 1;
 
 impl Rib {
-    pub fn new(no_nhid: bool) -> anyhow::Result<Self> {
+    pub fn new(no_nhid: bool, addr_recovery_enabled: bool) -> anyhow::Result<Self> {
         let fib = FibChannel::new();
         let fib_handle = FibHandle::new(fib.tx.clone(), no_nhid)?;
         let (tx, rx) = mpsc::unbounded_channel();
@@ -320,6 +327,7 @@ impl Rib {
             rib_sync_interval: DEFAULT_RIB_SYNC_INTERVAL_SEC,
             sr0_owned: false,
             addr_recovery: BTreeMap::new(),
+            addr_recovery_enabled,
         };
         rib.show_build();
         Ok(rib)
@@ -842,14 +850,15 @@ impl Rib {
                 self.router_id_update();
             }
             FibMessage::DelAddr(addr) => {
-                // If the deleted address is still in config, push it
-                // back to the kernel rather than tearing down state.
-                // Recovery may be suppressed (Step 7 hold-down) — in
-                // both cases skip the normal teardown so the
-                // connected route doesn't churn. The next NewAddr we
-                // receive (either from our own re-install, or from a
-                // future operator add) will run the sync chain.
-                if self.addr_recover_if_configured(&addr).await {
+                // When the address-recovery feature is enabled and the
+                // deleted address is still in config, push it back to
+                // the kernel rather than tearing down state. Recovery
+                // may be suppressed (Step 7 hold-down) — in both cases
+                // skip the normal teardown so the connected route
+                // doesn't churn. The next NewAddr we receive (either
+                // from our own re-install, or from a future operator
+                // add) will run the sync chain.
+                if self.addr_recovery_enabled && self.addr_recover_if_configured(&addr).await {
                     return;
                 }
 

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -448,37 +448,43 @@ impl Rib {
         // Suppression policy is shared with the kernel-driven DelAddr
         // recovery path: if a misbehaving external actor has already
         // triggered the cool-down for an address, link_up respects it.
-        let recover: Vec<IpNet> = link
-            .addr4
-            .iter()
-            .chain(link.addr6.iter())
-            .filter(|a| a.config && !a.fib)
-            .map(|a| a.addr)
-            .collect();
-        for prefix in recover {
-            let now = Instant::now();
-            let state = self.addr_recovery.entry((ifindex, prefix)).or_default();
-            // Don't record a "delete event" here — link_up isn't the
-            // kernel saying "deleted", it's us recovering after a
-            // bounce. Just consult the existing suppression state.
-            let suppressed = matches!(
-                state.suppressed_until,
-                Some(until) if until > now
-            );
-            if suppressed {
-                let remaining = state
-                    .suppressed_until
-                    .and_then(|until| until.checked_duration_since(now))
-                    .unwrap_or_default();
-                tracing::info!(
-                    "link_up: {} skipping re-install of {} ({}s cool-down remaining)",
-                    link_name,
-                    prefix,
-                    remaining.as_secs(),
+        //
+        // Gated by addr_recovery_enabled (`--enable-addr-recovery`); when
+        // off, the kernel-erased addresses simply stay erased until the
+        // operator re-applies config.
+        if self.addr_recovery_enabled {
+            let recover: Vec<IpNet> = link
+                .addr4
+                .iter()
+                .chain(link.addr6.iter())
+                .filter(|a| a.config && !a.fib)
+                .map(|a| a.addr)
+                .collect();
+            for prefix in recover {
+                let now = Instant::now();
+                let state = self.addr_recovery.entry((ifindex, prefix)).or_default();
+                // Don't record a "delete event" here — link_up isn't the
+                // kernel saying "deleted", it's us recovering after a
+                // bounce. Just consult the existing suppression state.
+                let suppressed = matches!(
+                    state.suppressed_until,
+                    Some(until) if until > now
                 );
-                continue;
+                if suppressed {
+                    let remaining = state
+                        .suppressed_until
+                        .and_then(|until| until.checked_duration_since(now))
+                        .unwrap_or_default();
+                    tracing::info!(
+                        "link_up: {} skipping re-install of {} ({}s cool-down remaining)",
+                        link_name,
+                        prefix,
+                        remaining.as_secs(),
+                    );
+                    continue;
+                }
+                self.addr_reinstall(ifindex, &link_name, &prefix).await;
             }
-            self.addr_reinstall(ifindex, &link_name, &prefix).await;
         }
 
         ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.links, &self.fib_handle).await;


### PR DESCRIPTION
## Summary
- Puts the kernel-driven address recovery feature (PR #377) behind a clap opt-in `--enable-addr-recovery`, defaulting **off**.
- Threads the flag through `Rib::new` into a new `Rib::addr_recovery_enabled` field and gates both recovery sites: the `FibMessage::DelAddr` handler and the `link_up` bulk re-install loop.
- When disabled (default), kernel-deleted configured addresses tear down exactly as they did before the recovery feature existed — connected route goes away, redistributions see AddrDel.

## Why
Recovery-on-by-default surprised operators who relied on the prior "kernel deletes win" behavior. Making it opt-in keeps the safety net available for environments that want it without changing default semantics.

## Test plan
- [x] `cargo build -p zebra-rs --bin zebra-rs` — clean
- [x] `cargo clippy -p zebra-rs --bin zebra-rs --no-deps` — clean
- [x] `cargo test -p zebra-rs --bin zebra-rs rib::route::tests` — 5/5 `addr_recover_decide` tests pass
- [x] `cargo fmt --all`
- [ ] Manual: with the flag off, `ip addr del` on a configured address tears the connected route down (pre-PR-#377 behavior)
- [ ] Manual: with `--enable-addr-recovery`, the same delete is recovered and the burst cool-down still trips after 3 deletes in 60s

Generated with [Claude Code](https://claude.com/claude-code)