### PR TITLE
book: add OSPFv2 chapter

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -18,6 +18,8 @@
 - [IS-IS](ch-07-00-isis.md)
   - [Timer Configuration](ch-07-01-isis-timers.md)
   - [Shared Risk Link Group (SRLG)](ch-07-02-isis-srlg.md)
+- [OSPFv2](ch-08-00-ospf.md)
+  - [Configuration](ch-08-01-ospf-configuration.md)
 
 ## SRv6
 

--- a/book/src/ch-08-00-ospf.md
+++ b/book/src/ch-08-00-ospf.md
@@ -1,0 +1,21 @@
+# OSPFv2 — Open Shortest Path First
+
+OSPFv2 (RFC 2328) is a link-state interior gateway protocol for IPv4.
+Routers flood Link State Advertisements (LSAs) describing local
+interface state, attached prefixes, and adjacencies; every router
+independently runs Dijkstra over the resulting database to compute
+shortest paths.
+
+zebra-rs implements OSPFv2 with the standard area model (a backbone
+area `0.0.0.0` and arbitrarily many non-backbone areas joined to it),
+Hello / Database-Description / LSA-Update / LSA-Request /
+LSA-Acknowledgement processing, the canonical IFSM and NFSM state
+machines, Fletcher (RFC 905 §A.4.1) LSA checksums, retransmission
+with per-neighbor `ls_rxmt` tracking, delayed LSAck aggregation,
+opaque-LSA (RFC 5250) processing for Segment Routing extensions,
+and SPF with route installation into the system RIB. Interop has
+been validated against FRR's `ospfd`.
+
+This section documents the configuration surface. See `router ospf`
+under `/router/ospf` in the YANG schema for the full configuration
+tree.

