### PR TITLE
book: add Policy chapter (control flow, match, set)

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -20,6 +20,13 @@
 
 - [SRv6](ch-04-00-srv6.md)
 
+## Policy
+
+- [Policy](ch-05-00-policy.md)
+  - [Control Flow](ch-05-01-policy-control-flow.md)
+  - [Match](ch-05-02-policy-match.md)
+  - [Set](ch-05-03-policy-set.md)
+
 ## Logging and Monitoring
 
 - [Logging Configuration](ch-03-00-logging-overview.md)

--- a/book/src/ch-05-00-policy.md
+++ b/book/src/ch-05-00-policy.md
@@ -1,0 +1,79 @@
+# Policy
+
+A *policy* in zebra-rs is the equivalent of what Cisco / Juniper /
+FRR call a *route-map* or *route-policy*. It is an ordered list of
+entries; each entry decides whether a route is accepted, rejected,
+or modified before being passed on. Policies are attached to BGP
+peers in either the `in` direction (applied to routes received from
+the peer) or the `out` direction (applied to routes advertised to
+the peer).
+
+A policy is built out of three pieces:
+
+- **Control flow** — each entry has a mandatory `action`: `permit`,
+  `next`, or `deny`. The action decides what happens after the
+  entry's match clauses succeed.
+- **Match** — zero or more conditions the route must satisfy for
+  the entry to fire. Conditions are AND'd together.
+- **Set** — zero or more modifications to apply to the route's
+  attributes when the entry fires (and the action is not `deny`).
+
+Most policy clauses reference a *set* — a separately-named
+collection of values. The defined set types are:
+
+- `prefix-set` — IP prefixes, optionally with `le`/`ge` length
+  bounds. Used by `match prefix`.
+- `community-set` — standard or extended community values, with
+  optional regex. Used by `match community`.
+- `ext-community-set` — extended communities only (`rt:`/`soo:`),
+  with optional regex. Used by `match ext-community`.
+- `large-community-set` — RFC 8092 large communities, with optional
+  regex. Used by `match large-community`.
+- `as-path-set` — regex against the AS_PATH. Used by
+  `match as-path`.
+
+A complete policy that prefers routes from a specific peer subnet
+and tags them with a community looks like this:
+
+```console
+prefix-set CUSTOMER-A {
+    prefix 10.0.0.0/8 {
+        le 32;
+    };
+}
+
+community-set TAG-CUST-A {
+    members {
+        65001:100;
+    }
+}
+
+policy IN-CUSTOMER-A {
+    entry 10 {
+        action permit;
+        match {
+            prefix CUSTOMER-A;
+        }
+        set {
+            local-preference {
+                set 200;
+            }
+            community {
+                name TAG-CUST-A;
+                additive;
+            }
+        }
+    }
+}
+
+router bgp {
+    neighbor 192.168.0.1 {
+        policy {
+            in IN-CUSTOMER-A;
+        }
+    }
+}
+```
+
+The next three sections cover control flow, match, and set in
+detail, with worked examples for every clause.

