### PR TITLE
isis: fold show isis adjacency into show isis interface

### DIFF
--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -425,7 +425,7 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
         // pseudonode adjacency, so transitioning now would leave us in
         // Other-with-adj=None — CSNPs would be dropped (packet.rs
         // csnp_recv guards on adj.is_some()), the self LSP would miss
-        // its pseudonode reach entry, and `show isis adjacency` would
+        // its pseudonode reach entry, and `show isis interface` would
         // report an inconsistent DIS without a binding. Election
         // outcome is recorded (`nbr.is_dis = true`); the late-LAN-ID
         // path in hello_recv re-fires DisSelection once lan_id arrives,

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -16,7 +16,7 @@ use crate::config::{Args, ConfigOp};
 use crate::context::Timer;
 use crate::isis_event_trace;
 use crate::rib::link::LinkAddr;
-use crate::rib::{Link, MacAddr};
+use crate::rib::{Link, LinkFlagsExt, MacAddr};
 
 use super::config::{IsisConfig, MtId};
 use super::ifsm::{self, has_level};
@@ -887,6 +887,49 @@ struct LinkInfo {
     is_up: bool,
     link_type: String,
     level: String,
+    dis: String,
+    adjacency: String,
+}
+
+// Pick the level whose DIS / adjacency state is displayed in the
+// summary view. Mirrors the prior behaviour (L2 only when the circuit
+// is L2-only; otherwise L1) so single-level operators see the level
+// they actually run, and L1L2 collapses to the more-common L1 view —
+// `show isis interface detail` is the place to see both levels.
+fn summary_level(link: &IsisLink) -> Level {
+    if link.state.level() == IsLevel::L2 {
+        Level::L2
+    } else {
+        Level::L1
+    }
+}
+
+// DIS column. Loopback gets N/A regardless of the configured
+// link-type because the kernel device can't carry an adjacency.
+// Non-LAN circuits also show N/A — DIS election only runs on LAN.
+fn dis_column(link: &IsisLink, level: Level) -> &'static str {
+    if link.flags.is_loopback() {
+        return "N/A";
+    }
+    if link.config.link_type() != LinkType::Lan {
+        return "N/A";
+    }
+    match link.state.dis_status.get(&level) {
+        DisStatus::Myself => "DIS",
+        DisStatus::Other => "Other",
+        DisStatus::NotSelected => "Selecting",
+    }
+}
+
+// Adjacency column: the LAN ID (sys-id + circuit-id) once the
+// pseudonode LSP has confirmed our adjacency. `link.state.adj` is
+// cleared on link-down and on DIS reset, so "Down" here means we
+// have no usable adjacency for this level.
+fn adjacency_column(link: &IsisLink, level: Level) -> String {
+    match link.state.adj.get(&level) {
+        Some((adj, _)) => format!("Up {}", adj),
+        None => "Down".to_string(),
+    }
 }
 
 pub fn show(isis: &Isis, _args: Args, json: bool) -> std::result::Result<String, std::fmt::Error> {
@@ -894,49 +937,44 @@ pub fn show(isis: &Isis, _args: Args, json: bool) -> std::result::Result<String,
         let mut links = Vec::new();
         for (_ifindex, link) in isis.links.iter() {
             if link.config.enabled() {
+                let level = summary_level(link);
                 links.push(LinkInfo {
                     name: link.state.name.clone(),
                     ifindex: link.ifindex,
                     is_up: link.state.is_up(),
                     link_type: link.config.link_type().to_string(),
                     level: link.state.level.to_string(),
+                    dis: dis_column(link, level).to_string(),
+                    adjacency: adjacency_column(link, level),
                 });
             }
         }
         return Ok(serde_json::to_string_pretty(&links).unwrap());
     }
