### PR TITLE
ospf: flood received v3 LSAs through area, exempting source

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1870,18 +1870,23 @@ impl Ospf<Ospfv3> {
         self.flood_self_originated_lsa(AREA0, &flood_lsa);
     }
 
-    /// Flood a self-originated v3 LSA to every Exchange-or-later
-    /// neighbor in the area. Minimal RFC 2328 §13.3 — no DR / BDR
-    /// ordering, no retransmit-list bookkeeping, no ls_req cleanup
-    /// for Exchange / Loading neighbors. Those land alongside the
-    /// §13.1 hardening of `ospfv3_ls_upd_recv`.
+    /// Flood a v3 LSA through `area_id`, optionally exempting the
+    /// source neighbor that fed it to us (RFC 2328 §13.3 Step 1c).
+    /// Mirrors v2's `flood_lsa_through_area`.
     ///
-    /// The LSU goes through the dedicated `Ospfv3Send` channel so
-    /// `network_v6::write_packet_v6` stamps the IPv6 pseudo-header
-    /// checksum. Source = the link's first link-local v6; dest =
-    /// the neighbor's link-local (the `/128` captured in
-    /// `ospfv3_hello_recv`).
-    fn flood_self_originated_lsa(&mut self, area_id: Ipv4Addr, lsa: &ospf_packet::Ospfv3Lsa) {
+    /// `source = None` is the self-origination path: every
+    /// Exchange-or-later neighbor on every area link is a
+    /// recipient. `source = Some((ifindex, nbr_v6))` is the
+    /// "received LSA" path: skip the (ifindex, neighbor link-local
+    /// v6) we got the LSA from. v3 identifies the source neighbor
+    /// by link-local v6 because that's what `Message::Flood<Ospfv3>`
+    /// carries (`V::Addr = Ipv6Addr`).
+    fn flood_lsa_through_area(
+        &mut self,
+        area_id: Ipv4Addr,
+        lsa: &ospf_packet::Ospfv3Lsa,
+        source: Option<(u32, std::net::Ipv6Addr)>,
+    ) {
         use ospf_packet::{Ospfv3LsUpdate, Ospfv3Packet, Ospfv3Payload};
 
         let Some(tx) = self.v3_send_tx.as_ref().cloned() else {
@@ -1903,13 +1908,16 @@ impl Ospf<Ospfv3> {
                 continue;
             };
 
-            // Snapshot Exchange-or-later neighbors as (router_id,
-            // link-local v6) so we can release the &link borrow
-            // before pushing into the channel.
             let recipients: Vec<(Ipv4Addr, std::net::Ipv6Addr)> = link
                 .nbrs
                 .values()
                 .filter(|n| n.state >= NfsmState::Exchange)
+                .filter(|n| match source {
+                    Some((src_if, src_v6)) => {
+                        !(ifindex == src_if && n.ident.prefix.addr() == src_v6)
+                    }
+                    None => true,
+                })
                 .map(|n| (n.ident.router_id, n.ident.prefix.addr()))
                 .collect();
 
@@ -1934,6 +1942,21 @@ impl Ospf<Ospfv3> {
                 }
             }
         }
+    }
+
+    /// Flood a self-originated v3 LSA to every Exchange-or-later
+    /// neighbor in the area. Minimal RFC 2328 §13.3 — no DR / BDR
+    /// ordering, no retransmit-list bookkeeping, no ls_req cleanup
+    /// for Exchange / Loading neighbors. Those land alongside the
+    /// §13.1 hardening of `ospfv3_ls_upd_recv`.
+    ///
+    /// The LSU goes through the dedicated `Ospfv3Send` channel so
+    /// `network_v6::write_packet_v6` stamps the IPv6 pseudo-header
+    /// checksum. Source = the link's first link-local v6; dest =
+    /// the neighbor's link-local (the `/128` captured in
+    /// `ospfv3_hello_recv`).
+    fn flood_self_originated_lsa(&mut self, area_id: Ipv4Addr, lsa: &ospf_packet::Ospfv3Lsa) {
+        self.flood_lsa_through_area(area_id, lsa, None);
     }
 
     /// Run an intra-area SPF calculation for `area_id`.
@@ -2066,6 +2089,12 @@ impl Ospf<Ospfv3> {
                 }
                 tracing::info!("[v3 SPF] Calculation triggered for area {}", area_id);
                 self.perform_spf_calculation(area_id);
