### PR TITLE
fib: subscribe to RTNLGRP_NEIGH and dump ARP/NDP/FDB at startup

### DIFF
--- a/zebra-rs/src/fib/message.rs
+++ b/zebra-rs/src/fib/message.rs
@@ -1,5 +1,9 @@
+use std::net::IpAddr;
+
 use ipnet::IpNet;
 use netlink_packet_route::link::LinkFlags;
+use netlink_packet_route::neighbour::{NeighbourFlags, NeighbourState};
+use netlink_packet_route::{AddressFamily, route::RouteType};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use crate::rib::{MacAddr, entry::RibEntry};
@@ -59,6 +63,44 @@ pub struct FibRoute {
     pub entry: RibEntry,
 }
 
+/// One row from the kernel's neighbor table — covers IPv4 ARP, IPv6
+/// NDP, and bridge FDB. The `family` field tells the consumer which
+/// of those it is:
+///
+/// - `AddressFamily::Inet` — ARP entry; `dst` is the IPv4 protocol
+///   address, `lladdr` is the MAC.
+/// - `AddressFamily::Inet6` — NDP entry; `dst` is the IPv6 protocol
+///   address, `lladdr` is the MAC.
+/// - `AddressFamily::Bridge` — FDB entry; `lladdr` is the MAC, `dst`
+///   is the remote VTEP IP for VXLAN-bridged entries (empty for
+///   ordinary bridge ports).
+///
+/// `vni` is set on AF_BRIDGE entries that came in with `NDA_VNI`
+/// (per-FDB-entry override of the device-wide VNI). `vlan` is the
+/// 802.1Q tag on traditional bridge entries. `master` is the bridge /
+/// VRF ifindex when the kernel sent `NDA_MASTER` (renamed
+/// `NDA_CONTROLLER` in current uapi).
+///
+/// Fields are populated for the upcoming EVPN Type-2 advertise path
+/// (which will key on family + lladdr + dst + vni). Reading them in
+/// the meantime is intentionally limited to the FibMessage Debug
+/// formatter — `#[allow(dead_code)]` keeps that staging visible to
+/// the reader without tripping `-D warnings`.
+#[allow(dead_code)]
+#[derive(Default, Debug, Clone)]
+pub struct FibNeighbor {
+    pub family: AddressFamily,
+    pub ifindex: u32,
+    pub state: NeighbourState,
+    pub flags: NeighbourFlags,
+    pub kind: RouteType,
+    pub lladdr: Option<MacAddr>,
+    pub dst: Option<IpAddr>,
+    pub vlan: Option<u16>,
+    pub vni: Option<u32>,
+    pub master: Option<u32>,
+}
+
 #[derive(Debug)]
 pub enum FibMessage {
     NewLink(FibLink),
@@ -67,4 +109,6 @@ pub enum FibMessage {
     DelAddr(FibAddr),
     NewRoute(FibRoute),
     DelRoute(FibRoute),
+    NewNeighbor(FibNeighbor),
+    DelNeighbor(FibNeighbor),
 }

--- a/zebra-rs/src/fib/netlink/dump.rs
+++ b/zebra-rs/src/fib/netlink/dump.rs
@@ -2,17 +2,25 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 
 use anyhow::Result;
 use futures::stream::TryStreamExt;
+use netlink_packet_route::AddressFamily;
 use rtnetlink::{IpVersion, RouteMessageBuilder};
 
 use crate::{fib::FibMessage, rib::Rib};
 
-use super::{addr_from_msg, link_from_msg, route_from_msg};
+use super::{addr_from_msg, link_from_msg, neighbor_from_msg, route_from_msg};
 
 pub async fn fib_dump(rib: &mut Rib) -> Result<()> {
     link_dump(rib, rib.fib_handle.handle.clone()).await?;
     address_dump(rib, rib.fib_handle.handle.clone()).await?;
     route_dump(rib, rib.fib_handle.handle.clone(), IpVersion::V4).await?;
     route_dump(rib, rib.fib_handle.handle.clone(), IpVersion::V6).await?;
+    // Neighbor tables: ARP (AF_INET), NDP (AF_INET6), and bridge FDB
+    // (AF_BRIDGE). Without these, neighbor entries that existed before
+    // zebra-rs started are invisible — only post-start RTM_NEWNEIGH
+    // events would be observed.
+    neighbor_dump(rib, rib.fib_handle.handle.clone(), AddressFamily::Inet).await?;
+    neighbor_dump(rib, rib.fib_handle.handle.clone(), AddressFamily::Inet6).await?;
+    neighbor_dump(rib, rib.fib_handle.handle.clone(), AddressFamily::Bridge).await?;
     Ok(())
 }
 
@@ -48,6 +56,29 @@ async fn route_dump(rib: &mut Rib, handle: rtnetlink::Handle, ip_version: IpVers
             let msg = FibMessage::NewRoute(route);
             rib.process_fib_msg(msg).await;
         }
+    }
+    Ok(())
+}
+
+async fn neighbor_dump(
+    rib: &mut Rib,
+    handle: rtnetlink::Handle,
+    family: AddressFamily,
+) -> Result<()> {
+    // The rtnetlink crate exposes `set_family(IpVersion)` for the
+    // common AF_INET / AF_INET6 cases; for AF_BRIDGE there's no
+    // convenience setter, so reach into `message_mut()` directly.
+    let mut req = handle.neighbours().get();
+    match family {
+        AddressFamily::Inet => req = req.set_family(IpVersion::V4),
+        AddressFamily::Inet6 => req = req.set_family(IpVersion::V6),
+        other => req.message_mut().header.family = other,
+    }
+    let mut neighbors = req.execute();
+    while let Some(msg) = neighbors.try_next().await? {
+        let nbr = neighbor_from_msg(msg);
+        let msg = FibMessage::NewNeighbor(nbr);
+        rib.process_fib_msg(msg).await;
     }
     Ok(())
 }

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -14,6 +14,7 @@ use netlink_packet_route::link::{
     AfSpecInet6, AfSpecUnspec, InfoData, InfoKind, InfoVxlan, LinkAttribute, LinkFlags, LinkInfo,
     LinkLayerType, LinkMessage,
 };
