### PR TITLE
bgp: parse and emit Tunnel Encapsulation attribute (type 23, RFC 9012)

### DIFF
--- a/crates/bgp-packet/src/attrs/attr.rs
+++ b/crates/bgp-packet/src/attrs/attr.rs
@@ -30,6 +30,7 @@ pub enum AttrType {
     Aigp = 26,
     LargeCom = 32,
     PrefixSid = 40,
+    TunnelEncap = 23,
     Unknown(u8),
 }
 
@@ -55,6 +56,7 @@ impl From<u8> for AttrType {
             26 => Aigp,
             32 => LargeCom,
             40 => PrefixSid,
+            23 => TunnelEncap,
             v => Unknown(v),
         }
     }
@@ -82,6 +84,7 @@ impl From<AttrType> for u8 {
             Aigp => 26,
             LargeCom => 32,
             PrefixSid => 40,
+            TunnelEncap => 23,
             Unknown(v) => v,
         }
     }
@@ -130,6 +133,8 @@ pub enum Attr {
     LargeCom(LargeCommunity),
     #[nom(Selector = "AttrSelector(AttrType::PrefixSid, None)")]
     PrefixSid(PrefixSid),
+    #[nom(Selector = "AttrSelector(AttrType::TunnelEncap, None)")]
+    TunnelEncap(TunnelEncap),
 }
 
 impl Attr {
@@ -152,6 +157,7 @@ impl Attr {
             Attr::LargeCom(v) => v.attr_emit(buf),
             Attr::Aigp(v) => v.attr_emit(buf),
             Attr::PrefixSid(v) => v.attr_emit(buf),
+            Attr::TunnelEncap(v) => v.attr_emit(buf),
             _ => {
                 //
             }
@@ -180,6 +186,7 @@ impl fmt::Display for Attr {
             Attr::LargeCom(v) => write!(f, "{}", v),
             Attr::Aigp(v) => write!(f, "{}", v),
             Attr::PrefixSid(v) => write!(f, "{}", v),
+            Attr::TunnelEncap(v) => write!(f, "{}", v),
             _ => write!(f, "Unknown"),
         }
     }
@@ -206,6 +213,7 @@ impl fmt::Debug for Attr {
             Attr::LargeCom(v) => write!(f, "{:?}", v),
             Attr::Aigp(v) => write!(f, "{:?}", v),
             Attr::PrefixSid(v) => write!(f, "{:?}", v),
+            Attr::TunnelEncap(v) => write!(f, "{:?}", v),
             _ => write!(f, "Unknown"),
         }
     }
@@ -392,6 +400,9 @@ pub fn parse_bgp_update_attribute(
             }
             Attr::PrefixSid(v) => {
                 bgp_attr.prefix_sid = Some(v);
+            }
+            Attr::TunnelEncap(v) => {
+                bgp_attr.tunnel_encap = Some(v);
             }
         }
         remaining = new_remaining;

--- a/crates/bgp-packet/src/attrs/mod.rs
+++ b/crates/bgp-packet/src/attrs/mod.rs
@@ -64,6 +64,9 @@ pub use pmsi_tunnel::*;
 pub mod prefix_sid;
 pub use prefix_sid::*;
 
+pub mod tunnel_encap;
+pub use tunnel_encap::*;
+
 pub mod mp_reach;
 pub use mp_reach::*;
 

