### PR TITLE
isis: gate self-LSP origination by is-type

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -411,6 +411,9 @@ impl Isis {
     }
 
     fn process_lsp_originate(&mut self, level: Level, seq_floor: Option<u32>) {
+        if !has_level(self.config.is_type(), level) {
+            return;
+        }
         let mut top = self.top();
         let mut lsp = lsp_generate(&mut top, level, seq_floor);
         // tracing::info!("[LSP:Gen] {}", lsp.lsp_id);
@@ -462,6 +465,9 @@ impl Isis {
         neighbor_id: IsisNeighborId,
         base: Option<u32>,
     ) {
+        if !has_level(self.config.is_type(), level) {
+            return;
+        }
         let mut top = self.top();
 
         let Some(ifindex) = resolve_dis_ifindex(top.links, level, neighbor_id) else {


### PR DESCRIPTION
## Summary
- Add a `has_level()` guard at the top of `process_lsp_originate` and `process_dis_originate` so a `level-2-only` instance never emits an L1 self-LSP (and symmetrically for `level-1-only`).
- Mirrors the existing Hello-path gate in `ifsm::hello_originate`.

## Test plan
- [ ] `cargo build --release` (passes locally)
- [ ] Configure `is-type level-2-only` and verify no L1 self-LSP appears in the L1 LSDB
- [ ] Configure `is-type level-1-only` and verify no L2 self-LSP appears in the L2 LSDB
- [ ] Existing `is-type level-1-2` behavior unchanged (both L1 and L2 LSPs originated)

Generated with [Claude Code](https://claude.com/claude-code)