### PR TITLE
bgp: emit RFC 8950 MP_REACH on ENHE-negotiated peers

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -84,6 +84,7 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
             rib_client: &bgp.ctx.rib,
             attr_store: &mut bgp.attr_store,
             update_groups: &mut bgp.update_groups,
+            interface_addrs: &bgp.interface_addrs,
         };
         route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers);
         bgp.peers.remove(&addr);

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -459,6 +459,7 @@ impl Bgp {
                     rib_client: &self.ctx.rib,
                     attr_store: &mut self.attr_store,
                     update_groups: &mut self.update_groups,
+                    interface_addrs: &self.interface_addrs,
                 };
 
                 fsm(&mut bgp_ref, &mut self.peers, ident, event);
@@ -478,6 +479,7 @@ impl Bgp {
                     &mut self.peers,
                     &mut self.attr_store,
                     &group_id,
+                    &self.interface_addrs,
                 );
             }
         }

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -520,13 +520,35 @@ impl Peer {
     /// once RFC 8950 Extended Next Hop is negotiated on this peer.
     /// Returns `None` for any peer that isn't interface-keyed, or when
     /// the egress interface's link-local hasn't been observed yet via
-    /// `RibRx::AddrAdd`. Callers must already have confirmed ENHE was
-    /// negotiated — this only resolves the address.
-    pub fn next_hop_v6(&self, bgp: &Bgp) -> Option<std::net::Ipv6Addr> {
+    /// `RibRx::AddrAdd`. Callers should pair this with
+    /// [`Self::is_enhe_v4_negotiated`] before emitting.
+    pub fn next_hop_v6(
+        &self,
+        addrs: &super::interface_addrs::InterfaceAddrs,
+    ) -> Option<std::net::Ipv6Addr> {
         if !matches!(self.origin, PeerOrigin::Interface { .. }) {
             return None;
         }
-        bgp.interface_addrs.link_local_for(self.scope_id?)
+        addrs.link_local_for(self.scope_id?)
+    }
+
+    /// True iff both directions of the BGP capability exchange
+    /// advertised RFC 8950 Extended Next Hop for (IPv4-unicast,
+    /// IPv6 next-hop). Mirrors the per-AFI/SAFI gate used by
+    /// `update_group::signature_of` so the encoder and the
+    /// update-group accounting agree on what's negotiated.
+    pub fn is_enhe_v4_negotiated(&self) -> bool {
+        let sent = self
+            .cap_send
+            .extended_nexthop
+            .as_ref()
+            .is_some_and(|c| c.supports_v6_nexthop_for_ipv4_unicast());
+        let received = self
+            .cap_recv
+            .extended_nexthop
+            .as_ref()
+            .is_some_and(|c| c.supports_v6_nexthop_for_ipv4_unicast());
+        sent && received
     }
 }
 
@@ -537,6 +559,9 @@ pub struct BgpTop<'a> {
     pub rib_client: &'a crate::rib::client::RibClient,
     pub attr_store: &'a mut BgpAttrStore,
     pub update_groups: &'a mut super::update_group::UpdateGroupMap,
+    /// Per-ifindex IPv6 link-local registry, used to resolve the v6
+    /// next-hop for RFC 8950 IPv4-over-IPv6 emit on interface peers.
+    pub interface_addrs: &'a super::interface_addrs::InterfaceAddrs,
 }
 
 pub fn fsm_next_state(peer: &mut Peer, event: Event) -> (State, FsmEffect) {
@@ -1272,6 +1297,7 @@ pub fn apply_soft_in_peer(bgp: &mut Bgp, peer_idx: usize) {
             rib_client: &bgp.ctx.rib,
             attr_store: &mut bgp.attr_store,
             update_groups: &mut bgp.update_groups,
+            interface_addrs: &bgp.interface_addrs,
         };
         super::route::route_soft_in_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
     } else if supports_refresh {
@@ -1300,6 +1326,7 @@ pub fn apply_soft_out_peer(bgp: &mut Bgp, peer_idx: usize) {
         rib_client: &bgp.ctx.rib,
         attr_store: &mut bgp.attr_store,
         update_groups: &mut bgp.update_groups,
+        interface_addrs: &bgp.interface_addrs,
     };
     super::route::route_soft_out_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1456,11 +1456,18 @@ fn route_soft_out_peer_table(
         newly_advertised.insert(*prefix);
     }
 
-    // Direct-emit IPv4 unicast batch (no group fan-out).
+    // Direct-emit IPv4 unicast batch (no group fan-out). When the
+    // peer negotiated RFC 8950 ENHE for IPv4 unicast, pass the
+    // per-interface link-local so the encoder emits MP_REACH instead
+    // of the legacy inline-NLRI form.
     if rd.is_none()
         && let Some(peer) = peers.get_by_idx(peer_idx)
     {
-        super::update_group::send_ipv4_direct(peer, ipv4_entries);
+        let enhe_v6 = peer
+            .is_enhe_v4_negotiated()
+            .then(|| peer.next_hop_v6(bgp.interface_addrs))
+            .flatten();
+        super::update_group::send_ipv4_direct(peer, ipv4_entries, enhe_v6);
     }
 
     let to_withdraw: Vec<Ipv4Net> = was_advertised
@@ -3236,7 +3243,11 @@ pub fn route_sync_ipv4(peer: &mut Peer, bgp: &mut BgpTop) {
         entries.push((arc_attr, nlri));
     }
 
-    super::update_group::send_ipv4_direct(peer, entries);
+    let enhe_v6 = peer
+        .is_enhe_v4_negotiated()
+        .then(|| peer.next_hop_v6(bgp.interface_addrs))
+        .flatten();
+    super::update_group::send_ipv4_direct(peer, entries, enhe_v6);
 
     // Send End-of-RIB marker for IPv4 Unicast
     send_eor_ipv4_unicast(peer);
@@ -3464,6 +3475,7 @@ impl Bgp {
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
             update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
         };
 
         if !selected.is_empty() {
@@ -3490,6 +3502,7 @@ impl Bgp {
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
             update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
         };
 
         let selected = bgp_ref.local_rib.select_best_path(prefix);
@@ -3568,6 +3581,7 @@ impl Bgp {
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
             update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
         };
 
         if !selected.is_empty() {
@@ -3594,6 +3608,7 @@ impl Bgp {
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
             update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
         };
 
         let selected = bgp_ref.local_rib.select_best_path(prefix);
@@ -3721,6 +3736,7 @@ impl Bgp {
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
             update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
         };
 
         if !selected.is_empty() {
@@ -3839,6 +3855,7 @@ impl Bgp {
             rib_client: &self.ctx.rib,
             attr_store: &mut self.attr_store,
             update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
         };
 
         if !selected.is_empty() {

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -421,6 +421,7 @@ pub fn flush_ipv4(
     peers: &mut PeerMap,
     _attr_store: &mut BgpAttrStore,
     id: &UpdateGroupId,
+    interface_addrs: &super::interface_addrs::InterfaceAddrs,
 ) {
     let afi_safi = AfiSafi::new(Afi::Ip, Safi::Unicast);
     let Some(af) = update_groups.get_mut(&afi_safi) else {
@@ -453,14 +454,34 @@ pub fn flush_ipv4(
     } else {
         bgp_packet::BGP_PACKET_LEN
     };
+    let enhe = group.sig.extended_next_hop;
     let member_idents: Vec<usize> = group.members.iter().copied().collect();
 
-    // Resolve packet_tx for each member up front.
-    let members: Vec<(usize, Option<mpsc::UnboundedSender<bytes::BytesMut>>)> = member_idents
+    // Resolve packet_tx and (when ENHE) per-member v6 next-hop up
+    // front. The next-hop derives from each peer's egress ifindex
+    // (`scope_id`), so it varies per member even within one
+    // update-group; the canonical-bytes sharing the legacy path
+    // relies on cannot apply.
+    struct MemberCtx {
+        ident: usize,
+        tx: Option<mpsc::UnboundedSender<bytes::BytesMut>>,
+        enhe_v6: Option<std::net::Ipv6Addr>,
+    }
+    let members: Vec<MemberCtx> = member_idents
         .iter()
         .map(|ident| {
-            let tx = peers.get_by_idx(*ident).and_then(|p| p.packet_tx.clone());
-            (*ident, tx)
+            let peer = peers.get_by_idx(*ident);
+            let tx = peer.and_then(|p| p.packet_tx.clone());
+            let enhe_v6 = if enhe {
+                peer.and_then(|p| p.next_hop_v6(interface_addrs))
+            } else {
+                None
+            };
+            MemberCtx {
+                ident: *ident,
+                tx,
+                enhe_v6,
+            }
         })
         .collect();
 
@@ -476,6 +497,52 @@ pub fn flush_ipv4(
             .filter(|m| source_idents.contains(m))
             .collect();
 
+        if enhe {
+            // Per-member encode: each member's v6 next-hop is its own
+            // interface link-local; canonical-bytes sharing across
+            // members would force every member onto the same LL,
+            // which would break ENHE for everyone but one peer.
+            for ctx in &members {
+                let Some(tx) = ctx.tx.as_ref() else { continue };
+                let Some(ll) = ctx.enhe_v6 else {
+                    // ND hasn't observed any link-local on this
+                    // peer's egress interface yet; the operator-side
+                    // address-add events haven't reached BGP. Skip
+                    // this member's flush — we'll re-cache on the
+                    // next event arrival rather than emit a
+                    // garbage next-hop.
+                    continue;
+                };
+                let nlris: Vec<Ipv4Nlri> = entries
+                    .iter()
+                    .filter(|(_, src)| *src != ctx.ident)
+                    .map(|(n, _)| n.clone())
+                    .collect();
+                if nlris.is_empty() {
+                    if pruned_members.contains(&ctx.ident)
+                        && let Some(group) = af.group_by_id_mut(id)
+                    {
+                        group.counters.split_horizon_excluded += 1;
+                    }
+                    continue;
+                }
+                let bytes_list = encode_ipv4_update(&attr, &nlris, max_packet_size, Some(ll));
+                let byte_total: usize = bytes_list.iter().map(|b| b.len()).sum();
+                for bytes in &bytes_list {
+                    let _ = tx.send(bytes.clone());
+                }
+                if let Some(group) = af.group_by_id_mut(id) {
+                    group.counters.messages_formatted += bytes_list.len() as u64;
+                    group.counters.messages_replicated += bytes_list.len() as u64;
+                    group.counters.bytes_formatted += byte_total as u64;
+                    if pruned_members.contains(&ctx.ident) {
+                        group.counters.split_horizon_excluded += 1;
+                    }
+                }
+            }
+            continue;
+        }
+
         // Canonical UPDATE: every NLRI in the bucket.
         let canonical: Vec<Ipv4Nlri> = entries.iter().map(|(n, _)| n.clone()).collect();
         let canonical_bytes = encode_ipv4_update(&attr, &canonical, max_packet_size, None);
@@ -489,11 +556,11 @@ pub fn flush_ipv4(
         }
 
         // Send canonical to every non-pruned member.
-        for (ident, packet_tx) in &members {
-            if pruned_members.contains(ident) {
+        for ctx in &members {
+            if pruned_members.contains(&ctx.ident) {
                 continue;
             }
-            if let Some(tx) = packet_tx {
+            if let Some(tx) = ctx.tx.as_ref() {
                 for bytes in &canonical_bytes {
                     let _ = tx.send(bytes.clone());
                 }
@@ -524,7 +591,11 @@ pub fn flush_ipv4(
                 group.counters.bytes_formatted += pruned_byte_total as u64;
                 group.counters.split_horizon_excluded += 1;
             }
-            if let Some((_, Some(tx))) = members.iter().find(|(i, _)| *i == prune_ident) {
+            if let Some(tx) = members
+                .iter()
+                .find(|c| c.ident == prune_ident)
+                .and_then(|c| c.tx.as_ref())
+            {
                 for bytes in &pruned_bytes {
                     let _ = tx.send(bytes.clone());
                 }
@@ -546,7 +617,17 @@ pub fn flush_ipv4(
 /// peer's `packet_tx`. Per-attr clustering preserves the wire-level
 /// efficiency the cache provided (one MP_REACH UPDATE per shared
 /// attr-set rather than one per NLRI).
-pub(super) fn send_ipv4_direct(peer: &Peer, entries: Vec<(Arc<BgpAttr>, Ipv4Nlri)>) {
+///
+/// `extended_next_hop_v6` is the IPv6 next-hop to emit in MP_REACH
+/// for RFC 8950 IPv4-over-IPv6; `None` keeps the legacy
+/// `pop_ipv4` / inline-NLRI emit. Callers compute this from the
+/// peer's negotiated ENHE state and its egress interface's
+/// link-local.
+pub(super) fn send_ipv4_direct(
+    peer: &Peer,
+    entries: Vec<(Arc<BgpAttr>, Ipv4Nlri)>,
+    extended_next_hop_v6: Option<Ipv6Addr>,
+) {
     if entries.is_empty() {
         return;
     }
@@ -560,7 +641,7 @@ pub(super) fn send_ipv4_direct(peer: &Peer, entries: Vec<(Arc<BgpAttr>, Ipv4Nlri
         bgp_packet::BGP_PACKET_LEN
     };
     for (attr, nlris) in buckets {
-        let bytes_list = encode_ipv4_update(&attr, &nlris, max_packet_size, None);
+        let bytes_list = encode_ipv4_update(&attr, &nlris, max_packet_size, extended_next_hop_v6);
         for buf in bytes_list {
             peer.send_packet(buf);
         }


### PR DESCRIPTION
## Summary

- `flush_ipv4` branches on `UpdateGroupSig::extended_next_hop`. For ENHE update-groups it encodes per-member with that member's egress link-local — canonical-bytes sharing would otherwise force every member onto the same v6 next-hop and break ENHE for everyone but one peer.
- `send_ipv4_direct` grows an `Option<Ipv6Addr>` parameter so the route-sync and soft-out paths emit MP_REACH for ENHE peers too. Both callers compute it from `peer.is_enhe_v4_negotiated() && peer.next_hop_v6(addrs)`.
- `Peer::is_enhe_v4_negotiated()` is the per-peer gate (mirrors `enhe_negotiated_for` from update-groups so encoder and accounting agree). `Peer::next_hop_v6` now takes `&InterfaceAddrs` directly — no longer needs `&Bgp`.
- `BgpTop` carries `&InterfaceAddrs` so the per-peer send paths can resolve the v6 next-hop without juggling borrows.
- Non-ENHE peers are byte-for-byte unchanged. Fourth and final wiring PR in the RFC 8950 IPv4-over-IPv6 series (#653, #654, #655); receive-side FIB install for v6-next-hop IPv4 routes is a separate follow-up.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` — bgp-packet 74, main 498, all green
- [ ] End-to-end veth + FRR validation is deferred (see TODO; needs cross-vendor BDD scaffolding)

Generated with [Claude Code](https://claude.com/claude-code)