### PR TITLE
rib: wire up /show/hostname

### DIFF
--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1060,7 +1060,17 @@ impl Rib {
         self.show_add("/show/l2/neighbor", l2_neighbor_show);
         self.show_add("/show/segment-routing/srv6/sid", sid_show);
         self.show_add("/show/vrf", vrf_show);
+        self.show_add("/show/hostname", hostname_show);
     }
+}
+
+pub fn hostname_show(_rib: &Rib, _args: Args, _json: bool) -> String {
+    hostname::get()
+        .ok()
+        .and_then(|s| s.into_string().ok())
+        .filter(|s| !s.is_empty())
+        .map(|s| format!("{s}\n"))
+        .unwrap_or_else(|| "unknown\n".to_string())
 }
 
 pub fn vrf_show(rib: &Rib, _args: Args, _json: bool) -> String {


### PR DESCRIPTION
## Summary

`/show/hostname` was declared in `yang/exec.yang` but had no handler in either registry, so it silently returned empty output in both exec and configure modes. Register a `hostname_show` callback in RIB's protocol-show registry — the same registry that already backs `/show/interface`, `/show/vrf`, etc. — so the command works in both modes.

The handler reuses the `hostname::get()` + `into_string()` + non-empty filter pattern already used by `Bgp::hostname()` in `bgp/inst.rs:241`. Falls back to the literal `unknown` when the OS hostname is unset or non-UTF-8.

## Test plan

- [x] `cargo build` clean
- [x] `cargo fmt --all` applied
- [ ] Live: `show hostname` prints the OS hostname in both exec and configure modes

Generated with [Claude Code](https://claude.com/claude-code)