### PR TITLE
ospf-packet: implement Ospfv3Lsa::update Fletcher checksum + length

### DIFF
--- a/crates/ospf-packet/src/parser.rs
+++ b/crates/ospf-packet/src/parser.rs
@@ -451,7 +451,12 @@ impl OspfLsa {
 
 /// Calculate LSA checksum according to RFC 2328 using Fletcher algorithm.
 /// The checksum is calculated over the data with the checksum field at `cksum_offset`.
-fn lsa_checksum_calc(data: &[u8], cksum_offset: usize) -> u16 {
+///
+/// Shared between `OspfLsa::update` (RFC 2328 §A.4.1) and
+/// `Ospfv3Lsa::update` (RFC 5340 §A.4.2). The two versions have the
+/// same checksum-field placement at LSA-offset 16 / data-offset 14,
+/// so the algorithm and offset are identical.
+pub(crate) fn lsa_checksum_calc(data: &[u8], cksum_offset: usize) -> u16 {
     if data.len() <= cksum_offset {
         return 0;
     }

--- a/crates/ospf-packet/src/v3.rs
+++ b/crates/ospf-packet/src/v3.rs
@@ -1388,6 +1388,34 @@ impl Ospfv3Lsa {
         self.h.emit(buf);
         self.body.emit(buf);
     }
+
+    /// Recompute `length` and `ls_checksum` after the caller
+    /// mutated header fields (`ls_age` / `ls_seq_number`) or the
+    /// body — for instance during LSA refresh or flush.
+    ///
+    /// Per RFC 5340 §A.4.2.1 the v3 LSA header is the same 20
+    /// octets as v2's (§A.4.1) with LS Checksum at offset 16 and
+    /// Length at offset 18. The Fletcher checksum (RFC 905 Annex
+    /// B / RFC 1008) is computed over the whole LSA **except**
+    /// the LS Age field, with the checksum field included as
+    /// zero. Both versions share the same checksum offset, so
+    /// the calculator is reused from the v2 codec.
+    pub fn update(&mut self) {
+        // 1) Length = 20-octet header + serialized body length.
+        let mut body_buf = BytesMut::new();
+        self.body.emit(&mut body_buf);
+        self.h.length = (OSPFV3_LSA_HEADER_LEN as usize + body_buf.len()) as u16;
+
+        // 2) Zero the checksum field, emit the header, append the
+        //    body, and run Fletcher over (LSA[2..]) — skipping the
+        //    LS Age. The checksum field's position within the
+        //    Fletcher data is 14 (16 in LSA - 2 for skipped age).
+        self.h.ls_checksum = 0;
+        let mut buf = BytesMut::with_capacity(self.h.length as usize);
+        self.h.emit(&mut buf);
+        buf.extend_from_slice(&body_buf);
+        self.h.ls_checksum = super::parser::lsa_checksum_calc(&buf[2..], 14);
+    }
 }
 
 impl ParseBe<Ospfv3Lsa> for Ospfv3Lsa {
@@ -1765,6 +1793,48 @@ mod tests {
             &buf[OSPFV3_CHECKSUM_OFFSET + 2..],
             &buf2[OSPFV3_CHECKSUM_OFFSET + 2..]
         );
+    }
+
+    /// `Ospfv3Lsa::update` recomputes `length` to match the
+    /// serialized body and stamps a non-zero Fletcher `ls_checksum`.
+    /// Mutating any header or body field and re-running `update`
+    /// produces a different checksum; mutating without running
+    /// `update` is a no-op (the field stays at whatever the
+    /// caller left it).
+    #[test]
+    fn ospfv3_lsa_update_recomputes_length_and_checksum() {
+        let body = make_router_lsa();
+        let mut lsa = Ospfv3Lsa {
+            h: Ospfv3LsaHeader {
+                ls_age: 0,
+                ls_type: OSPFV3_ROUTER_LSA_TYPE,
+                link_state_id: 0,
+                advertising_router: Ipv4Addr::new(10, 0, 0, 1),
+                ls_seq_number: 0x8000_0001,
+                ls_checksum: 0,
+                length: 0,
+            },
+            body: Ospfv3LsBody::Router(body),
+        };
+
+        lsa.update();
+
+        // Length matches serialized form (20 octets header + body).
+        let mut buf = BytesMut::new();
+        lsa.emit(&mut buf);
+        assert_eq!(lsa.h.length as usize, buf.len());
+
+        // Checksum is non-zero (Fletcher on a non-trivial body
+        // can technically come out to any 16-bit value, but for
+        // the make_router_lsa fixture it isn't 0).
+        assert_ne!(lsa.h.ls_checksum, 0);
+        let checksum_first = lsa.h.ls_checksum;
+
+        // Bumping the sequence number and re-running `update`
+        // changes the checksum.
+        lsa.h.ls_seq_number += 1;
+        lsa.update();
+        assert_ne!(lsa.h.ls_checksum, checksum_first);
     }
 
     /// Empty LSU (zero LSAs) still emits the 4-byte count and parses

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -281,12 +281,8 @@ impl OspfVersion for Ospfv3 {
     fn set_ls_seq_number(h: &mut Ospfv3LsaHeader, seq: u32) {
         h.ls_seq_number = seq;
     }
-    fn update_lsa(_lsa: &mut Ospfv3Lsa) {
-        // TODO: implement Ospfv3Lsa::update() in ospf-packet —
-        // Fletcher checksum + length over §A.4.2.1 layout. Until
-        // that lands, this is a no-op. Safe today because no v3
-        // instance is running, so no caller relies on the updated
-        // fields.
+    fn update_lsa(lsa: &mut Ospfv3Lsa) {
+        lsa.update();
     }
     #[allow(dead_code)]
     fn ls_type(h: &Ospfv3LsaHeader) -> u16 {


### PR DESCRIPTION
## Summary

Phase 6 PR 7i — **first real v3 protocol work** after 14 PRs of cascade refactoring. Implement RFC 5340 §A.4.2 Fletcher checksum + length recompute on `Ospfv3Lsa`, mirroring v2's `OspfLsa::update`.

The v3 LSA header layout (RFC 5340 §A.4.2.1) is identical in size and checksum-field placement to v2's (RFC 2328 §A.4.1): 20-octet header, LS Checksum at offset 16, Length at offset 18. Both versions use the Fletcher algorithm (RFC 905 Annex B / RFC 1008) over the LSA except the LS Age field. Result: the v2 `lsa_checksum_calc` helper applies unchanged for v3; just need to expose it `pub(crate)` and feed it the v3-shaped LSA bytes.

## Changes

- **parser.rs** — `lsa_checksum_calc` gains `pub(crate)` visibility plus a docstring noting the v2/v3 sharing.
- **v3.rs** — `Ospfv3Lsa::update` emits the body, recomputes `length`, zeros the checksum field, runs Fletcher over `LSA[2..]` with `checksum_offset=14`.
- **version.rs** — `Ospfv3::update_lsa` trait impl drops the TODO no-op and calls `lsa.update()`.

## Test

New test `ospfv3_lsa_update_recomputes_length_and_checksum` verifies:
- `length` matches the serialized LSA size
- checksum is non-zero for a non-trivial LSA
- bumping `ls_seq_number` and re-running `update` changes the checksum

## Why this matters

Unblocks the cascade's `refresh_lsa` / `refresh_lsa_with_seq` path for v3 — previously `V::update_lsa` for `Ospfv3` was a no-op, so generic `Lsdb::refresh_lsa` would emit stale-length / zero-checksum v3 LSAs. With this PR, v3 LSAs flow through the generic refresh path correctly.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p ospf-packet --lib v3` — new test passes
- [x] `cargo test -p zebra-rs --bins` — 596 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)