### PR TITLE
ospf: add v3 network_lsa_originate + Full-transition wiring

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1955,9 +1955,25 @@ impl Ospf<Ospfv3> {
                 super::packet_v3::ospfv3_hello_send(link, tx);
             }
             Message::Nfsm(index, src, ev) => {
+                let old_state = self
+                    .links
+                    .get(&index)
+                    .and_then(|link| link.nbrs.get(&src))
+                    .map(|nbr| nbr.state);
+
                 if let Some((mut link, nbr)) = self.ospf_interface(index, &src) {
                     let ident = link.ident;
                     super::nfsm::ospf_nfsm(&mut link, nbr, ev, ident);
+                }
+
+                let new_state = self
+                    .links
+                    .get(&index)
+                    .and_then(|link| link.nbrs.get(&src))
+                    .map(|nbr| nbr.state);
+
+                if let (Some(old_state), Some(new_state)) = (old_state, new_state) {
+                    self.process_neighbor_state_change(index, src, old_state, new_state);
                 }
             }
             other => {
@@ -1967,6 +1983,126 @@ impl Ospf<Ospfv3> {
                 );
             }
         }
+    }
+
+    /// Detect Full state transitions on `nbr` and re-originate the
+    /// LSAs that depend on the full-adjacency set. Mirrors v2's
+    /// `process_neighbor_state_change`:
+    ///
+    /// - Router-LSA always re-originates when Full changes (since
+    ///   transit-network link records list only Full-DR adjacencies).
+    /// - Network-LSA (DR only) re-originates / flushes based on the
+    ///   updated Full-neighbor set.
+    fn process_neighbor_state_change(
+        &mut self,
+        ifindex: u32,
+        nbr_addr: Ipv4Addr,
+        old_state: NfsmState,
+        new_state: NfsmState,
+    ) {
+        if old_state == new_state {
+            return;
+        }
+        let full_state_changed = (old_state == NfsmState::Full && new_state != NfsmState::Full)
+            || (old_state != NfsmState::Full && new_state == NfsmState::Full);
+        if !full_state_changed {
+            return;
+        }
+
+        let if_state = {
+            let Some(link) = self.links.get_mut(&ifindex) else {
+                return;
+            };
+            link.full_nbr_count = link
+                .nbrs
+                .values()
+                .filter(|nbr| nbr.state == NfsmState::Full)
+                .count();
+            link.state
+        };
+
+        tracing::info!(
+            "[v3 NFSM:FullTransition] ifindex={} nbr={} {} -> {}",
+            ifindex,
+            nbr_addr,
+            old_state,
+            new_state
+        );
+
+        self.router_lsa_originate();
+
+        if if_state == IfsmState::DR {
+            self.network_lsa_originate(ifindex);
+        }
+    }
+
+    /// Originate (or flush) the v3 Network-LSA for the broadcast
+    /// segment on `ifindex`. Mirrors v2's
+    /// `update_network_lsa_by_interface` with the v3-specific
+    /// differences:
+    ///
+    /// - LS-ID is the DR's **Interface ID** (RFC 5340 §A.4.4),
+    ///   not the DR's interface IP as in v2.
+    /// - LSA-type is `OSPFV3_NETWORK_LSA_TYPE` (0x2002) — the v3
+    ///   ls_type doesn't compress to a v2 `OspfLsType`, so the
+    ///   LSDB flush uses `flush_lsa_by_raw_key`.
+    /// - The v3 body carries no netmask (prefixes move to
+    ///   Intra-Area-Prefix-LSA in v3).
+    ///
+    /// Flushes the existing Network-LSA when this router is no
+    /// longer DR or has no Full-adjacent neighbors on the segment;
+    /// otherwise installs the fresh LSA and floods it to every
+    /// Exchange-or-later neighbor in the area.
+    pub fn network_lsa_originate(&mut self, ifindex: u32) {
+        use ospf_packet::OSPFV3_NETWORK_LSA_TYPE;
+
+        let Some(link) = self.links.get(&ifindex) else {
+            return;
+        };
+        let area_id = link.area;
+        let interface_id = link.interface_id;
+        let is_dr = link.ident.d_router == self.router_id;
+        let full_nbr_count = link
+            .nbrs
+            .values()
+            .filter(|n| n.state == NfsmState::Full)
+            .count();
+
+        let key: super::lsdb::OspfLsaKey = (OSPFV3_NETWORK_LSA_TYPE, interface_id, self.router_id);
+
+        // No Full neighbors (or no longer DR): flush the LSA so
+        // receivers age it out of their LSDBs.
+        if !is_dr || full_nbr_count == 0 {
+            let flushed = if let Some(area) = self.areas.get_mut(area_id) {
+                area.lsdb.flush_lsa_by_raw_key(key, &self.tx, Some(area_id))
+            } else {
+                None
+            };
+            if let Some(lsa) = flushed {
+                self.flood_self_originated_lsa(area_id, &lsa);
+            }
+            return;
+        }
+
+        let Some(mut lsa) = self.build_network_lsa(ifindex) else {
+            return;
+        };
+
+        if let Some(area) = self.areas.get(area_id)
+            && let Some(prev_seq) = area
+                .lsdb
+                .lookup_by_raw_key(key)
+                .map(|prev| prev.h.ls_seq_number)
+        {
+            lsa.h.ls_seq_number = lsa.h.ls_seq_number.max(prev_seq.saturating_add(1));
+        }
+        lsa.update();
+
+        let flood_lsa = lsa.clone();
+        if let Some(area) = self.areas.get_mut(area_id) {
+            area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
+        }
+        self.flood_self_originated_lsa(area_id, &flood_lsa);
     }
 
     /// Dispatch one v3 packet received off the wire (`network_v6`).

