### PR TITLE
isis: per-algo SPF gating with FAD constraint filtering

### DIFF
--- a/zebra-rs/src/isis/flex_algo.rs
+++ b/zebra-rs/src/isis/flex_algo.rs
@@ -207,6 +207,106 @@ pub fn build_link_asla(affinity: &BTreeSet<String>, am: &AffinityMap) -> Option<
     })
 }
 
+/// Resolve a set of affinity names to an `ExtAdminGroup` bitmap via
+/// the affinity-map. Names with no matching entry are silently
+/// dropped (best-effort, matches `build_link_asla` semantics).
+///
+/// Used by per-algo SPF to derive the bitmap for our own ExtIsReach
+/// edges, since peer-ingested `peer_link_affinity` deliberately
+/// excludes the local sys-id (the rebuild skips self).
+pub fn local_link_affinity(affinity: &BTreeSet<String>, am: &AffinityMap) -> ExtAdminGroup {
+    let mut g = ExtAdminGroup::default();
+    for name in affinity {
+        if let Some(bit) = am.bit(name) {
+            g.set(bit);
+        }
+    }
+    g
+}
+
+/// Apply the RFC 9350 §6 link-attribute constraints from `entry`
+/// against `affinity`. Returns true when the link is admissible for
+/// the algorithm's SPF graph.
+///
+/// `affinity = None` means the source LSP did not advertise an ASLA
+/// bitmap for this neighbor — treated as the empty bitmap (every bit
+/// = 0). That's the right default for peers that simply haven't
+/// configured admin-groups: include-any with a non-empty constraint
+/// rejects them, which matches the §6 "no link attribute" reading.
+///
+/// Constraint semantics:
+///   - **exclude-any**: link fails if any of the FAD's excluded bits
+///     is set in `affinity` (intersection non-empty).
+///   - **include-any**: when the FAD lists any bit here, the link
+///     must have at least one of them set (intersection non-empty).
+///     Empty constraint = no requirement.
+///   - **include-all**: every bit in the FAD's constraint must be set
+///     on the link.
+///
+/// Name resolution failures (a constraint name not in `am`) are
+/// silently dropped, matching `build_fad_subs` — the wire form would
+/// not have carried that bit anyway.
+pub fn link_passes_fad(
+    affinity: Option<&ExtAdminGroup>,
+    entry: &FlexAlgoEntry,
+    am: &AffinityMap,
+) -> bool {
+    let exclude = local_link_affinity(&entry.exclude_any, am);
+    let include_any = local_link_affinity(&entry.include_any, am);
+    let include_all = local_link_affinity(&entry.include_all, am);
+
+    let empty = ExtAdminGroup::default();
+    let bitmap = affinity.unwrap_or(&empty);
+
+    if !ext_admin_group_intersection(&exclude, bitmap).is_empty() {
+        return false;
+    }
+    if !include_any.words.iter().all(|w| *w == 0)
+        && ext_admin_group_intersection(&include_any, bitmap).is_empty()
+    {
+        return false;
+    }
+    if !ext_admin_group_contains(bitmap, &include_all) {
+        return false;
+    }
+    true
+}
+
+/// Bitwise AND of two `ExtAdminGroup` bitmaps. Returned bitmap is
+/// length min(a, b) — trailing zero words from a longer operand do
+/// not contribute set bits.
+fn ext_admin_group_intersection(a: &ExtAdminGroup, b: &ExtAdminGroup) -> ExtAdminGroup {
+    let len = a.words.len().min(b.words.len());
+    let mut out = Vec::with_capacity(len);
+    for i in 0..len {
+        out.push(a.words[i] & b.words[i]);
+    }
+    ExtAdminGroup { words: out }
+}
+
+/// True iff every set bit in `needed` is also set in `bitmap`.
+/// Trailing words past `bitmap.words.len()` in `needed` must be zero.
+fn ext_admin_group_contains(bitmap: &ExtAdminGroup, needed: &ExtAdminGroup) -> bool {
+    for (i, w) in needed.words.iter().enumerate() {
+        let have = bitmap.words.get(i).copied().unwrap_or(0);
+        if *w & !have != 0 {
+            return false;
+        }
+    }
+    true
+}
+
+/// True iff `g` has no set bits.
+trait ExtAdminGroupExt {
+    fn is_empty(&self) -> bool;
+}
+
+impl ExtAdminGroupExt for ExtAdminGroup {
+    fn is_empty(&self) -> bool {
+        self.words.iter().all(|w| *w == 0)
+    }
+}
+
 /// Build the per-algorithm Prefix-SID sub-TLVs (RFC 8667 §2.1 +
 /// RFC 9350 §7) to attach to one prefix's IP-reach entry. Each map
 /// entry produces one additional Prefix-SID sub-TLV with the
