### PR TITLE
ospf: retransmit DD packets and handle late DD per RFC 2328 §10.6/§10.8

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -901,6 +901,37 @@ impl Ospf {
         ));
     }
 
+    /// Handle Database Description master-retransmit timer firing
+    /// (RFC 2328 §10.8). Resend the DD packet stored in `nbr.dd.sent` while
+    /// the master is still in ExStart or Exchange. The timer is replaced
+    /// (not cancelled) when the master sends the next DD; once the neighbor
+    /// progresses past Exchange the regular timer-set logic clears it.
+    fn process_dd_retransmit(&mut self, ifindex: u32, addr: Ipv4Addr) {
+        let Some((link, nbr)) = self.ospf_interface(ifindex, &addr) else {
+            return;
+        };
+        if (nbr.state != NfsmState::ExStart && nbr.state != NfsmState::Exchange)
+            || !nbr.dd.flags.master()
+        {
+            nbr.timer.db_desc = None;
+            return;
+        }
+        let Some(ref sent) = nbr.dd.sent else {
+            return;
+        };
+        let packet = Ospfv2Packet::new(
+            link.router_id,
+            &link.area_id,
+            Ospfv2Payload::DbDesc(sent.clone()),
+        );
+        tracing::info!("[DB Desc:Retransmit] to {} seq={:#x}", addr, sent.seqnum);
+        let _ = nbr.ptx.send(Message::Send(
+            packet,
+            nbr.ifindex,
+            Some(nbr.ident.prefix.addr()),
+        ));
+    }
+
     /// Handle Link State Request retransmit timer firing for a neighbor
     /// (RFC 2328 §10.9). Resend the pending LS Request packet built from
     /// `nbr.ls_req`. Stop the timer once the list is empty or the neighbor
