### PR TITLE
ospf: parameterize Neighbor<V> over V::DbDesc, V::LsaHeader, V::Lsa

### DIFF
--- a/zebra-rs/src/ospf/neigh.rs
+++ b/zebra-rs/src/ospf/neigh.rs
@@ -3,18 +3,42 @@ use std::fmt::Display;
 use std::net::Ipv4Addr;
 
 use bitfield_struct::bitfield;
-use ipnet::Ipv4Net;
 use ospf_packet::*;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::time::Instant;
 
 use super::lsdb::OspfLsaKey;
 use super::task::Timer;
+use super::version::{OspfVersion, Ospfv2};
 use super::{Identity, Message, NfsmEvent, NfsmState};
 
-pub struct Neighbor {
+/// Per-neighbor protocol state.
+///
+/// Parameterized over `V: OspfVersion` so the wire-type-carrying
+/// fields (`dd`, `db_sum`, `ls_rxmt`) can specialize to v2 or v3
+/// types via the trait's associated types. Default `V = Ospfv2`
+/// keeps every existing callsite resolving to `Neighbor<Ospfv2>`
+/// without textual churn — same pattern as `Identity<V>` from
+/// the previous PR.
+///
+/// **Not yet parameterized** (still v2-bound concrete types):
+///   - `options: OspfOptions` — v3 uses `Ospfv3Options`, a 24-bit
+///     bitfield with a different layout. Pending a `V::Options`
+///     associated type.
+///   - `ls_req` / `ls_req_last` — v3 has `Ospfv3LsRequest` /
+///     `Ospfv3LsRequestEntry`. Pending a `V::LsRequest` associated
+///     type.
+///   - `tx` / `ptx: UnboundedSender<Message>` — v3 will need its
+///     own Message-like enum since the v2 one carries v2-specific
+///     packet variants. This is the largest single remaining
+///     parameterization; deferred to its own PR.
+///
+/// `Neighbor<Ospfv3>` won't yet construct (the v2-bound fields
+/// constrain instantiation to v2 in practice), but the wire-type
+/// fields are already future-proofed.
+pub struct Neighbor<V: OspfVersion = Ospfv2> {
     pub ifindex: u32,
-    pub ident: Identity,
+    pub ident: Identity<V>,
     pub state: NfsmState,
     pub ostate: NfsmState,
     pub timer: NeighborTimer,
@@ -22,12 +46,12 @@ pub struct Neighbor {
     pub flags: NeighborFlags,
     pub tx: UnboundedSender<Message>,
     pub state_change: usize,
-    pub dd: NeighborDbDesc,
+    pub dd: NeighborDbDesc<V>,
     pub ptx: UnboundedSender<Message>,
-    pub db_sum: Vec<OspfLsaHeader>,
+    pub db_sum: Vec<V::LsaHeader>,
     pub ls_req: Vec<OspfLsRequestEntry>,
     pub ls_req_last: Option<OspfLsRequest>,
-    pub ls_rxmt: BTreeMap<OspfLsaKey, OspfLsa>,
+    pub ls_rxmt: BTreeMap<OspfLsaKey, V::Lsa>,
     pub uptime: Instant,
     pub last_progressive: Option<Instant>,
     pub last_regressive: Option<Instant>,
@@ -51,30 +75,51 @@ pub struct NeighborTimer {
     pub ls_rxmt: Option<Timer>,
 }
 
+/// DBD-exchange bookkeeping for one neighbor.
+///
+/// `flags` and `seqnum` are version-agnostic (RFC 5340 §10.6 reuses
+/// v2's I/M/MS layout for v3). `recv` and `sent` carry the actual
+/// DBD bodies, which differ between versions via `V::DbDesc`.
 #[derive(Debug)]
-pub struct NeighborDbDesc {
+pub struct NeighborDbDesc<V: OspfVersion = Ospfv2> {
     pub flags: DbDescFlags,
     pub seqnum: u32,
-    pub recv: OspfDbDesc,
-    pub sent: Option<OspfDbDesc>,
+    pub recv: V::DbDesc,
+    pub sent: Option<V::DbDesc>,
 }
 
-impl NeighborDbDesc {
+impl<V: OspfVersion> NeighborDbDesc<V>
+where
+    V::DbDesc: Default,
+{
     pub fn new() -> Self {
         Self {
             flags: 0.into(),
             seqnum: 0,
-            recv: OspfDbDesc::default(),
+            recv: V::DbDesc::default(),
             sent: None,
         }
     }
 }
 
-impl Neighbor {
+impl<V: OspfVersion> Default for NeighborDbDesc<V>
+where
+    V::DbDesc: Default,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<V: OspfVersion> Neighbor<V>
+where
+    V::Prefix: Default,
+    V::DbDesc: Default,
+{
     pub fn new(
         tx: UnboundedSender<Message>,
         ifindex: u32,
-        prefix: Ipv4Net,
+        prefix: V::Prefix,
         router_id: &Ipv4Addr,
         _dead_interval: u64,
         ptx: UnboundedSender<Message>,
@@ -84,12 +129,12 @@ impl Neighbor {
             state: NfsmState::Down,
             ostate: NfsmState::Down,
             timer: NeighborTimer::default(),
-            ident: Identity::new(*router_id),
+            ident: Identity::<V>::new(*router_id),
             options: 0.into(),
             flags: 0.into(),
             tx,
             state_change: 0,
-            dd: NeighborDbDesc::new(),
+            dd: NeighborDbDesc::<V>::new(),
             ptx,
             db_sum: vec![],
             ls_req: vec![],
@@ -103,7 +148,9 @@ impl Neighbor {
         nbr.ident.prefix = prefix;
         nbr
     }
+}
 
+impl<V: OspfVersion> Neighbor<V> {
     pub fn is_pointopoint(&self) -> bool {
         // Return true is parent interface is one of following:
         // PointToPoint
@@ -118,7 +165,7 @@ impl Neighbor {
     }
 }
 
-impl Display for Neighbor {
+impl<V: OspfVersion> Display for Neighbor<V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,


### PR DESCRIPTION
## Summary

Phase 6 PR 3 (Option A: full generics). Make `Neighbor` and `NeighborDbDesc` generic over `V: OspfVersion`. Default `V = Ospfv2` keeps every existing callsite (~70 sites across ifsm/nfsm/link/packet/inst.rs/flood.rs) resolving to `Neighbor<Ospfv2>` without textual churn.

## Parameterized fields

| Field | Generic type |
|---|---|
| `ident` | `Identity<V>` (V::Prefix) |
| `dd` | `NeighborDbDesc<V>` (V::DbDesc, twice) |
| `db_sum` | `Vec<V::LsaHeader>` |
| `ls_rxmt` | `BTreeMap<OspfLsaKey, V::Lsa>` |

## Still v2-bound (concrete types)

- `options: OspfOptions` — v3 has `Ospfv3Options` (24-bit, different layout). Pending `V::Options` trait type.
- `ls_req` / `ls_req_last` — v3 has `Ospfv3LsRequest` / `Entry`. Pending `V::LsRequest` trait type.
- `tx` / `ptx: UnboundedSender<Message>` — the v2 `Message` enum carries v2-specific packet variants. The largest remaining parameterization; deferred to its own PR.
- `flags: DbDescFlags` — I/M/MS layout identical between v2 and v3 (RFC 5340 §10.6 reuses v2 layout); no parameterization needed.

`Neighbor<Ospfv3>` doesn't yet construct (the v2-bound fields constrain instantiation to v2 in practice), but the wire-type fields are now future-proofed and the cascade can continue with Link, Lsdb, and Ospf.

## Trait bounds on constructors

`Neighbor::new` requires `V::Prefix: Default` (from `Identity::new`) and `V::DbDesc: Default` (from `NeighborDbDesc::new`). Both hold for v2 (`OspfDbDesc` derives `Default`). v3 callers will need either to derive `Default` on `Ospfv3DbDesc` or to provide a non-default constructor when they materialize — chosen at the time, since both options are cheap.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p zebra-rs --bins` — 596 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)