### PR TITLE
bgp: cache local FDB to fix cold-boot race with advertise-all-vni

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -6,6 +6,7 @@ use crate::bgp::InOut;
 use crate::config::{Args, ConfigOp};
 use crate::policy;
 use crate::policy::com_list::*;
+use crate::rib::api::FdbEntry;
 
 use super::auth::{AoConfig, CryptoAlgorithm, Key};
 use super::peer::BgpTop;
@@ -321,11 +322,27 @@ fn config_advertise_all_vni(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
     if afi_safi.afi != Afi::L2vpn || afi_safi.safi != Safi::Evpn {
         return None;
     }
-    if op.is_set() {
-        let enabled = args.boolean()?;
-        bgp.advertise_all_vni = enabled;
-    } else {
-        bgp.advertise_all_vni = false;
+    let was_enabled = bgp.advertise_all_vni;
+    let enabled = if op.is_set() { args.boolean()? } else { false };
+    bgp.advertise_all_vni = enabled;
+
+    // Replay the local FDB cache across the gate transition. The
+    // false→true case fixes the cold-boot race: fib_dump's FdbAdd
+    // events arrive on `rib_rx` before `config.load_config` lands the
+    // advertise-all-vni Set on `cm.rx`, so on the live ingest path
+    // every entry was dropped at the gate inside `evpn_originate_macip`.
+    // The true→false case mirrors what an operator-driven runtime
+    // toggle should do — clear the originated routes from peers.
+    if !was_enabled && enabled {
+        let entries: Vec<FdbEntry> = bgp.local_fdb.values().cloned().collect();
+        for entry in entries {
+            bgp.evpn_originate_macip(&entry);
+        }
+    } else if was_enabled && !enabled {
+        let entries: Vec<FdbEntry> = bgp.local_fdb.values().cloned().collect();
+        for entry in entries {
+            bgp.evpn_withdraw_macip(&entry);
+        }
     }
     Some(())
 }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -11,10 +11,10 @@ use crate::config::{
 use crate::context::Task;
 use crate::policy::com_list::CommunityListMap;
 use crate::policy::{self, PolicyRxChannel};
-use crate::rib;
-use crate::rib::api::{RibRx, RibRxChannel};
+use crate::rib::api::{FdbEntry, RibRx, RibRxChannel};
+use crate::rib::{self, MacAddr};
 use socket2::{Domain, Protocol, Socket, Type};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::net::{Ipv4Addr, SocketAddr};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc::{self, Sender, UnboundedReceiver, UnboundedSender};
@@ -66,6 +66,19 @@ pub struct Bgp {
     /// The Rib::neighbors -> EvpnPrefix::MacIp pipeline that reads
     /// this lands separately.
     pub advertise_all_vni: bool,
+    /// Local bridge FDB shadow keyed by `(vni, mac)`. Populated from
+    /// every `RibRx::FdbAdd`, removed on `RibRx::FdbDel`. We need
+    /// durable state (not just one-shot event handling) because the
+    /// FDB events from `Rib::subscribe` / `fib_dump` race with the
+    /// config commit that flips `advertise_all_vni` to true: at cold
+    /// start, fib_dump's netlink walk almost always finishes before
+    /// `config.load_config` does, so the FdbAdd messages arrive while
+    /// the gate is still false and `evpn_originate_macip` drops them.
+    /// With the shadow, the config callback can replay every cached
+    /// entry on the false→true transition (and withdraw on true→false),
+    /// so origination becomes deterministic regardless of which
+    /// channel wins the boot race.
+    pub local_fdb: BTreeMap<(u32, MacAddr), FdbEntry>,
     /// Configured hostname for the local BGP speaker. Advertised in
     /// the FQDN capability (capability code 73). When None, falls back
     /// to the OS hostname; if that also fails, no FQDN capability is
@@ -133,6 +146,7 @@ impl Bgp {
             asn: 0,
             router_id: Ipv4Addr::UNSPECIFIED,
             advertise_all_vni: false,
+            local_fdb: BTreeMap::new(),
             hostname: None,
             peers: PeerMap::new(),
             tx,
@@ -430,12 +444,13 @@ impl Bgp {
                 self.set_router_id(router_id);
             }
             RibRx::FdbAdd(entry) => {
-                // Local bridge FDB learn. EVPN advertise-all-vni
-                // originates a Type-2 (MAC/IP) route into the local-
-                // RIB; wire transmission lands in a follow-up.
+                // Cache durably so we can replay on `advertise_all_vni`
+                // false→true transitions — see `local_fdb` doc.
+                self.local_fdb.insert((entry.vni, entry.mac), entry.clone());
                 self.evpn_originate_macip(&entry);
             }
             RibRx::FdbDel(entry) => {
+                self.local_fdb.remove(&(entry.vni, entry.mac));
                 self.evpn_withdraw_macip(&entry);
             }
             _ => {


### PR DESCRIPTION
## Summary

Fixes the cold-boot race where locally-known kernel FDB entries never appear in `show ip bgp l2vpn evpn` because the FdbAdd events arrive on BGP's `rib_rx` before the config commit lands the `advertise-all-vni` Set on `cm.rx`. With the gate still false, `evpn_originate_macip` silently drops every entry — and the events are gone by the time the gate flips.

User-visible symptom: `show l2 neighbor` shows every locally-learned MAC, but `show ip bgp l2vpn evpn` contains zero locally-originated Type-2 routes (only what peers advertised over the established session).

## Changes

- Add `Bgp::local_fdb: BTreeMap<(vni, mac), FdbEntry>` — a durable shadow of every FdbAdd/FdbDel from RIB.
- `process_rib_msg` inserts on FdbAdd, removes on FdbDel. Unconditionally, before the gated `evpn_originate_macip`/`evpn_withdraw_macip` calls.
- `config_advertise_all_vni` detects gate transitions and replays the cache: false→true originates every cached entry; true→false withdraws.

This makes origination deterministic regardless of which channel wins the boot race, and as a bonus handles operator-driven runtime toggling of `advertise-all-vni` correctly.

## Test plan

- [x] `cargo fmt --all`
- [x] `RUSTFLAGS=\"-D warnings\" cargo build -p zebra-rs --bin zebra-rs`
- [x] `RUSTFLAGS=\"-D warnings\" cargo test -p zebra-rs --bin zebra-rs` (169 passed)
- [x] `RUSTFLAGS=\"-D warnings\" cargo clippy --workspace --all-targets`
- [ ] Manual: cold-boot a node with `advertise-all-vni true` and pre-existing kernel FDB on the bridge → `show ip bgp l2vpn evpn` shows local Type-2 routes for every locally-learned MAC.
- [ ] Manual: at runtime, toggle `advertise-all-vni` true→false → local Type-2 routes withdrawn from peers; toggle false→true → routes re-originated.

Generated with [Claude Code](https://claude.com/claude-code)