### PR TITLE
policy: flatten naming — top-level `policy` and on BGP neighbors

### DIFF
--- a/bdd/tests/configs/bgp_basic_ebgp/z1-5.yaml
+++ b/bdd/tests/configs/bgp_basic_ebgp/z1-5.yaml
@@ -2,13 +2,12 @@ prefix-set:
 - name: out-test
   prefixes:
   - prefix: 10.0.0.1/32
-policy-options:
-  policy:
-  - name: out-test
-    entry:
-    - number: 10
-      match:
-        prefix-set: out-test
+policy:
+- name: out-test
+  entry:
+  - number: 10
+    match:
+      prefix-set: out-test
 router:
   bgp:
     global:
@@ -19,7 +18,7 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      apply-policy:
+      policy:
         out: out-test
       enabled: true
       peer-as: 65002

--- a/bdd/tests/configs/bgp_basic_ibgp/z1-5.yaml
+++ b/bdd/tests/configs/bgp_basic_ibgp/z1-5.yaml
@@ -2,13 +2,12 @@ prefix-set:
 - name: out-test
   prefixes:
   - prefix: 10.0.0.1/32
-policy-options:
-  policy:
-  - name: out-test
-    entry:
-    - number: 10
-      match:
-        prefix-set: out-test
+policy:
+- name: out-test
+  entry:
+  - number: 10
+    match:
+      prefix-set: out-test
 router:
   bgp:
     global:
@@ -19,7 +18,7 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      apply-policy:
+      policy:
         out: out-test
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_gobgpd_rr/rr1.yaml
+++ b/bdd/tests/configs/bgp_gobgpd_rr/rr1.yaml
@@ -1,65 +1,64 @@
 community-set:
 - name: 198.18.37.16/28
-  member:
+  members:
   - rt:^64371:.*$
 - name: 198.18.37.80/28
-  member:
+  members:
   - rt:^456:.*$
 - name: 198.18.39.80/28
-  member:
+  members:
   - rt:^31746:.*$
 - name: 198.18.39.96/28
-  member:
+  members:
   - rt:^14815:.*$
 - name: 198.18.39.128/28
-  member:
+  members:
   - rt:^2481:.*$
 - name: 198.18.39.144/28
-  member:
+  members:
   - rt:^10334:.*$
 - name: 198.18.39.160/28
-  member:
+  members:
   - rt:^51451:.*$
 - name: TENANT-RTS-20e08c2f48cf46e686beed9691459776
-  member:
+  members:
   - rt:^5882:.*$
-policy-options:
-  policy:
-  - name: 198.18.37.16/28
-    entry:
-    - number: 10
-      match:
-        community-set: 198.18.37.16/28
-  - name: 198.18.37.80/28
-    entry:
-    - number: 10
-      match:
-        community-set: 198.18.37.80/28
-  - name: 198.18.39.80/28
-    entry:
-    - number: 10
-      match:
-        community-set: 198.18.39.80/28
-  - name: 198.18.39.96/28
-    entry:
-    - number: 10
-      match:
-        community-set: 198.18.39.96/28
-  - name: 198.18.39.128/28
-    entry:
-    - number: 10
-      match:
-        community-set: 198.18.39.128/28
-  - name: 198.18.39.144/28
-    entry:
-    - number: 10
-      match:
-        community-set: 198.18.39.144/28
-  - name: 198.18.39.160/28
-    entry:
-    - number: 10
-      match:
-        community-set: 198.18.39.160/28
+policy:
+- name: 198.18.37.16/28
+  entry:
+  - number: 10
+    match:
+      community-set: 198.18.37.16/28
+- name: 198.18.37.80/28
+  entry:
+  - number: 10
+    match:
+      community-set: 198.18.37.80/28
+- name: 198.18.39.80/28
+  entry:
+  - number: 10
+    match:
+      community-set: 198.18.39.80/28
+- name: 198.18.39.96/28
+  entry:
+  - number: 10
+    match:
+      community-set: 198.18.39.96/28
+- name: 198.18.39.128/28
+  entry:
+  - number: 10
+    match:
+      community-set: 198.18.39.128/28
+- name: 198.18.39.144/28
+  entry:
+  - number: 10
+    match:
+      community-set: 198.18.39.144/28
+- name: 198.18.39.160/28
+  entry:
+  - number: 10
+    match:
+      community-set: 198.18.39.160/28
 router:
   bgp:
     global:
@@ -76,7 +75,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.37.16/28
         out: 198.18.37.16/28
       enabled: true
@@ -98,7 +97,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.37.16/28
         out: 198.18.37.16/28
       enabled: true
@@ -120,7 +119,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
       enabled: true
@@ -142,7 +141,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
       enabled: true
@@ -164,7 +163,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
       enabled: true
@@ -186,7 +185,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
       enabled: true
@@ -208,7 +207,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
       enabled: true
@@ -230,7 +229,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
       enabled: true
@@ -252,7 +251,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
       enabled: true
@@ -274,7 +273,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
       enabled: true
@@ -296,7 +295,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
       enabled: true
@@ -318,7 +317,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
       enabled: true
@@ -340,7 +339,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.39.96/28
         out: 198.18.39.96/28
       enabled: true
@@ -362,7 +361,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.39.96/28
         out: 198.18.39.96/28
       enabled: true
@@ -384,7 +383,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
       enabled: true
@@ -406,7 +405,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
       enabled: true
@@ -428,7 +427,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
       enabled: true
@@ -450,7 +449,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
       enabled: true
@@ -472,7 +471,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
       enabled: true
@@ -494,7 +493,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
       enabled: true
@@ -516,7 +515,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
       enabled: true
@@ -538,7 +537,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
       enabled: true
@@ -560,7 +559,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
       enabled: true
@@ -582,7 +581,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
       enabled: true
@@ -604,7 +603,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.39.144/28
         out: 198.18.39.144/28
       enabled: true
@@ -626,7 +625,7 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
-      apply-policy:
+      policy:
         in: 198.18.39.144/28
         out: 198.18.39.144/28
       enabled: true

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-both.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-both.yaml
@@ -3,13 +3,12 @@ prefix-set:
   prefixes:
   - prefix: 1.1.1.1/32
   - prefix: 2.2.2.2/32
-policy-options:
-  policy:
-  - name: HOGE
-    entry:
-    - number: 10
-      match:
-        prefix-set: HOGE
+policy:
+- name: HOGE
+  entry:
+  - number: 10
+    match:
+      prefix-set: HOGE
 router:
   bgp:
     global:
@@ -20,7 +19,7 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      apply-policy:
+      policy:
         in: HOGE
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-initial.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-initial.yaml
@@ -2,13 +2,12 @@ prefix-set:
 - name: HOGE
   prefixes:
   - prefix: 1.1.1.1/32
-policy-options:
-  policy:
-  - name: HOGE
-    entry:
-    - number: 10
-      match:
-        prefix-set: HOGE
+policy:
+- name: HOGE
+  entry:
+  - number: 10
+    match:
+      prefix-set: HOGE
 router:
   bgp:
     global:
@@ -19,7 +18,7 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      apply-policy:
+      policy:
         in: HOGE
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-other.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-other.yaml
@@ -2,13 +2,12 @@ prefix-set:
 - name: HOGE
   prefixes:
   - prefix: 2.2.2.2/32
-policy-options:
-  policy:
-  - name: HOGE
-    entry:
-    - number: 10
-      match:
-        prefix-set: HOGE
+policy:
+- name: HOGE
+  entry:
+  - number: 10
+    match:
+      prefix-set: HOGE
 router:
   bgp:
     global:
@@ -19,7 +18,7 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      apply-policy:
+      policy:
         in: HOGE
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z1.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z1.yaml
@@ -3,15 +3,14 @@ prefix-set:
   prefixes:
   - prefix: 0.0.0.0/0
     le: 32
-policy-options:
-  policy:
-  - name: SET-MED-100
-    entry:
-    - number: 10
-      match:
-        prefix-set: ALL-V4
-      set:
-        med: 100
+policy:
+- name: SET-MED-100
+  entry:
+  - number: 10
+    match:
+      prefix-set: ALL-V4
+    set:
+      med: 100
 router:
   bgp:
     global:
@@ -22,7 +21,7 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      apply-policy:
+      policy:
         out: SET-MED-100
       enabled: true
       peer-as: 65002

