### PR TITLE
isis: add lsp-gen-interval throttle and reusable Throttle + docs

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -15,6 +15,8 @@
 - [BGP](ch-02-00-what-is-bgp.md)
   - [Dynamic Neighbors](ch-02-01-dynamic-neighbors.md)
   - [Session Authentication (TCP MD5 / TCP-AO)](ch-02-02-tcp-authentication.md)
+- [IS-IS](ch-07-00-isis.md)
+  - [Timer Configuration](ch-07-01-isis-timers.md)
 
 ## SRv6
 

--- a/book/src/ch-07-00-isis.md
+++ b/book/src/ch-07-00-isis.md
@@ -1,0 +1,18 @@
+# IS-IS — Intermediate System to Intermediate System
+
+IS-IS (ISO 10589, RFC 1195) is a link-state interior gateway protocol
+operating directly over the data link layer (no IP transport). It
+flood-distributes Link State PDUs (LSPs) describing each router's
+local adjacencies and reachability, and each router independently
+runs Dijkstra over the resulting database to compute paths.
+
+zebra-rs implements IS-IS with the dual-level area model (L1 intra-
+area, L2 inter-area, L1L2 routers participating in both), wire-format
+parity with reference IOS-XR / FRR implementations, multi-topology
+extensions for IPv6 (RFC 5120, MT 2), Segment Routing extensions for
+MPLS and SRv6, and post-convergence Topology-Independent LFA repair
+paths (TI-LFA, RFC 9490).
+
+This section documents operational tuning surfaces. See `router isis`
+under `/router/isis` in the YANG schema for the full configuration
+tree.

