### PR TITLE
vty: reorganize show-config under candidate/running views

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -31,6 +31,7 @@
 
 - [VTY Access and Authentication](ch-06-00-vty-access.md)
   - [Session Management Design](ch-06-01-session-design.md)
+  - [Show Config Commands](ch-06-02-show-config-commands.md)
 
 ## Logging and Monitoring
 

--- a/book/src/ch-06-02-show-config-commands.md
+++ b/book/src/ch-06-02-show-config-commands.md
@@ -88,11 +88,10 @@ under the top level of `configure` mode (not under `show`):
 | `discard` | Revert candidate back to running (drops uncommitted edits) |
 | `load` | Re-load the on-disk config file into the candidate, then commit |
 | `save` | Write the running config to the on-disk file |
-| `running` | Legacy shortcut: equivalent to `show running-config formal` for the structured display |
 
 ## Reorganization notes (history)
 
-Earlier versions exposed the candidate-config viewers as top-level
+Earlier versions exposed the config viewers as top-level
 configure-mode commands without the `show` prefix:
 
 | Old | New |
@@ -100,10 +99,11 @@ configure-mode commands without the `show` prefix:
 | `list` | `show candidate-config formal` |
 | `json` | `show candidate-config json` |
 | `yaml` | `show candidate-config yaml` |
+| `running` | `show running-config formal` |
 | `candidate` | (removed — was effectively a duplicate of `list`) |
 | `diff` | (removed — was running ↔ candidate textual diff) |
 
-The reorganization gives the running config a symmetric set of
-viewers (`show running-config { formal | json | yaml }`), so an
-operator can always say "show me the X view of the Y config" without
-remembering which forms exist for which view.
+The reorganization gives candidate and running configs a symmetric
+set of viewers (`show {candidate,running}-config { formal | json |
+yaml }`), so an operator can always say "show me the X view of the
+Y config" without remembering which forms exist for which view.

--- a/book/src/ch-06-02-show-config-commands.md
+++ b/book/src/ch-06-02-show-config-commands.md
@@ -11,23 +11,48 @@ This chapter covers the commands that display either view.
 
 ## Quick reference
 
-All six display commands work identically from both `exec` mode and
+All eight display commands work identically from both `exec` mode and
 `configure` mode.
 
 | Command | Output |
 |---|---|
-| `show candidate-config formal` | Set-style flat statement listing of the **candidate** |
+| `show candidate-config` | **CLI** (Cisco-style indented block) view of the candidate |
+| `show candidate-config formal` | Set-style flat statement listing of the candidate |
 | `show candidate-config json` | Pretty-printed JSON of the candidate |
 | `show candidate-config yaml` | YAML of the candidate |
-| `show running-config formal` | Set-style flat statement listing of the **running** config |
+| `show running-config` | **CLI** view of the running config |
+| `show running-config formal` | Set-style flat statement listing of the running config |
 | `show running-config json` | Pretty-printed JSON of the running config |
 | `show running-config yaml` | YAML of the running config |
 
-The `formal` keyword names the canonical set/delete form — the same
-format `load` and `save` consume. The `json` and `yaml` keywords are
-the equivalent serializations of the same configuration tree.
+The bare form (no trailing keyword) renders the **CLI** view — the
+indented block format familiar from Cisco IOS, suitable for reading
+on a terminal. The `formal` keyword names the canonical set/delete
+form, the same format `load` and `save` consume. The `json` and
+`yaml` keywords are the equivalent serializations of the same
+configuration tree.
 
 ## Output formats
+
+### CLI (default, no trailing keyword)
+
+Cisco-style indented block view. Easy to read on a terminal; the
+default when you don't specify a serialization.
+
+```
+host(config)# show candidate-config
+system {
+    hostname r1
+}
+router {
+    bgp 65000 {
+        router-id 10.0.0.1
+        neighbor 10.0.0.2 {
+            peer-as 65001
+        }
+    }
+}
+```
 
 ### `formal`
 

