### PR TITLE
isis: Flex-Algorithm (RFC 9350) YANG schema + config builder

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -253,6 +253,8 @@ impl Isis {
             link::config_ipv6_enable,
         );
         self.callback_add("/router/isis/distribute/rib", config_distribute_rib);
+
+        super::flex_algo::callback_register(self);
     }
 }
 

--- a/zebra-rs/src/isis/flex_algo.rs
+++ b/zebra-rs/src/isis/flex_algo.rs
@@ -1,0 +1,498 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::str::FromStr;
+
+use anyhow::{Context, Result, bail};
+
+use crate::config::{Args, ConfigOp};
+
+use super::Isis;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FadMetricType {
+    Igp,                // FAD Metric-Type 0
+    MinUnidirLinkDelay, // FAD Metric-Type 1 (RFC 8570)
+    TeDefault,          // FAD Metric-Type 2 (RFC 5305)
+}
+
+impl FadMetricType {
+    /// FAD Sub-TLV Metric-Type code (RFC 9350 §5.1, IANA registry).
+    /// Held here so the LSP-emit follow-up has a single source of
+    /// truth for the on-the-wire byte.
+    #[allow(dead_code)]
+    pub fn wire(self) -> u8 {
+        match self {
+            Self::Igp => 0,
+            Self::MinUnidirLinkDelay => 1,
+            Self::TeDefault => 2,
+        }
+    }
+}
+
+impl FromStr for FadMetricType {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "igp" => Ok(Self::Igp),
+            "min-unidir-link-delay" => Ok(Self::MinUnidirLinkDelay),
+            "te-default" => Ok(Self::TeDefault),
+            _ => bail!("unknown flex-algo metric-type: {s}"),
+        }
+    }
+}
+
+/// One Flexible Algorithm Definition (RFC 9350) as configured on this
+/// router. Mirrors the YANG schema under /router/isis/flex-algo.
+#[derive(Debug, Default, Clone)]
+pub struct FlexAlgoEntry {
+    pub delete: bool,
+    pub advertise_definition: Option<bool>,
+    pub metric_type: Option<FadMetricType>,
+    pub priority: Option<u8>,
+    pub prefix_metric: Option<bool>,
+    pub dataplane_sr_mpls: Option<bool>,
+    pub dataplane_srv6: Option<bool>,
+    pub dataplane_ip: Option<bool>,
+    pub include_any: BTreeSet<String>,
+    pub include_all: BTreeSet<String>,
+    pub exclude_any: BTreeSet<String>,
+    pub srlg_exclude: BTreeSet<String>,
+    pub ti_lfa: bool,
+}
+
+pub struct FlexAlgoConfig {
+    pub config: BTreeMap<u8, FlexAlgoEntry>,
+    pub cache: BTreeMap<u8, FlexAlgoEntry>,
+    builder: ConfigBuilder,
+}
+
+impl Default for FlexAlgoConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FlexAlgoConfig {
+    pub fn new() -> Self {
+        Self {
+            config: BTreeMap::new(),
+            cache: BTreeMap::new(),
+            builder: config_builder(),
+        }
+    }
+
+    /// Stage one leaf update into the pending cache. Mirrors
+    /// `StaticConfig::exec` in rib/static/config.rs — pure staging,
+    /// no side effects until `commit` is called.
+    pub fn exec(&mut self, path: String, mut args: Args, op: ConfigOp) -> Result<()> {
+        const CONFIG_ERR: &str = "missing flex-algo config handler";
+        const ALGO_ERR: &str = "missing flex-algo algorithm arg";
+
+        let func = self
+            .builder
+            .map
+            .get(&(path, op))
+            .context(CONFIG_ERR)?;
+        let algo = args.u8().context(ALGO_ERR)?;
+        if !(128..=255).contains(&algo) {
+            bail!("flex-algo identifier must be 128..=255 (got {algo})");
+        }
+        func(&mut self.config, &mut self.cache, algo, &mut args)
+    }
+
+    /// Drain the pending cache into the committed map. Apply / drop
+    /// semantics match `StaticConfig::commit`. Side-effects driven by
+    /// definition changes (LSP re-origination, SPF schedule, dataplane
+    /// install) will be wired in follow-up PRs — for now this is a pure
+    /// in-memory commit.
+    pub fn commit(&mut self) {
+        while let Some((algo, entry)) = self.cache.pop_first() {
+            if entry.delete {
+                self.config.remove(&algo);
+            } else {
+                self.config.insert(algo, entry);
+            }
+        }
+    }
+}
+
+struct ConfigBuilder {
+    path: String,
+    pub map: BTreeMap<(String, ConfigOp), Handler>,
+}
+
+impl Default for ConfigBuilder {
+    fn default() -> Self {
+        Self {
+            path: String::new(),
+            map: BTreeMap::new(),
+        }
+    }
+}
+
+type Handler = fn(
+    config: &mut BTreeMap<u8, FlexAlgoEntry>,
+    cache: &mut BTreeMap<u8, FlexAlgoEntry>,
+    algo: u8,
+    args: &mut Args,
+) -> Result<()>;
+
+impl ConfigBuilder {
+    pub fn path(mut self, path: &str) -> Self {
+        self.path = path.to_string();
+        self
+    }
+
+    pub fn set(mut self, func: Handler) -> Self {
+        self.map.insert((self.path.clone(), ConfigOp::Set), func);
+        self
+    }
+
+    pub fn del(mut self, func: Handler) -> Self {
+        self.map.insert((self.path.clone(), ConfigOp::Delete), func);
+        self
+    }
+}
+
+fn config_get(config: &BTreeMap<u8, FlexAlgoEntry>, algo: u8) -> FlexAlgoEntry {
+    config.get(&algo).cloned().unwrap_or_default()
+}
+
+fn config_lookup(config: &BTreeMap<u8, FlexAlgoEntry>, algo: u8) -> Option<FlexAlgoEntry> {
+    config.get(&algo).cloned()
+}
+
+fn cache_get<'a>(
+    config: &BTreeMap<u8, FlexAlgoEntry>,
+    cache: &'a mut BTreeMap<u8, FlexAlgoEntry>,
+    algo: u8,
+) -> Option<&'a mut FlexAlgoEntry> {
+    if cache.get(&algo).is_none() {
+        cache.insert(algo, config_get(config, algo));
+    }
+    cache.get_mut(&algo)
+}
+
+fn cache_lookup<'a>(
+    config: &BTreeMap<u8, FlexAlgoEntry>,
+    cache: &'a mut BTreeMap<u8, FlexAlgoEntry>,
+    algo: u8,
+) -> Option<&'a mut FlexAlgoEntry> {
+    if cache.get(&algo).is_none() {
+        cache.insert(algo, config_lookup(config, algo)?);
+    }
+    let entry = cache.get_mut(&algo)?;
+    if entry.delete { None } else { Some(entry) }
+}
+
+fn config_builder() -> ConfigBuilder {
+    const CONFIG_ERR: &str = "flex-algo entry parse error";
+    const BOOL_ERR: &str = "flex-algo boolean arg parse error";
+    const U8_ERR: &str = "flex-algo u8 arg parse error";
+    const ENUM_ERR: &str = "flex-algo enum arg parse error";
+    const NAME_ERR: &str = "flex-algo name arg parse error";
+
+    ConfigBuilder::default()
+        .path("/router/isis/flex-algo")
+        .set(|config, cache, algo, _args| {
+            let _ = cache_get(config, cache, algo).context(CONFIG_ERR)?;
+            Ok(())
+        })
+        .del(|config, cache, algo, _args| {
+            if let Some(e) = cache.get_mut(&algo) {
+                e.delete = true;
+            } else {
+                let mut e = config_lookup(config, algo).context(CONFIG_ERR)?;
+                e.delete = true;
+                cache.insert(algo, e);
+            }
+            Ok(())
+        })
+        .path("/router/isis/flex-algo/advertise-definition")
+        .set(|config, cache, algo, args| {
+            let e = cache_get(config, cache, algo).context(CONFIG_ERR)?;
+            e.advertise_definition = Some(args.boolean().context(BOOL_ERR)?);
+            Ok(())
+        })
+        .del(|config, cache, algo, _args| {
+            let e = cache_lookup(config, cache, algo).context(CONFIG_ERR)?;
+            e.advertise_definition = None;
+            Ok(())
+        })
+        .path("/router/isis/flex-algo/metric-type")
+        .set(|config, cache, algo, args| {
+            let e = cache_get(config, cache, algo).context(CONFIG_ERR)?;
+            e.metric_type = Some(args.string().context(ENUM_ERR)?.parse()?);
+            Ok(())
+        })
+        .del(|config, cache, algo, _args| {
+            let e = cache_lookup(config, cache, algo).context(CONFIG_ERR)?;
+            e.metric_type = None;
+            Ok(())
+        })
+        .path("/router/isis/flex-algo/priority")
+        .set(|config, cache, algo, args| {
+            let e = cache_get(config, cache, algo).context(CONFIG_ERR)?;
+            e.priority = Some(args.u8().context(U8_ERR)?);
+            Ok(())
+        })
+        .del(|config, cache, algo, _args| {
+            let e = cache_lookup(config, cache, algo).context(CONFIG_ERR)?;
+            e.priority = None;
+            Ok(())
+        })
+        .path("/router/isis/flex-algo/prefix-metric")
+        .set(|config, cache, algo, args| {
+            let e = cache_get(config, cache, algo).context(CONFIG_ERR)?;
+            e.prefix_metric = Some(args.boolean().context(BOOL_ERR)?);
+            Ok(())
+        })
+        .del(|config, cache, algo, _args| {
+            let e = cache_lookup(config, cache, algo).context(CONFIG_ERR)?;
+            e.prefix_metric = None;
+            Ok(())
+        })
+        .path("/router/isis/flex-algo/dataplane/sr-mpls")
+        .set(|config, cache, algo, args| {
+            let e = cache_get(config, cache, algo).context(CONFIG_ERR)?;
+            e.dataplane_sr_mpls = Some(args.boolean().context(BOOL_ERR)?);
+            Ok(())
+        })
+        .del(|config, cache, algo, _args| {
+            let e = cache_lookup(config, cache, algo).context(CONFIG_ERR)?;
+            e.dataplane_sr_mpls = None;
+            Ok(())
+        })
+        .path("/router/isis/flex-algo/dataplane/srv6")
+        .set(|config, cache, algo, args| {
+            let e = cache_get(config, cache, algo).context(CONFIG_ERR)?;
+            e.dataplane_srv6 = Some(args.boolean().context(BOOL_ERR)?);
+            Ok(())
+        })
+        .del(|config, cache, algo, _args| {
+            let e = cache_lookup(config, cache, algo).context(CONFIG_ERR)?;
+            e.dataplane_srv6 = None;
+            Ok(())
+        })
+        .path("/router/isis/flex-algo/dataplane/ip")
+        .set(|config, cache, algo, args| {
+            let e = cache_get(config, cache, algo).context(CONFIG_ERR)?;
+            e.dataplane_ip = Some(args.boolean().context(BOOL_ERR)?);
+            Ok(())
+        })
+        .del(|config, cache, algo, _args| {
+            let e = cache_lookup(config, cache, algo).context(CONFIG_ERR)?;
+            e.dataplane_ip = None;
+            Ok(())
+        })
+        .path("/router/isis/flex-algo/affinity/include-any")
+        .set(|config, cache, algo, args| {
+            let e = cache_get(config, cache, algo).context(CONFIG_ERR)?;
+            let name = args.string().context(NAME_ERR)?;
+            e.include_any.insert(name);
+            Ok(())
+        })
+        .del(|config, cache, algo, args| {
+            let e = cache_lookup(config, cache, algo).context(CONFIG_ERR)?;
+            let name = args.string().context(NAME_ERR)?;
+            e.include_any.remove(&name);
+            Ok(())
+        })
+        .path("/router/isis/flex-algo/affinity/include-all")
+        .set(|config, cache, algo, args| {
+            let e = cache_get(config, cache, algo).context(CONFIG_ERR)?;
+            let name = args.string().context(NAME_ERR)?;
+            e.include_all.insert(name);
+            Ok(())
+        })
+        .del(|config, cache, algo, args| {
+            let e = cache_lookup(config, cache, algo).context(CONFIG_ERR)?;
+            let name = args.string().context(NAME_ERR)?;
+            e.include_all.remove(&name);
+            Ok(())
+        })
+        .path("/router/isis/flex-algo/affinity/exclude-any")
+        .set(|config, cache, algo, args| {
+            let e = cache_get(config, cache, algo).context(CONFIG_ERR)?;
+            let name = args.string().context(NAME_ERR)?;
+            e.exclude_any.insert(name);
+            Ok(())
+        })
+        .del(|config, cache, algo, args| {
+            let e = cache_lookup(config, cache, algo).context(CONFIG_ERR)?;
+            let name = args.string().context(NAME_ERR)?;
+            e.exclude_any.remove(&name);
+            Ok(())
+        })
+        .path("/router/isis/flex-algo/srlg-exclude")
+        .set(|config, cache, algo, args| {
+            let e = cache_get(config, cache, algo).context(CONFIG_ERR)?;
+            let name = args.string().context(NAME_ERR)?;
+            e.srlg_exclude.insert(name);
+            Ok(())
+        })
+        .del(|config, cache, algo, args| {
+            let e = cache_lookup(config, cache, algo).context(CONFIG_ERR)?;
+            let name = args.string().context(NAME_ERR)?;
+            e.srlg_exclude.remove(&name);
+            Ok(())
+        })
+        .path("/router/isis/flex-algo/fast-reroute/ti-lfa")
+        .set(|config, cache, algo, _args| {
+            let e = cache_get(config, cache, algo).context(CONFIG_ERR)?;
+            e.ti_lfa = true;
+            Ok(())
+        })
+        .del(|config, cache, algo, _args| {
+            let e = cache_lookup(config, cache, algo).context(CONFIG_ERR)?;
+            e.ti_lfa = false;
+            Ok(())
+        })
+}
+
+// ── Wiring into the existing IS-IS callback dispatcher ────────────
+//
+// The IS-IS instance dispatches per-leaf via `Isis::callbacks`, with
+// callback signature `fn(&mut Isis, Args, ConfigOp) -> Option<()>`. We
+// register one shim per path here; each shim forwards into
+// `isis.flex_algo.exec(path, ...)` and then `commit()` so the new value
+// is visible synchronously, the way the rest of IS-IS expects.
+
+macro_rules! flex_algo_cb {
+    ($name:ident, $path:literal) => {
+        fn $name(isis: &mut Isis, args: Args, op: ConfigOp) -> Option<()> {
+            isis.flex_algo.exec($path.to_string(), args, op).ok()?;
+            isis.flex_algo.commit();
+            Some(())
+        }
+    };
+}
+
+flex_algo_cb!(cb_entry, "/router/isis/flex-algo");
+flex_algo_cb!(cb_advertise_definition, "/router/isis/flex-algo/advertise-definition");
+flex_algo_cb!(cb_metric_type, "/router/isis/flex-algo/metric-type");
+flex_algo_cb!(cb_priority, "/router/isis/flex-algo/priority");
+flex_algo_cb!(cb_prefix_metric, "/router/isis/flex-algo/prefix-metric");
+flex_algo_cb!(cb_dp_sr_mpls, "/router/isis/flex-algo/dataplane/sr-mpls");
+flex_algo_cb!(cb_dp_srv6, "/router/isis/flex-algo/dataplane/srv6");
+flex_algo_cb!(cb_dp_ip, "/router/isis/flex-algo/dataplane/ip");
+flex_algo_cb!(cb_affinity_include_any, "/router/isis/flex-algo/affinity/include-any");
+flex_algo_cb!(cb_affinity_include_all, "/router/isis/flex-algo/affinity/include-all");
+flex_algo_cb!(cb_affinity_exclude_any, "/router/isis/flex-algo/affinity/exclude-any");
+flex_algo_cb!(cb_srlg_exclude, "/router/isis/flex-algo/srlg-exclude");
+flex_algo_cb!(cb_ti_lfa, "/router/isis/flex-algo/fast-reroute/ti-lfa");
+
+pub fn callback_register(isis: &mut Isis) {
+    isis.callback_add("/router/isis/flex-algo", cb_entry);
+    isis.callback_add("/router/isis/flex-algo/advertise-definition", cb_advertise_definition);
+    isis.callback_add("/router/isis/flex-algo/metric-type", cb_metric_type);
+    isis.callback_add("/router/isis/flex-algo/priority", cb_priority);
+    isis.callback_add("/router/isis/flex-algo/prefix-metric", cb_prefix_metric);
+    isis.callback_add("/router/isis/flex-algo/dataplane/sr-mpls", cb_dp_sr_mpls);
+    isis.callback_add("/router/isis/flex-algo/dataplane/srv6", cb_dp_srv6);
+    isis.callback_add("/router/isis/flex-algo/dataplane/ip", cb_dp_ip);
+    isis.callback_add("/router/isis/flex-algo/affinity/include-any", cb_affinity_include_any);
+    isis.callback_add("/router/isis/flex-algo/affinity/include-all", cb_affinity_include_all);
+    isis.callback_add("/router/isis/flex-algo/affinity/exclude-any", cb_affinity_exclude_any);
+    isis.callback_add("/router/isis/flex-algo/srlg-exclude", cb_srlg_exclude);
+    isis.callback_add("/router/isis/flex-algo/fast-reroute/ti-lfa", cb_ti_lfa);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+
+    fn args(items: &[&str]) -> Args {
+        Args(items.iter().map(|s| s.to_string()).collect::<VecDeque<_>>())
+    }
+
+    #[test]
+    fn set_advertise_definition_then_commit_persists() {
+        let mut fa = FlexAlgoConfig::new();
+        fa.exec(
+            "/router/isis/flex-algo/advertise-definition".into(),
+            args(&["128", "true"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        fa.commit();
+        let e = fa.config.get(&128).unwrap();
+        assert_eq!(e.advertise_definition, Some(true));
+    }
+
+    #[test]
+    fn set_metric_type_then_priority_share_entry() {
+        let mut fa = FlexAlgoConfig::new();
+        fa.exec(
+            "/router/isis/flex-algo/metric-type".into(),
+            args(&["128", "min-unidir-link-delay"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        fa.commit();
+        fa.exec(
+            "/router/isis/flex-algo/priority".into(),
+            args(&["128", "200"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        fa.commit();
+        let e = fa.config.get(&128).unwrap();
+        assert_eq!(e.metric_type, Some(FadMetricType::MinUnidirLinkDelay));
+        assert_eq!(e.priority, Some(200));
+    }
+
+    #[test]
+    fn affinity_exclude_any_is_a_set() {
+        let mut fa = FlexAlgoConfig::new();
+        for color in ["blue", "red", "blue"] {
+            fa.exec(
+                "/router/isis/flex-algo/affinity/exclude-any".into(),
+                args(&["129", color]),
+                ConfigOp::Set,
+            )
+            .unwrap();
+            fa.commit();
+        }
+        let e = fa.config.get(&129).unwrap();
+        assert_eq!(e.exclude_any.len(), 2);
+        assert!(e.exclude_any.contains("blue"));
+        assert!(e.exclude_any.contains("red"));
+    }
+
+    #[test]
+    fn delete_entry_removes_it() {
+        let mut fa = FlexAlgoConfig::new();
+        fa.exec(
+            "/router/isis/flex-algo/priority".into(),
+            args(&["128", "100"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        fa.commit();
+        assert!(fa.config.contains_key(&128));
+
+        fa.exec(
+            "/router/isis/flex-algo".into(),
+            args(&["128"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        fa.commit();
+        assert!(!fa.config.contains_key(&128));
+    }
+
+    #[test]
+    fn algo_outside_user_range_rejected() {
+        let mut fa = FlexAlgoConfig::new();
+        let err = fa
+            .exec(
+                "/router/isis/flex-algo/priority".into(),
+                args(&["127", "100"]),
+                ConfigOp::Set,
+            )
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("128..=255"), "unexpected err: {err}");
+    }
+}

--- a/zebra-rs/src/isis/flex_algo.rs
+++ b/zebra-rs/src/isis/flex_algo.rs
@@ -111,18 +111,10 @@ impl FlexAlgoConfig {
     }
 }
 
+#[derive(Default)]
 struct ConfigBuilder {
     path: String,
     pub map: BTreeMap<(String, ConfigOp), Handler>,
-}
-
-impl Default for ConfigBuilder {
-    fn default() -> Self {
-        Self {
-            path: String::new(),
-            map: BTreeMap::new(),
-        }
-    }
 }
 
 type Handler = fn(

--- a/zebra-rs/src/isis/flex_algo.rs
+++ b/zebra-rs/src/isis/flex_algo.rs
@@ -87,11 +87,7 @@ impl FlexAlgoConfig {
         const CONFIG_ERR: &str = "missing flex-algo config handler";
         const ALGO_ERR: &str = "missing flex-algo algorithm arg";
 
-        let func = self
-            .builder
-            .map
-            .get(&(path, op))
-            .context(CONFIG_ERR)?;
+        let func = self.builder.map.get(&(path, op)).context(CONFIG_ERR)?;
         let algo = args.u8().context(ALGO_ERR)?;
         if !(128..=255).contains(&algo) {
             bail!("flex-algo identifier must be 128..=255 (got {algo})");
@@ -368,31 +364,55 @@ macro_rules! flex_algo_cb {
 }
 
 flex_algo_cb!(cb_entry, "/router/isis/flex-algo");
-flex_algo_cb!(cb_advertise_definition, "/router/isis/flex-algo/advertise-definition");
+flex_algo_cb!(
+    cb_advertise_definition,
+    "/router/isis/flex-algo/advertise-definition"
+);
 flex_algo_cb!(cb_metric_type, "/router/isis/flex-algo/metric-type");
 flex_algo_cb!(cb_priority, "/router/isis/flex-algo/priority");
 flex_algo_cb!(cb_prefix_metric, "/router/isis/flex-algo/prefix-metric");
 flex_algo_cb!(cb_dp_sr_mpls, "/router/isis/flex-algo/dataplane/sr-mpls");
 flex_algo_cb!(cb_dp_srv6, "/router/isis/flex-algo/dataplane/srv6");
 flex_algo_cb!(cb_dp_ip, "/router/isis/flex-algo/dataplane/ip");
-flex_algo_cb!(cb_affinity_include_any, "/router/isis/flex-algo/affinity/include-any");
-flex_algo_cb!(cb_affinity_include_all, "/router/isis/flex-algo/affinity/include-all");
-flex_algo_cb!(cb_affinity_exclude_any, "/router/isis/flex-algo/affinity/exclude-any");
+flex_algo_cb!(
+    cb_affinity_include_any,
+    "/router/isis/flex-algo/affinity/include-any"
+);
+flex_algo_cb!(
+    cb_affinity_include_all,
+    "/router/isis/flex-algo/affinity/include-all"
+);
+flex_algo_cb!(
+    cb_affinity_exclude_any,
+    "/router/isis/flex-algo/affinity/exclude-any"
+);
 flex_algo_cb!(cb_srlg_exclude, "/router/isis/flex-algo/srlg-exclude");
 flex_algo_cb!(cb_ti_lfa, "/router/isis/flex-algo/fast-reroute/ti-lfa");
 
 pub fn callback_register(isis: &mut Isis) {
     isis.callback_add("/router/isis/flex-algo", cb_entry);
-    isis.callback_add("/router/isis/flex-algo/advertise-definition", cb_advertise_definition);
+    isis.callback_add(
+        "/router/isis/flex-algo/advertise-definition",
+        cb_advertise_definition,
+    );
     isis.callback_add("/router/isis/flex-algo/metric-type", cb_metric_type);
     isis.callback_add("/router/isis/flex-algo/priority", cb_priority);
     isis.callback_add("/router/isis/flex-algo/prefix-metric", cb_prefix_metric);
     isis.callback_add("/router/isis/flex-algo/dataplane/sr-mpls", cb_dp_sr_mpls);
     isis.callback_add("/router/isis/flex-algo/dataplane/srv6", cb_dp_srv6);
     isis.callback_add("/router/isis/flex-algo/dataplane/ip", cb_dp_ip);
-    isis.callback_add("/router/isis/flex-algo/affinity/include-any", cb_affinity_include_any);
-    isis.callback_add("/router/isis/flex-algo/affinity/include-all", cb_affinity_include_all);
-    isis.callback_add("/router/isis/flex-algo/affinity/exclude-any", cb_affinity_exclude_any);
+    isis.callback_add(
+        "/router/isis/flex-algo/affinity/include-any",
+        cb_affinity_include_any,
+    );
+    isis.callback_add(
+        "/router/isis/flex-algo/affinity/include-all",
+        cb_affinity_include_all,
+    );
+    isis.callback_add(
+        "/router/isis/flex-algo/affinity/exclude-any",
+        cb_affinity_exclude_any,
+    );
     isis.callback_add("/router/isis/flex-algo/srlg-exclude", cb_srlg_exclude);
     isis.callback_add("/router/isis/flex-algo/fast-reroute/ti-lfa", cb_ti_lfa);
 }

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -61,6 +61,11 @@ pub struct Isis {
     pub show: ShowChannel,
     pub show_cb: HashMap<String, ShowCallback>,
     pub config: IsisConfig,
+    /// Flex-Algorithm (RFC 9350) configuration tree, keyed by the
+    /// numeric algorithm identifier (128..=255). Owns its own
+    /// pending-cache → commit pipeline mirroring the static-route
+    /// config builder in rib/static/config.rs.
+    pub flex_algo: super::flex_algo::FlexAlgoConfig,
     pub tracing: IsisTracing,
     pub lsdb: Levels<Lsdb>,
     pub lsp_map: Levels<LspMap>,
@@ -319,6 +324,7 @@ impl Isis {
             show: ShowChannel::new(),
             show_cb: HashMap::new(),
             config: IsisConfig::default(),
+            flex_algo: super::flex_algo::FlexAlgoConfig::new(),
             tracing: IsisTracing::default(),
             lsdb: Levels::<Lsdb>::default(),
             lsp_map: Levels::<LspMap>::default(),

--- a/zebra-rs/src/isis/mod.rs
+++ b/zebra-rs/src/isis/mod.rs
@@ -56,3 +56,5 @@ pub mod graph;
 pub mod rib;
 
 pub mod throttle;
+
+pub mod flex_algo;

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -461,6 +461,149 @@ module config {
               // global locator is committed.
               type string;
             }
+            list flex-algo-locator {
+              // Per-Flex-Algorithm SRv6 locator binding. The named
+              // locator is advertised in SRv6 Locator TLV 27 with the
+              // Algorithm field set to `algo` (RFC 9352 §7.1). The
+              // base `locator` leaf above carries algorithm 0 (regular
+              // SPF); flex-algos (128..255) bind here. As with the
+              // base leaf, the locator name is a plain string so the
+              // IS-IS config can be staged before the matching
+              // /segment-routing/locator entry is committed.
+              key "algo";
+              leaf algo {
+                type uint8 { range "128..255"; }
+              }
+              leaf locator {
+                type string;
+              }
+            }
+          }
+        }
+
+        container affinity-map {
+          // Named affinity (admin-group) table local to this IS-IS
+          // instance. Each entry binds an operator-friendly name to a
+          // bit position in the 256-bit Extended Admin Group bitmap
+          // (RFC 7308). Per-link `affinity` leaf-lists and per-flex-
+          // algo include-any / include-all / exclude-any constraints
+          // reference these names. Held inside /router/isis to match
+          // IOS-XR's `router isis / affinity-map` placement; if/when
+          // OSPF flex-algo arrives the table can be promoted to a
+          // global sibling of /srlg.
+          list affinity {
+            key "name";
+            leaf name {
+              type string;
+            }
+            leaf bit-position {
+              type uint16 { range "0..255"; }
+              mandatory true;
+              description
+                "Bit index in the 256-bit Extended Admin Group
+                 (RFC 7308). The on-the-wire bitmap is the union of
+                 bit positions referenced by all `affinity` names
+                 attached to a given link, advertised inside the
+                 ASLA sub-TLV (RFC 9479) when at least one flex-algo
+                 references the attribute.";
+            }
+          }
+        }
+
+        list flex-algo {
+          // IS-IS Flexible Algorithm (RFC 9350) definition. Each list
+          // entry describes one algorithm this router participates in
+          // and is keyed by the on-the-wire numeric identifier
+          // (FRR / Cisco IOS-XR style: `flex-algo 128`). The same
+          // numeric value keys per-interface `flex-algo-prefix-sid`
+          // and SRv6 `flex-algo-locator` bindings — a single
+          // identifier ties FAD config, per-link SIDs and the value
+          // emitted in the FAD sub-TLV's Flex Algorithm field.
+          // `advertise-definition true` causes the router to
+          // originate the FAD sub-TLV inside Router Capability TLV
+          // 242; without it the router participates using a FAD
+          // learned from another node — at least one (preferably
+          // two) routers per area MUST advertise.
+          key "algo";
+          leaf algo {
+            type uint8 { range "128..255"; }
+            description
+              "Flex-Algorithm identifier (RFC 9350 §4). 0..127 are
+               reserved by IANA; 128..255 are user-defined.";
+          }
+
+          leaf advertise-definition {
+            type boolean;
+            default false;
+            description
+              "When true, originate the FAD sub-TLV for this
+               algorithm. If no router in the area advertises the
+               FAD, every participant fails to compute paths.";
+          }
+
+          leaf metric-type {
+            type enumeration {
+              enum igp;                   // FAD Metric-Type 0
+              enum min-unidir-link-delay; // FAD Metric-Type 1 (RFC 8570)
+              enum te-default;            // FAD Metric-Type 2 (RFC 5305)
+            }
+            default igp;
+          }
+
+          leaf priority {
+            // FAD Priority (RFC 9350 §5.1). Tie-breaker when more
+            // than one router originates a FAD for the same algo;
+            // higher priority wins.
+            type uint8;
+            default 128;
+          }
+
+          leaf prefix-metric {
+            // M-flag in the FAD Flags sub-TLV (RFC 9350 §6.4).
+            // When set, the computed path metric to a prefix
+            // includes the advertised prefix metric in addition
+            // to the path metric.
+            type boolean;
+            default false;
+          }
+
+          container dataplane {
+            // Per-algorithm dataplane participation. Explicit flags
+            // (FRR style) so the FAD sub-TLV bits, the SPF graph
+            // filter, and the SID-install path can all be driven
+            // from configuration rather than inferred from which
+            // SIDs happen to be present.
+            leaf sr-mpls { type boolean; default false; }
+            leaf srv6    { type boolean; default false; }
+            leaf ip      { type boolean; default false; }
+          }
+
+          container affinity {
+            // FAD Exclude / Include-Any / Include-All Affinity
+            // sub-TLVs (RFC 9350 §6.1). Each leaf-list value is a
+            // name from this instance's /affinity-map table.
+            leaf-list include-any { type string; }
+            leaf-list include-all { type string; }
+            leaf-list exclude-any { type string; }
+          }
+
+          leaf-list srlg-exclude {
+            // FAD Exclude SRLG sub-TLV (RFC 9350 §6.2). Each entry
+            // references a /srlg/group name; the per-link SRLG
+            // memberships configured under
+            // /router/isis/interface/srlg drive the actual link
+            // exclusion at SPF time.
+            type string;
+          }
+
+          container fast-reroute {
+            // Per-algo override of the instance-level
+            // /router/isis/fast-reroute/ti-lfa toggle. Empty
+            // container is a no-op; the child presence container
+            // turns the per-algo TI-LFA computation on.
+            container ti-lfa {
+              presence "Enable Topology-Independent LFA for this flex-algo";
+            }
           }
         }
 
@@ -691,6 +834,25 @@ module config {
                 type uint32;
               }
             }
+            list flex-algo-prefix-sid {
+              // Per-Flex-Algorithm Prefix-SID for the IPv4 address(es)
+              // of this interface. Advertised as additional Prefix-SID
+              // sub-TLVs (RFC 8667) with the Algorithm field set to
+              // `algo` (RFC 9350 §7), alongside the algo-0 SID in the
+              // `prefix-sid` container above. Typically attached to a
+              // loopback so the SID identifies this node in the
+              // flex-algo's topology.
+              key "algo";
+              leaf algo {
+                type uint8 { range "128..255"; }
+              }
+              leaf index {
+                type uint32;
+              }
+              leaf absolute {
+                type uint32;
+              }
+            }
           }
           container ipv6 {
             leaf enable {
@@ -737,6 +899,19 @@ module config {
                 "Name of a `/bfd/profile` entry whose parameters
                  apply to BFD sessions formed on this interface.";
             }
+          }
+
+          leaf-list affinity {
+            // Names of /router/isis/affinity-map entries this link
+            // belongs to. The union of their bit-positions forms the
+            // 256-bit Extended Admin Group bitmap (RFC 7308)
+            // advertised for this link inside the ASLA sub-TLV
+            // (RFC 9479) whenever at least one flex-algo references
+            // an attribute. Held as a plain string (not a leafref)
+            // so the per-interface config can be staged before the
+            // matching `affinity-map` entry is committed — matches
+            // the staging pattern of `srlg` directly below.
+            type string;
           }
 
           leaf-list srlg {


### PR DESCRIPTION
## Summary

First two steps of IS-IS Flex-Algorithm support:

- **YANG schema** (`zebra-rs/yang/config.yang`) — all per-FAD config plus the supporting per-link / per-instance bindings:
  - `/router/isis/affinity-map/affinity` — named admin-group table (RFC 7308 bit positions)
  - `/router/isis/flex-algo` list, keyed by numeric algo (128..=255, FRR/Cisco style), with `advertise-definition`, `metric-type`, `priority`, `prefix-metric` (M-flag), explicit `dataplane {sr-mpls,srv6,ip}` flags, `affinity {include-any,include-all,exclude-any}`, `srlg-exclude`, per-algo `fast-reroute/ti-lfa`
  - `/router/isis/interface/affinity` leaf-list — per-link admin-group membership
  - `/router/isis/interface/ipv4/flex-algo-prefix-sid` — per-algo Prefix-SID (sibling of the existing algo-0 prefix-sid; non-breaking)
  - `/router/isis/segment-routing/srv6/flex-algo-locator` — per-algo SRv6 locator binding (sibling of the existing algo-0 locator)
- **Config builder + callbacks** (`zebra-rs/src/isis/flex_algo.rs`) — self-contained module mirroring `rib/static/config.rs`: chained `.path/.set/.del`, `cache_get`/`cache_lookup` helpers, `exec → commit` lifecycle, `FlexAlgoEntry` keyed by `u8`, `FadMetricType` enum carrying the wire byte. Per-path shim callbacks register all 13 FAD leaves into the existing `Isis::callbacks` dispatcher and commit synchronously.

Storage-only — `FlexAlgoEntry` is reachable via `isis.flex_algo.config` but nothing reads it yet. LSP emit (FAD sub-TLV in Router Capability TLV 242) and SPF gating land in follow-ups.

Design notes are in the YANG comments: name-based references (no leafrefs) keep config staging-friendly, matching the existing `/srlg` and `/segment-routing/locator` convention.

## Test plan

- [x] `cargo build -p zebra-rs --bin zebra-rs` — clean (one expected dead-code warning on `FadMetricType::wire` until LSP-emit PR consumes it; `#[allow(dead_code)]` applied)
- [x] `cargo test -p zebra-rs --bin zebra-rs isis::flex_algo::` — 5 tests pass (staging, multi-leaf coalescing, leaf-list dedup, delete, out-of-range algo rejection)
- [ ] End-to-end CLI exercise once LSP-emit PR lands

Generated with [Claude Code](https://claude.com/claude-code)