### PR TITLE
yang: drop block leaf from isis segment-routing mpls

### DIFF
--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -367,13 +367,6 @@ module config {
         container segment-routing {
           container mpls {
             presence "Enable Segment Routing over MPLS dataplane";
-            leaf block {
-              // Name of a block defined under the global
-              // /segment-routing/block list. Held as a string (not a
-              // leafref) so an IS-IS config can be staged before the
-              // global block is committed.
-              type string;
-            }
           }
           container srv6 {
             presence "Enable Segment Routing over IPv6 dataplane";


### PR DESCRIPTION
## Summary
- Remove the per-instance \`block\` leaf under \`/router/isis/segment-routing/mpls\` from the YANG schema. The IS-IS instance has no per-instance block override anymore — it uses the canonical \`default\` block seeded by the RIB.

## Follow-up
- Dead callback registration for \`/router/isis/segment-routing/mpls/block\` and the \`IsisConfig::sr_mpls_block\` field will be cleaned up separately.

## Test plan
- [ ] CI green (fmt + clippy + test)

Generated with [Claude Code](https://claude.com/claude-code)