### PR TITLE
bdd: parallel-safe runs via per-feature scoping; zebra-rs --pid-file

### DIFF
--- a/bdd/src/netns.rs
+++ b/bdd/src/netns.rs
@@ -352,12 +352,11 @@ pub async fn list_bridges_with_prefix(prefix: &str) -> Result<Vec<String>> {
     for line in text.lines() {
         // `ip -o link show` emits lines like:
         //   "12: br_3f2a: <BROADCAST,...> mtu 1500 ..."
-        if let Some(rest) = line.split_once(": ") {
-            if let Some((name, _)) = rest.1.split_once(": ") {
-                if name.starts_with(prefix) {
-                    out.push(name.to_string());
-                }
-            }
+        if let Some(rest) = line.split_once(": ")
+            && let Some((name, _)) = rest.1.split_once(": ")
+            && name.starts_with(prefix)
+        {
+            out.push(name.to_string());
         }
     }
     Ok(out)

--- a/bdd/src/netns.rs
+++ b/bdd/src/netns.rs
@@ -1,6 +1,15 @@
 use anyhow::{Context, Result, bail};
+use std::path::Path;
 use std::process::Stdio;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::fs;
 use tokio::process::Command;
+
+/// Per-process counter for generating unique temporary veth names in
+/// `connect_netns_pair`. Names get renamed and moved into namespaces
+/// immediately after creation, so they only need to be unique on the
+/// host between `ip link add` and `ip link set`.
+static PAIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 /// Run a command and check for success
 async fn run_cmd(args: &[&str], error_msg: &str) -> Result<()> {
@@ -106,15 +115,23 @@ pub async fn delete_bridge(bridge_name: &str) -> Result<()> {
     .await
 }
 
-/// Create a veth pair and connect namespace to bridge with IP
-pub async fn connect_netns_to_bridge(netns: &str, bridge_name: &str) -> Result<()> {
-    let veth_host = format!("v{}", netns);
-    let veth_ns = format!("v{}ns", netns);
-
+/// Create a veth pair and connect a namespace to a bridge.
+///
+/// `veth_host` must be unique in the host's default namespace.
+/// `veth_ns` is the name the veth takes inside `netns` and need only be
+/// unique within that namespace; YAML configs and feature-file step
+/// arguments reference this name, so callers typically pick the bare
+/// `v{logical}ns` form (e.g. `vz1ns`).
+pub async fn connect_netns_to_bridge(
+    netns: &str,
+    bridge_name: &str,
+    veth_host: &str,
+    veth_ns: &str,
+) -> Result<()> {
     // Create veth pair
     run_cmd(
         &[
-            "ip", "link", "add", &veth_host, "type", "veth", "peer", "name", &veth_ns,
+            "ip", "link", "add", veth_host, "type", "veth", "peer", "name", veth_ns,
         ],
         &format!("Failed to create veth pair for {}", netns),
     )
@@ -122,27 +139,27 @@ pub async fn connect_netns_to_bridge(netns: &str, bridge_name: &str) -> Result<(
 
     // Move veth to namespace
     run_cmd(
-        &["ip", "link", "set", &veth_ns, "netns", netns],
+        &["ip", "link", "set", veth_ns, "netns", netns],
         &format!("Failed to move veth to namespace {}", netns),
     )
     .await?;
 
     // Add host veth to bridge
     run_cmd(
-        &["ip", "link", "set", &veth_host, "master", bridge_name],
+        &["ip", "link", "set", veth_host, "master", bridge_name],
         &format!("Failed to add veth to bridge {}", bridge_name),
     )
     .await?;
 
     // Bring up host veth
     run_cmd(
-        &["ip", "link", "set", &veth_host, "up"],
+        &["ip", "link", "set", veth_host, "up"],
         &format!("Failed to bring up host veth {}", veth_host),
     )
     .await?;
 
     // Bring up namespace veth
-    exec_in_netns(netns, "ip", &["link", "set", &veth_ns, "up"]).await?;
+    exec_in_netns(netns, "ip", &["link", "set", veth_ns, "up"]).await?;
 
     Ok(())
 }
@@ -157,13 +174,19 @@ pub async fn connect_netns_to_bridge(netns: &str, bridge_name: &str) -> Result<(
 /// then `ip link set <link> netns <ns> name <newname>` moves and renames
 /// each end in one atomic step.
 pub async fn connect_netns_pair(
+    short_id: &str,
     netns_a: &str,
     iface_a: &str,
     netns_b: &str,
     iface_b: &str,
 ) -> Result<()> {
-    let tmp_a = format!("vp{}{}a", netns_a, netns_b);
-    let tmp_b = format!("vp{}{}b", netns_a, netns_b);
+    // Temporary names live briefly in the host namespace; they need to be
+    // unique on the host between `ip link add` and `ip link set ... netns`.
+    // Using `short_id` plus a per-process counter keeps them well under
+    // IFNAMSIZ (15) regardless of how long `netns_a` / `netns_b` are.
+    let n = PAIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let tmp_a = format!("v{}_p{}a", short_id, n);
+    let tmp_b = format!("v{}_p{}b", short_id, n);
 
     run_cmd(
         &[
@@ -204,12 +227,13 @@ pub async fn connect_netns_pair(
     Ok(())
 }
 
-/// Delete the veth interface for a namespace (host side)
-pub async fn delete_veth(netns: &str) -> Result<()> {
-    let veth_host = format!("v{}", netns);
-    // Ignore errors as the veth might not exist
+/// Delete a host-side veth interface by name. Best-effort: missing
+/// interface is not an error.
+pub async fn delete_veth(veth_host: &str) -> Result<()> {
     let _ = Command::new("sudo")
-        .args(["ip", "link", "del", &veth_host])
+        .args(["ip", "link", "del", veth_host])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .status()
         .await;
     Ok(())
@@ -234,11 +258,10 @@ pub async fn spawn_in_netns(
         .with_context(|| format!("Failed to spawn {} in netns {}", cmd, netns))
 }
 
-/// Bring the namespace-side veth (the one created by connect_netns_to_bridge)
-/// administratively up or down.
-pub async fn set_link_state(netns: &str, up: bool) -> Result<()> {
-    let veth_ns = format!("v{}ns", netns);
-    set_interface_state(netns, &veth_ns, up).await
+/// Bring the namespace-side veth administratively up or down.
+/// Caller passes the veth name (typically `v{logical}ns`).
+pub async fn set_link_state(netns: &str, veth: &str, up: bool) -> Result<()> {
+    set_interface_state(netns, veth, up).await
 }
 
 /// Bring an arbitrary interface inside a namespace administratively up or down.
@@ -248,16 +271,113 @@ pub async fn set_interface_state(netns: &str, interface: &str, up: bool) -> Resu
     Ok(())
 }
 
-/// Kill all zebra-rs processes on the host (across all namespaces).
-/// Errors are ignored — it's fine if no process is running.
-pub async fn killall_zebra_rs() -> Result<()> {
+/// Read a PID from a file. Returns None if the file is missing or
+/// unparseable.
+async fn read_pid(path: &Path) -> Option<u32> {
+    let contents = fs::read_to_string(path).await.ok()?;
+    contents.trim().parse::<u32>().ok()
+}
+
+/// Returns true if the PID written in `path` is currently a live
+/// process. Sends signal 0 (no-op signal that still triggers the
+/// permission/existence check). Missing file or unparseable contents
+/// count as not alive.
+pub async fn pidfile_alive(path: &Path) -> bool {
+    let Some(pid) = read_pid(path).await else {
+        return false;
+    };
+    Command::new("sudo")
+        .args(["kill", "-0", &pid.to_string()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// SIGKILL the PID recorded in `path` and remove the file. Best-effort:
+/// missing file, dead process, or unparseable contents are not errors.
+///
+/// We delete via `sudo rm` because zebra-rs is launched with `sudo ip
+/// netns exec ...`, so the pid file is owned by root and `/tmp` has
+/// the sticky bit set — non-root deletion silently fails.
+pub async fn kill_pidfile(path: &Path) -> Result<()> {
+    if let Some(pid) = read_pid(path).await {
+        let _ = Command::new("sudo")
+            .args(["kill", "-9", &pid.to_string()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await;
+    }
     let _ = Command::new("sudo")
-        .args(["killall", "-9", "zebra-rs"])
+        .arg("rm")
+        .arg("-f")
+        .arg(path)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
         .await;
     Ok(())
+}
+
+/// List all network namespaces whose name starts with `prefix`.
+pub async fn list_netns_with_prefix(prefix: &str) -> Result<Vec<String>> {
+    let output = Command::new("sudo")
+        .args(["ip", "netns", "list"])
+        .stdout(Stdio::piped())
+        .output()
+        .await
+        .context("Failed to list network namespaces")?;
+    let list = String::from_utf8_lossy(&output.stdout);
+    Ok(list
+        .lines()
+        .filter_map(|line| line.split_whitespace().next())
+        .filter(|name| name.starts_with(prefix))
+        .map(String::from)
+        .collect())
+}
+
+/// List host bridges whose name starts with `prefix`.
+pub async fn list_bridges_with_prefix(prefix: &str) -> Result<Vec<String>> {
+    let output = Command::new("sudo")
+        .args(["ip", "-o", "link", "show", "type", "bridge"])
+        .stdout(Stdio::piped())
+        .output()
+        .await
+        .context("Failed to list bridges")?;
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut out = Vec::new();
+    for line in text.lines() {
+        // `ip -o link show` emits lines like:
+        //   "12: br_3f2a: <BROADCAST,...> mtu 1500 ..."
+        if let Some(rest) = line.split_once(": ") {
+            if let Some((name, _)) = rest.1.split_once(": ") {
+                if name.starts_with(prefix) {
+                    out.push(name.to_string());
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// List PID files in `dir` whose filename starts with `prefix` and ends
+/// with `.pid`. Returns absolute paths.
+pub async fn list_pidfiles(dir: &Path, prefix: &str) -> Result<Vec<std::path::PathBuf>> {
+    let mut entries = fs::read_dir(dir)
+        .await
+        .with_context(|| format!("Failed to read dir {:?}", dir))?;
+    let mut out = Vec::new();
+    while let Some(entry) = entries.next_entry().await? {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with(prefix) && name.ends_with(".pid") {
+            out.push(entry.path());
+        }
+    }
+    Ok(out)
 }
 
 /// Ping an IPv6 target from inside a namespace. Returns true on success,

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -1,9 +1,9 @@
 use std::fs;
+use std::path::Path;
 
 use bdd::netns;
 use cucumber::{World, WriterExt, given, then, when, writer};
 use serde_json::Value;
-use tokio::process::Command;
 
 #[derive(Debug, Default, World)]
 pub struct BgpWorld {
@@ -11,76 +11,155 @@ pub struct BgpWorld {
     feature_tag: String,
 }
 
-#[given("a clean test environment")]
-async fn clean_test_environment(_world: &mut BgpWorld) {
-    // Clean up any existing test resources (ignore errors)
-    // Kill any leftover zebra-rs processes before tearing down namespaces,
-    // otherwise their open netlink sockets can keep the namespace alive.
-    let _ = netns::killall_zebra_rs().await;
-
-    // Delete veths first (must be done before namespaces are deleted).
-    // Cleanup is best-effort across z1..z4 so the same step works for both
-    // the bridge-attached topologies (z1, z2) and the linear point-to-point
-    // chain used by the SRv6 scenario (z1..z4).
-    for ns in ["z1", "z2", "z3", "z4"] {
-        let _ = netns::delete_veth(ns).await;
-        let _ = netns::delete_netns(ns).await;
+impl BgpWorld {
+    fn short_id(&self) -> String {
+        let mut hash: u32 = 0x811c_9dc5;
+        for byte in self.feature_tag.as_bytes() {
+            hash ^= *byte as u32;
+            hash = hash.wrapping_mul(0x0100_0193);
+        }
+        format!("{:04x}", hash & 0xffff)
     }
-    let _ = netns::delete_bridge("br0").await;
 
-    println!("✓ Test environment cleaned");
+    fn ns(&self, logical: &str) -> String {
+        format!("{}_{}", self.feature_tag, logical)
+    }
+
+    fn bridge(&self, _logical: &str) -> String {
+        format!("br_{}", self.short_id())
+    }
+
+    fn host_veth(&self, logical: &str) -> String {
+        format!("v{}_{}", self.short_id(), logical)
+    }
+
+    fn ns_veth(&self, logical: &str) -> String {
+        format!("v{}ns", logical)
+    }
+
+    fn pid_file(&self, logical: &str) -> String {
+        format!("/tmp/{}.pid", self.ns(logical))
+    }
+}
+
+#[given("a clean test environment")]
+async fn clean_test_environment(world: &mut BgpWorld) {
+    // Per-feature deterministic prefix lets parallel runs of *different*
+    // features coexist without colliding on host-global namespace, bridge,
+    // or veth names. We sweep only resources owned by this feature.
+    assert!(
+        !world.feature_tag.is_empty(),
+        "feature must declare a tag (e.g. @bgp_basic_ibgp) for parallel-safe scoping"
+    );
+
+    let ns_prefix = format!("{}_", world.feature_tag);
+    let pid_prefix = ns_prefix.clone();
+    let bridge_name = world.bridge("");
+
+    // 1. Detect concurrent run of the same feature: if any pid file in
+    // /tmp matching this feature points to a live process, abort. The
+    // operator should wait for the other run to finish (or use a
+    // different feature for parallelism).
+    if let Ok(pidfiles) = netns::list_pidfiles(Path::new("/tmp"), &pid_prefix).await {
+        for path in &pidfiles {
+            if netns::pidfile_alive(path).await {
+                panic!(
+                    "another run of feature {} is in progress (live pid file {:?}); refusing to clobber its resources",
+                    world.feature_tag, path
+                );
+            }
+        }
+        // Stale pid files from a crashed prior run: best-effort kill +
+        // remove. kill_pidfile tolerates missing process / file.
+        for path in pidfiles {
+            let _ = netns::kill_pidfile(&path).await;
+        }
+    }
+
+    // 2. Sweep stale namespaces from a crashed prior run of THIS
+    // feature. Deleting a netns auto-destroys its in-namespace
+    // interfaces (including the ns end of any veth pair, which by
+    // veth semantics also destroys the host end).
+    if let Ok(stale) = netns::list_netns_with_prefix(&ns_prefix).await {
+        for ns in stale {
+            let _ = netns::delete_netns(&ns).await;
+        }
+    }
+
+    // 3. Sweep stale bridges. We use a single bridge name per feature
+    // (br_{short_id}); list-by-prefix picks it up if it survived.
+    if let Ok(stale) = netns::list_bridges_with_prefix(&bridge_name).await {
+        for br in stale {
+            let _ = netns::delete_bridge(&br).await;
+        }
+    }
+
+    println!(
+        "✓ Test environment cleaned for feature {}",
+        world.feature_tag
+    );
 }
 
 #[when(expr = "I create namespace {string}")]
-async fn create_namespace_plain(_world: &mut BgpWorld, namespace: String) {
-    netns::create_netns(&namespace)
+async fn create_namespace_plain(world: &mut BgpWorld, namespace: String) {
+    let scoped = world.ns(&namespace);
+    netns::create_netns(&scoped)
         .await
         .expect("Failed to create namespace");
-    println!("✓ Namespace {} created (no bridge)", namespace);
+    println!("✓ Namespace {} created (no bridge)", scoped);
 }
 
 #[when(
     expr = "I connect namespace {string} interface {string} to namespace {string} interface {string}"
 )]
 async fn connect_two_namespaces(
-    _world: &mut BgpWorld,
+    world: &mut BgpWorld,
     ns_a: String,
     iface_a: String,
     ns_b: String,
     iface_b: String,
 ) {
-    netns::connect_netns_pair(&ns_a, &iface_a, &ns_b, &iface_b)
+    let a = world.ns(&ns_a);
+    let b = world.ns(&ns_b);
+    let short = world.short_id();
+    netns::connect_netns_pair(&short, &a, &iface_a, &b, &iface_b)
         .await
         .expect("Failed to connect namespace pair");
-    println!("✓ Linked {}:{} <-> {}:{}", ns_a, iface_a, ns_b, iface_b);
+    println!("✓ Linked {}:{} <-> {}:{}", a, iface_a, b, iface_b);
 }
 
 #[when(expr = "I create bridge {string}")]
-async fn create_bridge(_world: &mut BgpWorld, bridge_name: String) {
-    netns::create_bridge(&bridge_name)
+async fn create_bridge(world: &mut BgpWorld, bridge_name: String) {
+    let scoped = world.bridge(&bridge_name);
+    netns::create_bridge(&scoped)
         .await
         .expect("Failed to create bridge");
-    println!("✓ Bridge {} created and up", bridge_name);
+    println!("✓ Bridge {} created and up", scoped);
 }
 
 #[when(expr = "I create namespace {string} with IP {string} on bridge {string}")]
 async fn create_namespace_with_ip(
-    _world: &mut BgpWorld,
+    world: &mut BgpWorld,
     namespace: String,
     ip: String,
     bridge_name: String,
 ) {
-    netns::create_netns(&namespace)
+    let scoped_ns = world.ns(&namespace);
+    let scoped_br = world.bridge(&bridge_name);
+    let host_veth = world.host_veth(&namespace);
+    let ns_veth = world.ns_veth(&namespace);
+
+    netns::create_netns(&scoped_ns)
         .await
         .expect("Failed to create namespace");
 
-    netns::connect_netns_to_bridge(&namespace, &bridge_name)
+    netns::connect_netns_to_bridge(&scoped_ns, &scoped_br, &host_veth, &ns_veth)
         .await
         .expect("Failed to connect namespace to bridge");
 
     println!(
         "✓ Namespace {} created with IP {} on bridge {}",
-        namespace, ip, bridge_name
+        scoped_ns, ip, scoped_br
     );
 }
 
@@ -88,43 +167,52 @@ async fn create_namespace_with_ip(
     expr = "I create namespace {string} with loopback and veth interface on the bridge {string}"
 )]
 async fn create_namespace_with_loopback(
-    _world: &mut BgpWorld,
+    world: &mut BgpWorld,
     namespace: String,
     bridge_name: String,
 ) {
-    netns::create_netns(&namespace)
+    let scoped_ns = world.ns(&namespace);
+    let scoped_br = world.bridge(&bridge_name);
+    let host_veth = world.host_veth(&namespace);
+    let ns_veth = world.ns_veth(&namespace);
+
+    netns::create_netns(&scoped_ns)
         .await
         .expect("Failed to create namespace");
 
-    netns::connect_netns_to_bridge(&namespace, &bridge_name)
+    netns::connect_netns_to_bridge(&scoped_ns, &scoped_br, &host_veth, &ns_veth)
         .await
         .expect("Failed to connect namespace to bridge");
 
     println!(
         "✓ Namespace {} created with loopback and veth on bridge {}",
-        namespace, bridge_name
+        scoped_ns, scoped_br
     );
 }
 
 #[when(expr = "I bring link down in namespace {string}")]
-async fn bring_link_down(_world: &mut BgpWorld, namespace: String) {
-    netns::set_link_state(&namespace, false)
+async fn bring_link_down(world: &mut BgpWorld, namespace: String) {
+    let scoped = world.ns(&namespace);
+    let veth = world.ns_veth(&namespace);
+    netns::set_link_state(&scoped, &veth, false)
         .await
         .expect("Failed to bring link down");
-    println!("✓ Link brought down in namespace {}", namespace);
+    println!("✓ Link brought down in namespace {}", scoped);
 }
 
 #[when(expr = "I bring link up in namespace {string}")]
-async fn bring_link_up(_world: &mut BgpWorld, namespace: String) {
-    netns::set_link_state(&namespace, true)
+async fn bring_link_up(world: &mut BgpWorld, namespace: String) {
+    let scoped = world.ns(&namespace);
+    let veth = world.ns_veth(&namespace);
+    netns::set_link_state(&scoped, &veth, true)
         .await
         .expect("Failed to bring link up");
-    println!("✓ Link brought up in namespace {}", namespace);
+    println!("✓ Link brought up in namespace {}", scoped);
 }
 
 #[when(expr = "I make namespace {string} interface {string} {word}")]
 async fn set_namespace_interface_state(
-    _world: &mut BgpWorld,
+    world: &mut BgpWorld,
     namespace: String,
     interface: String,
     state: String,
@@ -137,12 +225,13 @@ async fn set_namespace_interface_state(
             other
         ),
     };
-    netns::set_interface_state(&namespace, &interface, up)
+    let scoped = world.ns(&namespace);
+    netns::set_interface_state(&scoped, &interface, up)
         .await
         .expect("Failed to set interface state");
     println!(
         "✓ Interface {} in namespace {} set {}",
-        interface, namespace, state
+        interface, scoped, state
     );
 }
 
@@ -152,42 +241,47 @@ async fn wait_seconds(_world: &mut BgpWorld, seconds: u64) {
 }
 
 #[then(expr = "ping from {string} to {string} should succeed")]
-async fn ping_should_succeed(_world: &mut BgpWorld, namespace: String, target: String) {
-    let success = netns::ping6(&namespace, &target, 3, 2)
+async fn ping_should_succeed(world: &mut BgpWorld, namespace: String, target: String) {
+    let scoped = world.ns(&namespace);
+    let success = netns::ping6(&scoped, &target, 3, 2)
         .await
         .expect("ping6 failed to run");
     assert!(
         success,
         "ping from {} to {} did not succeed",
-        namespace, target
+        scoped, target
     );
-    println!("✓ ping from {} to {} succeeded", namespace, target);
+    println!("✓ ping from {} to {} succeeded", scoped, target);
 }
 
 #[then(expr = "ping from {string} to {string} should fail")]
-async fn ping_should_fail(_world: &mut BgpWorld, namespace: String, target: String) {
-    let success = netns::ping6(&namespace, &target, 1, 1)
+async fn ping_should_fail(world: &mut BgpWorld, namespace: String, target: String) {
+    let scoped = world.ns(&namespace);
+    let success = netns::ping6(&scoped, &target, 1, 1)
         .await
         .expect("ping6 failed to run");
     assert!(
         !success,
         "ping from {} to {} unexpectedly succeeded",
-        namespace, target
+        scoped, target
     );
-    println!(
-        "✓ ping from {} to {} failed (as expected)",
-        namespace, target
-    );
+    println!("✓ ping from {} to {} failed (as expected)", scoped, target);
 }
 
 #[when(expr = "I start zebra-rs in namespace {string}")]
-async fn start_zebra_rs(_world: &mut BgpWorld, namespace: String) {
-    let log_file = format!("{}.log", namespace);
+async fn start_zebra_rs(world: &mut BgpWorld, namespace: String) {
+    let scoped = world.ns(&namespace);
+    let log_file = format!("{}.log", scoped);
+    let pid_file = world.pid_file(&namespace);
 
     let _child = netns::spawn_in_netns(
-        &namespace,
+        &scoped,
         "zebra-rs",
-        &["--log-output=file", &format!("--log-file={}", log_file)],
+        &[
+            "--log-output=file",
+            &format!("--log-file={}", log_file),
+            &format!("--pid-file={}", pid_file),
+        ],
     )
     .await
     .expect("Failed to start zebra-rs");
@@ -195,20 +289,29 @@ async fn start_zebra_rs(_world: &mut BgpWorld, namespace: String) {
     // Wait a moment for zebra-rs to start
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
-    println!("✓ zebra-rs started in namespace {}", namespace);
+    println!(
+        "✓ zebra-rs started in namespace {} (pid file {})",
+        scoped, pid_file
+    );
 }
 
 #[when(expr = "I stop zebra-rs in namespace {string}")]
-async fn stop_zebra_rs(_world: &mut BgpWorld, namespace: String) {
-    let _ = netns::exec_in_netns(&namespace, "pkill", &["-9", "zebra-rs"]).await;
-    println!("✓ zebra-rs stopped in namespace {}", namespace);
+async fn stop_zebra_rs(world: &mut BgpWorld, namespace: String) {
+    let pid_file = world.pid_file(&namespace);
+    let _ = netns::kill_pidfile(Path::new(&pid_file)).await;
+    println!(
+        "✓ zebra-rs stopped in namespace {} (via {})",
+        world.ns(&namespace),
+        pid_file
+    );
 }
 
 #[when(expr = "I apply config {string} to namespace {string}")]
 async fn apply_config(world: &mut BgpWorld, config_file: String, namespace: String) {
     let config_path = format!("tests/configs/{}/{}", world.feature_tag, config_file);
+    let scoped = world.ns(&namespace);
 
-    let stdout = netns::exec_in_netns(&namespace, "vtyctl", &["apply", "-f", &config_path])
+    let stdout = netns::exec_in_netns(&scoped, "vtyctl", &["apply", "-f", &config_path])
         .await
         .expect("Failed to apply config");
 
@@ -223,13 +326,13 @@ async fn apply_config(world: &mut BgpWorld, config_file: String, namespace: Stri
         !trimmed.starts_with("error:"),
         "vtyctl apply rejected {} in namespace {}: {}",
         config_file,
-        namespace,
+        scoped,
         trimmed
     );
 
     println!(
         "✓ Config {} applied to namespace {} ({})",
-        config_file, namespace, trimmed
+        config_file, scoped, trimmed
     );
 }
 
@@ -240,49 +343,50 @@ async fn wait_for_bgp(_world: &mut BgpWorld, seconds: u64) {
 }
 
 #[when(expr = "I clear namespace {string} neighbor {string}")]
-async fn clear_bgp_neighbor(_world: &mut BgpWorld, namespace: String, neighbor: String) {
+async fn clear_bgp_neighbor(world: &mut BgpWorld, namespace: String, neighbor: String) {
+    let scoped = world.ns(&namespace);
     let cmd = format!("clear ip bgp neighbors {}", neighbor);
-    netns::exec_in_netns(&namespace, "vtyctl", &["clear", &cmd])
+    netns::exec_in_netns(&scoped, "vtyctl", &["clear", &cmd])
         .await
         .expect("Failed to clear BGP neighbor");
 
     println!(
         "✓ Cleared BGP neighbor {} in namespace {}",
-        neighbor, namespace
+        neighbor, scoped
     );
 }
 
 #[when(expr = "I delete namespace {string}")]
-async fn delete_namespace(_world: &mut BgpWorld, namespace: String) {
-    // Delete veth on host side first
-    // let _ = netns::delete_veth(&namespace).await;
-
-    netns::delete_netns(&namespace)
+async fn delete_namespace(world: &mut BgpWorld, namespace: String) {
+    let scoped = world.ns(&namespace);
+    netns::delete_netns(&scoped)
         .await
         .expect("Failed to delete namespace");
 
-    println!("✓ Namespace {} deleted", namespace);
+    println!("✓ Namespace {} deleted", scoped);
 }
 
 #[when(expr = "I delete bridge {string}")]
-async fn delete_bridge(_world: &mut BgpWorld, bridge_name: String) {
-    netns::delete_bridge(&bridge_name)
+async fn delete_bridge(world: &mut BgpWorld, bridge_name: String) {
+    let scoped = world.bridge(&bridge_name);
+    netns::delete_bridge(&scoped)
         .await
         .expect("Failed to delete bridge");
 
-    println!("✓ Bridge {} deleted", bridge_name);
+    println!("✓ Bridge {} deleted", scoped);
 }
 
 #[then(expr = "BGP session in {string} to {string} should be {string}")]
 async fn verify_bgp_session(
-    _world: &mut BgpWorld,
+    world: &mut BgpWorld,
     namespace: String,
     neighbor: String,
     expected_state: String,
 ) {
+    let scoped = world.ns(&namespace);
     let cmd = format!("show ip bgp neighbors {}", neighbor);
     let binding = ["show", "-j", &cmd];
-    let output = netns::exec_in_netns(&namespace, "vtyctl", &binding)
+    let output = netns::exec_in_netns(&scoped, "vtyctl", &binding)
         .await
         .expect("Failed to get BGP neighbor state");
 
@@ -294,7 +398,7 @@ async fn verify_bgp_session(
             .to_lowercase()
             .contains(&expected_state.to_lowercase()),
         "BGP session {} -> {} is not {}, got: {}",
-        namespace,
+        scoped,
         neighbor,
         expected_state,
         output
@@ -302,20 +406,21 @@ async fn verify_bgp_session(
 
     println!(
         "✓ BGP session {} -> {} is {}",
-        namespace, neighbor, expected_state
+        scoped, neighbor, expected_state
     );
 }
 
 #[then(expr = "BGP session in {string} to {string} should not be {string}")]
 async fn verify_bgp_session_not(
-    _world: &mut BgpWorld,
+    world: &mut BgpWorld,
     namespace: String,
     neighbor: String,
     unexpected_state: String,
 ) {
+    let scoped = world.ns(&namespace);
     let cmd = format!("show ip bgp neighbors {}", neighbor);
     let binding = ["show", "-j", &cmd];
-    let output = netns::exec_in_netns(&namespace, "vtyctl", &binding)
+    let output = netns::exec_in_netns(&scoped, "vtyctl", &binding)
         .await
         .expect("Failed to get BGP neighbor state");
 
@@ -325,7 +430,7 @@ async fn verify_bgp_session_not(
     assert!(
         state.to_lowercase() != unexpected_state.to_lowercase(),
         "BGP session {} -> {} should not be {}, got: {}",
-        namespace,
+        scoped,
         neighbor,
         unexpected_state,
         state
@@ -333,13 +438,14 @@ async fn verify_bgp_session_not(
 
     println!(
         "✓ BGP session {} -> {} is not {}",
-        namespace, neighbor, unexpected_state
+        scoped, neighbor, unexpected_state
     );
 }
 
 #[then(expr = "BGP route in {string} has {string}")]
-async fn verify_bgp_route(_world: &mut BgpWorld, namespace: String, expected_prefix: String) {
-    let output = netns::exec_in_netns(&namespace, "vtyctl", &["show", "-j", "show ip bgp"])
+async fn verify_bgp_route(world: &mut BgpWorld, namespace: String, expected_prefix: String) {
+    let scoped = world.ns(&namespace);
+    let output = netns::exec_in_netns(&scoped, "vtyctl", &["show", "-j", "show ip bgp"])
         .await
         .expect("Failed to get BGP routes");
 
@@ -356,18 +462,19 @@ async fn verify_bgp_route(_world: &mut BgpWorld, namespace: String, expected_pre
     assert!(
         has_prefix,
         "BGP route {} not found in namespace {}, got: {}",
-        expected_prefix, namespace, output
+        expected_prefix, scoped, output
     );
 
     println!(
         "✓ BGP route {} found in namespace {}",
-        expected_prefix, namespace
+        expected_prefix, scoped
     );
 }
 
 #[then(expr = "BGP route in {string} does not have {string}")]
-async fn verify_bgp_route_not(_world: &mut BgpWorld, namespace: String, unexpected_prefix: String) {
-    let output = netns::exec_in_netns(&namespace, "vtyctl", &["show", "-j", "show ip bgp"])
+async fn verify_bgp_route_not(world: &mut BgpWorld, namespace: String, unexpected_prefix: String) {
+    let scoped = world.ns(&namespace);
+    let output = netns::exec_in_netns(&scoped, "vtyctl", &["show", "-j", "show ip bgp"])
         .await
         .expect("Failed to get BGP routes");
 
@@ -385,24 +492,25 @@ async fn verify_bgp_route_not(_world: &mut BgpWorld, namespace: String, unexpect
     assert!(
         !has_prefix,
         "BGP route {} should not be in namespace {}, got: {}",
-        unexpected_prefix, namespace, output
+        unexpected_prefix, scoped, output
     );
 
     println!(
         "✓ BGP route {} not found in namespace {}",
-        unexpected_prefix, namespace
+        unexpected_prefix, scoped
     );
 }
 
 #[then(expr = "BGP route in {string} has {string} with {string} value {string}")]
 async fn verify_bgp_route_field(
-    _world: &mut BgpWorld,
+    world: &mut BgpWorld,
     namespace: String,
     expected_prefix: String,
     field_name: String,
     expected_value: String,
 ) {
-    let output = netns::exec_in_netns(&namespace, "vtyctl", &["show", "-j", "show ip bgp"])
+    let scoped = world.ns(&namespace);
+    let output = netns::exec_in_netns(&scoped, "vtyctl", &["show", "-j", "show ip bgp"])
         .await
         .expect("Failed to get BGP routes");
 
@@ -416,7 +524,7 @@ async fn verify_bgp_route_field(
     let route = route.unwrap_or_else(|| {
         panic!(
             "BGP route {} not found in namespace {}, got: {}",
-            expected_prefix, namespace, output
+            expected_prefix, scoped, output
         )
     });
 
@@ -445,14 +553,16 @@ async fn verify_bgp_route_field(
 
     println!(
         "✓ BGP route {} in namespace {} has {} = {}",
-        expected_prefix, namespace, field_name, expected_value
+        expected_prefix, scoped, field_name, expected_value
     );
 }
 
 #[given("the test topology exists")]
 async fn test_topology_exists(world: &mut BgpWorld) {
-    world.topology_running = netns::netns_exists("z1").await.unwrap_or(false)
-        && netns::netns_exists("z2").await.unwrap_or(false);
+    let z1 = world.ns("z1");
+    let z2 = world.ns("z2");
+    world.topology_running = netns::netns_exists(&z1).await.unwrap_or(false)
+        && netns::netns_exists(&z2).await.unwrap_or(false);
 }
 
 /// Run a `vtyctl show <command>` inside a namespace and assert the
@@ -462,50 +572,70 @@ async fn test_topology_exists(world: &mut BgpWorld) {
 /// for LSDB / route-table assertions.
 #[then(expr = "show command {string} in namespace {string} should contain {string}")]
 async fn show_command_contains(
-    _world: &mut BgpWorld,
+    world: &mut BgpWorld,
     show_cmd: String,
     namespace: String,
     needle: String,
 ) {
-    let output = netns::exec_in_netns(&namespace, "vtyctl", &["show", &show_cmd])
+    let scoped = world.ns(&namespace);
+    let output = netns::exec_in_netns(&scoped, "vtyctl", &["show", &show_cmd])
         .await
         .expect("Failed to run show command");
     assert!(
         output.contains(&needle),
         "show '{}' in namespace {} did not contain '{}'\nfull output:\n{}",
         show_cmd,
-        namespace,
+        scoped,
         needle,
         output,
     );
     println!(
         "✓ show '{}' in namespace {} contains '{}'",
-        show_cmd, namespace, needle
+        show_cmd, scoped, needle
     );
 }
 
 #[then("the test environment should be clean")]
-async fn verify_clean_environment(_world: &mut BgpWorld) {
-    let z1_exists = netns::netns_exists("z1").await.unwrap_or(false);
-    let z2_exists = netns::netns_exists("z2").await.unwrap_or(false);
-
-    assert!(!z1_exists, "Namespace z1 still exists");
-    assert!(!z2_exists, "Namespace z2 still exists");
-
-    let output = Command::new("sudo")
-        .args(["ip", "link", "show", "br0"])
-        .output()
+async fn verify_clean_environment(world: &mut BgpWorld) {
+    let ns_prefix = format!("{}_", world.feature_tag);
+    let leftover_ns = netns::list_netns_with_prefix(&ns_prefix)
         .await
-        .expect("Failed to check bridge");
+        .unwrap_or_default();
+    assert!(
+        leftover_ns.is_empty(),
+        "Namespaces still exist: {:?}",
+        leftover_ns
+    );
 
-    assert!(!output.status.success(), "Bridge br0 still exists");
+    let bridge = world.bridge("");
+    let leftover_br = netns::list_bridges_with_prefix(&bridge)
+        .await
+        .unwrap_or_default();
+    assert!(
+        leftover_br.is_empty(),
+        "Bridges still exist: {:?}",
+        leftover_br
+    );
+
+    let leftover_pid = netns::list_pidfiles(Path::new("/tmp"), &ns_prefix)
+        .await
+        .unwrap_or_default();
+    assert!(
+        leftover_pid.is_empty(),
+        "PID files still exist: {:?}",
+        leftover_pid
+    );
 
     println!("✓ Test environment is clean");
 }
 
 #[tokio::main]
 async fn main() {
-    let file = fs::File::create("allure-results/results.json").unwrap();
+    // Scope Allure output by PID so concurrent `cargo test` invocations
+    // don't clobber each other's results.json.
+    let _ = fs::create_dir_all("allure-results");
+    let results_path = format!("allure-results/results-{}.json", std::process::id());
+    let file = fs::File::create(&results_path).unwrap();
     BgpWorld::cucumber()
         .before(|feature, _rule, _scenario, world| {
             Box::pin(async move {

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -56,6 +56,12 @@ struct Arg {
         help = "Re-install configured addresses removed by the kernel (cool-down on burst); off by default"
     )]
     enable_addr_recovery: bool,
+
+    #[arg(
+        long,
+        help = "Write PID to this file on startup; in --daemon mode replaces /var/run/zebra-rs.pid"
+    )]
+    pid_file: Option<String>,
 }
 
 // 1. Option Yang path
@@ -111,9 +117,9 @@ fn system_path(arg: &Arg) -> PathBuf {
     }
 }
 
-fn daemonize() -> anyhow::Result<()> {
+fn daemonize(pid_file: Option<&str>) -> anyhow::Result<()> {
     let daemonize = Daemonize::new()
-        .pid_file("/var/run/zebra-rs.pid") // Every method except `new` and `start`
+        .pid_file(pid_file.unwrap_or("/var/run/zebra-rs.pid"))
         .chown_pid_file(true) // is optional, see `Daemonize` documentation
         .working_directory("/") // for default behaviour.
         .umask(0o027) // Set umask, `0o027` by default.
@@ -123,6 +129,11 @@ fn daemonize() -> anyhow::Result<()> {
         Ok(_) => Ok(()),
         Err(e) => Err(anyhow::anyhow!("Failed to daemonize: {}", e)),
     }
+}
+
+fn write_pid_file(path: &str) -> anyhow::Result<()> {
+    std::fs::write(path, format!("{}\n", std::process::id()))
+        .map_err(|e| anyhow::anyhow!("Failed to write PID to {}: {}", path, e))
 }
 
 #[tokio::main]
@@ -168,7 +179,9 @@ async fn main() -> anyhow::Result<()> {
 
     // Daemonize if requested (after tracing setup)
     if arg.daemon {
-        daemonize()?;
+        daemonize(arg.pid_file.as_deref())?;
+    } else if let Some(ref path) = arg.pid_file {
+        write_pid_file(path)?;
     }
 
     tracing::info!("zebra-rs started");


### PR DESCRIPTION
## Summary

- Make BDD test suite safe to run multiple times in parallel on the same host. Today, two `make -C bdd run` (or two different feature targets) collide on host-global names `z1..z4`, `br0`, and host-side veth pairs derived from those.
- Add `--pid-file <PATH>` arg to `zebra-rs` so the harness can identify and kill exactly the daemon it spawned. Replaces a host-wide `killall -9 zebra-rs` that would tear down a parallel run's daemons.
- Feature files and YAML configs are not modified — all scoping happens inside `bdd/tests/cucumber.rs` and `bdd/src/netns.rs`.

## Naming scheme

| Resource | Pattern | Example for `bgp_basic_ibgp` |
|---|---|---|
| Network namespace | `{feature_tag}_{logical}` | `bgp_basic_ibgp_z1` |
| Bridge | `br_{short_id}` | `br_dedc` |
| Host-side veth | `v{short_id}_{logical}` | `vdedc_z1` |
| NS-side veth | `v{logical}ns` (unchanged) | `vz1ns` |
| Pair temp veths | `v{short_id}_p{n}a/b` | `vdedc_p1a` |
| PID file | `/tmp/{feature_tag}_{logical}.pid` | `/tmp/bgp_basic_ibgp_z1.pid` |
| Allure JSON | `allure-results/results-{pid}.json` | `allure-results/results-12345.json` |

`short_id` is a deterministic 4-hex-char FNV-1a hash of `feature_tag` (no new crate deps). Linux IFNAMSIZ=15 forces a short prefix on bridge/veth names; `ns-side veth` keeps the bare `v{logical}ns` form because YAML configs reference it directly.

## Cleanup contract

- Start of feature: pid-file collision detection (live PID = abort with "another run in progress"); sweep stale `{feature_tag}_*` namespaces and `br_{short_id}` bridge.
- Cross-feature crashes self-heal: any feature that ran before will be cleaned up the next time *that same feature* runs.
- Same-feature parallel: detected and aborted on startup. Different features in parallel: fully isolated.

## Behavioral change

- `netns::killall_zebra_rs` is removed (was host-wide `killall -9 zebra-rs`). Cleanup is now precise per-pid-file.

## Test plan

- [x] `--pid-file` smoke (write, kill via file) works standalone
- [x] Single ibgp run: pass/fail rate identical to `bdd-clean-up` baseline (5 pre-existing flakes confirmed by running same test on parent branch)
- [x] Parallel ibgp + ebgp runs simultaneously with distinct prefixes (`bgp_basic_ibgp_*` / `br_dedc` and `bgp_basic_ebgp_*` / `br_6bd0`); zero leftover namespaces, bridges, or pid files
- [ ] Full suite still passes on a clean host
- [ ] Verify same-feature collision aborts correctly with clear error

Generated with [Claude Code](https://claude.com/claude-code)