### PR TITLE
ospf: re-enable on link_up after kernel-driven LinkDown

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -203,11 +203,31 @@ impl<V: OspfVersion> Ospf<V> {
 
     /// Mark a link operationally up and, if OSPF is enabled on it,
     /// fire `Ifsm::InterfaceUp`. Shared by v2 and v3.
+    ///
+    /// A kernel-driven `LinkDown` queues a `Message::Disable` that
+    /// clears `link.enabled` / `link.area` — but the operator's
+    /// YANG config (`link.config.enable`, `link.config.area`) stays
+    /// intact. When the kernel link comes back up, the runtime
+    /// state is stale and a bare `if link.enabled` check would skip
+    /// `InterfaceUp`, leaving the IFSM in `Down` with no Hellos
+    /// flowing. Peer Hellos still arrive on the still-joined
+    /// multicast socket, so the neighbor lands in `Init` and never
+    /// progresses — that's the symptom. Re-fire `Enable` from the
+    /// config to repair the runtime state; the `Enable` arm
+    /// re-originates LSAs and fires `InterfaceUp` itself.
     fn link_up(&mut self, ifindex: u32) {
         let Some(link) = self.links.get_mut(&ifindex) else {
             return;
         };
         link.link_flags |= LinkFlags::Up | LinkFlags::LowerUp;
+
+        if !link.enabled
+            && link.config.enable
+            && let Some(area) = link.config.area
+        {
+            let _ = self.tx.send(Message::Enable(ifindex, area));
+            return;
+        }
 
         if link.enabled {
             let _ = self.tx.send(Message::Ifsm(ifindex, IfsmEvent::InterfaceUp));


### PR DESCRIPTION
## Summary
- Kernel \`LinkDown\` queues \`Message::Disable\` whose handler clears \`link.enabled\` and \`link.area\`. The operator's YANG config (\`link.config.enable\`, \`link.config.area\`) stays intact.
- When the kernel link comes back up, \`link_up\`'s bare \`if link.enabled\` check skips \`Ifsm::InterfaceUp\` because the runtime state is stale — IFSM stays in \`Down\`, no Hellos go out. But the multicast socket is still joined, so peer Hellos arrive: \`ospfv3_hello_recv\` creates the neighbor at \`Init\`, our next Hello never fires, peer never lists us, and the neighbor never progresses past \`Init\`.
- Fix: in \`link_up\`, if config says \`enable: true\` but runtime \`link.enabled\` is false, re-fire \`Message::Enable\` from the config. The \`Enable\` arm re-originates LSAs and fires \`InterfaceUp\` itself.

Shared fix for both v2 and v3 — the same stale-runtime-state bug applies to both.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --exclude bdd\`
- [ ] On FRR interop, run \`ip link set enp0s6 down && sleep 2 && ip link set enp0s6 up\` and confirm the neighbor progresses past \`Init\` back to \`Full\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)