### PR TITLE
bdd: add BGP no-export / no-advertise community test

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -44,6 +44,10 @@ bgp_policy_dynamic_update:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_policy_dynamic_update"
 
+bgp_community_no_export_advertise:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_community_no_export_advertise"
+
 generate:
 	rm -rf allure-report
 	allure generate
@@ -63,4 +67,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation bgp_evpn_capability bgp_route_map_match bgp_policy_dynamic_update generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation bgp_evpn_capability bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE

--- a/bdd/tests/configs/bgp_community_no_export_advertise/z1-1.yaml
+++ b/bdd/tests/configs/bgp_community_no_export_advertise/z1-1.yaml
@@ -1,0 +1,12 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      peer-as: 65002

--- a/bdd/tests/configs/bgp_community_no_export_advertise/z1-2.yaml
+++ b/bdd/tests/configs/bgp_community_no_export_advertise/z1-2.yaml
@@ -1,0 +1,16 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      peer-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 1.1.1.1/32

--- a/bdd/tests/configs/bgp_community_no_export_advertise/z1-3.yaml
+++ b/bdd/tests/configs/bgp_community_no_export_advertise/z1-3.yaml
@@ -1,0 +1,36 @@
+community-set:
+- name: comm-no-export
+  members:
+  - no-export
+prefix-set:
+- name: adv-1111
+  prefixes:
+  - prefix: 1.1.1.1/32
+policy:
+- name: set-no-export
+  entry:
+  - number: 10
+    action: permit
+    match:
+      prefix: adv-1111
+    set:
+      community:
+        name: comm-no-export
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      policy:
+        out: set-no-export
+      enabled: true
+      peer-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 1.1.1.1/32

--- a/bdd/tests/configs/bgp_community_no_export_advertise/z1-4.yaml
+++ b/bdd/tests/configs/bgp_community_no_export_advertise/z1-4.yaml
@@ -1,0 +1,36 @@
+community-set:
+- name: comm-no-advertise
+  members:
+  - no-advertise
+prefix-set:
+- name: adv-1111
+  prefixes:
+  - prefix: 1.1.1.1/32
+policy:
+- name: set-no-advertise
+  entry:
+  - number: 10
+    action: permit
+    match:
+      prefix: adv-1111
+    set:
+      community:
+        name: comm-no-advertise
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      policy:
+        out: set-no-advertise
+      enabled: true
+      peer-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 1.1.1.1/32

--- a/bdd/tests/configs/bgp_community_no_export_advertise/z2-1.yaml
+++ b/bdd/tests/configs/bgp_community_no_export_advertise/z2-1.yaml
@@ -1,0 +1,18 @@
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      peer-as: 65001
+    - remote-address: 192.168.0.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      peer-as: 65002

--- a/bdd/tests/configs/bgp_community_no_export_advertise/z3-1.yaml
+++ b/bdd/tests/configs/bgp_community_no_export_advertise/z3-1.yaml
@@ -1,0 +1,12 @@
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.3
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      peer-as: 65002

