### PR TITLE
ospf: add ospfv3_db_desc_send + v3 trait override

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -112,6 +112,12 @@ pub struct OspfInterface<'a, V: OspfVersion = Ospfv2> {
     pub mtu_ignore: bool,
     pub retransmit_interval: u16,
     pub tracing: &'a OspfTracing,
+    /// v3-only outbound packet channel borrow. Carries the `Ospfv3Send`
+    /// sender that the `network_v6::write_packet_v6` task consumes.
+    /// `None` on v2 (where the v2 `Message::Send` path on `tx` is used
+    /// instead). Populated by `Ospf<Ospfv3>::ospf_interface` from
+    /// `self.v3_send_tx`.
+    pub v3_send_tx: Option<&'a UnboundedSender<super::network_v6::Ospfv3Send>>,
 }
 
 // Version-agnostic helpers. These methods touch only generic-safe
@@ -150,6 +156,7 @@ impl<V: OspfVersion> Ospf<V> {
                             mtu_ignore: link.config.mtu_ignore,
                             retransmit_interval,
                             tracing: &self.tracing,
+                            v3_send_tx: self.v3_send_tx.as_ref(),
                         },
                         nbr,
                     )

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -7,12 +7,15 @@
 use std::net::Ipv6Addr;
 
 use ipnet::Ipv6Net;
-use ospf_packet::{Ospfv3Hello, Ospfv3Options, Ospfv3Packet, Ospfv3Payload};
+use ospf_packet::{Ospfv3DbDesc, Ospfv3Hello, Ospfv3Options, Ospfv3Packet, Ospfv3Payload};
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::network_v6::Ospfv3Send;
 use super::version::Ospfv3;
-use super::{IfsmEvent, IfsmState, Message, Neighbor, NfsmEvent, NfsmState, OspfLink};
+use super::{
+    Identity, IfsmEvent, IfsmState, Message, Neighbor, NfsmEvent, NfsmState, OspfLink,
+    inst::OspfInterface,
+};
 
 /// First link-local address on this interface, or `None` if none has
 /// been picked up from `rib::Link` yet. The v3 send loop folds this
@@ -230,5 +233,99 @@ pub fn ospfv3_hello_recv(
                 .send(Message::Ifsm(oi.index, IfsmEvent::NeighborChange))
                 .unwrap();
         }
