### PR TITLE
bgp: cascade neighbor-group delete to inherited peers

### DIFF
--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -32,7 +32,10 @@ pub struct NeighborGroup {
 }
 
 /// `set router bgp neighbor-groups neighbor-group <name>` — list-key
-/// callback. Creates the entry on `Set` and removes it on `Delete`.
+/// callback. Creates the entry on `Set`; on `Delete` cascades through
+/// the sweep helper (so any peers that inherited from the group are
+/// torn down even when libyang's commit path skips the per-leaf
+/// delete callbacks) and then removes the entry.
 pub fn config_neighbor_group(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     match op {
@@ -40,6 +43,12 @@ pub fn config_neighbor_group(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
             bgp.neighbor_groups.entry(name).or_default();
         }
         ConfigOp::Delete => {
+            // Same shape as a remote-as Delete: any inherited peer
+            // resets to `remote_as = 0` and is sent `Event::Stop`.
+            // Idempotent if the per-leaf delete already ran — the
+            // second pass finds peers with `remote_as_inherited =
+            // false` and returns `SweepAction::Ignore`.
+            sweep_peers_for_group(bgp, &name, None);
             bgp.neighbor_groups.remove(&name);
         }
         _ => {}


### PR DESCRIPTION
## Summary

Builds on #758 / #760. `delete router bgp neighbor-groups neighbor-group <X>` used to remove the stored group but leave inherited peers in their pre-delete state — if libyang's commit path delivered only the list-key delete without firing the per-leaf delete callback first, those peers stayed on the old asn until the next session reset.

`config_neighbor_group`'s Delete arm now runs the existing `sweep_peers_for_group(bgp, &name, None)` helper before dropping the entry. Inherited peers are reset to `remote_as = 0`, `remote_as_inherited = false`, and sent `Event::Stop`. Peers carrying an explicit per-peer `remote-as` are left alone.

Idempotent against the per-leaf delete path: if `config_neighbor_group_remote_as` already swept the peers, the second sweep finds `remote_as_inherited = false` and returns `SweepAction::Ignore` for each — no double-bounce.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --exclude bdd` green (606 zebra-rs tests; PR 760's `sweep_action` matrix already covers Delete-on-inherited and Delete-on-non-inherited)
- [ ] Manual: configure `neighbor-group RR { remote-as 65000 }` and a `neighbor 10.0.0.1 { neighbor-group RR }` session in Established. `delete router bgp neighbor-groups neighbor-group RR` → confirm peer tears down.

Generated with [Claude Code](https://claude.com/claude-code)