### PR TITLE
rib: resolve nested Multi members inside Nexthop::List

### DIFF
--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -1001,11 +1001,27 @@ fn rib_resolve_nexthop(
         resolve_nexthop_multi(multi, nmap, set);
     }
     if let Nexthop::List(pro) = &mut entry.nexthop {
-        let mut _pro_valid = false;
-        for uni in pro.iter_unis_mut() {
-            let valid = resolve_nexthop_uni(uni, nmap, table);
-            if valid {
-                _pro_valid = true;
+        // Walk members explicitly (not via `iter_unis_mut`) so each
+        // `NexthopMember::Multi` gets a kernel-side group allocated
+        // via `resolve_nexthop_multi` — the iter-unis version
+        // flattens the structure and leaves the Multi wrapper's
+        // `gid` at 0, which makes the FIB install fail with ENODEV
+        // (Nhid(0)) at RTM_NEWROUTE time.
+        for member in pro.nexthops.iter_mut() {
+            match member {
+                NexthopMember::Uni(uni) => {
+                    let _ = resolve_nexthop_uni(uni, nmap, table);
+                }
+                NexthopMember::Multi(multi) => {
+                    let mut set = BTreeSet::<(usize, u8)>::new();
+                    for uni in multi.nexthops.iter_mut() {
+                        let valid = resolve_nexthop_uni(uni, nmap, table);
+                        if valid {
+                            set.insert((uni.gid, uni.weight));
+                        }
+                    }
+                    resolve_nexthop_multi(multi, nmap, set);
+                }
             }
         }
     }
@@ -1393,8 +1409,26 @@ fn rib_resolve_nexthop_v6(
         resolve_nexthop_multi(multi, nmap, set);
     }
     if let Nexthop::List(pro) = &mut entry.nexthop {
-        for uni in pro.iter_unis_mut() {
-            let _ = resolve_nexthop_uni_v6(uni, nmap, table);
+        // Mirror of the v4 fix: walk members explicitly so each
+        // `NexthopMember::Multi` gets a kernel-side group allocated
+        // (without this, the Multi wrapper's `gid` stays at 0 and
+        // the FIB install fails with ENODEV at Nhid(0)).
+        for member in pro.nexthops.iter_mut() {
+            match member {
+                NexthopMember::Uni(uni) => {
+                    let _ = resolve_nexthop_uni_v6(uni, nmap, table);
+                }
+                NexthopMember::Multi(multi) => {
+                    let mut set = BTreeSet::<(usize, u8)>::new();
+                    for uni in multi.nexthops.iter_mut() {
+                        let valid = resolve_nexthop_uni_v6(uni, nmap, table);
+                        if valid {
+                            set.insert((uni.gid, uni.weight));
+                        }
+                    }
+                    resolve_nexthop_multi(multi, nmap, set);
+                }
+            }
         }
     }
     // If one of nexthop is valid, the entry is valid.
@@ -1635,5 +1669,59 @@ mod tests {
             RecoveryDecision::Recover
         );
         assert_eq!(state.history.len(), 1);
+    }
+
+    /// Regression: `Nexthop::List { Multi(...), Uni(backup) }` must
+    /// allocate a kernel-side group for the nested Multi via
+    /// `resolve_nexthop_multi`. Before the fix, only the Multi's
+    /// leg Unis were resolved (via `iter_unis_mut`) and the Multi
+    /// wrapper's `gid` stayed at 0 — the FIB then installed a route
+    /// with `Nhid(0)` and the kernel returned ENODEV.
+    #[test]
+    fn list_with_nested_multi_resolves_multi_gid() {
+        use super::super::entry::RibEntry;
+        use super::super::nexthop::NexthopUni;
+        use super::super::{Nexthop, NexthopList, NexthopMap, NexthopMember, NexthopMulti};
+        use super::super::{RibEntries, RibType};
+        use super::rib_resolve_nexthop;
+        use ipnet::Ipv4Net;
+        use prefix_trie::PrefixMap;
+
+        let leg_a = NexthopUni::new("10.0.0.1".parse().unwrap(), 1011, vec![]);
+        let leg_b = NexthopUni::new("10.0.0.2".parse().unwrap(), 1011, vec![]);
+        let multi = NexthopMulti {
+            metric: 1011,
+            nexthops: vec![leg_a, leg_b],
+            ..Default::default()
+        };
+        let backup = NexthopUni::new("10.0.0.3".parse().unwrap(), 1012, vec![]);
+
+        let mut entry = RibEntry::new(RibType::Isis);
+        entry.nexthop = Nexthop::List(NexthopList {
+            nexthops: vec![NexthopMember::Multi(multi), NexthopMember::Uni(backup)],
+        });
+
+        let mut nmap = NexthopMap::default();
+        let table: PrefixMap<Ipv4Net, RibEntries> = PrefixMap::new();
+        rib_resolve_nexthop(&mut entry, &table, &mut nmap);
+
+        let Nexthop::List(pro) = &entry.nexthop else {
+            panic!("entry.nexthop should still be List");
+        };
+        let multi_member = pro
+            .nexthops
+            .iter()
+            .find_map(|m| match m {
+                NexthopMember::Multi(m) => Some(m),
+                _ => None,
+            })
+            .expect("multi member preserved");
+        assert!(
+            multi_member.gid != 0,
+            "nested Multi must get a kernel-side group allocated (gid != 0)"
+        );
+        for leg in &multi_member.nexthops {
+            assert!(leg.gid != 0, "each leg also gets a gid");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the FIB install failure surfaced by the trace in PR #554:

```
NewRoute error: 192.168.4.0/24 No such device (os error 19) use_nhid=true
  nh=Multi{gid=0 metric=1011 legs=[
    {addr=192.168.3.2 ifindex=Some(4) gid=2 ...},
    {addr=192.168.10.2 ifindex=Some(3) gid=1 ...}
  ]}
```

`gid=0` on the outer Multi was the smoking gun: the leg Unis got valid kernel-side groups (`gid=1`, `gid=2`), but the Multi wrapper itself never did, so the FIB emitted `Nhid(0)` and the kernel returned ENODEV.

### Root cause

In `rib_resolve_nexthop` / `rib_resolve_nexthop_v6`, the `Nexthop::List` branch walked members via `pro.iter_unis_mut()`, which flattens the structure to a stream of leg `NexthopUni`s. Each leg got `resolve_nexthop_uni` called on it (allocating its gid), but the `NexthopMember::Multi` wrapper was never passed to `resolve_nexthop_multi` to allocate the multipath group.

### Fix

Walk List members explicitly, dispatched by variant:
- `NexthopMember::Uni` → `resolve_nexthop_uni` (unchanged)
- `NexthopMember::Multi` → resolve each leg via `resolve_nexthop_uni` + the wrapper's `resolve_nexthop_multi` call (mirrors the top-level `Nexthop::Multi` treatment)

Applied symmetrically to v4 and v6.

After this, the `Multi` wrapper gets a non-zero `gid`, the FIB emits a valid `Nhid(N)`, and the kernel install succeeds. The `Nhid(0)` warn-and-skip sanity check in PR #554 becomes redundant (but harmless) — both paths now produce valid gids.

### Test

`list_with_nested_multi_resolves_multi_gid` — constructs `List { Multi(2 legs), Uni(backup) }`, runs `rib_resolve_nexthop` against an empty table, asserts the Multi wrapper's `gid != 0` and each leg's `gid != 0`. The empty table is intentional — `resolve_nexthop_multi` allocates the kernel-side group from `fetch_multi` independent of leg validity.

## Test plan

- [x] All 342 tests pass (was 341 + 1 new)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean

Generated with [Claude Code](https://claude.com/claude-code)