### PR TITLE
rib: sync pre-existing kernel FDB entries to BGP EVPN advertise

### DIFF
--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -479,6 +479,52 @@ impl Rib {
             .and_then(|link| link.vni)
     }
 
+    /// Re-emit `RibRx::FdbAdd` for every existing AF_BRIDGE entry on
+    /// `bridge_ifindex`. Called from `link_add` when a VXLAN device
+    /// gains a bridge master so MACs that were learned BEFORE the
+    /// VXLAN was wired in get re-evaluated and pushed to BGP.
+    ///
+    /// Without this, the operator's typical sequence — bridge ->
+    /// VXLAN -> enslave VXLAN -> enslave physical port -> traffic
+    /// flows -> MAC learned -> *operator wonders why BGP shows
+    /// nothing* — leaves data-plane-learned MACs invisible until
+    /// the kernel happens to re-learn them. Each successful re-emit
+    /// flows through `evpn_originate_macip` whose `update_evpn` is
+    /// idempotent (matches on `(ident, remote_id)`), so a benign
+    /// re-fire on already-known entries doesn't multiply the route.
+    pub fn rescan_fdb_for_bridge(&self, bridge_ifindex: u32) {
+        let Some(vni) = self.vni_for_bridge(bridge_ifindex) else {
+            return;
+        };
+        for (key, nbr) in self.neighbors.iter() {
+            let NeighborKey::Bridge {
+                ifindex,
+                mac,
+                vlan: _,
+            } = key
+            else {
+                continue;
+            };
+            // Match only entries whose slave port belongs to this
+            // bridge (either via the cached IFLA_MASTER on the slave
+            // link, or via NDA_MASTER on the FDB entry itself).
+            let slave_master = self.links.get(ifindex).and_then(|l| l.master);
+            let belongs_here =
+                slave_master == Some(bridge_ifindex) || nbr.master == Some(bridge_ifindex);
+            if !belongs_here {
+                continue;
+            }
+            let entry = FdbEntry {
+                vni,
+                mac: *mac,
+                ifindex: *ifindex,
+                bridge_ifindex,
+                flags: nbr.flags.bits(),
+            };
+            self.api_fdb_add(&entry);
+        }
+    }
+
     /// Resolve the device the kernel binds the seg6local action to,
     /// per behavior. End / uN / End.DT4 / End.DT6 are local-processing
     /// actions; all four ride on the sr0 dummy so the install can stay
@@ -677,6 +723,22 @@ impl Rib {
             for addr in link.addr6.iter() {
                 let msg = RibRx::AddrAdd(addr.clone());
                 tx.send(msg).unwrap();
+            }
+        }
+        // FDB dump. Replay every existing AF_BRIDGE neighbor that
+        // resolves to a known VNI. Without this, FDB entries learned
+        // during `fib_dump` — i.e. *before* BGP subscribed — would
+        // never reach the EVPN advertise path: `api_fdb_add` would
+        // have sent them into `self.redists` while `self.redists` was
+        // still empty. The typical cold-start order is fib_dump
+        // (populates `self.neighbors`) → BGP subscribe (this fn), so
+        // every entry needs an explicit replay here.
+        for (key, nbr) in self.neighbors.iter() {
+            if !matches!(key, NeighborKey::Bridge { .. }) {
+                continue;
+            }
+            if let Some(entry) = fdb_entry_from_neighbor(self, nbr) {
+                let _ = tx.send(RibRx::FdbAdd(entry));
             }
         }
         self.redists.push(tx.clone());
