### PR TITLE
ospf: Lsa<V> wrapper accessors + show.rs migration to trait

### DIFF
--- a/zebra-rs/src/ospf/lsdb.rs
+++ b/zebra-rs/src/ospf/lsdb.rs
@@ -90,17 +90,63 @@ impl<V: OspfVersion> Lsa<V> {
         }
     }
 
+    /// Borrow the LSA header. Convenience over `V::lsa_header(&lsa.data)`.
+    pub fn header(&self) -> &V::LsaHeader {
+        V::lsa_header(&self.data)
+    }
+
     /// Compute the current LSA age: original ls_age plus elapsed
-    /// time since install, capped at MaxAge. Now generic — reads
-    /// the header via `V::lsa_header` and `V::ls_age`, which both
-    /// `Ospfv2` and `Ospfv3` impl identically (the field has the
-    /// same semantics in RFC 2328 §A.4.1 and RFC 5340 §A.4.2.1).
+    /// time since install, capped at MaxAge.
     pub fn current_age(&self) -> u16 {
-        let header = V::lsa_header(&self.data);
-        let initial_age = V::ls_age(header);
+        let initial_age = V::ls_age(self.header());
         let elapsed = self.birth_time.elapsed().as_secs() as u16;
         let age = initial_age.saturating_add(elapsed);
         age.min(OSPF_MAX_AGE)
+    }
+
+    /// True when the LSA's `ls_age` field has reached MaxAge —
+    /// the canonical signal that an LSA is being flushed.
+    #[allow(dead_code)]
+    pub fn is_max_age(&self) -> bool {
+        V::ls_age(self.header()) == OSPF_MAX_AGE
+    }
+
+    // The remaining wrappers below delegate to the matching
+    // OspfVersion trait accessors. They give consumers a uniform
+    // `lsa.foo()` method-call surface instead of `V::foo(&lsa.data)`,
+    // which is easier on the eye for show / display code that
+    // needs several fields at once.
+
+    /// LS Type as a 16-bit value. See [`OspfVersion::ls_type`].
+    #[allow(dead_code)]
+    pub fn ls_type(&self) -> u16 {
+        V::ls_type(self.header())
+    }
+
+    /// Link State ID as a 32-bit value. See [`OspfVersion::ls_id`].
+    #[allow(dead_code)]
+    pub fn ls_id(&self) -> u32 {
+        V::ls_id(self.header())
+    }
+
+    /// Advertising Router. See [`OspfVersion::adv_router`].
+    pub fn adv_router(&self) -> Ipv4Addr {
+        V::adv_router(self.header())
+    }
+
+    /// LS Sequence Number. See [`OspfVersion::ls_seq_number`].
+    pub fn ls_seq_number(&self) -> u32 {
+        V::ls_seq_number(self.header())
+    }
+
+    /// LSA checksum. See [`OspfVersion::ls_checksum`].
+    pub fn ls_checksum(&self) -> u16 {
+        V::ls_checksum(self.header())
+    }
+
+    /// LSA total length in octets. See [`OspfVersion::length`].
+    pub fn length(&self) -> u16 {
+        V::length(self.header())
     }
 }
 

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -317,7 +317,7 @@ fn render_link(out: &mut String, oi: &OspfLink, ospf: &Ospf) {
         writeln!(
             out,
             "  Saved Network-LSA sequence number 0x{:08x}",
-            lsa.data.h.ls_seq_number
+            lsa.ls_seq_number()
         )
         .unwrap();
     }
@@ -872,8 +872,8 @@ fn show_ospf_database(
                     link_id: lsa_id.to_string(),
                     adv_router: adv_router.to_string(),
                     age: lsa.current_age(),
-                    seq_number: format!("0x{:08x}", lsa.data.h.ls_seq_number),
-                    checksum: format!("0x{:04x}", lsa.data.h.ls_checksum),
+                    seq_number: format!("0x{:08x}", lsa.ls_seq_number()),
+                    checksum: format!("0x{:04x}", lsa.ls_checksum()),
                     link_count,
                 });
             }
