### PR TITLE
interface: bind to VRF via per-interface `vrf` leaf

### DIFF
--- a/bdd/docs/interface_vrf_binding.md
+++ b/bdd/docs/interface_vrf_binding.md
@@ -1,0 +1,51 @@
+# Interface VRF Binding
+
+## Overview
+
+As a network operator
+I want to enslave individual interfaces to a VRF master device
+So that traffic on those interfaces is routed in the VRF's table instead
+of the default routing instance.
+
+## Test Topology
+
+```
+              ┌─────────────────────┐
+              │         z1          │
+              │                     │
+              │   ┌─────────────┐   │
+              │   │  vrf vrf1   │   │   table-id (allocated)
+              │   │  ifindex N  │   │
+              │   └──────┬──────┘   │
+              │          │ master   │
+              │   ┌──────┴──────┐   │
+              │   │   enp0s6    │   │   192.168.10.1/24
+              │   └─────────────┘   │
+              │                     │
+              │       enp0s7        │   default VRF
+              └─────────────────────┘
+```
+
+## Config Files
+
+- z1.yaml:
+  - `vrf vrf1`
+  - `interface enp0s6 vrf vrf1`
+  - `interface enp0s6 ipv4 address 192.168.10.1/24`
+  - `interface enp0s7 ipv4 address 10.0.0.1/24` (default VRF, control)
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Configure VRF; verify `ip -d link show vrf1` reports `vrf table <id>` | |
+| Configure interface VRF binding; verify `ip -d link show enp0s6` reports `master vrf1` | |
+| `show vrf` lists vrf1 with enp0s6 in Members column | |
+| `show interface brief` shows VRF column = `vrf1` for enp0s6, `default` for enp0s7 | |
+| Configure IPv4 address before VRF binding (same commit); kernel ends up with the address in the VRF's table | |
+| `delete interface enp0s6 vrf`; verify `ip -d link show enp0s6` reports `nomaster` | |
+| Re-bind enp0s6 from vrf1 to a second `vrf vrf2`; verify `master vrf2` | |
+| Configure binding before the kernel device exists; create the netdev (e.g. `ip link add type dummy`); binding fires automatically | |
+| Configure binding before the VRF; commit creates VRF first then enslaves enp0s6 | |
+| `delete vrf vrf1` while enp0s6 is bound; kernel detaches enp0s6 (`ip link show enp0s6` reports no master); operator's binding intent is retained so re-creating vrf1 re-enslaves | |
+| Teardown: delete all VRFs and bindings; interfaces return to default VRF | |

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -1388,6 +1388,32 @@ impl FibHandle {
         }
     }
 
