### PR TITLE
isis: advertise lsp-mtu-size in TLV 14 + add wire_len helper

### DIFF
--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -560,6 +560,23 @@ pub enum IsisTlv {
 }
 
 impl IsisTlv {
+    /// On-wire byte cost of this TLV: 2 bytes of TL header plus the
+    /// serialized value. Used by the send-side fragmentation packer
+    /// to decide whether a TLV instance fits in the current
+    /// fragment's remaining budget.
+    ///
+    /// `TlvEmitter::len()` returns the same byte count as a `u8`,
+    /// which silently wraps for malformed TLVs whose value exceeds
+    /// 255 bytes. This helper emits into a scratch buffer and
+    /// reports the true length so the packer can detect oversize
+    /// instances and split them at the entry boundary before they
+    /// reach `tlv_emit`.
+    pub fn wire_len(&self) -> usize {
+        let mut buf = BytesMut::new();
+        self.emit(&mut buf);
+        buf.len()
+    }
+
     pub fn emit(&self, buf: &mut BytesMut) {
         use IsisTlv::*;
         match self {
@@ -1177,6 +1194,23 @@ pub fn parse(input: &[u8]) -> IsisIResult<&[u8], IsisPacket> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Sanity-check `IsisTlv::wire_len` for a small fixed-size TLV.
+    /// The packer relies on this returning a stable 4 bytes (2-byte
+    /// TL header + 2-byte value) for the buffer-size TLV so its
+    /// per-fragment budget accounting is correct.
+    #[test]
+    fn wire_len_counts_tl_header_plus_value() {
+        let tlv: IsisTlv = IsisTlvLspBufferSize { size: 1492 }.into();
+        assert_eq!(tlv.wire_len(), 4);
+
+        let host: IsisTlv = IsisTlvHostname {
+            hostname: "router-7".to_string(),
+        }
+        .into();
+        // 2 header + 8 chars of "router-7".
+        assert_eq!(host.wire_len(), 10);
+    }
 
     /// Round-trip a TLV 14 LSP Buffer Size: emit through tlv_emit,
     /// then re-parse via parse_tlvs and recover the original size.

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -9,6 +9,7 @@ use strum_macros::{Display, EnumString};
 use crate::config::{Args, ConfigOp};
 
 use super::Isis;
+use super::ifsm::has_level;
 use super::inst::{Callback, Message};
 use super::link::Afis;
 use super::tracing::{PacketConfig, PacketDirection};
@@ -87,6 +88,7 @@ impl Isis {
             "/router/isis/lsp-gen-interval/maximum-wait",
             config_lsp_gen_maximum_wait,
         );
+        self.callback_add("/router/isis/lsp-mtu-size", config_lsp_mtu_size);
         self.callback_add("/router/isis/te-router-id", config_te_router_id);
         self.callback_add("/router/isis/segment-routing/mpls", config_sr_mpls_enable);
         self.callback_add(
@@ -180,6 +182,13 @@ pub struct IsisConfig {
     pub lsp_gen_initial_wait: Option<u32>,
     pub lsp_gen_secondary_wait: Option<u32>,
     pub lsp_gen_maximum_wait: Option<u32>,
+
+    /// Originating LSP Buffer Size (ISO 10589 §7.2.5.1
+    /// `originatingLSPBufferSize`, advertised in TLV 14 per RFC 1195).
+    /// Caps the byte length of every self-originated LSP PDU and
+    /// drives the send-side packer's fragment boundary. Default
+    /// 1492 — the universally-accepted IS-IS PDU size.
+    pub lsp_mtu_size: Option<u16>,
     pub te_router_id: Option<Ipv4Addr>,
     pub rib_router_id: Option<Ipv4Addr>,
     pub enable: Afis<usize>,
@@ -249,6 +258,10 @@ impl IsisConfig {
     const DEFAULT_LSP_GEN_INITIAL_WAIT_MS: u32 = 50;
     const DEFAULT_LSP_GEN_SECONDARY_WAIT_MS: u32 = 5000;
     const DEFAULT_LSP_GEN_MAXIMUM_WAIT_MS: u32 = 5000;
+    /// ISO 10589 §7.2.5.1: the originatingLSPBufferSize every IS-IS
+    /// implementation is required to accept. Larger values are valid
+    /// on links where every peer agrees, but 1492 is the safe default.
+    pub const DEFAULT_LSP_MTU_SIZE: u16 = 1492;
 
     pub fn is_type(&self) -> IsLevel {
         self.is_type.unwrap_or(IsLevel::L1L2)
@@ -309,6 +322,10 @@ impl IsisConfig {
     pub fn lsp_gen_maximum_wait(&self) -> u32 {
         self.lsp_gen_maximum_wait
             .unwrap_or(Self::DEFAULT_LSP_GEN_MAXIMUM_WAIT_MS)
+    }
+
+    pub fn lsp_mtu_size(&self) -> u16 {
+        self.lsp_mtu_size.unwrap_or(Self::DEFAULT_LSP_MTU_SIZE)
     }
 
     /// True when either SR dataplane is enabled. Used to gate emission
@@ -445,6 +462,27 @@ fn config_lsp_gen_secondary_wait(isis: &mut Isis, mut args: Args, op: ConfigOp) 
 fn config_lsp_gen_maximum_wait(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     let ms = args.u32()?;
     isis.config.lsp_gen_maximum_wait = if op == ConfigOp::Set { Some(ms) } else { None };
+    Some(())
+}
+
+fn config_lsp_mtu_size(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let size = args.u16()?;
+
+    if op == ConfigOp::Set {
+        isis.config.lsp_mtu_size = Some(size);
+    } else {
+        isis.config.lsp_mtu_size = None;
+    }
+
+    // Re-originate so the new buffer size lands in TLV 14 and (once
+    // the packer is wired up) so the new fragment boundary takes
+    // effect immediately rather than waiting for the next natural
+    // origination trigger.
+    for level in [Level::L1, Level::L2] {
+        if has_level(isis.config.is_type(), level) {
+            let _ = isis.tx.send(Message::LspOriginate(level, None));
+        }
+    }
     Some(())
 }
 

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -241,6 +241,17 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
         lsp.tlvs.push(IsisTlvProtoSupported { nlpids }.into());
     }
 
+    // Originating LSP Buffer Size (TLV 14, RFC 1195). Advertises the
+    // PDU size we accept on this link; peers cap their own fragments
+    // against this value when sending to us. Frag-0 only — receivers
+    // ignore TLV 14 outside fragment 0.
+    lsp.tlvs.push(
+        IsisTlvLspBufferSize {
+            size: top.config.lsp_mtu_size(),
+        }
+        .into(),
+    );
+
     // Hostname (RFC 5301). Configured value wins, then the OS hostname.
     // If neither is available, skip the TLV entirely and clear any
     // stale entry from the local hostname map so show output falls

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -507,6 +507,20 @@ module config {
           }
         }
 
+        leaf lsp-mtu-size {
+          type uint16 {
+            range "128..16384";
+          }
+          units "bytes";
+          description
+            "Originating LSP Buffer Size (ISO 10589 originatingLSPBufferSize,
+             advertised as TLV 14 per RFC 1195). Sets the maximum byte length
+             of a self-originated LSP PDU; the packer fragments TLVs into
+             multiple LSPs so each fragment stays at or below this value.
+             Default 1492 matches ISO 10589 and is the value every IS-IS
+             peer is required to accept.";
+        }
+
         list interface {
           // Last item in "router isis" node.
           ext:sort "-10";


### PR DESCRIPTION
## Summary

Foundation for the upcoming send-side LSP fragmentation packer. Three small pieces in one commit because each is useless alone:

- **YANG** `/router/isis/lsp-mtu-size` (range 128..16384, default 1492) maps to `IsisConfig::lsp_mtu_size`. Re-originates the self-LSP on change so the new buffer size lands immediately rather than waiting for a natural origination trigger.
- **`lsp_generate`** now appends TLV 14 (Originating LSP Buffer Size, RFC 1195) carrying the configured value. Frag-0 only — receivers ignore TLV 14 outside fragment 0.
- **`IsisTlv::wire_len()`** returns the true 2-byte-header + value byte count via a scratch BytesMut. `TlvEmitter::len()` returns u8 and so silently wraps for any TLV whose value exceeds 255 bytes; the packer needs the un-truncated count to detect oversized TLV instances and split them at the entry boundary before they reach `tlv_emit`.

Diff: +97 lines across 4 files.

## Test plan

- [x] \`cargo build -p zebra-rs\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo test --workspace --exclude bdd\` all green (isis-packet 28 incl. new \`wire_len_counts_tl_header_plus_value\`, plus the existing \`lsp_buffer_size_round_trip\`)

Generated with [Claude Code](https://claude.com/claude-code)