### PR TITLE
policy: add numeric match clauses (Phase B)

### DIFF
--- a/crates/bgp-packet/src/attrs/aspath.rs
+++ b/crates/bgp-packet/src/attrs/aspath.rs
@@ -332,6 +332,20 @@ impl As4Path {
         self.length
     }
 
+    /// Returns the count of distinct ASes across all segments
+    /// (sequences, sets, confederation segments). Used by the
+    /// policy engine for `match as-path-len-uniq`.
+    pub fn unique_length(&self) -> u32 {
+        use std::collections::HashSet;
+        let mut seen: HashSet<u32> = HashSet::new();
+        for seg in &self.segs {
+            for asn in &seg.asn {
+                seen.insert(*asn);
+            }
+        }
+        seen.len() as u32
+    }
+
     /// Prepend an AS path to this path.
     /// Returns a new AS path with `other` prepended to `self`.
     pub fn prepend(&self, other: Self) -> Self {

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2591,12 +2591,43 @@ fn entry_matches(entry: &crate::policy::PolicyEntry, nlri: &Ipv4Nlri, bgp_attr: 
     }
     if let Some(med_match) = &entry.match_med {
         let med = bgp_attr.med.as_ref().map(|m| m.med).unwrap_or(0);
-        let ok = match med_match {
-            crate::policy::MedMatch::Eq(v) => med == *v,
-            crate::policy::MedMatch::Le(v) => med <= *v,
-            crate::policy::MedMatch::Ge(v) => med >= *v,
-        };
-        if !ok {
+        if !med_match.matches(med) {
+            return false;
+        }
+    }
+    if let Some(m) = &entry.match_as_path_len {
+        let len = bgp_attr.aspath.as_ref().map(|p| p.length()).unwrap_or(0);
+        if !m.matches(len) {
+            return false;
+        }
+    }
+    if let Some(m) = &entry.match_as_path_len_uniq {
+        let uniq = bgp_attr
+            .aspath
+            .as_ref()
+            .map(|p| p.unique_length())
+            .unwrap_or(0);
+        if !m.matches(uniq) {
+            return false;
+        }
+    }
+    if let Some(m) = &entry.match_local_pref {
+        let lp = bgp_attr
+            .local_pref
+            .as_ref()
+            .map(|l| l.local_pref)
+            .unwrap_or(0);
+        if !m.matches(lp) {
+            return false;
+        }
+    }
+    if let Some(m) = &entry.match_weight {
+        // BGP weight is a per-router/per-route attribute that the
+        // local router carries in its RIB, not on the wire. Until
+        // we plumb a weight field through BgpAttr, treat absence
+        // as 0 — only `eq 0` / `le N` style matches will succeed.
+        let weight = 0u32;
+        if !m.matches(weight) {
             return false;
         }
     }
@@ -3308,7 +3339,7 @@ mod policy_apply_tests {
 
     use super::*;
     use crate::policy::prefix::set::PrefixSetEntry;
-    use crate::policy::{AsPathMatcher, AsPathSet, MedMatch, PolicyList, PrefixSet};
+    use crate::policy::{AsPathMatcher, AsPathSet, NumericMatch, PolicyList, PrefixSet};
 
     fn nlri(prefix: &str) -> Ipv4Nlri {
         Ipv4Nlri {
@@ -3345,7 +3376,7 @@ mod policy_apply_tests {
     #[test]
     fn match_med_ge() {
         let mut list = PolicyList::default();
-        list.entry(10).match_med = Some(MedMatch::Ge(100));
+        list.entry(10).match_med = Some(NumericMatch::Ge(100));
 
         assert!(
             policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", Some(150), None))
@@ -3364,7 +3395,7 @@ mod policy_apply_tests {
     #[test]
     fn match_med_le() {
         let mut list = PolicyList::default();
-        list.entry(10).match_med = Some(MedMatch::Le(200));
+        list.entry(10).match_med = Some(NumericMatch::Le(200));
 
         assert!(
             policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", Some(150), None))
@@ -3384,7 +3415,7 @@ mod policy_apply_tests {
     #[test]
     fn match_med_eq() {
         let mut list = PolicyList::default();
-        list.entry(10).match_med = Some(MedMatch::Eq(100));
+        list.entry(10).match_med = Some(NumericMatch::Eq(100));
 
         assert!(
             policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", Some(100), None))
@@ -3452,7 +3483,7 @@ mod policy_apply_tests {
         let entry = list.entry(10);
         entry.as_path_set = Some(set);
         entry.match_origin = Some(Origin::Igp);
-        entry.match_med = Some(MedMatch::Le(50));
+        entry.match_med = Some(NumericMatch::Le(50));
 
         let pass = attr_with("65001 65002", Some(40), Some(Origin::Igp));
         let bad_origin = attr_with("65001 65002", Some(40), Some(Origin::Egp));
@@ -3463,6 +3494,116 @@ mod policy_apply_tests {
         assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), bad_origin).is_none());
         assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), bad_med).is_none());
         assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), bad_path).is_none());
+    }
+
+    #[test]
+    fn match_as_path_len() {
+        // `1 2 3 4 5` -> length 5.
+        let mut list = PolicyList::default();
+        list.entry(10).match_as_path_len = Some(NumericMatch::Eq(5));
+        assert!(
+            policy_list_apply(
+                &list,
+                &nlri("10.0.0.0/8"),
+                attr_with("1 2 3 4 5", None, None)
+            )
+            .is_some()
+        );
+        assert!(
+            policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1 2 3 4", None, None))
+                .is_none()
+        );
+
+        let mut list = PolicyList::default();
+        list.entry(10).match_as_path_len = Some(NumericMatch::Ge(3));
+        assert!(
+            policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1 2 3", None, None)).is_some()
+        );
+        assert!(
+            policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1 2", None, None)).is_none()
+        );
+    }
+
+    #[test]
+    fn match_as_path_len_uniq() {
+        // `1 2 1 2 1` -> length 5, unique 2.
+        let mut list = PolicyList::default();
+        list.entry(10).match_as_path_len_uniq = Some(NumericMatch::Eq(2));
+        assert!(
+            policy_list_apply(
+                &list,
+                &nlri("10.0.0.0/8"),
+                attr_with("1 2 1 2 1", None, None)
+            )
+            .is_some()
+        );
+        // `1 2 3 4 5` -> length 5, unique 5: `eq 2` should miss.
+        assert!(
+            policy_list_apply(
+                &list,
+                &nlri("10.0.0.0/8"),
+                attr_with("1 2 3 4 5", None, None)
+            )
+            .is_none()
+        );
+
+        let mut list = PolicyList::default();
+        list.entry(10).match_as_path_len_uniq = Some(NumericMatch::Le(3));
+        assert!(
+            policy_list_apply(
+                &list,
+                &nlri("10.0.0.0/8"),
+                attr_with("1 2 1 2 1", None, None)
+            )
+            .is_some()
+        );
+        assert!(
+            policy_list_apply(
+                &list,
+                &nlri("10.0.0.0/8"),
+                attr_with("1 2 3 4 5", None, None)
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn match_local_preference() {
+        use bgp_packet::LocalPref;
+        let mut list = PolicyList::default();
+        list.entry(10).match_local_pref = Some(NumericMatch::Ge(100));
+
+        let mut attr_hi = attr_with("1", None, None);
+        attr_hi.local_pref = Some(LocalPref::new(150));
+        let mut attr_eq = attr_with("1", None, None);
+        attr_eq.local_pref = Some(LocalPref::new(100));
+        let mut attr_lo = attr_with("1", None, None);
+        attr_lo.local_pref = Some(LocalPref::new(50));
+
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_hi).is_some());
+        assert!(
+            policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_eq).is_some(),
+            "ge accepts equality"
+        );
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_lo).is_none());
+    }
+
+    #[test]
+    fn match_weight_treats_absent_as_zero() {
+        // Weight is not yet plumbed onto BgpAttr; the matcher reads
+        // 0 as a placeholder. Lock that contract: `eq 0` and `le N`
+        // with N>=0 succeed; `ge 1` fails.
+        let mut list = PolicyList::default();
+        list.entry(10).match_weight = Some(NumericMatch::Eq(0));
+        assert!(
+            policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", None, None)).is_some()
+        );
+
+        let mut list = PolicyList::default();
+        list.entry(10).match_weight = Some(NumericMatch::Ge(1));
+        assert!(
+            policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", None, None)).is_none()
+        );
     }
 }
 

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -73,14 +73,40 @@ impl AsPathPrependConfig {
     }
 }
 
-/// Operator for `match med {eq|le|ge} NUM`. The operand is bundled
-/// into the variant so the type itself encodes "exactly one operator
-/// with its value".
+/// Operator for numeric match clauses (`match med`,
+/// `match as-path-len`, `match as-path-len-uniq`,
+/// `match local-preference`, `match weight`) of shape
+/// `{eq|le|ge} NUM`. The operand is bundled into the variant so
+/// the type itself encodes "exactly one operator with its value".
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum MedMatch {
+pub enum NumericMatch {
     Eq(u32),
     Le(u32),
     Ge(u32),
+}
+
+impl NumericMatch {
+    pub fn op_str(&self) -> &'static str {
+        match self {
+            NumericMatch::Eq(_) => "eq",
+            NumericMatch::Le(_) => "le",
+            NumericMatch::Ge(_) => "ge",
+        }
+    }
+
+    pub fn value(&self) -> u32 {
+        match self {
+            NumericMatch::Eq(v) | NumericMatch::Le(v) | NumericMatch::Ge(v) => *v,
+        }
+    }
+
+    pub fn matches(&self, v: u32) -> bool {
+        match self {
+            NumericMatch::Eq(target) => v == *target,
+            NumericMatch::Le(target) => v <= *target,
+            NumericMatch::Ge(target) => v >= *target,
+        }
+    }
 }
 
 /// Operation applied by `set community NAME {|additive|delete}`.
@@ -126,7 +152,11 @@ pub struct PolicyEntry {
     pub as_path_set: Option<AsPathSet>,
     pub next_hop_set_name: Option<String>,
     pub next_hop_set: Option<PrefixSet>,
-    pub match_med: Option<MedMatch>,
+    pub match_med: Option<NumericMatch>,
+    pub match_as_path_len: Option<NumericMatch>,
+    pub match_as_path_len_uniq: Option<NumericMatch>,
+    pub match_local_pref: Option<NumericMatch>,
+    pub match_weight: Option<NumericMatch>,
     pub match_origin: Option<Origin>,
     // Set.
     pub local_pref: Option<u32>,
@@ -388,13 +418,13 @@ impl ConfigBuilder {
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.entry(seq);
-                entry.match_med = Some(MedMatch::Eq(args.u32().context(ARG_ERR)?));
+                entry.match_med = Some(NumericMatch::Eq(args.u32().context(ARG_ERR)?));
                 Ok(())
             })
             .del(|policy, cache, name, seq, _args| {
                 let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.lookup(&seq).context(ARG_ERR)?;
-                if matches!(entry.match_med, Some(MedMatch::Eq(_))) {
+                if matches!(entry.match_med, Some(NumericMatch::Eq(_))) {
                     entry.match_med = None;
                 }
                 Ok(())
@@ -403,13 +433,13 @@ impl ConfigBuilder {
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.entry(seq);
-                entry.match_med = Some(MedMatch::Le(args.u32().context(ARG_ERR)?));
+                entry.match_med = Some(NumericMatch::Le(args.u32().context(ARG_ERR)?));
                 Ok(())
             })
             .del(|policy, cache, name, seq, _args| {
                 let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.lookup(&seq).context(ARG_ERR)?;
-                if matches!(entry.match_med, Some(MedMatch::Le(_))) {
+                if matches!(entry.match_med, Some(NumericMatch::Le(_))) {
                     entry.match_med = None;
                 }
                 Ok(())
@@ -418,13 +448,13 @@ impl ConfigBuilder {
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.entry(seq);
-                entry.match_med = Some(MedMatch::Ge(args.u32().context(ARG_ERR)?));
+                entry.match_med = Some(NumericMatch::Ge(args.u32().context(ARG_ERR)?));
                 Ok(())
             })
             .del(|policy, cache, name, seq, _args| {
                 let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.lookup(&seq).context(ARG_ERR)?;
-                if matches!(entry.match_med, Some(MedMatch::Ge(_))) {
+                if matches!(entry.match_med, Some(NumericMatch::Ge(_))) {
                     entry.match_med = None;
                 }
                 Ok(())
@@ -435,6 +465,218 @@ impl ConfigBuilder {
                 let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.lookup(&seq).context(ARG_ERR)?;
                 entry.match_med = None;
+                Ok(())
+            })
+            // `match as-path-len {eq|le|ge} NUM` — same shape as med.
+            .path("/entry/match/as-path-len/eq")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.match_as_path_len = Some(NumericMatch::Eq(args.u32().context(ARG_ERR)?));
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if matches!(entry.match_as_path_len, Some(NumericMatch::Eq(_))) {
+                    entry.match_as_path_len = None;
+                }
+                Ok(())
+            })
+            .path("/entry/match/as-path-len/le")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.match_as_path_len = Some(NumericMatch::Le(args.u32().context(ARG_ERR)?));
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if matches!(entry.match_as_path_len, Some(NumericMatch::Le(_))) {
+                    entry.match_as_path_len = None;
+                }
+                Ok(())
+            })
+            .path("/entry/match/as-path-len/ge")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.match_as_path_len = Some(NumericMatch::Ge(args.u32().context(ARG_ERR)?));
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if matches!(entry.match_as_path_len, Some(NumericMatch::Ge(_))) {
+                    entry.match_as_path_len = None;
+                }
+                Ok(())
+            })
+            .path("/entry/match/as-path-len")
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.match_as_path_len = None;
+                Ok(())
+            })
+            // `match as-path-len-uniq {eq|le|ge} NUM` — same shape.
+            .path("/entry/match/as-path-len-uniq/eq")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.match_as_path_len_uniq = Some(NumericMatch::Eq(args.u32().context(ARG_ERR)?));
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if matches!(entry.match_as_path_len_uniq, Some(NumericMatch::Eq(_))) {
+                    entry.match_as_path_len_uniq = None;
+                }
+                Ok(())
+            })
+            .path("/entry/match/as-path-len-uniq/le")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.match_as_path_len_uniq = Some(NumericMatch::Le(args.u32().context(ARG_ERR)?));
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if matches!(entry.match_as_path_len_uniq, Some(NumericMatch::Le(_))) {
+                    entry.match_as_path_len_uniq = None;
+                }
+                Ok(())
+            })
+            .path("/entry/match/as-path-len-uniq/ge")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.match_as_path_len_uniq = Some(NumericMatch::Ge(args.u32().context(ARG_ERR)?));
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if matches!(entry.match_as_path_len_uniq, Some(NumericMatch::Ge(_))) {
+                    entry.match_as_path_len_uniq = None;
+                }
+                Ok(())
+            })
+            .path("/entry/match/as-path-len-uniq")
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.match_as_path_len_uniq = None;
+                Ok(())
+            })
+            // `match local-preference {eq|le|ge} NUM` — same shape.
+            .path("/entry/match/local-preference/eq")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.match_local_pref = Some(NumericMatch::Eq(args.u32().context(ARG_ERR)?));
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if matches!(entry.match_local_pref, Some(NumericMatch::Eq(_))) {
+                    entry.match_local_pref = None;
+                }
+                Ok(())
+            })
+            .path("/entry/match/local-preference/le")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.match_local_pref = Some(NumericMatch::Le(args.u32().context(ARG_ERR)?));
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if matches!(entry.match_local_pref, Some(NumericMatch::Le(_))) {
+                    entry.match_local_pref = None;
+                }
+                Ok(())
+            })
+            .path("/entry/match/local-preference/ge")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.match_local_pref = Some(NumericMatch::Ge(args.u32().context(ARG_ERR)?));
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if matches!(entry.match_local_pref, Some(NumericMatch::Ge(_))) {
+                    entry.match_local_pref = None;
+                }
+                Ok(())
+            })
+            .path("/entry/match/local-preference")
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.match_local_pref = None;
+                Ok(())
+            })
+            // `match weight {eq|le|ge} NUM` — same shape.
+            .path("/entry/match/weight/eq")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.match_weight = Some(NumericMatch::Eq(args.u32().context(ARG_ERR)?));
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if matches!(entry.match_weight, Some(NumericMatch::Eq(_))) {
+                    entry.match_weight = None;
+                }
+                Ok(())
+            })
+            .path("/entry/match/weight/le")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.match_weight = Some(NumericMatch::Le(args.u32().context(ARG_ERR)?));
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if matches!(entry.match_weight, Some(NumericMatch::Le(_))) {
+                    entry.match_weight = None;
+                }
+                Ok(())
+            })
+            .path("/entry/match/weight/ge")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.match_weight = Some(NumericMatch::Ge(args.u32().context(ARG_ERR)?));
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if matches!(entry.match_weight, Some(NumericMatch::Ge(_))) {
+                    entry.match_weight = None;
+                }
+                Ok(())
+            })
+            .path("/entry/match/weight")
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.match_weight = None;
                 Ok(())
             })
             .path("/entry/match/origin")
