### PR TITLE
evpn: originate Type-3 (Inclusive Multicast) per local VTEP

### DIFF
--- a/crates/bgp-packet/src/attrs/pmsi_tunnel.rs
+++ b/crates/bgp-packet/src/attrs/pmsi_tunnel.rs
@@ -1,19 +1,69 @@
 use std::fmt;
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use bytes::{BufMut, BytesMut};
-use nom::number::complete::be_u24;
-use nom_derive::*;
+use nom::IResult;
+use nom::bytes::complete::take;
+use nom::number::complete::{be_u8, be_u24};
 
 use crate::{AttrEmitter, AttrFlags, AttrType, ParseBe, u32_u24};
 
-#[derive(Clone, NomBE, PartialEq, Eq, Hash)]
+/// PMSI Tunnel Attribute (RFC 6514 §5).
+///
+/// Wire layout:
+/// ```text
+///   Flags         (1 octet)
+///   Tunnel Type   (1 octet)
+///   MPLS Label    (3 octets, low 24 bits — the VXLAN VNI for EVPN
+///                  per RFC 8365 §5.1.3)
+///   Tunnel Identifier — variable per Tunnel Type. For Ingress
+///                       Replication (type 6) it is the local PE's
+///                       IP address: 4 octets for IPv4, 16 for IPv6.
+///                       Family is implicit from the slice length;
+///                       the BGP attribute header carries the
+///                       overall length.
+/// ```
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PmsiTunnel {
     pub flags: u8,
     pub tunnel_type: u8,
-    #[nom(Parse = "be_u24")]
     pub vni: u32,
-    pub endpoint: Ipv4Addr,
+    pub endpoint: IpAddr,
+}
+
+impl ParseBe<PmsiTunnel> for PmsiTunnel {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, flags) = be_u8(input)?;
+        let (input, tunnel_type) = be_u8(input)?;
+        let (input, vni) = be_u24(input)?;
+        let endpoint = match input.len() {
+            4 => {
+                let (_, bytes) = take(4usize)(input)?;
+                IpAddr::V4(Ipv4Addr::new(bytes[0], bytes[1], bytes[2], bytes[3]))
+            }
+            16 => {
+                let (_, bytes) = take(16usize)(input)?;
+                let mut octets = [0u8; 16];
+                octets.copy_from_slice(bytes);
+                IpAddr::V6(Ipv6Addr::from(octets))
+            }
+            _ => {
+                return Err(nom::Err::Error(nom::error::Error::new(
+                    input,
+                    nom::error::ErrorKind::LengthValue,
+                )));
+            }
+        };
+        Ok((
+            &input[input.len()..],
+            PmsiTunnel {
+                flags,
+                tunnel_type,
+                vni,
+                endpoint,
+            },
+        ))
+    }
 }
 
 impl AttrEmitter for PmsiTunnel {
@@ -33,7 +83,10 @@ impl AttrEmitter for PmsiTunnel {
         buf.put_u8(self.flags);
         buf.put_u8(self.tunnel_type);
         buf.put(&u32_u24(self.vni)[..]);
-        buf.put(&self.endpoint.octets()[..]);
+        match self.endpoint {
+            IpAddr::V4(v4) => buf.put(&v4.octets()[..]),
+            IpAddr::V6(v6) => buf.put(&v6.octets()[..]),
+        }
     }
 }
 

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -338,10 +338,20 @@ fn config_advertise_all_vni(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
         for entry in entries {
             bgp.evpn_originate_macip(&entry);
         }
+        let vxlans: Vec<(u32, std::net::IpAddr)> =
+            bgp.local_vxlans.iter().map(|(k, v)| (*k, *v)).collect();
+        for (vni, vtep_local) in vxlans {
+            bgp.evpn_originate_imet(vni, vtep_local);
+        }
     } else if was_enabled && !enabled {
         let entries: Vec<FdbEntry> = bgp.local_fdb.values().cloned().collect();
         for entry in entries {
             bgp.evpn_withdraw_macip(&entry);
+        }
+        let vxlans: Vec<(u32, std::net::IpAddr)> =
+            bgp.local_vxlans.iter().map(|(k, v)| (*k, *v)).collect();
+        for (vni, vtep_local) in vxlans {
+            bgp.evpn_withdraw_imet(vni, vtep_local);
         }
     }
     Some(())

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -79,6 +79,13 @@ pub struct Bgp {
     /// so origination becomes deterministic regardless of which
     /// channel wins the boot race.
     pub local_fdb: BTreeMap<(u32, MacAddr), FdbEntry>,
+    /// Local VXLAN VTEP shadow keyed by VNI, value = local VTEP IP
+    /// (the VXLAN device's `IFLA_VXLAN_LOCAL` / `LOCAL6`). Populated
+    /// from `RibRx::VxlanAdd`, removed on `RibRx::VxlanDel`. Drives
+    /// Type-3 (Inclusive Multicast) origination — one IMET per VNI
+    /// — and replays on `advertise_all_vni` / `router_id` transitions
+    /// just like `local_fdb`.
+    pub local_vxlans: BTreeMap<u32, std::net::IpAddr>,
     /// Configured hostname for the local BGP speaker. Advertised in
     /// the FQDN capability (capability code 73). When None, falls back
     /// to the OS hostname; if that also fails, no FQDN capability is
@@ -147,6 +154,7 @@ impl Bgp {
             router_id: Ipv4Addr::UNSPECIFIED,
             advertise_all_vni: false,
             local_fdb: BTreeMap::new(),
+            local_vxlans: BTreeMap::new(),
             hostname: None,
             peers: PeerMap::new(),
             tx,
@@ -243,10 +251,23 @@ impl Bgp {
         // to withdraw).
         let old_router_id = self.router_id;
         let advertising = self.advertise_all_vni;
-        if advertising && !old_router_id.is_unspecified() && !self.local_fdb.is_empty() {
-            let entries: Vec<FdbEntry> = self.local_fdb.values().cloned().collect();
-            for entry in entries {
-                self.evpn_withdraw_macip(&entry);
+        if advertising && !old_router_id.is_unspecified() {
+            if !self.local_fdb.is_empty() {
+                let entries: Vec<FdbEntry> = self.local_fdb.values().cloned().collect();
+                for entry in entries {
+                    self.evpn_withdraw_macip(&entry);
+                }
+            }
+            // Same RD-rebind story for Type-3 (IMET): each VXLAN's
+            // outbound IMET is keyed by the local router-id-derived
+            // RD; a router-id change requires withdrawing under the
+            // old RD and re-originating under the new.
+            if !self.local_vxlans.is_empty() {
+                let vxlans: Vec<(u32, std::net::IpAddr)> =
+                    self.local_vxlans.iter().map(|(k, v)| (*k, *v)).collect();
+                for (vni, vtep_local) in vxlans {
+                    self.evpn_withdraw_imet(vni, vtep_local);
+                }
             }
         }
 
@@ -260,10 +281,19 @@ impl Bgp {
         // Same gate as the false→true advertise-all-vni replay; the
         // `evpn_originate_macip` body re-checks both conditions, so
         // an unspecified `router_id` here is a safe no-op.
-        if advertising && !router_id.is_unspecified() && !self.local_fdb.is_empty() {
-            let entries: Vec<FdbEntry> = self.local_fdb.values().cloned().collect();
-            for entry in entries {
-                self.evpn_originate_macip(&entry);
+        if advertising && !router_id.is_unspecified() {
+            if !self.local_fdb.is_empty() {
+                let entries: Vec<FdbEntry> = self.local_fdb.values().cloned().collect();
+                for entry in entries {
+                    self.evpn_originate_macip(&entry);
+                }
+            }
+            if !self.local_vxlans.is_empty() {
+                let vxlans: Vec<(u32, std::net::IpAddr)> =
+                    self.local_vxlans.iter().map(|(k, v)| (*k, *v)).collect();
+                for (vni, vtep_local) in vxlans {
+                    self.evpn_originate_imet(vni, vtep_local);
+                }
             }
         }
     }
@@ -485,6 +515,15 @@ impl Bgp {
             RibRx::FdbDel(entry) => {
                 self.local_fdb.remove(&(entry.vni, entry.mac));
                 self.evpn_withdraw_macip(&entry);
+            }
+            RibRx::VxlanAdd { vni, vtep_local } => {
+                self.local_vxlans.insert(vni, vtep_local);
+                self.evpn_originate_imet(vni, vtep_local);
+            }
+            RibRx::VxlanDel { vni } => {
+                if let Some(vtep_local) = self.local_vxlans.remove(&vni) {
+                    self.evpn_withdraw_imet(vni, vtep_local);
+                }
             }
             _ => {
                 //

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2646,6 +2646,106 @@ impl Bgp {
         // figure it out when they see the MP_UNREACH.
         route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
     }
+
+    /// Originate a Type-3 (Inclusive Multicast Ethernet Tag) route
+    /// for one local VTEP×VNI pair (RFC 7432 §4.3, §11.3 + RFC 8365
+    /// §5.1.3). One IMET per VNI tells remote PEs "send your BUM
+    /// traffic for this VNI to me, encapsulated with VXLAN at this
+    /// IP". Receivers install a zero-MAC FDB row whose `dst` = the
+    /// nexthop, used for ingress-replication of broadcast / unknown
+    /// unicast / multicast.
+    ///
+    /// Required attributes:
+    ///   - RT (Two-Octet AS Specific) carrying VNI in low 3 bytes
+    ///     of Local Admin (same as Type-2).
+    ///   - Encapsulation extended community = VXLAN (8) per RFC 9012.
+    ///   - PMSI Tunnel attribute (RFC 6514 §5) — Tunnel Type 6
+    ///     (Ingress Replication), Label = VNI, Tunnel Identifier =
+    ///     local VTEP IP. Without it, peers won't know which tunnel
+    ///     mechanism to use and will reject the route.
+    ///   - Nexthop = local VTEP IP. Same as Type-2 origination.
+    ///
+    /// Same gates as `evpn_originate_macip`: `advertise_all_vni` on
+    /// AND a valid router-id. RD = `<router-id>:<VNI>`.
+    pub fn evpn_originate_imet(&mut self, vni: u32, vtep_local: IpAddr) {
+        if !self.advertise_all_vni {
+            return;
+        }
+        if self.router_id.is_unspecified() {
+            return;
+        }
+        let Some(rd) = rd_from_router_id_vni(self.router_id, vni) else {
+            tracing::warn!(
+                "evpn_originate_imet: VNI {} > 65535, RD encoding not yet supported",
+                vni
+            );
+            return;
+        };
+        let prefix = EvpnPrefix::InclusiveMulticast {
+            eth_tag: 0,
+            orig: vtep_local,
+        };
+        let mut attr = BgpAttr::new();
+        attr.ecom = Some(ExtCommunity(vec![
+            evpn_route_target(self.asn, vni),
+            evpn_encap_vxlan(),
+        ]));
+        attr.pmsi_tunnel = Some(PmsiTunnel {
+            // Flags = 0 (no leaf info required, per RFC 6514 §5).
+            flags: 0,
+            // Tunnel Type 6 = Ingress Replication.
+            tunnel_type: 6,
+            vni,
+            endpoint: vtep_local,
+        });
+        attr.nexthop = Some(BgpNexthop::Evpn(vtep_local));
+
+        let mut rib = BgpRib::new(
+            ORIGINATED_PEER,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            0,
+            32768,
+            &attr,
+            None,
+            None,
+            false,
+        );
+        let (_replaced, selected, next_id) =
+            self.local_rib.update_evpn(rd, prefix.clone(), rib.clone());
+        rib.local_id = next_id;
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_tx: &self.rib_tx,
+            attr_store: &mut self.attr_store,
+        };
+
+        if !selected.is_empty() {
+            route_advertise_evpn_to_peers(rd, prefix, &selected, &mut bgp_ref, &mut self.peers);
+        }
+    }
+
+    /// Inverse of `evpn_originate_imet`. Mirrors `evpn_withdraw_macip`:
+    /// remove from candidate set, evict the per-prefix `selected`
+    /// entry via `select_best_path_evpn`, fan out MP_UNREACH to peers.
+    pub fn evpn_withdraw_imet(&mut self, vni: u32, vtep_local: IpAddr) {
+        if !self.advertise_all_vni {
+            return;
+        }
+        let Some(rd) = rd_from_router_id_vni(self.router_id, vni) else {
+            return;
+        };
+        let prefix = EvpnPrefix::InclusiveMulticast {
+            eth_tag: 0,
+            orig: vtep_local,
+        };
+        let _ = self.local_rib.remove_evpn(rd, &prefix, 0, ORIGINATED_PEER);
+        let _ = self.local_rib.select_best_path_evpn(&rd, &prefix);
+        route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
+    }
 }
 
 /// `NTF_EXT_LEARNED` from `<linux/neighbour.h>` — bit 0x10. Set on

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -59,6 +59,20 @@ pub enum RibRx {
     FdbAdd(FdbEntry),
     /// Inverse of `FdbAdd` — emitted on `FibMessage::DelNeighbor`.
     FdbDel(FdbEntry),
+    /// Local VXLAN device with `IFLA_VXLAN_LOCAL` set. Emitted by
+    /// RIB when a VXLAN slave is registered (`register_vxlan_ifindex`
+    /// path in `link_add`) and replayed at subscribe time. The EVPN
+    /// advertise path uses it to originate one Type-3 (Inclusive
+    /// Multicast) route per local VTEP×VNI pair.
+    VxlanAdd {
+        vni: u32,
+        vtep_local: IpAddr,
+    },
+    /// Inverse of `VxlanAdd` — emitted when the VXLAN device is
+    /// removed or its VNI changes.
+    VxlanDel {
+        vni: u32,
+    },
     EoR,
 }
 
@@ -104,6 +118,18 @@ impl Rib {
     pub fn api_fdb_del(&self, entry: &FdbEntry) {
         for tx in self.redists.iter() {
             let _ = tx.send(RibRx::FdbDel(entry.clone()));
+        }
+    }
+
+    pub fn api_vxlan_add(&self, vni: u32, vtep_local: IpAddr) {
+        for tx in self.redists.iter() {
+            let _ = tx.send(RibRx::VxlanAdd { vni, vtep_local });
+        }
+    }
+
+    pub fn api_vxlan_del(&self, vni: u32) {
+        for tx in self.redists.iter() {
+            let _ = tx.send(RibRx::VxlanDel { vni });
         }
     }
 }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -758,6 +758,19 @@ impl Rib {
                 tx.send(msg).unwrap();
             }
         }
+        // VXLAN dump. Replay every observed VXLAN device with a
+        // local IP — same cold-start race motivation as the FDB
+        // replay below: without this, BGP misses VXLANs that
+        // `link_add` saw during `fib_dump` and Type-3 (IMET) routes
+        // would never originate.
+        for link in self.links.values() {
+            if let (Some(vni), Some(local)) = (link.vni, link.vxlan_local) {
+                let _ = tx.send(RibRx::VxlanAdd {
+                    vni,
+                    vtep_local: local,
+                });
+            }
+        }
         // FDB dump. Replay every existing AF_BRIDGE neighbor that
         // resolves to a known VNI. Without this, FDB entries learned
         // during `fib_dump` — i.e. *before* BGP subscribed — would

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -523,9 +523,13 @@ impl Rib {
         if prev_vni != now_vni {
             if let Some(prev) = prev_vni {
                 self.fib_handle.unregister_vxlan_ifindex(prev);
+                self.api_vxlan_del(prev);
             }
             if let Some(new) = now_vni {
                 self.fib_handle.register_vxlan_ifindex(new, ifindex);
+                if let Some(local) = self.links.get(&ifindex).and_then(|l| l.vxlan_local) {
+                    self.api_vxlan_add(new, local);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Two zebra-rs nodes peering with each other had no zero-MAC FDB entries on either side because neither was originating Type-3 (IMET) routes — only Type-2 was implemented. Without IMET, no ingress-replication target lands in the kernel, BUM (broadcast / unknown-unicast / multicast) has nowhere to flood, and ARP/ND across the VXLAN tunnel never resolves. Visible symptom: \`bridge fdb show dev <vxlan>\` had only Type-2 unicast rows; no \`00:00:00:00:00:00 dst <peer-VTEP>\` line; multicast pings on the bridge never reached the peer.

## Changes

**PMSI Tunnel attribute (RFC 6514 §5)**:
- \`PmsiTunnel.endpoint\` extended from \`Ipv4Addr\` to \`IpAddr\`.
- Custom \`ParseBe\` replaces the NomBE-derived parser; the BGP attribute framework slices the payload to the attribute's declared length, so the parser detects v4 vs v6 from the remaining-bytes count (4 → IPv4, 16 → IPv6). Symmetric emit handles either family.

**RIB → BGP plumbing**:
- New \`RibRx::VxlanAdd { vni, vtep_local }\` / \`VxlanDel { vni }\` events.
- \`link_add\`'s post-block VXLAN registration reconciliation also fires \`api_vxlan_add\` / \`api_vxlan_del\` on transitions.
- \`Rib::subscribe\` replays existing VXLANs at subscribe time (mirrors the existing FDB replay; same cold-boot race rationale).

**BGP local-RIB shadow + origination**:
- \`Bgp::local_vxlans: BTreeMap<u32, IpAddr>\` parallels \`local_fdb\`, durably populated from VxlanAdd/Del.
- \`evpn_originate_imet(vni, vtep_local)\` builds Type-3 with RT (\`<asn>:<vni>\`), Encap (VXLAN), and PMSI Tunnel (Type 6 = Ingress Replication, label = VNI, endpoint = local VTEP). Nexthop = local VTEP. RD = \`<router-id>:<vni>\`.
- \`evpn_withdraw_imet\` mirrors \`evpn_withdraw_macip\` (remove + select_best_path_evpn + MP_UNREACH).

**Replay paths** mirror Type-2 transitions:
- \`set_router_id\` change: withdraw under old RD, re-originate under new.
- \`config_advertise_all_vni\` transition: drain \`local_vxlans\` and originate / withdraw each.

Receive side already supported IPv6 origin (Type-3 NLRI parser accepts addr_len=128) and IPv6 dst on FDB-zero-MAC install (PR #412), so a peer running this code lands a working zero-MAC entry on us; we land one on them.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo build -p zebra-rs --bin zebra-rs\`
- [x] \`RUSTFLAGS=\"-D warnings\" cargo test -p zebra-rs --bin zebra-rs\` (171 passed)
- [x] \`RUSTFLAGS=\"-D warnings\" cargo clippy --workspace --all-targets\`
- [x] Smoke-tested daemon startup: VxlanAdd replay fires for vni550 with local IP captured.
- [ ] Manual: both sides upgraded → \`show ip bgp l2vpn evpn\` shows \`[3]:[0]:[128]:[2001:db8::1]\` (or v4 equivalent) under each side's RD; \`bridge fdb show dev vni550\` lists \`00:00:00:00:00:00 dst <peer-VTEP> self extern_learn\`; \`ping6 -c5 ff02::1%br50\` gets responses from peer's bridge.

Generated with [Claude Code](https://claude.com/claude-code)