### PR TITLE
spf: terminology cleanup, SRLG support, IS-IS LAN test

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1615,41 +1615,41 @@ pub fn graph(
             collect_adjacency_sids(&lsp, &mut adjacency_sids);
         }
 
-        // Create graph node
-        let node = create_graph_node(top, level, node_id, &sys_id, &lsp);
-        graph.insert(node_id, node);
+        // Create graph vertex
+        let vertex = create_graph_vertex(top, level, node_id, &sys_id, &lsp);
+        graph.insert(node_id, vertex);
     }
 
     (graph, source_node, adjacency_sids)
 }
 
-/// Create a graph node from an LSP
-fn create_graph_node(
+/// Create a graph vertex from an LSP
+fn create_graph_vertex(
     top: &mut IsisTop,
     level: Level,
     node_id: usize,
     sys_id: &IsisSysId,
     lsp: &IsisLsp,
-) -> spf::Node {
+) -> spf::Vertex {
     // Get hostname if available
-    let node_name = top
+    let vertex_name = top
         .hostname
         .get(&level)
         .get(sys_id)
         .map(|(hostname, _)| hostname.clone())
         .unwrap_or_else(|| sys_id.to_string());
 
-    let mut node = spf::Node {
+    let mut vertex = spf::Vertex {
         id: node_id,
-        name: node_name,
+        name: vertex_name,
         sys_id: sys_id.to_string(),
         ..Default::default()
     };
 
     // Process outgoing links
-    process_outgoing_links(top, level, node_id, sys_id, lsp, &mut node.olinks);
+    process_outgoing_links(top, level, node_id, sys_id, lsp, &mut vertex.olinks);
 
-    node
+    vertex
 }
 
 /// Process outgoing links from Extended IS Reachability TLVs
@@ -1778,37 +1778,37 @@ pub fn graph_mt2(
         if is_originated {
             source_node = Some(node_id);
         }
-        let node = create_graph_node_mt2(top, level, node_id, &sys_id, &lsp);
-        graph.insert(node_id, node);
+        let vertex = create_graph_vertex_mt2(top, level, node_id, &sys_id, &lsp);
+        graph.insert(node_id, vertex);
     }
 
     (graph, source_node, adjacency_sids)
 }
 
-fn create_graph_node_mt2(
+fn create_graph_vertex_mt2(
     top: &mut IsisTop,
     level: Level,
     node_id: usize,
     sys_id: &IsisSysId,
     lsp: &IsisLsp,
-) -> spf::Node {
-    let node_name = top
+) -> spf::Vertex {
+    let vertex_name = top
         .hostname
         .get(&level)
         .get(sys_id)
         .map(|(hostname, _)| hostname.clone())
         .unwrap_or_else(|| sys_id.to_string());
 
-    let mut node = spf::Node {
+    let mut vertex = spf::Vertex {
         id: node_id,
-        name: node_name,
+        name: vertex_name,
         sys_id: sys_id.to_string(),
         ..Default::default()
     };
 
-    process_outgoing_links_mt2(top, level, node_id, sys_id, lsp, &mut node.olinks);
+    process_outgoing_links_mt2(top, level, node_id, sys_id, lsp, &mut vertex.olinks);
 
-    node
+    vertex
 }
 
 fn process_outgoing_links_mt2(

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1332,7 +1332,7 @@ fn graph(top: &mut Ospf, area_id: Ipv4Addr) -> (spf::Graph, Option<usize>) {
         }
     }
 
-    // Process each Router-LSA to build graph nodes and edges.
+    // Process each Router-LSA to build graph vertices and edges.
     for (adv_router, originated, lsa_data) in &router_lsas {
         let node_id = top.lsp_map.get(*adv_router);
 
@@ -1340,7 +1340,7 @@ fn graph(top: &mut Ospf, area_id: Ipv4Addr) -> (spf::Graph, Option<usize>) {
             source_node = Some(node_id);
         }
 
-        let mut node = spf::Node {
+        let mut vertex = spf::Vertex {
             id: node_id,
             name: adv_router.to_string(),
             sys_id: adv_router.to_string(),
@@ -1353,7 +1353,7 @@ fn graph(top: &mut Ospf, area_id: Ipv4Addr) -> (spf::Graph, Option<usize>) {
                     OspfLinkType::P2p | OspfLinkType::VirtualLink => {
                         // Point-to-Point or Virtual Link: link_id = neighbor router ID.
                         let to_id = top.lsp_map.get(link.link_id);
-                        node.olinks.push(spf::Link {
+                        vertex.olinks.push(spf::Link {
                             from: node_id,
                             to: to_id,
                             cost: link.tos_0_metric as u32,
@@ -1366,7 +1366,7 @@ fn graph(top: &mut Ospf, area_id: Ipv4Addr) -> (spf::Graph, Option<usize>) {
                             for attached_router in attached {
                                 if *attached_router != *adv_router {
                                     let to_id = top.lsp_map.get(*attached_router);
-                                    node.olinks.push(spf::Link {
+                                    vertex.olinks.push(spf::Link {
                                         from: node_id,
                                         to: to_id,
                                         cost: link.tos_0_metric as u32,
@@ -1382,7 +1382,7 @@ fn graph(top: &mut Ospf, area_id: Ipv4Addr) -> (spf::Graph, Option<usize>) {
             }
         }
 
-        graph.insert(node_id, node);
+        graph.insert(node_id, vertex);
     }
 
     (graph, source_node)

--- a/zebra-rs/src/spf/calc.rs
+++ b/zebra-rs/src/spf/calc.rs
@@ -133,7 +133,7 @@ impl Path {
 pub fn spf_calc(
     graph: &Graph,
     root: usize,
-    x: Option<usize>,
+    x: &[usize],
     opt: &SpfOpt,
     direct: &SpfDirect,
 ) -> BTreeMap<usize, Path> {
@@ -155,19 +155,15 @@ pub fn spf_calc(
             continue;
         };
 
-        // For TI-LFA, we skip the failed vertex.
-        if let Some(x) = x
-            && edge.id == x
-        {
+        // For TI-LFA / SRLG, skip any excluded vertex (do not relax
+        // edges out of it).
+        if x.contains(&edge.id) {
             continue;
         }
 
         for link in edge.links(direct).iter() {
-            // For TI-LFA, we skip a link which connects to the failed vertex.
-            if let Some(x) = x
-                && let Some(next) = graph.get(&link.id(direct))
-                && next.id == x
-            {
+            // Skip links that connect to an excluded vertex.
+            if x.contains(&link.id(direct)) {
                 continue;
             }
 
@@ -243,18 +239,19 @@ pub fn spf_calc(
 }
 
 pub fn spf(graph: &Graph, root: usize, opt: &SpfOpt) -> BTreeMap<usize, Path> {
-    spf_calc(graph, root, None, opt, &SpfDirect::Normal)
+    spf_calc(graph, root, &[], opt, &SpfDirect::Normal)
 }
 
 pub fn spf_reverse(graph: &Graph, root: usize, opt: &SpfOpt) -> BTreeMap<usize, Path> {
-    spf_calc(graph, root, None, opt, &SpfDirect::Reverse)
+    spf_calc(graph, root, &[], opt, &SpfDirect::Reverse)
 }
 
-pub fn path_has_x(path: &[usize], x: usize) -> bool {
-    path.contains(&x)
+/// True if `path` contains any of the excluded vertices in `x`.
+pub fn path_has_x(path: &[usize], x: &[usize]) -> bool {
+    path.iter().any(|p| x.contains(p))
 }
 
-pub fn p_space_vertices(graph: &Graph, s: usize, x: usize) -> HashSet<usize> {
+pub fn p_space_vertices(graph: &Graph, s: usize, x: &[usize]) -> HashSet<usize> {
     let spf = spf(graph, s, &SpfOpt::full_path());
 
     spf.iter()
@@ -268,7 +265,7 @@ pub fn p_space_vertices(graph: &Graph, s: usize, x: usize) -> HashSet<usize> {
         .collect::<HashSet<_>>()
 }
 
-pub fn q_space_vertices(graph: &Graph, d: usize, x: usize) -> HashSet<usize> {
+pub fn q_space_vertices(graph: &Graph, d: usize, x: &[usize]) -> HashSet<usize> {
     let spf = spf_reverse(graph, d, &SpfOpt::full_path());
 
     spf.iter()
@@ -282,8 +279,8 @@ pub fn q_space_vertices(graph: &Graph, d: usize, x: usize) -> HashSet<usize> {
         .collect::<HashSet<_>>()
 }
 
-pub fn pc_paths(graph: &Graph, s: usize, d: usize, x: usize) -> Vec<Vec<usize>> {
-    spf_calc(graph, s, Some(x), &SpfOpt::full_path(), &SpfDirect::Normal)
+pub fn pc_paths(graph: &Graph, s: usize, d: usize, x: &[usize]) -> Vec<Vec<usize>> {
+    spf_calc(graph, s, x, &SpfOpt::full_path(), &SpfDirect::Normal)
         .remove(&d)
         .map_or_else(Vec::new, |data| data.paths)
 }
@@ -381,7 +378,7 @@ pub fn repair_list_print(graph: &Graph, repair_list: &Vec<SrSegment>) {
     }
 }
 
-pub fn tilfa(graph: &Graph, s: usize, d: usize, x: usize) -> Vec<Vec<SrSegment>> {
+pub fn tilfa(graph: &Graph, s: usize, d: usize, x: &[usize]) -> Vec<Vec<SrSegment>> {
     let p_vertices = p_space_vertices(graph, s, x);
     let q_vertices = q_space_vertices(graph, d, x);
     let mut pc_paths = pc_paths(graph, s, d, x);
@@ -678,7 +675,7 @@ mod tests {
         // *  First, P(S, N1) is computed and results in [N3, N2, R1].
         let s = 0;
         let d = 7;
-        let x = 1;
+        let x: &[usize] = &[1];
 
         let p = p_space_vertices(&graph, s, x);
         let mut p_vertices = BTreeSet::<String>::new();
@@ -795,7 +792,7 @@ mod tests {
 
         let s = 0;
         let d = 7;
-        let x = 1;
+        let x: &[usize] = &[1];
 
         let repair_paths = tilfa(&graph, s, d, x);
         assert_eq!(repair_paths.len(), 1);

--- a/zebra-rs/src/spf/calc.rs
+++ b/zebra-rs/src/spf/calc.rs
@@ -2,7 +2,7 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-pub type Graph = BTreeMap<usize, Node>;
+pub type Graph = BTreeMap<usize, Vertex>;
 
 #[derive(Default)]
 pub struct SpfOpt {
@@ -27,7 +27,7 @@ impl SpfOpt {
 }
 
 #[derive(Debug, Default, Eq, PartialEq, Clone)]
-pub struct Node {
+pub struct Vertex {
     pub id: usize,
     pub name: String,
     pub sys_id: String,
@@ -42,7 +42,7 @@ pub enum SpfDirect {
     Reverse,
 }
 
-impl Node {
+impl Vertex {
     #[allow(dead_code)]
     pub fn new(name: &str, id: usize) -> Self {
         Self {
@@ -155,7 +155,7 @@ pub fn spf_calc(
             continue;
         };
 
-        // For TI-LFA, we skip down node.
+        // For TI-LFA, we skip the failed vertex.
         if let Some(x) = x
             && edge.id == x
         {
@@ -163,7 +163,7 @@ pub fn spf_calc(
         }
 
         for link in edge.links(direct).iter() {
-            // For TI-LFA, we skip a link which connects to down node.
+            // For TI-LFA, we skip a link which connects to the failed vertex.
             if let Some(x) = x
                 && let Some(next) = graph.get(&link.id(direct))
                 && next.id == x
@@ -254,30 +254,30 @@ pub fn path_has_x(path: &[usize], x: usize) -> bool {
     path.contains(&x)
 }
 
-pub fn p_space_nodes(graph: &Graph, s: usize, x: usize) -> HashSet<usize> {
+pub fn p_space_vertices(graph: &Graph, s: usize, x: usize) -> HashSet<usize> {
     let spf = spf(graph, s, &SpfOpt::full_path());
 
     spf.iter()
-        .filter_map(|(node, path)| {
-            if *node == s {
-                return None; // Skip the source node
+        .filter_map(|(vertex, path)| {
+            if *vertex == s {
+                return None; // Skip the source vertex
             }
             let has_valid_paths = path.paths.iter().any(|p| !path_has_x(p, x));
-            if has_valid_paths { Some(*node) } else { None }
+            if has_valid_paths { Some(*vertex) } else { None }
         })
-        .collect::<HashSet<_>>() // Collect into HashSet instead of Vec
+        .collect::<HashSet<_>>()
 }
 
-pub fn q_space_nodes(graph: &Graph, d: usize, x: usize) -> HashSet<usize> {
+pub fn q_space_vertices(graph: &Graph, d: usize, x: usize) -> HashSet<usize> {
     let spf = spf_reverse(graph, d, &SpfOpt::full_path());
 
     spf.iter()
-        .filter_map(|(node, path)| {
-            if *node == d {
-                return None; // Skip the source node
+        .filter_map(|(vertex, path)| {
+            if *vertex == d {
+                return None; // Skip the source vertex
             }
             let has_valid_paths = path.paths.iter().any(|p| !path_has_x(p, x));
-            if has_valid_paths { Some(*node) } else { None }
+            if has_valid_paths { Some(*vertex) } else { None }
         })
         .collect::<HashSet<_>>()
 }
@@ -382,8 +382,8 @@ pub fn repair_list_print(graph: &Graph, repair_list: &Vec<SrSegment>) {
 }
 
 pub fn tilfa(graph: &Graph, s: usize, d: usize, x: usize) -> Vec<Vec<SrSegment>> {
-    let p_nodes = p_space_nodes(graph, s, x);
-    let q_nodes = q_space_nodes(graph, d, x);
+    let p_vertices = p_space_vertices(graph, s, x);
+    let q_vertices = q_space_vertices(graph, d, x);
     let mut pc_paths = pc_paths(graph, s, d, x);
 
     // PCPaths.
@@ -393,7 +393,7 @@ pub fn tilfa(graph: &Graph, s: usize, d: usize, x: usize) -> Vec<Vec<SrSegment>>
         path.pop();
 
         // Intersect.
-        let pc_inter = intersect(path, &p_nodes, &q_nodes);
+        let pc_inter = intersect(path, &p_vertices, &q_vertices);
 
         // Convert PC intersects into repair list.
         let repair_list = make_repair_list(&pc_inter, s, d);
@@ -405,15 +405,15 @@ pub fn tilfa(graph: &Graph, s: usize, d: usize, x: usize) -> Vec<Vec<SrSegment>>
 
 pub fn disp(spf: &BTreeMap<usize, Path>, full_path: bool) {
     if full_path {
-        for (node, path) in spf {
-            println!("node: {} nexthops: {}", node, path.paths.len());
+        for (vertex, path) in spf {
+            println!("vertex: {} nexthops: {}", vertex, path.paths.len());
             for p in &path.paths {
                 println!("  metric {} path {:?}", path.cost, p);
             }
         }
     } else {
-        for (node, nhops) in spf {
-            println!("node: {} nexthops: {}", node, nhops.nexthops.len());
+        for (vertex, nhops) in spf {
+            println!("vertex: {} nexthops: {}", vertex, nhops.nexthops.len());
             for p in &nhops.nexthops {
                 println!("  metric {} path {:?}", nhops.cost, p);
             }
@@ -425,15 +425,15 @@ use std::fmt::Write;
 
 pub fn disp_out(buf: &mut String, spf: &BTreeMap<usize, Path>, full_path: bool) {
     if full_path {
-        for (node, path) in spf {
-            let _ = writeln!(buf, "node: {} nexthops: {}", node, path.paths.len());
+        for (vertex, path) in spf {
+            let _ = writeln!(buf, "vertex: {} nexthops: {}", vertex, path.paths.len());
             for p in &path.paths {
                 let _ = writeln!(buf, "  metric {} path {:?}", path.cost, p);
             }
         }
     } else {
-        for (node, nhops) in spf {
-            let _ = writeln!(buf, "node: {} nexthops: {}", node, nhops.nexthops.len());
+        for (vertex, nhops) in spf {
+            let _ = writeln!(buf, "vertex: {} nexthops: {}", vertex, nhops.nexthops.len());
             for p in &nhops.nexthops {
                 let _ = writeln!(buf, "  metric {} path {:?}", nhops.cost, p);
             }
@@ -451,20 +451,20 @@ mod tests {
     fn ecmp() {
         let mut graph = BTreeMap::new();
 
-        // First, insert all nodes
-        let nodes = vec![
-            Node::new("N1", 0),
-            Node::new("N2", 1),
-            Node::new("N3", 2),
-            Node::new("N4", 3),
-            Node::new("N5", 4),
+        // First, insert all vertices
+        let vertices = vec![
+            Vertex::new("N1", 0),
+            Vertex::new("N2", 1),
+            Vertex::new("N3", 2),
+            Vertex::new("N4", 3),
+            Vertex::new("N5", 4),
         ];
 
-        for node in nodes {
-            graph.insert(node.id, node);
+        for vertex in vertices {
+            graph.insert(vertex.id, vertex);
         }
 
-        // Define links between nodes
+        // Define links between vertices
         let links = vec![
             (0, 1, 10),
             (0, 2, 10),
@@ -480,7 +480,7 @@ mod tests {
             (4, 3, 10),
         ];
 
-        // Now add links to the respective nodes stored in our BTreeMap
+        // Now add links to the respective vertices stored in our BTreeMap
         for (from, to, cost) in links {
             graph
                 .get_mut(&from)
@@ -493,31 +493,31 @@ mod tests {
         let mut opt = SpfOpt::new();
         let tree = spf(&graph, 0, &opt);
 
-        // node: 0 nexthops: 1
+        // vertex:0 nexthops: 1
         //   metric 0 path []
-        // node: 1 nexthops: 1
+        // vertex:1 nexthops: 1
         //   metric 10 path [1]
-        // node: 2 nexthops: 1
+        // vertex:2 nexthops: 1
         //   metric 10 path [2]
-        // node: 3 nexthops: 2
+        // vertex:3 nexthops: 2
         //   metric 20 path [2]
         //   metric 20 path [1]
-        // node: 4 nexthops: 2
+        // vertex:4 nexthops: 2
         //   metric 30 path [1]
         //   metric 30 path [2]
 
-        // Verify source node has only one nexthop with metric = 0 and empty
+        // Verify source vertex has only one nexthop with metric = 0 and empty
         // path.
         let Some(s) = tree.get(&0) else {
-            panic!("SPF does not have source node");
+            panic!("SPF does not have source vertex");
         };
         assert_eq!(s.cost, 0);
         assert_eq!(s.nexthops.len(), 1);
         assert!(s.nexthops.iter().next().unwrap().is_empty());
 
-        // Verify ECMP node.
+        // Verify ECMP vertex.
         let Some(n) = tree.get(&3) else {
-            panic!("SPF node 3 does not exist");
+            panic!("SPF vertex 3 does not exist");
         };
         assert_eq!(n.cost, 20);
         assert_eq!(n.nexthops.len(), 2);
@@ -528,30 +528,30 @@ mod tests {
         opt.full_path = true;
         let tree = spf(&graph, 0, &opt);
 
-        // node: 0 nexthops: 1
+        // vertex:0 nexthops: 1
         //   metric 0 path []
-        // node: 1 nexthops: 1
+        // vertex:1 nexthops: 1
         //   metric 10 path [1]
-        // node: 2 nexthops: 1
+        // vertex:2 nexthops: 1
         //   metric 10 path [2]
-        // node: 3 nexthops: 2
+        // vertex:3 nexthops: 2
         //   metric 20 path [1, 3]
         //   metric 20 path [2, 3]
-        // node: 4 nexthops: 2
+        // vertex:4 nexthops: 2
         //   metric 30 path [1, 3, 4]
         //   metric 30 path [2, 3, 4]
 
-        // Source node.
+        // Source vertex.
         let Some(s) = tree.get(&0) else {
-            panic!("SPF does not have source node");
+            panic!("SPF does not have source vertex");
         };
         assert_eq!(s.cost, 0);
         assert_eq!(s.nexthops.len(), 1);
         assert!(s.nexthops.iter().next().unwrap().is_empty());
 
-        // Node 4.
+        // Vertex 4.
         let Some(n) = tree.get(&4) else {
-            panic!("SPF node 4 does not exist");
+            panic!("SPF vertex 4 does not exist");
         };
         assert_eq!(n.cost, 30);
         assert_eq!(n.paths.len(), 2);
@@ -563,20 +563,20 @@ mod tests {
         opt.path_max = Some(1);
         let tree = spf(&graph, 0, &opt);
 
-        // node: 0 nexthops: 1
+        // vertex:0 nexthops: 1
         //   metric 0 path []
-        // node: 1 nexthops: 1
+        // vertex:1 nexthops: 1
         //   metric 10 path [1]
-        // node: 2 nexthops: 1
+        // vertex:2 nexthops: 1
         //   metric 10 path [2]
-        // node: 3 nexthops: 1
+        // vertex:3 nexthops: 1
         //   metric 20 path [1, 3]
-        // node: 4 nexthops: 1
+        // vertex:4 nexthops: 1
         //   metric 30 path [1, 3, 4]
 
-        // Node 3.
+        // Vertex 3.
         let Some(n) = tree.get(&3) else {
-            panic!("SPF node 3 does not exist");
+            panic!("SPF vertex 3 does not exist");
         };
         assert_eq!(n.cost, 20);
         assert_eq!(n.paths.len(), 1);
@@ -586,20 +586,20 @@ mod tests {
     fn tilfa_graph() -> Graph {
         let mut graph = BTreeMap::new();
 
-        // Insert nodes
-        let nodes = [
-            Node::new("S", 0),
-            Node::new("N1", 1),
-            Node::new("N2", 2),
-            Node::new("N3", 3),
-            Node::new("R1", 4),
-            Node::new("R2", 5),
-            Node::new("R3", 6),
-            Node::new("D", 7),
+        // Insert vertices
+        let vertices = [
+            Vertex::new("S", 0),
+            Vertex::new("N1", 1),
+            Vertex::new("N2", 2),
+            Vertex::new("N3", 3),
+            Vertex::new("R1", 4),
+            Vertex::new("R2", 5),
+            Vertex::new("R3", 6),
+            Vertex::new("D", 7),
         ];
 
-        for node in nodes.iter() {
-            graph.insert(node.id, node.clone());
+        for vertex in vertices.iter() {
+            graph.insert(vertex.id, vertex.clone());
         }
 
         // Define links
@@ -636,7 +636,7 @@ mod tests {
             (7, 6, 1), // R3
         ];
 
-        // Insert links into nodes
+        // Insert links into vertices
         for (from, to, cost) in links {
             graph
                 .get_mut(&from)
@@ -671,7 +671,8 @@ mod tests {
     fn tilfa_test() {
         let graph = tilfa_graph();
 
-        let node_name = |graph: &Graph, id: usize| graph.get(&id).map(|n| &n.name).unwrap().clone();
+        let vertex_name =
+            |graph: &Graph, id: usize| graph.get(&id).map(|n| &n.name).unwrap().clone();
 
         // TI-LFA draft
         // *  First, P(S, N1) is computed and results in [N3, N2, R1].
@@ -679,25 +680,25 @@ mod tests {
         let d = 7;
         let x = 1;
 
-        let p = p_space_nodes(&graph, s, x);
-        let mut p_nodes = BTreeSet::<String>::new();
+        let p = p_space_vertices(&graph, s, x);
+        let mut p_vertices = BTreeSet::<String>::new();
         for n in p.iter() {
-            let name = node_name(&graph, *n);
-            p_nodes.insert(name);
+            let name = vertex_name(&graph, *n);
+            p_vertices.insert(name);
         }
         assert_eq!(
-            p_nodes,
+            p_vertices,
             BTreeSet::from(["N3".into(), "N2".into(), "R1".into()])
         );
 
         // Then, Q(D, N1) is computed and results in [R3].
-        let q = q_space_nodes(&graph, d, x);
-        let mut q_nodes = BTreeSet::<String>::new();
+        let q = q_space_vertices(&graph, d, x);
+        let mut q_vertices = BTreeSet::<String>::new();
         for n in q.iter() {
-            let name = node_name(&graph, *n);
-            q_nodes.insert(name);
+            let name = vertex_name(&graph, *n);
+            q_vertices.insert(name);
         }
-        assert_eq!(q_nodes, BTreeSet::from(["R3".into()]));
+        assert_eq!(q_vertices, BTreeSet::from(["R3".into()]));
 
         // *  The expected post-convergence path from S to D considering the
         // failure of N1 is <N2 -> R1 -> R2 -> R3 -> D> (we are naming it
@@ -705,12 +706,12 @@ mod tests {
         let mut pc_paths = pc_paths(&graph, s, d, x);
         assert_eq!(pc_paths.len(), 1);
         let pc_path = pc_paths.first().unwrap();
-        let mut pc_nodes = Vec::<String>::new();
+        let mut pc_vertices = Vec::<String>::new();
         for n in pc_path.iter() {
-            let name = node_name(&graph, *n);
-            pc_nodes.push(name);
+            let name = vertex_name(&graph, *n);
+            pc_vertices.push(name);
         }
-        assert_eq!(pc_nodes, vec!["N2", "R1", "R2", "R3", "D"]);
+        assert_eq!(pc_vertices, vec!["N2", "R1", "R2", "R3", "D"]);
 
         // * P(S, N1) intersection with PCPath is [N2, R1], R1 being the deeper
         // downstream node in PCPath, it can be assumed to be used as P node
@@ -729,7 +730,7 @@ mod tests {
 
             print!("  ");
             for i in pc_inter.iter() {
-                let name = node_name(&graph, i.id);
+                let name = vertex_name(&graph, i.id);
                 print!(" {}", name);
             }
             println!();
@@ -750,7 +751,7 @@ mod tests {
             let mut p_inter = Vec::<String>::new();
             for i in pc_inter.iter() {
                 if i.p {
-                    let name = node_name(&graph, i.id);
+                    let name = vertex_name(&graph, i.id);
                     p_inter.push(name);
                 };
             }
@@ -760,7 +761,7 @@ mod tests {
             let mut q_inter = Vec::<String>::new();
             for i in pc_inter.iter().rev() {
                 if i.q {
-                    let name = node_name(&graph, i.id);
+                    let name = vertex_name(&graph, i.id);
                     q_inter.push(name);
                 };
             }

--- a/zebra-rs/src/spf/calc.rs
+++ b/zebra-rs/src/spf/calc.rs
@@ -444,6 +444,58 @@ mod tests {
 
     use super::*;
 
+    // RFC 9855 §5 TI-LFA topology, modelled as all-LAN. Each
+    // router-pair becomes a pseudonode (router → PN cost = the
+    // router's interface metric; PN → router cost = 0). SPF cost
+    // from S to every router must match `tilfa_graph()` — the
+    // pseudonode hops are zero-cost, so totals are preserved.
+    //
+    // Sys-id mapping (cosmetic only; the algorithm uses the usize id):
+    //   S : 49.0000.0000.0000.0001.00
+    //   N1: 49.0000.0000.0000.0002.00
+    //   N2: 49.0000.0000.0000.0003.00
+    //   N3: 49.0000.0000.0000.0004.00
+    //   R1: 49.0000.0000.0000.0005.00
+    //   R2: 49.0000.0000.0000.0006.00
+    //   R3: 49.0000.0000.0000.0007.00
+    //   D : 49.0000.0000.0000.0008.00
+    #[test]
+    fn isis_lan() {
+        let lan = isis_lan_graph();
+        let p2p = tilfa_graph();
+
+        let opt = SpfOpt::full_path();
+        let lan_tree = spf(&lan, 0, &opt);
+        let p2p_tree = spf(&p2p, 0, &opt);
+
+        // Cost to every router (id 0..=7) must match the P2P model
+        // exactly — LAN pseudonodes add path length but no cost.
+        for rtr in 0..=7 {
+            let lan_cost = lan_tree.get(&rtr).map(|p| p.cost);
+            let p2p_cost = p2p_tree.get(&rtr).map(|p| p.cost);
+            assert_eq!(
+                lan_cost, p2p_cost,
+                "router {rtr}: LAN cost {lan_cost:?} != P2P cost {p2p_cost:?}"
+            );
+        }
+
+        // All 11 pseudonodes (ids 8..=18) must appear in the SPF
+        // tree — confirms they are actually traversed, not orphaned.
+        for pn in 8..=18 {
+            assert!(
+                lan_tree.contains_key(&pn),
+                "pseudonode {pn} missing from SPF tree"
+            );
+        }
+
+        // S → D shortest path: S → PN_S_N1(8) → N1(1) → PN_N1_D(13) → D(7),
+        // total cost 1 + 0 + 1 + 0 = 2 (same as P2P).
+        let d = lan_tree.get(&7).expect("D reachable from S");
+        assert_eq!(d.cost, 2);
+        assert_eq!(d.paths.len(), 1, "no ECMP expected at D");
+        assert_eq!(d.paths[0], vec![8, 1, 13, 7]);
+    }
+
     #[test]
     fn ecmp() {
         let mut graph = BTreeMap::new();
@@ -646,6 +698,75 @@ mod tests {
                 .ilinks
                 .push(Link::new(from, to, cost));
         }
+        graph
+    }
+
+    /// Attach a pseudonode (one per IS-IS LAN) to the graph.
+    ///
+    /// `members` is a list of (router_id, router-side cost). For each
+    /// member the helper appends:
+    ///   router → PN  with the router's interface cost
+    ///   PN     → router  with cost 0  (always — IS-IS LAN modelling)
+    /// olinks/ilinks stay symmetric so reverse SPF (used by Q-space)
+    /// works the same as for P2P links.
+    fn add_lan(graph: &mut Graph, pn_id: usize, name: &str, members: &[(usize, u32)]) {
+        graph.insert(pn_id, Vertex::new(name, pn_id));
+        for &(rtr, cost) in members {
+            graph
+                .get_mut(&rtr)
+                .unwrap()
+                .olinks
+                .push(Link::new(rtr, pn_id, cost));
+            graph
+                .get_mut(&pn_id)
+                .unwrap()
+                .ilinks
+                .push(Link::new(rtr, pn_id, cost));
+            graph
+                .get_mut(&pn_id)
+                .unwrap()
+                .olinks
+                .push(Link::new(pn_id, rtr, 0));
+            graph
+                .get_mut(&rtr)
+                .unwrap()
+                .ilinks
+                .push(Link::new(pn_id, rtr, 0));
+        }
+    }
+
+    /// Same systems as `tilfa_graph()`, but each underlying point-to-point
+    /// link is rebuilt as an IS-IS LAN with one pseudonode (ids 8..=18).
+    /// SPF cost between any two routers is preserved by construction.
+    fn isis_lan_graph() -> Graph {
+        let mut graph = BTreeMap::new();
+
+        for r in [
+            Vertex::new("S", 0),
+            Vertex::new("N1", 1),
+            Vertex::new("N2", 2),
+            Vertex::new("N3", 3),
+            Vertex::new("R1", 4),
+            Vertex::new("R2", 5),
+            Vertex::new("R3", 6),
+            Vertex::new("D", 7),
+        ] {
+            graph.insert(r.id, r);
+        }
+
+        // 11 LANs, one pseudonode each. Costs mirror tilfa_graph().
+        add_lan(&mut graph, 8, "PN_S_N1", &[(0, 1), (1, 1)]);
+        add_lan(&mut graph, 9, "PN_S_N2", &[(0, 1), (2, 1)]);
+        add_lan(&mut graph, 10, "PN_S_N3", &[(0, 1000), (3, 1000)]);
+        add_lan(&mut graph, 11, "PN_N1_R1", &[(1, 1), (4, 1)]);
+        add_lan(&mut graph, 12, "PN_N1_R2", &[(1, 1), (5, 1)]);
+        add_lan(&mut graph, 13, "PN_N1_D", &[(1, 1), (7, 1)]);
+        add_lan(&mut graph, 14, "PN_N2_R1", &[(2, 1), (4, 1)]);
+        add_lan(&mut graph, 15, "PN_N3_R1", &[(3, 1000), (4, 1000)]);
+        add_lan(&mut graph, 16, "PN_R1_R2", &[(4, 1000), (5, 1000)]);
+        add_lan(&mut graph, 17, "PN_R2_R3", &[(5, 1000), (6, 1000)]);
+        add_lan(&mut graph, 18, "PN_R3_D", &[(6, 1), (7, 1)]);
+
         graph
     }
 


### PR DESCRIPTION
## Summary
Three related SPF refactor commits, ordered to compose:

1. **`ca1c89d` — rename Node → Vertex.** Aligns with OSPF RFC 2328 §16 and IS-IS ISO 10589 §C.2 (both use *vertex* for the SPF graph element). \`Link\` stays — RFC 2328 LSAs literally contain Link records, and the rest of the codebase / operator vernacular agrees on \"link.\" Vertex (algorithm-level) + Link (protocol-level) is the natural pairing. Also touches \`isis::create_graph_node{,_mt2}\` → \`create_graph_vertex{,_mt2}\` since they construct \`spf::Vertex\`.
2. **`f350609` — \`x: Option<usize>\` → \`x: &[usize]\`.** Lets \`spf_calc\` / \`pc_paths\` / \`p_space_vertices\` / \`q_space_vertices\` / \`tilfa\` accept multiple excluded vertices, in support of SRLG (Shared Risk Link Group) and multi-vertex failure scenarios. \`spf\` / \`spf_reverse\` (no-exclusion wrappers) pass \`&[]\`. The link-skip in \`spf_calc\` simplifies — previously fetched the destination vertex from the graph just to compare ids; now compares against \`link.id(direct)\` directly.
3. **`b05ab12` — IS-IS LAN topology SPF test.** New \`add_lan()\` helper and \`isis_lan_graph()\` build the RFC 9855 §5 topology with each router-pair modelled as a pseudonode (router → PN cost = interface metric; PN → router cost = 0). New \`isis_lan\` test asserts SPF cost from S to every router (ids 0..=7) is identical to the P2P \`tilfa_graph()\` model — pseudonode hops are zero-cost so totals are preserved. All 11 pseudonodes (ids 8..=18) appear in the SPF tree; S → D follows \`[PN_S_N1, N1, PN_N1_D, D]\` at cost 2.

The TI-LFA assertion on the LAN topology is intentionally **not** included — \`make_repair_list\` is not yet pseudonode-aware (would emit \`NodeSid(PN_X)\` which is invalid in SR). That's a follow-up.

## Test plan
- [x] \`cargo build --bin zebra-rs --release\` clean.
- [x] \`cargo test --release -p zebra-rs\` — 252 passed (was 251; new \`isis_lan\` test).
- [x] All 4 SPF tests pass: \`ecmp\`, \`isis_lan\`, \`tilfa_test\`, \`tilfa_api\`.
- [x] CI fmt/clippy/test.

Generated with [Claude Code](https://claude.com/claude-code)