### PR TITLE
isis: wire remaining Flex-Algorithm config trees

### DIFF
--- a/zebra-rs/src/isis/affinity_map.rs
+++ b/zebra-rs/src/isis/affinity_map.rs
@@ -1,0 +1,246 @@
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result, bail};
+
+use crate::config::{Args, ConfigOp};
+
+use super::Isis;
+
+/// IS-IS-local named affinity (admin-group) table. Each entry binds an
+/// operator-friendly name to a bit position in the 256-bit Extended
+/// Admin Group bitmap (RFC 7308). Mirrors the YANG list at
+/// /router/isis/affinity-map/affinity.
+///
+/// Held inside the IS-IS instance to match IOS-XR placement; promotable
+/// to a global sibling of /srlg once OSPF flex-algo arrives.
+#[derive(Default)]
+pub struct AffinityMap {
+    pub config: BTreeMap<String, AffinityEntry>,
+    pub cache: BTreeMap<String, AffinityEntry>,
+    builder: ConfigBuilder,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct AffinityEntry {
+    pub delete: bool,
+    pub bit_position: Option<u16>,
+}
+
+impl AffinityMap {
+    pub fn new() -> Self {
+        Self {
+            config: BTreeMap::new(),
+            cache: BTreeMap::new(),
+            builder: config_builder(),
+        }
+    }
+
+    /// Stage one leaf update into the pending cache. Mirrors
+    /// `FlexAlgoConfig::exec` / `StaticConfig::exec`.
+    pub fn exec(&mut self, path: String, mut args: Args, op: ConfigOp) -> Result<()> {
+        const CONFIG_ERR: &str = "missing affinity-map config handler";
+        const NAME_ERR: &str = "missing affinity name arg";
+
+        let func = self.builder.map.get(&(path, op)).context(CONFIG_ERR)?;
+        let name = args.string().context(NAME_ERR)?;
+        func(&mut self.config, &mut self.cache, name, &mut args)
+    }
+
+    pub fn commit(&mut self) {
+        while let Some((name, entry)) = self.cache.pop_first() {
+            if entry.delete {
+                self.config.remove(&name);
+            } else {
+                self.config.insert(name, entry);
+            }
+        }
+    }
+
+    /// Bit position currently committed for `name`, if any. Used at
+    /// LSP-build time to assemble the per-link 256-bit Extended Admin
+    /// Group bitmap from the names attached to each link.
+    #[allow(dead_code)]
+    pub fn bit(&self, name: &str) -> Option<u16> {
+        self.config.get(name).and_then(|e| e.bit_position)
+    }
+}
+
+#[derive(Default)]
+struct ConfigBuilder {
+    path: String,
+    pub map: BTreeMap<(String, ConfigOp), Handler>,
+}
+
+type Handler = fn(
+    config: &mut BTreeMap<String, AffinityEntry>,
+    cache: &mut BTreeMap<String, AffinityEntry>,
+    name: String,
+    args: &mut Args,
+) -> Result<()>;
+
+impl ConfigBuilder {
+    pub fn path(mut self, path: &str) -> Self {
+        self.path = path.to_string();
+        self
+    }
+
+    pub fn set(mut self, func: Handler) -> Self {
+        self.map.insert((self.path.clone(), ConfigOp::Set), func);
+        self
+    }
+
+    pub fn del(mut self, func: Handler) -> Self {
+        self.map.insert((self.path.clone(), ConfigOp::Delete), func);
+        self
+    }
+}
+
+fn config_get(config: &BTreeMap<String, AffinityEntry>, name: &str) -> AffinityEntry {
+    config.get(name).cloned().unwrap_or_default()
+}
+
+fn config_lookup(config: &BTreeMap<String, AffinityEntry>, name: &str) -> Option<AffinityEntry> {
+    config.get(name).cloned()
+}
+
+fn cache_get<'a>(
+    config: &BTreeMap<String, AffinityEntry>,
+    cache: &'a mut BTreeMap<String, AffinityEntry>,
+    name: String,
+) -> Option<&'a mut AffinityEntry> {
+    if !cache.contains_key(&name) {
+        cache.insert(name.clone(), config_get(config, &name));
+    }
+    cache.get_mut(&name)
+}
+
+fn cache_lookup<'a>(
+    config: &BTreeMap<String, AffinityEntry>,
+    cache: &'a mut BTreeMap<String, AffinityEntry>,
+    name: String,
+) -> Option<&'a mut AffinityEntry> {
+    if !cache.contains_key(&name) {
+        cache.insert(name.clone(), config_lookup(config, &name)?);
+    }
+    let entry = cache.get_mut(&name)?;
+    if entry.delete { None } else { Some(entry) }
+}
+
+fn config_builder() -> ConfigBuilder {
+    const CONFIG_ERR: &str = "affinity entry parse error";
+    const BIT_ERR: &str = "affinity bit-position parse error";
+
+    ConfigBuilder::default()
+        .path("/router/isis/affinity-map/affinity")
+        .set(|config, cache, name, _args| {
+            let _ = cache_get(config, cache, name).context(CONFIG_ERR)?;
+            Ok(())
+        })
+        .del(|config, cache, name, _args| {
+            if let Some(e) = cache.get_mut(&name) {
+                e.delete = true;
+            } else {
+                let mut e = config_lookup(config, &name).context(CONFIG_ERR)?;
+                e.delete = true;
+                cache.insert(name, e);
+            }
+            Ok(())
+        })
+        .path("/router/isis/affinity-map/affinity/bit-position")
+        .set(|config, cache, name, args| {
+            let bit = args.u16().context(BIT_ERR)?;
+            if bit > 255 {
+                bail!("affinity bit-position must be 0..=255 (got {bit})");
+            }
+            let e = cache_get(config, cache, name).context(CONFIG_ERR)?;
+            e.bit_position = Some(bit);
+            Ok(())
+        })
+        .del(|config, cache, name, _args| {
+            let e = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+            e.bit_position = None;
+            Ok(())
+        })
+}
+
+macro_rules! affinity_cb {
+    ($name:ident, $path:literal) => {
+        fn $name(isis: &mut Isis, args: Args, op: ConfigOp) -> Option<()> {
+            isis.affinity_map.exec($path.to_string(), args, op).ok()?;
+            isis.affinity_map.commit();
+            Some(())
+        }
+    };
+}
+
+affinity_cb!(cb_entry, "/router/isis/affinity-map/affinity");
+affinity_cb!(
+    cb_bit_position,
+    "/router/isis/affinity-map/affinity/bit-position"
+);
+
+pub fn callback_register(isis: &mut Isis) {
+    isis.callback_add("/router/isis/affinity-map/affinity", cb_entry);
+    isis.callback_add(
+        "/router/isis/affinity-map/affinity/bit-position",
+        cb_bit_position,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+
+    fn args(items: &[&str]) -> Args {
+        Args(items.iter().map(|s| s.to_string()).collect::<VecDeque<_>>())
+    }
+
+    #[test]
+    fn set_then_commit_persists_bit() {
+        let mut am = AffinityMap::new();
+        am.exec(
+            "/router/isis/affinity-map/affinity/bit-position".into(),
+            args(&["blue", "4"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        am.commit();
+        assert_eq!(am.bit("blue"), Some(4));
+    }
+
+    #[test]
+    fn delete_removes_entry() {
+        let mut am = AffinityMap::new();
+        am.exec(
+            "/router/isis/affinity-map/affinity/bit-position".into(),
+            args(&["blue", "4"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        am.commit();
+        am.exec(
+            "/router/isis/affinity-map/affinity".into(),
+            args(&["blue"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        am.commit();
+        assert_eq!(am.bit("blue"), None);
+        assert!(!am.config.contains_key("blue"));
+    }
+
+    #[test]
+    fn bit_out_of_range_rejected() {
+        let mut am = AffinityMap::new();
+        let err = am
+            .exec(
+                "/router/isis/affinity-map/affinity/bit-position".into(),
+                args(&["blue", "256"]),
+                ConfigOp::Set,
+            )
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("0..=255"), "unexpected err: {err}");
+    }
+}

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -248,6 +248,19 @@ impl Isis {
         );
         self.callback_add("/router/isis/interface/metric", link::config_metric);
         self.callback_add("/router/isis/interface/srlg", link::config_srlg);
+        self.callback_add("/router/isis/interface/affinity", link::config_affinity);
+        self.callback_add(
+            "/router/isis/interface/ipv4/flex-algo-prefix-sid",
+            link::config_ipv4_flex_algo_prefix_sid,
+        );
+        self.callback_add(
+            "/router/isis/interface/ipv4/flex-algo-prefix-sid/index",
+            link::config_ipv4_flex_algo_prefix_sid_index,
+        );
+        self.callback_add(
+            "/router/isis/segment-routing/srv6/flex-algo-locator/locator",
+            config_sr_srv6_flex_algo_locator,
+        );
         self.callback_add(
             "/router/isis/interface/ipv6/enable",
             link::config_ipv6_enable,
@@ -255,6 +268,7 @@ impl Isis {
         self.callback_add("/router/isis/distribute/rib", config_distribute_rib);
 
         super::flex_algo::callback_register(self);
+        super::affinity_map::callback_register(self);
     }
 }
 
@@ -312,6 +326,14 @@ pub struct IsisConfig {
     /// /segment-routing/locator list. Same staging-friendly rationale
     /// as sr_mpls_block.
     pub sr_srv6_locator: Option<String>,
+
+    /// Per-Flex-Algorithm SRv6 locator bindings, from the YANG list at
+    /// /router/isis/segment-routing/srv6/flex-algo-locator[algo=N].
+    /// Each entry binds an algorithm (128..=255) to a /segment-routing/
+    /// locator name; the LSP-emit follow-up will originate a SRv6
+    /// Locator TLV 27 with Algorithm=N (RFC 9352 §7.1) for each entry.
+    /// Names, not leafrefs — staged the same way as `sr_srv6_locator`.
+    pub sr_srv6_flex_algo_locators: BTreeMap<u8, String>,
 
     /// Set when /router/isis/fast-reroute/ti-lfa is committed (the
     /// presence-marked YANG container). Will gate post-convergence
@@ -700,6 +722,28 @@ fn config_sr_srv6_locator(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Opti
         isis.config.sr_srv6_locator = None;
     }
     isis.reconcile_locator_watch();
+    Some(())
+}
+
+// `/router/isis/segment-routing/srv6/flex-algo-locator[algo=N]/locator`
+// — bind a /segment-routing/locator name to algorithm N for SRv6
+// origination. Storage-only here; the LSP emit follow-up will turn
+// each entry into an SRv6 Locator TLV 27 with Algorithm=N (RFC 9352
+// §7.1). The locator-watch reconciliation that fires for the algo-0
+// `sr_srv6_locator` is not invoked here — per-algo locators live in
+// the same /segment-routing/locator namespace and will be folded into
+// the watch set in the same PR that consumes the map.
+fn config_sr_srv6_flex_algo_locator(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let algo = args.u8()?;
+    if !(128..=255).contains(&algo) {
+        return None;
+    }
+    if op.is_set() {
+        let name = args.string()?;
+        isis.config.sr_srv6_flex_algo_locators.insert(algo, name);
+    } else {
+        isis.config.sr_srv6_flex_algo_locators.remove(&algo);
+    }
     Some(())
 }
 

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -67,6 +67,11 @@ pub struct Isis {
     /// pending-cache → commit pipeline mirroring the static-route
     /// config builder in rib/static/config.rs.
     pub flex_algo: super::flex_algo::FlexAlgoConfig,
+    /// Affinity (admin-group) name table local to this IS-IS instance,
+    /// from /router/isis/affinity-map. Resolves the per-link `affinity`
+    /// leaf-list names into 256-bit Extended Admin Group bit positions
+    /// (RFC 7308) at LSP-build time.
+    pub affinity_map: super::affinity_map::AffinityMap,
     pub tracing: IsisTracing,
     pub lsdb: Levels<Lsdb>,
     pub lsp_map: Levels<LspMap>,
@@ -311,6 +316,7 @@ impl Isis {
             show_cb: HashMap::new(),
             config: IsisConfig::default(),
             flex_algo: super::flex_algo::FlexAlgoConfig::new(),
+            affinity_map: super::affinity_map::AffinityMap::new(),
             tracing: IsisTracing::default(),
             lsdb: Levels::<Lsdb>::default(),
             lsp_map: Levels::<LspMap>::default(),

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -227,6 +227,26 @@ pub struct LinkConfig {
     /// because the order influences the byte layout of TLVs 138/139
     /// (RFC 5307 / RFC 6119) and so the LSP-content signature.
     pub srlg_groups: BTreeSet<String>,
+
+    /// Affinity (admin-group) names this link belongs to, from
+    /// /router/isis/interface/<name>/affinity. Each name references a
+    /// /router/isis/affinity-map/affinity entry; the bit positions are
+    /// resolved to a 256-bit Extended Admin Group bitmap (RFC 7308) at
+    /// LSP-build time, advertised inside the ASLA sub-TLV (RFC 9479)
+    /// whenever at least one flex-algo references the attribute.
+    /// `BTreeSet` for the same deterministic-iteration reason as
+    /// `srlg_groups`.
+    pub affinity: BTreeSet<String>,
+
+    /// Per-Flex-Algorithm Prefix-SID for this link's IPv4 address(es).
+    /// Populated from
+    /// /router/isis/interface/<name>/ipv4/flex-algo-prefix-sid[algo=N].
+    /// Each entry produces an additional Prefix-SID sub-TLV (RFC 8667)
+    /// on the link's IP-reach TLV with the Algorithm field set to the
+    /// map key (RFC 9350 §7), alongside the algo-0 SID in
+    /// `prefix_sid`. Storage-only — the LSP emitter consumes it once
+    /// per-algo origination lands.
+    pub ipv4_flex_algo_prefix_sids: BTreeMap<u8, SidLabelValue>,
 }
 
 /// IS-IS-side mirror of the YANG `bfd { enable, profile }` container.
@@ -835,6 +855,23 @@ pub fn config_srlg(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> 
     Some(())
 }
 
+// `/router/isis/interface/<ifname>/affinity` — one call per affinity
+// name in the leaf-list. Storage-only; the LSP emit follow-up will
+// resolve names against `Isis::affinity_map` to build the 256-bit
+// Extended Admin Group bitmap (RFC 7308) inside ASLA (RFC 9479).
+pub fn config_affinity(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let ifname = args.string()?;
+    let name = args.string()?;
+
+    let link = isis.links.get_mut_by_name(&ifname)?;
+    if op.is_set() {
+        link.config.affinity.insert(name);
+    } else {
+        link.config.affinity.remove(&name);
+    }
+    Some(())
+}
+
 pub fn config_metric(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     let ifname = args.string()?;
     let metric = args.u32()?;
@@ -891,6 +928,51 @@ pub fn config_ipv4_prefix_sid_index(isis: &mut Isis, mut args: Args, op: ConfigO
         link.config.prefix_sid = None;
     }
 
+    Some(())
+}
+
+// `/router/isis/interface/<ifname>/ipv4/flex-algo-prefix-sid[algo=N]`
+// list root. libyang fires Set on entry creation (no value yet) and
+// Delete when the entire algo entry is removed.
+pub fn config_ipv4_flex_algo_prefix_sid(
+    isis: &mut Isis,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let ifname = args.string()?;
+    let algo = args.u8()?;
+    if !(128..=255).contains(&algo) {
+        return None;
+    }
+    let link = isis.links.get_mut_by_name(&ifname)?;
+    if !op.is_set() {
+        link.config.ipv4_flex_algo_prefix_sids.remove(&algo);
+    }
+    Some(())
+}
+
+// `.../flex-algo-prefix-sid[algo=N]/index` — per-algo index-form SID
+// for this link's IPv4 address(es), advertised as an additional
+// Prefix-SID sub-TLV with Algorithm=N (RFC 9350 §7).
+pub fn config_ipv4_flex_algo_prefix_sid_index(
+    isis: &mut Isis,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let ifname = args.string()?;
+    let algo = args.u8()?;
+    if !(128..=255).contains(&algo) {
+        return None;
+    }
+    let index = args.u32()?;
+    let link = isis.links.get_mut_by_name(&ifname)?;
+    if op.is_set() {
+        link.config
+            .ipv4_flex_algo_prefix_sids
+            .insert(algo, SidLabelValue::Index(index));
+    } else {
+        link.config.ipv4_flex_algo_prefix_sids.remove(&algo);
+    }
     Some(())
 }
 

--- a/zebra-rs/src/isis/mod.rs
+++ b/zebra-rs/src/isis/mod.rs
@@ -59,4 +59,6 @@ pub mod srlg;
 
 pub mod throttle;
 
+pub mod affinity_map;
+
 pub mod flex_algo;


### PR DESCRIPTION
## Summary

Closes the config-layer gap left after PR #605 (FAD-only). All four remaining YANG subtrees from that PR's schema now have callbacks and storage.

| YANG path | Storage location | Pattern |
|---|---|---|
| `/router/isis/affinity-map/affinity` (list keyed by name, `bit-position` leaf) | `Isis::affinity_map: AffinityMap` (new module) | Full builder/cache/commit, mirrors `flex_algo.rs` |
| `/router/isis/interface/<if>/affinity` (leaf-list of names) | `LinkConfig::affinity: BTreeSet<String>` | Single direct callback `link::config_affinity`, next to `config_srlg` |
| `/router/isis/interface/<if>/ipv4/flex-algo-prefix-sid[algo=N]/index` | `LinkConfig::ipv4_flex_algo_prefix_sids: BTreeMap<u8, SidLabelValue>` | List-root + per-leaf callbacks in `link.rs`, next to `config_ipv4_prefix_sid_index` |
| `/router/isis/segment-routing/srv6/flex-algo-locator[algo=N]/locator` | `IsisConfig::sr_srv6_flex_algo_locators: BTreeMap<u8, String>` | Single direct callback in `config.rs`, next to `config_sr_srv6_locator` |

Hybrid intentional — full builder for the one tree with shared-state semantics (affinity-map), direct callbacks for the three trees with single-leaf semantics that already have similar neighbors. Each new callback sits next to its analogue.

All four trees are **storage-only**. LSP origination, FAD sub-TLV emit, SPF gating, and per-algo RIB install land in follow-up PRs. Two storage-only helpers (`AffinityMap::bit`, `FadMetricType::wire` from PR #605) carry `#[allow(dead_code)]` until consumers land.

## Test plan

- [x] `cargo build -p zebra-rs --bin zebra-rs` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p zebra-rs --bin zebra-rs --all-targets -- -D warnings` — clean
- [x] `cargo test -p zebra-rs --bin zebra-rs isis::` — 60 pass, including 3 new affinity_map tests (staging, delete, bit-position range validation) and the 5 existing flex_algo tests
- [ ] End-to-end CLI exercise once FAD sub-TLV emit lands

Generated with [Claude Code](https://claude.com/claude-code)