### PR TITLE
vty: show '(config)' tag in the configure-mode prompt

### DIFF
--- a/vty/additions/vty.sh
+++ b/vty/additions/vty.sh
@@ -58,7 +58,10 @@ _cli_prompt_setup ()
     CLI_MODE_CHAR="#"
   fi
 
-  export PS1="$(hostname)${CLI_MODE_PROMPT}${CLI_MODE_CHAR}"
+  # Mode tag (e.g. "(config)") follows the mode character so the user
+  # sees `host#(config)` in configure mode and a plain `host>` /
+  # `host#` in exec mode (where CLI_MODE_PROMPT is empty).
+  export PS1="$(hostname)${CLI_MODE_CHAR}${CLI_MODE_PROMPT}"
 }
 
 _cli_pager_setup ()

--- a/zebra-rs/src/config/commands.rs
+++ b/zebra-rs/src/config/commands.rs
@@ -83,7 +83,7 @@ fn show_ip_route_prefix(_config: &ConfigManager) -> (ExecCode, String) {
 
 fn configure(_config: &ConfigManager) -> (ExecCode, String) {
     let cli_command = r#"SuccessExec
-CLI_MODE=configure;CLI_MODE_STR=Configure;CLI_PRIVILEGE=15;_cli_refresh"#;
+CLI_MODE=configure;CLI_MODE_STR=Configure;CLI_MODE_PROMPT='(config)';CLI_PRIVILEGE=15;_cli_refresh"#;
     (ExecCode::Success, cli_command.to_string())
 }
 
@@ -126,7 +126,7 @@ CLI_FORMAT=terminal;_cli_refresh"#;
 
 fn exit(_config: &ConfigManager) -> (ExecCode, String) {
     let cli_command = r#"SuccessExec
-CLI_MODE=exec;CLI_PRIVILEGE=1;_cli_refresh"#;
+CLI_MODE=exec;CLI_MODE_PROMPT='';CLI_PRIVILEGE=1;_cli_refresh"#;
     (ExecCode::Success, cli_command.to_string())
 }
 

--- a/zebra-rs/src/config/commands.rs
+++ b/zebra-rs/src/config/commands.rs
@@ -81,10 +81,16 @@ fn show_ip_route_prefix(_config: &ConfigManager) -> (ExecCode, String) {
     (ExecCode::Show, String::from("show ip route prefix"))
 }
 
+const CLI_CONFIGURE_MODE_PROMPT: &str = "(config)";
+
 fn configure(_config: &ConfigManager) -> (ExecCode, String) {
-    let cli_command = r#"SuccessExec
-CLI_MODE=configure;CLI_MODE_STR=Configure;CLI_MODE_PROMPT='(config)';CLI_PRIVILEGE=15;_cli_refresh"#;
-    (ExecCode::Success, cli_command.to_string())
+    let cli_command = format!(
+        "SuccessExec\n\
+         CLI_MODE=configure;CLI_MODE_STR=Configure;\
+         CLI_MODE_PROMPT='{CLI_CONFIGURE_MODE_PROMPT}';\
+         CLI_PRIVILEGE=15;_cli_refresh"
+    );
+    (ExecCode::Success, cli_command)
 }
 
 /// Fallback handler for `enable` typed via DoExec.


### PR DESCRIPTION
## Summary

The configure-mode prompt was a bare `host#`, indistinguishable
from a privileged exec prompt. Add a `(config)` suffix after the
mode character so the operator can tell at a glance which mode
they're in.

| State | Prompt |
|---|---|
| exec, non-admin | `host>` |
| exec, admin | `host#` |
| **configure mode** | **`host#(config)`** |

## Implementation

- `configure()` handler now emits `CLI_MODE_PROMPT='(config)'`
  alongside the existing `CLI_MODE=configure` /
  `CLI_PRIVILEGE=15` flips. Quoted so bash sees a string, not an
  array.
- `exit()` handler clears `CLI_MODE_PROMPT=''` symmetrically when
  returning to exec mode.
- `_cli_prompt_setup` in `vty.sh` now appends `CLI_MODE_PROMPT`
  after `CLI_MODE_CHAR` so the visible order is mode-char then
  tag. In exec mode the tag is empty so the prompt is unchanged.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `rm -rf vty/build && make -C vty` rebuilds cleanly
- [ ] CI: fmt, clippy, test
- [ ] Manual: install rebuilt vty; `configure` -> prompt becomes
      `host#(config)`; `exit` -> prompt becomes `host>` /
      `host#`.

Generated with [Claude Code](https://claude.com/claude-code)