### PR TITLE
bgp-packet: implement MP_REACH encoder for EVPN Type-2 / Type-3

### DIFF
--- a/crates/bgp-packet/src/attrs/mp_reach.rs
+++ b/crates/bgp-packet/src/attrs/mp_reach.rs
@@ -6,9 +6,11 @@ use nom::error::{ErrorKind, make_error};
 use nom::number::complete::{be_u8, be_u32, be_u128};
 use nom_derive::*;
 
+use bytes::BufMut;
+
 use crate::{
-    Afi, EvpnRoute, Ipv4Nlri, Ipv6Nlri, ParseBe, ParseNlri, ParseOption, Rtcv4, Safi, Vpnv4Nexthop,
-    Vpnv4Nlri, many0_complete,
+    Afi, AttrFlags, AttrType, EvpnRoute, Ipv4Nlri, Ipv6Nlri, ParseBe, ParseNlri, ParseOption,
+    Rtcv4, Safi, Vpnv4Nexthop, Vpnv4Nlri, many0_complete,
 };
 
 use super::{AttrEmitter, RouteDistinguisher, Rtcv4Reach, Vpnv4Reach};
@@ -49,6 +51,13 @@ impl MpReachAttr {
             }
             MpReachAttr::Rtcv4(nlri) => {
                 nlri.attr_emit(buf);
+            }
+            MpReachAttr::Evpn {
+                snpa,
+                nhop,
+                updates,
+            } => {
+                evpn_attr_emit(*snpa, nhop, updates, buf);
             }
             _ => {
                 //
@@ -235,4 +244,58 @@ impl fmt::Debug for MpReachAttr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{self}")
     }
+}
+
+/// Serialize an `MpReachAttr::Evpn { snpa, nhop, updates }` as a
+/// complete `MP_REACH_NLRI` path attribute (header + value).
+///
+/// Wire format (RFC 4760 §3 + RFC 7432 §7):
+/// ```text
+///   AFI  (2 octets) = 25 (L2VPN)
+///   SAFI (1 octet)  = 70 (EVPN)
+///   Nexthop Length (1 octet) = 4 or 16
+///   Nexthop Address
+///   Reserved / SNPA (1 octet) = 0
+///   NLRIs (one or more EvpnRoute encodings)
+/// ```
+///
+/// The value is buffered first so the attribute length can be set
+/// before writing the header — extended (2-byte) length is used when
+/// the value exceeds 255 octets, matching the convention used by
+/// `Vpnv4Reach::attr_emit_mut`.
+fn evpn_attr_emit(_snpa: u8, nhop: &IpAddr, updates: &[EvpnRoute], buf: &mut BytesMut) {
+    let mut value = BytesMut::new();
+    value.put_u16(u16::from(Afi::L2vpn));
+    value.put_u8(u8::from(Safi::Evpn));
+    match nhop {
+        IpAddr::V4(v4) => {
+            value.put_u8(4);
+            value.put(&v4.octets()[..]);
+        }
+        IpAddr::V6(v6) => {
+            value.put_u8(16);
+            value.put(&v6.octets()[..]);
+        }
+    }
+    // Reserved / SNPA byte, always zero per RFC 4760 §3.
+    value.put_u8(0);
+    for r in updates {
+        r.nlri_emit(&mut value);
+    }
+
+    let len = value.len();
+    let extended = len > 255;
+    let flags = if extended {
+        AttrFlags::new().with_optional(true).with_extended(true)
+    } else {
+        AttrFlags::new().with_optional(true)
+    };
+    buf.put_u8(flags.into());
+    buf.put_u8(AttrType::MpReachNlri.into());
+    if extended {
+        buf.put_u16(len as u16);
+    } else {
+        buf.put_u8(len as u8);
+    }
+    buf.put(&value[..]);
 }

--- a/crates/bgp-packet/src/attrs/nlri_evpn.rs
+++ b/crates/bgp-packet/src/attrs/nlri_evpn.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
+use bytes::{BufMut, BytesMut};
 use nom::IResult;
 use nom::bytes::complete::take;
 use nom::error::{ErrorKind, make_error};
@@ -243,6 +244,80 @@ impl ParseNlri<EvpnRoute> for EvpnRoute {
     }
 }
 
