### PR TITLE
bgp: rename afi-safi identities and drop unused AFs

### DIFF
--- a/bdd/docs/bgp_evpn_capability.md
+++ b/bdd/docs/bgp_evpn_capability.md
@@ -24,8 +24,8 @@ Multicast) lands in follow-up features.
 
 ## Config Files
 
-- z1-1.yaml: AS 65001, peer to 192.168.0.2, l2vpn-evpn enabled
-- z2-1.yaml: AS 65001, peer to 192.168.0.1, l2vpn-evpn enabled
+- z1-1.yaml: AS 65001, peer to 192.168.0.2, evpn enabled
+- z2-1.yaml: AS 65001, peer to 192.168.0.1, evpn enabled
 
 ## Test Scenarios
 

--- a/bdd/docs/bgp_gobgpd_etcd.md
+++ b/bdd/docs/bgp_gobgpd_etcd.md
@@ -36,7 +36,7 @@ Using a test topology with one zebra-rs RR, etcd, and 29 gobgpd RR clients
 ## Config Files
 
 - rr.yaml: AS 64512, zebra-rs RR with cluster-id 198.18.39.94, peers to all gobgpd clients
-- gobgpd clients configured as RR clients with l3vpn-ipv4-unicast AFI/SAFI
+- gobgpd clients configured as RR clients with vpnv4 AFI/SAFI
 - etcd: Key-value store backend for zebra-rs configuration
 
 ## Test Scenarios

--- a/bdd/docs/bgp_gobgpd_rr.md
+++ b/bdd/docs/bgp_gobgpd_rr.md
@@ -36,7 +36,7 @@ Using a test topology with one zebra-rs RR and 29 gobgpd RR clients
 ## Config Files
 
 - rr.yaml: AS 64512, zebra-rs RR with cluster-id 198.18.39.94, peers to all gobgpd clients
-- gobgpd clients configured as RR clients with l3vpn-ipv4-unicast AFI/SAFI
+- gobgpd clients configured as RR clients with vpnv4 AFI/SAFI
 
 ## Test Scenarios
 

--- a/bdd/tests/configs/bgp_basic_ebgp/z1-1.yaml
+++ b/bdd/tests/configs/bgp_basic_ebgp/z1-1.yaml
@@ -6,7 +6,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       enabled: true
       peer-as: 65002

--- a/bdd/tests/configs/bgp_basic_ebgp/z1-3.yaml
+++ b/bdd/tests/configs/bgp_basic_ebgp/z1-3.yaml
@@ -6,11 +6,11 @@ router:
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       enabled: true
       peer-as: 65002
     afi-safi:
-    - name: ipv4-unicast
+    - name: ipv4
       network:
       - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_basic_ebgp/z1-4.yaml
+++ b/bdd/tests/configs/bgp_basic_ebgp/z1-4.yaml
@@ -6,12 +6,12 @@ router:
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       enabled: true
       peer-as: 65002
     afi-safi:
-    - name: ipv4-unicast
+    - name: ipv4
       network:
       - prefix: 10.0.0.1/32
       - prefix: 10.0.0.2/32

--- a/bdd/tests/configs/bgp_basic_ebgp/z1-5.yaml
+++ b/bdd/tests/configs/bgp_basic_ebgp/z1-5.yaml
@@ -17,14 +17,14 @@ router:
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       apply-policy:
         out: out-test
       enabled: true
       peer-as: 65002
     afi-safi:
-    - name: ipv4-unicast
+    - name: ipv4
       network:
       - prefix: 10.0.0.1/32
       - prefix: 10.0.0.2/32

--- a/bdd/tests/configs/bgp_basic_ebgp/z2-1.yaml
+++ b/bdd/tests/configs/bgp_basic_ebgp/z2-1.yaml
@@ -6,7 +6,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_basic_ibgp/z1-1.yaml
+++ b/bdd/tests/configs/bgp_basic_ibgp/z1-1.yaml
@@ -6,7 +6,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_basic_ibgp/z1-3.yaml
+++ b/bdd/tests/configs/bgp_basic_ibgp/z1-3.yaml
@@ -6,11 +6,11 @@ router:
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       enabled: true
       peer-as: 65001
     afi-safi:
-    - name: ipv4-unicast
+    - name: ipv4
       network:
       - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_basic_ibgp/z1-4.yaml
+++ b/bdd/tests/configs/bgp_basic_ibgp/z1-4.yaml
@@ -6,12 +6,12 @@ router:
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       enabled: true
       peer-as: 65001
     afi-safi:
-    - name: ipv4-unicast
+    - name: ipv4
       network:
       - prefix: 10.0.0.1/32
       - prefix: 10.0.0.2/32

--- a/bdd/tests/configs/bgp_basic_ibgp/z1-5.yaml
+++ b/bdd/tests/configs/bgp_basic_ibgp/z1-5.yaml
@@ -17,14 +17,14 @@ router:
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       apply-policy:
         out: out-test
       enabled: true
       peer-as: 65001
     afi-safi:
-    - name: ipv4-unicast
+    - name: ipv4
       network:
       - prefix: 10.0.0.1/32
       - prefix: 10.0.0.2/32

--- a/bdd/tests/configs/bgp_basic_ibgp/z2-1.yaml
+++ b/bdd/tests/configs/bgp_basic_ibgp/z2-1.yaml
@@ -6,7 +6,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_evpn_capability/z1-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_capability/z1-1.yaml
@@ -8,7 +8,7 @@ router:
       enabled: true
       peer-as: 65001
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
-      - name: l2vpn-evpn
+      - name: evpn
         enabled: true

--- a/bdd/tests/configs/bgp_evpn_capability/z2-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_capability/z2-1.yaml
@@ -8,7 +8,7 @@ router:
       enabled: true
       peer-as: 65001
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
-      - name: l2vpn-evpn
+      - name: evpn
         enabled: true

--- a/bdd/tests/configs/bgp_gobgpd_rr/rr1.yaml
+++ b/bdd/tests/configs/bgp_gobgpd_rr/rr1.yaml
@@ -68,7 +68,7 @@ router:
     neighbor:
     - remote-address: 198.18.37.17
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -90,7 +90,7 @@ router:
       rtc: true
     - remote-address: 198.18.37.30
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -112,7 +112,7 @@ router:
       rtc: true
     - remote-address: 198.18.37.81
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -134,7 +134,7 @@ router:
       rtc: true
     - remote-address: 198.18.37.82
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -156,7 +156,7 @@ router:
       rtc: true
     - remote-address: 198.18.37.83
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -178,7 +178,7 @@ router:
       rtc: true
     - remote-address: 198.18.37.88
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -200,7 +200,7 @@ router:
       rtc: true
     - remote-address: 198.18.37.89
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -222,7 +222,7 @@ router:
       rtc: true
     - remote-address: 198.18.37.90
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -244,7 +244,7 @@ router:
       rtc: true
     - remote-address: 198.18.37.91
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -266,7 +266,7 @@ router:
       rtc: true
     - remote-address: 198.18.37.92
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -288,7 +288,7 @@ router:
       rtc: true
     - remote-address: 198.18.37.93
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -310,7 +310,7 @@ router:
       rtc: true
     - remote-address: 198.18.37.94
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -332,7 +332,7 @@ router:
       rtc: true
     - remote-address: 198.18.39.97
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -354,7 +354,7 @@ router:
       rtc: true
     - remote-address: 198.18.39.110
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -376,7 +376,7 @@ router:
       rtc: true
     - remote-address: 198.18.39.129
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -398,7 +398,7 @@ router:
       rtc: true
     - remote-address: 198.18.39.130
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -420,7 +420,7 @@ router:
       rtc: true
     - remote-address: 198.18.39.131
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -442,7 +442,7 @@ router:
       rtc: true
     - remote-address: 198.18.39.136
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -464,7 +464,7 @@ router:
       rtc: true
     - remote-address: 198.18.39.137
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -486,7 +486,7 @@ router:
       rtc: true
     - remote-address: 198.18.39.138
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -508,7 +508,7 @@ router:
       rtc: true
     - remote-address: 198.18.39.139
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -530,7 +530,7 @@ router:
       rtc: true
     - remote-address: 198.18.39.140
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -552,7 +552,7 @@ router:
       rtc: true
     - remote-address: 198.18.39.141
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -574,7 +574,7 @@ router:
       rtc: true
     - remote-address: 198.18.39.142
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -596,7 +596,7 @@ router:
       rtc: true
     - remote-address: 198.18.39.145
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:
@@ -618,7 +618,7 @@ router:
       rtc: true
     - remote-address: 198.18.39.158
       afi-safi:
-      - name: l3vpn-ipv4-unicast
+      - name: vpnv4
         enabled: true
         add-path: send
         graceful-restart:

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z1.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z1.yaml
@@ -6,12 +6,12 @@ router:
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       enabled: true
       peer-as: 65002
     afi-safi:
-    - name: ipv4-unicast
+    - name: ipv4
       network:
       - prefix: 1.1.1.1/32
       - prefix: 2.2.2.2/32

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-both.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-both.yaml
@@ -18,7 +18,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       apply-policy:
         in: HOGE

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-initial.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-initial.yaml
@@ -17,7 +17,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       apply-policy:
         in: HOGE

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-other.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-other.yaml
@@ -17,7 +17,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       apply-policy:
         in: HOGE

--- a/bdd/tests/configs/bgp_route_map_match/z1.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z1.yaml
@@ -20,14 +20,14 @@ router:
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       apply-policy:
         out: SET-MED-100
       enabled: true
       peer-as: 65002
     afi-safi:
-    - name: ipv4-unicast
+    - name: ipv4
       network:
       - prefix: 10.0.0.1/32
       - prefix: 10.0.0.2/32

--- a/bdd/tests/configs/bgp_route_map_match/z2-aspath-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-aspath-fail.yaml
@@ -17,7 +17,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       apply-policy:
         in: IN-ASPATH

--- a/bdd/tests/configs/bgp_route_map_match/z2-aspath-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-aspath-pass.yaml
@@ -17,7 +17,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       apply-policy:
         in: IN-ASPATH

--- a/bdd/tests/configs/bgp_route_map_match/z2-base.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-base.yaml
@@ -6,7 +6,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-eq-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-eq-fail.yaml
@@ -13,7 +13,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       apply-policy:
         in: IN-MED

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-eq-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-eq-pass.yaml
@@ -13,7 +13,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       apply-policy:
         in: IN-MED

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-range-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-range-fail.yaml
@@ -13,7 +13,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       apply-policy:
         in: IN-MED

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-range-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-range-pass.yaml
@@ -14,7 +14,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       apply-policy:
         in: IN-MED

--- a/bdd/tests/configs/bgp_route_map_match/z2-nh-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-nh-fail.yaml
@@ -18,7 +18,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       apply-policy:
         in: IN-NEXTHOP

--- a/bdd/tests/configs/bgp_route_map_match/z2-nh-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-nh-pass.yaml
@@ -18,7 +18,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       apply-policy:
         in: IN-NEXTHOP

--- a/bdd/tests/configs/bgp_route_map_match/z2-origin-egp.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-origin-egp.yaml
@@ -13,7 +13,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       apply-policy:
         in: IN-ORIGIN

--- a/bdd/tests/configs/bgp_route_map_match/z2-origin-igp.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-origin-igp.yaml
@@ -13,7 +13,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       apply-policy:
         in: IN-ORIGIN

--- a/bdd/tests/configs/bgp_tcp_ao_auth/z1-1.yaml
+++ b/bdd/tests/configs/bgp_tcp_ao_auth/z1-1.yaml
@@ -17,7 +17,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       enabled: true
       peer-as: 65002

--- a/bdd/tests/configs/bgp_tcp_ao_auth/z2-1.yaml
+++ b/bdd/tests/configs/bgp_tcp_ao_auth/z2-1.yaml
@@ -17,7 +17,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_tcp_md5_auth/z1-1.yaml
+++ b/bdd/tests/configs/bgp_tcp_md5_auth/z1-1.yaml
@@ -6,7 +6,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       enabled: true
       peer-as: 65002

