### PR TITLE
packaging: refresh changelog.yaml for 26.5.1

### DIFF
--- a/packaging/changelog.yaml
+++ b/packaging/changelog.yaml
@@ -1,31 +1,24 @@
 # changelog.yaml – keep newest entry first
 # All timestamps must be in full ISO-8601 format.
-# Fields “distribution” and “urgency” are optional per-entry; if you omit
+# Fields "distribution" and "urgency" are optional per-entry; if you omit
 # them, the defaults from .chglog.yml (or chglog config) are used.
-# Remove the comments (# …) in real files.
 
-- semver: 1.2.3                    # Debian version string (no leading “v”)
-  date: 2025-05-23T18:00:00+08:00  # Upload date (your local TZ or UTC)
-  distribution: unstable           # e.g. unstable | testing | stable
-  urgency: medium                  # low | medium | high | critical
-  packager: Kunihiro Ishiguro <you@example.com>
+- semver: 26.5.1
+  date: 2026-05-21T18:00:00+09:00
+  distribution: unstable
+  urgency: medium
+  packager: Kunihiro Ishiguro <kunihiro@zebra.dev>
   changes:
     - note: |
         ### Added
-        * First public release with SCTP “Come Back Later” congestion control
-        * Golang OpenTelemetry hooks for AMF
+        * OSPFv3 packet codec: header, Hello, DBDesc, LSR, LSUpdate, LSAck,
+          and Router/Network/Inter-Area/AS-External/Link/Intra-Area-Prefix LSAs
+        * OSPFv3 socket primitives and IPv6 pseudo-header checksum
+        * BGP per-VRF MPLS/VPN: label allocator, ILM decap, import/export hooks,
+          per-VRF network statements, `show ip bgp vrf`
+        * BGP color-aware policy (route-map match color, NHT consumer)
 
     - note: |
-        ### Fixed
-        * Memory leak in AMF N2 handler (closes #124)
-
-# ──────────────────────────────────────────────────────────────
-# Copy-and-paste the block above and adjust for every version.
-# ──────────────────────────────────────────────────────────────
-
-- semver: 1.2.2
-  date: 2025-04-15T15:30:00+08:00
-  packager: Kunihiro Ishiguro <you@example.com>
-  changes:
-    - note: |
-        * Maintenance release – bumped dependencies only
+        ### Changed
+        * OSPF parameterised over `OspfVersion` trait (Ospfv2 / Ospfv3 markers)
+        * OSPF CLI aligned with IS-IS style


### PR DESCRIPTION
## Summary
- Replace the example template (versions 1.2.3 / 1.2.2, `you@example.com`) with a real 26.5.1 entry so `nfpm package` embeds a correct `changelog.Debian.gz` in the .deb.
- Maintainer matches `packaging/nfpm-*.yaml` (`Kunihiro Ishiguro <kunihiro@zebra.dev>`).
- Highlights cover the recent OSPFv3 packet/socket primitives, BGP per-VRF MPLS/VPN, color-aware policy, and OspfVersion-trait refactor.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('packaging/changelog.yaml'))"` passes
- [x] `nfpm package --packager=deb --config=packaging/nfpm-arm64.yaml` succeeds
- [x] `dpkg-deb -I` shows the right Version/Maintainer; embedded `changelog.Debian.gz` lists the 26.5.1 entry

Generated with [Claude Code](https://claude.com/claude-code)