### PR TITLE
ospf: add Ospfv3Instance spine (Phase 6 PR 1)

### DIFF
--- a/zebra-rs/src/ospf/mod.rs
+++ b/zebra-rs/src/ospf/mod.rs
@@ -55,3 +55,5 @@ pub mod tracing;
 
 pub mod reach_map;
 pub use reach_map::*;
+
+pub mod v3;

--- a/zebra-rs/src/ospf/v3/inst.rs
+++ b/zebra-rs/src/ospf/v3/inst.rs
@@ -1,0 +1,111 @@
+//! v3 protocol instance: socket + I/O task wiring.
+//!
+//! This is the spine. It opens the raw IPv6 socket, spawns the
+//! `read_packet_v6` and `write_packet_v6` tasks introduced by the
+//! Phase 5 network PRs, and runs a minimal event loop that drains
+//! incoming packets. The IFSM / NFSM / LSDB layers attach to this
+//! struct in subsequent Phase 6 PRs.
+//!
+//! Distinct from `super::super::Ospf` (the v2 instance) per the
+//! hybrid plan: the two instances run side-by-side, share the
+//! `OspfVersion` trait + `ProtoContext` + SPF infrastructure, and
+//! diverge on packet types, LSDB, and FSM state. A future
+//! refactor may unify them via generics once v3 protocol logic
+//! has matured enough to constrain the trait surface.
+
+use std::sync::Arc;
+
+use socket2::Socket;
+use tokio::io::unix::AsyncFd;
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+
+use crate::context::{ProtoContext, Task};
+
+use super::super::network_v6::{Ospfv3Recv, Ospfv3Send, read_packet_v6, write_packet_v6};
+use super::super::socket::ospf_socket_ipv6;
+
+/// Standalone OSPFv3 protocol instance.
+///
+/// Holds the v6 raw socket plus the two halves of the I/O
+/// channels: `rx_recv` drains parsed `Ospfv3Recv` items from the
+/// rx loop, `tx_send` lets the protocol layer enqueue
+/// `Ospfv3Send` items for the tx loop.
+pub struct Ospfv3Instance {
+    /// VRF / network namespace context. Held so subsequent PRs can
+    /// reach netlink, RIB, etc. through the same handle the v2
+    /// instance uses.
+    pub ctx: ProtoContext,
+    /// Raw IPv6 socket, shared with the spawned rx/tx tasks via
+    /// `Arc<AsyncFd<…>>`.
+    pub sock: Arc<AsyncFd<Socket>>,
+    /// Receiver end of the rx-loop channel. The rx-loop owns the
+    /// `tx_recv` half (consumed during construction); this end is
+    /// drained by the instance's event loop.
+    rx_recv: UnboundedReceiver<Ospfv3Recv>,
+    /// Sender end of the tx-loop channel. Protocol code (Hello
+    /// timer, DBD exchange, flood-out, etc.) pushes outgoing
+    /// packets here; the spawned tx loop owns the `rx_send` half.
+    pub tx_send: UnboundedSender<Ospfv3Send>,
+}
+
+impl Ospfv3Instance {
+    /// Create a new v3 instance: opens the raw v6 socket through
+    /// `ProtoContext` (so VRF binding inherits automatically) and
+    /// spawns the two long-lived I/O tasks bound to it.
+    ///
+    /// Returns `Err` only when the kernel refuses to give us the
+    /// raw socket (typically missing `CAP_NET_RAW`); on success
+    /// the instance is fully wired but the event loop is not yet
+    /// running — the caller drives that via [`serve`].
+    pub fn new(ctx: ProtoContext) -> std::io::Result<Self> {
+        let sock = Arc::new(AsyncFd::new(ospf_socket_ipv6(&ctx)?)?);
+
+        let (tx_recv, rx_recv) = mpsc::unbounded_channel::<Ospfv3Recv>();
+        let (tx_send, rx_send) = mpsc::unbounded_channel::<Ospfv3Send>();
+
+        // Spawn the rx loop. It owns its sender half; the
+        // instance keeps the receiver half on `rx_recv`.
+        let rx_sock = sock.clone();
+        tokio::spawn(async move {
+            read_packet_v6(rx_sock, tx_recv).await;
+        });
+
+        // Spawn the tx loop. It owns its receiver half; the
+        // instance keeps the sender half on `tx_send`.
+        let tx_sock = sock.clone();
+        tokio::spawn(async move {
+            write_packet_v6(tx_sock, rx_send).await;
+        });
+
+        Ok(Self {
+            ctx,
+            sock,
+            rx_recv,
+            tx_send,
+        })
+    }
+
+    /// Drain incoming v3 packets. For now just trace-logs them
+    /// — IFSM dispatch and neighbor lookup land in the next
+    /// Phase 6 PRs.
+    pub async fn event_loop(&mut self) {
+        while let Some(recv) = self.rx_recv.recv().await {
+            tracing::info!(
+                "ospfv3: rx type={:?} from {} dst={} ifindex={}",
+                recv.packet.typ,
+                recv.src,
+                recv.dst,
+                recv.ifindex,
+            );
+        }
+    }
+}
+
+/// Spawn the v3 instance's event loop on the tokio runtime,
+/// returning a handle that aborts the task on drop. Mirrors the
+/// v2 `super::super::inst::serve` shape.
+pub fn serve(mut inst: Ospfv3Instance) -> Task<()> {
+    Task::spawn(async move {
+        inst.event_loop().await;
+    })
+}

