### PR TITLE
yang: add End.DT46 action and vrf leaf to SRv6 static IPv6 routes

### DIFF
--- a/zebra-rs/yang/config-static.yang
+++ b/zebra-rs/yang/config-static.yang
@@ -214,9 +214,16 @@ module config-static {
              terminal action on this prefix. Mutually exclusive
              with `segments` (which configures an outer H.Encap
              push). Only the local-action variants — End, uN,
-             End.DT4, End.DT6 — are usable today; End.X / uA
-             require a per-adjacency nexthop that this list
-             doesn't model yet.";
+             End.DT4, End.DT6, End.DT46 — are usable today;
+             End.X / uA require a per-adjacency nexthop that this
+             list doesn't model yet.
+
+             End.DT4 / End.DT6 / End.DT46 decapsulate the outer
+             IPv6 header and look the inner packet up in the VRF
+             named by the sibling `vrf` leaf — End.DT4 for the
+             VRF's IPv4 unicast table, End.DT6 for IPv6 unicast,
+             End.DT46 for both (selected by the inner header's
+             address family).";
           type enumeration {
             enum "End";
             enum "End.X";
@@ -224,7 +231,21 @@ module config-static {
             enum "uA";
             enum "End.DT4";
             enum "End.DT6";
+            enum "End.DT46";
           }
+        }
+        leaf vrf {
+          type string;
+          description
+            "Name of the VRF whose routing table is consulted
+             after decapsulation. Required when `action` is
+             End.DT4, End.DT6, or End.DT46; ignored otherwise.
+
+             Held as a plain string (not a leafref to the
+             top-level /vrf list) for the same staging-friendly
+             reason as IS-IS uses for `block` and `locator`
+             references — a static SID block can be parsed
+             before the VRF is declared at the top level.";
         }
       }
     }


### PR DESCRIPTION
## Summary
Adds the `End.DT46` SRv6 endpoint behavior (RFC 9252 §5.2 — decap and lookup in a VRF, AF selected by the inner header) to the `action` enum on `static/ipv6/route`, plus a sibling `vrf` leaf so the SID can name its target VRF:

```
static {
  ipv6 {
    route fcbb:bbbb:3:fe10::/128 {
      action End.DT46;
      vrf vrf1;
    }
  }
}
```

The `vrf` leaf is required (semantically) when `action` is End.DT4, End.DT6, or End.DT46; ignored otherwise. The schema doesn't yet encode this with `when`/`must` — the runtime callback will validate when VRF FIB support lands.

`vrf` is held as a plain string, not a leafref to the top-level `/vrf` list — same staging-friendly pattern used elsewhere (IS-IS `block`/`locator`, BGP per-VRF `vrf` key from PR #390). A static SID block can be parsed before the VRF is declared at the top level.

## Test plan
- [x] `cargo build -p zebra-rs --bin zebra-rs` — clean
- [x] `cargo test -p zebra-rs --bin zebra-rs` — **164/164 pass**
- [x] `cargo clippy` — clean (no .rs changes)
- [ ] Manual: `set router static ipv6 route fcbb:bbbb:3:fe10::/128 action End.DT46` parses; `set ... vrf vrf1` parses. Rust callback to install the seg6local SEG6_LOCAL_ACTION_END_DT46 with table=VRF is the follow-up.

## Notes
- Independent of PR #390 (BGP per-VRF RD); no conflict — different files.

Generated with [Claude Code](https://claude.com/claude-code)