### PR TITLE
ospf: stamp configured area into outgoing packets

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -826,11 +826,8 @@ impl Ospf {
                     num_adv: 1,
                     lsas: vec![lsa.clone()],
                 };
-                let packet = Ospfv2Packet::new(
-                    &self.router_id,
-                    &Ipv4Addr::UNSPECIFIED,
-                    Ospfv2Payload::LsUpdate(ls_upd),
-                );
+                let packet =
+                    Ospfv2Packet::new(&self.router_id, &area_id, Ospfv2Payload::LsUpdate(ls_upd));
                 tracing::info!(
                     "[Flood] Sending LSA type={:?} id={} adv={} to nbr={}",
                     lsa.h.ls_type,
@@ -874,6 +871,7 @@ impl Ospf {
             return;
         };
         let retransmit_interval = link.retransmit_interval();
+        let area_id = link.area;
         let Some(nbr) = link.nbrs.get_mut(&addr) else {
             return;
         };
@@ -887,11 +885,7 @@ impl Ospf {
             num_adv: lsas.len() as u32,
             lsas,
         };
-        let packet = Ospfv2Packet::new(
-            &self.router_id,
-            &Ipv4Addr::UNSPECIFIED,
-            Ospfv2Payload::LsUpdate(ls_upd),
-        );
+        let packet = Ospfv2Packet::new(&self.router_id, &area_id, Ospfv2Payload::LsUpdate(ls_upd));
         let _ = nbr.ptx.send(Message::Send(
             packet,
             nbr.ifindex,
@@ -923,11 +917,7 @@ impl Ospf {
         let ls_ack = OspfLsAck {
             lsa_headers: ack_headers,
         };
-        let packet = Ospfv2Packet::new(
-            &self.router_id,
-            &Ipv4Addr::UNSPECIFIED,
-            Ospfv2Payload::LsAck(ls_ack),
-        );
+        let packet = Ospfv2Packet::new(&self.router_id, &link.area, Ospfv2Payload::LsAck(ls_ack));
         // Send to AllSPFRouters multicast.
         let _ = link.ptx.send(Message::Send(packet, ifindex, None));
     }
@@ -1087,6 +1077,8 @@ impl Ospf {
                     return;
                 };
                 link.enabled = true;
+                link.area = area_id;
+                link.area_id = area_id;
                 let area = self.areas.fetch(area_id);
                 area.links.insert(ifindex);
                 self.router_lsa_originate();
@@ -1097,6 +1089,8 @@ impl Ospf {
                     return;
                 };
                 link.enabled = false;
+                link.area = Ipv4Addr::UNSPECIFIED;
+                link.area_id = Ipv4Addr::UNSPECIFIED;
                 let area = self.areas.fetch(area_id);
                 area.links.remove(&ifindex);
                 self.router_lsa_originate();

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -186,7 +186,7 @@ pub fn ospf_packet_db_desc_set(nbr: &mut Neighbor, dd: &mut OspfDbDesc) {
 }
 
 pub fn ospf_db_desc_send(link: &mut OspfInterface, nbr: &mut Neighbor, oident: &Identity) {
-    let area: Ipv4Addr = Ipv4Addr::UNSPECIFIED;
+    let area = link.area_id;
     let mut dd = OspfDbDesc::default();
 
     tracing::info!("DB_DESC: send {:?}", nbr.dd.flags);
@@ -218,8 +218,8 @@ pub fn ospf_packet_ls_req_set(nbr: &mut Neighbor, ls_req: &mut OspfLsRequest) {
     }
 }
 
-pub fn ospf_ls_req_send(_link: &mut OspfInterface, nbr: &mut Neighbor, oident: &Identity) {
-    let area: Ipv4Addr = Ipv4Addr::UNSPECIFIED;
+pub fn ospf_ls_req_send(link: &mut OspfInterface, nbr: &mut Neighbor, oident: &Identity) {
+    let area = link.area_id;
     let mut ls_req = OspfLsRequest::default();
 
     ospf_packet_ls_req_set(nbr, &mut ls_req);
@@ -441,7 +441,7 @@ pub fn ospf_db_desc_recv(
 }
 
 pub fn ospf_ls_upd_send(oi: &OspfInterface, nbr: &Neighbor, lsas: Vec<OspfLsa>) {
-    let area = Ipv4Addr::UNSPECIFIED;
+    let area = oi.area_id;
     let ls_upd = OspfLsUpdate {
         num_adv: lsas.len() as u32,
         lsas,
@@ -458,7 +458,7 @@ pub fn ospf_ls_upd_send(oi: &OspfInterface, nbr: &Neighbor, lsas: Vec<OspfLsa>) 
 }
 
 pub fn ospf_ls_ack_send(oi: &OspfInterface, nbr: &Neighbor, lsa_headers: Vec<OspfLsaHeader>) {
-    let area = Ipv4Addr::UNSPECIFIED;
+    let area = oi.area_id;
     let ls_ack = OspfLsAck { lsa_headers };
     let packet = Ospfv2Packet::new(&oi.ident.router_id, &area, Ospfv2Payload::LsAck(ls_ack));
     tracing::info!("[LS Ack:Send] to {}", nbr.ident.prefix.addr());


### PR DESCRIPTION
## Summary

- `OspfLink.area` / `OspfLink.area_id` were declared but never assigned. `Message::Enable` added the link to the area's link set without recording the area on the link, so every non-Hello packet built its OSPF header with `Ipv4Addr::UNSPECIFIED` and Hello also read the unwritten field.
- Result: DB Desc / LS Request / LS Update / LS Ack — and even Hello — all advertised area 0 regardless of configuration, breaking any non-backbone deployment.
- Fix: assign `link.area` / `link.area_id` in the `Enable` handler (clear them in `Disable`) and replace the seven hardcoded `Ipv4Addr::UNSPECIFIED` packet-construction sites with the live area.

Sites touched: `packet.rs:189, 222, 444, 461` and `inst.rs:831, 892, 928` plus the Enable/Disable handlers.

This is the first of several focused Phase 0 stabilization fixes ahead of the OSPFv2/v3 dual-stack work.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo clippy -p zebra-rs --bins` clean
- [x] `cargo test -p zebra-rs --bins` — all 532 tests pass
- [ ] Manual: bring up zebra-rs OSPF on a non-zero area against a peer and verify Hello/DBD packets carry the configured area ID (deferred to Phase 0 verification step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)