### PR TITLE
vty: Phase 4-d — env-var-driven service accounts (D21)

### DIFF
--- a/book/src/ch-06-00-vty-access.md
+++ b/book/src/ch-06-00-vty-access.md
@@ -190,6 +190,38 @@ each call is just logged. The allow-list applies only to Unix-socket
 connections; TCP connections carry no peer-cred and are not subject
 to the check.
 
+### `ZEBRA_VTY_SERVICE_ACCOUNTS` — permanent-admin uids
+
+Sessions for uids listed here start with the `Admin` role from
+session creation and do not require an interactive `enable`. Use
+this for automation accounts (Ansible, cron jobs, monitoring) that
+cannot meaningfully type a password.
+
+```bash
+# uid 999 and 1001 are permanent admins; no PAM auth required for them.
+ZEBRA_VTY_SERVICE_ACCOUNTS=999,1001 zebra-rs
+```
+
+The typical deployment sets this in a systemd drop-in:
+
+```ini
+# /etc/systemd/system/zebra-rs.service.d/service-accounts.conf
+[Service]
+Environment=ZEBRA_VTY_SERVICE_ACCOUNTS=999,1001
+```
+
+Notes:
+
+- The value is read once at daemon startup; runtime changes require
+  a `systemctl restart zebra-rs`.
+- Root (uid 0) is always implicit admin and does not need to be
+  listed.
+- If a service-account uid happens to type `enable`, the daemon
+  returns success without invoking PAM (no password prompt).
+- A service-account session can still call `disable` to drop to
+  View for that session only; reconnecting yields a fresh Admin
+  session.
+
 ## Migration from earlier versions
 
 The default transport changed from `tcp:0.0.0.0:2666` to

