### PR TITLE
bgp: dispatch global VPNv4 routes to importing VRF tasks

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -88,6 +88,7 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
             vrf_export: None,
             color_policy: Some(&bgp.color_policy),
             flex_algo_routes: Some(&bgp.flex_algo_routes),
+            vrf_import: None,
         };
         route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers);
         bgp.peers.remove(&addr);

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -128,6 +128,56 @@ pub(crate) fn tag_attr_with_export_rts(
     attr
 }
 
+/// Walk `vrf_index` and return every VRF name whose
+/// `import_rts_v4` intersects the route's Route-Target extended
+/// communities in `ecom`. RTs on the wire are distinguished from
+/// other extended communities by the (`high_type`, `low_type`)
+/// pair — RFC 4360 §4.1 puts the sub-type at `low_type = 0x02`.
+/// Routes with no RT extcomms match no VRF; routes with RTs that
+/// no configured VRF imports match no VRF either (and the global
+/// VPNv4 row sits in `local_rib.v4vpn` unimported).
+pub(crate) fn matching_import_vrfs(
+    vrf_index: &BTreeMap<String, RibKnownVrf>,
+    ecom: &Option<bgp_packet::ExtCommunity>,
+) -> Vec<String> {
+    let Some(ecom) = ecom else {
+        return Vec::new();
+    };
+    // Build the set of RTs the route carries: every extcomm with
+    // RT sub-type, reinterpreted as a `RouteDistinguisher` (RT and
+    // RD share the on-wire 6-octet shape — same trick as step 17a).
+    let route_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher> = ecom
+        .0
+        .iter()
+        .filter(|v| v.low_type == 0x02)
+        .map(|v| {
+            use bgp_packet::RouteDistinguisherType;
+            // high_type 0x00 = Two-Octet AS, 0x01 = IPv4. Anything
+            // else (0x02 = 4-byte AS, future types) maps onto ASN
+            // by default — `RouteDistinguisher::PartialEq` is per-
+            // byte so a 4-byte ASN extcomm just won't intersect
+            // any configured RT (the config builder rejects 4-byte
+            // ASN strings today).
+            let typ = if v.high_type == 0x01 {
+                RouteDistinguisherType::IP
+            } else {
+                RouteDistinguisherType::ASN
+            };
+            let mut rd = bgp_packet::RouteDistinguisher::new(typ);
+            rd.val = v.val;
+            rd
+        })
+        .collect();
+    if route_rts.is_empty() {
+        return Vec::new();
+    }
+    vrf_index
+        .iter()
+        .filter(|(_, info)| !info.import_rts_v4.is_disjoint(&route_rts))
+        .map(|(name, _)| name.clone())
+        .collect()
+}
+
 /// Kernel VRF master info as observed by `Bgp` via
 /// `RibRx::VrfAdd` and the matching RT sets observed via
 /// `RibRx::VrfRouteTargets`. Used by
