### PR TITLE
deps: bump libyang to fix local-typedef union arm resolution

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -19,7 +19,7 @@ tokio-stream.workspace = true
 tonic.workspace = true
 tonic-prost.workspace = true
 console-subscriber = "0.5"
-libyang = { git = "https://github.com/zebra-rs/libyang", rev = "025b9b24a89d5893730135dc2178d7287d4860e8" }
+libyang = { git = "https://github.com/zebra-rs/libyang", rev = "e2825a7fd41cce5331a254fe2d8202b0f44dea6a" }
 #libyang = { path = "../../libyang" }
 regex = "1.10"
 similar = "3"


### PR DESCRIPTION
## Summary

Bumps libyang to [e2825a7](https://github.com/zebra-rs/libyang/pull/21), which fixes two cooperating bugs in `type_resolve` that surfaced after PRs #19 / #20 made string-pattern restrictions actually take effect:

- `type_path_resolve`'s local-typedef branch now resolves union arms the same way the prefixed branch already did (`type peer-id-or-all` no longer reaches the matcher with `kind = Path` arms).
- `type_union_resolve` no longer drops inline non-`Path` arms (e.g. `type string { pattern "all"; }` written directly inside a union).

## Concrete failure

Pre-bump:
```
# clear bgp ipv4 neighbor 10.0.0.5
% No such command: clear bgp ipv4 neighbor 10.0.0.5
```

The `address` leaf was typed as `peer-id-or-all` — a local typedef whose underlying type is `union { inet:ipv4-address; inet:ipv6-address; string { pattern "all"; } }`. After the bump, the IPv4 arm is properly tagged with `typedef = "inet:ipv4-address"` (dispatching to the Ipv4Addr matcher), the pattern arm survives, and the leaf accepts an IPv4 literal or the keyword `all`.

## Test plan

- [x] `cargo build` clean
- [ ] Live: `clear bgp ipv4 neighbor 10.0.0.5` parses; `clear bgp ipv4 neighbor all` parses; `clear bgp ipv4 neighbor garbage` is rejected.

Generated with [Claude Code](https://claude.com/claude-code)