### PR TITLE
bgp-packet: decode MUP Type 2 Direct Segment Discovery body

### DIFF
--- a/crates/bgp-packet/src/attrs/mp_reach.rs
+++ b/crates/bgp-packet/src/attrs/mp_reach.rs
@@ -561,11 +561,16 @@ mod tests {
         v
     }
 
+    /// Minimal DSD body for the IPv4 outer AFI: 8 RD + 4 zero address bytes.
+    fn min_dsd_body_v4() -> Vec<u8> {
+        vec![0u8; 8 + 4]
+    }
+
     #[test]
     fn mup_ipv4_round_trip_via_parse_nlri_opt() {
         let nhop: Ipv4Addr = "192.0.2.1".parse().unwrap();
         let mut nlri = mup_nlri(1, &min_isd_body());
-        nlri.extend_from_slice(&mup_nlri(2, &[0x01, 0x02]));
+        nlri.extend_from_slice(&mup_nlri(2, &min_dsd_body_v4()));
         let value = build(1, 85, &nhop.octets(), &nlri);
         let (_rest, mp) = MpReachAttr::parse_nlri_opt(&value, None).expect("must parse");
         match mp {

--- a/crates/bgp-packet/src/attrs/mp_unreach.rs
+++ b/crates/bgp-packet/src/attrs/mp_unreach.rs
@@ -367,7 +367,9 @@ mod tests {
 
     #[test]
     fn mup_ipv6_unreach_round_trips() {
-        let nlri = mup_nlri(2, &[0x10]);
+        // Minimal DSD body for IPv6 outer AFI: 8 RD + 16 zero address bytes.
+        let dsd_body = vec![0u8; 8 + 16];
+        let nlri = mup_nlri(2, &dsd_body);
         let value = build(2, &nlri);
         let (_rest, mp) = MpUnreachAttr::parse_nlri_opt(&value, None).expect("must parse");
         match mp {

--- a/crates/bgp-packet/src/attrs/nlri_mup.rs
+++ b/crates/bgp-packet/src/attrs/nlri_mup.rs
@@ -14,18 +14,20 @@
 //! +------------------------------------+
 //! ```
 //!
-//! As of Phase 4, the Type 1 (Interwork Segment Discovery, §3.1.1)
-//! body is decoded into typed fields (RD + prefix). Types 2–4 remain
-//! opaque (`Vec<u8>`) and land in Phases 5–6. Add-Path follows the
-//! EVPN convention used elsewhere in this crate: a non-zero `id`
-//! signals a 4-octet RFC 7911 Path Identifier on the wire.
+//! As of Phase 5, Type 1 (Interwork Segment Discovery, §3.1.1) and
+//! Type 2 (Direct Segment Discovery, §3.1.2) bodies are decoded into
+//! typed fields. Types 3–4 remain opaque (`Vec<u8>`) and land in
+//! Phase 6. Add-Path follows the EVPN convention used elsewhere in
+//! this crate: a non-zero `id` signals a 4-octet RFC 7911 Path
+//! Identifier on the wire.
 //!
-//! Parsing the typed ISD body requires the outer AFI (IPv4 ⇒ 4-octet
-//! prefix max; IPv6 ⇒ 16-octet prefix max), so `MupRoute::parse` is
-//! an associated function rather than a `ParseNlri` impl — that
-//! trait's signature does not carry AFI context.
+//! Parsing the typed ISD / DSD bodies requires the outer AFI
+//! (IPv4 ⇒ 4-octet address; IPv6 ⇒ 16-octet address), so
+//! `MupRoute::parse` is an associated function rather than a
+//! `ParseNlri` impl — that trait's signature does not carry AFI
+//! context.
 
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use bytes::{BufMut, BytesMut};
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
@@ -122,10 +124,16 @@ pub enum MupRoute {
         rd: RouteDistinguisher,
         prefix: IpNet,
     },
+    /// Direct Segment Discovery Route (RFC 9833 §3.1.2).
+    ///
+    /// Wire body: 8-octet RD + 4-octet (IPv4) or 16-octet (IPv6)
+    /// segment endpoint address. The address family is selected by
+    /// the outer AFI at parse time.
     Dsd {
         id: u32,
         arch: MupArchitectureType,
-        body: Vec<u8>,
+        rd: RouteDistinguisher,
+        address: IpAddr,
     },
     T1st {
         id: u32,
@@ -181,8 +189,13 @@ impl MupRoute {
     pub fn body_len(&self) -> usize {
         match self {
             MupRoute::Isd { prefix, .. } => 8 + 1 + nlri_psize(prefix.prefix_len()),
-            MupRoute::Dsd { body, .. }
-            | MupRoute::T1st { body, .. }
+            MupRoute::Dsd { address, .. } => {
+                8 + match address {
+                    IpAddr::V4(_) => 4,
+                    IpAddr::V6(_) => 16,
+                }
+            }
+            MupRoute::T1st { body, .. }
             | MupRoute::T2st { body, .. }
             | MupRoute::Unknown { body, .. } => body.len(),
         }
@@ -244,11 +257,34 @@ impl MupRoute {
                     prefix,
                 }
             }
-            MupRouteType::Dsd => MupRoute::Dsd {
-                id,
-                arch,
-                body: body_slice.to_vec(),
-            },
+            MupRouteType::Dsd => {
+                let (rest, rd) = RouteDistinguisher::parse_be(body_slice)?;
+                let address = match afi {
+                    Afi::Ip => {
+                        if rest.len() < 4 {
+                            return Err(nom::Err::Error(make_error(input, ErrorKind::Eof)));
+                        }
+                        let mut octets = [0u8; 4];
+                        octets.copy_from_slice(&rest[..4]);
+                        IpAddr::V4(Ipv4Addr::from(octets))
+                    }
+                    Afi::Ip6 => {
+                        if rest.len() < 16 {
+                            return Err(nom::Err::Error(make_error(input, ErrorKind::Eof)));
+                        }
+                        let mut octets = [0u8; 16];
+                        octets.copy_from_slice(&rest[..16]);
+                        IpAddr::V6(Ipv6Addr::from(octets))
+                    }
+                    _ => return Err(nom::Err::Error(make_error(input, ErrorKind::Verify))),
+                };
+                MupRoute::Dsd {
+                    id,
+                    arch,
+                    rd,
+                    address,
+                }
+            }
             MupRouteType::T1st => MupRoute::T1st {
                 id,
                 arch,
@@ -295,8 +331,15 @@ impl MupRoute {
                     IpNet::V6(p) => payload.put(&p.addr().octets()[..psize]),
                 }
             }
-            MupRoute::Dsd { body, .. }
-            | MupRoute::T1st { body, .. }
+            MupRoute::Dsd { rd, address, .. } => {
+                payload.put_u16(rd.typ as u16);
+                payload.put(&rd.val[..]);
+                match address {
+                    IpAddr::V4(v4) => payload.put(&v4.octets()[..]),
+                    IpAddr::V6(v6) => payload.put(&v6.octets()[..]),
+                }
+            }
+            MupRoute::T1st { body, .. }
             | MupRoute::T2st { body, .. }
             | MupRoute::Unknown { body, .. } => {
                 payload.put(&body[..]);
@@ -480,16 +523,67 @@ mod tests {
     }
 
     #[test]
-    fn dsd_opaque_round_trip() {
+    fn dsd_v4_round_trip() {
         round_trip(
             MupRoute::Dsd {
                 id: 0,
                 arch: MupArchitectureType::Gpp5g,
-                body: vec![1, 2, 3],
+                rd: sample_rd(),
+                address: "203.0.113.7".parse().unwrap(),
             },
             false,
             Afi::Ip,
         );
+    }
+
+    #[test]
+    fn dsd_v6_round_trip() {
+        round_trip(
+            MupRoute::Dsd {
+                id: 0,
+                arch: MupArchitectureType::Gpp5g,
+                rd: sample_rd(),
+                address: "2001:db8::1".parse().unwrap(),
+            },
+            false,
+            Afi::Ip6,
+        );
+    }
+
+    #[test]
+    fn dsd_add_path_round_trip() {
+        round_trip(
+            MupRoute::Dsd {
+                id: 0xDEADBEEF,
+                arch: MupArchitectureType::Gpp5g,
+                rd: sample_rd(),
+                address: "192.0.2.99".parse().unwrap(),
+            },
+            true,
+            Afi::Ip,
+        );
+    }
+
+    #[test]
+    fn dsd_v4_truncated_address_errors() {
+        // length=11 = 8 RD + 3 bytes (one short of the IPv4 address).
+        let mut v = vec![0x01, 0x00, 0x02, 11];
+        v.extend_from_slice(&[0; 8]);
+        v.extend_from_slice(&[10, 0, 0]);
+        assert!(MupRoute::parse(&v, false, Afi::Ip).is_err());
+    }
+
+    #[test]
+    fn dsd_body_len_matches_emitted_size() {
+        let route = MupRoute::Dsd {
+            id: 0,
+            arch: MupArchitectureType::Gpp5g,
+            rd: sample_rd(),
+            address: "2001:db8::1".parse().unwrap(),
+        };
+        let mut buf = BytesMut::new();
+        route.nlri_emit(&mut buf);
+        assert_eq!(buf.len(), 4 + route.body_len());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Phase 5 of BGP SRv6 MUP support (RFC 9833 §3.1.2). The Type 2 Direct Segment Discovery route now carries typed fields (`rd: RouteDistinguisher`, `address: IpAddr`) instead of opaque bytes. IPv4 outer AFI parses a 4-octet address, IPv6 a 16-octet address. Types 3/4 stay opaque until Phase 6.
- `body_len()` derives the encoded size for DSD as 8 + 4 (v4) or 8 + 16 (v6). Add-Path round-trip matches ISD.
- Phase 3 dispatch tests that previously used a 1–2-byte opaque DSD payload are updated to a minimum-valid DSD body (RD + zero address) so they still exercise the shell against the now-strict parser.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p bgp-packet` (141 unit tests, 0 failures; 5 new DSD tests: IPv4 round-trip, IPv6 round-trip, Add-Path, truncated-address rejection, and the body-len ↔ emitted-size invariant)

Generated with [Claude Code](https://claude.com/claude-code)