### PR TITLE
deps: refresh dependency versions across the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,12 @@ license = "AGPL-3.0-or-later"
 
 [workspace.dependencies]
 anyhow = "1.0"
-prost = "0.13"
+prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
-tonic = "0.13"
-tonic-build = "0.13"
+tonic = "0.14"
+tonic-prost = "0.14"
+tonic-prost-build = "0.14"
 clap = { version = "4", features = ["derive"] }
 
 # Workspace-wide clippy configuration. Crates inherit this via

--- a/bdd/Cargo.toml
+++ b/bdd/Cargo.toml
@@ -10,13 +10,13 @@ tokio = { workspace = true, features = ["process", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
-thiserror = "1"
+thiserror = "2"
 anyhow.workspace = true
 
 [dev-dependencies]
-rstest = "0.18"
+rstest = "0.26"
 tempfile = "3"
-cucumber = { version = "0.21", features = ["output-json"] }
+cucumber = { version = "0.23", features = ["output-json"] }
 futures = "0.3"
 
 [[test]]

--- a/crates/bgp-packet/Cargo.toml
+++ b/crates/bgp-packet/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 description = "Parser for the BGP protocol"
 
 [dependencies]
-bitfield-struct = "0.11.0"
+bitfield-struct = "0.13"
 bitflags = "2.6.0"
 byteorder = "1.5"
 bytes = "1.9"
@@ -21,9 +21,9 @@ num_enum = "0.7.5"
 regex = "1.11.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-strum = "0.27.2"
-strum_macros = "0.27.2"
-thiserror = "1.0"
+strum = "0.28"
+strum_macros = "0.28"
+thiserror = "2"
 
 [dev-dependencies]
 hex-literal = "1.0"

--- a/crates/isis-packet/Cargo.toml
+++ b/crates/isis-packet/Cargo.toml
@@ -8,7 +8,7 @@ description = "Parser for the IS-IS protocol"
 
 [dependencies]
 packet-utils = { path = "../packet-utils" }
-bitfield-struct = "0.11"
+bitfield-struct = "0.13"
 byteorder = "1.5"
 bytes = "1.9"
 fletcher = "1.0.0"
@@ -19,9 +19,9 @@ nom = "8"
 nom-derive = { git = "https://github.com/rust-bakery/nom-derive", branch = "master" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-strum = "0.27.2"
-strum_macros = "0.27.2"
-thiserror = "1.0"
+strum = "0.28"
+strum_macros = "0.28"
+thiserror = "2"
 
 [dev-dependencies]
 hex-literal = "1.0"

--- a/crates/ospf-packet/Cargo.toml
+++ b/crates/ospf-packet/Cargo.toml
@@ -8,7 +8,7 @@ description = "Parser for the OSPFv2 and OSPFv3 protocol"
 
 [dependencies]
 packet-utils = { path = "../packet-utils" }
-bitfield-struct = "0.11.0"
+bitfield-struct = "0.13"
 byteorder = "1.5"
 bytes = "1.9"
 fletcher = "1.0.0"

--- a/crates/packet-utils/Cargo.toml
+++ b/crates/packet-utils/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 description = "Common utilities for protocol packet parsing"
 
 [dependencies]
-bitfield-struct = "0.11"
+bitfield-struct = "0.13"
 byteorder = "1.5"
 bytes = "1.9"
 fletcher = "1.0.0"
@@ -18,9 +18,9 @@ nom = "8"
 nom-derive = { git = "https://github.com/rust-bakery/nom-derive", branch = "master" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-strum = "0.27.2"
-strum_macros = "0.27.2"
-thiserror = "1.0"
+strum = "0.28"
+strum_macros = "0.28"
+thiserror = "2"
 
 [dev-dependencies]
 hex-literal = "1.0"

--- a/vtyctl/Cargo.toml
+++ b/vtyctl/Cargo.toml
@@ -10,6 +10,7 @@ prost.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
+tonic-prost.workspace = true
 
 # MCP server dependencies
 serde = { version = "1.0", features = ["derive"] }
@@ -18,7 +19,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [build-dependencies]
-tonic-build.workspace = true
+tonic-prost-build.workspace = true
 
 [lints]
 workspace = true

--- a/vtyctl/build.rs
+++ b/vtyctl/build.rs
@@ -1,4 +1,4 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("../proto/vty.proto")?;
+    tonic_prost_build::compile_protos("../proto/vty.proto")?;
     Ok(())
 }

--- a/vtyhelper/Cargo.toml
+++ b/vtyhelper/Cargo.toml
@@ -10,9 +10,10 @@ prost.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
+tonic-prost.workspace = true
 
 [build-dependencies]
-tonic-build.workspace = true
+tonic-prost-build.workspace = true
 
 [lints]
 workspace = true

--- a/vtyhelper/build.rs
+++ b/vtyhelper/build.rs
@@ -1,4 +1,4 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("../proto/vty.proto")?;
+    tonic_prost_build::compile_protos("../proto/vty.proto")?;
     Ok(())
 }

--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -17,11 +17,12 @@ prost.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
-console-subscriber = "0.4"
+tonic-prost.workspace = true
+console-subscriber = "0.5"
 libyang = { git = "https://github.com/zebra-rs/libyang", rev = "52413c2859e73364c7d877f942268cb69c65f4a2" }
 #libyang = { path = "../../libyang" }
 regex = "1.10"
-similar = "2"
+similar = "3"
 dirs = "6"
 async-trait = "0.1"
 prefix-trie = "0.8.2"
@@ -37,10 +38,10 @@ serde_yaml = "0.9"
 clap = { version = "4", features = ["derive"] }
 alphanumeric-sort = "1.5.3"
 bitflags = "2.6.0"
-sysctl = "0.6"
+sysctl = "0.7"
 #nanomsg = "0.7.2"
-socket2 = "0.5.8"
-nix = { version = "0.30", features = ["fs", "net", "socket", "uio", "user"] }
+socket2 = "0.6"
+nix = { version = "0.31", features = ["fs", "net", "socket", "uio", "user"] }
 libc = "0.2.167"
 bgp-packet = { path = "../crates/bgp-packet" }
 bgp-macros = { path = "../crates/bgp-macros" }
@@ -48,16 +49,16 @@ ospf-packet = { path = "../crates/ospf-packet" }
 ospf-macros = { path = "../crates/ospf-macros" }
 isis-packet = { path = "../crates/isis-packet" }
 isis-macros = { path = "../crates/isis-macros" }
-bitfield-struct = "0.11"
-rand = "0.9"
+bitfield-struct = "0.13"
+rand = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 hostname = "0.4"
-bit-vec = "0.8.0"
+bit-vec = "0.9"
 audit = "0.7.3"
 daemonize = "0.5"
 hex = "0.4.3"
-strum = "0.27"
-strum_macros = "0.27"
+strum = "0.28"
+strum_macros = "0.28"
 num_enum = "0.7.5"
 nanomsg = "0.7.2"
 itertools = "0.14.0"
@@ -72,10 +73,10 @@ futures = "0.3"
 scan_fmt = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-nix = { version = "0.30", features = ["net"] }
+nix = { version = "0.31", features = ["net"] }
 ioctl-rs = "0.2.0"
 net-route = "0.4.2"
 
 [build-dependencies]
-tonic-build.workspace = true
+tonic-prost-build.workspace = true
 chrono = "0.4"

--- a/zebra-rs/build.rs
+++ b/zebra-rs/build.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("../proto/vty.proto")?;
+    tonic_prost_build::compile_protos("../proto/vty.proto")?;
 
     // Capture git information at build time
     set_git_info();

--- a/zebra-rs/src/bgp/timer.rs
+++ b/zebra-rs/src/bgp/timer.rs
@@ -1,7 +1,7 @@
 use std::cmp::min;
 
 use bgp_packet::{AfiSafi, OpenPacket};
-use rand::Rng;
+use rand::RngExt;
 
 use crate::config::{Args, ConfigOp};
 use crate::context::Timer;

--- a/zebra-rs/src/isis/socket.rs
+++ b/zebra-rs/src/isis/socket.rs
@@ -1,34 +1,30 @@
 use std::os::fd::AsRawFd;
 
 use nix::sys::socket::{self, LinkAddr, SockaddrLike};
-use socket2::{Domain, Protocol, Socket, Type};
+use socket2::{Domain, Protocol, SockFilter, Socket, Type};
 
-const ISIS_BPF_FILTER: [libc::sock_filter; 10] = [
+const ISIS_BPF_FILTER: [SockFilter; 10] = [
     // l0: ldh [0]
-    bpf_filter_block(0x28, 0, 0, 0x00000000),
+    SockFilter::new(0x28, 0, 0, 0x00000000),
     // l1: jeq #0xfefe, l2, l4
-    bpf_filter_block(0x15, 0, 2, 0x0000fefe),
+    SockFilter::new(0x15, 0, 2, 0x0000fefe),
     // l2: ldb [3]
-    bpf_filter_block(0x30, 0, 0, 0x00000003),
+    SockFilter::new(0x30, 0, 0, 0x00000003),
     // l3: jmp l7
-    bpf_filter_block(0x05, 0, 0, 0x00000003),
+    SockFilter::new(0x05, 0, 0, 0x00000003),
     // l4: ldh proto
-    bpf_filter_block(0x28, 0, 0, 0xfffff000),
+    SockFilter::new(0x28, 0, 0, 0xfffff000),
     // l5: jeq #0x00fe, l6, l9
-    bpf_filter_block(0x15, 0, 3, 0x000000fe),
+    SockFilter::new(0x15, 0, 3, 0x000000fe),
     // l6: ldb [0]
-    bpf_filter_block(0x30, 0, 0, 0x00000000),
+    SockFilter::new(0x30, 0, 0, 0x00000000),
     // l7: jeq #0x83, l8, l9
-    bpf_filter_block(0x15, 0, 1, 0x00000083),
+    SockFilter::new(0x15, 0, 1, 0x00000083),
     // l8: ret #0x40000
-    bpf_filter_block(0x06, 0, 0, 0x00040000),
+    SockFilter::new(0x06, 0, 0, 0x00040000),
     // l9: ret #0
-    bpf_filter_block(0x06, 0, 0, 0x00000000),
+    SockFilter::new(0x06, 0, 0, 0x00000000),
 ];
-
-const fn bpf_filter_block(code: u16, jt: u8, jf: u8, k: u32) -> libc::sock_filter {
-    libc::sock_filter { code, jt, jf, k }
-}
 
 pub fn isis_socket(ifindex: u32) -> Result<Socket, std::io::Error> {
     let socket = Socket::new(

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use ospf_packet::*;
-use rand::Rng;
+use rand::RngExt;
 use tokio::time::Instant;
 
 use crate::ospf::ospf_db_desc_send;

--- a/zebra-rs/src/ospf/socket.rs
+++ b/zebra-rs/src/ospf/socket.rs
@@ -16,7 +16,7 @@ pub fn ospf_socket_ipv4() -> Result<Socket, std::io::Error> {
     socket.set_reuse_address(true)?;
     socket.set_multicast_loop_v4(false)?;
     socket.set_multicast_ttl_v4(1)?;
-    socket.set_tos(libc::IPTOS_PREC_INTERNETCONTROL as u32)?;
+    socket.set_tos_v4(libc::IPTOS_PREC_INTERNETCONTROL as u32)?;
     set_ipv4_pktinfo(&socket);
 
     Ok(socket)


### PR DESCRIPTION
## Summary

Bring direct deps to current crates.io releases. All bumps verified by `cargo build --release`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace --exclude bdd` (251 tests pass), and `cargo fmt --all --check`.

### Workspace dependencies (`/Cargo.toml`)
- `prost`              0.13 → 0.14
- `tonic`              0.13 → 0.14
- `tonic-build`        dropped (split out of upstream)
- `tonic-prost`        new — runtime codec for the generated gRPC bindings
- `tonic-prost-build`  new — replaces `tonic-build` for prost-based codegen

### `bdd/Cargo.toml`
- `cucumber`           0.21 → 0.23
- `rstest`             0.18 → 0.26
- `thiserror`          1    → 2

### `zebra-rs/Cargo.toml`
- `nix`                0.30 → 0.31
- `bit-vec`            0.8  → 0.9
- `sysctl`             0.6  → 0.7
- `console-subscriber` 0.4  → 0.5
- `rand`               0.9  → 0.10
- `socket2`            0.5  → 0.6
- `similar`            2    → 3
- `strum` / `strum_macros` 0.27 → 0.28
- `bitfield-struct`    0.11 → 0.13

### `crates/{bgp,isis,ospf}-packet`, `crates/packet-utils`
- `strum` / `strum_macros` 0.27.2 → 0.28
- `bitfield-struct`        0.11    → 0.13
- `thiserror`              1.0     → 2 (where applicable)

## API adjustments

- **`tonic` 0.14** split out the prost integration. The free function `tonic_build::compile_protos` is gone; replaced by `tonic_prost_build::compile_protos`. The generated stubs reference `tonic_prost::ProstCodec` at runtime, so each crate that consumes them now depends on `tonic-prost`. Updated `zebra-rs/build.rs`, `vtyctl/build.rs`, `vtyhelper/build.rs` and the corresponding Cargo.toml files.

- **`rand` 0.10** split `Rng::random()` / `random_range()` into a separate `RngExt` trait. `bgp/timer.rs` and `ospf/nfsm.rs` now import `RngExt` instead of `Rng`.

- **`socket2` 0.6**:
  - `Socket::set_tos` → `set_tos_v4` (`ospf/socket.rs`).
  - `attach_filter` now takes `&[socket2::SockFilter]` instead of `&[libc::sock_filter]`. The IS-IS BPF filter table moves to the `SockFilter::new(code, jt, jf, k)` const ctor; the local `bpf_filter_block` helper is deleted as redundant (`isis/socket.rs`).

## Not bumped

- `matchit` 0.8.4 → 0.8.6 — pinned by `axum v0.8.9` (latest release) with an exact `=0.8.4` requirement. Verified that `cargo update -p matchit --precise 0.8.6` and a `[patch.crates-io]` override both fail (cargo rejects same-source registry patches). Will move once axum relaxes the pin.

## Test plan

- [x] `cargo build --release`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` (251 tests pass)
- [x] `cargo fmt --all --check`

Generated with [Claude Code](https://claude.com/claude-code)