### PR TITLE
bgp: hook per-VRF best-path into the global VPNv4 export pipeline

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -85,6 +85,7 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
             attr_store: &mut bgp.attr_store,
             update_groups: &mut bgp.update_groups,
             interface_addrs: &bgp.interface_addrs,
+            vrf_export: None,
         };
         route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers);
         bgp.peers.remove(&addr);

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -618,6 +618,7 @@ impl Bgp {
                     attr_store: &mut self.attr_store,
                     update_groups: &mut self.update_groups,
                     interface_addrs: &self.interface_addrs,
+                    vrf_export: None,
                 };
 
                 fsm(&mut bgp_ref, &mut self.peers, ident, event);

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -579,6 +579,13 @@ pub struct BgpTop<'a> {
     /// Per-ifindex IPv6 link-local registry, used to resolve the v6
     /// next-hop for RFC 8950 IPv4-over-IPv6 emit on interface peers.
     pub interface_addrs: &'a super::interface_addrs::InterfaceAddrs,
+    /// Per-VRF export hook. `None` when the runtime is the global
+    /// `Bgp` (no VPNv4 export happens from default-VRF traffic);
+    /// `Some(...)` when running inside a `BgpVrf` task — the
+    /// shared route pipeline calls `vrf_emit_export` /
+    /// `vrf_emit_withdraw` on best-path transitions so the global
+    /// instance's VPNv4 LocRIB picks them up.
+    pub vrf_export: Option<&'a super::vrf::VrfExporter>,
 }
 
 pub fn fsm_next_state(peer: &mut Peer, event: Event) -> (State, FsmEffect) {
@@ -1315,6 +1322,7 @@ pub fn apply_soft_in_peer(bgp: &mut Bgp, peer_idx: usize) {
             attr_store: &mut bgp.attr_store,
             update_groups: &mut bgp.update_groups,
             interface_addrs: &bgp.interface_addrs,
+            vrf_export: None,
         };
         super::route::route_soft_in_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
     } else if supports_refresh {
@@ -1344,6 +1352,7 @@ pub fn apply_soft_out_peer(bgp: &mut Bgp, peer_idx: usize) {
         attr_store: &mut bgp.attr_store,
         update_groups: &mut bgp.update_groups,
         interface_addrs: &bgp.interface_addrs,
+        vrf_export: None,
     };
     super::route::route_soft_out_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -844,6 +844,22 @@ pub fn route_ipv4_update(
     rib.weight = decision.weight;
     let (_, selected, next_id) = bgp.local_rib.update(rd, nlri.prefix, rib.clone());
 
+    // Step 17b-iii: per-VRF best-path → global VPNv4 export. The
+    // hook only fires for IPv4 unicast (rd==None) inside a VRF
+    // task (`vrf_export` is Some). Empty `selected` after an
+    // update means the new candidate didn't survive best-path
+    // and there are no remaining winners — translate to a
+    // WithdrawExport so the global instance drops the row.
+    if rd.is_none()
+        && let Some(exporter) = bgp.vrf_export
+    {
+        if let Some(winner) = selected.first() {
+            super::vrf::vrf_emit_export(exporter, nlri.prefix, &winner.attr, 0);
+        } else {
+            super::vrf::vrf_emit_withdraw(exporter, nlri.prefix);
+        }
+    }
+
     // Plain IPv4 unicast best-path winners are installed to the kernel
     // FIB via RIB. VPNv4 lives in `local_rib.v4vpn` and has its own
     // (still-deferred) install path, so gate on rd==None.
@@ -1825,6 +1841,20 @@ pub fn route_ipv4_withdraw(
     // and a fresh Ipv4Add carries the new attrs.
     if rd.is_none() {
         fib_install_v4(bgp.rib_client, nlri.prefix, &selected);
+    }
+
+    // Step 17b-iii: VRF export — symmetric with `route_update_ipv4`.
+    // After a withdraw, either a replacement winner exists (emit a
+    // fresh Export so the global v4vpn row carries the new attrs)
+    // or `selected` is empty (emit WithdrawExport to drop the row).
+    if rd.is_none()
+        && let Some(exporter) = bgp.vrf_export
+    {
+        if let Some(winner) = selected.first() {
+            super::vrf::vrf_emit_export(exporter, nlri.prefix, &winner.attr, 0);
+        } else {
+            super::vrf::vrf_emit_withdraw(exporter, nlri.prefix);
+        }
     }
     if !selected.is_empty() || !removed.is_empty() {
         route_advertise_to_peers(rd, nlri.prefix, &selected, ident, bgp, peers);
@@ -3676,6 +3706,7 @@ impl Bgp {
             attr_store: &mut self.attr_store,
             update_groups: &mut self.update_groups,
             interface_addrs: &self.interface_addrs,
+            vrf_export: None,
         };
 
         if !selected.is_empty() {
@@ -3703,6 +3734,7 @@ impl Bgp {
             attr_store: &mut self.attr_store,
             update_groups: &mut self.update_groups,
             interface_addrs: &self.interface_addrs,
+            vrf_export: None,
         };
 
         let selected = bgp_ref.local_rib.select_best_path(prefix);
@@ -3793,6 +3825,7 @@ impl Bgp {
             attr_store: &mut self.attr_store,
             update_groups: &mut self.update_groups,
             interface_addrs: &self.interface_addrs,
+            vrf_export: None,
         };
 
         if !selected.is_empty() {
@@ -3820,6 +3853,7 @@ impl Bgp {
             attr_store: &mut self.attr_store,
             update_groups: &mut self.update_groups,
             interface_addrs: &self.interface_addrs,
+            vrf_export: None,
         };
 
         let selected = bgp_ref.local_rib.select_best_path(prefix);
@@ -3952,6 +3986,7 @@ impl Bgp {
             attr_store: &mut self.attr_store,
             update_groups: &mut self.update_groups,
             interface_addrs: &self.interface_addrs,
+            vrf_export: None,
         };
 
         if !selected.is_empty() {
@@ -4071,6 +4106,7 @@ impl Bgp {
             attr_store: &mut self.attr_store,
             update_groups: &mut self.update_groups,
             interface_addrs: &self.interface_addrs,
+            vrf_export: None,
         };
 
         if !selected.is_empty() {

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -123,6 +123,54 @@ pub struct BgpVrf {
 /// (step 16 / 18) can locate the matching VRF's queue.
 pub type BgpVrfInbox = UnboundedSender<BgpVrfMsg>;
 
+/// Hook handed to the shared `route_update_ipv4` path so a
+/// per-VRF best-path winner gets pushed up to the global Bgp
+/// task as a VPNv4 export candidate. Carries the VRF name (so
+/// the global side can look up RD + RT) and the per-VRF
+/// `global_tx` channel.
+///
+/// The global `Bgp` task constructs its own `BgpTop` with
+/// `vrf_export = None`, so the shared route pipeline doesn't
+/// fire any export for default-VRF traffic. Per-VRF tasks build
+/// a `BgpTop` with `Some(VrfExporter { ... })` and the same
+/// code path emits exports as a side-effect.
+pub struct VrfExporter {
+    pub name: String,
+    pub tx: UnboundedSender<BgpGlobalMsg>,
+}
+
+/// Send a `BgpGlobalMsg::Export` for `prefix` carrying the
+/// winner's `BgpAttr` (cloned out of the `Arc` so the global
+/// task can re-intern). Step 17b-iii's hook calls this from
+/// `route_update_ipv4` after best-path returns a non-empty
+/// `selected`. `label = 0` is the step-19 stub — the global
+/// handler treats that as "skip the per-route install" rather
+/// than emit an explicit-null label.
+pub fn vrf_emit_export(
+    exporter: &VrfExporter,
+    prefix: ipnet::Ipv4Net,
+    attr: &bgp_packet::BgpAttr,
+    label: u32,
+) {
+    let _ = exporter.tx.send(BgpGlobalMsg::Export {
+        vrf: exporter.name.clone(),
+        prefix,
+        attr: attr.clone(),
+        label,
+    });
+}
+
+/// Send a `BgpGlobalMsg::WithdrawExport` for `prefix`. Step
+/// 17b-iii calls this when `route_update_ipv4` / withdraw path
+/// observes the per-VRF best-path go from "has a winner" to
+/// "empty" — the global instance drops the matching VPNv4 row.
+pub fn vrf_emit_withdraw(exporter: &VrfExporter, prefix: ipnet::Ipv4Net) {
+    let _ = exporter.tx.send(BgpGlobalMsg::WithdrawExport {
+        vrf: exporter.name.clone(),
+        prefix,
+    });
+}
+
 impl BgpVrf {
     /// Build a `BgpVrf` and the matching inbound sender. The
     /// caller (step 14's `spawn_bgp_vrf`) keeps the
@@ -247,6 +295,17 @@ impl BgpVrf {
         use super::super::peer::{BgpTop, fsm};
         match msg {
             Message::Event(ident, event) => {
+                // Build a fresh `VrfExporter` per call so the
+                // shared `route_update_ipv4` path emits Export to
+                // the global Bgp instance when this VRF's
+                // best-path changes. The handle is the same
+                // `global_tx` the per-VRF runtime already holds;
+                // we wrap it with the VRF name so the receiver
+                // can resolve RD/RT.
+                let exporter = VrfExporter {
+                    name: self.name.clone(),
+                    tx: self.global_tx.clone(),
+                };
                 let mut top = BgpTop {
                     router_id: &self.router_id,
                     local_rib: &mut self.local_rib,
@@ -255,6 +314,7 @@ impl BgpVrf {
                     attr_store: &mut self.attr_store,
                     update_groups: &mut self.update_groups,
                     interface_addrs: &self.interface_addrs,
+                    vrf_export: Some(&exporter),
                 };
                 fsm(&mut top, &mut self.peers, ident, event);
             }
@@ -458,6 +518,59 @@ mod tests {
         match msg {
             BgpGlobalMsg::WithdrawExport { vrf: v, prefix: p } => {
                 assert_eq!(v, "vrf-withdraw");
+                assert_eq!(p, prefix);
+            }
+            other => panic!("expected WithdrawExport, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn vrf_emit_export_sends_export_msg_via_exporter() {
+        // Step 17b-iii: the free-function hook called from
+        // `route_update_ipv4`'s post-best-path arm pushes an
+        // Export with the winner's prefix + attr + label stub.
+        let (tx, mut rx) = unbounded_channel::<BgpGlobalMsg>();
+        let exporter = VrfExporter {
+            name: "vrf-hook".to_string(),
+            tx,
+        };
+        let prefix: ipnet::Ipv4Net = "10.0.0.0/24".parse().unwrap();
+        let attr = bgp_packet::BgpAttr::default();
+
+        vrf_emit_export(&exporter, prefix, &attr, 0);
+
+        let msg = rx.try_recv().expect("Export pushed");
+        match msg {
+            BgpGlobalMsg::Export {
+                vrf,
+                prefix: p,
+                attr: a,
+                label,
+            } => {
+                assert_eq!(vrf, "vrf-hook");
+                assert_eq!(p, prefix);
+                assert_eq!(a, attr);
+                assert_eq!(label, 0);
+            }
+            other => panic!("expected Export, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn vrf_emit_withdraw_sends_withdraw_export_msg() {
+        let (tx, mut rx) = unbounded_channel::<BgpGlobalMsg>();
+        let exporter = VrfExporter {
+            name: "vrf-hook2".to_string(),
+            tx,
+        };
+        let prefix: ipnet::Ipv4Net = "10.0.0.0/24".parse().unwrap();
+
+        vrf_emit_withdraw(&exporter, prefix);
+
+        let msg = rx.try_recv().expect("WithdrawExport pushed");
+        match msg {
+            BgpGlobalMsg::WithdrawExport { vrf, prefix: p } => {
+                assert_eq!(vrf, "vrf-hook2");
                 assert_eq!(p, prefix);
             }
             other => panic!("expected WithdrawExport, got {other:?}"),

--- a/zebra-rs/src/bgp/vrf/mod.rs
+++ b/zebra-rs/src/bgp/vrf/mod.rs
@@ -24,5 +24,6 @@ pub mod spawn;
 // only reach for the names below. `inst::{BgpVrf, serve_vrf}` and
 // `msg::BgpVrfMsg` stay internal — they're constructed / consumed
 // inside `vrf::spawn` only.
+pub use inst::{VrfExporter, vrf_emit_export, vrf_emit_withdraw};
 pub use msg::BgpGlobalMsg;
 pub use spawn::{BgpVrfHandle, compute_vrf_diff, despawn_bgp_vrf, spawn_bgp_vrf};


### PR DESCRIPTION
## Summary

Step 17b-iii of the BGP MPLS/VPN refactor. Closes the producer
side of the export pipeline: the shared `route_update_ipv4` /
`route_ipv4_withdraw` paths now fire `BgpGlobalMsg::Export` /
`WithdrawExport` as a side-effect of best-path transitions when
they run inside a `BgpVrf` task. Step 17b-ii's handler already
writes those into `LocalRib.v4vpn`, so this PR completes the
LocRIB-write half of the pipeline.

Missing for end-to-end "VRF CE peer advertises a prefix, PE peer
sees VPNv4 NLRI on the wire": the update-group flush from
`LocalRib.v4vpn` out to PE peers. That's step 17c.

- `VrfExporter { name, tx }` and `vrf_emit_export` /
  `vrf_emit_withdraw` free functions in `bgp::vrf::inst`. Re-
  exported via `bgp::vrf` for cross-module use.
- `BgpTop` gains `vrf_export: Option<&'a VrfExporter>`. Every
  existing site sets `vrf_export: None`. `BgpVrf::process_msg(Event)`
  constructs a `VrfExporter` per call and threads
  `Some(&exporter)` to `fsm()`.
- `route_update_ipv4` (post `local_rib.update`) and
  `route_ipv4_withdraw` (post withdraw) gate on
  `rd.is_none() && bgp.vrf_export.is_some()`. Non-empty `selected`
  -> Export with the winner's attr; empty -> WithdrawExport.
  Label stub `0` (step 19 wires the real label).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` (579 unit tests pass;
      +2 new emit-helper tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)