### PR TITLE
config: skip choice/case leaves from container mandatory list

### DIFF
--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -599,9 +599,15 @@ pub fn parse(
     }
 
     // Elem for set/delete/exec func.
+    //
+    // A `mandatory true` leaf nested under `choice`/`case` is only
+    // required when its case is selected (RFC 7950 §7.6.5). libyang
+    // flattens cases into the parent `dir` but tags each entry with
+    // its choice/case names — skip those here so the validator does
+    // not demand sibling cases that the user did not select.
     let mut mandatory = Vec::<String>::new();
     for entry in mx.matched_entry.dir.borrow().iter() {
-        if entry.mandatory {
+        if entry.mandatory && entry.choice.borrow().is_none() {
             mandatory.push(entry.name.clone());
         }
     }


### PR DESCRIPTION
## Summary
- Validator was treating `mandatory true` leaves inside `choice`/`case` as unconditionally required, raising spurious "missing mandatory node 'add'" / "'sub'" errors when committing e.g. `set local-preference { set 123; }`.
- Per RFC 7950 §7.6.5, a mandatory leaf inside a case is only required when its case is selected. libyang flattens cases into the parent `dir` and tags each entry with the originating choice/case, leaving consumers to enforce mutual exclusion.
- Fix is one line in `zebra-rs/src/config/parse.rs`: when collecting the parent container's mandatory child list, skip entries where `entry.choice` is set. Non-choice mandatory leaves (e.g. `leaf area { mandatory true; }`, list keys) keep their current enforcement.

## Test plan
- [x] `cargo build --bin zebra-rs --release` clean.
- [x] `cargo test --release -p zebra-rs` — 251 passed.
- [ ] Re-commit the original snippet with `set local-preference { set 123; }` interactively and confirm no spurious errors.

## Follow-up (out of scope)
A separate gap exists: when `choice "op" { mandatory true; }` is declared and the user submits an empty container with no case selected, the validator silently accepts it. Closing that requires libyang to surface the choice's own `mandatory` flag and a new "any-of these case members" check on the validator side.

Generated with [Claude Code](https://claude.com/claude-code)