### PR TITLE
ospf: initialize OspfLink::interface_id from link.index

### DIFF
--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -119,9 +119,10 @@ pub struct OspfLink<V: OspfVersion = Ospfv2> {
     pub ls_ack_delayed: Vec<V::LsaHeader>,
     /// 32-bit Interface ID advertised in v3 Hellos and Router-LSA
     /// links (RFC 5340 §A.3.2 / §A.4.3). Unused by v2 (where the
-    /// equivalent role is filled by the interface IP). Defaulted
-    /// to 0; the v3 interface-enable path sets it.
-    #[allow(dead_code)]
+    /// equivalent role is filled by the interface IP). Initialized
+    /// from the kernel ifindex so it's unique per interface on
+    /// this router (RFC 5340 §3.2 only requires per-router
+    /// uniqueness).
     pub interface_id: u32,
     /// Per-link LSDB (RFC 5340 §A.4.9). Holds link-scope LSAs —
     /// `Link-LSAs` — that the v3 standard restricts to flooding
@@ -176,7 +177,7 @@ where
             ptx,
             config: LinkConfig::default(),
             ls_ack_delayed: Vec::new(),
-            interface_id: 0,
+            interface_id: link.index,
             lsdb: super::lsdb::Lsdb::new(),
         }
     }


### PR DESCRIPTION
## Summary
`OspfLink::from` left `interface_id` at the struct-init default of `0` and there was no later setter — every v3 interface on a router shared `link_state_id = 0` in its Link-LSA, and the same `0` in Hellos and Router-LSA links. A single-interface v3 router worked by coincidence; a multi-interface router collided its own LSAs.

Initialize from `link.index` (the kernel ifindex). RFC 5340 §3.2 only requires per-router uniqueness, which ifindex meets. v2 doesn't read the field, so this is a no-op for v2 instances. Drops the now-misleading "v3 interface-enable path sets it" line from the doc comment and the `#[allow(dead_code)]` (the field is read by `build_link_lsa` / `build_router_lsa`).

## Test plan
- [x] `cargo build`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` (925 passed / 0 failed)

Generated with [Claude Code](https://claude.com/claude-code)