### PR TITLE
bdd: rename host veth from v{hash}_{ns} to {ns}_{hash}

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -18,7 +18,7 @@ impl World {
             hash ^= *byte as u32;
             hash = hash.wrapping_mul(0x0100_0193);
         }
-        format!("{:04x}", hash & 0xffff)
+        format!("{:08x}", hash)
     }
 
     fn ns(&self, logical: &str) -> String {
@@ -30,7 +30,10 @@ impl World {
     }
 
     fn host_veth(&self, logical: &str) -> String {
-        format!("v{}_{}", self.short_id(), logical)
+        // `{ns}_{hash}` order (no `v` prefix) so `ip link` output
+        // groups veths by namespace name, which is the field
+        // operators read first when debugging a failed run.
+        format!("{}_{}", logical, self.short_id())
     }
 
     fn ns_veth(&self, logical: &str) -> String {


### PR DESCRIPTION
## Summary

When inspecting a failed BDD run, `ip link` output is the first stop. The previous naming had the per-feature hash prefix first:

```
vb64d_z1@if48    UP    ...
vb64d_z2@if50    UP    ...
```

so unrelated namespaces from concurrent runs interleaved on the hash bucket, and the field operators care about (`z1` / `z2`) was buried after a non-mnemonic 4-char hash plus a `v` prefix.

After:

```
z1_xxxxxxxx@if48    UP    ...
z2_xxxxxxxx@if50    UP    ...
```

`ip link` output now groups by namespace name; the wider hash trailer makes per-feature collisions much rarer when many parallel feature runs share a host. Length stays well within IFNAMSIZ (15) — longest produced name is still under 12.

## Changes

Two small changes in `World` (`bdd/tests/cucumber.rs`):
- `host_veth` formatter: `v{hash}_{logical}` → `{logical}_{hash}`.
- `short_id` widened from `{:04x}` of `hash & 0xffff` to `{:08x}` of the full FNV-1a hash.

## Test plan

- [x] `cargo build --release -p bdd --tests`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`

Generated with [Claude Code](https://claude.com/claude-code)