--- a/zebra-rs/src/ospf/lsdb.rs
+++ b/zebra-rs/src/ospf/lsdb.rs
@@ -301,6 +301,27 @@ impl<V: OspfVersion> Lsdb<V> {
         self.tables.get(&key).map(|lsa| &lsa.data)
     }
 
+    /// Flush an LSA by the flat 3-tuple key directly. Same as
+    /// `flush_lsa` but accepts the raw key — used by v3 callers
+    /// where `ls_type` is a `u16` that doesn't compress to
+    /// `OspfLsType` (e.g. `OSPFV3_NETWORK_LSA_TYPE = 0x2002`).
+    pub fn flush_lsa_by_raw_key(
+        &mut self,
+        key: OspfLsaKey,
+        tx: &UnboundedSender<Message<V>>,
+        area_id: Option<Ipv4Addr>,
+    ) -> Option<V::Lsa> {
+        if let Some(lsa) = self.tables.get_mut(&key) {
+            V::set_ls_age(V::lsa_header_mut(&mut lsa.data), OSPF_MAX_AGE);
+            lsa.birth_time = tokio::time::Instant::now();
+            lsa.refresh_timer = None;
+            lsa.hold_timer = Some(hold_timer(tx, area_id, key, OSPF_MAX_AGE));
+            Some(lsa.data.clone())
+        } else {
+            None
+        }
+    }
+
     /// Look up the full LSDB entry (including bookkeeping) by key.
     /// Now generic.
     pub fn lookup_lsa(


### PR DESCRIPTION
## Summary

When two v3 routers reach Full on a broadcast segment, the elected DR now originates a Network-LSA listing all Full-adjacent routers (including itself); when they leave Full, it's re-originated or flushed. Mirrors v2's `update_network_lsa_by_interface` shape.

### `lsdb.rs`

- Add `Lsdb::flush_lsa_by_raw_key(key, tx, area_id)` — generic flush parallel to `lookup_by_raw_key` (#779). v3 needs it because `OSPFV3_NETWORK_LSA_TYPE = 0x2002` doesn't compress to a v2 `OspfLsType`.

### `impl Ospf<Ospfv3>`

- **`process_neighbor_state_change(ifindex, nbr_addr, old, new)`** — mirror of v2: skip if no Full-state change; recompute `link.full_nbr_count`; always re-originate Router-LSA; if `link.state == DR`, re-originate Network-LSA.

- **`network_lsa_originate(ifindex)`** — v3-specific differences from v2's helper:
  - LS-ID is the **Interface ID** (RFC 5340 §A.4.4), not the DR's interface IP.
  - LSA-type `OSPFV3_NETWORK_LSA_TYPE = 0x2002`; LSDB lookup / flush via `lookup_by_raw_key` / `flush_lsa_by_raw_key`.
  - No netmask in body (v3 moves prefixes to Intra-Area-Prefix-LSA).
  - If not DR or `full_nbr_count == 0`: flush via `flush_lsa_by_raw_key` and flood the MaxAge'd LSA so receivers age it out.
  - Otherwise: build via `build_network_lsa(ifindex)`, bump seq from prior LSDB entry, restamp via `Ospfv3Lsa::update`, install via `install_originated`, flood via `flood_self_originated_lsa`.

- `Message::Nfsm` arm in `process_msg` now snapshots neighbor state before/after the NFSM call and dispatches `process_neighbor_state_change` on transition.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 925 passed, 0 failed

Generated with [Claude Code](https://claude.com/claude-code)