### PR TITLE
fib: set keep_addr_on_down per link on notification

### DIFF
--- a/zebra-rs/src/fib/netlink/sysctl.rs
+++ b/zebra-rs/src/fib/netlink/sysctl.rs
@@ -32,3 +32,10 @@ pub fn sysctl_seg6_enable(ifname: &String) -> anyhow::Result<()> {
     let _ = ctl.set_value_string("1")?;
     Ok(())
 }
+
+pub fn sysctl_keep_addr_on_down(ifname: &String) -> anyhow::Result<()> {
+    let ctlname = format!("net.ipv6.conf.{}.keep_addr_on_down", ifname);
+    let ctl = sysctl::Ctl::new(ctlname.as_str())?;
+    let _ = ctl.set_value_string("1")?;
+    Ok(())
+}

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::config::{Args, ConfigOp};
 use crate::fib::message::{FibAddr, FibLink};
 use crate::fib::os_traffic_dump;
-use crate::fib::sysctl::{sysctl_mpls_enable, sysctl_seg6_enable};
+use crate::fib::sysctl::{sysctl_keep_addr_on_down, sysctl_mpls_enable, sysctl_seg6_enable};
 
 use super::api::RibRx;
 use super::entry::RibEntry;
@@ -503,6 +503,7 @@ impl Rib {
             let link = Link::from(fib_link);
             let _ = sysctl_mpls_enable(&link.name);
             let _ = sysctl_seg6_enable(&link.name);
+            let _ = sysctl_keep_addr_on_down(&link.name);
             self.api_link_add(&link);
             self.links.insert(link.index, link.clone());
 


### PR DESCRIPTION
## Summary
- Add `sysctl_keep_addr_on_down(ifname)` helper alongside the existing `sysctl_seg6_enable` in `fib/netlink/sysctl.rs`.
- Call it from `Rib`'s new-link path in `rib/link.rs`, right after `sysctl_seg6_enable`, so every link the kernel notifies has `net.ipv6.conf.<if>.keep_addr_on_down=1` set.
- Complements PR #472's global `all`/`default` entries by also covering interfaces created after daemon start (veth, vlan, vxlan, etc.).

## Test plan
- [ ] `cargo build --release` (verified locally)
- [ ] Bring up a veth pair after the daemon is running, then read `sysctl net.ipv6.conf.<if>.keep_addr_on_down` — should report `1`.
- [ ] Bounce a link with an IPv6 address configured; the address should remain on the interface (`ip -6 addr show`).

Generated with [Claude Code](https://claude.com/claude-code)