### PR TITLE
bgp: originate EVPN Type-2 routes from kernel FDB into local-RIB

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -429,6 +429,15 @@ impl Bgp {
                 // `set router bgp global identifier <ip>`.
                 self.set_router_id(router_id);
             }
+            RibRx::FdbAdd(entry) => {
+                // Local bridge FDB learn. EVPN advertise-all-vni
+                // originates a Type-2 (MAC/IP) route into the local-
+                // RIB; wire transmission lands in a follow-up.
+                self.evpn_originate_macip(&entry);
+            }
+            RibRx::FdbDel(entry) => {
+                self.evpn_withdraw_macip(&entry);
+            }
             _ => {
                 //
             }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -9,7 +9,7 @@ use prefix_trie::PrefixMap;
 
 use crate::bgp::timer::start_stale_timer;
 use crate::policy::PolicyList;
-use crate::rib::{self, MacAddr};
+use crate::rib::{self, MacAddr, api::FdbEntry};
 
 use super::cap::CapAfiMap;
 use super::peer::{BgpTop, Event, Peer, PeerType};
@@ -2026,4 +2026,102 @@ impl Bgp {
             );
         }
     }
+
+    /// Originate an EVPN Type-2 (MAC/IP Advertisement) route from a
+    /// kernel-learned bridge FDB entry.
+    ///
+    /// Inserts into `Bgp::local_rib.evpn` only — wire transmission
+    /// (route_advertise_evpn_to_peers + send_evpn) lands in a follow-up.
+    /// Verification target this PR: `show bgp l2vpn evpn` lists the
+    /// route after a local FDB learn.
+    ///
+    /// Gates:
+    ///   - `advertise_all_vni` must be true (FRR-style global enable).
+    ///   - `NTF_EXT_LEARNED` must be clear in the FDB flags. Set bits
+    ///     mark FDB rows that arrived via netlink from another speaker
+    ///     (typically zebra-rs's own `mac_add` path installing a
+    ///     remote VTEP MAC); re-advertising them would loop.
+    ///
+    /// Hardcodes (per RFC 8365 single-homed VLAN-Based service):
+    ///   - ESI = 0 (no multi-homing)
+    ///   - Ethernet Tag = 0 (one bridge per VNI)
+    ///   - IP component absent (MAC-only Type-2; MAC+IP needs ARP/NDP
+    ///     correlation, follow-up).
+    ///   - RD = `<router-id>:<VNI>` (Type-1, IPv4 + 2-byte). VNIs
+    ///     above 65535 are skipped — Type-0 ASN-format RD support
+    ///     for big VNIs is a follow-up.
+    pub fn evpn_originate_macip(&mut self, entry: &FdbEntry) {
+        if !self.advertise_all_vni {
+            return;
+        }
+        if entry.flags & NTF_EXT_LEARNED != 0 {
+            return;
+        }
+        let Some(rd) = rd_from_router_id_vni(self.router_id, entry.vni) else {
+            tracing::warn!(
+                "evpn_originate_macip: VNI {} > 65535, RD encoding not yet supported; \
+                 dropping local origination for {}",
+                entry.vni,
+                entry.mac
+            );
+            return;
+        };
+        let prefix = EvpnPrefix::MacIp {
+            eth_tag: 0,
+            mac: entry.mac.octets(),
+            ip: None,
+        };
+        let attr = BgpAttr::new();
+        let rib = BgpRib::new(
+            ORIGINATED_PEER,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            0, // remote_id — fixed at 0 for locally-originated; the
+            // withdraw path matches against the same value.
+            32768,
+            &attr,
+            None,
+            None,
+            false,
+        );
+        let _ = self.local_rib.update_evpn(rd, prefix, rib);
+    }
+
+    /// Inverse of `evpn_originate_macip`. No-op when
+    /// `advertise_all_vni` is false (we never originated anything to
+    /// withdraw) or when the entry's VNI exceeds the Type-1 RD
+    /// encoding range.
+    pub fn evpn_withdraw_macip(&mut self, entry: &FdbEntry) {
+        if !self.advertise_all_vni {
+            return;
+        }
+        let Some(rd) = rd_from_router_id_vni(self.router_id, entry.vni) else {
+            return;
+        };
+        let prefix = EvpnPrefix::MacIp {
+            eth_tag: 0,
+            mac: entry.mac.octets(),
+            ip: None,
+        };
+        let _ = self.local_rib.remove_evpn(rd, &prefix, 0, ORIGINATED_PEER);
+    }
+}
+
+/// `NTF_EXT_LEARNED` from `<linux/neighbour.h>` — bit 0x10. Set on
+/// FDB entries learned from external sources (e.g. another EVPN
+/// speaker that installed via netlink). Must be filtered out of
+/// origination to avoid advertise loops.
+const NTF_EXT_LEARNED: u8 = 0x10;
+
+/// Build a Type-1 RD (4-byte IPv4 + 2-byte assigned number) from
+/// the local router-id and VNI per RFC 8365 §5.1.2. Returns None
+/// when the VNI exceeds 16 bits — Type-1 only has 2 bytes for the
+/// assigned-number field; supporting VNIs above 65535 needs the
+/// Type-0 (ASN) format and is a follow-up.
+fn rd_from_router_id_vni(router_id: Ipv4Addr, vni: u32) -> Option<RouteDistinguisher> {
+    let vni_short: u16 = vni.try_into().ok()?;
+    let mut rd = RouteDistinguisher::new(RouteDistinguisherType::IP);
+    rd.val[0..4].copy_from_slice(&router_id.octets());
+    rd.val[4..6].copy_from_slice(&vni_short.to_be_bytes());
+    Some(rd)
 }

