### PR TITLE
ospf: add LSA-header trait accessors + migrate 6 Lsdb methods to generic

### DIFF
--- a/zebra-rs/src/ospf/lsdb.rs
+++ b/zebra-rs/src/ospf/lsdb.rs
@@ -89,15 +89,15 @@ impl<V: OspfVersion> Lsa<V> {
             refresh_timer: None,
         }
     }
-}
 
-impl Lsa<Ospfv2> {
     /// Compute the current LSA age: original ls_age plus elapsed
-    /// time since install, capped at MaxAge. v2-specific because
-    /// it reads `self.data.h.ls_age` — the v3 LsaHeader has the
-    /// same field but no shared trait method yet exposes it.
+    /// time since install, capped at MaxAge. Now generic — reads
+    /// the header via `V::lsa_header` and `V::ls_age`, which both
+    /// `Ospfv2` and `Ospfv3` impl identically (the field has the
+    /// same semantics in RFC 2328 §A.4.1 and RFC 5340 §A.4.2.1).
     pub fn current_age(&self) -> u16 {
-        let initial_age = self.data.h.ls_age;
+        let header = V::lsa_header(&self.data);
+        let initial_age = V::ls_age(header);
         let elapsed = self.birth_time.elapsed().as_secs() as u16;
         let age = initial_age.saturating_add(elapsed);
         age.min(OSPF_MAX_AGE)
@@ -175,6 +175,72 @@ impl<V: OspfVersion> Lsdb<V> {
             .iter()
             .filter(move |((t, _, _), _)| *t == ls_type)
             .map(|(_, lsa)| lsa)
+    }
+
+    /// Drop the LSA at the given key. Key-only operation — no
+    /// header field access, so trivially generic.
+    pub fn remove_lsa(&mut self, ls_type: OspfLsType, ls_id: Ipv4Addr, adv_router: Ipv4Addr) {
+        self.tables.remove(&(ls_type, ls_id, adv_router));
+    }
+
+    /// Flush an LSA by setting its age to MaxAge and returning a
+    /// clone for re-flooding. The refresh timer is cancelled, and
+    /// a new hold timer is set. Now generic — header mutation goes
+    /// through `V::lsa_header_mut` + `V::set_ls_age`.
+    pub fn flush_lsa(
+        &mut self,
+        ls_type: OspfLsType,
+        ls_id: Ipv4Addr,
+        adv_router: Ipv4Addr,
+        tx: &UnboundedSender<Message>,
+        area_id: Option<Ipv4Addr>,
+    ) -> Option<V::Lsa> {
+        let lsa_key: OspfLsaKey = (ls_type, ls_id, adv_router);
+        if let Some(lsa) = self.tables.get_mut(&lsa_key) {
+            V::set_ls_age(V::lsa_header_mut(&mut lsa.data), OSPF_MAX_AGE);
+            lsa.birth_time = tokio::time::Instant::now();
+            lsa.refresh_timer = None;
+            lsa.hold_timer = Some(hold_timer(tx, area_id, lsa_key, OSPF_MAX_AGE));
+            Some(lsa.data.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Look up an LSA's payload by key. Returns a reference into
+    /// the LSDB. Now generic — no header field access.
+    pub fn lookup_by_id(
+        &self,
+        ls_type: OspfLsType,
+        ls_id: Ipv4Addr,
+        adv_router: Ipv4Addr,
+    ) -> Option<&V::Lsa> {
+        self.tables
+            .get(&(ls_type, ls_id, adv_router))
+            .map(|lsa| &lsa.data)
+    }
+
+    /// Look up the full LSDB entry (including bookkeeping) by key.
+    /// Now generic.
+    pub fn lookup_lsa(
+        &self,
+        ls_type: OspfLsType,
+        ls_id: Ipv4Addr,
+        adv_router: Ipv4Addr,
+    ) -> Option<&Lsa<V>> {
+        self.tables.get(&(ls_type, ls_id, adv_router))
+    }
+
+    /// Return the install timestamp of an LSA, if present. Now
+    /// generic.
+    pub fn lookup_install_time(
+        &self,
+        ls_type: OspfLsType,
+        ls_id: Ipv4Addr,
+        adv_router: Ipv4Addr,
+    ) -> Option<tokio::time::Instant> {
+        self.lookup_lsa(ls_type, ls_id, adv_router)
+            .map(|lsa| lsa.install_time)
     }
 }
 
@@ -260,32 +326,6 @@ impl Lsdb<Ospfv2> {
         }
     }
 
-    pub fn remove_lsa(&mut self, ls_type: OspfLsType, ls_id: Ipv4Addr, adv_router: Ipv4Addr) {
-        self.tables.remove(&(ls_type, ls_id, adv_router));
-    }
-
-    /// Flush an LSA by setting its age to MaxAge and returning a clone for reflooding.
-    /// The refresh timer is cancelled, and a new hold timer is set.
-    pub fn flush_lsa(
-        &mut self,
-        ls_type: OspfLsType,
-        ls_id: Ipv4Addr,
-        adv_router: Ipv4Addr,
-        tx: &UnboundedSender<Message>,
-        area_id: Option<Ipv4Addr>,
-    ) -> Option<OspfLsa> {
-        let lsa_key: OspfLsaKey = (ls_type, ls_id, adv_router);
-        if let Some(lsa) = self.tables.get_mut(&lsa_key) {
-            lsa.data.h.ls_age = OSPF_MAX_AGE;
-            lsa.birth_time = tokio::time::Instant::now();
-            lsa.refresh_timer = None;
-            lsa.hold_timer = Some(hold_timer(tx, area_id, lsa_key, OSPF_MAX_AGE));
-            Some(lsa.data.clone())
-        } else {
-            None
-        }
-    }
-
     pub fn refresh_lsa(
         &mut self,
         ls_type: OspfLsType,
@@ -306,36 +346,6 @@ impl Lsdb<Ospfv2> {
             lsa.refresh_timer = Some(refresh_timer(tx, area_id, lsa_key));
             self.tables.insert(lsa_key, lsa);
         }
-    }
-
-    pub fn lookup_by_id(
-        &self,
-        ls_type: OspfLsType,
-        ls_id: Ipv4Addr,
-        adv_router: Ipv4Addr,
-    ) -> Option<&OspfLsa> {
-        self.tables
-            .get(&(ls_type, ls_id, adv_router))
-            .map(|lsa| &lsa.data)
-    }
-
-    pub fn lookup_lsa(
-        &self,
-        ls_type: OspfLsType,
-        ls_id: Ipv4Addr,
-        adv_router: Ipv4Addr,
-    ) -> Option<&Lsa> {
-        self.tables.get(&(ls_type, ls_id, adv_router))
-    }
-
-    pub fn lookup_install_time(
-        &self,
-        ls_type: OspfLsType,
-        ls_id: Ipv4Addr,
-        adv_router: Ipv4Addr,
-    ) -> Option<tokio::time::Instant> {
-        self.lookup_lsa(ls_type, ls_id, adv_router)
-            .map(|lsa| lsa.install_time)
     }
 
     pub fn refresh_lsa_with_seq(

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -86,6 +86,32 @@ pub trait OspfVersion: 'static + Send + Sync + Copy + Clone {
 
     /// AllDRouters multicast group: 224.0.0.6 (v2) or ff02::6 (v3).
     const ALL_DROUTERS: Self::Addr;
+
+    // ---- LSA / header accessors --------------------------------
+    //
+    // Static-style trait methods (called as `V::ls_age(h)`, not
+    // `h.ls_age()`) per the Phase 6 PR 7 direction. The associated
+    // types `Lsa` and `LsaHeader` are opaque to generic code; these
+    // methods are how generic Lsdb / NFSM code reads and mutates
+    // the header fields that have identical semantics in v2
+    // (RFC 2328 §A.4.1) and v3 (RFC 5340 §A.4.2.1).
+
+    /// Borrow the LSA header out of an LSA. Both `OspfLsa` and
+    /// `Ospfv3Lsa` carry it as a public `h` field — this method is
+    /// the trait surface that lets generic code reach it.
+    fn lsa_header(lsa: &Self::Lsa) -> &Self::LsaHeader;
+
+    /// Mutably borrow the LSA header. Used by methods that update
+    /// `ls_age` / `ls_seq_number` etc. when refreshing or flushing
+    /// an LSA.
+    fn lsa_header_mut(lsa: &mut Self::Lsa) -> &mut Self::LsaHeader;
+
+    /// LS Age in seconds. 16-bit in both versions.
+    fn ls_age(h: &Self::LsaHeader) -> u16;
+
+    /// Set the LS Age in the header. Hold-timer expiry, flushing,
+    /// and refresh all need this.
+    fn set_ls_age(h: &mut Self::LsaHeader, age: u16);
 }
 
 /// OSPFv2 dispatch marker (RFC 2328).
@@ -102,6 +128,19 @@ impl OspfVersion for Ospfv2 {
     type Lsa = OspfLsa;
     const ALL_SPF_ROUTERS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 5);
     const ALL_DROUTERS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 6);
+
+    fn lsa_header(lsa: &OspfLsa) -> &OspfLsaHeader {
+        &lsa.h
+    }
+    fn lsa_header_mut(lsa: &mut OspfLsa) -> &mut OspfLsaHeader {
+        &mut lsa.h
+    }
+    fn ls_age(h: &OspfLsaHeader) -> u16 {
+        h.ls_age
+    }
+    fn set_ls_age(h: &mut OspfLsaHeader, age: u16) {
+        h.ls_age = age;
+    }
 }
 
 /// OSPFv3 dispatch marker (RFC 5340). Distinct from the
@@ -130,4 +169,17 @@ impl OspfVersion for Ospfv3 {
     const ALL_SPF_ROUTERS: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 5);
     /// AllDRouters in v3 (RFC 5340 §A.1): `ff02::6`.
     const ALL_DROUTERS: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 6);
