### PR TITLE
show: label visibility on Nexthop::List + show isis repair-list

### DIFF
--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -1,9 +1,12 @@
 use std::collections::BTreeSet;
 use std::fmt::Write;
 
+use ipnet::{Ipv4Net, Ipv6Net};
 use isis_packet::{IsisProto, IsisSysId, IsisTlv, Nsap};
+use prefix_trie::PrefixMap;
 use serde::Serialize;
 
+use super::inst::{SpfRoute, SpfRouteV6};
 use super::{Isis, inst::ShowCallback};
 
 use crate::config::Args;
@@ -33,6 +36,11 @@ impl Isis {
         self.show_add("/show/isis/graph", show_isis_graph);
         self.show_add("/show/isis/spf", show_isis_spf);
         self.show_add("/show/isis/spf/detail", show_isis_spf_detail);
+        self.show_add("/show/isis/repair-list", show_isis_repair_list);
+        self.show_add(
+            "/show/isis/repair-list/detail",
+            show_isis_repair_list_detail,
+        );
         self.show_add("/show/isis/topology", show_isis_topology);
     }
 }
@@ -1206,6 +1214,198 @@ fn show_isis_spf_detail(
     Ok(buf)
 }
 
+// ---- show isis repair-list / repair-list detail ----------------------
+//
+// Walks isis.rib (IPv4 / SR-MPLS) and isis.rib_v6 (IPv6 / SRv6) for
+// nhops whose `backup` is populated by TI-LFA, and renders one row per
+// (prefix, primary nhop) with the repair next-hop and label / segment
+// stack. Detail mode adds a NodeSID/AdjSID breakdown per segment.
+
+#[derive(Serialize)]
+struct RepairListJson {
+    routes: Vec<RepairRowJson>,
+}
+
+#[derive(Serialize)]
+struct RepairRowJson {
+    level: String,
+    family: &'static str,
+    prefix: String,
+    primary_nexthop: String,
+    primary_ifindex: u32,
+    primary_metric: u32,
+    repair_nexthop: String,
+    repair_ifindex: u32,
+    repair_metric: u32,
+    segments: Vec<RepairSegmentJson>,
+}
+
+#[derive(Serialize)]
+struct RepairSegmentJson {
+    /// "NodeSID" / "AdjSID" for SR-MPLS, "End" / "End.X" for SRv6.
+    kind: &'static str,
+    /// MPLS label value as a number, or SRv6 segment address as a string.
+    value: String,
+}
+
+/// First segment is conventionally the prefix-SID of the P-node
+/// (1-label / 1-segment repair → that's the destination itself);
+/// any subsequent segment is the AdjSID / End.X bridging P→Q.
+fn mpls_segment_kind(idx: usize) -> &'static str {
+    if idx == 0 { "NodeSID" } else { "AdjSID" }
+}
+
+fn srv6_segment_kind(idx: usize) -> &'static str {
+    if idx == 0 { "End" } else { "End.X" }
+}
+
+fn label_value_str(label: &crate::rib::Label) -> String {
+    match label {
+        crate::rib::Label::Implicit(l) => format!("{l} (implicit-null)"),
+        crate::rib::Label::Explicit(l) => format!("{l}"),
+    }
+}
+
+fn collect_repair_rows(isis: &Isis) -> Vec<RepairRowJson> {
+    let mut rows = Vec::new();
+    for level in [Level::L1, Level::L2] {
+        let v4: &PrefixMap<Ipv4Net, SpfRoute> = isis.rib.get(&level);
+        for (prefix, route) in v4.iter() {
+            for (addr, nhop) in route.nhops.iter() {
+                let Some(backup) = nhop.backup.as_ref() else {
+                    continue;
+                };
+                let segments = backup
+                    .labels
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, label)| RepairSegmentJson {
+                        kind: mpls_segment_kind(idx),
+                        value: label_value_str(label),
+                    })
+                    .collect();
+                rows.push(RepairRowJson {
+                    level: format!("{level:?}"),
+                    family: "ipv4",
+                    prefix: prefix.to_string(),
+                    primary_nexthop: addr.to_string(),
+                    primary_ifindex: nhop.ifindex,
+                    primary_metric: route.metric,
+                    repair_nexthop: backup.addr.to_string(),
+                    repair_ifindex: backup.ifindex,
+                    repair_metric: route.metric.saturating_add(1),
+                    segments,
+                });
+            }
+        }
+        let v6: &PrefixMap<Ipv6Net, SpfRouteV6> = isis.rib_v6.get(&level);
+        for (prefix, route) in v6.iter() {
+            for (addr, nhop) in route.nhops.iter() {
+                let Some(backup) = nhop.backup.as_ref() else {
+                    continue;
+                };
+                let segments = backup
+                    .segs
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, seg)| RepairSegmentJson {
+                        kind: srv6_segment_kind(idx),
+                        value: seg.to_string(),
+                    })
+                    .collect();
+                rows.push(RepairRowJson {
+                    level: format!("{level:?}"),
+                    family: "ipv6",
+                    prefix: prefix.to_string(),
+                    primary_nexthop: addr.to_string(),
+                    primary_ifindex: nhop.ifindex,
+                    primary_metric: route.metric,
+                    repair_nexthop: backup.addr.to_string(),
+                    repair_ifindex: backup.ifindex,
+                    repair_metric: route.metric.saturating_add(1),
+                    segments,
+                });
+            }
+        }
+    }
+    rows
+}
+
+fn show_isis_repair_list(
+    isis: &Isis,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let rows = collect_repair_rows(isis);
+    if json {
+        return Ok(
+            serde_json::to_string_pretty(&RepairListJson { routes: rows })
+                .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}")),
+        );
+    }
+    let mut buf = String::new();
+    if rows.is_empty() {
+        let _ = writeln!(buf, "(no TI-LFA repair-list entries)");
+        return Ok(buf);
+    }
+    writeln!(
+        buf,
+        "{:<5} {:<5} {:<22} {:<22} {:<22} Segments",
+        "Level", "AFI", "Prefix", "Primary via", "Repair via",
+    )?;
+    for row in &rows {
+        let segs: Vec<String> = row.segments.iter().map(|s| s.value.clone()).collect();
+        writeln!(
+            buf,
+            "{:<5} {:<5} {:<22} {:<22} {:<22} [{}]",
+            row.level,
+            row.family,
+            row.prefix,
+            row.primary_nexthop,
+            row.repair_nexthop,
+            segs.join(", "),
+        )?;
+    }
+    Ok(buf)
+}
+
+fn show_isis_repair_list_detail(
+    isis: &Isis,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let rows = collect_repair_rows(isis);
+    if json {
+        return Ok(
+            serde_json::to_string_pretty(&RepairListJson { routes: rows })
+                .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}")),
+        );
+    }
+    let mut buf = String::new();
+    write_spf_status_banner(isis, &mut buf);
+    if rows.is_empty() {
+        let _ = writeln!(buf, "(no TI-LFA repair-list entries)");
+        return Ok(buf);
+    }
+    for row in &rows {
+        writeln!(buf, "{} {} {}", row.level, row.family, row.prefix)?;
+        writeln!(
+            buf,
+            "  Primary: via {} (ifindex {}), metric {}",
+            row.primary_nexthop, row.primary_ifindex, row.primary_metric,
+        )?;
+        writeln!(
+            buf,
+            "  Repair:  via {} (ifindex {}), metric {}",
+            row.repair_nexthop, row.repair_ifindex, row.repair_metric,
+        )?;
+        for seg in &row.segments {
+            writeln!(buf, "    {} {}", seg.kind, seg.value)?;
+        }
+    }
+    Ok(buf)
+}
+
 fn write_spf_status_banner(isis: &Isis, buf: &mut String) {
     let ti_lfa = isis.config.ti_lfa_enabled;
     let sr_mpls = isis.config.sr_mpls_enabled;
@@ -1347,5 +1547,33 @@ mod tests {
         };
         let row = render_locator_row("LOC_N1", Some(&loc));
         assert!(row.trim_end().ends_with("Down"));
+    }
+
+    #[test]
+    fn mpls_segment_kind_first_is_node_rest_is_adj() {
+        // Convention: index 0 is the P-node's prefix-SID (NodeSID),
+        // any subsequent label is an AdjSID bridging P->Q.
+        assert_eq!(mpls_segment_kind(0), "NodeSID");
+        assert_eq!(mpls_segment_kind(1), "AdjSID");
+        assert_eq!(mpls_segment_kind(7), "AdjSID");
+    }
+
+    #[test]
+    fn srv6_segment_kind_first_is_end_rest_is_endx() {
+        // SRv6 analogue: End first, then End.X for adjacency hops.
+        assert_eq!(srv6_segment_kind(0), "End");
+        assert_eq!(srv6_segment_kind(1), "End.X");
+    }
+
+    #[test]
+    fn label_value_str_marks_implicit_null() {
+        assert_eq!(
+            label_value_str(&crate::rib::Label::Implicit(3)),
+            "3 (implicit-null)"
+        );
+        assert_eq!(
+            label_value_str(&crate::rib::Label::Explicit(16002)),
+            "16002"
+        );
     }
 }

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 use crate::{
     config::Args,
-    rib::{Label, Nexthop, nexthop::NexthopUni},
+    rib::{Label, Nexthop, nexthop::NexthopMember, nexthop::NexthopUni},
 };
 
 use super::{Group, Rib, entry::RibEntry, inst::ShowCallback, link::link_show, nexthop_show};
