### PR TITLE
bgp: introduce per-VRF BgpVrf task type and lifecycle

### DIFF
--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -16,6 +16,7 @@ pub mod peer_map;
 pub mod show;
 pub mod show_update_group;
 pub mod update_group;
+pub mod vrf;
 pub mod vrf_config;
 
 pub mod cap;

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -1,0 +1,260 @@
+//! Per-VRF BGP task — owns the runtime state for one
+//! `router bgp vrf X` block.
+//!
+//! Mirrors the global [`crate::bgp::Bgp`] structure on a smaller
+//! surface: a [`PeerMap`] for CE peers (populated in step 15),
+//! a per-VRF [`LocalRib`] for the IPv4/IPv6 unicast Loc-RIB
+//! (populated by best-path / import in step 17 / 18), and the
+//! identity (`name`, `rd`, `router_id`) the global task supplies
+//! at spawn time.
+//!
+//! Step 13 ships the type and the lifecycle (`event_loop`,
+//! `serve_vrf`, `Shutdown` handling). Everything else lands in the
+//! steps named in [`crate::bgp::vrf`].
+//!
+//! Most of this module is `dead_code` from rustc's point of view
+//! until step 14 wires `spawn_bgp_vrf` — the test module
+//! constructs `BgpVrf` and runs `event_loop`, but those calls only
+//! happen under `#[cfg(test)]`, so the non-test build sees zero
+//! production consumers. The blanket allow goes away the moment
+//! the spawn site lands.
+#![allow(dead_code)]
+
+use std::net::Ipv4Addr;
+
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+
+use bgp_packet::RouteDistinguisher;
+
+use crate::config::{ConfigChannel, ShowChannel};
+use crate::context::{ProtoContext, Task};
+
+use super::super::peer_map::PeerMap;
+use super::super::route::LocalRib;
+use super::msg::{BgpGlobalMsg, BgpVrfMsg};
+
+/// Per-VRF BGP runtime. One task per `router bgp vrf X` block.
+pub struct BgpVrf {
+    /// VRF name (matches the YANG list key under
+    /// `/router/bgp/vrf/<name>`). Used in log lines, `show bgp vrf
+    /// <name> ...` dispatch, and as the `BgpGlobalMsg::Export` /
+    /// `RegisterPeer` payload so the global task can attribute
+    /// cross-task messages back to a VRF.
+    pub name: String,
+    /// Spawn-time runtime context built by step 14 via
+    /// [`ProtoContext::for_vrf`]. Every socket the per-VRF runtime
+    /// opens flows through `ctx.tcp_socket_v*` / `ctx.tcp_listen`
+    /// and therefore inherits the `SO_BINDTODEVICE` binding step 8
+    /// installed.
+    pub ctx: ProtoContext,
+    /// Per-VRF peer table — CE peers configured under
+    /// `/router/bgp/vrf/<name>/neighbor/...`. Populated in step 15.
+    pub peers: PeerMap,
+    /// IPv4/IPv6 unicast Loc-RIB scoped to this VRF. VPNv4/v6 /
+    /// EVPN stay anchored on the global Loc-RIB; the per-VRF Loc-
+    /// RIB holds only the CE-facing surface plus routes imported
+    /// from the global Loc-RIB via [`BgpVrfMsg::ImportV4`] /
+    /// [`BgpVrfMsg::ImportV6`] (step 18).
+    pub local_rib: LocalRib,
+    /// Route Distinguisher prepended to VPNv4/v6 advertisements
+    /// originated from this VRF. `None` until the operator has
+    /// committed `set router bgp vrf <name> rd <RD>`; export to
+    /// the global Loc-RIB (step 17) is gated on `rd.is_some()`.
+    pub rd: Option<RouteDistinguisher>,
+    /// Per-VRF BGP router-id. Defaults to the global router-id at
+    /// spawn time (passed through by step 14); the operator may
+    /// override via `set router bgp vrf <name> router-id <addr>`,
+    /// in which case step 14 respawns the VRF with the new value.
+    pub router_id: Ipv4Addr,
+    /// Config-manager subscription. Path-dispatch by step 14
+    /// routes `/router/bgp/vrf/<name>/...` callbacks here so the
+    /// per-VRF runtime owns its own commit sequencing.
+    pub cm: ConfigChannel,
+    /// Show-command subscription. Step 20 wires `show bgp vrf
+    /// <name> ...` to dispatch through this channel.
+    pub show: ShowChannel,
+    /// Outbound channel to the global `Bgp` task. Used for peer
+    /// registration (step 16) and per-VRF best-path exports
+    /// (step 17 / 18).
+    pub global_tx: UnboundedSender<BgpGlobalMsg>,
+    /// Inbound channel from the global `Bgp` task. The accept
+    /// dispatcher (step 16) and the import pipeline (step 18) push
+    /// here. `Shutdown` from `despawn_bgp_vrf` (step 14) also
+    /// arrives on this channel.
+    pub global_rx: UnboundedReceiver<BgpVrfMsg>,
+}
+
+/// Sender side of the per-VRF inbound channel — handed back to
+/// the global task at spawn time so `despawn_bgp_vrf` can send
+/// `BgpVrfMsg::Shutdown`, and so the accept / import dispatchers
+/// (step 16 / 18) can locate the matching VRF's queue.
+pub type BgpVrfInbox = UnboundedSender<BgpVrfMsg>;
+
+impl BgpVrf {
+    /// Build a `BgpVrf` and the matching inbound sender. The
+    /// caller (step 14's `spawn_bgp_vrf`) keeps the
+    /// `BgpVrfInbox`, hands the `BgpVrf` to [`serve_vrf`], and
+    /// stashes the inbox in a per-VRF registry so cross-task
+    /// messages can locate this task.
+    pub fn new(
+        name: String,
+        ctx: ProtoContext,
+        rd: Option<RouteDistinguisher>,
+        router_id: Ipv4Addr,
+        global_tx: UnboundedSender<BgpGlobalMsg>,
+    ) -> (Self, BgpVrfInbox) {
+        let (inbox_tx, global_rx) = mpsc::unbounded_channel();
+        let vrf = Self {
+            name,
+            ctx,
+            peers: PeerMap::new(),
+            local_rib: LocalRib::default(),
+            rd,
+            router_id,
+            cm: ConfigChannel::new(),
+            show: ShowChannel::new(),
+            global_tx,
+            global_rx,
+        };
+        (vrf, inbox_tx)
+    }
+
+    /// Drive the per-VRF task. The loop exits cleanly when the
+    /// global task sends [`BgpVrfMsg::Shutdown`] or when the
+    /// inbound channel is closed (i.e. every sender — the global
+    /// task plus any per-peer holds — has dropped).
+    pub async fn event_loop(&mut self) {
+        loop {
+            tokio::select! {
+                msg = self.global_rx.recv() => {
+                    match msg {
+                        Some(BgpVrfMsg::Shutdown) => {
+                            tracing::info!(vrf = %self.name, "bgp vrf: shutdown");
+                            break;
+                        }
+                        Some(other) => self.process_global_msg(other),
+                        None => {
+                            // All senders dropped — the global task
+                            // exited without sending Shutdown.
+                            tracing::info!(
+                                vrf = %self.name,
+                                "bgp vrf: inbound channel closed; exiting",
+                            );
+                            break;
+                        }
+                    }
+                }
+                _msg = self.cm.rx.recv() => {
+                    // CM dispatch from /router/bgp/vrf/<name>/...
+                    // arrives in step 14 once `spawn_bgp_vrf`
+                    // registers the path handler. Step 13 drops it
+                    // on the floor — no consumer has been wired
+                    // yet, and the channel staying drained keeps
+                    // the select! arm from livelocking.
+                }
+                _msg = self.show.rx.recv() => {
+                    // `show bgp vrf <name> ...` dispatch lands in
+                    // step 20. Same drain rationale as above.
+                }
+            }
+        }
+    }
+
+    /// Per-task handling of cross-task messages that aren't
+    /// `Shutdown`. Step 13 is intentionally a no-op match — every
+    /// non-`Shutdown` variant is a stub for later steps.
+    fn process_global_msg(&mut self, msg: BgpVrfMsg) {
+        match msg {
+            BgpVrfMsg::Accept(_, _) => {
+                // Step 16 wires this to per-VRF passive-accept.
+                tracing::debug!(
+                    vrf = %self.name,
+                    "bgp vrf: ignored Accept (step 16 wires the handler)",
+                );
+            }
+            BgpVrfMsg::ImportV4 { .. } | BgpVrfMsg::ImportV6 { .. } => {
+                // Step 18 wires the import insert + best-path.
+            }
+            BgpVrfMsg::WithdrawImport { .. } => {
+                // Step 18.
+            }
+            BgpVrfMsg::Shutdown => unreachable!("handled in event_loop"),
+        }
+    }
+}
+
+/// Spawn the per-VRF event loop on its own tokio task. Mirrors
+/// [`crate::bgp::inst::serve`] / [`crate::nd::inst::serve`].
+pub fn serve_vrf(mut vrf: BgpVrf) -> Task<()> {
+    Task::spawn(async move {
+        vrf.event_loop().await;
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::sync::mpsc::unbounded_channel;
+
+    use crate::rib::client::{ProtoId, RibClient, RibInbound};
+
+    use super::*;
+
+    fn test_ctx_for_vrf(table_id: u32, ifname: &str) -> ProtoContext {
+        // Parked RibClient — the test doesn't exercise rib.send().
+        let (inbound_tx, inbound_rx) = unbounded_channel::<RibInbound>();
+        Box::leak(Box::new(inbound_rx));
+        let rib = RibClient::new(inbound_tx, ProtoId::from_raw(0));
+        ProtoContext::for_vrf(rib, table_id, ifname.to_string())
+    }
+
+    #[tokio::test]
+    async fn shutdown_message_exits_event_loop_within_timeout() {
+        // Step 13's lifecycle invariant: `Shutdown` on the inbound
+        // channel makes `event_loop` return — without that
+        // contract, `despawn_bgp_vrf` (step 14) wouldn't be able
+        // to tear a VRF task down cleanly.
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = test_ctx_for_vrf(10, "vrf-test");
+        let (mut vrf, inbox) = BgpVrf::new(
+            "vrf-test".to_string(),
+            ctx,
+            None,
+            Ipv4Addr::UNSPECIFIED,
+            global_tx,
+        );
+
+        inbox.send(BgpVrfMsg::Shutdown).expect("inbound rx alive");
+
+        // Two-second timeout: the loop should exit on the very
+        // next `recv` call; a slow exit would indicate a deadlock
+        // on the inbound channel.
+        tokio::time::timeout(Duration::from_secs(2), vrf.event_loop())
+            .await
+            .expect("event_loop returns after Shutdown");
+    }
+
+    #[tokio::test]
+    async fn inbox_drop_closes_event_loop() {
+        // If every sender to the inbound channel is dropped, the
+        // VRF task exits anyway — defensive cleanup so a buggy
+        // step-14 caller that forgets to send `Shutdown` still
+        // doesn't leak the task.
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = test_ctx_for_vrf(11, "vrf-test2");
+        let (mut vrf, inbox) = BgpVrf::new(
+            "vrf-test2".to_string(),
+            ctx,
+            None,
+            Ipv4Addr::UNSPECIFIED,
+            global_tx,
+        );
+
+        drop(inbox);
+
+        tokio::time::timeout(Duration::from_secs(2), vrf.event_loop())
+            .await
+            .expect("event_loop exits when inbox is dropped");
+    }
+}

--- a/zebra-rs/src/bgp/vrf/mod.rs
+++ b/zebra-rs/src/bgp/vrf/mod.rs
@@ -1,0 +1,28 @@
+//! Per-VRF BGP runtime (step 13 of the BGP MPLS/VPN refactor).
+//!
+//! Sibling of the global [`crate::bgp::Bgp`] runtime: one
+//! [`BgpVrf`] task per `router bgp vrf X` block. Step 13 lays down
+//! the task shape and lifecycle — message enums, the event loop,
+//! channels to the global task — without wiring peers or the
+//! import/export pipeline. Subsequent steps fill those in:
+//!
+//! * step 14 — `spawn_bgp_vrf` / `despawn_bgp_vrf` from the
+//!   commit-time diff against [`crate::bgp::Bgp::vrfs`].
+//! * step 15 — per-VRF peer configure + active connect via
+//!   `ProtoContext::for_vrf` (the per-VRF socket binding gets
+//!   exercised end-to-end here).
+//! * step 16 — passive accept dispatch from the global task to the
+//!   matching VRF via `BgpVrfMsg::Accept`.
+//! * step 17 / 18 — export to / import from the global VPNv4
+//!   Loc-RIB across the `BgpGlobalMsg` / `BgpVrfMsg` channels.
+
+pub mod inst;
+pub mod msg;
+
+// Step-14 consumers (`spawn_bgp_vrf` / `despawn_bgp_vrf`) will
+// reach for these names. The `unused_imports` allow is removed
+// at that point.
+#[allow(unused_imports)]
+pub use inst::{BgpVrf, serve_vrf};
+#[allow(unused_imports)]
+pub use msg::{BgpGlobalMsg, BgpVrfMsg};

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -1,0 +1,107 @@
+//! Message types crossing the boundary between the global
+//! `Bgp` task and a per-VRF [`BgpVrf`] task.
+//!
+//! - [`BgpVrfMsg`] travels global → VRF. It carries handoffs from
+//!   the global passive-accept dispatcher (step 16), VPNv4/v6
+//!   import deliveries from the global Loc-RIB (step 18), and the
+//!   `Shutdown` signal that ends the VRF task's event loop.
+//! - [`BgpGlobalMsg`] travels VRF → global. It carries the
+//!   inverse: best-path exports the global task should re-emit as
+//!   VPNv4/v6 (step 17), peer registration so the global accept
+//!   dispatcher knows which VRF to forward a given source IP to
+//!   (step 16), and the matching withdraw/unregister events.
+//!
+//! Step 13 lands the enums with `Shutdown` / `Accept` populated;
+//! every other variant is a stub waiting on its consumer. Adding
+//! the variants now keeps the channel typing stable across later
+//! steps — adding a variant to a public enum that other modules
+//! `match` exhaustively is the only kind of change that would
+//! force a wide refactor at step 16/17/18.
+//!
+//! The module-level allow goes away when step 14 wires the
+//! cross-task channel ends to real producers / consumers.
+#![allow(dead_code)]
+
+use std::net::SocketAddr;
+
+use tokio::net::TcpStream;
+
+use bgp_packet::RouteDistinguisher;
+
+/// Message from the global `Bgp` task to a per-VRF [`BgpVrf`]
+/// task. The receiver lives on `BgpVrf::global_rx`.
+#[derive(Debug)]
+pub enum BgpVrfMsg {
+    /// Inbound TCP connection accepted on `:179` whose source IP
+    /// matches a peer configured in this VRF. The stream is handed
+    /// off to the per-VRF runtime, which continues the FSM on its
+    /// own task. Populated by step 16's accept dispatcher; the
+    /// step-13 event loop just drops the connection.
+    #[allow(dead_code)]
+    Accept(TcpStream, SocketAddr),
+
+    /// VPNv4 best-path import. The global Loc-RIB resolved a route
+    /// whose RT list intersects this VRF's import-RT set; the per-
+    /// VRF task inserts it into its IPv4 unicast Loc-RIB and runs
+    /// best-path. Payload shape lands with step 18.
+    #[allow(dead_code)]
+    ImportV4 {
+        rd: RouteDistinguisher,
+        // step 18 fills the remaining fields: prefix, BgpAttr id,
+        // label, peer ident, etc.
+    },
+
+    /// VPNv6 best-path import. Symmetric to [`Self::ImportV4`].
+    #[allow(dead_code)]
+    ImportV6 {
+        rd: RouteDistinguisher,
+        // step 18 fills the remaining fields.
+    },
+
+    /// Withdraw a previously-imported route. RD identifies the
+    /// origin row; the per-VRF task locates the matching imported
+    /// path and runs best-path withdraw.
+    #[allow(dead_code)]
+    WithdrawImport { rd: RouteDistinguisher },
+
+    /// Tear the VRF task down cleanly. The event loop exits on the
+    /// next select iteration after receiving this. Used by step
+    /// 14's `despawn_bgp_vrf` and during daemon shutdown.
+    Shutdown,
+}
+
+/// Message from a per-VRF [`BgpVrf`] task to the global `Bgp`
+/// task. The receiver lives on the global task; each VRF holds an
+/// `UnboundedSender<BgpGlobalMsg>` in `BgpVrf::global_tx`.
+#[derive(Debug)]
+pub enum BgpGlobalMsg {
+    /// A best-path winner inside this VRF that the global task
+    /// should re-emit as VPNv4/v6 (step 17). Carries the VRF name
+    /// so the global task can look up the RD/RT policy when
+    /// re-encoding the NLRI.
+    #[allow(dead_code)]
+    Export {
+        vrf: String,
+        // step 17 fills prefix, BgpAttr id, label, etc.
+    },
+
+    /// Inverse of [`Self::Export`]. Tells the global task to
+    /// withdraw the corresponding VPNv4/v6 advertisement.
+    #[allow(dead_code)]
+    WithdrawExport {
+        vrf: String,
+        // step 17 fills the prefix identifier.
+    },
+
+    /// Register a peer IP with the global accept dispatcher so an
+    /// inbound `:179` connect from that IP is handed to this VRF
+    /// via [`BgpVrfMsg::Accept`]. Emitted by step 15 / 16 when a
+    /// passive peer is configured in this VRF.
+    #[allow(dead_code)]
+    RegisterPeer { vrf: String, addr: std::net::IpAddr },
+
+    /// Inverse of [`Self::RegisterPeer`]. The global dispatcher
+    /// stops routing inbound connects from this IP to the VRF.
+    #[allow(dead_code)]
+    UnregisterPeer { vrf: String, addr: std::net::IpAddr },
+}


### PR DESCRIPTION
## Summary

Step 13 of the BGP MPLS/VPN refactor. One tokio task per
`router bgp vrf X`, with its own event loop, channels to the
global Bgp task, and a `Shutdown` signal. No peers / CM / import
yet — step 14 spawns; steps 15-18 fill in the rest.

- `bgp::vrf::msg`:
  - `BgpVrfMsg` (global → VRF): `Accept(TcpStream, SocketAddr)`,
    `ImportV4 { rd }`, `ImportV6 { rd }`, `WithdrawImport { rd }`,
    `Shutdown`.
  - `BgpGlobalMsg` (VRF → global): `Export`, `WithdrawExport`,
    `RegisterPeer`, `UnregisterPeer`.
  Every non-`Shutdown` variant is a stub for steps 16-18 — putting
  them in now keeps every cross-task `match` site stable.
- `bgp::vrf::inst`:
  - `BgpVrf` struct: `name`, `ctx` (via `ProtoContext::for_vrf`),
    `peers` (`PeerMap`), `local_rib` (`LocalRib`), `rd`,
    `router_id`, `cm`, `show`, `global_tx`, `global_rx`.
  - `BgpVrf::new(...) -> (Self, BgpVrfInbox)` — returns the
    inbound sender so the spawner can stash it for cross-task
    dispatch.
  - `event_loop`: drains the inbound channel; exits cleanly on
    `Shutdown` or when every inbound sender has dropped.
  - `serve_vrf(BgpVrf) -> Task<()>`.
- Two integration tests covering both exit paths (Shutdown signal,
  inbound-channel-closed).

Module-level `#![allow(dead_code)]` on `vrf::inst` and `vrf::msg`
goes away when step 14 wires production consumers.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` (524 unit tests pass;
      +2 new BgpVrf tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)