### PR TITLE
rib: NexthopList holds NexthopMember (Uni or Multi)

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -318,8 +318,8 @@ impl FibHandle {
                 self.route_ipv4_add_uni(prefix, entry, &entry.nexthop).await;
             }
             Nexthop::List(pro) => {
-                for uni in pro.nexthops.iter() {
-                    self.route_ipv4_add_uni(prefix, entry, &Nexthop::Uni(uni.clone()))
+                for member in pro.nexthops.iter() {
+                    self.route_ipv4_add_uni(prefix, entry, &member.as_nexthop())
                         .await;
                 }
             }
@@ -427,8 +427,8 @@ impl FibHandle {
                 self.route_ipv4_del_uni(prefix, entry, &entry.nexthop).await;
             }
             Nexthop::List(list) => {
-                for uni in &list.nexthops {
-                    self.route_ipv4_del_uni(prefix, entry, &Nexthop::Uni(uni.clone()))
+                for member in &list.nexthops {
+                    self.route_ipv4_del_uni(prefix, entry, &member.as_nexthop())
                         .await;
                 }
             }
@@ -621,8 +621,8 @@ impl FibHandle {
                 self.route_ipv6_add_uni(prefix, entry, &entry.nexthop).await;
             }
             Nexthop::List(pro) => {
-                for uni in pro.nexthops.iter() {
-                    self.route_ipv6_add_uni(prefix, entry, &Nexthop::Uni(uni.clone()))
+                for member in pro.nexthops.iter() {
+                    self.route_ipv6_add_uni(prefix, entry, &member.as_nexthop())
                         .await;
                 }
             }
@@ -752,8 +752,8 @@ impl FibHandle {
                 self.route_ipv6_del_uni(prefix, entry, &entry.nexthop).await;
             }
             Nexthop::List(list) => {
-                for uni in &list.nexthops {
-                    self.route_ipv6_del_uni(prefix, entry, &Nexthop::Uni(uni.clone()))
+                for member in &list.nexthops {
+                    self.route_ipv6_del_uni(prefix, entry, &member.as_nexthop())
                         .await;
                 }
             }

--- a/zebra-rs/src/rib/entry.rs
+++ b/zebra-rs/src/rib/entry.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 use crate::fib::FibHandle;
 
 use super::nexthop::{GroupTrait, NexthopUni};
-use super::{Nexthop, NexthopMap, NexthopMulti, RibSubType, RibType};
+use super::{Nexthop, NexthopMap, NexthopMember, NexthopMulti, RibSubType, RibType};
 
 pub type RibEntries = Vec<RibEntry>;
 
@@ -97,8 +97,7 @@ impl RibEntry {
                 .iter()
                 .any(|nhop| nmap.get(nhop.gid).is_some_and(|group| group.is_valid())),
             Nexthop::List(pro) => pro
-                .nexthops
-                .iter()
+                .iter_unis()
                 .any(|nhop| nmap.get(nhop.gid).is_some_and(|group| group.is_valid())),
             _ => false,
         }
@@ -115,8 +114,16 @@ impl RibEntry {
             multi_group_sync(multi, nmap, fib).await;
         }
         if let Nexthop::List(pro) = &mut self.nexthop {
-            for uni in pro.nexthops.iter_mut() {
-                uni_group_sync(uni, nmap, fib).await;
+            for member in pro.nexthops.iter_mut() {
+                match member {
+                    NexthopMember::Uni(uni) => uni_group_sync(uni, nmap, fib).await,
+                    NexthopMember::Multi(multi) => {
+                        for uni in multi.nexthops.iter_mut() {
+                            uni_group_sync(uni, nmap, fib).await;
+                        }
+                        multi_group_sync(multi, nmap, fib).await;
+                    }
+                }
             }
         }
     }
@@ -140,8 +147,18 @@ impl RibEntry {
                 }
             }
             Nexthop::List(pro) => {
-                for uni in &pro.nexthops {
-                    self.handle_nexthop_group(nmap, fib, uni.gid).await;
+                for member in &pro.nexthops {
+                    match member {
+                        NexthopMember::Uni(uni) => {
+                            self.handle_nexthop_group(nmap, fib, uni.gid).await;
+                        }
+                        NexthopMember::Multi(multi) => {
+                            self.handle_nexthop_group(nmap, fib, multi.gid).await;
+                            for uni in &multi.nexthops {
+                                self.handle_nexthop_group(nmap, fib, uni.gid).await;
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/zebra-rs/src/rib/nexthop/inst.rs
+++ b/zebra-rs/src/rib/nexthop/inst.rs
@@ -122,15 +122,67 @@ impl Default for Nexthop {
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize)]
 pub struct NexthopList {
-    pub nexthops: Vec<NexthopUni>,
+    pub nexthops: Vec<NexthopMember>,
+}
+
+// A path within a NexthopList. Uni is a single nexthop at one metric
+// (the only shape produced today, since every existing caller is the
+// inter-protocol merge that combines two single-nexthop entries at
+// different distances). Multi is an ECMP group at one shared metric —
+// the slot TI-LFA's "ECMP primary + per-primary repair" install fills.
+// `#[serde(untagged)]` so JSON output preserves the pre-refactor flat
+// shape: each member serializes as its inner type.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(untagged)]
+pub enum NexthopMember {
+    Uni(NexthopUni),
+    // Multi is constructed in tests but no production code path
+    // emits one yet — TI-LFA's "ECMP primary + per-primary repair"
+    // install will be the first real user. Drop the allow when that
+    // lands.
+    #[allow(dead_code)]
+    Multi(NexthopMulti),
+}
+
+impl NexthopMember {
+    pub fn metric(&self) -> u32 {
+        match self {
+            Self::Uni(u) => u.metric,
+            Self::Multi(m) => m.metric,
+        }
+    }
+
+    /// Wrap the member back into a top-level `Nexthop`, used by the
+    /// FIB writer to re-dispatch member install through the existing
+    /// per-variant install paths.
+    pub fn as_nexthop(&self) -> Nexthop {
+        match self {
+            Self::Uni(u) => Nexthop::Uni(u.clone()),
+            Self::Multi(m) => Nexthop::Multi(m.clone()),
+        }
+    }
 }
 
 impl NexthopList {
     pub fn metric(&self) -> u32 {
-        match self.nexthops.first() {
-            Some(nhop) => nhop.metric,
-            None => 0,
-        }
+        self.nexthops.first().map_or(0, |m| m.metric())
+    }
+
+    /// Walk every `NexthopUni` leaf in member order. Uni members
+    /// yield once; Multi members yield each inner uni in turn.
+    pub fn iter_unis(&self) -> impl Iterator<Item = &NexthopUni> + '_ {
+        self.nexthops.iter().flat_map(|m| match m {
+            NexthopMember::Uni(u) => std::slice::from_ref(u).iter(),
+            NexthopMember::Multi(grp) => grp.nexthops.iter(),
+        })
+    }
+
+    /// Mutable counterpart of `iter_unis`, used by the resolver.
+    pub fn iter_unis_mut(&mut self) -> impl Iterator<Item = &mut NexthopUni> + '_ {
+        self.nexthops.iter_mut().flat_map(|m| match m {
+            NexthopMember::Uni(u) => std::slice::from_mut(u).iter_mut(),
+            NexthopMember::Multi(grp) => grp.nexthops.iter_mut(),
+        })
     }
 }
 
@@ -144,4 +196,82 @@ pub struct NexthopMulti {
 
     // Nexthop Group id for multipath.
     pub gid: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk_uni(addr: &str, metric: u32) -> NexthopUni {
+        NexthopUni::new(addr.parse().unwrap(), metric, vec![])
+    }
+
+    #[test]
+    fn list_metric_returns_first_member_metric() {
+        // Primary (metric 20) sorted ahead of backup (metric 21):
+        // NexthopList::metric() returns 20.
+        let list = NexthopList {
+            nexthops: vec![
+                NexthopMember::Uni(mk_uni("10.0.0.1", 20)),
+                NexthopMember::Uni(mk_uni("10.0.0.5", 21)),
+            ],
+        };
+        assert_eq!(list.metric(), 20);
+    }
+
+    #[test]
+    fn list_metric_returns_zero_when_empty() {
+        let list = NexthopList::default();
+        assert_eq!(list.metric(), 0);
+    }
+
+    #[test]
+    fn member_metric_delegates_to_inner() {
+        let uni_member = NexthopMember::Uni(mk_uni("10.0.0.1", 20));
+        let multi = NexthopMulti {
+            metric: 30,
+            nexthops: vec![mk_uni("10.0.0.2", 30), mk_uni("10.0.0.3", 30)],
+            ..Default::default()
+        };
+        let multi_member = NexthopMember::Multi(multi);
+        assert_eq!(uni_member.metric(), 20);
+        assert_eq!(multi_member.metric(), 30);
+    }
+
+    #[test]
+    fn iter_unis_flattens_multi_members() {
+        // A list with a Uni primary and a 2-uni Multi backup yields
+        // three NexthopUni references — caller doesn't need to know
+        // about the grouping.
+        let multi = NexthopMulti {
+            metric: 21,
+            nexthops: vec![mk_uni("10.0.0.5", 21), mk_uni("10.0.0.6", 21)],
+            ..Default::default()
+        };
+        let list = NexthopList {
+            nexthops: vec![
+                NexthopMember::Uni(mk_uni("10.0.0.1", 20)),
+                NexthopMember::Multi(multi),
+            ],
+        };
+        let addrs: Vec<_> = list.iter_unis().map(|u| u.addr.to_string()).collect();
+        assert_eq!(addrs, vec!["10.0.0.1", "10.0.0.5", "10.0.0.6"]);
+    }
+
+    #[test]
+    fn as_nexthop_redispatches_to_top_level_variant() {
+        // FIB writer relies on this to reuse the existing per-variant
+        // install paths for each member.
+        let uni = mk_uni("10.0.0.1", 20);
+        let uni_member = NexthopMember::Uni(uni.clone());
+        assert_eq!(uni_member.as_nexthop(), Nexthop::Uni(uni));
+
+        let multi = NexthopMulti {
+            metric: 21,
+            nexthops: vec![mk_uni("10.0.0.5", 21)],
+            ..Default::default()
+        };
+        let multi_member = NexthopMember::Multi(multi.clone());
+        assert_eq!(multi_member.as_nexthop(), Nexthop::Multi(multi));
+    }
 }

--- a/zebra-rs/src/rib/resolve.rs
+++ b/zebra-rs/src/rib/resolve.rs
@@ -64,7 +64,7 @@ fn entry_nexthop_ifindex(entry: &RibEntry) -> Option<u32> {
     match &entry.nexthop {
         Nexthop::Uni(uni) if uni.ifindex().is_some() => uni.ifindex(),
         Nexthop::Multi(multi) => first_ifindex(&multi.nexthops),
-        Nexthop::List(list) => first_ifindex(&list.nexthops),
+        Nexthop::List(list) => list.iter_unis().find_map(|u| u.ifindex()),
         _ => None,
     }
 }
@@ -84,8 +84,8 @@ fn entry_nexthop_addr(entry: &RibEntry) -> Option<IpAddr> {
             .filter(|u| u.ifindex().is_none())
             .map(|u| u.addr),
         Nexthop::List(list) => list
-            .nexthops
-            .first()
+            .iter_unis()
+            .next()
             .filter(|u| u.ifindex().is_none())
             .map(|u| u.addr),
         _ => None,

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -12,7 +12,8 @@ use super::entry::RibEntry;
 use super::inst::{IlmEntry, Rib};
 use super::nexthop::NexthopUni;
 use super::{
-    Group, GroupTrait, Message, NexthopList, NexthopMap, NexthopMulti, RibEntries, RibType,
+    Group, GroupTrait, Message, NexthopList, NexthopMap, NexthopMember, NexthopMulti, RibEntries,
+    RibType,
 };
 
 // Flip to true to re-enable IPv6 RIB/FIB diagnostic trace.
@@ -912,10 +913,10 @@ fn entry_resolve(entry: &mut RibEntry, nmap: &NexthopMap, _ifdown: bool) {
             entry.valid = false;
         }
         Nexthop::List(list) => {
-            for uni in list.nexthops.iter_mut() {
+            for uni in list.iter_unis_mut() {
                 nexthop_uni_resolve(uni, nmap);
             }
-            for uni in list.nexthops.iter() {
+            for uni in list.iter_unis() {
                 if uni.valid {
                     entry.metric = uni.metric;
                     entry.valid = uni.valid;
@@ -1001,7 +1002,7 @@ fn rib_resolve_nexthop(
     }
     if let Nexthop::List(pro) = &mut entry.nexthop {
         let mut _pro_valid = false;
-        for uni in pro.nexthops.iter_mut() {
+        for uni in pro.iter_unis_mut() {
             let valid = resolve_nexthop_uni(uni, nmap, table);
             if valid {
                 _pro_valid = true;
@@ -1050,9 +1051,9 @@ fn rib_add_system(table: &mut PrefixMap<Ipv4Net, RibEntries>, prefix: &Ipv4Net, 
                         Nexthop::Uni(euni)
                     } else {
                         let mut pro = NexthopList::default();
-                        pro.nexthops.push(uni.clone());
-                        pro.nexthops.push(euni);
-                        pro.nexthops.sort_by_key(|n| n.metric);
+                        pro.nexthops.push(NexthopMember::Uni(uni.clone()));
+                        pro.nexthops.push(NexthopMember::Uni(euni));
+                        pro.nexthops.sort_by_key(|m| m.metric());
                         e.metric = pro.metric();
                         Nexthop::List(pro)
                     }
@@ -1061,16 +1062,15 @@ fn rib_add_system(table: &mut PrefixMap<Ipv4Net, RibEntries>, prefix: &Ipv4Net, 
                     // Current One.
                     let mut btree = BTreeMap::new();
 
-                    for l in list.nexthops.iter() {
-                        // println!("");
-                        btree.insert(l.metric, l.clone());
+                    for member in list.nexthops.iter() {
+                        btree.insert(member.metric(), member.clone());
                     }
 
                     let Nexthop::Uni(uni) = entry.nexthop else {
                         return;
                     };
 
-                    btree.insert(uni.metric, uni);
+                    btree.insert(uni.metric, NexthopMember::Uni(uni));
 
                     let vec: Vec<_> = btree.values().cloned().collect();
                     let list = NexthopList { nexthops: vec };
@@ -1103,11 +1103,14 @@ fn rib_replace_system(
         Nexthop::Uni(uni) => uni.metric == entry.metric,
         Nexthop::Multi(multi) => multi.metric == entry.metric,
         Nexthop::List(list) => {
-            list.nexthops.retain(|x| x.metric != entry.metric);
+            list.nexthops.retain(|m| m.metric() != entry.metric);
             if list.nexthops.len() == 1 {
-                let uni = list.nexthops.pop().unwrap();
-                e.metric = uni.metric;
-                e.nexthop = Nexthop::Uni(uni);
+                let member = list.nexthops.pop().unwrap();
+                e.metric = member.metric();
+                e.nexthop = match member {
+                    NexthopMember::Uni(u) => Nexthop::Uni(u),
+                    NexthopMember::Multi(m) => Nexthop::Multi(m),
+                };
             }
             false
         }
@@ -1262,9 +1265,9 @@ fn rib_add_system_v6(
                         Nexthop::Uni(euni)
                     } else {
                         let mut pro = NexthopList::default();
-                        pro.nexthops.push(uni.clone());
-                        pro.nexthops.push(euni);
-                        pro.nexthops.sort_by_key(|n| n.metric);
+                        pro.nexthops.push(NexthopMember::Uni(uni.clone()));
+                        pro.nexthops.push(NexthopMember::Uni(euni));
+                        pro.nexthops.sort_by_key(|m| m.metric());
                         e.metric = pro.metric();
                         Nexthop::List(pro)
                     }
@@ -1273,16 +1276,15 @@ fn rib_add_system_v6(
                     // Current One.
                     let mut btree = BTreeMap::new();
 
-                    for l in list.nexthops.iter() {
-                        // println!("");
-                        btree.insert(l.metric, l.clone());
+                    for member in list.nexthops.iter() {
+                        btree.insert(member.metric(), member.clone());
                     }
 
                     let Nexthop::Uni(uni) = entry.nexthop else {
                         return;
                     };
 
-                    btree.insert(uni.metric, uni);
+                    btree.insert(uni.metric, NexthopMember::Uni(uni));
 
                     let vec: Vec<_> = btree.values().cloned().collect();
                     let list = NexthopList { nexthops: vec };
@@ -1313,11 +1315,14 @@ fn rib_replace_system_v6(
         Nexthop::Uni(uni) => uni.metric == entry.metric,
         Nexthop::Multi(multi) => multi.metric == entry.metric,
         Nexthop::List(list) => {
-            list.nexthops.retain(|x| x.metric != entry.metric);
+            list.nexthops.retain(|m| m.metric() != entry.metric);
             if list.nexthops.len() == 1 {
-                let uni = list.nexthops.pop().unwrap();
-                e.metric = uni.metric;
-                e.nexthop = Nexthop::Uni(uni);
+                let member = list.nexthops.pop().unwrap();
+                e.metric = member.metric();
+                e.nexthop = match member {
+                    NexthopMember::Uni(u) => Nexthop::Uni(u),
+                    NexthopMember::Multi(m) => Nexthop::Multi(m),
+                };
             }
             false
         }
@@ -1388,7 +1393,7 @@ fn rib_resolve_nexthop_v6(
         resolve_nexthop_multi(multi, nmap, set);
     }
     if let Nexthop::List(pro) = &mut entry.nexthop {
-        for uni in pro.nexthops.iter_mut() {
+        for uni in pro.iter_unis_mut() {
             let _ = resolve_nexthop_uni_v6(uni, nmap, table);
         }
     }

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -165,8 +165,7 @@ fn rib_entry_to_json(rib: &Rib, prefix: &Ipv4Net, e: &RibEntry) -> RouteEntry {
             })
             .collect(),
         Nexthop::List(pro) => pro
-            .nexthops
-            .iter()
+            .iter_unis()
             .map(|uni| NexthopJson {
                 address: Some(uni.addr.to_string()),
                 interface: rib.link_name(uni.ifindex().unwrap_or(0)),
@@ -279,8 +278,7 @@ fn rib_entry_to_json_v6(rib: &Rib, prefix: &Ipv6Net, e: &RibEntry) -> RouteEntry
             })
             .collect(),
         Nexthop::List(pro) => pro
-            .nexthops
-            .iter()
+            .iter_unis()
             .map(|uni| NexthopJson {
                 address: Some(uni.addr.to_string()),
                 interface: rib.link_name(uni.ifindex().unwrap_or(0)),
@@ -443,7 +441,7 @@ pub fn rib_entry_show(
                 }
             }
             Nexthop::List(pro) => {
-                for (i, uni) in pro.nexthops.iter().enumerate() {
+                for (i, uni) in pro.iter_unis().enumerate() {
                     if i != 0 {
                         buf.push_str(&" ".repeat(offset));
                     }
@@ -589,7 +587,7 @@ pub fn rib_entry_show_v6(
                 }
             }
             Nexthop::List(pro) => {
-                for (i, uni) in pro.nexthops.iter().enumerate() {
+                for (i, uni) in pro.iter_unis().enumerate() {
                     if i != 0 {
                         buf.push_str(&" ".repeat(offset));
                     }

--- a/zebra-rs/src/rib/static/route.rs
+++ b/zebra-rs/src/rib/static/route.rs
@@ -5,7 +5,7 @@ use isis_packet::srv6::EncapType;
 
 use crate::rib::entry::RibEntry;
 use crate::rib::nexthop::{Label, NexthopUni};
-use crate::rib::{Nexthop, NexthopList, NexthopMulti, RibType, SidBehavior};
+use crate::rib::{Nexthop, NexthopList, NexthopMember, NexthopMulti, RibType, SidBehavior};
 
 use super::config::StaticFamily;
 
@@ -194,7 +194,7 @@ impl<F: StaticFamily> StaticRoute<F> {
                     mpls_label: n.labels.clone(),
                     ..Default::default()
                 };
-                pro.nexthops.push(nhop);
+                pro.nexthops.push(NexthopMember::Uni(nhop));
             }
             entry.nexthop = Nexthop::List(pro);
         }


### PR DESCRIPTION
## Summary
- `NexthopList.nexthops` changes from `Vec<NexthopUni>` to `Vec<NexthopMember>`, where `NexthopMember` is a new `Uni(NexthopUni) | Multi(NexthopMulti)` enum.
- The motivation is TI-LFA: RFC 9490 wants a repair path per ECMP primary, so a list entry must be able to be a *group* of paths sharing one metric, not just one path. Today's `Uni`-only shape can express "primary + backup" but not "ECMP primary + per-primary ECMP backup."
- No semantic change for existing callers — every production code path produces `Uni`-only lists today, and `#[serde(untagged)]` keeps the pre-refactor JSON shape.

## What's preserved
- The merge code in `rib/route.rs` that builds a List when two protocols hand the RIB the same prefix at different distances.
- The FIB writer behavior for each member (re-dispatches via `as_nexthop()` to the existing per-variant install paths).
- All existing tests pass — 258 total, 0 failed.

## What's new
- `NexthopMember::metric()`, `as_nexthop()` helpers.
- `NexthopList::iter_unis()`, `iter_unis_mut()` flatten across members for callers that don't care about grouping (resolver, show, validity/refcount).
- 5 new unit tests in `rib::nexthop::inst::tests` pin the new shape.

## Test plan
- [x] `cargo build --bin zebra-rs --release` clean
- [x] `cargo clippy --workspace --release` clean
- [x] `cargo fmt --all` no diff
- [x] `cargo test --bin zebra-rs --release` — 258 passed, 0 failed
- [x] Daemon starts (`zebra-rs started`) — YANG + RIB init unchanged

## Caveats
- `Multi` variant is `#[allow(dead_code)]` for now (only constructed in tests). The allow gets dropped when TI-LFA repair install starts producing Multi members.

Generated with [Claude Code](https://claude.com/claude-code)