### PR TITLE
policy: schema cleanup pass (4 commits)

### DIFF
--- a/bdd/tests/configs/bgp_basic_ebgp/z1-5.yaml
+++ b/bdd/tests/configs/bgp_basic_ebgp/z1-5.yaml
@@ -7,7 +7,7 @@ policy:
   entry:
   - number: 10
     match:
-      prefix-set: out-test
+      prefix: out-test
 router:
   bgp:
     global:

--- a/bdd/tests/configs/bgp_basic_ibgp/z1-5.yaml
+++ b/bdd/tests/configs/bgp_basic_ibgp/z1-5.yaml
@@ -7,7 +7,7 @@ policy:
   entry:
   - number: 10
     match:
-      prefix-set: out-test
+      prefix: out-test
 router:
   bgp:
     global:

--- a/bdd/tests/configs/bgp_gobgpd_rr/rr1.yaml
+++ b/bdd/tests/configs/bgp_gobgpd_rr/rr1.yaml
@@ -28,37 +28,37 @@ policy:
   entry:
   - number: 10
     match:
-      community-set: 198.18.37.16/28
+      community: 198.18.37.16/28
 - name: 198.18.37.80/28
   entry:
   - number: 10
     match:
-      community-set: 198.18.37.80/28
+      community: 198.18.37.80/28
 - name: 198.18.39.80/28
   entry:
   - number: 10
     match:
-      community-set: 198.18.39.80/28
+      community: 198.18.39.80/28
 - name: 198.18.39.96/28
   entry:
   - number: 10
     match:
-      community-set: 198.18.39.96/28
+      community: 198.18.39.96/28
 - name: 198.18.39.128/28
   entry:
   - number: 10
     match:
-      community-set: 198.18.39.128/28
+      community: 198.18.39.128/28
 - name: 198.18.39.144/28
   entry:
   - number: 10
     match:
-      community-set: 198.18.39.144/28
+      community: 198.18.39.144/28
 - name: 198.18.39.160/28
   entry:
   - number: 10
     match:
-      community-set: 198.18.39.160/28
+      community: 198.18.39.160/28
 router:
   bgp:
     global:

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-both.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-both.yaml
@@ -8,7 +8,7 @@ policy:
   entry:
   - number: 10
     match:
-      prefix-set: HOGE
+      prefix: HOGE
 router:
   bgp:
     global:

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-initial.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-initial.yaml
@@ -7,7 +7,7 @@ policy:
   entry:
   - number: 10
     match:
-      prefix-set: HOGE
+      prefix: HOGE
 router:
   bgp:
     global:

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-other.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-other.yaml
@@ -7,7 +7,7 @@ policy:
   entry:
   - number: 10
     match:
-      prefix-set: HOGE
+      prefix: HOGE
 router:
   bgp:
     global:

--- a/bdd/tests/configs/bgp_route_map_match/z1.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z1.yaml
@@ -8,7 +8,7 @@ policy:
   entry:
   - number: 10
     match:
-      prefix-set: ALL-V4
+      prefix: ALL-V4
     set:
       med: 100
 router:

--- a/bdd/tests/configs/bgp_route_map_match/z2-aspath-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-aspath-fail.yaml
@@ -7,7 +7,7 @@ policy:
   entry:
   - number: 10
     match:
-      as-path-set: FROM-65999
+      as-path: FROM-65999
 router:
   bgp:
     global:

--- a/bdd/tests/configs/bgp_route_map_match/z2-aspath-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-aspath-pass.yaml
@@ -7,7 +7,7 @@ policy:
   entry:
   - number: 10
     match:
-      as-path-set: FROM-65001
+      as-path: FROM-65001
 router:
   bgp:
     global:

--- a/bdd/tests/configs/bgp_route_map_match/z2-nh-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-nh-fail.yaml
@@ -8,7 +8,7 @@ policy:
   entry:
   - number: 10
     match:
-      next-hop-set: WRONG-SUBNET
+      next-hop: WRONG-SUBNET
 router:
   bgp:
     global:

--- a/bdd/tests/configs/bgp_route_map_match/z2-nh-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-nh-pass.yaml
@@ -8,7 +8,7 @@ policy:
   entry:
   - number: 10
     match:
-      next-hop-set: PEER-SUBNET
+      next-hop: PEER-SUBNET
 router:
   bgp:
     global:

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2558,21 +2558,14 @@ fn entry_matches(entry: &crate::policy::PolicyEntry, nlri: &Ipv4Nlri, bgp_attr: 
             return false;
         }
     }
