### PR TITLE
ospf: spawn Ospf<Ospfv3> from config + minimal /enable callback

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -10,7 +10,7 @@ use super::files::load_config_file;
 use super::isis::{despawn_isis, spawn_isis};
 use super::json::json_read;
 use super::nd::spawn_nd;
-use super::ospf::{despawn_ospf, spawn_ospf};
+use super::ospf::{despawn_ospf, despawn_ospfv3, spawn_ospf, spawn_ospfv3};
 use super::parse::State;
 use super::parse::parse;
 use super::paths::{path_try_trim, paths_str};
@@ -365,6 +365,7 @@ impl ConfigManager {
         let remove_first_char = |s: &str| -> String { s.chars().skip(1).collect() };
 
         let mut ospf = false;
+        let mut ospfv3 = false;
         let mut isis = false;
         let mut bgp = false;
         let mut bfd = false;
@@ -421,7 +422,18 @@ impl ConfigManager {
             if paths.is_none() {
                 continue;
             }
-            if !ospf && op == ConfigOp::Set && line.starts_with("router ospf") {
+            // `router ospfv3` must be matched before `router ospf`:
+            // the latter's prefix-match would otherwise swallow it
+            // and spawn an OSPFv2 instance for a v3 config block.
+            if !ospfv3 && op == ConfigOp::Set && line.starts_with("router ospfv3") {
+                ospfv3 = true;
+                spawn_ospfv3(self);
+            }
+            if !ospf
+                && op == ConfigOp::Set
+                && line.starts_with("router ospf")
+                && !line.starts_with("router ospfv3")
+            {
                 ospf = true;
                 spawn_ospf(self);
             }
@@ -511,7 +523,17 @@ impl ConfigManager {
         if self.protocol_tasks.borrow().contains_key("bgp") && !proto_in_candidate("bgp") {
             despawn_bgp(self);
         }
-        if self.protocol_tasks.borrow().contains_key("ospf") && !proto_in_candidate("ospf") {
+        // `router ospf` vs `router ospfv3`: the prefix-match in
+        // `proto_in_candidate` would match v2 against a v3-only
+        // config, so look up v3 first with its full needle.
+        if self.protocol_tasks.borrow().contains_key("ospfv3") && !proto_in_candidate("ospfv3") {
+            despawn_ospfv3(self);
+        }
+        if self.protocol_tasks.borrow().contains_key("ospf")
+            && !candidate
+                .lines()
+                .any(|l| l.starts_with("router ospf") && !l.starts_with("router ospfv3"))
+        {
             despawn_ospf(self);
         }
         if self.protocol_tasks.borrow().contains_key("isis") && !proto_in_candidate("isis") {

--- a/zebra-rs/src/config/ospf.rs
+++ b/zebra-rs/src/config/ospf.rs
@@ -25,3 +25,30 @@ pub fn despawn_ospf(config: &ConfigManager) {
         proto: "ospf".to_string(),
     });
 }
+
+/// Spawn an OSPFv3 instance. Mirrors [`spawn_ospf`] but constructs
+/// `Ospf<Ospfv3>` instead of the default-typed `Ospf<Ospfv2>` and
+/// uses the `"ospfv3"` proto-name across the rib client / config
+/// manager / protocol-tasks tables so it doesn't collide with a
+/// concurrent OSPFv2 instance.
+pub fn spawn_ospfv3(config: &ConfigManager) {
+    let (rib_client, rib_rx) = config.subscribe_to_rib("ospfv3");
+    let ctx = ProtoContext::default_table(rib_client);
+    let ospf = inst::Ospf::<crate::ospf::Ospfv3>::new(ctx, rib_rx);
+    config.subscribe("ospfv3", ospf.cm.tx.clone());
+    config.subscribe_show("ospfv3", ospf.show.tx.clone());
+    let task = inst::serve_v3(ospf);
+    config
+        .protocol_tasks
+        .borrow_mut()
+        .insert("ospfv3".to_string(), task);
+}
+
+pub fn despawn_ospfv3(config: &ConfigManager) {
+    config.cm_clients.borrow_mut().remove("ospfv3");
+    config.show_clients.borrow_mut().remove("ospfv3");
+    config.protocol_tasks.borrow_mut().remove("ospfv3");
+    let _ = config.rib_tx.send(rib::Message::ProtoCleanup {
+        proto: "ospfv3".to_string(),
+    });
+}

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -5,11 +5,16 @@ use super::Ospf;
 use super::OspfLink;
 use super::ifsm::{IfsmEvent, ospf_hello_timer};
 use super::tracing::{config_tracing_fsm, config_tracing_packet};
+use super::version::{OspfVersion, Ospfv2};
 
 use crate::config::{Args, ConfigOp};
 use crate::ospf::Message;
 
-pub type Callback = fn(&mut Ospf, Args, ConfigOp) -> Option<()>;
+/// YANG-path → handler dispatch type. Parameterized over `V` so an
+/// `Ospf<Ospfv3>` instance carries its own `Callback<Ospfv3>` table,
+/// distinct from `Ospf<Ospfv2>`'s. Defaults to `Ospfv2` to keep
+/// existing v2 callsites resolving unchanged.
+pub type Callback<V = Ospfv2> = fn(&mut Ospf<V>, Args, ConfigOp) -> Option<()>;
 
 impl Ospf {
     const OSPF: &str = "/router/ospf";
@@ -62,7 +67,7 @@ impl Ospf {
 /// the 32-bit area ID. `area 0` and `area 0.0.0.0` both normalize to
 /// `0.0.0.0`. Tries dotted-quad first (more specific) so a bare digit
 /// only falls through to the decimal interpretation.
-fn parse_area_id(s: &str) -> Option<Ipv4Addr> {
+pub(super) fn parse_area_id(s: &str) -> Option<Ipv4Addr> {
     if let Ok(addr) = s.parse::<Ipv4Addr>() {
         return Some(addr);
     }
@@ -73,7 +78,7 @@ fn parse_area_id(s: &str) -> Option<Ipv4Addr> {
 /// comes from the parent `area` list in the YANG schema; each
 /// per-interface callback writes it into `link.config.area` so this
 /// IFSM transition helper keeps working unchanged.
-pub(super) fn link_should_enable(link: &OspfLink) -> (bool, Ipv4Addr) {
+pub(super) fn link_should_enable<V: OspfVersion>(link: &OspfLink<V>) -> (bool, Ipv4Addr) {
     if !link.config.enable {
         return (false, Ipv4Addr::UNSPECIFIED);
     }
@@ -81,7 +86,11 @@ pub(super) fn link_should_enable(link: &OspfLink) -> (bool, Ipv4Addr) {
     (true, area)
 }
 
-pub(super) fn apply_link_enable_transition(link: &OspfLink, next: bool, next_id: Ipv4Addr) {
+pub(super) fn apply_link_enable_transition<V: OspfVersion>(
+    link: &OspfLink<V>,
+    next: bool,
+    next_id: Ipv4Addr,
+) {
     let curr = link.enabled;
     let curr_id = link.area_id;
 
@@ -107,10 +116,10 @@ fn config_ospf_router_id(_ospf: &mut Ospf, mut args: Args, _op: ConfigOp) -> Opt
     None
 }
 
-fn ospf_link_get_mut_by_name<'a>(
-    links: &'a mut BTreeMap<u32, OspfLink>,
+pub(super) fn ospf_link_get_mut_by_name<'a, V: OspfVersion>(
+    links: &'a mut BTreeMap<u32, OspfLink<V>>,
     name: &str,
-) -> Option<&'a mut OspfLink> {
+) -> Option<&'a mut OspfLink<V>> {
     links.values_mut().find(|link| link.name == name)
 }
 

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -1,0 +1,70 @@
+//! OSPFv3 YANG-path callback handlers.
+//!
+//! Sibling of v2's `config.rs`. Currently registers just the
+//! `/area/interface/enable` handler — the minimum needed for a v3
+//! instance to bring an interface up via the existing
+//! `container ospfv3 { area { interface { enable } } }` YANG stub
+//! (PR #759). Per-link priority / hello-interval / dead-interval /
+//! retransmit-interval / mtu-ignore / prefix-sid callbacks aren't
+//! in the v3 YANG schema yet; they're added alongside the schema
+//! expansion in a follow-up.
+
+use super::config::{
+    Callback, apply_link_enable_transition, link_should_enable, ospf_link_get_mut_by_name,
+    parse_area_id,
+};
+use super::version::Ospfv3;
+use super::{Ospf, OspfLink};
+
+use crate::config::{Args, ConfigOp};
+
+const OSPFV3: &str = "/router/ospfv3";
+
+impl Ospf<Ospfv3> {
+    /// Register the v3 YANG-path → handler dispatch table. Mirrors
+    /// v2's `callback_build` shape; the table is keyed by full path
+    /// (e.g. `/router/ospfv3/area/interface/enable`) so `process_msg`
+    /// can look up handlers directly.
+    pub fn callback_build(&mut self) {
+        let prefix = OSPFV3;
+        self.callbacks.insert(
+            format!("{}{}", prefix, "/area/interface/enable"),
+            config_ospfv3_interface_enable as Callback<Ospfv3>,
+        );
+    }
+}
+
+/// Toggle the link's `enabled` state and re-evaluate the IFSM
+/// transition. Mirrors v2's `config_ospf_interface_enable`: the
+/// path-args queue carries `(area-id, if-name, enable-bool)`.
+///
+/// On `Set` with `enable = true`, the area is captured from the
+/// parent list key; on `Delete` (or `enable = false`), both `enable`
+/// and the cached area are cleared. The transition helper
+/// (`apply_link_enable_transition`) fires `Message::Enable` /
+/// `Message::Disable` into the instance channel, which drives the
+/// v3 cascade (LSA origination, IFSM `InterfaceUp` / `Down`).
+fn config_ospfv3_interface_enable(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let enable = args.boolean()?;
+
+    let link: &mut OspfLink<Ospfv3> = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+
+    if op.is_set() {
+        link.config.enable = enable;
+        link.config.area = Some(area_id);
+    } else {
+        link.config.enable = false;
+        link.config.area = None;
+    }
+
+    let (next, next_id) = link_should_enable(link);
+    apply_link_enable_transition(link, next, next_id);
+
+    Some(())
+}

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -60,7 +60,7 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     pub rx: UnboundedReceiver<Message<V>>,
     pub ptx: UnboundedSender<Message<V>>,
     pub cm: ConfigChannel,
-    pub callbacks: HashMap<String, Callback>,
+    pub callbacks: HashMap<String, Callback<V>>,
     pub ctx: crate::context::ProtoContext,
     pub rib_rx: UnboundedReceiver<RibRx>,
     pub links: BTreeMap<u32, OspfLink<V>>,
@@ -1453,7 +1453,7 @@ impl Ospf<Ospfv3> {
             });
         }
 
-        Self {
+        let mut ospf = Self {
             tx,
             rx,
             ptx,
@@ -1478,6 +1478,19 @@ impl Ospf<Ospfv3> {
             sock,
             v3_send_tx: Some(v3_send_tx),
             v3_recv_rx: Some(v3_recv_rx),
+        };
+        ospf.callback_build();
+        ospf
+    }
+
+    /// Look up the v3 YANG-path handler for `msg.paths` and invoke
+    /// it. Mirrors v2's `process_cm_msg`. Currently only
+    /// `/router/ospfv3/area/interface/enable` is registered (#791-stub
+    /// path); more leaves land alongside the YANG schema expansion.
+    pub fn process_cm_msg(&mut self, msg: ConfigRequest) {
+        let (path, args) = path_from_command(&msg.paths);
+        if let Some(f) = self.callbacks.get(&path) {
+            f(self, args, msg.op);
         }
     }
 
@@ -2210,9 +2223,10 @@ impl Ospf<Ospfv3> {
         }
     }
 
-    /// Main event loop for the v3 instance. Mirrors v2's `event_loop`
-    /// but only `rx` / `rib_rx` / the v3 packet recv channel are
-    /// wired; `cm.rx` / `show.rx` follow with the v3 config schema.
+    /// Main event loop for the v3 instance. Mirrors v2's `event_loop`:
+    /// pulls instance events from `rx`, RIB updates from `rib_rx`,
+    /// config-manager requests from `cm.rx`, show requests from
+    /// `show.rx`, and v3 packets from `v3_recv_rx`.
     ///
     /// `self.v3_recv_rx` is taken out of the `Option` at start so
     /// the `select!` arm doesn't have to re-borrow it through the
@@ -2231,6 +2245,12 @@ impl Ospf<Ospfv3> {
                 Some(_msg) = self.rib_rx.recv() => {
                     // v3 RIB integration TBD; drain for now so the
                     // channel doesn't back-pressure the rib client.
+                }
+                Some(msg) = self.cm.rx.recv() => {
+                    self.process_cm_msg(msg);
+                }
+                Some(_msg) = self.show.rx.recv() => {
+                    // v3 show path TBD; drain for now.
                 }
                 Some(recv) = v3_recv_rx.recv() => {
                     self.process_recv(recv);

--- a/zebra-rs/src/ospf/mod.rs
+++ b/zebra-rs/src/ospf/mod.rs
@@ -31,6 +31,8 @@ pub mod show;
 
 pub mod config;
 
+pub mod config_v3;
+
 pub mod network;
 
 pub mod network_v6;


### PR DESCRIPTION
## Summary

Make the v3 instance reachable end-to-end from the config-manager path. A live `router ospfv3 { area N { interface X { enable true } } }` block now spawns an `Ospf<Ospfv3>`, dispatches the config callback into the v3 instance, fires `Message::Enable`, and kicks off the cascade (Router-LSA + Intra-Area-Prefix-LSA origination, IFSM `InterfaceUp`, Hello on `ff02::5`).

### Genericization (prep)

- `config.rs`: `Callback` becomes `Callback<V = Ospfv2>` — v2 callsites unchanged. Helpers `link_should_enable`, `apply_link_enable_transition`, `ospf_link_get_mut_by_name`, `parse_area_id` lifted to `<V: OspfVersion>` so v3 can share them.
- `inst.rs`: `Ospf::callbacks` typed `HashMap<String, Callback<V>>`.

### New v3 module

- **`config_v3.rs`**: registers `/router/ospfv3/area/interface/enable` → `config_ospfv3_interface_enable`, which mirrors the v2 handler exactly (the helpers it calls are now generic). `Ospf<Ospfv3>::callback_build` is defined here.

### v3 instance plumbing

- `inst.rs::Ospf<Ospfv3>::new` calls `callback_build()` before returning.
- Adds `process_cm_msg(msg)`.
- `event_loop` gains `select!` arms for `cm.rx` (dispatch via `process_cm_msg`) and `show.rx` (drained stub).

### Spawn wiring

- `config/ospf.rs::spawn_ospfv3` / `despawn_ospfv3` — mirrors `spawn_ospf`. Subscribes under `"ospfv3"` (distinct proto-name so the two can coexist). Uses `inst::serve_v3`.
- `config/manager.rs` adds `ospfv3` state guard. Matches `router ospfv3` **before** `router ospf` because the latter's prefix-match would otherwise swallow v3 lines. Despawn similarly disambiguated.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 925 passed, 0 failed

Generated with [Claude Code](https://claude.com/claude-code)