### PR TITLE
ospf: add Ospf<Ospfv3>::new() constructor

### DIFF
--- a/zebra-rs/src/config/ospf.rs
+++ b/zebra-rs/src/config/ospf.rs
@@ -7,7 +7,7 @@ use super::ConfigManager;
 pub fn spawn_ospf(config: &ConfigManager) {
     let (rib_client, rib_rx) = config.subscribe_to_rib("ospf");
     let ctx = ProtoContext::default_table(rib_client);
-    let ospf = inst::Ospf::new(ctx, rib_rx);
+    let ospf = inst::Ospf::<crate::ospf::Ospfv2>::new(ctx, rib_rx);
     config.subscribe("ospf", ospf.cm.tx.clone());
     config.subscribe_show("ospf", ospf.show.tx.clone());
     let task = inst::serve(ospf);

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1376,6 +1376,63 @@ impl Ospf<Ospfv2> {
 /// builder can be reviewed and tested ahead of the spawn wiring.
 #[allow(dead_code)]
 impl Ospf<Ospfv3> {
+    /// Construct an `Ospf<Ospfv3>` instance.
+    ///
+    /// Mirrors the shape of `Ospf<Ospfv2>::new` (see above) so the
+    /// two version-specific constructors stay readable side by side.
+    /// The differences from v2:
+    ///
+    /// - **Socket.** Uses `ospf_socket_ipv6` — same IP protocol
+    ///   number 89, but `Domain::IPV6` with `IPV6_V6ONLY`,
+    ///   `IPV6_MULTICAST_HOPS=1`, and `IPV6_RECVPKTINFO` enabled.
+    /// - **Router-id default.** Still 32-bit (RFC 5340 §2.1).
+    /// - **No `callback_build` / `show_build`.** The v2 versions
+    ///   register paths under `/router/ospf/...`; the v3 schema is
+    ///   currently an empty `container ospfv3` stub with no Rust
+    ///   handlers wired. The `callbacks` and `show_cb` maps stay
+    ///   empty for v3 until the v3 config plumbing lands.
+    /// - **No network read/write task spawn.** The v2 path uses
+    ///   `read_packet` / `write_packet`, which are typed against
+    ///   `Message<Ospfv2>` and the v2 wire format. The v3 packet
+    ///   path is its own substantial PR (Hello over `ff02::5`,
+    ///   pseudo-header checksum, Interface-ID handling); until it
+    ///   lands the `tx` / `ptx` channels exist but nothing drives
+    ///   them. The four `build_*_lsa` self-origination helpers
+    ///   above can still be exercised from tests.
+    ///
+    /// Behind `#[allow(dead_code)]` until `main.rs` learns to spawn
+    /// an `Ospf<Ospfv3>` alongside (or in place of) the v2 instance.
+    pub fn new(ctx: crate::context::ProtoContext, rib_rx: UnboundedReceiver<RibRx>) -> Self {
+        let sock = Arc::new(AsyncFd::new(super::socket::ospf_socket_ipv6(&ctx).unwrap()).unwrap());
+
+        let (tx, rx) = mpsc::unbounded_channel();
+        let (ptx, _prx) = mpsc::unbounded_channel();
+        Self {
+            tx,
+            rx,
+            ptx,
+            cm: ConfigChannel::new(),
+            callbacks: HashMap::new(),
+            rib_rx,
+            ctx,
+            links: BTreeMap::new(),
+            areas: OspfAreaMap::new(),
+            show: ShowChannel::new(),
+            show_cb: HashMap::new(),
+            router_id: Ipv4Addr::from_str("10.0.0.1").unwrap(),
+            lsdb_as: Lsdb::new(),
+            lsp_map: LspMap::default(),
+            spf_result: None,
+            graph: None,
+            rib: PrefixMap::new(),
+            tracing: OspfTracing::default(),
+            segment_routing: super::srmpls::SegmentRoutingMode::default(),
+            spf_last: None,
+            spf_duration: None,
+            sock,
+        }
+    }
+
     /// Build the v3 Intra-Area-Prefix-LSA that references this
     /// router's Router-LSA in `area_id` (RFC 5340 §A.4.10).
     ///


### PR DESCRIPTION
## Summary

Mirror the v2 constructor onto `impl Ospf<Ospfv3>` so the v3 instance is constructible end-to-end (modulo the v3 packet path and v3 config schema that follow in their own PRs). This is the next step after the four self-origination LSA builders that landed in #753, #754, #755, #756.

Differences from `Ospf<Ospfv2>::new`:

- **Socket.** `ospf_socket_ipv6` instead of `ospf_socket_ipv4` — same IP protocol number 89 but `Domain::IPV6` with `IPV6_V6ONLY`, multicast hops=1 (RFC 5340 §A.1), and `IPV6_RECVPKTINFO` enabled.
- **No `callback_build` / `show_build`.** The `container ospfv3` YANG stub from #759 has no Rust handlers yet, so the `callbacks` and `show_cb` maps stay empty for v3 until the v3 config plumbing lands.
- **No network read/write task spawn.** `read_packet` / `write_packet` are typed against `Message<Ospfv2>` and the v2 wire format. The v3 packet path (Hello over `ff02::5`, pseudo-header checksum, Interface-ID) is its own substantial PR. The `tx` / `ptx` channels exist; nothing drives them until then. The four `build_*_lsa` self-origination helpers can still be exercised from tests.

Behind `#[allow(dead_code)]` until `main.rs` learns to spawn an `Ospf<Ospfv3>` alongside (or in place of) the v2 instance.

With two `new` methods now visible on `Ospf`, the existing v2 spawn callsite in `config/ospf.rs` switches to the explicit turbofish `Ospf::<Ospfv2>::new` to disambiguate.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 867 passed, 0 failed
- [ ] End-to-end smoke (deferred to the PR that spawns `Ospf<Ospfv3>` from `main.rs`)

Generated with [Claude Code](https://claude.com/claude-code)