### PR TITLE
ospf: per-area SPF in-flight gate (v2 + v3)

### DIFF
--- a/zebra-rs/src/ospf/area.rs
+++ b/zebra-rs/src/ospf/area.rs
@@ -67,6 +67,13 @@ pub struct OspfArea<V: OspfVersion = Ospfv2> {
 
     // SPF calculation timer.
     pub spf_timer: Option<Timer>,
+
+    // SPF in-flight gate: true while a SPF run for this area is
+    // executing. New `Message::SpfCalc(area_id)` events that arrive
+    // during a run set `spf_pending` instead of starting a second
+    // SPF; the completion path re-fires exactly one follow-up.
+    pub spf_inflight: bool,
+    pub spf_pending: bool,
 }
 
 impl<V: OspfVersion> OspfArea<V> {
@@ -77,6 +84,8 @@ impl<V: OspfVersion> OspfArea<V> {
             links: BTreeSet::new(),
             lsdb: Lsdb::<V>::new(),
             spf_timer: None,
+            spf_inflight: false,
+            spf_pending: false,
         }
     }
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1337,11 +1337,26 @@ impl Ospf<Ospfv2> {
                 }
             }
             Message::SpfCalc(area_id) => {
-                if let Some(area) = self.areas.get_mut(area_id) {
-                    area.spf_timer = None;
+                let Some(area) = self.areas.get_mut(area_id) else {
+                    return;
+                };
+                if area.spf_inflight {
+                    // A SPF is already running for this area. Remember
+                    // that another trigger arrived; the completion
+                    // path re-fires exactly one follow-up SpfCalc.
+                    area.spf_pending = true;
+                    return;
                 }
+                area.spf_timer = None;
+                area.spf_inflight = true;
                 tracing::info!("[SPF] Calculation triggered for area {}", area_id);
                 perform_spf_calculation(self, area_id);
+                if let Some(area) = self.areas.get_mut(area_id) {
+                    area.spf_inflight = false;
+                    if std::mem::take(&mut area.spf_pending) {
+                        let _ = self.tx.send(Message::SpfCalc(area_id));
+                    }
+                }
             }
             _ => {}
         }
@@ -2061,11 +2076,26 @@ impl Ospf<Ospfv3> {
                 }
             }
             Message::SpfCalc(area_id) => {
-                if let Some(area) = self.areas.get_mut(area_id) {
-                    area.spf_timer = None;
+                let Some(area) = self.areas.get_mut(area_id) else {
+                    return;
+                };
+                if area.spf_inflight {
+                    // A SPF is already running for this area. Remember
+                    // that another trigger arrived; the completion
+                    // path re-fires exactly one follow-up SpfCalc.
+                    area.spf_pending = true;
+                    return;
                 }
+                area.spf_timer = None;
+                area.spf_inflight = true;
                 tracing::info!("[v3 SPF] Calculation triggered for area {}", area_id);
                 self.perform_spf_calculation(area_id);
+                if let Some(area) = self.areas.get_mut(area_id) {
+                    area.spf_inflight = false;
+                    if std::mem::take(&mut area.spf_pending) {
+                        let _ = self.tx.send(Message::SpfCalc(area_id));
+                    }
+                }
             }
             Message::Lsdb(ev, area_id, key) => {
                 // RFC 2328 §13.4: a peer flooded our own LSA back to


### PR DESCRIPTION
## Summary
- Add `spf_inflight` / `spf_pending` booleans to `OspfArea<V>` (shared by v2 and v3).
- Gate both `Message::SpfCalc` handlers: while a SPF is running for an area, additional triggers set `spf_pending` instead of starting a second SPF; the completion path clears `spf_inflight` and re-fires exactly one follow-up. Bursts collapse into a single re-run.
- Preparation for moving SPF onto `tokio::task::spawn_blocking`. No behavior change today: SPF is still synchronous inline, so `spf_inflight` is always observed as `false` at handler entry and the re-fire path is dead.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI green
- [ ] Sanity-check: SPF still runs on LSA install / AS-scope events (no regression vs. current synchronous path)

Generated with [Claude Code](https://claude.com/claude-code)