### PR TITLE
zebra-rs: bump libyang for inline-union arm fix

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -19,7 +19,7 @@ tokio-stream.workspace = true
 tonic.workspace = true
 tonic-prost.workspace = true
 console-subscriber = "0.5"
-libyang = { git = "https://github.com/zebra-rs/libyang", rev = "e2825a7fd41cce5331a254fe2d8202b0f44dea6a" }
+libyang = { git = "https://github.com/zebra-rs/libyang", rev = "afe164df37bfb1137bb50088d80b2b515d749903" }
 #libyang = { path = "../../libyang" }
 regex = "1.10"
 similar = "3"


### PR DESCRIPTION
## Summary
- Bump `libyang` git rev in `zebra-rs/Cargo.toml:22` from `e2825a7…` to the merge commit `afe164d…` (zebra-rs/libyang#22).
- That libyang fix preserves inline non-`Path` arms in unions declared directly on a leaf. Without it, the `router ospf area <decimal>` form did not match because the inline `type uint32;` arm of the `area-id` union (`zebra-rs/yang/config.yang:321-324`) was silently dropped during YANG store resolution; only the `inet:ipv4-address` arm survived. No zebra-rs schema or matcher change is needed.

## Test plan
- [x] `cargo build -p zebra-rs` clean.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [ ] In the CLI, confirm `router ospf area 0` now matches alongside `router ospf area 0.0.0.0`.

Generated with [Claude Code](https://claude.com/claude-code)