### PR TITLE
policy: speed up prefix-set match with per-family radix trie

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -3240,7 +3240,7 @@ mod policy_apply_tests {
     #[test]
     fn match_next_hop_set() {
         let mut next_hop = PrefixSet::default();
-        next_hop.prefixes.insert(
+        next_hop.insert(
             Ipv4Net::from_str("10.0.0.0/8").unwrap().into(),
             PrefixSetEntry::default(),
         );

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -604,9 +604,7 @@ mod tests {
         // Create a prefix-set named "pset" with prefix 1.1.1.1/32
         let mut prefix_set = PrefixSet::default();
         let prefix = Ipv4Net::from_str("1.1.1.1/32").unwrap();
-        prefix_set
-            .prefixes
-            .insert(prefix.into(), PrefixSetEntry::default());
+        prefix_set.insert(prefix.into(), PrefixSetEntry::default());
 
         // Create a policy-list with entry that matches "pset" and has action accept (permit)
         let mut plist = PolicyList::default();
@@ -629,8 +627,8 @@ mod tests {
         }
 
         // Verify prefix-set contains the correct prefix
-        assert_eq!(prefix_set.prefixes.len(), 1);
-        assert!(prefix_set.prefixes.contains_key(&prefix.into()));
+        assert_eq!(prefix_set.len(), 1);
+        assert!(prefix_set.contains_prefix(&prefix.into()));
 
         // Note: Default deny behavior is implicit - if no entry matches,
         // the policy should deny by default (this would be implemented

--- a/zebra-rs/src/policy/prefix/BENCHMARKS.md
+++ b/zebra-rs/src/policy/prefix/BENCHMARKS.md
@@ -1,0 +1,62 @@
+# prefix-set match performance
+
+Benchmark of `PrefixSet::matches()` after switching from a linear scan
+over a `BTreeMap<IpNet, _>` to a per-family binary radix trie
+(`PrefixTrie`) keyed on MSB-aligned bits.
+
+## Results
+
+10,000 IPv4 `/32` queries against a set of `n` IPv4 `/24` prefixes,
+release build. Both columns produce the same hit count (40), confirming
+algorithmic equivalence.
+
+| Set size  | Linear scan | Trie        | Speedup     |
+| --------- | ----------- | ----------- | ----------- |
+| 100       | 2.26 ms     | 59 µs       | 38×         |
+| 1,000     | 23.3 ms     | 30 µs       | 771×        |
+| 10,000    | 234 ms      | 32 µs       | 7,282×      |
+| 100,000   | 2.60 s      | 34 µs       | 75,492×     |
+
+The trie time is essentially flat across set sizes because lookup depth
+is bounded by the prefix length (≤32 for IPv4, ≤128 for IPv6) regardless
+of `n`. The linear scan grows linearly with `n`, exactly as the original
+O(n) algorithm predicts.
+
+## Complexity
+
+| Operation        | Old (linear)        | New (trie)                 |
+| ---------------- | ------------------- | -------------------------- |
+| `matches()`      | O(n)                | O(L + k · log n)           |
+| `insert/remove`  | O(log n)            | O(L + log n)               |
+
+Where:
+- `n` = number of prefixes in the set
+- `L` = prefix length of the query (≤32 for v4, ≤128 for v6)
+- `k` = number of enclosing prefixes encountered along the trie walk
+  (typically ≤ `L`, in practice much smaller)
+
+The `log n` term in the new `matches()` comes from the `BTreeMap::get`
+done for each enclosing prefix to fetch its `le/eq/ge` entry; the trie
+itself only stores key markers.
+
+## Reproducing
+
+The benchmark lives as an `#[ignore]`d test inside
+`zebra-rs/src/policy/prefix/set.rs` (`bench_matches_vs_linear_scan`).
+Run it with:
+
+```
+cargo test --release --bin zebra-rs -- \
+    --ignored --nocapture bench_matches_vs_linear_scan
+```
+
+The test asserts that the trie and the in-place reference linear scan
+return identical hit counts for every workload, so any regression in
+correctness will fail the test rather than silently affect the timings.
+
+## Environment
+
+- CPU: aarch64, 4 cores
+- Kernel: Linux 6.8.0
+- Toolchain: rustc 1.95.0 (release profile)
+- Date: 2026-05-07

--- a/zebra-rs/src/policy/prefix/config.rs
+++ b/zebra-rs/src/policy/prefix/config.rs
@@ -132,13 +132,13 @@ impl ConfigBuilder {
             .set(|config, cache, name, args| {
                 let prefix = args.net().context(PREFIX_ERR)?;
                 let set = cache_get(config, cache, name).context(CONFIG_ERR)?;
-                let _entry = set.prefixes.entry(prefix).or_default();
+                let _entry = set.entry(prefix);
                 Ok(())
             })
             .del(|config, cache, name, args| {
                 let prefix = args.net().context(PREFIX_ERR)?;
                 let set = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
-                set.prefixes.remove(&prefix).context(CONFIG_ERR)?;
+                set.remove(&prefix).context(CONFIG_ERR)?;
                 Ok(())
             })
             .path("/prefixes/le")
@@ -147,7 +147,7 @@ impl ConfigBuilder {
                 let le = args.u8().context(LE_ERR)?;
 
                 let set = cache_get(config, cache, name).context(CONFIG_ERR)?;
-                let entry = set.prefixes.entry(prefix).or_default();
+                let entry = set.entry(prefix);
                 entry.le = Some(le);
                 Ok(())
             })
@@ -155,7 +155,7 @@ impl ConfigBuilder {
                 let prefix = args.net().context(PREFIX_ERR)?;
 
                 let set = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
-                let entry = set.prefixes.get_mut(&prefix).context(LE_ERR)?;
+                let entry = set.get_mut(&prefix).context(LE_ERR)?;
                 entry.le = None;
                 Ok(())
             })
@@ -165,7 +165,7 @@ impl ConfigBuilder {
                 let eq = args.u8().context(EQ_ERR)?;
 
                 let set = cache_get(config, cache, name).context(CONFIG_ERR)?;
-                let entry = set.prefixes.entry(prefix).or_default();
+                let entry = set.entry(prefix);
                 entry.eq = Some(eq);
                 Ok(())
             })
@@ -173,7 +173,7 @@ impl ConfigBuilder {
                 let prefix = args.net().context(PREFIX_ERR)?;
 
                 let set = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
-                let entry = set.prefixes.get_mut(&prefix).context(EQ_ERR)?;
+                let entry = set.get_mut(&prefix).context(EQ_ERR)?;
                 entry.eq = None;
                 Ok(())
             })
@@ -183,7 +183,7 @@ impl ConfigBuilder {
                 let ge = args.u8().context(GE_ERR)?;
 
                 let set = cache_get(config, cache, name).context(CONFIG_ERR)?;
-                let entry = set.prefixes.entry(prefix).or_default();
+                let entry = set.entry(prefix);
                 entry.ge = Some(ge);
                 Ok(())
             })
