### PR TITLE
ospf: widen OspfLsaKey to (u16, u32, Ipv4Addr)

### DIFF
--- a/zebra-rs/src/ospf/flood.rs
+++ b/zebra-rs/src/ospf/flood.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use ospf_packet::*;
 
 use super::inst::Message;
-use super::lsdb::{LsdbEvent, OSPF_MIN_LS_ARRIVAL, OspfLsaKey};
+use super::lsdb::{LsdbEvent, OSPF_MIN_LS_ARRIVAL, OspfLsaKey, v2_lsa_key};
 use super::task::{Timer, TimerType};
 use super::{Neighbor, NfsmState, inst::OspfInterface, nfsm::ospf_nfsm_check_nbr_loading};
 
@@ -90,7 +90,7 @@ pub fn ospf_is_self_originated(oi: &OspfInterface, lsa: &OspfLsa) -> bool {
 /// The actual re-origination or flush is handled by the Ospf instance
 /// via the message channel, since it needs access to the full router state.
 pub fn ospf_flood_self_originated_lsa(oi: &OspfInterface, lsa: &OspfLsa) {
-    let key = (lsa.h.ls_type, lsa.h.ls_id, lsa.h.adv_router);
+    let key = v2_lsa_key(lsa.h.ls_type, lsa.h.ls_id, lsa.h.adv_router);
     let msg = Message::Lsdb(LsdbEvent::SelfOriginatedReceived, Some(oi.area_id), key);
     let _ = oi.tx.send(msg);
 }
@@ -181,7 +181,7 @@ pub fn ospf_retransmit_timer(nbr: &Neighbor, retransmit_interval: u16) -> Timer 
 }
 
 pub fn ospf_ls_retransmit_add(nbr: &mut Neighbor, lsa: &OspfLsa, retransmit_interval: u16) {
-    let key: OspfLsaKey = (lsa.h.ls_type, lsa.h.ls_id, lsa.h.adv_router);
+    let key: OspfLsaKey = v2_lsa_key(lsa.h.ls_type, lsa.h.ls_id, lsa.h.adv_router);
     nbr.ls_rxmt.insert(key, lsa.clone());
     if nbr.timer.ls_rxmt.is_none() {
         nbr.timer.ls_rxmt = Some(ospf_retransmit_timer(nbr, retransmit_interval));
@@ -189,7 +189,7 @@ pub fn ospf_ls_retransmit_add(nbr: &mut Neighbor, lsa: &OspfLsa, retransmit_inte
 }
 
 pub fn ospf_ls_retransmit_delete(nbr: &mut Neighbor, lsa: &OspfLsa) {
-    let key: OspfLsaKey = (lsa.h.ls_type, lsa.h.ls_id, lsa.h.adv_router);
+    let key: OspfLsaKey = v2_lsa_key(lsa.h.ls_type, lsa.h.ls_id, lsa.h.adv_router);
     nbr.ls_rxmt.remove(&key);
     if nbr.ls_rxmt.is_empty() {
         nbr.timer.ls_rxmt = None;
@@ -197,6 +197,6 @@ pub fn ospf_ls_retransmit_delete(nbr: &mut Neighbor, lsa: &OspfLsa) {
 }
 
 pub fn ospf_ls_retransmit_lookup<'a>(nbr: &'a Neighbor, lsa: &OspfLsa) -> Option<&'a OspfLsa> {
-    let key: OspfLsaKey = (lsa.h.ls_type, lsa.h.ls_id, lsa.h.adv_router);
+    let key: OspfLsaKey = v2_lsa_key(lsa.h.ls_type, lsa.h.ls_id, lsa.h.adv_router);
     nbr.ls_rxmt.get(&key)
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -30,7 +30,7 @@ use super::area::{OspfArea, OspfAreaMap};
 use super::config::Callback;
 use super::ifsm::{IfsmEvent, IfsmState, ospf_ifsm};
 use super::link::{OspfLink, OspfNetworkType};
-use super::lsdb::{LsdbEvent, OspfLsaKey};
+use super::lsdb::{LsdbEvent, OspfLsaKey, v2_lsa_key_unpack};
 use super::network::{read_packet, write_packet};
 use super::nfsm::{NfsmEvent, ospf_nfsm};
 use super::socket::ospf_socket_ipv4;
@@ -449,7 +449,9 @@ impl Ospf<Ospfv2> {
     }
 
     fn process_lsdb(&mut self, ev: LsdbEvent, area_id: Option<Ipv4Addr>, key: OspfLsaKey) {
-        let (ls_type, ls_id, adv_router) = key;
+        // Unpack the widened key back into v2-typed components for the
+        // v2-bound match arms / method calls below.
+        let (ls_type, ls_id, adv_router) = v2_lsa_key_unpack(key);
 
         // Handle SelfOriginatedReceived before borrowing lsdb, since
         // re-origination needs full &mut self access.

--- a/zebra-rs/src/ospf/lsdb.rs
+++ b/zebra-rs/src/ospf/lsdb.rs
@@ -33,11 +33,35 @@ pub type LsTable<V = Ospfv2> = BTreeMap<OspfLsaKey, Lsa<V>>;
 
 /// LSDB key: `(LS-Type, LS-ID, Advertising-Router)`.
 ///
-/// Still v2-shaped — uses `OspfLsType` (v2's u8 enum). v3 LS-Types
-/// are 16-bit numeric per RFC 5340 §A.4.2.1; a unified key (or a
-/// `V::LsType` associated type) lands when the v3 LSDB consumer
-/// materializes.
-pub type OspfLsaKey = (OspfLsType, Ipv4Addr, Ipv4Addr);
+/// Widened from `(OspfLsType, Ipv4Addr, Ipv4Addr)` to a flat
+/// `(u16, u32, Ipv4Addr)` shape so v3 LS-Types (16-bit per
+/// RFC 5340 §A.4.2.1) and v3 Link State IDs (32-bit opaque
+/// values, not always IPs) fit alongside v2's smaller types.
+/// v2 callers convert their `OspfLsType` enum to `u16` via the
+/// existing `u8::from(ls_type)` impl, and their `Ipv4Addr`
+/// `ls_id` to `u32` via `u32::from`; the reverse conversions
+/// (`OspfLsType::from(x as u8)`, `Ipv4Addr::from(x)`) are used
+/// where the original v2-typed value is wanted back.
+pub type OspfLsaKey = (u16, u32, Ipv4Addr);
+
+/// Construct an `OspfLsaKey` from v2-typed components — `OspfLsType`
+/// widens to `u16` (via the existing `u8::from(ls_type)` impl) and
+/// `Ipv4Addr` widens to `u32`. Convenience for the v2-bound code
+/// paths that already speak the v2 types and just need a key for
+/// LSDB / channel use.
+pub fn v2_lsa_key(ls_type: OspfLsType, ls_id: Ipv4Addr, adv_router: Ipv4Addr) -> OspfLsaKey {
+    (u8::from(ls_type) as u16, u32::from(ls_id), adv_router)
+}
+
+/// Destructure an `OspfLsaKey` back into v2-typed components.
+/// Inverse of [`v2_lsa_key`]; `OspfLsType::from(u8)` round-trips
+/// from u16, and `Ipv4Addr::from(u32)` from u32. The reverse
+/// conversion is safe for v2-shaped keys; on v3-shaped keys the
+/// `OspfLsType::from(... as u8)` truncates the upper byte and
+/// returns the `Unknown` variant for codepoints that don't fit v2.
+pub fn v2_lsa_key_unpack(key: OspfLsaKey) -> (OspfLsType, Ipv4Addr, Ipv4Addr) {
+    (OspfLsType::from(key.0 as u8), Ipv4Addr::from(key.1), key.2)
+}
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum LsdbEvent {
@@ -208,25 +232,27 @@ impl<V: OspfVersion> Lsdb<V> {
         &self,
         ls_type: OspfLsType,
     ) -> impl Iterator<Item = ((Ipv4Addr, Ipv4Addr), &Lsa<V>)> {
+        let want: u16 = u8::from(ls_type) as u16;
         self.tables
             .iter()
-            .filter(move |((t, _, _), _)| *t == ls_type)
-            .map(|((_, id, adv), lsa)| ((*id, *adv), lsa))
+            .filter(move |((t, _, _), _)| *t == want)
+            .map(|((_, id, adv), lsa)| ((Ipv4Addr::from(*id), *adv), lsa))
     }
 
     /// Iterate just the LSA values of a particular LS-Type. Convenience
     /// over `iter_by_type` for callers that don't need the key.
     pub fn values_by_type(&self, ls_type: OspfLsType) -> impl Iterator<Item = &Lsa<V>> {
+        let want: u16 = u8::from(ls_type) as u16;
         self.tables
             .iter()
-            .filter(move |((t, _, _), _)| *t == ls_type)
+            .filter(move |((t, _, _), _)| *t == want)
             .map(|(_, lsa)| lsa)
     }
 
     /// Drop the LSA at the given key. Key-only operation — no
     /// header field access, so trivially generic.
     pub fn remove_lsa(&mut self, ls_type: OspfLsType, ls_id: Ipv4Addr, adv_router: Ipv4Addr) {
-        self.tables.remove(&(ls_type, ls_id, adv_router));
+        self.tables.remove(&v2_lsa_key(ls_type, ls_id, adv_router));
     }
 
     /// Flush an LSA by setting its age to MaxAge and returning a
@@ -241,7 +267,7 @@ impl<V: OspfVersion> Lsdb<V> {
         tx: &UnboundedSender<Message<V>>,
         area_id: Option<Ipv4Addr>,
     ) -> Option<V::Lsa> {
-        let lsa_key: OspfLsaKey = (ls_type, ls_id, adv_router);
+        let lsa_key: OspfLsaKey = v2_lsa_key(ls_type, ls_id, adv_router);
         if let Some(lsa) = self.tables.get_mut(&lsa_key) {
             V::set_ls_age(V::lsa_header_mut(&mut lsa.data), OSPF_MAX_AGE);
             lsa.birth_time = tokio::time::Instant::now();
@@ -262,7 +288,7 @@ impl<V: OspfVersion> Lsdb<V> {
         adv_router: Ipv4Addr,
     ) -> Option<&V::Lsa> {
         self.tables
-            .get(&(ls_type, ls_id, adv_router))
+            .get(&v2_lsa_key(ls_type, ls_id, adv_router))
             .map(|lsa| &lsa.data)
     }
 
@@ -274,7 +300,7 @@ impl<V: OspfVersion> Lsdb<V> {
         ls_id: Ipv4Addr,
         adv_router: Ipv4Addr,
     ) -> Option<&Lsa<V>> {
-        self.tables.get(&(ls_type, ls_id, adv_router))
+        self.tables.get(&v2_lsa_key(ls_type, ls_id, adv_router))
     }
 
     /// Return the install timestamp of an LSA, if present. Now
@@ -301,7 +327,7 @@ impl<V: OspfVersion> Lsdb<V> {
         tx: &UnboundedSender<Message<V>>,
         area_id: Option<Ipv4Addr>,
     ) {
-        let lsa_key: OspfLsaKey = (ls_type, ls_id, adv_router);
+        let lsa_key: OspfLsaKey = v2_lsa_key(ls_type, ls_id, adv_router);
         if let Some(old_lsa) = self.tables.get(&lsa_key) {
             let mut new_data = old_lsa.data.clone();
             let h = V::lsa_header_mut(&mut new_data);
@@ -330,7 +356,7 @@ impl<V: OspfVersion> Lsdb<V> {
         tx: &UnboundedSender<Message<V>>,
         area_id: Option<Ipv4Addr>,
     ) {
-        let lsa_key: OspfLsaKey = (ls_type, ls_id, adv_router);
+        let lsa_key: OspfLsaKey = v2_lsa_key(ls_type, ls_id, adv_router);
         if let Some(old_lsa) = self.tables.get(&lsa_key) {
             let mut new_data = old_lsa.data.clone();
             let h = V::lsa_header_mut(&mut new_data);
@@ -366,7 +392,8 @@ impl Lsdb<Ospfv2> {
             Router | Network | Summary | SummaryAsbr | AsExternal | NssaAsExternal
             | OpaqueAreaLocal => {
                 ospf_lsa.update();
-                let lsa_key: OspfLsaKey = (ls_type, ospf_lsa.h.ls_id, ospf_lsa.h.adv_router);
+                let lsa_key: OspfLsaKey =
+                    v2_lsa_key(ls_type, ospf_lsa.h.ls_id, ospf_lsa.h.adv_router);
                 let mut lsa = Lsa::<Ospfv2>::new(ospf_lsa);
                 lsa.originated = true;
                 lsa.hold_timer = Some(hold_timer(tx, area_id, lsa_key, lsa.data.h.ls_age));
@@ -384,7 +411,7 @@ impl Lsdb<Ospfv2> {
         area_id: Option<Ipv4Addr>,
     ) {
         let ls_type = ospf_lsa.h.ls_type;
-        let lsa_key: OspfLsaKey = (ls_type, ospf_lsa.h.ls_id, ospf_lsa.h.adv_router);
+        let lsa_key: OspfLsaKey = v2_lsa_key(ls_type, ospf_lsa.h.ls_id, ospf_lsa.h.adv_router);
 
         self.update_lsa(&ospf_lsa);
 

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -821,7 +821,7 @@ pub fn ospf_ls_ack_recv(
 
     // Remove acknowledged LSAs from retransmit list.
     for lsah in ls_ack.lsa_headers.iter() {
-        let key = (lsah.ls_type, lsah.ls_id, lsah.adv_router);
+        let key = super::lsdb::v2_lsa_key(lsah.ls_type, lsah.ls_id, lsah.adv_router);
         if let Some(rxmt_lsa) = nbr.ls_rxmt.get(&key)
             && rxmt_lsa.h.ls_seq_number == lsah.ls_seq_number
             && rxmt_lsa.h.ls_checksum == lsah.ls_checksum


### PR DESCRIPTION
## Summary

Phase 6 PR 7h (Option A: behavioral arc). Widen the LSDB key tuple from v2-shaped `(OspfLsType, Ipv4Addr, Ipv4Addr)` to `(u16, u32, Ipv4Addr)` so v3 LS-Types (16-bit per RFC 5340 §A.4.2.1) and v3 Link State IDs (32-bit opaque values, not always IPs) fit alongside v2's smaller types.

## Two new helpers in lsdb.rs

```rust
v2_lsa_key(OspfLsType, Ipv4Addr, Ipv4Addr) -> OspfLsaKey
v2_lsa_key_unpack(OspfLsaKey) -> (OspfLsType, Ipv4Addr, Ipv4Addr)
```

Bridge v2-bound code that still speaks v2 types to the widened key shape. `OspfLsType: From<u8>` already exists for the round-trip back.

## Call-site touches

- **lsdb.rs** — 5 key constructions (insert / flush / refresh / refresh-with-seq) routed through `v2_lsa_key`. `iter_by_type` / `values_by_type` widen the filter comparison and map the u32 LS-ID back to `Ipv4Addr` at the boundary so callers destructure unchanged.
- **flood.rs** — 4 key constructions in retransmit / self-origination flood paths.
- **packet.rs** — 1 key construction in LS-Ack handler.
- **inst.rs** — 1 destructure in `process_lsdb` routed through `v2_lsa_key_unpack` so downstream match arms / method calls keep operating on v2 types.

## What changes / what doesn't

- **Functional behavior unchanged.** BTreeMap ordering shifts slightly (numeric u16 vs `OspfLsType` custom Ord), but the Ord-derived ordering for v2 LS-Type discriminants matches the numeric ordering of their u8 representations, so lookups behave identically.
- **Unlocks** future PRs that migrate flood.rs / packet.rs / nfsm methods to be generic over V — they can now construct LSDB keys without committing to v2's enum shape.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p zebra-rs --bins` — 596 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)