### PR TITLE
vty: Phase 6 Logout RPC + bash EXIT trap

### DIFF
--- a/proto/vty.proto
+++ b/proto/vty.proto
@@ -7,6 +7,17 @@ package vty;
 // The Command execution.
 service Exec {
   rpc DoExec(ExecRequest) returns (ExecReply) {}
+  // Released by the vty bash EXIT trap. Drops the caller's session
+  // from the server-side SessionTable so the slot is reclaimed
+  // immediately on a clean shell exit (in parallel with the kernel
+  // pidfd watcher that handles abnormal exits).
+  rpc Logout(LogoutRequest) returns (LogoutReply) {}
+}
+
+message LogoutRequest {}
+
+message LogoutReply {
+  bool ok = 1;
 }
 
 // Command message type.

--- a/vty/additions/vty.sh
+++ b/vty/additions/vty.sh
@@ -319,6 +319,10 @@ if [[ $interactive ]]; then
   _cli_pager_setup
   _cli_bind_key
   _cli_prompt_setup
+  # Tell the daemon to drop our session as soon as the shell exits.
+  # The kernel pidfd watcher also catches this case; the explicit
+  # logout RPC just shaves a moment off the cleanup for clean exits.
+  trap '${cli_command} -l >/dev/null 2>&1 || true' EXIT
 else
   CLI_PAGER="cat"
 fi

--- a/vtyhelper/src/main.rs
+++ b/vtyhelper/src/main.rs
@@ -5,7 +5,7 @@ use tokio::io::{self, AsyncWriteExt};
 use tokio_stream::StreamExt;
 use vty::exec_client::ExecClient;
 use vty::show_client::ShowClient;
-use vty::{CommandPath, ExecCode, ExecReply, ExecRequest, ExecType, ShowRequest};
+use vty::{CommandPath, ExecCode, ExecReply, ExecRequest, ExecType, LogoutRequest, ShowRequest};
 
 mod endpoint;
 
@@ -36,6 +36,13 @@ struct Cli {
 
     #[arg(short, long, help = "Show output in JSON format")]
     json: bool,
+
+    #[arg(
+        short,
+        long,
+        help = "Logout: tear down the server-side session (invoked from vty bash EXIT trap)"
+    )]
+    logout: bool,
 
     #[arg(
         short,
@@ -190,8 +197,20 @@ async fn exec(cli: Cli) -> Result<()> {
     Ok(())
 }
 