--- a/book/src/ch-08-01-ospf-configuration.md
+++ b/book/src/ch-08-01-ospf-configuration.md
@@ -1,0 +1,236 @@
+# OSPFv2 Configuration
+
+OSPFv2 configuration in zebra-rs lives under `router ospf` and is
+shaped around the standard `area { interface }` hierarchy: each
+participating interface is declared inside the area it belongs to.
+
+```
+router ospf {
+  router-id 10.0.0.1;
+  area 0 {
+    interface enp0s6 {
+      enable true;
+    }
+  }
+  area 0.0.0.1 {
+    interface enp0s7 {
+      enable true;
+      hello-interval 5;
+      dead-interval 20;
+    }
+  }
+}
+```
+
+There is no separate `network X area Y` table — an interface
+participates in OSPF if and only if it appears under some area with
+`enable true`, and the area it belongs to is implicit from the parent
+list entry.
+
+## Area identifier — decimal or dotted-quad
+
+The `area` list key is a union of `uint32` and `inet:ipv4-address`,
+so both spellings are accepted and they normalize to the same 32-bit
+area ID:
+
+```
+area 0           # backbone (0.0.0.0)
+area 0.0.0.0     # backbone (equivalent)
+area 1           # non-backbone (0.0.0.1)
+area 0.0.0.1     # non-backbone (equivalent)
+```
+
+Internally the area ID is always a 32-bit value matching the on-the-
+wire `Area ID` field of OSPFv2 headers (RFC 2328 §A.3.1). Dotted-quad
+is the canonical rendering in `show` output regardless of how the
+operator wrote it.
+
+| YANG leaf | Type | Notes |
+|---|---|---|
+| `/router/ospf/router-id` | `inet:ipv4-address` | Optional; falls back to the system-wide router-id selection rules. |
+| `/router/ospf/area/<id>/area-id` | `union { uint32; ipv4-address }` | List key — see above. |
+
+## Per-interface knobs
+
+Each `interface` entry under an area carries the standard set of
+per-link OSPF timers and tuning parameters. All values match the
+defaults from RFC 2328 Appendix C ("Configurable Parameters") except
+where noted.
+
+| YANG leaf | Default | Range | Units |
+|---|---|---|---|
+| `/router/ospf/area/<id>/interface/<n>/enable` | `false` | — | boolean |
+| `/router/ospf/area/<id>/interface/<n>/priority` | 64 | 0..255 | (count) |
+| `/router/ospf/area/<id>/interface/<n>/hello-interval` | 10 | 1..65535 | seconds |
+| `/router/ospf/area/<id>/interface/<n>/dead-interval` | 40 | 1..4294967295 | seconds |
+| `/router/ospf/area/<id>/interface/<n>/retransmit-interval` | 5 | 1..65535 | seconds |
+| `/router/ospf/area/<id>/interface/<n>/mtu-ignore` | `false` | — | boolean |
+
+Notes:
+
+- **`priority`** is the DR-election priority advertised in Hellos.
+  Higher wins; zero forbids the router from becoming DR or BDR on
+  that segment. The zebra-rs default of 64 is the IOS-XR baseline; a
+  router unconditionally configured higher than its peers becomes
+  the DR on a freshly-formed broadcast segment.
+- **`hello-interval`** and **`dead-interval`** must match on all
+  routers on the same segment for adjacency to form. The on-the-wire
+  Hello carries both; mismatches cause Hellos to be silently
+  discarded and the adjacency never leaves `Down`. The conventional
+  ratio is `dead = 4 × hello`; sub-second adjacency detection is
+  better delegated to BFD.
+- **`retransmit-interval`** governs how often unacknowledged LSAs in
+  the per-neighbor `ls_rxmt` list are re-sent. The default of 5 s
+  is conservative and rarely needs tuning on healthy links.
+- **`mtu-ignore`** disables the MTU-mismatch check during DBD
+  exchange (RFC 2328 §10.6). Default `false` matches the RFC; set
+  to `true` only when intentionally peering across links with
+  different MTUs and accepting the resulting black-hole risk for
+  jumbo packets.
+
+## Segment Routing extensions
+
+OSPFv2 SR-MPLS (RFC 8665) is configured at instance and per-interface
+scope:
+
+```
+router ospf {
+  segment-routing mpls;
+  area 0 {
+    interface enp0s6 {
+      enable true;
+      prefix-sid {
+        index 16001;
+      }
+    }
+  }
+}
+```
+
+| YANG leaf | Type | Notes |
+|---|---|---|
+| `/router/ospf/segment-routing` | enum `{ mpls }` | Enables Router Information LSA (RFC 7770) advertising SR capability. |
+| `/router/ospf/area/<id>/interface/<n>/prefix-sid/index` | `uint32` | SID-index form (advertised as Extended Prefix LSA, RFC 7684). |
+| `/router/ospf/area/<id>/interface/<n>/prefix-sid/absolute` | `uint32` | Absolute-label form (alternative to index). |
+
+`index` and `absolute` are mutually exclusive — set one or the
+other. Toggling `segment-routing mpls` originates or flushes the
+Router Information LSA and all Extended Prefix LSAs for configured
+interfaces in a single step.
+
+## Tracing and diagnostics
+
+Diagnostic tracing for OSPFv2 lives under `router ospf tracing`:
+
+```
+router ospf {
+  tracing {
+    packet hello { direction both; }
+    packet ls-update { direction send; }
+    fsm nfsm { detail true; }
+    database lsdb;
+  }
+}
+```
+
+| Category | Subtypes |
+|---|---|
+| `packet` | `hello`, `dd`, `ls-request`, `ls-update`, `ls-ack` |
+| `event` | `lsp-originate`, `lsp-refresh`, `spf-calculation`, `adjacency`, `flooding`, `all` |
+| `fsm` | `ifsm`, `nfsm`, `all` (with optional `detail true`) |
+| `database` | `lsdb`, `spf-tree`, `rib`, `all` |
+
+Each `packet` entry takes a `direction` of `send`, `receive`, or
+`both` (default `both`). FSM tracing with `detail true` logs every
+state-transition event, not just regressive transitions; useful
+during adjacency-formation debugging, noisy in steady-state.
+
+## Moving an interface between areas
+
+Because the area is part of the configuration path, moving an
+interface from area 0 to area 0.0.0.1 is two operations:
+
+```
+no router ospf area 0 interface enp0s6
+router ospf area 0.0.0.1 interface enp0s6 enable true
+```
+
+zebra-rs handles this internally via a `Disable → Enable` transition
+pair (`Message::Disable` followed by `Message::Enable` carrying the
+new area-id), which tears down the old IFSM state machine and starts
+a fresh one in the new area. No daemon restart is required.
+
+If the same interface name accidentally appears under two areas at
+once, the second area's `enable true` wins (the link's
+`config.area` is overwritten). This is not a supported configuration
+and zebra-rs may add a validation error for it in a future release.
+
+## Minimal worked example — two routers, one area
+
+R1:
+```
+router ospf {
+  router-id 10.0.0.1;
+  area 0 {
+    interface enp0s6 {
+      enable true;
+    }
+  }
+}
+```
+
+R2:
+```
+router ospf {
+  router-id 10.0.0.2;
+  area 0 {
+    interface enp0s6 {
+      enable true;
+    }
+  }
+}
+```
+
+With matching default Hello/Dead intervals (10/40 s), adjacency
+progresses Down → Init → 2-Way → ExStart → Exchange → Loading → Full
+within roughly two hello cycles. `show ip ospf neighbor` reports
+`Full/DR` and `Full/BDR` for the elected pair; `show ip ospf database`
+lists the Router LSAs and (for broadcast segments) the Network LSA
+generated by the DR.
+
+## Cross-reference — FRR `ospfd` command mapping
+
+| zebra-rs YANG | FRR `ospfd` command |
+|---|---|
+| `router-id` | `ospf router-id` |
+| `area/<id>/interface/<n>/enable true` | `network <prefix> area <id>` (interface inferred from prefix) |
+| `area/<id>/interface/<n>/priority` | `ip ospf priority` (interface) |
+| `area/<id>/interface/<n>/hello-interval` | `ip ospf hello-interval` (interface) |
+| `area/<id>/interface/<n>/dead-interval` | `ip ospf dead-interval` (interface) |
+| `area/<id>/interface/<n>/retransmit-interval` | `ip ospf retransmit-interval` (interface) |
+| `area/<id>/interface/<n>/mtu-ignore` | `ip ospf mtu-ignore` (interface) |
+| `segment-routing mpls` | `segment-routing on` + `segment-routing mpls` |
+| `area/<id>/interface/<n>/prefix-sid/index` | `ip ospf prefix-sid index` (interface) |
+
+The shape differs: zebra-rs declares interfaces under their area
+directly, while FRR uses a separate `network` statement to bind
+prefix-matched interfaces to an area. The resulting on-the-wire
+behaviour is the same.
+
+## Gaps relative to FRR `ospfd`
+
+OSPFv2 features not yet implemented in zebra-rs:
+
+- Stub / NSSA / Totally-Stubby area types (RFC 2328 §3.6, RFC 3101).
+- Virtual links across non-backbone areas.
+- ABR Type 3 (Summary) and Type 4 (ASBR-Summary) origination.
+- Type 5 (AS-External) origination from redistribution and Type 7
+  (NSSA-External) translation.
+- Per-interface authentication (none / simple-password / MD5 /
+  HMAC-SHA, RFC 5709).
+- Per-area `spf-interval` / `lsa-gen-interval` throttles (currently
+  un-throttled — every LSDB change schedules an immediate SPF).
+- Graceful Restart helper / restarter (RFC 3623).
+
+Most of these are tracked alongside the OSPFv3 work and will land as
+v2 and v3 share the same generic infrastructure.


