### PR TITLE
nd: YANG opt-in for send-advertisements on interface/ipv6

### DIFF
--- a/zebra-rs/src/config/nd.rs
+++ b/zebra-rs/src/config/nd.rs
@@ -8,9 +8,10 @@ use super::ConfigManager;
 /// — called once from [`ConfigManager`] init regardless of whether
 /// any config has been loaded yet. Reason: ND is the receive substrate
 /// for IPv6 unnumbered BGP, and we want incoming Router Advertisements
-/// to be observable as soon as the daemon is up. Sending RAs still
-/// requires an explicit operator opt-in via YANG (the leaf wiring
-/// lands in a follow-up PR).
+/// to be observable as soon as the daemon is up. Sending RAs requires
+/// an explicit operator opt-in via the `send-advertisements` YANG
+/// leaf — the per-leaf callback is registered by `Nd::new` itself
+/// (see [`crate::nd::config`]).
 ///
 /// If `CAP_NET_RAW` is missing the raw ICMPv6 socket cannot be opened;
 /// we log a `warn!` and continue. The daemon stays functional, just
@@ -18,6 +19,7 @@ use super::ConfigManager;
 pub fn spawn_nd(config: &ConfigManager) {
     match inst::Nd::new(config.rib_tx.clone()) {
         Ok(nd) => {
+            config.subscribe("nd", nd.cm.tx.clone());
             let task = inst::serve(nd);
             config
                 .protocol_tasks

--- a/zebra-rs/src/nd/config.rs
+++ b/zebra-rs/src/nd/config.rs
@@ -1,0 +1,53 @@
+//! YANG callback dispatch for the per-interface RA send opt-in
+//! (`interface X ipv6 router-advertisements send-advertisements …`).
+//!
+//! Modelled on `bfd::config` — each leaf gets a free-standing callback
+//! that mutates `Nd` state directly. Registration happens once at
+//! [`super::inst::Nd::new`] time via [`Nd::callback_build`]. The
+//! dispatcher in [`super::inst::Nd::process_cm_msg`] routes
+//! `ConfigRequest`s to the right callback by path.
+
+use std::time::Instant;
+
+use crate::config::{Args, ConfigOp};
+
+use super::inst::Nd;
+use super::send::RaSendConfig;
+
+pub type Callback = fn(&mut Nd, Args, ConfigOp) -> Option<()>;
+
+impl Nd {
+    /// All paths registered by [`Self::callback_build`] are prefixed
+    /// with this. Keeping it as a constant matches the OSPF / BFD
+    /// pattern in this repo and makes additions easier to spot.
+    const ND_IF: &str = "/interface/ipv6/router-advertisements";
+
+    pub fn callback_build(&mut self) {
+        self.config_add("/send-advertisements", config_send_advertisements);
+    }
+
+    fn config_add(&mut self, path: &str, cb: Callback) {
+        self.callbacks
+            .insert(format!("{}{}", Self::ND_IF, path), cb);
+    }
+}
+
+fn config_send_advertisements(nd: &mut Nd, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let enable = args.boolean()?;
+
+    // RIB may not have notified us about this link yet — for example
+    // the operator stages config before bringing the interface up.
+    // The lookup miss is expected; the future link-add notification
+    // path will need to re-evaluate pending config. For this first
+    // cut we silently drop — the operator can re-apply.
+    let ifindex = nd.engine().ifindex_of(&name)?;
+
+    if op.is_set() && enable {
+        nd.engine_mut()
+            .enable_interface(ifindex, RaSendConfig::default(), Instant::now());
+    } else {
+        nd.engine_mut().disable_interface(ifindex);
+    }
+    Some(())
+}

--- a/zebra-rs/src/nd/inst.rs
+++ b/zebra-rs/src/nd/inst.rs
@@ -8,15 +8,18 @@
 //! [`crate::config::ConfigManager`] calls both at startup.
 #![allow(dead_code)]
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::time::sleep_until;
 
+use crate::config::{ConfigChannel, ConfigRequest, path_from_command};
 use crate::context::Task;
 use crate::rib::api::{RibRx, RibRxChannel};
 
+use super::config::Callback;
 use super::engine::{NdEngine, NdEvent};
 use super::network::{read_packet, write_packet};
 use super::send::RaSendConfig;
@@ -39,6 +42,13 @@ pub struct Nd {
     client_rx: UnboundedReceiver<NdClientReq>,
     client_tx: UnboundedSender<NdClientReq>,
     rib_rx: UnboundedReceiver<RibRx>,
+    /// Config-manager subscription endpoints. The receive half drains
+    /// in the event loop and feeds [`Self::process_cm_msg`].
+    pub cm: ConfigChannel,
+    /// Callback table — path → handler — populated by
+    /// [`Self::callback_build`] (in `super::config`) and consumed by
+    /// [`Self::process_cm_msg`].
+    pub callbacks: HashMap<String, Callback>,
     // Hold the spawned read / write tasks so dropping `Nd` aborts them.
     _read_task: Task<()>,
     _write_task: Task<()>,
@@ -70,16 +80,30 @@ impl Nd {
             write_packet(write_socket, send_rx).await;
         });
 
-        Ok(Self {
+        let mut nd = Self {
             engine: NdEngine::new(),
             recv_rx,
             send_tx,
             client_rx,
             client_tx,
             rib_rx: rib_chan.rx,
+            cm: ConfigChannel::new(),
+            callbacks: HashMap::new(),
             _read_task: read_task,
             _write_task: write_task,
-        })
+        };
+        nd.callback_build();
+        Ok(nd)
+    }
+
+    /// Internal accessor for callbacks living in [`super::config`].
+    pub(super) fn engine(&self) -> &NdEngine {
+        &self.engine
+    }
+
+    /// Internal accessor for callbacks living in [`super::config`].
+    pub(super) fn engine_mut(&mut self) -> &mut NdEngine {
+        &mut self.engine
     }
 
     /// Clone of the client-request sender. Distribute to YANG callback
@@ -107,6 +131,9 @@ impl Nd {
                 Some(rmsg) = self.rib_rx.recv() => {
                     self.process_rib_msg(rmsg);
                 }
+                Some(cmsg) = self.cm.rx.recv() => {
+                    self.process_cm_msg(cmsg);
+                }
                 _ = sleep_until_opt(wakeup) => {
                     let now = Instant::now();
                     for frame in self.engine.tick(now) {
@@ -127,6 +154,13 @@ impl Nd {
         // link-local in a follow-up PR).
         if let RibRx::LinkAdd(link) = msg {
             self.engine.process_link_add(&link);
+        }
+    }
+
+    pub fn process_cm_msg(&mut self, msg: ConfigRequest) {
+        let (path, args) = path_from_command(&msg.paths);
+        if let Some(f) = self.callbacks.get(&path).copied() {
+            f(self, args, msg.op);
         }
     }
 

--- a/zebra-rs/src/nd/mod.rs
+++ b/zebra-rs/src/nd/mod.rs
@@ -17,6 +17,7 @@ use std::net::Ipv6Addr;
 
 use nd_packet::{RouterAdvert, RouterSolicit};
 
+pub mod config;
 pub mod engine;
 pub mod inst;
 pub mod network;

--- a/zebra-rs/yang/configure.yang
+++ b/zebra-rs/yang/configure.yang
@@ -34,6 +34,10 @@ module configure {
     prefix zbng;
   }
 
+  import zebra-ipv6-router-advertisements {
+    prefix zird;
+  }
+
   container set {
     ext:help "Set configuration";
     uses "config:config";

--- a/zebra-rs/yang/zebra-ipv6-router-advertisements.yang
+++ b/zebra-rs/yang/zebra-ipv6-router-advertisements.yang
@@ -1,0 +1,79 @@
+module zebra-ipv6-router-advertisements {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-ipv6-router-advertisements";
+  prefix "zird";
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "Per-interface IPv6 Router Advertisement transmit knobs.
+
+     Receive is always on — the daemon's `nd` subsystem ingests RAs
+     unconditionally so the BGP unnumbered hand-off (a future PR)
+     can observe a peer's link-local as soon as it appears.
+
+     Send is opt-in. RFC 8349's RA model is more elaborate than what
+     this first cut needs; for now we expose only the explicit
+     `send-advertisements` switch, with all RFC 4861 §6.2.1 templates
+     (router lifetime, MinRtrAdvInterval, etc.) defaulted in the
+     runtime. Additional knobs can be added incrementally without
+     breaking on-disk config.";
+
+  grouping ipv6-router-advertisements-extension {
+    description
+      "Container hung off `interface/ipv6`.";
+    container router-advertisements {
+      ext:help "IPv6 Router Advertisement configuration";
+      leaf send-advertisements {
+        type boolean;
+        default false;
+        description
+          "If true, this interface emits unsolicited Router
+           Advertisements per RFC 4861 §6.2 and responds to Router
+           Solicitations within MAX_RA_DELAY_TIME (500 ms). Default
+           false — send is opt-in to avoid surprising operators of
+           routers that haven't explicitly asked for it.
+
+           Toggling this off removes the per-interface RA scheduler;
+           toggling back on re-runs the initial bring-up burst (3
+           unsolicited RAs within MAX_INITIAL_RTR_ADVERT_INTERVAL).";
+      }
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:interface/config:ipv6" {
+    description
+      "Attach the router-advertisements container under
+       `interface/ipv6` in the candidate-set subtree.";
+    uses ipv6-router-advertisements-extension;
+  }
+
+  augment "/configure:delete/config:interface/config:ipv6" {
+    description
+      "Same attachment for the delete subtree so
+       `delete interface X ipv6 router-advertisements …` is
+       path-valid.";
+    uses ipv6-router-advertisements-extension;
+  }
+}


### PR DESCRIPTION
## Summary
- Wires up the operator-visible knob that enables Router Advertisement send on a given interface — the missing piece between the always-on ND receive substrate (#624) and the per-interface RA send state machine (#622).
- New YANG: `zebra-ipv6-router-advertisements.yang` augments `interface/ipv6` (in both `configure:set` and `configure:delete` subtrees) with a `router-advertisements` container holding a single `send-advertisements` boolean leaf (default `false`). The opt-in is explicit by design — a stray BGP config must not flood RAs onto a production segment. RFC 4861 §6.2.1 template knobs (router-lifetime, MinRtrAdvInterval, …) stay at runtime defaults; more leaves can be added incrementally without breaking on-disk config.
- Runtime: `Nd` gains a `cm: ConfigChannel`, a `callbacks: HashMap`, `callback_build` (in the new `nd/config.rs`), `process_cm_msg` dispatcher, and a fourth `tokio::select!` arm draining `cm.rx`. Per-leaf callback `config_send_advertisements` resolves the operator-typed `if-name` to ifindex via `engine.ifindex_of(name)` and calls `enable_interface` / `disable_interface`. Lookup misses (link not yet known by RIB) silently drop.
- `config/nd.rs::spawn_nd` now also registers the cm channel with the `ConfigManager`.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` — full suite stays green; this PR is all glue + schema, no new unit tests on top of the 22 nd:: tests already on main

## Notes
Builds on #623 / #624. With this PR the locked decision "RA needs explicit opt-in" is enforced end-to-end: `interface eth0 ipv6 router-advertisements send-advertisements true` is the only switch that turns RA send on.

Generated with [Claude Code](https://claude.com/claude-code)