### PR TITLE
policy: add ext-community-set and large-community-set (Phase D)

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2575,6 +2575,16 @@ fn entry_matches(entry: &crate::policy::PolicyEntry, nlri: &Ipv4Nlri, bgp_attr: 
     {
         return false;
     }
+    if let Some(set) = &entry.ext_community_set
+        && !set.matches(bgp_attr)
+    {
+        return false;
+    }
+    if let Some(set) = &entry.large_community_set
+        && !set.matches(bgp_attr)
+    {
+        return false;
+    }
     if let Some(as_path_set) = &entry.as_path_set
         && !as_path_set.matches(bgp_attr)
     {
@@ -3622,6 +3632,82 @@ mod policy_apply_tests {
         assert!(
             policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", None, None)).is_none()
         );
+    }
+
+    #[test]
+    fn match_ext_community_exact() {
+        use bgp_packet::ExtCommunity;
+        use std::collections::BTreeSet;
+        let mut set = crate::policy::ExtCommunitySet::default();
+        set.vals.insert(
+            crate::policy::ExtCommunityMatcher::from_str("rt:65001:100")
+                .expect("parses rt:65001:100"),
+        );
+        let _: &BTreeSet<_> = &set.vals; // type sanity
+
+        let mut list = PolicyList::default();
+        list.entry(10).ext_community_set = Some(set);
+
+        let mut attr_match = attr_with("1", None, None);
+        attr_match.ecom = Some(ExtCommunity::from_str("rt:65001:100").unwrap());
+        let mut attr_miss = attr_with("1", None, None);
+        attr_miss.ecom = Some(ExtCommunity::from_str("rt:65001:200").unwrap());
+
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_match).is_some());
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_miss).is_none());
+        // Absent ecom => no match
+        assert!(
+            policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_with("1", None, None)).is_none()
+        );
+    }
+
+    #[test]
+    fn match_ext_community_regex() {
+        use bgp_packet::ExtCommunity;
+        let mut set = crate::policy::ExtCommunitySet::default();
+        set.vals
+            .insert(crate::policy::ExtCommunityMatcher::from_str("rt:^65001:.*").unwrap());
+
+        let mut list = PolicyList::default();
+        list.entry(10).ext_community_set = Some(set);
+
+        let mut attr_match = attr_with("1", None, None);
+        attr_match.ecom = Some(ExtCommunity::from_str("rt:65001:100 rt:65002:200").unwrap());
+        let mut attr_miss = attr_with("1", None, None);
+        attr_miss.ecom = Some(ExtCommunity::from_str("rt:65003:100").unwrap());
+
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_match).is_some());
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_miss).is_none());
+    }
+
+    #[test]
+    fn match_large_community_exact_and_regex() {
+        use bgp_packet::LargeCommunity;
+        let mut set = crate::policy::LargeCommunitySet::default();
+        set.vals
+            .insert(crate::policy::LargeCommunityMatcher::from_str("65001:100:200").unwrap());
+
+        let mut list = PolicyList::default();
+        list.entry(10).large_community_set = Some(set);
+
+        let mut attr_match = attr_with("1", None, None);
+        attr_match.lcom = Some(LargeCommunity::from_str("65001:100:200 65002:300:400").unwrap());
+        let mut attr_miss = attr_with("1", None, None);
+        attr_miss.lcom = Some(LargeCommunity::from_str("65001:100:201").unwrap());
+
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_match).is_some());
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_miss).is_none());
+
+        // Regex variant
+        let mut set = crate::policy::LargeCommunitySet::default();
+        set.vals
+            .insert(crate::policy::LargeCommunityMatcher::from_str("^65001:.*:.*$").unwrap());
+        let mut list = PolicyList::default();
+        list.entry(10).large_community_set = Some(set);
+
+        let mut attr_regex = attr_with("1", None, None);
+        attr_regex.lcom = Some(LargeCommunity::from_str("65001:9:9").unwrap());
+        assert!(policy_list_apply(&list, &nlri("10.0.0.0/8"), attr_regex).is_some());
     }
 }
 

