### PR TITLE
bfd: per-neighbor BFD config in BGP (PR 5b of 10)

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -335,6 +335,30 @@ fn config_soft_reconfig_in(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
     Some(())
 }
 
+/// `set router bgp neighbor X bfd enable true|false` — flips the
+/// BFD attachment for this neighbor. PR 5b stores the bit on
+/// `peer.config.bfd.enable`; the subscribe/unsubscribe call to BFD
+/// lands in PR 5c once `Bgp` carries a `bfd_client_tx` handle.
+fn config_peer_bfd_enable(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let enable = args.boolean()?;
+    let peer = bgp.peers.get_mut(&addr)?;
+    peer.config.bfd.enable = op.is_set() && enable;
+    Some(())
+}
+
+/// `set router bgp neighbor X bfd profile NAME` — selects the BFD
+/// profile applied when this neighbor's BFD session is created.
+/// Stored verbatim; resolution against `/bfd/profile/<name>` is
+/// the responsibility of the PR 5c subscribe path.
+fn config_peer_bfd_profile(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let name = args.string()?;
+    let peer = bgp.peers.get_mut(&addr)?;
+    peer.config.bfd.profile = op.is_set().then_some(name);
+    Some(())
+}
+
 fn config_afi_safi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let key: AfiSafi = args.afi_safi()?;
