### PR TITLE
ospf: parameterize Message<V> + thread it through tx/ptx fields

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -56,9 +56,9 @@ pub type ShowCallback = fn(&Ospf, Args, bool) -> Result<String, std::fmt::Error>
 /// `OspfVersion` trait grows accessor methods, in a future round
 /// of trait expansion.
 pub struct Ospf<V: OspfVersion = Ospfv2> {
-    pub tx: UnboundedSender<Message>,
-    pub rx: UnboundedReceiver<Message>,
-    pub ptx: UnboundedSender<Message>,
+    pub tx: UnboundedSender<Message<V>>,
+    pub rx: UnboundedReceiver<Message<V>>,
+    pub ptx: UnboundedSender<Message<V>>,
     pub cm: ConfigChannel,
     pub callbacks: HashMap<String, Callback>,
     pub ctx: crate::context::ProtoContext,
@@ -86,7 +86,7 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
 // into v3-shaped state (Identity<V>, Lsdb<V>, Vec<OspfAddr<V>>).
 // Default V = Ospfv2 keeps function signatures unchanged at callsites.
 pub struct OspfInterface<'a, V: OspfVersion = Ospfv2> {
-    pub tx: &'a UnboundedSender<Message>,
+    pub tx: &'a UnboundedSender<Message<V>>,
     pub router_id: &'a Ipv4Addr,
     pub ident: &'a Identity<V>,
     pub addr: &'a Vec<OspfAddr<V>>,
@@ -1371,21 +1371,42 @@ pub fn serve(mut ospf: Ospf) -> Task<()> {
     })
 }
 
