### PR TITLE
isis,rib: CLI dispatch for route/fast-reroute detail (PR A)

### DIFF
--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -24,6 +24,15 @@ impl Isis {
         self.show_add("/show/isis", show_isis);
         self.show_add("/show/isis/summary", show_isis_summary);
         self.show_add("/show/isis/route", show_isis_route);
+        self.show_add("/show/isis/route/detail", show_isis_route_detail);
+        self.show_add(
+            "/show/isis/fast-reroute/summary",
+            show_isis_fast_reroute_summary,
+        );
+        self.show_add(
+            "/show/isis/fast-reroute/prefix/detail",
+            show_isis_fast_reroute_prefix_detail,
+        );
         self.show_add("/show/isis/interface", link::show);
         self.show_add("/show/isis/interface/detail", link::show_detail);
         self.show_add("/show/isis/dis/statistics", link::show_dis_statistics);
@@ -258,6 +267,47 @@ struct NexthopJson {
 struct RoutesJson {
     level_1: Vec<RouteJson>,
     level_2: Vec<RouteJson>,
+}
+
+/// `show isis route detail` (PR A: dispatch surface only). The TI-LFA
+/// backup / SR-MPLS / SRv6 detail renderer lands in PR C; for now we
+/// surface a header so the wired path is visible.
+fn show_isis_route_detail(
+    isis: &Isis,
+    args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let body = show_isis_route(isis, args, json)?;
+    if json {
+        Ok(body)
+    } else {
+        Ok(format!("[detail format pending — PR C]\n{body}"))
+    }
+}
+
+/// `show isis fast-reroute summary` (PR A stub; renderer lands in PR D).
+fn show_isis_fast_reroute_summary(
+    _isis: &Isis,
+    _args: Args,
+    _json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    Ok("[fast-reroute summary pending — PR D]\n".to_string())
+}
+
+/// `show isis fast-reroute prefix A.B.C.D/N detail` (PR A stub;
+/// renderer lands in PR D). Validates the prefix arg now so the
+/// dispatch is honest about input parsing.
+fn show_isis_fast_reroute_prefix_detail(
+    _isis: &Isis,
+    mut args: Args,
+    _json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let Some(prefix) = args.v4net() else {
+        return Ok("% Invalid IPv4 prefix\n".to_string());
+    };
+    Ok(format!(
+        "[fast-reroute detail for {prefix} pending — PR D]\n"
+    ))
 }
 
 fn show_isis_route(

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -721,6 +721,70 @@ pub fn rib_show(rib: &Rib, _args: Args, json: bool) -> String {
     }
 }
 
+/// `show ip route detail` (PR A: dispatch surface only). The detail
+/// renderer lands in PR B; for now we surface a header so the wired
+/// path is visible, then fall through to the one-line layout.
+pub fn rib_show_detail(rib: &Rib, args: Args, json: bool) -> String {
+    let body = rib_show(rib, args, json);
+    if json {
+        body
+    } else {
+        format!("[detail format pending — PR B]\n{body}")
+    }
+}
+
+/// `show ip route prefix A.B.C.D/N` — single-prefix filter, one-line
+/// layout. Falls back to "% No route" when the prefix isn't in the
+/// table or the argument fails to parse.
+pub fn rib_show_prefix(rib: &Rib, mut args: Args, json: bool) -> String {
+    let Some(prefix) = args.v4net() else {
+        return "% Invalid IPv4 prefix\n".to_string();
+    };
+    rib_show_one(rib, &prefix, json, false)
+}
+
+/// `show ip route prefix A.B.C.D/N detail` — single-prefix filter,
+/// detail layout. Detail renderer lands in PR B; falls back to
+/// one-line with a pending-detail header.
+pub fn rib_show_prefix_detail(rib: &Rib, mut args: Args, json: bool) -> String {
+    let Some(prefix) = args.v4net() else {
+        return "% Invalid IPv4 prefix\n".to_string();
+    };
+    rib_show_one(rib, &prefix, json, true)
+}
+
+/// Shared helper for the two `prefix`-keyed handlers. `detail`
+/// currently only flips the header — PR B replaces the body with
+/// the IOS-XR-style routing-descriptor-block renderer.
+fn rib_show_one(rib: &Rib, prefix: &Ipv4Net, json: bool, detail: bool) -> String {
+    let Some(entries) = rib.table.get(prefix) else {
+        return if json {
+            "{\"routes\": []}\n".to_string()
+        } else {
+            format!("% No route for {prefix}\n")
+        };
+    };
+
+    if json {
+        let routes: Vec<RouteEntry> = entries
+            .iter()
+            .map(|e| rib_entry_to_json(rib, prefix, e))
+            .collect();
+        return serde_json::to_string_pretty(&RouteTable { routes })
+            .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize routes: {}\"}}", e));
+    }
+
+    let mut buf = String::new();
+    if detail {
+        buf.push_str("[detail format pending — PR B]\n");
+    }
+    buf.push_str(SHOW_IPV4_HEADER);
+    for entry in entries.iter() {
+        let _ = write!(buf, "{}", rib_entry_show(rib, prefix, entry, json).unwrap());
+    }
+    buf
+}
+
 pub fn rib6_show(rib: &Rib, _args: Args, json: bool) -> String {
     if json {
         let mut routes = Vec::new();
@@ -750,6 +814,66 @@ pub fn rib6_show(rib: &Rib, _args: Args, json: bool) -> String {
         }
         buf
     }
+}
+
+/// `show ipv6 route detail` (PR A: dispatch surface only).
+pub fn rib6_show_detail(rib: &Rib, args: Args, json: bool) -> String {
+    let body = rib6_show(rib, args, json);
+    if json {
+        body
+    } else {
+        format!("[detail format pending — PR B]\n{body}")
+    }
+}
+
+/// `show ipv6 route prefix X::Y/N` — single-prefix, one-line layout.
+pub fn rib6_show_prefix(rib: &Rib, mut args: Args, json: bool) -> String {
+    let Some(prefix) = args.v6net() else {
+        return "% Invalid IPv6 prefix\n".to_string();
+    };
+    rib6_show_one(rib, &prefix, json, false)
+}
+
+/// `show ipv6 route prefix X::Y/N detail` — single-prefix, detail
+/// layout (renderer pending PR B).
+pub fn rib6_show_prefix_detail(rib: &Rib, mut args: Args, json: bool) -> String {
+    let Some(prefix) = args.v6net() else {
+        return "% Invalid IPv6 prefix\n".to_string();
+    };
+    rib6_show_one(rib, &prefix, json, true)
+}
+
+fn rib6_show_one(rib: &Rib, prefix: &Ipv6Net, json: bool, detail: bool) -> String {
+    let Some(entries) = rib.table_v6.get(prefix) else {
+        return if json {
+            "{\"routes\": []}\n".to_string()
+        } else {
+            format!("% No route for {prefix}\n")
+        };
+    };
+
+    if json {
+        let routes: Vec<RouteEntry> = entries
+            .iter()
+            .map(|e| rib_entry_to_json_v6(rib, prefix, e))
+            .collect();
+        return serde_json::to_string_pretty(&RouteTable { routes })
+            .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize routes: {}\"}}", e));
+    }
+
+    let mut buf = String::new();
+    if detail {
+        buf.push_str("[detail format pending — PR B]\n");
+    }
+    buf.push_str(SHOW_IPV6_HEADER);
+    for entry in entries.iter() {
+        let _ = write!(
+            buf,
+            "{}",
+            rib_entry_show_v6(rib, prefix, entry, json).unwrap()
+        );
+    }
+    buf
 }
 
 // JSON structures for MPLS ILM display
