### PR TITLE
rib: store kernel neighbor table + `show l2 neighbor`

### DIFF
--- a/zebra-rs/src/fib/message.rs
+++ b/zebra-rs/src/fib/message.rs
@@ -1,9 +1,9 @@
 use std::net::IpAddr;
 
 use ipnet::IpNet;
+use netlink_packet_route::AddressFamily;
 use netlink_packet_route::link::LinkFlags;
 use netlink_packet_route::neighbour::{NeighbourFlags, NeighbourState};
-use netlink_packet_route::{AddressFamily, route::RouteType};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use crate::rib::{MacAddr, entry::RibEntry};
@@ -81,19 +81,18 @@ pub struct FibRoute {
 /// VRF ifindex when the kernel sent `NDA_MASTER` (renamed
 /// `NDA_CONTROLLER` in current uapi).
 ///
-/// Fields are populated for the upcoming EVPN Type-2 advertise path
-/// (which will key on family + lladdr + dst + vni). Reading them in
-/// the meantime is intentionally limited to the FibMessage Debug
-/// formatter — `#[allow(dead_code)]` keeps that staging visible to
-/// the reader without tripping `-D warnings`.
-#[allow(dead_code)]
+/// Fields are read by `Rib::neighbor_key` (for keying the `Rib::neighbors`
+/// map) and by `l2_neighbor_show` (for the `show l2 neighbor` command).
+/// EVPN Type-2 advertise will iterate the same map in a follow-up.
 #[derive(Default, Debug, Clone)]
 pub struct FibNeighbor {
     pub family: AddressFamily,
     pub ifindex: u32,
     pub state: NeighbourState,
+    /// `NTF_*` flags. `NTF_EXT_LEARNED` matters for EVPN — a MAC the
+    /// kernel learned from a remote VTEP (often via this very daemon's
+    /// own `mac_add` push) shouldn't be re-advertised back into BGP.
     pub flags: NeighbourFlags,
-    pub kind: RouteType,
     pub lladdr: Option<MacAddr>,
     pub dst: Option<IpAddr>,
     pub vlan: Option<u16>,

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -2124,7 +2124,6 @@ pub fn neighbor_from_msg(msg: NeighbourMessage) -> FibNeighbor {
         ifindex: msg.header.ifindex,
         state: msg.header.state,
         flags: msg.header.flags,
-        kind: msg.header.kind,
         ..Default::default()
     };
 

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -13,7 +13,7 @@ use crate::config::{ConfigChannel, ConfigOp, ConfigRequest, DisplayRequest, Show
 use crate::context::Timer;
 use crate::fib::fib_dump;
 use crate::fib::sysctl::sysctl_enable;
-use crate::fib::{FibChannel, FibHandle, FibMessage};
+use crate::fib::{FibChannel, FibHandle, FibMessage, FibNeighbor};
 use crate::rib::route::{
     AddrRecoveryState, ipv4_nexthop_sync, ipv4_route_sync, ipv6_nexthop_sync, ipv6_route_sync,
 };
@@ -205,6 +205,30 @@ pub struct MacEntry {
     pub installed: bool,
 }
 
+/// Composite key for `Rib::neighbors`. The kernel's neighbor table mixes
+/// three address families behind one RTM_NEWNEIGH; the key distinguishes
+/// them while staying naturally Ord/Hash so all three can live in one
+/// BTreeMap.
+///
+/// - `Inet` covers `AF_INET` (ARP) and `AF_INET6` (NDP) — uniqueness is
+///   `(ifindex, ip)`. The `IpAddr` discriminant carries the family.
+/// - `Bridge` covers `AF_BRIDGE` (FDB) — uniqueness is
+///   `(ifindex, mac, vlan)`. VXLAN's per-VNI uniqueness comes via the
+///   `dst` and `vni` attributes inside the stored `FibNeighbor`; on a
+///   classic bridge the `vlan` portion of the key handles 802.1Q.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum NeighborKey {
+    Inet {
+        ifindex: u32,
+        addr: IpAddr,
+    },
+    Bridge {
+        ifindex: u32,
+        mac: MacAddr,
+        vlan: Option<u16>,
+    },
+}
+
 pub struct Rib {
     pub cm: ConfigChannel,
     pub show: ShowChannel,
@@ -225,6 +249,12 @@ pub struct Rib {
     pub table_v6: PrefixMap<Ipv6Net, RibEntries>,
     pub ilm: BTreeMap<u32, IlmEntry>,
     pub mac_table: BTreeMap<(u32, MacAddr), MacEntry>,
+    /// Local snapshot of the kernel's neighbor table (ARP + NDP + bridge
+    /// FDB). Populated from `FibMessage::NewNeighbor` / `DelNeighbor`,
+    /// initially seeded by `fib_dump` at startup. Read by `show l2
+    /// neighbor` today; the EVPN Type-2 advertise path will iterate
+    /// the `NeighborKey::Bridge` entries in a follow-up.
+    pub neighbors: BTreeMap<NeighborKey, FibNeighbor>,
     pub tx: UnboundedSender<Message>,
     pub rx: UnboundedReceiver<Message>,
     pub static_v4: StaticConfig<V4>,
@@ -314,6 +344,7 @@ impl Rib {
             table_v6: PrefixMap::new(),
             ilm: BTreeMap::new(),
             mac_table: BTreeMap::new(),
+            neighbors: BTreeMap::new(),
             tx,
             rx,
             static_v4: StaticConfig::<V4>::new(),
@@ -942,16 +973,15 @@ impl Rib {
                     self.ipv4_route_del(&prefix, route.entry).await;
                 }
             }
-            // Inbound L2/L3-neighbor visibility for the upcoming EVPN
-            // work. No consumer yet; logged at debug for now so the
-            // wire is exercised end-to-end (subscribe + parse + dispatch)
-            // without committing to any protocol behavior. Type-2 MAC/IP
-            // advertisement will read these in a follow-up.
             FibMessage::NewNeighbor(nbr) => {
-                tracing::debug!("FibMessage::NewNeighbor {:?}", nbr);
+                if let Some(key) = neighbor_key(&nbr) {
+                    self.neighbors.insert(key, nbr);
+                }
             }
             FibMessage::DelNeighbor(nbr) => {
-                tracing::debug!("FibMessage::DelNeighbor {:?}", nbr);
+                if let Some(key) = neighbor_key(&nbr) {
+                    self.neighbors.remove(&key);
+                }
             }
         }
     }
@@ -1134,6 +1164,33 @@ fn sid_rib_entry(sid: &Sid) -> RibEntry {
 /// SID is withdrawn.
 fn is_seg6local_entry(entry: &RibEntry) -> bool {
     matches!(&entry.nexthop, Nexthop::Uni(uni) if uni.seg6local_action.is_some())
+}
+
+/// Build a `NeighborKey` from a `FibNeighbor` so the entry can be inserted
+/// into / removed from `Rib::neighbors`. Returns `None` when the entry
+/// lacks the discriminator the family requires (no `dst` for ARP/NDP, no
+/// `lladdr` for FDB) — those are dropped silently rather than stored
+/// under an ambiguous key.
+fn neighbor_key(nbr: &FibNeighbor) -> Option<NeighborKey> {
+    use netlink_packet_route::AddressFamily;
+    match nbr.family {
+        AddressFamily::Inet | AddressFamily::Inet6 => {
+            let addr = nbr.dst?;
+            Some(NeighborKey::Inet {
+                ifindex: nbr.ifindex,
+                addr,
+            })
+        }
+        AddressFamily::Bridge => {
+            let mac = nbr.lladdr?;
+            Some(NeighborKey::Bridge {
+                ifindex: nbr.ifindex,
+                mac,
+                vlan: nbr.vlan,
+            })
+        }
+        _ => None,
+    }
 }
 
 pub fn serve(mut rib: Rib) {

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -972,6 +972,7 @@ impl Rib {
         self.show_add("/show/nexthop", nexthop_show);
         self.show_add("/show/mpls/ilm", ilm_show);
         self.show_add("/show/l2/mac/table", mac_show);
+        self.show_add("/show/l2/neighbor", l2_neighbor_show);
         self.show_add("/show/segment-routing/srv6/sid", sid_show);
         self.show_add("/show/vrf", vrf_show);
     }
@@ -983,6 +984,65 @@ pub fn vrf_show(rib: &Rib, _args: Args, _json: bool) -> String {
     writeln!(buf, " {:-<32}  {:-<10}", "", "").unwrap();
     for vrf in rib.vrfs.values() {
         writeln!(buf, " {:<32}{:>10}", vrf.name, vrf.table_id).unwrap();
+    }
+    buf
+}
+
+/// Render the bridge FDB slice of `rib.neighbors` (the AF_BRIDGE entries).
+/// Modelled on `bridge fdb show` — one row per (ifindex, mac, vlan)
+/// triple, with the resolved interface name and any per-FDB-entry
+/// attributes (VLAN, VNI, remote VTEP IP) the kernel supplied. ARP/NDP
+/// (AF_INET / AF_INET6) lives in the same map but isn't shown here —
+/// `show ip arp` / `show ipv6 neighbor` will surface those separately.
+pub fn l2_neighbor_show(rib: &Rib, _args: Args, _json: bool) -> String {
+    use super::inst::NeighborKey;
+    let mut buf = String::new();
+    writeln!(
+        buf,
+        " {mac:<18} {ifname:<16} {vlan:>5}  {vni:>10}  {dst:<40} {state:<14} {flags:<10}",
+        mac = "MAC",
+        ifname = "Interface",
+        vlan = "VLAN",
+        vni = "VNI",
+        dst = "Dst",
+        state = "State",
+        flags = "Flags",
+    )
+    .unwrap();
+    writeln!(
+        buf,
+        " {:-<18} {:-<16} {:->5}  {:->10}  {:-<40} {:-<14} {:-<10}",
+        "", "", "", "", "", "", "",
+    )
+    .unwrap();
+    for (key, nbr) in rib.neighbors.iter() {
+        let NeighborKey::Bridge { ifindex, mac, vlan } = key else {
+            continue;
+        };
+        let ifname = rib
+            .links
+            .get(ifindex)
+            .map(|l| l.name.clone())
+            .unwrap_or_else(|| format!("if#{ifindex}"));
+        let vlan_s = vlan.map(|v| v.to_string()).unwrap_or_else(|| "-".into());
+        let vni_s = nbr.vni.map(|v| v.to_string()).unwrap_or_else(|| "-".into());
+        let dst_s = nbr.dst.map(|d| d.to_string()).unwrap_or_else(|| "-".into());
+        // Format `flags` via `.bits()` rather than Debug so the field
+        // counts as a real read for dead-code analysis (CI runs with
+        // `-D warnings`); the hex form is also more compact than the
+        // bitflags Debug rendering and keeps the column width stable.
+        writeln!(
+            buf,
+            " {:<18} {:<16} {:>5}  {:>10}  {:<40} {:<14?} 0x{:02x}",
+            mac.to_string(),
+            ifname,
+            vlan_s,
+            vni_s,
+            dst_s,
+            nbr.state,
+            nbr.flags.bits(),
+        )
+        .unwrap();
     }
     buf
 }

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -42,6 +42,14 @@ module exec {
       ext:help "Show VRF table";
       type empty;
     }
+    container l2 {
+      ext:help "Show L2 / data-link information";
+      presence "Show L2";
+      leaf neighbor {
+        ext:help "Show bridge FDB entries";
+        type empty;
+      }
+    }
     leaf community-set {
       ext:help "Show community-set";
       type empty;


### PR DESCRIPTION
## Summary
Builds on the `FibMessage::{NewNeighbor, DelNeighbor}` visibility from PR #393 — the inbound events are now consumed instead of just debug-logged. Adds the storage and a show command so the same information that `bridge fdb show` / `ip neigh show` print is available from inside zebra-rs's CLI, and so the upcoming EVPN Type-2 advertise path has a structured iteration target.

## What lands
- **`NeighborKey` enum** — `Inet` for ARP/NDP keyed by `(ifindex, ip)`; `Bridge` for FDB keyed by `(ifindex, mac, vlan)`. One `BTreeMap` holds all three families behind one key for now — the show callback filters by variant, future EVPN advertise will too.
- **`Rib::neighbors: BTreeMap<NeighborKey, FibNeighbor>`** — populated incrementally from `FibMessage::{NewNeighbor, DelNeighbor}`, seeded by `fib_dump`'s `RTM_GETNEIGH` dumps at startup.
- **`neighbor_key(&FibNeighbor)`** helper drops entries that lack the key discriminator (no `dst` for ARP/NDP, no `lladdr` for FDB) rather than storing them under an ambiguous key.
- **`l2_neighbor_show`** callback at `/show/l2/neighbor` renders the AF_BRIDGE slice — matching `bridge fdb show` columns plus raw `NTF_*` flags hex (`NTF_EXT_LEARNED` is the bit EVPN will key off to skip MACs we ourselves installed from a remote VTEP).
- **`/show/l2/neighbor` YANG entry** in `exec.yang` so the CLI tab-completes.
- **`FibNeighbor` cleaned up**: dropped the unused `kind` field; kept `flags` and read via `.bits()` so it counts as a real read for dead-code analysis under `-D warnings`. The struct's `#[allow(dead_code)]` staging marker is gone — every field is now read by either the key helper or the show callback.

## Sample output
```
 MAC                Interface         VLAN         VNI  Dst                                      State          Flags
 ------------------ ---------------- -----  ----------  ---------------------------------------- -------------- ----------
 aa:bb:cc:dd:ee:ff  vxlan100             -         100  10.0.0.2                                 Permanent      0x02
```

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo test -p zebra-rs --bin zebra-rs` — **169/169 pass** (mirrored CI conditions)
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets` — clean
- [x] `cargo fmt --all`
- [ ] Manual on a Linux box: trigger an FDB learn (e.g. `bridge fdb add aa:bb:cc:dd:ee:ff dev br0` or a packet that causes one), then `vtyctl show 'show l2 neighbor'` — entry surfaces with the right interface name + flags. Existing entries from before daemon start also appear (validates the dump path).

## Out of scope (next PR)
- EVPN Type-2 advertise: iterate `Rib::neighbors` filtering on `NeighborKey::Bridge` and on `flags & NTF_EXT_LEARNED == 0` (locally-learned only), build EVPN NLRIs, emit MP_REACH.
- ARP/NDP-derived MAC↔IP binding for the IP component of Type-2 routes.
- `show ip arp` / `show ipv6 neighbor` for the AF_INET / AF_INET6 slice of the same map.

Generated with [Claude Code](https://claude.com/claude-code)