### PR TITLE
rib, bgp: parse and broadcast per-VRF route-targets

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -99,14 +99,26 @@ pub(crate) fn peer_index_unregister(
 }
 
 /// Kernel VRF master info as observed by `Bgp` via
-/// `RibRx::VrfAdd`. Used by [`Bgp::maybe_respawn_vrf_with_kernel_ctx`]
-/// to lift a step-14 placeholder `ProtoContext` to a real
-/// `ProtoContext::for_vrf(rib, table_id, name)`.
-#[derive(Debug, Clone, Copy)]
+/// `RibRx::VrfAdd` and the matching RT sets observed via
+/// `RibRx::VrfRouteTargets`. Used by
+/// [`Bgp::maybe_respawn_vrf_with_kernel_ctx`] to lift a step-14
+/// placeholder `ProtoContext` to a real
+/// `ProtoContext::for_vrf(rib, table_id, name)`; step 17b's
+/// Export pipeline reads `export_rts_v4`/`v6` and step 18's
+/// Import pipeline reads `import_rts_v4`/`v6`.
+#[derive(Debug, Clone, Default)]
 pub struct RibKnownVrf {
     pub table_id: u32,
     #[allow(dead_code)] // read by step 16's accept dispatcher.
     pub ifindex: u32,
+    #[allow(dead_code)] // first reader lands in step 18.
+    pub import_rts_v4: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+    #[allow(dead_code)] // first reader lands in step 17b.
+    pub export_rts_v4: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+    #[allow(dead_code)] // first reader lands in step 18.
+    pub import_rts_v6: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+    #[allow(dead_code)] // first reader lands in step 17b.
+    pub export_rts_v6: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
 }
 
 #[allow(dead_code)]
