### PR TITLE
proto: rename vtysh.proto to vty.proto

### DIFF
--- a/proto/vty.proto
+++ b/proto/vty.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package vtysh;
+package vty;
 
 // The Command execution.
 service Exec {

--- a/vtyctl/build.rs
+++ b/vtyctl/build.rs
@@ -1,4 +1,4 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("../proto/vtysh.proto")?;
+    tonic_build::compile_protos("../proto/vty.proto")?;
     Ok(())
 }

--- a/vtyctl/src/apply.rs
+++ b/vtyctl/src/apply.rs
@@ -4,11 +4,11 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process::exit;
 use tonic::Request;
-use vtysh::apply_client::ApplyClient;
-use vtysh::{ApplyCode, ApplyRequest};
+use vty::apply_client::ApplyClient;
+use vty::{ApplyCode, ApplyRequest};
 
-pub mod vtysh {
-    tonic::include_proto!("vtysh");
+pub mod vty {
+    tonic::include_proto!("vty");
 }
 
 fn print_help() {

--- a/vtyctl/src/clear.rs
+++ b/vtyctl/src/clear.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
 use std::process::exit;
 use tonic::Request;
-use vtysh::clear_client::ClearClient;
-use vtysh::exec_client::ExecClient;
-use vtysh::{ClearRequest, ExecRequest, ExecType};
+use vty::clear_client::ClearClient;
+use vty::exec_client::ExecClient;
+use vty::{ClearRequest, ExecRequest, ExecType};
 
-pub mod vtysh {
-    tonic::include_proto!("vtysh");
+pub mod vty {
+    tonic::include_proto!("vty");
 }
 
 pub async fn clear(host: &str, command: &str) -> Result<()> {

--- a/vtyctl/src/main.rs
+++ b/vtyctl/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
-pub mod vtysh {
-    tonic::include_proto!("vtysh");
+pub mod vty {
+    tonic::include_proto!("vty");
 }
 pub mod apply;
 pub mod clear;

--- a/vtyctl/src/mcp/client.rs
+++ b/vtyctl/src/mcp/client.rs
@@ -3,8 +3,8 @@ use tokio_stream::StreamExt;
 use tonic::Request;
 use tracing::{debug, error};
 
-use crate::vtysh::show_client::ShowClient;
-use crate::vtysh::{CommandPath, ShowRequest, YangMatch};
+use crate::vty::show_client::ShowClient;
+use crate::vty::{CommandPath, ShowRequest, YangMatch};
 
 /// Client for communicating with zebra-rs daemon via gRPC
 #[derive(Clone)]

--- a/vtyctl/src/show.rs
+++ b/vtyctl/src/show.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
 use std::process::exit;
 use tonic::Request;
-use vtysh::exec_client::ExecClient;
-use vtysh::show_client::ShowClient;
-use vtysh::{ExecRequest, ExecType, ShowRequest};
+use vty::exec_client::ExecClient;
+use vty::show_client::ShowClient;
+use vty::{ExecRequest, ExecType, ShowRequest};
 
-pub mod vtysh {
-    tonic::include_proto!("vtysh");
+pub mod vty {
+    tonic::include_proto!("vty");
 }
 
 pub async fn show(host: &str, command: &str, json: bool) -> Result<()> {

--- a/vtyhelper/build.rs
+++ b/vtyhelper/build.rs
@@ -1,4 +1,4 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("../proto/vtysh.proto")?;
+    tonic_build::compile_protos("../proto/vty.proto")?;
     Ok(())
 }

--- a/vtyhelper/src/main.rs
+++ b/vtyhelper/src/main.rs
@@ -3,12 +3,12 @@ use clap::Parser;
 use std::env;
 use tokio::io::{self, AsyncWriteExt};
 use tokio_stream::StreamExt;
-use vtysh::exec_client::ExecClient;
-use vtysh::show_client::ShowClient;
-use vtysh::{CommandPath, ExecCode, ExecReply, ExecRequest, ExecType, ShowRequest};
+use vty::exec_client::ExecClient;
+use vty::show_client::ShowClient;
+use vty::{CommandPath, ExecCode, ExecReply, ExecRequest, ExecType, ShowRequest};
 
-pub mod vtysh {
-    tonic::include_proto!("vtysh");
+pub mod vty {
+    tonic::include_proto!("vty");
 }
 
 #[derive(Parser)]

--- a/zebra-rs/build.rs
+++ b/zebra-rs/build.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("../proto/vtysh.proto")?;
+    tonic_build::compile_protos("../proto/vty.proto")?;
 
     // Capture git information at build time
     set_git_info();

--- a/zebra-rs/src/config/api.rs
+++ b/zebra-rs/src/config/api.rs
@@ -1,4 +1,4 @@
-use super::vtysh::CommandPath;
+use super::vty::CommandPath;
 use super::{ApplyCode, Completion, ExecCode};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot::Sender;

--- a/zebra-rs/src/config/comps.rs
+++ b/zebra-rs/src/config/comps.rs
@@ -1,7 +1,7 @@
 use super::Config;
 use super::parse::State;
 use super::parse::{entry_is_key, ymatch_complete, ytype_from_typedef};
-use super::vtysh::YangMatch;
+use super::vty::YangMatch;
 use libyang::{Entry, TypeNode, YangType};
 use std::collections::HashSet;
 use std::rc::Rc;

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -3,7 +3,7 @@ use bgp_packet::{Afi, AfiSafi, Safi};
 use super::Completion;
 use super::parse::match_keyword;
 use super::parse::{Match, MatchType};
-use super::vtysh::{CommandPath, YangMatch};
+use super::vty::{CommandPath, YangMatch};
 
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use std::collections::{HashSet, VecDeque};
@@ -732,7 +732,7 @@ pub fn config_match(config: &Rc<Config>, input: &str, mx: &mut Match) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::vtysh::CommandPath;
+    use crate::config::vty::CommandPath;
 
     #[test]
     fn test_leaf_list_round_trip() {

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -12,7 +12,7 @@ use super::parse::State;
 use super::parse::parse;
 use super::paths::{path_try_trim, paths_str};
 use super::util::trim_first_line;
-use super::vtysh::CommandPath;
+use super::vty::CommandPath;
 use super::yaml::yaml_parse;
 use super::{ApplyCode, Completion, Config, ConfigRequest, DisplayRequest, ExecCode};
 

--- a/zebra-rs/src/config/mod.rs
+++ b/zebra-rs/src/config/mod.rs
@@ -1,8 +1,8 @@
-mod vtysh {
-    tonic::include_proto!("vtysh");
+mod vty {
+    tonic::include_proto!("vty");
 }
-pub use vtysh::ApplyCode;
-pub use vtysh::ExecCode;
+pub use vty::ApplyCode;
+pub use vty::ExecCode;
 
 mod manager;
 pub use manager::ConfigManager;

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -6,7 +6,7 @@ use super::ip::*;
 use super::mac::match_mac_addr;
 use super::nsap::match_nsap_addr;
 use super::util::*;
-use super::vtysh::{CommandPath, YangMatch};
+use super::vty::{CommandPath, YangMatch};
 use super::{Completion, Config, ExecCode};
 use libyang::{Entry, MinMax, RangeExtract, RangeNode, TypeNode, YangType, range_match};
 use regex::Regex;

--- a/zebra-rs/src/config/paths.rs
+++ b/zebra-rs/src/config/paths.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use super::Args;
 use super::configs::ymatch_enum;
-use super::vtysh::{CommandPath, YangMatch};
+use super::vty::{CommandPath, YangMatch};
 
 pub fn paths_str(paths: &[CommandPath]) -> String {
     let mut s = String::from("");

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -11,11 +11,11 @@ use super::api::{
     ClearTxRequest, CompletionRequest, CompletionResponse, DisplayRequest, DisplayTxRequest,
     ExecuteRequest, ExecuteResponse, Message,
 };
-use super::vtysh::apply_server::{Apply, ApplyServer};
-use super::vtysh::clear_server::{Clear, ClearServer};
-use super::vtysh::exec_server::{Exec, ExecServer};
-use super::vtysh::show_server::{Show, ShowServer};
-use super::vtysh::{
+use super::vty::apply_server::{Apply, ApplyServer};
+use super::vty::clear_server::{Clear, ClearServer};
+use super::vty::exec_server::{Exec, ExecServer};
+use super::vty::show_server::{Show, ShowServer};
+use super::vty::{
     ApplyReply, ApplyRequest, ClearReply, ClearRequest, CommandPath, ExecCode, ExecReply,
     ExecRequest, ExecType, ShowReply, ShowRequest, YangMatch,
 };


### PR DESCRIPTION
## Summary

The proto schema has long since outgrown its original "vtysh" name — it now drives every gRPC surface zebra-rs offers (Exec, Show, Apply, Clear, Config, Register, ExecModule). Rename the file and the proto package so the `include_proto!` / generated module name lines up with the rest of the `vty*` crate family.

Mechanical sweep:
- `proto/vtysh.proto` → `proto/vty.proto`, `package vtysh` → `package vty`
- 3 `build.rs` files: `compile_protos` path
- `vtyctl`, `vtyhelper`, `zebra-rs`: `include_proto!("vty")`, `mod vty`, every `vtysh::` use → `vty::`

The unrelated `vty/additions/vtysh.{c,h}` (the bash CLI extension, not the proto) is intentionally left alone.

## Test plan

- [x] `cargo build --workspace` — compiles
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

Generated with [Claude Code](https://claude.com/claude-code)