### PR TITLE
policy: structured set as-path-prepend ASN repeat NUM

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -8,7 +8,7 @@ use ipnet::Ipv4Net;
 use prefix_trie::PrefixMap;
 
 use crate::bgp::timer::{start_adv_timer_evpn, start_stale_timer};
-use crate::policy::{CommunityMatcher, PolicyList, StandardMatcher};
+use crate::policy::{AsPathPrependConfig, CommunityMatcher, PolicyList, StandardMatcher};
 use crate::rib::route::DEBUG_EVPN;
 use crate::rib::{self, MacAddr, api::FdbEntry};
 
@@ -2625,13 +2625,15 @@ fn apply_set_community(
     bgp_attr.com = Some(com);
 }
 
-/// Apply a `set as-path-prepend <asn>...` action by prepending the given
-/// ASNs onto the existing AS-path (or installing a new one if absent).
-fn apply_set_as_path_prepend(bgp_attr: &mut BgpAttr, asns: &[u32]) {
-    if asns.is_empty() {
+/// Apply a `set as-path-prepend ASN repeat NUM` action by prepending
+/// `cfg.asn` `cfg.repeat` times onto the existing AS-path (or
+/// installing a new one if absent). `repeat` is bounded `1..=255` by
+/// the YANG schema; a zero would be a no-op anyway.
+fn apply_set_as_path_prepend(bgp_attr: &mut BgpAttr, cfg: &AsPathPrependConfig) {
+    if cfg.repeat == 0 {
         return;
     }
-    let prepend_path = As4Path::from(asns.to_vec());
+    let prepend_path = As4Path::from(vec![cfg.asn; cfg.repeat as usize]);
     match bgp_attr.aspath.as_mut() {
         Some(existing) => existing.prepend_mut(prepend_path),
         None => bgp_attr.aspath = Some(prepend_path),
@@ -3409,7 +3411,7 @@ mod tests {
     use ipnet::Ipv4Net;
 
     use super::policy_list_apply;
-    use crate::policy::{CommunityMatcher, CommunitySet, PolicyList};
+    use crate::policy::{AsPathPrependConfig, CommunityMatcher, CommunitySet, PolicyList};
 
     fn nlri(s: &str) -> Ipv4Nlri {
         Ipv4Nlri {
@@ -3543,7 +3545,10 @@ mod tests {
     #[test]
     fn policy_list_apply_as_path_prepend_onto_empty() {
         let mut list = PolicyList::default();
-        list.entry(10).set_as_path_prepend = Some(vec![65001, 65001]);
+        list.entry(10).set_as_path_prepend = Some(AsPathPrependConfig {
+            asn: 65001,
+            repeat: 2,
+        });
 
         let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), BgpAttr::default()).unwrap();
         let path = out.aspath.expect("aspath set");
@@ -3554,7 +3559,7 @@ mod tests {
     #[test]
     fn policy_list_apply_as_path_prepend_onto_existing() {
         let mut list = PolicyList::default();
-        list.entry(10).set_as_path_prepend = Some(vec![65001]);
+        list.entry(10).set_as_path_prepend = Some(AsPathPrependConfig::new(65001));
 
         // Existing path: 100 200 (origin AS at the right).
         let attr = BgpAttr {
@@ -3569,9 +3574,12 @@ mod tests {
     }
 
     #[test]
-    fn policy_list_apply_as_path_prepend_multi_asn() {
+    fn policy_list_apply_as_path_prepend_repeat_three_onto_existing() {
         let mut list = PolicyList::default();
-        list.entry(10).set_as_path_prepend = Some(vec![65001, 65002, 65003]);
+        list.entry(10).set_as_path_prepend = Some(AsPathPrependConfig {
+            asn: 65001,
+            repeat: 3,
+        });
 
         let attr = BgpAttr {
             aspath: Some(As4Path::from(vec![100])),
@@ -3580,7 +3588,7 @@ mod tests {
 
         let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
         let path = out.aspath.expect("aspath set");
-        assert_eq!(path.as_path_display(), "65001 65002 65003 100");
+        assert_eq!(path.as_path_display(), "65001 65001 65001 100");
         assert_eq!(path.length(), 4);
     }
 

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -49,6 +49,21 @@ fn parse_origin(s: &str) -> Result<Origin> {
     }
 }
 
+/// Set-action config for `set as-path-prepend ASN repeat NUM`.
+/// At apply time the same ASN is prepended `repeat` times onto
+/// AS_PATH — equivalent to IOS-XR's `prepend as-path NUM repeats N`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AsPathPrependConfig {
+    pub asn: u32,
+    pub repeat: u8,
+}
+
+impl AsPathPrependConfig {
+    pub fn new(asn: u32) -> Self {
+        Self { asn, repeat: 1 }
+    }
+}
+
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct PolicyEntry {
     // Match.
@@ -70,7 +85,7 @@ pub struct PolicyEntry {
     pub set_community_name: Option<String>,
     pub set_community: Option<CommunitySet>,
     pub set_community_additive: bool,
-    pub set_as_path_prepend: Option<Vec<u32>>,
+    pub set_as_path_prepend: Option<AsPathPrependConfig>,
     pub set_next_hop: Option<Ipv4Addr>,
     // Action.
     pub action: Option<PolicyAction>,
@@ -439,25 +454,58 @@ impl ConfigBuilder {
                 entry.set_community_additive = false;
                 Ok(())
             })
-            .path("/entry/set/as-path-prepend")
+            // `set as-path-prepend ASN [repeat NUM]` is modeled as
+            // a presence container with two leaves. YANG fires
+            // callbacks per leaf, so we patch the partial config
+            // incrementally; a missing `repeat` defaults to 1
+            // (matches the YANG default).
+            .path("/entry/set/as-path-prepend/asn")
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.entry(seq);
-
-                let raw = args.string().context(ARG_ERR)?;
-                let asns: Vec<u32> = raw
-                    .split_whitespace()
-                    .map(|s| s.parse::<u32>())
-                    .collect::<Result<Vec<_>, _>>()
-                    .context("as-path-prepend: invalid AS number")?;
-                if asns.is_empty() {
-                    anyhow::bail!("as-path-prepend: empty AS list");
+                let asn = args.u32().context("as-path-prepend asn: parse")?;
+                match entry.set_as_path_prepend.as_mut() {
+                    Some(cfg) => cfg.asn = asn,
+                    None => entry.set_as_path_prepend = Some(AsPathPrependConfig::new(asn)),
                 }
-                entry.set_as_path_prepend = Some(asns);
-
                 Ok(())
             })
             .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                // `asn` is mandatory; deleting it invalidates the
+                // whole config.
+                entry.set_as_path_prepend = None;
+                Ok(())
+            })
+            .path("/entry/set/as-path-prepend/repeat")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                let repeat = args.u8().context("as-path-prepend repeat: parse")?;
+                if repeat == 0 {
+                    anyhow::bail!("as-path-prepend repeat: must be >= 1");
+                }
+                if let Some(cfg) = entry.set_as_path_prepend.as_mut() {
+                    cfg.repeat = repeat;
+                }
+                // If asn isn't set yet the leaf order is unusual but
+                // valid (commit will fire the asn callback next);
+                // silently no-op rather than synthesizing an invalid
+                // config.
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if let Some(cfg) = entry.set_as_path_prepend.as_mut() {
+                    cfg.repeat = 1;
+                }
+                Ok(())
+            })
+            .path("/entry/set/as-path-prepend")
+            .del(|policy, cache, name, seq, _args| {
+                // Container-level delete clears the whole config.
                 let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.lookup(&seq).context(ARG_ERR)?;
                 entry.set_as_path_prepend = None;
@@ -572,12 +620,11 @@ pub fn show(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> 
                 let _ = writeln!(buf, "  set: community {}{}", set_community, suffix);
             }
             if let Some(prepend) = &entry.set_as_path_prepend {
-                let s = prepend
-                    .iter()
-                    .map(|a| a.to_string())
-                    .collect::<Vec<_>>()
-                    .join(" ");
-                let _ = writeln!(buf, "  set: as-path-prepend {}", s);
+                let _ = writeln!(
+                    buf,
+                    "  set: as-path-prepend {} repeat {}",
+                    prepend.asn, prepend.repeat
+                );
             }
             if let Some(nh) = &entry.set_next_hop {
                 let _ = writeln!(buf, "  set: next-hop {}", nh);

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -885,13 +885,28 @@ module config {
           leaf "community-additive" {
             type boolean;
           }
-          leaf "as-path-prepend" {
-            type string;
+          container "as-path-prepend" {
+            presence "Prepend `asn` onto AS_PATH `repeat` times.";
             description
-              "Space-separated list of AS numbers to prepend to the
-               AS-path. Example: '65001 65001 65002' prepends three
-               segments. Equivalent to IOS-XR 'prepend as-path' or
-               FRR 'set as-path prepend'.";
+              "Prepend a single AS number to AS_PATH. The same `asn`
+               is prepended `repeat` times — equivalent to IOS-XR's
+               `prepend as-path NUM repeats N` and the typical
+               BGP traffic-engineering knob for biasing best-path
+               selection on the receiver.";
+            leaf "asn" {
+              type inet:as-number;
+              mandatory true;
+              description
+                "AS number to prepend onto AS_PATH.";
+            }
+            leaf "repeat" {
+              type uint8 {
+                range "1..255";
+              }
+              default "1";
+              description
+                "Number of times to prepend `asn`. Default 1.";
+            }
           }
         }
         leaf "action" {


### PR DESCRIPTION
## Summary
Replace the string-based `set as-path-prepend` (FRR-style space-separated ASN list) with an IOS-XR-style structured container: `set as-path-prepend ASN repeat NUM`. The same ASN is prepended `repeat` times at apply time — the typical BGP traffic-engineering knob for biasing best-path selection on the receiver.

### YANG (config.yang)
`policy/entry/set/as-path-prepend` becomes a presence container:
- `asn` — `inet:as-number`, mandatory.
- `repeat` — `uint8 { range "1..255"; }`, default 1.

### Rust
- New `AsPathPrependConfig { asn: u32, repeat: u8 }` struct with `::new(asn)` defaulting repeat to 1. `PolicyEntry::set_as_path_prepend` switches from `Option<Vec<u32>>` to `Option<AsPathPrependConfig>` so the user's intent is preserved through to show output.
- Three YANG path callbacks: `…/asn`, `…/repeat`, container-level delete. Setting `asn` creates the config; deleting `asn` invalidates the whole feature (mandatory). Setting `repeat` patches the existing config; `repeat=0` is rejected. Container-level delete clears everything.
- `apply_set_as_path_prepend` expands `vec![cfg.asn; cfg.repeat as usize]` into the prepend segment.
- Show line: `set: as-path-prepend ASN repeat N`.

### Tests
- Two existing tests rewritten against the struct.
- One test (multi-distinct-ASN prepend) deleted — that capability went away with the schema narrowing.
- New test `policy_list_apply_as_path_prepend_repeat_three_onto_existing` covers the repeat semantics explicitly.

## Test plan
- [x] `cargo build --release` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --exclude bdd` clean (13 policy_list tests pass, including the new repeat test)
- [x] `cargo fmt --all -- --check` clean
- [x] Smoke test: YAML with both shapes (`asn` + `repeat`, and `asn` alone defaulting to repeat=1) is accepted by the daemon

Generated with [Claude Code](https://claude.com/claude-code)