### PR TITLE
startup: don't cascade-panic when ND raw socket fails to open

### DIFF
--- a/zebra-rs/src/config/nd.rs
+++ b/zebra-rs/src/config/nd.rs
@@ -1,4 +1,5 @@
 use crate::nd::inst;
+use crate::nd::socket::nd_socket;
 
 use super::ConfigManager;
 
@@ -16,23 +17,28 @@ use super::ConfigManager;
 /// If `CAP_NET_RAW` is missing the raw ICMPv6 socket cannot be opened;
 /// we log a `warn!` and continue. The daemon stays functional, just
 /// without ND.
+///
+/// The socket is opened *before* `subscribe_to_rib` so that a socket
+/// failure doesn't leave a dead `RibRx` receiver queued in RIB's
+/// inbox — RIB would panic on the link-dump send in that case.
 pub fn spawn_nd(config: &ConfigManager) {
-    let (_rib_client, rib_rx) = config.subscribe_to_rib("nd");
-    match inst::Nd::new(rib_rx) {
-        Ok(nd) => {
-            config.subscribe("nd", nd.cm.tx.clone());
-            // Publish the ND client-request channel so other protocol
-            // modules (BGP unnumbered) can attach a subscriber for
-            // `NeighborDiscovered` events at their own spawn time.
-            *config.nd_client_tx.borrow_mut() = Some(nd.client_tx());
-            let task = inst::serve(nd);
-            config
-                .protocol_tasks
-                .borrow_mut()
-                .insert("nd".to_string(), task);
-        }
+    let socket = match nd_socket() {
+        Ok(s) => s,
         Err(e) => {
             tracing::warn!("nd: not started ({e}); IPv6 RA send / receive disabled");
+            return;
         }
-    }
+    };
+    let (_rib_client, rib_rx) = config.subscribe_to_rib("nd");
+    let nd = inst::Nd::new(socket, rib_rx);
+    config.subscribe("nd", nd.cm.tx.clone());
+    // Publish the ND client-request channel so other protocol modules
+    // (BGP unnumbered) can attach a subscriber for `NeighborDiscovered`
+    // events at their own spawn time.
+    *config.nd_client_tx.borrow_mut() = Some(nd.client_tx());
+    let task = inst::serve(nd);
+    config
+        .protocol_tasks
+        .borrow_mut()
+        .insert("nd".to_string(), task);
 }

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -2434,51 +2434,46 @@ pub fn neighbor_from_msg(msg: NeighbourMessage) -> FibNeighbor {
 }
 
 fn process_msg(msg: NetlinkMessage<RouteNetlinkMessage>, tx: UnboundedSender<FibMessage>) {
+    // Every arm forwards a parsed event to the RIB inbox. If RIB has
+    // already shut down (or panicked) the receiver is dropped and the
+    // send returns `SendError`; that is benign here — we don't want a
+    // closing channel to take down the netlink reader task with a
+    // secondary panic.
     if let NetlinkPayload::InnerMessage(msg) = msg.payload {
         match msg {
             RouteNetlinkMessage::NewLink(msg) => {
                 let link = link_from_msg(msg);
-                let msg = FibMessage::NewLink(link);
-                tx.send(msg).unwrap();
+                let _ = tx.send(FibMessage::NewLink(link));
             }
             RouteNetlinkMessage::DelLink(msg) => {
                 let link = link_from_msg(msg);
-                let msg = FibMessage::DelLink(link);
-                tx.send(msg).unwrap();
+                let _ = tx.send(FibMessage::DelLink(link));
             }
             RouteNetlinkMessage::NewAddress(msg) => {
                 let addr = addr_from_msg(msg);
-                let msg = FibMessage::NewAddr(addr);
-                tx.send(msg).unwrap();
+                let _ = tx.send(FibMessage::NewAddr(addr));
             }
             RouteNetlinkMessage::DelAddress(msg) => {
                 let addr = addr_from_msg(msg);
-                let msg = FibMessage::DelAddr(addr);
-                tx.send(msg).unwrap();
+                let _ = tx.send(FibMessage::DelAddr(addr));
             }
             RouteNetlinkMessage::NewRoute(msg) => {
-                let route = route_from_msg(msg);
-                if let Some(route) = route {
-                    let msg = FibMessage::NewRoute(route);
-                    tx.send(msg).unwrap();
+                if let Some(route) = route_from_msg(msg) {
+                    let _ = tx.send(FibMessage::NewRoute(route));
                 }
             }
             RouteNetlinkMessage::DelRoute(msg) => {
-                let route = route_from_msg(msg);
-                if let Some(route) = route {
-                    let msg = FibMessage::DelRoute(route);
-                    tx.send(msg).unwrap();
+                if let Some(route) = route_from_msg(msg) {
+                    let _ = tx.send(FibMessage::DelRoute(route));
                 }
             }
             RouteNetlinkMessage::NewNeighbour(msg) => {
                 let neighbor = neighbor_from_msg(msg);
-                let msg = FibMessage::NewNeighbor(neighbor);
-                tx.send(msg).unwrap();
+                let _ = tx.send(FibMessage::NewNeighbor(neighbor));
             }
             RouteNetlinkMessage::DelNeighbour(msg) => {
                 let neighbor = neighbor_from_msg(msg);
-                let msg = FibMessage::DelNeighbor(neighbor);
-                tx.send(msg).unwrap();
+                let _ = tx.send(FibMessage::DelNeighbor(neighbor));
             }
             // TODO: Phase 4B - Add MDB message handling when netlink-packet-route supports it
             // RouteNetlinkMessage::NewMdb(_) => {

--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -165,6 +165,13 @@ async fn run() -> anyhow::Result<()> {
     }
     let yang_path = yang_path.unwrap();
 
+    // Setup tracing before any subsystem spin-up so warn/error events
+    // emitted during construction (e.g. ND failing to open its raw
+    // socket inside `ConfigManager::new`) are actually surfaced to the
+    // operator instead of being swallowed by the default subscriber.
+    let log_config = logging_config_from_args(&arg.log_output, &arg.log_file, &arg.log_format);
+    tracing_set(arg.daemon, Some(log_config));
+
     let rib = Rib::new(arg.no_nhid, arg.enable_addr_recovery)?;
 
     let policy = Policy::new();
@@ -205,10 +212,6 @@ async fn run() -> anyhow::Result<()> {
 
     rib::serve(rib);
     // rib::nanomsg::serve();
-
-    // Setup tracing based on CLI arguments
-    let log_config = logging_config_from_args(&arg.log_output, &arg.log_file, &arg.log_format);
-    tracing_set(arg.daemon, Some(log_config));
 
     // Daemonize if requested (after tracing setup)
     if arg.daemon {

--- a/zebra-rs/src/nd/inst.rs
+++ b/zebra-rs/src/nd/inst.rs
@@ -12,6 +12,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
+use socket2::Socket;
+use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::time::sleep_until;
 
@@ -23,7 +25,6 @@ use super::config::Callback;
 use super::engine::{NdEngine, NdEvent};
 use super::network::{read_packet, write_packet};
 use super::send::RaSendConfig;
-use super::socket::{SocketError, nd_socket};
 use super::{NdRecv, NdSend};
 
 /// Control requests from external clients (the YANG callback layer
@@ -66,12 +67,20 @@ pub struct Nd {
 }
 
 impl Nd {
-    /// Build a new instance. Opens the raw socket, spawns the read /
-    /// write tasks, and subscribes to RIB so the engine learns about
-    /// links as the kernel exposes them. The event loop is *not*
-    /// spawned here — call [`serve`] for that.
-    pub fn new(rib_rx: UnboundedReceiver<RibRx>) -> Result<Self, SocketError> {
-        let socket = Arc::new(nd_socket()?);
+    /// Build a new instance from a pre-opened raw ICMPv6 socket.
+    ///
+    /// Spawns the read / write tasks and wires up the RIB
+    /// subscription channel so the engine learns about links as the
+    /// kernel exposes them. The event loop is *not* spawned here —
+    /// call [`serve`] for that.
+    ///
+    /// The socket is opened by the caller (see `super::socket::nd_socket`)
+    /// so that socket failures can be detected *before* registering a
+    /// `RibRx` subscriber — otherwise the caller would have to drop
+    /// `rib_rx` on the error path, leaving a dead receiver queued in
+    /// RIB's inbox and causing a panic when RIB tries to dump links.
+    pub fn new(socket: AsyncFd<Socket>, rib_rx: UnboundedReceiver<RibRx>) -> Self {
+        let socket = Arc::new(socket);
         let (recv_tx, recv_rx) = mpsc::unbounded_channel();
         let (send_tx, send_rx) = mpsc::unbounded_channel();
         let (client_tx, client_rx) = mpsc::unbounded_channel();
@@ -98,7 +107,7 @@ impl Nd {
             _write_task: write_task,
         };
         nd.callback_build();
-        Ok(nd)
+        nd
     }
 
     /// Internal accessor for callbacks living in [`super::config`].

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -869,17 +869,36 @@ impl Rib {
     /// broadcast paths and by `proto_cleanup`). The initial-state
     /// dump and the trailing `EoR` are unchanged.
     pub fn subscribe(&mut self, proto_id: ProtoId, tx: UnboundedSender<RibRx>, proto: String) {
+        // A subscriber may have dropped its receiver before this
+        // handler ran (e.g. its constructor failed after the
+        // `Message::Subscribe` was already queued). Every dump send
+        // below is therefore best-effort: on the first `SendError` we
+        // bail out without registering the subscriber, so we don't
+        // panic and don't leave a dead entry in `client_registry` /
+        // `redists`.
+        if tx.is_closed() {
+            tracing::warn!(
+                "rib: subscriber '{proto}' dropped before subscribe could deliver dump; skipping"
+            );
+            return;
+        }
         // Link dump.
         for (_, link) in self.links.iter() {
             let msg = RibRx::LinkAdd(link.clone());
-            tx.send(msg).unwrap();
+            if tx.send(msg).is_err() {
+                return;
+            }
             for addr in link.addr4.iter() {
                 let msg = RibRx::AddrAdd(addr.clone());
-                tx.send(msg).unwrap();
+                if tx.send(msg).is_err() {
+                    return;
+                }
             }
             for addr in link.addr6.iter() {
                 let msg = RibRx::AddrAdd(addr.clone());
-                tx.send(msg).unwrap();
+                if tx.send(msg).is_err() {
+                    return;
+                }
             }
         }
         // VXLAN dump. Replay every observed VXLAN device with a
@@ -911,14 +930,18 @@ impl Rib {
                 let _ = tx.send(RibRx::FdbAdd(entry));
             }
         }
-        self.client_registry
-            .register_with_id(proto_id, &proto, tx.clone());
-        self.redists.insert(proto, tx.clone());
         if !self.router_id.is_unspecified() {
             let msg = RibRx::RouterIdUpdate(self.router_id);
-            tx.send(msg).unwrap();
+            if tx.send(msg).is_err() {
+                return;
+            }
         }
-        tx.send(RibRx::EoR).unwrap();
+        if tx.send(RibRx::EoR).is_err() {
+            return;
+        }
+        self.client_registry
+            .register_with_id(proto_id, &proto, tx.clone());
+        self.redists.insert(proto, tx);
     }
 
     async fn proto_cleanup(&mut self, proto: String) {
@@ -1885,10 +1908,15 @@ pub fn serve(mut rib: Rib) {
         rib.event_loop().await;
     });
     tokio::spawn(async move {
-        tokio::signal::ctrl_c().await.unwrap();
+        if tokio::signal::ctrl_c().await.is_err() {
+            return;
+        }
         let (tx, rx) = oneshot::channel::<()>();
         let _ = rib_tx.send(Message::Shutdown { tx });
-        rx.await.unwrap();
+        // If the event loop is already gone (e.g. panicked earlier),
+        // `rx` resolves to `Err(RecvError)`. Exit anyway — there's
+        // nothing left to wait for.
+        let _ = rx.await;
         std::process::exit(0);
     });
 }


### PR DESCRIPTION
## Summary

- `spawn_nd` ran unconditionally from `ConfigManager::new` and registered a RIB `RibRx` subscriber *before* trying to open the raw ICMPv6 socket. When `nd_socket()` failed (e.g. missing `CAP_NET_RAW`), the receiver was dropped, RIB's `subscribe` handler then panicked on the first `tx.send(LinkAdd).unwrap()`, killing the RIB event loop and cascading into secondary panics in the ctrl-c shutdown handler (`rib/inst.rs` `serve`) and the netlink reader (`fib/netlink/handle.rs` `process_msg`).
- The warn that would have explained the failure (`nd: not started (…)`) was also silently swallowed because `tracing_set` ran *after* `ConfigManager::new`.

## Changes

- Open the ICMPv6 socket *before* `subscribe_to_rib` in `spawn_nd`; `Nd::new` now takes a pre-opened socket and is infallible. A socket failure now logs a warn and returns without ever queuing a Subscribe.
- Move `tracing_set` ahead of `ConfigManager::new` in `main.rs` so startup warnings are visible.
- Harden `Rib::subscribe` against a dead subscriber: short-circuit on the first `SendError` and only insert into `client_registry` / `redists` once the dump (including `EoR`) is delivered, so we never leave zombie entries.
- Tolerate channel closure during teardown in the ctrl-c handler and in the netlink → RIB forwarder.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo build --bin zebra-rs --release`
- [x] Ran `target/release/zebra-rs` without `CAP_NET_RAW`: the `nd: not started (…)` warn is now visible at startup and no cascade panic occurs from the ND path.
- [ ] Re-run with `make run` (caps set) to confirm normal startup is unchanged.

Generated with [Claude Code](https://claude.com/claude-code)