### PR TITLE
bgp: add global adv-interval timer config (iBGP/eBGP split)

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -15,6 +15,7 @@
 - [BGP](ch-02-00-what-is-bgp.md)
   - [Dynamic Neighbors](ch-02-01-dynamic-neighbors.md)
   - [Session Authentication (TCP MD5 / TCP-AO)](ch-02-02-tcp-authentication.md)
+  - [Timer Configuration](ch-02-03-bgp-timers.md)
 - [IS-IS](ch-07-00-isis.md)
   - [Timer Configuration](ch-07-01-isis-timers.md)
   - [Shared Risk Link Group (SRLG)](ch-07-02-isis-srlg.md)

--- a/book/src/ch-02-03-bgp-timers.md
+++ b/book/src/ch-02-03-bgp-timers.md
@@ -1,0 +1,106 @@
+# BGP Timer Configuration
+
+BGP behaviour is shaped by a handful of timers that govern session
+liveness, retry cadence, and how aggressively the speaker batches
+outbound advertisements. This chapter documents the timers zebra-rs
+exposes today, the defaults it ships with, and the operational
+trade-offs behind tuning them.
+
+Per-neighbor timers live under each neighbor; the global advertisement
+interval lives under `router bgp timer`.
+
+```
+router bgp {
+  timer {
+    adv-interval {
+      ibgp 5;
+      ebgp 30;
+    }
+  }
+}
+```
+
+Defaults are chosen to match RFC 4271 §10 and the Cisco IOS-XR
+implementation where the semantics align, so configurations written
+against IOS-XR carry across without surprise.
+
+## Advertisement interval (MRAI)
+
+The **MinRouteAdvertisementInterval** (MRAI) — RFC 4271 §9.2.1.1 — is
+the minimum time a BGP speaker waits between successive advertisements
+of routes carrying overlapping NLRI. Internally it acts as a
+coalescing knob: when a route change arrives, zebra-rs starts a
+debounce timer; further changes that land before the timer fires are
+batched into the same MP_REACH UPDATE per attribute group. Without
+this debounce, a flap or a burst of redistribute events would
+translate into one UPDATE per change.
+
+zebra-rs splits the MRAI by peer type so iBGP can run a faster cadence
+than eBGP — typical in operator networks where iBGP sees more
+frequent intra-AS route churn while eBGP cadence is shaped by
+peering-policy concerns.
+
+| YANG leaf | Default | Range | Units |
+|---|---|---|---|
+| `/router/bgp/timer/adv-interval/ibgp` | 5 | 0..65535 | seconds |
+| `/router/bgp/timer/adv-interval/ebgp` | 30 | 0..65535 | seconds |
+
+The defaults follow RFC 4271 §10: 5 s for internal sessions, 30 s for
+external sessions.
+
+**Scope.** The setting is global to the BGP instance. Every iBGP
+update-group reads the `ibgp` value; every eBGP update-group reads the
+`ebgp` value. Per-neighbor override is not supported in this revision
+— the IETF `advertisement-interval` leaf under `neighbor … timers`
+remains in the schema but is not yet wired into the advertise pipeline.
+
+**Live application.** When either value changes via configuration,
+zebra-rs re-snapshots the new cadence onto every existing peer and
+update-group. Already-armed debounce timers keep running with their
+captured value until they fire — there is no observable benefit to
+cancelling them early, since the MRAI is a coalescing knob rather
+than a session timer. The very next batch flush therefore uses the
+new value.
+
+**Tuning trade-offs.**
+
+- Lowering MRAI shortens advertisement latency at the cost of more
+  UPDATEs (potentially one per route change) and higher peer-side
+  decode load.
+- Raising MRAI lets more changes pack into a single MP_REACH UPDATE
+  per attribute group, reducing message count at the cost of slower
+  convergence.
+- An MRAI of `0` disables the debounce entirely — every route change
+  ships immediately. Useful in lab environments and when running
+  against a peer that does its own coalescing; not recommended in
+  production.
+- The MRAI applies to advertisements, not withdrawals. Withdraw
+  messages are not held by the timer.
+
+**Worked example — converging a redistribute burst.**
+Suppose a redistribute trigger injects 200 prefixes within 100 ms onto
+a router with iBGP sessions to four route-reflector clients. With the
+default 5-second iBGP MRAI:
+
+1. The first NLRI lands in the update-group's pending-advert cache and
+   arms a 5-second debounce timer.
+2. The remaining 199 prefixes accumulate into the same cache during
+   the debounce window, bucketed by attribute set.
+3. On fire, the cache drains: each attribute bucket becomes one
+   MP_REACH UPDATE containing all of its NLRIs, replicated once per
+   non-source member of the update-group.
+
+Net wire result: a small number of large UPDATEs instead of 200 tiny
+ones, at the price of ≤ 5 seconds of advertisement latency.
+
+## Per-neighbor session timers
+
+The classic BGP session timers — keepalive, hold-time, connect-retry,
+idle-hold, delay-open — are configured per neighbor under the IETF
+`neighbor … timers` container and are documented in their respective
+sections (their semantics match RFC 4271 unchanged).
+
+These knobs control session liveness and reconnect cadence; they do
+not interact with the MRAI debounce above. The advertisement pipeline
+runs only against peers in the `Established` state, so MRAI tuning
+affects message rate, not session establishment.

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1670,6 +1670,21 @@ impl Bgp {
         self.timer("/advertisement-interval", timer::config::adv_interval);
         self.timer("/originate-interval", timer::config::orig_interval);
 
+        // Global BGP timer configuration (zebra-bgp-timer.yang).
+        // `router bgp timer adv-interval { ibgp; ebgp; }` overrides
+        // the MRAI cadence used by the IPv4 / VPNv4 / EVPN adv-debounce
+        // timers; defaults are 5s (iBGP) and 30s (eBGP) per RFC 4271
+        // §10. The callbacks write to `Bgp::adv_interval` and re-snapshot
+        // every existing peer and update-group.
+        self.callback_add(
+            "/router/bgp/timer/adv-interval/ibgp",
+            timer::config::adv_interval_ibgp,
+        );
+        self.callback_add(
+            "/router/bgp/timer/adv-interval/ebgp",
+            timer::config::adv_interval_ebgp,
+        );
+
         self.pcallback_add("/community-list", config_com_list);
         self.pcallback_add("/community-list/seq", config_com_list_seq);
         self.pcallback_add("/community-list/seq/action", config_com_list_action);

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -442,6 +442,12 @@ pub struct Bgp {
     /// follow-up (step 5b).
     pub redist_v4: BTreeMap<(crate::rib::RibType, ipnet::Ipv4Net), crate::rib::RouteEntryV4>,
     pub redist_v6: BTreeMap<(crate::rib::RibType, ipnet::Ipv6Net), crate::rib::RouteEntryV6>,
+
+    /// Global MinRouteAdvertisementInterval (MRAI) per RFC 4271
+    /// §9.2.1.1, split by peer type. Source of truth for the per-Peer
+    /// / per-UpdateGroup `adv_interval` snapshots. Configured under
+    /// `router bgp timer adv-interval { ibgp; ebgp; }`.
+    pub adv_interval: super::timer::AdvInterval,
 }
 
 impl Bgp {
@@ -529,6 +535,7 @@ impl Bgp {
             redistribute: BTreeMap::new(),
             redist_v4: BTreeMap::new(),
             redist_v6: BTreeMap::new(),
+            adv_interval: super::timer::AdvInterval::default(),
         };
         bgp.callback_build();
         bgp.show_build();

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -393,6 +393,13 @@ pub struct Peer {
     /// the peer is in; written by `update_group::attach` on entering
     /// Established and cleared by `detach` on leaving. Empty otherwise.
     pub update_group_id: BTreeMap<AfiSafi, super::update_group::UpdateGroupId>,
+
+    /// Snapshot of `Bgp::adv_interval` captured at peer construction
+    /// and refreshed by the global config callback. Read by the VPNv4
+    /// / EVPN adv-debounce timers (`start_adv_timer_vpnv4` /
+    /// `start_adv_timer_evpn`) so the timer-arming path doesn't need
+    /// to reach back into the global `Bgp`.
+    pub adv_interval: timer::AdvInterval,
 }
 
 impl Peer {
@@ -453,6 +460,7 @@ impl Peer {
             cache_evpn_timer: None,
             last_ao_installed: None,
             update_group_id: BTreeMap::new(),
+            adv_interval: timer::AdvInterval::default(),
         };
         peer.config
             .mp

--- a/zebra-rs/src/bgp/timer.rs
+++ b/zebra-rs/src/bgp/timer.rs
@@ -6,7 +6,7 @@ use rand::RngExt;
 use crate::config::{Args, ConfigOp};
 use crate::context::Timer;
 
-use super::peer::{Event, Peer, State};
+use super::peer::{Event, Peer, PeerType, State};
 use super::{Bgp, Message};
 
 #[derive(Debug, Default, Clone)]
@@ -17,6 +17,37 @@ pub struct Config {
     pub connect_retry_time: Option<u16>,
     pub min_adv_interval: Option<u16>,
     pub orig_interval: Option<u16>,
+}
+
+/// Global MinRouteAdvertisementInterval (MRAI) per RFC 4271 §9.2.1.1,
+/// split by peer type. Stored once on `Bgp` and snapshotted onto each
+/// `Peer` / `UpdateGroup` so the timer-arming code path doesn't need
+/// to reach the global instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AdvInterval {
+    pub ibgp: u16,
+    pub ebgp: u16,
+}
+
+impl AdvInterval {
+    pub const DEFAULT_IBGP: u16 = 5;
+    pub const DEFAULT_EBGP: u16 = 30;
+
+    pub fn secs_for(&self, peer_type: PeerType) -> u64 {
+        match peer_type {
+            PeerType::IBGP => self.ibgp as u64,
+            PeerType::EBGP => self.ebgp as u64,
+        }
+    }
+}
+
+impl Default for AdvInterval {
+    fn default() -> Self {
+        Self {
+            ibgp: Self::DEFAULT_IBGP,
+            ebgp: Self::DEFAULT_EBGP,
+        }
+    }
 }
 
 impl Config {
@@ -103,22 +134,16 @@ fn start_hold_timer(peer: &Peer) -> Timer {
 }
 
 pub fn start_adv_timer_vpnv4(peer: &Peer) -> Timer {
-    if peer.is_ibgp() {
-        start_timer!(peer, 5_u64, Event::AdvTimerVpnv4Expires)
-    } else {
-        start_timer!(peer, 30_u64, Event::AdvTimerVpnv4Expires)
-    }
+    let secs = peer.adv_interval.secs_for(peer.peer_type);
+    start_timer!(peer, secs, Event::AdvTimerVpnv4Expires)
 }
 
 /// EVPN advertise debounce — same iBGP/eBGP cadence as the IPv4 /
 /// VPNv4 timers. Buffers a burst of FDB learns into one MP_REACH
 /// UPDATE per attribute group.
 pub fn start_adv_timer_evpn(peer: &Peer) -> Timer {
-    if peer.is_ibgp() {
-        start_timer!(peer, 5_u64, Event::AdvTimerEvpnExpires)
-    } else {
-        start_timer!(peer, 30_u64, Event::AdvTimerEvpnExpires)
-    }
+    let secs = peer.adv_interval.secs_for(peer.peer_type);
+    start_timer!(peer, secs, Event::AdvTimerEvpnExpires)
 }
 
 fn start_keepalive_timer(peer: &Peer) -> Timer {
@@ -315,5 +340,48 @@ pub mod config {
             peer.config.timer.orig_interval = None;
         }
         Some(())
+    }
+
+    /// `router bgp timer adv-interval ibgp <secs>` — global iBGP MRAI.
+    /// Updating the value re-snapshots `peer.adv_interval` /
+    /// `update_group.adv_interval` for every existing peer / group so
+    /// the next timer arm picks up the new value. Already-armed timers
+    /// keep their captured value until they fire — there is no
+    /// observable benefit to cancelling them early since the
+    /// adv-debounce is a coalescing knob, not a session timer.
+    pub fn adv_interval_ibgp(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+        let val = if op.is_set() {
+            args.u16()?
+        } else {
+            AdvInterval::DEFAULT_IBGP
+        };
+        bgp.adv_interval.ibgp = val;
+        propagate_adv_interval(bgp);
+        Some(())
+    }
+
+    /// `router bgp timer adv-interval ebgp <secs>` — global eBGP MRAI.
+    /// See [`adv_interval_ibgp`] for the propagation contract.
+    pub fn adv_interval_ebgp(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+        let val = if op.is_set() {
+            args.u16()?
+        } else {
+            AdvInterval::DEFAULT_EBGP
+        };
+        bgp.adv_interval.ebgp = val;
+        propagate_adv_interval(bgp);
+        Some(())
+    }
+
+    fn propagate_adv_interval(bgp: &mut Bgp) {
+        let snapshot = bgp.adv_interval;
+        for (_, peer) in bgp.peers.iter_mut_all() {
+            peer.adv_interval = snapshot;
+        }
+        for af in bgp.update_groups.values_mut() {
+            for group in af.groups.values_mut() {
+                group.adv_interval = snapshot;
+            }
+        }
     }
 }

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -34,6 +34,7 @@ use super::BgpAttrStore;
 use super::inst::Message;
 use super::peer::{Peer, PeerType};
 use super::peer_map::PeerMap;
+use super::timer::AdvInterval;
 use crate::bgp::InOut;
 use crate::context::Timer;
 
@@ -148,6 +149,13 @@ pub struct UpdateGroup {
     /// Adv-debounce timer. Started on first send; on fire,
     /// `Bgp::serve` drains the cache and ships UPDATEs to members.
     pub cache_ipv4_timer: Option<Timer>,
+
+    /// Snapshot of `Bgp::adv_interval` captured at group creation
+    /// (`attach`) and refreshed by the global config callback. Used
+    /// by `start_adv_timer_ipv4` to arm the debounce — the
+    /// peer-type→seconds lookup happens against this snapshot, not a
+    /// hard-coded 5/30.
+    pub adv_interval: AdvInterval,
 }
 
 /// Per-AFI/SAFI bookkeeping: the active groups plus a monotonic seq
@@ -252,7 +260,10 @@ pub fn attach(update_groups: &mut UpdateGroupMap, peers: &mut PeerMap, peer_idx:
     };
 
     // Snapshot signatures so we can mutate update_groups + peer
-    // without overlapping borrows.
+    // without overlapping borrows. The adv_interval snapshot rides
+    // along onto every freshly-created group so the IPv4 adv-timer
+    // can read its cadence without reaching back into `Bgp`.
+    let adv_interval = peer.adv_interval;
     let mut sigs: Vec<(AfiSafi, UpdateGroupSig)> = Vec::new();
     for (afi, safi) in TRACKED_AFI_SAFIS {
         if let Some(sig) = signature_of(peer, afi, safi) {
@@ -274,6 +285,7 @@ pub fn attach(update_groups: &mut UpdateGroupMap, peers: &mut PeerMap, peer_idx:
                 cache_ipv4: HashMap::new(),
                 cache_ipv4_rev: HashMap::new(),
                 cache_ipv4_timer: None,
+                adv_interval,
             }
         });
         entry.members.insert(peer_idx);
@@ -337,9 +349,6 @@ pub fn detach(update_groups: &mut UpdateGroupMap, peers: &mut PeerMap, peer_idx:
 // group cache via `send_ipv4_direct` — encoding stays per-attr-
 // batched without fanning out to the whole group.
 
-const ADV_TIMER_IBGP_SECS: u64 = 5;
-const ADV_TIMER_EBGP_SECS: u64 = 30;
-
 /// Bucket the (nlri, attr, source_ident) into the group's IPv4
 /// pending-advert cache. Also kicks the adv-debounce timer if not
 /// already running. The `tx` channel is the global Bgp tx (every
@@ -360,7 +369,8 @@ pub fn send_ipv4(
         .insert(nlri.clone(), source_ident);
     group.cache_ipv4_rev.insert(nlri, attr);
     if kick_timer && group.cache_ipv4_timer.is_none() {
-        group.cache_ipv4_timer = Some(start_adv_timer_ipv4(tx, &group.id, group.sig.peer_type));
+        let secs = group.adv_interval.secs_for(group.sig.peer_type);
+        group.cache_ipv4_timer = Some(start_adv_timer_ipv4(tx, &group.id, secs));
     }
 }
 
@@ -383,15 +393,7 @@ pub fn cache_remove_ipv4(group: &mut UpdateGroup, prefix: ipnet::Ipv4Net, id: u3
     }
 }
 
-fn start_adv_timer_ipv4(
-    tx: &mpsc::Sender<Message>,
-    id: &UpdateGroupId,
-    peer_type: PeerType,
-) -> Timer {
-    let secs = match peer_type {
-        PeerType::IBGP => ADV_TIMER_IBGP_SECS,
-        PeerType::EBGP => ADV_TIMER_EBGP_SECS,
-    };
+fn start_adv_timer_ipv4(tx: &mpsc::Sender<Message>, id: &UpdateGroupId, secs: u64) -> Timer {
     let tx = tx.clone();
     let id = id.clone();
     Timer::once(secs, move || {
@@ -810,6 +812,7 @@ mod tests {
                 cache_ipv4: HashMap::new(),
                 cache_ipv4_rev: HashMap::new(),
                 cache_ipv4_timer: None,
+                adv_interval: AdvInterval::default(),
             },
         );
         af.next_seq = 1;

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -64,6 +64,10 @@ module config {
     prefix zbsr;
   }
 
+  import zebra-bgp-timer {
+    prefix zbtm;
+  }
+
   import openconfig-isis-types {
     prefix isis;
   }

--- a/zebra-rs/yang/zebra-bgp-timer.yang
+++ b/zebra-rs/yang/zebra-bgp-timer.yang
@@ -1,0 +1,114 @@
+module zebra-bgp-timer {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-timer";
+  prefix "zbtm";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "Global BGP timer configuration under `router bgp timer`.
+
+     Today this carries the `adv-interval` knob — the
+     MinRouteAdvertisementInterval (MRAI) per RFC 4271 §9.2.1.1 —
+     split into separate iBGP and eBGP values. The interval gates how
+     frequently each update-group flushes its pending advertisement
+     cache, batching multiple route changes into a single MP_REACH
+     UPDATE per attribute group.
+
+     Example:
+
+       router bgp {
+         timer {
+           adv-interval {
+             ibgp 5;
+             ebgp 30;
+           }
+         }
+       }
+
+     Defaults (RFC 4271 §10): iBGP=5s, eBGP=30s.";
+
+  revision 2026-05-22 {
+    description
+      "Initial revision — global iBGP/eBGP adv-interval knobs.";
+    reference
+      "RFC 4271: A Border Gateway Protocol 4 (BGP-4), §9.2.1.1
+       and §10 (MinRouteAdvertisementInterval).";
+  }
+
+  grouping bgp-timer-extension {
+    description
+      "Container `timer` under the BGP top-level. Today carries
+       only `adv-interval`; future per-AFI/SAFI or per-peer timer
+       knobs (originate-interval, refresh) attach here.";
+
+    container timer {
+      ext:help "Global BGP timer configuration";
+
+      container adv-interval {
+        ext:help "MinRouteAdvertisementInterval (MRAI), split by peer type";
+        description
+          "Per-peer-type MRAI override. iBGP and eBGP peers
+           consult separate values when arming the advertisement
+           debounce timer used to coalesce burst route changes
+           into a single MP_REACH UPDATE.";
+
+        leaf ibgp {
+          ext:help "iBGP MRAI in seconds (default 5)";
+          type uint16;
+          units "seconds";
+          description
+            "MinRouteAdvertisementInterval applied to iBGP
+             update-groups. Default 5s per RFC 4271 §10.";
+        }
+        leaf ebgp {
+          ext:help "eBGP MRAI in seconds (default 30)";
+          type uint16;
+          units "seconds";
+          description
+            "MinRouteAdvertisementInterval applied to eBGP
+             update-groups. Default 30s per RFC 4271 §10.";
+        }
+      }
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router/bgp:bgp" {
+    description
+      "Attach the timer block to the BGP top-level in the
+       candidate-set subtree.";
+    uses bgp-timer-extension;
+  }
+
+  augment "/configure:delete/config:router/bgp:bgp" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp timer adv-interval ibgp` is path-valid.";
+    uses bgp-timer-extension;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `router bgp timer adv-interval { ibgp; ebgp; }` to configure the BGP MinRouteAdvertisementInterval (MRAI, RFC 4271 §9.2.1.1) globally with separate iBGP / eBGP values. Defaults: 5s iBGP, 30s eBGP (RFC 4271 §10) — matching the values that were previously hard-coded in `start_adv_timer_ipv4` / `_vpnv4` / `_evpn`.
- Config writes to `Bgp::adv_interval` and propagates snapshots onto every existing `Peer` and `UpdateGroup` so the next timer arm picks up the new cadence; already-armed debounce timers keep their captured value until they fire.
- New `zebra-bgp-timer.yang` augments `/configure:set/config:router/bgp:bgp`; registered as two callbacks under `/router/bgp/timer/adv-interval/{ibgp,ebgp}`.
- New chapter `book/src/ch-02-03-bgp-timers.md` documents semantics, defaults, live-application behavior, and tuning trade-offs.

## Test plan

- [x] `cargo build` clean
- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p zebra-rs` — 596 passed, 0 failed
- [ ] Reviewer: try `set router bgp timer adv-interval ibgp 10` / `ebgp 60` and verify next adv batch arms with the new cadence

Generated with [Claude Code](https://claude.com/claude-code)