### PR TITLE
Makefile: drop bdd test targets in favor of bdd/Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,22 +60,6 @@ clean:
 perf:
 	sudo perf record -g --call-graph dwarf ./target/release/zebra-rs
 
-# Integration tests (bdd)
-test:
-	mkdir -p bdd/allure-results
-	cargo test -p bdd --test cucumber -- --concurrency=1
-
-test-ibgp:
-	mkdir -p bdd/allure-results
-	cargo test -p bdd --test cucumber -- --concurrency=1 --tags "@bgp_basic_ibgp"
-
-test-ebgp:
-	mkdir -p bdd/allure-results
-	cargo test -p bdd --test cucumber -- --concurrency=1 --tags "@bgp_basic_ebgp"
-
-test-rr:
-	mkdir -p bdd/allure-results
-	cargo test -p bdd --test cucumber -- --concurrency=1 --tags "@bgp_basic_rr"
-
-test-report:
-	cd bdd && rm -rf allure-report && allure generate && allure open
+# Integration tests (cucumber/bdd) live in bdd/Makefile. Run them
+# from there, e.g. `make -C bdd run`, `make -C bdd ibgp`,
+# `make -C bdd open`.


### PR DESCRIPTION
## Summary

The top-level Makefile carried five integration-test targets — `test`, `test-ibgp`, `test-ebgp`, `test-rr`, `test-report` — that duplicated `bdd/Makefile`'s existing `run`, `ibgp`, `ebgp`, `rr`, `generate` / `open`. Drop the duplicates and leave a one-line pointer comment so contributors know where to find them.

Invocations now go through `make -C bdd <target>`, e.g. `make -C bdd run`, `make -C bdd ibgp`, `make -C bdd open`.

## Test plan

- [x] `make -C bdd -n run` dry-run still expands to the expected `cargo test --test cucumber -- --concurrency=1` invocation.
- [x] `make -n test` at the top level now correctly errors ("No rule to make target 'test'.").

Generated with [Claude Code](https://claude.com/claude-code)