### PR TITLE
bfd: timer + outbound + sessions (PR 3b of 10)

### DIFF
--- a/zebra-rs/src/bfd/fsm.rs
+++ b/zebra-rs/src/bfd/fsm.rs
@@ -8,11 +8,6 @@
 //! side effects: updating its own state, resetting the detection
 //! timer, notifying clients, and so on.
 
-// PR 3a stages the full Event surface (`DetectExpired`, `AdminDown`,
-// `AdminUp`); the production wiring that constructs the non-`Rx`
-// variants arrives in PR 3b (timer expiry) and PR 4 (admin shutdown).
-#![allow(dead_code)]
-
 use bfd_packet::{Diag, State};
 
 /// External events that can drive a state change.

--- a/zebra-rs/src/bfd/inst.rs
+++ b/zebra-rs/src/bfd/inst.rs
@@ -1,28 +1,44 @@
+use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
 use std::sync::Arc;
 
 use tokio::io::unix::AsyncFd;
-use tokio::sync::mpsc::{self, UnboundedReceiver};
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use crate::context::{Context, Task};
 
-use super::network::read_packet;
-use super::session::SessionTable;
+use super::fsm::Event;
+use super::network::{WriteRequest, read_packet, write_packet};
+use super::session::{Session, SessionKey, SessionParams, SessionTable, StateChange};
 use super::socket::{BFD_SINGLE_HOP_PORT, bfd_socket_ipv4};
+use super::timer::{InitialParams, TimerCmd, session_timer};
 
-/// Top-level BFD instance. Holds the IPv4 single-hop socket, the
-/// session table, and the event channel; the read task feeds events
-/// in and the event loop demuxes them to sessions.
-///
-/// PR 3a wires the session table into the event loop's demux path.
-/// PR 3b adds the public `add_session` API, the TX scheduler, and the
-/// detection timer.
+/// Top-level BFD instance. Owns the IPv4 single-hop UDP socket, the
+/// session table, and a per-session timer handle map. Read and write
+/// tasks are tokio-spawned at construction and feed the event loop
+/// via `main_tx` / `write_tx`.
 pub struct Bfd {
     pub rx: UnboundedReceiver<Message>,
     pub sessions: SessionTable,
+    /// Local address the recv socket was bound to. Useful to tests
+    /// that bind to ephemeral ports — `local_addr.port()` reveals the
+    /// kernel-chosen value so the peer can be told where to send.
+    pub local_addr: SocketAddrV4,
+    main_tx: UnboundedSender<Message>,
+    write_tx: UnboundedSender<WriteRequest>,
+    timer_handles: HashMap<SessionKey, TimerHandle>,
+    notify_tx: Option<UnboundedSender<BfdEvent>>,
 }
 
