### PR TITLE
isis: parse peer FAD sub-TLVs into Isis::peer_fad

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -96,6 +96,14 @@ pub struct Isis {
     /// (parallel to label_map for SR-MPLS). Used by TI-LFA Step 4d to
     /// assemble the SRH segment list for a 1-segment repair.
     pub srv6_end_map: Levels<BTreeMap<IsisSysId, Ipv6Addr>>,
+
+    /// Per-peer Flex-Algorithm Definition store. Outer key is peer
+    /// sys-id; inner key is the algo identifier (128..=255). Populated
+    /// from peer LSP fragment 0 Router Capability TLV by
+    /// `lsdb::rebuild_sys_state`. Consumers (future SPF gating,
+    /// `show isis flex-algo`) read from here instead of re-walking
+    /// the LSDB. Cleared on peer purge.
+    pub peer_fad: Levels<BTreeMap<IsisSysId, BTreeMap<u8, isis_packet::IsisSubFlexAlgoDef>>>,
     pub rib: Levels<PrefixMap<Ipv4Net, SpfRoute>>,
     pub rib_v6: Levels<PrefixMap<Ipv6Net, SpfRouteV6>>,
     pub ilm: Levels<BTreeMap<u32, SpfIlm>>,
@@ -238,6 +246,11 @@ pub struct IsisTop<'a> {
     pub mt_membership: &'a mut Levels<BTreeMap<IsisSysId, BTreeSet<MtId>>>,
     pub label_map: &'a mut Levels<IsisLabelMap>,
     pub srv6_end_map: &'a mut Levels<BTreeMap<IsisSysId, Ipv6Addr>>,
+    /// Per-peer FAD store (see `Isis::peer_fad`). Threaded through
+    /// IsisTop so the LSDB rebuild path can populate it from peer
+    /// Router Capability TLVs.
+    pub peer_fad:
+        &'a mut Levels<BTreeMap<IsisSysId, BTreeMap<u8, isis_packet::IsisSubFlexAlgoDef>>>,
     pub rib: &'a mut Levels<PrefixMap<Ipv4Net, SpfRoute>>,
     pub rib_v6: &'a mut Levels<PrefixMap<Ipv6Net, SpfRouteV6>>,
     pub ilm: &'a mut Levels<BTreeMap<u32, SpfIlm>>,
@@ -315,65 +328,69 @@ impl Isis {
 
         let (tx, rx) = mpsc::unbounded_channel();
         let (bfd_event_tx, bfd_event_rx) = mpsc::unbounded_channel();
-        let mut isis = Self {
-            tx,
-            rx,
-            cm: ConfigChannel::new(),
-            callbacks: HashMap::new(),
-            rib_rx: chan.rx,
-            rib_tx,
-            links: IsisLinks::default(),
-            show: ShowChannel::new(),
-            show_cb: HashMap::new(),
-            config: IsisConfig::default(),
-            flex_algo: super::flex_algo::FlexAlgoConfig::new(),
-            affinity_map: super::affinity_map::AffinityMap::new(),
-            tracing: IsisTracing::default(),
-            lsdb: Levels::<Lsdb>::default(),
-            lsp_map: Levels::<LspMap>::default(),
-            reach_map: Levels::<Afis<ReachMap>>::default(),
-            reach_map_v6: Levels::<ReachMapV6>::default(),
-            mt2_reach_map_v6: Levels::<ReachMapV6>::default(),
-            mt_membership: Levels::<BTreeMap<IsisSysId, BTreeSet<MtId>>>::default(),
-            label_map: Levels::<IsisLabelMap>::default(),
-            srv6_end_map: Levels::<BTreeMap<IsisSysId, Ipv6Addr>>::default(),
-            rib: Levels::<PrefixMap<Ipv4Net, SpfRoute>>::default(),
-            rib_v6: Levels::<PrefixMap<Ipv6Net, SpfRouteV6>>::default(),
-            ilm: Levels::<BTreeMap<u32, SpfIlm>>::default(),
-            hostname: Levels::<Hostname>::default(),
-            spf_timer: Levels::<Option<Timer>>::default(),
-            spf_throttle: Levels::<Throttle>::default(),
-            lsp_gen_timer: Levels::<Option<Timer>>::default(),
-            lsp_gen_throttle: Levels::<Throttle>::default(),
-            lsp_gen_pending_floor: Levels::<Option<u32>>::default(),
-            // Adjacency-SID label pool is owned by the SR-MPLS feature.
-            // Stays None until `segment-routing mpls` is configured —
-            // otherwise we'd allocate labels for every hello and emit
-            // LanAdjSid sub-TLVs that turn into MPLS ILM installs the
-            // kernel rejects (EOPNOTSUPP) on hosts without an MPLS path.
-            local_pool: None,
-            graph: Levels::<Option<spf::Graph>>::default(),
-            spf_result: Levels::<Option<BTreeMap<usize, spf::Path>>>::default(),
-            tilfa_result: Levels::<Option<BTreeMap<usize, Vec<spf::RepairPath>>>>::default(),
-            mt2_graph: Levels::<Option<spf::Graph>>::default(),
-            mt2_spf_result: Levels::<Option<BTreeMap<usize, spf::Path>>>::default(),
-            sr_rx,
-            watched_block: None,
-            watched_locator: None,
-            sr_block: None,
-            sr_locator: None,
-            sr_end_sid: None,
-            elib: super::srv6::ElibPool::new(),
-            lsp_seq_wrap_wait: Levels::<BTreeMap<u8, Timer>>::default(),
-            lsp_placement_memory: Levels::<BTreeMap<TlvKey, u8>>::default(),
-            redist_v4: BTreeMap::new(),
-            redist_v6: BTreeMap::new(),
-            srlg_config: SrlgGroupBuilder::new(),
-            srlg_groups: BTreeMap::new(),
-            bfd_client_tx,
-            bfd_event_tx,
-            bfd_event_rx,
-        };
+        let mut isis =
+            Self {
+                tx,
+                rx,
+                cm: ConfigChannel::new(),
+                callbacks: HashMap::new(),
+                rib_rx: chan.rx,
+                rib_tx,
+                links: IsisLinks::default(),
+                show: ShowChannel::new(),
+                show_cb: HashMap::new(),
+                config: IsisConfig::default(),
+                flex_algo: super::flex_algo::FlexAlgoConfig::new(),
+                affinity_map: super::affinity_map::AffinityMap::new(),
+                tracing: IsisTracing::default(),
+                lsdb: Levels::<Lsdb>::default(),
+                lsp_map: Levels::<LspMap>::default(),
+                reach_map: Levels::<Afis<ReachMap>>::default(),
+                reach_map_v6: Levels::<ReachMapV6>::default(),
+                mt2_reach_map_v6: Levels::<ReachMapV6>::default(),
+                mt_membership: Levels::<BTreeMap<IsisSysId, BTreeSet<MtId>>>::default(),
+                label_map: Levels::<IsisLabelMap>::default(),
+                srv6_end_map: Levels::<BTreeMap<IsisSysId, Ipv6Addr>>::default(),
+                peer_fad: Levels::<
+                    BTreeMap<IsisSysId, BTreeMap<u8, isis_packet::IsisSubFlexAlgoDef>>,
+                >::default(),
+                rib: Levels::<PrefixMap<Ipv4Net, SpfRoute>>::default(),
+                rib_v6: Levels::<PrefixMap<Ipv6Net, SpfRouteV6>>::default(),
+                ilm: Levels::<BTreeMap<u32, SpfIlm>>::default(),
+                hostname: Levels::<Hostname>::default(),
+                spf_timer: Levels::<Option<Timer>>::default(),
+                spf_throttle: Levels::<Throttle>::default(),
+                lsp_gen_timer: Levels::<Option<Timer>>::default(),
+                lsp_gen_throttle: Levels::<Throttle>::default(),
+                lsp_gen_pending_floor: Levels::<Option<u32>>::default(),
+                // Adjacency-SID label pool is owned by the SR-MPLS feature.
+                // Stays None until `segment-routing mpls` is configured —
+                // otherwise we'd allocate labels for every hello and emit
+                // LanAdjSid sub-TLVs that turn into MPLS ILM installs the
+                // kernel rejects (EOPNOTSUPP) on hosts without an MPLS path.
+                local_pool: None,
+                graph: Levels::<Option<spf::Graph>>::default(),
+                spf_result: Levels::<Option<BTreeMap<usize, spf::Path>>>::default(),
+                tilfa_result: Levels::<Option<BTreeMap<usize, Vec<spf::RepairPath>>>>::default(),
+                mt2_graph: Levels::<Option<spf::Graph>>::default(),
+                mt2_spf_result: Levels::<Option<BTreeMap<usize, spf::Path>>>::default(),
+                sr_rx,
+                watched_block: None,
+                watched_locator: None,
+                sr_block: None,
+                sr_locator: None,
+                sr_end_sid: None,
+                elib: super::srv6::ElibPool::new(),
+                lsp_seq_wrap_wait: Levels::<BTreeMap<u8, Timer>>::default(),
+                lsp_placement_memory: Levels::<BTreeMap<TlvKey, u8>>::default(),
+                redist_v4: BTreeMap::new(),
+                redist_v6: BTreeMap::new(),
+                srlg_config: SrlgGroupBuilder::new(),
+                srlg_groups: BTreeMap::new(),
+                bfd_client_tx,
+                bfd_event_tx,
+                bfd_event_rx,
+            };
         isis.callback_build();
         isis.show_build();
         isis
@@ -1086,6 +1103,7 @@ impl Isis {
             mt_membership: &mut self.mt_membership,
             label_map: &mut self.label_map,
             srv6_end_map: &mut self.srv6_end_map,
+            peer_fad: &mut self.peer_fad,
             rib: &mut self.rib,
             rib_v6: &mut self.rib_v6,
             ilm: &mut self.ilm,
@@ -1131,6 +1149,7 @@ impl Isis {
             mt_membership: &mut self.mt_membership,
             label_map: &mut self.label_map,
             srv6_end_map: &mut self.srv6_end_map,
+            peer_fad: &mut self.peer_fad,
             spf_timer: &mut self.spf_timer,
             spf_throttle: &mut self.spf_throttle,
             rib_tx: &self.rib_tx,

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -134,6 +134,12 @@ pub struct LinkTop<'a> {
         &'a mut Levels<std::collections::BTreeMap<IsisSysId, std::collections::BTreeSet<MtId>>>,
     pub label_map: &'a mut Levels<IsisLabelMap>,
     pub srv6_end_map: &'a mut Levels<std::collections::BTreeMap<IsisSysId, std::net::Ipv6Addr>>,
+    pub peer_fad: &'a mut Levels<
+        std::collections::BTreeMap<
+            IsisSysId,
+            std::collections::BTreeMap<u8, isis_packet::IsisSubFlexAlgoDef>,
+        >,
+    >,
     pub spf_timer: &'a mut Levels<Option<Timer>>,
     pub spf_throttle: &'a mut Levels<super::throttle::Throttle>,
 

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -123,10 +123,8 @@ pub fn lsp_cap_view<'a>(tlv: &'a IsisTlvRouterCap) -> LspCapView<'a> {
             cap::IsisSubTlv::Srv6(srv6) => {
                 view.srv6 = Some(srv6);
             }
-            cap::IsisSubTlv::FlexAlgoDef(_) => {
-                // FAD consumers (peer FAD store, SPF gating) land in
-                // a follow-up PR; for now we round-trip the sub-TLV
-                // but don't surface it through the cap view.
+            cap::IsisSubTlv::FlexAlgoDef(fad) => {
+                view.fads.push(fad);
             }
             cap::IsisSubTlv::Unknown(_) => {
                 // Simpply ignore unknown sub tlv.
@@ -143,6 +141,10 @@ pub struct LspCapView<'a> {
     pub lb: Option<&'a IsisSubSegmentRoutingLB>,
     pub sid_depth: Option<&'a IsisSubNodeMaxSidDepth>,
     pub srv6: Option<&'a IsisSubSrv6>,
+    /// Flex-Algorithm Definitions (RFC 9350 §5.1) advertised by this
+    /// peer. One entry per FAD sub-TLV; multiple FADs for distinct
+    /// algorithms are allowed in a single Router Capability TLV.
+    pub fads: Vec<&'a IsisSubFlexAlgoDef>,
 }
 
 /// References to every per-sys-id map that depends on TLV content
@@ -157,6 +159,12 @@ pub(super) struct SysStateRefs<'a> {
     pub mt_membership: &'a mut BTreeMap<IsisSysId, BTreeSet<MtId>>,
     pub mt2_reach_v6: &'a mut ReachMapV6,
     pub srv6_end_map: &'a mut BTreeMap<IsisSysId, Ipv6Addr>,
+    /// Per-peer Flex-Algorithm Definition store. Outer key is peer
+    /// sys-id, inner key is the FAD's `flex_algorithm` field
+    /// (128..=255). RFC 9350 §5.1 places FADs inside Router
+    /// Capability TLV 242, which is a fragment-0-only TLV, so the
+    /// rebuild only inspects fragment 0 for FAD content.
+    pub peer_fad: &'a mut BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>>,
 }
 
 /// Recompute the per-sys-id consumer maps from the union of every
@@ -213,6 +221,7 @@ pub(super) fn rebuild_sys_state(
         s.mt_membership.remove(sys_id);
         s.mt2_reach_v6.remove(sys_id);
         s.srv6_end_map.remove(sys_id);
+        s.peer_fad.remove(sys_id);
         return;
     }
 
@@ -279,6 +288,24 @@ pub(super) fn rebuild_sys_state(
         s.mt_membership.remove(sys_id);
     } else {
         s.mt_membership.insert(*sys_id, mt_set);
+    }
+
+    // Flex-Algorithm Definitions (RFC 9350 §5.1). Live inside Router
+    // Capability TLV 242, which is fragment-0-only — so the existing
+    // `frag0_cap` lookup above is the right source. Multiple FADs
+    // for distinct algorithms can appear in a single Router
+    // Capability; if a peer (incorrectly) emits two FADs for the
+    // same algo, last-wins via BTreeMap::insert.
+    let mut fad_map: BTreeMap<u8, IsisSubFlexAlgoDef> = BTreeMap::new();
+    if let Some(cap_tlv) = frag0_cap {
+        for fad in lsp_cap_view(cap_tlv).fads {
+            fad_map.insert(fad.flex_algorithm, fad.clone());
+        }
+    }
+    if fad_map.is_empty() {
+        s.peer_fad.remove(sys_id);
+    } else {
+        s.peer_fad.insert(*sys_id, fad_map);
     }
 
     // --- Distributable (union across fragments) ---------------------
@@ -411,6 +438,7 @@ pub fn insert_lsp(top: &mut LinkTop, level: Level, lsp: IsisLsp, bytes: Vec<u8>)
                 mt_membership: top.mt_membership.get_mut(&level),
                 mt2_reach_v6: top.mt2_reach_map_v6.get_mut(&level),
                 srv6_end_map: top.srv6_end_map.get_mut(&level),
+                peer_fad: top.peer_fad.get_mut(&level),
             },
         );
     }