-pub enum Message {
+/// Internal control / data messages threaded through the OSPF
+/// instance's main mpsc channel.
+///
+/// Parameterized over `V: OspfVersion` (default `Ospfv2`) so the
+/// variants carrying wire-shaped data (`Recv` / `Send` /
+/// `Flood` / `FloodAs` / `DelayedAckQueue`) specialize on the
+/// per-version packet, LSA, and address types. The remaining 13
+/// variants don't carry version-specific data — they're agnostic
+/// in shape even though they live on a `Message<V>` enum.
+///
+/// Default `V = Ospfv2` keeps every existing v2 callsite — both
+/// pattern matches and `Message::Foo(...)` constructions —
+/// resolving transparently to `Message<Ospfv2>`.
+pub enum Message<V: OspfVersion = Ospfv2> {
     Enable(u32, Ipv4Addr),
     Disable(u32, Ipv4Addr),
     Ifsm(u32, IfsmEvent),
     Nfsm(u32, Ipv4Addr, NfsmEvent),
     HelloTimer(u32),
-    Recv(Ospfv2Packet, Ipv4Addr, Ipv4Addr, u32, Ipv4Addr),
-    Send(Ospfv2Packet, u32, Option<Ipv4Addr>),
+    /// Packet received off the wire. v2 carries
+    /// `(Ospfv2Packet, src_addr, dst_group, ifindex, ifaddr)` where
+    /// every address is `Ipv4Addr`; v3 will use `Ipv6Addr` for
+    /// src/dst/ifaddr per its raw IPv6 socket layer.
+    Recv(V::Packet, V::Addr, V::Addr, u32, V::Addr),
+    /// Packet to send. v2 carries
+    /// `(Ospfv2Packet, ifindex, Option<Ipv4Addr>)` — the optional
+    /// destination is the multicast group or unicast nbr address.
+    /// v3 uses `V::Addr = Ipv6Addr` accordingly.
+    Send(V::Packet, u32, Option<V::Addr>),
     Lsdb(LsdbEvent, Option<Ipv4Addr>, OspfLsaKey),
     /// Flood LSA through area, excluding source neighbor.
     /// (area_id, lsa, source_ifindex, source_nbr_addr)
-    Flood(Ipv4Addr, OspfLsa, u32, Ipv4Addr),
+    Flood(Ipv4Addr, V::Lsa, u32, V::Addr),
     /// Flood AS-scoped LSA through all normal areas, excluding source neighbor.
     /// (lsa, source_ifindex, source_nbr_addr)
-    FloodAs(OspfLsa, u32, Ipv4Addr),
+    FloodAs(V::Lsa, u32, V::Addr),
     /// Retransmit LSAs to a specific neighbor.
     /// (ifindex, nbr_addr)
     Retransmit(u32, Ipv4Addr),
@@ -1400,7 +1421,7 @@ pub enum Message {
     DelayedAck(u32),
     /// Queue delayed ack headers on an interface.
     /// (ifindex, headers)
-    DelayedAckQueue(u32, Vec<OspfLsaHeader>),
+    DelayedAckQueue(u32, Vec<V::LsaHeader>),
     /// Request SPF scheduling for an area.
     SpfSchedule(Option<Ipv4Addr>),
     /// Timer-fired: perform SPF calculation for an area.

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -103,7 +103,7 @@ pub struct OspfLink<V: OspfVersion = Ospfv2> {
     pub ostate: IfsmState,
     pub sock: Arc<AsyncFd<Socket>>,
     pub ident: Identity<V>,
-    pub tx: UnboundedSender<Message>,
+    pub tx: UnboundedSender<Message<V>>,
     pub nbrs: BTreeMap<Ipv4Addr, Neighbor<V>>,
     pub flags: OspfLinkFlags,
     pub link_flags: LinkFlags,
@@ -114,7 +114,7 @@ pub struct OspfLink<V: OspfVersion = Ospfv2> {
     pub state_change: usize,
     pub db_desc_in: usize,
     pub full_nbr_count: usize,
-    pub ptx: UnboundedSender<Message>,
+    pub ptx: UnboundedSender<Message<V>>,
     pub config: LinkConfig,
     pub ls_ack_delayed: Vec<V::LsaHeader>,
 }
@@ -132,11 +132,11 @@ where
     V::Prefix: Default,
 {
     pub fn from(
-        tx: UnboundedSender<Message>,
+        tx: UnboundedSender<Message<V>>,
         link: Link,
         sock: Arc<AsyncFd<Socket>>,
         router_id: Ipv4Addr,
-        ptx: UnboundedSender<Message>,
+        ptx: UnboundedSender<Message<V>>,
     ) -> Self {
         Self {
             index: link.index,

--- a/zebra-rs/src/ospf/lsdb.rs
+++ b/zebra-rs/src/ospf/lsdb.rs
@@ -104,8 +104,8 @@ impl<V: OspfVersion> Lsa<V> {
     }
 }
 
-fn lsdb_timer(
-    tx: &UnboundedSender<Message>,
+fn lsdb_timer<V: OspfVersion>(
+    tx: &UnboundedSender<Message<V>>,
     area_id: Option<Ipv4Addr>,
     key: OspfLsaKey,
     secs: u64,
@@ -114,15 +114,15 @@ fn lsdb_timer(
     let tx = tx.clone();
     Timer::new(Duration::from_secs(secs), TimerType::Once, move || {
         let tx = tx.clone();
-        let msg = Message::Lsdb(ev, area_id, key);
+        let msg = Message::<V>::Lsdb(ev, area_id, key);
         async move {
             let _ = tx.send(msg);
         }
     })
 }
 
-fn hold_timer(
-    tx: &UnboundedSender<Message>,
+fn hold_timer<V: OspfVersion>(
+    tx: &UnboundedSender<Message<V>>,
     area_id: Option<Ipv4Addr>,
     key: OspfLsaKey,
     ls_age: u16,
@@ -131,8 +131,8 @@ fn hold_timer(
     lsdb_timer(tx, area_id, key, remaining, LsdbEvent::HoldTimerExpire)
 }
 
-fn refresh_timer(
-    tx: &UnboundedSender<Message>,
+fn refresh_timer<V: OspfVersion>(
+    tx: &UnboundedSender<Message<V>>,
     area_id: Option<Ipv4Addr>,
     key: OspfLsaKey,
 ) -> Timer {
@@ -192,7 +192,7 @@ impl<V: OspfVersion> Lsdb<V> {
         ls_type: OspfLsType,
         ls_id: Ipv4Addr,
         adv_router: Ipv4Addr,
-        tx: &UnboundedSender<Message>,
+        tx: &UnboundedSender<Message<V>>,
         area_id: Option<Ipv4Addr>,
     ) -> Option<V::Lsa> {
         let lsa_key: OspfLsaKey = (ls_type, ls_id, adv_router);
@@ -252,7 +252,7 @@ impl<V: OspfVersion> Lsdb<V> {
         ls_type: OspfLsType,
         ls_id: Ipv4Addr,
         adv_router: Ipv4Addr,
-        tx: &UnboundedSender<Message>,
+        tx: &UnboundedSender<Message<V>>,
         area_id: Option<Ipv4Addr>,
     ) {
         let lsa_key: OspfLsaKey = (ls_type, ls_id, adv_router);
@@ -281,7 +281,7 @@ impl<V: OspfVersion> Lsdb<V> {
         ls_id: Ipv4Addr,
         adv_router: Ipv4Addr,
         min_seq: u32,
-        tx: &UnboundedSender<Message>,
+        tx: &UnboundedSender<Message<V>>,
         area_id: Option<Ipv4Addr>,
     ) {
         let lsa_key: OspfLsaKey = (ls_type, ls_id, adv_router);
@@ -311,7 +311,7 @@ impl Lsdb<Ospfv2> {
     pub fn insert_self_originated(
         &mut self,
         mut ospf_lsa: OspfLsa,
-        tx: &UnboundedSender<Message>,
+        tx: &UnboundedSender<Message<Ospfv2>>,
         area_id: Option<Ipv4Addr>,
     ) {
         use OspfLsType::*;
@@ -334,7 +334,7 @@ impl Lsdb<Ospfv2> {
     pub fn insert_received(
         &mut self,
         ospf_lsa: OspfLsa,
-        tx: &UnboundedSender<Message>,
+        tx: &UnboundedSender<Message<Ospfv2>>,
         area_id: Option<Ipv4Addr>,
     ) {
         let ls_type = ospf_lsa.h.ls_type;

--- a/zebra-rs/src/ospf/neigh.rs
+++ b/zebra-rs/src/ospf/neigh.rs
@@ -44,10 +44,10 @@ pub struct Neighbor<V: OspfVersion = Ospfv2> {
     pub timer: NeighborTimer,
     pub options: OspfOptions,
     pub flags: NeighborFlags,
-    pub tx: UnboundedSender<Message>,
+    pub tx: UnboundedSender<Message<V>>,
     pub state_change: usize,
     pub dd: NeighborDbDesc<V>,
-    pub ptx: UnboundedSender<Message>,
+    pub ptx: UnboundedSender<Message<V>>,
     pub db_sum: Vec<V::LsaHeader>,
     pub ls_req: Vec<OspfLsRequestEntry>,
     pub ls_req_last: Option<OspfLsRequest>,
@@ -117,12 +117,12 @@ where
     V::DbDesc: Default,
 {
     pub fn new(
-        tx: UnboundedSender<Message>,
+        tx: UnboundedSender<Message<V>>,
         ifindex: u32,
         prefix: V::Prefix,
         router_id: &Ipv4Addr,
         _dead_interval: u64,
-        ptx: UnboundedSender<Message>,
+        ptx: UnboundedSender<Message<V>>,
     ) -> Self {
         let mut nbr = Self {
             ifindex,
@@ -160,7 +160,7 @@ impl<V: OspfVersion> Neighbor<V> {
         false
     }
 
-    pub fn event(&self, ev: Message) {
+    pub fn event(&self, ev: Message<V>) {
         self.tx.send(ev).unwrap();
     }
 }

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -37,7 +37,11 @@ pub trait OspfVersion: 'static + Send + Sync + Copy + Clone {
     /// `Ipv4Addr` for v2, `Ipv6Addr` for v3. Router-id and area-id
     /// stay 32-bit in both versions and live separately as `Ipv4Addr`
     /// even on v3 (RFC 5340 §A.3.1).
-    type Addr: Copy + Eq + Ord + Hash + Display + Debug + 'static;
+    //
+    // `Send + Sync` because `Message<V>` carries `V::Addr` and is
+    // sent across tokio's mpsc channels; both `Ipv4Addr` and
+    // `Ipv6Addr` are trivially Send + Sync.
+    type Addr: Copy + Eq + Ord + Hash + Display + Debug + Send + Sync + 'static;
 
     /// Prefix (network + length) type. `Ipv4Net` for v2, `Ipv6Net`
     /// for v3. Both are `ipnet::*Net` types so they share `Copy`,


### PR DESCRIPTION
## Summary

Phase 6 PR 7e (Option A: behavioral arc). Make the internal control / data `Message` enum generic over `V: OspfVersion`. Default `V = Ospfv2` keeps every existing v2 callsite resolving unchanged.

## Version-specific variants

| Variant | Generic types |
|---|---|
| `Recv` | `V::Packet`, `V::Addr` × 3 |
| `Send` | `V::Packet`, `Option<V::Addr>` |
| `Flood` | `V::Lsa`, `V::Addr` |
| `FloodAs` | `V::Lsa`, `V::Addr` |
| `DelayedAckQueue` | `Vec<V::LsaHeader>` |

The remaining 13 variants don't carry version-specific data (ifindex, area-ids, `NfsmEvent`, `IfsmEvent`, `OspfLsaKey` — still v2-shaped per PR 7a's note — retransmit triggers). They live on `Message<V>` but have identical shape across versions.

## Field types updated to propagate V

- `Ospf<V>::tx/rx/ptx` — `Message<V>`
- `OspfInterface<'a, V>::tx` — `&Message<V>`
- `OspfLink<V>::tx/ptx` — `Message<V>`
- `Neighbor<V>::tx/ptx` — `Message<V>`
- `Neighbor::event(ev: Message<V>)`

## lsdb.rs helpers generified

`lsdb_timer` / `hold_timer` / `refresh_timer` become `<V: OspfVersion>` free functions taking `&UnboundedSender<Message<V>>`. `Lsdb<V>`'s generic methods (`flush_lsa`, `refresh_lsa`, `refresh_lsa_with_seq`) now correctly thread V through their tx param. The two v2-only `Lsdb` methods (`insert_self_originated`, `insert_received`) keep `Message<Ospfv2>` explicitly.

## Trait bound addition

`OspfVersion::Addr` gained `Send + Sync` bounds — required since `Message<V>` carries `V::Addr` through tokio's mpsc Send-bounded channels. Both `Ipv4Addr` and `Ipv6Addr` satisfy them trivially.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p zebra-rs --bins` — 596 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)