### PR TITLE
policy: set origin (Phase G)

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2596,6 +2596,9 @@ pub fn policy_list_apply(
                 if let Some(addr) = &entry.set_next_hop {
                     decision.attr.nexthop = Some(BgpNexthop::Ipv4(*addr));
                 }
+                if let Some(origin) = entry.set_origin {
+                    decision.attr.origin = Some(origin);
+                }
                 if entry.action == PolicyAction::Permit {
                     return Some(decision);
                 }
@@ -3697,6 +3700,28 @@ mod policy_apply_tests {
         assert!(d.is_some(), "weight=500 should match Eq(500)");
         let d = super::policy_list_apply(&list, &nlri("10.0.0.0/8"), attr, 0);
         assert!(d.is_none(), "weight=0 should not match Eq(500)");
+    }
+
+    #[test]
+    fn set_origin_overrides_incoming() {
+        let mut list = PolicyList::default();
+        list.entry(10).set_origin = Some(Origin::Egp);
+
+        let attr = attr_with("1", None, Some(Origin::Igp));
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/8"), attr).expect("permit");
+        assert_eq!(out.origin, Some(Origin::Egp));
+    }
+
+    #[test]
+    fn set_origin_on_absent() {
+        // Originating an ORIGIN attribute on a route that didn't
+        // carry one previously.
+        let mut list = PolicyList::default();
+        list.entry(10).set_origin = Some(Origin::Incomplete);
+
+        let attr = attr_with("1", None, None);
+        let out = policy_list_apply(&list, &nlri("10.0.0.0/8"), attr).expect("permit");
+        assert_eq!(out.origin, Some(Origin::Incomplete));
     }
 
     #[test]

--- a/zebra-rs/src/policy/policy_list.rs
+++ b/zebra-rs/src/policy/policy_list.rs
@@ -208,6 +208,7 @@ pub struct PolicyEntry {
     pub set_community: Option<SetCommunityConfig>,
     pub set_as_path_prepend: Option<AsPathPrependConfig>,
     pub set_next_hop: Option<Ipv4Addr>,
+    pub set_origin: Option<Origin>,
     // Action.
     pub action: PolicyAction,
 }
@@ -1044,6 +1045,20 @@ impl ConfigBuilder {
                 entry.set_next_hop = None;
                 Ok(())
             })
+            .path("/entry/set/origin")
+            .set(|policy, cache, name, seq, args| {
+                let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.entry(seq);
+                let s = args.string().context(ARG_ERR)?;
+                entry.set_origin = Some(parse_origin(&s).context(ARG_ERR)?);
+                Ok(())
+            })
+            .del(|policy, cache, name, seq, _args| {
+                let list = cache_lookup(policy, cache, &name).context(ARG_ERR)?;
+                let entry = list.lookup(&seq).context(ARG_ERR)?;
+                entry.set_origin = None;
+                Ok(())
+            })
             .path("/entry/action")
             .set(|policy, cache, name, seq, args| {
                 let list = cache_get(policy, cache, &name).context(ARG_ERR)?;
@@ -1157,6 +1172,9 @@ pub fn show(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> 
             }
             if let Some(nh) = &entry.set_next_hop {
                 let _ = writeln!(buf, "  set: next-hop {}", nh);
+            }
+            if let Some(o) = &entry.set_origin {
+                let _ = writeln!(buf, "  set: origin {:?}", o);
             }
         }
     }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1129,6 +1129,16 @@ module config {
           leaf "next-hop" {
             type inet:ipv4-address;
           }
+          leaf "origin" {
+            type enumeration {
+              enum igp;
+              enum egp;
+              enum incomplete;
+            }
+            description
+              "Set the route's ORIGIN attribute. Mirrors the
+               three values that `match origin` accepts.";
+          }
           container "community" {
             presence "set community";
             description


### PR DESCRIPTION
## Summary

Phase G of the policy spec — add `set origin {igp|egp|incomplete}`. Symmetric counterpart of the `match origin` clause that's already in Phase A.

## Changes

- **YANG**: new `policy/entry/set/origin` enum leaf with the three standard ORIGIN values.
- **Rust**: `PolicyEntry` gains `pub set_origin: Option<Origin>`. Handler reuses the existing `parse_origin` helper. Show line renders alongside the other set actions.
- **Apply**: `policy_list_apply` writes `decision.attr.origin = Some(origin)` so the route's ORIGIN is updated for downstream best-path selection and outbound advertisement.

## Test plan

- [x] `cargo build --release`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` — 2 new tests (`set_origin_overrides_incoming`, `set_origin_on_absent`); 248 total.
- [x] `cargo fmt --all --check`

Pure addition — no breaking changes.

Generated with [Claude Code](https://claude.com/claude-code)