### PR TITLE
vty: Phase 4-b — vtypam helper + PAM sample + Makefile install

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install build deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          sudo apt-get install -y protobuf-compiler libpam0g-dev
       - name: Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -50,7 +50,7 @@ jobs:
       - name: Install build deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          sudo apt-get install -y protobuf-compiler libpam0g-dev
       - name: Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "zebra-rs",
   "vtyctl",
   "vtyhelper",
+  "vtypam",
   "crates/bgp-packet",
   "crates/bgp-macros",
   "crates/packet-utils",

--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,26 @@ install:
 	cp target/release/zebra ${HOME}/.zebra/bin
 	cp target/release/vtyhelper ${HOME}/.zebra/bin
 	cp target/release/vtyctl ${HOME}/.zebra/bin
+ifneq ("$(wildcard target/release/vtypam)","")
+	cp target/release/vtypam ${HOME}/.zebra/bin
+	@echo '[vtypam installed to $${HOME}/.zebra/bin/vtypam — grant caps with: sudo setcap cap_dac_read_search,cap_audit_write=ep $${HOME}/.zebra/bin/vtypam]'
+endif
 ifneq ("$(wildcard vty/vty)","")
 	cp vty/vty ${HOME}/.zebra/bin
 endif
 	cp zebra/yang/* ${HOME}/.zebra/yang
 	touch ${HOME}/.zebra/zebra.conf
 	@echo '[Please add $${HOME}/.zebra/bin to your PATH]'
+
+# System-wide installation of vtypam to /usr/sbin with file caps.
+# Use this on production hosts; the per-user `install` target above
+# is for dev convenience and cannot set caps.
+.PHONY: install-vtypam
+install-vtypam:
+	sudo install -m 0755 -o root -g root target/release/vtypam /usr/sbin/vtypam
+	sudo setcap cap_dac_read_search,cap_audit_write=ep /usr/sbin/vtypam
+	@echo '[vtypam installed to /usr/sbin/vtypam with file caps]'
+	@echo '[Copy etc/pam.d/zebra-rs.example to /etc/pam.d/zebra-rs and adjust for your distro]'
 
 doc:
 	rustdoc

--- a/etc/pam.d/zebra-rs.example
+++ b/etc/pam.d/zebra-rs.example
@@ -1,0 +1,67 @@
+# PAM service file for the zebra-rs VTY 'enable' command.
+#
+# *** DO NOT install this file as-is. ***
+#
+# Copy this file to /etc/pam.d/zebra-rs and adjust to match your
+# distribution's PAM conventions. The daemon (via the `vtypam` helper)
+# starts a PAM transaction with the service name "zebra-rs" and runs
+# the `auth` and `account` phases. No session or password phases are
+# used today.
+#
+# ------------------------------------------------------------
+# Option A — Distribution-stacked configuration (recommended)
+# ------------------------------------------------------------
+# On Debian / Ubuntu, inherit the system-wide auth stack so PAM
+# extensions configured for sudo/login (faillock, MFA, etc.) apply
+# automatically here too:
+#
+#   auth      include   common-auth
+#   account   include   common-account
+#
+# On RHEL / CentOS / Fedora, the equivalent is:
+#
+#   auth      include   password-auth
+#   account   include   password-auth
+#
+# ------------------------------------------------------------
+# Option B — Explicit minimal stack (this file's default)
+# ------------------------------------------------------------
+# Authenticates against local /etc/shadow only. Suitable for
+# appliances that do not use distro common-* stacks.
+
+auth      required  pam_unix.so
+account   required  pam_unix.so
+
+# ------------------------------------------------------------
+# Optional — Brute-force lockout via pam_faillock
+# ------------------------------------------------------------
+# Layer this in front of pam_unix to lock an account after a burst
+# of failed attempts. Tune `deny=` and `unlock_time=` to taste:
+#
+#   auth      required  pam_faillock.so preauth silent deny=5 unlock_time=900
+#   auth      required  pam_unix.so
+#   auth      [default=die]  pam_faillock.so authfail deny=5 unlock_time=900
+#   account   required  pam_faillock.so
+#   account   required  pam_unix.so
+#
+# The daemon also enforces an in-memory per-uid rate limit (5 failed
+# `enable` attempts in 30 seconds trigger a 30-second lockout) that is
+# independent of the PAM stack. pam_faillock complements it with
+# system-wide, persistent lockouts.
+#
+# ------------------------------------------------------------
+# Optional — TACACS+ via pam_tacplus
+# ------------------------------------------------------------
+# Try TACACS+ first, fall back to local pam_unix on TACACS+ failure
+# (server down, network partition, etc.). Configure the server list
+# and shared secret in /etc/tacplus_servers.
+#
+#   auth      [success=done default=ignore] pam_tacplus.so encrypt login=pap
+#   auth      required  pam_unix.so
+#   account   [success=done default=ignore] pam_tacplus.so
+#   account   required  pam_unix.so
+#
+# zebra-rs uses TACACS+ for authentication only. It does NOT consume
+# the priv-lvl attribute from TACACS+ responses; role assignment is
+# decided locally via `enable` + service-accounts. See
+# book/src/ch-06-01-session-design.md (D13, D14).

--- a/vtypam/Cargo.toml
+++ b/vtypam/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "vtypam"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+libc = "0.2"

--- a/vtypam/src/main.rs
+++ b/vtypam/src/main.rs
@@ -1,0 +1,261 @@
+//! `vtypam` — minimal PAM authentication helper for zebra-rs.
+//!
+//! Invoked by the zebra-rs daemon to verify an operator's password when the
+//! VTY `enable` command is issued. Kept as a small standalone binary so the
+//! daemon does not need the privileges required to read `/etc/shadow`.
+//!
+//! See `book/src/ch-06-01-session-design.md` (D6, D14, D15) for the full
+//! design.
+//!
+//! ## I/O contract
+//!
+//! - `argv[1]`: target username.
+//! - stdin: password on a single line (trailing newline stripped).
+//! - PAM service name: `"zebra-rs"` (set up by the admin under
+//!   `/etc/pam.d/zebra-rs`, see `etc/pam.d/zebra-rs.example`).
+//!
+//! ## Exit codes
+//!
+//! | Code | Meaning                                            |
+//! |------|----------------------------------------------------|
+//! |  0   | authentication and account check both succeeded    |
+//! |  1   | authentication failure (wrong password, unknown user, etc.) |
+//! |  2   | account invalid (expired, locked, denied by acct)  |
+//! |  3   | system error (PAM setup failure, syscall failure)  |
+//!
+//! ## Privilege
+//!
+//! Installed with `setcap cap_dac_read_search,cap_audit_write=ep` (D15);
+//! setuid root is documented as a fallback for distros that strip caps.
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("vtypam: this helper is only supported on Linux");
+    std::process::exit(3);
+}
+
+#[cfg(target_os = "linux")]
+fn main() {
+    std::process::exit(linux::run());
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::ffi::CString;
+    use std::io::{self, BufRead};
+    use std::os::raw::{c_char, c_int, c_void};
+    use std::ptr;
+
+    // PAM return codes from linux-pam <security/_pam_types.h>. Only the
+    // ones we actually branch on.
+    const PAM_SUCCESS: c_int = 0;
+    const PAM_BUF_ERR: c_int = 5;
+    const PAM_PERM_DENIED: c_int = 6;
+    const PAM_AUTH_ERR: c_int = 7;
+    const PAM_CRED_INSUFFICIENT: c_int = 8;
+    const PAM_AUTHINFO_UNAVAIL: c_int = 9;
+    const PAM_USER_UNKNOWN: c_int = 10;
+    const PAM_MAXTRIES: c_int = 11;
+    const PAM_ACCT_EXPIRED: c_int = 13;
+    const PAM_CONV_ERR: c_int = 19;
+
+    // Message styles passed to the PAM conversation callback.
+    const PAM_PROMPT_ECHO_OFF: c_int = 1;
+    const PAM_PROMPT_ECHO_ON: c_int = 2;
+
+    #[repr(C)]
+    struct PamMessage {
+        msg_style: c_int,
+        msg: *const c_char,
+    }
+
+    #[repr(C)]
+    struct PamResponse {
+        resp: *mut c_char,
+        resp_retcode: c_int,
+    }
+
+    #[repr(C)]
+    struct PamConv {
+        conv: extern "C" fn(
+            num_msg: c_int,
+            msg: *mut *const PamMessage,
+            resp: *mut *mut PamResponse,
+            appdata_ptr: *mut c_void,
+        ) -> c_int,
+        appdata_ptr: *mut c_void,
+    }
+
+    // PAM is opaque to us; just track the handle pointer.
+    type PamHandle = *mut c_void;
+
+    #[link(name = "pam")]
+    unsafe extern "C" {
+        fn pam_start(
+            service_name: *const c_char,
+            user: *const c_char,
+            pam_conv: *const PamConv,
+            pamh: *mut PamHandle,
+        ) -> c_int;
+        fn pam_authenticate(pamh: PamHandle, flags: c_int) -> c_int;
+        fn pam_acct_mgmt(pamh: PamHandle, flags: c_int) -> c_int;
+        fn pam_end(pamh: PamHandle, pam_status: c_int) -> c_int;
+    }
+
+    /// PAM conversation callback. Linux PAM passes `msg` as
+    /// `const struct pam_message **` (pointer-to-array-of-pointers).
+    ///
+    /// Allocates a `PamResponse` array via `libc::calloc` so PAM can `free()`
+    /// each entry. For each `PAM_PROMPT_ECHO_OFF` / `PAM_PROMPT_ECHO_ON`
+    /// prompt we hand back the cached password (likewise `libc::malloc`'d).
+    extern "C" fn conv(
+        num_msg: c_int,
+        msg: *mut *const PamMessage,
+        resp: *mut *mut PamResponse,
+        appdata: *mut c_void,
+    ) -> c_int {
+        if num_msg <= 0 || msg.is_null() || resp.is_null() || appdata.is_null() {
+            return PAM_CONV_ERR;
+        }
+
+        // SAFETY: appdata is the &Vec<u8> we passed in pam_conv.appdata_ptr.
+        let password: &Vec<u8> = unsafe { &*(appdata as *const Vec<u8>) };
+
+        // SAFETY: PAM expects this allocation; it will libc::free each entry.
+        let responses = unsafe {
+            libc::calloc(
+                num_msg as libc::size_t,
+                std::mem::size_of::<PamResponse>() as libc::size_t,
+            ) as *mut PamResponse
+        };
+        if responses.is_null() {
+            return PAM_BUF_ERR;
+        }
+
+        for i in 0..num_msg as isize {
+            // SAFETY: msg[i] is one of the PAM-owned message pointers.
+            let m_ptr = unsafe { *msg.offset(i) };
+            if m_ptr.is_null() {
+                continue;
+            }
+            let style = unsafe { (*m_ptr).msg_style };
+            // SAFETY: write into our own allocation.
+            let r = unsafe { &mut *responses.offset(i) };
+
+            if style == PAM_PROMPT_ECHO_OFF || style == PAM_PROMPT_ECHO_ON {
+                let len = password.len();
+                // SAFETY: PAM will libc::free the buffer when it frees the response.
+                let buf = unsafe { libc::malloc(len + 1) as *mut c_char };
+                if buf.is_null() {
+                    // Free what we've allocated so far and bail out.
+                    free_response_array(responses, i);
+                    return PAM_BUF_ERR;
+                }
+                unsafe {
+                    if len > 0 {
+                        ptr::copy_nonoverlapping(password.as_ptr() as *const c_char, buf, len);
+                    }
+                    *buf.add(len) = 0;
+                }
+                r.resp = buf;
+                r.resp_retcode = 0;
+            }
+            // PAM_TEXT_INFO / PAM_ERROR_MSG: leave resp as null.
+        }
+
+        unsafe { *resp = responses };
+        PAM_SUCCESS
+    }
+
+    /// Free response slots 0..up_to inclusive, then the array itself.
+    fn free_response_array(responses: *mut PamResponse, up_to: isize) {
+        unsafe {
+            for j in 0..up_to {
+                let entry = &mut *responses.offset(j);
+                if !entry.resp.is_null() {
+                    libc::free(entry.resp as *mut c_void);
+                }
+            }
+            libc::free(responses as *mut c_void);
+        }
+    }
+
+    pub fn run() -> i32 {
+        let user = match std::env::args().nth(1) {
+            Some(u) if !u.is_empty() => u,
+            _ => {
+                eprintln!("vtypam: usage: vtypam <username>");
+                return 3;
+            }
+        };
+
+        let user_c = match CString::new(user.as_bytes()) {
+            Ok(c) => c,
+            Err(_) => {
+                eprintln!("vtypam: username contains NUL");
+                return 3;
+            }
+        };
+        let service_c = CString::new("zebra-rs").unwrap();
+
+        let mut password = String::new();
+        if let Err(e) = io::stdin().lock().read_line(&mut password) {
+            eprintln!("vtypam: failed to read password from stdin: {e}");
+            return 3;
+        }
+        // Strip a single trailing newline; tolerate password with no terminator.
+        if password.ends_with('\n') {
+            password.pop();
+            if password.ends_with('\r') {
+                password.pop();
+            }
+        }
+        let password_bytes = password.into_bytes();
+
+        let conv_data = PamConv {
+            conv,
+            appdata_ptr: &password_bytes as *const Vec<u8> as *mut c_void,
+        };
+
+        let mut pamh: PamHandle = ptr::null_mut();
+        let rc = unsafe { pam_start(service_c.as_ptr(), user_c.as_ptr(), &conv_data, &mut pamh) };
+        if rc != PAM_SUCCESS {
+            eprintln!("vtypam: pam_start failed: {rc}");
+            return 3;
+        }
+
+        let auth_rc = unsafe { pam_authenticate(pamh, 0) };
+        let exit = match auth_rc {
+            PAM_SUCCESS => {
+                let acct_rc = unsafe { pam_acct_mgmt(pamh, 0) };
+                match acct_rc {
+                    PAM_SUCCESS => 0,
+                    PAM_ACCT_EXPIRED | PAM_PERM_DENIED => 2,
+                    PAM_USER_UNKNOWN => 1, // unknown user surfaces here for some stacks
+                    _ => 3,
+                }
+            }
+            PAM_AUTH_ERR | PAM_CRED_INSUFFICIENT | PAM_USER_UNKNOWN | PAM_MAXTRIES => 1,
+            PAM_AUTHINFO_UNAVAIL => 3,
+            _ => 3,
+        };
+
+        // pam_end returns the last status so PAM modules can act on the
+        // session outcome.
+        unsafe {
+            pam_end(pamh, auth_rc);
+        }
+
+        // Zero the in-memory password (best effort; the kernel may have
+        // copied it elsewhere already).
+        // SAFETY: password_bytes is still owned by us at this point because
+        // PAM does not retain the appdata pointer past the conversation.
+        let mut pw = password_bytes;
+        unsafe {
+            ptr::write_bytes(pw.as_mut_ptr(), 0u8, pw.len());
+        }
+        drop(pw);
+
+        exit
+    }
+}


### PR DESCRIPTION
## Summary

Adds the binary the daemon will spawn for password verification when
the VTY `enable` command lands in Phase 4-c. Keeps the daemon free
of shadow-read privileges and confines libpam (a C library invoking
arbitrary modules) inside a minimal helper.

### `vtypam` binary (new workspace member)

- Linux-only (cfg-gated; non-Linux is a stub that exits 3).
- Raw libpam FFI; no third-party PAM crate dependency.
- I/O: `argv[1]` = username, stdin = password line.
- PAM service name: `"zebra-rs"`.
- Calls `pam_start` -> `pam_authenticate` -> `pam_acct_mgmt` -> `pam_end`.
- Exit codes per the documented contract:
  `0`=ok, `1`=auth_fail, `2`=acct_invalid, `3`=sys_error.
- Best-effort password zeroing on exit.

### PAM sample

`etc/pam.d/zebra-rs.example` ships a minimal `pam_unix` stack with
inline documentation for:
- Debian/Ubuntu `@include common-auth` form
- RHEL/CentOS `@include password-auth` form
- Optional `pam_faillock` brute-force lockout
- Optional TACACS+ via `pam_tacplus` (auth-only, per D13)

Per D16 this file is **not** installed; the admin copies it into
place.

### Makefile

- `make install` copies `vtypam` to `${HOME}/.zebra/bin` when present
  (dev convenience; no setcap because that needs root).
- New `make install-vtypam` does a system install to `/usr/sbin`
  with `setcap cap_dac_read_search,cap_audit_write=ep` per D15.

### CI

- `libpam0g-dev` added to the clippy + test jobs so the workspace
  links against libpam on the runners.

Phase 4-c will add the Enable/Disable RPCs and wire the daemon to
spawn vtypam.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (vtypam included)
- [x] `cargo test --workspace --exclude bdd`
- [x] `cargo test -p zebra-rs config::session` — 15/15 pass
- [x] Smoke test: `vtypam` (no argv) exits 3; `vtypam nonexistent_user`
      with junk stdin exits 1 (PAM falls back to `other` and denies)
- [ ] CI: fmt, clippy, test

Generated with [Claude Code](https://claude.com/claude-code)