### PR TITLE
bdd: add teardown scenario to isis_srv6 feature

### DIFF
--- a/bdd/tests/features/isis_srv6.feature
+++ b/bdd/tests/features/isis_srv6.feature
@@ -51,3 +51,15 @@ Feature: IS-IS SRv6 end-to-end with H.Encap and End.DT6
     And I apply config "z4.conf" to namespace "z4"
     And I wait 45 seconds
     Then ping from "z1" to "2001:db8:ff00:5::2" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I stop zebra-rs in namespace "z4"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete namespace "z4"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary
- Add a `Teardown topology` scenario at the end of `bdd/tests/features/isis_srv6.feature` so the SRv6 chain run cleans up after itself instead of leaving dangling z1..z4 namespaces.
- Mirrors the teardown style used by the other features, scaled to four namespaces. No bridge delete because this feature wires point-to-point veth pairs directly between namespaces — they go away when their namespaces are deleted.

## Test plan
- [ ] `make -C bdd isis_srv6` — both scenarios pass; post-run there should be no `isis_srv6_z1..z4` netns.

Generated with [Claude Code](https://claude.com/claude-code)