### PR TITLE
nd: raw ICMPv6 socket scaffolding for RA send / receive

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -50,6 +50,7 @@ ospf-macros = { path = "../crates/ospf-macros" }
 isis-packet = { path = "../crates/isis-packet" }
 isis-macros = { path = "../crates/isis-macros" }
 bfd-packet = { path = "../crates/bfd-packet" }
+nd-packet = { path = "../crates/nd-packet" }
 bitfield-struct = "0.13"
 rand = "0.10"
 chrono = { version = "0.4", features = ["serde"] }

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -13,6 +13,7 @@ mod bfd;
 mod context;
 mod fib;
 mod isis;
+mod nd;
 mod ospf;
 mod srv6;
 

--- a/zebra-rs/src/nd/mod.rs
+++ b/zebra-rs/src/nd/mod.rs
@@ -1,0 +1,52 @@
+//! IPv6 Neighbor Discovery — Router Advertisement / Router Solicitation
+//! transport plumbing.
+//!
+//! This module is the runtime counterpart to the `nd-packet` crate: it
+//! brings up a raw `IPPROTO_ICMPV6` socket configured per RFC 4861
+//! §6.1 (hop limit = 255 on both send and receive, ICMP6_FILTER scoped
+//! to RS + RA only) and provides async read / write tasks that hand
+//! parsed packets to the rest of the daemon via channels.
+//!
+//! Higher-level concerns (per-interface RA send state machine, RIB
+//! integration, BGP unnumbered hand-off) live in follow-up PRs. The
+//! scaffolding here is deliberately runtime-passive — nothing is
+//! spawned from `main.rs` yet — so this PR is shippable on its own.
+#![allow(dead_code)]
+
+use std::net::Ipv6Addr;
+
+use nd_packet::{RouterAdvert, RouterSolicit};
+
+pub mod network;
+pub mod socket;
+
+/// Inbound ND messages produced by [`network::read_packet`].
+#[derive(Debug)]
+pub enum NdRecv {
+    RouterAdvert {
+        ifindex: u32,
+        src: Ipv6Addr,
+        ra: RouterAdvert,
+    },
+    RouterSolicit {
+        ifindex: u32,
+        src: Ipv6Addr,
+        rs: RouterSolicit,
+    },
+}
+
+/// Outbound ND messages consumed by [`network::write_packet`].
+#[derive(Debug)]
+pub enum NdSend {
+    /// Send a Router Advertisement out `ifindex` to `dst`. For an
+    /// unsolicited multicast RA `dst` should be `ff02::1`; for a
+    /// solicited reply, the unicast source of the RS.
+    RouterAdvert {
+        ifindex: u32,
+        dst: Ipv6Addr,
+        ra: RouterAdvert,
+    },
+    /// Send a Router Solicitation out `ifindex` to `ff02::2`
+    /// (all-routers multicast).
+    RouterSolicit { ifindex: u32, rs: RouterSolicit },
+}

