### PR TITLE
evpn: clean peer-down RIB; use VXLAN local IP as nexthop

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1740,6 +1740,100 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
     let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
     peer.adj_out.v4vpn.clear();
 
+    // EVPN. Same shape as the VPNv4 block above:
+    //   * If both ends advertised LLGR for L2VPN/EVPN, retain the
+    //     adj-in entries marked stale (with the LLGR_STALE community
+    //     attached) and re-import them into the local-RIB so best
+    //     path selection still considers them; the stale timer
+    //     evicts them later.
+    //   * Otherwise, withdraw every route the peer had given us.
+    //     `route_evpn_withdraw` removes from adj-in + local-RIB and
+    //     fans out MP_UNREACH to other peers (covering any kernel
+    //     install/withdraw via `route_evpn_export_selected`).
+    let afi_safi_evpn = AfiSafi::new(Afi::L2vpn, Safi::Evpn);
+    let llgr_evpn = peer.cap_send.llgr.contains_key(&afi_safi_evpn)
+        && peer.cap_recv.llgr.contains_key(&afi_safi_evpn);
+    if llgr_evpn {
+        let stale_time = peer
+            .cap_recv
+            .llgr
+            .get(&afi_safi_evpn)
+            .expect("checked above")
+            .stale_time();
+        peer.timer.stale_timer.insert(
+            afi_safi_evpn,
+            start_stale_timer(peer, afi_safi_evpn, stale_time),
+        );
+        for (_rd, table) in peer.adj_in.evpn.iter_mut() {
+            for (_prefix, ribs) in table.0.iter_mut() {
+                for rib in ribs.iter_mut() {
+                    rib.stale = true;
+                    let mut new_attr = (*rib.attr).clone();
+                    match &mut new_attr.com {
+                        Some(com) => {
+                            com.push(CommunityValue::LLGR_STALE.value());
+                        }
+                        None => {
+                            let mut com = Community::new();
+                            com.push(CommunityValue::LLGR_STALE.value());
+                            new_attr.com = Some(com);
+                        }
+                    }
+                    rib.attr = bgp.attr_store.intern(new_attr);
+                }
+            }
+        }
+
+        // Re-import the now-stale entries into local-RIB so best-path
+        // re-evaluation includes the stale attr+community.
+        let stale_updates: Vec<(EvpnRoute, BgpAttr, IpAddr)> = {
+            let mut updates = Vec::new();
+            for (rd, table) in peer.adj_in.evpn.iter() {
+                for (prefix, ribs) in table.0.iter() {
+                    for rib in ribs.iter() {
+                        if let Some(route) = build_evpn_route(rd, prefix, rib) {
+                            let nhop = match rib.attr.nexthop.as_ref() {
+                                Some(BgpNexthop::Evpn(addr)) => *addr,
+                                _ => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                            };
+                            updates.push((route, (*rib.attr).clone(), nhop));
+                        }
+                    }
+                }
+            }
+            updates
+        };
+        for (route, attr, nhop) in stale_updates {
+            route_evpn_update(peer_id, &route, nhop, &attr, bgp, peers, true);
+        }
+    } else {
+        let withdrawn: Vec<EvpnRoute> = {
+            let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+            let mut out = Vec::new();
+            for (rd, table) in peer.adj_in.evpn.iter() {
+                for (prefix, ribs) in table.0.iter() {
+                    for rib in ribs.iter() {
+                        if let Some(route) = build_evpn_route(rd, prefix, rib) {
+                            out.push(route);
+                        }
+                    }
+                }
+            }
+            out
+        };
+        for route in withdrawn.iter() {
+            route_evpn_withdraw(peer_id, route, bgp, peers);
+        }
+        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+        peer.adj_in.evpn.clear();
+    }
+
+    let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+    peer.adj_out.evpn.clear();
+    peer.cache_evpn.clear();
+    peer.cache_evpn_rev.clear();
+    peer.cache_evpn_timer = None;
+
     peer.cap_map = CapAfiMap::new();
     peer.cap_recv = BgpCap::default();
     peer.opt.clear();
@@ -1747,6 +1841,38 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
     // IPv4 RTC.
     peer.rtcv4.clear();
     peer.eor.clear();
