### PR TITLE
bgp: extend route-policy set actions (local-pref, community, as-path-prepend, next-hop)

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -8,7 +8,7 @@ use ipnet::Ipv4Net;
 use prefix_trie::PrefixMap;
 
 use crate::bgp::timer::{start_adv_timer_evpn, start_stale_timer};
-use crate::policy::PolicyList;
+use crate::policy::{CommunityMatcher, PolicyList, StandardMatcher};
 use crate::rib::{self, MacAddr, api::FdbEntry};
 
 use super::cap::CapAfiMap;
@@ -2184,8 +2184,18 @@ pub fn policy_list_apply(
         // If we matched to the statement or no match statement at all.
         match (prefix_matched, community_matched) {
             (None | Some(true), None | Some(true)) => {
+                if let Some(local_pref) = &entry.local_pref {
+                    bgp_attr.local_pref = Some(LocalPref::new(*local_pref));
+                }
                 if let Some(med) = &entry.med {
                     bgp_attr.med = Some(Med { med: *med });
+                }
+                if let Some(set_community) = &entry.set_community {
+                    apply_set_community(
+                        &mut bgp_attr,
+                        set_community,
+                        entry.set_community_additive,
+                    );
                 }
                 return Some(bgp_attr);
             }
@@ -2195,6 +2205,44 @@ pub fn policy_list_apply(
         }
     }
     None
+}
+
+/// Apply a `set community <community-set> [additive]` action to `bgp_attr`.
+///
+/// Only `Standard::Exact` matchers contribute concrete values; regex and
+/// extended-community matchers are skipped (extended communities live in
+/// a separate BGP attribute, and regex patterns are not concrete values).
+/// With `additive = false` the existing community list is replaced; with
+/// `additive = true` the new values are merged in. The result is always
+/// sorted and deduplicated.
+fn apply_set_community(
+    bgp_attr: &mut BgpAttr,
+    set_community: &crate::policy::CommunitySet,
+    additive: bool,
+) {
+    let new_vals: Vec<u32> = set_community
+        .vals
+        .iter()
+        .filter_map(|m| match m {
+            CommunityMatcher::Standard(StandardMatcher::Exact(v)) => Some(v.0),
+            _ => None,
+        })
+        .collect();
+    if new_vals.is_empty() && !additive {
+        // Replace with empty: drop the attribute entirely.
+        bgp_attr.com = None;
+        return;
+    }
+    let mut com = if additive {
+        bgp_attr.com.clone().unwrap_or_default()
+    } else {
+        Community::new()
+    };
+    for v in new_vals {
+        com.push(v);
+    }
+    com.sort_uniq();
+    bgp_attr.com = Some(com);
 }
 
 pub fn route_sync_ipv4(peer: &mut Peer, bgp: &mut BgpTop) {
@@ -2801,4 +2849,144 @@ fn evpn_encap_vxlan() -> ExtCommunityValue {
     // Encapsulation type 8 = VXLAN, occupies the trailing 2 octets.
     encap.val[5] = 8;
     encap
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use bgp_packet::{BgpAttr, Community, CommunityValue, Ipv4Nlri, LocalPref};
+    use ipnet::Ipv4Net;
+
+    use super::policy_list_apply;
+    use crate::policy::{CommunityMatcher, CommunitySet, PolicyList};
+
+    fn nlri(s: &str) -> Ipv4Nlri {
+        Ipv4Nlri {
+            id: 0,
+            prefix: Ipv4Net::from_str(s).unwrap(),
+        }
+    }
+
+    fn community_set(members: &[&str]) -> CommunitySet {
+        let mut set = CommunitySet::default();
+        for m in members {
+            set.vals
+                .insert(CommunityMatcher::from_str(m).unwrap_or_else(|_| panic!("parse {m}")));
+        }
+        set
+    }
+
+    fn com_val(s: &str) -> u32 {
+        CommunityValue::from_readable_str(s)
+            .unwrap_or_else(|| panic!("parse {s}"))
+            .0
+    }
+
+    #[test]
+    fn policy_list_apply_sets_local_pref() {
+        let mut list = PolicyList::default();
+        list.entry(10).local_pref = Some(250);
+
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), BgpAttr::default())
+            .expect("entry with no match clause should apply");
+        assert_eq!(out.local_pref.expect("local_pref applied").local_pref, 250);
+    }
+
+    #[test]
+    fn policy_list_apply_sets_local_pref_and_med() {
+        let mut list = PolicyList::default();
+        let entry = list.entry(10);
+        entry.local_pref = Some(150);
+        entry.med = Some(42);
+
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), BgpAttr::default()).unwrap();
+        assert_eq!(out.local_pref.unwrap().local_pref, 150);
+        assert_eq!(out.med.unwrap().med, 42);
+    }
+
+    #[test]
+    fn policy_list_apply_local_pref_overrides_existing() {
+        let mut list = PolicyList::default();
+        list.entry(10).local_pref = Some(200);
+
+        let attr = BgpAttr {
+            local_pref: Some(LocalPref::new(100)),
+            ..Default::default()
+        };
+
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        assert_eq!(out.local_pref.unwrap().local_pref, 200);
+    }
+
+    #[test]
+    fn policy_list_apply_community_replace() {
+        let mut list = PolicyList::default();
+        let entry = list.entry(10);
+        entry.set_community = Some(community_set(&["100:200", "no-export"]));
+        entry.set_community_additive = false;
+
+        // Existing community 999:999 must be wiped on replace.
+        let attr = BgpAttr {
+            com: Some(Community(vec![com_val("999:999")])),
+            ..Default::default()
+        };
+
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        let com = out.com.expect("community attribute set");
+        assert!(com.contains(&com_val("100:200")));
+        assert!(com.contains(&CommunityValue::NO_EXPORT.value()));
+        assert!(!com.contains(&com_val("999:999")));
+        assert_eq!(com.0.len(), 2);
+    }
+
+    #[test]
+    fn policy_list_apply_community_additive() {
+        let mut list = PolicyList::default();
+        let entry = list.entry(10);
+        entry.set_community = Some(community_set(&["100:200"]));
+        entry.set_community_additive = true;
+
+        let attr = BgpAttr {
+            com: Some(Community(vec![com_val("999:999")])),
+            ..Default::default()
+        };
+
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        let com = out.com.expect("community attribute set");
+        assert!(com.contains(&com_val("100:200")));
+        assert!(com.contains(&com_val("999:999")));
+        assert_eq!(com.0.len(), 2);
+    }
+
+    #[test]
+    fn policy_list_apply_community_additive_dedups() {
+        let mut list = PolicyList::default();
+        let entry = list.entry(10);
+        entry.set_community = Some(community_set(&["100:200"]));
+        entry.set_community_additive = true;
+
+        // 100:200 already present — additive should not duplicate.
+        let attr = BgpAttr {
+            com: Some(Community(vec![com_val("100:200")])),
+            ..Default::default()
+        };
+
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        let com = out.com.expect("community attribute set");
+        assert_eq!(com.0, vec![com_val("100:200")]);
+    }
+
+    #[test]
+    fn policy_list_apply_community_replace_skips_regex() {
+        let mut list = PolicyList::default();
+        let entry = list.entry(10);
+        // Mix concrete + regex; only 100:200 is materializable.
+        entry.set_community = Some(community_set(&["100:200", "^65000:.*"]));
+        entry.set_community_additive = false;
+
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), BgpAttr::default()).unwrap();
+        let com = out.com.expect("community attribute set");
+        assert_eq!(com.0, vec![com_val("100:200")]);
+    }
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2197,6 +2197,9 @@ pub fn policy_list_apply(
                         entry.set_community_additive,
                     );
                 }
