### PR TITLE
isis: walk all fragments when resolving TI-LFA adj-SIDs

### DIFF
--- a/zebra-rs/src/isis/tilfa.rs
+++ b/zebra-rs/src/isis/tilfa.rs
@@ -3,7 +3,7 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 
 use isis_packet::neigh;
 use isis_packet::srv6::EncapType;
-use isis_packet::{IsisLspId, IsisNeighborId, IsisSysId, IsisTlv, SidLabelValue};
+use isis_packet::{IsisNeighborId, IsisSysId, IsisTlv, SidLabelValue};
 
 use crate::rib;
 use crate::spf;
@@ -233,46 +233,55 @@ fn adj_sid_label_for_link(
         IsisNeighborId::from_sys_id(&to_sys, 0)
     };
 
-    let lsp_key = IsisLspId::new(from_sys, 0, 0);
-    let lsa = top.lsdb.get(&level).get(&lsp_key)?;
-    for tlv in &lsa.lsp.tlvs {
-        let IsisTlv::ExtIsReach(reach) = tlv else {
+    // Walk every non-pseudonode fragment originated by `from_sys` at
+    // this level. With send-side LSP fragmentation a router spreads
+    // its TLV 22 (ExtIsReach) entries across fragments 0..N, so the
+    // adjacency carrying the adj-SID can live in any of them. Frag-0-
+    // only would miss SIDs for any adjacency whose IS-reach entry the
+    // packer placed in a higher fragment.
+    for (lsp_id, lsa) in top.lsdb.get(&level).iter() {
+        if lsp_id.sys_id() != from_sys || lsp_id.is_pseudo() {
             continue;
-        };
-        for entry in &reach.entries {
-            if entry.neighbor_id != target_neighbor_id {
+        }
+        for tlv in &lsa.lsp.tlvs {
+            let IsisTlv::ExtIsReach(reach) = tlv else {
                 continue;
-            }
-            for sub in &entry.subs {
-                match sub {
-                    neigh::IsisSubTlv::AdjSid(adj) => {
-                        if let Some(l) = resolve_sid_to_label(
-                            top,
-                            level,
-                            &from_sys,
-                            &adj.sid,
-                            SrBlockKind::Local,
-                        ) {
-                            return Some(l);
-                        }
-                    }
-                    neigh::IsisSubTlv::LanAdjSid(lan_adj) => {
-                        let Some(to_sys) = top.lsp_map.get(&level).resolve(to_vertex) else {
-                            continue;
-                        };
-                        if &lan_adj.system_id == to_sys
-                            && let Some(l) = resolve_sid_to_label(
+            };
+            for entry in &reach.entries {
+                if entry.neighbor_id != target_neighbor_id {
+                    continue;
+                }
+                for sub in &entry.subs {
+                    match sub {
+                        neigh::IsisSubTlv::AdjSid(adj) => {
+                            if let Some(l) = resolve_sid_to_label(
                                 top,
                                 level,
                                 &from_sys,
-                                &lan_adj.sid,
+                                &adj.sid,
                                 SrBlockKind::Local,
-                            )
-                        {
-                            return Some(l);
+                            ) {
+                                return Some(l);
+                            }
                         }
+                        neigh::IsisSubTlv::LanAdjSid(lan_adj) => {
+                            let Some(to_sys) = top.lsp_map.get(&level).resolve(to_vertex) else {
+                                continue;
+                            };
+                            if &lan_adj.system_id == to_sys
+                                && let Some(l) = resolve_sid_to_label(
+                                    top,
+                                    level,
+                                    &from_sys,
+                                    &lan_adj.sid,
+                                    SrBlockKind::Local,
+                                )
+                            {
+                                return Some(l);
+                            }
+                        }
+                        _ => {}
                     }
-                    _ => {}
                 }
             }
         }


### PR DESCRIPTION
## Summary

\`adj_sid_label_for_link\` looked up the peer's adjacency-SID by reaching directly into fragment 0 of the originator's self-LSP (\`IsisLspId::new(from_sys, 0, 0)\`) and scanning that one LSDB entry's TLV 22 entries. After the send-side LSP fragmentation packer landed (PR #583), the originator may have placed the matching IS-Reach entry in fragment 1, 2, etc. — so the lookup returned \`None\` and the caller installed a partial / missing repair-path label stack.

**Fix**: iterate every non-pseudonode LSDB fragment originated by \`from_sys\` at this level and scan each one's \`ExtIsReach\` TLVs. Mirrors the union-across-fragments treatment that \`rebuild_sys_state\` already performs on the receive side for hostname / cap / reach maps.

Audit confirms this is the only direct-LSDB walk that needed the change: \`node_sid_label_for_vertex\` and the build_repair_path_* helpers go through \`top.reach_map\` / \`top.srv6_end_map\` / \`top.label_map\`, which are already rebuilt as fragment-union maps by \`rebuild_sys_state\`.

Closes the follow-up flagged in PR #585 (per-fragment seq-wrap).

Diff: +42 / −33 in one file.

## Test plan

- [x] \`cargo build -p zebra-rs\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo test --workspace --exclude bdd\` all green (no behavior changes to the existing TI-LFA regression net — this fixes a path that didn't have coverage before fragmentation existed)

Generated with [Claude Code](https://claude.com/claude-code)