### PR TITLE
bfd: add UDP/3784 receive scaffolding (PR 2 of 10)

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -49,6 +49,7 @@ ospf-packet = { path = "../crates/ospf-packet" }
 ospf-macros = { path = "../crates/ospf-macros" }
 isis-packet = { path = "../crates/isis-packet" }
 isis-macros = { path = "../crates/isis-macros" }
+bfd-packet = { path = "../crates/bfd-packet" }
 bitfield-struct = "0.13"
 rand = "0.10"
 chrono = { version = "0.4", features = ["serde"] }

--- a/zebra-rs/src/bfd/inst.rs
+++ b/zebra-rs/src/bfd/inst.rs
@@ -1,0 +1,81 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
+use std::sync::Arc;
+
+use tokio::io::unix::AsyncFd;
+use tokio::sync::mpsc::{self, UnboundedReceiver};
+
+use crate::context::{Context, Task};
+
+use super::network::read_packet;
+use super::socket::{BFD_SINGLE_HOP_PORT, bfd_socket_ipv4};
+
+/// Top-level BFD instance. PR 2 only stands up the IPv4 single-hop
+/// receive path: open the UDP/3784 socket, spawn the read task, and
+/// drain the resulting event stream with a debug log. The session
+/// table, FSM, timers, and outbound packet path arrive in PR 3.
+pub struct Bfd {
+    pub rx: UnboundedReceiver<Message>,
+}
+
+/// Event-loop messages. PR 3 adds Send / interface / config variants.
+#[derive(Debug)]
+pub enum Message {
+    /// A parsed, GTSM-validated control packet arrived.
+    Recv {
+        packet: bfd_packet::ControlPacket,
+        src: SocketAddrV4,
+        dst: Option<IpAddr>,
+        ifindex: u32,
+    },
+}
+
+impl Bfd {
+    /// Bind the IPv4 single-hop socket on `0.0.0.0:3784` and spawn the
+    /// receive task.
+    pub fn new(_ctx: Context) -> std::io::Result<Self> {
+        let sock = bfd_socket_ipv4(SocketAddrV4::new(
+            Ipv4Addr::UNSPECIFIED,
+            BFD_SINGLE_HOP_PORT,
+        ))?;
+        let sock = Arc::new(AsyncFd::new(sock)?);
+
+        let (tx, rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            read_packet(sock, tx).await;
+        });
+
+        Ok(Self { rx })
+    }
+
+    pub async fn event_loop(&mut self) {
+        while let Some(msg) = self.rx.recv().await {
+            match msg {
+                Message::Recv {
+                    packet,
+                    src,
+                    dst,
+                    ifindex,
+                } => {
+                    tracing::debug!(
+                        ?src,
+                        ?dst,
+                        ifindex,
+                        state = ?packet.state,
+                        my_disc = format_args!("{:#010x}", packet.my_disc),
+                        your_disc = format_args!("{:#010x}", packet.your_disc),
+                        "bfd: rx control packet",
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Spawn the event loop. Mirrors [`crate::ospf::serve`]. The returned
+/// [`Task`] handle owns the spawned future; dropping it aborts the
+/// loop (see [`crate::config::bfd::despawn_bfd`]).
+pub fn serve(mut bfd: Bfd) -> Task<()> {
+    Task::spawn(async move {
+        bfd.event_loop().await;
+    })
+}

--- a/zebra-rs/src/bfd/mod.rs
+++ b/zebra-rs/src/bfd/mod.rs
@@ -1,0 +1,3 @@
+pub mod inst;
+pub mod network;
+pub mod socket;

--- a/zebra-rs/src/bfd/network.rs
+++ b/zebra-rs/src/bfd/network.rs
@@ -1,0 +1,204 @@
+use std::io::{ErrorKind, IoSliceMut};
+use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
+use std::os::fd::AsRawFd;
+use std::sync::Arc;
+
+use nix::sys::socket::{self, ControlMessageOwned, SockaddrIn};
+use socket2::Socket;
+use tokio::io::Interest;
+use tokio::io::unix::AsyncFd;
+use tokio::sync::mpsc::UnboundedSender;
+
+use super::inst::Message;
+
+/// GTSM expected TTL for single-hop BFD (RFC 5881 §5).
+const GTSM_TTL: u8 = 255;
+
+/// Async receive loop. Pulls one BFD control packet at a time off
+/// `sock`, runs structural validation via
+/// [`bfd_packet::ControlPacket::parse`], drops packets that fail GTSM
+/// (TTL < 255) with a debug log, and forwards survivors to the event
+/// loop via `tx`.
+pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message>) {
+    let mut buf = [0u8; 1500];
+    let mut iov = [IoSliceMut::new(&mut buf)];
+    let mut cmsgspace = nix::cmsg_space!(libc::in_pktinfo, libc::c_int);
+
+    loop {
+        let _ = sock
+            .async_io(Interest::READABLE, |sock| {
+                let msg = socket::recvmsg::<SockaddrIn>(
+                    sock.as_raw_fd(),
+                    &mut iov,
+                    Some(&mut cmsgspace),
+                    socket::MsgFlags::empty(),
+                )?;
+
+                let Some(src) = msg.address else {
+                    return Err(ErrorKind::AddrNotAvailable.into());
+                };
+                let src = SocketAddrV4::new(src.ip(), src.port());
+
+                let mut dst: Option<Ipv4Addr> = None;
+                let mut ifindex: u32 = 0;
+                let mut ttl: u8 = 0;
+                for cmsg in msg.cmsgs()? {
+                    match cmsg {
+                        ControlMessageOwned::Ipv4PacketInfo(pi) => {
+                            dst = Some(Ipv4Addr::from(pi.ipi_addr.s_addr.to_be()));
+                            ifindex = pi.ipi_ifindex as u32;
+                        }
+                        ControlMessageOwned::Ipv4Ttl(v) => ttl = v.clamp(0, 255) as u8,
+                        _ => {}
+                    }
+                }
+
+                if ttl != GTSM_TTL {
+                    // RFC 5881 §5: single-hop control packets MUST arrive
+                    // with TTL=255. Misconfigured peer; debug-log only
+                    // so a chatty bad neighbour can't flood the logs.
+                    tracing::debug!(
+                        ?src,
+                        ?dst,
+                        ttl,
+                        ifindex,
+                        "bfd: GTSM violation, dropping packet",
+                    );
+                    return Ok(());
+                }
+
+                let Some(payload) = msg.iovs().next() else {
+                    return Err(ErrorKind::UnexpectedEof.into());
+                };
+
+                let packet = match bfd_packet::ControlPacket::parse(payload) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        tracing::debug!(?src, error = %e, "bfd: invalid control packet");
+                        return Ok(());
+                    }
+                };
+
+                let _ = tx.send(Message::Recv {
+                    packet,
+                    src,
+                    dst: dst.map(IpAddr::V4),
+                    ifindex,
+                });
+                Ok(())
+            })
+            .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bfd_packet::{ControlPacket, State};
+    use bytes::BytesMut;
+    use socket2::SockAddr;
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::bfd::socket::bfd_socket_ipv4;
+
+    fn loopback_recv_socket() -> (Arc<AsyncFd<Socket>>, u16) {
+        let sock = bfd_socket_ipv4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let port = sock.local_addr().unwrap().as_socket_ipv4().unwrap().port();
+        (Arc::new(AsyncFd::new(sock).unwrap()), port)
+    }
+
+    fn send_raw(buf: &[u8], dst_port: u16, ttl: u32) {
+        let sock = Socket::new(
+            socket2::Domain::IPV4,
+            socket2::Type::DGRAM,
+            Some(socket2::Protocol::UDP),
+        )
+        .unwrap();
+        sock.set_ttl_v4(ttl).unwrap();
+        sock.bind(&SockAddr::from(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)))
+            .unwrap();
+        let dst = SocketAddrV4::new(Ipv4Addr::LOCALHOST, dst_port);
+        sock.send_to(buf, &SockAddr::from(dst)).unwrap();
+    }
+
+    /// End-to-end loopback: bind an ephemeral receive socket, send a
+    /// hand-crafted Down-state packet with TTL=255, and verify the
+    /// recv path delivers a parsed [`Message::Recv`].
+    #[tokio::test]
+    async fn loopback_recv_one_packet() {
+        let (sock, port) = loopback_recv_socket();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let read_handle = tokio::spawn(async move { read_packet(sock, tx).await });
+
+        let packet = ControlPacket {
+            state: State::Down,
+            my_disc: 0x1234_5678,
+            ..ControlPacket::default()
+        };
+        let mut wire = BytesMut::new();
+        packet.emit(&mut wire);
+        send_raw(&wire, port, 255);
+
+        let got = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("recv timed out")
+            .expect("channel closed");
+
+        let Message::Recv {
+            packet: rx_packet, ..
+        } = got;
+        assert_eq!(rx_packet, packet);
+
+        read_handle.abort();
+    }
+
+    /// Packets with TTL < 255 are dropped per the GTSM rule in
+    /// RFC 5881 §5. No event reaches the channel.
+    #[tokio::test]
+    async fn gtsm_drops_low_ttl() {
+        let (sock, port) = loopback_recv_socket();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let read_handle = tokio::spawn(async move { read_packet(sock, tx).await });
+
+        let packet = ControlPacket {
+            state: State::Down,
+            my_disc: 0xdead_beef,
+            ..ControlPacket::default()
+        };
+        let mut wire = BytesMut::new();
+        packet.emit(&mut wire);
+        send_raw(&wire, port, 1);
+
+        let timed = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
+        assert!(
+            timed.is_err(),
+            "GTSM should have dropped the TTL=1 packet, got: {:?}",
+            timed.ok()
+        );
+
+        read_handle.abort();
+    }
+
+    /// A malformed packet (zero discriminator) is dropped by parse
+    /// validation; no event reaches the channel.
+    #[tokio::test]
+    async fn parse_error_dropped() {
+        let (sock, port) = loopback_recv_socket();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let read_handle = tokio::spawn(async move { read_packet(sock, tx).await });
+
+        // A 24-byte buffer with version=1 but zero My Discriminator —
+        // ControlPacket::parse rejects it (ZeroMyDisc).
+        let mut wire = [0u8; 24];
+        wire[0] = 0x20; // version=1
+        wire[2] = 3; // detect mult
+        wire[3] = 24; // length
+        // my_disc bytes 4..8 left zero on purpose.
+        send_raw(&wire, port, 255);
+
+        let timed = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
+        assert!(timed.is_err(), "malformed packet must be dropped");
+
+        read_handle.abort();
+    }
+}

--- a/zebra-rs/src/bfd/socket.rs
+++ b/zebra-rs/src/bfd/socket.rs
@@ -1,0 +1,67 @@
+use std::net::SocketAddrV4;
+use std::os::fd::AsRawFd;
+use std::os::raw::c_int;
+
+use socket2::{Domain, Protocol, Socket, Type};
+
+/// IANA-assigned UDP port for BFD single-hop control packets (RFC 5881 §4).
+pub const BFD_SINGLE_HOP_PORT: u16 = 3784;
+
+/// Build an IPv4 UDP socket suitable for sending and receiving BFD
+/// single-hop control packets.
+///
+/// The socket is configured to:
+///   * send with IP TTL = 255 (RFC 5881 §5, GTSM on egress);
+///   * report the received TTL via `IP_RECVTTL` ancillary data so the
+///     receive path can enforce GTSM on ingress;
+///   * report the destination address and ingress ifindex via
+///     `IP_PKTINFO` so multi-address hosts can demultiplex sessions.
+///
+/// `bind` controls the local socket address. Production callers pass
+/// `(0.0.0.0, BFD_SINGLE_HOP_PORT)`; tests can pass an ephemeral port.
+pub fn bfd_socket_ipv4(bind: SocketAddrV4) -> std::io::Result<Socket> {
+    let socket = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))?;
+
+    socket.set_nonblocking(true)?;
+    socket.set_reuse_address(true)?;
+    socket.set_ttl_v4(255)?; // GTSM: every outgoing packet leaves with TTL=255
+    set_ipv4_recvttl(&socket)?;
+    set_ipv4_pktinfo(&socket)?;
+
+    socket.bind(&bind.into())?;
+    Ok(socket)
+}
+
+fn set_ipv4_recvttl(socket: &Socket) -> std::io::Result<()> {
+    let on: c_int = 1;
+    let rc = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IP,
+            libc::IP_RECVTTL,
+            &on as *const _ as *const libc::c_void,
+            std::mem::size_of::<c_int>() as libc::socklen_t,
+        )
+    };
+    if rc < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn set_ipv4_pktinfo(socket: &Socket) -> std::io::Result<()> {
+    let on: c_int = 1;
+    let rc = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IP,
+            libc::IP_PKTINFO,
+            &on as *const _ as *const libc::c_void,
+            std::mem::size_of::<c_int>() as libc::socklen_t,
+        )
+    };
+    if rc < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}

