### PR TITLE
bdd+config: IS-IS SRv6 scenario + fix CLI pattern-leaf parser

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -24,6 +24,10 @@ isis_ipv6:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_ipv6"
 
+isis_srv6:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_srv6"
+
 generate:
 	rm -rf allure-report
 	allure generate
@@ -43,4 +47,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 generate open docs FORCE

--- a/bdd/src/netns.rs
+++ b/bdd/src/netns.rs
@@ -147,6 +147,63 @@ pub async fn connect_netns_to_bridge(netns: &str, bridge_name: &str) -> Result<(
     Ok(())
 }
 
+/// Create a point-to-point veth pair between two existing namespaces and
+/// rename each end to a caller-chosen interface name. Brings both ends
+/// administratively up but does not assign addresses — that is left to the
+/// router's own config so the test fixtures stay self-describing.
+///
+/// The pair is created in the host namespace with throwaway names (an
+/// `ip link add NAME ...` in the host ns requires globally unique names),
+/// then `ip link set <link> netns <ns> name <newname>` moves and renames
+/// each end in one atomic step.
+pub async fn connect_netns_pair(
+    netns_a: &str,
+    iface_a: &str,
+    netns_b: &str,
+    iface_b: &str,
+) -> Result<()> {
+    let tmp_a = format!("vp{}{}a", netns_a, netns_b);
+    let tmp_b = format!("vp{}{}b", netns_a, netns_b);
+
+    run_cmd(
+        &[
+            "ip", "link", "add", &tmp_a, "type", "veth", "peer", "name", &tmp_b,
+        ],
+        &format!(
+            "Failed to create veth pair between {} and {}",
+            netns_a, netns_b
+        ),
+    )
+    .await?;
+
+    run_cmd(
+        &[
+            "ip", "link", "set", &tmp_a, "netns", netns_a, "name", iface_a,
+        ],
+        &format!(
+            "Failed to move/rename veth {} into {} as {}",
+            tmp_a, netns_a, iface_a
+        ),
+    )
+    .await?;
+
+    run_cmd(
+        &[
+            "ip", "link", "set", &tmp_b, "netns", netns_b, "name", iface_b,
+        ],
+        &format!(
+            "Failed to move/rename veth {} into {} as {}",
+            tmp_b, netns_b, iface_b
+        ),
+    )
+    .await?;
+
+    exec_in_netns(netns_a, "ip", &["link", "set", iface_a, "up"]).await?;
+    exec_in_netns(netns_b, "ip", &["link", "set", iface_b, "up"]).await?;
+
+    Ok(())
+}
+
 /// Delete the veth interface for a namespace (host side)
 pub async fn delete_veth(netns: &str) -> Result<()> {
     let veth_host = format!("v{}", netns);

--- a/bdd/tests/configs/isis_srv6/z1.conf
+++ b/bdd/tests/configs/isis_srv6/z1.conf
@@ -1,0 +1,64 @@
+interface enp0s6 {
+  ipv4 {
+    address 192.168.10.1/24;
+  }
+  ipv6 {
+    address 2001:db8:ff00:10::1/64;
+  }
+}
+interface enp0s7 {
+  ipv4 {
+    address 192.168.3.1/24;
+  }
+  ipv6 {
+    address 2001:db8:ff00:3::1/64;
+  }
+}
+interface lo {
+  ipv4 {
+    address 10.0.0.1/32;
+  }
+  ipv6 {
+    address 2001:db8:1::1/128;
+  }
+}
+router {
+  isis {
+    net 49.0000.0000.0000.0001.00;
+    is-type level-2-only;
+    te-router-id 10.0.0.1;
+    interface enp0s6 {
+      circuit-type level-2-only;
+      ipv4 {
+        enable true;
+      }
+      ipv6 {
+        enable true;
+      }
+      priority 63;
+    }
+    interface enp0s7;
+    interface lo {
+      circuit-type level-2-only;
+      ipv4 {
+        enable true;
+      }
+    }
+  }
+  static {
+    ipv6 {
+      route 2001:db8:ff00:5::/64 {
+        segments {
+          fcbb:bbbb:3:fe00::;
+        };
+      }
+    }
+  }
+}
+segment-routing {
+  locator LOC_uN1 {
+    behavior usid;
+    prefix fcbb:bbbb:1::/48;
+  }
+}
+

--- a/bdd/tests/configs/isis_srv6/z2.conf
+++ b/bdd/tests/configs/isis_srv6/z2.conf
@@ -1,0 +1,41 @@
+interface enp0s6 {
+  ipv6 {
+    address 2001:db8:ff00:10::2/64;
+  }
+}
+interface enp0s7 {
+  ipv6 {
+    address 2001:db8:ff00:2::1/64;
+  }
+}
+router {
+  isis {
+    net 49.0000.0000.0000.0002.00;
+    is-type level-2-only;
+    te-router-id 10.0.0.2;
+    segment-routing {
+      srv6 {
+        locator LOC_uN1;
+      }
+    }
+    interface enp0s6 {
+      circuit-type level-2-only;
+      ipv6 {
+        enable true;
+      }
+    }
+    interface enp0s7 {
+      circuit-type level-2-only;
+      ipv6 {
+        enable true;
+      }
+      link-type point-to-point;
+    }
+  }
+}
+segment-routing {
+  locator LOC_uN1 {
+    behavior usid;
+    prefix fcbb:bbbb:2::/48;
+  }
+}

--- a/bdd/tests/configs/isis_srv6/z3.conf
+++ b/bdd/tests/configs/isis_srv6/z3.conf
@@ -1,0 +1,42 @@
+interface enp0s6 {
+  ipv6 {
+    address 2001:db8:ff00:2::2/64;
+  }
+}
+interface enp0s7 {
+  ipv6 {
+    address 2001:db8:ff00:5::1/64;
+  }
+}
+router {
+  isis {
+    net 49.0000.0000.0000.0008.00;
+    is-type level-2-only;
+    te-router-id 10.0.0.3;
+    segment-routing {
+      srv6 {
+        locator LOC_uD;
+      }
+    }
+    interface enp0s6 {
+      circuit-type level-2-only;
+      ipv6 {
+        enable true;
+      }
+      link-type point-to-point;
+    }
+  }
+  static {
+    ipv6 {
+      route fcbb:bbbb:3:fe00::/128 {
+        action End.DT6;
+      }
+    }
+  }
+}
+segment-routing {
+  locator LOC_uD {
+    behavior usid;
+    prefix fcbb:bbbb:3::/48;
+  }
+}

--- a/bdd/tests/configs/isis_srv6/z4.conf
+++ b/bdd/tests/configs/isis_srv6/z4.conf
@@ -1,0 +1,14 @@
+interface enp0s7 {
+  ipv6 {
+    address 2001:db8:ff00:5::2/64;
+  }
+}
+router {
+  static {
+    ipv6 {
+      route ::/0 {
+        nexthop 2001:db8:ff00:5::1;
+      }
+    }
+  }
+}

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -18,14 +18,41 @@ async fn clean_test_environment(_world: &mut BgpWorld) {
     // otherwise their open netlink sockets can keep the namespace alive.
     let _ = netns::killall_zebra_rs().await;
 
-    // Delete veths first (must be done before namespaces are deleted)
-    let _ = netns::delete_veth("z1").await;
-    let _ = netns::delete_veth("z2").await;
-    let _ = netns::delete_netns("z1").await;
-    let _ = netns::delete_netns("z2").await;
+    // Delete veths first (must be done before namespaces are deleted).
+    // Cleanup is best-effort across z1..z4 so the same step works for both
+    // the bridge-attached topologies (z1, z2) and the linear point-to-point
+    // chain used by the SRv6 scenario (z1..z4).
+    for ns in ["z1", "z2", "z3", "z4"] {
+        let _ = netns::delete_veth(ns).await;
+        let _ = netns::delete_netns(ns).await;
+    }
     let _ = netns::delete_bridge("br0").await;
 
     println!("✓ Test environment cleaned");
+}
+
+#[when(expr = "I create namespace {string}")]
+async fn create_namespace_plain(_world: &mut BgpWorld, namespace: String) {
+    netns::create_netns(&namespace)
+        .await
+        .expect("Failed to create namespace");
+    println!("✓ Namespace {} created (no bridge)", namespace);
+}
+
+#[when(
+    expr = "I connect namespace {string} interface {string} to namespace {string} interface {string}"
+)]
+async fn connect_two_namespaces(
+    _world: &mut BgpWorld,
+    ns_a: String,
+    iface_a: String,
+    ns_b: String,
+    iface_b: String,
+) {
+    netns::connect_netns_pair(&ns_a, &iface_a, &ns_b, &iface_b)
+        .await
+        .expect("Failed to connect namespace pair");
+    println!("✓ Linked {}:{} <-> {}:{}", ns_a, iface_a, ns_b, iface_b);
 }
 
 #[when(expr = "I create bridge {string}")]
