### PR TITLE
bgp: next-hop-self rewrite for ENHE-sourced routes on outbound

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2726,7 +2726,18 @@ pub fn route_update_ipv4(
     }
 
     // 3. NEXT_HOP
-    if peer.is_ebgp() || rib.is_originated() {
+    //
+    // eBGP and self-originated routes always get a v4 rewrite. ENHE-
+    // sourced routes (`egress_ifindex_v6.is_some()`) join that set
+    // unconditionally: the inbound NEXT_HOP for such a route is
+    // 0.0.0.0 (RFC 8950 §4) — preserving it for iBGP-iBGP, the way
+    // RFC 4271 normally prescribes, would forward a black-hole. The
+    // rewrite is harmless for ENHE-aware peers (they ignore the v4
+    // NEXT_HOP attribute and read the LL from MP_REACH per RFC 8950
+    // §4) and necessary for non-ENHE peers (they're the ones who
+    // can't decode an MP_REACH with a v6 next-hop in the first place).
+    let needs_v4_rewrite = peer.is_ebgp() || rib.is_originated() || rib.egress_ifindex_v6.is_some();
+    if needs_v4_rewrite {
         let nexthop = if let Some(ref local_addr) = peer.param.local_addr
             && let IpAddr::V4(local_addr) = local_addr.ip()
         {


### PR DESCRIPTION
## Summary

Closes the mixed-mesh black-hole left over from the RFC 8950 BGP-unnumbered series. When we receive a route via MP_REACH(AFI=1) with an IPv6 next-hop, the v4 NEXT_HOP attribute is 0.0.0.0 by convention (RFC 8950 §4: sender SHOULD set it that way, receivers MUST ignore it for forwarding). Loc-RIB stores that 0.0.0.0 verbatim — and the legacy `pop_ipv4` encode path forwards it to non-ENHE peers, who'd see a route via 0.0.0.0 (black hole).

The fix is a one-condition extension to the existing eBGP / originated NEXT_HOP rewrite in `route_update_ipv4`: also fire when `rib.egress_ifindex_v6.is_some()`. For non-ENHE peers, the recipient now sees a valid v4 NEXT_HOP pointing at our local v4 address (peer.param.local_addr, fallback to bgp.router_id). For ENHE peers, the v4 NEXT_HOP attribute is ignored per RFC 8950 §4 — the rewrite is cosmetic.

Closes gap #1 from `memory/zebra-rs-rfc8950-wire-format-todo.md`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` — 522 main tests pass
- [ ] Direct unit test for `route_update_ipv4` deferred (would need a `&mut Peer` + `&mut BgpTop` fixture; the function has no existing tests at that boundary). The condition extension is mechanical and the comment in the diff documents why each combination is correct.

Generated with [Claude Code](https://claude.com/claude-code)