### PR TITLE
bdd: integration scenario for IS-IS LSP fragmentation

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -28,6 +28,10 @@ isis_srv6:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_srv6"
 
+isis_fragmentation:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_fragmentation"
+
 bgp_evpn_capability:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_capability"
@@ -59,4 +63,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 bgp_evpn_capability bgp_route_map_match bgp_policy_dynamic_update generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation bgp_evpn_capability bgp_route_map_match bgp_policy_dynamic_update generate open docs FORCE

--- a/bdd/docs/isis_fragmentation.md
+++ b/bdd/docs/isis_fragmentation.md
@@ -1,0 +1,43 @@
+# IS-IS LSP fragmentation under a tight lsp-mtu-size
+
+## Overview
+
+As a network operator
+I want zebra-rs to fragment its self-originated LSP across multiple
+PDUs when the TLV content exceeds `lsp-mtu-size`, deliver every
+fragment to peers via the standard flooding path, and have the
+receiver correctly merge those fragments back into a single logical
+origin so SPF can still install routes to the originator's loopback.
+
+## Test Topology
+
+```
+  ┌────────────────────────────────────────┐
+  │                  br0                   │
+  └────────────┬───────────────┬───────────┘
+               │               │
+       2001:db8:1::1/64   2001:db8:1::2/64
+            (vz1ns)             (vz2ns)
+          ┌────┴────┐     ┌────┴────┐
+          │   z1    │     │   z2    │
+          │ MTU 400 │     │         │
+          │ 40 net  │     │         │
+          └─────────┘     └─────────┘
+   lo: 2001:db8:0:ffff::1   lo: 2001:db8:0:ffff::2
+              /128                  /128
+```
+
+## Config Files
+
+- z1-1.yaml: lsp-mtu-size 400 + 40 IPv6 networks. Forces the packer
+- z2-1.yaml: default config; verifies the receiver-side rebuild from
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup fragmentation topology | |
+| lsp-mtu-size shows up in show isis summary | |
+| z2 observes z1's self-LSP as multiple fragments | |
+| z2 reaches z1's loopback despite z1's self-LSP being fragmented | |
+| Teardown topology | |

--- a/bdd/tests/configs/isis_fragmentation/z1-1.yaml
+++ b/bdd/tests/configs/isis_fragmentation/z1-1.yaml
@@ -1,0 +1,73 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::1/128
+- if-name: vz1ns
+  ipv6:
+    address: 2001:db8:1::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    # Force fragmentation: 400-byte cap on each LSP PDU, then push
+    # well past one fragment's worth of TLV 236 reachability via 40
+    # /64 networks. Each entry costs 14 wire bytes (RFC 5308: 4
+    # metric + 1 flags + 1 prefix-len + 8 bytes of /64 prefix), so
+    # 40 entries → ~560 wire bytes of TLV 236 value, exceeding the
+    # single-TLV 255-byte ceiling. The splitter shards into multiple
+    # TLV 236 instances; the packer spreads them across fragments
+    # until each fits within lsp-mtu-size − 27 bytes of PDU overhead.
+    lsp-mtu-size: 400
+    afi-safi:
+    - name: ipv6
+      network:
+      - prefix: 2001:db8:cafe:00::/64
+      - prefix: 2001:db8:cafe:01::/64
+      - prefix: 2001:db8:cafe:02::/64
+      - prefix: 2001:db8:cafe:03::/64
+      - prefix: 2001:db8:cafe:04::/64
+      - prefix: 2001:db8:cafe:05::/64
+      - prefix: 2001:db8:cafe:06::/64
+      - prefix: 2001:db8:cafe:07::/64
+      - prefix: 2001:db8:cafe:08::/64
+      - prefix: 2001:db8:cafe:09::/64
+      - prefix: 2001:db8:cafe:0a::/64
+      - prefix: 2001:db8:cafe:0b::/64
+      - prefix: 2001:db8:cafe:0c::/64
+      - prefix: 2001:db8:cafe:0d::/64
+      - prefix: 2001:db8:cafe:0e::/64
+      - prefix: 2001:db8:cafe:0f::/64
+      - prefix: 2001:db8:cafe:10::/64
+      - prefix: 2001:db8:cafe:11::/64
+      - prefix: 2001:db8:cafe:12::/64
+      - prefix: 2001:db8:cafe:13::/64
+      - prefix: 2001:db8:cafe:14::/64
+      - prefix: 2001:db8:cafe:15::/64
+      - prefix: 2001:db8:cafe:16::/64
+      - prefix: 2001:db8:cafe:17::/64
+      - prefix: 2001:db8:cafe:18::/64
+      - prefix: 2001:db8:cafe:19::/64
+      - prefix: 2001:db8:cafe:1a::/64
+      - prefix: 2001:db8:cafe:1b::/64
+      - prefix: 2001:db8:cafe:1c::/64
+      - prefix: 2001:db8:cafe:1d::/64
+      - prefix: 2001:db8:cafe:1e::/64
+      - prefix: 2001:db8:cafe:1f::/64
+      - prefix: 2001:db8:cafe:20::/64
+      - prefix: 2001:db8:cafe:21::/64
+      - prefix: 2001:db8:cafe:22::/64
+      - prefix: 2001:db8:cafe:23::/64
+      - prefix: 2001:db8:cafe:24::/64
+      - prefix: 2001:db8:cafe:25::/64
+      - prefix: 2001:db8:cafe:26::/64
+      - prefix: 2001:db8:cafe:27::/64
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+    - if-name: vz1ns
+      circuit-type: level-2-only
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/isis_fragmentation/z2-1.yaml
+++ b/bdd/tests/configs/isis_fragmentation/z2-1.yaml
@@ -1,0 +1,21 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::2/128
+- if-name: vz2ns
+  ipv6:
+    address: 2001:db8:1::2/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+    - if-name: vz2ns
+      circuit-type: level-2-only
+      ipv6:
+        enable: true

