### PR TITLE
fib: detailed trace for NewRoute / NewNexthop errors

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -39,8 +39,83 @@ use crate::rib::inst::IlmEntry;
 use crate::rib::route::{DEBUG_ADDR, DEBUG_EVPN};
 use crate::rib::{
     AddrGenMode, Bridge, Group, GroupTrait, MacAddr, Nexthop, NexthopMulti, NexthopUni, RibType,
-    Vxlan, link,
+    Vxlan, link, nexthop::NexthopMember,
 };
+
+/// Compact one-line dump of a `Nexthop` for diagnostic logging.
+/// Surfaces the fields that matter when the kernel rejects an
+/// install — `gid` (so we can spot `Nhid(0)` mistakes), per-leg
+/// address + resolved ifindex, MPLS label stack, and per-leg
+/// weight on Multi.
+fn fmt_nexthop_for_trace(nh: &Nexthop) -> String {
+    fn fmt_uni(u: &NexthopUni) -> String {
+        format!(
+            "{{addr={} ifindex={:?} gid={} metric={} mpls={:?} weight={}}}",
+            u.addr,
+            u.ifindex(),
+            u.gid,
+            u.metric,
+            u.mpls,
+            u.weight,
+        )
+    }
+    fn fmt_multi(m: &NexthopMulti) -> String {
+        let legs: Vec<String> = m.nexthops.iter().map(fmt_uni).collect();
+        format!(
+            "Multi{{gid={} metric={} legs=[{}]}}",
+            m.gid,
+            m.metric,
+            legs.join(", ")
+        )
+    }
+    match nh {
+        Nexthop::Uni(u) => format!("Uni{}", fmt_uni(u)),
+        Nexthop::Multi(m) => fmt_multi(m),
+        Nexthop::List(l) => {
+            let members: Vec<String> = l
+                .nexthops
+                .iter()
+                .enumerate()
+                .map(|(i, m)| match m {
+                    NexthopMember::Uni(u) => format!("#{i}=Uni{}", fmt_uni(u)),
+                    NexthopMember::Multi(mm) => format!("#{i}={}", fmt_multi(mm)),
+                })
+                .collect();
+            format!("List[{}]", members.join(", "))
+        }
+        Nexthop::Link(ifindex) => format!("Link(ifindex={ifindex})"),
+    }
+}
+
+/// Compact one-line dump of a kernel-side `Group` (the
+/// nexthop-table object referenced by `Nhid`). Surfaces the gid,
+/// for a Uni leg the (addr, ifindex), for a Multi the member-id
+/// list — enough to correlate an `RTM_NEWNEXTHOP` ENODEV with the
+/// stale link that produced it.
+fn fmt_group_for_trace(group: &Group) -> String {
+    match group {
+        Group::Uni(u) => format!(
+            "Group::Uni{{gid={} addr={} ifindex={:?} valid={} installed={}}}",
+            u.gid(),
+            u.addr,
+            u.ifindex(),
+            u.is_valid(),
+            u.is_installed(),
+        ),
+        Group::Multi(m) => {
+            let members: Vec<String> = m
+                .valid
+                .iter()
+                .map(|(id, w)| format!("({id}, w={w})"))
+                .collect();
+            format!(
+                "Group::Multi{{gid={} members=[{}]}}",
+                m.gid(),
+                members.join(", ")
+            )
+        }
+    }
+}
 
 // Flip to true to re-enable IPv6 FIB install diagnostic prints.
 const DEBUG_V6: bool = false;
@@ -298,10 +373,23 @@ impl FibHandle {
         let mut req = NetlinkMessage::from(RouteNetlinkMessage::NewRoute(msg));
         req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL;
 
+        // Pre-send dump — `tracing::debug!` so production stays
+        // quiet; enable via `RUST_LOG=zebra_rs::fib=debug` when
+        // chasing an install failure.
+        tracing::debug!(
+            "RTM_NEWROUTE v4 {prefix} use_nhid={} nh={}",
+            self.use_nhid,
+            fmt_nexthop_for_trace(nexthop),
+        );
+
         let mut response = self.handle.clone().request(req).unwrap();
         while let Some(msg) = response.next().await {
             if let NetlinkPayload::Error(e) = msg.payload {
-                tracing::info!("NewRoute error: {prefix} {e}");
+                tracing::info!(
+                    "NewRoute error: {prefix} {e} use_nhid={} nh={}",
+                    self.use_nhid,
+                    fmt_nexthop_for_trace(nexthop),
+                );
             }
         }
     }
