### PR TITLE
bgp: inject redistributed prefixes into Loc-RIB (step 5b, IPv4 only)

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -642,10 +642,19 @@ impl Bgp {
         match batch {
             crate::rib::RouteBatch::V4(entries) => {
                 for e in entries {
-                    self.redist_v4.insert((rtype, e.prefix), e);
+                    let prefix = e.prefix;
+                    let rib_metric = e.metric;
+                    self.redist_v4.insert((rtype, prefix), e);
+                    // Lower into Loc-RIB. Per-AFI override metric beats
+                    // the RIB cost; no override → use RIB cost as MED.
+                    let metric = self
+                        .redist_metric_v4_override(rtype, prefix)
+                        .unwrap_or(rib_metric);
+                    self.route_redist_inject(rtype, prefix, metric);
                 }
             }
             crate::rib::RouteBatch::V6(entries) => {
+                // v6 stays storage-only until LocalRib grows a v6 path.
                 for e in entries {
                     self.redist_v6.insert((rtype, e.prefix), e);
                 }
@@ -658,14 +667,43 @@ impl Bgp {
             crate::rib::RouteBatch::V4(entries) => {
                 for e in entries {
                     self.redist_v4.remove(&(rtype, e.prefix));
+                    self.route_redist_withdraw(rtype, e.prefix);
                 }
             }
             crate::rib::RouteBatch::V6(entries) => {
+                // v6 storage-only — see route_redist_add.
                 for e in entries {
                     self.redist_v6.remove(&(rtype, e.prefix));
                 }
             }
         }
+    }
+
+    /// Pull the `metric` static override from any `Bgp.redistribute`
+    /// row matching `(rtype, ipv4-unicast)`. Iterates because the map
+    /// is keyed by full `AfiSafi`, and we only care about the IPv4
+    /// unicast row here. `None` means "no override, use RIB cost".
+    fn redist_metric_v4_override(
+        &self,
+        rtype: crate::rib::RibType,
+        _prefix: ipnet::Ipv4Net,
+    ) -> Option<u32> {
+        use crate::bgp::config::BgpRedistSource;
+        use bgp_packet::{Afi, Safi};
+        let source = match rtype {
+            crate::rib::RibType::Connected => BgpRedistSource::Connected,
+            crate::rib::RibType::Static => BgpRedistSource::Static,
+            crate::rib::RibType::Isis => BgpRedistSource::Isis,
+            crate::rib::RibType::Ospf => BgpRedistSource::Ospf,
+            _ => return None,
+        };
+        let afi_safi = bgp_packet::AfiSafi {
+            afi: Afi::Ip,
+            safi: Safi::Unicast,
+        };
+        self.redistribute
+            .get(&(afi_safi, source))
+            .and_then(|c| c.metric)
     }
 
     pub async fn process_policy_msg(&mut self, msg: policy::PolicyRx) {

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -3481,6 +3481,110 @@ impl Bgp {
         }
     }
 
+    // ---- redistribute injection -----------------------------------
+    //
+    // `route_redist_inject` / `route_redist_withdraw` are siblings of
+    // `route_add` / `route_del`, but
+    //   - carry a `metric` (lowered to MED on the originated route),
+    //   - tag the originator with a per-rtype `remote_id` discriminator
+    //     so a redistributed Connected route and a `network`
+    //     statement for the same prefix do NOT collide in the
+    //     LocalRibTable — both look like `ORIGINATED_PEER` to the
+    //     update path, and same-prefix-same-(ident,remote_id) keys
+    //     replace one another.
+    //
+    // IPv6 redistribution stays storage-only on `Bgp.redist_v6` until
+    // a follow-up adds the LocalRib v6 path; today `LocalRib` only
+    // holds v4 / VPNv4 / EVPN.
+
+    /// Per-rtype remote_id discriminator, so distinct redistribute
+    /// sources (and the `network` statement at id=0) coexist for the
+    /// same prefix without overwriting one another. Values are local
+    /// and never appear on the wire.
+    pub(super) fn redist_remote_id(rtype: crate::rib::RibType) -> u32 {
+        match rtype {
+            crate::rib::RibType::Connected => 1,
+            crate::rib::RibType::Static => 2,
+            crate::rib::RibType::Ospf => 3,
+            crate::rib::RibType::Isis => 4,
+            crate::rib::RibType::Kernel => 5,
+            crate::rib::RibType::Bgp => 0, // self-loop prevented upstream
+            _ => 0,
+        }
+    }
+
+    pub fn route_redist_inject(
+        &mut self,
+        rtype: crate::rib::RibType,
+        prefix: Ipv4Net,
+        metric: u32,
+    ) {
+        let ident = ORIGINATED_PEER;
+        let remote_id = Self::redist_remote_id(rtype);
+        let mut attr = BgpAttr::new();
+        attr.med = Some(bgp_packet::Med::new(metric));
+        let mut rib = BgpRib::new(
+            ident,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            remote_id,
+            32768,
+            &attr,
+            None,
+            None,
+            false,
+        );
+        let (_replaced, selected, next_id) = self.local_rib.update(None, prefix, rib.clone());
+        rib.local_id = next_id;
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_tx: &self.rib_tx,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+        };
+
+        if !selected.is_empty() {
+            route_advertise_to_peers(
+                None,
+                prefix,
+                &selected,
+                ident,
+                &mut bgp_ref,
+                &mut self.peers,
+            );
+        }
+    }
+
+    pub fn route_redist_withdraw(&mut self, rtype: crate::rib::RibType, prefix: Ipv4Net) {
+        let ident = ORIGINATED_PEER;
+        let remote_id = Self::redist_remote_id(rtype);
+        let removed = self.local_rib.remove(None, prefix, remote_id, ident);
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_tx: &self.rib_tx,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+        };
+
+        let selected = bgp_ref.local_rib.select_best_path(prefix);
+        if !selected.is_empty() || !removed.is_empty() {
+            route_advertise_to_peers(
+                None,
+                prefix,
+                &selected,
+                ident,
+                &mut bgp_ref,
+                &mut self.peers,
+            );
+        }
+    }
+
     /// Originate an EVPN Type-2 (MAC/IP Advertisement) route from a
     /// kernel-learned bridge FDB entry.
     ///


