### PR TITLE
bgp: add as-path-set, next-hop, MED, and origin route-map match clauses

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -32,6 +32,10 @@ bgp_evpn_capability:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_capability"
 
+bgp_route_map_match:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_route_map_match"
+
 generate:
 	rm -rf allure-report
 	allure generate
@@ -51,4 +55,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 bgp_evpn_capability generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 bgp_evpn_capability bgp_route_map_match generate open docs FORCE

--- a/bdd/docs/bgp_route_map_match.md
+++ b/bdd/docs/bgp_route_map_match.md
@@ -1,0 +1,54 @@
+# BGP route-map match clauses
+
+## Overview
+
+As a network operator
+I want zebra-rs policy-list entries to filter received routes by
+All four match types are exercised against an established eBGP session
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                   │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+```
+
+## Config Files
+
+- z1.yaml: AS 65001, advertises 10.0.0.1/32 + 10.0.0.2/32, outbound
+- z2-base.yaml: AS 65002, no input policy; baseline that accepts both
+- z2-aspath-pass.yaml: input policy `match as-path-set FROM-65001`
+- z2-aspath-fail.yaml: input policy `match as-path-set FROM-65999`
+- z2-origin-igp.yaml: input policy `match origin igp` — matches
+- z2-origin-egp.yaml: input policy `match origin egp` — no route
+- z2-med-eq-pass.yaml: input policy `match med-eq 100` — matches.
+- z2-med-eq-fail.yaml: input policy `match med-eq 999` — no match.
+- z2-med-range-pass.yaml: input policy `match med-ge 50, med-le 200`
+- z2-med-range-fail.yaml: input policy `match med-ge 200` — MED=100
+- z2-nh-pass.yaml: input policy `match next-hop-set PEER-SUBNET`
+- z2-nh-fail.yaml: input policy `match next-hop-set WRONG-SUBNET`
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish BGP session with MED-stamping policy | |
+| match as-path-set accepts routes whose AS_PATH matches the regex | |
+| match as-path-set rejects routes whose AS_PATH does not match | |
+| match origin igp accepts network-originated routes | |
+| match origin egp rejects network-originated (igp) routes | |
+| match med-eq accepts routes with the exact MED value | |
+| match med-eq rejects routes with a different MED value | |
+| match med-ge and med-le accept routes inside the range | |
+| match med-ge rejects routes below the floor | |
+| match next-hop-set accepts routes whose nexthop is in the prefix-set | |
+| match next-hop-set rejects routes whose nexthop is outside the prefix-set | |
+| Teardown topology | |

--- a/bdd/tests/configs/bgp_route_map_match/z1.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z1.yaml
@@ -1,0 +1,33 @@
+prefix-set:
+- name: ALL-V4
+  prefixes:
+  - prefix: 0.0.0.0/0
+    le: 32
+policy-options:
+  policy:
+  - name: SET-MED-100
+    entry:
+    - number: 10
+      match:
+        prefix-set: ALL-V4
+      set:
+        med: 100
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4-unicast
+        enabled: true
+      apply-policy:
+        out: SET-MED-100
+      enabled: true
+      peer-as: 65002
+    afi-safi:
+    - name: ipv4-unicast
+      network:
+      - prefix: 10.0.0.1/32
+      - prefix: 10.0.0.2/32

--- a/bdd/tests/configs/bgp_route_map_match/z2-aspath-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-aspath-fail.yaml
@@ -1,0 +1,25 @@
+as-path-set:
+- name: FROM-65999
+  member:
+  - "^65999$"
+policy-options:
+  policy:
+  - name: IN-ASPATH
+    entry:
+    - number: 10
+      match:
+        as-path-set: FROM-65999
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4-unicast
+        enabled: true
+      apply-policy:
+        in: IN-ASPATH
+      enabled: true
+      peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-aspath-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-aspath-pass.yaml
@@ -1,0 +1,25 @@
+as-path-set:
+- name: FROM-65001
+  member:
+  - "^65001$"
+policy-options:
+  policy:
+  - name: IN-ASPATH
+    entry:
+    - number: 10
+      match:
+        as-path-set: FROM-65001
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4-unicast
+        enabled: true
+      apply-policy:
+        in: IN-ASPATH
+      enabled: true
+      peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-base.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-base.yaml
@@ -1,0 +1,12 @@
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4-unicast
+        enabled: true
+      enabled: true
+      peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-eq-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-eq-fail.yaml
@@ -1,0 +1,21 @@
+policy-options:
+  policy:
+  - name: IN-MED
+    entry:
+    - number: 10
+      match:
+        med-eq: 999
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4-unicast
+        enabled: true
+      apply-policy:
+        in: IN-MED
+      enabled: true
+      peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-eq-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-eq-pass.yaml
@@ -1,0 +1,21 @@
+policy-options:
+  policy:
+  - name: IN-MED
+    entry:
+    - number: 10
+      match:
+        med-eq: 100
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4-unicast
+        enabled: true
+      apply-policy:
+        in: IN-MED
+      enabled: true
+      peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-range-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-range-fail.yaml
@@ -1,0 +1,21 @@
+policy-options:
+  policy:
+  - name: IN-MED
+    entry:
+    - number: 10
+      match:
+        med-ge: 200
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4-unicast
+        enabled: true
+      apply-policy:
+        in: IN-MED
+      enabled: true
+      peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-range-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-range-pass.yaml
@@ -1,0 +1,22 @@
+policy-options:
+  policy:
+  - name: IN-MED
+    entry:
+    - number: 10
+      match:
+        med-ge: 50
+        med-le: 200
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4-unicast
+        enabled: true
+      apply-policy:
+        in: IN-MED
+      enabled: true
+      peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-nh-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-nh-fail.yaml
@@ -1,0 +1,26 @@
+prefix-set:
+- name: WRONG-SUBNET
+  prefixes:
+  - prefix: 10.10.0.0/16
+    le: 32
+policy-options:
+  policy:
+  - name: IN-NEXTHOP
+    entry:
+    - number: 10
+      match:
+        next-hop-set: WRONG-SUBNET
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4-unicast
+        enabled: true
+      apply-policy:
+        in: IN-NEXTHOP
+      enabled: true
+      peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-nh-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-nh-pass.yaml
@@ -1,0 +1,26 @@
+prefix-set:
+- name: PEER-SUBNET
+  prefixes:
+  - prefix: 192.168.0.0/24
+    le: 32
+policy-options:
+  policy:
+  - name: IN-NEXTHOP
+    entry:
+    - number: 10
+      match:
+        next-hop-set: PEER-SUBNET
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4-unicast
+        enabled: true
+      apply-policy:
+        in: IN-NEXTHOP
+      enabled: true
+      peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-origin-egp.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-origin-egp.yaml
@@ -1,0 +1,21 @@
+policy-options:
+  policy:
+  - name: IN-ORIGIN
+    entry:
+    - number: 10
+      match:
+        origin: egp
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4-unicast
+        enabled: true
+      apply-policy:
+        in: IN-ORIGIN
+      enabled: true
+      peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-origin-igp.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-origin-igp.yaml
@@ -1,0 +1,21 @@
+policy-options:
+  policy:
+  - name: IN-ORIGIN
+    entry:
+    - number: 10
+      match:
+        origin: igp
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4-unicast
+        enabled: true
+      apply-policy:
+        in: IN-ORIGIN
+      enabled: true
+      peer-as: 65001

--- a/bdd/tests/features/bgp_route_map_match.feature
+++ b/bdd/tests/features/bgp_route_map_match.feature
@@ -1,0 +1,156 @@
+@serial
+@bgp_route_map_match
+Feature: BGP route-map match clauses
+  As a network operator
+  I want zebra-rs policy-list entries to filter received routes by
+  as-path-set, next-hop-set, MED comparison, and origin, so that
+  inbound policy can express the same conditions as IOS-XR RPL.
+
+  All four match types are exercised against an established eBGP session
+  by swapping z2's input policy and asserting which advertised prefixes
+  appear in z2's RIB. z1 attaches an outbound policy that stamps MED=100
+  on every advertised route so MED match scenarios have something
+  deterministic to compare against.
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                   │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+  ```
+
+  Config files:
+  - z1.yaml: AS 65001, advertises 10.0.0.1/32 + 10.0.0.2/32, outbound
+    SET-MED-100 stamps MED=100 on every route.
+  - z2-base.yaml: AS 65002, no input policy; baseline that accepts both
+    routes.
+  - z2-aspath-pass.yaml: input policy `match as-path-set FROM-65001`
+    (regex `^65001$`) — matches the single-AS path from z1.
+  - z2-aspath-fail.yaml: input policy `match as-path-set FROM-65999`
+    (regex `^65999$`) — no route matches.
+  - z2-origin-igp.yaml: input policy `match origin igp` — matches
+    network-originated routes.
+  - z2-origin-egp.yaml: input policy `match origin egp` — no route
+    matches.
+  - z2-med-eq-pass.yaml: input policy `match med-eq 100` — matches.
+  - z2-med-eq-fail.yaml: input policy `match med-eq 999` — no match.
+  - z2-med-range-pass.yaml: input policy `match med-ge 50, med-le 200`
+    — matches MED=100.
+  - z2-med-range-fail.yaml: input policy `match med-ge 200` — MED=100
+    is below the floor, no match.
+  - z2-nh-pass.yaml: input policy `match next-hop-set PEER-SUBNET`
+    where the prefix-set is 192.168.0.0/24 — matches z1's nexthop
+    192.168.0.1.
+  - z2-nh-fail.yaml: input policy `match next-hop-set WRONG-SUBNET`
+    where the prefix-set is 10.10.0.0/16 — no route matches.
+
+  Scenario: Setup topology and establish BGP session with MED-stamping policy
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2-base.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP route in "z2" has "10.0.0.1/32"
+    And BGP route in "z2" has "10.0.0.2/32"
+
+  Scenario: match as-path-set accepts routes whose AS_PATH matches the regex
+    Given the test topology exists
+    When I apply config "z2-aspath-pass.yaml" to namespace "z2"
+    And I clear namespace "z2" neighbor "192.168.0.1"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z2" has "10.0.0.1/32"
+    And BGP route in "z2" has "10.0.0.2/32"
+
+  Scenario: match as-path-set rejects routes whose AS_PATH does not match
+    Given the test topology exists
+    When I apply config "z2-aspath-fail.yaml" to namespace "z2"
+    And I clear namespace "z2" neighbor "192.168.0.1"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z2" does not have "10.0.0.1/32"
+    And BGP route in "z2" does not have "10.0.0.2/32"
+
+  Scenario: match origin igp accepts network-originated routes
+    Given the test topology exists
+    When I apply config "z2-origin-igp.yaml" to namespace "z2"
+    And I clear namespace "z2" neighbor "192.168.0.1"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z2" has "10.0.0.1/32"
+    And BGP route in "z2" has "10.0.0.2/32"
+
+  Scenario: match origin egp rejects network-originated (igp) routes
+    Given the test topology exists
+    When I apply config "z2-origin-egp.yaml" to namespace "z2"
+    And I clear namespace "z2" neighbor "192.168.0.1"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z2" does not have "10.0.0.1/32"
+    And BGP route in "z2" does not have "10.0.0.2/32"
+
+  Scenario: match med-eq accepts routes with the exact MED value
+    Given the test topology exists
+    When I apply config "z2-med-eq-pass.yaml" to namespace "z2"
+    And I clear namespace "z2" neighbor "192.168.0.1"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z2" has "10.0.0.1/32"
+    And BGP route in "z2" has "10.0.0.2/32"
+
+  Scenario: match med-eq rejects routes with a different MED value
+    Given the test topology exists
+    When I apply config "z2-med-eq-fail.yaml" to namespace "z2"
+    And I clear namespace "z2" neighbor "192.168.0.1"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z2" does not have "10.0.0.1/32"
+    And BGP route in "z2" does not have "10.0.0.2/32"
+
+  Scenario: match med-ge and med-le accept routes inside the range
+    Given the test topology exists
+    When I apply config "z2-med-range-pass.yaml" to namespace "z2"
+    And I clear namespace "z2" neighbor "192.168.0.1"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z2" has "10.0.0.1/32"
+    And BGP route in "z2" has "10.0.0.2/32"
+
+  Scenario: match med-ge rejects routes below the floor
+    Given the test topology exists
+    When I apply config "z2-med-range-fail.yaml" to namespace "z2"
+    And I clear namespace "z2" neighbor "192.168.0.1"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z2" does not have "10.0.0.1/32"
+    And BGP route in "z2" does not have "10.0.0.2/32"
+
+  Scenario: match next-hop-set accepts routes whose nexthop is in the prefix-set
+    Given the test topology exists
+    When I apply config "z2-nh-pass.yaml" to namespace "z2"
+    And I clear namespace "z2" neighbor "192.168.0.1"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z2" has "10.0.0.1/32"
+    And BGP route in "z2" has "10.0.0.2/32"
+
+  Scenario: match next-hop-set rejects routes whose nexthop is outside the prefix-set
+    Given the test topology exists
+    When I apply config "z2-nh-fail.yaml" to namespace "z2"
+    And I clear namespace "z2" neighbor "192.168.0.1"
+    And I wait 5 seconds for BGP to operate
+    Then BGP route in "z2" does not have "10.0.0.1/32"
+    And BGP route in "z2" does not have "10.0.0.2/32"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2165,36 +2165,69 @@ pub fn policy_list_apply(
     mut bgp_attr: BgpAttr,
 ) -> Option<BgpAttr> {
     for (_, entry) in policy_list.entry.iter() {
-        let mut prefix_matched: Option<bool> = None;
-        if let Some(prefix_set) = &entry.prefix_set {
-            if prefix_set.matches(nlri.prefix) {
-                prefix_matched = Some(true);
-            } else {
-                prefix_matched = Some(false);
-            }
+        if !entry_matches(entry, nlri, &bgp_attr) {
+            continue;
         }
-        let mut community_matched: Option<bool> = None;
-        if let Some(community_set) = &entry.community_set {
-            if community_set.matches(&bgp_attr) {
-                community_matched = Some(true);
-            } else {
-                community_matched = Some(false);
-            }
+        if let Some(med) = &entry.med {
+            bgp_attr.med = Some(Med { med: *med });
         }
-        // If we matched to the statement or no match statement at all.
-        match (prefix_matched, community_matched) {
-            (None | Some(true), None | Some(true)) => {
-                if let Some(med) = &entry.med {
-                    bgp_attr.med = Some(Med { med: *med });
-                }
-                return Some(bgp_attr);
-            }
-            (_, _) => {
-                //
-            }
-        }
+        return Some(bgp_attr);
     }
     None
+}
+
+fn entry_matches(entry: &crate::policy::PolicyEntry, nlri: &Ipv4Nlri, bgp_attr: &BgpAttr) -> bool {
+    if let Some(prefix_set) = &entry.prefix_set
+        && !prefix_set.matches(nlri.prefix)
+    {
+        return false;
+    }
+    if let Some(community_set) = &entry.community_set
+        && !community_set.matches(bgp_attr)
+    {
+        return false;
+    }
+    if let Some(as_path_set) = &entry.as_path_set
+        && !as_path_set.matches(bgp_attr)
+    {
+        return false;
+    }
+    if let Some(next_hop_set) = &entry.next_hop_set {
+        let Some(BgpNexthop::Ipv4(addr)) = bgp_attr.nexthop.as_ref() else {
+            return false;
+        };
+        let net = ipnet::Ipv4Net::new(*addr, 32).expect("valid /32 nexthop");
+        if !next_hop_set.matches(net) {
+            return false;
+        }
+    }
+    if let Some(eq) = entry.match_med_eq {
+        let med = bgp_attr.med.as_ref().map(|m| m.med).unwrap_or(0);
+        if med != eq {
+            return false;
+        }
+    }
+    if let Some(ge) = entry.match_med_ge {
+        let med = bgp_attr.med.as_ref().map(|m| m.med).unwrap_or(0);
+        if med < ge {
+            return false;
+        }
+    }
+    if let Some(le) = entry.match_med_le {
+        let med = bgp_attr.med.as_ref().map(|m| m.med).unwrap_or(0);
+        if med > le {
+            return false;
+        }
+    }
+    if let Some(want) = entry.match_origin {
+        let Some(have) = bgp_attr.origin else {
+            return false;
+        };
+        if have != want {
+            return false;
+        }
+    }
+    true
 }
 
 pub fn route_sync_ipv4(peer: &mut Peer, bgp: &mut BgpTop) {
@@ -2801,4 +2834,149 @@ fn evpn_encap_vxlan() -> ExtCommunityValue {
     // Encapsulation type 8 = VXLAN, occupies the trailing 2 octets.
     encap.val[5] = 8;
     encap
+}
+
+#[cfg(test)]
+mod policy_apply_tests {
+    use std::str::FromStr;
+
+    use bgp_packet::{As4Path, BgpNexthop, Med, Origin};
+    use ipnet::Ipv4Net;
+
+    use super::*;
+    use crate::policy::prefix::set::PrefixSetEntry;
+    use crate::policy::{AsPathMatcher, AsPathSet, PolicyList, PrefixSet};
+
+    fn nlri(prefix: &str) -> Ipv4Nlri {
+        Ipv4Nlri {
+            id: 0,
+            prefix: Ipv4Net::from_str(prefix).unwrap(),
+        }
+    }
+
+    fn attr_with(path: &str, med: Option<u32>, origin: Option<Origin>) -> BgpAttr {
+        let mut attr = BgpAttr::new();
+        attr.aspath = Some(As4Path::from_str(path).unwrap());
+        attr.med = med.map(|m| Med { med: m });
+        attr.origin = origin;
+        attr
+    }
+
+    #[test]
+    fn match_as_path_set() {
+        let mut set = AsPathSet::default();
+        set.vals
+            .insert(AsPathMatcher::from_str("\\b65001\\b").unwrap());
+
+        let mut list = PolicyList::default();
+        let entry = list.entry(10);
+        entry.as_path_set = Some(set);
+
+        let attr_match = attr_with("65001 65002 65003", None, None);
+        let attr_miss = attr_with("65010 65020", None, None);
+
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_match).is_some());
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_miss).is_none());
+    }
+
+    #[test]
+    fn match_med_eq_ge_le() {
+        let mut list = PolicyList::default();
+        let entry = list.entry(10);
+        entry.match_med_ge = Some(100);
+        entry.match_med_le = Some(200);
+
+        assert!(
+            policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", Some(150), None))
+                .is_some()
+        );
+        assert!(
+            policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", Some(50), None)).is_none()
+        );
+        assert!(
+            policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", Some(250), None))
+                .is_none()
+        );
+
+        let mut list = PolicyList::default();
+        let entry = list.entry(10);
+        entry.match_med_eq = Some(100);
+        assert!(
+            policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", Some(100), None))
+                .is_some()
+        );
+        assert!(
+            policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", Some(101), None))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn match_origin() {
+        let mut list = PolicyList::default();
+        let entry = list.entry(10);
+        entry.match_origin = Some(Origin::Egp);
+
+        assert!(
+            policy_list_apply(
+                &list,
+                &nlri("10.0.0.0/8"),
+                attr_with("1", None, Some(Origin::Egp))
+            )
+            .is_some()
+        );
+        assert!(
+            policy_list_apply(
+                &list,
+                &nlri("10.0.0.0/8"),
+                attr_with("1", None, Some(Origin::Igp))
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn match_next_hop_set() {
+        let mut next_hop = PrefixSet::default();
+        next_hop.prefixes.insert(
+            Ipv4Net::from_str("10.0.0.0/8").unwrap().into(),
+            PrefixSetEntry::default(),
+        );
+
+        let mut list = PolicyList::default();
+        let entry = list.entry(10);
+        entry.next_hop_set = Some(next_hop);
+
+        let mut attr_in = attr_with("1", None, None);
+        attr_in.nexthop = Some(BgpNexthop::Ipv4(std::net::Ipv4Addr::new(10, 1, 1, 1)));
+
+        let mut attr_out = attr_with("1", None, None);
+        attr_out.nexthop = Some(BgpNexthop::Ipv4(std::net::Ipv4Addr::new(192, 168, 0, 1)));
+
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_in).is_some());
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_out).is_none());
+    }
+
+    #[test]
+    fn multiple_match_clauses_all_required() {
+        let mut set = AsPathSet::default();
+        set.vals
+            .insert(AsPathMatcher::from_str("^65001\\b").unwrap());
+
+        let mut list = PolicyList::default();
+        let entry = list.entry(10);
+        entry.as_path_set = Some(set);
+        entry.match_origin = Some(Origin::Igp);
+        entry.match_med_le = Some(50);
+
+        let pass = attr_with("65001 65002", Some(40), Some(Origin::Igp));
+        let bad_origin = attr_with("65001 65002", Some(40), Some(Origin::Egp));
+        let bad_med = attr_with("65001 65002", Some(60), Some(Origin::Igp));
+        let bad_path = attr_with("65010 65002", Some(40), Some(Origin::Igp));
+
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), pass).is_some());
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), bad_origin).is_none());
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), bad_med).is_none());
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), bad_path).is_none());
+    }
 }

