### PR TITLE
bgp, policy: propagate live policy / prefix-set edits to peers

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -36,6 +36,10 @@ bgp_route_map_match:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_route_map_match"
 
+bgp_policy_dynamic_update:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_policy_dynamic_update"
+
 generate:
 	rm -rf allure-report
 	allure generate
@@ -55,4 +59,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 bgp_evpn_capability bgp_route_map_match generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 bgp_evpn_capability bgp_route_map_match bgp_policy_dynamic_update generate open docs FORCE

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z1.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z1.yaml
@@ -1,0 +1,17 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4-unicast
+        enabled: true
+      enabled: true
+      peer-as: 65002
+    afi-safi:
+    - name: ipv4-unicast
+      network:
+      - prefix: 1.1.1.1/32
+      - prefix: 2.2.2.2/32

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-both.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-both.yaml
@@ -1,0 +1,26 @@
+prefix-set:
+- name: HOGE
+  prefixes:
+  - prefix: 1.1.1.1/32
+  - prefix: 2.2.2.2/32
+policy-options:
+  policy:
+  - name: HOGE
+    entry:
+    - number: 10
+      match:
+        prefix-set: HOGE
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4-unicast
+        enabled: true
+      apply-policy:
+        in: HOGE
+      enabled: true
+      peer-as: 65001

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-initial.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-initial.yaml
@@ -1,0 +1,25 @@
+prefix-set:
+- name: HOGE
+  prefixes:
+  - prefix: 1.1.1.1/32
+policy-options:
+  policy:
+  - name: HOGE
+    entry:
+    - number: 10
+      match:
+        prefix-set: HOGE
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4-unicast
+        enabled: true
+      apply-policy:
+        in: HOGE
+      enabled: true
+      peer-as: 65001

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-other.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-other.yaml
@@ -1,0 +1,25 @@
+prefix-set:
+- name: HOGE
+  prefixes:
+  - prefix: 2.2.2.2/32
+policy-options:
+  policy:
+  - name: HOGE
+    entry:
+    - number: 10
+      match:
+        prefix-set: HOGE
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4-unicast
+        enabled: true
+      apply-policy:
+        in: HOGE
+      enabled: true
+      peer-as: 65001