--- a/book/src/ch-05-01-policy-control-flow.md
+++ b/book/src/ch-05-01-policy-control-flow.md
@@ -1,0 +1,267 @@
+# Control Flow
+
+Every policy is an ordered list of *entries*. Each entry is keyed
+by an integer sequence number and has three parts:
+
+```console
+policy NAME {
+    entry SEQ {
+        action {permit | next | deny};
+        match {
+            ...;
+        }
+        set {
+            ...;
+        }
+    }
+}
+```
+
+The walker visits entries in ascending sequence-number order. For
+each entry it evaluates all `match` clauses (they are AND'd
+together — see the next section). If every `match` clause
+succeeds the entry *fires* and its `action` decides what happens
+next. If any `match` clause fails the entry is skipped and the
+walker moves on.
+
+`action` is mandatory on every entry — there is no implicit
+default.
+
+## The three actions
+
+### `permit` — accept and stop
+
+Apply the entry's `set` clauses, then return the (possibly
+modified) route. The walker stops. Subsequent entries are not
+evaluated.
+
+```console
+policy ACCEPT-CUSTOMER-A {
+    entry 10 {
+        action permit;
+        match {
+            prefix CUSTOMER-A;
+        }
+        set {
+            local-preference {
+                set 200;
+            }
+        }
+    }
+}
+```
+
+A route inside `CUSTOMER-A` gets `LOCAL_PREF=200` and is accepted.
+A route outside falls through to the next entry — but there are
+no more entries, so it hits the default-deny rule (see below).
+
+### `next` — apply set, then keep scanning
+
+Apply the entry's `set` clauses to the working attribute set, then
+move to the next entry without producing a verdict. Lets you
+layer modifications across several entries.
+
+```console
+policy LAYERED {
+    entry 10 {
+        action next;
+        match {
+            prefix CUSTOMER-A;
+        }
+        set {
+            community {
+                name TAG-CUST-A;
+                additive;
+            }
+        }
+    }
+    entry 20 {
+        action next;
+        match {
+            as-path FROM-AS65003;
+        }
+        set {
+            local-preference {
+                set 50;
+            }
+        }
+    }
+    entry 30 {
+        action permit;
+    }
+}
+```
+
+A route in `CUSTOMER-A` whose AS_PATH also matches `FROM-AS65003`
+gets *both* the community tag and the lowered `local-preference`,
+then is accepted by entry 30 (an unconditional `permit`).
+
+### `deny` — reject, do not apply set
+
+Drop the route. The entry's `set` clauses are *not* applied — a
+denied route never picks up incidental modifications.
+
+```console
+policy BLOCK-MARTIANS {
+    entry 10 {
+        action deny;
+        match {
+            prefix MARTIANS;
+        }
+    }
+    entry 20 {
+        action permit;
+    }
+}
+```
+
+Routes in `MARTIANS` are dropped at entry 10. Everything else
+falls through to entry 20 and is accepted.
+
+## Default-deny
+
+If the walker reaches the end of the policy without producing a
+permit verdict, the route is **rejected**. This includes the case
+where the only matching entries fall through with `next`:
+
+```console
+policy ENDS-ON-NEXT {
+    entry 10 {
+        action next;
+        match {
+            prefix CUSTOMER-A;
+        }
+        set {
+            community {
+                name TAG-CUST-A;
+                additive;
+            }
+        }
+    }
+}
+```
+
+This policy *drops* every route — even routes in `CUSTOMER-A`,
+because the only match path falls through to the end of the list
+with no permit. To accept the modified route, the policy must
+end with a permit:
+
+```console
+policy CORRECT {
+    entry 10 {
+        action next;
+        match {
+            prefix CUSTOMER-A;
+        }
+        set {
+            community {
+                name TAG-CUST-A;
+                additive;
+            }
+        }
+    }
+    entry 20 {
+        action permit;
+    }
+}
+```
+
+The default-deny rule is also why a policy with only `match` and
+no entries that ever permit is equivalent to "drop everything".
+
+## "Default permit" pattern
+
+To express "modify routes that match, accept everything else", end
+the policy with an unconditional `permit`:
+
+```console
+policy DEFAULT-PERMIT {
+    entry 10 {
+        action permit;
+        match {
+            prefix CUSTOMER-A;
+        }
+        set {
+            local-preference {
+                set 200;
+            }
+        }
+    }
+    entry 20 {
+        action deny;
+        match {
+            prefix MARTIANS;
+        }
+    }
+    entry 99 {
+        action permit;
+    }
+}
+```
+
+Routes in `CUSTOMER-A` permit at entry 10 with their LP boosted.
+Routes in `MARTIANS` deny at entry 20. Anything else falls
+through to entry 99 and is accepted unchanged.
+
+## Worked example: precedence and termination
+
+```console
+policy ORDER-DEMO {
+    entry 10 {
+        action deny;
+        match {
+            prefix BLOCKLIST;
+        }
+    }
+    entry 20 {
+        action permit;
+        match {
+            prefix VIPS;
+        }
+        set {
+            local-preference {
+                set 300;
+            }
+        }
+    }
+    entry 30 {
+        action next;
+        match {
+            community {
+                name HAS-NO-EXPORT;
+            }
+        }
+        set {
+            community {
+                name TAG-INTERNAL;
+                additive;
+            }
+        }
+    }
+    entry 40 {
+        action permit;
+    }
+}
+```
+
+For a route 1.2.3.4/32 with community `65001:42`:
+
+| Entry | Match? | Effect |
+|-------|--------|--------|
+| 10 | not in `BLOCKLIST` | skipped |
+| 20 | not in `VIPS` | skipped |
+| 30 | community `no-export` not present | skipped |
+| 40 | unconditional | `permit` — accept the route unchanged |
+
+For a route in `BLOCKLIST`:
+
+| Entry | Match? | Effect |
+|-------|--------|--------|
+| 10 | yes | `deny` — drop, walker stops, no `set` applied |
+
+For a route in `VIPS`:
+
+| Entry | Match? | Effect |
+|-------|--------|--------|
+| 10 | not in `BLOCKLIST` | skipped |
+| 20 | yes | apply `LP=300`, `permit` — accept and stop |