--- a/zebra-rs/src/policy/aspath/config.rs
+++ b/zebra-rs/src/policy/aspath/config.rs
@@ -1,0 +1,169 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::str::FromStr;
+
+use anyhow::{Context, Result};
+
+use crate::{
+    config::{Args, ConfigOp},
+    policy::AsPathMatcher,
+};
+
+use super::AsPathSet;
+
+#[derive(Default)]
+pub struct AsPathSetConfig {
+    pub config: BTreeMap<String, AsPathSet>,
+    pub cache: BTreeMap<String, AsPathSet>,
+    builder: ConfigBuilder,
+}
+
+impl AsPathSetConfig {
+    pub fn new() -> Self {
+        AsPathSetConfig {
+            config: BTreeMap::new(),
+            cache: BTreeMap::new(),
+            builder: ConfigBuilder::new(),
+        }
+    }
+
+    pub fn exec(&mut self, path: String, mut args: Args, op: ConfigOp) -> Result<()> {
+        const CONFIG_ERR: &str = "missing config handler";
+        const AS_PATH_SET_NAME_ERR: &str = "missing as-path-set name arg";
+
+        let handler = self
+            .builder
+            .map
+            .get(&(path.to_string(), op))
+            .context(CONFIG_ERR)?;
+
+        let name = args.string().context(AS_PATH_SET_NAME_ERR)?;
+
+        handler(&mut self.config, &mut self.cache, &name, &mut args)
+    }
+
+    pub fn commit(&mut self) {
+        while let Some((name, s)) = self.cache.pop_first() {
+            if s.delete {
+                self.config.remove(&name);
+            } else {
+                self.config.insert(name, s);
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct ConfigBuilder {
+    path: String,
+    map: BTreeMap<(String, ConfigOp), Handler>,
+}
+
+type Handler = fn(
+    config: &mut BTreeMap<String, AsPathSet>,
+    cache: &mut BTreeMap<String, AsPathSet>,
+    name: &String,
+    args: &mut Args,
+) -> Result<()>;
+
+fn config_get(clist: &BTreeMap<String, AsPathSet>, name: &String) -> AsPathSet {
+    let Some(entry) = clist.get(name) else {
+        return AsPathSet {
+            vals: BTreeSet::new(),
+            delete: false,
+        };
+    };
+    AsPathSet {
+        vals: entry.vals.clone(),
+        delete: entry.delete,
+    }
+}
+
+fn config_lookup(clist: &BTreeMap<String, AsPathSet>, name: &String) -> Option<AsPathSet> {
+    let entry = clist.get(name)?;
+    Some(AsPathSet {
+        vals: entry.vals.clone(),
+        delete: entry.delete,
+    })
+}
+
+fn cache_get<'a>(
+    config: &'a BTreeMap<String, AsPathSet>,
+    cache: &'a mut BTreeMap<String, AsPathSet>,
+    name: &'a String,
+) -> Option<&'a mut AsPathSet> {
+    if cache.get(name).is_none() {
+        cache.insert(name.to_string(), config_get(config, name));
+    }
+    cache.get_mut(name)
+}
+
+fn cache_lookup<'a>(
+    config: &'a BTreeMap<String, AsPathSet>,
+    cache: &'a mut BTreeMap<String, AsPathSet>,
+    name: &'a String,
+) -> Option<&'a mut AsPathSet> {
+    if cache.get(name).is_none() {
+        cache.insert(name.to_string(), config_lookup(config, name)?);
+    }
+    let cache = cache.get_mut(name)?;
+    if cache.delete { None } else { Some(cache) }
+}
+
+impl ConfigBuilder {
+    pub fn new() -> Self {
+        const CONFIG_ERR: &str = "missing config";
+        const MEMBER_ERR: &str = "missing member";
+
+        ConfigBuilder::default()
+            .path("")
+            .set(|config, cache, name, _args| {
+                let _ = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                if let Some(list) = cache.get_mut(name) {
+                    list.delete = true;
+                } else {
+                    let mut list = config_lookup(config, name).context(CONFIG_ERR)?;
+                    list.delete = true;
+                    cache.insert(name.to_string(), list);
+                }
+                Ok(())
+            })
+            .path("/member")
+            .set(|config, cache, name, args| {
+                let set = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                while let Some(member_str) = args.string() {
+                    if let Ok(matcher) = AsPathMatcher::from_str(&member_str) {
+                        set.vals.insert(matcher);
+                    }
+                }
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let member_str = args.string().context(MEMBER_ERR)?;
+                let set = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+
+                if let Ok(matcher) = AsPathMatcher::from_str(&member_str) {
+                    set.vals.retain(|x| x.pattern() != matcher.pattern());
+                }
+                Ok(())
+            })
+    }
+
+    pub fn path(mut self, path: &str) -> Self {
+        let prefix = "/as-path-set";
+        self.path = format!("{prefix}{path}");
+        self
+    }
+
+    pub fn set(mut self, func: Handler) -> Self {
+        self.map.insert((self.path.clone(), ConfigOp::Set), func);
+        self
+    }
+
+    pub fn del(mut self, func: Handler) -> Self {
+        self.map.insert((self.path.clone(), ConfigOp::Delete), func);
+        self
+    }
+}

