### PR TITLE
fib, bgp, rib: gate EVPN diagnostic tracing behind DEBUG_EVPN

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -19,6 +19,10 @@ use super::{Bgp, InOut, Message};
 
 pub const ORIGINATED_PEER: usize = usize::MAX;
 
+// Flip to true to log EVPN-related diagnostic traces (e.g., VNI
+// extraction from RT extended communities).
+const DEBUG_EVPN: bool = false;
+
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
 pub enum BgpRibType {
     IBGP,
@@ -1427,7 +1431,9 @@ fn extract_vni_from_attr(attr: &BgpAttr) -> Option<u32> {
                     ((ec.val[3] as u32) << 16) | ((ec.val[4] as u32) << 8) | (ec.val[5] as u32);
 
                 if vni > 0 && vni < 0x1000000 {
-                    tracing::info!("extract_vni_from_attr: RT yields VNI {}", vni);
+                    if DEBUG_EVPN {
+                        tracing::info!("extract_vni_from_attr: RT yields VNI {}", vni);
+                    }
                     return Some(vni);
                 }
             }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -9,6 +9,7 @@ use prefix_trie::PrefixMap;
 
 use crate::bgp::timer::{start_adv_timer_evpn, start_stale_timer};
 use crate::policy::{CommunityMatcher, PolicyList, StandardMatcher};
+use crate::rib::route::DEBUG_EVPN;
 use crate::rib::{self, MacAddr, api::FdbEntry};
 
 use super::cap::CapAfiMap;
@@ -18,10 +19,6 @@ use super::timer::{start_adv_timer_ipv4, start_adv_timer_vpnv4};
 use super::{Bgp, InOut, Message};
 
 pub const ORIGINATED_PEER: usize = usize::MAX;
-
-// Flip to true to log EVPN-related diagnostic traces (e.g., VNI
-// extraction from RT extended communities).
-const DEBUG_EVPN: bool = false;
 
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
 pub enum BgpRibType {

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -36,7 +36,7 @@ use crate::fib::sysctl::sysctl_enable;
 use crate::fib::{FibAddr, FibLink, FibMessage, FibNeighbor, FibRoute};
 use crate::rib::entry::RibEntry;
 use crate::rib::inst::IlmEntry;
-use crate::rib::route::DEBUG_ADDR;
+use crate::rib::route::{DEBUG_ADDR, DEBUG_EVPN};
 use crate::rib::{
     AddrGenMode, Bridge, Group, GroupTrait, MacAddr, Nexthop, NexthopMulti, NexthopUni, RibType,
     Vxlan, link,
@@ -51,12 +51,6 @@ const DEBUG_V6: bool = false;
 // the kernel are reported regardless. Mirrored by RIB via this same
 // constant (re-exported as `crate::fib::netlink::handle::DEBUG_SID`).
 pub const DEBUG_SID: bool = false;
-
-// Flip to true to log every EVPN-related FDB / MDB / VXLAN VNI
-// registration the FIB performs (mac_add, mac_del, mdb_add, mdb_del,
-// register/unregister VXLAN ifindex). Errors from the kernel are
-// reported regardless.
-const DEBUG_EVPN: bool = false;
 
 /// Mask the lower (128 - prefix_len) bits of an IPv6 address. The
 /// kernel ignores bits past the prefix length on install, but masking

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -52,6 +52,12 @@ const DEBUG_V6: bool = false;
 // constant (re-exported as `crate::fib::netlink::handle::DEBUG_SID`).
 pub const DEBUG_SID: bool = false;
 
+// Flip to true to log every EVPN-related FDB / MDB / VXLAN VNI
+// registration the FIB performs (mac_add, mac_del, mdb_add, mdb_del,
+// register/unregister VXLAN ifindex). Errors from the kernel are
+// reported regardless.
+const DEBUG_EVPN: bool = false;
+
 /// Mask the lower (128 - prefix_len) bits of an IPv6 address. The
 /// kernel ignores bits past the prefix length on install, but masking
 /// keeps the netlink trace honest and the address shape predictable
@@ -1661,17 +1667,21 @@ impl FibHandle {
     /// Register VXLAN interface with its VNI for FDB operations
     /// Called when a VXLAN interface is created to establish VNI→ifindex mapping
     pub fn register_vxlan_ifindex(&mut self, vni: u32, ifindex: u32) {
-        tracing::info!(
-            "[FIB] Registered VXLAN VNI {} with ifindex {}",
-            vni,
-            ifindex
-        );
+        if DEBUG_EVPN {
+            tracing::info!(
+                "[FIB] Registered VXLAN VNI {} with ifindex {}",
+                vni,
+                ifindex
+            );
+        }
         self.vni_ifindex_map.insert(vni, ifindex);
     }
 
     /// Unregister VXLAN interface mapping
     pub fn unregister_vxlan_ifindex(&mut self, vni: u32) {
-        tracing::info!("[FIB] Unregistered VXLAN VNI {}", vni);
+        if DEBUG_EVPN {
+            tracing::info!("[FIB] Unregistered VXLAN VNI {}", vni);
+        }
         self.vni_ifindex_map.remove(&vni);
     }
 
@@ -1708,23 +1718,27 @@ impl FibHandle {
         esi: Option<[u8; 10]>,
     ) {
         let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
-            tracing::info!(
-                "mac_add: no local VXLAN for VNI {} — skipping (mac {})",
-                vni,
-                mac
-            );
+            if DEBUG_EVPN {
+                tracing::info!(
+                    "mac_add: no local VXLAN for VNI {} — skipping (mac {})",
+                    vni,
+                    mac
+                );
+            }
             return;
         };
 
-        tracing::info!(
-            "mac_add: VNI {} mac {} ifindex {} dst {}",
-            vni,
-            mac,
-            vxlan_ifindex,
-            tunnel_endpoint
-                .map(|e| e.to_string())
-                .unwrap_or_else(|| "-".into()),
-        );
+        if DEBUG_EVPN {
+            tracing::info!(
+                "mac_add: VNI {} mac {} ifindex {} dst {}",
+                vni,
+                mac,
+                vxlan_ifindex,
+                tunnel_endpoint
+                    .map(|e| e.to_string())
+                    .unwrap_or_else(|| "-".into()),
+            );
+        }
 
         // Entry 1 — bridge master FDB. No VXLAN-specific attrs.
         // NUD_REACHABLE matches what Linux records for kernel-learned
@@ -1770,6 +1784,7 @@ impl FibHandle {
         // will be wired in Phase 5 when ECMP nexthop groups are supported.
         if let Some(esi_val) = esi
             && esi_val != [0u8; 10]
+            && DEBUG_EVPN
         {
             tracing::info!("mac_add: ESI type {} for MAC {}", esi_val[0], mac);
         }
@@ -1866,15 +1881,19 @@ impl FibHandle {
         // `unwrap_or(vni)` would have issued a stray RTM_DELNEIGH
         // against a random interface.
         let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
-            tracing::info!(
-                "mac_del: no local VXLAN for VNI {} — skipping (mac {})",
-                vni,
-                mac
-            );
+            if DEBUG_EVPN {
+                tracing::info!(
+                    "mac_del: no local VXLAN for VNI {} — skipping (mac {})",
+                    vni,
+                    mac
+                );
+            }
             return;
         };
 
-        tracing::info!("mac_del: VNI {} mac {} ifindex {}", vni, mac, vxlan_ifindex);
+        if DEBUG_EVPN {
+            tracing::info!("mac_del: VNI {} mac {} ifindex {}", vni, mac, vxlan_ifindex);
+        }
 
         // Mirror `mac_add` — remove BOTH the bridge master entry and
         // the VXLAN self entry. NUD state is irrelevant on delete
@@ -1937,20 +1956,24 @@ impl FibHandle {
         _seq: u32,
     ) {
         let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
-            tracing::info!(
-                "mdb_add: no local VXLAN for VNI {} — skipping (group {})",
-                vni,
-                group
-            );
+            if DEBUG_EVPN {
+                tracing::info!(
+                    "mdb_add: no local VXLAN for VNI {} — skipping (group {})",
+                    vni,
+                    group
+                );
+            }
             return;
         };
 
-        tracing::info!(
-            "mdb_add: VNI {} dst {} ifindex {} (zero-MAC FDB / ingress replication)",
-            vni,
-            group,
-            vxlan_ifindex,
-        );
+        if DEBUG_EVPN {
+            tracing::info!(
+                "mdb_add: VNI {} dst {} ifindex {} (zero-MAC FDB / ingress replication)",
+                vni,
+                group,
+                vxlan_ifindex,
+            );
+        }
 
         const NTF_SELF: u8 = 0x02;
         const NTF_EXT_LEARNED: u8 = 0x10;
@@ -1977,20 +2000,24 @@ impl FibHandle {
     /// Counterpart of `mdb_add`; same rationale on naming.
     pub async fn mdb_del(&self, vni: u32, group: IpAddr, _source: Option<IpAddr>, _ifindex: u32) {
         let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
-            tracing::info!(
-                "mdb_del: no local VXLAN for VNI {} — skipping (group {})",
-                vni,
-                group
-            );
+            if DEBUG_EVPN {
+                tracing::info!(
+                    "mdb_del: no local VXLAN for VNI {} — skipping (group {})",
+                    vni,
+                    group
+                );
+            }
             return;
         };
 
-        tracing::info!(
-            "mdb_del: VNI {} dst {} ifindex {} (zero-MAC FDB / ingress replication)",
-            vni,
-            group,
-            vxlan_ifindex,
-        );
+        if DEBUG_EVPN {
+            tracing::info!(
+                "mdb_del: VNI {} dst {} ifindex {} (zero-MAC FDB / ingress replication)",
+                vni,
+                group,
+                vxlan_ifindex,
+            );
+        }
 
         const NTF_SELF: u8 = 0x02;
 

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -13,7 +13,7 @@ use crate::fib::sysctl::{sysctl_mpls_enable, sysctl_seg6_enable};
 
 use super::api::RibRx;
 use super::entry::RibEntry;
-use super::route::DEBUG_ADDR;
+use super::route::{DEBUG_ADDR, DEBUG_EVPN};
 use super::util::IpNetExt;
 use super::{LinkFlagsExt, MacAddr, Message, Rib, RibType};
 
@@ -429,13 +429,15 @@ pub fn link_addr_del(link: &mut Link, addr: LinkAddr) -> Option<()> {
 
 impl Rib {
     pub async fn link_add(&mut self, fib_link: FibLink) {
-        tracing::info!(
-            "link_add: ifindex {} name {} vni {:?} master {:?}",
-            fib_link.index,
-            fib_link.name,
-            fib_link.vni,
-            fib_link.master,
-        );
+        if DEBUG_EVPN {
+            tracing::info!(
+                "link_add: ifindex {} name {} vni {:?} master {:?}",
+                fib_link.index,
+                fib_link.name,
+                fib_link.vni,
+                fib_link.master,
+            );
+        }
         // Capture pre-state so we can detect a VXLAN-bridge association
         // gaining valid `(master, vni)` and trigger an FDB rescan. The
         // common case is operator-driven sequence:

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -21,6 +21,13 @@ const DEBUG_V6: bool = false;
 // Flip to true to re-enable IP address diagnostic trace.
 pub const DEBUG_ADDR: bool = false;
 
+// Flip to true to log EVPN-related diagnostic traces (VXLAN VNI
+// register/unregister, mac_add / mac_del / mdb_add / mdb_del,
+// link_add EVPN bridge association, BGP RT→VNI extraction). Errors
+// from the kernel are reported regardless. Imported by the FIB and
+// BGP modules so all EVPN diagnostics share one switch.
+pub const DEBUG_EVPN: bool = false;
+
 /// Hold-down policy for kernel-driven address recovery.
 ///
 /// If a configured address is deleted by an external actor (NetworkManager,


### PR DESCRIPTION
## Summary

Mirror the `DEBUG_V6` / `DEBUG_ADDR` / `DEBUG_SID` pattern for EVPN. Every EVPN-related `tracing::info!` diagnostic is now gated behind a single `pub const DEBUG_EVPN` declared in `rib/route.rs`; flip it once and every EVPN trace turns on or off together.

Sites gated:
- `fib/netlink/handle.rs`: `register_vxlan_ifindex`, `unregister_vxlan_ifindex`, `mac_add` (3 prints), `mac_del` (2 prints), `mdb_add` (2 prints), `mdb_del` (2 prints).
- `bgp/route.rs`: `extract_vni_from_attr` "RT yields VNI" trace.
- `rib/link.rs`: `link_add` "ifindex/name/vni/master" trace.

Error paths (`NewLink vxlan error`, `fdb_neigh_send` netlink error) stay visible, matching the convention `DEBUG_V6` follows.

## Test plan

- [x] `cargo build -p zebra-rs --bin zebra-rs` — compiles
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

Generated with [Claude Code](https://claude.com/claude-code)