### PR TITLE
bfd: IS-IS per-interface BFD config (PR 6 of 10)

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -143,6 +143,14 @@ impl Isis {
             "/router/isis/interface/ipv4/enable",
             link::config_ipv4_enable,
         );
+        // Per-interface BFD attachment (PR 6 — storage only; the
+        // adjacency-FSM subscribe and BfdEvent::Down teardown paths
+        // land in PR 7).
+        self.callback_add("/router/isis/interface/bfd/enable", link::config_bfd_enable);
+        self.callback_add(
+            "/router/isis/interface/bfd/profile",
+            link::config_bfd_profile,
+        );
         self.callback_add(
             "/router/isis/interface/ipv4/prefix-sid/index",
             link::config_ipv4_prefix_sid_index,

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -210,6 +210,21 @@ pub struct LinkConfig {
     /// to the link's `metric` leaf above. PR 2 reads this when
     /// emitting MT IS Reach (TLV 222) entries.
     pub mt_metrics: BTreeMap<MtId, u32>,
+
+    /// Per-interface BFD attachment recorded from
+    /// `/router/isis/interface/<name>/bfd/{enable,profile}`. Storage
+    /// in PR 6; the adjacency FSM subscribe path (on Up) and the
+    /// BfdEvent::Down → adjacency teardown path arrive in PR 7.
+    pub bfd: LinkBfdConfig,
+}
+
+/// IS-IS-side mirror of the YANG `bfd { enable, profile }` container.
+/// Empty defaults match the YANG schema; PR 7 reads this when the
+/// adjacency FSM reaches Up to decide whether to subscribe.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct LinkBfdConfig {
+    pub enable: bool,
+    pub profile: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, EnumString, Display)]
@@ -658,6 +673,30 @@ pub fn config_priority(isis: &mut Isis, mut args: Args, _op: ConfigOp) -> Option
     let msg = Message::Ifsm(IfsmEvent::DisSelection, link.ifindex, None);
     let _ = isis.tx.send(msg);
 
+    Some(())
+}
+
+/// `set router isis interface X bfd enable true|false` — flips the
+/// per-interface BFD attachment recorded on the IS-IS link. PR 6
+/// is storage-only; PR 7 wires the runtime subscribe path (on
+/// adjacency FSM Up) and the teardown path (on BfdEvent::Down).
+pub fn config_bfd_enable(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let enable = args.boolean()?;
+    let link = isis.links.get_mut_by_name(&name)?;
+    link.config.bfd.enable = op.is_set() && enable;
+    Some(())
+}
+
+/// `set router isis interface X bfd profile NAME` — records the
+/// BFD profile to apply when this interface's adjacencies form a
+/// BFD session. Stored verbatim; resolution against
+/// `/bfd/profile/<name>` is the runtime subscribe path's job.
+pub fn config_bfd_profile(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let profile = args.string()?;
+    let link = isis.links.get_mut_by_name(&name)?;
+    link.config.bfd.profile = op.is_set().then_some(profile);
     Some(())
 }
 
@@ -1553,4 +1592,40 @@ pub fn show_dis_history(
     }
 
     Ok(buf)
+}
+
+#[cfg(test)]
+mod bfd_config_tests {
+    use super::*;
+
+    /// LinkBfdConfig default mirrors the YANG defaults
+    /// (`enable=false`, no profile).
+    #[test]
+    fn default_bfd_is_disabled() {
+        let bfd = LinkBfdConfig::default();
+        assert!(!bfd.enable);
+        assert!(bfd.profile.is_none());
+
+        // Lives on LinkConfig with the same default.
+        let lc = LinkConfig::default();
+        assert_eq!(lc.bfd, bfd);
+    }
+
+    /// Round-trip: setting enable + profile mirrors the CLI flow
+    /// (`bfd enable true; bfd profile FAST`) producing the state
+    /// the PR 7 adjacency-FSM subscribe path will read.
+    #[test]
+    fn enable_and_profile_round_trip() {
+        let mut lc = LinkConfig::default();
+        lc.bfd.enable = true;
+        lc.bfd.profile = Some("FAST".to_string());
+
+        assert_eq!(
+            lc.bfd,
+            LinkBfdConfig {
+                enable: true,
+                profile: Some("FAST".to_string()),
+            },
+        );
+    }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -606,6 +606,33 @@ module config {
               type uint32;
             }
           }
+
+          container bfd {
+            ext:help "BFD attachment for this IS-IS interface";
+            description
+              "Per-interface BFD attachment for IS-IS. When `enable`
+               is true the IS-IS adjacency FSM subscribes a BFD
+               session at the moment it reaches Up; a subsequent
+               BFD Down event drives the adjacency back to Down
+               per RFC 5882 §5. Storage-only in PR 6; PR 7 wires
+               the runtime subscribe / teardown calls.";
+
+            leaf enable {
+              type boolean;
+              default false;
+              description
+                "Activates the BFD session for adjacencies on this
+                 interface. Disabling (or removing the `bfd` block)
+                 detaches the session.";
+            }
+
+            leaf profile {
+              type string;
+              description
+                "Name of a `/bfd/profile` entry whose parameters
+                 apply to BFD sessions formed on this interface.";
+            }
+          }
         }
         container tracing {
           leaf all {


### PR DESCRIPTION
## Summary

Storage-only step for IS-IS BFD integration, mirroring PR 5b's
BGP work. Adds an FRR-style `bfd { enable, profile }` container
under each IS-IS interface in YANG, mirrors the leaves on the
existing `LinkConfig`, and registers the matching callbacks. No
subscribe / teardown traffic flows yet — PR 7 wires the
adjacency-FSM trigger and `BfdEvent` handling.

- **`zebra-rs/yang/config.yang`** — adds `container bfd { leaf
  enable; leaf profile; }` under `/router/isis/interface`. Defined
  inline in `config.yang` (rather than as a separate augment
  module like `zebra-bgp-bfd.yang`) because IS-IS YANG is already
  inline.
- **`src/isis/link.rs`** — new `LinkBfdConfig { enable, profile }`
  plus `pub bfd: LinkBfdConfig` on `LinkConfig`. Two new callback
  functions `config_bfd_enable` / `config_bfd_profile` that mutate
  `link.config.bfd`, mirroring `config_priority` etc.
- **`src/isis/config.rs`** — registers the two callbacks under
  `/router/isis/interface/bfd/{enable,profile}`.

IS-IS gets BFD's `client_req_tx` for free from PR 5c
(`ConfigManager` publishes it; `spawn_isis` will grab it in PR 7).
The runtime subscribe path (on adjacency FSM Up) and
`BfdEvent::Down` teardown arrive in PR 7.

Net change: 110 lines.

## Test plan

- [x] `cargo test -p zebra-rs --bin zebra-rs -- isis::link::bfd_config_tests`
  — 2 new tests pass:
  - `default_bfd_is_disabled`
  - `enable_and_profile_round_trip`
- [x] `cargo test -p zebra-rs --bin zebra-rs -- bfd:: bgp::` — 99
  existing tests still pass
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

Generated with [Claude Code](https://claude.com/claude-code)