### PR TITLE
vty: update GNU bash from 5.2.21 to 5.3

### DIFF
--- a/vty/Makefile
+++ b/vty/Makefile
@@ -1,12 +1,12 @@
-# vty: GNU bash 5.2 with vtysh integration patches.
+# vty: GNU bash 5.3 with vtysh integration patches.
 #
 # bash sources are fetched at build time and cached locally.
 # This directory contains only the deltas.
 
-BASH_VERSION  := 5.2.21
+BASH_VERSION  := 5.3
 BASH_TARBALL  := bash-$(BASH_VERSION).tar.gz
 BASH_URL      := https://ftp.gnu.org/gnu/bash/$(BASH_TARBALL)
-BASH_SHA256   := c8e31bdc59b69aaffc5b36509905ba3e5cbb12747091d27b4b977f078560d5b8
+BASH_SHA256   := 0d5cd86965f869a26cf64f4b71be7b96f90a3ba8b3d74e27e8e9d9d5550f31ba
 
 CACHE_DIR     ?= $(HOME)/.cache/zebra-rs
 TARBALL       := $(CACHE_DIR)/$(BASH_TARBALL)

--- a/vty/README.md
+++ b/vty/README.md
@@ -1,7 +1,7 @@
-# vty — GNU bash 5.2 with vtysh hooks
+# vty — GNU bash 5.3 with vtysh hooks
 
 This directory builds `vty`, a router-CLI shell derived from GNU
-bash 5.2.21 with patches that integrate it with the rest of
+bash 5.3 with patches that integrate it with the rest of
 zebra-rs. Bash sources are fetched at build time; only the deltas
 live here.
 
@@ -9,10 +9,10 @@ live here.
 
     make
 
-The first build downloads `bash-5.2.21.tar.gz` (~11 MB) into
+The first build downloads `bash-5.3.tar.gz` (~11 MB) into
 `~/.cache/zebra-rs/`, verifies its SHA-256, extracts it under
 `build/` (via `tar --strip-components=1`, so no redundant
-`build/bash-5.2.21/` layer), lays additions on top, applies the
+`build/bash-5.3/` layer), lays additions on top, applies the
 patch, then runs `./configure && make`. The resulting binary is
 `build/vty`, with a copy at `vty` for packaging.
 
@@ -21,7 +21,7 @@ Override the cache location with `CACHE_DIR=/some/path`.
 ## Layout
 
     additions/                  vtysh-specific source files (real source)
-    patches/0001-vty-hooks.patch  modifications to bash-5.2 sources
+    patches/0001-vty-hooks.patch  modifications to bash-5.3 sources
     Makefile                    build glue
 
 ## Tests

--- a/vty/patches/0001-vty-hooks.patch
+++ b/vty/patches/0001-vty-hooks.patch
@@ -1,6 +1,6 @@
-diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.c' '--exclude=vtysh.h' '--exclude=y.tab.c' '--exclude=y.tab.h' bash-5.2.21/bashline.c vty/bashline.c
---- bash-5.2.21/bashline.c	2022-04-17 15:37:12.000000000 -0700
-+++ vty/bashline.c	2026-05-03 17:38:43.426171820 -0700
+diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.c' '--exclude=vtysh.h' '--exclude=y.tab.c' '--exclude=y.tab.h' bash-5.3/bashline.c vty/bashline.c
+--- bash-5.3/bashline.c	2025-06-25 12:53:44.000000000 -0700
++++ vty/bashline.c	2026-05-09 14:26:17.332000431 -0700
 @@ -80,6 +80,8 @@
  #  include "pcomplete.h"
  #endif
@@ -10,7 +10,7 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
  /* These should agree with the defines for emacs_mode and vi_mode in
     rldefs.h, even though that's not a public readline header file. */
  #ifndef EMACS_EDITING_MODE
-@@ -1443,6 +1445,10 @@
+@@ -1467,6 +1469,10 @@
    register int s, os, ns;
  
    os = 0;
