### PR TITLE
isis: stable TLV placement memory for self-LSP packer

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -33,7 +33,7 @@ use super::ifsm::{csnp_timer, has_level};
 use super::link::{Afis, IsisLinks, LinkTop};
 use super::lsdb::insert_self_originate;
 use super::lsp::{
-    dis_generate, lsp_emit, lsp_generate, resolve_dis_ifindex, target_block_name,
+    TlvKey, dis_generate, lsp_emit, lsp_generate, resolve_dis_ifindex, target_block_name,
     target_locator_name,
 };
 use super::nfsm::nbr_hold_timer_expire;
@@ -155,6 +155,27 @@ pub struct Isis {
     /// See ISO 10589 §7.3.16.4.
     pub lsp_seq_wrap_wait: Levels<BTreeMap<u8, Timer>>,
 
+    /// Memoised TLV-to-fragment placement for the router's self-LSP
+    /// set, keyed by stable per-TLV identity (e.g. TLV 22 keyed by
+    /// neighbor id). The packer consults this before greedy bin-
+    /// packing so a previously-placed TLV ends up in the same
+    /// fragment it lived in last origination, as long as it still
+    /// fits. Without this, adding or removing one TLV can cascade-
+    /// shift every TLV after it across fragment boundaries, causing
+    /// every fragment's seq + checksum to churn and the whole set
+    /// to re-flood.
+    ///
+    /// The memory is rebuilt from scratch after every successful
+    /// origination — only TLVs in the emitted fragments get
+    /// recorded, so stale entries (TLVs that disappeared from the
+    /// origination) naturally fall out.
+    ///
+    /// Only the router LSP path stabilises today. Pseudonode LSPs
+    /// (`dis_generate`) use the greedy packer directly; their
+    /// neighbor list is comparatively static so reshuffle pressure
+    /// is low.
+    pub lsp_placement_memory: Levels<BTreeMap<TlvKey, u8>>,
+
     /// SRLG-update return channel from the RIB. Carries the full
     /// SRLG table snapshot on subscribe and after every commit that
     /// changes any group.
@@ -224,6 +245,10 @@ pub struct IsisTop<'a> {
     /// through so `lsp_generate` can short-circuit per fragment and
     /// arm the timer without round-tripping through the event loop.
     pub lsp_seq_wrap_wait: &'a mut Levels<BTreeMap<u8, Timer>>,
+
+    /// Stable-placement memory for the self-LSP packer; see
+    /// `Isis::lsp_placement_memory`.
+    pub lsp_placement_memory: &'a mut Levels<BTreeMap<TlvKey, u8>>,
 }
 
 impl Isis {
@@ -311,6 +336,7 @@ impl Isis {
             sr_end_sid: None,
             elib: super::srv6::ElibPool::new(),
             lsp_seq_wrap_wait: Levels::<BTreeMap<u8, Timer>>::default(),
+            lsp_placement_memory: Levels::<BTreeMap<TlvKey, u8>>::default(),
             srlg_rx,
             srlg_groups: BTreeMap::new(),
             bfd_client_tx,
@@ -970,6 +996,7 @@ impl Isis {
             sr_end_sid: &self.sr_end_sid,
             srlg_groups: &self.srlg_groups,
             lsp_seq_wrap_wait: &mut self.lsp_seq_wrap_wait,
+            lsp_placement_memory: &mut self.lsp_placement_memory,
         }
     }
 

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::net::Ipv4Addr;
 
 use bytes::BytesMut;
@@ -29,6 +30,36 @@ const LSP_PDU_OVERHEAD: usize = 27;
 /// list overflows this boundary into multiple TLV instances of
 /// the same type before the packer ever sees them.
 const TLV_WIRE_MAX: usize = 257;
+
+/// Stable identity for a single-entry distributable TLV instance.
+/// Lets the packer place this TLV in the same fragment it lived in
+/// last time we originated — so adding or removing a neighbor only
+/// shifts that one TLV instead of reshuffling the whole set.
+///
+/// Multi-entry TLVs (TLV 135 / 236 / 237 / 222 with more than one
+/// entry per instance) are not keyed in this first cut; the
+/// splitter shards them and each shard's identity depends on entry
+/// ordering, so per-entry stability needs a different model. Those
+/// TLVs go through the greedy fall-back path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TlvKey {
+    /// TLV 22 instance with exactly one neighbor entry. Our LSP
+    /// builder emits one such instance per local adjacency, so the
+    /// key uniquely identifies a per-adjacency TLV.
+    ExtIsReach(IsisNeighborId),
+}
+
+/// Return the stable key for a TLV instance, if one is defined.
+/// Used both for "where did this TLV go last time?" lookups and
+/// for "record where this TLV ended up this time" writes.
+pub(super) fn key_for_tlv(tlv: &IsisTlv) -> Option<TlvKey> {
+    match tlv {
+        IsisTlv::ExtIsReach(t) if t.entries.len() == 1 => {
+            Some(TlvKey::ExtIsReach(t.entries[0].neighbor_id))
+        }
+        _ => None,
+    }
+}
 
 use super::config::{IsisConfig, MtId};
 use super::ifsm::has_level;
