### PR TITLE
bgp: originate per-VRF network statements + 2-PE VPNv4 BDD

### DIFF
--- a/bdd/tests/configs/bgp_vrf_vpnv4_export/z1-1.yaml
+++ b/bdd/tests/configs/bgp_vrf_vpnv4_export/z1-1.yaml
@@ -1,0 +1,27 @@
+vrf:
+- name: vrf-blue
+  ipv4:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+      enabled: true
+      peer-as: 65001
+    vrf:
+    - name: vrf-blue
+      rd: 65001:100
+      afi-safi:
+        ipv4-unicast:
+          network:
+          - prefix: 10.1.0.0/24

--- a/bdd/tests/configs/bgp_vrf_vpnv4_export/z2-1.yaml
+++ b/bdd/tests/configs/bgp_vrf_vpnv4_export/z2-1.yaml
@@ -1,0 +1,23 @@
+vrf:
+- name: vrf-blue
+  ipv4:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+      enabled: true
+      peer-as: 65001
+    vrf:
+    - name: vrf-blue
+      rd: 65001:200

--- a/bdd/tests/features/bgp_vrf_vpnv4_export.feature
+++ b/bdd/tests/features/bgp_vrf_vpnv4_export.feature
@@ -1,0 +1,63 @@
+@serial
+@bgp_vrf_vpnv4_export
+Feature: BGP per-VRF VPNv4 export to a remote PE
+  As a network operator
+  I want to advertise a network configured under `router bgp vrf X
+  afi-safi ipv4-unicast` as a VPNv4 NLRI toward a remote PE
+  Using a two-namespace topology where z1 originates the prefix
+  inside vrf-blue and z2 peers with z1 over VPNv4 only.
+
+  Test Topology:
+  ```
+  ┌─────────────┐                ┌─────────────┐
+  │     z1      │   VPNv4 iBGP   │     z2      │
+  │  AS 65001   │ ◀────────────▶ │  AS 65001   │
+  │ vrf-blue:   │                │ vrf-blue:   │
+  │  RD 65001:  │                │  RD 65001:  │
+  │   100       │                │   200       │
+  │  RT 65001:  │                │  RT 65001:  │
+  │   100 imp/  │                │   100 imp/  │
+  │   exp       │                │   exp       │
+  │  net 10.1.  │                │             │
+  │   0.0/24    │                │             │
+  └─────────────┘                └─────────────┘
+   192.168.0.1                    192.168.0.2
+  ```
+
+  Config files:
+  - z1-1.yaml: AS 65001, vrf-blue with RD 65001:100, RT 65001:100,
+    and a self-originated network 10.1.0.0/24. VPNv4 iBGP to z2.
+  - z2-1.yaml: AS 65001, vrf-blue with RD 65001:200, RT 65001:100
+    (matching import). VPNv4 iBGP to z1.
+
+  Scenario: Setup topology
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+
+  Scenario: z1 advertises the self-originated network as VPNv4
+    Given the test topology exists
+    Then show command "ip bgp vpnv4" in namespace "z1" should contain "10.1.0.0/24"
+    And show command "ip bgp vpnv4" in namespace "z1" should contain "65001:100"
+
+  Scenario: z2 receives the VPNv4 NLRI under the same RD
+    Given the test topology exists
+    Then show command "ip bgp vpnv4" in namespace "z2" should contain "10.1.0.0/24"
+    And show command "ip bgp vpnv4" in namespace "z2" should contain "65001:100"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -171,6 +171,13 @@ pub fn spawn_bgp_vrf(
         });
     }
 
+    // Step 21b: self-originated networks from
+    // `router bgp vrf X afi-safi ipv4-unicast network <p>` land
+    // in `vrf.local_rib.v4` as `BgpRibType::Originated` and
+    // emit a `BgpGlobalMsg::Export` so the global instance
+    // promotes them to VPNv4 advertisements toward PE peers.
+    let network_count = materialize_self_originated_networks(&mut vrf, cfg);
+
     // Step 19b: install the AF_MPLS DecapVrf ILM at the
     // allocated label so a remote PE's VPNv4 packet with this
     // label pops + lands in `vrf_tables[table_id]`. Only when
