### PR TITLE
build(vty): extract bash sources directly under build/

### DIFF
--- a/vty/Makefile
+++ b/vty/Makefile
@@ -12,12 +12,11 @@ CACHE_DIR     ?= $(HOME)/.cache/zebra-rs
 TARBALL       := $(CACHE_DIR)/$(BASH_TARBALL)
 
 BUILD_DIR     := build
-SRC_DIR       := $(BUILD_DIR)/vty
-TARGET        := $(SRC_DIR)/vty
+TARGET        := $(BUILD_DIR)/vty
 BINARY        := vty
 PATCH         := patches/0001-vty-hooks.patch
 ADDITIONS     := $(wildcard additions/*)
-STAMP_PREPARE := $(SRC_DIR)/.zebra-prepared
+STAMP_PREPARE := $(BUILD_DIR)/.zebra-prepared
 
 .PHONY: all prepare clean distclean
 
@@ -29,16 +28,15 @@ $(BINARY): $(TARGET)
 	cp $< $@
 
 $(TARGET): $(STAMP_PREPARE)
-	cd $(SRC_DIR) && ./configure
-	$(MAKE) -C $(SRC_DIR)
+	cd $(BUILD_DIR) && ./configure
+	$(MAKE) -C $(BUILD_DIR)
 
 $(STAMP_PREPARE): $(TARBALL) $(PATCH) $(ADDITIONS)
-	rm -rf $(SRC_DIR)
+	rm -rf $(BUILD_DIR)
 	mkdir -p $(BUILD_DIR)
-	tar -xzf $(TARBALL) -C $(BUILD_DIR)
-	mv $(BUILD_DIR)/bash-$(BASH_VERSION) $(SRC_DIR)
-	cp $(ADDITIONS) $(SRC_DIR)/
-	cd $(SRC_DIR) && patch -p1 --no-backup-if-mismatch < $(abspath $(PATCH))
+	tar -xzf $(TARBALL) -C $(BUILD_DIR) --strip-components=1
+	cp $(ADDITIONS) $(BUILD_DIR)/
+	cd $(BUILD_DIR) && patch -p1 --no-backup-if-mismatch < $(abspath $(PATCH))
 	touch $@
 
 $(TARBALL):

--- a/vty/README.md
+++ b/vty/README.md
@@ -11,8 +11,10 @@ live here.
 
 The first build downloads `bash-5.2.21.tar.gz` (~11 MB) into
 `~/.cache/zebra-rs/`, verifies its SHA-256, extracts it under
-`build/vty/`, lays additions on top, applies the patch, then runs
-`./configure && make`. The resulting binary is `build/vty/vty`.
+`build/` (via `tar --strip-components=1`, so no redundant
+`build/bash-5.2.21/` layer), lays additions on top, applies the
+patch, then runs `./configure && make`. The resulting binary is
+`build/vty`, with a copy at `vty` for packaging.
 
 Override the cache location with `CACHE_DIR=/some/path`.
 
@@ -26,4 +28,4 @@ Override the cache location with `CACHE_DIR=/some/path`.
 
 After `make`, bash's own regression suite is available:
 
-    cd build/vty/tests && ./run-all
+    cd build/tests && ./run-all


### PR DESCRIPTION
## Summary
Flatten the vty build layout. The bash-5.2.21 tarball used to extract into `build/`, get renamed to `build/vty/`, and then build to `build/vty/vty` — three nested layers for what's logically one source tree. Use `tar --strip-components=1` so sources land directly in `build/`. The binary is now `build/vty` (file), with the top-level `vty/vty` copy unchanged.

## Why packaging stays untouched
`packaging/Makefile` and `packaging/nfpm-*.yaml` both reference `../vty/vty` (the top-level copy produced by the Makefile's final `cp $< $@` step). That file's location doesn't change — only the source dir layout does — so packaging is unaffected.

## Changes
- `vty/Makefile`: drop `SRC_DIR` indirection (collapses to `BUILD_DIR`); `tar -xzf … --strip-components=1` instead of extract+`mv`.
- `vty/README.md`: describe the new layout (`build/vty` binary; tests at `build/tests/`).

## Test plan
- [x] `make -C vty clean && make -C vty` — builds cleanly with cached tarball
- [x] `vty/build/vty` — 4.8 MB binary at the new path
- [x] `vty/vty` — top-level copy still produced (unchanged path used by packaging)
- [x] `vty/vty --version` — runs and reports `GNU bash, version 5.2.21(1)-release`
- [ ] CI build-{amd,arm}64 jobs — these run `make -C vty` and depend on `vty/vty` for nfpm; the change is internal to `make -C vty` so they should pass without modification

Generated with [Claude Code](https://claude.com/claude-code)