### PR TITLE
ospf: trunc-compare in v3 self-prefix link lookup

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -3704,8 +3704,14 @@ fn build_rib6_from_spf(
                 // resolve the link by matching the prefix back to
                 // `link.addr` so the route renders with the right
                 // ifindex.
+                //
+                // `link.addr` carries the kernel-reported address
+                // *with host bits* (e.g. `2001:db8::1/64`), but the
+                // LSA-derived `net` is truncated to the network
+                // (e.g. `2001:db8::/64`) by `ospfv3_prefix_to_ipv6net`.
+                // Truncate both sides or the find never matches.
                 let Some(link) = top.links.values().find(|l| {
-                    l.enabled && l.area == area_id && l.addr.iter().any(|a| a.prefix == net)
+                    l.enabled && l.area == area_id && l.addr.iter().any(|a| a.prefix.trunc() == net)
                 }) else {
                     continue;
                 };


### PR DESCRIPTION
## Summary
- PR #825 walks self-originated Intra-Area-Prefix-LSAs and matches each prefix back to a local link by \`link.addr.iter().any(|a| a.prefix == net)\` — but the comparison silently never matched. \`link.addr\` carries the kernel-reported address *with host bits* (e.g. \`2001:db8::1/64\`), while \`net\` is the LSA-derived prefix truncated to the network (e.g. \`2001:db8::/64\`) by \`ospfv3_prefix_to_ipv6net\`. \`find\` returned \`None\` for every self-prefix → route skipped → segment prefix still disappeared from \`show ipv6 ospf route\` whenever zebra-rs won the DR election. The exact regression PR #825 was supposed to close.
- Truncate the link-side prefix before equality so the network portions compare cleanly.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo build -p zebra-rs\`
- [ ] Re-run against FRR \`ospf6d\` with zebra-rs as DR; confirm the shared-segment prefix now appears as \`directly attached via <ifname>\` at cost = link's output_cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)