### PR TITLE
policy: match next-hop takes a direct address (Phase C)

### DIFF
--- a/bdd/docs/bgp_route_map_match.md
+++ b/bdd/docs/bgp_route_map_match.md
@@ -33,8 +33,8 @@ All four match types are exercised against an established eBGP session
 - z2-med-eq-fail.yaml: input policy `match med-eq 999` — no match.
 - z2-med-range-pass.yaml: input policy `match med-ge 50, med-le 200`
 - z2-med-range-fail.yaml: input policy `match med-ge 200` — MED=100
-- z2-nh-pass.yaml: input policy `match next-hop-set PEER-SUBNET`
-- z2-nh-fail.yaml: input policy `match next-hop-set WRONG-SUBNET`
+- z2-nh-pass.yaml: input policy `match next-hop 192.168.0.1` — matches the peer's address
+- z2-nh-fail.yaml: input policy `match next-hop 10.10.10.10` — does not match
 
 ## Test Scenarios
 
@@ -49,6 +49,6 @@ All four match types are exercised against an established eBGP session
 | match med-eq rejects routes with a different MED value | |
 | match med-ge and med-le accept routes inside the range | |
 | match med-ge rejects routes below the floor | |
-| match next-hop-set accepts routes whose nexthop is in the prefix-set | |
-| match next-hop-set rejects routes whose nexthop is outside the prefix-set | |
+| match next-hop accepts routes whose nexthop equals the configured address | |
+| match next-hop rejects routes whose nexthop is a different address | |
 | Teardown topology | |

--- a/bdd/tests/configs/bgp_route_map_match/z2-nh-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-nh-fail.yaml
@@ -1,15 +1,10 @@
-prefix-set:
-- name: WRONG-SUBNET
-  prefixes:
-  - prefix: 10.10.0.0/16
-    le: 32
 policy:
 - name: IN-NEXTHOP
   entry:
   - number: 10
     action: permit
     match:
-      next-hop: WRONG-SUBNET
+      next-hop: 10.10.10.10
 router:
   bgp:
     global:

--- a/bdd/tests/configs/bgp_route_map_match/z2-nh-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-nh-pass.yaml
@@ -1,15 +1,10 @@
-prefix-set:
-- name: PEER-SUBNET
-  prefixes:
-  - prefix: 192.168.0.0/24
-    le: 32
 policy:
 - name: IN-NEXTHOP
   entry:
   - number: 10
     action: permit
     match:
