### PR TITLE
yang: extract static-routing schema into config-static, allow per-VRF

### DIFF
--- a/zebra-rs/yang/config-static.yang
+++ b/zebra-rs/yang/config-static.yang
@@ -1,0 +1,232 @@
+module config-static {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-static";
+  prefix "static";
+
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  description
+    "Schema for the zebra-rs static-routing tree. Extracted from
+     config.yang so the same shape can be instantiated twice — once
+     at the global level (`router static {...}`, the default VRF)
+     and once inside each per-VRF entry (`router static vrf NAME
+     {...}`). The on-the-wire data tree is unchanged for the global
+     instantiation; the per-VRF tree mirrors it under each VRF key.";
+
+  grouping static-routes {
+    description
+      "Address-family static-routing constructs (mpls + ipv4 + ipv6).
+       `uses` this grouping wherever a routing-instance-scoped static
+       configuration is needed.";
+
+    container mpls {
+      list label {
+        key "value";
+        leaf value {
+          type uint32;
+        }
+        list nexthop {
+          key "address";
+          leaf "address" {
+            type inet:ipv4-address;
+            description "Nexthop of the route";
+          }
+          leaf "outgoing-label" {
+            type uint32;
+          }
+        }
+      }
+    }
+
+    container ipv4 {
+      ext:help "IPv4 configuration";
+      list route {
+        key "prefix";
+        leaf prefix {
+          type inet:ipv4-prefix;
+        }
+        list nexthop {
+          key "address";
+          leaf "address" {
+            type inet:ipv4-address;
+            description "Nexthop of the route";
+          }
+          leaf metric {
+            type uint32;
+            description "Metric of the route.";
+          }
+          leaf weight {
+            type uint8;
+            description "Weight of ECMP route.";
+          }
+          leaf-list label {
+            type uint32;
+          }
+        }
+        leaf distance {
+          type uint8;
+          description "Distance of the route.";
+        }
+        leaf metric {
+          type uint32;
+          description "Metric of the route.";
+        }
+        container srv6 {
+          leaf-list segments {
+            type inet:ipv6-address;
+          }
+          leaf if-name {
+            ext:dynamic "rib:interface";
+            type string;
+          }
+        }
+      }
+
+      list arp {
+        key "address";
+        leaf "address" {
+          type inet:ipv4-address;
+          description "ARP neighbor address";
+        }
+        leaf mac {
+          type yang:mac-address;
+          description "MAC Address";
+        }
+      }
+
+      list srv6 {
+        key "prefix";
+        leaf prefix {
+          type inet:ipv4-prefix;
+        }
+        leaf encap {
+          type enumeration {
+            enum seg6;
+            enum seg6local;
+          }
+        }
+        leaf mode {
+          type enumeration {
+            enum encap;
+            enum inline;
+          }
+        }
+        leaf-list segs {
+          type string;
+          description "SRv6 segments";
+        }
+        leaf action {
+          type enumeration {
+            enum End;
+            enum End.DT4;
+          }
+        }
+        leaf dev {
+          type string;
+          description "Outgoing interface";
+        }
+        leaf table {
+          type uint32;
+        }
+        leaf flavors {
+          type enumeration {
+            enum next-csid;
+            enum psp;
+            enum usp;
+            enum usd;
+          }
+        }
+        leaf lblen {
+          type uint8;
+        }
+        leaf nflen {
+          type uint8;
+        }
+      }
+    }
+
+    container ipv6 {
+      ext:help "IPv6 configuration";
+
+      list neighbor {
+        key "address";
+        leaf "address" {
+          type inet:ipv6-address;
+          description "ARP neighbor address";
+        }
+        leaf mac {
+          type yang:mac-address;
+          description "MAC Address";
+        }
+      }
+
+      list route {
+        key "prefix";
+        leaf prefix {
+          type inet:ipv6-prefix;
+        }
+        list nexthop {
+          key "address";
+          leaf "address" {
+            type inet:ipv6-address;
+            description "Nexthop of the route";
+          }
+          leaf metric {
+            type uint32;
+            description "Metric of the route.";
+          }
+          leaf weight {
+            type uint8;
+            description "Weight of ECMP route.";
+          }
+        }
+        leaf distance {
+          type uint8;
+          description "Distance of the route.";
+        }
+        leaf metric {
+          type uint32;
+          description "Metric of the route.";
+        }
+        leaf-list segments {
+          type inet:ipv6-address;
+        }
+        leaf encap-type {
+          type enumeration {
+            enum "H.Encap";
+            enum "H.Encap.Red";
+          }
+        }
+        leaf action {
+          description
+            "SRv6 endpoint behavior installed as a seg6local
+             terminal action on this prefix. Mutually exclusive
+             with `segments` (which configures an outer H.Encap
+             push). Only the local-action variants — End, uN,
+             End.DT4, End.DT6 — are usable today; End.X / uA
+             require a per-adjacency nexthop that this list
+             doesn't model yet.";
+          type enumeration {
+            enum "End";
+            enum "End.X";
+            enum "uN";
+            enum "uA";
+            enum "End.DT4";
+            enum "End.DT6";
+          }
+        }
+      }
+    }
+  }
+}

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -36,6 +36,10 @@ module config {
     prefix isis;
   }
 
