### PR TITLE
nd: set IPV6_CHECKSUM at IPPROTO_IPV6 level, not IPPROTO_ICMPV6

### DIFF
--- a/zebra-rs/src/nd/socket.rs
+++ b/zebra-rs/src/nd/socket.rs
@@ -120,7 +120,19 @@ fn set_recv_pkt_info(s: &Socket) -> io::Result<()> {
 }
 
 fn set_checksum_offset(s: &Socket, offset: c_int) -> io::Result<()> {
-    unsafe { setsockopt_int(s.as_raw_fd(), IPPROTO_ICMPV6, libc::IPV6_CHECKSUM, offset) }
+    // `IPV6_CHECKSUM` lives at the `IPPROTO_IPV6` level (RFC 3542 §3.1),
+    // not at `IPPROTO_ICMPV6`. Passing the ICMPv6 level here caused
+    // Linux to return `ENOPROTOOPT` ("Protocol not available"), which
+    // surfaced as the `nd: not started (set IPV6_CHECKSUM failed: …)`
+    // warn at every BGP / RA-related commit.
+    unsafe {
+        setsockopt_int(
+            s.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            libc::IPV6_CHECKSUM,
+            offset,
+        )
+    }
 }
 
 fn apply_icmp6_filter(s: &Socket, filter: &Icmp6Filter) -> io::Result<()> {


### PR DESCRIPTION
## Summary

`IPV6_CHECKSUM` is documented in RFC 3542 §3.1 as a socket option at the `IPPROTO_IPV6` level. Every other ICMPv6-related setsockopt in `nd/socket.rs` passes `libc::IPPROTO_IPV6` correctly, but `set_checksum_offset` mistakenly passed the local `IPPROTO_ICMPV6` constant (= 58). Linux returned `ENOPROTOOPT` ("Protocol not available", errno 92), which surfaced as:

```
WARN zebra-rs/src/config/nd.rs: nd: not started (set IPV6_CHECKSUM failed: Protocol not available (os error 92)); IPv6 RA send / receive disabled
```

The warn was dormant for hosts that never spawned ND. PR #635 made `router bgp` an additional trigger for `spawn_nd`, which exercised this path on hosts where it had always been broken.

One-line fix; commented for posterity.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo build --bin zebra-rs --release`
- [ ] Run with `router bgp` configured and caps set → no `nd: not started …` warn at commit.

Generated with [Claude Code](https://claude.com/claude-code)