### PR TITLE
bfd: BGP teardown on BFD Down (PR 5e of 10)

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1254,4 +1254,100 @@ mod bfd_wiring_tests {
             .unwrap();
         assert!(peer.config.bfd.enable, "config bit still flips");
     }
+
+    // -----------------------------------------------------------------
+    // PR 5e: process_bfd_event teardown behaviour
+    // -----------------------------------------------------------------
+
+    use crate::bfd::inst::BfdEvent;
+    use crate::bfd::session::StateChange;
+    use crate::bgp::inst::Message;
+    use crate::bgp::peer::Event as PeerEvent;
+    use bfd_packet::{Diag, State};
+
+    fn make_state_change(from: State, to: State) -> StateChange {
+        StateChange {
+            from,
+            to,
+            diag: Diag::None,
+        }
+    }
+
+    fn make_event(remote: Ipv4Addr, from: State, to: State) -> BfdEvent {
+        BfdEvent::StateChange {
+            key: SessionKey {
+                local: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+                remote: IpAddr::V4(remote),
+                ifindex: 0,
+                multihop: false,
+            },
+            change: make_state_change(from, to),
+        }
+    }
+
+    /// BFD going Up → Down for a known peer sends `Event::Stop` to
+    /// the matching peer FSM (RFC 5882 §5 path-failure response).
+    #[tokio::test]
+    async fn bfd_down_triggers_event_stop() {
+        let (mut bgp, _bfd_rx) = fresh_bgp_with_bfd();
+        let addr = Ipv4Addr::new(10, 0, 0, 5);
+        config_peer(&mut bgp, arg_words(&["10.0.0.5"]), ConfigOp::Set).unwrap();
+        let peer_idx = bgp.peers.get(&IpAddr::V4(addr)).unwrap().ident;
+
+        bgp.process_bfd_event(make_event(addr, State::Up, State::Down));
+
+        let msg = bgp.rx.try_recv().expect("Event::Stop must be queued");
+        match msg {
+            Message::Event(idx, ev) => {
+                assert_eq!(idx, peer_idx);
+                assert!(matches!(ev, PeerEvent::Stop));
+            }
+            other => panic!("expected Message::Event(_, Stop), got {other:?}"),
+        }
+    }
+
+    /// Synthetic Down→Down events emitted by `Bfd::subscribe` (so a
+    /// new subscriber can act on the current state immediately) must
+    /// NOT trigger teardown — there's no transition to react to.
+    #[tokio::test]
+    async fn synthetic_down_to_down_is_ignored() {
+        let (mut bgp, _bfd_rx) = fresh_bgp_with_bfd();
+        let addr = Ipv4Addr::new(10, 0, 0, 6);
+        config_peer(&mut bgp, arg_words(&["10.0.0.6"]), ConfigOp::Set).unwrap();
+
+        bgp.process_bfd_event(make_event(addr, State::Down, State::Down));
+        assert!(
+            bgp.rx.try_recv().is_err(),
+            "synthetic Down→Down must not enqueue any message",
+        );
+    }
+
+    /// BFD coming Up is informational — BGP doesn't need to do
+    /// anything in particular (its own FSM is already running).
+    #[tokio::test]
+    async fn bfd_up_does_not_tear_down() {
+        let (mut bgp, _bfd_rx) = fresh_bgp_with_bfd();
+        let addr = Ipv4Addr::new(10, 0, 0, 7);
+        config_peer(&mut bgp, arg_words(&["10.0.0.7"]), ConfigOp::Set).unwrap();
+
+        bgp.process_bfd_event(make_event(addr, State::Init, State::Up));
+        assert!(
+            bgp.rx.try_recv().is_err(),
+            "BFD Up must not enqueue any message",
+        );
+    }
+
+    /// A Down event for a peer that no longer exists (raced against
+    /// neighbor deletion) is logged but otherwise ignored — no
+    /// panic, no spurious Event::Stop.
+    #[tokio::test]
+    async fn bfd_down_for_unknown_peer_is_noop() {
+        let (mut bgp, _bfd_rx) = fresh_bgp_with_bfd();
+        bgp.process_bfd_event(make_event(
+            Ipv4Addr::new(10, 99, 99, 99),
+            State::Up,
+            State::Down,
+        ));
+        assert!(bgp.rx.try_recv().is_err());
+    }
 }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -698,10 +698,17 @@ impl Bgp {
     }
 
     /// Handle a [`crate::bfd::inst::BfdEvent`] forwarded by the BFD