@@ -495,6 +523,7 @@ pub fn remove_lsp(top: &mut IsisTop, level: Level, key: IsisLspId) {
             mt_membership: top.mt_membership.get_mut(&level),
             mt2_reach_v6: top.mt2_reach_map_v6.get_mut(&level),
             srv6_end_map: top.srv6_end_map.get_mut(&level),
+            peer_fad: top.peer_fad.get_mut(&level),
         },
     );
 }
@@ -594,6 +623,7 @@ mod tests {
         let mut mt_membership: BTreeMap<IsisSysId, BTreeSet<MtId>> = BTreeMap::new();
         let mut mt2_reach_v6 = ReachMapV6::default();
         let mut srv6_end_map: BTreeMap<IsisSysId, Ipv6Addr> = BTreeMap::new();
+        let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
 
         rebuild_sys_state(
             &lsdb,
@@ -607,6 +637,7 @@ mod tests {
                 mt_membership: &mut mt_membership,
                 mt2_reach_v6: &mut mt2_reach_v6,
                 srv6_end_map: &mut srv6_end_map,
+                peer_fad: &mut peer_fad,
             },
         );
 
@@ -634,6 +665,7 @@ mod tests {
                 mt_membership: &mut mt_membership,
                 mt2_reach_v6: &mut mt2_reach_v6,
                 srv6_end_map: &mut srv6_end_map,
+                peer_fad: &mut peer_fad,
             },
         );
         assert!(
@@ -658,6 +690,7 @@ mod tests {
                 mt_membership: &mut mt_membership,
                 mt2_reach_v6: &mut mt2_reach_v6,
                 srv6_end_map: &mut srv6_end_map,
+                peer_fad: &mut peer_fad,
             },
         );
         assert!(reach_v4.get(&peer).is_none());
