### PR TITLE
ospf: add Ospf<Ospfv3>::build_router_lsa (first v3 protocol builder)

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -36,7 +36,7 @@ use super::nfsm::{NfsmEvent, ospf_nfsm};
 use super::socket::ospf_socket_ipv4;
 use super::task::{Timer, TimerType};
 use super::tracing::OspfTracing;
-use super::version::OspfVersion;
+use super::version::{OspfVersion, Ospfv3};
 use super::{
     AREA0, Identity, Lsdb, Neighbor, NfsmState, ospf_ls_ack_recv, ospf_ls_req_recv,
     ospf_ls_upd_recv,
@@ -1364,6 +1364,84 @@ impl Ospf<Ospfv2> {
                 }
             }
         }
+    }
+}
+
+/// v3-specific methods on the parameterized `Ospf` instance.
+///
+/// First piece of v3 protocol logic that walks `Ospf<Ospfv3>`
+/// state and produces a wire LSA. Currently dead code -- no caller
+/// constructs `Ospf<Ospfv3>` yet (that lands when the v3
+/// instance's `new()` is written). The method exists so the
+/// builder can be reviewed and tested ahead of the spawn wiring.
+#[allow(dead_code)]
+impl Ospf<Ospfv3> {
+    /// Build the Router-LSA for self-origination (RFC 5340 §A.4.3).
+    ///
+    /// Walks every enabled `OspfLink<Ospfv3>` and emits one
+    /// `Ospfv3RouterLsaLink` per qualifying adjacency:
+    ///
+    ///   - Broadcast network with a full-state DR adjacency
+    ///     -> TransitNetwork link naming the DR's interface_id +
+    ///     router-id (per §A.4.3 the "neighbor" fields on Transit
+    ///     links point at the DR, not at every adjacent peer).
+    ///
+    /// PointToPoint and VirtualLink emission lands when the
+    /// matching `OspfNetworkType` variants surface in zebra-rs
+    /// (currently the enum has only Broadcast and NBMA; v3 needs
+    /// PointToPoint as a network type for Router-LSA link type 1
+    /// to be emittable).
+    ///
+    /// Returns an `Ospfv3Lsa` with checksum + length stamped via
+    /// `Ospfv3Lsa::update` (PR 7i). Ready to install through
+    /// `Lsdb::install_originated` (PR 7j).
+    pub fn build_router_lsa(&self) -> ospf_packet::Ospfv3Lsa {
+        use ospf_packet::{
+            OSPFV3_ROUTER_LSA_FLAG_E, OSPFV3_ROUTER_LSA_TYPE, Ospfv3LsBody, Ospfv3Lsa,
+            Ospfv3LsaHeader, Ospfv3Options, Ospfv3RouterLsa, Ospfv3RouterLsaLink,
+        };
+
+        let mut links = Vec::new();
+        for link in self.links.values() {
+            if !link.enabled {
+                continue;
+            }
+            let cost = link.output_cost as u16;
+            let my_iid = link.interface_id;
+
+            if matches!(link.network_type, OspfNetworkType::Broadcast) {
+                let dr_router_id = link.ident.d_router;
+                if dr_router_id == Ipv4Addr::UNSPECIFIED {
+                    continue;
+                }
+                if let Some(dr_nbr) = link.nbrs.get(&dr_router_id)
+                    && dr_nbr.state == NfsmState::Full
+                {
+                    links.push(Ospfv3RouterLsaLink::transit_network(
+                        cost,
+                        my_iid,
+                        dr_nbr.interface_id,
+                        dr_router_id,
+                    ));
+                }
+            }
+        }
+
+        let body = Ospfv3RouterLsa::new(OSPFV3_ROUTER_LSA_FLAG_E, Ospfv3Options::default(), links);
+        let mut lsa = Ospfv3Lsa {
+            h: Ospfv3LsaHeader {
+                ls_age: 0,
+                ls_type: OSPFV3_ROUTER_LSA_TYPE,
+                link_state_id: 0,
+                advertising_router: self.router_id,
+                ls_seq_number: 0x8000_0001,
+                ls_checksum: 0,
+                length: 0,
+            },
+            body: Ospfv3LsBody::Router(body),
+        };
+        lsa.update();
+        lsa
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 6 PR 7p — **first piece of v3 protocol code that walks `Ospf<V>` state to produce a wire LSA.** Builds the Router-LSA for self-origination per RFC 5340 §A.4.3 by iterating every enabled `OspfLink<Ospfv3>` and emitting one `Ospfv3RouterLsaLink` per qualifying adjacency.

## Logic

```
For each enabled link:
  if network_type is Broadcast:
    look up the DR neighbor by link.ident.d_router (router-id)
    if that neighbor is in Full state, emit a TransitNetwork
      link naming the DR's interface_id + router-id.
```

PointToPoint / VirtualLink emission waits for the matching `OspfNetworkType` variants to land in zebra-rs (currently only Broadcast and NBMA). A v3 router that reaches Broadcast adjacencies starts emitting a useful Router-LSA from this PR.

Wrap in `Ospfv3Lsa` with header (`ls_type = 0x2001`, `ls_id = 0`, initial seq# `0x80000001`), call `.update()` to stamp Fletcher checksum + length (PR 7i). Return ready for `Lsdb::install_originated` (PR 7j).

## Glues together the v3 pieces from across the cascade

| | |
|---|---|
| `V::nbr_addr` (PR 7k) | related plumbing |
| `OspfLink<V>::interface_id` + `Neighbor<V>::interface_id` (PR 7o) | source of link IDs |
| `Ospfv3RouterLsaLink::transit_network` (PR 7n) | typed link constructor |
| `Ospfv3RouterLsa::new` (PR 7n) | body constructor |
| `Ospfv3Lsa::update` Fletcher (PR 7i) | checksum stamp |
| `Lsdb::install_originated` (PR 7j) | install target |

## Status

`#[allow(dead_code)]` on the impl block because nothing constructs `Ospf<Ospfv3>` yet — the next PR(s) will write the v3 `new()` and main-spawn paths, at which point this method becomes the heart of `router_lsa_originate` for v3.

## Test plan

- [x] `cargo build -p zebra-rs` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p zebra-rs --bins` — 596 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)