--- a/zebra-rs/src/nd/network.rs
+++ b/zebra-rs/src/nd/network.rs
@@ -1,0 +1,151 @@
+//! Async read / write tasks for the ND raw socket.
+//!
+//! Mirrors the OSPF `read_packet` / `write_packet` shape in
+//! `crate::ospf::network` so the runtime wiring (channels, cmsg
+//! plumbing, `AsyncFd::async_io`) is familiar.
+//!
+//! Inbound packets are filtered to ICMPv6 RA + RS by the kernel
+//! (`ICMP6_FILTER` was set in [`super::socket::nd_socket`]); we add
+//! one more application-layer check here: drop anything whose
+//! IPv6 hop limit isn't 255, per RFC 4861 §6.1.2. The kernel can't
+//! enforce that on raw sockets, so it's our job.
+#![allow(dead_code)]
+
+use std::io::{ErrorKind, IoSlice, IoSliceMut};
+use std::net::Ipv6Addr;
+use std::os::fd::AsRawFd;
+use std::sync::Arc;
+
+use bytes::BytesMut;
+use nd_packet::{Icmp6Type, RouterAdvert, RouterSolicit};
+use nix::sys::socket::{self, ControlMessageOwned, SockaddrIn6};
+use socket2::Socket;
+use tokio::io::Interest;
+use tokio::io::unix::AsyncFd;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+
+use super::{NdRecv, NdSend};
+
+/// Hop limit required by RFC 4861 §6.1.2 — anything else is dropped.
+const REQUIRED_HOP_LIMIT: i32 = 255;
+
+/// All-routers multicast address (RFC 4291 §2.7.1).
+const ALL_ROUTERS: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0x2);
+
+/// Read loop: parse ICMPv6 packets off the raw socket, deliver
+/// [`NdRecv`] messages on `tx`. Drops malformed packets and packets
+/// failing the hop-limit-255 check silently — both situations are
+/// "MUST silently discard" in RFC 4861.
+pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<NdRecv>) {
+    let mut buf = [0u8; 1500];
+    let mut iov = [IoSliceMut::new(&mut buf)];
+    let mut cmsgspace = nix::cmsg_space!(libc::in6_pktinfo, libc::c_int);
+
+    loop {
+        let _ = sock
+            .async_io(Interest::READABLE, |sock| {
+                let msg = socket::recvmsg::<SockaddrIn6>(
+                    sock.as_raw_fd(),
+                    &mut iov,
+                    Some(&mut cmsgspace),
+                    socket::MsgFlags::empty(),
+                )?;
+
+                let Some(src_sa) = msg.address else {
+                    return Err(ErrorKind::AddrNotAvailable.into());
+                };
+                let src: Ipv6Addr = src_sa.ip();
+
+                let mut ifindex: Option<u32> = None;
+                let mut hop_limit: Option<i32> = None;
+                for cm in msg.cmsgs()? {
+                    match cm {
+                        ControlMessageOwned::Ipv6PacketInfo(info) => {
+                            ifindex = Some(info.ipi6_ifindex);
+                        }
+                        ControlMessageOwned::Ipv6HopLimit(hl) => {
+                            hop_limit = Some(hl);
+                        }
+                        _ => {}
+                    }
+                }
+                let (Some(ifindex), Some(hop_limit)) = (ifindex, hop_limit) else {
+                    return Err(ErrorKind::InvalidData.into());
+                };
+                if hop_limit != REQUIRED_HOP_LIMIT {
+                    // RFC 4861 §6.1.2: silently drop.
+                    return Ok(());
+                }
+
+                let Some(payload) = msg.iovs().next() else {
+                    return Err(ErrorKind::UnexpectedEof.into());
+                };
+                if payload.is_empty() {
+                    return Ok(());
+                }
+
+                let parsed = match Icmp6Type::from_u8(payload[0]) {
+                    Some(Icmp6Type::RouterAdvert) => match RouterAdvert::parse(payload, None) {
+                        Ok(ra) => NdRecv::RouterAdvert { ifindex, src, ra },
+                        Err(_) => return Ok(()),
+                    },
+                    Some(Icmp6Type::RouterSolicit) => match RouterSolicit::parse(payload, None) {
+                        Ok(rs) => NdRecv::RouterSolicit { ifindex, src, rs },
+                        Err(_) => return Ok(()),
+                    },
+                    None => return Ok(()),
+                };
+
+                // If the parent task drops the receiver, the read task
+                // should exit rather than spin — but a SendError doesn't
+                // surface here. Caller is expected to keep tx alive for
+                // the socket's lifetime.
+                let _ = tx.send(parsed);
+                Ok(())
+            })
+            .await;
+    }
+}
+
+/// Write loop: serialize [`NdSend`] messages and emit them via
+/// sendmsg with an `IPV6_PKTINFO` cmsg pinning the egress ifindex.
+/// The ICMPv6 checksum is computed by the kernel (we set
+/// `IPV6_CHECKSUM = 2` on socket bring-up).
+pub async fn write_packet(sock: Arc<AsyncFd<Socket>>, mut rx: UnboundedReceiver<NdSend>) {
+    while let Some(msg) = rx.recv().await {
+        let (ifindex, dst, payload) = match msg {
+            NdSend::RouterAdvert { ifindex, dst, ra } => {
+                let mut buf = BytesMut::new();
+                ra.emit_without_checksum(&mut buf);
+                (ifindex, dst, buf)
+            }
+            NdSend::RouterSolicit { ifindex, rs } => {
+                let mut buf = BytesMut::new();
+                rs.emit_without_checksum(&mut buf);
+                (ifindex, ALL_ROUTERS, buf)
+            }
+        };
+
+        let iov = [IoSlice::new(&payload)];
+        let sockaddr: SockaddrIn6 = std::net::SocketAddrV6::new(dst, 0, 0, ifindex).into();
+        let pktinfo = libc::in6_pktinfo {
+            ipi6_addr: libc::in6_addr { s6_addr: [0u8; 16] },
+            ipi6_ifindex: ifindex,
+        };
+        let cmsg = [socket::ControlMessage::Ipv6PacketInfo(&pktinfo)];
+
+        let _ = sock
+            .async_io(Interest::WRITABLE, |sock| {
+                socket::sendmsg(
+                    sock.as_raw_fd(),
+                    &iov,
+                    &cmsg,
+                    socket::MsgFlags::empty(),
+                    Some(&sockaddr),
+                )
+                .map_err(std::io::Error::from)?;
+                Ok(())
+            })
+            .await;
+    }
+}

