### PR TITLE
fix(config): accept ':' so ::/0 survives startup-config load

### DIFF
--- a/zebra-rs/src/config/files.rs
+++ b/zebra-rs/src/config/files.rs
@@ -110,6 +110,44 @@ segment-routing {
     }
 
     #[test]
+    fn test_static_ipv6_default_route_survives_load() {
+        // Regression: a user-reported bug where a startup-config with a
+        // default IPv6 static route was loaded with the default route
+        // missing. Root cause was in token.rs (':' wasn't accepted as
+        // the first character of a String token, so `::/0` was silently
+        // truncated to `0`). Pin the full loader pipeline so a similar
+        // tokenizer-vs-loader regression is caught here even if the
+        // tokenizer's own unit test is moved or rewritten.
+        let config = r#"
+static {
+  ipv6 {
+    route 2001:db8:ff00:5::/64 {
+      segments {
+        fcbb:bbbb:3:fe00::;
+      }
+    }
+    route ::/0 {
+      nexthop 2001:db8:ff00:10::2;
+    }
+  }
+}
+"#;
+        let cmds = load_config_file(config.to_string());
+        let dump = cmds.join("\n");
+        assert!(
+            cmds.iter()
+                .any(|c| c == "set static ipv6 route ::/0 nexthop 2001:db8:ff00:10::2"),
+            "default-route nexthop set line missing; got:\n{dump}"
+        );
+        assert!(
+            cmds.iter()
+                .any(|c| c
+                    == "set static ipv6 route 2001:db8:ff00:5::/64 segments fcbb:bbbb:3:fe00::"),
+            "specific-prefix segments set line missing; got:\n{dump}"
+        );
+    }
+
+    #[test]
     fn test_leaf_list_old_format() {
         // Test that old single-line format would have been parsed differently
         let config = r#"

--- a/zebra-rs/src/config/token.rs
+++ b/zebra-rs/src/config/token.rs
@@ -20,7 +20,16 @@ pub fn tokenizer(input: String) -> Vec<Token> {
             ch if ch.is_whitespace() => {
                 continue;
             }
-            'a'..='z' | 'A'..='Z' | '0'..='9' => {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | ':' => {
+                // ':' as a leader covers IPv6 prefixes that start with the
+                // double-colon shorthand: `::/0`, `::1/128`, etc. Without
+                // it the tokenizer dropped the leading `:` characters and
+                // mis-tokenized `::/0` as `0`, so the file loader emitted
+                // `set ... route 0 nexthop ...`. libyang then rejected
+                // the line as not-a-valid-IPv6-prefix and the default
+                // route silently disappeared. CLI input arrives already
+                // split by the shell, so the bug only surfaced on
+                // startup-config / saved-config loads.
                 let s: String = iter::once(ch)
                     .chain(from_fn(|| {
                         chars.by_ref().next_if(|c| {
@@ -103,5 +112,33 @@ router {
             &Token::String("neighbors".to_string())
         );
         assert_eq!(tokens.get(11).unwrap(), &Token::LeftBrace);
+    }
+
+    #[test]
+    fn test_tokenizer_ipv6_double_colon_prefix_kept_intact() {
+        // Regression: the tokenizer used to require the first character
+        // of a String token to be alphanumeric, which silently dropped
+        // the leading `:` of an IPv6 prefix written in double-colon
+        // shorthand. `::/0` ended up as the bare token "0", and the
+        // file loader then emitted `set ... route 0 nexthop ...` which
+        // libyang rejected — so a startup-config carrying a default
+        // IPv6 route lost it. Pin all four shorthand shapes so we
+        // notice if the leader rule is ever tightened again.
+        let cases = [
+            ("::/0;", vec!["::/0"]),
+            ("::1/128;", vec!["::1/128"]),
+            ("::ffff:1.2.3.4/128;", vec!["::ffff:1.2.3.4/128"]),
+            ("nexthop ::1;", vec!["nexthop", "::1"]),
+        ];
+        for (input, expected) in cases {
+            let strings: Vec<String> = tokenizer(input.to_string())
+                .into_iter()
+                .filter_map(|t| match t {
+                    Token::String(s) => Some(s),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(strings, expected, "input was {input:?}");
+        }
     }
 }


### PR DESCRIPTION
## Summary
A user-reported bug: when `zebra-rs.conf` contained a static IPv6 default route, it disappeared after the file was loaded:

```
static {
  ipv6 {
    route 2001:db8:ff00:5::/64 { segments { fcbb:bbbb:3:fe00::; } }
    route ::/0 { nexthop 2001:db8:ff00:10::2; }      <-- silently dropped
  }
}
```

CLI was unaffected.

## Root cause
The candidate-config tokenizer (`zebra-rs/src/config/token.rs`) required the first character of a `String` token to be alphanumeric:

```rust
'a'..='z' | 'A'..='Z' | '0'..='9' => { /* start collecting … */ }
```

An IPv6 prefix in double-colon shorthand starts with `:`. Each leading `:` fell into the catch-all `_ => {}` arm and was silently dropped. `::/0` emerged as the bare token `"0"`, the file loader emitted `set static ipv6 route 0 nexthop …`, and libyang rejected the line as not-a-valid-IPv6-prefix — so the route silently disappeared. CLI input arrives already word-split by the shell, so the operator path was fine, which is why the bug hid for so long.

## Fix
Add `':'` to the leader set:

```rust
'a'..='z' | 'A'..='Z' | '0'..='9' | ':' => { … }
```

Unambiguous — no valid YANG identifier or value starts with `:` other than IPv6 shorthand. The continuation rule already accepts `:`, so once we start, the rest of the prefix follows naturally.

## Pinned with two regression tests
- **Tokenizer-level** (`token.rs`): `::/0`, `::1/128`, `::ffff:1.2.3.4/128`, and `nexthop ::1` round-trip to the expected `Token::String` shapes.
- **Loader-level** (`files.rs`): the user's exact reported config shape goes through `load_config_file` and produces both the default-route `nexthop` line and the specific-prefix `segments` line.

## Test plan
- [x] `cargo build -p zebra-rs --bin zebra-rs` — clean
- [x] `cargo clippy -p zebra-rs --bin zebra-rs --no-deps` — clean
- [x] `cargo test -p zebra-rs --bin zebra-rs` — **161/161 pass** (159 pre-existing + 2 new)
- [x] `cargo fmt --all`
- [ ] Manual: load the user's exact reported `zebra-rs.conf` and verify `show ip route` shows both the `::/0` and `2001:db8:ff00:5::/64` static entries

Generated with [Claude Code](https://claude.com/claude-code)