### PR TITLE
fib: register VXLAN by kernel VNI; skip mac_add when unregistered

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -1639,9 +1639,24 @@ impl FibHandle {
         _seq: u32,
         esi: Option<[u8; 10]>,
     ) {
-        // Resolve VNI to VXLAN interface index using the registered mapping
-        // If not found, use VNI as fallback (for testing/simple configs)
-        let vxlan_ifindex = self.vni_ifindex_map.get(&vni).copied().unwrap_or(vni);
+        // Resolve VNI to VXLAN interface index via the map populated
+        // by `register_vxlan_ifindex` when the VXLAN device is observed
+        // on netlink. If the map has no entry, this VNI isn't
+        // configured on the local node — skip rather than fall back
+        // to using the VNI itself as ifindex. The previous
+        // `unwrap_or(vni)` shipped install requests to whatever
+        // unrelated interface happened to have that ifindex (e.g.
+        // VNI 550 → ifindex 550 → enp0s5), creating bogus FDB rows
+        // on the wrong device. See sibling `mdb_add` for the same
+        // pattern.
+        let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
+            tracing::debug!(
+                "mac_add: no local VXLAN for VNI {} — skipping (mac {})",
+                vni,
+                mac
+            );
+            return;
+        };
 
         // Build bridge FDB entry using rtnetlink neighbours API
         use netlink_packet_route::neighbour::{NeighbourAttribute, NeighbourMessage};
@@ -1726,8 +1741,19 @@ impl FibHandle {
 
     /// Delete EVPN MAC entry from bridge FDB
     pub async fn mac_del(&self, vni: u32, mac: &MacAddr) {
-        // Resolve VNI to VXLAN interface index using the registered mapping
-        let vxlan_ifindex = self.vni_ifindex_map.get(&vni).copied().unwrap_or(vni);
+        // Mirror `mac_add` — skip when no local VXLAN registered for
+        // this VNI. With `mac_add` skipping installs in the same case,
+        // there's nothing in the kernel to delete; the old
+        // `unwrap_or(vni)` would have issued a stray RTM_DELNEIGH
+        // against a random interface.
+        let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
+            tracing::debug!(
+                "mac_del: no local VXLAN for VNI {} — skipping (mac {})",
+                vni,
+                mac
+            );
+            return;
+        };
 
         // Build delete request via netlink
         use netlink_packet_route::neighbour::{NeighbourAttribute, NeighbourMessage};

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -476,10 +476,18 @@ impl Rib {
             self.api_link_add(&link);
             self.links.insert(link.index, link.clone());
 
-            // Register VXLAN interface with FIB for MAC FDB operations
-            if let Some(vxlan) = self.vxlan.get(&link.name)
-                && let Some(vni) = vxlan.vni
-            {
+            // Register VXLAN interface with FIB for MAC/MDB FDB
+            // operations. The VNI comes from the kernel's
+            // `IFLA_INFO_DATA / VXLAN / IFLA_VXLAN_ID` attribute,
+            // captured into `link.vni` by `link_from_msg`. The
+            // previous gate required a matching entry in
+            // `self.vxlan` (zebra-rs's own `/vxlan` config tree),
+            // so VXLANs created externally with `ip link add` —
+            // the typical lab setup — were never registered, and
+            // `mac_add`'s VNI→ifindex lookup later fell back to
+            // sending kernel installs against a random interface
+            // that happened to have ifindex == VNI.
+            if let Some(vni) = link.vni {
                 self.fib_handle.register_vxlan_ifindex(vni, link.index);
             }
 
@@ -505,10 +513,9 @@ impl Rib {
     }
 
     pub fn link_delete(&mut self, oslink: FibLink) {
-        // Unregister VXLAN interface from FIB if applicable
-        if let Some(vxlan) = self.vxlan.get(&oslink.name)
-            && let Some(vni) = vxlan.vni
-        {
+        // Unregister via the kernel-derived VNI on the netlink
+        // message (mirrors the registration trigger in `link_add`).
+        if let Some(vni) = oslink.vni {
             self.fib_handle.unregister_vxlan_ifindex(vni);
         }
         self.links.remove(&oslink.index);


### PR DESCRIPTION
## Summary

User reported a remote MAC from BGP-EVPN Type-2 landing on the wrong interface:

\`\`\`
$ bridge fdb show | grep '00:1c:42:5f:0b:08'
00:1c:42:5f:0b:08 dev enp0s5 self permanent     # expected: dev vxlan550 dst 10.0.0.5
\`\`\`

Two compounding bugs:

1. **\`mac_add\` / \`mac_del\` defective fallback** — \`unwrap_or(vni)\` shipped install requests with the VNI value as ifindex, so VNI 550 → ifindex 550 → some random interface (\`enp0s5\` here). Same pattern as the \`mdb_add\` bug fixed in PR #403; same fix: skip when no local VXLAN registered for the VNI.

2. **VXLAN registration gated on \`/vxlan\` config tree** — \`link_add\` only called \`register_vxlan_ifindex\` when zebra-rs had a matching \`/vxlan\` config entry. But \`link.vni\` is already extracted from the kernel's netlink message (\`InfoVxlan::Id\`). For an externally-created VXLAN (typical lab setup with \`ip link add ... type vxlan ...\`), the config tree is empty, registration never fires, and \`vni_ifindex_map\` stays empty — which then triggers bug 1.

Drive registration off \`link.vni\` directly so externally-created VXLANs register correctly. \`link_delete\` updated symmetrically.

## Changes

- \`fib/netlink/handle.rs\` — \`mac_add\` and \`mac_del\` skip when no \`vni_ifindex_map\` entry exists.
- \`rib/link.rs\` — \`link_add\` registers based on kernel-derived \`link.vni\`; \`link_delete\` unregisters based on \`oslink.vni\`.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo build -p zebra-rs --bin zebra-rs\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo test -p zebra-rs --bin zebra-rs\` (169 passed)
- [x] \`RUSTFLAGS=\"-D warnings\" cargo clippy --workspace --all-targets\`
- [ ] Manual: with \`vxlan550\` created externally and the BGP session up, \`bridge fdb show dev vxlan550\` lists peer-advertised MACs with \`dst <peer-VTEP>\` and \`extern_learn\`. \`enp0s5\` (or whatever interface used to receive the bogus install) is clean.
- [ ] Manual: peer advertises Type-2 for a VNI not configured locally → no \`MAC add error\` log, no FDB pollution on unrelated interfaces.

Generated with [Claude Code](https://claude.com/claude-code)