### PR TITLE
bdd: add teardown scenario to isis_ipv6 feature

### DIFF
--- a/bdd/tests/features/isis_ipv6.feature
+++ b/bdd/tests/features/isis_ipv6.feature
@@ -55,3 +55,12 @@ Feature: IS-IS IPv6 single-topology
     And I wait 30 seconds
     Then ping from "z1" to "2001:db8:0:ffff::2" should succeed
     And ping from "z2" to "2001:db8:0:ffff::1" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary
- Add a `Teardown topology` scenario at the end of `bdd/tests/features/isis_ipv6.feature` that stops both zebra-rs instances, deletes the z1/z2 namespaces and the shared `br0` bridge, then asserts a clean test environment.
- Mirrors the existing teardown pattern in `bgp_basic_ibgp.feature` so `@isis_ipv6` runs leave the host in a clean state instead of dangling namespaces/bridges between runs.

## Test plan
- [ ] `make -C bdd isis_ipv6` — all four scenarios (setup, reciprocal routes, link bounce, teardown) should pass and post-run there should be no `isis_ipv6_z1` / `isis_ipv6_z2` netns and no `br0`.

Generated with [Claude Code](https://claude.com/claude-code)