### PR TITLE
bgp: soft-reconfiguration inbound/outbound + RFC 2918 Route Refresh

### DIFF
--- a/crates/bgp-packet/src/lib.rs
+++ b/crates/bgp-packet/src/lib.rs
@@ -2,12 +2,14 @@ pub mod notification;
 pub mod open;
 pub mod packet;
 pub mod parser;
+pub mod route_refresh;
 pub mod update;
 
 pub use notification::*;
 pub use open::*;
 pub use packet::*;
 pub use parser::*;
+pub use route_refresh::*;
 pub use update::*;
 
 pub mod caps;

--- a/crates/bgp-packet/src/packet.rs
+++ b/crates/bgp-packet/src/packet.rs
@@ -1,7 +1,7 @@
 use bytes::{BufMut, BytesMut};
 use nom_derive::*;
 
-use crate::{NotificationPacket, OpenPacket, UpdatePacket};
+use crate::{NotificationPacket, OpenPacket, RouteRefreshPacket, UpdatePacket};
 
 pub const BGP_PACKET_LEN: usize = 4096;
 pub const BGP_EXTENDED_PACKET_LEN: usize = 65535;
@@ -53,4 +53,5 @@ pub enum BgpPacket {
     Keepalive(BgpHeader),
     Notification(NotificationPacket),
     Update(Box<UpdatePacket>),
+    RouteRefresh(RouteRefreshPacket),
 }

--- a/crates/bgp-packet/src/parser.rs
+++ b/crates/bgp-packet/src/parser.rs
@@ -5,7 +5,7 @@ use nom_derive::*;
 
 use crate::{
     Afi, AfiSafi, BGP_EXTENDED_PACKET_LEN, BGP_PACKET_LEN, BgpHeader, BgpPacket, BgpParseError,
-    BgpType, NotificationPacket, OpenPacket, Safi, UpdatePacket,
+    BgpType, NotificationPacket, OpenPacket, RouteRefreshPacket, Safi, UpdatePacket,
 };
 
 #[derive(Default, Debug, Clone)]