--- a/bdd/tests/features/bgp_policy_dynamic_update.feature
+++ b/bdd/tests/features/bgp_policy_dynamic_update.feature
@@ -1,0 +1,73 @@
+@serial
+@bgp_policy_dynamic_update
+Feature: BGP reacts to live prefix-set / policy edits without session reset
+  As a network operator
+  I want zebra-rs to re-evaluate Adj-RIB-In when a referenced prefix-set
+  or policy-list is edited, so that operational changes propagate
+  immediately without me having to clear the BGP session.
+
+  The exercise: z2 attaches `apply-policy in HOGE`, where policy HOGE
+  matches `prefix-set HOGE`. Because the prefix-set is referenced
+  *indirectly* via the policy's match clause, the harness must follow
+  the cascade prefix-set HOGE -> policy HOGE -> peer's Adj-RIB-In
+  every time the prefix-set is edited. Without the cascade, BGP would
+  only see the change after a manual `clear ... soft in`.
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                   │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+  ```
+
+  Config files:
+  - z1.yaml: AS 65001, advertises 1.1.1.1/32 + 2.2.2.2/32, no policy.
+  - z2-initial.yaml: prefix-set HOGE = { 1.1.1.1/32 }; policy HOGE matches
+    prefix-set HOGE; neighbor applies HOGE inbound; soft-reconfig in.
+  - z2-both.yaml: prefix-set HOGE = { 1.1.1.1/32, 2.2.2.2/32 } (added).
+  - z2-other.yaml: prefix-set HOGE = { 2.2.2.2/32 } (1.1.1.1/32 removed).
+
+  Scenario: Setup topology and verify initial filter
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2-initial.yaml" to namespace "z2"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP route in "z2" has "1.1.1.1/32"
+    And BGP route in "z2" does not have "2.2.2.2/32"
+
+  Scenario: Adding a prefix to the referenced prefix-set propagates without session reset
+    Given the test topology exists
+    When I apply config "z2-both.yaml" to namespace "z2"
+    And I wait 2 seconds for BGP to operate
+    Then BGP route in "z2" has "1.1.1.1/32"
+    And BGP route in "z2" has "2.2.2.2/32"
+
+  Scenario: Removing a prefix from the referenced prefix-set withdraws the corresponding route
+    Given the test topology exists
+    When I apply config "z2-other.yaml" to namespace "z2"
+    And I wait 2 seconds for BGP to operate
+    Then BGP route in "z2" has "2.2.2.2/32"
+    And BGP route in "z2" does not have "1.1.1.1/32"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -161,92 +161,141 @@ fn config_peer_as(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     Some(())
 }
 
+/// Drive `Register` / `Unregister` messages to Policy as a peer's
+/// attachment changes. `prior` is the name the peer was bound to
+/// before this call (or None on first attach), `new` is what it's
+/// being bound to now (or None on detach).
+///
+/// - prior == new: idempotent reapply, no-op.
+/// - prior present, new differs: Unregister(prior) + Register(new).
+/// - new only: Register(new) (first attach).
+/// - prior only: Unregister(prior) (detach).
+///
+/// Always-Unregister-before-Register avoids the watcher leak that
+/// previously occurred when the operator switched a peer from
+/// `apply-policy in hoge` to `apply-policy in fuga` — the "hoge"
+/// watcher would otherwise stay registered forever.
+fn policy_attach_msgs(
+    policy_tx: &tokio::sync::mpsc::UnboundedSender<policy::Message>,
+    ident: usize,
+    policy_type: policy::PolicyType,
+    prior: Option<String>,
+    new: Option<String>,
+) {
+    if prior == new {
+        return;
+    }
+    if let Some(prior_name) = prior {
+        let _ = policy_tx.send(policy::Message::Unregister {
+            proto: "bgp".to_string(),
+            name: prior_name,
+            ident,
+            policy_type,
+        });
+    }
+    if let Some(new_name) = new {
+        let _ = policy_tx.send(policy::Message::Register {
+            proto: "bgp".to_string(),
+            name: new_name,
+            ident,
+            policy_type,
+        });
+    }
+}
+
 fn config_policy_in(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
-    let peer = bgp.peers.get_mut(&addr)?;
-    let policy_name = args.string()?;
-    if op.is_set() {
-        let config = peer.policy_list.get_mut(&InOut::Input);
-        config.name = Some(policy_name.clone());
-
-        let msg = policy::Message::Register {
-            proto: "bgp".to_string(),
-            name: policy_name,
-            ident: peer.ident,
-            policy_type: policy::PolicyType::PolicyListIn,
-        };
-        let _ = bgp.policy_tx.send(msg);
+    let new_name = if op.is_set() {
+        Some(args.string()?)
     } else {
-        let config = peer.policy_list.get_mut(&InOut::Input);
-        config.name = None;
-    }
+        None
+    };
+    let peer = bgp.peers.get_mut(&addr)?;
+    let peer_ident = peer.ident;
+    let config = peer.policy_list.get_mut(&InOut::Input);
+    let prior = match &new_name {
+        Some(n) => config.name.replace(n.clone()),
+        None => config.name.take(),
+    };
+    policy_attach_msgs(
+        &bgp.policy_tx,
+        peer_ident,
+        policy::PolicyType::PolicyListIn,
+        prior,
+        new_name,
+    );
     Some(())
 }
 
 fn config_policy_out(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
-    let peer = bgp.peers.get_mut(&addr)?;
-    let policy_name = args.string()?;
-    if op.is_set() {
-        let config = peer.policy_list.get_mut(&InOut::Output);
-        config.name = Some(policy_name.clone());
-
-        let msg = policy::Message::Register {
-            proto: "bgp".to_string(),
-            name: policy_name,
-            ident: peer.ident,
-            policy_type: policy::PolicyType::PolicyListOut,
-        };
-        // tracing::info!("{:?}", msg);
-        let _ = bgp.policy_tx.send(msg);
+    let new_name = if op.is_set() {
+        Some(args.string()?)
     } else {
-        let config = peer.policy_list.get_mut(&InOut::Output);
-        config.name = None;
-    }
+        None
+    };
+    let peer = bgp.peers.get_mut(&addr)?;
+    let peer_ident = peer.ident;
+    let config = peer.policy_list.get_mut(&InOut::Output);
+    let prior = match &new_name {
+        Some(n) => config.name.replace(n.clone()),
+        None => config.name.take(),
+    };
+    policy_attach_msgs(
+        &bgp.policy_tx,
+        peer_ident,
+        policy::PolicyType::PolicyListOut,
+        prior,
+        new_name,
+    );
     Some(())
 }
 
 fn config_prefix_in(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
-    let peer = bgp.peers.get_mut(&addr)?;
-    let policy = args.string()?;
-    if op.is_set() {
-        let config = peer.prefix_set.get_mut(&InOut::Input);
-        config.name = Some(policy.clone());
-
-        let msg = policy::Message::Register {
-            proto: "bgp".to_string(),
-            name: policy,
-            ident: peer.ident,
-            policy_type: policy::PolicyType::PrefixSetIn,
-        };
-        let _ = bgp.policy_tx.send(msg);
+    let new_name = if op.is_set() {
+        Some(args.string()?)
     } else {
-        let config = peer.prefix_set.get_mut(&InOut::Input);
-        config.name = None;
-    }
+        None
+    };
+    let peer = bgp.peers.get_mut(&addr)?;
+    let peer_ident = peer.ident;
+    let config = peer.prefix_set.get_mut(&InOut::Input);
+    let prior = match &new_name {
+        Some(n) => config.name.replace(n.clone()),
+        None => config.name.take(),
+    };
+    policy_attach_msgs(
+        &bgp.policy_tx,
+        peer_ident,
+        policy::PolicyType::PrefixSetIn,
+        prior,
+        new_name,
+    );
     Some(())
 }
 
 fn config_prefix_out(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
-    let peer = bgp.peers.get_mut(&addr)?;
-    let policy = args.string()?;
-    if op.is_set() {
-        let config = peer.prefix_set.get_mut(&InOut::Output);
-        config.name = Some(policy.clone());
-
-        let msg = policy::Message::Register {
-            proto: "bgp".to_string(),
-            name: policy,
-            ident: peer.ident,
-            policy_type: policy::PolicyType::PrefixSetOut,
-        };
-        let _ = bgp.policy_tx.send(msg);
+    let new_name = if op.is_set() {
+        Some(args.string()?)
     } else {
-        let config = peer.prefix_set.get_mut(&InOut::Output);
-        config.name = None;
-    }
+        None
+    };
+    let peer = bgp.peers.get_mut(&addr)?;
+    let peer_ident = peer.ident;
+    let config = peer.prefix_set.get_mut(&InOut::Output);
+    let prior = match &new_name {
+        Some(n) => config.name.replace(n.clone()),
+        None => config.name.take(),
+    };
+    policy_attach_msgs(
+        &bgp.policy_tx,
+        peer_ident,
+        policy::PolicyType::PrefixSetOut,
+        prior,
+        new_name,
+    );
     Some(())
 }
 

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -538,6 +538,12 @@ impl Bgp {
     }
 
     pub async fn process_policy_msg(&mut self, msg: policy::PolicyRx) {
+        // Two responsibilities per message: refresh the per-peer policy
+        // snapshot, then trigger a soft-reconfiguration so already-
+        // received Adj-RIB-In or already-advertised Loc-RIB entries
+        // get re-evaluated against the new policy. Without the second
+        // step a prefix-set / policy-list edit only affects routes
+        // that arrive *after* the edit.
         match msg {
             policy::PolicyRx::PrefixSet {
                 name: _,
@@ -548,12 +554,17 @@ impl Bgp {
                 let Some(peer) = self.peers.get_mut_by_idx(ident) else {
                     return;
                 };
-                if policy_type == policy::PolicyType::PrefixSetIn {
-                    let config = peer.prefix_set.get_mut(&InOut::Input);
-                    config.prefix_set = prefix_set;
-                } else if policy_type == policy::PolicyType::PrefixSetOut {
-                    let config = peer.prefix_set.get_mut(&InOut::Output);
-                    config.prefix_set = prefix_set;
+                let direction = match policy_type {
+                    policy::PolicyType::PrefixSetIn => InOut::Input,
+                    policy::PolicyType::PrefixSetOut => InOut::Output,
+                    _ => return,
+                };
+                let config = peer.prefix_set.get_mut(&direction);
+                config.prefix_set = prefix_set;
+
+                match direction {
+                    InOut::Input => super::peer::apply_soft_in_peer(self, ident),
+                    InOut::Output => super::peer::apply_soft_out_peer(self, ident),
                 }
             }
             policy::PolicyRx::PolicyList {
@@ -565,18 +576,17 @@ impl Bgp {
                 let Some(peer) = self.peers.get_mut_by_idx(ident) else {
                     return;
                 };
-                match policy_type {
-                    policy::PolicyType::PolicyListIn => {
-                        let config = peer.policy_list.get_mut(&InOut::Input);
-                        config.policy_list = policy_list;
-                    }
-                    policy::PolicyType::PolicyListOut => {
-                        let config = peer.policy_list.get_mut(&InOut::Output);
-                        config.policy_list = policy_list;
-                    }
-                    _ => {
-                        //
-                    }
+                let direction = match policy_type {
+                    policy::PolicyType::PolicyListIn => InOut::Input,
+                    policy::PolicyType::PolicyListOut => InOut::Output,
+                    _ => return,
+                };
+                let config = peer.policy_list.get_mut(&direction);
+                config.policy_list = policy_list;
+
+                match direction {
+                    InOut::Input => super::peer::apply_soft_in_peer(self, ident),
+                    InOut::Output => super::peer::apply_soft_out_peer(self, ident),
                 }
             }
         }

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1116,6 +1116,71 @@ pub fn clear(bgp: &Bgp, args: &mut Args) -> std::result::Result<String, std::fmt
     }
 }
 
+/// Replay Adj-RIB-In through the current inbound policy for `peer_idx`,
+/// without bouncing the session. If the peer has `soft-reconfiguration
+/// inbound` configured we replay locally from the stored Adj-RIB-In.
+/// Otherwise we fall back to RFC 2918 Route Refresh provided the peer
+/// advertised the capability. With neither, the call is a silent no-op
+/// — the peer will only converge on its next update.
+///
+/// Used by both the CLI (`clear_soft_in`) and the policy-update path
+/// in `process_policy_msg`. The CLI variant additionally formats a
+/// human-readable status string; this helper performs the side
+/// effects only.
+pub fn apply_soft_in_peer(bgp: &mut Bgp, peer_idx: usize) {
+    let Some(peer) = bgp.peers.get_by_idx(peer_idx) else {
+        return;
+    };
+    if !peer.state.is_established() {
+        return;
+    }
+    let soft_in = peer.config.soft_reconfig_in;
+    let supports_refresh = peer.cap_recv.refresh.is_some();
+    let mp_pairs: Vec<(u16, u8)> = peer
+        .cap_recv
+        .mp
+        .keys()
+        .map(|af| (u16::from(af.afi), u8::from(af.safi)))
+        .collect();
+
+    if soft_in {
+        let mut bgp_ref = BgpTop {
+            router_id: &bgp.router_id,
+            local_rib: &mut bgp.local_rib,
+            tx: &bgp.tx,
+            rib_tx: &bgp.rib_tx,
+            attr_store: &mut bgp.attr_store,
+        };
+        super::route::route_soft_in_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
+    } else if supports_refresh {
+        let peer = bgp.peers.get_mut_by_idx(peer_idx).expect("peer exists");
+        for (afi, safi) in &mp_pairs {
+            peer_send_route_refresh(peer, *afi, *safi);
+        }
+    }
+}
+
+/// Replay Loc-RIB through the current outbound policy for `peer_idx`,
+/// without bouncing the session. Always works when the peer is
+/// Established — no peer cooperation needed because we drive the
+/// re-advertisement from our local RIB.
+pub fn apply_soft_out_peer(bgp: &mut Bgp, peer_idx: usize) {
+    let Some(peer) = bgp.peers.get_by_idx(peer_idx) else {
+        return;
+    };
+    if !peer.state.is_established() {
+        return;
+    }
+    let mut bgp_ref = BgpTop {
+        router_id: &bgp.router_id,
+        local_rib: &mut bgp.local_rib,
+        tx: &bgp.tx,
+        rib_tx: &bgp.rib_tx,
+        attr_store: &mut bgp.attr_store,
+    };
+    super::route::route_soft_out_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
+}
+
 // Soft-clear outbound: re-apply outbound policy and refresh
 // Adj-RIB-Out for this peer without bouncing the session. Returns
 // immediately if the peer isn't established (nothing to refresh).