--- a/zebra-rs/src/policy/aspath/mod.rs
+++ b/zebra-rs/src/policy/aspath/mod.rs
@@ -1,0 +1,10 @@
+pub mod config;
+pub use config::AsPathSetConfig;
+
+pub mod parser;
+pub use parser::*;
+
+pub mod set;
+pub use set::AsPathSet;
+
+pub mod show;

--- a/zebra-rs/src/policy/aspath/parser.rs
+++ b/zebra-rs/src/policy/aspath/parser.rs
@@ -1,0 +1,124 @@
+// BGP AS-Path Matcher Implementation
+//
+// Each member of an as-path-set is a regular expression matched against the
+// route's AS_PATH attribute rendered as a space-separated string (e.g.
+// "65001 65002 65003" or "65001 {65010 65011} 65003").
+//
+// Examples:
+//   as-path-set CUSTOMER {
+//     member ^65001 .*;        // path starts with 65001 (neighbor-is)
+//     member 65535$;           // path ends with 65535 (originates-from)
+//     member \\b65001\\b;      // 65001 anywhere in the path
+//   }
+
+use std::str::FromStr;
+
+use bgp_packet::BgpAttr;
+use regex::Regex;
+
+#[derive(Clone)]
+pub struct AsPathMatcher {
+    pattern: String,
+    regex: Regex,
+}
+
+impl AsPathMatcher {
+    pub fn pattern(&self) -> &str {
+        &self.pattern
+    }
+}
+
+impl FromStr for AsPathMatcher {
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let regex = Regex::new(input).map_err(|_| ())?;
+        Ok(Self {
+            pattern: input.to_string(),
+            regex,
+        })
+    }
+}
+
+impl std::fmt::Debug for AsPathMatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AsPathMatcher")
+            .field("pattern", &self.pattern)
+            .finish()
+    }
+}
+
+impl PartialEq for AsPathMatcher {
+    fn eq(&self, other: &Self) -> bool {
+        self.pattern == other.pattern
+    }
+}
+
+impl Eq for AsPathMatcher {}
+
+impl PartialOrd for AsPathMatcher {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for AsPathMatcher {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.pattern.cmp(&other.pattern)
+    }
+}
+
+pub fn match_as_path_set(matcher: &AsPathMatcher, bgp_attr: &BgpAttr) -> bool {
+    let Some(aspath) = &bgp_attr.aspath else {
+        return false;
+    };
+    let rendered = aspath.as_path_display();
+    matcher.regex.is_match(&rendered)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bgp_packet::As4Path;
+
+    fn attr_with_path(path: &str) -> BgpAttr {
+        let mut attr = BgpAttr::new();
+        attr.aspath = Some(As4Path::from_str(path).unwrap());
+        attr
+    }
+
+    #[test]
+    fn neighbor_is_anchored_start() {
+        let m = AsPathMatcher::from_str("^65001\\b").unwrap();
+        assert!(match_as_path_set(&m, &attr_with_path("65001 65002 65003")));
+        assert!(!match_as_path_set(&m, &attr_with_path("65000 65001 65002")));
+    }
+
+    #[test]
+    fn originates_from_anchored_end() {
+        let m = AsPathMatcher::from_str("\\b65535$").unwrap();
+        assert!(match_as_path_set(&m, &attr_with_path("65001 65002 65535")));
+        assert!(!match_as_path_set(&m, &attr_with_path("65535 65001 65002")));
+    }
+
+    #[test]
+    fn passes_through() {
+        let m = AsPathMatcher::from_str("\\b777\\b").unwrap();
+        assert!(match_as_path_set(&m, &attr_with_path("65001 777 65003")));
+        assert!(match_as_path_set(&m, &attr_with_path("777 65001")));
+        assert!(!match_as_path_set(&m, &attr_with_path("7777 65001")));
+    }
+
+    #[test]
+    fn empty_path() {
+        let m = AsPathMatcher::from_str("\\b65001\\b").unwrap();
+        let mut attr = BgpAttr::new();
+        attr.aspath = None;
+        assert!(!match_as_path_set(&m, &attr));
+    }
+
+    #[test]
+    fn invalid_regex_rejected() {
+        assert!(AsPathMatcher::from_str("[invalid(").is_err());
+    }
+}

