### PR TITLE
bgp+yang: add `advertise-all-vni` knob (FRR-style EVPN service)

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -312,6 +312,24 @@ fn config_network(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     Some(())
 }
 
+fn config_advertise_all_vni(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    // The leaf only carries meaning for l2vpn-evpn; ignore on other
+    // AFI/SAFIs. The YANG `advertise-all-vni` extension is augmented
+    // into the global afi-safi list which spans every AF, so we have
+    // to filter at the callback.
+    if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
+        return None;
+    }
+    if op.is_set() {
+        let enabled = args.boolean()?;
+        bgp.advertise_all_vni = enabled;
+    } else {
+        bgp.advertise_all_vni = false;
+    }
+    Some(())
+}
+
 fn config_add_path(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let afi_safi: AfiSafi = args.afi_safi()?;
@@ -901,6 +919,15 @@ impl Bgp {
 
         // Network configuration
         self.callback_add("/router/bgp/afi-safi/network", config_network);
+
+        // EVPN: FRR-style `advertise-all-vni` under
+        // `router bgp afi-safi l2vpn-evpn`. Augmented in by
+        // zebra-bgp-evpn.yang. Schema-only consumer for now —
+        // origination from Rib::neighbors lands in a follow-up.
+        self.callback_add(
+            "/router/bgp/afi-safi/advertise-all-vni",
+            config_advertise_all_vni,
+        );
 
         // Applying policy.
         self.callback_peer("/apply-policy/in", config_policy_in);

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -53,6 +53,19 @@ pub type ShowCallback = fn(&Bgp, Args, bool) -> std::result::Result<String, std:
 pub struct Bgp {
     pub asn: u32,
     pub router_id: Ipv4Addr,
+    /// FRR-style `advertise-all-vni` knob under `router bgp afi-safi
+    /// l2vpn-evpn`. When true, every locally-configured VXLAN VNI
+    /// participates in EVPN advertisement: Type-2 (MAC/IP) routes
+    /// from the kernel's bridge FDB and Type-3 (Inclusive Multicast)
+    /// routes per local VTEP. Bridge -> VNI mapping is inferred from
+    /// the kernel (each bridge's VXLAN slave supplies the VNI). RD =
+    /// router-id:VNI; RT-import / RT-export = local-AS:VNI per
+    /// RFC 8365 §5.1.2.
+    ///
+    /// Schema-only in the PR that introduced this — no consumer yet.
+    /// The Rib::neighbors -> EvpnPrefix::MacIp pipeline that reads
+    /// this lands separately.
+    pub advertise_all_vni: bool,
     /// Configured hostname for the local BGP speaker. Advertised in
     /// the FQDN capability (capability code 73). When None, falls back
     /// to the OS hostname; if that also fails, no FQDN capability is
@@ -119,6 +132,7 @@ impl Bgp {
         let mut bgp = Self {
             asn: 0,
             router_id: Ipv4Addr::UNSPECIFIED,
+            advertise_all_vni: false,
             hostname: None,
             peers: PeerMap::new(),
             tx,

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -36,6 +36,10 @@ module config {
     prefix zbv;
   }
 
+  import zebra-bgp-evpn {
+    prefix zbe;
+  }
+
   import openconfig-isis-types {
     prefix isis;
   }

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -1,0 +1,96 @@
+module zebra-bgp-evpn {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-evpn";
+  prefix "zbe";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "EVPN service extensions to the BGP candidate-config tree.
+
+     Adds the FRR-style `advertise-all-vni` knob under the BGP
+     global AFI/SAFI list — when enabled for the `l2vpn-evpn`
+     AFI/SAFI, every locally-configured VXLAN VNI participates in
+     EVPN advertisement (Type-2 MAC/IP + Type-3 Inclusive Multicast)
+     with auto-derived RD and RT.
+
+     Resulting CLI / config shape:
+
+       router bgp {
+         neighbor 10.0.0.1 {
+           peer-as 65001;
+           afi-safi {
+             name l2vpn-evpn;
+             enabled true;
+           }
+         }
+         afi-safi {
+           name l2vpn-evpn;
+           advertise-all-vni true;
+         }
+       }
+
+     IOS-XR-style per-VNI configuration (explicit RD / route-target
+     per VNI) is a follow-up.";
+
+  reference
+    "RFC 7432: BGP MPLS-Based Ethernet VPN
+     RFC 8365: Network Virtualization Overlay Solution Using EVPN";
+
+  grouping bgp-afi-safi-evpn-extension {
+    description
+      "Per-AFI/SAFI EVPN extensions on the global afi-safi list. Only
+       meaningful when the list entry's name is `bt:l2vpn-evpn` —
+       harmless and ignored on other AFI/SAFIs.";
+    leaf advertise-all-vni {
+      type boolean;
+      default false;
+      description
+        "When true, advertise EVPN Type-2 (MAC/IP) and Type-3
+         (Inclusive Multicast) routes for every locally-configured
+         VXLAN VNI. Bridge -> VNI mapping is inferred from the kernel
+         (the VXLAN slave of each bridge supplies the VNI). RD is
+         auto-derived as <router-id>:<VNI> per RFC 8365 §5.1.2;
+         import / export RT is auto-derived as <local-AS>:<VNI>.
+
+         Equivalent to FRR's `advertise-all-vni` under
+         `address-family l2vpn evpn`.";
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router/bgp:bgp/bgp:afi-safi" {
+    description
+      "Attach the EVPN extension leaves to the global afi-safi list
+       in the candidate-set subtree.";
+    uses bgp-afi-safi-evpn-extension;
+  }
+
+  augment "/configure:delete/config:router/bgp:bgp/bgp:afi-safi" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp afi-safi l2vpn-evpn advertise-all-vni`
+       is path-valid.";
+    uses bgp-afi-safi-evpn-extension;
+  }
+}


### PR DESCRIPTION
## Summary
Foundation PR for local Type-2 (MAC/IP) origination. Adds the operator-facing knob and the BGP-side state; no consumer yet.

```
router bgp afi-safi l2vpn-evpn {
  advertise-all-vni true;
}
```

YAML form:
```yaml
router:
  bgp:
    afi-safi:
    - name: l2vpn-evpn
      advertise-all-vni: true
```

## What lands
- **`zebra-bgp-evpn.yang`** (new) augments the global `afi-safi` list with `leaf advertise-all-vni: boolean (default false)`. Both `/configure:set` and `/configure:delete` subtrees, mirroring the `zebra-bgp-vrf.yang` pattern.
- **`config.yang`** imports the new module so libyang loads the augment.
- **`Bgp::advertise_all_vni: bool`** field, default `false`.
- **`config_advertise_all_vni` callback** at `/router/bgp/afi-safi/advertise-all-vni`. Filters to `name=l2vpn-evpn` — the same global afi-safi list spans every AFI/SAFI so we have to gate at the callback rather than the YANG (a `when` inside the augment is awkward; doc-only constraint is fine here).

## Semantics (per FRR / RFC 8365 §5.1.2)
- When `true`, every locally-configured VXLAN VNI participates in EVPN advertisement. Bridge↔VNI mapping is inferred from the kernel — each bridge's VXLAN slave carries the VNI via `IFLA_VXLAN_ID` + `IFLA_MASTER`.
- RD = `<router-id>:<VNI>`; RT-import / RT-export = `<local-AS>:<VNI>`.
- When `false` (default), no EVPN routes are originated locally.

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo test -p zebra-rs --bin zebra-rs` — **169/169 pass**
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets` — clean
- [x] `cargo fmt --all`
- [ ] Manual: `set router bgp afi-safi l2vpn-evpn advertise-all-vni true` → `show running-config` round-trips, `show ip bgp summary` (or similar) is unchanged (no consumer yet).

## Out of scope (next PR)
- Bridge↔VNI inference helper reading `Rib::links` VXLAN slaves.
- `RibRx::FdbAdd / FdbDel` variants emitted from `Rib::neighbors`.
- BGP consumer that builds `EvpnPrefix::MacIp` + inserts into local-RIB when `advertise_all_vni` is true.

Generated with [Claude Code](https://claude.com/claude-code)