### PR TITLE
isis: advertise adj-sid B-flag when ti-lfa is enabled

### DIFF
--- a/crates/isis-packet/src/sub/neigh.rs
+++ b/crates/isis-packet/src/sub/neigh.rs
@@ -670,4 +670,39 @@ mod tests {
         long.emit(&mut buf);
         assert_eq!(buf.len(), 252);
     }
+
+    #[test]
+    fn adj_sid_flag_ipv4_baseline_is_l_and_v_only() {
+        // RFC 8667 §2.2.1: F=0 (IPv4), L=1 (local), V=1 (label value),
+        // B=S=P=0. Bit positions: L=0x10, V=0x20.
+        let byte: u8 = AdjSidFlags::lan_adj_flag_ipv4().into();
+        assert_eq!(byte, 0x30);
+    }
+
+    #[test]
+    fn adj_sid_emits_b_flag_when_protected() {
+        // TI-LFA on: the B-flag (bit 6, 0x40) layered on top of the
+        // V|L baseline yields 0x70 as the first sub-TLV body byte.
+        let sub = IsisSubAdjSid {
+            flags: AdjSidFlags::lan_adj_flag_ipv4().with_b_flag(true),
+            weight: 0,
+            sid: SidLabelValue::Label(16001),
+        };
+        let mut buf = BytesMut::new();
+        sub.emit(&mut buf);
+        assert_eq!(buf[0], 0x70);
+    }
+
+    #[test]
+    fn lan_adj_sid_emits_b_flag_when_protected() {
+        let sub = IsisSubLanAdjSid {
+            flags: AdjSidFlags::lan_adj_flag_ipv4().with_b_flag(true),
+            weight: 0,
+            system_id: IsisSysId::default(),
+            sid: SidLabelValue::Label(16001),
+        };
+        let mut buf = BytesMut::new();
+        sub.emit(&mut buf);
+        assert_eq!(buf[0], 0x70);
+    }
 }

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -333,6 +333,13 @@ fn config_sr_srv6_locator(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Opti
 
 fn config_ti_lfa(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
     isis.config.ti_lfa_enabled = op.is_set();
+    // Adj-SID B-flag (RFC 8667 §2.2.1) is built from ti_lfa_enabled
+    // at LSP-generation time, so the toggle is only observable after
+    // a fresh origination. has_level() inside process_lsp_originate
+    // filters out the level that doesn't apply for level-1-only /
+    // level-2-only instances, so sending both unconditionally is safe.
+    let _ = isis.tx.send(Message::LspOriginate(Level::L1, None));
+    let _ = isis.tx.send(Message::LspOriginate(Level::L2, None));
     Some(())
 }
 

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1179,16 +1179,25 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
         for (_, nbr) in link.state.nbrs.get(&level).iter() {
             for (_key, value) in nbr.addr4.iter() {
                 if let Some(label) = value.label {
+                    // RFC 8667 §2.2.1 B-flag: "Adj-SID is eligible for
+                    // protection." We flip it on whenever TI-LFA is
+                    // enabled on this instance — i.e. we're asserting
+                    // a TI-LFA repair has been (or will be) computed
+                    // for this adjacency. Per-adjacency truthfulness
+                    // (B=0 on islands where no repair exists) is a
+                    // follow-up once the repair-path SPF lands.
+                    let flags =
+                        AdjSidFlags::lan_adj_flag_ipv4().with_b_flag(top.config.ti_lfa_enabled);
                     if nbr.link_type.is_p2p() {
                         let sub = IsisSubAdjSid {
-                            flags: AdjSidFlags::lan_adj_flag_ipv4(),
+                            flags,
                             weight: 0,
                             sid: SidLabelValue::Label(label),
                         };
                         is_reach.subs.push(neigh::IsisSubTlv::AdjSid(sub));
                     } else {
                         let sub = IsisSubLanAdjSid {
-                            flags: AdjSidFlags::lan_adj_flag_ipv4(),
+                            flags,
                             weight: 0,
                             system_id: nbr.sys_id,
                             sid: SidLabelValue::Label(label),


### PR DESCRIPTION
## Summary
- Flip RFC 8667 §2.2.1 B-flag (bit 6, 0x40) on every advertised Adj-SID and LAN-Adj-SID sub-TLV when `router isis fast-reroute ti-lfa` is committed. The originator is asserting that a TI-LFA repair is (or will be) computed for the adjacency.
- `config_ti_lfa` now sends `Message::LspOriginate` for both levels so the toggle is observable immediately; `has_level()` inside `process_lsp_originate` filters the dispatch for level-1-only / level-2-only instances.
- Three byte-level tests in `crates/isis-packet/src/sub/neigh.rs` lock the wire-format invariant: baseline `0x30` (V\|L), B-set `0x70` for both P2P and LAN variants.

## What this does NOT do
Per-adjacency truthfulness — B=0 on adjacencies where no repair path exists (singly-connected islands) — is deferred until repair-path SPF lands. Today every advertised adj-SID gets the same flag value derived from `ti_lfa_enabled`.

## Test plan
- [x] `cargo build --bin zebra-rs --release` clean
- [x] `cargo clippy --workspace --release` clean
- [x] `cargo fmt --all` no diff
- [x] `cargo test -p isis-packet --lib` — 26 passed including 3 new tests (`adj_sid_flag_ipv4_baseline_is_l_and_v_only`, `adj_sid_emits_b_flag_when_protected`, `lan_adj_sid_emits_b_flag_when_protected`)
- [x] `cargo test --bin zebra-rs --release isis::` — 18 passed

Generated with [Claude Code](https://claude.com/claude-code)