### PR TITLE
rib, isis: publish per-algo IS-IS routes to a RIB-side shadow

### DIFF
--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -241,6 +241,93 @@ fn build_rib_nexthop(nhops: Vec<rib::NexthopUni>) -> rib::Nexthop {
     }
 }
 
+/// Convert one entry of IS-IS's internal `SpfRoute` shape into the
+/// public `rib::api::FlexAlgoRoute` snapshot. Returns `None` when
+/// the route lacks a resolved per-algo SID or has no usable
+/// nexthops — both signal "no forwarding plane for this prefix in
+/// algo-N" and downstream callers should treat it as a delete.
+fn make_flex_algo_route(
+    algo: u8,
+    prefix: Ipv4Net,
+    route: &SpfRoute,
+) -> Option<crate::rib::api::FlexAlgoRoute> {
+    let outer_label = route.sid?;
+    let nexthops: Vec<crate::rib::api::FlexAlgoNexthop> = route
+        .nhops
+        .iter()
+        .map(|(addr, nhop)| crate::rib::api::FlexAlgoNexthop {
+            addr: *addr,
+            ifindex: nhop.ifindex,
+            label: outer_label,
+        })
+        .collect();
+    if nexthops.is_empty() {
+        return None;
+    }
+    Some(crate::rib::api::FlexAlgoRoute {
+        algo,
+        prefix,
+        metric: route.metric,
+        nexthops,
+    })
+}
+
+/// Diff per-algo IPv4 RIB snapshots and emit `Message::FlexAlgoRoute
+/// Add` / `Del` messages so RIB's shadow tracks the live state.
+///
+/// Iteration covers every algo present in either side so an algo
+/// dropped from `flex_algo.config` (and therefore absent from `next`)
+/// yields one Del per prefix that used to be there.
+///
+/// Within an algo we use `spf::table_diff` for the same `only_curr /
+/// different / only_next` split the IPv4 and IPv6 diff helpers use,
+/// so the semantics of "route changed under the hood but same
+/// prefix" match what RIB already sees from algo-0.
+pub fn diff_apply_flex_algo(
+    rib_client: &crate::rib::client::RibClient,
+    prev: &BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>>,
+    next: &BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>>,
+) {
+    let all_algos: BTreeSet<u8> = prev.keys().chain(next.keys()).copied().collect();
+    let empty: PrefixMap<Ipv4Net, SpfRoute> = PrefixMap::new();
+    for algo in all_algos {
+        let prev_table = prev.get(&algo).unwrap_or(&empty);
+        let next_table = next.get(&algo).unwrap_or(&empty);
+        let diff = spf::table_diff(prev_table.iter(), next_table.iter());
+
+        for (prefix, _) in diff.only_curr.iter() {
+            let msg = rib::Message::FlexAlgoRouteDel {
+                algo,
+                prefix: **prefix,
+            };
+            rib_client.send(msg).unwrap();
+        }
+        for (prefix, _, route) in diff.different.iter() {
+            // A changed route that no longer has a usable forwarding
+            // plane (lost SID or lost all nhops) collapses to a Del.
+            match make_flex_algo_route(algo, **prefix, route) {
+                Some(r) => {
+                    let msg = rib::Message::FlexAlgoRouteAdd { route: r };
+                    rib_client.send(msg).unwrap();
+                }
+                None => {
+                    let msg = rib::Message::FlexAlgoRouteDel {
+                        algo,
+                        prefix: **prefix,
+                    };
+                    rib_client.send(msg).unwrap();
+                }
+            }
+        }
+        for (prefix, route) in diff.only_next.iter() {
+            if let Some(r) = make_flex_algo_route(algo, **prefix, route) {
+                let msg = rib::Message::FlexAlgoRouteAdd { route: r };
+                rib_client.send(msg).unwrap();
+            }
+        }
+    }
+}
+
 pub fn diff_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffResult) {
     // Delete.
     for (prefix, route) in diff.only_curr.iter() {
@@ -1021,18 +1108,12 @@ pub(super) fn perform_spf_calculation(top: &mut IsisTop, level: Level) {
         .iter()
         .map(|(k, v)| (*k, v.clone()))
         .collect();
-    {
-        let active: BTreeSet<u8> = configured_algos.iter().map(|(k, _)| *k).collect();
-        top.graph_flex_algo
-            .get_mut(&level)
-            .retain(|k, _| active.contains(k));
-        top.spf_flex_algo
-            .get_mut(&level)
-            .retain(|k, _| active.contains(k));
-        top.rib_flex_algo
-            .get_mut(&level)
-            .retain(|k, _| active.contains(k));
-    }
+    // Build the new per-algo state into fresh maps; we diff against
+    // the previous `top.rib_flex_algo[level]` before swapping so the
+    // RIB-side shadow stays consistent with this cycle.
+    let mut new_flex_algo_graphs: BTreeMap<u8, Option<spf::Graph>> = BTreeMap::new();
+    let mut new_flex_algo_spfs: BTreeMap<u8, Option<BTreeMap<usize, spf::Path>>> = BTreeMap::new();
+    let mut new_flex_algo_rib: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>> = BTreeMap::new();
     for (algo, entry) in &configured_algos {
         let (algo_graph, algo_source, _) = graph_flex_algo(top, level, *algo, entry);
         let algo_spf = algo_source.map(|src| spf::spf(&algo_graph, src, &spf::SpfOpt::full_path()));
@@ -1050,12 +1131,28 @@ pub(super) fn perform_spf_calculation(top: &mut IsisTop, level: Level) {
             _ => PrefixMap::<Ipv4Net, SpfRoute>::new(),
         };
 
-        top.graph_flex_algo
-            .get_mut(&level)
-            .insert(*algo, Some(algo_graph));
-        top.spf_flex_algo.get_mut(&level).insert(*algo, algo_spf);
-        top.rib_flex_algo.get_mut(&level).insert(*algo, algo_rib);
+        new_flex_algo_graphs.insert(*algo, Some(algo_graph));
+        new_flex_algo_spfs.insert(*algo, algo_spf);
+        new_flex_algo_rib.insert(*algo, algo_rib);
     }
+    // Per-algo route diff → RIB publish (Phase 3). The shadow on
+    // `Rib::flex_algo_routes` is the colour-aware nexthop resolver's
+    // source of truth for the outer MPLS label per (algo, prefix).
+    if top.config.distribute.rib {
+        diff_apply_flex_algo(
+            top.rib_client,
+            top.rib_flex_algo.get(&level),
+            &new_flex_algo_rib,
+        );
+    }
+
+    // Swap the new state in. The retain that used to live above is
+    // implicit: any algo present in the old map but absent from the
+    // new one yielded `FlexAlgoRouteDel` messages above; the swap
+    // drops the old entry entirely.
+    *top.graph_flex_algo.get_mut(&level) = new_flex_algo_graphs;
+    *top.spf_flex_algo.get_mut(&level) = new_flex_algo_spfs;
+    *top.rib_flex_algo.get_mut(&level) = new_flex_algo_rib;
 
     *top.spf_result.get_mut(&level) = Some(spf_result);
     *top.tilfa_result.get_mut(&level) = Some(tilfa_result);
@@ -1215,6 +1312,180 @@ mod tests {
 
     fn mk_uni(addr: &str, metric: u32) -> rib::NexthopUni {
         rib::NexthopUni::new(addr.parse().unwrap(), metric, vec![])
+    }
+
+    fn spf_route(metric: u32, sid: Option<u32>, nhops: &[(&str, u32)]) -> SpfRoute {
+        let mut nh = BTreeMap::new();
+        for (addr, ifindex) in nhops {
+            nh.insert(
+                addr.parse::<Ipv4Addr>().unwrap(),
+                super::SpfNexthop {
+                    ifindex: *ifindex,
+                    adjacency: false,
+                    sys_id: None,
+                    backup: None,
+                },
+            );
+        }
+        SpfRoute {
+            metric,
+            nhops: nh,
+            sid,
+            prefix_sid: None,
+            dest_vertex: None,
+        }
+    }
+
+    fn pfx(s: &str) -> Ipv4Net {
+        s.parse().unwrap()
+    }
+
+    fn rib_client_for_test() -> (
+        crate::rib::client::RibClient,
+        tokio::sync::mpsc::UnboundedReceiver<crate::rib::client::RibInbound>,
+    ) {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        (
+            crate::rib::client::RibClient::new(tx, crate::rib::client::ProtoId::from_raw(u32::MAX)),
+            rx,
+        )
+    }
+
+    fn drain(
+        rx: &mut tokio::sync::mpsc::UnboundedReceiver<crate::rib::client::RibInbound>,
+    ) -> Vec<crate::rib::inst::Message> {
+        let mut out = Vec::new();
+        while let Ok(m) = rx.try_recv() {
+            out.push(m.msg);
+        }
+        out
+    }
+
+    #[test]
+    fn make_flex_algo_route_skips_route_with_no_sid() {
+        let r = spf_route(10, None, &[("10.0.0.1", 7)]);
+        assert!(make_flex_algo_route(128, pfx("192.0.2.0/24"), &r).is_none());
+    }
+
+    #[test]
+    fn make_flex_algo_route_skips_route_with_no_nhops() {
+        let r = spf_route(10, Some(17128), &[]);
+        assert!(make_flex_algo_route(128, pfx("192.0.2.0/24"), &r).is_none());
+    }
+
+    #[test]
+    fn make_flex_algo_route_flattens_multiple_nhops() {
+        let r = spf_route(10, Some(17128), &[("10.0.0.1", 7), ("10.0.0.2", 8)]);
+        let fr = make_flex_algo_route(128, pfx("192.0.2.0/24"), &r).expect("Some");
+        assert_eq!(fr.algo, 128);
+        assert_eq!(fr.metric, 10);
+        assert_eq!(fr.nexthops.len(), 2);
+        for n in &fr.nexthops {
+            assert_eq!(n.label, 17128);
+        }
+    }
+
+    #[test]
+    fn diff_apply_flex_algo_emits_add_for_new_route() {
+        let (client, mut rx) = rib_client_for_test();
+        let mut next: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>> = BTreeMap::new();
+        let mut t = PrefixMap::new();
+        t.insert(
+            pfx("10.0.0.1/32"),
+            spf_route(20, Some(17128), &[("10.0.0.5", 9)]),
+        );
+        next.insert(128, t);
+
+        diff_apply_flex_algo(&client, &BTreeMap::new(), &next);
+        let msgs = drain(&mut rx);
+        assert_eq!(msgs.len(), 1);
+        assert!(matches!(
+            msgs[0],
+            crate::rib::inst::Message::FlexAlgoRouteAdd { ref route }
+                if route.algo == 128 && route.prefix == pfx("10.0.0.1/32")
+        ));
+    }
+
+    #[test]
+    fn diff_apply_flex_algo_emits_del_for_removed_algo() {
+        let (client, mut rx) = rib_client_for_test();
+        let mut prev: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>> = BTreeMap::new();
+        let mut t = PrefixMap::new();
+        t.insert(
+            pfx("10.0.0.1/32"),
+            spf_route(20, Some(17128), &[("10.0.0.5", 9)]),
+        );
+        t.insert(
+            pfx("10.0.0.2/32"),
+            spf_route(20, Some(17129), &[("10.0.0.5", 9)]),
+        );
+        prev.insert(128, t);
+
+        diff_apply_flex_algo(&client, &prev, &BTreeMap::new());
+        let msgs = drain(&mut rx);
+        assert_eq!(msgs.len(), 2);
+        for m in &msgs {
+            assert!(matches!(
+                m,
+                crate::rib::inst::Message::FlexAlgoRouteDel { algo: 128, .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn diff_apply_flex_algo_changed_route_emits_single_add() {
+        let (client, mut rx) = rib_client_for_test();
+        let mut prev: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>> = BTreeMap::new();
+        let mut p = PrefixMap::new();
+        p.insert(
+            pfx("10.0.0.1/32"),
+            spf_route(20, Some(17128), &[("10.0.0.5", 9)]),
+        );
+        prev.insert(128, p);
+
+        let mut next: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>> = BTreeMap::new();
+        let mut n = PrefixMap::new();
+        // Same prefix, different metric → counts as `different`.
+        n.insert(
+            pfx("10.0.0.1/32"),
+            spf_route(30, Some(17128), &[("10.0.0.5", 9)]),
+        );
+        next.insert(128, n);
+
+        diff_apply_flex_algo(&client, &prev, &next);
+        let msgs = drain(&mut rx);
+        assert_eq!(msgs.len(), 1);
+        assert!(matches!(
+            msgs[0],
+            crate::rib::inst::Message::FlexAlgoRouteAdd { ref route }
+                if route.metric == 30
+        ));
+    }
+
+    #[test]
+    fn diff_apply_flex_algo_changed_route_losing_sid_collapses_to_del() {
+        let (client, mut rx) = rib_client_for_test();
+        let mut prev: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>> = BTreeMap::new();
+        let mut p = PrefixMap::new();
+        p.insert(
+            pfx("10.0.0.1/32"),
+            spf_route(20, Some(17128), &[("10.0.0.5", 9)]),
+        );
+        prev.insert(128, p);
+
+        let mut next: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>> = BTreeMap::new();
+        let mut n = PrefixMap::new();
+        // Lost SID — no per-algo forwarding plane, must be a Del.
+        n.insert(pfx("10.0.0.1/32"), spf_route(30, None, &[("10.0.0.5", 9)]));
+        next.insert(128, n);
+
+        diff_apply_flex_algo(&client, &prev, &next);
+        let msgs = drain(&mut rx);
+        assert_eq!(msgs.len(), 1);
+        assert!(matches!(
+            msgs[0],
+            crate::rib::inst::Message::FlexAlgoRouteDel { algo: 128, .. }
+        ));
     }
 
     #[test]

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -1,8 +1,40 @@
 use std::net::{IpAddr, Ipv4Addr};
 
+use ipnet::Ipv4Net;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use super::{BulkPhase, Link, MacAddr, Rib, RibType, RouteBatch, link::LinkAddr};
+
+/// One nexthop entry inside a `FlexAlgoRoute`. Flattens the IS-IS
+/// internal `SpfNexthop` to the public-API minimum: the IPv4 next-hop
+/// address, the egress ifindex, and the outer MPLS label to push.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FlexAlgoNexthop {
+    pub addr: Ipv4Addr,
+    pub ifindex: u32,
+    /// Outer MPLS label = the route origin's SRGB.start + the algo-N
+    /// Prefix-SID index. The receiver of this struct (Color-aware
+    /// nexthop resolver) pushes this label as the outermost LSP
+    /// segment when forwarding a service route into the Flex-Algo
+    /// path.
+    pub label: u32,
+}
+
+/// Per-algorithm IPv4 route snapshot published from IS-IS (RFC 9350)
+/// to RIB. Carries only the fields downstream consumers need —
+/// IS-IS internals (`dest_vertex`, TI-LFA backup, raw `SidLabelValue`)
+/// stay in the IS-IS module.
+///
+/// `algo` is the IS-IS Flex-Algorithm id (128..=255). The same
+/// `(algo, prefix)` pair may arrive multiple times across IS-IS SPF
+/// cycles; each arrival replaces the previous snapshot for that key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FlexAlgoRoute {
+    pub algo: u8,
+    pub prefix: Ipv4Net,
+    pub metric: u32,
+    pub nexthops: Vec<FlexAlgoNexthop>,
+}
 
 /// One bridge-FDB row, distilled from the larger `FibNeighbor` so
 /// subscribers don't need to drag the full address-family / state
@@ -116,6 +148,25 @@ pub enum RibRx {
         rtype: RibType,
         routes: RouteBatch,
         bulk: BulkPhase,
+    },
+
+    // ---- IS-IS Flex-Algorithm route fan-out -----------------------
+    //
+    // Phase 3 of the BGP ↔ IS-IS Flex-Algorithm integration: IS-IS
+    // publishes per-algo route snapshots to RIB via
+    // `Message::FlexAlgoRouteAdd/Del`; RIB shadows them in
+    // `flex_algo_routes` and re-broadcasts via the two RibRx variants
+    // below. The colour-aware nexthop resolver (next PR) is the first
+    // consumer; today the fan-out lands on every subscribed protocol
+    // and they ignore it.
+    #[allow(dead_code)]
+    FlexAlgoRouteAdd {
+        route: FlexAlgoRoute,
+    },
+    #[allow(dead_code)]
+    FlexAlgoRouteDel {
+        algo: u8,
+        prefix: Ipv4Net,
     },
 }
 
@@ -242,6 +293,25 @@ impl Rib {
     pub fn api_vxlan_del(&self, vni: u32) {
         for (_, sub) in self.client_registry.iter() {
             let _ = sub.rib_rx_tx.send(RibRx::VxlanDel { vni });
+        }
+    }
+
+    /// Fan-out a Flex-Algorithm route add to every default-VRF
+    /// subscriber. Per-algo routes are global today — IS-IS runs as a
+    /// single instance and the colour-aware nexthop resolver (BGP)
+    /// resolves against the default-VRF table. When per-VRF flex-algo
+    /// arrives a vrf_id filter slots in here.
+    pub fn api_flex_algo_route_add(&self, route: &FlexAlgoRoute) {
+        for (_, sub) in self.client_registry.iter_vrf(0) {
+            let _ = sub.rib_rx_tx.send(RibRx::FlexAlgoRouteAdd {
+                route: route.clone(),
+            });
+        }
+    }
+
+    pub fn api_flex_algo_route_del(&self, algo: u8, prefix: Ipv4Net) {
+        for (_, sub) in self.client_registry.iter_vrf(0) {
+            let _ = sub.rib_rx_tx.send(RibRx::FlexAlgoRouteDel { algo, prefix });
         }
     }
 }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -59,6 +59,21 @@ pub enum Message {
         label: u32,
         ilm: IlmEntry,
     },
+    /// IS-IS publishes a per-algorithm IPv4 route snapshot. RIB
+    /// shadows it in `flex_algo_routes` and re-broadcasts via
+    /// `RibRx::FlexAlgoRouteAdd`. No FIB install — per-algo IPv4
+    /// would collide with algo-0 in the kernel; forwarding goes
+    /// through the algo-N MPLS LFIB which IS-IS already installs.
+    FlexAlgoRouteAdd {
+        route: crate::rib::api::FlexAlgoRoute,
+    },
+    /// Inverse of `FlexAlgoRouteAdd`. Either the prefix is no longer
+    /// reachable in algo-N, or the algo itself has been removed from
+    /// the configuration.
+    FlexAlgoRouteDel {
+        algo: u8,
+        prefix: Ipv4Net,
+    },
     BridgeAdd {
         name: String,
         config: BridgeConfig,
@@ -358,6 +373,17 @@ pub struct Rib {
     pub table: PrefixMap<Ipv4Net, RibEntries>,
     pub table_v6: PrefixMap<Ipv6Net, RibEntries>,
     pub ilm: BTreeMap<u32, IlmEntry>,
+    /// Per-IS-IS-Flex-Algorithm IPv4 route shadow (Phase 3 of the
+    /// BGP ↔ IS-IS Flex-Algo integration). Outer key is the algo id
+    /// (128..=255); inner map mirrors the per-algo subset of IS-IS's
+    /// `Isis::rib_flex_algo`. Populated by `Message::FlexAlgoRouteAdd`
+    /// / `Del`, cleared on shutdown. **Not** installed to the kernel
+    /// IPv4 table — algo-N routes would collide with algo-0; the
+    /// per-algo MPLS LFIB (already in `Isis::ilm` and pushed through
+    /// `ilm_add`) provides forwarding. The colour-aware nexthop
+    /// resolver (next PR) reads this shadow to attach the outer MPLS
+    /// label for service routes carrying a Color extcomm.
+    pub flex_algo_routes: BTreeMap<u8, PrefixMap<Ipv4Net, crate::rib::api::FlexAlgoRoute>>,
     pub mac_table: BTreeMap<(u32, MacAddr), MacEntry>,
     /// Remote VTEPs we've installed as VXLAN BUM ingress-replication
     /// targets (zero-MAC FDB rows on the VXLAN device, keyed by
@@ -470,6 +496,7 @@ impl Rib {
             table: PrefixMap::new(),
             table_v6: PrefixMap::new(),
             ilm: BTreeMap::new(),
+            flex_algo_routes: BTreeMap::new(),
             mac_table: BTreeMap::new(),
             vtep_table: std::collections::BTreeSet::new(),
             neighbors: BTreeMap::new(),
@@ -1256,6 +1283,29 @@ impl Rib {
             }
             Message::IlmDel { label, ilm } => {
                 self.ilm_del(label, ilm).await;
+            }
+            Message::FlexAlgoRouteAdd { route } => {
+                // Last-writer-wins on (algo, prefix). The same key
+                // re-published from a later SPF cycle overwrites the
+                // previous snapshot in place; consumers see the new
+                // metric / nexthops on the next subscribe-side recv.
+                self.flex_algo_routes
+                    .entry(route.algo)
+                    .or_default()
+                    .insert(route.prefix, route.clone());
+                self.api_flex_algo_route_add(&route);
+            }
+            Message::FlexAlgoRouteDel { algo, prefix } => {
+                let became_empty = if let Some(table) = self.flex_algo_routes.get_mut(&algo) {
+                    table.remove(&prefix);
+                    table.iter().next().is_none()
+                } else {
+                    false
+                };
+                if became_empty {
+                    self.flex_algo_routes.remove(&algo);
+                }
+                self.api_flex_algo_route_del(algo, prefix);
             }
             Message::BridgeAdd { name, config } => {
                 let bridge = Bridge {


### PR DESCRIPTION
## Summary

Phase 3 of the BGP ↔ IS-IS Flex-Algorithm integration. The **load-bearing plumbing**: IS-IS hands every per-algorithm IPv4 route over to RIB on each SPF cycle so a future colour-aware nexthop resolver (next PR) can pick up the outer MPLS label without poking into IS-IS internals.

### New \`rib::api\` types

- \`FlexAlgoNexthop { addr, ifindex, label }\` — one resolved nexthop; \`label\` is the outer MPLS push the resolver will use.
- \`FlexAlgoRoute { algo, prefix, metric, nexthops }\` — the public snapshot. IS-IS internals (\`dest_vertex\`, TI-LFA backup, raw \`SidLabelValue\`) stay in the IS-IS module.

### New \`rib::inst::Message\` variants

- \`FlexAlgoRouteAdd { route }\`, \`FlexAlgoRouteDel { algo, prefix }\`.
- Handled in \`process_msg\`: update \`Rib::flex_algo_routes\` shadow (\`BTreeMap<algo, PrefixMap<Ipv4Net, FlexAlgoRoute>>\`), fan out to every default-VRF subscriber via two new \`RibRx\` variants.

The shadow is **not** installed into the kernel IPv4 table — algo-N routes would collide with algo-0; forwarding goes through the per-algo MPLS LFIB IS-IS already installs.

### IS-IS side (\`perform_spf_calculation\`)

- Build all per-algo state into fresh BTreeMaps.
- \`diff_apply_flex_algo\` walks both prev and next, runs \`spf::table_diff\` per algo, emits one Message per delta. Algos dropped from \`flex_algo.config\` yield Del messages for every prefix that used to live there before the swap.
- \`make_flex_algo_route\` flattens \`SpfRoute\` → \`FlexAlgoRoute\`; routes without a usable SID or nhops collapse to Del so a "lost reachability" cycle clears the shadow.

### No new consumer yet

Every subscribed protocol receives \`RibRx::FlexAlgoRouteAdd/Del\` and ignores them. The colour-aware nexthop resolver — \`bgp_attr.colors() × Bgp::color_policy × Rib::flex_algo_routes\` → forwarding decision — lands next.

## Test plan

- [x] 7 new unit tests cover \`make_flex_algo_route\` (skip-on-no-sid / skip-on-no-nhops / multi-nhop flatten) and \`diff_apply_flex_algo\` (add-for-new / del-for-removed-algo / single-add-on-change / sid-loss-collapses-to-del). Test helper constructs a \`RibClient\` over an mpsc channel to capture emitted messages.
- [x] All 95 IS-IS tests + 137 BGP tests pass.
- [x] \`cargo fmt --check\` clean.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.

## Roadmap status after this PR

- ✅ IS-IS Phase 0 — peer_algos cache, SPF gating, per-algo RIB + MPLS LFIB, show commands.
- ✅ BGP Phase 1 codec layer — Prefix-SID, Tunnel-Encap, Color extcomm.
- ✅ BGP Phase 2 — color → flex-algorithm binding, route-map plumbing, receive-side accessors.
- ✅ BGP Phase 3a — IS-IS → RIB per-algo route publication ← this PR.
- ⏭️ BGP Phase 3b — BGP colour-aware NHT: consume \`Rib::flex_algo_routes\` to attach outer MPLS labels onto service-route FIB installs. Closes the loop end-to-end.

Generated with [Claude Code](https://claude.com/claude-code)