### PR TITLE
ospf: emit v3 Router-LSA transit link when self is DR

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1948,7 +1948,29 @@ impl Ospf<Ospfv3> {
                 if dr_router_id == Ipv4Addr::UNSPECIFIED {
                     continue;
                 }
-                if let Some(dr_nbr) = link.nbrs.get(&dr_router_id)
+                if dr_router_id == self.router_id {
+                    // RFC 5340 §A.4.3: when this router is the DR
+                    // for the segment, the Transit-link's "neighbor"
+                    // fields name us — our own interface_id and
+                    // router-id. Without this branch the link is
+                    // silently dropped on the DR side (`link.nbrs`
+                    // never contains an entry keyed by our own
+                    // router-id), the Router-LSA goes out with zero
+                    // links, and SPF can never relax through the
+                    // Network-LSA pseudo-node we just originated.
+                    // Only emit when at least one neighbor reached
+                    // Full so the matching Network-LSA actually
+                    // exists in the LSDB to back-link against.
+                    let has_full_nbr = link.nbrs.values().any(|n| n.state == NfsmState::Full);
+                    if has_full_nbr {
+                        links.push(Ospfv3RouterLsaLink::transit_network(
+                            cost,
+                            my_iid,
+                            my_iid,
+                            self.router_id,
+                        ));
+                    }
+                } else if let Some(dr_nbr) = link.nbrs.get(&dr_router_id)
                     && dr_nbr.state == NfsmState::Full
                 {
                     links.push(Ospfv3RouterLsaLink::transit_network(


### PR DESCRIPTION
## Summary
- \`Ospf<Ospfv3>::build_router_lsa\` skipped the Transit-link emission whenever \`dr_router_id == self.router_id\` — the \`link.nbrs.get(&dr_router_id)\` lookup never finds \"ourselves\" because we don't keep a neighbor record keyed by our own router-id. As a result, when zebra-rs won the DR election the Router-LSA went out with zero links, SPF couldn't relax through the Network-LSA pseudo-node we'd just originated, and \`show ipv6 ospf route\` reported 0 routes against a correctly-formed LSDB.
- Mirror v2's \`link_has_transit_adjacency\`: when we are the DR and at least one neighbor on the segment is Full (so the matching Network-LSA is non-empty), push a Transit link whose neighbor fields name us — \`my_iid\` + \`self.router_id\` per RFC 5340 §A.4.3. The SPF back-link check (\"Network-LSA must list us in attached_routers\") is already satisfied because the same router-id appears in both our Router-LSA's Transit link and our own Network-LSA.
- Keep two low-noise \`tracing::debug!\` summary lines in \`graph_v3\` and \`apply_v3_spf_result\` so future v3-SPF debugging doesn't need a one-off tracing PR.

## Diagnostic walk-through
Tracing showed our LSDB held every expected LSA after Full transition, but our Router-LSA always reported \`links=0\` while peer's reported \`links=1\`:

\`\`\`
[v3 SPF:graph]   lsdb type=0x2002 ls_id=3 adv=10.0.0.1 age=0   ← OUR Network-LSA (we're DR)
[v3 SPF:graph]   lsdb type=0x2002 ls_id=3 adv=10.0.0.2 age=3600 ← peer's flushed copy
[v3 SPF:graph]   router_lsa adv=10.0.0.1 originated=true links=0
[v3 SPF:graph]   router_lsa adv=10.0.0.2 originated=false links=1
\`\`\`

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --exclude bdd\`
- [ ] Run zebra-rs with priority 64 against FRR \`ospf6d\` (default priority 1), confirm zebra-rs becomes DR, the adjacency reaches Full, and \`show ipv6 ospf route\` lists v6 routes for each Intra-Area-Prefix-LSA the peer advertises (manual, on the ospfv3-frr branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)