### PR TITLE
yang: drop redundant case-leaf mandatory under mandatory choices

### DIFF
--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -922,19 +922,16 @@ module config {
               case eq-case {
                 leaf "eq" {
                   type uint32;
-                  mandatory true;
                 }
               }
               case le-case {
                 leaf "le" {
                   type uint32;
-                  mandatory true;
                 }
               }
               case ge-case {
                 leaf "ge" {
                   type uint32;
-                  mandatory true;
                 }
               }
             }
@@ -950,19 +947,16 @@ module config {
               case eq-case {
                 leaf "eq" {
                   type uint32;
-                  mandatory true;
                 }
               }
               case le-case {
                 leaf "le" {
                   type uint32;
-                  mandatory true;
                 }
               }
               case ge-case {
                 leaf "ge" {
                   type uint32;
-                  mandatory true;
                 }
               }
             }
@@ -978,19 +972,16 @@ module config {
               case eq-case {
                 leaf "eq" {
                   type uint32;
-                  mandatory true;
                 }
               }
               case le-case {
                 leaf "le" {
                   type uint32;
-                  mandatory true;
                 }
               }
               case ge-case {
                 leaf "ge" {
                   type uint32;
-                  mandatory true;
                 }
               }
             }
@@ -1005,19 +996,16 @@ module config {
               case eq-case {
                 leaf "eq" {
                   type uint32;
-                  mandatory true;
                 }
               }
               case le-case {
                 leaf "le" {
                   type uint32;
-                  mandatory true;
                 }
               }
               case ge-case {
                 leaf "ge" {
                   type uint32;
-                  mandatory true;
                 }
               }
             }
@@ -1033,19 +1021,16 @@ module config {
               case eq-case {
                 leaf "eq" {
                   type uint32;
-                  mandatory true;
                 }
               }
               case le-case {
                 leaf "le" {
                   type uint32;
-                  mandatory true;
                 }
               }
               case ge-case {
                 leaf "ge" {
                   type uint32;
-                  mandatory true;
                 }
               }
             }
@@ -1072,19 +1057,16 @@ module config {
               case set-case {
                 leaf "set" {
                   type uint32;
-                  mandatory true;
                 }
               }
               case add-case {
                 leaf "add" {
                   type uint32;
-                  mandatory true;
                 }
               }
               case sub-case {
                 leaf "sub" {
                   type uint32;
-                  mandatory true;
                 }
               }
             }
@@ -1100,19 +1082,16 @@ module config {
               case set-case {
                 leaf "set" {
                   type uint32;
-                  mandatory true;
                 }
               }
               case add-case {
                 leaf "add" {
                   type uint32;
-                  mandatory true;
                 }
               }
               case sub-case {
                 leaf "sub" {
                   type uint32;
-                  mandatory true;
                 }
               }
             }
@@ -1144,13 +1123,11 @@ module config {
                     type inet:ipv4-address;
                     type inet:ipv6-address;
                   }
-                  mandatory true;
                 }
               }
               case self-case {
                 leaf "self" {
                   type empty;
-                  mandatory true;
                 }
               }
             }


### PR DESCRIPTION
## Summary
- Per RFC 7950 §7.6.5/§7.9.4: a `mandatory true` leaf inside a `case` is required only when its case is selected, and a case is selected when one of its descendants is present. When a case has exactly one direct child, "case selected" ≡ "that child present" — the leaf-level mandatory restates a tautology already covered by the enclosing `choice "op" { mandatory true; }`.
- Drops 23 redundant lines across 8 single-leaf case bodies.

## Affected containers
- `match {med, as-path-len, as-path-len-uniq, local-preference, weight}` — eq/le/ge cases.
- `set {local-preference, med}` — set/add/sub cases.
- `set next-hop` — address/self cases.

## Test plan
- [x] `cargo build --bin zebra-rs --release` clean (YANG schema parses).
- [x] CI fmt/clippy/test.
- [ ] No behaviour change expected — validator already (post #467) skips choice-tagged entries when collecting parent mandatory lists.

Generated with [Claude Code](https://claude.com/claude-code)