### PR TITLE
isis: fix TI-LFA X selection for LAN first-hops

### DIFF
--- a/zebra-rs/src/isis/tilfa.rs
+++ b/zebra-rs/src/isis/tilfa.rs
@@ -334,12 +334,29 @@ pub(super) fn tilfa_repair_path(
             continue;
         }
 
-        // X
+        // X — the protected element. For a P2P first-hop this is the
+        // physical neighbor router. For a LAN first-hop the primary
+        // path is `[PN, N, ...]`; the pseudonode is just a modeling
+        // artifact for the LAN segment, and excluding it alone gives
+        // (LAN-)link-protection (N keeps every physical edge to R1/R2/
+        // etc., so P-space and Q-space collapse and the repair list
+        // ends up shorter than P2P's). Advance past the pseudonode to
+        // `first[1]` so LAN matches P2P's node-protection model, and
+        // so that a destination equal to the physical neighbor is
+        // skipped via the empty-modified-SPF path (same as P2P, where
+        // `d == x` makes `spf::tilfa` return `vec![]`).
         let first = &path.paths[0];
         if first.is_empty() {
             continue;
         }
-        let x = first[0];
+        let x = if graph.get(&first[0]).is_some_and(|v| v.is_pseudo_node()) {
+            // `[PN]` alone (destination is the pseudonode itself)
+            // shouldn't happen for a real destination, but fall back
+            // to the pseudonode so we don't index past the end.
+            first.get(1).copied().unwrap_or(first[0])
+        } else {
+            first[0]
+        };
 
         let repair_paths = spf::tilfa(graph, source, *d, &[x]);
         if !repair_paths.is_empty() {


### PR DESCRIPTION
## Summary
`tilfa_repair_path` was using `first[0]` as the protected element X. For a P2P first-hop that's the physical neighbor (node protection). For a LAN first-hop the primary path is `[PN, N, ...]`, so X ended up as the pseudonode — which downgrades the failure model to (LAN-)link-protection: N keeps every direct edge to R1/R2/etc., P-space and Q-space collapse, and the repair list comes out shorter than the equivalent P2P case.

Observed on a topology where the S↔N1 attachment is reconfigured P2P→LAN:

- `d = R3` / `R2` / `D`: segment list shrank to `[NodeSid(r1)]` even though P2P (same physical topology) produced `[NodeSid(r1), AdjSid(r1,r2), AdjSid(r2,r3)]`.
- A spurious repair entry was emitted for `d = N1` (the LAN's physical neighbor). P2P silently skipped it because `d == x` makes `spf::tilfa` return `vec![]`.

Fix: when `first[0]` is a pseudonode, advance to `first[1]` so X is always the physical neighbor. Falls back to `first[0]` for the (shouldn't-happen) `[PN]`-only path.

## Test plan
- [x] `cargo build --bin zebra-rs` — clean.
- [x] `cargo clippy --bin zebra-rs --no-deps` — clean.
- [x] `cargo test --bin zebra-rs spf` — 11/11 pass (`tilfa_test`, `tilfa_lan_api`, etc.).
- [ ] On a multi-router topology with S↔N1 as a LAN, verify `show isis ti-lfa`:
  - No repair entry for `d = N1` (the LAN neighbor — protected node).
  - Repair entry for `d = R3` matches the P2P case's segment list (e.g. `NodeSid(r1), AdjSid(r1,r2), AdjSid(r2,r3)`).

Generated with [Claude Code](https://claude.com/claude-code)