### PR TITLE
isis: emit per-algorithm Prefix-SID for SR-MPLS flex-algo

### DIFF
--- a/zebra-rs/src/isis/flex_algo.rs
+++ b/zebra-rs/src/isis/flex_algo.rs
@@ -6,7 +6,7 @@ use isis_packet::neigh::IsisSubTlv as NeighSubTlv;
 use isis_packet::{
     Algo, ExtAdminGroup, FadSubTlv, IsisSubAdminGrp, IsisSubAsla, IsisSubFadExcludeAg,
     IsisSubFadExcludeSrlg, IsisSubFadFlags, IsisSubFadIncludeAllAg, IsisSubFadIncludeAnyAg,
-    IsisSubFlexAlgoDef,
+    IsisSubFlexAlgoDef, IsisSubPrefixSid, SidLabelValue,
 };
 
 use crate::config::{Args, ConfigOp};
@@ -164,6 +164,22 @@ pub fn build_link_asla(affinity: &BTreeSet<String>, am: &AffinityMap) -> Option<
         udabm: Vec::new(),
         subs: vec![NeighSubTlv::AdminGrp(IsisSubAdminGrp { groups: words })],
     })
+}
+
+/// Build the per-algorithm Prefix-SID sub-TLVs (RFC 8667 §2.1 +
+/// RFC 9350 §7) to attach to one prefix's IP-reach entry. Each map
+/// entry produces one additional Prefix-SID sub-TLV with the
+/// Algorithm field set to the flex-algo id. Iteration order matches
+/// the BTreeMap (ascending algo id) so the wire byte sequence is
+/// deterministic.
+pub fn build_per_algo_prefix_sids(map: &BTreeMap<u8, SidLabelValue>) -> Vec<IsisSubPrefixSid> {
+    map.iter()
+        .map(|(&algo, sid)| IsisSubPrefixSid {
+            flags: 0.into(),
+            algo: Algo::FlexAlgo(algo),
+            sid: sid.clone(),
+        })
+        .collect()
 }
 
 /// Algorithms this router advertises in the SR Algorithm sub-TLV
@@ -663,6 +679,36 @@ mod tests {
         .unwrap();
         fa.commit();
         assert!(!fa.config.contains_key(&128));
+    }
+
+    #[test]
+    fn build_per_algo_prefix_sids_empty_map_yields_empty_vec() {
+        let map: BTreeMap<u8, SidLabelValue> = BTreeMap::new();
+        assert!(build_per_algo_prefix_sids(&map).is_empty());
+    }
+
+    #[test]
+    fn build_per_algo_prefix_sids_emits_one_per_algo_in_sorted_order() {
+        let mut map: BTreeMap<u8, SidLabelValue> = BTreeMap::new();
+        map.insert(129, SidLabelValue::Index(1129));
+        map.insert(128, SidLabelValue::Index(1128));
+        let sids = build_per_algo_prefix_sids(&map);
+        assert_eq!(sids.len(), 2);
+        // BTreeMap iterates ascending → algo 128 first, 129 second.
+        assert_eq!(sids[0].algo, Algo::FlexAlgo(128));
+        assert_eq!(sids[0].sid, SidLabelValue::Index(1128));
+        assert_eq!(sids[1].algo, Algo::FlexAlgo(129));
+        assert_eq!(sids[1].sid, SidLabelValue::Index(1129));
+    }
+
+    #[test]
+    fn build_per_algo_prefix_sids_preserves_label_vs_index_form() {
+        let mut map: BTreeMap<u8, SidLabelValue> = BTreeMap::new();
+        map.insert(128, SidLabelValue::Index(42));
+        map.insert(129, SidLabelValue::Label(20128));
+        let sids = build_per_algo_prefix_sids(&map);
+        assert_eq!(sids[0].sid, SidLabelValue::Index(42));
+        assert_eq!(sids[1].sid, SidLabelValue::Label(20128));
     }
 
     fn affinity_set(names: &[&str]) -> BTreeSet<String> {

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -1054,9 +1054,19 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
                     } else {
                         None
                     };
+                    // Per-algo Prefix-SID sub-TLVs (RFC 8667 §2.1 +
+                    // RFC 9350 §7). One additional Prefix-SID per
+                    // configured algo with Algorithm=N, attached to
+                    // the same IP-reach entry as the algo-0 SID so a
+                    // receiver can resolve any of {0, N1, N2, ...}
+                    // for this prefix from a single TLV.
+                    let per_algo_sids = super::flex_algo::build_per_algo_prefix_sids(
+                        &link.config.ipv4_flex_algo_prefix_sids,
+                    );
+                    let has_subs = sub_tlv.is_some() || !per_algo_sids.is_empty();
                     let flags = Ipv4ControlInfo::new()
                         .with_prefixlen(prefix.prefix_len() as usize)
-                        .with_sub_tlv(sub_tlv.is_some())
+                        .with_sub_tlv(has_subs)
                         .with_distribution(false);
                     let mut entry = IsisTlvExtIpReachEntry {
                         metric: 10,
@@ -1066,6 +1076,9 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
                     };
                     if let Some(sub_tlv) = sub_tlv {
                         entry.subs.push(sub_tlv);
+                    }
+                    for sid in per_algo_sids {
+                        entry.subs.push(prefix::IsisSubTlv::PrefixSid(sid));
                     }
                     ext_ip_reach.entries.push(entry);
                 }


### PR DESCRIPTION
## Summary

Closes the SR-MPLS produce side. PRs #610 / #612 / #613 advertise FAD definitions, SR Algorithm participation, and the per-link ASLA Extended Admin Group bitmap, but the matching Prefix-SID labels were only being emitted for algo-0. Without per-algo Prefix-SIDs on the loopback IP-reach entry, a receiver computing flex-algo SPF would have no label to install in the MPLS dataplane.

- `flex_algo::build_per_algo_prefix_sids(map)` — iterates `LinkConfig::ipv4_flex_algo_prefix_sids` (populated by PR #609's per-interface callbacks) and returns one `IsisSubPrefixSid` per entry with `algo: Algo::FlexAlgo(N)`. BTreeMap iteration gives deterministic ascending-algo wire byte order. Index- and Label-form `SidLabelValue` are preserved.
- `lsp.rs` IPv4 IP-reach builder (~line 1047) — pushes per-algo sub-TLVs onto the loopback entry alongside the algo-0 SID. The `has_subs` flag is now `algo-0 OR per-algo`, so a router with only flex-algo SIDs (no algo-0) still gets `S=1` set on the Ipv4ControlInfo byte.

### Deliberately out of scope
- Per-algo SRv6 Locator TLV 27 emit (last produce-side PR).
- IPv6 per-algo Prefix-SID — YANG only models `ipv4/flex-algo-prefix-sid` today; the symmetric `ipv6/prefix-sid` is also absent.
- Consume side: ASLA parse, FAD parse, SPF gating, per-algo RIB install.

## Test plan

- [x] `cargo build -p zebra-rs --bin zebra-rs` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p zebra-rs --bin zebra-rs --all-targets -- -D warnings` — clean
- [x] `cargo test -p zebra-rs --bin zebra-rs isis::flex_algo::` — 16 pass (3 new on `build_per_algo_prefix_sids`: empty map → empty vec, two algos sorted, Index/Label preservation)
- [ ] End-to-end CLI: `tcpdump` shows multiple Prefix-SID sub-TLVs on a single IP-reach entry, one per configured algo (manual, post-merge)

Generated with [Claude Code](https://claude.com/claude-code)