### PR TITLE
policy: implement permit/next/deny control flow (Phase A)

### DIFF
--- a/bdd/tests/configs/bgp_basic_ebgp/z1-5.yaml
+++ b/bdd/tests/configs/bgp_basic_ebgp/z1-5.yaml
@@ -6,6 +6,7 @@ policy:
 - name: out-test
   entry:
   - number: 10
+    action: permit
     match:
       prefix: out-test
 router:

--- a/bdd/tests/configs/bgp_basic_ibgp/z1-5.yaml
+++ b/bdd/tests/configs/bgp_basic_ibgp/z1-5.yaml
@@ -6,6 +6,7 @@ policy:
 - name: out-test
   entry:
   - number: 10
+    action: permit
     match:
       prefix: out-test
 router:

--- a/bdd/tests/configs/bgp_gobgpd_rr/rr1.yaml
+++ b/bdd/tests/configs/bgp_gobgpd_rr/rr1.yaml
@@ -27,36 +27,43 @@ policy:
 - name: 198.18.37.16/28
   entry:
   - number: 10
+    action: permit
     match:
       community: 198.18.37.16/28
 - name: 198.18.37.80/28
   entry:
   - number: 10
+    action: permit
     match:
       community: 198.18.37.80/28
 - name: 198.18.39.80/28
   entry:
   - number: 10
+    action: permit
     match:
       community: 198.18.39.80/28
 - name: 198.18.39.96/28
   entry:
   - number: 10
+    action: permit
     match:
       community: 198.18.39.96/28
 - name: 198.18.39.128/28
   entry:
   - number: 10
+    action: permit
     match:
       community: 198.18.39.128/28
 - name: 198.18.39.144/28
   entry:
   - number: 10
+    action: permit
     match:
       community: 198.18.39.144/28
 - name: 198.18.39.160/28
   entry:
   - number: 10
+    action: permit
     match:
       community: 198.18.39.160/28
 router:

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-both.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-both.yaml
@@ -7,6 +7,7 @@ policy:
 - name: HOGE
   entry:
   - number: 10
+    action: permit
     match:
       prefix: HOGE
 router:

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-initial.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-initial.yaml
@@ -6,6 +6,7 @@ policy:
 - name: HOGE
   entry:
   - number: 10
+    action: permit
     match:
       prefix: HOGE
 router:

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-other.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-other.yaml
@@ -6,6 +6,7 @@ policy:
 - name: HOGE
   entry:
   - number: 10
+    action: permit
     match:
       prefix: HOGE
 router:

--- a/bdd/tests/configs/bgp_route_map_match/z1.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z1.yaml
@@ -7,6 +7,7 @@ policy:
 - name: SET-MED-100
   entry:
   - number: 10
+    action: permit
     match:
       prefix: ALL-V4
     set:

--- a/bdd/tests/configs/bgp_route_map_match/z2-aspath-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-aspath-fail.yaml
@@ -6,6 +6,7 @@ policy:
 - name: IN-ASPATH
   entry:
   - number: 10
+    action: permit
     match:
       as-path: FROM-65999
 router:

--- a/bdd/tests/configs/bgp_route_map_match/z2-aspath-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-aspath-pass.yaml
@@ -6,6 +6,7 @@ policy:
 - name: IN-ASPATH
   entry:
   - number: 10
+    action: permit
     match:
       as-path: FROM-65001
 router:

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-eq-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-eq-fail.yaml
@@ -2,6 +2,7 @@ policy:
 - name: IN-MED
   entry:
   - number: 10
+    action: permit
     match:
       med-eq: 999
 router:

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-eq-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-eq-pass.yaml
@@ -2,6 +2,7 @@ policy:
 - name: IN-MED
   entry:
   - number: 10
+    action: permit
     match:
       med-eq: 100
 router:

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-range-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-range-fail.yaml
@@ -2,6 +2,7 @@ policy:
 - name: IN-MED
   entry:
   - number: 10
+    action: permit
     match:
       med-ge: 200
 router:

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-range-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-range-pass.yaml
@@ -2,6 +2,7 @@ policy:
 - name: IN-MED
   entry:
   - number: 10
+    action: permit
     match:
       med-ge: 50
       med-le: 200

--- a/bdd/tests/configs/bgp_route_map_match/z2-nh-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-nh-fail.yaml
@@ -7,6 +7,7 @@ policy:
 - name: IN-NEXTHOP
   entry:
   - number: 10
+    action: permit
     match:
       next-hop: WRONG-SUBNET
 router:

