### PR TITLE
ospf: don't panic when v2 network tasks outlive the event loop

### DIFF
--- a/zebra-rs/src/ospf/network.rs
+++ b/zebra-rs/src/ospf/network.rs
@@ -71,19 +71,25 @@ pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message
 
                 // We will verify Area later.
 
-                tx.send(Message::Recv(packet.1, src.ip(), group, ifindex, ifaddr))
-                    .unwrap();
+                let _ = tx.send(Message::Recv(packet.1, src.ip(), group, ifindex, ifaddr));
 
                 Ok(())
             })
             .await;
+        // The OSPF event loop owns the receiver; once the instance
+        // is torn down (e.g. `delete router ospf`) the channel
+        // closes and there is no one left to deliver to.
+        if tx.is_closed() {
+            return;
+        }
     }
 }
 
 pub async fn write_packet(sock: Arc<AsyncFd<Socket>>, mut rx: UnboundedReceiver<Message>) {
-    loop {
-        let msg = rx.recv().await;
-        let Message::Send(packet, ifindex, dest) = msg.unwrap() else {
+    // Exits the loop when the event loop drops the sender on
+    // instance teardown — mirrors `network_v6::write_packet_v6`.
+    while let Some(msg) = rx.recv().await {
+        let Message::Send(packet, ifindex, dest) = msg else {
             continue;
         };
 


### PR DESCRIPTION
## Summary
`delete router ospf` drops the `Ospf` instance and with it the `Message` channel endpoints. The per-instance v2 `read_packet` and `write_packet` tasks (spawned at startup, owned by the tokio runtime) keep running for one more iteration and hit:

- `network.rs:75` — `tx.send(...).unwrap()` panics with `SendError` once the receiver is dropped.
- `network.rs:86` — `rx.recv().await.unwrap()` panics with `Option::unwrap on None` once the sender is dropped.

Both replaced with the same graceful-exit pattern already used by `network_v6::{read_packet_v6, write_packet_v6}`:

- `read_packet` swallows the send error inside the `async_io` closure and breaks out of the outer loop when `tx.is_closed()`.
- `write_packet` rewritten as `while let Some(msg) = rx.recv().await` which exits naturally on `None`.

Reproduces with two stack traces (`panicked at network.rs:75` and `network.rs:86`) on `delete router ospf` in a running daemon.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI green
- [ ] Smoke: enable v2 OSPF, then `delete router ospf` — daemon stays up, no panic

Generated with [Claude Code](https://claude.com/claude-code)