+/// Tear down the server-side session. Invoked from the vty bash `EXIT`
+/// trap, so this path is silent on success and on failure — the user's
+/// shell is already exiting and any stdout would be jarring.
+async fn logout(cli: Cli) -> Result<()> {
+    let channel = endpoint::connect(&endpoint_uri(&cli.base, cli.port)).await?;
+    let mut client = ExecClient::new(channel);
+    let _ = client.logout(tonic::Request::new(LogoutRequest {})).await?;
+    Ok(())
+}
+
 async fn run(cli: Cli) -> Result<()> {
-    if cli.show {
+    if cli.logout {
+        logout(cli).await?;
+    } else if cli.show {
         show(cli, None, Vec::new()).await?;
     } else if cli.completion || cli.trailing || cli.first {
         completion(cli).await?;
@@ -207,8 +226,13 @@ async fn main() -> Result<()> {
     if let Ok(val) = env::var("CLI_SERVER_URL") {
         cli.base = val;
     }
+    let logout_mode = cli.logout;
     if let Err(_err) = run(cli).await {
-        println!("dummy\ncommands\n\n");
+        // Logout runs from the bash EXIT trap; staying silent on failure
+        // keeps a tidy shell-exit experience even if the daemon is gone.
+        if !logout_mode {
+            println!("dummy\ncommands\n\n");
+        }
     }
     Ok(())
 }

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -10,8 +10,8 @@ use tonic::transport::Server;
 use crate::config::api::DeployRequest;
 #[cfg(target_os = "linux")]
 use crate::config::session::{
-    DEFAULT_GC_INTERVAL, DEFAULT_IDLE_TTL, ProcfsReader, SessionError, SessionTable, run_gc,
-    watch_bash_death,
+    DEFAULT_GC_INTERVAL, DEFAULT_IDLE_TTL, ProcfsReader, SessionContext, SessionError,
+    SessionTable, run_gc, watch_bash_death,
 };
 
 use super::api::{
@@ -24,11 +24,13 @@ use super::vty::exec_server::{Exec, ExecServer};
 use super::vty::show_server::{Show, ShowServer};
 use super::vty::{
     ApplyReply, ApplyRequest, ClearReply, ClearRequest, CommandPath, ExecCode, ExecReply,
-    ExecRequest, ExecType, ShowReply, ShowRequest, YangMatch,
+    ExecRequest, ExecType, LogoutReply, LogoutRequest, ShowReply, ShowRequest, YangMatch,
 };
 #[derive(Debug)]
 struct ExecService {
     pub tx: mpsc::Sender<Message>,
+    #[cfg(target_os = "linux")]
+    pub sessions: Arc<SessionTable>,
 }
 
 impl ExecService {
@@ -114,6 +116,20 @@ impl Exec for ExecService {
             }
             _ => self.reply(ExecCode::Success, String::from("Success\n")),
         }
+    }
+
+    async fn logout(
+        &self,
+        #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] request: tonic::Request<
+            LogoutRequest,
+        >,
+    ) -> Result<Response<LogoutReply>, tonic::Status> {
+        #[cfg(target_os = "linux")]
+        if let Some(ctx) = request.extensions().get::<SessionContext>() {
+            let removed = self.sessions.remove(&ctx.key);
+            tracing::info!(uid = ctx.key.0, bash_pid = ctx.key.1, removed, "vty logout",);
+        }
+        Ok(Response::new(LogoutReply { ok: true }))
     }
 }
 
@@ -408,7 +424,10 @@ impl VtyPeerInterceptor {
 }
 
 impl tonic::service::Interceptor for VtyPeerInterceptor {
-    fn call(&mut self, req: tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> {
+    fn call(
+        &mut self,
+        #[cfg_attr(not(target_os = "linux"), allow(unused_mut))] mut req: tonic::Request<()>,
+    ) -> Result<tonic::Request<()>, tonic::Status> {
         #[cfg(target_os = "linux")]
         if let Some(info) = req
             .extensions()
@@ -429,6 +448,9 @@ impl tonic::service::Interceptor for VtyPeerInterceptor {
 
             match self.sessions.resolve(&ProcfsReader, uid, pid) {
                 Ok(((skey_uid, bash_pid), is_new)) => {
+                    req.extensions_mut().insert(SessionContext {
+                        key: (skey_uid, bash_pid),
+                    });
                     if is_new {
                         tracing::info!(uid = skey_uid, gid, pid, bash_pid, "vty rpc (new session)");
                         let table = self.sessions.clone();
@@ -470,13 +492,17 @@ impl tonic::service::Interceptor for VtyPeerInterceptor {
 }
 
 pub fn serve(cli: Cli, addr: VtyAddr) -> anyhow::Result<()> {
-    let exec_service = ExecService { tx: cli.tx.clone() };
+    #[cfg(target_os = "linux")]
+    let sessions = SessionTable::new();
+
+    let exec_service = ExecService {
+        tx: cli.tx.clone(),
+        #[cfg(target_os = "linux")]
+        sessions: sessions.clone(),
+    };
     let show_service = ShowService { tx: cli.tx.clone() };
     let apply_service = ApplyService { tx: cli.tx.clone() };
     let clear_service = ClearService { tx: cli.tx.clone() };
-
-    #[cfg(target_os = "linux")]
-    let sessions = SessionTable::new();
 
     let interceptor = VtyPeerInterceptor::from_env(
         #[cfg(target_os = "linux")]

--- a/zebra-rs/src/config/session.rs
+++ b/zebra-rs/src/config/session.rs
@@ -28,6 +28,17 @@ pub const DEFAULT_GC_INTERVAL: Duration = Duration::from_secs(60);
 /// Composite session identifier: `(peer_uid, parent_pid)`.
 pub type SessionKey = (u32, u32);
 
+/// Per-request session context attached to `tonic::Request` extensions by
+/// `VtyPeerInterceptor` after a successful resolve. Handlers can read it to
+/// act on the caller's session (e.g. the Logout handler removes the entry).
+///
+/// Wrapped in a newtype so the extension lookup is unambiguous — bare
+/// tuples would collide with anything else stored as `(u32, u32)`.
+#[derive(Debug, Clone, Copy)]
+pub struct SessionContext {
+    pub key: SessionKey,
+}
+
 /// Minimal session record. Phase 1 keeps only what is needed to track
 /// connections; enable/RBAC fields are added in Phase 4. Fields are written
 /// on session create/refresh but not yet consumed outside tests.


### PR DESCRIPTION
## Summary

Fourth step of VTY session management (see
book/src/ch-06-01-session-design.md, Phase 6).

Adds an explicit Logout path so the daemon reclaims a session the
instant a normal shell exit happens, without waiting for the pidfd
watcher to fire. Acts as the fastest layer in the three-tier
cleanup (logout RPC → pidfd → GC sweep).

### Proto

- New `Exec.Logout(LogoutRequest) -> LogoutReply`.

### Server

- `VtyPeerInterceptor` now injects a `SessionContext` newtype
  (wrapping the session key) into each request's tonic extensions.
  Handlers can read it without re-resolving SO_PEERCRED, and Phase 4
  RBAC will use the same mechanism.
- `ExecService` gains `Arc<SessionTable>` and the `logout` handler
  reads `SessionContext`, calls `SessionTable::remove()`, and logs
  the outcome.

### Client

- `vtyhelper` grows `-l/--logout`. The logout path is silent on both
  success and failure — the user's shell is already exiting, so any
  stdout would be jarring.

### Shell integration

- `vty.sh`'s interactive setup installs
  `trap '${cli_command} -l >/dev/null 2>&1 || true' EXIT`,
  firing the RPC on every clean exit and swallowing failure so a
  down daemon doesn't break shell teardown.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs config::session` — 15/15 pass
- [ ] CI: fmt, clippy, test
- [ ] Manual smoke test: start daemon, open `vty`, `exit`, confirm
      `vty logout uid=... bash_pid=... removed=true` in daemon log

Generated with [Claude Code](https://claude.com/claude-code)