--- a/bdd/tests/configs/bgp_route_map_match/z2-nh-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-nh-pass.yaml
@@ -7,6 +7,7 @@ policy:
 - name: IN-NEXTHOP
   entry:
   - number: 10
+    action: permit
     match:
       next-hop: PEER-SUBNET
 router:

--- a/bdd/tests/configs/bgp_route_map_match/z2-origin-egp.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-origin-egp.yaml
@@ -2,6 +2,7 @@ policy:
 - name: IN-ORIGIN
   entry:
   - number: 10
+    action: permit
     match:
       origin: egp
 router:

--- a/bdd/tests/configs/bgp_route_map_match/z2-origin-igp.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-origin-igp.yaml
@@ -2,6 +2,7 @@ policy:
 - name: IN-ORIGIN
   entry:
   - number: 10
+    action: permit
     match:
       origin: igp
 router:

--- a/bdd/tests/configs/bgp_update_group_ipv4/z1-1.yaml
+++ b/bdd/tests/configs/bgp_update_group_ipv4/z1-1.yaml
@@ -32,6 +32,8 @@ policy:
 - name: out-shared
   entry:
   - number: 10
+    action: permit
 - name: out-different
   entry:
   - number: 10
+    action: permit

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2504,32 +2504,63 @@ impl Peer {
     }
 }
 
