### PR TITLE
isis: introduce fast-reroute ti-lfa config skeleton

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -65,6 +65,7 @@ impl Isis {
             "/router/isis/segment-routing/srv6/locator",
             config_sr_srv6_locator,
         );
+        self.callback_add("/router/isis/fast-reroute/ti-lfa", config_fr_ti_lfa);
         self.callback_add("/router/isis/multi-topology", config_mt);
         self.callback_add(
             "/router/isis/interface/multi-topology/metric",
@@ -142,6 +143,12 @@ pub struct IsisConfig {
     /// /segment-routing/locator list. Same staging-friendly rationale
     /// as sr_mpls_block.
     pub sr_srv6_locator: Option<String>,
+
+    /// Set when /router/isis/fast-reroute/ti-lfa is committed (the
+    /// presence-marked YANG container). Will gate post-convergence
+    /// SPF + SR-label backup install once the repair-path computation
+    /// lands; for now no code reads it.
+    pub fr_ti_lfa_enabled: bool,
 
     /// True when `/router/isis/multi-topology` carries an MT id.
     /// Drives whether IS-IS originates TLV 229 and the per-MT reach
@@ -321,6 +328,11 @@ fn config_sr_srv6_locator(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Opti
         isis.config.sr_srv6_locator = None;
     }
     isis.reconcile_locator_watch();
+    Some(())
+}
+
+fn config_fr_ti_lfa(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
+    isis.config.fr_ti_lfa_enabled = op.is_set();
     Some(())
 }
 

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -65,7 +65,7 @@ impl Isis {
             "/router/isis/segment-routing/srv6/locator",
             config_sr_srv6_locator,
         );
-        self.callback_add("/router/isis/fast-reroute/ti-lfa", config_fr_ti_lfa);
+        self.callback_add("/router/isis/fast-reroute/ti-lfa", config_ti_lfa);
         self.callback_add("/router/isis/multi-topology", config_mt);
         self.callback_add(
             "/router/isis/interface/multi-topology/metric",
@@ -148,7 +148,7 @@ pub struct IsisConfig {
     /// presence-marked YANG container). Will gate post-convergence
     /// SPF + SR-label backup install once the repair-path computation
     /// lands; for now no code reads it.
-    pub fr_ti_lfa_enabled: bool,
+    pub ti_lfa_enabled: bool,
 
     /// True when `/router/isis/multi-topology` carries an MT id.
     /// Drives whether IS-IS originates TLV 229 and the per-MT reach
@@ -331,8 +331,8 @@ fn config_sr_srv6_locator(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Opti
     Some(())
 }
 
-fn config_fr_ti_lfa(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
-    isis.config.fr_ti_lfa_enabled = op.is_set();
+fn config_ti_lfa(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
+    isis.config.ti_lfa_enabled = op.is_set();
     Some(())
 }
 

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -380,6 +380,18 @@ module config {
           }
         }
 
+        container fast-reroute {
+          // IS-IS fast-reroute mechanisms. Empty container is a no-op;
+          // the per-mechanism child presence containers turn features on.
+          container ti-lfa {
+            // Topology-Independent Loop-Free Alternate (TI-LFA, RFC 9490).
+            // Computes a post-convergence repair path expressed as
+            // SR-MPLS labels, so segment-routing/mpls must also be
+            // enabled for the repair to install in the dataplane.
+            presence "Enable Topology-Independent LFA (TI-LFA)";
+          }
+        }
+
         leaf multi-topology {
           // RFC 5120 M-ISIS Multi Topology (MT). IPv6 unicast is the
           // only option used in the industry today, so the enum


### PR DESCRIPTION
## Summary
- Add `/router/isis/fast-reroute/ti-lfa` as a presence container in the IS-IS YANG, reserving the `fast-reroute` subtree for future LFA / microloop-avoidance siblings.
- Wire the runtime: `IsisConfig::ti_lfa_enabled` bool + `config_ti_lfa` callback registered in `callback_build`. Commit sets the flag, delete clears it.
- No protocol behavior yet — the flag is observed by no code. Repair-path SPF + SR-label install lands in a follow-up. This PR just lets the config commit cleanly instead of being silently dropped.

## Test plan
- [x] `cargo build --bin zebra-rs --release` clean.
- [x] `cargo fmt --all` no diff.
- [x] `cargo clippy --bin zebra-rs --release` clean.
- [x] Daemon starts and reaches the `zebra-rs started` log line — confirms YANG loads and all callbacks register without conflict.

Generated with [Claude Code](https://claude.com/claude-code)