### PR TITLE
isis,spf: extract first_router_hop_idx + show first_hop_links in disp

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2494,6 +2494,20 @@ fn build_adjacency_ilm(
     ilm
 }
 
+/// Index of the first non-pseudonode vertex on `path`, skipping any
+/// leading pseudonode hops. Returns `None` when the path is empty or
+/// consists entirely of pseudonodes — both cases mean there's no
+/// real router to install as the first-hop. RIB-builders use this to
+/// land on the actual nexthop router (whose adjacency carries the
+/// peer addresses) rather than on the LAN's transit-only PN vertex.
+fn first_router_hop_idx(lsp_map: &LspMap, path: &[usize]) -> Option<usize> {
+    let mut idx = 0;
+    while idx < path.len() && lsp_map.is_pseudo(path[idx]) {
+        idx += 1;
+    }
+    (idx < path.len()).then_some(idx)
+}
+
 /// Build RIB from SPF calculation results
 fn build_rib_from_spf(
     top: &mut IsisTop,
@@ -2540,17 +2554,9 @@ fn build_rib_from_spf(
         // asymmetric metrics and P2P+LAN mix).
         let mut spf_nhops = BTreeMap::new();
         for p in &nhops.paths {
-            if p.is_empty() {
+            let Some(nhop_idx) = first_router_hop_idx(top.lsp_map.get(&level), p) else {
                 continue;
-            }
-
-            let mut nhop_idx = 0;
-            while nhop_idx < p.len() && top.lsp_map.get(&level).is_pseudo(p[nhop_idx]) {
-                nhop_idx += 1;
-            }
-            if nhop_idx >= p.len() {
-                continue;
-            }
+            };
 
             let Some(nhop_sys_id) = top.lsp_map.get(&level).resolve(p[nhop_idx]) else {
                 continue;
@@ -2702,9 +2708,6 @@ fn build_rib_from_spf_v6(
         // strict-gate every transit node, not just the first hop.
         let mut spf_nhops = BTreeMap::new();
         'next_path: for p in &nhops.paths {
-            if p.is_empty() {
-                continue;
-            }
             // In legacy mode, every node on the path must advertise IPv6.
             // In MT 2 mode the graph itself is pre-filtered, so we skip.
             // Pseudonode hops bypass the IPv6 NLPID check — they don't
@@ -2726,13 +2729,9 @@ fn build_rib_from_spf_v6(
 
             // Skip leading pseudonode hops to land on the actual nexthop
             // router whose adjacency carries the link-local v6 address.
-            let mut nhop_idx = 0;
-            while nhop_idx < p.len() && top.lsp_map.get(&level).is_pseudo(p[nhop_idx]) {
-                nhop_idx += 1;
-            }
-            if nhop_idx >= p.len() {
+            let Some(nhop_idx) = first_router_hop_idx(top.lsp_map.get(&level), p) else {
                 continue;
-            }
+            };
             let Some(nhop_id) = top.lsp_map.get(&level).resolve(p[nhop_idx]) else {
                 continue;
             };

--- a/zebra-rs/src/spf/calc.rs
+++ b/zebra-rs/src/spf/calc.rs
@@ -612,6 +612,7 @@ pub fn disp_out(buf: &mut String, spf: &BTreeMap<usize, Path>, full_path: bool) 
             for p in &path.paths {
                 let _ = writeln!(buf, "  metric {} path {:?}", path.cost, p);
             }
+            write_first_hop_links(buf, &path.first_hop_links);
         }
     } else {
         for (vertex, nhops) in spf {
@@ -619,8 +620,20 @@ pub fn disp_out(buf: &mut String, spf: &BTreeMap<usize, Path>, full_path: bool) 
             for p in &nhops.nexthops {
                 let _ = writeln!(buf, "  metric {} path {:?}", nhops.cost, p);
             }
+            write_first_hop_links(buf, &nhops.first_hop_links);
         }
     }
+}
+
+/// Render `first_hop_links` sorted by (vertex_id, link_id) so the
+/// output is stable across runs — `HashSet` iteration order isn't.
+fn write_first_hop_links(buf: &mut String, links: &HashSet<(usize, u32)>) {
+    if links.is_empty() {
+        return;
+    }
+    let mut sorted: Vec<(usize, u32)> = links.iter().copied().collect();
+    sorted.sort();
+    let _ = writeln!(buf, "  first_hop_links: {:?}", sorted);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Two related cleanups in the SPF/RIB path:

- **Extract `first_router_hop_idx`** (`zebra-rs/src/isis/inst.rs`): the leading-pseudonode skip pattern needed to land on the first real router on an SPF path was open-coded in both the IPv4 and IPv6 RIB builders. Move it into a single helper `first_router_hop_idx(path, lsp_map) -> Option<usize>` and use it at both call sites. The empty-path early-return in each builder becomes redundant — `first_router_hop_idx` returns `None` for an empty path, and the only `p[0]` access (IPv4 builder) is reached only after the `Some(nhop_idx)` binding succeeds, which guarantees `p.len() >= 1`.
- **Show `first_hop_links` in `spf::disp_out`**: print the set per vertex (only when non-empty), sorted by `(vertex_id, link_id)` so output is stable across runs (`HashSet` iteration order isn't). Helps debugging when looking at SPF dumps.

No production behavior change — this is display + refactor.

## Test plan

- [x] All 340 existing tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

Generated with [Claude Code](https://claude.com/claude-code)