--- a/zebra-rs/src/policy/ext_community/config.rs
+++ b/zebra-rs/src/policy/ext_community/config.rs
@@ -1,0 +1,167 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::str::FromStr;
+
+use anyhow::{Context, Result};
+
+use crate::config::{Args, ConfigOp};
+
+use super::{ExtCommunityMatcher, ExtCommunitySet};
+
+#[derive(Default)]
+pub struct ExtCommunitySetConfig {
+    pub config: BTreeMap<String, ExtCommunitySet>,
+    pub cache: BTreeMap<String, ExtCommunitySet>,
+    builder: ConfigBuilder,
+}
+
+impl ExtCommunitySetConfig {
+    pub fn new() -> Self {
+        Self {
+            config: BTreeMap::new(),
+            cache: BTreeMap::new(),
+            builder: ConfigBuilder::new(),
+        }
+    }
+
+    pub fn exec(&mut self, path: String, mut args: Args, op: ConfigOp) -> Result<()> {
+        const CONFIG_ERR: &str = "missing config handler";
+        const NAME_ERR: &str = "missing ext-community-set name arg";
+
+        let handler = self
+            .builder
+            .map
+            .get(&(path.to_string(), op))
+            .context(CONFIG_ERR)?;
+        let name = args.string().context(NAME_ERR)?;
+        handler(&mut self.config, &mut self.cache, &name, &mut args)
+    }
+
+    pub fn commit(&mut self) {
+        while let Some((name, s)) = self.cache.pop_first() {
+            if s.delete {
+                self.config.remove(&name);
+            } else {
+                self.config.insert(name, s);
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct ConfigBuilder {
+    path: String,
+    map: BTreeMap<(String, ConfigOp), Handler>,
+}
+
+type Handler = fn(
+    config: &mut BTreeMap<String, ExtCommunitySet>,
+    cache: &mut BTreeMap<String, ExtCommunitySet>,
+    name: &String,
+    args: &mut Args,
+) -> Result<()>;
+
+fn config_get(clist: &BTreeMap<String, ExtCommunitySet>, name: &String) -> ExtCommunitySet {
+    let Some(entry) = clist.get(name) else {
+        return ExtCommunitySet {
+            vals: BTreeSet::new(),
+            delete: false,
+        };
+    };
+    ExtCommunitySet {
+        vals: entry.vals.clone(),
+        delete: entry.delete,
+    }
+}
+
+fn config_lookup(
+    clist: &BTreeMap<String, ExtCommunitySet>,
+    name: &String,
+) -> Option<ExtCommunitySet> {
+    let entry = clist.get(name)?;
+    Some(ExtCommunitySet {
+        vals: entry.vals.clone(),
+        delete: entry.delete,
+    })
+}
+
+fn cache_get<'a>(
+    config: &'a BTreeMap<String, ExtCommunitySet>,
+    cache: &'a mut BTreeMap<String, ExtCommunitySet>,
+    name: &'a String,
+) -> Option<&'a mut ExtCommunitySet> {
+    if cache.get(name).is_none() {
+        cache.insert(name.to_string(), config_get(config, name));
+    }
+    cache.get_mut(name)
+}
+
+fn cache_lookup<'a>(
+    config: &'a BTreeMap<String, ExtCommunitySet>,
+    cache: &'a mut BTreeMap<String, ExtCommunitySet>,
+    name: &'a String,
+) -> Option<&'a mut ExtCommunitySet> {
+    if cache.get(name).is_none() {
+        cache.insert(name.to_string(), config_lookup(config, name)?);
+    }
+    let cache = cache.get_mut(name)?;
+    if cache.delete { None } else { Some(cache) }
+}
+
+impl ConfigBuilder {
+    pub fn new() -> Self {
+        const CONFIG_ERR: &str = "missing config";
+        const MEMBER_ERR: &str = "missing member";
+
+        ConfigBuilder::default()
+            .path("")
+            .set(|config, cache, name, _args| {
+                let _ = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                if let Some(list) = cache.get_mut(name) {
+                    list.delete = true;
+                } else {
+                    let mut list = config_lookup(config, name).context(CONFIG_ERR)?;
+                    list.delete = true;
+                    cache.insert(name.to_string(), list);
+                }
+                Ok(())
+            })
+            .path("/members")
+            .set(|config, cache, name, args| {
+                let set = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                while let Some(member_str) = args.string() {
+                    if let Ok(matcher) = ExtCommunityMatcher::from_str(&member_str) {
+                        set.vals.insert(matcher);
+                    }
+                }
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let member_str = args.string().context(MEMBER_ERR)?;
+                let set = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                if let Ok(matcher) = ExtCommunityMatcher::from_str(&member_str) {
+                    let key = format!("{:?}", matcher);
+                    set.vals.retain(|x| format!("{:?}", x) != key);
+                }
+                Ok(())
+            })
+    }
+
+    pub fn path(mut self, path: &str) -> Self {
+        let prefix = "/ext-community-set";
+        self.path = format!("{prefix}{path}");
+        self
+    }
+
+    pub fn set(mut self, func: Handler) -> Self {
+        self.map.insert((self.path.clone(), ConfigOp::Set), func);
+        self
+    }
+
+    pub fn del(mut self, func: Handler) -> Self {
+        self.map.insert((self.path.clone(), ConfigOp::Delete), func);
+        self
+    }
+}

--- a/zebra-rs/src/policy/ext_community/mod.rs
+++ b/zebra-rs/src/policy/ext_community/mod.rs
@@ -1,0 +1,10 @@
+pub mod config;
+pub use config::ExtCommunitySetConfig;
+
+pub mod parser;
+pub use parser::{ExtCommunityMatcher, match_ext_community_set};
+
+pub mod set;
+pub use set::ExtCommunitySet;
+
+pub mod show;

