### PR TITLE
ospf: parameterize OspfAddr<V> over Prefix

### DIFF
--- a/zebra-rs/src/ospf/addr.rs
+++ b/zebra-rs/src/ospf/addr.rs
@@ -1,14 +1,27 @@
-use ipnet::Ipv4Net;
-
 use crate::rib::link::LinkAddr;
 
-#[derive(Debug, Default, Clone)]
-pub struct OspfAddr {
-    pub prefix: Ipv4Net,
+use super::OspfVersion;
+
+/// A configured address on an OSPF interface. Generic over the
+/// address family so v3 (`Ipv6Net`) can reuse the wrapper unchanged.
+#[derive(Debug, Clone)]
+pub struct OspfAddr<V: OspfVersion> {
+    pub prefix: V::Prefix,
 }
 
-impl OspfAddr {
-    pub fn from(_addr: &LinkAddr, prefix: &Ipv4Net) -> Self {
+impl<V: OspfVersion> OspfAddr<V> {
+    pub fn from(_addr: &LinkAddr, prefix: &V::Prefix) -> Self {
         Self { prefix: *prefix }
+    }
+}
+
+impl<V: OspfVersion> Default for OspfAddr<V>
+where
+    V::Prefix: Default,
+{
+    fn default() -> Self {
+        Self {
+            prefix: V::Prefix::default(),
+        }
     }
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -14,6 +14,7 @@ use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use crate::config::{DisplayRequest, ShowChannel};
+use crate::ospf::Ospfv2;
 use crate::ospf::addr::OspfAddr;
 use crate::ospf::packet::{ospf_db_desc_recv, ospf_hello_recv, ospf_hello_send};
 use crate::rib::api::RibRx;
@@ -72,7 +73,7 @@ pub struct OspfInterface<'a> {
     pub tx: &'a UnboundedSender<Message>,
     pub router_id: &'a Ipv4Addr,
     pub ident: &'a Identity,
-    pub addr: &'a Vec<OspfAddr>,
+    pub addr: &'a Vec<OspfAddr<Ospfv2>>,
     pub mtu: u32,
     pub db_desc_in: &'a mut usize,
     pub lsdb: &'a mut Lsdb,

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -12,7 +12,7 @@ use ospf_packet::OspfLsaHeader;
 
 use crate::rib::Link;
 
-use super::{Identity, IfsmState, Message, Neighbor};
+use super::{Identity, IfsmState, Message, Neighbor, Ospfv2};
 use super::{addr::OspfAddr, task::Timer};
 
 pub const OSPF_DEFAULT_PRIORITY: u8 = 64;
@@ -70,7 +70,7 @@ pub struct OspfLink {
     pub name: String,
     pub mtu: u32,
     pub enabled: bool,
-    pub addr: Vec<OspfAddr>,
+    pub addr: Vec<OspfAddr<Ospfv2>>,
     pub area: Ipv4Addr,
     pub area_id: Ipv4Addr,
     pub state: IfsmState,

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -18,6 +18,8 @@ use std::fmt::{Debug, Display};
 use std::hash::Hash;
 use std::net::Ipv4Addr;
 
+use ipnet::Ipv4Net;
+
 /// Marker / dispatch trait for an OSPF protocol version (v2 or v3).
 ///
 /// Both versions use the same IP protocol number (89), so it's a
@@ -31,6 +33,11 @@ pub trait OspfVersion: 'static + Send + Sync + Copy + Clone {
     /// source address differs — those v3-specific fields will land
     /// when `Ospfv3` is added.
     type Addr: Copy + Eq + Ord + Hash + Display + Debug + 'static;
+
+    /// Prefix (network + length) type. v2 uses `Ipv4Net`; v3 will
+    /// use `Ipv6Net`. Both are `ipnet::*Net` types so they share
+    /// `Copy`, `Eq`, `Display`, etc.
+    type Prefix: Copy + Eq + Display + Debug + 'static;
 
     /// IP protocol number for OSPF packets — 89 in both versions
     /// (RFC 2328 §A and RFC 5340 §2.3).
@@ -49,6 +56,7 @@ pub struct Ospfv2;
 
 impl OspfVersion for Ospfv2 {
     type Addr = Ipv4Addr;
+    type Prefix = Ipv4Net;
     const ALL_SPF_ROUTERS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 5);
     const ALL_DROUTERS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 6);
 }


### PR DESCRIPTION
## Summary

Phase 3 PR 2. Add `type Prefix` to `OspfVersion` (`Ipv4Net` for v2, `Ipv6Net` for v3 when it lands) and make the `OspfAddr` wrapper generic over `V`. The holder structs (`OspfLink`, `OspfInterface`) bridge at the boundary by writing the concrete `OspfAddr<Ospfv2>` in their `addr` field, keeping the rest of the codebase v2-bound until later PRs lift `<V>` higher.

Two trivial trait-bound dances:

- `OspfAddr<V>::Default` is gated on `V::Prefix: Default`. `Ipv4Net` / `Ipv6Net` both satisfy this; v3 will inherit.
- `OspfAddr::from` takes `&V::Prefix` instead of `&Ipv4Net`.

No behavior change. Sets up the pattern for parameterizing `Identity`, `Neighbor`, `OspfLink` in subsequent PRs.

## Stacking note

This PR is stacked on top of #694 (the trait scaffold). It currently shows both commits in its diff; once #694 merges, this branch needs `git rebase origin/main` and `--force-with-lease` push to narrow the diff. Same workflow we used for Phase 0.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo clippy -p zebra-rs --bins` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p zebra-rs --bins` — all 558 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)