### PR TITLE
vty: Phase 4-a — Role enum + RBAC/enable fields on Session

### DIFF
--- a/book/src/ch-06-01-session-design.md
+++ b/book/src/ch-06-01-session-design.md
@@ -344,6 +344,11 @@ Each phase is intended to ship as an independent PR.
 | D12 | The daemon and its clients must share a PID namespace. `peer_pid == 0` from SO_PEERCRED is rejected as cross-PID-ns access. |
 | D13 | TACACS+ integration is authentication-only via `pam_tacplus`. No login/command accounting, no per-command authorization. |
 | D14 | vtypam communicates result via exit code only. priv-lvl and TACACS+ AV-pairs are not propagated to the daemon. |
+| D15 | vtypam is installed with file capabilities `cap_dac_read_search,cap_audit_write=ep`, not setuid root. setuid root is documented as a fallback for environments where file caps are stripped by packaging. |
+| D16 | The daemon does **not** install `/etc/pam.d/zebra-rs`. A `zebra-rs.example` sample (minimal `pam_unix` stack) is shipped and the admin copies it into place, optionally rewriting it as `@include common-auth` on Debian/Ubuntu. |
+| D17 | enable failure rate-limit lives in the daemon (per-uid counter, 5 failures within 30 s triggers a 30 s lockout, in-memory only). `pam_faillock` is documented as an optional stronger layer that admins can stack in the PAM service file. |
+| D18 | RBAC is 3-tier: `View`, `Operator`, `Admin`. Maps cleanly onto Cisco priv-lvl ranges 0-1 / 2-14 / 15. YANG-configurable roles are explicitly out of scope. |
+| D19 | Default idle session TTL is **600 s** with a 60 s sweep interval (Cisco IOS `exec-timeout 10 0` convention). Configurable later if a deployment needs it. |
 
 ## Deferred work
 
@@ -372,11 +377,6 @@ the relevant phase begins:
 
 | # | Question | Phase |
 |---|---|---|
-| Q4 | vtypam capability model: setuid root vs `cap_dac_read_search,cap_audit_write=ep` | 4 |
-| Q5 | Default `/etc/pam.d/zebra-rs` content: explicit modules, `@include common-auth`, or admin-supplied | 4 |
-| Q6 | enable rate-limit: daemon-internal counter, `pam_faillock`, or both | 4 |
-| Q7 | RBAC granularity: 2-tier (view/admin), 3-tier (view/operator/admin), or YANG-configurable | 4 |
-| Q10 | Default idle session TTL value | 2 |
 | Q12a | vtyhelper streaming model: per-command subcommands vs unified streaming dispatch | 7 |
 | Q12b | `monitor terminal` output format: human-readable, JSON, or both | 7 |
 | Q12c | `monitor terminal` max concurrent subscribers | 7 |

--- a/zebra-rs/src/config/session.rs
+++ b/zebra-rs/src/config/session.rs
@@ -28,6 +28,24 @@ pub const DEFAULT_GC_INTERVAL: Duration = Duration::from_secs(60);
 /// Composite session identifier: `(peer_uid, parent_pid)`.
 pub type SessionKey = (u32, u32);
 
+/// VTY authorization role. See decision D18.
+///
+/// - `View`: read-only access (default for new sessions).
+/// - `Operator`: intermediate (clear, restart, ping/traceroute, etc.).
+/// - `Admin`: full configuration access; required for configure/commit.
+///
+/// Sessions start at `View`. The `enable` command (Phase 4-c) authenticates
+/// the operator via PAM and promotes them to `Admin` for a bounded window
+/// (see [`Session::enable_expires`] / [`Session::enable_hard_deadline`]).
+/// Service accounts (Phase 4-d) start at `Admin` permanently.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    View,
+    Operator,
+    Admin,
+}
+
 /// Per-request session context attached to `tonic::Request` extensions by
 /// `VtyPeerInterceptor` after a successful resolve. Handlers can read it to
 /// act on the caller's session (e.g. the Logout handler removes the entry).
