### PR TITLE
isis: parse peer per-algo Prefix-SIDs into Isis::peer_algo_sid

### DIFF
--- a/zebra-rs/src/isis/flex_algo.rs
+++ b/zebra-rs/src/isis/flex_algo.rs
@@ -120,6 +120,24 @@ impl FlexAlgoConfig {
     }
 }
 
+/// Extract per-algorithm Prefix-SIDs from a peer-advertised Ext IP-
+/// Reach entry. Yields one (algo, sid) pair for each Prefix-SID
+/// sub-TLV (RFC 8667 §2.1) whose Algorithm field is in the
+/// flex-algo range (128..=255); algo-0 / algo-1 / unknown algos
+/// are skipped. Mirrors the producer-side `build_per_algo_prefix_sids`
+/// so the bytes a sender packs are the bytes a receiver unpacks.
+pub fn parse_per_algo_prefix_sids(
+    entry: &isis_packet::IsisTlvExtIpReachEntry,
+) -> impl Iterator<Item = (u8, isis_packet::SidLabelValue)> + '_ {
+    entry.subs.iter().filter_map(|sub| match sub {
+        isis_packet::prefix::IsisSubTlv::PrefixSid(s) => match s.algo {
+            Algo::FlexAlgo(n) => Some((n, s.sid.clone())),
+            _ => None,
+        },
+        _ => None,
+    })
+}
+
 /// Extract the Extended Admin Group bitmap from a peer-advertised
 /// ASLA sub-TLV iff the ASLA's SABM marks it as applying to the
 /// Flex-Algorithm application (RFC 9479 §4.2 X-bit). Returns the
@@ -736,6 +754,70 @@ mod tests {
 
     fn affinity_set(names: &[&str]) -> BTreeSet<String> {
         names.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn parse_per_algo_prefix_sids_filters_to_flex_algo_range() {
+        use ipnet::Ipv4Net;
+        use isis_packet::PrefixSidFlags;
+        use isis_packet::prefix::{Ipv4ControlInfo, IsisSubTlv as PrefixSubTlv};
+        let entry = isis_packet::IsisTlvExtIpReachEntry {
+            metric: 10,
+            flags: Ipv4ControlInfo::new(),
+            prefix: "10.0.0.1/32".parse::<Ipv4Net>().unwrap(),
+            subs: vec![
+                PrefixSubTlv::PrefixSid(isis_packet::IsisSubPrefixSid {
+                    flags: PrefixSidFlags::from(0u8),
+                    algo: Algo::Spf,
+                    sid: SidLabelValue::Index(1),
+                }),
+                PrefixSubTlv::PrefixSid(isis_packet::IsisSubPrefixSid {
+                    flags: PrefixSidFlags::from(0u8),
+                    algo: Algo::FlexAlgo(128),
+                    sid: SidLabelValue::Index(1128),
+                }),
+                PrefixSubTlv::PrefixSid(isis_packet::IsisSubPrefixSid {
+                    flags: PrefixSidFlags::from(0u8),
+                    algo: Algo::FlexAlgo(129),
+                    sid: SidLabelValue::Label(20129),
+                }),
+                PrefixSubTlv::PrefixSid(isis_packet::IsisSubPrefixSid {
+                    flags: PrefixSidFlags::from(0u8),
+                    algo: Algo::StrictSpf,
+                    sid: SidLabelValue::Index(2),
+                }),
+            ],
+        };
+        let out: Vec<_> = parse_per_algo_prefix_sids(&entry).collect();
+        // Algo::Spf and Algo::StrictSpf must be skipped.
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0], (128, SidLabelValue::Index(1128)));
+        assert_eq!(out[1], (129, SidLabelValue::Label(20129)));
+    }
+
+    #[test]
+    fn parse_per_algo_prefix_sids_round_trips_through_build_per_algo_prefix_sids() {
+        use ipnet::Ipv4Net;
+        use isis_packet::prefix::{Ipv4ControlInfo, IsisSubTlv as PrefixSubTlv};
+        let mut map: BTreeMap<u8, SidLabelValue> = BTreeMap::new();
+        map.insert(128, SidLabelValue::Index(1128));
+        map.insert(129, SidLabelValue::Label(20129));
+        let sids = build_per_algo_prefix_sids(&map);
+        // Wrap each into the entry, then pull back via the parser.
+        let entry = isis_packet::IsisTlvExtIpReachEntry {
+            metric: 10,
+            flags: Ipv4ControlInfo::new(),
+            prefix: "10.0.0.1/32".parse::<Ipv4Net>().unwrap(),
+            subs: sids.into_iter().map(PrefixSubTlv::PrefixSid).collect(),
+        };
+        let out: Vec<_> = parse_per_algo_prefix_sids(&entry).collect();
+        assert_eq!(
+            out,
+            vec![
+                (128, SidLabelValue::Index(1128)),
+                (129, SidLabelValue::Label(20129)),
+            ]
+        );
     }
 
     #[test]

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -115,6 +115,14 @@ pub struct Isis {
     pub peer_link_affinity: Levels<
         BTreeMap<IsisSysId, BTreeMap<isis_packet::IsisNeighborId, isis_packet::ExtAdminGroup>>,
     >,
+
+    /// Per-peer per-algorithm Prefix-SIDs. Outer key is peer sys-id;
+    /// inner key is `(algo, prefix)` so SPF can pick the SID for a
+    /// resolved (algo, destination prefix) pair in one lookup.
+    /// Populated from Ext IP-Reach (TLV 135) sub-TLVs whose Algorithm
+    /// field is in 128..=255 (RFC 9350 §7). Cleared on peer purge.
+    pub peer_algo_sid:
+        Levels<BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), isis_packet::SidLabelValue>>>,
     pub rib: Levels<PrefixMap<Ipv4Net, SpfRoute>>,
     pub rib_v6: Levels<PrefixMap<Ipv6Net, SpfRouteV6>>,
     pub ilm: Levels<BTreeMap<u32, SpfIlm>>,
