### PR TITLE
yang: add per-VRF BGP context with Route Distinguisher (IOS-XR style)

### DIFF
--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -32,6 +32,10 @@ module config {
     prefix zba;
   }
 
+  import zebra-bgp-vrf {
+    prefix zbv;
+  }
+
   import openconfig-isis-types {
     prefix isis;
   }

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -1,0 +1,142 @@
+module zebra-bgp-vrf {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-vrf";
+  prefix "zbv";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "Per-VRF BGP configuration for zebra-rs, modelled after Cisco
+     IOS-XR. The Route Distinguisher lives in the BGP context
+     (`router bgp { vrf X { rd ...; } }`) — keeping it close to the
+     protocol that actually emits VPNv4 / VPNv6 NLRIs — while RT
+     import/export policy continues to live on the top-level
+     /vrf/<name>/{ipv4,ipv6}/route-target leaves added previously.
+
+     Resulting CLI / config shape:
+
+       router bgp {
+         vrf vrf1 {
+           rd 65000:10;
+         }
+       }
+
+     `vrf` is keyed by a plain string (not a leafref to /vrf), so a
+     `router bgp vrf X` block can be parsed before `vrf X` is
+     declared at the top level — same staging-friendly pattern used
+     by IS-IS for `block` and `locator` references.";
+
+  reference "RFC 4364: BGP/MPLS IP VPNs §4.2 (Route Distinguishers)";
+
+  typedef route-distinguisher {
+    type string {
+      pattern
+          '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+        + '6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{0,3}|0)'
+        + ':'
+        + '(429496729[0-5]|42949672[0-8][0-9]|'
+        + '4294967[01][0-9]{2}|429496[0-6][0-9]{3}|'
+        + '42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|'
+        + '429[0-3][0-9]{6}|42[0-8][0-9]{7}|'
+        + '4[01][0-9]{8}|[1-3][0-9]{9}|'
+        + '[1-9][0-9]{0,8}|0)'
+        + '|'
+        + '((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}'
+        + '(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])'
+        + ':'
+        + '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+        + '6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{0,3}|0)'
+        + '|'
+        + '(429496729[0-5]|42949672[0-8][0-9]|'
+        + '4294967[01][0-9]{2}|429496[0-6][0-9]{3}|'
+        + '42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|'
+        + '429[0-3][0-9]{6}|42[0-8][0-9]{7}|'
+        + '4[01][0-9]{8}|[1-3][0-9]{9}|'
+        + '[1-9][0-9]{0,8}|0)'
+        + ':'
+        + '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|'
+        + '6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{0,3}|0)';
+    }
+    description
+      "BGP/MPLS VPN Route Distinguisher in operator-friendly notation
+       (no leading type-number prefix). Three encodings are accepted:
+
+         Type 0:  2-byte-ASN:4-byte-number    e.g. 65000:10
+         Type 1:  IPv4-address:2-byte-number  e.g. 192.0.2.1:10
+         Type 2:  4-byte-ASN:2-byte-number    e.g. 4200000000:10
+
+       Disambiguation between Type 0 and Type 2 is by the magnitude
+       of the first field: <= 65535 means Type 0, otherwise Type 2.
+       Type 1 is recognised by the dotted-quad in the first field.
+
+       The RD is prepended to each VPN route originating from the
+       VRF to make it unique in the global VPNv4 / VPNv6 RIB.
+
+       Wire format and pattern are identical to a Route Target —
+       the two are kept as separate typedefs purely for documentation
+       clarity (RD = uniqueness, RT = import/export filtering).";
+    reference
+      "RFC 4360: BGP Extended Communities Attribute
+       RFC 4364: BGP/MPLS IP Virtual Private Networks (VPNs) §4.2
+       RFC 5668: 4-Octet AS Specific BGP Extended Community";
+  }
+
+  grouping bgp-vrf-extension {
+    description
+      "Per-VRF BGP block hung off the top-level `router bgp` tree.";
+    list vrf {
+      key "name";
+      description
+        "Per-VRF BGP context. The VRF name is a plain string and need
+         not yet be declared at the top-level /vrf list when this
+         config is parsed — same staging pattern as IS-IS uses for
+         `block` and `locator`.";
+      leaf name {
+        type string;
+        description
+          "Name of the VRF this BGP block applies to.";
+      }
+      leaf rd {
+        type route-distinguisher;
+        description
+          "Route Distinguisher prepended to VPNv4 / VPNv6 NLRIs
+           originating from this VRF. See RFC 4364 §4.2.";
+      }
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router/bgp:bgp" {
+    description
+      "Attach the per-VRF list to `router bgp` in the candidate-set
+       subtree.";
+    uses bgp-vrf-extension;
+  }
+
+  augment "/configure:delete/config:router/bgp:bgp" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp vrf X rd` is path-valid.";
+    uses bgp-vrf-extension;
+  }
+}


### PR DESCRIPTION
## Summary
New YANG module `zebra-bgp-vrf.yang` augments `router bgp` with a per-VRF list carrying the Route Distinguisher. Cisco IOS-XR convention — RD lives close to the protocol that emits VPNv4 / VPNv6 NLRIs, while RT import/export policy stays on the top-level `/vrf/<name>/{ipv4,ipv6}/route-target` leaves added in earlier work.

```
router bgp {
  vrf vrf1 {
    rd 65000:10;
  }
}
```

## Design
- **`route-distinguisher` typedef**: same operator-friendly notation as the existing `vrf-route-target` typedef (Type 0 / 1 / 2, no leading type-number prefix). Kept as a separate typedef for documentation clarity — RD = uniqueness, RT = import/export filtering. Wire format and pattern are identical.
- **`vrf` keyed by plain string, not leafref to `/vrf`** — same staging-friendly pattern that IS-IS uses for `block` and `locator`, so `router bgp vrf X { rd ... }` parses before `vrf X` is declared at the top level.
- **Augments `/configure:{set,delete}/config:router/bgp:bgp`** — mirrors the existing `zebra-bgp-auth.yang` pattern (which augments `bgp:bgp/bgp:neighbor` with TCP-MD5/AO leaves).

## Test plan
- [x] `cargo build -p zebra-rs --bin zebra-rs` — clean
- [x] `cargo test -p zebra-rs --bin zebra-rs` — **164/164 pass**
- [x] `cargo clippy` — clean (no .rs changes)
- [ ] Manual: `set router bgp vrf vrf1 rd 65000:10` parses and round-trips through `show running-config`. Rust callback to actually use the RD when emitting VPN NLRIs is the follow-up.

Generated with [Claude Code](https://claude.com/claude-code)