### PR TITLE
isis: drop unwrap() in graph link insertion

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1706,16 +1706,13 @@ pub fn graph(
                         .get_mut(&level)
                         .get(&neighbor_lsp_id.neighbor_id());
 
-                    graph.get_mut(&node_id).unwrap().olinks.push(spf::Link::new(
-                        node_id,
-                        to_id,
-                        entry.metric,
-                    ));
-                    graph.get_mut(&to_id).unwrap().ilinks.push(spf::Link::new(
-                        node_id,
-                        to_id,
-                        entry.metric,
-                    ));
+                    let link = spf::Link::new(node_id, to_id, entry.metric);
+                    if let Some(from_id) = graph.get_mut(&node_id) {
+                        from_id.olinks.push(link.clone());
+                    }
+                    if let Some(to_id) = graph.get_mut(&to_id) {
+                        to_id.ilinks.push(link);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Replace `graph.get_mut(...).unwrap()` with `if let Some(...)` for both the olink (origin vertex) and ilink (target vertex) inserts in `graph()`.
- Both `node_id` and `to_id` are guaranteed present by the preceding vertex loop, but `if let` is the idiomatic safe form and removes the TODO markers.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo build --release --bin zebra-rs`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd`

Generated with [Claude Code](https://claude.com/claude-code)