### PR TITLE
bgp: flat `neighbor X password PASSWORD` alias for TCP MD5

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -980,6 +980,12 @@ impl Bgp {
         self.callback_peer("/update-source", config_transport_local_address);
         self.callback_peer("/tcp-md5/password", config_peer_tcp_md5_password);
         self.callback_peer("/tcp-md5/encoding", config_peer_tcp_md5_encoding);
+        // FRR / IOS-XR flat alias from zebra-bgp-password.yang. Same
+        // backing field (`peer.config.transport.md5_password`) and
+        // same `setsockopt(TCP_MD5SIG)` site as the structured
+        // `/tcp-md5/password` path above; either CLI form is accepted,
+        // both lower onto the same runtime state.
+        self.callback_peer("/password", config_peer_tcp_md5_password);
         self.callback_peer("/tcp-ao/key-chain", config_peer_tcp_ao_key_chain);
         self.callback_peer(
             "/tcp-ao/include-tcp-options",

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -44,6 +44,10 @@ module config {
     prefix zbt;
   }
 
+  import zebra-bgp-password {
+    prefix zbp;
+  }
+
   import zebra-bgp-soft-reconfiguration {
     prefix zbsr;
   }

--- a/zebra-rs/yang/zebra-bgp-password.yang
+++ b/zebra-rs/yang/zebra-bgp-password.yang
@@ -1,0 +1,93 @@
+module zebra-bgp-password {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-password";
+  prefix "zbp";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "FRR / IOS-XR style flat per-neighbor TCP MD5 password alias.
+
+     Adds `password` directly under each BGP neighbor:
+
+       router bgp {
+         neighbor 10.0.0.5 {
+           remote-as 65501;
+           password secret;
+         }
+       }
+
+     Functionally equivalent to the IETF-shaped `neighbor/tcp-md5/
+     password` leaf from zebra-bgp-auth.yang; both lower onto the
+     same runtime field (`peer.config.transport.md5_password`) and
+     the same `setsockopt(TCP_MD5SIG)` site on the listener. The
+     `tcp-md5` container path is retained for operators using the
+     structured form; this module is for the flat CLI shortcut.";
+
+  revision 2026-05-15 {
+    description "Initial revision.";
+    reference "FRR `neighbor X password`; Cisco IOS / IOS-XR equivalent; RFC 2385.";
+  }
+
+  grouping bgp-neighbor-password-extension {
+    description
+      "FRR-style flat password leaf on a BGP neighbor.";
+
+    leaf password {
+      ext:help "Shared MD5 secret (RFC 2385)";
+      type string {
+        length "1..80";
+      }
+      description
+        "Shared MD5 secret. Max 80 bytes matches Linux's
+         TCP_MD5SIG_MAXKEYLEN. Both peers MUST configure identical
+         bytes or the TCP SYNs are silently dropped by the kernel
+         and the session never establishes.
+
+         Equivalent to `neighbor/tcp-md5/password` in
+         zebra-bgp-auth.yang.";
+      reference "RFC 2385";
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Attach the flat password leaf to BGP neighbors in the
+       candidate-set subtree.";
+    uses bgp-neighbor-password-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp neighbor X password` is path-valid.";
+    uses bgp-neighbor-password-extension;
+  }
+}


### PR DESCRIPTION
## Summary

Adds FRR / IOS-XR style `set router bgp neighbor X password PASSWORD` as a flat alias for the structured `neighbor X tcp-md5 password ...` already in `zebra-bgp-auth.yang`. Both paths lower onto the same backing field (`peer.config.transport.md5_password`) and the same listener `setsockopt(TCP_MD5SIG)` site — operators keep their existing CLI and new operators get the shorthand.

- **New module `zebra-bgp-password.yang`**: `bgp-neighbor-password-extension` grouping with `leaf password` (`type string { length "1..80"; }`, same constraint as `tcp-md5/password`), augmented onto `/configure:set` and `/configure:delete` neighbor subtrees. Mirrors `zebra-bgp-transport.yang`.
- **`config.yang`**: import the new module.
- **`bgp/config.rs`**: register `/password` against the existing `config_peer_tcp_md5_password` handler — same alias pattern used by `/update-source` → `/transport/local-address`.

## Test plan

- [x] `cargo build` clean
- [x] `cargo fmt --all` applied
- [x] `libyang` parser: `zebra-bgp-password.yang` parses without error
- [ ] `set router bgp neighbor 10.0.0.5 password secret` (new flat form) installs key on listener
- [ ] `set router bgp neighbor 10.0.0.5 tcp-md5 password secret` (existing structured form) still works
- [ ] `delete router bgp neighbor 10.0.0.5 password` clears the key (same handler path with `op == Delete`)

Generated with [Claude Code](https://claude.com/claude-code)