### PR TITLE
ospf: V::nbr_addr trait + generic flood.rs retransmit helpers

### DIFF
--- a/zebra-rs/src/ospf/flood.rs
+++ b/zebra-rs/src/ospf/flood.rs
@@ -5,6 +5,7 @@ use ospf_packet::*;
 use super::inst::Message;
 use super::lsdb::{LsdbEvent, OSPF_MIN_LS_ARRIVAL, OspfLsaKey, v2_lsa_key};
 use super::task::{Timer, TimerType};
+use super::version::OspfVersion;
 use super::{Neighbor, NfsmState, inst::OspfInterface, nfsm::ospf_nfsm_check_nbr_loading};
 
 #[derive(Debug, PartialEq)]
@@ -164,10 +165,18 @@ pub fn ospf_flood(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) {
 
 // Retransmit list functions.
 
-pub fn ospf_retransmit_timer(nbr: &Neighbor, retransmit_interval: u16) -> Timer {
+/// Construct an LSDB key from a `V::Lsa` via the trait header
+/// accessors. Used by the retransmit-list helpers below; v2
+/// callers get the same key shape `v2_lsa_key` produces.
+fn lsa_to_key<V: OspfVersion>(lsa: &V::Lsa) -> OspfLsaKey {
+    let h = V::lsa_header(lsa);
+    (V::ls_type(h), V::ls_id(h), V::adv_router(h))
+}
+
+pub fn ospf_retransmit_timer<V: OspfVersion>(nbr: &Neighbor<V>, retransmit_interval: u16) -> Timer {
     let tx = nbr.tx.clone();
     let ifindex = nbr.ifindex;
-    let addr = nbr.ident.prefix.addr();
+    let addr = V::nbr_addr(&nbr.ident);
     Timer::new(
         Timer::second(retransmit_interval as u64),
         TimerType::Once,
@@ -180,23 +189,30 @@ pub fn ospf_retransmit_timer(nbr: &Neighbor, retransmit_interval: u16) -> Timer 
     )
 }
 
-pub fn ospf_ls_retransmit_add(nbr: &mut Neighbor, lsa: &OspfLsa, retransmit_interval: u16) {
-    let key: OspfLsaKey = v2_lsa_key(lsa.h.ls_type, lsa.h.ls_id, lsa.h.adv_router);
+pub fn ospf_ls_retransmit_add<V: OspfVersion>(
+    nbr: &mut Neighbor<V>,
+    lsa: &V::Lsa,
+    retransmit_interval: u16,
+) {
+    let key: OspfLsaKey = lsa_to_key::<V>(lsa);
     nbr.ls_rxmt.insert(key, lsa.clone());
     if nbr.timer.ls_rxmt.is_none() {
         nbr.timer.ls_rxmt = Some(ospf_retransmit_timer(nbr, retransmit_interval));
     }
 }
 
-pub fn ospf_ls_retransmit_delete(nbr: &mut Neighbor, lsa: &OspfLsa) {
-    let key: OspfLsaKey = v2_lsa_key(lsa.h.ls_type, lsa.h.ls_id, lsa.h.adv_router);
+pub fn ospf_ls_retransmit_delete<V: OspfVersion>(nbr: &mut Neighbor<V>, lsa: &V::Lsa) {
+    let key: OspfLsaKey = lsa_to_key::<V>(lsa);
     nbr.ls_rxmt.remove(&key);
     if nbr.ls_rxmt.is_empty() {
         nbr.timer.ls_rxmt = None;
     }
 }
 
-pub fn ospf_ls_retransmit_lookup<'a>(nbr: &'a Neighbor, lsa: &OspfLsa) -> Option<&'a OspfLsa> {
-    let key: OspfLsaKey = v2_lsa_key(lsa.h.ls_type, lsa.h.ls_id, lsa.h.adv_router);
+pub fn ospf_ls_retransmit_lookup<'a, V: OspfVersion>(
+    nbr: &'a Neighbor<V>,
+    lsa: &V::Lsa,
+) -> Option<&'a V::Lsa> {
+    let key: OspfLsaKey = lsa_to_key::<V>(lsa);
     nbr.ls_rxmt.get(&key)
 }

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -170,6 +170,22 @@ pub trait OspfVersion: 'static + Send + Sync + Copy + Clone {
     /// Length of the full LSA (header + body) in octets. Header
     /// itself is 20 octets in both versions.
     fn length(h: &Self::LsaHeader) -> u16;
+
+    /// Address by which a neighbor is uniquely identified on the
+    /// local router, projected to a 32-bit value for storage in
+    /// the v2-shaped `Message::Retransmit` / `Nfsm` channel
+    /// variants (those carry an `Ipv4Addr` regardless of V).
+    ///
+    /// - v2 (RFC 2328 §10): the neighbor's interface IP, i.e.
+    ///   `ident.prefix.addr()`.
+    /// - v3 (RFC 5340 §10): the neighbor's router-id, i.e.
+    ///   `ident.router_id`. v3 keys neighbor identity by
+    ///   router-id since multiple v6 link-local sources can share
+    ///   a router and v3 link-local addresses aren't suitable as
+    ///   stable identifiers.
+    fn nbr_addr(ident: &crate::ospf::Identity<Self>) -> Ipv4Addr
+    where
+        Self: Sized;
 }
 
 /// OSPFv2 dispatch marker (RFC 2328).
@@ -233,6 +249,9 @@ impl OspfVersion for Ospfv2 {
     #[allow(dead_code)]
     fn length(h: &OspfLsaHeader) -> u16 {
         h.length
+    }
+    fn nbr_addr(ident: &crate::ospf::Identity<Ospfv2>) -> Ipv4Addr {
+        ident.prefix.addr()
     }
 }
 
@@ -303,5 +322,8 @@ impl OspfVersion for Ospfv3 {
     #[allow(dead_code)]
     fn length(h: &Ospfv3LsaHeader) -> u16 {
         h.length
+    }
+    fn nbr_addr(ident: &crate::ospf::Identity<Ospfv3>) -> Ipv4Addr {
+        ident.router_id
     }
 }


### PR DESCRIPTION
## Summary

Phase 6 PR 7k (behavioral arc). Add the `nbr_addr` trait method to `OspfVersion` so generic protocol code can extract the 32-bit neighbor identifier from `Identity<V>` — v2 uses the interface IP (`ident.prefix.addr()`), v3 uses the router-id (`ident.router_id`, per RFC 5340 §10's switch to router-id-based neighbor identity).

## Migrated to `<V: OspfVersion>`

- `ospf_retransmit_timer(nbr: &Neighbor<V>, ri) -> Timer`
- `ospf_ls_retransmit_add(nbr: &mut Neighbor<V>, lsa: &V::Lsa, ri)`
- `ospf_ls_retransmit_delete(nbr: &mut Neighbor<V>, lsa: &V::Lsa)`
- `ospf_ls_retransmit_lookup(nbr: &Neighbor<V>, lsa: &V::Lsa) -> Option<&V::Lsa>`

Plus a small `lsa_to_key<V>(&V::Lsa) -> OspfLsaKey` helper that mirrors `v2_lsa_key` but works for any V via `V::lsa_header` + the existing header accessors.

## Message shape unchanged

`Message::Retransmit` keeps its `(u32, Ipv4Addr)` shape across both versions — v2 passes interface-IP, v3 passes router-id, both projected to the same `Ipv4Addr` storage. The semantic interpretation diverges but the channel wire shape doesn't.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p zebra-rs --bins` — 596 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)