### PR TITLE
ospf: add show ipv6 ospf commands for v3 instance

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -42,7 +42,11 @@ use super::{
     ospf_ls_upd_recv,
 };
 
-pub type ShowCallback = fn(&Ospf, Args, bool) -> Result<String, std::fmt::Error>;
+/// `show <path>` dispatch handler. Parameterized over `V` so an
+/// `Ospf<Ospfv3>` instance carries its own `ShowCallback<Ospfv3>`
+/// table distinct from `Ospf<Ospfv2>`'s. Defaults to `Ospfv2` to
+/// keep existing v2 callsites resolving unchanged.
+pub type ShowCallback<V = Ospfv2> = fn(&Ospf<V>, Args, bool) -> Result<String, std::fmt::Error>;
 
 /// OSPF protocol instance.
 ///
@@ -66,7 +70,7 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     pub links: BTreeMap<u32, OspfLink<V>>,
     pub areas: OspfAreaMap<V>,
     pub show: ShowChannel,
-    pub show_cb: HashMap<String, ShowCallback>,
+    pub show_cb: HashMap<String, ShowCallback<V>>,
     pub sock: Arc<AsyncFd<Socket>>,
     pub router_id: Ipv4Addr,
     pub lsdb_as: Lsdb<V>,
@@ -1518,6 +1522,7 @@ impl Ospf<Ospfv3> {
             v3_recv_rx: Some(v3_recv_rx),
         };
         ospf.callback_build();
+        ospf.show_build();
         ospf
     }
 
@@ -1529,6 +1534,19 @@ impl Ospf<Ospfv3> {
         let (path, args) = path_from_command(&msg.paths);
         if let Some(f) = self.callbacks.get(&path) {
             f(self, args, msg.op);
+        }
+    }
+
+    /// Look up the v3 show-path handler for `msg.paths` and invoke
+    /// it. Mirrors v2's `process_show_msg`.
+    pub async fn process_show_msg(&self, msg: DisplayRequest) {
+        let (path, args) = path_from_command(&msg.paths);
+        if let Some(f) = self.show_cb.get(&path) {
+            let output = match f(self, args, msg.json) {
+                Ok(result) => result,
+                Err(e) => format!("Error formatting output: {}", e),
+            };
+            msg.resp.send(output).await.unwrap();
         }
     }
 
