### PR TITLE
rib: suppress DEBUG_ADDR + sr0-create info trace

### DIFF
--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -458,7 +458,7 @@ impl Rib {
         };
         self.fib_handle.link_set_up(ifindex).await;
         self.sr0_owned = true;
-        tracing::info!("sr0 dummy created (ifindex={})", ifindex);
+        // tracing::info!("sr0 dummy created (ifindex={})", ifindex);
     }
 
     /// Inverse of `ensure_sr0_dummy` — only deletes when this process

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -19,7 +19,7 @@ use super::{
 const DEBUG_V6: bool = false;
 
 // Flip to true to re-enable IP address diagnostic trace.
-pub const DEBUG_ADDR: bool = true;
+pub const DEBUG_ADDR: bool = false;
 
 /// Hold-down policy for kernel-driven address recovery.
 ///


### PR DESCRIPTION
## Summary
Two small noise reductions in the RIB tracing surface, both at info level. No behavior change.

- `zebra-rs/src/rib/route.rs`: flip `DEBUG_ADDR = true → false`. The recovery feature is now opt-in (PR #380), so leaving the diagnostic trace on by default produced output in builds where the feature is dormant. The flag is still flippable in source for a debugging session.
- `zebra-rs/src/rib/inst.rs`: comment out the `sr0 dummy created (ifindex=…)` info line in `ensure_sr0_dummy`. Useful during initial SRv6 bring-up, redundant once the dummy is a stable startup fact.

Mirrors the precedent in `5f7355c chore(fib): disable DEBUG_V6 / DEBUG_SID in committed code` and `c24bd7e rib: drop NewAddr/DelAddr debug tracing lines`.

## Test plan
- [x] `cargo build -p zebra-rs --bin zebra-rs` — clean
- [ ] Manual: confirm the `sr0 dummy created` and `addr_recover/addr_reinstall` info lines no longer appear in a default startup log

Generated with [Claude Code](https://claude.com/claude-code)