@@ -1202,21 +1264,31 @@ fn is_seg6local_entry(entry: &RibEntry) -> bool {
 /// Returns `None` when the neighbor isn't a publishable FDB row:
 ///   - non-`AF_BRIDGE` family (covered by `RibRx::FdbAdd` only)
 ///   - no MAC address attached
-///   - no master ifindex (entry isn't bridged anywhere)
+///   - the slave port has no resolvable bridge master
 ///   - the master bridge has no VXLAN slave with a known VNI — until
 ///     the bridge is wired to VXLAN, an EVPN advertise consumer
 ///     wouldn't have anywhere to put the route, so dropping early
 ///     keeps the message stream tidy.
 ///
-/// All four `Option::?` paths return early so the only published
-/// entries are exactly those an EVPN Type-2 advertise can use.
+/// **Bridge resolution is two-tier**: try `NDA_MASTER` from the FDB
+/// message first (set by userland tools — e.g. `bridge fdb add ...
+/// master <br>` — and by some sticky/permanent path), then fall back
+/// to the slave port's `IFLA_MASTER` (which we cached when the link
+/// came up). Without the fallback, data-plane-learned MACs that the
+/// kernel broadcasts WITHOUT `NDA_MASTER` are silently dropped here
+/// — matched user-visible bug: `bridge fdb show` lists the MAC but
+/// `show ip bgp l2vpn evpn` doesn't, because the operator-added MACs
+/// (which carry NDA_MASTER) succeed and the data-plane-learned ones
+/// don't.
 fn fdb_entry_from_neighbor(rib: &Rib, nbr: &FibNeighbor) -> Option<FdbEntry> {
     use netlink_packet_route::AddressFamily;
     if nbr.family != AddressFamily::Bridge {
         return None;
     }
     let mac = nbr.lladdr?;
-    let bridge_ifindex = nbr.master?;
+    let bridge_ifindex = nbr
+        .master
+        .or_else(|| rib.links.get(&nbr.ifindex).and_then(|link| link.master))?;
     let vni = rib.vni_for_bridge(bridge_ifindex)?;
     Some(FdbEntry {
         vni,

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -416,6 +416,21 @@ pub fn link_addr_del(link: &mut Link, addr: LinkAddr) -> Option<()> {
 
 impl Rib {
     pub async fn link_add(&mut self, fib_link: FibLink) {
+        // Capture pre-state so we can detect a VXLAN-bridge association
+        // gaining valid `(master, vni)` and trigger an FDB rescan. The
+        // common case is operator-driven sequence:
+        //   1. ip link add br50 type bridge      (no master/vni)
+        //   2. ip link add vxlan100 type vxlan id 100   (vni set, no master)
+        //   3. ip link set vxlan100 master br50  (master gained — THIS PATH)
+        // Without rescan, FDB entries already learned on `br50` between
+        // steps 1 and 3 would never reach the EVPN advertise path until
+        // they re-learn; with rescan we re-emit `RibRx::FdbAdd` for them.
+        let ifindex = fib_link.index;
+        let prev_evpn_bridge: Option<u32> = self
+            .links
+            .get(&ifindex)
+            .and_then(|l| if l.vni.is_some() { l.master } else { None });
+
         if let Some(link) = self.links.get_mut(&fib_link.index) {
             // When link already exists, we are going to check interface up &
             // down event handling.
@@ -447,6 +462,13 @@ impl Rib {
                     ifindex: link.index,
                 });
             }
+            // Master / VNI can change on an existing link too — most
+            // commonly when a VXLAN device is enslaved or re-enslaved
+            // via `ip link set ... master <br>` after creation. Track
+            // them so `vni_for_bridge` reflects the current state and
+            // FDB resolution gets the right bridge.
+            link.master = fib_link.master;
+            link.vni = fib_link.vni;
         } else {
             let link = Link::from(fib_link);
             let _ = sysctl_mpls_enable(&link.name);
@@ -464,6 +486,21 @@ impl Rib {
             if !link.is_up() {
                 self.make_link_up(link.index).await;
             }
+        }
+
+        // Did this link just gain (or change) its EVPN bridge
+        // association? If so, walk the neighbor table and re-emit
+        // `RibRx::FdbAdd` for every AF_BRIDGE entry on that bridge.
+        // BGP's `evpn_originate_macip` is idempotent (update_evpn
+        // replaces same ident+remote_id) so duplicate fires are safe.
+        let now_evpn_bridge: Option<u32> = self
+            .links
+            .get(&ifindex)
+            .and_then(|l| if l.vni.is_some() { l.master } else { None });
+        if let Some(bridge) = now_evpn_bridge
+            && prev_evpn_bridge != Some(bridge)
+        {
+            self.rescan_fdb_for_bridge(bridge);
         }
     }
 


### PR DESCRIPTION
## Summary

Three gaps prevented the operator's local kernel FDB from being fully visible in `show ip bgp l2vpn evpn`:

1. **`fdb_entry_from_neighbor` required `NDA_MASTER`** — data-plane learns arrive without it (only operator-added `bridge fdb add ... master <br>` carries it). Fall back to the slave port's cached `IFLA_MASTER` so dynamic learns resolve to a bridge.

2. **MACs learned before VXLAN enslave were invisible forever** — `link_add` now propagates `master`/`vni` updates on existing links and triggers `rescan_fdb_for_bridge` when a VXLAN gains a bridge-master association. `update_evpn` is idempotent so re-fires don't duplicate routes.

3. **`Rib::subscribe` skipped FDB on initial replay** — at cold start, `fib_dump` populates `self.neighbors` *before* BGP subscribes, so `api_fdb_add` writes to a still-empty `self.redists` and the entries are lost. Subscribe now replays AF_BRIDGE neighbors that resolve to a known VNI, mirroring the live-ingest path.

## Test plan

- [x] `cargo fmt --all`
- [x] `RUSTFLAGS="-D warnings" cargo build -p zebra-rs --bin zebra-rs`
- [x] `RUSTFLAGS="-D warnings" cargo test -p zebra-rs --bin zebra-rs` (169 passing)
- [x] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets`
- [ ] Verify on live setup: data-plane-learned MACs visible in `show ip bgp l2vpn evpn` after cold-start
- [ ] Verify on live setup: MAC learned before VXLAN enslave appears after enslave

Generated with [Claude Code](https://claude.com/claude-code)