### PR TITLE
isis: parse peer ASLA Flex-Algo bitmaps into Isis::peer_link_affinity

### DIFF
--- a/zebra-rs/src/isis/flex_algo.rs
+++ b/zebra-rs/src/isis/flex_algo.rs
@@ -120,6 +120,29 @@ impl FlexAlgoConfig {
     }
 }
 
+/// Extract the Extended Admin Group bitmap from a peer-advertised
+/// ASLA sub-TLV iff the ASLA's SABM marks it as applying to the
+/// Flex-Algorithm application (RFC 9479 §4.2 X-bit). Returns the
+/// nested IsisSubAdminGrp's bitmap as an ExtAdminGroup; returns
+/// `None` when the SABM byte 0 is missing, the X-bit is clear, or
+/// no AdminGrp sub-sub-TLV is present. Mirrors the producer-side
+/// `build_link_asla` so SPF gating sees the same bits a sender
+/// sets.
+pub fn parse_asla_flex_algo_bitmap(asla: &IsisSubAsla) -> Option<ExtAdminGroup> {
+    let first = asla.sabm.first()?;
+    if first & SABM_FLEX_ALGO == 0 {
+        return None;
+    }
+    for sub in &asla.subs {
+        if let NeighSubTlv::AdminGrp(g) = sub {
+            return Some(ExtAdminGroup {
+                words: g.groups.clone(),
+            });
+        }
+    }
+    None
+}
+
 /// SABM byte (RFC 9479 §4.2) with the Flex-Algorithm (X-bit) set.
 /// Bit layout in the first SABM byte, MSB-first: R(7) S(6) F(5) X(4)
 /// reserved(3..0). Used as the Selective Application-specific