-/// Event-loop messages. PR 3 adds Send / interface / config variants.
+/// Holds the per-session timer task and its command channel. Dropping
+/// the `Task` aborts the timer loop; the `cmd_tx` is used to update
+/// intervals, reset the detection timer, and request graceful
+/// shutdown.
+struct TimerHandle {
+    cmd_tx: UnboundedSender<TimerCmd>,
+    _task: Task<()>,
+}
+
 #[derive(Debug)]
 pub enum Message {
     /// A parsed, GTSM-validated control packet arrived.
@@ -32,27 +48,108 @@ pub enum Message {
         dst: Option<IpAddr>,
         ifindex: u32,
     },
+    /// Periodic transmission timer fired for `key`.
+    TxTick { key: SessionKey },
+    /// Detection timer fired for `key`.
+    DetectExpired { key: SessionKey },
+}
+
+/// Lifecycle events emitted by the instance for clients (tests today,
+/// protocol modules like BGP / OSPF in later PRs) to observe.
+#[derive(Debug, Clone, Copy)]
+pub enum BfdEvent {
+    StateChange {
+        key: SessionKey,
+        change: StateChange,
+    },
 }
 
 impl Bfd {
-    /// Bind the IPv4 single-hop socket on `0.0.0.0:3784` and spawn the
-    /// receive task.
-    pub fn new(_ctx: Context) -> std::io::Result<Self> {
-        let sock = bfd_socket_ipv4(SocketAddrV4::new(
-            Ipv4Addr::UNSPECIFIED,
-            BFD_SINGLE_HOP_PORT,
-        ))?;
+    /// Production constructor — binds to `0.0.0.0:3784` and emits no
+    /// `BfdEvent` notifications.
+    pub fn new(ctx: Context) -> std::io::Result<Self> {
+        Self::new_with(
+            ctx,
+            SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, BFD_SINGLE_HOP_PORT),
+            None,
+        )
+    }
+
+    /// Explicit constructor that lets the caller pick the bind
+    /// address (used by the integration test to run two instances on
+    /// loopback ephemeral ports) and supply an optional [`BfdEvent`]
+    /// notifier.
+    pub fn new_with(
+        _ctx: Context,
+        bind: SocketAddrV4,
+        notify_tx: Option<UnboundedSender<BfdEvent>>,
+    ) -> std::io::Result<Self> {
+        let sock = bfd_socket_ipv4(bind)?;
+        let local_addr = sock
+            .local_addr()?
+            .as_socket_ipv4()
+            .ok_or_else(|| std::io::Error::other("bound socket has no IPv4 local address"))?;
         let sock = Arc::new(AsyncFd::new(sock)?);
 
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (main_tx, rx) = mpsc::unbounded_channel::<Message>();
+        let (write_tx, write_rx) = mpsc::unbounded_channel::<WriteRequest>();
+
+        let read_sock = sock.clone();
+        let read_tx = main_tx.clone();
         tokio::spawn(async move {
-            read_packet(sock, tx).await;
+            read_packet(read_sock, read_tx).await;
+        });
+
+        let write_sock = sock.clone();
+        tokio::spawn(async move {
+            write_packet(write_sock, write_rx).await;
         });
 
         Ok(Self {
             rx,
             sessions: SessionTable::new(),
+            local_addr,
+            main_tx,
+            write_tx,
+            timer_handles: HashMap::new(),
+            notify_tx,
         })
+    }
+
+    /// Insert a new session and spawn its timer task. Returns the
+    /// locally-assigned, non-zero, collision-free discriminator.
+    pub fn add_session(&mut self, key: SessionKey, params: SessionParams) -> u32 {
+        let disc = self.sessions.insert(key, params);
+
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        let initial = InitialParams {
+            // No peer reply yet → start TX at our desired interval;
+            // the negotiated value lands on the first Rx.
+            tx_interval_us: params.desired_min_tx_us,
+            // No peer reply yet → detection timer is not armed.
+            detection_time_us: 0,
+            detect_mult: params.detect_mult,
+        };
+        let main_tx = self.main_tx.clone();
+        let task = Task::spawn(session_timer(key, initial, cmd_rx, main_tx));
+        self.timer_handles.insert(
+            key,
+            TimerHandle {
+                cmd_tx,
+                _task: task,
+            },
+        );
+
+        disc
+    }
+
+    /// Remove a session and shut down its timer task. Returns the
+    /// removed session, if any.
+    pub fn remove_session(&mut self, key: &SessionKey) -> Option<Session> {
+        if let Some(h) = self.timer_handles.remove(key) {
+            let _ = h.cmd_tx.send(TimerCmd::Shutdown);
+        }
+        self.sessions.remove(key)
     }
 
     pub async fn event_loop(&mut self) {
@@ -64,15 +161,12 @@ impl Bfd {
                     dst,
                     ifindex,
                 } => self.on_recv(packet, src, dst, ifindex),
+                Message::TxTick { key } => self.on_tx_tick(key),
+                Message::DetectExpired { key } => self.on_detect_expired(key),
             }
         }
     }
 
