### PR TITLE
bgp: spawn / despawn per-VRF BgpVrf tasks from CommitEnd diff

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -163,11 +163,30 @@ pub struct Bgp {
     /// [`super::interface_neighbor::materialize_peer`].
     pub interface_neighbors: BTreeMap<String, super::interface_neighbor::InterfaceNeighborCfg>,
     /// Staged per-VRF BGP intent — populated by the callbacks for
-    /// `/router/bgp/vrf/<name>/...` (zebra-bgp-vrf.yang). Step 13
-    /// reads this map at `CommitEnd` to spawn / despawn per-VRF
-    /// tasks; until then `bgp::vrf_config::log_commit_diff` is the
-    /// only consumer, emitting a debug log line per entry.
+    /// `/router/bgp/vrf/<name>/...` (zebra-bgp-vrf.yang, steps 11
+    /// and 12). Diffed against [`Self::vrf_registry`] at each
+    /// `CommitEnd` to drive [`super::vrf::spawn_bgp_vrf`] and
+    /// [`super::vrf::despawn_bgp_vrf`] (step 14).
     pub vrfs: BTreeMap<String, super::vrf_config::BgpVrfConfig>,
+    /// Per-VRF tasks currently running. The diff against
+    /// [`Self::vrfs`] at `CommitEnd` spawns the names that show up
+    /// in the desired set but not here, and despawns names that
+    /// show up here but not in the desired set. Step 14's
+    /// placeholder `ProtoContext::default_table_no_rib` means the
+    /// per-VRF tasks aren't yet bound to any kernel VRF — step 15
+    /// lifts the context to a real `ProtoContext::for_vrf` once
+    /// the peer-bind site needs the binding.
+    pub vrf_registry: BTreeMap<String, super::vrf::BgpVrfHandle>,
+    /// Outbound sender every per-VRF task uses to push messages
+    /// back to the global runtime — peer registration, exports,
+    /// withdraws. Cloned into [`super::vrf::BgpVrf::global_tx`] at
+    /// spawn time so all VRFs fan in to one channel here.
+    pub vrf_global_tx: UnboundedSender<super::vrf::BgpGlobalMsg>,
+    /// Receiver paired with [`Self::vrf_global_tx`], drained in
+    /// the event loop. Step 14 logs each variant at debug; the
+    /// real handlers wire in at step 16 (peer register / accept
+    /// dispatch) and step 17 (export -> VPNv4/v6).
+    pub vrf_global_rx: UnboundedReceiver<super::vrf::BgpGlobalMsg>,
     /// `if-name` → `ifindex` mirror fed by `RibRx::LinkAdd`. Needed
     /// because the YANG callback receives a name but
     /// `PeerKey::Interface` keys on ifindex. Lookups that miss
@@ -256,6 +275,10 @@ impl Bgp {
 
         let (tx, rx) = mpsc::channel(8192);
         let (bfd_event_tx, bfd_event_rx) = mpsc::unbounded_channel();
+        // Fan-in channel: every per-VRF task gets a clone of
+        // `vrf_global_tx_init` at spawn time, so all VRF→global
+        // messages land on one receiver in the global event loop.
+        let (vrf_global_tx_init, vrf_global_rx_init) = mpsc::unbounded_channel();
 
         // Subscribe to ND `NeighborDiscovered` events so the BGP
         // unnumbered runtime can materialize an interface-keyed Peer
@@ -296,6 +319,9 @@ impl Bgp {
             dynamic_peer_count: 0,
             interface_neighbors: super::interface_neighbor::empty_map(),
             vrfs: BTreeMap::new(),
+            vrf_registry: BTreeMap::new(),
+            vrf_global_tx: vrf_global_tx_init,
+            vrf_global_rx: vrf_global_rx_init,
             link_index_by_name: BTreeMap::new(),
             interface_addrs: super::interface_addrs::InterfaceAddrs::new(),
             update_groups: super::update_group::empty_map(),
@@ -540,6 +566,38 @@ impl Bgp {
             .collect()
     }
 
+    /// Reconcile [`Self::vrfs`] (desired set, populated by step 12
+    /// callbacks) against [`Self::vrf_registry`] (running set):
+    /// spawn the additions, despawn the removals. Called from
+    /// `CommitEnd` once per commit.
+    fn apply_vrf_commit_diff(&mut self) {
+        let (to_spawn, to_despawn) = super::vrf::compute_vrf_diff(&self.vrfs, &self.vrf_registry);
+
+        for name in to_despawn {
+            if let Some(handle) = self.vrf_registry.remove(&name) {
+                super::vrf::despawn_bgp_vrf(&name, &handle);
+                // `handle` drops at end of scope — its `Task<()>`
+                // aborts the spawned event loop if Shutdown
+                // hadn't already drained it.
+            }
+        }
+
+        for name in to_spawn {
+            // `to_spawn` came from a key iteration on `self.vrfs`;
+            // the entry is guaranteed to still be present.
+            let Some(cfg) = self.vrfs.get(&name).cloned() else {
+                continue;
+            };
+            let handle = super::vrf::spawn_bgp_vrf(
+                name.clone(),
+                &cfg,
+                self.router_id,
+                self.vrf_global_tx.clone(),
+            );
+            self.vrf_registry.insert(name, handle);
+        }
+    }
+
     pub fn process_cm_msg(&mut self, msg: ConfigRequest) {
         match msg.op {
             ConfigOp::CommitStart => {
@@ -552,10 +610,15 @@ impl Bgp {
                 }
             }
             ConfigOp::CommitEnd => {
-                // Step 12: observe the per-VRF intent that just
-                // committed. Step 13 replaces this with spawn /
-                // despawn against a `running` map.
+                // Step 12 observed the per-VRF intent at debug;
+                // step 14 turns the observation into action: diff
+                // `self.vrfs` (desired) against `self.vrf_registry`
+                // (running), spawn the additions, despawn the
+                // removals. Edits to an already-spawned VRF aren't
+                // detected here — step 15 layers cfg-hash
+                // comparison on top.
                 super::vrf_config::log_commit_diff(self);
+                self.apply_vrf_commit_diff();
             }
             ConfigOp::Completion => {
                 msg.resp.unwrap().send(self.peer_comps()).unwrap();
@@ -900,6 +963,41 @@ impl Bgp {
                 Some(event) = self.nd_event_rx.recv() => {
                     self.process_nd_event(event);
                 }
+                Some(msg) = self.vrf_global_rx.recv() => {
+                    // VRF→global fan-in. Step 14 just logs each
+                    // variant — the real handlers wire in later
+                    // (step 16: peer register / accept dispatch;
+                    // step 17: Export → VPNv4/v6).
+                    self.process_vrf_global_msg(msg);
+                }
+            }
+        }
+    }
+
+    fn process_vrf_global_msg(&mut self, msg: super::vrf::BgpGlobalMsg) {
+        match msg {
+            super::vrf::BgpGlobalMsg::Export { vrf } => {
+                tracing::debug!(vrf = %vrf, "bgp: ignored Export (step 17 wires the handler)");
+            }
+            super::vrf::BgpGlobalMsg::WithdrawExport { vrf } => {
+                tracing::debug!(
+                    vrf = %vrf,
+                    "bgp: ignored WithdrawExport (step 17 wires the handler)",
+                );
+            }
+            super::vrf::BgpGlobalMsg::RegisterPeer { vrf, addr } => {
+                tracing::debug!(
+                    vrf = %vrf,
+                    %addr,
+                    "bgp: ignored RegisterPeer (step 16 wires the handler)",
+                );
+            }
+            super::vrf::BgpGlobalMsg::UnregisterPeer { vrf, addr } => {
+                tracing::debug!(
+                    vrf = %vrf,
+                    %addr,
+                    "bgp: ignored UnregisterPeer (step 16 wires the handler)",
+                );
             }
         }
     }

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -9,16 +9,8 @@
 //! at spawn time.
 //!
 //! Step 13 ships the type and the lifecycle (`event_loop`,
-//! `serve_vrf`, `Shutdown` handling). Everything else lands in the
-//! steps named in [`crate::bgp::vrf`].
-//!
-//! Most of this module is `dead_code` from rustc's point of view
-//! until step 14 wires `spawn_bgp_vrf` — the test module
-//! constructs `BgpVrf` and runs `event_loop`, but those calls only
-//! happen under `#[cfg(test)]`, so the non-test build sees zero
-//! production consumers. The blanket allow goes away the moment
-//! the spawn site lands.
-#![allow(dead_code)]
+//! `serve_vrf`, `Shutdown` handling); step 14's `spawn_bgp_vrf`
+//! is the first production consumer.
 
 use std::net::Ipv4Addr;
 
@@ -34,6 +26,11 @@ use super::super::route::LocalRib;
 use super::msg::{BgpGlobalMsg, BgpVrfMsg};
 
 /// Per-VRF BGP runtime. One task per `router bgp vrf X` block.
+///
+/// Most fields are written by `BgpVrf::new` at spawn time but
+/// don't gain a reader until later steps (15-18). The
+/// `dead_code` allow goes away as each consumer site lands.
+#[allow(dead_code)]
 pub struct BgpVrf {
     /// VRF name (matches the YANG list key under
     /// `/router/bgp/vrf/<name>`). Used in log lines, `show bgp vrf

--- a/zebra-rs/src/bgp/vrf/mod.rs
+++ b/zebra-rs/src/bgp/vrf/mod.rs
@@ -18,11 +18,11 @@
 
 pub mod inst;
 pub mod msg;
+pub mod spawn;
 
-// Step-14 consumers (`spawn_bgp_vrf` / `despawn_bgp_vrf`) will
-// reach for these names. The `unused_imports` allow is removed
-// at that point.
-#[allow(unused_imports)]
-pub use inst::{BgpVrf, serve_vrf};
-#[allow(unused_imports)]
-pub use msg::{BgpGlobalMsg, BgpVrfMsg};
+// External consumers (`Bgp` field types, `process_vrf_global_msg`)
+// only reach for the names below. `inst::{BgpVrf, serve_vrf}` and
+// `msg::BgpVrfMsg` stay internal — they're constructed / consumed
+// inside `vrf::spawn` only.
+pub use msg::BgpGlobalMsg;
+pub use spawn::{BgpVrfHandle, compute_vrf_diff, despawn_bgp_vrf, spawn_bgp_vrf};

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -11,16 +11,12 @@
 //!   dispatcher knows which VRF to forward a given source IP to
 //!   (step 16), and the matching withdraw/unregister events.
 //!
-//! Step 13 lands the enums with `Shutdown` / `Accept` populated;
-//! every other variant is a stub waiting on its consumer. Adding
-//! the variants now keeps the channel typing stable across later
-//! steps — adding a variant to a public enum that other modules
-//! `match` exhaustively is the only kind of change that would
-//! force a wide refactor at step 16/17/18.
-//!
-//! The module-level allow goes away when step 14 wires the
-//! cross-task channel ends to real producers / consumers.
-#![allow(dead_code)]
+//! Step 13 landed the enums with `Shutdown` and `Accept`
+//! populated; step 14 drains `BgpGlobalMsg` in the global event
+//! loop (`process_vrf_global_msg`) and uses `Shutdown` from
+//! `despawn_bgp_vrf`. Every other variant is still a stub for
+//! steps 16-18; the per-variant `#[allow(dead_code)]` on those
+//! variants will drop as each step lands its consumer.
 
 use std::net::SocketAddr;
 

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -1,0 +1,187 @@
+//! Spawn / despawn of [`BgpVrf`] tasks driven by the global Bgp's
+//! `CommitEnd` diff (step 14 of the BGP MPLS/VPN refactor).
+//!
+//! The committed intent lives in [`crate::bgp::Bgp::vrfs`] (a
+//! `BTreeMap<String, BgpVrfConfig>` populated by step 12's
+//! callbacks). The running task set lives in
+//! [`crate::bgp::Bgp::vrf_registry`]. After every commit the
+//! diff between the two maps is computed, new VRF names get a
+//! fresh [`BgpVrf`] + [`serve_vrf`], deleted names get a
+//! [`BgpVrfMsg::Shutdown`].
+//!
+//! The current cut deliberately uses a placeholder
+//! [`ProtoContext::default_table_no_rib`] for the per-VRF runtime:
+//! step 14 doesn't open any per-VRF sockets, and the
+//! `SO_BINDTODEVICE` plumbing only matters once peers exist
+//! (step 15). The same step 15 lifts the placeholder to a real
+//! [`ProtoContext::for_vrf`] built from a fresh per-VRF
+//! `RibClient` subscription that carries the kernel `table_id`
+//! through to [`crate::rib::client::ClientRegistry`].
+
+use std::collections::BTreeMap;
+
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::context::{ProtoContext, Task};
+
+use super::super::vrf_config::BgpVrfConfig;
+use super::inst::{BgpVrf, BgpVrfInbox, serve_vrf};
+use super::msg::{BgpGlobalMsg, BgpVrfMsg};
+
+/// Per-VRF task handle stashed on [`crate::bgp::Bgp::vrf_registry`].
+/// Holds the inbound sender so the global task can dispatch
+/// `Shutdown` / `Accept` / import deliveries, plus the spawned
+/// [`Task`] so dropping the handle aborts the runtime cleanly.
+pub struct BgpVrfHandle {
+    pub inbox: BgpVrfInbox,
+    /// Held so dropping the handle aborts the spawned event loop
+    /// even if `despawn_bgp_vrf` was never called (defence in
+    /// depth — a clean teardown sends `Shutdown` first). Not
+    /// read directly anywhere; `Task` already runs its
+    /// `AbortHandle` via `Drop`.
+    #[allow(dead_code)]
+    pub task: Task<()>,
+}
+
+/// Pure diff: which VRF names need to be spawned (in `desired`
+/// but not `running`) and which need to be despawned (in
+/// `running` but not `desired`). Names that appear in both are
+/// considered unchanged at this step — step 14 doesn't yet detect
+/// edits to `rd` / `router-id` / `label-mode`; step 15 layers
+/// edit detection on top by hashing the cfg.
+pub fn compute_vrf_diff(
+    desired: &BTreeMap<String, BgpVrfConfig>,
+    running: &BTreeMap<String, BgpVrfHandle>,
+) -> (Vec<String>, Vec<String>) {
+    let to_spawn: Vec<String> = desired
+        .keys()
+        .filter(|name| !running.contains_key(*name))
+        .cloned()
+        .collect();
+    let to_despawn: Vec<String> = running
+        .keys()
+        .filter(|name| !desired.contains_key(*name))
+        .cloned()
+        .collect();
+    (to_spawn, to_despawn)
+}
+
+/// Build + spawn a per-VRF task. Returns the handle the caller
+/// stashes on `vrf_registry`. The `global_tx` argument is the
+/// shared sender every VRF task uses to push back to the global
+/// runtime (one channel, fanned in from every VRF).
+pub fn spawn_bgp_vrf(
+    name: String,
+    cfg: &BgpVrfConfig,
+    router_id: std::net::Ipv4Addr,
+    global_tx: UnboundedSender<BgpGlobalMsg>,
+) -> BgpVrfHandle {
+    // Placeholder context — step 15 lifts this to
+    // `ProtoContext::for_vrf(rib, table_id, ifname)` once a per-VRF
+    // RibClient subscription with the right vrf_id is in place.
+    let ctx = ProtoContext::default_table_no_rib();
+    // Per-VRF override on router-id wins over the global one. Step
+    // 14 reads the cfg snapshot at spawn time; an operator edit to
+    // router-id post-spawn doesn't bubble through yet — step 15
+    // adds the respawn-on-edit detection.
+    let effective_router_id = cfg.router_id.unwrap_or(router_id);
+    let (vrf, inbox) = BgpVrf::new(name.clone(), ctx, cfg.rd, effective_router_id, global_tx);
+    let task = serve_vrf(vrf);
+    tracing::info!(
+        vrf = %name,
+        rd = ?cfg.rd,
+        router_id = %effective_router_id,
+        "bgp: spawned per-VRF task",
+    );
+    BgpVrfHandle { inbox, task }
+}
+
+/// Send `Shutdown` to the per-VRF task. Caller drops the handle
+/// from `vrf_registry` *after* this returns; dropping the handle
+/// without sending `Shutdown` first would leak a final
+/// `BgpVrfMsg` send window — the FSM might miss state it needs to
+/// flush. The handle's `Task` aborts on drop regardless, so a
+/// failure path here doesn't strand the runtime.
+pub fn despawn_bgp_vrf(name: &str, handle: &BgpVrfHandle) {
+    if handle.inbox.send(BgpVrfMsg::Shutdown).is_err() {
+        // Receiver already gone — the task exited on its own
+        // (e.g. inbox-drop path). Nothing left to do.
+        tracing::debug!(
+            vrf = %name,
+            "bgp: despawn target already exited; cleanup is a no-op",
+        );
+        return;
+    }
+    tracing::info!(vrf = %name, "bgp: sent Shutdown to per-VRF task");
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pure-function tests on [`compute_vrf_diff`]. Spawn /
+    //! despawn themselves need a `Bgp` to drive end-to-end, which
+    //! is exercised by the BDD scenarios in step 14's follow-up;
+    //! the diff function is the part that's worth unit-testing in
+    //! isolation because it's where the spawn / despawn decision
+    //! actually lives.
+    use std::net::Ipv4Addr;
+
+    use tokio::sync::mpsc::unbounded_channel;
+
+    use super::*;
+
+    fn handle(name: &str) -> BgpVrfHandle {
+        let (global_tx, _global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let cfg = BgpVrfConfig::default();
+        spawn_bgp_vrf(name.to_string(), &cfg, Ipv4Addr::UNSPECIFIED, global_tx)
+    }
+
+    #[tokio::test]
+    async fn diff_with_no_running_yields_all_as_spawn() {
+        let mut desired = BTreeMap::new();
+        desired.insert("v1".to_string(), BgpVrfConfig::default());
+        desired.insert("v2".to_string(), BgpVrfConfig::default());
+        let running: BTreeMap<String, BgpVrfHandle> = BTreeMap::new();
+
+        let (to_spawn, to_despawn) = compute_vrf_diff(&desired, &running);
+        assert_eq!(to_spawn, vec!["v1".to_string(), "v2".to_string()]);
+        assert!(to_despawn.is_empty());
+    }
+
+    #[tokio::test]
+    async fn diff_with_no_desired_yields_all_as_despawn() {
+        let desired: BTreeMap<String, BgpVrfConfig> = BTreeMap::new();
+        let mut running: BTreeMap<String, BgpVrfHandle> = BTreeMap::new();
+        running.insert("v1".to_string(), handle("v1"));
+        running.insert("v2".to_string(), handle("v2"));
+
+        let (to_spawn, to_despawn) = compute_vrf_diff(&desired, &running);
+        assert!(to_spawn.is_empty());
+        assert_eq!(to_despawn, vec!["v1".to_string(), "v2".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn diff_mixed_returns_only_deltas() {
+        let mut desired = BTreeMap::new();
+        desired.insert("v1".to_string(), BgpVrfConfig::default());
+        desired.insert("v3".to_string(), BgpVrfConfig::default()); // new
+        let mut running: BTreeMap<String, BgpVrfHandle> = BTreeMap::new();
+        running.insert("v1".to_string(), handle("v1")); // unchanged
+        running.insert("v2".to_string(), handle("v2")); // removed
+
+        let (to_spawn, to_despawn) = compute_vrf_diff(&desired, &running);
+        assert_eq!(to_spawn, vec!["v3".to_string()]);
+        assert_eq!(to_despawn, vec!["v2".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn diff_with_matching_sets_is_empty() {
+        let mut desired = BTreeMap::new();
+        desired.insert("v1".to_string(), BgpVrfConfig::default());
+        let mut running: BTreeMap<String, BgpVrfHandle> = BTreeMap::new();
+        running.insert("v1".to_string(), handle("v1"));
+
+        let (to_spawn, to_despawn) = compute_vrf_diff(&desired, &running);
+        assert!(to_spawn.is_empty());
+        assert!(to_despawn.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Step 14 of the BGP MPLS/VPN refactor. The committed intent in
`Bgp::vrfs` (step 12) is now diffed against a running-task
registry at every `CommitEnd`; new names get a `BgpVrf` +
`serve_vrf`, deleted names get a `BgpVrfMsg::Shutdown`.

- New `bgp::vrf::spawn`:
  - `BgpVrfHandle { inbox, task }` stashed on
    `Bgp::vrf_registry`. Dropping the handle aborts the spawned
    loop (defence in depth; clean teardown sends `Shutdown`
    first).
  - `compute_vrf_diff(desired, running) -> (to_spawn, to_despawn)`
    — pure key-set diff. Edits to existing entries intentionally
    not detected here; step 15 adds cfg-hash comparison.
  - `spawn_bgp_vrf(...)` builds + spawns. Per-VRF `ProtoContext`
    is `default_table_no_rib()` for now — step 14 doesn't open
    per-VRF sockets, step 15 lifts to real `for_vrf`.
  - `despawn_bgp_vrf(...)` sends `Shutdown`, tolerates an exited
    receiver.
- `Bgp` gains `vrf_registry: BTreeMap<String, BgpVrfHandle>` and
  the `vrf_global_tx` / `vrf_global_rx` fan-in channel every VRF
  task uses for VRF→global messages.
- `process_cm_msg` calls `apply_vrf_commit_diff` on `CommitEnd`,
  replacing step 12's log-only stub.
- `event_loop` drains `vrf_global_rx` via `process_vrf_global_msg`
  (debug log per variant; step 16 wires Register/Unregister +
  Accept, step 17 wires Export).
- Module-level `#![allow(dead_code)]` on `bgp::vrf::inst` and
  `bgp::vrf::msg` removed — step 14 is the production consumer.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` (528 unit tests pass;
      +4 new `compute_vrf_diff` tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)