### PR TITLE
bdd: bgp_vrf_show feature for show ip bgp vrf

### DIFF
--- a/bdd/tests/configs/bgp_vrf_show/z1-1.yaml
+++ b/bdd/tests/configs/bgp_vrf_show/z1-1.yaml
@@ -1,0 +1,5 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1

--- a/bdd/tests/configs/bgp_vrf_show/z1-2.yaml
+++ b/bdd/tests/configs/bgp_vrf_show/z1-2.yaml
@@ -1,0 +1,16 @@
+vrf:
+- name: vrf-blue
+  ipv4:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    vrf:
+    - name: vrf-blue
+      rd: 65001:100

--- a/bdd/tests/features/bgp_vrf_show.feature
+++ b/bdd/tests/features/bgp_vrf_show.feature
@@ -1,0 +1,54 @@
+@serial
+@bgp_vrf_show
+Feature: BGP per-VRF show command
+  As a network operator
+  I want to inspect the per-VRF state of a running zebra-rs
+  Using a single-namespace topology that drives the local config
+  callbacks end-to-end so `show ip bgp vrf` reports the committed
+  Route Distinguisher / Route Target / MPLS label.
+
+  Test Topology:
+  ```
+  ┌─────────┐
+  │   z1    │   AS 65001
+  │ 192.168 │   vrf-blue: RD 65001:100, RT 65001:100
+  │  .0.1/24│
+  └─────────┘
+  ```
+
+  Config files:
+  - z1-1.yaml: baseline `router bgp` with no per-VRF block.
+  - z1-2.yaml: adds top-level vrf-blue (with RT import/export) and
+    a matching `router bgp vrf vrf-blue` block with RD 65001:100.
+
+  Scenario: Setup topology
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I wait 2 seconds for BGP to operate
+    Then show command "ip bgp vrf" in namespace "z1" should contain "(no VRFs configured)"
+
+  Scenario: Configure vrf-blue and observe via show
+    Given the test topology exists
+    When I apply config "z1-2.yaml" to namespace "z1"
+    And I wait 5 seconds for BGP to operate
+    Then show command "ip bgp vrf" in namespace "z1" should contain "vrf-blue"
+    And show command "ip bgp vrf" in namespace "z1" should contain "65001:100"
+    And show command "ip bgp vrf vrf-blue" in namespace "z1" should contain "Route Distinguisher: 65001:100"
+    And show command "ip bgp vrf vrf-blue" in namespace "z1" should contain "Import RTs"
+    And show command "ip bgp vrf vrf-blue" in namespace "z1" should contain "Export RTs"
+
+  Scenario: Remove vrf-blue and observe row drops
+    Given the test topology exists
+    When I apply config "z1-1.yaml" to namespace "z1"
+    And I wait 2 seconds for BGP to operate
+    Then show command "ip bgp vrf" in namespace "z1" should contain "(no VRFs configured)"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I delete namespace "z1"
+    And I delete bridge "br0"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

Step 21a of the BGP MPLS/VPN refactor — single-namespace BDD
scenario that drives the local config callbacks end-to-end so
`show ip bgp vrf` reports the committed Route Distinguisher,
Route Target, and MPLS label.

The feature is for manual reproduction (BDD is excluded from CI
per CAP_NET_ADMIN gating). First scenario exercising:

- top-level `vrf X { ipv4 { route-target { import/export ... } } }`
  → `Rib::vrfs[X]` + `RibRx::VrfRouteTargets` broadcast.
- `router bgp vrf X { rd ... }` → `BgpVrfConfig`,
  `BgpVrf::label` allocator + `BgpVrfHandle`.
- `show ip bgp vrf` / `show ip bgp vrf X` end-to-end.

Follow-up (step 21b/c) is a two-PE topology with a real VPNv4
session and a gobgpd CE simulator — deliberately deferred.

- `bdd/tests/features/bgp_vrf_show.feature` (4 scenarios)
- `bdd/tests/configs/bgp_vrf_show/z1-1.yaml` (baseline)
- `bdd/tests/configs/bgp_vrf_show/z1-2.yaml` (vrf-blue + RD/RTs)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` (596 unit tests pass)
- [ ] Manual: `sudo cargo test -p bdd --test cucumber -- @bgp_vrf_show`

🤖 Generated with [Claude Code](https://claude.com/claude-code)