### PR TITLE
isis: emit per-link ASLA Extended Admin Group for flex-algo

### DIFF
--- a/zebra-rs/src/isis/flex_algo.rs
+++ b/zebra-rs/src/isis/flex_algo.rs
@@ -2,9 +2,11 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr;
 
 use anyhow::{Context, Result, bail};
+use isis_packet::neigh::IsisSubTlv as NeighSubTlv;
 use isis_packet::{
-    Algo, ExtAdminGroup, FadSubTlv, IsisSubFadExcludeAg, IsisSubFadExcludeSrlg, IsisSubFadFlags,
-    IsisSubFadIncludeAllAg, IsisSubFadIncludeAnyAg, IsisSubFlexAlgoDef,
+    Algo, ExtAdminGroup, FadSubTlv, IsisSubAdminGrp, IsisSubAsla, IsisSubFadExcludeAg,
+    IsisSubFadExcludeSrlg, IsisSubFadFlags, IsisSubFadIncludeAllAg, IsisSubFadIncludeAnyAg,
+    IsisSubFlexAlgoDef,
 };
 
 use crate::config::{Args, ConfigOp};
@@ -116,6 +118,52 @@ impl FlexAlgoConfig {
             }
         }
     }
+}
+
+/// SABM byte (RFC 9479 §4.2) with the Flex-Algorithm (X-bit) set.
+/// Bit layout in the first SABM byte, MSB-first: R(7) S(6) F(5) X(4)
+/// reserved(3..0). Used as the Selective Application-specific
+/// Attribute Bitmap on a per-link ASLA sub-TLV so receivers know
+/// these link attributes apply to flex-algo path computation.
+const SABM_FLEX_ALGO: u8 = 0x10;
+
+/// Build the per-link Extended Admin Group bitmap from a set of
+/// affinity names by resolving each name to its bit position via the
+/// affinity-map and packing the bits into RFC 7308 32-bit words.
+/// Names with no matching `/router/isis/affinity-map/affinity` entry
+/// are silently dropped (best-effort emit, matches `build_fad_subs`).
+fn link_admin_group_words(affinity: &BTreeSet<String>, am: &AffinityMap) -> Vec<u32> {
+    let mut g = ExtAdminGroup::default();
+    for name in affinity {
+        if let Some(bit) = am.bit(name) {
+            g.set(bit);
+        }
+    }
+    g.words
+}
+
+/// Build a per-link ASLA sub-TLV (RFC 9479) carrying the link's
+/// affinity (Extended Admin Group, RFC 7308) for the Flex-Algorithm
+/// application. Returns `None` when no affinity bits resolved — a
+/// zero-byte AdminGrp inside an ASLA would be a meaningless wire
+/// artifact.
+///
+/// SABM is set to a single byte with only the X-bit (Flex-Algorithm,
+/// 0x10) — these link attributes apply to flex-algo SPF only. The
+/// L-flag stays cleared (modern non-legacy interpretation per
+/// RFC 9479 §4.2). UDABM is left empty: every receiver that
+/// understands ASLA understands Flex-Algorithm.
+pub fn build_link_asla(affinity: &BTreeSet<String>, am: &AffinityMap) -> Option<IsisSubAsla> {
+    let words = link_admin_group_words(affinity, am);
+    if words.is_empty() {
+        return None;
+    }
+    Some(IsisSubAsla {
+        l_flag: false,
+        sabm: vec![SABM_FLEX_ALGO],
+        udabm: Vec::new(),
+        subs: vec![NeighSubTlv::AdminGrp(IsisSubAdminGrp { groups: words })],
+    })
 }
 
 /// Algorithms this router advertises in the SR Algorithm sub-TLV