@@ -501,6 +589,19 @@ impl FibHandle {
         }
 
         if self.use_nhid {
+            // Pre-send sanity check — mirror of route_ipv4_add_uni.
+            let gid_for_check = match &nexthop {
+                Nexthop::Uni(u) => Some(u.gid),
+                Nexthop::Multi(m) => Some(m.gid),
+                _ => None,
+            };
+            if let Some(0) = gid_for_check {
+                tracing::warn!(
+                    "RTM_NEWROUTE v6 skipped for {prefix}: nexthop gid is 0 (would Nhid(0) -> ENODEV); nh={}",
+                    fmt_nexthop_for_trace(nexthop),
+                );
+                return;
+            }
             if let Nexthop::Uni(uni) = &nexthop {
                 if DEBUG_V6 {
                     tracing::info!(
@@ -602,12 +703,23 @@ impl FibHandle {
         let mut req = NetlinkMessage::from(RouteNetlinkMessage::NewRoute(msg));
         req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL;
 
+        // Pre-send dump — `tracing::debug!` so production stays
+        // quiet; enable via `RUST_LOG=zebra_rs::fib=debug` when
+        // chasing an install failure.
+        tracing::debug!(
+            "RTM_NEWROUTE v6 {prefix} use_nhid={} nh={}",
+            self.use_nhid,
+            fmt_nexthop_for_trace(nexthop),
+        );
+
         let mut response = self.handle.clone().request(req).unwrap();
         while let Some(msg) = response.next().await {
-            if let NetlinkPayload::Error(e) = msg.payload
-                && DEBUG_ADDR
-            {
-                tracing::info!("NewRoute IPv6 error: {prefix} {e}");
+            if let NetlinkPayload::Error(e) = msg.payload {
+                tracing::info!(
+                    "NewRoute IPv6 error: {prefix} {e} use_nhid={} nh={}",
+                    self.use_nhid,
+                    fmt_nexthop_for_trace(nexthop),
+                );
             }
         }
     }
@@ -921,11 +1033,17 @@ impl FibHandle {
         let mut req = NetlinkMessage::from(RouteNetlinkMessage::NewNexthop(msg));
         req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE;
 
+        let group_summary = fmt_group_for_trace(nexthop);
+        tracing::debug!("RTM_NEWNEXTHOP {}", group_summary);
+
         let mut response = self.handle.clone().request(req).unwrap();
         while let Some(msg) = response.next().await {
             match msg.payload {
                 NetlinkPayload::Error(e) => {
-                    tracing::info!("NewNexthop error: {e} gid: {gid} refcnt: {refcnt}");
+                    tracing::info!(
+                        "NewNexthop error: {e} gid: {gid} refcnt: {refcnt} {}",
+                        group_summary,
+                    );
                 }
                 NetlinkPayload::Done(m) => {
                     tracing::info!("NewNexthop done {m:?}");

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -3164,15 +3164,12 @@ fn tilfa_repair_path(
     let mut tilfa_result = BTreeMap::new();
 
     for (d, path) in spf_result.iter() {
-        print!("{}: {:?}", d, path.paths);
         // Source is skipped.
         if *d == source {
-            println!(" => Source is skipped");
             continue;
         }
         // ECMP is skipped.
         if path.paths.len() > 1 {
-            println!(" => ECMP is skipped");
             continue;
         }
 
@@ -3184,11 +3181,6 @@ fn tilfa_repair_path(
         let x = first[0];
 
         let repair_paths = spf::tilfa(graph, source, *d, &[x]);
-        if let Some(repair) = repair_paths.first() {
-            println!(" => [{}] {:?}", repair.first_hop, repair.segs);
-        } else {
-            println!(" => no repair path");
-        }
         if !repair_paths.is_empty() {
             tilfa_result.insert(*d, repair_paths);
         }


### PR DESCRIPTION
## Summary

Two commits:

### `e07a0e0f` — Remove debug println

Local cleanup carried along from main: drops 8 stray `println!` lines from `isis/inst.rs`.

### `5338fef0` — Detailed trace for NewRoute / NewNexthop errors

`NewRoute` / `NewNexthop` install failures previously logged only the prefix and the bare errno. When the kernel returns ENODEV (errno 19) for a route with TI-LFA backup `List` shape, there's no way to tell from the log which member's nexthop group is bad or whether the issue is a stale ifindex on a leg vs a `Nhid(0)` reference.

Adds:

- **`fmt_nexthop_for_trace`** — one-line dump of a `Nexthop` showing `gid` (so `Nhid(0)` bugs jump out), per-leg `addr` + resolved `ifindex`, MPLS stack, and weight on `Multi`. Walks `List` members and tags primary vs backup by index.
- **`fmt_group_for_trace`** — sibling for `Group` (the kernel-side nexthop-table object referenced by `Nhid`).
- **Pre-send `tracing::debug!` dumps** on `route_ipv{4,6}_add_uni` and `nexthop_add`. Enable with `RUST_LOG=zebra_rs::fib=debug`.
- **Enhanced error logs** at the three install sites to include the formatted nexthop / group so the failing object is visible without re-running with debug-level on.
- **Pre-send sanity check**: if `use_nhid` and the gid is 0, log a warning and skip the install — surfaces the bug locally rather than chasing the kernel's ENODEV after the fact.
- Dropped the `DEBUG_ADDR` gate on the v6 `NewRoute` error log so v6 install failures are visible by default, matching v4.

No behavior change for successful installs.

## Test plan

- [x] All 341 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

## Sample expected output

```
NewRoute error: 192.168.4.0/24 No such device (os error 19) use_nhid=true \
  nh=List[#0=Multi{gid=42 metric=1011 legs=[{addr=192.168.3.2 ifindex=Some(3) gid=10 ...}, ...]}, \
         #1=Uni{addr=192.168.3.2 ifindex=Some(3) gid=0 metric=1012 mpls=[Explicit(16500)] ...}]
```

`gid=0` on the backup `Uni` would be the smoking gun for the suspected TI-LFA backup install bug.

Generated with [Claude Code](https://claude.com/claude-code)