### PR TITLE
ospf: trait ls_seq_number + update_lsa, migrate refresh paths

### DIFF
--- a/zebra-rs/src/ospf/lsdb.rs
+++ b/zebra-rs/src/ospf/lsdb.rs
@@ -242,6 +242,63 @@ impl<V: OspfVersion> Lsdb<V> {
         self.lookup_lsa(ls_type, ls_id, adv_router)
             .map(|lsa| lsa.install_time)
     }
+
+    /// Re-originate an existing LSA with a bumped sequence number.
+    /// Drops it back at age 0, runs the version-specific
+    /// `update_lsa` to refresh length / checksum, and resets the
+    /// hold / refresh timers. Now generic.
+    pub fn refresh_lsa(
+        &mut self,
+        ls_type: OspfLsType,
+        ls_id: Ipv4Addr,
+        adv_router: Ipv4Addr,
+        tx: &UnboundedSender<Message>,
+        area_id: Option<Ipv4Addr>,
+    ) {
+        let lsa_key: OspfLsaKey = (ls_type, ls_id, adv_router);
+        if let Some(old_lsa) = self.tables.get(&lsa_key) {
+            let mut new_data = old_lsa.data.clone();
+            let h = V::lsa_header_mut(&mut new_data);
+            V::set_ls_seq_number(h, V::ls_seq_number(h) + 1);
+            V::set_ls_age(h, 0);
+            V::update_lsa(&mut new_data);
+            let mut lsa = Lsa::<V>::new(new_data);
+            lsa.originated = true;
+            lsa.hold_timer = Some(hold_timer(tx, area_id, lsa_key, 0));
+            lsa.refresh_timer = Some(refresh_timer(tx, area_id, lsa_key));
+            self.tables.insert(lsa_key, lsa);
+        }
+    }
+
+    /// Re-originate an existing LSA but only after raising the
+    /// sequence number above `min_seq`. Used when we see a peer
+    /// advertising our LSA with a higher sequence than what we
+    /// have on file (RFC 2328 §13.4 self-originated catch-up).
+    /// Now generic.
+    pub fn refresh_lsa_with_seq(
+        &mut self,
+        ls_type: OspfLsType,
+        ls_id: Ipv4Addr,
+        adv_router: Ipv4Addr,
+        min_seq: u32,
+        tx: &UnboundedSender<Message>,
+        area_id: Option<Ipv4Addr>,
+    ) {
+        let lsa_key: OspfLsaKey = (ls_type, ls_id, adv_router);
+        if let Some(old_lsa) = self.tables.get(&lsa_key) {
+            let mut new_data = old_lsa.data.clone();
+            let h = V::lsa_header_mut(&mut new_data);
+            let next_seq = V::ls_seq_number(h).max(min_seq) + 1;
+            V::set_ls_seq_number(h, next_seq);
+            V::set_ls_age(h, 0);
+            V::update_lsa(&mut new_data);
+            let mut lsa = Lsa::<V>::new(new_data);
+            lsa.originated = true;
+            lsa.hold_timer = Some(hold_timer(tx, area_id, lsa_key, 0));
+            lsa.refresh_timer = Some(refresh_timer(tx, area_id, lsa_key));
+            self.tables.insert(lsa_key, lsa);
+        }
+    }
 }
 
 impl<V: OspfVersion> Default for Lsdb<V> {
@@ -323,52 +380,6 @@ impl Lsdb<Ospfv2> {
             for tlv in lsp.tlvs.iter() {
                 self.reach_map.insert(tlv.prefix, tlv.subs.clone());
             }
-        }
-    }
-
-    pub fn refresh_lsa(
-        &mut self,
-        ls_type: OspfLsType,
-        ls_id: Ipv4Addr,
-        adv_router: Ipv4Addr,
-        tx: &UnboundedSender<Message>,
-        area_id: Option<Ipv4Addr>,
-    ) {
-        let lsa_key: OspfLsaKey = (ls_type, ls_id, adv_router);
-        if let Some(old_lsa) = self.tables.get(&lsa_key) {
-            let mut new_data = old_lsa.data.clone();
-            new_data.h.ls_seq_number += 1;
-            new_data.h.ls_age = 0;
-            new_data.update();
-            let mut lsa = Lsa::<Ospfv2>::new(new_data);
-            lsa.originated = true;
-            lsa.hold_timer = Some(hold_timer(tx, area_id, lsa_key, 0));
-            lsa.refresh_timer = Some(refresh_timer(tx, area_id, lsa_key));
-            self.tables.insert(lsa_key, lsa);
-        }
-    }
-
-    pub fn refresh_lsa_with_seq(
-        &mut self,
-        ls_type: OspfLsType,
-        ls_id: Ipv4Addr,
-        adv_router: Ipv4Addr,
-        min_seq: u32,
-        tx: &UnboundedSender<Message>,
-        area_id: Option<Ipv4Addr>,
-    ) {
-        let lsa_key: OspfLsaKey = (ls_type, ls_id, adv_router);
-        if let Some(old_lsa) = self.tables.get(&lsa_key) {
-            let mut new_data = old_lsa.data.clone();
-            let next_seq = old_lsa.data.h.ls_seq_number.max(min_seq) + 1;
-            new_data.h.ls_seq_number = next_seq;
-            new_data.h.ls_age = 0;
-            new_data.update();
-            let mut lsa = Lsa::<Ospfv2>::new(new_data);
-            lsa.originated = true;
-            lsa.hold_timer = Some(hold_timer(tx, area_id, lsa_key, 0));
-            lsa.refresh_timer = Some(refresh_timer(tx, area_id, lsa_key));
-            self.tables.insert(lsa_key, lsa);
         }
     }
 }

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -112,6 +112,24 @@ pub trait OspfVersion: 'static + Send + Sync + Copy + Clone {
     /// Set the LS Age in the header. Hold-timer expiry, flushing,
     /// and refresh all need this.
     fn set_ls_age(h: &mut Self::LsaHeader, age: u16);