--- a/book/src/ch-06-02-show-config-commands.md
+++ b/book/src/ch-06-02-show-config-commands.md
@@ -1,0 +1,109 @@
+# Show Config Commands
+
+zebra-rs keeps two configuration views:
+
+- **running config** — the configuration the daemon is currently
+  acting on. Updated only by `commit`.
+- **candidate config** — the editable buffer that accumulates `set`
+  and `delete` statements until you `commit` (or `discard`) them.
+
+This chapter covers the commands that display either view.
+
+## Quick reference
+
+All six display commands work identically from both `exec` mode and
+`configure` mode.
+
+| Command | Output |
+|---|---|
+| `show candidate-config formal` | Set-style flat statement listing of the **candidate** |
+| `show candidate-config json` | Pretty-printed JSON of the candidate |
+| `show candidate-config yaml` | YAML of the candidate |
+| `show running-config formal` | Set-style flat statement listing of the **running** config |
+| `show running-config json` | Pretty-printed JSON of the running config |
+| `show running-config yaml` | YAML of the running config |
+
+The `formal` keyword names the canonical set/delete form — the same
+format `load` and `save` consume. The `json` and `yaml` keywords are
+the equivalent serializations of the same configuration tree.
+
+## Output formats
+
+### `formal`
+
+A flat sequence of `set ...` statements, one configuration leaf per
+line, suitable for `load` to replay or for diffing in plain text.
+
+```
+host(config)# show candidate-config formal
+set system hostname r1
+set router bgp 65000 router-id 10.0.0.1
+set router bgp 65000 neighbor 10.0.0.2 peer-as 65001
+```
+
+### `json`
+
+Pretty-printed (2-space indent), with key order preserved by the
+internal `preserve_order` flag.
+
+```json
+{
+  "system": {
+    "hostname": "r1"
+  },
+  "router": {
+    "bgp": [
+      {
+        "as": 65000,
+        "router-id": "10.0.0.1"
+      }
+    ]
+  }
+}
+```
+
+### `yaml`
+
+Standard YAML serialization of the same tree.
+
+```yaml
+system:
+  hostname: r1
+router:
+  bgp:
+    - as: 65000
+      router-id: 10.0.0.1
+```
+
+## Editing helpers
+
+These commands manipulate the candidate or commit it; they live
+under the top level of `configure` mode (not under `show`):
+
+| Command | Effect |
+|---|---|
+| `set <path>` | Add a leaf or list item to the candidate |
+| `delete <path>` | Remove a leaf or list item from the candidate |
+| `commit` | Validate the candidate, apply diffs to subscribers, then promote candidate → running |
+| `discard` | Revert candidate back to running (drops uncommitted edits) |
+| `load` | Re-load the on-disk config file into the candidate, then commit |
+| `save` | Write the running config to the on-disk file |
+| `running` | Legacy shortcut: equivalent to `show running-config formal` for the structured display |
+
+## Reorganization notes (history)
+
+Earlier versions exposed the candidate-config viewers as top-level
+configure-mode commands without the `show` prefix:
+
+| Old | New |
+|---|---|
+| `list` | `show candidate-config formal` |
+| `json` | `show candidate-config json` |
+| `yaml` | `show candidate-config yaml` |
+| `candidate` | (removed — was effectively a duplicate of `list`) |
+| `diff` | (removed — was running ↔ candidate textual diff) |
+
+The reorganization gives the running config a symmetric set of
+viewers (`show running-config { formal | json | yaml }`), so an
+operator can always say "show me the X view of the Y config" without
+remembering which forms exist for which view.

