### PR TITLE
rib: add redistribute message types (step 1 of 4 — types only)

### DIFF
--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -2,7 +2,7 @@ use std::net::{IpAddr, Ipv4Addr};
 
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
-use super::{Link, MacAddr, Rib, link::LinkAddr};
+use super::{BulkPhase, Link, MacAddr, Rib, RibSubType, RibType, RouteBatch, link::LinkAddr};
 
 /// One bridge-FDB row, distilled from the larger `FibNeighbor` so
 /// subscribers don't need to drag the full address-family / state
@@ -74,6 +74,30 @@ pub enum RibRx {
         vni: u32,
     },
     EoR,
+
+    // ---- redistribute route push ---------------------------------
+    //
+    // Per-filter-row delivery of routes matched by a subscriber's
+    // `RedistAdd` / `RedistUpdate`. `rtype` and `subtype` echo the
+    // matched route so the consumer can re-key against its filter
+    // table without RIB carrying extra opaque ids. Self-route
+    // filtering is enforced by RIB before send — a subscriber whose
+    // proto maps to `rtype` will never see a RouteAdd of that rtype.
+    // Pure types in this PR — no sender wired yet.
+    #[allow(dead_code)]
+    RouteAdd {
+        rtype: RibType,
+        subtype: RibSubType,
+        routes: RouteBatch,
+        bulk: BulkPhase,
+    },
+    #[allow(dead_code)]
+    RouteDel {
+        rtype: RibType,
+        subtype: RibSubType,
+        routes: RouteBatch,
+        bulk: BulkPhase,
+    },
 }
 
 impl Rib {

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -199,6 +199,50 @@ pub enum Message {
         proto: String,
         tx: UnboundedSender<RibRx>,
     },
+
+    // ---- redistribute subscription messages ----------------------
+    //
+    // Per-(proto, AFI, rtype) subscriptions. Subtype is a wildcard
+    // set (empty = match every subtype under `rtype`). Self-route
+    // filtering (route's rtype belonging to the subscriber's proto)
+    // is enforced unconditionally by RIB before any other check.
+    // No consumer wired yet — the walker / steady-state hook and the
+    // per-protocol senders land in follow-ups.
+    /// Walk the FIB for the current matching set, then keep delivering
+    /// future deltas for `(proto, afi, rtype)` with subtype filtered
+    /// by `subtypes`. Empty `subtypes` is wildcard. Triggers a bulk
+    /// replay followed by a `BulkPhase::Eor` marker.
+    #[allow(dead_code)]
+    RedistAdd {
+        proto: String,
+        afi: super::RedistAfi,
+        rtype: RibType,
+        subtypes: BTreeSet<super::RibSubType>,
+    },
+    /// Replace the previous `subtypes` set for the same
+    /// `(proto, afi, rtype)` row. RIB diffs old vs new:
+    ///   - removed subtypes → RouteDel of their matching prefixes;
+    ///   - added subtypes → walk-and-replay of those prefixes.
+    ///
+    /// No-op on identical sets. Issuing RedistUpdate for a row that
+    /// was never RedistAdd'd is treated as RedistAdd.
+    #[allow(dead_code)]
+    RedistUpdate {
+        proto: String,
+        afi: super::RedistAfi,
+        rtype: RibType,
+        subtypes: BTreeSet<super::RibSubType>,
+    },
+    /// Tear down a redistribute subscription. RIB sends RouteDel for
+    /// every currently-matched prefix (in chunks ending in
+    /// `BulkPhase::Eor`) so the consumer can withdraw without having
+    /// to remember its own per-filter state.
+    #[allow(dead_code)]
+    RedistDel {
+        proto: String,
+        afi: super::RedistAfi,
+        rtype: RibType,
+    },
     /// Tear down all RIB state owned by a protocol whose task is
     /// being despawned (`no router bgp` / `no router isis` / `no
     /// router ospf`). Withdraws every route / ILM whose `rtype`
@@ -1250,6 +1294,13 @@ impl Rib {
             } => {
                 self.mdb_del(vni, group, source, ifindex).await;
             }
+            // Redistribute subscription messages — types-only PR.
+            // The walk-and-replay + steady-state dispatch lands in a
+            // follow-up; drain silently for now so the dispatcher
+            // stays exhaustive.
+            Message::RedistAdd { .. }
+            | Message::RedistUpdate { .. }
+            | Message::RedistDel { .. } => {}
         }
     }
 

--- a/zebra-rs/src/rib/mod.rs
+++ b/zebra-rs/src/rib/mod.rs
@@ -23,7 +23,10 @@ pub mod show;
 pub mod srv6;
 
 pub mod types;
-pub use types::{RibSubType, RibType};
+pub use types::{BulkPhase, RedistAfi, RibSubType, RibType, RouteBatch};
+// `RouteEntryV4`, `RouteEntryV6`, and `REDIST_BATCH_MAX` are re-exported
+// once the RIB walker (and the per-protocol consumers that construct
+// `RouteBatch::V4(vec![RouteEntryV4 { … }])`) land in follow-up PRs.
 
 pub mod util;
 

--- a/zebra-rs/src/rib/types.rs
+++ b/zebra-rs/src/rib/types.rs
@@ -146,3 +146,96 @@ impl RibSubType {
         }
     }
 }
