### PR TITLE
isis: don't panic when network write task outlives the event loop

### DIFF
--- a/zebra-rs/src/isis/network.rs
+++ b/zebra-rs/src/isis/network.rs
@@ -99,10 +99,10 @@ pub const L2_ISS: [u8; 6] = [0x01, 0x80, 0xC2, 0x00, 0x00, 0x15];
 pub const P2P_ISS: [u8; 6] = [0x09, 0x00, 0x2B, 0x00, 0x00, 0x05];
 
 pub async fn write_packet(sock: Arc<AsyncFd<Socket>>, mut rx: UnboundedReceiver<PacketMessage>) {
-    loop {
-        let msg = rx.recv().await;
-        let PacketMessage::Send(packet, ifindex, level, dest) = msg.unwrap();
-
+    // Exits the loop when the event loop drops the sender on
+    // instance teardown — same pattern as `ospf::network` and
+    // `ospf::network_v6`.
+    while let Some(PacketMessage::Send(packet, ifindex, level, dest)) = rx.recv().await {
         let buf = match packet {
             Packet::Packet(packet) => {
                 let mut buf = BytesMut::new();


### PR DESCRIPTION
## Summary
Same teardown-panic pattern fixed for OSPFv2 in #809, but in IS-IS. The per-instance `write_packet` task does `rx.recv().await.unwrap()`, so once the event loop drops the sender on instance teardown the task panics with `Option::unwrap on None` at `isis/network.rs:104`.

Rewrite as `while let Some(PacketMessage::Send(...)) = rx.recv().await`. `PacketMessage` has a single variant (`Send`) so the destructure stays irrefutable and the body is unchanged. `read_packet` already uses `let _ = tx.send(...)` (line 89) so it needed no change.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI green
- [ ] Smoke: enable IS-IS, then tear it down — daemon stays up, no panic

Generated with [Claude Code](https://claude.com/claude-code)