### PR TITLE
isis: add spf-interval exponential-backoff throttle

### DIFF
--- a/zebra-rs/src/context/task.rs
+++ b/zebra-rs/src/context/task.rs
@@ -47,17 +47,21 @@ pub enum TimerType {
 }
 
 impl Timer {
-    pub fn new<F, Fut>(sec: u64, typ: TimerType, mut cb: F) -> Timer
+    pub fn new<F, Fut>(sec: u64, typ: TimerType, cb: F) -> Timer
     where
         F: FnMut() -> Fut + Send + 'static,
         Fut: Future<Output = ()> + Send,
     {
         // Make it sure sec is not zero.
         let sec = if sec == 0 { 1 } else { sec };
+        Self::new_dur(Duration::new(sec, 0), typ, cb)
+    }
 
-        // println!("Timer create: duration {}", sec);
-        let duration = Duration::new(sec, 0);
-
+    pub fn new_dur<F, Fut>(duration: Duration, typ: TimerType, mut cb: F) -> Timer
+    where
+        F: FnMut() -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send,
+    {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let last_reset = Arc::new(Mutex::new(Instant::now()));
 
@@ -107,6 +111,14 @@ impl Timer {
         Fut: Future<Output = ()> + Send,
     {
         Self::new(sec, TimerType::Once, cb)
+    }
+
+    pub fn once_ms<F, Fut>(ms: u64, cb: F) -> Timer
+    where
+        F: FnMut() -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send,
+    {
+        Self::new_dur(Duration::from_millis(ms.max(1)), TimerType::Once, cb)
     }
 
     pub fn repeat<F, Fut>(sec: u64, cb: F) -> Timer

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -63,6 +63,18 @@ impl Isis {
             "/router/isis/timers/min-lsp-arrival-time",
             config_min_lsp_arrival_time,
         );
+        self.callback_add(
+            "/router/isis/spf-interval/initial-wait",
+            config_spf_initial_wait,
+        );
+        self.callback_add(
+            "/router/isis/spf-interval/secondary-wait",
+            config_spf_secondary_wait,
+        );
+        self.callback_add(
+            "/router/isis/spf-interval/maximum-wait",
+            config_spf_maximum_wait,
+        );
         self.callback_add("/router/isis/te-router-id", config_te_router_id);
         self.callback_add("/router/isis/segment-routing/mpls", config_sr_mpls_enable);
         self.callback_add(
@@ -150,6 +162,9 @@ pub struct IsisConfig {
     pub refresh_time: Option<u16>,
     pub hold_time: Option<u16>,
     pub min_lsp_arrival_time: Option<u32>,
+    pub spf_initial_wait: Option<u32>,
+    pub spf_secondary_wait: Option<u32>,
+    pub spf_maximum_wait: Option<u32>,
     pub te_router_id: Option<Ipv4Addr>,
     pub rib_router_id: Option<Ipv4Addr>,
     pub enable: Afis<usize>,
@@ -209,6 +224,10 @@ impl IsisConfig {
     // RFC 4444 §3.1 storm-protection floor for accepting new LSP versions.
     // 100 ms matches IOS-XR's default.
     const DEFAULT_MIN_LSP_ARRIVAL_TIME_MS: u32 = 100;
+    // IOS-XR-style SPF exponential-backoff defaults (in milliseconds).
+    const DEFAULT_SPF_INITIAL_WAIT_MS: u32 = 50;
+    const DEFAULT_SPF_SECONDARY_WAIT_MS: u32 = 200;
+    const DEFAULT_SPF_MAXIMUM_WAIT_MS: u32 = 5000;
 
     pub fn is_type(&self) -> IsLevel {
         self.is_type.unwrap_or(IsLevel::L1L2)
@@ -239,6 +258,21 @@ impl IsisConfig {
     pub fn min_lsp_arrival_time(&self) -> u32 {
         self.min_lsp_arrival_time
             .unwrap_or(Self::DEFAULT_MIN_LSP_ARRIVAL_TIME_MS)
+    }
+
+    pub fn spf_initial_wait(&self) -> u32 {
+        self.spf_initial_wait
+            .unwrap_or(Self::DEFAULT_SPF_INITIAL_WAIT_MS)
+    }
+
+    pub fn spf_secondary_wait(&self) -> u32 {
+        self.spf_secondary_wait
+            .unwrap_or(Self::DEFAULT_SPF_SECONDARY_WAIT_MS)
+    }
+
+    pub fn spf_maximum_wait(&self) -> u32 {
+        self.spf_maximum_wait
+            .unwrap_or(Self::DEFAULT_SPF_MAXIMUM_WAIT_MS)
     }
 
     /// True when either SR dataplane is enabled. Used to gate emission
@@ -339,6 +373,24 @@ fn config_min_lsp_arrival_time(isis: &mut Isis, mut args: Args, op: ConfigOp) ->
     } else {
         isis.config.min_lsp_arrival_time = None;
     }
+    Some(())
+}
+
+fn config_spf_initial_wait(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let ms = args.u32()?;
+    isis.config.spf_initial_wait = if op == ConfigOp::Set { Some(ms) } else { None };
+    Some(())
+}
+
+fn config_spf_secondary_wait(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let ms = args.u32()?;
+    isis.config.spf_secondary_wait = if op == ConfigOp::Set { Some(ms) } else { None };
+    Some(())
+}
+
+fn config_spf_maximum_wait(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let ms = args.u32()?;
+    isis.config.spf_maximum_wait = if op == ConfigOp::Set { Some(ms) } else { None };
     Some(())
 }
 

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -37,7 +37,7 @@ use super::lsp::{
     target_locator_name,
 };
 use super::nfsm::nbr_hold_timer_expire;
-use super::rib::{SpfIlm, SpfRoute, SpfRouteV6, perform_spf_calculation};
+use super::rib::{SpfIlm, SpfRoute, SpfRouteV6, SpfThrottle, perform_spf_calculation};
 use super::srmpls::IsisLabelMap;
 use super::{Hostname, IfsmEvent, Lsdb, LsdbEvent, NfsmEvent, csnp_send, srm_set_for_all_lsp};
 use super::{LabelPool, Level, Levels, process_packet};
@@ -87,6 +87,7 @@ pub struct Isis {
     pub ilm: Levels<BTreeMap<u32, SpfIlm>>,
     pub hostname: Levels<Hostname>,
     pub spf_timer: Levels<Option<Timer>>,
+    pub spf_throttle: Levels<SpfThrottle>,
     pub local_pool: Option<LabelPool>,
     pub graph: Levels<Option<spf::Graph>>,
     pub spf_result: Levels<Option<BTreeMap<usize, spf::Path>>>,
@@ -143,6 +144,7 @@ pub struct IsisTop<'a> {
     pub rib_tx: &'a UnboundedSender<rib::Message>,
     pub hostname: &'a mut Levels<Hostname>,
     pub spf_timer: &'a mut Levels<Option<Timer>>,
+    pub spf_throttle: &'a mut Levels<SpfThrottle>,
     pub graph: &'a mut Levels<Option<spf::Graph>>,
     pub spf_result: &'a mut Levels<Option<BTreeMap<usize, spf::Path>>>,
     pub mt2_graph: &'a mut Levels<Option<spf::Graph>>,
@@ -200,6 +202,7 @@ impl Isis {
             ilm: Levels::<BTreeMap<u32, SpfIlm>>::default(),
             hostname: Levels::<Hostname>::default(),
             spf_timer: Levels::<Option<Timer>>::default(),
+            spf_throttle: Levels::<SpfThrottle>::default(),
             // Adjacency-SID label pool is owned by the SR-MPLS feature.
             // Stays None until `segment-routing mpls` is configured —
             // otherwise we'd allocate labels for every hello and emit
@@ -598,6 +601,7 @@ impl Isis {
             rib_tx: &self.rib_tx,
             hostname: &mut self.hostname,
             spf_timer: &mut self.spf_timer,
+            spf_throttle: &mut self.spf_throttle,
             graph: &mut self.graph,
             spf_result: &mut self.spf_result,
             mt2_graph: &mut self.mt2_graph,
@@ -629,6 +633,7 @@ impl Isis {
             label_map: &mut self.label_map,
             srv6_end_map: &mut self.srv6_end_map,
             spf_timer: &mut self.spf_timer,
+            spf_throttle: &mut self.spf_throttle,
             rib_tx: &self.rib_tx,
             sr_locator: &self.sr_locator,
             watched_locator: &self.watched_locator,

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -134,6 +134,7 @@ pub struct LinkTop<'a> {
     pub label_map: &'a mut Levels<IsisLabelMap>,
     pub srv6_end_map: &'a mut Levels<std::collections::BTreeMap<IsisSysId, std::net::Ipv6Addr>>,
     pub spf_timer: &'a mut Levels<Option<Timer>>,
+    pub spf_throttle: &'a mut Levels<super::rib::SpfThrottle>,
 
     /// SR state needed for End.X (adjacency) SID allocation. Threaded
     /// through so packet handlers can carve a function from the ELIB

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -19,7 +19,7 @@ use super::{
     inst::IsisTop,
     link::Afi,
     lsp::{lsp_emit, lsp_flood},
-    rib::spf_schedule,
+    rib::{spf_schedule, spf_schedule_top},
 };
 
 #[derive(Default)]
@@ -409,12 +409,8 @@ pub fn insert_self_originate(
     // would not refresh the graph until some peer LSP arrives.
     // After a link bounce the graph could stay stale — z1's TLV
     // pointing at z1.NN-00 sees the PN LSP missing from the LSDB
-    // at SPF time and drops the edge. Inlined here because IsisTop
-    // and LinkTop both expose spf_timer/tx but spf_schedule's
-    // signature is over LinkTop.
-    if top.spf_timer.get(&level).is_none() {
-        *top.spf_timer.get_mut(&level) = Some(crate::isis::rib::spf_timer(top.tx, level));
-    }
+    // at SPF time and drops the edge.
+    spf_schedule_top(top, level);
     prev
 }
 

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -1,11 +1,14 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::{Ipv4Addr, Ipv6Addr};
+use std::time::Instant;
 
 use ipnet::{Ipv4Net, Ipv6Net};
 use isis_packet::*;
 use prefix_trie::PrefixMap;
 use tokio::sync::mpsc::UnboundedSender;
 
+use super::config::IsisConfig;
+use super::level::Levels;
 use crate::context::Timer;
 use crate::rib::inst::{IlmEntry, IlmType};
 use crate::rib::{self, Nexthop, NexthopMulti, NexthopUni, RibType};
@@ -27,9 +30,21 @@ use super::tilfa::{
     first_router_hop_id, tilfa_repair_path,
 };
 
-pub fn spf_timer(tx: &UnboundedSender<Message>, level: Level) -> Timer {
+/// Per-level state for the SPF exponential-backoff throttle.
+///
+/// `current_wait_ms` is the wait that will be used the NEXT time
+/// `spf_schedule` arms a timer during an ongoing burst. After a quiet
+/// period it gets reset to `initial-wait`; otherwise each scheduling
+/// event doubles it (capped at `maximum-wait`).
+#[derive(Default, Debug)]
+pub struct SpfThrottle {
+    pub current_wait_ms: u32,
+    pub last_run_at: Option<Instant>,
+}
+
+fn spf_timer_ms(tx: &UnboundedSender<Message>, level: Level, ms: u64) -> Timer {
     let tx = tx.clone();
-    Timer::once(1, move || {
+    Timer::once_ms(ms, move || {
         let tx = tx.clone();
         async move {
             let msg = Message::SpfCalc(level);
@@ -38,10 +53,67 @@ pub fn spf_timer(tx: &UnboundedSender<Message>, level: Level) -> Timer {
     })
 }
 
-pub fn spf_schedule(top: &mut LinkTop, level: Level) {
-    if top.spf_timer.get(&level).is_none() {
-        *top.spf_timer.get_mut(&level) = Some(spf_timer(top.tx, level));
+/// Arm the SPF timer for `level` if not already armed, honouring the
+/// IOS-XR-style exponential-backoff algorithm:
+///
+///   - First event after a quiet period > 2 × maximum-wait: use
+///     initial-wait.
+///   - Subsequent events during the burst: use the planned next wait
+///     (initial → secondary → secondary × 2 → ... capped at maximum).
+///
+/// The actual SPF run on timer expiry stamps `last_run_at` (see
+/// `perform_spf_calculation`) so future scheduling events can tell
+/// whether we're still in a burst.
+fn spf_schedule_inner(
+    spf_timer: &mut Levels<Option<Timer>>,
+    spf_throttle: &mut Levels<SpfThrottle>,
+    tx: &UnboundedSender<Message>,
+    config: &IsisConfig,
+    level: Level,
+) {
+    if spf_timer.get(&level).is_some() {
+        return;
     }
+
+    let initial = config.spf_initial_wait();
+    let secondary = config.spf_secondary_wait();
+    let maximum = config.spf_maximum_wait();
+
+    let throttle = spf_throttle.get_mut(&level);
+    let now = Instant::now();
+    let quiet_threshold = std::time::Duration::from_millis(2u64 * maximum as u64);
+    let in_burst = throttle
+        .last_run_at
+        .is_some_and(|t| now.duration_since(t) < quiet_threshold);
+
+    let wait_ms = if in_burst {
+        throttle.current_wait_ms
+    } else {
+        initial
+    };
+
+    // Plan the NEXT wait used if another event arrives during the burst.
+    throttle.current_wait_ms = if wait_ms == initial {
+        secondary.min(maximum)
+    } else {
+        (wait_ms.saturating_mul(2)).min(maximum)
+    };
+
+    *spf_timer.get_mut(&level) = Some(spf_timer_ms(tx, level, wait_ms as u64));
+}
+
+pub fn spf_schedule(top: &mut LinkTop, level: Level) {
+    spf_schedule_inner(
+        top.spf_timer,
+        top.spf_throttle,
+        top.tx,
+        top.up_config,
+        level,
+    );
+}
+
+pub fn spf_schedule_top(top: &mut IsisTop, level: Level) {
+    spf_schedule_inner(top.spf_timer, top.spf_throttle, top.tx, top.config, level);
 }
 
 #[derive(Debug, PartialEq)]
@@ -904,6 +976,9 @@ fn apply_routing_updates(
 pub(super) fn perform_spf_calculation(top: &mut IsisTop, level: Level) {
     // Turn off SPF calculation timer.
     *top.spf_timer.get_mut(&level) = None;
+    // Stamp completion time so spf_schedule can tell whether the next
+    // scheduling event lands inside or outside the burst window.
+    top.spf_throttle.get_mut(&level).last_run_at = Some(Instant::now());
 
     // Legacy graph + SPF — drives IPv4 RIB and IPv6 in non-MT mode.
     let (graph, source_node, adjacency_sids) = graph(top, level);

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -461,6 +461,27 @@ module config {
           }
         }
 
+        container spf-interval {
+          leaf initial-wait {
+            type uint32 {
+              range "1..120000";
+            }
+            units "milliseconds";
+          }
+          leaf secondary-wait {
+            type uint32 {
+              range "1..120000";
+            }
+            units "milliseconds";
+          }
+          leaf maximum-wait {
+            type uint32 {
+              range "1..120000";
+            }
+            units "milliseconds";
+          }
+        }
+
         list interface {
           // Last item in "router isis" node.
           ext:sort "-10";


### PR DESCRIPTION
## Summary

Replaces the fixed 1-second SPF coalesce with an IOS-XR-style exponential-backoff throttle.

**Algorithm:**
- First event after a quiet period > 2 × `maximum-wait`: arm timer with `initial-wait`
- Subsequent events during the burst: arm with the planned next wait (`initial` → `secondary` → `secondary × 2` → ... saturating-capped at `maximum`)
- `perform_spf_calculation` stamps `last_run_at`; next `spf_schedule` uses that to decide burst vs. quiet

**Defaults match IOS-XR: 50ms / 200ms / 5000ms.** With the new defaults an isolated topology change fires SPF after 50 ms instead of the prior fixed 1000 ms; sustained churn backs off to ≤5 s.

## New surface

**YANG** (`/router/isis/spf-interval/`):
- `initial-wait` (uint32 ms, range 1..120000)
- `secondary-wait` (uint32 ms, range 1..120000)
- `maximum-wait` (uint32 ms, range 1..120000)

**Timer infra** (`zebra-rs/src/context/task.rs`):
- `Timer::once_ms(ms, cb)` — millisecond-precision one-shot
- Extracted `Timer::new_dur(Duration, ...)` from `new()` so ms and second variants share the same spawn body

**Per-level throttle state** (`zebra-rs/src/isis/rib.rs`):
- `SpfThrottle { current_wait_ms, last_run_at }`
- `spf_timer_ms()` replaces the old fixed-second `spf_timer()`
- `spf_schedule_inner()` carries the algorithm; `spf_schedule()` (LinkTop) and `spf_schedule_top()` (IsisTop) wrap it
- Wired `spf_throttle: Levels<SpfThrottle>` through `Isis` / `IsisTop` / `LinkTop` and their factories

`lsdb.rs`'s previously-inlined copy of the spf_schedule logic now calls `spf_schedule_top(top, level)`.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo clippy -p zebra-rs --all-targets` clean
- [x] `cargo fmt -p zebra-rs --check` clean
- [x] `cargo test -p zebra-rs` — all 342 tests pass
- [ ] Smoke test: configure short `maximum-wait` (e.g. 500 ms), then trigger a burst of LSP updates and watch debug logs / trace to confirm timer arms first at initial, then at secondary, then doubles, then caps at maximum
- [ ] Smoke test: trigger an isolated topology change after >1 second of quiet and verify SPF runs after ~50 ms (not 1000 ms)

Generated with [Claude Code](https://claude.com/claude-code)