### PR TITLE
bgp: stage color → flex-algorithm binding table

### DIFF
--- a/zebra-rs/src/bgp/color_policy.rs
+++ b/zebra-rs/src/bgp/color_policy.rs
@@ -1,0 +1,123 @@
+//! Color → Flex-Algorithm binding table (zebra-bgp-color-policy.yang).
+//!
+//! Maps a BGP Color extended community value (RFC 9012 §4.3) to an
+//! IS-IS Flex-Algorithm id (RFC 9350) so the color-aware nexthop
+//! resolver (Phase 3 of the BGP ↔ Flex-Algo plan) can pick the
+//! correct entry in `Isis::rib_flex_algo`.
+//!
+//! This module is storage-only on landing — no consumer reads
+//! `Bgp::color_policy` yet. Config callbacks stage / commit edits
+//! against the live map; the resolver wires in alongside the route-
+//! map work in a subsequent PR.
+
+use std::collections::BTreeMap;
+
+use crate::config::{Args, ConfigOp};
+
+use super::Bgp;
+
+/// Live color → flex-algorithm binding table. Wrapped in a struct so
+/// future fields (per-entry strict / fallback knobs, source attribution
+/// for show output) have a stable home without touching every call
+/// site.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ColorPolicy {
+    /// Color value (RFC 9012 §4.3, 0..2^32-1) → Flex-Algorithm id
+    /// (128..=255 per RFC 9350 §4). Multiple colors may map to the
+    /// same algorithm.
+    pub bindings: BTreeMap<u32, u8>,
+}
+
+impl ColorPolicy {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Look up the flex-algorithm currently bound to `color`. Returns
+    /// `None` when no binding is configured — the caller decides
+    /// whether to fall back (RFC 9256 §2.5) or treat the resolution
+    /// as unreachable.
+    #[allow(dead_code)]
+    pub fn flex_algo_for(&self, color: u32) -> Option<u8> {
+        self.bindings.get(&color).copied()
+    }
+}
+
+/// `set router bgp color-policy color <N>` (and `delete ...`).
+///
+/// The presence of the list entry is what matters; the
+/// flex-algorithm leaf below carries the value. A Set with no
+/// flex-algorithm leaf simply ensures the slot exists with the
+/// default placeholder (no algorithm yet → no resolution).
+pub fn config_color(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let color = args.u32()?;
+    match op {
+        ConfigOp::Set => {
+            // Insert-if-missing — preserves any flex-algorithm value
+            // set by a separate leaf callback in the same commit.
+            bgp.color_policy.bindings.entry(color).or_insert(0);
+        }
+        ConfigOp::Delete => {
+            bgp.color_policy.bindings.remove(&color);
+        }
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp color-policy color <N> flex-algorithm <M>` (and
+/// `delete ...`).
+pub fn config_color_flex_algorithm(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let color = args.u32()?;
+    match op {
+        ConfigOp::Set => {
+            let algo = args.u8()?;
+            // YANG already constrains 128..=255 — defensive guard
+            // here too so unit tests that bypass YANG don't smuggle
+            // out-of-range values into the resolver.
+            if !(128..=255).contains(&algo) {
+                return None;
+            }
+            bgp.color_policy.bindings.insert(color, algo);
+        }
+        ConfigOp::Delete => {
+            // Per-leaf delete clears the algorithm but keeps the
+            // color slot present (matches how peer-level leaf deletes
+            // behave elsewhere). The color slot itself is removed by
+            // `config_color` with op=Delete.
+            if let Some(slot) = bgp.color_policy.bindings.get_mut(&color) {
+                *slot = 0;
+            }
+        }
+        _ => {}
+    }
+    Some(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flex_algo_for_returns_none_when_unbound() {
+        let p = ColorPolicy::new();
+        assert!(p.flex_algo_for(100).is_none());
+    }
+
+    #[test]
+    fn flex_algo_for_returns_bound_value() {
+        let mut p = ColorPolicy::new();
+        p.bindings.insert(100, 128);
+        assert_eq!(p.flex_algo_for(100), Some(128));
+        assert!(p.flex_algo_for(101).is_none());
+    }
+
+    #[test]
+    fn multiple_colors_can_map_to_same_algo() {
+        let mut p = ColorPolicy::new();
+        p.bindings.insert(100, 128);
+        p.bindings.insert(200, 128);
+        assert_eq!(p.flex_algo_for(100), Some(128));
+        assert_eq!(p.flex_algo_for(200), Some(128));
+    }
+}

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1515,6 +1515,18 @@ impl Bgp {
             "/router/bgp/dynamic-neighbors/listen-range/neighbor-group",
             super::dynamic_neighbors::config_listen_range_neighbor_group,
         );
+        // `set router bgp color-policy color <N> [flex-algorithm <M>]`
+        // (zebra-bgp-color-policy.yang). Storage-only on landing —
+        // the consumer is the color-aware nexthop resolver that lands
+        // in a follow-up PR.
+        self.callback_add(
+            "/router/bgp/color-policy/color",
+            super::color_policy::config_color,
+        );
+        self.callback_add(
+            "/router/bgp/color-policy/color/flex-algorithm",
+            super::color_policy::config_color_flex_algorithm,
+        );
         // `set router bgp vrf <name> [...]` (zebra-bgp-vrf.yang).
         // Staging-only in step 12: the callbacks populate
         // `Bgp::vrfs` and the CommitEnd hook in `process_cm_msg`

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -194,6 +194,13 @@ pub struct Bgp {
     /// `PeerConfig::neighbor_group` is not wired in the runtime
     /// yet — that lands in a follow-up.
     pub neighbor_groups: BTreeMap<String, super::neighbor_group::NeighborGroup>,
+
+    /// Color → Flex-Algorithm binding table
+    /// (zebra-bgp-color-policy.yang). Storage-only on landing — the
+    /// color-aware nexthop resolver (Phase 3 of the BGP ↔ Flex-Algo
+    /// plan) reads this to pick a per-algo entry from
+    /// `Isis::rib_flex_algo` when a route carries a Color extcomm.
+    pub color_policy: super::color_policy::ColorPolicy,
     /// `dynamic-neighbors` runtime (zebra-bgp-dynamic-neighbors.yang).
     /// Holds the configured listen-ranges and the soft cap on
     /// materialized passive peers. `dynamic_peer_count` is bumped on
@@ -387,6 +394,7 @@ impl Bgp {
             listen_fd_v6: None,
             key_chains: HashMap::new(),
             neighbor_groups: super::neighbor_group::empty_map(),
+            color_policy: super::color_policy::ColorPolicy::new(),
             dynamic_neighbors: super::dynamic_neighbors::DynamicNeighbors::default(),
             dynamic_peer_count: 0,
             interface_neighbors: super::interface_neighbor::empty_map(),

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -19,6 +19,8 @@ pub mod update_group;
 pub mod vrf;
 pub mod vrf_config;
 
+pub mod color_policy;
+
 pub mod cap;
 
 pub mod tracing;

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -56,6 +56,10 @@ module config {
     prefix zbb;
   }
 
+  import zebra-bgp-color-policy {
+    prefix zbcp;
+  }
+
   import zebra-bgp-soft-reconfiguration {
     prefix zbsr;
   }

--- a/zebra-rs/yang/zebra-bgp-color-policy.yang
+++ b/zebra-rs/yang/zebra-bgp-color-policy.yang
@@ -1,0 +1,108 @@
+module zebra-bgp-color-policy {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-color-policy";
+  prefix "zbcp";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "Color → Flex-Algorithm binding table for BGP. Maps a value of the
+     BGP Color Extended Community (RFC 9012 §4.3, type 0x03 0x0b) to
+     an IS-IS Flexible Algorithm identifier (RFC 9350) so the
+     resolver can pick the correct per-algorithm SR-MPLS LFIB entry
+     for routes carrying that color.
+
+     Example:
+
+       router bgp {
+         color-policy {
+           color 100 { flex-algorithm 128; }
+           color 200 { flex-algorithm 129; }
+         }
+       }
+
+     Multiple Color values may map to the same flex-algorithm
+     (RFC 9256 §2.5 fallback ordering); the mapping lives BGP-local —
+     IS-IS does not learn about BGP color. Schema-only on landing;
+     color-aware nexthop resolution against the IS-IS per-algo SPF
+     follows in a later PR.";
+
+  revision 2026-05-21 {
+    description
+      "Initial revision — color → flex-algorithm map. Storage on
+       `Bgp::color_policy`. No consumer in the runtime yet; the
+       resolver (Phase 3 of the BGP ↔ IS-IS Flex-Algo plan)
+       converts a route's Color list into an algo to look up in
+       `Isis::rib_flex_algo`.";
+    reference
+      "RFC 9012 §4.3 (Color extended community),
+       RFC 9256 §2.5 (SR Policy color-only fallback),
+       RFC 9350 (IGP Flexible Algorithm).";
+  }
+
+  grouping bgp-color-policy-extension {
+    description
+      "Container `color-policy` under the BGP top-level. Holds an
+       ordered list of color entries; ordering is BTreeMap key order
+       at runtime (ascending color id).";
+
+    container color-policy {
+      ext:help "Color → Flex-Algorithm binding table";
+      presence "Configure color-policy entries";
+
+      list color {
+        ext:help "One color → flex-algorithm binding";
+        key value;
+        leaf value {
+          ext:help "BGP Color community value (RFC 9012 §4.3, 0..2^32-1)";
+          type uint32;
+        }
+        leaf flex-algorithm {
+          ext:help "IS-IS Flex-Algorithm id (128..255 per RFC 9350 §4)";
+          type uint8 {
+            range "128..255";
+          }
+        }
+      }
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router/bgp:bgp" {
+    description
+      "Attach the color-policy block to the BGP top-level in the
+       candidate-set subtree.";
+    uses bgp-color-policy-extension;
+  }
+
+  augment "/configure:delete/config:router/bgp:bgp" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp color-policy color X` is path-valid.";
+    uses bgp-color-policy-extension;
+  }
+}


