### PR TITLE
rib: redistribute steady-state delta hook (step 3 of 4)

### DIFF
--- a/zebra-rs/src/rib/redist.rs
+++ b/zebra-rs/src/rib/redist.rs
@@ -1,22 +1,27 @@
 //! Redistribute filter registry and walk-and-replay.
 //!
-//! Owns the per-(proto, AFI, rtype) subtype filter sets and the
-//! one-shot FIB walker that pushes matching routes to a subscriber.
-//! Self-route filtering is enforced here unconditionally — a
+//! Owns the per-(proto, AFI, rtype) subtype filter sets, the one-shot
+//! FIB walker that pushes the current matching set at subscription
+//! time, and the steady-state delta hook that fires from
+//! `ipv{4,6}_route_{add,del}` after a mutation flips the selected
+//! entry. Self-route filtering is enforced unconditionally — a
 //! subscription whose `proto` maps to its own `rtype` is silently
 //! dropped at registration time.
 //!
-//! Sender side only; the steady-state delta hook that fires on
-//! FIB churn is a follow-up.
+//! Known gap: nexthop-resolution-driven selection changes that don't
+//! flow through `ipv{4,6}_route_{add,del}` (e.g. the debounced
+//! `ipv4_route_resolve` path) are not yet hooked. The initial walk
+//! at subscription time still covers those, but they won't update
+//! in steady state until a follow-up generalizes the hook.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use ipnet::{Ipv4Net, Ipv6Net};
 use prefix_trie::PrefixMap;
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::api::RibRx;
-use super::entry::RibEntries;
+use super::entry::{RibEntries, RibEntry};
 use super::nexthop::Nexthop;
 use super::types::{
     BulkPhase, REDIST_BATCH_MAX, RedistAfi, RibSubType, RibType, RouteBatch, RouteEntryV4,
@@ -249,6 +254,213 @@ fn flush_v6(
             rtype,
             routes,
             bulk,
+        },
+    };
+    let _ = tx.send(msg);
+}
+
+// ---- steady-state delta notification --------------------------------
+//
+// Called from the route_{add,del} entry points after a FIB mutation
+// has updated the selected entry. Compares the before/after selected
+// entries per subscriber and emits single-entry RouteAdd / RouteDel
+// messages for each filter row that's affected.
+//
+// Known gap: nexthop-resolution-driven selection changes that don't
+// flow through `ipv{4,6}_route_{add,del}` (e.g. the debounced
+// `ipv4_route_resolve` path) are not yet hooked. The initial walk
+// at subscription time still covers those, but they won't update
+// in steady state until step 4 generalizes the hook.
+
+fn build_v4_entry(prefix: &Ipv4Net, e: &RibEntry) -> Option<RouteEntryV4> {
+    let nh = first_v4_nexthop(&e.nexthop)?;
+    Some(RouteEntryV4 {
+        prefix: *prefix,
+        nexthop: nh,
+        subtype: e.rsubtype.clone(),
+        metric: e.metric,
+        tag: 0,
+        ifindex: e.ifindex,
+    })
+}
+
+fn build_v6_entry(prefix: &Ipv6Net, e: &RibEntry) -> Option<RouteEntryV6> {
+    let nh = first_v6_nexthop(&e.nexthop)?;
+    Some(RouteEntryV6 {
+        prefix: *prefix,
+        nexthop: nh,
+        subtype: e.rsubtype.clone(),
+        metric: e.metric,
+        tag: 0,
+        ifindex: e.ifindex,
+    })
+}
+
+/// Notify every subscriber whose filter matches the before/after
+/// transition of the selected entry at `prefix`. Single-entry batches,
+/// `bulk: More`. EoR is reserved for initial walk / Redist{Add,Update,
+/// Del} replays — steady-state never emits Eor.
+pub fn notify_v4_delta(
+    filters: &HashMap<String, FilterMap>,
+    redists: &HashMap<String, UnboundedSender<RibRx>>,
+    prefix: &Ipv4Net,
+    before: Option<&RibEntry>,
+    after: Option<&RibEntry>,
+) {
+    if before.is_none() && after.is_none() {
+        return;
+    }
+    for (proto, filter_map) in filters {
+        let Some(tx) = redists.get(proto) else {
+            continue;
+        };
+        // For each (afi, rtype) row this proto has — only IPv4 rows
+        // apply here, and only those whose rtype matches at least one
+        // side of the transition.
+        for ((afi, rtype), subtypes) in filter_map {
+            if *afi != RedistAfi::Ipv4 {
+                continue;
+            }
+            let old = entry_for_subscriber_v4(prefix, before, *rtype, subtypes, proto);
+            let new = entry_for_subscriber_v4(prefix, after, *rtype, subtypes, proto);
+            emit_v4_diff(tx, *rtype, old, new);
+        }
+    }
+}
+
+pub fn notify_v6_delta(
+    filters: &HashMap<String, FilterMap>,
+    redists: &HashMap<String, UnboundedSender<RibRx>>,
+    prefix: &Ipv6Net,
+    before: Option<&RibEntry>,
+    after: Option<&RibEntry>,
+) {
+    if before.is_none() && after.is_none() {
+        return;
+    }
+    for (proto, filter_map) in filters {
+        let Some(tx) = redists.get(proto) else {
+            continue;
+        };
+        for ((afi, rtype), subtypes) in filter_map {
+            if *afi != RedistAfi::Ipv6 {
+                continue;
+            }
+            let old = entry_for_subscriber_v6(prefix, before, *rtype, subtypes, proto);
+            let new = entry_for_subscriber_v6(prefix, after, *rtype, subtypes, proto);
+            emit_v6_diff(tx, *rtype, old, new);
+        }
+    }
+}
+
+/// Build the delivered `RouteEntryV4` only when the source entry
+/// matches the subscriber's filter row (rtype, subtype, deliverable).
+/// Returns `None` when no entry should be delivered.
+fn entry_for_subscriber_v4(
+    prefix: &Ipv4Net,
+    entry: Option<&RibEntry>,
+    rtype: RibType,
+    subtypes: &BTreeSet<RibSubType>,
+    proto: &str,
+) -> Option<RouteEntryV4> {
+    let e = entry?;
+    if e.rtype != rtype {
+        return None;
+    }
+    if !deliverable(proto, e.rtype) {
+        return None;
+    }
+    if !subtype_matches(subtypes, &e.rsubtype) {
+        return None;
+    }
+    build_v4_entry(prefix, e)
+}
+
+fn entry_for_subscriber_v6(
+    prefix: &Ipv6Net,
+    entry: Option<&RibEntry>,
+    rtype: RibType,
+    subtypes: &BTreeSet<RibSubType>,
+    proto: &str,
+) -> Option<RouteEntryV6> {
+    let e = entry?;
+    if e.rtype != rtype {
+        return None;
+    }
+    if !deliverable(proto, e.rtype) {
+        return None;
+    }
+    if !subtype_matches(subtypes, &e.rsubtype) {
+        return None;
+    }
+    build_v6_entry(prefix, e)
+}
+
+fn emit_v4_diff(
+    tx: &UnboundedSender<RibRx>,
+    rtype: RibType,
+    old: Option<RouteEntryV4>,
+    new: Option<RouteEntryV4>,
+) {
+    match (old, new) {
+        (None, None) => {}
+        (Some(o), None) => send_v4_one(tx, rtype, WalkOp::Del, o),
+        (None, Some(n)) => send_v4_one(tx, rtype, WalkOp::Add, n),
+        (Some(o), Some(n)) if o == n => {}
+        (Some(o), Some(n)) => {
+            send_v4_one(tx, rtype, WalkOp::Del, o);
+            send_v4_one(tx, rtype, WalkOp::Add, n);
+        }
+    }
+}
+
+fn emit_v6_diff(
+    tx: &UnboundedSender<RibRx>,
+    rtype: RibType,
+    old: Option<RouteEntryV6>,
+    new: Option<RouteEntryV6>,
+) {
+    match (old, new) {
+        (None, None) => {}
+        (Some(o), None) => send_v6_one(tx, rtype, WalkOp::Del, o),
+        (None, Some(n)) => send_v6_one(tx, rtype, WalkOp::Add, n),
+        (Some(o), Some(n)) if o == n => {}
+        (Some(o), Some(n)) => {
+            send_v6_one(tx, rtype, WalkOp::Del, o);
+            send_v6_one(tx, rtype, WalkOp::Add, n);
+        }
+    }
+}
+
+fn send_v4_one(tx: &UnboundedSender<RibRx>, rtype: RibType, op: WalkOp, entry: RouteEntryV4) {
+    let routes = RouteBatch::V4(vec![entry]);
+    let msg = match op {
+        WalkOp::Add => RibRx::RouteAdd {
+            rtype,
+            routes,
+            bulk: BulkPhase::More,
+        },
+        WalkOp::Del => RibRx::RouteDel {
+            rtype,
+            routes,
+            bulk: BulkPhase::More,
+        },
+    };
+    let _ = tx.send(msg);
+}
+
+fn send_v6_one(tx: &UnboundedSender<RibRx>, rtype: RibType, op: WalkOp, entry: RouteEntryV6) {
+    let routes = RouteBatch::V6(vec![entry]);
+    let msg = match op {
+        WalkOp::Add => RibRx::RouteAdd {
+            rtype,
+            routes,
+            bulk: BulkPhase::More,
+        },
+        WalkOp::Del => RibRx::RouteDel {
+            rtype,
+            routes,
+            bulk: BulkPhase::More,
         },
     };
     let _ = tx.send(msg);

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -513,6 +513,7 @@ impl Rib {
     }
 
     pub async fn ipv4_route_add(&mut self, prefix: &Ipv4Net, mut entry: RibEntry) {
+        let before = selected_v4(&self.table, prefix).cloned();
         if entry.is_protocol() {
             let mut replace = rib_replace(&mut self.table, prefix, entry.rtype);
             rib_resolve_nexthop(&mut entry, &self.table, &mut self.nmap);
@@ -522,6 +523,14 @@ impl Rib {
             rib_add_system(&mut self.table, prefix, entry);
             self.rib_selection(prefix, None).await;
         }
+        let after = selected_v4(&self.table, prefix).cloned();
+        super::redist::notify_v4_delta(
+            &self.redist_filters,
+            &self.redists,
+            prefix,
+            before.as_ref(),
+            after.as_ref(),
+        );
 
         // Any RIB add can shift the FIB — debounced resolve catches static /
         // SRv6 nexthops that were unreachable before and are now covered by
@@ -530,6 +539,7 @@ impl Rib {
     }
 
     pub async fn ipv4_route_del(&mut self, prefix: &Ipv4Net, entry: RibEntry) {
+        let before = selected_v4(&self.table, prefix).cloned();
         if entry.is_protocol() {
             let mut replace = rib_replace(&mut self.table, prefix, entry.rtype);
             self.rib_selection(prefix, replace.pop()).await;
@@ -538,6 +548,14 @@ impl Rib {
             let mut replace = rib_replace_system(&mut self.table, prefix, entry);
             self.rib_selection(prefix, replace.pop()).await;
         }
+        let after = selected_v4(&self.table, prefix).cloned();
+        super::redist::notify_v4_delta(
+            &self.redist_filters,
+            &self.redists,
+            prefix,
+            before.as_ref(),
+            after.as_ref(),
+        );
 
         self.schedule_rib_sync();
     }
@@ -587,6 +605,7 @@ impl Rib {
             uni.ifindex_origin = Some(ifindex);
         }
 
+        let before = selected_v6(&self.table_v6, prefix).cloned();
         if entry.is_protocol() {
             let mut replace = rib_replace_v6(&mut self.table_v6, prefix, entry.rtype);
             rib_resolve_nexthop_v6(&mut entry, &self.table_v6, &mut self.nmap);
@@ -603,6 +622,14 @@ impl Rib {
             rib_add_system_v6(&mut self.table_v6, prefix, entry);
             self.rib_selection_v6(prefix, None).await;
         }
+        let after = selected_v6(&self.table_v6, prefix).cloned();
+        super::redist::notify_v6_delta(
+            &self.redist_filters,
+            &self.redists,
+            prefix,
+            before.as_ref(),
+            after.as_ref(),
+        );
 
         // Any RIB add can shift the FIB — debounced resolve catches static /
         // SRv6 nexthops that were unreachable before and are now covered by
@@ -611,6 +638,7 @@ impl Rib {
     }
 
     pub async fn ipv6_route_del(&mut self, prefix: &Ipv6Net, entry: RibEntry) {
+        let before = selected_v6(&self.table_v6, prefix).cloned();
         if entry.is_protocol() {
             let mut replace = rib_replace_v6(&mut self.table_v6, prefix, entry.rtype);
             self.rib_selection_v6(prefix, replace.pop()).await;
@@ -619,6 +647,14 @@ impl Rib {
             let mut replace = rib_replace_system_v6(&mut self.table_v6, prefix, entry);
             self.rib_selection_v6(prefix, replace.pop()).await;
         }
+        let after = selected_v6(&self.table_v6, prefix).cloned();
+        super::redist::notify_v6_delta(
+            &self.redist_filters,
+            &self.redists,
+            prefix,
+            before.as_ref(),
+            after.as_ref(),
+        );
 
         self.schedule_rib_sync();
     }
@@ -1157,6 +1193,23 @@ fn rib_replace(
 
 fn rib_prev(ribs: &RibEntries) -> Option<usize> {
     ribs.iter().position(|e| e.is_selected())
+}
+
+/// Snapshot of the currently-selected entry at `prefix`. Used by the
+/// redistribute steady-state delta hook to compare before/after a
+/// mutation in `ipv{4,6}_route_{add,del}`.
+fn selected_v4<'a>(
+    table: &'a PrefixMap<Ipv4Net, RibEntries>,
+    prefix: &Ipv4Net,
+) -> Option<&'a RibEntry> {
+    table.get(prefix)?.iter().find(|e| e.is_selected())
+}
+
+fn selected_v6<'a>(
+    table: &'a PrefixMap<Ipv6Net, RibEntries>,
+    prefix: &Ipv6Net,
+) -> Option<&'a RibEntry> {
+    table.get(prefix)?.iter().find(|e| e.is_selected())
 }
 
 fn rib_next(ribs: &RibEntries) -> Option<usize> {


### PR DESCRIPTION
## Summary
Step 3 of the protocol⇄RIB redistribute pipeline. Wires the FIB-mutation paths to notify redistribute subscribers when the selected entry at a prefix flips. Builds on the registry + initial walk-and-replay from PR #598; protocols subscribed via `RedistAdd` now see follow-up changes, not just the snapshot at subscription time.

**Hook sites** (`rib/route.rs`):
- `ipv{4,6}_route_add` / `ipv{4,6}_route_del` each take a selected-entry snapshot before the existing mutation path, run it, take an after snapshot, and call the notifier.
- New private `selected_v{4,6}` helpers walk `RibEntries` for `is_selected()`.

**Notifier** (`rib/redist.rs`):
- `notify_v{4,6}_delta` iterate `Rib.redist_filters`; per-subscriber, per-filter-row, build `RouteEntryV{4,6}` only when the source entry matches the row's (AFI, rtype, subtype) predicate and passes the unconditional self-route filter.
- Four-way diff:
  - `(None, None)` → no-op
  - `(Some, None)` → `RouteDel { bulk: More }`
  - `(None, Some)` → `RouteAdd { bulk: More }`
  - `(Some(a), Some(b))` equal → no-op
  - `(Some, Some)` differ → `RouteDel(old) + RouteAdd(new)`
- EoR stays reserved for the initial walk and `Redist{Add,Update,Del}` replays; steady-state never emits Eor.

## Documented gap
The debounced `ipv{4,6}_route_resolve` / `ipv{4,6}_nexthop_sync` paths can flip the selected entry (validity changes → different winner from `rib_next`) without flowing through `route_add`/`del`. Those re-selections are not yet hooked; the initial walk still picks up correct state at subscription time, only follow-up resolve-driven changes are missed. Generalizing the hook by moving the notification into `ipv{4,6}_entry_selection` is a step-3b / step-4 concern.

## Test plan
- [x] `cargo build --bin zebra-rs` — clean.
- [x] `cargo clippy --bin zebra-rs --no-deps` — clean.
- [ ] Functional verification deferred to step 4 when a real consumer wires up — today there's still no producer of `RedistAdd` or consumer of `RouteAdd`/`Del`, so the hook is reachable but inert.

Generated with [Claude Code](https://claude.com/claude-code)