### PR TITLE
nd: spawn before BGP so unnumbered always gets a live handle

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -91,11 +91,12 @@ pub struct ConfigManager {
     /// BFD attach logic.
     pub bfd_client_tx: RefCell<Option<UnboundedSender<crate::bfd::inst::ClientReq>>>,
     /// Sender side of the ND client-request channel. Populated by
-    /// [`super::nd::spawn_nd`] on the first `ipv6 router-advertisements`
-    /// config line (see `commit_config`); clones distributed to BGP
-    /// (via [`super::bgp::spawn_bgp`]) so the BGP unnumbered runtime
-    /// can submit `NdClientReq::SetNotifier` and observe
-    /// `NeighborDiscovered` events. `None` while ND has not been
+    /// [`super::nd::spawn_nd`] on either the first
+    /// `ipv6 router-advertisements` line or the first `router bgp`
+    /// line — whichever comes first in the commit. `spawn_bgp`
+    /// captures the handle by value, so the eager spawn-before-BGP
+    /// step in `commit_config` is what guarantees BGP unnumbered
+    /// always sees a live handle. `None` while ND has not been
     /// spawned, or while ND failed to start (missing `CAP_NET_RAW`,
     /// kernel rejecting a socket option, …); consumers silently skip
     /// in that case.
@@ -309,6 +310,15 @@ impl ConfigManager {
             }
             if !bgp && op == ConfigOp::Set && line.starts_with("router bgp") {
                 bgp = true;
+                // Spawn ND first if it hasn't started yet — `spawn_bgp`
+                // captures `nd_client_tx` by value, so BGP unnumbered
+                // gets no handle if ND lands afterwards. The reverse
+                // order (RA config before `router bgp`) already works
+                // via the per-line trigger below.
+                if !nd {
+                    nd = true;
+                    spawn_nd(self);
+                }
                 spawn_bgp(self);
             }
             if !bfd && op == ConfigOp::Set && line.starts_with("bfd") {

--- a/zebra-rs/src/config/nd.rs
+++ b/zebra-rs/src/config/nd.rs
@@ -3,19 +3,23 @@ use crate::nd::socket::nd_socket;
 
 use super::ConfigManager;
 
-/// Spawn the ND instance on first commit that mentions
-/// `ipv6 router-advertisements`.
+/// Spawn the ND instance. Triggered by [`commit_config`] in two
+/// places:
 ///
-/// Mirrors `spawn_ospf` / `spawn_bgp` / `spawn_bfd`: the dispatch in
-/// [`crate::config::ConfigManager::commit_config`] gates the call so
-/// hosts that never configure RAs don't pay the cost of opening a
-/// raw ICMPv6 socket (and don't see a startup `warn!` if the kernel
-/// rejects one of the socket options or `CAP_NET_RAW` is missing).
+///   * the first config line that contains
+///     `ipv6 router-advertisements`, or
+///   * the first `router bgp` line — eagerly, so BGP unnumbered's
+///     `spawn_bgp` (which captures `nd_client_tx` by value) gets a
+///     live handle regardless of whether the operator wrote the RA
+///     line first.
 ///
-/// BGP unnumbered also depends on ND — `spawn_bgp` captures
-/// `nd_client_tx` at spawn time. If `router bgp` is committed before
-/// any RA-touching line, BGP's handle stays `None`; that ordering
-/// caveat is identical to the BFD case noted in `spawn_bgp`.
+/// Mirrors `spawn_ospf` / `spawn_isis` / `spawn_bfd`: hosts that
+/// never configure either of those subtrees don't pay the cost of
+/// opening a raw ICMPv6 socket (and don't see a startup `warn!` if
+/// the kernel rejects one of the socket options or `CAP_NET_RAW` is
+/// missing).
+///
+/// [`commit_config`]: crate::config::ConfigManager::commit_config
 ///
 /// If `CAP_NET_RAW` is missing the raw ICMPv6 socket cannot be opened;
 /// we log a `warn!` and continue. The daemon stays functional, just


### PR DESCRIPTION
## Summary

`spawn_bgp` captures `nd_client_tx` by value at spawn time. With the conditional ND spawn from #634, ND can land *after* `router bgp` in the commit — either because the operator wrote `router bgp` on an earlier line or because they never wrote `ipv6 router-advertisements` at all. In both cases BGP unnumbered's handle stays `None` and the RA hand-off silently no-ops.

Fix: spawn ND eagerly inside the `router bgp` trigger in `commit_config`, gated on the same `nd` flag so we never double-spawn. The per-interface `ipv6 router-advertisements` trigger keeps working for the no-BGP case.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo build --bin zebra-rs --release`
- [ ] Commit `router bgp …` *without* any `ipv6 router-advertisements` line → ND visible in `protocol_tasks` after commit; `nd_client_tx` is `Some(_)` when `spawn_bgp` runs.
- [ ] Commit `ipv6 router-advertisements …` only (no BGP) → ND still spawns via the original trigger; no regression.
- [ ] Commit both with BGP listed first → ND spawns once, BGP gets the handle.

Generated with [Claude Code](https://claude.com/claude-code)