### PR TITLE
evpn: skip multicast MACs in FDB <-> BGP plumbing

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1286,11 +1286,14 @@ fn route_evpn_export_selected(
         };
         match prefix {
             EvpnPrefix::MacIp { mac, .. } => {
+                // Match the announce-side filter: never installed
+                // multicast MAC entries → nothing to delete.
+                let mac_addr = MacAddr::from(*mac);
+                if mac_addr.is_multicast() {
+                    return;
+                }
                 if let Some(vni) = extract_vni_from_attr(&wd.attr) {
-                    let msg = rib::Message::MacDel {
-                        vni,
-                        mac: MacAddr::from(*mac),
-                    };
+                    let msg = rib::Message::MacDel { vni, mac: mac_addr };
                     let _ = bgp.rib_tx.send(msg);
                 } else {
                     eprintln!(
@@ -1326,11 +1329,21 @@ fn route_evpn_export_selected(
 
     match prefix {
         EvpnPrefix::MacIp { mac, .. } => {
+            // Defensive: the local FDB->BGP origination path skips
+            // multicast MACs in `fdb_entry_from_neighbor`, but a peer
+            // running different software may still have advertised
+            // one. Don't try to install — there is no remote host
+            // behind a multicast MAC and the kernel FDB rows for
+            // these are local-reception filters owned by the OS.
+            let mac_addr = MacAddr::from(*mac);
+            if mac_addr.is_multicast() {
+                return;
+            }
             // RFC 8365: VNI must come from Route Target extended community
             if let Some(vni) = extract_vni_from_attr(&best.attr) {
                 let msg = rib::Message::MacAdd {
                     vni,
-                    mac: MacAddr::from(*mac),
+                    mac: mac_addr,
                     tunnel_endpoint: extract_tunnel_endpoint(best),
                     flags: extract_flags_from_attr(&best.attr),
                     seq: extract_mac_mobility_seq(&best.attr),

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -523,6 +523,10 @@ impl Rib {
             if !belongs_here {
                 continue;
             }
+            // Match `fdb_entry_from_neighbor`: drop multicast/broadcast.
+            if mac.is_multicast() {
+                continue;
+            }
             let entry = FdbEntry {
                 vni,
                 mac: *mac,
@@ -1318,6 +1322,15 @@ fn fdb_entry_from_neighbor(rib: &Rib, nbr: &FibNeighbor) -> Option<FdbEntry> {
         return None;
     }
     let mac = nbr.lladdr?;
+    // Skip multicast / broadcast MACs. The kernel's bridge FDB
+    // contains rows for every multicast group the local device
+    // joined (`33:33:..` for IPv6, `01:00:5e:..` for IPv4, plus
+    // reserved-link addresses like `01:80:c2:..`); these are
+    // local-reception filters, not remote hosts, and have no
+    // meaning as EVPN Type-2 MAC advertisements.
+    if mac.is_multicast() {
+        return None;
+    }
     let bridge_ifindex = nbr
         .master
         .or_else(|| rib.links.get(&nbr.ifindex).and_then(|link| link.master))?;

--- a/zebra-rs/src/rib/mac_addr.rs
+++ b/zebra-rs/src/rib/mac_addr.rs
@@ -16,6 +16,18 @@ impl MacAddr {
     pub fn octets(&self) -> [u8; 6] {
         self.octets
     }
+
+    /// IEEE 802 group bit on the first octet — true for multicast
+    /// and broadcast addresses (covers IPv4 multicast `01:00:5e:..`,
+    /// IPv6 multicast `33:33:..`, broadcast `ff:ff:..`, and
+    /// reserved-link L2 destinations like `01:80:c2:..`). EVPN
+    /// Type-2 carries unicast host MACs only — multicast MACs that
+    /// appear in the kernel FDB are reception filters on the local
+    /// device, not remote hosts, and must not be originated to BGP
+    /// peers nor installed from peer-advertised routes.
+    pub fn is_multicast(&self) -> bool {
+        (self.octets[0] & 0x01) != 0
+    }
 }
 
 impl From<[u8; 6]> for MacAddr {
@@ -36,5 +48,31 @@ impl std::fmt::Display for MacAddr {
             self.octets[4],
             self.octets[5],
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MacAddr;
+
+    #[test]
+    fn is_multicast_covers_v4_v6_groups_and_broadcast() {
+        // IPv4 multicast 01:00:5e:..
+        assert!(MacAddr::from([0x01, 0x00, 0x5e, 0x00, 0x00, 0x01]).is_multicast());
+        // IPv6 multicast 33:33:..
+        assert!(MacAddr::from([0x33, 0x33, 0x00, 0x00, 0x00, 0x01]).is_multicast());
+        assert!(MacAddr::from([0x33, 0x33, 0xff, 0xca, 0x56, 0x57]).is_multicast());
+        // Broadcast.
+        assert!(MacAddr::from([0xff; 6]).is_multicast());
+        // Reserved-link L2 (bridge BPDUs etc.) — group bit set.
+        assert!(MacAddr::from([0x01, 0x80, 0xc2, 0x00, 0x00, 0x00]).is_multicast());
+    }
+
+    #[test]
+    fn is_multicast_false_for_unicast() {
+        assert!(!MacAddr::from([0x00, 0x1c, 0x42, 0x5f, 0x0b, 0x08]).is_multicast());
+        assert!(!MacAddr::from([0xfe, 0xb2, 0x14, 0x6c, 0x11, 0x6e]).is_multicast());
+        // Locally-administered unicast (U/L bit set, group bit clear).
+        assert!(!MacAddr::from([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]).is_multicast());
     }
 }


### PR DESCRIPTION
## Summary

The local kernel FDB contains rows for every multicast group the OS joined (\`33:33:..\` for IPv6, \`01:00:5e:..\` for IPv4, reserved-link L2 like \`01:80:c2:..\`). These are reception filters owned by the kernel, not remote hosts. They have no meaning as EVPN Type-2 advertisements, and installing peer-advertised ones makes no sense either. Visible symptom: BGP RIB carrying junk like

\`\`\`
[2]:[0]:[48]:[33:33:00:00:00:01]
[2]:[0]:[48]:[01:00:5e:00:00:01]
\`\`\`

## Changes

Filter both directions:

- **FDB → BGP**: \`fdb_entry_from_neighbor\` and \`rescan_fdb_for_bridge\` (\`rib/inst.rs\`) drop the entry before it becomes an \`FdbEntry\`. Covers origination, subscribe-time replay, and link-add rescan.
- **BGP → FDB**: \`route_evpn_export_selected\` (\`bgp/route.rs\`) skips kernel install on announce and withdraw paths. The route stays in BGP local-RIB; it just doesn't reach the kernel.

Helper: \`MacAddr::is_multicast()\` tests the IEEE 802 I/G bit (LSB of first octet — same predicate as \`std::net::Ipv4Addr::is_multicast\`, tcpdump, Wireshark, iproute2). Covers IPv4 multicast \`01:00:5e:..\` (RFC 1112), IPv6 multicast \`33:33:..\` (RFC 2464), broadcast, and reserved-link L2 \`01:80:c2:..\`.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo build -p zebra-rs --bin zebra-rs\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo test -p zebra-rs --bin zebra-rs\` (171 passed — 2 new)
- [x] \`RUSTFLAGS=\"-D warnings\" cargo clippy --workspace --all-targets\`
- [x] Verified bit semantics against IEEE 802, RFC 1112, RFC 2464.
- [ ] Manual: \`show ip bgp l2vpn evpn\` no longer lists \`33:33:..\` / \`01:00:5e:..\` / \`01:80:c2:..\` MACs as locally-originated Type-2 routes.
- [ ] Manual: \`bridge fdb show\` does not gain \`extern_learn\` rows for multicast MACs even if a non-zebra-rs peer advertises them.

Generated with [Claude Code](https://claude.com/claude-code)