### PR TITLE
ospf: document IFSM/NFSM enums as v2/v3-shared

### DIFF
--- a/zebra-rs/src/ospf/ifsm.rs
+++ b/zebra-rs/src/ospf/ifsm.rs
@@ -6,7 +6,18 @@ use crate::ospf::socket::{ospf_join_alldrouters, ospf_join_if, ospf_leave_alldro
 use super::task::{Timer, TimerType};
 use super::{Identity, Message, NfsmEvent, NfsmState, OspfLink};
 
-// Interface state machine.
+/// Interface state machine state — RFC 2328 §9.1.
+///
+/// **Shared across OSPFv2 and OSPFv3.** RFC 5340 §4.2.1 states that
+/// the OSPFv3 IFSM "is essentially the same as the OSPFv2 [Interface
+/// state machine]", reusing this exact state taxonomy. No v3-specific
+/// state variants are needed; the enum and its Display impl are
+/// version-agnostic.
+///
+/// `Loopback` and `Point-to-Point` from the RFC are intentionally
+/// elided — zebra-rs does not yet support loopback interfaces in
+/// OSPF nor non-broadcast point-to-point links; both will be added
+/// when the corresponding wiring lands.
 #[derive(Debug, Default, PartialEq, PartialOrd, Eq, Clone, Copy)]
 pub enum IfsmState {
     #[default]
@@ -31,6 +42,11 @@ impl Display for IfsmState {
     }
 }
 
+/// Interface state machine event — RFC 2328 §9.2.
+///
+/// **Shared across OSPFv2 and OSPFv3.** RFC 5340 §4.2.1 reuses the
+/// same event taxonomy. Loopback-related events (`LoopInd`, `UnloopInd`)
+/// are omitted along with the corresponding state (see `IfsmState`).
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum IfsmEvent {
     InterfaceUp,

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -11,6 +11,16 @@ use super::{
     ospf_ls_req_send, ospf_ls_request_isempty, tracing::FsmType,
 };
 
+/// Neighbor state machine state — RFC 2328 §10.1.
+///
+/// **Shared across OSPFv2 and OSPFv3.** RFC 5340 §4.2.2 states that
+/// "the Neighbor state machine for OSPFv3 is exactly the same as the
+/// OSPFv2 Neighbor state machine (Section 10.3 of [OSPFV2])". This
+/// enum and its Display impl carry no version-specific data and are
+/// reused directly by `Neighbor<V>` for any `V: OspfVersion`.
+///
+/// `Attempt` from the RFC is intentionally elided — zebra-rs does
+/// not yet implement NBMA networks where it would apply.
 #[derive(Debug, PartialEq, PartialOrd, Eq, Clone, Copy)]
 pub enum NfsmState {
     Down,
@@ -38,6 +48,12 @@ impl Display for NfsmState {
     }
 }
 
+/// Neighbor state machine event — RFC 2328 §10.2.
+///
+/// **Shared across OSPFv2 and OSPFv3.** Same as `NfsmState`, the v3
+/// RFC reuses the v2 event taxonomy verbatim. `KillNbr` and
+/// `LLDown` from the RFC are folded into normal transition handling
+/// where applicable; `Start` (NBMA-only) is omitted.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum NfsmEvent {
     HelloReceived,


### PR DESCRIPTION
## Summary

RFC 5340 makes the OSPFv3 IFSM and NFSM explicitly identical to v2:

- §4.2.1: the v3 IFSM is "essentially the same as the OSPFv2 [Interface state machine]"
- §4.2.2: the v3 NFSM is "exactly the same as the OSPFv2 Neighbor state machine (Section 10.3 of [OSPFV2])"

The corresponding enums in zebra-rs (`IfsmState` / `IfsmEvent` / `NfsmState` / `NfsmEvent` plus their Display impls) already carry no version-specific data — they'll be reused unchanged by `Neighbor<Ospfv3>` and `OspfLink<Ospfv3>` once the FSM handler functions follow.

This PR adds Rust doc comments stating that contract, citing both RFCs, and noting the variants intentionally elided in zebra-rs (Loopback / Point-to-Point for IFSM; Attempt / NBMA-only events for NFSM).

No functional change. Doc-only. Confirms the v3 FSM work doesn't need to fork these enums — the next IFSM/NFSM PR can genericize the handler functions over `V` and keep using these enums as-is.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace` — verified by CI

Generated with [Claude Code](https://claude.com/claude-code)