### PR TITLE
isis: add network statement under afi-safi (BGP-style)

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 use std::net::Ipv4Addr;
 use std::str::FromStr;
 
+use ipnet::{Ipv4Net, Ipv6Net};
 use isis_packet::{IsLevel, Nsap};
 use strum_macros::{Display, EnumString};
 
@@ -67,6 +68,7 @@ impl Isis {
         );
         self.callback_add("/router/isis/fast-reroute/ti-lfa", config_ti_lfa);
         self.callback_add("/router/isis/multi-topology", config_mt);
+        self.callback_add("/router/isis/afi-safi/network", config_network);
         self.callback_add(
             "/router/isis/interface/multi-topology/metric",
             link::config_mt_metric,
@@ -164,6 +166,16 @@ pub struct IsisConfig {
     /// future MTs (multicast variants, geo-redundancy, ...) doesn't
     /// reshape the runtime checks that read it.
     pub mt_topologies: BTreeSet<MtId>,
+
+    /// Operator-configured IPv4 prefixes to advertise unconditionally
+    /// in every self-originated LSP, BGP-style. Populated from
+    /// `/router/isis/afi-safi[name=ipv4]/network`. Emitted as TLV 135
+    /// entries with metric 0 (receivers add their own IS-reach metric).
+    pub networks_v4: BTreeSet<Ipv4Net>,
+
+    /// IPv6 sibling of `networks_v4`. Emitted as TLV 236 in legacy
+    /// mode, TLV 237 when MT 2 is enabled — see `lsp_generate`.
+    pub networks_v6: BTreeSet<Ipv6Net>,
 }
 
 impl IsisConfig {
@@ -363,6 +375,42 @@ fn config_mt(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
         isis.config.mt_enabled = false;
         isis.config.mt_topologies.clear();
     }
+    Some(())
+}
+
+/// `/router/isis/afi-safi[name=ipv4|ipv6]/network[prefix=...]`.
+///
+/// Mirrors BGP's `network` statement: configured prefixes are
+/// advertised in every self-originated LSP independently of any
+/// interface address. Family validation happens here (v4 prefix under
+/// afi-safi=ipv4, v6 under ipv6); a mismatch returns None so libyang
+/// surfaces it as a commit failure.
+fn config_network(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let afi = args.string()?;
+    match afi.as_str() {
+        "ipv4" => {
+            let network = args.v4net()?;
+            if op.is_set() {
+                isis.config.networks_v4.insert(network);
+            } else {
+                isis.config.networks_v4.remove(&network);
+            }
+        }
+        "ipv6" => {
+            let network = args.v6net()?;
+            if op.is_set() {
+                isis.config.networks_v6.insert(network);
+            } else {
+                isis.config.networks_v6.remove(&network);
+            }
+        }
+        _ => return None,
+    }
+    // Re-originate both levels so the change reaches peers without
+    // waiting for the refresh timer. `process_lsp_originate` filters
+    // out the level that doesn't apply on single-level instances.
+    let _ = isis.tx.send(Message::LspOriginate(Level::L1, None));
+    let _ = isis.tx.send(Message::LspOriginate(Level::L2, None));
     Some(())
 }
 

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -571,6 +571,21 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
             }
         }
     }
+    // Operator-configured `network` prefixes — BGP-style. Metric 0 so
+    // receivers add only their own IS-reach metric to us, matching the
+    // SRv6-locator advertise pattern below.
+    for prefix in top.config.networks_v4.iter() {
+        let flags = Ipv4ControlInfo::new()
+            .with_prefixlen(prefix.prefix_len() as usize)
+            .with_sub_tlv(false)
+            .with_distribution(false);
+        ext_ip_reach.entries.push(IsisTlvExtIpReachEntry {
+            metric: 0,
+            flags,
+            prefix: *prefix,
+            subs: vec![],
+        });
+    }
     if !ext_ip_reach.entries.is_empty() {
         lsp.tlvs.push(ext_ip_reach.into());
     }
@@ -608,6 +623,17 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
             metric: 0,
             flags,
             prefix,
+            subs: Vec::new(),
+        });
+    }
+    // Operator-configured IPv6 `network` prefixes — sibling of the
+    // IPv4 path above. Same metric-0 rationale.
+    for prefix in top.config.networks_v6.iter() {
+        let flags = Ipv6ControlInfo::new().with_sub_tlv(false);
+        ipv6_reach.entries.push(IsisTlvIpv6ReachEntry {
+            metric: 0,
+            flags,
+            prefix: *prefix,
             subs: Vec::new(),
         });
     }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -414,6 +414,27 @@ module config {
           }
         }
 
+        list afi-safi {
+          // Configured-network advertisement, BGP-style.
+          // Each `network` entry under afi-safi=ipv4|ipv6 is emitted in
+          // every self-originated LSP as an IP-reach TLV (135 / 236 /
+          // 237 depending on MT). Prefix family must match the
+          // afi-safi name; the callback rejects mismatches.
+          key "name";
+          leaf name {
+            type enumeration {
+              enum ipv4;
+              enum ipv6;
+            }
+          }
+          list network {
+            key "prefix";
+            leaf prefix {
+              type inet:ip-prefix;
+            }
+          }
+        }
+
         leaf te-router-id {
           type inet:ipv4-address;
         }


### PR DESCRIPTION
## Summary

Adds a BGP-style \`network\` statement to IS-IS, letting the operator advertise specific prefixes via the protocol without binding them to an interface address:

\`\`\`
router isis {
  afi-safi ipv4 {
    network 1.1.1.1/32;
    network 2.2.2.2/32;
  }
  afi-safi ipv6 {
    network 2001:db8::/64;
    network 2001:db8:a::/64;
  }
}
\`\`\`

### YANG

Mirrors BGP's \`afi-safi/network\` list shape under \`router isis\`:

- \`list afi-safi\` keyed by \`name\` (\`ipv4\` | \`ipv6\` enum)
- \`list network\` keyed by \`prefix\` (\`inet:ip-prefix\` so both families share the schema)
- Family validation done in the callback — v4 prefix under afi-safi=ipv4, v6 under ipv6; mismatches fail the commit.

### Runtime

\`IsisConfig\` gains \`networks_v4: BTreeSet<Ipv4Net>\` and \`networks_v6: BTreeSet<Ipv6Net>\`. \`lsp_generate\` (PR series #558-#561 split's \`lsp.rs\`) now appends:

- One \`IsisTlvExtIpReachEntry\` (TLV 135) per configured v4 prefix
- One \`IsisTlvIpv6ReachEntry\` (TLV 236, or TLV 237 / MtIpv6Reach under MT 2) per configured v6 prefix

Metric 0 in both cases — receivers add only their own IS-reach metric to us, matching the SRv6-locator-advertise convention already in \`lsp_generate\`. Set / unset triggers \`Message::LspOriginate\` on both levels so the change reaches peers without waiting for the refresh timer.

## Test plan

- [x] \`cargo build --bin zebra-rs\` — clean
- [x] \`cargo clippy --bin zebra-rs -- -D warnings\` — clean
- [x] \`cargo test --bin zebra-rs\` — 342 passed, 0 failed
- [x] \`cargo fmt --all\` — clean
- [ ] Live-CLI round-trip not yet exercised — vty/yang commit + LSP-show on a running instance should confirm v4 and v6 entries appear in the LSDB; MT 2 should route v6 to TLV 237.

Generated with [Claude Code](https://claude.com/claude-code)