### PR TITLE
rib: collapse rtype/rsubtype columns in show ip route

### DIFF
--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -7,10 +7,28 @@ use crate::{
     rib::{Label, Nexthop, nexthop::NexthopMember, nexthop::NexthopUni},
 };
 
-use super::{Group, Rib, entry::RibEntry, inst::ShowCallback, link::link_show, nexthop_show};
+use super::{
+    Group, Rib, entry::RibEntry, inst::ShowCallback, link::link_show, nexthop_show,
+    types::RibSubType, types::RibType,
+};
 use std::fmt::Write;
 use std::net::IpAddr;
 use std::time::Duration;
+
+// Two-char tag column used in `show ip route` lines. When the route has
+// a meaningful sub-type (OSPF inter-area, IS-IS L1/L2, …) we show that
+// two-letter tag; otherwise we show the protocol letter padded with one
+// space so the `*>` FIB-mark column lines up across both forms:
+//   `D  *> 0.0.0.0/0 …`
+//   `O IA *> 10.0.0.0/24 …`
+fn route_tag(rtype: &RibType, rsubtype: &RibSubType) -> String {
+    let sub = rsubtype.abbrev();
+    if sub.is_empty() {
+        format!("{} ", rtype.abbrev())
+    } else {
+        sub
+    }
+}
 
 /// Format a route's age the way `show ip route` lines render it:
 /// `HH:MM:SS` for sub-day, `Nd Nh Nm` for ≥ 24 hours. Matches the
@@ -383,9 +401,8 @@ pub fn rib_entry_show(
     // All type route.
     write!(
         buf,
-        "{} {} {} {}",
-        e.rtype.abbrev(),
-        e.rsubtype.abbrev(),
+        "{} {} {}",
+        route_tag(&e.rtype, &e.rsubtype),
         e.selected(),
         prefix,
     )?;
@@ -534,9 +551,8 @@ pub fn rib_entry_show_v6(
     // All type route.
     write!(
         buf,
-        "{} {} {} {}",
-        e.rtype.abbrev(),
-        e.rsubtype.abbrev(),
+        "{} {} {}",
+        route_tag(&e.rtype, &e.rsubtype),
         e.selected(),
         prefix,
     )?;

--- a/zebra-rs/src/rib/types.rs
+++ b/zebra-rs/src/rib/types.rs
@@ -133,7 +133,7 @@ impl From<u8> for RibSubType {
 impl RibSubType {
     pub fn abbrev(&self) -> String {
         match self {
-            Self::Default => "  ".to_string(),
+            Self::Default => "".to_string(),
             Self::OspfIa => "IA".to_string(),
             Self::OspfNssa1 => "N1".to_string(),
             Self::OspfNssa2 => "N2".to_string(),
@@ -142,7 +142,7 @@ impl RibSubType {
             Self::IsisLevel1 => "L1".to_string(),
             Self::IsisLevel2 => "L2".to_string(),
             Self::IsisIntraArea => "ia".to_string(),
-            Self::Other(_) => "  ".to_string(),
+            Self::Other(_) => "".to_string(),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Show a single 2-char tag column before the FIB-mark \`*>\` instead of \"rtype rsubtype\".
- When the route has a meaningful sub-type (OSPF \`IA\`/\`N1\`/\`N2\`/\`E1\`/\`E2\`, IS-IS \`L1\`/\`L2\`/\`ia\`) we print just that two-letter tag; otherwise we print the protocol letter padded with one space.
- \`*>\` column stays aligned across both forms because every tag is exactly two chars.

Before:
\`\`\`
D    *> 0.0.0.0/0 [0/100] via 10.211.55.1, enp0s5, 00:00:03
C    *> 10.0.0.1/32 is directly connected, lo, 00:00:03
i    *> 10.0.0.2/32 [115/20] via 192.168.10.2, enp0s6, label 16200 (implicit-null), 00:00:03
O IA *> 10.0.0.0/24 …
\`\`\`

After:
\`\`\`
D  *> 0.0.0.0/0 [0/100] via 10.211.55.1, enp0s5, 00:00:03
C  *> 10.0.0.1/32 is directly connected, lo, 00:00:03
i  *> 10.0.0.2/32 [115/20] via 192.168.10.2, enp0s6, label 16200 (implicit-null), 00:00:03
IA *> 10.0.0.0/24 …
\`\`\`

## Test plan

- [ ] \`cargo build --bin zebra-rs\` (verified locally)
- [ ] \`cargo fmt --all\` (clean)
- [ ] CI green
- [ ] Spot-check \`show ip route\` and \`show ipv6 route\` against a live daemon to confirm alignment

Generated with [Claude Code](https://claude.com/claude-code)