### PR TITLE
ospf: introduce OspfVersion trait + Ospfv2 marker

### DIFF
--- a/zebra-rs/src/ospf/mod.rs
+++ b/zebra-rs/src/ospf/mod.rs
@@ -1,3 +1,6 @@
+pub mod version;
+pub use version::{OspfVersion, Ospfv2};
+
 pub mod inst;
 pub use inst::{Message, Ospf, ShowCallback};
 

--- a/zebra-rs/src/ospf/socket.rs
+++ b/zebra-rs/src/ospf/socket.rs
@@ -1,7 +1,5 @@
-use std::net::Ipv4Addr;
 use std::os::fd::AsRawFd;
 use std::os::raw::c_int;
-use std::str::FromStr;
 
 use socket2::InterfaceIndexOrAddress;
 use socket2::{Domain, Protocol, Socket};
@@ -9,12 +7,12 @@ use tokio::io::unix::AsyncFd;
 
 use crate::context::ProtoContext;
 
-const OSPF_IP_PROTO: i32 = 89;
+use super::{OspfVersion, Ospfv2};
 
 pub fn ospf_socket_ipv4(ctx: &ProtoContext) -> Result<Socket, std::io::Error> {
     // Initial socket through the context so VRF binding (when
     // step 8 lights up `SO_BINDTODEVICE`) applies automatically.
-    let socket = ctx.raw_socket(Domain::IPV4, Protocol::from(OSPF_IP_PROTO))?;
+    let socket = ctx.raw_socket(Domain::IPV4, Protocol::from(Ospfv2::IP_PROTO as i32))?;
 
     socket.set_nonblocking(true)?;
     socket.set_reuse_address(true)?;
@@ -40,7 +38,7 @@ pub fn set_ipv4_pktinfo(socket: &Socket) {
 }
 
 pub fn ospf_join_if(socket: &AsyncFd<Socket>, ifindex: u32) {
-    let maddr: Ipv4Addr = Ipv4Addr::from_str("224.0.0.5").unwrap();
+    let maddr = Ospfv2::ALL_SPF_ROUTERS;
     if let Err(e) = socket
         .get_ref()
         .join_multicast_v4_n(&maddr, &InterfaceIndexOrAddress::Index(ifindex))
@@ -50,7 +48,7 @@ pub fn ospf_join_if(socket: &AsyncFd<Socket>, ifindex: u32) {
 }
 
 pub fn ospf_join_alldrouters(socket: &AsyncFd<Socket>, ifindex: u32) {
-    let maddr: Ipv4Addr = Ipv4Addr::from_str("224.0.0.6").unwrap();
+    let maddr = Ospfv2::ALL_DROUTERS;
     if let Err(e) = socket
         .get_ref()
         .join_multicast_v4_n(&maddr, &InterfaceIndexOrAddress::Index(ifindex))
@@ -60,7 +58,7 @@ pub fn ospf_join_alldrouters(socket: &AsyncFd<Socket>, ifindex: u32) {
 }
 
 pub fn ospf_leave_alldrouters(socket: &AsyncFd<Socket>, ifindex: u32) {
-    let maddr: Ipv4Addr = Ipv4Addr::from_str("224.0.0.6").unwrap();
+    let maddr = Ospfv2::ALL_DROUTERS;
     if let Err(e) = socket
         .get_ref()
         .leave_multicast_v4_n(&maddr, &InterfaceIndexOrAddress::Index(ifindex))

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -1,0 +1,54 @@
+//! OSPF address-family abstraction.
+//!
+//! The plan is to grow this trait into the boundary between
+//! version-agnostic protocol logic (IFSM / NFSM / LSDB plumbing /
+//! flooding) and the v2-vs-v3-specific bits (packet formats, address
+//! sizes, multicast groups). For now it captures only the small set
+//! of constants that already differ between v2 and v3 — `Addr`,
+//! protocol number, and the two well-known multicast groups — so the
+//! socket layer can reference them through the trait instead of
+//! hardcoding v2 literals.
+//!
+//! Subsequent PRs in the Phase 3 series will parameterize
+//! `Ospf<V>`, `OspfLink<V>`, `Neighbor<V>`, and `Lsdb<V>` and migrate
+//! the remaining `Ipv4Addr` references that are genuinely
+//! address-family-agnostic to `V::Addr`.
+
+use std::fmt::{Debug, Display};
+use std::hash::Hash;
+use std::net::Ipv4Addr;
+
+/// Marker / dispatch trait for an OSPF protocol version (v2 or v3).
+///
+/// Both versions use the same IP protocol number (89), so it's a
+/// default on the trait. The well-known multicast groups
+/// (AllSPFRouters / AllDRouters) and the address family itself are
+/// what actually differs.
+pub trait OspfVersion: 'static + Send + Sync + Copy + Clone {
+    /// Address type used on the wire and for router/area identifiers.
+    /// v2 uses `Ipv4Addr`; v3 will use `Ipv6Addr`. Router-id and
+    /// area-id remain 32-bit in both versions, but the link-local
+    /// source address differs — those v3-specific fields will land
+    /// when `Ospfv3` is added.
+    type Addr: Copy + Eq + Ord + Hash + Display + Debug + 'static;
+
+    /// IP protocol number for OSPF packets — 89 in both versions
+    /// (RFC 2328 §A and RFC 5340 §2.3).
+    const IP_PROTO: u8 = 89;
+
+    /// AllSPFRouters multicast group: 224.0.0.5 (v2) or ff02::5 (v3).
+    const ALL_SPF_ROUTERS: Self::Addr;
+
+    /// AllDRouters multicast group: 224.0.0.6 (v2) or ff02::6 (v3).
+    const ALL_DROUTERS: Self::Addr;
+}
+
+/// OSPFv2 dispatch marker (RFC 2328).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Ospfv2;
+
+impl OspfVersion for Ospfv2 {
+    type Addr = Ipv4Addr;
+    const ALL_SPF_ROUTERS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 5);
+    const ALL_DROUTERS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 6);
+}


### PR DESCRIPTION
## Summary

First PR of the Phase 3 generics refactor. Establish the trait that later PRs will use to parameterize `Ospf<V>`, `OspfLink<V>`, `Neighbor<V>`, and `Lsdb<V>`. This PR introduces only the trait and one impl, plus a minimal migration in `socket.rs` to prove the pattern.

The trait captures three small bits that already differ between v2 and v3:

- `type Addr`: `Ipv4Addr` (v2) vs `Ipv6Addr` (when v3 lands)
- `const IP_PROTO`: 89, identical in both versions (default on the trait)
- `const ALL_SPF_ROUTERS` / `ALL_DROUTERS`: 224.0.0.5 / 224.0.0.6 for v2; ff02::5 / ff02::6 for v3

## Why minimal

The full Phase 3 refactor touches every OSPF source file. To keep PRs reviewable, this one defines only the trait and migrates `socket.rs` — the smallest consumer with the clearest hardcoded literals. Subsequent PRs will parameterize one struct at a time:

1. (this PR) Trait scaffold + socket.rs constants
2. Parameterize `OspfAddr` and small wrappers
3. Parameterize `Identity` and `Neighbor`
4. Parameterize `OspfLink`
5. Parameterize `Lsdb` / `Lsa`
6. Parameterize `Ospf` instance and `Message` enum

v2 must keep working as `V = Ospfv2` throughout.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo clippy -p zebra-rs --bins` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p zebra-rs --bins` — all 558 pass
- Behavior is identical: same constants, just looked up through the trait instead of as local literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)