### PR TITLE
nd: engine + Nd instance plumbing for the RA subsystem

### DIFF
--- a/zebra-rs/src/nd/engine.rs
+++ b/zebra-rs/src/nd/engine.rs
@@ -1,0 +1,295 @@
+//! Pure-logic core for the ND subsystem.
+//!
+//! Owns the per-interface [`RaSender`]s, holds a single subscriber
+//! [`mpsc::UnboundedSender<NdEvent>`] for downstream consumers (the
+//! BGP unnumbered runtime in a follow-up PR), and turns received
+//! [`NdRecv`] frames + timer ticks into outbound [`NdSend`] frames
+//! plus [`NdEvent`] notifications.
+//!
+//! Synchronous — no I/O, no tokio. The async wrapper in `inst.rs`
+//! drives this with a `tokio::select!` loop. Keeping the logic
+//! separable lets the wakeup ordering, RS-collapse semantics, and
+//! enable / disable lifecycle be unit-tested in milliseconds without
+//! a raw socket.
+#![allow(dead_code)]
+
+use std::collections::BTreeMap;
+use std::net::Ipv6Addr;
+use std::time::Instant;
+
+use super::send::{RaEvent, RaSendConfig, RaSender};
+use super::{NdRecv, NdSend};
+
+/// Lifecycle events emitted by [`NdEngine`] for downstream consumers.
+/// One subscriber today (BGP unnumbered will plug in here); a
+/// broadcast fan-out can replace the single Sender later if needed.
+#[derive(Debug, Clone)]
+pub enum NdEvent {
+    /// A Router Advertisement arrived on `ifindex` whose source IPv6
+    /// address (a link-local) identifies a potential BGP unnumbered
+    /// peer. Sent once per RA — the consumer is responsible for
+    /// debouncing repeats.
+    NeighborDiscovered { ifindex: u32, src: Ipv6Addr },
+}
+
+pub struct NdEngine {
+    senders: BTreeMap<u32, RaSender>,
+    notifier: Option<tokio::sync::mpsc::UnboundedSender<NdEvent>>,
+}
+
+impl NdEngine {
+    pub fn new() -> Self {
+        Self {
+            senders: BTreeMap::new(),
+            notifier: None,
+        }
+    }
+
+    /// Attach a single downstream subscriber. Calling twice replaces
+    /// the previous channel; consumers that need multi-subscriber
+    /// fan-out should layer a broadcast outside.
+    pub fn set_notifier(&mut self, tx: tokio::sync::mpsc::UnboundedSender<NdEvent>) {
+        self.notifier = Some(tx);
+    }
+
+    pub fn enable_interface(&mut self, ifindex: u32, cfg: RaSendConfig, now: Instant) {
+        // Replacing an existing sender re-runs initial bring-up; that
+        // matches operator expectation when toggling RA off and on.
+        self.senders.insert(ifindex, RaSender::new(cfg, now));
+    }
+
+    pub fn disable_interface(&mut self, ifindex: u32) {
+        self.senders.remove(&ifindex);
+    }
+
+    pub fn is_enabled(&self, ifindex: u32) -> bool {
+        self.senders.contains_key(&ifindex)
+    }
+
+    /// Earliest pending wakeup across all enabled interfaces. `None`
+    /// when no interfaces are enabled — caller can park the timer
+    /// indefinitely.
+    pub fn next_wakeup(&self) -> Option<Instant> {
+        self.senders.values().map(|s| s.next_wakeup()).min()
+    }
+
+    /// Handle an inbound ND frame: emit a [`NdEvent::NeighborDiscovered`]
+    /// for the RA case (the BGP unnumbered hand-off), and forward RS
+    /// events into the matching sender so a solicited reply gets
+    /// scheduled.
+    pub fn on_recv(&mut self, recv: NdRecv, now: Instant) {
+        match recv {
+            NdRecv::RouterAdvert { ifindex, src, .. } => {
+                if let Some(tx) = &self.notifier {
+                    // Ignore SendError — a closed subscriber just
+                    // means nobody's listening, not a fatal state.
+                    let _ = tx.send(NdEvent::NeighborDiscovered { ifindex, src });
+                }
+            }
+            NdRecv::RouterSolicit { ifindex, src, .. } => {
+                if let Some(sender) = self.senders.get_mut(&ifindex) {
+                    sender.on_router_solicit(src, now);
+                }
+            }
+        }
+    }
+
+    /// Advance the timer to `now`. Returns the outbound frames that
+    /// should be written to the socket — typically empty, occasionally
+    /// one per interface whose scheduler matured.
+    pub fn tick(&mut self, now: Instant) -> Vec<NdSend> {
+        let mut out = Vec::new();
+        for (&ifindex, sender) in self.senders.iter_mut() {
+            for ev in sender.tick(now) {
+                match ev {
+                    RaEvent::SendUnsolicited { ra } => out.push(NdSend::RouterAdvert {
+                        ifindex,
+                        dst: ALL_NODES,
+                        ra,
+                    }),
+                    RaEvent::SendSolicited { ra } => out.push(NdSend::RouterAdvert {
+                        ifindex,
+                        dst: ALL_NODES,
+                        ra,
+                    }),
+                }
+            }
+        }
+        out
+    }
+}
+
+impl Default for NdEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// `ff02::1` — all-nodes multicast (RFC 4291 §2.7.1). Used as the
+/// destination for both unsolicited RAs and (per RFC 4861 §6.2.6,
+/// when the RS arrived from a multicast source) solicited replies.
+/// Unicast-replied solicited RAs are not yet emitted by this engine.
+const ALL_NODES: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0x1);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nd::send::RaSendConfig;
+    use nd_packet::{RouterAdvert, RouterSolicit};
+    use tokio::sync::mpsc;
+
+    fn t0() -> Instant {
+        Instant::now()
+    }
+
+    fn ll(s: &str) -> Ipv6Addr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn no_interfaces_means_no_wakeup() {
+        let eng = NdEngine::new();
+        assert!(eng.next_wakeup().is_none());
+    }
+
+    #[test]
+    fn enable_then_disable_clears_wakeup() {
+        let start = t0();
+        let mut eng = NdEngine::new();
+        eng.enable_interface(7, RaSendConfig::default(), start);
+        assert!(eng.next_wakeup().is_some());
+
+        eng.disable_interface(7);
+        assert!(eng.next_wakeup().is_none());
+        assert!(!eng.is_enabled(7));
+    }
+
+    #[test]
+    fn next_wakeup_returns_earliest_across_interfaces() {
+        let start = t0();
+        let mut eng = NdEngine::new();
+        eng.enable_interface(1, RaSendConfig::default(), start);
+        eng.enable_interface(2, RaSendConfig::default(), start);
+
+        // Wakeup must be >= start (initial RA scheduled in the future).
+        let next = eng.next_wakeup().unwrap();
+        assert!(next >= start);
+    }
+
+    #[test]
+    fn router_advert_recv_emits_neighbor_discovered() {
+        let mut eng = NdEngine::new();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        eng.set_notifier(tx);
+
+        eng.on_recv(
+            NdRecv::RouterAdvert {
+                ifindex: 5,
+                src: ll("fe80::1"),
+                ra: RouterAdvert {
+                    cur_hop_limit: 64,
+                    flags: Default::default(),
+                    router_lifetime: 1800,
+                    reachable_time: 0,
+                    retrans_timer: 0,
+                    options: vec![],
+                },
+            },
+            t0(),
+        );
+
+        let ev = rx.try_recv().expect("notifier received an event");
+        match ev {
+            NdEvent::NeighborDiscovered { ifindex, src } => {
+                assert_eq!(ifindex, 5);
+                assert_eq!(src, ll("fe80::1"));
+            }
+        }
+    }
+
+    #[test]
+    fn router_advert_recv_without_notifier_is_a_noop() {
+        let mut eng = NdEngine::new();
+        // No notifier attached — must not panic.
+        eng.on_recv(
+            NdRecv::RouterAdvert {
+                ifindex: 5,
+                src: ll("fe80::1"),
+                ra: RouterAdvert {
+                    cur_hop_limit: 64,
+                    flags: Default::default(),
+                    router_lifetime: 0,
+                    reachable_time: 0,
+                    retrans_timer: 0,
+                    options: vec![],
+                },
+            },
+            t0(),
+        );
+    }
+
+    #[test]
+    fn router_solicit_recv_schedules_reply_on_enabled_iface() {
+        let start = t0();
+        let mut eng = NdEngine::new();
+        eng.enable_interface(5, RaSendConfig::default(), start);
+
+        let initial_wakeup = eng.next_wakeup().unwrap();
+        eng.on_recv(
+            NdRecv::RouterSolicit {
+                ifindex: 5,
+                src: ll("fe80::abcd"),
+                rs: RouterSolicit::default(),
+            },
+            start,
+        );
+        let after = eng.next_wakeup().unwrap();
+        // The RS reply jitter is at most 500ms — the new wakeup must
+        // be earlier than the initial unsolicited schedule.
+        assert!(
+            after < initial_wakeup,
+            "expected RS reply to fire before the next unsolicited RA"
+        );
+    }
+
+    #[test]
+    fn router_solicit_recv_on_disabled_iface_is_dropped() {
+        let mut eng = NdEngine::new();
+        // No interface enabled.
+        eng.on_recv(
+            NdRecv::RouterSolicit {
+                ifindex: 99,
+                src: ll("fe80::abcd"),
+                rs: RouterSolicit::default(),
+            },
+            t0(),
+        );
+        assert!(eng.next_wakeup().is_none());
+    }
+
+    #[test]
+    fn tick_at_scheduled_time_emits_send_frame() {
+        let start = t0();
+        let mut eng = NdEngine::new();
+        eng.enable_interface(3, RaSendConfig::default(), start);
+        let wakeup = eng.next_wakeup().unwrap();
+
+        let frames = eng.tick(wakeup);
+        assert_eq!(frames.len(), 1);
+        match &frames[0] {
+            NdSend::RouterAdvert { ifindex, dst, .. } => {
+                assert_eq!(*ifindex, 3);
+                assert_eq!(*dst, ALL_NODES);
+            }
+            other => panic!("expected RouterAdvert, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn tick_before_scheduled_time_emits_nothing() {
+        let start = t0();
+        let mut eng = NdEngine::new();
+        eng.enable_interface(3, RaSendConfig::default(), start);
+        assert!(eng.tick(start).is_empty());
+    }
+}

--- a/zebra-rs/src/nd/inst.rs
+++ b/zebra-rs/src/nd/inst.rs
@@ -1,0 +1,138 @@
+//! Async wrapper around [`super::engine::NdEngine`]. Owns the raw
+//! ICMPv6 socket, spawns the read / write tasks, and runs the
+//! `tokio::select!` loop that drives the engine in real time.
+//!
+//! `Nd::new()` constructs the instance and immediately spawns the
+//! read and write tasks. [`serve`] takes ownership and drives the
+//! event loop on a third spawned task. Nothing calls `serve` from
+//! `main.rs` yet — the YANG-config PR (RA-5) wires it in.
+#![allow(dead_code)]
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio::time::sleep_until;
+
+use crate::context::Task;
+
+use super::engine::{NdEngine, NdEvent};
+use super::network::{read_packet, write_packet};
+use super::send::RaSendConfig;
+use super::socket::{SocketError, nd_socket};
+use super::{NdRecv, NdSend};
+
+/// Control requests from external clients (the YANG callback layer
+/// in RA-5, and tests).
+#[derive(Debug)]
+pub enum NdClientReq {
+    EnableInterface { ifindex: u32, cfg: RaSendConfig },
+    DisableInterface { ifindex: u32 },
+}
+
+/// Top-level ND instance.
+pub struct Nd {
+    engine: NdEngine,
+    recv_rx: UnboundedReceiver<NdRecv>,
+    send_tx: UnboundedSender<NdSend>,
+    client_rx: UnboundedReceiver<NdClientReq>,
+    client_tx: UnboundedSender<NdClientReq>,
+    // Hold the spawned read / write tasks so dropping `Nd` aborts them.
+    _read_task: Task<()>,
+    _write_task: Task<()>,
+}
+
+impl Nd {
+    /// Build a new instance. Opens the raw socket and spawns the
+    /// read / write tasks immediately. The event loop is *not* spawned
+    /// here — call [`serve`] for that.
+    pub fn new() -> Result<Self, SocketError> {
+        let socket = Arc::new(nd_socket()?);
+        let (recv_tx, recv_rx) = mpsc::unbounded_channel();
+        let (send_tx, send_rx) = mpsc::unbounded_channel();
+        let (client_tx, client_rx) = mpsc::unbounded_channel();
+
+        let read_socket = socket.clone();
+        let read_task = Task::spawn(async move {
+            read_packet(read_socket, recv_tx).await;
+        });
+        let write_socket = socket;
+        let write_task = Task::spawn(async move {
+            write_packet(write_socket, send_rx).await;
+        });
+
+        Ok(Self {
+            engine: NdEngine::new(),
+            recv_rx,
+            send_tx,
+            client_rx,
+            client_tx,
+            _read_task: read_task,
+            _write_task: write_task,
+        })
+    }
+
+    /// Clone of the client-request sender. Distribute to YANG callback
+    /// glue / tests so they can drive `EnableInterface` etc.
+    pub fn client_tx(&self) -> UnboundedSender<NdClientReq> {
+        self.client_tx.clone()
+    }
+
+    /// Attach the single downstream subscriber. The BGP unnumbered
+    /// runtime calls this once at startup.
+    pub fn set_notifier(&mut self, tx: UnboundedSender<NdEvent>) {
+        self.engine.set_notifier(tx);
+    }
+
+    async fn event_loop(&mut self) {
+        loop {
+            let wakeup = self.engine.next_wakeup();
+            tokio::select! {
+                Some(msg) = self.recv_rx.recv() => {
+                    self.engine.on_recv(msg, Instant::now());
+                }
+                Some(req) = self.client_rx.recv() => {
+                    self.process_client_req(req);
+                }
+                _ = sleep_until_opt(wakeup) => {
+                    let now = Instant::now();
+                    for frame in self.engine.tick(now) {
+                        // SendError is benign — the write task may be
+                        // back-pressured for a moment; the next tick
+                        // will retry.
+                        let _ = self.send_tx.send(frame);
+                    }
+                }
+            }
+        }
+    }
+
+    fn process_client_req(&mut self, req: NdClientReq) {
+        match req {
+            NdClientReq::EnableInterface { ifindex, cfg } => {
+                self.engine.enable_interface(ifindex, cfg, Instant::now());
+            }
+            NdClientReq::DisableInterface { ifindex } => {
+                self.engine.disable_interface(ifindex);
+            }
+        }
+    }
+}
+
+/// Spawn the event loop. Mirrors [`crate::bfd::serve`].
+pub fn serve(mut nd: Nd) -> Task<()> {
+    Task::spawn(async move {
+        nd.event_loop().await;
+    })
+}
+
+/// Park `tokio::time::sleep_until` on a far-future Instant when the
+/// engine has nothing scheduled, so the `select!` arm never wakes
+/// up spuriously. `sleep_until(None)` isn't a thing in tokio, so we
+/// roll our own.
+async fn sleep_until_opt(when: Option<Instant>) {
+    match when {
+        Some(t) => sleep_until(t.into()).await,
+        None => std::future::pending::<()>().await,
+    }
+}

--- a/zebra-rs/src/nd/mod.rs
+++ b/zebra-rs/src/nd/mod.rs
@@ -17,6 +17,8 @@ use std::net::Ipv6Addr;
 
 use nd_packet::{RouterAdvert, RouterSolicit};
 
+pub mod engine;
+pub mod inst;
 pub mod network;
 pub mod send;
 pub mod socket;


### PR DESCRIPTION
## Summary
- Async wrapper around the per-interface RA send state machine, plus the pure-logic engine it drives. With this PR the ND subsystem has all its in-process plumbing — only the config-manager spawn / RIB subscription / YANG opt-in remain before an operator can turn it on.
- `engine.rs`: `NdEngine` owns the per-ifindex `RaSender`s and a single subscriber `UnboundedSender<NdEvent>`. Synchronous — no I/O, no tokio — so wakeup ordering, RS-collapse semantics, and the enable / disable lifecycle are unit-testable in milliseconds. `NdEvent::NeighborDiscovered { ifindex, src }` is the BGP unnumbered hand-off, emitted on every received RA.
- `inst.rs`: `Nd::new()` opens the raw socket via `nd_socket()`, spawns the existing `read_packet` / `write_packet` tasks, and holds the `NdClientReq::{EnableInterface, DisableInterface}` request channel. `serve(nd) -> Task` spawns the `tokio::select!` event loop. `sleep_until_opt(None)` parks on `pending()` so the timer arm doesn't spin when no interfaces are enabled.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bin zebra-rs nd::` — 20 ND tests pass (9 new engine tests on top of the 8 send-state-machine + 3 socket-filter tests already on main)
- [x] Full workspace test suite stays green

## Notes
Builds on #620 / #621 / #622 (the nd-packet codec + socket scaffolding + send state machine). RIB subscription, config-manager spawn, and the YANG opt-in for `send-advertisements` land in a follow-up PR.

Generated with [Claude Code](https://claude.com/claude-code)