### PR TITLE
Makefile: 'make run' uses caller's uid; 'make clean' also cleans vty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ run:
 	@sudo rm -f /tmp/ipc/pair/config-ng_bgpd
 	@RUSTFLAGS="--cfg tokio_unstable" cargo build --bin zebra-rs --release
 	@sudo setcap 'cap_net_bind_service=ep cap_net_admin=ep cap_net_bind_service=ep cap_net_broadcast=ep cap_net_raw=ep' target/release/zebra-rs
-	@ZEBRA_VTY_SERVICE_ACCOUNTS=1000 target/release/zebra-rs
+	@ZEBRA_VTY_SERVICE_ACCOUNTS=$(id -u) target/release/zebra-rs
+	#@target/release/zebra-rs
 	#target/release/zebra-rs --no-nhid
 	#target/release/zebra-rs --log-format elasticsearch
 	#target/release/zebra-rs --log-output file
@@ -70,6 +71,7 @@ clean:
 	cargo cache --remove-dir all
 	rm -rf target
 	rm -f Cargo.lock
+	make -C vty clean
 
 perf:
 	sudo perf record -g --call-graph dwarf ./target/release/zebra-rs

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ run:
 	@sudo rm -f /tmp/ipc/pair/config-ng_bgpd
 	@RUSTFLAGS="--cfg tokio_unstable" cargo build --bin zebra-rs --release
 	@sudo setcap 'cap_net_bind_service=ep cap_net_admin=ep cap_net_bind_service=ep cap_net_broadcast=ep cap_net_raw=ep' target/release/zebra-rs
-	@ZEBRA_VTY_SERVICE_ACCOUNTS=$(id -u) target/release/zebra-rs
+	@ZEBRA_VTY_SERVICE_ACCOUNTS=$$(id -u) target/release/zebra-rs
 	#@target/release/zebra-rs
 	#target/release/zebra-rs --no-nhid
 	#target/release/zebra-rs --log-format elasticsearch


### PR DESCRIPTION
## Summary

Two small dev-workflow tweaks:

1. `make run` reads the invoking user's uid dynamically via
   `$$(id -u)` (the `$$` escapes the dollar for the shell) instead
   of the hardcoded `1000`. Now the same target works for any dev
   user without local edits.

2. `make clean` runs `make -C vty clean` so the vty build dir is
   wiped alongside `target/`. Helps avoid the stale-vty.sh class
   of bug we just hit.

Verified with `make -n run`:

```
ZEBRA_VTY_SERVICE_ACCOUNTS=$(id -u) target/release/zebra-rs
```

(make passes a literal `$(id -u)` to the shell, which the shell
expands at run time.)

## Test plan

- [x] `make -n run` shows the recipe expands to a shell command
      substitution, not an empty value
- [ ] CI: fmt, clippy, test

Generated with [Claude Code](https://claude.com/claude-code)