@@ -88,6 +88,13 @@ pub struct NexthopJson {
     pub weight: Option<u8>,
     pub metric: Option<u32>,
     pub mpls_labels: Vec<Value>,
+    /// True when this nexthop is a backup entry inside a
+    /// `Nexthop::List`: anything in the list beyond the first
+    /// member (the primary at the lowest metric) is a TI-LFA-style
+    /// repair path. Omitted from JSON when false so non-FRR routes
+    /// keep their pre-flag schema.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub backup: bool,
 }
 
 #[derive(Serialize)]
@@ -108,6 +115,7 @@ fn rib_entry_to_json(rib: &Rib, prefix: &Ipv4Net, e: &RibEntry) -> RouteEntry {
                 weight: None,
                 metric: None,
                 mpls_labels: vec![],
+                backup: false,
             }]
         }
         Nexthop::Uni(uni) => {
@@ -139,6 +147,7 @@ fn rib_entry_to_json(rib: &Rib, prefix: &Ipv4Net, e: &RibEntry) -> RouteEntry {
                         }),
                     })
                     .collect(),
+                backup: false,
             }]
         }
         Nexthop::Multi(multi) => multi
@@ -162,28 +171,39 @@ fn rib_entry_to_json(rib: &Rib, prefix: &Ipv4Net, e: &RibEntry) -> RouteEntry {
                         }),
                     })
                     .collect(),
