### PR TITLE
bgp: rename `show ip bgp l2vpn evpn` to `show ip bgp evpn`

### DIFF
--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1787,7 +1787,7 @@ fn show_evpn_ecom(attr: &BgpAttr) -> String {
         .join(" ")
 }
 
-fn show_bgp_l2vpn_evpn(
+fn show_bgp_evpn(
     bgp: &Bgp,
     _args: Args,
     json: bool,
@@ -2019,7 +2019,7 @@ impl Bgp {
             show_bgp_received_vpnv4,
         );
         self.show_add("/show/ip/bgp/neighbors/rtcv4", show_bgp_rtcv4);
-        self.show_add("/show/ip/bgp/l2vpn/evpn", show_bgp_l2vpn_evpn);
+        self.show_add("/show/ip/bgp/evpn", show_bgp_evpn);
         // self.show_add("/show/community-list", show_community_list);
         self.show_add("/show/ip/bgp/attributes", show_bgp_attributes);
         self.show_add("/show/evpn/vni/all", show_evpn_vni_all);

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -122,11 +122,9 @@ module exec {
             type inet:ipv4-address;
           }
         }
-        container l2vpn {
-          presence "BGP L2VPN RIB";
-          leaf evpn {
-            type empty;
-          }
+        leaf evpn {
+          ext:help "BGP EVPN RIB";
+          type empty;
         }
         leaf summary {
           ext:help "BGP summary information";


### PR DESCRIPTION
## Summary
- Flatten EVPN show command: drop the `l2vpn` container in `yang/exec.yang` and expose `evpn` as a direct leaf under `container bgp` (with `ext:help "BGP EVPN RIB"`).
- Rename the handler `show_bgp_l2vpn_evpn` → `show_bgp_evpn` and update the registered path from `/show/ip/bgp/l2vpn/evpn` to `/show/ip/bgp/evpn`.

## Test plan
- [ ] `cargo build --release` succeeds
- [ ] `show ip bgp evpn` is reachable from both exec and configure modes
- [ ] `show ip bgp l2vpn evpn` no longer parses (old path removed)

Generated with [Claude Code](https://claude.com/claude-code)