+
+    fn lsa_header(lsa: &Ospfv3Lsa) -> &Ospfv3LsaHeader {
+        &lsa.h
+    }
+    fn lsa_header_mut(lsa: &mut Ospfv3Lsa) -> &mut Ospfv3LsaHeader {
+        &mut lsa.h
+    }
+    fn ls_age(h: &Ospfv3LsaHeader) -> u16 {
+        h.ls_age
+    }
+    fn set_ls_age(h: &mut Ospfv3LsaHeader, age: u16) {
+        h.ls_age = age;
+    }
 }


### PR DESCRIPTION
## Summary

Phase 6 PR 7b (Option A: full generics, **behavioral arc** — first PR that moves method *bodies* from `impl Foo<Ospfv2>` to `impl<V> Foo<V>`).

Add four static-style trait accessor methods to `OspfVersion` and migrate the `Lsdb` / `Lsa` methods that only need those accessors into a generic `impl<V> Lsdb<V>`.

## New trait methods

```rust
fn lsa_header(lsa: &Self::Lsa) -> &Self::LsaHeader;
fn lsa_header_mut(lsa: &mut Self::Lsa) -> &mut Self::LsaHeader;
fn ls_age(h: &Self::LsaHeader) -> u16;
fn set_ls_age(h: &mut Self::LsaHeader, age: u16);
```

