### PR TITLE
isis: implement self-LSP seq-number wrap-up (ISO 10589 §7.3.16.4)

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -122,6 +122,16 @@ pub struct Isis {
     /// Reset whenever the watched locator changes so stale function
     /// reservations don't leak across prefix swaps.
     pub elib: super::srv6::ElibPool,
+
+    /// Per-level seq-number-wrap wait. Armed when `lsp_generate`
+    /// would have emitted a self-LSP with seq == 0xFFFFFFFF: we
+    /// instead push a purge (RemainingLifetime = 0) and freeze
+    /// self-LSP origination until this timer fires, then re-originate
+    /// with seq = 1. Wait length = `config.hold_time() + 60s` —
+    /// long enough that any peer's surviving copy of our old LSP has
+    /// aged out so they accept the seq = 1 origination as newer.
+    /// See ISO 10589 §7.3.16.4.
+    pub lsp_seq_wrap_wait: Levels<Option<Timer>>,
 }
 
 pub struct IsisTop<'a> {
@@ -154,6 +164,11 @@ pub struct IsisTop<'a> {
     pub sr_block: &'a Option<Block>,
     pub sr_locator: &'a Option<Locator>,
     pub sr_end_sid: &'a Option<std::net::Ipv6Addr>,
+
+    /// Seq-wrap wait timer (see `Isis::lsp_seq_wrap_wait`). Threaded
+    /// through so `lsp_generate` can short-circuit and arm the timer
+    /// without round-tripping through the event loop.
+    pub lsp_seq_wrap_wait: &'a mut Levels<Option<Timer>>,
 }
 
 impl Isis {
@@ -217,6 +232,7 @@ impl Isis {
             sr_locator: None,
             sr_end_sid: None,
             elib: super::srv6::ElibPool::new(),
+            lsp_seq_wrap_wait: Levels::<Option<Timer>>::default(),
         };
         isis.callback_build();
         isis.show_build();
@@ -411,6 +427,9 @@ impl Isis {
                     *link.timer.csnp.get_mut(&level) = Some(csnp_timer(&link, level));
                 }
             }
+            Message::LspSeqWrapClear(level) => {
+                self.process_lsp_seq_wrap_clear(level);
+            }
         }
     }
 
@@ -419,22 +438,28 @@ impl Isis {
             return;
         }
         let mut top = self.top();
-        let mut lsp = lsp_generate(&mut top, level, seq_floor);
-        // tracing::info!("[LSP:Gen] {}", lsp.lsp_id);
+        // lsp_generate returns None when origination is suppressed
+        // (seq-wrap freeze active). Skip emit + insert in that case
+        // — the freeze timer will trigger a fresh origination later.
+        let Some(mut lsp) = lsp_generate(&mut top, level, seq_floor) else {
+            return;
+        };
         let buf = lsp_emit(&mut lsp, level);
         let lsp_id = lsp.lsp_id;
         insert_self_originate(&mut top, level, lsp, Some(buf.to_vec()));
 
         top.lsdb.get_mut(&level).srm_set_all(top.tx, level, &lsp_id);
