### PR TITLE
rib: redistribute filter registry + walk-and-replay (step 2 of 4)

### DIFF
--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -2,7 +2,7 @@ use std::net::{IpAddr, Ipv4Addr};
 
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
-use super::{BulkPhase, Link, MacAddr, Rib, RibSubType, RibType, RouteBatch, link::LinkAddr};
+use super::{BulkPhase, Link, MacAddr, Rib, RibType, RouteBatch, link::LinkAddr};
 
 /// One bridge-FDB row, distilled from the larger `FibNeighbor` so
 /// subscribers don't need to drag the full address-family / state
@@ -78,23 +78,22 @@ pub enum RibRx {
     // ---- redistribute route push ---------------------------------
     //
     // Per-filter-row delivery of routes matched by a subscriber's
-    // `RedistAdd` / `RedistUpdate`. `rtype` and `subtype` echo the
-    // matched route so the consumer can re-key against its filter
-    // table without RIB carrying extra opaque ids. Self-route
-    // filtering is enforced by RIB before send — a subscriber whose
-    // proto maps to `rtype` will never see a RouteAdd of that rtype.
-    // Pure types in this PR — no sender wired yet.
+    // `RedistAdd` / `RedistUpdate`. `rtype` is at the message level
+    // (every entry in a batch shares it by construction); `subtype`
+    // is per-entry inside `RouteEntryV4`/`V6` so a wildcard
+    // subscription replays in a single pass with one final EoR
+    // instead of N walks and N EoRs. Self-route filtering is
+    // enforced by RIB before send — a subscriber whose proto maps
+    // to `rtype` will never see a RouteAdd of that rtype.
     #[allow(dead_code)]
     RouteAdd {
         rtype: RibType,
-        subtype: RibSubType,
         routes: RouteBatch,
         bulk: BulkPhase,
     },
     #[allow(dead_code)]
     RouteDel {
         rtype: RibType,
-        subtype: RibSubType,
         routes: RouteBatch,
         bulk: BulkPhase,
     },

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -317,6 +317,12 @@ pub struct Rib {
     pub fib: FibChannel,
     pub fib_handle: FibHandle,
     pub redists: HashMap<String, UnboundedSender<RibRx>>,
+    /// Per-proto redistribute subscription registry. Outer key is the
+    /// subscriber's protocol name (matches `redists`); inner map is
+    /// keyed by `(afi, rtype)` and holds the subtype filter set
+    /// (empty = wildcard). Updated by RedistAdd / RedistUpdate /
+    /// RedistDel; consulted by the steady-state delta hook (follow-up).
+    pub redist_filters: HashMap<String, super::redist::FilterMap>,
     pub links: BTreeMap<u32, Link>,
     pub bridges: BTreeMap<String, Bridge>,
     pub vxlan: BTreeMap<String, Vxlan>,
@@ -438,6 +444,7 @@ impl Rib {
             fib,
             fib_handle,
             redists: HashMap::new(),
+            redist_filters: HashMap::new(),
             links: BTreeMap::new(),
             bridges: BTreeMap::new(),
             vxlan: BTreeMap::new(),
@@ -950,6 +957,7 @@ impl Rib {
         }
 
         self.redists.remove(&proto);
+        self.redist_filters.remove(&proto);
         self.sr_clients.remove(&proto);
         for watchers in self.block_watch.values_mut() {
             watchers.remove(&proto);
@@ -958,6 +966,176 @@ impl Rib {
             watchers.remove(&proto);
         }
         self.srlg_clients.remove(&proto);
+    }
+
+    // ---- redistribute subscription handlers ------------------------
+    //
+    // Step 2: registry + walk-and-replay. Steady-state delta hook
+    // (firing on FIB churn) lands in step 3; per-protocol senders /
+    // consumers land in step 4.
+
+    /// Self-route check + registry insert. Returns the Tx the walker
+    /// should push routes to, or `None` if the subscription is to be
+    /// silently dropped (self-loop, or subscriber never called
+    /// Subscribe so there's no Tx).
+    fn redist_register(
+        &mut self,
+        proto: &str,
+        afi: super::RedistAfi,
+        rtype: RibType,
+        subtypes: std::collections::BTreeSet<super::RibSubType>,
+    ) -> Option<UnboundedSender<RibRx>> {
+        // Self-route filter — unconditional. A subscriber whose proto
+        // maps to the rtype it's asking for would never receive
+        // anything; drop at registration so the registry stays clean.
+        if !super::redist::deliverable(proto, rtype) {
+            return None;
+        }
+        let tx = self.redists.get(proto)?.clone();
+        self.redist_filters
+            .entry(proto.to_string())
+            .or_default()
+            .insert((afi, rtype), subtypes);
+        Some(tx)
+    }
+
+    fn redist_add(
+        &mut self,
+        proto: String,
+        afi: super::RedistAfi,
+        rtype: RibType,
+        subtypes: std::collections::BTreeSet<super::RibSubType>,
+    ) {
+        let Some(tx) = self.redist_register(&proto, afi, rtype, subtypes.clone()) else {
+            return;
+        };
+        self.redist_walk(
+            &proto,
+            afi,
+            rtype,
+            &subtypes,
+            super::redist::WalkOp::Add,
+            &tx,
+        );
+    }
+
+    /// Replace the prior subtype set for `(proto, afi, rtype)` and
+    /// emit the appropriate Add/Del delta. Treats a missing prior row
+    /// as empty (so first-ever Update behaves like Add).
+    ///
+    /// Wildcard handling (`subtypes: {}` means "match every subtype"):
+    /// the symmetric-difference shortcut is only valid when both
+    /// sides are non-wildcard. When either side is wildcard, fall
+    /// back to a full `Del(prior) + Add(new)` sweep — slightly
+    /// heavier but the only correct option since "every subtype
+    /// except this list" isn't expressible as a finite set without
+    /// enumerating `RibSubType::Other(u8)`.
+    fn redist_update(
+        &mut self,
+        proto: String,
+        afi: super::RedistAfi,
+        rtype: RibType,
+        subtypes: std::collections::BTreeSet<super::RibSubType>,
+    ) {
+        if !super::redist::deliverable(&proto, rtype) {
+            return;
+        }
+        let Some(tx) = self.redists.get(&proto).cloned() else {
+            return;
+        };
+        let prior = self
+            .redist_filters
+            .get(&proto)
+            .and_then(|f| f.get(&(afi, rtype)))
+            .cloned()
+            .unwrap_or_default();
+        if prior == subtypes {
+            return; // no-op
+        }
+
+        if prior.is_empty() || subtypes.is_empty() {
+            // Wildcard on either side — fall back to full re-walk.
+            // Consumer briefly sees Del then Add for any routes
+            // shared by both filters; acceptable for redistribute
+            // (config-time, not data-plane).
+            self.redist_walk(&proto, afi, rtype, &prior, super::redist::WalkOp::Del, &tx);
+            self.redist_walk(
+                &proto,
+                afi,
+                rtype,
+                &subtypes,
+                super::redist::WalkOp::Add,
+                &tx,
+            );
+        } else {
+            // Both non-wildcard — symmetric difference is correct and
+            // avoids the brief Del→Add glitch on shared subtypes.
+            let removed: std::collections::BTreeSet<super::RibSubType> =
+                prior.difference(&subtypes).cloned().collect();
+            if !removed.is_empty() {
+                self.redist_walk(
+                    &proto,
+                    afi,
+                    rtype,
+                    &removed,
+                    super::redist::WalkOp::Del,
+                    &tx,
+                );
+            }
+            let added: std::collections::BTreeSet<super::RibSubType> =
+                subtypes.difference(&prior).cloned().collect();
+            if !added.is_empty() {
+                self.redist_walk(&proto, afi, rtype, &added, super::redist::WalkOp::Add, &tx);
+            }
+        }
+
+        self.redist_filters
+            .entry(proto)
+            .or_default()
+            .insert((afi, rtype), subtypes);
+    }
+
+    fn redist_del(&mut self, proto: String, afi: super::RedistAfi, rtype: RibType) {
+        let Some(tx) = self.redists.get(&proto).cloned() else {
+            // No Tx → nothing to withdraw. Still clear the filter row
+            // so memory doesn't leak across re-subscribes.
+            if let Some(f) = self.redist_filters.get_mut(&proto) {
+                f.remove(&(afi, rtype));
+            }
+            return;
+        };
+        // Withdraw using whatever filter we had registered.
+        let Some(filter) = self
+            .redist_filters
+            .get(&proto)
+            .and_then(|f| f.get(&(afi, rtype)))
+            .cloned()
+        else {
+            return;
+        };
+        self.redist_walk(&proto, afi, rtype, &filter, super::redist::WalkOp::Del, &tx);
+        if let Some(f) = self.redist_filters.get_mut(&proto) {
+            f.remove(&(afi, rtype));
+        }
+    }
+
+    fn redist_walk(
+        &self,
+        proto: &str,
+        afi: super::RedistAfi,
+        rtype: RibType,
+        subtypes: &std::collections::BTreeSet<super::RibSubType>,
+        op: super::redist::WalkOp,
+        tx: &UnboundedSender<RibRx>,
+    ) {
+        match afi {
+            super::RedistAfi::Ipv4 => {
+                super::redist::walk_v4(&self.table, proto, rtype, subtypes, op, tx);
+            }
+            super::RedistAfi::Ipv6 => {
+                super::redist::walk_v6(&self.table_v6, proto, rtype, subtypes, op, tx);
+            }
+        }
     }
 
     async fn process_msg(&mut self, msg: Message) {
@@ -1294,13 +1472,25 @@ impl Rib {
             } => {
                 self.mdb_del(vni, group, source, ifindex).await;
             }
-            // Redistribute subscription messages — types-only PR.
-            // The walk-and-replay + steady-state dispatch lands in a
-            // follow-up; drain silently for now so the dispatcher
-            // stays exhaustive.
-            Message::RedistAdd { .. }
-            | Message::RedistUpdate { .. }
-            | Message::RedistDel { .. } => {}
+            Message::RedistAdd {
+                proto,
+                afi,
+                rtype,
+                subtypes,
+            } => {
+                self.redist_add(proto, afi, rtype, subtypes);
+            }
+            Message::RedistUpdate {
+                proto,
+                afi,
+                rtype,
+                subtypes,
+            } => {
+                self.redist_update(proto, afi, rtype, subtypes);
+            }
+            Message::RedistDel { proto, afi, rtype } => {
+                self.redist_del(proto, afi, rtype);
+            }
         }
     }
 

--- a/zebra-rs/src/rib/mod.rs
+++ b/zebra-rs/src/rib/mod.rs
@@ -25,8 +25,10 @@ pub mod srv6;
 pub mod types;
 pub use types::{BulkPhase, RedistAfi, RibSubType, RibType, RouteBatch};
 // `RouteEntryV4`, `RouteEntryV6`, and `REDIST_BATCH_MAX` are re-exported
-// once the RIB walker (and the per-protocol consumers that construct
-// `RouteBatch::V4(vec![RouteEntryV4 { … }])`) land in follow-up PRs.
+// once the per-protocol consumers that construct
+// `RouteBatch::V4(vec![RouteEntryV4 { … }])` land in follow-up PRs.
+
+pub mod redist;
 
 pub mod util;
 

--- a/zebra-rs/src/rib/redist.rs
+++ b/zebra-rs/src/rib/redist.rs
@@ -1,0 +1,255 @@
+//! Redistribute filter registry and walk-and-replay.
+//!
+//! Owns the per-(proto, AFI, rtype) subtype filter sets and the
+//! one-shot FIB walker that pushes matching routes to a subscriber.
+//! Self-route filtering is enforced here unconditionally — a
+//! subscription whose `proto` maps to its own `rtype` is silently
+//! dropped at registration time.
+//!
+//! Sender side only; the steady-state delta hook that fires on
+//! FIB churn is a follow-up.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use ipnet::{Ipv4Net, Ipv6Net};
+use prefix_trie::PrefixMap;
+use tokio::sync::mpsc::UnboundedSender;
+
+use super::api::RibRx;
+use super::entry::RibEntries;
+use super::nexthop::Nexthop;
+use super::types::{
+    BulkPhase, REDIST_BATCH_MAX, RedistAfi, RibSubType, RibType, RouteBatch, RouteEntryV4,
+    RouteEntryV6,
+};
+
+/// Per-(AFI, rtype) subtype filter. Empty set = wildcard (match every
+/// subtype under `rtype`).
+pub type FilterMap = BTreeMap<(RedistAfi, RibType), BTreeSet<RibSubType>>;
+
+/// Map a `RibType` back to the protocol identifier that owns it.
+/// Used for the unconditional self-route filter — a subscriber whose
+/// proto matches a route's owning protocol never receives that route.
+/// Returns `None` for rtypes that aren't owned by a registerable
+/// protocol (kernel, connected, static, dhcp, other) — those are
+/// always deliverable.
+pub fn proto_for_rtype(rtype: RibType) -> Option<&'static str> {
+    match rtype {
+        RibType::Bgp => Some("bgp"),
+        RibType::Isis => Some("isis"),
+        RibType::Ospf => Some("ospf"),
+        _ => None,
+    }
+}
+
+/// Whether a route owned by `rtype` is deliverable to a subscriber
+/// running under `proto`. Self-route filter — unconditional, never
+/// configurable.
+pub fn deliverable(proto: &str, rtype: RibType) -> bool {
+    proto_for_rtype(rtype).is_none_or(|owner| owner != proto)
+}
+
+/// Whether a route with the given `subtype` matches a filter row.
+/// Empty filter set is wildcard.
+pub fn subtype_matches(filter: &BTreeSet<RibSubType>, subtype: &RibSubType) -> bool {
+    filter.is_empty() || filter.contains(subtype)
+}
+
+/// Direction of the bulk push — produces either `RouteAdd` or
+/// `RouteDel` for each batched chunk.
+#[derive(Debug, Clone, Copy)]
+pub enum WalkOp {
+    Add,
+    Del,
+}
+
+/// Walk the IPv4 FIB and push every matching route to `tx`. Sends one
+/// or more `RouteAdd`/`RouteDel { bulk: More }` messages of up to
+/// `REDIST_BATCH_MAX` entries, then a final `{ bulk: Eor }` (even if
+/// the last chunk would otherwise be empty) so the consumer knows the
+/// replay is done.
+pub fn walk_v4(
+    table: &PrefixMap<Ipv4Net, RibEntries>,
+    proto: &str,
+    rtype: RibType,
+    subtype_filter: &BTreeSet<RibSubType>,
+    op: WalkOp,
+    tx: &UnboundedSender<RibRx>,
+) {
+    let mut buf: Vec<RouteEntryV4> = Vec::with_capacity(REDIST_BATCH_MAX);
+    for (prefix, entries) in table.iter() {
+        let Some(entry) = pick_entry(entries, rtype, subtype_filter) else {
+            continue;
+        };
+        if !deliverable(proto, entry.rtype) {
+            continue;
+        }
+        let Some(nh4) = first_v4_nexthop(&entry.nexthop) else {
+            continue;
+        };
+        buf.push(RouteEntryV4 {
+            prefix: *prefix,
+            nexthop: nh4,
+            subtype: entry.rsubtype.clone(),
+            metric: entry.metric,
+            tag: 0,
+            ifindex: entry.ifindex,
+        });
+        if buf.len() >= REDIST_BATCH_MAX {
+            flush_v4(&mut buf, rtype, op, BulkPhase::More, tx);
+        }
+    }
+    // Final flush carrying Eor. Even an empty residual buf needs an
+    // Eor marker so the consumer can complete its replay state.
+    flush_v4(&mut buf, rtype, op, BulkPhase::Eor, tx);
+}
+
+/// IPv6 sibling of `walk_v4`. Same chunking + EoR semantics.
+pub fn walk_v6(
+    table: &PrefixMap<Ipv6Net, RibEntries>,
+    proto: &str,
+    rtype: RibType,
+    subtype_filter: &BTreeSet<RibSubType>,
+    op: WalkOp,
+    tx: &UnboundedSender<RibRx>,
+) {
+    let mut buf: Vec<RouteEntryV6> = Vec::with_capacity(REDIST_BATCH_MAX);
+    for (prefix, entries) in table.iter() {
+        let Some(entry) = pick_entry(entries, rtype, subtype_filter) else {
+            continue;
+        };
+        if !deliverable(proto, entry.rtype) {
+            continue;
+        }
+        let Some(nh6) = first_v6_nexthop(&entry.nexthop) else {
+            continue;
+        };
+        buf.push(RouteEntryV6 {
+            prefix: *prefix,
+            nexthop: nh6,
+            subtype: entry.rsubtype.clone(),
+            metric: entry.metric,
+            tag: 0,
+            ifindex: entry.ifindex,
+        });
+        if buf.len() >= REDIST_BATCH_MAX {
+            flush_v6(&mut buf, rtype, op, BulkPhase::More, tx);
+        }
+    }
+    flush_v6(&mut buf, rtype, op, BulkPhase::Eor, tx);
+}
+
+/// Pick the first `RibEntries` row that's both selected (so the
+/// replay reflects FIB-installed state, not shadowed alternates) and
+/// matches the `(rtype, subtype-filter)` predicate.
+fn pick_entry<'a>(
+    entries: &'a RibEntries,
+    rtype: RibType,
+    subtype_filter: &BTreeSet<RibSubType>,
+) -> Option<&'a super::entry::RibEntry> {
+    entries.iter().find(|e| {
+        e.is_selected() && e.rtype == rtype && subtype_matches(subtype_filter, &e.rsubtype)
+    })
+}
+
+/// Resolve the first IPv4 nexthop address from a Nexthop. Returns
+/// `None` for Link-only (connected) or empty / non-v4 Multi/List —
+/// callers skip the route in that case rather than emit a malformed
+/// entry.
+fn first_v4_nexthop(nh: &Nexthop) -> Option<std::net::Ipv4Addr> {
+    match nh {
+        Nexthop::Uni(uni) => match uni.addr {
+            std::net::IpAddr::V4(a) => Some(a),
+            _ => None,
+        },
+        Nexthop::Multi(m) => m.nexthops.first().and_then(|u| match u.addr {
+            std::net::IpAddr::V4(a) => Some(a),
+            _ => None,
+        }),
+        Nexthop::List(l) => l.nexthops.first().and_then(|m| match m {
+            super::nexthop::NexthopMember::Uni(u) => match u.addr {
+                std::net::IpAddr::V4(a) => Some(a),
+                _ => None,
+            },
+            super::nexthop::NexthopMember::Multi(mm) => {
+                mm.nexthops.first().and_then(|u| match u.addr {
+                    std::net::IpAddr::V4(a) => Some(a),
+                    _ => None,
+                })
+            }
+        }),
+        Nexthop::Link(_) => None,
+    }
+}
+
+fn first_v6_nexthop(nh: &Nexthop) -> Option<std::net::Ipv6Addr> {
+    match nh {
+        Nexthop::Uni(uni) => match uni.addr {
+            std::net::IpAddr::V6(a) => Some(a),
+            _ => None,
+        },
+        Nexthop::Multi(m) => m.nexthops.first().and_then(|u| match u.addr {
+            std::net::IpAddr::V6(a) => Some(a),
+            _ => None,
+        }),
+        Nexthop::List(l) => l.nexthops.first().and_then(|m| match m {
+            super::nexthop::NexthopMember::Uni(u) => match u.addr {
+                std::net::IpAddr::V6(a) => Some(a),
+                _ => None,
+            },
+            super::nexthop::NexthopMember::Multi(mm) => {
+                mm.nexthops.first().and_then(|u| match u.addr {
+                    std::net::IpAddr::V6(a) => Some(a),
+                    _ => None,
+                })
+            }
+        }),
+        Nexthop::Link(_) => None,
+    }
+}
+
+fn flush_v4(
+    buf: &mut Vec<RouteEntryV4>,
+    rtype: RibType,
+    op: WalkOp,
+    bulk: BulkPhase,
+    tx: &UnboundedSender<RibRx>,
+) {
+    let routes = RouteBatch::V4(std::mem::take(buf));
+    let msg = match op {
+        WalkOp::Add => RibRx::RouteAdd {
+            rtype,
+            routes,
+            bulk,
+        },
+        WalkOp::Del => RibRx::RouteDel {
+            rtype,
+            routes,
+            bulk,
+        },
+    };
+    let _ = tx.send(msg);
+}
+
+fn flush_v6(
+    buf: &mut Vec<RouteEntryV6>,
+    rtype: RibType,
+    op: WalkOp,
+    bulk: BulkPhase,
+    tx: &UnboundedSender<RibRx>,
+) {
+    let routes = RouteBatch::V6(std::mem::take(buf));
+    let msg = match op {
+        WalkOp::Add => RibRx::RouteAdd {
+            rtype,
+            routes,
+            bulk,
+        },
+        WalkOp::Del => RibRx::RouteDel {
+            rtype,
+            routes,
+            bulk,
+        },
+    };
+    let _ = tx.send(msg);
+}