--- a/bdd/tests/configs/bgp_route_map_match/z2-aspath-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-aspath-fail.yaml
@@ -1,14 +1,13 @@
 as-path-set:
 - name: FROM-65999
-  member:
+  members:
   - "^65999$"
-policy-options:
-  policy:
-  - name: IN-ASPATH
-    entry:
-    - number: 10
-      match:
-        as-path-set: FROM-65999
+policy:
+- name: IN-ASPATH
+  entry:
+  - number: 10
+    match:
+      as-path-set: FROM-65999
 router:
   bgp:
     global:
@@ -19,7 +18,7 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      apply-policy:
+      policy:
         in: IN-ASPATH
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-aspath-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-aspath-pass.yaml
@@ -1,14 +1,13 @@
 as-path-set:
 - name: FROM-65001
-  member:
+  members:
   - "^65001$"
-policy-options:
-  policy:
-  - name: IN-ASPATH
-    entry:
-    - number: 10
-      match:
-        as-path-set: FROM-65001
+policy:
+- name: IN-ASPATH
+  entry:
+  - number: 10
+    match:
+      as-path-set: FROM-65001
 router:
   bgp:
     global:
@@ -19,7 +18,7 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      apply-policy:
+      policy:
         in: IN-ASPATH
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-eq-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-eq-fail.yaml
@@ -1,10 +1,9 @@
-policy-options:
-  policy:
-  - name: IN-MED
-    entry:
-    - number: 10
-      match:
-        med-eq: 999
+policy:
+- name: IN-MED
+  entry:
+  - number: 10
+    match:
+      med-eq: 999
 router:
   bgp:
     global:
@@ -15,7 +14,7 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      apply-policy:
+      policy:
         in: IN-MED
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-eq-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-eq-pass.yaml
@@ -1,10 +1,9 @@
-policy-options:
-  policy:
-  - name: IN-MED
-    entry:
-    - number: 10
-      match:
-        med-eq: 100
+policy:
+- name: IN-MED
+  entry:
+  - number: 10
+    match:
+      med-eq: 100
 router:
   bgp:
     global:
@@ -15,7 +14,7 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      apply-policy:
+      policy:
         in: IN-MED
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-range-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-range-fail.yaml
@@ -1,10 +1,9 @@
-policy-options:
-  policy:
-  - name: IN-MED
-    entry:
-    - number: 10
-      match:
-        med-ge: 200
+policy:
+- name: IN-MED
+  entry:
+  - number: 10
+    match:
+      med-ge: 200
 router:
   bgp:
     global:
@@ -15,7 +14,7 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      apply-policy:
+      policy:
         in: IN-MED
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-range-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-range-pass.yaml
@@ -1,11 +1,10 @@
-policy-options:
-  policy:
-  - name: IN-MED
-    entry:
-    - number: 10
-      match:
-        med-ge: 50
-        med-le: 200
+policy:
+- name: IN-MED
+  entry:
+  - number: 10
+    match:
+      med-ge: 50
+      med-le: 200
 router:
   bgp:
     global:
@@ -16,7 +15,7 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      apply-policy:
+      policy:
         in: IN-MED
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-nh-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-nh-fail.yaml
@@ -3,13 +3,12 @@ prefix-set:
   prefixes:
   - prefix: 10.10.0.0/16
     le: 32
-policy-options:
-  policy:
-  - name: IN-NEXTHOP
-    entry:
-    - number: 10
-      match:
-        next-hop-set: WRONG-SUBNET
+policy:
+- name: IN-NEXTHOP
+  entry:
+  - number: 10
+    match:
+      next-hop-set: WRONG-SUBNET
 router:
   bgp:
     global:
@@ -20,7 +19,7 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      apply-policy:
+      policy:
         in: IN-NEXTHOP
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-nh-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-nh-pass.yaml
@@ -3,13 +3,12 @@ prefix-set:
   prefixes:
   - prefix: 192.168.0.0/24
     le: 32
-policy-options:
-  policy:
-  - name: IN-NEXTHOP
-    entry:
-    - number: 10
-      match:
-        next-hop-set: PEER-SUBNET
+policy:
+- name: IN-NEXTHOP
+  entry:
+  - number: 10
+    match:
+      next-hop-set: PEER-SUBNET
 router:
   bgp:
     global:
@@ -20,7 +19,7 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      apply-policy:
+      policy:
         in: IN-NEXTHOP
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-origin-egp.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-origin-egp.yaml
@@ -1,10 +1,9 @@
-policy-options:
-  policy:
-  - name: IN-ORIGIN
-    entry:
-    - number: 10
-      match:
-        origin: egp
+policy:
+- name: IN-ORIGIN
+  entry:
+  - number: 10
+    match:
+      origin: egp
 router:
   bgp:
     global:
@@ -15,7 +14,7 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      apply-policy:
+      policy:
         in: IN-ORIGIN
       enabled: true
       peer-as: 65001

--- a/bdd/tests/configs/bgp_route_map_match/z2-origin-igp.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-origin-igp.yaml
@@ -1,10 +1,9 @@
-policy-options:
-  policy:
-  - name: IN-ORIGIN
-    entry:
-    - number: 10
-      match:
-        origin: igp
+policy:
+- name: IN-ORIGIN
+  entry:
+  - number: 10
+    match:
+      origin: igp
 router:
   bgp:
     global:
@@ -15,7 +14,7 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      apply-policy:
+      policy:
         in: IN-ORIGIN
       enabled: true
       peer-as: 65001

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -173,7 +173,7 @@ fn config_peer_as(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
 ///
 /// Always-Unregister-before-Register avoids the watcher leak that
 /// previously occurred when the operator switched a peer from
-/// `apply-policy in hoge` to `apply-policy in fuga` — the "hoge"
+/// `policy in hoge` to `policy in fuga` — the "hoge"
 /// watcher would otherwise stay registered forever.
 fn policy_attach_msgs(
     policy_tx: &tokio::sync::mpsc::UnboundedSender<policy::Message>,
@@ -1022,8 +1022,8 @@ impl Bgp {
         );
 
         // Applying policy.
-        self.callback_peer("/apply-policy/in", config_policy_in);
-        self.callback_peer("/apply-policy/out", config_policy_out);
+        self.callback_peer("/policy/in", config_policy_in);
+        self.callback_peer("/policy/out", config_policy_out);
         self.callback_peer("/prefix-set/in", config_prefix_in);
         self.callback_peer("/prefix-set/out", config_prefix_out);
 

--- a/zebra-rs/src/policy/aspath/config.rs
+++ b/zebra-rs/src/policy/aspath/config.rs
@@ -130,7 +130,7 @@ impl ConfigBuilder {
                 }
                 Ok(())
             })
