### PR TITLE
bgp: complete IPv4 update-group migration; drop per-peer cache (Phase 3d)

### DIFF
--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -81,7 +81,6 @@ pub enum Event {
     // through the FSM rather than tearing the session down.
     RouteRefreshMsg(u16, u8),
     StaleTimerExipires(AfiSafi),
-    AdvTimerIpv4Expires,
     AdvTimerVpnv4Expires,
     AdvTimerEvpnExpires,
 }
@@ -336,8 +335,6 @@ pub struct Peer {
     pub reflector_client: bool,
     pub instant: Option<Instant>,
     pub first_start: bool,
-    pub cache_ipv4: HashMap<Arc<BgpAttr>, HashSet<Ipv4Nlri>>,
-    pub cache_ipv4_rev: HashMap<Ipv4Nlri, Arc<BgpAttr>>,
     pub cache_vpnv4: HashMap<Arc<BgpAttr>, HashSet<Vpnv4Nlri>>,
     pub cache_vpnv4_rev: HashMap<Vpnv4Nlri, Arc<BgpAttr>>,
     /// EVPN advertise cache. Mirrors `cache_vpnv4` shape — NLRIs
@@ -346,7 +343,6 @@ pub struct Peer {
     /// the reverse map; not yet implemented in this PR.
     pub cache_evpn: HashMap<Arc<BgpAttr>, HashSet<EvpnRoute>>,
     pub cache_evpn_rev: HashMap<EvpnRoute, Arc<BgpAttr>>,
-    pub cache_ipv4_timer: Option<Timer>,
     pub cache_vpnv4_timer: Option<Timer>,
     pub cache_evpn_timer: Option<Timer>,
     // Runtime bookkeeping for TCP-AO listener state: the (send_id,
@@ -408,13 +404,10 @@ impl Peer {
             reflector_client: false,
             instant: None,
             first_start: true,
-            cache_ipv4: HashMap::default(),
-            cache_ipv4_rev: HashMap::default(),
             cache_vpnv4: HashMap::default(),
             cache_vpnv4_rev: HashMap::default(),
             cache_evpn: HashMap::default(),
             cache_evpn_rev: HashMap::default(),
-            cache_ipv4_timer: None,
             cache_vpnv4_timer: None,
             cache_evpn_timer: None,
             last_ao_installed: None,
@@ -520,7 +513,6 @@ pub fn fsm_next_state(peer: &mut Peer, event: Event) -> (State, FsmEffect) {
             peer.timer.stale_timer.remove(&afi_safi);
             (peer.state, FsmEffect::StaleExpire(afi_safi))
         }
-        Event::AdvTimerIpv4Expires => (fsm_adv_timer_ipv4_expires(peer), FsmEffect::None),
         Event::AdvTimerVpnv4Expires => (fsm_adv_timer_vpnv4_expires(peer), FsmEffect::None),
         Event::AdvTimerEvpnExpires => (fsm_adv_timer_evpn_expires(peer), FsmEffect::None),
     }
@@ -591,12 +583,6 @@ pub fn fsm(bgp_ref: &mut BgpTop, peer_map: &mut PeerMap, id: usize, event: Event
             super::update_group::attach(bgp_ref.update_groups, peer_map, id);
         }
     }
-}
-
-pub fn fsm_adv_timer_ipv4_expires(peer: &mut Peer) -> State {
-    peer.cache_ipv4_timer = None;
-    peer.flush_ipv4();
-    State::Established
 }
 
 pub fn fsm_adv_timer_vpnv4_expires(peer: &mut Peer) -> State {

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -15,7 +15,7 @@ use crate::rib::{self, MacAddr, api::FdbEntry};
 use super::cap::CapAfiMap;
 use super::peer::{BgpTop, Event, Peer, PeerType};
 use super::peer_map::PeerMap;
-use super::timer::{start_adv_timer_ipv4, start_adv_timer_vpnv4};
+use super::timer::start_adv_timer_vpnv4;
 use super::{Bgp, InOut, Message};
 
 pub const ORIGINATED_PEER: usize = usize::MAX;
@@ -769,7 +769,11 @@ fn route_advertise_to_addpath(
                 {
                     super::update_group::send_ipv4(group, nlri, attr, rib.ident, bgp.tx, true);
                 } else {
-                    peer.send_ipv4(nlri, attr, true);
+                    tracing::warn!(
+                        peer = %peer.address,
+                        prefix = %prefix,
+                        "IPv4 addpath advertise: peer Established but not in any update-group; advertise skipped"
+                    );
                 }
             }
         }