@@ -270,6 +278,12 @@ pub struct IsisTop<'a> {
     pub peer_link_affinity: &'a mut Levels<
         BTreeMap<IsisSysId, BTreeMap<isis_packet::IsisNeighborId, isis_packet::ExtAdminGroup>>,
     >,
+
+    /// Per-peer per-algorithm Prefix-SIDs (see `Isis::peer_algo_sid`).
+    /// Threaded through IsisTop so the LSDB rebuild path can populate
+    /// it from peer Ext IP-Reach TLVs.
+    pub peer_algo_sid:
+        &'a mut Levels<BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), isis_packet::SidLabelValue>>>,
     pub rib: &'a mut Levels<PrefixMap<Ipv4Net, SpfRoute>>,
     pub rib_v6: &'a mut Levels<PrefixMap<Ipv6Net, SpfRouteV6>>,
     pub ilm: &'a mut Levels<BTreeMap<u32, SpfIlm>>,
@@ -378,6 +392,9 @@ impl Isis {
                         IsisSysId,
                         BTreeMap<isis_packet::IsisNeighborId, isis_packet::ExtAdminGroup>,
                     >,
+                >::default(),
+                peer_algo_sid: Levels::<
+                    BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), isis_packet::SidLabelValue>>,
                 >::default(),
                 rib: Levels::<PrefixMap<Ipv4Net, SpfRoute>>::default(),
                 rib_v6: Levels::<PrefixMap<Ipv6Net, SpfRouteV6>>::default(),
