### PR TITLE
bgp-packet: register SAFI 85 (MUP) and ext-com type 0x0c

### DIFF
--- a/crates/bgp-packet/src/afi.rs
+++ b/crates/bgp-packet/src/afi.rs
@@ -36,6 +36,8 @@ pub enum Safi {
     #[strum(serialize = "RTC")]
     Rtc = 132,
     Flowspec = 133,
+    #[strum(serialize = "MUP")]
+    Mup = 85,
     #[strum(to_string = "Unknown({0})")]
     Unknown(u8),
 }
@@ -146,6 +148,7 @@ impl From<Safi> for u8 {
             MplsVpn => 128,
             Rtc => 132,
             Flowspec => 133,
+            Mup => 85,
             Unknown(v) => v,
         }
     }
@@ -160,6 +163,7 @@ impl From<u8> for Safi {
             4 => MplsLabel,
             7 => Encap,
             70 => Evpn,
+            85 => Mup,
             128 => MplsVpn,
             132 => Rtc,
             133 => Flowspec,
@@ -185,3 +189,42 @@ impl Safi {
 }
 
 // Display implementation now provided by strum_macros::Display
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safi_round_trip_known_values() {
+        let known = [
+            Safi::Unicast,
+            Safi::Multicast,
+            Safi::MplsLabel,
+            Safi::Encap,
+            Safi::Evpn,
+            Safi::Mup,
+            Safi::MplsVpn,
+            Safi::Rtc,
+            Safi::Flowspec,
+        ];
+        for safi in known {
+            let raw: u8 = safi.into();
+            assert_eq!(Safi::from(raw), safi, "round-trip failed for {safi}");
+        }
+    }
+
+    #[test]
+    fn safi_mup_wire_value() {
+        assert_eq!(u8::from(Safi::Mup), 85);
+        assert_eq!(Safi::from(85u8), Safi::Mup);
+        assert_eq!(format!("{}", Safi::Mup), "MUP");
+    }
+
+    #[test]
+    fn safi_unknown_round_trip() {
+        let unknown = Safi::Unknown(200);
+        let raw: u8 = unknown.into();
+        assert_eq!(raw, 200);
+        assert_eq!(Safi::from(raw), unknown);
+    }
+}

--- a/crates/bgp-packet/src/attrs/ext_com_type.rs
+++ b/crates/bgp-packet/src/attrs/ext_com_type.rs
@@ -7,6 +7,10 @@ pub enum ExtCommunityType {
     // TransIpv4Addr = 0x01,
     // TransFourOctetAS = 0x03,
     TransOpaque = 0x03,
+    /// RFC 9833 — BGP MUP Extended Community high-type byte. Sub-type
+    /// decode is deferred to a later phase; raw 8-byte value passes
+    /// through the generic ExtCommunity path for now.
+    Mup = 0x0c,
 }
 
 #[derive(


### PR DESCRIPTION
## Summary
- Phase 1 of BGP SRv6 MUP support (RFC 9833): packet-layer surface only.
- Adds `Safi::Mup = 85` with bi-directional `u8` conversions, and `ExtCommunityType::Mup = 0x0c`.
- No NLRI body parsing, no `MP_REACH` / `MP_UNREACH` dispatch, no ext-com sub-type decode yet — deferred to later phases.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p bgp-packet` (118 tests, 0 failures; 3 new SAFI round-trip tests)

Generated with [Claude Code](https://claude.com/claude-code)