### PR TITLE
bfd: BGP subscribe/unsubscribe on neighbor bfd (PR 5d of 10)

### DIFF
--- a/zebra-rs/src/bfd/mod.rs
+++ b/zebra-rs/src/bfd/mod.rs
@@ -1,9 +1,11 @@
-// The client-subscription API (subscribe / unsubscribe / ClientReq)
-// is only exercised by tests until PR 5b wires BGP through it; the
-// timer / session machinery similarly waits for PR 6+ production
-// callers. One module-wide allow is cleaner than peppering
-// individual files — the lint returns naturally as the protocol
-// integrations land.
+// Several surfaces remain unexercised by production until later
+// PRs: the admin-shutdown FSM events (`AdminDown` / `AdminUp` —
+// pending a "shutdown" config callback path), `TimerCmd::ResetDetect`
+// (currently subsumed by `Update`), the `Stats` counters and
+// `local_addr` (pending show-command wiring), and a handful of
+// SessionTable helpers used only by tests. One module-wide allow is
+// cleaner than peppering individual files; the lint returns
+// naturally as those production callers land.
 #![allow(dead_code)]
 
 pub mod config;

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1,7 +1,9 @@
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use bgp_packet::*;
 
+use crate::bfd::inst::ClientReq;
+use crate::bfd::session::{SessionKey, SessionParams};
 use crate::bgp::InOut;
 use crate::config::{Args, ConfigOp};
 use crate::policy;
@@ -336,15 +338,72 @@ fn config_soft_reconfig_in(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
 }
 
 /// `set router bgp neighbor X bfd enable true|false` — flips the
-/// BFD attachment for this neighbor. PR 5b stores the bit on
-/// `peer.config.bfd.enable`; the subscribe/unsubscribe call to BFD
-/// lands in PR 5c once `Bgp` carries a `bfd_client_tx` handle.
+/// BFD attachment for this neighbor. PR 5b stored the bit on
+/// `peer.config.bfd.enable`; PR 5d wires the same flip into a
+/// `ClientReq::Subscribe` / `Unsubscribe` against the BFD instance
+/// (when `bgp.bfd_client_tx` is populated — see PR 5c).
 fn config_peer_bfd_enable(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let enable = args.boolean()?;
-    let peer = bgp.peers.get_mut(&addr)?;
-    peer.config.bfd.enable = op.is_set() && enable;
+    let new_enable = op.is_set() && enable;
+    // Stash data we need from the peer, then drop the borrow so we
+    // can touch other Bgp fields without fighting the borrow checker.
+    let local = {
+        let peer = bgp.peers.get_mut(&addr)?;
+        peer.config.bfd.enable = new_enable;
+        peer.config
+            .transport
+            .update_source
+            .unwrap_or_else(|| unspecified_for(&addr))
+    };
+    let Some(client_tx) = bgp.bfd_client_tx.as_ref() else {
+        if new_enable {
+            tracing::debug!(
+                peer = %addr,
+                "bgp: bfd enable=true but bfd_client_tx is None (BFD not yet spawned)",
+            );
+        }
+        return Some(());
+    };
+    let key = SessionKey {
+        local,
+        remote: addr,
+        ifindex: 0,
+        multihop: false,
+    };
+    let req = if new_enable {
+        // PR 5d uses SessionParams::default() for every neighbor — the
+        // peer's `bfd profile` reference is stored but not yet read.
+        // Profile resolution against `/bfd/profile/<name>` is a
+        // follow-up that needs cross-task config access (BGP would
+        // need a snapshot of BFD's BfdConfig, or BFD has to resolve
+        // profiles internally on Subscribe).
+        ClientReq::Subscribe {
+            client: "bgp".to_string(),
+            key,
+            params: SessionParams::default(),
+            notifier: bgp.bfd_event_tx.clone(),
+        }
+    } else {
+        ClientReq::Unsubscribe {
+            client: "bgp".to_string(),
+            key,
+        }
+    };
+    let _ = client_tx.send(req);
     Some(())
+}
+
+/// Pick an unspecified local address whose family matches `remote`.
+/// Used when the peer has no `update-source` set — BFD's SessionKey
+/// just needs *something* in the `local` slot to demux against, and
+/// 0.0.0.0 / :: are unambiguous within a single (local, remote, ifindex)
+/// tuple.
+fn unspecified_for(remote: &IpAddr) -> IpAddr {
+    match remote {
+        IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        IpAddr::V6(_) => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+    }
 }
 
 /// `set router bgp neighbor X bfd profile NAME` — selects the BFD
