### PR TITLE
ospf: include all LSDB scopes in DBD summary list

### DIFF
--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -304,23 +304,35 @@ pub fn ospf_db_summary_add(nbr: &mut Neighbor, lsa: &OspfLsa) {
     nbr.db_sum.push(lsa.h.clone());
 }
 
+fn ospf_db_summary_add_table(nbr: &mut Neighbor, table: &super::lsdb::LsTable) {
+    use super::lsdb::OSPF_MAX_AGE;
+    for lsa in table.values() {
+        if lsa.data.h.ls_age >= OSPF_MAX_AGE {
+            continue;
+        }
+        ospf_db_summary_add(nbr, &lsa.data);
+    }
+}
+
 pub fn ospf_nfsm_negotiation_done(
     oi: &mut OspfInterface,
     nbr: &mut Neighbor,
     _oident: &Identity,
 ) -> Option<NfsmState> {
-    let table = oi.lsdb.tables.get(&OspfLsType::Router);
-    for lsa in table.values() {
-        ospf_db_summary_add(nbr, &lsa.data);
+    use super::area::AreaType;
+
+    // RFC 2328 §10.8: Initial DD Summary list is the attached area's LSDB.
+    ospf_db_summary_add_table(nbr, &oi.lsdb.tables.router);
+    ospf_db_summary_add_table(nbr, &oi.lsdb.tables.network);
+    ospf_db_summary_add_table(nbr, &oi.lsdb.tables.summary);
+    ospf_db_summary_add_table(nbr, &oi.lsdb.tables.summary_asbr);
+    ospf_db_summary_add_table(nbr, &oi.lsdb.tables.opaque_area);
+
+    // AS-scope LSAs included only for non-stub / non-NSSA areas.
+    if oi.area_type == AreaType::Normal {
+        ospf_db_summary_add_table(nbr, &oi.lsdb_as.tables.as_external);
     }
-    let table = oi.lsdb.tables.get(&OspfLsType::Network);
-    for lsa in table.values() {
-        ospf_db_summary_add(nbr, &lsa.data);
-    }
-    let table = oi.lsdb.tables.get(&OspfLsType::Summary);
-    for lsa in table.values() {
-        ospf_db_summary_add(nbr, &lsa.data);
-    }
+
     tracing::info!("[NFSM:NegotiationDone] DB Summary len {}", nbr.db_sum.len());
     None
 }


### PR DESCRIPTION
## Summary

- `ospf_nfsm_negotiation_done` only walked the Router / Network / Summary buckets when building the initial DD list (`nfsm.rs:307-326`).
- SummaryAsbr (type 4), OpaqueAreaLocal (type 10), and AsExternal (type 5) LSAs from the area / AS LSDB were never advertised during initial sync, so ASBR summaries and external routes never converged across the adjacency.
- Walks all dedicated area-scope buckets, then the AS-scope `as_external` bucket gated on `AreaType::Normal` (stub / NSSA suppress AS-external in the DD exchange per RFC 2328 §10.8). Skips MaxAge entries per the same section.

## Known follow-up

The catch-all `unknown` `LsTypes` bucket (currently holds type 7 NssaAsExternal and type 11 OpaqueAsWide) is intentionally not walked here. Those types need dedicated buckets before they can be summarized correctly — the bucket conflates LSAs with different flood scopes. Tracked separately.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo clippy -p zebra-rs --bins` clean
- [x] `cargo test -p zebra-rs --bins` — all 532 pass
- [ ] Manual: form adjacency with a peer originating AsExternal LSAs; confirm they appear in our LSDB via DD exchange (deferred to Phase 0 verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)