+use netlink_packet_route::neighbour::{NeighbourAddress, NeighbourAttribute, NeighbourMessage};
 use netlink_packet_route::nexthop::{NexthopAttribute, NexthopFlags, NexthopGroup, NexthopMessage};
 use netlink_packet_route::route::{
     MplsLabel, RouteAddress, RouteAttribute, RouteHeader, RouteLwEnCapType, RouteLwTunnelEncap,
@@ -25,13 +26,14 @@ use rtnetlink::{
     LinkDummy, LinkVrf,
     constants::{
         RTMGRP_IPV4_IFADDR, RTMGRP_IPV4_ROUTE, RTMGRP_IPV6_IFADDR, RTMGRP_IPV6_ROUTE, RTMGRP_LINK,
+        RTMGRP_NEIGH,
     },
     new_connection,
 };
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::fib::sysctl::sysctl_enable;
-use crate::fib::{FibAddr, FibLink, FibMessage, FibRoute};
+use crate::fib::{FibAddr, FibLink, FibMessage, FibNeighbor, FibRoute};
 use crate::rib::entry::RibEntry;
 use crate::rib::inst::IlmEntry;
 use crate::rib::route::DEBUG_ADDR;
@@ -164,7 +166,11 @@ impl FibHandle {
             | RTMGRP_IPV4_ROUTE
             | RTMGRP_IPV6_ROUTE
             | RTMGRP_IPV4_IFADDR
-            | RTMGRP_IPV6_IFADDR;
+            | RTMGRP_IPV6_IFADDR
+            // Covers RTM_NEWNEIGH / RTM_DELNEIGH for AF_INET (ARP),
+            // AF_INET6 (NDP), and AF_BRIDGE (FDB) — all three flow
+            // through the same group.
+            | RTMGRP_NEIGH;
 
         let addr = SocketAddr::new(0, mgroup_flags);
         connection.socket_mut().socket_mut().bind(&addr)?;
@@ -2098,6 +2104,52 @@ pub fn route_from_msg(msg: RouteMessage) -> Option<FibRoute> {
     Some(msg)
 }
 
+/// Translate a kernel `RTM_NEWNEIGH` / `RTM_DELNEIGH` payload into the
+/// internal [`FibNeighbor`] form. Supports the three address families
+/// the consumer cares about today:
+///
+/// - `AF_INET` — ARP entries (NDA_DST = IPv4 protocol address,
+///   NDA_LLADDR = MAC).
+/// - `AF_INET6` — NDP entries (NDA_DST = IPv6 protocol address,
+///   NDA_LLADDR = MAC).
+/// - `AF_BRIDGE` — FDB entries (NDA_LLADDR = MAC, NDA_DST optional =
+///   remote VTEP IP for VXLAN, NDA_VNI optional, NDA_VLAN optional).
+///
+/// Other families fall through with the header populated and the
+/// attribute fields left at their defaults — easier to debug than
+/// silently dropping them.
+pub fn neighbor_from_msg(msg: NeighbourMessage) -> FibNeighbor {
+    let mut nbr = FibNeighbor {
+        family: msg.header.family,
+        ifindex: msg.header.ifindex,
+        state: msg.header.state,
+        flags: msg.header.flags,
+        kind: msg.header.kind,
+        ..Default::default()
+    };
+
+    for attr in msg.attributes.into_iter() {
+        match attr {
+            NeighbourAttribute::Destination(addr) => match addr {
+                NeighbourAddress::Inet(v4) => nbr.dst = Some(IpAddr::V4(v4)),
+                NeighbourAddress::Inet6(v6) => nbr.dst = Some(IpAddr::V6(v6)),
+                NeighbourAddress::Other(_) => {}
+                // Non-exhaustive enum; future-proof against new variants.
+                _ => {}
+            },
+            NeighbourAttribute::LinkLocalAddress(bytes) => {
+                nbr.lladdr = MacAddr::from_vec(bytes);
+            }
+            NeighbourAttribute::Vlan(vlan) => nbr.vlan = Some(vlan),
+            NeighbourAttribute::Vni(vni) => nbr.vni = Some(vni),
+            NeighbourAttribute::Controller(idx) => nbr.master = Some(idx),
+            _ => {}
+        }
+    }
+
+    nbr
+}
+
 fn process_msg(msg: NetlinkMessage<RouteNetlinkMessage>, tx: UnboundedSender<FibMessage>) {
     if let NetlinkPayload::InnerMessage(msg) = msg.payload {
         match msg {
@@ -2134,6 +2186,16 @@ fn process_msg(msg: NetlinkMessage<RouteNetlinkMessage>, tx: UnboundedSender<Fib
                     let msg = FibMessage::DelRoute(route);
                     tx.send(msg).unwrap();
                 }
+            }
+            RouteNetlinkMessage::NewNeighbour(msg) => {
+                let neighbor = neighbor_from_msg(msg);
+                let msg = FibMessage::NewNeighbor(neighbor);
+                tx.send(msg).unwrap();
+            }
+            RouteNetlinkMessage::DelNeighbour(msg) => {
+                let neighbor = neighbor_from_msg(msg);
+                let msg = FibMessage::DelNeighbor(neighbor);
+                tx.send(msg).unwrap();
             }
             // TODO: Phase 4B - Add MDB message handling when netlink-packet-route supports it
             // RouteNetlinkMessage::NewMdb(_) => {

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -942,6 +942,17 @@ impl Rib {
                     self.ipv4_route_del(&prefix, route.entry).await;
                 }
             }
+            // Inbound L2/L3-neighbor visibility for the upcoming EVPN
+            // work. No consumer yet; logged at debug for now so the
+            // wire is exercised end-to-end (subscribe + parse + dispatch)
+            // without committing to any protocol behavior. Type-2 MAC/IP
+            // advertisement will read these in a follow-up.
+            FibMessage::NewNeighbor(nbr) => {
+                tracing::debug!("FibMessage::NewNeighbor {:?}", nbr);
+            }
+            FibMessage::DelNeighbor(nbr) => {
+                tracing::debug!("FibMessage::DelNeighbor {:?}", nbr);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
First wire-up of L2/L3-neighbor visibility from the kernel — the foundation for upcoming **EVPN Type-2 (MAC/IP) advertise**. No protocol behavior in this PR; the RIB consumer just logs at debug, so the end-to-end path (subscribe + parse + dispatch + dump) is exercised without committing to any state machine yet.

## What lands
- **`mgroup_flags |= RTMGRP_NEIGH`** — covers AF_INET ARP, AF_INET6 NDP, and AF_BRIDGE FDB through one socket.
- **`neighbor_from_msg(NeighbourMessage) -> FibNeighbor`** parser walks `NDA_DST`, `NDA_LLADDR`, `NDA_VLAN`, `NDA_VNI`, `NDA_CONTROLLER` and fills the relevant fields.
- **`RouteNetlinkMessage::{NewNeighbour, DelNeighbour}`** arms in `process_msg` dispatch `FibMessage::{NewNeighbor, DelNeighbor}`.
- **Startup dumps** in `fib_dump`: three `RTM_GETNEIGH` runs (`AF_INET`, `AF_INET6`, `AF_BRIDGE`) so neighbor entries that pre-existed the daemon are visible — without this, only post-start events would be observed.

## FibNeighbor fields
`family / ifindex / state / flags / kind / lladdr / dst / vlan / vni / master` so the EVPN consumer can distinguish ARP (`Inet`/`Inet6`, `dst` = protocol addr) from FDB (`Bridge`, optional `dst` = remote VTEP IP, optional `vni`). Marked `#[allow(dead_code)]` for the staging interval — fields are populated for the next PR's EVPN reader.

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo test -p zebra-rs --bin zebra-rs` — **169/169 pass** (mirrored CI conditions per the lesson from PR #392)
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets` — clean
- [x] `cargo fmt --all`
- [ ] Manual on a Linux box: run zebra-rs with `RUST_LOG=debug`; in another shell run `bridge fdb show` and `ip neigh show` (existing entries surface via the startup dump), then trigger new ones (e.g. `ping 192.0.2.1`) — debug log shows `FibMessage::NewNeighbor` traffic.

## Out of scope (next PR)
- An actual consumer in the RIB (e.g. `Rib::neighbors` map, `show l2 neighbors`).
- EVPN Type-2 advertise: read local FDB entries, build EVPN NLRIs, emit MP_REACH.
- ARP/NDP-derived MAC↔IP binding for Type-2 routes that include the IP component.

Generated with [Claude Code](https://claude.com/claude-code)