### PR TITLE
ospf: spawn v3 read/write loops from Ospf<Ospfv3>::new

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -78,6 +78,18 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     pub segment_routing: super::srmpls::SegmentRoutingMode,
     pub spf_last: Option<Instant>,
     pub spf_duration: Option<Duration>,
+    /// v3-only outbound packet channel. `Ospf<Ospfv3>::new` spawns
+    /// `network_v6::write_packet_v6` consuming the matching receiver;
+    /// producers of v3 outgoing packets (the v3 IFSM/NFSM, once they
+    /// land) clone this sender to push packets. `None` on v2.
+    #[allow(dead_code)]
+    pub v3_send_tx: Option<UnboundedSender<super::network_v6::Ospfv3Send>>,
+    /// v3-only inbound packet channel. `Ospf<Ospfv3>::new` spawns
+    /// `network_v6::read_packet_v6` producing into the matching
+    /// sender; the v3 serve loop (once it lands) will `take()` this
+    /// receiver. `None` on v2.
+    #[allow(dead_code)]
+    pub v3_recv_rx: Option<UnboundedReceiver<super::network_v6::Ospfv3Recv>>,
 }
 
 // OSPF inteface structure which points out upper layer struct members.
@@ -204,6 +216,8 @@ impl Ospf<Ospfv2> {
             spf_last: None,
             spf_duration: None,
             sock,
+            v3_send_tx: None,
+            v3_recv_rx: None,
         };
         ospf.callback_build();
         ospf.show_build();