--- a/crates/bgp-packet/src/attrs/tunnel_encap.rs
+++ b/crates/bgp-packet/src/attrs/tunnel_encap.rs
@@ -1,0 +1,315 @@
+use std::fmt;
+
+use bytes::{BufMut, BytesMut};
+use nom::IResult;
+use nom::number::complete::{be_u8, be_u16};
+
+use crate::{AttrType, ParseBe};
+
+use super::{AttrEmitter, AttrFlags};
+
+/// BGP Tunnel Encapsulation path attribute (type 23, RFC 9012).
+///
+/// Carries an ordered list of Tunnel TLVs; each TLV nests an ordered
+/// list of Sub-TLVs whose length-field width depends on the Sub-TLV
+/// Type (1 octet when type < 128, 2 octets when type >= 128, per
+/// RFC 9012 §3.1). v1 decodes the framing structurally and leaves
+/// Sub-TLV values as opaque bytes — type-specific decoders
+/// (Preference, Remote-Endpoint, Binding-SID, Segment List, …) land
+/// in follow-up PRs alongside the consumers that need them.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct TunnelEncap {
+    pub tunnels: Vec<TunnelTlv>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TunnelTlv {
+    /// IANA Tunnel Type registry — 13 = MPLS-in-GRE, 15 = SR Policy,
+    /// etc. Unknown values are preserved verbatim and propagated.
+    pub tunnel_type: u16,
+    pub sub_tlvs: Vec<TunnelSubTlv>,
+}
+
+/// Opaque sub-TLV. Type-specific decoding (Color, Preference,
+/// Remote-Endpoint, Binding-SID, Segment List, Policy-Name,
+/// Policy-Candidate-Path-Name, ...) is the next layer of work.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TunnelSubTlv {
+    pub typ: u8,
+    pub value: Vec<u8>,
+}
+
+impl ParseBe<TunnelEncap> for TunnelEncap {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], TunnelEncap> {
+        let mut remaining = input;
+        let mut tunnels = Vec::new();
+        while !remaining.is_empty() {
+            let (rest, tunnel_type) = be_u16(remaining)?;
+            let (rest, len) = be_u16(rest)?;
+            let (rest, value) = nom::bytes::complete::take(len as usize)(rest)?;
+            let (_, sub_tlvs) = parse_sub_tlvs(value)?;
+            tunnels.push(TunnelTlv {
+                tunnel_type,
+                sub_tlvs,
+            });
+            remaining = rest;
+        }
+        Ok((remaining, TunnelEncap { tunnels }))
+    }
+}
+
+/// Walk a Tunnel TLV's value bytes, peeling off sub-TLVs whose length
+/// width depends on the type code (RFC 9012 §3.1).
+fn parse_sub_tlvs(input: &[u8]) -> IResult<&[u8], Vec<TunnelSubTlv>> {
+    let mut remaining = input;
+    let mut out = Vec::new();
+    while !remaining.is_empty() {
+        let (rest, typ) = be_u8(remaining)?;
+        let (rest, len) = if typ < 128 {
+            let (r, l) = be_u8(rest)?;
+            (r, l as u16)
+        } else {
+            be_u16(rest)?
+        };
+        let (rest, value) = nom::bytes::complete::take(len as usize)(rest)?;
+        out.push(TunnelSubTlv {
+            typ,
+            value: value.to_vec(),
+        });
+        remaining = rest;
+    }
+    Ok((remaining, out))
+}
+
+impl TunnelEncap {
+    fn encoded_len(&self) -> usize {
+        self.tunnels.iter().map(tunnel_encoded_len).sum()
+    }
+}
+
+fn tunnel_encoded_len(tunnel: &TunnelTlv) -> usize {
+    // Tunnel header: 2 (type) + 2 (length) = 4.
+    4 + tunnel.sub_tlvs.iter().map(sub_encoded_len).sum::<usize>()
+}
+
+fn sub_encoded_len(sub: &TunnelSubTlv) -> usize {
+    let header = if sub.typ < 128 { 2 } else { 3 };
+    header + sub.value.len()
+}
+
+fn emit_sub_tlv(buf: &mut BytesMut, sub: &TunnelSubTlv) {
+    buf.put_u8(sub.typ);
+    if sub.typ < 128 {
+        buf.put_u8(sub.value.len() as u8);
+    } else {
+        buf.put_u16(sub.value.len() as u16);
+    }
+    buf.put(&sub.value[..]);
+}
+
+fn emit_tunnel(buf: &mut BytesMut, tunnel: &TunnelTlv) {
+    buf.put_u16(tunnel.tunnel_type);
+    let body_len: usize = tunnel.sub_tlvs.iter().map(sub_encoded_len).sum();
+    buf.put_u16(body_len as u16);
+    for sub in &tunnel.sub_tlvs {
+        emit_sub_tlv(buf, sub);
+    }
+}
+
+impl AttrEmitter for TunnelEncap {
+    fn attr_flags(&self) -> AttrFlags {
+        // RFC 9012 §2: Optional Transitive.
+        AttrFlags::new().with_optional(true).with_transitive(true)
+    }
+
+    fn attr_type(&self) -> AttrType {
+        AttrType::TunnelEncap
+    }
+
+    fn len(&self) -> Option<usize> {
+        Some(self.encoded_len())
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        for tunnel in &self.tunnels {
+            emit_tunnel(buf, tunnel);
+        }
+    }
+}
+
+impl fmt::Display for TunnelEncap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TunnelEncap[")?;
+        for (i, t) in self.tunnels.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "type={} subs={}", t.tunnel_type, t.sub_tlvs.len())?;
+        }
+        write!(f, "]")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn round_trip(orig: TunnelEncap) -> TunnelEncap {
+        let mut buf = BytesMut::new();
+        orig.emit(&mut buf);
+        let bytes: Vec<u8> = buf.to_vec();
+        let (rest, parsed) = TunnelEncap::parse_be(&bytes).expect("parse");
+        assert!(rest.is_empty(), "trailing bytes after parse");
+        parsed
+    }
+
+    #[test]
+    fn empty_attribute_parses_to_empty_list() {
+        let (rest, parsed) = TunnelEncap::parse_be(&[]).expect("empty");
+        assert!(rest.is_empty());
+        assert!(parsed.tunnels.is_empty());
+    }
+
+    #[test]
+    fn one_tunnel_with_no_sub_tlvs_round_trips() {
+        // Tunnel-Type 15 (SR Policy) with no sub-TLVs.
+        let enc = TunnelEncap {
+            tunnels: vec![TunnelTlv {
+                tunnel_type: 15,
+                sub_tlvs: vec![],
+            }],
+        };
+        assert_eq!(round_trip(enc.clone()), enc);
+    }
+
+    #[test]
+    fn short_sub_tlv_uses_one_byte_length() {
+        // Sub-TLV type 4 (Color, < 128) → 1-octet length field.
+        let enc = TunnelEncap {
+            tunnels: vec![TunnelTlv {
+                tunnel_type: 15,
+                sub_tlvs: vec![TunnelSubTlv {
+                    typ: 4,
+                    value: vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x64],
+                }],
+            }],
+        };
+        let mut buf = BytesMut::new();
+        enc.emit(&mut buf);
+        let bytes: Vec<u8> = buf.to_vec();
+        // Layout: tunnel_type(2) + tlen(2) + sub_type(1) + sub_len(1) + value(8) = 14
+        assert_eq!(bytes.len(), 14);
+        // Sub-TLV header at offset 4: type=4, then 1-octet length=8.
+        assert_eq!(bytes[4], 4);
+        assert_eq!(bytes[5], 8);
+        assert_eq!(round_trip(enc.clone()), enc);
+    }
+
+    #[test]
+    fn long_sub_tlv_uses_two_byte_length() {
+        // Sub-TLV type 128 (Segment List, >= 128) → 2-octet length.
+        let payload = vec![0xab; 300];
+        let enc = TunnelEncap {
+            tunnels: vec![TunnelTlv {
+                tunnel_type: 15,
+                sub_tlvs: vec![TunnelSubTlv {
+                    typ: 128,
+                    value: payload.clone(),
+                }],
+            }],
+        };
+        let mut buf = BytesMut::new();
+        enc.emit(&mut buf);
+        let bytes: Vec<u8> = buf.to_vec();
+        // Sub-TLV header at offset 4: type=128, then 2-octet length=300.
+        assert_eq!(bytes[4], 128);
+        let len_field = u16::from_be_bytes([bytes[5], bytes[6]]);
+        assert_eq!(len_field, 300);
+        assert_eq!(round_trip(enc.clone()), enc);
+    }
+
+    #[test]
+    fn multiple_tunnels_with_mixed_sub_tlvs_preserve_order() {
+        let enc = TunnelEncap {
+            tunnels: vec![
+                TunnelTlv {
+                    tunnel_type: 13, // MPLS-in-GRE
+                    sub_tlvs: vec![TunnelSubTlv {
+                        typ: 6, // Preference
+                        value: vec![0, 0, 0, 0, 0x07, 0xd0],
+                    }],
+                },
+                TunnelTlv {
+                    tunnel_type: 15, // SR Policy
+                    sub_tlvs: vec![
+                        TunnelSubTlv {
+                            typ: 12, // Remote-Endpoint
+                            value: vec![0, 0, 0xfd, 0xe8, 0, 1, 192, 0, 2, 1],
+                        },
+                        TunnelSubTlv {
+                            typ: 128, // Segment List
+                            value: vec![0xde, 0xad, 0xbe, 0xef],
+                        },
+                    ],
+                },
+            ],
+        };
+        let rt = round_trip(enc.clone());
+        assert_eq!(rt, enc);
+        assert_eq!(rt.tunnels.len(), 2);
+        assert_eq!(rt.tunnels[0].tunnel_type, 13);
+        assert_eq!(rt.tunnels[1].sub_tlvs.len(), 2);
+        assert_eq!(rt.tunnels[1].sub_tlvs[0].typ, 12);
+        assert_eq!(rt.tunnels[1].sub_tlvs[1].typ, 128);
+    }
+
+    #[test]
+    fn unknown_tunnel_type_round_trips_verbatim() {
+        let enc = TunnelEncap {
+            tunnels: vec![TunnelTlv {
+                tunnel_type: 9999,
+                sub_tlvs: vec![TunnelSubTlv {
+                    typ: 200,
+                    value: vec![0x01, 0x02, 0x03],
+                }],
+            }],
+        };
+        assert_eq!(round_trip(enc.clone()), enc);
+    }
+
+    #[test]
+    fn truncated_tunnel_length_is_rejected() {
+        // Tunnel claims length 10 but only 5 bytes of value follow.
+        let bytes: Vec<u8> = vec![
+            0, 15, // tunnel_type
+            0, 10, // length 10
+            0xaa, 0xbb, 0xcc, 0xdd, 0xee, // only 5 bytes
+        ];
+        assert!(TunnelEncap::parse_be(&bytes).is_err());
+    }
+
+    #[test]
+    fn truncated_short_sub_tlv_length_is_rejected() {
+        let bytes: Vec<u8> = vec![
+            0, 15, // tunnel_type
+            0, 4, // tlen = 4
+            4, // sub type (short)
+            6, // sub len 6
+            0xaa, 0xbb, // only 2 bytes
+        ];
+        assert!(TunnelEncap::parse_be(&bytes).is_err());
+    }
+
+    #[test]
+    fn long_sub_tlv_with_short_header_field_underrun_rejected() {
+        // Sub-TLV type 200 requires a 2-octet length field but only
+        // 1 byte after the type is present.
+        let bytes: Vec<u8> = vec![
+            0, 15, // tunnel_type
+            0, 2,   // tlen = 2
+            200, // type
+            0,   // truncated length byte
+        ];
+        assert!(TunnelEncap::parse_be(&bytes).is_err());
+    }
+}