--- a/zebra-rs/src/policy/aspath/set.rs
+++ b/zebra-rs/src/policy/aspath/set.rs
@@ -1,0 +1,17 @@
+use std::collections::BTreeSet;
+
+use bgp_packet::BgpAttr;
+
+use super::{AsPathMatcher, match_as_path_set};
+
+#[derive(Default, Clone, Debug, PartialEq)]
+pub struct AsPathSet {
+    pub vals: BTreeSet<AsPathMatcher>,
+    pub delete: bool,
+}
+
+impl AsPathSet {
+    pub fn matches(&self, bgp_attr: &BgpAttr) -> bool {
+        self.vals.iter().any(|x| match_as_path_set(x, bgp_attr))
+    }
+}

--- a/zebra-rs/src/policy/aspath/show.rs
+++ b/zebra-rs/src/policy/aspath/show.rs
@@ -1,0 +1,35 @@
+use anyhow::{Context, Error};
+use std::fmt::Write;
+
+use crate::{config::Args, policy::Policy};
+
+pub fn as_path_set(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> {
+    let mut buf = String::new();
+
+    for (name, set) in policy.as_path_config.config.iter() {
+        writeln!(buf, "as-path-set: {} len: {}", name, set.vals.len())?;
+        for matcher in &set.vals {
+            writeln!(buf, "  {}", matcher.pattern())?;
+        }
+    }
+
+    Ok(buf)
+}
+
+pub fn as_path_set_name(policy: &Policy, mut args: Args, _json: bool) -> Result<String, Error> {
+    let mut buf = String::new();
+
+    let name = args.string().context("missing as-path-set name")?;
+    let set = policy
+        .as_path_config
+        .config
+        .get(&name)
+        .context(format!("as-path-set '{}' not found", name))?;
+
+    writeln!(buf, "as-path-set: {}", name)?;
+    for matcher in &set.vals {
+        writeln!(buf, "  {}", matcher.pattern())?;
+    }
+
+    Ok(buf)
+}

--- a/zebra-rs/src/policy/inst.rs
+++ b/zebra-rs/src/policy/inst.rs
@@ -7,7 +7,9 @@ use crate::config::{
     Args, ConfigChannel, ConfigOp, ConfigRequest, DisplayRequest, ShowChannel, path_from_command,
 };
 
-use super::{CommunitySetConfig, PolicyConfig, PolicyList, PrefixSet, PrefixSetConfig};
+use super::{
+    AsPathSetConfig, CommunitySetConfig, PolicyConfig, PolicyList, PrefixSet, PrefixSetConfig,
+};
 
 pub type ShowCallback = fn(&Policy, Args, bool) -> Result<String, Error>;
 
@@ -151,6 +153,7 @@ pub struct Policy {
     pub policy_config: PolicyConfig,
     pub prefix_config: PrefixSetConfig,
     pub community_config: CommunitySetConfig,
+    pub as_path_config: AsPathSetConfig,
     pub clients: BTreeMap<String, UnboundedSender<PolicyRx>>,
     pub watch_prefix: BTreeMap<String, Vec<PolicyWatch>>,
     pub watch_policy: BTreeMap<String, Vec<PolicyWatch>>,
@@ -175,6 +178,7 @@ impl Policy {
             policy_config: PolicyConfig::new(),
             prefix_config: PrefixSetConfig::new(),
             community_config: CommunitySetConfig::new(),
+            as_path_config: AsPathSetConfig::new(),
             clients: BTreeMap::new(),
             watch_prefix: BTreeMap::new(),
             watch_policy: BTreeMap::new(),
@@ -249,6 +253,8 @@ impl Policy {
                     let _ = self.prefix_config.exec(path, args, msg.op);
                 } else if path.as_str().starts_with("/community-set") {
                     let _ = self.community_config.exec(path, args, msg.op);
+                } else if path.as_str().starts_with("/as-path-set") {
+                    let _ = self.as_path_config.exec(path, args, msg.op);
                 }
             }
             ConfigOp::CommitEnd => {
@@ -264,6 +270,8 @@ impl Policy {
                 );
                 // Sync community-set.
                 self.community_config.commit();
+                // Sync as-path-set.
+                self.as_path_config.commit();
 
                 // Sync policy-list.
                 let syncer = PolicySyncer {
@@ -275,6 +283,7 @@ impl Policy {
                     &mut self.policy_config.cache,
                     &self.prefix_config,
                     &self.community_config,
+                    &self.as_path_config,
                     syncer,
                 );
             }

--- a/zebra-rs/src/policy/mod.rs
+++ b/zebra-rs/src/policy/mod.rs
@@ -19,4 +19,7 @@ pub use prefix::*;
 pub mod community;
 pub use community::*;
 
+pub mod aspath;
+pub use aspath::*;
+
 pub mod show;

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -2,11 +2,15 @@ use std::collections::BTreeMap;
 use std::fmt::Write;
 
 use anyhow::{Context, Error, Result};
+use bgp_packet::Origin;
 use strum_macros::{Display, EnumString};
 
 use crate::config::{Args, ConfigOp};
 
-use super::{CommunitySet, CommunitySetConfig, Policy, PrefixSet, PrefixSetConfig};
+use super::{
+    AsPathSet, AsPathSetConfig, CommunitySet, CommunitySetConfig, Policy, PrefixSet,
+    PrefixSetConfig,
+};
 
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct PolicyList {
@@ -35,6 +39,15 @@ pub enum PolicyAction {
     Reject,
 }
 
+fn parse_origin(s: &str) -> Result<Origin> {
+    match s {
+        "igp" => Ok(Origin::Igp),
+        "egp" => Ok(Origin::Egp),
+        "incomplete" => Ok(Origin::Incomplete),
+        other => Err(anyhow::anyhow!("invalid origin: {}", other)),
+    }
+}
+
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct PolicyEntry {
     // Match.
@@ -42,6 +55,14 @@ pub struct PolicyEntry {
     pub prefix_set: Option<PrefixSet>,
     pub community_set_name: Option<String>,
     pub community_set: Option<CommunitySet>,
+    pub as_path_set_name: Option<String>,
+    pub as_path_set: Option<AsPathSet>,
+    pub next_hop_set_name: Option<String>,
+    pub next_hop_set: Option<PrefixSet>,
+    pub match_med_eq: Option<u32>,
+    pub match_med_ge: Option<u32>,
+    pub match_med_le: Option<u32>,
+    pub match_origin: Option<Origin>,
     // Set.
     pub local_pref: Option<u32>,
     pub med: Option<u32>,
@@ -53,6 +74,7 @@ pub fn policy_entry_sync(
     policy_list: &mut PolicyList,
     prefix_set: &PrefixSetConfig,
     community_set: &CommunitySetConfig,
+    as_path_set: &AsPathSetConfig,
 ) {
     for (_, policy) in policy_list.entry.iter_mut() {
         if let Some(name) = &policy.prefix_set_name {
@@ -67,6 +89,20 @@ pub fn policy_entry_sync(
                 policy.community_set = Some(community_set.clone());
             } else {
                 policy.community_set = None;
+            }
+        }
+        if let Some(name) = &policy.as_path_set_name {
+            if let Some(as_path_set) = as_path_set.config.get(name) {
+                policy.as_path_set = Some(as_path_set.clone());
+            } else {
+                policy.as_path_set = None;
+            }
+        }
+        if let Some(name) = &policy.next_hop_set_name {
+            if let Some(prefix_set) = prefix_set.config.get(name) {
+                policy.next_hop_set = Some(prefix_set.clone());
+            } else {
+                policy.next_hop_set = None;
             }
         }
     }
@@ -112,6 +148,7 @@ impl PolicyConfig {
         cache: &mut BTreeMap<String, PolicyList>,
         prefix_config: &PrefixSetConfig,
         community_config: &CommunitySetConfig,
+        as_path_config: &AsPathSetConfig,
         syncer: S,
     ) {
         while let Some((name, mut s)) = cache.pop_first() {
@@ -119,7 +156,7 @@ impl PolicyConfig {
                 syncer.policy_list_remove(&name);
                 config.remove(&name);
             } else {
-                policy_entry_sync(&mut s, prefix_config, community_config);
+                policy_entry_sync(&mut s, prefix_config, community_config, as_path_config);
                 syncer.policy_list_update(&name, &s);
                 config.insert(name, s);
             }
@@ -239,6 +276,91 @@ impl ConfigBuilder {
                 entry.community_set_name = None;
                 Ok(())
             })
+            .path("/entry/match/as-path-set")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+
+                let as_path_set = args.string().context(ARG_ERR)?;
+                entry.as_path_set_name = Some(as_path_set);
+
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.as_path_set_name = None;
+                Ok(())
+            })
+            .path("/entry/match/next-hop-set")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+
+                let next_hop_set = args.string().context(ARG_ERR)?;
+                entry.next_hop_set_name = Some(next_hop_set);
+
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.next_hop_set_name = None;
+                Ok(())
+            })
+            .path("/entry/match/med-eq")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.match_med_eq = Some(args.u32().context(ARG_ERR)?);
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.match_med_eq = None;
+                Ok(())
+            })
+            .path("/entry/match/med-ge")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.match_med_ge = Some(args.u32().context(ARG_ERR)?);
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.match_med_ge = None;
+                Ok(())
+            })
+            .path("/entry/match/med-le")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.match_med_le = Some(args.u32().context(ARG_ERR)?);
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.match_med_le = None;
+                Ok(())
+            })
+            .path("/entry/match/origin")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                let origin_str = args.string().context(ARG_ERR)?;
+                entry.match_origin = Some(parse_origin(&origin_str).context(ARG_ERR)?);
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.match_origin = None;
+                Ok(())
+            })
             .path("/entry/set/local-preference")
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
@@ -330,6 +452,24 @@ pub fn show(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> 
             }
             if let Some(community_set) = &entry.community_set_name {
                 let _ = writeln!(buf, "  match: community_set {}", community_set);
+            }
+            if let Some(as_path_set) = &entry.as_path_set_name {
+                let _ = writeln!(buf, "  match: as_path_set {}", as_path_set);
+            }
+            if let Some(next_hop_set) = &entry.next_hop_set_name {
+                let _ = writeln!(buf, "  match: next_hop_set {}", next_hop_set);
+            }
+            if let Some(med) = &entry.match_med_eq {
+                let _ = writeln!(buf, "  match: med eq {}", med);
+            }
+            if let Some(med) = &entry.match_med_ge {
+                let _ = writeln!(buf, "  match: med ge {}", med);
+            }
+            if let Some(med) = &entry.match_med_le {
+                let _ = writeln!(buf, "  match: med le {}", med);
+            }
+            if let Some(origin) = &entry.match_origin {
+                let _ = writeln!(buf, "  match: origin {:?}", origin);
             }
             if let Some(local_pref) = &entry.local_pref {
                 let _ = writeln!(buf, "  set: local-pref {}", local_pref);

--- a/zebra-rs/src/policy/show.rs
+++ b/zebra-rs/src/policy/show.rs
@@ -1,6 +1,7 @@
 use crate::policy::Policy;
 use crate::policy::inst::ShowCallback;
 
+use super::aspath;
 use super::community;
 use super::policy_list;
 use super::prefix;
@@ -19,5 +20,7 @@ impl Policy {
             "/show/community-set/name",
             community::show::community_set_name,
         );
+        self.show_add("/show/as-path-set", aspath::show::as_path_set);
+        self.show_add("/show/as-path-set/name", aspath::show::as_path_set_name);
     }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -735,6 +735,21 @@ module config {
       }
     }
 
