### PR TITLE
bgp: add neighbor-group scaffolding (IOS-XR style)

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -130,6 +130,21 @@ fn clear_peer_listener_auth(bgp: &mut Bgp, addr: &IpAddr) {
     }
 }
 
+/// `set router bgp neighbor <addr> neighbor-group <name>` —
+/// stores the reference on the peer's `PeerConfig`. No inheritance
+/// resolution yet; follow-up reads this and merges fields from
+/// `Bgp::neighbor_groups`.
+fn config_peer_neighbor_group(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let peer = bgp.peers.get_mut(&addr)?;
+    peer.config.neighbor_group = if op == ConfigOp::Set {
+        args.string()
+    } else {
+        None
+    };
+    Some(())
+}
+
 fn config_peer_as(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     if op == ConfigOp::Set {
         if let Some(addr) = args.v4addr() {
@@ -940,6 +955,19 @@ impl Bgp {
         self.callback_add("/router/bgp/global/hostname", config_global_hostname);
         self.callback_peer("", config_peer);
         self.callback_peer("/peer-as", config_peer_as);
+        // Per-peer reference to a `neighbor-group`. Storage only —
+        // resolution lands in the follow-up that adds field-level
+        // override semantics.
+        self.callback_peer("/neighbor-group", config_peer_neighbor_group);
+        // `set router bgp neighbor-groups neighbor-group <name> [...]`.
+        self.callback_add(
+            "/router/bgp/neighbor-groups/neighbor-group",
+            super::neighbor_group::config_neighbor_group,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-groups/neighbor-group/peer-as",
+            super::neighbor_group::config_neighbor_group_peer_as,
+        );
         self.callback_peer("/local-identifier", config_local_identifier);
         self.callback_peer("/transport/passive-mode", config_transport_passive);
         self.callback_peer("/transport/local-address", config_transport_local_address);

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -149,6 +149,14 @@ pub struct Bgp {
     // by config callbacks for /key-chains/... and referenced from a
     // peer's AoConfig.key_chain leafref.
     pub key_chains: HashMap<String, super::auth::KeyChain>,
+
+    /// IOS-XR-style `neighbor-group` definitions
+    /// (zebra-bgp-neighbor-group.yang). Phase-1 storage: each entry
+    /// holds the group's overridable defaults; field-level
+    /// inheritance into peers that reference a group via
+    /// `PeerConfig::neighbor_group` is not wired in the runtime
+    /// yet — that lands in a follow-up.
+    pub neighbor_groups: BTreeMap<String, super::neighbor_group::NeighborGroup>,
     /// Debug configuration flags
     pub debug_flags: BgpDebugFlags,
     pub policy_tx: UnboundedSender<policy::Message>,
@@ -202,6 +210,7 @@ impl Bgp {
             listen_fd_v4: None,
             listen_fd_v6: None,
             key_chains: HashMap::new(),
+            neighbor_groups: super::neighbor_group::empty_map(),
             debug_flags: BgpDebugFlags::default(),
             policy_tx,
             policy_rx: policy_chan.rx,

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -6,6 +6,7 @@ pub use constant::*;
 
 pub mod auth;
 pub mod config;
+pub mod neighbor_group;
 pub mod peer;
 pub mod peer_map;
 pub mod show;

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -1,0 +1,63 @@
+//! IOS-XR-style BGP `neighbor-group` (zebra-bgp-neighbor-group.yang).
+//!
+//! Phase 1 (this commit): schema + storage only. Each
+//! `set router bgp neighbor-groups neighbor-group <name> peer-as <asn>`
+//! lands here; each `set router bgp neighbor <addr> neighbor-group <g>`
+//! records the per-peer reference. The runtime does NOT yet resolve
+//! field-level inheritance — peers continue to use values set
+//! explicitly on the neighbor (and zero / default for the rest).
+//! Field-level override resolution is a follow-up.
+//!
+//! Naming-wise this sits alongside the existing
+//! `peer-groups/peer-group` schema, not on top of it: a peer can
+//! reference exactly one of (neighbor-group, peer-group) — for now
+//! the runtime ignores both, and the future resolver will pick
+//! one.
+
+use std::collections::BTreeMap;
+
+use super::Bgp;
+use crate::config::{Args, ConfigOp};
+
+#[derive(Debug, Default, Clone)]
+pub struct NeighborGroup {
+    pub peer_as: Option<u32>,
+}
+
+/// `set router bgp neighbor-groups neighbor-group <name>` — list-key
+/// callback. Creates the entry on `Set` and removes it on `Delete`.
+pub fn config_neighbor_group(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    match op {
+        ConfigOp::Set => {
+            bgp.neighbor_groups.entry(name).or_default();
+        }
+        ConfigOp::Delete => {
+            bgp.neighbor_groups.remove(&name);
+        }
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp neighbor-groups neighbor-group <name> peer-as <asn>`.
+pub fn config_neighbor_group_peer_as(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let group = bgp.neighbor_groups.entry(name).or_default();
+    match op {
+        ConfigOp::Set => {
+            group.peer_as = Some(args.u32()?);
+        }
+        ConfigOp::Delete => {
+            group.peer_as = None;
+        }
+        _ => {}
+    }
+    Some(())
+}
+
+/// Empty initialiser for the per-Bgp neighbor-group map. Centralised
+/// so `Bgp::new` doesn't need to know the storage type.
+pub fn empty_map() -> BTreeMap<String, NeighborGroup> {
+    BTreeMap::new()
+}

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -171,6 +171,12 @@ pub struct PeerConfig {
     pub soft_reconfig_in: bool,
     pub timer: timer::Config,
     pub sub: BTreeMap<AfiSafi, PeerSubConfig>,
+    /// Reference to a `neighbor-group` (zebra-bgp-neighbor-group.yang)
+    /// whose attributes this peer should inherit. Recorded on
+    /// `set router bgp neighbor <addr> neighbor-group <name>`. The
+    /// runtime stores the reference but does not yet resolve
+    /// inheritance — that's a follow-up.
+    pub neighbor_group: Option<String>,
 }
 
 impl Default for PeerConfig {
@@ -187,6 +193,7 @@ impl Default for PeerConfig {
             soft_reconfig_in: Default::default(),
             timer: Default::default(),
             sub: Default::default(),
+            neighbor_group: None,
         }
     }
 }

--- a/zebra-rs/yang/configure.yang
+++ b/zebra-rs/yang/configure.yang
@@ -30,6 +30,10 @@ module configure {
     prefix zbc;
   }
 
+  import zebra-bgp-neighbor-group {
+    prefix zbng;
+  }
+
   container set {
     ext:help "Set configuration";
     uses "config:config";

--- a/zebra-rs/yang/zebra-bgp-neighbor-group.yang
+++ b/zebra-rs/yang/zebra-bgp-neighbor-group.yang
@@ -1,0 +1,133 @@
+module zebra-bgp-neighbor-group {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-neighbor-group";
+  prefix "zbng";
+
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "IOS-XR-style `neighbor-group` for zebra-rs BGP. Sits alongside
+     the existing `peer-groups/peer-group` with a deliberately
+     focused attribute surface — the goal is to make the common
+     'these N peers share these few attributes' case ergonomic,
+     not to mirror every leaf of `neighbor-group-config`.
+
+     This first cut exposes only `peer-as`. The runtime currently
+     stores the group definition and per-neighbor reference but
+     does NOT yet resolve inheritance — that lands in a follow-up.
+     Field-level override semantics: any field set explicitly on
+     the neighbor wins; otherwise the neighbor inherits from the
+     referenced group.
+
+     Resulting CLI / config shape (target):
+
+       router bgp {
+         neighbor-groups {
+           neighbor-group RR-CLIENTS {
+             peer-as 65000;
+           }
+         }
+         neighbor 10.0.0.1 {
+           neighbor-group RR-CLIENTS;
+         }
+         neighbor 10.0.0.2 {
+           neighbor-group RR-CLIENTS;
+         }
+       }
+
+     The reference leaf accepts a plain string (not a leafref) so
+     a `neighbor X { neighbor-group G; }` block is path-valid even
+     before `neighbor-group G` has been declared — the same
+     staging-friendly pattern other zebra-bgp-* augments use.";
+
+  grouping bgp-neighbor-groups-extension {
+    description
+      "Top-level `neighbor-groups` container hung off `router bgp`.";
+    container neighbor-groups {
+      ext:help "BGP neighbor-groups (IOS-XR style)";
+      list neighbor-group {
+        key "name";
+        description
+          "List of BGP neighbor-groups configured on the local
+           system, uniquely identified by name.";
+        leaf name {
+          type string;
+          description
+            "Name of the neighbor-group.";
+        }
+        leaf peer-as {
+          type inet:as-number;
+          description
+            "AS number inherited by neighbors that reference this
+             group. A `peer-as` set on the neighbor itself wins.";
+        }
+      }
+    }
+  }
+
+  grouping bgp-neighbor-attach-extension {
+    description
+      "Per-neighbor reference leaf attaching the neighbor to a
+       neighbor-group.";
+    leaf neighbor-group {
+      type string;
+      description
+        "Name of the `neighbor-group` whose attributes this
+         neighbor inherits. Resolved at config commit; per-leaf
+         values set on the neighbor override the group.";
+    }
+  }
+
+  augment "/configure:set/config:router/bgp:bgp" {
+    description
+      "Attach the `neighbor-groups` container to `router bgp` in
+       the candidate-set subtree.";
+    uses bgp-neighbor-groups-extension;
+  }
+
+  augment "/configure:delete/config:router/bgp:bgp" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp neighbor-groups neighbor-group X` is
+       path-valid.";
+    uses bgp-neighbor-groups-extension;
+  }
+
+  augment "/configure:set/config:router/bgp:bgp/bgp:neighbor" {
+    description
+      "Attach the `neighbor-group` reference leaf to each BGP
+       neighbor entry in the candidate-set subtree.";
+    uses bgp-neighbor-attach-extension;
+  }
+
+  augment "/configure:delete/config:router/bgp:bgp/bgp:neighbor" {
+    description
+      "Same attachment for the delete subtree.";
+    uses bgp-neighbor-attach-extension;
+  }
+}


### PR DESCRIPTION
## Summary
- New YANG augment `zebra-bgp-neighbor-group.yang` adds `router bgp neighbor-groups neighbor-group <name> { peer-as }` and a per-neighbor `neighbor-group` reference leaf, IOS-XR style. `configure.yang` imports it so libyang loads it.
- New `bgp/neighbor_group.rs` stores `NeighborGroup { peer_as }` keyed by name on `Bgp`. `PeerConfig` gains a `neighbor_group: Option<String>` reference. Three callbacks wired up in `callback_build`.
- Schema + storage only — peers still take their `peer-as` from the explicit `set neighbor X peer-as Y`. Field-level inheritance from group → peer, cascaded re-resolution on group edits, additional inheritable fields, and BDD coverage all land in follow-ups.

## Test plan
- [x] `cargo build --release` clean
- [x] `cargo clippy --workspace` clean
- [x] `cargo test --workspace` clean
- [x] `cargo fmt --all` clean
- [x] vtyhelper smoke test: `set router bgp ?` shows `neighbor-groups`, `set router bgp neighbor-groups neighbor-group RR ?` exposes `peer-as`, `set router bgp neighbor 1.2.3.4 ?` exposes `neighbor-group`

Generated with [Claude Code](https://claude.com/claude-code)