### PR DESCRIPTION
## Summary

Adds the BGP-local color-policy storage that the future color-aware nexthop resolver (Phase 3 of the BGP ↔ Flex-Algo plan) will consult to pick a per-algorithm entry from \`Isis::rib_flex_algo\` when a route carries a Color extended community (RFC 9012 §4.3) that maps to an IS-IS Flex-Algorithm (RFC 9350).

\`\`\`
router bgp {
  color-policy {
    color 100 { flex-algorithm 128; }
    color 200 { flex-algorithm 129; }
  }
}
\`\`\`

Pieces:
- **zebra-bgp-color-policy.yang** — new module augmenting \`/configure:{set,delete}/config:router/bgp:bgp\` with a \`color-policy/color/<value>/flex-algorithm\` subtree (uint32 → uint8, range 128..=255 per RFC 9350 §4). Wired into \`config.yang\`'s import list.
- **\`bgp::color_policy\` module** — \`ColorPolicy\` struct wrapping a \`BTreeMap<u32 color, u8 algo>\`; \`flex_algo_for(color)\` accessor for future consumers; staging callbacks for list-entry presence and the per-leaf flex-algorithm value.
- **\`Bgp::color_policy\` field**, initialized in \`Bgp::new\` and wired into \`callback_build\` for the two paths.

Multiple colors may map to the same algorithm (RFC 9256 §2.5 fallback ordering); the mapping lives BGP-local — IS-IS does not learn about BGP color.

No consumer yet; the resolver lands in the follow-up PR alongside route-map match/set.

## Test plan

- [x] 3 new unit tests cover empty-table lookup, single-binding lookup, and many-colors-one-algo.
- [x] All 129 zebra-rs::bgp tests pass.
- [x] \`cargo fmt --check\` clean.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.

## Roadmap status after this PR

- ✅ IS-IS Phase 0 — peer_algos cache, SPF gating, per-algo RIB + MPLS LFIB, show commands (#670/#675/#679/#681).
- ✅ BGP Phase 1 codec layer — Prefix-SID (#683), Tunnel-Encap (#684), Color extcomm (#686).
- ✅ BGP Phase 2.2 — color → flex-algorithm binding table ← this PR.
- ⏭️ BGP Phase 2.1 — route-map \`match color\` / \`set color\` / \`set prefix-sid label-index\` plumbing.
- ⏭️ BGP Phase 2.3 — receive-side ingest stashing color list + label-index on adj-RIB-in entries.

Generated with [Claude Code](https://claude.com/claude-code)