### PR TITLE
bfd: client subscription API (PR 5a of 10)

### DIFF
--- a/zebra-rs/src/bfd/config.rs
+++ b/zebra-rs/src/bfd/config.rs
@@ -323,7 +323,6 @@ mod tests {
         Bfd::new_with(
             Context::default(),
             SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0),
-            None,
         )
         .expect("bind loopback")
     }

--- a/zebra-rs/src/bfd/inst.rs
+++ b/zebra-rs/src/bfd/inst.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
 use std::sync::Arc;
 
@@ -15,12 +15,20 @@ use super::session::{Session, SessionKey, SessionParams, SessionTable, StateChan
 use super::socket::{BFD_SINGLE_HOP_PORT, bfd_socket_ipv4};
 use super::timer::{InitialParams, TimerCmd, session_timer};
 
+/// Identifier for a BFD subscriber. Conventionally the proto name
+/// ("bgp", "ospf", "isis", "static"), plus an optional disambiguator
+/// when one process registers more than one logical client per
+/// session (rare in Phase 1).
+pub type ClientId = String;
+
 /// Top-level BFD instance. Owns the IPv4 single-hop UDP socket, the
-/// session table, the committed YANG config mirror, and a
-/// per-session timer handle map. Read and write tasks are
-/// tokio-spawned at construction and feed the event loop via
-/// `main_tx` / `write_tx`. The config-manager subscription drains
-/// through `cm.rx`.
+/// session table, the committed YANG config mirror, a per-session
+/// timer handle map, and the client-subscription registry. Read and
+/// write tasks are tokio-spawned at construction and feed the event
+/// loop via `main_tx` / `write_tx`. The config-manager subscription
+/// drains through `cm.rx`, and external clients (BGP / OSPF / IS-IS
+/// / static) submit subscribe/unsubscribe requests through
+/// `client_req.rx`.
 pub struct Bfd {
     pub rx: UnboundedReceiver<Message>,
     pub sessions: SessionTable,
@@ -37,10 +45,62 @@ pub struct Bfd {
     /// Config-manager subscription endpoints (the receive half drains
     /// in the event loop).
     pub cm: ConfigChannel,
+    /// Inbound client request channel — protocol modules send
+    /// `ClientReq::Subscribe` / `Unsubscribe` here to attach to BFD
+    /// sessions. Clones of the sender half are distributed via
+    /// `client_req.tx.clone()` (cf. [`Self::client_req_tx`]).
+    pub client_req: ClientReqChannel,
+    /// Per-session subscriber registry. The hot demux path uses this
+    /// to fan state-change events out to every interested client.
+    /// Empty for a session means no client is waiting — the session
+    /// is torn down as soon as the last subscriber leaves
+    /// ([`Self::unsubscribe`]).
+    subscribers: HashMap<SessionKey, BTreeMap<ClientId, UnboundedSender<BfdEvent>>>,
     main_tx: UnboundedSender<Message>,
     write_tx: UnboundedSender<WriteRequest>,
     timer_handles: HashMap<SessionKey, TimerHandle>,
-    notify_tx: Option<UnboundedSender<BfdEvent>>,
+}
+
+/// Sender/receiver pair for the inbound client-request channel.
+/// Modelled on [`crate::config::ConfigChannel`] so cloning the sender
+/// for distribution to other protocols is the obvious idiom.
+#[derive(Debug)]
+pub struct ClientReqChannel {
+    pub tx: UnboundedSender<ClientReq>,
+    pub rx: UnboundedReceiver<ClientReq>,
+}
+
+impl ClientReqChannel {
+    pub fn new() -> Self {
+        let (tx, rx) = mpsc::unbounded_channel();
+        Self { tx, rx }
+    }
+}
+
+impl Default for ClientReqChannel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Requests sent to the BFD instance by external clients (BGP / OSPF
+/// / IS-IS / static) that want to attach to a BFD session.
+#[derive(Debug)]
+pub enum ClientReq {
+    /// Register interest in `key`. If no session yet exists for that
+    /// key, BFD creates one using `params`; otherwise `params` is
+    /// ignored and the existing session is reused. State-change
+    /// events for the session are forwarded to `notifier` until the
+    /// matching [`ClientReq::Unsubscribe`] arrives.
+    Subscribe {
+        client: ClientId,
+        key: SessionKey,
+        params: SessionParams,
+        notifier: UnboundedSender<BfdEvent>,
+    },
+    /// Drop `client`'s interest in `key`. When the last subscriber
+    /// unsubscribes, BFD tears the session down.
+    Unsubscribe { client: ClientId, key: SessionKey },
 }
 
 /// Holds the per-session timer task and its command channel. Dropping
@@ -78,25 +138,20 @@ pub enum BfdEvent {
 }
 
 impl Bfd {
-    /// Production constructor — binds to `0.0.0.0:3784` and emits no
-    /// `BfdEvent` notifications.
+    /// Production constructor — binds to `0.0.0.0:3784`.
     pub fn new(ctx: Context) -> std::io::Result<Self> {
         Self::new_with(
             ctx,
             SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, BFD_SINGLE_HOP_PORT),
-            None,
         )
     }
 
     /// Explicit constructor that lets the caller pick the bind
     /// address (used by the integration test to run two instances on
-    /// loopback ephemeral ports) and supply an optional [`BfdEvent`]
-    /// notifier.
-    pub fn new_with(
-        _ctx: Context,
-        bind: SocketAddrV4,
-        notify_tx: Option<UnboundedSender<BfdEvent>>,
-    ) -> std::io::Result<Self> {
+    /// loopback ephemeral ports). Client event notifications go
+    /// through the [`Self::client_req`] channel — see
+    /// [`Self::client_req_tx`] for the standard distribution path.
+    pub fn new_with(_ctx: Context, bind: SocketAddrV4) -> std::io::Result<Self> {
         let sock = bfd_socket_ipv4(bind)?;
         let local_addr = sock
             .local_addr()?
@@ -125,13 +180,91 @@ impl Bfd {
             config: BfdConfig::default(),
             callbacks: HashMap::new(),
             cm: ConfigChannel::new(),
+            client_req: ClientReqChannel::new(),
+            subscribers: HashMap::new(),
             main_tx,
             write_tx,
             timer_handles: HashMap::new(),
-            notify_tx,
         };
         bfd.callback_build();
         Ok(bfd)
+    }
+
+    /// Clone the inbound client-request sender. Distribute this to
+    /// other protocols (BGP / OSPF / IS-IS / static) so they can
+    /// submit [`ClientReq::Subscribe`] / [`ClientReq::Unsubscribe`]
+    /// after both BFD and the caller have been served.
+    pub fn client_req_tx(&self) -> UnboundedSender<ClientReq> {
+        self.client_req.tx.clone()
+    }
+
+    /// Apply a [`ClientReq`]. Public so pre-`serve` callers (notably
+    /// the integration test) can drive the API directly without going
+    /// through the channel; production callers go through
+    /// `client_req_tx`.
+    pub fn process_client_req(&mut self, req: ClientReq) {
+        match req {
+            ClientReq::Subscribe {
+                client,
+                key,
+                params,
+                notifier,
+            } => self.subscribe(client, key, params, notifier),
+            ClientReq::Unsubscribe { client, key } => self.unsubscribe(&client, &key),
+        }
+    }
+
+    /// Add `client` as a subscriber on `key`. Creates the underlying
+    /// session if it does not yet exist (otherwise `params` is
+    /// ignored and the existing session is reused). If the session is
+    /// already Up, the new subscriber is informed via an immediate
+    /// synthetic [`BfdEvent::StateChange`].
+    pub fn subscribe(
+        &mut self,
+        client: ClientId,
+        key: SessionKey,
+        params: SessionParams,
+        notifier: UnboundedSender<BfdEvent>,
+    ) {
+        // Lazy create the session on the first subscriber. Subsequent
+        // subscribers reuse the existing session — their `params` are
+        // ignored on the assumption that the BFD config is the
+        // authoritative source of truth.
+        if self.sessions.get_by_key(&key).is_none() {
+            self.add_session(key, params);
+        }
+        // Mirror the current state to the new subscriber so it can
+        // act on already-Up sessions without waiting for the next
+        // transition.
+        if let Some(session) = self.sessions.get_by_key(&key) {
+            let _ = notifier.send(BfdEvent::StateChange {
+                key,
+                change: StateChange {
+                    from: session.local_state,
+                    to: session.local_state,
+                    diag: session.local_diag,
+                },
+            });
+        }
+        self.subscribers
+            .entry(key)
+            .or_default()
+            .insert(client, notifier);
+    }
+
+    /// Drop `client`'s subscription on `key`. Tears down the
+    /// underlying session if this was the last subscriber.
+    pub fn unsubscribe(&mut self, client: &str, key: &SessionKey) {
+        let now_empty = if let Some(subs) = self.subscribers.get_mut(key) {
+            subs.remove(client);
+            subs.is_empty()
+        } else {
+            return;
+        };
+        if now_empty {
+            self.subscribers.remove(key);
+            self.remove_session(key);
+        }
     }
 
     /// Dispatch a single committed config request through the
@@ -190,6 +323,9 @@ impl Bfd {
                 },
                 Some(msg) = self.cm.rx.recv() => {
                     self.process_cm_msg(msg);
+                }
+                Some(req) = self.client_req.rx.recv() => {
+                    self.process_client_req(req);
                 }
             }
         }
@@ -300,8 +436,10 @@ impl Bfd {
             diag = %change.diag,
             "bfd: session state change",
         );
-        if let Some(tx) = &self.notify_tx {
-            let _ = tx.send(BfdEvent::StateChange { key, change });
+        if let Some(subs) = self.subscribers.get(&key) {
+            for tx in subs.values() {
+                let _ = tx.send(BfdEvent::StateChange { key, change });
+            }
         }
     }
 }
@@ -313,4 +451,165 @@ pub fn serve(mut bfd: Bfd) -> Task<()> {
     Task::spawn(async move {
         bfd.event_loop().await;
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh_bfd() -> Bfd {
+        Bfd::new_with(
+            Context::default(),
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0),
+        )
+        .expect("bind loopback")
+    }
+
+    fn loopback_key(remote_octet: u8) -> SessionKey {
+        SessionKey {
+            local: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            remote: IpAddr::V4(Ipv4Addr::new(127, 0, 0, remote_octet)),
+            ifindex: 0,
+            multihop: false,
+        }
+    }
+
+    /// Single-client subscribe creates the underlying session and
+    /// fires an immediate StateChange (Down→Down) so the client can
+    /// observe the starting state without waiting for a transition.
+    #[tokio::test]
+    async fn subscribe_creates_session_and_notifies() {
+        let mut bfd = fresh_bfd();
+        let key = loopback_key(2);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        bfd.subscribe("test".into(), key, SessionParams::default(), tx);
+        assert!(bfd.sessions.get_by_key(&key).is_some());
+
+        let event = rx.try_recv().expect("immediate state event");
+        let BfdEvent::StateChange { change, .. } = event;
+        assert_eq!(change.from, bfd_packet::State::Down);
+        assert_eq!(change.to, bfd_packet::State::Down);
+    }
+
+    /// Two clients on the same key share one session; neither
+    /// observes an extra session creation.
+    #[tokio::test]
+    async fn two_clients_share_one_session() {
+        let mut bfd = fresh_bfd();
+        let key = loopback_key(3);
+
+        let (tx_a, _rx_a) = mpsc::unbounded_channel();
+        let (tx_b, _rx_b) = mpsc::unbounded_channel();
+        bfd.subscribe("bgp".into(), key, SessionParams::default(), tx_a);
+        bfd.subscribe("ospf".into(), key, SessionParams::default(), tx_b);
+
+        assert_eq!(bfd.sessions.len(), 1, "subscribers share one session");
+        assert_eq!(
+            bfd.subscribers
+                .get(&key)
+                .map(BTreeMap::len)
+                .unwrap_or_default(),
+            2,
+        );
+    }
+
+    /// Both subscribers observe a synthetic state-change notification
+    /// when the FSM transitions — exercises the broadcast path.
+    #[tokio::test]
+    async fn broadcast_reaches_every_subscriber() {
+        let mut bfd = fresh_bfd();
+        let key = loopback_key(4);
+        let (tx_a, mut rx_a) = mpsc::unbounded_channel();
+        let (tx_b, mut rx_b) = mpsc::unbounded_channel();
+
+        bfd.subscribe("a".into(), key, SessionParams::default(), tx_a);
+        bfd.subscribe("b".into(), key, SessionParams::default(), tx_b);
+
+        // Drain the initial Down→Down event from both subscribers.
+        let _ = rx_a.recv().await;
+        let _ = rx_b.recv().await;
+
+        // Synthesize a transition by feeding handle_event directly.
+        let change = bfd
+            .sessions
+            .get_by_key_mut(&key)
+            .unwrap()
+            .handle_event(super::super::fsm::Event::Rx {
+                remote_state: bfd_packet::State::Down,
+            })
+            .expect("Down + Rx Down → Init");
+        bfd.notify_state_change(key, change);
+
+        let got_a = rx_a.recv().await.expect("a sees Init");
+        let got_b = rx_b.recv().await.expect("b sees Init");
+        let BfdEvent::StateChange { change: a, .. } = got_a;
+        let BfdEvent::StateChange { change: b, .. } = got_b;
+        assert_eq!(a.to, bfd_packet::State::Init);
+        assert_eq!(b.to, bfd_packet::State::Init);
+    }
+
+    /// Unsubscribing one of two clients leaves the session up so the
+    /// remaining client keeps receiving events.
+    #[tokio::test]
+    async fn unsubscribe_one_keeps_session() {
+        let mut bfd = fresh_bfd();
+        let key = loopback_key(5);
+
+        let (tx_a, _rx_a) = mpsc::unbounded_channel();
+        let (tx_b, _rx_b) = mpsc::unbounded_channel();
+        bfd.subscribe("a".into(), key, SessionParams::default(), tx_a);
+        bfd.subscribe("b".into(), key, SessionParams::default(), tx_b);
+
+        bfd.unsubscribe("a", &key);
+        assert!(
+            bfd.sessions.get_by_key(&key).is_some(),
+            "session must survive while b is still subscribed",
+        );
+        assert_eq!(
+            bfd.subscribers.get(&key).map(BTreeMap::len),
+            Some(1),
+            "only b remains",
+        );
+    }
+
+    /// Unsubscribing the last subscriber tears the session down and
+    /// removes the per-key subscribers entry.
+    #[tokio::test]
+    async fn unsubscribe_last_tears_down_session() {
+        let mut bfd = fresh_bfd();
+        let key = loopback_key(6);
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        bfd.subscribe("solo".into(), key, SessionParams::default(), tx);
+        assert!(bfd.sessions.get_by_key(&key).is_some());
+
+        bfd.unsubscribe("solo", &key);
+        assert!(bfd.sessions.get_by_key(&key).is_none());
+        assert!(!bfd.subscribers.contains_key(&key));
+    }
+
+    /// process_client_req dispatches Subscribe / Unsubscribe so
+    /// channel-based callers (BGP / OSPF / IS-IS in later PRs)
+    /// see the same behaviour as the direct method.
+    #[tokio::test]
+    async fn process_client_req_dispatches() {
+        let mut bfd = fresh_bfd();
+        let key = loopback_key(7);
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        bfd.process_client_req(ClientReq::Subscribe {
+            client: "x".into(),
+            key,
+            params: SessionParams::default(),
+            notifier: tx,
+        });
+        assert!(bfd.sessions.get_by_key(&key).is_some());
+
+        bfd.process_client_req(ClientReq::Unsubscribe {
+            client: "x".into(),
+            key,
+        });
+        assert!(bfd.sessions.get_by_key(&key).is_none());
+    }
 }

--- a/zebra-rs/src/bfd/integration.rs
+++ b/zebra-rs/src/bfd/integration.rs
@@ -1,9 +1,9 @@
 //! Two-instance loopback integration test.
 //!
-//! Brings two BFD instances up on ephemeral loopback ports, adds a
-//! session on each pointing at the other, and asserts that both
-//! sessions reach the `Up` state — the three-way handshake from
-//! RFC 5880 §6.8.6.
+//! Brings two BFD instances up on ephemeral loopback ports, subscribes
+//! a fake client to a session on each pointing at the other, and
+//! asserts that both sessions reach the `Up` state — the three-way
+//! handshake from RFC 5880 §6.8.6.
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
 use std::time::Duration;
@@ -39,26 +39,18 @@ async fn wait_for_up(rx: &mut mpsc::UnboundedReceiver<BfdEvent>, timeout: Durati
     panic!("{who}: did not reach Up within {timeout:?}");
 }
 
-/// Cross-add sessions between two Bfd instances and assert both
-/// reach `Up`. Uses 50ms intervals so the handshake completes
-/// quickly (typical timing: well under a second).
+/// Cross-subscribe sessions between two Bfd instances and assert both
+/// reach `Up`. Uses 50 ms intervals so the handshake completes well
+/// under a second.
 #[tokio::test]
 async fn two_instances_reach_up() {
     let (tx_a, mut rx_a) = mpsc::unbounded_channel();
     let (tx_b, mut rx_b) = mpsc::unbounded_channel();
 
-    let mut bfd_a = Bfd::new_with(
-        Context::default(),
-        SocketAddrV4::new(LOOPBACK, 0),
-        Some(tx_a),
-    )
-    .expect("bind A");
-    let mut bfd_b = Bfd::new_with(
-        Context::default(),
-        SocketAddrV4::new(LOOPBACK, 0),
-        Some(tx_b),
-    )
-    .expect("bind B");
+    let mut bfd_a =
+        Bfd::new_with(Context::default(), SocketAddrV4::new(LOOPBACK, 0)).expect("bind A");
+    let mut bfd_b =
+        Bfd::new_with(Context::default(), SocketAddrV4::new(LOOPBACK, 0)).expect("bind B");
 
     let port_a = bfd_a.local_addr.port();
     let port_b = bfd_b.local_addr.port();
@@ -74,8 +66,8 @@ async fn two_instances_reach_up() {
         dst_port,
     };
 
-    bfd_a.add_session(loopback_key(), params(port_b));
-    bfd_b.add_session(loopback_key(), params(port_a));
+    bfd_a.subscribe("test".into(), loopback_key(), params(port_b), tx_a);
+    bfd_b.subscribe("test".into(), loopback_key(), params(port_a), tx_b);
 
     let _ta = serve(bfd_a);
     let _tb = serve(bfd_b);

--- a/zebra-rs/src/bfd/mod.rs
+++ b/zebra-rs/src/bfd/mod.rs
@@ -1,10 +1,9 @@
-// PR 3b stages the timer engine, outbound packet path, and the
-// `Bfd::add_session` API; the runtime spawn point that consumes them
-// (config-driven session creation) arrives in PR 4. Until then a
-// number of items are only reached from the integration test, so
-// the bin-only compilation surface them as `dead_code`. Suppress
-// module-wide rather than peppering individual files — the lint
-// returns naturally as PR 4 wires the production callers.
+// The client-subscription API (subscribe / unsubscribe / ClientReq)
+// is only exercised by tests until PR 5b wires BGP through it; the
+// timer / session machinery similarly waits for PR 6+ production
+// callers. One module-wide allow is cleaner than peppering
+// individual files — the lint returns naturally as the protocol
+// integrations land.
 #![allow(dead_code)]
 
 pub mod config;


### PR DESCRIPTION
## Summary

Introduces a ref-counted, per-session subscription surface so
multiple protocol clients (BGP / OSPF / IS-IS / static) can attach
to a single BFD session and observe state-change events through
their own notifier channels. The integration test is ported to the
new API. PR 5b wires `neighbor X bfd` from BGP through this surface.

- **`Bfd`** now holds `subscribers: HashMap<SessionKey, BTreeMap<ClientId,
  UnboundedSender<BfdEvent>>>` in place of the previous
  single-subscriber `notify_tx`. State changes broadcast to every
  notifier registered for the affected session key.
- **`subscribe(client, key, params, notifier)`** lazily creates the
  underlying session on the first subscriber; subsequent subscribers
  for the same key reuse the existing session and receive an immediate
  synthetic `StateChange` so they can act on already-Up sessions
  without waiting for the next transition.
- **`unsubscribe(client, key)`** removes the notifier and, when the
  subscribers entry for the key empties, tears the session down via
  the existing `remove_session` path.
- **Channel-based API**: `ClientReq { Subscribe / Unsubscribe }` and a
  `ClientReqChannel` mirroring `ConfigChannel`. The event loop drains
  `client_req.rx` through `process_client_req` so post-`serve` callers
  submit requests through the channel; pre-`serve` callers (today's
  integration test) can still call `subscribe` directly.
- **`Bfd::new_with`** no longer takes a `notify_tx` parameter — the
  subscriber model replaces it. The integration test now subscribes a
  single fake `"test"` client on each instance and awaits the `Up`
  notification through that subscriber's channel.

## Test plan

- [x] `cargo test -p zebra-rs --bin zebra-rs -- bfd::` — 29 / 29 pass
  (6 new):
  - `inst::tests::subscribe_creates_session_and_notifies`
  - `inst::tests::two_clients_share_one_session`
  - `inst::tests::broadcast_reaches_every_subscriber`
  - `inst::tests::unsubscribe_one_keeps_session`
  - `inst::tests::unsubscribe_last_tears_down_session`
  - `inst::tests::process_client_req_dispatches`
- [x] `cargo test -p bfd-packet` — 20 codec tests still pass
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

Generated with [Claude Code](https://claude.com/claude-code)