Both `Ospfv2` and `Ospfv3` impl these as one-line field accesses — `OspfLsa` / `Ospfv3Lsa` both carry the header as `h`, and both header types expose `ls_age` as a public `u16` with the same RFC 2328 §A.4.1 / RFC 5340 §A.4.2.1 semantics.

## Migrated to `impl<V: OspfVersion>` (generic)

- `Lsa::current_age` — `V::lsa_header` + `V::ls_age`
- `Lsdb::remove_lsa` — key-only, no header access
- `Lsdb::lookup_by_id` → `Option<&V::Lsa>`
- `Lsdb::lookup_lsa` → `Option<&Lsa<V>>`
- `Lsdb::lookup_install_time`
- `Lsdb::flush_lsa` — `V::lsa_header_mut` + `V::set_ls_age`, returns `Option<V::Lsa>`

## Still in `impl Lsdb<Ospfv2>`

- `insert_self_originated` — matches `OspfLsType` enum, calls v2's `OspfLsa::update` for Fletcher checksum
- `insert_received` — calls `update_lsa` which destructures v2-only `OspfLsp` variants
- `update_lsa` — v2-only SR-MPLS / Opaque ExtPrefix ingestion; no v3 analogue yet
- `refresh_lsa` / `refresh_lsa_with_seq` — need `V::ls_seq_number` + `V::update_lsa` trait methods, deferred

## What this proves

The "trait static methods + V::foo(...) dispatch" pattern works for migrating bodies. With 4 small trait methods, we converted 6 method bodies from v2-bound to generic. The remaining behavioral migration is more of the same — add more trait accessors, move more methods.

Method signatures still take v2-shaped key tuples. `OspfLsaKey` (the `(OspfLsType, Ipv4Addr, Ipv4Addr)` tuple) is the next thing to generify; the v3 16-bit LS-Type / 32-bit LS-ID question is open.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p zebra-rs --bins` — 596 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)