### PR TITLE
vty: skip configure auto-elevate prompt for already-enabled users

### DIFF
--- a/vty/additions/vty.sh
+++ b/vty/additions/vty.sh
@@ -353,36 +353,42 @@ configure ()
     return 1
   fi
 
-  # Optimistic first attempt — admin sessions succeed immediately
-  # without any prompt.
-  local out first_line
-  out=$(${cli_command} -m exec configure 2>&1)
-  first_line=$(echo "$out" | head -n 1)
-  if [[ "${first_line}" != "SuccessExec" ]]; then
-    # Permission denied (or other error). Prompt for the root
-    # password and elevate via PAM.
-    local pw
-    if [[ -t 0 ]]; then
-      stty -echo
-      read -r -p "Password: " pw
-      stty echo
-      echo
-    else
-      IFS= read -r pw
-    fi
-    CLI_ENABLE_PASSWORD="${pw}" ${cli_command} -e --auth-user root -m ${CLI_MODE}
-    local rc=$?
-    pw=""
-    unset pw
-    if [[ ${rc} -ne 0 ]]; then
-      echo "% Configuration access denied"
-      return 1
+  # Fast path: if the caller already enabled (CLI_PRIVILEGE >= 15),
+  # skip the auto-elevate probe entirely. enable() sets
+  # CLI_PRIVILEGE=15 on success, so this avoids re-prompting an
+  # already-authenticated operator under any circumstance.
+  if (( CLI_PRIVILEGE < 15 )); then
+    # Optimistic first attempt — root / service-account sessions
+    # succeed immediately without any prompt.
+    local out first_line
+    out=$(${cli_command} -m exec configure 2>&1)
+    first_line=$(echo "$out" | head -n 1)
+    if [[ "${first_line}" != "SuccessExec" ]]; then
+      # Permission denied (or other error). Prompt for the root
+      # password and elevate via PAM.
+      local pw
+      if [[ -t 0 ]]; then
+        stty -echo
+        read -r -p "Password: " pw
+        stty echo
+        echo
+      else
+        IFS= read -r pw
+      fi
+      CLI_ENABLE_PASSWORD="${pw}" ${cli_command} -e --auth-user root -m ${CLI_MODE}
+      local rc=$?
+      pw=""
+      unset pw
+      if [[ ${rc} -ne 0 ]]; then
+        echo "% Configuration access denied"
+        return 1
+      fi
     fi
   fi
 
-  # Either the optimistic attempt succeeded or we just elevated.
-  # Run the command for real via the standard exec path so the
-  # daemon's SuccessExec script flips CLI_MODE etc.
+  # Either we were already admin, the optimistic attempt succeeded,
+  # or we just elevated. Run the command for real via the standard
+  # exec path so the daemon's SuccessExec script flips CLI_MODE etc.
   _cli_exec configure
   CLI_PRIVILEGE=15
   _cli_prompt_setup


### PR DESCRIPTION
## Summary

The `configure` shell function ran an optimistic
`vtyhelper -m exec configure` probe and only prompted for a
password when the probe returned `PermissionDenied`. That's the
right strategy for root and for service-account sessions where
the local shell has no way to know it's already admin
server-side.

But for users who explicitly ran `enable`, the shell already
flipped `CLI_PRIVILEGE=15` to drive the prompt change. Probing
the daemon for those users is unnecessary, and any path on which
the probe spuriously reported a non-`SuccessExec` line would drop
the operator into a "Password:" prompt right after they had just
authenticated. The result was a confusing double-auth.

## Fix

Add a fast-path check at the top of `configure()`: if
`CLI_PRIVILEGE >= 15`, skip both the optimistic probe and the
prompt branch and go straight to the mode-flip via `_cli_exec
configure`. The probe + prompt logic still runs for non-enabled
sessions, covering both the already-admin root / service-account
case (probe succeeds) and the needs-elevate case (probe fails ->
prompt).

## Behavior matrix

| Caller state | `configure` behavior |
|---|---|
| root (implicit admin) | probe succeeds → enter immediately |
| service-account uid | probe succeeds → enter immediately |
| user with active `enable` (CLI_PRIVILEGE=15) | **fast-path → enter immediately, no probe** |
| user not enabled | probe fails → `Password:` → root PAM → enter |

## Test plan

- [x] `rm -rf vty/build && make -C vty` produces a fresh binary
- [x] `grep -ac CLI_ENABLE_PASSWORD vty/build/vty` returns 2
- [ ] CI: fmt, clippy, test
- [ ] Manual: install rebuilt vty; `enable` succeeds; subsequent
      `configure` enters configure mode with no password prompt

Generated with [Claude Code](https://claude.com/claude-code)