### PR TITLE
ospf: genericize IFSM functions over V: OspfVersion

### DIFF
--- a/zebra-rs/src/ospf/ident.rs
+++ b/zebra-rs/src/ospf/ident.rs
@@ -42,23 +42,9 @@ where
     }
 }
 
-impl Identity<Ospfv2> {
-    /// True iff this identity considers itself the DR on its link
-    /// (v2 semantics: `d_router` is the DR's interface IP, which
-    /// matches our own when we won the election).
-    ///
-    /// v2-only because v3 stores router-ids in `d_router` per
-    /// RFC 5340 §A.3.2; the equivalent check there compares
-    /// `d_router` against `self.router_id`, not `prefix.addr()`.
-    /// The v3 variant lands when an `Identity<Ospfv3>` consumer
-    /// needs it.
-    pub fn is_declared_dr(&self) -> bool {
-        self.prefix.addr() == self.d_router
-    }
-
-    /// True iff this identity considers itself the BDR. v2-only
-    /// for the same reason as [`Self::is_declared_dr`].
-    pub fn is_declared_bdr(&self) -> bool {
-        self.prefix.addr() == self.bd_router
-    }
-}
+// Note: the v2-bound `is_declared_dr` / `is_declared_bdr` inherent
+// methods were replaced by `OspfVersion::is_declared_dr` /
+// `OspfVersion::is_declared_bdr` static methods in `version.rs`.
+// The trait accessors carry v3 semantics too (router-id comparison
+// per RFC 5340 §A.3.2) and are how the generic IFSM reaches the
+// DR / BDR predicates.

--- a/zebra-rs/src/ospf/ifsm.rs
+++ b/zebra-rs/src/ospf/ifsm.rs
@@ -1,9 +1,8 @@
 use std::fmt::Display;
 use std::net::Ipv4Addr;
 
-use crate::ospf::socket::{ospf_join_alldrouters, ospf_join_if, ospf_leave_alldrouters};
-
 use super::task::{Timer, TimerType};
+use super::version::OspfVersion;
 use super::{Identity, Message, NfsmEvent, NfsmState, OspfLink};
 
 /// Interface state machine state — RFC 2328 §9.1.
@@ -56,10 +55,10 @@ pub enum IfsmEvent {
     InterfaceDown,
 }
 
