### PR TITLE
ospf: rebuild Router / Network LSA from current state on refresh

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -435,7 +435,9 @@ impl Ospf {
             return;
         }
 
-        // Handle RefreshTimerExpire: refresh in LSDB then flood to neighbors.
+        // Handle RefreshTimerExpire: rebuild the LSA from current state when
+        // a dedicated originator exists (Router / Network LSA). Otherwise
+        // fall back to cloning the old body and bumping the sequence number.
         if ev == LsdbEvent::RefreshTimerExpire {
             tracing::info!(
                 "LSDB refresh timer expired: type={} id={} adv={}",
@@ -443,7 +445,37 @@ impl Ospf {
                 ls_id,
                 adv_router
             );
-            // Refresh the LSA and clone it for flooding.
+
+            // Self-originated only. Defensive — refresh timers should only
+            // ever be armed for our own LSAs.
+            if adv_router != self.router_id {
+                return;
+            }
+
+            match ls_type {
+                OspfLsType::Router => {
+                    self.router_lsa_originate();
+                    return;
+                }
+                OspfLsType::Network => {
+                    // The Network LSA's LS-ID is the DR interface IP. Find
+                    // the matching interface and rebuild from its current
+                    // Full-adjacency set.
+                    let ifindex = self.links.iter().find_map(|(idx, link)| {
+                        link.addr
+                            .iter()
+                            .any(|a| a.prefix.addr() == ls_id)
+                            .then_some(*idx)
+                    });
+                    if let Some(ifindex) = ifindex {
+                        self.update_network_lsa_by_interface(ifindex);
+                    }
+                    return;
+                }
+                _ => {}
+            }
+
+            // Fallback: clone body, bump seq#, reinstall, then flood.
             let refreshed = {
                 let lsdb = if let Some(area_id) = area_id {
                     let Some(area) = self.areas.get_mut(area_id) else {
@@ -456,7 +488,6 @@ impl Ospf {
                 lsdb.refresh_lsa(ls_type, ls_id, adv_router, &self.tx, area_id);
                 lsdb.lookup_by_id(ls_type, ls_id, adv_router).cloned()
             };
-            // Flood the refreshed LSA to all Full neighbors in the area.
             if let Some(lsa) = refreshed
                 && let Some(area_id) = area_id
             {


### PR DESCRIPTION
## Summary

`Lsdb::refresh_lsa` (`lsdb.rs:260-282`) clones the existing LSA body and just bumps the sequence number / resets `ls_age`. That's fine for opaque or summary LSAs whose contents are driven entirely by an explicit re-originate call, but it's wrong for Router and Network LSAs whose body must reflect the live interface and adjacency state.

If anything changed since the last event-driven origination — an adjacency that came up without propagating, an interface metric tweak, a link state change that didn't trigger re-origination — the 30-minute refresh would re-flood stale content.

## Implementation

In the `RefreshTimerExpire` path of `process_lsdb` (`inst.rs:438+`), dispatch on the LSA type and call the dedicated rebuilder when one exists:

- **Router LSA**: `router_lsa_originate` — already rebuilds from scratch via `router_lsa_build`.
- **Network LSA**: locate the owning interface via the LS-ID (which is the DR interface IP) and call `update_network_lsa_by_interface`, which walks the current Full-adjacency set.
- **Other types** fall back to the existing clone+bump path — their refresh hasn't been wired to an originator yet (tracked as separate work, including opaque LSA refresh).

Also defends against refreshing a non-self-originated LSA (a refresh timer should never be armed for one, but the check is cheap).

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo clippy -p zebra-rs --bins` clean
- [x] `cargo test -p zebra-rs --bins` — all 532 pass
- [ ] Manual: bring up adjacency, wait 30 min for Router LSA refresh, confirm rebuilt body matches current link state (deferred to Phase 0 verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)