--- a/bdd/tests/features/isis_fragmentation.feature
+++ b/bdd/tests/features/isis_fragmentation.feature
@@ -1,0 +1,68 @@
+@serial
+@isis_fragmentation
+Feature: IS-IS LSP fragmentation under a tight lsp-mtu-size
+  As a network operator
+  I want zebra-rs to fragment its self-originated LSP across multiple
+  PDUs when the TLV content exceeds `lsp-mtu-size`, deliver every
+  fragment to peers via the standard flooding path, and have the
+  receiver correctly merge those fragments back into a single logical
+  origin so SPF can still install routes to the originator's loopback.
+
+  Test Topology:
+  ```
+  ┌────────────────────────────────────────┐
+  │                  br0                   │
+  └────────────┬───────────────┬───────────┘
+               │               │
+       2001:db8:1::1/64   2001:db8:1::2/64
+            (vz1ns)             (vz2ns)
+          ┌────┴────┐     ┌────┴────┐
+          │   z1    │     │   z2    │
+          │ MTU 400 │     │         │
+          │ 40 net  │     │         │
+          └─────────┘     └─────────┘
+   lo: 2001:db8:0:ffff::1   lo: 2001:db8:0:ffff::2
+              /128                  /128
+  ```
+
+  Config files:
+  - z1-1.yaml: lsp-mtu-size 400 + 40 IPv6 networks. Forces the packer
+    to spread TLV 236 entries across multiple LSP fragments.
+  - z2-1.yaml: default config; verifies the receiver-side rebuild from
+    a fragmented peer LSP works end-to-end.
+
+  Scenario: Setup fragmentation topology
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with loopback and veth interface on the bridge "br0"
+    And I create namespace "z2" with loopback and veth interface on the bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 20 seconds
+    Then ping from "z1" to "2001:db8:1::2" should succeed
+    And ping from "z2" to "2001:db8:1::1" should succeed
+
+  Scenario: lsp-mtu-size shows up in show isis summary
+    Given the test topology exists
+    Then show command "show isis summary" in namespace "z1" should contain "LSP MTU: 400 bytes"
+
+  Scenario: z2 observes z1's self-LSP as multiple fragments
+    Given the test topology exists
+    Then show command "show isis database" in namespace "z2" should contain "Fragment Summary"
+    And show command "show isis database" in namespace "z2" should contain "z1.00"
+
+  Scenario: z2 reaches z1's loopback despite z1's self-LSP being fragmented
+    Given the test topology exists
+    Then ping from "z2" to "2001:db8:0:ffff::1" should succeed
+    And ping from "z1" to "2001:db8:0:ffff::2" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

End-to-end BDD scenario exercising every layer of the IS-IS LSP fragmentation work that landed in #577–#589. Forces multi-fragment self-LSP origination on one peer and verifies the other peer receives, correctly aggregates, and computes SPF over the fragmented set.

**Config**: \`z1-1.yaml\` sets \`lsp-mtu-size: 400\` (just above the \`LSP_PDU_OVERHEAD + max-TLV-wire\` floor where the packer can still fit a maxed single TLV) and pads \`afi-safi[ipv6]/network\` with 40 /64 prefixes. At 14 wire bytes each (RFC 5308 IPv6 reach entry with no sub-TLVs), that's ~560 bytes of TLV 236 value — well past the 255-byte single-TLV ceiling, so the splitter shards into multiple TLV 236 instances and the packer spreads them across fragments until each fits the 373-byte (400 − 27 overhead) per-fragment TLV budget.

**Scenarios**:

- Bring up two namespaces on a shared bridge, form an L2 adjacency, verify link reachability in both directions.
- \`show isis summary\` on z1 reports \`LSP MTU: 400 bytes\` — confirms the configured value reaches the operational view.
- \`show isis database\` on z2 contains the \`Fragment Summary\` block plus a \`z1.00\` row — confirms z2 actually received multiple fragments from z1 and the per-origin aggregator in \`show.rs\` surfaces them.
- Ping z1's and z2's loopbacks from each other — confirms SPF correctly merges z1's fragment set into a single logical node (the receive-side rebuild from #577) so the loopback prefix is reachable even though it's advertised across multiple PDUs.
- Standard teardown.

\`bdd/Makefile\` gets an \`isis_fragmentation\` target so the scenario can be run in isolation (\`make isis_fragmentation\`) the same way other IS-IS features can.

Diff: +210 / −1 across 5 files.

## Test plan

- [x] \`cargo build -p bdd --tests\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo test --workspace --exclude bdd\` all green (no regression on unit / integration suites)
- [x] Cucumber harness parses every step in the new feature, runs setup, executes teardown cleanly (local sandbox lacks netns root capabilities so the body of the scenario was validated to step-match correctly rather than fully executed — CI runs as root with the right capabilities)

Generated with [Claude Code](https://claude.com/claude-code)