@@ -986,6 +1010,12 @@ impl Bgp {
         // `/tcp-md5/password` path above; either CLI form is accepted,
         // both lower onto the same runtime state.
         self.callback_peer("/password", config_peer_tcp_md5_password);
+        // FRR-style per-neighbor BFD attachment from
+        // zebra-bgp-bfd.yang. PR 5b stores the leaves on
+        // `peer.config.bfd`; PR 5c wires the runtime subscribe /
+        // unsubscribe path to the BFD client API.
+        self.callback_peer("/bfd/enable", config_peer_bfd_enable);
+        self.callback_peer("/bfd/profile", config_peer_bfd_profile);
         self.callback_peer("/tcp-ao/key-chain", config_peer_tcp_ao_key_chain);
         self.callback_peer(
             "/tcp-ao/include-tcp-options",

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -152,6 +152,17 @@ pub struct PeerTransportConfig {
     pub resolved_ao_key: Option<super::auth::ResolvedAoKey>,
 }
 
+/// Per-neighbor BFD attachment recorded from
+/// `set router bgp neighbor <addr> bfd { enable | profile }`
+/// (zebra-bgp-bfd.yang). PR 5b stores the configuration here; PR 5c
+/// wires `enable` flips to subscribe / unsubscribe calls on the BFD
+/// instance via `bfd::inst::Bfd::client_req_tx`.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PeerBfdConfig {
+    pub enable: bool,
+    pub profile: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct PeerConfig {
     pub transport: PeerTransportConfig,
@@ -176,6 +187,9 @@ pub struct PeerConfig {
     /// runtime stores the reference but does not yet resolve
     /// inheritance — that's a follow-up.
     pub neighbor_group: Option<String>,
+    /// BFD attachment for this neighbor. Inert in PR 5b — the
+    /// `bfd.client_req_tx` plumbing arrives in PR 5c.
+    pub bfd: PeerBfdConfig,
 }
 
 impl Default for PeerConfig {
@@ -193,6 +207,7 @@ impl Default for PeerConfig {
             timer: Default::default(),
             sub: Default::default(),
             neighbor_group: None,
+            bfd: PeerBfdConfig::default(),
         }
     }
 }
@@ -1256,4 +1271,40 @@ pub fn clear_bgp_action(
         targets.len(),
         op
     ))
+}
+
+#[cfg(test)]
+mod bfd_config_tests {
+    use super::*;
+
+    /// PeerBfdConfig default mirrors the YANG defaults
+    /// (`enable=false`, no profile).
+    #[test]
+    fn default_bfd_is_disabled() {
+        let bfd = PeerBfdConfig::default();
+        assert!(!bfd.enable);
+        assert!(bfd.profile.is_none());
+
+        // Lives on PeerConfig with the same default.
+        let pc = PeerConfig::default();
+        assert_eq!(pc.bfd, bfd);
+    }
+
+    /// Round-trip: setting enable + profile mirrors the CLI flow
+    /// (`bfd enable true; bfd profile FAST`) producing the recorded
+    /// state the PR-5c subscribe path will read.
+    #[test]
+    fn enable_and_profile_round_trip() {
+        let mut pc = PeerConfig::default();
+        pc.bfd.enable = true;
+        pc.bfd.profile = Some("FAST".to_string());
+
+        assert_eq!(
+            pc.bfd,
+            PeerBfdConfig {
+                enable: true,
+                profile: Some("FAST".to_string()),
+            },
+        );
+    }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -48,6 +48,10 @@ module config {
     prefix zbp;
   }
 
+  import zebra-bgp-bfd {
+    prefix zbb;
+  }
+
   import zebra-bgp-soft-reconfiguration {
     prefix zbsr;
   }

--- a/zebra-rs/yang/zebra-bgp-bfd.yang
+++ b/zebra-rs/yang/zebra-bgp-bfd.yang
@@ -1,0 +1,110 @@
+module zebra-bgp-bfd {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-bfd";
+  prefix "zbb";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "FRR-style per-neighbor BFD attachment for BGP. Adds a flat
+     `bfd` container under each BGP neighbor:
+
+       router bgp {
+         neighbor 10.0.0.5 {
+           remote-as 65501;
+           bfd {
+             enable true;
+             profile FAST;
+           }
+         }
+       }
+
+     PR 5b stores the per-neighbor BFD configuration on
+     `peer.config.bfd` (see `bgp::peer::PeerBfdConfig`). PR 5c wires
+     these leaves to the BFD client subscription API — when
+     `enable` flips to true, the BGP code path subscribes the
+     neighbor to BFD via the channel exposed by
+     `bfd::inst::Bfd::client_req_tx`; a transition to Down then
+     terminates the BGP session.";
+
+  revision 2026-05-19 {
+    description "Initial revision (PR 5b — storage only).";
+    reference
+      "FRR `neighbor X bfd` / `neighbor X bfd profile P`.
+       Cisco IOS-XR `neighbor X bfd fast-detect`.
+       RFC 5880, RFC 9314.";
+  }
+
+  grouping bgp-neighbor-bfd-extension {
+    description
+      "FRR-style flat `bfd { ... }` block on a BGP neighbor.";
+
+    container bfd {
+      ext:help "BFD attachment for this neighbor";
+      description
+        "When `enable` is true, BGP attaches a BFD session to this
+         neighbor. The optional `profile` selects a named bundle of
+         session parameters defined under `/bfd/profile`; without a
+         profile, BFD's own defaults are used.";
+
+      leaf enable {
+        type boolean;
+        default false;
+        description
+          "Activates the BFD session for this neighbor. Disabling
+           (or removing the `bfd` block entirely) detaches the
+           session.";
+      }
+
+      leaf profile {
+        type string;
+        description
+          "Name of a `/bfd/profile` entry whose parameters apply
+           to this neighbor's BFD session. Leafref validation will
+           be added once libyang exposes cross-tree leafref
+           resolution.";
+      }
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Attach the flat bfd block to BGP neighbors in the
+       candidate-set subtree.";
+    uses bgp-neighbor-bfd-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp neighbor X bfd ...` is path-valid.";
+    uses bgp-neighbor-bfd-extension;
+  }
+}


### PR DESCRIPTION
## Summary

Storage-only step in the BGP integration. Adds an FRR-style
`bfd { enable, profile }` block under each BGP neighbor in YANG,
mirrors the leaves on `peer.config.bfd`, and registers the matching
callbacks. No BFD subscribe / unsubscribe calls fire yet — PR 5c
plumbs the `client_req_tx` handle and wires the runtime session
lifecycle (and `BfdEvent` → neighbor teardown).

- **`zebra-rs/yang/zebra-bgp-bfd.yang`** (new) — `container bfd { leaf
  enable; leaf profile; }` grouping, augmented onto both the set and
  delete subtrees under `/configure/.../bgp/neighbor`, following the
  `zebra-bgp-password.yang` pattern.
- **`config.yang`** imports `zebra-bgp-bfd` with the `zbb` prefix so
  libyang picks the augment up.
- **`src/bgp/peer.rs`** — new `PeerBfdConfig { enable, profile }`
  added as `pub bfd: PeerBfdConfig` on `PeerConfig` with Default
  behaviour matching the YANG defaults.
- **`src/bgp/config.rs`** — `config_peer_bfd_enable` and
  `config_peer_bfd_profile` callbacks plus their `callback_peer`
  registrations under `/router/bgp/neighbor/bfd/{enable,profile}`.
  PR 5c will turn the stored bit into a BFD subscribe / unsubscribe
  once `Bgp` gains a `bfd_client_tx` handle.

Net change: ~85 lines of code + the 110-line YANG augment module.

## Test plan

- [x] `cargo test -p zebra-rs --bin zebra-rs -- bgp::peer::bfd_config_tests`
  — 2 new tests pass:
  - `default_bfd_is_disabled`
  - `enable_and_profile_round_trip`
- [x] `cargo test -p zebra-rs --bin zebra-rs -- bfd::` — 29 existing
  BFD tests still pass
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

Generated with [Claude Code](https://claude.com/claude-code)