### PR TITLE
vty: abstract Unix-socket transport with SO_PEERCRED allow-list

### DIFF
--- a/vtyctl/Cargo.toml
+++ b/vtyctl/Cargo.toml
@@ -11,6 +11,8 @@ tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
 tonic-prost.workspace = true
+tower = { version = "0.5", default-features = false, features = ["util"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
 
 # MCP server dependencies
 serde = { version = "1.0", features = ["derive"] }

--- a/vtyctl/src/apply.rs
+++ b/vtyctl/src/apply.rs
@@ -15,7 +15,7 @@ fn print_help() {
     eprintln!("vtyctl apply must specify -f or --filename.");
 }
 
-pub async fn apply(host: &String, filename: &String, command: Option<&String>) -> Result<()> {
+pub async fn apply(host: &str, filename: &str, command: Option<&String>) -> Result<()> {
     let mut vec = Vec::new();
     if let Some(cmd) = command {
         // The shell hands us the two-character literal `\n` (not a

--- a/vtyctl/src/apply.rs
+++ b/vtyctl/src/apply.rs
@@ -54,11 +54,15 @@ pub async fn apply(host: &String, filename: &String, command: Option<&String>) -
         exit(1);
     }
 
-    let client = ApplyClient::connect(format!("http://{}:{}", host, 2666)).await;
-    let Ok(mut client) = client else {
-        eprintln!("Can't connect to {}", host);
-        exit(3);
+    let uri = crate::endpoint::host_uri(host);
+    let channel = match crate::endpoint::connect(&uri).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Can't connect to {uri}: {e}");
+            exit(3);
+        }
     };
+    let mut client = ApplyClient::new(channel);
 
     let requests = tokio_stream::iter(vec);
 

--- a/vtyctl/src/clear.rs
+++ b/vtyctl/src/clear.rs
@@ -18,11 +18,15 @@ pub async fn clear(host: &str, command: &str) -> Result<()> {
     }
 
     // Phase 1: Call Exec::do_exec to get paths
-    let exec_client = ExecClient::connect(format!("http://{}:{}", host, 2666)).await;
-    let Ok(mut exec_client) = exec_client else {
-        eprintln!("Can't connect to {}", host);
-        exit(3);
+    let uri = crate::endpoint::host_uri(host);
+    let channel = match crate::endpoint::connect(&uri).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Can't connect to {uri}: {e}");
+            exit(3);
+        }
     };
+    let mut exec_client = ExecClient::new(channel.clone());
 
     let exec_request = ExecRequest {
         r#type: ExecType::Exec as i32,
@@ -37,11 +41,7 @@ pub async fn clear(host: &str, command: &str) -> Result<()> {
     let reply = exec_reply.into_inner();
 
     // Phase 2: Use the paths from exec_reply in ClearRequest
-    let clear_client = ClearClient::connect(format!("http://{}:{}", host, 2666)).await;
-    let Ok(mut clear_client) = clear_client else {
-        eprintln!("Can't connect to {} for clear service", host);
-        exit(3);
-    };
+    let mut clear_client = ClearClient::new(channel);
 
     let request = ClearRequest {
         line: command.to_string(),

--- a/vtyctl/src/endpoint.rs
+++ b/vtyctl/src/endpoint.rs
@@ -5,9 +5,9 @@ use tonic::transport::{Channel, Endpoint};
 ///
 /// Accepts:
 /// - bare hostname/IP (`127.0.0.1`) — becomes `http://127.0.0.1:2666`
-/// - `unix-abstract:NAME`, `tcp://…`, `http://…`, `https://…` — used as-is
+/// - `unix:NAME`, `tcp://…`, `http://…`, `https://…` — used as-is
 pub fn host_uri(host: &str) -> String {
-    if host.starts_with("unix-abstract:") || host.contains("://") {
+    if host.starts_with("unix:") || host.contains("://") {
         host.to_string()
     } else {
         format!("http://{host}:2666")
@@ -19,10 +19,10 @@ pub fn host_uri(host: &str) -> String {
 /// Supported URI forms:
 /// - `http://host:port` / `https://host:port` — TCP via tonic Endpoint
 /// - `tcp://host:port` — alias for `http://host:port`
-/// - `unix-abstract:NAME` — Linux abstract Unix socket (e.g. `unix-abstract:zebra-rs/vty`)
+/// - `unix:NAME` — Linux abstract Unix socket (e.g. `unix:zebra-rs/vty`)
 pub async fn connect(uri: &str) -> Result<Channel> {
     #[cfg(target_os = "linux")]
-    if let Some(name) = uri.strip_prefix("unix-abstract:") {
+    if let Some(name) = uri.strip_prefix("unix:") {
         return connect_abstract(name).await;
     }
     let normalized = if let Some(rest) = uri.strip_prefix("tcp://") {
@@ -47,7 +47,7 @@ async fn connect_abstract(name: &str) -> Result<Channel> {
 
     let name = name.trim_start_matches('@').to_string();
     if name.is_empty() {
-        return Err(anyhow!("unix-abstract name must be non-empty"));
+        return Err(anyhow!("unix name must be non-empty"));
     }
     let name_for_err = name.clone();
     // The endpoint URI is a placeholder; the connector ignores it and dials
@@ -65,5 +65,5 @@ async fn connect_abstract(name: &str) -> Result<Channel> {
             }
         }))
         .await
-        .map_err(|e| anyhow!("connect unix-abstract:{name_for_err}: {e}"))
+        .map_err(|e| anyhow!("connect unix:{name_for_err}: {e}"))
 }

--- a/vtyctl/src/endpoint.rs
+++ b/vtyctl/src/endpoint.rs
@@ -1,0 +1,69 @@
+use anyhow::{Result, anyhow};
+use tonic::transport::{Channel, Endpoint};
+
+/// Normalize the `--host` flag into a full endpoint URI.
+///
+/// Accepts:
+/// - bare hostname/IP (`127.0.0.1`) — becomes `http://127.0.0.1:2666`
+/// - `unix-abstract:NAME`, `tcp://…`, `http://…`, `https://…` — used as-is
+pub fn host_uri(host: &str) -> String {
+    if host.starts_with("unix-abstract:") || host.contains("://") {
+        host.to_string()
+    } else {
+        format!("http://{host}:2666")
+    }
+}
+
+/// Connect to the zebra-rs VTY gRPC server.
+///
+/// Supported URI forms:
+/// - `http://host:port` / `https://host:port` — TCP via tonic Endpoint
+/// - `tcp://host:port` — alias for `http://host:port`
+/// - `unix-abstract:NAME` — Linux abstract Unix socket (e.g. `unix-abstract:zebra-rs/vty`)
+pub async fn connect(uri: &str) -> Result<Channel> {
+    #[cfg(target_os = "linux")]
+    if let Some(name) = uri.strip_prefix("unix-abstract:") {
+        return connect_abstract(name).await;
+    }
+    let normalized = if let Some(rest) = uri.strip_prefix("tcp://") {
+        format!("http://{rest}")
+    } else {
+        uri.to_string()
+    };
+    Endpoint::try_from(normalized.clone())
+        .map_err(|e| anyhow!("invalid endpoint {normalized:?}: {e}"))?
+        .connect()
+        .await
+        .map_err(|e| anyhow!("connect {normalized}: {e}"))
+}
+
+#[cfg(target_os = "linux")]
+async fn connect_abstract(name: &str) -> Result<Channel> {
+    use hyper_util::rt::TokioIo;
+    use std::os::linux::net::SocketAddrExt;
+    use std::os::unix::net::{SocketAddr as StdSockAddr, UnixStream as StdUnixStream};
+    use tokio::net::UnixStream;
+    use tower::service_fn;
+
+    let name = name.trim_start_matches('@').to_string();
+    if name.is_empty() {
+        return Err(anyhow!("unix-abstract name must be non-empty"));
+    }
+    let name_for_err = name.clone();
+    // The endpoint URI is a placeholder; the connector ignores it and dials
+    // the abstract Unix socket each time tonic calls it.
+    Endpoint::try_from("http://[::]:50051")?
+        .connect_with_connector(service_fn(move |_: tonic::transport::Uri| {
+            let name = name.clone();
+            async move {
+                let addr = StdSockAddr::from_abstract_name(name.as_bytes())
+                    .map_err(std::io::Error::other)?;
+                let std = StdUnixStream::connect_addr(&addr)?;
+                std.set_nonblocking(true)?;
+                let stream = UnixStream::from_std(std)?;
+                Ok::<_, std::io::Error>(TokioIo::new(stream))
+            }
+        }))
+        .await
+        .map_err(|e| anyhow!("connect unix-abstract:{name_for_err}: {e}"))
+}

--- a/vtyctl/src/main.rs
+++ b/vtyctl/src/main.rs
@@ -6,6 +6,7 @@ pub mod vty {
 }
 pub mod apply;
 pub mod clear;
+pub mod endpoint;
 pub mod mcp;
 pub mod show;
 

--- a/vtyctl/src/main.rs
+++ b/vtyctl/src/main.rs
@@ -21,7 +21,7 @@ struct Cli {
 enum Commands {
     #[command(disable_help_flag = true)]
     Apply {
-        #[arg(short, long, default_value = "127.0.0.1")]
+        #[arg(short, long, default_value = "unix:zebra-rs/vty")]
         host: String,
 
         #[arg(short, long, help = "Config filename", default_value = "")]
@@ -32,7 +32,7 @@ enum Commands {
     },
     #[command(disable_help_flag = true)]
     Clear {
-        #[arg(short, long, default_value = "127.0.0.1")]
+        #[arg(short, long, default_value = "unix:zebra-rs/vty")]
         host: String,
 
         #[arg(help = "Clear command to execute")]
@@ -40,7 +40,7 @@ enum Commands {
     },
     #[command(disable_help_flag = true)]
     Show {
-        #[arg(short, long, default_value = "127.0.0.1")]
+        #[arg(short, long, default_value = "unix:zebra-rs/vty")]
         host: String,
 
         #[arg(short, long, help = "Output in JSON format")]
@@ -51,10 +51,15 @@ enum Commands {
     },
     /// Start MCP (Model Context Protocol) server for AI assistant integration
     Mcp {
-        #[arg(short = 'H', long, default_value = "127.0.0.1")]
+        #[arg(short = 'H', long, default_value = "unix:zebra-rs/vty")]
         host: String,
 
-        #[arg(short, long, help = "gRPC server port", default_value = "2666")]
+        #[arg(
+            short,
+            long,
+            help = "gRPC server port (TCP only)",
+            default_value = "2666"
+        )]
         port: u32,
 
         #[arg(short, long, help = "Enable debug logging")]

--- a/vtyctl/src/mcp/client.rs
+++ b/vtyctl/src/mcp/client.rs
@@ -20,10 +20,15 @@ impl ZebraClient {
 
     /// Execute a show command and return the result as JSON
     pub async fn show_command(&self, command: &str, json: bool) -> Result<String> {
-        let endpoint = format!("{}:{}", self.base_url, self.port);
+        let endpoint = if self.base_url.starts_with("unix:") || self.base_url.contains("://") {
+            self.base_url.clone()
+        } else {
+            format!("http://{}:{}", self.base_url, self.port)
+        };
         debug!("Connecting to zebra-rs at {}", endpoint);
 
-        let mut client = ShowClient::connect(endpoint).await?;
+        let channel = crate::endpoint::connect(&endpoint).await?;
+        let mut client = ShowClient::new(channel);
 
         let mut paths = Vec::new();
         let cmds: Vec<&str> = command.split_whitespace().collect();

--- a/vtyctl/src/show.rs
+++ b/vtyctl/src/show.rs
@@ -18,11 +18,15 @@ pub async fn show(host: &str, command: &str, json: bool) -> Result<()> {
     }
 
     // Phase 1: Call Exec::do_exec to get paths
-    let exec_client = ExecClient::connect(format!("http://{}:{}", host, 2666)).await;
-    let Ok(mut exec_client) = exec_client else {
-        eprintln!("Can't connect to {}", host);
-        exit(3);
+    let uri = crate::endpoint::host_uri(host);
+    let channel = match crate::endpoint::connect(&uri).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Can't connect to {uri}: {e}");
+            exit(3);
+        }
     };
+    let mut exec_client = ExecClient::new(channel.clone());
 
     let exec_request = ExecRequest {
         r#type: ExecType::Exec as i32,
@@ -37,11 +41,7 @@ pub async fn show(host: &str, command: &str, json: bool) -> Result<()> {
     let reply = exec_reply.into_inner();
 
     // Phase 2: Use the paths from exec_reply in ShowRequest
-    let show_client = ShowClient::connect(format!("http://{}:{}", host, 2666)).await;
-    let Ok(mut show_client) = show_client else {
-        eprintln!("Can't connect to {} for show service", host);
-        exit(3);
-    };
+    let mut show_client = ShowClient::new(channel);
 
     let request = ShowRequest {
         line: command.to_string(),

--- a/vtyhelper/Cargo.toml
+++ b/vtyhelper/Cargo.toml
@@ -11,6 +11,8 @@ tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
 tonic-prost.workspace = true
+tower = { version = "0.5", default-features = false, features = ["util"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
 
 [build-dependencies]
 tonic-prost-build.workspace = true

--- a/vtyhelper/src/endpoint.rs
+++ b/vtyhelper/src/endpoint.rs
@@ -1,0 +1,56 @@
+use anyhow::{Result, anyhow};
+use tonic::transport::{Channel, Endpoint};
+
+/// Connect to the zebra-rs VTY gRPC server.
+///
+/// Supported URI forms:
+/// - `http://host:port` / `https://host:port` — TCP via tonic Endpoint
+/// - `tcp://host:port` — alias for `http://host:port`
+/// - `unix-abstract:NAME` — Linux abstract Unix socket (e.g. `unix-abstract:zebra-rs/vty`)
+pub async fn connect(uri: &str) -> Result<Channel> {
+    #[cfg(target_os = "linux")]
+    if let Some(name) = uri.strip_prefix("unix-abstract:") {
+        return connect_abstract(name).await;
+    }
+    let normalized = if let Some(rest) = uri.strip_prefix("tcp://") {
+        format!("http://{rest}")
+    } else {
+        uri.to_string()
+    };
+    Endpoint::try_from(normalized.clone())
+        .map_err(|e| anyhow!("invalid endpoint {normalized:?}: {e}"))?
+        .connect()
+        .await
+        .map_err(|e| anyhow!("connect {normalized}: {e}"))
+}
+
+#[cfg(target_os = "linux")]
+async fn connect_abstract(name: &str) -> Result<Channel> {
+    use hyper_util::rt::TokioIo;
+    use std::os::linux::net::SocketAddrExt;
+    use std::os::unix::net::{SocketAddr as StdSockAddr, UnixStream as StdUnixStream};
+    use tokio::net::UnixStream;
+    use tower::service_fn;
+
+    let name = name.trim_start_matches('@').to_string();
+    if name.is_empty() {
+        return Err(anyhow!("unix-abstract name must be non-empty"));
+    }
+    let name_for_err = name.clone();
+    // The endpoint URI is a placeholder; the connector ignores it and dials
+    // the abstract Unix socket each time tonic calls it.
+    Endpoint::try_from("http://[::]:50051")?
+        .connect_with_connector(service_fn(move |_: tonic::transport::Uri| {
+            let name = name.clone();
+            async move {
+                let addr = StdSockAddr::from_abstract_name(name.as_bytes())
+                    .map_err(std::io::Error::other)?;
+                let std = StdUnixStream::connect_addr(&addr)?;
+                std.set_nonblocking(true)?;
+                let stream = UnixStream::from_std(std)?;
+                Ok::<_, std::io::Error>(TokioIo::new(stream))
+            }
+        }))
+        .await
+        .map_err(|e| anyhow!("connect unix-abstract:{name_for_err}: {e}"))
+}

--- a/vtyhelper/src/endpoint.rs
+++ b/vtyhelper/src/endpoint.rs
@@ -6,10 +6,10 @@ use tonic::transport::{Channel, Endpoint};
 /// Supported URI forms:
 /// - `http://host:port` / `https://host:port` — TCP via tonic Endpoint
 /// - `tcp://host:port` — alias for `http://host:port`
-/// - `unix-abstract:NAME` — Linux abstract Unix socket (e.g. `unix-abstract:zebra-rs/vty`)
+/// - `unix:NAME` — Linux abstract Unix socket (e.g. `unix:zebra-rs/vty`)
 pub async fn connect(uri: &str) -> Result<Channel> {
     #[cfg(target_os = "linux")]
-    if let Some(name) = uri.strip_prefix("unix-abstract:") {
+    if let Some(name) = uri.strip_prefix("unix:") {
         return connect_abstract(name).await;
     }
     let normalized = if let Some(rest) = uri.strip_prefix("tcp://") {
@@ -34,7 +34,7 @@ async fn connect_abstract(name: &str) -> Result<Channel> {
 
     let name = name.trim_start_matches('@').to_string();
     if name.is_empty() {
-        return Err(anyhow!("unix-abstract name must be non-empty"));
+        return Err(anyhow!("unix name must be non-empty"));
     }
     let name_for_err = name.clone();
     // The endpoint URI is a placeholder; the connector ignores it and dials
@@ -52,5 +52,5 @@ async fn connect_abstract(name: &str) -> Result<Channel> {
             }
         }))
         .await
-        .map_err(|e| anyhow!("connect unix-abstract:{name_for_err}: {e}"))
+        .map_err(|e| anyhow!("connect unix:{name_for_err}: {e}"))
 }

--- a/vtyhelper/src/main.rs
+++ b/vtyhelper/src/main.rs
@@ -7,6 +7,8 @@ use vty::exec_client::ExecClient;
 use vty::show_client::ShowClient;
 use vty::{CommandPath, ExecCode, ExecReply, ExecRequest, ExecType, ShowRequest};
 
+mod endpoint;
+
 pub mod vty {
     tonic::include_proto!("vty");
 }
@@ -53,6 +55,24 @@ fn privilege_get() -> u32 {
     }
 }
 
+/// Build the endpoint URI from the parsed CLI.
+///
+/// `--base` may already be a full URI (`unix-abstract:…`, `tcp://host:port`,
+/// `http://host:port`) — in which case `--port` is ignored. Otherwise the
+/// legacy `{base}:{port}` concatenation is used, matching the historical
+/// `http://127.0.0.1` + `2666` defaults.
+fn endpoint_uri(base: &str, port: u32) -> String {
+    if base.starts_with("unix-abstract:")
+        || base.starts_with("tcp://")
+        || base.starts_with("http://") && base.matches(':').count() >= 2
+        || base.starts_with("https://") && base.matches(':').count() >= 2
+    {
+        base.to_string()
+    } else {
+        format!("{base}:{port}")
+    }
+}
+
 fn output(reply: ExecReply) {
     if reply.code == ExecCode::Show as i32 {
         println!("Show");
@@ -89,7 +109,8 @@ fn exec_request(exec_type: i32, mode: &String, commands: &Vec<String>) -> ExecRe
 
 async fn show(cli: Cli, port: Option<u32>, paths: Vec<CommandPath>) -> Result<()> {
     let port = port.unwrap_or(cli.port);
-    let mut client = ShowClient::connect(format!("{}:{}", cli.base, port)).await?;
+    let channel = endpoint::connect(&endpoint_uri(&cli.base, port)).await?;
+    let mut client = ShowClient::new(channel);
 
     let commands = commands_trim_run(&cli.commands);
     let request = tonic::Request::new(ShowRequest {
@@ -112,7 +133,8 @@ async fn show(cli: Cli, port: Option<u32>, paths: Vec<CommandPath>) -> Result<()
 }
 
 async fn completion(cli: Cli) -> Result<()> {
-    let mut client = ExecClient::connect(format!("{}:{}", cli.base, cli.port)).await?;
+    let channel = endpoint::connect(&endpoint_uri(&cli.base, cli.port)).await?;
+    let mut client = ExecClient::new(channel);
 
     let exec_type: i32 = if cli.completion {
         ExecType::Complete as i32
@@ -132,7 +154,8 @@ async fn completion(cli: Cli) -> Result<()> {
 }
 
 async fn redirect(cli: Cli, port: u32) -> Result<()> {
-    let mut client = ExecClient::connect(format!("{}:{}", cli.base, port)).await?;
+    let channel = endpoint::connect(&endpoint_uri(&cli.base, port)).await?;
+    let mut client = ExecClient::new(channel);
 
     let commands = commands_trim_run(&cli.commands);
     let request = tonic::Request::new(exec_request(ExecType::Exec as i32, &cli.mode, &commands));
@@ -144,7 +167,8 @@ async fn redirect(cli: Cli, port: u32) -> Result<()> {
 }
 
 async fn exec(cli: Cli) -> Result<()> {
-    let mut client = ExecClient::connect(format!("{}:{}", cli.base, cli.port)).await?;
+    let channel = endpoint::connect(&endpoint_uri(&cli.base, cli.port)).await?;
+    let mut client = ExecClient::new(channel);
 
     let request = tonic::Request::new(exec_request(
         ExecType::Exec as i32,

--- a/vtyhelper/src/main.rs
+++ b/vtyhelper/src/main.rs
@@ -40,8 +40,9 @@ struct Cli {
     #[arg(
         short,
         long,
-        help = "Base URL of the server",
-        default_value = "http://127.0.0.1"
+        help = "Server endpoint URI (unix:NAME, tcp://host:port, http://host:port). \
+                Bare host like 'http://127.0.0.1' is combined with --port for backward compat.",
+        default_value = "unix:zebra-rs/vty"
     )]
     base: String,
 

--- a/vtyhelper/src/main.rs
+++ b/vtyhelper/src/main.rs
@@ -57,12 +57,12 @@ fn privilege_get() -> u32 {
 
 /// Build the endpoint URI from the parsed CLI.
 ///
-/// `--base` may already be a full URI (`unix-abstract:…`, `tcp://host:port`,
+/// `--base` may already be a full URI (`unix:…`, `tcp://host:port`,
 /// `http://host:port`) — in which case `--port` is ignored. Otherwise the
 /// legacy `{base}:{port}` concatenation is used, matching the historical
 /// `http://127.0.0.1` + `2666` defaults.
 fn endpoint_uri(base: &str, port: u32) -> String {
-    if base.starts_with("unix-abstract:")
+    if base.starts_with("unix:")
         || base.starts_with("tcp://")
         || base.starts_with("http://") && base.matches(':').count() >= 2
         || base.starts_with("https://") && base.matches(':').count() >= 2

--- a/zebra-rs/src/config/mod.rs
+++ b/zebra-rs/src/config/mod.rs
@@ -10,6 +10,7 @@ pub use manager::event_loop;
 
 mod serve;
 pub use serve::Cli;
+pub use serve::VtyAddr;
 pub use serve::serve;
 
 mod configs;

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use tokio::sync::mpsc::{Sender, UnboundedSender};
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::{StreamExt, wrappers::ReceiverStream};
@@ -321,7 +322,46 @@ impl Apply for ApplyService {
     }
 }
 
-pub fn serve(cli: Cli) {
+/// VTY gRPC listen endpoint.
+///
+/// `AbstractUds` uses a Linux abstract Unix socket whose name is scoped by the
+/// process network namespace, which is the isolation primitive we rely on for
+/// per-netns zebra-rs deployments.
+#[derive(Debug, Clone)]
+pub enum VtyAddr {
+    Tcp(SocketAddr),
+    #[cfg(target_os = "linux")]
+    AbstractUds(String),
+}
+
+impl VtyAddr {
+    pub fn parse(s: &str) -> anyhow::Result<Self> {
+        if let Some(rest) = s.strip_prefix("tcp:") {
+            let addr: SocketAddr = rest
+                .parse()
+                .map_err(|e| anyhow::anyhow!("invalid tcp address {rest:?}: {e}"))?;
+            return Ok(Self::Tcp(addr));
+        }
+        if let Some(rest) = s.strip_prefix("unix-abstract:") {
+            #[cfg(target_os = "linux")]
+            {
+                let name = rest.trim_start_matches('@').to_string();
+                if name.is_empty() {
+                    anyhow::bail!("unix-abstract name must be non-empty");
+                }
+                return Ok(Self::AbstractUds(name));
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                let _ = rest;
+                anyhow::bail!("unix-abstract sockets are only supported on Linux");
+            }
+        }
+        anyhow::bail!("--vty-socket must start with 'tcp:' or 'unix-abstract:'");
+    }
+}
+
+pub fn serve(cli: Cli, addr: VtyAddr) -> anyhow::Result<()> {
     let exec_service = ExecService { tx: cli.tx.clone() };
     let exec_server = ExecServer::new(exec_service);
 
@@ -334,15 +374,43 @@ pub fn serve(cli: Cli) {
     let clear_service = ClearService { tx: cli.tx.clone() };
     let clear_server = ClearServer::new(clear_service);
 
-    let addr = "0.0.0.0:2666".parse().unwrap();
+    let builder = Server::builder()
+        .add_service(exec_server)
+        .add_service(show_server)
+        .add_service(apply_server)
+        .add_service(clear_server);
 
-    tokio::spawn(async move {
-        Server::builder()
-            .add_service(exec_server)
-            .add_service(show_server)
-            .add_service(apply_server)
-            .add_service(clear_server)
-            .serve(addr)
-            .await
-    });
+    match addr {
+        VtyAddr::Tcp(addr) => {
+            tracing::info!("VTY gRPC listening on tcp://{addr}");
+            tokio::spawn(async move { builder.serve(addr).await });
+        }
+        #[cfg(target_os = "linux")]
+        VtyAddr::AbstractUds(name) => {
+            let incoming = bind_abstract_uds(&name)?;
+            tracing::info!("VTY gRPC listening on abstract UDS @{name}");
+            tokio::spawn(async move { builder.serve_with_incoming(incoming).await });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn bind_abstract_uds(name: &str) -> anyhow::Result<tokio_stream::wrappers::UnixListenerStream> {
+    use std::os::linux::net::SocketAddrExt;
+    use std::os::unix::net::SocketAddr as StdSockAddr;
+    use std::os::unix::net::UnixListener as StdUnixListener;
+    use tokio::net::UnixListener;
+    use tokio_stream::wrappers::UnixListenerStream;
+
+    let addr = StdSockAddr::from_abstract_name(name.as_bytes())
+        .map_err(|e| anyhow::anyhow!("from_abstract_name: {e}"))?;
+    let std_listener =
+        StdUnixListener::bind_addr(&addr).map_err(|e| anyhow::anyhow!("bind_addr: {e}"))?;
+    std_listener
+        .set_nonblocking(true)
+        .map_err(|e| anyhow::anyhow!("set_nonblocking: {e}"))?;
+    let listener =
+        UnixListener::from_std(std_listener).map_err(|e| anyhow::anyhow!("from_std: {e}"))?;
+    Ok(UnixListenerStream::new(listener))
 }

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -342,22 +342,22 @@ impl VtyAddr {
                 .map_err(|e| anyhow::anyhow!("invalid tcp address {rest:?}: {e}"))?;
             return Ok(Self::Tcp(addr));
         }
-        if let Some(rest) = s.strip_prefix("unix-abstract:") {
+        if let Some(rest) = s.strip_prefix("unix:") {
             #[cfg(target_os = "linux")]
             {
                 let name = rest.trim_start_matches('@').to_string();
                 if name.is_empty() {
-                    anyhow::bail!("unix-abstract name must be non-empty");
+                    anyhow::bail!("unix name must be non-empty");
                 }
                 return Ok(Self::AbstractUds(name));
             }
             #[cfg(not(target_os = "linux"))]
             {
                 let _ = rest;
-                anyhow::bail!("unix-abstract sockets are only supported on Linux");
+                anyhow::bail!("unix sockets are only supported on Linux");
             }
         }
-        anyhow::bail!("--vty-socket must start with 'tcp:' or 'unix-abstract:'");
+        anyhow::bail!("--vty-socket must start with 'tcp:' or 'unix:'");
     }
 }
 

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -1,5 +1,6 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
+use std::sync::Arc;
 use tokio::sync::mpsc::{Sender, UnboundedSender};
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::{StreamExt, wrappers::ReceiverStream};
@@ -361,24 +362,86 @@ impl VtyAddr {
     }
 }
 
+/// Per-RPC interceptor that surfaces peer identity from SO_PEERCRED.
+///
+/// Behaviour for PR3 is **log-only**: every UDS request gets a tracing event
+/// with uid/pid, and an optional `ZEBRA_VTY_ALLOW_UIDS` allow-list produces
+/// warnings for non-matching peers but does not actually reject them. PR4
+/// will turn the warning into a `Status::permission_denied`.
+#[derive(Clone)]
+struct VtyPeerInterceptor {
+    allow_uids: Option<Arc<HashSet<u32>>>,
+}
+
+impl VtyPeerInterceptor {
+    fn from_env() -> Self {
+        let allow_uids = std::env::var("ZEBRA_VTY_ALLOW_UIDS").ok().and_then(|raw| {
+            let set: HashSet<u32> = raw
+                .split(',')
+                .filter_map(|s| s.trim().parse::<u32>().ok())
+                .collect();
+            if set.is_empty() {
+                None
+            } else {
+                Some(Arc::new(set))
+            }
+        });
+        Self { allow_uids }
+    }
+}
+
+impl tonic::service::Interceptor for VtyPeerInterceptor {
+    fn call(&mut self, req: tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> {
+        #[cfg(target_os = "linux")]
+        if let Some(info) = req
+            .extensions()
+            .get::<tonic::transport::server::UdsConnectInfo>()
+            && let Some(cred) = &info.peer_cred
+        {
+            let uid = cred.uid();
+            let gid = cred.gid();
+            let pid = cred.pid().unwrap_or(-1);
+            match &self.allow_uids {
+                Some(allowed) if !allowed.contains(&uid) => {
+                    tracing::warn!(
+                        uid,
+                        gid,
+                        pid,
+                        "vty rpc from peer not in ZEBRA_VTY_ALLOW_UIDS (would deny)"
+                    );
+                }
+                _ => tracing::info!(uid, gid, pid, "vty rpc"),
+            }
+        }
+        Ok(req)
+    }
+}
+
 pub fn serve(cli: Cli, addr: VtyAddr) -> anyhow::Result<()> {
     let exec_service = ExecService { tx: cli.tx.clone() };
-    let exec_server = ExecServer::new(exec_service);
-
     let show_service = ShowService { tx: cli.tx.clone() };
-    let show_server = ShowServer::new(show_service);
-
     let apply_service = ApplyService { tx: cli.tx.clone() };
-    let apply_server = ApplyServer::new(apply_service);
-
     let clear_service = ClearService { tx: cli.tx.clone() };
-    let clear_server = ClearServer::new(clear_service);
+
+    let interceptor = VtyPeerInterceptor::from_env();
+    if let Some(set) = &interceptor.allow_uids {
+        tracing::info!(uids = ?set, "VTY peer UID allow-list active (log-only)");
+    }
 
     let builder = Server::builder()
-        .add_service(exec_server)
-        .add_service(show_server)
-        .add_service(apply_server)
-        .add_service(clear_server);
+        .add_service(ExecServer::with_interceptor(
+            exec_service,
+            interceptor.clone(),
+        ))
+        .add_service(ShowServer::with_interceptor(
+            show_service,
+            interceptor.clone(),
+        ))
+        .add_service(ApplyServer::with_interceptor(
+            apply_service,
+            interceptor.clone(),
+        ))
+        .add_service(ClearServer::with_interceptor(clear_service, interceptor));
 
     match addr {
         VtyAddr::Tcp(addr) => {

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -364,10 +364,10 @@ impl VtyAddr {
 
 /// Per-RPC interceptor that surfaces peer identity from SO_PEERCRED.
 ///
-/// Behaviour for PR3 is **log-only**: every UDS request gets a tracing event
-/// with uid/pid, and an optional `ZEBRA_VTY_ALLOW_UIDS` allow-list produces
-/// warnings for non-matching peers but does not actually reject them. PR4
-/// will turn the warning into a `Status::permission_denied`.
+/// Logs uid/gid/pid for every UDS request. When the optional
+/// `ZEBRA_VTY_ALLOW_UIDS` env var is set (comma-separated UID list), peers
+/// outside the list are rejected with `Status::permission_denied`. When the
+/// env var is unset, every peer is allowed (logged only).
 #[derive(Clone)]
 struct VtyPeerInterceptor {
     allow_uids: Option<Arc<HashSet<u32>>>,
@@ -403,12 +403,10 @@ impl tonic::service::Interceptor for VtyPeerInterceptor {
             let pid = cred.pid().unwrap_or(-1);
             match &self.allow_uids {
                 Some(allowed) if !allowed.contains(&uid) => {
-                    tracing::warn!(
-                        uid,
-                        gid,
-                        pid,
-                        "vty rpc from peer not in ZEBRA_VTY_ALLOW_UIDS (would deny)"
-                    );
+                    tracing::warn!(uid, gid, pid, "vty rpc denied: uid not in allow-list");
+                    return Err(tonic::Status::permission_denied(format!(
+                        "uid {uid} is not permitted to use the VTY"
+                    )));
                 }
                 _ => tracing::info!(uid, gid, pid, "vty rpc"),
             }

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -62,6 +62,13 @@ struct Arg {
         help = "Write PID to this file on startup; in --daemon mode replaces /var/run/zebra-rs.pid"
     )]
     pid_file: Option<String>,
+
+    #[arg(
+        long,
+        help = "VTY gRPC listen address. Forms: tcp:HOST:PORT or unix-abstract:NAME (Linux only)",
+        default_value = "tcp:0.0.0.0:2666"
+    )]
+    vty_socket: String,
 }
 
 // 1. Option Yang path
@@ -164,7 +171,8 @@ async fn main() -> anyhow::Result<()> {
 
     let cli = Cli::new(config.tx.clone());
 
-    config::serve(cli);
+    let vty_addr = config::VtyAddr::parse(&arg.vty_socket)?;
+    config::serve(cli, vty_addr)?;
 
     policy::serve(policy);
 

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -65,7 +65,7 @@ struct Arg {
 
     #[arg(
         long,
-        help = "VTY gRPC listen address. Forms: tcp:HOST:PORT or unix-abstract:NAME (Linux only)",
+        help = "VTY gRPC listen address. Forms: tcp:HOST:PORT or unix:NAME (Linux only)",
         default_value = "tcp:0.0.0.0:2666"
     )]
     vty_socket: String,

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -65,8 +65,8 @@ struct Arg {
 
     #[arg(
         long,
-        help = "VTY gRPC listen address. Forms: tcp:HOST:PORT or unix:NAME (Linux only)",
-        default_value = "tcp:0.0.0.0:2666"
+        help = "VTY gRPC listen address. Forms: unix:NAME (Linux abstract socket) or tcp:HOST:PORT",
+        default_value = "unix:zebra-rs/vty"
     )]
     vty_socket: String,
 }


### PR DESCRIPTION
## Summary
Switch the zebra-rs VTY gRPC channel from a public-to-LAN `0.0.0.0:2666` TCP listener to a Linux abstract Unix socket (`@zebra-rs/vty`), so per-netns deployments get free isolation and TCP is no longer the default attack surface.

- Server binds an abstract UDS via `--vty-socket unix:zebra-rs/vty` (now the default). TCP still works via `--vty-socket tcp:HOST:PORT`.
- vtyhelper and vtyctl learn a `unix:NAME` URI form and default to the same socket. Bare `127.0.0.1` / `http://…` forms still work.
- A tonic interceptor reads `UdsConnectInfo` (which tonic already attaches for Unix sockets) and emits `tracing` events with uid/gid/pid for every RPC.
- Optional `ZEBRA_VTY_ALLOW_UIDS` env var (comma-separated UIDs) enforces a peer allow-list with `Status::permission_denied`. Unset = allow-all.

**BREAKING**: the default transport flipped from TCP to UDS. Anyone relying on `0.0.0.0:2666` needs `--vty-socket tcp:0.0.0.0:2666` on the server and a bare hostname / `tcp://…` URI on the clients. The MCP subcommand's `--port` is now TCP-only.

Per-netns usage:
\`\`\`bash
ip netns exec vrf-red zebra-rs &              # binds @zebra-rs/vty inside vrf-red
ip netns exec vrf-red vtyctl show 'show ip route'
\`\`\`
Each netns has its own abstract namespace, so the same socket name in every netns is automatically isolated.

Deferred to follow-ups: systemd templating for per-netns (skipped per discussion) and removal of the TCP code path (skipped — UDS-by-default already captures most of the security benefit).

## Test plan
- [x] \`cargo build --release\` and \`cargo fmt --all -- --check\` clean
- [x] \`cargo test -p zebra-rs -p vtyhelper -p vtyctl\` — 292 passed
- [x] Default-flags end-to-end: \`zebra-rs\` + \`vtyctl show 'show ip route'\` works over \`@zebra-rs/vty\`
- [x] Server log shows \`vty rpc uid=… gid=… pid=…\` per RPC
- [x] \`ZEBRA_VTY_ALLOW_UIDS=99999 zebra-rs\` rejects \`vtyctl\` with \`permission_denied "uid 1000 is not permitted to use the VTY"\`
- [x] \`ZEBRA_VTY_ALLOW_UIDS=\$(id -u) zebra-rs\` allows
- [x] Backward-compat: \`--vty-socket tcp:0.0.0.0:2666\` still binds TCP; \`vtyctl --host 127.0.0.1\` still composes \`http://127.0.0.1:2666\`
- [ ] Per-netns smoke test on a multi-VRF box (requires a real test env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)