+    /// Set or clear the IFLA_MASTER (renamed to `Controller` in
+    /// netlink-packet-route) of `ifindex`. Pass `master == 0` to detach
+    /// (equivalent to `ip link set <link> nomaster`); a non-zero value
+    /// enslaves the link to that master device. Used for VRF interface
+    /// binding.
+    pub async fn link_set_master(&self, ifindex: u32, master: u32) {
+        let mut msg = LinkMessage::default();
+        msg.header.index = ifindex;
+        msg.attributes.push(LinkAttribute::Controller(master));
+
+        let mut req = NetlinkMessage::from(RouteNetlinkMessage::NewLink(msg));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK;
+
+        let mut response = self.handle.clone().request(req).unwrap();
+        while let Some(m) = response.next().await {
+            if let NetlinkPayload::Error(e) = m.payload {
+                tracing::warn!(
+                    "link_set_master(ifindex={}, master={}) error: {}",
+                    ifindex,
+                    master,
+                    e
+                );
+            }
+        }
+    }
+
     pub async fn addr_add_ipv4(
         &self,
         ifindex: u32,

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -137,6 +137,15 @@ pub enum Message {
     VrfDel {
         name: String,
     },
+    /// Bind / unbind an interface to a VRF master device.
+    /// `vrf == Some(name)` enslaves; `vrf == None` clears the binding
+    /// (sets IFLA_MASTER = 0). The handler tolerates the interface or
+    /// the VRF not yet existing in our tables and stages the intent in
+    /// `pending_vrf_bind` so it fires when the missing piece arrives.
+    LinkVrfBind {
+        ifname: String,
+        vrf: Option<String>,
+    },
     MacAdd {
         vni: u32,
         mac: MacAddr,
@@ -245,6 +254,11 @@ pub struct Rib {
     /// `Message::VrfDel` removes the entry and releases the id.
     pub vrfs: BTreeMap<String, Vrf>,
     pub vrf_id_alloc: VrfIdAllocator,
+    /// Operator intent for per-interface VRF binding, keyed by ifname.
+    /// `Some(vrf)` = enslave; `None` = unbind. The handler retries this
+    /// when a missing interface or VRF master appears later, and clears
+    /// the entry once the netlink call succeeds.
+    pub pending_vrf_bind: BTreeMap<String, Option<String>>,
     pub table: PrefixMap<Ipv4Net, RibEntries>,
     pub table_v6: PrefixMap<Ipv6Net, RibEntries>,
     pub ilm: BTreeMap<u32, IlmEntry>,
@@ -348,6 +362,7 @@ impl Rib {
             vxlan: BTreeMap::new(),
             vrfs: BTreeMap::new(),
             vrf_id_alloc: VrfIdAllocator::new(),
+            pending_vrf_bind: BTreeMap::new(),
             table: PrefixMap::new(),
             table_v6: PrefixMap::new(),
             ilm: BTreeMap::new(),
@@ -863,20 +878,37 @@ impl Rib {
                     tracing::warn!("vrf_add({}) failed — id space exhausted", name);
                     return;
                 };
-                if self.fib_handle.vrf_add(&name, table_id).await.is_none() {
+                let Some(ifindex) = self.fib_handle.vrf_add(&name, table_id).await else {
                     // Netlink rejected the create — release the id so
                     // the next attempt isn't penalised by a leak.
                     self.vrf_id_alloc.release(table_id);
                     return;
-                }
+                };
                 self.vrfs.insert(
                     name.clone(),
                     Vrf {
                         name: name.clone(),
                         table_id,
+                        ifindex,
                     },
                 );
-                tracing::info!("vrf_add: {} table_id={}", name, table_id);
+                tracing::info!(
+                    "vrf_add: {} table_id={} ifindex={}",
+                    name,
+                    table_id,
+                    ifindex
+                );
+                // Replay any interface bindings that were waiting for
+                // this VRF to come up.
+                let to_replay: Vec<(String, Option<String>)> = self
+                    .pending_vrf_bind
+                    .iter()
+                    .filter(|(_, vrf)| vrf.as_deref() == Some(name.as_str()))
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+                for (ifname, vrf) in to_replay {
+                    let _ = self.tx.send(Message::LinkVrfBind { ifname, vrf });
+                }
             }
             Message::VrfDel { name } => {
                 let Some(vrf) = self.vrfs.remove(&name) else {
@@ -890,6 +922,50 @@ impl Rib {
                 self.fib_handle.vrf_del(&name).await;
                 self.vrf_id_alloc.release(vrf.table_id);
                 tracing::info!("vrf_del: {} (table_id={})", name, vrf.table_id);
+            }
+            Message::LinkVrfBind { ifname, vrf } => {
+                // Always record operator intent so a later kernel
+                // NewLink (interface appears) or VrfAdd (master is
+                // created) can fire the bind without the operator
+                // re-issuing the command.
+                if vrf.is_none() {
+                    self.pending_vrf_bind.remove(&ifname);
+                } else {
+                    self.pending_vrf_bind
+                        .insert(ifname.clone(), vrf.clone());
+                }
+
+                let Some(link) = self.links.values().find(|l| l.name == ifname) else {
+                    tracing::info!(
+                        "link_vrf_bind: interface {} not present yet — pending",
+                        ifname
+                    );
+                    return;
+                };
+                let ifindex = link.index;
+
+                let master = match &vrf {
+                    Some(vrf_name) => match self.vrfs.get(vrf_name) {
+                        Some(v) => v.ifindex,
+                        None => {
+                            tracing::info!(
+                                "link_vrf_bind: vrf {} not present yet — pending",
+                                vrf_name
+                            );
+                            return;
+                        }
+                    },
+                    None => 0,
+                };
+
+                self.fib_handle.link_set_master(ifindex, master).await;
+                tracing::info!(
+                    "link_vrf_bind: ifname={} ifindex={} master={} vrf={:?}",
+                    ifname,
+                    ifindex,
+                    master,
+                    vrf
+                );
             }
             Message::BlockAdd { name, config } => {
                 let block = config.to_block(&name);

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -931,8 +931,7 @@ impl Rib {
                 if vrf.is_none() {
                     self.pending_vrf_bind.remove(&ifname);
                 } else {
-                    self.pending_vrf_bind
-                        .insert(ifname.clone(), vrf.clone());
+                    self.pending_vrf_bind.insert(ifname.clone(), vrf.clone());
                 }
 
                 let Some(link) = self.links.values().find(|l| l.name == ifname) else {

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -133,12 +133,7 @@ impl fmt::Display for LinkType {
     }
 }
 
-fn link_info_show(
-    rib: &Rib,
-    link: &Link,
-    buf: &mut String,
-    cb: &impl Fn(&String, &mut String),
-) {
+fn link_info_show(rib: &Rib, link: &Link, buf: &mut String, cb: &impl Fn(&String, &mut String)) {
     writeln!(buf, "Interface: {}", link.name).unwrap();
     write!(buf, "  Hardware is {}", link.link_type).unwrap();
     if link.link_type == LinkType::Ethernet {

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -133,7 +133,12 @@ impl fmt::Display for LinkType {
     }
 }
 
-fn link_info_show(link: &Link, buf: &mut String, cb: &impl Fn(&String, &mut String)) {
+fn link_info_show(
+    rib: &Rib,
+    link: &Link,
+    buf: &mut String,
+    cb: &impl Fn(&String, &mut String),
+) {
     writeln!(buf, "Interface: {}", link.name).unwrap();
     write!(buf, "  Hardware is {}", link.link_type).unwrap();
     if link.link_type == LinkType::Ethernet {
@@ -158,7 +163,10 @@ fn link_info_show(link: &Link, buf: &mut String, cb: &impl Fn(&String, &mut Stri
     )
     .unwrap();
     writeln!(buf, "  {}", link.flags).unwrap();
-    writeln!(buf, "  VRF Binding: Not bound").unwrap();
+    let vrf_label = link_vrf_name(rib, link)
+        .map(|n| format!("vrf {}", n))
+        .unwrap_or_else(|| "Not bound".to_string());
+    writeln!(buf, "  VRF Binding: {}", vrf_label).unwrap();
     writeln!(
         buf,
         "  Label switching is {}",
@@ -219,12 +227,13 @@ pub fn link_brief_show(rib: &Rib, buf: &mut String) {
 
     for link in rib.links.values() {
         let status = if link.is_up() { "Up" } else { "Down" };
+        let vrf = link_vrf_name(rib, link).unwrap_or("default");
         let addrs = link.addr4.iter().chain(link.addr6.iter());
 
         let mut addrs_iter = addrs.peekable();
         if addrs_iter.peek().is_none() {
             // No addresses
-            writeln!(buf, "{:<16} {:<6} {:<14}", link.name, status, "default").unwrap();
+            writeln!(buf, "{:<16} {:<6} {:<14}", link.name, status, vrf).unwrap();
         } else {
             let mut first = true;
             for addr in addrs_iter {
@@ -232,7 +241,7 @@ pub fn link_brief_show(rib: &Rib, buf: &mut String) {
                     writeln!(
                         buf,
                         "{:<16} {:<6} {:<14} {}",
-                        link.name, status, "default", addr.addr
+                        link.name, status, vrf, addr.addr
                     )
                     .unwrap();
                     first = false;
@@ -262,7 +271,9 @@ pub fn link_brief_show_json(rib: &Rib) -> String {
             } else {
                 "Down".to_string()
             },
-            vrf: "default".to_string(),
+            vrf: link_vrf_name(rib, link)
+                .map(str::to_string)
+                .unwrap_or_else(|| "default".to_string()),
             addresses,
         };
 
@@ -278,7 +289,7 @@ pub fn link_detailed_show_json(rib: &Rib, link_name: Option<&str>) -> String {
     if let Some(name) = link_name {
         // Show single interface
         if let Some(link) = rib.link_by_name(name) {
-            interfaces.push(link_to_detailed_json(link));
+            interfaces.push(link_to_detailed_json(rib, link));
         } else {
             let error = serde_json::json!({
                 "error": format!("interface {} not found", name)
@@ -288,14 +299,14 @@ pub fn link_detailed_show_json(rib: &Rib, link_name: Option<&str>) -> String {
     } else {
         // Show all interfaces
         for link in rib.links.values() {
-            interfaces.push(link_to_detailed_json(link));
+            interfaces.push(link_to_detailed_json(rib, link));
         }
     }
 
     serde_json::to_string_pretty(&interfaces).unwrap_or_else(|_| "{}".to_string())
 }
 
-fn link_to_detailed_json(link: &Link) -> InterfaceDetailed {
+fn link_to_detailed_json(rib: &Rib, link: &Link) -> InterfaceDetailed {
     let inet_addresses: Vec<InterfaceAddress> = link
         .addr4
         .iter()
@@ -323,7 +334,9 @@ fn link_to_detailed_json(link: &Link) -> InterfaceDetailed {
             "Down".to_string()
         },
         flags: format!("{}", link.flags),
-        vrf_binding: "Not bound".to_string(),
+        vrf_binding: link_vrf_name(rib, link)
+            .map(|n| format!("vrf {}", n))
+            .unwrap_or_else(|| "Not bound".to_string()),
         label_switching: if link.label {
             "enabled".to_string()
         } else {
@@ -344,7 +357,7 @@ pub fn link_show(rib: &Rib, mut args: Args, json: bool) -> String {
             return link_detailed_show_json(rib, None);
         } else {
             for (_, link) in rib.links.iter() {
-                link_info_show(link, &mut buf, &cb);
+                link_info_show(rib, link, &mut buf, &cb);
             }
         }
     } else {
@@ -363,7 +376,7 @@ pub fn link_show(rib: &Rib, mut args: Args, json: bool) -> String {
             return link_detailed_show_json(rib, Some(&link_name));
         } else {
             if let Some(link) = rib.link_by_name(&link_name) {
-                link_info_show(link, &mut buf, &cb)
+                link_info_show(rib, link, &mut buf, &cb)
             } else {
                 write!(buf, "% interface {} not found", link_name).unwrap();
             }
@@ -546,6 +559,18 @@ impl Rib {
             && prev_evpn_bridge != Some(bridge)
         {
             self.rescan_fdb_for_bridge(bridge);
+        }
+
+        // If a VRF binding is pending for this interface (operator
+        // configured it before the kernel device appeared, or before
+        // the VRF master was created), replay it now.
+        let ifname = self
+            .links
+            .get(&ifindex)
+            .map(|l| l.name.clone())
+            .unwrap_or_default();
+        if let Some(vrf) = self.pending_vrf_bind.get(&ifname).cloned() {
+            let _ = self.tx.send(Message::LinkVrfBind { ifname, vrf });
         }
     }
 
@@ -881,6 +906,19 @@ pub async fn link_config_exec(
                 println!("Interface {} not found", ifname);
             }
         }
+    } else if path == "/interface/vrf" {
+        // `set interface X vrf Y`   → enslave X to VRF master Y.
+        // `delete interface X vrf [Y]` → unbind X from whatever VRF it
+        // currently sits in. The optional Y on delete is ignored: the
+        // intent is unambiguous and we want to tolerate either form.
+        let vrf = if op.is_set() {
+            Some(args.string().context("missing vrf name")?)
+        } else {
+            // Drain any trailing token so it isn't picked up later.
+            let _ = args.string();
+            None
+        };
+        let _ = rib.tx.send(Message::LinkVrfBind { ifname, vrf });
     }
     Ok(())
 }
@@ -893,6 +931,18 @@ pub fn link_lookup(rib: &Rib, name: String) -> Option<u32> {
     }
 
     None
+}
+
+/// Resolve the VRF a link is enslaved to, by matching `link.master`
+/// against the ifindex of each known VRF master device. Returns
+/// `Some(name)` if the link is in a configured VRF, `None` for the
+/// default VRF or for slaves of non-VRF masters (e.g. bridges).
+pub fn link_vrf_name<'a>(rib: &'a Rib, link: &Link) -> Option<&'a str> {
+    let master = link.master?;
+    rib.vrfs
+        .values()
+        .find(|v| v.ifindex == master)
+        .map(|v| v.name.as_str())
 }
 
 #[cfg(test)]

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -980,10 +980,23 @@ impl Rib {
 
 pub fn vrf_show(rib: &Rib, _args: Args, _json: bool) -> String {
     let mut buf = String::new();
-    writeln!(buf, " {:<32}{:>10}", "Name", "Table-ID").unwrap();
-    writeln!(buf, " {:-<32}  {:-<10}", "", "").unwrap();
+    writeln!(buf, " {:<24}{:>10}  Members", "Name", "Table-ID").unwrap();
+    writeln!(buf, " {:-<24}  {:-<10}  {:-<32}", "", "", "").unwrap();
     for vrf in rib.vrfs.values() {
-        writeln!(buf, " {:<32}{:>10}", vrf.name, vrf.table_id).unwrap();
+        let members: Vec<&str> = rib
+            .links
+            .values()
+            .filter(|l| l.master == Some(vrf.ifindex))
+            .map(|l| l.name.as_str())
+            .collect();
+        writeln!(
+            buf,
+            " {:<24}{:>10}  {}",
+            vrf.name,
+            vrf.table_id,
+            members.join(", ")
+        )
+        .unwrap();
     }
     buf
 }

--- a/zebra-rs/src/rib/vrf/inst.rs
+++ b/zebra-rs/src/rib/vrf/inst.rs
@@ -3,10 +3,11 @@
 /// Created when `Message::VrfAdd { name }` is handled by the RIB —
 /// the allocator hands out a fresh table ID, the netlink layer creates
 /// the kernel `vrf` master interface, and the result is recorded here.
-/// `ifindex` is filled in opportunistically when the kernel emits the
-/// resulting `NewLink`; until then it stays `None`.
+/// `ifindex` is the kernel-assigned ifindex of the VRF master device;
+/// callers enslave member interfaces to it via `IFLA_MASTER`.
 #[derive(Debug, Clone)]
 pub struct Vrf {
     pub name: String,
     pub table_id: u32,
+    pub ifindex: u32,
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -773,6 +773,15 @@ module config {
         ext:dynamic "rib:interface";
         type string;
       }
+      leaf vrf {
+        type leafref {
+          path "/vrf/name";
+        }
+        description
+          "Enslave this interface to the named VRF master device.
+           Omitted means the interface lives in the default routing
+           instance.";
+      }
       container ipv4 {
         leaf address {
           type inet:ipv4-prefix;


### PR DESCRIPTION
## Summary

- Adds `leaf vrf` (leafref to `/vrf/name`) to `list interface` in `config.yang`, enabling per-interface VRF binding via the standard config tree.
- Threads the operator intent through a new `Message::LinkVrfBind` handler that programs `IFLA_MASTER` on the kernel side (`fib::netlink::handle::link_set_master`).
- Tolerates ordering: if the interface or the VRF master device isn't present yet, the intent is staged in `pending_vrf_bind` and replayed on the next `NewLink` / `VrfAdd`.
- `show vrf` and `show interface [brief]` now reflect the real binding (members column / VRF name) instead of the previous hardcoded `default` / `Not bound`.

## Operator UX

```
set vrf vrf1
set interface enp0s6 vrf vrf1
set interface enp0s6 ipv4 address 192.168.10.1/24
```

`delete interface enp0s6 vrf` returns the interface to the default VRF (sets master to 0).

## Out of scope (follow-ups)

This PR is the foundation. It does **not** yet:

- Program connected/static routes into the bound VRF's table.
- Bind BGP/OSPF/ISIS protocol instances to a non-default VRF.

Those build on the binding plumbing landed here.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo clippy -p zebra-rs --no-deps` clean
- [x] `cargo test -p zebra-rs --bins` (171 unit tests pass)
- [ ] BDD: configure `vrf vrf1`, bind `enp0s6`, verify `ip -d link show enp0s6` reports `master vrf1`
- [ ] BDD: `delete interface enp0s6 vrf`, verify `nomaster`
- [ ] BDD: configure binding before kernel device exists; create dummy → binding fires automatically
- [ ] BDD: configure binding before VRF; commit creates VRF first then enslaves
- [ ] Verify IPv6 address persistence across enslave on the target kernel (older kernels flush; we may need explicit re-add)

Scenario doc: `bdd/docs/interface_vrf_binding.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)