--- a/bdd/tests/configs/bgp_tcp_md5_auth/z2-1.yaml
+++ b/bdd/tests/configs/bgp_tcp_md5_auth/z2-1.yaml
@@ -6,7 +6,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_tcp_md5_auth/z2-2.yaml
+++ b/bdd/tests/configs/bgp_tcp_md5_auth/z2-2.yaml
@@ -6,7 +6,7 @@ router:
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       enabled: true
       peer-as: 65001

--- a/bdd/tests/features/bgp_evpn_capability.feature
+++ b/bdd/tests/features/bgp_evpn_capability.feature
@@ -26,13 +26,13 @@ Feature: BGP L2VPN/EVPN capability negotiation
   ```
 
   Both peers enable two AFI/SAFIs:
-    - ipv4-unicast (so the session has a fallback AF and matches the
+    - ipv4 (so the session has a fallback AF and matches the
       established BDD pattern)
-    - l2vpn-evpn  (the AF this scenario is actually validating)
+    - evpn  (the AF this scenario is actually validating)
 
   Config files:
-  - z1-1.yaml: AS 65001, peer to 192.168.0.2, l2vpn-evpn enabled
-  - z2-1.yaml: AS 65001, peer to 192.168.0.1, l2vpn-evpn enabled
+  - z1-1.yaml: AS 65001, peer to 192.168.0.2, evpn enabled
+  - z2-1.yaml: AS 65001, peer to 192.168.0.1, evpn enabled
 
   Scenario: Setup topology and establish iBGP session with EVPN capability
     Given a clean test environment

--- a/bdd/tests/features/bgp_gobgpd_etcd.feature
+++ b/bdd/tests/features/bgp_gobgpd_etcd.feature
@@ -35,7 +35,7 @@ Feature: BGP RR tests with gobgpd clients and etcd
 
   Config files:
   - rr.yaml: AS 64512, zebra-rs RR with cluster-id 198.18.39.94, peers to all gobgpd clients
-  - gobgpd clients configured as RR clients with l3vpn-ipv4-unicast AFI/SAFI
+  - gobgpd clients configured as RR clients with vpnv4 AFI/SAFI
   - etcd: Key-value store backend for zebra-rs configuration
 
   Scenario: Setup topology and establish BGP session

--- a/bdd/tests/features/bgp_gobgpd_rr.feature
+++ b/bdd/tests/features/bgp_gobgpd_rr.feature
@@ -35,7 +35,7 @@ Feature: BGP RR tests with gobgpd clients
 
   Config files:
   - rr.yaml: AS 64512, zebra-rs RR with cluster-id 198.18.39.94, peers to all gobgpd clients
-  - gobgpd clients configured as RR clients with l3vpn-ipv4-unicast AFI/SAFI
+  - gobgpd clients configured as RR clients with vpnv4 AFI/SAFI
 
   Scenario: Setup topology and establish BGP session
     Given a clean test environment

--- a/book/src/ch-02-02-tcp-authentication.md
+++ b/book/src/ch-02-02-tcp-authentication.md
@@ -112,7 +112,7 @@ router:
       peer-as: 65002
       enabled: true
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       tcp-md5:
         encoding: clear
@@ -151,7 +151,7 @@ router:
       peer-as: 65002
       enabled: true
       afi-safi:
-      - name: ipv4-unicast
+      - name: ipv4
         enabled: true
       tcp-ao:
         key-chain: BGP-AO

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -374,7 +374,7 @@ fn config_network(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
 
 fn config_advertise_all_vni(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let afi_safi: AfiSafi = args.afi_safi()?;
-    // The leaf only carries meaning for l2vpn-evpn; ignore on other
+    // The leaf only carries meaning for evpn; ignore on other
     // AFI/SAFIs. The YANG `advertise-all-vni` extension is augmented
     // into the global afi-safi list which spans every AF, so we have
     // to filter at the callback.
@@ -1013,7 +1013,7 @@ impl Bgp {
         self.callback_add("/router/bgp/afi-safi/network", config_network);
 
         // EVPN: FRR-style `advertise-all-vni` under
-        // `router bgp afi-safi l2vpn-evpn`. Augmented in by
+        // `router bgp afi-safi evpn`. Augmented in by
         // zebra-bgp-evpn.yang. Schema-only consumer for now —
         // origination from Rib::neighbors lands in a follow-up.
         self.callback_add(

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -83,7 +83,7 @@ pub struct Bgp {
     pub asn: u32,
     pub router_id: Ipv4Addr,
     /// FRR-style `advertise-all-vni` knob under `router bgp afi-safi