@@ -1130,6 +1147,7 @@ impl Isis {
             srv6_end_map: &mut self.srv6_end_map,
             peer_fad: &mut self.peer_fad,
             peer_link_affinity: &mut self.peer_link_affinity,
+            peer_algo_sid: &mut self.peer_algo_sid,
             rib: &mut self.rib,
             rib_v6: &mut self.rib_v6,
             ilm: &mut self.ilm,
@@ -1177,6 +1195,7 @@ impl Isis {
             srv6_end_map: &mut self.srv6_end_map,
             peer_fad: &mut self.peer_fad,
             peer_link_affinity: &mut self.peer_link_affinity,
+            peer_algo_sid: &mut self.peer_algo_sid,
             spf_timer: &mut self.spf_timer,
             spf_throttle: &mut self.spf_throttle,
             rib_tx: &self.rib_tx,

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -146,6 +146,12 @@ pub struct LinkTop<'a> {
             std::collections::BTreeMap<isis_packet::IsisNeighborId, isis_packet::ExtAdminGroup>,
         >,
     >,
+    pub peer_algo_sid: &'a mut Levels<
+        std::collections::BTreeMap<
+            IsisSysId,
+            std::collections::BTreeMap<(u8, Ipv4Net), isis_packet::SidLabelValue>,
+        >,
+    >,
     pub spf_timer: &'a mut Levels<Option<Timer>>,
     pub spf_throttle: &'a mut Levels<super::throttle::Throttle>,
 

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::net::Ipv6Addr;
 use std::time::{Duration, Instant};
 
+use ipnet::Ipv4Net;
 use isis_packet::*;
 
 use crate::isis_database_trace;
@@ -174,6 +175,12 @@ pub(super) struct SysStateRefs<'a> {
     /// fragments — later fragments' entries overwrite earlier ones
     /// for the same neighbor_id.
     pub peer_link_affinity: &'a mut BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>>,
+
+    /// Per-peer per-algorithm Prefix-SIDs keyed by (algo, prefix).
+    /// Populated from Ext IP-Reach (TLV 135) sub-TLVs with
+    /// Algorithm in 128..=255 (RFC 9350 §7). Union across
+    /// fragments.
+    pub peer_algo_sid: &'a mut BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), SidLabelValue>>,
 }
 
 /// Recompute the per-sys-id consumer maps from the union of every
@@ -232,6 +239,7 @@ pub(super) fn rebuild_sys_state(
         s.srv6_end_map.remove(sys_id);
         s.peer_fad.remove(sys_id);
         s.peer_link_affinity.remove(sys_id);
+        s.peer_algo_sid.remove(sys_id);
         return;
     }
 
@@ -351,6 +359,28 @@ pub(super) fn rebuild_sys_state(
         s.peer_link_affinity.remove(sys_id);
     } else {
         s.peer_link_affinity.insert(*sys_id, link_affinity);
+    }
+
+    // Per-algorithm Prefix-SIDs from peer Ext IP-Reach (TLV 135)
+    // entries (RFC 8667 §2.1 + RFC 9350 §7). One entry per
+    // (peer, algo, prefix); for the same key across fragments,
+    // last-wins via BTreeMap::insert.
+    let mut algo_sids: BTreeMap<(u8, ipnet::Ipv4Net), SidLabelValue> = BTreeMap::new();
+    for f in &frags {
+        for tlv in &f.tlvs {
+            if let IsisTlv::ExtIpReach(t) = tlv {
+                for entry in &t.entries {
+                    for (algo, sid) in super::flex_algo::parse_per_algo_prefix_sids(entry) {
+                        algo_sids.insert((algo, entry.prefix), sid);
+                    }
+                }
+            }
+        }
+    }
+    if algo_sids.is_empty() {
+        s.peer_algo_sid.remove(sys_id);
+    } else {
+        s.peer_algo_sid.insert(*sys_id, algo_sids);
     }
 
     // --- Distributable (union across fragments) ---------------------
@@ -485,6 +515,7 @@ pub fn insert_lsp(top: &mut LinkTop, level: Level, lsp: IsisLsp, bytes: Vec<u8>)
                 srv6_end_map: top.srv6_end_map.get_mut(&level),
                 peer_fad: top.peer_fad.get_mut(&level),
                 peer_link_affinity: top.peer_link_affinity.get_mut(&level),
+                peer_algo_sid: top.peer_algo_sid.get_mut(&level),
             },
         );
     }
