### PR TITLE
rib,ospf: propagate kernel link removal to protocol subscribers

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -229,6 +229,20 @@ impl<V: OspfVersion> Ospf<V> {
         }
     }
 
+    /// The kernel link is gone. If OSPF was enabled on it, fire
+    /// `Disable` so the IFSM tears the adjacency down, then drop
+    /// the link from `self.links`. Shared by v2 and v3.
+    fn link_del(&mut self, ifindex: u32) {
+        let Some(link) = self.links.get(&ifindex) else {
+            return;
+        };
+        if link.enabled {
+            let area_id = link.area_id;
+            let _ = self.tx.send(Message::Disable(ifindex, area_id));
+        }
+        self.links.remove(&ifindex);
+    }
+
     /// Count Exchange/Loading neighbors across all links in the same area.
     fn count_exchange_loading_neighbors(&self, ifindex: u32) -> usize {
         let Some(link) = self.links.get(&ifindex) else {
@@ -1410,6 +1424,9 @@ impl Ospf<Ospfv2> {
             RibRx::LinkDown(ifindex) => {
                 self.link_down(ifindex);
             }
+            RibRx::LinkDel(ifindex) => {
+                self.link_del(ifindex);
+            }
             RibRx::AddrAdd(addr) => {
                 self.addr_add(addr);
             }
@@ -1586,6 +1603,7 @@ impl Ospf<Ospfv3> {
             RibRx::LinkAdd(link) => self.link_add(link),
             RibRx::LinkUp(ifindex) => self.link_up(ifindex),
             RibRx::LinkDown(ifindex) => self.link_down(ifindex),
+            RibRx::LinkDel(ifindex) => self.link_del(ifindex),
             _ => {}
         }
     }

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -81,6 +81,11 @@ pub enum RibRx {
     LinkAdd(Link),
     LinkUp(u32),
     LinkDown(u32),
+    /// The kernel link with this ifindex no longer exists. Protocol
+    /// subscribers should drop any state keyed off it. Distinct from
+    /// `LinkDown` (operational down) — `LinkDel` is permanent for
+    /// this ifindex.
+    LinkDel(u32),
     AddrAdd(LinkAddr),
     AddrDel(LinkAddr),
     RouterIdUpdate(Ipv4Addr),
@@ -230,6 +235,17 @@ impl Rib {
         let vrf_id = self.ifindex_vrf_id(ifindex);
         for (_, sub) in self.client_registry.iter_vrf(vrf_id) {
             let _ = sub.rib_rx_tx.send(RibRx::LinkDown(ifindex));
+        }
+    }
+
+    /// Announce that the kernel link is gone. Call this BEFORE
+    /// removing the link from `self.links`, otherwise
+    /// `ifindex_vrf_id` falls back to default VRF and the message
+    /// goes to the wrong subscribers.
+    pub fn api_link_del(&self, ifindex: u32) {
+        let vrf_id = self.ifindex_vrf_id(ifindex);
+        for (_, sub) in self.client_registry.iter_vrf(vrf_id) {
+            let _ = sub.rib_rx_tx.send(RibRx::LinkDel(ifindex));
         }
     }
 

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -577,6 +577,10 @@ impl Rib {
         if let Some(vni) = oslink.vni {
             self.fib_handle.unregister_vxlan_ifindex(vni);
         }
+        // Notify subscribers BEFORE removing the link entry, so the
+        // VRF lookup in `api_link_del` still resolves to the right
+        // subscribers instead of falling through to default VRF.
+        self.api_link_del(oslink.index);
         self.links.remove(&oslink.index);
     }
 


### PR DESCRIPTION
## Summary
`rib::Rib::link_delete` (driven from `FibMessage::DelLink`) removed the kernel link from its local table and silently exited — no subscriber was notified. Protocols kept the stale link in their own per-instance tables (`Ospf::links` etc.) until the daemon restarted.

Three-part fix:

- **`rib/api.rs`**: add `RibRx::LinkDel(u32)` variant and `api_link_del` helper that iterates VRF subscribers. Distinct from `LinkDown` (operational down, state retained) — `LinkDel` means the ifindex is gone for good.
- **`rib/link.rs`**: call `self.api_link_del(oslink.index)` from `link_delete` **before** removing the link entry, otherwise `ifindex_vrf_id` falls back to default VRF and the message goes to the wrong subscribers.
- **`ospf/inst.rs`**: add `link_del` to the generic `impl<V> Ospf<V>` block (sibling of `link_add`/`link_up`/`link_down`); fires `Message::Disable` if OSPF was enabled on the link so the IFSM tears the adjacency, then drops the link from `self.links`. Add `RibRx::LinkDel` arms to both v2 and v3 `process_rib_msg`.

## Out of scope
BGP and IS-IS already have wildcard `_` arms in their `process_rib_msg`, so they silently ignore the new variant. Explicit handling in those subsystems is a follow-up PR if/when needed.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI green
- [ ] Smoke: enable OSPF on an interface, then remove the interface (`ip link del`); verify the daemon stays up, the link disappears from `show ip ospf interface` / `show ipv6 ospf interface`, and the adjacency tears down cleanly

Generated with [Claude Code](https://claude.com/claude-code)