### PR TITLE
bgp/fib: fix EVPN remote MAC install end-to-end + diagnostics

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1175,16 +1175,23 @@ pub fn route_rtcv4_sync(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
 fn extract_vni_from_attr(attr: &BgpAttr) -> Option<u32> {
     if let Some(ecom) = &attr.ecom {
         for ec in &ecom.0 {
-            // RFC 4360: Route Target Type is high_type 0x00, low_type 0x02
+            // RFC 4360 Two-Octet AS Specific Route Target: high 0x00,
+            // low 0x02. Wire layout of the 6-byte value:
+            //   val[0..2] = Global Administrator (2-byte ASN)
+            //   val[2..6] = Local Administrator (4 bytes)
+            // RFC 8365 §5.1.2.4 places the VNI in the *lower 3 bytes*
+            // of the 4-byte Local Administrator — i.e. val[3..6]. The
+            // earlier code read val[2..5] which is offset by one byte
+            // and grabbed the high (always-zero for ≤24-bit VNIs)
+            // byte, producing values 256× too small. For RT 65501:550
+            // the buggy read returned 2; for any 24-bit VNI < 0x100
+            // it returned 0 and skipped the route entirely.
             if ec.high_type == 0x00 && ec.low_type == 0x02 {
-                // RT value: [2 bytes ASN][4 bytes target]
-                // VNI is lower 3 bytes of the 4-byte target value
-                // Extract from bytes [2:5] (skip 2-byte ASN)
                 let vni =
-                    ((ec.val[2] as u32) << 16) | ((ec.val[3] as u32) << 8) | (ec.val[4] as u32);
+                    ((ec.val[3] as u32) << 16) | ((ec.val[4] as u32) << 8) | (ec.val[5] as u32);
 
                 if vni > 0 && vni < 0x1000000 {
-                    eprintln!("[BGP] Extracted VNI {} from Route Target (RFC 8365)", vni);
+                    tracing::info!("extract_vni_from_attr: RT yields VNI {}", vni);
                     return Some(vni);
                 }
             }
@@ -1234,12 +1241,21 @@ fn extract_mac_mobility_seq(attr: &BgpAttr) -> u32 {
     0
 }
 
-/// Extract tunnel endpoint from BgpRib nexthop
+/// Extract the remote VTEP IP for a received EVPN route. The VTEP
+/// is the BGP nexthop, but EVPN routes carry it in
+/// `BgpAttr::nexthop` as `BgpNexthop::Evpn(IpAddr)` — populated from
+/// the MP_REACH_NLRI nexthop field on receive (`bgp/route.rs:960`).
+///
+/// `BgpRib::nexthop` is the VPNv4-specific `Vpnv4Nexthop` slot and
+/// is always None for EVPN; the previous code read that field and
+/// produced `tunnel_endpoint = None` for every received Type-2,
+/// which made `mac_add` build an FDB row with no NDA_DST and the
+/// kernel rejected the install with EINVAL.
 fn extract_tunnel_endpoint(rib: &BgpRib) -> Option<IpAddr> {
-    rib.nexthop.as_ref().map(|nh| {
-        // Vpnv4Nexthop has nhop field (not nexthop) containing the VTEP IP
-        IpAddr::V4(nh.nhop)
-    })
+    match rib.attr.nexthop.as_ref()? {
+        BgpNexthop::Evpn(addr) => Some(*addr),
+        _ => None,
+    }
 }
 
 /// Export selected EVPN MAC entry to RIB for kernel installation

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -1650,13 +1650,23 @@ impl FibHandle {
         // on the wrong device. See sibling `mdb_add` for the same
         // pattern.
         let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
-            tracing::debug!(
+            tracing::info!(
                 "mac_add: no local VXLAN for VNI {} — skipping (mac {})",
                 vni,
                 mac
             );
             return;
         };
+
+        tracing::info!(
+            "mac_add: VNI {} mac {} ifindex {} dst {}",
+            vni,
+            mac,
+            vxlan_ifindex,
+            tunnel_endpoint
+                .map(|e| e.to_string())
+                .unwrap_or_else(|| "-".into()),
+        );
 
         // Build bridge FDB entry using rtnetlink neighbours API
         use netlink_packet_route::neighbour::{NeighbourAttribute, NeighbourMessage};
@@ -1711,10 +1721,14 @@ impl FibHandle {
             tracing::info!("mac_add: ESI type {} for MAC {}", esi_val[0], mac);
         }
 
-        // Build netlink request
+        // Build netlink request. `NLM_F_CREATE | NLM_F_REPLACE` is
+        // upsert semantics — needed because `NLM_F_REPLACE` alone
+        // requires the entry to already exist; on first install
+        // (the common case for a remote MAC just learned via BGP)
+        // the kernel returns ENOENT and the row never lands.
         use netlink_packet_route::RouteNetlinkMessage;
         let mut req = NetlinkMessage::from(RouteNetlinkMessage::NewNeighbour(msg));
-        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_REPLACE;
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE;
 
         // Send request
         let mut response = self.handle.clone().request(req).unwrap();
@@ -1747,7 +1761,7 @@ impl FibHandle {
         // `unwrap_or(vni)` would have issued a stray RTM_DELNEIGH
         // against a random interface.
         let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
-            tracing::debug!(
+            tracing::info!(
                 "mac_del: no local VXLAN for VNI {} — skipping (mac {})",
                 vni,
                 mac
@@ -1755,12 +1769,21 @@ impl FibHandle {
             return;
         };
 
+        tracing::info!("mac_del: VNI {} mac {} ifindex {}", vni, mac, vxlan_ifindex,);
+
         // Build delete request via netlink
         use netlink_packet_route::neighbour::{NeighbourAttribute, NeighbourMessage};
 
         let mut msg = NeighbourMessage::default();
         msg.header.family = AddressFamily::Bridge;
         msg.header.ifindex = vxlan_ifindex;
+        // `mac_add` installs with NTF_SELF (0x02) so the row lives in
+        // the VXLAN device's own FDB, not the bridge's master FDB.
+        // The delete must carry the same flag or the kernel scans the
+        // wrong table and returns ENOENT. iproute2's `bridge fdb del`
+        // defaults to NTF_SELF for the same reason.
+        use netlink_packet_route::neighbour::NeighbourFlags;
+        msg.header.flags = NeighbourFlags::from_bits_retain(0x02);
 
         // Add MAC address for identification
         msg.attributes
@@ -1821,13 +1844,21 @@ impl FibHandle {
         // return EINVAL for ifindex 0 anyway, producing log spam for
         // routes whose presence wasn't actionable here).
         let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
-            tracing::debug!(
+            tracing::info!(
                 "mdb_add: no local VXLAN for VNI {} — skipping (group {})",
                 vni,
                 group
             );
             return;
         };
+
+        tracing::info!(
+            "mdb_add: VNI {} group {} source {} ifindex {}",
+            vni,
+            group,
+            source.map(|s| s.to_string()).unwrap_or_else(|| "-".into()),
+            vxlan_ifindex,
+        );
 
         let mut msg = MdbMessage::default();
         msg.header.family = AddressFamily::Bridge;
@@ -1885,13 +1916,21 @@ impl FibHandle {
         // Mirror `mdb_add` — caller's `ifindex` is a sentinel; resolve
         // via the registered map and skip when no local VXLAN exists.
         let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
-            tracing::debug!(
+            tracing::info!(
                 "mdb_del: no local VXLAN for VNI {} — skipping (group {})",
                 vni,
                 group
             );
             return;
         };
+
+        tracing::info!(
+            "mdb_del: VNI {} group {} source {} ifindex {}",
+            vni,
+            group,
+            source.map(|s| s.to_string()).unwrap_or_else(|| "-".into()),
+            vxlan_ifindex,
+        );
 
         let mut msg = MdbMessage::default();
         msg.header.family = AddressFamily::Bridge;

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -416,6 +416,13 @@ pub fn link_addr_del(link: &mut Link, addr: LinkAddr) -> Option<()> {
 
 impl Rib {
     pub async fn link_add(&mut self, fib_link: FibLink) {
+        tracing::info!(
+            "link_add: ifindex {} name {} vni {:?} master {:?}",
+            fib_link.index,
+            fib_link.name,
+            fib_link.vni,
+            fib_link.master,
+        );
         // Capture pre-state so we can detect a VXLAN-bridge association
         // gaining valid `(master, vni)` and trigger an FDB rescan. The
         // common case is operator-driven sequence:


### PR DESCRIPTION
## Summary

Peer-advertised EVPN Type-2 routes were not landing in the kernel FDB despite showing up in \`show ip bgp l2vpn evpn\`. Four distinct gaps along the receive→install path, each surfaced by tracing::info! logging on mac_add/mac_del/mdb_add/mdb_del.

## Fixes

1. **\`extract_vni_from_attr\` off-by-one (bgp/route.rs)** — read RT Local-Admin lower 3 bytes (val[3..6]) per RFC 8365 §5.1.2.4. Old code read val[2..5] and grabbed the high byte; RT 65501:550 came out as VNI 2.

2. **\`extract_tunnel_endpoint\` wrong field (bgp/route.rs)** — read EVPN nexthop from \`rib.attr.nexthop\` as \`BgpNexthop::Evpn(addr)\`. The old code read \`rib.nexthop\` (a VPNv4-only slot, always None on EVPN), so every install went out without NDA_DST and the kernel rejected with EINVAL.

3. **\`mac_add\` netlink flags (fib/netlink/handle.rs)** — \`NLM_F_CREATE | NLM_F_REPLACE\` for upsert. \`NLM_F_REPLACE\` alone requires the entry to already exist; first install returned ENOENT.

4. **\`mac_del\` missing NTF_SELF (fib/netlink/handle.rs)** — \`mac_add\` installs with \`NTF_SELF | NTF_EXT_LEARNED\` so the row lives in the VXLAN device's own FDB. \`mac_del\` was sending flags=0 so the kernel scanned the bridge master FDB instead, didn't find the entry, ENOENT. Match the install side with NTF_SELF (0x02). iproute2's \`bridge fdb del\` defaults the same way.

## Logging

- mac_add/mac_del/mdb_add/mdb_del get info-level entry logs (vni, mac/group, ifindex, dst).
- Skip-paths bumped from \`debug!\` to \`info!\`.
- \`extract_vni_from_attr\` replaces \`eprintln\` with \`tracing::info\`.
- \`link_add\` gains a one-line entry log so registration timing vs mac_add can be traced.

## Out of scope (separate follow-up)

\`mdb_add\` still rejects with EINVAL — RTM_NEWMDB needs \`header.ifindex = bridge\` (not VXLAN), and Linux conventionally uses FDB zero-MAC for VXLAN BUM head-end replication anyway. Will be addressed in a separate PR.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo build -p zebra-rs --bin zebra-rs\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo test -p zebra-rs --bin zebra-rs\` (169 passed)
- [x] \`RUSTFLAGS=\"-D warnings\" cargo clippy --workspace --all-targets\`
- [ ] Manual: peer advertises Type-2; \`bridge fdb show dev <vxlan>\` lists the MAC with \`dst <peer-VTEP> self extern_learn\`. Daemon log shows \`mac_add: VNI N mac M ifindex K dst <peer-VTEP>\` and no error.
- [ ] Manual: peer withdraws; \`bridge fdb show\` no longer lists the MAC; daemon log shows \`mac_del: VNI N mac M ifindex K\` and no error.

Generated with [Claude Code](https://claude.com/claude-code)