--- a/book/src/ch-06-01-session-design.md
+++ b/book/src/ch-06-01-session-design.md
@@ -244,19 +244,21 @@ The Session struct carries a `role` field (`View`, `Operator`,
   without invoking PAM.
 - **Interactive**: type `enable`, authenticate via PAM, hold Admin
   for the TTL.
-- **Service account** (for automation): a uid listed in YANG
-  `vty.service-accounts` is permanently Admin without enable:
+- **Service account** (for automation): a uid listed in the env
+  var `ZEBRA_VTY_SERVICE_ACCOUNTS` (CSV of decimal uids) is
+  permanently Admin without enable. Typically set in the
+  daemon's systemd unit:
 
-  ```yaml
-  vty:
-    service-accounts:
-      - uid: 999
-        role: admin
-        description: "Ansible automation account"
+  ```ini
+  # /etc/systemd/system/zebra-rs.service.d/service-accounts.conf
+  [Service]
+  Environment=ZEBRA_VTY_SERVICE_ACCOUNTS=999,1001
   ```
 
   Service accounts bypass PAM (no password to ship in scripts) and
-  are identified by uid alone via SO_PEERCRED.
+  are identified by uid alone via SO_PEERCRED. The env var is read
+  once at daemon startup (D21); changes require restart. Future
+  YANG-driven runtime mutability is the deferred Phase 4-d-ii.
 
 `vtyctl` invocations are short-lived; their sessions exist for one
 or two RPCs and then idle out. Because session state is per-bash_pid
@@ -353,6 +355,7 @@ Each phase is intended to ship as an independent PR.
 | D18 | RBAC is 3-tier: `View`, `Operator`, `Admin`. Maps cleanly onto Cisco priv-lvl ranges 0-1 / 2-14 / 15. YANG-configurable roles are explicitly out of scope. |
 | D19 | Default idle session TTL is **600 s** with a 60 s sweep interval (Cisco IOS `exec-timeout 10 0` convention). Configurable later if a deployment needs it. |
 | D20 | **Root (uid=0) is implicitly Admin.** New sessions for uid=0 are created with `role=Admin` / `enabled=true` / no deadlines; the `enable` RPC short-circuits to success without spawning vtypam. Service-account configuration (Phase 4-d) does not need to list uid 0. Reason: root already owns the host and `pam_unix` against the daemon's own owning account is awkward UX. |
+| D21 | **Service-accounts via env var** for Phase 4-d initial implementation. `ZEBRA_VTY_SERVICE_ACCOUNTS=999,1001,...` (CSV of decimal uids) names uids that are permanent Admin from session creation, with the same shape as root (no deadlines, enable short-circuits to success). State is fixed at daemon startup; runtime changes require a restart. Full YANG integration is deferred to a follow-up (Phase 4-d-ii) if a deployment demands runtime mutability. |
 
 ## Deferred work
 

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -38,6 +38,21 @@ struct ExecService {
     pub enable_rate: Arc<EnableRateLimiter>,
 }
 
+/// Parse the `ZEBRA_VTY_SERVICE_ACCOUNTS` env var into a uid set (D21).
+///
+/// Format: comma-separated decimal uids, optional whitespace around each
+/// entry. Anything that doesn't parse as a `u32` is silently dropped so a
+/// typo in one entry doesn't take out the rest.
+#[cfg(target_os = "linux")]
+fn parse_service_accounts(raw: Option<&str>) -> std::collections::HashSet<u32> {
+    let Some(raw) = raw else {
+        return std::collections::HashSet::new();
+    };
+    raw.split(',')
+        .filter_map(|s| s.trim().parse::<u32>().ok())
+        .collect()
+}
+
 /// Resolve the path to the `vtypam` helper.
 ///
 /// `ZEBRA_VTYPAM_BIN` env var wins for developer convenience; otherwise
@@ -195,10 +210,11 @@ impl Exec for ExecService {
             .ok_or_else(|| tonic::Status::unauthenticated("no session"))?;
         let uid = key.0;
 
-        // Root is already Admin from session creation (D20). Acknowledge
-        // the enable RPC without spawning PAM so no password is prompted.
-        if uid == 0 {
-            tracing::info!(uid, "enable noop (root is implicit admin)");
+        // Root (D20) and configured service accounts (D21) are already
+        // Admin from session creation. Acknowledge the enable RPC without
+        // spawning PAM so no password is prompted.
+        if uid == 0 || self.sessions.is_service_account(uid) {
+            tracing::info!(uid, "enable noop (permanent admin)");
             return Ok(Response::new(EnableReply {
                 ok: true,
                 message: String::new(),
@@ -645,7 +661,17 @@ impl tonic::service::Interceptor for VtyPeerInterceptor {
 
 pub fn serve(cli: Cli, addr: VtyAddr) -> anyhow::Result<()> {
     #[cfg(target_os = "linux")]
-    let sessions = SessionTable::new();
+    let sessions = {
+        let service_accounts =
+            parse_service_accounts(std::env::var("ZEBRA_VTY_SERVICE_ACCOUNTS").ok().as_deref());
+        if !service_accounts.is_empty() {
+            tracing::info!(
+                uids = ?service_accounts,
+                "VTY service-account uids (permanent admin)",
+            );
+        }
+        SessionTable::with_service_accounts(service_accounts)
+    };
     #[cfg(target_os = "linux")]
     let enable_rate = EnableRateLimiter::new();
 
@@ -735,4 +761,34 @@ fn bind_abstract_uds(name: &str) -> anyhow::Result<tokio_stream::wrappers::UnixL
     let listener =
         UnixListener::from_std(std_listener).map_err(|e| anyhow::anyhow!("from_std: {e}"))?;
     Ok(UnixListenerStream::new(listener))
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::parse_service_accounts;
+
+    #[test]
+    fn parse_service_accounts_handles_csv_with_whitespace() {
+        let set = parse_service_accounts(Some(" 999, 1001 ,1003"));
+        assert_eq!(set.len(), 3);
+        assert!(set.contains(&999));
+        assert!(set.contains(&1001));
+        assert!(set.contains(&1003));
+    }
+
+    #[test]
+    fn parse_service_accounts_silently_drops_non_numeric_entries() {
+        // One bad entry should not take out the rest of the list.
+        let set = parse_service_accounts(Some("999,not-a-uid,1001"));
+        assert_eq!(set.len(), 2);
+        assert!(set.contains(&999));
+        assert!(set.contains(&1001));
+    }
+
+    #[test]
+    fn parse_service_accounts_unset_yields_empty() {
+        assert!(parse_service_accounts(None).is_empty());
+        assert!(parse_service_accounts(Some("")).is_empty());
+        assert!(parse_service_accounts(Some(",,,")).is_empty());
+    }
 }

--- a/zebra-rs/src/config/session.rs
+++ b/zebra-rs/src/config/session.rs
@@ -10,6 +10,7 @@
 //! No proto changes, no behavioral changes for existing RPCs — the table
 //! merely observes and records sessions.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -142,14 +143,34 @@ pub enum SessionError {
 #[derive(Debug, Default)]
 pub struct SessionTable {
     sessions: DashMap<SessionKey, Session>,
+    /// uids that are permanently Admin without enable. Read-only after
+    /// construction (env var is fixed at daemon startup; see D21).
+    service_accounts: HashSet<u32>,
 }
 
 #[cfg(target_os = "linux")]
 impl SessionTable {
+    #[cfg(test)]
     pub fn new() -> Arc<Self> {
+        Self::with_service_accounts(HashSet::new())
+    }
+
+    /// Construct a SessionTable with a fixed set of permanent-admin uids.
+    /// uid 0 is always implicitly Admin via [D20]; passing it here is
+    /// allowed but redundant.
+    pub fn with_service_accounts(service_accounts: HashSet<u32>) -> Arc<Self> {
         Arc::new(Self {
             sessions: DashMap::new(),
+            service_accounts,
         })
+    }
+
+    /// Whether the given uid is permanently Admin via the service-account
+    /// allow-list. Used by the Enable handler to short-circuit PAM (a
+    /// service account that mistakenly runs `enable` gets fast success
+    /// instead of a baffling PAM failure).
+    pub fn is_service_account(&self, uid: u32) -> bool {
+        self.service_accounts.contains(&uid)
     }
 
     /// Resolve the session for an incoming RPC.
@@ -198,13 +219,12 @@ impl SessionTable {
 
         let username = reader.resolve_username(peer_uid);
         let mut session = Session::new(peer_uid, ppid_u32, username);
-        // Root is implicitly Admin: it owns the system and has no
-        // meaningful PAM identity to authenticate against. See D20.
-        if peer_uid == 0 {
+        // Permanent-admin uids: root (D20) and any uid in the
+        // service-account allow-list (D21). Both bypass enable and have
+        // no deadlines.
+        if peer_uid == 0 || self.service_accounts.contains(&peer_uid) {
             session.role = Role::Admin;
             session.enabled = true;
-            // Deadlines stay None — root is permanent admin, not a
-            // time-bounded promotion.
         }
         self.sessions.insert(key, session);
         Ok((key, true))
@@ -625,6 +645,47 @@ mod tests {
         // Non-root sessions start as View, not enabled.
         assert_eq!(sess.role, Role::View);
         assert!(!sess.enabled);
+    }
+
+    #[test]
+    fn service_account_session_starts_as_permanent_admin() {
+        // D21: any uid listed in service_accounts is implicit Admin from
+        // session creation, with no deadlines (same shape as root).
+        let mut accounts = HashSet::new();
+        accounts.insert(999);
+        let table = SessionTable::with_service_accounts(accounts);
+        let reader = StubReader::default();
+        reader.set_ppid(1234, 2000);
+        reader.set_ruid(2000, 999);
+
+        let (key, is_new) = table.resolve(&reader, 999, 1234).unwrap();
+        assert_eq!(key, (999, 2000));
+        assert!(is_new);
+        let sess = table.get(&key).unwrap();
+        assert_eq!(sess.role, Role::Admin);
+        assert!(sess.enabled);
+        assert!(sess.enable_expires.is_none());
+        assert!(sess.enable_hard_deadline.is_none());
+
+        // Non-service-account uid on the same table stays View.
+        reader.set_ppid(1235, 3000);
+        reader.set_ruid(3000, 1000);
+        let (other, _) = table.resolve(&reader, 1000, 1235).unwrap();
+        let other_sess = table.get(&other).unwrap();
+        assert_eq!(other_sess.role, Role::View);
+        assert!(!other_sess.enabled);
+    }
+
+    #[test]
+    fn is_service_account_reports_membership() {
+        let mut accounts = HashSet::new();
+        accounts.insert(999);
+        accounts.insert(1001);
+        let table = SessionTable::with_service_accounts(accounts);
+        assert!(table.is_service_account(999));
+        assert!(table.is_service_account(1001));
+        assert!(!table.is_service_account(1000));
+        assert!(!table.is_service_account(0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a permanent-admin path for automation accounts (Ansible, cron,
monitoring) that cannot meaningfully type a password. Mirrors the
existing root special-casing (D20).

### Behavior

- New env var `ZEBRA_VTY_SERVICE_ACCOUNTS=999,1001` (CSV of decimal
  uids). Listed uids are promoted to Admin from session creation
  with the same shape as root: `enabled=true`, no deadlines.
- The Enable RPC short-circuits to success for service-account uids
  (no PAM spawn, no password prompt) — matches the root path so a
  service account that mistakenly types `enable` doesn't get a
  baffling PAM failure.
- Value is read once at daemon startup; runtime changes require a
  restart. Full YANG-driven mutability is deferred (Phase 4-d-ii).
- A service-account session can still call `disable` to drop to
  View for that session only; reconnecting yields a fresh Admin
  session.

### Implementation

- `SessionTable` now carries an immutable `service_accounts:
  HashSet<u32>` set at construction. New `with_service_accounts`
  constructor; the no-arg `new()` is now test-only.
- `resolve()` extends the root branch to also promote any uid in
  the service-accounts set.
- `is_service_account(uid)` exposed for the Enable handler to
  short-circuit.
- `serve.rs` parses the env var via `parse_service_accounts(...)`
  (silently drops non-numeric entries so a typo doesn't take out
  the rest of the list) and passes the result to
  `SessionTable::with_service_accounts`.

### Tests

- Two new session tests:
  `service_account_session_starts_as_permanent_admin` verifies
  promotion + checks that non-service-account uids stay View on
  the same table. `is_service_account_reports_membership` covers
  the lookup helper.
- Three new serve.rs tests for the CSV parser (whitespace, bad
  entries, empty/unset).

### Docs

- Design notes: D21 added; RBAC section updated to use the env-var
  form (replacing the earlier YANG placeholder snippet).
- `ch-06-00-vty-access.md` gains a `ZEBRA_VTY_SERVICE_ACCOUNTS`
  section with a systemd drop-in example.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs config::` — 62/62 pass
- [ ] CI: fmt, clippy, test
- [ ] Manual: start daemon with
      `ZEBRA_VTY_SERVICE_ACCOUNTS=$(id -u)`, verify Admin role from
      first RPC without enable

Generated with [Claude Code](https://claude.com/claude-code)