--- a/zebra-rs/src/config/bfd.rs
+++ b/zebra-rs/src/config/bfd.rs
@@ -1,0 +1,39 @@
+use crate::bfd::inst;
+use crate::context::Context;
+use crate::rib;
+
+use super::ConfigManager;
+
+/// Spawn the BFD instance the first time `bfd` configuration appears.
+/// Mirrors [`super::ospf::spawn_ospf`] / [`super::isis::spawn_isis`] /
+/// [`super::bgp::spawn_bgp`].
+///
+/// The YANG schema and config-callback wiring land in PR 4; until
+/// then this function is reachable from manager.rs but never actually
+/// invoked at runtime (no YANG → no `bfd` config lines reach the
+/// candidate).
+pub fn spawn_bfd(config: &ConfigManager) {
+    match inst::Bfd::new(Context::default()) {
+        Ok(bfd) => {
+            let task = inst::serve(bfd);
+            config
+                .protocol_tasks
+                .borrow_mut()
+                .insert("bfd".to_string(), task);
+        }
+        Err(e) => tracing::warn!("bfd: failed to start instance: {e}"),
+    }
+}
+
+/// Tear down the BFD instance when its top-level `bfd` block has been
+/// removed from the candidate config. Dropping the [`Task`] aborts
+/// the event loop; [`rib::Message::ProtoCleanup`] withdraws any
+/// future BFD-installed routes.
+pub fn despawn_bfd(config: &ConfigManager) {
+    config.cm_clients.borrow_mut().remove("bfd");
+    config.show_clients.borrow_mut().remove("bfd");
+    config.protocol_tasks.borrow_mut().remove("bfd");
+    let _ = config.rib_tx.send(rib::Message::ProtoCleanup {
+        proto: "bfd".to_string(),
+    });
+}

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1,6 +1,7 @@
 use crate::config::api::{ClearTxResponse, DeployResponse, DisplayTxResponse};
 
 use super::api::{CompletionResponse, ConfigOp, ExecuteResponse, Message};
