### PR TITLE
isis: emit Flex-Algorithm Definition sub-TLV (RFC 9350)

### DIFF
--- a/crates/isis-packet/src/sub/cap.rs
+++ b/crates/isis-packet/src/sub/cap.rs
@@ -3,7 +3,7 @@ use std::net::Ipv4Addr;
 use bitfield_struct::bitfield;
 use bytes::{BufMut, BytesMut};
 use nom::IResult;
-use nom::number::complete::{be_u8, be_u16, be_u24};
+use nom::number::complete::{be_u8, be_u16, be_u24, be_u32};
 use nom_derive::*;
 use packet_utils::{Algo, SidLabelTlv, parse_sid_label};
 use serde::{Deserialize, Serialize};
@@ -27,6 +27,8 @@ pub enum IsisSubTlv {
     NodeMaxSidDepth(IsisSubNodeMaxSidDepth),
     #[nom(Selector = "IsisCapCode::Srv6")]
     Srv6(IsisSubSrv6),
+    #[nom(Selector = "IsisCapCode::FlexAlgoDef")]
+    FlexAlgoDef(IsisSubFlexAlgoDef),
     #[nom(Selector = "_")]
     Unknown(IsisSubTlvUnknown),
 }
@@ -51,6 +53,7 @@ impl IsisSubTlv {
             SegmentRoutingLB(v) => v.len(),
             NodeMaxSidDepth(v) => v.len(),
             Srv6(v) => v.len(),
+            FlexAlgoDef(v) => v.len(),
             Unknown(v) => v.len,
         }
     }
@@ -67,6 +70,7 @@ impl IsisSubTlv {
             SegmentRoutingLB(v) => v.tlv_emit(buf),
             NodeMaxSidDepth(v) => v.tlv_emit(buf),
             Srv6(v) => v.tlv_emit(buf),
+            FlexAlgoDef(v) => v.tlv_emit(buf),
             Unknown(v) => v.tlv_emit(buf),
         }
     }