+
+// ---- redistribute messaging types ------------------------------------
+//
+// Shared between `rib::Message` (proto → rib subscribe/filter) and
+// `RibRx` (rib → proto route push). Pure data only — the walker and
+// the steady-state dispatch hook land in follow-ups.
+
+/// Address-family selector for a redistribute subscription. Kept as a
+/// thin enum (not the heavier `bgp_packet::AfiSafi`) because RIB only
+/// distinguishes IPv4 vs IPv6 for redistribution — SAFI doesn't apply.
+#[allow(dead_code)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
+pub enum RedistAfi {
+    Ipv4,
+    Ipv6,
+}
+
+/// Where this batch sits in the message stream for a given filter row.
+/// `More` is steady-state delivery (mid-bulk or post-EoR delta);
+/// `Eor` marks the end of the initial walk-and-replay triggered by
+/// `RedistAdd` / `RedistUpdate`, or the final batch of withdrawals
+/// triggered by `RedistDel`.
+#[allow(dead_code)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum BulkPhase {
+    More,
+    Eor,
+}
+
+/// Minimal route attributes delivered to a redistribute subscriber.
+/// Carries what policy almost always matches on (prefix, nexthop,
+/// metric, tag) plus the egress ifindex. Communities / originator-id
+/// etc. are BGP-only and intentionally omitted from this baseline —
+/// they'd grow `extra: Option<…>` later without changing the wire
+/// shape.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteEntryV4 {
+    pub prefix: ipnet::Ipv4Net,
+    pub nexthop: std::net::Ipv4Addr,
+    pub metric: u32,
+    pub tag: u32,
+    pub ifindex: u32,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteEntryV6 {
+    pub prefix: ipnet::Ipv6Net,
+    pub nexthop: std::net::Ipv6Addr,
+    pub metric: u32,
+    pub tag: u32,
+    pub ifindex: u32,
+}
+
+/// Homogeneous per-AFI batch. One of these variants per `RouteAdd` /
+/// `RouteDel` message — keeps the inner `Vec` tight (no per-entry
+/// AFI tag, no `enum{V4(…),V6(…)}` overhead) since a single
+/// subscription is always one AFI by construction.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RouteBatch {
+    V4(Vec<RouteEntryV4>),
+    V6(Vec<RouteEntryV6>),
+}
+
+#[allow(dead_code)]
+impl RouteBatch {
+    pub fn len(&self) -> usize {
+        match self {
+            Self::V4(v) => v.len(),
+            Self::V6(v) => v.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn afi(&self) -> RedistAfi {
+        match self {
+            Self::V4(_) => RedistAfi::Ipv4,
+            Self::V6(_) => RedistAfi::Ipv6,
+        }
+    }
+}
+
+/// Cap per-message route count. Bounded so a slow consumer can't be
+/// blocked by one giant Vec, and so steady-state GC pressure stays
+/// flat. ~32 KiB per IPv4 batch at this size; tune later if profiles
+/// say so.
+#[allow(dead_code)]
+pub const REDIST_BATCH_MAX: usize = 1024;


### PR DESCRIPTION
## Summary
Pure-types PR for the protocol⇄RIB redistribute pipeline. Adds the message variants and supporting data types both sides will exchange; no walker, no senders, no consumers.

**Proto → RIB** (`rib::Message`):
- `RedistAdd    { proto, afi, rtype, subtypes }` — subscribe; empty `subtypes` = match every subtype under `rtype`.
- `RedistUpdate { proto, afi, rtype, subtypes }` — replace the previous subtype set for `(proto, afi, rtype)`; RIB diffs old vs new and emits only the delta.
- `RedistDel    { proto, afi, rtype }` — withdraw the row; RIB will send `RouteDel` for every previously-matched prefix.

**RIB → Proto** (`RibRx`):
- `RouteAdd { rtype, subtype, routes, bulk }`
- `RouteDel { rtype, subtype, routes, bulk }`

`routes` is a per-AFI homogeneous batch (`V4(Vec<RouteEntryV4>)` or `V6(Vec<RouteEntryV6>)`), capped at `REDIST_BATCH_MAX = 1024`. `bulk` is `More` for steady-state / mid-replay, `Eor` for the final batch of a walk-and-replay or a `Redist{Update,Del}` sweep.

**Supporting types** in `rib::types`:
- `RedistAfi { Ipv4, Ipv6 }`
- `BulkPhase { More, Eor }`
- `RouteEntryV4 { prefix, nexthop, metric, tag, ifindex }` + v6 sibling — minimal attribute set policy normally matches on (communities/originator-id deferred until we have a BGP source consumer).
- `RouteBatch { V4(Vec<…>), V6(Vec<…>) }` + `len` / `is_empty` / `afi` helpers.

**Behaviour locked in for future steps** (encoded here in doc comments only):
- Self-route filter is unconditional: a subscriber whose `proto` maps to a route's `rtype` will never see that route, ever.
- `subtypes: BTreeSet::new()` is wildcard at every entry point.
- `RedistUpdate` is the toggling primitive (cheaper than Del+Add and easier to handle in consumers).

Dispatcher gets a no-op arm for the three new `Message` variants so the existing `match msg` stays exhaustive. The walker, the steady-state hook, and the per-protocol senders/consumers land in PRs 2–4 of this series.

## Test plan
- [x] `cargo build --bin zebra-rs` — clean.
- [x] `cargo clippy --bin zebra-rs --no-deps` — clean.
- [ ] No runtime behaviour to verify — types-only.

Generated with [Claude Code](https://claude.com/claude-code)