### PR TITLE
isis: add show isis ti-lfa for per-destination repair paths

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -102,6 +102,7 @@ pub struct Isis {
     pub local_pool: Option<LabelPool>,
     pub graph: Levels<Option<spf::Graph>>,
     pub spf_result: Levels<Option<BTreeMap<usize, spf::Path>>>,
+    pub tilfa_result: Levels<Option<BTreeMap<usize, Vec<spf::RepairPath>>>>,
 
     /// MT 2 (IPv6 unicast) graph and SPF result. Computed alongside
     /// the legacy graph when `mt_enabled` and MT 2 is in
@@ -226,6 +227,7 @@ pub struct IsisTop<'a> {
     pub spf_throttle: &'a mut Levels<Throttle>,
     pub graph: &'a mut Levels<Option<spf::Graph>>,
     pub spf_result: &'a mut Levels<Option<BTreeMap<usize, spf::Path>>>,
+    pub tilfa_result: &'a mut Levels<Option<BTreeMap<usize, Vec<spf::RepairPath>>>>,
     pub mt2_graph: &'a mut Levels<Option<spf::Graph>>,
     pub mt2_spf_result: &'a mut Levels<Option<BTreeMap<usize, spf::Path>>>,
 
@@ -326,6 +328,7 @@ impl Isis {
             local_pool: None,
             graph: Levels::<Option<spf::Graph>>::default(),
             spf_result: Levels::<Option<BTreeMap<usize, spf::Path>>>::default(),
+            tilfa_result: Levels::<Option<BTreeMap<usize, Vec<spf::RepairPath>>>>::default(),
             mt2_graph: Levels::<Option<spf::Graph>>::default(),
             mt2_spf_result: Levels::<Option<BTreeMap<usize, spf::Path>>>::default(),
             sr_rx,
@@ -1006,6 +1009,7 @@ impl Isis {
             spf_throttle: &mut self.spf_throttle,
             graph: &mut self.graph,
             spf_result: &mut self.spf_result,
+            tilfa_result: &mut self.tilfa_result,
             mt2_graph: &mut self.mt2_graph,
             mt2_spf_result: &mut self.mt2_spf_result,
             sr_block: &self.sr_block,

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -988,6 +988,7 @@ pub(super) fn perform_spf_calculation(top: &mut IsisTop, level: Level) {
     };
 
     *top.spf_result.get_mut(&level) = Some(spf_result);
+    *top.tilfa_result.get_mut(&level) = Some(tilfa_result);
     mpls_route(&rib, &mut ilm);
     apply_routing_updates(top, level, rib, rib_v6, ilm);
 }

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -55,6 +55,7 @@ impl Isis {
             show_isis_repair_list_detail,
         );
         self.show_add("/show/isis/topology", show_isis_topology);
+        self.show_add("/show/isis/ti-lfa", show_isis_tilfa);
     }
 }
 
@@ -2010,6 +2011,158 @@ fn show_isis_repair_list_detail(
         }
     }
     Ok(buf)
