### PR TITLE
ospf: add v3 LSDB lookup, lift DBD-proc TODO

### DIFF
--- a/zebra-rs/src/ospf/lsdb.rs
+++ b/zebra-rs/src/ospf/lsdb.rs
@@ -292,6 +292,15 @@ impl<V: OspfVersion> Lsdb<V> {
             .map(|lsa| &lsa.data)
     }
 
+    /// Look up an LSA by the flat 3-tuple key directly. Same as
+    /// `lookup_by_id` but without the v2-typed `OspfLsType` arg —
+    /// v3 carries `ls_type` as a raw `u16` per RFC 5340 §A.4.2.1
+    /// (U / S2 / S1 / function-code packing), so it builds the
+    /// key itself rather than going through `v2_lsa_key`.
+    pub fn lookup_by_raw_key(&self, key: OspfLsaKey) -> Option<&V::Lsa> {
+        self.tables.get(&key).map(|lsa| &lsa.data)
+    }
+
     /// Look up the full LSDB entry (including bookkeeping) by key.
     /// Now generic.
     pub fn lookup_lsa(

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -7,7 +7,10 @@
 use std::net::Ipv6Addr;
 
 use ipnet::Ipv6Net;
-use ospf_packet::{Ospfv3DbDesc, Ospfv3Hello, Ospfv3Options, Ospfv3Packet, Ospfv3Payload};
+use ospf_packet::{
+    Ospfv3DbDesc, Ospfv3Hello, Ospfv3LsRequestEntry, Ospfv3Lsa, Ospfv3LsaHeader, Ospfv3Options,
+    Ospfv3Packet, Ospfv3Payload,
+};
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::network_v6::Ospfv3Send;
@@ -376,12 +379,45 @@ fn ospfv3_db_desc_resend(oi: &OspfInterface<Ospfv3>, nbr: &Neighbor<Ospfv3>) {
     }
 }
 
+/// RFC 5340 §A.4.2.1: ls_type is encoded `U | S2 | S1 | function-code`.
+/// Bits 14:13 are the scope: 00 = link-local, 01 = area, 10 = AS,
+/// 11 = reserved. Decode the scope for LSDB routing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Ospfv3LsaScope {
+    Link,
+    Area,
+    As,
+    Reserved,
+}
+
+fn ospfv3_ls_type_scope(ls_type: u16) -> Ospfv3LsaScope {
+    match (ls_type >> 13) & 0x3 {
+        0 => Ospfv3LsaScope::Link,
+        1 => Ospfv3LsaScope::Area,
+        2 => Ospfv3LsaScope::As,
+        _ => Ospfv3LsaScope::Reserved,
+    }
+}
+
+/// Look up an LSA in the correct LSDB for its scope. Mirrors v2's
+/// `ospf_lsa_lookup`. Link-scope LSAs aren't yet tracked in any
+/// dedicated link-LSDB; they return `None` for now (same shape as
+/// v2's Unknown-scope fallthrough).
+fn ospfv3_lsa_lookup<'a>(
+    oi: &'a OspfInterface<Ospfv3>,
+    h: &Ospfv3LsaHeader,
+) -> Option<&'a Ospfv3Lsa> {
+    let key: super::lsdb::OspfLsaKey = (h.ls_type, h.link_state_id, h.advertising_router);
+    match ospfv3_ls_type_scope(h.ls_type) {
+        Ospfv3LsaScope::Area => oi.lsdb.lookup_by_raw_key(key),
+        Ospfv3LsaScope::As => oi.lsdb_as.lookup_by_raw_key(key),
+        Ospfv3LsaScope::Link | Ospfv3LsaScope::Reserved => None,
+    }
+}
+
 /// Per-DBD processing once both sides have agreed on master / slave.
-/// Mirrors v2's `ospf_db_desc_proc`. **Scope note:** the per-header
-/// LSA lookup (which decides whether to queue an LS Request) is
-/// intentionally skipped in this PR — the v3 LSDB lookup helper +
-/// `V::send_ls_request` lift land in the next PR. Loading therefore
-/// completes immediately with an empty `ls_req` list.
+/// Mirrors v2's `ospf_db_desc_proc`. Walks the received LSA headers
+/// and queues an LS Request for any LSA we don't already hold.
 fn ospfv3_db_desc_proc(
     oi: &mut OspfInterface<Ospfv3>,
     nbr: &mut Neighbor<Ospfv3>,
@@ -389,8 +425,23 @@ fn ospfv3_db_desc_proc(
 ) {
     nbr.dd.recv = dd.clone();
 
-    // TODO: walk `dd.lsa_headers`, call v3 LSDB lookup, add missing
-    // entries to `nbr.ls_req`, arm ls_req timer. Tracked separately.
+    // RFC 2328 §10.6 (reused by v3): for each header in the
+    // received DBD, if we don't already have the LSA, add it to
+    // the LS Request list and (re)arm the LS Request timer.
+    let mut added = false;
+    for h in dd.lsa_headers.iter() {
+        if ospfv3_lsa_lookup(oi, h).is_none() {
+            nbr.ls_req.push(Ospfv3LsRequestEntry::new(
+                h.ls_type,
+                h.link_state_id,
+                h.advertising_router,
+            ));
+            added = true;
+        }
+    }
+    if added {
+        super::nfsm::ospf_nfsm_ls_req_timer_on(nbr, oi.retransmit_interval);
+    }
 
     let oident = *oi.ident;
 


### PR DESCRIPTION
## Summary

Lift the TODO inside `ospfv3_db_desc_proc` (#777). The v3 DBD recv state machine can now actually populate `nbr.ls_req` with LSAs the peer holds but we don't — so two v3 routers reach Exchange with a non-empty LS Request list, ready for the `ospfv3_ls_req_send` PR.

### `lsdb.rs`

- Add `Lsdb::lookup_by_raw_key(key: OspfLsaKey) -> Option<&V::Lsa>` to `impl<V: OspfVersion>`. Same as `lookup_by_id` but accepts the flat 3-tuple key directly, so v3 callers don't have to go through the v2-typed `OspfLsType` conversion. v3 carries `ls_type` as a raw `u16` per RFC 5340 §A.4.2.1.

### `packet_v3.rs`

- `Ospfv3LsaScope` + `ospfv3_ls_type_scope` decode the v3 ls_type scope bits (S2|S1) per §A.4.2.1. Bits 14:13 give scope: `00` = link-local, `01` = area, `10` = AS, `11` = reserved.
- `ospfv3_lsa_lookup(oi, h)` mirrors v2's `ospf_lsa_lookup`. Routes area-scope to `oi.lsdb`, AS-scope to `oi.lsdb_as`. Link-scope returns `None` for now — zebra-rs doesn't yet maintain a per-link LSDB (where Link-LSAs would live); that lands with the v3 LSA origination wiring.
- `ospfv3_db_desc_proc` walks `dd.lsa_headers`, calls the lookup for each, pushes `Ospfv3LsRequestEntry` for missing LSAs, and arms the LS Request timer via the now-generic `ospf_nfsm_ls_req_timer_on` (#771).

### What's next

After this PR, two v3 routers complete ExStart → Exchange and queue LS Requests for missing LSAs. `Ospfv3::send_ls_request` is still a no-op (#771), so the requests aren't actually emitted on the wire — that's the next PR.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace` — verified by CI

Generated with [Claude Code](https://claude.com/claude-code)