@@ -615,6 +663,82 @@ mod tests {
         .unwrap();
         fa.commit();
         assert!(!fa.config.contains_key(&128));
+    }
+
+    fn affinity_set(names: &[&str]) -> BTreeSet<String> {
+        names.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn build_link_asla_returns_none_for_empty_affinity() {
+        let am = AffinityMap::new();
+        assert!(build_link_asla(&BTreeSet::new(), &am).is_none());
+    }
+
+    #[test]
+    fn build_link_asla_returns_none_when_all_names_unresolved() {
+        let am = AffinityMap::new();
+        // `blue` is referenced but the affinity-map is empty.
+        assert!(build_link_asla(&affinity_set(&["blue"]), &am).is_none());
+    }
+
+    #[test]
+    fn build_link_asla_emits_sabm_flex_algo_and_admin_grp() {
+        let mut am = AffinityMap::new();
+        for (name, bit) in [("blue", "0"), ("low-lat", "4"), ("red", "31")] {
+            am.exec(
+                "/router/isis/affinity-map/affinity/bit-position".into(),
+                args(&[name, bit]),
+                ConfigOp::Set,
+            )
+            .unwrap();
+            am.commit();
+        }
+        let asla = build_link_asla(&affinity_set(&["blue", "low-lat", "red"]), &am)
+            .expect("ASLA expected");
+        // L-flag clear, SABM = [0x10] (X-bit only), UDABM empty.
+        assert!(!asla.l_flag);
+        assert_eq!(asla.sabm, vec![SABM_FLEX_ALGO]);
+        assert!(asla.udabm.is_empty());
+        // One nested sub-TLV: AdminGrp with bits 0, 4, 31 packed into
+        // the first 32-bit word.
+        assert_eq!(asla.subs.len(), 1);
+        match &asla.subs[0] {
+            NeighSubTlv::AdminGrp(ag) => {
+                assert_eq!(ag.groups.len(), 1);
+                let w = ag.groups[0];
+                assert!(w & (1 << 0) != 0, "bit 0 (blue) missing");
+                assert!(w & (1 << 4) != 0, "bit 4 (low-lat) missing");
+                assert!(w & (1 << 31) != 0, "bit 31 (red) missing");
+                // No unexpected bits.
+                let expected = (1u32 << 0) | (1u32 << 4) | (1u32 << 31);
+                assert_eq!(w, expected);
+            }
+            other => panic!("expected AdminGrp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_link_asla_grows_bitmap_to_multiple_words() {
+        let mut am = AffinityMap::new();
+        for (name, bit) in [("a", "0"), ("b", "32"), ("c", "200")] {
+            am.exec(
+                "/router/isis/affinity-map/affinity/bit-position".into(),
+                args(&[name, bit]),
+                ConfigOp::Set,
+            )
+            .unwrap();
+            am.commit();
+        }
+        let asla = build_link_asla(&affinity_set(&["a", "b", "c"]), &am).expect("ASLA");
+        match &asla.subs[0] {
+            NeighSubTlv::AdminGrp(ag) => {
+                // bit 200 lives in word 6 (200/32=6), so we need
+                // at least 7 words.
+                assert_eq!(ag.groups.len(), 7);
+            }
+            _ => panic!("expected AdminGrp"),
+        }
     }
 
     #[test]

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -803,6 +803,17 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
             metric: link.config.metric(),
             subs: Vec::new(),
         };
+        // Per-link ASLA sub-TLV (RFC 9479) with the Extended Admin
+        // Group bitmap for flex-algo path computation. Only emitted
+        // when at least one affinity name resolves — receivers can
+        // intersect this bitmap with any FAD's
+        // include-any/include-all/exclude-any constraint sub-TLV to
+        // decide whether the link is in the algorithm's topology.
+        if let Some(asla) =
+            super::flex_algo::build_link_asla(&link.config.affinity, top.affinity_map)
+        {
+            is_reach.subs.push(neigh::IsisSubTlv::Asla(asla));
+        }
         // Neighbor
         for (_, nbr) in link.state.nbrs.get(&level).iter() {
             for (_key, value) in nbr.addr4.iter() {
@@ -981,6 +992,14 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
                 metric,
                 subs: Vec::new(),
             };
+            // Per-link ASLA carries the same affinity bitmap on the
+            // MT IS-reach entry as on the legacy TLV 22 entry —
+            // affinities are MT-agnostic in the YANG model.
+            if let Some(asla) =
+                super::flex_algo::build_link_asla(&link.config.affinity, top.affinity_map)
+            {
+                entry.subs.push(neigh::IsisSubTlv::Asla(asla));
+            }
             for (_, nbr) in link.state.nbrs.get(&level).iter() {
                 if let Some((_, sid_addr)) = nbr.endx_sid {
                     if nbr.network_type.is_p2p() {


### PR DESCRIPTION
## Summary

Closes the per-link half of the flex-algo wire story: PRs #610 / #612 originate FAD definitions and SR Algorithm participation, but until now our Extended IS-Reach (TLV 22) and MT IS-Reach (TLV 222) neighbor entries carried no affinity information, so a peer with our FAD couldn't decide which of our links satisfy its include-any / include-all / exclude-any constraints.

- `SABM_FLEX_ALGO = 0x10` — RFC 9479 §4.2 first-byte SABM layout `R(7) S(6) F(5) X(4)`; X is the Flex-Algorithm application bit.
- `flex_algo::link_admin_group_words(affinity, am)` — resolves each affinity name to its bit position via `Isis::affinity_map`, packs the union into RFC 7308 32-bit words via `ExtAdminGroup::set`. Names with no matching entry are silently dropped (matches `build_fad_subs` policy).
- `flex_algo::build_link_asla(affinity, am)` — wraps the resolved bitmap in `IsisSubAsla` with `SABM=[0x10]`, L-flag clear, UDABM empty, and one nested `IsisSubAdminGrp` (sub-TLV 14). Returns `None` when nothing resolved.
- `lsp.rs` — both Ext IS-Reach (TLV 22, ~line 800) and MT IS-Reach (TLV 222, ~line 990) builders push the resulting Asla sub-TLV onto each link's neighbor entry. Affinity is MT-agnostic in the YANG schema, so the same bytes go on both topologies.

### Deliberately out of scope (follow-up PRs)
- Per-algo Prefix-SID sub-TLV emit.
- Per-algo SRv6 Locator TLV 27 emit.
- Consume side: ASLA parse + per-peer admin-group store, FAD parse, SPF gating, per-algo RIB install.

## Test plan

- [x] `cargo build -p zebra-rs --bin zebra-rs` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p zebra-rs --bin zebra-rs --all-targets -- -D warnings` — clean
- [x] `cargo test -p zebra-rs --bin zebra-rs isis::flex_algo::` — 13 pass (4 new on `build_link_asla`: empty → None, all-unresolved → None, three bits packed into one word, bit-200 growth to 7 words)
- [ ] End-to-end CLI: `tcpdump` shows ASLA sub-TLV with SABM 0x10 + AdminGrp on IS-reach entries for links with configured affinity (manual, post-merge)

Generated with [Claude Code](https://claude.com/claude-code)