@@ -1099,5 +1158,100 @@ impl Bgp {
         // Stored-mode soft-in: retain pre-policy Adj-RIB-In so `clear soft in`
         // can replay locally without sending a Route Refresh.
         self.callback_peer("/soft-reconfiguration/inbound", config_soft_reconfig_in);
+    }
+}
+
+#[cfg(test)]
+mod bfd_wiring_tests {
+    use std::collections::VecDeque;
+
+    use tokio::sync::mpsc;
+
+    use super::*;
+
+    fn arg_words(parts: &[&str]) -> Args {
+        Args(
+            parts
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect::<VecDeque<_>>(),
+        )
+    }
+
+    /// Construct a Bgp with mock channels and an optional BFD
+    /// client_tx. Returned alongside the BFD ClientReq receiver so
+    /// the caller can assert what was sent.
+    fn fresh_bgp_with_bfd() -> (Bgp, mpsc::UnboundedReceiver<ClientReq>) {
+        let (rib_tx, _rib_rx) = mpsc::unbounded_channel();
+        let (policy_tx, _policy_rx) = mpsc::unbounded_channel();
+        let (bfd_client_tx, bfd_client_rx) = mpsc::unbounded_channel();
+        let bgp = Bgp::new(rib_tx, policy_tx, Some(bfd_client_tx));
+        (bgp, bfd_client_rx)
+    }
+
+    /// `bfd enable true` on a known neighbor sends a
+    /// `ClientReq::Subscribe` carrying the matching SessionKey.
+    #[tokio::test]
+    async fn enable_sends_subscribe() {
+        let (mut bgp, mut bfd_rx) = fresh_bgp_with_bfd();
+        // Add the peer first (the callback only fires for known peers).
+        config_peer(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        // Now flip BFD on.
+        config_peer_bfd_enable(&mut bgp, arg_words(&["10.0.0.2", "true"]), ConfigOp::Set).unwrap();
+
+        let req = bfd_rx.try_recv().expect("BGP must send a ClientReq");
+        match req {
+            ClientReq::Subscribe { client, key, .. } => {
+                assert_eq!(client, "bgp");
+                assert_eq!(
+                    key.remote,
+                    IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+                    "remote address mirrors the configured neighbor",
+                );
+                assert!(!key.multihop, "single-hop only in PR 5d");
+                assert_eq!(key.ifindex, 0);
+            }
+            other => panic!("expected Subscribe, got {other:?}"),
+        }
+    }
+
+    /// Flipping `bfd enable` back to false (or deleting it) sends an
+    /// `Unsubscribe` for the same key.
+    #[tokio::test]
+    async fn disable_sends_unsubscribe() {
+        let (mut bgp, mut bfd_rx) = fresh_bgp_with_bfd();
+        config_peer(&mut bgp, arg_words(&["10.0.0.3"]), ConfigOp::Set).unwrap();
+        config_peer_bfd_enable(&mut bgp, arg_words(&["10.0.0.3", "true"]), ConfigOp::Set).unwrap();
+        let _ = bfd_rx.try_recv().expect("subscribe arrived first");
+
+        config_peer_bfd_enable(&mut bgp, arg_words(&["10.0.0.3", "true"]), ConfigOp::Delete)
+            .unwrap();
+        let req = bfd_rx.try_recv().expect("unsubscribe must follow");
+        match req {
+            ClientReq::Unsubscribe { client, key } => {
+                assert_eq!(client, "bgp");
+                assert_eq!(key.remote, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)));
+            }
+            other => panic!("expected Unsubscribe, got {other:?}"),
+        }
+    }
+
+    /// If `bfd_client_tx` is None (BFD not spawned at BGP start time)
+    /// the callback is a no-op — peer config still flips, but no
+    /// ClientReq goes out.
+    #[tokio::test]
+    async fn enable_without_bfd_handle_is_noop() {
+        let (rib_tx, _rib_rx) = mpsc::unbounded_channel();
+        let (policy_tx, _policy_rx) = mpsc::unbounded_channel();
+        let mut bgp = Bgp::new(rib_tx, policy_tx, None);
+        config_peer(&mut bgp, arg_words(&["10.0.0.4"]), ConfigOp::Set).unwrap();
+        // No bfd handle to assert against; the call must not panic.
+        config_peer_bfd_enable(&mut bgp, arg_words(&["10.0.0.4", "true"]), ConfigOp::Set).unwrap();
+
+        let peer = bgp
+            .peers
+            .get(&IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4)))
+            .unwrap();
+        assert!(peer.config.bfd.enable, "config bit still flips");
     }
 }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -170,13 +170,22 @@ pub struct Bgp {
     pub policy_tx: UnboundedSender<policy::Message>,
     pub policy_rx: UnboundedReceiver<policy::PolicyRx>,
     /// Handle into the BFD instance's client-request channel — used
-    /// by the per-neighbor `bfd { enable }` path (PR 5d) to submit
+    /// by the per-neighbor `bfd { enable }` path to submit
     /// `ClientReq::Subscribe` / `Unsubscribe`. `None` means BFD has
     /// not (yet) been configured: BGP silently skips its BFD attach
     /// logic in that case. Captured at spawn time from
     /// `ConfigManager::bfd_client_tx`; not refreshed if BFD respawns
-    /// later (PR 5d adds a refresh path if needed).
+    /// later (late-binding work is a follow-up).
     pub bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
+    /// Sender half of the per-instance `BfdEvent` channel. Cloned and
+    /// handed to BFD as the `notifier` on every `Subscribe`, so all
+    /// state-change events for BGP-attached BFD sessions land on the
+    /// matching `bfd_event_rx` below.
+    pub bfd_event_tx: UnboundedSender<crate::bfd::inst::BfdEvent>,
+    /// Receive half drained by the BGP event loop in
+    /// [`Self::event_loop`]. PR 5d logs the events; PR 5e replaces
+    /// the log with neighbor teardown on `BfdEvent::Down`.
+    pub bfd_event_rx: UnboundedReceiver<crate::bfd::inst::BfdEvent>,
     // BgpAttr shared storage.
     pub attr_store: BgpAttrStore,
 }