@@ -89,6 +89,10 @@ impl BgpPacket {
             BgpType::Keepalive => {
                 let (input, header) = BgpHeader::parse_be(input)?;
                 Ok((input, BgpPacket::Keepalive(header)))
+            }
+            BgpType::RouteRefresh => {
+                let (input, packet) = RouteRefreshPacket::parse_packet(input)?;
+                Ok((input, BgpPacket::RouteRefresh(packet)))
             }
             _ => Err(BgpParseError::NomError(
                 "Unknown BGP packet type".to_string(),

--- a/crates/bgp-packet/src/route_refresh.rs
+++ b/crates/bgp-packet/src/route_refresh.rs
@@ -1,0 +1,82 @@
+use bytes::{BufMut, BytesMut};
+use nom::IResult;
+use nom_derive::*;
+
+use super::{BGP_HEADER_LEN, BgpHeader, BgpType};
+
+// RFC 2918 §3 fixes the Route Refresh payload at 4 bytes after the
+// 19-byte BGP header: AFI (2) | reserved (1) | SAFI (1).
+const ROUTE_REFRESH_PAYLOAD_LEN: u16 = 4;
+const ROUTE_REFRESH_TOTAL_LEN: u16 = BGP_HEADER_LEN + ROUTE_REFRESH_PAYLOAD_LEN;
+
+// BGP Route Refresh message (type 5, RFC 2918). The single-byte
+// reserved field is co-opted by RFC 7313 Enhanced Route Refresh as a
+// subtype (0 = normal refresh, 1 = BoRR, 2 = EoRR); plain RFC 2918
+// senders set it to 0 and receivers ignore it. AFI/SAFI are kept as
+// raw integers so unknown values round-trip without lossy casts.
+#[derive(Debug, Clone, NomBE)]
+pub struct RouteRefreshPacket {
+    pub header: BgpHeader,
+    pub afi: u16,
+    pub subtype: u8,
+    pub safi: u8,
+}
+
+impl RouteRefreshPacket {
+    pub fn new(afi: u16, safi: u8) -> Self {
+        Self {
+            header: BgpHeader::new(BgpType::RouteRefresh, ROUTE_REFRESH_TOTAL_LEN),
+            afi,
+            subtype: 0,
+            safi,
+        }
+    }
+
+    pub fn parse_packet(input: &[u8]) -> IResult<&[u8], RouteRefreshPacket> {
+        Self::parse_be(input)
+    }
+}
+
+impl From<RouteRefreshPacket> for BytesMut {
+    fn from(p: RouteRefreshPacket) -> Self {
+        let mut buf = BytesMut::new();
+        let header: BytesMut = p.header.into();
+        buf.put(&header[..]);
+        buf.put_u16(p.afi);
+        buf.put_u8(p.subtype);
+        buf.put_u8(p.safi);
+        buf
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn route_refresh_roundtrip_ipv4_unicast() {
+        let original = RouteRefreshPacket::new(1, 1);
+        let bytes: BytesMut = original.into();
+        assert_eq!(bytes.len(), ROUTE_REFRESH_TOTAL_LEN as usize);
+
+        let (rest, parsed) = RouteRefreshPacket::parse_packet(&bytes).expect("parse");
+        assert!(rest.is_empty());
+        assert_eq!(parsed.afi, 1);
+        assert_eq!(parsed.safi, 1);
+        assert_eq!(parsed.subtype, 0);
+        assert_eq!(parsed.header.length, ROUTE_REFRESH_TOTAL_LEN);
+    }
+
+    #[test]
+    fn route_refresh_preserves_unknown_afi_safi() {
+        // Unknown AFI/SAFI must round-trip — receivers should not
+        // reject Route Refresh just because they don't recognise the
+        // address family (RFC 2918 leaves handling AFI/SAFI mismatch
+        // to the receiver, but the wire form must still parse).
+        let original = RouteRefreshPacket::new(9999, 200);
+        let bytes: BytesMut = original.into();
+        let (_, parsed) = RouteRefreshPacket::parse_packet(&bytes).expect("parse");
+        assert_eq!(parsed.afi, 9999);
+        assert_eq!(parsed.safi, 200);
+    }
+}

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -260,6 +260,16 @@ fn config_route_reflector(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option
     None
 }
 
+fn config_soft_reconfig_in(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let flag = args.boolean()?;
+
+    let peer = bgp.peers.get_mut(&addr)?;
+
+    peer.config.soft_reconfig_in = op.is_set() && flag;
+    Some(())
+}
+
 fn config_afi_safi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let key: AfiSafi = args.afi_safi()?;
@@ -970,5 +980,10 @@ impl Bgp {
 
         // Route Reflector.
         self.callback_peer("/route-reflector/client", config_route_reflector);
+
+        // Soft-reconfiguration inbound (zebra-bgp-soft-reconfiguration.yang).
+        // Stored-mode soft-in: retain pre-policy Adj-RIB-In so `clear soft in`
+        // can replay locally without sending a Route Refresh.
+        self.callback_peer("/soft-reconfiguration/inbound", config_soft_reconfig_in);
     }
 }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -378,6 +378,12 @@ impl Bgp {
                     "/clear/ip/bgp/keepalive-recv" => {
                         let _ = peer::clear_keepalive_recv(self, &mut args);
                     }
+                    "/clear/ip/bgp/soft-out" => {
+                        let _ = peer::clear_soft_out(self, &mut args);
+                    }
+                    "/clear/ip/bgp/soft-in" => {
+                        let _ = peer::clear_soft_in(self, &mut args);
+                    }
                     _ => {
                         //
                     }

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -76,6 +76,10 @@ pub enum Event {
     NotifMsg(NotificationPacket), // 25
     KeepAliveMsg,                 // 26
     UpdateMsg(UpdatePacket),      // 27
+    // RFC 2918 Route Refresh receive. Carries the AFI/SAFI from the
+    // wire (raw u16/u8) so unknown-AF refreshes still dispatch
+    // through the FSM rather than tearing the session down.
+    RouteRefreshMsg(u16, u8),
     StaleTimerExipires(AfiSafi),
     AdvTimerIpv4Expires,
     AdvTimerVpnv4Expires,
@@ -86,6 +90,14 @@ pub enum FsmEffect {
     None,
     RouteUpdate(UpdatePacket),
     StaleExpire(AfiSafi),
+    // Peer asked us to re-send the Adj-RIB-Out for an AFI/SAFI
+    // (RFC 2918). The current implementation re-runs the full
+    // soft-out replay across every negotiated AFI/SAFI rather than
+    // narrowing to the requested one — over-eager but correct, and
+    // simpler than threading AFI/SAFI through the route layer. The
+    // (afi, safi) pair is kept in the variant so a future revision
+    // can do the targeted version without an FSM change.
+    RouteRefreshRecv { afi: u16, safi: u8 },
 }
 
 #[derive(Debug, Default)]
@@ -151,6 +163,12 @@ pub struct PeerConfig {
     pub llgr: AfiSafis<LlgrValue>,
     pub addpath: AfiSafis<AddPathValue>,
     pub route_refresh: bool,
+    // When true, the peer's pre-policy Adj-RIB-In is replayed locally
+    // on `clear ... soft in` instead of (or in addition to) sending a
+    // Route Refresh. Lets policy changes take effect without a session
+    // bounce when the peer doesn't support RFC 2918, at the cost of
+    // keeping received UPDATEs in memory.
+    pub soft_reconfig_in: bool,
     pub timer: timer::Config,
     pub sub: BTreeMap<AfiSafi, PeerSubConfig>,
 }
@@ -166,6 +184,7 @@ impl Default for PeerConfig {
             llgr: AfiSafis::new(),
             addpath: AfiSafis::new(),
             route_refresh: Default::default(),
+            soft_reconfig_in: Default::default(),
             timer: Default::default(),
             sub: Default::default(),
         }
@@ -479,6 +498,11 @@ pub fn fsm_next_state(peer: &mut Peer, event: Event) -> (State, FsmEffect) {
             timer::refresh_hold_timer(peer);
             (State::Established, FsmEffect::RouteUpdate(packet))
         }
+        Event::RouteRefreshMsg(afi, safi) => {
+            peer.counter[BgpType::RouteRefresh as usize].rcvd += 1;
+            timer::refresh_hold_timer(peer);
+            (peer.state, FsmEffect::RouteRefreshRecv { afi, safi })
+        }
         Event::StaleTimerExipires(afi_safi) => {
             peer.timer.stale_timer.remove(&afi_safi);
             (peer.state, FsmEffect::StaleExpire(afi_safi))
@@ -497,6 +521,9 @@ fn fsm_effect(id: usize, effect: FsmEffect, bgp: &mut BgpTop, peers: &mut PeerMa
         }
         FsmEffect::StaleExpire(_afi_safi) => {
             stale_route_withdraw(id, bgp, peers);
+        }
+        FsmEffect::RouteRefreshRecv { afi: _, safi: _ } => {
+            super::route::route_soft_out_peer(id, bgp, peers);
         }
     }
 }
@@ -725,6 +752,11 @@ pub async fn peer_packet_parse(
                 }
                 BgpPacket::Update(p) => {
                     let _ = tx.send(Message::Event(ident, Event::UpdateMsg(*p))).await;
+                }
+                BgpPacket::RouteRefresh(p) => {
+                    let _ = tx
+                        .send(Message::Event(ident, Event::RouteRefreshMsg(p.afi, p.safi)))
+                        .await;
                 }
             }
             Ok(())
@@ -971,6 +1003,21 @@ pub fn peer_send_keepalive(peer: &mut Peer) {
     let _ = packet_tx.send(bytes);
 }
 
+// Send a BGP Route Refresh (RFC 2918, type 5) for one AFI/SAFI. The
+// caller is responsible for verifying the peer is established and
+// advertised the Route Refresh capability — sending REFRESH to a peer
+// that didn't advertise the cap is technically permitted but the peer
+// is allowed to ignore it.
+pub fn peer_send_route_refresh(peer: &mut Peer, afi: u16, safi: u8) {
+    let Some(packet_tx) = peer.packet_tx.as_ref() else {
+        return;
+    };
+    let pkt = RouteRefreshPacket::new(afi, safi);
+    let bytes: BytesMut = pkt.into();
+    peer.counter[BgpType::RouteRefresh as usize].sent += 1;
+    let _ = packet_tx.send(bytes);
+}
+
 /// Reject a connection by sending a NOTIFICATION and closing the socket.
 /// Spawns an async task with a timeout to prevent FD exhaustion.
 fn reject_connection(stream: TcpStream, code: NotifyCode, sub_code: u8) {
@@ -1067,6 +1114,102 @@ pub fn clear(bgp: &Bgp, args: &mut Args) -> std::result::Result<String, std::fmt
         Ok(()) => Ok(format!("%% peer {} is cleared", addr)),
         Err(e) => Ok(format!("%% failed to clear peer {}: {}", addr, e)),
     }
+}
+
+// Soft-clear outbound: re-apply outbound policy and refresh
+// Adj-RIB-Out for this peer without bouncing the session. Returns
+// immediately if the peer isn't established (nothing to refresh).
+pub fn clear_soft_out(
+    bgp: &mut Bgp,
+    args: &mut Args,
+) -> std::result::Result<String, std::fmt::Error> {
+    let Some(addr) = args.addr() else {
+        return Ok("peer not found".to_string());
+    };
+
+    let Some(peer) = bgp.peers.get(&addr) else {
+        return Ok("peer not found".to_string());
+    };
+
+    if !peer.state.is_established() {
+        return Ok(format!("%% peer {} is not established", addr));
+    }
+    let peer_idx = peer.ident;
+
+    let mut bgp_ref = BgpTop {
+        router_id: &bgp.router_id,
+        local_rib: &mut bgp.local_rib,
+        tx: &bgp.tx,
+        rib_tx: &bgp.rib_tx,
+        attr_store: &mut bgp.attr_store,
+    };
+    super::route::route_soft_out_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
+
+    Ok(format!("%% peer {} soft-out done", addr))
+}
+
+// Soft-clear inbound: replay the stored Adj-RIB-In through the current
+// inbound policy and reconcile Loc-RIB. Requires
+// `neighbor X soft-reconfiguration inbound`. When the flag is off,
+// fall back is "send Route Refresh" — Phase 5 wires that path; for
+// now we surface a clear error.
+pub fn clear_soft_in(
+    bgp: &mut Bgp,
+    args: &mut Args,
+) -> std::result::Result<String, std::fmt::Error> {
+    let Some(addr) = args.addr() else {
+        return Ok("peer not found".to_string());
+    };
+
+    let Some(peer) = bgp.peers.get(&addr) else {
+        return Ok("peer not found".to_string());
+    };
+
+    if !peer.state.is_established() {
+        return Ok(format!("%% peer {} is not established", addr));
+    }
+
+    // Stored mode: replay Adj-RIB-In locally. Doesn't touch the wire,
+    // so works even when the peer doesn't speak Route Refresh.
+    if peer.config.soft_reconfig_in {
+        let peer_idx = peer.ident;
+        let mut bgp_ref = BgpTop {
+            router_id: &bgp.router_id,
+            local_rib: &mut bgp.local_rib,
+            tx: &bgp.tx,
+            rib_tx: &bgp.rib_tx,
+            attr_store: &mut bgp.attr_store,
+        };
+        super::route::route_soft_in_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
+        return Ok(format!("%% peer {} soft-in done (stored replay)", addr));
+    }
+
+    // Fallback: ask the peer to re-send via RFC 2918 Route Refresh,
+    // if they advertised the capability. One REFRESH per negotiated
+    // (afi, safi) — peer.cap_recv.mp tracks what the peer can
+    // actually carry.
+    if peer.cap_recv.refresh.is_none() {
+        return Ok(format!(
+            "%% peer {addr}: no stored Adj-RIB-In and peer did not advertise Route Refresh capability; \
+             enable `neighbor {addr} soft-reconfiguration inbound` or hard-clear the session"
+        ));
+    }
+    let pairs: Vec<(u16, u8)> = peer
+        .cap_recv
+        .mp
+        .keys()
+        .map(|af| (u16::from(af.afi), u8::from(af.safi)))
+        .collect();
+
+    let peer = bgp.peers.get_mut(&addr).expect("peer exists");
+    for (afi, safi) in &pairs {
+        peer_send_route_refresh(peer, *afi, *safi);
+    }
+    Ok(format!(
+        "%% peer {} soft-in done (sent {} Route Refresh)",
+        addr,
+        pairs.len()
+    ))
 }
 
 pub fn clear_keepalive(bgp: &Bgp, args: &mut Args) -> std::result::Result<String, std::fmt::Error> {

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1104,6 +1104,242 @@ fn route_withdraw_ipv4(peer: &mut Peer, rd: Option<RouteDistinguisher>, prefix: 
     peer.send_packet(update.into());
 }
 
+// Soft-reconfiguration outbound: walk Loc-RIB for the AFI/SAFIs the
+// peer has negotiated, run each prefix through the per-peer advertise
+// builder + outbound policy, and either re-send the UPDATE or withdraw
+// (when a previously-advertised prefix newly fails policy or filtering).
+// Caller is responsible for ensuring the peer is established.
+//
+// Phase 2 covers IPv4 unicast and IPv4 MPLS-VPN. EVPN soft-out is left
+// for a follow-up — it would mirror this with `route_update_evpn` /
+// `route_apply_policy_evpn_out` over `bgp.local_rib.evpn[rd]`.
+pub fn route_soft_out_peer(peer_idx: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
+    let (do_v4, vpn_rds) = {
+        let Some(peer) = peers.get_by_idx(peer_idx) else {
+            return;
+        };
+        if !peer.state.is_established() {
+            return;
+        }
+        let do_v4 = peer.is_afi_safi(Afi::Ip, Safi::Unicast);
+        let do_vpn = peer.is_afi_safi(Afi::Ip, Safi::MplsVpn);
+        let rds: Vec<RouteDistinguisher> = if do_vpn {
+            bgp.local_rib.v4vpn.keys().copied().collect()
+        } else {
+            Vec::new()
+        };
+        (do_v4, rds)
+    };
+
+    if do_v4 {
+        route_soft_out_peer_table(peer_idx, None, bgp, peers);
+    }
+    for rd in vpn_rds {
+        route_soft_out_peer_table(peer_idx, Some(rd), bgp, peers);
+    }
+}
+
+fn route_soft_out_peer_table(
+    peer_idx: usize,
+    rd: Option<RouteDistinguisher>,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+) {
+    let (afi, safi) = if rd.is_some() {
+        (Afi::Ip, Safi::MplsVpn)
+    } else {
+        (Afi::Ip, Safi::Unicast)
+    };
+
+    // Snapshot Loc-RIB selected so the iteration outlives later
+    // mutable borrows of `bgp` (attr_store.intern, send paths).
+    let selected: Vec<(Ipv4Net, BgpRib)> = match rd {
+        Some(rd) => bgp
+            .local_rib
+            .v4vpn
+            .get(&rd)
+            .map(|t| t.1.iter().map(|(p, r)| (*p, r.clone())).collect())
+            .unwrap_or_default(),
+        None => bgp
+            .local_rib
+            .v4
+            .1
+            .iter()
+            .map(|(p, r)| (*p, r.clone()))
+            .collect(),
+    };
+
+    // Snapshot what's currently in this peer's Adj-RIB-Out so we can
+    // detect which previously-advertised prefixes need a withdraw.
+    let was_advertised: BTreeSet<Ipv4Net> = {
+        let peer = peers.get_mut_by_idx(peer_idx).expect("peer exists");
+        match rd {
+            Some(rd) => peer
+                .adj_out
+                .v4vpn
+                .get(&rd)
+                .map(|t| t.0.keys().copied().collect())
+                .unwrap_or_default(),
+            None => peer.adj_out.v4.0.keys().copied().collect(),
+        }
+    };
+
+    let mut newly_advertised: BTreeSet<Ipv4Net> = BTreeSet::new();
+
+    for (prefix, rib) in &selected {
+        let peer = peers.get_mut_by_idx(peer_idx).expect("peer exists");
+        let add_path = peer.opt.is_add_path_send(afi, safi);
+
+        let Some((nlri, attr)) = route_update_ipv4(peer, prefix, rib, bgp, add_path) else {
+            continue;
+        };
+        let Some(attr) = route_apply_policy_out(peer, &nlri, attr) else {
+            continue;
+        };
+        if rd.is_some() && !peer.rtcv4.is_empty() && !rtc_match(&peer.rtcv4, &attr.ecom) {
+            continue;
+        }
+
+        let attr = bgp.attr_store.intern(attr);
+        let mut adj = rib.clone();
+        adj.attr = attr.clone();
+        peer.adj_out.add(rd, nlri.prefix, adj);
+
+        if let Some(rd_val) = rd {
+            let vpnv4_nlri = Vpnv4Nlri {
+                label: Label::default(),
+                rd: rd_val,
+                nlri,
+            };
+            peer.send_vpnv4(vpnv4_nlri, attr, true);
+        } else {
+            peer.send_ipv4(nlri, attr, true);
+        }
+
+        newly_advertised.insert(*prefix);
+    }
+
+    let to_withdraw: Vec<Ipv4Net> = was_advertised
+        .difference(&newly_advertised)
+        .copied()
+        .collect();
+    for prefix in to_withdraw {
+        let peer = peers.get_mut_by_idx(peer_idx).expect("peer exists");
+        match rd {
+            Some(rd) => peer.cache_remove_vpnv4(rd, prefix, 0),
+            None => peer.cache_remove_ipv4(prefix, 0),
+        };
+        peer.adj_out.remove(rd, prefix, 0);
+        route_withdraw_ipv4(peer, rd, prefix, 0);
+    }
+}
+
+// Soft-reconfiguration inbound (stored mode): replay the peer's
+// pre-policy Adj-RIB-In through the current inbound policy and
+// reconcile Loc-RIB. The caller must have already verified
+// `peer.config.soft_reconfig_in` and that the peer is established.
+//
+// For each stored entry: re-apply inbound policy. If accepted, refresh
+// the Loc-RIB candidate with the (possibly new) post-policy attrs and
+// fan out best-path changes via the normal advertise paths. If denied,
+// withdraw from Loc-RIB only — the Adj-RIB-In entry stays so the next
+// replay (e.g., after another policy edit) still has it.
+//
+// Phase 3 covers IPv4 unicast and IPv4 MPLS-VPN. EVPN soft-in is left
+// for a follow-up, mirroring the EVPN soft-out gap.
+pub fn route_soft_in_peer(peer_idx: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
+    let (do_v4, vpn_rds) = {
+        let Some(peer) = peers.get_by_idx(peer_idx) else {
+            return;
+        };
+        if !peer.state.is_established() {
+            return;
+        }
+        let do_v4 = peer.is_afi_safi(Afi::Ip, Safi::Unicast);
+        let do_vpn = peer.is_afi_safi(Afi::Ip, Safi::MplsVpn);
+        let rds: Vec<RouteDistinguisher> = if do_vpn {
+            peer.adj_in.v4vpn.keys().copied().collect()
+        } else {
+            Vec::new()
+        };
+        (do_v4, rds)
+    };
+
+    if do_v4 {
+        route_soft_in_peer_table(peer_idx, None, bgp, peers);
+    }
+    for rd in vpn_rds {
+        route_soft_in_peer_table(peer_idx, Some(rd), bgp, peers);
+    }
+}
+
+fn route_soft_in_peer_table(
+    peer_idx: usize,
+    rd: Option<RouteDistinguisher>,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+) {
+    // Snapshot stored Adj-RIB-In entries so subsequent mutable borrows
+    // of `peers` / `bgp` (policy apply, Loc-RIB update, advertise
+    // fan-out) don't conflict with the iteration.
+    let entries: Vec<(Ipv4Net, Vec<BgpRib>)> = {
+        let peer = peers.get_mut_by_idx(peer_idx).expect("peer exists");
+        match rd {
+            Some(rd) => peer
+                .adj_in
+                .v4vpn
+                .get(&rd)
+                .map(|t| t.0.iter().map(|(p, ribs)| (*p, ribs.clone())).collect())
+                .unwrap_or_default(),
+            None => peer
+                .adj_in
+                .v4
+                .0
+                .iter()
+                .map(|(p, ribs)| (*p, ribs.clone()))
+                .collect(),
+        }
+    };
+
+    for (prefix, ribs) in entries {
+        for stored in ribs {
+            let nlri = Ipv4Nlri {
+                id: stored.remote_id,
+                prefix,
+            };
+
+            // Re-run inbound policy against the stored pre-policy
+            // attributes. The Adj-RIB-In keeps the original attr; only
+            // the Loc-RIB candidate gets the post-policy version.
+            let pre_attr: BgpAttr = (*stored.attr).clone();
+            let post_attr_opt = {
+                let peer = peers.get_mut_by_idx(peer_idx).expect("peer exists");
+                route_apply_policy_in(peer, &nlri, pre_attr)
+            };
+
+            match post_attr_opt {
+                None => {
+                    // Policy denies this route under the new rules.
+                    // rib_in=false leaves the Adj-RIB-In entry in
+                    // place so subsequent replays still see it.
+                    route_ipv4_withdraw(peer_idx, &nlri, rd, None, bgp, peers, false);
+                }
+                Some(post_attr) => {
+                    let mut new_rib = stored.clone();
+                    new_rib.attr = bgp.attr_store.intern(post_attr);
+                    let (_, selected, next_id) = bgp.local_rib.update(rd, prefix, new_rib.clone());
+
+                    if !selected.is_empty() {
+                        route_advertise_to_peers(rd, prefix, &selected, peer_idx, bgp, peers);
+                    }
+                    new_rib.local_id = next_id;
+                    route_advertise_to_addpath(rd, prefix, &new_rib, peer_idx, bgp, peers);
+                }
+            }
+        }
+    }
+}
+
 pub fn route_ipv4_withdraw(
     ident: usize,
     nlri: &Ipv4Nlri,

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1111,6 +1111,11 @@ struct Neighbor<'a> {
     cap_map: CapAfiMap,
     count: HashMap<&'a str, PeerCounter>,
     reflector_client: bool,
+    // FRR-style `neighbor X soft-reconfiguration inbound` flag
+    // (zebra-bgp-soft-reconfiguration.yang). When true, the peer's
+    // pre-policy Adj-RIB-In is retained so `clear ... soft in` can
+    // replay it locally without sending Route Refresh.
+    soft_reconfig_in: bool,
 }
 
 const ONE_DAY_SECOND: u64 = 60 * 60 * 24;
@@ -1231,6 +1236,7 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         cap_map: peer.cap_map.clone(),
         count: HashMap::default(),
         reflector_client: peer.reflector_client,
+        soft_reconfig_in: peer.config.soft_reconfig_in,
     };
 
     // Timers.
@@ -1304,6 +1310,11 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
             idle_hold_rem
         )?;
     }
