### PR TITLE
ospf: populate v3 initial DBD summary

### DIFF
--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -4,7 +4,7 @@ use ospf_packet::*;
 use rand::RngExt;
 use tokio::time::Instant;
 
-use super::version::{OspfVersion, Ospfv2};
+use super::version::{OspfVersion, Ospfv2, Ospfv3};
 use super::{
     Identity, IfsmEvent, Message, Neighbor, Timer, TimerType, inst::OspfInterface,
     ospf_ls_request_isempty, tracing::FsmType,
@@ -362,7 +362,7 @@ pub(super) fn ospf_db_summary_add_table<'a, V: OspfVersion>(
 /// RFC 2328 §10.8: walk every LSA type that belongs in the initial
 /// DBD summary and push its header into `nbr.db_sum`. The list of
 /// types is v2-specific (v3 uses a different LSA-type taxonomy);
-/// the v3 equivalent lands when the v3 NFSM path is wired.
+/// the v3 equivalent lives in `ospfv3_populate_initial_db_summary`.
 pub fn ospfv2_populate_initial_db_summary(
     oi: &mut OspfInterface<Ospfv2>,
     nbr: &mut Neighbor<Ospfv2>,
@@ -378,6 +378,45 @@ pub fn ospfv2_populate_initial_db_summary(
     // AS-scope LSAs included only for non-stub / non-NSSA areas.
     if oi.area_type == AreaType::Normal {
         ospf_db_summary_add_table(nbr, oi.lsdb_as.values_by_type(OspfLsType::AsExternal));
+    }
+}
+
+/// v3 NFSM helper invoked from `Ospfv3::populate_initial_db_summary`.
+/// RFC 5340 §4.2.2 inheriting RFC 2328 §10.8: walk every area-scope
+/// LSA type and the AS-scope AS-External-LSA (only in Normal areas);
+/// push each non-MaxAge header into `nbr.db_sum`. Link-scope LSAs
+/// (Link-LSA, type 0x0008) are intentionally excluded — RFC 5340
+/// §4.2.2 says Link-LSAs MUST NOT be included in DBDs because they
+/// only have link scope and are already known to peers on the
+/// segment.
+pub fn ospfv3_populate_initial_db_summary(
+    oi: &mut OspfInterface<Ospfv3>,
+    nbr: &mut Neighbor<Ospfv3>,
+) {
+    use super::area::AreaType;
+    use ospf_packet::{
+        OSPFV3_AS_EXTERNAL_LSA_TYPE, OSPFV3_INTER_AREA_PREFIX_LSA_TYPE,
+        OSPFV3_INTER_AREA_ROUTER_LSA_TYPE, OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE,
+        OSPFV3_NETWORK_LSA_TYPE, OSPFV3_ROUTER_LSA_TYPE,
+    };
+
+    for ls_type in [
+        OSPFV3_ROUTER_LSA_TYPE,
+        OSPFV3_NETWORK_LSA_TYPE,
+        OSPFV3_INTER_AREA_PREFIX_LSA_TYPE,
+        OSPFV3_INTER_AREA_ROUTER_LSA_TYPE,
+        OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE,
+    ] {
+        ospf_db_summary_add_table(nbr, oi.lsdb.iter_by_raw_type(ls_type).map(|(_, lsa)| lsa));
+    }
+
+    if oi.area_type == AreaType::Normal {
+        ospf_db_summary_add_table(
+            nbr,
+            oi.lsdb_as
+                .iter_by_raw_type(OSPFV3_AS_EXTERNAL_LSA_TYPE)
+                .map(|(_, lsa)| lsa),
+        );
     }
 }
 

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -495,8 +495,6 @@ fn ospfv3_db_desc_proc(
 ///   `Ipv4Addr`.
 /// - No netmask check (v3 Hello doesn't carry one; DBD MTU check
 ///   is the same).
-/// - LSA-header processing inside `ospfv3_db_desc_proc` is currently
-///   a TODO (see that function's docs).
 pub fn ospfv3_db_desc_recv(
     oi: &mut OspfInterface<Ospfv3>,
     nbr: &mut Neighbor<Ospfv3>,

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -524,4 +524,10 @@ impl OspfVersion for Ospfv3 {
     ) {
         crate::ospf::packet_v3::ospfv3_ls_req_send(oi, nbr, oident);
     }
+    fn populate_initial_db_summary(
+        oi: &mut crate::ospf::inst::OspfInterface<Ospfv3>,
+        nbr: &mut crate::ospf::Neighbor<Ospfv3>,
+    ) {
+        crate::ospf::nfsm::ospfv3_populate_initial_db_summary(oi, nbr);
+    }
 }


### PR DESCRIPTION
## Summary
`Ospfv3::populate_initial_db_summary` defaulted to the trait's no-op body, so on the ExStart → Exchange transition the v3 `ospf_nfsm_negotiation_done` left `nbr.db_sum` empty. Every DBD we emitted carried zero `lsa_headers`, and the peer's §10.6 LSReq path stayed quiet — initial database sync relied on flooding alone, which is slow on large LSDBs and was the most likely source of FRR-peer interop misbehavior.

Add `ospfv3_populate_initial_db_summary` (in `nfsm.rs`) and wire it through the trait. Walks `oi.lsdb` for the five area-scope v3 LSA types (Router, Network, Inter-Area-Prefix, Inter-Area-Router, Intra-Area-Prefix) and `oi.lsdb_as` for AS-External in Normal areas, dropping MaxAge entries on the way (same filter `ospf_db_summary_add_table` already applies). Link-LSAs (link-scope, 0x0008) are intentionally excluded per RFC 5340 §4.2.2 — peers learn them via ordinary on-link flooding.

Drop the now-stale "LSA-header processing inside ospfv3_db_desc_proc is currently a TODO" line from `ospfv3_db_desc_recv`'s doc comment — that handler has walked `dd.lsa_headers` into `nbr.ls_req` since it was first wired up; the real gap was on the originate side.

## Test plan
- [x] `cargo build`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd` (925 passed / 0 failed)
- [ ] Manual two-router verification of fast DB sync (deferred to FRR-peer harness).

Generated with [Claude Code](https://claude.com/claude-code)