### PR TITLE
config: wire vtyctl apply -c end-to-end (frontend + daemon)

### DIFF
--- a/vtyctl/src/apply.rs
+++ b/vtyctl/src/apply.rs
@@ -15,32 +15,50 @@ fn print_help() {
     eprintln!("vtyctl apply must specify -f or --filename.");
 }
 
-pub async fn apply(host: &String, filename: &String) -> Result<()> {
-    if filename.is_empty() {
+pub async fn apply(host: &String, filename: &String, command: Option<&String>) -> Result<()> {
+    let mut vec = Vec::new();
+    if let Some(cmd) = command {
+        // The shell hands us the two-character literal `\n` (not a
+        // real newline) for the common
+        //   vtyctl apply -c "set ... \n set ..."
+        // invocation. Normalise the escape into a real newline so
+        // callers don't have to reach for $'...' quoting, then
+        // forward each line as one ApplyRequest — same shape as
+        // the file-mode path below. `str::lines()` matches
+        // `BufReader::lines()`: it splits on `\n`/`\r\n`, strips
+        // the terminator, and doesn't emit a trailing empty line
+        // when the input ends with one.
+        let normalised = cmd.replace("\\n", "\n");
+        for line in normalised.lines() {
+            println!("line:{}", line);
+            vec.push(ApplyRequest {
+                line: line.to_string() + "\n",
+            });
+        }
+    } else if !filename.is_empty() {
+        let path = Path::new(filename);
+        let file = match File::open(path) {
+            Ok(file) => file,
+            Err(err) => {
+                eprintln!("Can't open file {}: {}", filename, err);
+                exit(2);
+            }
+        };
+        for line in BufReader::new(file).lines() {
+            vec.push(ApplyRequest {
+                line: line.unwrap() + "\n",
+            });
+        }
+    } else {
         print_help();
         exit(1);
     }
-    let path = Path::new(filename);
-    let file = match File::open(path) {
-        Ok(file) => file,
-        Err(err) => {
-            eprintln!("Can't open file {}: {}", filename, err);
-            exit(2);
-        }
-    };
 
     let client = ApplyClient::connect(format!("http://{}:{}", host, 2666)).await;
     let Ok(mut client) = client else {
         eprintln!("Can't connect to {}", host);
         exit(3);
     };
-
-    let mut vec = Vec::new();
-    for line in BufReader::new(file).lines() {
-        vec.push(ApplyRequest {
-            line: line.unwrap() + "\n",
-        });
-    }
 
     let requests = tokio_stream::iter(vec);
 
@@ -51,7 +69,7 @@ pub async fn apply(host: &String, filename: &String) -> Result<()> {
     if reply.apply_code == ApplyCode::Applied as i32 {
         println!("applied");
     } else {
-        println!("error: {}", reply.description)
+        println!("error reply: {}", reply.description)
     }
 
     Ok(())

--- a/vtyctl/src/main.rs
+++ b/vtyctl/src/main.rs
@@ -23,8 +23,11 @@ enum Commands {
         #[arg(short, long, default_value = "127.0.0.1")]
         host: String,
 
-        #[arg(short, long, help = "Base URL of the server", default_value = "")]
+        #[arg(short, long, help = "Config filename", default_value = "")]
         filename: String,
+
+        #[arg(short, long, help = "Command line strings")]
+        command: Option<String>,
     },
     #[command(disable_help_flag = true)]
     Clear {
@@ -73,8 +76,12 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match &cli.command {
-        Some(Commands::Apply { host, filename }) => {
-            apply::apply(host, filename).await?;
+        Some(Commands::Apply {
+            host,
+            filename,
+            command,
+        }) => {
+            apply::apply(host, filename, command.as_ref()).await?;
         }
         Some(Commands::Clear { host, command }) => {
             clear::clear(host, command).await?;

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -429,16 +429,25 @@ impl ConfigManager {
                 }
                 let entry = entry.unwrap();
 
-                let cmds = match config_format_type(&req.config) {
+                let format_type = config_format_type(&req.config);
+                let cmds = match format_type {
                     ConfigFormat::Cli => load_config_file(req.config.clone()),
                     ConfigFormat::Json => json_read(entry, req.config.as_str()),
                     ConfigFormat::Yaml => {
                         let config = yaml_parse(req.config.as_str());
                         json_read(entry, config.as_str())
                     }
+                    ConfigFormat::SetDelete => req
+                        .config
+                        .lines()
+                        .filter(|l| !l.trim().is_empty())
+                        .map(str::to_string)
+                        .collect(),
                 };
 
-                self.store.candidate_clear();
+                if format_type != ConfigFormat::SetDelete {
+                    self.store.candidate_clear();
+                }
                 for cmd in cmds.iter() {
                     let (code, _output, _paths) = self.execute(mode, cmd);
                     if code != ExecCode::Show {
@@ -605,11 +614,12 @@ fn collect_dynamics(entry: &Entry, set: &mut HashSet<String>) {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ConfigFormat {
     Cli,
     Json,
     Yaml,
+    SetDelete,
 }
 
 pub fn config_format_type(config_str: &str) -> ConfigFormat {
@@ -618,6 +628,8 @@ pub fn config_format_type(config_str: &str) -> ConfigFormat {
         ConfigFormat::Json
     } else if first_line.ends_with('{') {
         ConfigFormat::Cli
+    } else if first_line.starts_with("set ") || first_line.starts_with("delete ") {
+        ConfigFormat::SetDelete
     } else {
         ConfigFormat::Yaml
     }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -623,7 +623,15 @@ pub enum ConfigFormat {
 }
 
 pub fn config_format_type(config_str: &str) -> ConfigFormat {
-    let first_line = config_str.lines().next().unwrap_or("").trim();
+    // Use the first *meaningful* line for format sniffing. Skip
+    // blank lines and `#`-prefixed comments so leading whitespace
+    // or commentary in a file or `-c` payload doesn't fall through
+    // to the YAML default.
+    let first_line = config_str
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty() && !l.starts_with('#'))
+        .unwrap_or("");
     if first_line.starts_with('{') {
         ConfigFormat::Json
     } else if first_line.ends_with('{') {


### PR DESCRIPTION
## Summary

End-to-end wiring of \`vtyctl apply -c "set ...\nset ..."\`. Supersedes #504 — this branch combines the vtyctl frontend (re-committed by the user) with the daemon-side fixes the frontend depends on.

Three commits:

1. **\`config: fix ConfigFormat::SetDelete arm in Deploy handler\`** — the SetDelete arm in \`Message::Deploy\` was a compile-error placeholder (\`split('\n').collect::<Vec<String>>()\` from \`&str\`). Replaced with \`req.config.lines().filter(|l| !l.trim().is_empty()).map(str::to_string).collect()\`. Also adds the \`ConfigFormat::SetDelete\` enum variant + \`PartialEq\` derive and skips \`candidate_clear()\` when the payload is in SetDelete form so existing config isn't wiped before the set/delete lines run.
2. **\`config: skip blank and \`#\`-comment lines in format sniffing\`** — \`config_format_type\` walks lines via \`find()\` until the first non-empty, non-\`#\`-prefixed line. A leading blank or commented header used to fall through to the YAML default and error in \`yaml_parse\`.
3. **\`Add -c option to vtyctl apply.\`** — adds the \`-c, --command\` flag to vtyctl; normalises shell-literal \`\n\` to real newlines and forwards each line as one \`ApplyRequest\`.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo build --bin zebra-rs --bin vtyctl\`
- [x] \`cargo clippy --bin zebra-rs --tests --no-deps -p zebra-rs -- -D warnings\`
- [x] \`cargo clippy --bin vtyctl --no-deps -- -D warnings\`
- [x] \`cargo test --bin zebra-rs\` — 289 passed
- [ ] Manual: \`vtyctl apply -c "set router bgp global as 65501\nset router bgp global identifier 1.1.1.1"\` against a running daemon → both lines applied; \`show running-config\` reflects the new BGP config.

Generated with [Claude Code](https://claude.com/claude-code)