@@ -713,6 +736,83 @@ mod tests {
 
     fn affinity_set(names: &[&str]) -> BTreeSet<String> {
         names.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn parse_asla_flex_algo_bitmap_returns_none_without_x_bit() {
+        // SABM = [0x80] sets R-bit (RSVP-TE) but not X-bit.
+        let asla = IsisSubAsla {
+            l_flag: false,
+            sabm: vec![0x80],
+            udabm: vec![],
+            subs: vec![NeighSubTlv::AdminGrp(IsisSubAdminGrp {
+                groups: vec![0xFF],
+            })],
+        };
+        assert!(parse_asla_flex_algo_bitmap(&asla).is_none());
+    }
+
+    #[test]
+    fn parse_asla_flex_algo_bitmap_returns_none_with_empty_sabm() {
+        let asla = IsisSubAsla {
+            l_flag: false,
+            sabm: vec![],
+            udabm: vec![],
+            subs: vec![NeighSubTlv::AdminGrp(IsisSubAdminGrp {
+                groups: vec![0xFF],
+            })],
+        };
+        assert!(parse_asla_flex_algo_bitmap(&asla).is_none());
+    }
+
+    #[test]
+    fn parse_asla_flex_algo_bitmap_returns_none_when_no_admin_grp_nested() {
+        let asla = IsisSubAsla {
+            l_flag: false,
+            sabm: vec![SABM_FLEX_ALGO],
+            udabm: vec![],
+            subs: vec![],
+        };
+        assert!(parse_asla_flex_algo_bitmap(&asla).is_none());
+    }
+
+    #[test]
+    fn parse_asla_flex_algo_bitmap_extracts_admin_grp_when_x_bit_set() {
+        // SABM = [0x90] sets R-bit AND X-bit — both are honored; X
+        // alone is enough to surface the bitmap.
+        let asla = IsisSubAsla {
+            l_flag: false,
+            sabm: vec![0x90],
+            udabm: vec![],
+            subs: vec![NeighSubTlv::AdminGrp(IsisSubAdminGrp {
+                groups: vec![0x11, 0x80000000],
+            })],
+        };
+        let bitmap = parse_asla_flex_algo_bitmap(&asla).expect("bitmap");
+        assert_eq!(bitmap.words, vec![0x11, 0x80000000]);
+    }
+
+    #[test]
+    fn parse_asla_flex_algo_bitmap_round_trips_through_build_link_asla() {
+        // Build an ASLA on the producer side, parse it on the
+        // consumer side — the bitmap must round-trip bit-for-bit.
+        let mut am = AffinityMap::new();
+        for (name, bit) in [("blue", "0"), ("red", "200")] {
+            am.exec(
+                "/router/isis/affinity-map/affinity/bit-position".into(),
+                args(&[name, bit]),
+                ConfigOp::Set,
+            )
+            .unwrap();
+            am.commit();
+        }
+        let asla = build_link_asla(&affinity_set(&["blue", "red"]), &am).expect("ASLA");
+        let parsed = parse_asla_flex_algo_bitmap(&asla).expect("bitmap");
+        // bit 0 in word 0, bit (200 - 6*32 = 8) in word 6.
+        assert_eq!(parsed.words.len(), 7);
+        assert!(parsed.get(0));
+        assert!(parsed.get(200));
+        assert!(!parsed.get(1));
     }
 
     #[test]

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -104,6 +104,17 @@ pub struct Isis {
     /// `show isis flex-algo`) read from here instead of re-walking
     /// the LSDB. Cleared on peer purge.
     pub peer_fad: Levels<BTreeMap<IsisSysId, BTreeMap<u8, isis_packet::IsisSubFlexAlgoDef>>>,
+
+    /// Per-peer per-link affinity bitmaps. Outer key is peer sys-id;
+    /// inner key is the IS-reach neighbor identifier (a 7-byte tuple
+    /// of 6-byte sys-id and 1-byte circuit/pseudo id). Populated
+    /// from IsisSubAsla sub-TLVs on Ext IS-Reach (TLV 22) and MT
+    /// IS-Reach (TLV 222) entries whose SABM byte 0 has the
+    /// Flex-Algorithm X-bit set (RFC 9479 §4.2). Cleared on peer
+    /// purge.
+    pub peer_link_affinity: Levels<
+        BTreeMap<IsisSysId, BTreeMap<isis_packet::IsisNeighborId, isis_packet::ExtAdminGroup>>,
+    >,
     pub rib: Levels<PrefixMap<Ipv4Net, SpfRoute>>,
     pub rib_v6: Levels<PrefixMap<Ipv6Net, SpfRouteV6>>,
     pub ilm: Levels<BTreeMap<u32, SpfIlm>>,
@@ -251,6 +262,14 @@ pub struct IsisTop<'a> {
     /// Router Capability TLVs.
     pub peer_fad:
         &'a mut Levels<BTreeMap<IsisSysId, BTreeMap<u8, isis_packet::IsisSubFlexAlgoDef>>>,
+
+    /// Per-peer per-link affinity bitmaps (see
+    /// `Isis::peer_link_affinity`). Threaded through IsisTop so the
+    /// LSDB rebuild path can populate it from peer IS-reach ASLA
+    /// sub-TLVs.
+    pub peer_link_affinity: &'a mut Levels<
+        BTreeMap<IsisSysId, BTreeMap<isis_packet::IsisNeighborId, isis_packet::ExtAdminGroup>>,
+    >,
     pub rib: &'a mut Levels<PrefixMap<Ipv4Net, SpfRoute>>,
     pub rib_v6: &'a mut Levels<PrefixMap<Ipv6Net, SpfRouteV6>>,
     pub ilm: &'a mut Levels<BTreeMap<u32, SpfIlm>>,
@@ -353,6 +372,12 @@ impl Isis {
                 srv6_end_map: Levels::<BTreeMap<IsisSysId, Ipv6Addr>>::default(),
                 peer_fad: Levels::<
                     BTreeMap<IsisSysId, BTreeMap<u8, isis_packet::IsisSubFlexAlgoDef>>,
+                >::default(),
+                peer_link_affinity: Levels::<
+                    BTreeMap<
+                        IsisSysId,
+                        BTreeMap<isis_packet::IsisNeighborId, isis_packet::ExtAdminGroup>,
+                    >,
                 >::default(),
                 rib: Levels::<PrefixMap<Ipv4Net, SpfRoute>>::default(),
                 rib_v6: Levels::<PrefixMap<Ipv6Net, SpfRouteV6>>::default(),
@@ -1104,6 +1129,7 @@ impl Isis {
             label_map: &mut self.label_map,
             srv6_end_map: &mut self.srv6_end_map,
             peer_fad: &mut self.peer_fad,
+            peer_link_affinity: &mut self.peer_link_affinity,
             rib: &mut self.rib,
             rib_v6: &mut self.rib_v6,
             ilm: &mut self.ilm,
@@ -1150,6 +1176,7 @@ impl Isis {
             label_map: &mut self.label_map,
             srv6_end_map: &mut self.srv6_end_map,
             peer_fad: &mut self.peer_fad,
+            peer_link_affinity: &mut self.peer_link_affinity,
             spf_timer: &mut self.spf_timer,
             spf_throttle: &mut self.spf_throttle,
             rib_tx: &self.rib_tx,

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -140,6 +140,12 @@ pub struct LinkTop<'a> {
             std::collections::BTreeMap<u8, isis_packet::IsisSubFlexAlgoDef>,
         >,
     >,
+    pub peer_link_affinity: &'a mut Levels<
+        std::collections::BTreeMap<
+            IsisSysId,
+            std::collections::BTreeMap<isis_packet::IsisNeighborId, isis_packet::ExtAdminGroup>,
+        >,
+    >,
     pub spf_timer: &'a mut Levels<Option<Timer>>,
     pub spf_throttle: &'a mut Levels<super::throttle::Throttle>,
 

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -165,6 +165,15 @@ pub(super) struct SysStateRefs<'a> {
     /// Capability TLV 242, which is a fragment-0-only TLV, so the
     /// rebuild only inspects fragment 0 for FAD content.
     pub peer_fad: &'a mut BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>>,
+
+    /// Per-peer per-link affinity bitmaps. Inner key is the IS-reach
+    /// neighbor identifier (6-byte sys-id + 1-byte circuit/pseudo
+    /// id). Populated from ASLA sub-TLVs on Ext IS-Reach (TLV 22)
+    /// and MT IS-Reach (TLV 222) entries whose SABM has the
+    /// Flex-Algorithm X-bit set (RFC 9479 §4.2). Union across
+    /// fragments — later fragments' entries overwrite earlier ones
+    /// for the same neighbor_id.
+    pub peer_link_affinity: &'a mut BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>>,
 }
 
 /// Recompute the per-sys-id consumer maps from the union of every
@@ -222,6 +231,7 @@ pub(super) fn rebuild_sys_state(
         s.mt2_reach_v6.remove(sys_id);
         s.srv6_end_map.remove(sys_id);
         s.peer_fad.remove(sys_id);
+        s.peer_link_affinity.remove(sys_id);
         return;
     }
 
@@ -306,6 +316,41 @@ pub(super) fn rebuild_sys_state(
         s.peer_fad.remove(sys_id);
     } else {
         s.peer_fad.insert(*sys_id, fad_map);
+    }
+
+    // Per-link affinity bitmaps from peer-advertised ASLA sub-TLVs
+    // (RFC 9479). Walk every fragment's Ext IS-Reach (TLV 22) and
+    // MT IS-Reach (TLV 222) entries; for each entry's IsisSubAsla
+    // sub-TLV whose SABM marks Flex-Algorithm application, extract
+    // the nested IsisSubAdminGrp bitmap and stash it keyed by the
+    // neighbor_id. Multiple entries for the same neighbor_id across
+    // fragments (or across TLV 22 / TLV 222 for the same link) yield
+    // last-wins via BTreeMap::insert — by construction the producer
+    // emits the same bytes on both topologies (PR #613), so any
+    // duplication is benign.
+    let mut link_affinity: BTreeMap<IsisNeighborId, ExtAdminGroup> = BTreeMap::new();
+    for f in &frags {
+        for tlv in &f.tlvs {
+            let entries: &[IsisTlvExtIsReachEntry] = match tlv {
+                IsisTlv::ExtIsReach(t) => &t.entries,
+                IsisTlv::MtIsReach(t) => &t.entries,
+                _ => continue,
+            };
+            for entry in entries {
+                for sub in &entry.subs {
+                    if let isis_packet::neigh::IsisSubTlv::Asla(asla) = sub
+                        && let Some(bitmap) = super::flex_algo::parse_asla_flex_algo_bitmap(asla)
+                    {
+                        link_affinity.insert(entry.neighbor_id, bitmap);
+                    }
+                }
+            }
+        }
+    }
+    if link_affinity.is_empty() {
+        s.peer_link_affinity.remove(sys_id);
+    } else {
+        s.peer_link_affinity.insert(*sys_id, link_affinity);
     }
 
     // --- Distributable (union across fragments) ---------------------
@@ -439,6 +484,7 @@ pub fn insert_lsp(top: &mut LinkTop, level: Level, lsp: IsisLsp, bytes: Vec<u8>)
                 mt2_reach_v6: top.mt2_reach_map_v6.get_mut(&level),
                 srv6_end_map: top.srv6_end_map.get_mut(&level),
                 peer_fad: top.peer_fad.get_mut(&level),
+                peer_link_affinity: top.peer_link_affinity.get_mut(&level),
             },
         );
     }
@@ -524,6 +570,7 @@ pub fn remove_lsp(top: &mut IsisTop, level: Level, key: IsisLspId) {
             mt2_reach_v6: top.mt2_reach_map_v6.get_mut(&level),
             srv6_end_map: top.srv6_end_map.get_mut(&level),
             peer_fad: top.peer_fad.get_mut(&level),
+            peer_link_affinity: top.peer_link_affinity.get_mut(&level),
         },
     );
 }
