### PR TITLE
isis: add min-lsp-arrival-time receive-side rate limit

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -59,6 +59,10 @@ impl Isis {
             "/router/isis/timers/lsp-refresh-interval",
             config_lsp_refresh_interval,
         );
+        self.callback_add(
+            "/router/isis/timers/min-lsp-arrival-time",
+            config_min_lsp_arrival_time,
+        );
         self.callback_add("/router/isis/te-router-id", config_te_router_id);
         self.callback_add("/router/isis/segment-routing/mpls", config_sr_mpls_enable);
         self.callback_add(
@@ -145,6 +149,7 @@ pub struct IsisConfig {
     pub is_type: Option<IsLevel>,
     pub refresh_time: Option<u16>,
     pub hold_time: Option<u16>,
+    pub min_lsp_arrival_time: Option<u32>,
     pub te_router_id: Option<Ipv4Addr>,
     pub rib_router_id: Option<Ipv4Addr>,
     pub enable: Afis<usize>,
@@ -201,6 +206,9 @@ pub struct IsisConfig {
 impl IsisConfig {
     const DEFAULT_REFRESH_TIME: u16 = 15 * 60;
     const DEFAULT_HOLD_TIME: u16 = 1200;
+    // RFC 4444 §3.1 storm-protection floor for accepting new LSP versions.
+    // 100 ms matches IOS-XR's default.
+    const DEFAULT_MIN_LSP_ARRIVAL_TIME_MS: u32 = 100;
 
     pub fn is_type(&self) -> IsLevel {
         self.is_type.unwrap_or(IsLevel::L1L2)
@@ -226,6 +234,11 @@ impl IsisConfig {
 
     pub fn hold_time(&self) -> u16 {
         self.hold_time.unwrap_or(Self::DEFAULT_HOLD_TIME)
+    }
+
+    pub fn min_lsp_arrival_time(&self) -> u32 {
+        self.min_lsp_arrival_time
+            .unwrap_or(Self::DEFAULT_MIN_LSP_ARRIVAL_TIME_MS)
     }
 
     /// True when either SR dataplane is enabled. Used to gate emission
@@ -314,6 +327,17 @@ fn config_lsp_refresh_interval(isis: &mut Isis, mut args: Args, op: ConfigOp) ->
         isis.config.refresh_time = Some(refresh_time);
     } else {
         isis.config.refresh_time = None;
+    }
+    Some(())
+}
+
+fn config_min_lsp_arrival_time(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let ms = args.u32()?;
+
+    if op == ConfigOp::Set {
+        isis.config.min_lsp_arrival_time = Some(ms);
+    } else {
+        isis.config.min_lsp_arrival_time = None;
     }
     Some(())
 }

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::collections::btree_map::{Iter, Values};
+use std::time::{Duration, Instant};
 
 use isis_packet::*;
 
@@ -40,6 +41,10 @@ pub struct Lsa {
     pub refresh_timer: Option<Timer>,
     pub ifindex: u32,
     pub bytes: Vec<u8>,
+    // When this entry was inserted via the receive path. None for
+    // self-originated LSPs and as the pre-fill on fresh entries.
+    // Used by `insert_lsp` to enforce min-lsp-arrival-time.
+    pub last_received: Option<Instant>,
 }
 
 impl Lsa {
@@ -51,6 +56,7 @@ impl Lsa {
             refresh_timer: None,
             ifindex: 0,
             bytes: vec![],
+            last_received: None,
         }
     }
 }
@@ -317,17 +323,32 @@ pub fn insert_lsp(top: &mut LinkTop, level: Level, lsp: IsisLsp, bytes: Vec<u8>)
         return None;
     }
 
-    // Check sequence number.
-    if let Some(lsa) = top.lsdb.get(&level).get(&lsp.lsp_id)
-        && lsp.seq_number <= lsa.lsp.seq_number
-    {
-        isis_database_trace!(
-            top.tracing,
-            Lsdb,
-            &level,
-            "Same or smaller seq_number, no need of updating LSDB"
-        );
-        return None;
+    // Sequence-number and min-lsp-arrival-time gating against the
+    // existing entry. RFC 4444 §3.1: storm-protect by ignoring new
+    // versions that arrive within the arrival window after the last
+    // accepted version of the same LSP.
+    if let Some(lsa) = top.lsdb.get(&level).get(&lsp.lsp_id) {
+        if lsp.seq_number <= lsa.lsp.seq_number {
+            isis_database_trace!(
+                top.tracing,
+                Lsdb,
+                &level,
+                "Same or smaller seq_number, no need of updating LSDB"
+            );
+            return None;
+        }
+        let window = Duration::from_millis(top.up_config.min_lsp_arrival_time() as u64);
+        if let Some(last) = lsa.last_received
+            && last.elapsed() < window
+        {
+            isis_database_trace!(
+                top.tracing,
+                Lsdb,
+                &level,
+                "Within min-lsp-arrival-time window, dropping"
+            );
+            return None;
+        }
     }
 
     if key.is_pseudo() {
@@ -342,6 +363,7 @@ pub fn insert_lsp(top: &mut LinkTop, level: Level, lsp: IsisLsp, bytes: Vec<u8>)
     lsa.ifindex = top.ifindex;
     lsa.bytes = bytes;
     lsa.hold_timer = Some(hold_timer(top.tx, level, key, hold_time));
+    lsa.last_received = Some(Instant::now());
 
     top.lsdb.get_mut(&level).map.insert(key, lsa)
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -453,6 +453,12 @@ module config {
             }
             units "seconds";
           }
+          leaf min-lsp-arrival-time {
+            type uint32 {
+              range "1..600000";
+            }
+            units "milliseconds";
+          }
         }
 
         list interface {


### PR DESCRIPTION
## Summary

RFC 4444 §3.1 storm-protection for the LSDB. When a new version of an LSP we already have arrives within a configurable window after the last accepted version, drop the new one. Without this, a misbehaving neighbor (or a flapping path) can drive arbitrarily fast LSDB churn and SPF reschedules.

Adds:
- **YANG** `/router/isis/timers/min-lsp-arrival-time` (uint32 ms, range 1..600000)
- **`IsisConfig::min_lsp_arrival_time`** + getter, `DEFAULT_MIN_LSP_ARRIVAL_TIME_MS = 100` (matches IOS-XR default)
- **`Lsa::last_received: Option<Instant>`** — None for self-originated and fresh entries (both cases skip the window check)

`insert_lsp` now collapses the seq-number guard and the arrival-window guard into one borrow of the existing LSDB entry, then sets `last_received = Some(Instant::now())` on the inserted Lsa.

## Behavior matrix

| Case | Action |
|---|---|
| First time we see an LSP ID | Accept |
| Higher seq, outside window | Accept, refresh timestamp |
| Higher seq, inside window | **NEW**: drop with database trace |
| Same or smaller seq | Drop (unchanged) |
| Self-originated (`insert_self_originate` path) | Unchanged (no last_received) |

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo clippy -p zebra-rs --all-targets` clean
- [x] `cargo fmt -p zebra-rs --check` clean
- [ ] Smoke test: configure `set router isis timers min-lsp-arrival-time 500`, then on a peer flap a route fast enough to bump LSP seq twice within 500 ms; verify only the first update lands in our LSDB and the second is dropped with the trace message

Generated with [Claude Code](https://claude.com/claude-code)