@@ -314,6 +318,393 @@ impl From<IsisSubSrv6> for IsisSubTlv {
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────
+// RFC 9350 — Flex-Algorithm Definition (FAD) sub-TLV (type 26) and
+// its nested sub-TLVs. The FAD lives inside Router Capability TLV 242
+// and carries one algorithm's definition: ID + metric type + calc type
+// + priority + a set of constraint sub-TLVs (admin-group include /
+// exclude, exclude-SRLG, flags). The FAD itself is originated by one
+// (or two, for redundancy) routers per area; every participant uses
+// it as the recipe for SPF on the matching algorithm.
+// ─────────────────────────────────────────────────────────────────────
+
+/// Sub-TLV type codes that may appear inside a FAD body (RFC 9350
+/// §5.1). These live in a FAD-local namespace, distinct from the
+/// `IsisCapCode` space the FAD itself lives in.
+#[repr(u8)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
+pub enum FadSubCode {
+    #[default]
+    ExcludeAg = 1, // RFC 9350 §6.1
+    IncludeAnyAg = 2, // RFC 9350 §6.1
+    IncludeAllAg = 3, // RFC 9350 §6.1
+    Flags = 4,        // RFC 9350 §6.4 (M-flag for prefix metric)
+    ExcludeSrlg = 5,  // RFC 9350 §6.2
+    Unknown(u8),
+}
+
+impl From<FadSubCode> for u8 {
+    fn from(typ: FadSubCode) -> Self {
+        use FadSubCode::*;
+        match typ {
+            ExcludeAg => 1,
+            IncludeAnyAg => 2,
+            IncludeAllAg => 3,
+            Flags => 4,
+            ExcludeSrlg => 5,
+            Unknown(v) => v,
+        }
+    }
+}
+
+impl From<u8> for FadSubCode {
+    fn from(typ: u8) -> Self {
+        use FadSubCode::*;
+        match typ {
+            1 => ExcludeAg,
+            2 => IncludeAnyAg,
+            3 => IncludeAllAg,
+            4 => Flags,
+            5 => ExcludeSrlg,
+            v => Unknown(v),
+        }
+    }
+}
+
+impl FadSubCode {
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, typ) = be_u8(input)?;
+        Ok((input, typ.into()))
+    }
+}
+
+/// Extended Admin Group bitmap payload (RFC 7308): a sequence of
+/// 32-bit big-endian words holding 32 group bits each. Word N covers
+/// group ids `(N*32)..((N+1)*32)`; within a word, bit 0 is the LSB
+/// and the word is serialized big-endian. Used by the three FAD
+/// admin-group constraint sub-TLVs below.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ExtAdminGroup {
+    pub words: Vec<u32>,
+}
+
+impl ExtAdminGroup {
+    /// Set bit `n` (RFC 7308 group id). Grows the bitmap as needed.
+    pub fn set(&mut self, n: u16) {
+        let word = (n / 32) as usize;
+        let bit = (n % 32) as u32;
+        if word >= self.words.len() {
+            self.words.resize(word + 1, 0);
+        }
+        self.words[word] |= 1u32 << bit;
+    }
+
+    /// True iff bit `n` is set.
+    pub fn get(&self, n: u16) -> bool {
+        let word = (n / 32) as usize;
+        let bit = (n % 32) as u32;
+        self.words
+            .get(word)
+            .is_some_and(|w| (*w & (1u32 << bit)) != 0)
+    }
+
+    /// Byte length on the wire (4 per word).
+    pub fn byte_len(&self) -> usize {
+        self.words.len() * 4
+    }
+}
+
+fn parse_ext_admin_group(input: &[u8]) -> IResult<&[u8], ExtAdminGroup> {
+    let (input, words) = many0_complete(be_u32).parse(input)?;
+    Ok((input, ExtAdminGroup { words }))
+}
+
+fn emit_ext_admin_group(g: &ExtAdminGroup, buf: &mut BytesMut) {
+    for w in &g.words {
+        buf.put_u32(*w);
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubFadExcludeAg {
+    pub group: ExtAdminGroup,
+}
+
+impl ParseBe<IsisSubFadExcludeAg> for IsisSubFadExcludeAg {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, group) = parse_ext_admin_group(input)?;
+        Ok((input, Self { group }))
+    }
+}
+
+impl TlvEmitter for IsisSubFadExcludeAg {
+    fn typ(&self) -> u8 {
+        FadSubCode::ExcludeAg.into()
+    }
+    fn len(&self) -> u8 {
+        self.group.byte_len().min(255) as u8
+    }
+    fn emit(&self, buf: &mut BytesMut) {
+        emit_ext_admin_group(&self.group, buf);
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubFadIncludeAnyAg {
+    pub group: ExtAdminGroup,
+}
+
+impl ParseBe<IsisSubFadIncludeAnyAg> for IsisSubFadIncludeAnyAg {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, group) = parse_ext_admin_group(input)?;
+        Ok((input, Self { group }))
+    }
+}
+
+impl TlvEmitter for IsisSubFadIncludeAnyAg {
+    fn typ(&self) -> u8 {
+        FadSubCode::IncludeAnyAg.into()
+    }
+    fn len(&self) -> u8 {
+        self.group.byte_len().min(255) as u8
+    }
+    fn emit(&self, buf: &mut BytesMut) {
+        emit_ext_admin_group(&self.group, buf);
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubFadIncludeAllAg {
+    pub group: ExtAdminGroup,
+}
+
+impl ParseBe<IsisSubFadIncludeAllAg> for IsisSubFadIncludeAllAg {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, group) = parse_ext_admin_group(input)?;
+        Ok((input, Self { group }))
+    }
+}
+
+impl TlvEmitter for IsisSubFadIncludeAllAg {
+    fn typ(&self) -> u8 {
+        FadSubCode::IncludeAllAg.into()
+    }
+    fn len(&self) -> u8 {
+        self.group.byte_len().min(255) as u8
+    }
+    fn emit(&self, buf: &mut BytesMut) {
+        emit_ext_admin_group(&self.group, buf);
+    }
+}
+
+/// FAD Flags sub-TLV (RFC 9350 §6.4). One byte minimum; only the
+/// M-flag (bit 0 of byte 0, "Prefix Metric") is currently defined.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubFadFlags {
+    pub m_flag: bool,
+    /// Trailing bytes preserved on parse to round-trip flags defined
+    /// after this codec was written.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub trailing: Vec<u8>,
+}
+
+impl ParseBe<IsisSubFadFlags> for IsisSubFadFlags {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, first) = be_u8(input)?;
+        // RFC 9350 §6.4: M-flag is the MSB of byte 0 (bit position 7
+        // when bit 0 is LSB).
+        let m_flag = (first & 0x80) != 0;
+        let trailing = input.to_vec();
+        Ok((&[], Self { m_flag, trailing }))
+    }
+}
+
+impl TlvEmitter for IsisSubFadFlags {
+    fn typ(&self) -> u8 {
+        FadSubCode::Flags.into()
+    }
+    fn len(&self) -> u8 {
+        (1 + self.trailing.len()).min(255) as u8
+    }
+    fn emit(&self, buf: &mut BytesMut) {
+        let first: u8 = if self.m_flag { 0x80 } else { 0x00 };
+        buf.put_u8(first);
+        buf.put_slice(&self.trailing);
+    }
+}
+
+/// FAD Exclude SRLG sub-TLV (RFC 9350 §6.2). Carries an ordered list
+/// of 32-bit SRLG identifiers; any link whose advertised SRLG set
+/// intersects this list is excluded from the algorithm's SPF.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubFadExcludeSrlg {
+    pub srlgs: Vec<u32>,
+}
+
+impl ParseBe<IsisSubFadExcludeSrlg> for IsisSubFadExcludeSrlg {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, srlgs) = many0_complete(be_u32).parse(input)?;
+        Ok((input, Self { srlgs }))
+    }
+}
+
+impl TlvEmitter for IsisSubFadExcludeSrlg {
+    fn typ(&self) -> u8 {
+        FadSubCode::ExcludeSrlg.into()
+    }
+    fn len(&self) -> u8 {
+        (self.srlgs.len().min(63) * 4) as u8
+    }
+    fn emit(&self, buf: &mut BytesMut) {
+        for s in self.srlgs.iter().take(63) {
+            buf.put_u32(*s);
+        }
+    }
+}
+
+/// Nested sub-TLV under a FAD. Dispatched by `FadSubCode` per
+/// RFC 9350 §5.1.
+#[derive(Debug, NomBE, Clone, Serialize, Deserialize, PartialEq)]
+#[nom(Selector = "FadSubCode")]
+pub enum FadSubTlv {
+    #[nom(Selector = "FadSubCode::ExcludeAg")]
+    ExcludeAg(IsisSubFadExcludeAg),
+    #[nom(Selector = "FadSubCode::IncludeAnyAg")]
+    IncludeAnyAg(IsisSubFadIncludeAnyAg),
+    #[nom(Selector = "FadSubCode::IncludeAllAg")]
+    IncludeAllAg(IsisSubFadIncludeAllAg),
+    #[nom(Selector = "FadSubCode::Flags")]
+    Flags(IsisSubFadFlags),
+    #[nom(Selector = "FadSubCode::ExcludeSrlg")]
+    ExcludeSrlg(IsisSubFadExcludeSrlg),
+    #[nom(Selector = "_")]
+    Unknown(IsisSubTlvUnknown),
+}
+
+impl FadSubTlv {
+    pub fn parse_subs(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, cl) = IsisCodeLen::parse_be(input)?;
+        let (input, sub) = packet_utils::safe_split_at(input, cl.len as usize)?;
+        let (_, mut val) = Self::parse_be(sub, cl.code.into())?;
+        if let FadSubTlv::Unknown(ref mut v) = val {
+            v.code = cl.code;
+            v.len = cl.len;
+        }
+        Ok((input, val))
+    }
+
+    pub fn len(&self) -> u8 {
+        use FadSubTlv::*;
+        match self {
+            ExcludeAg(v) => v.len(),
+            IncludeAnyAg(v) => v.len(),
+            IncludeAllAg(v) => v.len(),
+            Flags(v) => v.len(),
+            ExcludeSrlg(v) => v.len(),
+            Unknown(v) => v.len,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn emit(&self, buf: &mut BytesMut) {
+        use FadSubTlv::*;
+        match self {
+            ExcludeAg(v) => v.tlv_emit(buf),
+            IncludeAnyAg(v) => v.tlv_emit(buf),
+            IncludeAllAg(v) => v.tlv_emit(buf),
+            Flags(v) => v.tlv_emit(buf),
+            ExcludeSrlg(v) => v.tlv_emit(buf),
+            Unknown(v) => v.tlv_emit(buf),
+        }
+    }
+}
+
+/// Flex-Algorithm Definition sub-TLV (RFC 9350 §5.1, IsisCapCode = 26).
+///
+/// Fixed header layout:
+/// ```text
+///   0                   1                   2                   3
+///   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+///  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+///  |  Flex-Algo    |  Metric-Type  |  Calc-Type    |   Priority    |
+///  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+///  //                       Sub-TLVs                              //
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubFlexAlgoDef {
+    /// Algorithm identifier, 128..=255 per RFC 9350 §4.
+    pub flex_algorithm: u8,
+    /// Metric-Type per RFC 9350 §5.1 IANA registry
+    /// (0=IGP, 1=Min Unidir Link Delay, 2=TE Default).
+    pub metric_type: u8,
+    /// Calc-Type. Only 0 (SPF) is currently defined (RFC 9350 §5.1).
+    pub calc_type: u8,
+    /// Tie-breaker priority when multiple routers originate a FAD for
+    /// the same Flex-Algorithm. Higher wins; ties resolved by router
+    /// system ID (RFC 9350 §5.2).
+    pub priority: u8,
+    /// Nested FAD constraint sub-TLVs (admin-group include/exclude,
+    /// flags, exclude-SRLG).
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub subs: Vec<FadSubTlv>,
+}
+
+impl ParseBe<IsisSubFlexAlgoDef> for IsisSubFlexAlgoDef {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, flex_algorithm) = be_u8(input)?;
+        let (input, metric_type) = be_u8(input)?;
+        let (input, calc_type) = be_u8(input)?;
+        let (input, priority) = be_u8(input)?;
+        let (input, subs) = many0_complete(FadSubTlv::parse_subs).parse(input)?;
+        Ok((
+            input,
+            Self {
+                flex_algorithm,
+                metric_type,
+                calc_type,
+                priority,
+                subs,
+            },
+        ))
+    }
+}
+
+impl IsisSubFlexAlgoDef {
+    fn sub_len(&self) -> usize {
+        // 2 bytes (type + length) per nested sub-TLV header.
+        self.subs.iter().map(|s| 2 + s.len() as usize).sum()
+    }
+}
+
+impl TlvEmitter for IsisSubFlexAlgoDef {
+    fn typ(&self) -> u8 {
+        IsisCapCode::FlexAlgoDef.into()
+    }
+
+    fn len(&self) -> u8 {
+        (4 + self.sub_len()).min(255) as u8
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(self.flex_algorithm);
+        buf.put_u8(self.metric_type);
+        buf.put_u8(self.calc_type);
+        buf.put_u8(self.priority);
+        for s in &self.subs {
+            s.emit(buf);
+        }
+    }
+}
+
+impl From<IsisSubFlexAlgoDef> for IsisSubTlv {
+    fn from(sub: IsisSubFlexAlgoDef) -> Self {
+        IsisSubTlv::FlexAlgoDef(sub)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -344,5 +735,125 @@ mod tests {
         let mut buf = BytesMut::new();
         long.emit(&mut buf);
         assert_eq!(buf.len(), 255);
+    }
+
+    #[test]
+    fn ext_admin_group_set_grows_and_round_trips() {
+        let mut g = ExtAdminGroup::default();
+        g.set(0);
+        g.set(31);
+        g.set(32);
+        g.set(255);
+        assert!(g.get(0) && g.get(31) && g.get(32) && g.get(255));
+        assert!(!g.get(1) && !g.get(254));
+        // bit 255 lives in word 7 (zero-indexed), so we expect 8 words.
+        assert_eq!(g.words.len(), 8);
+        assert_eq!(g.byte_len(), 32);
+    }
+
+    fn round_trip_fad(fad: IsisSubFlexAlgoDef) -> IsisSubFlexAlgoDef {
+        let mut buf = BytesMut::new();
+        fad.emit(&mut buf);
+        let (rest, parsed) = IsisSubFlexAlgoDef::parse_be(&buf).expect("parse");
+        assert!(rest.is_empty(), "leftover bytes: {rest:?}");
+        parsed
+    }
+
+    #[test]
+    fn fad_header_only_round_trip() {
+        let fad = IsisSubFlexAlgoDef {
+            flex_algorithm: 128,
+            metric_type: 1, // min-unidir-link-delay
+            calc_type: 0,   // SPF
+            priority: 200,
+            subs: vec![],
+        };
+        let parsed = round_trip_fad(fad.clone());
+        assert_eq!(parsed, fad);
+        // 4 header bytes only.
+        let mut buf = BytesMut::new();
+        fad.emit(&mut buf);
+        assert_eq!(buf.len(), 4);
+    }
+
+    #[test]
+    fn fad_with_exclude_and_flags_round_trips() {
+        let mut excl = ExtAdminGroup::default();
+        excl.set(0); // "blue"
+        let fad = IsisSubFlexAlgoDef {
+            flex_algorithm: 129,
+            metric_type: 0,
+            calc_type: 0,
+            priority: 128,
+            subs: vec![
+                FadSubTlv::ExcludeAg(IsisSubFadExcludeAg { group: excl }),
+                FadSubTlv::Flags(IsisSubFadFlags {
+                    m_flag: true,
+                    trailing: vec![],
+                }),
+                FadSubTlv::ExcludeSrlg(IsisSubFadExcludeSrlg {
+                    srlgs: vec![100, 200],
+                }),
+            ],
+        };
+        let parsed = round_trip_fad(fad.clone());
+        assert_eq!(parsed, fad);
+    }
+
+    #[test]
+    fn fad_unknown_sub_preserved_on_round_trip() {
+        // Inject an unknown FAD sub-TLV (type 99) by hand-crafting the bytes
+        // and parsing them; the result must include an Unknown variant whose
+        // re-emission reproduces the original bytes.
+        let bytes: &[u8] = &[
+            128, // flex-algorithm
+            0,   // metric-type
+            0,   // calc-type
+            128, // priority
+            99,  // unknown sub-tlv type
+            3,   // length
+            0xDE, 0xAD, 0xBE,
+        ];
+        let (rest, fad) = IsisSubFlexAlgoDef::parse_be(bytes).expect("parse");
+        assert!(rest.is_empty());
+        assert_eq!(fad.subs.len(), 1);
+        match &fad.subs[0] {
+            FadSubTlv::Unknown(u) => {
+                assert_eq!(u.code, 99);
+                assert_eq!(u.len, 3);
+            }
+            _ => panic!("expected Unknown FAD sub-TLV"),
+        }
+        let mut buf = BytesMut::new();
+        fad.emit(&mut buf);
+        assert_eq!(&buf[..], bytes);
+    }
+
+    #[test]
+    fn router_cap_dispatches_fad_variant() {
+        // Build a Router Capability TLV containing a FAD and round-trip
+        // through the IsisSubTlv codec used by lsp_generate.
+        let fad = IsisSubFlexAlgoDef {
+            flex_algorithm: 128,
+            metric_type: 1,
+            calc_type: 0,
+            priority: 128,
+            subs: vec![],
+        };
+        let cap = IsisTlvRouterCap {
+            router_id: Ipv4Addr::new(1, 1, 1, 1),
+            flags: 0u8.into(),
+            subs: vec![fad.into()],
+        };
+        // Serialize Router Capability body + parse it back.
+        let mut buf = BytesMut::new();
+        cap.emit(&mut buf);
+        let (rest, parsed) = IsisTlvRouterCap::parse_be(&buf).expect("parse");
+        assert!(rest.is_empty());
+        assert_eq!(parsed.subs.len(), 1);
+        match &parsed.subs[0] {
+            IsisSubTlv::FlexAlgoDef(p) => assert_eq!(p.flex_algorithm, 128),
+            other => panic!("expected FlexAlgoDef variant, got {other:?}"),
+        }
     }
 }

--- a/crates/isis-packet/src/sub/cap_code.rs
+++ b/crates/isis-packet/src/sub/cap_code.rs
@@ -11,6 +11,7 @@ pub enum IsisCapCode {
     SegmentRoutingLb = 22,
     NodeMaxSidDepth = 23,
     Srv6 = 25,
+    FlexAlgoDef = 26,
     Unknown(u8),
 }
 
@@ -23,6 +24,7 @@ impl From<IsisCapCode> for u8 {
             SegmentRoutingLb => 22,
             NodeMaxSidDepth => 23,
             Srv6 => 25,
+            FlexAlgoDef => 26,
             Unknown(v) => v,
         }
     }