--- a/bdd/tests/features/bgp_community_no_export_advertise.feature
+++ b/bdd/tests/features/bgp_community_no_export_advertise.feature
@@ -1,0 +1,100 @@
+@serial
+@bgp_community_no_export_advertise
+Feature: BGP well-known community handling (no-export, no-advertise)
+  As a network operator
+  I want to verify that the well-known communities NO_EXPORT and
+  NO_ADVERTISE are honoured when re-advertising routes across eBGP
+  and iBGP sessions, using a three-router topology.
+
+  Test Topology:
+  ```
+  ┌──────────────────────────────────────────────────────────┐
+  │                          br0                             │
+  └─────────┬──────────────────┬──────────────────┬──────────┘
+            │                  │                  │
+       ┌────┴────┐        ┌────┴────┐        ┌────┴────┐
+       │   z1    │  eBGP  │   z2    │  iBGP  │   z3    │
+       │  (A)    │◀──────▶│  (B)    │◀──────▶│  (C)    │
+       │ AS65001 │        │ AS65002 │        │ AS65002 │
+       │192.168. │        │192.168. │        │192.168. │
+       │  0.1/24 │        │  0.2/24 │        │  0.3/24 │
+       └─────────┘        └─────────┘        └─────────┘
+  ```
+
+  Config files:
+  - z1-1.yaml: A baseline — eBGP peer to B, no network advertised.
+  - z1-2.yaml: A advertises 1.1.1.1/32 with no community attribute.
+  - z1-3.yaml: A advertises 1.1.1.1/32 with community "no-export".
+  - z1-4.yaml: A advertises 1.1.1.1/32 with community "no-advertise".
+  - z2-1.yaml: B — eBGP to A, iBGP to C.
+  - z3-1.yaml: C — iBGP to B only.
+
+  Convergence wait-time rationale:
+  - eBGP MinRouteAdvertisementInterval = 30 s
+    (ADV_TIMER_EBGP_SECS in zebra-rs/src/bgp/update_group.rs)
+  - iBGP MinRouteAdvertisementInterval =  5 s
+    (ADV_TIMER_IBGP_SECS in zebra-rs/src/bgp/update_group.rs)
+  - End-to-end A → B → C propagation: up to 30 + 5 = 35 s.
+  - Each scenario that triggers a fresh advertisement on A waits
+    35 seconds; a session clear before the wait forces an immediate
+    re-flood instead of relying on incremental triggers.
+
+  Scenario: Setup topology and establish BGP sessions
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I create namespace "z3" with IP "192.168.0.3/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I apply config "z3-1.yaml" to namespace "z3"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z2" to "192.168.0.3" should be "Established"
+    And BGP session in "z3" to "192.168.0.2" should be "Established"
+
+  Scenario: A advertises 1.1.1.1/32 with no community — C receives it
+    Given the test topology exists
+    When I apply config "z1-2.yaml" to namespace "z1"
+    And I wait 35 seconds for BGP to operate
+    Then BGP route in "z2" has "1.1.1.1/32"
+    And BGP route in "z3" has "1.1.1.1/32"
+
+  Scenario: A re-advertises 1.1.1.1/32 with community no-export — C still receives it
+    Given the test topology exists
+    When I apply config "z1-3.yaml" to namespace "z1"
+    And I clear namespace "z1" neighbor "192.168.0.2"
+    And I wait 35 seconds for BGP to operate
+    Then BGP route in "z2" has "1.1.1.1/32"
+    And BGP route in "z3" has "1.1.1.1/32"
+
+  Scenario: A re-advertises 1.1.1.1/32 with community no-advertise — C does NOT receive it
+    Given the test topology exists
+    When I apply config "z1-4.yaml" to namespace "z1"
+    And I clear namespace "z1" neighbor "192.168.0.2"
+    And I wait 35 seconds for BGP to operate
+    Then BGP route in "z2" has "1.1.1.1/32"
+    And BGP route in "z3" does not have "1.1.1.1/32"
+
+  Scenario: A reverts to plain advertisement — C receives it again
+    Given the test topology exists
+    When I apply config "z1-2.yaml" to namespace "z1"
+    And I clear namespace "z1" neighbor "192.168.0.2"
+    And I wait 35 seconds for BGP to operate
+    Then BGP route in "z2" has "1.1.1.1/32"
+    And BGP route in "z3" has "1.1.1.1/32"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete bridge "br0"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary
- Adds a three-router BDD feature (`bgp_community_no_export_advertise`) covering the NO_EXPORT and NO_ADVERTISE well-known communities.
- Topology: `A (z1, AS65001) ─eBGP─ B (z2, AS65002) ─iBGP─ C (z3, AS65002)`, all on `br0` / `192.168.0.0/24`.
- Scenarios: baseline plain advertisement, NO_EXPORT re-advertisement (expect C still has the route since B→C is iBGP), NO_ADVERTISE re-advertisement (expect C does NOT have it), revert to plain, plus setup/teardown.
- Wait time = **35 s** per advertise step, derived from `ADV_TIMER_EBGP_SECS = 30` + `ADV_TIMER_IBGP_SECS = 5` in `zebra-rs/src/bgp/update_group.rs`.
- Each re-advertisement uses `clear neighbor` to force a fresh flood rather than waiting on the incremental trigger.

Heads-up: `is_no_export()` exists in `crates/bgp-packet/src/attrs/com.rs` but is not currently consulted on the outbound UPDATE path in `zebra-rs/src/bgp/`. The NO_EXPORT and NO_ADVERTISE scenarios will likely fail today — which is the gap this test is meant to surface.

## Test plan
- [ ] `cd bdd && make bgp_community_no_export_advertise`
- [ ] Confirm scenarios 1 (setup), 2 (plain), 5 (revert), 6 (teardown) pass.
- [ ] Confirm scenarios 3 (no-export) and 4 (no-advertise) fail in the expected direction (C receives the route despite the community), documenting the missing outbound filter.

Generated with [Claude Code](https://claude.com/claude-code)