### PR TITLE
bgp: per-VRF MPLS label allocator (step 19a)

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -348,6 +348,12 @@ pub struct Bgp {
     /// step-9 inbound dispatcher routes route installs into
     /// `vrf_tables[table_id]`.
     pub rib_subscriber: crate::config::RibSubscriber,
+    /// Per-VRF MPLS label allocator (step 19a). Hands out one
+    /// label per `spawn_bgp_vrf` call; reclaims at despawn. The
+    /// label gets stamped onto every `BgpGlobalMsg::Export` the
+    /// VRF emits and (step 19b) drives the matching ILM Decap
+    /// install on the PE.
+    pub vrf_label_alloc: super::vrf::VrfLabelAllocator,
     /// Inbound `:179` dispatch index — peer source IP to VRF name.
     /// Populated by [`super::vrf::BgpGlobalMsg::RegisterPeer`]
     /// each per-VRF task emits at spawn / materialise time, and
@@ -505,6 +511,7 @@ impl Bgp {
             vrf_registry: BTreeMap::new(),
             rib_known_vrfs: BTreeMap::new(),
             rib_subscriber,
+            vrf_label_alloc: super::vrf::VrfLabelAllocator::new(),
             peer_index: BTreeMap::new(),
             vrf_global_tx: vrf_global_tx_init,
             vrf_global_rx: vrf_global_rx_init,
@@ -797,6 +804,11 @@ impl Bgp {
         for name in to_despawn {
             if let Some(handle) = self.vrf_registry.remove(&name) {
                 super::vrf::despawn_bgp_vrf(&name, &handle);
+                // Return the label to the pool so a future VRF
+                // can pick it back up. Reclaim before the handle
+                // drops — handle drop aborts the task but doesn't
+                // know about the allocator.
+                self.vrf_label_alloc.free(handle.label);
                 // Drop every `peer_index` entry that pointed at
                 // this VRF — defensive cleanup against the VRF
                 // task exiting before its `UnregisterPeer`
@@ -812,11 +824,21 @@ impl Bgp {
                 continue;
             };
             let kernel = self.rib_known_vrfs.get(&name).cloned();
+            // Allocate a fresh MPLS label for this VRF — used in
+            // every `BgpGlobalMsg::Export` it emits and (step 19b)
+            // bound to an AF_MPLS ILM for PE-side decap. The
+            // 20-bit label space is large enough that the
+            // `.unwrap_or(0)` fallback effectively never fires;
+            // 0 would mean "no label" downstream, which the
+            // Export handler already treats as "skip label
+            // install" — a safe degradation.
+            let label = self.vrf_label_alloc.alloc().unwrap_or(0);
             let handle = super::vrf::spawn_bgp_vrf(
                 name.clone(),
                 &cfg,
                 self.router_id,
                 self.asn,
+                label,
                 kernel,
                 &self.rib_subscriber,
                 self.vrf_global_tx.clone(),
@@ -848,19 +870,26 @@ impl Bgp {
         // Tear the placeholder-ctx task down before spawning the
         // real one. `despawn_bgp_vrf` sends Shutdown; the handle
         // drop right after aborts the runtime if the loop hasn't
-        // yet drained the signal.
-        if let Some(handle) = self.vrf_registry.remove(name) {
+        // yet drained the signal. Preserve the existing label so
+        // the respawn stays addressable from any PE that already
+        // cached it; the original allocation stays held on the
+        // new handle.
+        let preserved_label = if let Some(handle) = self.vrf_registry.remove(name) {
             super::vrf::despawn_bgp_vrf(name, &handle);
             // Clear stale `peer_index` entries — the spawned task
             // is about to push fresh RegisterPeer messages.
             self.peer_index.retain(|_, owner| owner != name);
-        }
+            handle.label
+        } else {
+            self.vrf_label_alloc.alloc().unwrap_or(0)
+        };
         let table_id = kernel.table_id;
         let new_handle = super::vrf::spawn_bgp_vrf(
             name.to_string(),
             &cfg,
             self.router_id,
             self.asn,
+            preserved_label,
             Some(kernel),
             &self.rib_subscriber,
             self.vrf_global_tx.clone(),

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -900,7 +900,7 @@ pub fn route_ipv4_update(
         && let Some(exporter) = bgp.vrf_export
     {
         if let Some(winner) = selected.first() {
-            super::vrf::vrf_emit_export(exporter, nlri.prefix, &winner.attr, 0);
+            super::vrf::vrf_emit_export(exporter, nlri.prefix, &winner.attr);
         } else {
             super::vrf::vrf_emit_withdraw(exporter, nlri.prefix);
         }
@@ -1916,7 +1916,7 @@ pub fn route_ipv4_withdraw(
         && let Some(exporter) = bgp.vrf_export
     {
         if let Some(winner) = selected.first() {
-            super::vrf::vrf_emit_export(exporter, nlri.prefix, &winner.attr, 0);
+            super::vrf::vrf_emit_export(exporter, nlri.prefix, &winner.attr);
         } else {
             super::vrf::vrf_emit_withdraw(exporter, nlri.prefix);
         }

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -98,6 +98,13 @@ pub struct BgpVrf {
     /// separate ASN today; if a future spec requires one this is
     /// where it lives.
     pub asn: u32,
+    /// Per-VRF MPLS label, allocated by `Bgp::vrf_label_alloc`
+    /// at spawn time. Stamped onto every `BgpGlobalMsg::Export`
+    /// this VRF emits so receiving PEs can identify the egress
+    /// VRF; step 19b installs the matching AF_MPLS ILM that pops
+    /// this label and routes the inner packet into
+    /// `vrf_tables[table_id]`.
+    pub label: u32,
     /// Dedup pool for `BgpAttr` instances seen by this VRF's
     /// peers. Step 15d gives every per-VRF runtime its own pool
     /// (cheaper than threading a shared lock across the `!Send`
@@ -137,6 +144,13 @@ pub type BgpVrfInbox = UnboundedSender<BgpVrfMsg>;
 pub struct VrfExporter {
     pub name: String,
     pub tx: UnboundedSender<BgpGlobalMsg>,
+    /// Per-VRF MPLS label, allocated by `Bgp::vrf_label_alloc`.
+    /// Stamped onto every `BgpGlobalMsg::Export` emitted from
+    /// this exporter; the receiving PE binds an AF_MPLS ILM at
+    /// this label (step 19b) so data-plane forwarding pops the
+    /// label and looks the inner packet up in the matching VRF
+    /// table.
+    pub label: u32,
 }
 
 /// Send a `BgpGlobalMsg::Export` for `prefix` carrying the
@@ -146,17 +160,12 @@ pub struct VrfExporter {
 /// `selected`. `label = 0` is the step-19 stub — the global
 /// handler treats that as "skip the per-route install" rather
 /// than emit an explicit-null label.
-pub fn vrf_emit_export(
-    exporter: &VrfExporter,
-    prefix: ipnet::Ipv4Net,
-    attr: &bgp_packet::BgpAttr,
-    label: u32,
-) {
+pub fn vrf_emit_export(exporter: &VrfExporter, prefix: ipnet::Ipv4Net, attr: &bgp_packet::BgpAttr) {
     let _ = exporter.tx.send(BgpGlobalMsg::Export {
         vrf: exporter.name.clone(),
         prefix,
         attr: attr.clone(),
-        label,
+        label: exporter.label,
     });
 }
 
@@ -243,6 +252,7 @@ impl BgpVrf {
         rd: Option<RouteDistinguisher>,
         router_id: Ipv4Addr,
         asn: u32,
+        label: u32,
         global_tx: UnboundedSender<BgpGlobalMsg>,
     ) -> (Self, BgpVrfInbox) {
         let (inbox_tx, global_rx) = mpsc::unbounded_channel();
@@ -261,6 +271,7 @@ impl BgpVrf {
             tx,
             rx,
             asn,
+            label,
             attr_store: BgpAttrStore::new(),
             update_groups: super::super::update_group::empty_map(),
             interface_addrs: InterfaceAddrs::new(),
@@ -365,6 +376,7 @@ impl BgpVrf {
                 let exporter = VrfExporter {
                     name: self.name.clone(),
                     tx: self.global_tx.clone(),
+                    label: self.label,
                 };
                 let mut top = BgpTop {
                     router_id: &self.router_id,
@@ -633,6 +645,7 @@ mod tests {
             None,
             Ipv4Addr::UNSPECIFIED,
             65000,
+            /* label */ 16,
             global_tx,
         );
 
@@ -660,6 +673,7 @@ mod tests {
             None,
             Ipv4Addr::UNSPECIFIED,
             65000,
+            /* label */ 16,
             global_tx,
         );
 
@@ -685,6 +699,7 @@ mod tests {
             None,
             Ipv4Addr::UNSPECIFIED,
             65000,
+            /* label */ 16,
             global_tx,
         );
 
@@ -721,6 +736,7 @@ mod tests {
             None,
             Ipv4Addr::UNSPECIFIED,
             65000,
+            /* label */ 16,
             global_tx,
         );
 
@@ -748,11 +764,12 @@ mod tests {
         let exporter = VrfExporter {
             name: "vrf-hook".to_string(),
             tx,
+            label: 42,
         };
         let prefix: ipnet::Ipv4Net = "10.0.0.0/24".parse().unwrap();
         let attr = bgp_packet::BgpAttr::default();
 
-        vrf_emit_export(&exporter, prefix, &attr, 0);
+        vrf_emit_export(&exporter, prefix, &attr);
 
         let msg = rx.try_recv().expect("Export pushed");
         match msg {
@@ -765,7 +782,7 @@ mod tests {
                 assert_eq!(vrf, "vrf-hook");
                 assert_eq!(p, prefix);
                 assert_eq!(a, attr);
-                assert_eq!(label, 0);
+                assert_eq!(label, 42, "exporter's label is stamped onto Export");
             }
             other => panic!("expected Export, got {other:?}"),
         }
@@ -777,6 +794,7 @@ mod tests {
         let exporter = VrfExporter {
             name: "vrf-hook2".to_string(),
             tx,
+            label: 17,
         };
         let prefix: ipnet::Ipv4Net = "10.0.0.0/24".parse().unwrap();
 

--- a/zebra-rs/src/bgp/vrf/label.rs
+++ b/zebra-rs/src/bgp/vrf/label.rs
@@ -1,0 +1,151 @@
+//! Per-VRF MPLS label allocator (step 19a of the BGP MPLS/VPN
+//! refactor).
+//!
+//! Hands out a single label per VRF at spawn time and reclaims it
+//! at despawn. The pool is a counter starting at 16 (the first
+//! non-reserved MPLS label per RFC 3032 §2.1) plus a free-list of
+//! reclaimed labels so cycling VRFs in / out doesn't burn through
+//! the 20-bit label space.
+//!
+//! The allocator lives on `Bgp` (one per global instance — labels
+//! are a global resource), and the allocated value is mirrored
+//! onto `BgpVrf::label` for the per-VRF runtime to stamp onto
+//! `BgpGlobalMsg::Export`. Step 19b's ILM Decap install consumes
+//! the same label to bind the netlink AF_MPLS route.
+//!
+//! Today the pool is unconstrained — there's no operator-visible
+//! reservation YANG. A future PR can layer that on by injecting a
+//! `(min, max)` range at `Bgp::new` and treating `min` as the
+//! initial counter.
+
+use std::collections::BTreeSet;
+
+/// First non-reserved MPLS label per RFC 3032 §2.1. Labels 0..=15
+/// are reserved (IPv4 / IPv6 Explicit Null, Implicit Null,
+/// Router Alert, OAM Alert, Entropy Label Indicator, etc.).
+pub const FIRST_USABLE_LABEL: u32 = 16;
+
+/// Maximum valid MPLS label per RFC 3032 — labels are 20 bits.
+pub const LAST_USABLE_LABEL: u32 = 0x000F_FFFF;
+
+/// Counter-based allocator that hands out one label per VRF.
+/// Released labels are queued back onto `free` so churned VRFs
+/// don't bleed the space.
+#[derive(Debug)]
+pub struct VrfLabelAllocator {
+    /// Next never-allocated label. Bumped on each fresh alloc;
+    /// the free list is preferred so the counter only grows when
+    /// every freed label has already been re-issued.
+    next: u32,
+    /// Released labels, sorted so the lowest-numbered ones come
+    /// out first — predictable for tests and operator readability.
+    free: BTreeSet<u32>,
+}
+
+impl VrfLabelAllocator {
+    pub fn new() -> Self {
+        Self {
+            next: FIRST_USABLE_LABEL,
+            free: BTreeSet::new(),
+        }
+    }
+
+    /// Hand out the next available label. Returns `None` only
+    /// when the entire 20-bit space is exhausted, which would
+    /// mean ~1M live VRFs — well past any deployment ceiling.
+    /// Callers can `expect("label space exhausted")` if they
+    /// want to assert that bound.
+    pub fn alloc(&mut self) -> Option<u32> {
+        if let Some(reused) = self.free.pop_first() {
+            return Some(reused);
+        }
+        if self.next > LAST_USABLE_LABEL {
+            return None;
+        }
+        let label = self.next;
+        self.next += 1;
+        Some(label)
+    }
+
+    /// Return `label` to the pool. Idempotent — double-frees are
+    /// silently ignored (the second insert into `BTreeSet` is a
+    /// no-op). Reserved labels (`< FIRST_USABLE_LABEL`) are
+    /// rejected because they were never ours to start with.
+    pub fn free(&mut self, label: u32) {
+        if !(FIRST_USABLE_LABEL..=LAST_USABLE_LABEL).contains(&label) {
+            return;
+        }
+        self.free.insert(label);
+    }
+}
+
+impl Default for VrfLabelAllocator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_allocator_starts_at_first_usable_label() {
+        let mut a = VrfLabelAllocator::new();
+        assert_eq!(a.alloc(), Some(FIRST_USABLE_LABEL));
+    }
+
+    #[test]
+    fn allocs_are_sequential_when_nothing_is_freed() {
+        let mut a = VrfLabelAllocator::new();
+        let l1 = a.alloc().unwrap();
+        let l2 = a.alloc().unwrap();
+        let l3 = a.alloc().unwrap();
+        assert_eq!(l1, FIRST_USABLE_LABEL);
+        assert_eq!(l2, FIRST_USABLE_LABEL + 1);
+        assert_eq!(l3, FIRST_USABLE_LABEL + 2);
+    }
+
+    #[test]
+    fn free_then_alloc_reuses_lowest_freed_label() {
+        // Operator churns VRFs: vrf1=16, vrf2=17, vrf3=18.
+        // Deleting vrf2 returns 17; the next vrf to spawn should
+        // pick up 17 rather than bumping the counter to 19.
+        let mut a = VrfLabelAllocator::new();
+        let l1 = a.alloc().unwrap();
+        let l2 = a.alloc().unwrap();
+        let l3 = a.alloc().unwrap();
+        assert_eq!((l1, l2, l3), (16, 17, 18));
+
+        a.free(l2);
+        a.free(l1);
+        assert_eq!(a.alloc(), Some(16), "lowest freed first");
+        assert_eq!(a.alloc(), Some(17));
+        assert_eq!(
+            a.alloc(),
+            Some(19),
+            "counter resumes after free pool drained"
+        );
+    }
+
+    #[test]
+    fn free_reserved_label_is_ignored() {
+        // Caller can't poison the pool with reserved values.
+        let mut a = VrfLabelAllocator::new();
+        a.free(0);
+        a.free(15);
+        // First alloc still comes from the counter.
+        assert_eq!(a.alloc(), Some(FIRST_USABLE_LABEL));
+    }
+
+    #[test]
+    fn double_free_is_a_noop() {
+        let mut a = VrfLabelAllocator::new();
+        let l = a.alloc().unwrap();
+        a.free(l);
+        a.free(l);
+        assert_eq!(a.alloc(), Some(l));
+        // No third return; counter resumes.
+        assert_eq!(a.alloc(), Some(l + 1));
+    }
+}

--- a/zebra-rs/src/bgp/vrf/mod.rs
+++ b/zebra-rs/src/bgp/vrf/mod.rs
@@ -17,8 +17,11 @@
 //!   Loc-RIB across the `BgpGlobalMsg` / `BgpVrfMsg` channels.
 
 pub mod inst;
+pub mod label;
 pub mod msg;
 pub mod spawn;
+
+pub use label::VrfLabelAllocator;
 
 // External consumers (`Bgp` field types, `process_vrf_global_msg`)
 // only reach for the names below. `inst::{BgpVrf, serve_vrf}` and

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -44,6 +44,13 @@ pub struct BgpVrfHandle {
     /// `AbortHandle` via `Drop`.
     #[allow(dead_code)]
     pub task: Task<()>,
+    /// MPLS label allocated for this VRF by `Bgp::vrf_label_alloc`
+    /// at spawn time. Mirrored back onto the handle so the global
+    /// `Bgp` can reclaim it on despawn and reuse it on
+    /// respawn-with-kernel-ctx — a respawn must keep the same
+    /// label, otherwise a brief outage would invalidate PE-side
+    /// FIB entries that already point at this VRF's old label.
+    pub label: u32,
 }
 
 /// Pure diff: which VRF names need to be spawned (in `desired`
@@ -93,6 +100,7 @@ pub fn spawn_bgp_vrf(
     cfg: &BgpVrfConfig,
     router_id: std::net::Ipv4Addr,
     asn: u32,
+    label: u32,
     kernel: Option<RibKnownVrf>,
     rib_subscriber: &RibSubscriber,
     global_tx: UnboundedSender<BgpGlobalMsg>,
@@ -131,6 +139,7 @@ pub fn spawn_bgp_vrf(
         cfg.rd,
         effective_router_id,
         asn,
+        label,
         global_tx,
     );
 
@@ -160,10 +169,11 @@ pub fn spawn_bgp_vrf(
         rd = ?cfg.rd,
         router_id = %effective_router_id,
         table_id = ?kernel_table_id,
+        label,
         peers = peer_count,
         "bgp: spawned per-VRF task",
     );
-    BgpVrfHandle { inbox, task }
+    BgpVrfHandle { inbox, task, label }
 }
 
 /// Build `Peer` objects from `cfg.neighbors` and insert them into
@@ -255,6 +265,7 @@ mod tests {
             &cfg,
             Ipv4Addr::UNSPECIFIED,
             65000,
+            /* label */ 16,
             None,
             &subscriber,
             global_tx,
@@ -293,6 +304,7 @@ mod tests {
             None,
             Ipv4Addr::UNSPECIFIED,
             65000,
+            /* label */ 16,
             global_tx,
         );
 
@@ -339,6 +351,7 @@ mod tests {
             None,
             Ipv4Addr::UNSPECIFIED,
             65000,
+            /* label */ 16,
             global_tx,
         );
 


### PR DESCRIPTION
## Summary

Step 19a of the BGP MPLS/VPN refactor. Replaces the `label: 0`
stub in every `BgpGlobalMsg::Export` emit with a real per-VRF
MPLS label allocated at `spawn_bgp_vrf` time and reclaimed at
despawn. PE peers now learn a per-VRF label they can bind to
an AF_MPLS ILM (step 19b) — pop on receive, look the inner
packet up in `vrf_tables[table_id]`.

The label is stable across `maybe_respawn_vrf_with_kernel_ctx`
(the placeholder → real-`for_vrf` swap): the original
allocation is held on `BgpVrfHandle::label` and reused on
respawn so a brief outage doesn't invalidate PE-side ILM
entries.

- `bgp::vrf::VrfLabelAllocator` (in `vrf/label.rs`): counter
  from 16 (first non-reserved label per RFC 3032 §2.1), sorted
  free-list, reserved-label frees ignored, double-free
  idempotent.
- `Bgp::vrf_label_alloc` field; allocate on spawn, free on
  despawn. `maybe_respawn` reuses the existing handle's label.
- `BgpVrf::label`, `BgpVrfHandle::label`, `VrfExporter::label`.
- `vrf_emit_export` reads from `exporter.label`; callers
  shrink by one arg.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` (596 unit tests pass;
      +5 new `VrfLabelAllocator` tests; +1 updated emit-test
      asserting label propagation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)