### PR TITLE
bgp: advertise VRF Export winners to VPNv4 peers

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1353,16 +1353,47 @@ impl Bgp {
                     esi: None,
                 };
 
-                let (added, removed, _gen) = self.local_rib.update(Some(rd), prefix, rib);
+                let (_, selected, _gen) = self.local_rib.update(Some(rd), prefix, rib);
+                let selected_len = selected.len();
+
+                // Step 17c: fan out the new VPNv4 winner to PE
+                // peers via the existing `route_advertise_to_peers`
+                // helper. The helper iterates Established peers
+                // matching (Afi=Ip, Safi=MplsVpn), runs split-
+                // horizon + outbound policy + RTC, and pushes to
+                // each peer's `cache_vpnv4` (debounced flush). The
+                // global instance has `vrf_export = None`, so no
+                // infinite loop on the export hook in
+                // `route_ipv4_update`.
+                let mut top = super::peer::BgpTop {
+                    router_id: &self.router_id,
+                    local_rib: &mut self.local_rib,
+                    tx: &self.tx,
+                    rib_client: &self.ctx.rib,
+                    attr_store: &mut self.attr_store,
+                    update_groups: &mut self.update_groups,
+                    interface_addrs: &self.interface_addrs,
+                    color_policy: Some(&self.color_policy),
+                    flex_algo_routes: Some(&self.flex_algo_routes),
+                    vrf_export: None,
+                };
+                super::route::route_advertise_to_peers(
+                    Some(rd),
+                    prefix,
+                    &selected,
+                    /* source peer */ 0,
+                    &mut top,
+                    &mut self.peers,
+                );
+
                 tracing::info!(
                     vrf = %vrf,
                     %prefix,
                     rd = %rd,
                     export_rts = export_rts.len(),
                     label,
-                    added = added.len(),
-                    removed = removed.len(),
-                    "bgp: export written to LocalRib.v4vpn (update-group flush lands in step 17c)",
+                    winners = selected_len,
+                    "bgp: export written to LocalRib.v4vpn and advertised to PE peers",
                 );
             }
             super::vrf::BgpGlobalMsg::WithdrawExport { vrf, prefix } => {
@@ -1379,12 +1410,41 @@ impl Bgp {
                 // matching Export); the remove path uses that
                 // tuple to identify the row.
                 let removed = self.local_rib.remove(Some(rd), prefix, 0, 0);
+
+                // Re-run best-path so any remaining candidate at
+                // (rd, prefix) becomes the new selected winner.
+                // Pass that result to `route_advertise_to_peers` —
+                // empty `selected` triggers the Withdraw branch
+                // there (`peer.adj_out` cleanup, MP_UNREACH emit).
+                let selected = self.local_rib.select_best_path_vpn(&rd, prefix);
+                let mut top = super::peer::BgpTop {
+                    router_id: &self.router_id,
+                    local_rib: &mut self.local_rib,
+                    tx: &self.tx,
+                    rib_client: &self.ctx.rib,
+                    attr_store: &mut self.attr_store,
+                    update_groups: &mut self.update_groups,
+                    interface_addrs: &self.interface_addrs,
+                    color_policy: Some(&self.color_policy),
+                    flex_algo_routes: Some(&self.flex_algo_routes),
+                    vrf_export: None,
+                };
+                super::route::route_advertise_to_peers(
+                    Some(rd),
+                    prefix,
+                    &selected,
+                    /* source peer */ 0,
+                    &mut top,
+                    &mut self.peers,
+                );
+
                 tracing::info!(
                     vrf = %vrf,
                     %prefix,
                     rd = %rd,
                     removed = removed.len(),
-                    "bgp: export withdrawn from LocalRib.v4vpn",
+                    winners = selected.len(),
+                    "bgp: export withdrawn from LocalRib.v4vpn and PE peers",
                 );
             }
             super::vrf::BgpGlobalMsg::RegisterPeer { vrf, addr } => {

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1111,7 +1111,7 @@ fn bump_group_counters_on_miss(
     }
 }
 
-fn route_advertise_to_peers(
+pub(super) fn route_advertise_to_peers(
     rd: Option<RouteDistinguisher>,
     prefix: Ipv4Net,
     selected: &[BgpRib],


### PR DESCRIPTION
## Summary

Step 17c of the BGP MPLS/VPN refactor. Completes the export
pipeline: when the global Bgp's Export handler writes a new
VPNv4 row into `LocalRib.v4vpn[rd]`, every Established peer
with (AFI=Ip, SAFI=MplsVpn) gets the new path through the
existing `route_advertise_to_peers` helper (split-horizon,
outbound policy, RTC filtering, attribute interning, then
`peer.send_vpnv4` -> debounced MP_REACH UPDATE on the wire).
Symmetric `WithdrawExport` re-runs best-path and feeds the
result to the same helper — empty fires the existing Withdraw
branch (MP_UNREACH).

- `route::route_advertise_to_peers` promoted from `fn` to
  `pub(super) fn`.
- `Bgp::process_vrf_global_msg(Export)` constructs a `BgpTop`
  with `vrf_export: None` (avoids the step-17b-iii hook re-
  firing inside the global instance) and calls the helper.
- `Bgp::process_vrf_global_msg(WithdrawExport)` calls
  `local_rib.select_best_path_vpn(&rd, prefix)` after `remove`,
  then advertises via the same helper.

End-to-end: CE peer advertising a prefix -> step-17b-iii hook
-> step-17b-ii LocRIB write -> step-17c update-group flush ->
VPNv4 UPDATE on the wire. Label is still the step-19 stub.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` (579 unit tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)