### PR TITLE
bdd: BGP L2VPN/EVPN capability negotiation smoke test

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -28,6 +28,10 @@ isis_srv6:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_srv6"
 
+bgp_evpn_capability:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_capability"
+
 generate:
 	rm -rf allure-report
 	allure generate
@@ -47,4 +51,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 bgp_evpn_capability generate open docs FORCE

--- a/bdd/tests/configs/bgp_evpn_capability/z1-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_capability/z1-1.yaml
@@ -1,0 +1,14 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      peer-as: 65001
+      afi-safi:
+      - name: ipv4-unicast
+        enabled: true
+      - name: l2vpn-evpn
+        enabled: true

--- a/bdd/tests/configs/bgp_evpn_capability/z2-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_capability/z2-1.yaml
@@ -1,0 +1,14 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      enabled: true
+      peer-as: 65001
+      afi-safi:
+      - name: ipv4-unicast
+        enabled: true
+      - name: l2vpn-evpn
+        enabled: true

--- a/bdd/tests/features/bgp_evpn_capability.feature
+++ b/bdd/tests/features/bgp_evpn_capability.feature
@@ -1,0 +1,53 @@
+@serial
+@bgp_evpn_capability
+Feature: BGP L2VPN/EVPN capability negotiation
+  As a network operator
+  I want two zebra-rs instances to negotiate the L2VPN/EVPN multiprotocol
+  capability (AFI=25 / SAFI=70) and bring an iBGP session to Established,
+  so that the foundation for EVPN Type-2 / Type-3 advertisements is
+  validated end-to-end before route exchange is implemented.
+
+  No EVPN routes flow in this scenario — capability negotiation is the
+  unit under test. Route exchange (Type-2 MAC/IP, Type-3 Inclusive
+  Multicast) lands in follow-up features.
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                   │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65001 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+  ```
+
+  Both peers enable two AFI/SAFIs:
+    - ipv4-unicast (so the session has a fallback AF and matches the
+      established BDD pattern)
+    - l2vpn-evpn  (the AF this scenario is actually validating)
+
+  Config files:
+  - z1-1.yaml: AS 65001, peer to 192.168.0.2, l2vpn-evpn enabled
+  - z2-1.yaml: AS 65001, peer to 192.168.0.1, l2vpn-evpn enabled
+
+  Scenario: Setup topology and establish iBGP session with EVPN capability
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+
+  Scenario: L2VPN/EVPN capability is advertised and received on both sides
+    Given the test topology exists
+    Then show command "show ip bgp neighbors 192.168.0.2" in namespace "z1" should contain "L2VPN EVPN: advertised and received"
+    And show command "show ip bgp neighbors 192.168.0.1" in namespace "z2" should contain "L2VPN EVPN: advertised and received"


### PR DESCRIPTION
## Summary
First end-to-end exercise of the existing EVPN code in BGP — capability negotiation + adj-RIB structures + ingest path that have been merged over time without an automated check. This scenario validates the foundation; route exchange (Type-2, Type-3) lands in follow-up.

## Topology
Mirrors `bgp_basic_ibgp`: two zebra-rs instances on a shared bridge, iBGP, both peers enable two AFI/SAFIs:
- `ipv4-unicast` — so the session has a fallback AF and matches the established BDD pattern
- `l2vpn-evpn` — the AFI/SAFI actually under test

## Scenarios
1. **Setup + Established.** Bring the session up with both AFI/SAFIs enabled and assert it reaches Established on both sides.
2. **Capability surfaces correctly.** Assert that `show ip bgp neighbors <peer>` on both sides contains `L2VPN EVPN: advertised and received`.

## What this validates
- `peer_send_open` walks `peer.config.mp` and emits `CapMultiProtocol(L2vpn=25, Evpn=70)` in OPEN.
- Receive parses the capability; `cap_register_recv` and `cap_register_send` flip both flags.
- `show.rs:1348` writes `L2VPN EVPN: advertised and received` when both flags are set.

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo build --manifest-path bdd/Cargo.toml --tests` — clean
- [ ] On a Linux host with sudo + zebra-rs in PATH: `cd bdd && make bgp_evpn_capability`

## Out of scope (next PRs)
- Local origination of Type-2 (MAC/IP) routes from `Rib::neighbors` Bridge entries (PRs #393 / #394 set up the consumer surface).
- Type-3 (Inclusive Multicast) origination on local VXLAN VTEP up.
- Per-VNI EVPN service config (RD / RT-import / RT-export keyed by VNI).

Generated with [Claude Code](https://claude.com/claude-code)