@@ -883,8 +883,8 @@ fn show_ospf_database(
                     link_id: lsa_id.to_string(),
                     adv_router: adv_router.to_string(),
                     age: lsa.current_age(),
-                    seq_number: format!("0x{:08x}", lsa.data.h.ls_seq_number),
-                    checksum: format!("0x{:04x}", lsa.data.h.ls_checksum),
+                    seq_number: format!("0x{:08x}", lsa.ls_seq_number()),
+                    checksum: format!("0x{:04x}", lsa.ls_checksum()),
                     link_count: None,
                 });
             }
@@ -894,8 +894,8 @@ fn show_ospf_database(
                     link_id: lsa_id.to_string(),
                     adv_router: adv_router.to_string(),
                     age: lsa.current_age(),
-                    seq_number: format!("0x{:08x}", lsa.data.h.ls_seq_number),
-                    checksum: format!("0x{:04x}", lsa.data.h.ls_checksum),
+                    seq_number: format!("0x{:08x}", lsa.ls_seq_number()),
+                    checksum: format!("0x{:04x}", lsa.ls_checksum()),
                     link_count: None,
                 });
             }
@@ -946,8 +946,8 @@ fn show_ospf_database(
                 lsa_id,
                 adv_router,
                 lsa.current_age(),
-                lsa.data.h.ls_seq_number,
-                lsa.data.h.ls_checksum,
+                lsa.ls_seq_number(),
+                lsa.ls_checksum(),
                 lsp.links.len(),
             );
         }
@@ -968,8 +968,8 @@ fn show_ospf_database(
                 lsa_id,
                 adv_router,
                 lsa.current_age(),
-                lsa.data.h.ls_seq_number,
-                lsa.data.h.ls_checksum,
+                lsa.ls_seq_number(),
+                lsa.ls_checksum(),
             );
         }
 
@@ -993,8 +993,8 @@ fn show_ospf_database(
                     lsa_id,
                     adv_router,
                     lsa.current_age(),
-                    lsa.data.h.ls_seq_number,
-                    lsa.data.h.ls_checksum,
+                    lsa.ls_seq_number(),
+                    lsa.ls_checksum(),
                 );
             }
         }
@@ -1047,10 +1047,10 @@ fn show_ospf_database_detail(
                     ls_age: lsa.current_age(),
                     options: format_options_flags(&opts),
                     link_state_id: lsa.data.h.ls_id.to_string(),
-                    advertising_router: lsa.data.h.adv_router.to_string(),
-                    ls_seq_number: format!("0x{:08x}", lsa.data.h.ls_seq_number),
-                    checksum: format!("0x{:04x}", lsa.data.h.ls_checksum),
-                    length: lsa.data.h.length,
+                    advertising_router: lsa.adv_router().to_string(),
+                    ls_seq_number: format!("0x{:08x}", lsa.ls_seq_number()),
+                    checksum: format!("0x{:04x}", lsa.ls_checksum()),
+                    length: lsa.length(),
                     num_links: lsp.links.len(),
                     links,
                 });
@@ -1067,10 +1067,10 @@ fn show_ospf_database_detail(
                     ls_age: lsa.current_age(),
                     options: format_options_flags(&opts),
                     link_state_id: lsa.data.h.ls_id.to_string(),
-                    advertising_router: lsa.data.h.adv_router.to_string(),
-                    ls_seq_number: format!("0x{:08x}", lsa.data.h.ls_seq_number),
-                    checksum: format!("0x{:04x}", lsa.data.h.ls_checksum),
-                    length: lsa.data.h.length,
+                    advertising_router: lsa.adv_router().to_string(),
+                    ls_seq_number: format!("0x{:08x}", lsa.ls_seq_number()),
+                    checksum: format!("0x{:04x}", lsa.ls_checksum()),
+                    length: lsa.length(),
                     network_mask: format!("/{}", u32::from(lsp.netmask).leading_ones()),
                     attached_routers,
                 });