-    /// Demux an incoming control packet. RFC 5880 §6.8.6: when `Your
-    /// Discriminator` is non-zero, look up the session by that value;
-    /// otherwise the bootstrap (`(local, remote, ifindex)`) demux
-    /// path applies — that fallback lands in PR 3b together with the
-    /// outbound packet path that creates the first peer-side state.
     fn on_recv(
         &mut self,
         packet: bfd_packet::ControlPacket,
@@ -80,32 +174,106 @@ impl Bfd {
         dst: Option<IpAddr>,
         ifindex: u32,
     ) {
-        if packet.your_disc == 0 {
+        let lookup = if packet.your_disc != 0 {
+            self.sessions.get_by_disc(packet.your_disc).map(|s| s.key)
+        } else {
+            self.bootstrap_lookup(src, ifindex)
+        };
+        let Some(key) = lookup else {
             tracing::debug!(
                 ?src,
                 ?dst,
                 ifindex,
-                "bfd: rx packet with Your Disc = 0; bootstrap demux not yet wired",
-            );
-            return;
-        }
-        let Some(session) = self.sessions.get_by_disc_mut(packet.your_disc) else {
-            tracing::debug!(
-                ?src,
-                ifindex,
                 your_disc = format_args!("{:#010x}", packet.your_disc),
-                "bfd: no session for received discriminator",
+                "bfd: no session matches received packet",
             );
             return;
         };
-        if let Some(change) = session.handle_packet(&packet) {
-            tracing::info!(
-                key = ?session.key,
-                from = %change.from,
-                to = %change.to,
-                diag = %change.diag,
-                "bfd: session state change",
-            );
+
+        let (change, new_tx_us, new_detect_us, new_detect_mult) = {
+            let session = self
+                .sessions
+                .get_by_key_mut(&key)
+                .expect("just looked up by key");
+            let change = session.handle_packet(&packet);
+            (
+                change,
+                session.tx_interval_us(),
+                session.detection_time_us(),
+                session.detect_mult,
+            )
+        };
+
+        // Every valid Rx must reset the detection timer (RFC 5880
+        // §6.8.4). When intervals are also negotiated freshly, the
+        // Update command implicitly does the reset as part of arming.
+        if let Some(h) = self.timer_handles.get(&key) {
+            let _ = h.cmd_tx.send(TimerCmd::Update {
+                tx_interval_us: new_tx_us,
+                detection_time_us: new_detect_us,
+                detect_mult: new_detect_mult,
+            });
+        }
+
+        if let Some(change) = change {
+            self.notify_state_change(key, change);
+        }
+    }
+
+    /// Find an existing session that matches an incoming packet whose
+    /// `Your Discriminator` is zero (RFC 5880 §6.8.6 bootstrap path).
+    /// Linear scan — fine for the small session counts a single
+    /// process maintains; an explicit (local, remote, ifindex) index
+    /// can be added later if it shows up in profiles.
+    fn bootstrap_lookup(&self, src: SocketAddrV4, ifindex: u32) -> Option<SessionKey> {
+        let src_ip = IpAddr::V4(*src.ip());
+        self.sessions.iter().find_map(|(_, s)| {
+            let ifindex_match = s.key.ifindex == 0 || s.key.ifindex == ifindex;
+            if s.key.remote == src_ip && ifindex_match {
+                Some(s.key)
+            } else {
+                None
+            }
+        })
+    }
+
+    fn on_tx_tick(&self, key: SessionKey) {
+        let Some(session) = self.sessions.get_by_key(&key) else {
+            return;
+        };
+        let IpAddr::V4(remote) = session.key.remote else {
+            // PR 7 adds IPv6.
+            return;
+        };
+        let dst = SocketAddrV4::new(remote, session.dst_port);
+        let ifindex = (session.key.ifindex != 0).then_some(session.key.ifindex);
+        let _ = self.write_tx.send(WriteRequest {
+            packet: session.build_packet(),
+            dst,
+            ifindex,
+        });
+    }
+
+    fn on_detect_expired(&mut self, key: SessionKey) {
+        let Some(session) = self.sessions.get_by_key_mut(&key) else {
+            return;
+        };
+        let change = session.handle_event(Event::DetectExpired);
+        if let Some(change) = change {
+            self.notify_state_change(key, change);
+        }
+    }
+
+    fn notify_state_change(&self, key: SessionKey, change: StateChange) {
+        tracing::info!(
+            ?key,
+            from = %change.from,
+            to = %change.to,
+            diag = %change.diag,
+            "bfd: session state change",
+        );
+        if let Some(tx) = &self.notify_tx {
+            let _ = tx.send(BfdEvent::StateChange { key, change });
         }
     }
 }

--- a/zebra-rs/src/bfd/integration.rs
+++ b/zebra-rs/src/bfd/integration.rs
@@ -1,0 +1,86 @@
+//! Two-instance loopback integration test.
+//!
+//! Brings two BFD instances up on ephemeral loopback ports, adds a
+//! session on each pointing at the other, and asserts that both
+//! sessions reach the `Up` state — the three-way handshake from
+//! RFC 5880 §6.8.6.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
+use std::time::Duration;
+
+use bfd_packet::State;
+use tokio::sync::mpsc;
+
+use super::inst::{Bfd, BfdEvent, serve};
+use super::session::{SessionKey, SessionParams};
+use crate::context::Context;
+
+const LOOPBACK: Ipv4Addr = Ipv4Addr::LOCALHOST;
+
+fn loopback_key() -> SessionKey {
+    SessionKey {
+        local: IpAddr::V4(LOOPBACK),
+        remote: IpAddr::V4(LOOPBACK),
+        ifindex: 0,
+        multihop: false,
+    }
+}
+
+async fn wait_for_up(rx: &mut mpsc::UnboundedReceiver<BfdEvent>, timeout: Duration, who: &str) {
+    let started = std::time::Instant::now();
+    while started.elapsed() < timeout {
+        match tokio::time::timeout(timeout - started.elapsed(), rx.recv()).await {
+            Ok(Some(BfdEvent::StateChange { change, .. })) if change.to == State::Up => return,
+            Ok(Some(_)) => continue, // intermediate transitions (Down → Init)
+            Ok(None) => panic!("{who}: notifier channel closed before Up"),
+            Err(_) => break, // timed out
+        }
+    }
+    panic!("{who}: did not reach Up within {timeout:?}");
+}
+
+/// Cross-add sessions between two Bfd instances and assert both
+/// reach `Up`. Uses 50ms intervals so the handshake completes
+/// quickly (typical timing: well under a second).
+#[tokio::test]
+async fn two_instances_reach_up() {
+    let (tx_a, mut rx_a) = mpsc::unbounded_channel();
+    let (tx_b, mut rx_b) = mpsc::unbounded_channel();
+
+    let mut bfd_a = Bfd::new_with(
+        Context::default(),
+        SocketAddrV4::new(LOOPBACK, 0),
+        Some(tx_a),
+    )
+    .expect("bind A");
+    let mut bfd_b = Bfd::new_with(
+        Context::default(),
+        SocketAddrV4::new(LOOPBACK, 0),
+        Some(tx_b),
+    )
+    .expect("bind B");
+
+    let port_a = bfd_a.local_addr.port();
+    let port_b = bfd_b.local_addr.port();
+    assert_ne!(
+        port_a, port_b,
+        "ephemeral allocator must give distinct ports"
+    );
+
+    let params = |dst_port| SessionParams {
+        desired_min_tx_us: 50_000,
+        required_min_rx_us: 50_000,
+        detect_mult: 3,
+        dst_port,
+    };
+
+    bfd_a.add_session(loopback_key(), params(port_b));
+    bfd_b.add_session(loopback_key(), params(port_a));
+
+    let _ta = serve(bfd_a);
+    let _tb = serve(bfd_b);
+
+    let deadline = Duration::from_secs(5);
+    wait_for_up(&mut rx_a, deadline, "A").await;
+    wait_for_up(&mut rx_b, deadline, "B").await;
+}

--- a/zebra-rs/src/bfd/mod.rs
+++ b/zebra-rs/src/bfd/mod.rs
@@ -1,5 +1,18 @@
+// PR 3b stages the timer engine, outbound packet path, and the
+// `Bfd::add_session` API; the runtime spawn point that consumes them
+// (config-driven session creation) arrives in PR 4. Until then a
+// number of items are only reached from the integration test, so
+// the bin-only compilation surface them as `dead_code`. Suppress
+// module-wide rather than peppering individual files — the lint
+// returns naturally as PR 4 wires the production callers.
+#![allow(dead_code)]
+
 pub mod fsm;
 pub mod inst;
 pub mod network;
 pub mod session;
 pub mod socket;
+pub mod timer;
+
+#[cfg(test)]
+mod integration;

--- a/zebra-rs/src/bfd/network.rs
+++ b/zebra-rs/src/bfd/network.rs
@@ -1,18 +1,31 @@
-use std::io::{ErrorKind, IoSliceMut};
+use std::io::{ErrorKind, IoSlice, IoSliceMut};
 use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
 use std::os::fd::AsRawFd;
 use std::sync::Arc;
 
+use bytes::BytesMut;
 use nix::sys::socket::{self, ControlMessageOwned, SockaddrIn};
 use socket2::Socket;
 use tokio::io::Interest;
 use tokio::io::unix::AsyncFd;
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use super::inst::Message;
 
 /// GTSM expected TTL for single-hop BFD (RFC 5881 §5).
 const GTSM_TTL: u8 = 255;
+
+/// Egress request consumed by [`write_packet`]. The event loop pushes
+/// these whenever a [`super::timer::TimerEvent::TxTick`] fires (or in
+/// future PRs, when a poll-sequence packet must be sent off-schedule).
+#[derive(Debug)]
+pub struct WriteRequest {
+    pub packet: bfd_packet::ControlPacket,
+    pub dst: SocketAddrV4,
+    /// Optional egress ifindex (sent via `IP_PKTINFO`). `None` lets
+    /// the kernel route normally.
+    pub ifindex: Option<u32>,
+}
 
 /// Async receive loop. Pulls one BFD control packet at a time off
 /// `sock`, runs structural validation via
@@ -91,6 +104,48 @@ pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message
     }
 }
 
