### PR TITLE
ospf: parameterize Ospf<V>, OspfArea<V>, OspfInterface<V>

### DIFF
--- a/zebra-rs/src/ospf/area.rs
+++ b/zebra-rs/src/ospf/area.rs
@@ -3,6 +3,7 @@ use std::net::Ipv4Addr;
 
 use super::Lsdb;
 use super::task::Timer;
+use super::version::{OspfVersion, Ospfv2};
 
 pub const AREA0: Ipv4Addr = Ipv4Addr::UNSPECIFIED;
 
@@ -12,35 +13,46 @@ pub enum AreaType {
     Normal,
 }
 
-pub struct OspfAreaMap(BTreeMap<Ipv4Addr, OspfArea>);
+/// Map of OSPF area-id → `OspfArea<V>`.
+///
+/// Generic over `V: OspfVersion` so v3's areas will carry
+/// `Lsdb<Ospfv3>` when the v3 instance materializes. Default
+/// `V = Ospfv2` keeps existing callers resolving to the v2 shape.
+pub struct OspfAreaMap<V: OspfVersion = Ospfv2>(BTreeMap<Ipv4Addr, OspfArea<V>>);
 
-impl OspfAreaMap {
+impl<V: OspfVersion> OspfAreaMap<V> {
     pub fn new() -> Self {
         let mut areas = Self(BTreeMap::new());
         areas.fetch(Ipv4Addr::UNSPECIFIED);
         areas
     }
 
-    pub fn get(&self, id: Ipv4Addr) -> Option<&OspfArea> {
+    pub fn get(&self, id: Ipv4Addr) -> Option<&OspfArea<V>> {
         self.0.get(&id)
     }
 
-    pub fn get_mut(&mut self, id: Ipv4Addr) -> Option<&mut OspfArea> {
+    pub fn get_mut(&mut self, id: Ipv4Addr) -> Option<&mut OspfArea<V>> {
         self.0.get_mut(&id)
     }
 
-    pub fn fetch(&mut self, area_id: Ipv4Addr) -> &mut OspfArea {
+    pub fn fetch(&mut self, area_id: Ipv4Addr) -> &mut OspfArea<V> {
         self.0
             .entry(area_id)
             .or_insert_with(|| OspfArea::new(area_id))
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&Ipv4Addr, &OspfArea)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&Ipv4Addr, &OspfArea<V>)> {
         self.0.iter()
     }
 }
 
-pub struct OspfArea {
+impl<V: OspfVersion> Default for OspfAreaMap<V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct OspfArea<V: OspfVersion = Ospfv2> {
     // OSPF area id.  This value may be treated as IPv4 address.
     pub id: Ipv4Addr,
 
@@ -51,19 +63,19 @@ pub struct OspfArea {
     pub links: BTreeSet<u32>,
 
     // LSDB of this area.
-    pub lsdb: Lsdb,
+    pub lsdb: Lsdb<V>,
 
     // SPF calculation timer.
     pub spf_timer: Option<Timer>,
 }
 
-impl OspfArea {
+impl<V: OspfVersion> OspfArea<V> {
     pub fn new(id: Ipv4Addr) -> Self {
         Self {
             id,
             area_type: AreaType::default(),
             links: BTreeSet::new(),
-            lsdb: Lsdb::new(),
+            lsdb: Lsdb::<V>::new(),
             spf_timer: None,
         }
     }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -36,6 +36,7 @@ use super::nfsm::{NfsmEvent, ospf_nfsm};
 use super::socket::ospf_socket_ipv4;
 use super::task::{Timer, TimerType};
 use super::tracing::OspfTracing;
+use super::version::OspfVersion;
 use super::{
     AREA0, Identity, Lsdb, Neighbor, NfsmState, ospf_ls_ack_recv, ospf_ls_req_recv,
     ospf_ls_upd_recv,
@@ -43,7 +44,18 @@ use super::{
 
 pub type ShowCallback = fn(&Ospf, Args, bool) -> Result<String, std::fmt::Error>;
 
-pub struct Ospf {
+/// OSPF protocol instance.
+///
+/// Parameterized over `V: OspfVersion` (default `Ospfv2`) so the
+/// embedded link/area/LSDB state can specialize per version while
+/// keeping every existing v2 callsite resolving to `Ospf<Ospfv2>`
+/// without textual churn. Methods on `Ospf` are still v2-bound and
+/// live in `impl Ospf<Ospfv2>` below — they manipulate v2-specific
+/// LSA bodies (`OspfLsp::OpaqueAreaRouterInfo`, etc.) and the v2
+/// `Message` enum directly. They generalize when the
+/// `OspfVersion` trait grows accessor methods, in a future round
+/// of trait expansion.
+pub struct Ospf<V: OspfVersion = Ospfv2> {
     pub tx: UnboundedSender<Message>,
     pub rx: UnboundedReceiver<Message>,
     pub ptx: UnboundedSender<Message>,
@@ -51,13 +63,13 @@ pub struct Ospf {
     pub callbacks: HashMap<String, Callback>,
     pub ctx: crate::context::ProtoContext,
     pub rib_rx: UnboundedReceiver<RibRx>,
-    pub links: BTreeMap<u32, OspfLink>,
-    pub areas: OspfAreaMap,
+    pub links: BTreeMap<u32, OspfLink<V>>,
+    pub areas: OspfAreaMap<V>,
     pub show: ShowChannel,
     pub show_cb: HashMap<String, ShowCallback>,
     pub sock: Arc<AsyncFd<Socket>>,
     pub router_id: Ipv4Addr,
-    pub lsdb_as: Lsdb,
+    pub lsdb_as: Lsdb<V>,
     pub lsp_map: LspMap,
     pub spf_result: Option<BTreeMap<usize, Path>>,
     pub graph: Option<spf::Graph>,
@@ -69,15 +81,19 @@ pub struct Ospf {
 }
 
 // OSPF inteface structure which points out upper layer struct members.
-pub struct OspfInterface<'a> {
+//
+// Parameterized over V: OspfVersion via the borrowed references
+// into v3-shaped state (Identity<V>, Lsdb<V>, Vec<OspfAddr<V>>).
+// Default V = Ospfv2 keeps function signatures unchanged at callsites.
+pub struct OspfInterface<'a, V: OspfVersion = Ospfv2> {
     pub tx: &'a UnboundedSender<Message>,
     pub router_id: &'a Ipv4Addr,
-    pub ident: &'a Identity,
-    pub addr: &'a Vec<OspfAddr<Ospfv2>>,
+    pub ident: &'a Identity<V>,
+    pub addr: &'a Vec<OspfAddr<V>>,
     pub mtu: u32,
     pub db_desc_in: &'a mut usize,
-    pub lsdb: &'a mut Lsdb,
-    pub lsdb_as: &'a mut Lsdb,
+    pub lsdb: &'a mut Lsdb<V>,
+    pub lsdb_as: &'a mut Lsdb<V>,
     pub area_id: Ipv4Addr,
     pub area_type: super::area::AreaType,
     pub exchange_loading_count: usize,
@@ -86,7 +102,7 @@ pub struct OspfInterface<'a> {
     pub tracing: &'a OspfTracing,
 }
 
-impl Ospf {
+impl Ospf<Ospfv2> {
     pub fn ospf_interface<'a>(
         &'a mut self,
         ifindex: u32,


### PR DESCRIPTION
## Summary

Phase 6 PR 6 (Option A: full generics). Add `V: OspfVersion = Ospfv2` default param to the remaining structural types. **This completes the structural parameterization** — the cascade through Identity → Neighbor → OspfLink → Lsdb → OspfArea → Ospf is now end-to-end generic.

## Parameterized

- `OspfAreaMap<V>(BTreeMap<Ipv4Addr, OspfArea<V>>)`
- `OspfArea<V> { lsdb: Lsdb<V>, ... }`
- `Ospf<V> { links: BTreeMap<u32, OspfLink<V>>, areas: OspfAreaMap<V>, lsdb_as: Lsdb<V>, ... }`
- `OspfInterface<'a, V> { ident: &Identity<V>, addr: &Vec<OspfAddr<V>>, lsdb / lsdb_as: &mut Lsdb<V>, ... }`

## Still v2-bound

- `Ospf::tx / rx / ptx`: Message channels — the v2 `Message` enum carries v2-specific packet variants; pending its own PR.
- `Ospf::rib`: `PrefixMap<Ipv4Net, SpfRoute>` — SpfRoute holds Ipv4Addr-shaped nexthops; v3 RIB shape decided when its consumer materializes.
- `Ospf::lsp_map`: v2 `LspMap` for SR-MPLS / opaque LSA tracking.

## Where the methods live

The entire `impl Ospf` block (~1700 lines of method bodies) moves into `impl Ospf<Ospfv2>` — these methods destructure `OspfLsa` headers, match on `OspfLsp` variants, build `OspfLsUpdate` packets, etc. With default `V = Ospfv2` on the struct, callers continue to write `Ospf` without turbofish and method dispatch routes to `impl Ospf<Ospfv2>` transparently.

## Behavioral migration is a separate arc

Moving method bodies from `impl Foo<Ospfv2>` into generic `impl<V> Foo<V>` requires the `OspfVersion` trait to grow accessor methods (`fn ls_age`, `fn ls_type`, `fn ls_id`, etc.). That round of trait expansion is the next milestone before `Ospf<Ospfv3>` can have real behavior. PR 7 (spawning `Ospf<Ospfv3>` alongside `Ospf<Ospfv2>`) cannot meaningfully ship until that migration progresses.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p zebra-rs --bins` — 596 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)