### PR TITLE
bdd: rename bgp community feature file

### DIFF
--- a/bdd/tests/features/bgp_community.feature
+++ b/bdd/tests/features/bgp_community.feature
@@ -1,5 +1,5 @@
 @serial
-@bgp_community_no_export_advertise
+@bgp_community
 Feature: BGP well-known community handling (no-export, no-advertise)
   As a network operator
   I want to verify that the well-known communities NO_EXPORT and


### PR DESCRIPTION
## Summary

- Renames `bdd/tests/features/bgp_community_no_export_advertise.feature` to `bgp_community.feature`.
- Renames the matching Gherkin tag `@bgp_community_no_export_advertise` to `@bgp_community` so the tag stays aligned with the filename.
- Lets future BGP community scenarios (no-export-subconfed, local-AS, large-community, …) land in the same feature file instead of spawning per-community files.

No other code references the old name; the only reference was the in-file tag.

## Test plan

- [ ] BDD suite (excluded from CI; manual verification by the BDD operator if/when they pick this up)
- [ ] No occurrences of `bgp_community_no_export_advertise` remain after this rename (verified locally with grep)

Generated with [Claude Code](https://claude.com/claude-code)