--- a/zebra-rs/src/ospf/v3/mod.rs
+++ b/zebra-rs/src/ospf/v3/mod.rs
@@ -1,0 +1,22 @@
+//! OSPFv3 protocol-side implementation.
+//!
+//! Hybrid layout per the Phase 6 plan: this module owns the
+//! v3-specific instance, link, neighbor, LSDB, and FSM state. The
+//! `OspfVersion` trait (in `super::version`), the v3 wire codec
+//! (in the `ospf-packet` crate), the v6 socket primitives (in
+//! `super::socket`), the v6 network read/write loops (in
+//! `super::network_v6`), and the SPF Dijkstra (in `crate::spf`)
+//! are all shared with v2 — only the protocol logic that has to
+//! differ lives here.
+//!
+//! Most of this module's types are introduced incrementally across
+//! Phase 6 PRs; this first PR adds only the instance spine.
+
+// `dead_code` and `unused_imports` allow-attributes cover the
+// fact that nothing constructs an `Ospfv3Instance` yet — the
+// daemon's main spawn path comes in a later PR. The re-export
+// below is the intended public surface for that future caller.
+#![allow(dead_code, unused_imports)]
+
+pub mod inst;
+pub use inst::{Ospfv3Instance, serve};


### PR DESCRIPTION
## Summary

Standalone v3 protocol instance. Opens the raw IPv6 socket via `ospf_socket_ipv6` (Phase 5 PR 1), spawns `read_packet_v6` / `write_packet_v6` tasks (Phase 5 PR 3) bound to it, and runs a minimal event loop that drains parsed incoming packets and trace-logs them.

The hybrid plan (chosen over full `Ospf<V>` generics): v3 protocol state lives in its own `ospf::v3::` submodule rather than parameterizing the v2 instance. Shared infrastructure — the `OspfVersion` trait, `ProtoContext`, v6 socket primitives, v6 network loops, SPF Dijkstra, the entire `ospf-packet` crate — is reused via direct calls; only the protocol layer that genuinely diverges is duplicated.

## Plan for the rest of Phase 6

- **PR 2** — `Ospfv3Link` + `Ospfv3Neighbor` + Hello-driven adjacency
- **PR 3** — `Ospfv3Lsdb` + DBD exchange
- **PR 4** — SPF + RIB install
- **PR 5** — daemon `main()` spawn (wires the instance into the rest of the daemon)

## Notes

- The new module carries `#![allow(dead_code, unused_imports)]` at the mod.rs level since no caller in the daemon constructs an `Ospfv3Instance` yet — that wiring lands with PR 5.
- No behavior change for any existing code path.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p zebra-rs --bins` — 596 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)