### PR TITLE
ospf: expand v3 YANG + wire per-interface knob callbacks

### DIFF
--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -1,20 +1,21 @@
 //! OSPFv3 YANG-path callback handlers.
 //!
-//! Sibling of v2's `config.rs`. Currently registers just the
-//! `/area/interface/enable` handler — the minimum needed for a v3
-//! instance to bring an interface up via the existing
-//! `container ospfv3 { area { interface { enable } } }` YANG stub
-//! (PR #759). Per-link priority / hello-interval / dead-interval /
-//! retransmit-interval / mtu-ignore / prefix-sid callbacks aren't
-//! in the v3 YANG schema yet; they're added alongside the schema
-//! expansion in a follow-up.
+//! Sibling of v2's `config.rs`. Registers the
+//! `/router/ospfv3/area/interface/*` handlers — `enable`,
+//! `priority`, `hello-interval`, `dead-interval`,
+//! `retransmit-interval`, `mtu-ignore`. The handler bodies mirror
+//! v2 almost line-for-line; the generic helpers in `config.rs`
+//! (`link_should_enable`, `apply_link_enable_transition`,
+//! `ospf_link_get_mut_by_name`, `parse_area_id`, `ospf_hello_timer`)
+//! make this possible without duplication.
 
 use super::config::{
     Callback, apply_link_enable_transition, link_should_enable, ospf_link_get_mut_by_name,
     parse_area_id,
 };
+use super::ifsm::{IfsmEvent, ospf_hello_timer};
 use super::version::Ospfv3;
-use super::{Ospf, OspfLink};
+use super::{Message, Ospf, OspfLink};
 
 use crate::config::{Args, ConfigOp};
 
@@ -27,10 +28,29 @@ impl Ospf<Ospfv3> {
     /// can look up handlers directly.
     pub fn callback_build(&mut self) {
         let prefix = OSPFV3;
-        self.callbacks.insert(
-            format!("{}{}", prefix, "/area/interface/enable"),
-            config_ospfv3_interface_enable as Callback<Ospfv3>,
-        );
+        let entries: &[(&str, Callback<Ospfv3>)] = &[
+            ("/area/interface/enable", config_ospfv3_interface_enable),
+            ("/area/interface/priority", config_ospfv3_interface_priority),
+            (
+                "/area/interface/hello-interval",
+                config_ospfv3_interface_hello_interval,
+            ),
+            (
+                "/area/interface/dead-interval",
+                config_ospfv3_interface_dead_interval,
+            ),
+            (
+                "/area/interface/retransmit-interval",
+                config_ospfv3_interface_retransmit_interval,
+            ),
+            (
+                "/area/interface/mtu-ignore",
+                config_ospfv3_interface_mtu_ignore,
+            ),
+        ];
+        for (path, cb) in entries {
+            self.callbacks.insert(format!("{}{}", prefix, path), *cb);
+        }
     }
 }
 
@@ -65,6 +85,107 @@ fn config_ospfv3_interface_enable(
 
     let (next, next_id) = link_should_enable(link);
     apply_link_enable_transition(link, next, next_id);
+
+    Some(())
+}
+
+fn config_ospfv3_interface_priority(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let priority = args.u8()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config.priority = Some(priority);
+    } else {
+        link.config.priority = None;
+    }
+    link.ident.priority = link.priority();
+
+    let ifindex = link.index;
+    let _ = link
+        .tx
+        .send(Message::Ifsm(ifindex, IfsmEvent::NeighborChange));
+
+    Some(())
+}
+
+fn config_ospfv3_interface_hello_interval(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let hello_interval = args.u16()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config.hello_interval = Some(hello_interval);
+    } else {
+        link.config.hello_interval = None;
+    }
+
+    if link.timer.hello.is_some() {
+        link.timer.hello = Some(ospf_hello_timer(link));
+    }
+
+    Some(())
+}
+
+fn config_ospfv3_interface_dead_interval(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let dead_interval = args.u32()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config.dead_interval = Some(dead_interval);
+    } else {
+        link.config.dead_interval = None;
+    }
+
+    Some(())
+}
+
+fn config_ospfv3_interface_retransmit_interval(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let retransmit_interval = args.u16()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config.retransmit_interval = Some(retransmit_interval);
+    } else {
+        link.config.retransmit_interval = None;
+    }
+
+    Some(())
+}
+
+fn config_ospfv3_interface_mtu_ignore(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let mtu_ignore = args.boolean()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    link.config.mtu_ignore = op.is_set() && mtu_ignore;
 
     Some(())
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -434,10 +434,12 @@ module config {
         }
       }
       container ospfv3 {
-        // Schema stub mirroring the OSPFv2 shape. No Rust wiring yet:
-        // `Ospf<Ospfv3>::new` is not implemented and there is no v3
-        // config callback registration. Present so configs can be
-        // staged and the CLI completion works once v3 lands.
+        // OSPFv3 (RFC 5340). Shape mirrors `container ospf` so a
+        // v3 config differs from v2 only in the top-level keyword.
+        // Per-interface knobs (`priority`, `hello-interval`,
+        // `dead-interval`, `retransmit-interval`, `mtu-ignore`)
+        // share semantics with their v2 counterparts; the v3
+        // callbacks live in `config_v3.rs`.
         presence "Enables configuration of OSPFv3";
         leaf router-id {
           type inet:ipv4-address;
@@ -457,6 +459,21 @@ module config {
               type string;
             }
             leaf enable {
+              type boolean;
+            }
+            leaf priority {
+              type uint8;
+            }
+            leaf hello-interval {
+              type uint16;
+            }
+            leaf dead-interval {
+              type uint32;
+            }
+            leaf retransmit-interval {
+              type uint16;
+            }
+            leaf mtu-ignore {
               type boolean;
             }
           }


### PR DESCRIPTION
## Summary

Add the per-interface tuning leaves to the v3 schema so a v3 config can carry the same knobs v2 already accepts. The handler bodies mirror v2 line-for-line — the generic helpers (`link_should_enable`, `apply_link_enable_transition`, `ospf_link_get_mut_by_name`, `parse_area_id`, `ospf_hello_timer`) make duplication unnecessary.

### `config.yang`

`container ospfv3 / list area / list interface` gains:
- `leaf priority` (uint8)
- `leaf hello-interval` (uint16)
- `leaf dead-interval` (uint32)
- `leaf retransmit-interval` (uint16)
- `leaf mtu-ignore` (boolean)

### `config_v3.rs`

- `Ospf<Ospfv3>::callback_build` registers five new entries alongside `enable`, each pointing at a v3 sibling handler.
- **`config_ospfv3_interface_priority`** — sets `link.config.priority`, refreshes `link.ident.priority`, fires `Ifsm::NeighborChange` so the IFSM re-evaluates DR election.
- **`config_ospfv3_interface_hello_interval`** — sets the per-link override; if the hello timer is armed, restart it via `ospf_hello_timer(link)` so the new interval takes effect at the next emit.
- **`config_ospfv3_interface_dead_interval` / `_retransmit_interval`** — straight field writes; the values feed `oi.dead_interval()` / `oi.retransmit_interval()` accessors that other paths already consult.
- **`config_ospfv3_interface_mtu_ignore`** — toggles the DBD MTU-mismatch suppression flag.

After this PR, v3 has feature parity with v2's per-interface config surface (only segment-routing and prefix-sid remain v2-only because SR isn't wired for v3 yet).

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace` — verified by CI

Generated with [Claude Code](https://claude.com/claude-code)