-    /// instance. PR 5d logs the transition at info level so operators
-    /// can observe BFD activity; PR 5e replaces the log with the
-    /// actual neighbor-teardown call once the BGP-side FSM hook is
-    /// identified.
+    /// instance. RFC 5882 §5 prescribes that a BFD signal of session
+    /// Down should be treated as a path-failure indication for the
+    /// IGP/BGP session — we react by sending `Event::Stop` to the
+    /// matching peer's FSM, which triggers the usual BGP teardown
+    /// path (NOTIFICATION + TCP close + transition to Idle).
+    ///
+    /// Synthetic Down→Down notifications (emitted by BFD when a new
+    /// subscriber attaches before any peer Rx has arrived) are
+    /// ignored — they carry no state-transition information and
+    /// would otherwise tear down a peer that hasn't yet had a chance
+    /// to establish.
     pub fn process_bfd_event(&mut self, event: crate::bfd::inst::BfdEvent) {
         let crate::bfd::inst::BfdEvent::StateChange { key, change } = event;
         tracing::info!(
@@ -711,6 +718,31 @@ impl Bgp {
             diag = %change.diag,
             "bgp: bfd session state change",
         );
+
+        // Synthetic "current state" mirror from `Bfd::subscribe`
+        // — no transition has occurred.
+        if change.from == change.to {
+            return;
+        }
+
+        if change.to != bfd_packet::State::Down {
+            return;
+        }
+
+        // SessionKey.remote is the BGP neighbor address — direct
+        // lookup. A missing peer means the user removed the
+        // neighbor since BGP last subscribed; safe to ignore.
+        let Some(peer) = self.peers.get(&key.remote) else {
+            tracing::debug!(?key, "bgp: bfd-down for unknown peer; ignoring",);
+            return;
+        };
+        let peer_idx = peer.ident;
+        tracing::warn!(
+            peer = %key.remote,
+            diag = %change.diag,
+            "bgp: tearing down peer on bfd-down (RFC 5882 §5)",
+        );
+        let _ = self.tx.try_send(Message::Event(peer_idx, Event::Stop));
     }
 }
 


### PR DESCRIPTION
## Summary

Closes the BGP+BFD loop. Replaces the PR-5d placeholder info-log in
`process_bfd_event` with the actual neighbor-teardown call: on a
real transition into `Down`, BGP enqueues
`Message::Event(idx, Event::Stop)` for the matching peer, which runs
through the existing FSM Stop path (NOTIFICATION + TCP close +
transition to Idle) per RFC 5882 §5.

- **`process_bfd_event`** ignores synthetic Down→Down notifications
  (`Bfd::subscribe` mirrors the current state to a new subscriber so
  it can act on already-Up sessions; treating that as a transition
  would tear down a peer that hasn't yet had a chance to establish).
- Only `to == State::Down && from != to` triggers `Event::Stop`;
  Up / Init transitions are informational only.
- `SessionKey.remote` → peer lookup uses the existing peer map. A
  missing peer (raced against neighbor delete) is logged at debug
  and otherwise ignored.

End-to-end after this PR:
`bfd { profile X { ... } peer Y { ... } }` plus
`router bgp { neighbor Y { bfd { enable true } } }` produces a
closed loop — BFD detects path failure, signals Down, BGP tears the
neighbor down.

## Test plan

- [x] `cargo test -p zebra-rs --bin zebra-rs -- bfd:: bgp::` — 99
  tests pass (4 new):
  - `bgp::config::bfd_wiring_tests::bfd_down_triggers_event_stop`
  - `bgp::config::bfd_wiring_tests::synthetic_down_to_down_is_ignored`
  - `bgp::config::bfd_wiring_tests::bfd_up_does_not_tear_down`
  - `bgp::config::bfd_wiring_tests::bfd_down_for_unknown_peer_is_noop`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

Generated with [Claude Code](https://claude.com/claude-code)