@@ -1130,5 +1230,127 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("128..=255"), "unexpected err: {err}");
+    }
+
+    /// Build a synthetic affinity-map with the requested name → bit
+    /// assignments. Each name gets its own slot starting at bit 0.
+    fn affinity_map(names: &[&str]) -> AffinityMap {
+        let mut am = AffinityMap::new();
+        for (i, name) in names.iter().enumerate() {
+            am.config.insert(
+                (*name).to_string(),
+                super::super::affinity_map::AffinityEntry {
+                    delete: false,
+                    bit_position: Some(i as u16),
+                },
+            );
+        }
+        am
+    }
+
+    /// Build an `ExtAdminGroup` from a list of bit positions.
+    fn admin_group(bits: &[u16]) -> ExtAdminGroup {
+        let mut g = ExtAdminGroup::default();
+        for b in bits {
+            g.set(*b);
+        }
+        g
+    }
+
+    fn fad_entry(
+        exclude_any: &[&str],
+        include_any: &[&str],
+        include_all: &[&str],
+    ) -> FlexAlgoEntry {
+        FlexAlgoEntry {
+            exclude_any: affinity_set(exclude_any),
+            include_any: affinity_set(include_any),
+            include_all: affinity_set(include_all),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn link_passes_fad_no_constraints_accepts_anything() {
+        let am = affinity_map(&["red"]);
+        let entry = fad_entry(&[], &[], &[]);
+        assert!(link_passes_fad(None, &entry, &am));
+        let g = admin_group(&[0]);
+        assert!(link_passes_fad(Some(&g), &entry, &am));
+    }
+
+    #[test]
+    fn link_passes_fad_exclude_any_drops_link_with_excluded_bit() {
+        let am = affinity_map(&["red", "blue"]);
+        let entry = fad_entry(&["red"], &[], &[]);
+        let red = admin_group(&[0]);
+        let blue = admin_group(&[1]);
+        assert!(!link_passes_fad(Some(&red), &entry, &am));
+        assert!(link_passes_fad(Some(&blue), &entry, &am));
+        // Missing affinity = empty bitmap = no excluded bit set.
+        assert!(link_passes_fad(None, &entry, &am));
+    }
+
+    #[test]
+    fn link_passes_fad_include_any_requires_at_least_one_bit() {
+        let am = affinity_map(&["red", "blue", "green"]);
+        let entry = fad_entry(&[], &["red", "blue"], &[]);
+        // No bits set → fails include-any when constraint is non-empty.
+        assert!(!link_passes_fad(None, &entry, &am));
+        // Unrelated bit only → still fails.
+        let green = admin_group(&[2]);
+        assert!(!link_passes_fad(Some(&green), &entry, &am));
+        // One of the required bits → passes.
+        let red = admin_group(&[0]);
+        assert!(link_passes_fad(Some(&red), &entry, &am));
+        // Both required bits → passes.
+        let red_blue = admin_group(&[0, 1]);
+        assert!(link_passes_fad(Some(&red_blue), &entry, &am));
+    }
+
+    #[test]
+    fn link_passes_fad_include_all_requires_every_bit() {
+        let am = affinity_map(&["red", "blue", "green"]);
+        let entry = fad_entry(&[], &[], &["red", "blue"]);
+        // Empty bitmap → missing both → fails.
+        assert!(!link_passes_fad(None, &entry, &am));
+        // Only one of the required bits → fails.
+        let red = admin_group(&[0]);
+        assert!(!link_passes_fad(Some(&red), &entry, &am));
+        // Both required bits → passes.
+        let red_blue = admin_group(&[0, 1]);
+        assert!(link_passes_fad(Some(&red_blue), &entry, &am));
+        // Superset (all required + extra) → still passes.
+        let red_blue_green = admin_group(&[0, 1, 2]);
+        assert!(link_passes_fad(Some(&red_blue_green), &entry, &am));
+    }
+
+    #[test]
+    fn link_passes_fad_combined_constraints_all_must_pass() {
+        // exclude red, include-any {blue, green}, include-all {blue}
+        let am = affinity_map(&["red", "blue", "green"]);
+        let entry = fad_entry(&["red"], &["blue", "green"], &["blue"]);
+        // red present → exclude trips first.
+        let red_blue = admin_group(&[0, 1]);
+        assert!(!link_passes_fad(Some(&red_blue), &entry, &am));
+        // blue alone → satisfies include-any (blue ∈ {blue, green}) and
+        // include-all ({blue} ⊆ {blue}).
+        let blue = admin_group(&[1]);
+        assert!(link_passes_fad(Some(&blue), &entry, &am));
+        // green alone → satisfies include-any but not include-all.
+        let green = admin_group(&[2]);
+        assert!(!link_passes_fad(Some(&green), &entry, &am));
+    }
+
+    #[test]
+    fn link_passes_fad_unresolved_constraint_names_silently_drop() {
+        // FAD references "purple" which isn't in the affinity-map; the
+        // bit cannot be encoded into the local bitmap, so an include-
+        // all on it alone reduces to an empty requirement → passes.
+        let am = affinity_map(&["red"]);
+        let entry = fad_entry(&[], &[], &["purple"]);
+        assert!(link_passes_fad(None, &entry, &am));
+        let red = admin_group(&[0]);
+        assert!(link_passes_fad(Some(&red), &entry, &am));
     }
 }

--- a/zebra-rs/src/isis/graph.rs
+++ b/zebra-rs/src/isis/graph.rs
@@ -9,6 +9,7 @@ use isis_packet::{
 use crate::spf;
 
 use super::config::MtId;
+use super::flex_algo::{FlexAlgoEntry, link_passes_fad, local_link_affinity};
 use super::inst::IsisTop;
 use super::level::Level;
 
@@ -475,4 +476,160 @@ fn process_neighbor_link_mt2(
         cost: entry.metric,
         link_id: 0,
     });
+}
+
+/// Build a per-algorithm SPF graph for Flex-Algo `algo` using `entry`
+/// as the Flexible Algorithm Definition (RFC 9350 §5). The result has
+/// the same shape as `graph()` so existing `spf::spf` consumers work
+/// unchanged.
+///
+/// Filtering vs the legacy graph:
+///   - **Peer participation gate (§5.2):** vertices from non-self
+///     LSPs are dropped when the source sys-id is missing from
+///     `peer_algos` or has not listed `algo`. The local router is
+///     always included — `flex_algo.config[algo]` is the participation
+///     signal on our side, and SPF is only called for algos in that
+///     map.
+///   - **Per-link affinity gate (§6):** every ExtIsReach edge is
+///     filtered through `link_passes_fad`. Our own edges resolve
+///     local `LinkConfig::affinity` via `affinity_map`; peer edges
+///     read `peer_link_affinity[source_sys][neighbor_id]`.
+///   - **SRLG exclude:** *not* enforced — peer SRLG state is not yet
+///     cached. `entry.srlg_exclude` is read but produces no effect; a
+///     `tracing::warn` would be reasonable but is left to the
+///     scheduler layer.
+///   - **Metric type:** IGP only. `entry.metric_type ==
+///     MinUnidirLinkDelay` or `TeDefault` falls back to IGP with no
+///     warning (TODO when those metric caches arrive).
+pub fn graph_flex_algo(
+    top: &mut IsisTop,
+    level: Level,
+    algo: u8,
+    entry: &FlexAlgoEntry,
+) -> (spf::Graph, Option<usize>, BTreeMap<u32, IsisSysId>) {
+    let mut graph = spf::Graph::new();
+    let mut source_node = None;
+    let mut adjacency_sids = BTreeMap::new();
+    let self_sys_id = top.config.net.sys_id();
+
+    // First pass: clone every LSP we plan to walk. Mirrors `graph()`
+    // so the borrow of `top.lsdb` releases before we start mutating
+    // `top.lsp_map` in the second pass. Same fragment-collapse
+    // behaviour applies (LspMap keys on IsisNeighborId).
+    //
+    // Peer-participation filter happens here: drop non-self real
+    // routers that haven't listed `algo` in SR-Algorithms. Pseudonode
+    // LSPs are always kept — they belong to a real router whose
+    // participation is already gated by this filter.
+    let peer_algos_at_level = top.peer_algos.get(&level);
+    let mut nodes_to_process = Vec::new();
+    for (_, lsa) in top.lsdb.get(&level).iter() {
+        let neighbor_id = lsa.lsp.lsp_id.neighbor_id();
+        let is_originated = lsa.originated;
+        let is_pseudo = lsa.lsp.lsp_id.is_pseudo();
+
+        if !is_originated && !is_pseudo {
+            let participates = peer_algos_at_level
+                .get(&neighbor_id.sys_id())
+                .is_some_and(|s| s.contains(&algo));
+            if !participates {
+                continue;
+            }
+        }
+        let lsp = lsa.lsp.clone();
+        nodes_to_process.push((neighbor_id, is_originated, lsp));
+    }
+
+    // Vertex construction — identical to graph().
+    for (neighbor_id, is_originated, lsp) in nodes_to_process.iter() {
+        let node_id = top.lsp_map.get_mut(&level).get(neighbor_id);
+        if *is_originated && !lsp.lsp_id.is_pseudo() {
+            source_node = Some(node_id);
+            collect_adjacency_sids(lsp, &mut adjacency_sids);
+        }
+        let vertex = create_graph_vertex(top, level, node_id, neighbor_id, lsp);
+        graph.insert(node_id, vertex);
+    }
+
+    // Same local-adj → ifindex map as graph(); used both for link_id
+    // stamping and for resolving the local link's affinity.
+    let mut local_adj_to_ifindex: BTreeMap<IsisNeighborId, u32> = BTreeMap::new();
+    for (ifindex, link) in top.links.iter() {
+        if let Some((adj, _)) = link.state.adj.get(&level) {
+            local_adj_to_ifindex.insert(*adj, *ifindex);
+        }
+    }
+
+    // Edge construction with per-link affinity filtering.
+    for (neighbor_id, is_originated, lsp) in nodes_to_process.iter() {
+        let node_id = top.lsp_map.get_mut(&level).get(neighbor_id);
+        let own_router_lsp = *is_originated && !lsp.lsp_id.is_pseudo();
+        let source_sys_id = neighbor_id.sys_id();
+
+        for tlv in &lsp.tlvs {
+            let IsisTlv::ExtIsReach(ext_reach) = tlv else {
+                continue;
+            };
+            for entry_reach in &ext_reach.entries {
+                let neighbor_lsp_id: IsisLspId = entry_reach.neighbor_id.into();
+
+                if top.lsdb.get(&level).get(&neighbor_lsp_id).is_none() {
+                    continue;
+                }
+
+                // Resolve the link's affinity bitmap for the FAD
+                // predicate. Local LSPs are not in
+                // `peer_link_affinity` (rebuild skips self), so own
+                // edges go through `LinkConfig::affinity` + the
+                // configured `affinity_map`.
+                let local_affinity;
+                let affinity: Option<&isis_packet::ExtAdminGroup> = if source_sys_id == self_sys_id
+                {
+                    let ifindex = local_adj_to_ifindex.get(&entry_reach.neighbor_id).copied();
+                    if let Some(ifx) = ifindex
+                        && let Some(link) = top.links.get(&ifx)
+                    {
+                        local_affinity =
+                            local_link_affinity(&link.config.affinity, top.affinity_map);
+                        Some(&local_affinity)
+                    } else {
+                        None
+                    }
+                } else {
+                    top.peer_link_affinity
+                        .get(&level)
+                        .get(&source_sys_id)
+                        .and_then(|m| m.get(&entry_reach.neighbor_id))
+                };
+
+                if !link_passes_fad(affinity, entry, top.affinity_map) {
+                    continue;
+                }
+
+                let to_id = top
+                    .lsp_map
+                    .get_mut(&level)
+                    .get(&neighbor_lsp_id.neighbor_id());
+
+                let link_id = if own_router_lsp {
+                    local_adj_to_ifindex
+                        .get(&entry_reach.neighbor_id)
+                        .copied()
+                        .unwrap_or(0)
+                } else {
+                    0
+                };
+
+                let link = spf::Link::with_id(node_id, to_id, entry_reach.metric, link_id);
+                if let Some(from) = graph.get_mut(&node_id) {
+                    from.olinks.push(link.clone());
+                }
+                if let Some(to) = graph.get_mut(&to_id) {
+                    to.ilinks.push(link);
+                }
+            }
+        }
+    }
+
+    (graph, source_node, adjacency_sids)
 }

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -158,6 +158,16 @@ pub struct Isis {
     pub mt2_graph: Levels<Option<spf::Graph>>,
     pub mt2_spf_result: Levels<Option<BTreeMap<usize, spf::Path>>>,
 
+    /// Per-algorithm SPF graphs (RFC 9350). Outer key is the algo id
+    /// from `flex_algo.config` (128..=255); inner Option mirrors the
+    /// legacy `graph` shape — None means SPF could not run this cycle
+    /// (e.g. we have no source LSP yet). Recomputed every time
+    /// `perform_spf_calculation` runs; stale algos no longer in
+    /// `flex_algo.config` are purged before each refill so the
+    /// snapshot stays consistent with current config.
+    pub graph_flex_algo: Levels<BTreeMap<u8, Option<spf::Graph>>>,
+    pub spf_flex_algo: Levels<BTreeMap<u8, Option<BTreeMap<usize, spf::Path>>>>,
+
     /// SR-update return channel from the RIB. Carries the current value of
     /// the watched block / locator and any subsequent updates.
     pub sr_rx: UnboundedReceiver<RibSrRx>,
@@ -313,6 +323,13 @@ pub struct IsisTop<'a> {
     pub mt2_graph: &'a mut Levels<Option<spf::Graph>>,
     pub mt2_spf_result: &'a mut Levels<Option<BTreeMap<usize, spf::Path>>>,
 
+    /// Per-algorithm SPF state (see `Isis::graph_flex_algo` /
+    /// `spf_flex_algo`). Threaded through IsisTop so
+    /// `perform_spf_calculation` can refresh per-algo runs alongside
+    /// the legacy + MT 2 SPF.
+    pub graph_flex_algo: &'a mut Levels<BTreeMap<u8, Option<spf::Graph>>>,
+    pub spf_flex_algo: &'a mut Levels<BTreeMap<u8, Option<BTreeMap<usize, spf::Path>>>>,
+
     /// Read-only access to the SR snapshot the IS-IS instance is caching
     /// from RIB::SrSubscribe. lsp_generate uses these to populate the SR
     /// Capability / SRv6 sub-TLVs.
@@ -428,6 +445,9 @@ impl Isis {
                 tilfa_result: Levels::<Option<BTreeMap<usize, Vec<spf::RepairPath>>>>::default(),
                 mt2_graph: Levels::<Option<spf::Graph>>::default(),
                 mt2_spf_result: Levels::<Option<BTreeMap<usize, spf::Path>>>::default(),
+                graph_flex_algo: Levels::<BTreeMap<u8, Option<spf::Graph>>>::default(),
+                spf_flex_algo: Levels::<BTreeMap<u8, Option<BTreeMap<usize, spf::Path>>>>::default(
+                ),
                 sr_rx,
                 watched_block: None,
                 watched_locator: None,
@@ -1173,6 +1193,8 @@ impl Isis {
             tilfa_result: &mut self.tilfa_result,
             mt2_graph: &mut self.mt2_graph,
             mt2_spf_result: &mut self.mt2_spf_result,
+            graph_flex_algo: &mut self.graph_flex_algo,
+            spf_flex_algo: &mut self.spf_flex_algo,
             sr_block: &self.sr_block,
             sr_locator: &self.sr_locator,
             sr_end_sid: &self.sr_end_sid,

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -19,7 +19,8 @@ use crate::spf;
 use isis_packet::srv6::EncapType;
 
 use super::config::MtId;
-use super::graph::{graph, graph_mt2};
+use super::flex_algo::FlexAlgoEntry;
+use super::graph::{graph, graph_flex_algo, graph_mt2};
 use super::inst::{IsisTop, Message};
 use super::level::Level;
 use super::link::{Afi, LinkTop};
@@ -996,6 +997,39 @@ pub(super) fn perform_spf_calculation(top: &mut IsisTop, level: Level) {
         *top.mt2_spf_result.get_mut(&level) = None;
         build_rib_from_spf_v6(top, level, source, &spf_result, &tilfa_result, false)
     };
+
+    // Per-algorithm SPF (RFC 9350). For every algo in
+    // `flex_algo.config` build the FAD-filtered graph and run
+    // Dijkstra; the result feeds future per-algo RIB / MPLS LFIB
+    // install (next PR). Algos no longer in config are purged from
+    // the level's BTreeMap so the snapshot tracks current intent.
+    //
+    // Entries are cloned out of `top.flex_algo.config` because
+    // `graph_flex_algo` takes `&mut top` and we'd otherwise hold a
+    // read borrow on `top.flex_algo` across the call.
+    let configured_algos: Vec<(u8, FlexAlgoEntry)> = top
+        .flex_algo
+        .config
+        .iter()
+        .map(|(k, v)| (*k, v.clone()))
+        .collect();
+    {
+        let active: BTreeSet<u8> = configured_algos.iter().map(|(k, _)| *k).collect();
+        top.graph_flex_algo
+            .get_mut(&level)
+            .retain(|k, _| active.contains(k));
+        top.spf_flex_algo
+            .get_mut(&level)
+            .retain(|k, _| active.contains(k));
+    }
+    for (algo, entry) in &configured_algos {
+        let (algo_graph, algo_source, _) = graph_flex_algo(top, level, *algo, entry);
+        let algo_spf = algo_source.map(|src| spf::spf(&algo_graph, src, &spf::SpfOpt::full_path()));
+        top.graph_flex_algo
+            .get_mut(&level)
+            .insert(*algo, Some(algo_graph));
+        top.spf_flex_algo.get_mut(&level).insert(*algo, algo_spf);
+    }
 
     *top.spf_result.get_mut(&level) = Some(spf_result);
     *top.tilfa_result.get_mut(&level) = Some(tilfa_result);


### PR DESCRIPTION
## Summary

- Adds `graph_flex_algo(top, level, algo, entry)` in `isis/graph.rs` — mirrors `graph()` but drops non-participating peers via `Isis::peer_algos` (RFC 9350 §5.2) and gates each ExtIsReach edge through `link_passes_fad` against the FAD's exclude-any / include-any / include-all constraints (RFC 9350 §6).
- `perform_spf_calculation` now runs per-algo SPF for every entry in `flex_algo.config` after the legacy + MT 2 runs. Results land in new `Isis::graph_flex_algo` / `Isis::spf_flex_algo` levels-maps keyed by algo; stale algos are purged before each refill so the snapshot tracks current config.
- Own-router edges resolve local `LinkConfig::affinity` via `affinity_map`; peer edges read `peer_link_affinity` (cached in the prior PR).

New `flex_algo.rs` helpers:
- `link_passes_fad(affinity, entry, am)` — predicate covering all three constraint types with name-resolution semantics matching `build_fad_subs`.
- `local_link_affinity(names, am)` — resolves names to an `ExtAdminGroup` for our own LSP edges (peer-ingest skips self).

## Out of scope (next PRs in the roadmap)

- Per-algo RIB / MPLS LFIB install
- SRLG-exclude enforcement (peer SRLG cache doesn't exist yet)
- Non-IGP metric types (delay, te-default) — fall back to IGP

## Test plan

- [x] 6 new predicate unit tests under `isis::flex_algo::tests::link_passes_fad_*`: no-constraints, exclude-any, include-any, include-all, combined, unresolved-name.
- [x] All 88 IS-IS tests pass (`cargo test --bin zebra-rs isis::`).
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [ ] End-to-end SPF gating integration test deferred to the per-algo RIB-install PR — that PR introduces the natural assertion target (kernel routes for algo-N) instead of having to peek at internal `spf_flex_algo` state.

Generated with [Claude Code](https://claude.com/claude-code)