### PR TITLE
policy: add match evpn route-type and vni

### DIFF
--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1047,6 +1047,48 @@ module config {
               enum incomplete;
             }
           }
+          container "evpn" {
+            description
+              "Match EVPN route attributes. `route-type` selects
+               one of the BGP-EVPN NLRI route types (RFC 7432
+               §7.1–7.5; RFC 9136 for Type-5); `vni` matches a
+               specific VXLAN Network Identifier carried in the
+               route (encapsulation extended community or
+               Type-2/Type-3 MPLS label field).";
+            leaf "route-type" {
+              type enumeration {
+                enum ead {
+                  description
+                    "EAD (Type-1) route";
+                }
+                enum macip {
+                  description
+                    "MAC-IP (Type-2) route";
+                }
+                enum multicast {
+                  description
+                    "Multicast (Type-3) route";
+                }
+                enum es {
+                  description
+                    "Ethernet Segment (Type-4) route";
+                }
+                enum prefix {
+                  description
+                    "Prefix (Type-5) route";
+                }
+              }
+              description
+                "Match EVPN route type.";
+            }
+            leaf "vni" {
+              type uint32 {
+                range "1..16777215";
+              }
+              description
+                "Match EVPN VNI ID.";
+            }
+          }
         }
         container "set" {
           ext:sort "3";


### PR DESCRIPTION
## Summary
- Adds `container "evpn"` under route-map `match` in `zebra-rs/yang/config.yang`.
- Exposes two new match statements:
  - `match evpn route-type {ead|macip|multicast|es|prefix}` — RFC 7432 §7.1–7.4 + RFC 9136 Type-5.
  - `match evpn vni (1-16777215)` — 24-bit VXLAN Network Identifier.
- Pure YANG addition; the existing `Enumeration`/`Uint32` dispatch in `zebra-rs/src/config/parse.rs` auto-generates CLI completion and range hinting.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo build --bin zebra-rs`
- [x] `cargo clippy --bin zebra-rs --no-deps -- -D warnings`
- [x] `cargo test --bin zebra-rs` — 281 passed, 0 failed
- [ ] Manual CLI walkthrough: `match evpn route-type ?` shows ead/macip/multicast/es/prefix; `match evpn vni ?` shows `(1-16777215)`.

Generated with [Claude Code](https://claude.com/claude-code)