-    let mut buf = String::from("  Interface   CircId   State    Type     Level\n");
+    let mut buf = String::new();
+    writeln!(
+        buf,
+        "  {:<11} {:<8} {:<8} {:<8} {:<5} {:<9} Adjacency",
+        "Interface", "CircId", "State", "Type", "Level", "DIS",
+    )?;
     for (_ifindex, link) in isis.links.iter() {
-        if link.config.enabled() {
-            let mut dis_status = if link.state.level == IsLevel::L2 {
-                match link.state.dis_status.get(&Level::L2) {
-                    DisStatus::NotSelected => "no DIS is selected",
-                    DisStatus::Other => "is not DIS",
-                    DisStatus::Myself => "is DIS",
-                }
-            } else {
-                match link.state.dis_status.get(&Level::L1) {
-                    DisStatus::NotSelected => "no DIS is selected",
-                    DisStatus::Other => "is not DIS",
-                    DisStatus::Myself => "is DIS",
-                }
-            };
-            if link.config.link_type() != LinkType::Lan {
-                dis_status = "";
-            }
-            let link_state = if link.state.is_up() { "Up" } else { "Down" };
-            writeln!(
-                buf,
-                "  {:<11} 0x{:02X}     {:<8} {:<8} {} {}",
-                link.state.name,
-                link.ifindex,
-                link_state,
-                link.config.link_type().to_string(),
-                link.state.level,
-                dis_status,
-            )
-            .unwrap();
+        if !link.config.enabled() {
+            continue;
         }
+        let level = summary_level(link);
+        let link_state = if link.state.is_up() { "Up" } else { "Down" };
+        let circ_id = format!("0x{:02X}", link.ifindex);
+        writeln!(
+            buf,
+            "  {:<11} {:<8} {:<8} {:<8} {:<5} {:<9} {}",
+            link.state.name,
+            circ_id,
+            link_state,
+            link.config.link_type().to_string(),
+            link.state.level.to_string(),
+            dis_column(link, level),
+            adjacency_column(link, level),
+        )?;
     }
     Ok(buf)
 }

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -27,7 +27,6 @@ impl Isis {
         self.show_add("/show/isis/dis/history", link::show_dis_history);
         self.show_add("/show/isis/neighbor", neigh::show);
         self.show_add("/show/isis/neighbor/detail", neigh::show_detail);
-        self.show_add("/show/isis/adjacency", show_isis_adjacency);
         self.show_add("/show/isis/database", show_isis_database);
         self.show_add("/show/isis/database/detail", show_isis_database_detail);
         self.show_add("/show/isis/hostname", hostname::show);
@@ -1169,25 +1168,6 @@ fn show_isis_database_detail(
 
         Ok(result)
     }
-}
-
-fn show_isis_adjacency(
-    top: &Isis,
-    _args: Args,
-    _json: bool,
-) -> std::result::Result<String, std::fmt::Error> {
-    let mut buf = String::new();
-
-    for (_, link) in top.links.iter() {
-        writeln!(buf, "Interface: {}", top.ifname(link.ifindex))?;
-        if let Some((adj, _)) = &link.state.adj.get(&Level::L1) {
-            writeln!(buf, "  L1 Adj: {}", adj)?;
-        }
-        if let Some((adj, _)) = &link.state.adj.get(&Level::L2) {
-            writeln!(buf, "  L2 Adj: {}", adj).unwrap();
-        }
-    }
-    Ok(buf)
 }
 
 fn show_isis_spf(

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -225,14 +225,6 @@ module exec {
         ext:help "IS-IS SPF tree (per-AFI today; per-MT once multi-topology lands)";
         type empty;
       }
-      container adjacency {
-        ext:help "IS-IS adjacency";
-        presence "IS-IS adjacency";
-        leaf detail {
-          ext:help "IS-IS adjacency detail";
-          type empty;
-        }
-      }
       container neighbor {
         ext:help "IS-IS neighbor";
         presence "IS-IS neighbor";


### PR DESCRIPTION
## Summary
- `show isis interface` now carries DIS and Adjacency columns. DIS shows `DIS` / `Other` / `Selecting` on LAN, `N/A` on loopback (kernel `IFF_LOOPBACK`) and on non-LAN circuits where DIS election does not apply.
- Adjacency renders `Up <lan-id>` once the pseudonode LSP has confirmed our binding (`link.state.adj` is set), `Down` otherwise — the same data the old `show isis adjacency` was sourcing.
- Drops the standalone `show isis adjacency` YANG container, registration, and handler. The JSON output of `show isis interface` gains `dis` and `adjacency` fields for parity.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo build --bin zebra-rs --release`
- [x] `cargo clippy --bin zebra-rs --release -- -D warnings`
- [x] `cargo test --release --workspace --exclude zebra-rs-bdd`
- [ ] Manual: bring up a LAN adjacency and confirm `show isis interface` shows `DIS` / `Other` / `Selecting` and the LAN-ID in Adjacency; on `lo` confirm `N/A` / `Down`.

Generated with [Claude Code](https://claude.com/claude-code)