### PR TITLE
bgp: wire originated, redist, soft-in paths to FIB install

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1774,6 +1774,13 @@ fn route_soft_in_peer_table(
                     new_rib.weight = decision.weight;
                     let (_, selected, next_id) = bgp.local_rib.update(rd, prefix, new_rib.clone());
 
+                    // Policy-in change may have shifted the best path
+                    // for this prefix; reconcile the FIB so the kernel
+                    // tracks whatever Loc-RIB now considers best.
+                    if rd.is_none() {
+                        fib_install_v4(bgp.rib_client, prefix, &selected);
+                    }
+
                     if !selected.is_empty() {
                         route_advertise_to_peers(rd, prefix, &selected, peer_idx, bgp, peers);
                     }
@@ -3608,6 +3615,14 @@ impl Bgp {
         let (_replaced, selected, next_id) = self.local_rib.update(None, prefix, rib.clone());
         rib.local_id = next_id;
 
+        // An originated route lacks a v4 NEXT_HOP attribute, so when
+        // it wins best by weight=32768 `fib_install_v4` will emit an
+        // `Ipv4Del` for any BGP-typed FIB entry that a peer route
+        // previously installed for the same prefix. That's correct:
+        // the underlying source (Static / Connected / IGP) owns the
+        // forwarding entry now, and BGP shouldn't shadow it.
+        fib_install_v4(&self.ctx.rib, prefix, &selected);
+
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
             local_rib: &mut self.local_rib,
@@ -3646,6 +3661,11 @@ impl Bgp {
         };
 
         let selected = bgp_ref.local_rib.select_best_path(prefix);
+        // When the originated route disappears, a peer route may now
+        // be the best (or no path may remain). Reconcile so the FIB
+        // matches Loc-RIB.
+        fib_install_v4(bgp_ref.rib_client, prefix, &selected);
+
         if !selected.is_empty() || !removed.is_empty() {
             route_advertise_to_peers(
                 None,
@@ -3714,6 +3734,12 @@ impl Bgp {
         let (_replaced, selected, next_id) = self.local_rib.update(None, prefix, rib.clone());
         rib.local_id = next_id;
 
+        // Same logic as `route_add`: the redistributed BGP route has
+        // no v4 NEXT_HOP, so winning best causes BGP to withdraw any
+        // peer-installed FIB entry for this prefix and let the source
+        // protocol's own RIB entry handle forwarding.
+        fib_install_v4(&self.ctx.rib, prefix, &selected);
+
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
             local_rib: &mut self.local_rib,
@@ -3752,6 +3778,10 @@ impl Bgp {
         };
 
         let selected = bgp_ref.local_rib.select_best_path(prefix);
+        // A peer route may now be best again (or nothing's left);
+        // reconcile the FIB.
+        fib_install_v4(bgp_ref.rib_client, prefix, &selected);
+
         if !selected.is_empty() || !removed.is_empty() {
             route_advertise_to_peers(
                 None,


### PR DESCRIPTION
## Summary

PR #660 wired `fib_install_v4` into the receive-side steady state (`route_ipv4_update` / `route_ipv4_withdraw`) but left the other Loc-RIB write paths unwired. Plug them in:

- `route_add` / `route_del` — operator-typed `network <prefix>` originated routes.
- `route_redist_inject` / `route_redist_withdraw` — redistribute from other protocols (Connected / Static / OSPF / IS-IS / Kernel).
- `route_soft_in_peer` permit branch — policy-in change replays AdjRibIn through new rules; best path may shift.

Soft-in's deny branch already piggybacked on `route_ipv4_withdraw`'s hook.

### Subtle correctness note (covered in commit message + inline comments)

Originated/redist BgpRibs have no v4 NEXT_HOP attribute. `make_bgp_rib_entry_v4` returns `None` for them and `fib_install_v4` fires `Ipv4Del`. That's the right behavior — when an originated route wins best by weight=32768, BGP should withdraw any Bgp-typed FIB entry that a peer route previously installed and let the source protocol (Connected / Static / IGP) own forwarding. On withdraw the peer route may win again, and reconcile fires `Ipv4Add`.

Closes gap #1 from `memory/zebra-rs-rfc8950-wire-format-todo.md`.

## Test plan

- [x] `cargo fmt --all -- --check` (run separately this time, not piped — last PR had to fix-up after a shell-pipe exit-code mask)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` — 717 tests pass workspace-wide

Generated with [Claude Code](https://claude.com/claude-code)