### PR TITLE
bgp: handle RibRx::RouterIdUpdate so OPEN doesn't ship 0.0.0.0

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -28,7 +28,12 @@ fn config_global_asn(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> 
 fn config_global_identifier(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     if op == ConfigOp::Set {
         let router_id = args.v4addr()?;
-        bgp.router_id = router_id;
+        // Go through `set_router_id` so the new value is also
+        // propagated to every existing peer's `router_id` snapshot
+        // — peers created before the operator typed this line would
+        // otherwise keep their stale (often 0.0.0.0) value and emit
+        // OPEN with the wrong BGP Identifier.
+        bgp.set_router_id(router_id);
     }
     Some(())
 }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -181,6 +181,32 @@ impl Bgp {
         }
     }
 
+    /// Update the BGP router-id and propagate it to every peer's
+    /// `router_id` snapshot. `Peer::new` captures `bgp.router_id` at
+    /// peer-create time; without this propagation, peers configured
+    /// before the router-id was known would emit OPEN messages with
+    /// `0.0.0.0` in the BGP Identifier field forever.
+    ///
+    /// Inputs:
+    ///   - operator config (`set router bgp global identifier <ip>`)
+    ///     via `config_global_identifier`.
+    ///   - RIB-derived auto-pick (`RibRx::RouterIdUpdate`) when no
+    ///     explicit identifier is configured. Same precedence Cisco /
+    ///     Junos use — last write wins for now; an explicit / auto
+    ///     priority pin is a follow-up.
+    ///
+    /// Existing established sessions keep using the value they sent
+    /// at OPEN; the next OPEN (after a reset) picks up the new one.
+    pub fn set_router_id(&mut self, router_id: Ipv4Addr) {
+        if self.router_id == router_id {
+            return;
+        }
+        self.router_id = router_id;
+        for (_, peer) in self.peers.iter_mut() {
+            peer.router_id = router_id;
+        }
+    }
+
     pub fn pcallback_add(&mut self, path: &str, cb: PCallback) {
         self.pcallbacks.insert(path.to_string(), cb);
     }
@@ -379,6 +405,15 @@ impl Bgp {
             RibRx::AddrDel(_addr) => {
                 // isis_info!("Isis::AddrDel {}", addr.addr);
                 // self.addr_del(addr);
+            }
+            RibRx::RouterIdUpdate(router_id) => {
+                // RIB auto-derived a router-id from interface IPv4
+                // addresses (highest loopback, falling back to
+                // non-loopback). Without this arm BGP missed the
+                // notification and emitted OPEN with 0.0.0.0 in the
+                // BGP Identifier whenever the operator hadn't typed
+                // `set router bgp global identifier <ip>`.
+                self.set_router_id(router_id);
             }
             _ => {
                 //

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -865,6 +865,18 @@ pub fn peer_send_open(peer: &mut Peer) {
     } else {
         peer.router_id
     };
+    // Sending 0.0.0.0 as the BGP Identifier is a protocol error per
+    // RFC 4271 §4.2; the peer will respond with NOTIFICATION
+    // (Bad BGP Identifier). Surface it loudly here so the operator
+    // sees it before chasing FSM symptoms.
+    if router_id.is_unspecified() {
+        tracing::warn!(
+            "peer {}: sending OPEN with router-id 0.0.0.0 — \
+             configure `router bgp global identifier <ipv4>` or wait \
+             for an interface address to seed the auto-derivation",
+            peer.address
+        );
+    }
     let mut bgp_cap = BgpCap::default();
 
     for (afi_safi, _) in peer.config.mp.0.iter() {


### PR DESCRIPTION
## Summary
BGP was emitting OPEN with router-id `0.0.0.0` — invalid BGP Identifier per RFC 4271 §4.2 — whenever the operator hadn't typed `set router bgp global identifier <ip>`. Two interlocking bugs caused it; this PR fixes both.

## Root cause
**Bug 1: BGP didn't subscribe to RIB router-id updates.** The RIB auto-derives a router-id from interface IPv4 addresses (highest loopback, fallback to non-loopback) and pushes `RibRx::RouterIdUpdate(addr)` to all subscribers. OSPF (`ospf/inst.rs:1189`) and IS-IS (`isis/inst.rs:281`) handle that variant; BGP's `process_rib_msg` had a wildcard `_ => {}` arm that silently swallowed it. So with no explicit identifier configured, `bgp.router_id` stayed `Ipv4Addr::UNSPECIFIED` forever.

**Bug 2: Per-peer router-id was a stale snapshot.** `Peer::new` captures `bgp.router_id` at peer-create time. `peer_send_open` reads `peer.router_id`, never re-reading `bgp.router_id`. So an operator who typed `neighbor X peer-as Y` *before* `global identifier Z` was permanently stuck with whatever value `bgp.router_id` had at the earlier moment.

## Fix
Mirrors the existing `Bgp::config_set_hostname` pattern. New `Bgp::set_router_id(&mut self, id)` updates `self.router_id` AND iterates `self.peers.values_mut()` to refresh every per-peer snapshot. Wired in:

- **`process_rib_msg`** — new `RibRx::RouterIdUpdate(id)` arm calls `set_router_id`. Subscribe + receive plumbing was already in place (`Bgp::new` registers via `Message::Subscribe`, pre-EoR drain loop processes replay, main `tokio::select!` handles live updates) — only the variant arm was missing. After this fix BGP's router-id propagation is structurally identical to IS-IS / OSPF.
- **`config_global_identifier`** — explicit operator config now also goes through `set_router_id` so peers refresh on operator-driven changes too.

## Safety net
`peer_send_open` warns when the about-to-be-sent router-id is `0.0.0.0`. Any future regression that lets the field stay zero through to OPEN-send time becomes immediately visible in the log instead of hiding behind a peer's NOTIFICATION (Bad BGP Identifier).

## Out of scope
- Last-write-wins between auto-derived and operator-explicit for now. Proper precedence (explicit pinned, RIB updates ignored when an explicit value is set) is a follow-up.
- Bumping established sessions when router-id changes — current behavior is "next OPEN after a reset picks up the new value", same as `config_set_hostname`. Force-reset is a separate operator decision.

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo test -p zebra-rs --bin zebra-rs` — **169/169 pass**
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets` — clean
- [x] `cargo fmt --all`
- [ ] Manual on a Linux box: `set router bgp neighbor 192.168.0.2 peer-as 65002` first (no global identifier configured); bring up a loopback `10.0.0.1/32`; observe BGP OPEN goes out with `10.0.0.1` in the BGP Identifier field (capture via `tcpdump -i any port 179`).
- [ ] Manual: explicit `set router bgp global identifier 1.1.1.1` after peer creation — peer's snapshot updates, next OPEN uses `1.1.1.1`.

Generated with [Claude Code](https://claude.com/claude-code)