@@ -236,6 +267,7 @@ fn pack_into_fragments(
     types: IsisLspTypes,
     hold_time: u16,
     lsp_mtu_size: u16,
+    memory: Option<&BTreeMap<TlvKey, u8>>,
 ) -> Vec<IsisLsp> {
     let mtu = lsp_mtu_size as usize;
     let budget = mtu.saturating_sub(LSP_PDU_OVERHEAD);
@@ -258,30 +290,79 @@ fn pack_into_fragments(
     });
     frag_bytes.push(anchor_bytes);
 
+    // Pre-open any non-zero fragments that the memory expects to
+    // exist, so a hint pointing at frag 5 finds a slot even if
+    // earlier-in-iteration TLVs haven't filled up frags 1..4 yet.
+    // Empty fragments at the tail are valid wire output — receivers
+    // accept them — and the tail-purge logic in
+    // `process_lsp_originate` retires any that go unused.
+    if let Some(m) = memory
+        && let Some(&max_hint) = m.values().max()
+        && max_hint > 0
+    {
+        for i in 1..=max_hint as usize {
+            if i >= frags.len() {
+                let frag_id = i as u8;
+                frags.push(IsisLsp {
+                    hold_time,
+                    lsp_id: IsisLspId::from_neighbor_id(base, frag_id),
+                    types,
+                    tlvs: Vec::new(),
+                    ..Default::default()
+                });
+                frag_bytes.push(0);
+            }
+        }
+    }
+
     for tlv in distributable {
         let n = tlv.wire_len();
-        let target = (0..frags.len()).find(|&i| frag_bytes[i] + n <= budget);
-        if let Some(i) = target {
-            frags[i].tlvs.push(tlv);
-            frag_bytes[i] += n;
-        } else {
-            if frags.len() >= 256 {
-                tracing::warn!(
-                    "[LspPack] LSPDBOverflow: cannot fit TLV (wire_len={}) in any of 256 fragments; dropping",
-                    n
-                );
-                break;
+
+        // Honor the placement memory first: if this TLV has a stable
+        // key and the remembered fragment still has room, slot it
+        // there. Falls through to greedy when the hint is stale (no
+        // remembered fragment, fragment gone, or doesn't fit).
+        let hint = memory
+            .and_then(|m| key_for_tlv(&tlv).and_then(|k| m.get(&k)))
+            .copied();
+        let target = hint
+            .filter(|&h| (h as usize) < frags.len() && frag_bytes[h as usize] + n <= budget)
+            .map(|h| h as usize)
+            .or_else(|| (0..frags.len()).find(|&i| frag_bytes[i] + n <= budget));
+
+        match target {
+            Some(i) => {
+                frags[i].tlvs.push(tlv);
+                frag_bytes[i] += n;
             }
-            let frag_id = frags.len() as u8;
-            frags.push(IsisLsp {
-                hold_time,
-                lsp_id: IsisLspId::from_neighbor_id(base, frag_id),
-                types,
-                tlvs: vec![tlv],
-                ..Default::default()
-            });
-            frag_bytes.push(n);
+            None => {
+                if frags.len() >= 256 {
+                    tracing::warn!(
+                        "[LspPack] LSPDBOverflow: cannot fit TLV (wire_len={}) in any of 256 fragments; dropping",
+                        n
+                    );
+                    break;
+                }
+                let frag_id = frags.len() as u8;
+                frags.push(IsisLsp {
+                    hold_time,
+                    lsp_id: IsisLspId::from_neighbor_id(base, frag_id),
+                    types,
+                    tlvs: vec![tlv],
+                    ..Default::default()
+                });
+                frag_bytes.push(n);
+            }
         }
+    }
+
+    // Drop trailing empty fragments — these are pre-opened slots
+    // for hints that turned out to be stale (or never reached).
+    // Keeping them would emit empty LSPs and trigger tail-purge
+    // unnecessarily on the very next origination.
+    while frags.len() > 1 && frag_bytes.last() == Some(&0) {
+        frags.pop();
+        frag_bytes.pop();
     }
 
     frags
@@ -333,6 +414,10 @@ pub fn dis_generate(
         split_distributable_at_255(IsisTlv::ExtIsReach(is_reach))
     };
 
+    // Pseudonode LSPs don't use placement memory today — see
+    // `Isis::lsp_placement_memory`. The LAN's neighbor list rarely
+    // churns once DIS election settles, so the cost-benefit of a
+    // per-pseudonode memory map isn't there yet.
     let mut fragments = pack_into_fragments(
         Vec::new(),
         distributable,
@@ -340,6 +425,7 @@ pub fn dis_generate(
         types,
         top.config.hold_time(),
         top.config.lsp_mtu_size(),
+        None,
     );
 
     // Resolve seq numbers per fragment. Fragment 0 honors `base`
@@ -1044,6 +1130,10 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
         .collect();
 
     // Bin-pack into fragments under the configured originatingLSPBufferSize.
+    // Pass the stable-placement memory so per-adjacency TLV 22
+    // instances land in the same fragment they previously occupied
+    // (when they still fit), avoiding cascade reshuffles when one
+    // adjacency joins or leaves.
     let mut fragments = pack_into_fragments(
         anchors,
         distributable,
@@ -1051,6 +1141,7 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
         types,
         top.config.hold_time(),
         top.config.lsp_mtu_size(),
+        Some(top.lsp_placement_memory.get(&level)),
     );
 
     // Resolve seq numbers per fragment. Fragment 0 uses the seq we
@@ -1103,6 +1194,27 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
         frag.seq_number = seq;
         emit_set.push(frag);
     }
+
+    // Refresh the stable-placement memory from this emission's
+    // actual placements. Built from scratch — only TLVs that
+    // survived (frag 0 always; higher fragments unless frozen)
+    // are recorded, so memory entries for dropped TLVs naturally
+    // age out. Frozen-fragment placements are intentionally
+    // forgotten — next emit will re-place those TLVs greedy.
+    let new_memory = {
+        let mut m: BTreeMap<TlvKey, u8> = BTreeMap::new();
+        for frag in &emit_set {
+            let frag_id = frag.lsp_id.fragment_id();
+            for tlv in &frag.tlvs {
+                if let Some(key) = key_for_tlv(tlv) {
+                    m.insert(key, frag_id);
+                }
+            }
+        }
+        m
+    };
+    *top.lsp_placement_memory.get_mut(&level) = new_memory;
+
     emit_set
 }
 
@@ -1395,6 +1507,7 @@ mod tests {
             IsisLspTypes::from(2),
             1200,
             1492,
+            None,
         );
         assert_eq!(frags.len(), 1, "everything fits in one fragment under 1492");
         let f0 = &frags[0];
@@ -1434,6 +1547,7 @@ mod tests {
             IsisLspTypes::from(2),
             1200,
             mtu,
+            None,
         );
         assert!(frags.len() >= 2, "expected packer to open fragment 1");
         assert_eq!(frags[0].lsp_id.fragment_id(), 0);
@@ -1447,5 +1561,110 @@ mod tests {
             .iter()
             .any(|t| matches!(t, IsisTlv::AreaAddr(_)));
         assert!(!anchor_in_one, "anchors must not leak into fragment 1");
+    }
+
+    fn ext_is_reach_for(b: u8) -> IsisTlv {
+        IsisTlv::ExtIsReach(IsisTlvExtIsReach {
+            entries: vec![IsisTlvExtIsReachEntry {
+                neighbor_id: IsisNeighborId::from_sys_id(
+                    &IsisSysId {
+                        id: [0, 0, 0, 0, 0, b],
+                    },
+                    0,
+                ),
+                metric: 10,
+                subs: vec![],
+            }],
+        })
+    }
+
+    fn frag_id_for(frags: &[IsisLsp], key: TlvKey) -> Option<u8> {
+        for f in frags {
+            for tlv in &f.tlvs {
+                if key_for_tlv(tlv) == Some(key) {
+                    return Some(f.lsp_id.fragment_id());
+                }
+            }
+        }
+        None
+    }
+
+    /// Greedy first-fit reshuffles when a TLV is removed mid-set:
+    /// downstream TLVs slide forward into the gap. With placement
+    /// memory the survivors stay in their previous fragment. Build
+    /// 5 ExtIsReach TLVs under a tight mtu so they span 2 fragments,
+    /// remember the placement, then re-pack with one removed and
+    /// verify nobody else moved.
+    #[test]
+    fn placement_memory_preserves_survivors_after_removal() {
+        let area = IsisTlv::AreaAddr(IsisTlvAreaAddr {
+            area_addr: vec![0x49, 0x00, 0x01],
+        });
+        let tlvs: Vec<IsisTlv> = (1..=5).map(ext_is_reach_for).collect();
+        let base = IsisNeighborId::from_sys_id(&IsisSysId::default(), 0);
+
+        // Tight mtu — anchors (3-byte area + 2-byte header) + 3 of
+        // these single-entry TLV 22 instances fit; the 4th spills.
+        // Each TLV 22 instance is ~16 bytes wire (2 header + 11
+        // entry + 1 sublen + 0 subs = 14, near the lower bound).
+        let mtu = (LSP_PDU_OVERHEAD + 5 + 3 * 18) as u16;
+
+        let frags = pack_into_fragments(
+            vec![area.clone()],
+            tlvs.clone(),
+            base,
+            IsisLspTypes::from(2),
+            1200,
+            mtu,
+            None,
+        );
+        assert!(
+            frags.len() >= 2,
+            "tight mtu should force at least 2 fragments"
+        );
+
+        // Snapshot every TLV's fragment id.
+        let mut memory: BTreeMap<TlvKey, u8> = BTreeMap::new();
+        let mut original: BTreeMap<TlvKey, u8> = BTreeMap::new();
+        for f in &frags {
+            for tlv in &f.tlvs {
+                if let Some(key) = key_for_tlv(tlv) {
+                    memory.insert(key, f.lsp_id.fragment_id());
+                    original.insert(key, f.lsp_id.fragment_id());
+                }
+            }
+        }
+
+        // Drop the third TLV (the one most likely to be at the
+        // boundary between fragments under tight budget) and re-pack
+        // with the memory in hand.
+        let mut tlvs_after = tlvs.clone();
+        let dropped_key = key_for_tlv(&tlvs[2]).expect("third TLV has a stable key");
+        tlvs_after.remove(2);
+        let frags_after = pack_into_fragments(
+            vec![area],
+            tlvs_after,
+            base,
+            IsisLspTypes::from(2),
+            1200,
+            mtu,
+            Some(&memory),
+        );
+
+        // Every survivor must be in the fragment it occupied before.
+        for (key, &was) in &original {
+            if *key == dropped_key {
+                continue;
+            }
+            let now = frag_id_for(&frags_after, *key);
+            assert_eq!(
+                now,
+                Some(was),
+                "TLV {:?} moved: was frag {} now frag {:?}",
+                key,
+                was,
+                now
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Greedy first-fit cascades reshuffles when a TLV joins or leaves mid-set: every TLV downstream of the change slides forward into the freed slot, bumping every fragment's seq + checksum and forcing the whole set to re-flood.

Add a small \`lsp_placement_memory\` per level on the \`Isis\` struct that maps each stable-keyed TLV to the fragment it last occupied. The packer consults this before greedy bin-packing — a previously-placed TLV stays in its remembered fragment as long as it still fits. New TLVs and TLVs whose memory entry no longer fits fall through to greedy.

- \`TlvKey::ExtIsReach(IsisNeighborId)\` covers single-entry TLV 22 (per-adjacency) only in this first cut — that's the highest-churn distributable TLV in real deployments (adjacency UP/DOWN, neighbor metric changes, adj-SID changes). Multi-entry TLVs (135 / 236 / 237 / 222) need per-entry stability to be worthwhile and would require restructuring the splitter; they pass through unchanged via the greedy fall-back.
- \`pack_into_fragments\` grows an \`Option<&BTreeMap<TlvKey, u8>>\` parameter. Pseudonode LSPs use \`None\` — the LAN's neighbor list is comparatively static once DIS election settles.
- Memory is rebuilt from scratch from the emit set after each origination, so stale entries (TLVs that disappeared) and entries for frozen fragments naturally age out.
- The packer pre-opens empty fragments up to the max hint, then drops trailing empty fragments — so a stale "hint at frag 5" doesn't permanently inflate the fragment count.

New unit test \`placement_memory_preserves_survivors_after_removal\` packs five per-adjacency TLV 22 instances under a tight mtu so they span two fragments, snapshots the placement, then re-packs with the middle TLV removed and verifies every remaining TLV stayed in its original fragment.

Diff: +267 / −21 across 2 files.

## Test plan

- [x] \`cargo build -p zebra-rs\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo test --workspace --exclude bdd\` all green (396 zebra-rs tests incl. the new placement-memory test)

Generated with [Claude Code](https://claude.com/claude-code)