@@ -805,12 +809,9 @@ fn route_withdraw_from_addpath(
         if let Some(ref rd) = rd {
             peer.cache_remove_vpnv4(*rd, prefix, removed.local_id);
         } else {
-            // Per-peer cleanup covers any IPv4 entries left by paths
-            // still on the per-peer cache. Idempotent if already gone.
-            peer.cache_remove_ipv4(prefix, removed.local_id);
-            // Group cache cleanup (Phase 3c). Idempotent across the
-            // peer-iteration: first peer in the group cleans the
-            // bucket; subsequent peers find it gone.
+            // Group cache cleanup. Idempotent across the peer
+            // iteration: first peer in the group cleans the bucket;
+            // subsequent peers find it gone.
             let group_id = peer.update_group_id.get(&afi_safi).cloned();
             if let Some(gid) = group_id
                 && let Some(af) = bgp.update_groups.get_mut(&afi_safi)
@@ -985,10 +986,17 @@ fn route_advertise_to_peers(
                             true,
                         );
                     } else {
-                        // Fallback for an Established peer that
-                        // somehow isn't in a group — should not
-                        // happen, but the per-peer cache still works.
-                        peer.send_ipv4(nlri, attr, true);
+                        // Established peer with no IPv4 unicast
+                        // group is a bug — `update_group::attach`
+                        // is supposed to enroll every peer that
+                        // reaches Established. Skip the advertise
+                        // rather than silently dropping it on the
+                        // floor or panicking.
+                        tracing::warn!(
+                            peer = %peer.address,
+                            prefix = %prefix,
+                            "IPv4 advertise: peer is Established but not in any update-group; advertise skipped"
+                        );
                     }
                 }
             }