-    /// l2vpn-evpn`. When true, every locally-configured VXLAN VNI
+    /// evpn`. When true, every locally-configured VXLAN VNI
     /// participates in EVPN advertisement: Type-2 (MAC/IP) routes
     /// from the kernel's bridge FDB and Type-3 (Inclusive Multicast)
     /// routes per local VTEP. Bridge -> VNI mapping is inferred from

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -130,13 +130,11 @@ impl Args {
     pub fn afi_safi(&mut self) -> Option<AfiSafi> {
         let item = self.0.pop_front()?;
         match item.as_str() {
-            "ipv4-unicast" => Some(AfiSafi::new(Afi::Ip, Safi::Unicast)),
-            "ipv4-labeled-unicast" => Some(AfiSafi::new(Afi::Ip, Safi::MplsLabel)),
-            "l3vpn-ipv4-unicast" => Some(AfiSafi::new(Afi::Ip, Safi::MplsVpn)),
-            "l2vpn-evpn" => Some(AfiSafi::new(Afi::L2vpn, Safi::Evpn)),
-            "ipv6-unicast" => Some(AfiSafi::new(Afi::Ip6, Safi::Unicast)),
-            "ipv6-labeled-unicast" => Some(AfiSafi::new(Afi::Ip6, Safi::MplsLabel)),
-            "l3vpn-ipv6-unicast" => Some(AfiSafi::new(Afi::Ip, Safi::MplsVpn)),
+            "ipv4" => Some(AfiSafi::new(Afi::Ip, Safi::Unicast)),
+            "ipv6" => Some(AfiSafi::new(Afi::Ip6, Safi::Unicast)),
+            "vpnv4" => Some(AfiSafi::new(Afi::Ip, Safi::MplsVpn)),
+            "vpnv6" => Some(AfiSafi::new(Afi::Ip6, Safi::MplsVpn)),
+            "evpn" => Some(AfiSafi::new(Afi::L2vpn, Safi::Evpn)),
             _ => None,
         }
     }

--- a/zebra-rs/yang/iana-bgp-types@2023-07-05.yang
+++ b/zebra-rs/yang/iana-bgp-types@2023-07-05.yang
@@ -288,7 +288,7 @@ module iana-bgp-types {
       "RFC4760: Multiprotocol Extentions for BGP-4.";
   }
 
-  identity ipv4-unicast {
+  identity ipv4 {
     base afi-safi-type;
     description
       "IPv4 unicast (AFI,SAFI = 1,1)";
@@ -296,15 +296,7 @@ module iana-bgp-types {
       "RFC4760: Multiprotocol Extentions for BGP-4.";
   }
 
-  identity ipv4-labeled-unicast {
-    base afi-safi-type;
-    description
-      "Labeled IPv4 unicast (AFI,SAFI = 1,4)";
-    reference
-      "RFC 8277: Using BGP to Bind MPLS Labels to Address Prefixes.";
-  }
-
-  identity ipv6-unicast {
+  identity ipv6 {
     base afi-safi-type;
     description
       "IPv6 unicast (AFI,SAFI = 2,1)";
@@ -312,31 +304,15 @@ module iana-bgp-types {
       "RFC4760: Multiprotocol Extentions for BGP-4.";
   }
 
-  identity ipv6-labeled-unicast {
-    base afi-safi-type;
-    description
-      "Labeled IPv6 unicast (AFI,SAFI = 2,4)";
-    reference
-      "RFC 8277: Using BGP to Bind MPLS Labels to Address Prefixes.";
-  }
-
-  identity l3vpn-ipv4-unicast {
+  identity vpnv4 {
     base afi-safi-type;
     description
       "Unicast IPv4 MPLS L3VPN (AFI,SAFI = 1,128)";
     reference
       "RFC 4364: BGP/MPLS IP Virtual Private Networks (VPNs).";
   }
-  identity l3vpn-ipv4-multicast {
-    base afi-safi-type;
-    description
-      "Multicast IPv4 MPLS L3VPN (AFI,SAFI = 1,129)";
-    reference
-      "RFC 6514: BGP Encodings and Procedures for Multicast in
-       MPLS/BGP IP VPNs.";
-  }
 
-  identity l3vpn-ipv6-unicast {
+  identity vpnv6 {
     base afi-safi-type;
     description
       "Unicast IPv6 MPLS L3VPN (AFI,SAFI = 2,128)";
@@ -345,30 +321,12 @@ module iana-bgp-types {
        for IPv6 VPN.";
   }
 
-  identity l3vpn-ipv6-multicast {
-    base afi-safi-type;
-    description
-      "Multicast IPv6 MPLS L3VPN (AFI,SAFI = 2,129)";
-    reference
-      "RFC 6514: BGP Encodings and Procedures for Multicast in
-       MPLS/BGP IP VPNs.";
-  }
-
-  identity l2vpn-evpn {
+  identity evpn {
     base afi-safi-type;
     description
       "BGP MPLS Based Ethernet VPN (AFI,SAFI = 25,70)";
     reference
       "RFC 7432: BGP MPLS-Based Ethernet VPN.";
-  }
-
-  identity l2vpn-vpls {
-    base afi-safi-type;
-    description
-      "BGP-signalled VPLS (AFI,SAFI = 25,65)";
-    reference
-      "RFC 4761: Virtual Private LAN Service (VPLS) Using BGP for
-       Auto-Discovery and Signaling.";
   }
 
   /* BGP Remove Private AS Identities. */

--- a/zebra-rs/yang/ietf-bgp-common-multiprotocol@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-common-multiprotocol@2023-07-05.yang
@@ -162,8 +162,8 @@ submodule ietf-bgp-common-multiprotocol {
        for AFI-SAFI entries";
     // import and export policy included for the afi/safi
     uses rt-pol:apply-policy-group;
-    container ipv4-unicast {
-      when "../name = 'bt:ipv4-unicast'" {
+    container ipv4 {
+      when "../name = 'bt:ipv4'" {
         description
           "Include this container for IPv4 Unicast specific
            configuration";
@@ -174,8 +174,8 @@ submodule ietf-bgp-common-multiprotocol {
       uses mp-ipv4-ipv6-unicast-common;
       // placeholder for IPv4 unicast specific configuration
     }
-    container ipv6-unicast {
-      when "../name = 'bt:ipv6-unicast'" {
+    container ipv6 {
+      when "../name = 'bt:ipv6'" {
         description
           "Include this container for IPv6 Unicast specific
            configuration";
@@ -187,32 +187,8 @@ submodule ietf-bgp-common-multiprotocol {
       // placeholder for IPv6 unicast specific configuration
       // options
     }
-    container ipv4-labeled-unicast {
-      when "../name = 'bt:ipv4-labeled-unicast'" {
-        description
-          "Include this container for IPv4 Labeled Unicast specific
-           configuration";
-      }
-      description
-        "IPv4 Labeled Unicast configuration options";
-      uses mp-all-afi-safi-common;
-      // placeholder for IPv4 Labeled Unicast specific config
-      // options
-    }
-    container ipv6-labeled-unicast {
-      when "../name = 'bt:ipv6-labeled-unicast'" {
-        description
-          "Include this container for IPv6 Labeled Unicast specific
-           configuration";
-      }
-      description
-        "IPv6 Labeled Unicast configuration options";
-      uses mp-all-afi-safi-common;
-      // placeholder for IPv6 Labeled Unicast specific config
-      // options.
-    }
-    container l3vpn-ipv4-unicast {
-      when "../name = 'bt:l3vpn-ipv4-unicast'" {
+    container vpnv4 {
+      when "../name = 'bt:vpnv4'" {
         description
           "Include this container for IPv4 Unicast L3VPN specific
            configuration";
@@ -223,8 +199,8 @@ submodule ietf-bgp-common-multiprotocol {
       uses mp-l3vpn-ipv4-ipv6-unicast-common;
       // placeholder for IPv4 Unicast L3VPN specific config options.
     }
-    container l3vpn-ipv6-unicast {
-      when "../name = 'bt:l3vpn-ipv6-unicast'" {
+    container vpnv6 {
+      when "../name = 'bt:vpnv6'" {
         description
           "Include this container for unicast IPv6 L3VPN specific
            configuration";
@@ -236,47 +212,8 @@ submodule ietf-bgp-common-multiprotocol {
       // placeholder for IPv6 Unicast L3VPN specific configuration
       // options
     }
-    container l3vpn-ipv4-multicast {
-      when "../name = 'bt:l3vpn-ipv4-multicast'" {
-        description
-          "Include this container for multicast IPv6 L3VPN specific
-           configuration";
-      }
-      description
-        "Multicast IPv4 L3VPN configuration options";
-      // include common L3VPN multicast options
-      uses mp-l3vpn-ipv4-ipv6-multicast-common;
-      // placeholder for IPv4 Multicast L3VPN specific configuration
-      // options
-    }
-    container l3vpn-ipv6-multicast {
-      when "../name = 'bt:l3vpn-ipv6-multicast'" {
-        description
-          "Include this container for multicast IPv6 L3VPN specific
-           configuration";
-      }
-      description
-        "Multicast IPv6 L3VPN configuration options";
-      // include common L3VPN multicast options
-      uses mp-l3vpn-ipv4-ipv6-multicast-common;
-      // placeholder for IPv6 Multicast L3VPN specific configuration
-      // options
-    }
-    container l2vpn-vpls {
-      when "../name = 'bt:l2vpn-vpls'" {
-        description
-          "Include this container for BGP-signalled VPLS specific
-           configuration";
-      }
-      description
-        "BGP-signalled VPLS configuration options";
-      // include common L2VPN options
-      uses mp-l2vpn-common;
-      // placeholder for BGP-signalled VPLS specific configuration
-      // options
-    }
-    container l2vpn-evpn {
-      when "../name = 'bt:l2vpn-evpn'" {
+    container evpn {
+      when "../name = 'bt:evpn'" {
         description
           "Include this container for BGP EVPN specific
            configuration";
@@ -324,15 +261,6 @@ submodule ietf-bgp-common-multiprotocol {
        and IPv6";
     // placeholder -- specific configuration options that are generic
     // across IPv[46] unicast address families.
-    uses mp-all-afi-safi-common;
-  }
-
-  grouping mp-l3vpn-ipv4-ipv6-multicast-common {
-    description
-      "Common configuration applied across L3VPN for IPv4
-       and IPv6";
-    // placeholder -- specific configuration options that are
-    // generic across IPv[46] multicast address families.
     uses mp-all-afi-safi-common;
   }
 

--- a/zebra-rs/yang/ietf-bgp-rib@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-rib@2023-07-05.yang
@@ -447,14 +447,14 @@ submodule ietf-bgp-rib {
             description
               "AFI,SAFI name.";
           }
-          container ipv4-unicast {
-            when "../name = 'bt:ipv4-unicast'" {
+          container ipv4 {
+            when "../name = 'bt:ipv4'" {
               description
                 "Include this container for IPv4 unicast RIB.";
             }
             description
               "Routing tables for IPv4 unicast -- active when the
-               afi-safi name is ipv4-unicast.";
+               afi-safi name is ipv4.";
 
             container loc-rib {
               config false;
@@ -566,14 +566,14 @@ submodule ietf-bgp-rib {
             }
           }
 
-          container ipv6-unicast {
-            when "../name = 'bt:ipv6-unicast'" {
+          container ipv6 {
+            when "../name = 'bt:ipv6'" {
               description
                 "Include this container for IPv6 unicast RIB.";
             }
             description
               "Routing tables for IPv6 unicast -- active when the
-               afi-safi name is ipv6-unicast.";
+               afi-safi name is ipv6.";
 
             container loc-rib {
               config false;

--- a/zebra-rs/yang/zebra-bgp-evpn.yang
+++ b/zebra-rs/yang/zebra-bgp-evpn.yang
@@ -26,7 +26,7 @@ module zebra-bgp-evpn {
     "EVPN service extensions to the BGP candidate-config tree.
 
      Adds the FRR-style `advertise-all-vni` knob under the BGP
-     global AFI/SAFI list — when enabled for the `l2vpn-evpn`
+     global AFI/SAFI list — when enabled for the `evpn`
      AFI/SAFI, every locally-configured VXLAN VNI participates in
      EVPN advertisement (Type-2 MAC/IP + Type-3 Inclusive Multicast)
      with auto-derived RD and RT.
@@ -37,12 +37,12 @@ module zebra-bgp-evpn {
          neighbor 10.0.0.1 {
            peer-as 65001;
            afi-safi {
-             name l2vpn-evpn;
+             name evpn;
              enabled true;
            }
          }
          afi-safi {
-           name l2vpn-evpn;
+           name evpn;
            advertise-all-vni true;
          }
        }
@@ -57,7 +57,7 @@ module zebra-bgp-evpn {
   grouping bgp-afi-safi-evpn-extension {
     description
       "Per-AFI/SAFI EVPN extensions on the global afi-safi list. Only
-       meaningful when the list entry's name is `bt:l2vpn-evpn` —
+       meaningful when the list entry's name is `bt:evpn` —
        harmless and ignored on other AFI/SAFIs.";
     leaf advertise-all-vni {
       type boolean;
@@ -89,7 +89,7 @@ module zebra-bgp-evpn {
   augment "/configure:delete/config:router/bgp:bgp/bgp:afi-safi" {
     description
       "Same attachment for the delete subtree so
-       `delete router bgp afi-safi l2vpn-evpn advertise-all-vni`
+       `delete router bgp afi-safi evpn advertise-all-vni`
        is path-valid.";
     uses bgp-afi-safi-evpn-extension;
   }


### PR DESCRIPTION
## Summary
- Rename BGP `afi-safi-type` identities in `iana-bgp-types` to short names: `ipv4`, `ipv6`, `vpnv4`, `vpnv6`, `evpn`. Drop unused identities (`ipv4-labeled-unicast`, `ipv6-labeled-unicast`, `l3vpn-ipv4-multicast`, `l3vpn-ipv6-multicast`, `l2vpn-vpls`) along with their per-AF containers and the orphan `mp-l3vpn-ipv4-ipv6-multicast-common` grouping.
- Update the Rust `Args::afi_safi` string parser in `src/config/configs.rs` to match the new names. Also fix a latent bug where `l3vpn-ipv6-unicast` mapped to `AfiSafi(Ip, MplsVpn)` instead of `AfiSafi(Ip6, MplsVpn)` — the new `vpnv6` arm is correct.
- Refresh BGP doc comments and zebra-bgp-evpn.yang references.
- Update 35 BDD config YAMLs, 3 Gherkin feature files, BDD docs, and the book chapter that exposed the old names. ISIS multi-topology (which has its own `ipv6-unicast` enum, unrelated to the BGP identity) is left alone.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo build --release --package zebra-rs`
- [x] `cargo clippy --release --package zebra-rs --bin zebra-rs -- -D warnings`
- [x] `cargo test --release --workspace --exclude zebra-rs-bdd`
- [x] Daemon smoke test with `--yang-path` reaches `zebra-rs started`, confirming the YANG schema loads and identityrefs resolve.
- [ ] Run BDD suite locally if needed (the renamed YAMLs and feature files will exercise the new names end-to-end).

Generated with [Claude Code](https://claude.com/claude-code)