@@ -1053,7 +1177,13 @@ impl Rib {
     pub fn show_build(&mut self) {
         self.show_add("/show/interface", link_show);
         self.show_add("/show/ip/route", rib_show);
+        self.show_add("/show/ip/route/detail", rib_show_detail);
+        self.show_add("/show/ip/route/prefix", rib_show_prefix);
+        self.show_add("/show/ip/route/prefix/detail", rib_show_prefix_detail);
         self.show_add("/show/ipv6/route", rib6_show);
+        self.show_add("/show/ipv6/route/detail", rib6_show_detail);
+        self.show_add("/show/ipv6/route/prefix", rib6_show_prefix);
+        self.show_add("/show/ipv6/route/prefix/detail", rib6_show_prefix_detail);
         self.show_add("/show/nexthop", nexthop_show);
         self.show_add("/show/mpls/ilm", ilm_show);
         self.show_add("/show/l2/mac/table", mac_show);

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -153,10 +153,25 @@ module exec {
     }
     container ip {
       ext:help "Show IP commands";
-      leaf route {
-        ext:help "IP route prefix";
-        // type inet:ipv4-prefix;
-        type empty;
+      container route {
+        ext:help "IPv4 routing table";
+        presence "Show IPv4 routes";
+        leaf detail {
+          ext:help "Show all routes in detail format (IOS-XR style)";
+          type empty;
+        }
+        list prefix {
+          ext:help "Filter to a specific IPv4 prefix";
+          ext:presence "Show one IPv4 prefix";
+          key value;
+          leaf value {
+            type inet:ipv4-prefix;
+          }
+          leaf detail {
+            ext:help "Show this prefix in detail format";
+            type empty;
+          }
+        }
       }
       container bgp {
         ext:help "BGP commands";
@@ -263,9 +278,33 @@ module exec {
         ext:help "IS-IS summary";
         type empty;
       }
-      leaf route {
+      container route {
         ext:help "IS-IS route";
-        type empty;
+        presence "Show IS-IS routes";
+        leaf detail {
+          ext:help "Show IS-IS routes in detail format (TI-LFA, SR-MPLS, SRv6)";
+          type empty;
+        }
+      }
+      container fast-reroute {
+        ext:help "IS-IS Fast ReRoute (TI-LFA) information";
+        presence "Show TI-LFA information";
+        leaf summary {
+          ext:help "Per-level counters: protected / unprotected prefixes";
+          type empty;
+        }
+        list prefix {
+          ext:help "Per-prefix TI-LFA repair detail";
+          ext:presence "Show TI-LFA repair detail for one prefix";
+          key value;
+          leaf value {
+            type inet:ipv4-prefix;
+          }
+          leaf detail {
+            ext:help "Detail format (P/Q nodes, segment list, backup-src)";
+            type empty;
+          }
+        }
       }
       container interface {
         ext:help "IS-IS interface";
@@ -329,14 +368,25 @@ module exec {
     }
     container ipv6 {
       ext:help "Show IPv6 commands";
-      leaf route {
-        ext:help "IPv6 address";
-        // type inet:ipv6-address;
-        type empty;
-      }
-      leaf prefix {
-        ext:help "IPv6 prefix";
-        type inet:ipv6-prefix;
+      container route {
+        ext:help "IPv6 routing table";
+        presence "Show IPv6 routes";
+        leaf detail {
+          ext:help "Show all routes in detail format (IOS-XR style)";
+          type empty;
+        }
+        list prefix {
+          ext:help "Filter to a specific IPv6 prefix";
+          ext:presence "Show one IPv6 prefix";
+          key value;
+          leaf value {
+            type inet:ipv6-prefix;
+          }
+          leaf detail {
+            ext:help "Show this prefix in detail format";
+            type empty;
+          }
+        }
       }
     }
     container "policy" {


### PR DESCRIPTION
## Summary

PR A of the route-detail series. Wires the YANG grammar and show-callback dispatch for new detail-view commands. Renderers are stubs — they emit a header and fall through to the existing one-line layout (or return a placeholder for fast-reroute, which has no existing equivalent). Subsequent PRs replace the stubs:

- **PR B** — RIB detail rendering (`rib::show_*_detail`)
- **PR C** — IS-IS route detail (`show isis route detail`)
- **PR D** — fast-reroute summary + per-prefix detail

### YANG changes (`exec.yang`)

- `show ip route` and `show ipv6 route` become containers (with presence) holding a `detail` leaf and a `prefix` list keyed by value. Removed the stale `show ipv6 prefix` leaf (no handler was registered).
- `show isis route` becomes a container with `detail` leaf.
- New `show isis fast-reroute` container with `summary` leaf and `prefix <pfx> [detail]` list.

### Commands users can type now

```
show ip route                               (existing one-line)
show ip route detail                        (PR B will format as block)
show ip route prefix A.B.C.D/N              (one-line, single prefix)
show ip route prefix A.B.C.D/N detail       (PR B will format as block)
show ipv6 route ...                         (mirror)
show isis route                             (existing)
show isis route detail                      (PR C)
show isis fast-reroute summary              (PR D)
show isis fast-reroute prefix X detail      (PR D)
```

### Stub behavior

- bare `detail` commands prepend a `[... pending — PR X]` header and call the existing one-line renderer so output is non-empty during PR A.
- `prefix` variants extract the v4net/v6net arg, filter the table to that one entry, and reuse the existing per-entry renderer. A bad prefix arg surfaces `% Invalid IPv4 prefix`.
- fast-reroute stubs return a header line only.

### What stays unchanged

Existing `show ip route` / `show ipv6 route` / `show isis route` paths and output are byte-identical to before this PR.

## Test plan

- [x] All 331 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

Generated with [Claude Code](https://claude.com/claude-code)