-            .path("/member")
+            .path("/members")
             .set(|config, cache, name, args| {
                 let set = cache_get(config, cache, name).context(CONFIG_ERR)?;
                 while let Some(member_str) = args.string() {

--- a/zebra-rs/src/policy/community/config.rs
+++ b/zebra-rs/src/policy/community/config.rs
@@ -130,7 +130,7 @@ impl ConfigBuilder {
                 }
                 Ok(())
             })
-            .path("/member")
+            .path("/members")
             .set(|config, cache, name, args| {
                 let set = cache_get(config, cache, name).context(CONFIG_ERR)?;
                 while let Some(member_str) = args.string() {

--- a/zebra-rs/src/policy/inst.rs
+++ b/zebra-rs/src/policy/inst.rs
@@ -35,7 +35,7 @@ pub enum Message {
         policy_type: PolicyType,
     },
     /// Counterpart of `Register`. Sent by a protocol when a peer
-    /// detaches a policy (operator runs `delete apply-policy in X`,
+    /// detaches a policy (operator runs `delete policy in X`,
     /// or rebinds to a different name). Without this the watcher
     /// list grows unbounded as peers churn or rename their policy
     /// references.
@@ -278,7 +278,7 @@ impl Policy {
         match msg.op {
             ConfigOp::Set | ConfigOp::Delete => {
                 let (path, args) = path_from_command(&msg.paths);
-                if path.as_str().starts_with("/policy-options") {
+                if path.as_str().starts_with("/policy") {
                     let _ = self.policy_config.exec(path, args, msg.op);
                 } else if path.as_str().starts_with("/prefix-set") {
                     let _ = self.prefix_config.exec(path, args, msg.op);
@@ -388,11 +388,11 @@ impl Policy {
 /// of the changed sets, skipping policies that were already directly
 /// committed in this same batch. This is what makes
 ///
-///     set policy-options prefix-set hoge prefixes 2.2.2.2/32
+///     set prefix-set hoge prefixes 2.2.2.2/32
 ///
-/// reach a peer attached via `apply-policy in <policy that
-/// matches prefix-set hoge>` — the prefix-set edit alone wouldn't
-/// fire `policy_list_update` for that policy without this cascade.
+/// reach a peer attached via `policy in <policy that matches
+/// prefix-set hoge>` — the prefix-set edit alone wouldn't fire
+/// `policy_list_update` for that policy without this cascade.
 #[allow(clippy::too_many_arguments)]
 fn cascade_indirect_policy_updates(
     policy_config: &mut BTreeMap<String, PolicyList>,

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -148,7 +148,7 @@ impl PolicyConfig {
             .context(CONFIG_ERR)?;
 
         let name = args.string().context(POLICY_NAME_ERR)?;
-        if !path.starts_with("/policy-options/policy/entry") {
+        if !path.starts_with("/policy/entry") {
             handler(&mut self.config, &mut self.cache, name, 0, &mut args)
         } else {
             let seq = args.u32().context(ENTRY_SEQ_ERR)?;
@@ -511,7 +511,7 @@ impl ConfigBuilder {
     }
 
     pub fn path(mut self, path: &str) -> Self {
-        let prefix = "/policy-options/policy";
+        let prefix = "/policy";
         self.path = format!("{prefix}{path}");
         self
     }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -709,7 +709,7 @@ module config {
       leaf name {
         type string;
       }
-      leaf-list member {
+      leaf-list members {
         type string;
         description
           "Members of the community set";
@@ -722,7 +722,7 @@ module config {
       leaf name {
         type string;
       }
-      leaf-list member {
+      leaf-list members {
         type string;
         description
           "Regular expression members matched against the route's
@@ -815,93 +815,91 @@ module config {
         uses vrf-route-target-policy;
       }
     }
-    container policy-options {
+    list policy {
       ext:sort "4";
-      list policy {
-        key "name";
-        leaf "name" {
-          type string;
+      key "name";
+      leaf "name" {
+        type string;
+      }
+      leaf "default-action" {
+        ext:sort "10";
+        type enumeration {
+          enum accept;
+          enum reject;
         }
-        leaf "default-action" {
-          ext:sort "10";
+      }
+      list entry {
+        ext:sort "5";
+        key "number";
+        leaf "number" {
+          type uint32;
+        }
+        container "match" {
+          ext:sort "7";
+          leaf "prefix-set" {
+            type string;
+          }
+          leaf "community-set" {
+            type string;
+          }
+          leaf "as-path-set" {
+            type string;
+          }
+          leaf "next-hop-set" {
+            type string;
+            description
+              "Reference to a prefix-set whose members are matched
+               against the route's BGP NEXT_HOP attribute.";
+          }
+          leaf "med-eq" {
+            type uint32;
+          }
+          leaf "med-ge" {
+            type uint32;
+          }
+          leaf "med-le" {
+            type uint32;
+          }
+          leaf "origin" {
+            type enumeration {
+              enum igp;
+              enum egp;
+              enum incomplete;
+            }
+          }
+        }
+        container "set" {
+          ext:sort "3";
+          leaf "local-preference" {
+            type uint32;
+          }
+          leaf "med" {
+            type uint32;
+          }
+          leaf "next-hop" {
+            type inet:ipv4-address;
+          }
+          leaf "community-set" {
+            type string;
+          }
+          leaf "community-additive" {
+            type boolean;
+          }
+          leaf "as-path-prepend" {
+            type string;
+            description
+              "Space-separated list of AS numbers to prepend to the
+               AS-path. Example: '65001 65001 65002' prepends three
+               segments. Equivalent to IOS-XR 'prepend as-path' or
+               FRR 'set as-path prepend'.";
+          }
+        }
+        leaf "action" {
+          ext:sort "1";
           type enumeration {
             enum accept;
             enum reject;
-          }
-        }
-        list entry {
-          ext:sort "5";
-          key "number";
-          leaf "number" {
-            type uint32;
-          }
-          container "match" {
-            ext:sort "7";
-            leaf "prefix-set" {
-              type string;
-            }
-            leaf "community-set" {
-              type string;
-            }
-            leaf "as-path-set" {
-              type string;
-            }
-            leaf "next-hop-set" {
-              type string;
-              description
-                "Reference to a prefix-set whose members are matched
-                 against the route's BGP NEXT_HOP attribute.";
-            }
-            leaf "med-eq" {
-              type uint32;
-            }
-            leaf "med-ge" {
-              type uint32;
-            }
-            leaf "med-le" {
-              type uint32;
-            }
-            leaf "origin" {
-              type enumeration {
-                enum igp;
-                enum egp;
-                enum incomplete;
-              }
-            }
-          }
-          container "set" {
-            ext:sort "3";
-            leaf "local-preference" {
-              type uint32;
-            }
-            leaf "med" {
-              type uint32;
-            }
-            leaf "next-hop" {
-              type inet:ipv4-address;
-            }
-            leaf "community-set" {
-              type string;
-            }
-            leaf "community-additive" {
-              type boolean;
-            }
-            leaf "as-path-prepend" {
-              type string;
-              description
-                "Space-separated list of AS numbers to prepend to the
-                 AS-path. Example: '65001 65001 65002' prepends three
-                 segments. Equivalent to IOS-XR 'prepend as-path' or
-                 FRR 'set as-path prepend'.";
-            }
-          }
-          leaf "action" {
-            ext:sort "1";
-            type enumeration {
-              enum accept;
-              enum reject;
-              enum pass;
-            }
+            enum pass;
           }
         }
       }

--- a/zebra-rs/yang/ietf-routing-policy@2021-10-11.yang
+++ b/zebra-rs/yang/ietf-routing-policy@2021-10-11.yang
@@ -497,7 +497,7 @@ module ietf-routing-policy {
       "Top-level container for routing policy applications.  This
        grouping is intended to be used in routing models where
        needed.";
-    container apply-policy {
+    container policy {
       description
         "Anchor point for routing policies in the model.
          Import and export policies are with respect to the local


### PR DESCRIPTION
## Summary
Three coordinated schema renames so the policy vocabulary across CLI and YAML reads consistently:

- **`member` → `members`** (leaf-list under `community-set` / `as-path-set`). Matches the existing `list prefixes` shape (plural collection, singular `prefix` entry-key) and reads better in YAML.
- **Drop `container policy-options`**. Hoist its inner `list policy` to a top-level sibling of `prefix-set` / `community-set` / `as-path-set`.
- **`apply-policy` → `policy`** in `grouping apply-policy-group` (ietf-routing-policy). Every BGP surface that uses this grouping (peer, global, per-AF afi-safi) inherits the rename. The two `policy` namespaces don't collide — top-level definitions live at `/policy/NAME/...`, BGP per-peer attachment at `/router/bgp/neighbor/X/policy/{in,out}`.

### Updated paths
- `policy/policy_list.rs`: handler prefix `/policy-options/policy` → `/policy`; entry dispatch keys off `/policy/entry`.
- `policy/inst.rs`: dispatcher prefix `/policy-options` → `/policy`.
- `policy/{community,aspath}/config.rs`: leaf-list handler `/member` → `/members`.
- `bgp/config.rs`: peer callbacks `/apply-policy/{in,out}` → `/policy/{in,out}`.
- 17 BDD YAMLs updated structurally (top-level outdent + key renames).

Diff: 24 files, +279 / -298.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --release --workspace`
- [x] `cargo clippy --release --workspace -- -D warnings`
- [x] `cargo test --release --workspace --exclude zebra-rs-bdd`
- [x] Daemon smoke test (vtyhelper, configure mode):
  - `set ?` shows `policy` alongside `prefix-set` / `community-set` / `as-path-set`
  - `set policy NAME ?` exposes `default-action` and `entry`
  - `set router bgp neighbor X ?` shows `policy ->` (no `apply-policy`)
  - `set router bgp neighbor X policy ?` exposes `in` / `out`
  - `set policy-options ?` and `set router bgp neighbor X apply-policy ?` → `NoMatch`

Generated with [Claude Code](https://claude.com/claude-code)