### PR TITLE
docs: polish intro and add missing BDD doc renderings

### DIFF
--- a/bdd/docs/bgp_policy_dynamic_update.md
+++ b/bdd/docs/bgp_policy_dynamic_update.md
@@ -1,0 +1,45 @@
+# BGP reacts to live prefix-set / policy edits without session reset
+
+## Overview
+
+As a network operator
+I want zebra-rs to re-evaluate Adj-RIB-In when a referenced prefix-set
+or policy-list is edited, so that operational changes propagate
+immediately without me having to clear the BGP session.
+The exercise: z2 attaches `apply-policy in HOGE`, where policy HOGE
+matches `prefix-set HOGE`. Because the prefix-set is referenced
+*indirectly* via the policy's match clause, the harness must follow
+the cascade prefix-set HOGE -> policy HOGE -> peer's Adj-RIB-In
+every time the prefix-set is edited. Without the cascade, BGP would
+only see the change after a manual `clear ... soft in`.
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                   │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+```
+
+## Config Files
+
+- z1.yaml: AS 65001, advertises 1.1.1.1/32 + 2.2.2.2/32, no policy.
+- z2-initial.yaml: prefix-set HOGE = { 1.1.1.1/32 }; policy HOGE matches
+- z2-both.yaml: prefix-set HOGE = { 1.1.1.1/32, 2.2.2.2/32 } (added).
+- z2-other.yaml: prefix-set HOGE = { 2.2.2.2/32 } (1.1.1.1/32 removed).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and verify initial filter | |
+| Adding a prefix to the referenced prefix-set propagates without session reset | |
+| Removing a prefix from the referenced prefix-set withdraws the corresponding route | |
+| Teardown topology | |

--- a/bdd/docs/bgp_update_group_ipv4.md
+++ b/bdd/docs/bgp_update_group_ipv4.md
@@ -1,0 +1,42 @@
+# BGP Update-Group IPv4 Unicast Formation
+
+## Overview
+
+As a network operator I want IOS-XR-style update-groups to form
+correctly: peers whose outbound advertisement signature is identical
+cluster into one group, and peers whose signature differs land in
+separate groups. The runtime then shares attribute transform /
+outbound policy work across same-group members (Phase 2) and shares
+encoded UPDATE bytes across non-source members (Phase 3).
+This feature exercises grouping by **outbound policy name**, the
+primary signature differentiator under operator control. Three
+eBGP peers from z1: two share `out-shared`, one uses `out-different`.
+Expected: `show bgp update-group` reports exactly 2 groups on z1.
+
+## Test Topology
+
+```
+  ┌──────────────────────────────────────────────────────────────┐
+  │                          br0                                 │
+  └──────┬───────────────┬───────────────┬───────────────┬───────┘
+         │               │               │               │
+    ┌────┴────┐     ┌────┴────┐     ┌────┴────┐     ┌────┴────┐
+    │   z1    │     │   z2    │     │   z3    │     │   z4    │
+    │ AS65001 │     │ AS65002 │     │ AS65003 │     │ AS65004 │
+    │.0.1/24  │     │.0.2/24  │     │.0.3/24  │     │.0.4/24  │
+    └─────────┘     └─────────┘     └─────────┘     └─────────┘
+```
+
+## Config Files
+
+- z1-1.yaml: AS 65001, three eBGP peers; .2 and .3 attach
+- z2-1.yaml / z3-1.yaml / z4-1.yaml: simple peer back to .0.1.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup 3-peer topology and establish all sessions | |
+| Two peers sharing policy form one update-group; the third forms its own | |
+| Group detail surfaces the negotiated capabilities | |
+| Teardown topology | |

--- a/book/src/ch-00-00-introduction.md
+++ b/book/src/ch-00-00-introduction.md
@@ -1,16 +1,15 @@
 # Introduction
 
-Welcome to *The Zebra Routing Software*, an introductory book about zebra-rs.
-zebra-rs is routing software that supports various routing protocols, such as
-BGP, OSPF and IS-IS. It is built from scratch using the Rust programming
-language.
+Welcome to an introductory book about *zebra-rs*. zebra-rs is routing software
+that supports various routing protocols, such as BGP, OSPF and IS-IS. It is
+built from scratch using the Rust programming language.
 
 ## History
 
-The original implementation of The Zebra Routing Software began in 1996 as the
-GNU Zebra project, which was written in the C programming language. Since then,
-GNU Zebra has been forked into several projects such as `quagga` and `FRR`.
-Current most updated maintained version is [FRRouting](https://frrouting.org/).
+The original implementation of zebra-rs began in 1996 as the GNU Zebra project,
+which was written in the C programming language. Since then, GNU Zebra has been
+forked into several projects such as `quagga` and `FRR`. Current most updated
+maintained version is [FRRouting](https://frrouting.org/).
 
 ## Architecture
 
@@ -18,5 +17,5 @@ GNU Zebra was implemented using a multi-server architecture to take advantage of
 multi-core CPUs. When it was designed in 1996, multi-process architecture was
 the best approach for multi-core CPUs. Today, the Rust programming language
 offers excellent support for multi-threading and multi-tasking, such as through
-the tokio library. Therefore, The Zebra Routing Software is designed as a
-single-process application that runs multiple tasks within it.
+the tokio library. Therefore, zebra-rs is designed as a single-process
+application that runs multiple tasks within it.


### PR DESCRIPTION
## Summary

- **book/src/ch-00-00-introduction.md**: drop the redundant "The Zebra Routing Software" prose in favor of just `zebra-rs`, matching the tone of the rest of the book.
- **bdd/docs/bgp_policy_dynamic_update.md** and **bdd/docs/bgp_update_group_ipv4.md**: add the two feature renderings that had been generated locally but never committed. Both are produced by the corrected `feature2md.sh` from PR #460.

## Test plan

- [x] `make book` builds clean (mdbook html backend).
- [x] `feature2md.sh` regenerated `bgp_update_group_ipv4.md` to pick up the description-continuation fix from PR #460.

Generated with [Claude Code](https://claude.com/claude-code)