### PR TITLE
ospf: bridge v3 receive path + add ospfv3_hello_recv

### DIFF
--- a/crates/ospf-packet/src/v3.rs
+++ b/crates/ospf-packet/src/v3.rs
@@ -394,7 +394,7 @@ impl Ospfv3LsaHeader {
 ///   - Flags (1 octet) — same I/M/MS layout as v2 `DbDescFlags`
 ///   - DD Sequence Number (4 octets)
 ///   - LSA headers (variable, 20 octets each)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Ospfv3DbDesc {
     pub options: Ospfv3Options,
     pub if_mtu: u16,

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1840,6 +1840,12 @@ impl Ospf<Ospfv3> {
                 };
                 super::packet_v3::ospfv3_hello_send(link, tx);
             }
+            Message::Nfsm(index, src, ev) => {
+                if let Some((mut link, nbr)) = self.ospf_interface(index, &src) {
+                    let ident = link.ident;
+                    super::nfsm::ospf_nfsm(&mut link, nbr, ev, ident);
+                }
+            }
             other => {
                 tracing::debug!(
                     "v3 process_msg: unhandled variant {:?}",
@@ -1849,11 +1855,49 @@ impl Ospf<Ospfv3> {
         }
     }
 
+    /// Dispatch one v3 packet received off the wire (`network_v6`).
+    /// Bridges the `Ospfv3Recv` channel into the v3 instance by
+    /// looking up the ingress link and routing by payload type.
+    /// Only Hello is handled at the moment; the four other v3 packet
+    /// types (DBD / LSReq / LSUpd / LSAck) fall through with a debug
+    /// log until their recv handlers land.
+    pub fn process_recv(&mut self, recv: super::network_v6::Ospfv3Recv) {
+        let super::network_v6::Ospfv3Recv {
+            packet,
+            src,
+            dst: _,
+            ifindex,
+        } = recv;
+        let our_router_id = self.router_id;
+        let Some(link) = self.links.get_mut(&ifindex) else {
+            return;
+        };
+        match &packet.payload {
+            Ospfv3Payload::Hello(_) => {
+                super::packet_v3::ospfv3_hello_recv(&our_router_id, link, &packet, &src);
+            }
+            other => {
+                tracing::debug!(
+                    "v3 process_recv: unhandled packet payload {:?}",
+                    std::mem::discriminant(other)
+                );
+            }
+        }
+    }
+
     /// Main event loop for the v3 instance. Mirrors v2's `event_loop`
-    /// but only `rx` (instance-level events) and `rib_rx` (RIB updates)
-    /// are wired here; `cm.rx` / `show.rx` will follow when the v3
-    /// config schema and show paths land.
+    /// but only `rx` / `rib_rx` / the v3 packet recv channel are
+    /// wired; `cm.rx` / `show.rx` follow with the v3 config schema.
+    ///
+    /// `self.v3_recv_rx` is taken out of the `Option` at start so
+    /// the `select!` arm doesn't have to re-borrow it through the
+    /// `&mut self` used by `process_*`. `Ospf<Ospfv3>::new` always
+    /// populates it (#768).
     pub async fn event_loop(&mut self) {
+        let mut v3_recv_rx = self
+            .v3_recv_rx
+            .take()
+            .expect("Ospf<Ospfv3> has no v3 recv channel");
         loop {
             tokio::select! {
                 Some(msg) = self.rx.recv() => {
@@ -1862,6 +1906,9 @@ impl Ospf<Ospfv3> {
                 Some(_msg) = self.rib_rx.recv() => {
                     // v3 RIB integration TBD; drain for now so the
                     // channel doesn't back-pressure the rib client.
+                }
+                Some(recv) = v3_recv_rx.recv() => {
+                    self.process_recv(recv);
                 }
             }
         }

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -1,17 +1,18 @@
 //! OSPFv3 packet send / receive — wire layer above `network_v6`.
 //!
-//! Sibling of v2's `packet.rs`. For now this only carries the Hello
-//! sender; the other four packet types (DBD / LSReq / LSUpd / LSAck)
-//! land in subsequent PRs as the v3 NFSM is wired end-to-end.
+//! Sibling of v2's `packet.rs`. Currently carries the Hello send /
+//! recv pair; the other four packet types (DBD / LSReq / LSUpd /
+//! LSAck) land in subsequent PRs as the v3 NFSM is wired end-to-end.
 
 use std::net::Ipv6Addr;
 
+use ipnet::Ipv6Net;
 use ospf_packet::{Ospfv3Hello, Ospfv3Options, Ospfv3Packet, Ospfv3Payload};
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::network_v6::Ospfv3Send;
 use super::version::Ospfv3;
-use super::{NfsmState, OspfLink};
+use super::{IfsmEvent, IfsmState, Message, Neighbor, NfsmEvent, NfsmState, OspfLink};
 
 /// First link-local address on this interface, or `None` if none has
 /// been picked up from `rib::Link` yet. The v3 send loop folds this
@@ -100,4 +101,134 @@ pub fn ospfv3_hello_send(link: &mut OspfLink<Ospfv3>, v3_send_tx: &UnboundedSend
     }
 
     link.flags.set_hello_sent(true);
+}
+
+/// Check whether the peer's Hello acknowledges us by listing our
+/// router-id in its neighbors set (RFC 5340 §4.2.2 / RFC 2328 §10.5).
+fn hello_twoway_check(our_router_id: &std::net::Ipv4Addr, hello: &Ospfv3Hello) -> bool {
+    hello.neighbors.iter().any(|n| n == our_router_id)
+}
+
+/// Whether a neighbor's role on the segment changed in a way that
+/// the local IFSM needs to re-evaluate (DR / BDR election triggers
+/// or priority changes). Same shape as v2's check, but uses
+/// router-id semantics from RFC 5340 §A.3.2 — the neighbor's
+/// identity is its router-id, not its interface IP.
+fn hello_is_nbr_changed(nbr: &Neighbor<Ospfv3>, prev: &super::Identity<Ospfv3>) -> bool {
+    let current = nbr.ident;
+    let nbr_id = nbr.ident.router_id;
+
+    (nbr_id != prev.d_router && nbr_id == current.d_router)
+        || (nbr_id == prev.d_router && nbr_id != current.d_router)
+        || (nbr_id != prev.bd_router && nbr_id == current.bd_router)
+        || (nbr_id == prev.bd_router && nbr_id != current.bd_router)
+        || prev.priority != current.priority
+}
+
+/// Process one v3 Hello packet received off the wire.
+///
+/// Mirrors v2's `ospf_hello_recv`. Differences per RFC 5340:
+///
+/// - Neighbor keyed by **router-id** (from the packet header), not
+///   the source IP. v3 link-local v6 addresses aren't suitable as
+///   stable identifiers (§10).
+/// - No netmask field in the Hello (`Ospfv3Hello` doesn't carry
+///   one); the prefix-length check is dropped accordingly.
+/// - DR / BDR comparisons against router-ids, not interface IPs.
+///
+/// `src` is the v6 link-local from `Ospfv3Recv`. We store it as a
+/// `/128` in the neighbor's prefix so the existing IFSM helpers
+/// that look up `nbr.ident.prefix` keep working.
+pub fn ospfv3_hello_recv(
+    our_router_id: &std::net::Ipv4Addr,
+    oi: &mut OspfLink<Ospfv3>,
+    packet: &Ospfv3Packet,
+    src: &Ipv6Addr,
+) {
+    if oi.is_passive() {
+        return;
+    }
+
+    let Ospfv3Payload::Hello(ref hello) = packet.payload else {
+        return;
+    };
+
+    let nbr_router_id = packet.router_id;
+
+    // Neighbor key in `oi.nbrs` is Ipv4Addr in both versions; v3
+    // stores the router-id (RFC 5340 §10), which matches what
+    // `V::nbr_addr` returns for v3.
+    let mut init = false;
+    let dead_interval = oi.dead_interval() as u64;
+    let prefix = Ipv6Net::new(*src, 128).unwrap();
+    let nbr = oi.nbrs.entry(nbr_router_id).or_insert_with(|| {
+        init = true;
+        Neighbor::<Ospfv3>::new(
+            oi.tx.clone(),
+            oi.index,
+            prefix,
+            &nbr_router_id,
+            dead_interval,
+            oi.ptx.clone(),
+        )
+    });
+
+    // Remember the Interface ID the neighbor reported (§A.3.2);
+    // the v3 Router-LSA builder folds this into TransitNetwork /
+    // PointToPoint link records.
+    nbr.interface_id = hello.interface_id;
+
+    oi.tx
+        .send(Message::Nfsm(
+            oi.index,
+            nbr_router_id,
+            NfsmEvent::HelloReceived,
+        ))
+        .unwrap();
+
+    // Snapshot identity before we update it.
+    let ident = nbr.ident;
+
+    // Update from the new Hello.
+    nbr.ident.priority = hello.priority;
+    nbr.ident.d_router = hello.d_router;
+    nbr.ident.bd_router = hello.bd_router;
+
+    if !hello_twoway_check(our_router_id, hello) {
+        oi.tx
+            .send(Message::Nfsm(
+                oi.index,
+                nbr_router_id,
+                NfsmEvent::OneWayReceived,
+            ))
+            .unwrap();
+    } else {
+        oi.tx
+            .send(Message::Nfsm(
+                oi.index,
+                nbr_router_id,
+                NfsmEvent::TwoWayReceived,
+            ))
+            .unwrap();
+        nbr.options = (nbr.options.into_bits() | hello.options.into_bits()).into();
+
+        if oi.state == IfsmState::Waiting {
+            if nbr_router_id == hello.bd_router {
+                oi.tx
+                    .send(Message::Ifsm(oi.index, IfsmEvent::BackupSeen))
+                    .unwrap();
+            }
+            if nbr_router_id == hello.d_router && hello.bd_router.is_unspecified() {
+                oi.tx
+                    .send(Message::Ifsm(oi.index, IfsmEvent::BackupSeen))
+                    .unwrap();
+            }
+        }
+
+        if !init && hello_is_nbr_changed(nbr, &ident) {
+            oi.tx
+                .send(Message::Ifsm(oi.index, IfsmEvent::NeighborChange))
+                .unwrap();
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Wire the v3 packet recv channel created in #768 into the v3 IFSM driver from #773, then add the first wire-level recv handler so two v3 routers exchanging Hellos progress to 2-Way.

### `packet_v3.rs`

- **`hello_twoway_check(our_router_id, hello)`** — RFC 2328 §10.5 / RFC 5340 §4.2.2 check: peer acknowledges us when our router-id appears in its neighbors list.
- **`hello_is_nbr_changed(nbr, prev)`** — DR / BDR / priority transition predicate, router-id semantics throughout.
- **`ospfv3_hello_recv(our_router_id, oi, packet, src)`** — mirror of v2's `ospf_hello_recv`. Differences per RFC 5340:
  - neighbor keyed by `packet.router_id` (§10), not source IP
  - no netmask check (`Ospfv3Hello` carries no netmask)
  - DR / BDR comparisons against router-ids (§A.3.2)
  - stores the neighbor's link-local v6 as a `/128` so existing IFSM helpers that read `nbr.ident.prefix` keep working
  - remembers the reported `interface_id` (§A.3.2) — the v3 Router-LSA builder folds it into TransitNetwork / PointToPoint link records.

  Fires `Nfsm HelloReceived` then `OneWayReceived` or `TwoWayReceived` based on the twoway check, plus IFSM `BackupSeen` and `NeighborChange` as v2 does.

### `impl Ospf<Ospfv3>` (`inst.rs`)

- `Message::Nfsm(index, src, ev)` arm in `process_msg` routes to the now-generic `ospf_nfsm` (#771).
- `process_recv(Ospfv3Recv)` looks up the ingress link by ifindex and dispatches by payload type. Only Hello is handled; the other four packet types fall through with a debug log until their recv handlers land.
- `event_loop` now `.take()`s `v3_recv_rx` and adds a third `select!` arm that drains it into `process_recv`.

### `ospf-packet` crate

- `Ospfv3DbDesc` gains `Default` derive — required by `Neighbor::<Ospfv3>::new`'s `V::DbDesc: Default` bound, which fires when `ospfv3_hello_recv` inserts a brand-new neighbor.

### Status after this PR

v3 Hello round-trip is end-to-end: outbound Hellos fire on timer → received Hellos drive NFSM through Init → 2-Way. DBD / LS-Req / LS-Upd / LS-Ack handlers remain no-op trait defaults from #771, so progression past 2-Way still needs the v3 DBD send/recv PR.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 872 passed, 0 failed

Generated with [Claude Code](https://claude.com/claude-code)