+impl EvpnRoute {
+    /// Emit one EVPN NLRI (Route Type byte + Length byte + payload)
+    /// onto `buf`. Mirror of `parse_nlri`. Add-Path is signalled by a
+    /// non-zero `id`: when set, the four-byte path identifier is
+    /// prepended before the route-type byte (RFC 7911), matching the
+    /// asymmetry the existing `Vpnv4Reach::emit` uses.
+    ///
+    /// The length byte is the count of octets that follow it,
+    /// computed by buffering the payload first and reading its size —
+    /// keeps the encoder honest against future field additions
+    /// (e.g. Type-2 IP component going from absent → IPv4 → IPv6).
+    pub fn nlri_emit(&self, buf: &mut BytesMut) {
+        match self {
+            EvpnRoute::Mac(m) => {
+                if m.id != 0 {
+                    buf.put_u32(m.id);
+                }
+                let mut payload = BytesMut::new();
+                // RD (8 octets): 2-byte type + 6-byte value.
+                payload.put_u16(m.rd.typ as u16);
+                payload.put(&m.rd.val[..]);
+                // ESI (10 octets).
+                payload.put(&m.esi[..]);
+                // Ethernet Tag (4 octets).
+                payload.put_u32(m.ether_tag);
+                // MAC Address Length in bits (1 octet) — always 48
+                // for an EVPN MAC route. RFC 7432 §7.2.
+                payload.put_u8(48);
+                // MAC Address (6 octets).
+                payload.put(&m.mac[..]);
+                // IP Address Length (1 octet). MAC-only Type-2 routes
+                // emit length 0 with no following IP — operator-side
+                // MAC+IP support is a follow-up that will set 32 (IPv4)
+                // or 128 (IPv6) and emit the address.
+                payload.put_u8(0);
+                // MPLS Label1 / VNI (3 octets, big-endian, low 24
+                // bits of the u32). RFC 8365 §5.1.3.
+                let vni_bytes = m.vni.to_be_bytes();
+                payload.put(&vni_bytes[1..4]);
+                buf.put_u8(2); // Route Type 2 — MAC/IP Advertisement.
+                buf.put_u8(payload.len() as u8);
+                buf.put(&payload[..]);
+            }
+            EvpnRoute::Multicast(m) => {
+                if m.id != 0 {
+                    buf.put_u32(m.id);
+                }
+                let mut payload = BytesMut::new();
+                // RD (8 octets).
+                payload.put_u16(m.rd.typ as u16);
+                payload.put(&m.rd.val[..]);
+                // Ethernet Tag (4 octets).
+                payload.put_u32(m.ether_tag);
+                match m.addr {
+                    IpAddr::V4(v4) => {
+                        // IP Address Length in bits (1 octet) — 32
+                        // for IPv4. Mirror of the parse side which
+                        // accepts 32 → 4-octet read.
+                        payload.put_u8(32);
+                        payload.put(&v4.octets()[..]);
+                    }
+                    IpAddr::V6(v6) => {
+                        payload.put_u8(128);
+                        payload.put(&v6.octets()[..]);
+                    }
+                }
+                buf.put_u8(3); // Route Type 3 — Inclusive Multicast.
+                buf.put_u8(payload.len() as u8);
+                buf.put(&payload[..]);
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod evpn_prefix_tests {
     use super::*;
@@ -294,5 +369,141 @@ mod evpn_prefix_tests {
         assert_eq!(i.route_type(), 3);
         // Type 2 sorts before Type 3 (variant order).
         assert!(m < i);
+    }
+}
+
+#[cfg(test)]
+mod evpn_emit_tests {
+    use super::*;
+    use crate::RouteDistinguisherType;
+
+    /// Type-1 RD `192.0.2.1:100`. Type byte 0x0001 then 4-byte IPv4
+    /// followed by 2-byte assigned number.
+    fn rd_type1_ip(ip: Ipv4Addr, num: u16) -> RouteDistinguisher {
+        let mut rd = RouteDistinguisher::new(RouteDistinguisherType::IP);
+        rd.val[0..4].copy_from_slice(&ip.octets());
+        rd.val[4..6].copy_from_slice(&num.to_be_bytes());
+        rd
+    }
+
+    /// Type-2 NLRI: route-type byte (2), length byte, then 33 octets
+    /// of MAC-only payload — 8 (RD) + 10 (ESI) + 4 (eth-tag) + 1 + 6
+    /// (MAC) + 1 (IP-len=0) + 3 (VNI) = 33.
+    #[test]
+    fn macip_nlri_emit_macros_only() {
+        let mac = EvpnMac {
+            id: 0,
+            rd: rd_type1_ip(Ipv4Addr::new(192, 0, 2, 1), 100),
+            esi: [0; 10],
+            ether_tag: 0,
+            mac: [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff],
+            vni: 100,
+        };
+        let route = EvpnRoute::Mac(mac);
+        let mut buf = BytesMut::new();
+        route.nlri_emit(&mut buf);
+
+        assert_eq!(buf[0], 2, "route type");
+        assert_eq!(buf[1], 33, "length");
+        assert_eq!(&buf[2..4], &[0x00, 0x01], "RD type 1");
+        assert_eq!(&buf[4..8], &[192, 0, 2, 1], "RD IP");
+        assert_eq!(&buf[8..10], &[0x00, 0x64], "RD assigned-number = 100");
+        assert_eq!(&buf[10..20], &[0u8; 10], "ESI all zeros");
+        assert_eq!(&buf[20..24], &[0, 0, 0, 0], "eth-tag = 0");
+        assert_eq!(buf[24], 48, "MAC length in bits");
+        assert_eq!(&buf[25..31], &[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+        assert_eq!(buf[31], 0, "IP length 0 — MAC-only Type-2");
+        assert_eq!(&buf[32..35], &[0x00, 0x00, 0x64], "VNI 100 in 24 bits");
+        assert_eq!(buf.len(), 35, "1 + 1 + 33");
+    }
+
+    /// Add-Path: when `id != 0` the four-byte path id leads.
+    #[test]
+    fn macip_nlri_emit_addpath() {
+        let mac = EvpnMac {
+            id: 7,
+            rd: rd_type1_ip(Ipv4Addr::new(10, 0, 0, 1), 50),
+            esi: [0; 10],
+            ether_tag: 0,
+            mac: [0; 6],
+            vni: 50,
+        };
+        let mut buf = BytesMut::new();
+        EvpnRoute::Mac(mac).nlri_emit(&mut buf);
+        assert_eq!(&buf[0..4], &[0, 0, 0, 7], "path id 7 prepended");
+        assert_eq!(buf[4], 2, "route type follows id");
+    }
+
+    /// Type-3 NLRI: 8 (RD) + 4 (eth-tag) + 1 (IP-len=32) + 4 (IP) = 17.
+    #[test]
+    fn inclusive_multicast_nlri_emit_v4() {
+        let m = EvpnMulticast {
+            id: 0,
+            rd: rd_type1_ip(Ipv4Addr::new(10, 0, 0, 5), 100),
+            ether_tag: 0,
+            addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5)),
+        };
+        let mut buf = BytesMut::new();
+        EvpnRoute::Multicast(m).nlri_emit(&mut buf);
+        assert_eq!(buf[0], 3);
+        assert_eq!(buf[1], 17);
+        assert_eq!(&buf[2..10], &[0x00, 0x01, 10, 0, 0, 5, 0x00, 0x64]);
+        assert_eq!(&buf[10..14], &[0, 0, 0, 0], "eth-tag = 0");
+        assert_eq!(buf[14], 32, "IPv4 origin = 32 bits");
+        assert_eq!(&buf[15..19], &[10, 0, 0, 5]);
+        assert_eq!(buf.len(), 19);
+    }
+
+    /// Round-trip: emit a Type-2 route, then parse the bytes back as
+    /// an MP_REACH-style NLRI stream. The parser must recover the
+    /// same RD, eth-tag, MAC, and VNI we emitted.
+    #[test]
+    fn macip_emit_then_parse_roundtrip() {
+        let original = EvpnMac {
+            id: 0,
+            rd: rd_type1_ip(Ipv4Addr::new(192, 168, 0, 1), 200),
+            esi: [0; 10],
+            ether_tag: 0,
+            mac: [0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc],
+            vni: 200,
+        };
+        let mut buf = BytesMut::new();
+        EvpnRoute::Mac(original.clone()).nlri_emit(&mut buf);
+
+        let (_, parsed) =
+            EvpnRoute::parse_nlri(&buf, false).expect("parse_nlri must accept what we emit");
+        match parsed {
+            EvpnRoute::Mac(p) => {
+                assert_eq!(p.rd, original.rd);
+                assert_eq!(p.ether_tag, original.ether_tag);
+                assert_eq!(p.mac, original.mac);
+                assert_eq!(p.vni, original.vni);
+                assert_eq!(p.esi, original.esi);
+            }
+            _ => panic!("expected Mac variant"),
+        }
+    }
+
+    #[test]
+    fn inclusive_multicast_emit_then_parse_roundtrip() {
+        let original = EvpnMulticast {
+            id: 0,
+            rd: rd_type1_ip(Ipv4Addr::new(10, 0, 0, 5), 100),
+            ether_tag: 0,
+            addr: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5)),
+        };
+        let mut buf = BytesMut::new();
+        EvpnRoute::Multicast(original.clone()).nlri_emit(&mut buf);
+
+        let (_, parsed) =
+            EvpnRoute::parse_nlri(&buf, false).expect("parse_nlri must accept what we emit");
+        match parsed {
+            EvpnRoute::Multicast(p) => {
+                assert_eq!(p.rd, original.rd);
+                assert_eq!(p.ether_tag, original.ether_tag);
+                assert_eq!(p.addr, original.addr);
+            }
+            _ => panic!("expected Multicast variant"),
+        }
     }
 }


### PR DESCRIPTION
## Summary
Wire-format foundation for outbound EVPN advertisements. Receive side (`parse_nlri` / `parse_nlri_opt`) was complete; send side was empty — `MpReachAttr::attr_emit` only handled `Vpnv4` / `Rtcv4`, and `EvpnRoute` had no emit path at all. This PR closes that gap so the next zebra-rs PR (`send_evpn` / `flush_evpn` / `route_advertise_evpn_to_peers`) can plug in.

## What lands

**`EvpnRoute::nlri_emit(buf)`** — RFC 7432 §7.2 / §7.3, RFC 8365 §5.1.3:
- **Mac (Route Type 2, MAC-only):** route-type(1) + length(1) + payload(33) = `RD(8) + ESI(10) + EthTag(4) + MACLen=48(1) + MAC(6) + IPLen=0(1) + VNI(3)`
- **Multicast (Route Type 3, IPv4):** route-type(1) + length(1) + payload(17) = `RD(8) + EthTag(4) + IPLen=32(1) + Origin(4)`

**`evpn_attr_emit(snpa, nhop, updates, buf)`** — RFC 4760 §3:
- Full `MP_REACH_NLRI` attribute (header + value)
- `AttrFlags(optional, possibly extended)` + `AttrType=14(MpReachNlri)` + len + `AFI=25(L2VPN)` + `SAFI=70(EVPN)` + `NhopLen(4 or 16)` + `Nhop` + `SNPA=0` + NLRIs.
- Length byte is computed from a buffered payload so future field additions (e.g. Type-2 IP component) stay honest.

Add-Path handled symmetrically with the existing Vpnv4 emitter: when `id != 0` the four-byte path id is prepended before the route-type byte (RFC 7911).

## Conscious limits (for next-PR / RFC 7432 follow-ups)
- **MAC-only Type-2** — IPlen=0; the wire format leaves room for IPv4 (32) and IPv6 (128) but the operator-side MAC+IP correlation needs ARP/NDP table integration first.
- **Single MPLS Label slot** — RFC 7432 allows two; second-label is only used for symmetric IRB which we're not building yet.
- **ESI passes through whatever the struct holds** — callers originating Type-2 routes hardcode zero (single-homed).
- **Type-1 (Ethernet AD) and Type-4 (Ethernet Segment)** are out of scope until multi-homing.

## Test plan
- [x] **5 new unit tests** in `evpn_emit_tests` pin both the byte layout and the emit→parse roundtrip for both route types
- [x] `RUSTFLAGS="-D warnings" cargo test -p bgp-packet` — all green
- [x] `RUSTFLAGS="-D warnings" cargo test -p zebra-rs --bin zebra-rs` — **169/169 pass**
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets` — clean
- [x] `cargo fmt --all`

Generated with [Claude Code](https://claude.com/claude-code)