### PR TITLE
ci: add nightly rolling build workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-key: ${{ matrix.dist }}
 
       - name: Install build dependencies
         run: |


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/nightly.yaml` that builds .deb packages for jammy/noble (native runners) and questing (ubuntu:26.04 container), each in amd64 + arm64, and publishes them as a rolling `nightly` GitHub Release on `workflow_dispatch`.
- Installs `xxd` alongside the other build deps — required by the vty build.
- Scopes the Swatinem/rust-cache key with `cache-key: ${{ matrix.dist }}` so jammy and noble matrix jobs don't share a `target/`. Without this, the cache from one Ubuntu version was being restored on the other, and proc-macro `.so` files built against a newer glibc failed to load on jammy, surfacing as `E0463: can't find crate for num_enum`.

## Test plan
- [ ] Trigger "Nightly Rolling Build" via workflow_dispatch and confirm all six matrix jobs succeed
- [ ] Confirm six `.deb` artifacts (jammy/noble/questing × amd64/arm64) attach to the `nightly` release

🤖 Generated with [Claude Code](https://claude.com/claude-code)