### PR TITLE
bgp: share outbound policy + transform per update-group (Phase 2)

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -80,6 +80,7 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
             tx: &bgp.tx,
             rib_tx: &bgp.rib_tx,
             attr_store: &mut bgp.attr_store,
+            update_groups: &mut bgp.update_groups,
         };
         route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers);
         bgp.peers.remove(&addr);

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -371,15 +371,10 @@ impl Bgp {
                     tx: &self.tx,
                     rib_tx: &self.rib_tx,
                     attr_store: &mut self.attr_store,
+                    update_groups: &mut self.update_groups,
                 };
 
-                fsm(
-                    &mut bgp_ref,
-                    &mut self.peers,
-                    &mut self.update_groups,
-                    ident,
-                    event,
-                );
+                fsm(&mut bgp_ref, &mut self.peers, ident, event);
             }
             Message::Accept(socket, sockaddr) => {
                 // println!("Accept: {:?}", sockaddr);

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -489,6 +489,7 @@ pub struct BgpTop<'a> {
     pub tx: &'a mpsc::Sender<Message>,
     pub rib_tx: &'a UnboundedSender<rib::Message>,
     pub attr_store: &'a mut BgpAttrStore,
+    pub update_groups: &'a mut super::update_group::UpdateGroupMap,
 }
 
 pub fn fsm_next_state(peer: &mut Peer, event: Event) -> (State, FsmEffect) {
@@ -540,13 +541,7 @@ fn fsm_effect(id: usize, effect: FsmEffect, bgp: &mut BgpTop, peers: &mut PeerMa
     }
 }
 
