### PR TITLE
release: bump zebra-rs to 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 authors = ["Kunihiro Ishiguro <kunihiro@zebra.dev>"]
 license = "AGPL-3.0-or-later"

--- a/packaging/nfpm-amd64.yaml
+++ b/packaging/nfpm-amd64.yaml
@@ -9,7 +9,7 @@
 name: "zebra-rs"
 arch: "amd64"
 platform: "linux"
-version: "0.9.0"
+version: "0.9.1"
 section: "default"
 priority: "extra"
 replaces:

--- a/packaging/nfpm-arm64.yaml
+++ b/packaging/nfpm-arm64.yaml
@@ -9,7 +9,7 @@
 name: "zebra-rs"
 arch: "arm64"
 platform: "linux"
-version: "0.9.0"
+version: "0.9.1"
 section: "default"
 priority: "extra"
 replaces:

--- a/packaging/version-update.sh
+++ b/packaging/version-update.sh
@@ -1,5 +1,10 @@
 #! /bin/bash
 
+for file in ../Cargo.toml
+do
+    sed -i "s/^version = .*/version = \"$(cat ../version)\"/" ${file}
+done
+
 for file in ./nfpm-amd64.yaml ./nfpm-arm64.yaml
 do
     sed -i "s/^version: .*/version: \"$(cat ../version)\"/" ${file}


### PR DESCRIPTION
## Summary
- Bump nfpm yaml `version:` (amd64 and arm64) from 0.9.0 to 0.9.1.
- Bump workspace `[workspace.package].version` from 0.9.0 to 0.9.1; with the template refactor in #434 every crate inherits this, so all 12 workspace packages now report 0.9.1 (verified via `cargo metadata`).
- Re-add a one-element workspace-only sed loop to `packaging/version-update.sh`. PR #434 stripped the previous five-element loop because per-crate Cargo.tomls no longer carry `version = "..."`; the workspace root still has a literal `version =` line, so a degenerate one-file loop keeps `./version` → workspace bump auto-syncing on future revisions.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --release --workspace`
- [x] `cargo metadata` reports 0.9.1 for all workspace members.

Generated with [Claude Code](https://claude.com/claude-code)