@@ -624,6 +671,8 @@ mod tests {
         let mut mt2_reach_v6 = ReachMapV6::default();
         let mut srv6_end_map: BTreeMap<IsisSysId, Ipv6Addr> = BTreeMap::new();
         let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
+        let mut peer_link_affinity: BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>> =
+            BTreeMap::new();
 
         rebuild_sys_state(
             &lsdb,
@@ -638,6 +687,7 @@ mod tests {
                 mt2_reach_v6: &mut mt2_reach_v6,
                 srv6_end_map: &mut srv6_end_map,
                 peer_fad: &mut peer_fad,
+                peer_link_affinity: &mut peer_link_affinity,
             },
         );
 
@@ -666,6 +716,7 @@ mod tests {
                 mt2_reach_v6: &mut mt2_reach_v6,
                 srv6_end_map: &mut srv6_end_map,
                 peer_fad: &mut peer_fad,
+                peer_link_affinity: &mut peer_link_affinity,
             },
         );
         assert!(
@@ -691,6 +742,7 @@ mod tests {
                 mt2_reach_v6: &mut mt2_reach_v6,
                 srv6_end_map: &mut srv6_end_map,
                 peer_fad: &mut peer_fad,
+                peer_link_affinity: &mut peer_link_affinity,
             },
         );
         assert!(reach_v4.get(&peer).is_none());
