### PR TITLE
config: spawn protocol tasks on demand, tear down on `no router`

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -132,7 +132,6 @@ pub struct Bgp {
     pub show_cb: HashMap<String, ShowCallback>,
     pub rib_tx: UnboundedSender<rib::Message>,
     pub rib_rx: UnboundedReceiver<RibRx>,
-    pub redist: RibRxChannel,
     pub callbacks: HashMap<String, Callback>,
     pub pcallbacks: HashMap<String, PCallback>,
     /// BGP Local RIB (Loc-RIB) for best path selection
@@ -210,7 +209,6 @@ impl Bgp {
             cm: ConfigChannel::new(),
             show: ShowChannel::new(),
             show_cb: HashMap::new(),
-            redist: RibRxChannel::new(),
             callbacks: HashMap::new(),
             pcallbacks: HashMap::new(),
             listen_task: None,
@@ -675,8 +673,8 @@ impl Bgp {
     }
 }
 
-pub fn serve(mut bgp: Bgp) {
-    tokio::spawn(async move {
+pub fn serve(mut bgp: Bgp) -> Task<()> {
+    Task::spawn(async move {
         bgp.event_loop().await;
-    });
+    })
 }

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -1,5 +1,5 @@
 pub mod inst;
-pub use inst::{Bgp, Message, serve};
+pub use inst::{Bgp, Message};
 
 pub mod constant;
 pub use constant::*;

--- a/zebra-rs/src/config/bgp.rs
+++ b/zebra-rs/src/config/bgp.rs
@@ -1,0 +1,24 @@
+use crate::bgp::inst;
+use crate::rib;
+
+use super::ConfigManager;
+
+pub fn spawn_bgp(config: &ConfigManager) {
+    let bgp = inst::Bgp::new(config.rib_tx.clone(), config.policy_tx.clone());
+    config.subscribe("bgp", bgp.cm.tx.clone());
+    config.subscribe_show("bgp", bgp.show.tx.clone());
+    let task = inst::serve(bgp);
+    config
+        .protocol_tasks
+        .borrow_mut()
+        .insert("bgp".to_string(), task);
+}
+
+pub fn despawn_bgp(config: &ConfigManager) {
+    config.cm_clients.borrow_mut().remove("bgp");
+    config.show_clients.borrow_mut().remove("bgp");
+    config.protocol_tasks.borrow_mut().remove("bgp");
+    let _ = config.rib_tx.send(rib::Message::ProtoCleanup {
+        proto: "bgp".to_string(),
+    });
+}

--- a/zebra-rs/src/config/isis.rs
+++ b/zebra-rs/src/config/isis.rs
@@ -1,5 +1,6 @@
 use crate::context::Context;
 use crate::isis::inst;
+use crate::rib;
 
 use super::ConfigManager;
 
@@ -8,5 +9,18 @@ pub fn spawn_isis(config: &ConfigManager) {
     let isis = inst::Isis::new(ctx, config.rib_tx.clone());
     config.subscribe("isis", isis.cm.tx.clone());
     config.subscribe_show("isis", isis.show.tx.clone());
-    inst::serve(isis);
+    let task = inst::serve(isis);
+    config
+        .protocol_tasks
+        .borrow_mut()
+        .insert("isis".to_string(), task);
+}
+
+pub fn despawn_isis(config: &ConfigManager) {
+    config.cm_clients.borrow_mut().remove("isis");
+    config.show_clients.borrow_mut().remove("isis");
+    config.protocol_tasks.borrow_mut().remove("isis");
+    let _ = config.rib_tx.send(rib::Message::ProtoCleanup {
+        proto: "isis".to_string(),
+    });
 }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1,13 +1,14 @@
 use crate::config::api::{ClearTxResponse, DeployResponse, DisplayTxResponse};
 
 use super::api::{CompletionResponse, ConfigOp, ExecuteResponse, Message};
+use super::bgp::{despawn_bgp, spawn_bgp};
 use super::commands::Mode;
 use super::commands::{configure_mode_create, exec_mode_create};
 use super::configs::{carbon_copy, delete, set};
 use super::files::load_config_file;
-use super::isis::spawn_isis;
+use super::isis::{despawn_isis, spawn_isis};
 use super::json::json_read;
-use super::ospf::spawn_ospf;
+use super::ospf::{despawn_ospf, spawn_ospf};
 use super::parse::State;
 use super::parse::parse;
 use super::paths::{path_try_trim, paths_str};
@@ -16,6 +17,7 @@ use super::vty::CommandPath;
 use super::yaml::yaml_parse;
 use super::{ApplyCode, Completion, Config, ConfigRequest, DisplayRequest, ExecCode};
 
+use crate::context::Task;
 use libyang::{Entry, YangStore, to_entry};
 use similar::TextDiff;
 use std::cell::RefCell;
@@ -64,6 +66,8 @@ pub struct ConfigManager {
     pub cm_clients: RefCell<HashMap<String, UnboundedSender<ConfigRequest>>>,
     pub show_clients: RefCell<HashMap<String, UnboundedSender<DisplayRequest>>>,
     pub rib_tx: UnboundedSender<crate::rib::Message>,
+    pub policy_tx: UnboundedSender<crate::policy::Message>,
+    pub protocol_tasks: RefCell<HashMap<String, Task<()>>>,
     /// Runtime-mutable YANG-defined service-accounts (D25). Updated by
     /// `commit_config` when `vty service-account uid N` changes; read by
     /// `SessionTable::is_service_account` at session creation.
@@ -76,6 +80,7 @@ impl ConfigManager {
         mut system_path: PathBuf,
         yang_path: String,
         rib_tx: UnboundedSender<crate::rib::Message>,
+        policy_tx: UnboundedSender<crate::policy::Message>,
         #[cfg(target_os = "linux")] yang_service_accounts: std::sync::Arc<
             std::sync::RwLock<std::collections::HashSet<u32>>,
         >,
@@ -97,6 +102,8 @@ impl ConfigManager {
             cm_clients: RefCell::new(HashMap::new()),
             show_clients: RefCell::new(HashMap::new()),
             rib_tx,
+            policy_tx,
+            protocol_tasks: RefCell::new(HashMap::new()),
             #[cfg(target_os = "linux")]
             yang_service_accounts,
         };
@@ -176,6 +183,7 @@ impl ConfigManager {
 
         let mut ospf = false;
         let mut isis = false;
+        let mut bgp = false;
         for (proto, tx) in self.cm_clients.borrow().iter() {
             tx.send(ConfigRequest::new(Vec::new(), ConfigOp::CommitStart))
                 .unwrap();
@@ -184,6 +192,9 @@ impl ConfigManager {
             }
             if proto == "isis" {
                 isis = true;
+            }
+            if proto == "bgp" {
+                bgp = true;
             }
         }
         for line in diff.lines() {
@@ -205,6 +216,10 @@ impl ConfigManager {
             if !isis && op == ConfigOp::Set && line.starts_with("router isis") {
                 isis = true;
                 spawn_isis(self);
+            }
+            if !bgp && op == ConfigOp::Set && line.starts_with("router bgp") {
+                bgp = true;
+                spawn_bgp(self);
             }
             // Handle logging configuration changes
             if op == ConfigOp::Set && line.starts_with("logging output") {
@@ -240,6 +255,26 @@ impl ConfigManager {
             tx.send(ConfigRequest::new(Vec::new(), ConfigOp::CommitEnd))
                 .unwrap();
         }
+
+        // Tear down protocol tasks whose `router <proto>` config has
+        // disappeared from the candidate. Top-level config lines have
+        // no leading whitespace, so a starts_with prefix scan is
+        // sufficient. `protocol_tasks` gates the check so we don't
+        // try to despawn a proto that was never running.
+        let proto_in_candidate = |proto: &str| {
+            let needle = format!("router {}", proto);
+            candidate.lines().any(|l| l.starts_with(&needle))
+        };
+        if self.protocol_tasks.borrow().contains_key("bgp") && !proto_in_candidate("bgp") {
+            despawn_bgp(self);
+        }
+        if self.protocol_tasks.borrow().contains_key("ospf") && !proto_in_candidate("ospf") {
+            despawn_ospf(self);
+        }
+        if self.protocol_tasks.borrow().contains_key("isis") && !proto_in_candidate("isis") {
+            despawn_isis(self);
+        }
+
         self.store.commit();
         Ok(())
     }

--- a/zebra-rs/src/config/mod.rs
+++ b/zebra-rs/src/config/mod.rs
@@ -29,6 +29,7 @@ pub use paths::path_from_command;
 mod api;
 pub use api::{ConfigChannel, ConfigOp, ConfigRequest, DisplayRequest, ShowChannel};
 
+mod bgp;
 mod commands;
 mod files;
 mod ip;

--- a/zebra-rs/src/config/ospf.rs
+++ b/zebra-rs/src/config/ospf.rs
@@ -1,5 +1,6 @@
 use crate::context::Context;
 use crate::ospf::inst;
+use crate::rib;
 
 use super::ConfigManager;
 
@@ -8,5 +9,18 @@ pub fn spawn_ospf(config: &ConfigManager) {
     let ospf = inst::Ospf::new(ctx, config.rib_tx.clone());
     config.subscribe("ospf", ospf.cm.tx.clone());
     config.subscribe_show("ospf", ospf.show.tx.clone());
-    inst::serve(ospf);
+    let task = inst::serve(ospf);
+    config
+        .protocol_tasks
+        .borrow_mut()
+        .insert("ospf".to_string(), task);
+}
+
+pub fn despawn_ospf(config: &ConfigManager) {
+    config.cm_clients.borrow_mut().remove("ospf");
+    config.show_clients.borrow_mut().remove("ospf");
+    config.protocol_tasks.borrow_mut().remove("ospf");
+    let _ = config.rib_tx.send(rib::Message::ProtoCleanup {
+        proto: "ospf".to_string(),
+    });
 }

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -14,7 +14,7 @@ use crate::rib::{
 };
 
 use crate::config::{DisplayRequest, ShowChannel};
-use crate::context::Timer;
+use crate::context::{Task, Timer};
 use crate::isis::tracing::IsisTracing;
 use crate::isis::{ifsm, lsdb};
 use crate::rib::api::RibRx;
@@ -793,10 +793,10 @@ impl Isis {
     }
 }
 
-pub fn serve(mut isis: Isis) {
-    tokio::spawn(async move {
+pub fn serve(mut isis: Isis) -> Task<()> {
+    Task::spawn(async move {
         isis.event_loop().await;
-    });
+    })
 }
 
 pub enum Message {

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -5,7 +5,6 @@ mod version;
 use config::{Cli, ConfigManager};
 use std::path::PathBuf;
 mod bgp;
-use bgp::Bgp;
 mod rib;
 use rib::{LogFormatType, LogOutputType, Rib, logging_config_from_args, tracing_set};
 mod policy;
@@ -164,12 +163,9 @@ async fn run() -> anyhow::Result<()> {
     }
     let yang_path = yang_path.unwrap();
 
-    let mut rib = Rib::new(arg.no_nhid, arg.enable_addr_recovery)?;
+    let rib = Rib::new(arg.no_nhid, arg.enable_addr_recovery)?;
 
     let policy = Policy::new();
-
-    let bgp = Bgp::new(rib.tx.clone(), policy.tx.clone());
-    rib.subscribe(bgp.redist.tx.clone(), "bgp".to_string());
 
     // Runtime-mutable YANG-defined service-accounts (D25). Shared
     // between ConfigManager (writes on commit) and SessionTable (reads
@@ -184,14 +180,13 @@ async fn run() -> anyhow::Result<()> {
         system_path(&arg),
         yang_path,
         rib.tx.clone(),
+        policy.tx.clone(),
         #[cfg(target_os = "linux")]
         yang_service_accounts.clone(),
     )?;
     config.subscribe("rib", rib.cm.tx.clone());
-    config.subscribe("bgp", bgp.cm.tx.clone());
     config.subscribe("policy", policy.cm.tx.clone());
     config.subscribe_show("rib", rib.show.tx.clone());
-    config.subscribe_show("bgp", bgp.show.tx.clone());
     config.subscribe_show("policy", policy.show.tx.clone());
 
     let cli = Cli::new(
@@ -204,8 +199,6 @@ async fn run() -> anyhow::Result<()> {
     config::serve(cli, vty_addr)?;
 
     policy::serve(policy);
-
-    bgp::serve(bgp);
 
     rib::serve(rib);
     // rib::nanomsg::serve();

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -22,7 +22,7 @@ use crate::rib::{self, Link, RibType};
 use crate::spf::label_block::LabelConfig;
 use crate::{
     config::{Args, ConfigChannel, ConfigRequest, path_from_command},
-    context::Context,
+    context::{Context, Task},
     rib::RibRxChannel,
 };
 
@@ -1248,10 +1248,10 @@ impl Ospf {
     }
 }
 
-pub fn serve(mut ospf: Ospf) {
-    tokio::spawn(async move {
+pub fn serve(mut ospf: Ospf) -> Task<()> {
+    Task::spawn(async move {
         ospf.event_loop().await;
-    });
+    })
 }
 
 pub enum Message {

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -78,57 +78,57 @@ pub enum RibRx {
 
 impl Rib {
     pub fn api_link_add(&self, link: &Link) {
-        for tx in self.redists.iter() {
+        for tx in self.redists.values() {
             let link = RibRx::LinkAdd(link.clone());
             let _ = tx.send(link);
         }
     }
 
     pub fn api_link_up(&self, ifindex: u32) {
-        for tx in self.redists.iter() {
+        for tx in self.redists.values() {
             let _ = tx.send(RibRx::LinkUp(ifindex));
         }
     }
 
     pub fn api_link_down(&self, ifindex: u32) {
-        for tx in self.redists.iter() {
+        for tx in self.redists.values() {
             let _ = tx.send(RibRx::LinkDown(ifindex));
         }
     }
 
     pub fn api_addr_add(&self, addr: &LinkAddr) {
-        for tx in self.redists.iter() {
+        for tx in self.redists.values() {
             let link = RibRx::AddrAdd(addr.clone());
             let _ = tx.send(link);
         }
     }
 
     pub fn api_router_id_update(&self, router_id: Ipv4Addr) {
-        for tx in self.redists.iter() {
+        for tx in self.redists.values() {
             let _ = tx.send(RibRx::RouterIdUpdate(router_id));
         }
     }
 
     pub fn api_fdb_add(&self, entry: &FdbEntry) {
-        for tx in self.redists.iter() {
+        for tx in self.redists.values() {
             let _ = tx.send(RibRx::FdbAdd(entry.clone()));
         }
     }
 
     pub fn api_fdb_del(&self, entry: &FdbEntry) {
-        for tx in self.redists.iter() {
+        for tx in self.redists.values() {
             let _ = tx.send(RibRx::FdbDel(entry.clone()));
         }
     }
 
     pub fn api_vxlan_add(&self, vni: u32, vtep_local: IpAddr) {
-        for tx in self.redists.iter() {
+        for tx in self.redists.values() {
             let _ = tx.send(RibRx::VxlanAdd { vni, vtep_local });
         }
     }
 
     pub fn api_vxlan_del(&self, vni: u32) {
-        for tx in self.redists.iter() {
+        for tx in self.redists.values() {
             let _ = tx.send(RibRx::VxlanDel { vni });
         }
     }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -179,6 +179,14 @@ pub enum Message {
         proto: String,
         tx: UnboundedSender<RibRx>,
     },
+    /// Tear down all RIB state owned by a protocol whose task is
+    /// being despawned (`no router bgp` / `no router isis` / `no
+    /// router ospf`). Withdraws every route / ILM whose `rtype`
+    /// matches, drops the redist sender, and clears SR watchers
+    /// registered under the proto name. Idempotent.
+    ProtoCleanup {
+        proto: String,
+    },
 }
 
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -244,7 +252,7 @@ pub struct Rib {
     pub show_cb: HashMap<String, ShowCallback>,
     pub fib: FibChannel,
     pub fib_handle: FibHandle,
-    pub redists: Vec<UnboundedSender<RibRx>>,
+    pub redists: HashMap<String, UnboundedSender<RibRx>>,
     pub links: BTreeMap<u32, Link>,
     pub bridges: BTreeMap<String, Bridge>,
     pub vxlan: BTreeMap<String, Vxlan>,
@@ -356,7 +364,7 @@ impl Rib {
             show_cb: HashMap::new(),
             fib,
             fib_handle,
-            redists: Vec::new(),
+            redists: HashMap::new(),
             links: BTreeMap::new(),
             bridges: BTreeMap::new(),
             vxlan: BTreeMap::new(),
@@ -759,7 +767,7 @@ impl Rib {
         }
     }
 
-    pub fn subscribe(&mut self, tx: UnboundedSender<RibRx>, _proto: String) {
+    pub fn subscribe(&mut self, tx: UnboundedSender<RibRx>, proto: String) {
         // Link dump.
         for (_, link) in self.links.iter() {
             let msg = RibRx::LinkAdd(link.clone());
@@ -802,12 +810,63 @@ impl Rib {
                 let _ = tx.send(RibRx::FdbAdd(entry));
             }
         }
-        self.redists.push(tx.clone());
+        self.redists.insert(proto, tx.clone());
         if !self.router_id.is_unspecified() {
             let msg = RibRx::RouterIdUpdate(self.router_id);
             tx.send(msg).unwrap();
         }
         tx.send(RibRx::EoR).unwrap();
+    }
+
+    async fn proto_cleanup(&mut self, proto: String) {
+        let rtype = match proto.as_str() {
+            "bgp" => RibType::Bgp,
+            "isis" => RibType::Isis,
+            "ospf" => RibType::Ospf,
+            _ => return,
+        };
+
+        let v4_prefixes: Vec<Ipv4Net> = self
+            .table
+            .iter()
+            .filter_map(|(prefix, entries)| {
+                entries.iter().any(|e| e.rtype == rtype).then_some(*prefix)
+            })
+            .collect();
+        for prefix in v4_prefixes {
+            self.ipv4_route_del(&prefix, RibEntry::new(rtype)).await;
+        }
+
+        let v6_prefixes: Vec<Ipv6Net> = self
+            .table_v6
+            .iter()
+            .filter_map(|(prefix, entries)| {
+                entries.iter().any(|e| e.rtype == rtype).then_some(*prefix)
+            })
+            .collect();
+        for prefix in v6_prefixes {
+            self.ipv6_route_del(&prefix, RibEntry::new(rtype)).await;
+        }
+
+        let labels: Vec<u32> = self
+            .ilm
+            .iter()
+            .filter_map(|(label, e)| (e.rtype == rtype).then_some(*label))
+            .collect();
+        for label in labels {
+            if let Some(ilm) = self.ilm.get(&label).cloned() {
+                self.ilm_del(label, ilm).await;
+            }
+        }
+
+        self.redists.remove(&proto);
+        self.sr_clients.remove(&proto);
+        for watchers in self.block_watch.values_mut() {
+            watchers.remove(&proto);
+        }
+        for watchers in self.locator_watch.values_mut() {
+            watchers.remove(&proto);
+        }
     }
 
     async fn process_msg(&mut self, msg: Message) {
@@ -1098,6 +1157,9 @@ impl Rib {
             }
             Message::Subscribe { tx, proto } => {
                 self.subscribe(tx, proto);
+            }
+            Message::ProtoCleanup { proto } => {
+                self.proto_cleanup(proto).await;
             }
             Message::MacAdd {
                 vni,

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -701,7 +701,7 @@ impl Rib {
 
             link_addr_del(link, addr.clone());
 
-            for tx in self.redists.iter() {
+            for tx in self.redists.values() {
                 let link = RibRx::AddrDel(addr.clone());
                 let _ = tx.send(link);
             }


### PR DESCRIPTION
## Summary
- BGP, IS-IS, and OSPF now follow a uniform lifecycle: each task is spawned by `commit_config` on the first `router <proto>` line and torn down when the candidate no longer contains it. BGP used to start unconditionally at boot (binding port 179 even without config); IS-IS and OSPF spawned lazily but had no teardown path.
- Each protocol's `serve()` now returns a `context::task::Task<()>`. `ConfigManager` owns those handles keyed by proto name; dropping a handle aborts the event loop.
- New `rib::Message::ProtoCleanup { proto }` withdraws all routes / ILMs whose `RibType` matches, removes the proto from `redists`, and clears any SR clients / watchers keyed by proto. `rib.redists` is now keyed by proto name so cleanup is targeted and a respawn replaces a dead sender in place.
- Dropped the vestigial `Bgp::redist` channel — its receiver was never consumed; the only writer was `main.rs`'s synchronous `rib.subscribe`, also removed.

## Test plan
- [x] `cargo check -p zebra-rs`
- [x] `cargo clippy -p zebra-rs --all-targets`
- [x] `cargo fmt -p zebra-rs --check`
- [x] `cargo test -p zebra-rs` (342 passed, 1 ignored)
- [ ] Manual smoke: empty config → `ss -tlnp \| grep ':179 '` empty; commit `router bgp <asn>` → port 179 bound; `no router bgp` → port 179 freed, `ip route show proto bgp` empty; repeat for `router ospf` / `router isis`.
- [ ] Manual smoke: respawn (`no router bgp` followed by `router bgp ...` in a later commit) reattaches cleanly.

Generated with [Claude Code](https://claude.com/claude-code)