### PR TITLE
bgp: interface-neighbor YANG + RA discovery hand-off

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1513,6 +1513,19 @@ impl Bgp {
             "/router/bgp/dynamic-neighbors/listen-range/neighbor-group",
             super::dynamic_neighbors::config_listen_range_neighbor_group,
         );
+        // `set router bgp interface-neighbor <name> [...]`.
+        self.callback_add(
+            "/router/bgp/interface-neighbor",
+            super::interface_neighbor::config_interface_neighbor,
+        );
+        self.callback_add(
+            "/router/bgp/interface-neighbor/neighbor-group",
+            super::interface_neighbor::config_interface_neighbor_neighbor_group,
+        );
+        self.callback_add(
+            "/router/bgp/interface-neighbor/remote-as",
+            super::interface_neighbor::config_interface_neighbor_remote_as,
+        );
         self.callback_peer("/local-identifier", config_local_identifier);
         self.callback_peer("/transport/passive-mode", config_transport_passive);
         self.callback_peer("/transport/local-address", config_transport_local_address);
@@ -1723,7 +1736,7 @@ mod bfd_wiring_tests {
         let (rib_tx, _rib_rx) = mpsc::unbounded_channel();
         let (policy_tx, _policy_rx) = mpsc::unbounded_channel();
         let (bfd_client_tx, bfd_client_rx) = mpsc::unbounded_channel();
-        let bgp = Bgp::new(rib_tx, policy_tx, Some(bfd_client_tx));
+        let bgp = Bgp::new(rib_tx, policy_tx, Some(bfd_client_tx), None);
         (bgp, bfd_client_rx)
     }
 
