### PR TITLE
ospf: genericize NFSM functions over V: OspfVersion

### DIFF
--- a/zebra-rs/src/ospf/flood.rs
+++ b/zebra-rs/src/ospf/flood.rs
@@ -32,7 +32,7 @@ pub fn lsa_flood_scope(ls_type: OspfLsType) -> FloodScope {
     }
 }
 
-pub fn ospf_ls_request_isempty(nbr: &Neighbor) -> bool {
+pub fn ospf_ls_request_isempty<V: super::version::OspfVersion>(nbr: &Neighbor<V>) -> bool {
     nbr.ls_req.is_empty()
 }
 

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -4,11 +4,10 @@ use ospf_packet::*;
 use rand::RngExt;
 use tokio::time::Instant;
 
-use crate::ospf::ospf_db_desc_send;
-
+use super::version::{OspfVersion, Ospfv2};
 use super::{
     Identity, IfsmEvent, Message, Neighbor, Timer, TimerType, inst::OspfInterface,
-    ospf_ls_req_send, ospf_ls_request_isempty, tracing::FsmType,
+    ospf_ls_request_isempty, tracing::FsmType,
 };
 
 /// Neighbor state machine state — RFC 2328 §10.1.
@@ -87,10 +86,14 @@ impl Display for NfsmEvent {
     }
 }
 