+}
+
+fn show_isis_tilfa(
+    isis: &Isis,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    if json {
+        let view = TilfaResultJson {
+            levels: [
+                (
+                    "L1",
+                    isis.graph.get(&Level::L1),
+                    isis.tilfa_result.get(&Level::L1),
+                ),
+                (
+                    "L2",
+                    isis.graph.get(&Level::L2),
+                    isis.tilfa_result.get(&Level::L2),
+                ),
+            ]
+            .into_iter()
+            .filter_map(|(name, graph, tilfa)| {
+                let g = graph.as_ref()?;
+                let t = tilfa.as_ref()?;
+                Some((name.to_string(), tilfa_level_json(g, t)))
+            })
+            .collect(),
+        };
+        return Ok(serde_json::to_string_pretty(&view)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}")));
+    }
+
+    let mut buf = String::new();
+    write_spf_status_banner(isis, &mut buf);
+
+    let mut wrote_any = false;
+    for level in &[Level::L1, Level::L2] {
+        let (Some(graph), Some(tilfa)) = (
+            isis.graph.get(level).as_ref(),
+            isis.tilfa_result.get(level).as_ref(),
+        ) else {
+            continue;
+        };
+        if tilfa.is_empty() {
+            continue;
+        }
+        wrote_any = true;
+        writeln!(buf, "\n{} TI-LFA repair paths:", level)?;
+        for (dest, repairs) in tilfa.iter() {
+            let dest_name = vertex_name(graph, *dest);
+            writeln!(buf, "  Destination {} (vertex {})", dest_name, dest)?;
+            for (i, rp) in repairs.iter().enumerate() {
+                let fh_name = vertex_name(graph, rp.first_hop);
+                writeln!(
+                    buf,
+                    "    [{}] first-hop {} (vertex {}, link_id {})",
+                    i, fh_name, rp.first_hop, rp.first_hop_link_id,
+                )?;
+                if rp.segs.is_empty() {
+                    writeln!(buf, "        segments: (none — direct repair)")?;
+                } else {
+                    writeln!(buf, "        segments:")?;
+                    for seg in &rp.segs {
+                        writeln!(buf, "          {}", format_sr_segment(graph, seg))?;
+                    }
+                }
+            }
+        }
+    }
+    if !wrote_any {
+        writeln!(buf, "(no TI-LFA repair paths computed)")?;
+    }
+    Ok(buf)
+}
+
+fn vertex_name(graph: &spf::Graph, id: usize) -> String {
+    graph
+        .get(&id)
+        .map(|v| v.name.clone())
+        .unwrap_or_else(|| format!("v{id}"))
+}
+
+fn format_sr_segment(graph: &spf::Graph, seg: &spf::SrSegment) -> String {
+    match seg {
+        spf::SrSegment::NodeSid(v) => format!("NodeSid({})", vertex_name(graph, *v)),
+        spf::SrSegment::AdjSid(from, to, None) => {
+            format!(
+                "AdjSid({}, {})",
+                vertex_name(graph, *from),
+                vertex_name(graph, *to)
+            )
+        }
+        spf::SrSegment::AdjSid(from, to, Some(via)) => format!(
+            "AdjSid({}, {}, via {})",
+            vertex_name(graph, *from),
+            vertex_name(graph, *to),
+            vertex_name(graph, *via),
+        ),
+    }
+}
+
+fn tilfa_level_json(
+    graph: &spf::Graph,
+    tilfa: &BTreeMap<usize, Vec<spf::RepairPath>>,
+) -> TilfaLevelJson {
+    let destinations = tilfa
+        .iter()
+        .map(|(dest, repairs)| TilfaDestinationJson {
+            vertex_id: *dest,
+            name: vertex_name(graph, *dest),
+            repair_paths: repairs
+                .iter()
+                .map(|rp| TilfaRepairPathJson {
+                    first_hop_vertex_id: rp.first_hop,
+                    first_hop_name: vertex_name(graph, rp.first_hop),
+                    first_hop_link_id: rp.first_hop_link_id,
+                    segments: rp
+                        .segs
+                        .iter()
+                        .map(|s| format_sr_segment(graph, s))
+                        .collect(),
+                })
+                .collect(),
+        })
+        .collect();
+    TilfaLevelJson { destinations }
+}
+
+#[derive(Serialize)]
+struct TilfaResultJson {
+    levels: BTreeMap<String, TilfaLevelJson>,
+}
+
+#[derive(Serialize)]
+struct TilfaLevelJson {
+    destinations: Vec<TilfaDestinationJson>,
+}
+
+#[derive(Serialize)]
+struct TilfaDestinationJson {
+    vertex_id: usize,
+    name: String,
+    repair_paths: Vec<TilfaRepairPathJson>,
+}
+
+#[derive(Serialize)]
+struct TilfaRepairPathJson {
+    first_hop_vertex_id: usize,
+    first_hop_name: String,
+    first_hop_link_id: u32,
+    segments: Vec<String>,
 }
 
 fn write_spf_status_banner(isis: &Isis, buf: &mut String) {

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -341,6 +341,10 @@ module exec {
           type empty;
         }
       }
+      leaf ti-lfa {
+        ext:help "IS-IS TI-LFA per-destination repair paths (graph-level view)";
+        type empty;
+      }
       leaf topology {
         ext:help "IS-IS SPF tree (per-AFI today; per-MT once multi-topology lands)";
         type empty;


### PR DESCRIPTION
## Summary
- New CLI command `show isis ti-lfa` exposes the in-memory `tilfa_result` keyed by destination vertex.
- Each entry prints the first-hop vertex (resolved to hostname via the per-level graph), the SPF-chosen `first_hop_link_id`, and the SR segment list (NodeSid / AdjSid with optional pseudonode `via`).
- JSON output is supported alongside text and uses stable keys for tooling.
- Wires the supporting `tilfa_result` storage on `Isis`/`IsisTop` (mirroring the existing `spf_result` plumbing) and populates it in `perform_spf_calculation` from `tilfa_repair_path`, so the show handler has something to read.

This is a graph-level view that sits beside `show isis repair-list` (FIB-installed view) — useful when debugging whether TI-LFA actually produced a repair for a destination, before the rib-builder lowers it to MPLS/SRv6.

## Test plan
- [ ] `cargo build --bin zebra-rs` — clean.
- [ ] `cargo clippy --bin zebra-rs --no-deps` — clean.
- [ ] Run a TI-LFA topology and verify `show isis ti-lfa` prints destinations with repair paths whose `first-hop` matches the post-conv SPF chosen neighbor.
- [ ] Verify segment list resolves NodeSid/AdjSid endpoints to hostnames (and `via` shows the LAN pseudonode where applicable).
- [ ] Verify JSON output: `show isis ti-lfa | json` (or equivalent) round-trips through `jq`.

Generated with [Claude Code](https://claude.com/claude-code)