+/// Async send loop. Drains [`WriteRequest`] from `rx`, encodes the
+/// control packet, and dispatches it via `sendmsg`. The outgoing TTL
+/// is fixed to 255 by the socket option configured in
+/// [`super::socket::bfd_socket_ipv4`]. When `WriteRequest::ifindex`
+/// is `Some`, an `IP_PKTINFO` ancillary message pins egress to that
+/// interface; otherwise the kernel routes normally.
+pub async fn write_packet(sock: Arc<AsyncFd<Socket>>, mut rx: UnboundedReceiver<WriteRequest>) {
+    while let Some(req) = rx.recv().await {
+        let mut buf = BytesMut::new();
+        req.packet.emit(&mut buf);
+        let iov = [IoSlice::new(&buf)];
+        let sockaddr: SockaddrIn = req.dst.into();
+
+        let pktinfo = req.ifindex.map(|ifindex| libc::in_pktinfo {
+            ipi_ifindex: ifindex as i32,
+            ipi_spec_dst: libc::in_addr { s_addr: 0 },
+            ipi_addr: libc::in_addr { s_addr: 0 },
+        });
+        let cmsg_storage;
+        let cmsgs: &[socket::ControlMessage<'_>] = if let Some(ref pi) = pktinfo {
+            cmsg_storage = [socket::ControlMessage::Ipv4PacketInfo(pi)];
+            &cmsg_storage
+        } else {
+            &[]
+        };
+
+        let _ = sock
+            .async_io(Interest::WRITABLE, |sock| {
+                socket::sendmsg(
+                    sock.as_raw_fd(),
+                    &iov,
+                    cmsgs,
+                    socket::MsgFlags::empty(),
+                    Some(&sockaddr),
+                )
+                .map_err(std::io::Error::from)?;
+                Ok(())
+            })
+            .await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use bfd_packet::{ControlPacket, State};
@@ -146,7 +201,10 @@ mod tests {
 
         let Message::Recv {
             packet: rx_packet, ..
-        } = got;
+        } = got
+        else {
+            panic!("expected Recv, got {got:?}");
+        };
         assert_eq!(rx_packet, packet);
 
         read_handle.abort();

--- a/zebra-rs/src/bfd/session.rs
+++ b/zebra-rs/src/bfd/session.rs
@@ -11,12 +11,6 @@
 //! expose a public `add_session` API or run a TX/detection timer —
 //! both arrive in PR 3b together with the outbound packet path.
 
-// Several RFC §6.8.1 fields (`local_disc`, `desired_min_tx_us`, …) and
-// the [`SessionParams`] constructor type are only read by code that
-// arrives in PR 3b (timer engine, outbound TX) and PR 4 (show). Keep
-// them defined at spec parity now; the production wiring follows.
-#![allow(dead_code)]
-
 use std::collections::{BTreeMap, HashMap};
 use std::net::IpAddr;
 use std::time::Instant;
@@ -40,12 +34,16 @@ pub struct SessionKey {
 /// Per-session timer / detection parameters as locally configured
 /// (i.e. before any peer negotiation). RFC 5880 §6.8.1 calls these
 /// `bfd.DesiredMinTxInterval`, `bfd.RequiredMinRxInterval`, and
-/// `bfd.DetectMult`.
+/// `bfd.DetectMult`. `dst_port` is the UDP destination used when
+/// transmitting — production callers pass
+/// [`super::socket::BFD_SINGLE_HOP_PORT`] (3784) for single-hop and
+/// 4784 for multihop (RFC 5883); tests pass the peer's ephemeral port.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SessionParams {
     pub desired_min_tx_us: u32,
     pub required_min_rx_us: u32,
     pub detect_mult: u8,
+    pub dst_port: u16,
 }
 
 impl Default for SessionParams {
@@ -57,6 +55,7 @@ impl Default for SessionParams {
             desired_min_tx_us: 1_000_000,
             required_min_rx_us: 1_000_000,
             detect_mult: 3,
+            dst_port: super::socket::BFD_SINGLE_HOP_PORT,
         }
     }
 }
@@ -93,6 +92,9 @@ pub struct Session {
     pub desired_min_tx_us: u32,
     pub required_min_rx_us: u32,
     pub detect_mult: u8,
+
+    /// UDP destination port to send to (3784 single-hop, 4784 multi-hop).
+    pub dst_port: u16,
 
     /// Reported by the peer in the most recent control packet.
     pub remote_min_tx_us: u32,
@@ -133,6 +135,7 @@ impl Session {
             desired_min_tx_us: params.desired_min_tx_us,
             required_min_rx_us: params.required_min_rx_us,
             detect_mult: params.detect_mult,
+            dst_port: params.dst_port,
             remote_min_tx_us: 0,
             remote_min_rx_us: 0,
             remote_detect_mult: 0,
@@ -190,6 +193,48 @@ impl Session {
         self.handle_event(Event::Rx {
             remote_state: packet.state,
         })
+    }
+
+    /// The actual outgoing transmission interval (microseconds) per
+    /// RFC 5880 §6.8.7: the maximum of what we'd like to send and
+    /// what the peer can receive. If the peer reports
+    /// `Required Min RX Interval = 0` we suspend periodic transmission
+    /// — represented here by returning 0.
+    pub fn tx_interval_us(&self) -> u32 {
+        if self.remote_min_rx_us == 0 {
+            return 0;
+        }
+        self.desired_min_tx_us.max(self.remote_min_rx_us)
+    }
+
+    /// Detection time (microseconds) per RFC 5880 §6.8.4: the peer's
+    /// detect multiplier times the larger of our required-receive and
+    /// the peer's desired-transmit. Zero when no valid packet has
+    /// been received yet (so the detection timer is not yet armed).
+    pub fn detection_time_us(&self) -> u32 {
+        if self.remote_detect_mult == 0 {
+            return 0;
+        }
+        let base = self.required_min_rx_us.max(self.remote_min_tx_us);
+        u32::from(self.remote_detect_mult).saturating_mul(base)
+    }
+
+    /// Build an outgoing BFD control packet that reflects the
+    /// session's current state. The Length field and `auth_present`
+    /// flag are populated by the encoder.
+    pub fn build_packet(&self) -> ControlPacket {
+        ControlPacket {
+            diag: self.local_diag,
+            state: self.local_state,
+            detect_mult: self.detect_mult,
+            my_disc: self.local_disc,
+            your_disc: self.remote_disc,
+            desired_min_tx_interval: self.desired_min_tx_us,
+            required_min_rx_interval: self.required_min_rx_us,
+            required_min_echo_rx_interval: 0,
+            demand: self.demand,
+            ..ControlPacket::default()
+        }
     }
 }
 

--- a/zebra-rs/src/bfd/timer.rs
+++ b/zebra-rs/src/bfd/timer.rs
@@ -1,0 +1,190 @@
+//! Per-session timer task.
+//!
+//! Each [`Session`](super::session::Session) gets exactly one
+//! [`session_timer`] task. The task owns two timers:
+//!
+//!   * a periodic **TX scheduler** that fires at a jittered fraction
+//!     of the negotiated `tx_interval` (RFC 5880 §6.8.7); each fire
+//!     sends a [`TimerEvent::TxTick`] to the main event loop, which
+//!     builds the packet from the live session state and dispatches
+//!     it via the write task;
+//!   * a **detection timer** that fires once when no valid packet
+//!     has arrived in `detection_time` (RFC 5880 §6.8.4); the event
+//!     loop drives the FSM with [`super::fsm::Event::DetectExpired`]
+//!     in response.
+//!
+//! Both intervals can be adjusted at runtime by sending [`TimerCmd::Update`]
+//! (whenever negotiation changes the effective rates).
+//! [`TimerCmd::ResetDetect`] is sent on every valid receive so the
+//! detection timer rearms.
+
+use std::time::Duration;
+
+use rand::RngExt;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::time::{Instant, sleep_until};
+
+use super::inst::Message;
+use super::session::SessionKey;
+
+/// Commands the event loop sends to a session's timer task.
+#[derive(Debug, Clone, Copy)]
+pub enum TimerCmd {
+    /// Negotiation result changed; recompute deadlines.
+    /// `detect_mult` is the *local* multiplier and is only used to
+    /// cap the per-TX jitter envelope per RFC 5880 §6.8.7.
+    Update {
+        tx_interval_us: u32,
+        detection_time_us: u32,
+        detect_mult: u8,
+    },
+    /// A valid packet just arrived; reset the detection timer.
+    ResetDetect,
+    /// Shut the task down. Equivalent to dropping the cmd channel.
+    Shutdown,
+}
+
+/// Initial timer parameters supplied when the task is spawned.
+#[derive(Debug, Clone, Copy)]
+pub struct InitialParams {
+    pub tx_interval_us: u32,
+    pub detection_time_us: u32,
+    pub detect_mult: u8,
+}
+
+/// Per-session timer task body. Runs until the cmd channel closes
+/// (the [`crate::context::Task`] handle is dropped) or [`TimerCmd::Shutdown`]
+/// arrives.
+pub async fn session_timer(
+    key: SessionKey,
+    initial: InitialParams,
+    mut cmd_rx: UnboundedReceiver<TimerCmd>,
+    event_tx: UnboundedSender<Message>,
+) {
+    let mut tx_us = initial.tx_interval_us;
+    let mut detect_us = initial.detection_time_us;
+    let mut detect_mult = initial.detect_mult.max(1);
+
+    let mut next_tx = arm_tx(tx_us, detect_mult);
+    let mut detect_at = arm_detect(detect_us);
+
+    loop {
+        // tokio::select! cannot match on Option<Sleep>, so we always
+        // build a sleep and use the `if` guard to gate the arm.
+        let tx_at = next_tx.unwrap_or_else(far_future);
+        let detect_at_or_far = detect_at.unwrap_or_else(far_future);
+        let tx_sleep = sleep_until(tx_at);
+        let det_sleep = sleep_until(detect_at_or_far);
+        tokio::pin!(tx_sleep, det_sleep);
+
+        tokio::select! {
+            _ = &mut tx_sleep, if next_tx.is_some() => {
+                if event_tx.send(Message::TxTick { key }).is_err() {
+                    return; // event loop gone
+                }
+                next_tx = arm_tx(tx_us, detect_mult);
+            }
+            _ = &mut det_sleep, if detect_at.is_some() => {
+                if event_tx.send(Message::DetectExpired { key }).is_err() {
+                    return;
+                }
+                // Don't rearm — the FSM transition to Down means there
+                // is no detection timer until the peer comes back.
+                detect_at = None;
+            }
+            cmd = cmd_rx.recv() => match cmd {
+                None | Some(TimerCmd::Shutdown) => return,
+                Some(TimerCmd::Update {
+                    tx_interval_us,
+                    detection_time_us,
+                    detect_mult: mult,
+                }) => {
+                    tx_us = tx_interval_us;
+                    detect_us = detection_time_us;
+                    detect_mult = mult.max(1);
+                    next_tx = arm_tx(tx_us, detect_mult);
+                    detect_at = arm_detect(detect_us);
+                }
+                Some(TimerCmd::ResetDetect) => {
+                    detect_at = arm_detect(detect_us);
+                }
+            }
+        }
+    }
+}
+
+/// Pick the next TX deadline, applying RFC 5880 §6.8.7 jitter. Zero
+/// transmission interval means the peer has suspended async transmit
+/// (`Required Min RX Interval = 0`) and we mustn't send.
+fn arm_tx(tx_us: u32, detect_mult: u8) -> Option<Instant> {
+    if tx_us == 0 {
+        return None;
+    }
+    Some(Instant::now() + Duration::from_micros(jittered_tx_us(tx_us, detect_mult) as u64))
+}
+
+/// Pick the next detection-time deadline. Zero means we haven't
+/// heard from the peer yet (RFC 5880 §6.8.4 initial condition).
+fn arm_detect(detect_us: u32) -> Option<Instant> {
+    if detect_us == 0 {
+        return None;
+    }
+    Some(Instant::now() + Duration::from_micros(detect_us as u64))
+}
+
+/// Compute a single jittered transmit interval per RFC 5880 §6.8.7:
+///
+///   * normally the actual interval is 75–100% of the negotiated value;
+///   * when `detect_mult == 1`, the upper bound drops to 90% so a
+///     single missed packet cannot exceed the detection time.
+fn jittered_tx_us(tx_us: u32, detect_mult: u8) -> u32 {
+    let upper: u32 = if detect_mult <= 1 { 90 } else { 100 };
+    let lower: u32 = 75;
+    let pct: u32 = rand::rng().random_range(lower..=upper);
+    // Multiply in u64 to avoid overflow at the u32 upper end.
+    ((u64::from(tx_us) * u64::from(pct)) / 100) as u32
+}
+
+fn far_future() -> Instant {
+    Instant::now() + Duration::from_secs(3600)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Jitter must stay within the RFC 5880 §6.8.7 envelope at every
+    /// detect-multiplier setting; a few hundred draws is enough to
+    /// catch off-by-one mistakes on the bound clamping.
+    #[test]
+    fn jitter_envelope() {
+        let tx_us: u32 = 1_000_000;
+        for &mult in &[1u8, 2, 3, 5, 100] {
+            let upper_pct: u32 = if mult == 1 { 90 } else { 100 };
+            for _ in 0..500 {
+                let j = jittered_tx_us(tx_us, mult);
+                let pct = (u64::from(j) * 100) / u64::from(tx_us);
+                assert!(
+                    (75..=u64::from(upper_pct)).contains(&pct),
+                    "mult={mult} pct={pct} (j={j})",
+                );
+            }
+        }
+    }
+
+    /// Zero TX interval suppresses transmission per RFC 5880 §6.8.7
+    /// (peer's Required Min RX Interval = 0).
+    #[test]
+    fn zero_tx_disables_arm() {
+        assert!(arm_tx(0, 3).is_none());
+        assert!(arm_tx(50_000, 3).is_some());
+    }
+
+    /// Zero detection time leaves the detect arm un-set (no peer
+    /// data yet, so nothing to time out against).
+    #[test]
+    fn zero_detect_disables_arm() {
+        assert!(arm_detect(0).is_none());
+        assert!(arm_detect(150_000).is_some());
+    }
+}


### PR DESCRIPTION
## Summary

Closes out the BFD session lifecycle: per-session jittered TX,
detection-time tracking, an outbound packet path, public
`add_session` / `remove_session` APIs, and a two-instance loopback
integration test that brings a session to `Up` via RFC 5880 §6.8.6's
three-way handshake.

- **`src/bfd/timer.rs`** — per-session timer task. Owns the periodic
  TX scheduler (RFC 5880 §6.8.7 jitter — 75–100% normally, capped
  at 90% when `detect_mult == 1`) and a one-shot detection timer
  (§6.8.4). Commands: `Update`, `ResetDetect`, `Shutdown`. Sends
  `Message::TxTick` / `DetectExpired` back to the event loop on fire.
- **`src/bfd/network.rs`** — adds `WriteRequest` and `write_packet`.
  Uses `sendmsg` with optional `IP_PKTINFO ipi_ifindex` to pin egress
  interface; TTL=255 is enforced by the socket option from PR 2.
- **`src/bfd/session.rs`** — `SessionParams` gains `dst_port` (3784
  single-hop, 4784 multihop, ephemeral in tests). `Session` gains
  `dst_port`, `tx_interval_us()` / `detection_time_us()` (the
  RFC §6.8.7 / §6.8.4 negotiation formulas), and `build_packet()`
  which snapshots the current state into a `ControlPacket` for TX.
- **`src/bfd/inst.rs`** — `Bfd` grows `local_addr`, `main_tx`,
  `write_tx`, `timer_handles`, `notify_tx`. New
  `BfdEvent::StateChange` surfaces transitions to interested clients
  (tests today, BGP / OSPF / IS-IS in later PRs).
  `Bfd::new_with(bind, notify_tx)` lets the integration test bind to
  ephemeral loopback ports and observe. Event loop demuxes `Recv`
  by `your_disc` with a `(local, remote, ifindex)` bootstrap
  fallback for the first packet of a session. Every valid Rx pushes
  `TimerCmd::Update` so the detection timer rearms with the
  freshly-negotiated detection time.
- **`src/bfd/integration.rs`** — `#[tokio::test]` that brings up two
  `Bfd` instances on 127.0.0.1 ephemeral ports, cross-adds sessions
  at 50ms intervals, and asserts both notifiers see a transition to
  `Up` within 5 seconds.

The `#![allow(dead_code)]` is now a single declaration at
`bfd/mod.rs` with a comment; the per-file allows in `fsm.rs` /
`session.rs` from PR 3a are dropped. The remaining lint surface
(`add_session`, `remove_session`, `TxTick`, `DetectExpired`, …)
lights up at runtime once PR 4 drives session creation from YANG
config.

## Test plan

- [x] `cargo test -p zebra-rs --bin zebra-rs -- bfd::` — 18 / 18
  pass (4 new):
  - `timer::tests::jitter_envelope` — 2500 draws across 5
    detect-multiplier settings stay within the RFC envelope
  - `timer::tests::zero_tx_disables_arm`
  - `timer::tests::zero_detect_disables_arm`
  - `integration::two_instances_reach_up` — the headline integration
- [x] `cargo test -p bfd-packet` — 20 codec tests from PR 1 still pass
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

Generated with [Claude Code](https://claude.com/claude-code)