@@ -724,6 +776,8 @@ mod tests {
         let mut mt2_reach_v6 = ReachMapV6::default();
         let mut srv6_end_map: BTreeMap<IsisSysId, Ipv6Addr> = BTreeMap::new();
         let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
+        let mut peer_link_affinity: BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>> =
+            BTreeMap::new();
 
         rebuild_sys_state(
             &lsdb,
@@ -738,6 +792,7 @@ mod tests {
                 mt2_reach_v6: &mut mt2_reach_v6,
                 srv6_end_map: &mut srv6_end_map,
                 peer_fad: &mut peer_fad,
+                peer_link_affinity: &mut peer_link_affinity,
             },
         );
 
@@ -790,6 +845,8 @@ mod tests {
         let mut mt2_reach_v6 = ReachMapV6::default();
         let mut srv6_end_map: BTreeMap<IsisSysId, Ipv6Addr> = BTreeMap::new();
         let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
+        let mut peer_link_affinity: BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>> =
+            BTreeMap::new();
 
         rebuild_sys_state(
             &lsdb,
@@ -804,6 +861,7 @@ mod tests {
                 mt2_reach_v6: &mut mt2_reach_v6,
                 srv6_end_map: &mut srv6_end_map,
                 peer_fad: &mut peer_fad,
+                peer_link_affinity: &mut peer_link_affinity,
             },
         );
 
@@ -829,11 +887,120 @@ mod tests {
                 mt2_reach_v6: &mut mt2_reach_v6,
                 srv6_end_map: &mut srv6_end_map,
                 peer_fad: &mut peer_fad,
+                peer_link_affinity: &mut peer_link_affinity,
             },
         );
         assert!(
             !peer_fad.contains_key(&peer),
             "FADs must clear when the fragment 0 / Router Capability TLV disappears"
         );
+    }
+
+    /// A peer Ext IS-Reach entry with an ASLA Flex-Algo bitmap must
+    /// populate `peer_link_affinity[sys_id][neighbor_id]`. An entry
+    /// without the X-bit set must be ignored. Dropping the fragment
+    /// must clear the peer entry.
+    #[test]
+    fn rebuild_populates_and_clears_peer_link_affinity() {
+        let mut lsdb = Lsdb::default();
+        let peer = sys(7);
+        let nbr_a = IsisNeighborId {
+            id: [1, 1, 1, 1, 1, 1, 0],
+        };
+        let nbr_b = IsisNeighborId {
+            id: [2, 2, 2, 2, 2, 2, 0],
+        };
+
+        // Entry A: ASLA with Flex-Algo X-bit (0x10) + AdminGrp.
+        let asla_flex = IsisSubAsla {
+            l_flag: false,
+            sabm: vec![0x10],
+            udabm: vec![],
+            subs: vec![isis_packet::neigh::IsisSubTlv::AdminGrp(IsisSubAdminGrp {
+                groups: vec![0b1001], // bits 0 and 3 set
+            })],
+        };
+        // Entry B: ASLA with only R-bit (0x80) — must be ignored.
+        let asla_rsvp = IsisSubAsla {
+            l_flag: false,
+            sabm: vec![0x80],
+            udabm: vec![],
+            subs: vec![isis_packet::neigh::IsisSubTlv::AdminGrp(IsisSubAdminGrp {
+                groups: vec![0xFF],
+            })],
+        };
+        let ext_is_reach = IsisTlvExtIsReach {
+            entries: vec![
+                IsisTlvExtIsReachEntry {
+                    neighbor_id: nbr_a,
+                    metric: 10,
+                    subs: vec![isis_packet::neigh::IsisSubTlv::Asla(asla_flex)],
+                },
+                IsisTlvExtIsReachEntry {
+                    neighbor_id: nbr_b,
+                    metric: 10,
+                    subs: vec![isis_packet::neigh::IsisSubTlv::Asla(asla_rsvp)],
+                },
+            ],
+        };
+        let mut f0 = frag(peer, 0);
+        f0.tlvs.push(IsisTlv::ExtIsReach(ext_is_reach));
+        lsdb.map.insert(f0.lsp_id, Lsa::new(f0));
+
+        let mut hostname = Hostname::default();
+        let mut label_map = IsisLabelMap::default();
+        let mut reach_v4 = ReachMap::default();
+        let mut reach_v6 = ReachMapV6::default();
+        let mut mt_membership: BTreeMap<IsisSysId, BTreeSet<MtId>> = BTreeMap::new();
+        let mut mt2_reach_v6 = ReachMapV6::default();
+        let mut srv6_end_map: BTreeMap<IsisSysId, Ipv6Addr> = BTreeMap::new();
+        let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
+        let mut peer_link_affinity: BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>> =
+            BTreeMap::new();
+
+        rebuild_sys_state(
+            &lsdb,
+            &sys(0xFF),
+            &peer,
+            SysStateRefs {
+                hostname: &mut hostname,
+                label_map: &mut label_map,
+                reach_v4: &mut reach_v4,
+                reach_v6: &mut reach_v6,
+                mt_membership: &mut mt_membership,
+                mt2_reach_v6: &mut mt2_reach_v6,
+                srv6_end_map: &mut srv6_end_map,
+                peer_fad: &mut peer_fad,
+                peer_link_affinity: &mut peer_link_affinity,
+            },
+        );
+
+        let entries = peer_link_affinity
+            .get(&peer)
+            .expect("affinity map must populate for the Flex-Algo entry");
+        assert_eq!(entries.len(), 1, "RSVP-only entry must not be cached");
+        let bitmap = entries.get(&nbr_a).expect("nbr_a bitmap");
+        assert_eq!(bitmap.words, vec![0b1001]);
+        assert!(!entries.contains_key(&nbr_b));
+
+        // Drop the fragment — affinity map must clear.
+        lsdb.map.remove(&IsisLspId::new(peer, 0, 0));
+        rebuild_sys_state(
+            &lsdb,
+            &sys(0xFF),
+            &peer,
+            SysStateRefs {
+                hostname: &mut hostname,
+                label_map: &mut label_map,
+                reach_v4: &mut reach_v4,
+                reach_v6: &mut reach_v6,
+                mt_membership: &mut mt_membership,
+                mt2_reach_v6: &mut mt2_reach_v6,
+                srv6_end_map: &mut srv6_end_map,
+                peer_fad: &mut peer_fad,
+                peer_link_affinity: &mut peer_link_affinity,
+            },
+        );
+        assert!(!peer_link_affinity.contains_key(&peer));
     }
 }