+                backup: false,
             })
             .collect(),
         Nexthop::List(pro) => pro
-            .iter_unis()
-            .map(|uni| NexthopJson {
-                address: Some(uni.addr.to_string()),
-                interface: rib.link_name(uni.ifindex().unwrap_or(0)),
-                weight: Some(uni.weight),
-                metric: Some(uni.metric),
-                mpls_labels: uni
-                    .mpls
-                    .iter()
-                    .map(|label| match label {
-                        Label::Implicit(l) => serde_json::json!({
-                            "label": l,
-                            "label_type": "implicit"
-                        }),
-                        Label::Explicit(l) => serde_json::json!({
-                            "label": l
-                        }),
-                    })
-                    .collect(),
+            .nexthops
+            .iter()
+            .enumerate()
+            .flat_map(|(idx, member)| {
+                let is_backup = idx > 0;
+                let unis: Vec<&NexthopUni> = match member {
+                    NexthopMember::Uni(u) => vec![u],
+                    NexthopMember::Multi(m) => m.nexthops.iter().collect(),
+                };
+                unis.into_iter().map(move |uni| NexthopJson {
+                    address: Some(uni.addr.to_string()),
+                    interface: rib.link_name(uni.ifindex().unwrap_or(0)),
+                    weight: Some(uni.weight),
+                    metric: Some(uni.metric),
+                    mpls_labels: uni
+                        .mpls
+                        .iter()
+                        .map(|label| match label {
+                            Label::Implicit(l) => serde_json::json!({
+                                "label": l,
+                                "label_type": "implicit"
+                            }),
+                            Label::Explicit(l) => serde_json::json!({
+                                "label": l
+                            }),
+                        })
+                        .collect(),
+                    backup: is_backup,
+                })
             })
             .collect(),
     };
@@ -221,6 +241,7 @@ fn rib_entry_to_json_v6(rib: &Rib, prefix: &Ipv6Net, e: &RibEntry) -> RouteEntry
                 weight: None,
                 metric: None,
                 mpls_labels: vec![],
+                backup: false,
             }]
         }
         Nexthop::Uni(uni) => {
@@ -252,6 +273,7 @@ fn rib_entry_to_json_v6(rib: &Rib, prefix: &Ipv6Net, e: &RibEntry) -> RouteEntry
                         }),
                     })
                     .collect(),