### PR DESCRIPTION
## Summary
BGP-side counterpart of PR #602 (IS-IS LSP emission). Each route delivered into `Bgp.redist_v4` is now lowered into Loc-RIB as a `BgpRibType::Originated` entry with MED set from the per-row `metric` override (falling back to the RIB cost when none). After insertion the existing `route_advertise_to_peers` ships the route through every eligible peer's update pipeline.

**IPv4-only this PR** — `LocalRib` only holds v4 / VPNv4 / EVPN today, so v6 redistribute keeps reaching `Bgp.redist_v6` but isn't yet injected. Lands when LocalRib grows a v6 path.

**`bgp/route.rs`**:
- `redist_remote_id(rtype)` — Connected=1, Static=2, Ospf=3, Isis=4, Kernel=5, default 0. Keeps redistribute Connected and a `network 1.0.0.0/24` for the same prefix from overwriting each other in `LocalRibTable` — both look like `ORIGINATED_PEER` to the update path, which keys on `(ident, remote_id)`.
- `route_redist_inject(rtype, prefix, metric)` — mirror of `route_add` but carries `BgpAttr.med = Some(Med::new(metric))` and uses the per-rtype `remote_id`.
- `route_redist_withdraw(rtype, prefix)` — mirror of `route_del` with the same discriminator.

**`bgp/inst.rs`**:
- `route_redist_add` lowers each v4 batch entry into Loc-RIB after storing in `redist_v4`. Metric resolution: per-row `metric` override wins; otherwise the RIB cost.
- `route_redist_del` withdraws the corresponding entry.
- `redist_metric_v4_override` looks up the `(ipv4-unicast, source)` row in `Bgp.redistribute` to pull `metric`. None means "use RIB cost".

## Documented gaps
- IPv6 redistribute reaches storage but doesn't inject.
- `policy NAME` is stored but not applied (same gap as IS-IS step 5).
- `multipath` is stored but not honored — best-only today.
- ECMP source routes collapse to the first nexthop at the RIB walker; not specific to this PR.

## Test plan
- [x] `cargo build --bin zebra-rs` — clean.
- [x] `cargo clippy --bin zebra-rs --no-deps` — clean.
- [ ] `router bgp / afi-safi ipv4 / redistribute connected` → connected /32 loopback appears in `show bgp ipv4` as an Originated route with MED matching the RIB cost.
- [ ] Add `metric 200` to that row → MED becomes 200.
- [ ] Configure both `network 1.0.0.0/24` and `redistribute connected` matching the same prefix; verify both rows live in the candidate list and neither overwrites the other (per-rtype `remote_id` discriminator).
- [ ] Verify peers receive the redistributed prefix in BGP UPDATE.

Generated with [Claude Code](https://claude.com/claude-code)