@@ -693,7 +705,7 @@ impl Bgp {
             let Some(cfg) = self.vrfs.get(&name).cloned() else {
                 continue;
             };
-            let kernel = self.rib_known_vrfs.get(&name).copied();
+            let kernel = self.rib_known_vrfs.get(&name).cloned();
             let handle = super::vrf::spawn_bgp_vrf(
                 name.clone(),
                 &cfg,
@@ -724,7 +736,7 @@ impl Bgp {
         if !self.vrf_registry.contains_key(name) {
             return;
         }
-        let Some(kernel) = self.rib_known_vrfs.get(name).copied() else {
+        let Some(kernel) = self.rib_known_vrfs.get(name).cloned() else {
             return;
         };
         // Tear the placeholder-ctx task down before spawning the
@@ -737,6 +749,7 @@ impl Bgp {
             // is about to push fresh RegisterPeer messages.
             self.peer_index.retain(|_, owner| owner != name);
         }
+        let table_id = kernel.table_id;
         let new_handle = super::vrf::spawn_bgp_vrf(
             name.to_string(),
             &cfg,
@@ -749,7 +762,7 @@ impl Bgp {
         self.vrf_registry.insert(name.to_string(), new_handle);
         tracing::info!(
             vrf = %name,
-            table_id = kernel.table_id,
+            table_id,
             "bgp: respawned per-VRF task with real ProtoContext::for_vrf",
         );
     }
@@ -943,8 +956,32 @@ impl Bgp {
                 table_id,
                 ifindex,
             } => {
-                self.rib_known_vrfs
-                    .insert(name.clone(), RibKnownVrf { table_id, ifindex });
+                // Preserve any RT cache already populated from a
+                // prior `VrfRouteTargets` (e.g. when the operator
+                // sets RTs in the same commit as the VRF itself
+                // and they happen to arrive before `VrfAdd`).
+                let prev_rts = self.rib_known_vrfs.remove(&name);
+                let entry = RibKnownVrf {
+                    table_id,
+                    ifindex,
+                    import_rts_v4: prev_rts
+                        .as_ref()
+                        .map(|p| p.import_rts_v4.clone())
+                        .unwrap_or_default(),
+                    export_rts_v4: prev_rts
+                        .as_ref()
+                        .map(|p| p.export_rts_v4.clone())
+                        .unwrap_or_default(),
+                    import_rts_v6: prev_rts
+                        .as_ref()
+                        .map(|p| p.import_rts_v6.clone())
+                        .unwrap_or_default(),
+                    export_rts_v6: prev_rts
+                        .as_ref()
+                        .map(|p| p.export_rts_v6.clone())
+                        .unwrap_or_default(),
+                };
+                self.rib_known_vrfs.insert(name.clone(), entry);
                 // If the operator already committed `router bgp vrf
                 // <name> ...` and the step-14 placeholder context
                 // is in place, swap it for a real `for_vrf` now. The
@@ -960,6 +997,27 @@ impl Bgp {
                 // per-VRF task carries the YANG intent. If the
                 // operator subsequently deletes the BGP VRF block,
                 // step 14's `apply_vrf_commit_diff` handles teardown.
+            }
+            RibRx::VrfRouteTargets {
+                name,
+                ipv4_import_rts,
+                ipv4_export_rts,
+                ipv6_import_rts,
+                ipv6_export_rts,
+            } => {
+                // Mutate-in-place if a `VrfAdd` already populated
+                // the row; otherwise stage the RT cache so a later
+                // `VrfAdd` picks it up (defensive against
+                // out-of-order delivery — step 15a's replay
+                // contract puts VrfAdd first, but the active
+                // commit path sends them as separate messages and
+                // a slow `tokio::select!` could draw the RT
+                // message ahead of the VrfAdd).
+                let entry = self.rib_known_vrfs.entry(name).or_default();
+                entry.import_rts_v4 = ipv4_import_rts;
+                entry.export_rts_v4 = ipv4_export_rts;
+                entry.import_rts_v6 = ipv6_import_rts;
+                entry.export_rts_v6 = ipv6_export_rts;
             }
             // Redistribute deliveries from RIB — initial walk
             // (chunks ending in `bulk: Eor`) plus steady-state deltas

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -97,6 +97,9 @@ pub fn spawn_bgp_vrf(
     rib_subscriber: &RibSubscriber,
     global_tx: UnboundedSender<BgpGlobalMsg>,
 ) -> BgpVrfHandle {
+    // Snapshot for logging so we can move `kernel` into the
+    // ctx-building arm without re-borrowing later.
+    let kernel_table_id = kernel.as_ref().map(|k| k.table_id);
     let ctx = match kernel {
         Some(k) => {
             // Mint a fresh `RibClient` for this VRF. The
@@ -156,7 +159,7 @@ pub fn spawn_bgp_vrf(
         vrf = %name,
         rd = ?cfg.rd,
         router_id = %effective_router_id,
-        table_id = ?kernel.map(|k| k.table_id),
+        table_id = ?kernel_table_id,
         peers = peer_count,
         "bgp: spawned per-VRF task",
     );

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -93,6 +93,19 @@ pub enum RibRx {
     VrfDel {
         name: String,
     },
+    /// Route-target sets attached to a VRF.
+    /// `set vrf X {ipv4,ipv6} route-target {import,export} ...`
+    /// flows in through `VrfBuilder` and lands here as a snapshot
+    /// (the full set replaces whatever the subscriber had).
+    /// Replayed at subscribe time alongside `VrfAdd` so a
+    /// late-subscribing BGP catches the running config.
+    VrfRouteTargets {
+        name: String,
+        ipv4_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+        ipv4_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+        ipv6_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+        ipv6_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+    },
     EoR,
 
     // ---- redistribute route push ---------------------------------
@@ -235,6 +248,23 @@ impl Rib {
         for (_, sub) in self.client_registry.iter_vrf(0) {
             let _ = sub.rib_rx_tx.send(RibRx::VrfDel {
                 name: name.to_string(),
+            });
+        }
+    }
+
+    /// Push the current RT snapshot for `vrf` to default-VRF
+    /// subscribers. The plan in step 17 / 18 is to give BGP a
+    /// chance to import / export against the matching RT set;
+    /// step 17a caches the snapshot on `Bgp::rib_known_vrfs`
+    /// without using it yet.
+    pub fn api_vrf_route_targets(&self, vrf: &crate::rib::vrf::Vrf) {
+        for (_, sub) in self.client_registry.iter_vrf(0) {
+            let _ = sub.rib_rx_tx.send(RibRx::VrfRouteTargets {
+                name: vrf.name.clone(),
+                ipv4_import_rts: vrf.ipv4_import_rts.clone(),
+                ipv4_export_rts: vrf.ipv4_export_rts.clone(),
+                ipv6_import_rts: vrf.ipv6_import_rts.clone(),
+                ipv6_export_rts: vrf.ipv6_export_rts.clone(),
             });
         }
     }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -138,6 +138,20 @@ pub enum Message {
     VrfDel {
         name: String,
     },
+    /// Replace the route-target sets for `name`. Emitted by
+    /// `VrfBuilder::commit` on every commit cycle so the RIB
+    /// state stays a snapshot of the staged config. Carries every
+    /// (afi, kind) tuple in one message so the receiving end
+    /// updates atomically — no risk of a half-updated state being
+    /// observed by a subscriber that drains the channel between
+    /// individual mutations.
+    VrfRouteTargets {
+        name: String,
+        ipv4_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+        ipv4_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+        ipv6_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+        ipv6_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+    },
     /// Bind / unbind an interface to a VRF master device.
     /// `vrf == Some(name)` enslaves; `vrf == None` clears the binding
     /// (sets IFLA_MASTER = 0). The handler tolerates the interface or
@@ -956,6 +970,19 @@ impl Rib {
                 if tx.send(msg).is_err() {
                     return;
                 }
+                // RT snapshot follows the VrfAdd. The receiver
+                // can already key off `name` because step 15a's
+                // replay guarantees VrfAdd lands first.
+                let rt_msg = RibRx::VrfRouteTargets {
+                    name: vrf.name.clone(),
+                    ipv4_import_rts: vrf.ipv4_import_rts.clone(),
+                    ipv4_export_rts: vrf.ipv4_export_rts.clone(),
+                    ipv6_import_rts: vrf.ipv6_import_rts.clone(),
+                    ipv6_export_rts: vrf.ipv6_export_rts.clone(),
+                };
+                if tx.send(rt_msg).is_err() {
+                    return;
+                }
             }
         }
         if tx.send(RibRx::EoR).is_err() {
@@ -1317,6 +1344,14 @@ impl Rib {
                         name: name.clone(),
                         table_id,
                         ifindex,
+                        // RT sets arrive separately via
+                        // `Message::VrfRouteTargets` once the VRF
+                        // config builder has finished parsing
+                        // /vrf/<name>/{ipv4,ipv6}/route-target.
+                        ipv4_import_rts: std::collections::BTreeSet::new(),
+                        ipv4_export_rts: std::collections::BTreeSet::new(),
+                        ipv6_import_rts: std::collections::BTreeSet::new(),
+                        ipv6_export_rts: std::collections::BTreeSet::new(),
                     },
                 );
                 // Park an empty per-VRF routing table set keyed by the
@@ -1370,6 +1405,34 @@ impl Rib {
                 self.vrf_id_alloc.release(vrf.table_id);
                 tracing::info!("vrf_del: {} (table_id={})", name, vrf.table_id);
                 self.api_vrf_del(&name);
+            }
+            Message::VrfRouteTargets {
+                name,
+                ipv4_import_rts,
+                ipv4_export_rts,
+                ipv6_import_rts,
+                ipv6_export_rts,
+            } => {
+                // Idempotent — the message carries a full snapshot
+                // of the staged RT sets, replacing whatever was on
+                // the `Vrf` row before. A `VrfRouteTargets` for an
+                // unknown VRF name is dropped silently: the YANG
+                // commit always emits `VrfAdd` first, so the only
+                // way to hit the `None` arm is via an out-of-order
+                // self-send.
+                if let Some(vrf) = self.vrfs.get_mut(&name) {
+                    vrf.ipv4_import_rts = ipv4_import_rts;
+                    vrf.ipv4_export_rts = ipv4_export_rts;
+                    vrf.ipv6_import_rts = ipv6_import_rts;
+                    vrf.ipv6_export_rts = ipv6_export_rts;
+                    let vrf_snapshot = vrf.clone();
+                    self.api_vrf_route_targets(&vrf_snapshot);
+                } else {
+                    tracing::debug!(
+                        vrf = %name,
+                        "rib: VrfRouteTargets for unknown VRF; dropping",
+                    );
+                }
             }
             Message::LinkVrfBind { ifname, vrf } => {
                 // Always record operator intent so a later kernel

--- a/zebra-rs/src/rib/vrf/builder.rs
+++ b/zebra-rs/src/rib/vrf/builder.rs
@@ -50,8 +50,24 @@ impl VrfBuilder {
                 self.config.remove(&name);
                 let _ = tx.send(Message::VrfDel { name });
             } else {
+                // Snapshot the RT sets before moving `config` into
+                // `self.config`. The two sends order matters: the
+                // receiving end relies on the `Vrf` row existing
+                // before `VrfRouteTargets` arrives so the RT
+                // update has a target to mutate.
+                let ipv4_import_rts = config.ipv4_import_rts.clone();
+                let ipv4_export_rts = config.ipv4_export_rts.clone();
+                let ipv6_import_rts = config.ipv6_import_rts.clone();
+                let ipv6_export_rts = config.ipv6_export_rts.clone();
                 self.config.insert(name.clone(), config);
-                let _ = tx.send(Message::VrfAdd { name });
+                let _ = tx.send(Message::VrfAdd { name: name.clone() });
+                let _ = tx.send(Message::VrfRouteTargets {
+                    name,
+                    ipv4_import_rts,
+                    ipv4_export_rts,
+                    ipv6_import_rts,
+                    ipv6_export_rts,
+                });
             }
         }
     }
@@ -101,7 +117,12 @@ struct ConfigBuilder {
 
 impl ConfigBuilder {
     pub fn new() -> Self {
+        use std::str::FromStr;
+
         const CONFIG_ERR: &str = "missing config";
+        const RT_ERR: &str = "missing route-target argument";
+        const RT_PARSE_ERR: &str =
+            "route-target must parse as ASN:value, IPv4:value, or 4byteASN:value";
 
         ConfigBuilder::default()
             .path("")
@@ -117,6 +138,96 @@ impl ConfigBuilder {
                     s.delete = true;
                     cache.insert(name.clone(), s);
                 }
+                Ok(())
+            })
+            // /vrf/<name>/ipv4/route-target/import — leaf-list, one
+            // RT value per callback. RT shares the on-wire 6-octet
+            // encoding with RD, so we parse via the `bgp_packet`
+            // `RouteDistinguisher::from_str` and store the same
+            // `RouteDistinguisher` value. The YANG-layer label
+            // distinguishes RT from RD at the user surface.
+            .path("/ipv4/route-target/import")
+            .set(|config, cache, name, args| {
+                let raw = args.string().context(RT_ERR)?;
+                let rt = bgp_packet::RouteDistinguisher::from_str(&raw)
+                    .map_err(|_| anyhow::anyhow!(RT_PARSE_ERR))?;
+                cache_get(config, cache, name)
+                    .context(CONFIG_ERR)?
+                    .ipv4_import_rts
+                    .insert(rt);
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let raw = args.string().context(RT_ERR)?;
+                let rt = bgp_packet::RouteDistinguisher::from_str(&raw)
+                    .map_err(|_| anyhow::anyhow!(RT_PARSE_ERR))?;
+                cache_get(config, cache, name)
+                    .context(CONFIG_ERR)?
+                    .ipv4_import_rts
+                    .remove(&rt);
+                Ok(())
+            })
+            .path("/ipv4/route-target/export")
+            .set(|config, cache, name, args| {
+                let raw = args.string().context(RT_ERR)?;
+                let rt = bgp_packet::RouteDistinguisher::from_str(&raw)
+                    .map_err(|_| anyhow::anyhow!(RT_PARSE_ERR))?;
+                cache_get(config, cache, name)
+                    .context(CONFIG_ERR)?
+                    .ipv4_export_rts
+                    .insert(rt);
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let raw = args.string().context(RT_ERR)?;
+                let rt = bgp_packet::RouteDistinguisher::from_str(&raw)
+                    .map_err(|_| anyhow::anyhow!(RT_PARSE_ERR))?;
+                cache_get(config, cache, name)
+                    .context(CONFIG_ERR)?
+                    .ipv4_export_rts
+                    .remove(&rt);
+                Ok(())
+            })
+            .path("/ipv6/route-target/import")
+            .set(|config, cache, name, args| {
+                let raw = args.string().context(RT_ERR)?;
+                let rt = bgp_packet::RouteDistinguisher::from_str(&raw)
+                    .map_err(|_| anyhow::anyhow!(RT_PARSE_ERR))?;
+                cache_get(config, cache, name)
+                    .context(CONFIG_ERR)?
+                    .ipv6_import_rts
+                    .insert(rt);
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let raw = args.string().context(RT_ERR)?;
+                let rt = bgp_packet::RouteDistinguisher::from_str(&raw)
+                    .map_err(|_| anyhow::anyhow!(RT_PARSE_ERR))?;
+                cache_get(config, cache, name)
+                    .context(CONFIG_ERR)?
+                    .ipv6_import_rts
+                    .remove(&rt);
+                Ok(())
+            })
+            .path("/ipv6/route-target/export")
+            .set(|config, cache, name, args| {
+                let raw = args.string().context(RT_ERR)?;
+                let rt = bgp_packet::RouteDistinguisher::from_str(&raw)
+                    .map_err(|_| anyhow::anyhow!(RT_PARSE_ERR))?;
+                cache_get(config, cache, name)
+                    .context(CONFIG_ERR)?
+                    .ipv6_export_rts
+                    .insert(rt);
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let raw = args.string().context(RT_ERR)?;
+                let rt = bgp_packet::RouteDistinguisher::from_str(&raw)
+                    .map_err(|_| anyhow::anyhow!(RT_PARSE_ERR))?;
+                cache_get(config, cache, name)
+                    .context(CONFIG_ERR)?
+                    .ipv6_export_rts
+                    .remove(&rt);
                 Ok(())
             })
     }
@@ -135,5 +246,96 @@ impl ConfigBuilder {
     pub fn del(mut self, func: Handler) -> Self {
         self.map.insert((self.path.clone(), ConfigOp::Delete), func);
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use tokio::sync::mpsc;
+
+    use crate::config::{Args, ConfigOp};
+
+    use super::*;
+
+    fn args(words: &[&str]) -> Args {
+        Args(words.iter().map(|s| s.to_string()).collect())
+    }
+
+    #[test]
+    fn commit_emits_vrf_add_then_route_targets() {
+        // Operator typed:
+        //   set vrf v1 ipv4 route-target import 65000:1
+        //   set vrf v1 ipv4 route-target export 65000:2
+        //   commit
+        // The receiving end should see `VrfAdd { v1 }` followed
+        // by a `VrfRouteTargets { v1, ... }` carrying both RTs.
+        let mut builder = VrfBuilder::new();
+        builder
+            .exec("/vrf".into(), args(&["v1"]), ConfigOp::Set)
+            .expect("create vrf");
+        builder
+            .exec(
+                "/vrf/ipv4/route-target/import".into(),
+                args(&["v1", "65000:1"]),
+                ConfigOp::Set,
+            )
+            .expect("add import RT");
+        builder
+            .exec(
+                "/vrf/ipv4/route-target/export".into(),
+                args(&["v1", "65000:2"]),
+                ConfigOp::Set,
+            )
+            .expect("add export RT");
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        builder.commit(tx);
+
+        let first = rx.try_recv().expect("VrfAdd present");
+        let Message::VrfAdd { name } = first else {
+            panic!("first message is not VrfAdd");
+        };
+        assert_eq!(name, "v1");
+
+        let second = rx.try_recv().expect("VrfRouteTargets present");
+        let Message::VrfRouteTargets {
+            name,
+            ipv4_import_rts,
+            ipv4_export_rts,
+            ipv6_import_rts,
+            ipv6_export_rts,
+        } = second
+        else {
+            panic!("second message is not VrfRouteTargets");
+        };
+        assert_eq!(name, "v1");
+        let imp = bgp_packet::RouteDistinguisher::from_str("65000:1").unwrap();
+        let exp = bgp_packet::RouteDistinguisher::from_str("65000:2").unwrap();
+        assert!(ipv4_import_rts.contains(&imp));
+        assert!(ipv4_export_rts.contains(&exp));
+        assert!(ipv6_import_rts.is_empty());
+        assert!(ipv6_export_rts.is_empty());
+        assert!(rx.try_recv().is_err(), "no third message expected");
+    }
+
+    #[test]
+    fn invalid_rt_string_returns_an_error() {
+        let mut builder = VrfBuilder::new();
+        builder
+            .exec("/vrf".into(), args(&["v1"]), ConfigOp::Set)
+            .expect("create vrf");
+        let err = builder
+            .exec(
+                "/vrf/ipv4/route-target/import".into(),
+                args(&["v1", "not-an-rt"]),
+                ConfigOp::Set,
+            )
+            .expect_err("garbage RT must be rejected");
+        assert!(
+            err.to_string().contains("route-target"),
+            "expected RT-specific error, got: {err}",
+        );
     }
 }

--- a/zebra-rs/src/rib/vrf/config.rs
+++ b/zebra-rs/src/rib/vrf/config.rs
@@ -5,11 +5,70 @@
 /// deletes. The `name` itself is the list key and lives in the
 /// containing `BTreeMap`'s key, not here.
 ///
-/// First iteration carries no payload other than `delete` because the
-/// VRF schema only has the `name` key today; per-AF route-target
-/// import/export is configured against the same VRF name but routed
-/// through a different builder.
-#[derive(Default, Debug, Clone)]
+/// The route-target sets are stored as `BTreeSet` because the YANG
+/// leaf-lists carry no ordering and the BGP-side consumer
+/// (`bgp::Bgp::rib_known_vrfs`) compares against incoming attribute
+/// communities — set semantics, not list semantics. Both lists
+/// reuse [`RouteDistinguisher`] for storage because RTs and RDs
+/// share the on-wire 6-octet extended-community encoding; the
+/// user-facing distinction is a YANG-layer label.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct VrfConfig {
     pub delete: bool,
+    /// IPv4-unicast RT import set —
+    /// `set vrf X ipv4 route-target import …`.
+    pub ipv4_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+    /// IPv4-unicast RT export set —
+    /// `set vrf X ipv4 route-target export …`.
+    pub ipv4_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+    /// IPv6-unicast RT import set —
+    /// `set vrf X ipv6 route-target import …`.
+    pub ipv6_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+    /// IPv6-unicast RT export set —
+    /// `set vrf X ipv6 route-target export …`.
+    pub ipv6_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn default_has_no_rts_and_is_not_marked_for_deletion() {
+        let cfg = VrfConfig::default();
+        assert!(!cfg.delete);
+        assert!(cfg.ipv4_import_rts.is_empty());
+        assert!(cfg.ipv4_export_rts.is_empty());
+        assert!(cfg.ipv6_import_rts.is_empty());
+        assert!(cfg.ipv6_export_rts.is_empty());
+    }
+
+    #[test]
+    fn rt_strings_parse_via_route_distinguisher_from_str() {
+        // The two encodings the existing
+        // `RouteDistinguisher::from_str` supports — 2-byte ASN and
+        // IPv4 — both flow through to RT storage unchanged.
+        // 4-byte ASN encoding is allowed by the YANG pattern but
+        // not (yet) by the Rust parser; the YANG-side `commit`
+        // will reject it.
+        let a = bgp_packet::RouteDistinguisher::from_str("65000:100").unwrap();
+        let b = bgp_packet::RouteDistinguisher::from_str("192.0.2.1:100").unwrap();
+        let mut cfg = VrfConfig::default();
+        cfg.ipv4_import_rts.insert(a);
+        cfg.ipv4_import_rts.insert(b);
+        assert_eq!(cfg.ipv4_import_rts.len(), 2);
+    }
+
+    #[test]
+    fn import_and_export_sets_are_independent() {
+        // A common config mistake is conflating import / export
+        // — confirm the struct keeps them as distinct sets.
+        let rt = bgp_packet::RouteDistinguisher::from_str("65000:1").unwrap();
+        let mut cfg = VrfConfig::default();
+        cfg.ipv4_import_rts.insert(rt);
+        assert!(cfg.ipv4_import_rts.contains(&rt));
+        assert!(!cfg.ipv4_export_rts.contains(&rt));
+    }
 }

--- a/zebra-rs/src/rib/vrf/inst.rs
+++ b/zebra-rs/src/rib/vrf/inst.rs
@@ -13,11 +13,20 @@ use crate::rib::inst::IlmEntry;
 /// the kernel `vrf` master interface, and the result is recorded here.
 /// `ifindex` is the kernel-assigned ifindex of the VRF master device;
 /// callers enslave member interfaces to it via `IFLA_MASTER`.
+///
+/// Route-target sets attached via
+/// `set vrf X {ipv4,ipv6} route-target {import,export} …` flow in
+/// through [`Message::VrfRouteTargets`] and live on this struct so
+/// they replay alongside the kernel info when a subscriber attaches.
 #[derive(Debug, Clone)]
 pub struct Vrf {
     pub name: String,
     pub table_id: u32,
     pub ifindex: u32,
+    pub ipv4_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+    pub ipv4_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+    pub ipv6_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+    pub ipv6_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
 }
 
 /// Per-VRF routing-table set. Mirrors the `table` / `table_v6` /


### PR DESCRIPTION
## Summary

Step 17 (first slice) of the BGP MPLS/VPN refactor. Wires YANG
callbacks for `/vrf/<name>/{ipv4,ipv6}/route-target/{import,export}`
into Rust storage, broadcasts the parsed sets via a new
`RibRx::VrfRouteTargets`, and caches them on
`Bgp::rib_known_vrfs` for the eventual Export / Import pipeline
(step 17b / 18). No BGP NLRI changes — plumbing only.

- `rib::vrf::VrfConfig` gains 4 `BTreeSet<RouteDistinguisher>`
  fields (RT shares wire encoding with RD).
- `VrfBuilder` registers 8 new path handlers parsing RT strings
  via `from_str`; bad input errors out on commit.
- `Message::VrfRouteTargets` carries the full RT snapshot
  (idempotent). Emitted right after `VrfAdd` so the RIB side
  matches the staged config every commit.
- `Rib::subscribe` replays the RT snapshot per known VRF; late-
  subscribing BGP catches the running set.
- `Bgp::rib_known_vrfs` extended with `import_rts_v4/v6` and
  `export_rts_v4/v6`. Each `#[allow(dead_code)]` — first readers
  land in step 17b (Export) and step 18 (Import). The RT-message
  arm tolerates out-of-order delivery (RT-before-VrfAdd creates
  the row with zero-RT sets).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` (555 unit tests
      pass; +5 new tests — VrfConfig RT shape, RT parsing,
      builder commit ordering, bad-RT error path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)