@@ -37,6 +39,7 @@ impl From<u8> for IsisCapCode {
             22 => SegmentRoutingLb,
             23 => NodeMaxSidDepth,
             25 => Srv6,
+            26 => FlexAlgoDef,
             v => Unknown(v),
         }
     }

--- a/crates/isis-packet/src/sub/cap_disp.rs
+++ b/crates/isis-packet/src/sub/cap_disp.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Display, Formatter, Result};
 
-use super::cap::{IsisSubSrv6, IsisSubTlv, RouterCapFlags};
+use super::cap::{FadSubTlv, IsisSubFlexAlgoDef, IsisSubSrv6, IsisSubTlv, RouterCapFlags};
 use super::{
     IsisSubNodeMaxSidDepth, IsisSubSegmentRoutingAlgo, IsisSubSegmentRoutingCap,
     IsisSubSegmentRoutingLB, IsisTlvRouterCap, SegmentRoutingCapFlags,
@@ -35,7 +35,50 @@ impl Display for IsisSubTlv {
             SegmentRoutingLB(v) => write!(f, "{}", v),
             NodeMaxSidDepth(v) => write!(f, "{}", v),
             Srv6(v) => write!(f, "{}", v),
+            FlexAlgoDef(v) => write!(f, "{}", v),
             Unknown(v) => write!(f, "   Unknown Code: {} Len: {}", v.code, v.len),
+        }
+    }
+}
+
+impl Display for IsisSubFlexAlgoDef {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(
+            f,
+            "   Flex-Algorithm Definition: Algo {}, Metric-Type {}, Calc-Type {}, Priority {}",
+            self.flex_algorithm, self.metric_type, self.calc_type, self.priority
+        )?;
+        for sub in &self.subs {
+            write!(f, "\n{}", sub)?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for FadSubTlv {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        use FadSubTlv::*;
+        match self {
+            ExcludeAg(v) => write!(
+                f,
+                "     FAD Exclude Admin-Group ({} words)",
+                v.group.words.len()
+            ),
+            IncludeAnyAg(v) => write!(
+                f,
+                "     FAD Include-Any Admin-Group ({} words)",
+                v.group.words.len()
+            ),
+            IncludeAllAg(v) => write!(
+                f,
+                "     FAD Include-All Admin-Group ({} words)",
+                v.group.words.len()
+            ),
+            Flags(v) => write!(f, "     FAD Flags M:{}", v.m_flag as u8),
+            ExcludeSrlg(v) => {
+                write!(f, "     FAD Exclude SRLG: {} ids", v.srlgs.len())
+            }
+            Unknown(v) => write!(f, "     FAD Unknown Code: {} Len: {}", v.code, v.len),
         }
     }
 }

--- a/crates/isis-packet/src/sub/mod.rs
+++ b/crates/isis-packet/src/sub/mod.rs
@@ -8,8 +8,10 @@ pub struct IsisCodeLen {
 
 pub mod cap;
 pub use cap::{
+    ExtAdminGroup, FadSubCode, FadSubTlv, IsisSubFadExcludeAg, IsisSubFadExcludeSrlg,
+    IsisSubFadFlags, IsisSubFadIncludeAllAg, IsisSubFadIncludeAnyAg, IsisSubFlexAlgoDef,
     IsisSubNodeMaxSidDepth, IsisSubSegmentRoutingAlgo, IsisSubSegmentRoutingCap,
-    IsisSubSegmentRoutingLB, IsisSubSrv6, IsisTlvRouterCap, SegmentRoutingCapFlags,
+    IsisSubSegmentRoutingLB, IsisSubSrv6, IsisSubTlv, IsisTlvRouterCap, SegmentRoutingCapFlags,
 };
 pub use packet_utils::SidLabelTlv;
 pub mod cap_code;

--- a/zebra-rs/src/isis/affinity_map.rs
+++ b/zebra-rs/src/isis/affinity_map.rs
@@ -168,6 +168,16 @@ macro_rules! affinity_cb {
         fn $name(isis: &mut Isis, args: Args, op: ConfigOp) -> Option<()> {
             isis.affinity_map.exec($path.to_string(), args, op).ok()?;
             isis.affinity_map.commit();
+            // Affinity-name → bit changes feed straight into the
+            // Extended Admin Group bitmaps inside originated FADs;
+            // re-originate both levels so peers see the new bits
+            // without waiting for the refresh timer.
+            let _ = isis
+                .tx
+                .send(super::Message::LspOriginate(super::Level::L1, None));
+            let _ = isis
+                .tx
+                .send(super::Message::LspOriginate(super::Level::L2, None));
             Some(())
         }
     };

--- a/zebra-rs/src/isis/flex_algo.rs
+++ b/zebra-rs/src/isis/flex_algo.rs
@@ -2,10 +2,16 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr;
 
 use anyhow::{Context, Result, bail};
+use isis_packet::{
+    ExtAdminGroup, FadSubTlv, IsisSubFadExcludeAg, IsisSubFadExcludeSrlg, IsisSubFadFlags,
+    IsisSubFadIncludeAllAg, IsisSubFadIncludeAnyAg, IsisSubFlexAlgoDef,
+};
 
 use crate::config::{Args, ConfigOp};
 
 use super::Isis;
+use super::affinity_map::AffinityMap;
+use super::srlg::SrlgGroup;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FadMetricType {
@@ -16,9 +22,8 @@ pub enum FadMetricType {
 
 impl FadMetricType {
     /// FAD Sub-TLV Metric-Type code (RFC 9350 §5.1, IANA registry).
-    /// Held here so the LSP-emit follow-up has a single source of
-    /// truth for the on-the-wire byte.
-    #[allow(dead_code)]
+    /// Single source of truth for the on-the-wire byte, consumed by
+    /// `build_fad_subs` at LSP-build time.
     pub fn wire(self) -> u8 {
         match self {
             Self::Igp => 0,
@@ -96,10 +101,12 @@ impl FlexAlgoConfig {
     }
 
     /// Drain the pending cache into the committed map. Apply / drop
-    /// semantics match `StaticConfig::commit`. Side-effects driven by
-    /// definition changes (LSP re-origination, SPF schedule, dataplane
-    /// install) will be wired in follow-up PRs — for now this is a pure
-    /// in-memory commit.
+    /// semantics match `StaticConfig::commit`. SPF gating and
+    /// per-algo RIB install will be wired in follow-up PRs; LSP
+    /// re-origination is triggered by the per-leaf shim callbacks
+    /// (so a single config change that hits multiple leaves
+    /// originates the LSP once per leaf — acceptable churn given the
+    /// LSP-gen throttle).
     pub fn commit(&mut self) {
         while let Some((algo, entry)) = self.cache.pop_first() {
             if entry.delete {
@@ -109,6 +116,93 @@ impl FlexAlgoConfig {
             }
         }
     }
+}
+
+/// Build the FAD sub-TLVs (RFC 9350 §5.1) this router will originate
+/// inside Router Capability TLV 242. One FAD per
+/// `FlexAlgoConfig.config` entry with `advertise_definition == true`;
+/// entries with the flag absent or false stay purely local.
+///
+/// Affinity names are resolved against `affinity_map` to 256-bit
+/// Extended Admin Group bit positions (RFC 7308) — names with no
+/// matching entry are silently dropped (LSP-gen is best-effort, the
+/// operator's mistake doesn't deserve a build failure). SRLG names
+/// are resolved against the global SRLG map (`Isis::srlg_groups`)
+/// to 32-bit identifiers the same way.
+pub fn build_fad_subs(
+    fa: &FlexAlgoConfig,
+    am: &AffinityMap,
+    srlg_groups: &BTreeMap<String, SrlgGroup>,
+) -> Vec<IsisSubFlexAlgoDef> {
+    fn group_from_names<I: IntoIterator<Item = S>, S: AsRef<str>>(
+        am: &AffinityMap,
+        names: I,
+    ) -> ExtAdminGroup {
+        let mut g = ExtAdminGroup::default();
+        for n in names {
+            if let Some(bit) = am.bit(n.as_ref()) {
+                g.set(bit);
+            }
+        }
+        g
+    }
+
+    let mut out = Vec::new();
+    for (&algo, entry) in &fa.config {
+        if entry.advertise_definition != Some(true) {
+            continue;
+        }
+        let metric_type = entry.metric_type.unwrap_or(FadMetricType::Igp).wire();
+        let priority = entry.priority.unwrap_or(128);
+
+        let mut subs = Vec::new();
+
+        if !entry.exclude_any.is_empty() {
+            let group = group_from_names(am, entry.exclude_any.iter());
+            if !group.words.is_empty() {
+                subs.push(FadSubTlv::ExcludeAg(IsisSubFadExcludeAg { group }));
+            }
+        }
+        if !entry.include_any.is_empty() {
+            let group = group_from_names(am, entry.include_any.iter());
+            if !group.words.is_empty() {
+                subs.push(FadSubTlv::IncludeAnyAg(IsisSubFadIncludeAnyAg { group }));
+            }
+        }
+        if !entry.include_all.is_empty() {
+            let group = group_from_names(am, entry.include_all.iter());
+            if !group.words.is_empty() {
+                subs.push(FadSubTlv::IncludeAllAg(IsisSubFadIncludeAllAg { group }));
+            }
+        }
+        if entry.prefix_metric == Some(true) {
+            subs.push(FadSubTlv::Flags(IsisSubFadFlags {
+                m_flag: true,
+                trailing: Vec::new(),
+            }));
+        }
+        if !entry.srlg_exclude.is_empty() {
+            let mut ids: Vec<u32> = entry
+                .srlg_exclude
+                .iter()
+                .filter_map(|n| srlg_groups.get(n).map(|g| g.value))
+                .collect();
+            ids.sort();
+            ids.dedup();
+            if !ids.is_empty() {
+                subs.push(FadSubTlv::ExcludeSrlg(IsisSubFadExcludeSrlg { srlgs: ids }));
+            }
+        }
+
+        out.push(IsisSubFlexAlgoDef {
+            flex_algorithm: algo,
+            metric_type,
+            calc_type: 0, // Only SPF defined today (RFC 9350 §5.1).
+            priority,
+            subs,
+        });
+    }
+    out
 }
 
 #[derive(Default)]
@@ -350,6 +444,16 @@ macro_rules! flex_algo_cb {
         fn $name(isis: &mut Isis, args: Args, op: ConfigOp) -> Option<()> {
             isis.flex_algo.exec($path.to_string(), args, op).ok()?;
             isis.flex_algo.commit();
+            // Re-originate both levels so FAD changes propagate to
+            // peers without waiting for the refresh timer. The
+            // process_lsp_originate path filters by `has_level` for
+            // single-level instances, so unconditional send is safe.
+            let _ = isis
+                .tx
+                .send(super::Message::LspOriginate(super::Level::L1, None));
+            let _ = isis
+                .tx
+                .send(super::Message::LspOriginate(super::Level::L2, None));
             Some(())
         }
     };
@@ -492,6 +596,129 @@ mod tests {
         .unwrap();
         fa.commit();
         assert!(!fa.config.contains_key(&128));
+    }
+
+    #[test]
+    fn build_fad_subs_skips_entries_without_advertise_flag() {
+        let mut fa = FlexAlgoConfig::new();
+        // Algo 128 — advertise-definition NOT set, so should be skipped.
+        fa.exec(
+            "/router/isis/flex-algo/priority".into(),
+            args(&["128", "200"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        fa.commit();
+        // Algo 129 — advertise-definition set, should be emitted.
+        fa.exec(
+            "/router/isis/flex-algo/advertise-definition".into(),
+            args(&["129", "true"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        fa.commit();
+
+        let am = AffinityMap::new();
+        let srlg = BTreeMap::new();
+        let subs = build_fad_subs(&fa, &am, &srlg);
+        assert_eq!(subs.len(), 1);
+        assert_eq!(subs[0].flex_algorithm, 129);
+        // Defaults: igp metric type, priority 128, no nested subs.
+        assert_eq!(subs[0].metric_type, FadMetricType::Igp.wire());
+        assert_eq!(subs[0].priority, 128);
+        assert!(subs[0].subs.is_empty());
+    }
+
+    #[test]
+    fn build_fad_subs_emits_exclude_ag_and_srlg() {
+        let mut fa = FlexAlgoConfig::new();
+        for (path, args_) in [
+            (
+                "/router/isis/flex-algo/advertise-definition",
+                &["128", "true"][..],
+            ),
+            (
+                "/router/isis/flex-algo/affinity/exclude-any",
+                &["128", "blue"],
+            ),
+            ("/router/isis/flex-algo/srlg-exclude", &["128", "risk-A"]),
+            ("/router/isis/flex-algo/prefix-metric", &["128", "true"]),
+        ] {
+            fa.exec(path.into(), args(args_), ConfigOp::Set).unwrap();
+            fa.commit();
+        }
+
+        let mut am = AffinityMap::new();
+        am.exec(
+            "/router/isis/affinity-map/affinity/bit-position".into(),
+            args(&["blue", "4"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        am.commit();
+
+        let mut srlg = BTreeMap::new();
+        srlg.insert(
+            "risk-A".to_string(),
+            SrlgGroup {
+                name: "risk-A".into(),
+                value: 100,
+            },
+        );
+
+        let subs = build_fad_subs(&fa, &am, &srlg);
+        assert_eq!(subs.len(), 1);
+        let fad = &subs[0];
+        assert_eq!(fad.flex_algorithm, 128);
+        // Exactly three nested sub-TLVs: ExcludeAg, Flags (M=1), ExcludeSrlg.
+        assert_eq!(fad.subs.len(), 3);
+        let mut has_excl = false;
+        let mut has_flags = false;
+        let mut has_srlg = false;
+        for sub in &fad.subs {
+            match sub {
+                FadSubTlv::ExcludeAg(v) => {
+                    has_excl = true;
+                    assert!(v.group.get(4));
+                }
+                FadSubTlv::Flags(v) => {
+                    has_flags = true;
+                    assert!(v.m_flag);
+                }
+                FadSubTlv::ExcludeSrlg(v) => {
+                    has_srlg = true;
+                    assert_eq!(v.srlgs, vec![100]);
+                }
+                _ => panic!("unexpected sub: {sub:?}"),
+            }
+        }
+        assert!(has_excl && has_flags && has_srlg);
+    }
+
+    #[test]
+    fn build_fad_subs_drops_unresolved_affinity_names() {
+        let mut fa = FlexAlgoConfig::new();
+        fa.exec(
+            "/router/isis/flex-algo/advertise-definition".into(),
+            args(&["128", "true"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        fa.exec(
+            "/router/isis/flex-algo/affinity/exclude-any".into(),
+            args(&["128", "ghost"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        fa.commit();
+
+        // Empty affinity map — `ghost` is referenced but not defined.
+        let am = AffinityMap::new();
+        let subs = build_fad_subs(&fa, &am, &BTreeMap::new());
+        assert_eq!(subs.len(), 1);
+        // No ExcludeAg sub-TLV emitted because the bitmap would be
+        // empty — a 0-byte sub-TLV is meaningless on the wire.
+        assert!(subs[0].subs.is_empty(), "got subs: {:?}", subs[0].subs);
     }
 
     #[test]

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -263,6 +263,17 @@ pub struct IsisTop<'a> {
     /// names through this map when emitting TLVs 138 / 139.
     pub srlg_groups: &'a BTreeMap<String, SrlgGroup>,
 
+    /// Read-only access to the Flex-Algorithm definition store. The
+    /// LSP emitter walks the entries with `advertise_definition=true`
+    /// and emits one FAD sub-TLV (RFC 9350 §5.1) per entry inside
+    /// Router Capability TLV 242.
+    pub flex_algo: &'a super::flex_algo::FlexAlgoConfig,
+
+    /// Read-only access to the affinity-map. Used to resolve admin-
+    /// group names referenced by FAD constraint sub-TLVs into the
+    /// 256-bit Extended Admin Group bitmap (RFC 7308).
+    pub affinity_map: &'a super::affinity_map::AffinityMap,
+
     /// Seq-wrap wait timers (see `Isis::lsp_seq_wrap_wait`). Threaded
     /// through so `lsp_generate` can short-circuit per fragment and
     /// arm the timer without round-tripping through the event loop.
@@ -1091,6 +1102,8 @@ impl Isis {
             sr_locator: &self.sr_locator,
             sr_end_sid: &self.sr_end_sid,
             srlg_groups: &self.srlg_groups,
+            flex_algo: &self.flex_algo,
+            affinity_map: &self.affinity_map,
             lsp_seq_wrap_wait: &mut self.lsp_seq_wrap_wait,
             lsp_placement_memory: &mut self.lsp_placement_memory,
             redist_v4: &self.redist_v4,

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -123,6 +123,11 @@ pub fn lsp_cap_view<'a>(tlv: &'a IsisTlvRouterCap) -> LspCapView<'a> {
             cap::IsisSubTlv::Srv6(srv6) => {
                 view.srv6 = Some(srv6);
             }
+            cap::IsisSubTlv::FlexAlgoDef(_) => {
+                // FAD consumers (peer FAD store, SPF gating) land in
+                // a follow-up PR; for now we round-trip the sub-TLV
+                // but don't surface it through the cap view.
+            }
             cap::IsisSubTlv::Unknown(_) => {
                 // Simpply ignore unknown sub tlv.
             }

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -675,6 +675,18 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
             }
         }
 
+        // Flex-Algorithm Definitions (RFC 9350 §5.1). One sub-TLV per
+        // entry the operator marked `advertise-definition true`;
+        // entries without the flag stay purely local (the router
+        // computes for them using a FAD learned from another node).
+        // Per-algo SR Algorithm sub-TLV participation extension and
+        // per-link ASLA admin-group emit land in follow-up PRs.
+        for fad in
+            super::flex_algo::build_fad_subs(top.flex_algo, top.affinity_map, top.srlg_groups)
+        {
+            cap.subs.push(fad.into());
+        }
+
         anchors.push(cap.into());
     }
 


### PR DESCRIPTION
## Summary

First visible-on-wire flex-algo output. For each entry in `isis.flex_algo.config` marked `advertise-definition true`, originate a Flex-Algorithm Definition (FAD) sub-TLV inside Router Capability TLV 242 of the self LSP.

### `isis-packet` codec
- `IsisCapCode::FlexAlgoDef = 26` (RFC 9350 §5.1).
- `IsisSubFlexAlgoDef` with `flex_algorithm` / `metric_type` / `calc_type` / `priority` + nested `FadSubTlv` list.
- 5 nested sub-TLV structs: `ExcludeAg`, `IncludeAnyAg`, `IncludeAllAg` (RFC 9350 §6.1), `Flags` with M-bit (§6.4), `ExcludeSrlg` (§6.2).
- `ExtAdminGroup` wrapper over `Vec<u32>` with `set(bit)` API — RFC 7308 256-bit Extended Admin Group bitmap.
- `FadSubTlv` dispatcher with `parse_subs` / `len` / `emit` mirroring `IsisSubTlv`.
- `IsisSubTlv` extended with `FlexAlgoDef` variant; `lsdb::lsp_cap_view` handles the new variant (no-op until peer-FAD store lands).
- Display impls + 5 round-trip tests covering header-only emit, full FAD with exclude-AG/flags/exclude-SRLG, unknown nested sub-TLV preservation, `ExtAdminGroup` bit-set growth, and Router Capability dispatch.

### `zebra-rs` integration
- `flex_algo::build_fad_subs(fa, am, srlg_groups)` — walks `FlexAlgoConfig.config`, skips entries without `advertise-definition`, resolves affinity names via `AffinityMap::bit()` into `ExtAdminGroup` bitmaps and SRLG names via `srlg_groups` into u32 ids. Unresolved names silently dropped (best-effort emit).
- `flex_algo.rs` + `affinity_map.rs` shim callbacks now send `Message::LspOriginate(L1) + (L2)` after commit — matches the `link::config_srlg` pattern.
- `IsisTop` gains read-only `flex_algo` + `affinity_map` refs.
- `lsp.rs:lsp_generate` pushes FAD sub-TLVs onto `cap.subs` inside the existing Router Capability builder. Gated by `sr_enabled()` via the surrounding block — FAD without any SID space would be inert anyway.

### Deliberately out of scope
- Per-algo SR Algorithm sub-TLV (19) participation extension — receivers can see the FAD but cannot yet tell this router participates.
- Per-link ASLA Extended Admin Group emit on neighbor TLVs.
- Per-algo Prefix-SID sub-TLV emit.
- FAD parse from peer LSPs into a per-peer flex-algo state map.

## Test plan

- [x] `cargo build -p zebra-rs --bin zebra-rs` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p zebra-rs --bin zebra-rs --all-targets -- -D warnings` — clean
- [x] `cargo test -p zebra-rs --bin zebra-rs isis::flex_algo::` — 8 pass (3 new for `build_fad_subs`: skip-without-flag, exclude-AG + SRLG emit, drop-unresolved-affinity)
- [x] `cargo test -p isis-packet --lib sub::cap::` — 7 pass (5 new for FAD codec)
- [ ] End-to-end CLI: config `flex-algo 128 advertise-definition true` + `tcpdump` against a peer (manual, post-merge)

Generated with [Claude Code](https://claude.com/claude-code)