@@ -1115,9 +1115,9 @@ fn show_ospf_database_detail(
             writeln!(out, "  LS Type: Router Links")?;
             writeln!(out, "  Link State ID: {}", lsa_id)?;
             writeln!(out, "  Advertising Router: {}", adv_router)?;
-            writeln!(out, "  LS Seq Number: 0x{:08x}", lsa.data.h.ls_seq_number)?;
-            writeln!(out, "  Checksum: 0x{:04x}", lsa.data.h.ls_checksum)?;
-            writeln!(out, "  Length: {}", lsa.data.h.length)?;
+            writeln!(out, "  LS Seq Number: 0x{:08x}", lsa.ls_seq_number())?;
+            writeln!(out, "  Checksum: 0x{:04x}", lsa.ls_checksum())?;
+            writeln!(out, "  Length: {}", lsa.length())?;
 
             let OspfLsp::Router(ref lsp) = lsa.data.lsp else {
                 continue;
@@ -1193,9 +1193,9 @@ fn show_ospf_database_detail(
                 lsa_id
             )?;
             writeln!(out, "  Advertising Router: {}", adv_router)?;
-            writeln!(out, "  LS Seq Number: 0x{:08x}", lsa.data.h.ls_seq_number)?;
-            writeln!(out, "  Checksum: 0x{:04x}", lsa.data.h.ls_checksum)?;
-            writeln!(out, "  Length: {}", lsa.data.h.length)?;
+            writeln!(out, "  LS Seq Number: 0x{:08x}", lsa.ls_seq_number())?;
+            writeln!(out, "  Checksum: 0x{:04x}", lsa.ls_checksum())?;
+            writeln!(out, "  Length: {}", lsa.length())?;
 
             let OspfLsp::Network(ref lsp) = lsa.data.lsp else {
                 continue;
@@ -1252,11 +1252,11 @@ fn show_ospf_database_detail(
                 writeln!(out, "  Opaque-Type {} ({})", opaque_type, opaque_type_name)?;
                 writeln!(out, "  Opaque-ID   0x{:x}", opaque_id)?;
                 writeln!(out, "  Advertising Router: {}", adv_router)?;
-                writeln!(out, "  LS Seq Number: 0x{:08x}", lsa.data.h.ls_seq_number)?;
-                writeln!(out, "  Checksum: 0x{:04x}", lsa.data.h.ls_checksum)?;
-                writeln!(out, "  Length: {}", lsa.data.h.length)?;
+                writeln!(out, "  LS Seq Number: 0x{:08x}", lsa.ls_seq_number())?;
+                writeln!(out, "  Checksum: 0x{:04x}", lsa.ls_checksum())?;
+                writeln!(out, "  Length: {}", lsa.length())?;
 
-                let payload_len = lsa.data.h.length.saturating_sub(20);
+                let payload_len = lsa.length().saturating_sub(20);
                 writeln!(out, "  Opaque-Info: {} octets of data", payload_len)?;
 
                 match &lsa.data.lsp {
@@ -1586,7 +1586,7 @@ fn show_ospf_segment_routing(
             let algo_str = lsdb
                 .values_by_type(OspfLsType::OpaqueAreaLocal)
                 .find_map(|lsa| {
-                    if lsa.data.h.adv_router == *router_id
+                    if lsa.adv_router() == *router_id
                         && let OspfLsp::OpaqueAreaRouterInfo(ref ri) = lsa.data.lsp
                     {
                         return Some(format_algo_list(ri));
@@ -1626,7 +1626,7 @@ fn show_ospf_segment_routing(
 
             // Find Extended Prefix LSAs from this router.
             for (_, lsa) in lsdb.iter_by_type(OspfLsType::OpaqueAreaLocal) {
-                if lsa.data.h.adv_router != *router_id {
+                if lsa.adv_router() != *router_id {
                     continue;
                 }
                 if let OspfLsp::OpaqueAreaExtPrefix(ref ep) = lsa.data.lsp {

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -135,19 +135,19 @@ pub trait OspfVersion: 'static + Send + Sync + Copy + Clone {
     /// running. Tracked as a follow-up in the `ospf-packet` crate.
     fn update_lsa(lsa: &mut Self::Lsa);
 
-    // The five read-only header accessors below are part of the
-    // trait surface that subsequent behavioral-migration PRs will
-    // consume (rewriting v2-bound flooding / show / packet code
-    // to read header fields via V::foo(...) instead of direct
-    // field access). The `dead_code` allow attribute on the trait
-    // declarations themselves silences "associated function never
-    // used" until the first consumer in PR 7g.
+    // The five read-only header accessors below — `ls_type`,
+    // `ls_id`, `adv_router`, `ls_checksum`, `length` — are
+    // consumed by the matching wrapper methods on `Lsa<V>` in
+    // `lsdb.rs` (PR 7g), which in turn back the JSON-format
+    // database show paths in `show.rs`. `ls_type` and `ls_id`
+    // have wrappers but no callers yet — those land as more
+    // show / flooding / packet code migrates off direct
+    // `lsa.data.h.foo` access.
 
     /// LS Type as a 16-bit value. v2's `OspfLsType` is u8-sized so
     /// it widens cleanly; v3's `ls_type` is natively u16 per
     /// RFC 5340 §A.4.2.1 (U/S2/S1/function-code packing). u16 is
     /// the lower-common-denominator that fits both.
-    #[allow(dead_code)]
     fn ls_type(h: &Self::LsaHeader) -> u16;
 
     /// Link State ID as a 32-bit value. v2 carries it as
@@ -155,24 +155,20 @@ pub trait OspfVersion: 'static + Send + Sync + Copy + Clone {
     /// IP, sometimes a network address depending on the LSA type);
     /// v3 (§A.4.2.1) carries an opaque 32-bit identifier. u32
     /// covers both.
-    #[allow(dead_code)]
     fn ls_id(h: &Self::LsaHeader) -> u32;
 
     /// Advertising Router. 32-bit router-id in both versions
     /// (RFC 2328 §A.4.1 / RFC 5340 §A.4.2.1 keep it as a 4-octet
     /// router-id; v3 §A.3.1 says router-ids stay 32-bit even on
     /// v3).
-    #[allow(dead_code)]
     fn adv_router(h: &Self::LsaHeader) -> Ipv4Addr;
 
     /// LSA checksum field (Fletcher in both versions per their
     /// respective §A.4).
-    #[allow(dead_code)]
     fn ls_checksum(h: &Self::LsaHeader) -> u16;
 
     /// Length of the full LSA (header + body) in octets. Header
     /// itself is 20 octets in both versions.
-    #[allow(dead_code)]
     fn length(h: &Self::LsaHeader) -> u16;
 }
 


### PR DESCRIPTION
## Summary

Phase 6 PR 7g (Option A: behavioral arc, first consumer of PR 7f's accessors). Add 8 wrapper accessor methods on `Lsa<V>` that delegate to the `OspfVersion` trait, and migrate show.rs's JSON / detail-output LSA-render code from direct field access (`lsa.data.h.foo`) to method calls (`lsa.foo()`).

## New methods on `Lsa<V>`

```rust
fn header(&self) -> &V::LsaHeader      // shortcut for V::lsa_header
fn current_age(&self) -> u16           // already existed
fn is_max_age(&self) -> bool           // new convenience
fn ls_type(&self) -> u16
fn ls_id(&self) -> u32
fn adv_router(&self) -> Ipv4Addr
fn ls_seq_number(&self) -> u32
fn ls_checksum(&self) -> u16
fn length(&self) -> u16
```

These give consumers a uniform `lsa.foo()` surface instead of `V::foo(&lsa.data)` — easier on the eye for code reading several header fields in a row.

## Consumers migrated

- `show.rs`: every `lsa.data.h.{ls_seq_number, ls_checksum, adv_router, length}` access switched to the wrapper call. Bijective swap — types unchanged.

## Two accessors stay un-migrated for now

- **`ls_type`** — v2 prints as `OspfLsType` debug ("Router"), v3 would print as u16 ("8193"). Different display format.
- **`ls_id`** — v2 prints as `Ipv4Addr` ("10.0.0.1"), v3 as u32.

Their `Lsa<V>` wrappers exist and consume the trait accessors (silencing PR 7f's dead_code warning at the trait level) but they're marked `#[allow(dead_code)]` at the wrapper level until a future PR adds a version-aware display helper. `is_max_age` is similarly unused-but-present.

## Cleanup

Removes `#[allow(dead_code)]` from the 5 trait method declarations added in PR 7f.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p zebra-rs --bins` — 596 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)