### PR TITLE
nd: subscribe to RIB and spawn from config-manager startup

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -9,6 +9,7 @@ use super::configs::{carbon_copy, delete, set};
 use super::files::load_config_file;
 use super::isis::{despawn_isis, spawn_isis};
 use super::json::json_read;
+use super::nd::spawn_nd;
 use super::ospf::{despawn_ospf, spawn_ospf};
 use super::parse::State;
 use super::parse::parse;
@@ -120,6 +121,13 @@ impl ConfigManager {
             yang_service_accounts,
         };
         cm.init()?;
+
+        // ND is the receive substrate for IPv6 unnumbered BGP, so it
+        // runs from daemon startup. Sending RAs still requires an
+        // explicit operator opt-in via YANG (the leaf wiring lands
+        // in a follow-up PR); the spawn is safe to do unconditionally
+        // because the engine sits idle with no enabled interfaces.
+        spawn_nd(&cm);
 
         Ok(cm)
     }

--- a/zebra-rs/src/config/mod.rs
+++ b/zebra-rs/src/config/mod.rs
@@ -37,6 +37,7 @@ mod ip;
 mod isis;
 mod json;
 mod mac;
+mod nd;
 mod nsap;
 mod ospf;
 mod parse;

--- a/zebra-rs/src/config/nd.rs
+++ b/zebra-rs/src/config/nd.rs
@@ -1,0 +1,31 @@
+use crate::nd::inst;
+
+use super::ConfigManager;
+
+/// Spawn the ND instance at zebra-rs startup.
+///
+/// Unlike `spawn_ospf` / `spawn_bgp` / `spawn_bfd` this is unconditional
+/// — called once from [`ConfigManager`] init regardless of whether
+/// any config has been loaded yet. Reason: ND is the receive substrate
+/// for IPv6 unnumbered BGP, and we want incoming Router Advertisements
+/// to be observable as soon as the daemon is up. Sending RAs still
+/// requires an explicit operator opt-in via YANG (the leaf wiring
+/// lands in a follow-up PR).
+///
+/// If `CAP_NET_RAW` is missing the raw ICMPv6 socket cannot be opened;
+/// we log a `warn!` and continue. The daemon stays functional, just
+/// without ND.
+pub fn spawn_nd(config: &ConfigManager) {
+    match inst::Nd::new(config.rib_tx.clone()) {
+        Ok(nd) => {
+            let task = inst::serve(nd);
+            config
+                .protocol_tasks
+                .borrow_mut()
+                .insert("nd".to_string(), task);
+        }
+        Err(e) => {
+            tracing::warn!("nd: not started ({e}); IPv6 RA send / receive disabled");
+        }
+    }
+}

--- a/zebra-rs/src/nd/engine.rs
+++ b/zebra-rs/src/nd/engine.rs
@@ -17,6 +17,8 @@ use std::collections::BTreeMap;
 use std::net::Ipv6Addr;
 use std::time::Instant;
 
+use crate::rib::link::Link;
+
 use super::send::{RaEvent, RaSendConfig, RaSender};
 use super::{NdRecv, NdSend};
 
