### PR TITLE
ospf: add v6 network read/write loop

### DIFF
--- a/crates/ospf-packet/src/lib.rs
+++ b/crates/ospf-packet/src/lib.rs
@@ -22,7 +22,7 @@ pub use v3::{
     Ospfv3LsRequest, Ospfv3LsRequestEntry, Ospfv3LsUpdate, Ospfv3Lsa, Ospfv3LsaHeader,
     Ospfv3NetworkLsa, Ospfv3Options, Ospfv3Packet, Ospfv3Payload, Ospfv3PrefixOptions,
     Ospfv3RouterLinkType, Ospfv3RouterLsa, Ospfv3RouterLsaLink, ospfv3_compute_checksum,
-    ospfv3_prefix_wire_len, ospfv3_verify_checksum,
+    ospfv3_prefix_wire_len, ospfv3_verify_checksum, parse_v3,
 };
 
 pub use packet_utils::many0_complete;

--- a/crates/ospf-packet/src/v3.rs
+++ b/crates/ospf-packet/src/v3.rs
@@ -101,6 +101,14 @@ pub fn ospfv3_verify_checksum(src: &Ipv6Addr, dst: &Ipv6Addr, packet_bytes: &[u8
     ospfv3_compute_checksum(src, dst, packet_bytes) == [0, 0]
 }
 
+/// Parse a v3 OSPF packet from raw socket bytes. Convenience entry
+/// point for callers (the network rx loop) that don't want to bring
+/// the `nom_derive` / `ParseBe` traits into scope explicitly —
+/// mirrors v2's `ospf_packet::parse`.
+pub fn parse_v3(input: &[u8]) -> IResult<&[u8], Ospfv3Packet> {
+    Ospfv3Packet::parse_be(input)
+}
+
 /// OSPFv3 packet header (RFC 5340 §A.3.1).
 #[derive(Debug, Clone, NomBE)]
 pub struct Ospfv3Packet {

--- a/zebra-rs/src/ospf/mod.rs
+++ b/zebra-rs/src/ospf/mod.rs
@@ -33,6 +33,8 @@ pub mod config;
 
 pub mod network;
 
+pub mod network_v6;
+
 pub mod socket;
 
 pub mod packet;

--- a/zebra-rs/src/ospf/network_v6.rs
+++ b/zebra-rs/src/ospf/network_v6.rs
@@ -1,0 +1,180 @@
+//! OSPFv3 raw-IPv6 read/write loop.
+//!
+//! Mirrors `network.rs` for v4. Two long-lived tasks drive the v6
+//! socket: `read_packet_v6` receives raw IPv6 packets, verifies the
+//! pseudo-header checksum, parses an `Ospfv3Packet`, and forwards
+//! the result over an mpsc channel; `write_packet_v6` takes
+//! `Ospfv3Send` items from a peer channel, stamps the checksum with
+//! the supplied source/destination, and emits via `sendmsg` with an
+//! `in6_pktinfo` ancillary message so the kernel uses the egress
+//! interface we picked instead of doing a fresh route lookup.
+//!
+//! These tasks are dormant until the `Ospf<Ospfv3>` instance type
+//! (Phase 6) spawns them — every public item carries
+//! `#[allow(dead_code)]` for now.
+
+use std::io::{ErrorKind, IoSlice, IoSliceMut};
+use std::net::Ipv6Addr;
+use std::os::fd::AsRawFd;
+use std::sync::Arc;
+
+use bytes::BytesMut;
+use nix::sys::socket::{self, ControlMessageOwned, SockaddrIn6};
+use socket2::Socket;
+use tokio::io::Interest;
+use tokio::io::unix::AsyncFd;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+
+use super::{OspfVersion, Ospfv3};
+use ospf_packet::{Ospfv3Packet, ospfv3_verify_checksum, parse_v3};
+
+/// One v3 packet pending transmission.
+///
+/// `dest` defaults to `ff02::5` (AllSPFRouters) when `None` —
+/// matches the v2 loop's convention for "send to the multicast
+/// group of the link". `src` is the egress interface's link-local
+/// address; the IPv6 pseudo-header checksum (RFC 5340 §4.4) folds
+/// it in, so the receiver's verify will fail if this doesn't
+/// match what the kernel ends up putting in the IPv6 header.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct Ospfv3Send {
+    pub packet: Ospfv3Packet,
+    pub ifindex: u32,
+    pub dest: Option<Ipv6Addr>,
+    pub src: Ipv6Addr,
+}
+
+/// One v3 packet just received off the wire.
+///
+/// Carries the parsed packet plus the transport-layer metadata the
+/// upper-layer protocol code needs to dispatch it: src/dst v6 from
+/// the `in6_pktinfo` ancillary message + the recvmsg sockaddr, and
+/// the ingress ifindex.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct Ospfv3Recv {
+    pub packet: Ospfv3Packet,
+    pub src: Ipv6Addr,
+    pub dst: Ipv6Addr,
+    pub ifindex: u32,
+}
+
+/// Long-lived recv loop for the v3 socket. Drops packets whose
+/// pseudo-header checksum fails verification or whose body fails
+/// to parse; the upper layer never sees malformed traffic.
+///
+/// IPv6 raw sockets (unlike v4) deliver the OSPF payload directly
+/// — the kernel strips the IPv6 header on receive — so there's no
+/// `IPV4_HEADER_LEN` skip to mirror.
+#[allow(dead_code)]
+pub async fn read_packet_v6(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Ospfv3Recv>) {
+    let mut buf = [0u8; 1024 * 16];
+    let mut iov = [IoSliceMut::new(&mut buf)];
+    let mut cmsgspace = nix::cmsg_space!(libc::in6_pktinfo);
+
+    loop {
+        let _ = sock
+            .async_io(Interest::READABLE, |sock| {
+                let msg = socket::recvmsg::<SockaddrIn6>(
+                    sock.as_raw_fd(),
+                    &mut iov,
+                    Some(&mut cmsgspace),
+                    socket::MsgFlags::empty(),
+                )?;
+
+                let mut cmsgs = msg.cmsgs()?;
+
+                let Some(src_sa) = msg.address else {
+                    return Err(ErrorKind::AddrNotAvailable.into());
+                };
+                let src: Ipv6Addr = src_sa.ip();
+
+                let Some(ControlMessageOwned::Ipv6PacketInfo(pktinfo)) = cmsgs.next() else {
+                    return Err(ErrorKind::AddrNotAvailable.into());
+                };
+                // On receive, `ipi6_addr` carries the destination
+                // address (the multicast group or the unicast
+                // address) of the packet. The kernel populates it
+                // from the IPV6_RECVPKTINFO socket option we set in
+                // `socket::ospf_socket_ipv6`.
+                let dst: Ipv6Addr = Ipv6Addr::from(pktinfo.ipi6_addr.s6_addr);
+                let ifindex = pktinfo.ipi6_ifindex;
+
+                let Some(input) = msg.iovs().next() else {
+                    return Err(ErrorKind::UnexpectedEof.into());
+                };
+
+                // RFC 5340 §4.4: drop packets whose pseudo-header
+                // checksum is wrong before any further processing.
+                if !ospfv3_verify_checksum(&src, &dst, input) {
+                    return Err(ErrorKind::InvalidData.into());
+                }
+
+                let Ok((_, packet)) = parse_v3(input) else {
+                    return Err(ErrorKind::UnexpectedEof.into());
+                };
+
+                let _ = tx.send(Ospfv3Recv {
+                    packet,
+                    src,
+                    dst,
+                    ifindex,
+                });
+
+                Ok(())
+            })
+            .await;
+    }
+}
+
+/// Long-lived send loop for the v3 socket. Consumes `Ospfv3Send`
+/// items from `rx` and pushes them onto the wire with the IPv6
+/// pseudo-header checksum stamped in.
+#[allow(dead_code)]
+pub async fn write_packet_v6(sock: Arc<AsyncFd<Socket>>, mut rx: UnboundedReceiver<Ospfv3Send>) {
+    while let Some(item) = rx.recv().await {
+        let Ospfv3Send {
+            packet,
+            ifindex,
+            dest,
+            src,
+        } = item;
+        let dest = dest.unwrap_or(Ospfv3::ALL_SPF_ROUTERS);
+
+        let mut buf = BytesMut::new();
+        // emit_with_checksum lays the packet down with checksum=0
+        // and then stamps the pseudo-header checksum at octets
+        // 12..14, folding in (src, dst).
+        packet.emit_with_checksum(&mut buf, &src, &dest);
+
+        let iov = [IoSlice::new(&buf)];
+        let sockaddr: SockaddrIn6 = std::net::SocketAddrV6::new(dest, 0, 0, 0).into();
+        // On send, `ipi6_addr` carries the *source* address (the
+        // opposite of recv). Setting it pins the IPv6 source the
+        // kernel emits; otherwise the kernel would pick its own
+        // based on the destination route, and our pseudo-header
+        // checksum wouldn't match.
+        let mut src_addr = libc::in6_addr { s6_addr: [0u8; 16] };
+        src_addr.s6_addr = src.octets();
+        let pktinfo = libc::in6_pktinfo {
+            ipi6_addr: src_addr,
+            ipi6_ifindex: ifindex,
+        };
+        let cmsg = [socket::ControlMessage::Ipv6PacketInfo(&pktinfo)];
+
+        let _ = sock
+            .async_io(Interest::WRITABLE, |sock| {
+                socket::sendmsg(
+                    sock.as_raw_fd(),
+                    &iov,
+                    &cmsg,
+                    socket::MsgFlags::empty(),
+                    Some(&sockaddr),
+                )
+                .map_err(std::io::Error::from)?;
+                Ok(())
+            })
+            .await;
+    }
+}


