### PR TITLE
rib: reconcile VXLAN VNI registration on every link transition

### DIFF
--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -430,6 +430,14 @@ impl Rib {
             .links
             .get(&ifindex)
             .and_then(|l| if l.vni.is_some() { l.master } else { None });
+        // Pre-update VNI snapshot so the existing-link path can fire
+        // `register_vxlan_ifindex` / `unregister_vxlan_ifindex` on
+        // transitions. Without this, a VXLAN whose RTM_NEWLINK arrives
+        // a second time (e.g. partial first emission, then a full one
+        // carrying `IFLA_VXLAN_ID`) only gets its VNI cached on `Link`
+        // but never registered with FIB — so subsequent `mac_add`
+        // calls find no entry in `vni_ifindex_map` and silently skip.
+        let prev_vni: Option<u32> = self.links.get(&ifindex).and_then(|l| l.vni);
 
         if let Some(link) = self.links.get_mut(&fib_link.index) {
             // When link already exists, we are going to check interface up &
@@ -476,23 +484,36 @@ impl Rib {
             self.api_link_add(&link);
             self.links.insert(link.index, link.clone());
 
-            // Register VXLAN interface with FIB for MAC/MDB FDB
-            // operations. The VNI comes from the kernel's
-            // `IFLA_INFO_DATA / VXLAN / IFLA_VXLAN_ID` attribute,
-            // captured into `link.vni` by `link_from_msg`. The
-            // previous gate required a matching entry in
-            // `self.vxlan` (zebra-rs's own `/vxlan` config tree),
-            // so VXLANs created externally with `ip link add` —
-            // the typical lab setup — were never registered, and
-            // `mac_add`'s VNI→ifindex lookup later fell back to
-            // sending kernel installs against a random interface
-            // that happened to have ifindex == VNI.
-            if let Some(vni) = link.vni {
-                self.fib_handle.register_vxlan_ifindex(vni, link.index);
-            }
+            // Note: VXLAN VNI registration happens in the unified
+            // post-block reconciliation below (covers both new-link
+            // and existing-link paths uniformly).
 
             if !link.is_up() {
                 self.make_link_up(link.index).await;
+            }
+        }
+
+        // Reconcile FIB's VNI→ifindex map across (prev_vni → now_vni)
+        // transitions for both branches uniformly:
+        //   None    → Some(n): register (new VXLAN, or pre-existing
+        //                      link gained its VXLAN ID)
+        //   Some(m) → Some(n), m ≠ n: unregister m, register n
+        //   Some(n) → None: unregister n (rare — kernel doesn't
+        //                   normally strip the VNI from a live VXLAN)
+        //   unchanged: no-op
+        // Doing this post-block (rather than only in the new-link
+        // branch) is what fixes the case where RTM_NEWLINK is
+        // re-emitted with `IFLA_VXLAN_ID` after the link was first
+        // observed without it — without reconciliation, the VNI
+        // would land on `Link::vni` but never reach `vni_ifindex_map`,
+        // and `mac_add` would silently skip every install.
+        let now_vni: Option<u32> = self.links.get(&ifindex).and_then(|l| l.vni);
+        if prev_vni != now_vni {
+            if let Some(prev) = prev_vni {
+                self.fib_handle.unregister_vxlan_ifindex(prev);
+            }
+            if let Some(new) = now_vni {
+                self.fib_handle.register_vxlan_ifindex(new, ifindex);
             }
         }
 


### PR DESCRIPTION
## Summary

PR #408 moved VXLAN registration to use the kernel-derived \`link.vni\` (so externally-created VXLANs get registered without needing a matching zebra-rs \`/vxlan\` config entry). But the registration call only fired in the **new-link** branch of \`link_add\`. RTM_NEWLINK can re-emit for the same VXLAN device — kernel does it on attribute changes, on enslave, and zebra-rs's own \`/vxlan\` config callbacks trigger it — and the second emission falls through the **existing-link** branch, which updates \`link.vni\` on the cached entry but never calls \`register_vxlan_ifindex\`. Net effect: \`vni_ifindex_map[vni]\` stays empty, and \`mac_add\` (which after #408 skips when no mapping exists) drops every install.

User-visible: BGP-advertised remote MACs accepted into the local Loc-RIB (\`show ip bgp l2vpn evpn\` lists them), but \`bridge fdb show\` is empty for them.

## Fix

Move registration out of the new-link branch and into a unified post-block reconciliation that fires for both branches by comparing pre- vs post-update VNI:

- \`None    → Some(n)\` : register
- \`Some(m) → Some(n)\`, m ≠ n : unregister m, register n
- \`Some(n) → None\`    : unregister n
- unchanged : no-op

Pre-state captured before the branch dispatch. Also tightens correctness for VNI-rebind scenarios that the old code couldn't express at all.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo build -p zebra-rs --bin zebra-rs\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo test -p zebra-rs --bin zebra-rs\` (169 passed)
- [x] \`RUSTFLAGS=\"-D warnings\" cargo clippy --workspace --all-targets\`
- [ ] Manual: bring up a VXLAN externally (\`ip link add vxlan550 type vxlan id 550 ...\`), restart zebra-rs, verify \`[FIB] Registered VXLAN VNI 550 with ifindex N\` log line.
- [ ] Manual: peer advertises Type-2 for VNI 550 → \`bridge fdb show dev vxlan550\` lists the MAC with \`dst <peer-VTEP> self extern_learn\`.

Generated with [Claude Code](https://claude.com/claude-code)