--- a/book/src/ch-05-02-policy-match.md
+++ b/book/src/ch-05-02-policy-match.md
@@ -1,0 +1,360 @@
+# Match
+
+`match` clauses select which routes an entry applies to. All
+clauses inside a single `match` block are AND'd together — every
+clause must succeed for the entry to fire. An empty `match` block
+(or no `match` block at all) means the entry matches every route.
+
+This chapter covers all match clauses grouped by shape:
+
+1. **Set references** — `prefix`, `community`, `ext-community`,
+   `large-community`, `as-path` — name a separately-defined set.
+2. **Direct address** — `next-hop` — exact equality against the
+   route's NEXT_HOP attribute.
+3. **Numeric** — `med`, `as-path-len`, `as-path-len-uniq`,
+   `local-preference`, `weight` — compare against a single
+   `eq` / `le` / `ge` operator.
+4. **Enum** — `origin` — one of `igp` / `egp` / `incomplete`.
+
+## Set references
+
+### `match prefix`
+
+References a `prefix-set`. The route's prefix is checked against
+each entry of the set; if any matches (with optional `le` / `ge`
+length bounds), the clause succeeds.
+
+```console
+prefix-set CUSTOMER-NETS {
+    prefix 10.0.0.0/8 {
+        le 32;
+    }
+    prefix 192.168.0.0/16 {
+        le 24;
+        ge 24;
+    }
+}
+
+policy IN-CUSTOMER {
+    entry 10 {
+        action permit;
+        match {
+            prefix CUSTOMER-NETS;
+        }
+    }
+}
+```
+
+The set permits anything inside `10.0.0.0/8` of any length up to
+/32, plus exactly /24 prefixes inside `192.168.0.0/16`.
+
+### `match community`
+
+References a `community-set`. The set's members are matched
+against the route's COMMUNITIES attribute. Members can be:
+
+- standard community values (`100:200`, `no-export`, …)
+- standard community regex patterns (`^65001:.*`)
+- extended community exact values (`rt:65001:100`, `soo:1.2.3.4:50`)
+- extended community regex patterns (`rt:^65001:.*`)
+
+```console
+community-set INTERNAL {
+    members {
+        no-export;
+        65001:100;
+        ^65001:42[0-9]+$;
+    }
+}
+
+policy DROP-INTERNAL {
+    entry 10 {
+        action deny;
+        match {
+            community INTERNAL;
+        }
+    }
+    entry 20 {
+        action permit;
+    }
+}
+```
+
+### `match ext-community`
+
+References an `ext-community-set`. Like `community` but only
+accepts extended-community syntax — `rt:` and `soo:` only;
+standard-community values are rejected at parse time.
+
+```console
+ext-community-set TENANT-A {
+    members {
+        rt:65001:100;
+        rt:1.2.3.4:200;
+        soo:^65001:.*;
+    }
+}
+
+policy IN-TENANT-A {
+    entry 10 {
+        action permit;
+        match {
+            ext-community TENANT-A;
+        }
+    }
+}
+```
+
+### `match large-community`
+
+References a `large-community-set`. Members are either an exact
+`A:B:C` triple of `uint32`s (RFC 8092) or a regex matched against
+the textual `A:B:C` form of each LARGE_COMMUNITIES element.
+
+```console
+large-community-set ASN-65001 {
+    members {
+        65001:100:200;
+        ^65001:.*:.*$;
+    }
+}
+
+policy MATCH-LARGE {
+    entry 10 {
+        action permit;
+        match {
+            large-community ASN-65001;
+        }
+    }
+}
+```
+
+### `match as-path`
+
+References an `as-path-set`. Each member is a regex matched
+against the AS_PATH formatted as a space-separated list of ASNs.
+
+```console
+as-path-set FROM-65003 {
+    members {
+        \\b65003\\b;
+    }
+}
+
+policy DROP-65003-TRANSIT {
+    entry 10 {
+        action deny;
+        match {
+            as-path FROM-65003;
+        }
+    }
+    entry 20 {
+        action permit;
+    }
+}
+```
+
+`\\b` is a regex word-boundary anchor that prevents `65003` from
+matching `650030` or `650031`.
+
+## Direct address
+
+### `match next-hop`
+
+Takes an IPv4 *or* IPv6 address — not a prefix-set name — and
+compares it for **exact equality** against the route's BGP
+NEXT_HOP attribute. To match a *range* of addresses, use a
+prefix-set with `match prefix` against the route prefix, or
+write multiple entries.
+
+```console
+policy ONLY-FROM-PEER1 {
+    entry 10 {
+        action permit;
+        match {
+            next-hop 192.168.0.1;
+        }
+    }
+}
+```
+
+Note: `BgpNexthop` is IPv4-only today, so an IPv6 address parses
+cleanly but never matches a route. That gap closes when IPv6
+unicast nexthop is wired through.
+
+## Numeric match
+
+`med`, `as-path-len`, `as-path-len-uniq`, `local-preference`, and
+`weight` all share the same shape: a presence container with a
+mandatory `op` choice between `eq NUM`, `le NUM`, and `ge NUM`.
+At most one operator per clause; combine with `next` actions or
+multiple entries to express ranges.
+
+### `match med`
+
+```console
+policy LOW-MED-ONLY {
+    entry 10 {
+        action permit;
+        match {
+            med {
+                le 100;
+            }
+        }
+    }
+}
+```
+
+To express "MED between 50 and 200":
+
+```console
+policy MED-RANGE {
+    entry 10 {
+        action permit;
+        match {
+            med {
+                ge 50;
+            }
+        }
+        set {
+            ...;
+        }
+    }
+}
+```
+
+Combined with another entry that filters out high values, or
+with a single `match` block carrying both `match med ge 50` and a
+second AND'd clause from a separate `next`-chained entry. (Today
+each `match` block has exactly one `med` clause; the spec admits
+range-by-chain.)
+
+### `match as-path-len`
+
+The total number of ASes in the AS_PATH, counting prepends.
+
+```console
+policy SHORT-PATHS-ONLY {
+    entry 10 {
+        action permit;
+        match {
+            as-path-len {
+                le 3;
+            }
+        }
+    }
+    entry 20 {
+        action deny;
+    }
+}
+```
+
+### `match as-path-len-uniq`
+
+The number of *distinct* ASes — same as `as-path-len` but
+collapses duplicates. Useful for catching pathological prepend
+counts:
+
+```console
+policy NO-WEIRD-PREPENDS {
+    entry 10 {
+        action deny;
+        match {
+            as-path-len {
+                ge 20;
+            }
+            as-path-len-uniq {
+                le 3;
+            }
+        }
+    }
+    entry 20 {
+        action permit;
+    }
+}
+```
+
+A path of 20+ ASes that are really only 3 distinct ones (e.g.
+`65001 65001 65001 ... 65002 65003`) trips this filter.
+
+### `match local-preference`
+
+```console
+policy KEEP-HIGH-LP {
+    entry 10 {
+        action permit;
+        match {
+            local-preference {
+                ge 150;
+            }
+        }
+    }
+}
+```
+
+### `match weight`
+
+BGP weight is a per-router value (not on the wire) that lives on
+the local RIB entry. The matcher reads the route's current
+weight as carried through the policy apply path.
+
+```console
+policy WEIGHT-1000 {
+    entry 10 {
+        action permit;
+        match {
+            weight {
+                eq 1000;
+            }
+        }
+    }
+}
+```
+
+For a route arriving on a peer where no `set weight` has been
+applied yet, the carried weight is 0. `match weight eq 0`
+matches; `match weight ge 1` does not.
+
+## Enum match
+
+### `match origin`
+
+Matches the route's ORIGIN attribute against one of the three
+RFC 4271 values:
+
+```console
+policy IGP-ONLY {
+    entry 10 {
+        action permit;
+        match {
+            origin igp;
+        }
+    }
+    entry 20 {
+        action deny;
+    }
+}
+```
+
+## All clauses are AND'd
+
+```console
+policy STRICT {
+    entry 10 {
+        action permit;
+        match {
+            prefix CUSTOMER-NETS;
+            as-path FROM-65003;
+            med {
+                le 100;
+            }
+            origin igp;
+        }
+    }
+}
+```
+
+A route is permitted only if it is in `CUSTOMER-NETS`, has an
+AS_PATH containing `65003`, has `MED <= 100`, and has `ORIGIN =
+igp`. Any one missing — and the clause fails, the entry skips,
+default-deny applies.