--- a/zebra-rs/src/policy/ext_community/parser.rs
+++ b/zebra-rs/src/policy/ext_community/parser.rs
@@ -1,0 +1,157 @@
+// Ext-community matcher.
+//
+// Mirrors `ExtendedMatcher` from the `community` module but is its
+// own type so that `ext-community-set` only accepts ext-community
+// syntax (`rt:`, `soo:`) — no standard-community values, no
+// well-known names. Regex patterns are matched against the value
+// portion (after the `rt:`/`soo:` prefix) to mirror the existing
+// extended-community matching semantics.
+
+use std::str::FromStr;
+
+use bgp_packet::{BgpAttr, ExtCommunity, ExtCommunitySubType, ExtCommunityValue};
+
+use crate::policy::community::CompiledRegex;
+
+#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq)]
+pub enum ExtCommunityMatcher {
+    Exact(ExtCommunityValue),
+    Regex(ExtCommunitySubType, CompiledRegex),
+}
+
+impl FromStr for ExtCommunityMatcher {
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        if let Some(value_str) = input.strip_prefix("rt:") {
+            if let Ok(ext_com) = ExtCommunity::from_str(input)
+                && let Some(first) = ext_com.0.first()
+            {
+                return Ok(ExtCommunityMatcher::Exact(first.clone()));
+            }
+            let compiled = CompiledRegex::new(value_str).map_err(|_| ())?;
+            return Ok(ExtCommunityMatcher::Regex(
+                ExtCommunitySubType::RouteTarget,
+                compiled,
+            ));
+        }
+        if let Some(value_str) = input.strip_prefix("soo:") {
+            if let Ok(ext_com) = ExtCommunity::from_str(input)
+                && let Some(first) = ext_com.0.first()
+            {
+                return Ok(ExtCommunityMatcher::Exact(first.clone()));
+            }
+            let compiled = CompiledRegex::new(value_str).map_err(|_| ())?;
+            return Ok(ExtCommunityMatcher::Regex(
+                ExtCommunitySubType::RouteOrigin,
+                compiled,
+            ));
+        }
+        Err(())
+    }
+}
+
+pub fn match_ext_community_set(matcher: &ExtCommunityMatcher, bgp_attr: &BgpAttr) -> bool {
+    let Some(ref ecom) = bgp_attr.ecom else {
+        return false;
+    };
+    match matcher {
+        ExtCommunityMatcher::Exact(target) => ecom.0.iter().any(|v| {
+            v.high_type == target.high_type && v.low_type == target.low_type && v.val == target.val
+        }),
+        ExtCommunityMatcher::Regex(sub_type, compiled) => {
+            let target_low_type: u8 = (*sub_type).into();
+            for v in &ecom.0 {
+                if v.low_type == target_low_type {
+                    let s = v.to_string();
+                    if let Some((_, value_part)) = s.split_once(':')
+                        && compiled.is_match(value_part)
+                    {
+                        return true;
+                    }
+                }
+            }
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_rt_exact_asn() {
+        let m = ExtCommunityMatcher::from_str("rt:100:200").unwrap();
+        let ExtCommunityMatcher::Exact(v) = m else {
+            panic!("expected exact");
+        };
+        assert_eq!(v.low_type, 0x02);
+    }
+
+    #[test]
+    fn parse_rt_exact_ip() {
+        let m = ExtCommunityMatcher::from_str("rt:1.2.3.4:100").unwrap();
+        let ExtCommunityMatcher::Exact(v) = m else {
+            panic!("expected exact");
+        };
+        assert_eq!(v.low_type, 0x02);
+    }
+
+    #[test]
+    fn parse_rt_regex() {
+        let m = ExtCommunityMatcher::from_str("rt:^65001:.*").unwrap();
+        let ExtCommunityMatcher::Regex(st, c) = m else {
+            panic!("expected regex");
+        };
+        assert_eq!(st, ExtCommunitySubType::RouteTarget);
+        assert_eq!(c.pattern(), "^65001:.*");
+    }
+
+    #[test]
+    fn parse_soo_exact() {
+        let m = ExtCommunityMatcher::from_str("soo:100:200").unwrap();
+        let ExtCommunityMatcher::Exact(v) = m else {
+            panic!("expected exact");
+        };
+        assert_eq!(v.low_type, 0x03);
+    }
+
+    #[test]
+    fn parse_rejects_standard_community() {
+        // Bare standard community syntax is not valid in
+        // ext-community-set. This is what differentiates it from
+        // the legacy community-set.
+        assert!(ExtCommunityMatcher::from_str("100:200").is_err());
+        assert!(ExtCommunityMatcher::from_str("no-export").is_err());
+    }
+
+    #[test]
+    fn match_exact_rt() {
+        let mut attr = BgpAttr::new();
+        attr.ecom = Some(ExtCommunity::from_str("rt:100:200").unwrap());
+
+        let m = ExtCommunityMatcher::from_str("rt:100:200").unwrap();
+        assert!(match_ext_community_set(&m, &attr));
+
+        let m = ExtCommunityMatcher::from_str("rt:100:300").unwrap();
+        assert!(!match_ext_community_set(&m, &attr));
+    }
+
+    #[test]
+    fn regex_does_not_cross_subtype() {
+        let mut attr = BgpAttr::new();
+        attr.ecom = Some(ExtCommunity::from_str("rt:100:200").unwrap());
+
+        // soo regex must not match rt-typed community.
+        let m = ExtCommunityMatcher::from_str("soo:100:.*").unwrap();
+        assert!(!match_ext_community_set(&m, &attr));
+    }
+
+    #[test]
+    fn no_ecom_attr_never_matches() {
+        let attr = BgpAttr::new();
+        let m = ExtCommunityMatcher::from_str("rt:100:200").unwrap();
+        assert!(!match_ext_community_set(&m, &attr));
+    }
+}

--- a/zebra-rs/src/policy/ext_community/set.rs
+++ b/zebra-rs/src/policy/ext_community/set.rs
@@ -1,0 +1,19 @@
+use std::collections::BTreeSet;
+
+use bgp_packet::BgpAttr;
+
+use super::{ExtCommunityMatcher, match_ext_community_set};
+
+#[derive(Default, Clone, Debug, PartialEq)]
+pub struct ExtCommunitySet {
+    pub vals: BTreeSet<ExtCommunityMatcher>,
+    pub delete: bool,
+}
+
+impl ExtCommunitySet {
+    pub fn matches(&self, bgp_attr: &BgpAttr) -> bool {
+        self.vals
+            .iter()
+            .any(|m| match_ext_community_set(m, bgp_attr))
+    }
+}

--- a/zebra-rs/src/policy/ext_community/show.rs
+++ b/zebra-rs/src/policy/ext_community/show.rs
@@ -1,0 +1,45 @@
+use std::fmt::Write;
+
+use anyhow::{Context, Error};
+
+use super::ExtCommunityMatcher;
+use crate::{config::Args, policy::Policy};
+
+pub fn ext_community_set(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> {
+    let mut buf = String::new();
+    for (name, set) in policy.ext_community_config.config.iter() {
+        writeln!(buf, "ext-community-set: {} len: {}", name, set.vals.len())?;
+        for matcher in &set.vals {
+            writeln!(buf, "  {}", format_matcher(matcher))?;
+        }
+    }
+    Ok(buf)
+}
+
+pub fn ext_community_set_name(
+    policy: &Policy,
+    mut args: Args,
+    _json: bool,
+) -> Result<String, Error> {
+    let mut buf = String::new();
+    let name = args.string().context("missing ext-community-set name")?;
+    let set = policy
+        .ext_community_config
+        .config
+        .get(&name)
+        .context(format!("ext-community-set '{}' not found", name))?;
+    writeln!(buf, "ext-community-set: {}", name)?;
+    for matcher in &set.vals {
+        writeln!(buf, "  {}", format_matcher(matcher))?;
+    }
+    Ok(buf)
+}
+
+fn format_matcher(matcher: &ExtCommunityMatcher) -> String {
+    match matcher {
+        ExtCommunityMatcher::Exact(val) => val.to_string(),
+        ExtCommunityMatcher::Regex(sub_type, compiled) => {
+            format!("{}:{}", sub_type, compiled.pattern())
+        }
+    }
+}

--- a/zebra-rs/src/policy/inst.rs
+++ b/zebra-rs/src/policy/inst.rs
@@ -8,8 +8,8 @@ use crate::config::{
 };
 
 use super::{
-    AsPathSetConfig, CommunitySetConfig, PolicyConfig, PolicyList, PrefixSet, PrefixSetConfig,
-    policy_entry_sync,
+    AsPathSetConfig, CommunitySetConfig, ExtCommunitySetConfig, LargeCommunitySetConfig,
+    PolicyConfig, PolicyList, PrefixSet, PrefixSetConfig, policy_entry_sync,
 };
 
 pub type ShowCallback = fn(&Policy, Args, bool) -> Result<String, Error>;
@@ -165,6 +165,8 @@ pub struct Policy {
     pub policy_config: PolicyConfig,
     pub prefix_config: PrefixSetConfig,
     pub community_config: CommunitySetConfig,
+    pub ext_community_config: ExtCommunitySetConfig,
+    pub large_community_config: LargeCommunitySetConfig,
     pub as_path_config: AsPathSetConfig,
     pub clients: BTreeMap<String, UnboundedSender<PolicyRx>>,
     pub watch_prefix: BTreeMap<String, Vec<PolicyWatch>>,
@@ -190,6 +192,8 @@ impl Policy {
             policy_config: PolicyConfig::new(),
             prefix_config: PrefixSetConfig::new(),
             community_config: CommunitySetConfig::new(),
+            ext_community_config: ExtCommunitySetConfig::new(),
+            large_community_config: LargeCommunitySetConfig::new(),
             as_path_config: AsPathSetConfig::new(),
             clients: BTreeMap::new(),
             watch_prefix: BTreeMap::new(),
@@ -284,6 +288,10 @@ impl Policy {
                     let _ = self.prefix_config.exec(path, args, msg.op);
                 } else if path.as_str().starts_with("/community-set") {
                     let _ = self.community_config.exec(path, args, msg.op);
+                } else if path.as_str().starts_with("/ext-community-set") {
+                    let _ = self.ext_community_config.exec(path, args, msg.op);
+                } else if path.as_str().starts_with("/large-community-set") {
+                    let _ = self.large_community_config.exec(path, args, msg.op);
                 } else if path.as_str().starts_with("/as-path-set") {
                     let _ = self.as_path_config.exec(path, args, msg.op);
                 }
@@ -300,6 +308,10 @@ impl Policy {
                     self.prefix_config.cache.keys().cloned().collect();
                 let changed_community_sets: std::collections::BTreeSet<String> =
                     self.community_config.cache.keys().cloned().collect();
+                let changed_ext_community_sets: std::collections::BTreeSet<String> =
+                    self.ext_community_config.cache.keys().cloned().collect();
+                let changed_large_community_sets: std::collections::BTreeSet<String> =
+                    self.large_community_config.cache.keys().cloned().collect();
                 let changed_as_path_sets: std::collections::BTreeSet<String> =
                     self.as_path_config.cache.keys().cloned().collect();
                 let changed_policies: std::collections::BTreeSet<String> =
@@ -317,6 +329,10 @@ impl Policy {
                 );
                 // Sync community-set.
                 self.community_config.commit();
+                // Sync ext-community-set.
+                self.ext_community_config.commit();
+                // Sync large-community-set.
+                self.large_community_config.commit();
                 // Sync as-path-set.
                 self.as_path_config.commit();
 
@@ -330,6 +346,8 @@ impl Policy {
                     &mut self.policy_config.cache,
                     &self.prefix_config,
                     &self.community_config,
+                    &self.ext_community_config,
+                    &self.large_community_config,
                     &self.as_path_config,
                     syncer,
                 );
@@ -343,11 +361,15 @@ impl Policy {
                     &mut self.policy_config.config,
                     &self.prefix_config,
                     &self.community_config,
+                    &self.ext_community_config,
+                    &self.large_community_config,
                     &self.as_path_config,
                     &self.watch_policy,
                     &self.clients,
                     &changed_prefix_sets,
                     &changed_community_sets,
+                    &changed_ext_community_sets,
+                    &changed_large_community_sets,
                     &changed_as_path_sets,
                     &changed_policies,
                 );
@@ -398,16 +420,22 @@ fn cascade_indirect_policy_updates(
     policy_config: &mut BTreeMap<String, PolicyList>,
     prefix_config: &PrefixSetConfig,
     community_config: &CommunitySetConfig,
+    ext_community_config: &ExtCommunitySetConfig,
+    large_community_config: &LargeCommunitySetConfig,
     as_path_config: &AsPathSetConfig,
     watch_policy: &BTreeMap<String, Vec<PolicyWatch>>,
     clients: &BTreeMap<String, UnboundedSender<PolicyRx>>,
     changed_prefix_sets: &std::collections::BTreeSet<String>,
     changed_community_sets: &std::collections::BTreeSet<String>,
+    changed_ext_community_sets: &std::collections::BTreeSet<String>,
+    changed_large_community_sets: &std::collections::BTreeSet<String>,
     changed_as_path_sets: &std::collections::BTreeSet<String>,
     changed_policies: &std::collections::BTreeSet<String>,
 ) {
     if changed_prefix_sets.is_empty()
         && changed_community_sets.is_empty()
+        && changed_ext_community_sets.is_empty()
+        && changed_large_community_sets.is_empty()
         && changed_as_path_sets.is_empty()
     {
         return;
@@ -428,6 +456,12 @@ fn cascade_indirect_policy_updates(
                 || e.set_community
                     .as_ref()
                     .is_some_and(|c| changed_community_sets.contains(&c.name))
+                || e.ext_community_set_name
+                    .as_ref()
+                    .is_some_and(|n| changed_ext_community_sets.contains(n))
+                || e.large_community_set_name
+                    .as_ref()
+                    .is_some_and(|n| changed_large_community_sets.contains(n))
                 || e.as_path_set_name
                     .as_ref()
                     .is_some_and(|n| changed_as_path_sets.contains(n))
@@ -435,7 +469,14 @@ fn cascade_indirect_policy_updates(
         if !needs_resync {
             continue;
         }
-        policy_entry_sync(policy_list, prefix_config, community_config, as_path_config);
+        policy_entry_sync(
+            policy_list,
+            prefix_config,
+            community_config,
+            ext_community_config,
+            large_community_config,
+            as_path_config,
+        );
         if let Some(watches) = watch_policy.get(name) {
             for watch in watches {
                 if let Some(tx) = clients.get(&watch.proto) {

--- a/zebra-rs/src/policy/large_community/config.rs
+++ b/zebra-rs/src/policy/large_community/config.rs
@@ -1,0 +1,167 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::str::FromStr;
+
+use anyhow::{Context, Result};
+
+use crate::config::{Args, ConfigOp};
+
+use super::{LargeCommunityMatcher, LargeCommunitySet};
+
+#[derive(Default)]
+pub struct LargeCommunitySetConfig {
+    pub config: BTreeMap<String, LargeCommunitySet>,
+    pub cache: BTreeMap<String, LargeCommunitySet>,
+    builder: ConfigBuilder,
+}
+
+impl LargeCommunitySetConfig {
+    pub fn new() -> Self {
+        Self {
+            config: BTreeMap::new(),
+            cache: BTreeMap::new(),
+            builder: ConfigBuilder::new(),
+        }
+    }
+
+    pub fn exec(&mut self, path: String, mut args: Args, op: ConfigOp) -> Result<()> {
+        const CONFIG_ERR: &str = "missing config handler";
+        const NAME_ERR: &str = "missing large-community-set name arg";
+
+        let handler = self
+            .builder
+            .map
+            .get(&(path.to_string(), op))
+            .context(CONFIG_ERR)?;
+        let name = args.string().context(NAME_ERR)?;
+        handler(&mut self.config, &mut self.cache, &name, &mut args)
+    }
+
+    pub fn commit(&mut self) {
+        while let Some((name, s)) = self.cache.pop_first() {
+            if s.delete {
+                self.config.remove(&name);
+            } else {
+                self.config.insert(name, s);
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct ConfigBuilder {
+    path: String,
+    map: BTreeMap<(String, ConfigOp), Handler>,
+}
+
+type Handler = fn(
+    config: &mut BTreeMap<String, LargeCommunitySet>,
+    cache: &mut BTreeMap<String, LargeCommunitySet>,
+    name: &String,
+    args: &mut Args,
+) -> Result<()>;
+
+fn config_get(clist: &BTreeMap<String, LargeCommunitySet>, name: &String) -> LargeCommunitySet {
+    let Some(entry) = clist.get(name) else {
+        return LargeCommunitySet {
+            vals: BTreeSet::new(),
+            delete: false,
+        };
+    };
+    LargeCommunitySet {
+        vals: entry.vals.clone(),
+        delete: entry.delete,
+    }
+}
+
+fn config_lookup(
+    clist: &BTreeMap<String, LargeCommunitySet>,
+    name: &String,
+) -> Option<LargeCommunitySet> {
+    let entry = clist.get(name)?;
+    Some(LargeCommunitySet {
+        vals: entry.vals.clone(),
+        delete: entry.delete,
+    })
+}
+
+fn cache_get<'a>(
+    config: &'a BTreeMap<String, LargeCommunitySet>,
+    cache: &'a mut BTreeMap<String, LargeCommunitySet>,
+    name: &'a String,
+) -> Option<&'a mut LargeCommunitySet> {
+    if cache.get(name).is_none() {
+        cache.insert(name.to_string(), config_get(config, name));
+    }
+    cache.get_mut(name)
+}
+
+fn cache_lookup<'a>(
+    config: &'a BTreeMap<String, LargeCommunitySet>,
+    cache: &'a mut BTreeMap<String, LargeCommunitySet>,
+    name: &'a String,
+) -> Option<&'a mut LargeCommunitySet> {
+    if cache.get(name).is_none() {
+        cache.insert(name.to_string(), config_lookup(config, name)?);
+    }
+    let cache = cache.get_mut(name)?;
+    if cache.delete { None } else { Some(cache) }
+}
+
+impl ConfigBuilder {
+    pub fn new() -> Self {
+        const CONFIG_ERR: &str = "missing config";
+        const MEMBER_ERR: &str = "missing member";
+
+        ConfigBuilder::default()
+            .path("")
+            .set(|config, cache, name, _args| {
+                let _ = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                if let Some(list) = cache.get_mut(name) {
+                    list.delete = true;
+                } else {
+                    let mut list = config_lookup(config, name).context(CONFIG_ERR)?;
+                    list.delete = true;
+                    cache.insert(name.to_string(), list);
+                }
+                Ok(())
+            })
+            .path("/members")
+            .set(|config, cache, name, args| {
+                let set = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                while let Some(member_str) = args.string() {
+                    if let Ok(matcher) = LargeCommunityMatcher::from_str(&member_str) {
+                        set.vals.insert(matcher);
+                    }
+                }
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let member_str = args.string().context(MEMBER_ERR)?;
+                let set = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                if let Ok(matcher) = LargeCommunityMatcher::from_str(&member_str) {
+                    let key = format!("{:?}", matcher);
+                    set.vals.retain(|x| format!("{:?}", x) != key);
+                }
+                Ok(())
+            })
+    }
+
+    pub fn path(mut self, path: &str) -> Self {
+        let prefix = "/large-community-set";
+        self.path = format!("{prefix}{path}");
+        self
+    }
+
+    pub fn set(mut self, func: Handler) -> Self {
+        self.map.insert((self.path.clone(), ConfigOp::Set), func);
+        self
+    }
+
+    pub fn del(mut self, func: Handler) -> Self {
+        self.map.insert((self.path.clone(), ConfigOp::Delete), func);
+        self
+    }
+}

--- a/zebra-rs/src/policy/large_community/mod.rs
+++ b/zebra-rs/src/policy/large_community/mod.rs
@@ -1,0 +1,10 @@
+pub mod config;
+pub use config::LargeCommunitySetConfig;
+
+pub mod parser;
+pub use parser::{LargeCommunityMatcher, match_large_community_set};
+
+pub mod set;
+pub use set::LargeCommunitySet;
+
+pub mod show;

--- a/zebra-rs/src/policy/large_community/parser.rs
+++ b/zebra-rs/src/policy/large_community/parser.rs
@@ -1,0 +1,119 @@
+// Large-community matcher.
+//
+// A `large-community-set` member is one of:
+//   - an exact value `A:B:C` (three colon-separated u32s, RFC 8092),
+//   - a regex pattern matched against the textual `A:B:C` form of
+//     each LARGE_COMMUNITIES element on the route.
+//
+// Parsing tries the exact form first; anything else compiles as
+// regex. (Bare patterns without regex metacharacters still parse as
+// regex if they aren't valid literal triples — that mirrors how the
+// legacy community-set treats fallthrough.)
+
+use std::str::FromStr;
+
+use bgp_packet::{BgpAttr, LargeCommunityValue};
+
+use crate::policy::community::CompiledRegex;
+
+#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq)]
+pub enum LargeCommunityMatcher {
+    Exact(LargeCommunityValue),
+    Regex(CompiledRegex),
+}
+
+fn parse_literal(s: &str) -> Option<LargeCommunityValue> {
+    let parts: Vec<&str> = s.split(':').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    let global = parts[0].parse::<u32>().ok()?;
+    let local1 = parts[1].parse::<u32>().ok()?;
+    let local2 = parts[2].parse::<u32>().ok()?;
+    Some(LargeCommunityValue {
+        global,
+        local1,
+        local2,
+    })
+}
+
+impl FromStr for LargeCommunityMatcher {
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        if let Some(v) = parse_literal(input) {
+            return Ok(LargeCommunityMatcher::Exact(v));
+        }
+        let compiled = CompiledRegex::new(input).map_err(|_| ())?;
+        Ok(LargeCommunityMatcher::Regex(compiled))
+    }
+}
+
+pub fn match_large_community_set(matcher: &LargeCommunityMatcher, bgp_attr: &BgpAttr) -> bool {
+    let Some(ref lcom) = bgp_attr.lcom else {
+        return false;
+    };
+    match matcher {
+        LargeCommunityMatcher::Exact(target) => lcom.0.iter().any(|v| v == target),
+        LargeCommunityMatcher::Regex(compiled) => {
+            lcom.0.iter().any(|v| compiled.is_match(&v.to_str()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bgp_packet::LargeCommunity;
+
+    #[test]
+    fn parse_exact_triple() {
+        let m = LargeCommunityMatcher::from_str("65001:100:200").unwrap();
+        let LargeCommunityMatcher::Exact(v) = m else {
+            panic!("expected exact");
+        };
+        assert_eq!(v.global, 65001);
+        assert_eq!(v.local1, 100);
+        assert_eq!(v.local2, 200);
+    }
+
+    #[test]
+    fn parse_regex_when_not_a_triple() {
+        let m = LargeCommunityMatcher::from_str("^65001:.*:.*$").unwrap();
+        let LargeCommunityMatcher::Regex(c) = m else {
+            panic!("expected regex");
+        };
+        assert_eq!(c.pattern(), "^65001:.*:.*$");
+    }
+
+    #[test]
+    fn match_exact() {
+        let mut attr = BgpAttr::new();
+        attr.lcom = Some(LargeCommunity::from_str("65001:100:200 65002:300:400").unwrap());
+
+        let m = LargeCommunityMatcher::from_str("65001:100:200").unwrap();
+        assert!(match_large_community_set(&m, &attr));
+
+        let m = LargeCommunityMatcher::from_str("65001:100:201").unwrap();
+        assert!(!match_large_community_set(&m, &attr));
+    }
+
+    #[test]
+    fn match_regex() {
+        let mut attr = BgpAttr::new();
+        attr.lcom = Some(LargeCommunity::from_str("65001:100:200 65002:300:400").unwrap());
+
+        let m = LargeCommunityMatcher::from_str("^65001:.*:.*$").unwrap();
+        assert!(match_large_community_set(&m, &attr));
+
+        let m = LargeCommunityMatcher::from_str("^99999:.*").unwrap();
+        assert!(!match_large_community_set(&m, &attr));
+    }
+
+    #[test]
+    fn no_lcom_attr_never_matches() {
+        let attr = BgpAttr::new();
+        let m = LargeCommunityMatcher::from_str("65001:100:200").unwrap();
+        assert!(!match_large_community_set(&m, &attr));
+    }
+}

--- a/zebra-rs/src/policy/large_community/set.rs
+++ b/zebra-rs/src/policy/large_community/set.rs
@@ -1,0 +1,19 @@
+use std::collections::BTreeSet;
+
+use bgp_packet::BgpAttr;
+
+use super::{LargeCommunityMatcher, match_large_community_set};
+
+#[derive(Default, Clone, Debug, PartialEq)]
+pub struct LargeCommunitySet {
+    pub vals: BTreeSet<LargeCommunityMatcher>,
+    pub delete: bool,
+}
+
+impl LargeCommunitySet {
+    pub fn matches(&self, bgp_attr: &BgpAttr) -> bool {
+        self.vals
+            .iter()
+            .any(|m| match_large_community_set(m, bgp_attr))
+    }
+}

--- a/zebra-rs/src/policy/large_community/show.rs
+++ b/zebra-rs/src/policy/large_community/show.rs
@@ -1,0 +1,43 @@
+use std::fmt::Write;
+
+use anyhow::{Context, Error};
+
+use super::LargeCommunityMatcher;
+use crate::{config::Args, policy::Policy};
+
+pub fn large_community_set(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> {
+    let mut buf = String::new();
+    for (name, set) in policy.large_community_config.config.iter() {
+        writeln!(buf, "large-community-set: {} len: {}", name, set.vals.len())?;
+        for matcher in &set.vals {
+            writeln!(buf, "  {}", format_matcher(matcher))?;
+        }
+    }
+    Ok(buf)
+}
+
+pub fn large_community_set_name(
+    policy: &Policy,
+    mut args: Args,
+    _json: bool,
+) -> Result<String, Error> {
+    let mut buf = String::new();
+    let name = args.string().context("missing large-community-set name")?;
+    let set = policy
+        .large_community_config
+        .config
+        .get(&name)
+        .context(format!("large-community-set '{}' not found", name))?;
+    writeln!(buf, "large-community-set: {}", name)?;
+    for matcher in &set.vals {
+        writeln!(buf, "  {}", format_matcher(matcher))?;
+    }
+    Ok(buf)
+}
+
+fn format_matcher(matcher: &LargeCommunityMatcher) -> String {
+    match matcher {
+        LargeCommunityMatcher::Exact(val) => val.to_str(),
+        LargeCommunityMatcher::Regex(compiled) => compiled.pattern().to_string(),
+    }
+}

--- a/zebra-rs/src/policy/mod.rs
+++ b/zebra-rs/src/policy/mod.rs
@@ -19,6 +19,12 @@ pub use prefix::*;
 pub mod community;
 pub use community::*;
 
+pub mod ext_community;
+pub use ext_community::*;
+
+pub mod large_community;
+pub use large_community::*;
+
 pub mod aspath;
 pub use aspath::*;
 

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -9,7 +9,8 @@ use strum_macros::{Display, EnumString};
 use crate::config::{Args, ConfigOp};
 
 use super::{
-    AsPathSet, AsPathSetConfig, CommunitySet, CommunitySetConfig, Policy, PrefixSet,
+    AsPathSet, AsPathSetConfig, CommunitySet, CommunitySetConfig, ExtCommunitySet,
+    ExtCommunitySetConfig, LargeCommunitySet, LargeCommunitySetConfig, Policy, PrefixSet,
     PrefixSetConfig,
 };
 
@@ -148,6 +149,10 @@ pub struct PolicyEntry {
     pub prefix_set: Option<PrefixSet>,
     pub community_set_name: Option<String>,
     pub community_set: Option<CommunitySet>,
+    pub ext_community_set_name: Option<String>,
+    pub ext_community_set: Option<ExtCommunitySet>,
+    pub large_community_set_name: Option<String>,
+    pub large_community_set: Option<LargeCommunitySet>,
     pub as_path_set_name: Option<String>,
     pub as_path_set: Option<AsPathSet>,
     pub match_next_hop: Option<IpAddr>,
@@ -171,6 +176,8 @@ pub fn policy_entry_sync(
     policy_list: &mut PolicyList,
     prefix_set: &PrefixSetConfig,
     community_set: &CommunitySetConfig,
+    ext_community_set: &ExtCommunitySetConfig,
+    large_community_set: &LargeCommunitySetConfig,
     as_path_set: &AsPathSetConfig,
 ) {
     for (_, policy) in policy_list.entry.iter_mut() {
@@ -187,6 +194,12 @@ pub fn policy_entry_sync(
             } else {
                 policy.community_set = None;
             }
+        }
+        if let Some(name) = &policy.ext_community_set_name {
+            policy.ext_community_set = ext_community_set.config.get(name).cloned();
+        }
+        if let Some(name) = &policy.large_community_set_name {
+            policy.large_community_set = large_community_set.config.get(name).cloned();
         }
         if let Some(name) = &policy.as_path_set_name {
             if let Some(as_path_set) = as_path_set.config.get(name) {
@@ -236,11 +249,14 @@ impl PolicyConfig {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn commit<S: crate::policy::Syncer>(
         config: &mut BTreeMap<String, PolicyList>,
         cache: &mut BTreeMap<String, PolicyList>,
         prefix_config: &PrefixSetConfig,
         community_config: &CommunitySetConfig,
+        ext_community_config: &ExtCommunitySetConfig,
+        large_community_config: &LargeCommunitySetConfig,
         as_path_config: &AsPathSetConfig,
         syncer: S,
     ) {
@@ -249,7 +265,14 @@ impl PolicyConfig {
                 syncer.policy_list_remove(&name);
                 config.remove(&name);
             } else {
-                policy_entry_sync(&mut s, prefix_config, community_config, as_path_config);
+                policy_entry_sync(
+                    &mut s,
+                    prefix_config,
+                    community_config,
+                    ext_community_config,
+                    large_community_config,
+                    as_path_config,
+                );
                 syncer.policy_list_update(&name, &s);
                 config.insert(name, s);
             }
@@ -367,6 +390,32 @@ impl ConfigBuilder {
                 let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.lookup(&seq).context(ARG_ERR)?;
                 entry.community_set_name = None;
+                Ok(())
+            })
+            .path("/entry/match/ext-community")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.ext_community_set_name = Some(args.string().context(ARG_ERR)?);
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.ext_community_set_name = None;
+                Ok(())
+            })
+            .path("/entry/match/large-community")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.large_community_set_name = Some(args.string().context(ARG_ERR)?);
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.large_community_set_name = None;
                 Ok(())
             })
             .path("/entry/match/as-path")
@@ -910,6 +959,12 @@ pub fn show(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> 
             }
             if let Some(community_set) = &entry.community_set_name {
                 let _ = writeln!(buf, "  match: community_set {}", community_set);
+            }
+            if let Some(name) = &entry.ext_community_set_name {
+                let _ = writeln!(buf, "  match: ext-community {}", name);
+            }
+            if let Some(name) = &entry.large_community_set_name {
+                let _ = writeln!(buf, "  match: large-community {}", name);
             }
             if let Some(as_path_set) = &entry.as_path_set_name {
                 let _ = writeln!(buf, "  match: as_path_set {}", as_path_set);

--- a/zebra-rs/src/policy/show.rs
+++ b/zebra-rs/src/policy/show.rs
@@ -3,6 +3,8 @@ use crate::policy::inst::ShowCallback;
 
 use super::aspath;
 use super::community;
+use super::ext_community;
+use super::large_community;
 use super::policy_list;
 use super::prefix;
 
@@ -19,6 +21,22 @@ impl Policy {
         self.show_add(
             "/show/community-set/name",
             community::show::community_set_name,
+        );
+        self.show_add(
+            "/show/ext-community-set",
+            ext_community::show::ext_community_set,
+        );
+        self.show_add(
+            "/show/ext-community-set/name",
+            ext_community::show::ext_community_set_name,
+        );
+        self.show_add(
+            "/show/large-community-set",
+            large_community::show::large_community_set,
+        );
+        self.show_add(
+            "/show/large-community-set/name",
+            large_community::show::large_community_set_name,
         );
         self.show_add("/show/as-path-set", aspath::show::as_path_set);
         self.show_add("/show/as-path-set/name", aspath::show::as_path_set_name);

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -716,6 +716,42 @@ module config {
       }
     }
 
+    list ext-community-set {
+      ext:sort "5";
+      key "name";
+      leaf name {
+        type string;
+      }
+      leaf-list members {
+        type string;
+        description
+          "Ext-community matchers. Each member is one of:
+            - `rt:ASN:NN` / `rt:IPv4:NN` (Route Target),
+            - `soo:ASN:NN` / `soo:IPv4:NN` (Site-of-Origin),
+            - `rt:<regex>` / `soo:<regex>` (regex applied to the
+              value portion after the `rt:`/`soo:` prefix).
+           Standard-community syntax is rejected here; use
+           `community-set` for those.";
+      }
+    }
+
+    list large-community-set {
+      ext:sort "5";
+      key "name";
+      leaf name {
+        type string;
+      }
+      leaf-list members {
+        type string;
+        description
+          "Large-community matchers. Each member is either an
+           exact `A:B:C` triple (three colon-separated uint32s
+           per RFC 8092) or a regex applied to the textual
+           `A:B:C` form of each LARGE_COMMUNITIES element on
+           the route.";
+      }
+    }
+
     list as-path-set {
       ext:sort "5";
       key "name";
@@ -838,6 +874,20 @@ module config {
             type string;
             description
               "Reference to a `community-set` by name.";
+          }
+          leaf "ext-community" {
+            type string;
+            description
+              "Reference to an `ext-community-set` by name. The
+               set's members are checked against the route's
+               EXT_COMMUNITIES attribute.";
+          }
+          leaf "large-community" {
+            type string;
+            description
+              "Reference to a `large-community-set` by name. The
+               set's members are checked against the route's
+               LARGE_COMMUNITIES attribute.";
           }
           leaf "as-path" {
             type string;


### PR DESCRIPTION
## Summary

Phase D of the policy statement spec — two new top-level set types and their match clauses, mirroring the existing `community-set` / `aspath-set` shape.

### New sets

- **`ext-community-set NAME { members [...] }`** — IOS-XR style extended-community matchers. Each member is `rt:ASN:NN`, `rt:IPv4:NN`, `soo:ASN:NN`, `soo:IPv4:NN`, or `rt:<regex>` / `soo:<regex>` against the value portion. Standard-community syntax is rejected — that's what keeps this distinct from the legacy `community-set`, which still accepts both shapes.
- **`large-community-set NAME { members [...] }`** — RFC 8092 large-community matchers. Each member is either an exact `A:B:C` triple of uint32s, or a regex against the textual `A:B:C` form of each LARGE_COMMUNITIES element on the route.

### New match clauses

- `match ext-community NAME` — references an `ext-community-set`; checks the route's EXT_COMMUNITIES.
- `match large-community NAME` — references a `large-community-set`; checks LARGE_COMMUNITIES.

## Wiring

- `Policy` struct gains `ext_community_config` / `large_community_config`.
- `process_cm_msg` routes `/ext-community-set` and `/large-community-set` paths.
- `CommitEnd` commits the new caches; `policy_entry_sync`, `PolicyConfig::commit`, and `cascade_indirect_policy_updates` track changes to the new sets so peers attached to a referencing policy see Adj-RIB-In re-evaluations.
- New show callbacks: `show ext-community-set` / `show large-community-set` (and the `/name` variants).
- The matchers reuse `CompiledRegex` from the community module.

## Pure addition

No schema breaks. Existing `community-set` configs that use `rt:`/`soo:` continue to work unchanged; the two flavours coexist while operators migrate or split.

## Test plan

- [x] `cargo build --release`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` — 13 new tests: 7 in ext-community parser, 4 in large-community parser, 3 in `bgp::route::policy_apply_tests` covering exact / regex / absent attribute. 239 total in zebra-rs (up 16 from baseline).
- [x] `cargo fmt --all --check`

Generated with [Claude Code](https://claude.com/claude-code)