@@ -191,7 +191,7 @@ impl ConfigBuilder {
                 let prefix = args.net().context(PREFIX_ERR)?;
 
                 let set = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
-                let entry = set.prefixes.get_mut(&prefix).context(GE_ERR)?;
+                let entry = set.get_mut(&prefix).context(GE_ERR)?;
                 entry.ge = None;
                 Ok(())
             })

--- a/zebra-rs/src/policy/prefix/mod.rs
+++ b/zebra-rs/src/policy/prefix/mod.rs
@@ -5,3 +5,5 @@ pub mod config;
 pub use config::PrefixSetConfig;
 
 pub mod show;
+
+mod trie;

--- a/zebra-rs/src/policy/prefix/set.rs
+++ b/zebra-rs/src/policy/prefix/set.rs
@@ -1,10 +1,15 @@
 use std::collections::BTreeMap;
+use std::collections::btree_map;
 
 use ipnet::IpNet;
 
-#[derive(Default, Clone, Debug, PartialEq)]
+use super::trie::{PrefixTrie, ipnet_to_bits, truncate_prefix};
+
+#[derive(Default, Clone, Debug)]
 pub struct PrefixSet {
-    pub prefixes: BTreeMap<IpNet, PrefixSetEntry>,
+    prefixes: BTreeMap<IpNet, PrefixSetEntry>,
+    trie4: PrefixTrie,
+    trie6: PrefixTrie,
     pub delete: bool,
 }
 
@@ -15,52 +20,131 @@ pub struct PrefixSetEntry {
     pub ge: Option<u8>,
 }
 
