### PR TITLE
bgp: scope_id plumbing for link-local connect

### DIFF
--- a/zebra-rs/src/bgp/interface_neighbor.rs
+++ b/zebra-rs/src/bgp/interface_neighbor.rs
@@ -92,10 +92,24 @@ pub fn materialize_peer(
         bgp.tx.clone(),
     );
     peer.origin = PeerOrigin::Interface { ifindex };
+    // Required for the kernel connect(2) to a fe80:: target —
+    // SocketAddrV6 without a scope_id returns EINVAL. The connect
+    // path in `peer_start_connection` reads this back out and
+    // builds the SocketAddrV6 accordingly.
+    peer.scope_id = Some(ifindex);
     bgp.peers.insert_with_key(PeerKey::Interface(ifindex), peer);
-    bgp.peers
-        .get_by_key(&PeerKey::Interface(ifindex))
-        .map(|p| p.ident)
+
+    // Kick the FSM. `peer.start()` arms the idle-hold timer which
+    // fires Event::Start → fsm_start → peer_start_connection. The
+    // timer captures `peer.ident`, so it must run AFTER insert (which
+    // assigns the real ident). The gate inside start() also requires
+    // `remote_as != 0`, so peers materialized from a `RemoteAsSpec::
+    // External` (which yields 0 as a placeholder until OPEN backfill)
+    // remain dormant — that case lands in a follow-up alongside the
+    // OPEN-side validation.
+    let peer = bgp.peers.get_mut_by_key(&PeerKey::Interface(ifindex))?;
+    peer.start();
+    Some(peer.ident)
 }
 
 /// `set router bgp interface-neighbor <name>` — list-key callback.

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -321,6 +321,14 @@ pub struct Peer {
     /// `Dynamic { range_prefix }` for peers materialized on inbound
     /// accept by a configured listen-range.
     pub origin: PeerOrigin,
+    /// IPv6 scope identifier for the outbound connect, populated for
+    /// interface-keyed peers whose `address` is a link-local. The
+    /// kernel rejects a `connect(2)` to `fe80::/10` without a scope,
+    /// so this is the ifindex captured at materialization time
+    /// (see [`super::interface_neighbor::materialize_peer`]). `None`
+    /// for address-keyed peers — `connect(2)` treats the v4/v6 global
+    /// case fine without it.
+    pub scope_id: Option<u32>,
     pub router_id: Ipv4Addr,
     pub local_identifier: Option<Ipv4Addr>,
     pub remote_id: Ipv4Addr,
@@ -398,6 +406,7 @@ impl Peer {
             local_hostname,
             address,
             origin: PeerOrigin::Static,
+            scope_id: None,
             active: false,
             peer_type: PeerType::IBGP,
             state: State::Idle,
@@ -874,6 +883,7 @@ pub fn peer_start_connection(peer: &mut Peer) -> Task<()> {
     let ident = peer.ident;
     let tx = peer.tx.clone();
     let address = peer.address;
+    let scope_id = peer.scope_id;
     let update_source = peer.config.transport.update_source;
     let md5_password = peer.config.transport.md5_password.clone();
     let ao_key = peer.config.transport.resolved_ao_key.clone();
@@ -881,7 +891,18 @@ pub fn peer_start_connection(peer: &mut Peer) -> Task<()> {
         let tx = tx.clone();
         let remote: SocketAddr = match address {
             IpAddr::V4(addr) => SocketAddr::new(IpAddr::V4(addr), BGP_PORT),
-            IpAddr::V6(addr) => SocketAddr::new(IpAddr::V6(addr), BGP_PORT),
+            // Pass `scope_id` through `SocketAddrV6` so a link-local
+            // target (fe80::/10) resolves to the right interface — the
+            // kernel `connect(2)` returns EINVAL otherwise. For global
+            // v6 addresses `scope_id = 0` is fine, which is what
+            // `unwrap_or(0)` produces when the peer wasn't materialized
+            // by interface-neighbor.
+            IpAddr::V6(addr) => SocketAddr::V6(std::net::SocketAddrV6::new(
+                addr,
+                BGP_PORT,
+                0,
+                scope_id.unwrap_or(0),
+            )),
         };
         let result = peer_connect(remote, update_source, md5_password.as_deref(), ao_key).await;
         match result {


### PR DESCRIPTION
## Summary
- Adds the missing piece between the interface-neighbor RA hand-off (#627) and a session actually coming up over `fe80::%ifindex`.
- `Peer` gains `scope_id: Option<u32>`, default `None`. Set to `Some(ifindex)` only when a peer is materialized by `interface_neighbor::materialize_peer`.
- `peer_start_connection` reads `scope_id` back out and builds `SocketAddrV6` via `SocketAddrV6::new(addr, port, 0, scope_id.unwrap_or(0))` — the kernel `connect(2)` returns EINVAL for an `fe80::/10` target without a scope. Global v6 connects (scope_id stays 0 from `unwrap_or`) are unchanged.
- `materialize_peer` now also calls `peer.start()` after insertion to arm the idle-hold timer that fires `Event::Start` → `fsm_start` → `peer_start_connection`. The timer captures `peer.ident`, so `start()` must run AFTER `PeerMap::insert_with_key` assigns the real index.

## End-to-end use case enabled
```
interface eth0 { ipv6 { router-advertisements { send-advertisements true; } } }
router bgp { interface-neighbor eth0 { remote-as 65001; } }
```
The daemon receives an RA → materializes `PeerKey::Interface(N)` → initiates TCP/179 to `fe80::xxx%eth0` → session up for IPv6 unicast. IPv4 routes still need ENHE (separate follow-up).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] Full workspace test suite stays green (468 + 1 ignored)

## Known scope deferrals
- `RemoteAsSpec::External` peers stay dormant — `peer.start()`'s gate requires `remote_as != 0`, and External materializes with `0` as a placeholder for OPEN to backfill. Lifting that gate alongside strict same-AS rejection in `fsm_bgp_open` is a follow-up.
- ENHE auto-on for interface peers (so IPv4 routes carry IPv6 next-hop).
- RFC 8950 IPv4-over-IPv6 UPDATE emit/parse.
- Passive-side listener match by ifindex for inbound fe80:: source.

Builds on #627.

Generated with [Claude Code](https://claude.com/claude-code)