--- a/zebra-rs/src/fib/message.rs
+++ b/zebra-rs/src/fib/message.rs
@@ -31,6 +31,13 @@ pub struct FibLink {
     pub link_type: LinkType,
     pub mtu: u32,
     pub mac: Option<MacAddr>,
+    /// `IFLA_MASTER` ifindex for slave interfaces — the bridge or VRF
+    /// this link is enslaved to. None for top-level links.
+    pub master: Option<u32>,
+    /// VNI from `LinkInfo::Data(InfoData::Vxlan(InfoVxlan::Id(_)))` on
+    /// VXLAN links. Used by the EVPN advertise path to map a bridge
+    /// (via its VXLAN slave) to the L2VPN VNI it carries.
+    pub vni: Option<u32>,
 }
 
 impl FibLink {

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -1913,12 +1913,28 @@ pub fn link_from_msg(msg: LinkMessage) -> FibLink {
             }
             LinkAttribute::Address(addr) => {
                 link.mac = MacAddr::from_vec(addr);
-                // if addr.len() == 6 {
-                //     let slice = addr.as_slice();
-                //     let mut mac = [0u8; 6];
-                //     mac.copy_from_slice(slice);
-                //     link.mac = Some(mac);
-                // }
+            }
+            LinkAttribute::Controller(idx) => {
+                // `IFLA_MASTER` (kernel constant; rtnetlink renamed
+                // the variant to `Controller`). Slave-of-bridge /
+                // slave-of-VRF membership.
+                link.master = Some(idx);
+            }
+            LinkAttribute::LinkInfo(infos) => {
+                // VXLAN link kind carries the VNI in
+                // `LinkInfo::Data(InfoData::Vxlan(InfoVxlan::Id(_)))`.
+                // Walk both the Kind and Data sub-attrs and pick the
+                // VNI when present — non-VXLAN links contribute
+                // nothing here.
+                for info in infos {
+                    if let LinkInfo::Data(InfoData::Vxlan(vxlan_attrs)) = info {
+                        for v in vxlan_attrs {
+                            if let InfoVxlan::Id(vni) = v {
+                                link.vni = Some(vni);
+                            }
+                        }
+                    }
+                }
             }
             _ => {}
         }

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -2,7 +2,25 @@ use std::net::Ipv4Addr;
 
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
-use super::{Link, Rib, link::LinkAddr};
+use super::{Link, MacAddr, Rib, link::LinkAddr};
+
+/// One bridge-FDB row, distilled from the larger `FibNeighbor` so
+/// subscribers don't need to drag the full address-family / state
+/// surface around. Sent on `Rib::neighbors` insert / remove for
+/// AF_BRIDGE entries whose master maps to a known VNI.
+///
+/// `flags` carries the kernel's `NTF_*` bits — most importantly
+/// `NTF_EXT_LEARNED` (bit 0x10), which an EVPN advertise consumer
+/// must check to avoid re-advertising MACs that this same daemon
+/// just installed from a remote peer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FdbEntry {
+    pub vni: u32,
+    pub mac: MacAddr,
+    pub ifindex: u32,
+    pub bridge_ifindex: u32,
+    pub flags: u8,
+}
 
 #[allow(dead_code)]
 pub struct RibRxChannel {
@@ -26,6 +44,13 @@ pub enum RibRx {
     AddrAdd(LinkAddr),
     AddrDel(LinkAddr),
     RouterIdUpdate(Ipv4Addr),
+    /// Bridge FDB entry just learned (or installed) on this host —
+    /// emitted by RIB when a `FibMessage::NewNeighbor` for an
+    /// AF_BRIDGE entry resolves to a known VNI. The EVPN advertise
+    /// path consumes this to originate Type-2 routes.
+    FdbAdd(FdbEntry),
+    /// Inverse of `FdbAdd` — emitted on `FibMessage::DelNeighbor`.
+    FdbDel(FdbEntry),
     EoR,
 }
 
@@ -59,6 +84,18 @@ impl Rib {
     pub fn api_router_id_update(&self, router_id: Ipv4Addr) {
         for tx in self.redists.iter() {
             let _ = tx.send(RibRx::RouterIdUpdate(router_id));
+        }
+    }
+
+    pub fn api_fdb_add(&self, entry: &FdbEntry) {
+        for tx in self.redists.iter() {
+            let _ = tx.send(RibRx::FdbAdd(entry.clone()));
+        }
+    }
+
+    pub fn api_fdb_del(&self, entry: &FdbEntry) {
+        for tx in self.redists.iter() {
+            let _ = tx.send(RibRx::FdbDel(entry.clone()));
         }
     }
 }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -1,4 +1,4 @@
-use super::api::RibRx;
+use super::api::{FdbEntry, RibRx};
 use super::entry::RibEntry;
 use super::link::{LinkConfig, link_config_exec};
 use super::{
@@ -459,6 +459,24 @@ impl Rib {
             .values()
             .find(|link| link.is_loopback())
             .map(|link| link.index)
+    }
+
+    /// Resolve the L2VPN VNI for a bridge.
+    ///
+    /// Walks the link table looking for a link whose `master` is the
+    /// requested bridge ifindex AND whose `vni` is set — i.e. a VXLAN
+    /// device enslaved to this bridge. Returns the VNI of the first
+    /// such slave (typical EVPN deployment is exactly one VXLAN per
+    /// bridge per VNI).
+    ///
+    /// Used by the EVPN advertise path: a kernel FDB entry tells us
+    /// `(master = bridge_ifindex, mac, ...)`; this helper turns the
+    /// bridge into the VNI used to derive the Type-2 route's RD/RT.
+    pub fn vni_for_bridge(&self, bridge_ifindex: u32) -> Option<u32> {
+        self.links
+            .values()
+            .find(|link| link.master == Some(bridge_ifindex) && link.vni.is_some())
+            .and_then(|link| link.vni)
     }
 
     /// Resolve the device the kernel binds the seg6local action to,
@@ -974,13 +992,21 @@ impl Rib {
                 }
             }
             FibMessage::NewNeighbor(nbr) => {
+                let fdb_entry = fdb_entry_from_neighbor(self, &nbr);
                 if let Some(key) = neighbor_key(&nbr) {
                     self.neighbors.insert(key, nbr);
                 }
+                if let Some(entry) = fdb_entry {
+                    self.api_fdb_add(&entry);
+                }
             }
             FibMessage::DelNeighbor(nbr) => {
+                let fdb_entry = fdb_entry_from_neighbor(self, &nbr);
                 if let Some(key) = neighbor_key(&nbr) {
                     self.neighbors.remove(&key);
+                }
+                if let Some(entry) = fdb_entry {
+                    self.api_fdb_del(&entry);
                 }
             }
         }
