### PR TITLE
fib: enable keep_addr_on_down for IPv6

### DIFF
--- a/zebra-rs/src/fib/netlink/sysctl.rs
+++ b/zebra-rs/src/fib/netlink/sysctl.rs
@@ -5,6 +5,8 @@ const CTLNAMES: &[(&str, &str)] = &[
     ("net.ipv6.conf.all.forwarding", "1"),
     ("net.ipv6.conf.all.seg6_enabled", "1"),
     ("net.ipv6.conf.default.seg6_enabled", "1"),
+    ("net.ipv6.conf.all.keep_addr_on_down", "1"),
+    ("net.ipv6.conf.default.keep_addr_on_down", "1"),
     ("net.vrf.strict_mode", "1"),
     ("net.mpls.platform_labels", "1048575"),
 ];


### PR DESCRIPTION
## Summary
- Add `net.ipv6.conf.{all,default}.keep_addr_on_down=1` to the sysctl bring-up list so IPv6 addresses persist across link-down events.
- `all` is included alongside `default` so the setting takes effect on existing interfaces (the kernel ORs `all` in at runtime), not just interfaces created after start-up. Mirrors the existing `seg6_enabled` pattern in the same table.

## Test plan
- [ ] `cargo build --release` (verified locally)
- [ ] On Linux: bounce a link with an IPv6 address configured and confirm the address is retained on the interface (`ip -6 addr show <if>`) instead of being flushed.
- [ ] Confirm `sysctl net.ipv6.conf.all.keep_addr_on_down` reads `1` after daemon start.

Generated with [Claude Code](https://claude.com/claude-code)