+                backup: false,
             }]
         }
         Nexthop::Multi(multi) => multi
@@ -275,28 +297,39 @@ fn rib_entry_to_json_v6(rib: &Rib, prefix: &Ipv6Net, e: &RibEntry) -> RouteEntry
                         }),
                     })
                     .collect(),
+                backup: false,
             })
             .collect(),
         Nexthop::List(pro) => pro
-            .iter_unis()
-            .map(|uni| NexthopJson {
-                address: Some(uni.addr.to_string()),
-                interface: rib.link_name(uni.ifindex().unwrap_or(0)),
-                weight: Some(uni.weight),
-                metric: Some(uni.metric),
-                mpls_labels: uni
-                    .mpls
-                    .iter()
-                    .map(|label| match label {
-                        Label::Implicit(l) => serde_json::json!({
-                            "label": l,
-                            "label_type": "implicit"
-                        }),
-                        Label::Explicit(l) => serde_json::json!({
-                            "label": l
-                        }),
-                    })
-                    .collect(),
+            .nexthops
+            .iter()
+            .enumerate()
+            .flat_map(|(idx, member)| {
+                let is_backup = idx > 0;
+                let unis: Vec<&NexthopUni> = match member {
+                    NexthopMember::Uni(u) => vec![u],
+                    NexthopMember::Multi(m) => m.nexthops.iter().collect(),
+                };
+                unis.into_iter().map(move |uni| NexthopJson {
+                    address: Some(uni.addr.to_string()),
+                    interface: rib.link_name(uni.ifindex().unwrap_or(0)),
+                    weight: Some(uni.weight),
+                    metric: Some(uni.metric),
+                    mpls_labels: uni
+                        .mpls
+                        .iter()
+                        .map(|label| match label {
+                            Label::Implicit(l) => serde_json::json!({
+                                "label": l,
+                                "label_type": "implicit"
+                            }),
+                            Label::Explicit(l) => serde_json::json!({
+                                "label": l
+                            }),
+                        })
+                        .collect(),
+                    backup: is_backup,
+                })
             })
             .collect(),
     };
@@ -441,20 +474,47 @@ pub fn rib_entry_show(
                 }
             }
             Nexthop::List(pro) => {
-                for (i, uni) in pro.iter_unis().enumerate() {
-                    if i != 0 {
-                        buf.push_str(&" ".repeat(offset));
+                // Walk members so we can distinguish primaries (first
+                // member, idx == 0) from TI-LFA backups (idx > 0).
+                let mut row = 0;
+                for (member_idx, member) in pro.nexthops.iter().enumerate() {
+                    let is_backup = member_idx > 0;
+                    let unis: Vec<&NexthopUni> = match member {
+                        NexthopMember::Uni(u) => vec![u],
+                        NexthopMember::Multi(m) => m.nexthops.iter().collect(),
+                    };
+                    for uni in unis {
+                        if row != 0 {
+                            buf.push_str(&" ".repeat(offset));
+                        }
+                        row += 1;
+                        write!(
+                            buf,
+                            " {} {}, {}, metric {}",
+                            via_word(uni),
+                            via_addr(uni),
+                            rib.link_name(uni.ifindex().unwrap_or(0)),
+                            uni.metric,
+                        )
+                        .unwrap();
+                        if !uni.mpls.is_empty() {
+                            write!(buf, ", label").unwrap();
+                            for mpls in uni.mpls.iter() {
+                                match mpls {
+                                    Label::Implicit(label) => {
+                                        write!(buf, " {} implicit-null", label).unwrap();
+                                    }
+                                    Label::Explicit(label) => {
+                                        write!(buf, " {}", label).unwrap();
+                                    }
+                                }
+                            }
+                        }
+                        if is_backup {
+                            write!(buf, ", backup").unwrap();
+                        }
+                        writeln!(buf, ", {}", uptime).unwrap();
                     }
-                    writeln!(
-                        buf,
-                        " {} {}, {}, metric {}, {}",
-                        via_word(uni),
-                        via_addr(uni),
-                        rib.link_name(uni.ifindex().unwrap_or(0)),
-                        uni.metric,
-                        uptime,
-                    )
-                    .unwrap();
                 }
             }
         }
@@ -587,20 +647,47 @@ pub fn rib_entry_show_v6(
                 }
             }
             Nexthop::List(pro) => {
-                for (i, uni) in pro.iter_unis().enumerate() {
-                    if i != 0 {
-                        buf.push_str(&" ".repeat(offset));
+                // Walk members so we can distinguish primaries (first
+                // member, idx == 0) from TI-LFA backups (idx > 0).
+                let mut row = 0;
+                for (member_idx, member) in pro.nexthops.iter().enumerate() {
+                    let is_backup = member_idx > 0;
+                    let unis: Vec<&NexthopUni> = match member {
+                        NexthopMember::Uni(u) => vec![u],
+                        NexthopMember::Multi(m) => m.nexthops.iter().collect(),
+                    };
+                    for uni in unis {
+                        if row != 0 {
+                            buf.push_str(&" ".repeat(offset));
+                        }
+                        row += 1;
+                        write!(
+                            buf,
+                            " {} {}, {}, metric {}",
+                            via_word(uni),
+                            via_addr(uni),
+                            rib.link_name(uni.ifindex().unwrap_or(0)),
+                            uni.metric,
+                        )
+                        .unwrap();
+                        if !uni.mpls.is_empty() {
+                            write!(buf, ", label").unwrap();
+                            for mpls in uni.mpls.iter() {
+                                match mpls {
+                                    Label::Implicit(label) => {
+                                        write!(buf, " {} implicit-null", label).unwrap();
+                                    }
+                                    Label::Explicit(label) => {
+                                        write!(buf, " {}", label).unwrap();
+                                    }
+                                }
+                            }
+                        }
+                        if is_backup {
+                            write!(buf, ", backup").unwrap();
+                        }
+                        writeln!(buf, ", {}", uptime).unwrap();
                     }
-                    writeln!(
-                        buf,
-                        " {} {}, {}, metric {}, {}",
-                        via_word(uni),
-                        via_addr(uni),
-                        rib.link_name(uni.ifindex().unwrap_or(0)),
-                        uni.metric,
-                        uptime,
-                    )
-                    .unwrap();
                 }
             }
         }
@@ -1314,5 +1401,42 @@ mod tests {
             assert!(line.contains("LOC_N1"));
             assert!(line.contains("dynamic"));
         }
+    }
+
+    #[test]
+    fn nexthop_json_omits_backup_when_false() {
+        // Default (primary) entries shouldn't carry a `backup` key —
+        // keeps the schema unchanged for non-FRR routes.
+        let nh = NexthopJson {
+            address: Some("10.0.0.1".to_string()),
+            interface: "eth0".to_string(),
+            weight: Some(1),
+            metric: Some(20),
+            mpls_labels: vec![],
+            backup: false,
+        };
+        let json = serde_json::to_string(&nh).unwrap();
+        assert!(
+            !json.contains("backup"),
+            "primary nhop should not emit backup field: {json}"
+        );
+    }
+
+    #[test]
+    fn nexthop_json_emits_backup_when_true() {
+        // TI-LFA repair entries inside Nexthop::List carry backup=true.
+        let nh = NexthopJson {
+            address: Some("10.0.0.5".to_string()),
+            interface: "eth1".to_string(),
+            weight: Some(1),
+            metric: Some(21),
+            mpls_labels: vec![],
+            backup: true,
+        };
+        let json = serde_json::to_string(&nh).unwrap();
+        assert!(
+            json.contains("\"backup\":true"),
+            "expected backup flag: {json}"
+        );
     }
 }

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -239,6 +239,14 @@ module exec {
           type empty;
         }
       }
