### PR TITLE
bgp: advertise EVPN Type-2 routes on the wire (RT + Encap + nexthop)

### DIFF
--- a/crates/bgp-packet/src/attrs/mp_reach.rs
+++ b/crates/bgp-packet/src/attrs/mp_reach.rs
@@ -263,7 +263,7 @@ impl fmt::Debug for MpReachAttr {
 /// before writing the header — extended (2-byte) length is used when
 /// the value exceeds 255 octets, matching the convention used by
 /// `Vpnv4Reach::attr_emit_mut`.
-fn evpn_attr_emit(_snpa: u8, nhop: &IpAddr, updates: &[EvpnRoute], buf: &mut BytesMut) {
+pub(crate) fn evpn_attr_emit(_snpa: u8, nhop: &IpAddr, updates: &[EvpnRoute], buf: &mut BytesMut) {
     let mut value = BytesMut::new();
     value.put_u16(u16::from(Afi::L2vpn));
     value.put_u8(u8::from(Safi::Evpn));

--- a/crates/bgp-packet/src/attrs/nlri_evpn.rs
+++ b/crates/bgp-packet/src/attrs/nlri_evpn.rs
@@ -52,13 +52,13 @@ pub struct Evpn {
     pub ether_tag: u32,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum EvpnRoute {
     Mac(EvpnMac),
     Multicast(EvpnMulticast),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EvpnMac {
     pub id: u32,
     pub rd: RouteDistinguisher,
@@ -68,7 +68,7 @@ pub struct EvpnMac {
     pub vni: u32,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EvpnMulticast {
     pub id: u32,
     pub rd: RouteDistinguisher,

--- a/crates/bgp-packet/src/update.rs
+++ b/crates/bgp-packet/src/update.rs
@@ -119,6 +119,60 @@ impl UpdatePacket {
         Some(buf)
     }
 
+    /// Emit the BGP UPDATE that carries an `MP_REACH_NLRI` for EVPN
+    /// (AFI=25 / SAFI=70). Mirrors `pop_vpnv4`'s framing — empty IPv4
+    /// withdraw, attributes, MP_REACH — but uses the un-paginated
+    /// `evpn_attr_emit` helper from `mp_reach`. All NLRIs in the
+    /// `MpReachAttr::Evpn::updates` vector are emitted in a single
+    /// packet; pagination across multiple UPDATEs (e.g. when a
+    /// large RD's MAC table doesn't fit) is a follow-up.
+    ///
+    /// Returns `None` when the packet has no EVPN payload to emit
+    /// (caller can stop iterating). Distinct from `pop_vpnv4` in
+    /// that it's idempotently single-shot — callers that want to
+    /// emit multiple UPDATEs should batch into separate
+    /// `UpdatePacket` instances.
+    pub fn pop_evpn(&mut self) -> Option<BytesMut> {
+        let (snpa, nhop, updates) = match &self.mp_update {
+            Some(MpReachAttr::Evpn {
+                snpa,
+                nhop,
+                updates,
+            }) if !updates.is_empty() => (*snpa, *nhop, updates.clone()),
+            _ => return None,
+        };
+
+        let mut buf = FixedBuf::new(self.max_packet_size);
+        let header: BytesMut = self.header.clone().into();
+        let _ = buf.put(&header[..]);
+
+        // No IPv4 withdraw on EVPN UPDATEs — same as the VPNv4 path.
+        let _ = buf.put_u16(0u16);
+
+        let attr_len_pos = buf.len();
+        let _ = buf.put_u16(0u16); // placeholder
+
+        if let Some(bgp_attr) = &self.bgp_attr {
+            bgp_attr.attr_emit(buf.get_mut());
+        }
+
+        super::attrs::mp_reach::evpn_attr_emit(snpa, &nhop, &updates, buf.get_mut());
+
+        let attr_len: u16 = (buf.len() - attr_len_pos - 2) as u16;
+        let _ = buf.put_u16_at(attr_len_pos, attr_len);
+
+        let length: u16 = buf.len() as u16;
+        let _ = buf.put_u16_at(16, length);
+
+        // Drain so a second call returns None — matches VPNv4's
+        // "consume once" semantics from the flush_vpnv4 callers.
+        if let Some(MpReachAttr::Evpn { updates, .. }) = self.mp_update.as_mut() {
+            updates.clear();
+        }
+
+        Some(buf.get())
+    }
+
     pub fn pop_vpnv4(&mut self) -> Option<BytesMut> {
         match &self.mp_update {
             Some(MpReachAttr::Vpnv4(vpnv4)) if !vpnv4.updates.is_empty() => {}

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -79,6 +79,7 @@ pub enum Event {
     StaleTimerExipires(AfiSafi),
     AdvTimerIpv4Expires,
     AdvTimerVpnv4Expires,
+    AdvTimerEvpnExpires,
 }
 
 pub enum FsmEffect {
@@ -313,8 +314,15 @@ pub struct Peer {
     pub cache_ipv4_rev: HashMap<Ipv4Nlri, Arc<BgpAttr>>,
     pub cache_vpnv4: HashMap<Arc<BgpAttr>, HashSet<Vpnv4Nlri>>,
     pub cache_vpnv4_rev: HashMap<Vpnv4Nlri, Arc<BgpAttr>>,
+    /// EVPN advertise cache. Mirrors `cache_vpnv4` shape — NLRIs
+    /// grouped by attribute so a single MP_REACH UPDATE on flush can
+    /// carry every route that shares one attr set. Withdraw path uses
+    /// the reverse map; not yet implemented in this PR.
+    pub cache_evpn: HashMap<Arc<BgpAttr>, HashSet<EvpnRoute>>,
+    pub cache_evpn_rev: HashMap<EvpnRoute, Arc<BgpAttr>>,
     pub cache_ipv4_timer: Option<Timer>,
     pub cache_vpnv4_timer: Option<Timer>,
+    pub cache_evpn_timer: Option<Timer>,
     // Runtime bookkeeping for TCP-AO listener state: the (send_id,
     // recv_id) pair most recently installed via TCP_AO_ADD_KEY for
     // this peer. Needed because TCP_AO_DEL_KEY requires the exact
@@ -374,8 +382,11 @@ impl Peer {
             cache_ipv4_rev: HashMap::default(),
             cache_vpnv4: HashMap::default(),
             cache_vpnv4_rev: HashMap::default(),
+            cache_evpn: HashMap::default(),
+            cache_evpn_rev: HashMap::default(),
             cache_ipv4_timer: None,
             cache_vpnv4_timer: None,
+            cache_evpn_timer: None,
             last_ao_installed: None,
         };
         peer.config
@@ -474,6 +485,7 @@ pub fn fsm_next_state(peer: &mut Peer, event: Event) -> (State, FsmEffect) {
         }
         Event::AdvTimerIpv4Expires => (fsm_adv_timer_ipv4_expires(peer), FsmEffect::None),
         Event::AdvTimerVpnv4Expires => (fsm_adv_timer_vpnv4_expires(peer), FsmEffect::None),
+        Event::AdvTimerEvpnExpires => (fsm_adv_timer_evpn_expires(peer), FsmEffect::None),
     }
 }
 
@@ -533,6 +545,12 @@ pub fn fsm_adv_timer_ipv4_expires(peer: &mut Peer) -> State {
 pub fn fsm_adv_timer_vpnv4_expires(peer: &mut Peer) -> State {
     peer.cache_vpnv4_timer = None;
     peer.flush_vpnv4();
+    State::Established
+}
+
+pub fn fsm_adv_timer_evpn_expires(peer: &mut Peer) -> State {
+    peer.cache_evpn_timer = None;
+    peer.flush_evpn();
     State::Established
 }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7,7 +7,7 @@ use bytes::BytesMut;
 use ipnet::Ipv4Net;
 use prefix_trie::PrefixMap;
 
-use crate::bgp::timer::start_stale_timer;
+use crate::bgp::timer::{start_adv_timer_evpn, start_stale_timer};
 use crate::policy::PolicyList;
 use crate::rib::{self, MacAddr, api::FdbEntry};
 
@@ -891,6 +891,119 @@ fn route_advertise_to_peers(
     }
 }
 
+/// Per-peer EVPN advertise builder. Mirrors `route_update_ipv4`:
+/// applies split-horizon, the iBGP-iBGP / route-reflector filter,
+/// and fixes up AS_PATH / NEXT_HOP / LOCAL_PREF for the outgoing
+/// direction. Returns `(EvpnRoute, BgpAttr)` if the peer should
+/// receive an advertisement, `None` otherwise.
+///
+/// VNI is sourced from the RT extended community on the inbound
+/// attribute (per RFC 8365 §5.1.2.4). For locally-originated routes
+/// `evpn_originate_macip` attaches the RT first, so the lookup
+/// always succeeds; for re-advertised routes the upstream RT is
+/// preserved.
+pub fn route_update_evpn(
+    peer: &mut Peer,
+    rd: &RouteDistinguisher,
+    prefix: &EvpnPrefix,
+    rib: &BgpRib,
+    bgp: &mut BgpTop,
+    add_path: bool,
+) -> Option<(EvpnRoute, BgpAttr)> {
+    if rib.ident == peer.ident {
+        return None;
+    }
+    if peer.peer_type == PeerType::IBGP
+        && rib.typ == BgpRibType::IBGP
+        && !peer.is_reflector_client()
+    {
+        return None;
+    }
+
+    let id = if add_path { rib.local_id } else { 0 };
+
+    let route = match prefix {
+        EvpnPrefix::MacIp { eth_tag, mac, .. } => {
+            let vni = extract_vni_from_attr(&rib.attr).unwrap_or(0);
+            EvpnRoute::Mac(EvpnMac {
+                id,
+                rd: *rd,
+                esi: rib.esi.unwrap_or([0; 10]),
+                ether_tag: *eth_tag,
+                mac: *mac,
+                vni,
+            })
+        }
+        EvpnPrefix::InclusiveMulticast { eth_tag, orig } => EvpnRoute::Multicast(EvpnMulticast {
+            id,
+            rd: *rd,
+            ether_tag: *eth_tag,
+            addr: *orig,
+        }),
+    };
+
+    let mut attrs = (*rib.attr).clone();
+
+    if peer.is_ebgp()
+        && let Some(ref mut aspath) = attrs.aspath
+    {
+        let local_as_path = As4Path::from(vec![peer.local_as]);
+        aspath.prepend_mut(local_as_path);
+    }
+
+    if peer.is_ebgp() || rib.is_originated() {
+        let nexthop: IpAddr = if let Some(ref local_addr) = peer.param.local_addr {
+            local_addr.ip()
+        } else {
+            IpAddr::V4(*bgp.router_id)
+        };
+        attrs.nexthop = Some(BgpNexthop::Evpn(nexthop));
+    }
+
+    if peer.is_ibgp() && attrs.local_pref.is_none() {
+        attrs.local_pref = Some(LocalPref::default());
+    }
+
+    Some((route, attrs))
+}
+
+/// Fan out an EVPN best-path selection to every peer with the
+/// `(L2vpn, Evpn)` AFI/SAFI established. Skips peers filtered by
+/// split-horizon / iBGP rules inside `route_update_evpn`. Withdraw
+/// path (MpUnreach for EVPN) is a follow-up — this PR only
+/// advertises new best paths.
+pub fn route_advertise_evpn_to_peers(
+    rd: RouteDistinguisher,
+    prefix: EvpnPrefix,
+    selected: &[BgpRib],
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+) {
+    let Some(new_best) = selected.last() else {
+        return;
+    };
+
+    let peer_addrs: Vec<IpAddr> = peers
+        .iter()
+        .filter(|(_, p)| p.state.is_established())
+        .filter(|(_, p)| p.is_afi_safi(Afi::L2vpn, Safi::Evpn))
+        .map(|(addr, _)| *addr)
+        .collect();
+
+    for peer_addr in peer_addrs {
+        let peer = peers.get_mut(&peer_addr).expect("peer exists");
+        let add_path = peer.opt.is_add_path_send(Afi::L2vpn, Safi::Evpn);
+
+        let Some((route, attr)) = route_update_evpn(peer, &rd, &prefix, new_best, bgp, add_path)
+        else {
+            continue;
+        };
+
+        let attr = bgp.attr_store.intern(attr);
+        peer.send_evpn(route, attr, true);
+    }
+}
+
 // Send BGP withdrawal for a prefix
 fn route_withdraw_ipv4(peer: &mut Peer, rd: Option<RouteDistinguisher>, prefix: Ipv4Net, id: u32) {
     let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
@@ -1723,6 +1836,56 @@ impl Peer {
         }
     }
 
+    /// Cache an EVPN route for advertisement, grouped by attribute.
+    /// Mirrors `send_vpnv4`: same timer-debounce shape, same
+    /// per-attribute batching so a single MP_REACH UPDATE can carry
+    /// every route that shares an attribute set.
+    pub fn send_evpn(&mut self, route: EvpnRoute, attr: Arc<BgpAttr>, timer: bool) {
+        self.cache_evpn
+            .entry(attr.clone())
+            .or_default()
+            .insert(route.clone());
+        self.cache_evpn_rev.insert(route, attr);
+        if timer && self.cache_evpn_timer.is_none() {
+            self.cache_evpn_timer = Some(start_adv_timer_evpn(self));
+        }
+    }
+
+    /// Drain `cache_evpn` and emit one BGP UPDATE per attribute
+    /// group via `pop_evpn`. Pagination across multiple UPDATEs is a
+    /// follow-up; the encoder currently emits all NLRIs from a
+    /// single attr group in one packet.
+    pub fn flush_evpn(&mut self) {
+        let packet_tx = self.packet_tx.clone();
+        let max_size = self.max_packet_size();
+        for (attr, routes) in self.cache_evpn.drain() {
+            let mut update = UpdatePacket::with_max_packet_size(max_size);
+
+            // Nexthop comes from the cached attribute. EVPN allows
+            // either an IPv4 or IPv6 nexthop; if neither was set on
+            // the attr (shouldn't happen for locally-originated
+            // routes), default to 0.0.0.0 — the receiver will
+            // notice and drop, which is the right behavior.
+            let nhop = match attr.nexthop.as_ref() {
+                Some(BgpNexthop::Evpn(addr)) => *addr,
+                _ => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            };
+            update.mp_update = Some(MpReachAttr::Evpn {
+                snpa: 0,
+                nhop,
+                updates: routes.into_iter().collect(),
+            });
+            update.bgp_attr = Some((*attr).clone());
+
+            if let Some(bytes) = update.pop_evpn()
+                && let Some(ref tx) = packet_tx
+            {
+                let _ = tx.send(bytes);
+            }
+        }
+        self.cache_evpn_rev.clear();
+    }
+
     // Flush BGP update.
     pub fn flush_vpnv4(&mut self) {
         let packet_tx = self.packet_tx.clone();
@@ -2071,8 +2234,24 @@ impl Bgp {
             mac: entry.mac.octets(),
             ip: None,
         };
-        let attr = BgpAttr::new();
-        let rib = BgpRib::new(
+
+        // Build the BGP attributes for this origination. RFC 8365
+        // §5.1.2.4 requires both:
+        //   - RT (Route Target) carrying the VNI so receivers can
+        //     install into the right L2VPN (auto-derived
+        //     <local-AS>:<VNI>, two-octet ASN form for now).
+        //   - Encapsulation extended community = VXLAN (8) so the
+        //     receiver knows which data plane to use.
+        // Nexthop is the local router-id; per-peer NEXT_HOP rewrite
+        // for eBGP happens inside `route_update_evpn`.
+        let mut attr = BgpAttr::new();
+        attr.ecom = Some(ExtCommunity(vec![
+            evpn_route_target(self.asn, entry.vni),
+            evpn_encap_vxlan(),
+        ]));
+        attr.nexthop = Some(BgpNexthop::Evpn(IpAddr::V4(self.router_id)));
+
+        let mut rib = BgpRib::new(
             ORIGINATED_PEER,
             Ipv4Addr::UNSPECIFIED,
             BgpRibType::Originated,
@@ -2084,7 +2263,21 @@ impl Bgp {
             None,
             false,
         );
-        let _ = self.local_rib.update_evpn(rd, prefix, rib);
+        let (_replaced, selected, next_id) =
+            self.local_rib.update_evpn(rd, prefix.clone(), rib.clone());
+        rib.local_id = next_id;
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_tx: &self.rib_tx,
+            attr_store: &mut self.attr_store,
+        };
+
+        if !selected.is_empty() {
+            route_advertise_evpn_to_peers(rd, prefix, &selected, &mut bgp_ref, &mut self.peers);
+        }
     }
 
     /// Inverse of `evpn_originate_macip`. No-op when
@@ -2124,4 +2317,40 @@ fn rd_from_router_id_vni(router_id: Ipv4Addr, vni: u32) -> Option<RouteDistingui
     rd.val[0..4].copy_from_slice(&router_id.octets());
     rd.val[4..6].copy_from_slice(&vni_short.to_be_bytes());
     Some(rd)
+}
+
+/// Build the auto-derived Route Target extended community for an EVPN
+/// route per RFC 8365 §5.1.2.4: type 0x00 / sub 0x02 (Two-Octet AS
+/// Specific Route Target) carrying `<local-AS>:<VNI>`. The 2-byte
+/// ASN sits in the first two octets; the VNI fills the remaining
+/// four (24-bit VNI naturally encoded big-endian into the low 3 of
+/// 4 bytes; 32-bit values would clobber the high byte but VNIs are
+/// 24-bit per RFC 7348).
+fn evpn_route_target(asn: u32, vni: u32) -> ExtCommunityValue {
+    let mut rt = ExtCommunityValue {
+        high_type: 0x00,
+        low_type: 0x02,
+        val: [0; 6],
+    };
+    let asn16 = asn as u16;
+    rt.val[0..2].copy_from_slice(&asn16.to_be_bytes());
+    rt.val[2..6].copy_from_slice(&vni.to_be_bytes());
+    rt
+}
+
+/// Build the Tunnel Encapsulation extended community for VXLAN per
+/// RFC 9012 §6.1: type 0x03 (Transitive Opaque) / sub 0x0c
+/// (Encapsulation), value = encapsulation type 8 (VXLAN) in the low
+/// two octets. Without this community a Type-2 receiver that
+/// understands EVPN but supports multiple data planes can't tell
+/// which encap to install, so RFC 8365 §5.1.2.4 makes it mandatory.
+fn evpn_encap_vxlan() -> ExtCommunityValue {
+    let mut encap = ExtCommunityValue {
+        high_type: 0x03,
+        low_type: 0x0c,
+        val: [0; 6],
+    };
+    // Encapsulation type 8 = VXLAN, occupies the trailing 2 octets.
+    encap.val[5] = 8;
+    encap
 }

--- a/zebra-rs/src/bgp/timer.rs
+++ b/zebra-rs/src/bgp/timer.rs
@@ -118,6 +118,17 @@ pub fn start_adv_timer_vpnv4(peer: &Peer) -> Timer {
     }
 }
 
+/// EVPN advertise debounce — same iBGP/eBGP cadence as the IPv4 /
+/// VPNv4 timers. Buffers a burst of FDB learns into one MP_REACH
+/// UPDATE per attribute group.
+pub fn start_adv_timer_evpn(peer: &Peer) -> Timer {
+    if peer.is_ibgp() {
+        start_timer!(peer, 5_u64, Event::AdvTimerEvpnExpires)
+    } else {
+        start_timer!(peer, 30_u64, Event::AdvTimerEvpnExpires)
+    }
+}
+
 fn start_keepalive_timer(peer: &Peer) -> Timer {
     start_repeater!(
         peer,


### PR DESCRIPTION
## Summary
Closes the loop on the FRR-style `advertise-all-vni` consumer. Local FDB learns now flow all the way to the wire as Type-2 (MAC/IP) UPDATEs rather than just sitting in the local-RIB.

## End-to-end flow after this PR
```
kernel learns MAC on VXLAN-attached bridge
  → RibRx::FdbAdd
  → Bgp::evpn_originate_macip
      builds BgpAttr with:
        - RT = <local-AS>:<VNI>          (RFC 8365 §5.1.2.4)
        - Encap = VXLAN(8)                (RFC 9012 §6.1)
        - nexthop = local router-id       (BgpNexthop::Evpn)
      inserts into local_rib.evpn (PR #398), runs best-path
      select, fans out via route_advertise_evpn_to_peers
  → per peer with (L2vpn, Evpn) Established and not blocked by
     split-horizon / iBGP filter, route_update_evpn rewrites
     NEXT_HOP / AS_PATH / LOCAL_PREF for the outgoing direction;
     peer.send_evpn caches keyed by attribute
  → debounced timer (5s iBGP / 30s eBGP) fires
  → peer.flush_evpn drains the cache, one MP_REACH UPDATE per
     attribute group via UpdatePacket::pop_evpn → packet_tx
```

## What lands

**bgp-packet**
- `PartialEq + Eq + Hash` on `EvpnRoute / EvpnMac / EvpnMulticast` so they can key `HashMap<Arc<BgpAttr>, HashSet<EvpnRoute>>`.
- `evpn_attr_emit` (PR #399) made `pub(crate)` so `pop_evpn` reuses it.
- New `UpdatePacket::pop_evpn` — full UPDATE framing (header + empty IPv4 withdraw + attrs + MP_REACH(L2VPN/EVPN)). All NLRIs in one packet for now; pagination is a follow-up.

**zebra-rs**
- Peer fields: `cache_evpn`, `cache_evpn_rev`, `cache_evpn_timer`.
- `Event::AdvTimerEvpnExpires` + `fsm_adv_timer_evpn_expires`.
- `timer.rs`: `start_adv_timer_evpn` — same cadence as VPNv4/IPv4.
- `peer.send_evpn` — cache + start timer (mirror of `send_vpnv4`).
- `peer.flush_evpn` — drain cache, build `UpdatePacket` per attr, `pop_evpn`, `packet_tx`.
- `route_update_evpn` — per-peer split-horizon / iBGP-iBGP / route-reflector / AS_PATH / NEXT_HOP / LOCAL_PREF rewrite. Builds `EvpnRoute (Mac/Multicast)` from RD + `EvpnPrefix` + the inbound `BgpRib`'s RT-extracted VNI.
- `route_advertise_evpn_to_peers` — fan out a best-path selection to every peer with `(L2vpn, Evpn)` Established.
- `evpn_originate_macip` extended: `BgpAttr` now carries RT + Encap + nexthop; after local-RIB update, fans out.
- `evpn_route_target` / `evpn_encap_vxlan` helpers — auto-derived extended communities.

## Out of scope (follow-ups, called out in the commit)
- **MpUnreach for EVPN** — `evpn_withdraw_macip` removes from local-RIB but doesn't send withdraws to peers yet.
- **4-byte ASN RT** — currently uses 2-byte form via `asn as u16` truncation.
- **VNI > 65535** — Type-1 RD has 2-byte tail; Type-0 ASN-form RD is a follow-up.
- **Per-peer EVPN adj-RIB-out** — no `peer.adj_out` insert; means withdraw-on-policy-change can't reconstruct what was advertised.
- **BDD verification** — needs a Linux host with two zebras + VXLAN-attached bridges.

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo test -p zebra-rs --bin zebra-rs` — **169/169 pass**
- [x] `RUSTFLAGS="-D warnings" cargo test -p bgp-packet` — all green
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets` — clean
- [x] `cargo fmt --all`
- [ ] **Manual on a Linux host**: with two zebras peered iBGP and `advertise-all-vni true`, `bridge fdb add aa:bb:cc:dd:ee:ff dev <vxlan-bridge-port>` on z1 → `show bgp l2vpn evpn` on z2 lists the route after the 5s debounce. Tcpdump shows MP_REACH(25/70) carrying the Type-2 NLRI with the expected RT and Encap=VXLAN.

Generated with [Claude Code](https://claude.com/claude-code)