@@ -39,9 +57,13 @@ pub struct SessionContext {
     pub key: SessionKey,
 }
 
-/// Minimal session record. Phase 1 keeps only what is needed to track
-/// connections; enable/RBAC fields are added in Phase 4. Fields are written
-/// on session create/refresh but not yet consumed outside tests.
+/// Session record.
+///
+/// Phase 1 added the identity and timing fields. Phase 4-a adds the RBAC
+/// (`role`) and enable-state (`enabled`, `enable_expires`,
+/// `enable_hard_deadline`) fields. Phase 4-c (Enable/Disable RPC) wires the
+/// consumption logic; until then these fields are populated with default
+/// values but never read outside tests.
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct Session {
@@ -49,6 +71,17 @@ pub struct Session {
     pub bash_pid: u32,
     pub created: Instant,
     pub last_active: Instant,
+    /// Current authorization role. Defaults to `View`.
+    pub role: Role,
+    /// Whether the session has authenticated via `enable`. When `true`,
+    /// both `enable_expires` and `enable_hard_deadline` are `Some`.
+    pub enabled: bool,
+    /// Sliding deadline (refreshed on each authorized RPC). Phase 4-c will
+    /// drop back to disabled when `now >= enable_expires`.
+    pub enable_expires: Option<Instant>,
+    /// Absolute deadline from the original `enable`. Not extended by
+    /// activity (see D2).
+    pub enable_hard_deadline: Option<Instant>,
 }
 
 impl Session {
@@ -59,6 +92,10 @@ impl Session {
             bash_pid,
             created: now,
             last_active: now,
+            role: Role::View,
+            enabled: false,
+            enable_expires: None,
+            enable_hard_deadline: None,
         }
     }
 }
@@ -208,6 +245,10 @@ impl SessionTable {
                 bash_pid: key.1,
                 created: last_active,
                 last_active,
+                role: Role::View,
+                enabled: false,
+                enable_expires: None,
+                enable_hard_deadline: None,
             },
         );
     }


### PR DESCRIPTION
## Summary

Groundwork for Phase 4 (RBAC + enable). No proto changes, no
behavior changes for existing RPCs. Just records decisions and
extends the in-memory Session struct with fields the upcoming
Enable/Disable RPC and admin-gate checks will consume.

### Design notes (book/src/ch-06-01-session-design.md)

Records the decisions that close Q4-Q7 (and folds in Q10/D19):

- **D15** vtypam ships with file capabilities
  `cap_dac_read_search,cap_audit_write=ep`, not setuid root. setuid
  root remains documented as a fallback.
- **D16** zebra-rs.example is shipped as a sample; the daemon does
  not install /etc/pam.d/zebra-rs. Admin copies it into place,
  optionally rewriting it as `@include common-auth`.
- **D17** enable rate-limit is daemon-internal (5 failures / 30 s
  per uid, in-memory). pam_faillock is documented as an optional
  stronger layer.
- **D18** RBAC is 3-tier: View / Operator / Admin.
- **D19** Default idle TTL = 600 s, sweep = 60 s (the values
  already shipped in Phase 2).

Q4-Q7 and Q10 removed from the open-questions list.

### Code (zebra-rs/src/config/session.rs)

- New `Role` enum (`View`, `Operator`, `Admin`). Variants are
  `#[allow(dead_code)]` until Phase 4-c consumes them.
- `Session` now carries `role`, `enabled`, `enable_expires`, and
  `enable_hard_deadline`. All sessions are created with View /
  disabled / no deadlines; promotion logic ships in Phase 4-c.
- `insert_for_test` updated to populate the new fields with
  defaults.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs config::session` — 15/15 pass
- [ ] CI: fmt, clippy, test

Generated with [Claude Code](https://claude.com/claude-code)