### PR TITLE
bgp: reactively propagate neighbor-group remote-as changes

### DIFF
--- a/zebra-rs/src/bgp/interface_neighbor.rs
+++ b/zebra-rs/src/bgp/interface_neighbor.rs
@@ -50,13 +50,35 @@ pub struct InterfaceNeighborCfg {
     pub remote_as: RemoteAsSpec,
 }
 
-/// Look up the resolved remote AS for an interface-neighbor against
-/// its referenced neighbor-group fallback.
-pub fn resolve_remote_as(bgp: &Bgp, cfg: &InterfaceNeighborCfg) -> Option<u32> {
+/// Resolved remote-as for an interface-neighbor plus a hint about
+/// where the value came from. The provenance bit lets
+/// [`materialize_peer`] stamp the inheritance flag on the synthesized
+/// peer so the reactive sweep in
+/// [`super::neighbor_group::config_neighbor_group_remote_as`] picks
+/// it up later.
+struct ResolvedRemoteAs {
+    asn: u32,
+    inherited_from_group: bool,
+}
+
+/// Resolve the interface-neighbor's remote-as with provenance. Returns
+/// `None` when neither the per-cfg spec nor the referenced group
+/// supplies one.
+fn resolve_remote_as_with_source(
+    bgp: &Bgp,
+    cfg: &InterfaceNeighborCfg,
+) -> Option<ResolvedRemoteAs> {
     if let Some(asn) = cfg.remote_as.materialize(bgp.asn) {
-        return Some(asn);
+        return Some(ResolvedRemoteAs {
+            asn,
+            inherited_from_group: false,
+        });
     }
-    super::neighbor_group::group_remote_as(bgp, cfg.neighbor_group.as_ref()?)
+    let asn = super::neighbor_group::group_remote_as(bgp, cfg.neighbor_group.as_ref()?)?;
+    Some(ResolvedRemoteAs {
+        asn,
+        inherited_from_group: true,
+    })
 }
 
 /// Materialize a Peer for `interface-neighbor IFNAME` once an RA has
@@ -70,7 +92,7 @@ pub fn materialize_peer(
     link_local: Ipv6Addr,
 ) -> Option<usize> {
     let cfg = bgp.interface_neighbors.get(name)?.clone();
-    let remote_as = resolve_remote_as(bgp, &cfg)?;
+    let resolved = resolve_remote_as_with_source(bgp, &cfg)?;
 
     // Already materialized? Refresh address (the peer's link-local
     // can change if the kernel reassigns it) but otherwise leave the
@@ -84,7 +106,7 @@ pub fn materialize_peer(
         0,
         bgp.asn,
         bgp.router_id,
-        remote_as,
+        resolved.asn,
         link_local.into(),
         bgp.hostname(),
         bgp.tx.clone(),
@@ -96,6 +118,13 @@ pub fn materialize_peer(
     // path in `peer_start_connection` reads this back out and
     // builds the SocketAddrV6 accordingly.
     peer.scope_id = Some(ifindex);
+    // When the remote-as came off the group rather than the per-cfg
+    // spec, stamp the back-reference so the reactive sweep on
+    // `neighbor-group remote-as` changes can find this peer.
+    if resolved.inherited_from_group {
+        peer.config.neighbor_group = cfg.neighbor_group.clone();
+        peer.config.remote_as_inherited = true;
+    }
     bgp.peers.insert_with_key(PeerKey::Interface(ifindex), peer);
 
     // Kick the FSM. `peer.start()` arms the idle-hold timer which

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -2,10 +2,16 @@
 //!
 //! Storage + the resolver shared by every peer-materialization path
 //! that may inherit from a group: static peers (`config_peer_neighbor_group`),
-//! IPv6 unnumbered (`interface_neighbor::resolve_remote_as`), and dynamic
+//! IPv6 unnumbered (`interface_neighbor::materialize_peer`), and dynamic
 //! peers (`peer::try_dynamic_accept`). The v1 surface inherits only
 //! `remote-as`; per-peer overrides win via the
 //! [`super::peer::PeerConfig::remote_as_inherited`] flag.
+//!
+//! Group mutations are reactive: `config_neighbor_group_remote_as`
+//! mutates the stored value and then sweeps every peer with a matching
+//! `config.neighbor_group` reference to propagate the change (or tear
+//! the inherited peer down on Delete) — see
+//! [`config_neighbor_group_remote_as`].
 //!
 //! Naming-wise this sits alongside the existing
 //! `peer-groups/peer-group` schema, not on top of it: a peer can
@@ -16,6 +22,8 @@
 use std::collections::BTreeMap;
 
 use super::Bgp;
+use super::inst::Message;
+use super::peer::{Event, PeerType};
 use crate::config::{Args, ConfigOp};
 
 #[derive(Debug, Default, Clone)]
@@ -40,19 +48,135 @@ pub fn config_neighbor_group(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
 }
 
 /// `set router bgp neighbor-groups neighbor-group <name> remote-as <asn>`.
+///
+/// Mutates the stored value and then reactively sweeps every peer that
+/// references the group with an inherited (or absent) `remote-as`:
+/// - On `Set` the new value is propagated; dormant peers start, and
+///   peers whose remote-as actually changed bounce so the FSM
+///   renegotiates with the new value.
+/// - On `Delete` inherited peers are reset to `remote_as = 0` and
+///   sent `Event::Stop`. Peers with an explicit per-peer remote-as
+///   are left alone.
 pub fn config_neighbor_group_remote_as(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
-    let group = bgp.neighbor_groups.entry(name).or_default();
-    match op {
-        ConfigOp::Set => {
-            group.remote_as = Some(args.u32()?);
-        }
-        ConfigOp::Delete => {
-            group.remote_as = None;
-        }
-        _ => {}
-    }
+    let new_asn = match op {
+        ConfigOp::Set => Some(args.u32()?),
+        ConfigOp::Delete => None,
+        _ => return Some(()),
+    };
+
+    bgp.neighbor_groups
+        .entry(name.clone())
+        .or_default()
+        .remote_as = new_asn;
+
+    sweep_peers_for_group(bgp, &name, new_asn);
     Some(())
+}
+
+/// Decide what to do with one peer that references the group whose
+/// `remote-as` just changed. Pure function so the (small) sweep logic
+/// is unit-testable without standing up a full [`Bgp`] instance.
+///
+/// `peer_remote_as` / `peer_inherited` describe the peer's current
+/// state; `new_asn` is the group's new value (`None` = removed).
+/// Returns the action the sweep should take.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum SweepAction {
+    /// Peer is unaffected — either it doesn't reference this group's
+    /// remote-as for its own (explicit per-peer override wins), or
+    /// the value didn't actually change.
+    Ignore,
+    /// Adopt the new asn. Caller must rewrite `peer.remote_as`,
+    /// mark `remote_as_inherited = true`, refresh `peer_type` and
+    /// kick `peer.start()`.
+    Adopt(u32),
+    /// Peer was inherited and its asn changed — caller must rewrite
+    /// the new asn, then bounce the session via `Event::Stop` so the
+    /// FSM renegotiates.
+    Rebounce(u32),
+    /// Group's remote-as was deleted while this peer was inherited —
+    /// caller must reset `remote_as = 0`, clear inheritance, deactivate
+    /// the peer and send `Event::Stop`.
+    TearDown,
+}
+
+pub(super) fn sweep_action(
+    peer_remote_as: u32,
+    peer_inherited: bool,
+    peer_active: bool,
+    new_asn: Option<u32>,
+) -> SweepAction {
+    // Explicit per-peer remote-as always wins.
+    if !peer_inherited && peer_remote_as != 0 {
+        return SweepAction::Ignore;
+    }
+    match new_asn {
+        Some(asn) => {
+            if peer_remote_as == asn {
+                SweepAction::Ignore
+            } else if peer_active {
+                SweepAction::Rebounce(asn)
+            } else {
+                SweepAction::Adopt(asn)
+            }
+        }
+        None if peer_inherited => SweepAction::TearDown,
+        None => SweepAction::Ignore,
+    }
+}
+
+/// Apply [`sweep_action`] to every peer whose `config.neighbor_group`
+/// matches `name`. Collects FSM stop signals to send after the
+/// peer-iteration borrow ends.
+fn sweep_peers_for_group(bgp: &mut Bgp, name: &str, new_asn: Option<u32>) {
+    let local_asn = bgp.asn;
+    let mut stops: Vec<usize> = Vec::new();
+
+    for (_, peer) in bgp.peers.iter_mut() {
+        if peer.config.neighbor_group.as_deref() != Some(name) {
+            continue;
+        }
+        match sweep_action(
+            peer.remote_as,
+            peer.config.remote_as_inherited,
+            peer.active,
+            new_asn,
+        ) {
+            SweepAction::Ignore => {}
+            SweepAction::Adopt(asn) => {
+                peer.remote_as = asn;
+                peer.config.remote_as_inherited = true;
+                peer.peer_type = if asn == local_asn {
+                    PeerType::IBGP
+                } else {
+                    PeerType::EBGP
+                };
+                peer.start();
+            }
+            SweepAction::Rebounce(asn) => {
+                peer.remote_as = asn;
+                peer.config.remote_as_inherited = true;
+                peer.peer_type = if asn == local_asn {
+                    PeerType::IBGP
+                } else {
+                    PeerType::EBGP
+                };
+                peer.active = false;
+                stops.push(peer.ident);
+            }
+            SweepAction::TearDown => {
+                peer.remote_as = 0;
+                peer.config.remote_as_inherited = false;
+                peer.active = false;
+                stops.push(peer.ident);
+            }
+        }
+    }
+
+    for ident in stops {
+        let _ = bgp.tx.try_send(Message::Event(ident, Event::Stop));
+    }
 }
 
 /// Empty initialiser for the per-Bgp neighbor-group map. Centralised
@@ -96,5 +220,72 @@ mod tests {
         let mut map: BTreeMap<String, NeighborGroup> = BTreeMap::new();
         map.insert("RR".into(), NeighborGroup { remote_as: None });
         assert_eq!(map.get("RR").and_then(|g| g.remote_as), None);
+    }
+
+    // Sweep-decision matrix. Inputs: (peer_remote_as, peer_inherited,
+    // peer_active, new_asn). The pure helper keeps the decision logic
+    // in [`sweep_peers_for_group`] testable without standing up a
+    // full Bgp instance.
+
+    #[test]
+    fn sweep_ignores_explicit_per_peer_override() {
+        // Peer has its own explicit asn — group change must not touch
+        // it regardless of Set/Delete.
+        assert_eq!(
+            sweep_action(65001, false, false, Some(65000)),
+            SweepAction::Ignore
+        );
+        assert_eq!(sweep_action(65001, false, false, None), SweepAction::Ignore);
+    }
+
+    #[test]
+    fn sweep_adopts_when_dormant_inherited_peer_gets_asn() {
+        assert_eq!(
+            sweep_action(0, true, false, Some(65000)),
+            SweepAction::Adopt(65000),
+        );
+    }
+
+    #[test]
+    fn sweep_adopts_when_peer_has_no_remote_as_at_all() {
+        // Static peer with only `neighbor-group X` reference — the
+        // inheritance flag may not yet be flipped (e.g. peer created
+        // before the group was). `remote_as == 0` is the trigger.
+        assert_eq!(
+            sweep_action(0, false, false, Some(65000)),
+            SweepAction::Adopt(65000),
+        );
+    }
+
+    #[test]
+    fn sweep_rebounces_when_active_inherited_peers_asn_changes() {
+        assert_eq!(
+            sweep_action(65000, true, true, Some(65001)),
+            SweepAction::Rebounce(65001),
+        );
+    }
+
+    #[test]
+    fn sweep_ignores_no_op_change() {
+        assert_eq!(
+            sweep_action(65000, true, true, Some(65000)),
+            SweepAction::Ignore,
+        );
+    }
+
+    #[test]
+    fn sweep_tears_down_inherited_peer_on_delete() {
+        assert_eq!(sweep_action(65000, true, true, None), SweepAction::TearDown);
+        assert_eq!(
+            sweep_action(65000, true, false, None),
+            SweepAction::TearDown
+        );
+    }
+
+    #[test]
+    fn sweep_ignores_delete_when_peer_has_no_asn_anyway() {
+        // Peer was never inherited and never got an explicit asn —
+        // Delete on the group is a no-op from the sweep's perspective.
+        assert_eq!(sweep_action(0, false, false, None), SweepAction::Ignore);
     }
 }


### PR DESCRIPTION
## Summary

Builds on #758. The Set/Delete callback for `neighbor-groups neighbor-group <X> remote-as <N>` used to mutate the stored value but never touch already-referencing peers, so:
- A `remote-as` typed *after* the peer block stayed dormant forever.
- A `remote-as` removal left inherited peers stuck on the old asn.

`config_neighbor_group_remote_as` now sweeps every peer whose `config.neighbor_group` references the mutated group and applies the right action:
- **Adopt** new asn + kick `peer.start()` for dormant peers.
- **Rebounce** active peers via `Event::Stop` when the asn actually changed (so the FSM renegotiates).
- **TearDown** inherited peers on a group delete; explicit per-peer `remote-as` always wins.

The decision matrix lives in a pure `sweep_action` helper so it's unit-testable without standing up a full `Bgp`. Tests cover the override / adopt / rebounce / no-op / teardown cases.

`interface_neighbor::materialize_peer` now also stamps `config.neighbor_group` + `remote_as_inherited = true` when the asn came from the group, so interface-keyed peers are reachable by the sweep too (parity with the static + dynamic-accept paths).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --exclude bdd` green (606 zebra-rs tests, +7 sweep cases vs. main)
- [ ] Manual: `neighbor-group RR { remote-as 65000 }` + `neighbor 10.0.0.1 { neighbor-group RR }`, then change RR to 65001 → confirm session bounces and reestablishes
- [ ] Manual: delete `neighbor-group RR remote-as` on a live inherited session → confirm peer tears down

Generated with [Claude Code](https://claude.com/claude-code)