@@ -1170,6 +1201,9 @@ impl Ospf {
             Message::LsReqRetransmit(ifindex, addr) => {
                 self.process_ls_req_retransmit(ifindex, addr);
             }
+            Message::DdRetransmit(ifindex, addr) => {
+                self.process_dd_retransmit(ifindex, addr);
+            }
             Message::DelayedAck(ifindex) => {
                 self.process_delayed_ack(ifindex);
             }
@@ -1285,6 +1319,9 @@ pub enum Message {
     /// Retransmit pending Link State Request packet to a neighbor in
     /// Exchange or Loading. (ifindex, nbr_addr)
     LsReqRetransmit(u32, Ipv4Addr),
+    /// Master retransmit of pending Database Description packet.
+    /// (ifindex, nbr_addr)
+    DdRetransmit(u32, Ipv4Addr),
     /// Send delayed LS Acks on an interface.
     /// (ifindex)
     DelayedAck(u32),

--- a/zebra-rs/src/ospf/neigh.rs
+++ b/zebra-rs/src/ospf/neigh.rs
@@ -56,6 +56,7 @@ pub struct NeighborDbDesc {
     pub flags: DbDescFlags,
     pub seqnum: u32,
     pub recv: OspfDbDesc,
+    pub sent: Option<OspfDbDesc>,
 }
 
 impl NeighborDbDesc {
@@ -64,6 +65,7 @@ impl NeighborDbDesc {
             flags: 0.into(),
             seqnum: 0,
             recv: OspfDbDesc::default(),
+            sent: None,
         }
     }
 }

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -182,6 +182,9 @@ pub fn ospf_nfsm_reset_nbr(nbr: &mut Neighbor) {
     // Clear Retransmit list.
     nbr.ls_rxmt.clear();
 
+    // Clear last sent DD copy so a fresh DD is built next time.
+    nbr.dd.sent = None;
+
     // Clear timers.
     nbr.timer.inactivity = None;
     nbr.timer.db_desc = None;
@@ -222,6 +225,22 @@ pub fn ospf_nfsm_timer_set(nbr: &mut Neighbor) {
             nbr.timer.ls_upd = None;
         }
     }
+}
+
+pub fn ospf_db_desc_timer(nbr: &Neighbor, retransmit_interval: u16) -> Timer {
+    let tx = nbr.tx.clone();
+    let prefix = nbr.ident.prefix;
+    let ifindex = nbr.ifindex;
+    Timer::new(
+        Timer::second(retransmit_interval as u64),
+        TimerType::Infinite,
+        move || {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send(Message::DdRetransmit(ifindex, prefix.addr()));
+            }
+        },
+    )
 }
 
 pub fn ospf_ls_req_timer(nbr: &Neighbor, retransmit_interval: u16) -> Timer {

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -200,16 +200,32 @@ pub fn ospf_db_desc_send(link: &mut OspfInterface, nbr: &mut Neighbor, oident: &
 
     ospf_packet_db_desc_set(nbr, &mut dd);
 
+    // RFC 2328 §10.8: remember the DD we sent so it can be retransmitted by
+    // the master while waiting for the slave's response, or resent by the
+    // slave when the master sends a duplicate.
+    nbr.dd.sent = Some(dd.clone());
+
+    // RFC 2328 §10.8: master retransmits its DD at RxmtInterval until acked.
+    // Slave does not retransmit on a timer; it only resends on duplicate
+    // receipt. Replacing the timer here also resets the interval whenever a
+    // fresh DD is sent.
+    if nbr.dd.flags.master() {
+        nbr.timer.db_desc = Some(super::nfsm::ospf_db_desc_timer(
+            nbr,
+            link.retransmit_interval,
+        ));
+    } else {
+        nbr.timer.db_desc = None;
+    }
+
     let packet = Ospfv2Packet::new(&oident.router_id, &area, Ospfv2Payload::DbDesc(dd));
     tracing::info!("DB_DESC: Send");
     // tracing::info!("{}", packet);
-    nbr.ptx
-        .send(Message::Send(
-            packet,
-            nbr.ifindex,
-            Some(nbr.ident.prefix.addr()),
-        ))
-        .unwrap();
+    let _ = nbr.ptx.send(Message::Send(
+        packet,
+        nbr.ifindex,
+        Some(nbr.ident.prefix.addr()),
+    ));
 }
 
 pub fn ospf_packet_ls_req_set(nbr: &mut Neighbor, ls_req: &mut OspfLsRequest) {
@@ -407,9 +423,13 @@ pub fn ospf_db_desc_recv(
         Exchange => {
             if is_dd_dup(dd, &nbr.dd.recv) {
                 if nbr.dd.flags.master() {
-                    // Packet dup (Master).
+                    // We are master, slave is repeating its previous reply.
+                    // Master ignores the dup; its own retransmit timer drives
+                    // forward progress.
                 } else {
-                    // Resend packet.
+                    // We are slave, master is retransmitting. Resend our last
+                    // DD packet (RFC 2328 §10.6).
+                    ospf_db_desc_resend(oi, nbr);
                 }
                 return;
             }
@@ -434,10 +454,36 @@ pub fn ospf_db_desc_recv(
 
             ospf_db_desc_proc(oi, nbr, dd);
         }
-        _ => {
-            //
+        Loading | Full => {
+            // RFC 2328 §10.6: in Loading or Full, the only valid DD packet
+            // from the peer is a duplicate of its last DD. Slave resends its
+            // last response; master treats any DD as a sequence-number
+            // mismatch (forcing renegotiation).
+            if is_dd_dup(dd, &nbr.dd.recv) && !nbr.dd.flags.master() {
+                ospf_db_desc_resend(oi, nbr);
+            } else {
+                nbr_sched_event(nbr, NfsmEvent::SeqNumberMismatch);
+            }
         }
     }
+}
+
+/// Resend the DD packet stored in `nbr.dd.sent`. Used by the slave on
+/// duplicate DD receipt (RFC 2328 §10.6) and by the master retransmit timer.
+fn ospf_db_desc_resend(oi: &OspfInterface, nbr: &Neighbor) {
+    let Some(ref sent) = nbr.dd.sent else {
+        return;
+    };
+    let packet = Ospfv2Packet::new(
+        &oi.ident.router_id,
+        &oi.area_id,
+        Ospfv2Payload::DbDesc(sent.clone()),
+    );
+    let _ = nbr.ptx.send(Message::Send(
+        packet,
+        nbr.ifindex,
+        Some(nbr.ident.prefix.addr()),
+    ));
 }
 
 pub fn ospf_ls_upd_send(oi: &OspfInterface, nbr: &Neighbor, lsas: Vec<OspfLsa>) {


### PR DESCRIPTION
## Summary

Three correctness gaps in the Database Description exchange:

1. **Master never retransmitted its DD.** `ospf_db_desc_send` sent the packet once and walked away. Any DD lost in flight — in particular the very first DD that drives `ExStart -> Exchange` — stalled the adjacency.
2. **Slave never resent its DD on a duplicate from the master.** The Exchange-state dup-detection branch (`packet.rs:421-428`) had a placeholder \"Resend packet\" comment with no code, so master-side retransmits never got a reply.
3. **`ospf_db_desc_recv` did nothing in Loading / Full.** RFC 2328 §10.6 requires the slave to resend its last DD in those states and the master to treat any DD as `SeqNumberMismatch`.

## Implementation

- Added `sent: Option<OspfDbDesc>` to `NeighborDbDesc` to cache the last DD we sent. Used as the source of truth for both retransmit paths.
- `ospf_db_desc_send` caches the DD before sending, and arms an `Infinite` `db_desc` retransmit timer at `RxmtInterval` only when we are master (slave never arms the timer).
- New `Message::DdRetransmit` dispatches to `process_dd_retransmit`, which self-stops the timer if the neighbor has dropped out of ExStart / Exchange or flipped to slave.
- New helper `ospf_db_desc_resend` rebuilds and sends `nbr.dd.sent` — used by the slave on duplicate DD receipt and in the Loading / Full branch.
- Loading / Full DBD reception now resends (slave) or fires `SeqNumberMismatch` (master) per §10.6.

Switched the `.unwrap()` on `Message::Send` to `let _ =` for consistency with the rest of the OSPF send paths.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo clippy -p zebra-rs --bins` clean
- [x] `cargo test -p zebra-rs --bins` — all 532 pass
- [ ] Manual: form an adjacency with a peer where DD packets are dropped intermittently; confirm master keeps retransmitting and adjacency progresses through Exchange to Full (deferred to Phase 0 verification)
- [ ] Manual: send a stray DD to a Full neighbor; confirm master tears down adjacency via `SeqNumberMismatch` instead of silently dropping

🤖 Generated with [Claude Code](https://claude.com/claude-code)