### PR DESCRIPTION
## Summary

Phase 5 PR 3. Mirror `network.rs` for v3. Two long-lived async tasks drive the v6 raw socket:

- `read_packet_v6` — receives raw IPv6 packets, verifies the pseudo-header checksum (PR 2), parses an `Ospfv3Packet`, forwards as `Ospfv3Recv` over an mpsc channel.
- `write_packet_v6` — takes `Ospfv3Send` items from a peer channel, stamps the checksum with the supplied src/dest, emits via `sendmsg` with an `in6_pktinfo` ancillary so the kernel uses the caller's egress interface.

The v6 raw socket differs from the v4 one in ways the loop has to handle:
- the kernel strips the IPv6 header on receive (unlike v4 raw, which keeps the 20-byte v4 header) — no header skip
- src address comes from `recvmsg`'s `SockaddrIn6`
- dst (multicast group or our unicast) comes from the `in6_pktinfo` ancillary's `ipi6_addr`
- `in6_pktinfo::ipi6_addr` means destination on rx and source on tx (RFC 3542)
- checksum uses the IPv6 pseudo-header form (RFC 5340 §4.4)

The loop uses purpose-built channel types `Ospfv3Send` / `Ospfv3Recv` rather than reusing the v4 `Message` enum. The Phase 6 PR that adds the `Ospf<Ospfv3>` instance can decide whether to fold these into a unified message type. All public items carry `#[allow(dead_code)]` until that wiring lands.

Also adds `parse_v3()` as a public convenience entry point in `ospf-packet` (mirrors v2's `ospf_packet::parse`) so external callers don't need to bring the `nom_derive` / `ParseBe` traits into scope.

## Stack note

This PR is stacked on top of #724 (the pseudo-header checksum). Once #724 merges, this branch needs `git rebase origin/main` + `--force-with-lease` push to narrow its diff.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p zebra-rs --bins` — 596 pass
- [x] `cargo test -p ospf-packet --lib v3` — 31 pass
- [ ] End-to-end test against a peer (deferred to Phase 6 when the `Ospf<Ospfv3>` instance lands and the loop is wired up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)