@@ -690,6 +723,7 @@ mod tests {
         let mut mt_membership: BTreeMap<IsisSysId, BTreeSet<MtId>> = BTreeMap::new();
         let mut mt2_reach_v6 = ReachMapV6::default();
         let mut srv6_end_map: BTreeMap<IsisSysId, Ipv6Addr> = BTreeMap::new();
+        let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
 
         rebuild_sys_state(
             &lsdb,
@@ -703,11 +737,103 @@ mod tests {
                 mt_membership: &mut mt_membership,
                 mt2_reach_v6: &mut mt2_reach_v6,
                 srv6_end_map: &mut srv6_end_map,
+                peer_fad: &mut peer_fad,
             },
         );
 
         let (host, originate) = hostname.get(&me).expect("self entry must survive");
         assert_eq!(host, "real");
         assert!(originate, "originate flag must not be cleared by rebuild");
+    }
+
+    /// A peer LSP fragment 0 carrying a Router Capability TLV with
+    /// two FADs must populate `peer_fad[sys_id]` with one entry per
+    /// FAD, keyed by the algorithm id. Dropping the fragment must
+    /// clear the entry. Mirrors the hostname / SR capability rebuild
+    /// pattern.
+    #[test]
+    fn rebuild_populates_and_clears_peer_fad() {
+        let mut lsdb = Lsdb::default();
+        let peer = sys(42);
+
+        let fad_128 = IsisSubFlexAlgoDef {
+            flex_algorithm: 128,
+            metric_type: 1, // min-unidir-link-delay
+            calc_type: 0,
+            priority: 200,
+            subs: vec![],
+        };
+        let fad_129 = IsisSubFlexAlgoDef {
+            flex_algorithm: 129,
+            metric_type: 0,
+            calc_type: 0,
+            priority: 128,
+            subs: vec![],
+        };
+        let cap = IsisTlvRouterCap {
+            router_id: Ipv4Addr::new(2, 2, 2, 2),
+            flags: 0u8.into(),
+            subs: vec![
+                cap::IsisSubTlv::FlexAlgoDef(fad_128.clone()),
+                cap::IsisSubTlv::FlexAlgoDef(fad_129.clone()),
+            ],
+        };
+        let mut f0 = frag(peer, 0);
+        f0.tlvs.push(IsisTlv::RouterCap(cap));
+        lsdb.map.insert(f0.lsp_id, Lsa::new(f0));
+
+        let mut hostname = Hostname::default();
+        let mut label_map = IsisLabelMap::default();
+        let mut reach_v4 = ReachMap::default();
+        let mut reach_v6 = ReachMapV6::default();
+        let mut mt_membership: BTreeMap<IsisSysId, BTreeSet<MtId>> = BTreeMap::new();
+        let mut mt2_reach_v6 = ReachMapV6::default();
+        let mut srv6_end_map: BTreeMap<IsisSysId, Ipv6Addr> = BTreeMap::new();
+        let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
+
+        rebuild_sys_state(
+            &lsdb,
+            &sys(0xFF),
+            &peer,
+            SysStateRefs {
+                hostname: &mut hostname,
+                label_map: &mut label_map,
+                reach_v4: &mut reach_v4,
+                reach_v6: &mut reach_v6,
+                mt_membership: &mut mt_membership,
+                mt2_reach_v6: &mut mt2_reach_v6,
+                srv6_end_map: &mut srv6_end_map,
+                peer_fad: &mut peer_fad,
+            },
+        );
+
+        let entries = peer_fad
+            .get(&peer)
+            .expect("FADs must populate after fragment 0 ingest");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries.get(&128), Some(&fad_128));
+        assert_eq!(entries.get(&129), Some(&fad_129));
+
+        // Drop fragment 0 — peer_fad must clear the peer entry.
+        lsdb.map.remove(&IsisLspId::new(peer, 0, 0));
+        rebuild_sys_state(
+            &lsdb,
+            &sys(0xFF),
+            &peer,
+            SysStateRefs {
+                hostname: &mut hostname,
+                label_map: &mut label_map,
+                reach_v4: &mut reach_v4,
+                reach_v6: &mut reach_v6,
+                mt_membership: &mut mt_membership,
+                mt2_reach_v6: &mut mt2_reach_v6,
+                srv6_end_map: &mut srv6_end_map,
+                peer_fad: &mut peer_fad,
+            },
+        );
+        assert!(
+            !peer_fad.contains_key(&peer),
+            "FADs must clear when the fragment 0 / Router Capability TLV disappears"
+        );
     }
 }


