### PR TITLE
config: install /show/version in configure mode

### DIFF
--- a/zebra-rs/src/config/commands.rs
+++ b/zebra-rs/src/config/commands.rs
@@ -43,6 +43,11 @@ pub fn configure_mode_create(entry: Rc<Entry>) -> Mode {
     mode.install_func(String::from("/help"), help);
     mode.install_func(String::from("/exit"), exit);
     mode.install_func(String::from("/show"), show);
+    // Same operator command as exec mode. Without this, `show version`
+    // in configure mode falls through to the RedirectShow path, where
+    // no protocol-show handler claims it and the output is silently
+    // empty.
+    mode.install_func(String::from("/show/version"), show_version);
     mode.install_func(String::from("/candidate"), candidate);
     mode.install_func(String::from("/running"), running);
     mode.install_func(String::from("/json"), json);


### PR DESCRIPTION
## Summary

`show version` worked in exec mode but produced empty output in configure mode. The exec-mode `fmap` had `/show/version` registered; the configure-mode `fmap` only had a bare `/show` catchall. Missing fmap entry made the parser fall through to the `RedirectShow` path, where no protocol-show handler (BGP / OSPF / RIB / policy / …) claimed it — version isn't a protocol-level command — so the response was silently empty.

`/show/version` is the only asymmetric `/show/*` command. Every other `/show/*` path lives in the mode-independent protocol-show registry and already worked in both modes.

## Reproducer

Before:
```
$ vty
s> show version
zebra-rs version 26.5.1 (428e02f7)
Build Date: 2026-05-16 00:34:12 UTC
s> configure
s# show version
s#
```

After: `show version` in configure mode prints the same banner as in exec mode.

## Test plan

- [x] `cargo build` clean
- [x] `cargo fmt --all` applied
- [ ] Live: `show version` in configure mode prints the version banner

## Related findings (not fixed here)

While auditing, three `/show/*` paths in `yang/exec.yang` have no handler in either registry and produce empty output in both modes:

- `/show/hostname`
- `/show/bgp/update-group` (note: `bgp`, not `ip/bgp`)
- `/show/ipv6/prefix`

These are equally broken in both modes — distinct from the asymmetry this PR fixes — and worth a follow-up if they're actually used.

Generated with [Claude Code](https://claude.com/claude-code)