@@ -621,6 +671,17 @@ impl Bgp {
                 // dynamic-peer GC below.
                 let prev_state = self.peers.get_by_idx(ident).map(|p| p.state);
 
+                // Step 18a: the global v4vpn ingest path uses this
+                // dispatcher to fan accepted VPNv4 routes out to
+                // every VRF whose `import_rts_v4` matches. Borrows
+                // are disjoint from the BgpTop mutable refs below
+                // (`rib_known_vrfs` and `vrf_registry` are different
+                // fields).
+                let import_dispatcher = super::vrf::VrfImportDispatcher {
+                    rib_known_vrfs: &self.rib_known_vrfs,
+                    vrf_registry: &self.vrf_registry,
+                };
+
                 let mut bgp_ref = BgpTop {
                     router_id: &self.router_id,
                     local_rib: &mut self.local_rib,
@@ -632,6 +693,7 @@ impl Bgp {
                     vrf_export: None,
                     color_policy: Some(&self.color_policy),
                     flex_algo_routes: Some(&self.flex_algo_routes),
+                    vrf_import: Some(&import_dispatcher),
                 };
 
                 fsm(&mut bgp_ref, &mut self.peers, ident, event);
@@ -1376,6 +1438,7 @@ impl Bgp {
                     color_policy: Some(&self.color_policy),
                     flex_algo_routes: Some(&self.flex_algo_routes),
                     vrf_export: None,
+                    vrf_import: None,
                 };
                 super::route::route_advertise_to_peers(
                     Some(rd),
@@ -1428,6 +1491,7 @@ impl Bgp {
                     color_policy: Some(&self.color_policy),
                     flex_algo_routes: Some(&self.flex_algo_routes),
                     vrf_export: None,
+                    vrf_import: None,
                 };
                 super::route::route_advertise_to_peers(
                     Some(rd),
@@ -1688,6 +1752,99 @@ mod tests {
             assert_eq!(ecom.0.len(), 2, "colour + RT");
             assert_eq!(ecom.0[0], preexisting, "colour stays at index 0");
             assert_eq!(ecom.0[1].low_type, 0x02, "RT appended");
+        }
+    }
+
+    /// Step 18a: `matching_import_vrfs` walks `rib_known_vrfs`
+    /// and returns every VRF whose `import_rts_v4` intersects
+    /// the route's RT ext-communities.
+    mod matching_import_vrfs_tests {
+        use std::collections::{BTreeMap, BTreeSet};
+        use std::str::FromStr;
+
+        use bgp_packet::{ExtCommunity, ExtCommunityValue, RouteDistinguisher};
+
+        use super::super::{RibKnownVrf, matching_import_vrfs};
+
+        fn rt(s: &str) -> RouteDistinguisher {
+            RouteDistinguisher::from_str(s).unwrap()
+        }
+
+        fn rt_extcom(rt_str: &str) -> ExtCommunityValue {
+            let mut v: ExtCommunityValue = rt(rt_str).into();
+            v.low_type = 0x02;
+            v
+        }
+
+        fn vrf_with_imports(rts: &[&str]) -> RibKnownVrf {
+            let mut import_rts_v4 = BTreeSet::new();
+            for s in rts {
+                import_rts_v4.insert(rt(s));
+            }
+            RibKnownVrf {
+                table_id: 100,
+                ifindex: 1,
+                import_rts_v4,
+                export_rts_v4: BTreeSet::new(),
+                import_rts_v6: BTreeSet::new(),
+                export_rts_v6: BTreeSet::new(),
+            }
+        }
+
+        #[test]
+        fn no_ecom_attr_matches_no_vrf() {
+            // A VPNv4 route with no RT ext-communities can't be
+            // imported anywhere.
+            let mut index = BTreeMap::new();
+            index.insert("v1".to_string(), vrf_with_imports(&["65000:1"]));
+            assert!(matching_import_vrfs(&index, &None).is_empty());
+        }
+
+        #[test]
+        fn empty_ecom_attr_matches_no_vrf() {
+            let mut index = BTreeMap::new();
+            index.insert("v1".to_string(), vrf_with_imports(&["65000:1"]));
+            let ecom = Some(ExtCommunity::default());
+            assert!(matching_import_vrfs(&index, &ecom).is_empty());
+        }
+
+        #[test]
+        fn rt_matches_single_importing_vrf() {
+            let mut index = BTreeMap::new();
+            index.insert("v1".to_string(), vrf_with_imports(&["65000:1"]));
+            index.insert("v2".to_string(), vrf_with_imports(&["65000:2"]));
+            let ecom = Some(ExtCommunity(vec![rt_extcom("65000:1")]));
+            assert_eq!(matching_import_vrfs(&index, &ecom), vec!["v1".to_string()]);
+        }
+
+        #[test]
+        fn rt_matches_multiple_importing_vrfs() {
+            // Two VRFs both import RT 65000:99. A route with that
+            // RT should be delivered to both. Order follows
+            // BTreeMap key iteration (sorted by name) — caller
+            // doesn't depend on order but the test pins it for
+            // determinism.
+            let mut index = BTreeMap::new();
+            index.insert("v1".to_string(), vrf_with_imports(&["65000:99"]));
+            index.insert("v2".to_string(), vrf_with_imports(&["65000:99"]));
+            let ecom = Some(ExtCommunity(vec![rt_extcom("65000:99")]));
+            let mut got = matching_import_vrfs(&index, &ecom);
+            got.sort();
+            assert_eq!(got, vec!["v1".to_string(), "v2".to_string()]);
+        }
+
+        #[test]
+        fn non_rt_extcomm_does_not_count_as_rt() {
+            // An ext-community with low_type != 0x02 (e.g.
+            // Route-Origin sub-type 0x03) must not be treated as
+            // an RT — even if its 6-octet value happens to match
+            // a configured RT.
+            let mut origin: ExtCommunityValue = rt("65000:1").into();
+            origin.low_type = 0x03;
+            let mut index = BTreeMap::new();
+            index.insert("v1".to_string(), vrf_with_imports(&["65000:1"]));
+            let ecom = Some(ExtCommunity(vec![origin]));
+            assert!(matching_import_vrfs(&index, &ecom).is_empty());
         }
     }
 }

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -586,6 +586,13 @@ pub struct BgpTop<'a> {
     /// `vrf_emit_withdraw` on best-path transitions so the global
     /// instance's VPNv4 LocRIB picks them up.
     pub vrf_export: Option<&'a super::vrf::VrfExporter>,
+    /// VRF import dispatcher. Inverse of `vrf_export`: `Some(...)`
+    /// in the global `Bgp` task; the v4vpn ingest path fans
+    /// incoming routes out to every VRF whose `import_rts_v4`
+    /// intersects the route's RT extcomms via
+    /// `BgpVrfMsg::ImportV4`. `None` inside per-VRF tasks (they
+    /// never receive VPNv4 NLRI directly).
+    pub vrf_import: Option<&'a super::vrf::VrfImportDispatcher<'a>>,
     /// Colour-aware nexthop resolver inputs (Phase 3b). Optional
     /// because per-VRF BGP runtimes don't carry them today — Color →
     /// Flex-Algo binding is a default-VRF concept; per-VRF support
@@ -1337,6 +1344,7 @@ pub fn apply_soft_in_peer(bgp: &mut Bgp, peer_idx: usize) {
             vrf_export: None,
             color_policy: Some(&bgp.color_policy),
             flex_algo_routes: Some(&bgp.flex_algo_routes),
+            vrf_import: None,
         };
         super::route::route_soft_in_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
     } else if supports_refresh {
@@ -1369,6 +1377,7 @@ pub fn apply_soft_out_peer(bgp: &mut Bgp, peer_idx: usize) {
         vrf_export: None,
         color_policy: Some(&bgp.color_policy),
         flex_algo_routes: Some(&bgp.flex_algo_routes),
+        vrf_import: None,
     };
     super::route::route_soft_out_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -906,6 +906,25 @@ pub fn route_ipv4_update(
         }
     }
 
+    // Step 18a: global v4vpn best-path → per-VRF import. Inverse
+    // of the step-17b-iii hook: when an incoming VPNv4 route
+    // becomes the global best-path winner, fan out to every VRF
+    // whose `import_rts_v4` intersects the route's RT extcomms.
+    // `vrf_import` is `Some(...)` only in the global Bgp task;
+    // per-VRF runtimes never receive VPNv4 NLRI directly.
+    if let Some(rd) = rd
+        && let Some(dispatcher) = bgp.vrf_import
+    {
+        if let Some(winner) = selected.first() {
+            super::vrf::dispatch_import_v4(dispatcher, rd, nlri.prefix, &winner.attr, 0);
+        } else {
+            // best-path stripped the candidate; flood withdraw
+            // using the *new* attr (the one just rejected) so
+            // the matching-VRF set still resolves the same way.
+            super::vrf::dispatch_withdraw_import_v4(dispatcher, rd, nlri.prefix, &rib.attr);
+        }
+    }
+
     // Plain IPv4 unicast best-path winners are installed to the kernel
     // FIB via RIB. VPNv4 lives in `local_rib.v4vpn` and has its own
     // (still-deferred) install path, so gate on rd==None.
@@ -1900,6 +1919,22 @@ pub fn route_ipv4_withdraw(
             super::vrf::vrf_emit_export(exporter, nlri.prefix, &winner.attr, 0);
         } else {
             super::vrf::vrf_emit_withdraw(exporter, nlri.prefix);
+        }
+    }
+
+    // Step 18a: global v4vpn withdraw → per-VRF import dispatch.
+    // If a replacement winner survives best-path, that VPNv4 row
+    // now carries a different attr; re-import with the new attr.
+    // If `selected` is empty, the route truly went away — flood
+    // a WithdrawImport using the *removed* row's attr to resolve
+    // the matching-VRF set (we no longer have the new attr).
+    if let Some(rd) = rd
+        && let Some(dispatcher) = bgp.vrf_import
+    {
+        if let Some(winner) = selected.first() {
+            super::vrf::dispatch_import_v4(dispatcher, rd, nlri.prefix, &winner.attr, 0);
+        } else if let Some(gone) = removed.first() {
+            super::vrf::dispatch_withdraw_import_v4(dispatcher, rd, nlri.prefix, &gone.attr);
         }
     }
     if !selected.is_empty() || !removed.is_empty() {
@@ -3747,6 +3782,7 @@ impl Bgp {
             vrf_export: None,
             color_policy: Some(&self.color_policy),
             flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
         };
 
         // An originated route lacks a v4 NEXT_HOP attribute, so when
@@ -3785,6 +3821,7 @@ impl Bgp {
             vrf_export: None,
             color_policy: Some(&self.color_policy),
             flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
         };
 
         let selected = bgp_ref.local_rib.select_best_path(prefix);
@@ -3872,6 +3909,7 @@ impl Bgp {
             vrf_export: None,
             color_policy: Some(&self.color_policy),
             flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
         };
 
         // Same logic as `route_add`: the redistributed BGP route has
@@ -3908,6 +3946,7 @@ impl Bgp {
             vrf_export: None,
             color_policy: Some(&self.color_policy),
             flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
         };
 
         let selected = bgp_ref.local_rib.select_best_path(prefix);
@@ -4043,6 +4082,7 @@ impl Bgp {
             vrf_export: None,
             color_policy: Some(&self.color_policy),
             flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
         };
 
         if !selected.is_empty() {
@@ -4165,6 +4205,7 @@ impl Bgp {
             vrf_export: None,
             color_policy: Some(&self.color_policy),
             flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
         };
 
         if !selected.is_empty() {

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -171,6 +171,66 @@ pub fn vrf_emit_withdraw(exporter: &VrfExporter, prefix: ipnet::Ipv4Net) {
     });
 }
 
+/// Inverse of [`VrfExporter`] — references the global Bgp state
+/// the shared `route_ipv4_update` path needs to fan a VPNv4
+/// route out to every importing VRF task.
+///
+/// Carries `rib_known_vrfs` (for the RT intersection check) and
+/// `vrf_registry` (for the per-VRF inbound senders). Both are
+/// borrowed from the global `Bgp` for the span of one
+/// `process_msg` call.
+pub struct VrfImportDispatcher<'a> {
+    pub rib_known_vrfs: &'a std::collections::BTreeMap<String, super::super::inst::RibKnownVrf>,
+    pub vrf_registry: &'a std::collections::BTreeMap<String, super::spawn::BgpVrfHandle>,
+}
+
+/// Fan a freshly best-path-selected VPNv4 route out to every
+/// VRF whose `import_rts_v4` intersects the route's RT extcomms.
+/// Called from the shared `route_ipv4_update` after
+/// `local_rib.update(Some(rd), ...)` returns. `label = 0` is the
+/// step-19 stub — the receiving VRF treats it the same way the
+/// Export side does (skip the install).
+pub fn dispatch_import_v4(
+    dispatcher: &VrfImportDispatcher<'_>,
+    rd: bgp_packet::RouteDistinguisher,
+    prefix: ipnet::Ipv4Net,
+    attr: &bgp_packet::BgpAttr,
+    label: u32,
+) {
+    let matches = super::super::inst::matching_import_vrfs(dispatcher.rib_known_vrfs, &attr.ecom);
+    for vrf_name in matches {
+        let Some(handle) = dispatcher.vrf_registry.get(&vrf_name) else {
+            continue;
+        };
+        let _ = handle.inbox.send(BgpVrfMsg::ImportV4 {
+            rd,
+            prefix,
+            attr: attr.clone(),
+            label,
+        });
+    }
+}
+
+/// Inverse of [`dispatch_import_v4`]. Floods
+/// `BgpVrfMsg::WithdrawImport` to every VRF whose
+/// `import_rts_v4` matches; the receiver decides whether the
+/// matching imported route is one it actually holds (step 18b
+/// wires the receive-side filter).
+pub fn dispatch_withdraw_import_v4(
+    dispatcher: &VrfImportDispatcher<'_>,
+    rd: bgp_packet::RouteDistinguisher,
+    prefix: ipnet::Ipv4Net,
+    attr: &bgp_packet::BgpAttr,
+) {
+    let matches = super::super::inst::matching_import_vrfs(dispatcher.rib_known_vrfs, &attr.ecom);
+    for vrf_name in matches {
+        let Some(handle) = dispatcher.vrf_registry.get(&vrf_name) else {
+            continue;
+        };
+        let _ = handle.inbox.send(BgpVrfMsg::WithdrawImport { rd, prefix });
+    }
+}
+
 impl BgpVrf {
     /// Build a `BgpVrf` and the matching inbound sender. The
     /// caller (step 14's `spawn_bgp_vrf`) keeps the
@@ -319,6 +379,9 @@ impl BgpVrf {
                     // concept today; per-VRF support is a follow-up.
                     color_policy: None,
                     flex_algo_routes: None,
+                    // Per-VRF tasks never receive VPNv4 NLRI directly,
+                    // so no import dispatcher to thread through.
+                    vrf_import: None,
                 };
                 fsm(&mut top, &mut self.peers, ident, event);
             }