@@ -2504,8 +2522,8 @@ impl Ospf<Ospfv3> {
                 Some(msg) = self.cm.rx.recv() => {
                     self.process_cm_msg(msg);
                 }
-                Some(_msg) = self.show.rx.recv() => {
-                    // v3 show path TBD; drain for now.
+                Some(msg) = self.show.rx.recv() => {
+                    self.process_show_msg(msg).await;
                 }
                 Some(recv) = v3_recv_rx.recv() => {
                     self.process_recv(recv);

--- a/zebra-rs/src/ospf/mod.rs
+++ b/zebra-rs/src/ospf/mod.rs
@@ -29,6 +29,8 @@ pub use area::*;
 
 pub mod show;
 
+pub mod show_v3;
+
 pub mod config;
 
 pub mod config_v3;

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -1,0 +1,488 @@
+//! OSPFv3 `show ipv6 ospf ...` command handlers.
+//!
+//! Sibling of v2's `show.rs`. Mirrors the v2 dispatch shape — one
+//! handler per `/show/ipv6/ospf/...` path, registered through
+//! `Ospf<Ospfv3>::show_build`, dispatched by the v3 event loop's
+//! `process_show_msg` arm. Output formatting is plain text by
+//! default; the `json` flag carried by `ShowCallback` produces a
+//! JSON document instead.
+
+use std::fmt::Write;
+
+use serde::Serialize;
+
+use super::lsdb::OSPF_MAX_AGE;
+use super::version::Ospfv3;
+use super::{Ospf, ShowCallback};
+
+use crate::config::Args;
+
+const SHOW_OSPFV3: &str = "/show/ipv6/ospf";
+
+impl Ospf<Ospfv3> {
+    /// Register the v3 show-path dispatch table. Mirrors v2's
+    /// `show_build` shape and command set, minus `segment-routing`
+    /// (no v3 SR wiring yet).
+    pub fn show_build(&mut self) {
+        let prefix = SHOW_OSPFV3;
+        let entries: &[(&str, ShowCallback<Ospfv3>)] = &[
+            ("", show_ospfv3_summary),
+            ("/interface", show_ospfv3_interface),
+            ("/neighbor", show_ospfv3_neighbor),
+            ("/neighbor/detail", show_ospfv3_neighbor_detail),
+            ("/database", show_ospfv3_database),
+            ("/database/detail", show_ospfv3_database_detail),
+            ("/route", show_ospfv3_route),
+            ("/spf", show_ospfv3_spf),
+            ("/graph", show_ospfv3_graph),
+        ];
+        for (path, cb) in entries {
+            self.show_cb.insert(format!("{}{}", prefix, path), *cb);
+        }
+    }
+}
+
+// ---- helpers ----------------------------------------------------
+
+fn render_or<T: serde::Serialize>(
+    json: bool,
+    value: &T,
+    text: String,
+) -> Result<String, std::fmt::Error> {
+    if json {
+        Ok(serde_json::to_string_pretty(value).unwrap_or_else(|_| String::from("{}")))
+    } else {
+        Ok(text)
+    }
+}
+
+fn ls_type_name(ls_type: u16) -> &'static str {
+    use ospf_packet::{
+        OSPFV3_AS_EXTERNAL_LSA_TYPE, OSPFV3_INTER_AREA_PREFIX_LSA_TYPE,
+        OSPFV3_INTER_AREA_ROUTER_LSA_TYPE, OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE, OSPFV3_LINK_LSA_TYPE,
+        OSPFV3_NETWORK_LSA_TYPE, OSPFV3_ROUTER_LSA_TYPE,
+    };
+    match ls_type {
+        OSPFV3_ROUTER_LSA_TYPE => "Router-LSA",
+        OSPFV3_NETWORK_LSA_TYPE => "Network-LSA",
+        OSPFV3_INTER_AREA_PREFIX_LSA_TYPE => "Inter-Area-Prefix-LSA",
+        OSPFV3_INTER_AREA_ROUTER_LSA_TYPE => "Inter-Area-Router-LSA",
+        OSPFV3_AS_EXTERNAL_LSA_TYPE => "AS-External-LSA",
+        OSPFV3_LINK_LSA_TYPE => "Link-LSA",
+        OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE => "Intra-Area-Prefix-LSA",
+        _ => "Unknown",
+    }
+}
+
+// ---- show ipv6 ospf (instance summary) --------------------------
+
+#[derive(Serialize)]
+struct Ospfv3SummaryJson {
+    router_id: String,
+    area_count: usize,
+    link_count: usize,
+    spf_last_ms_ago: Option<u128>,
+    spf_duration_us: Option<u128>,
+}
+
+fn show_ospfv3_summary(
+    top: &Ospf<Ospfv3>,
+    _args: Args,
+    json: bool,
+) -> Result<String, std::fmt::Error> {
+    let summary = Ospfv3SummaryJson {
+        router_id: top.router_id.to_string(),
+        area_count: top.areas.iter().count(),
+        link_count: top.links.len(),
+        spf_last_ms_ago: top.spf_last.map(|t| t.elapsed().as_millis()),
+        spf_duration_us: top.spf_duration.map(|d| d.as_micros()),
+    };
+    let mut text = String::new();
+    writeln!(text, "OSPFv3 Routing Process")?;
+    writeln!(text, "  Router ID:    {}", summary.router_id)?;
+    writeln!(text, "  Areas:        {}", summary.area_count)?;
+    writeln!(text, "  Interfaces:   {}", summary.link_count)?;
+    if let Some(ms) = summary.spf_last_ms_ago {
+        writeln!(text, "  Last SPF run: {} ms ago", ms)?;
+    }
+    if let Some(us) = summary.spf_duration_us {
+        writeln!(text, "  SPF duration: {} us", us)?;
+    }
+    render_or(json, &summary, text)
+}
+
+// ---- show ipv6 ospf interface -----------------------------------
+
+#[derive(Serialize)]
+struct Ospfv3InterfaceJson {
+    name: String,
+    ifindex: u32,
+    interface_id: u32,
+    enabled: bool,
+    area_id: String,
+    state: String,
+    d_router: String,
+    bd_router: String,
+    priority: u8,
+    hello_interval: u16,
+    dead_interval: u32,
+    neighbor_count: usize,
+}
+
+fn show_ospfv3_interface(
+    top: &Ospf<Ospfv3>,
+    _args: Args,
+    json: bool,
+) -> Result<String, std::fmt::Error> {
+    let entries: Vec<Ospfv3InterfaceJson> = top
+        .links
+        .values()
+        .map(|link| Ospfv3InterfaceJson {
+            name: link.name.clone(),
+            ifindex: link.index,
+            interface_id: link.interface_id,
+            enabled: link.enabled,
+            area_id: link.area_id.to_string(),
+            state: link.state.to_string(),
+            d_router: link.ident.d_router.to_string(),
+            bd_router: link.ident.bd_router.to_string(),
+            priority: link.priority(),
+            hello_interval: link.hello_interval(),
+            dead_interval: link.dead_interval(),
+            neighbor_count: link.nbrs.len(),
+        })
+        .collect();
+    let mut text = String::new();
+    for e in &entries {
+        writeln!(
+            text,
+            "{} (ifindex {}, area {}, state {}, neighbors {})",
+            e.name, e.ifindex, e.area_id, e.state, e.neighbor_count
+        )?;
+        writeln!(
+            text,
+            "  Interface ID: {}  Priority: {}  Hello {}s  Dead {}s",
+            e.interface_id, e.priority, e.hello_interval, e.dead_interval
+        )?;
+        writeln!(text, "  DR: {}  BDR: {}", e.d_router, e.bd_router)?;
+    }
+    render_or(json, &entries, text)
+}
+
+// ---- show ipv6 ospf neighbor ------------------------------------
+
+#[derive(Serialize)]
+struct Ospfv3NeighborJson {
+    router_id: String,
+    interface: String,
+    interface_id: u32,
+    state: String,
+    priority: u8,
+    d_router: String,
+    bd_router: String,
+}
+
+fn collect_neighbors(top: &Ospf<Ospfv3>) -> Vec<Ospfv3NeighborJson> {
+    let mut out = Vec::new();
+    for link in top.links.values() {
+        for nbr in link.nbrs.values() {
+            out.push(Ospfv3NeighborJson {
+                router_id: nbr.ident.router_id.to_string(),
+                interface: link.name.clone(),
+                interface_id: nbr.interface_id,
+                state: nbr.state.to_string(),
+                priority: nbr.ident.priority,
+                d_router: nbr.ident.d_router.to_string(),
+                bd_router: nbr.ident.bd_router.to_string(),
+            });
+        }
+    }
+    out
+}
+
+fn show_ospfv3_neighbor(
+    top: &Ospf<Ospfv3>,
+    _args: Args,
+    json: bool,
+) -> Result<String, std::fmt::Error> {
+    let entries = collect_neighbors(top);
+    let mut text = String::new();
+    writeln!(
+        text,
+        "{:<16} {:<10} {:<10} {:<10}",
+        "Router-ID", "Iface", "State", "DR"
+    )?;
+    for n in &entries {
+        writeln!(
+            text,
+            "{:<16} {:<10} {:<10} {:<10}",
+            n.router_id, n.interface, n.state, n.d_router
+        )?;
+    }
+    render_or(json, &entries, text)
+}
+
+fn show_ospfv3_neighbor_detail(
+    top: &Ospf<Ospfv3>,
+    _args: Args,
+    json: bool,
+) -> Result<String, std::fmt::Error> {
+    let entries = collect_neighbors(top);
+    let mut text = String::new();
+    for n in &entries {
+        writeln!(text, "Neighbor {}", n.router_id)?;
+        writeln!(
+            text,
+            "  Interface:    {} (id {})",
+            n.interface, n.interface_id
+        )?;
+        writeln!(text, "  State:        {}", n.state)?;
+        writeln!(text, "  Priority:     {}", n.priority)?;
+        writeln!(text, "  DR / BDR:     {} / {}", n.d_router, n.bd_router)?;
+    }
+    render_or(json, &entries, text)
+}
+
+// ---- show ipv6 ospf database ------------------------------------
+
+#[derive(Serialize)]
+struct Ospfv3LsaHeaderJson {
+    ls_type: String,
+    ls_type_raw: u16,
+    link_state_id: u32,
+    advertising_router: String,
+    ls_seq_number: String,
+    ls_age: u16,
+    length: u16,
+    scope: String,
+}
+
+#[derive(Serialize, Default)]
+struct Ospfv3DatabaseJson {
+    area: Vec<Ospfv3LsaHeaderJson>,
+    as_scope: Vec<Ospfv3LsaHeaderJson>,
+    link: Vec<Ospfv3LsaHeaderJson>,
+}
+
+fn ls_type_scope_label(ls_type: u16) -> &'static str {
+    match (ls_type >> 13) & 0x3 {
+        0 => "Link",
+        1 => "Area",
+        2 => "AS",
+        _ => "Reserved",
+    }
+}
+
+fn hdr_to_json(h: &ospf_packet::Ospfv3LsaHeader) -> Ospfv3LsaHeaderJson {
+    Ospfv3LsaHeaderJson {
+        ls_type: ls_type_name(h.ls_type).to_string(),
+        ls_type_raw: h.ls_type,
+        link_state_id: h.link_state_id,
+        advertising_router: h.advertising_router.to_string(),
+        ls_seq_number: format!("0x{:08x}", h.ls_seq_number),
+        ls_age: h.ls_age,
+        length: h.length,
+        scope: ls_type_scope_label(h.ls_type).to_string(),
+    }
+}
+
+fn collect_database(top: &Ospf<Ospfv3>) -> Ospfv3DatabaseJson {
+    let mut db = Ospfv3DatabaseJson::default();
+    for (_, area) in top.areas.iter() {
+        for (_, lsa) in area.lsdb.tables.iter() {
+            if lsa.data.h.ls_age >= OSPF_MAX_AGE {
+                continue;
+            }
+            db.area.push(hdr_to_json(&lsa.data.h));
+        }
+    }
+    for (_, lsa) in top.lsdb_as.tables.iter() {
+        if lsa.data.h.ls_age >= OSPF_MAX_AGE {
+            continue;
+        }
+        db.as_scope.push(hdr_to_json(&lsa.data.h));
+    }
+    for link in top.links.values() {
+        for (_, lsa) in link.lsdb.tables.iter() {
+            if lsa.data.h.ls_age >= OSPF_MAX_AGE {
+                continue;
+            }
+            db.link.push(hdr_to_json(&lsa.data.h));
+        }
+    }
+    db
+}
+
+fn show_ospfv3_database(
+    top: &Ospf<Ospfv3>,
+    _args: Args,
+    json: bool,
+) -> Result<String, std::fmt::Error> {
+    let db = collect_database(top);
+    let mut text = String::new();
+    for (label, entries) in [
+        ("Area-scope", &db.area),
+        ("AS-scope", &db.as_scope),
+        ("Link-scope", &db.link),
+    ] {
+        if entries.is_empty() {
+            continue;
+        }
+        writeln!(text, "{}:", label)?;
+        writeln!(
+            text,
+            "  {:<22} {:<16} {:<16} {:<10} Age",
+            "Type", "LS-ID", "Adv-Router", "Seq#"
+        )?;
+        for h in entries {
+            writeln!(
+                text,
+                "  {:<22} {:<16} {:<16} {:<10} {}",
+                h.ls_type, h.link_state_id, h.advertising_router, h.ls_seq_number, h.ls_age
+            )?;
+        }
+    }
+    render_or(json, &db, text)
+}
+
+fn show_ospfv3_database_detail(
+    top: &Ospf<Ospfv3>,
+    args: Args,
+    json: bool,
+) -> Result<String, std::fmt::Error> {
+    // For now `detail` produces the same output as the non-detail
+    // form — the v3 LSA-body printers will land alongside more
+    // detailed renderings of each scope's contents. JSON output is
+    // identical to the summary case.
+    show_ospfv3_database(top, args, json)
+}
+
+// ---- show ipv6 ospf route ---------------------------------------
+
+fn show_ospfv3_route(
+    _top: &Ospf<Ospfv3>,
+    _args: Args,
+    json: bool,
+) -> Result<String, std::fmt::Error> {
+    // v3's RIB push (#797) sends IPv6 routes directly to the
+    // system rib_client without retaining a per-instance shadow;
+    // there's no `rib6: PrefixMap` to walk here yet. Render an
+    // empty placeholder until the shadow lands.
+    let empty: Vec<()> = Vec::new();
+    let text =
+        String::from("(v3 RIB shadow not yet retained; routes go straight to the system RIB)\n");
+    render_or(json, &empty, text)
+}
+
+// ---- show ipv6 ospf spf -----------------------------------------
+
+#[derive(Serialize)]
+struct Ospfv3SpfPathJson {
+    vertex_id: usize,
+    router_id: String,
+    cost: u32,
+    first_hop_routers: Vec<String>,
+}
+
+fn show_ospfv3_spf(top: &Ospf<Ospfv3>, _args: Args, json: bool) -> Result<String, std::fmt::Error> {
+    let entries: Vec<Ospfv3SpfPathJson> = top
+        .spf_result
+        .as_ref()
+        .map(|paths| {
+            paths
+                .iter()
+                .map(|(id, path)| {
+                    let router_id = top
+                        .lsp_map
+                        .resolve(*id)
+                        .map_or_else(|| String::from("?"), |r| r.to_string());
+                    let first_hop_routers: Vec<String> = path
+                        .first_hop_links
+                        .iter()
+                        .filter_map(|(vid, _)| top.lsp_map.resolve(*vid).map(|r| r.to_string()))
+                        .collect();
+                    Ospfv3SpfPathJson {
+                        vertex_id: *id,
+                        router_id,
+                        cost: path.cost,
+                        first_hop_routers,
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut text = String::new();
+    writeln!(text, "OSPFv3 SPF tree ({} vertices)", entries.len())?;
+    for p in &entries {
+        writeln!(
+            text,
+            "  {} cost {} via {}",
+            p.router_id,
+            p.cost,
+            if p.first_hop_routers.is_empty() {
+                "(self)".to_string()
+            } else {
+                p.first_hop_routers.join(", ")
+            }
+        )?;
+    }
+    render_or(json, &entries, text)
+}
+
+// ---- show ipv6 ospf graph ---------------------------------------
+
+#[derive(Serialize)]
+struct Ospfv3GraphLinkJson {
+    from: String,
+    to: String,
+    cost: u32,
+}
+
+#[derive(Serialize)]
+struct Ospfv3GraphVertexJson {
+    id: usize,
+    name: String,
+    links: Vec<Ospfv3GraphLinkJson>,
+}
+
+fn show_ospfv3_graph(
+    top: &Ospf<Ospfv3>,
+    _args: Args,
+    json: bool,
+) -> Result<String, std::fmt::Error> {
+    let entries: Vec<Ospfv3GraphVertexJson> = top
+        .graph
+        .as_ref()
+        .map(|g| {
+            g.iter()
+                .map(|(id, vertex)| Ospfv3GraphVertexJson {
+                    id: *id,
+                    name: vertex.name.clone(),
+                    links: vertex
+                        .olinks
+                        .iter()
+                        .map(|l| Ospfv3GraphLinkJson {
+                            from: vertex.name.clone(),
+                            to: top
+                                .lsp_map
+                                .resolve(l.to)
+                                .map_or_else(|| l.to.to_string(), |r| r.to_string()),
+                            cost: l.cost,
+                        })
+                        .collect(),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut text = String::new();
+    writeln!(text, "OSPFv3 area graph ({} vertices)", entries.len())?;
+    for v in &entries {
+        writeln!(text, "  {} (id {})", v.name, v.id)?;
+        for l in &v.links {
+            writeln!(text, "    -> {} cost {}", l.to, l.cost)?;
+        }
+    }
+    render_or(json, &entries, text)
+}

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -426,6 +426,37 @@ module exec {
           }
         }
       }
+      container ospf {
+        ext:help "OSPFv3 commands";
+        presence "OSPFv3 instance";
+        leaf interface {
+          ext:help "OSPFv3 interface";
+          type empty;
+        }
+        container neighbor {
+          ext:help "OSPFv3 neighbor";
+          presence "OSPFv3 neighbor";
+          leaf detail {
+            type empty;
+          }
+        }
+        container database {
+          ext:help "OSPFv3 LSDB";
+          presence "OSPFv3 LSDB";
+          leaf detail {
+            type empty;
+          }
+        }
+        leaf route {
+          type empty;
+        }
+        leaf graph {
+          type empty;
+        }
+        leaf spf {
+          type empty;
+        }
+      }
     }
     container "policy" {
       ext:help "Show policy";


### PR DESCRIPTION
## Summary

Port v2's `show ip ospf …` command set to the v3 instance under `show ipv6 ospf …`. Nine handlers covering instance summary, interface, neighbor (+detail), database (+detail), route, spf, and graph — minus `segment-routing` (no v3 SR wiring yet).

### Genericization

- `ShowCallback` becomes `ShowCallback<V = Ospfv2>` so v2 callsites are unchanged.
- `Ospf::show_cb` typed `HashMap<String, ShowCallback<V>>`.

### YANG (`exec.yang`)

Add `container ospf` under `container ipv6` mirroring the v2 `show ip ospf` subcommand layout (interface, neighbor + detail, database + detail, route, spf, graph).

### New module `show_v3.rs`

- `Ospf<Ospfv3>::show_build` registers nine entries under `/show/ipv6/ospf/...`.
- Each handler renders both plain text and JSON (the `ShowCallback` `json` flag picks). Output structure mirrors v2's where the data is comparable:
  - `show ipv6 ospf` — router-id, area/interface count, SPF duration / last-run.
  - `show ipv6 ospf interface` — per-link state, area, DR/BDR, Interface ID, intervals, neighbor count.
  - `show ipv6 ospf neighbor` / `… detail` — neighbor table (router-id keying, state, DR/BDR).
  - `show ipv6 ospf database` / `… detail` — LSDB header listing grouped by scope (area / AS / link), filtered to non-MaxAge.
  - `show ipv6 ospf spf` — SPF result: per-vertex (router-id, cost, first-hop routers).
  - `show ipv6 ospf graph` — graph dump: per-vertex outgoing links with cost.
  - `show ipv6 ospf route` — placeholder; v3's RIB push (#797) sends routes straight to the system rib without retaining a shadow on the instance. Empty output with a comment until a `rib6` field lands.

### Instance wiring (`inst.rs`)

- `Ospf<Ospfv3>::new` calls `show_build()` after `callback_build()`.
- New `process_show_msg(msg)` mirrors v2's: look up handler by path, invoke, send the rendered output back through `msg.resp`.
- `event_loop`'s `show.rx` arm now dispatches via `process_show_msg` instead of draining.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace` — verified by CI

Generated with [Claude Code](https://claude.com/claude-code)