### PR TITLE
ospf: install v2 self-attached intra-area routes (FRR parity)

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -3455,6 +3455,40 @@ fn add_inter_area_routes(
     }
 }
 
+/// Find the local enabled v2 link in `area_id` whose interface
+/// address equals `addr` — used for self transit-network links,
+/// where `link.link_id` is our own interface IP (we are the DR).
+fn self_link_by_addr(top: &Ospf, area_id: Ipv4Addr, addr: Ipv4Addr) -> Option<&OspfLink> {
+    top.links
+        .values()
+        .find(|l| l.enabled && l.area == area_id && l.addr.iter().any(|a| a.prefix.addr() == addr))
+}
+
+/// Find the local enabled v2 link in `area_id` whose configured
+/// prefix matches the stub `prefix` — used for self stub links
+/// (loopback /32 or segment /N from our own Router-LSA).
+fn self_link_by_prefix(top: &Ospf, area_id: Ipv4Addr, prefix: Ipv4Net) -> Option<&OspfLink> {
+    top.links.values().find(|l| {
+        l.enabled && l.area == area_id && l.addr.iter().any(|a| a.prefix.trunc() == prefix)
+    })
+}
+
+/// Build the v2 nexthop set for a directly-attached self route:
+/// single entry keyed by `Ipv4Addr::UNSPECIFIED` with the local
+/// ifindex. The show layer treats UNSPECIFIED as "directly attached".
+fn attached_nhops(ifindex: u32) -> BTreeMap<Ipv4Addr, SpfNexthop> {
+    let mut nhops = BTreeMap::new();
+    nhops.insert(
+        Ipv4Addr::UNSPECIFIED,
+        SpfNexthop {
+            ifindex,
+            adjacency: false,
+            router_id: None,
+        },
+    );
+    nhops
+}
+
 fn build_rib_from_spf(
     top: &Ospf,
     area_id: Ipv4Addr,
@@ -3468,11 +3502,14 @@ fn build_rib_from_spf(
     };
 
     // Intra-area: walk each SPF destination's Router-LSA links.
+    // Self is included so locally-attached stub prefixes (loopback /32s,
+    // p2p stubs) and transit prefixes where we are the DR install with
+    // empty (directly-attached) nexthops, mirroring v3's
+    // `build_rib6_from_spf`. The kernel's connected route (admin 0)
+    // wins over the OSPF route (admin 110) in the FIB, so this only
+    // changes `show ip ospf route` — bringing it into parity with FRR.
     for (node, nhops) in spf_result {
-        // Skip self node.
-        if *node == source {
-            continue;
-        }
+        let is_self = *node == source;
 
         // Resolve node to router-id.
         let Some(router_id) = top.lsp_map.resolve(*node) else {
@@ -3499,9 +3536,26 @@ fn build_rib_from_spf(
                                 if let Ok(prefix) = Ipv4Net::new(link.link_id, mask) {
                                     let prefix = prefix.trunc();
 
+                                    let (metric, route_nhops) = if is_self {
+                                        // Self transit: we are the DR.
+                                        // link.link_id is our interface
+                                        // address on the segment; find
+                                        // the local link and stamp its
+                                        // ifindex as a directly-attached
+                                        // nexthop.
+                                        let Some(local) =
+                                            self_link_by_addr(top, area_id, link.link_id)
+                                        else {
+                                            break;
+                                        };
+                                        (link.tos_0_metric as u32, attached_nhops(local.index))
+                                    } else {
+                                        (nhops.cost, spf_nhops.clone())
+                                    };
+
                                     let spf_route = SpfRoute {
-                                        metric: nhops.cost,
-                                        nhops: spf_nhops.clone(),
+                                        metric,
+                                        nhops: route_nhops,
                                         sid: None,
                                         prefix_sid: None,
                                     };
@@ -3517,9 +3571,23 @@ fn build_rib_from_spf(
                         let mask = u32::from(link.link_data).leading_ones() as u8;
                         if let Ok(prefix) = Ipv4Net::new(link.link_id, mask) {
                             let prefix = prefix.trunc();
+
+                            let (metric, route_nhops) = if is_self {
+                                // Self stub: find the local link whose
+                                // address sits inside this prefix
+                                // (loopback /32 matches itself; segment
+                                // stub matches the configured /N).
+                                let Some(local) = self_link_by_prefix(top, area_id, prefix) else {
+                                    continue;
+                                };
+                                (link.tos_0_metric as u32, attached_nhops(local.index))
+                            } else {
+                                (nhops.cost, spf_nhops.clone())
+                            };
+
                             let spf_route = SpfRoute {
-                                metric: nhops.cost,
-                                nhops: spf_nhops.clone(),
+                                metric,
+                                nhops: route_nhops,
                                 sid: None,
                                 prefix_sid: None,
                             };

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -1453,25 +1453,29 @@ fn show_ospf_route(
             //     String::from("")
             // };
             let sid = String::from("");
+            // UNSPECIFIED nexthop is the self-attached marker stamped by
+            // `attached_nhops` in inst.rs; render it FRR-style as
+            // "directly attached to <ifname>".
+            let via = if addr.is_unspecified() {
+                format!("directly attached to {}", ospf.ifname(nhop.ifindex))
+            } else {
+                format!("via {}, {}", addr, ospf.ifname(nhop.ifindex))
+            };
             if !shown {
                 writeln!(
                     buf,
-                    "{:<20} [{}] via {}, {}{}",
+                    "{:<20} [{}] {}{}",
                     prefix.to_string(),
                     route.metric,
-                    addr,
-                    ospf.ifname(nhop.ifindex),
+                    via,
                     sid
                 )?;
                 shown = true;
             } else {
                 writeln!(
                     buf,
-                    "                     [{}] via {}, {}{}",
-                    route.metric,
-                    addr,
-                    ospf.ifname(nhop.ifindex),
-                    sid
+                    "                     [{}] {}{}",
+                    route.metric, via, sid
                 )?;
             }
         }


### PR DESCRIPTION
## Summary

- v2 route builder previously skipped the SPF source node, so prefixes the local router itself advertises were missing from `show ip ospf route`: stub links (loopback /32, p2p stubs) and the transit prefix where we are the DR.
- v3 (`build_rib6_from_spf` at `zebra-rs/src/ospf/inst.rs:3837`) already installs self prefixes with `UNSPECIFIED` nexthop + local ifindex; v2 now mirrors that pattern so both protocols match FRR's `directly attached to <ifname>` rendering.
- Cost: `link.tos_0_metric` from our own Router-LSA (== the link's `output_cost`). Local link resolved by matching the LSA's `link_id`/`link_data` against `OspfLink.addr`.
- Show formatter renders `Ipv4Addr::UNSPECIFIED` nexthop as `directly attached to <ifname>`. FIB still prefers the kernel's connected route (admin 0) over OSPF (admin 110), so this only changes the OSPF route table view.

## Follow-up (separate PR)

- Non-self Stub/Transit metric at `inst.rs:3503/3521` uses `nhops.cost` only; RFC 2328 §16.1.1 requires `nhops.cost + link.tos_0_metric`. The current pasted output (`192.168.2.0/24 [10]` instead of `[20]`) is from this bug, not the self-install gap fixed here.

## Test plan

- [ ] Two-router topology (this router is DR on a transit segment); confirm `show ip ospf route` now lists the loopback /32 and the transit /N as `directly attached to <ifname>`.
- [ ] DR-role flip: take down the peer, regain DR; the self entries should appear/move accordingly without manual SPF kick.
- [ ] Kernel FIB unchanged — connected routes still install at admin 0; no OSPF override.
- [ ] `cargo fmt --all --check` clean.
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)