### PR DESCRIPTION
## Summary

Document the OSPFv2 configuration surface now that the YANG schema has settled on the standard `area { interface }` shape (landed in #759).

- `book/src/ch-08-00-ospf.md` — short overview mirroring the IS-IS chapter opener; lists what's implemented (LSDB, IFSM/NFSM, Fletcher checksums, retransmission, opaque-LSAs, FRR `ospfd` interop) and points readers at `/router/ospf` in the YANG schema.
- `book/src/ch-08-01-ospf-configuration.md` — full configuration reference:
  - area-id union type (`area 0` vs. `area 0.0.0.0`, both normalize)
  - per-interface defaults table (priority 64, hello 10s, dead 40s, retransmit 5s, mtu-ignore false)
  - Segment Routing extensions (SR-MPLS, prefix-sid index/absolute)
  - tracing categories (packet/event/fsm/database)
  - area-move recipe and minimal two-router worked example
  - FRR `ospfd` command-mapping table
  - explicit gaps section (stub/NSSA, virtual links, Type 3/4/5 origination, authentication, SPF throttle, GR)
- `book/src/SUMMARY.md` — link the two new pages between IS-IS and SRv6.

## Test plan

- [x] `mdbook build` succeeds with no broken links
- [x] Chapters render in the book TOC after IS-IS

Generated with [Claude Code](https://claude.com/claude-code)