--- a/crates/bgp-packet/src/bgp_attr.rs
+++ b/crates/bgp-packet/src/bgp_attr.rs
@@ -5,7 +5,7 @@ use bytes::BytesMut;
 use crate::{
     Aggregator, Aigp, As4Path, AtomicAggregate, AttrEmitter, BgpNexthop, ClusterList, Community,
     ExtCommunity, LargeCommunity, LocalPref, Med, NexthopAttr, Origin, OriginatorId, PmsiTunnel,
-    PrefixSid,
+    PrefixSid, TunnelEncap,
 };
 
 // BGP Attribute for quick access to each attribute. This would be used for
@@ -44,6 +44,12 @@ pub struct BgpAttr {
     /// the RFC 9252 SRv6 Service TLVs. Parse-only for v1; semantics
     /// land in follow-up PRs (SR-MPLS labeled unicast, SRv6 services).
     pub prefix_sid: Option<PrefixSid>,
+    /// BGP Tunnel Encapsulation (RFC 9012). Carries SR Policy
+    /// candidate-path encoding (Color, Preference, Binding-SID,
+    /// Segment List, ...) and other tunnel endpoint signalling.
+    /// Sub-TLV bodies are opaque in v1; structural framing is bit-
+    /// exact for forward-propagation.
+    pub tunnel_encap: Option<TunnelEncap>,
     // TODO: Unknown Attributes.
 }
 
