### PR TITLE
bgp: send EVPN MP_UNREACH withdraws when local FDB entry goes away

### DIFF
--- a/crates/bgp-packet/src/attrs/mp_unreach.rs
+++ b/crates/bgp-packet/src/attrs/mp_unreach.rs
@@ -1,12 +1,12 @@
 use std::fmt;
 
-use bytes::BytesMut;
+use bytes::{BufMut, BytesMut};
 use nom::error::{ErrorKind, make_error};
 use nom_derive::*;
 
 use crate::{
-    Afi, EvpnRoute, Ipv6Nlri, ParseBe, ParseNlri, ParseOption, Rtcv4, Rtcv4Unreach, Safi,
-    Vpnv4Nlri, many0_complete,
+    Afi, AttrFlags, AttrType, EvpnRoute, Ipv6Nlri, ParseBe, ParseNlri, ParseOption, Rtcv4,
+    Rtcv4Unreach, Safi, Vpnv4Nlri, many0_complete,
 };
 
 use super::{AttrEmitter, Vpnv4Unreach};
@@ -50,11 +50,57 @@ impl MpUnreachAttr {
                 let attr = Rtcv4Unreach { withdraw: vec![] };
                 attr.attr_emit(buf);
             }
+            MpUnreachAttr::Evpn(withdraw) => {
+                evpn_unreach_attr_emit(withdraw, buf);
+            }
+            MpUnreachAttr::EvpnEor => {
+                evpn_unreach_attr_emit(&[], buf);
+            }
             _ => {
                 //
             }
         }
     }
+}
+
+/// Serialize an `MpUnreachAttr::Evpn(updates)` (or `EvpnEor` when
+/// `updates` is empty) as a complete `MP_UNREACH_NLRI` path attribute
+/// (header + value).
+///
+/// Wire format (RFC 4760 §4):
+/// ```text
+///   AFI  (2 octets) = 25 (L2VPN)
+///   SAFI (1 octet)  = 70 (EVPN)
+///   Withdrawn Routes (one or more EvpnRoute encodings; empty for EoR)
+/// ```
+///
+/// MP_UNREACH carries neither nexthop nor SNPA — only the AFI/SAFI
+/// header and the NLRI list. The NLRI body bytes are produced by
+/// `EvpnRoute::nlri_emit` (PR #399), the same encoder used by the
+/// MP_REACH advertise path.
+fn evpn_unreach_attr_emit(withdraw: &[EvpnRoute], buf: &mut BytesMut) {
+    let mut value = BytesMut::new();
+    value.put_u16(u16::from(Afi::L2vpn));
+    value.put_u8(u8::from(Safi::Evpn));
+    for r in withdraw {
+        r.nlri_emit(&mut value);
+    }
+
+    let len = value.len();
+    let extended = len > 255;
+    let flags = if extended {
+        AttrFlags::new().with_optional(true).with_extended(true)
+    } else {
+        AttrFlags::new().with_optional(true)
+    };
+    buf.put_u8(flags.into());
+    buf.put_u8(AttrType::MpUnreachNlri.into());
+    if extended {
+        buf.put_u16(len as u16);
+    } else {
+        buf.put_u8(len as u8);
+    }
+    buf.put(&value[..]);
 }
 
 impl MpUnreachAttr {

--- a/crates/bgp-packet/src/attrs/nlri_evpn.rs
+++ b/crates/bgp-packet/src/attrs/nlri_evpn.rs
@@ -484,6 +484,34 @@ mod evpn_emit_tests {
         }
     }
 
