### PR TITLE
bdd: assign the requested IP in 'create namespace ... with IP'

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -157,6 +157,10 @@ async fn create_namespace_with_ip(
         .await
         .expect("Failed to connect namespace to bridge");
 
+    netns::exec_in_netns(&scoped_ns, "ip", &["addr", "add", &ip, "dev", &ns_veth])
+        .await
+        .expect("Failed to assign IP address to namespace veth");
+
     println!(
         "✓ Namespace {} created with IP {} on bridge {}",
         scoped_ns, ip, scoped_br


### PR DESCRIPTION
## Summary

The Cucumber step

    When I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"

was creating the namespace, the host-side veth, the bridge link, and bringing both veth ends up — but the `ip` argument it received was only echoed in the success print and never assigned to the in-namespace veth.

Tests that depended on the IP being present (BGP basic iBGP / eBGP, anything else using this step) had to work around it in their YAML config or relied on side effects elsewhere.

## Fix

After `connect_netns_to_bridge`, run `ip addr add <ip> dev <ns_veth>` inside the namespace via the existing `exec_in_netns` helper. The veth is already up at that point, so the address assignment happens on a live interface.

## Test plan

- [x] `cargo build --release -p bdd --tests`

Generated with [Claude Code](https://claude.com/claude-code)