### PR TITLE
rib: always-on address recovery; drop --enable-addr-recovery

### DIFF
--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -59,12 +59,6 @@ struct Arg {
 
     #[arg(
         long,
-        help = "Re-install configured addresses removed by the kernel (cool-down on burst); off by default"
-    )]
-    enable_addr_recovery: bool,
-
-    #[arg(
-        long,
         help = "Write PID to this file on startup; in --daemon mode replaces /var/run/zebra-rs.pid"
     )]
     pid_file: Option<String>,
@@ -163,7 +157,7 @@ async fn run(arg: Arg) -> anyhow::Result<()> {
     let log_config = logging_config(&arg.log_output, &arg.log_file, &arg.log_format);
     tracing_set(arg.daemon, Some(log_config));
 
-    let rib = Rib::new(arg.no_nhid, arg.enable_addr_recovery)?;
+    let rib = Rib::new(arg.no_nhid)?;
 
     let policy = Policy::new();
 
@@ -178,6 +172,7 @@ async fn run(arg: Arg) -> anyhow::Result<()> {
         policy.tx.clone(),
         service_accounts.clone(),
     )?;
+
     config.subscribe("rib", rib.cm.tx.clone());
     config.subscribe("policy", policy.cm.tx.clone());
     config.subscribe_show("rib", rib.show.tx.clone());

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -426,13 +426,6 @@ pub struct Rib {
     /// `crate::rib::route::RECOVERY_*` if an external actor keeps
     /// fighting us.
     pub addr_recovery: BTreeMap<(u32, IpNet), AddrRecoveryState>,
-
-    /// Master switch for the kernel-driven address recovery feature
-    /// (re-install configured addresses on RTM_DELADDR, plus the link_up
-    /// bulk recovery loop). Set via `--enable-addr-recovery`. Off by
-    /// default — when false, an external delete tears the address down
-    /// the same way it did before the feature existed.
-    pub addr_recovery_enabled: bool,
 }
 
 /// Name of the dummy interface that hosts End-style seg6local routes
@@ -442,7 +435,7 @@ pub const SR0_DUMMY_NAME: &str = "sr0";
 const DEFAULT_RIB_SYNC_INTERVAL_SEC: u64 = 1;
 
 impl Rib {
-    pub fn new(no_nhid: bool, addr_recovery_enabled: bool) -> anyhow::Result<Self> {
+    pub fn new(no_nhid: bool) -> anyhow::Result<Self> {
         let fib = FibChannel::new();
         let fib_handle = FibHandle::new(fib.tx.clone(), no_nhid)?;
         let (tx, rx) = mpsc::unbounded_channel();
@@ -500,7 +493,6 @@ impl Rib {
             rib_sync_interval: DEFAULT_RIB_SYNC_INTERVAL_SEC,
             sr0_owned: false,
             addr_recovery: BTreeMap::new(),
-            addr_recovery_enabled,
         };
         rib.show_build();
         Ok(rib)
@@ -1561,15 +1553,14 @@ impl Rib {
                 self.router_id_update();
             }
             FibMessage::DelAddr(addr) => {
-                // When the address-recovery feature is enabled and the
-                // deleted address is still in config, push it back to
-                // the kernel rather than tearing down state. Recovery
-                // may be suppressed (Step 7 hold-down) — in both cases
+                // If the deleted address is still in config, push it back
+                // to the kernel rather than tearing down state. Recovery
+                // may be suppressed (Step 7 hold-down); in either case
                 // skip the normal teardown so the connected route
-                // doesn't churn. The next NewAddr we receive (either
-                // from our own re-install, or from a future operator
-                // add) will run the sync chain.
-                if self.addr_recovery_enabled && self.addr_recover_if_configured(&addr).await {
+                // doesn't churn. The next NewAddr we receive (from our
+                // own re-install, or from a future operator add) runs
+                // the sync chain.
+                if self.addr_recover_if_configured(&addr).await {
                     return;
                 }
 

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -456,43 +456,37 @@ impl Rib {
         // Suppression policy is shared with the kernel-driven DelAddr
         // recovery path: if a misbehaving external actor has already
         // triggered the cool-down for an address, link_up respects it.
-        //
-        // Gated by addr_recovery_enabled (`--enable-addr-recovery`); when
-        // off, the kernel-erased addresses simply stay erased until the
-        // operator re-applies config.
-        if self.addr_recovery_enabled {
-            let recover: Vec<IpNet> = link
-                .addr4
-                .iter()
-                .chain(link.addr6.iter())
-                .filter(|a| a.config && !a.fib)
-                .map(|a| a.addr)
-                .collect();
-            for prefix in recover {
-                let now = Instant::now();
-                let state = self.addr_recovery.entry((ifindex, prefix)).or_default();
-                // Don't record a "delete event" here — link_up isn't the
-                // kernel saying "deleted", it's us recovering after a
-                // bounce. Just consult the existing suppression state.
-                let suppressed = matches!(
-                    state.suppressed_until,
-                    Some(until) if until > now
+        let recover: Vec<IpNet> = link
+            .addr4
+            .iter()
+            .chain(link.addr6.iter())
+            .filter(|a| a.config && !a.fib)
+            .map(|a| a.addr)
+            .collect();
+        for prefix in recover {
+            let now = Instant::now();
+            let state = self.addr_recovery.entry((ifindex, prefix)).or_default();
+            // Don't record a "delete event" here — link_up isn't the
+            // kernel saying "deleted", it's us recovering after a
+            // bounce. Just consult the existing suppression state.
+            let suppressed = matches!(
+                state.suppressed_until,
+                Some(until) if until > now
+            );
+            if suppressed {
+                let remaining = state
+                    .suppressed_until
+                    .and_then(|until| until.checked_duration_since(now))
+                    .unwrap_or_default();
+                tracing::info!(
+                    "link_up: {} skipping re-install of {} ({}s cool-down remaining)",
+                    link_name,
+                    prefix,
+                    remaining.as_secs(),
                 );
-                if suppressed {
-                    let remaining = state
-                        .suppressed_until
-                        .and_then(|until| until.checked_duration_since(now))
-                        .unwrap_or_default();
-                    tracing::info!(
-                        "link_up: {} skipping re-install of {} ({}s cool-down remaining)",
-                        link_name,
-                        prefix,
-                        remaining.as_secs(),
-                    );
-                    continue;
-                }
-                self.addr_reinstall(ifindex, &link_name, &prefix).await;
+                continue;
             }
+            self.addr_reinstall(ifindex, &link_name, &prefix).await;
         }
 
         ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.links, &self.fib_handle).await;


### PR DESCRIPTION
## Summary

- Kernel-driven address recovery (re-install configured addresses on `RTM_DELADDR`, plus the `link_up` bulk recovery loop) already ships with hold-down suppression (`RECOVERY_BURST_THRESHOLD` / `RECOVERY_COOLDOWN`) that breaks delete/re-install fights with a misbehaving peer.
- With that suppression in place the feature is safe to leave on by default. Drop the `--enable-addr-recovery` opt-in: the CLI flag, the `addr_recovery_enabled: bool` field on `Rib`, and the two call-site gates (`FibMessage::DelAddr` handler and the `link_up` recovery loop).

## Test plan

- [x] `cargo build --bin zebra-rs` clean.
- [x] `cargo clippy --bin zebra-rs --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all` clean.
- [x] `cargo test --bin zebra-rs` — 490 passed / 0 failed.

Generated with [Claude Code](https://claude.com/claude-code)