### PR TITLE
bgp, config: per-VRF RibClient subscription via RibSubscriber

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1806,6 +1806,21 @@ mod bfd_wiring_tests {
         (ctx, rib_rx)
     }
 
+    /// Build a minimal `RibSubscriber` for tests. Mints into a
+    /// leaked rib channel — the spawn site for per-VRF subscriptions
+    /// is exercised in integration / BDD tests; the BGP-config
+    /// callbacks tested here never call into the subscriber.
+    fn test_rib_subscriber() -> crate::config::RibSubscriber {
+        let (rib_tx, _rib_rx) = mpsc::unbounded_channel();
+        let (rib_inbound_tx, _inbound_rx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(_rib_rx));
+        Box::leak(Box::new(_inbound_rx));
+        // ProtoId allocator starts from 1 to avoid colliding with
+        // the `ProtoId::from_raw(0)` baked into `test_ctx`.
+        let next_proto_id = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(1));
+        crate::config::RibSubscriber::for_test(rib_tx, rib_inbound_tx, next_proto_id)
+    }
+
     /// Construct a Bgp with mock channels and an optional BFD
     /// client_tx. Returned alongside the BFD ClientReq receiver so
     /// the caller can assert what was sent.
@@ -1813,7 +1828,14 @@ mod bfd_wiring_tests {
         let (ctx, rib_rx) = test_ctx();
         let (policy_tx, _policy_rx) = mpsc::unbounded_channel();
         let (bfd_client_tx, bfd_client_rx) = mpsc::unbounded_channel();
-        let bgp = Bgp::new(ctx, rib_rx, policy_tx, Some(bfd_client_tx), None);
+        let bgp = Bgp::new(
+            ctx,
+            rib_rx,
+            test_rib_subscriber(),
+            policy_tx,
+            Some(bfd_client_tx),
+            None,
+        );
         (bgp, bfd_client_rx)
     }
 
