### PR TITLE
ospf: filter 'show ipv6 ospf interface' to v3-enabled interfaces

### DIFF
--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -134,9 +134,14 @@ fn show_ospfv3_interface(
     _args: Args,
     json: bool,
 ) -> Result<String, std::fmt::Error> {
+    // Only list interfaces the operator enabled v3 on — matches v2's
+    // `show_ospf_interface` filter (`if !oi.enabled { continue; }`).
+    // Without this filter every kernel link the RIB has surfaced
+    // shows up, which is noisy and inconsistent with v2.
     let entries: Vec<Ospfv3InterfaceJson> = top
         .links
         .values()
+        .filter(|link| link.enabled)
         .map(|link| Ospfv3InterfaceJson {
             name: link.name.clone(),
             ifindex: link.index,


### PR DESCRIPTION
## Summary
`show ospfv3_interface` (`show_v3.rs`) iterated `top.links.values()` with no filter, so every kernel link the RIB surfaced was printed — including links the operator never configured v3 on. v2's `show_ospf_interface` already filters with `if !oi.enabled { continue; }`, so the two commands now report the same scope.

Reproduces with a single v3-configured area/interface: the rendered list contained lo, every enp\*, and a bridge dev. After the fix, only links whose `OspfLink::enabled` is true appear.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI green
- [ ] Manual: configure v3 on one interface, run `show ipv6 ospf interface`, verify only that interface is listed

Generated with [Claude Code](https://claude.com/claude-code)