### PR TITLE
ospf: flatten Lsdb storage to single BTreeMap<OspfLsaKey, Lsa<V>>

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1454,11 +1454,11 @@ fn graph(top: &mut Ospf, area_id: Ipv4Addr) -> (spf::Graph, Option<usize>) {
 
     // Collect non-MaxAge Router-LSA data.
     let mut router_lsas = Vec::new();
-    for ((_ls_id, adv_router), lsa) in area.lsdb.tables.router.iter() {
+    for ((_ls_id, adv_router), lsa) in area.lsdb.iter_by_type(OspfLsType::Router) {
         if lsa.data.h.ls_age >= OSPF_MAX_AGE {
             continue;
         }
-        router_lsas.push((*adv_router, lsa.originated, lsa.data.clone()));
+        router_lsas.push((adv_router, lsa.originated, lsa.data.clone()));
     }
 
     // Side-table for the bidirectional back-link check on P2P / Virtual
@@ -1473,12 +1473,12 @@ fn graph(top: &mut Ospf, area_id: Ipv4Addr) -> (spf::Graph, Option<usize>) {
     // Collect non-MaxAge Network-LSA attached routers for transit
     // network expansion.
     let mut network_lsas: HashMap<Ipv4Addr, Vec<Ipv4Addr>> = HashMap::new();
-    for ((ls_id, _adv_router), lsa) in area.lsdb.tables.network.iter() {
+    for ((ls_id, _adv_router), lsa) in area.lsdb.iter_by_type(OspfLsType::Network) {
         if lsa.data.h.ls_age >= OSPF_MAX_AGE {
             continue;
         }
         if let OspfLsp::Network(ref net_lsa) = lsa.data.lsp {
-            network_lsas.insert(*ls_id, net_lsa.attached_routers.clone());
+            network_lsas.insert(ls_id, net_lsa.attached_routers.clone());
         }
     }
 
@@ -1658,7 +1658,7 @@ fn add_inter_area_routes(
         return;
     };
 
-    for ((ls_id, _key_adv), lsa) in area.lsdb.tables.summary.iter() {
+    for ((ls_id, _key_adv), lsa) in area.lsdb.iter_by_type(OspfLsType::Summary) {
         // RFC 2328 §16.2: skip MaxAge LSAs.
         if lsa.data.h.ls_age >= OSPF_MAX_AGE {
             continue;
@@ -1685,7 +1685,7 @@ fn add_inter_area_routes(
         };
 
         let mask = u32::from(summary.netmask).leading_ones() as u8;
-        let Ok(prefix) = Ipv4Net::new(*ls_id, mask) else {
+        let Ok(prefix) = Ipv4Net::new(ls_id, mask) else {
             continue;
         };
         let prefix = prefix.trunc();
@@ -1742,7 +1742,7 @@ fn build_rib_from_spf(
                     OspfLinkType::Transit => {
                         // Transit Network: look up Network-LSA to get the
                         // network prefix (link_id = dr's interface ip).
-                        for ((_ls_id, _adv), nlsa) in area.lsdb.tables.network.iter() {
+                        for ((_ls_id, _adv), nlsa) in area.lsdb.iter_by_type(OspfLsType::Network) {
                             if let OspfLsp::Network(ref net) = nlsa.data.lsp
                                 && nlsa.data.h.ls_id == link.link_id
                             {
@@ -1819,7 +1819,7 @@ fn add_as_external_routes(
     // E flag in the AS-external LSA's `ext_and_resvd` byte.
     const E_FLAG: u8 = 0x80;
 
-    for ((ls_id, _key_adv), lsa) in top.lsdb_as.tables.as_external.iter() {
+    for ((ls_id, _key_adv), lsa) in top.lsdb_as.iter_by_type(OspfLsType::AsExternal) {
         if lsa.data.h.ls_age >= OSPF_MAX_AGE {
             continue;
         }
@@ -1852,7 +1852,7 @@ fn add_as_external_routes(
         };
 
         let mask = u32::from(ext.netmask).leading_ones() as u8;
-        let Ok(prefix) = Ipv4Net::new(*ls_id, mask) else {
+        let Ok(prefix) = Ipv4Net::new(ls_id, mask) else {
             continue;
         };
         let prefix = prefix.trunc();

--- a/zebra-rs/src/ospf/lsdb.rs
+++ b/zebra-rs/src/ospf/lsdb.rs
@@ -19,12 +19,17 @@ pub const OSPF_LS_REFRESH_TIME: u64 = 1800;
 pub const OSPF_MAX_LSA_SEQ: u32 = 0x7FFFFFFF;
 pub const OSPF_MIN_LS_ARRIVAL: u64 = 1; // 1 second (RFC 2328)
 
-/// Per-LSA-type storage indexed by `(LS-ID, Advertising-Router)`.
+/// Flat LSDB storage: a single BTreeMap keyed by the full
+/// `(LS-Type, LS-ID, Advertising-Router)` triple. Replaces the
+/// earlier per-LS-type bucket layout (`LsTypes<LsTable>`).
 ///
-/// Generic over `V: OspfVersion` so v3's LSDB can wrap `Ospfv3Lsa`
-/// when its consumers materialize. Default `V = Ospfv2` keeps all
-/// existing references resolving to the v2 shape.
-pub type LsTable<V = Ospfv2> = BTreeMap<(Ipv4Addr, Ipv4Addr), Lsa<V>>;
+/// The flat shape is friendlier to the v3 generification arc — v3's
+/// LSA types (RFC 5340 §A.4.2.1, 0x2001 / 0x2002 / 0x2003 / …)
+/// don't map cleanly onto v2's named buckets (Router / Network /
+/// Summary / SummaryAsbr / AsExternal / OpaqueAreaLocal /
+/// Unknown). Iterating per-type now goes through
+/// [`Lsdb::iter_by_type`].
+pub type LsTable<V = Ospfv2> = BTreeMap<OspfLsaKey, Lsa<V>>;
 
 /// LSDB key: `(LS-Type, LS-ID, Advertising-Router)`.
 ///
@@ -44,54 +49,17 @@ pub enum LsdbEvent {
 /// Per-area (or AS-scope) Link State Database.
 ///
 /// Parameterized over `V: OspfVersion`. The storage layout
-/// (`tables: LsTypes<LsTable<V>>`) is generic; the methods that
+/// (`tables: LsTable<V>`) is generic; the methods that
 /// manipulate LSAs live in `impl Lsdb<Ospfv2>` for now because they
 /// destructure v2-specific header / body types
 /// (`OspfLsType` enum match, `OspfLsp::OpaqueAreaRouterInfo` body
 /// shape). Those move into a generic impl when the `OspfVersion`
 /// trait grows accessor methods (`fn ls_type(&Lsa) -> u16`,
-/// `fn ls_id(&Lsa) -> Ipv4Addr`, etc.).
+/// `fn ls_id(&Lsa) -> Ipv4Addr`, etc.) — PR 7b.
 pub struct Lsdb<V: OspfVersion = Ospfv2> {
-    pub tables: LsTypes<LsTable<V>>,
+    pub tables: LsTable<V>,
     pub label_map: OspfLabelMap,
     pub reach_map: ReachMap,
-}
-
-#[derive(Default, Debug)]
-pub struct LsTypes<T> {
-    pub router: T,
-    pub network: T,
-    pub summary: T,
-    pub summary_asbr: T,
-    pub as_external: T,
-    pub opaque_area: T,
-    pub unknown: T,
-}
-
-impl<T> LsTypes<T> {
-    pub fn get(&self, ls_type: &OspfLsType) -> &T {
-        match ls_type {
-            OspfLsType::Router => &self.router,
-            OspfLsType::Network => &self.network,
-            OspfLsType::Summary => &self.summary,
-            OspfLsType::SummaryAsbr => &self.summary_asbr,
-            OspfLsType::AsExternal => &self.as_external,
-            OspfLsType::OpaqueAreaLocal => &self.opaque_area,
-            _ => &self.unknown,
-        }
-    }
-
-    pub fn get_mut(&mut self, ls_type: &OspfLsType) -> &mut T {
-        match ls_type {
-            OspfLsType::Router => &mut self.router,
-            OspfLsType::Network => &mut self.network,
-            OspfLsType::Summary => &mut self.summary,
-            OspfLsType::SummaryAsbr => &mut self.summary_asbr,
-            OspfLsType::AsExternal => &mut self.as_external,
-            OspfLsType::OpaqueAreaLocal => &mut self.opaque_area,
-            _ => &mut self.unknown,
-        }
-    }
 }
 
 /// One LSDB entry — the parsed LSA plus the bookkeeping the LSDB
@@ -180,10 +148,33 @@ fn refresh_timer(
 impl<V: OspfVersion> Lsdb<V> {
     pub fn new() -> Self {
         Self {
-            tables: LsTypes::<LsTable<V>>::default(),
+            tables: LsTable::<V>::default(),
             label_map: OspfLabelMap::default(),
             reach_map: ReachMap::default(),
         }
+    }
+
+    /// Iterate the LSAs of a particular LS-Type. Yields the
+    /// historic `(ls_id, adv_router)` 2-tuple key shape so existing
+    /// callsites that destructure `((ls_id, adv_router), lsa)`
+    /// keep working unchanged after the storage flattening.
+    pub fn iter_by_type(
+        &self,
+        ls_type: OspfLsType,
+    ) -> impl Iterator<Item = ((Ipv4Addr, Ipv4Addr), &Lsa<V>)> {
+        self.tables
+            .iter()
+            .filter(move |((t, _, _), _)| *t == ls_type)
+            .map(|((_, id, adv), lsa)| ((*id, *adv), lsa))
+    }
+
+    /// Iterate just the LSA values of a particular LS-Type. Convenience
+    /// over `iter_by_type` for callers that don't need the key.
+    pub fn values_by_type(&self, ls_type: OspfLsType) -> impl Iterator<Item = &Lsa<V>> {
+        self.tables
+            .iter()
+            .filter(move |((t, _, _), _)| *t == ls_type)
+            .map(|(_, lsa)| lsa)
     }
 }
 
@@ -206,13 +197,12 @@ impl Lsdb<Ospfv2> {
             Router | Network | Summary | SummaryAsbr | AsExternal | NssaAsExternal
             | OpaqueAreaLocal => {
                 ospf_lsa.update();
-                let key = (ospf_lsa.h.ls_id, ospf_lsa.h.adv_router);
                 let lsa_key: OspfLsaKey = (ls_type, ospf_lsa.h.ls_id, ospf_lsa.h.adv_router);
                 let mut lsa = Lsa::<Ospfv2>::new(ospf_lsa);
                 lsa.originated = true;
                 lsa.hold_timer = Some(hold_timer(tx, area_id, lsa_key, lsa.data.h.ls_age));
                 lsa.refresh_timer = Some(refresh_timer(tx, area_id, lsa_key));
-                self.tables.get_mut(&ls_type).insert(key, lsa);
+                self.tables.insert(lsa_key, lsa);
             }
             _ => {}
         }
@@ -225,7 +215,6 @@ impl Lsdb<Ospfv2> {
         area_id: Option<Ipv4Addr>,
     ) {
         let ls_type = ospf_lsa.h.ls_type;
-        let key = (ospf_lsa.h.ls_id, ospf_lsa.h.adv_router);
         let lsa_key: OspfLsaKey = (ls_type, ospf_lsa.h.ls_id, ospf_lsa.h.adv_router);
 
         self.update_lsa(&ospf_lsa);
@@ -233,7 +222,7 @@ impl Lsdb<Ospfv2> {
         let mut lsa = Lsa::<Ospfv2>::new(ospf_lsa);
         lsa.hold_timer = Some(hold_timer(tx, area_id, lsa_key, lsa.data.h.ls_age));
 
-        self.tables.get_mut(&lsa.data.h.ls_type).insert(key, lsa);
+        self.tables.insert(lsa_key, lsa);
     }
 
     pub fn update_lsa(&mut self, lsa: &OspfLsa) {
@@ -272,8 +261,7 @@ impl Lsdb<Ospfv2> {
     }
 
     pub fn remove_lsa(&mut self, ls_type: OspfLsType, ls_id: Ipv4Addr, adv_router: Ipv4Addr) {
-        let table = self.tables.get_mut(&ls_type);
-        table.remove(&(ls_id, adv_router));
+        self.tables.remove(&(ls_type, ls_id, adv_router));
     }
 
     /// Flush an LSA by setting its age to MaxAge and returning a clone for reflooding.
@@ -286,13 +274,11 @@ impl Lsdb<Ospfv2> {
         tx: &UnboundedSender<Message>,
         area_id: Option<Ipv4Addr>,
     ) -> Option<OspfLsa> {
-        let table = self.tables.get_mut(&ls_type);
-        let key = (ls_id, adv_router);
-        if let Some(lsa) = table.get_mut(&key) {
+        let lsa_key: OspfLsaKey = (ls_type, ls_id, adv_router);
+        if let Some(lsa) = self.tables.get_mut(&lsa_key) {
             lsa.data.h.ls_age = OSPF_MAX_AGE;
             lsa.birth_time = tokio::time::Instant::now();
             lsa.refresh_timer = None;
-            let lsa_key: OspfLsaKey = (ls_type, ls_id, adv_router);
             lsa.hold_timer = Some(hold_timer(tx, area_id, lsa_key, OSPF_MAX_AGE));
             Some(lsa.data.clone())
         } else {
@@ -308,19 +294,17 @@ impl Lsdb<Ospfv2> {
         tx: &UnboundedSender<Message>,
         area_id: Option<Ipv4Addr>,
     ) {
-        let table = self.tables.get_mut(&ls_type);
-        let key = (ls_id, adv_router);
-        if let Some(old_lsa) = table.get(&key) {
+        let lsa_key: OspfLsaKey = (ls_type, ls_id, adv_router);
+        if let Some(old_lsa) = self.tables.get(&lsa_key) {
             let mut new_data = old_lsa.data.clone();
             new_data.h.ls_seq_number += 1;
             new_data.h.ls_age = 0;
             new_data.update();
-            let lsa_key: OspfLsaKey = (ls_type, ls_id, adv_router);
             let mut lsa = Lsa::<Ospfv2>::new(new_data);
             lsa.originated = true;
             lsa.hold_timer = Some(hold_timer(tx, area_id, lsa_key, 0));
             lsa.refresh_timer = Some(refresh_timer(tx, area_id, lsa_key));
-            table.insert(key, lsa);
+            self.tables.insert(lsa_key, lsa);
         }
     }
 
@@ -330,8 +314,9 @@ impl Lsdb<Ospfv2> {
         ls_id: Ipv4Addr,
         adv_router: Ipv4Addr,
     ) -> Option<&OspfLsa> {
-        let table = self.tables.get(&ls_type);
-        table.get(&(ls_id, adv_router)).map(|lsa| &lsa.data)
+        self.tables
+            .get(&(ls_type, ls_id, adv_router))
+            .map(|lsa| &lsa.data)
     }
 
     pub fn lookup_lsa(
@@ -340,8 +325,7 @@ impl Lsdb<Ospfv2> {
         ls_id: Ipv4Addr,
         adv_router: Ipv4Addr,
     ) -> Option<&Lsa> {
-        let table = self.tables.get(&ls_type);
-        table.get(&(ls_id, adv_router))
+        self.tables.get(&(ls_type, ls_id, adv_router))
     }
 
     pub fn lookup_install_time(
@@ -363,20 +347,18 @@ impl Lsdb<Ospfv2> {
         tx: &UnboundedSender<Message>,
         area_id: Option<Ipv4Addr>,
     ) {
-        let table = self.tables.get_mut(&ls_type);
-        let key = (ls_id, adv_router);
-        if let Some(old_lsa) = table.get(&key) {
+        let lsa_key: OspfLsaKey = (ls_type, ls_id, adv_router);
+        if let Some(old_lsa) = self.tables.get(&lsa_key) {
             let mut new_data = old_lsa.data.clone();
             let next_seq = old_lsa.data.h.ls_seq_number.max(min_seq) + 1;
             new_data.h.ls_seq_number = next_seq;
             new_data.h.ls_age = 0;
             new_data.update();
-            let lsa_key: OspfLsaKey = (ls_type, ls_id, adv_router);
             let mut lsa = Lsa::<Ospfv2>::new(new_data);
             lsa.originated = true;
             lsa.hold_timer = Some(hold_timer(tx, area_id, lsa_key, 0));
             lsa.refresh_timer = Some(refresh_timer(tx, area_id, lsa_key));
-            table.insert(key, lsa);
+            self.tables.insert(lsa_key, lsa);
         }
     }
 }

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -325,9 +325,12 @@ pub fn ospf_db_summary_add(nbr: &mut Neighbor, lsa: &OspfLsa) {
     nbr.db_sum.push(lsa.h.clone());
 }
 
-fn ospf_db_summary_add_table(nbr: &mut Neighbor, table: &super::lsdb::LsTable) {
+fn ospf_db_summary_add_table<'a>(
+    nbr: &mut Neighbor,
+    lsas: impl Iterator<Item = &'a super::lsdb::Lsa>,
+) {
     use super::lsdb::OSPF_MAX_AGE;
-    for lsa in table.values() {
+    for lsa in lsas {
         if lsa.data.h.ls_age >= OSPF_MAX_AGE {
             continue;
         }
@@ -343,15 +346,15 @@ pub fn ospf_nfsm_negotiation_done(
     use super::area::AreaType;
 
     // RFC 2328 §10.8: Initial DD Summary list is the attached area's LSDB.
-    ospf_db_summary_add_table(nbr, &oi.lsdb.tables.router);
-    ospf_db_summary_add_table(nbr, &oi.lsdb.tables.network);
-    ospf_db_summary_add_table(nbr, &oi.lsdb.tables.summary);
-    ospf_db_summary_add_table(nbr, &oi.lsdb.tables.summary_asbr);
-    ospf_db_summary_add_table(nbr, &oi.lsdb.tables.opaque_area);
+    ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::Router));
+    ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::Network));
+    ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::Summary));
+    ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::SummaryAsbr));
+    ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::OpaqueAreaLocal));
 
     // AS-scope LSAs included only for non-stub / non-NSSA areas.
     if oi.area_type == AreaType::Normal {
-        ospf_db_summary_add_table(nbr, &oi.lsdb_as.tables.as_external);
+        ospf_db_summary_add_table(nbr, oi.lsdb_as.values_by_type(OspfLsType::AsExternal));
     }
 
     tracing::info!("[NFSM:NegotiationDone] DB Summary len {}", nbr.db_sum.len());

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -862,7 +862,7 @@ fn show_ospf_database(
         let mut areas = Vec::new();
         if let Some(area) = ospf.areas.get(AREA0) {
             let mut router_lsas = Vec::new();
-            for ((lsa_id, adv_router), lsa) in area.lsdb.tables.get(&OspfLsType::Router).iter() {
+            for ((lsa_id, adv_router), lsa) in area.lsdb.iter_by_type(OspfLsType::Router) {
                 let link_count = if let OspfLsp::Router(ref lsp) = lsa.data.lsp {
                     Some(lsp.links.len())
                 } else {
@@ -878,7 +878,7 @@ fn show_ospf_database(
                 });
             }
             let mut network_lsas = Vec::new();
-            for ((lsa_id, adv_router), lsa) in area.lsdb.tables.get(&OspfLsType::Network).iter() {
+            for ((lsa_id, adv_router), lsa) in area.lsdb.iter_by_type(OspfLsType::Network) {
                 network_lsas.push(OspfLsaSummaryJson {
                     link_id: lsa_id.to_string(),
                     adv_router: adv_router.to_string(),
@@ -889,9 +889,7 @@ fn show_ospf_database(
                 });
             }
             let mut opaque_area_lsas = Vec::new();
-            for ((lsa_id, adv_router), lsa) in
-                area.lsdb.tables.get(&OspfLsType::OpaqueAreaLocal).iter()
-            {
+            for ((lsa_id, adv_router), lsa) in area.lsdb.iter_by_type(OspfLsType::OpaqueAreaLocal) {
                 opaque_area_lsas.push(OspfLsaSummaryJson {
                     link_id: lsa_id.to_string(),
                     adv_router: adv_router.to_string(),
@@ -931,7 +929,7 @@ fn show_ospf_database(
         let _ = writeln!(out);
 
         let mut header = true;
-        for ((lsa_id, adv_router), lsa) in area.lsdb.tables.get(&OspfLsType::Router).iter() {
+        for ((lsa_id, adv_router), lsa) in area.lsdb.iter_by_type(OspfLsType::Router) {
             if header {
                 header = false;
                 writeln!(
@@ -959,7 +957,7 @@ fn show_ospf_database(
         writeln!(out)?;
 
         let mut header = true;
-        for ((lsa_id, adv_router), lsa) in area.lsdb.tables.get(&OspfLsType::Network).iter() {
+        for ((lsa_id, adv_router), lsa) in area.lsdb.iter_by_type(OspfLsType::Network) {
             if header {
                 header = false;
                 writeln!(out, "Link ID         ADV Router      Age  Seq#       CkSum")?;
@@ -975,8 +973,11 @@ fn show_ospf_database(
             );
         }
 
-        let opaque_table = area.lsdb.tables.get(&OspfLsType::OpaqueAreaLocal);
-        if !opaque_table.is_empty() {
+        let mut opaque_iter = area
+            .lsdb
+            .iter_by_type(OspfLsType::OpaqueAreaLocal)
+            .peekable();
+        if opaque_iter.peek().is_some() {
             writeln!(out)?;
             writeln!(
                 out,
@@ -985,7 +986,7 @@ fn show_ospf_database(
             )?;
             writeln!(out)?;
             writeln!(out, "Opaque-Type/Id  ADV Router      Age  Seq#       CkSum")?;
-            for ((lsa_id, adv_router), lsa) in opaque_table.iter() {
+            for ((lsa_id, adv_router), lsa) in opaque_iter {
                 let _ = writeln!(
                     out,
                     "{:15} {:15} {:4} 0x{:08x} 0x{:04x}",
@@ -1017,7 +1018,7 @@ fn show_ospf_database_detail(
         let mut areas = Vec::new();
         if let Some(area) = ospf.areas.get(AREA0) {
             let mut router_lsas = Vec::new();
-            for ((_lsa_id, _adv_router), lsa) in area.lsdb.tables.get(&OspfLsType::Router).iter() {
+            for ((_lsa_id, _adv_router), lsa) in area.lsdb.iter_by_type(OspfLsType::Router) {
                 let opts = OspfOptions::from(lsa.data.h.options);
                 let OspfLsp::Router(ref lsp) = lsa.data.lsp else {
                     continue;
@@ -1055,7 +1056,7 @@ fn show_ospf_database_detail(
                 });
             }
             let mut network_lsas = Vec::new();
-            for ((_lsa_id, _adv_router), lsa) in area.lsdb.tables.get(&OspfLsType::Network).iter() {
+            for ((_lsa_id, _adv_router), lsa) in area.lsdb.iter_by_type(OspfLsType::Network) {
                 let opts = OspfOptions::from(lsa.data.h.options);
                 let OspfLsp::Network(ref lsp) = lsa.data.lsp else {
                     continue;
@@ -1102,7 +1103,7 @@ fn show_ospf_database_detail(
         writeln!(out, "                Router Link States (Area {})", area.id)?;
         writeln!(out)?;
 
-        for ((lsa_id, adv_router), lsa) in area.lsdb.tables.get(&OspfLsType::Router).iter() {
+        for ((lsa_id, adv_router), lsa) in area.lsdb.iter_by_type(OspfLsType::Router) {
             writeln!(out, "  LS age: {}", lsa.current_age())?;
             let opts = OspfOptions::from(lsa.data.h.options);
             writeln!(
@@ -1176,7 +1177,7 @@ fn show_ospf_database_detail(
         writeln!(out, "                Net Link States (Area {})", area.id)?;
         writeln!(out)?;
 
-        for ((lsa_id, adv_router), lsa) in area.lsdb.tables.get(&OspfLsType::Network).iter() {
+        for ((lsa_id, adv_router), lsa) in area.lsdb.iter_by_type(OspfLsType::Network) {
             writeln!(out, "  LS age: {}", lsa.current_age())?;
             let opts = OspfOptions::from(lsa.data.h.options);
             writeln!(
@@ -1211,8 +1212,11 @@ fn show_ospf_database_detail(
             writeln!(out)?;
         }
 
-        let opaque_table = area.lsdb.tables.get(&OspfLsType::OpaqueAreaLocal);
-        if !opaque_table.is_empty() {
+        let mut opaque_iter = area
+            .lsdb
+            .iter_by_type(OspfLsType::OpaqueAreaLocal)
+            .peekable();
+        if opaque_iter.peek().is_some() {
             writeln!(
                 out,
                 "                Area-Local Opaque-LSA (Area {})",
@@ -1220,7 +1224,7 @@ fn show_ospf_database_detail(
             )?;
             writeln!(out)?;
 
-            for ((lsa_id, adv_router), lsa) in opaque_table.iter() {
+            for ((lsa_id, adv_router), lsa) in opaque_iter {
                 let octets = lsa_id.octets();
                 let opaque_type = octets[0];
                 let opaque_id =
@@ -1580,9 +1584,7 @@ fn show_ospf_segment_routing(
 
             // Look up Router Info LSA for this router to get algorithm info.
             let algo_str = lsdb
-                .tables
-                .opaque_area
-                .values()
+                .values_by_type(OspfLsType::OpaqueAreaLocal)
                 .find_map(|lsa| {
                     if lsa.data.h.adv_router == *router_id
                         && let OspfLsp::OpaqueAreaRouterInfo(ref ri) = lsa.data.lsp
@@ -1623,7 +1625,7 @@ fn show_ospf_segment_routing(
             )?;
 
             // Find Extended Prefix LSAs from this router.
-            for (_, lsa) in lsdb.tables.opaque_area.iter() {
+            for (_, lsa) in lsdb.iter_by_type(OspfLsType::OpaqueAreaLocal) {
                 if lsa.data.h.adv_router != *router_id {
                     continue;
                 }


### PR DESCRIPTION
## Summary

Phase 6 PR 7a (Option A: full generics, behavioral arc prep). Drop the per-LSA-type `LsTypes<T>` bucket struct. Replace with a single flat `BTreeMap` keyed by the full `(LS-Type, LS-ID, Advertising-Router)` triple.

The flat shape is friendlier to v3's LSA types (RFC 5340 §A.4.2.1: 0x2001 Router, 0x2002 Network, 0x2003 Inter-Area-Prefix, 0x2004 Inter-Area-Router, 0x4005 AsExternal, 0x0008 Link, 0x2009 Intra-Area-Prefix). v3's set doesn't map onto v2's named buckets, so a unified flat map sidesteps the impedance mismatch and lets the next PR move `Lsdb` methods into a generic `impl<V> Lsdb<V>`.

## Callsite migration

- Per-bucket iteration was e.g. `lsdb.tables.router.iter()`. Now: `lsdb.iter_by_type(OspfLsType::Router)`. The helper yields the historic `((ls_id, adv_router), &Lsa)` 2-tuple shape so destructuring at callsites is unchanged.
- For value-only iteration, `lsdb.values_by_type(LsType)` is the convenience over `iter_by_type`.
- `ospf_db_summary_add_table` in nfsm.rs switched from taking a `&LsTable` to taking an iterator. Callers pass `oi.lsdb.values_by_type(...)` directly.
- Two show.rs sites (`let opaque_table = ...` then `is_empty()` + `iter()` reuse) restructured around a peekable iterator since the new helpers can't be "borrowed twice as a reference."

## Scope

This is a v2-only refactor. **No generic-ifying of method bodies yet** — those still live in `impl Lsdb<Ospfv2>`. PR 7b adds the `OspfVersion` trait accessors (`ls_age`, `ls_type`, `ls_id`, `adv_router`, `ls_seq_number`, …) and migrates method bodies into generic `impl<V> Lsdb<V>`.

`OspfLsaKey` remains `(OspfLsType, Ipv4Addr, Ipv4Addr)` — v2-shaped. v3's 16-bit LS-Type / 32-bit LS-ID will need a generic key shape in a subsequent PR (likely a new `V::LsType` associated type or a widened `(u16, u32, Ipv4Addr)` tuple).

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p zebra-rs --bins` — 596 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)