@@ -682,13 +924,30 @@ pub fn show(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> 
             if let Some(next_hop_set) = &entry.next_hop_set_name {
                 let _ = writeln!(buf, "  match: next_hop_set {}", next_hop_set);
             }
-            if let Some(med) = &entry.match_med {
-                let (op, value) = match med {
-                    MedMatch::Eq(v) => ("eq", v),
-                    MedMatch::Le(v) => ("le", v),
-                    MedMatch::Ge(v) => ("ge", v),
-                };
-                let _ = writeln!(buf, "  match: med {} {}", op, value);
+            if let Some(m) = &entry.match_med {
+                let _ = writeln!(buf, "  match: med {} {}", m.op_str(), m.value());
+            }
+            if let Some(m) = &entry.match_as_path_len {
+                let _ = writeln!(buf, "  match: as-path-len {} {}", m.op_str(), m.value());
+            }
+            if let Some(m) = &entry.match_as_path_len_uniq {
+                let _ = writeln!(
+                    buf,
+                    "  match: as-path-len-uniq {} {}",
+                    m.op_str(),
+                    m.value()
+                );
+            }
+            if let Some(m) = &entry.match_local_pref {
+                let _ = writeln!(
+                    buf,
+                    "  match: local-preference {} {}",
+                    m.op_str(),
+                    m.value()
+                );
+            }
+            if let Some(m) = &entry.match_weight {
+                let _ = writeln!(buf, "  match: weight {} {}", m.op_str(), m.value());
             }
             if let Some(origin) = &entry.match_origin {
                 let _ = writeln!(buf, "  match: origin {:?}", origin);

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -885,6 +885,117 @@ module config {
               }
             }
           }
+          container "as-path-len" {
+            presence "match as-path-len";
+            description
+              "Match the total length of the route's AS_PATH
+               (count of ASes across all segments) against
+               `eq`/`le`/`ge` NUM. Same shape as `match med`.";
+            choice "op" {
+              mandatory true;
+              case eq-case {
+                leaf "eq" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+              case le-case {
+                leaf "le" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+              case ge-case {
+                leaf "ge" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+            }
+          }
+          container "as-path-len-uniq" {
+            presence "match as-path-len-uniq";
+            description
+              "Match the count of distinct ASes in the route's
+               AS_PATH (duplicates collapsed) against
+               `eq`/`le`/`ge` NUM. Same shape as `match med`.";
+            choice "op" {
+              mandatory true;
+              case eq-case {
+                leaf "eq" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+              case le-case {
+                leaf "le" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+              case ge-case {
+                leaf "ge" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+            }
+          }
+          container "local-preference" {
+            presence "match local-preference";
+            description
+              "Match the route's LOCAL_PREF attribute against
+               `eq`/`le`/`ge` NUM. Same shape as `match med`.";
+            choice "op" {
+              mandatory true;
+              case eq-case {
+                leaf "eq" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+              case le-case {
+                leaf "le" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+              case ge-case {
+                leaf "ge" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+            }
+          }
+          container "weight" {
+            presence "match weight";
+            description
+              "Match the route's BGP weight (per-router,
+               implementation attribute) against `eq`/`le`/`ge`
+               NUM. Same shape as `match med`.";
+            choice "op" {
+              mandatory true;
+              case eq-case {
+                leaf "eq" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+              case le-case {
+                leaf "le" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+              case ge-case {
+                leaf "ge" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+            }
+          }
           leaf "origin" {
             type enumeration {
               enum igp;


### PR DESCRIPTION
## Summary

Phase B of the policy statement spec — add four numeric match clauses in the `{eq|le|ge} NUM` shape already used by `match med`:

- `match as-path-len {eq|le|ge} NUM` — total AS_PATH length
- `match as-path-len-uniq {eq|le|ge} NUM` — count of distinct ASes
- `match local-preference {eq|le|ge} NUM` — LOCAL_PREF attribute
- `match weight {eq|le|ge} NUM` — BGP weight (per-router; not yet plumbed onto `BgpAttr`, so reads 0 — documented in test)

## Changes

- **YANG**: four new presence containers under `policy/entry/match`, each with a mandatory `op` choice (eq/le/ge cases).
- **Rust**: `MedMatch` -> `NumericMatch` (no longer med-specific), with `op_str`/`value`/`matches` helpers that simplify both show and the matcher.
- `PolicyEntry` gains four `Option<NumericMatch>` fields.
- 16 new path handlers (3 ops + 1 container-delete per clause).
- `As4Path::unique_length()` added to bgp-packet — flattens all segments and counts distinct ASes.
- 4 new tests in `bgp/route.rs::policy_apply_tests`.

## Test plan

- [x] `cargo build --release`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` (4 new tests pass; bgp-packet tests pass)
- [x] `cargo fmt --all --check`

Generated with [Claude Code](https://claude.com/claude-code)