### PR TITLE
ospf: drain v3 RIB subscribe-time replay before serving cm requests

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -2727,6 +2727,20 @@ impl Ospf<Ospfv3> {
             .v3_recv_rx
             .take()
             .expect("Ospf<Ospfv3> has no v3 recv channel");
+        // Pre-roll: drain the RIB subscribe-time replay (LinkAdd,
+        // AddrAdd, RouterIdUpdate, ...) before touching `cm.rx`.
+        // Without this, a `set router ospfv3 area ... interface
+        // <name> enable true` config message can race ahead of the
+        // `LinkAdd` for that ifname; `ospf_link_get_mut_by_name`
+        // then returns `None` and the enable silently no-ops.
+        // Mirrors v2's pre-roll in `Ospf<Ospfv2>::event_loop`.
+        loop {
+            match self.rib_rx.recv().await {
+                Some(RibRx::EoR) => break,
+                Some(msg) => self.process_rib_msg(msg),
+                None => break,
+            }
+        }
         loop {
             tokio::select! {
                 Some(msg) = self.rx.recv() => {


### PR DESCRIPTION
## Summary
`set router ospfv3 area 0 interface <name> enable true` could leave `OspfLink::enabled = false` because v3's `event_loop` jumped straight into the `tokio::select!` over `rx` / `rib_rx` / `cm.rx` / `show.rx` / `v3_recv_rx`. tokio picks across channels non-deterministically, so the config message from the spawn-time commit broadcast could be processed before the `RibRx::LinkAdd` for that ifname arrived — `ospf_link_get_mut_by_name` then returned `None` and the enable silently no-op'd.

Add v2's pre-roll loop to v3: drain `self.rib_rx` until `RibRx::EoR` before entering the main `select!`. With the subscribe-time replay finished, the link is in `self.links` by the time the config callback runs.

## Reproduces
Configure the v3 interface-enable line in a fresh commit; `show ipv6 ospf interface` came back empty after PR #817 (filter to enabled-only) merged.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI green
- [ ] Manual: `set router ospfv3 area 0 interface <name> enable true` then `show ipv6 ospf interface` lists the configured link

Generated with [Claude Code](https://claude.com/claude-code)