### PR TITLE
rib, bgp, fib: install AF_MPLS DecapVrf ILM per VRF (step 19b)

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -804,6 +804,22 @@ impl Bgp {
         for name in to_despawn {
             if let Some(handle) = self.vrf_registry.remove(&name) {
                 super::vrf::despawn_bgp_vrf(&name, &handle);
+                // Step 19b: withdraw the AF_MPLS DecapVrf ILM
+                // ahead of returning the label. The netlink
+                // delete keys off the label alone so the
+                // IlmEntry contents are mostly informational —
+                // any non-zero match on `rtype = Bgp` works.
+                if let Some(vrf_ifindex) = handle.ilm_decap_ifindex {
+                    let entry = crate::rib::inst::IlmEntry {
+                        rtype: crate::rib::RibType::Bgp,
+                        ilm_type: crate::rib::inst::IlmType::DecapVrf {
+                            table_id: 0,
+                            vrf_ifindex,
+                        },
+                        nexthop: crate::rib::Nexthop::default(),
+                    };
+                    self.rib_subscriber.send_ilm_del(handle.label, entry);
+                }
                 // Return the label to the pool so a future VRF
                 // can pick it back up. Reclaim before the handle
                 // drops — handle drop aborts the task but doesn't

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -51,6 +51,12 @@ pub struct BgpVrfHandle {
     /// label, otherwise a brief outage would invalidate PE-side
     /// FIB entries that already point at this VRF's old label.
     pub label: u32,
+    /// VRF master ifindex used in the AF_MPLS DecapVrf ILM, when
+    /// step 19b's spawn site successfully installed one. `None`
+    /// when the spawn ran with no kernel info (placeholder ctx);
+    /// the next `maybe_respawn_vrf_with_kernel_ctx` after the
+    /// kernel VRF appears installs the ILM.
+    pub ilm_decap_ifindex: Option<u32>,
 }
 
 /// Pure diff: which VRF names need to be spawned (in `desired`
@@ -105,9 +111,11 @@ pub fn spawn_bgp_vrf(
     rib_subscriber: &RibSubscriber,
     global_tx: UnboundedSender<BgpGlobalMsg>,
 ) -> BgpVrfHandle {
-    // Snapshot for logging so we can move `kernel` into the
-    // ctx-building arm without re-borrowing later.
+    // Snapshot for logging + ILM install so we can move
+    // `kernel` into the ctx-building arm without re-borrowing
+    // later.
     let kernel_table_id = kernel.as_ref().map(|k| k.table_id);
+    let kernel_ifindex = kernel.as_ref().map(|k| k.ifindex);
     let ctx = match kernel {
         Some(k) => {
             // Mint a fresh `RibClient` for this VRF. The
@@ -163,6 +171,28 @@ pub fn spawn_bgp_vrf(
         });
     }
 
+    // Step 19b: install the AF_MPLS DecapVrf ILM at the
+    // allocated label so a remote PE's VPNv4 packet with this
+    // label pops + lands in `vrf_tables[table_id]`. Only when
+    // we have kernel info — a placeholder-ctx spawn skips the
+    // install; the `maybe_respawn_vrf_with_kernel_ctx` path
+    // re-runs with kernel info and installs the ILM then.
+    let ilm_decap_ifindex = match (kernel_table_id, kernel_ifindex) {
+        (Some(table_id), Some(vrf_ifindex)) if label != 0 => {
+            let entry = crate::rib::inst::IlmEntry {
+                rtype: crate::rib::RibType::Bgp,
+                ilm_type: crate::rib::inst::IlmType::DecapVrf {
+                    table_id,
+                    vrf_ifindex,
+                },
+                nexthop: crate::rib::Nexthop::default(),
+            };
+            rib_subscriber.send_ilm_add(label, entry);
+            Some(vrf_ifindex)
+        }
+        _ => None,
+    };
+
     let task = serve_vrf(vrf);
     tracing::info!(
         vrf = %name,
@@ -170,10 +200,16 @@ pub fn spawn_bgp_vrf(
         router_id = %effective_router_id,
         table_id = ?kernel_table_id,
         label,
+        ilm_installed = ilm_decap_ifindex.is_some(),
         peers = peer_count,
         "bgp: spawned per-VRF task",
     );
-    BgpVrfHandle { inbox, task, label }
+    BgpVrfHandle {
+        inbox,
+        task,
+        label,
+        ilm_decap_ifindex,
+    }
 }
 
 /// Build `Peer` objects from `cfg.neighbors` and insert them into

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -111,6 +111,23 @@ impl RibSubscriber {
         let client = crate::rib::client::RibClient::new(self.rib_inbound_tx.clone(), proto_id);
         (client, chan.rx)
     }
+
+    /// Send a `Message::IlmAdd` directly to RIB. Step 19b's
+    /// per-VRF BGP spawn site uses this to install the
+    /// AF_MPLS Decap ILM bound to the VRF master interface.
+    /// The legacy `rib_tx` is the right channel — `IlmAdd` is
+    /// a global RIB mutation, not a per-protocol envelope, so
+    /// the `RibInbound` path doesn't fit.
+    pub fn send_ilm_add(&self, label: u32, ilm: crate::rib::inst::IlmEntry) {
+        let _ = self.rib_tx.send(crate::rib::Message::IlmAdd { label, ilm });
+    }
+
+    /// Inverse of [`Self::send_ilm_add`]. Reclaims the AF_MPLS
+    /// route at `despawn_bgp_vrf` time so a freed VRF doesn't
+    /// leave its decap route in the FIB.
+    pub fn send_ilm_del(&self, label: u32, ilm: crate::rib::inst::IlmEntry) {
+        let _ = self.rib_tx.send(crate::rib::Message::IlmDel { label, ilm });
+    }
 }
 
 pub struct ConfigManager {

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -35,7 +35,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::fib::sysctl::sysctl_enable;
 use crate::fib::{FibAddr, FibLink, FibMessage, FibNeighbor, FibRoute};
 use crate::rib::entry::RibEntry;
-use crate::rib::inst::IlmEntry;
+use crate::rib::inst::{IlmEntry, IlmType};
 use crate::rib::route::{DEBUG_ADDR, DEBUG_EVPN};
 use crate::rib::{
     AddrGenMode, Bridge, Group, GroupTrait, MacAddr, Nexthop, NexthopMulti, NexthopUni, RibType,
@@ -1713,6 +1713,37 @@ impl FibHandle {
 
         msg.header.scope = RouteScope::Universe;
         msg.header.kind = RouteType::Unicast;
+
+        // BGP/MPLS-VPN per-VRF decap: emit a pure-pop AF_MPLS
+        // route — no NEW_DESTINATION (= no swap), just an
+        // `Oif(vrf_ifindex)` so the kernel routes the popped
+        // packet via the VRF master, which lands in
+        // `vrf_tables[table_id]`. Skips the per-`Nexthop` branch
+        // because `IlmEntry::nexthop` is `Nexthop::default()` for
+        // this variant.
+        if let IlmType::DecapVrf {
+            table_id: _,
+            vrf_ifindex,
+        } = ilm.ilm_type
+        {
+            msg.attributes.push(RouteAttribute::Oif(vrf_ifindex));
+            let attr = RouteAttribute::Destination(RouteAddress::Mpls(MplsLabel {
+                label,
+                traffic_class: 0,
+                bottom_of_stack: true,
+                ttl: 0,
+            }));
+            msg.attributes.push(attr);
+            let mut req = NetlinkMessage::from(RouteNetlinkMessage::NewRoute(msg));
+            req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE;
+            let mut response = self.handle.clone().request(req).unwrap();
+            while let Some(msg) = response.next().await {
+                if let NetlinkPayload::Error(e) = msg.payload {
+                    tracing::info!("ilm_add DecapVrf error: {}", e);
+                }
+            }
+            return;
+        }
 
         match ilm.nexthop {
             Nexthop::Uni(ref uni) => {

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -283,6 +283,18 @@ pub enum IlmType {
     None,
     Node(u32),
     Adjacency(u32),
+    /// BGP/MPLS-VPN per-VRF decap (RFC 4364). The kernel pops
+    /// the label and routes the inner packet through the VRF
+    /// master device, which lands the lookup in
+    /// `vrf_tables[table_id]`. `vrf_ifindex` is the kernel
+    /// ifindex of the VRF master (e.g. `ip link show vrf-blue`);
+    /// `table_id` is informational only (the netlink action
+    /// keys off the Oif, not the table id), but the show path
+    /// renders it for operators.
+    DecapVrf {
+        table_id: u32,
+        vrf_ifindex: u32,
+    },
 }
 
 #[derive(Default, Debug, Clone)]

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1306,6 +1306,10 @@ fn write_ilm_entry(
     let prefix_or_id = match &ilm.ilm_type {
         super::inst::IlmType::Node(idx) => format!("SR Pfx (idx {:<3})", idx),
         super::inst::IlmType::Adjacency(idx) => format!("SR Adj (idx {:<3})", idx),
+        super::inst::IlmType::DecapVrf {
+            table_id,
+            vrf_ifindex: _,
+        } => format!("VPN Decap (tbl {:<3})", table_id),
         super::inst::IlmType::None => {
             // Try to find a matching route for this nexthop
             if let Some((prefix, _)) = find_route_for_nexthop(rib, uni) {
@@ -1356,6 +1360,10 @@ fn ilm_to_json(
     let prefix_or_id = match &ilm.ilm_type {
         super::inst::IlmType::Node(idx) => format!("SR Pfx (idx {})", idx),
         super::inst::IlmType::Adjacency(idx) => format!("SR Adj (idx {})", idx),
+        super::inst::IlmType::DecapVrf {
+            table_id,
+            vrf_ifindex: _,
+        } => format!("VPN Decap (tbl {})", table_id),
         super::inst::IlmType::None => {
             if let Some((prefix, _)) = find_route_for_nexthop(rib, uni) {
                 prefix.to_string()


### PR DESCRIPTION
## Summary

Step 19b of the BGP MPLS/VPN refactor — data-plane half of the
label work. With step 19a's allocator already giving each VRF a
stable label, this PR installs the matching AF_MPLS route so a
remote PE's labelled VPNv4 packet actually pops and lands in
`vrf_tables[table_id]`.

The kernel binding is an AF_MPLS route at `label/20` with no
NEW_DESTINATION (pure pop) plus `Oif(vrf_ifindex)` set to the
VRF master device. Linux routes the popped inner packet via the
VRF master, which lands the lookup in the slave table.

- `rib::inst::IlmType::DecapVrf { table_id, vrf_ifindex }` +
  show.rs renderer.
- `fib::netlink::handle::ilm_add` special-cases the variant
  ahead of the existing `Nexthop::{Uni,Multi}` arms.
- `RibSubscriber::send_ilm_add` / `send_ilm_del` wrap
  `Message::Ilm{Add,Del}` for use from BGP code.
- `BgpVrfHandle::ilm_decap_ifindex: Option<u32>`. `spawn_bgp_vrf`
  installs when kernel info is known and label != 0;
  placeholder-ctx skips and `maybe_respawn` picks it up.
- `Bgp::apply_vrf_commit_diff` despawn arm sends IlmDel before
  reclaiming the label.

End-to-end VPN routing is now both control- and data-plane
complete for the labelled VPNv4 path. Untested at netlink level
without `CAP_NET_RAW`; step 21's BDD covers that.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` (596 unit tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)