### PR TITLE
bgp: route IPv4 addpath through update-group cache (Phase 3c)

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -721,6 +721,7 @@ fn route_advertise_to_addpath(
     } else {
         (Afi::Ip, Safi::Unicast)
     };
+    let afi_safi = AfiSafi::new(afi, safi);
 
     let peer_addrs: Vec<IpAddr> = peers
         .iter()
@@ -744,10 +745,10 @@ fn route_advertise_to_addpath(
                 continue;
             }
             let attr = bgp.attr_store.intern(attr);
-            let mut rib = rib.clone();
-            rib.attr = attr.clone();
+            let mut rib_clone = rib.clone();
+            rib_clone.attr = attr.clone();
 
-            peer.adj_out.add(rd, nlri.prefix, rib);
+            peer.adj_out.add(rd, nlri.prefix, rib_clone);
             if let Some(ref rd) = rd {
                 let vpnv4_nlri = Vpnv4Nlri {
                     label: Label::default(),
@@ -756,7 +757,20 @@ fn route_advertise_to_addpath(
                 };
                 peer.send_vpnv4(vpnv4_nlri, attr, true);
             } else {
-                peer.send_ipv4(nlri, attr, true);
+                // IPv4 unicast addpath: bucket into the group cache
+                // (Phase 3c). All addpath-enabled peers share the
+                // same `addpath_send: true` signature, so the group
+                // contains only addpath peers — fan-out at flush
+                // time goes only to other addpath peers.
+                let group_id = peer.update_group_id.get(&afi_safi).cloned();
+                if let Some(gid) = group_id
+                    && let Some(af) = bgp.update_groups.get_mut(&afi_safi)
+                    && let Some(group) = af.group_by_id_mut(&gid)
+                {
+                    super::update_group::send_ipv4(group, nlri, attr, rib.ident, bgp.tx, true);
+                } else {
+                    peer.send_ipv4(nlri, attr, true);
+                }
             }
         }
     }
@@ -767,7 +781,7 @@ fn route_withdraw_from_addpath(
     prefix: Ipv4Net,
     removed: &BgpRib,
     _source_peer: usize,
-    _bgp: &mut BgpTop,
+    bgp: &mut BgpTop,
     peers: &mut PeerMap,
 ) {
     let (afi, safi) = if rd.is_some() {
@@ -775,6 +789,7 @@ fn route_withdraw_from_addpath(
     } else {
         (Afi::Ip, Safi::Unicast)
     };
+    let afi_safi = AfiSafi::new(afi, safi);
 
     let peer_addrs: Vec<IpAddr> = peers
         .iter()
@@ -790,7 +805,19 @@ fn route_withdraw_from_addpath(
         if let Some(ref rd) = rd {
             peer.cache_remove_vpnv4(*rd, prefix, removed.local_id);
         } else {
+            // Per-peer cleanup covers any IPv4 entries left by paths
+            // still on the per-peer cache. Idempotent if already gone.
             peer.cache_remove_ipv4(prefix, removed.local_id);
+            // Group cache cleanup (Phase 3c). Idempotent across the
+            // peer-iteration: first peer in the group cleans the
+            // bucket; subsequent peers find it gone.
+            let group_id = peer.update_group_id.get(&afi_safi).cloned();
+            if let Some(gid) = group_id
+                && let Some(af) = bgp.update_groups.get_mut(&afi_safi)
+                && let Some(group) = af.group_by_id_mut(&gid)
+            {
+                super::update_group::cache_remove_ipv4(group, prefix, removed.local_id);
+            }
         }
         route_withdraw_ipv4(peer, rd, prefix, removed.local_id);
         peer.adj_out.remove(rd, prefix, removed.local_id);
@@ -983,7 +1010,7 @@ fn route_advertise_to_peers(
                         && let Some(af) = bgp.update_groups.get_mut(&afi_safi)
                         && let Some(group) = af.group_by_id_mut(&gid)
                     {
-                        super::update_group::cache_remove_ipv4(group, prefix);
+                        super::update_group::cache_remove_ipv4(group, prefix, 0);
                     }
                 }
                 if peer.adj_out.contains_key(rd, &prefix) {

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -340,9 +340,12 @@ pub fn send_ipv4(
 /// Remove an NLRI from the group's IPv4 pending-advert cache. The
 /// flush timer keeps running; an empty bucket is dropped.
 /// Idempotent — calling on an absent NLRI is a no-op.
-#[allow(dead_code)]
-pub fn cache_remove_ipv4(group: &mut UpdateGroup, prefix: ipnet::Ipv4Net) {
-    let nlri = Ipv4Nlri { id: 0, prefix };
+///
+/// `id` is the AddPath path-id (zero for non-AddPath). Bucket entries
+/// are keyed by the full `Ipv4Nlri`, so AddPath and non-AddPath
+/// withdrawals must pass distinct ids when both modes are mixed.
+pub fn cache_remove_ipv4(group: &mut UpdateGroup, prefix: ipnet::Ipv4Net, id: u32) {
+    let nlri = Ipv4Nlri { id, prefix };
     if let Some(attr) = group.cache_ipv4_rev.remove(&nlri)
         && let Some(bucket) = group.cache_ipv4.get_mut(&attr)
     {


### PR DESCRIPTION
## Summary
`route_advertise_to_addpath` and `route_withdraw_from_addpath` now bucket their IPv4 unicast cache operations into the **group's** `cache_ipv4` rather than each peer's. AddPath-enabled peers all share the `addpath_send: true` signature field, so they cluster into addpath-only groups — the group's flush fan-out correctly hits only AddPath peers.

### Changes
- `update_group::cache_remove_ipv4` gains an `id: u32` parameter for the AddPath path-id. Phase 3b's caller updated to pass 0 (non-AddPath). Bucket entries are keyed by the full `Ipv4Nlri`, so AddPath (non-zero path-id) and non-AddPath (id=0) withdrawals are correctly disjoint when both modes are active.
- `route_advertise_to_addpath` IPv4 branch: replaces `peer.send_ipv4(nlri, attr, true)` with the group send. Source ident is `rib.ident` (the peer that originated the selected path).
- `route_withdraw_from_addpath` IPv4 branch: keeps the per-peer `peer.cache_remove_ipv4(prefix, removed.local_id)` (still needed for residue from soft-out / sync, which migrate in 3d) and adds the group cache_remove. Idempotent across the addpath-peer iteration: first peer in the group cleans the bucket; subsequent peers find it gone.

### Out of scope (Phase 3d)
- `route_soft_out_peer_table` and `route_sync_ipv4` still on per-peer cache. Both target a **single** peer; routing through the group cache would fan out to the whole group, double-sending to peers that already have those routes. Both need a direct-encode bypass.
- `Peer::cache_ipv4*` fields and `Event::AdvTimerIpv4Expires` removal waits for those last callers.

## Test plan
- [x] `cargo build --release` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --exclude bdd` clean (4 unit tests in `update_group::tests`)
- [x] `cargo fmt --all -- --check` clean
- [x] Smoke test: empty-peer daemon `show bgp update-group` (text + JSON) renders correctly

Generated with [Claude Code](https://claude.com/claude-code)