### PR TITLE
ospf: add Ospfv3 OspfVersion impl + ospf_socket_ipv6 primitives

### DIFF
--- a/zebra-rs/src/ospf/mod.rs
+++ b/zebra-rs/src/ospf/mod.rs
@@ -1,5 +1,5 @@
 pub mod version;
-pub use version::{OspfVersion, Ospfv2};
+pub use version::{OspfVersion, Ospfv2, Ospfv3};
 
 pub mod inst;
 pub use inst::{Message, Ospf, ShowCallback};

--- a/zebra-rs/src/ospf/socket.rs
+++ b/zebra-rs/src/ospf/socket.rs
@@ -7,7 +7,7 @@ use tokio::io::unix::AsyncFd;
 
 use crate::context::ProtoContext;
 
-use super::{OspfVersion, Ospfv2};
+use super::{OspfVersion, Ospfv2, Ospfv3};
 
 pub fn ospf_socket_ipv4(ctx: &ProtoContext) -> Result<Socket, std::io::Error> {
     // Initial socket through the context so VRF binding (when
@@ -64,5 +64,85 @@ pub fn ospf_leave_alldrouters(socket: &AsyncFd<Socket>, ifindex: u32) {
         .leave_multicast_v4_n(&maddr, &InterfaceIndexOrAddress::Index(ifindex))
     {
         tracing::warn!("ospf: leave AllDRouters on ifindex {ifindex} failed: {e}");
+    }
+}
+
+/// Create the raw IPv6 socket used by an OSPFv3 instance.
+///
+/// Mirrors `ospf_socket_ipv4`'s setup but for v6: same protocol
+/// number (89; OSPFv2 and v3 share it), `IPV6_V6ONLY` so dual-stack
+/// kernels don't surface v4-mapped sources, multicast loop off,
+/// multicast hop limit pinned to 1 (RFC 5340 §A.1 — OSPFv3 packets
+/// MUST NOT cross a router), and `IPV6_RECVPKTINFO` so the rx
+/// loop can recover the ingress ifindex and the destination v6
+/// address used for the IPv6 pseudo-header checksum.
+///
+/// The pseudo-header checksum itself (RFC 5340 §4.4) and the
+/// network read / write loop land in subsequent Phase 5 PRs; this
+/// function just constructs the socket and is not yet called by
+/// any consumer — hence the `dead_code` allow on the whole v6
+/// socket family below.
+#[allow(dead_code)]
+pub fn ospf_socket_ipv6(ctx: &ProtoContext) -> Result<Socket, std::io::Error> {
+    let socket = ctx.raw_socket(Domain::IPV6, Protocol::from(Ospfv3::IP_PROTO as i32))?;
+
+    socket.set_nonblocking(true)?;
+    socket.set_reuse_address(true)?;
+    socket.set_only_v6(true)?;
+    socket.set_multicast_loop_v6(false)?;
+    socket.set_multicast_hops_v6(1)?;
+    set_ipv6_pktinfo(&socket);
+
+    Ok(socket)
+}
+
+/// Enable `IPV6_RECVPKTINFO` on the raw v6 socket. socket2 doesn't
+/// expose this directly, so set it via raw `setsockopt`. The rx
+/// loop reads the resulting `in6_pktinfo` ancillary data to recover
+/// (a) the ingress ifindex, used to dispatch the packet to the
+/// matching `OspfLink<Ospfv3>`, and (b) the destination v6 address,
+/// needed when verifying the IPv6 pseudo-header checksum (§4.4) on
+/// receive.
+#[allow(dead_code)]
+pub fn set_ipv6_pktinfo(socket: &Socket) {
+    let optval = true as c_int;
+    unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            libc::IPV6_RECVPKTINFO,
+            &optval as *const _ as *const libc::c_void,
+            std::mem::size_of::<i32>() as libc::socklen_t,
+        );
+    };
+}
+
+/// Join `ff02::5` (AllSPFRouters) on the given interface.
+#[allow(dead_code)]
+pub fn ospf_join_if_v6(socket: &AsyncFd<Socket>, ifindex: u32) {
+    let maddr = Ospfv3::ALL_SPF_ROUTERS;
+    if let Err(e) = socket.get_ref().join_multicast_v6(&maddr, ifindex) {
+        tracing::warn!("ospf: join AllSPFRouters (v6) on ifindex {ifindex} failed: {e}");
+    }
+}
+
+/// Join `ff02::6` (AllDRouters) on the given interface. Called when
+/// the v3 interface FSM transitions a router into the DR or BDR
+/// role on a broadcast / NBMA segment.
+#[allow(dead_code)]
+pub fn ospf_join_alldrouters_v6(socket: &AsyncFd<Socket>, ifindex: u32) {
+    let maddr = Ospfv3::ALL_DROUTERS;
+    if let Err(e) = socket.get_ref().join_multicast_v6(&maddr, ifindex) {
+        tracing::warn!("ospf: join AllDRouters (v6) on ifindex {ifindex} failed: {e}");
+    }
+}
+
+/// Leave `ff02::6` on the given interface. Called when the v3 FSM
+/// drops out of the DR / BDR role.
+#[allow(dead_code)]
+pub fn ospf_leave_alldrouters_v6(socket: &AsyncFd<Socket>, ifindex: u32) {
+    let maddr = Ospfv3::ALL_DROUTERS;
+    if let Err(e) = socket.get_ref().leave_multicast_v6(&maddr, ifindex) {
+        tracing::warn!("ospf: leave AllDRouters (v6) on ifindex {ifindex} failed: {e}");
     }
 }

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -16,9 +16,9 @@
 
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
-use ipnet::Ipv4Net;
+use ipnet::{Ipv4Net, Ipv6Net};
 
 /// Marker / dispatch trait for an OSPF protocol version (v2 or v3).
 ///
