### PR TITLE
ospf: add interface_id state to OspfLink<V> and Neighbor<V>

### DIFF
--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -117,6 +117,12 @@ pub struct OspfLink<V: OspfVersion = Ospfv2> {
     pub ptx: UnboundedSender<Message<V>>,
     pub config: LinkConfig,
     pub ls_ack_delayed: Vec<V::LsaHeader>,
+    /// 32-bit Interface ID advertised in v3 Hellos and Router-LSA
+    /// links (RFC 5340 §A.3.2 / §A.4.3). Unused by v2 (where the
+    /// equivalent role is filled by the interface IP). Defaulted
+    /// to 0; the v3 interface-enable path sets it.
+    #[allow(dead_code)]
+    pub interface_id: u32,
 }
 
 #[derive(Default)]
@@ -164,6 +170,7 @@ where
             ptx,
             config: LinkConfig::default(),
             ls_ack_delayed: Vec::new(),
+            interface_id: 0,
         }
     }
 }

--- a/zebra-rs/src/ospf/neigh.rs
+++ b/zebra-rs/src/ospf/neigh.rs
@@ -56,6 +56,13 @@ pub struct Neighbor<V: OspfVersion = Ospfv2> {
     pub last_progressive: Option<Instant>,
     pub last_regressive: Option<Instant>,
     pub last_regressive_reason: Option<NfsmEvent>,
+    /// 32-bit Interface ID this neighbor reported in its last
+    /// Hello (RFC 5340 §A.3.2). Used by the v3 Router-LSA builder
+    /// as the `neighbor_interface_id` field of TransitNetwork /
+    /// PointToPoint / VirtualLink records (§A.4.3). Unused by v2;
+    /// defaulted to 0.
+    #[allow(dead_code)]
+    pub interface_id: u32,
 }
 
 #[bitfield(u8, debug = true)]
@@ -144,6 +151,7 @@ where
             last_progressive: None,
             last_regressive: None,
             last_regressive_reason: None,
+            interface_id: 0,
         };
         nbr.ident.prefix = prefix;
         nbr


### PR DESCRIPTION
## Summary

Phase 6 PR 7o — foundation for the v3 self-origination Router-LSA builder. Add a `pub interface_id: u32` field to both `OspfLink<V>` and `Neighbor<V>` so v3 protocol code can carry the 32-bit Interface ID that RFC 5340 §A.3.2 introduces alongside the IPv4 ifindex (which becomes purely a kernel handle in v3).

| Field | Role |
|---|---|
| `OspfLink<V>::interface_id` | This router's Interface ID for this link, advertised in our v3 Hellos and used as the `interface_id` field of self-originated Router-LSA links (§A.4.3). |
| `Neighbor<V>::interface_id` | The neighbor's Interface ID from its last received Hello. Used as `neighbor_interface_id` in our Router-LSA links. |

Both fields default to 0. v2 ignores them (v2's Router-LSA links carry the interface IP / netmask instead). v3's interface-enable path (separate follow-up PR) populates them.

`#[allow(dead_code)]` on the fields since no consumer reads them yet — removed when the v3 Router-LSA builder lands.

## Why now

With these two fields in place, the next PR can implement the real v3 `router_lsa_originate` against the typed link constructors from PR 7n: walk `Ospf<Ospfv3>::links` and each link's `nbrs`, emit one `Ospfv3RouterLsaLink` per full-state adjacency.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p zebra-rs --bins` — 596 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)