### PR TITLE
vty: park enable/disable yang and (config) prompt while auth design settles

### DIFF
--- a/zebra-rs/src/config/commands.rs
+++ b/zebra-rs/src/config/commands.rs
@@ -81,7 +81,8 @@ fn show_ip_route_prefix(_config: &ConfigManager) -> (ExecCode, String) {
     (ExecCode::Show, String::from("show ip route prefix"))
 }
 
-const CLI_CONFIGURE_MODE_PROMPT: &str = "(config)";
+// const CLI_CONFIGURE_MODE_PROMPT: &str = "(config)";
+const CLI_CONFIGURE_MODE_PROMPT: &str = ""; // Keep backward compatibility for now.
 
 fn configure(_config: &ConfigManager) -> (ExecCode, String) {
     let cli_command = format!(

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -22,6 +22,12 @@ module exec {
     type empty;
   }
 
+  // Temporarily disabled: the authorization framework (role tiers,
+  // task groups, enable/disable semantics) is still being designed.
+  // The vty shell's enable()/disable() bash functions remain functional
+  // because they go through the dedicated Enable/Disable RPCs, not
+  // DoExec. Re-enable these leaves once the model is settled.
+  /*
   leaf enable {
     ext:help "Promote this session to the admin role (PAM auth)";
     type empty;
@@ -31,6 +37,7 @@ module exec {
     ext:help "Drop this session back to the view role";
     type empty;
   }
+  */
 
   container show {
     ext:help "Show command";


### PR DESCRIPTION
## Summary

Walk back the still-visible UX of the in-flight authorization
framework until the overall model (role tiers vs IOS-XR-style
task groups, enable/disable semantics, configure-mode lock) is
settled.

Two small reversible knobs:

### 1. Comment out `enable` / `disable` YANG leaves

`zebra-rs/yang/exec.yang` no longer advertises `enable` /
`disable` as first-level exec commands. Tab completion (`ena<Tab>`,
`dis<Tab>`) and `?` help stop listing them.

The vty shell's `enable()` / `disable()` bash functions remain
fully functional because they go through the dedicated Enable /
Disable RPCs, not DoExec, so this is a presentation-only change.

The matching `install_func` entries in `commands.rs` are left in
place — harmless dead code while the leaves are absent, instant
revival once the leaves are uncommented.

### 2. Blank the configure-mode prompt tag

`CLI_CONFIGURE_MODE_PROMPT` flipped from `"(config)"` to `""`, so
configure-mode prompt is a bare `host#` again instead of
`host#(config)`. Original value kept on a commented-out line for
one-line restoration.

Both changes are explicitly temporary.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs config::` — 74/74 pass
- [ ] CI: fmt, clippy, test
- [ ] Manual: install rebuilt vty; typing `enable` still prompts
      for password and succeeds; `configure` enters configure
      mode with bare `host#` prompt.

Generated with [Claude Code](https://claude.com/claude-code)