### PR TITLE
bgp: route IPv4 advertise through update-group cache (Phase 3b)

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -939,14 +939,52 @@ fn route_advertise_to_peers(
                     };
                     peer.send_vpnv4(vpnv4_nlri, attr, true);
                 } else {
-                    peer.send_ipv4(nlri, attr, true);
+                    // IPv4 unicast: bucket into the group's pending
+                    // cache (Phase 3b). Source ident comes from the
+                    // selected best path so split-horizon pruning at
+                    // flush time can drop NLRIs from their originator.
+                    let source_ident = new_best.map(|b| b.ident).unwrap_or(peer.ident);
+                    let group_id = peer.update_group_id.get(&afi_safi).cloned();
+                    if let Some(gid) = group_id
+                        && let Some(af) = bgp.update_groups.get_mut(&afi_safi)
+                        && let Some(group) = af.group_by_id_mut(&gid)
+                    {
+                        super::update_group::send_ipv4(
+                            group,
+                            nlri,
+                            attr,
+                            source_ident,
+                            bgp.tx,
+                            true,
+                        );
+                    } else {
+                        // Fallback for an Established peer that
+                        // somehow isn't in a group — should not
+                        // happen, but the per-peer cache still works.
+                        peer.send_ipv4(nlri, attr, true);
+                    }
                 }
             }
             AdvertiseOutcome::Withdraw => {
                 if let Some(ref rd) = rd {
                     peer.cache_remove_vpnv4(*rd, prefix, 0);
                 } else {
+                    // Per-peer cleanup covers any IPv4 entries left
+                    // by paths still on the per-peer cache (addpath /
+                    // soft-out / sync) — these migrate in 3c/3d.
                     peer.cache_remove_ipv4(prefix, 0);
+                    // Group cache cleanup (Phase 3b). Skipped for
+                    // split-horizon Withdraws: the source peer never
+                    // contributed an entry, but other group members
+                    // may have. Removing here would clobber theirs.
+                    let is_split_horizon = new_best.map(|b| b.ident == peer.ident).unwrap_or(false);
+                    if !is_split_horizon
+                        && let Some(gid) = peer.update_group_id.get(&afi_safi).cloned()
+                        && let Some(af) = bgp.update_groups.get_mut(&afi_safi)
+                        && let Some(group) = af.group_by_id_mut(&gid)
+                    {
+                        super::update_group::cache_remove_ipv4(group, prefix);
+                    }
                 }
                 if peer.adj_out.contains_key(rd, &prefix) {
                     route_withdraw_ipv4(peer, rd, prefix, 0);


### PR DESCRIPTION
## Summary
`route_advertise_to_peers`'s IPv4 unicast path now buckets pending advertisements into the **group's** `cache_ipv4` rather than each peer's. The Phase 3a scaffolding (cache fields on `UpdateGroup`, `Message::FlushUpdateGroupIpv4`, `update_group::send_ipv4` / `cache_remove_ipv4` / `flush_ipv4`) becomes live.

### Changes
- **Advertise arm (IPv4 branch)**: looks up `peer.update_group_id[afi_safi]`, finds the group via `bgp.update_groups[afi_safi].group_by_id_mut(id)`, and calls `update_group::send_ipv4(group, nlri, attr, source_ident, bgp.tx, true)`. Source ident is `best.ident` from the selected best path. Falls back to per-peer `peer.send_ipv4` if the peer isn't in a group (defensive).
- **Withdraw arm (IPv4 branch)**: keeps the per-peer `peer.cache_remove_ipv4` (still needed for residue from addpath / soft-out / sync, which haven't migrated yet) **and** adds a group-level `update_group::cache_remove_ipv4`, gated on `!is_split_horizon`. The split-horizon gate is load-bearing: without it, peer A's split-horizon Withdraw would clobber bucket entries that peer B just added in the same advertise pass.
- **Counter movement** now visible in `show bgp update-group <id>`: `messages_formatted` (encoded UPDATE PDUs per attr-bucket), `messages_replicated` (sends per non-source member), `bytes_formatted`, `split_horizon_excluded` (per pruned source-member).

### Out of scope (Phase 3c/3d)
- `route_advertise_to_addpath`, `route_soft_out_peer_table`, and `route_sync_ipv4` still on per-peer cache. `route_sync_ipv4` in particular needs a direct-encode bypass since full-RIB sync should target one peer rather than fan out to the whole group.
- `Peer::cache_ipv4*` fields and `Event::AdvTimerIpv4Expires` stay until all callers are migrated.

## Test plan
- [x] `cargo build --release` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --exclude bdd` clean (4 unit tests in `update_group::tests`)
- [x] `cargo fmt --all -- --check` clean
- [x] Smoke test: empty-peer daemon `show bgp update-group` (text + JSON) renders correctly. Counter movement requires real Established peers — left for BDD coverage in a later phase.

Generated with [Claude Code](https://claude.com/claude-code)