### PR TITLE
Makefile: make 'make run' grant uid 1000 permanent admin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ run:
 	@sudo rm -f /tmp/ipc/pair/config-ng_bgpd
 	@RUSTFLAGS="--cfg tokio_unstable" cargo build --bin zebra-rs --release
 	@sudo setcap 'cap_net_bind_service=ep cap_net_admin=ep cap_net_bind_service=ep cap_net_broadcast=ep cap_net_raw=ep' target/release/zebra-rs
-	@target/release/zebra-rs
+	@ZEBRA_VTY_SERVICE_ACCOUNTS=1000 target/release/zebra-rs
 	#target/release/zebra-rs --no-nhid
 	#target/release/zebra-rs --log-format elasticsearch
 	#target/release/zebra-rs --log-output file


### PR DESCRIPTION
## Summary

Adds `ZEBRA_VTY_SERVICE_ACCOUNTS=1000` to the dev `make run`
target so a typical single-user dev VM (uid 1000) can enter
configure mode immediately without typing root's password every
iteration.

Production installs should set this via a systemd drop-in
(`Environment=ZEBRA_VTY_SERVICE_ACCOUNTS=...`) instead.

## Test plan

- [x] `make run` still builds and starts the daemon
- [ ] CI: fmt, clippy, test

Generated with [Claude Code](https://claude.com/claude-code)