--- a/book/src/ch-05-03-policy-set.md
+++ b/book/src/ch-05-03-policy-set.md
@@ -1,0 +1,383 @@
+# Set
+
+`set` clauses modify the route's attributes when the entry fires
+with action `permit` or `next`. (A `deny` action drops the route
+without applying any `set` — a denied route never picks up
+incidental modifications.)
+
+This chapter walks every `set` clause grouped by what it touches:
+
+1. **Numeric attributes (signed deltas)** — `local-preference`
+   and `med` accept `set`/`add`/`sub`; arithmetic saturates.
+2. **Numeric attribute (plain assign)** — `weight`.
+3. **Enum** — `origin`.
+4. **Address** — `next-hop` (IPv4 / IPv6 / `self`).
+5. **Communities** — `community` (replace / additive / delete).
+6. **AS path** — `as-path-prepend`.
+
+## Numeric attributes with deltas
+
+### `set local-preference`
+
+`local-preference` and `med` use the same shape: a presence
+container with a mandatory `op` choice between three cases.
+
+```console
+policy SET-LP {
+    entry 10 {
+        action permit;
+        set {
+            local-preference {
+                set 200;
+            }
+        }
+    }
+}
+```
+
+`set 200` overwrites the route's LOCAL_PREF, regardless of what
+the route arrived with. The two delta forms are:
+
+```console
+policy BUMP-LP {
+    entry 10 {
+        action permit;
+        match {
+            community {
+                name PREFERRED;
+            }
+        }
+        set {
+            local-preference {
+                add 50;
+            }
+        }
+    }
+    entry 20 {
+        action permit;
+        match {
+            community {
+                name DEPRIORITIZE;
+            }
+        }
+        set {
+            local-preference {
+                sub 50;
+            }
+        }
+    }
+    entry 30 {
+        action permit;
+    }
+}
+```
+
+`add 50` adds 50 to whatever the route currently has; `sub 50`
+subtracts 50. If the route has no LOCAL_PREF on it (the
+attribute is absent), the current value is treated as 0.
+
+**Saturation.** Underflow on `sub` clamps at 0, never wraps.
+Overflow on `add` clamps at `u32::MAX`. A `sub 200` against a
+route with `LOCAL_PREF=100` produces 0 — not -100, not
+`u32::MAX-100`.
+
+### `set med`
+
+Identical shape:
+
+```console
+policy SHIFT-MED {
+    entry 10 {
+        action permit;
+        set {
+            med {
+                add 1000;
+            }
+        }
+    }
+}
+```
+
+## `set weight`
+
+A plain `uint32` assignment — no `add` / `sub`. Higher weight
+wins in best-path selection. Weight is per-router and is not
+advertised to peers; it lives on the local RIB entry.
+
+```console
+policy PREFER-PEER1 {
+    entry 10 {
+        action permit;
+        match {
+            next-hop 192.168.0.1;
+        }
+        set {
+            weight 32768;
+        }
+    }
+    entry 20 {
+        action permit;
+    }
+}
+```
+
+A route arriving from `192.168.0.1` enters the local RIB with
+`weight=32768`; routes from other peers default to 0, so the
+`192.168.0.1` route wins ties.
+
+## `set origin`
+
+```console
+policy MARK-AS-IGP {
+    entry 10 {
+        action permit;
+        set {
+            origin igp;
+        }
+    }
+}
+```
+
+Three values are accepted: `igp`, `egp`, `incomplete` — the same
+three that `match origin` accepts.
+
+## `set next-hop`
+
+A presence container with a mandatory choice: an explicit
+IPv4 / IPv6 address, or the bare keyword `self`.
+
+### Explicit address
+
+```console
+policy NH-EXPLICIT {
+    entry 10 {
+        action permit;
+        set {
+            next-hop {
+                address 10.0.0.1;
+            }
+        }
+    }
+}
+```
+
+### `self` — local router
+
+`set next-hop self` resolves at apply time to the local
+router-id of the BGP session that's advertising the route. The
+typical use case is iBGP route reflection or "next-hop-self"
+toward eBGP peers.
+
+```console
+policy IBGP-NH-SELF {
+    entry 10 {
+        action permit;
+        set {
+            next-hop {
+                self;
+            }
+        }
+    }
+}
+
+router bgp {
+    neighbor 10.0.0.2 {
+        policy {
+            out IBGP-NH-SELF;
+        }
+    }
+}
+```
+
+When the route is sent to `10.0.0.2`, its NEXT_HOP attribute is
+rewritten to the local router-id of the local↔10.0.0.2 session.
+
+### IPv6 (today)
+
+An IPv6 address parses cleanly but does not currently affect the
+route — `BgpNexthop` is IPv4-only today. The clause is in the
+schema for forward compatibility; a follow-up adds the IPv6
+unicast nexthop and emit path.
+
+## `set community`
+
+Apply a `community-set` to the route's COMMUNITIES attribute,
+with three modes:
+
+- **replace** (default) — overwrite the COMMUNITIES attribute
+  with the set's members.
+- **additive** — merge the set's members into whatever
+  COMMUNITIES the route already carries.
+- **delete** — remove the set's members from the route's
+  COMMUNITIES (set difference).
+
+```console
+community-set TAG-INTERNAL {
+    members {
+        65001:100;
+        65001:200;
+    }
+}
+
+policy ADD-INTERNAL-TAG {
+    entry 10 {
+        action permit;
+        match {
+            prefix INTERNAL-NETS;
+        }
+        set {
+            community {
+                name TAG-INTERNAL;
+                additive;
+            }
+        }
+    }
+}
+```
+
+The `additive` keyword is what makes this *add* the tags; without
+it the route's existing communities would be replaced wholesale:
+
+```console
+policy CLEAR-AND-RESET {
+    entry 10 {
+        action permit;
+        set {
+            community {
+                name TAG-INTERNAL;
+            }
+        }
+    }
+}
+```
+
+Any communities the route arrived with are gone after this entry
+fires. To explicitly remove tags:
+
+```console
+community-set NO-EXPORT-TAGS {
+    members {
+        no-export;
+        no-advertise;
+    }
+}
+
+policy STRIP-NO-EXPORT {
+    entry 10 {
+        action permit;
+        set {
+            community {
+                name NO-EXPORT-TAGS;
+                delete;
+            }
+        }
+    }
+}
+```
+
+## `set as-path-prepend`
+
+Prepend an ASN onto the AS_PATH a configurable number of times.
+Used in outbound policy to make a path artificially longer and
+discourage upstreams from preferring it.
+
+```console
+policy PREPEND-OUT {
+    entry 10 {
+        action permit;
+        set {
+            as-path-prepend {
+                asn 65001;
+                repeat 3;
+            }
+        }
+    }
+}
+```
+
+`repeat 3` adds the ASN three times. The default is `repeat 1`
+when omitted. The ASN to prepend is independent of the local
+ASN — typically an operator prepends their own ASN, but the
+schema doesn't enforce that.
+
+## Apply order within a single entry
+
+When an entry has several `set` clauses, they apply in this
+order against the working attribute set:
+
+1. `local-preference`
+2. `med`
+3. `weight`
+4. `community`
+5. `as-path-prepend`
+6. `next-hop`
+7. `origin`
+
+The order matters in two cases:
+
+- `as-path-prepend` after `set community` means a regex on the
+  *prepended* AS_PATH won't see the prepend if a downstream entry
+  uses `match as-path` — that downstream match runs against the
+  already-modified path.
+- For `community` with `additive`, the set's members are merged
+  into whatever COMMUNITIES the route had at the *start of the
+  entry* — a `set community` earlier in the same entry would
+  have replaced/cleared first.
+
+Within a single entry these orderings are usually invisible. If
+you need fine control, split into multiple entries chained by
+`action next`.
+
+## Worked example: combining set clauses
+
+```console
+prefix-set CUSTOMER-A {
+    prefix 10.10.0.0/16 {
+        le 24;
+    }
+}
+
+community-set TAG-CUST-A {
+    members {
+        65001:100;
+    }
+}
+
+policy IN-CUSTOMER-A {
+    entry 10 {
+        action permit;
+        match {
+            prefix CUSTOMER-A;
+        }
+        set {
+            local-preference {
+                set 200;
+            }
+            community {
+                name TAG-CUST-A;
+                additive;
+            }
+            origin igp;
+            weight 100;
+        }
+    }
+    entry 20 {
+        action permit;
+    }
+}
+```
+
+For a route 10.10.5.0/24 from this peer with `LOCAL_PREF=100`,
+`ORIGIN=incomplete`, and existing community `65000:42`:
+
+1. `local-preference set 200` → `LOCAL_PREF=200`
+2. `community { name TAG-CUST-A; additive; }` →
+   `COMMUNITIES = {65000:42, 65001:100}`
+3. `origin igp` → `ORIGIN=igp`
+4. `weight 100` → local rib entry weight = 100
+5. `permit` → route is accepted, walker stops.
+
+For a route 192.168.0.0/24 (not in `CUSTOMER-A`):
+
+1. Entry 10's `match prefix` fails. Entry skipped.
+2. Entry 20: unconditional `permit`. Accepted unchanged.


