### PR TITLE
bgp: update LocalRib selected map on local EVPN withdraw

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2628,6 +2628,18 @@ impl Bgp {
             ip: None,
         };
         let _ = self.local_rib.remove_evpn(rd, &prefix, 0, ORIGINATED_PEER);
+        // `remove_evpn` only edits `cands`; the per-prefix `selected`
+        // map (the one `show ip bgp l2vpn evpn` iterates) is updated
+        // by `select_best_path_evpn`, which evicts the entry when no
+        // candidate remains. Without this call the withdrawn route
+        // stays visible in `show` and orphan RDs accumulate after
+        // every router-id change. Don't route the result through
+        // `route_evpn_export_selected` — that path triggers kernel
+        // FDB del via `MacDel`, which is appropriate for received
+        // EVPN routes but wrong for locally-originated ones (the
+        // kernel row is the operator's local MAC, not something we
+        // installed via mac_add).
+        let _ = self.local_rib.select_best_path_evpn(&rd, &prefix);
         // Tell every EVPN peer the route is gone. No best-path
         // re-evaluation here — for a locally-originated route there
         // is no other path that would replace it; the peers can


### PR DESCRIPTION
## Summary

After PR #416 wired router-id transitions to withdraw the old RD's routes before re-originating under the new one, operators saw stale RDs continue to appear in \`show ip bgp l2vpn evpn\` after every auto-pick of the local router-id. With three different interface addresses available (e.g. \`lo\`, \`br-f5be5e13a83c\`, \`enp0s6\`), three RDs accumulated even though each one was supposed to be withdrawn before the next was originated.

## Root cause

\`LocalRib::remove_evpn\` only edits the per-prefix \`cands\` vec — it does NOT touch the \`selected\` map that the show command iterates. \`evpn_withdraw_macip\` called \`remove_evpn\` and fanned out MP_UNREACH to peers, but the local-RIB's \`selected\` entry kept pointing at the now-deleted candidate, so the row stayed visible in \`show\` and orphan RDs accumulated forever.

The receive-side \`route_evpn_withdraw\` already follows \`remove_evpn\` with \`select_best_path_evpn\` (which evicts \`selected\` when no candidate remains). \`evpn_withdraw_macip\` was missing the second call.

## Fix

Add the \`select_best_path_evpn\` call. Did NOT route through \`route_evpn_export_selected\` — that path triggers kernel \`MacDel\`, which is correct for received Type-2 but wrong for locally-originated routes (the kernel FDB row is the operator's actual local MAC, not BGP-installed state we own).

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo build -p zebra-rs --bin zebra-rs\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo test -p zebra-rs --bin zebra-rs\` (171 passed)
- [x] \`RUSTFLAGS=\"-D warnings\" cargo clippy --workspace --all-targets\`
- [ ] Manual: boot zebra-rs in an env where RIB auto-pick walks several interface IPs (e.g. with \`lo\`, docker bridges, enp0sN) → \`show ip bgp l2vpn evpn\` shows ONLY the current router-id's RD, no orphan RDs from prior auto-picks.

Generated with [Claude Code](https://claude.com/claude-code)