### PR TITLE
vty: exempt root peers from parent-uid check (D26)

### DIFF
--- a/book/src/ch-06-00-vty-access.md
+++ b/book/src/ch-06-00-vty-access.md
@@ -161,6 +161,34 @@ forge them). The server logs the peer for each call at INFO:
 INFO vty rpc uid=1000 gid=1000 pid=109579
 ```
 
+### Parent-shell check and `sudo`
+
+In addition to the peer's own uid, the daemon walks `/proc` to find
+the client's parent process and — for non-root peers — verifies the
+parent's real uid matches the peer uid. This binds a session to the
+shell that spawned the client and rejects mismatched-uid ancestry
+(PID-reuse races, unexpected setuid chains).
+
+There is one exception: **when the peer uid is 0, the parent-uid
+match is skipped.** Without this short-circuit, `sudo <cmd>` from a
+non-root login fails with `parent uid mismatch` because the outer
+`sudo` process retains the invoking user's real uid even though the
+client itself is running as root. With the short-circuit, the
+following all work:
+
+```bash
+sudo vtyctl apply -f cfg.yaml
+sudo ip netns exec vrf-red vtyctl show 'show ip route'
+```
+
+The remaining guards still apply to root peers: cross-PID-namespace
+clients and orphaned clients (parent reparented to init, or the
+parent process disappeared between the credential snapshot and the
+`/proc` lookup) are rejected regardless of uid.
+
+Non-root peers must connect from a same-uid shell — a setuid
+escalation to a non-root effective uid is still refused.
+
 ### `ZEBRA_VTY_ALLOW_UIDS` — peer UID allow-list
 
 Set this environment variable on the `zebra-rs` process to restrict

--- a/book/src/ch-06-01-session-design.md
+++ b/book/src/ch-06-01-session-design.md
@@ -106,10 +106,13 @@ fn resolve_session_key(peer_uid: u32, peer_pid: u32)
         ));
     }
 
-    // Guard 2: parent uid must match peer uid (PID-reuse race).
+    // Guard 2: parent uid must match peer uid (PID-reuse race), except
+    // for root peers — D26 short-circuits the match so that `sudo <cmd>`
+    // (whose outer process retains the invoking user's ruid) works.
     let parent = procfs::process::Process::new(ppid as i32)
         .map_err(|_| Status::unauthenticated("parent shell vanished"))?;
-    if parent.status().map(|s| s.ruid).unwrap_or(u32::MAX) != peer_uid {
+    let parent_ruid = parent.status().map(|s| s.ruid).unwrap_or(u32::MAX);
+    if peer_uid != 0 && parent_ruid != peer_uid {
         return Err(Status::unauthenticated("parent uid mismatch"));
     }
 
@@ -360,6 +363,7 @@ Each phase is intended to ship as an independent PR.
 | D23 | **Configure-mode admin gate** on `DoExec`. For `ExecType::Exec` only (completion paths remain free): admin is required when `mode != "exec"` (catches a client that sets `mode=configure` directly) and when `mode == "exec" && first_word == "configure"` (UX courtesy — block at entry so the prompt doesn't flip uselessly). Configure-mode mutex/lock is deliberately NOT included; multiple admins can enter configure simultaneously (D11 still deferred). |
 | D24 | **Auto-elevate on `configure`**. When a non-admin user types `configure`, the vty bash shell function optimistically tries first (admins succeed silently). On `PermissionDenied` it prompts for `Password:` (echo off) and sends an `Enable` RPC against the caller's own account (sudo-style) — so the same password that works for `enable` works here. On success it retries `configure` and flips `CLI_PRIVILEGE`. `EnableRequest` carries an optional `auth_user` field that the daemon honors when non-empty (kept for future su-style flows); the configure auto-elevate path leaves it empty. |
 | D25 | **YANG-driven service-accounts** (Phase 4-d-ii). New `vty.yang` module with `list service-account { key uid; leaf description; }` under `container vty` in the global `grouping config`. `ConfigManager` maintains an `Arc<RwLock<HashSet<u32>>>` updated by `commit_config` on `vty service-account uid N` Set/Delete diffs; `SessionTable` reads the union of this set and the env-var set in `is_service_account`. The env var (D21) remains as a startup-only seed for environments where YANG config is unavailable; YANG is the runtime-mutable path. |
+| D26 | **Root peers bypass the parent-uid check.** `resolve_session_key` skips Guard 2 when `peer_uid == 0`. Rationale: the strict match rejected the common `sudo <cmd>` pattern, where the outer `sudo` process retains the invoking user's ruid while the client itself runs as uid 0. Risk surface: any uid-0 connector is trusted regardless of ancestry, but `SO_PEERCRED`'s effective-uid attestation already implies that — a process running as root can already do anything on the host. The remaining guards (D12 cross-PID-namespace, OrphanClient, ParentVanished) still fire for root peers. Non-root peers are unaffected — the parent-uid match is still enforced, so a setuid escalation to a non-zero uid is still refused. |
 
 ## Deferred work
 

--- a/zebra-rs/src/config/session.rs
+++ b/zebra-rs/src/config/session.rs
@@ -148,7 +148,8 @@ pub enum SessionError {
     /// `/proc` lookup.
     ParentVanished,
     /// Parent process uid does not match the peer uid (PID reuse race or
-    /// privilege boundary violation).
+    /// privilege boundary violation). Only raised for non-root peers; uid 0
+    /// is exempt from the parent-uid match by D26 to allow `sudo <cmd>`.
     ParentUidMismatch,
 }
 
@@ -209,6 +210,13 @@ impl SessionTable {
     /// for the peer's parent pid, verify the parent uid matches, then create
     /// the session.
     ///
+    /// Root short-circuit (D26): when `peer_uid == 0`, the parent-uid check
+    /// is skipped. This lets `sudo <cmd>` invocations work (the outer `sudo`
+    /// process retains the invoking user's ruid, which would otherwise fail
+    /// the match) without weakening the check for non-root peers. The
+    /// `ParentVanished` guard still runs so an orphaned uid-0 client is
+    /// rejected.
+    ///
     /// Returns `(key, is_new)` so callers can choose log verbosity.
     pub fn resolve<P: ProcStatusReader>(
         &self,
@@ -238,11 +246,14 @@ impl SessionTable {
             return Ok((key, false));
         }
 
-        // Slow path: validate parent uid matches.
+        // Slow path: validate parent exists, and (for non-root peers) that
+        // its uid matches. Root (D26) is exempt from the uid match so that
+        // `sudo <cmd>` works — the outer sudo retains the invoking user's
+        // ruid, which would otherwise trip ParentUidMismatch.
         let parent_uid = reader
             .read_ruid(ppid)
             .map_err(|_| SessionError::ParentVanished)?;
-        if parent_uid != peer_uid {
+        if peer_uid != 0 && parent_uid != peer_uid {
             return Err(SessionError::ParentUidMismatch);
         }
 
@@ -698,6 +709,36 @@ mod tests {
         reader.set_ruid(1000, 999); // parent is uid 999, peer claims 1000
         let err = table.resolve(&reader, 1000, 1234).unwrap_err();
         assert_eq!(err, SessionError::ParentUidMismatch);
+    }
+
+    #[test]
+    fn root_peer_bypasses_parent_uid_check() {
+        // D26: `sudo <cmd>` leaves the outer sudo (ruid = invoking user)
+        // as the client's parent. Root peers must accept this — the check
+        // is only meaningful for non-root uids.
+        let table = SessionTable::new();
+        let reader = StubReader::default();
+        reader.set_ppid(1234, 1000);
+        reader.set_ruid(1000, 1000); // parent shell is uid 1000 (the sudo user)
+        let (key, is_new) = table.resolve(&reader, 0, 1234).unwrap();
+        assert_eq!(key, (0, 1000));
+        assert!(is_new);
+        let sess = table.get(&key).unwrap();
+        // Root is still implicit Admin (D20) even when arriving via sudo.
+        assert_eq!(sess.role, Role::Admin);
+        assert!(sess.enabled);
+    }
+
+    #[test]
+    fn root_peer_still_rejects_vanished_parent() {
+        // The D26 bypass only skips the uid match; the ParentVanished
+        // guard still fires so an orphaned uid-0 client is refused.
+        let table = SessionTable::new();
+        let reader = StubReader::default();
+        reader.set_ppid(1234, 1000);
+        reader.set_missing(1000);
+        let err = table.resolve(&reader, 0, 1234).unwrap_err();
+        assert_eq!(err, SessionError::ParentVanished);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `SessionTable::resolve` now skips the parent-uid match when `peer_uid == 0`, so `sudo <cmd>` invocations (where the outer `sudo` retains the invoking user's ruid while the client itself runs as uid 0) are accepted.
- Non-root peers still face the strict match; `ParentVanished`, `OrphanClient`, and `CrossPidNamespace` still fire for root peers.
- Documented the new behavior in `book/src/ch-06-00-vty-access.md` (user-facing "Parent-shell check and `sudo`" subsection) and recorded **D26** in the design decisions table in `book/src/ch-06-01-session-design.md`.

## Test plan

- [x] `cargo test -p zebra-rs --bin zebra-rs config::session` — 28 tests pass, including two new ones (`root_peer_bypasses_parent_uid_check`, `root_peer_still_rejects_vanished_parent`).
- [x] `cargo build -p zebra-rs` clean.
- [ ] Manual: `sudo ip netns exec <ns> vtyctl apply -f <yaml>` succeeds (the original failing case).

Generated with [Claude Code](https://claude.com/claude-code)