### PR DESCRIPTION
## Summary

New top-level Policy section in the mdbook covering everything that landed across phases A-H. Four pages, ~1k lines:

- **`ch-05-00-policy.md`** — overview: the three pieces (control flow / match / set), the five defined-set types (prefix / community / ext-community / large-community / as-path), and a complete worked policy that ties them together.
- **`ch-05-01-policy-control-flow.md`** — anatomy of an entry, the three actions (`permit` / `next` / `deny`) with worked examples, default-deny semantics, the "default permit" pattern, and a precedence-walkthrough table.
- **`ch-05-02-policy-match.md`** — every match clause grouped by shape: set-references (`prefix`, `community`, `ext-community`, `large-community`, `as-path`), direct-address (`next-hop`), numeric (`med`, `as-path-len`, `as-path-len-uniq`, `local-preference`, `weight`) with `eq`/`le`/`ge`, and the `origin` enum. Each clause has a worked example. AND'ing semantics documented.
- **`ch-05-03-policy-set.md`** — every set clause: signed-delta numeric (`local-preference`, `med`) with saturation rules, plain-assign `weight`, `origin`, `next-hop` (address / `self` / v6-inert), `community` (replace / additive / delete), and `as-path-prepend`. In-entry apply order documented.

`SUMMARY.md` gains a `## Policy` group between SRv6 and Logging.

## Test plan

- [x] `make book` builds clean (mdbook html backend, no warnings)

Generated with [Claude Code](https://claude.com/claude-code)