--- a/zebra-rs/src/nd/socket.rs
+++ b/zebra-rs/src/nd/socket.rs
@@ -1,0 +1,231 @@
+//! Raw `IPPROTO_ICMPV6` socket bring-up for Neighbor Discovery.
+//!
+//! All knobs follow RFC 4861 §6.1:
+//!   * Outgoing hop limit = 255 (both unicast and multicast). Routers
+//!     receiving NDP messages MUST silently drop any frame whose hop
+//!     limit isn't 255, which is how we get on-link guarantees.
+//!   * `IPV6_RECVHOPLIMIT` on so the receive side can enforce the
+//!     same check on inbound packets.
+//!   * `IPV6_RECVPKTINFO` on so the receive side learns the
+//!     destination address and arriving ifindex.
+//!   * `IPV6_CHECKSUM` set to the 2-byte offset of the ICMPv6
+//!     checksum field, letting the kernel compute and write it for us
+//!     — saves the userland round-trip.
+//!   * `ICMP6_FILTER` scoped to RS (133) + RA (134) so neighbor
+//!     solicitation / advertisement (135 / 136) and the kernel's NDP
+//!     cache are left alone.
+//!
+//! Errors from each setsockopt are surfaced via the [`SocketError`]
+//! enum so callers can distinguish "no CAP_NET_RAW" from a knob the
+//! kernel rejected.
+#![allow(dead_code)]
+
+use std::io;
+use std::mem;
+use std::os::fd::AsRawFd;
+use std::os::raw::c_int;
+
+use socket2::{Domain, Protocol, Socket, Type};
+use tokio::io::unix::AsyncFd;
+
+/// ICMPv6 protocol number per RFC 4443.
+const IPPROTO_ICMPV6: i32 = 58;
+
+/// `ICMP6_FILTER` is not in libc as a constant on all targets; the
+/// kernel ABI value is 1 on Linux.
+const ICMP6_FILTER_OPT: c_int = 1;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SocketError {
+    #[error("create raw ICMPv6 socket failed (need CAP_NET_RAW): {0}")]
+    Create(io::Error),
+    #[error("set IPV6_MULTICAST_HOPS=255 failed: {0}")]
+    MulticastHops(io::Error),
+    #[error("set IPV6_UNICAST_HOPS=255 failed: {0}")]
+    UnicastHops(io::Error),
+    #[error("set IPV6_RECVHOPLIMIT failed: {0}")]
+    RecvHopLimit(io::Error),
+    #[error("set IPV6_RECVPKTINFO failed: {0}")]
+    RecvPktInfo(io::Error),
+    #[error("set IPV6_CHECKSUM failed: {0}")]
+    Checksum(io::Error),
+    #[error("set ICMP6_FILTER failed: {0}")]
+    Filter(io::Error),
+    #[error("wrap socket in AsyncFd failed: {0}")]
+    AsyncFd(io::Error),
+}
+
+/// Build a configured ICMPv6 ND socket and wrap it for tokio I/O.
+pub fn nd_socket() -> Result<AsyncFd<Socket>, SocketError> {
+    let socket = Socket::new(
+        Domain::IPV6,
+        Type::RAW,
+        Some(Protocol::from(IPPROTO_ICMPV6)),
+    )
+    .map_err(SocketError::Create)?;
+    socket.set_nonblocking(true).map_err(SocketError::Create)?;
+
+    set_multicast_hops_255(&socket).map_err(SocketError::MulticastHops)?;
+    set_unicast_hops_255(&socket).map_err(SocketError::UnicastHops)?;
+    set_recv_hop_limit(&socket).map_err(SocketError::RecvHopLimit)?;
+    set_recv_pkt_info(&socket).map_err(SocketError::RecvPktInfo)?;
+    // Kernel-computed checksum: the field is at byte offset 2 of any
+    // ICMPv6 message.
+    set_checksum_offset(&socket, 2).map_err(SocketError::Checksum)?;
+    let filter = Icmp6Filter::pass_only(&[133, 134]);
+    apply_icmp6_filter(&socket, &filter).map_err(SocketError::Filter)?;
+
+    AsyncFd::new(socket).map_err(SocketError::AsyncFd)
+}
+
+fn set_multicast_hops_255(s: &Socket) -> io::Result<()> {
+    let v: c_int = 255;
+    unsafe {
+        setsockopt_int(
+            s.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            libc::IPV6_MULTICAST_HOPS,
+            v,
+        )
+    }
+}
+
+fn set_unicast_hops_255(s: &Socket) -> io::Result<()> {
+    let v: c_int = 255;
+    unsafe {
+        setsockopt_int(
+            s.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            libc::IPV6_UNICAST_HOPS,
+            v,
+        )
+    }
+}
+
+fn set_recv_hop_limit(s: &Socket) -> io::Result<()> {
+    let v: c_int = 1;
+    unsafe {
+        setsockopt_int(
+            s.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            libc::IPV6_RECVHOPLIMIT,
+            v,
+        )
+    }
+}
+
+fn set_recv_pkt_info(s: &Socket) -> io::Result<()> {
+    let v: c_int = 1;
+    unsafe { setsockopt_int(s.as_raw_fd(), libc::IPPROTO_IPV6, libc::IPV6_RECVPKTINFO, v) }
+}
+
+fn set_checksum_offset(s: &Socket, offset: c_int) -> io::Result<()> {
+    unsafe { setsockopt_int(s.as_raw_fd(), IPPROTO_ICMPV6, libc::IPV6_CHECKSUM, offset) }
+}
+
+fn apply_icmp6_filter(s: &Socket, filter: &Icmp6Filter) -> io::Result<()> {
+    let ret = unsafe {
+        libc::setsockopt(
+            s.as_raw_fd(),
+            IPPROTO_ICMPV6,
+            ICMP6_FILTER_OPT,
+            filter.as_ptr(),
+            mem::size_of::<Icmp6Filter>() as libc::socklen_t,
+        )
+    };
+    if ret < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+unsafe fn setsockopt_int(fd: i32, level: c_int, name: c_int, value: c_int) -> io::Result<()> {
+    let ret = unsafe {
+        libc::setsockopt(
+            fd,
+            level,
+            name,
+            &value as *const c_int as *const libc::c_void,
+            mem::size_of::<c_int>() as libc::socklen_t,
+        )
+    };
+    if ret < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+/// `struct icmp6_filter` from `<netinet/icmp6.h>`. 8 × 32 bits, one
+/// bit per ICMPv6 type — a set bit means BLOCK, a clear bit means
+/// PASS (when used with the "block list" semantics). We always start
+/// from an all-block state and clear bits for the types we want.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct Icmp6Filter {
+    filt: [u32; 8],
+}
+
+impl Icmp6Filter {
+    /// Build a filter that passes only the ICMPv6 types in `types`.
+    /// Everything else is blocked.
+    pub fn pass_only(types: &[u8]) -> Self {
+        let mut f = Self {
+            filt: [0xffff_ffff; 8],
+        };
+        for &t in types {
+            // Clear the bit at position `t` — the kernel macro
+            // `ICMP6_FILTER_SETPASS` indexes filt[type >> 5] and
+            // clears bit `type & 0x1f`.
+            let word = (t as usize) >> 5;
+            let bit = (t as usize) & 0x1f;
+            f.filt[word] &= !(1u32 << bit);
+        }
+        f
+    }
+
+    fn as_ptr(&self) -> *const libc::c_void {
+        self as *const Self as *const libc::c_void
+    }
+
+    /// Test helper: would this filter pass an ICMPv6 message of type
+    /// `t`? Mirrors the `ICMP6_FILTER_WILLPASS` kernel macro.
+    pub fn will_pass(&self, t: u8) -> bool {
+        let word = (t as usize) >> 5;
+        let bit = (t as usize) & 0x1f;
+        (self.filt[word] & (1u32 << bit)) == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filter_pass_only_passes_listed_types() {
+        let f = Icmp6Filter::pass_only(&[133, 134]);
+        assert!(f.will_pass(133));
+        assert!(f.will_pass(134));
+        assert!(!f.will_pass(135));
+        assert!(!f.will_pass(136));
+        assert!(!f.will_pass(128));
+        assert!(!f.will_pass(0));
+    }
+
+    #[test]
+    fn filter_empty_list_blocks_everything() {
+        let f = Icmp6Filter::pass_only(&[]);
+        for t in 0u8..=255 {
+            assert!(!f.will_pass(t), "type {} unexpectedly passed", t);
+        }
+    }
+
+    #[test]
+    fn filter_struct_layout_matches_kernel() {
+        // The kernel ABI is a 32-byte struct of 8 little-endian u32s.
+        // Rust's #[repr(C)] on a primitive-array struct matches that
+        // on Linux. Asserting the size catches accidental drift.
+        assert_eq!(mem::size_of::<Icmp6Filter>(), 32);
+    }
+}


### PR DESCRIPTION
## Summary
- Runtime counterpart to `nd-packet`: brings up a raw `IPPROTO_ICMPV6` socket per RFC 4861 §6.1 plus the async read / write tasks that the upcoming RA send state machine will drive.
- `socket.rs::nd_socket()` returns `AsyncFd<Socket>` with all RFC-mandated knobs in place:
  * `IPV6_{MULTICAST,UNICAST}_HOPS = 255` (every outbound NDP frame must have HL 255 — that's the on-link guarantee).
  * `IPV6_RECVHOPLIMIT` + `IPV6_RECVPKTINFO` so the read path learns the arriving HL and ifindex.
  * `IPV6_CHECKSUM = 2` — kernel computes the outbound ICMPv6 checksum.
  * `ICMP6_FILTER` scoped to types 133 (RS) + 134 (RA) so NS / NA and the kernel's NDP cache are left undisturbed.
- `network.rs::read_packet` / `write_packet` follow the OSPF pattern (`AsyncFd`, `nix::sys::socket::{recvmsg,sendmsg}` with cmsg plumbing). Read path enforces hop-limit == 255 at the application layer per RFC 4861 §6.1.2; bad packets are dropped silently.
- Wired into `main.rs` as `mod nd;` but **no tasks are spawned yet** — module sits at `#![allow(dead_code)]` until the send state-machine PR plugs it in.
- `Icmp6Filter` ABI struct with kernel-layout asserts.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bin zebra-rs nd::` — 3 unit tests pass (Icmp6Filter struct size matches kernel ABI, pass-list semantics, empty-list blocks everything)
- [x] Full workspace test suite stays green

## Notes
Builds on #620 (nd-packet codec) — depends on the `nd_packet` crate that PR introduced.

Generated with [Claude Code](https://claude.com/claude-code)