+  import config-static {
+    prefix static;
+  }
+
   typedef vrf-route-target {
     type string {
       pattern
@@ -582,204 +586,33 @@ module config {
       }
       container static {
         ext:help "Static route configuration";
-        container mpls {
-          list label {
-            key "value";
-            leaf value {
-              type uint32;
-            }
-            list nexthop {
-              key "address";
-              leaf "address" {
-                type inet:ipv4-address;
-                description "Nexthop of the route";
-              }
-              leaf "outgoing-label" {
-                type uint32;
-              }
-            }
+
+        // Default / global instance — no `vrf` key. The on-the-wire
+        // paths under `router/static/{ipv4,ipv6,mpls}` are unchanged
+        // from before the extraction, so existing callbacks keep
+        // their registrations.
+        uses static:static-routes;
+
+        // Per-VRF instance. The same static-routes shape is reused
+        // for each named VRF; routes configured here install into
+        // the VRF's routing table once VRF support is wired into
+        // the FIB. The `vrf` key is a plain string (matches the
+        // staging-friendly pattern used by IS-IS for `block` and
+        // `locator`) — the VRF need not yet be declared at the
+        // top-level `vrf` list when this config is parsed.
+        list vrf {
+          key "name";
+          description
+            "Per-VRF static-routing tree. All address families allowed
+             at the global level are also allowed here.";
+          leaf name {
+            type string;
+            description
+              "Name of the VRF this static block applies to. Matches
+               the key of the top-level `vrf` list.";
           }
+          uses static:static-routes;
         }
-
-        container ipv4 {
-          ext:help "IPv4 configuration";
-          list route {
-            key "prefix";
-            leaf prefix {
-              type inet:ipv4-prefix;
-            }
-            list nexthop {
-              key "address";
-              leaf "address" {
-                type inet:ipv4-address;
-                description "Nexthop of the route";
-              }
-              leaf metric {
-                type uint32;
-                description "Metric of the route.";
-              }
-              leaf weight {
-                type uint8;
-                description "Weight of ECMP route.";
-              }
-              leaf-list label {
-                type uint32;
-              }
-            }
-            leaf distance {
-              type uint8;
-              description "Distance of the route.";
-            }
-            leaf metric {
-              type uint32;
-              description "Metric of the route.";
-            }
-            container srv6 {
-              leaf-list segments {
-                type inet:ipv6-address;
-              }
-              leaf if-name {
-                ext:dynamic "rib:interface";
-                type string;
-              }
-            }
-          }
-
-          list arp {
-            key "address";
-            leaf "address" {
-              type inet:ipv4-address;
-              description "ARP neighbor address";
-            }
-            leaf mac {
-              type yang:mac-address;
-              description "MAC Address";
-            }
-          }
-
-          list srv6 {
-            key "prefix";
-            leaf prefix {
-              type inet:ipv4-prefix;
-            }
-            leaf encap {
-              type enumeration {
-                enum seg6;
-                enum seg6local;
-              }
-            }
-            leaf mode {
-              type enumeration {
-                enum encap;
-                enum inline;
-              }
-            }
-            leaf-list segs {
-              type string;
-              description "SRv6 segments";
-            }
-            leaf action {
-              type enumeration {
-                enum End;
-                enum End.DT4;
-              }
-            }
-            leaf dev {
-              type string;
-              description "Outgoing interface";
-            }
-            leaf table {
-              type uint32;
-            }
-            leaf flavors {
-              type enumeration {
-                enum next-csid;
-                enum psp;
-                enum usp;
-                enum usd;
-              }
-            }
-            leaf lblen {
-              type uint8;
-            }
-            leaf nflen {
-              type uint8;
-            }
-          }
-        }
-        container ipv6 {
-          ext:help "IPv6 configuration";
-
-          list neighbor {
-            key "address";
-            leaf "address" {
-              type inet:ipv6-address;
-              description "ARP neighbor address";
-            }
-            leaf mac {
-              type yang:mac-address;
-              description "MAC Address";
-            }
-          }
-
-          list route {
-            key "prefix";
-            leaf prefix {
-              type inet:ipv6-prefix;
-            }
-            list nexthop {
-              key "address";
-              leaf "address" {
-                type inet:ipv6-address;
-                description "Nexthop of the route";
-              }
-              leaf metric {
-                type uint32;
-                description "Metric of the route.";
-              }
-              leaf weight {
-                type uint8;
-                description "Weight of ECMP route.";
-              }
-            }
-            leaf distance {
-              type uint8;
-              description "Distance of the route.";
-            }
-            leaf metric {
-              type uint32;
-              description "Metric of the route.";
-            }
-            leaf-list segments {
-              type inet:ipv6-address;
-            }
-            leaf encap-type {
-              type enumeration {
-                enum "H.Encap";
-                enum "H.Encap.Red";
-              }
-            }
-            leaf action {
-              description
-                "SRv6 endpoint behavior installed as a seg6local
-                 terminal action on this prefix. Mutually exclusive
-                 with `segments` (which configures an outer H.Encap
-                 push). Only the local-action variants — End, uN,
-                 End.DT4, End.DT6 — are usable today; End.X / uA
-                 require a per-adjacency nexthop that this list
-                 doesn't model yet.";
-              type enumeration {
-                enum "End";
-                enum "End.X";
-                enum "uN";
-                enum "uA";
-                enum "End.DT4";
-                enum "End.DT6";
-              }
-            }
-          }
-        }
-
       }
     }
 


### PR DESCRIPTION
## Summary
First step of the VRF integration: carve the existing `router static {...}` body (mpls + ipv4 + ipv6) into a new `config-static` module's `static-routes` grouping, and `uses` it twice in `config.yang`:

- **At the global level (default VRF)** — same on-the-wire paths as before (`/router/static/{ipv4,ipv6,mpls}/...`), so existing Rust callbacks under `rib/static` and `rib/mpls` keep their registrations and continue to work unchanged.
- **Inside a new `list vrf { key "name"; ... uses static-routes; }`** nested under `static`, enabling per-VRF static routes:

```
router {
  static {
    ipv4 { route 10.0.0.0/24 { nexthop 192.0.2.1; } }   # global / default
    vrf CUST-A {                                        # per-VRF
      ipv6 {
        route 2001:db8:ff00:5::/64 {
          segments { fcbb:bbbb:3:fe00::; }
        }
      }
    }
  }
}
```

The `vrf` key is a plain string, **not** a leafref to the top-level `/vrf` list — same staging-friendly pattern as IS-IS uses for `block` and `locator` references, so a `static vrf X` block can be parsed before `vrf X` is declared at the top level.

## Scope: schema-only
The per-VRF paths (`/router/static/vrf/<name>/...`) parse and validate against YANG, but no Rust handler consumes them yet — VRF static config is silently applied to the default table until the FIB layer learns to route per-VRF lookups to the right routing table. That's the follow-up.

## Test plan
- [x] `cargo build -p zebra-rs --bin zebra-rs` — clean
- [x] `cargo clippy -p zebra-rs --bin zebra-rs --no-deps` — clean
- [x] `cargo test -p zebra-rs --bin zebra-rs` — **164/164 pass**
- [x] Existing global static-routes shape under `router/static` is byte-for-byte identical to what was inlined before, so existing BDD fixtures (which exercise `router/static/ipv6/route` and similar — including the IS-IS SRv6 scenario merged in PR #388) continue to parse.
- [ ] Manual: load a config with both global and per-VRF static blocks and verify the per-VRF block parses (Rust callback to actually install per-VRF routes is the follow-up).

Generated with [Claude Code](https://claude.com/claude-code)