+      container repair-list {
+        ext:help "IS-IS TI-LFA repair-list";
+        presence "IS-IS repair-list";
+        leaf detail {
+          ext:help "IS-IS repair-list detail (per-segment NodeSID/AdjSID breakdown)";
+          type empty;
+        }
+      }
       leaf topology {
         ext:help "IS-IS SPF tree (per-AFI today; per-MT once multi-topology lands)";
         type empty;


### PR DESCRIPTION
## Summary
Two related show-output improvements (one commit each on the branch):

### `cc04906` — `show ip route`: labels on Nexthop::List + backup flag
- Text output for `Nexthop::List` (TI-LFA primary + repair) was the odd one out — Uni and Multi already rendered MPLS labels (with `"N implicit-null"` for `Label::Implicit`) but List skipped them. Now List entries print labels the same way and append `", backup"` before uptime on non-primary members.
- JSON `NexthopJson` gains `backup: bool` with `#[serde(skip_serializing_if = "std::ops::Not::not")]` — emitted as `"backup": true` only on repair entries, omitted otherwise (preserves the schema for non-FRR routes).
- Both v4 and v6 List branches walk `NexthopList.nexthops` member-by-member instead of `iter_unis()` so the primary/backup boundary is preserved across Multi members.

### `962c599` — `show isis repair-list [detail]`
- New CLI commands `/show/isis/repair-list` (brief) and `/show/isis/repair-list/detail` (with per-segment NodeSID/AdjSID labels for SR-MPLS, End/End.X for SRv6).
- Position-based segment-kind convention: index 0 → NodeSID/End, index 1+ → AdjSID/End.X. Matches the textbook TI-LFA stack `[NodeSID(P), AdjSID(P→Q)]`. Today the compute side only emits the 1-segment PQ-overlap-at-destination case so every row shows exactly one NodeSID/End; the kinds are pre-wired for the 2-segment follow-up.
- YANG: `container repair-list { leaf detail }` under `container isis`.

## Test plan
- [x] `cargo build --bin zebra-rs --release` clean
- [x] `cargo clippy --bin zebra-rs --release` clean
- [x] `cargo fmt --all` no diff
- [x] `cargo test --bin zebra-rs --release rib::` — 96 passed (2 new: `nexthop_json_omits_backup_when_false`, `nexthop_json_emits_backup_when_true`)
- [x] `cargo test --bin zebra-rs --release isis::show` — 7 passed (3 new: `mpls_segment_kind_first_is_node_rest_is_adj`, `srv6_segment_kind_first_is_end_rest_is_endx`, `label_value_str_marks_implicit_null`)
- [x] Daemon starts (`zebra-rs started` log line) — YANG load + show-callback registration both green.

Generated with [Claude Code](https://claude.com/claude-code)