### PR TITLE
bgp: payload for BgpGlobalMsg::Export + per-VRF emit helpers

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1213,14 +1213,63 @@ impl Bgp {
 
     fn process_vrf_global_msg(&mut self, msg: super::vrf::BgpGlobalMsg) {
         match msg {
-            super::vrf::BgpGlobalMsg::Export { vrf } => {
-                tracing::debug!(vrf = %vrf, "bgp: ignored Export (step 17 wires the handler)");
+            super::vrf::BgpGlobalMsg::Export {
+                vrf,
+                prefix,
+                attr: _,
+                label,
+            } => {
+                // Step 17b-i: resolve RD and export-RT set from
+                // already-staged state; emit a single info log so
+                // the operator can see the export decision land
+                // in real time. Step 17b-ii replaces this body
+                // with the actual `LocalRib.v4vpn[rd]` write and
+                // the update-group flush to VPNv4 peers.
+                let rd = self.vrfs.get(&vrf).and_then(|cfg| cfg.rd);
+                let export_rts = self
+                    .rib_known_vrfs
+                    .get(&vrf)
+                    .map(|k| k.export_rts_v4.len())
+                    .unwrap_or(0);
+                match rd {
+                    Some(rd) => {
+                        tracing::info!(
+                            vrf = %vrf,
+                            %prefix,
+                            rd = %rd,
+                            export_rts = export_rts,
+                            label,
+                            "bgp: export (step 17b-ii will write to LocalRib.v4vpn)",
+                        );
+                    }
+                    None => {
+                        tracing::warn!(
+                            vrf = %vrf,
+                            %prefix,
+                            "bgp: export dropped — VRF has no RD configured",
+                        );
+                    }
+                }
             }
-            super::vrf::BgpGlobalMsg::WithdrawExport { vrf } => {
-                tracing::debug!(
-                    vrf = %vrf,
-                    "bgp: ignored WithdrawExport (step 17 wires the handler)",
-                );
+            super::vrf::BgpGlobalMsg::WithdrawExport { vrf, prefix } => {
+                let rd = self.vrfs.get(&vrf).and_then(|cfg| cfg.rd);
+                match rd {
+                    Some(rd) => {
+                        tracing::info!(
+                            vrf = %vrf,
+                            %prefix,
+                            rd = %rd,
+                            "bgp: withdraw-export (step 17b-ii will withdraw from LocalRib.v4vpn)",
+                        );
+                    }
+                    None => {
+                        tracing::debug!(
+                            vrf = %vrf,
+                            %prefix,
+                            "bgp: withdraw-export dropped — VRF has no RD configured",
+                        );
+                    }
+                }
             }
             super::vrf::BgpGlobalMsg::RegisterPeer { vrf, addr } => {
                 peer_index_register(&mut self.peer_index, vrf, addr);

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -204,6 +204,39 @@ impl BgpVrf {
         }
     }
 
+    /// Step 17b-i hook: push a freshly-elected best-path winner to
+    /// the global Bgp task as a VPNv4 export candidate. The global
+    /// side prepends the VRF's RD and tags the configured
+    /// export-RT set before inserting into `LocalRib.v4vpn`.
+    ///
+    /// Caller hands over `attr` by value — the global task
+    /// re-interns into its own `BgpAttrStore`. `label` is a per-VRF
+    /// MPLS label allocated by step 19; until that lands, callers
+    /// pass `0` and the global side logs / skips the install.
+    ///
+    /// Not yet wired into the per-VRF FSM. Step 17b-ii hooks it
+    /// to the post-best-path notification in
+    /// [`Self::process_msg`].
+    #[allow(dead_code)] // first caller lands in step 17b-ii.
+    pub fn export_best_path(&self, prefix: ipnet::Ipv4Net, attr: bgp_packet::BgpAttr, label: u32) {
+        let _ = self.global_tx.send(BgpGlobalMsg::Export {
+            vrf: self.name.clone(),
+            prefix,
+            attr,
+            label,
+        });
+    }
+
+    /// Inverse of [`Self::export_best_path`]. Tells the global
+    /// task to withdraw the matching VPNv4 advertisement.
+    #[allow(dead_code)] // first caller lands in step 17b-ii.
+    pub fn withdraw_exported(&self, prefix: ipnet::Ipv4Net) {
+        let _ = self.global_tx.send(BgpGlobalMsg::WithdrawExport {
+            vrf: self.name.clone(),
+            prefix,
+        });
+    }
+
     /// Handle a per-VRF FSM event off `self.rx`. Step 15d wires
     /// the same set the global `Bgp::process_msg` handles —
     /// minus `Accept` (passive accept lives at the global task
@@ -360,5 +393,74 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(2), vrf.event_loop())
             .await
             .expect("event_loop exits when inbox is dropped");
+    }
+
+    #[tokio::test]
+    async fn export_best_path_sends_global_msg_with_payload() {
+        // Step 17b-i invariant: `export_best_path` pushes a
+        // `BgpGlobalMsg::Export` carrying the VRF name, prefix,
+        // attr (by value), and label stub. The global instance's
+        // handler is exercised separately; here we only verify
+        // the producer side.
+        let (global_tx, mut global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = test_ctx_for_vrf(20, "vrf-export");
+        let (vrf, _inbox) = BgpVrf::new(
+            "vrf-export".to_string(),
+            ctx,
+            None,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            global_tx,
+        );
+
+        let prefix: ipnet::Ipv4Net = "10.0.0.0/24".parse().unwrap();
+        let attr = bgp_packet::BgpAttr::default();
+        vrf.export_best_path(prefix, attr.clone(), 0);
+
+        let msg = global_rx
+            .try_recv()
+            .expect("Export pushed onto global channel");
+        match msg {
+            BgpGlobalMsg::Export {
+                vrf: v,
+                prefix: p,
+                attr: a,
+                label,
+            } => {
+                assert_eq!(v, "vrf-export");
+                assert_eq!(p, prefix);
+                assert_eq!(a, attr);
+                assert_eq!(label, 0);
+            }
+            other => panic!("expected Export, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn withdraw_exported_sends_global_msg() {
+        let (global_tx, mut global_rx) = unbounded_channel::<BgpGlobalMsg>();
+        let ctx = test_ctx_for_vrf(21, "vrf-withdraw");
+        let (vrf, _inbox) = BgpVrf::new(
+            "vrf-withdraw".to_string(),
+            ctx,
+            None,
+            Ipv4Addr::UNSPECIFIED,
+            65000,
+            global_tx,
+        );
+
+        let prefix: ipnet::Ipv4Net = "10.0.0.0/24".parse().unwrap();
+        vrf.withdraw_exported(prefix);
+
+        let msg = global_rx
+            .try_recv()
+            .expect("WithdrawExport pushed onto global channel");
+        match msg {
+            BgpGlobalMsg::WithdrawExport { vrf: v, prefix: p } => {
+                assert_eq!(v, "vrf-withdraw");
+                assert_eq!(p, prefix);
+            }
+            other => panic!("expected WithdrawExport, got {other:?}"),
+        }
     }
 }

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -20,9 +20,10 @@
 
 use std::net::SocketAddr;
 
+use ipnet::Ipv4Net;
 use tokio::net::TcpStream;
 
-use bgp_packet::RouteDistinguisher;
+use bgp_packet::{BgpAttr, RouteDistinguisher};
 
 /// Message from the global `Bgp` task to a per-VRF [`BgpVrf`]
 /// task. The receiver lives on `BgpVrf::global_rx`.
@@ -77,22 +78,29 @@ pub enum BgpVrfMsg {
 #[derive(Debug)]
 pub enum BgpGlobalMsg {
     /// A best-path winner inside this VRF that the global task
-    /// should re-emit as VPNv4/v6 (step 17). Carries the VRF name
-    /// so the global task can look up the RD/RT policy when
-    /// re-encoding the NLRI.
-    #[allow(dead_code)]
+    /// should re-emit as VPNv4. The VRF name lets the global side
+    /// look up the matching RD (from `Bgp::vrfs`) and the export
+    /// RT set (from `Bgp::rib_known_vrfs`). `attr` travels by
+    /// value — the receiver re-interns into its own
+    /// `BgpAttrStore`. `label` is a per-VRF MPLS label allocated
+    /// by step 19; step 17b passes `0` as a stub and the global
+    /// instance treats that as "no label yet" (skip the install
+    /// until a real label arrives).
     Export {
         vrf: String,
-        // step 17 fills prefix, BgpAttr id, label, etc.
+        prefix: Ipv4Net,
+        // First reader lands in step 17b-ii (LocRIB write). The
+        // step-17b-i handler logs the export decision but doesn't
+        // yet consume the attributes themselves.
+        #[allow(dead_code)]
+        attr: BgpAttr,
+        label: u32,
     },
 
-    /// Inverse of [`Self::Export`]. Tells the global task to
-    /// withdraw the corresponding VPNv4/v6 advertisement.
-    #[allow(dead_code)]
-    WithdrawExport {
-        vrf: String,
-        // step 17 fills the prefix identifier.
-    },
+    /// Inverse of [`Self::Export`]. The global instance withdraws
+    /// the VPNv4 advertisement matching this VRF's RD and the
+    /// given prefix.
+    WithdrawExport { vrf: String, prefix: Ipv4Net },
 
     /// Register a peer IP with the global accept dispatcher so an
     /// inbound `:179` connect from that IP is handed to this VRF


### PR DESCRIPTION
## Summary

Step 17b (first slice) of the BGP MPLS/VPN refactor. Lands the
cross-task payload BGP needs to ship a per-VRF best-path winner
into the global VPNv4 advertise pipeline, and adds the per-VRF
producer helpers. The global handler is a stub: it resolves the
RD + RT lookup and logs at info — no LocRIB write or update-group
flush yet (that's step 17b-ii).

- `BgpGlobalMsg::Export` payload extended with `prefix`,
  `attr: BgpAttr` (by value; receiver re-interns), and `label:
  u32` (stub `0` until step 19). `WithdrawExport` adds `prefix`.
- `BgpVrf::export_best_path(prefix, attr, label)` and
  `BgpVrf::withdraw_exported(prefix)` send via `self.global_tx`.
  Not yet wired into the FSM (step 17b-ii hooks them).
- `Bgp::process_vrf_global_msg(Export)` looks up the VRF's RD
  and export-RT set; info-log when present, warn on missing RD.
  `WithdrawExport` handler is symmetric.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` (565 unit tests pass;
      +2 new tests on `export_best_path` / `withdraw_exported`
      producers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)