### PR TITLE
evpn: defer origination until router-id settled; block VXLAN-port loop

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -229,9 +229,42 @@ impl Bgp {
         if self.router_id == router_id {
             return;
         }
+        // EVPN RD = `<router-id>:<VNI>` (RFC 8365 §5.1.2). When
+        // router-id changes, every locally-originated route is now
+        // sitting under a stale RD that no peer (and no future
+        // re-originate) will withdraw. Drain the local FDB cache and
+        // withdraw under the OLD router-id BEFORE flipping the field,
+        // then re-originate under the NEW value below. Skips the
+        // withdraw when the old router-id is unspecified (initial
+        // 0.0.0.0 → operator value transition — nothing was ever
+        // originated under the all-zero RD because
+        // `evpn_originate_macip` gates on a valid router-id) or when
+        // `advertise_all_vni` is off (we never originated, so nothing
+        // to withdraw).
+        let old_router_id = self.router_id;
+        let advertising = self.advertise_all_vni;
+        if advertising && !old_router_id.is_unspecified() && !self.local_fdb.is_empty() {
+            let entries: Vec<FdbEntry> = self.local_fdb.values().cloned().collect();
+            for entry in entries {
+                self.evpn_withdraw_macip(&entry);
+            }
+        }
+
         self.router_id = router_id;
         for (_, peer) in self.peers.iter_mut() {
             peer.router_id = router_id;
+        }
+
+        // Re-originate under the new router-id so the cache contents
+        // come back into the local-RIB / wire under the right RD.
+        // Same gate as the false→true advertise-all-vni replay; the
+        // `evpn_originate_macip` body re-checks both conditions, so
+        // an unspecified `router_id` here is a safe no-op.
+        if advertising && !router_id.is_unspecified() && !self.local_fdb.is_empty() {
+            let entries: Vec<FdbEntry> = self.local_fdb.values().cloned().collect();
+            for entry in entries {
+                self.evpn_originate_macip(&entry);
+            }
         }
     }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2523,6 +2523,17 @@ impl Bgp {
         if entry.flags & NTF_EXT_LEARNED != 0 {
             return;
         }
+        // Defer until router-id is set. The `local_fdb` cache holds
+        // the entry; `set_router_id` replays the cache when the
+        // router-id transitions from unspecified to a real value
+        // (auto-derived from interface addrs or set by operator
+        // config). Without this gate, a cold-boot race would emit
+        // routes under RD `0.0.0.0:VNI`, peers would accept them,
+        // and the subsequent router-id update would leave the
+        // 0.0.0.0 RD orphaned (no path withdraws it).
+        if self.router_id.is_unspecified() {
+            return;
+        }
         let Some(rd) = rd_from_router_id_vni(self.router_id, entry.vni) else {
             tracing::warn!(
                 "evpn_originate_macip: VNI {} > 65535, RD encoding not yet supported; \

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -540,6 +540,12 @@ impl Rib {
             if mac.is_multicast() {
                 continue;
             }
+            // And drop MACs learned on VXLAN ports (remote hosts).
+            if let Some(slave) = self.links.get(ifindex)
+                && slave.vni.is_some()
+            {
+                continue;
+            }
             let entry = FdbEntry {
                 vni,
                 mac: *mac,
@@ -1343,6 +1349,19 @@ fn fdb_entry_from_neighbor(rib: &Rib, nbr: &FibNeighbor) -> Option<FdbEntry> {
     // local-reception filters, not remote hosts, and have no
     // meaning as EVPN Type-2 MAC advertisements.
     if mac.is_multicast() {
+        return None;
+    }
+    // Skip MACs the bridge learned on a VXLAN port — those are
+    // remote hosts whose frames came in over a tunnel; advertising
+    // them as locally-originated would loop the route back to
+    // peers. NTF_EXT_LEARNED catches operator-installed entries
+    // but NOT data-plane learns (kernel sets neither flag on a
+    // dynamically learned bridge FDB row), so the slave-port type
+    // is the authoritative signal: any link with a `vni` is a
+    // VXLAN device.
+    if let Some(slave) = rib.links.get(&nbr.ifindex)
+        && slave.vni.is_some()
+    {
         return None;
     }
     let bridge_ifindex = nbr


### PR DESCRIPTION
## Summary

Two regressions surfaced together once the FDB→BGP and BGP→FDB plumbing actually started landing routes end-to-end.

### 1. Stale RD lingering after operator router-id config takes effect

Cold-boot flow:
- RIB auto-derives a router-id from interface IPv4 (e.g. \`docker0\` → \`172.17.0.1\`) and pushes it via \`RibRx::RouterIdUpdate\`.
- \`advertise-all-vni\` lands via \`cm.rx\` — origination kicks off under \`RD 172.17.0.1:550\`.
- Operator config later sets \`identifier 10.0.0.1\`. New routes appear under \`10.0.0.1:550\` — but the old \`172.17.0.1:550\` routes are never withdrawn, so the local-RIB carries two RDs for the same VNI from the same node, and peers see both for the rest of the session.

**Fix:**
- \`evpn_originate_macip\` gates on \`!router_id.is_unspecified()\` — the auto-derived 0.0.0.0 boot state never produces routes.
- \`set_router_id\` detects the transition: with \`advertise_all_vni\` on and a non-empty \`local_fdb\` cache, drain entries and \`evpn_withdraw_macip\` BEFORE flipping \`self.router_id\` (so the RD is computed from the OLD value), then re-originate under the new router-id. Same shape as the existing false→true \`advertise_all_vni\` replay. No timer needed — fix is deterministic.

### 2. Peer's MAC re-originated as locally-learned under our RD

When a remote MAC is installed via \`mac_add\` (\`NTF_EXT_LEARNED\` on both bridge-master and VXLAN-self entries), traffic from that MAC arrives at our \`vni550\` device, gets decap'd, hits the bridge — and the bridge data-plane-learns the source MAC on the \`vni550\` port. The kernel emits RTM_NEWNEIGH for that learn **without** \`NTF_EXT_LEARNED\` (operator-install-only flag; data-plane learns are unflagged). Our existing flag-based filter missed it, so \`evpn_originate_macip\` fired and our local-RIB ended up carrying peer's MACs under our own RD.

**Fix:** filter on slave port type instead. In \`fdb_entry_from_neighbor\` and \`rescan_fdb_for_bridge\`, drop the FDB entry if the slave port (\`nbr.ifindex\`) is itself a VXLAN device. Anything learned over a tunnel is remote by definition and must never be advertised as local.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo build -p zebra-rs --bin zebra-rs\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo test -p zebra-rs --bin zebra-rs\` (171 passed)
- [x] \`RUSTFLAGS=\"-D warnings\" cargo clippy --workspace --all-targets\`
- [ ] Manual (regression 1): boot zebra-rs with auto-derived router-id, then operator-set \`identifier 10.0.0.1\` → \`show ip bgp l2vpn evpn\` shows ONLY RD \`10.0.0.1:550\`, no stale RD with the auto-derived value.
- [ ] Manual (regression 2): peer advertises MACs → \`show ip bgp l2vpn evpn\` lists the peer's MACs ONLY under the peer's RD (e.g. \`10.0.0.5:550\`), NOT under our local RD.

Generated with [Claude Code](https://claude.com/claude-code)