--- a/zebra-rs/src/policy/inst.rs
+++ b/zebra-rs/src/policy/inst.rs
@@ -9,6 +9,7 @@ use crate::config::{
 
 use super::{
     AsPathSetConfig, CommunitySetConfig, PolicyConfig, PolicyList, PrefixSet, PrefixSetConfig,
+    policy_entry_sync,
 };
 
 pub type ShowCallback = fn(&Policy, Args, bool) -> Result<String, Error>;
@@ -28,6 +29,17 @@ pub enum Message {
         tx: UnboundedSender<PolicyRx>,
     },
     Register {
+        proto: String,
+        name: String,
+        ident: usize,
+        policy_type: PolicyType,
+    },
+    /// Counterpart of `Register`. Sent by a protocol when a peer
+    /// detaches a policy (operator runs `delete apply-policy in X`,
+    /// or rebinds to a different name). Without this the watcher
+    /// list grows unbounded as peers churn or rename their policy
+    /// references.
+    Unregister {
         proto: String,
         name: String,
         ident: usize,
@@ -240,6 +252,25 @@ impl Policy {
                     }
                 }
             }
+            Message::Unregister {
+                proto,
+                name,
+                ident,
+                policy_type,
+            } => {
+                let map = match policy_type {
+                    PolicyType::PrefixSetIn | PolicyType::PrefixSetOut => &mut self.watch_prefix,
+                    PolicyType::PolicyListIn | PolicyType::PolicyListOut => &mut self.watch_policy,
+                };
+                if let Some(watches) = map.get_mut(&name) {
+                    watches.retain(|w| {
+                        !(w.proto == proto && w.ident == ident && w.policy_type == policy_type)
+                    });
+                    if watches.is_empty() {
+                        map.remove(&name);
+                    }
+                }
+            }
         }
     }
 