+/// Apply a policy to a route. Walks entries in numeric-key order;
+/// on each match consults the entry's terminal action:
+///
+/// - **`permit`**: apply any `set` clauses, return the modified
+///   attribute (the route is accepted).
+/// - **`next`**: apply any `set` clauses, then continue to the
+///   next entry. Lets one entry decorate a route while another
+///   later entry decides the verdict.
+/// - **`deny`**: do NOT apply any `set` clauses; return `None`
+///   (the route is dropped).
+///
+/// Default-deny when no entry matches (or all matching entries
+/// fall through with `next` and the policy ends): returns `None`.
+/// Operators express "default permit" by appending an
+/// unconditional final entry with `action: permit`.
 pub fn policy_list_apply(
     policy_list: &PolicyList,
     nlri: &Ipv4Nlri,
     mut bgp_attr: BgpAttr,
 ) -> Option<BgpAttr> {
+    use crate::policy::PolicyAction;
     for (_, entry) in policy_list.entry.iter() {
         if !entry_matches(entry, nlri, &bgp_attr) {
             continue;
         }
-        if let Some(local_pref) = &entry.local_pref {
-            bgp_attr.local_pref = Some(LocalPref::new(*local_pref));
+        match entry.action {
+            PolicyAction::Deny => {
+                // Drop the route without applying any set clauses.
+                return None;
+            }
+            PolicyAction::Permit | PolicyAction::Next => {
+                // Apply the entry's set clauses to the working
+                // attribute, then either return (Permit) or fall
+                // through to the next entry (Next).
+                if let Some(local_pref) = &entry.local_pref {
+                    bgp_attr.local_pref = Some(LocalPref::new(*local_pref));
+                }
+                if let Some(med) = &entry.med {
+                    bgp_attr.med = Some(Med { med: *med });
+                }
+                if let Some(cfg) = &entry.set_community {
+                    apply_set_community(&mut bgp_attr, cfg);
+                }
+                if let Some(prepend) = &entry.set_as_path_prepend {
+                    apply_set_as_path_prepend(&mut bgp_attr, prepend);
+                }
+                if let Some(addr) = &entry.set_next_hop {
+                    bgp_attr.nexthop = Some(BgpNexthop::Ipv4(*addr));
+                }
+                if entry.action == PolicyAction::Permit {
+                    return Some(bgp_attr);
+                }
+                // Next: continue with the modified attribute.
+            }
         }
-        if let Some(med) = &entry.med {
-            bgp_attr.med = Some(Med { med: *med });
-        }
-        if let Some(cfg) = &entry.set_community {
-            apply_set_community(&mut bgp_attr, cfg);
-        }
-        if let Some(prepend) = &entry.set_as_path_prepend {
-            apply_set_as_path_prepend(&mut bgp_attr, prepend);
-        }
-        if let Some(addr) = &entry.set_next_hop {
-            bgp_attr.nexthop = Some(BgpNexthop::Ipv4(*addr));
-        }
-        return Some(bgp_attr);
     }
+    // End of list reached without a permit verdict — default deny.
     None
 }
 
@@ -3447,9 +3478,10 @@ mod tests {
     use ipnet::Ipv4Net;
 
     use super::policy_list_apply;
+    use crate::policy::prefix::set::PrefixSetEntry;
     use crate::policy::{
-        AsPathPrependConfig, CommunityMatcher, CommunitySet, PolicyList, SetCommunityConfig,
-        SetCommunityMode,
+        AsPathPrependConfig, CommunityMatcher, CommunitySet, PolicyList, PrefixSet,
+        SetCommunityConfig, SetCommunityMode,
     };
 
     fn set_community_cfg(members: &[&str], mode: SetCommunityMode) -> SetCommunityConfig {
@@ -3710,5 +3742,94 @@ mod tests {
             BgpNexthop::Ipv4(a) => assert_eq!(a, Ipv4Addr::new(10, 1, 1, 1)),
             other => panic!("expected Ipv4 nexthop, got {:?}", other),
         }
+    }
+
+    // ── Phase A: control-flow semantics for permit / next / deny ──
+
+    #[test]
+    fn policy_action_deny_drops_route_and_skips_set() {
+        let mut list = PolicyList::default();
+        let entry = list.entry(10);
+        entry.local_pref = Some(999);
+        entry.action = crate::policy::PolicyAction::Deny;
+
+        // Match clause empty → entry matches every route.
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), BgpAttr::default());
+        assert!(out.is_none(), "deny must drop the route");
+    }
+
+    #[test]
+    fn policy_action_next_applies_set_and_falls_through() {
+        let mut list = PolicyList::default();
+        list.entry(10).local_pref = Some(150);
+        list.entry(10).action = crate::policy::PolicyAction::Next;
+        // Entry 20 takes the verdict.
+        list.entry(20).med = Some(42);
+        list.entry(20).action = crate::policy::PolicyAction::Permit;
+
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), BgpAttr::default()).unwrap();
+        // Both decorations applied: entry 10's local_pref AND
+        // entry 20's med.
+        assert_eq!(out.local_pref.unwrap().local_pref, 150);
+        assert_eq!(out.med.unwrap().med, 42);
+    }
+
+    #[test]
+    fn policy_action_default_deny_when_no_entry_matches() {
+        let mut list = PolicyList::default();
+        // Entry only matches a non-default prefix.
+        let entry = list.entry(10);
+        let mut pset = PrefixSet::default();
+        pset.insert(
+            Ipv4Net::from_str("192.168.0.0/16").unwrap().into(),
+            PrefixSetEntry::default(),
+        );
+        entry.prefix_set = Some(pset);
+        entry.action = crate::policy::PolicyAction::Permit;
+
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), BgpAttr::default());
+        assert!(out.is_none(), "no match → default deny");
+    }
+
+    #[test]
+    fn policy_action_next_falling_through_to_end_of_list_is_default_deny() {
+        let mut list = PolicyList::default();
+        list.entry(10).local_pref = Some(150);
+        list.entry(10).action = crate::policy::PolicyAction::Next;
+        // No further entries — fall-through past the end of the
+        // policy is default-deny.
+
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), BgpAttr::default());
+        assert!(
+            out.is_none(),
+            "next falling through end of policy → default deny"
+        );
+    }
+
+    #[test]
+    fn policy_action_default_permit_via_unconditional_final_entry() {
+        // The "default permit" idiom: a final entry with no match
+        // clauses and action=permit accepts everything that fell
+        // through.
+        let mut list = PolicyList::default();
+        let mut pset = PrefixSet::default();
+        pset.insert(
+            Ipv4Net::from_str("10.0.0.0/8").unwrap().into(),
+            PrefixSetEntry::default(),
+        );
+        let entry = list.entry(10);
+        entry.prefix_set = Some(pset);
+        entry.action = crate::policy::PolicyAction::Deny;
+
+        // Final unconditional permit — the "default permit" idiom.
+        list.entry(20).action = crate::policy::PolicyAction::Permit;
+
+        // 10.0.0.0/24 hits entry 10 (deny).
+        let denied = policy_list_apply(&list, &nlri("10.0.0.0/24"), BgpAttr::default());
+        assert!(denied.is_none());
+
+        // 192.168.0.0/24 falls through to entry 20 (permit).
+        let permitted = policy_list_apply(&list, &nlri("192.168.0.0/24"), BgpAttr::default());
+        assert!(permitted.is_some());
     }
 }

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -29,8 +29,18 @@ impl PolicyList {
     }
 }
 