-        // lsp_flood(&mut top, level, &lsp_id);
     }
 
     fn process_lsp_purge(&mut self, level: Level, lsp_id: IsisLspId) {
         let mut top = self.top();
 
-        // Get current LSP if it exists
+        // Get current LSP if it exists. `saturating_add` so the
+        // seq-number-wrap purge path (existing = u32::MAX - 1) emits
+        // a final LSP at u32::MAX without panicking; the freeze
+        // installed by lsp_generate then prevents a follow-on bump.
         let seq_number = if let Some(existing) = top.lsdb.get(&level).get(&lsp_id) {
-            existing.lsp.seq_number + 1
+            existing.lsp.seq_number.saturating_add(1)
         } else {
             isis_event_trace!(
                 self.tracing,
@@ -461,6 +486,25 @@ impl Isis {
 
         top.lsdb.get_mut(&level).srm_set_all(top.tx, level, &lsp_id);
         // lsp_flood(&mut top, level, &lsp_id);
+    }
+
+    /// ISO 10589 §7.3.16.4 wait expired: drop the per-level freeze,
+    /// drop the purged self-LSP record from the local LSDB so the
+    /// next `lsp_generate` sees no existing entry and computes
+    /// seq = 1, then kick LSP origination.
+    fn process_lsp_seq_wrap_clear(&mut self, level: Level) {
+        isis_event_trace!(
+            self.tracing,
+            LspOriginate,
+            &level,
+            "[LspSeqWrap] MaxAge wait expired — clearing freeze and re-originating from seq 1"
+        );
+        *self.lsp_seq_wrap_wait.get_mut(&level) = None;
+
+        let lsp_id = IsisLspId::new(self.config.net.sys_id(), 0, 0);
+        self.lsdb.get_mut(&level).remove(&lsp_id);
+
+        let _ = self.tx.send(Message::LspOriginate(level, None));
     }
 
     fn process_dis_originate(
@@ -605,6 +649,7 @@ impl Isis {
             sr_block: &self.sr_block,
             sr_locator: &self.sr_locator,
             sr_end_sid: &self.sr_end_sid,
+            lsp_seq_wrap_wait: &mut self.lsp_seq_wrap_wait,
         }
     }
 
@@ -824,6 +869,11 @@ pub enum Message {
     DisOriginate(Level, IsisNeighborId, Option<u32>),
     SpfCalc(Level),
     AdjacencyUp(Level, u32),
+    /// MaxAge wait expired after a seq-number-wrap purge (ISO 10589
+    /// §7.3.16.4). Clears the per-level freeze and re-originates the
+    /// self LSP, which will compute seq = 1 (no existing entry in
+    /// LSDB once the purge has been removed).
+    LspSeqWrapClear(Level),
 }
 
 impl Display for Message {
@@ -857,6 +907,9 @@ impl Display for Message {
             Message::SpfCalc(level) => write!(f, "[Message::SpfCalc({})]", level),
             Message::AdjacencyUp(level, ifindex) => {
                 write!(f, "[Message::AdjacencyUp({}:{})]", level, ifindex)
+            }
+            Message::LspSeqWrapClear(level) => {
+                write!(f, "[Message::LspSeqWrapClear({})]", level)
             }
         }
     }

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -5,9 +5,15 @@ use isis_packet::neigh::{self, IsisSubAdjSid};
 use isis_packet::prefix::{self, Ipv4ControlInfo, Ipv6ControlInfo};
 use isis_packet::*;
 
+use crate::context::Timer;
 use crate::isis_event_trace;
 use crate::rib::util::IpNetExt;
 use crate::rib::{DEFAULT_BLOCK_NAME, LocatorBehavior, MacAddr};
+
+/// Per ISO 10589 §7.3.16.4, the additional grace beyond MaxAge a
+/// purged LSP needs before any surviving copy is fully evicted from
+/// every LSDB. Cisco treats this as a non-configurable constant.
+const ZERO_AGE_LIFETIME: u16 = 60;
 
 use super::config::{IsisConfig, MtId};
 use super::ifsm::has_level;
@@ -135,19 +141,39 @@ pub fn dis_generate(
     Some(lsp)
 }
 
-pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> IsisLsp {
+pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> Option<IsisLsp> {
     // LSP ID with no pseudo id and no fragmentation.
     let lsp_id = IsisLspId::new(top.config.net.sys_id(), 0, 0);
+
+    // ISO 10589 §7.3.16.4: when the previous origination's seq hit
+    // 0xFFFFFFFF we sent a purge and armed a freeze. Until that
+    // expires we must not emit a fresh self-LSP — origination is
+    // suppressed entirely (Cisco-style pragmatic interpretation of
+    // "IS-IS process disabled").
+    if top.lsp_seq_wrap_wait.get(&level).is_some() {
+        isis_event_trace!(
+            top.tracing,
+            LspOriginate,
+            &level,
+            "[LspOriginate] suppressed — seq-wrap freeze in effect"
+        );
+        return None;
+    }
 
     // ISO 10589 §7.3.16.4: when a peer floods our own LSP back at us
     // with `recv_seq > existing_seq`, we have to bump the next
     // emission past `recv_seq` so the network converges on our
     // authoritative copy. `seq_floor` carries that signal.
+    //
+    // `saturating_add` guards every arm — the wrap-detection branch
+    // below sees u32::MAX whether we got there from existing == MAX
+    // (post-purge LSDB entry) or from existing == MAX - 1 (first
+    // bump that trips the boundary).
     let existing = top.lsdb.get(&level).get(&lsp_id).map(|x| x.lsp.seq_number);
     let seq_number = match (existing, seq_floor) {
-        (Some(e), Some(f)) => e.max(f) + 1,
-        (Some(e), None) => e + 1,
-        (None, Some(f)) => f + 1,
+        (Some(e), Some(f)) => e.max(f).saturating_add(1),
+        (Some(e), None) => e.saturating_add(1),
+        (None, Some(f)) => f.saturating_add(1),
         (None, None) => 0x0001,
     };
 
@@ -160,19 +186,33 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
         seq_number
     );
 
-    // ISO 10589 Section 7.3.16.4: Sequence number wrap-around handling.
-    // When sequence number reaches maximum (0xFFFFFFFF), we must purge the LSP
-    // and wait for it to age out before originating a new one with seq 1.
+    // ISO 10589 §7.3.16.4: sequence-number wrap-up.
+    //
+    // Emit one final LSP at seq = 0xFFFFFFFF with RemainingLifetime
+    // = 0 (the purge), then freeze origination for
+    // `lsp_hold_time + ZeroAgeLifetime` so any surviving copy in any
+    // peer's LSDB has fully aged out. When the freeze clears, the
+    // LSDB entry is dropped and the next origination computes
+    // seq = 1 from scratch.
     if seq_number == u32::MAX {
         isis_event_trace!(
             top.tracing,
             LspOriginate,
             &level,
-            "[LspOriginate] seq number reached maximum, purging LSP"
+            "[LspSeqWrap] hit u32::MAX — purging and freezing origination"
         );
-        // TODO: After age out, we need to originate a new one with seq 1.
         let _ = top.tx.send(Message::LspPurge(level, lsp_id));
-        return IsisLsp::default();
+
+        let wait_secs = top.config.hold_time().saturating_add(ZERO_AGE_LIFETIME);
+        let tx = top.tx.clone();
+        let timer = Timer::once(wait_secs as u64, move || {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send(Message::LspSeqWrapClear(level));
+            }
+        });
+        *top.lsp_seq_wrap_wait.get_mut(&level) = Some(timer);
+        return None;
     }
 
     // Generate self originated LSP.
@@ -650,7 +690,7 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
             lsp.tlvs.push(ipv6_reach.into());
         }
     }
-    lsp
+    Some(lsp)
 }
 
 pub fn lsp_emit(lsp: &mut IsisLsp, level: Level) -> BytesMut {


### PR DESCRIPTION
## Summary

Pragmatic Cisco-style implementation of the LSP seq-number wrap procedure from ISO 10589 §7.3.16.4. The old code was a stub: it sent \`LspPurge\` and then returned \`Default::default()\`, which the caller dutifully emitted as a seq=0 LSP — exactly the wrong thing.

### What changes

When \`lsp_generate\` would compute seq = \`0xFFFFFFFF\`:

1. Emit one final LSP at seq = \`u32::MAX\` with \`RemainingLifetime=0\` (the purge) via the existing \`Message::LspPurge\` path.
2. Arm a per-level freeze timer for \`hold_time + ZeroAgeLifetime\` (60s). With default \`hold_time=30s\` that freezes for 90s; if the operator sets \`hold_time=1200\` it becomes 1260s — matching the strict spec naturally.
3. While the freeze is active, \`lsp_generate\` returns \`None\` and \`process_lsp_originate\` skips emit + insert. Adjacencies, hellos, LSDB processing all continue — only self-LSP origination is suspended. (\"IS-IS process disabled\" interpreted as \"self-LSP origination suspended,\" not full protocol shutdown — see decision log below.)
4. When the freeze fires (\`Message::LspSeqWrapClear\`), the timer is dropped, the purged self-LSP is removed from the local LSDB, and \`Message::LspOriginate\` is sent. With no existing entry, \`lsp_generate\` computes \`seq = 1\` from scratch.

### Bug fix bundled in

\`process_lsp_purge\` previously did \`existing.seq + 1\` which overflows if called with \`existing.seq == u32::MAX\` (the wrap path leaves exactly that state in the LSDB). Replaced with \`saturating_add(1)\`; same fix applied to the seq computation arms in \`lsp_generate\` so a stale post-restart \`u32::MAX\` entry can't crash the daemon.

### Wait-time rationale

ISO 10589 §7.3.16.4 calls for \`MaxAge + ZeroAgeLifetime\` (~1260s in the spec). For zebra-rs the right value is \`config.hold_time() + 60s\` because \`hold_time\` is what our LSPs actually carry in \`RemainingLifetime\` — there's no point waiting longer than the longest copy of our own LSP could survive in any peer's LSDB. The 60s tail is non-negotiable: if any peer still has our old \`seq=u32::MAX\` copy when we re-originate at \`seq=1\`, §7.3.16 says higher seq is newer, so they'd flood their old copy back at us and we'd loop.

### Design decision: pragmatic vs strict

The strict spec wording is \"IS-IS process disabled\" — full protocol shutdown for the wait, then restart. The pragmatic interpretation (this PR) freezes self-LSP origination only. Reference: FRRouting (master) skips the whole procedure entirely — they let seq wrap to 0 and just log a counter. We chose mid-strict because the prior stub was already wrong and a clean fix is small.

## Test plan

- [x] \`cargo build --bin zebra-rs\` — clean
- [x] \`cargo clippy --bin zebra-rs -- -D warnings\` — clean
- [x] \`cargo test --bin zebra-rs\` — 342 passed, 0 failed
- [x] \`cargo fmt --all\` — clean
- [ ] Live wrap-event test not feasible in CI (would need ~4 billion forced re-originations). Path can be exercised by temporarily lowering the wrap threshold in a debug build if we want to add an integration test later.

Generated with [Claude Code](https://claude.com/claude-code)