### PR TITLE
isis: fast-converge on peer-initiated adj down + network-type reset

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2557,6 +2557,7 @@ fn build_rib_from_spf(
             };
             let nhop_sys_id = *nhop_sys_id;
 
+            // p[0] could be pseudonode.
             for (_, link_id) in nhops.first_hop_links.iter().filter(|(v, _)| *v == p[0]) {
                 if *link_id == 0 {
                     continue;

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -838,16 +838,36 @@ pub fn config_network_type(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Opt
     let name = args.string()?;
     let network_type = args.string()?.parse::<NetworkType>().ok()?;
 
-    let ifindex = {
+    let (ifindex, type_changed) = {
         let link = isis.links.get_mut_by_name(&name)?;
+        let old_type = link.config.network_type();
 
         if op.is_set() {
             link.config.network_type = Some(network_type);
         } else {
             link.config.network_type = None;
         }
-        link.ifindex
+        let new_type = link.config.network_type();
+        (link.ifindex, old_type != new_type)
     };
+
+    // A network-type change makes any existing adjacency stale.
+    // ExtIsReach uses a different shape per type — P2P emits
+    // (peer_sys_id, 0); LAN emits the pseudonode's (DIS_sys_id,
+    // pseudo_id) — so the cached `link.state.adj` from the old type
+    // would be wrong under the new one. dis_selection's branch at
+    // ifsm.rs:507 only installs the LAN PN id when `adj.is_none()`,
+    // so a stale P2P adj indefinitely blocks the LAN transition and
+    // our LSP keeps advertising the P2P-style ExtIsReach. Bounce
+    // the link via link_state_down + link_state_up — drops nbrs,
+    // clears adj / dis_status / nbrs_up, re-originates LSP, and
+    // schedules SPF for both levels. Adjacencies rebuild through
+    // the normal hello / NFSM path under the new type.
+    if type_changed {
+        isis.link_state_down(ifindex);
+        isis.link_state_up(ifindex);
+        return Some(());
+    }
 
     if let Some(mut top) = isis.link_top(ifindex) {
         ifsm::hello_originate(&mut top, Level::L1);

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -7,7 +7,7 @@ use isis_macros::isis_pdu_handler;
 use isis_packet::*;
 
 use crate::fmt::DisplayOpt;
-use crate::isis::inst::csnp_generate;
+use crate::isis::inst::{csnp_generate, spf_schedule};
 use crate::isis::link::DisStatus;
 use crate::isis::neigh::Neighbor;
 use crate::isis::nfsm::nfsm_hold_timer;
@@ -225,6 +225,7 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
 
     // Start state transition.
     let mut state = nbr.state;
+    let was_up = state == NfsmState::Up;
 
     if state == NfsmState::Down {
         // 8.4.2.5.1
@@ -295,7 +296,19 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
         // tracing::info!("NFSM {} => {}", nbr.state, state);
     }
 
-    nbr.state = state
+    nbr.state = state;
+
+    // Up→{Init,Down} regressed by the peer (TLV 6 no longer reports
+    // our MAC). Without these triggers we keep the dead adjacency in
+    // our LSP's ExtIsReach and the RIB keeps routing through it until
+    // the hold timer expires. `dis_selection` only re-originates the
+    // LSP when the DIS itself changes, so for a non-DIS neighbor
+    // going down there is no other path that wakes LSP/SPF until
+    // hold-time (typically ~30s).
+    if was_up && state != NfsmState::Up {
+        let _ = link.tx.send(Message::LspOriginate(level, None));
+        spf_schedule(link, level);
+    }
 }
 
 #[isis_pdu_handler(Hello, Recv)]
@@ -369,6 +382,7 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
 
         // Start state transition.
         let mut state = nbr.state;
+        let was_up = state == NfsmState::Up;
 
         // When it is three way handshake.
         if state == NfsmState::Down {
@@ -392,12 +406,41 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
             let _ = link.tx.send(Message::AdjacencyUp(level, nbr.ifindex));
         }
 
+        // RFC 5303 §6.1: peer's P2P-3way TLV no longer reports our
+        // sys-id as their neighbor — they've torn down the adjacency
+        // from their side. Mirror the regression locally so we stop
+        // advertising the edge before our hold timer fires (~30s).
+        // Keeps nbr entry alive so the Init→Up path can resume if the
+        // peer comes back (labels and End.X SID stay allocated).
+        if state == NfsmState::Up && !has_my_sys_id {
+            state = NfsmState::Init;
+            if link.tracing.fsm.nfsm.enabled {
+                tracing::info!(
+                    "[NBR] {} Up -> Init (peer no longer reports our sys-id)",
+                    nbr.sys_id
+                );
+            }
+            *link.state.adj.get_mut(&level) = None;
+            link.lsdb.get_mut(&level).adj_clear(nbr.ifindex);
+            let counter = link.state.nbrs_up.get_mut(&level);
+            *counter = counter.saturating_sub(1);
+            nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
+        }
+
         // When neighbor state has been changed.
         if nbr.state != state {
             // tracing::info!("NFSM {}:{} => {}", nbr.sys_id, nbr.state, state);
         }
 
-        nbr.state = state
+        nbr.state = state;
+
+        // Same fast-converge as the LAN soft-down path: re-originate
+        // our own LSP so the now-down ExtIsReach entry is dropped
+        // before hold-time, and schedule SPF for the route table.
+        if was_up && state != NfsmState::Up {
+            let _ = link.tx.send(Message::LspOriginate(level, None));
+            spf_schedule(link, level);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Two related adjacency-state hygiene fixes that prevent the local LSP / RIB from holding stale topology beyond what the protocol requires.

### 1. Fast-converge on peer-initiated adjacency down (`packet.rs`)

Hello receipt regresses an Up adjacency to Init when the peer stops reporting our address (TLV 6 IsNeighbor for LAN, P2p3Way's neighbor_id for P2P), but did **not** re-originate the local LSP or schedule SPF. The dead adjacency stayed in our ExtIsReach and the RIB kept routing through it until the hold timer fired (~30s).

`dis_selection` only re-originates the LSP when the DIS itself changes, so a non-DIS neighbor going Up→Init has no other path that wakes LSP/SPF in the meantime.

- LAN (`hello_recv`): capture `was_up` before transitions; after `nbr.state = state`, on Up→non-Up fire `LspOriginate` and `spf_schedule`.
- P2P (`hello_p2p_recv`): add the missing Up→Init regression when `state == Up && !has_my_sys_id` (RFC 5303 §6.1 — peer's P2P 3-way TLV no longer reports our sys-id). Clear `link.state.adj`, `adj_clear` the lsdb side, decrement `nbrs_up`, fire `HelloOriginate`. Then the same Up→non-Up trigger pattern.

Neighbor entries and per-adjacency resources (labels, End.X SID) stay allocated across the soft-down — the Init→Up resume path picks them back up if the peer recovers before hold-time.

### 2. Bounce link on network-type change (`link.rs`)

`config_network_type` was only updating the config field and firing `HelloOriginate`, leaving `link.state.adj` and `dis_status` from the old type intact. On P2P→LAN the stale `(peer_sys_id, 0)` adj remains `Some`, and `dis_selection`'s guard at `ifsm.rs:507`

```rust
if link.state.adj.get(&level).is_none() && let Some(lan_id) = ... 
```

skips the install of the new PN `(DIS_sys_id, pseudo_id)` adj. The NotSelected→Other transition at `ifsm.rs:473-490` only clears adj when `old_status` was Other or Myself, not NotSelected — and P2P never ran DIS election, so `dis_status` was always NotSelected. Net effect: the LSP keeps emitting an ExtIsReach with the P2P-style `neighbor_id`, so the SPF graph shows `s -> n1` (direct) instead of `s -> n1.<pn>` (via PN) after the link type changes — observable in `show isis graph`.

Fix: when the resolved `network_type` actually changes, call `link_state_down + link_state_up`. That drops neighbors, clears adj / dis_status / nbrs_up / csnp_timer at both levels, re-originates the self LSP without the stale ExtIsReach, and schedules SPF. Adjacencies rebuild through the normal hello / NFSM path under the new type. LAN↔P2P transitions both route through this path symmetrically.

## Test plan

- [x] All 340 existing tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [ ] Manual: bring up P2P adjacency, change to LAN on one side, verify `show isis graph` shows pseudonode edge (not stale direct edge)
- [ ] Manual: LAN adjacency Up, peer drops us from TLV 6 (e.g., admin-shut peer interface briefly), verify our LSP is re-flooded within ~1s (SPF debounce) rather than waiting hold-time

Generated with [Claude Code](https://claude.com/claude-code)