### PR TITLE
isis: skip pseudonode destinations from TI-LFA

### DIFF
--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -958,7 +958,7 @@ pub(super) fn perform_spf_calculation(top: &mut IsisTop, level: Level) {
     // knob is off we still install the primary RIB built from
     // `spf_result`, just without the per-destination repair list.
     let tilfa_result = if top.config.ti_lfa_enabled {
-        tilfa_repair_path(&graph, source, &spf_result)
+        tilfa_repair_path(&graph, top.lsp_map.get(&level), source, &spf_result)
     } else {
         BTreeMap::new()
     };
@@ -978,7 +978,7 @@ pub(super) fn perform_spf_calculation(top: &mut IsisTop, level: Level) {
         if let Some(mt2_src) = mt2_source {
             let mt2_spf = spf::spf(&mt2_graph, mt2_src, &spf::SpfOpt::full_path());
             let mt2_tilfa = if top.config.ti_lfa_enabled {
-                tilfa_repair_path(&mt2_graph, mt2_src, &mt2_spf)
+                tilfa_repair_path(&mt2_graph, top.lsp_map.get(&level), mt2_src, &mt2_spf)
             } else {
                 BTreeMap::new()
             };

--- a/zebra-rs/src/isis/tilfa.rs
+++ b/zebra-rs/src/isis/tilfa.rs
@@ -319,6 +319,7 @@ fn repair_segments_to_mpls_labels(
 /// repair list. The returned map is keyed by destination vertex id.
 pub(super) fn tilfa_repair_path(
     graph: &spf::Graph,
+    lsp_map: &LspMap,
     source: usize,
     spf_result: &BTreeMap<usize, spf::Path>,
 ) -> BTreeMap<usize, Vec<spf::RepairPath>> {
@@ -331,6 +332,10 @@ pub(super) fn tilfa_repair_path(
         }
         // ECMP is skipped.
         if path.paths.len() > 1 {
+            continue;
+        }
+        // Pseudonode is skipped — no destination prefix to install.
+        if lsp_map.is_pseudo(*d) {
             continue;
         }
 


### PR DESCRIPTION
## Summary
- Pseudonodes are transit-only and own no destination prefix (the RIB builder already filters them at \`rib.rs:494\`). Computing a TI-LFA repair list for a pseudonode destination just wastes a \`tilfa()\` call.
- Add the skip to \`tilfa_repair_path\` by threading \`lsp_map: &LspMap\` through the signature; both legacy/MT-0 and MT-2 callers in \`perform_spf_calculation\` pass \`top.lsp_map.get(&level)\`.

## Test plan
- [x] \`cargo build --bin zebra-rs\` clean
- [x] \`cargo test -p zebra-rs spf\` — 13 passed
- [x] \`cargo fmt --all\` clean
- [x] \`cargo clippy --all-targets\` clean

Generated with [Claude Code](https://claude.com/claude-code)