### PR TITLE
bgp: add redistribute YANG + config-plane storage (no behavior yet)

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -515,6 +515,256 @@ fn config_advertise_all_vni(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
     Some(())
 }
 
+// ---- redistribute -----------------------------------------------------
+//
+// Per-AFI redistribution sources (zebra-bgp-redistribute.yang). Each
+// source is a presence container with modifier leaves; storage is a
+// BTreeMap<(AfiSafi, Source), BgpRedistribute> on the Bgp instance.
+// Storage-only today — the BGP RIB-source plumbing that consumes
+// these entries lands in a follow-up.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum BgpRedistSource {
+    Connected,
+    Static,
+    Isis,
+    Ospf,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum BgpRedistIsisLevel {
+    L1,
+    L2,
+    L1InterArea,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum BgpRedistOspfMatch {
+    Internal,
+    External1,
+    External2,
+    NssaExternal1,
+    NssaExternal2,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct BgpRedistribute {
+    pub policy: Option<String>,
+    pub metric: Option<u32>,
+    pub multipath: bool,
+    /// Populated only when source == Isis. Empty set means "no filter".
+    pub isis_levels: std::collections::BTreeSet<BgpRedistIsisLevel>,
+    /// Populated only when source == Ospf. Empty set means "no filter".
+    pub ospf_match: std::collections::BTreeSet<BgpRedistOspfMatch>,
+}
+
+/// Only AFs BGP actually originates from are valid redistribute
+/// targets. The YANG augment attaches the container to every
+/// afi-safi list entry, so we filter at the callback. Returns `None`
+/// for AFs we don't support — the callback in turn returns `None` and
+/// libyang surfaces it as a commit failure.
+fn redist_afi_valid(afi_safi: &bgp_packet::AfiSafi) -> bool {
+    use bgp_packet::{Afi, Safi};
+    matches!(
+        (afi_safi.afi, afi_safi.safi),
+        (Afi::Ip, Safi::Unicast) | (Afi::Ip6, Safi::Unicast)
+    )
+}
+
+fn bgp_redist_set_presence(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+    src: BgpRedistSource,
+) -> Option<()> {
+    let afi_safi: bgp_packet::AfiSafi = args.afi_safi()?;
+    if !redist_afi_valid(&afi_safi) {
+        return None;
+    }
+    if op.is_set() {
+        bgp.redistribute.entry((afi_safi, src)).or_default();
+    } else {
+        bgp.redistribute.remove(&(afi_safi, src));
+    }
+    Some(())
+}
+
+fn bgp_redist_with<F>(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+    src: BgpRedistSource,
+    f: F,
+) -> Option<()>
+where
+    F: FnOnce(&mut BgpRedistribute, &mut Args, ConfigOp) -> Option<()>,
+{
+    let afi_safi: bgp_packet::AfiSafi = args.afi_safi()?;
+    if !redist_afi_valid(&afi_safi) {
+        return None;
+    }
+    let entry = bgp.redistribute.entry((afi_safi, src)).or_default();
+    f(entry, &mut args, op)
+}
+
+fn bgp_set_policy(e: &mut BgpRedistribute, a: &mut Args, op: ConfigOp) -> Option<()> {
+    e.policy = if op.is_set() { Some(a.string()?) } else { None };
+    Some(())
+}
+fn bgp_set_metric(e: &mut BgpRedistribute, a: &mut Args, op: ConfigOp) -> Option<()> {
+    e.metric = if op.is_set() { Some(a.u32()?) } else { None };
+    Some(())
+}
+fn bgp_set_multipath(e: &mut BgpRedistribute, _a: &mut Args, op: ConfigOp) -> Option<()> {
+    e.multipath = op.is_set();
+    Some(())
+}
+fn bgp_set_isis_level(e: &mut BgpRedistribute, a: &mut Args, op: ConfigOp) -> Option<()> {
+    let v = match a.string()?.as_str() {
+        "level-1" => BgpRedistIsisLevel::L1,
+        "level-2" => BgpRedistIsisLevel::L2,
+        "level-1-inter-area" => BgpRedistIsisLevel::L1InterArea,
+        _ => return None,
+    };
+    if op.is_set() {
+        e.isis_levels.insert(v);
+    } else {
+        e.isis_levels.remove(&v);
+    }
+    Some(())
+}
+fn bgp_set_ospf_match(e: &mut BgpRedistribute, a: &mut Args, op: ConfigOp) -> Option<()> {
+    let v = match a.string()?.as_str() {
+        "internal" => BgpRedistOspfMatch::Internal,
+        "external-1" => BgpRedistOspfMatch::External1,
+        "external-2" => BgpRedistOspfMatch::External2,
+        "nssa-external-1" => BgpRedistOspfMatch::NssaExternal1,
+        "nssa-external-2" => BgpRedistOspfMatch::NssaExternal2,
+        _ => return None,
+    };
+    if op.is_set() {
+        e.ospf_match.insert(v);
+    } else {
+        e.ospf_match.remove(&v);
+    }
+    Some(())
+}
+
+// Per-source presence + modifier wrappers. Mirrors the IS-IS shape.
+pub(super) fn config_redistribute_connected(bgp: &mut Bgp, args: Args, op: ConfigOp) -> Option<()> {
+    bgp_redist_set_presence(bgp, args, op, BgpRedistSource::Connected)
+}
+pub(super) fn config_redistribute_connected_policy(
+    bgp: &mut Bgp,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    bgp_redist_with(bgp, args, op, BgpRedistSource::Connected, bgp_set_policy)
+}
+pub(super) fn config_redistribute_connected_metric(
+    bgp: &mut Bgp,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    bgp_redist_with(bgp, args, op, BgpRedistSource::Connected, bgp_set_metric)
+}
+pub(super) fn config_redistribute_connected_multipath(
+    bgp: &mut Bgp,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    bgp_redist_with(bgp, args, op, BgpRedistSource::Connected, bgp_set_multipath)
+}
+
+pub(super) fn config_redistribute_static(bgp: &mut Bgp, args: Args, op: ConfigOp) -> Option<()> {
+    bgp_redist_set_presence(bgp, args, op, BgpRedistSource::Static)
+}
+pub(super) fn config_redistribute_static_policy(
+    bgp: &mut Bgp,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    bgp_redist_with(bgp, args, op, BgpRedistSource::Static, bgp_set_policy)
+}
+pub(super) fn config_redistribute_static_metric(
+    bgp: &mut Bgp,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    bgp_redist_with(bgp, args, op, BgpRedistSource::Static, bgp_set_metric)
+}
+pub(super) fn config_redistribute_static_multipath(
+    bgp: &mut Bgp,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    bgp_redist_with(bgp, args, op, BgpRedistSource::Static, bgp_set_multipath)
+}
+
+pub(super) fn config_redistribute_isis(bgp: &mut Bgp, args: Args, op: ConfigOp) -> Option<()> {
+    bgp_redist_set_presence(bgp, args, op, BgpRedistSource::Isis)
+}
+pub(super) fn config_redistribute_isis_policy(
+    bgp: &mut Bgp,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    bgp_redist_with(bgp, args, op, BgpRedistSource::Isis, bgp_set_policy)
+}
+pub(super) fn config_redistribute_isis_metric(
+    bgp: &mut Bgp,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    bgp_redist_with(bgp, args, op, BgpRedistSource::Isis, bgp_set_metric)
+}
+pub(super) fn config_redistribute_isis_multipath(
+    bgp: &mut Bgp,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    bgp_redist_with(bgp, args, op, BgpRedistSource::Isis, bgp_set_multipath)
+}
+pub(super) fn config_redistribute_isis_level(
+    bgp: &mut Bgp,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    bgp_redist_with(bgp, args, op, BgpRedistSource::Isis, bgp_set_isis_level)
+}
+
+pub(super) fn config_redistribute_ospf(bgp: &mut Bgp, args: Args, op: ConfigOp) -> Option<()> {
+    bgp_redist_set_presence(bgp, args, op, BgpRedistSource::Ospf)
+}
+pub(super) fn config_redistribute_ospf_policy(
+    bgp: &mut Bgp,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    bgp_redist_with(bgp, args, op, BgpRedistSource::Ospf, bgp_set_policy)
+}
+pub(super) fn config_redistribute_ospf_metric(
+    bgp: &mut Bgp,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    bgp_redist_with(bgp, args, op, BgpRedistSource::Ospf, bgp_set_metric)
+}
+pub(super) fn config_redistribute_ospf_multipath(
+    bgp: &mut Bgp,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    bgp_redist_with(bgp, args, op, BgpRedistSource::Ospf, bgp_set_multipath)
+}
+pub(super) fn config_redistribute_ospf_match_type(
+    bgp: &mut Bgp,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    bgp_redist_with(bgp, args, op, BgpRedistSource::Ospf, bgp_set_ospf_match)
+}
+
 fn config_add_path(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let afi_safi: AfiSafi = args.afi_safi()?;
@@ -1143,6 +1393,83 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/afi-safi/advertise-all-vni",
             config_advertise_all_vni,
+        );
+
+        // Per-AFI redistribution (zebra-bgp-redistribute.yang).
+        // One presence-container callback per source plus one per
+        // modifier leaf, dispatched through `bgp_redist_set_presence`
+        // / `bgp_redist_with`. Storage-only today.
+        self.callback_add(
+            "/router/bgp/afi-safi/redistribute/connected",
+            config_redistribute_connected,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/redistribute/connected/policy",
+            config_redistribute_connected_policy,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/redistribute/connected/metric",
+            config_redistribute_connected_metric,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/redistribute/connected/multipath",
+            config_redistribute_connected_multipath,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/redistribute/static",
+            config_redistribute_static,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/redistribute/static/policy",
+            config_redistribute_static_policy,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/redistribute/static/metric",
+            config_redistribute_static_metric,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/redistribute/static/multipath",
+            config_redistribute_static_multipath,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/redistribute/isis",
+            config_redistribute_isis,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/redistribute/isis/policy",
+            config_redistribute_isis_policy,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/redistribute/isis/metric",
+            config_redistribute_isis_metric,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/redistribute/isis/multipath",
+            config_redistribute_isis_multipath,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/redistribute/isis/level",
+            config_redistribute_isis_level,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/redistribute/ospf",
+            config_redistribute_ospf,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/redistribute/ospf/policy",
+            config_redistribute_ospf_policy,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/redistribute/ospf/metric",
+            config_redistribute_ospf_metric,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/redistribute/ospf/multipath",
+            config_redistribute_ospf_multipath,
+        );
+        self.callback_add(
+            "/router/bgp/afi-safi/redistribute/ospf/match/type",
+            config_redistribute_ospf_match_type,
         );
 
         // Applying policy.

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -188,6 +188,19 @@ pub struct Bgp {
     pub bfd_event_rx: UnboundedReceiver<crate::bfd::inst::BfdEvent>,
     // BgpAttr shared storage.
     pub attr_store: BgpAttrStore,
+
+    /// Per-AFI redistribution configuration. Populated by the
+    /// `/router/bgp/afi-safi/redistribute/<source>...` callbacks
+    /// (zebra-bgp-redistribute.yang); one entry per (AfiSafi, source)
+    /// pair, holding policy / metric / multipath plus per-source
+    /// extras (IS-IS level filter, OSPF match types).
+    ///
+    /// Storage-only today — the BGP RIB-source plumbing that reads
+    /// from this map lands in a follow-up.
+    pub redistribute: BTreeMap<
+        (bgp_packet::AfiSafi, super::config::BgpRedistSource),
+        super::config::BgpRedistribute,
+    >,
 }
 
 impl Bgp {
@@ -245,6 +258,7 @@ impl Bgp {
             bfd_event_tx,
             bfd_event_rx,
             attr_store: BgpAttrStore::new(),
+            redistribute: BTreeMap::new(),
         };
         bgp.callback_build();
         bgp.show_build();

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -40,6 +40,10 @@ module config {
     prefix zbe;
   }
 
+  import zebra-bgp-redistribute {
+    prefix zbr;
+  }
+
   import zebra-bgp-transport {
     prefix zbt;
   }

--- a/zebra-rs/yang/zebra-bgp-redistribute.yang
+++ b/zebra-rs/yang/zebra-bgp-redistribute.yang
@@ -1,0 +1,172 @@
+module zebra-bgp-redistribute {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-redistribute";
+  prefix "zbr";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "Per-AFI redistribution into BGP. Augments the global afi-safi
+     list on the BGP candidate-config tree with a `redistribute`
+     container; each source is a presence container with a small set
+     of modifier leaves. No instance keying — zebra-rs has a single
+     instance per protocol.
+
+     Resulting CLI / config shape:
+
+       router bgp {
+         afi-safi ipv4 {
+           redistribute {
+             connected { policy HOGE; }
+             static    { policy STATIC-OUT; metric 100; }
+             isis      { policy ISIS-LEAK; level level-2; multipath; }
+             ospf      { policy OSPF-LEAK; match { type external-1; type external-2; } }
+           }
+         }
+       }
+
+     Modeling notes:
+       - `policy` is a plain string (not a leafref to /policy/name)
+         so the redistribute config can be staged before the policy
+         is committed — same convention as the existing IS-IS
+         redistribute and `srv6 / locator` references.
+       - BGP-from-IS-IS uses repeatable `level <N>` tokens per
+         IOS-XR (`level 1 level 2 level 1-inter-area`); modeled
+         as a leaf-list.
+       - BGP-from-OSPF allows the full E1/E2/NSSA-1/NSSA-2 matrix
+         in one entry (combinable, unlike OSPF-into-IS-IS); modeled
+         as a leaf-list.
+       - `multipath` (BGP-only) installs all RIB-resolved paths,
+         not just the best one. Per-source.
+
+     Config plane only in the PR that introduces this module —
+     the BGP RIB-source and policy-evaluation hooks that consume
+     these entries land in a follow-up.";
+
+  reference
+    "Cisco IOS-XR UM YANG (`Cisco-IOS-XR-um-router-bgp-cfg.yang`),
+     `redistribute` container under `address-family ipv4|ipv6
+     unicast|multicast`.";
+
+  grouping bgp-redist-common {
+    description
+      "Common per-source knobs for BGP redistribution.";
+    leaf policy {
+      type string;
+      description
+        "Name of a top-level `policy`. Plain string (not a leafref)
+         so the redistribute config can be staged before the policy
+         is committed.";
+    }
+    leaf metric {
+      type uint32;
+      description
+        "Static MED override for redistributed routes. When omitted,
+         MED follows the source RIB cost / protocol default.";
+    }
+    leaf multipath {
+      type empty;
+      description
+        "Install all RIB-resolved paths from this source, not just
+         the best one. BGP-only knob (IOS-XR `redistribute … multipath`).";
+    }
+  }
+
+  grouping bgp-redist-isis-level {
+    description
+      "BGP-from-IS-IS level filter. IOS-XR uses repeatable
+       `level <N>` tokens (`level 1 level 2 level 1-inter-area`),
+       so modeled as a leaf-list — order is insignificant.";
+    leaf-list level {
+      type enumeration {
+        enum level-1;
+        enum level-2;
+        enum level-1-inter-area;
+      }
+    }
+  }
+
+  grouping bgp-redist-ospf-match {
+    description
+      "BGP-from-OSPF source filter. IOS-XR allows any combination of
+       internal / external-1 / external-2 / nssa-external-1 /
+       nssa-external-2 in a single redistribute entry (unlike
+       OSPF-into-IS-IS, which is single-value).";
+    container match {
+      leaf-list type {
+        type enumeration {
+          enum internal;
+          enum external-1;
+          enum external-2;
+          enum nssa-external-1;
+          enum nssa-external-2;
+        }
+      }
+    }
+  }
+
+  grouping bgp-afi-safi-redistribute {
+    description
+      "Attached to every global afi-safi list entry. Meaningful for
+       the AFs BGP actually originates from (ipv4|ipv6 / unicast,
+       multicast); harmless on other AFI/SAFIs — the Rust callback
+       filters at commit time.";
+    container redistribute {
+      presence "Enable route redistribution into BGP for this AFI";
+      container connected {
+        presence "Redistribute connected routes";
+        uses bgp-redist-common;
+      }
+      container static {
+        presence "Redistribute static routes";
+        uses bgp-redist-common;
+      }
+      container isis {
+        presence "Redistribute IS-IS routes";
+        uses bgp-redist-common;
+        uses bgp-redist-isis-level;
+      }
+      container ospf {
+        presence "Redistribute OSPF routes";
+        uses bgp-redist-common;
+        uses bgp-redist-ospf-match;
+      }
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router/bgp:bgp/bgp:afi-safi" {
+    description
+      "Attach the redistribute container to the global afi-safi
+       list in the candidate-set subtree.";
+    uses bgp-afi-safi-redistribute;
+  }
+
+  augment "/configure:delete/config:router/bgp:bgp/bgp:afi-safi" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp afi-safi ipv4 redistribute connected`
+       is path-valid.";
+    uses bgp-afi-safi-redistribute;
+  }
+}


### PR DESCRIPTION
## Summary
Sibling of #595 (IS-IS redistribute). Adds per-AFI `redistribute` under `router bgp / afi-safi`, mirroring the IOS-XR shape but without instance keying (zebra-rs has one instance per protocol). Four sources as presence containers: `connected`, `static`, `isis`, `ospf`. Each carries `policy`, `metric`, `multipath` (BGP-only). `isis` adds a leaf-list `level` (IOS-XR repeatable `level <N>` form: level-1 / level-2 / level-1-inter-area). `ospf` adds `match { type … }` leaf-list with the full E1/E2/NSSA-1/NSSA-2 matrix per IOS-XR (combinable in one entry, unlike OSPF-into-IS-IS).

YANG (`zebra-bgp-redistribute.yang`, new):
- Augments `/configure:{set,delete}/config:router/bgp:bgp/bgp:afi-safi`.
- Groupings: `bgp-redist-common`, `bgp-redist-isis-level`, `bgp-redist-ospf-match`, `bgp-afi-safi-redistribute`.

Rust (`bgp/config.rs`):
- New enums `BgpRedistSource`, `BgpRedistIsisLevel`, `BgpRedistOspfMatch`.
- `BgpRedistribute` modifier struct + `Bgp.redistribute: BTreeMap<(AfiSafi, Source), BgpRedistribute>`.
- 18 callbacks, dispatched through two helpers (`bgp_redist_set_presence`, `bgp_redist_with`) so each callback stays a one-liner.
- `redist_afi_valid` restricts to `ipv4|ipv6 / unicast`; rejects evpn / mpls-vpn / etc. at commit time (the YANG augment attaches to every afi-safi list entry).

**Config plane only.** The BGP RIB-source plumbing and policy-evaluation hooks that consume `bgp.redistribute` aren't wired yet; that lands in a follow-up. Today the entries round-trip through commit/show with no functional effect.

## CLI shape
```
router bgp {
  afi-safi ipv4 {
    redistribute {
      connected { policy HOGE; }
      static    { policy STATIC-OUT; metric 100; multipath; }
      isis      { policy ISIS-LEAK; level level-2; level level-1-inter-area; }
      ospf      { policy OSPF-LEAK; match { type external-1; type external-2; } multipath; }
    }
  }
}
```

## Test plan
- [x] `cargo build --bin zebra-rs` — clean.
- [x] `cargo clippy --bin zebra-rs --no-deps` — clean.
- [ ] Commit each source variant under both ipv4 and ipv6 unicast, confirm `Bgp.redistribute` shape (storage round-trip).
- [ ] Verify `redistribute` under `afi-safi evpn` is rejected at commit time (AFI filter).

Generated with [Claude Code](https://claude.com/claude-code)