### PR TITLE
isis: gate TI-LFA repair-path on fast-reroute ti-lfa

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -336,9 +336,9 @@ pub struct IsisConfig {
     pub sr_srv6_flex_algo_locators: BTreeMap<u8, String>,
 
     /// Set when /router/isis/fast-reroute/ti-lfa is committed (the
-    /// presence-marked YANG container). Will gate post-convergence
-    /// SPF + SR-label backup install once the repair-path computation
-    /// lands; for now no code reads it.
+    /// presence-marked YANG container). Gates the per-destination
+    /// `tilfa_repair_path` calls in `perform_spf_calculation` and the
+    /// Adj-SID B-flag (RFC 8667 §2.2.1) emitted in TLV 22 sub-TLVs.
     pub ti_lfa_enabled: bool,
 
     /// True when `/router/isis/multi-topology` carries an MT id.
@@ -748,14 +748,22 @@ fn config_sr_srv6_flex_algo_locator(isis: &mut Isis, mut args: Args, op: ConfigO
 }
 
 fn config_ti_lfa(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
+    let prev = isis.config.ti_lfa_enabled;
     isis.config.ti_lfa_enabled = op.is_set();
-    // Adj-SID B-flag (RFC 8667 §2.2.1) is built from ti_lfa_enabled
-    // at LSP-generation time, so the toggle is only observable after
-    // a fresh origination. has_level() inside process_lsp_originate
-    // filters out the level that doesn't apply for level-1-only /
-    // level-2-only instances, so sending both unconditionally is safe.
+    if isis.config.ti_lfa_enabled == prev {
+        return Some(());
+    }
+    // Re-originate the self LSP so the Adj-SID B-flag (RFC 8667 §2.2.1)
+    // reflects the new state at LSP-generation time. has_level() inside
+    // process_lsp_originate filters out the wrong level for
+    // level-1-only / level-2-only instances, so sending both
+    // unconditionally is safe.
     let _ = isis.tx.send(Message::LspOriginate(Level::L1, None));
     let _ = isis.tx.send(Message::LspOriginate(Level::L2, None));
+    // Recompute SPF so the RIB picks up repair paths (on enable) or
+    // drops them (on disable) for every prefix in this instance.
+    let _ = isis.tx.send(Message::SpfCalc(Level::L1));
+    let _ = isis.tx.send(Message::SpfCalc(Level::L2));
     Some(())
 }
 

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -954,8 +954,14 @@ pub(super) fn perform_spf_calculation(top: &mut IsisTop, level: Level) {
     // §5 strict NLPID gating across every transit node.
     let spf_result = spf::spf(&graph, source, &spf::SpfOpt::full_path());
 
-    // TI-LFA repair path.
-    let tilfa_result = tilfa_repair_path(&graph, source, &spf_result);
+    // TI-LFA repair path. Gated on `fast-reroute ti-lfa` — when the
+    // knob is off we still install the primary RIB built from
+    // `spf_result`, just without the per-destination repair list.
+    let tilfa_result = if top.config.ti_lfa_enabled {
+        tilfa_repair_path(&graph, source, &spf_result)
+    } else {
+        BTreeMap::new()
+    };
 
     // Build RIB.
     let rib = build_rib_from_spf(top, level, source, &spf_result, &tilfa_result);
@@ -971,7 +977,11 @@ pub(super) fn perform_spf_calculation(top: &mut IsisTop, level: Level) {
         *top.mt2_graph.get_mut(&level) = Some(mt2_graph.clone());
         if let Some(mt2_src) = mt2_source {
             let mt2_spf = spf::spf(&mt2_graph, mt2_src, &spf::SpfOpt::full_path());
-            let mt2_tilfa = tilfa_repair_path(&mt2_graph, mt2_src, &mt2_spf);
+            let mt2_tilfa = if top.config.ti_lfa_enabled {
+                tilfa_repair_path(&mt2_graph, mt2_src, &mt2_spf)
+            } else {
+                BTreeMap::new()
+            };
             let rib_v6 = build_rib_from_spf_v6(top, level, mt2_src, &mt2_spf, &mt2_tilfa, true);
             *top.mt2_spf_result.get_mut(&level) = Some(mt2_spf);
             rib_v6


### PR DESCRIPTION
## Summary

- `set router isis fast-reroute ti-lfa` is now actually wired up as the TI-LFA calculation knob: `perform_spf_calculation` only invokes `tilfa_repair_path` when `top.config.ti_lfa_enabled` is true.
- Both the legacy / MT-0 SPF and the MT-2 (TLV 222 / 237) SPF paths are gated the same way. When disabled, an empty repair map flows through so the primary RIB still installs but without backup nexthops.
- `config_ti_lfa` now compares against the previous value; on an actual toggle it sends `Message::LspOriginate` (existing — for the Adj-SID B-flag) **and** `Message::SpfCalc` for L1 and L2, so the RIB picks up or drops repair paths immediately instead of waiting for the next natural SPF trigger.
- Field doc updated; the old "for now no code reads it" line is no longer accurate.

## Test plan

- [x] `cargo build --bin zebra-rs`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib` (16 SPF/TI-LFA tests pass)
- [ ] Manual: toggle `set router isis fast-reroute ti-lfa` on a converged topology and verify `show isis route detail` repair lists appear / disappear without waiting for a fresh LSP event.

Generated with [Claude Code](https://claude.com/claude-code)