### PR TITLE
bgp: add BDD scenarios for neighbor-group inheritance

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -48,6 +48,10 @@ bgp_community:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_community"
 
+bgp_neighbor_group:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_neighbor_group"
+
 generate:
 	rm -rf allure-report
 	allure generate

--- a/bdd/tests/configs/bgp_neighbor_group/z1-1.yaml
+++ b/bdd/tests/configs/bgp_neighbor_group/z1-1.yaml
@@ -1,0 +1,16 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    neighbor-groups:
+      neighbor-group:
+      - name: RR
+        remote-as: 65002
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      neighbor-group: RR

--- a/bdd/tests/configs/bgp_neighbor_group/z1-2.yaml
+++ b/bdd/tests/configs/bgp_neighbor_group/z1-2.yaml
@@ -1,0 +1,16 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    neighbor-groups:
+      neighbor-group:
+      - name: RR
+        remote-as: 65099
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      neighbor-group: RR

--- a/bdd/tests/configs/bgp_neighbor_group/z2-1.yaml
+++ b/bdd/tests/configs/bgp_neighbor_group/z2-1.yaml
@@ -1,0 +1,12 @@
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001

--- a/bdd/tests/features/bgp_neighbor_group.feature
+++ b/bdd/tests/features/bgp_neighbor_group.feature
@@ -1,0 +1,72 @@
+@serial
+@bgp_neighbor_group
+Feature: BGP neighbor-group inheritance end-to-end
+  As a network operator
+  I want a peer that only references a neighbor-group (no per-peer remote-as)
+  to inherit the group's remote-as, establish a session, and react to
+  later changes to the group's remote-as.
+
+  This exercises the runtime path landed in PRs #758 (static-peer
+  resolver), #760 (reactive sweep on group remote-as Set/Delete), and
+  #762 (group-level delete cascade) through the full YAML/YANG/CLI
+  stack — not just the in-memory callback wiring covered by the
+  unit tests in #764.
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                   │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+  ```
+
+  Config files:
+  - z1-1.yaml: AS 65001, neighbor-group "RR" with remote-as 65002,
+    peer 192.168.0.2 references RR (no per-peer remote-as).
+  - z1-2.yaml: same shape, but RR's remote-as is 65099 (wrong) —
+    used to verify the reactive sweep tears the session down.
+  - z2-1.yaml: plain AS 65002 peer to 192.168.0.1 remote-as 65001.
+
+  Scenario: Setup topology
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+
+  Scenario: Inheritance — peer with only a neighbor-group reference establishes
+    Given the test topology exists
+    When I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+
+  Scenario: Reactive sweep — changing the group's remote-as drops the session
+    Given the test topology exists
+    When I apply config "z1-2.yaml" to namespace "z1"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should not be "Established"
+
+  Scenario: Reactive sweep — restoring the group's remote-as brings it back
+    Given the test topology exists
+    When I apply config "z1-1.yaml" to namespace "z1"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

Closes out the neighbor-group v1 series (#758 / #760 / #762 / #764 / #766) with end-to-end coverage through the full YAML/YANG/CLI/TCP stack — the existing unit + callback-wiring tests only exercise the in-memory callback flow.

Three scenarios on the standard two-namespace bridge topology:
- **Inheritance** — a peer that only references `neighbor-group RR` (no per-peer remote-as) establishes a session, proving the resolver pulled the asn off the group and reached the FSM through the YAML load path.
- **Reactive change** — flipping the group's `remote-as` to a wrong value drops the session, proving `sweep_peers_for_group` mutates a live peer and the rebounce reaches the FSM via `Event::Stop`.
- **Restore** — flipping the group's `remote-as` back brings the session back, proving the same sweep adopts on the next change.

No new step expressions or Rust code — reuses `BGP session in {ns} to {addr} should [not] be {state}`.

Files:
- `bdd/tests/features/bgp_neighbor_group.feature`
- `bdd/tests/configs/bgp_neighbor_group/{z1-1,z1-2,z2-1}.yaml`
- `bdd/Makefile` — adds the `bgp_neighbor_group` target.

## Test plan

- [x] Cucumber harness still compiles (`cd bdd && cargo test --test cucumber --no-run`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] Local run (needs root + netns; CI excludes BDD): `cd bdd && make bgp_neighbor_group`

Generated with [Claude Code](https://claude.com/claude-code)