-    if let Some(eq) = entry.match_med_eq {
+    if let Some(med_match) = &entry.match_med {
         let med = bgp_attr.med.as_ref().map(|m| m.med).unwrap_or(0);
-        if med != eq {
-            return false;
-        }
-    }
-    if let Some(ge) = entry.match_med_ge {
-        let med = bgp_attr.med.as_ref().map(|m| m.med).unwrap_or(0);
-        if med < ge {
-            return false;
-        }
-    }
-    if let Some(le) = entry.match_med_le {
-        let med = bgp_attr.med.as_ref().map(|m| m.med).unwrap_or(0);
-        if med > le {
+        let ok = match med_match {
+            crate::policy::MedMatch::Eq(v) => med == *v,
+            crate::policy::MedMatch::Le(v) => med <= *v,
+            crate::policy::MedMatch::Ge(v) => med >= *v,
+        };
+        if !ok {
             return false;
         }
     }
@@ -3284,7 +3277,7 @@ mod policy_apply_tests {
 
     use super::*;
     use crate::policy::prefix::set::PrefixSetEntry;
-    use crate::policy::{AsPathMatcher, AsPathSet, PolicyList, PrefixSet};
+    use crate::policy::{AsPathMatcher, AsPathSet, MedMatch, PolicyList, PrefixSet};
 
     fn nlri(prefix: &str) -> Ipv4Nlri {
         Ipv4Nlri {
@@ -3319,27 +3312,49 @@ mod policy_apply_tests {
     }
 
     #[test]
-    fn match_med_eq_ge_le() {
+    fn match_med_ge() {
         let mut list = PolicyList::default();
-        let entry = list.entry(10);
-        entry.match_med_ge = Some(100);
-        entry.match_med_le = Some(200);
+        list.entry(10).match_med = Some(MedMatch::Ge(100));
 
         assert!(
             policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", Some(150), None))
                 .is_some()
         );
         assert!(
+            policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", Some(100), None))
+                .is_some(),
+            "ge accepts equality"
+        );
+        assert!(
             policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", Some(50), None)).is_none()
+        );
+    }
+
+    #[test]
+    fn match_med_le() {
+        let mut list = PolicyList::default();
+        list.entry(10).match_med = Some(MedMatch::Le(200));
+
+        assert!(
+            policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", Some(150), None))
+                .is_some()
+        );
+        assert!(
+            policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", Some(200), None))
+                .is_some(),
+            "le accepts equality"
         );
         assert!(
             policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", Some(250), None))
                 .is_none()
         );
+    }
 
+    #[test]
+    fn match_med_eq() {
         let mut list = PolicyList::default();
-        let entry = list.entry(10);
-        entry.match_med_eq = Some(100);
+        list.entry(10).match_med = Some(MedMatch::Eq(100));
+
         assert!(
             policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", Some(100), None))
                 .is_some()
@@ -3406,7 +3421,7 @@ mod policy_apply_tests {
         let entry = list.entry(10);
         entry.as_path_set = Some(set);
         entry.match_origin = Some(Origin::Igp);
-        entry.match_med_le = Some(50);
+        entry.match_med = Some(MedMatch::Le(50));
 
         let pass = attr_with("65001 65002", Some(40), Some(Origin::Igp));
         let bad_origin = attr_with("65001 65002", Some(40), Some(Origin::Egp));

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2519,8 +2519,8 @@ pub fn policy_list_apply(
         if let Some(med) = &entry.med {
             bgp_attr.med = Some(Med { med: *med });
         }
-        if let Some(set_community) = &entry.set_community {
-            apply_set_community(&mut bgp_attr, set_community, entry.set_community_additive);
+        if let Some(cfg) = &entry.set_community {
+            apply_set_community(&mut bgp_attr, cfg);
         }
         if let Some(prepend) = &entry.set_as_path_prepend {
             apply_set_as_path_prepend(&mut bgp_attr, prepend);
@@ -2595,12 +2595,14 @@ fn entry_matches(entry: &crate::policy::PolicyEntry, nlri: &Ipv4Nlri, bgp_attr: 
 /// With `additive = false` the existing community list is replaced; with
 /// `additive = true` the new values are merged in. The result is always
 /// sorted and deduplicated.
-fn apply_set_community(
-    bgp_attr: &mut BgpAttr,
-    set_community: &crate::policy::CommunitySet,
-    additive: bool,
-) {
-    let new_vals: Vec<u32> = set_community
+fn apply_set_community(bgp_attr: &mut BgpAttr, cfg: &crate::policy::SetCommunityConfig) {
+    // Unresolved name (community-set was deleted or never defined):
+    // skip silently rather than touch the attribute. policy_entry_sync
+    // re-resolves on changes.
+    let Some(set) = cfg.resolved.as_ref() else {
+        return;
+    };
+    let new_vals: Vec<u32> = set
         .vals
         .iter()
         .filter_map(|m| match m {
@@ -2608,21 +2610,40 @@ fn apply_set_community(
             _ => None,
         })
         .collect();
-    if new_vals.is_empty() && !additive {
-        // Replace with empty: drop the attribute entirely.
-        bgp_attr.com = None;
-        return;
+
+    use crate::policy::SetCommunityMode;
+    match cfg.mode {
+        SetCommunityMode::Replace => {
+            if new_vals.is_empty() {
+                bgp_attr.com = None;
+                return;
+            }
+            let mut com = Community::new();
+            for v in new_vals {
+                com.push(v);
+            }
+            com.sort_uniq();
+            bgp_attr.com = Some(com);
+        }
+        SetCommunityMode::Additive => {
+            let mut com = bgp_attr.com.clone().unwrap_or_default();
+            for v in new_vals {
+                com.push(v);
+            }
+            com.sort_uniq();
+            bgp_attr.com = Some(com);
+        }
+        SetCommunityMode::Delete => {
+            // Set difference: drop matching values from existing
+            // community attribute. No-op if attribute absent.
+            let Some(mut com) = bgp_attr.com.clone() else {
+                return;
+            };
+            let drop: std::collections::HashSet<u32> = new_vals.into_iter().collect();
+            com.0.retain(|v| !drop.contains(v));
+            bgp_attr.com = if com.0.is_empty() { None } else { Some(com) };
+        }
     }
-    let mut com = if additive {
-        bgp_attr.com.clone().unwrap_or_default()
-    } else {
-        Community::new()
-    };
-    for v in new_vals {
-        com.push(v);
-    }
-    com.sort_uniq();
-    bgp_attr.com = Some(com);
 }
 
 /// Apply a `set as-path-prepend ASN repeat NUM` action by prepending
@@ -3411,7 +3432,18 @@ mod tests {
     use ipnet::Ipv4Net;
 
     use super::policy_list_apply;
-    use crate::policy::{AsPathPrependConfig, CommunityMatcher, CommunitySet, PolicyList};
+    use crate::policy::{
+        AsPathPrependConfig, CommunityMatcher, CommunitySet, PolicyList, SetCommunityConfig,
+        SetCommunityMode,
+    };
+
+    fn set_community_cfg(members: &[&str], mode: SetCommunityMode) -> SetCommunityConfig {
+        SetCommunityConfig {
+            name: "test".into(),
+            mode,
+            resolved: Some(community_set(members)),
+        }
+    }
 
     fn nlri(s: &str) -> Ipv4Nlri {
         Ipv4Nlri {
@@ -3475,8 +3507,10 @@ mod tests {
     fn policy_list_apply_community_replace() {
         let mut list = PolicyList::default();
         let entry = list.entry(10);
-        entry.set_community = Some(community_set(&["100:200", "no-export"]));
-        entry.set_community_additive = false;
+        entry.set_community = Some(set_community_cfg(
+            &["100:200", "no-export"],
+            SetCommunityMode::Replace,
+        ));
 
         // Existing community 999:999 must be wiped on replace.
         let attr = BgpAttr {
@@ -3496,8 +3530,7 @@ mod tests {
     fn policy_list_apply_community_additive() {
         let mut list = PolicyList::default();
         let entry = list.entry(10);
-        entry.set_community = Some(community_set(&["100:200"]));
-        entry.set_community_additive = true;
+        entry.set_community = Some(set_community_cfg(&["100:200"], SetCommunityMode::Additive));
 
         let attr = BgpAttr {
             com: Some(Community(vec![com_val("999:999")])),
@@ -3515,8 +3548,7 @@ mod tests {
     fn policy_list_apply_community_additive_dedups() {
         let mut list = PolicyList::default();
         let entry = list.entry(10);
-        entry.set_community = Some(community_set(&["100:200"]));
-        entry.set_community_additive = true;
+        entry.set_community = Some(set_community_cfg(&["100:200"], SetCommunityMode::Additive));
 
         // 100:200 already present — additive should not duplicate.
         let attr = BgpAttr {
@@ -3534,12 +3566,56 @@ mod tests {
         let mut list = PolicyList::default();
         let entry = list.entry(10);
         // Mix concrete + regex; only 100:200 is materializable.
-        entry.set_community = Some(community_set(&["100:200", "^65000:.*"]));
-        entry.set_community_additive = false;
+        entry.set_community = Some(set_community_cfg(
+            &["100:200", "^65000:.*"],
+            SetCommunityMode::Replace,
+        ));
 
         let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), BgpAttr::default()).unwrap();
         let com = out.com.expect("community attribute set");
         assert_eq!(com.0, vec![com_val("100:200")]);
+    }
+
+    #[test]
+    fn policy_list_apply_community_delete_removes_matching() {
+        let mut list = PolicyList::default();
+        let entry = list.entry(10);
+        entry.set_community = Some(set_community_cfg(
+            &["100:200", "no-export"],
+            SetCommunityMode::Delete,
+        ));
+
+        // Existing has both targets and a non-target — only the
+        // targets are removed; non-target survives.
+        let attr = BgpAttr {
+            com: Some(Community(vec![
+                com_val("100:200"),
+                com_val("999:999"),
+                CommunityValue::NO_EXPORT.value(),
+            ])),
+            ..Default::default()
+        };
+
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        let com = out.com.expect("community attribute survives");
+        assert_eq!(com.0, vec![com_val("999:999")]);
+    }
+
+    #[test]
+    fn policy_list_apply_community_delete_drops_attr_when_empty() {
+        let mut list = PolicyList::default();
+        let entry = list.entry(10);
+        entry.set_community = Some(set_community_cfg(&["100:200"], SetCommunityMode::Delete));
+
+        // Single value matches the deletion → attribute should be
+        // None rather than an empty Community vec.
+        let attr = BgpAttr {
+            com: Some(Community(vec![com_val("100:200")])),
+            ..Default::default()
+        };
+
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        assert!(out.com.is_none());
     }
 
     #[test]

--- a/zebra-rs/src/policy/inst.rs
+++ b/zebra-rs/src/policy/inst.rs
@@ -428,9 +428,9 @@ fn cascade_indirect_policy_updates(
                 || e.community_set_name
                     .as_ref()
                     .is_some_and(|n| changed_community_sets.contains(n))
-                || e.set_community_name
+                || e.set_community
                     .as_ref()
-                    .is_some_and(|n| changed_community_sets.contains(n))
+                    .is_some_and(|c| changed_community_sets.contains(&c.name))
                 || e.as_path_set_name
                     .as_ref()
                     .is_some_and(|n| changed_as_path_sets.contains(n))

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -63,6 +63,16 @@ impl AsPathPrependConfig {
     }
 }
 
+/// Operator for `match med {eq|le|ge} NUM`. The operand is bundled
+/// into the variant so the type itself encodes "exactly one operator
+/// with its value".
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MedMatch {
+    Eq(u32),
+    Le(u32),
+    Ge(u32),
+}
+
 /// Operation applied by `set community NAME {|additive|delete}`.
 /// `Replace` overwrites the COMMUNITIES attribute with the set's
 /// members; `Additive` merges them in; `Delete` removes them
@@ -106,9 +116,7 @@ pub struct PolicyEntry {
     pub as_path_set: Option<AsPathSet>,
     pub next_hop_set_name: Option<String>,
     pub next_hop_set: Option<PrefixSet>,
-    pub match_med_eq: Option<u32>,
-    pub match_med_ge: Option<u32>,
-    pub match_med_le: Option<u32>,
+    pub match_med: Option<MedMatch>,
     pub match_origin: Option<Origin>,
     // Set.
     pub local_pref: Option<u32>,
@@ -361,43 +369,62 @@ impl ConfigBuilder {
                 entry.next_hop_set_name = None;
                 Ok(())
             })
-            .path("/entry/match/med-eq")
+            // `match med {eq|le|ge} NUM` — presence container with
+            // a `choice op` enforcing exactly-one operator. Each
+            // case carries a mandatory uint32 operand; setting any
+            // case writes the variant; deleting it (or the
+            // container) clears the whole match.
+            .path("/entry/match/med/eq")
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.entry(seq);
-                entry.match_med_eq = Some(args.u32().context(ARG_ERR)?);
+                entry.match_med = Some(MedMatch::Eq(args.u32().context(ARG_ERR)?));
                 Ok(())
             })
             .del(|policy, cache, name, seq, _args| {
                 let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.lookup(&seq).context(ARG_ERR)?;
-                entry.match_med_eq = None;
+                if matches!(entry.match_med, Some(MedMatch::Eq(_))) {
+                    entry.match_med = None;
+                }
                 Ok(())
             })
-            .path("/entry/match/med-ge")
+            .path("/entry/match/med/le")
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.entry(seq);
-                entry.match_med_ge = Some(args.u32().context(ARG_ERR)?);
+                entry.match_med = Some(MedMatch::Le(args.u32().context(ARG_ERR)?));
                 Ok(())
             })
             .del(|policy, cache, name, seq, _args| {
                 let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.lookup(&seq).context(ARG_ERR)?;
-                entry.match_med_ge = None;
+                if matches!(entry.match_med, Some(MedMatch::Le(_))) {
+                    entry.match_med = None;
+                }
                 Ok(())
             })
-            .path("/entry/match/med-le")
+            .path("/entry/match/med/ge")
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.entry(seq);
-                entry.match_med_le = Some(args.u32().context(ARG_ERR)?);
+                entry.match_med = Some(MedMatch::Ge(args.u32().context(ARG_ERR)?));
                 Ok(())
             })
             .del(|policy, cache, name, seq, _args| {
                 let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.lookup(&seq).context(ARG_ERR)?;
-                entry.match_med_le = None;
+                if matches!(entry.match_med, Some(MedMatch::Ge(_))) {
+                    entry.match_med = None;
+                }
+                Ok(())
+            })
+            .path("/entry/match/med")
+            .del(|policy, cache, name, seq, _args| {
+                // Container-level delete clears the whole match.
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.match_med = None;
                 Ok(())
             })
             .path("/entry/match/origin")
@@ -645,14 +672,13 @@ pub fn show(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> 
             if let Some(next_hop_set) = &entry.next_hop_set_name {
                 let _ = writeln!(buf, "  match: next_hop_set {}", next_hop_set);
             }
-            if let Some(med) = &entry.match_med_eq {
-                let _ = writeln!(buf, "  match: med eq {}", med);
-            }
-            if let Some(med) = &entry.match_med_ge {
-                let _ = writeln!(buf, "  match: med ge {}", med);
-            }
-            if let Some(med) = &entry.match_med_le {
-                let _ = writeln!(buf, "  match: med le {}", med);
+            if let Some(med) = &entry.match_med {
+                let (op, value) = match med {
+                    MedMatch::Eq(v) => ("eq", v),
+                    MedMatch::Le(v) => ("le", v),
+                    MedMatch::Ge(v) => ("ge", v),
+                };
+                let _ = writeln!(buf, "  match: med {} {}", op, value);
             }
             if let Some(origin) = &entry.match_origin {
                 let _ = writeln!(buf, "  match: origin {:?}", origin);

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -16,7 +16,6 @@ use super::{
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct PolicyList {
     pub entry: BTreeMap<u32, PolicyEntry>,
-    pub default_action: Option<PolicyAction>,
     pub delete: bool,
 }
 
@@ -64,6 +63,38 @@ impl AsPathPrependConfig {
     }
 }
 
+/// Operation applied by `set community NAME {|additive|delete}`.
+/// `Replace` overwrites the COMMUNITIES attribute with the set's
+/// members; `Additive` merges them in; `Delete` removes them
+/// (set difference).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SetCommunityMode {
+    #[default]
+    Replace,
+    Additive,
+    Delete,
+}
+
+/// Set-action config for `set community NAME {|additive|delete}`.
+/// `name` references a community-set; `resolved` is populated by
+/// `policy_entry_sync` from the community-set registry.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SetCommunityConfig {
+    pub name: String,
+    pub mode: SetCommunityMode,
+    pub resolved: Option<CommunitySet>,
+}
+
+impl SetCommunityConfig {
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            mode: SetCommunityMode::Replace,
+            resolved: None,
+        }
+    }
+}
+
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct PolicyEntry {
     // Match.
@@ -82,9 +113,7 @@ pub struct PolicyEntry {
     // Set.
     pub local_pref: Option<u32>,
     pub med: Option<u32>,
-    pub set_community_name: Option<String>,
-    pub set_community: Option<CommunitySet>,
-    pub set_community_additive: bool,
+    pub set_community: Option<SetCommunityConfig>,
     pub set_as_path_prepend: Option<AsPathPrependConfig>,
     pub set_next_hop: Option<Ipv4Addr>,
     // Action.
@@ -126,12 +155,8 @@ pub fn policy_entry_sync(
                 policy.next_hop_set = None;
             }
         }
-        if let Some(name) = &policy.set_community_name {
-            if let Some(community_set) = community_set.config.get(name) {
-                policy.set_community = Some(community_set.clone());
-            } else {
-                policy.set_community = None;
-            }
+        if let Some(cfg) = policy.set_community.as_mut() {
+            cfg.resolved = community_set.config.get(&cfg.name).cloned();
         }
     }
 }
@@ -421,37 +446,77 @@ impl ConfigBuilder {
                 entry.med = None;
                 Ok(())
             })
-            .path("/entry/set/community-set")
+            // `set community NAME {|additive|delete}` — presence
+            // container with a mandatory `name` and a `choice mode`
+            // whose three cases are bare keywords (or empty for
+            // replace). YANG fires per-leaf callbacks; we maintain a
+            // single `SetCommunityConfig` and patch in/out the mode.
+            .path("/entry/set/community/name")
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.entry(seq);
-
-                let community_set = args.string().context(ARG_ERR)?;
-                entry.set_community_name = Some(community_set);
-
+                let community_name = args.string().context(ARG_ERR)?;
+                match entry.set_community.as_mut() {
+                    Some(cfg) => cfg.name = community_name,
+                    None => entry.set_community = Some(SetCommunityConfig::new(community_name)),
+                }
                 Ok(())
             })
             .del(|policy, cache, name, seq, _args| {
                 let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.lookup(&seq).context(ARG_ERR)?;
-                entry.set_community_name = None;
+                // `name` is mandatory; deleting it invalidates the
+                // whole config.
                 entry.set_community = None;
                 Ok(())
             })
-            .path("/entry/set/community-additive")
-            .set(|policy, cache, name, seq, args| {
+            .path("/entry/set/community/additive")
+            .set(|policy, cache, name, seq, _args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.entry(seq);
-
-                let additive = args.boolean().context(ARG_ERR)?;
-                entry.set_community_additive = additive;
-
+                if let Some(cfg) = entry.set_community.as_mut() {
+                    cfg.mode = SetCommunityMode::Additive;
+                }
+                // No-op if name not yet set; the YANG choice ensures
+                // additive and delete are mutually exclusive at the
+                // schema level.
                 Ok(())
             })
             .del(|policy, cache, name, seq, _args| {
                 let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.lookup(&seq).context(ARG_ERR)?;
-                entry.set_community_additive = false;
+                if let Some(cfg) = entry.set_community.as_mut()
+                    && cfg.mode == SetCommunityMode::Additive
+                {
+                    cfg.mode = SetCommunityMode::Replace;
+                }
+                Ok(())
+            })
+            .path("/entry/set/community/delete")
+            .set(|policy, cache, name, seq, _args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                if let Some(cfg) = entry.set_community.as_mut() {
+                    cfg.mode = SetCommunityMode::Delete;
+                }
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if let Some(cfg) = entry.set_community.as_mut()
+                    && cfg.mode == SetCommunityMode::Delete
+                {
+                    cfg.mode = SetCommunityMode::Replace;
+                }
+                Ok(())
+            })
+            .path("/entry/set/community")
+            .del(|policy, cache, name, seq, _args| {
+                // Container-level delete clears the whole config.
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.set_community = None;
                 Ok(())
             })
             // `set as-path-prepend ASN [repeat NUM]` is modeled as
@@ -543,19 +608,6 @@ impl ConfigBuilder {
                 entry.action = None;
                 Ok(())
             })
-            .path("/default-action")
-            .set(|policy, cache, name, _seq, args| {
-                let _list = cache_get(policy, cache, &name).context(ARG_ERR)?;
-                let _default_action = args.string().context(ARG_ERR)?;
-
-                Ok(())
-            })
-            .del(|policy, cache, name, seq, _args| {
-                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
-                let entry = list.lookup(&seq).context(ARG_ERR)?;
-                entry.action = None;
-                Ok(())
-            })
     }
 
     pub fn path(mut self, path: &str) -> Self {
@@ -611,13 +663,13 @@ pub fn show(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> 
             if let Some(med) = &entry.med {
                 let _ = writeln!(buf, "  set: med {}", med);
             }
-            if let Some(set_community) = &entry.set_community_name {
-                let suffix = if entry.set_community_additive {
-                    " additive"
-                } else {
-                    ""
+            if let Some(cfg) = &entry.set_community {
+                let suffix = match cfg.mode {
+                    SetCommunityMode::Replace => "",
+                    SetCommunityMode::Additive => " additive",
+                    SetCommunityMode::Delete => " delete",
                 };
-                let _ = writeln!(buf, "  set: community {}{}", set_community, suffix);
+                let _ = writeln!(buf, "  set: community {}{}", cfg.name, suffix);
             }
             if let Some(prepend) = &entry.set_as_path_prepend {
                 let _ = writeln!(
@@ -629,9 +681,6 @@ pub fn show(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> 
             if let Some(nh) = &entry.set_next_hop {
                 let _ = writeln!(buf, "  set: next-hop {}", nh);
             }
-        }
-        if let Some(default_action) = &policy.default_action {
-            let _ = writeln!(buf, " default-action: {}", default_action);
         }
     }
     Ok(buf)

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -305,7 +305,7 @@ impl ConfigBuilder {
                 list.entry.remove(&seq).context(ARG_ERR)?;
                 Ok(())
             })
-            .path("/entry/match/prefix-set")
+            .path("/entry/match/prefix")
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.entry(seq);
@@ -321,7 +321,7 @@ impl ConfigBuilder {
                 entry.prefix_set_name = None;
                 Ok(())
             })
-            .path("/entry/match/community-set")
+            .path("/entry/match/community")
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.entry(seq);
@@ -337,7 +337,7 @@ impl ConfigBuilder {
                 entry.community_set_name = None;
                 Ok(())
             })
-            .path("/entry/match/as-path-set")
+            .path("/entry/match/as-path")
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.entry(seq);
@@ -353,7 +353,7 @@ impl ConfigBuilder {
                 entry.as_path_set_name = None;
                 Ok(())
             })
-            .path("/entry/match/next-hop-set")
+            .path("/entry/match/next-hop")
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.entry(seq);

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -31,12 +31,12 @@ impl PolicyList {
 
 #[derive(EnumString, Display, Clone, Debug, PartialEq)]
 pub enum PolicyAction {
-    #[strum(serialize = "accept")]
-    Accept,
-    #[strum(serialize = "pass")]
-    Pass,
-    #[strum(serialize = "reject")]
-    Reject,
+    #[strum(serialize = "permit")]
+    Permit,
+    #[strum(serialize = "next")]
+    Next,
+    #[strum(serialize = "deny")]
+    Deny,
 }
 
 fn parse_origin(s: &str) -> Result<Origin> {
@@ -728,13 +728,13 @@ mod tests {
         let prefix = Ipv4Net::from_str("1.1.1.1/32").unwrap();
         prefix_set.insert(prefix.into(), PrefixSetEntry::default());
 
-        // Create a policy-list with entry that matches "pset" and has action accept (permit)
+        // Create a policy-list with an entry that matches "pset" and permits.
         let mut plist = PolicyList::default();
 
-        // Entry 10: match prefix-set "pset" and action accept
+        // Entry 10: match prefix-set "pset" and action permit.
         let entry = plist.entry(10);
         entry.prefix_set_name = Some("pset".to_string());
-        entry.action = Some(PolicyAction::Accept);
+        entry.action = Some(PolicyAction::Permit);
 
         // Verify the policy list configuration
         assert_eq!(plist.entry.len(), 1);
@@ -742,10 +742,10 @@ mod tests {
         assert_eq!(entry.prefix_set_name, Some("pset".to_string()));
 
         match &entry.action {
-            Some(PolicyAction::Accept) => {
-                // Test passes - action is Accept (permit)
+            Some(PolicyAction::Permit) => {
+                // Test passes - action is Permit.
             }
-            _ => panic!("Expected PolicyAction::Accept"),
+            _ => panic!("Expected PolicyAction::Permit"),
         }
 
         // Verify prefix-set contains the correct prefix

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -844,14 +844,39 @@ module config {
               "Reference to a prefix-set whose members are matched
                against the route's BGP NEXT_HOP attribute.";
           }
-          leaf "med-eq" {
-            type uint32;
-          }
-          leaf "med-ge" {
-            type uint32;
-          }
-          leaf "med-le" {
-            type uint32;
+          container "med" {
+            presence "match med";
+            description
+              "Match the route's MULTI_EXIT_DISC against a single
+               operator + value. Exactly one of `eq`, `le`, `ge`
+               must be set when the container is present —
+               schema-enforced via the `op` choice.";
+            choice "op" {
+              mandatory true;
+              description
+                "Comparison operator. Each case carries a
+                 mandatory uint32 operand; the bare-keyword case
+                 names mirror the CLI shape `match med eq NUM`,
+                 `match med le NUM`, `match med ge NUM`.";
+              case eq-case {
+                leaf "eq" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+              case le-case {
+                leaf "le" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+              case ge-case {
+                leaf "ge" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+            }
           }
           leaf "origin" {
             type enumeration {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -829,20 +829,27 @@ module config {
         }
         container "match" {
           ext:sort "7";
-          leaf "prefix-set" {
-            type string;
-          }
-          leaf "community-set" {
-            type string;
-          }
-          leaf "as-path-set" {
-            type string;
-          }
-          leaf "next-hop-set" {
+          leaf "prefix" {
             type string;
             description
-              "Reference to a prefix-set whose members are matched
-               against the route's BGP NEXT_HOP attribute.";
+              "Reference to a `prefix-set` by name.";
+          }
+          leaf "community" {
+            type string;
+            description
+              "Reference to a `community-set` by name.";
+          }
+          leaf "as-path" {
+            type string;
+            description
+              "Reference to an `as-path-set` by name.";
+          }
+          leaf "next-hop" {
+            type string;
+            description
+              "Reference to a `prefix-set` by name; its members
+               are matched against the route's BGP NEXT_HOP
+               attribute.";
           }
           container "med" {
             presence "match med";

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -965,10 +965,16 @@ module config {
         }
         leaf "action" {
           ext:sort "1";
+          description
+            "Terminal action when the entry matches.
+             `permit` accepts the route and stops scanning.
+             `deny` rejects the route.
+             `next` falls through to the next entry without
+             a verdict.";
           type enumeration {
-            enum accept;
-            enum reject;
-            enum pass;
+            enum permit;
+            enum deny;
+            enum next;
           }
         }
       }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -821,13 +821,6 @@ module config {
       leaf "name" {
         type string;
       }
-      leaf "default-action" {
-        ext:sort "10";
-        type enumeration {
-          enum accept;
-          enum reject;
-        }
-      }
       list entry {
         ext:sort "5";
         key "number";
@@ -879,11 +872,47 @@ module config {
           leaf "next-hop" {
             type inet:ipv4-address;
           }
-          leaf "community-set" {
-            type string;
-          }
-          leaf "community-additive" {
-            type boolean;
+          container "community" {
+            presence "set community";
+            description
+              "Apply a community-set to the route. The choice
+               between {replace-case|additive-case|delete-case}
+               selects the operation: replace (default) overwrites
+               the COMMUNITIES attribute with the set's members,
+               additive merges them in, delete removes them from
+               the existing attribute (set difference).";
+            leaf "name" {
+              type string;
+              mandatory true;
+              description
+                "Reference to a community-set by name.";
+            }
+            choice "mode" {
+              default replace-case;
+              description
+                "Operation applied to the route's COMMUNITIES
+                 attribute. The bare-keyword `additive` and
+                 `delete` cases mirror the CLI shape.";
+              case replace-case {
+                description "Default — overwrite the attribute.";
+              }
+              case additive-case {
+                leaf "additive" {
+                  type empty;
+                  description
+                    "Merge the set's members into the existing
+                     COMMUNITIES attribute.";
+                }
+              }
+              case delete-case {
+                leaf "delete" {
+                  type empty;
+                  description
+                    "Remove the set's members from the existing
+                     COMMUNITIES attribute.";
+                }
+              }
+            }
           }
           container "as-path-prepend" {
             presence "Prepend `asn` onto AS_PATH `repeat` times.";


### PR DESCRIPTION
## Summary
Four policy-schema cleanups stacked into one PR. Each commit is independent; reviewable per-commit.

### 1. `set community NAME {|additive|delete}` + drop `default-action`
Replace parallel `community-set` + boolean `community-additive` leaves with a presence container holding `name` (mandatory) and a `choice mode` whose three cases (`replace-case` empty default, `additive`, `delete`) mirror the CLI grammar 1:1. New `SetCommunityMode` enum + `SetCommunityConfig` struct collapses three peer fields into one. Adds `Delete` semantics (set difference). Same commit drops the dead `policy/default-action` leaf and its broken handler.

### 2. `match med {eq|le|ge} NUM`
Replaces three parallel `med-eq` / `med-ge` / `med-le` leaves with a presence container `med` carrying `choice op { mandatory true; }` — exactly-one-operator enforced at the schema level. New `MedMatch::Eq(u32) | Le(u32) | Ge(u32)` enum bundles operator + value into the variant; three `Option<u32>` fields collapse to one. Three focused tests replace the old combined-operator test (which the new schema can't represent).

### 3. Action keyword rename `accept/pass/reject` → `permit/next/deny`
Aligns per-entry terminal-action keywords with industry route-policy vocabulary (Cisco IOS-XR, FRR route-map). YANG enum cases + `PolicyAction` variants both renamed; strum serialize attrs match the new keywords.

### 4. Drop `-set` suffix from match leafrefs
`match prefix-set` → `match prefix`, `match community-set` → `match community`, `match as-path-set` → `match as-path`, `match next-hop-set` → `match next-hop`. Top-level `prefix-set NAME { ... }` / `community-set NAME { ... }` / `as-path-set NAME { ... }` definitions keep their existing names. 11 BDD configs migrated via context-aware sed (only indented refs, not top-level list defs).

## Test plan
- [x] `cargo build --release` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --exclude bdd` clean (existing community / med / multi-clause tests rewritten against the new types; 2 new community-delete tests + 3 split med-operator tests added)
- [x] `cargo fmt --all -- --check` clean
- [x] Smoke tests (per commit): all three set-community modes accepted, all three match-med operators accepted, `permit/deny/next` accepted while `accept` rejected, migrated YAML applies cleanly

Generated with [Claude Code](https://claude.com/claude-code)