@@ -202,6 +209,7 @@ pub fn spawn_bgp_vrf(
         label,
         ilm_installed = ilm_decap_ifindex.is_some(),
         peers = peer_count,
+        networks = network_count,
         "bgp: spawned per-VRF task",
     );
     BgpVrfHandle {
@@ -251,6 +259,80 @@ fn materialize_peers(vrf: &mut BgpVrf, cfg: &BgpVrfConfig) -> usize {
         );
         peer.start();
         vrf.peers.insert_with_key(PeerKey::Addr(*addr), peer);
+        count += 1;
+    }
+    count
+}
+
+/// Step 21b: insert each prefix from
+/// `cfg.ipv4_unicast.networks` into the per-VRF Loc-RIB as a
+/// `BgpRibType::Originated` row and emit a `BgpGlobalMsg::Export`
+/// so the global instance promotes it to a VPNv4 advertisement.
+///
+/// Mirrors `Bgp::route_add` (the global-Bgp equivalent for plain
+/// IPv4-unicast `network` statements) but bypasses the
+/// `route_advertise_to_peers` call — CE peers under this VRF
+/// reach the same prefix via the existing best-path → advertise
+/// path when an actual CE session establishes; the only emit
+/// path we need at spawn time is the cross-task `Export` toward
+/// PE peers.
+///
+/// We *don't* go through `route_ipv4_update` (which would also
+/// fire the step-17b-iii export hook) because that entry takes a
+/// `BgpTop` and treats the new candidate as if it came from a
+/// real peer — split-horizon and policy filters would have to
+/// be threaded through. The direct-write here is the same shape
+/// `Bgp::route_add` uses for the global case.
+fn materialize_self_originated_networks(vrf: &mut BgpVrf, cfg: &BgpVrfConfig) -> usize {
+    use bgp_packet::{BgpAttr, BgpNexthop, Origin};
+
+    let Some(af) = cfg.ipv4_unicast.as_ref() else {
+        return 0;
+    };
+    if af.networks.is_empty() {
+        return 0;
+    }
+
+    let exporter = super::VrfExporter {
+        name: vrf.name.clone(),
+        tx: vrf.global_tx.clone(),
+        label: vrf.label,
+    };
+
+    let mut count = 0usize;
+    for prefix in &af.networks {
+        // Build a self-originated attr: IGP origin, next-hop-self.
+        // Local-pref / weight default to the same values
+        // `BgpAttr::new` uses for the global `network` path.
+        let mut attr = BgpAttr::new();
+        attr.origin = Some(Origin::Igp);
+        attr.nexthop = Some(BgpNexthop::Ipv4(vrf.router_id));
+        let interned = vrf.attr_store.intern(attr);
+
+        let rib = super::super::route::BgpRib {
+            remote_id: 0,
+            local_id: 0,
+            attr: interned,
+            ident: 0,
+            router_id: vrf.router_id,
+            weight: 32768,
+            typ: super::super::route::BgpRibType::Originated,
+            best_path: false,
+            best_reason: super::super::route::Reason::Default,
+            label: None,
+            nexthop: None,
+            egress_ifindex_v6: None,
+            stale: false,
+            esi: None,
+        };
+
+        let (_, selected, _) = vrf.local_rib.update(None, *prefix, rib);
+        // Best-path runs as part of `update`. A freshly-inserted
+        // self-originated row always wins (nothing else exists),
+        // so `selected.first()` carries the winner; emit Export.
+        if let Some(winner) = selected.first() {
+            super::vrf_emit_export(&exporter, *prefix, &winner.attr);
+        }
         count += 1;
     }
     count


### PR DESCRIPTION
## Summary

Step 21b of the BGP MPLS/VPN refactor. Wires the per-VRF
`network <prefix>` knob (under `router bgp vrf X afi-safi
ipv4-unicast`) to actually originate the prefix into the VRF's
Loc-RIB and drive `BgpGlobalMsg::Export` so it becomes a VPNv4
advertisement. Adds a two-namespace BDD verifying export end-to-end.

Without this consumer the YANG callbacks landed in step 12
staged the prefix on `BgpVrfConfig.ipv4_unicast.networks` but
nothing read them.

- `materialize_self_originated_networks`: walks
  `cfg.ipv4_unicast.networks` at spawn, builds a self-originated
  `BgpRib { typ: Originated, ident: 0, attr: { origin: Igp,
  nexthop: Ipv4(vrf.router_id), weight: 32768 } }`, calls
  `vrf.local_rib.update(None, prefix, rib)`, emits
  `vrf_emit_export`.
- Called from `spawn_bgp_vrf` after `materialize_peers`; logged
  with `networks = <count>`.
- BDD `bgp_vrf_vpnv4_export.feature`: z1 (vrf-blue, RD 65001:100,
  RT 65001:100, network 10.1.0.0/24) + z2 (vrf-blue, RD 65001:200,
  RT 65001:100 import) ─ VPNv4 iBGP. Asserts session establishes
  + 10.1.0.0/24 with RD 65001:100 appears in both PEs'
  `show ip bgp vpnv4`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` (596 unit tests pass)
- [ ] Manual: `sudo cargo test -p bdd --test cucumber -- @bgp_vrf_vpnv4_export`

🤖 Generated with [Claude Code](https://claude.com/claude-code)