### PR TITLE
vtyctl: support apply -c for inline configuration

### DIFF
--- a/vtyctl/src/apply.rs
+++ b/vtyctl/src/apply.rs
@@ -15,32 +15,49 @@ fn print_help() {
     eprintln!("vtyctl apply must specify -f or --filename.");
 }
 
-pub async fn apply(host: &String, filename: &String) -> Result<()> {
-    if filename.is_empty() {
+pub async fn apply(host: &String, filename: &String, command: Option<&String>) -> Result<()> {
+    let mut vec = Vec::new();
+    if let Some(cmd) = command {
+        // The shell hands us the two-character literal `\n` (not a
+        // real newline) for the common
+        //   vtyctl apply -c "set ... \n set ..."
+        // invocation. Normalise the escape into a real newline so
+        // callers don't have to reach for $'...' quoting, then
+        // forward each line as one ApplyRequest — same shape as
+        // the file-mode path below. `str::lines()` matches
+        // `BufReader::lines()`: it splits on `\n`/`\r\n`, strips
+        // the terminator, and doesn't emit a trailing empty line
+        // when the input ends with one.
+        let normalised = cmd.replace("\\n", "\n");
+        for line in normalised.lines() {
+            vec.push(ApplyRequest {
+                line: line.to_string() + "\n",
+            });
+        }
+    } else if !filename.is_empty() {
+        let path = Path::new(filename);
+        let file = match File::open(path) {
+            Ok(file) => file,
+            Err(err) => {
+                eprintln!("Can't open file {}: {}", filename, err);
+                exit(2);
+            }
+        };
+        for line in BufReader::new(file).lines() {
+            vec.push(ApplyRequest {
+                line: line.unwrap() + "\n",
+            });
+        }
+    } else {
         print_help();
         exit(1);
     }
-    let path = Path::new(filename);
-    let file = match File::open(path) {
-        Ok(file) => file,
-        Err(err) => {
-            eprintln!("Can't open file {}: {}", filename, err);
-            exit(2);
-        }
-    };
 
     let client = ApplyClient::connect(format!("http://{}:{}", host, 2666)).await;
     let Ok(mut client) = client else {
         eprintln!("Can't connect to {}", host);
         exit(3);
     };
-
-    let mut vec = Vec::new();
-    for line in BufReader::new(file).lines() {
-        vec.push(ApplyRequest {
-            line: line.unwrap() + "\n",
-        });
-    }
 
     let requests = tokio_stream::iter(vec);
 

--- a/vtyctl/src/main.rs
+++ b/vtyctl/src/main.rs
@@ -23,8 +23,11 @@ enum Commands {
         #[arg(short, long, default_value = "127.0.0.1")]
         host: String,
 
-        #[arg(short, long, help = "Base URL of the server", default_value = "")]
+        #[arg(short, long, help = "Config filename", default_value = "")]
         filename: String,
+
+        #[arg(short, long, help = "Command line strings")]
+        command: Option<String>,
     },
     #[command(disable_help_flag = true)]
     Clear {
@@ -73,8 +76,12 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match &cli.command {
-        Some(Commands::Apply { host, filename }) => {
-            apply::apply(host, filename).await?;
+        Some(Commands::Apply {
+            host,
+            filename,
+            command,
+        }) => {
+            apply::apply(host, filename, command.as_ref()).await?;
         }
         Some(Commands::Clear { host, command }) => {
             clear::clear(host, command).await?;


### PR DESCRIPTION
## Summary

Add a `-c, --command` flag to `vtyctl apply` so a config snippet can be applied without writing a file:

\`\`\`
vtyctl apply -c "set router bgp global as 65501\nset router bgp global identifier 1.1.1.1"
\`\`\`

- `main.rs` threads the new `command: Option<String>` parameter through clap into `apply::apply`.
- `apply.rs` normalises the shell-supplied literal `\n` escape into real newlines (so callers don't need `$'...'` quoting), then forwards each line as one `ApplyRequest` with a trailing `\n` — same shape as the existing file-mode path.
- `str::lines()` matches `BufReader::lines()` semantics (splits on `\n`/`\r\n`, strips the terminator, skips a trailing empty when the input ends with one).
- Fallback unchanged: no `-c` and empty `--filename` → `print_help(); exit(1)`.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo build --bin vtyctl`
- [x] `cargo clippy --bin vtyctl --no-deps -- -D warnings`
- [x] Smoke: `vtyctl apply -c "set ... \n set ..."` reaches the daemon; the request stream contains both lines as separate `ApplyRequest`s.
- [x] `vtyctl apply` (no args) → prints help and exits 1.

Generated with [Claude Code](https://claude.com/claude-code)