### PR TITLE
isis: wire TI-LFA repair_path into SpfNexthop.backup

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2508,6 +2508,59 @@ fn first_router_hop_id(lsp_map: &LspMap, path: &[usize]) -> Option<usize> {
     (idx < path.len()).then_some(path[idx])
 }
 
+/// Translate a graph-level `spf::RepairPath` into the FIB-ready
+/// `RepairPathMpls`: resolve the SR segment list to an absolute MPLS
+/// label stack and pin the post-conv first-hop's local egress
+/// (ifindex from `first_hop_link_id`; addr from the link's neighbor
+/// table). Returns `None` when any segment fails to resolve or when
+/// the first-hop has no usable IPv4 address — partial stacks are
+/// refused because a divergent label path would silently misroute.
+///
+/// LAN trivial-repair (empty label stack, first_hop is a pseudonode)
+/// is skipped: picking an arbitrary LAN member for an un-steered
+/// repair can loop, and the per-path "real router after the PN" is
+/// not carried on `RepairPath` today. SR-steered LAN repairs are
+/// fine — the labels drive forwarding independent of which LAN
+/// member receives the packet first.
+fn build_repair_path_mpls(
+    top: &IsisTop,
+    level: Level,
+    rp: &spf::RepairPath,
+) -> Option<RepairPathMpls> {
+    let labels = repair_segments_to_mpls_labels(top, level, &rp.segs)?;
+
+    let ifindex = (rp.first_hop_link_id != 0).then_some(rp.first_hop_link_id)?;
+    let link = top.links.get(&ifindex)?;
+    let lsp_map = top.lsp_map.get(&level);
+
+    let addr = if lsp_map.is_pseudo(rp.first_hop) {
+        if labels.is_empty() {
+            return None;
+        }
+        link.state
+            .nbrs
+            .get(&level)
+            .values()
+            .find_map(|nbr| nbr.addr4.keys().next().copied())?
+    } else {
+        let sys_id = lsp_map.resolve(rp.first_hop)?;
+        link.state
+            .nbrs
+            .get(&level)
+            .get(sys_id)?
+            .addr4
+            .keys()
+            .next()
+            .copied()?
+    };
+
+    Some(RepairPathMpls {
+        ifindex,
+        addr,
+        labels,
+    })
+}
+
 /// Build RIB from SPF calculation results
 fn build_rib_from_spf(
     top: &mut IsisTop,
@@ -2586,10 +2639,20 @@ fn build_rib_from_spf(
             }
         }
 
-        // TI-LFA backup path.
-        if let Some(repair_path) = tilfa_result.get(node) {
-            // Found TI-LFA backup path.
-            println!("repair_path:{:?}", repair_path);
+        // TI-LFA backup path. tilfa_repair_path() only emits entries
+        // for single-primary-first-hop destinations today (ECMP at
+        // the primary level is skipped), so spf_nhops shares a single
+        // protected first-hop — stamping the same backup on every
+        // entry is correct by construction. When primary-ECMP-aware
+        // TI-LFA lands, match each entry in the Vec to its specific
+        // protected primary by first-hop vertex.
+        if let Some(repair_paths) = tilfa_result.get(node)
+            && let Some(repair) = repair_paths.first()
+            && let Some(backup) = build_repair_path_mpls(top, level, repair)
+        {
+            for nhop in spf_nhops.values_mut() {
+                nhop.backup = Some(backup.clone());
+            }
         }
 
         // Process reachability entries for this node.


### PR DESCRIPTION
## Summary

Replace the placeholder `println!("repair_path:{:?}", repair_path);` at `build_rib_from_spf`'s TI-LFA hook with the real stamping into `SpfNexthop.backup`. The slot was designed for exactly this; the FIB install side already consumes it via the metric-offset convention (primary at `route.metric`, backup at `route.metric + BACKUP_METRIC_OFFSET`, see `make_rib_entry` at inst.rs:2112).

### New helper

`build_repair_path_mpls(top, level, &spf::RepairPath) -> Option<RepairPathMpls>`:

- **labels**: via the existing `repair_segments_to_mpls_labels` scaffold (now reachable from live code; transitive chain `node_sid_label_for_vertex` / `adj_sid_label_for_link` / `resolve_sid_to_label` / `SrBlockKind` all become live).
- **ifindex**: directly from `RepairPath.first_hop_link_id` (added in the prior PR).
- **addr**: for P2P first_hop, look up the resolved sys_id on the chosen interface's nbr table. For LAN first_hop (pseudonode), when the label stack is non-empty any LAN member works because the SR labels carry the steering — pick the first available. For trivial LAN repair (empty stack), skip until `RepairPath` carries the specific post-PN router.

Returns `None` on any resolution failure (partial label stacks are refused — installing a divergent path silently misroutes).

### Wiring at line 2589

Stamps the resolved backup onto every entry in `spf_nhops`. Correct by construction today because `tilfa_repair_path()` only emits entries for single-primary-first-hop destinations; per-primary-vertex matching is a follow-up when primary-ECMP-aware TI-LFA lands.

### Net effect

Before: `SpfNexthop.backup` was always `None`, so every route went through the 1-metric `Uni`/`Multi` arm in `build_rib_nexthop`. After: destinations covered by TI-LFA cross into the 2-group `Nexthop::List` arm — the metric-offset install pipeline is now reachable.

## Known follow-ups (already documented in code comments)

- Primary-ECMP destinations still skipped at the `tilfa_repair_path()` source — needs per-primary-vertex keying.
- LAN trivial-repair (empty label stack, first_hop is a PN) returns `None` until `RepairPath` carries the per-path post-PN router.
- Anycast clobber on the equal-metric merge (documented in `build_rib_from_spf` comment from the prior PR).

## Test plan

- [x] All 341 existing tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

Generated with [Claude Code](https://claude.com/claude-code)