+}
+
+/// Reconstruct the wire `EvpnRoute` from a Loc-RIB / Adj-RIB entry,
+/// re-deriving the per-NLRI fields (path-id, ESI, VNI) from the
+/// stored `BgpRib`. Used by the peer-down cleanup path to feed
+/// `route_evpn_withdraw`.
+fn build_evpn_route(
+    rd: &RouteDistinguisher,
+    prefix: &EvpnPrefix,
+    rib: &BgpRib,
+) -> Option<EvpnRoute> {
+    match prefix {
+        EvpnPrefix::MacIp { eth_tag, mac, .. } => {
+            let vni = extract_vni_from_attr(&rib.attr).unwrap_or(0);
+            Some(EvpnRoute::Mac(EvpnMac {
+                id: rib.remote_id,
+                rd: *rd,
+                esi: rib.esi.unwrap_or([0; 10]),
+                ether_tag: *eth_tag,
+                mac: *mac,
+                vni,
+            }))
+        }
+        EvpnPrefix::InclusiveMulticast { eth_tag, orig } => {
+            Some(EvpnRoute::Multicast(EvpnMulticast {
+                id: rib.remote_id,
+                rd: *rd,
+                ether_tag: *eth_tag,
+                addr: *orig,
+            }))
+        }
+    }
 }
 
 pub fn stale_route_withdraw(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
@@ -2419,14 +2545,31 @@ impl Bgp {
         //     <local-AS>:<VNI>, two-octet ASN form for now).
         //   - Encapsulation extended community = VXLAN (8) so the
         //     receiver knows which data plane to use.
-        // Nexthop is the local router-id; per-peer NEXT_HOP rewrite
-        // for eBGP happens inside `route_update_evpn`.
+        // Nexthop = local VTEP source IP (RFC 8365 §5.1.3 — the
+        // egress PE for VXLAN is the VTEP). RIB resolved this from
+        // the VXLAN slave's `IFLA_VXLAN_LOCAL` / `LOCAL6` and stuck
+        // it on the FdbEntry. Falling back to router-id keeps an
+        // older configuration where the VXLAN was created without
+        // an explicit `local` from emitting a 0.0.0.0 nexthop, but
+        // operators with an actual VTEP IP set will get the right
+        // family in the wire encoding (v4 → 4-byte nexthop, v6 →
+        // 16-byte nexthop). Per-peer NEXT_HOP rewrite for eBGP
+        // still happens inside `route_update_evpn`.
         let mut attr = BgpAttr::new();
         attr.ecom = Some(ExtCommunity(vec![
             evpn_route_target(self.asn, entry.vni),
             evpn_encap_vxlan(),
         ]));
-        attr.nexthop = Some(BgpNexthop::Evpn(IpAddr::V4(self.router_id)));
+        let nexthop = entry.vxlan_local.unwrap_or(IpAddr::V4(self.router_id));
+        if entry.vxlan_local.is_none() {
+            tracing::warn!(
+                "evpn_originate_macip: VXLAN for VNI {} has no local IP; \
+                 falling back to router-id {} as nexthop",
+                entry.vni,
+                self.router_id,
+            );
+        }
+        attr.nexthop = Some(BgpNexthop::Evpn(nexthop));
 
         let mut rib = BgpRib::new(
             ORIGINATED_PEER,

--- a/zebra-rs/src/fib/message.rs
+++ b/zebra-rs/src/fib/message.rs
@@ -38,6 +38,13 @@ pub struct FibLink {
     /// VXLAN links. Used by the EVPN advertise path to map a bridge
     /// (via its VXLAN slave) to the L2VPN VNI it carries.
     pub vni: Option<u32>,
+    /// Local VTEP source IP from `IFLA_VXLAN_LOCAL` (4 bytes IPv4) or
+    /// `IFLA_VXLAN_LOCAL6` (16 bytes IPv6) on VXLAN links — i.e. the
+    /// `local` address shown by `ip -d link show <vxlan>`. Used by
+    /// the EVPN advertise path as the BGP nexthop in MP_REACH_NLRI
+    /// per RFC 8365 §5.1.3 (egress PE = local VTEP). None on
+    /// non-VXLAN links and on VXLANs configured without a local IP.
+    pub vxlan_local: Option<std::net::IpAddr>,
 }
 
 impl FibLink {

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -2013,16 +2013,27 @@ pub fn link_from_msg(msg: LinkMessage) -> FibLink {
                 link.master = Some(idx);
             }
             LinkAttribute::LinkInfo(infos) => {
-                // VXLAN link kind carries the VNI in
-                // `LinkInfo::Data(InfoData::Vxlan(InfoVxlan::Id(_)))`.
-                // Walk both the Kind and Data sub-attrs and pick the
-                // VNI when present — non-VXLAN links contribute
-                // nothing here.
+                // VXLAN link data carries both the VNI (`IFLA_VXLAN_ID`)
+                // and the local VTEP source IP (`IFLA_VXLAN_LOCAL` or
+                // `IFLA_VXLAN_LOCAL6`). Walk every Vxlan sub-attr and
+                // capture them. Non-VXLAN links contribute nothing.
                 for info in infos {
                     if let LinkInfo::Data(InfoData::Vxlan(vxlan_attrs)) = info {
                         for v in vxlan_attrs {
-                            if let InfoVxlan::Id(vni) = v {
-                                link.vni = Some(vni);
+                            match v {
+                                InfoVxlan::Id(vni) => link.vni = Some(vni),
+                                InfoVxlan::Local(bytes) if bytes.len() == 4 => {
+                                    link.vxlan_local = Some(IpAddr::V4(std::net::Ipv4Addr::new(
+                                        bytes[0], bytes[1], bytes[2], bytes[3],
+                                    )));
+                                }
+                                InfoVxlan::Local6(bytes) if bytes.len() == 16 => {
+                                    let mut octets = [0u8; 16];
+                                    octets.copy_from_slice(&bytes);
+                                    link.vxlan_local =
+                                        Some(IpAddr::V6(std::net::Ipv6Addr::from(octets)));
+                                }
+                                _ => {}
                             }
                         }
                     }

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr};
 
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
@@ -20,6 +20,14 @@ pub struct FdbEntry {
     pub ifindex: u32,
     pub bridge_ifindex: u32,
     pub flags: u8,
+    /// Local VTEP source IP — the `local` address configured on the
+    /// VXLAN slave of `bridge_ifindex` (`IFLA_VXLAN_LOCAL` /
+    /// `IFLA_VXLAN_LOCAL6`). The EVPN advertise path uses this as
+    /// the BGP MP_REACH nexthop per RFC 8365 §5.1.3 — that's the IP
+    /// remote peers will encapsulate VXLAN packets to. None when the
+    /// VXLAN was created without an explicit `local` (kernel uses
+    /// 0.0.0.0 / :: in that case); callers fall back to router-id.
+    pub vxlan_local: Option<IpAddr>,
 }
 
 #[allow(dead_code)]

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -488,6 +488,18 @@ impl Rib {
             .and_then(|link| link.vni)
     }
 
+    /// Sibling of `vni_for_bridge` returning the same VXLAN slave's
+    /// local source IP (`IFLA_VXLAN_LOCAL` / `IFLA_VXLAN_LOCAL6`),
+    /// when set. The EVPN advertise path uses this for the BGP
+    /// MP_REACH nexthop on Type-2 / Type-3 routes — receivers
+    /// encapsulate VXLAN packets to this address.
+    pub fn vxlan_local_for_bridge(&self, bridge_ifindex: u32) -> Option<IpAddr> {
+        self.links
+            .values()
+            .find(|link| link.master == Some(bridge_ifindex) && link.vni.is_some())
+            .and_then(|link| link.vxlan_local)
+    }
+
     /// Re-emit `RibRx::FdbAdd` for every existing AF_BRIDGE entry on
     /// `bridge_ifindex`. Called from `link_add` when a VXLAN device
     /// gains a bridge master so MACs that were learned BEFORE the
@@ -505,6 +517,7 @@ impl Rib {
         let Some(vni) = self.vni_for_bridge(bridge_ifindex) else {
             return;
         };
+        let vxlan_local = self.vxlan_local_for_bridge(bridge_ifindex);
         for (key, nbr) in self.neighbors.iter() {
             let NeighborKey::Bridge {
                 ifindex,
@@ -533,6 +546,7 @@ impl Rib {
                 ifindex: *ifindex,
                 bridge_ifindex,
                 flags: nbr.flags.bits(),
+                vxlan_local,
             };
             self.api_fdb_add(&entry);
         }
@@ -1335,12 +1349,14 @@ fn fdb_entry_from_neighbor(rib: &Rib, nbr: &FibNeighbor) -> Option<FdbEntry> {
         .master
         .or_else(|| rib.links.get(&nbr.ifindex).and_then(|link| link.master))?;
     let vni = rib.vni_for_bridge(bridge_ifindex)?;
+    let vxlan_local = rib.vxlan_local_for_bridge(bridge_ifindex);
     Some(FdbEntry {
         vni,
         mac,
         ifindex: nbr.ifindex,
         bridge_ifindex,
         flags: nbr.flags.bits(),
+        vxlan_local,
     })
 }
 

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -47,6 +47,10 @@ pub struct Link {
     /// Used by the EVPN advertise path: a bridge's VXLAN slave maps the
     /// bridge to the L2VPN VNI it carries.
     pub vni: Option<u32>,
+    /// Local VTEP source IP from `IFLA_VXLAN_LOCAL` / `IFLA_VXLAN_LOCAL6`
+    /// on VXLAN links. Used as the BGP MP_REACH nexthop for EVPN
+    /// advertisements per RFC 8365 §5.1.3.
+    pub vxlan_local: Option<std::net::IpAddr>,
 }
 
 impl Link {
@@ -64,6 +68,7 @@ impl Link {
             addr6: Vec::new(),
             master: link.master,
             vni: link.vni,
+            vxlan_local: link.vxlan_local,
         }
     }
 
@@ -965,6 +970,7 @@ mod tests {
             addr6: Vec::new(),
             master: None,
             vni: None,
+            vxlan_local: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Two correctness fixes on the EVPN side, bundled because both touch the BGP/RIB origination path.

### 1. Peer-down route cleanup with LLGR support

Before: when a BGP peer went down, EVPN routes received from it stayed in the local-RIB forever. \`route_clean\` already handled IPv4 unicast and VPNv4 (including LLGR stale-mark) but had no EVPN block.

\`route_clean\` now mirrors the VPNv4 shape for L2VPN/EVPN:
- LLGR negotiated → adj-in entries marked stale, LLGR_STALE community attached, re-imported into local-RIB so best-path selection sees them as stale; per-AFI stale timer evicts later.
- No LLGR → each entry fed to \`route_evpn_withdraw\` which removes from adj-in / local-RIB, drives kernel \`mac_del\` / \`mdb_del\` via \`route_evpn_export_selected\`, and fans out MP_UNREACH to other peers.
- \`peer.adj_out.evpn\` / \`cache_evpn\` / \`cache_evpn_rev\` / \`cache_evpn_timer\` cleared so re-establish doesn't replay stale advertise state.

### 2. EVPN MP_REACH nexthop = VXLAN local IP (RFC 8365 §5.1.3)

Before: \`evpn_originate_macip\` hardcoded \`BgpNexthop::Evpn(IpAddr::V4(self.router_id))\`. A node with a VXLAN configured \`local 2001:db8::1\` (IPv6 VTEP) advertised nexthop = router-id (IPv4). Remote peers tried to encapsulate to that IPv4 address — but the tunnel terminates on the IPv6 VTEP. Forwarding silently broke across the family mismatch.

After: read the VXLAN slave's \`IFLA_VXLAN_LOCAL\` / \`IFLA_VXLAN_LOCAL6\` from netlink and thread it through to BGP:
- \`link_from_msg\` parses both v4 and v6 \`InfoVxlan::Local*\` into \`FibLink::vxlan_local: Option<IpAddr>\`.
- \`Link\` / \`Rib\` propagate it; new \`Rib::vxlan_local_for_bridge\` mirrors \`vni_for_bridge\`.
- \`FdbEntry\` gains \`vxlan_local\`, populated by \`fdb_entry_from_neighbor\` and \`rescan_fdb_for_bridge\`.
- \`evpn_originate_macip\` uses \`entry.vxlan_local\` for the nexthop, falling back to router-id with a warn log when the VXLAN has no \`local\` set. Wire encoding already supports either family on \`BgpNexthop::Evpn(IpAddr)\`.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo build -p zebra-rs --bin zebra-rs\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo test -p zebra-rs --bin zebra-rs\` (171 passed)
- [x] \`RUSTFLAGS=\"-D warnings\" cargo clippy --workspace --all-targets\`
- [ ] Manual (peer-down): bring BGP peer down → \`show ip bgp l2vpn evpn\` no longer shows the peer's RD; without LLGR, peer's MACs cleared from kernel FDB on the local node.
- [ ] Manual (nexthop): VXLAN configured \`local 2001:db8::1\` → \`show ip bgp l2vpn evpn\` shows \`Next Hop: 2001:db8::1\` for locally-originated Type-2; tcpdump on the BGP session confirms 16-byte nexthop in MP_REACH.

Generated with [Claude Code](https://claude.com/claude-code)