@@ -1171,6 +1197,36 @@ fn is_seg6local_entry(entry: &RibEntry) -> bool {
 /// lacks the discriminator the family requires (no `dst` for ARP/NDP, no
 /// `lladdr` for FDB) — those are dropped silently rather than stored
 /// under an ambiguous key.
+/// Build an `FdbEntry` for the api-side fan-out from a `FibNeighbor`.
+///
+/// Returns `None` when the neighbor isn't a publishable FDB row:
+///   - non-`AF_BRIDGE` family (covered by `RibRx::FdbAdd` only)
+///   - no MAC address attached
+///   - no master ifindex (entry isn't bridged anywhere)
+///   - the master bridge has no VXLAN slave with a known VNI — until
+///     the bridge is wired to VXLAN, an EVPN advertise consumer
+///     wouldn't have anywhere to put the route, so dropping early
+///     keeps the message stream tidy.
+///
+/// All four `Option::?` paths return early so the only published
+/// entries are exactly those an EVPN Type-2 advertise can use.
+fn fdb_entry_from_neighbor(rib: &Rib, nbr: &FibNeighbor) -> Option<FdbEntry> {
+    use netlink_packet_route::AddressFamily;
+    if nbr.family != AddressFamily::Bridge {
+        return None;
+    }
+    let mac = nbr.lladdr?;
+    let bridge_ifindex = nbr.master?;
+    let vni = rib.vni_for_bridge(bridge_ifindex)?;
+    Some(FdbEntry {
+        vni,
+        mac,
+        ifindex: nbr.ifindex,
+        bridge_ifindex,
+        flags: nbr.flags.bits(),
+    })
+}
+
 fn neighbor_key(nbr: &FibNeighbor) -> Option<NeighborKey> {
     use netlink_packet_route::AddressFamily;
     match nbr.family {

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -40,6 +40,13 @@ pub struct Link {
     pub mac: Option<MacAddr>,
     pub addr4: Vec<LinkAddr>,
     pub addr6: Vec<LinkAddr>,
+    /// `IFLA_MASTER` ifindex when this link is a slave of a bridge or
+    /// VRF master. None for top-level links.
+    pub master: Option<u32>,
+    /// VNI from the kernel's `IFLA_VXLAN_ID` attribute on VXLAN links.
+    /// Used by the EVPN advertise path: a bridge's VXLAN slave maps the
+    /// bridge to the L2VPN VNI it carries.
+    pub vni: Option<u32>,
 }
 
 impl Link {
@@ -55,6 +62,8 @@ impl Link {
             mac: link.mac,
             addr4: Vec::new(),
             addr6: Vec::new(),
+            master: link.master,
+            vni: link.vni,
         }
     }
 
@@ -882,6 +891,8 @@ mod tests {
             mac: None,
             addr4: Vec::new(),
             addr6: Vec::new(),
+            master: None,
+            vni: None,
         }
     }
 


### PR DESCRIPTION
## Summary
Consumer side of the FRR-style `advertise-all-vni` knob from PR #397. Wires the kernel's bridge FDB through the RIB into the BGP local-RIB so locally-learned MACs appear as EVPN Type-2 (MAC/IP) routes that can be advertised.

**Local-RIB only in this PR.** Wire transmission (`route_advertise_evpn_to_peers` + MP_REACH encode for EVPN) lands in a follow-up.

## End-to-end flow
```
kernel learns MAC on VXLAN-attached bridge
  → RTM_NEWNEIGH (AF_BRIDGE)
  → Rib::neighbors insert
  → vni_for_bridge resolves the bridge's VXLAN slave
  → RibRx::FdbAdd to BGP
  → evpn_originate_macip (gated by advertise_all_vni
     and NTF_EXT_LEARNED == 0)
  → bgp.local_rib.evpn[<router-id>:<vni>] carries the route
```

## What lands

**Bridge → VNI inference**
- `FibLink` and `Link` gain `master: Option<u32>` + `vni: Option<u32>`.
- `link_from_msg` parses `IFLA_MASTER` (Controller variant) and `LinkInfo::Data(InfoData::Vxlan(InfoVxlan::Id))`.
- `Rib::vni_for_bridge(bridge_ifindex)` walks the link table for a VXLAN slave whose `vni.is_some()` and returns the VNI.

**RIB → BGP plumbing**
- New `FdbEntry { vni, mac, ifindex, bridge_ifindex, flags }` — distilled from `FibNeighbor` so consumers don't drag the full address-family / state surface around.
- New `RibRx::FdbAdd(FdbEntry)` / `FdbDel(FdbEntry)` variants and matching `api_fdb_add` / `api_fdb_del` fan-out helpers.
- `FibMessage::{NewNeighbor, DelNeighbor}` arms emit `FdbAdd` / `FdbDel` for AF_BRIDGE entries that resolve to a known VNI; everything else is silently dropped (bridges without VXLAN slaves have nowhere for an EVPN advertise to put the route).

**BGP origination**
- New `Bgp::evpn_originate_macip` / `evpn_withdraw_macip` methods gate on `advertise_all_vni` AND `NTF_EXT_LEARNED == 0`. Build `EvpnPrefix::MacIp { eth_tag: 0, mac, ip: None }` and the RFC 8365 §5.1.2 Type-1 RD `<router-id>:<VNI>`, then update / remove against `bgp.local_rib.evpn`.

## Hardcodes (per RFC 8365 single-homed VLAN-Based service)
- ESI = 0 (no multi-homing)
- Ethernet Tag = 0 (one bridge per VNI)
- IP component absent (MAC-only Type-2 first cut; MAC+IP needs ARP/NDP correlation, follow-up).
- VNI ≤ 65535 (Type-1 RD has only 2-byte tail; Type-0 ASN encoding for big VNIs is a follow-up — currently logs a warn and drops).

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo test -p zebra-rs --bin zebra-rs` — **169/169 pass**
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets` — clean
- [x] `cargo fmt --all`
- [ ] **Manual on a Linux box**: with `advertise-all-vni true` and a bridge wired to a VXLAN device, `bridge fdb add aa:bb:cc:dd:ee:ff dev <port>` followed by `show bgp l2vpn evpn` lists a Type-2 entry under RD `<router-id>:<VNI>`. The route is in the local-RIB only — peers do not yet see it on the wire.

## Out of scope (next PR)
- `route_advertise_evpn_to_peers` (parallel to the existing IPv4 fan-out).
- `peer.send_evpn` (MP_REACH encode for EVPN).
- RT extended community attachment for advertise (`<local-AS>:<VNI>` per RFC 8365).
- Type-3 (Inclusive Multicast) origination on local VTEP-up.

Generated with [Claude Code](https://claude.com/claude-code)