@@ -996,14 +1004,10 @@ fn route_advertise_to_peers(
                 if let Some(ref rd) = rd {
                     peer.cache_remove_vpnv4(*rd, prefix, 0);
                 } else {
-                    // Per-peer cleanup covers any IPv4 entries left
-                    // by paths still on the per-peer cache (addpath /
-                    // soft-out / sync) — these migrate in 3c/3d.
-                    peer.cache_remove_ipv4(prefix, 0);
-                    // Group cache cleanup (Phase 3b). Skipped for
-                    // split-horizon Withdraws: the source peer never
-                    // contributed an entry, but other group members
-                    // may have. Removing here would clobber theirs.
+                    // Group cache cleanup. Skipped for split-horizon
+                    // Withdraws: the source peer never contributed
+                    // an entry, but other group members may have.
+                    // Removing here would clobber theirs.
                     let is_split_horizon = new_best.map(|b| b.ident == peer.ident).unwrap_or(false);
                     if !is_split_horizon
                         && let Some(gid) = peer.update_group_id.get(&afi_safi).cloned()
@@ -1316,6 +1320,11 @@ fn route_soft_out_peer_table(
     };
 
     let mut newly_advertised: BTreeSet<Ipv4Net> = BTreeSet::new();
+    // Soft-out targets a single peer; the per-group cache would
+    // fan out to every member. Accumulate IPv4 unicast entries
+    // and emit via `send_ipv4_direct` at the end so encoding
+    // stays per-attr-batched without touching the group cache.
+    let mut ipv4_entries: Vec<(Arc<BgpAttr>, Ipv4Nlri)> = Vec::new();
 
     for (prefix, rib) in &selected {
         let peer = peers.get_mut_by_idx(peer_idx).expect("peer exists");
@@ -1344,10 +1353,17 @@ fn route_soft_out_peer_table(
             };
             peer.send_vpnv4(vpnv4_nlri, attr, true);
         } else {
-            peer.send_ipv4(nlri, attr, true);
+            ipv4_entries.push((attr, nlri));
         }
 
         newly_advertised.insert(*prefix);
+    }
+
+    // Direct-emit IPv4 unicast batch (no group fan-out).
+    if rd.is_none()
+        && let Some(peer) = peers.get_by_idx(peer_idx)
+    {
+        super::update_group::send_ipv4_direct(peer, ipv4_entries);
     }
 
     let to_withdraw: Vec<Ipv4Net> = was_advertised
@@ -1356,10 +1372,12 @@ fn route_soft_out_peer_table(
         .collect();
     for prefix in to_withdraw {
         let peer = peers.get_mut_by_idx(peer_idx).expect("peer exists");
-        match rd {
-            Some(rd) => peer.cache_remove_vpnv4(rd, prefix, 0),
-            None => peer.cache_remove_ipv4(prefix, 0),
-        };
+        if let Some(rd) = rd {
+            peer.cache_remove_vpnv4(rd, prefix, 0);
+        }
+        // No IPv4 cache to remove from — direct-encode means there
+        // was never a pending bucket to drop. adj_out + the on-wire
+        // withdraw still happen.
         peer.adj_out.remove(rd, prefix, 0);
         route_withdraw_ipv4(peer, rd, prefix, 0);
     }
@@ -1992,7 +2010,6 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
     peer.adj_in.v4.0.clear();
     peer.adj_out.v4.0.clear();
 
-    peer.cache_ipv4.clear();
     peer.cache_vpnv4.clear();
 
     // IPv4 VPN.
@@ -2383,47 +2400,6 @@ impl Peer {
         }
     }
 
-    pub fn send_ipv4(&mut self, nlri: Ipv4Nlri, attr: Arc<BgpAttr>, timer: bool) {
-        self.cache_ipv4
-            .entry(attr.clone())
-            .or_default()
-            .insert(nlri.clone());
-        self.cache_ipv4_rev.insert(nlri, attr);
-        if timer && self.cache_ipv4_timer.is_none() {
-            self.cache_ipv4_timer = Some(start_adv_timer_ipv4(self));
-        }
-    }
-
-    pub fn cache_remove_ipv4(&mut self, prefix: Ipv4Net, id: u32) {
-        let nlri = Ipv4Nlri { id, prefix };
-        if let Some(attr) = self.cache_ipv4_rev.remove(&nlri)
-            && let Some(set) = self.cache_ipv4.get_mut(&attr)
-        {
-            set.remove(&nlri);
-            if set.is_empty() {
-                self.cache_ipv4.remove(&attr);
-            }
-        }
-    }
-
-    // Flush BGP update.
-    pub fn flush_ipv4(&mut self) {
-        let packet_tx = self.packet_tx.clone();
-        let max_size = self.max_packet_size();
-        for (attr, nlris) in self.cache_ipv4.drain() {
-            let mut update = UpdatePacket::with_max_packet_size(max_size);
-            update.bgp_attr = Some((*attr).clone());
-            update.ipv4_update = nlris.into_iter().collect();
-
-            while let Some(bytes) = update.pop_ipv4() {
-                if let Some(ref tx) = packet_tx {
-                    let _ = tx.send(bytes);
-                }
-            }
-        }
-        self.cache_ipv4_rev.clear();
-    }
-
     pub fn send_vpnv4(&mut self, nlri: Vpnv4Nlri, attr: Arc<BgpAttr>, timer: bool) {
         self.cache_vpnv4
             .entry(attr.clone())
@@ -2682,7 +2658,12 @@ pub fn route_sync_ipv4(peer: &mut Peer, bgp: &mut BgpTop) {
             .collect()
     };
 
-    // Advertise all best paths to the peer
+    // Sync targets a single peer; the per-group cache would fan
+    // out to every member, double-sending to peers that already
+    // have these routes. Accumulate locally and emit via
+    // `send_ipv4_direct`, which preserves the per-attr batching
+    // (one MP_REACH UPDATE per shared attr-set).
+    let mut entries: Vec<(Arc<BgpAttr>, Ipv4Nlri)> = Vec::new();
     for (prefix, mut rib) in routes {
         let Some((nlri, attr)) = route_update_ipv4(peer, &prefix, &rib, bgp, add_path) else {
             continue;
@@ -2697,11 +2678,10 @@ pub fn route_sync_ipv4(peer: &mut Peer, bgp: &mut BgpTop) {
         let arc_attr = rib.attr.clone();
         peer.adj_out.add(None, nlri.prefix, rib);
 
-        // Send the routes.
-        peer.send_ipv4(nlri, arc_attr, false);
+        entries.push((arc_attr, nlri));
     }
 
-    peer.flush_ipv4();
+    super::update_group::send_ipv4_direct(peer, entries);
 
     // Send End-of-RIB marker for IPv4 Unicast
     send_eor_ipv4_unicast(peer);

--- a/zebra-rs/src/bgp/timer.rs
+++ b/zebra-rs/src/bgp/timer.rs
@@ -102,14 +102,6 @@ fn start_hold_timer(peer: &Peer) -> Timer {
     start_timer!(peer, peer.param.hold_time as u64, Event::HoldTimerExpires)
 }
 
-pub fn start_adv_timer_ipv4(peer: &Peer) -> Timer {
-    if peer.is_ibgp() {
-        start_timer!(peer, 5_u64, Event::AdvTimerIpv4Expires)
-    } else {
-        start_timer!(peer, 30_u64, Event::AdvTimerIpv4Expires)
-    }
-}
-
 pub fn start_adv_timer_vpnv4(peer: &Peer) -> Timer {
     if peer.is_ibgp() {
         start_timer!(peer, 5_u64, Event::AdvTimerVpnv4Expires)
@@ -232,7 +224,6 @@ pub fn update_timers(peer: &mut Peer) {
         }
     }
     if peer.state != Established {
-        peer.cache_ipv4_timer = None;
         peer.cache_vpnv4_timer = None;
     }
 }

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -295,21 +295,16 @@ pub fn detach(update_groups: &mut UpdateGroupMap, peers: &mut PeerMap, peer_idx:
 
 // ── IPv4 unicast send / cache_remove / flush (Phase 3) ──
 //
-// These functions own the per-attr-bucket batching that used to live
-// on `Peer` (cache_ipv4 + cache_ipv4_rev + cache_ipv4_timer). Moving
-// them to the group lets one encoded UPDATE serve every non-source
-// member, with per-member split-horizon pruning at flush time.
-//
-// Phase 3a (this commit): scaffolding only. `flush_ipv4` is wired
-// to `Message::FlushUpdateGroupIpv4` in `Bgp::serve` but no caller
-// produces that message yet — `send_ipv4` is still dead until Phase
-// 3b migrates `route_advertise_to_peers`, `route_advertise_to_addpath`,
-// and friends off `Peer::send_ipv4`. Phase 3d then removes the
-// per-peer `cache_ipv4` fields entirely.
+// Owns the per-attr-bucket batching that used to live on `Peer`
+// (cache_ipv4 + cache_ipv4_rev + cache_ipv4_timer). Moving the
+// state here lets one encoded UPDATE serve every non-source
+// member of a group, with per-member split-horizon pruning at
+// flush time. Per-peer paths that target a single peer
+// (`route_sync_ipv4`, `route_soft_out_peer_table`) bypass the
+// group cache via `send_ipv4_direct` — encoding stays per-attr-
+// batched without fanning out to the whole group.
 
-#[allow(dead_code)]
 const ADV_TIMER_IBGP_SECS: u64 = 5;
-#[allow(dead_code)]
 const ADV_TIMER_EBGP_SECS: u64 = 30;
 
 /// Bucket the (nlri, attr, source_ident) into the group's IPv4
@@ -317,7 +312,6 @@ const ADV_TIMER_EBGP_SECS: u64 = 30;
 /// already running. The `tx` channel is the global Bgp tx (every
 /// peer carries a clone of it); on fire it delivers
 /// `Message::FlushUpdateGroupIpv4` back to `Bgp::serve`.
-#[allow(dead_code)]
 pub fn send_ipv4(
     group: &mut UpdateGroup,
     nlri: Ipv4Nlri,
@@ -356,7 +350,6 @@ pub fn cache_remove_ipv4(group: &mut UpdateGroup, prefix: ipnet::Ipv4Net, id: u3
     }
 }
 
-#[allow(dead_code)]
 fn start_adv_timer_ipv4(
     tx: &mpsc::Sender<Message>,
     id: &UpdateGroupId,
@@ -508,6 +501,37 @@ pub fn flush_ipv4(
                     group.counters.messages_replicated += pruned_bytes.len() as u64;
                 }
             }
+        }
+    }
+}
+
+/// Per-peer batched encode + send. Used by the route_sync_ipv4 and
+/// route_soft_out_peer_table paths that target a SINGLE peer — the
+/// group cache would fan-out to every member, so those callers
+/// bypass it and use this direct path instead.
+///
+/// Builds local per-attr buckets, encodes once per bucket via
+/// `encode_ipv4_update`, and ships every UPDATE byte buffer to the
+/// peer's `packet_tx`. Per-attr clustering preserves the wire-level
+/// efficiency the cache provided (one MP_REACH UPDATE per shared
+/// attr-set rather than one per NLRI).
+pub(super) fn send_ipv4_direct(peer: &Peer, entries: Vec<(Arc<BgpAttr>, Ipv4Nlri)>) {
+    if entries.is_empty() {
+        return;
+    }
+    let mut buckets: HashMap<Arc<BgpAttr>, Vec<Ipv4Nlri>> = HashMap::new();
+    for (attr, nlri) in entries {
+        buckets.entry(attr).or_default().push(nlri);
+    }
+    let max_packet_size = if peer.opt.extended_message {
+        bgp_packet::BGP_EXTENDED_PACKET_LEN
+    } else {
+        bgp_packet::BGP_PACKET_LEN
+    };
+    for (attr, nlris) in buckets {
+        let bytes_list = encode_ipv4_update(&attr, &nlris, max_packet_size);
+        for buf in bytes_list {
+            peer.send_packet(buf);
         }
     }
 }


### PR DESCRIPTION
## Summary
Last of the IPv4 unicast callers move off the per-peer cache, completing Phase 3 for IPv4 unicast.

### Migration
- `route_sync_ipv4` and `route_soft_out_peer_table` accumulate `(attr, nlri)` pairs locally and emit via the new `update_group::send_ipv4_direct(peer, entries)` helper. Both paths target a **single** peer; routing through the group cache would fan out to every member and double-send to peers that already have those routes. The direct helper preserves per-attr UPDATE batching (one MP_REACH per shared attr-set) without touching the group state.
- The "peer not in group" fallbacks in `route_advertise_to_peers` and `route_advertise_to_addpath` no longer fall back to `peer.send_ipv4` (which is gone). They `tracing::warn!` and skip — Established-peer-without-group is a bug, surfaced loudly rather than silently dropped.

### Removed (now dead)
- `Peer::cache_ipv4`, `cache_ipv4_rev`, `cache_ipv4_timer` fields
- `Peer::send_ipv4`, `Peer::cache_remove_ipv4`, `Peer::flush_ipv4` methods
- `Event::AdvTimerIpv4Expires` variant + FSM dispatch arm
- `fsm_adv_timer_ipv4_expires` function
- `start_adv_timer_ipv4` from `timer.rs`
- The `peer.cache_ipv4_timer = None` clear in `timer::update_timers`
- The `peer.cache_ipv4.clear()` in `route_clean`
- `#[allow(dead_code)]` attributes on `update_group::send_ipv4` / `start_adv_timer_ipv4` / `ADV_TIMER_*_SECS` (now used)

VPNv4 and EVPN remain on per-peer cache — out of Phase 3 scope.

Net diff: **91 insertions, 110 deletions** across 4 files.

## Test plan
- [x] `cargo build --release` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --exclude bdd` clean (4 unit tests in `update_group::tests`)
- [x] `cargo fmt --all -- --check` clean
- [x] Smoke test: empty-peer daemon `show bgp update-group` (text + JSON) renders correctly

Generated with [Claude Code](https://claude.com/claude-code)