### PR TITLE
bgp: dynamic neighbors via listen-range

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1500,6 +1500,19 @@ impl Bgp {
             "/router/bgp/neighbor-groups/neighbor-group/remote-as",
             super::neighbor_group::config_neighbor_group_remote_as,
         );
+        // `set router bgp dynamic-neighbors …`.
+        self.callback_add(
+            "/router/bgp/dynamic-neighbors/listen-limit",
+            super::dynamic_neighbors::config_listen_limit,
+        );
+        self.callback_add(
+            "/router/bgp/dynamic-neighbors/listen-range",
+            super::dynamic_neighbors::config_listen_range,
+        );
+        self.callback_add(
+            "/router/bgp/dynamic-neighbors/listen-range/neighbor-group",
+            super::dynamic_neighbors::config_listen_range_neighbor_group,
+        );
         self.callback_peer("/local-identifier", config_local_identifier);
         self.callback_peer("/transport/passive-mode", config_transport_passive);
         self.callback_peer("/transport/local-address", config_transport_local_address);

--- a/zebra-rs/src/bgp/dynamic_neighbors.rs
+++ b/zebra-rs/src/bgp/dynamic_neighbors.rs
@@ -1,0 +1,192 @@
+//! BGP dynamic-neighbors runtime (zebra-bgp-dynamic-neighbors.yang).
+//!
+//! Stores the configured `listen-range` prefixes and `listen-limit`,
+//! and exposes `lpm_match` for the accept-path. Materialization of
+//! the synthesized [`super::peer::Peer`] lives in
+//! [`super::peer::try_dynamic_accept`] — this module is just state
+//! + config callbacks.
+
+use std::collections::BTreeMap;
+use std::net::IpAddr;
+
+use ipnet::IpNet;
+
+use super::Bgp;
+use crate::config::{Args, ConfigOp};
+
+#[derive(Debug, Default, Clone)]
+pub struct ListenRange {
+    /// Name of the `neighbor-group` whose attributes a peer
+    /// materialized via this range inherits. `None` until the YANG
+    /// callback sets it (the leaf is `mandatory true` so the schema
+    /// catches an unset value at commit time).
+    pub neighbor_group: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DynamicNeighbors {
+    pub listen_limit: u32,
+    pub ranges: BTreeMap<IpNet, ListenRange>,
+}
+
+/// RFC-style operator default — IOS-XR ships 100, FRR ships 100,
+/// Arista ships 256. Picking 100 keeps us aligned with the more
+/// conservative end.
+const DEFAULT_LISTEN_LIMIT: u32 = 100;
+
+impl Default for DynamicNeighbors {
+    fn default() -> Self {
+        Self {
+            listen_limit: DEFAULT_LISTEN_LIMIT,
+            ranges: BTreeMap::new(),
+        }
+    }
+}
+
+impl DynamicNeighbors {
+    /// Longest-prefix match against the configured ranges. Returns
+    /// the matched `(prefix, range)` so the caller can record the
+    /// prefix on the synthesized peer's `PeerOrigin::Dynamic`.
+    pub fn lpm_match(&self, addr: &IpAddr) -> Option<(IpNet, &ListenRange)> {
+        let mut best: Option<(IpNet, &ListenRange)> = None;
+        for (prefix, range) in self.ranges.iter() {
+            if !prefix_contains(prefix, addr) {
+                continue;
+            }
+            let plen = prefix.prefix_len();
+            match best {
+                None => best = Some((*prefix, range)),
+                Some((p, _)) if plen > p.prefix_len() => best = Some((*prefix, range)),
+                _ => {}
+            }
+        }
+        best
+    }
+}
+
+/// `ipnet::IpNet::contains(&IpAddr)` exists but takes `IpAddr` by
+/// value; this wrapper hides the address-family bridging when the
+/// caller already has a typed `&IpAddr`.
+fn prefix_contains(net: &IpNet, addr: &IpAddr) -> bool {
+    match (net, addr) {
+        (IpNet::V4(n), IpAddr::V4(a)) => n.contains(a),
+        (IpNet::V6(n), IpAddr::V6(a)) => n.contains(a),
+        _ => false,
+    }
+}
+
+/// `set router bgp dynamic-neighbors listen-limit <N>`.
+pub fn config_listen_limit(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    match op {
+        ConfigOp::Set => {
+            bgp.dynamic_neighbors.listen_limit = args.u32()?;
+        }
+        ConfigOp::Delete => {
+            bgp.dynamic_neighbors.listen_limit = DEFAULT_LISTEN_LIMIT;
+        }
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp dynamic-neighbors listen-range <prefix>` —
+/// list-key callback. Creates the entry on `Set` and removes it on
+/// `Delete`.
+pub fn config_listen_range(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let prefix: IpNet = args.string()?.parse().ok()?;
+    match op {
+        ConfigOp::Set => {
+            bgp.dynamic_neighbors.ranges.entry(prefix).or_default();
+        }
+        ConfigOp::Delete => {
+            bgp.dynamic_neighbors.ranges.remove(&prefix);
+        }
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp dynamic-neighbors listen-range <prefix> neighbor-group <name>`.
+pub fn config_listen_range_neighbor_group(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let prefix: IpNet = args.string()?.parse().ok()?;
+    let entry = bgp.dynamic_neighbors.ranges.entry(prefix).or_default();
+    match op {
+        ConfigOp::Set => entry.neighbor_group = Some(args.string()?),
+        ConfigOp::Delete => entry.neighbor_group = None,
+        _ => {}
+    }
+    Some(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    fn net(s: &str) -> IpNet {
+        s.parse().unwrap()
+    }
+
+    fn addr(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn lpm_picks_longest_prefix() {
+        let mut dn = DynamicNeighbors::default();
+        dn.ranges.insert(
+            net("10.0.0.0/8"),
+            ListenRange {
+                neighbor_group: Some("default".into()),
+            },
+        );
+        dn.ranges.insert(
+            net("10.99.0.0/16"),
+            ListenRange {
+                neighbor_group: Some("special".into()),
+            },
+        );
+
+        let hit = dn.lpm_match(&addr("10.99.5.7")).unwrap();
+        assert_eq!(hit.0, net("10.99.0.0/16"));
+        assert_eq!(hit.1.neighbor_group.as_deref(), Some("special"));
+
+        let hit = dn.lpm_match(&addr("10.50.0.1")).unwrap();
+        assert_eq!(hit.0, net("10.0.0.0/8"));
+        assert_eq!(hit.1.neighbor_group.as_deref(), Some("default"));
+    }
+
+    #[test]
+    fn lpm_returns_none_on_miss() {
+        let mut dn = DynamicNeighbors::default();
+        dn.ranges.insert(net("10.0.0.0/8"), ListenRange::default());
+        assert!(dn.lpm_match(&addr("192.0.2.1")).is_none());
+    }
+
+    #[test]
+    fn ipv4_and_ipv6_dont_cross_match() {
+        let mut dn = DynamicNeighbors::default();
+        dn.ranges.insert(net("10.0.0.0/8"), ListenRange::default());
+        // IPv6 address must not match an IPv4 prefix.
+        assert!(dn.lpm_match(&addr("::ffff:10.0.0.1")).is_none());
+    }
+
+    #[test]
+    fn empty_table_returns_none() {
+        let dn = DynamicNeighbors::default();
+        assert!(
+            dn.lpm_match(&IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn default_listen_limit_is_one_hundred() {
+        let dn = DynamicNeighbors::default();
+        assert_eq!(dn.listen_limit, 100);
+    }
+}

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -160,6 +160,14 @@ pub struct Bgp {
     /// `PeerConfig::neighbor_group` is not wired in the runtime
     /// yet — that lands in a follow-up.
     pub neighbor_groups: BTreeMap<String, super::neighbor_group::NeighborGroup>,
+    /// `dynamic-neighbors` runtime (zebra-bgp-dynamic-neighbors.yang).
+    /// Holds the configured listen-ranges and the soft cap on
+    /// materialized passive peers. `dynamic_peer_count` is bumped on
+    /// successful accept-time materialization in `peer::accept`; it
+    /// is never decremented yet — session-close GC is deferred to a
+    /// follow-up so this PR stays focused on the accept path.
+    pub dynamic_neighbors: super::dynamic_neighbors::DynamicNeighbors,
+    pub dynamic_peer_count: u32,
     /// IOS-XR-style update-groups, keyed by `(AfiSafi, signature)`.
     /// Phase-1: signature + membership tracking only — the advertise
     /// pipeline does not yet share work across members. See
@@ -261,6 +269,8 @@ impl Bgp {
             listen_fd_v6: None,
             key_chains: HashMap::new(),
             neighbor_groups: super::neighbor_group::empty_map(),
+            dynamic_neighbors: super::dynamic_neighbors::DynamicNeighbors::default(),
+            dynamic_peer_count: 0,
             update_groups: super::update_group::empty_map(),
             debug_flags: BgpDebugFlags::default(),
             policy_tx,

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -6,6 +6,7 @@ pub use constant::*;
 
 pub mod auth;
 pub mod config;
+pub mod dynamic_neighbors;
 pub mod neighbor_group;
 pub mod peer;
 pub mod peer_key;

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1122,22 +1122,60 @@ fn handle_peer_connection(
 }
 
 pub fn accept(bgp: &mut Bgp, stream: TcpStream, sockaddr: SocketAddr) {
-    let remaining_stream = match sockaddr {
-        SocketAddr::V4(addr) => {
-            let peer_addr = IpAddr::V4(*addr.ip());
-            handle_peer_connection(bgp, peer_addr, stream)
-        }
-        SocketAddr::V6(addr) => {
-            let peer_addr = IpAddr::V6(*addr.ip());
-            handle_peer_connection(bgp, peer_addr, stream)
-        }
+    let peer_addr = match sockaddr {
+        SocketAddr::V4(addr) => IpAddr::V4(*addr.ip()),
+        SocketAddr::V6(addr) => IpAddr::V6(*addr.ip()),
     };
+    let mut remaining_stream = handle_peer_connection(bgp, peer_addr, stream);
 
-    // Next, lookup peer-group for dynamic peer.
+    // Static lookup missed — try a configured listen-range. If LPM
+    // hits and the per-range neighbor-group resolves to a usable
+    // `remote-as`, synthesize a passive Peer and re-run the connection
+    // handler so the new entry picks up the same FSM path as a
+    // statically-configured one.
+    if let Some(stream) = remaining_stream.take() {
+        remaining_stream = try_dynamic_accept(bgp, peer_addr, stream);
+    }
+
     if let Some(stream) = remaining_stream {
         // No configured peer found - just drop (sends TCP RST/FIN)
         drop(stream);
     }
+}
+
+/// Materialize a dynamic peer when `peer_addr` matches a configured
+/// `listen-range`. Returns `Some(stream)` (i.e. caller should drop)
+/// on any failure path so the listen-range never holds the socket
+/// open while we sort out a config gap.
+fn try_dynamic_accept(bgp: &mut Bgp, peer_addr: IpAddr, stream: TcpStream) -> Option<TcpStream> {
+    // Soft cap. The listen-limit guards against an attacker spamming
+    // SYNs from many sources in a wide listen-range — once we hit
+    // the limit, additional matches drop silently until existing
+    // dynamic peers are GC'd (session-close GC lands in a follow-up).
+    if bgp.dynamic_peer_count >= bgp.dynamic_neighbors.listen_limit {
+        return Some(stream);
+    }
+    let (range_prefix, range) = bgp.dynamic_neighbors.lpm_match(&peer_addr)?;
+    let group_name = range.neighbor_group.as_ref()?;
+    let remote_as = bgp.neighbor_groups.get(group_name)?.remote_as?;
+
+    let mut peer = Peer::new(
+        0,
+        bgp.asn,
+        bgp.router_id,
+        remote_as,
+        peer_addr,
+        bgp.hostname(),
+        bgp.tx.clone(),
+    );
+    peer.origin = super::peer_key::PeerOrigin::Dynamic { range_prefix };
+    // Dynamic peers are passive-only — they never initiate a connect.
+    peer.config.transport.passive = true;
+
+    bgp.peers.insert(peer_addr, peer);
+    bgp.dynamic_peer_count += 1;
+
+    handle_peer_connection(bgp, peer_addr, stream)
 }
 
 /// Replay Adj-RIB-In through the current inbound policy for `peer_idx`,

--- a/zebra-rs/yang/configure.yang
+++ b/zebra-rs/yang/configure.yang
@@ -38,6 +38,10 @@ module configure {
     prefix zird;
   }
 
+  import zebra-bgp-dynamic-neighbors {
+    prefix zbdn;
+  }
+
   container set {
     ext:help "Set configuration";
     uses "config:config";

--- a/zebra-rs/yang/zebra-bgp-dynamic-neighbors.yang
+++ b/zebra-rs/yang/zebra-bgp-dynamic-neighbors.yang
@@ -1,0 +1,121 @@
+module zebra-bgp-dynamic-neighbors {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-dynamic-neighbors";
+  prefix "zbdn";
+
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "BGP dynamic neighbors — passive-only peers materialized on
+     inbound accept when their TCP source matches a configured
+     listen-range. Modelled on the IOS-XR `bgp listen range`
+     CLI; equivalent to FRR `bgp listen range PREFIX peer-group G`
+     where `peer-group G` maps onto our IOS-XR-style
+     `neighbor-group G`.
+
+     Resulting config shape:
+
+       router bgp {
+         neighbor-groups {
+           neighbor-group LEAF-CLIENTS {
+             remote-as 65000;
+           }
+         }
+         dynamic-neighbors {
+           listen-limit 256;
+           listen-range 10.1.0.0/24 {
+             neighbor-group LEAF-CLIENTS;
+           }
+         }
+       }
+
+     A TCP SYN whose source is in the configured prefix is accepted
+     (subject to `listen-limit`), its peer state is synthesized from
+     the referenced `neighbor-group`, and `PeerOrigin::Dynamic` is
+     stamped so the runtime can later distinguish it from
+     statically-configured peers. Active outbound opens against a
+     listen-range are refused — dynamic peers are passive-only.";
+
+  grouping bgp-dynamic-neighbors-extension {
+    description
+      "Container hung off `router bgp`.";
+    container dynamic-neighbors {
+      ext:help "BGP dynamic neighbors (listen-range)";
+      leaf listen-limit {
+        type uint32;
+        default 100;
+        description
+          "Maximum number of dynamic peers the local speaker is
+           willing to materialize. Once reached, additional inbound
+           SYNs are dropped at accept time. Setting to 0 effectively
+           disables the listen-range without removing the prefix
+           list.";
+      }
+      list listen-range {
+        key "prefix";
+        description
+          "Per-prefix authorization to accept dynamic peers. Multiple
+           ranges may overlap; longest-prefix-match wins.";
+        leaf prefix {
+          type inet:ip-prefix;
+          description
+            "TCP source prefix to match against. Both IPv4 and IPv6
+             prefixes are accepted; lookup is per-AF.";
+        }
+        leaf neighbor-group {
+          type string;
+          mandatory true;
+          description
+            "Name of the `neighbor-group` whose attributes the newly
+             materialized peer inherits. Held as a plain string (not
+             a leafref) so the listen-range can be staged before the
+             group definition lands — same convention as other
+             zebra-bgp-* augments.";
+        }
+      }
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router/bgp:bgp" {
+    description
+      "Attach the dynamic-neighbors container in the candidate-set
+       subtree.";
+    uses bgp-dynamic-neighbors-extension;
+  }
+
+  augment "/configure:delete/config:router/bgp:bgp" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp dynamic-neighbors …` is path-valid.";
+    uses bgp-dynamic-neighbors-extension;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds the IOS-XR / FRR-style `bgp listen range` workflow: passive peers materialized on inbound accept when their TCP source matches a configured listen-range, attributes inherited from a referenced `neighbor-group`.
- Resulting config:
  ```
  router bgp {
    neighbor-groups {
      neighbor-group LEAF-CLIENTS { remote-as 65000; }
    }
    dynamic-neighbors {
      listen-limit 256;
      listen-range 10.1.0.0/24 { neighbor-group LEAF-CLIENTS; }
    }
  }
  ```

## What's in this PR

### YANG
- New `zebra-bgp-dynamic-neighbors.yang` augments `router bgp` with a `dynamic-neighbors` container holding `listen-limit` (uint32, default 100) and a `listen-range` list keyed by `inet:ip-prefix`. Each entry has a mandatory `neighbor-group` reference (plain string, staging-friendly — listen-range commits before the group definition; same convention as other `zebra-bgp-*` augments).

### Runtime
- `dynamic_neighbors.rs` carries `DynamicNeighbors` with a linear-scan `lpm_match` (longest-prefix wins) and three per-leaf config callbacks. IPv4-vs-IPv6 stay separate so an IPv6 source can't accidentally match an IPv4 prefix.
- `Bgp` gains `dynamic_neighbors: DynamicNeighbors` and `dynamic_peer_count: u32`. Counter bumps on successful accept-time materialization.
- `peer::accept` gains `try_dynamic_accept`: after the static lookup misses, runs LPM, resolves `neighbor-group → remote-as`, synthesizes a `Peer` keyed by source IP with `PeerOrigin::Dynamic { range_prefix }` and `transport.passive = true` (dynamic peers never initiate), inserts into `PeerMap`, increments `dynamic_peer_count`, then re-invokes `handle_peer_connection` so the new entry follows the same FSM path as a statically-configured one. `listen-limit` is enforced before the LPM lookup.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bin zebra-rs dynamic_neighbors` — 5 new unit tests pass (longest-prefix-wins, miss returns None, IPv4-vs-IPv6 don't cross-match, empty table returns None, default-limit-is-100)
- [x] Full workspace test suite stays green

## Known scope deferrals
- Dynamic peer GC on session close (peer stays in `PeerMap`, `dynamic_peer_count` never decrements). Either a Phase-6 add to `fsm()` or a `clear bgp dynamic` command — follow-up PR.
- `show bgp summary` annotation for dynamic peers.
- Refusing `set neighbor X.X.X.X` if `X.X.X.X` lies in a configured listen-range (defensive guard).

## Notes
Builds on #617 (PeerKey + PeerOrigin) — uses `PeerOrigin::Dynamic { range_prefix }` to distinguish materialized peers at GC time.

Generated with [Claude Code](https://claude.com/claude-code)