+    }
+}
+
+/// First link-local v6 address among the interface's configured
+/// addresses. Same helper as `link_local_src` but on the
+/// `OspfInterface<Ospfv3>` borrow used by NFSM-side packet senders.
+fn interface_link_local_src(oi: &OspfInterface<Ospfv3>) -> Option<Ipv6Addr> {
+    oi.addr.iter().find_map(|a| {
+        let addr = a.prefix.addr();
+        addr.is_unicast_link_local().then_some(addr)
+    })
+}
+
+/// Pack the LSAs currently queued on `nbr.db_sum` into `dd.lsa_headers`.
+/// Mirrors v2's `ospf_packet_db_desc_set`.
+fn db_desc_pack(nbr: &mut Neighbor<Ospfv3>, dd: &mut Ospfv3DbDesc) {
+    while let Some(lsah) = nbr.db_sum.pop() {
+        dd.lsa_headers.push(lsah);
+    }
+}
+
+/// Emit an OSPFv3 Database Description packet (RFC 5340 §A.3.3).
+///
+/// Mirrors v2's `ospf_db_desc_send`. Differences from v2:
+///
+/// - Wire format. The v3 DBD has a 24-bit Options field (V6/E/R
+///   set), an 8-bit reserved, then the master/slave flags and DD
+///   sequence number; LSA headers are v3-shaped (`Ospfv3LsaHeader`,
+///   §A.4.2).
+/// - Transport. v3 sends through the dedicated `Ospfv3Send` channel
+///   (so `network_v6::write_packet_v6` can stamp the IPv6
+///   pseudo-header checksum); v2 sends through the generic
+///   `Message<V>::Send` channel. The trait override
+///   `Ospfv3::send_db_desc` (in `version.rs`) routes here.
+/// - Destination is the neighbor's link-local v6 (a `/128` we
+///   captured from the Hello recv). Source is our own link-local.
+pub fn ospfv3_db_desc_send(
+    oi: &mut OspfInterface<Ospfv3>,
+    nbr: &mut Neighbor<Ospfv3>,
+    oident: &Identity<Ospfv3>,
+) {
+    let area = oi.area_id;
+    let mut dd = Ospfv3DbDesc {
+        if_mtu: oi.mtu as u16,
+        flags: nbr.dd.flags,
+        seqnum: nbr.dd.seqnum,
+        ..Default::default()
+    };
+    dd.options.set_v6(true);
+    dd.options.set_e(true);
+    dd.options.set_r(true);
+
+    db_desc_pack(nbr, &mut dd);
+
+    // Remember the DD we sent so it can be retransmitted by the
+    // master while waiting for the slave's response, or resent by
+    // the slave when the master sends a duplicate. RFC 2328 §10.8 /
+    // RFC 5340 §4.2.2 (reuses v2 §10.8).
+    nbr.dd.sent = Some(dd.clone());
+
+    // Master retransmits its DD at RxmtInterval until acked; slave
+    // does not retransmit on a timer, only on duplicate receipt.
+    if nbr.dd.flags.master() {
+        nbr.timer.db_desc = Some(super::nfsm::ospf_db_desc_timer(nbr, oi.retransmit_interval));
+    } else {
+        nbr.timer.db_desc = None;
+    }
+
+    let packet = Ospfv3Packet::new(
+        &oident.router_id,
+        &area,
+        0, // instance_id (RFC 5340 §A.3.1)
+        Ospfv3Payload::DbDesc(dd),
+    );
+
+    let Some(tx) = oi.v3_send_tx else {
+        tracing::debug!("[v3 DBD:Send] no v3 send channel on OspfInterface");
+        return;
+    };
+    let Some(src) = interface_link_local_src(oi) else {
+        tracing::debug!("[v3 DBD:Send] no link-local source on interface");
+        return;
+    };
+
+    let item = Ospfv3Send {
+        packet,
+        ifindex: nbr.ifindex,
+        // Unicast to the neighbor's link-local (captured in
+        // `ospfv3_hello_recv` as a `/128` Ipv6Net).
+        dest: Some(nbr.ident.prefix.addr()),
+        src,
+    };
+    if let Err(e) = tx.send(item) {
+        tracing::warn!("[v3 DBD:Send] channel send failed: {}", e);
     }
 }

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -509,4 +509,12 @@ impl OspfVersion for Ospfv3 {
     fn leave_alldrouters(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32) {
         crate::ospf::socket::ospf_leave_alldrouters_v6(sock, ifindex);
     }
+
+    fn send_db_desc(
+        oi: &mut crate::ospf::inst::OspfInterface<Ospfv3>,
+        nbr: &mut crate::ospf::Neighbor<Ospfv3>,
+        oident: &crate::ospf::Identity<Ospfv3>,
+    ) {
+        crate::ospf::packet_v3::ospfv3_db_desc_send(oi, nbr, oident);
+    }
 }


### PR DESCRIPTION
## Summary

Second v3 packet-send entrypoint, mirroring v2's `ospf_db_desc_send`. Lifts the no-op `Ospfv3::send_db_desc` default introduced in #771 — the v3 NFSM `ExStart` transition now actually puts a DBD on the wire via the `Ospfv3Send` channel.

### `packet_v3.rs`

- `interface_link_local_src(oi)` — analogue of `link_local_src` for the `OspfInterface` borrow used by NFSM-side packet senders.
- `db_desc_pack(nbr, dd)` — mirrors v2's `ospf_packet_db_desc_set`, drains the queued LSA headers into the outgoing DBD.
- `ospfv3_db_desc_send(oi, nbr, oident)` — emits `Ospfv3Payload::DbDesc(Ospfv3DbDesc)` per RFC 5340 §A.3.3. Differences from v2:
  - **Wire format.** 24-bit Options (V6/E/R set) + 8-bit reserved + DD flags + DD seqnum + v3 LSA headers.
  - **Transport.** Sends through the dedicated `Ospfv3Send` channel so `network_v6::write_packet_v6` can stamp the IPv6 pseudo-header checksum, instead of v2's generic `Message<V>::Send`.
  - **Destination** is the neighbor's link-local v6 (the `/128` captured from `ospfv3_hello_recv` and stored in `nbr.ident.prefix`). Source is our own link-local.
  - **Master retransmit** via the existing generic `ospf_db_desc_timer` (genericized in #771).

### `inst.rs`

- `OspfInterface<'a, V>` gains a `v3_send_tx: Option<&'a UnboundedSender<Ospfv3Send>>` borrow, populated in `ospf_interface()` from `self.v3_send_tx`. v2 instances pass `None` (unused — v2 uses its own packet path).

### `version.rs`

- `Ospfv3::send_db_desc` override routes to `ospfv3_db_desc_send`, replacing the no-op trait default.

### What's next

Receive-side handling still mostly drops at `process_recv` (only Hello is wired), so two v3 routers stall on the slave waiting for the master's DBD ack — that's the next PR (`ospfv3_db_desc_recv`).

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 872 passed, 0 failed

Generated with [Claude Code](https://claude.com/claude-code)