### PR TITLE
bgp: add FRR-style update-source leaf under neighbor

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -874,6 +874,12 @@ impl Bgp {
         self.callback_peer("/local-identifier", config_local_identifier);
         self.callback_peer("/transport/passive-mode", config_transport_passive);
         self.callback_peer("/transport/local-address", config_transport_local_address);
+        // FRR-style flat alias from zebra-bgp-transport.yang. Same
+        // backing field (`peer.config.transport.update_source`) and
+        // same `peer_connect` bind site as the IETF `local-address`
+        // path above; either CLI form is accepted, both lower onto
+        // the same runtime state.
+        self.callback_peer("/update-source", config_transport_local_address);
         self.callback_peer("/tcp-md5/password", config_peer_tcp_md5_password);
         self.callback_peer("/tcp-md5/encoding", config_peer_tcp_md5_encoding);
         self.callback_peer("/tcp-ao/key-chain", config_peer_tcp_ao_key_chain);

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -40,6 +40,10 @@ module config {
     prefix zbe;
   }
 
+  import zebra-bgp-transport {
+    prefix zbt;
+  }
+
   import openconfig-isis-types {
     prefix isis;
   }

--- a/zebra-rs/yang/zebra-bgp-transport.yang
+++ b/zebra-rs/yang/zebra-bgp-transport.yang
@@ -1,0 +1,101 @@
+module zebra-bgp-transport {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-transport";
+  prefix "zbt";
+
+  import ietf-inet-types {
+    prefix inet;
+    reference "RFC 6991: Common YANG Data Types.";
+  }
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "FRR-style flat per-neighbor transport extensions on the BGP
+     candidate-config tree.
+
+     Adds `update-source` directly under each BGP neighbor so the
+     CLI shape matches FRR / IOS:
+
+       router bgp {
+         neighbor 10.0.0.5 {
+           peer-as 65501;
+           update-source 10.0.0.1;
+         }
+       }
+
+     Functionally equivalent to the IETF YANG path
+     `neighbor/transport/local-address` (ietf-bgp-common@2023-07-05);
+     both lower onto the same runtime field
+     (`peer.config.transport.update_source`) and the same TCP-bind
+     site in `peer_connect`. Operators using the FRR vocabulary get
+     the flat form without giving up the IETF tree.";
+
+  revision 2026-05-05 {
+    description "Initial revision.";
+    reference "FRR `neighbor X update-source`; Cisco IOS equivalent.";
+  }
+
+  grouping bgp-neighbor-transport-extension {
+    description
+      "FRR-style transport leaves on a BGP neighbor.";
+
+    leaf update-source {
+      ext:help "Source address to bind for outbound BGP TCP connect";
+      type union {
+        type inet:ipv4-address;
+        type inet:ipv6-address;
+      }
+      description
+        "Local IP address (IPv4 or IPv6) to bind before the outbound
+         BGP TCP connect to this neighbor. The address family must
+         match the peer's address family. When absent, the kernel
+         picks the source via the routing table.
+
+         Equivalent to `neighbor X update-source` in FRR / Cisco
+         IOS, and to `neighbor/transport/local-address` in
+         ietf-bgp-common.";
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Attach update-source to BGP neighbors in the candidate-set
+       subtree.";
+    uses bgp-neighbor-transport-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp neighbor X update-source` is path-valid.";
+    uses bgp-neighbor-transport-extension;
+  }
+}


### PR DESCRIPTION
## Summary

Adds an `update-source` leaf directly under each BGP neighbor, with a union of `inet:ipv4-address` and `inet:ipv6-address`, so the operator can write the FRR/IOS-style flat form:

\`\`\`
router {
  bgp {
    neighbor 10.0.0.5 {
      peer-as 65501;
      update-source 10.0.0.1;
    }
  }
}
\`\`\`

When set, the outbound TCP connect to the peer binds to the configured local address before issuing `connect()`. Address family of the source must match the peer; mismatches are rejected with `EINVAL`.

## What changed

- **New YANG module** `zebra-rs/yang/zebra-bgp-transport.yang` — augments `update-source` under `bgp:neighbor` (both the set and delete subtrees), following the same pattern as `zebra-bgp-auth.yang` / `zebra-bgp-evpn.yang`.
- **config.yang** imports the new module.
- **bgp/config.rs** registers the existing `config_transport_local_address` handler at the new path. Same backing field (`peer.config.transport.update_source`) and same `peer_connect` bind site, no new logic.

The IETF path `neighbor/transport/local-address` (from `ietf-bgp-common@2023-07-05`) stays in place and lowers onto the same runtime state — either vocabulary is accepted.

## Test plan

- [x] `cargo fmt --all`
- [x] `RUSTFLAGS=\"-D warnings\" cargo build -p zebra-rs --bin zebra-rs`
- [x] `RUSTFLAGS=\"-D warnings\" cargo test -p zebra-rs --bin zebra-rs` (169 passed)
- [x] `RUSTFLAGS=\"-D warnings\" cargo clippy --workspace --all-targets`
- [x] Daemon smoke-start with `-y zebra-rs/yang` confirms the new YANG module loads cleanly (binary reaches `zebra-rs started`).
- [ ] Manual: configure `neighbor 10.0.0.5 update-source 10.0.0.1` on a node with multiple v4 addresses → tcpdump on outbound BGP confirms source IP is the bound address.
- [ ] Manual: configure mismatched address families (peer is v4, source is v6) → connect fails with `update-source address family does not match peer`.
- [ ] Manual: equivalent IETF form `neighbor 10.0.0.5 transport local-address 10.0.0.1` continues to work.

Generated with [Claude Code](https://claude.com/claude-code)