### PR TITLE
config: spawn BFD before BGP / IS-IS when a commit will set both

### DIFF
--- a/zebra-rs/src/config/bgp.rs
+++ b/zebra-rs/src/config/bgp.rs
@@ -4,11 +4,14 @@ use crate::rib;
 use super::ConfigManager;
 
 pub fn spawn_bgp(config: &ConfigManager) {
-    // Capture BFD's client handle (if BFD is already spawned) so per-
-    // neighbor `bfd { enable }` can later submit Subscribe / Unsubscribe.
-    // If `bfd { ... }` is configured *after* `router bgp`, BGP's handle
-    // stays None and the BFD attach is a no-op — PR 5d adds a refresh
-    // path for that ordering.
+    // Capture BFD / ND client handles so per-neighbor `bfd { enable }`
+    // and IPv6 unnumbered RA hand-off can submit requests later. Both
+    // are guaranteed to be populated when BGP is spawned via
+    // `commit_config`: the BGP arm there pre-spawns ND eagerly, and
+    // pre-spawns BFD when the same commit will set `bfd { … }`.
+    // Code paths that bypass `commit_config` and call `spawn_bgp`
+    // directly may still see `None` here; the captured-by-value
+    // contract has not changed.
     let bfd_client_tx = config.bfd_client_tx.borrow().clone();
     let nd_client_tx = config.nd_client_tx.borrow().clone();
     let (rib_client, rib_rx) = config.subscribe_to_rib("bgp");

--- a/zebra-rs/src/config/isis.rs
+++ b/zebra-rs/src/config/isis.rs
@@ -5,11 +5,12 @@ use crate::rib;
 use super::ConfigManager;
 
 pub fn spawn_isis(config: &ConfigManager) {
-    // Capture BFD's client handle (if BFD is already spawned) so per-
-    // interface `bfd { enable }` can later submit Subscribe /
-    // Unsubscribe. If `bfd { ... }` is configured *after* IS-IS, the
-    // handle stays None and the BFD attach is a no-op — late-binding
-    // refresh is a follow-up.
+    // Capture BFD's client handle so per-interface `bfd { enable }`
+    // can later submit Subscribe / Unsubscribe. `commit_config`
+    // guarantees BFD is already spawned when this commit will also
+    // set `bfd { … }`, even if `router isis` came first in the diff
+    // (the IS-IS arm there pre-spawns BFD on the will-set flag).
+    // Callers that bypass `commit_config` may still see `None`.
     let bfd_client_tx = config.bfd_client_tx.borrow().clone();
     let (rib_client, rib_rx) = config.subscribe_to_rib("isis");
     let ctx = ProtoContext::default_table(rib_client);

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -288,6 +288,27 @@ impl ConfigManager {
                 nd = true;
             }
         }
+        // Pre-scan the diff so we know whether this commit will
+        // introduce a `bfd { … }` block *before* we process lines in
+        // order. Needed because BGP / IS-IS capture `bfd_client_tx`
+        // by value at spawn time; if the operator wrote `router bgp`
+        // (or `router isis`) above `bfd` in the same commit, the
+        // naive line-order spawn would hand them a `None` BFD handle.
+        let mut will_set_bfd = false;
+        for line in diff.lines() {
+            let Some(first_char) = line.chars().next() else {
+                continue;
+            };
+            if first_char != '+' {
+                continue;
+            }
+            let line = remove_first_char(line);
+            if line.starts_with("bfd") {
+                will_set_bfd = true;
+                break;
+            }
+        }
+
         for line in diff.lines() {
             let first_char = line.chars().next().unwrap();
             let op = match first_char {
@@ -306,18 +327,29 @@ impl ConfigManager {
             }
             if !isis && op == ConfigOp::Set && line.starts_with("router isis") {
                 isis = true;
+                // Spawn BFD first if this commit will set BFD too —
+                // `spawn_isis` captures `bfd_client_tx` by value, so
+                // IS-IS gets no handle if `bfd { … }` lands later in
+                // the same commit.
+                if !bfd && will_set_bfd {
+                    bfd = true;
+                    spawn_bfd(self);
+                }
                 spawn_isis(self);
             }
             if !bgp && op == ConfigOp::Set && line.starts_with("router bgp") {
                 bgp = true;
-                // Spawn ND first if it hasn't started yet — `spawn_bgp`
-                // captures `nd_client_tx` by value, so BGP unnumbered
-                // gets no handle if ND lands afterwards. The reverse
-                // order (RA config before `router bgp`) already works
-                // via the per-line trigger below.
+                // `spawn_bgp` captures `bfd_client_tx` *and*
+                // `nd_client_tx` by value. ND is always eager (BGP
+                // unnumbered may want it regardless of explicit RA
+                // config). BFD only if this commit will set it.
                 if !nd {
                     nd = true;
                     spawn_nd(self);
+                }
+                if !bfd && will_set_bfd {
+                    bfd = true;
+                    spawn_bfd(self);
                 }
                 spawn_bgp(self);
             }


### PR DESCRIPTION
## Summary

`spawn_bgp` and `spawn_isis` capture `bfd_client_tx` by value at spawn time. When a commit wrote `router bgp` (or `router isis`) above `bfd { … }`, the line-order spawn would hand them a `None` BFD handle and the per-neighbor / per-interface `bfd { enable }` attach would silently no-op. Symmetric to the ND-vs-BGP case fixed in #635.

`commit_config` now does a single pre-scan of the diff for any Set line that starts with `bfd`; the BGP and IS-IS arms pre-spawn BFD on that flag (guarded by the existing `bfd` flag so no double-spawn). The per-line `starts_with(\"bfd\")` trigger still covers commits that only touch BFD.

The ND trigger inside the BGP arm is unchanged — that one stays eager because BGP unnumbered may want a live `nd_client_tx` regardless of whether the operator wrote an explicit RA line.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo build --bin zebra-rs --release`
- [ ] Commit a config that writes `router bgp … neighbor X bfd { enable }` and `bfd { … }` with `router bgp` *first* in the diff → BFD attach takes effect (BGP handle is `Some`).
- [ ] Same for `router isis` first → IS-IS handle is `Some`.
- [ ] Commit only `bfd { … }` → BFD spawns once via the per-line trigger; no regression.
- [ ] Commit only `router bgp` → BFD does *not* spawn (will-set flag stays false); previous behavior preserved.

Generated with [Claude Code](https://claude.com/claude-code)