@@ -371,11 +434,36 @@ impl BgpVrf {
                     "bgp vrf: received inbound Accept (FSM driver lands in step 15d)",
                 );
             }
-            BgpVrfMsg::ImportV4 { .. } | BgpVrfMsg::ImportV6 { .. } => {
-                // Step 18 wires the import insert + best-path.
+            BgpVrfMsg::ImportV4 {
+                rd,
+                prefix,
+                attr: _,
+                label,
+            } => {
+                // Step 18a delivers the payload; step 18b's
+                // handler runs best-path insert into
+                // `self.local_rib.v4` with `BgpRibType::Originated`.
+                // Until then, surface the import at info so
+                // operators can spot the path arriving via the
+                // log stream during a development bring-up.
+                tracing::info!(
+                    vrf = %self.name,
+                    %prefix,
+                    rd = %rd,
+                    label,
+                    "bgp vrf: received ImportV4 (LocRIB insert lands in step 18b)",
+                );
             }
-            BgpVrfMsg::WithdrawImport { .. } => {
-                // Step 18.
+            BgpVrfMsg::ImportV6 { .. } => {
+                // v6 import lands after v4 ships.
+            }
+            BgpVrfMsg::WithdrawImport { rd, prefix } => {
+                tracing::info!(
+                    vrf = %self.name,
+                    %prefix,
+                    rd = %rd,
+                    "bgp vrf: received WithdrawImport (LocRIB remove lands in step 18b)",
+                );
             }
             BgpVrfMsg::Shutdown => unreachable!("handled in event_loop"),
         }

--- a/zebra-rs/src/bgp/vrf/mod.rs
+++ b/zebra-rs/src/bgp/vrf/mod.rs
@@ -24,6 +24,9 @@ pub mod spawn;
 // only reach for the names below. `inst::{BgpVrf, serve_vrf}` and
 // `msg::BgpVrfMsg` stay internal — they're constructed / consumed
 // inside `vrf::spawn` only.
-pub use inst::{VrfExporter, vrf_emit_export, vrf_emit_withdraw};
+pub use inst::{
+    VrfExporter, VrfImportDispatcher, dispatch_import_v4, dispatch_withdraw_import_v4,
+    vrf_emit_export, vrf_emit_withdraw,
+};
 pub use msg::BgpGlobalMsg;
 pub use spawn::{BgpVrfHandle, compute_vrf_diff, despawn_bgp_vrf, spawn_bgp_vrf};

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -43,17 +43,25 @@ pub enum BgpVrfMsg {
     ),
 
     /// VPNv4 best-path import. The global Loc-RIB resolved a route
-    /// whose RT list intersects this VRF's import-RT set; the per-
-    /// VRF task inserts it into its IPv4 unicast Loc-RIB and runs
-    /// best-path. Payload shape lands with step 18.
-    #[allow(dead_code)]
+    /// whose RT list intersects this VRF's `import_rts_v4`; the
+    /// per-VRF task strips the RD and inserts the route into its
+    /// own IPv4 unicast Loc-RIB. `attr` travels by value so the
+    /// per-VRF task can re-intern into its own `BgpAttrStore`
+    /// without locking; `label` is the per-VRF MPLS label the
+    /// originator advertised (step 19 wires the matching ILM
+    /// install). Step 18a delivers the payload but the per-VRF
+    /// handler is still a log-only stub — the LocRIB write lands
+    /// in step 18b.
     ImportV4 {
         rd: RouteDistinguisher,
-        // step 18 fills the remaining fields: prefix, BgpAttr id,
-        // label, peer ident, etc.
+        prefix: ipnet::Ipv4Net,
+        #[allow(dead_code)] // first reader lands in step 18b.
+        attr: BgpAttr,
+        label: u32,
     },
 
     /// VPNv6 best-path import. Symmetric to [`Self::ImportV4`].
+    /// Stays a placeholder until v6 imports follow v4.
     #[allow(dead_code)]
     ImportV6 {
         rd: RouteDistinguisher,
@@ -63,8 +71,10 @@ pub enum BgpVrfMsg {
     /// Withdraw a previously-imported route. RD identifies the
     /// origin row; the per-VRF task locates the matching imported
     /// path and runs best-path withdraw.
-    #[allow(dead_code)]
-    WithdrawImport { rd: RouteDistinguisher },
+    WithdrawImport {
+        rd: RouteDistinguisher,
+        prefix: ipnet::Ipv4Net,
+    },
 
     /// Tear the VRF task down cleanly. The event loop exits on the
     /// next select iteration after receiving this. Used by step


### PR DESCRIPTION
## Summary

Step 18a of the BGP MPLS/VPN refactor — import-side counterpart
to step 17b-iii. When the global Bgp's v4vpn ingest path accepts
a VPNv4 UPDATE and best-path returns a winner, the shared
`route_ipv4_update` / `route_ipv4_withdraw` fan
`BgpVrfMsg::ImportV4` / `WithdrawImport` out to every VRF whose
`import_rts_v4` intersects the route's RT extended communities.
Per-VRF handler logs at info; LocRIB insert is step 18b.

- `BgpVrfMsg::ImportV4` payload: `prefix`, `attr` (by value),
  `label`. `WithdrawImport` adds `prefix`.
- `inst::matching_import_vrfs(rib_known_vrfs, ecom)` — pure
  helper scanning RT sub-type (`low_type == 0x02`) extcomms and
  returning every VRF whose `import_rts_v4` intersects.
- `bgp::vrf::VrfImportDispatcher<'a>` bundles `&rib_known_vrfs`
  + `&vrf_registry`; `dispatch_import_v4` /
  `dispatch_withdraw_import_v4` push to each matching VRF inbox.
- `BgpTop` gains `vrf_import`; global `Bgp::process_msg(Event)`
  constructs `Some(&dispatcher)`. Per-VRF tasks pass `None`.
- `route_ipv4_update` (rd.is_some): non-empty selected →
  `dispatch_import_v4` with winner attr; empty →
  `dispatch_withdraw_import_v4` with candidate attr. Symmetric
  hook in `route_ipv4_withdraw`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` (591 unit tests pass;
      +5 new `matching_import_vrfs_tests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)