@@ -59,4 +59,27 @@ impl OspfVersion for Ospfv2 {
     type Prefix = Ipv4Net;
     const ALL_SPF_ROUTERS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 5);
     const ALL_DROUTERS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 6);
+}
+
+/// OSPFv3 dispatch marker (RFC 5340). Distinct from the
+/// `Ospfv3Packet` / `Ospfv3Hello` / … codec types in the
+/// `ospf-packet` crate; this is the protocol-side address-family
+/// marker that subsequent Phase 5 PRs will use to thread v6
+/// constants into the socket / network code.
+//
+// `dead_code` allowed because nothing constructs `Ospfv3` yet —
+// the `Ospf<Ospfv3>` instance lands later in Phase 5 / Phase 6.
+// The trait impl is used (via `Ospfv3::ALL_SPF_ROUTERS` etc.) in
+// `socket.rs::ospf_socket_ipv6`.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Ospfv3;
+
+impl OspfVersion for Ospfv3 {
+    type Addr = Ipv6Addr;
+    type Prefix = Ipv6Net;
+    /// AllSPFRouters in v3 (RFC 5340 §A.1): `ff02::5`.
+    const ALL_SPF_ROUTERS: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 5);
+    /// AllDRouters in v3 (RFC 5340 §A.1): `ff02::6`.
+    const ALL_DROUTERS: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 6);
 }


### PR DESCRIPTION
## Summary

Phase 5 PR 1. Add the protocol-side address-family marker for v3 (distinct from the codec types in `ospf-packet`) and the raw v6 socket family that the upcoming `Ospf<Ospfv3>` instance will use.

**version.rs:**
- new `Ospfv3` marker struct, impl `OspfVersion` with `Addr = Ipv6Addr`, `Prefix = Ipv6Net`, `ALL_SPF_ROUTERS = ff02::5`, `ALL_DROUTERS = ff02::6`
- `IP_PROTO` stays at the trait default (89; v2 and v3 share it per RFC 5340 §2.3)

**socket.rs:**
- `ospf_socket_ipv6(ctx)` — raw IPv6 socket through `ProtoContext` (VRF binding inherits automatically), with `IPV6_V6ONLY`, multicast loop off, multicast hop limit pinned to 1 per §A.1, and `IPV6_RECVPKTINFO` set so the rx loop can recover the ingress ifindex and destination v6 address needed when verifying the IPv6 pseudo-header checksum (§4.4) on receive
- `set_ipv6_pktinfo(socket)` — raw setsockopt since socket2 doesn't expose `IPV6_RECVPKTINFO` directly
- `ospf_join_if_v6` / `ospf_join_alldrouters_v6` / `ospf_leave_alldrouters_v6` — mirror the v4 multicast helpers

All v6 helpers carry `#[allow(dead_code)]` for now — the network read/write loop and the `Ospf<Ospfv3>` instance that consume them land in subsequent Phase 5 PRs. The IPv6 pseudo-header checksum (§4.4) is the next natural follow-up.

## Stack note

This PR is stacked on top of #721 (the LSU capstone). Once #721 merges, this branch needs a rebase + force-push to narrow its diff.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p zebra-rs --bins` — 596 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)