### PR TITLE
ospf: migrate Ospf::ospf_interface / ifname / count helper to generic

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -102,12 +102,18 @@ pub struct OspfInterface<'a, V: OspfVersion = Ospfv2> {
     pub tracing: &'a OspfTracing,
 }
 
-impl Ospf<Ospfv2> {
+// Version-agnostic helpers. These methods touch only generic-safe
+// fields on `Ospf<V>` (links, areas, lsdb_as, router_id, tracing,
+// the v2-shaped tx channel) and produce `OspfInterface<V>` /
+// `&Neighbor<V>` values typed by `V`. They moved here from
+// `impl Ospf<Ospfv2>` as part of the Phase 6 behavioral migration
+// — same code, just no longer pinned to `Ospfv2`.
+impl<V: OspfVersion> Ospf<V> {
     pub fn ospf_interface<'a>(
         &'a mut self,
         ifindex: u32,
         src: &Ipv4Addr,
-    ) -> Option<(OspfInterface<'a>, &'a mut Neighbor)> {
+    ) -> Option<(OspfInterface<'a, V>, &'a mut Neighbor<V>)> {
         // Compute area-wide exchange/loading count before borrowing mutably.
         let exchange_loading_count = self.count_exchange_loading_neighbors(ifindex);
         self.links.get_mut(&ifindex).and_then(|link| {
@@ -167,7 +173,9 @@ impl Ospf<Ospfv2> {
             .get(&ifindex)
             .map_or_else(|| "unknown".to_string(), |link| link.name.clone())
     }
+}
 
+impl Ospf<Ospfv2> {
     pub fn new(ctx: crate::context::ProtoContext, rib_rx: UnboundedReceiver<RibRx>) -> Self {
         let sock = Arc::new(AsyncFd::new(ospf_socket_ipv4(&ctx).unwrap()).unwrap());
 


### PR DESCRIPTION
## Summary

Phase 6 PR 7d (Option A: behavioral arc). Move three v2-bound `Ospf` helpers into a new `impl<V: OspfVersion> Ospf<V>` block. They access only generic-safe fields (`links`, `areas`, `lsdb_as`, `router_id`, `tracing`) and produce generic-typed values (`OspfInterface<V>`, `&Neighbor<V>`).

## Migrated

- `ospf_interface` — constructs `OspfInterface<V>` + `&mut Neighbor<V>`
- `count_exchange_loading_neighbors` — pure iteration on links/nbrs
- `ifname` — link.name lookup

No trait additions; no callsite changes; same code, just no longer pinned to `Ospfv2` via the `impl Ospf<Ospfv2>` block.

## Note on Message

The `tx` channel inside `OspfInterface` stays `UnboundedSender<Message>` where `Message` is the v2-shaped enum — that's a separate parameterization (and a much larger one) deferred to its own PR. For now `Ospf<Ospfv3>` would inherit the v2 `Message` type via the concrete struct field, which is harmless until something actually constructs `Ospf<Ospfv3>`.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p zebra-rs --bins` — 596 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)