@@ -35,6 +37,14 @@ pub enum NdEvent {
 pub struct NdEngine {
     senders: BTreeMap<u32, RaSender>,
     notifier: Option<tokio::sync::mpsc::UnboundedSender<NdEvent>>,
+    /// Mirror of the RIB's link table — ifindex → name. Populated by
+    /// [`Self::process_link_add`] on every `RibRx::LinkAdd`. Lets the
+    /// future YANG callback layer (the operator types
+    /// `interface eth0 ipv6 router-advertisements …`) resolve the
+    /// `if-name` leaf to an `ifindex` before submitting
+    /// [`super::inst::NdClientReq::EnableInterface`].
+    ifindex_by_name: BTreeMap<String, u32>,
+    name_by_ifindex: BTreeMap<u32, String>,
 }
 
 impl NdEngine {
@@ -42,7 +52,39 @@ impl NdEngine {
         Self {
             senders: BTreeMap::new(),
             notifier: None,
+            ifindex_by_name: BTreeMap::new(),
+            name_by_ifindex: BTreeMap::new(),
         }
+    }
+
+    /// Absorb a link-add notification from RIB. The RIB never emits
+    /// LinkDel — once a link is known it stays in our table even if
+    /// the kernel administratively removes the device. That matches
+    /// the OSPF / BFD pattern in this repo.
+    pub fn process_link_add(&mut self, link: &Link) {
+        // Insert preserves the most recently seen name; renaming a
+        // link via `ip link set X name Y` is rare but if it happens,
+        // we drop the old name entry to keep the reverse map
+        // consistent.
+        if let Some(old_name) = self.name_by_ifindex.insert(link.index, link.name.clone())
+            && old_name != link.name
+        {
+            self.ifindex_by_name.remove(&old_name);
+        }
+        self.ifindex_by_name.insert(link.name.clone(), link.index);
+    }
+
+    /// Look up the ifindex for a given link name. Returns `None` if
+    /// RIB hasn't notified us about this link yet (race between
+    /// config load and the kernel dump) — the callback layer should
+    /// retry on later events.
+    pub fn ifindex_of(&self, name: &str) -> Option<u32> {
+        self.ifindex_by_name.get(name).copied()
+    }
+
+    /// Reverse lookup, mostly for show / debug output.
+    pub fn ifname_of(&self, ifindex: u32) -> Option<&str> {
+        self.name_by_ifindex.get(&ifindex).map(String::as_str)
     }
 
     /// Attach a single downstream subscriber. Calling twice replaces
@@ -135,7 +177,9 @@ const ALL_NODES: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0x1);
 mod tests {
     use super::*;
     use crate::nd::send::RaSendConfig;
+    use crate::rib::link::{Link, LinkType};
     use nd_packet::{RouterAdvert, RouterSolicit};
+    use netlink_packet_route::link::LinkFlags;
     use tokio::sync::mpsc;
 
     fn t0() -> Instant {
@@ -144,6 +188,24 @@ mod tests {
 
     fn ll(s: &str) -> Ipv6Addr {
         s.parse().unwrap()
+    }
+
+    fn link(name: &str, index: u32) -> Link {
+        Link {
+            index,
+            name: name.to_string(),
+            mtu: 1500,
+            metric: 1,
+            flags: LinkFlags::default(),
+            link_type: LinkType::Ethernet,
+            label: false,
+            mac: None,
+            addr4: Vec::new(),
+            addr6: Vec::new(),
+            master: None,
+            vni: None,
+            vxlan_local: None,
+        }
     }
 
     #[test]
@@ -291,5 +353,24 @@ mod tests {
         let mut eng = NdEngine::new();
         eng.enable_interface(3, RaSendConfig::default(), start);
         assert!(eng.tick(start).is_empty());
+    }
+
+    #[test]
+    fn link_add_populates_both_lookup_directions() {
+        let mut eng = NdEngine::new();
+        eng.process_link_add(&link("eth0", 7));
+        assert_eq!(eng.ifindex_of("eth0"), Some(7));
+        assert_eq!(eng.ifname_of(7), Some("eth0"));
+    }
+
+    #[test]
+    fn link_rename_drops_stale_name_entry() {
+        let mut eng = NdEngine::new();
+        eng.process_link_add(&link("eth0", 7));
+        // Rename: same ifindex, new name.
+        eng.process_link_add(&link("swp1", 7));
+        assert_eq!(eng.ifindex_of("eth0"), None);
+        assert_eq!(eng.ifindex_of("swp1"), Some(7));
+        assert_eq!(eng.ifname_of(7), Some("swp1"));
     }
 }

--- a/zebra-rs/src/nd/inst.rs
+++ b/zebra-rs/src/nd/inst.rs
@@ -4,8 +4,8 @@
 //!
 //! `Nd::new()` constructs the instance and immediately spawns the
 //! read and write tasks. [`serve`] takes ownership and drives the
-//! event loop on a third spawned task. Nothing calls `serve` from
-//! `main.rs` yet — the YANG-config PR (RA-5) wires it in.
+//! event loop on a third spawned task. The daemon's
+//! [`crate::config::ConfigManager`] calls both at startup.
 #![allow(dead_code)]
 
 use std::sync::Arc;
@@ -15,6 +15,7 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::time::sleep_until;
 
 use crate::context::Task;
+use crate::rib::api::{RibRx, RibRxChannel};
 
 use super::engine::{NdEngine, NdEvent};
 use super::network::{read_packet, write_packet};
@@ -37,20 +38,28 @@ pub struct Nd {
     send_tx: UnboundedSender<NdSend>,
     client_rx: UnboundedReceiver<NdClientReq>,
     client_tx: UnboundedSender<NdClientReq>,
+    rib_rx: UnboundedReceiver<RibRx>,
     // Hold the spawned read / write tasks so dropping `Nd` aborts them.
     _read_task: Task<()>,
     _write_task: Task<()>,
 }
 
 impl Nd {
-    /// Build a new instance. Opens the raw socket and spawns the
-    /// read / write tasks immediately. The event loop is *not* spawned
-    /// here — call [`serve`] for that.
-    pub fn new() -> Result<Self, SocketError> {
+    /// Build a new instance. Opens the raw socket, spawns the read /
+    /// write tasks, and subscribes to RIB so the engine learns about
+    /// links as the kernel exposes them. The event loop is *not*
+    /// spawned here — call [`serve`] for that.
+    pub fn new(rib_tx: UnboundedSender<crate::rib::Message>) -> Result<Self, SocketError> {
         let socket = Arc::new(nd_socket()?);
         let (recv_tx, recv_rx) = mpsc::unbounded_channel();
         let (send_tx, send_rx) = mpsc::unbounded_channel();
         let (client_tx, client_rx) = mpsc::unbounded_channel();
+
+        let rib_chan = RibRxChannel::new();
+        let _ = rib_tx.send(crate::rib::Message::Subscribe {
+            proto: "nd".to_string(),
+            tx: rib_chan.tx.clone(),
+        });
 
         let read_socket = socket.clone();
         let read_task = Task::spawn(async move {
@@ -67,6 +76,7 @@ impl Nd {
             send_tx,
             client_rx,
             client_tx,
+            rib_rx: rib_chan.rx,
             _read_task: read_task,
             _write_task: write_task,
         })
@@ -94,6 +104,9 @@ impl Nd {
                 Some(req) = self.client_rx.recv() => {
                     self.process_client_req(req);
                 }
+                Some(rmsg) = self.rib_rx.recv() => {
+                    self.process_rib_msg(rmsg);
+                }
                 _ = sleep_until_opt(wakeup) => {
                     let now = Instant::now();
                     for frame in self.engine.tick(now) {
@@ -104,6 +117,16 @@ impl Nd {
                     }
                 }
             }
+        }
+    }
+
+    fn process_rib_msg(&mut self, msg: RibRx) {
+        // Only LinkAdd is interesting at this stage; the engine doesn't
+        // need address or route notifications yet (those land when the
+        // BGP unnumbered hand-off needs to derive the local source
+        // link-local in a follow-up PR).
+        if let RibRx::LinkAdd(link) = msg {
+            self.engine.process_link_add(&link);
         }
     }
 


### PR DESCRIPTION
## Summary
- `ConfigManager::new` now calls `spawn_nd` unconditionally — ND is the receive substrate for IPv6 unnumbered BGP, so it should observe Router Advertisements as soon as the daemon is up. Sending RAs still requires explicit operator opt-in via YANG (the leaf wiring lands in a follow-up PR); the engine sits idle with no enabled interfaces until then.
- `Nd::new(rib_tx)` immediately subscribes via `rib::Message::Subscribe { proto: "nd", tx }`. The event loop gains a `rib_rx.recv()` arm whose `process_rib_msg` routes `RibRx::LinkAdd` into the engine; other `RibRx` variants are dropped at this stage.
- `NdEngine` gains a name↔ifindex mirror fed by `process_link_add(&Link)`, plus `ifindex_of(&str)` / `ifname_of(u32)` lookups. The future YANG-callback layer will use `ifindex_of` to translate the operator-typed `if-name` leaf into ifindex before submitting `NdClientReq::EnableInterface`.
- `zebra-rs/src/config/nd.rs::spawn_nd` mirrors the `spawn_bfd` / `spawn_ospf` pattern. `CAP_NET_RAW` failure logs a `warn!` and continues — daemon stays functional without ND.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bin zebra-rs nd::` — 22 ND tests pass (2 new link-map tests: `link_add_populates_both_lookup_directions`, `link_rename_drops_stale_name_entry`)
- [x] Full workspace test suite stays green

## Notes
Builds on #623 (nd engine + Nd instance plumbing).

Generated with [Claude Code](https://claude.com/claude-code)