### PR TITLE
ci: install libpam0g-dev in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y protobuf-compiler libnanomsg-dev bison xxd
+          sudo apt-get install -y protobuf-compiler libnanomsg-dev bison xxd libpam0g-dev
 
       - name: Install nfpm
         run: |
@@ -102,7 +102,7 @@ jobs:
       - name: Install build dependencies
         run: |
           apt-get update -y
-          apt-get install -y protobuf-compiler libnanomsg-dev bison xxd
+          apt-get install -y protobuf-compiler libnanomsg-dev bison xxd libpam0g-dev
 
       - name: Install nfpm
         run: |


### PR DESCRIPTION
## Summary
- The `vtypam` binary links against libpam, but `libpam0g-dev` was missing from `.github/workflows/nightly.yaml`, causing `rust-lld: error: unable to find library -lpam` during the nightly build.
- Add `libpam0g-dev` to the apt install lists in both the `build-native` and `build-container` jobs, matching the fix already present in `.github/workflows/build-amd64.yaml`.

## Test plan
- [ ] Trigger the nightly workflow via `workflow_dispatch` and confirm all six matrix builds (jammy/noble/resolute × amd64/arm64) succeed.

Generated with [Claude Code](https://claude.com/claude-code)