### PR TITLE
config: drop unused top-level choice-test YANG container

### DIFF
--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -703,29 +703,6 @@ module config {
       }
     }
 
-    container choice-test {
-      choice subnet {
-        mandatory true;
-        description
-          "The subnet can be specified as a prefix length or,
-             if the server supports non-contiguous netmasks, as
-             a netmask.";
-        leaf prefix-length {
-          type uint8 {
-            range "0..32";
-          }
-          description
-            "The length of the subnet prefix.";
-        }
-        leaf netmask {
-          if-feature ipv4-non-contiguous-netmasks;
-          type inet:ipv4-address;
-          description
-            "The subnet specified as a netmask.";
-        }
-      }
-    }
-
     list community-set {
       ext:sort "5";
       key "name";


### PR DESCRIPTION
## Summary
- Removes the `choice-test` container under `grouping config` in `zebra-rs/yang/config.yang`. It was an example/scaffold left over from earlier development with no consumers in source code, tests, or fixtures.

## Test plan
- [x] `cargo build --release --package zebra-rs --bin zebra-rs`
- [x] Repo-wide grep confirmed no references to `choice-test` remain.

Generated with [Claude Code](https://claude.com/claude-code)