### PR TITLE
policy: set local-preference / med with set|add|sub (Phase E)

### DIFF
--- a/bdd/tests/configs/bgp_route_map_match/z1.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z1.yaml
@@ -11,7 +11,8 @@ policy:
     match:
       prefix: ALL-V4
     set:
-      med: 100
+      med:
+        set: 100
 router:
   bgp:
     global:

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2538,11 +2538,19 @@ pub fn policy_list_apply(
                 // Apply the entry's set clauses to the working
                 // attribute, then either return (Permit) or fall
                 // through to the next entry (Next).
-                if let Some(local_pref) = &entry.local_pref {
-                    bgp_attr.local_pref = Some(LocalPref::new(*local_pref));
+                if let Some(action) = &entry.local_pref {
+                    let current = bgp_attr
+                        .local_pref
+                        .as_ref()
+                        .map(|l| l.local_pref)
+                        .unwrap_or(0);
+                    bgp_attr.local_pref = Some(LocalPref::new(action.apply(current)));
                 }
-                if let Some(med) = &entry.med {
-                    bgp_attr.med = Some(Med { med: *med });
+                if let Some(action) = &entry.med {
+                    let current = bgp_attr.med.as_ref().map(|m| m.med).unwrap_or(0);
+                    bgp_attr.med = Some(Med {
+                        med: action.apply(current),
+                    });
                 }
                 if let Some(cfg) = &entry.set_community {
                     apply_set_community(&mut bgp_attr, cfg);
@@ -3725,7 +3733,7 @@ mod tests {
     use super::policy_list_apply;
     use crate::policy::prefix::set::PrefixSetEntry;
     use crate::policy::{
-        AsPathPrependConfig, CommunityMatcher, CommunitySet, PolicyList, PrefixSet,
+        AsPathPrependConfig, CommunityMatcher, CommunitySet, NumericSet, PolicyList, PrefixSet,
         SetCommunityConfig, SetCommunityMode,
     };
 
@@ -3762,7 +3770,7 @@ mod tests {
     #[test]
     fn policy_list_apply_sets_local_pref() {
         let mut list = PolicyList::default();
-        list.entry(10).local_pref = Some(250);
+        list.entry(10).local_pref = Some(NumericSet::Set(250));
 
         let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), BgpAttr::default())
             .expect("entry with no match clause should apply");
@@ -3773,8 +3781,8 @@ mod tests {
     fn policy_list_apply_sets_local_pref_and_med() {
         let mut list = PolicyList::default();
         let entry = list.entry(10);
-        entry.local_pref = Some(150);
-        entry.med = Some(42);
+        entry.local_pref = Some(NumericSet::Set(150));
+        entry.med = Some(NumericSet::Set(42));
 
         let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), BgpAttr::default()).unwrap();
         assert_eq!(out.local_pref.unwrap().local_pref, 150);
@@ -3784,7 +3792,7 @@ mod tests {
     #[test]
     fn policy_list_apply_local_pref_overrides_existing() {
         let mut list = PolicyList::default();
-        list.entry(10).local_pref = Some(200);
+        list.entry(10).local_pref = Some(NumericSet::Set(200));
 
         let attr = BgpAttr {
             local_pref: Some(LocalPref::new(100)),
@@ -3793,6 +3801,75 @@ mod tests {
 
         let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
         assert_eq!(out.local_pref.unwrap().local_pref, 200);
+    }
+
+    #[test]
+    fn policy_list_apply_local_pref_add_to_existing() {
+        let mut list = PolicyList::default();
+        list.entry(10).local_pref = Some(NumericSet::Add(50));
+
+        let attr = BgpAttr {
+            local_pref: Some(LocalPref::new(100)),
+            ..Default::default()
+        };
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        assert_eq!(out.local_pref.unwrap().local_pref, 150);
+    }
+
+    #[test]
+    fn policy_list_apply_local_pref_add_to_absent_treats_as_zero() {
+        let mut list = PolicyList::default();
+        list.entry(10).local_pref = Some(NumericSet::Add(75));
+
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), BgpAttr::default()).unwrap();
+        assert_eq!(out.local_pref.unwrap().local_pref, 75);
+    }
+
+    #[test]
+    fn policy_list_apply_local_pref_sub_saturates_at_zero() {
+        let mut list = PolicyList::default();
+        list.entry(10).local_pref = Some(NumericSet::Sub(200));
+
+        let attr = BgpAttr {
+            local_pref: Some(LocalPref::new(100)),
+            ..Default::default()
+        };
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        assert_eq!(
+            out.local_pref.unwrap().local_pref,
+            0,
+            "underflow saturates at 0"
+        );
+    }
+
+    #[test]
+    fn policy_list_apply_med_add_saturates_at_max() {
+        let mut list = PolicyList::default();
+        list.entry(10).med = Some(NumericSet::Add(10));
+
+        let attr = BgpAttr {
+            med: Some(bgp_packet::Med { med: u32::MAX - 5 }),
+            ..Default::default()
+        };
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        assert_eq!(
+            out.med.unwrap().med,
+            u32::MAX,
+            "overflow saturates at u32::MAX"
+        );
+    }
+
+    #[test]
+    fn policy_list_apply_med_sub_clamps_to_zero() {
+        let mut list = PolicyList::default();
+        list.entry(10).med = Some(NumericSet::Sub(100));
+
+        let attr = BgpAttr {
+            med: Some(bgp_packet::Med { med: 30 }),
+            ..Default::default()
+        };
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), attr).unwrap();
+        assert_eq!(out.med.unwrap().med, 0);
     }
 
     #[test]
@@ -3995,7 +4072,7 @@ mod tests {
     fn policy_action_deny_drops_route_and_skips_set() {
         let mut list = PolicyList::default();
         let entry = list.entry(10);
-        entry.local_pref = Some(999);
+        entry.local_pref = Some(NumericSet::Set(999));
         entry.action = crate::policy::PolicyAction::Deny;
 
         // Match clause empty → entry matches every route.
@@ -4006,10 +4083,10 @@ mod tests {
     #[test]
     fn policy_action_next_applies_set_and_falls_through() {
         let mut list = PolicyList::default();
-        list.entry(10).local_pref = Some(150);
+        list.entry(10).local_pref = Some(NumericSet::Set(150));
         list.entry(10).action = crate::policy::PolicyAction::Next;
         // Entry 20 takes the verdict.
-        list.entry(20).med = Some(42);
+        list.entry(20).med = Some(NumericSet::Set(42));
         list.entry(20).action = crate::policy::PolicyAction::Permit;
 
         let out = policy_list_apply(&list, &nlri("10.0.0.0/24"), BgpAttr::default()).unwrap();
@@ -4039,7 +4116,7 @@ mod tests {
     #[test]
     fn policy_action_next_falling_through_to_end_of_list_is_default_deny() {
         let mut list = PolicyList::default();
-        list.entry(10).local_pref = Some(150);
+        list.entry(10).local_pref = Some(NumericSet::Set(150));
         list.entry(10).action = crate::policy::PolicyAction::Next;
         // No further entries — fall-through past the end of the
         // policy is default-deny.

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -110,6 +110,45 @@ impl NumericMatch {
     }
 }
 
+/// Operator for numeric set actions (`set local-preference`,
+/// `set med`) of shape `{set NUM | add NUM | sub NUM}`.
+/// `Set` overwrites the attribute; `Add` and `Sub` mutate the
+/// route's current value (treating absence as 0). Underflow on
+/// `Sub` and overflow on `Add` saturate; arithmetic never drops
+/// the route.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NumericSet {
+    Set(u32),
+    Add(u32),
+    Sub(u32),
+}
+
+impl NumericSet {
+    pub fn op_str(&self) -> &'static str {
+        match self {
+            NumericSet::Set(_) => "set",
+            NumericSet::Add(_) => "add",
+            NumericSet::Sub(_) => "sub",
+        }
+    }
+
+    pub fn value(&self) -> u32 {
+        match self {
+            NumericSet::Set(v) | NumericSet::Add(v) | NumericSet::Sub(v) => *v,
+        }
+    }
+
+    /// Apply the action to the route's current value, treating
+    /// absence as 0 and saturating on overflow / underflow.
+    pub fn apply(&self, current: u32) -> u32 {
+        match self {
+            NumericSet::Set(v) => *v,
+            NumericSet::Add(v) => current.saturating_add(*v),
+            NumericSet::Sub(v) => current.saturating_sub(*v),
+        }
+    }
+}
+
 /// Operation applied by `set community NAME {|additive|delete}`.
 /// `Replace` overwrites the COMMUNITIES attribute with the set's
 /// members; `Additive` merges them in; `Delete` removes them
@@ -163,8 +202,8 @@ pub struct PolicyEntry {
     pub match_weight: Option<NumericMatch>,
     pub match_origin: Option<Origin>,
     // Set.
-    pub local_pref: Option<u32>,
-    pub med: Option<u32>,
+    pub local_pref: Option<NumericSet>,
+    pub med: Option<NumericSet>,
     pub set_community: Option<SetCommunityConfig>,
     pub set_as_path_prepend: Option<AsPathPrependConfig>,
     pub set_next_hop: Option<Ipv4Addr>,
@@ -735,32 +774,110 @@ impl ConfigBuilder {
                 entry.match_origin = None;
                 Ok(())
             })
-            .path("/entry/set/local-preference")
+            // `set local-preference {set|add|sub} NUM` — presence
+            // container with mandatory choice; `set` overwrites,
+            // `add`/`sub` mutate the route's current value with
+            // saturating arithmetic.
+            .path("/entry/set/local-preference/set")
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.entry(seq);
-
-                let local_pref = args.u32().context(ARG_ERR)?;
-                entry.local_pref = Some(local_pref);
-
+                entry.local_pref = Some(NumericSet::Set(args.u32().context(ARG_ERR)?));
                 Ok(())
             })
             .del(|policy, cache, name, seq, _args| {
                 let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.lookup(&seq).context(ARG_ERR)?;
-                entry.local_pref = None;
+                if matches!(entry.local_pref, Some(NumericSet::Set(_))) {
+                    entry.local_pref = None;
+                }
                 Ok(())
             })
-            .path("/entry/set/med")
+            .path("/entry/set/local-preference/add")
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.entry(seq);
-
-                let med = args.u32().context(ARG_ERR)?;
-                entry.med = Some(med);
-
+                entry.local_pref = Some(NumericSet::Add(args.u32().context(ARG_ERR)?));
                 Ok(())
             })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if matches!(entry.local_pref, Some(NumericSet::Add(_))) {
+                    entry.local_pref = None;
+                }
+                Ok(())
+            })
+            .path("/entry/set/local-preference/sub")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.local_pref = Some(NumericSet::Sub(args.u32().context(ARG_ERR)?));
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if matches!(entry.local_pref, Some(NumericSet::Sub(_))) {
+                    entry.local_pref = None;
+                }
+                Ok(())
+            })
+            .path("/entry/set/local-preference")
+            .del(|policy, cache, name, seq, _args| {
+                // Container-level delete clears the whole action.
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.local_pref = None;
+                Ok(())
+            })
+            // `set med {set|add|sub} NUM` — same shape.
+            .path("/entry/set/med/set")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.med = Some(NumericSet::Set(args.u32().context(ARG_ERR)?));
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if matches!(entry.med, Some(NumericSet::Set(_))) {
+                    entry.med = None;
+                }
+                Ok(())
+            })
+            .path("/entry/set/med/add")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.med = Some(NumericSet::Add(args.u32().context(ARG_ERR)?));
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if matches!(entry.med, Some(NumericSet::Add(_))) {
+                    entry.med = None;
+                }
+                Ok(())
+            })
+            .path("/entry/set/med/sub")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                entry.med = Some(NumericSet::Sub(args.u32().context(ARG_ERR)?));
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                if matches!(entry.med, Some(NumericSet::Sub(_))) {
+                    entry.med = None;
+                }
+                Ok(())
+            })
+            .path("/entry/set/med")
             .del(|policy, cache, name, seq, _args| {
                 let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
                 let entry = list.lookup(&seq).context(ARG_ERR)?;
@@ -1000,11 +1117,11 @@ pub fn show(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> 
             if let Some(origin) = &entry.match_origin {
                 let _ = writeln!(buf, "  match: origin {:?}", origin);
             }
-            if let Some(local_pref) = &entry.local_pref {
-                let _ = writeln!(buf, "  set: local-pref {}", local_pref);
+            if let Some(s) = &entry.local_pref {
+                let _ = writeln!(buf, "  set: local-preference {} {}", s.op_str(), s.value());
             }
-            if let Some(med) = &entry.med {
-                let _ = writeln!(buf, "  set: med {}", med);
+            if let Some(s) = &entry.med {
+                let _ = writeln!(buf, "  set: med {} {}", s.op_str(), s.value());
             }
             if let Some(cfg) = &entry.set_community {
                 let suffix = match cfg.mode {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1060,11 +1060,62 @@ module config {
         }
         container "set" {
           ext:sort "3";
-          leaf "local-preference" {
-            type uint32;
+          container "local-preference" {
+            presence "set local-preference";
+            description
+              "Set the route's LOCAL_PREF attribute. Exactly one
+               of `set` (overwrite), `add` (saturating add to the
+               current value, treating absence as 0), or `sub`
+               (saturating subtract) must be present.";
+            choice "op" {
+              mandatory true;
+              case set-case {
+                leaf "set" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+              case add-case {
+                leaf "add" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+              case sub-case {
+                leaf "sub" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+            }
           }
-          leaf "med" {
-            type uint32;
+          container "med" {
+            presence "set med";
+            description
+              "Set the route's MULTI_EXIT_DISC. Same shape as
+               `set local-preference`: choice of `set`/`add`/`sub`
+               with a uint32 operand. `add`/`sub` saturate.";
+            choice "op" {
+              mandatory true;
+              case set-case {
+                leaf "set" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+              case add-case {
+                leaf "add" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+              case sub-case {
+                leaf "sub" {
+                  type uint32;
+                  mandatory true;
+                }
+              }
+            }
           }
           leaf "next-hop" {
             type inet:ipv4-address;


### PR DESCRIPTION
## Summary

Phase E of the policy spec — add saturating `set` / `add` / `sub` semantics to `set local-preference` and `set med`. Previously these were a flat `uint32` (overwrite-only).

### Schema shape

Each becomes a presence container with a mandatory `op` choice:

```yang
container "local-preference" {
  presence "set local-preference";
  choice "op" {
    mandatory true;
    case set-case { leaf "set" { type uint32; mandatory true; } }
    case add-case { leaf "add" { type uint32; mandatory true; } }
    case sub-case { leaf "sub" { type uint32; mandatory true; } }
  }
}
```

`set` overwrites; `add` and `sub` mutate the route's current value (treating absence as 0). Underflow on `sub` clamps at 0; overflow on `add` clamps at `u32::MAX`. Saturation never drops the route.

### Rust side

- New `NumericSet { Set | Add | Sub }(u32)` with `op_str` / `value` / `apply` helpers.
- `PolicyEntry::local_pref` and `med` change from `Option<u32>` to `Option<NumericSet>`.
- Apply path in `bgp/route.rs` calls `action.apply(current)` against the route's current LOCAL_PREF / MED.
- 8 new path-handler defs (3 op cases x 2 fields + 2 container-level deletes), 14 new callbacks.

### BDD migration

`bgp_route_map_match/z1.yaml` is the only BDD config that touched `set: med:` — migrated from `med: 100` to `med: { set: 100 }`.

## Test plan

- [x] `cargo build --release`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` — 5 new tests cover add-to-existing, add-to-absent (= 0), sub-saturates-at-0, add-saturates-at-u32::MAX, med sub clamp. 244 tests total (up 5 from baseline).
- [x] `cargo fmt --all --check`

## Breaking change

Schema break: configs using flat `set: med: 100` / `set: local-preference: 100` must move to the keyed form, e.g. `set: med: { set: 100 }`. The migrated BDD config above shows the shape.

Generated with [Claude Code](https://claude.com/claude-code)