### PR TITLE
bgp: emit 32-octet dual nexthop in RFC 8950 MP_REACH

### DIFF
--- a/crates/bgp-packet/src/update.rs
+++ b/crates/bgp-packet/src/update.rs
@@ -12,6 +12,23 @@ use crate::{
     parse_bgp_nlri_ipv4, parse_bgp_update_attribute,
 };
 
+/// IPv6 next-hop that an RFC 8950 IPv4-over-IPv6 advertisement carries
+/// in `MP_REACH_NLRI`. Pure-unnumbered links have no global half and
+/// emit the 16-octet `LinkLocal` form; speakers with both a global
+/// v6 and a link-local on the egress interface emit the 32-octet
+/// `Dual` form, which receivers prefer for next-hop resolution.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Ipv4MpReachNextHop {
+    /// 16-octet form — link-local only.
+    LinkLocal(Ipv6Addr),
+    /// 32-octet form — global address followed by link-local, per
+    /// RFC 8950 §3.
+    Dual {
+        global: Ipv6Addr,
+        link_local: Ipv6Addr,
+    },
+}
+
 #[derive(NomBE)]
 pub struct UpdatePacket {
     pub header: BgpHeader,
@@ -126,18 +143,23 @@ impl UpdatePacket {
     /// packet until adding another would exceed `max_packet_size`,
     /// push the spilled NLRI back, return the encoded packet.
     ///
+    /// `next_hop` controls whether the 16-octet (`LinkLocal`-only) or
+    /// 32-octet (global || link-local) form is emitted; both are
+    /// RFC 8950 §3 compliant and the receiver accepts either.
+    ///
     /// The MP_REACH attribute is emitted with the extended-length
     /// (2-octet length) form unconditionally — once a single /24 is
-    /// added alongside the 21-octet MP_REACH preamble the value
-    /// already crowds the 255-byte budget; pagination almost always
-    /// produces values that need 2-octet lengths.
+    /// added alongside the 21-octet (or 37-octet for dual) MP_REACH
+    /// preamble the value already crowds the 255-byte budget;
+    /// pagination almost always produces values that need 2-octet
+    /// lengths.
     ///
     /// `bgp_attr`, if set, is emitted verbatim (including any v4
     /// NEXT_HOP attribute). RFC 8950 §4 says the receiver MUST ignore
     /// NEXT_HOP when MP_REACH carries an IPv6 next-hop, so passing
     /// the attribute through is harmless and matches what FRR /
     /// IOS-XR emit.
-    pub fn pop_ipv4_mp_reach(&mut self, next_hop: Ipv6Addr) -> Option<BytesMut> {
+    pub fn pop_ipv4_mp_reach(&mut self, next_hop: Ipv4MpReachNextHop) -> Option<BytesMut> {
         if self.ipv4_update.is_empty() {
             return None;
         }
@@ -169,8 +191,21 @@ impl UpdatePacket {
         let mp_value_start = buf.len();
         buf.put_u16(u16::from(Afi::Ip));
         buf.put_u8(u8::from(Safi::Unicast));
-        buf.put_u8(16);
-        buf.put(&next_hop.octets()[..]);
+        match next_hop {
+            Ipv4MpReachNextHop::LinkLocal(ll) => {
+                buf.put_u8(16);
+                buf.put(&ll.octets()[..]);
+            }
+            Ipv4MpReachNextHop::Dual { global, link_local } => {
+                // RFC 8950 §3: 32-octet form carries global || LL in
+                // that order. Receivers prefer the global for next-hop
+                // resolution and use the LL when both peers agree the
+                // route is on-link.
+                buf.put_u8(32);
+                buf.put(&global.octets()[..]);
+                buf.put(&link_local.octets()[..]);
+            }
+        }
         buf.put_u8(0);
 
         // Per-NLRI emit, breaking out when the next prefix wouldn't
@@ -472,7 +507,7 @@ mod tests {
     /// `UpdatePacket::parse_packet`, then assert the recovered
     /// MP_REACH carries the next-hop and prefixes we put in.
     fn encode_and_parse(
-        next_hop: Ipv6Addr,
+        next_hop: Ipv4MpReachNextHop,
         nlris: &[Ipv4Nlri],
         max: usize,
     ) -> (UpdatePacket, Vec<BytesMut>) {
@@ -494,17 +529,25 @@ mod tests {
     #[test]
     fn returns_none_with_no_nlris() {
         let mut update = UpdatePacket::new();
-        let nh: Ipv6Addr = "fe80::1".parse().unwrap();
-        assert!(update.pop_ipv4_mp_reach(nh).is_none());
+        let ll: Ipv6Addr = "fe80::1".parse().unwrap();
+        assert!(
+            update
+                .pop_ipv4_mp_reach(Ipv4MpReachNextHop::LinkLocal(ll))
+                .is_none()
+        );
     }
 
     #[test]
     fn single_prefix_round_trips_through_decoder() {
-        let nh: Ipv6Addr = "fe80::1".parse().unwrap();
-        let (parsed, _) = encode_and_parse(nh, &[nlri("10.0.0.0/24")], BGP_PACKET_LEN);
+        let ll: Ipv6Addr = "fe80::1".parse().unwrap();
+        let (parsed, _) = encode_and_parse(
+            Ipv4MpReachNextHop::LinkLocal(ll),
+            &[nlri("10.0.0.0/24")],
+            BGP_PACKET_LEN,
+        );
         match parsed.mp_update {
             Some(MpReachAttr::Ipv4 { nhop, updates, .. }) => {
-                assert_eq!(nhop, IpAddr::V6(nh));
+                assert_eq!(nhop, IpAddr::V6(ll));
                 assert_eq!(updates.len(), 1);
                 assert_eq!(updates[0].prefix.to_string(), "10.0.0.0/24");
             }
@@ -512,15 +555,40 @@ mod tests {
         }
     }
 
+    /// 32-octet form carries `global || link-local`. The decoder
+    /// surfaces the global half, matching the RFC 8950 §3 receiver
+    /// recommendation and the convention FRR / IOS-XR follow.
+    #[test]
+    fn dual_nexthop_round_trips_global_half_to_decoder() {
+        let global: Ipv6Addr = "2001:db8::1".parse().unwrap();
+        let ll: Ipv6Addr = "fe80::abcd".parse().unwrap();
+        let (parsed, _) = encode_and_parse(
+            Ipv4MpReachNextHop::Dual {
+                global,
+                link_local: ll,
+            },
+            &[nlri("10.0.0.0/24")],
+            BGP_PACKET_LEN,
+        );
+        match parsed.mp_update {
+            Some(MpReachAttr::Ipv4 { nhop, updates, .. }) => {
+                assert_eq!(nhop, IpAddr::V6(global));
+                assert_eq!(updates.len(), 1);
+            }
+            other => panic!("expected MpReachAttr::Ipv4, got {other:?}"),
+        }
+    }
+
     #[test]
     fn many_prefixes_round_trip_into_one_packet() {
-        let nh: Ipv6Addr = "fe80::abcd".parse().unwrap();
+        let ll: Ipv6Addr = "fe80::abcd".parse().unwrap();
         let prefixes: Vec<Ipv4Nlri> = (0..50).map(|i| nlri(&format!("10.{i}.0.0/24"))).collect();
-        let (parsed, packets) = encode_and_parse(nh, &prefixes, BGP_PACKET_LEN);
+        let (parsed, packets) =
+            encode_and_parse(Ipv4MpReachNextHop::LinkLocal(ll), &prefixes, BGP_PACKET_LEN);
         assert_eq!(packets.len(), 1, "50 /24 should comfortably fit one MTU");
         match parsed.mp_update {
             Some(MpReachAttr::Ipv4 { nhop, updates, .. }) => {
-                assert_eq!(nhop, IpAddr::V6(nh));
+                assert_eq!(nhop, IpAddr::V6(ll));
                 assert_eq!(updates.len(), 50);
             }
             other => panic!("expected MpReachAttr::Ipv4, got {other:?}"),
@@ -534,7 +602,7 @@ mod tests {
     /// pushed in.
     #[test]
     fn pagination_splits_across_packets() {
-        let nh: Ipv6Addr = "fe80::1".parse().unwrap();
+        let ll: Ipv6Addr = "fe80::1".parse().unwrap();
         // Build 20 distinct /24s; cap at 80 bytes so only one or two
         // NLRIs (~4 bytes each) fit alongside ~50 bytes of header +
         // attrs + MP_REACH preamble.
@@ -544,7 +612,7 @@ mod tests {
         update.ipv4_update = prefixes.clone();
 
         let mut packets = Vec::new();
-        while let Some(bytes) = update.pop_ipv4_mp_reach(nh) {
+        while let Some(bytes) = update.pop_ipv4_mp_reach(Ipv4MpReachNextHop::LinkLocal(ll)) {
             packets.push(bytes);
         }
         assert!(
@@ -576,10 +644,14 @@ mod tests {
     /// empty MP_REACH packet.
     #[test]
     fn returns_none_when_first_nlri_does_not_fit() {
-        let nh: Ipv6Addr = "fe80::1".parse().unwrap();
+        let ll: Ipv6Addr = "fe80::1".parse().unwrap();
         let mut update = UpdatePacket::with_max_packet_size(40);
         update.bgp_attr = Some(BgpAttr::new());
         update.ipv4_update = vec![nlri("10.0.0.0/24")];
-        assert!(update.pop_ipv4_mp_reach(nh).is_none());
+        assert!(
+            update
+                .pop_ipv4_mp_reach(Ipv4MpReachNextHop::LinkLocal(ll))
+                .is_none()
+        );
     }
 }

--- a/zebra-rs/src/bgp/interface_addrs.rs
+++ b/zebra-rs/src/bgp/interface_addrs.rs
@@ -1,13 +1,20 @@
-//! Per-interface IPv6 link-local registry used as the next-hop for
-//! RFC 8950 IPv4-over-IPv6 advertisements on interface-keyed peers.
+//! Per-interface IPv6 address registry used to source the next-hop
+//! for RFC 8950 IPv4-over-IPv6 advertisements on interface-keyed
+//! peers.
 //!
 //! The table is populated from `RibRx::AddrAdd` / `AddrDel` events
-//! (filtered to addresses in `fe80::/10`) and consulted at MP_REACH
-//! emit time by [`super::peer::Peer::next_hop_v6`]. Multiple link-local
-//! addresses on one interface are uncommon but legal; this module
-//! keeps every observed LL and exposes a deterministic chosen-LL via
-//! [`InterfaceAddrs::link_local_for`] so peers see stable next-hops
-//! across daemon restarts and reorderings.
+//! and consulted at MP_REACH emit time by
+//! [`super::peer::Peer::next_hop_v6`] (link-local half) and
+//! [`super::peer::Peer::next_hop_v6_global`] (global half). Both
+//! halves can coexist on the same interface — when both are present
+//! the encoder emits the 32-octet `global || link-local` form per
+//! RFC 8950 §3; otherwise the 16-octet link-local-only form, which
+//! is the only thing pure-unnumbered links can produce.
+//!
+//! Multiple addresses of the same kind on one interface are uncommon
+//! but legal; this module keeps every observed entry and exposes a
+//! deterministic chosen address (numerically smallest) per kind so
+//! peers see stable next-hops across daemon restarts and reorderings.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::Ipv6Addr;
@@ -16,10 +23,11 @@ use ipnet::IpNet;
 
 use crate::rib::link::LinkAddr;
 
-/// Per-ifindex set of IPv6 link-local addresses observed on the box.
+/// Per-ifindex IPv6 address registry, split by kind.
 #[derive(Debug, Default)]
 pub struct InterfaceAddrs {
-    by_ifindex: BTreeMap<u32, BTreeSet<Ipv6Addr>>,
+    link_local: BTreeMap<u32, BTreeSet<Ipv6Addr>>,
+    global: BTreeMap<u32, BTreeSet<Ipv6Addr>>,
 }
 
 impl InterfaceAddrs {
@@ -27,26 +35,32 @@ impl InterfaceAddrs {
         Self::default()
     }
 
-    /// Register an address with the table. Non-link-local entries
-    /// (IPv4, IPv6 global, ULA, loopback, multicast …) are ignored.
+    /// Register an address with the table. IPv4, loopback, and the
+    /// unspecified address are ignored; link-locals and globals
+    /// (including ULA) are routed to their respective bucket.
     pub fn record(&mut self, addr: &LinkAddr) {
-        let Some(ll) = link_local(addr) else {
-            return;
-        };
-        self.by_ifindex.entry(addr.ifindex).or_default().insert(ll);
+        match classify(addr) {
+            Some(V6Kind::LinkLocal(host)) => {
+                self.link_local
+                    .entry(addr.ifindex)
+                    .or_default()
+                    .insert(host);
+            }
+            Some(V6Kind::Global(host)) => {
+                self.global.entry(addr.ifindex).or_default().insert(host);
+            }
+            None => {}
+        }
     }
 
-    /// Forget an address. If this was the last LL on the ifindex, the
-    /// map entry is dropped so [`Self::link_local_for`] returns `None`.
+    /// Forget an address previously passed to [`Self::record`]. If the
+    /// removal empties the bucket for this ifindex, the map entry is
+    /// dropped so subsequent lookups return `None`.
     pub fn forget(&mut self, addr: &LinkAddr) {
-        let Some(ll) = link_local(addr) else {
-            return;
-        };
-        if let Some(set) = self.by_ifindex.get_mut(&addr.ifindex) {
-            set.remove(&ll);
-            if set.is_empty() {
-                self.by_ifindex.remove(&addr.ifindex);
-            }
+        match classify(addr) {
+            Some(V6Kind::LinkLocal(host)) => drop_from(&mut self.link_local, addr.ifindex, host),
+            Some(V6Kind::Global(host)) => drop_from(&mut self.global, addr.ifindex, host),
+            None => {}
         }
     }
 
@@ -55,22 +69,54 @@ impl InterfaceAddrs {
     /// across runs so a peer's advertised next-hop doesn't shift
     /// whenever a transient LL appears or disappears.
     pub fn link_local_for(&self, ifindex: u32) -> Option<Ipv6Addr> {
-        self.by_ifindex.get(&ifindex)?.first().copied()
+        self.link_local.get(&ifindex)?.first().copied()
+    }
+
+    /// Return the chosen global IPv6 for `ifindex`, or `None` if none
+    /// is registered. Used by the RFC 8950 32-octet dual-nexthop
+    /// emit path — pure-unnumbered links typically have no global v6,
+    /// in which case this returns `None` and the encoder falls back
+    /// to the 16-octet link-local-only form.
+    pub fn global_for(&self, ifindex: u32) -> Option<Ipv6Addr> {
+        self.global.get(&ifindex)?.first().copied()
     }
 }
 
-/// Extract an IPv6 link-local host address from a `LinkAddr`. Returns
-/// `None` for v4, for v6 prefixes whose host bits aren't in `fe80::/10`,
-/// and for the unspecified address.
-fn link_local(addr: &LinkAddr) -> Option<Ipv6Addr> {
+fn drop_from(map: &mut BTreeMap<u32, BTreeSet<Ipv6Addr>>, ifindex: u32, addr: Ipv6Addr) {
+    if let Some(set) = map.get_mut(&ifindex) {
+        set.remove(&addr);
+        if set.is_empty() {
+            map.remove(&ifindex);
+        }
+    }
+}
+
+enum V6Kind {
+    LinkLocal(Ipv6Addr),
+    Global(Ipv6Addr),
+}
+
+/// Decide how to route an IPv6 interface address into the registry.
+/// `None` means "ignore" — IPv4, loopback, unspecified. Everything
+/// else routes to either the link-local or global bucket.
+fn classify(addr: &LinkAddr) -> Option<V6Kind> {
     let IpNet::V6(net) = addr.addr else {
         return None;
     };
     let host = net.addr();
-    if host.is_unspecified() || !is_unicast_link_local(host) {
+    if host.is_unspecified() || host.is_loopback() {
         return None;
     }
-    Some(host)
+    if is_unicast_link_local(host) {
+        Some(V6Kind::LinkLocal(host))
+    } else {
+        // ULA, GUA, and anything else routable in some scope — the
+        // RFC 8950 32-octet form just calls it "global IPv6", so we
+        // don't discriminate further. Multicast / loopback /
+        // unspecified are filtered above; multicast in particular
+        // shouldn't appear as an interface address anyway.
+        Some(V6Kind::Global(host))
+    }
 }
 
 /// `Ipv6Addr::is_unicast_link_local` is unstable as of Rust 1.84;
@@ -118,21 +164,53 @@ mod tests {
     }
 
     #[test]
-    fn ignores_v4_and_non_link_local_v6() {
+    fn ignores_v4_and_loopback() {
         let mut t = InterfaceAddrs::new();
         t.record(&v4("10.0.0.1", 24, 7));
+        t.record(&v6("::1", 128, 7));
+        assert_eq!(t.link_local_for(7), None);
+        assert_eq!(t.global_for(7), None);
+    }
+
+    #[test]
+    fn global_v6_lands_in_global_bucket() {
+        let mut t = InterfaceAddrs::new();
         t.record(&v6("2001:db8::1", 64, 7));
-        t.record(&v6("fc00::1", 64, 7)); // ULA, not LL.
+        assert_eq!(t.global_for(7), Some("2001:db8::1".parse().unwrap()));
+        // Should not leak into the LL bucket.
         assert_eq!(t.link_local_for(7), None);
     }
 
     #[test]
-    fn deterministic_smallest_wins_with_multiple_lls() {
+    fn ula_v6_is_treated_as_global() {
+        // ULAs are not "Internet-global" but RFC 8950 §3's
+        // "global || link-local" form just means "non-LL"; operators
+        // running BGP on ULA addressing should get the 32-octet
+        // emit.
+        let mut t = InterfaceAddrs::new();
+        t.record(&v6("fc00::1", 64, 7));
+        assert_eq!(t.global_for(7), Some("fc00::1".parse().unwrap()));
+        assert_eq!(t.link_local_for(7), None);
+    }
+
+    #[test]
+    fn both_buckets_coexist_on_one_ifindex() {
+        let mut t = InterfaceAddrs::new();
+        t.record(&v6("fe80::1", 64, 7));
+        t.record(&v6("2001:db8::1", 64, 7));
+        assert_eq!(t.link_local_for(7), Some("fe80::1".parse().unwrap()));
+        assert_eq!(t.global_for(7), Some("2001:db8::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn deterministic_smallest_wins_per_bucket() {
         let mut t = InterfaceAddrs::new();
         t.record(&v6("fe80::2", 64, 7));
         t.record(&v6("fe80::1", 64, 7));
-        t.record(&v6("fe80::3", 64, 7));
+        t.record(&v6("2001:db8::2", 64, 7));
+        t.record(&v6("2001:db8::1", 64, 7));
         assert_eq!(t.link_local_for(7), Some("fe80::1".parse().unwrap()));
+        assert_eq!(t.global_for(7), Some("2001:db8::1".parse().unwrap()));
     }
 
     #[test]
@@ -142,6 +220,16 @@ mod tests {
         t.record(&v6("fe80::2", 64, 7));
         t.forget(&v6("fe80::1", 64, 7));
         assert_eq!(t.link_local_for(7), Some("fe80::2".parse().unwrap()));
+    }
+
+    #[test]
+    fn forgetting_one_bucket_does_not_disturb_the_other() {
+        let mut t = InterfaceAddrs::new();
+        t.record(&v6("fe80::1", 64, 7));
+        t.record(&v6("2001:db8::1", 64, 7));
+        t.forget(&v6("2001:db8::1", 64, 7));
+        assert_eq!(t.link_local_for(7), Some("fe80::1".parse().unwrap()));
+        assert_eq!(t.global_for(7), None);
     }
 
     #[test]
@@ -158,6 +246,8 @@ mod tests {
     fn forget_unknown_is_noop() {
         let mut t = InterfaceAddrs::new();
         t.forget(&v6("fe80::1", 64, 7));
+        t.forget(&v6("2001:db8::1", 64, 7));
         assert_eq!(t.link_local_for(7), None);
+        assert_eq!(t.global_for(7), None);
     }
 }

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -516,12 +516,13 @@ impl Peer {
         false
     }
 
-    /// IPv6 next-hop to advertise in MP_REACH for IPv4-unicast NLRI
-    /// once RFC 8950 Extended Next Hop is negotiated on this peer.
-    /// Returns `None` for any peer that isn't interface-keyed, or when
-    /// the egress interface's link-local hasn't been observed yet via
-    /// `RibRx::AddrAdd`. Callers should pair this with
-    /// [`Self::is_enhe_v4_negotiated`] before emitting.
+    /// IPv6 link-local next-hop to advertise in MP_REACH for
+    /// IPv4-unicast NLRI once RFC 8950 Extended Next Hop is
+    /// negotiated on this peer. Returns `None` for any peer that
+    /// isn't interface-keyed, or when the egress interface's
+    /// link-local hasn't been observed yet via `RibRx::AddrAdd`.
+    /// Callers should pair this with [`Self::is_enhe_v4_negotiated`]
+    /// before emitting.
     pub fn next_hop_v6(
         &self,
         addrs: &super::interface_addrs::InterfaceAddrs,
@@ -530,6 +531,22 @@ impl Peer {
             return None;
         }
         addrs.link_local_for(self.scope_id?)
+    }
+
+    /// Global IPv6 next-hop for the egress interface, or `None` if
+    /// none is registered (pure-unnumbered links typically have no
+    /// global v6). When this returns `Some` and
+    /// [`Self::next_hop_v6`] also returns `Some`, the encoder emits
+    /// the RFC 8950 32-octet `global || link-local` form; otherwise
+    /// it emits the 16-octet link-local-only form.
+    pub fn next_hop_v6_global(
+        &self,
+        addrs: &super::interface_addrs::InterfaceAddrs,
+    ) -> Option<std::net::Ipv6Addr> {
+        if !matches!(self.origin, PeerOrigin::Interface { .. }) {
+            return None;
+        }
+        addrs.global_for(self.scope_id?)
     }
 
     /// True iff both directions of the BGP capability exchange

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1560,14 +1560,16 @@ fn route_soft_out_peer_table(
 
     // Direct-emit IPv4 unicast batch (no group fan-out). When the
     // peer negotiated RFC 8950 ENHE for IPv4 unicast, pass the
-    // per-interface link-local so the encoder emits MP_REACH instead
-    // of the legacy inline-NLRI form.
+    // per-interface next-hop so the encoder emits MP_REACH instead
+    // of the legacy inline-NLRI form. `compose_enhe_next_hop`
+    // selects 32-octet dual when the egress interface also has a
+    // global v6, else 16-octet link-local-only.
     if rd.is_none()
         && let Some(peer) = peers.get_by_idx(peer_idx)
     {
         let enhe_v6 = peer
             .is_enhe_v4_negotiated()
-            .then(|| peer.next_hop_v6(bgp.interface_addrs))
+            .then(|| super::update_group::compose_enhe_next_hop(peer, bgp.interface_addrs))
             .flatten();
         super::update_group::send_ipv4_direct(peer, ipv4_entries, enhe_v6);
     }
@@ -3392,7 +3394,7 @@ pub fn route_sync_ipv4(peer: &mut Peer, bgp: &mut BgpTop) {
 
     let enhe_v6 = peer
         .is_enhe_v4_negotiated()
-        .then(|| peer.next_hop_v6(bgp.interface_addrs))
+        .then(|| super::update_group::compose_enhe_next_hop(peer, bgp.interface_addrs))
         .flatten();
     super::update_group::send_ipv4_direct(peer, entries, enhe_v6);
 

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -21,11 +21,13 @@
 //! handles.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::net::{IpAddr, Ipv6Addr};
+use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Instant;
 
-use bgp_packet::{Afi, AfiSafi, BgpAttr, CapExtendedNextHop, Ipv4Nlri, Safi, UpdatePacket};
+use bgp_packet::{
+    Afi, AfiSafi, BgpAttr, CapExtendedNextHop, Ipv4MpReachNextHop, Ipv4Nlri, Safi, UpdatePacket,
+};
 use tokio::sync::mpsc;
 
 use super::BgpAttrStore;
@@ -465,7 +467,7 @@ pub fn flush_ipv4(
     struct MemberCtx {
         ident: usize,
         tx: Option<mpsc::UnboundedSender<bytes::BytesMut>>,
-        enhe_v6: Option<std::net::Ipv6Addr>,
+        enhe_v6: Option<Ipv4MpReachNextHop>,
     }
     let members: Vec<MemberCtx> = member_idents
         .iter()
@@ -473,7 +475,7 @@ pub fn flush_ipv4(
             let peer = peers.get_by_idx(*ident);
             let tx = peer.and_then(|p| p.packet_tx.clone());
             let enhe_v6 = if enhe {
-                peer.and_then(|p| p.next_hop_v6(interface_addrs))
+                peer.and_then(|p| compose_enhe_next_hop(p, interface_addrs))
             } else {
                 None
             };
@@ -504,7 +506,7 @@ pub fn flush_ipv4(
             // which would break ENHE for everyone but one peer.
             for ctx in &members {
                 let Some(tx) = ctx.tx.as_ref() else { continue };
-                let Some(ll) = ctx.enhe_v6 else {
+                let Some(nh) = ctx.enhe_v6 else {
                     // ND hasn't observed any link-local on this
                     // peer's egress interface yet; the operator-side
                     // address-add events haven't reached BGP. Skip
@@ -526,7 +528,7 @@ pub fn flush_ipv4(
                     }
                     continue;
                 }
-                let bytes_list = encode_ipv4_update(&attr, &nlris, max_packet_size, Some(ll));
+                let bytes_list = encode_ipv4_update(&attr, &nlris, max_packet_size, Some(nh));
                 let byte_total: usize = bytes_list.iter().map(|b| b.len()).sum();
                 for bytes in &bytes_list {
                     let _ = tx.send(bytes.clone());
@@ -620,13 +622,14 @@ pub fn flush_ipv4(
 ///
 /// `extended_next_hop_v6` is the IPv6 next-hop to emit in MP_REACH
 /// for RFC 8950 IPv4-over-IPv6; `None` keeps the legacy
-/// `pop_ipv4` / inline-NLRI emit. Callers compute this from the
-/// peer's negotiated ENHE state and its egress interface's
-/// link-local.
+/// `pop_ipv4` / inline-NLRI emit. Callers compute this via
+/// [`compose_enhe_next_hop`] which picks the 32-octet dual form when
+/// the egress interface also has a global v6, else the 16-octet
+/// link-local-only form.
 pub(super) fn send_ipv4_direct(
     peer: &Peer,
     entries: Vec<(Arc<BgpAttr>, Ipv4Nlri)>,
-    extended_next_hop_v6: Option<Ipv6Addr>,
+    extended_next_hop_v6: Option<Ipv4MpReachNextHop>,
 ) {
     if entries.is_empty() {
         return;
@@ -650,28 +653,25 @@ pub(super) fn send_ipv4_direct(
 
 /// Encode one or more UPDATE PDUs carrying `nlris` under `attr`.
 ///
-/// When `extended_next_hop_v6` is `Some(ll)`, NLRIs are emitted via
+/// When `extended_next_hop_v6` is `Some(...)`, NLRIs are emitted via
 /// `UpdatePacket::pop_ipv4_mp_reach` — MP_REACH(AFI=1, SAFI=1) with
-/// an IPv6 next-hop, per RFC 8950. When `None`, the legacy
-/// `pop_ipv4` path is used (NLRI inline, NEXT_HOP attribute carries
-/// the v4 next-hop).
-///
-/// All current callers pass `None`; the ENHE-aware call sites land
-/// in a follow-up that wires per-peer v6 next-hop derivation through
-/// to the flush/sync paths.
+/// an IPv6 next-hop, per RFC 8950. The `Ipv4MpReachNextHop` variant
+/// selects the 16-octet link-local-only form or the 32-octet
+/// `global || link-local` form. `None` keeps the legacy `pop_ipv4`
+/// path (NLRI inline, NEXT_HOP attribute carries the v4 next-hop).
 fn encode_ipv4_update(
     attr: &Arc<BgpAttr>,
     nlris: &[Ipv4Nlri],
     max_packet_size: usize,
-    extended_next_hop_v6: Option<Ipv6Addr>,
+    extended_next_hop_v6: Option<Ipv4MpReachNextHop>,
 ) -> Vec<bytes::BytesMut> {
     let mut update = UpdatePacket::with_max_packet_size(max_packet_size);
     update.bgp_attr = Some((**attr).clone());
     update.ipv4_update = nlris.to_vec();
     let mut out = Vec::new();
     match extended_next_hop_v6 {
-        Some(ll) => {
-            while let Some(bytes) = update.pop_ipv4_mp_reach(ll) {
+        Some(nh) => {
+            while let Some(bytes) = update.pop_ipv4_mp_reach(nh) {
                 out.push(bytes);
             }
         }
@@ -682,6 +682,24 @@ fn encode_ipv4_update(
         }
     }
     out
+}
+
+/// Build the `Ipv4MpReachNextHop` to advertise to `peer` for an
+/// RFC 8950 IPv4-over-IPv6 UPDATE. Returns `None` when the peer
+/// has no link-local on its egress interface — without a link-local
+/// the dual form is malformed and the speaker can't emit either
+/// MP_REACH variant. When both an LL and a global are registered on
+/// the egress ifindex, returns the 32-octet `Dual` form; otherwise
+/// the 16-octet `LinkLocal` form.
+pub(super) fn compose_enhe_next_hop(
+    peer: &Peer,
+    addrs: &super::interface_addrs::InterfaceAddrs,
+) -> Option<Ipv4MpReachNextHop> {
+    let link_local = peer.next_hop_v6(addrs)?;
+    match peer.next_hop_v6_global(addrs) {
+        Some(global) => Some(Ipv4MpReachNextHop::Dual { global, link_local }),
+        None => Some(Ipv4MpReachNextHop::LinkLocal(link_local)),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

PR #655 / #658 always emit the 16-octet link-local-only form of the RFC 8950 IPv4-over-IPv6 next-hop. That's correct for pure-unnumbered links (no global v6), but speakers running BGP on numbered v6 — or unnumbered with an operator-added global on the interface — have *both* halves to advertise. RFC 8950 §3 specifies the 32-octet `global || link-local` form for that case; receivers prefer the global half for next-hop resolution and fall back to the LL on local-link reachability.

Wire it through:
- `InterfaceAddrs` gains a parallel `global` bucket alongside `link_local`, populated from the same `RibRx::AddrAdd` / `AddrDel` events. ULA is treated as "global" — RFC 8950 §3 just calls it "global IPv6" and operators running BGP on ULA addressing should get the 32-octet emit.
- `Peer::next_hop_v6_global` mirrors the existing LL accessor.
- New `bgp_packet::Ipv4MpReachNextHop { LinkLocal(addr) | Dual { global, link_local } }` sum type drives `pop_ipv4_mp_reach`.
- `compose_enhe_next_hop` helper in `update_group` builds the right variant from a peer + addrs registry; both `flush_ipv4` (per-member encode) and `send_ipv4_direct`'s callers (route.rs) route through it.
- Behavior on pure unnumbered: byte-for-byte unchanged. No global registered → `LinkLocal(...)` → same wire bytes as before.

Closes gap #2 from `memory/zebra-rs-rfc8950-wire-format-todo.md` — RFC 8950 is now feature-complete in zebra-rs's BGP.

## Test plan

- [x] `cargo fmt --all -- --check` (run separately, not piped)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` — 724 tests pass
- [x] New tests: `InterfaceAddrs` now has 10 (up from 6) covering both buckets + isolation + ULA-as-global; `update.rs` has `dual_nexthop_round_trips_global_half_to_decoder` confirming the 32-octet form encode → decode round-trips through the existing PR #654 decoder arm.

Generated with [Claude Code](https://claude.com/claude-code)