### PR TITLE
ospf: add v3 IFSM driver (process_msg / event_loop / serve_v3)

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1786,9 +1786,100 @@ impl Ospf<Ospfv3> {
         lsa.update();
         lsa
     }
+
+    /// Dispatch one v3 instance-level message.
+    ///
+    /// Subset of v2's `process_msg` covering the IFSM-driver scope:
+    /// `Enable` / `Disable` (toggle the link's enabled flag and emit
+    /// the IFSM transition event), `Ifsm` (drive the FSM), and
+    /// `HelloTimer` (emit a v3 Hello via the v3 send channel).
+    ///
+    /// Other `Message<Ospfv3>` variants (Recv / Nfsm / Send / Flood /
+    /// Lsdb / SpfSchedule / SpfCalc) need additional v3-side wiring
+    /// — packet recv bridging, v3 NFSM dispatch, v3 LSA flooding —
+    /// and land in subsequent PRs. They fall through to a debug log
+    /// for now so traffic that arrives early doesn't panic.
+    pub async fn process_msg(&mut self, msg: Message<Ospfv3>) {
+        match msg {
+            Message::Enable(ifindex, area_id) => {
+                let Some(link) = self.links.get_mut(&ifindex) else {
+                    return;
+                };
+                link.enabled = true;
+                link.area = area_id;
+                link.area_id = area_id;
+                let area = self.areas.fetch(area_id);
+                area.links.insert(ifindex);
+                let _ = self.tx.send(Message::Ifsm(ifindex, IfsmEvent::InterfaceUp));
+            }
+            Message::Disable(ifindex, area_id) => {
+                let Some(link) = self.links.get_mut(&ifindex) else {
+                    return;
+                };
+                link.enabled = false;
+                link.area = Ipv4Addr::UNSPECIFIED;
+                link.area_id = Ipv4Addr::UNSPECIFIED;
+                let area = self.areas.fetch(area_id);
+                area.links.remove(&ifindex);
+                let _ = self
+                    .tx
+                    .send(Message::Ifsm(ifindex, IfsmEvent::InterfaceDown));
+            }
+            Message::Ifsm(index, ev) => {
+                let Some(link) = self.links.get_mut(&index) else {
+                    return;
+                };
+                ospf_ifsm(link, ev);
+            }
+            Message::HelloTimer(index) => {
+                let Some(link) = self.links.get_mut(&index) else {
+                    return;
+                };
+                let Some(tx) = self.v3_send_tx.as_ref() else {
+                    return;
+                };
+                super::packet_v3::ospfv3_hello_send(link, tx);
+            }
+            other => {
+                tracing::debug!(
+                    "v3 process_msg: unhandled variant {:?}",
+                    std::mem::discriminant(&other)
+                );
+            }
+        }
+    }
+
+    /// Main event loop for the v3 instance. Mirrors v2's `event_loop`
+    /// but only `rx` (instance-level events) and `rib_rx` (RIB updates)
+    /// are wired here; `cm.rx` / `show.rx` will follow when the v3
+    /// config schema and show paths land.
+    pub async fn event_loop(&mut self) {
+        loop {
+            tokio::select! {
+                Some(msg) = self.rx.recv() => {
+                    self.process_msg(msg).await;
+                }
+                Some(_msg) = self.rib_rx.recv() => {
+                    // v3 RIB integration TBD; drain for now so the
+                    // channel doesn't back-pressure the rib client.
+                }
+            }
+        }
+    }
 }
 
 pub fn serve(mut ospf: Ospf) -> Task<()> {
+    Task::spawn(async move {
+        ospf.event_loop().await;
+    })
+}
+
+/// Spawn the v3 instance's main event loop. Symmetric with v2's
+/// `serve`. Currently unused — `main.rs` doesn't yet construct an
+/// `Ospf<Ospfv3>`; the spawn wiring lands when the v3 config schema
+/// and `spawn_ospfv3` path follow.
+#[allow(dead_code)]
+pub fn serve_v3(mut ospf: Ospf<Ospfv3>) -> Task<()> {
     Task::spawn(async move {
         ospf.event_loop().await;
     })


### PR DESCRIPTION
## Summary

Wire the minimal v3 instance-level event dispatch needed to drive the IFSM end-to-end. Three new items on `impl Ospf<Ospfv3>`, all behind `#[allow(dead_code)]` until `main.rs` spawns the instance:

- **`process_msg(msg)`** — handles 4 variants (the IFSM-driver subset):
  - `Enable(ifindex, area_id)` flips link enabled, attaches to area, fires `Ifsm InterfaceUp`.
  - `Disable(ifindex, area_id)` flips link disabled, detaches from area, fires `Ifsm InterfaceDown`.
  - `Ifsm(index, ev)` calls `ospf_ifsm(link, ev)` (the generic IFSM driver from #770).
  - `HelloTimer(index)` calls `ospfv3_hello_send(link, &v3_send_tx)` (from #772).

  Other variants fall through to a debug log so early traffic doesn't panic.

- **`event_loop()`** — pulls from `self.rx` and `self.rib_rx` and dispatches. `cm.rx` / `show.rx` will follow with the v3 config schema; `rib_rx` is drained as a stub.

- **`serve_v3(ospf) -> Task<()>`** — symmetric with v2's `serve`.

### What's not wired yet

Notably skipped from v2's Enable / Disable: `router_lsa_originate()` — v2's helper lives in `impl Ospf<Ospfv2>`. The v3 equivalent calls the four `build_*_lsa` helpers and floods, which is its own follow-up PR. Same for the Recv path bridging (`v3_recv_rx` → `Message<Ospfv3>::Recv`) and the v3 LS-Upd/Ack flooding.

The outbound Hello path is now functionally end-to-end as soon as the instance is spawned: IFSM `Waiting`/`DROther`/`DR` arms the hello-timer → fires `HelloTimer(ifindex)` → `process_msg` calls `ospfv3_hello_send` → packet stamped with the pseudo-header checksum by the `network_v6` send loop → emitted via `sendmsg` to `ff02::5`.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 872 passed, 0 failed

Generated with [Claude Code](https://claude.com/claude-code)