### PR TITLE
yang: accept IPv6 in clear/show ip bgp neighbor

### DIFF
--- a/zebra-rs/yang/configure.yang
+++ b/zebra-rs/yang/configure.yang
@@ -104,16 +104,28 @@ module configure {
           key name;
           leaf name {
             ext:dynamic "bgp:neighbor";
-            type "inet:ipv4-address";
+            // Accept either family — the BGP runtime keys peers
+            // by `IpAddr` regardless of family, and the path stays
+            // under `ip` purely as a CLI-vocabulary convention.
+            type union {
+              type inet:ipv4-address;
+              type inet:ipv6-address;
+            }
           }
         }
         // Test for manual clear of keepalive timer.
         leaf keepalive {
-          type "inet:ipv4-address";
+          type union {
+            type inet:ipv4-address;
+            type inet:ipv6-address;
+          }
         }
         // Test for manual clear of keepalive timer.
         leaf keepalive-recv {
-          type "inet:ipv4-address";
+          type union {
+            type inet:ipv4-address;
+            type inet:ipv6-address;
+          }
         }
       }
     }

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -115,7 +115,11 @@ module exec {
           key name;
           leaf name {
             ext:dynamic "bgp:neighbor";
-            type "inet:ipv4-address";
+            // Accept either family — peers are keyed by `IpAddr`.
+            type union {
+              type inet:ipv4-address;
+              type inet:ipv6-address;
+            }
           }
           leaf rtcv4 {
             type empty;


### PR DESCRIPTION
## Summary

User report: \`clear ip bgp neighbor 2001:db8::1\` did not work even when the IPv6 peer was configured. The YANG schema for the neighbor key declared \`type \"inet:ipv4-address\"\`, so libyang rejected any IPv6 string before the runtime ever saw it. Same gap on the read side at \`show ip bgp neighbors\`.

## Changes

Union the type to accept either family:

- \`configure.yang\` — \`/clear/ip/bgp/neighbors/name\` (the failing case the user reported), plus sibling \`keepalive\` / \`keepalive-recv\` test leaves which had the same issue.
- \`exec.yang\` — \`/show/ip/bgp/neighbors/name\`.

The runtime side is already family-agnostic: \`args.addr()\` parses both v4 and v6 into \`IpAddr\`, and \`bgp.peers\` is keyed by \`IpAddr\` regardless of family. No code changes needed. Path stays under \`ip\` as a CLI-vocabulary convention (matches Cisco / FRR \`clear ip bgp\`).

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo build -p zebra-rs --bin zebra-rs\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo test -p zebra-rs --bin zebra-rs\` (171 passed)
- [x] \`RUSTFLAGS=\"-D warnings\" cargo clippy --workspace --all-targets\`
- [x] Smoke-tested YANG load — daemon parses both files cleanly.
- [ ] Manual: \`clear ip bgp neighbor 2001:db8::1\` resets the IPv6 BGP session and the daemon log shows the FSM go to Idle and re-establish.
- [ ] Manual: \`show ip bgp neighbors 2001:db8::1\` returns the neighbor's status block.

Generated with [Claude Code](https://claude.com/claude-code)