### PR TITLE
fib: log additional NetlinkPayload variants on NewNexthop

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -1048,6 +1048,15 @@ impl FibHandle {
                 NetlinkPayload::Done(m) => {
                     tracing::info!("NewNexthop done {m:?}");
                 }
+                NetlinkPayload::InnerMessage(e) => {
+                    tracing::info!("NewNexthop inner message {:?}", e);
+                }
+                NetlinkPayload::Noop => {
+                    tracing::info!("NewNexthop noop");
+                }
+                NetlinkPayload::Overrun(e) => {
+                    tracing::info!("NewNexthop Overrun {:?}", e);
+                }
                 _ => {
                     tracing::info!("NewNexthop other return");
                 }


### PR DESCRIPTION
## Summary
- The \`NewNexthop\` response handler had explicit arms only for the common variants and folded everything else into a single catch-all log line. Add explicit arms for \`InnerMessage\`, \`Noop\`, and \`Overrun\` so unexpected payloads are visible in traces with their decoded contents instead of being lumped into "NewNexthop other return".

## Test plan
- [x] \`cargo build --bin zebra-rs\` clean
- [x] \`cargo fmt --all\` clean
- [x] \`cargo clippy --all-targets\` clean

Generated with [Claude Code](https://claude.com/claude-code)