### PR TITLE
vty: Phase 4-c — Enable/Disable RPCs, vtypam spawn, rate-limit

### DIFF
--- a/proto/vty.proto
+++ b/proto/vty.proto
@@ -12,11 +12,39 @@ service Exec {
   // immediately on a clean shell exit (in parallel with the kernel
   // pidfd watcher that handles abnormal exits).
   rpc Logout(LogoutRequest) returns (LogoutReply) {}
+  // Promote the caller's session to Admin after PAM authenticates
+  // the supplied password. On success the session holds the Admin
+  // role until either ttl_secs idle (refreshed on each authorized
+  // RPC) or a 4 h hard cap elapses, whichever comes first.
+  rpc Enable(EnableRequest) returns (EnableReply) {}
+  // Drop the caller's session back to View. Idempotent.
+  rpc Disable(DisableRequest) returns (DisableReply) {}
 }
 
 message LogoutRequest {}
 
 message LogoutReply {
+  bool ok = 1;
+}
+
+message EnableRequest {
+  // Password for the peer uid's local account, verified by the
+  // 'zebra-rs' PAM service via the vtypam helper.
+  string password = 1;
+}
+
+message EnableReply {
+  bool ok = 1;
+  // Human-readable detail (auth failure reason, lockout message).
+  string message = 2;
+  // Sliding idle TTL in seconds. Refreshed on each authorized RPC
+  // up to a separate absolute hard cap.
+  uint32 ttl_secs = 3;
+}
+
+message DisableRequest {}
+
+message DisableReply {
   bool ok = 1;
 }
 

--- a/vty/additions/vty.sh
+++ b/vty/additions/vty.sh
@@ -315,6 +315,44 @@ _cli_refresh ()
   _cli_prompt_setup
 }
 
+enable ()
+{
+  if [[ ${CLI_MODE} != "exec" ]]; then
+    echo "% 'enable' is only available in exec mode."
+    return 1
+  fi
+  local pw
+  if [[ -t 0 ]]; then
+    stty -echo
+    read -r -p "Password: " pw
+    stty echo
+    echo
+  else
+    # Non-interactive: read a single password line from stdin.
+    IFS= read -r pw
+  fi
+  CLI_ENABLE_PASSWORD="${pw}" ${cli_command} -e -m ${CLI_MODE}
+  local rc=$?
+  pw=""
+  unset pw
+  if [[ ${rc} -eq 0 ]]; then
+    CLI_PRIVILEGE=15
+    _cli_prompt_setup
+  fi
+  return ${rc}
+}
+
+disable ()
+{
+  ${cli_command} -d -m ${CLI_MODE}
+  local rc=$?
+  if [[ ${rc} -eq 0 ]]; then
+    CLI_PRIVILEGE=1
+    _cli_prompt_setup
+  fi
+  return ${rc}
+}
+
 if [[ $interactive ]]; then
   _cli_pager_setup
   _cli_bind_key
@@ -327,6 +365,12 @@ else
   CLI_PAGER="cat"
 fi
 _cli_register_first_level_command
+# If the daemon registers 'enable'/'disable' as first-level commands,
+# strip the aliases so our functions above take precedence — they need
+# to read the password locally with stty -echo, not pass it through the
+# normal Exec RPC.
+unalias enable 2>/dev/null || true
+unalias disable 2>/dev/null || true
 
 # Local variables:
 # mode: shell-script

--- a/vtyhelper/src/main.rs
+++ b/vtyhelper/src/main.rs
@@ -5,7 +5,10 @@ use tokio::io::{self, AsyncWriteExt};
 use tokio_stream::StreamExt;
 use vty::exec_client::ExecClient;
 use vty::show_client::ShowClient;
-use vty::{CommandPath, ExecCode, ExecReply, ExecRequest, ExecType, LogoutRequest, ShowRequest};
+use vty::{
+    CommandPath, DisableRequest, EnableRequest, ExecCode, ExecReply, ExecRequest, ExecType,
+    LogoutRequest, ShowRequest,
+};
 
 mod endpoint;
 
