### PR TITLE
book: rename 'The Zebra' to 'zebra-rs' in titles

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -1,5 +1,5 @@
 [book]
-title = "The Zebra Routing Software"
+title = "zebra-rs Routing Software"
 authors = ["Kunihiro Ishiguro"]
 language = "en"
 src = "src"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,6 +1,6 @@
-# The Zebra Routing Software
+# zebra-rs Routing Software
 
-[The Zebra Routing Software](ch-00-00-introduction.md)
+[zebra-rs Routing Software](ch-00-00-introduction.md)
 - [Separation of Reachability Information and Forwarding Decision](ch-00-01-reachability-information.md)
 - [Router ID Selection](ch-00-02-router-id.md)
 


### PR DESCRIPTION
## Summary

Three occurrences across `book.toml` and `SUMMARY.md` aligned to
the canonical project name (matches the crate name, the binary
name, and the prose in `ch-00-00-introduction.md`).

| Before | After |
|---|---|
| `title = "The Zebra Routing Software"` (book.toml) | `title = "zebra-rs Routing Software"` |
| `# The Zebra Routing Software` (SUMMARY.md heading) | `# zebra-rs Routing Software` |
| `[The Zebra Routing Software](...)` (SUMMARY.md link) | `[zebra-rs Routing Software](...)` |

The historical `GNU Zebra` references in the introduction stay
unchanged — those name the original C project this software was
inspired by, not this codebase.

## Test plan

- [x] `grep -rn 'The Zebra' book/` returns no matches
- [ ] CI: fmt, clippy, test

Generated with [Claude Code](https://claude.com/claude-code)