+    list as-path-set {
+      ext:sort "5";
+      key "name";
+      leaf name {
+        type string;
+      }
+      leaf-list member {
+        type string;
+        description
+          "Regular expression members matched against the route's
+           AS_PATH attribute, rendered as a space-separated list of
+           ASNs (e.g. \"65001 65002 65003\").";
+      }
+    }
+
     list prefix-set {
       ext:sort "6";
       key "name";
@@ -837,6 +852,31 @@ module config {
             }
             leaf "community-set" {
               type string;
+            }
+            leaf "as-path-set" {
+              type string;
+            }
+            leaf "next-hop-set" {
+              type string;
+              description
+                "Reference to a prefix-set whose members are matched
+                 against the route's BGP NEXT_HOP attribute.";
+            }
+            leaf "med-eq" {
+              type uint32;
+            }
+            leaf "med-ge" {
+              type uint32;
+            }
+            leaf "med-le" {
+              type uint32;
+            }
+            leaf "origin" {
+              type enumeration {
+                enum igp;
+                enum egp;
+                enum incomplete;
+              }
             }
           }
           container "set" {

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -54,6 +54,16 @@ module exec {
       ext:help "Show community-set";
       type empty;
     }
+    container "as-path-set" {
+      ext:help "Show as-path-set";
+      presence "Show as-path-set";
+      list name {
+        key name;
+        leaf name {
+          type string;
+        }
+      }
+    }
     list interface {
       ext:help "Show interface commands";
       ext:presence "Show presence";


### PR DESCRIPTION
## Summary

zebra-rs's BGP route-map match was limited to `prefix-set` and `community-set`, so common IOS-XR RPL conditions (`as-path`, `next-hop`, `med`, `origin`) couldn't be expressed in inbound/outbound policy. This adds those four match types and exercises each one over a real eBGP session in BDD.

## Changes

**New `as-path-set` module** (`zebra-rs/src/policy/aspath/`)
- Mirrors `community-set`: top-level list with `member` regex patterns, matched against the route's AS_PATH rendered as a space-separated string (`As4Path::as_path_display()`).
- Includes `show as-path-set [name]` command.

**New match clauses under `policy-options/policy/entry/match/`**
| Clause | YANG type | Behavior |
|---|---|---|
| `as-path-set <name>` | string ref | regex member matches displayed AS_PATH |
| `next-hop-set <name>` | string ref to a prefix-set | tested against route's BGP NEXT_HOP |
| `med-eq` / `med-ge` / `med-le` | uint32 | absent MED treated as 0 |
| `origin` | enum {igp\|egp\|incomplete} | exact match |

**Wiring**
- `PolicyEntry`: 7 new fields (`as_path_set_name`/`set`, `next_hop_set_name`/`set`, `match_med_eq`/`ge`/`le`, `match_origin`).
- `policy_entry_sync()` resolves `as-path-set` and `next-hop-set` references on commit (the latter reuses `PrefixSetConfig` by name).
- `inst.rs` dispatches `/as-path-set` paths and threads the new config through `PolicyConfig::commit`.
- `bgp/route.rs::policy_list_apply` refactored to call `entry_matches()`, which AND's all clauses; first matching entry returns `Some(attr)`, else `None` (default reject preserved).

**BDD** (`@bgp_route_map_match`)
- 12 scenarios across one feature: setup, pass+fail per match type (plus a med-range variant), teardown.
- z1 (AS 65001) advertises `10.0.0.1/32` + `10.0.0.2/32` with an outbound policy that stamps MED=100 so MED scenarios have something deterministic to compare against.
- Each scenario swaps z2's input policy and asserts which prefixes appear in z2's RIB.
- Auto-generated `bdd/docs/bgp_route_map_match.md` and `make -C bdd bgp_route_map_match` target.

## Test plan

- [x] `cargo test -p zebra-rs --bin zebra-rs` — 181 passed (5 new aspath parser tests + 5 new policy_apply integration tests)
- [x] `cargo clippy -p zebra-rs --bin zebra-rs --all-targets -- -D warnings` clean
- [x] `cargo fmt --check -p zebra-rs -p bdd` clean
- [x] `cargo test --test cucumber --no-run` — BDD harness builds
- [ ] `make -C bdd bgp_route_map_match` — runs locally after installing fresh release binaries to `/usr/bin/` and YANG to `/etc/zebra-rs/yang/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)