### PR TITLE
nd: spawn only when ipv6 router-advertisements is configured

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -91,11 +91,14 @@ pub struct ConfigManager {
     /// BFD attach logic.
     pub bfd_client_tx: RefCell<Option<UnboundedSender<crate::bfd::inst::ClientReq>>>,
     /// Sender side of the ND client-request channel. Populated by
-    /// [`super::nd::spawn_nd`] at daemon startup; clones distributed
-    /// to BGP (via [`super::bgp::spawn_bgp`]) so the BGP unnumbered
-    /// runtime can submit `NdClientReq::SetNotifier` and observe
-    /// `NeighborDiscovered` events. `None` while ND failed to start
-    /// (missing `CAP_NET_RAW`); consumers silently skip in that case.
+    /// [`super::nd::spawn_nd`] on the first `ipv6 router-advertisements`
+    /// config line (see `commit_config`); clones distributed to BGP
+    /// (via [`super::bgp::spawn_bgp`]) so the BGP unnumbered runtime
+    /// can submit `NdClientReq::SetNotifier` and observe
+    /// `NeighborDiscovered` events. `None` while ND has not been
+    /// spawned, or while ND failed to start (missing `CAP_NET_RAW`,
+    /// kernel rejecting a socket option, …); consumers silently skip
+    /// in that case.
     pub nd_client_tx: RefCell<Option<UnboundedSender<crate::nd::inst::NdClientReq>>>,
     pub protocol_tasks: RefCell<HashMap<String, Task<()>>>,
     /// Runtime-mutable YANG-defined service-accounts (D25). Updated by
@@ -144,13 +147,17 @@ impl ConfigManager {
         };
         cm.init()?;
 
-        // ND is the receive substrate for IPv6 unnumbered BGP, so it
-        // runs from daemon startup. Sending RAs still requires an
-        // explicit operator opt-in via YANG (the leaf wiring lands
-        // in a follow-up PR); the spawn is safe to do unconditionally
-        // because the engine sits idle with no enabled interfaces.
-        spawn_nd(&cm);
-
+        // ND is no longer spawned at daemon startup — `commit_config`
+        // calls `spawn_nd` on the first config line that mentions
+        // `ipv6 router-advertisements`, matching the conditional
+        // pattern used by OSPF / IS-IS / BGP / BFD. Rationale: the
+        // raw ICMPv6 socket needs `CAP_NET_RAW` *and* a kernel that
+        // accepts every option we set (e.g. `IPV6_CHECKSUM` is
+        // unavailable in some namespaces / kernels), so an
+        // unconditional spawn produces a warn on every cold start
+        // for users who never touch RAs. BGP unnumbered, which also
+        // depends on ND, reads `nd_client_tx` at `spawn_bgp` time —
+        // if it spawns before any RA config the handle stays None.
         Ok(cm)
     }
 
@@ -260,6 +267,7 @@ impl ConfigManager {
         let mut isis = false;
         let mut bgp = false;
         let mut bfd = false;
+        let mut nd = false;
         for (proto, tx) in self.cm_clients.borrow().iter() {
             tx.send(ConfigRequest::new(Vec::new(), ConfigOp::CommitStart))
                 .unwrap();
@@ -274,6 +282,9 @@ impl ConfigManager {
             }
             if proto == "bfd" {
                 bfd = true;
+            }
+            if proto == "nd" {
+                nd = true;
             }
         }
         for line in diff.lines() {
@@ -303,6 +314,14 @@ impl ConfigManager {
             if !bfd && op == ConfigOp::Set && line.starts_with("bfd") {
                 bfd = true;
                 spawn_bfd(self);
+            }
+            // ND has no top-level `router nd` block — it's configured
+            // per-interface (`interface X ipv6 router-advertisements
+            // …`). Spawn on the first set line that mentions the
+            // subtree; ND's own callbacks then dispatch the leaves.
+            if !nd && op == ConfigOp::Set && line.contains("ipv6 router-advertisements") {
+                nd = true;
+                spawn_nd(self);
             }
             // Handle logging configuration changes
             if op == ConfigOp::Set && line.starts_with("logging output") {

--- a/zebra-rs/src/config/nd.rs
+++ b/zebra-rs/src/config/nd.rs
@@ -3,16 +3,19 @@ use crate::nd::socket::nd_socket;
 
 use super::ConfigManager;
 
-/// Spawn the ND instance at zebra-rs startup.
+/// Spawn the ND instance on first commit that mentions
+/// `ipv6 router-advertisements`.
 ///
-/// Unlike `spawn_ospf` / `spawn_bgp` / `spawn_bfd` this is unconditional
-/// — called once from [`ConfigManager`] init regardless of whether
-/// any config has been loaded yet. Reason: ND is the receive substrate
-/// for IPv6 unnumbered BGP, and we want incoming Router Advertisements
-/// to be observable as soon as the daemon is up. Sending RAs requires
-/// an explicit operator opt-in via the `send-advertisements` YANG
-/// leaf — the per-leaf callback is registered by `Nd::new` itself
-/// (see [`crate::nd::config`]).
+/// Mirrors `spawn_ospf` / `spawn_bgp` / `spawn_bfd`: the dispatch in
+/// [`crate::config::ConfigManager::commit_config`] gates the call so
+/// hosts that never configure RAs don't pay the cost of opening a
+/// raw ICMPv6 socket (and don't see a startup `warn!` if the kernel
+/// rejects one of the socket options or `CAP_NET_RAW` is missing).
+///
+/// BGP unnumbered also depends on ND — `spawn_bgp` captures
+/// `nd_client_tx` at spawn time. If `router bgp` is committed before
+/// any RA-touching line, BGP's handle stays `None`; that ordering
+/// caveat is identical to the BFD case noted in `spawn_bgp`.
 ///
 /// If `CAP_NET_RAW` is missing the raw ICMPv6 socket cannot be opened;
 /// we log a `warn!` and continue. The daemon stays functional, just


### PR DESCRIPTION
## Summary

ND was spawned unconditionally from `ConfigManager::new` on the assumption that BGP unnumbered would always want incoming RAs observable from cold start. That meant every daemon startup opened a raw ICMPv6 socket and applied a string of setsockopts. Some kernels reject one of those (e.g. `IPV6_CHECKSUM` returns `ENOPROTOOPT` in certain namespaces / configurations), producing a `nd: not started (…)` warn at every startup on hosts that never touch RAs.

Match the existing OSPF / IS-IS / BGP / BFD pattern: `commit_config` now spawns ND on the first config line that contains `ipv6 router-advertisements`. Hosts that don't configure RAs pay no socket cost and see no warn.

### Caveat

BGP unnumbered captures `nd_client_tx` at `spawn_bgp` time. If `router bgp` is committed before any RA-touching line, BGP's handle stays `None` — identical to the BFD ordering caveat already documented inside `spawn_bgp`. A refresh path for both can land separately.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo build --bin zebra-rs --release`
- [x] Daemon launched without RA config: no `nd: not started` warn at startup (previously emitted on this host).
- [ ] Add `interface X ipv6 router-advertisements send-advertisements true` interactively → ND spawns on commit (cap-equipped host).

Generated with [Claude Code](https://claude.com/claude-code)