+                if let Some(prepend) = &entry.set_as_path_prepend {
+                    apply_set_as_path_prepend(&mut bgp_attr, prepend);
+                }
                 return Some(bgp_attr);
             }
             (_, _) => {
@@ -2243,6 +2246,19 @@ fn apply_set_community(
     }
     com.sort_uniq();
     bgp_attr.com = Some(com);
+}
+
+/// Apply a `set as-path-prepend <asn>...` action by prepending the given
+/// ASNs onto the existing AS-path (or installing a new one if absent).
+fn apply_set_as_path_prepend(bgp_attr: &mut BgpAttr, asns: &[u32]) {
+    if asns.is_empty() {
+        return;
+    }
+    let prepend_path = As4Path::from(asns.to_vec());
+    match bgp_attr.aspath.as_mut() {
+        Some(existing) => existing.prepend_mut(prepend_path),
+        None => bgp_attr.aspath = Some(prepend_path),
+    }
 }
 
 pub fn route_sync_ipv4(peer: &mut Peer, bgp: &mut BgpTop) {
@@ -2855,7 +2871,7 @@ fn evpn_encap_vxlan() -> ExtCommunityValue {
 mod tests {
     use std::str::FromStr;
 
-    use bgp_packet::{BgpAttr, Community, CommunityValue, Ipv4Nlri, LocalPref};
+    use bgp_packet::{As4Path, BgpAttr, Community, CommunityValue, Ipv4Nlri, LocalPref};
     use ipnet::Ipv4Net;
 
     use super::policy_list_apply;
@@ -2988,5 +3004,49 @@ mod tests {
         let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), BgpAttr::default()).unwrap();
         let com = out.com.expect("community attribute set");
         assert_eq!(com.0, vec![com_val("100:200")]);
+    }
+
+    #[test]
+    fn policy_list_apply_as_path_prepend_onto_empty() {
+        let mut list = PolicyList::default();
+        list.entry(10).set_as_path_prepend = Some(vec![65001, 65001]);
+
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), BgpAttr::default()).unwrap();
+        let path = out.aspath.expect("aspath set");
+        assert_eq!(path.length(), 2);
+        assert_eq!(path.as_path_display(), "65001 65001");
+    }
+
+    #[test]
+    fn policy_list_apply_as_path_prepend_onto_existing() {
+        let mut list = PolicyList::default();
+        list.entry(10).set_as_path_prepend = Some(vec![65001]);
+
+        // Existing path: 100 200 (origin AS at the right).
+        let attr = BgpAttr {
+            aspath: Some(As4Path::from(vec![100, 200])),
+            ..Default::default()
+        };
+
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        let path = out.aspath.expect("aspath set");
+        assert_eq!(path.as_path_display(), "65001 100 200");
+        assert_eq!(path.length(), 3);
+    }
+
+    #[test]
+    fn policy_list_apply_as_path_prepend_multi_asn() {
+        let mut list = PolicyList::default();
+        list.entry(10).set_as_path_prepend = Some(vec![65001, 65002, 65003]);
+
+        let attr = BgpAttr {
+            aspath: Some(As4Path::from(vec![100])),
+            ..Default::default()
+        };
+
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        let path = out.aspath.expect("aspath set");
+        assert_eq!(path.as_path_display(), "65001 65002 65003 100");
+        assert_eq!(path.length(), 4);
     }
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2191,11 +2191,7 @@ pub fn policy_list_apply(
                     bgp_attr.med = Some(Med { med: *med });
                 }
                 if let Some(set_community) = &entry.set_community {
-                    apply_set_community(
-                        &mut bgp_attr,
-                        set_community,
-                        entry.set_community_additive,
-                    );
+                    apply_set_community(&mut bgp_attr, set_community, entry.set_community_additive);
                 }
                 if let Some(prepend) = &entry.set_as_path_prepend {
                     apply_set_as_path_prepend(&mut bgp_attr, prepend);
@@ -2876,7 +2872,9 @@ mod tests {
 
     use std::net::Ipv4Addr;
 
-    use bgp_packet::{As4Path, BgpAttr, BgpNexthop, Community, CommunityValue, Ipv4Nlri, LocalPref};
+    use bgp_packet::{
+        As4Path, BgpAttr, BgpNexthop, Community, CommunityValue, Ipv4Nlri, LocalPref,
+    };
     use ipnet::Ipv4Net;
 
     use super::policy_list_apply;

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2200,6 +2200,9 @@ pub fn policy_list_apply(
                 if let Some(prepend) = &entry.set_as_path_prepend {
                     apply_set_as_path_prepend(&mut bgp_attr, prepend);
                 }
+                if let Some(addr) = &entry.set_next_hop {
+                    bgp_attr.nexthop = Some(BgpNexthop::Ipv4(*addr));
+                }
                 return Some(bgp_attr);
             }
             (_, _) => {
@@ -2871,7 +2874,9 @@ fn evpn_encap_vxlan() -> ExtCommunityValue {
 mod tests {
     use std::str::FromStr;
 
-    use bgp_packet::{As4Path, BgpAttr, Community, CommunityValue, Ipv4Nlri, LocalPref};
+    use std::net::Ipv4Addr;
+
+    use bgp_packet::{As4Path, BgpAttr, BgpNexthop, Community, CommunityValue, Ipv4Nlri, LocalPref};
     use ipnet::Ipv4Net;
 
     use super::policy_list_apply;
@@ -3048,5 +3053,34 @@ mod tests {
         let path = out.aspath.expect("aspath set");
         assert_eq!(path.as_path_display(), "65001 65002 65003 100");
         assert_eq!(path.length(), 4);
+    }
+
+    #[test]
+    fn policy_list_apply_sets_next_hop() {
+        let mut list = PolicyList::default();
+        list.entry(10).set_next_hop = Some(Ipv4Addr::new(10, 1, 1, 1));
+
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), BgpAttr::default()).unwrap();
+        match out.nexthop.expect("nexthop set") {
+            BgpNexthop::Ipv4(a) => assert_eq!(a, Ipv4Addr::new(10, 1, 1, 1)),
+            other => panic!("expected Ipv4 nexthop, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn policy_list_apply_next_hop_overrides_existing() {
+        let mut list = PolicyList::default();
+        list.entry(10).set_next_hop = Some(Ipv4Addr::new(10, 1, 1, 1));
+
+        let attr = BgpAttr {
+            nexthop: Some(BgpNexthop::Ipv4(Ipv4Addr::new(192, 0, 2, 1))),
+            ..Default::default()
+        };
+
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        match out.nexthop.unwrap() {
+            BgpNexthop::Ipv4(a) => assert_eq!(a, Ipv4Addr::new(10, 1, 1, 1)),
+            other => panic!("expected Ipv4 nexthop, got {:?}", other),
+        }
     }
 }

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -45,6 +45,9 @@ pub struct PolicyEntry {
     // Set.
     pub local_pref: Option<u32>,
     pub med: Option<u32>,
+    pub set_community_name: Option<String>,
+    pub set_community: Option<CommunitySet>,
+    pub set_community_additive: bool,
     // Action.
     pub action: Option<PolicyAction>,
 }
@@ -67,6 +70,13 @@ pub fn policy_entry_sync(
                 policy.community_set = Some(community_set.clone());
             } else {
                 policy.community_set = None;
+            }
+        }
+        if let Some(name) = &policy.set_community_name {
+            if let Some(community_set) = community_set.config.get(name) {
+                policy.set_community = Some(community_set.clone());
+            } else {
+                policy.set_community = None;
             }
         }
     }
@@ -271,6 +281,39 @@ impl ConfigBuilder {
                 entry.med = None;
                 Ok(())
             })
+            .path("/entry/set/community-set")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+
+                let community_set = args.string().context(ARG_ERR)?;
+                entry.set_community_name = Some(community_set);
+
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.set_community_name = None;
+                entry.set_community = None;
+                Ok(())
+            })
+            .path("/entry/set/community-additive")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+
+                let additive = args.boolean().context(ARG_ERR)?;
+                entry.set_community_additive = additive;
+
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.set_community_additive = false;
+                Ok(())
+            })
             .path("/entry/action")
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
@@ -336,6 +379,14 @@ pub fn show(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> 
             }
             if let Some(med) = &entry.med {
                 let _ = writeln!(buf, "  set: med {}", med);
+            }
+            if let Some(set_community) = &entry.set_community_name {
+                let suffix = if entry.set_community_additive {
+                    " additive"
+                } else {
+                    ""
+                };
+                let _ = writeln!(buf, "  set: community {}{}", set_community, suffix);
             }
         }
         if let Some(default_action) = &policy.default_action {

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -48,6 +48,7 @@ pub struct PolicyEntry {
     pub set_community_name: Option<String>,
     pub set_community: Option<CommunitySet>,
     pub set_community_additive: bool,
+    pub set_as_path_prepend: Option<Vec<u32>>,
     // Action.
     pub action: Option<PolicyAction>,
 }
@@ -314,6 +315,30 @@ impl ConfigBuilder {
                 entry.set_community_additive = false;
                 Ok(())
             })
