### PR TITLE
config: route 'show ipv6 ospf ...' to the ospfv3 instance

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -765,6 +765,8 @@ impl ConfigManager {
             Message::DisplayTx(req) => {
                 let tx_option = if is_bgp(&req.paths) {
                     self.show_clients.borrow().get("bgp").cloned()
+                } else if is_ospfv3(&req.paths) {
+                    self.show_clients.borrow().get("ospfv3").cloned()
                 } else if is_ospf(&req.paths) {
                     self.show_clients.borrow().get("ospf").cloned()
                 } else if is_isis(&req.paths) {
@@ -792,6 +794,8 @@ impl ConfigManager {
                         if let Some(display_req) = fallback_rx.recv().await {
                             let protocol_name = if is_isis(&paths) {
                                 "ISIS"
+                            } else if is_ospfv3(&paths) {
+                                "OSPFv3"
                             } else if is_ospf(&paths) {
                                 "OSPF"
                             } else if is_bgp(&paths) {
@@ -884,6 +888,23 @@ fn is_bgp(paths: &[CommandPath]) -> bool {
 
 fn is_ospf(paths: &[CommandPath]) -> bool {
     paths.iter().any(|x| x.name == "ospf")
+}
+
+/// True for `show ipv6 ospf ...` paths, routed to the `"ospfv3"`
+/// subscriber. Must be checked BEFORE [`is_ospf`] — every v3 show
+/// path also contains an `"ospf"` segment, so `is_ospf` matches as
+/// well and would otherwise win.
+fn is_ospfv3(paths: &[CommandPath]) -> bool {
+    let mut has_ipv6 = false;
+    let mut has_ospf = false;
+    for p in paths {
+        if p.name == "ipv6" {
+            has_ipv6 = true;
+        } else if p.name == "ospf" {
+            has_ospf = true;
+        }
+    }
+    has_ipv6 && has_ospf
 }
 
 fn is_isis(paths: &[CommandPath]) -> bool {


### PR DESCRIPTION
## Summary
`show ipv6 ospf ...` was silently dropping output. Root cause: the `DisplayTx` dispatcher in `config/manager.rs` only knew `is_ospf`, which matches any path containing an `"ospf"` segment. So v3 show requests landed at the v2 OSPF instance, whose `show_cb` table only carries `/show/ip/ospf/...` keys; v2's `process_show_msg` did `if let Some(f) = self.show_cb.get(&path) { ... }`, found nothing, and dropped the request silently.

- Add `is_ospfv3(paths)` — true iff paths contains both `"ipv6"` and `"ospf"` segments.
- Check it **before** `is_ospf` in the `DisplayTx` dispatcher (order matters — `is_ospf` would otherwise win).
- Route to the `"ospfv3"` subscription set up by `spawn_ospfv3` (`config/ospf.rs:39`).
- Update the "protocol not configured" fallback message to say `OSPFv3` when the user typed an `ipv6 ospf` command without the instance running.

The v3 instance's `show_v3.rs` registers handlers under `/show/ipv6/ospf/...` (line 20: `const SHOW_OSPFV3: &str = "/show/ipv6/ospf";`), so once the request reaches v3 the existing dispatch table matches.

## Out of scope
Show-routing only. If v3's config-side plumbing leaves `area.links` empty for a configured interface, the handler will still render empty — separate `config_v3.rs` concern.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI green
- [ ] Manual: configure `ospfv3 { area 0 { interface ... { enable true; } } }`, then `show ipv6 ospf interface` returns non-empty (or v3's own "no interfaces" message instead of silent drop)
- [ ] Manual: with no v3 config, `show ipv6 ospf` now says "OSPFv3 is not configured or running" instead of silent drop

Generated with [Claude Code](https://claude.com/claude-code)