### PR TITLE
vty: enable/disable in YANG + pretty-print 'json' command

### DIFF
--- a/zebra-rs/src/config/commands.rs
+++ b/zebra-rs/src/config/commands.rs
@@ -160,9 +160,20 @@ fn running(config: &ConfigManager) -> (ExecCode, String) {
 }
 
 fn json(config: &ConfigManager) -> (ExecCode, String) {
-    let mut output = String::new();
-    config.store.candidate.borrow().json(&mut output);
-    (ExecCode::Show, output)
+    let mut compact = String::new();
+    config.store.candidate.borrow().json(&mut compact);
+    // Round-trip through serde to indent. The internal json() emitter
+    // produces compact JSON; for human display we want pretty-printed
+    // output with 2-space indent. `preserve_order` is enabled at the
+    // workspace level so key order survives the round-trip.
+    let pretty = serde_json::from_str::<serde_json::Value>(&compact)
+        .and_then(|v| serde_json::to_string_pretty(&v))
+        .map(|mut s| {
+            s.push('\n');
+            s
+        })
+        .unwrap_or(compact);
+    (ExecCode::Show, pretty)
 }
 
 fn yaml(config: &ConfigManager) -> (ExecCode, String) {

--- a/zebra-rs/src/config/commands.rs
+++ b/zebra-rs/src/config/commands.rs
@@ -33,6 +33,8 @@ pub fn exec_mode_create(entry: Rc<Entry>) -> Mode {
     mode.install_func(String::from("/help"), help);
     mode.install_func(String::from("/show/version"), show_version);
     mode.install_func(String::from("/configure"), configure);
+    mode.install_func(String::from("/enable"), enable);
+    mode.install_func(String::from("/disable"), disable);
     mode.install_func(String::from("/cli/format/json"), cli_format_json);
     mode.install_func(String::from("/cli/format/terminal"), cli_format_terminal);
     mode
@@ -83,6 +85,31 @@ fn configure(_config: &ConfigManager) -> (ExecCode, String) {
     let cli_command = r#"SuccessExec
 CLI_MODE=configure;CLI_MODE_STR=Configure;CLI_PRIVILEGE=15;_cli_refresh"#;
     (ExecCode::Success, cli_command.to_string())
+}
+
+/// Fallback handler for `enable` typed via DoExec.
+///
+/// The vty shell intercepts `enable` with a bash function (vty/additions/vty.sh)
+/// so the password can be read locally with `stty -echo`. The Enable RPC then
+/// carries the password — DoExec is never used for the interactive path. This
+/// handler exists for the rare manual case of `vtyhelper -m exec enable` and
+/// returns a usage hint instead of silently doing nothing.
+fn enable(_config: &ConfigManager) -> (ExecCode, String) {
+    let msg = "% 'enable' must be typed inside the 'vty' shell so the password \
+               can be read without echo.\n\
+               % From outside the vty shell, use 'vtyhelper -e' with the \
+               CLI_ENABLE_PASSWORD env var set.\n";
+    (ExecCode::Show, msg.to_string())
+}
+
+/// Fallback handler for `disable`. See `enable` above; for `disable` the vty
+/// shell wraps `vtyhelper -d` so it can also flip the local CLI_PRIVILEGE for
+/// the prompt change. From scripts, run `vtyhelper -d` directly.
+fn disable(_config: &ConfigManager) -> (ExecCode, String) {
+    let msg = "% 'disable' is handled by the vty shell wrapper so the local \
+               CLI_PRIVILEGE can be reset for the prompt.\n\
+               % From scripts, use 'vtyhelper -d' directly.\n";
+    (ExecCode::Show, msg.to_string())
 }
 
 fn cli_format_json(_config: &ConfigManager) -> (ExecCode, String) {

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -22,6 +22,16 @@ module exec {
     type empty;
   }
 
+  leaf enable {
+    ext:help "Promote this session to the admin role (PAM auth)";
+    type empty;
+  }
+
+  leaf disable {
+    ext:help "Drop this session back to the view role";
+    type empty;
+  }
+
   container show {
     ext:help "Show command";
     presence "Show command";


### PR DESCRIPTION
## Summary

Two small CLI ergonomics improvements bundled together.

### 1. enable / disable as first-class exec commands

- `exec.yang` gains `leaf enable` and `leaf disable` with help
  text. This is what was missing — until now both commands were
  only a bash wrapper in `vty/additions/vty.sh` and didn't appear
  in Tab completion or `?` help.
- `commands.rs` `exec_mode_create` installs fallback handlers for
  `/enable` and `/disable` so the rare manual
  `vtyhelper -m exec enable` path gets a usage hint instead of
  silently returning nothing.

The interactive flow is **unchanged**: the vty shell's bash
functions still intercept the typed command — `enable` so the
password can be read locally with `stty -echo`, `disable` so
`CLI_PRIVILEGE` can be flipped for the prompt change. Those
functions never go through DoExec; they call vtyhelper -e / -d
directly which use the dedicated Enable / Disable RPCs.

After this PR:
- `ena<Tab>` completes to `enable` (likewise `dis<Tab>`)
- `?` in exec mode lists both commands with their help text

### 2. `json` command pretty-prints

`json` in configure mode used to dump the candidate as a single
compact line — fine for machines, hard to read for humans. Now
round-trips through `serde_json` to get 2-space indent + trailing
newline. `preserve_order` is enabled at the workspace level so
key ordering survives the round-trip. Falls back to the compact
form on parse/serialize failure (empty candidate, etc.) so the
worst case is the prior behavior.

Before:

```
{"vty":{"service-account":[{"uid":1000}]}}
```

After:

```json
{
  "vty": {
    "service-account": [
      {
        "uid": 1000
      }
    ]
  }
}
```

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs config::` — 74/74 pass
- [ ] CI: fmt, clippy, test
- [ ] Manual smoke:
  - `vty` → `ena<Tab>` shows `enable`, `?` shows the help line
  - `configure` → `set vty service-account 1000` → `json` →
    output is indented across multiple lines

Generated with [Claude Code](https://claude.com/claude-code)