-pub type NfsmFunc = fn(&mut OspfInterface, &mut Neighbor, &Identity) -> Option<NfsmState>;
+pub type NfsmFunc<V> =
+    fn(&mut OspfInterface<V>, &mut Neighbor<V>, &Identity<V>) -> Option<NfsmState>;
 
 impl NfsmState {
-    pub fn fsm(&self, ev: NfsmEvent) -> (NfsmFunc, Option<Self>) {
+    pub fn fsm<V: super::version::OspfVersion>(
+        &self,
+        ev: NfsmEvent,
+    ) -> (NfsmFunc<V>, Option<Self>) {
         use NfsmEvent::*;
         use NfsmState::*;
 
@@ -183,7 +186,7 @@ impl NfsmState {
     }
 }
 
-pub fn ospf_db_summary_isempty(nbr: &Neighbor) -> bool {
+pub fn ospf_db_summary_isempty<V: OspfVersion>(nbr: &Neighbor<V>) -> bool {
     nbr.db_sum.is_empty()
 }
 
@@ -210,7 +213,7 @@ pub fn ospf_nfsm_reset_nbr<V: super::version::OspfVersion>(nbr: &mut Neighbor<V>
     nbr.timer.ls_rxmt = None;
 }
 
-pub fn ospf_nfsm_timer_set(nbr: &mut Neighbor) {
+pub fn ospf_nfsm_timer_set<V: OspfVersion>(nbr: &mut Neighbor<V>) {
     use NfsmState::*;
     match nbr.state {
         Down | Init | TwoWay => {
@@ -243,9 +246,9 @@ pub fn ospf_nfsm_timer_set(nbr: &mut Neighbor) {
     }
 }
 
-pub fn ospf_db_desc_timer(nbr: &Neighbor, retransmit_interval: u16) -> Timer {
+pub fn ospf_db_desc_timer<V: OspfVersion>(nbr: &Neighbor<V>, retransmit_interval: u16) -> Timer {
     let tx = nbr.tx.clone();
-    let prefix = nbr.ident.prefix;
+    let nbr_addr = V::nbr_addr(&nbr.ident);
     let ifindex = nbr.ifindex;
     Timer::new(
         Timer::second(retransmit_interval as u64),
@@ -253,15 +256,15 @@ pub fn ospf_db_desc_timer(nbr: &Neighbor, retransmit_interval: u16) -> Timer {
         move || {
             let tx = tx.clone();
             async move {
-                let _ = tx.send(Message::DdRetransmit(ifindex, prefix.addr()));
+                let _ = tx.send(Message::DdRetransmit(ifindex, nbr_addr));
             }
         },
     )
 }
 
-pub fn ospf_ls_req_timer(nbr: &Neighbor, retransmit_interval: u16) -> Timer {
+pub fn ospf_ls_req_timer<V: OspfVersion>(nbr: &Neighbor<V>, retransmit_interval: u16) -> Timer {
     let tx = nbr.tx.clone();
-    let prefix = nbr.ident.prefix;
+    let nbr_addr = V::nbr_addr(&nbr.ident);
     let ifindex = nbr.ifindex;
     Timer::new(
         Timer::second(retransmit_interval as u64),
@@ -269,44 +272,44 @@ pub fn ospf_ls_req_timer(nbr: &Neighbor, retransmit_interval: u16) -> Timer {
         move || {
             let tx = tx.clone();
             async move {
-                let _ = tx.send(Message::LsReqRetransmit(ifindex, prefix.addr()));
+                let _ = tx.send(Message::LsReqRetransmit(ifindex, nbr_addr));
             }
         },
     )
 }
 
-pub fn ospf_nfsm_ls_req_timer_on(nbr: &mut Neighbor, retransmit_interval: u16) {
+pub fn ospf_nfsm_ls_req_timer_on<V: OspfVersion>(nbr: &mut Neighbor<V>, retransmit_interval: u16) {
     if nbr.timer.ls_req.is_none() {
         nbr.timer.ls_req = Some(ospf_ls_req_timer(nbr, retransmit_interval));
     }
 }
 
-pub fn ospf_nfsm_ignore(
-    _oi: &mut OspfInterface,
-    _nbr: &mut Neighbor,
-    _oident: &Identity,
+pub fn ospf_nfsm_ignore<V: OspfVersion>(
+    _oi: &mut OspfInterface<V>,
+    _nbr: &mut Neighbor<V>,
+    _oident: &Identity<V>,
 ) -> Option<NfsmState> {
     None
 }
 
-pub fn ospf_inactivity_timer(nbr: &Neighbor) -> Timer {
+pub fn ospf_inactivity_timer<V: OspfVersion>(nbr: &Neighbor<V>) -> Timer {
     let tx = nbr.tx.clone();
-    let prefix = nbr.ident.prefix;
+    let nbr_addr = V::nbr_addr(&nbr.ident);
     let ifindex = nbr.ifindex;
     Timer::new(Timer::second(40), TimerType::Once, move || {
         use NfsmEvent::*;
         let tx = tx.clone();
         async move {
-            tx.send(Message::Nfsm(ifindex, prefix.addr(), InactivityTimer))
+            tx.send(Message::Nfsm(ifindex, nbr_addr, InactivityTimer))
                 .unwrap();
         }
     })
 }
 
-pub fn ospf_nfsm_hello_received(
-    _oi: &mut OspfInterface,
-    nbr: &mut Neighbor,
-    _oident: &Identity,
+pub fn ospf_nfsm_hello_received<V: OspfVersion>(
+    _oi: &mut OspfInterface<V>,
+    nbr: &mut Neighbor<V>,
+    _oident: &Identity<V>,
 ) -> Option<NfsmState> {
     // Start or Restart Inactivity Timer.
     nbr.timer.inactivity = Some(ospf_inactivity_timer(nbr));
@@ -314,10 +317,10 @@ pub fn ospf_nfsm_hello_received(
     None
 }
 
-pub fn ospf_nfsm_twoway_received(
-    _oi: &mut OspfInterface,
-    nbr: &mut Neighbor,
-    oident: &Identity,
+pub fn ospf_nfsm_twoway_received<V: OspfVersion>(
+    _oi: &mut OspfInterface<V>,
+    nbr: &mut Neighbor<V>,
+    oident: &Identity<V>,
 ) -> Option<NfsmState> {
     let mut next_state = NfsmState::TwoWay;
 
@@ -327,41 +330,45 @@ pub fn ospf_nfsm_twoway_received(
     }
 
     // If I'm DRouter or BDRouter.
-    if oident.prefix.addr() == oident.d_router || oident.prefix.addr() == oident.bd_router {
+    if V::is_declared_dr(oident) || V::is_declared_bdr(oident) {
         next_state = NfsmState::ExStart;
     }
-    // If Neighbor is DRouter.
-    if nbr.ident.prefix.addr() == oident.d_router || nbr.ident.prefix.addr() == oident.bd_router {
+    // If Neighbor is DRouter or BDRouter.
+    let nbr_id = V::nbr_addr(&nbr.ident);
+    if nbr_id == oident.d_router || nbr_id == oident.bd_router {
         next_state = NfsmState::ExStart;
     }
     Some(next_state)
 }
 
-pub fn ospf_db_summary_add(nbr: &mut Neighbor, lsa: &OspfLsa) {
-    nbr.db_sum.push(lsa.h.clone());
+pub fn ospf_db_summary_add<V: OspfVersion>(nbr: &mut Neighbor<V>, lsa: &V::Lsa) {
+    nbr.db_sum.push(V::lsa_header(lsa).clone());
 }
 
-fn ospf_db_summary_add_table<'a>(
-    nbr: &mut Neighbor,
-    lsas: impl Iterator<Item = &'a super::lsdb::Lsa>,
+pub(super) fn ospf_db_summary_add_table<'a, V: OspfVersion>(
+    nbr: &mut Neighbor<V>,
+    lsas: impl Iterator<Item = &'a super::lsdb::Lsa<V>>,
 ) {
     use super::lsdb::OSPF_MAX_AGE;
     for lsa in lsas {
-        if lsa.data.h.ls_age >= OSPF_MAX_AGE {
+        if V::ls_age(V::lsa_header(&lsa.data)) >= OSPF_MAX_AGE {
             continue;
         }
         ospf_db_summary_add(nbr, &lsa.data);
     }
 }
 
-pub fn ospf_nfsm_negotiation_done(
-    oi: &mut OspfInterface,
-    nbr: &mut Neighbor,
-    _oident: &Identity,
-) -> Option<NfsmState> {
+/// v2 NFSM helper invoked from `Ospfv2::populate_initial_db_summary`.
+/// RFC 2328 §10.8: walk every LSA type that belongs in the initial
+/// DBD summary and push its header into `nbr.db_sum`. The list of
+/// types is v2-specific (v3 uses a different LSA-type taxonomy);
+/// the v3 equivalent lands when the v3 NFSM path is wired.
+pub fn ospfv2_populate_initial_db_summary(
+    oi: &mut OspfInterface<Ospfv2>,
+    nbr: &mut Neighbor<Ospfv2>,
+) {
     use super::area::AreaType;
 
-    // RFC 2328 §10.8: Initial DD Summary list is the attached area's LSDB.
     ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::Router));
     ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::Network));
     ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::Summary));
@@ -372,38 +379,50 @@ pub fn ospf_nfsm_negotiation_done(
     if oi.area_type == AreaType::Normal {
         ospf_db_summary_add_table(nbr, oi.lsdb_as.values_by_type(OspfLsType::AsExternal));
     }
+}
+
+pub fn ospf_nfsm_negotiation_done<V: OspfVersion>(
+    oi: &mut OspfInterface<V>,
+    nbr: &mut Neighbor<V>,
+    _oident: &Identity<V>,
+) -> Option<NfsmState> {
+    // RFC 2328 §10.8: Initial DD Summary list is the attached area's
+    // LSDB. v2-specific LSA-type filtering lives in
+    // `ospfv2_populate_initial_db_summary` (called via the trait);
+    // v3 inherits the no-op default until its NFSM path lands.
+    V::populate_initial_db_summary(oi, nbr);
 
     tracing::info!("[NFSM:NegotiationDone] DB Summary len {}", nbr.db_sum.len());
     None
 }
 
-pub fn ospf_nfsm_exchange_done(
-    oi: &mut OspfInterface,
-    nbr: &mut Neighbor,
-    oident: &Identity,
+pub fn ospf_nfsm_exchange_done<V: OspfVersion>(
+    oi: &mut OspfInterface<V>,
+    nbr: &mut Neighbor<V>,
+    oident: &Identity<V>,
 ) -> Option<NfsmState> {
     if ospf_ls_request_isempty(nbr) {
         return Some(NfsmState::Full);
     }
 
-    ospf_ls_req_send(oi, nbr, oident);
+    V::send_ls_request(oi, nbr, oident);
 
     Some(NfsmState::Loading)
 }
 
-pub fn ospf_nfsm_bad_ls_req(
-    _oi: &mut OspfInterface,
-    nbr: &mut Neighbor,
-    _oident: &Identity,
+pub fn ospf_nfsm_bad_ls_req<V: OspfVersion>(
+    _oi: &mut OspfInterface<V>,
+    nbr: &mut Neighbor<V>,
+    _oident: &Identity<V>,
 ) -> Option<NfsmState> {
     ospf_nfsm_reset_nbr(nbr);
     None
 }
 
-pub fn ospf_nfsm_adj_ok(
-    _oi: &mut OspfInterface,
-    nbr: &mut Neighbor,
-    oident: &Identity,
+pub fn ospf_nfsm_adj_ok<V: OspfVersion>(
+    _oi: &mut OspfInterface<V>,
+    nbr: &mut Neighbor<V>,
+    oident: &Identity<V>,
 ) -> Option<NfsmState> {
     let mut adj_ok = false;
     let mut next_state = nbr.state;
@@ -412,11 +431,12 @@ pub fn ospf_nfsm_adj_ok(
         adj_ok = true;
     }
 
-    if oident.prefix.addr() == oident.d_router || oident.prefix.addr() == oident.bd_router {
+    if V::is_declared_dr(oident) || V::is_declared_bdr(oident) {
         adj_ok = true;
     }
 
-    if nbr.ident.prefix.addr() == oident.d_router || nbr.ident.prefix.addr() == oident.bd_router {
+    let nbr_id = V::nbr_addr(&nbr.ident);
+    if nbr_id == oident.d_router || nbr_id == oident.bd_router {
         adj_ok = true;
     }
 
@@ -430,28 +450,28 @@ pub fn ospf_nfsm_adj_ok(
     Some(next_state)
 }
 
-pub fn ospf_nfsm_seq_number_mismatch(
-    _oi: &mut OspfInterface,
-    nbr: &mut Neighbor,
-    _oident: &Identity,
+pub fn ospf_nfsm_seq_number_mismatch<V: OspfVersion>(
+    _oi: &mut OspfInterface<V>,
+    nbr: &mut Neighbor<V>,
+    _oident: &Identity<V>,
 ) -> Option<NfsmState> {
     ospf_nfsm_reset_nbr(nbr);
     None
 }
 
-pub fn ospf_nfsm_oneway_received(
-    _oi: &mut OspfInterface,
-    nbr: &mut Neighbor,
-    _oident: &Identity,
+pub fn ospf_nfsm_oneway_received<V: OspfVersion>(
+    _oi: &mut OspfInterface<V>,
+    nbr: &mut Neighbor<V>,
+    _oident: &Identity<V>,
 ) -> Option<NfsmState> {
     ospf_nfsm_reset_nbr(nbr);
     None
 }
 
-pub fn ospf_nfsm_kill_nbr(
-    _oi: &mut OspfInterface,
-    nbr: &mut Neighbor,
-    _oident: &Identity,
+pub fn ospf_nfsm_kill_nbr<V: OspfVersion>(
+    _oi: &mut OspfInterface<V>,
+    nbr: &mut Neighbor<V>,
+    _oident: &Identity<V>,
 ) -> Option<NfsmState> {
     // Reset neighbor state (clear lists and timers).
     ospf_nfsm_reset_nbr(nbr);
@@ -459,19 +479,19 @@ pub fn ospf_nfsm_kill_nbr(
     Some(NfsmState::Down)
 }
 
-pub fn ospf_nfsm_inactivity_timer(
-    oi: &mut OspfInterface,
-    nbr: &mut Neighbor,
-    oident: &Identity,
+pub fn ospf_nfsm_inactivity_timer<V: OspfVersion>(
+    oi: &mut OspfInterface<V>,
+    nbr: &mut Neighbor<V>,
+    oident: &Identity<V>,
 ) -> Option<NfsmState> {
     ospf_nfsm_kill_nbr(oi, nbr, oident)
 }
 
-fn ospf_nfsm_change_state(
-    oi: &mut OspfInterface,
-    nbr: &mut Neighbor,
+fn ospf_nfsm_change_state<V: OspfVersion>(
+    oi: &mut OspfInterface<V>,
+    nbr: &mut Neighbor<V>,
     state: NfsmState,
-    oident: &Identity,
+    oident: &Identity<V>,
     event: NfsmEvent,
 ) {
     use NfsmState::*;
@@ -489,7 +509,7 @@ fn ospf_nfsm_change_state(
     }
 
     if nbr.state < nbr.ostate {
-        nbr.options = 0.into();
+        nbr.options = V::Options::default();
     }
 
     if nbr.ostate < TwoWay && nbr.state >= TwoWay {
@@ -519,15 +539,15 @@ fn ospf_nfsm_change_state(
         nbr.dd.flags.set_init(true);
 
         tracing::info!("DB_DESC send from NFSM");
-        ospf_db_desc_send(oi, nbr, oident);
+        V::send_db_desc(oi, nbr, oident);
     }
 }
 
-pub fn ospf_nfsm(
-    link: &mut OspfInterface,
-    nbr: &mut Neighbor,
+pub fn ospf_nfsm<V: OspfVersion>(
+    link: &mut OspfInterface<V>,
+    nbr: &mut Neighbor<V>,
     event: NfsmEvent,
-    oident: &Identity,
+    oident: &Identity<V>,
 ) {
     // Decompose the result of the state function into the transition function
     // and next state.
@@ -560,12 +580,12 @@ pub fn ospf_nfsm(
     ospf_nfsm_timer_set(nbr);
 }
 
-pub fn ospf_nfsm_check_nbr_loading(nbr: &mut Neighbor) {
+pub fn ospf_nfsm_check_nbr_loading<V: OspfVersion>(nbr: &mut Neighbor<V>) {
     if nbr.state == NfsmState::Loading {
         if ospf_ls_request_isempty(nbr) {
             let _ = nbr.tx.send(Message::Nfsm(
                 nbr.ifindex,
-                nbr.ident.prefix.addr(),
+                V::nbr_addr(&nbr.ident),
                 NfsmEvent::LoadingDone,
             ));
         }

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -252,6 +252,58 @@ pub trait OspfVersion: 'static + Send + Sync + Copy + Clone + PartialEq + Eq {
     /// Leave the AllDRouters group. Called when this router moves
     /// out of DR / BDR back to DROther.
     fn leave_alldrouters(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32);
+
+    // ---- NFSM trait accessors ----------------------------------
+    //
+    // RFC 5340 §4.2.2 reuses the v2 NFSM verbatim, but the side
+    // effects on `Loading` / `Exchange` / `ExStart` transitions
+    // involve packet emission and database-summary population that
+    // are wire-format specific. The trait methods below dispatch
+    // those operations; v2 impls call the existing v2 packet
+    // helpers, v3 impls inherit the empty default body until the
+    // v3 packet path lands.
+
+    /// Emit a Database Description packet on the wire for `nbr`.
+    /// Called on transitions into ExStart (Master kicks off DBD
+    /// exchange) and during the master / slave handshake.
+    /// Default body: no-op.
+    fn send_db_desc(
+        oi: &mut crate::ospf::inst::OspfInterface<Self>,
+        nbr: &mut crate::ospf::Neighbor<Self>,
+        oident: &crate::ospf::Identity<Self>,
+    ) where
+        Self: Sized,
+    {
+        let _ = (oi, nbr, oident);
+    }
+
+    /// Emit a Link State Request packet for the pending LSAs on
+    /// `nbr.ls_req`. Called on the Exchange → Loading transition.
+    /// Default body: no-op.
+    fn send_ls_request(
+        oi: &mut crate::ospf::inst::OspfInterface<Self>,
+        nbr: &mut crate::ospf::Neighbor<Self>,
+        oident: &crate::ospf::Identity<Self>,
+    ) where
+        Self: Sized,
+    {
+        let _ = (oi, nbr, oident);
+    }
+
+    /// Populate `nbr.db_sum` with the LSAs that the initial DBD
+    /// summary should advertise (RFC 2328 §10.8). The set of LSA
+    /// types differs between v2 (Router / Network / Summary /
+    /// Summary-ASBR / Opaque-Area / AS-External) and v3 (which
+    /// adds Link / Intra-Area-Prefix and elides the v2 opaque
+    /// types). Default body: no-op.
+    fn populate_initial_db_summary(
+        oi: &mut crate::ospf::inst::OspfInterface<Self>,
+        nbr: &mut crate::ospf::Neighbor<Self>,
+    ) where
+        Self: Sized,
+    {
+        let _ = (oi, nbr);
+    }
 }
 
 /// OSPFv2 dispatch marker (RFC 2328).
@@ -340,6 +392,27 @@ impl OspfVersion for Ospfv2 {
     }
     fn leave_alldrouters(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32) {
         crate::ospf::socket::ospf_leave_alldrouters(sock, ifindex);
+    }
+
+    fn send_db_desc(
+        oi: &mut crate::ospf::inst::OspfInterface<Ospfv2>,
+        nbr: &mut crate::ospf::Neighbor<Ospfv2>,
+        oident: &crate::ospf::Identity<Ospfv2>,
+    ) {
+        crate::ospf::ospf_db_desc_send(oi, nbr, oident);
+    }
+    fn send_ls_request(
+        oi: &mut crate::ospf::inst::OspfInterface<Ospfv2>,
+        nbr: &mut crate::ospf::Neighbor<Ospfv2>,
+        oident: &crate::ospf::Identity<Ospfv2>,
+    ) {
+        crate::ospf::ospf_ls_req_send(oi, nbr, oident);
+    }
+    fn populate_initial_db_summary(
+        oi: &mut crate::ospf::inst::OspfInterface<Ospfv2>,
+        nbr: &mut crate::ospf::Neighbor<Ospfv2>,
+    ) {
+        crate::ospf::nfsm::ospfv2_populate_initial_db_summary(oi, nbr);
     }
 }
 


### PR DESCRIPTION
## Summary

RFC 5340 §4.2.2 reuses the v2 NFSM verbatim. This PR lifts the v2-only NFSM in `nfsm.rs` to be generic over `V: OspfVersion` so `Ospf<Ospfv3>` can drive the same code path. Pair with #770 (IFSM-generic).

Three trait methods abstract the v2-only side effects that fire on state transitions; **default bodies are no-ops**, overridden by `Ospfv2`:

- `send_db_desc(oi, nbr, oident)` — wraps `ospf_db_desc_send`. Called on the ExStart transition (Master initiates DBD exchange).
- `send_ls_request(oi, nbr, oident)` — wraps `ospf_ls_req_send`. Called on the Exchange → Loading transition.
- `populate_initial_db_summary(oi, nbr)` — wraps a new v2-only helper `ospfv2_populate_initial_db_summary` extracted from `ospf_nfsm_negotiation_done`. The set of LSA types that belong in the initial DBD summary is v2-specific (Router / Network / Summary / Summary-ASBR / Opaque-Area / AS-External via `OspfLsType::*`); v3 inherits the no-op default until its LSA taxonomy is wired.

All NFSM functions are now `<V: OspfVersion>`: 13 `ospf_nfsm_*` handlers, plus the timer helpers and the dispatch table (`NfsmFunc<V>`, `NfsmState::fsm<V>`).

### Body substitutions

- v2 `prefix.addr()` → `V::nbr_addr(&nbr.ident)` for the channel variants `Message::DdRetransmit / LsReqRetransmit / Nfsm` (which carry `Ipv4Addr` in both versions — interface-IP for v2, router-id for v3).
- v2 DR / BDR predicates → `V::is_declared_dr` / `V::is_declared_bdr` (from #770) plus `V::nbr_addr(...) == oident.d_router / bd_router` for the neighbor-side check.
- v2 packet ops → `V::send_db_desc` / `V::send_ls_request` / `V::populate_initial_db_summary`.
- `nbr.options = 0.into()` → `V::Options::default()` (the `Default` bound is already on the trait).
- `ospf_ls_request_isempty` in `flood.rs` made generic too — called from genericized NFSM functions.

### What's left

The v3 NFSM is now wire-driveable through the dispatch table, but the three trait methods are no-ops on v3 until the v3 packet path (Hello / DBD encode-decode + send_packet wiring) lands. The four `Ospf<Ospfv3>::build_*_lsa` helpers from earlier PRs can already be exercised in isolation.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 872 passed, 0 failed

Generated with [Claude Code](https://claude.com/claude-code)