@@ -106,6 +112,9 @@ impl BgpAttr {
         if let Some(v) = &self.prefix_sid {
             v.attr_emit(buf);
         }
+        if let Some(v) = &self.tunnel_encap {
+            v.attr_emit(buf);
+        }
     }
 
     pub fn neighboring_as(&self) -> Option<u32> {
@@ -158,6 +167,9 @@ impl fmt::Display for BgpAttr {
         }
         if let Some(v) = &self.prefix_sid {
             writeln!(f, " PrefixSid: {}", v)?;
+        }
+        if let Some(v) = &self.tunnel_encap {
+            writeln!(f, " TunnelEncap: {}", v)?;
         }
         // Nexthop
         if let Some(v) = &self.nexthop {


### PR DESCRIPTION
## Summary

Adds \`TunnelEncap\` path-attribute codec covering the RFC 9012 structural framing — a list of Tunnel TLVs, each carrying a 16-bit Tunnel Type and an ordered list of Sub-TLVs whose length field is **1 octet when Sub-TLV Type < 128** and **2 octets when >= 128** (§3.1).

Sub-TLV bodies stay opaque in v1; type-specific decoders (Preference, Remote-Endpoint, Binding-SID, Segment List, Policy-Name, Policy-Candidate-Path-Name) land in follow-up PRs alongside the consumers that need them. The structural codec is the load-bearing piece for forward-propagation.

Wired into the existing attribute dispatch:
- \`AttrType::TunnelEncap = 23\` in both \`From<u8>\` / \`From<AttrType>\` arms.
- \`Attr::TunnelEncap(TunnelEncap)\` variant with NomBE selector + emit / Display / Debug arms.
- \`BgpAttr::tunnel_encap\` field, included in \`attr_emit\` + \`Display\`.

Attribute flags default to Optional + Transitive per RFC 9012 §2.

## Test plan

- [x] 9 unit tests cover: empty attribute, tunnel with no sub-TLVs, short sub-TLV (type < 128) using 1-octet length, long sub-TLV (type >= 128) using 2-octet length, multiple tunnels with mixed sub-TLVs, unknown tunnel type verbatim round-trip, truncated tunnel length rejection, truncated short / long sub-TLV length rejection.
- [x] All bgp-packet tests pass, 126 zebra-rs::bgp tests pass — no regressions.
- [x] \`cargo fmt --check\` clean.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.

## Roadmap status after this PR

- ✅ IS-IS Phase 0 — peer_algos cache, SPF gating, per-algo RIB + MPLS LFIB, show commands (#670/#675/#679/#681).
- ✅ BGP Phase 1.1 — Prefix-SID attribute codec (#683).
- ✅ BGP Phase 1.2 — Tunnel Encapsulation attribute codec ← this PR.
- ⏭️ BGP Phase 1.3 — Color extended community (\`0x03 0x0b\`) decode in \`ext_com.rs\`. ~80 lines.

Generated with [Claude Code](https://claude.com/claude-code)