### PR TITLE
bgp: apply EVPN outbound policy at advertise + peer sync

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -586,6 +586,30 @@ pub fn route_apply_policy_in_evpn(
     })
 }
 
+/// Outbound policy entry point for an EVPN route. Mirrors
+/// `route_apply_policy_out` but skips the per-direction prefix-set
+/// (no IPv4 prefix on EVPN NLRIs) and dispatches to
+/// `policy_list_apply_evpn`. Default-permit when no output
+/// policy-list is bound, same as the IPv4 outbound path.
+pub fn route_apply_policy_out_evpn(
+    peer: &mut Peer,
+    route: &EvpnRoute,
+    bgp_attr: BgpAttr,
+    weight: u32,
+) -> Option<PolicyDecision> {
+    let config = peer.policy_list.get(&InOut::Output);
+    if config.name.is_some() {
+        let Some(policy_list) = &config.policy_list else {
+            return None;
+        };
+        return policy_list_apply_evpn(policy_list, route, bgp_attr, weight, peer.router_id);
+    }
+    Some(PolicyDecision {
+        attr: bgp_attr,
+        weight,
+    })
+}
+
 pub fn route_apply_policy_out(
     peer: &mut Peer,
     nlri: &Ipv4Nlri,
@@ -1252,7 +1276,12 @@ pub fn route_advertise_evpn_to_peers(
             continue;
         };
 
-        let attr = bgp.attr_store.intern(attr);
+        let Some(decision) = route_apply_policy_out_evpn(peer, &route, attr, new_best.weight)
+        else {
+            continue;
+        };
+
+        let attr = bgp.attr_store.intern(decision.attr);
         peer.send_evpn(route, attr, true);
     }
 }
@@ -3226,7 +3255,10 @@ pub fn route_sync_evpn(peer: &mut Peer, bgp: &mut BgpTop) {
         let Some((route, attr)) = route_update_evpn(peer, &rd, &prefix, &rib, bgp, add_path) else {
             continue;
         };
-        let attr = bgp.attr_store.intern(attr);
+        let Some(decision) = route_apply_policy_out_evpn(peer, &route, attr, rib.weight) else {
+            continue;
+        };
+        let attr = bgp.attr_store.intern(decision.attr);
         // `false`: don't arm the per-peer advertise timer — we flush
         // synchronously at end-of-sync so the new peer sees one
         // batched MP_REACH (or several, one per attribute group)


### PR DESCRIPTION
## Summary

Follow-up to #501. Wires the EVPN policy evaluator into the two outbound EVPN paths so locally-originated or replayed routes pass through `match evpn …` filters before hitting the wire.

- New `route_apply_policy_out_evpn(peer, &route, attr, weight)` in `bgp/route.rs:589` mirrors `route_apply_policy_out` / `route_apply_policy_in_evpn`: default-permit when no `policy_list[Output]` is bound, otherwise delegates to `policy_list_apply_evpn`. Skips the per-direction prefix-set check (no IPv4 prefix on EVPN NLRIs).
- Hooked in at:
  - `route_advertise_evpn_to_peers` (`route.rs:1276`) — locally-originated fan-out path called from `evpn_originate_macip` / `_imet`.
  - `route_sync_evpn` (`route.rs:3258`) — peer-Established replay, mirroring the existing `route_sync_ipv4` outbound policy call pattern.
- A deny silently skips that peer/route. A permit uses `decision.attr` for the wire.

Soft-out (policy-change-triggered withdrawal of previously-advertised routes) is still deferred — same EVPN-soft-out gap that the IPv4 `route_soft_out_peer` already calls out in its header comment.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo build --bin zebra-rs`
- [x] `cargo clippy --bin zebra-rs --no-deps --all-targets -- -D warnings`
- [x] `cargo test --bin zebra-rs` — 289 passed (no new tests; outbound dispatches to the same `policy_list_apply_evpn` already covered by #501's six tests).
- [ ] Manual: configure `match evpn route-type macip` on a peer's output policy-list, originate a Type-2 and a Type-3, verify only the Type-2 is advertised.

Generated with [Claude Code](https://claude.com/claude-code)