### PR TITLE
bgp: negotiate RFC 8950 Extended Next Hop on interface peers

### DIFF
--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1004,6 +1004,19 @@ pub fn peer_send_open(peer: &mut Peer) {
     if peer.config.extended_message {
         bgp_cap.extended = Some(CapExtended::default());
     }
+    // Auto-advertise RFC 8950 Extended Next Hop Encoding for IPv4
+    // unicast over IPv6 next-hop on interface-keyed (unnumbered)
+    // peers. Without this the peer can't carry IPv4 routes over a
+    // session that has no IPv4 source address. Other AFIs / SAFIs
+    // can be added once the operator has a knob, but the
+    // single-tuple case covers every interface-neighbor deployment.
+    if matches!(peer.origin, PeerOrigin::Interface { .. }) {
+        bgp_cap.extended_nexthop = Some(CapExtendedNextHop::new(vec![ExtendedNextHopValue::new(
+            Afi::Ip,
+            Safi::Unicast,
+            Afi::Ip6,
+        )]));
+    }
     if let Some(name) = &peer.local_hostname {
         // FQDN capability (draft-walton, code 73). Domain name is left
         // empty for now — operators have only asked for hostname.

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -25,7 +25,7 @@ use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Instant;
 
-use bgp_packet::{Afi, AfiSafi, BgpAttr, Ipv4Nlri, Safi, UpdatePacket};
+use bgp_packet::{Afi, AfiSafi, BgpAttr, CapExtendedNextHop, Ipv4Nlri, Safi, UpdatePacket};
 use tokio::sync::mpsc;
 
 use super::BgpAttrStore;
@@ -197,13 +197,44 @@ pub fn signature_of(peer: &Peer, afi: Afi, safi: Safi) -> Option<UpdateGroupSig>
         as4_negotiated: peer.as4,
         extended_message: peer.opt.extended_message,
         addpath_send: peer.opt.is_add_path_send(afi, safi),
-        // RFC 8950 / RFC 8277 are not yet negotiated by zebra-rs;
-        // hardcoded false until those capabilities land. The fields
-        // exist so the signature is forward-compatible.
-        extended_next_hop: false,
+        // RFC 8950 Extended Next Hop Encoding for IPv4 unicast over
+        // IPv6 next-hop is negotiated when both directions advertise
+        // the matching tuple. Only meaningful for the IPv4-unicast
+        // update-group; other AFI/SAFI groups stay at false until
+        // the codec / wire format extends.
+        extended_next_hop: enhe_negotiated(peer, afi, safi),
+        // RFC 8277 multiple-labels is still not negotiated by zebra-rs;
+        // the field is forward-compatible for the day it lands.
         multiple_labels: false,
         signature_version: SIGNATURE_VERSION,
     })
+}
+
+/// True iff both sides advertised the ENHE capability with an entry
+/// for (IPv4-Unicast, IPv6 next-hop), and the local update-group's
+/// AFI/SAFI is IPv4 unicast. The check is symmetric — a one-sided
+/// advertisement is treated as "not negotiated" per RFC 8950 §3.
+fn enhe_negotiated(peer: &Peer, afi: Afi, safi: Safi) -> bool {
+    enhe_negotiated_for(
+        peer.cap_send.extended_nexthop.as_ref(),
+        peer.cap_recv.extended_nexthop.as_ref(),
+        afi,
+        safi,
+    )
+}
+
+fn enhe_negotiated_for(
+    send: Option<&CapExtendedNextHop>,
+    recv: Option<&CapExtendedNextHop>,
+    afi: Afi,
+    safi: Safi,
+) -> bool {
+    if afi != Afi::Ip || safi != Safi::Unicast {
+        return false;
+    }
+    let sent = send.is_some_and(|c| c.supports_v6_nexthop_for_ipv4_unicast());
+    let received = recv.is_some_and(|c| c.supports_v6_nexthop_for_ipv4_unicast());
+    sent && received
 }
 
 /// Add `peer_idx` to its update-group for every tracked AFI/SAFI it