+    /// Roundtrip via the MP_UNREACH path: the NLRI body produced by
+    /// `nlri_emit` must round-trip through `EvpnRoute::parse_nlri`
+    /// exactly the same way it does for MP_REACH (the wire format
+    /// for the NLRI proper is identical between announce/withdraw).
+    #[test]
+    fn macip_emit_then_parse_roundtrip_for_withdraw_path() {
+        let original = EvpnMac {
+            id: 0,
+            rd: rd_type1_ip(Ipv4Addr::new(192, 0, 2, 1), 100),
+            esi: [0; 10],
+            ether_tag: 0,
+            mac: [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff],
+            vni: 100,
+        };
+        let mut buf = BytesMut::new();
+        EvpnRoute::Mac(original.clone()).nlri_emit(&mut buf);
+        let (_, parsed) =
+            EvpnRoute::parse_nlri(&buf, false).expect("withdraw NLRI must round-trip");
+        match parsed {
+            EvpnRoute::Mac(p) => {
+                assert_eq!(p.rd, original.rd);
+                assert_eq!(p.mac, original.mac);
+                assert_eq!(p.vni, original.vni);
+            }
+            _ => panic!("expected Mac variant"),
+        }
+    }
+
     #[test]
     fn inclusive_multicast_emit_then_parse_roundtrip() {
         let original = EvpnMulticast {

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -967,11 +967,88 @@ pub fn route_update_evpn(
     Some((route, attrs))
 }
 
+/// Send a single EVPN withdraw to one peer. Mirrors
+/// `route_withdraw_ipv4` — no caching, straight to the wire as a
+/// one-NLRI MP_UNREACH UPDATE. The receiver removes the route from
+/// its adj-RIB-in and re-runs best-path; an empty selection at the
+/// peer triggers `route_evpn_export_selected` which sends
+/// `Message::MacDel` / `MdbDel` and the kernel FDB row goes away.
+fn route_withdraw_evpn(peer: &mut Peer, route: EvpnRoute) {
+    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    update.mp_withdraw = Some(MpUnreachAttr::Evpn(vec![route]));
+    peer.send_packet(update.into());
+}
+
+/// Fan out a withdraw to every peer with `(L2vpn, Evpn)` Established.
+/// Also drains any pending advertise from each peer's `cache_evpn` —
+/// without this, a quick add/remove cycle would leave a stale
+/// announce in the cache that fires after the withdraw wins on the
+/// wire.
+pub fn route_withdraw_evpn_to_peers(
+    rd: RouteDistinguisher,
+    prefix: EvpnPrefix,
+    peers: &mut PeerMap,
+) {
+    let peer_addrs: Vec<IpAddr> = peers
+        .iter()
+        .filter(|(_, p)| p.state.is_established())
+        .filter(|(_, p)| p.is_afi_safi(Afi::L2vpn, Safi::Evpn))
+        .map(|(addr, _)| *addr)
+        .collect();
+
+    for peer_addr in peer_addrs {
+        let peer = peers.get_mut(&peer_addr).expect("peer exists");
+        let route = evpn_route_from_prefix(&rd, &prefix, 0);
+        // Drop a queued advertise for the same route from the peer's
+        // cache so flush_evpn doesn't ship a now-stale add after we
+        // ship the withdraw.
+        if let Some(attr) = peer.cache_evpn_rev.remove(&route)
+            && let Some(set) = peer.cache_evpn.get_mut(&attr)
+        {
+            set.remove(&route);
+            if set.is_empty() {
+                peer.cache_evpn.remove(&attr);
+            }
+        }
+        route_withdraw_evpn(peer, route);
+    }
+}
+
+/// Build an `EvpnRoute` (Mac/Multicast) from an `(rd, prefix)` pair
+/// — needed both at advertise time (in `route_update_evpn` via the
+/// inbound BgpRib's attr) and at withdraw time, where there's no
+/// inbound attr to consult and the VNI is recovered from the RD's
+/// trailing 2 bytes (Type-1 form). ESI defaults to zero, eth-tag
+/// passes through.
+fn evpn_route_from_prefix(rd: &RouteDistinguisher, prefix: &EvpnPrefix, id: u32) -> EvpnRoute {
+    match prefix {
+        EvpnPrefix::MacIp { eth_tag, mac, .. } => {
+            // RD type 1 (IPv4 + 2-byte assigned-number) is the form
+            // we emit at origination — the assigned-number bytes
+            // [4..6] carry the low 16 bits of the VNI.
+            let vni = u16::from_be_bytes([rd.val[4], rd.val[5]]) as u32;
+            EvpnRoute::Mac(EvpnMac {
+                id,
+                rd: *rd,
+                esi: [0; 10],
+                ether_tag: *eth_tag,
+                mac: *mac,
+                vni,
+            })
+        }
+        EvpnPrefix::InclusiveMulticast { eth_tag, orig } => EvpnRoute::Multicast(EvpnMulticast {
+            id,
+            rd: *rd,
+            ether_tag: *eth_tag,
+            addr: *orig,
+        }),
+    }
+}
+
 /// Fan out an EVPN best-path selection to every peer with the
 /// `(L2vpn, Evpn)` AFI/SAFI established. Skips peers filtered by
-/// split-horizon / iBGP rules inside `route_update_evpn`. Withdraw
-/// path (MpUnreach for EVPN) is a follow-up — this PR only
-/// advertises new best paths.
+/// split-horizon / iBGP rules inside `route_update_evpn`. Pairs with
+/// `route_withdraw_evpn_to_peers` for the inverse direction.
 pub fn route_advertise_evpn_to_peers(
     rd: RouteDistinguisher,
     prefix: EvpnPrefix,
@@ -2297,6 +2374,11 @@ impl Bgp {
             ip: None,
         };
         let _ = self.local_rib.remove_evpn(rd, &prefix, 0, ORIGINATED_PEER);
+        // Tell every EVPN peer the route is gone. No best-path
+        // re-evaluation here — for a locally-originated route there
+        // is no other path that would replace it; the peers can
+        // figure it out when they see the MP_UNREACH.
+        route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
     }
 }
 


### PR DESCRIPTION
## Summary
Closes the withdraw path called out in PR #400's "out of scope". Removing a local MAC from a VXLAN-attached bridge now propagates to peers as an MP_UNREACH UPDATE rather than just dropping out of the local-RIB.

## End-to-end flow
```
kernel deletes MAC from bridge
  → RibRx::FdbDel
  → Bgp::evpn_withdraw_macip
      local_rib.evpn remove (PR #398) +
      route_withdraw_evpn_to_peers fan-out
  → per peer with (L2vpn, Evpn) Established:
       drop the matching entry from peer.cache_evpn so a queued
       advertise can't shadow the withdraw
  → route_withdraw_evpn builds UpdatePacket with
     MpUnreachAttr::Evpn(vec![route]) and ships via packet_tx
  → receiver removes from adj-RIB-in, re-runs best-path,
     route_evpn_export_selected sends Message::MacDel to RIB,
     FibHandle::mac_del clears the kernel FDB row.
```

## What lands

**bgp-packet**
- New `evpn_unreach_attr_emit` writes the full MP_UNREACH attribute (header + AFI=25 + SAFI=70 + NLRI list using the existing `EvpnRoute::nlri_emit` from PR #399).
- `MpUnreachAttr::attr_emit` gains arms for `Evpn(...)` and `EvpnEor` — EoR is just an empty NLRI list per RFC 4724 §2.
- One new round-trip test confirms the NLRI body bytes round-trip the same way through withdraw as through advertise.

**zebra-rs**
- `route_withdraw_evpn` — per-peer wire send, no caching (mirror of `route_withdraw_ipv4`).
- `route_withdraw_evpn_to_peers` — fan-out filtered by `(L2vpn, Evpn)` Established. Drops the matching entry from each peer's `cache_evpn` so a queued advertise can't shadow the withdraw.
- `evpn_route_from_prefix` — reconstructs an `EvpnRoute` from an `(rd, prefix)` pair without needing the inbound `BgpRib`. VNI is recovered from the Type-1 RD's trailing 2 bytes.
- `evpn_withdraw_macip` now calls `route_withdraw_evpn_to_peers` after the local-RIB removal.

## Conscious limits (follow-ups)
- VNI recovery assumes Type-1 (IPv4 + 2-byte) RD form, matching what `evpn_originate_macip` produces. Type-0 ASN-form RD would need different recovery logic.
- ESI hardcoded to zero on withdraw (single-homed only).
- No per-peer EVPN adj-RIB-out yet — withdraw fans to all EVPN peers regardless of whether the route was actually advertised. Harmless (receiver tolerates withdraw-of-unknown) but wasteful at scale.
- No debounce timer on withdraws — matches the IPv4 path; a burst of FDB removes produces a burst of MP_UNREACH UPDATEs.

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo test -p zebra-rs --bin zebra-rs` — **169/169 pass**
- [x] `RUSTFLAGS="-D warnings" cargo test -p bgp-packet --lib` — **57/57 pass** (+1 new round-trip)
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets` — clean
- [x] `cargo fmt --all`
- [ ] **Manual on a Linux host**: with two zebras peered iBGP and `advertise-all-vni true`, run a `bridge fdb add` then `bridge fdb del` cycle — `show bgp l2vpn evpn` on the receiver shows the route appearing then disappearing. tcpdump shows MP_REACH followed by MP_UNREACH for the same NLRI.

Generated with [Claude Code](https://claude.com/claude-code)