@@ -1781,7 +1794,7 @@ mod bfd_wiring_tests {
     async fn enable_without_bfd_handle_is_noop() {
         let (rib_tx, _rib_rx) = mpsc::unbounded_channel();
         let (policy_tx, _policy_rx) = mpsc::unbounded_channel();
-        let mut bgp = Bgp::new(rib_tx, policy_tx, None);
+        let mut bgp = Bgp::new(rib_tx, policy_tx, None, None);
         config_peer(&mut bgp, arg_words(&["10.0.0.4"]), ConfigOp::Set).unwrap();
         // No bfd handle to assert against; the call must not panic.
         config_peer_bfd_enable(&mut bgp, arg_words(&["10.0.0.4", "true"]), ConfigOp::Set).unwrap();

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -168,6 +168,19 @@ pub struct Bgp {
     /// follow-up so this PR stays focused on the accept path.
     pub dynamic_neighbors: super::dynamic_neighbors::DynamicNeighbors,
     pub dynamic_peer_count: u32,
+    /// `interface-neighbor` config — operator types
+    /// `set router bgp interface-neighbor <name>`. Lookup key is the
+    /// interface name; the runtime resolves to ifindex via
+    /// [`Self::link_index_by_name`] when an RA arrives and triggers
+    /// peer materialization. Materialization itself happens in
+    /// [`super::interface_neighbor::materialize_peer`].
+    pub interface_neighbors: BTreeMap<String, super::interface_neighbor::InterfaceNeighborCfg>,
+    /// `if-name` → `ifindex` mirror fed by `RibRx::LinkAdd`. Needed
+    /// because the YANG callback receives a name but
+    /// `PeerKey::Interface` keys on ifindex. Lookups that miss
+    /// (config staged before the link surfaces) defer materialization
+    /// until the next link-add event.
+    pub link_index_by_name: BTreeMap<String, u32>,
     /// IOS-XR-style update-groups, keyed by `(AfiSafi, signature)`.
     /// Phase-1: signature + membership tracking only — the advertise
     /// pipeline does not yet share work across members. See
@@ -194,6 +207,12 @@ pub struct Bgp {
     /// [`Self::event_loop`]. PR 5d logs the events; PR 5e replaces
     /// the log with neighbor teardown on `BfdEvent::Down`.
     pub bfd_event_rx: UnboundedReceiver<crate::bfd::inst::BfdEvent>,
+    /// Receive half of the ND `NeighborDiscovered` subscription. ND's
+    /// engine sends here whenever a Router Advertisement arrives on
+    /// an interface; the BGP event loop drains it and materializes
+    /// an interface-keyed Peer for any matching `interface-neighbor`
+    /// config.
+    pub nd_event_rx: UnboundedReceiver<crate::nd::engine::NdEvent>,
     // BgpAttr shared storage.
     pub attr_store: BgpAttrStore,
 
@@ -227,6 +246,7 @@ impl Bgp {
         rib_tx: UnboundedSender<rib::Message>,
         policy_tx: UnboundedSender<policy::Message>,
         bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
+        nd_client_tx: Option<UnboundedSender<crate::nd::inst::NdClientReq>>,
     ) -> Self {
         let chan = RibRxChannel::new();
         let msg = rib::Message::Subscribe {
@@ -244,6 +264,17 @@ impl Bgp {
 
         let (tx, rx) = mpsc::channel(8192);
         let (bfd_event_tx, bfd_event_rx) = mpsc::unbounded_channel();
+
+        // Subscribe to ND `NeighborDiscovered` events so the BGP
+        // unnumbered runtime can materialize an interface-keyed Peer
+        // when an RA reveals the remote's link-local. If ND failed
+        // to start (no `CAP_NET_RAW`), the channel pair is created
+        // but no events ever arrive — the BGP event loop just sits
+        // on a dead arm.
+        let (nd_event_tx, nd_event_rx) = mpsc::unbounded_channel();
+        if let Some(ref tx) = nd_client_tx {
+            let _ = tx.send(crate::nd::inst::NdClientReq::SetNotifier { tx: nd_event_tx });
+        }
         let mut bgp = Self {
             asn: 0,
             router_id: Ipv4Addr::UNSPECIFIED,
@@ -271,6 +302,8 @@ impl Bgp {
             neighbor_groups: super::neighbor_group::empty_map(),
             dynamic_neighbors: super::dynamic_neighbors::DynamicNeighbors::default(),
             dynamic_peer_count: 0,
+            interface_neighbors: super::interface_neighbor::empty_map(),
+            link_index_by_name: BTreeMap::new(),
             update_groups: super::update_group::empty_map(),
             debug_flags: BgpDebugFlags::default(),
             policy_tx,
@@ -278,6 +311,7 @@ impl Bgp {
             bfd_client_tx,
             bfd_event_tx,
             bfd_event_rx,
+            nd_event_rx,
             attr_store: BgpAttrStore::new(),
             redistribute: BTreeMap::new(),
             redist_v4: BTreeMap::new(),
@@ -592,8 +626,13 @@ impl Bgp {
     pub fn process_rib_msg(&mut self, msg: RibRx) {
         // println!("RIB Message {:?}", msg);
         match msg {
-            RibRx::LinkAdd(_link) => {
-                //self.link_add(link);
+            RibRx::LinkAdd(link) => {
+                // Maintain the name↔ifindex mirror used by
+                // interface-neighbor materialization. Keeps the most
+                // recent name for an ifindex; renames are rare but
+                // covered by simple insert-replaces-on-collision.
+                self.link_index_by_name
+                    .insert(link.name.clone(), link.index);
             }
             RibRx::AddrAdd(_addr) => {
                 // isis_info!("Isis::AddrAdd {}", addr.addr);
@@ -809,8 +848,34 @@ impl Bgp {
                 Some(event) = self.bfd_event_rx.recv() => {
                     self.process_bfd_event(event);
                 }
+                Some(event) = self.nd_event_rx.recv() => {
+                    self.process_nd_event(event);
+                }
             }
         }
+    }
+
+    /// Handle an ND `NeighborDiscovered` notification by checking for
+    /// a configured `interface-neighbor` on the matching ifindex and,
+    /// if found, materializing the peer. The lookup is a linear scan
+    /// of `link_index_by_name` since the operator-typed leaf is keyed
+    /// by name; for typical (single-digit) interface-neighbor counts
+    /// this is fine, and it lets the config use the friendly name in
+    /// `show bgp summary`.
+    fn process_nd_event(&mut self, event: crate::nd::engine::NdEvent) {
+        let crate::nd::engine::NdEvent::NeighborDiscovered { ifindex, src } = event;
+        let name = self
+            .link_index_by_name
+            .iter()
+            .find(|(_, idx)| **idx == ifindex)
+            .map(|(name, _)| name.clone());
+        let Some(name) = name else {
+            // RA arrived on an interface RIB hasn't told us about yet
+            // — possible during early startup. Drop; the next RA will
+            // re-trigger this path.
+            return;
+        };
+        super::interface_neighbor::materialize_peer(self, &name, ifindex, src);
     }
 
     /// Handle a [`crate::bfd::inst::BfdEvent`] forwarded by the BFD

--- a/zebra-rs/src/bgp/interface_neighbor.rs
+++ b/zebra-rs/src/bgp/interface_neighbor.rs
@@ -1,0 +1,190 @@
+//! BGP interface-keyed neighbor runtime (IPv6 unnumbered).
+//!
+//! Stores the operator-typed `interface-neighbor` config and the
+//! ifindex-resolution machinery. Peer materialization on RA arrival
+//! is driven by [`super::inst::Bgp`]'s NdEvent subscription arm.
+
+use std::collections::BTreeMap;
+use std::net::Ipv6Addr;
+
+use super::Bgp;
+use super::peer::Peer;
+use super::peer_key::{PeerKey, PeerOrigin};
+use crate::config::{Args, ConfigOp};
+
+/// `remote-as` may be a numeric AS or one of the FRR-style
+/// shortcuts `external` / `internal`. The shortcuts are resolved at
+/// materialization time against the local ASN (for `internal`); the
+/// `external` case is materialized with `remote_as = 0` and the
+/// actual peer AS is learned from the OPEN — strict
+/// same-AS-rejection validation lands in a follow-up.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Copy)]
+pub enum RemoteAsSpec {
+    #[default]
+    Unset,
+    Asn(u32),
+    External,
+    Internal,
+}
+
+impl RemoteAsSpec {
+    /// Materialize the spec against the local ASN. Returns `None` if
+    /// the spec is `Unset` — the caller defers peer creation until
+    /// the operator types `remote-as` (or a referenced
+    /// `neighbor-group` carries one).
+    pub fn materialize(&self, local_as: u32) -> Option<u32> {
+        match self {
+            Self::Unset => None,
+            Self::Asn(a) => Some(*a),
+            Self::Internal => Some(local_as),
+            // External: actual remote AS is learned from OPEN. Use 0
+            // as the placeholder; fsm_bgp_open backfills.
+            Self::External => Some(0),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct InterfaceNeighborCfg {
+    pub neighbor_group: Option<String>,
+    pub remote_as: RemoteAsSpec,
+}
+
+/// Look up the resolved remote AS for an interface-neighbor against
+/// its referenced neighbor-group fallback.
+pub fn resolve_remote_as(bgp: &Bgp, cfg: &InterfaceNeighborCfg) -> Option<u32> {
+    if let Some(asn) = cfg.remote_as.materialize(bgp.asn) {
+        return Some(asn);
+    }
+    let group_name = cfg.neighbor_group.as_ref()?;
+    let group = bgp.neighbor_groups.get(group_name)?;
+    group.remote_as
+}
+
+/// Materialize a Peer for `interface-neighbor IFNAME` once an RA has
+/// surfaced its link-local. Returns the index assigned by PeerMap
+/// (or `None` if config gates aren't satisfied — silent so the caller
+/// can simply retry on the next RA).
+pub fn materialize_peer(
+    bgp: &mut Bgp,
+    name: &str,
+    ifindex: u32,
+    link_local: Ipv6Addr,
+) -> Option<usize> {
+    let cfg = bgp.interface_neighbors.get(name)?.clone();
+    let remote_as = resolve_remote_as(bgp, &cfg)?;
+
+    // Already materialized? Refresh address (the peer's link-local
+    // can change if the kernel reassigns it) but otherwise leave the
+    // FSM alone.
+    if let Some(existing) = bgp.peers.get_mut_by_key(&PeerKey::Interface(ifindex)) {
+        existing.address = link_local.into();
+        return Some(existing.ident);
+    }
+
+    let mut peer = Peer::new(
+        0,
+        bgp.asn,
+        bgp.router_id,
+        remote_as,
+        link_local.into(),
+        bgp.hostname(),
+        bgp.tx.clone(),
+    );
+    peer.origin = PeerOrigin::Interface { ifindex };
+    bgp.peers.insert_with_key(PeerKey::Interface(ifindex), peer);
+    bgp.peers
+        .get_by_key(&PeerKey::Interface(ifindex))
+        .map(|p| p.ident)
+}
+
+/// `set router bgp interface-neighbor <name>` — list-key callback.
+pub fn config_interface_neighbor(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    match op {
+        ConfigOp::Set => {
+            bgp.interface_neighbors.entry(name).or_default();
+        }
+        ConfigOp::Delete => {
+            // Take the cfg out first so we can tear the peer (if any)
+            // down without holding a borrow.
+            bgp.interface_neighbors.remove(&name);
+            if let Some(&ifindex) = bgp.link_index_by_name.get(&name) {
+                bgp.peers.remove_by_key(&PeerKey::Interface(ifindex));
+            }
+        }
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp interface-neighbor <name> neighbor-group <group>`.
+pub fn config_interface_neighbor_neighbor_group(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let entry = bgp.interface_neighbors.entry(name).or_default();
+    match op {
+        ConfigOp::Set => entry.neighbor_group = Some(args.string()?),
+        ConfigOp::Delete => entry.neighbor_group = None,
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp interface-neighbor <name> remote-as <ASN|external|internal>`.
+pub fn config_interface_neighbor_remote_as(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let entry = bgp.interface_neighbors.entry(name).or_default();
+    match op {
+        ConfigOp::Set => {
+            let raw = args.string()?;
+            entry.remote_as = match raw.as_str() {
+                "external" => RemoteAsSpec::External,
+                "internal" => RemoteAsSpec::Internal,
+                numeric => RemoteAsSpec::Asn(numeric.parse().ok()?),
+            };
+        }
+        ConfigOp::Delete => entry.remote_as = RemoteAsSpec::Unset,
+        _ => {}
+    }
+    Some(())
+}
+
+/// Empty initialiser for the per-Bgp interface-neighbor map.
+pub fn empty_map() -> BTreeMap<String, InterfaceNeighborCfg> {
+    BTreeMap::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn materialize_asn_returns_numeric() {
+        assert_eq!(RemoteAsSpec::Asn(65001).materialize(64512), Some(65001));
+    }
+
+    #[test]
+    fn materialize_internal_returns_local_as() {
+        assert_eq!(RemoteAsSpec::Internal.materialize(64512), Some(64512));
+    }
+
+    #[test]
+    fn materialize_external_returns_zero_placeholder() {
+        // OPEN backfills the real value; 0 keeps the peer at
+        // `remote_as = 0` until then.
+        assert_eq!(RemoteAsSpec::External.materialize(64512), Some(0));
+    }
+
+    #[test]
+    fn materialize_unset_returns_none() {
+        assert_eq!(RemoteAsSpec::Unset.materialize(64512), None);
+    }
+}

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -7,6 +7,7 @@ pub use constant::*;
 pub mod auth;
 pub mod config;
 pub mod dynamic_neighbors;
+pub mod interface_neighbor;
 pub mod neighbor_group;
 pub mod peer;
 pub mod peer_key;

--- a/zebra-rs/src/config/bgp.rs
+++ b/zebra-rs/src/config/bgp.rs
@@ -10,10 +10,12 @@ pub fn spawn_bgp(config: &ConfigManager) {
     // stays None and the BFD attach is a no-op — PR 5d adds a refresh
     // path for that ordering.
     let bfd_client_tx = config.bfd_client_tx.borrow().clone();
+    let nd_client_tx = config.nd_client_tx.borrow().clone();
     let bgp = inst::Bgp::new(
         config.rib_tx.clone(),
         config.policy_tx.clone(),
         bfd_client_tx,
+        nd_client_tx,
     );
     config.subscribe("bgp", bgp.cm.tx.clone());
     config.subscribe_show("bgp", bgp.show.tx.clone());

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -79,6 +79,13 @@ pub struct ConfigManager {
     /// configured — clients with a `None` handle silently skip their
     /// BFD attach logic.
     pub bfd_client_tx: RefCell<Option<UnboundedSender<crate::bfd::inst::ClientReq>>>,
+    /// Sender side of the ND client-request channel. Populated by
+    /// [`super::nd::spawn_nd`] at daemon startup; clones distributed
+    /// to BGP (via [`super::bgp::spawn_bgp`]) so the BGP unnumbered
+    /// runtime can submit `NdClientReq::SetNotifier` and observe
+    /// `NeighborDiscovered` events. `None` while ND failed to start
+    /// (missing `CAP_NET_RAW`); consumers silently skip in that case.
+    pub nd_client_tx: RefCell<Option<UnboundedSender<crate::nd::inst::NdClientReq>>>,
     pub protocol_tasks: RefCell<HashMap<String, Task<()>>>,
     /// Runtime-mutable YANG-defined service-accounts (D25). Updated by
     /// `commit_config` when `vty service-account uid N` changes; read by
@@ -116,6 +123,7 @@ impl ConfigManager {
             rib_tx,
             policy_tx,
             bfd_client_tx: RefCell::new(None),
+            nd_client_tx: RefCell::new(None),
             protocol_tasks: RefCell::new(HashMap::new()),
             #[cfg(target_os = "linux")]
             yang_service_accounts,

--- a/zebra-rs/src/config/nd.rs
+++ b/zebra-rs/src/config/nd.rs
@@ -20,6 +20,10 @@ pub fn spawn_nd(config: &ConfigManager) {
     match inst::Nd::new(config.rib_tx.clone()) {
         Ok(nd) => {
             config.subscribe("nd", nd.cm.tx.clone());
+            // Publish the ND client-request channel so other protocol
+            // modules (BGP unnumbered) can attach a subscriber for
+            // `NeighborDiscovered` events at their own spawn time.
+            *config.nd_client_tx.borrow_mut() = Some(nd.client_tx());
             let task = inst::serve(nd);
             config
                 .protocol_tasks

--- a/zebra-rs/src/nd/inst.rs
+++ b/zebra-rs/src/nd/inst.rs
@@ -27,11 +27,22 @@ use super::socket::{SocketError, nd_socket};
 use super::{NdRecv, NdSend};
 
 /// Control requests from external clients (the YANG callback layer
-/// in RA-5, and tests).
+/// in RA-5, BGP unnumbered for the `SetNotifier` variant, and tests).
 #[derive(Debug)]
 pub enum NdClientReq {
-    EnableInterface { ifindex: u32, cfg: RaSendConfig },
-    DisableInterface { ifindex: u32 },
+    EnableInterface {
+        ifindex: u32,
+        cfg: RaSendConfig,
+    },
+    DisableInterface {
+        ifindex: u32,
+    },
+    /// Attach a downstream subscriber for [`NdEvent`]. Replaces any
+    /// previously-attached notifier; consumers needing fan-out should
+    /// layer a broadcast outside.
+    SetNotifier {
+        tx: UnboundedSender<NdEvent>,
+    },
 }
 
 /// Top-level ND instance.
@@ -171,6 +182,9 @@ impl Nd {
             }
             NdClientReq::DisableInterface { ifindex } => {
                 self.engine.disable_interface(ifindex);
+            }
+            NdClientReq::SetNotifier { tx } => {
+                self.engine.set_notifier(tx);
             }
         }
     }

--- a/zebra-rs/yang/configure.yang
+++ b/zebra-rs/yang/configure.yang
@@ -38,6 +38,10 @@ module configure {
     prefix zird;
   }
 
+  import zebra-bgp-interface-neighbor {
+    prefix zbin;
+  }
+
   import zebra-bgp-dynamic-neighbors {
     prefix zbdn;
   }

--- a/zebra-rs/yang/zebra-bgp-interface-neighbor.yang
+++ b/zebra-rs/yang/zebra-bgp-interface-neighbor.yang
@@ -1,0 +1,148 @@
+module zebra-bgp-interface-neighbor {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-interface-neighbor";
+  prefix "zbin";
+
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "BGP interface-keyed neighbor (IPv6 unnumbered). Modelled on the
+     FRR `neighbor IFNAME interface remote-as …` workflow but
+     surfaced as a separate top-level `interface-neighbor` list under
+     `router bgp` — cleaner schema than a polymorphic `neighbor` keyed
+     by either IP or interface, and matches the IOS-XR shape.
+
+     Resulting config:
+
+       interface eth0 {
+         ipv6 {
+           router-advertisements { send-advertisements true; }
+         }
+       }
+       router bgp {
+         interface-neighbor eth0 {
+           remote-as external;
+         }
+       }
+
+     Operation:
+       1. The ND subsystem ingests inbound RAs (already running from
+          daemon startup) and emits NeighborDiscovered { ifindex,
+          src=link-local } events.
+       2. BGP listens for these and, when `interface-neighbor` matches
+          the ifindex, materializes a Peer keyed by
+          PeerKey::Interface(ifindex) with origin Interface and the
+          discovered link-local as `address`.
+       3. The session establishes over fe80::%ifindex; ENHE (RFC 8950)
+          carries IPv4 routes with an IPv6 link-local next-hop — that
+          codec is already in tree (#618); wiring it on for
+          interface peers is a follow-up.";
+
+  typedef remote-as-type {
+    type union {
+      type inet:as-number;
+      type enumeration {
+        enum external {
+          description
+            "FRR-style shorthand — the remote AS is anything other
+             than the local one. Resolved at session-establishment
+             time; the session is eBGP if the OPEN's AS matches the
+             local ASN this is treated as a config error.";
+        }
+        enum internal {
+          description
+            "FRR-style shorthand — the remote AS equals the local
+             ASN. iBGP session.";
+        }
+      }
+    }
+    description
+      "Remote AS specification. Accepts either a numeric AS (matching
+       the regular `neighbor X remote-as N` form) or the FRR shorthand
+       `external` / `internal`. Unnumbered configs are noisier without
+       the shorthand.";
+  }
+
+  grouping bgp-interface-neighbor-extension {
+    description
+      "Container hung off `router bgp`.";
+    list interface-neighbor {
+      key "interface";
+      ext:help "BGP interface-keyed neighbor (IPv6 unnumbered)";
+      description
+        "One entry per outbound interface participating in unnumbered
+         BGP. Peer state is materialized only when the ND subsystem
+         observes a Router Advertisement on the interface (so the
+         operator must also enable
+         `interface X ipv6 router-advertisements send-advertisements
+         true`).";
+      leaf interface {
+        type string;
+        description
+          "Outbound interface name. Resolved to ifindex via the RIB
+           link table; the per-leaf callback silently defers
+           materialization until the kernel surfaces the link.";
+      }
+      leaf neighbor-group {
+        type string;
+        description
+          "Optional reference to a `neighbor-group` whose attributes
+           the materialized peer inherits. Plain string (not a
+           leafref) so the interface-neighbor can be staged before
+           the group definition lands — same convention as other
+           zebra-bgp-* augments.";
+      }
+      leaf remote-as {
+        type remote-as-type;
+        description
+          "Remote AS. May be omitted if the referenced
+           `neighbor-group` carries one; otherwise mandatory at
+           session-establishment time (an unset value silently
+           prevents materialization).";
+      }
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router/bgp:bgp" {
+    description
+      "Attach the interface-neighbor list in the candidate-set
+       subtree.";
+    uses bgp-interface-neighbor-extension;
+  }
+
+  augment "/configure:delete/config:router/bgp:bgp" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp interface-neighbor X` is path-valid.";
+    uses bgp-interface-neighbor-extension;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds the operator-visible configuration surface for IPv6 unnumbered BGP (FRR-style `neighbor IFNAME interface remote-as …`) and the cross-protocol plumbing that materializes a peer when the ND subsystem observes an RA on a configured interface.

### Operator-facing config (target)
```
interface eth0 { ipv6 { router-advertisements { send-advertisements true; } } }
router bgp {
  asn 65001;
  interface-neighbor eth0 { remote-as external; }
}
```

### YANG
- New `zebra-bgp-interface-neighbor.yang` augments `router bgp` with an `interface-neighbor` list keyed by `interface` name. Each entry carries an optional `neighbor-group` reference plus a `remote-as` typedef that's a union of `inet:as-number` and an `external` / `internal` enum (FRR shorthand). Wired into `configure.yang`.

### Runtime
- New `bgp/interface_neighbor.rs`: `InterfaceNeighborCfg` + `RemoteAsSpec { Unset, Asn(u32), External, Internal }` with `materialize(local_as)` resolving the shorthand (Internal → local_as; External → 0 as placeholder for OPEN to backfill).
- `materialize_peer(name, ifindex, link_local)` synthesizes a `Peer` keyed by `PeerKey::Interface(ifindex)` with `origin: Interface` and address set to the discovered link-local. Idempotent — re-firing refreshes the address.

### Cross-protocol plumbing
- `NdClientReq` gains a `SetNotifier { tx }` variant routed via `Nd::process_client_req` to `engine.set_notifier`.
- `ConfigManager` gains `nd_client_tx`; `spawn_nd` populates it; `spawn_bgp` propagates to `Bgp::new`.
- `Bgp::new` creates an `(nd_event_tx, nd_event_rx)` pair and sends `SetNotifier` so events flow.
- `Bgp` gains `interface_neighbors`, `link_index_by_name`, `nd_event_rx`. Event loop has a new `nd_event_rx.recv()` arm that resolves ifindex → name via the link map and calls `materialize_peer`. `RibRx::LinkAdd` now maintains `link_index_by_name` (was a `// todo` arm before).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bin zebra-rs interface_neighbor` — 4 new tests on `RemoteAsSpec::materialize` (Asn / Internal / External-placeholder / Unset)
- [x] Full workspace test suite stays green

## Known scope deferrals (follow-up PRs)
- `scope_id` plumbing in `peer_connect` for link-local v6 connect (materialized peer can't yet establish a session without this — **next PR**).
- ENHE auto-on for interface peers.
- RFC 8950 IPv4-over-IPv6 UPDATE emit/parse.
- Passive-side listener match by ifindex for `fe80::` source.
- `external` strict same-AS rejection in OPEN handler.

## Notes
Builds on the ND substrate landed in #623-#625 and the PeerKey refactor in #617.

Generated with [Claude Code](https://claude.com/claude-code)