@@ -571,6 +602,7 @@ pub fn remove_lsp(top: &mut IsisTop, level: Level, key: IsisLspId) {
             srv6_end_map: top.srv6_end_map.get_mut(&level),
             peer_fad: top.peer_fad.get_mut(&level),
             peer_link_affinity: top.peer_link_affinity.get_mut(&level),
+            peer_algo_sid: top.peer_algo_sid.get_mut(&level),
         },
     );
 }
@@ -673,6 +705,8 @@ mod tests {
         let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
         let mut peer_link_affinity: BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>> =
             BTreeMap::new();
+        let mut peer_algo_sid: BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), SidLabelValue>> =
+            BTreeMap::new();
 
         rebuild_sys_state(
             &lsdb,
@@ -688,6 +722,7 @@ mod tests {
                 srv6_end_map: &mut srv6_end_map,
                 peer_fad: &mut peer_fad,
                 peer_link_affinity: &mut peer_link_affinity,
+                peer_algo_sid: &mut peer_algo_sid,
             },
         );
 
@@ -717,6 +752,7 @@ mod tests {
                 srv6_end_map: &mut srv6_end_map,
                 peer_fad: &mut peer_fad,
                 peer_link_affinity: &mut peer_link_affinity,
+                peer_algo_sid: &mut peer_algo_sid,
             },
         );
         assert!(
@@ -743,6 +779,7 @@ mod tests {
                 srv6_end_map: &mut srv6_end_map,
                 peer_fad: &mut peer_fad,
                 peer_link_affinity: &mut peer_link_affinity,
+                peer_algo_sid: &mut peer_algo_sid,
             },
         );
         assert!(reach_v4.get(&peer).is_none());
@@ -778,6 +815,8 @@ mod tests {
         let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
         let mut peer_link_affinity: BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>> =
             BTreeMap::new();
+        let mut peer_algo_sid: BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), SidLabelValue>> =
+            BTreeMap::new();
 
         rebuild_sys_state(
             &lsdb,
@@ -793,6 +832,7 @@ mod tests {
                 srv6_end_map: &mut srv6_end_map,
                 peer_fad: &mut peer_fad,
                 peer_link_affinity: &mut peer_link_affinity,
+                peer_algo_sid: &mut peer_algo_sid,
             },
         );
 
@@ -847,6 +887,8 @@ mod tests {
         let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
         let mut peer_link_affinity: BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>> =
             BTreeMap::new();
+        let mut peer_algo_sid: BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), SidLabelValue>> =
+            BTreeMap::new();
 
         rebuild_sys_state(
             &lsdb,
@@ -862,6 +904,7 @@ mod tests {
                 srv6_end_map: &mut srv6_end_map,
                 peer_fad: &mut peer_fad,
                 peer_link_affinity: &mut peer_link_affinity,
+                peer_algo_sid: &mut peer_algo_sid,
             },
         );
 
@@ -888,6 +931,7 @@ mod tests {
                 srv6_end_map: &mut srv6_end_map,
                 peer_fad: &mut peer_fad,
                 peer_link_affinity: &mut peer_link_affinity,
+                peer_algo_sid: &mut peer_algo_sid,
             },
         );
         assert!(
@@ -957,6 +1001,8 @@ mod tests {
         let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
         let mut peer_link_affinity: BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>> =
             BTreeMap::new();
+        let mut peer_algo_sid: BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), SidLabelValue>> =
+            BTreeMap::new();
 
         rebuild_sys_state(
             &lsdb,
@@ -972,6 +1018,7 @@ mod tests {
                 srv6_end_map: &mut srv6_end_map,
                 peer_fad: &mut peer_fad,
                 peer_link_affinity: &mut peer_link_affinity,
+                peer_algo_sid: &mut peer_algo_sid,
             },
         );
 
@@ -999,8 +1046,106 @@ mod tests {
                 srv6_end_map: &mut srv6_end_map,
                 peer_fad: &mut peer_fad,
                 peer_link_affinity: &mut peer_link_affinity,
+                peer_algo_sid: &mut peer_algo_sid,
             },
         );
         assert!(!peer_link_affinity.contains_key(&peer));