+
+    /// LS Sequence Number. Same field name and 32-bit width in
+    /// both versions (RFC 2328 §A.4.1 / RFC 5340 §A.4.2.1).
+    fn ls_seq_number(h: &Self::LsaHeader) -> u32;
+
+    /// Set the LS Sequence Number. Used when refreshing an LSA or
+    /// reseating one to override a higher sequence number we saw
+    /// on the wire.
+    fn set_ls_seq_number(h: &mut Self::LsaHeader, seq: u32);
+
+    /// Recompute the LSA's length and checksum after the caller
+    /// mutated header fields (`ls_age` / `ls_seq_number`) or the
+    /// body. For v2 this calls `OspfLsa::update` (Fletcher
+    /// checksum per RFC 2328 §A.4.1). For v3 the Fletcher
+    /// implementation hasn't landed yet — the impl is a TODO
+    /// no-op for now, fine since no `Ospf<Ospfv3>` instance is
+    /// running. Tracked as a follow-up in the `ospf-packet` crate.
+    fn update_lsa(lsa: &mut Self::Lsa);
 }
 
 /// OSPFv2 dispatch marker (RFC 2328).
@@ -140,6 +158,15 @@ impl OspfVersion for Ospfv2 {
     }
     fn set_ls_age(h: &mut OspfLsaHeader, age: u16) {
         h.ls_age = age;
+    }
+    fn ls_seq_number(h: &OspfLsaHeader) -> u32 {
+        h.ls_seq_number
+    }
+    fn set_ls_seq_number(h: &mut OspfLsaHeader, seq: u32) {
+        h.ls_seq_number = seq;
+    }
+    fn update_lsa(lsa: &mut OspfLsa) {
+        lsa.update();
     }
 }
 
@@ -181,5 +208,18 @@ impl OspfVersion for Ospfv3 {
     }
     fn set_ls_age(h: &mut Ospfv3LsaHeader, age: u16) {
         h.ls_age = age;
+    }
+    fn ls_seq_number(h: &Ospfv3LsaHeader) -> u32 {
+        h.ls_seq_number
+    }
+    fn set_ls_seq_number(h: &mut Ospfv3LsaHeader, seq: u32) {
+        h.ls_seq_number = seq;
+    }
+    fn update_lsa(_lsa: &mut Ospfv3Lsa) {
+        // TODO: implement Ospfv3Lsa::update() in ospf-packet —
+        // Fletcher checksum + length over §A.4.2.1 layout. Until
+        // that lands, this is a no-op. Safe today because no v3
+        // instance is running, so no caller relies on the updated
+        // fields.
     }
 }


### PR DESCRIPTION
## Summary

Phase 6 PR 7c (Option A: behavioral arc). Add three more `OspfVersion` accessor methods and migrate `Lsdb::refresh_lsa` + `Lsdb::refresh_lsa_with_seq` from `impl Lsdb<Ospfv2>` into the generic `impl<V> Lsdb<V>`.

## New trait methods

```rust
fn ls_seq_number(h: &Self::LsaHeader) -> u32;
fn set_ls_seq_number(h: &mut Self::LsaHeader, seq: u32);
fn update_lsa(lsa: &mut Self::Lsa);
```

- `Ospfv2`: `update_lsa` delegates to `OspfLsa::update` (RFC 2328 §A.4.1 Fletcher checksum + length recompute).
- `Ospfv3`: `update_lsa` is a documented TODO no-op — `Ospfv3Lsa::update` isn't implemented in `ospf-packet` yet (separate small follow-up). Safe today since no `Ospf<Ospfv3>` instance is running.

`ls_seq_number` field has identical 32-bit semantics in both versions per RFC 2328 §A.4.1 and RFC 5340 §A.4.2.1.

## Migrated to `impl<V: OspfVersion> Lsdb<V>`

- `refresh_lsa` — bumps seq by 1, resets age, runs `V::update_lsa` for checksum/length
- `refresh_lsa_with_seq` — bumps seq above `min_seq` (RFC 2328 §13.4 self-originated catch-up)

## Still v2-bound

- `insert_self_originated` — `OspfLsType` enum-match filter for originatable types; v3 needs its own type filter
- `insert_received` — calls `update_lsa` (the Lsdb method, not the trait method) for v2-specific SR-MPLS / Opaque ingestion
- `update_lsa` (Lsdb method) — destructures `OspfLsp` variants for SR-MPLS label map / extended-prefix reach map

The remaining v2-only methods are the ones that genuinely touch v2-specific LSA body shapes. They'll stay v2-only or get separate v3 impls when the v3 instance materializes.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p zebra-rs --bins` — 596 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)