### PR TITLE
isis: advertise flex-algo participation in SR Algorithm sub-TLV

### DIFF
--- a/zebra-rs/src/isis/flex_algo.rs
+++ b/zebra-rs/src/isis/flex_algo.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use anyhow::{Context, Result, bail};
 use isis_packet::{
-    ExtAdminGroup, FadSubTlv, IsisSubFadExcludeAg, IsisSubFadExcludeSrlg, IsisSubFadFlags,
+    Algo, ExtAdminGroup, FadSubTlv, IsisSubFadExcludeAg, IsisSubFadExcludeSrlg, IsisSubFadFlags,
     IsisSubFadIncludeAllAg, IsisSubFadIncludeAnyAg, IsisSubFlexAlgoDef,
 };
 
@@ -116,6 +116,25 @@ impl FlexAlgoConfig {
             }
         }
     }
+}
+
+/// Algorithms this router advertises in the SR Algorithm sub-TLV
+/// (RFC 8667 §3.2, sub-TLV 19). `Algo::Spf` (algo 0) is always
+/// present; every flex-algo entry in `fa.config` is added as
+/// `Algo::FlexAlgo(N)` in sorted order.
+///
+/// Required by RFC 9350 §5.2: a router that originates a FAD or
+/// participates in a flex-algo MUST list that algo here. The
+/// configuration model treats *any* entry in `flex_algo.config` as
+/// participation — `advertise_definition` controls FAD origination,
+/// not participation.
+pub fn sr_algorithms(fa: &FlexAlgoConfig) -> Vec<Algo> {
+    let mut algos = Vec::with_capacity(1 + fa.config.len());
+    algos.push(Algo::Spf);
+    for &n in fa.config.keys() {
+        algos.push(Algo::FlexAlgo(n));
+    }
+    algos
 }
 
 /// Build the FAD sub-TLVs (RFC 9350 §5.1) this router will originate
@@ -596,6 +615,32 @@ mod tests {
         .unwrap();
         fa.commit();
         assert!(!fa.config.contains_key(&128));
+    }
+
+    #[test]
+    fn sr_algorithms_lists_spf_plus_every_configured_algo() {
+        let mut fa = FlexAlgoConfig::new();
+        // No flex-algos yet — should yield exactly Algo::Spf.
+        assert_eq!(sr_algorithms(&fa), vec![Algo::Spf]);
+
+        // Add two flex-algos via any leaf write (priority is fine —
+        // participation is implied by the entry existing, not by
+        // advertise_definition).
+        for algo in ["129", "128"] {
+            fa.exec(
+                "/router/isis/flex-algo/priority".into(),
+                args(&[algo, "200"]),
+                ConfigOp::Set,
+            )
+            .unwrap();
+            fa.commit();
+        }
+        // BTreeMap iterates sorted, so flex-algos appear in 128, 129
+        // order after Spf.
+        assert_eq!(
+            sr_algorithms(&fa),
+            vec![Algo::Spf, Algo::FlexAlgo(128), Algo::FlexAlgo(129)]
+        );
     }
 
     #[test]

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -639,9 +639,11 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
                 cap.subs.push(sr_cap.into());
             }
 
-            // Sub: SR Algorithms
+            // Sub: SR Algorithms — Algo::Spf plus every flex-algo
+            // we participate in (RFC 9350 §5.2 requires participants
+            // to advertise here, not just FAD originators).
             let algo = IsisSubSegmentRoutingAlgo {
-                algo: vec![Algo::Spf],
+                algo: super::flex_algo::sr_algorithms(top.flex_algo),
             };
             cap.subs.push(algo.into());
 
@@ -669,7 +671,7 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
             // we still need to advertise the algorithm list once.
             if !top.config.sr_mpls_enabled {
                 let algo = IsisSubSegmentRoutingAlgo {
-                    algo: vec![Algo::Spf],
+                    algo: super::flex_algo::sr_algorithms(top.flex_algo),
                 };
                 cap.subs.push(algo.into());
             }


### PR DESCRIPTION
## Summary

Closes the RFC 9350 §5.2 conformance gap left by PR #610. A router that originates a FAD or participates in a flex-algo MUST list the algo in the SR Algorithm sub-TLV (RFC 8667 §3.2, sub-TLV 19); without it, peers see the FAD on the wire but can't tell this router actually participates.

- `flex_algo::sr_algorithms(fa)` — returns `Algo::Spf` followed by every algo in `fa.config.keys()` as `Algo::FlexAlgo(N)`, in sorted order.
- `lsp.rs` — both SR Algorithm sub-TLV emit sites (SR-MPLS path + SRv6-only path) now call `sr_algorithms(top.flex_algo)` instead of hard-coding `vec![Algo::Spf]`.

**Semantic note:** participation is implied by an entry existing in `flex_algo.config`. `advertise_definition` is orthogonal — it controls FAD origination, not participation. A router can participate (and need per-algo SIDs installed) without originating the FAD itself.

## Test plan

- [x] `cargo build -p zebra-rs --bin zebra-rs` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p zebra-rs --bin zebra-rs --all-targets -- -D warnings` — clean
- [x] `cargo test -p zebra-rs --bin zebra-rs isis::flex_algo::` — 9 pass (1 new: empty config → `[Spf]`, two flex-algos added → `[Spf, FlexAlgo(128), FlexAlgo(129)]`)
- [ ] End-to-end CLI: `tcpdump` shows SR Algorithm sub-TLV listing the configured flex-algos (manual, post-merge)

Generated with [Claude Code](https://claude.com/claude-code)