-      next-hop: PEER-SUBNET
+      next-hop: 192.168.0.1
 router:
   bgp:
     global:

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2580,12 +2580,17 @@ fn entry_matches(entry: &crate::policy::PolicyEntry, nlri: &Ipv4Nlri, bgp_attr: 
     {
         return false;
     }
-    if let Some(next_hop_set) = &entry.next_hop_set {
-        let Some(BgpNexthop::Ipv4(addr)) = bgp_attr.nexthop.as_ref() else {
+    if let Some(want) = &entry.match_next_hop {
+        // Exact equality. BgpAttr.nexthop is currently IPv4-only,
+        // so an IPv6 entry never matches today; that's acceptable
+        // until v6 nexthop is plumbed through.
+        let std::net::IpAddr::V4(want_v4) = want else {
             return false;
         };
-        let net = ipnet::Ipv4Net::new(*addr, 32).expect("valid /32 nexthop");
-        if !next_hop_set.matches(net) {
+        let Some(BgpNexthop::Ipv4(have_v4)) = bgp_attr.nexthop.as_ref() else {
+            return false;
+        };
+        if want_v4 != have_v4 {
             return false;
         }
     }
@@ -3338,8 +3343,7 @@ mod policy_apply_tests {
     use ipnet::Ipv4Net;
 
     use super::*;
-    use crate::policy::prefix::set::PrefixSetEntry;
-    use crate::policy::{AsPathMatcher, AsPathSet, NumericMatch, PolicyList, PrefixSet};
+    use crate::policy::{AsPathMatcher, AsPathSet, NumericMatch, PolicyList};
 
     fn nlri(prefix: &str) -> Ipv4Nlri {
         Ipv4Nlri {
@@ -3452,25 +3456,39 @@ mod policy_apply_tests {
     }
 
     #[test]
-    fn match_next_hop_set() {
-        let mut next_hop = PrefixSet::default();
-        next_hop.insert(
-            Ipv4Net::from_str("10.0.0.0/8").unwrap().into(),
-            PrefixSetEntry::default(),
-        );
-
+    fn match_next_hop_exact() {
         let mut list = PolicyList::default();
         let entry = list.entry(10);
-        entry.next_hop_set = Some(next_hop);
+        entry.match_next_hop = Some(std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 1, 1, 1)));
 
-        let mut attr_in = attr_with("1", None, None);
-        attr_in.nexthop = Some(BgpNexthop::Ipv4(std::net::Ipv4Addr::new(10, 1, 1, 1)));
+        let mut attr_match = attr_with("1", None, None);
+        attr_match.nexthop = Some(BgpNexthop::Ipv4(std::net::Ipv4Addr::new(10, 1, 1, 1)));
 
-        let mut attr_out = attr_with("1", None, None);
-        attr_out.nexthop = Some(BgpNexthop::Ipv4(std::net::Ipv4Addr::new(192, 168, 0, 1)));
+        let mut attr_diff = attr_with("1", None, None);
+        attr_diff.nexthop = Some(BgpNexthop::Ipv4(std::net::Ipv4Addr::new(10, 1, 1, 2)));
 
-        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_in).is_some());
-        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_out).is_none());
+        let attr_none = attr_with("1", None, None);
+
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_match).is_some());
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_diff).is_none());
+        assert!(
+            policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_none).is_none(),
+            "absent nexthop should not match"
+        );
+    }
+
+    #[test]
+    fn match_next_hop_v6_never_matches_v4_attr() {
+        // BgpAttr.nexthop is IPv4-only today. An IPv6 next-hop in
+        // the entry is accepted by YANG/parse but never matches
+        // the route. Locks that contract.
+        let mut list = PolicyList::default();
+        list.entry(10).match_next_hop = Some(std::net::IpAddr::V6("2001:db8::1".parse().unwrap()));
+
+        let mut attr = attr_with("1", None, None);
+        attr.nexthop = Some(BgpNexthop::Ipv4(std::net::Ipv4Addr::new(10, 1, 1, 1)));
+
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), attr).is_none());
     }
 
     #[test]

--- a/zebra-rs/src/policy/inst.rs
+++ b/zebra-rs/src/policy/inst.rs
@@ -422,9 +422,6 @@ fn cascade_indirect_policy_updates(
             e.prefix_set_name
                 .as_ref()
                 .is_some_and(|n| changed_prefix_sets.contains(n))
-                || e.next_hop_set_name
-                    .as_ref()
-                    .is_some_and(|n| changed_prefix_sets.contains(n))
                 || e.community_set_name
                     .as_ref()
                     .is_some_and(|n| changed_community_sets.contains(n))

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt::Write;
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr};
 
 use anyhow::{Context, Error, Result};
 use bgp_packet::Origin;
@@ -150,8 +150,7 @@ pub struct PolicyEntry {
     pub community_set: Option<CommunitySet>,
     pub as_path_set_name: Option<String>,
     pub as_path_set: Option<AsPathSet>,
-    pub next_hop_set_name: Option<String>,
-    pub next_hop_set: Option<PrefixSet>,
+    pub match_next_hop: Option<IpAddr>,
     pub match_med: Option<NumericMatch>,
     pub match_as_path_len: Option<NumericMatch>,
     pub match_as_path_len_uniq: Option<NumericMatch>,
@@ -194,13 +193,6 @@ pub fn policy_entry_sync(
                 policy.as_path_set = Some(as_path_set.clone());
             } else {
                 policy.as_path_set = None;
-            }
-        }
-        if let Some(name) = &policy.next_hop_set_name {
-            if let Some(prefix_set) = prefix_set.config.get(name) {
-                policy.next_hop_set = Some(prefix_set.clone());
-            } else {
-                policy.next_hop_set = None;
             }
         }
         if let Some(cfg) = policy.set_community.as_mut() {
@@ -393,20 +385,21 @@ impl ConfigBuilder {
                 entry.as_path_set_name = None;
                 Ok(())
             })