@@ -43,6 +46,20 @@ struct Cli {
         help = "Logout: tear down the server-side session (invoked from vty bash EXIT trap)"
     )]
     logout: bool,
+
+    #[arg(
+        short = 'e',
+        long,
+        help = "Enable: prompt-less PAM authentication; password is read from CLI_ENABLE_PASSWORD"
+    )]
+    enable: bool,
+
+    #[arg(
+        short = 'd',
+        long,
+        help = "Disable: drop the session back to View role"
+    )]
+    disable: bool,
 
     #[arg(
         short,
@@ -207,6 +224,80 @@ async fn logout(cli: Cli) -> Result<()> {
     Ok(())
 }
 
+/// Promote the session to Admin via the server's Enable RPC.
+///
+/// Reads the password from `CLI_ENABLE_PASSWORD` (set by the vty bash
+/// `enable` function which uses `read -s` to capture it without echo).
+/// Prints a one-line result and exits 0 on success, 1 on auth failure,
+/// or non-zero on other errors (transport, rate-limit, etc.).
+async fn enable(cli: Cli) -> i32 {
+    let password = env::var("CLI_ENABLE_PASSWORD").unwrap_or_default();
+    // Wipe the env var immediately so the password doesn't linger in our
+    // own process environment beyond the RPC call.
+    // SAFETY: single-threaded at this point; tokio runtime not yet handling
+    // concurrent env access for vtyhelper.
+    unsafe {
+        env::remove_var("CLI_ENABLE_PASSWORD");
+    }
+
+    let channel = match endpoint::connect(&endpoint_uri(&cli.base, cli.port)).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("% enable: connect failed: {e}");
+            return 2;
+        }
+    };
+    let mut client = ExecClient::new(channel);
+    match client
+        .enable(tonic::Request::new(EnableRequest { password }))
+        .await
+    {
+        Ok(reply) => {
+            let r = reply.into_inner();
+            if r.ok {
+                println!("% Enabled (admin role active for {} seconds)", r.ttl_secs);
+                0
+            } else {
+                println!("% Enable failed: {}", r.message);
+                1
+            }
+        }
+        Err(status) => {
+            // permission_denied = wrong password; everything else is a
+            // system/rate-limit problem worth distinguishing in scripts.
+            let code = if status.code() == tonic::Code::PermissionDenied {
+                1
+            } else {
+                2
+            };
+            println!("% Enable failed: {}", status.message());
+            code
+        }
+    }
+}
+
+/// Drop the session back to View. Idempotent; the daemon doesn't error.
+async fn disable(cli: Cli) -> i32 {
+    let channel = match endpoint::connect(&endpoint_uri(&cli.base, cli.port)).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("% disable: connect failed: {e}");
+            return 2;
+        }
+    };
+    let mut client = ExecClient::new(channel);
+    match client.disable(tonic::Request::new(DisableRequest {})).await {
+        Ok(_) => {
+            println!("% Disabled");
+            0
+        }
+        Err(status) => {
+            println!("% Disable failed: {}", status.message());
+            2
+        }
+    }
+}
+
 async fn run(cli: Cli) -> Result<()> {
     if cli.logout {
         logout(cli).await?;
@@ -226,6 +317,16 @@ async fn main() -> Result<()> {
     if let Ok(val) = env::var("CLI_SERVER_URL") {
         cli.base = val;
     }
+
+    // Enable/Disable need to control their own exit codes for the shell
+    // wrapper to react (e.g. flip CLI_PRIVILEGE on success).
+    if cli.enable {
+        std::process::exit(enable(cli).await);
+    }
+    if cli.disable {
+        std::process::exit(disable(cli).await);
+    }
+
     let logout_mode = cli.logout;
     if let Err(_err) = run(cli).await {
         // Logout runs from the bash EXIT trap; staying silent on failure

--- a/zebra-rs/src/config/enable_rate.rs
+++ b/zebra-rs/src/config/enable_rate.rs
@@ -1,0 +1,173 @@
+//! Per-uid rate limiter for the `enable` RPC (D17).
+//!
+//! Simple sliding-window counter held in memory. 5 failures within 30 s
+//! triggers a 30 s lockout for that uid. A success resets the window.
+//! State is in-memory only; it does not survive daemon restart (D3).
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+#[cfg(target_os = "linux")]
+use dashmap::DashMap;
+
+/// Window length over which failures accumulate.
+pub const WINDOW: Duration = Duration::from_secs(30);
+/// Failures within `WINDOW` that trigger a lockout.
+pub const MAX_FAILURES: u32 = 5;
+/// How long the uid stays locked out once `MAX_FAILURES` is reached.
+pub const LOCKOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Copy)]
+struct State {
+    /// Timestamp of the first failure in the current window.
+    window_started: Instant,
+    /// Number of failures in the current window.
+    failures: u32,
+    /// If set, requests are rejected until this instant.
+    locked_until: Option<Instant>,
+}
+
+impl State {
+    fn fresh(now: Instant) -> Self {
+        Self {
+            window_started: now,
+            failures: 0,
+            locked_until: None,
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, Default)]
+pub struct EnableRateLimiter {
+    state: DashMap<u32, State>,
+}
+
+#[cfg(target_os = "linux")]
+impl EnableRateLimiter {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            state: DashMap::new(),
+        })
+    }
+
+    /// Check whether the uid is currently allowed to attempt `enable`.
+    /// Returns `Err(remaining)` if currently locked out.
+    pub fn check(&self, uid: u32) -> Result<(), Duration> {
+        self.check_at(uid, Instant::now())
+    }
+
+    /// Record an authentication failure. Returns true if this failure
+    /// triggered a lockout.
+    pub fn record_failure(&self, uid: u32) -> bool {
+        self.record_failure_at(uid, Instant::now())
+    }
+
+    /// Reset the uid's failure window after a successful authentication.
+    pub fn record_success(&self, uid: u32) {
+        self.state.remove(&uid);
+    }
+
+    // Testable inner methods that take an explicit `now`.
+
+    fn check_at(&self, uid: u32, now: Instant) -> Result<(), Duration> {
+        if let Some(s) = self.state.get(&uid)
+            && let Some(until) = s.locked_until
+            && now < until
+        {
+            return Err(until.saturating_duration_since(now));
+        }
+        Ok(())
+    }
+
+    fn record_failure_at(&self, uid: u32, now: Instant) -> bool {
+        let mut entry = self.state.entry(uid).or_insert_with(|| State::fresh(now));
+
+        // If the previous window has expired, start a fresh one.
+        if now.saturating_duration_since(entry.window_started) > WINDOW {
+            *entry = State::fresh(now);
+        }
+        entry.failures += 1;
+
+        if entry.failures >= MAX_FAILURES {
+            entry.locked_until = Some(now + LOCKOUT);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_uid_is_not_locked() {
+        let r = EnableRateLimiter::new();
+        assert!(r.check(1000).is_ok());
+    }
+
+    #[test]
+    fn five_failures_trigger_lockout() {
+        let r = EnableRateLimiter::new();
+        let t0 = Instant::now();
+        for i in 0..(MAX_FAILURES - 1) {
+            let triggered = r.record_failure_at(1000, t0 + Duration::from_millis(100 * i as u64));
+            assert!(!triggered, "should not lock after {} failures", i + 1);
+        }
+        let triggered = r.record_failure_at(1000, t0 + Duration::from_secs(1));
+        assert!(triggered, "should lock on the 5th failure");
+        let err = r
+            .check_at(1000, t0 + Duration::from_secs(1))
+            .expect_err("locked");
+        assert!(err > Duration::from_secs(25));
+    }
+
+    #[test]
+    fn lockout_expires_after_30s() {
+        let r = EnableRateLimiter::new();
+        let t0 = Instant::now();
+        for i in 0..MAX_FAILURES {
+            r.record_failure_at(1000, t0 + Duration::from_millis(100 * i as u64));
+        }
+        assert!(r.check_at(1000, t0 + Duration::from_secs(10)).is_err());
+        assert!(r.check_at(1000, t0 + Duration::from_secs(31)).is_ok());
+    }
+
+    #[test]
+    fn window_resets_after_30s_of_quiet() {
+        // 4 failures, then wait 31 s, then a fresh failure starts a new
+        // window — should not trigger lockout.
+        let r = EnableRateLimiter::new();
+        let t0 = Instant::now();
+        for i in 0..(MAX_FAILURES - 1) {
+            r.record_failure_at(1000, t0 + Duration::from_millis(100 * i as u64));
+        }
+        let triggered = r.record_failure_at(1000, t0 + Duration::from_secs(31));
+        assert!(!triggered);
+        assert!(r.check_at(1000, t0 + Duration::from_secs(31)).is_ok());
+    }
+
+    #[test]
+    fn record_success_clears_state() {
+        let r = EnableRateLimiter::new();
+        let t0 = Instant::now();
+        r.record_failure_at(1000, t0);
+        r.record_failure_at(1000, t0 + Duration::from_millis(100));
+        r.record_success(1000);
+        // A subsequent failure should be counted from zero again.
+        assert!(!r.record_failure_at(1000, t0 + Duration::from_millis(200)));
+    }
+
+    #[test]
+    fn lockout_is_per_uid() {
+        let r = EnableRateLimiter::new();
+        let t0 = Instant::now();
+        for _ in 0..MAX_FAILURES {
+            r.record_failure_at(1000, t0);
+        }
+        assert!(r.check_at(1000, t0).is_err());
+        assert!(r.check_at(1001, t0).is_ok());
+    }
+}

--- a/zebra-rs/src/config/mod.rs
+++ b/zebra-rs/src/config/mod.rs
@@ -13,6 +13,7 @@ pub use serve::Cli;
 pub use serve::VtyAddr;
 pub use serve::serve;
 
+mod enable_rate;
 mod session;
 
 mod configs;

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -9,9 +9,11 @@ use tonic::transport::Server;
 
 use crate::config::api::DeployRequest;
 #[cfg(target_os = "linux")]
+use crate::config::enable_rate::EnableRateLimiter;
+#[cfg(target_os = "linux")]
 use crate::config::session::{
-    DEFAULT_GC_INTERVAL, DEFAULT_IDLE_TTL, ProcfsReader, SessionContext, SessionError,
-    SessionTable, run_gc, watch_bash_death,
+    DEFAULT_GC_INTERVAL, DEFAULT_IDLE_TTL, ENABLE_HARD_CAP, ENABLE_IDLE_TTL, ProcfsReader,
+    SessionContext, SessionError, SessionTable, run_gc, watch_bash_death,
 };
 
 use super::api::{
@@ -23,14 +25,53 @@ use super::vty::clear_server::{Clear, ClearServer};
 use super::vty::exec_server::{Exec, ExecServer};
 use super::vty::show_server::{Show, ShowServer};
 use super::vty::{
-    ApplyReply, ApplyRequest, ClearReply, ClearRequest, CommandPath, ExecCode, ExecReply,
-    ExecRequest, ExecType, LogoutReply, LogoutRequest, ShowReply, ShowRequest, YangMatch,
+    ApplyReply, ApplyRequest, ClearReply, ClearRequest, CommandPath, DisableReply, DisableRequest,
+    EnableReply, EnableRequest, ExecCode, ExecReply, ExecRequest, ExecType, LogoutReply,
+    LogoutRequest, ShowReply, ShowRequest, YangMatch,
 };
 #[derive(Debug)]
 struct ExecService {
     pub tx: mpsc::Sender<Message>,
     #[cfg(target_os = "linux")]
     pub sessions: Arc<SessionTable>,
+    #[cfg(target_os = "linux")]
+    pub enable_rate: Arc<EnableRateLimiter>,
+}
+
+/// Resolve the path to the `vtypam` helper.
+///
+/// `ZEBRA_VTYPAM_BIN` env var wins for developer convenience; otherwise
+/// falls back to the distribution install path `/usr/sbin/vtypam` (D6/D15).
+#[cfg(target_os = "linux")]
+fn vtypam_path() -> std::path::PathBuf {
+    std::env::var_os("ZEBRA_VTYPAM_BIN")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from("/usr/sbin/vtypam"))
+}
+
+/// Spawn vtypam, feed it the password on stdin, and return its exit code.
+///
+/// See `vtypam/src/main.rs` for the exit-code contract (0/1/2/3).
+#[cfg(target_os = "linux")]
+async fn spawn_vtypam(username: &str, password: &str) -> std::io::Result<i32> {
+    use std::process::Stdio;
+    use tokio::io::AsyncWriteExt;
+    use tokio::process::Command;
+
+    let mut child = Command::new(vtypam_path())
+        .arg(username)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(password.as_bytes()).await?;
+        stdin.write_all(b"\n").await?;
+        // Closing stdin signals EOF so vtypam stops waiting for input.
+        drop(stdin);
+    }
+    let status = child.wait().await?;
+    Ok(status.code().unwrap_or(3))
 }
 
 impl ExecService {
@@ -130,6 +171,106 @@ impl Exec for ExecService {
             tracing::info!(uid = ctx.key.0, bash_pid = ctx.key.1, removed, "vty logout",);
         }
         Ok(Response::new(LogoutReply { ok: true }))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    async fn enable(
+        &self,
+        _request: tonic::Request<EnableRequest>,
+    ) -> Result<Response<EnableReply>, tonic::Status> {
+        Err(tonic::Status::unimplemented(
+            "enable requires Linux PAM (vtypam helper)",
+        ))
+    }
+
+    #[cfg(target_os = "linux")]
+    async fn enable(
+        &self,
+        request: tonic::Request<EnableRequest>,
+    ) -> Result<Response<EnableReply>, tonic::Status> {
+        let key = request
+            .extensions()
+            .get::<SessionContext>()
+            .map(|c| c.key)
+            .ok_or_else(|| tonic::Status::unauthenticated("no session"))?;
+        let uid = key.0;
+
+        if let Err(remaining) = self.enable_rate.check(uid) {
+            tracing::warn!(
+                uid,
+                remaining_secs = remaining.as_secs(),
+                "enable rate limited"
+            );
+            return Err(tonic::Status::resource_exhausted(format!(
+                "rate limited; retry in {}s",
+                remaining.as_secs().max(1)
+            )));
+        }
+
+        let username = self.sessions.username(&key).ok_or_else(|| {
+            tracing::warn!(uid, "enable refused: uid not in passwd db");
+            tonic::Status::permission_denied("uid has no system account")
+        })?;
+
+        let password = request.into_inner().password;
+        let exit = match spawn_vtypam(&username, &password).await {
+            Ok(code) => code,
+            Err(e) => {
+                tracing::error!(uid, error = %e, "vtypam spawn failed");
+                return Err(tonic::Status::internal("authentication helper unavailable"));
+            }
+        };
+
+        match exit {
+            0 => {
+                self.enable_rate.record_success(uid);
+                let promoted =
+                    self.sessions
+                        .promote_to_admin(&key, ENABLE_IDLE_TTL, ENABLE_HARD_CAP);
+                if !promoted {
+                    return Err(tonic::Status::unauthenticated("session vanished"));
+                }
+                tracing::info!(uid, user = %username, "enable success");
+                Ok(Response::new(EnableReply {
+                    ok: true,
+                    message: String::new(),
+                    ttl_secs: ENABLE_IDLE_TTL.as_secs() as u32,
+                }))
+            }
+            1 => {
+                let locked = self.enable_rate.record_failure(uid);
+                tracing::warn!(uid, user = %username, locked, "enable auth failed");
+                Err(tonic::Status::permission_denied("authentication failed"))
+            }
+            2 => {
+                self.enable_rate.record_failure(uid);
+                tracing::warn!(uid, user = %username, "enable refused: account not permitted");
+                Err(tonic::Status::permission_denied("account not permitted"))
+            }
+            _ => {
+                tracing::error!(uid, user = %username, exit, "vtypam system error");
+                Err(tonic::Status::internal("authentication system error"))
+            }
+        }
+    }
+
+    async fn disable(
+        &self,
+        #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] request: tonic::Request<
+            DisableRequest,
+        >,
+    ) -> Result<Response<DisableReply>, tonic::Status> {
+        #[cfg(target_os = "linux")]
+        if let Some(ctx) = request.extensions().get::<SessionContext>() {
+            let cleared = self.sessions.disable(&ctx.key);
+            tracing::info!(
+                uid = ctx.key.0,
+                bash_pid = ctx.key.1,
+                cleared,
+                "vty disable",
+            );
+        }
+        Ok(Response::new(DisableReply { ok: true }))
     }
 }
 
@@ -494,11 +635,15 @@ impl tonic::service::Interceptor for VtyPeerInterceptor {
 pub fn serve(cli: Cli, addr: VtyAddr) -> anyhow::Result<()> {
     #[cfg(target_os = "linux")]
     let sessions = SessionTable::new();
+    #[cfg(target_os = "linux")]
+    let enable_rate = EnableRateLimiter::new();
 
     let exec_service = ExecService {
         tx: cli.tx.clone(),
         #[cfg(target_os = "linux")]
         sessions: sessions.clone(),
+        #[cfg(target_os = "linux")]
+        enable_rate: enable_rate.clone(),
     };
     let show_service = ShowService { tx: cli.tx.clone() };
     let apply_service = ApplyService { tx: cli.tx.clone() };

--- a/zebra-rs/src/config/session.rs
+++ b/zebra-rs/src/config/session.rs
@@ -59,16 +59,18 @@ pub struct SessionContext {
 
 /// Session record.
 ///
-/// Phase 1 added the identity and timing fields. Phase 4-a adds the RBAC
-/// (`role`) and enable-state (`enabled`, `enable_expires`,
-/// `enable_hard_deadline`) fields. Phase 4-c (Enable/Disable RPC) wires the
-/// consumption logic; until then these fields are populated with default
-/// values but never read outside tests.
+/// Phase 1 added the identity and timing fields. Phase 4-a added the RBAC
+/// (`role`) and enable-state fields. Phase 4-c adds `username` (resolved
+/// once at session creation) and wires the consumption logic.
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct Session {
     pub uid: u32,
     pub bash_pid: u32,
+    /// Resolved via `getpwuid_r` at session creation. `None` only when the
+    /// lookup failed (uid not in passwd db); in that case enable cannot
+    /// run and admin operations fail closed.
+    pub username: Option<String>,
     pub created: Instant,
     pub last_active: Instant,
     /// Current authorization role. Defaults to `View`.
@@ -76,20 +78,31 @@ pub struct Session {
     /// Whether the session has authenticated via `enable`. When `true`,
     /// both `enable_expires` and `enable_hard_deadline` are `Some`.
     pub enabled: bool,
-    /// Sliding deadline (refreshed on each authorized RPC). Phase 4-c will
-    /// drop back to disabled when `now >= enable_expires`.
+    /// Sliding deadline (refreshed on each authorized RPC). The session
+    /// drops back to disabled when `now >= enable_expires`.
     pub enable_expires: Option<Instant>,
     /// Absolute deadline from the original `enable`. Not extended by
     /// activity (see D2).
     pub enable_hard_deadline: Option<Instant>,
 }
 
+/// Default sliding idle TTL for the admin role granted by `enable`.
+/// 15 minutes per D2.
+#[cfg(target_os = "linux")]
+pub const ENABLE_IDLE_TTL: Duration = Duration::from_secs(15 * 60);
+
+/// Default hard cap on the admin role from the original `enable`.
+/// 4 hours per D2.
+#[cfg(target_os = "linux")]
+pub const ENABLE_HARD_CAP: Duration = Duration::from_secs(4 * 60 * 60);
+
 impl Session {
-    fn new(uid: u32, bash_pid: u32) -> Self {
+    fn new(uid: u32, bash_pid: u32, username: Option<String>) -> Self {
         let now = Instant::now();
         Self {
             uid,
             bash_pid,
+            username,
             created: now,
             last_active: now,
             role: Role::View,
@@ -183,8 +196,50 @@ impl SessionTable {
             return Err(SessionError::ParentUidMismatch);
         }
 
-        self.sessions.insert(key, Session::new(peer_uid, ppid_u32));
+        let username = reader.resolve_username(peer_uid);
+        self.sessions
+            .insert(key, Session::new(peer_uid, ppid_u32, username));
         Ok((key, true))
+    }
+
+    /// Promote a session to Admin after a successful `enable`.
+    ///
+    /// Sets `role = Admin`, `enabled = true`, and the two deadlines.
+    /// Returns true if the session existed (i.e. the promotion landed).
+    pub fn promote_to_admin(
+        &self,
+        key: &SessionKey,
+        idle_ttl: Duration,
+        hard_cap: Duration,
+    ) -> bool {
+        let now = Instant::now();
+        if let Some(mut s) = self.sessions.get_mut(key) {
+            s.role = Role::Admin;
+            s.enabled = true;
+            s.enable_expires = Some(now + idle_ttl);
+            s.enable_hard_deadline = Some(now + hard_cap);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Drop a session back to the View role. Idempotent.
+    pub fn disable(&self, key: &SessionKey) -> bool {
+        if let Some(mut s) = self.sessions.get_mut(key) {
+            s.role = Role::View;
+            s.enabled = false;
+            s.enable_expires = None;
+            s.enable_hard_deadline = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Read the username cached on the session, if present.
+    pub fn username(&self, key: &SessionKey) -> Option<String> {
+        self.sessions.get(key).and_then(|s| s.username.clone())
     }
 
     /// Sweep stale sessions in a single pass.
@@ -243,6 +298,7 @@ impl SessionTable {
             Session {
                 uid: key.0,
                 bash_pid: key.1,
+                username: None,
                 created: last_active,
                 last_active,
                 role: Role::View,
@@ -369,14 +425,17 @@ where
     }
 }
 
-/// Indirection over `/proc/{pid}/...` reads so unit tests can stub them
-/// without spawning real processes.
+/// Indirection over `/proc/{pid}/...` and `getpwuid_r` so unit tests can
+/// stub them without spawning real processes or relying on local passwd.
 pub trait ProcStatusReader {
     fn read_ppid(&self, pid: i32) -> Result<i32, std::io::Error>;
     fn read_ruid(&self, pid: i32) -> Result<u32, std::io::Error>;
     /// Lightweight check whether `/proc/{pid}` is still present. Used by
     /// the GC sweep to drop sessions whose parent shell has died.
     fn process_exists(&self, pid: i32) -> bool;
+    /// Resolve uid -> username via the system passwd database. `None` when
+    /// the uid has no passwd entry.
+    fn resolve_username(&self, uid: u32) -> Option<String>;
 }
 
 #[cfg(target_os = "linux")]
@@ -404,6 +463,36 @@ impl ProcStatusReader for ProcfsReader {
 
     fn process_exists(&self, pid: i32) -> bool {
         procfs::process::Process::new(pid).is_ok()
+    }
+
+    fn resolve_username(&self, uid: u32) -> Option<String> {
+        use std::ffi::CStr;
+        use std::mem::MaybeUninit;
+
+        // 1 KiB covers practical passwd entries. If a name+gecos field is
+        // huge, getpwuid_r returns ERANGE and we treat the lookup as a miss.
+        let mut buf = vec![0u8; 1024];
+        let mut pwd: MaybeUninit<libc::passwd> = MaybeUninit::uninit();
+        let mut result: *mut libc::passwd = std::ptr::null_mut();
+        // SAFETY: We pass our own pwd storage and a writable buf; libc fills
+        // both and sets `result` to either &pwd or NULL.
+        let rc = unsafe {
+            libc::getpwuid_r(
+                uid,
+                pwd.as_mut_ptr(),
+                buf.as_mut_ptr() as *mut libc::c_char,
+                buf.len(),
+                &mut result,
+            )
+        };
+        if rc != 0 || result.is_null() {
+            return None;
+        }
+        // SAFETY: getpwuid_r succeeded and result == &pwd; pw_name points
+        // into `buf` which we still own.
+        let pwd = unsafe { pwd.assume_init() };
+        let name = unsafe { CStr::from_ptr(pwd.pw_name) };
+        name.to_str().ok().map(String::from)
     }
 }
 
@@ -460,6 +549,11 @@ mod tests {
         }
         fn process_exists(&self, pid: i32) -> bool {
             !self.missing.lock().unwrap().contains(&pid)
+        }
+        fn resolve_username(&self, uid: u32) -> Option<String> {
+            // Tests don't care about the real passwd db; synthesize a
+            // deterministic name so they can verify the field is populated.
+            Some(format!("u{uid}"))
         }
     }
 


### PR DESCRIPTION
## Summary

Wires the daemon end-to-end so an operator can run `enable`,
authenticate via PAM (through the `vtypam` helper from Phase 4-b),
hold the Admin role for 15 min sliding (4 h hard cap per D2), and
drop back to View with `disable`.

### proto

- `Exec.Enable(EnableRequest{password}) -> EnableReply{ok, message, ttl_secs}`
- `Exec.Disable(DisableRequest{}) -> DisableReply{ok}`

### Daemon (`zebra-rs/src/config/{serve,session,enable_rate}.rs`)

- `Session` gains `username` (resolved via `getpwuid_r` at session
  creation; cached for the session lifetime).
- `SessionTable` gains `promote_to_admin(key, ttl, hard_cap)`,
  `disable(key)`, `username(key)`.
- New `enable_rate` module: per-uid sliding-window rate limiter
  (D17). 5 failures within 30 s -> 30 s lockout; success clears
  the window. In-memory only; doesn't survive restart (D3). 6 unit
  tests with controllable `Instant`.
- `ExecService::enable`:
  - Reads `SessionContext` (Phase 6 plumbing).
  - `check()` rate limit -> `ResourceExhausted`.
  - Looks up username from session -> `PermissionDenied` if uid has
    no passwd entry.
  - Spawns `vtypam` via `tokio::process` with password on stdin.
  - Maps exit 0 -> promote, 1 -> auth fail, 2 -> acct invalid,
    3+ -> internal.
  - Records failure on 1/2; clears on 0.
- `ExecService::disable`: clears role / enabled / deadlines.
- `ZEBRA_VTYPAM_BIN` env var overrides the `/usr/sbin/vtypam`
  default path (dev / packaging flexibility).

### Client (`vtyhelper`)

- New `-e/--enable` and `-d/--disable` flags. Both control their
  own exit codes so the shell wrapper can flip `CLI_PRIVILEGE`.
- Enable reads password from `CLI_ENABLE_PASSWORD` env, wipes it
  immediately, sends RPC, prints `% Enabled (...)` or
  `% Enable failed: ...`.
- Exit codes: 0 = success, 1 = auth fail, 2 = transport/other.

### Shell (`vty/additions/vty.sh`)

- `enable()` function: reads password with `stty -echo`, passes
  via env var, invokes `vtyhelper -e`, flips `CLI_PRIVILEGE=15` on
  success and refreshes the prompt.
- `disable()` function: invokes `vtyhelper -d`, flips
  `CLI_PRIVILEGE=1`.
- Unalias `enable`/`disable` after first-level command registration
  so the daemon's command alias never shadows our shell function.

### What this PR does NOT do

The handlers are wired but no RPC currently *consumes* the admin
role for authorization yet — `enable` doesn't gate anything in
this PR. Gating `configure`/`write`/`clear` etc. will land in a
follow-up that takes a side on which RPCs require Admin.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs config::` — 56/56 pass
  (15 session + 6 enable_rate + others)
- [ ] CI: fmt, clippy, test
- [ ] Manual smoke: install vtypam to /usr/sbin, copy
      etc/pam.d/zebra-rs.example to /etc/pam.d/zebra-rs, start vty,
      run `enable`, verify prompt flip + `% Enabled` line

Generated with [Claude Code](https://claude.com/claude-code)