### PR TITLE
bfd: plumb client_req_tx to BGP (PR 5c of 10)

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -169,6 +169,14 @@ pub struct Bgp {
     pub debug_flags: BgpDebugFlags,
     pub policy_tx: UnboundedSender<policy::Message>,
     pub policy_rx: UnboundedReceiver<policy::PolicyRx>,
+    /// Handle into the BFD instance's client-request channel — used
+    /// by the per-neighbor `bfd { enable }` path (PR 5d) to submit
+    /// `ClientReq::Subscribe` / `Unsubscribe`. `None` means BFD has
+    /// not (yet) been configured: BGP silently skips its BFD attach
+    /// logic in that case. Captured at spawn time from
+    /// `ConfigManager::bfd_client_tx`; not refreshed if BFD respawns
+    /// later (PR 5d adds a refresh path if needed).
+    pub bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
     // BgpAttr shared storage.
     pub attr_store: BgpAttrStore,
 }
@@ -177,6 +185,7 @@ impl Bgp {
     pub fn new(
         rib_tx: UnboundedSender<rib::Message>,
         policy_tx: UnboundedSender<policy::Message>,
+        bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
     ) -> Self {
         let chan = RibRxChannel::new();
         let msg = rib::Message::Subscribe {
@@ -222,6 +231,7 @@ impl Bgp {
             debug_flags: BgpDebugFlags::default(),
             policy_tx,
             policy_rx: policy_chan.rx,
+            bfd_client_tx,
             attr_store: BgpAttrStore::new(),
         };
         bgp.callback_build();

--- a/zebra-rs/src/config/bfd.rs
+++ b/zebra-rs/src/config/bfd.rs
@@ -13,6 +13,12 @@ pub fn spawn_bfd(config: &ConfigManager) {
     match inst::Bfd::new(Context::default()) {
         Ok(bfd) => {
             config.subscribe("bfd", bfd.cm.tx.clone());
+            // Publish the inbound client-request handle on the
+            // ConfigManager so protocol modules (BGP / OSPF / IS-IS /
+            // static) can pick it up at *their* spawn time and later
+            // submit ClientReq::Subscribe / Unsubscribe against this
+            // BFD instance.
+            *config.bfd_client_tx.borrow_mut() = Some(bfd.client_req_tx());
             let task = inst::serve(bfd);
             config
                 .protocol_tasks
@@ -26,11 +32,13 @@ pub fn spawn_bfd(config: &ConfigManager) {
 /// Tear down the BFD instance when its top-level `bfd` block has been
 /// removed from the candidate config. Dropping the [`Task`] aborts
 /// the event loop; [`rib::Message::ProtoCleanup`] withdraws any
-/// future BFD-installed routes.
+/// future BFD-installed routes. The published client_req_tx handle
+/// is also cleared so a respawn produces a fresh channel.
 pub fn despawn_bfd(config: &ConfigManager) {
     config.cm_clients.borrow_mut().remove("bfd");
     config.show_clients.borrow_mut().remove("bfd");
     config.protocol_tasks.borrow_mut().remove("bfd");
+    *config.bfd_client_tx.borrow_mut() = None;
     let _ = config.rib_tx.send(rib::Message::ProtoCleanup {
         proto: "bfd".to_string(),
     });

--- a/zebra-rs/src/config/bgp.rs
+++ b/zebra-rs/src/config/bgp.rs
@@ -4,7 +4,17 @@ use crate::rib;
 use super::ConfigManager;
 
 pub fn spawn_bgp(config: &ConfigManager) {
-    let bgp = inst::Bgp::new(config.rib_tx.clone(), config.policy_tx.clone());
+    // Capture BFD's client handle (if BFD is already spawned) so per-
+    // neighbor `bfd { enable }` can later submit Subscribe / Unsubscribe.
+    // If `bfd { ... }` is configured *after* `router bgp`, BGP's handle
+    // stays None and the BFD attach is a no-op — PR 5d adds a refresh
+    // path for that ordering.
+    let bfd_client_tx = config.bfd_client_tx.borrow().clone();
+    let bgp = inst::Bgp::new(
+        config.rib_tx.clone(),
+        config.policy_tx.clone(),
+        bfd_client_tx,
+    );
     config.subscribe("bgp", bgp.cm.tx.clone());
     config.subscribe_show("bgp", bgp.show.tx.clone());
     let task = inst::serve(bgp);

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -68,6 +68,16 @@ pub struct ConfigManager {
     pub show_clients: RefCell<HashMap<String, UnboundedSender<DisplayRequest>>>,
     pub rib_tx: UnboundedSender<crate::rib::Message>,
     pub policy_tx: UnboundedSender<crate::policy::Message>,
+    /// Sender side of the BFD client-request channel. Populated by
+    /// [`super::bfd::spawn_bfd`] when a `bfd { ... }` block first
+    /// appears in the candidate config; cleared by `despawn_bfd` when
+    /// the block is removed. Protocol modules (BGP / OSPF / IS-IS /
+    /// static) clone this at their own spawn time so they can later
+    /// submit `ClientReq::Subscribe` / `Unsubscribe` against the
+    /// running BFD instance. `None` indicates BFD has not (yet) been
+    /// configured — clients with a `None` handle silently skip their
+    /// BFD attach logic.
+    pub bfd_client_tx: RefCell<Option<UnboundedSender<crate::bfd::inst::ClientReq>>>,
     pub protocol_tasks: RefCell<HashMap<String, Task<()>>>,
     /// Runtime-mutable YANG-defined service-accounts (D25). Updated by
     /// `commit_config` when `vty service-account uid N` changes; read by
@@ -104,6 +114,7 @@ impl ConfigManager {
             show_clients: RefCell::new(HashMap::new()),
             rib_tx,
             policy_tx,
+            bfd_client_tx: RefCell::new(None),
             protocol_tasks: RefCell::new(HashMap::new()),
             #[cfg(target_os = "linux")]
             yang_service_accounts,


### PR DESCRIPTION
## Summary

Pure plumbing step in the BGP integration. Threads BFD's client-
request channel through `ConfigManager` so `spawn_bgp` can hand it
to the `Bgp` instance. No `Subscribe` / `Unsubscribe` traffic flows
yet — PR 5d turns committed `neighbor X bfd { enable }` into actual
`ClientReq` sends; PR 5e adds neighbor teardown on `BfdEvent::Down`.

- **`ConfigManager`** grows `bfd_client_tx: RefCell<Option<UnboundedSender<bfd::inst::ClientReq>>>`,
  initialised to `None`.
- **`spawn_bfd`** publishes the handle via `bfd.client_req_tx()`;
  **`despawn_bfd`** clears it (a respawn produces a fresh channel
  that won't reach already-spawned BGP — PR 5d's late-binding work
  handles that path).
- **`Bgp`** grows `bfd_client_tx: Option<UnboundedSender<ClientReq>>`;
  `Bgp::new` takes the new optional parameter so the only call site
  (`spawn_bgp`) threads the value through.
- **`spawn_bgp`** captures the handle by cloning
  `config.bfd_client_tx.borrow()` at spawn time. Documented
  spawn-order semantics: `bfd` configured first → BGP gets
  `Some(handle)`; `router bgp` first → BGP gets `None` (per-neighbor
  `bfd { enable }` is a no-op until PR 5d).

Mechanical-only change (41 lines): no new behaviour to test beyond
the existing suite's compile guarantees. PR 5d adds behavioural
tests when `ClientReq` sends actually fire.

## Test plan

- [x] `cargo test -p zebra-rs --bin zebra-rs -- bfd:: bgp::` — 92
  existing tests pass (compile-level confirmation of the type
  threading)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

Generated with [Claude Code](https://claude.com/claude-code)