### PR TITLE
ospf: fix v2 non-self stub/transit metric per RFC 2328 §16.1.1

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -3568,7 +3568,19 @@ fn build_rib_from_spf(
                                         };
                                         (link.tos_0_metric as u32, attached_nhops(local.index))
                                     } else {
-                                        (nhops.cost, spf_nhops.clone())
+                                        // RFC 2328 §16.1.1: transit metric
+                                        // is D(V) + V's link.tos_0_metric
+                                        // to the network — *not* just D(V).
+                                        // Without the per-link term, a
+                                        // peer's transit advertisement for
+                                        // the same prefix we serve as DR
+                                        // tied at our local cost and
+                                        // ECMP-merged with the
+                                        // directly-attached entry.
+                                        (
+                                            nhops.cost.saturating_add(link.tos_0_metric as u32),
+                                            spf_nhops.clone(),
+                                        )
                                     };
 
                                     let spf_route = SpfRoute {
@@ -3600,7 +3612,13 @@ fn build_rib_from_spf(
                                 };
                                 (link.tos_0_metric as u32, attached_nhops(local.index))
                             } else {
-                                (nhops.cost, spf_nhops.clone())
+                                // RFC 2328 §16.1.1: stub metric is
+                                // D(V) + L.cost (per V's Router-LSA).
+                                // Symmetric with the transit arm above.
+                                (
+                                    nhops.cost.saturating_add(link.tos_0_metric as u32),
+                                    spf_nhops.clone(),
+                                )
                             };
 
                             let spf_route = SpfRoute {


### PR DESCRIPTION
## Summary

- v2 route builder stamped `nhops.cost` (the SPF cost to the advertising router V) as the metric for non-self stub and transit Router-LSA links. RFC 2328 §16.1.1 requires `D(V) + L.cost`, where `L.cost` is V's per-link `tos_0_metric` from its own Router-LSA.
- The missing per-link term caused duplicate ECMP entries for prefixes we serve as DR while a peer also advertises the same prefix. With the correct formula the via-peer cost (e.g. 10+10=20) loses to our self-DR transit (10) and the directly-attached entry is the sole entry.
- v3's `build_rib6_from_spf` already computes `ref_path.cost + prefix.metric` correctly — no v3 change.
- Symmetric fix in both the Transit and Stub arms of `build_rib_from_spf` (`zebra-rs/src/ospf/inst.rs`).

## Before / after

Before (zebra-rs):
```
192.168.10.0/24      [10] directly attached to enp0s6
                     [10] via 192.168.10.2, enp0s6
```

After (matches FRR):
```
192.168.10.0/24      [10] directly attached to enp0s6
```

## Test plan

- [ ] Two-router LAN topology with this router as DR; confirm `show ip ospf route` shows the segment prefix only as `directly attached`, no duplicate via-peer entry.
- [ ] Multi-hop topology: non-self stub metric for a remote /24 reflects `SPF-cost-to-advertiser + advertised-stub-cost` (e.g. previously 10, now 20 for a one-hop neighbor advertising its segment at cost 10).
- [ ] DR-role flip: when peer becomes DR, our entry switches to via-peer with correct summed metric.
- [ ] FRR peer side-by-side: route metrics now agree numerically.
- [ ] `cargo fmt --all --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)