@@ -21,7 +21,7 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
    /* Flags == SD_NOJMP only because we want to skip over command substitutions
       in assignment statements.  Have to test whether this affects `standalone'
       command substitutions as individual words. */
-@@ -1491,7 +1497,10 @@
+@@ -1514,7 +1520,10 @@
  {
    register int e;
  
@@ -33,17 +33,16 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
    return e;
  }
  
-@@ -1624,7 +1633,8 @@
+@@ -1638,7 +1647,7 @@
      }
    else if (member (rl_line_buffer[ti], command_separator_chars))
      {
--      in_command_position++;
-+      if (!cli_mode())
-+        in_command_position++;
+-      if (char_is_quoted (rl_line_buffer, ti) == 0)
++      if (!cli_mode() && char_is_quoted (rl_line_buffer, ti) == 0)
+ 	in_command_position++;
  
-       if (check_redir (ti) == 1)
- 	in_command_position = -1;	/* sentinel that we're not the first word on the line */
-@@ -1654,6 +1664,7 @@
+       if (in_command_position && rl_line_buffer[ti] == '(' && check_extglob (ti) == 1) /*)*/
+@@ -1672,6 +1681,7 @@
       succeed.  Don't bother if readline found a single quote and we are
       completing on the substring.  */
    if (*text == '`' && rl_completion_quote_character != '\'' &&
@@ -51,7 +50,7 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
  	(in_command_position > 0 || (unclosed_pair (rl_line_buffer, start, "`") &&
  				     unclosed_pair (rl_line_buffer, end, "`"))))
      matches = rl_completion_matches (text, command_subst_completion_function);
-@@ -1663,7 +1674,7 @@
+@@ -1681,7 +1691,7 @@
    have_progcomps = prog_completion_enabled && (progcomp_size () > 0);
    iw_compspec = progcomp_search (INITIALWORD);
    if (matches == 0 &&
@@ -60,7 +59,7 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
        current_prompt_string == ps1_prompt)
      {
        int s, e, s1, e1, os, foundcs;
-@@ -1720,6 +1731,12 @@
+@@ -1744,6 +1754,12 @@
          prog_complete_matches = programmable_completions (EMPTYCMD, text, s, e, &foundcs);
        else if (start == end && text[0] == '\0' && s1 > start && whitespace (rl_line_buffer[start]))
          foundcs = 0;		/* whitespace before command name */
@@ -73,7 +72,7 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
        else if (e > s && was_assignment == 0 && e1 == end && rl_line_buffer[e] == 0 && whitespace (rl_line_buffer[e-1]) == 0)
  	{
  	  /* not assignment statement, but still want to perform command
-@@ -1802,6 +1819,11 @@
+@@ -1831,6 +1847,11 @@
  
    matches = (char **)NULL;
  
@@ -85,10 +84,10 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
    /* New posix-style command substitution or variable name? */
    if (*text == '$')
      {
-diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.c' '--exclude=vtysh.h' '--exclude=y.tab.c' '--exclude=y.tab.h' bash-5.2.21/Makefile.in vty/Makefile.in
---- bash-5.2.21/Makefile.in	2022-07-26 13:24:54.000000000 -0700
-+++ vty/Makefile.in	2026-05-03 17:38:43.428093861 -0700
-@@ -109,10 +109,10 @@
+diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.c' '--exclude=vtysh.h' '--exclude=y.tab.c' '--exclude=y.tab.h' bash-5.3/Makefile.in vty/Makefile.in
+--- bash-5.3/Makefile.in	2025-05-16 11:56:31.000000000 -0700
++++ vty/Makefile.in	2026-05-09 14:26:40.339000442 -0700
+@@ -110,10 +110,10 @@
  OBJEXT = @OBJEXT@
  
  # The name of this program and some version information.
@@ -102,7 +101,7 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
  Version = @BASHVERS@
  PatchLevel = `$(BUILD_DIR)/$(VERSPROG) -p`
  RELSTATUS = @RELSTATUS@
-@@ -450,7 +450,8 @@
+@@ -484,7 +484,8 @@
  	   input.c bashhist.c array.c arrayfunc.c assoc.c sig.c pathexp.c \
  	   unwind_prot.c siglist.c bashline.c bracecomp.c error.c \
  	   list.c stringlib.c locale.c findcmd.c redir.c \
@@ -112,7 +111,7 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
  
  HSOURCES = shell.h flags.h trap.h hashcmd.h hashlib.h jobs.h builtins.h \
  	   general.h variables.h config.h $(ALLOC_HEADERS) alias.h \
-@@ -459,6 +460,7 @@
+@@ -493,6 +494,7 @@
  	   subst.h externs.h siglist.h bashhist.h bashline.h bashtypes.h \
  	   array.h arrayfunc.h sig.h mailcheck.h bashintl.h bashjmp.h \
  	   execute_cmd.h parser.h pathexp.h pathnames.h pcomplete.h assoc.h \
@@ -120,7 +119,7 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
  	   $(BASHINCFILES)
  
  SOURCES	 = $(CSOURCES) $(HSOURCES) $(BUILTIN_DEFS)
-@@ -494,7 +496,8 @@
+@@ -532,7 +534,8 @@
  	   trap.o input.o unwind_prot.o pathexp.o sig.o test.o version.o \
  	   alias.o $(ARRAY_O) arrayfunc.o assoc.o braces.o bracecomp.o bashhist.o \
  	   bashline.o $(SIGLIST_O) list.o stringlib.o locale.o findcmd.o redir.o \
@@ -130,7 +129,7 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
  
  # Where the source code of the shell builtins resides.
  BUILTIN_SRCDIR=$(srcdir)/builtins
-@@ -547,8 +550,8 @@
+@@ -584,8 +587,8 @@
  BUILTINS_DEP = $(BUILTINS_LIBRARY)
  
  # Documentation for the shell.
@@ -141,25 +140,25 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
  
  # Translations and other i18n support files
  PO_SRC = $(srcdir)/po/
-@@ -568,7 +571,7 @@
- 		  buildversion.o mksignames.o signames.o buildsignames.o
+@@ -607,7 +610,7 @@
  CREATED_CONFIGURE = config.h config.cache config.status config.log \
- 		    stamp-h po/POTFILES config.status.lineno
+ 		    stamp-h po/POTFILES config.status.lineno \
+ 		    stdckdint.h buildconf.h
 -CREATED_MAKEFILES = Makefile builtins/Makefile doc/Makefile \
 +CREATED_MAKEFILES = Makefile builtins/Makefile \
  		    lib/readline/Makefile lib/glob/Makefile \
  		    lib/sh/Makefile lib/tilde/Makefile lib/malloc/Makefile \
  		    lib/termcap/Makefile examples/loadables/Makefile \
-@@ -587,7 +590,7 @@
+@@ -627,7 +630,7 @@
  # Keep GNU Make from exporting the entire environment for small machines.
  .NOEXPORT:
  
--.made: $(Program) bashbug $(SDIR)/man2html$(EXEEXT)
+-.made: $(Program) bashbug $(SUPPORT_DIR)/man2html$(EXEEXT)
 +.made: $(Program)
  	@echo "$(Program) last made for a $(Machine) running $(OS)" >.made
  
  $(Program): $(OBJECTS) $(BUILTINS_DEP) $(LIBDEP) .build
-@@ -596,7 +599,7 @@
+@@ -636,7 +639,7 @@
  	ls -l $(Program)
  	-$(SIZE) $(Program)
  
@@ -168,19 +167,19 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
  	@echo
  	@echo "	  ***********************************************************"
  	@echo "	  *                                                         *"
-@@ -605,11 +608,6 @@
+@@ -645,11 +648,6 @@
  	@echo "	  ***********************************************************"
  	@echo
  
--bashbug: $(SDIR)/bashbug.sh $(VERSPROG)
+-bashbug: $(SUPPORT_DIR)/bashbug.sh $(VERSPROG)
 -	@sed -e "s%!PATCHLEVEL!%$(PatchLevel)%" \
--	     $(SDIR)/bashbug.sh > $@
+-	     $(SUPPORT_DIR)/bashbug.sh > $@
 -	@chmod a+rx bashbug
 -
  strip:	$(Program) .made
  	$(STRIP) $(Program)
  	ls -l $(Program)
-@@ -643,7 +641,12 @@
+@@ -696,7 +694,12 @@
  	$(SHELL) $(SUPPORT_SRC)mkversion.sh -b -S ${topdir} -s $(RELSTATUS) -d $(Version) -o newversion.h \
  		&& mv newversion.h version.h
  
@@ -193,60 +192,62 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
 +vtyversion$(EXEEXT): buildversion.o $(SUPPORT_SRC)bashversion.c
  	$(CC_FOR_BUILD) $(CCFLAGS_FOR_BUILD) ${LDFLAGS_FOR_BUILD} -o $@ $(SUPPORT_SRC)bashversion.c buildversion.o ${LIBS_FOR_BUILD}
  
- buildversion.o: $(srcdir)/version.c
-@@ -831,22 +834,9 @@
+ bashversion$(EXEEXT): buildconf.h
+@@ -908,22 +911,9 @@
  
  installdirs:
  	@${SHELL} $(SUPPORT_SRC)mkinstalldirs $(DESTDIR)$(bindir)
 -	@${SHELL} $(SUPPORT_SRC)mkinstalldirs $(DESTDIR)$(man1dir)
 -	@${SHELL} $(SUPPORT_SRC)mkinstalldirs $(DESTDIR)$(infodir)
 -	@${SHELL} $(SUPPORT_SRC)mkinstalldirs $(DESTDIR)$(docdir)
--	-( cd $(PO_DIR) ; $(MAKE) $(MFLAGS) DESTDIR=$(DESTDIR) $@ )
+-	-( cd $(PO_DIR) ; $(MAKE) $(BASH_MAKEFLAGS) DESTDIR=$(DESTDIR) $@ )
  
  install:	.made installdirs
  	$(INSTALL_PROGRAM) $(INSTALLMODE) $(Program) $(DESTDIR)$(bindir)/$(Program)
 -	$(INSTALL_SCRIPT) $(INSTALLMODE2) bashbug $(DESTDIR)$(bindir)/bashbug
 -	$(INSTALL_DATA) $(OTHER_DOCS) $(DESTDIR)$(docdir)
--	-( cd $(DOCDIR) ; $(MAKE) $(MFLAGS) \
+-	-( cd $(DOCDIR) ; $(MAKE) $(BASH_MAKEFLAGS) \
 -		man1dir=$(man1dir) man1ext=$(man1ext) \
 -		man3dir=$(man3dir) man3ext=$(man3ext) \
 -		infodir=$(infodir) htmldir=$(htmldir) DESTDIR=$(DESTDIR) $@ )
--	-( cd $(DEFDIR) ; $(MAKE) $(MFLAGS) DESTDIR=$(DESTDIR) $@ )
--	-( cd $(PO_DIR) ; $(MAKE) $(MFLAGS) DESTDIR=$(DESTDIR) $@ )
--	-( cd $(LOADABLES_DIR) && $(MAKE) $(MFLAGS) DESTDIR=$(DESTDIR) $@ )
+-	-( cd $(DEFDIR) ; $(MAKE) $(BASH_MAKEFLAGS) DESTDIR=$(DESTDIR) $@ )
+-	-( cd $(PO_DIR) ; $(MAKE) $(BASH_MAKEFLAGS) DESTDIR=$(DESTDIR) $@ )
+-	-( cd $(LOADABLES_DIR) && $(MAKE) $(BASH_MAKEFLAGS) DESTDIR=$(DESTDIR) $@ )
  
  install-strip:
- 	$(MAKE) $(MFLAGS) INSTALL_PROGRAM='$(INSTALL_PROGRAM) -s' \
-@@ -886,14 +876,7 @@
- 	-( $(RM) $(DESTDIR)$(pkgconfigdir)/bash.pc )
+ 	$(MAKE) $(BASH_MAKEFLAGS) INSTALL_PROGRAM='$(INSTALL_STRIP_PROGRAM)' \
+@@ -987,15 +977,7 @@
+ 	-$(RMDIR) $(DESTDIR)$(headersdir)
  
  uninstall:	.made
 -	$(RM) $(DESTDIR)$(bindir)/$(Program) $(DESTDIR)$(bindir)/bashbug
 -	-( cd $(DESTDIR)$(docdir) && ${RM} ${OTHER_INSTALLED_DOCS} )
--	-( cd $(DOCDIR) ; $(MAKE) $(MFLAGS) \
+-	-( cd $(DOCDIR) ; $(MAKE) $(BASH_MAKEFLAGS) \
 -		man1dir=$(man1dir) man1ext=$(man1ext) \
 -		man3dir=$(man3dir) man3ext=$(man3ext) \
 -		infodir=$(infodir) htmldir=$(htmldir) DESTDIR=$(DESTDIR) $@ )
--	-( cd $(PO_DIR) ; $(MAKE) $(MFLAGS) DESTDIR=$(DESTDIR) $@ )
--	-( cd $(LOADABLES_DIR) && $(MAKE) $(MFLAGS) DESTDIR=$(DESTDIR) $@ )
+-	-( cd $(PO_DIR) ; $(MAKE) $(BASH_MAKEFLAGS) DESTDIR=$(DESTDIR) $@ )
+-	-( cd $(LOADABLES_DIR) && $(MAKE) $(BASH_MAKEFLAGS) DESTDIR=$(DESTDIR) $@ )
+-	-$(RMDIR) $(DESTDIR)$(loadablesdir) $(DESTDIR)$(docdir)
 +	$(RM) $(DESTDIR)$(bindir)/$(Program)
  
- .PHONY: basic-clean clean realclean maintainer-clean distclean mostlyclean maybe-clean
+ .PHONY: basic-clean clean maintainer-clean distclean mostlyclean maybe-clean
  
-@@ -901,11 +884,10 @@
+@@ -1003,11 +985,10 @@
  		${INTL_LIBDIR} ${TILDE_LIBDIR} ${ALLOC_LIBDIR} ${SH_LIBDIR}
  
  basic-clean:
 -	$(RM) $(OBJECTS) $(Program) bashbug
+-	$(RM) .build .made version.h 
 +	$(RM) $(OBJECTS) $(Program)
- 	$(RM) .build .made version.h 
++	$(RM) .build .made version.h
  
  clean:	basic-clean
--	( cd $(DOCDIR) && $(MAKE) $(MFLAGS) $@ )
- 	( cd builtins && $(MAKE) $(MFLAGS) $@ )
- 	-( cd $(SDIR) && $(MAKE) $(MFLAGS) $@ )
+-	( cd $(DOCDIR) && $(MAKE) $(BASH_MAKEFLAGS) $@ )
+ 	( cd builtins && $(MAKE) $(BASH_MAKEFLAGS) $@ )
+ 	-( cd $(SUPPORT_DIR) && $(MAKE) $(BASH_MAKEFLAGS) $@ )
  	-for libdir in ${LIB_SUBDIRS}; do \
-@@ -1334,6 +1316,7 @@
+@@ -1460,6 +1441,7 @@
  bashhist.o: flags.h input.h parser.h pathexp.h $(DEFSRC)/common.h bashline.h
  bashhist.o: ${BASHINCDIR}/ocache.h ${BASHINCDIR}/chartypes.h bashhist.h assoc.h
  bashhist.o: $(GLOB_LIBSRC)/strmatch.h ${GLOB_LIBSRC}/glob.h
@@ -254,7 +255,7 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
  bashline.o: config.h bashtypes.h ${BASHINCDIR}/posixstat.h bashansi.h ${BASHINCDIR}/ansi_stdlib.h
  bashline.o: shell.h syntax.h config.h bashjmp.h ${BASHINCDIR}/posixjmp.h command.h ${BASHINCDIR}/stdc.h error.h
  bashline.o: general.h xmalloc.h bashtypes.h variables.h arrayfunc.h conftypes.h array.h hashlib.h
-@@ -1441,6 +1424,8 @@
+@@ -1575,6 +1557,8 @@
  
  signames.o: config.h bashansi.h ${BASHINCDIR}/ansi_stdlib.h
  
@@ -263,9 +264,9 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
  # XXX - dependencies checked through here
  
  # builtin c sources
-diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.c' '--exclude=vtysh.h' '--exclude=y.tab.c' '--exclude=y.tab.h' bash-5.2.21/shell.c vty/shell.c
---- bash-5.2.21/shell.c	2022-11-05 14:27:41.000000000 -0700
-+++ vty/shell.c	2026-05-03 17:38:43.429037486 -0700
+diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.c' '--exclude=vtysh.h' '--exclude=y.tab.c' '--exclude=y.tab.h' bash-5.3/shell.c vty/shell.c
+--- bash-5.3/shell.c	2025-03-26 13:40:19.000000000 -0700
++++ vty/shell.c	2026-05-09 14:26:42.289000443 -0700
 @@ -57,6 +57,7 @@
  #include "mailcheck.h"
  #include "builtins.h"
@@ -274,15 +275,15 @@ diff -ruN '--exclude=vty' '--exclude=vty.c' '--exclude=vty.sh' '--exclude=vtysh.
  
  #if defined (JOB_CONTROL)
  #include "jobs.h"
-@@ -1241,8 +1242,9 @@
- 	  maybe_execute_file (SYS_BASHRC, 1);
- #  endif
- #endif
--	  maybe_execute_file (bashrc_file, 1);
--	}
-+	  maybe_execute_file(bashrc_file, 1);
-+	  cli_execute_startup_string();
-+        }
+@@ -1233,7 +1234,10 @@
+ 
+       /* bash */
+       if (act_like_sh == 0 && no_rc == 0)
+-	execute_bashrc_file ();
++	{
++	  execute_bashrc_file ();
++	  cli_execute_startup_string ();
++	}
        /* sh */
        else if (act_like_sh && privileged_mode == 0 && sourced_env++ == 0)
  	execute_env_file (get_string_value ("ENV"));


### PR DESCRIPTION
## Summary
- Bumps `BASH_VERSION` from 5.2.21 to 5.3 with the new SHA-256.
- Forward-ports `patches/0001-vty-hooks.patch` to apply cleanly against bash-5.3 (the old 5.2 patch had 8 hunks fail across `bashline.c`, `shell.c`, and `Makefile.in`).

## Patch port details
- **bashline.c** — 5.3 wraps `in_command_position++` in `if (char_is_quoted(...) == 0)`. The patch now AND-folds `!cli_mode()` into that guard instead of guarding a bare statement. Same net effect: CLI mode skips the increment.
- **shell.c** — 5.3 factored bashrc execution into `execute_bashrc_file()`. The CLI startup hook moves into a new block in the bash-only branch right after that call, preserving the original "after bashrc, bash-only" placement.
- **Makefile.in** — line offsets shifted; same removals (doc/bashbug/install/uninstall/clean cleanup) retargeted to 5.3's layout (`BASH_MAKEFLAGS`/`SUPPORT_DIR` instead of `MFLAGS`/`SDIR`, etc.).

## Test plan
- [x] Fresh `tar -xzf bash-5.3.tar.gz` → `patch -p1` applies with **no fuzz, no rejects**.
- [x] `./configure && make` builds a working `vty` binary.
- [x] `vty --version` reports `GNU bash, version 5.3.0(1)-release`.
- [x] End-to-end `make -C vty clean && make -C vty` from the project tree succeeds.

Generated with [Claude Code](https://claude.com/claude-code)