+impl PartialEq for PrefixSet {
+    fn eq(&self, other: &Self) -> bool {
+        self.prefixes == other.prefixes && self.delete == other.delete
+    }
+}
+
 impl PrefixSet {
+    /// Get a mutable reference to the entry for `prefix`, creating a
+    /// default entry (and registering the prefix in the trie) if
+    /// missing.
+    pub fn entry(&mut self, prefix: IpNet) -> &mut PrefixSetEntry {
+        match self.prefixes.entry(prefix) {
+            btree_map::Entry::Occupied(o) => o.into_mut(),
+            btree_map::Entry::Vacant(v) => {
+                let (bits, len, is_v4) = ipnet_to_bits(prefix);
+                let trie = if is_v4 {
+                    &mut self.trie4
+                } else {
+                    &mut self.trie6
+                };
+                trie.insert(bits, len);
+                v.insert(PrefixSetEntry::default())
+            }
+        }
+    }
+
+    /// Insert (or replace) the entry for `prefix`. Returns the
+    /// previous entry if one existed.
+    #[allow(dead_code)]
+    pub fn insert(&mut self, prefix: IpNet, entry: PrefixSetEntry) -> Option<PrefixSetEntry> {
+        let prev = self.prefixes.insert(prefix, entry);
+        if prev.is_none() {
+            let (bits, len, is_v4) = ipnet_to_bits(prefix);
+            let trie = if is_v4 {
+                &mut self.trie4
+            } else {
+                &mut self.trie6
+            };
+            trie.insert(bits, len);
+        }
+        prev
+    }
+
+    /// Remove `prefix` from the set, returning the removed entry.
+    pub fn remove(&mut self, prefix: &IpNet) -> Option<PrefixSetEntry> {
+        let removed = self.prefixes.remove(prefix);
+        if removed.is_some() {
+            let (bits, len, is_v4) = ipnet_to_bits(*prefix);
+            let trie = if is_v4 {
+                &mut self.trie4
+            } else {
+                &mut self.trie6
+            };
+            trie.remove(bits, len);
+        }
+        removed
+    }
+
+    /// Get a mutable reference to an existing entry without altering
+    /// the set membership.
+    pub fn get_mut(&mut self, prefix: &IpNet) -> Option<&mut PrefixSetEntry> {
+        self.prefixes.get_mut(prefix)
+    }
+
+    pub fn iter(&self) -> btree_map::Iter<'_, IpNet, PrefixSetEntry> {
+        self.prefixes.iter()
+    }
+
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.prefixes.len()
+    }
+
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.prefixes.is_empty()
+    }
+
+    #[allow(dead_code)]
+    pub fn contains_prefix(&self, prefix: &IpNet) -> bool {
+        self.prefixes.contains_key(prefix)
+    }
+
     /// Check if the given IPv4 or IPv6 network matches any prefix in this set.
     ///
     /// A network matches if:
     /// 1. Its network address is contained within a prefix in the set
     /// 2. Its prefix length satisfies the filtering criteria (le, eq, ge) of that prefix
     pub fn matches(&self, net: impl Into<IpNet> + Copy) -> bool {
-        let net_ip: IpNet = net.into();
-        let prefix_len = net_ip.prefix_len();
+        let net: IpNet = net.into();
+        let (bits, qlen, is_v4) = ipnet_to_bits(net);
+        let trie = if is_v4 { &self.trie4 } else { &self.trie6 };
 
-        // Check each prefix in the set
-        for (prefix, entry) in &self.prefixes {
-            // Check if the network's IP is contained within this prefix
-            if prefix.contains(&net_ip) {
-                // Check prefix length constraints
-                let mut matches = true;
-
-                // Check less-than-or-equal constraint
-                if let Some(le) = entry.le
-                    && prefix_len > le
-                {
-                    matches = false;
-                }
-
-                // Check equal constraint
-                if let Some(eq) = entry.eq
-                    && prefix_len != eq
-                {
-                    matches = false;
-                }
-
-                // Check greater-than-or-equal constraint
-                if let Some(ge) = entry.ge
-                    && prefix_len < ge
-                {
-                    matches = false;
-                }
-
-                if matches {
-                    return true;
-                }
+        let mut found = false;
+        trie.walk_enclosing(bits, qlen, |depth| {
+            let key = truncate_prefix(net, depth);
+            if let Some(entry) = self.prefixes.get(&key)
+                && entry_passes(entry, qlen)
+            {
+                found = true;
+                return true;
             }
-        }
-
-        false
+            false
+        });
+        found
     }
+}
+
+fn entry_passes(entry: &PrefixSetEntry, qlen: u8) -> bool {
+    if let Some(le) = entry.le
+        && qlen > le
+    {
+        return false;
+    }
+    if let Some(eq) = entry.eq
+        && qlen != eq
+    {
+        return false;
+    }
+    if let Some(ge) = entry.ge
+        && qlen < ge
+    {
+        return false;
+    }
+    true
 }
 
 #[cfg(test)]
