### PR TITLE
bgp: decode BGP Color extended community (0x03 0x0b, RFC 9012 §4.3)

### DIFF
--- a/crates/bgp-packet/src/attrs/ext_com.rs
+++ b/crates/bgp-packet/src/attrs/ext_com.rs
@@ -28,6 +28,65 @@ impl ExtCommunityValue {
         buf.put_u8(self.low_type);
         buf.put(&self.val[..]);
     }
+
+    /// True iff this entry encodes a Color extended community
+    /// (RFC 9012 §4.3): Transitive Opaque (0x03) + Color sub-type
+    /// (0x0b).
+    pub fn is_color(&self) -> bool {
+        self.high_type == ExtCommunityType::TransOpaque as u8
+            && self.low_type == ExtCommunitySubType::Color as u8
+    }
+
+    /// Decode the Color value if this entry is a Color extcomm.
+    /// Returns the 2-octet Flags field (CO bits live in the top two
+    /// bits, see draft-ietf-idr-bgp-ct §3.2.1) and the 4-octet color
+    /// identifier. Returns None for any other extcomm type.
+    pub fn as_color(&self) -> Option<Color> {
+        if !self.is_color() {
+            return None;
+        }
+        let flags = u16::from_be_bytes([self.val[0], self.val[1]]);
+        let color = u32::from_be_bytes([self.val[2], self.val[3], self.val[4], self.val[5]]);
+        Some(Color { flags, color })
+    }
+
+    /// Build a Color extended community. `co_bits` is the 2-bit
+    /// CO-bits field that occupies the top of the 16-bit Flags word;
+    /// any value > 3 is masked to the low two bits.
+    pub fn from_color(co_bits: u8, color: u32) -> Self {
+        let flags: u16 = ((co_bits as u16) & 0b11) << 14;
+        Color { flags, color }.into()
+    }
+}
+
+/// Decoded Color extended community (RFC 9012 §4.3). `flags` is the
+/// raw 16-bit field; `co_bits` is the top two bits per
+/// draft-ietf-idr-bgp-ct §3.2.1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Color {
+    pub flags: u16,
+    pub color: u32,
+}
+
+impl Color {
+    /// CO bits per draft-ietf-idr-bgp-ct §3.2.1: 00 default, 01 any
+    /// transport supporting color, 10 SR-aware transport, 11 reserved.
+    pub fn co_bits(self) -> u8 {
+        ((self.flags >> 14) & 0b11) as u8
+    }
+}
+
+impl From<Color> for ExtCommunityValue {
+    fn from(c: Color) -> Self {
+        let mut val = [0u8; 6];
+        val[0..2].copy_from_slice(&c.flags.to_be_bytes());
+        val[2..6].copy_from_slice(&c.color.to_be_bytes());
+        ExtCommunityValue {
+            high_type: ExtCommunityType::TransOpaque as u8,
+            low_type: ExtCommunitySubType::Color as u8,
+            val,
+        }
+    }
 }
 
 impl fmt::Display for ExtCommunityValue {
@@ -42,6 +101,13 @@ impl fmt::Display for ExtCommunityValue {
                 ExtCommunitySubType::display(self.low_type)
             )
         } else if self.high_type == TransOpaque as u8 {
+            // Color extcomm (RFC 9012 §4.3) has its own 2-octet flags
+            // + 4-octet color layout; surface that when it's set,
+            // otherwise fall back to the generic tunnel-type / opaque
+            // rendering.
+            if let Some(c) = self.as_color() {
+                return write!(f, "color:{}:{}", c.co_bits(), c.color);
+            }
             let ip = Ipv4Addr::new(self.val[0], self.val[1], self.val[2], self.val[3]);
             let val = u16::from_be_bytes([self.val[4], self.val[5]]);
             if let Ok(tunnel_type) = TunnelType::try_from(val) {
@@ -194,5 +260,78 @@ mod tests {
 
         let ecom: ExtCommunity = ExtCommunity::from_str("soo 1.2.3.4:200").unwrap();
         assert_eq!(ecom.to_string(), "soo:1.2.3.4:200");
+    }
+
+    #[test]
+    fn color_from_constructor_round_trips_decode() {
+        let c = ExtCommunityValue::from_color(0b10, 100);
+        assert!(c.is_color());
+        let decoded = c.as_color().expect("color decode");
+        assert_eq!(decoded.color, 100);
+        assert_eq!(decoded.co_bits(), 0b10);
+        // Top two bits of Flags carry the CO-bits.
+        assert_eq!(decoded.flags & 0xc000, 0b10 << 14);
+    }
+
+    #[test]
+    fn color_wire_layout_is_type_subtype_flags_color() {
+        let c = ExtCommunityValue::from_color(0, 0x0000_002a);
+        // [0x03, 0x0b, flags_hi=0, flags_lo=0, color bytes...]
+        assert_eq!(c.high_type, 0x03);
+        assert_eq!(c.low_type, 0x0b);
+        assert_eq!(c.val, [0, 0, 0, 0, 0, 0x2a]);
+    }
+
+    #[test]
+    fn color_co_bits_mask_to_two_bits() {
+        // CO=0b11 — explicit max value.
+        let c = ExtCommunityValue::from_color(0b11, 7);
+        assert_eq!(c.as_color().unwrap().co_bits(), 0b11);
+        // Values above 3 mask down — guards constructor callers that
+        // forget the field is only 2 bits wide.
+        let c = ExtCommunityValue::from_color(0b1111_0010, 7);
+        assert_eq!(c.as_color().unwrap().co_bits(), 0b10);
+    }
+
+    #[test]
+    fn is_color_false_for_rt_and_soo() {
+        let rt: ExtCommunity = ExtCommunity::from_str("rt:100:200").unwrap();
+        let soo: ExtCommunity = ExtCommunity::from_str("soo:1.2.3.4:200").unwrap();
+        assert!(!rt.0[0].is_color());
+        assert!(!soo.0[0].is_color());
+        assert!(rt.0[0].as_color().is_none());
+        assert!(soo.0[0].as_color().is_none());
+    }
+
+    #[test]
+    fn color_renders_in_display() {
+        let c = ExtCommunityValue::from_color(0b01, 4242);
+        assert_eq!(c.to_string(), "color:1:4242");
+    }
+
+    #[test]
+    fn color_round_trips_through_attribute_emit_parse() {
+        // Build an ExtCommunity attribute with one Color value,
+        // round-trip the wire bytes through emit, parse the raw 8
+        // octets back, and assert decode matches.
+        let original = ExtCommunityValue::from_color(0b10, 128);
+        let ecom = ExtCommunity(vec![original.clone()]);
+        let mut buf = BytesMut::new();
+        ecom.emit(&mut buf);
+        let bytes: Vec<u8> = buf.to_vec();
+        assert_eq!(bytes.len(), 8);
+        // Re-build the ExtCommunityValue from raw bytes to confirm
+        // wire layout matches our constructor.
+        let mut val = [0u8; 6];
+        val.copy_from_slice(&bytes[2..8]);
+        let parsed = ExtCommunityValue {
+            high_type: bytes[0],
+            low_type: bytes[1],
+            val,
+        };
+        assert_eq!(parsed, original);
+        let c = parsed.as_color().unwrap();
+        assert_eq!(c.color, 128);
+        assert_eq!(c.co_bits(), 0b10);
     }
 }

--- a/crates/bgp-packet/src/attrs/ext_com_type.rs
+++ b/crates/bgp-packet/src/attrs/ext_com_type.rs
@@ -28,6 +28,10 @@ pub enum ExtCommunitySubType {
     RouteTarget = 0x02,
     #[strum(serialize = "soo")]
     RouteOrigin = 0x03,
+    /// RFC 9012 §4.3 Color extended community. Sub-Type 0x0b when
+    /// carried inside Transitive Opaque extcomm type 0x03.
+    #[strum(serialize = "color")]
+    Color = 0x0b,
     #[strum(serialize = "opqque")]
     Opaque = 0x0c,
 }


### PR DESCRIPTION
## Summary

Adds the Color extended community as a structured decoder layered on the existing flat \`ExtCommunityValue\` model. No struct surgery — the wire form (Transitive Opaque + Sub-Type 0x0b + 2-octet Flags + 4-octet Color) is detected by \`is_color()\` and decoded into a small \`Color\` helper with a \`co_bits()\` accessor for the top two bits of the Flags field (draft-ietf-idr-bgp-ct §3.2.1).

Plumbing:
- \`ExtCommunitySubType::Color = 0x0b\` added so generic \`Display\` sees the right name when the typed branch is skipped.
- \`ExtCommunityValue::from_color(co_bits, color)\` constructor masks CO-bits to the low two bits before shifting into Flags.
- \`Display\` renders \`color:<co_bits>:<value>\` instead of the generic ip:val fallback when the entry is a Color extcomm.

No semantics yet — route-map match/set and color-aware NHT against IS-IS per-algo SPF land in Phase 2.

## Test plan

- [x] 6 new unit tests cover round-trip via constructor, wire layout, CO-bits masking, is_color negative cases, Display rendering, end-to-end emit→raw→parse→decode.
- [x] All 8 ext_com tests + 126 zebra-rs::bgp tests pass.
- [x] \`cargo fmt --check\` clean.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.

## Roadmap

- BGP Phase 1 codec layer complete: Prefix-SID (#683), Tunnel-Encap (#684), Color extcomm (this PR).
- Next: Phase 2 — route-map plumbing + color→algo binding + receive-side ingest.

Generated with [Claude Code](https://claude.com/claude-code)