@@ -680,5 +711,79 @@ mod tests {
         // Lookup miss: unknown id returns None.
         let missing = UpdateGroupId::new(Afi::Ip, Safi::Unicast, 99);
         assert!(af.group_by_id_mut(&missing).is_none());
+    }
+
+    fn enhe_v4_over_v6() -> CapExtendedNextHop {
+        use bgp_packet::ExtendedNextHopValue;
+        CapExtendedNextHop::new(vec![ExtendedNextHopValue::new(
+            Afi::Ip,
+            Safi::Unicast,
+            Afi::Ip6,
+        )])
+    }
+
+    #[test]
+    fn enhe_negotiated_requires_both_sides() {
+        let cap = enhe_v4_over_v6();
+
+        // Both sides advertised → true.
+        assert!(enhe_negotiated_for(
+            Some(&cap),
+            Some(&cap),
+            Afi::Ip,
+            Safi::Unicast
+        ));
+
+        // One side missing → false (no agreement).
+        assert!(!enhe_negotiated_for(
+            Some(&cap),
+            None,
+            Afi::Ip,
+            Safi::Unicast
+        ));
+        assert!(!enhe_negotiated_for(
+            None,
+            Some(&cap),
+            Afi::Ip,
+            Safi::Unicast
+        ));
+        assert!(!enhe_negotiated_for(None, None, Afi::Ip, Safi::Unicast));
+    }
+
+    #[test]
+    fn enhe_negotiated_only_for_ipv4_unicast() {
+        let cap = enhe_v4_over_v6();
+
+        // Wrong AFI / SAFI — the cap is irrelevant.
+        assert!(!enhe_negotiated_for(
+            Some(&cap),
+            Some(&cap),
+            Afi::Ip6,
+            Safi::Unicast
+        ));
+        assert!(!enhe_negotiated_for(
+            Some(&cap),
+            Some(&cap),
+            Afi::Ip,
+            Safi::Multicast
+        ));
+    }
+
+    #[test]
+    fn enhe_negotiated_ignores_unrelated_tuples() {
+        use bgp_packet::ExtendedNextHopValue;
+        // An ENHE cap that advertises only (IPv4-MplsVpn, IPv6) does
+        // NOT satisfy IPv4-unicast.
+        let cap = CapExtendedNextHop::new(vec![ExtendedNextHopValue::new(
+            Afi::Ip,
+            Safi::MplsVpn,
+            Afi::Ip6,
+        )]);
+        assert!(!enhe_negotiated_for(
+            Some(&cap),
+            Some(&cap),
+            Afi::Ip,
+            Safi::Unicast
+        ));
     }
 }


### PR DESCRIPTION
## Summary
Wires up the capability handshake the existing ENHE codec (#618) has been waiting for.

- `peer_send_open` auto-advertises ENHE for `(IPv4-Unicast, IPv6 next-hop)` when `peer.origin` is `PeerOrigin::Interface` — interface-keyed peers are the only ones that need it, and an operator-knob version can come later.
- `update_group::peer_sig` no longer hard-codes `extended_next_hop = false`. New `enhe_negotiated_for(send, recv, afi, safi)` returns true iff (a) the update-group is IPv4-unicast, and (b) BOTH `cap_send` and `cap_recv` advertise an ENHE tuple for IPv4-unicast → IPv6 next-hop. Symmetric per RFC 8950 §3 — one-sided advertisement is treated as "not negotiated".
- The negotiated bit flows through `UpdateGroupSig::extended_next_hop` into the IPv4-unicast update-group's signature; the wire-format gate that consults it (MP_REACH for IPv4 with a 16-byte v6 next-hop) is the next PR. Until then the bit is observable via `show update-groups` but doesn't change UPDATE bytes.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bin zebra-rs enhe` — 3 new unit tests on `enhe_negotiated_for` (both-sides-required, AFI/SAFI gating, unrelated-tuple rejection)
- [x] Full workspace test suite stays green (471 + 1 ignored)

## Known scope deferrals
- RFC 8950 IPv4-over-IPv6 UPDATE wire format (the actual MP_REACH emit / parse for IPv4 prefixes with v6 next-hop). The negotiation bit is in place; the encoder still emits via the legacy NEXT_HOP path until the wire-format PR(s) land.
- RIB install for IPv4 prefix with v6 next-hop.

Builds on #618 (codec) and #627 (interface-neighbor materialization).

Generated with [Claude Code](https://claude.com/claude-code)