@@ -1393,11 +1407,13 @@ impl Ospf<Ospfv3> {
     ///   empty for v3 until the v3 config plumbing lands.
     /// - **No network read/write task spawn.** The v2 path uses
     ///   `read_packet` / `write_packet`, which are typed against
-    ///   `Message<Ospfv2>` and the v2 wire format. The v3 packet
-    ///   path is its own substantial PR (Hello over `ff02::5`,
-    ///   pseudo-header checksum, Interface-ID handling); until it
-    ///   lands the `tx` / `ptx` channels exist but nothing drives
-    ///   them. The four `build_*_lsa` self-origination helpers
+    ///   `Message<Ospfv2>` and the v2 wire format. The v3 wire path
+    ///   uses `network_v6::{read_packet_v6, write_packet_v6}` —
+    ///   spawned here, but the channels they drive are not yet
+    ///   bridged into `Message<Ospfv3>` events. Until the v3 IFSM /
+    ///   NFSM lands the rx side just buffers; producers will clone
+    ///   `v3_send_tx` to push outgoing packets through the v6
+    ///   socket. The four `build_*_lsa` self-origination helpers
     ///   above can still be exercised from tests.
     ///
     /// Behind `#[allow(dead_code)]` until `main.rs` learns to spawn
@@ -1407,6 +1423,29 @@ impl Ospf<Ospfv3> {
 
         let (tx, rx) = mpsc::unbounded_channel();
         let (ptx, _prx) = mpsc::unbounded_channel();
+
+        // v3 raw-IPv6 packet path. `read_packet_v6` recvmsg's,
+        // verifies the RFC 5340 §4.4 pseudo-header checksum, parses
+        // `Ospfv3Packet`, and pushes `Ospfv3Recv` items. `write_packet_v6`
+        // consumes `Ospfv3Send` items, stamps the checksum using the
+        // supplied (src, dst) v6, and sendmsg's with an `in6_pktinfo`
+        // ancillary so the kernel emits from the chosen ifindex /
+        // link-local source.
+        let (v3_send_tx, v3_send_rx) = mpsc::unbounded_channel();
+        let (v3_recv_tx, v3_recv_rx) = mpsc::unbounded_channel();
+        {
+            let sock = sock.clone();
+            tokio::spawn(async move {
+                super::network_v6::read_packet_v6(sock, v3_recv_tx).await;
+            });
+        }
+        {
+            let sock = sock.clone();
+            tokio::spawn(async move {
+                super::network_v6::write_packet_v6(sock, v3_send_rx).await;
+            });
+        }
+
         Self {
             tx,
             rx,
@@ -1430,6 +1469,8 @@ impl Ospf<Ospfv3> {
             spf_last: None,
             spf_duration: None,
             sock,
+            v3_send_tx: Some(v3_send_tx),
+            v3_recv_rx: Some(v3_recv_rx),
         }
     }
 

--- a/zebra-rs/src/ospf/network_v6.rs
+++ b/zebra-rs/src/ospf/network_v6.rs
@@ -9,9 +9,9 @@
 //! `in6_pktinfo` ancillary message so the kernel uses the egress
 //! interface we picked instead of doing a fresh route lookup.
 //!
-//! These tasks are dormant until the `Ospf<Ospfv3>` instance type
-//! (Phase 6) spawns them — every public item carries
-//! `#[allow(dead_code)]` for now.
+//! Spawned by `Ospf<Ospfv3>::new` (see `ospf::inst`). The channels
+//! they drive are stored on the v3 instance as `v3_send_tx` /
+//! `v3_recv_rx`; consumers / producers wire up as the v3 FSM lands.
 
 use std::io::{ErrorKind, IoSlice, IoSliceMut};
 use std::net::Ipv6Addr;
@@ -36,7 +36,6 @@ use ospf_packet::{Ospfv3Packet, ospfv3_verify_checksum, parse_v3};
 /// address; the IPv6 pseudo-header checksum (RFC 5340 §4.4) folds
 /// it in, so the receiver's verify will fail if this doesn't
 /// match what the kernel ends up putting in the IPv6 header.
-#[allow(dead_code)]
 #[derive(Debug)]
 pub struct Ospfv3Send {
     pub packet: Ospfv3Packet,
@@ -67,7 +66,6 @@ pub struct Ospfv3Recv {
 /// IPv6 raw sockets (unlike v4) deliver the OSPF payload directly
 /// — the kernel strips the IPv6 header on receive — so there's no
 /// `IPV4_HEADER_LEN` skip to mirror.
-#[allow(dead_code)]
 pub async fn read_packet_v6(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Ospfv3Recv>) {
     let mut buf = [0u8; 1024 * 16];
     let mut iov = [IoSliceMut::new(&mut buf)];
@@ -131,7 +129,6 @@ pub async fn read_packet_v6(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Ospf
 /// Long-lived send loop for the v3 socket. Consumes `Ospfv3Send`
 /// items from `rx` and pushes them onto the wire with the IPv6
 /// pseudo-header checksum stamped in.
-#[allow(dead_code)]
 pub async fn write_packet_v6(sock: Arc<AsyncFd<Socket>>, mut rx: UnboundedReceiver<Ospfv3Send>) {
     while let Some(item) = rx.recv().await {
         let Ospfv3Send {


### PR DESCRIPTION
## Summary

`network_v6.rs` already had `read_packet_v6` and `write_packet_v6` — the v3 analogues of v2's network loops (recvmsg with `IPV6_RECVPKTINFO`, pseudo-header checksum verify/stamp per RFC 5340 §4.4, sendmsg with `in6_pktinfo` so the kernel emits from the chosen ifindex / link-local source). They were dead-code stubs waiting on a spawn.

This PR hooks them up:

- `Ospf<Ospfv3>::new` creates `(send_tx, send_rx)` and `(recv_tx, recv_rx)` channels (`Ospfv3Send` / `Ospfv3Recv`), `tokio::spawn`s the two loops, and stores `send_tx` + `recv_rx` on the instance.
- Two new fields on `Ospf<V>`, both `Option<>`:
  - `v3_send_tx: Option<UnboundedSender<Ospfv3Send>>` — `None` on v2; producers of outgoing v3 packets (v3 IFSM/NFSM, when they land) will clone this.
  - `v3_recv_rx: Option<UnboundedReceiver<Ospfv3Recv>>` — `None` on v2; the v3 serve loop will `take()` this.
- Drops `#[allow(dead_code)]` from `read_packet_v6`, `write_packet_v6`, and `Ospfv3Send` (now reachable). Keeps it on `Ospfv3Recv` and on the two new fields until bridging lands.

The receiver currently has no consumer, so received packets sit in the `Ospfv3Recv` queue. The sender currently has no producer either, so the write loop just blocks. Once the v3 FSM is in place those connect; until then the wire path is end-to-end ready.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace` — verified by CI

Generated with [Claude Code](https://claude.com/claude-code)