### PR TITLE
vty: gate session info logs on VTY_TRACING

### DIFF
--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -28,7 +28,7 @@ use super::vty::{
     LogoutRequest, ShowReply, ShowRequest, YangMatch,
 };
 
-const VTY_TRACING: bool = false;
+pub(super) const VTY_TRACING: bool = false;
 
 #[derive(Debug)]
 struct ExecService {

--- a/zebra-rs/src/config/session.rs
+++ b/zebra-rs/src/config/session.rs
@@ -17,6 +17,8 @@ use std::time::{Duration, Instant};
 #[cfg(target_os = "linux")]
 use dashmap::DashMap;
 
+use super::serve::VTY_TRACING;
+
 /// Default idle TTL for VTY sessions. Mirrors the typical Cisco IOS
 /// `exec-timeout 10 0` default.
 #[cfg(target_os = "linux")]
@@ -492,7 +494,9 @@ pub async fn watch_bash_death(table: Arc<SessionTable>, key: SessionKey, bash_pi
     match async_fd.readable().await {
         Ok(_guard) => {
             if table.remove(&key) {
-                tracing::info!(uid = key.0, bash_pid, "vty session removed (bash exited)");
+                if VTY_TRACING {
+                    tracing::info!(uid = key.0, bash_pid, "vty session removed (bash exited)");
+                }
             } else {
                 tracing::debug!(
                     uid = key.0,
@@ -523,12 +527,14 @@ where
         ticker.tick().await;
         let stats = table.gc_once(&reader, idle_ttl);
         if stats.removed_idle > 0 || stats.removed_gone > 0 {
-            tracing::info!(
-                removed_idle = stats.removed_idle,
-                removed_gone = stats.removed_gone,
-                remaining = stats.remaining,
-                "vty session GC",
-            );
+            if VTY_TRACING {
+                tracing::info!(
+                    removed_idle = stats.removed_idle,
+                    removed_gone = stats.removed_gone,
+                    remaining = stats.remaining,
+                    "vty session GC",
+                );
+            }
         } else {
             tracing::debug!(remaining = stats.remaining, "vty session GC (no-op)");
         }


### PR DESCRIPTION
## Summary

Mirrors the gating just landed in #643 for serve.rs. Both `tracing::info!` sites in `config/session.rs` (the pidfd-driven session-removal log and the periodic GC sweep summary) now wrap in `if VTY_TRACING { ... }`. Sibling `debug!` / `warn!` calls in the same blocks are untouched.

To share the flag, `VTY_TRACING` in `serve.rs` is bumped from private `const` to `pub(super) const` and imported in `session.rs` via `super::serve::VTY_TRACING`.

## Test plan

- [x] `cargo build --bin zebra-rs` clean.
- [x] `cargo clippy --bin zebra-rs --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all` clean.
- [x] `cargo test --bin zebra-rs` — 490 passed / 0 failed.

Generated with [Claude Code](https://claude.com/claude-code)