@@ -181,13 +208,28 @@ async fn stop_zebra_rs(_world: &mut BgpWorld, namespace: String) {
 async fn apply_config(world: &mut BgpWorld, config_file: String, namespace: String) {
     let config_path = format!("tests/configs/{}/{}", world.feature_tag, config_file);
 
-    netns::exec_in_netns(&namespace, "vtyctl", &["apply", "-f", &config_path])
+    let stdout = netns::exec_in_netns(&namespace, "vtyctl", &["apply", "-f", &config_path])
         .await
         .expect("Failed to apply config");
 
+    // `vtyctl apply` exits 0 even when the server rejects the config —
+    // it prints `error: <command>` (or `applied`) to stdout and returns.
+    // Without this check, a silently-rejected config would let the
+    // scenario continue past the apply step and fail later at a ping or
+    // a show with no obvious cause. Bail loudly with the offending line
+    // so the failure is diagnosable from the cucumber log alone.
+    let trimmed = stdout.trim();
+    assert!(
+        !trimmed.starts_with("error:"),
+        "vtyctl apply rejected {} in namespace {}: {}",
+        config_file,
+        namespace,
+        trimmed
+    );
+
     println!(
-        "✓ Config {} applied to namespace {}",
-        config_file, namespace
+        "✓ Config {} applied to namespace {} ({})",
+        config_file, namespace, trimmed
     );
 }
 

--- a/bdd/tests/features/isis_srv6.feature
+++ b/bdd/tests/features/isis_srv6.feature
@@ -1,0 +1,53 @@
+@serial
+@isis_srv6
+Feature: IS-IS SRv6 end-to-end with H.Encap and End.DT6
+  As a network operator
+  I want a 4-router IS-IS L2 chain to converge with SRv6 locators,
+  so a static IPv6 route at the head encapsulates traffic into a
+  uSID, the transit nodes forward by SRv6, and the tail decapsulates
+  via End.DT6 — letting Z1 reach a destination behind Z4 that is not
+  in any IGP.
+
+  Test Topology (linear chain, point-to-point veth pairs, no bridge):
+  ```
+  ┌────────┐  enp0s6 ── enp0s6  ┌────────┐  enp0s7 ── enp0s6  ┌────────┐  enp0s7 ── enp0s7  ┌────────┐
+  │   z1   │────────────────────│   z2   │────────────────────│   z3   │────────────────────│   z4   │
+  │ uN /48 │                    │ uN /48 │                    │ uD /48 │                    │ stub   │
+  │ fcbb:1 │                    │ fcbb:2 │                    │ fcbb:3 │                    │        │
+  └────────┘                    └────────┘                    └────────┘                    └────────┘
+   2001:db8:ff00:10::1/64       :10::2/64    :2::1/64          :2::2/64    :5::1/64           :5::2/64
+   (z1 enp0s6)                  (z2 enp0s6)  (z2 enp0s7)       (z3 enp0s6) (z3 enp0s7)        (z4 enp0s7)
+  ```
+
+  - z1, z2, z3 run IS-IS L2; z4 is a stub reached via a static
+    default route towards z3's enp0s7.
+  - z2 advertises locator `LOC_uN1` (fcbb:bbbb:2::/48); z3 advertises
+    `LOC_uD` (fcbb:bbbb:3::/48). z3 has a static `End.DT6` SID at
+    `fcbb:bbbb:3:fe00::/128`.
+  - z1 has a static IPv6 route to `2001:db8:ff00:5::/64` whose
+    nexthop is `segments fcbb:bbbb:3:fe00::` — H.Encap into uSID at
+    z1, transit through z2, decap on z3 via End.DT6, then plain
+    IPv6 forwarding to z4.
+
+  Config files (in `bdd/tests/configs/isis_srv6/`):
+  - z1.conf, z2.conf, z3.conf, z4.conf
+
+  Scenario: Setup the SRv6 chain and ping the far end through the SID
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I create namespace "z3"
+    And I create namespace "z4"
+    And I connect namespace "z1" interface "enp0s6" to namespace "z2" interface "enp0s6"
+    And I connect namespace "z2" interface "enp0s7" to namespace "z3" interface "enp0s6"
+    And I connect namespace "z3" interface "enp0s7" to namespace "z4" interface "enp0s7"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I start zebra-rs in namespace "z4"
+    And I apply config "z1.conf" to namespace "z1"
+    And I apply config "z2.conf" to namespace "z2"
+    And I apply config "z3.conf" to namespace "z3"
+    And I apply config "z4.conf" to namespace "z4"
+    And I wait 45 seconds
+    Then ping from "z1" to "2001:db8:ff00:5::2" should succeed

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -93,31 +93,52 @@ fn match_word(str: &str) -> (MatchType, usize) {
 }
 
 fn match_regexp(s: &str, regstr: &str) -> (MatchType, usize) {
-    let pos = 0usize;
-    let cache = REGEX_CACHE.lock().unwrap();
-    if let Some(regex) = cache.get(regstr) {
-        let matched = regex.is_match(s);
-        drop(cache);
-        return if matched {
-            (MatchType::Exact, pos)
-        } else {
-            (MatchType::None, pos)
-        };
+    // The CLI parser hands us the entire unparsed remainder of the line.
+    // A leaf value is one whitespace-delimited word, so identify the word
+    // boundary first and validate the pattern against just that word.
+    // Without this — and without returning the word length as `pos` — the
+    // caller at parse.rs:`remain = input.split_off(mx.pos)` would always
+    // see pos=0, re-feed the same input on the next recursion, and the
+    // recursion in `LeafMatched` state has no matcher so mx.count stays
+    // 0 → ExecCode::Nomatch. Net effect: every string-typed leaf with a
+    // YANG `pattern` (e.g. `isis:net` when not resolved to NsapAddr)
+    // failed to load via the CLI block format.
+    let word_end = s
+        .char_indices()
+        .find(|(_, c)| c.is_whitespace())
+        .map(|(i, _)| i)
+        .unwrap_or(s.len());
+    let word = &s[..word_end];
+
+    {
+        let cache = REGEX_CACHE.lock().unwrap();
+        if let Some(regex) = cache.get(regstr) {
+            return regex_match_word(regex, word, word_end);
+        }
     }
-    drop(cache);
 
     let Ok(regex) = Regex::new(regstr) else {
-        return (MatchType::None, pos);
+        return (MatchType::None, 0);
     };
-    let matched = regex.is_match(s);
+    let result = regex_match_word(&regex, word, word_end);
     REGEX_CACHE
         .lock()
         .unwrap()
         .insert(regstr.to_string(), regex);
-    if matched {
-        (MatchType::Exact, pos)
+    result
+}
+
+/// Helper for `match_regexp`: full-word match against the compiled regex.
+/// Anchoring is implicit — only an Exact start-to-end match counts, so a
+/// permissive pattern like `[0-9]+` won't accidentally accept `12abc`.
+fn regex_match_word(regex: &Regex, word: &str, word_end: usize) -> (MatchType, usize) {
+    if let Some(m) = regex.find(word)
+        && m.start() == 0
+        && m.end() == word.len()
+    {
+        (MatchType::Exact, word_end)
     } else {
-        (MatchType::None, pos)
+        (MatchType::None, 0)
     }
 }
 
@@ -700,5 +721,53 @@ pub fn parse(
             s.delete = true;
         }
         parse(&remain, next, config.clone(), s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression: `match_regexp` used to return `pos = 0` even on a
+    /// successful match, so the parser's `remain = input.split_off(pos)`
+    /// kept the entire input around and the next recursion (now in
+    /// `LeafMatched` state with no matcher) reported `Nomatch`. Net
+    /// effect: every string-typed leaf with a YANG `pattern` failed to
+    /// load via the CLI block format. Pinned at the helper level — pos
+    /// must equal the consumed word length, not 0.
+    #[test]
+    fn match_regexp_returns_consumed_word_length() {
+        // openconfig-isis-types `net` pattern: 1-octet AFI, 3-9 4-hex
+        // groups, 1-octet NSEL — also exercised by the BDD SRv6 fixture
+        // that surfaced the bug.
+        let pat = r"[a-fA-F0-9]{2}(\.[a-fA-F0-9]{4}){3,9}\.[a-fA-F0-9]{2}";
+
+        let (m, pos) = match_regexp("49.0000.0000.0000.0001.00", pat);
+        assert_eq!(m, MatchType::Exact);
+        assert_eq!(pos, 25);
+
+        // Trailing word still reported correctly: pos covers the leaf
+        // word only, so the parser advances exactly past it.
+        let (m, pos) = match_regexp("49.0000.0000.0000.0001.00 trailing", pat);
+        assert_eq!(m, MatchType::Exact);
+        assert_eq!(pos, 25);
+    }
+
+    #[test]
+    fn match_regexp_rejects_partial_word_match() {
+        // Permissive pattern — `is_match` would say yes for the leading
+        // digits, but as a leaf value `12abc` is invalid. Anchoring the
+        // match to the full word keeps the parser strict.
+        let pat = r"[0-9]+";
+        let (m, pos) = match_regexp("12abc", pat);
+        assert_eq!(m, MatchType::None);
+        assert_eq!(pos, 0);
+    }
+
+    #[test]
+    fn match_regexp_rejects_non_matching_word() {
+        let pat = r"[a-fA-F0-9]{2}(\.[a-fA-F0-9]{4}){3,9}\.[a-fA-F0-9]{2}";
+        let (m, _) = match_regexp("not-an-nsap", pat);
+        assert_eq!(m, MatchType::None);
     }
 }


### PR DESCRIPTION
## Summary
Adds a 4-router IS-IS SRv6 BDD scenario (linear chain Z1↔Z2↔Z3↔Z4, ping from Z1 to a destination behind Z4 that is not in any IGP — exercising H.Encap into a uSID at Z1, IS-IS SRv6 transit through Z2, End.DT6 decap on Z3, plain IPv6 to Z4). Surfaced and fixed a latent CLI parser bug along the way.

## BDD additions
- `bdd/tests/features/isis_srv6.feature` — the scenario.
- `bdd/tests/configs/isis_srv6/z{1,2,3,4}.conf` — the per-router CLI-block configs.
- `bdd/src/netns.rs::connect_netns_pair(ns_a, iface_a, ns_b, iface_b)` — point-to-point veth with caller-chosen interface names per side. Linux requires unique names in the host ns at link-add time, so the pair is created with throwaway names then moved + renamed into each ns in one `ip link set <link> netns <ns> name <newname>`.
- New cucumber steps: `I create namespace "X"` (no bridge) and `I connect namespace "A" interface "iA" to namespace "B" interface "iB"`.
- `clean_test_environment` now sweeps z1..z4 (was z1..z2) so the same step works for both bridge-attached and chain fixtures.
- `bdd/Makefile`: `isis_srv6` target.

## Diagnostic improvement
`apply_config` now captures vtyctl's stdout and bails the step with the rejected line. vtyctl exits 0 even when the server rejects the config (it just prints `error: <line>`), so without this a silently-rejected config would let the scenario continue and fail later at a ping with no obvious cause.

## Parser bug surfaced + fixed
The diagnostic immediately showed `error: set router isis net 49.0000.0000.0000.0001.00`. The line is well-formed and the value is accepted by both the YANG regex and the custom NSAP matcher. Root cause was in `zebra-rs/src/config/parse.rs::match_regexp`:

```rust
fn match_regexp(s: &str, regstr: &str) -> (MatchType, usize) {
    let pos = 0usize;        // never advanced
    ...
    if matched { (MatchType::Exact, pos) }   // returns pos=0 even on match
```

The caller computes `remain = input.split_off(pos)` and recurses; with pos=0 the recursion re-feeds the same input in `LeafMatched` state which has no matcher → `mx.count == 0` → `ExecCode::Nomatch`. **Net effect:** every string-typed leaf with a YANG `pattern` (when the typedef does not resolve to a custom matcher like `NsapAddr`) silently failed to load via CLI block format. YAML configs go through libyang directly so the bug was latent — every BDD config to date is YAML; this is the first CLI-block fixture that hit a string-with-pattern leaf in a non-key position.

**Fix:** identify the leaf-value word (everything up to whitespace), full-word-match the regex against just that word, and return the word length as `pos` so the parser advances correctly. Anchoring to the full word (rather than `is_match`'s any-substring semantics) keeps the parser strict — a permissive `[0-9]+` no longer accepts `12abc`.

## Pinned with regression tests
- `match_regexp_returns_consumed_word_length` — the user-reported NSAP value, with and without a trailing token
- `match_regexp_rejects_partial_word_match`
- `match_regexp_rejects_non_matching_word`

## Test plan
- [x] `cargo build -p zebra-rs --bin zebra-rs` — clean
- [x] `cargo build --manifest-path bdd/Cargo.toml --tests` — clean
- [x] `cargo clippy` (both packages) — clean
- [x] `cargo test -p zebra-rs --bin zebra-rs` — **164/164 pass** (3 new + 161 pre-existing)
- [x] `cargo fmt --all`
- [ ] BDD run on a Linux host with sudo + zebra-rs in PATH: `cd bdd && make isis_srv6` — apply step now succeeds on all four `.conf` files; ping convergence within 45s is the next thing to verify.

Generated with [Claude Code](https://claude.com/claude-code)