### PR TITLE
ospf: stamp loopback stub metric 0 in v2/v3 Router-LSAs (FRR/Junos parity)

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -19,7 +19,7 @@ use crate::ospf::addr::OspfAddr;
 use crate::ospf::packet::{ospf_db_desc_recv, ospf_hello_recv, ospf_hello_send};
 use crate::rib::api::RibRx;
 use crate::rib::link::LinkAddr;
-use crate::rib::{self, Link, RibType};
+use crate::rib::{self, Link, LinkFlagsExt, RibType};
 use crate::spf::label_block::LabelConfig;
 use crate::{
     config::{Args, ConfigChannel, ConfigRequest, path_from_command},
@@ -412,7 +412,17 @@ impl Ospf<Ospfv2> {
                 continue;
             }
 
-            let metric = link.output_cost.min(u16::MAX as u32) as u16;
+            // RFC 2328 §12.4.1.1 leaves the loopback stub metric as
+            // "the configured cost of the interface", but FRR and
+            // Juniper Junos hardcode 0 by convention (Cisco uses 1).
+            // Stamping the regular `output_cost` (default 10) on a
+            // loopback /32 inflates downstream route metrics by a
+            // phantom hop. Match the FRR/Junos convention.
+            let metric = if link.link_flags.is_loopback() {
+                0
+            } else {
+                link.output_cost.min(u16::MAX as u32) as u16
+            };
             let use_transit = matches!(
                 link.network_type,
                 OspfNetworkType::Broadcast | OspfNetworkType::NBMA
@@ -1739,7 +1749,15 @@ impl Ospf<Ospfv3> {
             if transit_with_adjacencies {
                 continue;
             }
-            let metric = link.output_cost as u16;
+            // Loopback parity with v2 / FRR / Junos: stamp 0 instead
+            // of the link's output_cost so a /128 (or /N) on `lo`
+            // doesn't add a phantom hop's worth of metric to every
+            // route that traverses this router.
+            let metric = if link.link_flags.is_loopback() {
+                0
+            } else {
+                link.output_cost as u16
+            };
             for a in link.addr.iter() {
                 // Skip link-local addresses — those are
                 // advertised by Link-LSAs (RFC 5340 §A.4.9), not


### PR DESCRIPTION
## Summary

- RFC 2328 §12.4.1.1 leaves the loopback stub metric as "the configured cost of the interface", but the dominant convention is 0: **Junos = 0**, **FRR = 0**, **Cisco = 1** (auto-cost). zebra-rs was stamping the regular `output_cost` (default 10), inflating downstream route metrics by a phantom hop and causing `show ip ospf route` to disagree numerically with FRR/Junos peers in mixed topologies.
- Match FRR/Junos = **0** for **all** loopback-interface prefixes (not just /32 host routes), gated on `link.link_flags.is_loopback()` so it keys off kernel interface type rather than prefix shape.
- Applied symmetrically in v2 (`Ospfv2::router_lsa_build`) and v3 (`Ospfv3::build_router_intra_area_prefix_lsa`).
- The self-attached route install from PR #829 picks up the new metric automatically — no follow-up needed there.

## Test plan

- [ ] Configure a /32 on `lo`; `show ip ospf database detail` shows that stub link as `TOS 0 Metric: 0`.
- [ ] `show ip ospf route` shows the loopback as `[0] directly attached to lo`.
- [ ] Regular (non-loopback) interface stub/transit unchanged: metric still equals interface `output_cost`.
- [ ] v3 equivalent: `show ipv6 ospf database` shows the loopback IPv6 prefix in the Router-ref Intra-Area-Prefix-LSA with `metric = 0`.
- [ ] FRR peer + zebra-rs side-by-side: loopback metrics agree across both implementations.
- [ ] `cargo fmt --all --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)