### PR TITLE
bdd: add scenario docs for BGP EVPN cap and IS-IS MT/SRv6

### DIFF
--- a/bdd/docs/bgp_evpn_capability.md
+++ b/bdd/docs/bgp_evpn_capability.md
@@ -1,0 +1,35 @@
+# BGP L2VPN/EVPN capability negotiation
+
+## Overview
+
+As a network operator
+I want two zebra-rs instances to negotiate the L2VPN/EVPN multiprotocol
+No EVPN routes flow in this scenario — capability negotiation is the
+Multicast) lands in follow-up features.
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                   │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65001 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+```
+
+## Config Files
+
+- z1-1.yaml: AS 65001, peer to 192.168.0.2, l2vpn-evpn enabled
+- z2-1.yaml: AS 65001, peer to 192.168.0.1, l2vpn-evpn enabled
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish iBGP session with EVPN capability | |
+| L2VPN/EVPN capability is advertised and received on both sides | |

--- a/bdd/docs/isis_multi_topology.md
+++ b/bdd/docs/isis_multi_topology.md
@@ -1,0 +1,17 @@
+# IS-IS multi-topology (RFC 5120)
+
+## Overview
+
+As a network operator
+I want two zebra-rs instances to participate in IS-IS multi-topology
+Test Topology (same shape as isis_ipv6 but both sides emit MT TLVs):
+Both configs add `multi-topology ipv6-unicast;` under `router/isis/`
+TLV 237 (MT IPv6 Reach).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup IS-IS L2 with MT 2 over a shared bridge and confirm the link is up | |
+| MT 2 SPF installs reciprocal IPv6 routes to peer loopbacks | |
+| LSPs carry the multi-topology TLVs | |

--- a/bdd/docs/isis_srv6.md
+++ b/bdd/docs/isis_srv6.md
@@ -1,0 +1,14 @@
+# IS-IS SRv6 end-to-end with H.Encap and End.DT6
+
+## Overview
+
+As a network operator
+I want a 4-router IS-IS L2 chain to converge with SRv6 locators,
+Test Topology (linear chain, point-to-point veth pairs, no bridge):
+Config files (in `bdd/tests/configs/isis_srv6/`):
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup the SRv6 chain and ping the far end through the SID | |


### PR DESCRIPTION
## Summary

Three scenario documents under \`bdd/docs/\` describing operator acceptance criteria for features already shipped in this tree:

- \`bgp_evpn_capability.md\` — BGP L2VPN/EVPN capability negotiation
- \`isis_multi_topology.md\` — IS-IS multi-topology (RFC 5120)
- \`isis_srv6.md\` — IS-IS SRv6 end-to-end with H.Encap and End.DT6

Docs only — no implementation or test code changes, no CI gates affected.

Generated with [Claude Code](https://claude.com/claude-code)