+    }
+
+    /// A peer Ext IP-Reach entry with mixed algo-0 + flex-algo
+    /// Prefix-SID sub-TLVs must populate
+    /// `peer_algo_sid[sys_id][(algo, prefix)]` with only the
+    /// flex-algo entries. Dropping the fragment clears the peer.
+    #[test]
+    fn rebuild_populates_and_clears_peer_algo_sid() {
+        use isis_packet::PrefixSidFlags;
+        use isis_packet::prefix::{Ipv4ControlInfo, IsisSubTlv as PrefixSubTlv};
+
+        let mut lsdb = Lsdb::default();
+        let peer = sys(11);
+        let prefix: Ipv4Net = "10.0.0.1/32".parse().unwrap();
+        let entry = IsisTlvExtIpReachEntry {
+            metric: 10,
+            flags: Ipv4ControlInfo::new(),
+            prefix,
+            subs: vec![
+                PrefixSubTlv::PrefixSid(isis_packet::IsisSubPrefixSid {
+                    flags: PrefixSidFlags::from(0u8),
+                    algo: Algo::Spf,
+                    sid: SidLabelValue::Index(1),
+                }),
+                PrefixSubTlv::PrefixSid(isis_packet::IsisSubPrefixSid {
+                    flags: PrefixSidFlags::from(0u8),
+                    algo: Algo::FlexAlgo(128),
+                    sid: SidLabelValue::Index(1128),
+                }),
+            ],
+        };
+        let mut f0 = frag(peer, 0);
+        f0.tlvs.push(IsisTlv::ExtIpReach(IsisTlvExtIpReach {
+            entries: vec![entry],
+        }));
+        lsdb.map.insert(f0.lsp_id, Lsa::new(f0));
+
+        let mut hostname = Hostname::default();
+        let mut label_map = IsisLabelMap::default();
+        let mut reach_v4 = ReachMap::default();
+        let mut reach_v6 = ReachMapV6::default();
+        let mut mt_membership: BTreeMap<IsisSysId, BTreeSet<MtId>> = BTreeMap::new();
+        let mut mt2_reach_v6 = ReachMapV6::default();
+        let mut srv6_end_map: BTreeMap<IsisSysId, Ipv6Addr> = BTreeMap::new();
+        let mut peer_fad: BTreeMap<IsisSysId, BTreeMap<u8, IsisSubFlexAlgoDef>> = BTreeMap::new();
+        let mut peer_link_affinity: BTreeMap<IsisSysId, BTreeMap<IsisNeighborId, ExtAdminGroup>> =
+            BTreeMap::new();
+        let mut peer_algo_sid: BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), SidLabelValue>> =
+            BTreeMap::new();
+
+        rebuild_sys_state(
+            &lsdb,
+            &sys(0xFF),
+            &peer,
+            SysStateRefs {
+                hostname: &mut hostname,
+                label_map: &mut label_map,
+                reach_v4: &mut reach_v4,
+                reach_v6: &mut reach_v6,
+                mt_membership: &mut mt_membership,
+                mt2_reach_v6: &mut mt2_reach_v6,
+                srv6_end_map: &mut srv6_end_map,
+                peer_fad: &mut peer_fad,
+                peer_link_affinity: &mut peer_link_affinity,
+                peer_algo_sid: &mut peer_algo_sid,
+            },
+        );
+
+        let entries = peer_algo_sid
+            .get(&peer)
+            .expect("peer_algo_sid must populate");
+        // Algo-0 entry must be skipped; only flex-algo 128 cached.
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries.get(&(128, prefix)),
+            Some(&SidLabelValue::Index(1128))
+        );
+
+        lsdb.map.remove(&IsisLspId::new(peer, 0, 0));
+        rebuild_sys_state(
+            &lsdb,
+            &sys(0xFF),
+            &peer,
+            SysStateRefs {
+                hostname: &mut hostname,
+                label_map: &mut label_map,
+                reach_v4: &mut reach_v4,
+                reach_v6: &mut reach_v6,
+                mt_membership: &mut mt_membership,
+                mt2_reach_v6: &mut mt2_reach_v6,
+                srv6_end_map: &mut srv6_end_map,
+                peer_fad: &mut peer_fad,
+                peer_link_affinity: &mut peer_link_affinity,
+                peer_algo_sid: &mut peer_algo_sid,
+            },
+        );
+        assert!(!peer_algo_sid.contains_key(&peer));
     }
 }