@@ -72,9 +156,7 @@ mod tests {
     fn test_matches_ipv4_no_constraints() {
         let mut prefix_set = PrefixSet::default();
         let prefix = IpNet::from_str("10.0.0.0/8").unwrap();
-        prefix_set
-            .prefixes
-            .insert(prefix, PrefixSetEntry::default());
+        prefix_set.insert(prefix, PrefixSetEntry::default());
 
         // Should match any prefix length within 10.0.0.0/8
         let net1 = IpNet::from_str("10.1.0.0/16").unwrap();
@@ -94,7 +176,7 @@ mod tests {
     fn test_matches_ipv4_with_le_constraint() {
         let mut prefix_set = PrefixSet::default();
         let prefix = IpNet::from_str("10.0.0.0/8").unwrap();
-        prefix_set.prefixes.insert(
+        prefix_set.insert(
             prefix,
             PrefixSetEntry {
                 le: Some(24),
@@ -118,7 +200,7 @@ mod tests {
     fn test_matches_ipv4_with_ge_constraint() {
         let mut prefix_set = PrefixSet::default();
         let prefix = IpNet::from_str("10.0.0.0/8").unwrap();
-        prefix_set.prefixes.insert(
+        prefix_set.insert(
             prefix,
             PrefixSetEntry {
                 le: None,
@@ -142,7 +224,7 @@ mod tests {
     fn test_matches_ipv4_with_eq_constraint() {
         let mut prefix_set = PrefixSet::default();
         let prefix = IpNet::from_str("10.0.0.0/8").unwrap();
-        prefix_set.prefixes.insert(
+        prefix_set.insert(
             prefix,
             PrefixSetEntry {
                 le: None,
@@ -166,7 +248,7 @@ mod tests {
     fn test_matches_ipv4_with_range_constraints() {
         let mut prefix_set = PrefixSet::default();
         let prefix = IpNet::from_str("10.0.0.0/8").unwrap();
-        prefix_set.prefixes.insert(
+        prefix_set.insert(
             prefix,
             PrefixSetEntry {
                 le: Some(24),
@@ -194,7 +276,7 @@ mod tests {
     fn test_matches_ipv6() {
         let mut prefix_set = PrefixSet::default();
         let prefix = IpNet::from_str("2001:db8::/32").unwrap();
-        prefix_set.prefixes.insert(
+        prefix_set.insert(
             prefix,
             PrefixSetEntry {
                 le: Some(64),
@@ -228,7 +310,7 @@ mod tests {
 
         // Add first prefix with constraints
         let prefix1 = IpNet::from_str("10.0.0.0/8").unwrap();
-        prefix_set.prefixes.insert(
+        prefix_set.insert(
             prefix1,
             PrefixSetEntry {
                 le: Some(24),
@@ -239,7 +321,7 @@ mod tests {
 
         // Add second prefix with different constraints
         let prefix2 = IpNet::from_str("192.168.0.0/16").unwrap();
-        prefix_set.prefixes.insert(
+        prefix_set.insert(
             prefix2,
             PrefixSetEntry {
                 le: None,
@@ -273,9 +355,7 @@ mod tests {
     fn test_prefix_containment() {
         let mut prefix_set = PrefixSet::default();
         let prefix = IpNet::from_str("10.1.0.0/16").unwrap();
-        prefix_set
-            .prefixes
-            .insert(prefix, PrefixSetEntry::default());
+        prefix_set.insert(prefix, PrefixSetEntry::default());
 
         // Should match - contained within 10.1.0.0/16
         let net1 = IpNet::from_str("10.1.2.0/24").unwrap();
@@ -288,5 +368,160 @@ mod tests {
         // Should match - exact match
         let net3 = IpNet::from_str("10.1.0.0/16").unwrap();
         assert!(prefix_set.matches(net3));
+    }
+
+    #[test]
+    fn test_overlapping_enclosing_prefixes_pick_first_passing() {
+        // /8 has le=15 (rejects /24); /16 has no constraint (accepts).
+        // Trie walk visits /8 then /16; the matcher must keep walking
+        // past the /8 rejection and accept on /16.
+        let mut prefix_set = PrefixSet::default();
+        prefix_set.insert(
+            IpNet::from_str("10.0.0.0/8").unwrap(),
+            PrefixSetEntry {
+                le: Some(15),
+                eq: None,
+                ge: None,
+            },
+        );
+        prefix_set.insert(
+            IpNet::from_str("10.1.0.0/16").unwrap(),
+            PrefixSetEntry::default(),
+        );
+
+        let q = IpNet::from_str("10.1.2.0/24").unwrap();
+        assert!(prefix_set.matches(q));
+    }
+
+    #[test]
+    fn test_remove_unindexes() {
+        let mut prefix_set = PrefixSet::default();
+        let prefix = IpNet::from_str("10.0.0.0/8").unwrap();
+        prefix_set.insert(prefix, PrefixSetEntry::default());
+
+        let q = IpNet::from_str("10.1.0.0/16").unwrap();
+        assert!(prefix_set.matches(q));
+
+        prefix_set.remove(&prefix);
+        assert!(!prefix_set.matches(q));
+    }
+
+    #[test]
+    fn test_v4_and_v6_isolated() {
+        // The IPv4 trie must not be consulted for IPv6 queries and
+        // vice versa, even when the bit patterns look similar.
+        let mut prefix_set = PrefixSet::default();
+        prefix_set.insert(
+            IpNet::from_str("10.0.0.0/8").unwrap(),
+            PrefixSetEntry::default(),
+        );
+        let v6_q = IpNet::from_str("a00::/8").unwrap();
+        assert!(!prefix_set.matches(v6_q));
+    }
+
+    #[test]
+    fn test_zero_prefix_root_matches_anything() {
+        let mut prefix_set = PrefixSet::default();
+        prefix_set.insert(
+            IpNet::from_str("0.0.0.0/0").unwrap(),
+            PrefixSetEntry::default(),
+        );
+        for net in &["10.0.0.0/8", "0.0.0.0/0", "192.168.1.1/32"] {
+            assert!(prefix_set.matches(IpNet::from_str(net).unwrap()));
+        }
+    }
+
+    /// Reference implementation matching the previous O(n) linear
+    /// scan, kept here so the benchmark below compares apples-to-
+    /// apples on identical data.
+    fn matches_linear(set: &PrefixSet, net: IpNet) -> bool {
+        let qlen = net.prefix_len();
+        for (prefix, entry) in set.iter() {
+            if !prefix.contains(&net) {
+                continue;
+            }
+            if let Some(le) = entry.le
+                && qlen > le
+            {
+                continue;
+            }
+            if let Some(eq) = entry.eq
+                && qlen != eq
+            {
+                continue;
+            }
+            if let Some(ge) = entry.ge
+                && qlen < ge
+            {
+                continue;
+            }
+            return true;
+        }
+        false
+    }
+
+    /// Run with: `cargo test --release --bin zebra-rs -- --ignored
+    /// --nocapture bench_matches_vs_linear_scan`
+    #[test]
+    #[ignore]
+    fn bench_matches_vs_linear_scan() {
+        use std::net::Ipv4Addr;
+        use std::time::Instant;
+
+        for &n in &[100usize, 1_000, 10_000, 100_000] {
+            // Build a set of /24s spread across the IPv4 space.
+            let mut set = PrefixSet::default();
+            for i in 0..n {
+                let a = ((i >> 16) & 0xff) as u8;
+                let b = ((i >> 8) & 0xff) as u8;
+                let c = (i & 0xff) as u8;
+                let prefix: IpNet = ipnet::Ipv4Net::new(Ipv4Addr::new(a, b, c, 0), 24)
+                    .unwrap()
+                    .into();
+                set.insert(prefix, PrefixSetEntry::default());
+            }
+
+            // Pick a deterministic mix of hits and misses.
+            let queries: Vec<IpNet> = (0..10_000)
+                .map(|i| {
+                    let a = ((i * 7919) & 0xff) as u8;
+                    let b = ((i * 31) & 0xff) as u8;
+                    let c = ((i * 17) & 0xff) as u8;
+                    ipnet::Ipv4Net::new(Ipv4Addr::new(a, b, c, 1), 32)
+                        .unwrap()
+                        .into()
+                })
+                .collect();
+
+            let start = Instant::now();
+            let mut hits_trie = 0usize;
+            for q in &queries {
+                if set.matches(*q) {
+                    hits_trie += 1;
+                }
+            }
+            let trie_elapsed = start.elapsed();
+
+            let start = Instant::now();
+            let mut hits_linear = 0usize;
+            for q in &queries {
+                if matches_linear(&set, *q) {
+                    hits_linear += 1;
+                }
+            }
+            let linear_elapsed = start.elapsed();
+
+            assert_eq!(hits_trie, hits_linear, "trie and linear must agree");
+            let speedup = linear_elapsed.as_nanos() as f64 / trie_elapsed.as_nanos().max(1) as f64;
+            println!(
+                "n={:>6}  queries={}  hits={:>5}  linear={:>10?}  trie={:>10?}  speedup={:.1}x",
+                n,
+                queries.len(),
+                hits_trie,
+                linear_elapsed,
+                trie_elapsed,
+                speedup,
+            );
+        }
     }
 }

--- a/zebra-rs/src/policy/prefix/show.rs
+++ b/zebra-rs/src/policy/prefix/show.rs
@@ -10,7 +10,7 @@ pub fn prefix_set(policy: &Policy, _args: Args, _json: bool) -> Result<String, E
     // Iterate through all prefix-sets
     for (name, set) in policy.prefix_config.config.iter() {
         writeln!(buf, "prefix-set: {}", name)?;
-        for (prefix, entry) in set.prefixes.iter() {
+        for (prefix, entry) in set.iter() {
             write!(buf, "  {}", prefix)?;
             if let Some(le) = entry.le {
                 write!(buf, " le {}", le)?;
@@ -45,7 +45,7 @@ pub fn prefix_set_name(policy: &Policy, mut args: Args, _json: bool) -> Result<S
     writeln!(buf, "prefix-set: {}", name)?;
 
     // Show all prefixes in this set
-    for (prefix, entry) in set.prefixes.iter() {
+    for (prefix, entry) in set.iter() {
         write!(buf, "  {}", prefix)?;
         if let Some(le) = entry.le {
             write!(buf, " le {}", le)?;

--- a/zebra-rs/src/policy/prefix/trie.rs
+++ b/zebra-rs/src/policy/prefix/trie.rs
@@ -1,0 +1,254 @@
+use ipnet::IpNet;
+
+/// Binary radix trie for IP prefixes.
+///
+/// Each path from the root spells out a prefix bit-by-bit (left = 0,
+/// right = 1). A node with `stored = true` denotes that the prefix
+/// terminating at that depth is a member of the set.
+///
+/// Addresses are normalized to MSB-aligned `u128`: an IPv4 address sits
+/// in the top 32 bits, an IPv6 address fills all 128 bits. At depth
+/// `d` (zero-indexed) the consulted bit is `(bits >> (127 - d)) & 1`.
+#[derive(Default, Clone, Debug)]
+pub struct PrefixTrie {
+    root: Box<TrieNode>,
+}
+
+#[derive(Default, Clone, Debug)]
+struct TrieNode {
+    children: [Option<Box<TrieNode>>; 2],
+    stored: bool,
+}
+
+impl TrieNode {
+    fn is_dead(&self) -> bool {
+        !self.stored && self.children[0].is_none() && self.children[1].is_none()
+    }
+}
+
+impl PrefixTrie {
+    pub fn insert(&mut self, bits: u128, len: u8) {
+        let mut node = self.root.as_mut();
+        for d in 0..len {
+            let b = bit_at(bits, d) as usize;
+            node = node.children[b].get_or_insert_with(Box::<TrieNode>::default);
+        }
+        node.stored = true;
+    }
+
+    pub fn remove(&mut self, bits: u128, len: u8) {
+        remove_rec(&mut self.root, bits, len, 0);
+    }
+
+    /// Walk the trie along the path described by `bits`/`len`. Whenever
+    /// a stored node is encountered (including depth 0 for a `/0` and
+    /// depth `len` for an exact match), invoke `callback(depth)`. If
+    /// the callback returns `true`, the walk stops.
+    pub fn walk_enclosing<F>(&self, bits: u128, len: u8, mut callback: F)
+    where
+        F: FnMut(u8) -> bool,
+    {
+        let mut node = self.root.as_ref();
+        for d in 0..=len {
+            if node.stored && callback(d) {
+                return;
+            }
+            if d == len {
+                break;
+            }
+            let b = bit_at(bits, d) as usize;
+            match node.children[b].as_deref() {
+                Some(child) => node = child,
+                None => return,
+            }
+        }
+    }
+}
+
+fn remove_rec(node: &mut Box<TrieNode>, bits: u128, len: u8, depth: u8) -> bool {
+    if depth == len {
+        node.stored = false;
+    } else {
+        let b = bit_at(bits, depth) as usize;
+        if let Some(child) = node.children[b].as_mut()
+            && remove_rec(child, bits, len, depth + 1)
+        {
+            node.children[b] = None;
+        }
+    }
+    node.is_dead()
+}
+
+#[inline]
+fn bit_at(bits: u128, depth: u8) -> u8 {
+    ((bits >> (127 - depth)) & 1) as u8
+}
+
+/// Convert an `IpNet` to (MSB-aligned bits, prefix length) and the
+/// family flag (`true` for IPv4).
+pub fn ipnet_to_bits(net: IpNet) -> (u128, u8, bool) {
+    match net {
+        IpNet::V4(n) => ((u32::from(n.network()) as u128) << 96, n.prefix_len(), true),
+        IpNet::V6(n) => (u128::from(n.network()), n.prefix_len(), false),
+    }
+}
+
+/// Build the IpNet that corresponds to taking the first `depth` bits
+/// from the given query network.
+pub fn truncate_prefix(net: IpNet, depth: u8) -> IpNet {
+    match net {
+        IpNet::V4(n) => ipnet::Ipv4Net::new(n.network(), depth)
+            .expect("depth <= 32 for v4")
+            .trunc()
+            .into(),
+        IpNet::V6(n) => ipnet::Ipv6Net::new(n.network(), depth)
+            .expect("depth <= 128 for v6")
+            .trunc()
+            .into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn bits_of(net_str: &str) -> (u128, u8) {
+        let net = IpNet::from_str(net_str).unwrap();
+        let (b, l, _) = ipnet_to_bits(net);
+        (b, l)
+    }
+
+    #[test]
+    fn insert_and_walk_v4() {
+        let mut trie = PrefixTrie::default();
+        let (b, l) = bits_of("10.0.0.0/8");
+        trie.insert(b, l);
+
+        let (q, ql) = bits_of("10.1.2.0/24");
+        let mut hits = vec![];
+        trie.walk_enclosing(q, ql, |d| {
+            hits.push(d);
+            false
+        });
+        assert_eq!(hits, vec![8]);
+    }
+
+    #[test]
+    fn walk_collects_all_enclosing() {
+        let mut trie = PrefixTrie::default();
+        for p in &["0.0.0.0/0", "10.0.0.0/8", "10.1.0.0/16", "10.1.2.0/24"] {
+            let (b, l) = bits_of(p);
+            trie.insert(b, l);
+        }
+        let (q, ql) = bits_of("10.1.2.128/25");
+        let mut hits = vec![];
+        trie.walk_enclosing(q, ql, |d| {
+            hits.push(d);
+            false
+        });
+        assert_eq!(hits, vec![0, 8, 16, 24]);
+    }
+
+    #[test]
+    fn walk_short_circuits() {
+        let mut trie = PrefixTrie::default();
+        for p in &["0.0.0.0/0", "10.0.0.0/8", "10.1.0.0/16"] {
+            let (b, l) = bits_of(p);
+            trie.insert(b, l);
+        }
+        let (q, ql) = bits_of("10.1.2.0/24");
+        let mut hits = vec![];
+        trie.walk_enclosing(q, ql, |d| {
+            hits.push(d);
+            d >= 8
+        });
+        assert_eq!(hits, vec![0, 8]);
+    }
+
+    #[test]
+    fn remove_clears_marker_and_trims() {
+        let mut trie = PrefixTrie::default();
+        let (b, l) = bits_of("10.1.0.0/16");
+        trie.insert(b, l);
+        trie.remove(b, l);
+
+        let (q, ql) = bits_of("10.1.2.0/24");
+        let mut hits = 0;
+        trie.walk_enclosing(q, ql, |_| {
+            hits += 1;
+            false
+        });
+        assert_eq!(hits, 0);
+    }
+
+    #[test]
+    fn remove_keeps_other_branches() {
+        let mut trie = PrefixTrie::default();
+        for p in &["10.0.0.0/8", "10.1.0.0/16"] {
+            let (b, l) = bits_of(p);
+            trie.insert(b, l);
+        }
+        let (b, l) = bits_of("10.1.0.0/16");
+        trie.remove(b, l);
+
+        let (q, ql) = bits_of("10.1.2.0/24");
+        let mut hits = vec![];
+        trie.walk_enclosing(q, ql, |d| {
+            hits.push(d);
+            false
+        });
+        assert_eq!(hits, vec![8]);
+    }
+
+    #[test]
+    fn ipv6_walk() {
+        let mut trie = PrefixTrie::default();
+        for p in &["2001:db8::/32", "2001:db8:1::/48"] {
+            let net = IpNet::from_str(p).unwrap();
+            let (b, l, _) = ipnet_to_bits(net);
+            trie.insert(b, l);
+        }
+        let net = IpNet::from_str("2001:db8:1:2::/64").unwrap();
+        let (q, ql, _) = ipnet_to_bits(net);
+        let mut hits = vec![];
+        trie.walk_enclosing(q, ql, |d| {
+            hits.push(d);
+            false
+        });
+        assert_eq!(hits, vec![32, 48]);
+    }
+
+    #[test]
+    fn root_zero_prefix_matches_all() {
+        let mut trie = PrefixTrie::default();
+        let (b, l) = bits_of("0.0.0.0/0");
+        trie.insert(b, l);
+        let (q, ql) = bits_of("192.168.1.0/24");
+        let mut hits = vec![];
+        trie.walk_enclosing(q, ql, |d| {
+            hits.push(d);
+            false
+        });
+        assert_eq!(hits, vec![0]);
+    }
+
+    #[test]
+    fn truncate_v4_and_v6() {
+        let q = IpNet::from_str("10.1.2.128/25").unwrap();
+        assert_eq!(
+            truncate_prefix(q, 8),
+            IpNet::from_str("10.0.0.0/8").unwrap()
+        );
+        assert_eq!(
+            truncate_prefix(q, 24),
+            IpNet::from_str("10.1.2.0/24").unwrap()
+        );
+
+        let q = IpNet::from_str("2001:db8:1:2::/64").unwrap();
+        assert_eq!(
+            truncate_prefix(q, 32),
+            IpNet::from_str("2001:db8::/32").unwrap()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `PrefixSet::matches()` was an O(n) linear scan over a `BTreeMap<IpNet, _>`. With large prefix-sets this dominates BGP policy evaluation per route.
- Replace it with a binary radix `PrefixTrie` per address family (IPv4, IPv6). Walk depth is bounded by the query's prefix length (≤32 / ≤128), so lookups are effectively constant in `n`.
- `PrefixSet`'s `prefixes` field is now private; mutations go through `entry / insert / remove / get_mut`, which keep the trie in sync with the canonical `BTreeMap`.

## Performance

10,000 IPv4 `/32` queries against `n` IPv4 `/24` prefixes (release, aarch64). Both implementations produce identical hit counts.

| Set size  | Linear scan | Trie  | Speedup    |
| --------- | ----------- | ----- | ---------- |
| 100       | 2.26 ms     | 59 µs | 38×        |
| 1,000     | 23.3 ms     | 30 µs | 771×       |
| 10,000    | 234 ms      | 32 µs | 7,282×     |
| 100,000   | 2.60 s      | 34 µs | 75,492×    |

Full numbers and reproduction in `zebra-rs/src/policy/prefix/BENCHMARKS.md`.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] `cargo test --bin zebra-rs` — 205 passed, including 11 new prefix-set / trie tests covering overlap fall-through, `/0` root, v4/v6 isolation, remove un-indexing
- [x] `cargo test --release -- --ignored bench_matches_vs_linear_scan` — trie and linear scan return identical hit counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)