### PR TITLE
bgp: show next idle hold timer value in `show ip bgp neighbor`

### DIFF
--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1103,6 +1103,7 @@ struct Neighbor<'a> {
     hold_timer_rem: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     idle_hold_timer_rem: Option<u64>,
+    idle_hold_timer_next: u64,
     #[serde(skip_serializing)]
     cap_send: BgpCap,
     #[serde(skip_serializing)]
@@ -1215,6 +1216,16 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
     let keepalive_timer_rem = peer.timer.keepalive.as_ref().map(|t| t.rem_sec());
     let hold_timer_rem = peer.timer.hold_timer.as_ref().map(|t| t.rem_sec());
     let idle_hold_timer_rem = peer.timer.idle_hold_timer.as_ref().map(|t| t.rem_sec());
+    // "Next idle hold timer value" — if a timer is currently running,
+    // report the value it was started with (its full duration);
+    // otherwise report the configured (or default) idle-hold-time
+    // that the next idle hold timer would be set to.
+    let idle_hold_timer_next = peer
+        .timer
+        .idle_hold_timer
+        .as_ref()
+        .map(|t| t.duration_sec())
+        .unwrap_or_else(|| peer.config.timer.idle_hold_time());
 
     let mut n = Neighbor {
         address: peer.address,
@@ -1231,6 +1242,7 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         keepalive_timer_rem,
         hold_timer_rem,
         idle_hold_timer_rem,
+        idle_hold_timer_next,
         cap_send: peer.cap_send.clone(),
         cap_recv: peer.cap_recv.clone(),
         cap_map: peer.cap_map.clone(),
@@ -1303,6 +1315,11 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
     if let Some(hold_rem) = neighbor.hold_timer_rem {
         writeln!(out, "  Next hold timer expires in {} seconds", hold_rem)?;
     }
+    writeln!(
+        out,
+        "  Next idle hold timer value {} seconds",
+        neighbor.idle_hold_timer_next
+    )?;
     if let Some(idle_hold_rem) = neighbor.idle_hold_timer_rem {
         writeln!(
             out,

--- a/zebra-rs/src/context/task.rs
+++ b/zebra-rs/src/context/task.rs
@@ -139,4 +139,9 @@ impl Timer {
             (self.duration - elapsed).as_secs()
         }
     }
+
+    /// Get the timer's full duration in seconds (the value it was set to)
+    pub fn duration_sec(&self) -> u64 {
+        self.duration.as_secs()
+    }
 }


### PR DESCRIPTION
## Summary
- Add `Timer::duration_sec()` accessor to expose a timer's full configured duration.
- Add a new `idle_hold_timer_next` field to the neighbor show payload — value is the running idle-hold-timer's full duration when active, otherwise the configured (or default) `idle-hold-time` that the next idle hold timer would be set to.
- Render a new `Next idle hold timer value <N> seconds` line above the existing `expires in` line.

## Test plan
- [ ] `show ip bgp neighbor` now displays the idle-hold-timer value for idle peers (in addition to remaining time when running).
- [ ] JSON output exposes the new `idle_hold_timer_next` field.
- [ ] `cargo build --release` succeeds.

Generated with [Claude Code](https://claude.com/claude-code)