+
+    if neighbor.soft_reconfig_in {
+        writeln!(out, "  Inbound soft reconfiguration allowed")?;
+    }
+
     writeln!(out)?;
 
     if neighbor.state == "Established" {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -44,6 +44,10 @@ module config {
     prefix zbt;
   }
 
+  import zebra-bgp-soft-reconfiguration {
+    prefix zbsr;
+  }
+
   import openconfig-isis-types {
     prefix isis;
   }

--- a/zebra-rs/yang/configure.yang
+++ b/zebra-rs/yang/configure.yang
@@ -127,6 +127,30 @@ module configure {
             type inet:ipv6-address;
           }
         }
+        // Soft-clear outbound: re-apply outbound policy to Loc-RIB
+        // and re-advertise to the named neighbor without bouncing the
+        // session. No persistent state is required (Loc-RIB already
+        // holds the routes); previously-advertised prefixes that
+        // newly fail outbound policy are withdrawn.
+        leaf soft-out {
+          type union {
+            type inet:ipv4-address;
+            type inet:ipv6-address;
+          }
+        }
+        // Soft-clear inbound: replay the peer's stored Adj-RIB-In
+        // through the current inbound policy. Requires
+        // `neighbor X soft-reconfiguration inbound` to be enabled —
+        // otherwise the per-peer pre-policy state is not preserved
+        // across policy changes. Phase 5 will fall back to sending a
+        // BGP Route Refresh (RFC 2918) when stored mode is off and
+        // the peer negotiated the capability.
+        leaf soft-in {
+          type union {
+            type inet:ipv4-address;
+            type inet:ipv6-address;
+          }
+        }
       }
     }
     container isis {

--- a/zebra-rs/yang/zebra-bgp-soft-reconfiguration.yang
+++ b/zebra-rs/yang/zebra-bgp-soft-reconfiguration.yang
@@ -1,0 +1,108 @@
+module zebra-bgp-soft-reconfiguration {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-soft-reconfiguration";
+  prefix "zbsr";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "FRR-style per-neighbor soft-reconfiguration inbound knob.
+
+     Adds the classical `neighbor X soft-reconfiguration inbound`
+     vocabulary directly under each BGP neighbor:
+
+       router bgp {
+         neighbor 10.0.0.5 {
+           peer-as 65501;
+           soft-reconfiguration {
+             inbound true;
+           }
+         }
+       }
+
+     When enabled, the operator can re-apply inbound policy without a
+     session reset by issuing `clear ... soft in`; the peer's
+     pre-policy Adj-RIB-In is replayed locally instead of relying on
+     the peer sending a Route Refresh (RFC 2918). This is the
+     traditional knob exposed by FRR / Cisco IOS / Quagga and
+     complements — does not replace — the Route-Refresh capability
+     advertised in OPEN.
+
+     The IETF BGP model (ietf-bgp@2023-07-05) only models the
+     operational `clear` action with mode `soft-in / soft-out / soft`;
+     it has no persistent config leaf for stored-mode soft-in. This
+     overlay fills that gap.";
+
+  revision 2026-05-05 {
+    description "Initial revision.";
+    reference "FRR `neighbor X soft-reconfiguration inbound`.";
+  }
+
+  grouping bgp-neighbor-soft-reconfiguration-extension {
+    description
+      "FRR-style soft-reconfiguration leaves on a BGP neighbor.";
+
+    container soft-reconfiguration {
+      description
+        "Soft-reconfiguration knobs for this neighbor.";
+
+      leaf inbound {
+        ext:help "Store received UPDATEs so inbound policy can be re-applied without a session reset";
+        type boolean;
+        default "false";
+        description
+          "When true, retain the peer's pre-policy Adj-RIB-In so that
+           `clear ... soft in` can replay received UPDATEs through the
+           current inbound policy without sending a Route Refresh or
+           tearing down the session. Costs memory proportional to the
+           number of routes received from this peer.
+
+           When false (default), `clear ... soft in` falls back to
+           sending a BGP Route Refresh (RFC 2918) if the peer
+           negotiated the capability.";
+      }
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Attach soft-reconfiguration to BGP neighbors in the
+       candidate-set subtree.";
+    uses bgp-neighbor-soft-reconfiguration-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp neighbor X soft-reconfiguration inbound`
+       is path-valid.";
+    uses bgp-neighbor-soft-reconfiguration-extension;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds the FRR-style per-neighbor `soft-reconfiguration inbound` knob (new `zebra-bgp-soft-reconfiguration.yang` overlay) plus `clear ip bgp soft-out <addr>` / `clear ip bgp soft-in <addr>` so inbound/outbound policy edits can be re-applied without bouncing the session.
- Wires the previously-unhandled incoming RFC 2918 Route Refresh (type 5) — it was hitting the `_ => Err(...)` arm in `BgpPacket::parse_packet` and tearing the session down. Receiving a refresh now triggers an outbound replay for the peer.
- Uses an outgoing Route Refresh as the `clear ... soft-in` fallback when stored mode is off but the peer advertised the capability; clear error when neither path is available.
- Exposes the flag in `show ip bgp neighbors <addr>`. The existing `... received-routes` already dumped Adj-RIB-In.

## Behaviour

| Operator action | Stored mode on | Stored mode off, peer advertised refresh | Stored mode off, peer didn't |
|---|---|---|---|
| `clear ... soft-out X` | Outbound replay against Loc-RIB | same | same |
| `clear ... soft-in X` | Local Adj-RIB-In replay | Send REFRESH per negotiated AFI/SAFI | Error pointing at the config knob |
| Peer sends REFRESH | Outbound replay (RFC 2918) | same | n/a |

Soft-out and soft-in cover IPv4 unicast and IPv4 MPLS-VPN. EVPN is left as a follow-up — noted in the function-level comments. The incoming-refresh handler currently re-runs the full per-peer soft-out across every negotiated AFI/SAFI rather than narrowing to the requested one; over-eager but RFC-correct, and noted in `FsmEffect::RouteRefreshRecv`.

## Peer-group inheritance

zebra-rs has no peer-group / neighbor-group support yet (the IETF YANG declares the leafref but no code consumes it), so soft-reconfiguration is per-neighbor only. When peer-group support lands, `soft_reconfig_in: bool` rides along the same inheritance plumbing as the other `PeerConfig` flags — no special handling required.

## Test plan

- [x] `cargo check` / `cargo build`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --all --workspace --exclude bdd` (includes 2 new RouteRefresh round-trip tests in `bgp-packet`)
- [x] Daemon boots with `--yang-path zebra-rs/yang` (validates new module imports + augments)
- [ ] Two-node BDD scenario: configure inbound policy, change it, run `clear ... soft in`, verify routes re-evaluated without uptime reset
- [ ] Same scenario with `soft_reconfig_in` off and Route Refresh negotiated
- [ ] `clear ... soft-out` exercises the new per-peer Loc-RIB replay