### PR TITLE
ospf: parameterize Identity<V> over V::Prefix

### DIFF
--- a/zebra-rs/src/ospf/ident.rs
+++ b/zebra-rs/src/ospf/ident.rs
@@ -1,33 +1,63 @@
 use std::net::Ipv4Addr;
 
-use ipnet::Ipv4Net;
-
 use super::link::OSPF_DEFAULT_PRIORITY;
+use super::version::{OspfVersion, Ospfv2};
 
+/// Per-interface identity carried in Hello-driven DR / BDR election
+/// and propagated through IFSM / NFSM events.
+///
+/// Parameterized over `V: OspfVersion` so the `prefix` field can be
+/// `Ipv4Net` for v2 and `Ipv6Net` for v3 in subsequent PRs. The
+/// default `V = Ospfv2` keeps every existing v2 callsite working
+/// without textual churn — `Identity` continues to mean
+/// `Identity<Ospfv2>` everywhere until a callsite is migrated.
+///
+/// `router_id`, `d_router`, and `bd_router` stay `Ipv4Addr` in both
+/// versions: router-ids remain 32-bit in v3 (RFC 5340 §A.3.1), and
+/// `d_router` / `bd_router` are 32-bit in both versions but carry
+/// different semantics — interface IPs in v2 vs. router-ids in v3
+/// per RFC 5340 §A.3.2. The v3-shaped interpretation lives on
+/// version-specific helper impls below.
 #[derive(Debug, PartialEq, Clone, Copy)]
-pub struct Identity {
-    pub prefix: Ipv4Net,
+pub struct Identity<V: OspfVersion = Ospfv2> {
+    pub prefix: V::Prefix,
     pub router_id: Ipv4Addr,
     pub d_router: Ipv4Addr,
     pub bd_router: Ipv4Addr,
     pub priority: u8,
 }
 
-impl Identity {
+impl<V: OspfVersion> Identity<V>
+where
+    V::Prefix: Default,
+{
     pub fn new(router_id: Ipv4Addr) -> Self {
         Self {
-            prefix: Ipv4Net::new(Ipv4Addr::UNSPECIFIED, 0).unwrap(),
+            prefix: V::Prefix::default(),
             router_id,
             d_router: Ipv4Addr::UNSPECIFIED,
             bd_router: Ipv4Addr::UNSPECIFIED,
             priority: OSPF_DEFAULT_PRIORITY,
         }
     }
+}
 
+impl Identity<Ospfv2> {
+    /// True iff this identity considers itself the DR on its link
+    /// (v2 semantics: `d_router` is the DR's interface IP, which
+    /// matches our own when we won the election).
+    ///
+    /// v2-only because v3 stores router-ids in `d_router` per
+    /// RFC 5340 §A.3.2; the equivalent check there compares
+    /// `d_router` against `self.router_id`, not `prefix.addr()`.
+    /// The v3 variant lands when an `Identity<Ospfv3>` consumer
+    /// needs it.
     pub fn is_declared_dr(&self) -> bool {
         self.prefix.addr() == self.d_router
     }
 
+    /// True iff this identity considers itself the BDR. v2-only
+    /// for the same reason as [`Self::is_declared_dr`].
     pub fn is_declared_bdr(&self) -> bool {
         self.prefix.addr() == self.bd_router
     }


### PR DESCRIPTION
## Summary

Phase 6 PR 2 (Option A: full generics). Make `Identity` generic over `V: OspfVersion` so its `prefix` field can hold `Ipv4Net` for v2 and `Ipv6Net` for v3.

Uses a **default type parameter** (`V: OspfVersion = Ospfv2`) so every existing `Identity` reference across `ifsm.rs` / `nfsm.rs` / `link.rs` / `neigh.rs` / `packet.rs` / `inst.rs` (~30 sites) continues to resolve to `Identity<Ospfv2>` without textual churn. When subsequent PRs migrate those callsites to be generic over `<V>` as well, they swap the default for an explicit parameter.

`Identity::new(router_id)` carries a `where V::Prefix: Default` clause and initializes the prefix via `V::Prefix::default()` — `Ipv4Net::default()` is `0.0.0.0/0`, equivalent to the previous explicit construction. Both `ipnet::Ipv4Net` and `ipnet::Ipv6Net` derive `Default`, so v3 inherits.

`is_declared_dr` and `is_declared_bdr` move into an `impl Identity<Ospfv2>` block. Their semantics differ in v3: RFC 5340 §A.3.2 stores router-ids in `d_router` / `bd_router` (not interface IPs), so the v2 `self.prefix.addr() == self.d_router` check doesn't translate directly. The v3 variant lands when an `Identity<Ospfv3>` consumer needs it.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p zebra-rs --bins` — 596 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)