### PR TITLE
isis: per-fragment seq-number wrap freeze

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -135,15 +135,25 @@ pub struct Isis {
     /// reservations don't leak across prefix swaps.
     pub elib: super::srv6::ElibPool,
 
-    /// Per-level seq-number-wrap wait. Armed when `lsp_generate`
-    /// would have emitted a self-LSP with seq == 0xFFFFFFFF: we
-    /// instead push a purge (RemainingLifetime = 0) and freeze
-    /// self-LSP origination until this timer fires, then re-originate
-    /// with seq = 1. Wait length = `config.hold_time() + 60s` —
-    /// long enough that any peer's surviving copy of our old LSP has
-    /// aged out so they accept the seq = 1 origination as newer.
+    /// Per-fragment seq-number-wrap wait. Keyed by fragment id
+    /// (LSPID byte 7). Armed when a fragment's next emission would
+    /// hit seq == 0xFFFFFFFF: we push a purge (RemainingLifetime = 0)
+    /// for that specific fragment and freeze its re-emission until
+    /// the timer fires, then re-originate with seq = 1.
+    ///
+    /// Wait length = `config.hold_time() + 60s` — long enough that
+    /// any peer's surviving copy of our old fragment has fully aged
+    /// out so they accept the seq = 1 origination as newer.
+    ///
+    /// Fragment 0's freeze blocks the entire LSP set from emitting,
+    /// since receivers treat a router without fragment 0 as missing
+    /// its node-wide attributes (hostname, capability, OL bit) and
+    /// drop it from SPF. Higher fragments' freezes only suppress
+    /// that specific fragment's re-emission; the rest of the set
+    /// continues to refresh normally.
+    ///
     /// See ISO 10589 §7.3.16.4.
-    pub lsp_seq_wrap_wait: Levels<Option<Timer>>,
+    pub lsp_seq_wrap_wait: Levels<BTreeMap<u8, Timer>>,
 
     /// SRLG-update return channel from the RIB. Carries the full
     /// SRLG table snapshot on subscribe and after every commit that
@@ -210,10 +220,10 @@ pub struct IsisTop<'a> {
     /// names through this map when emitting TLVs 138 / 139.
     pub srlg_groups: &'a BTreeMap<String, SrlgGroup>,
 
-    /// Seq-wrap wait timer (see `Isis::lsp_seq_wrap_wait`). Threaded
-    /// through so `lsp_generate` can short-circuit and arm the timer
-    /// without round-tripping through the event loop.
-    pub lsp_seq_wrap_wait: &'a mut Levels<Option<Timer>>,
+    /// Seq-wrap wait timers (see `Isis::lsp_seq_wrap_wait`). Threaded
+    /// through so `lsp_generate` can short-circuit per fragment and
+    /// arm the timer without round-tripping through the event loop.
+    pub lsp_seq_wrap_wait: &'a mut Levels<BTreeMap<u8, Timer>>,
 }
 
 impl Isis {
@@ -300,7 +310,7 @@ impl Isis {
             sr_locator: None,
             sr_end_sid: None,
             elib: super::srv6::ElibPool::new(),
-            lsp_seq_wrap_wait: Levels::<Option<Timer>>::default(),
+            lsp_seq_wrap_wait: Levels::<BTreeMap<u8, Timer>>::default(),
             srlg_rx,
             srlg_groups: BTreeMap::new(),
             bfd_client_tx,
@@ -509,8 +519,8 @@ impl Isis {
                     *link.timer.csnp.get_mut(&level) = Some(csnp_timer(&link, level));
                 }
             }
-            Message::LspSeqWrapClear(level) => {
-                self.process_lsp_seq_wrap_clear(level);
+            Message::LspSeqWrapClear(level, frag_id) => {
+                self.process_lsp_seq_wrap_clear(level, frag_id);
             }
             Message::BfdSubscribe(key) => {
                 self.process_bfd_subscribe(key);
@@ -682,20 +692,22 @@ impl Isis {
         // lsp_flood(&mut top, level, &lsp_id);
     }
 
-    /// ISO 10589 §7.3.16.4 wait expired: drop the per-level freeze,
-    /// drop the purged self-LSP record from the local LSDB so the
-    /// next `lsp_generate` sees no existing entry and computes
-    /// seq = 1, then kick LSP origination.
-    fn process_lsp_seq_wrap_clear(&mut self, level: Level) {
+    /// ISO 10589 §7.3.16.4 wait expired for one specific fragment:
+    /// drop the per-fragment freeze entry, drop that fragment's
+    /// purged self-LSP record from the local LSDB so the next
+    /// `lsp_generate` sees no existing entry and computes seq = 1
+    /// for it, then kick LSP origination.
+    fn process_lsp_seq_wrap_clear(&mut self, level: Level, frag_id: u8) {
         isis_event_trace!(
             self.tracing,
             LspOriginate,
             &level,
-            "[LspSeqWrap] MaxAge wait expired — clearing freeze and re-originating from seq 1"
+            "[LspSeqWrap] fragment {} MaxAge wait expired — clearing freeze and re-originating from seq 1",
+            frag_id
         );
-        *self.lsp_seq_wrap_wait.get_mut(&level) = None;
+        self.lsp_seq_wrap_wait.get_mut(&level).remove(&frag_id);
 
-        let lsp_id = IsisLspId::new(self.config.net.sys_id(), 0, 0);
+        let lsp_id = IsisLspId::new(self.config.net.sys_id(), 0, frag_id);
         self.lsdb.get_mut(&level).remove(&lsp_id);
 
         let _ = self.tx.send(Message::LspOriginate(level, None));
@@ -1164,10 +1176,11 @@ pub enum Message {
     SpfCalc(Level),
     AdjacencyUp(Level, u32),
     /// MaxAge wait expired after a seq-number-wrap purge (ISO 10589
-    /// §7.3.16.4). Clears the per-level freeze and re-originates the
-    /// self LSP, which will compute seq = 1 (no existing entry in
-    /// LSDB once the purge has been removed).
-    LspSeqWrapClear(Level),
+    /// §7.3.16.4). Clears the per-fragment freeze entry for
+    /// `(level, fragment_id)` and re-originates the self LSP set,
+    /// which will compute seq = 1 for the freshly-unfrozen fragment
+    /// (no existing entry in LSDB once the purge has been removed).
+    LspSeqWrapClear(Level, u8),
     /// An adjacency on a `bfd { enable true }` interface reached
     /// Up. The IS-IS event loop forwards this as a
     /// `ClientReq::Subscribe` against the BFD instance — see
@@ -1219,8 +1232,8 @@ impl Display for Message {
             Message::BfdUnsubscribe(key) => {
                 write!(f, "[Message::BfdUnsubscribe({:?})]", key.remote)
             }
-            Message::LspSeqWrapClear(level) => {
-                write!(f, "[Message::LspSeqWrapClear({})]", level)
+            Message::LspSeqWrapClear(level, frag_id) => {
+                write!(f, "[Message::LspSeqWrapClear({}, frag={})]", level, frag_id)
             }
         }
     }

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -366,17 +366,21 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
     // get their own seq from the LSDB at emit time.
     let frag0_id = IsisLspId::new(top.config.net.sys_id(), 0, 0);
 
-    // ISO 10589 §7.3.16.4: when the previous origination's seq hit
-    // 0xFFFFFFFF we sent a purge and armed a freeze. Until that
-    // expires we must not emit a fresh self-LSP — origination is
-    // suppressed entirely (Cisco-style pragmatic interpretation of
-    // "IS-IS process disabled").
-    if top.lsp_seq_wrap_wait.get(&level).is_some() {
+    // ISO 10589 §7.3.16.4: when fragment 0's previous origination's
+    // seq hit 0xFFFFFFFF we sent a purge and armed a freeze. While
+    // that freeze is active we must not emit any of the LSP set —
+    // receivers treat a router whose fragment 0 is absent as missing
+    // its node-wide attributes (hostname, capability, OL bit) and
+    // drop it from SPF, so refreshing higher fragments while frag 0
+    // is in zero-age limbo would just churn the network. Higher
+    // fragments' freezes are scoped to that one fragment and handled
+    // post-pack below.
+    if top.lsp_seq_wrap_wait.get(&level).contains_key(&0) {
         isis_event_trace!(
             top.tracing,
             LspOriginate,
             &level,
-            "[LspOriginate] suppressed — seq-wrap freeze in effect"
+            "[LspOriginate] suppressed — fragment 0 seq-wrap freeze in effect"
         );
         return Vec::new();
     }
@@ -413,34 +417,25 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
         frag0_seq
     );
 
-    // ISO 10589 §7.3.16.4: sequence-number wrap-up.
+    // ISO 10589 §7.3.16.4: sequence-number wrap-up for fragment 0.
     //
     // Emit one final LSP at seq = 0xFFFFFFFF with RemainingLifetime
     // = 0 (the purge), then freeze origination for
     // `lsp_hold_time + ZeroAgeLifetime` so any surviving copy in any
     // peer's LSDB has fully aged out. When the freeze clears, the
     // LSDB entry is dropped and the next origination computes
-    // seq = 1 from scratch. Wrap check is fragment-0 only here; per-
-    // fragment wrap (and the per-fragment freeze table that needs)
-    // is the follow-up after the packer lands.
+    // seq = 1 from scratch. Fragment 0's freeze is special — its
+    // absence makes the whole node unusable for SPF — so it short-
+    // circuits the entire origination. Higher fragments wrap
+    // independently and only suppress their own re-emission.
     if frag0_seq == u32::MAX {
         isis_event_trace!(
             top.tracing,
             LspOriginate,
             &level,
-            "[LspSeqWrap] hit u32::MAX — purging and freezing origination"
+            "[LspSeqWrap] fragment 0 hit u32::MAX — purging and freezing origination"
         );
-        let _ = top.tx.send(Message::LspPurge(level, frag0_id));
-
-        let wait_secs = top.config.hold_time().saturating_add(ZERO_AGE_LIFETIME);
-        let tx = top.tx.clone();
-        let timer = Timer::once(wait_secs as u64, move || {
-            let tx = tx.clone();
-            async move {
-                let _ = tx.send(Message::LspSeqWrapClear(level));
-            }
-        });
-        *top.lsp_seq_wrap_wait.get_mut(&level) = Some(timer);
+        arm_seq_wrap_freeze(top, level, frag0_id);
         return Vec::new();
     }
 
@@ -1038,23 +1033,78 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
     );
 
     // Resolve seq numbers per fragment. Fragment 0 uses the seq we
-    // computed above (with seq_floor); higher fragments derive their
-    // seq from the LSDB (existing+1 or 1). Per-fragment seq-wrap
-    // detection is intentionally deferred — Phase 4 generalises the
-    // wrap freeze table from per-level to per-(level, fragment_id).
-    for frag in fragments.iter_mut() {
-        if frag.lsp_id.fragment_id() == 0 {
+    // computed above (with seq_floor + wrap detection already
+    // applied). Higher fragments derive their seq from the LSDB
+    // (existing+1 or 1) and run wrap detection independently — if a
+    // fragment's seq would hit u32::MAX we purge that fragment,
+    // arm its own freeze timer, and drop it from the emit set. The
+    // rest of the LSP set continues to refresh normally.
+    let mut emit_set: Vec<IsisLsp> = Vec::with_capacity(fragments.len());
+    for mut frag in fragments.drain(..) {
+        let frag_id = frag.lsp_id.fragment_id();
+        if frag_id == 0 {
             frag.seq_number = frag0_seq;
-        } else {
-            let existing = top
-                .lsdb
-                .get(&level)
-                .get(&frag.lsp_id)
-                .map(|x| x.lsp.seq_number);
-            frag.seq_number = existing.map(|e| e.saturating_add(1)).unwrap_or(0x0001);
+            emit_set.push(frag);
+            continue;
         }
+
+        // Per-fragment freeze suppresses this fragment's re-emission
+        // until its `MaxAge + safety` timer fires; other fragments
+        // continue refreshing.
+        if top.lsp_seq_wrap_wait.get(&level).contains_key(&frag_id) {
+            isis_event_trace!(
+                top.tracing,
+                LspOriginate,
+                &level,
+                "[LspOriginate] fragment {} suppressed — seq-wrap freeze in effect",
+                frag_id
+            );
+            continue;
+        }
+
+        let existing = top
+            .lsdb
+            .get(&level)
+            .get(&frag.lsp_id)
+            .map(|x| x.lsp.seq_number);
+        let seq = existing.map(|e| e.saturating_add(1)).unwrap_or(0x0001);
+        if seq == u32::MAX {
+            isis_event_trace!(
+                top.tracing,
+                LspOriginate,
+                &level,
+                "[LspSeqWrap] fragment {} hit u32::MAX — purging and freezing this fragment",
+                frag_id
+            );
+            arm_seq_wrap_freeze(top, level, frag.lsp_id);
+            continue;
+        }
+        frag.seq_number = seq;
+        emit_set.push(frag);
     }
-    fragments
+    emit_set
+}
+
+/// Schedule the seq-wrap purge + freeze timer for one specific
+/// fragment. Sends `Message::LspPurge` so the standard purge path
+/// emits a `RemainingLifetime = 0` LSP at the wrapping seq, then
+/// installs a `MaxAge + ZeroAgeLifetime` timer that fires
+/// `Message::LspSeqWrapClear(level, frag_id)`; the clear handler
+/// drops the LSDB entry and re-triggers origination, allowing the
+/// next emit to compute seq = 1 from scratch.
+fn arm_seq_wrap_freeze(top: &mut IsisTop, level: Level, lsp_id: IsisLspId) {
+    let _ = top.tx.send(Message::LspPurge(level, lsp_id));
+
+    let wait_secs = top.config.hold_time().saturating_add(ZERO_AGE_LIFETIME);
+    let frag_id = lsp_id.fragment_id();
+    let tx = top.tx.clone();
+    let timer = Timer::once(wait_secs as u64, move || {
+        let tx = tx.clone();
+        async move {
+            let _ = tx.send(Message::LspSeqWrapClear(level, frag_id));
+        }
+    });
+    top.lsp_seq_wrap_wait.get_mut(&level).insert(frag_id, timer);
 }
 
 pub fn lsp_emit(lsp: &mut IsisLsp, level: Level) -> BytesMut {


### PR DESCRIPTION
## Summary

Sub-PR 3c of the IS-IS LSP fragmentation series. Generalises ISO 10589 §7.3.16.4 sequence-number-wrap handling from per-level to **per-(level, fragment)**. Each LSP fragment now has its own MAX-seq lifecycle: when fragment k's next emission would hit \`0xFFFFFFFF\` we purge that fragment, freeze its re-emission until \`MaxAge + ZeroAgeLifetime\`, and continue emitting the rest of the LSP set. Fragment 0 retains its special-case short-circuit (its freeze suppresses the whole origination because receivers treat a router without fragment 0 as missing its node-wide attributes and drop it from SPF).

- \`lsp_seq_wrap_wait\` shape: \`Levels<Option<Timer>>\` → \`Levels<BTreeMap<u8, Timer>>\`.
- \`Message::LspSeqWrapClear(Level)\` → \`LspSeqWrapClear(Level, u8)\`.
- \`process_lsp_seq_wrap_clear\` drops just the (level, frag) wait entry and matching LSDB entry, then re-originates.
- \`lsp_generate\`'s post-pack seq-resolution loop performs per-fragment freeze-check + wrap detection: frozen fragments are filtered out of the emit set; MAX-seq fragments arm a purge + freeze and are dropped from this emission.
- New private helper \`arm_seq_wrap_freeze(top, level, lsp_id)\` consolidates the purge + timer-arm sequence used by both fragment 0's top-of-function path and the higher-fragment loop.

**Audit finding flagged for follow-up** (not in this PR): \`tilfa.rs:236\` walks only fragment 0's \`ExtIsReach\` when scoring an LFA candidate, so peers with IS-reach spread across fragments would have later-fragment edges invisible to TI-LFA. Fix needs the same union-across-fragments treatment that \`rebuild_sys_state\` already does on the receive side.

Diff: +129 / −66 across 2 files.

## Test plan

- [x] \`cargo build -p zebra-rs\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo test --workspace --exclude bdd\` all green (389 zebra-rs tests, isis::lsp regression net unchanged)

Generated with [Claude Code](https://claude.com/claude-code)