+            .path("/entry/set/as-path-prepend")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+
+                let raw = args.string().context(ARG_ERR)?;
+                let asns: Vec<u32> = raw
+                    .split_whitespace()
+                    .map(|s| s.parse::<u32>())
+                    .collect::<Result<Vec<_>, _>>()
+                    .context("as-path-prepend: invalid AS number")?;
+                if asns.is_empty() {
+                    anyhow::bail!("as-path-prepend: empty AS list");
+                }
+                entry.set_as_path_prepend = Some(asns);
+
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.set_as_path_prepend = None;
+                Ok(())
+            })
             .path("/entry/action")
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
@@ -387,6 +412,14 @@ pub fn show(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> 
                     ""
                 };
                 let _ = writeln!(buf, "  set: community {}{}", set_community, suffix);
+            }
+            if let Some(prepend) = &entry.set_as_path_prepend {
+                let s = prepend
+                    .iter()
+                    .map(|a| a.to_string())
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                let _ = writeln!(buf, "  set: as-path-prepend {}", s);
             }
         }
         if let Some(default_action) = &policy.default_action {

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt::Write;
+use std::net::Ipv4Addr;
 
 use anyhow::{Context, Error, Result};
 use strum_macros::{Display, EnumString};
@@ -49,6 +50,7 @@ pub struct PolicyEntry {
     pub set_community: Option<CommunitySet>,
     pub set_community_additive: bool,
     pub set_as_path_prepend: Option<Vec<u32>>,
+    pub set_next_hop: Option<Ipv4Addr>,
     // Action.
     pub action: Option<PolicyAction>,
 }
@@ -339,6 +341,22 @@ impl ConfigBuilder {
                 entry.set_as_path_prepend = None;
                 Ok(())
             })