-#[derive(EnumString, Display, Clone, Debug, PartialEq)]
+/// Per-entry terminal action. `permit` accepts the route and stops
+/// scanning. `deny` rejects the route. `next` falls through to the
+/// next entry (after applying any `set`).
+///
+/// `Default` returns `Permit` so a partially-constructed
+/// `PolicyEntry` (e.g. mid config commit, before the YANG callback
+/// has fired) doesn't silently flip semantics. The YANG schema
+/// requires `action` to be explicitly set on every entry, so the
+/// default is only ever observed transiently.
+#[derive(EnumString, Display, Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum PolicyAction {
+    #[default]
     #[strum(serialize = "permit")]
     Permit,
     #[strum(serialize = "next")]
@@ -125,7 +135,7 @@ pub struct PolicyEntry {
     pub set_as_path_prepend: Option<AsPathPrependConfig>,
     pub set_next_hop: Option<Ipv4Addr>,
     // Action.
-    pub action: Option<PolicyAction>,
+    pub action: PolicyAction,
 }
 
 pub fn policy_entry_sync(
@@ -623,16 +633,16 @@ impl ConfigBuilder {
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.entry(seq);
-
-                let action: PolicyAction = args.string().context(ARG_ERR)?.parse()?;
-                entry.action = Some(action);
-
+                entry.action = args.string().context(ARG_ERR)?.parse()?;
                 Ok(())
             })
             .del(|policy, cache, name, seq, _args| {
                 let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.lookup(&seq).context(ARG_ERR)?;
-                entry.action = None;
+                // YANG marks `action` mandatory; deleting just the
+                // leaf reverts to the default (Permit). The whole
+                // entry should be deleted to remove the policy line.
+                entry.action = PolicyAction::default();
                 Ok(())
             })
     }
@@ -734,19 +744,13 @@ mod tests {
         // Entry 10: match prefix-set "pset" and action permit.
         let entry = plist.entry(10);
         entry.prefix_set_name = Some("pset".to_string());
-        entry.action = Some(PolicyAction::Permit);
+        entry.action = PolicyAction::Permit;
 
         // Verify the policy list configuration
         assert_eq!(plist.entry.len(), 1);
         let entry = plist.entry.get(&10).unwrap();
         assert_eq!(entry.prefix_set_name, Some("pset".to_string()));
-
-        match &entry.action {
-            Some(PolicyAction::Permit) => {
-                // Test passes - action is Permit.
-            }
-            _ => panic!("Expected PolicyAction::Permit"),
-        }
+        assert_eq!(entry.action, PolicyAction::Permit);
 
         // Verify prefix-set contains the correct prefix
         assert_eq!(prefix_set.len(), 1);

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -972,12 +972,18 @@ module config {
         }
         leaf "action" {
           ext:sort "1";
+          mandatory true;
           description
-            "Terminal action when the entry matches.
-             `permit` accepts the route and stops scanning.
-             `deny` rejects the route.
-             `next` falls through to the next entry without
-             a verdict.";
+            "Terminal action when the entry matches. Mandatory
+             on every entry; the policy walker honors the value.
+             `permit` accepts the route and stops scanning, after
+             applying any `set` clauses.
+             `deny` rejects the route. No `set` clauses are
+             applied.
+             `next` applies any `set` clauses, then falls through
+             to the next entry. Default-deny applies when no entry
+             matches (or all matching entries fall through with
+             `next`).";
           type enumeration {
             enum permit;
             enum deny;


### PR DESCRIPTION
## Summary

Phase A of the policy statement spec — make `action` mandatory and implement `permit` / `next` / `deny` semantics with default-deny.

- YANG: `policy/entry/action` is now `mandatory true` with documented permit/next/deny semantics.
- `PolicyAction` derives `Default` (Permit) + `Copy`; `PolicyEntry::action` changed from `Option<PolicyAction>` to `PolicyAction`.
- `policy_list_apply` rewritten:
  - `permit`: apply set clauses, accept route, stop scanning.
  - `next`: apply set clauses, fall through to next entry.
  - `deny`: drop route, no set clauses applied.
  - Default-deny when no entry matches or the list ends with `next`.
- 5 new control-flow tests in `bgp/route.rs` covering deny, next, default-deny, fall-through to end-of-list, and unconditional final-permit.
- 18 BDD YAML configs migrated to add explicit `action: permit`.

## Test plan

- [x] `cargo build --release`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` (5 new tests pass)
- [x] `cargo fmt --all --check`
- [x] Smoke: migrated YAML applies cleanly; deny-action config applies cleanly.

Generated with [Claude Code](https://claude.com/claude-code)