--- a/zebra-rs/src/rib/types.rs
+++ b/zebra-rs/src/rib/types.rs
@@ -7,7 +7,7 @@ const RIB_ISIS: u8 = 5;
 const RIB_BGP: u8 = 6;
 const RIB_DHCP: u8 = 7;
 
-#[derive(Debug, PartialEq, Eq, Clone, Default, Copy, serde::Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Default, Copy, PartialOrd, Ord, serde::Serialize)]
 pub enum RibType {
     Kernel,
     Connected,
@@ -88,7 +88,7 @@ impl RibType {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, serde::Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, PartialOrd, Ord, serde::Serialize)]
 pub enum RibSubType {
     Default,
     OspfIa,
@@ -177,15 +177,20 @@ pub enum BulkPhase {
 
 /// Minimal route attributes delivered to a redistribute subscriber.
 /// Carries what policy almost always matches on (prefix, nexthop,
-/// metric, tag) plus the egress ifindex. Communities / originator-id
-/// etc. are BGP-only and intentionally omitted from this baseline —
-/// they'd grow `extra: Option<…>` later without changing the wire
-/// shape.
+/// metric, tag, subtype) plus the egress ifindex. Communities /
+/// originator-id etc. are BGP-only and intentionally omitted from
+/// this baseline — they'd grow `extra: Option<…>` later without
+/// changing the wire shape.
+///
+/// `subtype` is per-entry (not per-message) so a wildcard
+/// subscription replays in a single pass with one final EoR, instead
+/// of N walks and N EoRs (one per subtype).
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RouteEntryV4 {
     pub prefix: ipnet::Ipv4Net,
     pub nexthop: std::net::Ipv4Addr,
+    pub subtype: RibSubType,
     pub metric: u32,
     pub tag: u32,
     pub ifindex: u32,
@@ -196,6 +201,7 @@ pub struct RouteEntryV4 {
 pub struct RouteEntryV6 {
     pub prefix: ipnet::Ipv6Net,
     pub nexthop: std::net::Ipv6Addr,
+    pub subtype: RibSubType,
     pub metric: u32,
     pub tag: u32,
     pub ifindex: u32,


### PR DESCRIPTION
## Summary
Step 2 of the protocol⇄RIB redistribute pipeline. Builds on the types-only PR #597 with the registry + one-shot FIB walker.

**Subtype placement changed** from per-message to per-entry. The original PR #597 shape put `subtype` on `RouteAdd`/`RouteDel`, which forced wildcard subscribers to receive N separate batches (one per subtype) and N EoR markers. Moving subtype into `RouteEntryV4`/`V6` lets a wildcard replay run as a single pass with one final EoR — at the cost of one extra byte per route.

**Filter registry** (`Rib.redist_filters`):
- `HashMap<String, BTreeMap<(RedistAfi, RibType), BTreeSet<RibSubType>>>`.
- Outer key matches `Rib.redists` (subscriber's proto name).
- Cleared by `proto_cleanup` alongside `Rib.redists`.

**Walker** (`rib::redist`):
- `walk_v4` / `walk_v6` iterate the FIB once for matching routes; push `RouteAdd { bulk: More }` (or `RouteDel`) batches of up to `REDIST_BATCH_MAX`; final `bulk: Eor` even if last chunk is empty.
- `pick_entry` requires `is_selected()` — consumers see FIB-installed state, not shadowed alternates.
- First-nexthop resolution from the selected entry's `Nexthop` (ECMP collapses to first hop; refinement deferred).
- `proto_for_rtype` + `deliverable` enforce the unconditional self-route filter.

**Handlers** in `process_msg`:
- `RedistAdd`: register filter row + initial walk-and-replay.
- `RedistUpdate`: replace the prior row, emit only the delta.
  - Both non-wildcard → symmetric difference (avoids brief Del→Add glitch on shared subtypes).
  - Either wildcard → full `Del(prior) + Add(new)` sweep (can't express "every subtype except this list" finitely).
- `RedistDel`: Del-walk using the registered filter, then drop the row.
- Self-route subscriptions are silently dropped at registration.

**Type derives**: `RibType` / `RibSubType` pick up `Ord`/`PartialOrd` so they can be `BTreeMap` keys / `BTreeSet` members. `RibSubType` also picks up `Eq`.

## What's NOT in this PR
- Steady-state delta hook — `ipv4_route_{add,del}` and `ipv6_route_{add,del}` don't notify the registry yet, so today's redistribute is a one-shot snapshot at registration. **Step 3.**
- Per-protocol senders / consumers — no IS-IS/BGP/OSPF callsite issues `RedistAdd`, nothing handles `RouteAdd`/`Del`. **Step 4.**

## Test plan
- [x] `cargo build --bin zebra-rs` — clean.
- [x] `cargo clippy --bin zebra-rs --no-deps` — clean.
- [ ] Functional verification deferred to step 4 when a real consumer wires up; the walker and handlers exercise only the existing FIB primitives, no observable behaviour change today.

Generated with [Claude Code](https://claude.com/claude-code)