+            .path("/entry/set/next-hop")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+
+                let addr = args.v4addr().context(ARG_ERR)?;
+                entry.set_next_hop = Some(addr);
+
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.set_next_hop = None;
+                Ok(())
+            })
             .path("/entry/action")
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
@@ -420,6 +438,9 @@ pub fn show(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> 
                     .collect::<Vec<_>>()
                     .join(" ");
                 let _ = writeln!(buf, "  set: as-path-prepend {}", s);
+            }
+            if let Some(nh) = &entry.set_next_hop {
+                let _ = writeln!(buf, "  set: next-hop {}", nh);
             }
         }
         if let Some(default_action) = &policy.default_action {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -856,6 +856,14 @@ module config {
             leaf "community-additive" {
               type boolean;
             }
+            leaf "as-path-prepend" {
+              type string;
+              description
+                "Space-separated list of AS numbers to prepend to the
+                 AS-path. Example: '65001 65001 65002' prepends three
+                 segments. Equivalent to IOS-XR 'prepend as-path' or
+                 FRR 'set as-path prepend'.";
+            }
           }
           leaf "action" {
             ext:sort "1";

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -850,6 +850,12 @@ module config {
             leaf "next-hop" {
               type inet:ipv4-address;
             }
+            leaf "community-set" {
+              type string;
+            }
+            leaf "community-additive" {
+              type boolean;
+            }
           }
           leaf "action" {
             ext:sort "1";


### PR DESCRIPTION
## Summary

Extends BGP route-policy `set` actions to bring zebra-rs closer to IOS-XR RPL parity:

- **`set local-preference`** — was parsed from YANG but never applied; now wired through `policy_list_apply` alongside `set med`.
- **`set community-set <name> [community-additive]`** — replace or append concrete `Standard::Exact` community values; regex/extended-community matchers are skipped on apply since they can't be materialized as concrete u32s. Equivalent to IOS-XR `set community ... [additive]`.
- **`set as-path-prepend "<asn>..."`** — prepend a space-separated AS list onto the AS-path (or install a new path if absent). Reuses `As4Path::prepend_mut`. Equivalent to FRR `set as-path prepend` and IOS-XR `prepend as-path` (with the `<count>` form expressible by repeating the AS).
- **`set next-hop <ipv4>`** — completes a previously dead YANG stub (the leaf was declared but had no parser handler or apply).

## Test plan

- [x] `cargo build -p zebra-rs --bin zebra-rs` clean
- [x] `cargo clippy -p zebra-rs --bin zebra-rs --tests` clean (no warnings)
- [x] `cargo test -p zebra-rs --bin zebra-rs` — 183 tests pass, of which 12 are new `policy_list_apply` cases:
  - 3 local-preference (apply, with-med, override existing)
  - 4 community (replace, additive, additive-dedup, replace-skips-regex)
  - 3 as-path-prepend (onto empty, onto existing, multi-ASN)
  - 2 next-hop (apply, override existing)
- [ ] Manual verification: configure a policy with each new `set` verb on a test peer and confirm advertised routes carry the modified attribute.

## Out of scope (follow-ups)

- `set next-hop {self | peer-address | discard}` — needs peer context at apply time.
- `set extcommunity rt|soo|color|bandwidth` — extended communities live in a separate BGP attribute (`ecom`) and need their own apply path.
- `set large-community`, `delete community {in|not-in|all}`, richer `set med` (`igp-cost`/`+n`/`-n`/`max-reachable`), `set origin`, `set weight`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)