### PR TITLE
ospf: actually retransmit the Link State Request packet on its timer

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -82,6 +82,7 @@ pub struct OspfInterface<'a> {
     pub area_type: super::area::AreaType,
     pub exchange_loading_count: usize,
     pub mtu_ignore: bool,
+    pub retransmit_interval: u16,
     pub tracing: &'a OspfTracing,
 }
 
@@ -95,6 +96,7 @@ impl Ospf {
         let exchange_loading_count = self.count_exchange_loading_neighbors(ifindex);
         self.links.get_mut(&ifindex).and_then(|link| {
             let link_area = link.area;
+            let retransmit_interval = link.retransmit_interval();
             self.areas.get_mut(link_area).and_then(|area| {
                 let area_type = area.area_type;
                 link.nbrs.get_mut(src).map(|nbr| {
@@ -112,6 +114,7 @@ impl Ospf {
                             area_type,
                             exchange_loading_count,
                             mtu_ignore: link.config.mtu_ignore,
+                            retransmit_interval,
                             tracing: &self.tracing,
                         },
                         nbr,
@@ -898,6 +901,23 @@ impl Ospf {
         ));
     }
 
+    /// Handle Link State Request retransmit timer firing for a neighbor
+    /// (RFC 2328 §10.9). Resend the pending LS Request packet built from
+    /// `nbr.ls_req`. Stop the timer once the list is empty or the neighbor
+    /// has left Exchange/Loading.
+    fn process_ls_req_retransmit(&mut self, ifindex: u32, addr: Ipv4Addr) {
+        let Some((mut link, nbr)) = self.ospf_interface(ifindex, &addr) else {
+            return;
+        };
+        if nbr.state < NfsmState::Exchange || nbr.state >= NfsmState::Full || nbr.ls_req.is_empty()
+        {
+            nbr.timer.ls_req = None;
+            return;
+        }
+        let ident = link.ident;
+        super::ospf_ls_req_send(&mut link, nbr, ident);
+    }
+
     /// Handle delayed ack timer firing for an interface.
     fn process_delayed_ack(&mut self, ifindex: u32) {
         let Some(link) = self.links.get_mut(&ifindex) else {
@@ -1147,6 +1167,9 @@ impl Ospf {
             Message::Retransmit(ifindex, addr) => {
                 self.process_retransmit(ifindex, addr);
             }
+            Message::LsReqRetransmit(ifindex, addr) => {
+                self.process_ls_req_retransmit(ifindex, addr);
+            }
             Message::DelayedAck(ifindex) => {
                 self.process_delayed_ack(ifindex);
             }
@@ -1259,6 +1282,9 @@ pub enum Message {
     /// Retransmit LSAs to a specific neighbor.
     /// (ifindex, nbr_addr)
     Retransmit(u32, Ipv4Addr),
+    /// Retransmit pending Link State Request packet to a neighbor in
+    /// Exchange or Loading. (ifindex, nbr_addr)
+    LsReqRetransmit(u32, Ipv4Addr),
     /// Send delayed LS Acks on an interface.
     /// (ifindex)
     DelayedAck(u32),

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -224,23 +224,25 @@ pub fn ospf_nfsm_timer_set(nbr: &mut Neighbor) {
     }
 }
 
-pub fn ospf_ls_req_timer(nbr: &Neighbor) -> Timer {
+pub fn ospf_ls_req_timer(nbr: &Neighbor, retransmit_interval: u16) -> Timer {
     let tx = nbr.tx.clone();
     let prefix = nbr.ident.prefix;
     let ifindex = nbr.ifindex;
-    Timer::new(Timer::second(1), TimerType::Once, move || {
-        use NfsmEvent::*;
-        let tx = tx.clone();
-        async move {
-            tx.send(Message::Nfsm(ifindex, prefix.addr(), InactivityTimer))
-                .unwrap();
-        }
-    })
+    Timer::new(
+        Timer::second(retransmit_interval as u64),
+        TimerType::Infinite,
+        move || {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send(Message::LsReqRetransmit(ifindex, prefix.addr()));
+            }
+        },
+    )
 }
 
-pub fn ospf_nfsm_ls_req_timer_on(nbr: &mut Neighbor) {
+pub fn ospf_nfsm_ls_req_timer_on(nbr: &mut Neighbor, retransmit_interval: u16) {
     if nbr.timer.ls_req.is_none() {
-        nbr.timer.ls_req = Some(ospf_ls_req_timer(nbr));
+        nbr.timer.ls_req = Some(ospf_ls_req_timer(nbr, retransmit_interval));
     }
 }
 

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -261,7 +261,7 @@ fn ospf_db_desc_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, dd: &OspfDbDesc
         if find.is_none() {
             let lsr = ospf_ls_rquest_new(lsah);
             ospf_ls_request_add(nbr, lsr);
-            ospf_nfsm_ls_req_timer_on(nbr);
+            ospf_nfsm_ls_req_timer_on(nbr, oi.retransmit_interval);
         }
     }
 


### PR DESCRIPTION
## Summary

The LS Request retransmit timer (`nfsm.rs:ospf_ls_req_timer`) was a `TimerType::Once` timer whose body sent `NfsmEvent::InactivityTimer`. `InactivityTimer` kills the neighbor — so any LS Request that wasn't answered within one second tore down the adjacency instead of being resent. Loading state could not survive any LS Update loss.

- Replaced the timer body with a recurring (`TimerType::Infinite`) trigger that fires the new `Message::LsReqRetransmit`.
- Added instance-level handler `process_ls_req_retransmit` that rebuilds the LS Request from `nbr.ls_req` via `ospf_ls_req_send`. The handler self-stops the timer when the request list is empty or the neighbor has left Exchange / Loading; `Drop` on `Timer` cancels the underlying async task.
- Use the link's configured `retransmit_interval` (default 5s, RFC 2328 §10.9) instead of the hardcoded 1s. Threaded via a new `retransmit_interval` field on `OspfInterface` so packet-level code can read it without touching `OspfLink` directly.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo clippy -p zebra-rs --bins` clean
- [x] `cargo test -p zebra-rs --bins` — all 532 pass
- [ ] Manual: form an adjacency with one peer dropping our LS Updates intermittently; confirm LS Requests keep retransmitting at the configured interval and the neighbor reaches Full instead of being killed (deferred to Phase 0 verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)