### PR DESCRIPTION
## Summary

Third consume-side flex-algo step. PR #614 emits per-algo Prefix-SID sub-TLVs on Ext IP-Reach (TLV 135) loopback entries; this PR closes the symmetry by decoding peer-advertised per-algo SIDs into a per-peer / per-(algo, prefix) label store. Combined with `peer_fad` and `peer_link_affinity`, the per-peer caches now hold every wire input SPF gating + per-algo RIB install will need.

- `flex_algo::parse_per_algo_prefix_sids(entry)` — iterator over `(algo, sid)` pairs for each Prefix-SID sub-TLV (RFC 8667 §2.1) on the IP-reach entry whose Algorithm is in the flex-algo range (128..=255). `Algo::Spf` / `Algo::StrictSpf` / unknown algos are filtered out. Round-trips with the producer-side `build_per_algo_prefix_sids`.
- `Isis::peer_algo_sid: Levels<BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), SidLabelValue>>>` — per L1/L2, per peer, per `(algo, prefix)` tuple. Threaded through `IsisTop`, `LinkTop`, `SysStateRefs` (10 construction sites: 2 production + 8 test).
- `rebuild_sys_state` walks every fragment's `IsisTlv::ExtIpReach`; per entry runs `parse_per_algo_prefix_sids` and inserts results keyed by `(algo, entry.prefix)`. Union across fragments with last-wins on duplicate `(algo, prefix)`. Empty result ⇒ `peer_algo_sid.remove(sys_id)`.

### Deliberately out of scope
- IPv6 per-algo Prefix-SID parse — YANG doesn't model `ipv6/flex-algo-prefix-sid` yet and PR #614 doesn't emit there.
- SPF gating that consumes `peer_fad` + `peer_link_affinity` + `peer_algo_sid` together (next PR).
- Per-algo RIB install (after SPF gating).

## Test plan

- [x] `cargo build -p zebra-rs --bin zebra-rs` — clean (rebased onto PR #617's PeerKey refactor)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p zebra-rs --bin zebra-rs --all-targets -- -D warnings` — clean
- [x] `cargo test -p zebra-rs --bin zebra-rs isis::` — 81 pass:
  - 2 new on `flex_algo::parse_per_algo_prefix_sids` (filter to flex-algo range, round-trip through `build_per_algo_prefix_sids`)
  - 1 new on `lsdb::rebuild_populates_and_clears_peer_algo_sid` (algo-0 entry skipped, flex-algo entry cached, fragment drop clears)
- [ ] End-to-end CLI: receive Prefix-SID-bearing LSP from peer, verify `peer_algo_sid` populates (manual, post-merge)

Generated with [Claude Code](https://claude.com/claude-code)