+            // `match next-hop ADDR` — direct IPv4/IPv6 address
+            // compared for exact equality against the route's
+            // BGP NEXT_HOP attribute.
             .path("/entry/match/next-hop")
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.entry(seq);
-
-                let next_hop_set = args.string().context(ARG_ERR)?;
-                entry.next_hop_set_name = Some(next_hop_set);
-
+                let s = args.string().context(ARG_ERR)?;
+                entry.match_next_hop = Some(s.parse::<IpAddr>()?);
                 Ok(())
             })
             .del(|policy, cache, name, seq, _args| {
                 let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.lookup(&seq).context(ARG_ERR)?;
-                entry.next_hop_set_name = None;
+                entry.match_next_hop = None;
                 Ok(())
             })
             // `match med {eq|le|ge} NUM` — presence container with
@@ -921,8 +914,8 @@ pub fn show(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> 
             if let Some(as_path_set) = &entry.as_path_set_name {
                 let _ = writeln!(buf, "  match: as_path_set {}", as_path_set);
             }
-            if let Some(next_hop_set) = &entry.next_hop_set_name {
-                let _ = writeln!(buf, "  match: next_hop_set {}", next_hop_set);
+            if let Some(addr) = &entry.match_next_hop {
+                let _ = writeln!(buf, "  match: next-hop {}", addr);
             }
             if let Some(m) = &entry.match_med {
                 let _ = writeln!(buf, "  match: med {} {}", m.op_str(), m.value());

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -845,11 +845,15 @@ module config {
               "Reference to an `as-path-set` by name.";
           }
           leaf "next-hop" {
-            type string;
+            type union {
+              type inet:ipv4-address;
+              type inet:ipv6-address;
+            }
             description
-              "Reference to a `prefix-set` by name; its members
-               are matched against the route's BGP NEXT_HOP
-               attribute.";
+              "Direct IP address. Compared for exact equality
+               against the route's BGP NEXT_HOP attribute. To
+               match a range of addresses, use `match prefix`
+               with a prefix-set instead.";
           }
           container "med" {
             presence "match med";


### PR DESCRIPTION
## Summary

Phase C of the policy statement spec — change `match next-hop` semantics from "reference to a prefix-set" to "direct IPv4 or IPv6 address compared for exact equality against the route's BGP NEXT_HOP." To match a range of addresses, use `match prefix` against a prefix-set instead.

## Changes

- **YANG**: `match next-hop` leaf changes from `type string` to `type union { inet:ipv4-address; inet:ipv6-address; }`.
- **Rust**: `PolicyEntry` drops `next_hop_set_name` and `next_hop_set` (2 fields) and gains `match_next_hop: Option<IpAddr>`. `policy_entry_sync` and `inst.rs` lose the next-hop-set resync paths.
- **Match logic**: exact equality against the IPv4 nexthop on BgpAttr. `BgpAttr.nexthop` is IPv4-only today; an IPv6 entry address parses but never matches a route — a regression test locks that contract.
- **BDD**: `z2-nh-pass.yaml` and `z2-nh-fail.yaml` switch to direct addresses (`192.168.0.1` / `10.10.10.10`) and drop the auxiliary prefix-set defs. Scenario doc updated.

## Test plan

- [x] `cargo build --release`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` (2 new tests pass; old `match_next_hop_set` retired)
- [x] `cargo fmt --all --check`

## Breaking change

This is a schema break: any existing config using `match next-hop: <prefix-set-name>` will fail to apply. Migration path is to either (a) replace with a direct address if the intent was an exact match, or (b) move to `match prefix: <prefix-set-name>` if a range was intended.

Generated with [Claude Code](https://claude.com/claude-code)