### PR DESCRIPTION
## Summary

First consume-side flex-algo step. The codec for `IsisSubFlexAlgoDef` landed in PR #610, but until now received FADs were silently dropped in `lsdb::lsp_cap_view`'s no-op match arm. This PR wires them into a per-peer cache that future SPF gating, show commands, and per-algo RIB install will read.

- `Isis::peer_fad: Levels<BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>>>` — per-level, per-peer, per-algo cache. Consumers do `peer_fad.get(level).get(sys_id).get(algo)`.
- Threaded through `IsisTop` and `LinkTop` so both the receive path and the hold-expire path can write.
- `LspCapView` extended with `fads: Vec<&IsisSubFlexAlgoDef>` — the no-op `FlexAlgoDef` arm in `lsp_cap_view` now collects refs.
- `rebuild_sys_state` clones the FAD list off fragment 0's Router Capability TLV (FAD is a fragment-0-only TLV by RFC 9350 §5.1, mirroring hostname / SR cap / MT cap discipline). Empty fragment set or absent Router Capability → `peer_fad.remove(sys_id)`. Two FADs from the same peer for the same algo (illegal but defensive) → BTreeMap last-wins.
- `SysStateRefs` gains `peer_fad`, threaded through all six construction sites (two production + four test).

### Deliberately out of scope
- Per-link ASLA parse into a per-peer admin-group store.
- Per-algo Prefix-SID parse off the IP-reach TLV.
- SPF gating that consumes `peer_fad`.
- `show isis flex-algo` output.

## Test plan

- [x] `cargo build -p zebra-rs --bin zebra-rs` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p zebra-rs --bin zebra-rs --all-targets -- -D warnings` — clean
- [x] `cargo test -p zebra-rs --bin zebra-rs isis::` — 72 pass (1 new on `lsdb::rebuild_populates_and_clears_peer_fad`: two FADs from a peer fragment 0 populate `peer_fad[peer]` with both entries; dropping the fragment clears the entry)

Generated with [Claude Code](https://claude.com/claude-code)