+use super::bfd::{despawn_bfd, spawn_bfd};
 use super::bgp::{despawn_bgp, spawn_bgp};
 use super::commands::Mode;
 use super::commands::{configure_mode_create, exec_mode_create};
@@ -184,6 +185,7 @@ impl ConfigManager {
         let mut ospf = false;
         let mut isis = false;
         let mut bgp = false;
+        let mut bfd = false;
         for (proto, tx) in self.cm_clients.borrow().iter() {
             tx.send(ConfigRequest::new(Vec::new(), ConfigOp::CommitStart))
                 .unwrap();
@@ -195,6 +197,9 @@ impl ConfigManager {
             }
             if proto == "bgp" {
                 bgp = true;
+            }
+            if proto == "bfd" {
+                bfd = true;
             }
         }
         for line in diff.lines() {
@@ -220,6 +225,10 @@ impl ConfigManager {
             if !bgp && op == ConfigOp::Set && line.starts_with("router bgp") {
                 bgp = true;
                 spawn_bgp(self);
+            }
+            if !bfd && op == ConfigOp::Set && line.starts_with("bfd") {
+                bfd = true;
+                spawn_bfd(self);
             }
             // Handle logging configuration changes
             if op == ConfigOp::Set && line.starts_with("logging output") {
@@ -273,6 +282,13 @@ impl ConfigManager {
         }
         if self.protocol_tasks.borrow().contains_key("isis") && !proto_in_candidate("isis") {
             despawn_isis(self);
+        }
+        // BFD's top-level keyword is `bfd` (FRR-style), not
+        // `router <proto>`, so it can't use `proto_in_candidate`.
+        if self.protocol_tasks.borrow().contains_key("bfd")
+            && !candidate.lines().any(|l| l.starts_with("bfd"))
+        {
+            despawn_bfd(self);
         }
 
         self.store.commit();

--- a/zebra-rs/src/config/mod.rs
+++ b/zebra-rs/src/config/mod.rs
@@ -29,6 +29,7 @@ pub use paths::path_from_command;
 mod api;
 pub use api::{ConfigChannel, ConfigOp, ConfigRequest, DisplayRequest, ShowChannel};
 
+mod bfd;
 mod bgp;
 mod commands;
 mod files;

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -9,6 +9,7 @@ mod rib;
 use rib::{LogFormatType, LogOutputType, Rib, logging_config_from_args, tracing_set};
 mod policy;
 use policy::Policy;
+mod bfd;
 mod context;
 mod fib;
 mod isis;


### PR DESCRIPTION
## Summary

Second PR in the BFD (RFC 5880) feature series. Stands up the IPv4
single-hop receive path end-to-end and wires it into the daemon's
spawn-on-config pattern. Sessions, FSM, outbound packets, config,
and show all remain deferred.

- **`src/bfd/socket.rs`** builds the UDP socket configured for GTSM:
  `IP_TTL=255` on egress (RFC 5881 §5), `IP_RECVTTL` + `IP_PKTINFO`
  on ingress so the recv path can enforce TTL=255 and surface the
  destination address / ifindex.
- **`src/bfd/network.rs`** runs the async recv loop using
  `nix::sys::socket::recvmsg` (mirroring the OSPF pattern). GTSM
  violations are silently dropped at debug level — a chatty
  misconfigured peer cannot flood the logs. Structural validation is
  delegated to `bfd_packet::ControlPacket::parse` from PR 1.
- **`src/bfd/inst.rs`** keeps the `Bfd` struct minimal for this PR
  (`{ rx }` only — debug-log stub event loop). The struct will grow
  the outbound channel, config / show channels, and RIB subscription
  in PR 3 when the FSM and outbound path arrive.
- **`src/config/bfd.rs`** adds a `spawn_bfd` shim mirroring
  `spawn_ospf` / `spawn_isis`. Wired from `config/manager.rs` on the
  first `bfd` config line; never reached at runtime until the YANG
  schema lands in PR 4 — its purpose right now is to keep the binary
  call chain alive at compile time so dead-code lints stay clean
  without `#[allow]` shims.

## Test plan

- [x] `cargo test -p zebra-rs --bin zebra-rs -- bfd::` — 3 new
  `#[tokio::test]`s green:
  - `loopback_recv_one_packet` (TX at TTL=255 → parsed Recv matches)
  - `gtsm_drops_low_ttl` (TX at TTL=1 via side socket → no Recv)
  - `parse_error_dropped` (zero My Discriminator → silent drop)
- [x] `cargo test -p bfd-packet` — 20 codec tests from PR 1 still pass
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

Generated with [Claude Code](https://claude.com/claude-code)