@@ -258,6 +289,22 @@ impl Policy {
                 }
             }
             ConfigOp::CommitEnd => {
+                // Capture which names are about to be touched directly,
+                // before any of the per-set commits drain their caches.
+                // Used after the direct syncs to find policies that
+                // reference these sets indirectly (via `match prefix-set
+                // X` etc.) and re-fire their watchers — without this
+                // step, BGP peers attached to such policies wouldn't
+                // see updates that flow through indirection.
+                let changed_prefix_sets: std::collections::BTreeSet<String> =
+                    self.prefix_config.cache.keys().cloned().collect();
+                let changed_community_sets: std::collections::BTreeSet<String> =
+                    self.community_config.cache.keys().cloned().collect();
+                let changed_as_path_sets: std::collections::BTreeSet<String> =
+                    self.as_path_config.cache.keys().cloned().collect();
+                let changed_policies: std::collections::BTreeSet<String> =
+                    self.policy_config.cache.keys().cloned().collect();
+
                 // Sync prefix-set.
                 let syncer = PolicySyncer {
                     watch_map: &self.watch_prefix,
@@ -286,6 +333,24 @@ impl Policy {
                     &self.as_path_config,
                     syncer,
                 );
+
+                // Cascade: a policy that wasn't itself edited may still
+                // be stale if any of the prefix/community/as-path sets
+                // it references were updated. Re-resolve those policies
+                // against the freshly-committed sets and notify their
+                // watchers so attached peers re-evaluate Adj-RIB-In.
+                cascade_indirect_policy_updates(
+                    &mut self.policy_config.config,
+                    &self.prefix_config,
+                    &self.community_config,
+                    &self.as_path_config,
+                    &self.watch_policy,
+                    &self.clients,
+                    &changed_prefix_sets,
+                    &changed_community_sets,
+                    &changed_as_path_sets,
+                    &changed_policies,
+                );
             }
             _ => {}
         }