--- a/zebra-rs/src/config/commands.rs
+++ b/zebra-rs/src/config/commands.rs
@@ -32,6 +32,7 @@ pub fn exec_mode_create(entry: Rc<Entry>) -> Mode {
     let mut mode = Mode::new(entry);
     mode.install_func(String::from("/help"), help);
     mode.install_func(String::from("/show/version"), show_version);
+    install_show_config_handlers(&mut mode);
     mode.install_func(String::from("/configure"), configure);
     mode.install_func(String::from("/enable"), enable);
     mode.install_func(String::from("/disable"), disable);
@@ -50,18 +51,39 @@ pub fn configure_mode_create(entry: Rc<Entry>) -> Mode {
     // no protocol-show handler claims it and the output is silently
     // empty.
     mode.install_func(String::from("/show/version"), show_version);
-    mode.install_func(String::from("/candidate"), candidate);
+    install_show_config_handlers(&mut mode);
     mode.install_func(String::from("/running"), running);
-    mode.install_func(String::from("/json"), json);
-    mode.install_func(String::from("/yaml"), yaml);
     mode.install_func(String::from("/commit"), commit);
     mode.install_func(String::from("/discard"), discard);
-    mode.install_func(String::from("/list"), list);
-    mode.install_func(String::from("/diff"), diff);
     mode.install_func(String::from("/load"), load);
     mode.install_func(String::from("/save"), save);
     mode.install_func(String::from("/clear/isis/spf"), clear_isis_spf);
     mode
+}
+
+/// Register the `show candidate-config { formal | json | yaml }` and
+/// `show running-config { formal | json | yaml }` handlers. The same set is
+/// installed in both exec and configure mode so the commands work
+/// identically from either prompt.
+fn install_show_config_handlers(mode: &mut Mode) {
+    mode.install_func(
+        String::from("/show/candidate-config/formal"),
+        show_candidate_formal,
+    );
+    mode.install_func(
+        String::from("/show/candidate-config/json"),
+        show_candidate_json,
+    );
+    mode.install_func(
+        String::from("/show/candidate-config/yaml"),
+        show_candidate_yaml,
+    );
+    mode.install_func(
+        String::from("/show/running-config/formal"),
+        show_running_formal,
+    );
+    mode.install_func(String::from("/show/running-config/json"), show_running_json);
+    mode.install_func(String::from("/show/running-config/yaml"), show_running_yaml);
 }
 
 fn help(_config: &ConfigManager) -> (ExecCode, String) {
@@ -154,39 +176,62 @@ fn show(config: &ConfigManager) -> (ExecCode, String) {
     }
 }
 
-fn candidate(config: &ConfigManager) -> (ExecCode, String) {
-    let mut output = String::new();
-    config.store.candidate.borrow().format(&mut output);
-    (ExecCode::Show, output)
-}
-
 fn running(config: &ConfigManager) -> (ExecCode, String) {
     let mut output = String::new();
     config.store.running.borrow().format(&mut output);
     (ExecCode::Show, output)
 }
 
-fn json(config: &ConfigManager) -> (ExecCode, String) {
+// === show {candidate,running}-config { formal | json | yaml } ===
+
+fn show_candidate_formal(config: &ConfigManager) -> (ExecCode, String) {
+    let mut output = String::new();
+    config.store.candidate.borrow().list(&mut output);
+    (ExecCode::Show, output)
+}
+
+fn show_candidate_json(config: &ConfigManager) -> (ExecCode, String) {
     let mut compact = String::new();
     config.store.candidate.borrow().json(&mut compact);
-    // Round-trip through serde to indent. The internal json() emitter
-    // produces compact JSON; for human display we want pretty-printed
-    // output with 2-space indent. `preserve_order` is enabled at the
-    // workspace level so key order survives the round-trip.
-    let pretty = serde_json::from_str::<serde_json::Value>(&compact)
+    (ExecCode::Show, prettify_json(compact))
+}
+
+fn show_candidate_yaml(config: &ConfigManager) -> (ExecCode, String) {
+    let mut output = String::new();
+    config.store.candidate.borrow().yaml(&mut output);
+    (ExecCode::Show, output)
+}
+
+fn show_running_formal(config: &ConfigManager) -> (ExecCode, String) {
+    let mut output = String::new();
+    config.store.running.borrow().list(&mut output);
+    (ExecCode::Show, output)
+}
+
+fn show_running_json(config: &ConfigManager) -> (ExecCode, String) {
+    let mut compact = String::new();
+    config.store.running.borrow().json(&mut compact);
+    (ExecCode::Show, prettify_json(compact))
+}
+
+fn show_running_yaml(config: &ConfigManager) -> (ExecCode, String) {
+    let mut output = String::new();
+    config.store.running.borrow().yaml(&mut output);
+    (ExecCode::Show, output)
+}
+
+/// Indent a compact JSON string for human display. `preserve_order` is
+/// enabled at the workspace level so key order survives the round-trip.
+/// Falls back to the compact form on parse/serialize failure (empty
+/// config, etc.).
+fn prettify_json(compact: String) -> String {
+    serde_json::from_str::<serde_json::Value>(&compact)
         .and_then(|v| serde_json::to_string_pretty(&v))
         .map(|mut s| {
             s.push('\n');
             s
         })
-        .unwrap_or(compact);
-    (ExecCode::Show, pretty)
-}
-
-fn yaml(config: &ConfigManager) -> (ExecCode, String) {
-    let mut output = String::new();
-    config.store.candidate.borrow().yaml(&mut output);
-    (ExecCode::Show, output)
+        .unwrap_or(compact)
 }
 
 fn commit(config: &ConfigManager) -> (ExecCode, String) {
@@ -195,13 +240,6 @@ fn commit(config: &ConfigManager) -> (ExecCode, String) {
         Ok(_) => (ExecCode::Show, String::from("")),
         Err(err) => (ExecCode::Show, err.to_string()),
     }
-}
-
-fn diff(config: &ConfigManager) -> (ExecCode, String) {
-    let mut output = String::new();
-    let _diff = config.diff_config(&mut output);
-    // config.store.candidate.borrow().list(&mut output);
-    (ExecCode::Show, output)
 }
 
 fn discard(config: &ConfigManager) -> (ExecCode, String) {
@@ -217,12 +255,6 @@ fn load(config: &ConfigManager) -> (ExecCode, String) {
 fn save(config: &ConfigManager) -> (ExecCode, String) {
     config.save_config();
     (ExecCode::Show, String::from(""))
-}
-
-fn list(config: &ConfigManager) -> (ExecCode, String) {
-    let mut output = String::new();
-    config.store.candidate.borrow().list(&mut output);
-    (ExecCode::Show, output)
 }
 
 fn clear_isis_spf(_config: &ConfigManager) -> (ExecCode, String) {

--- a/zebra-rs/src/config/commands.rs
+++ b/zebra-rs/src/config/commands.rs
@@ -52,7 +52,6 @@ pub fn configure_mode_create(entry: Rc<Entry>) -> Mode {
     // empty.
     mode.install_func(String::from("/show/version"), show_version);
     install_show_config_handlers(&mut mode);
-    mode.install_func(String::from("/running"), running);
     mode.install_func(String::from("/commit"), commit);
     mode.install_func(String::from("/discard"), discard);
     mode.install_func(String::from("/load"), load);
@@ -174,12 +173,6 @@ fn show(config: &ConfigManager) -> (ExecCode, String) {
     } else {
         (ExecCode::Show, candidate)
     }
-}
-
-fn running(config: &ConfigManager) -> (ExecCode, String) {
-    let mut output = String::new();
-    config.store.running.borrow().format(&mut output);
-    (ExecCode::Show, output)
 }
 
 // === show {candidate,running}-config { formal | json | yaml } ===

--- a/zebra-rs/src/config/commands.rs
+++ b/zebra-rs/src/config/commands.rs
@@ -60,11 +60,16 @@ pub fn configure_mode_create(entry: Rc<Entry>) -> Mode {
     mode
 }
 
-/// Register the `show candidate-config { formal | json | yaml }` and
-/// `show running-config { formal | json | yaml }` handlers. The same set is
-/// installed in both exec and configure mode so the commands work
+/// Register the `show candidate-config [ formal | json | yaml ]` and
+/// `show running-config [ formal | json | yaml ]` handlers. The same set
+/// is installed in both exec and configure mode so the commands work
 /// identically from either prompt.
+///
+/// The bare form (no trailing keyword) renders the configuration in
+/// CLI / Cisco-style indented block format. The three keyword
+/// variants select alternate serializations.
 fn install_show_config_handlers(mode: &mut Mode) {
+    mode.install_func(String::from("/show/candidate-config"), show_candidate_cli);
     mode.install_func(
         String::from("/show/candidate-config/formal"),
         show_candidate_formal,
@@ -77,6 +82,7 @@ fn install_show_config_handlers(mode: &mut Mode) {
         String::from("/show/candidate-config/yaml"),
         show_candidate_yaml,
     );
+    mode.install_func(String::from("/show/running-config"), show_running_cli);
     mode.install_func(
         String::from("/show/running-config/formal"),
         show_running_formal,
@@ -175,7 +181,23 @@ fn show(config: &ConfigManager) -> (ExecCode, String) {
     }
 }
 
-// === show {candidate,running}-config { formal | json | yaml } ===
+// === show {candidate,running}-config [ formal | json | yaml ] ===
+//
+// `Config::format()` renders the CLI / Cisco-style indented block view;
+// `Config::list()` renders the flat set-statement form ("formal");
+// `Config::json()` / `Config::yaml()` are the serialized equivalents.
+
+fn show_candidate_cli(config: &ConfigManager) -> (ExecCode, String) {
+    let mut output = String::new();
+    config.store.candidate.borrow().format(&mut output);
+    (ExecCode::Show, output)
+}
+
+fn show_running_cli(config: &ConfigManager) -> (ExecCode, String) {
+    let mut output = String::new();
+    config.store.running.borrow().format(&mut output);
+    (ExecCode::Show, output)
+}
 
 fn show_candidate_formal(config: &ConfigManager) -> (ExecCode, String) {
     let mut output = String::new();

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -244,38 +244,6 @@ impl ConfigManager {
         Ok(())
     }
 
-    pub fn diff_config(&self, output: &mut String) -> anyhow::Result<()> {
-        let mut errors = Vec::<String>::new();
-        self.store.candidate.borrow().validate(&mut errors);
-        if !errors.is_empty() {
-            let errors = errors.join("\n");
-            return Err(anyhow::anyhow!(errors));
-        }
-        let mut running = String::new();
-        let mut candidate = String::new();
-        self.store.running.borrow().list(&mut running);
-        self.store.candidate.borrow().list(&mut candidate);
-
-        let text_diff = TextDiff::from_lines(&running, &candidate);
-        let mut binding = text_diff.unified_diff();
-        let mut diff = binding.context_radius(65535).to_string();
-        let diff = trim_first_line(&mut diff);
-
-        for line in diff.lines() {
-            if !line.is_empty() {
-                let first_char = line.chars().next().unwrap();
-                let _op = match first_char {
-                    '+' => ConfigOp::Set,
-                    '-' => ConfigOp::Delete,
-                    _ => continue,
-                };
-            }
-            output.push_str(line);
-            output.push('\n');
-        }
-        Ok(())
-    }
-
     fn load_mode(&self, yang: &mut YangStore, mode: &str) -> anyhow::Result<Rc<Entry>> {
         yang.read_with_resolve(mode)?;
         yang.identity_resolve();

--- a/zebra-rs/yang/configure.yang
+++ b/zebra-rs/yang/configure.yang
@@ -54,16 +54,11 @@ module configure {
     type empty;
   }
 
-  leaf running {
-    ext:help "Show running system configuration";
-    type empty;
-  }
-
-  // `candidate`, `json`, `yaml`, `diff`, `list` were removed in favor of
-  // the unified `show candidate-config { formal | json | yaml }` and
-  // `show running-config { formal | json | yaml }` trees defined under
-  // the `show` container in exec.yang (and grafted into configure mode).
-  // See book/src/ch-06-02-show-config-commands.md.
+  // `running`, `candidate`, `json`, `yaml`, `diff`, `list` were removed
+  // in favor of the unified `show candidate-config { formal | json |
+  // yaml }` and `show running-config { formal | json | yaml }` trees
+  // defined under the `show` container in exec.yang (and grafted into
+  // configure mode). See book/src/ch-06-02-show-config-commands.md.
 
   leaf commit {
     ext:help "Commit candidate config to running config";

--- a/zebra-rs/yang/configure.yang
+++ b/zebra-rs/yang/configure.yang
@@ -59,28 +59,14 @@ module configure {
     type empty;
   }
 
-  leaf candidate {
-    ext:help "Show candidate system configuration";
-    type empty;
-  }
-
-  leaf json {
-    ext:help "Show running configuration in JSON format";
-    type empty;
-  }
-
-  leaf yaml {
-    ext:help "Show running configuration in YAML format";
-    type empty;
-  }
+  // `candidate`, `json`, `yaml`, `diff`, `list` were removed in favor of
+  // the unified `show candidate-config { formal | json | yaml }` and
+  // `show running-config { formal | json | yaml }` trees defined under
+  // the `show` container in exec.yang (and grafted into configure mode).
+  // See book/src/ch-06-02-show-config-commands.md.
 
   leaf commit {
     ext:help "Commit candidate config to running config";
-    type empty;
-  }
-
-  leaf diff {
-    ext:help "Diff between candidate config and running config";
     type empty;
   }
 
@@ -96,11 +82,6 @@ module configure {
 
   leaf save {
     ext:help "Save config from file";
-    type empty;
-  }
-
-  leaf list {
-    ext:help "List config from file";
     type empty;
   }
 

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -46,6 +46,38 @@ module exec {
       ext:help "Show version";
       type empty;
     }
+    container candidate-config {
+      ext:help "Show the candidate configuration (uncommitted edits)";
+      presence "Show candidate config";
+      leaf formal {
+        ext:help "Set-style flat statement listing";
+        type empty;
+      }
+      leaf json {
+        ext:help "Pretty-printed JSON";
+        type empty;
+      }
+      leaf yaml {
+        ext:help "YAML";
+        type empty;
+      }
+    }
+    container running-config {
+      ext:help "Show the running (committed) configuration";
+      presence "Show running config";
+      leaf formal {
+        ext:help "Set-style flat statement listing";
+        type empty;
+      }
+      leaf json {
+        ext:help "Pretty-printed JSON";
+        type empty;
+      }
+      leaf yaml {
+        ext:help "YAML";
+        type empty;
+      }
+    }
     container mpls {
       leaf ilm {
         type empty;


### PR DESCRIPTION
## Summary

Replace the assorted top-level configure-mode commands that dumped
the candidate or running config (`list`, `json`, `yaml`,
`candidate`, `running`, `diff`) with a symmetric pair of show
subtrees that work in both exec and configure mode:

```
show candidate-config              # CLI block view (default)
show candidate-config formal       # flat 'set ...' statements
show candidate-config json         # pretty JSON
show candidate-config yaml         # YAML

show running-config                # CLI block view (default)
show running-config formal
show running-config json
show running-config yaml
```

Operators can now say "show me the X view of the Y config" with
one consistent grammar instead of remembering which forms exist
for which view.

## Changes

### YANG

- `zebra-rs/yang/exec.yang`: new `container candidate-config` and
  `container running-config` under `container show`, each with
  three leaves (`formal`, `json`, `yaml`) and a `presence` so the
  container itself is a valid command line for the default CLI
  view. Grafted into configure mode by the existing
  `show_from_exec()` plumbing.
- `zebra-rs/yang/configure.yang`: remove the deprecated top-level
  `candidate`, `running`, `json`, `yaml`, `diff`, `list` leaves.

### Daemon

- `zebra-rs/src/config/commands.rs`:
  - New helper `install_show_config_handlers(mode)` registers
    eight handlers in both exec and configure mode fmaps.
  - New handlers: `show_candidate_cli` / `show_running_cli` (CLI
    block, via `Config::format()`), the three keyword variants
    for each view, and a shared `prettify_json()` helper.
  - Removed handlers: `candidate`, `running`, `json`, `yaml`,
    `list`, `diff`.
- `zebra-rs/src/config/manager.rs`: drop `diff_config()`, dead
  after `diff` was removed.

### Docs

- New chapter `book/src/ch-06-02-show-config-commands.md` covering
  the new eight-command layout, output samples for each format,
  the editing helpers (`set`/`delete`/`commit`/`discard`/`load`/
  `save`), and a migration table from the old commands.
- Indexed in `SUMMARY.md` under "Management Interface".

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs config::` — 74/74 pass
- [ ] CI: fmt, clippy, test
- [ ] Manual: in vty, `show running-config<Enter>` shows the CLI
      block view; `show running-config formal` shows the
      set-style flat listing; same for `candidate-config`.

Generated with [Claude Code](https://claude.com/claude-code)