--- a/book/src/ch-07-01-isis-timers.md
+++ b/book/src/ch-07-01-isis-timers.md
@@ -1,0 +1,396 @@
+# IS-IS Timer Configuration
+
+IS-IS behaviour is governed by a set of timers that control adjacency
+liveness, database synchronization, self-LSP origination rhythm, and
+convergence speed. This chapter documents each timer zebra-rs exposes,
+its default, the semantics it carries on the wire or inside the local
+state machine, and the operational considerations behind tuning it.
+
+All timer configuration lives under the IS-IS instance:
+
+```
+router isis
+  timers
+    ...
+  spf-interval
+    ...
+  interface <name>
+    hello
+      ...
+    csnp-interval ...
+    psnp-interval ...
+```
+
+Defaults are chosen to match Cisco IOS-XR where the semantics align,
+so configurations written against IOS-XR's `router isis` model carry
+across without surprise.
+
+## Adjacency timers — hello-interval and hello-multiplier
+
+Every active IS-IS interface periodically emits Intermediate-System
+Hello (IIH) PDUs to discover and maintain neighbours. Each hello
+carries a `holdingTime` field telling the receiver how long to keep
+the adjacency alive if no further hello is heard.
+
+zebra-rs follows the IOS-XR / RFC model: the operator sets the **hello
+interval** (how often we send) and the **hello multiplier** (how many
+intervals worth of silence before the receiver declares us dead).
+The hold time advertised on the wire is the product:
+
+```
+hold_time = hello_interval × hello_multiplier
+```
+
+| YANG leaf | Default | Range | Units |
+|---|---|---|---|
+| `/router/isis/interface/<n>/hello/interval` | 3 | 1..65535 | seconds |
+| `/router/isis/interface/<n>/hello/multiplier` | 10 | 2..1000 | (count) |
+
+With the defaults, a router emits a hello every 3 seconds and
+advertises a 30-second hold time. The multiplier default of 10 (rather
+than IOS-XR's 3) compensates for the shorter default hello interval
+(3 s versus IOS-XR's 10 s) — the resulting 30-second hold matches
+the conservative end of common deployments.
+
+**Live application.** When either value changes via configuration,
+zebra-rs sends `HelloOriginate` for each active level on the
+interface. This re-emits a fresh hello PDU (so the new `holdingTime`
+hits the wire immediately) and re-arms the periodic timer (so the
+new interval takes effect without an adjacency reset).
+
+**Tuning trade-offs.**
+
+- Lowering the interval shortens failure-detection time at the cost
+  of more hello traffic and CPU.
+- Raising the multiplier without changing the interval makes the
+  hello protocol more tolerant of single-packet loss on lossy links
+  without changing how often hellos are sent.
+- The product (hold time) is what the wire sees; a peer with a
+  10-second hello and multiplier 3 expects a 30-second hold from us
+  regardless of how we got there.
+- Sub-second adjacency detection is typically delegated to BFD rather
+  than aggressive hello tuning.
+
+The hold-time multiplication saturates at `u16::MAX` (the on-wire
+field's range). Extreme values (e.g. interval 65535 × multiplier 1000)
+clamp rather than overflow.
+
+## Hello padding
+
+Hello PDUs are normally padded to the interface MTU so adjacency
+formation can detect MTU mismatches early (a too-large hello won't
+fit through a smaller-MTU peer and the adjacency never comes up,
+which is the desired behaviour — silent black-holing of larger
+packets later is far worse).
+
+| YANG leaf | Default | Values |
+|---|---|---|
+| `/router/isis/interface/<n>/hello/padding` | `always` | `always`, `disable` |
+
+`disable` skips padding entirely. Operationally useful only when
+intentionally hiding an MTU mismatch (very rare) or to save a small
+amount of bandwidth on extremely high-fanout broadcast LANs.
+
+## Database synchronization — CSNP and PSNP intervals
+
+On broadcast LANs the Designated Intermediate System (DIS) periodically
+emits a Complete Sequence Number PDU (CSNP) summarising every LSP it
+holds. Receivers compare the summary against their own LSDB and use
+Partial Sequence Number PDUs (PSNPs) either to acknowledge already-held
+LSPs or to request missing ones. On point-to-point links PSNPs serve
+as the explicit per-LSP acknowledgement.
+
+| YANG leaf | Default | Range | Units | Scope |
+|---|---|---|---|---|
+| `/router/isis/interface/<n>/csnp-interval` | 10 | 1..65535 | seconds | broadcast DIS only |
+| `/router/isis/interface/<n>/psnp-interval` | 2 | 1..65535 | seconds | per-interface |
+
+These are best left at default. Stretching `csnp-interval` reduces
+periodic LAN overhead but slows recovery of lost LSPs on the segment;
+shortening it does the opposite.
+
+**Live application.** Changes apply on the next timer cycle — CSNP
+runs only on the DIS and PSNP only while there are pending
+acknowledgements, so recreating timers on the fly would mean
+cancelling whatever is currently armed for little benefit over
+waiting one cycle.
+
+## LSP refresh interval and maximum LSP lifetime
+
+Each self-originated LSP carries a `RemainingLifetime` field counting
+down from the maximum lifetime. Routers refresh their own LSPs (bump
+the sequence number, reset the lifetime, re-flood) on a periodic
+timer that fires before the lifetime would expire on receivers'
+LSDBs.
+
+| YANG leaf | Default | Range | Units |
+|---|---|---|---|
+| `/router/isis/timers/lsp-refresh-interval` | 900 | 1..65535 | seconds |
+| `/router/isis/timers/hold-time` (max LSP lifetime) | 1200 | — | seconds |
+
+The naming carries some history. zebra-rs calls the **maximum LSP
+lifetime** `hold-time` for the instance-level YANG leaf; IOS-XR's
+equivalent command is `max-lsp-lifetime`. Both control the same
+value: the `RemainingLifetime` we put on the wire when we originate
+or refresh a self-LSP, which receivers count down toward zero.
+
+**Invariant.** The refresh interval must be strictly less than the
+maximum lifetime, with enough margin for one refresh round-trip plus
+the LSP-zero-age window (60 s) — otherwise our own LSP can age out
+on a peer before our refresh reaches them. zebra-rs enforces this in
+`insert_self_originate`: the actual scheduled refresh is
+
+```
+min(config.refresh_time, lsp.hold_time − 65 s)
+```
+
+where the 65-second safety margin combines the ISO 10589 zero-age
+lifetime (60 s) and the minimum LSP transmission interval (5 s). If
+you shorten `hold-time` aggressively without lowering
+`lsp-refresh-interval`, this clamp keeps the refresh timer from
+running too late.
+
+**Tuning trade-offs.**
+
+- Raising both `lsp-refresh-interval` and `hold-time` (e.g. 65000 s
+  each) reduces background LSP flooding and CPU on very stable
+  networks; the trade-off is that stuck routers take longer to age
+  out of the database after an ungraceful exit.
+- Lowering refresh / lifetime accelerates LSDB cleanup at the cost
+  of more flooding traffic.
+
+## min-lsp-arrival-time — storm protection on the receive side
+
+When a peer's LSP arrives with a higher sequence number than the
+copy in our LSDB, we install the new version and re-flood. Without
+a rate limit a misbehaving neighbour (or a flapping path) can drive
+arbitrarily fast LSDB churn and SPF reschedules.
+
+`min-lsp-arrival-time` is a per-LSP receive-side floor: if a new
+version of an LSP we already have arrives within the configured
+window after the last accepted version of *the same LSP ID*, we
+drop the new copy.
+
+| YANG leaf | Default | Range | Units |
+|---|---|---|---|
+| `/router/isis/timers/min-lsp-arrival-time` | 100 | 1..600000 | milliseconds |
+
+Drop matrix:
+
+| Incoming LSP situation | Action |
+|---|---|
+| First time we see this LSP ID | Accept |
+| Higher seq number, outside window | Accept, refresh per-LSP timestamp |
+| Higher seq number, inside window | **Drop** (storm protection) |
+| Same or smaller seq number | Drop (RFC 1195 standard rule) |
+| Self-originated LSP (insert path) | Window not consulted |
+
+The window is checked per-LSP-ID, not per-sender, so it does not
+penalise legitimately fast updates to *different* LSPs during the
+same burst. Default matches IOS-XR; values much below 50 ms defeat
+the purpose, values above a few hundred milliseconds risk masking
+genuinely fast topology changes.
+
+## LSP generation throttle — lsp-gen-interval
+
+Many control-plane events ask us to re-originate our own LSP: a
+neighbour adjacency comes up, a per-link metric changes, a prefix
+gets added to the redistribution set, a peer floods our own LSP back
+at us with a higher sequence number. Without throttling, every
+event would trigger an immediate `lsp_generate` → `lsp_emit` →
+flood cycle, plus a peer-side SPF reschedule for every reflood.
+
+`lsp-gen-interval` applies the same exponential-backoff algorithm
+as `spf-interval` to LSP origination: events that arrive within the
+window are coalesced into a single regeneration. The seq-number
+floor across coalesced events is folded as `max(existing, new)`, so
+the resulting LSP bumps past the highest sequence any peer demanded
+during the burst.
+
+| YANG leaf | Default | Range | Units |
+|---|---|---|---|
+| `/router/isis/lsp-gen-interval/initial-wait` | 50 | 1..120000 | milliseconds |
+| `/router/isis/lsp-gen-interval/secondary-wait` | 5000 | 1..120000 | milliseconds |
+| `/router/isis/lsp-gen-interval/maximum-wait` | 5000 | 1..120000 | milliseconds |
+
+The IOS-XR-matching default (50 / 5000 / 5000) collapses the
+geometric ramp — secondary and maximum are equal, so after the
+initial 50 ms response the throttle jumps straight to 5 s spacing
+and stays there for the duration of the burst. This reflects the
+operational reality that self-LSP origination is expensive (every
+regen causes a network-wide reflood and peer-side SPF) and operators
+generally prefer conservative spacing once a burst is in progress.
+
+The internal machinery follows the same shape as the SPF throttle:
+`Isis::lsp_gen_timer: Levels<Option<Timer>>`,
+`Isis::lsp_gen_throttle: Levels<Throttle>`, and
+`Isis::lsp_gen_pending_floor: Levels<Option<u32>>` for the
+accumulated floor. `LspOriginate` is the front-door message;
+`LspGenFire` is the internal "throttle fired, run the work" event.
+Both share the generic `Throttle` type defined in
+`isis/throttle.rs` (also used by SPF).
+
+## SPF throttle — spf-interval
+
+zebra-rs schedules SPF after any LSDB change that could affect the
+shortest-path tree, but coalesces multiple changes that arrive in
+quick succession so a single SPF run absorbs a whole topology event.
+The coalescing window is governed by the IOS-XR-style exponential
+backoff algorithm.
+
+| YANG leaf | Default | Range | Units |
+|---|---|---|---|
+| `/router/isis/spf-interval/initial-wait` | 50 | 1..120000 | milliseconds |
+| `/router/isis/spf-interval/secondary-wait` | 200 | 1..120000 | milliseconds |
+| `/router/isis/spf-interval/maximum-wait` | 5000 | 1..120000 | milliseconds |
+
+### Algorithm
+
+The algorithm is best understood as a state machine carrying two
+per-level variables: `current_wait_ms` (the wait planned for the
+next scheduling event during this burst) and `last_run_at` (the
+timestamp of the last SPF completion).
+
+On every `spf_schedule()` event:
+
+1. If a timer is already armed, return — the in-flight SPF will
+   absorb this event.
+2. Otherwise, decide the wait:
+   - If `last_run_at` is `None` (first SPF ever), or
+     `now − last_run_at > 2 × maximum-wait` (quiescent period
+     elapsed) — reset and use `initial-wait`.
+   - Otherwise — use `current_wait_ms` (carried forward from the
+     prior event during the same burst).
+3. Plan the next wait for any subsequent event during this burst:
+   - If we just used `initial-wait`, plan `min(secondary-wait,
+     maximum-wait)` next.
+   - Otherwise, plan `min(current × 2, maximum-wait)` next
+     (saturating multiply).
+4. Arm a one-shot timer with the chosen wait. When it fires, SPF
+   runs; on completion the SPF handler stamps `last_run_at = now`
+   and clears the timer slot.
+
+### Worked example with defaults (50 / 200 / 5000)
+
+```
+t=0       topology change → wait 50 ms (initial)
+t=50      SPF runs, last_run_at=50, next planned=200
+t=70      another change → wait 200 ms (still in burst)
+t=270     SPF runs, last_run_at=270, next planned=400
+t=300     another change → wait 400 ms
+t=700     SPF runs, last_run_at=700, next planned=800
+...
+                          ... doubles until 5000 cap ...
+t+10s     no events for 10 s ( > 2 × 5000 = 10000 ms threshold )
+t+10s+1   topology change → wait 50 ms (quiet, reset)
+```
+
+### Tuning trade-offs
+
+- **Lowering `initial-wait`** makes isolated changes converge faster
+  but increases the chance of running SPF twice for what could have
+  been one coalesced run.
+- **Raising `maximum-wait`** strengthens storm dampening but extends
+  the worst-case time-to-converge during sustained churn. Default
+  5 s is the IOS-XR baseline; very stable networks can raise it to
+  10 s or more for better CPU economy.
+- **Raising `secondary-wait` close to `maximum-wait`** (e.g. setting
+  both to 5000 ms) effectively disables the geometric ramp and
+  jumps straight from `initial` to `maximum` after the first burst
+  event — useful when SPF is genuinely expensive and the operator
+  prefers conservative spacing throughout the burst.
+
+### Per-level state
+
+The throttle is independent per level: an event on L1 doesn't
+influence L2's wait time and vice versa. The configuration leaves
+are currently global (apply to both levels); per-level YANG
+qualifiers can be added later if a deployment needs them.
+
+## Summary — default-value reference
+
+| Knob | Default | Scope |
+|---|---|---|
+| hello interval | 3 s | per-interface |
+| hello multiplier | 10 | per-interface |
+| hello padding | always | per-interface |
+| csnp-interval | 10 s | per-interface |
+| psnp-interval | 2 s | per-interface |
+| lsp-refresh-interval | 900 s | instance |
+| hold-time (max LSP lifetime) | 1200 s | instance |
+| min-lsp-arrival-time | 100 ms | instance |
+| spf-interval initial-wait | 50 ms | instance |
+| spf-interval secondary-wait | 200 ms | instance |
+| spf-interval maximum-wait | 5000 ms | instance |
+| lsp-gen-interval initial-wait | 50 ms | instance |
+| lsp-gen-interval secondary-wait | 5000 ms | instance |
+| lsp-gen-interval maximum-wait | 5000 ms | instance |
+
+## Example configurations
+
+### Conservative, low-churn deployment
+
+```
+router isis
+  timers
+    lsp-refresh-interval 1800
+    hold-time 7200
+    min-lsp-arrival-time 200
+  spf-interval
+    initial-wait 200
+    secondary-wait 1000
+    maximum-wait 10000
+  interface eth0
+    hello
+      interval 10
+      multiplier 3
+    csnp-interval 30
+```
+
+Wider hello intervals and longer hold time reduce control-plane
+chatter on a network that rarely changes; SPF backs off more
+aggressively under any disturbance.
+
+### Aggressive, fast-convergence deployment
+
+```
+router isis
+  timers
+    min-lsp-arrival-time 50
+  spf-interval
+    initial-wait 20
+    secondary-wait 100
+    maximum-wait 1000
+  interface eth0
+    hello
+      interval 1
+      multiplier 3
+```
+
+Sub-second hello / 3-second hold and a 20 ms initial SPF wait
+prioritise convergence at the cost of additional control-plane
+traffic and CPU. For sub-second adjacency detection in production,
+prefer BFD over aggressive hellos.
+
+## Cross-reference — IOS-XR command mapping
+
+| zebra-rs YANG | IOS-XR command |
+|---|---|
+| `timers/lsp-refresh-interval` | `lsp-refresh-interval` |
+| `timers/hold-time` | `max-lsp-lifetime` |
+| `timers/min-lsp-arrival-time` | `min-lsp-arrival-time` |
+| `spf-interval/{initial,secondary,maximum}-wait` | `spf-interval initial-wait … secondary-wait … maximum-wait …` |
+| `lsp-gen-interval/{initial,secondary,maximum}-wait` | `lsp-gen-interval initial-wait … secondary-wait … maximum-wait …` |
+| `interface/<n>/hello/interval` | `isis hello-interval` (interface) |
+| `interface/<n>/hello/multiplier` | `isis hello-multiplier` (interface) |
+| `interface/<n>/hello/padding` | `isis hello-padding` (interface) |
+| `interface/<n>/csnp-interval` | `isis csnp-interval` (interface) |
+| `interface/<n>/psnp-interval` | `isis retransmit-interval`-adjacent (no exact IOS-XR equivalent — PSNP ack pacing) |
+
+Gaps relative to IOS-XR that zebra-rs does not yet implement:
+`prc-interval` (no partial route calculation distinct from full
+SPF), `lsp-interval` (LSP send pacing), `retransmit-interval` /
+`retransmit-throttle-interval` (no periodic LSP retransmit-until-ack
+on point-to-point), `lsp-mtu` (no LSP fragmentation yet),
+`adjacency-stagger`, and BFD client integration for IS-IS
+adjacencies.

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -75,6 +75,18 @@ impl Isis {
             "/router/isis/spf-interval/maximum-wait",
             config_spf_maximum_wait,
         );
+        self.callback_add(
+            "/router/isis/lsp-gen-interval/initial-wait",
+            config_lsp_gen_initial_wait,
+        );
+        self.callback_add(
+            "/router/isis/lsp-gen-interval/secondary-wait",
+            config_lsp_gen_secondary_wait,
+        );
+        self.callback_add(
+            "/router/isis/lsp-gen-interval/maximum-wait",
+            config_lsp_gen_maximum_wait,
+        );
         self.callback_add("/router/isis/te-router-id", config_te_router_id);
         self.callback_add("/router/isis/segment-routing/mpls", config_sr_mpls_enable);
         self.callback_add(
@@ -165,6 +177,9 @@ pub struct IsisConfig {
     pub spf_initial_wait: Option<u32>,
     pub spf_secondary_wait: Option<u32>,
     pub spf_maximum_wait: Option<u32>,
+    pub lsp_gen_initial_wait: Option<u32>,
+    pub lsp_gen_secondary_wait: Option<u32>,
+    pub lsp_gen_maximum_wait: Option<u32>,
     pub te_router_id: Option<Ipv4Addr>,
     pub rib_router_id: Option<Ipv4Addr>,
     pub enable: Afis<usize>,
@@ -228,6 +243,12 @@ impl IsisConfig {
     const DEFAULT_SPF_INITIAL_WAIT_MS: u32 = 50;
     const DEFAULT_SPF_SECONDARY_WAIT_MS: u32 = 200;
     const DEFAULT_SPF_MAXIMUM_WAIT_MS: u32 = 5000;
+    // IOS-XR-style LSP-generation exponential-backoff defaults
+    // (milliseconds). IOS-XR's defaults are 50 ms / 5000 ms / 5000 ms —
+    // a long maximum keeps self-LSP origination spaced out under churn.
+    const DEFAULT_LSP_GEN_INITIAL_WAIT_MS: u32 = 50;
+    const DEFAULT_LSP_GEN_SECONDARY_WAIT_MS: u32 = 5000;
+    const DEFAULT_LSP_GEN_MAXIMUM_WAIT_MS: u32 = 5000;
 
     pub fn is_type(&self) -> IsLevel {
         self.is_type.unwrap_or(IsLevel::L1L2)
@@ -273,6 +294,21 @@ impl IsisConfig {
     pub fn spf_maximum_wait(&self) -> u32 {
         self.spf_maximum_wait
             .unwrap_or(Self::DEFAULT_SPF_MAXIMUM_WAIT_MS)
+    }
+
+    pub fn lsp_gen_initial_wait(&self) -> u32 {
+        self.lsp_gen_initial_wait
+            .unwrap_or(Self::DEFAULT_LSP_GEN_INITIAL_WAIT_MS)
+    }
+
+    pub fn lsp_gen_secondary_wait(&self) -> u32 {
+        self.lsp_gen_secondary_wait
+            .unwrap_or(Self::DEFAULT_LSP_GEN_SECONDARY_WAIT_MS)
+    }
+
+    pub fn lsp_gen_maximum_wait(&self) -> u32 {
+        self.lsp_gen_maximum_wait
+            .unwrap_or(Self::DEFAULT_LSP_GEN_MAXIMUM_WAIT_MS)
     }
 
     /// True when either SR dataplane is enabled. Used to gate emission
@@ -391,6 +427,24 @@ fn config_spf_secondary_wait(isis: &mut Isis, mut args: Args, op: ConfigOp) -> O
 fn config_spf_maximum_wait(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     let ms = args.u32()?;
     isis.config.spf_maximum_wait = if op == ConfigOp::Set { Some(ms) } else { None };
+    Some(())
+}
+
+fn config_lsp_gen_initial_wait(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let ms = args.u32()?;
+    isis.config.lsp_gen_initial_wait = if op == ConfigOp::Set { Some(ms) } else { None };
+    Some(())
+}
+
+fn config_lsp_gen_secondary_wait(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let ms = args.u32()?;
+    isis.config.lsp_gen_secondary_wait = if op == ConfigOp::Set { Some(ms) } else { None };
+    Some(())
+}
+
+fn config_lsp_gen_maximum_wait(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let ms = args.u32()?;
+    isis.config.lsp_gen_maximum_wait = if op == ConfigOp::Set { Some(ms) } else { None };
     Some(())
 }
 

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -37,8 +37,9 @@ use super::lsp::{
     target_locator_name,
 };
 use super::nfsm::nbr_hold_timer_expire;
-use super::rib::{SpfIlm, SpfRoute, SpfRouteV6, SpfThrottle, perform_spf_calculation};
+use super::rib::{SpfIlm, SpfRoute, SpfRouteV6, perform_spf_calculation};
 use super::srmpls::IsisLabelMap;
+use super::throttle::Throttle;
 use super::{Hostname, IfsmEvent, Lsdb, LsdbEvent, NfsmEvent, csnp_send, srm_set_for_all_lsp};
 use super::{LabelPool, Level, Levels, process_packet};
 
@@ -87,7 +88,15 @@ pub struct Isis {
     pub ilm: Levels<BTreeMap<u32, SpfIlm>>,
     pub hostname: Levels<Hostname>,
     pub spf_timer: Levels<Option<Timer>>,
-    pub spf_throttle: Levels<SpfThrottle>,
+    pub spf_throttle: Levels<Throttle>,
+    /// LSP-gen coalescing slot. None means no run is currently pending;
+    /// Some(Timer) means a LspGenFire is armed and additional
+    /// LspOriginate events will fold into the same run.
+    pub lsp_gen_timer: Levels<Option<Timer>>,
+    pub lsp_gen_throttle: Levels<Throttle>,
+    /// Accumulated seq-number floor across coalesced LspOriginate
+    /// events. Reset to None after the throttled run consumes it.
+    pub lsp_gen_pending_floor: Levels<Option<u32>>,
     pub local_pool: Option<LabelPool>,
     pub graph: Levels<Option<spf::Graph>>,
     pub spf_result: Levels<Option<BTreeMap<usize, spf::Path>>>,
@@ -154,7 +163,7 @@ pub struct IsisTop<'a> {
     pub rib_tx: &'a UnboundedSender<rib::Message>,
     pub hostname: &'a mut Levels<Hostname>,
     pub spf_timer: &'a mut Levels<Option<Timer>>,
-    pub spf_throttle: &'a mut Levels<SpfThrottle>,
+    pub spf_throttle: &'a mut Levels<Throttle>,
     pub graph: &'a mut Levels<Option<spf::Graph>>,
     pub spf_result: &'a mut Levels<Option<BTreeMap<usize, spf::Path>>>,
     pub mt2_graph: &'a mut Levels<Option<spf::Graph>>,
@@ -217,7 +226,10 @@ impl Isis {
             ilm: Levels::<BTreeMap<u32, SpfIlm>>::default(),
             hostname: Levels::<Hostname>::default(),
             spf_timer: Levels::<Option<Timer>>::default(),
-            spf_throttle: Levels::<SpfThrottle>::default(),
+            spf_throttle: Levels::<Throttle>::default(),
+            lsp_gen_timer: Levels::<Option<Timer>>::default(),
+            lsp_gen_throttle: Levels::<Throttle>::default(),
+            lsp_gen_pending_floor: Levels::<Option<u32>>::default(),
             // Adjacency-SID label pool is owned by the SR-MPLS feature.
             // Stays None until `segment-routing mpls` is configured —
             // otherwise we'd allocate labels for every hello and emit
@@ -396,7 +408,16 @@ impl Isis {
                 let _ = process_packet(&mut top, packet, ifindex, mac);
             }
             Message::LspOriginate(level, floor) => {
+                self.schedule_lsp_originate(level, floor);
+            }
+            Message::LspGenFire(level) => {
+                // Pull the accumulated floor for the burst, run the
+                // origination, then stamp throttle completion and clear
+                // the timer slot so the next event can re-arm.
+                let floor = self.lsp_gen_pending_floor.get_mut(&level).take();
                 self.process_lsp_originate(level, floor);
+                self.lsp_gen_throttle.get_mut(&level).mark_run();
+                *self.lsp_gen_timer.get_mut(&level) = None;
             }
             Message::LspPurge(level, lsp_id) => {
                 self.process_lsp_purge(level, lsp_id);
@@ -411,7 +432,7 @@ impl Isis {
                 self.process_lsdb(ev, level, key);
             }
             Message::AdjacencyUp(level, ifindex) => {
-                self.process_lsp_originate(level, None);
+                self.schedule_lsp_originate(level, None);
 
                 let Some(mut link) = self.link_top(ifindex) else {
                     return;
@@ -452,6 +473,41 @@ impl Isis {
         insert_self_originate(&mut top, level, lsp, Some(buf.to_vec()));
 
         top.lsdb.get_mut(&level).srm_set_all(top.tx, level, &lsp_id);
+    }
+
+    /// Throttle-aware front door for self-LSP origination. Multiple
+    /// triggers (config edits, AdjacencyUp, peer-flooded-our-LSP-back)
+    /// arriving within the lsp-gen-interval window coalesce into a
+    /// single `process_lsp_originate` run. The seq-number floor is
+    /// folded across the burst as `max(existing, new)` so the
+    /// resulting LSP bumps past the highest seq any peer demanded.
+    fn schedule_lsp_originate(&mut self, level: Level, seq_floor: Option<u32>) {
+        // Fold this event's seq_floor into the burst-wide accumulator.
+        let pending = self.lsp_gen_pending_floor.get_mut(&level);
+        *pending = match (*pending, seq_floor) {
+            (Some(a), Some(b)) => Some(a.max(b)),
+            (Some(a), None) => Some(a),
+            (None, b) => b,
+        };
+
+        // Already armed — the in-flight run will consume the accumulator.
+        if self.lsp_gen_timer.get(&level).is_some() {
+            return;
+        }
+
+        let wait_ms = self.lsp_gen_throttle.get_mut(&level).schedule(
+            self.config.lsp_gen_initial_wait(),
+            self.config.lsp_gen_secondary_wait(),
+            self.config.lsp_gen_maximum_wait(),
+        );
+
+        let tx = self.tx.clone();
+        *self.lsp_gen_timer.get_mut(&level) = Some(Timer::once_ms(wait_ms as u64, move || {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send(Message::LspGenFire(level));
+            }
+        }));
     }
 
     fn process_lsp_purge(&mut self, level: Level, lsp_id: IsisLspId) {
@@ -864,6 +920,12 @@ pub enum Message {
     /// existing+1" — config edits, RIB router-id changes, link-state
     /// reactions all pass None.
     LspOriginate(Level, Option<u32>),
+    /// LSP generation throttle timer fired for `level`. Carries the
+    /// accumulated seq-number floor across all coalesced LspOriginate
+    /// events during the burst (max of all `floor` values seen).
+    /// Handler runs `process_lsp_originate(level, floor)`, stamps the
+    /// throttle, and clears the timer slot.
+    LspGenFire(Level),
     LspPurge(Level, IsisLspId),
     /// Re-originate the pseudonode LSP whose owner is the given
     /// `IsisNeighborId` (sys_id + pseudo_id). The handler resolves
@@ -903,6 +965,7 @@ impl Display for Message {
             Message::LspOriginate(level, floor) => {
                 write!(f, "[Message::LspOriginate({}, floor={:?})]", level, floor)
             }
+            Message::LspGenFire(level) => write!(f, "[Message::LspGenFire({})]", level),
             Message::LspPurge(level, lsp_id) => {
                 write!(f, "[Message::LspPurge({}, {})]", level, lsp_id)
             }

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -134,7 +134,7 @@ pub struct LinkTop<'a> {
     pub label_map: &'a mut Levels<IsisLabelMap>,
     pub srv6_end_map: &'a mut Levels<std::collections::BTreeMap<IsisSysId, std::net::Ipv6Addr>>,
     pub spf_timer: &'a mut Levels<Option<Timer>>,
-    pub spf_throttle: &'a mut Levels<super::rib::SpfThrottle>,
+    pub spf_throttle: &'a mut Levels<super::throttle::Throttle>,
 
     /// SR state needed for End.X (adjacency) SID allocation. Threaded
     /// through so packet handlers can carve a function from the ELIB

--- a/zebra-rs/src/isis/mod.rs
+++ b/zebra-rs/src/isis/mod.rs
@@ -54,3 +54,5 @@ pub mod tilfa;
 pub mod graph;
 
 pub mod rib;
+
+pub mod throttle;

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::{Ipv4Addr, Ipv6Addr};
-use std::time::Instant;
 
 use ipnet::{Ipv4Net, Ipv6Net};
 use isis_packet::*;
@@ -9,6 +8,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use super::config::IsisConfig;
 use super::level::Levels;
+use super::throttle::Throttle;
 use crate::context::Timer;
 use crate::rib::inst::{IlmEntry, IlmType};
 use crate::rib::{self, Nexthop, NexthopMulti, NexthopUni, RibType};
@@ -30,18 +30,6 @@ use super::tilfa::{
     first_router_hop_id, tilfa_repair_path,
 };
 
-/// Per-level state for the SPF exponential-backoff throttle.
-///
-/// `current_wait_ms` is the wait that will be used the NEXT time
-/// `spf_schedule` arms a timer during an ongoing burst. After a quiet
-/// period it gets reset to `initial-wait`; otherwise each scheduling
-/// event doubles it (capped at `maximum-wait`).
-#[derive(Default, Debug)]
-pub struct SpfThrottle {
-    pub current_wait_ms: u32,
-    pub last_run_at: Option<Instant>,
-}
-
 fn spf_timer_ms(tx: &UnboundedSender<Message>, level: Level, ms: u64) -> Timer {
     let tx = tx.clone();
     Timer::once_ms(ms, move || {
@@ -53,20 +41,9 @@ fn spf_timer_ms(tx: &UnboundedSender<Message>, level: Level, ms: u64) -> Timer {
     })
 }
 
-/// Arm the SPF timer for `level` if not already armed, honouring the
-/// IOS-XR-style exponential-backoff algorithm:
-///
-///   - First event after a quiet period > 2 × maximum-wait: use
-///     initial-wait.
-///   - Subsequent events during the burst: use the planned next wait
-///     (initial → secondary → secondary × 2 → ... capped at maximum).
-///
-/// The actual SPF run on timer expiry stamps `last_run_at` (see
-/// `perform_spf_calculation`) so future scheduling events can tell
-/// whether we're still in a burst.
 fn spf_schedule_inner(
     spf_timer: &mut Levels<Option<Timer>>,
-    spf_throttle: &mut Levels<SpfThrottle>,
+    spf_throttle: &mut Levels<Throttle>,
     tx: &UnboundedSender<Message>,
     config: &IsisConfig,
     level: Level,
@@ -75,30 +52,11 @@ fn spf_schedule_inner(
         return;
     }
 
-    let initial = config.spf_initial_wait();
-    let secondary = config.spf_secondary_wait();
-    let maximum = config.spf_maximum_wait();
-
-    let throttle = spf_throttle.get_mut(&level);
-    let now = Instant::now();
-    let quiet_threshold = std::time::Duration::from_millis(2u64 * maximum as u64);
-    let in_burst = throttle
-        .last_run_at
-        .is_some_and(|t| now.duration_since(t) < quiet_threshold);
-
-    let wait_ms = if in_burst {
-        throttle.current_wait_ms
-    } else {
-        initial
-    };
-
-    // Plan the NEXT wait used if another event arrives during the burst.
-    throttle.current_wait_ms = if wait_ms == initial {
-        secondary.min(maximum)
-    } else {
-        (wait_ms.saturating_mul(2)).min(maximum)
-    };
-
+    let wait_ms = spf_throttle.get_mut(&level).schedule(
+        config.spf_initial_wait(),
+        config.spf_secondary_wait(),
+        config.spf_maximum_wait(),
+    );
     *spf_timer.get_mut(&level) = Some(spf_timer_ms(tx, level, wait_ms as u64));
 }
 
@@ -978,7 +936,7 @@ pub(super) fn perform_spf_calculation(top: &mut IsisTop, level: Level) {
     *top.spf_timer.get_mut(&level) = None;
     // Stamp completion time so spf_schedule can tell whether the next
     // scheduling event lands inside or outside the burst window.
-    top.spf_throttle.get_mut(&level).last_run_at = Some(Instant::now());
+    top.spf_throttle.get_mut(&level).mark_run();
 
     // Legacy graph + SPF — drives IPv4 RIB and IPv6 in non-MT mode.
     let (graph, source_node, adjacency_sids) = graph(top, level);

--- a/zebra-rs/src/isis/throttle.rs
+++ b/zebra-rs/src/isis/throttle.rs
@@ -1,0 +1,48 @@
+use std::time::{Duration, Instant};
+
+/// IOS-XR-style exponential-backoff throttle state.
+///
+/// One instance per "rate-limited thing per level" (one for SPF per
+/// level, one for LSP generation per level, etc). The struct holds only
+/// the state — the caller owns the actual timer and the work — so the
+/// same algorithm can drive different schedulers without coupling them.
+///
+/// State machine: callers ask `schedule()` for the wait they should use
+/// to arm a timer. When the throttled work actually runs, they call
+/// `mark_run()`. Subsequent `schedule()` calls within `2 × maximum` of
+/// the last run return progressively-doubled waits — initial →
+/// secondary → secondary × 2 → ... capped at maximum. After a quiet
+/// period longer than `2 × maximum`, the next schedule resets to
+/// `initial`.
+#[derive(Default, Debug)]
+pub struct Throttle {
+    pub current_wait_ms: u32,
+    pub last_run_at: Option<Instant>,
+}
+
+impl Throttle {
+    pub fn schedule(&mut self, initial_ms: u32, secondary_ms: u32, maximum_ms: u32) -> u32 {
+        let quiet = Duration::from_millis(2u64 * maximum_ms as u64);
+        let in_burst = self
+            .last_run_at
+            .is_some_and(|t| Instant::now().duration_since(t) < quiet);
+
+        let wait_ms = if in_burst {
+            self.current_wait_ms
+        } else {
+            initial_ms
+        };
+
+        self.current_wait_ms = if wait_ms == initial_ms {
+            secondary_ms.min(maximum_ms)
+        } else {
+            wait_ms.saturating_mul(2).min(maximum_ms)
+        };
+
+        wait_ms
+    }
+
+    pub fn mark_run(&mut self) {
+        self.last_run_at = Some(Instant::now());
+    }
+}

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -482,6 +482,27 @@ module config {
           }
         }
 
+        container lsp-gen-interval {
+          leaf initial-wait {
+            type uint32 {
+              range "1..120000";
+            }
+            units "milliseconds";
+          }
+          leaf secondary-wait {
+            type uint32 {
+              range "1..120000";
+            }
+            units "milliseconds";
+          }
+          leaf maximum-wait {
+            type uint32 {
+              range "1..120000";
+            }
+            units "milliseconds";
+          }
+        }
+
         list interface {
           // Last item in "router isis" node.
           ext:sort "-10";


### PR DESCRIPTION
## Summary

Three things bundled because they are one logical step:

### 1. Extract `Throttle` to its own module (`zebra-rs/src/isis/throttle.rs`)

The IOS-XR exponential-backoff state machine landed inline in `rib.rs` with PR #570 as `SpfThrottle`. Move it to `isis/throttle.rs`, rename to the generic `Throttle`, and expose two methods:

```rust
pub fn schedule(&mut self, initial_ms: u32, secondary_ms: u32, maximum_ms: u32) -> u32;
pub fn mark_run(&mut self);
```

SPF callers switch to these methods; the local algorithm in `spf_schedule_inner` / `perform_spf_calculation` shrinks accordingly.

### 2. Apply the same throttle to LSP origination (`lsp-gen-interval`)

Three new per-level fields on `Isis`: `lsp_gen_timer` (armed/not), `lsp_gen_throttle` (`Throttle` state), `lsp_gen_pending_floor` (accumulated seq-number floor across coalesced events).

**`Message::LspOriginate`** now routes through a new `schedule_lsp_originate(level, floor)` front door:
- Fold this event's floor into the burst-wide accumulator as `max(existing, new)` so a peer-flooded-our-LSP-back event (which carries `Some(seq)`) is not lost behind `None` events
- If a timer is already armed, return; the in-flight run absorbs this event
- Otherwise compute `wait_ms = throttle.schedule(initial, secondary, maximum)` and arm a one-shot timer that fires `Message::LspGenFire(level)`

**`Message::LspGenFire`** (new variant) is the throttled run: `take()` the accumulated floor, call `process_lsp_originate` with it, `throttle.mark_run()`, clear the timer slot.

**`Message::AdjacencyUp`** switches from a direct `process_lsp_originate(level, None)` to the throttle-aware `schedule_lsp_originate(level, None)` so back-to-back adjacency bring-ups coalesce.

**YANG** (`/router/isis/lsp-gen-interval/`):
- `initial-wait` (uint32 ms, 1..120000)
- `secondary-wait` (uint32 ms, 1..120000)
- `maximum-wait` (uint32 ms, 1..120000)

**Defaults match IOS-XR: 50 / 5000 / 5000 ms.** The collapsed `secondary == maximum` form jumps straight from the snappy 50 ms first response to 5 s spacing for the rest of the burst — matches operational preference (self-LSP regen causes a network-wide reflood + peer SPF, so conservative spacing is desirable once a burst is in progress).

### 3. Document the full IS-IS timer surface (`book/`)

New chapters under "Routing Protocols":
- `book/src/ch-07-00-isis.md` — section intro
- `book/src/ch-07-01-isis-timers.md` — every timer this PR series exposed (hello interval/multiplier/padding, csnp/psnp, refresh/max-lifetime, min-lsp-arrival-time, spf-interval, the new lsp-gen-interval), with defaults table, worked SPF backoff example, two example configs, and an IOS-XR command-mapping table that also names the gaps zebra-rs still has

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo clippy -p zebra-rs --all-targets` clean
- [x] `cargo fmt -p zebra-rs --check` clean
- [x] `cargo test -p zebra-rs` — all 356 tests pass
- [x] `mdbook build` clean (no broken refs in SUMMARY.md)
- [ ] Smoke test: configure short `lsp-gen-interval/maximum-wait` (e.g. 500 ms), trigger a burst of config edits, verify only one fresh self-LSP is emitted per coalesced burst (debug log via `LspGenFire` trace)
- [ ] Smoke test: under default 50/5000/5000, time the gap between an isolated config edit and the next emitted self-LSP — expect ~50 ms

Generated with [Claude Code](https://claude.com/claude-code)