### PR TITLE
vty: humanize startup error messages (bind, etc.)

### DIFF
--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -850,15 +850,31 @@ fn bind_abstract_uds(name: &str) -> anyhow::Result<tokio_stream::wrappers::UnixL
     use tokio::net::UnixListener;
     use tokio_stream::wrappers::UnixListenerStream;
 
-    let addr = StdSockAddr::from_abstract_name(name.as_bytes())
-        .map_err(|e| anyhow::anyhow!("from_abstract_name: {e}"))?;
-    let std_listener =
-        StdUnixListener::bind_addr(&addr).map_err(|e| anyhow::anyhow!("bind_addr: {e}"))?;
+    let addr = StdSockAddr::from_abstract_name(name.as_bytes()).map_err(|e| {
+        anyhow::anyhow!("invalid abstract socket name '@{name}' (contains NUL?): {e}")
+    })?;
+
+    let std_listener = StdUnixListener::bind_addr(&addr).map_err(|e| match e.kind() {
+        std::io::ErrorKind::AddrInUse => anyhow::anyhow!(
+            "abstract VTY socket '@{name}' is already in use.\n\
+             Another zebra-rs daemon is likely running in this network namespace.\n\
+             Check with:    ss -xal | grep '@{name}'\n\
+             Then either stop the running daemon (e.g. 'systemctl stop zebra-rs')\n\
+             or start this one in a different netns ('ip netns exec ...').",
+        ),
+        std::io::ErrorKind::PermissionDenied => anyhow::anyhow!(
+            "permission denied binding abstract VTY socket '@{name}'.\n\
+             Abstract Unix sockets are scoped by the network namespace; check\n\
+             that the daemon has access to it (CAP_NET_ADMIN in the current ns).",
+        ),
+        _ => anyhow::anyhow!("failed to bind abstract VTY socket '@{name}': {e}"),
+    })?;
+
     std_listener
         .set_nonblocking(true)
-        .map_err(|e| anyhow::anyhow!("set_nonblocking: {e}"))?;
-    let listener =
-        UnixListener::from_std(std_listener).map_err(|e| anyhow::anyhow!("from_std: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("set_nonblocking on abstract VTY socket '@{name}': {e}"))?;
+    let listener = UnixListener::from_std(std_listener)
+        .map_err(|e| anyhow::anyhow!("register abstract VTY socket '@{name}' with tokio: {e}"))?;
     Ok(UnixListenerStream::new(listener))
 }
 

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -144,7 +144,17 @@ fn write_pid_file(path: &str) -> anyhow::Result<()> {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() {
+    if let Err(e) = run().await {
+        // Use anyhow's alternate-format Display to print the message
+        // and its cause chain without the (rarely actionable) stack
+        // backtrace that the default `Debug` representation includes.
+        eprintln!("zebra-rs: {e:#}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> anyhow::Result<()> {
     let arg = Arg::parse();
 
     let yang_path = yang_path(&arg);


### PR DESCRIPTION
## Summary

Two related improvements so an operator who runs into a startup
failure gets an actionable line of text instead of a stack trace.

### Before

```
Error: bind_addr: Address already in use (os error 98)

Stack backtrace:
   0: <std::backtrace::Backtrace>::create
   1: anyhow::error::<impl anyhow::Error>::msg
   ... (12 more frames)
```

### After

```
zebra-rs: abstract VTY socket '@zebra-rs/vty' is already in use.
Another zebra-rs daemon is likely running in this network namespace.
Check with:    ss -xal | grep '@zebra-rs/vty'
Then either stop the running daemon (e.g. 'systemctl stop zebra-rs')
or start this one in a different netns ('ip netns exec ...').
```

### `bind_abstract_uds`

Branch on `io::ErrorKind`:

- **AddrInUse** (by-far-most-common): the actionable message above.
- **PermissionDenied**: explains netns scoping and `CAP_NET_ADMIN`.
- **Other**: generic message that still includes the socket name.

The other paths in the function (`from_abstract_name`,
`set_nonblocking`, `from_std`) also get the socket name in their
text.

### `main`

Wrap the existing main body in a `run()` function. `main()` catches
its `Result` and prints with `{e:#}` (Display + cause chain)
instead of the default `Debug` representation, which suppresses
the rarely-actionable stack backtrace and emits a single
`zebra-rs: ` prefixed message.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs config::` — 74/74 pass
- [x] Manual smoke: ran two instances against the same abstract
      socket; the second printed the message above and exited 1
      with no backtrace.
- [ ] CI: fmt, clippy, test

Generated with [Claude Code](https://claude.com/claude-code)