+            }
+            Message::Flood(area_id, lsa, source_ifindex, source_nbr_addr) => {
+                // RFC 2328 §13.3: flood the LSA to every other
+                // Exchange-or-later neighbor in the area, exempting
+                // the (ifindex, router-id) pair we received it from.
+                self.flood_lsa_through_area(area_id, &lsa, Some((source_ifindex, source_nbr_addr)));
             }
             Message::Lsdb(ev, area_id, key) => {
                 // RFC 2328 §13.4: a peer flooded our own LSA back to

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -857,10 +857,15 @@ enum LsaProcessResult {
 }
 
 /// Per-LSA RFC 2328 §13.1 step machine.
+///
+/// `src` is the source neighbor's link-local v6 (passed through
+/// from `ospfv3_ls_upd_recv`); step 5 uses it to exempt the source
+/// from the `Message::Flood` re-broadcast (§13.3 Step 1c).
 fn ospfv3_ls_upd_proc(
     oi: &mut OspfInterface<Ospfv3>,
     nbr: &mut Neighbor<Ospfv3>,
     lsa: &Ospfv3Lsa,
+    src: &Ipv6Addr,
 ) -> LsaProcessResult {
     use super::area::AreaType;
     use super::lsdb::{OSPF_MAX_AGE, OSPF_MAX_LSA_SEQ};
@@ -925,6 +930,18 @@ fn ospfv3_ls_upd_proc(
         }
         if area_lsa_installed {
             let _ = oi.tx.send(Message::SpfSchedule(Some(area_id)));
+        }
+
+        // RFC 2328 §13.3: re-flood the LSA to every other
+        // Exchange-or-later neighbor in the area, exempting the
+        // source we got it from. Link-scope LSAs are NOT re-flooded
+        // across the area (§4.5.2 bounds them to the segment), but
+        // they're still installed on the link's per-link LSDB by
+        // the install path above.
+        if matches!(scope, Ospfv3LsaScope::Area | Ospfv3LsaScope::As) {
+            let _ = oi
+                .tx
+                .send(Message::Flood(area_id, lsa.clone(), nbr.ifindex, *src));
         }
 
         // RFC 2328 §13.4: peer sent us our own LSA at a higher
@@ -1012,7 +1029,7 @@ pub fn ospfv3_ls_upd_recv(
 
     for lsa in ls_upd.lsas.iter() {
         let h_for_ack = lsa.h.clone();
-        match ospfv3_ls_upd_proc(oi, nbr, lsa) {
+        match ospfv3_ls_upd_proc(oi, nbr, lsa, src) {
             LsaProcessResult::Installed | LsaProcessResult::AckAndDiscard => {
                 ack_headers.push(h_for_ack);
             }


### PR DESCRIPTION
## Summary

Closes the §13.1/§13.3 picture. After installing a received LSA in `ospfv3_ls_upd_proc` step 5, fire `Message::Flood` so the v3 instance re-floods it to every other Exchange-or-later neighbor in the area, exempting the `(ifindex, link-local v6)` pair we got the LSA from (RFC 2328 §13.3 Step 1c).

### `inst.rs`

- New **`flood_lsa_through_area(area_id, lsa, source)`** on `impl Ospf<Ospfv3>`. `source: Option<(u32, Ipv6Addr)>` — `None` is the self-origination path (every neighbor is a recipient); `Some((ifindex, nbr_v6))` is the "received LSA" path that skips the originating link-local source.
- `flood_self_originated_lsa(area_id, lsa)` is now a one-liner delegating to the source-aware helper with `source = None`.
- `process_msg` gains a `Message::Flood(area_id, lsa, source_ifindex, source_nbr_addr)` arm that dispatches to `flood_lsa_through_area` with the source filter populated.

### `packet_v3.rs`

- `ospfv3_ls_upd_proc` takes the source `&Ipv6Addr` and, after step 5 install, emits `Message::Flood` for area- and AS-scope LSAs. Link-scope LSAs are NOT re-flooded across the area (§4.5.2 keeps them on the segment); they're still installed in the per-link LSDB.
- `ospfv3_ls_upd_recv` forwards the source `src` to the step machine.

### Status

§13.1 is now complete for the wired LSA types. Outstanding items (not blocking):

- Retransmit-list bookkeeping at the originator side. The implied-ack branch is a no-op today since we never call `ospf_ls_retransmit_add`.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace` — verified by CI

Generated with [Claude Code](https://claude.com/claude-code)