-pub type IfsmFunc = fn(&mut OspfLink) -> Option<IfsmState>;
+pub type IfsmFunc<V> = fn(&mut OspfLink<V>) -> Option<IfsmState>;
 
 impl IfsmState {
-    pub fn fsm(&self, ev: IfsmEvent) -> (IfsmFunc, Option<Self>) {
+    pub fn fsm<V: OspfVersion>(&self, ev: IfsmEvent) -> (IfsmFunc<V>, Option<Self>) {
         use IfsmEvent::*;
         use IfsmState::*;
         match self {
@@ -102,22 +101,22 @@ impl IfsmState {
     }
 }
 
-fn ospf_ifsm_state(oi: &OspfLink) -> IfsmState {
+fn ospf_ifsm_state<V: OspfVersion>(oi: &OspfLink<V>) -> IfsmState {
     use IfsmState::*;
-    if oi.ident.is_declared_dr() {
+    if V::is_declared_dr(&oi.ident) {
         DR
-    } else if oi.ident.is_declared_bdr() {
+    } else if V::is_declared_bdr(&oi.ident) {
         Backup
     } else {
         DROther
     }
 }
 
-pub fn ospf_ifsm_ignore(_oi: &mut OspfLink) -> Option<IfsmState> {
+pub fn ospf_ifsm_ignore<V: OspfVersion>(_oi: &mut OspfLink<V>) -> Option<IfsmState> {
     None
 }
 
-pub fn ospf_hello_timer(oi: &OspfLink) -> Timer {
+pub fn ospf_hello_timer<V: OspfVersion>(oi: &OspfLink<V>) -> Timer {
     let tx = oi.tx.clone();
     let index = oi.index;
     let timer: u64 = oi.hello_interval().into();
@@ -129,7 +128,7 @@ pub fn ospf_hello_timer(oi: &OspfLink) -> Timer {
     })
 }
 
-pub fn ospf_wait_timer(oi: &OspfLink) -> Timer {
+pub fn ospf_wait_timer<V: OspfVersion>(oi: &OspfLink<V>) -> Timer {
     let tx = oi.tx.clone();
     let index = oi.index;
     Timer::new(
@@ -144,15 +143,12 @@ pub fn ospf_wait_timer(oi: &OspfLink) -> Timer {
     )
 }
 
-pub fn ospf_ifsm_interface_up(link: &mut OspfLink) -> Option<IfsmState> {
-    // println!("ospf_ifsm_interface_up");
+pub fn ospf_ifsm_interface_up<V: OspfVersion>(link: &mut OspfLink<V>) -> Option<IfsmState> {
     if link.addr.is_empty() {
-        // println!("link addr is empty");
         return None;
     }
 
-    // println!("ospf_join_if index {}", link.index);
-    ospf_join_if(&link.sock, link.index);
+    V::join_if(&link.sock, link.index);
     link.multicast_memberships.set_all_routers(true);
 
     // Comment out until we support pointopoint interface.
@@ -167,7 +163,7 @@ pub fn ospf_ifsm_interface_up(link: &mut OspfLink) -> Option<IfsmState> {
     }
 }
 
-pub fn ospf_ifsm_interface_down(oi: &mut OspfLink) -> Option<IfsmState> {
+pub fn ospf_ifsm_interface_down<V: OspfVersion>(oi: &mut OspfLink<V>) -> Option<IfsmState> {
     // Kill all neighbors.
     for nbr in oi.nbrs.values_mut() {
         super::nfsm::ospf_nfsm_reset_nbr(nbr);
@@ -189,8 +185,8 @@ pub fn ospf_ifsm_interface_down(oi: &mut OspfLink) -> Option<IfsmState> {
     None
 }
 
-fn ospf_dr_election_init(oi: &OspfLink) -> Vec<Identity> {
-    let mut v: Vec<Identity> = oi
+fn ospf_dr_election_init<V: OspfVersion>(oi: &OspfLink<V>) -> Vec<Identity<V>> {
+    let mut v: Vec<Identity<V>> = oi
         .nbrs
         .values()
         .filter(|nbr| nbr.state >= NfsmState::TwoWay)
@@ -205,7 +201,7 @@ fn ospf_dr_election_init(oi: &OspfLink) -> Vec<Identity> {
     v
 }
 
-pub fn ospf_dr_election_tiebreak(v: Vec<Identity>) -> Option<Identity> {
+pub fn ospf_dr_election_tiebreak<V: OspfVersion>(v: Vec<Identity<V>>) -> Option<Identity<V>> {
     v.into_iter().max_by(|a, b| {
         a.priority
             .cmp(&b.priority)
@@ -213,15 +209,15 @@ pub fn ospf_dr_election_tiebreak(v: Vec<Identity>) -> Option<Identity> {
     })
 }
 
-pub fn ospf_dr_election_dr(
-    oi: &mut OspfLink,
-    bdr: Option<Identity>,
-    v: Vec<Identity>,
-) -> Option<Identity> {
+pub fn ospf_dr_election_dr<V: OspfVersion>(
+    oi: &mut OspfLink<V>,
+    bdr: Option<Identity<V>>,
+    v: Vec<Identity<V>>,
+) -> Option<Identity<V>> {
     let _dr_candidates: Vec<_> = v
         .clone()
         .into_iter()
-        .filter(|ident| ident.is_declared_dr())
+        .filter(|ident| V::is_declared_dr(ident))
         .collect();
 
     let mut dr = ospf_dr_election_tiebreak(v);
@@ -231,21 +227,24 @@ pub fn ospf_dr_election_dr(
     }
 
     if let Some(ident) = dr {
-        oi.ident.d_router = ident.prefix.addr();
+        oi.ident.d_router = V::ident_dr_id(&ident);
     } else {
         oi.ident.d_router = Ipv4Addr::UNSPECIFIED;
     }
     dr
 }
 
-pub fn ospf_dr_election_bdr(oi: &mut OspfLink, v: Vec<Identity>) -> Option<Identity> {
+pub fn ospf_dr_election_bdr<V: OspfVersion>(
+    oi: &mut OspfLink<V>,
+    v: Vec<Identity<V>>,
+) -> Option<Identity<V>> {
     let non_dr_candidates: Vec<_> = v
         .into_iter()
-        .filter(|ident| !ident.is_declared_dr())
+        .filter(|ident| !V::is_declared_dr(ident))
         .collect();
     let bdr_candidates: Vec<_> = non_dr_candidates
         .iter()
-        .filter(|ident| ident.is_declared_bdr())
+        .filter(|ident| V::is_declared_bdr(ident))
         .cloned()
         .collect();
 
@@ -256,7 +255,7 @@ pub fn ospf_dr_election_bdr(oi: &mut OspfLink, v: Vec<Identity>) -> Option<Ident
     };
 
     if let Some(ident) = bdr {
-        oi.ident.bd_router = ident.prefix.addr();
+        oi.ident.bd_router = V::ident_dr_id(&ident);
     } else {
         oi.ident.bd_router = Ipv4Addr::UNSPECIFIED;
     }
@@ -264,7 +263,7 @@ pub fn ospf_dr_election_bdr(oi: &mut OspfLink, v: Vec<Identity>) -> Option<Ident
     bdr
 }
 
-fn ospf_dr_election_dr_change(oi: &mut OspfLink) {
+fn ospf_dr_election_dr_change<V: OspfVersion>(oi: &mut OspfLink<V>) {
     for (addr, nbr) in oi.nbrs.iter() {
         if !nbr.ident.router_id.is_unspecified() && nbr.state >= NfsmState::TwoWay {
             oi.tx
@@ -274,17 +273,12 @@ fn ospf_dr_election_dr_change(oi: &mut OspfLink) {
     }
 }
 
-fn ospf_dr_election(oi: &mut OspfLink) -> Option<IfsmState> {
-    // println!("== DR election! ==");
-
+fn ospf_dr_election<V: OspfVersion>(oi: &mut OspfLink<V>) -> Option<IfsmState> {
     let prev_dr = oi.ident.d_router;
     let prev_bdr = oi.ident.bd_router;
     let prev_state = oi.state;
 
     let v = ospf_dr_election_init(oi);
-    // for i in v.iter() {
-    //     println!("{:?}", i);
-    // }
     let bdr = ospf_dr_election_bdr(oi, v.clone());
     ospf_dr_election_dr(oi, bdr, v.clone());
     let mut new_state = ospf_ifsm_state(oi);
@@ -313,12 +307,12 @@ fn ospf_dr_election(oi: &mut OspfLink) -> Option<IfsmState> {
         if (prev_state != IfsmState::DR && prev_state != IfsmState::Backup)
             && (new_state == IfsmState::DR || new_state == IfsmState::Backup)
         {
-            ospf_join_alldrouters(&oi.sock, oi.index);
+            V::join_alldrouters(&oi.sock, oi.index);
             oi.multicast_memberships.set_all_drouters(true);
         } else if (prev_state == IfsmState::DR || prev_state == IfsmState::Backup)
             && (new_state != IfsmState::DR && new_state != IfsmState::Backup)
         {
-            ospf_leave_alldrouters(&oi.sock, oi.index);
+            V::leave_alldrouters(&oi.sock, oi.index);
             oi.multicast_memberships.set_all_drouters(false);
         }
     }
@@ -326,22 +320,19 @@ fn ospf_dr_election(oi: &mut OspfLink) -> Option<IfsmState> {
     Some(new_state)
 }
 
-fn ospf_ifsm_wait_timer(oi: &mut OspfLink) -> Option<IfsmState> {
-    // println!("ospf_ifsm_wait_timer");
+fn ospf_ifsm_wait_timer<V: OspfVersion>(oi: &mut OspfLink<V>) -> Option<IfsmState> {
     ospf_dr_election(oi)
 }
 
-fn ospf_ifsm_backup_seen(oi: &mut OspfLink) -> Option<IfsmState> {
-    // println!("ospf_ifsm_backup_seen");
+fn ospf_ifsm_backup_seen<V: OspfVersion>(oi: &mut OspfLink<V>) -> Option<IfsmState> {
     ospf_dr_election(oi)
 }
 
-fn ospf_ifsm_neighbor_change(oi: &mut OspfLink) -> Option<IfsmState> {
-    // println!("ospf_ifsm_neighbor_change");
+fn ospf_ifsm_neighbor_change<V: OspfVersion>(oi: &mut OspfLink<V>) -> Option<IfsmState> {
     ospf_dr_election(oi)
 }
 
-fn ospf_ifsm_timer_set(oi: &mut OspfLink) {
+fn ospf_ifsm_timer_set<V: OspfVersion>(oi: &mut OspfLink<V>) {
     use IfsmState::*;
     match oi.state {
         Down => {
@@ -362,7 +353,7 @@ fn ospf_ifsm_timer_set(oi: &mut OspfLink) {
     }
 }
 
-fn ospf_ifsm_change_state(oi: &mut OspfLink, state: IfsmState) {
+fn ospf_ifsm_change_state<V: OspfVersion>(oi: &mut OspfLink<V>, state: IfsmState) {
     oi.ostate = oi.state;
     oi.state = state;
     oi.state_change += 1;
@@ -376,7 +367,7 @@ fn ospf_ifsm_change_state(oi: &mut OspfLink, state: IfsmState) {
     }
 }
 
-pub fn ospf_ifsm(oi: &mut OspfLink, event: IfsmEvent) {
+pub fn ospf_ifsm<V: OspfVersion>(oi: &mut OspfLink<V>, event: IfsmEvent) {
     // Decompose the result of the state function into the transition function
     // and next state.
     let (fsm_func, fsm_next_state) = oi.state.fsm(event);

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -272,7 +272,7 @@ impl Ospf<Ospfv2> {
         if link.state == IfsmState::Waiting || link.full_nbr_count == 0 {
             return false;
         }
-        if link.ident.is_declared_dr() {
+        if Ospfv2::is_declared_dr(&link.ident) {
             return true;
         }
         if let Some(dr_nbr) = link.nbrs.get(&link.ident.d_router) {
@@ -827,7 +827,7 @@ impl Ospf<Ospfv2> {
             }
             for addr in link.addr.iter() {
                 if addr.prefix.addr() == ls_id {
-                    return link.ident.is_declared_dr();
+                    return Ospfv2::is_declared_dr(&link.ident);
                 }
             }
         }

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -187,7 +187,7 @@ pub fn ospf_db_summary_isempty(nbr: &Neighbor) -> bool {
     nbr.db_sum.is_empty()
 }
 
-pub fn ospf_nfsm_reset_nbr(nbr: &mut Neighbor) {
+pub fn ospf_nfsm_reset_nbr<V: super::version::OspfVersion>(nbr: &mut Neighbor<V>) {
     // Clear Database Summary list.
     nbr.db_sum.clear();
 

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -33,7 +33,7 @@ use ospf_packet::{
 /// default on the trait. The well-known multicast groups
 /// (AllSPFRouters / AllDRouters) and the address family itself are
 /// what actually differs.
-pub trait OspfVersion: 'static + Send + Sync + Copy + Clone {
+pub trait OspfVersion: 'static + Send + Sync + Copy + Clone + PartialEq + Eq {
     /// Address type used on the wire and for L3 source / destination.
     /// `Ipv4Addr` for v2, `Ipv6Addr` for v3. Router-id and area-id
     /// stay 32-bit in both versions and live separately as `Ipv4Addr`
@@ -204,6 +204,54 @@ pub trait OspfVersion: 'static + Send + Sync + Copy + Clone {
     fn nbr_addr(ident: &crate::ospf::Identity<Self>) -> Ipv4Addr
     where
         Self: Sized;
+
+    // ---- IFSM trait accessors ----------------------------------
+    //
+    // The IFSM is shared verbatim across v2 and v3 (RFC 5340 §4.2.1),
+    // but two pieces of its body are version-specific: DR / BDR
+    // identity (interface IP vs. router-id per RFC 5340 §A.3.2) and
+    // the multicast group joins on the underlying raw socket (v4
+    // groups via `IP_ADD_MEMBERSHIP` vs. v6 groups via
+    // `IPV6_JOIN_GROUP`). The accessors below are how the generic
+    // IFSM in `ifsm.rs` reaches each.
+
+    /// True iff `ident` considers itself the DR on its link.
+    ///
+    /// - v2 (RFC 2328 §9.4): `d_router` holds the DR's interface
+    ///   IP; we're the DR when that matches `prefix.addr()`.
+    /// - v3 (RFC 5340 §A.3.2): `d_router` holds the DR's router-id;
+    ///   we're the DR when that matches `router_id`.
+    fn is_declared_dr(ident: &crate::ospf::Identity<Self>) -> bool
+    where
+        Self: Sized;
+
+    /// True iff `ident` considers itself the BDR. Mirrors
+    /// `is_declared_dr` for the backup election.
+    fn is_declared_bdr(ident: &crate::ospf::Identity<Self>) -> bool
+    where
+        Self: Sized;
+
+    /// The 32-bit value to store in `Identity::d_router` /
+    /// `Identity::bd_router` after election picks `ident`.
+    ///
+    /// - v2: the elected router's interface IP (`prefix.addr()`).
+    /// - v3: the elected router's router-id.
+    fn ident_dr_id(ident: &crate::ospf::Identity<Self>) -> Ipv4Addr
+    where
+        Self: Sized;
+
+    /// Join the version's AllSPFRouters multicast group on the
+    /// raw socket scoped to the given interface. Called when the
+    /// IFSM moves an interface out of `Down`.
+    fn join_if(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32);
+
+    /// Join the version's AllDRouters multicast group. Called by
+    /// DR-election state changes when this router becomes DR or BDR.
+    fn join_alldrouters(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32);
+
+    /// Leave the AllDRouters group. Called when this router moves
+    /// out of DR / BDR back to DROther.
+    fn leave_alldrouters(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32);
 }
 
 /// OSPFv2 dispatch marker (RFC 2328).
@@ -273,6 +321,25 @@ impl OspfVersion for Ospfv2 {
     }
     fn nbr_addr(ident: &crate::ospf::Identity<Ospfv2>) -> Ipv4Addr {
         ident.prefix.addr()
+    }
+
+    fn is_declared_dr(ident: &crate::ospf::Identity<Ospfv2>) -> bool {
+        ident.prefix.addr() == ident.d_router
+    }
+    fn is_declared_bdr(ident: &crate::ospf::Identity<Ospfv2>) -> bool {
+        ident.prefix.addr() == ident.bd_router
+    }
+    fn ident_dr_id(ident: &crate::ospf::Identity<Ospfv2>) -> Ipv4Addr {
+        ident.prefix.addr()
+    }
+    fn join_if(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32) {
+        crate::ospf::socket::ospf_join_if(sock, ifindex);
+    }
+    fn join_alldrouters(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32) {
+        crate::ospf::socket::ospf_join_alldrouters(sock, ifindex);
+    }
+    fn leave_alldrouters(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32) {
+        crate::ospf::socket::ospf_leave_alldrouters(sock, ifindex);
     }
 }
 
@@ -349,5 +416,24 @@ impl OspfVersion for Ospfv3 {
     }
     fn nbr_addr(ident: &crate::ospf::Identity<Ospfv3>) -> Ipv4Addr {
         ident.router_id
+    }
+
+    fn is_declared_dr(ident: &crate::ospf::Identity<Ospfv3>) -> bool {
+        ident.d_router == ident.router_id
+    }
+    fn is_declared_bdr(ident: &crate::ospf::Identity<Ospfv3>) -> bool {
+        ident.bd_router == ident.router_id
+    }
+    fn ident_dr_id(ident: &crate::ospf::Identity<Ospfv3>) -> Ipv4Addr {
+        ident.router_id
+    }
+    fn join_if(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32) {
+        crate::ospf::socket::ospf_join_if_v6(sock, ifindex);
+    }
+    fn join_alldrouters(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32) {
+        crate::ospf::socket::ospf_join_alldrouters_v6(sock, ifindex);
+    }
+    fn leave_alldrouters(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32) {
+        crate::ospf::socket::ospf_leave_alldrouters_v6(sock, ifindex);
     }
 }


### PR DESCRIPTION
## Summary

RFC 5340 §4.2.1 says the v3 IFSM "is essentially the same as the OSPFv2 [Interface state machine]" — same states, same events, same transitions. This PR lifts the v2-only IFSM in `ifsm.rs` to be generic over `V: OspfVersion` so an `Ospf<Ospfv3>` instance can drive its own IFSM with the same code path.

Two pieces of the IFSM body are genuinely version-specific:

- **DR / BDR identity.** v2 stores the elected DR's interface IP in `Identity::d_router`; v3 stores its router-id (RFC 5340 §A.3.2). Three new `OspfVersion` trait methods route this:
  - `is_declared_dr(&Identity<Self>) -> bool`
  - `is_declared_bdr(&Identity<Self>) -> bool`
  - `ident_dr_id(&Identity<Self>) -> Ipv4Addr`

  v2 impls keep the existing `prefix.addr()` semantics; v3 impls use `router_id`.

- **Multicast group joins on the raw socket.** v2 uses `IP_ADD_MEMBERSHIP` for 224.0.0.5 / 224.0.0.6; v3 uses `IPV6_JOIN_GROUP` for ff02::5 / ff02::6. Three new trait methods route this:
  - `join_if(&AsyncFd<Socket>, u32)`
  - `join_alldrouters(&AsyncFd<Socket>, u32)`
  - `leave_alldrouters(&AsyncFd<Socket>, u32)`

  v2 wires to the existing `ospf_join_*` helpers in `socket.rs`; v3 wires to the `_v6` siblings already there from the Phase 5 socket work.

All `ospf_ifsm_*` functions now take `&mut OspfLink<V>`; `IfsmFunc` becomes `IfsmFunc<V>`; `IfsmState::fsm` takes `<V>`. DR-election helpers (`ospf_dr_election_*`) similarly genericize over `Identity<V>`.

### Side fixes

- `OspfVersion` trait now has `PartialEq + Eq` bounds so derived `PartialEq` on `Identity<V>` resolves — needed for `bdr == dr` comparison in the DR second-pass. Both `Ospfv2` and `Ospfv3` already derived these.
- `ospf_nfsm_reset_nbr` (called from `ospf_ifsm_interface_down`) bumped to `<V: OspfVersion>(nbr: &mut Neighbor<V>)`. The rest of nfsm.rs stays v2-bound and will follow in its own PR.
- Two callers in `inst.rs::link_has_transit_adjacency` switch from `link.ident.is_declared_dr()` to `Ospfv2::is_declared_dr(&link.ident)` (both live in `impl Ospf<Ospfv2>`).
- Redundant v2-only inherent methods on `Identity<Ospfv2>` are removed in favour of the trait surface.

NFSM genericization follows in a separate PR (~559 lines, larger surface).

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 872 passed, 0 failed

Generated with [Claude Code](https://claude.com/claude-code)