-pub fn fsm(
-    bgp_ref: &mut BgpTop,
-    peer_map: &mut PeerMap,
-    update_groups: &mut super::update_group::UpdateGroupMap,
-    id: usize,
-    event: Event,
-) {
+pub fn fsm(bgp_ref: &mut BgpTop, peer_map: &mut PeerMap, id: usize, event: Event) {
     // Phase 1: Compute new state (single match, only &mut Peer)
     let (prev_state, effect) = {
         let peer = peer_map.get_mut_by_idx(id).unwrap();
@@ -591,9 +586,9 @@ pub fn fsm(
             .map(|p| p.state.is_established())
             .unwrap_or(false);
         if prev_state.is_established() && !now_established {
-            super::update_group::detach(update_groups, peer_map, id);
+            super::update_group::detach(bgp_ref.update_groups, peer_map, id);
         } else if !prev_state.is_established() && now_established {
-            super::update_group::attach(update_groups, peer_map, id);
+            super::update_group::attach(bgp_ref.update_groups, peer_map, id);
         }
     }
 }
@@ -1169,6 +1164,7 @@ pub fn apply_soft_in_peer(bgp: &mut Bgp, peer_idx: usize) {
             tx: &bgp.tx,
             rib_tx: &bgp.rib_tx,
             attr_store: &mut bgp.attr_store,
+            update_groups: &mut bgp.update_groups,
         };
         super::route::route_soft_in_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
     } else if supports_refresh {
@@ -1196,6 +1192,7 @@ pub fn apply_soft_out_peer(bgp: &mut Bgp, peer_idx: usize) {
         tx: &bgp.tx,
         rib_tx: &bgp.rib_tx,
         attr_store: &mut bgp.attr_store,
+        update_groups: &mut bgp.update_groups,
     };
     super::route::route_soft_out_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -798,6 +798,62 @@ fn route_withdraw_from_addpath(
 }
 
 /// Advertise route changes to all appropriate peers
+/// Outcome of running the canonical-member transform + outbound
+/// policy for a route. Identical for every member of an
+/// `update-group` for a given (route, AFI/SAFI), modulo per-peer
+/// split-horizon (handled before cache lookup) and per-peer RTC
+/// (applied after).
+#[derive(Clone)]
+enum AdvertiseOutcome {
+    Advertise(Ipv4Nlri, BgpAttr),
+    Withdraw,
+}
+
+/// Run `route_update_ipv4` + `route_apply_policy_out` for `peer`.
+/// Caller has already verified split-horizon does NOT fire for this
+/// peer (`best.ident != peer.ident`); other filters inside
+/// `route_update_ipv4` (notably the iBGP-iBGP rule) depend only on
+/// signature fields, so the result is identical for every other
+/// non-source member of the same update-group.
+fn compute_advertise_outcome(
+    peer: &mut Peer,
+    prefix: &Ipv4Net,
+    best: &BgpRib,
+    bgp: &mut BgpTop,
+    add_path: bool,
+) -> AdvertiseOutcome {
+    if let Some((nlri, attr)) = route_update_ipv4(peer, prefix, best, bgp, add_path) {
+        if let Some(attr) = route_apply_policy_out(peer, &nlri, attr) {
+            AdvertiseOutcome::Advertise(nlri, attr)
+        } else {
+            AdvertiseOutcome::Withdraw
+        }
+    } else {
+        AdvertiseOutcome::Withdraw
+    }
+}
+
+/// Bump per-group counters for one cache miss. `denied` is true when
+/// the computed outcome was `Withdraw` because the outbound policy
+/// returned None — distinguishes deny-by-policy from skip-by-no-best.
+fn bump_group_counters_on_miss(
+    bgp: &mut BgpTop,
+    afi_safi: AfiSafi,
+    id: &super::update_group::UpdateGroupId,
+    denied: bool,
+) {
+    let Some(af) = bgp.update_groups.get_mut(&afi_safi) else {
+        return;
+    };
+    let Some(group) = af.group_by_id_mut(id) else {
+        return;
+    };
+    group.counters.policy_runs += 1;
+    if denied {
+        group.counters.policy_denials += 1;
+    }
+}
+
 fn route_advertise_to_peers(
     rd: Option<RouteDistinguisher>,
     prefix: Ipv4Net,
@@ -815,6 +871,7 @@ fn route_advertise_to_peers(
     } else {
         (Afi::Ip, Safi::Unicast)
     };
+    let afi_safi = AfiSafi::new(afi, safi);
 
     let peer_addrs: Vec<IpAddr> = peers
         .iter()
@@ -824,40 +881,50 @@ fn route_advertise_to_peers(
         .map(|(addr, _)| *addr)
         .collect();
 
+    // Per-call memo: outcome cached per update-group id for the
+    // span of this advertisement only. Members of the same group
+    // share the post-policy outcome (modulo split-horizon, which is
+    // checked per-peer before lookup so the canonical computation
+    // is always run on a non-source peer).
+    let mut memo: BTreeMap<super::update_group::UpdateGroupId, AdvertiseOutcome> = BTreeMap::new();
+
     for peer_addr in peer_addrs {
         let peer = peers.get_mut(&peer_addr).expect("peer exists");
 
         let add_path = peer.opt.is_add_path_send(afi, safi);
+        let group_id = peer.update_group_id.get(&afi_safi).cloned();
 
-        // Build the update/withdrawal for this peer
-        let (nlri_opt, attr_opt) = {
-            if let Some(best) = new_best {
-                // Try to advertise the new best path
-                if let Some((nlri, attr)) = route_update_ipv4(peer, &prefix, best, bgp, add_path) {
-                    // Apply outbound policy
-                    if let Some(attr) = route_apply_policy_out(peer, &nlri, attr) {
-                        (Some(nlri), Some(attr))
-                    } else {
-                        (Some(nlri), None) // Policy denied - will send withdrawal
-                    }
-                } else {
-                    (None, None) // Filtered by split-horizon, etc.
-                }
-            } else {
-                (None, None) // No best path
+        let outcome = match new_best {
+            None => AdvertiseOutcome::Withdraw,
+            Some(best) if best.ident == peer.ident => {
+                // Split-horizon: source peer does not receive its own
+                // route back. Cache must not be poisoned by this
+                // outcome — fall through directly.
+                AdvertiseOutcome::Withdraw
             }
+            Some(best) => match group_id.as_ref() {
+                Some(gid) => {
+                    if let Some(cached) = memo.get(gid) {
+                        cached.clone()
+                    } else {
+                        let outcome = compute_advertise_outcome(peer, &prefix, best, bgp, add_path);
+                        let denied = matches!(outcome, AdvertiseOutcome::Withdraw);
+                        memo.insert(gid.clone(), outcome.clone());
+                        bump_group_counters_on_miss(bgp, afi_safi, gid, denied);
+                        outcome
+                    }
+                }
+                None => compute_advertise_outcome(peer, &prefix, best, bgp, add_path),
+            },
         };
 
-        // Now apply the update/withdrawal
-        match (nlri_opt, attr_opt) {
-            (Some(nlri), Some(attr)) => {
-                if let Some(_rd) = rd {
-                    // RTC match.
-                    if !peer.rtcv4.is_empty() && !rtc_match(&peer.rtcv4, &attr.ecom) {
-                        continue;
-                    }
+        match outcome {
+            AdvertiseOutcome::Advertise(nlri, attr) => {
+                if rd.is_some() && !peer.rtcv4.is_empty() && !rtc_match(&peer.rtcv4, &attr.ecom) {
+                    // RTC: per-peer; varies independently of group
+                    // signature. Skip without withdrawing.
+                    continue;
                 }
-                // Send update
                 let attr = bgp.attr_store.intern(attr);
                 if let Some(best) = new_best {
                     let mut rib = best.clone();
@@ -875,14 +942,12 @@ fn route_advertise_to_peers(
                     peer.send_ipv4(nlri, attr, true);
                 }
             }
-            _ => {
-                // We remove the cache.
+            AdvertiseOutcome::Withdraw => {
                 if let Some(ref rd) = rd {
                     peer.cache_remove_vpnv4(*rd, prefix, 0);
                 } else {
                     peer.cache_remove_ipv4(prefix, 0);
                 }
-                // Send withdrawal if we had previously advertised
                 if peer.adj_out.contains_key(rd, &prefix) {
                     route_withdraw_ipv4(peer, rd, prefix, 0);
                     peer.adj_out.remove(rd, prefix, 0);
@@ -2788,6 +2853,7 @@ impl Bgp {
             tx: &self.tx,
             rib_tx: &self.rib_tx,
             attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
         };
 
         if !selected.is_empty() {
@@ -2813,6 +2879,7 @@ impl Bgp {
             tx: &self.tx,
             rib_tx: &self.rib_tx,
             attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
         };
 
         let selected = bgp_ref.local_rib.select_best_path(prefix);
@@ -2939,6 +3006,7 @@ impl Bgp {
             tx: &self.tx,
             rib_tx: &self.rib_tx,
             attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
         };
 
         if !selected.is_empty() {
@@ -3056,6 +3124,7 @@ impl Bgp {
             tx: &self.tx,
             rib_tx: &self.rib_tx,
             attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
         };
 
         if !selected.is_empty() {

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -138,6 +138,14 @@ pub struct UpdateGroupAf {
     pub next_seq: u32,
 }
 
+impl UpdateGroupAf {
+    /// Look up a mutable reference to the group with the given id.
+    /// Linear search; group counts per AFI/SAFI are bounded.
+    pub fn group_by_id_mut(&mut self, id: &UpdateGroupId) -> Option<&mut UpdateGroup> {
+        self.groups.values_mut().find(|g| &g.id == id)
+    }
+}
+
 /// Top-level container on `Bgp`.
 pub type UpdateGroupMap = BTreeMap<AfiSafi, UpdateGroupAf>;
 
@@ -349,5 +357,41 @@ mod tests {
         assert_eq!(id.to_string(), "vpnv4.7");
         let id = UpdateGroupId::new(Afi::L2vpn, Safi::Evpn, 2);
         assert_eq!(id.to_string(), "evpn.2");
+    }
+
+    /// Phase 2 hook: the counter-bump path uses `group_by_id_mut`
+    /// to find the group from a peer's back-reference id. Verifies
+    /// the lookup finds the group and that mutating returned
+    /// reference persists.
+    #[test]
+    fn group_by_id_mut_finds_and_mutates() {
+        let mut af = UpdateGroupAf::default();
+        let sig = base_sig();
+        let id = UpdateGroupId::new(Afi::Ip, Safi::Unicast, 0);
+        af.groups.insert(
+            sig.clone(),
+            UpdateGroup {
+                id: id.clone(),
+                sig,
+                members: BTreeSet::new(),
+                created_at: std::time::Instant::now(),
+                counters: UpdateGroupCounters::default(),
+            },
+        );
+        af.next_seq = 1;
+
+        // Lookup hit
+        let group = af.group_by_id_mut(&id).expect("group exists");
+        group.counters.policy_runs = 5;
+        group.counters.policy_denials = 2;
+
+        // Reload via lookup, verify the mutation persisted.
+        let again = af.group_by_id_mut(&id).expect("group still exists");
+        assert_eq!(again.counters.policy_runs, 5);
+        assert_eq!(again.counters.policy_denials, 2);
+
+        // Lookup miss: unknown id returns None.
+        let missing = UpdateGroupId::new(Afi::Ip, Safi::Unicast, 99);
+        assert!(af.group_by_id_mut(&missing).is_none());
     }
 }


### PR DESCRIPTION
## Summary
- `route_advertise_to_peers` now memoizes the post-policy `(nlri, attr)` outcome **per update-group within a single advertisement**. The first non-source member of a group runs `route_update_ipv4` + `route_apply_policy_out`; every other non-source member of the same group reuses the cached outcome.
- Counters: `policy_runs` and `policy_denials` increment **once per group on cache miss**, not once per peer. Visible in `show bgp update-group <id>`.
- Plumbing: `BgpTop` gains `update_groups: &mut UpdateGroupMap` (all 7 construction sites updated). New `UpdateGroupAf::group_by_id_mut` helper for the counter-bump path. New unit test `group_by_id_mut_finds_and_mutates`.

### Why the cache is safe
- All filters inside `route_update_ipv4` except split-horizon depend only on signature fields (`peer_type`, `reflector_client`, `local_as`, `local_addr`). Same-signature members compute identical attribute transforms.
- **Split-horizon** (`rib.ident == peer.ident`) is checked **before** the cache lookup, so the canonical computation always runs on a non-source peer.
- **RTC** (`rtc_match`) varies independently of group signature and is applied **per-peer after** cache lookup — matches IOS-XR sub-group semantics.
- The Phase 1 conservatism rule (any unmodelled outbound knob → singleton group) guarantees the cache cannot mix non-equivalent peers.

### Out of scope this PR
- Other advertise call sites (`route_advertise_to_addpath`, `route_advertise_evpn_to_peers`, `route_soft_out_peer_table`) are unchanged. They continue to work correctly but without the per-group sharing optimization. Will follow.
- Encoded UPDATE byte reuse and per-group send cache (Phase 3).
- Sub-groups for RTC / slow-peer / ORF (Phase 5).
- Wire-format byte goldens / BDD coverage.

## Test plan
- [x] `cargo build --release` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --exclude bdd` clean (4 unit tests in `update_group::tests`, including the new `group_by_id_mut_finds_and_mutates`)
- [x] `cargo fmt --all -- --check` clean
- [x] Smoke test: empty-daemon `show bgp update-group` (text + json) renders identically to Phase 1

Generated with [Claude Code](https://claude.com/claude-code)