### PR DESCRIPTION
## Summary

Second consume-side flex-algo step. PR #613 emits per-link admin-group bitmaps inside `IsisSubAsla` sub-TLVs on Ext IS-Reach (TLV 22) and MT IS-Reach (TLV 222) entries; this PR completes the symmetry by decoding peer-advertised ASLAs into a per-peer / per-link cache that SPF gating will use to enforce FAD include/exclude constraints.

- `flex_algo::parse_asla_flex_algo_bitmap(asla)` — returns the nested `IsisSubAdminGrp`'s bitmap as an `ExtAdminGroup` iff the ASLA's SABM byte 0 has the X-bit (Flex-Algorithm, 0x10) set (RFC 9479 §4.2). Returns `None` when SABM is empty, X-bit is clear, or no nested AdminGrp is present.
- `Isis::peer_link_affinity: Levels<BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>>>` — per L1/L2, per peer, per IS-reach neighbor entry. Threaded through `IsisTop`, `LinkTop`, and `SysStateRefs` (six construction sites: two production + four test).
- `rebuild_sys_state` walks every fragment's `IsisTlv::ExtIsReach` and `IsisTlv::MtIsReach` entries; per entry, runs `parse_asla_flex_algo_bitmap` over `IsisSubTlv::Asla` subs and stores non-`None` results keyed by `neighbor_id`. Union across fragments via `BTreeMap::insert` (last-wins on duplicates, benign because PR #613 emits the same bytes on TLV 22 and TLV 222 for the same link). Empty resulting map ⇒ `peer_link_affinity.remove(sys_id)` — matches the cleanup discipline of `peer_fad` / `mt_membership`.

### Deliberately out of scope
- Per-algo Prefix-SID parse off peer IP-reach TLVs.
- SPF gating that consumes `peer_fad` + `peer_link_affinity` together.
- `show isis flex-algo` (operator-visible diagnostics).

## Test plan

- [x] `cargo build -p zebra-rs --bin zebra-rs` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p zebra-rs --bin zebra-rs --all-targets -- -D warnings` — clean
- [x] `cargo test -p zebra-rs --bin zebra-rs isis::` — 78 pass:
  - 5 new on `flex_algo::parse_asla_flex_algo_bitmap` (X-bit absent → None, SABM empty → None, AdminGrp missing → None, X-bit set with AdminGrp → bitmap, round-trip through `build_link_asla`)
  - 1 new on `lsdb::rebuild_populates_and_clears_peer_link_affinity` (X-bit ASLA cached, RSVP-only ASLA ignored, fragment drop clears the peer entry)
- [ ] End-to-end CLI: receive ASLA-bearing LSP from peer, verify `peer_link_affinity` populates (manual, post-merge)

Generated with [Claude Code](https://claude.com/claude-code)