@@ -313,6 +378,76 @@ impl Policy {
                 }
                 Some(msg) = self.show.rx.recv() => {
                     self.process_show_msg(msg).await;
+                }
+            }
+        }
+    }
+}
+
+/// Re-resolve and re-fire policies that *indirectly* reference any
+/// of the changed sets, skipping policies that were already directly
+/// committed in this same batch. This is what makes
+///
+///     set policy-options prefix-set hoge prefixes 2.2.2.2/32
+///
+/// reach a peer attached via `apply-policy in <policy that
+/// matches prefix-set hoge>` — the prefix-set edit alone wouldn't
+/// fire `policy_list_update` for that policy without this cascade.
+#[allow(clippy::too_many_arguments)]
+fn cascade_indirect_policy_updates(
+    policy_config: &mut BTreeMap<String, PolicyList>,
+    prefix_config: &PrefixSetConfig,
+    community_config: &CommunitySetConfig,
+    as_path_config: &AsPathSetConfig,
+    watch_policy: &BTreeMap<String, Vec<PolicyWatch>>,
+    clients: &BTreeMap<String, UnboundedSender<PolicyRx>>,
+    changed_prefix_sets: &std::collections::BTreeSet<String>,
+    changed_community_sets: &std::collections::BTreeSet<String>,
+    changed_as_path_sets: &std::collections::BTreeSet<String>,
+    changed_policies: &std::collections::BTreeSet<String>,
+) {
+    if changed_prefix_sets.is_empty()
+        && changed_community_sets.is_empty()
+        && changed_as_path_sets.is_empty()
+    {
+        return;
+    }
+    for (name, policy_list) in policy_config.iter_mut() {
+        // Already fired by PolicyConfig::commit; the cache version
+        // already saw the updated sets via `policy_entry_sync`.
+        if changed_policies.contains(name) {
+            continue;
+        }
+        let needs_resync = policy_list.entry.values().any(|e| {
+            e.prefix_set_name
+                .as_ref()
+                .is_some_and(|n| changed_prefix_sets.contains(n))
+                || e.next_hop_set_name
+                    .as_ref()
+                    .is_some_and(|n| changed_prefix_sets.contains(n))
+                || e.community_set_name
+                    .as_ref()
+                    .is_some_and(|n| changed_community_sets.contains(n))
+                || e.set_community_name
+                    .as_ref()
+                    .is_some_and(|n| changed_community_sets.contains(n))
+                || e.as_path_set_name
+                    .as_ref()
+                    .is_some_and(|n| changed_as_path_sets.contains(n))
+        });
+        if !needs_resync {
+            continue;
+        }
+        policy_entry_sync(policy_list, prefix_config, community_config, as_path_config);
+        if let Some(watches) = watch_policy.get(name) {
+            for watch in watches {
+                if let Some(tx) = clients.get(&watch.proto) {
+                    let _ = tx.send(PolicyRx::PolicyList {
+                        name: name.clone(),
+                        ident: watch.ident,
+                        policy_type: watch.policy_type,
+                        policy_list: Some(policy_list.clone()),
+                    });
                 }
             }
         }


### PR DESCRIPTION
## Summary

A policy or prefix-set edit didn't reach attached BGP peers without a manual `clear ... soft in` because three pieces were missing:

1. **Direct trigger** — `bgp/inst.rs::process_policy_msg` updated the per-peer policy snapshot but never re-evaluated Adj-RIB-In / Loc-RIB. Now it dispatches `apply_soft_in_peer` (In) or `apply_soft_out_peer` (Out) right after the snapshot lands. The new helpers in `bgp/peer.rs` share `clear_soft_in/out`'s logic: replay locally if `soft-reconfiguration inbound` is configured, otherwise fall back to RFC 2918 Route Refresh, otherwise no-op.

2. **Watcher cleanup** — `Policy` accumulated a `PolicyWatch` per `apply-policy` attach but never removed one on detach or rebind. New `policy::Message::Unregister` variant; `bgp/config.rs` routes the four attach paths through a `policy_attach_msgs` helper that captures the prior name with `Option::replace` / `take` and emits Unregister(prior) + Register(new) as a pair (no-op when prior == new for idempotent reapplies).

3. **Indirect cascade** — A change to `prefix-set hoge` only fired *prefix-set* watchers, not the `policy hoge { match prefix-set hoge }` policies that reference it indirectly. New `cascade_indirect_policy_updates` in `policy/inst.rs` walks committed policies after every commit, finds those that reference any changed prefix-set / community-set / as-path-set, re-resolves their entries via `policy_entry_sync`, and re-fires `policy_list_update`. Skips policies that `PolicyConfig::commit` just touched directly to avoid double-firing.

Eval semantics in `route_apply_policy_in` already distinguish `name.is_some() && policy_list.is_none()` (deny all) from `name.is_none()` (allow all), so the deletion case lands correctly when Policy notifies with `policy_list: None`.

## Test plan

- [x] `cargo build --workspace` — compiles
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [ ] `make -C bdd bgp_policy_dynamic_update` — exercises the user's exact scenario (prefix-set { 1.1.1.1/32 } -> { 1.1.1.1/32, 2.2.2.2/32 } -> { 2.2.2.2/32 }) without a session reset. Could not validate locally because BGP session establishment is currently failing for *all* BDD tests on this host (pristine main also fails); please run on a clean host.

Generated with [Claude Code](https://claude.com/claude-code)