### PR TITLE
isis: trim show isis spf first-hop/nexthop line

### DIFF
--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -1820,7 +1820,7 @@ fn render_spf(
                 .filter_map(|(name, graph, spf)| {
                     let g = graph.as_ref()?;
                     let s = spf.as_ref()?;
-                    Some((name.to_string(), spf_topology_json(g, s, detail)))
+                    Some((name.to_string(), spf_topology_json(isis, g, s, detail)))
                 })
                 .collect(),
         };
@@ -1843,23 +1843,16 @@ fn render_spf(
         writeln!(buf, "\n{} SPF results:", name)?;
         for (dest, path) in spf.iter() {
             let dest_name = vertex_name(graph, *dest);
-            writeln!(
-                buf,
-                "  Destination {} (vertex {}), cost {}",
-                dest_name, dest, path.cost,
-            )?;
+            writeln!(buf, "  Destination {}, cost {}", dest_name, path.cost)?;
             if path.first_hop_links.is_empty() {
-                writeln!(buf, "    (no first-hop — self or unreachable)")?;
+                writeln!(buf, "    (no nexthop — self or unreachable)")?;
             } else {
                 let mut hops: Vec<(usize, u32)> = path.first_hop_links.iter().copied().collect();
                 hops.sort();
                 for (i, (fh_vertex, link_id)) in hops.iter().enumerate() {
                     let fh_name = vertex_name(graph, *fh_vertex);
-                    writeln!(
-                        buf,
-                        "    [{}] first-hop {} (vertex {}, link_id {})",
-                        i, fh_name, fh_vertex, link_id,
-                    )?;
+                    let ifname = isis.ifname(*link_id);
+                    writeln!(buf, "    [{}] nexthop {} ({})", i, fh_name, ifname)?;
                 }
             }
             if path.paths.is_empty() {
@@ -1923,6 +1916,7 @@ fn format_vertex_path(graph: &spf::Graph, path: &[usize]) -> String {
 }
 
 fn spf_topology_json(
+    isis: &Isis,
     graph: &spf::Graph,
     spf: &BTreeMap<usize, spf::Path>,
     _detail: bool,
@@ -1936,12 +1930,12 @@ fn spf_topology_json(
                 vertex_id: *dest,
                 name: vertex_name(graph, *dest),
                 cost: path.cost,
-                first_hops: hops
+                nexthops: hops
                     .into_iter()
-                    .map(|(v, link_id)| SpfFirstHopJson {
+                    .map(|(v, link_id)| SpfNexthopJson {
                         vertex_id: v,
                         name: vertex_name(graph, v),
-                        link_id,
+                        interface: isis.ifname(link_id),
                     })
                     .collect(),
                 paths: path
@@ -1981,15 +1975,15 @@ struct SpfDestinationJson {
     vertex_id: usize,
     name: String,
     cost: u32,
-    first_hops: Vec<SpfFirstHopJson>,
+    nexthops: Vec<SpfNexthopJson>,
     paths: Vec<Vec<SpfPathVertexJson>>,
 }
 
 #[derive(Serialize)]
-struct SpfFirstHopJson {
+struct SpfNexthopJson {
     vertex_id: usize,
     name: String,
-    link_id: u32,
+    interface: String,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
## Summary

Three follow-up edits on the same `show isis spf` first-hop line, bundled into one commit:

- Drop the internal `(vertex N)` annotations from destination and first-hop lines — SPF vertex ids are implementation detail.
- Look up the local interface via `Isis::ifname(link_id)` and print the bare interface name instead of the raw `link_id` integer.
- Rename the operator-facing term `first-hop` → `nexthop` (text and JSON: `first_hops` → `nexthops`, `SpfFirstHopJson` → `SpfNexthopJson`) to match the term the rest of the show layer already uses.

New line shape:
```
  Destination R1, cost 10
    [0] nexthop R2 (eth0)
```

Edges with no local interface (remote-origin / pseudonode edges where `link_id = 0`) render as `(unknown)`, matching `ifname()`'s fallback elsewhere in the show layer. `show isis ti-lfa` is left untouched; vertex/link ids there are still useful for cross-referencing the repair-path graph.

## Test plan

- [x] `cargo build --bin zebra-rs`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] Manual: `show isis spf` against a converged topology — verify the new line shape and the "(unknown)" fallback for remote-origin paths.

Generated with [Claude Code](https://claude.com/claude-code)