### PR TITLE
bgp: introduce PeerKey + PeerOrigin for keyed peers

### DIFF
--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -8,6 +8,7 @@ pub mod auth;
 pub mod config;
 pub mod neighbor_group;
 pub mod peer;
+pub mod peer_key;
 pub mod peer_map;
 pub mod show;
 pub mod show_update_group;

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -13,6 +13,7 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use bgp_packet::*;
 
+use super::peer_key::PeerOrigin;
 use super::peer_map::PeerMap;
 
 use caps::CapAs4;
@@ -314,6 +315,12 @@ impl PeerStat {
 pub struct Peer {
     pub ident: usize,
     pub address: IpAddr,
+    /// Provenance of this peer — set to [`PeerOrigin::Static`] for
+    /// peers configured by remote address; future commits will set
+    /// `Interface { ifindex }` for unnumbered neighbors and
+    /// `Dynamic { range_prefix }` for peers materialized on inbound
+    /// accept by a configured listen-range.
+    pub origin: PeerOrigin,
     pub router_id: Ipv4Addr,
     pub local_identifier: Option<Ipv4Addr>,
     pub remote_id: Ipv4Addr,
@@ -390,6 +397,7 @@ impl Peer {
             remote_as,
             local_hostname,
             address,
+            origin: PeerOrigin::Static,
             active: false,
             peer_type: PeerType::IBGP,
             state: State::Idle,

--- a/zebra-rs/src/bgp/peer_key.rs
+++ b/zebra-rs/src/bgp/peer_key.rs
@@ -1,0 +1,93 @@
+use std::net::IpAddr;
+
+use ipnet::IpNet;
+
+/// How a peer is keyed inside [`super::peer_map::PeerMap`].
+///
+/// Today every peer is keyed by remote address. Two future workflows
+/// need additional variants:
+///   * IPv6 unnumbered peers, where the remote link-local is unknown
+///     until a Router Advertisement is received and the long-lived
+///     identity of the peer is its outbound interface.
+///   * Dynamic peers accepted via `bgp listen range`, which are still
+///     keyed by remote address but originate from a configured prefix
+///     (see [`PeerOrigin`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum PeerKey {
+    Addr(IpAddr),
+    // Wired in by the follow-up interface-neighbor PR; defining the
+    // variant now keeps PeerMap signatures stable across that change.
+    #[allow(dead_code)]
+    Interface(u32),
+}
+
+impl PeerKey {
+    #[allow(dead_code)]
+    pub fn addr(&self) -> Option<IpAddr> {
+        match self {
+            Self::Addr(a) => Some(*a),
+            Self::Interface(_) => None,
+        }
+    }
+}
+
+impl From<IpAddr> for PeerKey {
+    fn from(addr: IpAddr) -> Self {
+        PeerKey::Addr(addr)
+    }
+}
+
+/// Provenance of a [`super::peer::Peer`].
+///
+/// Distinct from [`PeerKey`] because a dynamic peer is keyed by the
+/// connecting address (we only learn it on accept) but its origin is
+/// the configured listen-range prefix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PeerOrigin {
+    /// Configured by name/address: `router bgp ... neighbor X.X.X.X`.
+    #[default]
+    Static,
+    /// Configured by interface: `neighbor IFNAME interface ...`.
+    #[allow(dead_code)]
+    Interface { ifindex: u32 },
+    /// Created on inbound accept by a `bgp listen range` match.
+    #[allow(dead_code)]
+    Dynamic { range_prefix: IpNet },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn peer_key_addr_round_trip() {
+        let a: IpAddr = Ipv4Addr::new(10, 0, 0, 1).into();
+        let k: PeerKey = a.into();
+        assert_eq!(k, PeerKey::Addr(a));
+        assert_eq!(k.addr(), Some(a));
+    }
+
+    #[test]
+    fn peer_key_interface_has_no_addr() {
+        let k = PeerKey::Interface(42);
+        assert_eq!(k.addr(), None);
+    }
+
+    #[test]
+    fn peer_key_orders_addr_before_interface() {
+        // The variant ordering is part of the public contract because
+        // PeerMap's iteration order depends on it (BTreeMap key order).
+        // Keep Addr-keyed peers before Interface-keyed ones so existing
+        // address-ordered iteration is preserved when no interface
+        // peers exist.
+        let addr: PeerKey = IpAddr::from(Ipv4Addr::new(255, 255, 255, 255)).into();
+        let iface = PeerKey::Interface(0);
+        assert!(addr < iface);
+    }
+
+    #[test]
+    fn peer_origin_default_is_static() {
+        assert_eq!(PeerOrigin::default(), PeerOrigin::Static);
+    }
+}

--- a/zebra-rs/src/bgp/peer_map.rs
+++ b/zebra-rs/src/bgp/peer_map.rs
@@ -2,10 +2,11 @@ use std::collections::BTreeMap;
 use std::net::IpAddr;
 
 use super::peer::Peer;
+use super::peer_key::PeerKey;
 
 #[derive(Debug, Default)]
 pub struct PeerMap {
-    map: BTreeMap<IpAddr, usize>,
+    map: BTreeMap<PeerKey, usize>,
     peers: Vec<Option<Peer>>,
 }
 
@@ -15,12 +16,20 @@ impl PeerMap {
     }
 
     pub fn get(&self, addr: &IpAddr) -> Option<&Peer> {
-        let &idx = self.map.get(addr)?;
-        self.peers[idx].as_ref()
+        self.get_by_key(&PeerKey::Addr(*addr))
     }
 
     pub fn get_mut(&mut self, addr: &IpAddr) -> Option<&mut Peer> {
-        let &idx = self.map.get(addr)?;
+        self.get_mut_by_key(&PeerKey::Addr(*addr))
+    }
+
+    pub fn get_by_key(&self, key: &PeerKey) -> Option<&Peer> {
+        let &idx = self.map.get(key)?;
+        self.peers[idx].as_ref()
+    }
+
+    pub fn get_mut_by_key(&mut self, key: &PeerKey) -> Option<&mut Peer> {
+        let &idx = self.map.get(key)?;
         self.peers[idx].as_mut()
     }
 
@@ -36,27 +45,39 @@ impl PeerMap {
         self.peers.get(idx)?.as_ref().map(|p| p.address)
     }
 
-    pub fn insert(&mut self, addr: IpAddr, mut peer: Peer) {
-        if let Some(&idx) = self.map.get(&addr) {
+    pub fn insert(&mut self, addr: IpAddr, peer: Peer) {
+        self.insert_with_key(PeerKey::Addr(addr), peer);
+    }
+
+    pub fn insert_with_key(&mut self, key: PeerKey, mut peer: Peer) {
+        if let Some(&idx) = self.map.get(&key) {
             peer.ident = idx;
             self.peers[idx] = Some(peer);
         } else {
             let idx = self.peers.len();
             peer.ident = idx;
-            self.map.insert(addr, idx);
+            self.map.insert(key, idx);
             self.peers.push(Some(peer));
         }
     }
 
     pub fn remove(&mut self, addr: &IpAddr) -> Option<Peer> {
-        let &idx = self.map.get(addr)?;
+        self.remove_by_key(&PeerKey::Addr(*addr))
+    }
+
+    pub fn remove_by_key(&mut self, key: &PeerKey) -> Option<Peer> {
+        let &idx = self.map.get(key)?;
         self.peers[idx].take()
     }
 
+    /// Iterate over peers keyed by remote address. Interface-keyed
+    /// peers (when they exist) are skipped — use [`Self::iter_all`]
+    /// for full iteration including those.
     pub fn iter(&self) -> impl Iterator<Item = (&IpAddr, &Peer)> {
-        self.map
-            .iter()
-            .filter_map(move |(addr, &idx)| self.peers[idx].as_ref().map(|peer| (addr, peer)))
+        self.map.iter().filter_map(move |(key, &idx)| match key {
+            PeerKey::Addr(addr) => self.peers[idx].as_ref().map(|peer| (addr, peer)),
+            PeerKey::Interface(_) => None,
+        })
     }
 
     pub fn iter_mut(&mut self) -> impl Iterator<Item = (&IpAddr, &mut Peer)> {
@@ -68,17 +89,40 @@ impl PeerMap {
                 let peer = slot.as_mut()?;
                 map.iter()
                     .find(|(_, mapped_idx)| **mapped_idx == idx)
-                    .map(|(addr, _)| (addr, peer))
+                    .and_then(|(key, _)| match key {
+                        PeerKey::Addr(addr) => Some((addr, peer)),
+                        PeerKey::Interface(_) => None,
+                    })
+            })
+    }
+
+    /// Iterate over every peer regardless of key variant.
+    #[allow(dead_code)]
+    pub fn iter_all(&self) -> impl Iterator<Item = (&PeerKey, &Peer)> {
+        self.map
+            .iter()
+            .filter_map(move |(key, &idx)| self.peers[idx].as_ref().map(|peer| (key, peer)))
+    }
+
+    /// Iterate every peer regardless of key variant, mutable.
+    #[allow(dead_code)]
+    pub fn iter_mut_all(&mut self) -> impl Iterator<Item = (&PeerKey, &mut Peer)> {
+        let map = &self.map;
+        self.peers
+            .iter_mut()
+            .enumerate()
+            .filter_map(move |(idx, slot)| {
+                let peer = slot.as_mut()?;
+                map.iter()
+                    .find(|(_, mapped_idx)| **mapped_idx == idx)
+                    .map(|(key, _)| (key, peer))
             })
     }
 
     pub fn keys(&self) -> impl Iterator<Item = &IpAddr> {
-        self.map.iter().filter_map(move |(addr, &idx)| {
-            if self.peers[idx].is_some() {
-                Some(addr)
-            } else {
-                None
-            }
+        self.map.iter().filter_map(move |(key, &idx)| match key {
+            PeerKey::Addr(addr) if self.peers[idx].is_some() => Some(addr),
+            _ => None,
         })
     }
 
@@ -91,5 +135,68 @@ impl PeerMap {
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bgp::peer::Peer;
+    use std::net::Ipv4Addr;
+    use tokio::sync::mpsc;
+
+    fn make_peer(addr: IpAddr) -> Peer {
+        let (tx, _rx) = mpsc::channel(1);
+        Peer::new(0, 65000, Ipv4Addr::new(1, 1, 1, 1), 0, addr, None, tx)
+    }
+
+    #[test]
+    fn insert_then_get_by_addr() {
+        let mut m = PeerMap::new();
+        let a: IpAddr = Ipv4Addr::new(10, 0, 0, 1).into();
+        m.insert(a, make_peer(a));
+        assert!(m.get(&a).is_some());
+        assert_eq!(m.len(), 1);
+    }
+
+    #[test]
+    fn insert_with_interface_key_does_not_appear_in_iter() {
+        let mut m = PeerMap::new();
+        let a: IpAddr = Ipv4Addr::new(10, 0, 0, 1).into();
+        m.insert(a, make_peer(a));
+        m.insert_with_key(
+            PeerKey::Interface(7),
+            make_peer(Ipv4Addr::UNSPECIFIED.into()),
+        );
+
+        assert_eq!(m.iter().count(), 1, "addr-only iter skips interface peer");
+        assert_eq!(m.iter_all().count(), 2, "iter_all includes both");
+        assert_eq!(m.len(), 2);
+    }
+
+    #[test]
+    fn remove_by_key_clears_slot() {
+        let mut m = PeerMap::new();
+        let k = PeerKey::Interface(3);
+        m.insert_with_key(k, make_peer(Ipv4Addr::UNSPECIFIED.into()));
+        assert!(m.get_by_key(&k).is_some());
+
+        let removed = m.remove_by_key(&k);
+        assert!(removed.is_some());
+        assert!(m.get_by_key(&k).is_none());
+    }
+
+    #[test]
+    fn keys_only_yields_addr_variants() {
+        let mut m = PeerMap::new();
+        let a: IpAddr = Ipv4Addr::new(10, 0, 0, 1).into();
+        m.insert(a, make_peer(a));
+        m.insert_with_key(
+            PeerKey::Interface(11),
+            make_peer(Ipv4Addr::UNSPECIFIED.into()),
+        );
+
+        let keys: Vec<IpAddr> = m.keys().copied().collect();
+        assert_eq!(keys, vec![a]);
     }
 }


### PR DESCRIPTION
## Summary
- Re-keys `PeerMap` internally from `BTreeMap<IpAddr, usize>` to `BTreeMap<PeerKey, usize>` where `PeerKey { Addr(IpAddr), Interface(u32) }`. Existing `IpAddr`-taking API stays as a thin `PeerKey::Addr` wrapper, so all current call sites are unchanged.
- Adds `PeerOrigin { Static, Interface { ifindex }, Dynamic { range_prefix } }` and a `Peer.origin` field defaulting to `Static`. No behavior change.
- Prep for upcoming IPv6 unnumbered (`neighbor IFNAME interface`) and dynamic listen-range (`bgp listen range PREFIX`) work — both need keying beyond `IpAddr`.
- New keyed methods (`get_by_key` / `insert_with_key` / `remove_by_key` / `iter_all` / `iter_mut_all`) available for follow-up PRs; non-`Static`/`Addr` variants are `#[allow(dead_code)]` until they land.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` — 8 new unit tests pass (key round-trip, variant ordering, interface-key invisible to addr-only iteration, remove semantics)
- [x] Full bin test suite still green (428 passed, 1 pre-existing ignored)

Generated with [Claude Code](https://claude.com/claude-code)