@@ -1871,7 +1893,7 @@ mod bfd_wiring_tests {
     async fn enable_without_bfd_handle_is_noop() {
         let (ctx, rib_rx) = test_ctx();
         let (policy_tx, _policy_rx) = mpsc::unbounded_channel();
-        let mut bgp = Bgp::new(ctx, rib_rx, policy_tx, None, None);
+        let mut bgp = Bgp::new(ctx, rib_rx, test_rib_subscriber(), policy_tx, None, None);
         config_peer(&mut bgp, arg_words(&["10.0.0.4"]), ConfigOp::Set).unwrap();
         // No bfd handle to assert against; the call must not panic.
         config_peer_bfd_enable(&mut bgp, arg_words(&["10.0.0.4", "true"]), ConfigOp::Set).unwrap();

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -196,6 +196,13 @@ pub struct Bgp {
     /// context and the entry gets a respawn the moment `VrfAdd`
     /// arrives.
     pub rib_known_vrfs: BTreeMap<String, RibKnownVrf>,
+    /// Send-capable RIB-subscription handle, cloned from
+    /// `ConfigManager::rib_subscriber()` at spawn time. The
+    /// per-VRF spawn site uses this to mint a fresh `RibClient`
+    /// plus `Subscribe` with the VRF's kernel `table_id`, so the
+    /// step-9 inbound dispatcher routes route installs into
+    /// `vrf_tables[table_id]`.
+    pub rib_subscriber: crate::config::RibSubscriber,
     /// Outbound sender every per-VRF task uses to push messages
     /// back to the global runtime — peer registration, exports,
     /// withdraws. Cloned into [`super::vrf::BgpVrf::global_tx`] at
@@ -281,6 +288,7 @@ impl Bgp {
     pub fn new(
         ctx: ProtoContext,
         rib_rx: UnboundedReceiver<RibRx>,
+        rib_subscriber: crate::config::RibSubscriber,
         policy_tx: UnboundedSender<policy::Message>,
         bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
         nd_client_tx: Option<UnboundedSender<crate::nd::inst::NdClientReq>>,
@@ -340,6 +348,7 @@ impl Bgp {
             vrfs: BTreeMap::new(),
             vrf_registry: BTreeMap::new(),
             rib_known_vrfs: BTreeMap::new(),
+            rib_subscriber,
             vrf_global_tx: vrf_global_tx_init,
             vrf_global_rx: vrf_global_rx_init,
             link_index_by_name: BTreeMap::new(),
@@ -614,6 +623,7 @@ impl Bgp {
                 &cfg,
                 self.router_id,
                 kernel,
+                &self.rib_subscriber,
                 self.vrf_global_tx.clone(),
             );
             self.vrf_registry.insert(name, handle);
@@ -652,6 +662,7 @@ impl Bgp {
             &cfg,
             self.router_id,
             Some(kernel),
+            &self.rib_subscriber,
             self.vrf_global_tx.clone(),
         );
         self.vrf_registry.insert(name.to_string(), new_handle);

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -29,6 +29,8 @@ use super::super::vrf_config::BgpVrfConfig;
 use super::inst::{BgpVrf, BgpVrfInbox, serve_vrf};
 use super::msg::{BgpGlobalMsg, BgpVrfMsg};
 
+use crate::config::RibSubscriber;
+
 /// Per-VRF task handle stashed on [`crate::bgp::Bgp::vrf_registry`].
 /// Holds the inbound sender so the global task can dispatch
 /// `Shutdown` / `Accept` / import deliveries, plus the spawned
@@ -69,11 +71,19 @@ pub fn compute_vrf_diff(
 
 /// Build + spawn a per-VRF task. Returns the handle the caller
 /// stashes on `vrf_registry`. `kernel` carries the matching
-/// kernel VRF master info if RIB has already told us about it
-/// (step 15); when `None`, the spawn falls back to a placeholder
+/// kernel VRF master info if RIB has already told us about it;
+/// when `None`, the spawn falls back to a placeholder
 /// `ProtoContext::default_table_no_rib()` and the per-VRF runtime
 /// won't bind sockets to a VRF master until the global Bgp task
-/// re-spawns via [`super::super::inst::Bgp::maybe_respawn_vrf_with_kernel_ctx`].
+/// re-spawns via
+/// [`super::super::inst::Bgp::maybe_respawn_vrf_with_kernel_ctx`].
+///
+/// `rib_subscriber` mints the per-VRF [`RibClient`] when kernel
+/// info is present — route installs from this task flow through
+/// the matching `vrf_tables[table_id]` via step 9's inbound
+/// dispatcher. With no kernel info, the spawn uses a parked
+/// `RibClient`; routes sent through it land in the global table
+/// until the respawn happens.
 ///
 /// `global_tx` is the shared sender every VRF task uses to push
 /// back to the global runtime (one channel, fanned in from every
@@ -83,10 +93,23 @@ pub fn spawn_bgp_vrf(
     cfg: &BgpVrfConfig,
     router_id: std::net::Ipv4Addr,
     kernel: Option<RibKnownVrf>,
+    rib_subscriber: &RibSubscriber,
     global_tx: UnboundedSender<BgpGlobalMsg>,
 ) -> BgpVrfHandle {
     let ctx = match kernel {
-        Some(k) => ProtoContext::for_vrf_no_rib(k.table_id, name.clone()),
+        Some(k) => {
+            // Mint a fresh `RibClient` for this VRF. The
+            // subscription's `vrf_id` tells RIB to route the
+            // task's route installs into `vrf_tables[table_id]`
+            // (step 9's inbound dispatcher). The `RibRx` half is
+            // leaked here — per-VRF subscribers don't yet consume
+            // RIB outbound notifications; that's a step-15c
+            // follow-up.
+            let proto = format!("bgp:vrf:{name}");
+            let (rib_client, rib_rx) = rib_subscriber.subscribe_for_vrf(&proto, k.table_id);
+            Box::leak(Box::new(rib_rx));
+            ProtoContext::for_vrf(rib_client, k.table_id, name.clone())
+        }
         None => {
             tracing::debug!(
                 vrf = %name,
@@ -150,12 +173,26 @@ mod tests {
         // Pass `None` for the kernel info — the diff tests don't
         // need the per-VRF `SO_BINDTODEVICE` binding; the
         // placeholder context is enough for lifecycle testing.
+        let subscriber = test_rib_subscriber();
         spawn_bgp_vrf(
             name.to_string(),
             &cfg,
             Ipv4Addr::UNSPECIFIED,
             None,
+            &subscriber,
             global_tx,
+        )
+    }
+
+    fn test_rib_subscriber() -> RibSubscriber {
+        let (rib_tx, rib_rx) = unbounded_channel();
+        let (rib_inbound_tx, inbound_rx) = unbounded_channel();
+        Box::leak(Box::new(rib_rx));
+        Box::leak(Box::new(inbound_rx));
+        RibSubscriber::for_test(
+            rib_tx,
+            rib_inbound_tx,
+            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(1)),
         )
     }
 

--- a/zebra-rs/src/config/bgp.rs
+++ b/zebra-rs/src/config/bgp.rs
@@ -19,6 +19,7 @@ pub fn spawn_bgp(config: &ConfigManager) {
     let bgp = inst::Bgp::new(
         ctx,
         rib_rx,
+        config.rib_subscriber(),
         config.policy_tx.clone(),
         bfd_client_tx,
         nd_client_tx,

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -58,6 +58,61 @@ impl ConfigStore {
     }
 }
 
+/// Send-capable subset of [`ConfigManager`] that knows how to mint
+/// RIB subscriptions. Cloned into spawn sites that run inside a
+/// tokio task — `ConfigManager` itself is `!Send` (it holds
+/// `RefCell`s), so per-task code reaches for this instead.
+#[derive(Clone)]
+pub struct RibSubscriber {
+    rib_tx: UnboundedSender<crate::rib::Message>,
+    rib_inbound_tx: UnboundedSender<crate::rib::client::RibInbound>,
+    next_proto_id: std::sync::Arc<std::sync::atomic::AtomicU32>,
+}
+
+impl RibSubscriber {
+    /// Test-only constructor — production code reaches for
+    /// [`ConfigManager::rib_subscriber`].
+    #[cfg(test)]
+    pub fn for_test(
+        rib_tx: UnboundedSender<crate::rib::Message>,
+        rib_inbound_tx: UnboundedSender<crate::rib::client::RibInbound>,
+        next_proto_id: std::sync::Arc<std::sync::atomic::AtomicU32>,
+    ) -> Self {
+        Self {
+            rib_tx,
+            rib_inbound_tx,
+            next_proto_id,
+        }
+    }
+
+    /// Mint a `RibClient` and `RibRx` for `proto` bound to
+    /// `vrf_id`. Mirrors [`ConfigManager::subscribe_to_rib_for_vrf`]
+    /// but is callable from a `Send` context.
+    pub fn subscribe_for_vrf(
+        &self,
+        proto: &str,
+        vrf_id: u32,
+    ) -> (
+        crate::rib::client::RibClient,
+        tokio::sync::mpsc::UnboundedReceiver<crate::rib::api::RibRx>,
+    ) {
+        use std::sync::atomic::Ordering;
+        let id_raw = self.next_proto_id.fetch_add(1, Ordering::Relaxed);
+        let proto_id = crate::rib::client::ProtoId::from_raw(id_raw);
+
+        let chan = crate::rib::api::RibRxChannel::new();
+        let _ = self.rib_tx.send(crate::rib::Message::Subscribe {
+            proto_id,
+            proto: proto.to_string(),
+            tx: chan.tx.clone(),
+            vrf_id,
+        });
+
+        let client = crate::rib::client::RibClient::new(self.rib_inbound_tx.clone(), proto_id);
+        (client, chan.rx)
+    }
+}
+
 pub struct ConfigManager {
     pub yang_path: String,
     pub config_path: PathBuf,
@@ -76,9 +131,12 @@ pub struct ConfigManager {
     /// not attributable to a single subscriber.
     pub rib_inbound_tx: UnboundedSender<crate::rib::client::RibInbound>,
     /// Monotonic allocator for `ProtoId`s handed out at
-    /// `subscribe_to_rib` time. `Cell` because allocation is sync
-    /// and ConfigManager is `!Send` (uses `RefCell` elsewhere).
-    pub next_proto_id: std::cell::Cell<u32>,
+    /// `subscribe_to_rib` time. `Arc<AtomicU32>` so per-protocol
+    /// tasks that need to mint their own subscriptions later (e.g.
+    /// the per-VRF BGP spawn site, step 15) can clone the
+    /// allocator and call `fetch_add` from a tokio task without
+    /// re-entering `ConfigManager` (which is `!Send`).
+    pub next_proto_id: std::sync::Arc<std::sync::atomic::AtomicU32>,
     pub policy_tx: UnboundedSender<crate::policy::Message>,
     /// Sender side of the BFD client-request channel. Populated by
     /// [`super::bfd::spawn_bfd`] when a `bfd { ... }` block first
@@ -132,7 +190,7 @@ impl ConfigManager {
             show_clients: RefCell::new(HashMap::new()),
             rib_tx,
             rib_inbound_tx,
-            next_proto_id: std::cell::Cell::new(0),
+            next_proto_id: std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
             policy_tx,
             bfd_client_tx: RefCell::new(None),
             nd_client_tx: RefCell::new(None),
@@ -156,16 +214,15 @@ impl ConfigManager {
     }
 
     /// Allocate a `ProtoId`, build a `RibClient` bound to it, and
-    /// register the matching `RibRx` sender with RIB via the legacy
-    /// `Message::Subscribe` (still the only path that knows how to
-    /// replay the link / addr / VXLAN / FDB dump and emit `EoR`).
-    /// Returns the bound client plus the receiver half the caller
-    /// polls for notifications.
+    /// register the matching `RibRx` sender with RIB via
+    /// `Message::Subscribe`. Returns the bound client plus the
+    /// receiver half the caller polls for notifications.
     ///
-    /// In step 2 the returned `ProtoId` exists only in the client —
-    /// RIB doesn't yet consult it for dispatch. Step 9 wires it
-    /// through to the per-VRF table lookup; this allocator stays
-    /// the canonical mint point for ids regardless of that.
+    /// Default-VRF subscriptions go through this entry point; the
+    /// per-VRF sibling [`Self::subscribe_to_rib_for_vrf`] is used
+    /// by step 15+ to hand out subscriptions with a non-zero VRF
+    /// id so the inbound dispatcher (step 9) routes installs into
+    /// the matching per-VRF table.
     pub fn subscribe_to_rib(
         &self,
         proto: &str,
@@ -173,8 +230,40 @@ impl ConfigManager {
         crate::rib::client::RibClient,
         tokio::sync::mpsc::UnboundedReceiver<crate::rib::api::RibRx>,
     ) {
-        let id_raw = self.next_proto_id.get();
-        self.next_proto_id.set(id_raw + 1);
+        self.subscribe_to_rib_for_vrf(proto, 0)
+    }
+
+    /// Clone the Send-capable subset of [`ConfigManager`] used to
+    /// mint RIB subscriptions from inside a spawned task.
+    /// `ConfigManager` itself is `!Send` (holds `RefCell`s), but the
+    /// three fields the subscriber needs — `rib_tx`,
+    /// `rib_inbound_tx`, `next_proto_id` — are all clone-Send. Used
+    /// by step 15's BGP-per-VRF spawn site so each new per-VRF task
+    /// can register its own `RibClient` with a non-zero `vrf_id`.
+    pub fn rib_subscriber(&self) -> RibSubscriber {
+        RibSubscriber {
+            rib_tx: self.rib_tx.clone(),
+            rib_inbound_tx: self.rib_inbound_tx.clone(),
+            next_proto_id: std::sync::Arc::clone(&self.next_proto_id),
+        }
+    }
+
+    /// VRF-aware counterpart to [`Self::subscribe_to_rib`]. Used by
+    /// step 15's per-VRF BGP spawn site: every per-VRF task gets a
+    /// fresh `ProtoId` whose `Subscriber` row is bound to the VRF's
+    /// kernel `table_id`, so step 9's inbound dispatcher routes the
+    /// task's route installs into `vrf_tables[vrf_id]` instead of
+    /// the global table.
+    pub fn subscribe_to_rib_for_vrf(
+        &self,
+        proto: &str,
+        vrf_id: u32,
+    ) -> (
+        crate::rib::client::RibClient,
+        tokio::sync::mpsc::UnboundedReceiver<crate::rib::api::RibRx>,
+    ) {
+        use std::sync::atomic::Ordering;
+        let id_raw = self.next_proto_id.fetch_add(1, Ordering::Relaxed);
         let proto_id = crate::rib::client::ProtoId::from_raw(id_raw);
 
         let chan = crate::rib::api::RibRxChannel::new();
@@ -182,10 +271,7 @@ impl ConfigManager {
             proto_id,
             proto: proto.to_string(),
             tx: chan.tx.clone(),
-            // Default-VRF for every protocol task that uses this
-            // entry point. Per-VRF spawns (step 13) will go through
-            // a sibling that threads the VRF kernel table id here.
-            vrf_id: 0,
+            vrf_id,
         });
 
         let client = crate::rib::client::RibClient::new(self.rib_inbound_tx.clone(), proto_id);

--- a/zebra-rs/src/config/mod.rs
+++ b/zebra-rs/src/config/mod.rs
@@ -6,6 +6,7 @@ pub use vty::ExecCode;
 
 mod manager;
 pub use manager::ConfigManager;
+pub use manager::RibSubscriber;
 pub use manager::event_loop;
 
 mod serve;

--- a/zebra-rs/src/context/proto.rs
+++ b/zebra-rs/src/context/proto.rs
@@ -112,12 +112,10 @@ impl ProtoContext {
     }
 
     /// VRF-attached counterpart to [`Self::default_table_no_rib`].
-    /// Used by step 15's BGP-per-VRF spawn site, which doesn't yet
-    /// hand out a real per-VRF [`RibClient`] subscription — the
-    /// `SO_BINDTODEVICE` binding still fires on every socket the
-    /// factories return; the `ctx.rib.send(...)` path is a no-op
-    /// against a parked sender until a follow-up wires the
-    /// subscription.
+    /// Retained because tests construct contexts without a real
+    /// `RibClient`; production now goes through [`Self::for_vrf`]
+    /// since the per-VRF `RibClient` subscription landed.
+    #[allow(dead_code)]
     pub fn for_vrf_no_rib(vrf_id: u32, vrf_ifname: String) -> Self {
         debug_assert!(
             vrf_id != 0,


### PR DESCRIPTION
## Summary

Step 15 (second cut) of the BGP MPLS/VPN refactor. Lifts the
step-15a placeholder `for_vrf_no_rib` context to a real
`ProtoContext::for_vrf` backed by a fresh per-VRF `RibClient`
subscription. Route installs from a per-VRF BGP task's
`ctx.rib.send(...)` now flow through the step-9 inbound
dispatcher into `vrf_tables[table_id]`.

Per-VRF peer materialization and the active-connect BDD scenario
remain a step-15 follow-up.

- `ConfigManager::next_proto_id` changed from `Cell<u32>` to
  `Arc<AtomicU32>` so the allocator clones across the `!Send`
  boundary into tokio tasks.
- New `RibSubscriber` (`Clone`, `Send`) bundles `rib_tx`,
  `rib_inbound_tx`, `next_proto_id`.
  `ConfigManager::rib_subscriber()` mints one;
  `RibSubscriber::subscribe_for_vrf(proto, vrf_id)` mints a
  `RibClient` + `Subscribe` keyed to a non-zero VRF id.
- `subscribe_to_rib_for_vrf(proto, vrf_id)` added on
  `ConfigManager`. Existing `subscribe_to_rib` is now a thin
  wrapper passing `vrf_id = 0`.
- `Bgp::rib_subscriber: RibSubscriber` field plus an extra arg
  on `Bgp::new`. `spawn_bgp` hands one in via
  `config.rib_subscriber()`.
- `spawn_bgp_vrf` and `maybe_respawn_vrf_with_kernel_ctx` thread
  `&RibSubscriber` through. With kernel info present, the spawn
  mints a `RibClient` bound to the kernel `table_id` and builds
  the real `ProtoContext::for_vrf`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` (533 unit tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)