@@ -202,6 +211,7 @@ impl Bgp {
         let _ = policy_tx.send(msg);
 
         let (tx, rx) = mpsc::channel(8192);
+        let (bfd_event_tx, bfd_event_rx) = mpsc::unbounded_channel();
         let mut bgp = Self {
             asn: 0,
             router_id: Ipv4Addr::UNSPECIFIED,
@@ -232,6 +242,8 @@ impl Bgp {
             policy_tx,
             policy_rx: policy_chan.rx,
             bfd_client_tx,
+            bfd_event_tx,
+            bfd_event_rx,
             attr_store: BgpAttrStore::new(),
         };
         bgp.callback_build();
@@ -678,8 +690,27 @@ impl Bgp {
                 Some(msg) = self.policy_rx.recv() => {
                     self.process_policy_msg(msg).await;
                 }
+                Some(event) = self.bfd_event_rx.recv() => {
+                    self.process_bfd_event(event);
+                }
             }
         }
+    }
+
+    /// Handle a [`crate::bfd::inst::BfdEvent`] forwarded by the BFD
+    /// instance. PR 5d logs the transition at info level so operators
+    /// can observe BFD activity; PR 5e replaces the log with the
+    /// actual neighbor-teardown call once the BGP-side FSM hook is
+    /// identified.
+    pub fn process_bfd_event(&mut self, event: crate::bfd::inst::BfdEvent) {
+        let crate::bfd::inst::BfdEvent::StateChange { key, change } = event;
+        tracing::info!(
+            ?key,
+            from = %change.from,
+            to = %change.to,
+            diag = %change.diag,
+            "bgp: bfd session state change",
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Turns the stored-only `peer.config.bfd.enable` from PR 5b into an
actual `ClientReq` submission against the BFD instance (using the
handle plumbed in PR 5c) and starts draining `BfdEvent` in the BGP
event loop. PR 5e replaces the placeholder info-log on `BfdEvent`
with the real neighbor-teardown call.

- **`Bgp`** gains a per-instance `bfd_event` channel: `bfd_event_tx`
  is cloned into every `Subscribe` (so all BGP-attached BFD sessions
  notify back here), and `bfd_event_rx` is drained by a new
  `tokio::select!` arm in `event_loop`.
- **`config_peer_bfd_enable`**, after flipping
  `peer.config.bfd.enable`, builds a `SessionKey` from the peer's
  `transport.update_source` (or an unspecified local address of
  matching family) plus the peer's remote address, and dispatches
  `Subscribe` / `Unsubscribe` via `bgp.bfd_client_tx`. If
  `bfd_client_tx` is `None` (BFD not yet spawned) the callback is a
  no-op except for the config bit — a debug log records the skip.
- **`Bgp::process_bfd_event`** handles incoming
  `BfdEvent::StateChange` with an info-level trace. PR 5e replaces
  this with a real neighbor session terminator.

## Known limitations (documented in the code)

- Always uses `SessionParams::default()`. The peer's `bfd profile`
  reference is stored (PR 5b) but not yet read — profile resolution
  against `/bfd/profile/<name>` needs cross-task config access (BGP
  would need a snapshot of BFD's `BfdConfig`, or `Subscribe` needs to
  carry the profile name for BFD to resolve internally).
- If BFD is spawned *after* BGP, BGP's `bfd_client_tx` stays `None`
  permanently — late-binding refresh is a follow-up.
- Always single-hop; eBGP-multihop is deferred.

The BFD-module-level `#![allow(dead_code)]` is retained with a
refreshed comment — `ClientReq` / `BfdEvent` are now reached from
production, but admin-shutdown events, `Stats` counters, and
`local_addr` remain test / PR-6-only.

## Test plan

- [x] `cargo test -p zebra-rs --bin zebra-rs -- bfd:: bgp::` — 95
  tests pass (3 new):
  - `bgp::config::bfd_wiring_tests::enable_sends_subscribe`
  - `bgp::config::bfd_wiring_tests::disable_sends_unsubscribe`
  - `bgp::config::bfd_wiring_tests::enable_without_bfd_handle_is_noop`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

Generated with [Claude Code](https://claude.com/claude-code)