### PR TITLE
ospf: add v2 point-to-point network-type knob (FRR/IS-IS-style YANG)

### DIFF
--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -4,6 +4,7 @@ use std::net::Ipv4Addr;
 use super::Ospf;
 use super::OspfLink;
 use super::ifsm::{IfsmEvent, ospf_hello_timer};
+use super::link::OspfNetworkType;
 use super::tracing::{config_tracing_fsm, config_tracing_packet};
 use super::version::{OspfVersion, Ospfv2};
 
@@ -32,6 +33,10 @@ impl Ospf {
     pub fn callback_build(&mut self) {
         self.ospf_add("/router-id", config_ospf_router_id);
         self.ospf_add("/area/interface/enable", config_ospf_interface_enable);
+        self.ospf_add(
+            "/area/interface/network-type",
+            config_ospf_interface_network_type,
+        );
         self.ospf_add("/area/interface/priority", config_ospf_interface_priority);
         self.ospf_add(
             "/area/interface/hello-interval",
@@ -140,6 +145,38 @@ fn config_ospf_interface_enable(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -
 
     let (next, next_id) = link_should_enable(link);
     apply_link_enable_transition(link, next, next_id);
+
+    Some(())
+}
+
+/// `/router/ospf/area/<id>/interface/<name>/network-type` — accepts
+/// `broadcast` or `point-to-point` (YANG enum, kebab-case). Mirrors
+/// the IS-IS `network-type` knob: bounce the interface on any change
+/// so the IFSM re-initializes from the new type's entry state (P2P
+/// skips Waiting / DR election; Broadcast goes through Waiting).
+fn config_ospf_interface_network_type(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let network_type = args.string()?.parse::<OspfNetworkType>().ok()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    let old = link.config_network_type();
+    if op.is_set() {
+        link.config.network_type = Some(network_type);
+    } else {
+        link.config.network_type = None;
+    }
+    let new = link.config_network_type();
+
+    // Network-type change on an already-enabled interface invalidates
+    // the IFSM state (P2P shouldn't be in Waiting/DROther; broadcast
+    // shouldn't be in PointToPoint) and the cached neighbor list.
+    // Disable+Enable through the existing channel rebuilds both.
+    if old != new && link.enabled {
+        let area_id = link.area_id;
+        let _ = link.tx.send(Message::Disable(link.index, area_id));
+        let _ = link.tx.send(Message::Enable(link.index, area_id));
+    }
 
     Some(())
 }

--- a/zebra-rs/src/ospf/ifsm.rs
+++ b/zebra-rs/src/ospf/ifsm.rs
@@ -13,15 +13,16 @@ use super::{Identity, Message, NfsmEvent, NfsmState, OspfLink};
 /// state variants are needed; the enum and its Display impl are
 /// version-agnostic.
 ///
-/// `Loopback` and `Point-to-Point` from the RFC are intentionally
-/// elided — zebra-rs does not yet support loopback interfaces in
-/// OSPF nor non-broadcast point-to-point links; both will be added
-/// when the corresponding wiring lands.
+/// `Loopback` from the RFC is intentionally elided — zebra-rs does
+/// not yet support loopback interfaces in OSPF; it will be added when
+/// the corresponding wiring lands. `PointToPoint` was added once the
+/// `network-type point-to-point` knob landed.
 #[derive(Debug, Default, PartialEq, PartialOrd, Eq, Clone, Copy)]
 pub enum IfsmState {
     #[default]
     Down,
     Waiting,
+    PointToPoint,
     DROther,
     Backup,
     DR,
@@ -33,6 +34,7 @@ impl Display for IfsmState {
         let state = match self {
             Down => "Down",
             Waiting => "Waiting",
+            PointToPoint => "Point-To-Point",
             DROther => "DROther",
             Backup => "Backup",
             DR => "DR",
@@ -74,6 +76,16 @@ impl IfsmState {
                 WaitTimer => (ospf_ifsm_wait_timer, None),
                 BackupSeen => (ospf_ifsm_backup_seen, None),
                 NeighborChange => (ospf_ifsm_ignore, Some(Waiting)),
+                InterfaceDown => (ospf_ifsm_interface_down, Some(Down)),
+            },
+            // P2P is terminal in the IFSM — no DR/BDR election runs,
+            // no Wait timer, no NeighborChange handler (adjacency
+            // formation is driven entirely by the NFSM 2-way path).
+            PointToPoint => match ev {
+                InterfaceUp => (ospf_ifsm_ignore, Some(PointToPoint)),
+                WaitTimer => (ospf_ifsm_ignore, Some(PointToPoint)),
+                BackupSeen => (ospf_ifsm_ignore, Some(PointToPoint)),
+                NeighborChange => (ospf_ifsm_ignore, Some(PointToPoint)),
                 InterfaceDown => (ospf_ifsm_interface_down, Some(Down)),
             },
             DROther => match ev {
@@ -151,10 +163,12 @@ pub fn ospf_ifsm_interface_up<V: OspfVersion>(link: &mut OspfLink<V>) -> Option<
     V::join_if(&link.sock, link.index);
     link.multicast_memberships.set_all_routers(true);
 
-    // Comment out until we support pointopoint interface.
-    // if link.is_pointopoint() {
-    //     return IfsmState::PointToPoint;
-    // }
+    // P2P interfaces skip Waiting / DR election entirely (RFC 2328
+    // §10.3) — they go straight to PointToPoint and let the NFSM
+    // drive adjacency to Full on TwoWayReceived.
+    if link.is_pointopoint() {
+        return Some(IfsmState::PointToPoint);
+    }
 
     if link.ident.priority == 0 {
         Some(IfsmState::DROther)
@@ -346,7 +360,7 @@ fn ospf_ifsm_timer_set<V: OspfVersion>(oi: &mut OspfLink<V>) {
             oi.timer.wait.get_or_insert(ospf_wait_timer(oi));
             oi.timer.ls_ack = None;
         }
-        DROther | Backup | DR => {
+        DROther | Backup | DR | PointToPoint => {
             oi.timer.hello.get_or_insert(ospf_hello_timer(oi));
             oi.timer.wait = None;
         }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -121,6 +121,10 @@ pub struct OspfInterface<'a, V: OspfVersion = Ospfv2> {
     pub exchange_loading_count: usize,
     pub mtu_ignore: bool,
     pub retransmit_interval: u16,
+    /// Snapshot of the parent link's resolved network type. The NFSM
+    /// keys off this to decide 2-Way -> ExStart on P2P links without
+    /// gating on DR/BDR.
+    pub network_type: OspfNetworkType,
     pub tracing: &'a OspfTracing,
     /// v3-only outbound packet channel borrow. Carries the `Ospfv3Send`
     /// sender that the `network_v6::write_packet_v6` task consumes.
@@ -170,6 +174,7 @@ impl<V: OspfVersion> Ospf<V> {
                             exchange_loading_count,
                             mtu_ignore: link.config.mtu_ignore,
                             retransmit_interval,
+                            network_type: link.network_type,
                             tracing: &self.tracing,
                             v3_send_tx: self.v3_send_tx.as_ref(),
                             link_lsdb: &mut link.lsdb,
@@ -423,6 +428,38 @@ impl Ospf<Ospfv2> {
             } else {
                 link.output_cost.min(u16::MAX as u32) as u16
             };
+
+            // RFC 2328 §12.4.1.1, numbered point-to-point: one Type-1
+            // P2p link per Full neighbor (pointing at the neighbor's
+            // router-id, link_data = our interface address), plus a
+            // Type-3 Stub for the local /N. With no Full neighbor we
+            // fall through to Stub-only, which keeps the local prefix
+            // advertised even while the adjacency is still forming.
+            if link.is_pointopoint() {
+                for addr in &link.addr {
+                    if addr.prefix.addr().octets()[0] == 127 {
+                        continue;
+                    }
+                    for nbr in link.nbrs.values() {
+                        if nbr.state != NfsmState::Full {
+                            continue;
+                        }
+                        router_lsa.links.push(RouterLsaLink {
+                            link_id: nbr.ident.router_id,
+                            link_data: addr.prefix.addr(),
+                            link_type: OspfLinkType::P2p,
+                            num_tos: 0,
+                            tos_0_metric: metric,
+                            toses: vec![],
+                        });
+                    }
+                    router_lsa
+                        .links
+                        .push(Self::router_lsa_stub_link(addr.prefix, metric));
+                }
+                continue;
+            }
+
             let use_transit = matches!(
                 link.network_type,
                 OspfNetworkType::Broadcast | OspfNetworkType::NBMA
@@ -1301,6 +1338,10 @@ impl Ospf<Ospfv2> {
                 link.enabled = true;
                 link.area = area_id;
                 link.area_id = area_id;
+                // Sync the runtime network_type from config at enable
+                // time so IFSM / NFSM / Router-LSA emission key off
+                // the operator's choice (default Broadcast).
+                link.network_type = link.config_network_type();
                 let area = self.areas.fetch(area_id);
                 area.links.insert(ifindex);
                 self.router_lsa_originate();

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::{collections::BTreeMap, net::Ipv4Addr};
 
@@ -26,6 +27,7 @@ pub enum OspfNetworkType {
     #[default]
     Broadcast,
     NBMA,
+    PointToPoint,
 }
 
 impl Display for OspfNetworkType {
@@ -33,6 +35,22 @@ impl Display for OspfNetworkType {
         match self {
             OspfNetworkType::Broadcast => write!(f, "BROADCAST"),
             OspfNetworkType::NBMA => write!(f, "NBMA"),
+            OspfNetworkType::PointToPoint => write!(f, "POINT-TO-POINT"),
+        }
+    }
+}
+
+impl FromStr for OspfNetworkType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // YANG enum names (kebab-case) only; uppercase Display forms
+        // are output-only and not accepted back.
+        match s {
+            "broadcast" => Ok(Self::Broadcast),
+            "nbma" => Ok(Self::NBMA),
+            "point-to-point" => Ok(Self::PointToPoint),
+            _ => Err(()),
         }
     }
 }
@@ -56,6 +74,7 @@ pub struct LinkConfig {
     pub transmit_delay: Option<u16>,
     pub mtu_ignore: bool,
     pub prefix_sid: Option<PrefixSid>,
+    pub network_type: Option<OspfNetworkType>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -225,6 +244,19 @@ impl<V: OspfVersion> OspfLink<V> {
 
     pub fn is_nbma_if(&self) -> bool {
         self.network_type == OspfNetworkType::NBMA
+    }
+
+    pub fn is_pointopoint(&self) -> bool {
+        self.network_type == OspfNetworkType::PointToPoint
+    }
+
+    /// Resolve the configured network type, defaulting to Broadcast
+    /// (matches the historical zebra-rs behavior — every interface
+    /// was Broadcast unless code explicitly overrode it).
+    pub fn config_network_type(&self) -> OspfNetworkType {
+        self.config
+            .network_type
+            .unwrap_or(OspfNetworkType::Broadcast)
     }
 }
 

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -318,14 +318,20 @@ pub fn ospf_nfsm_hello_received<V: OspfVersion>(
 }
 
 pub fn ospf_nfsm_twoway_received<V: OspfVersion>(
-    _oi: &mut OspfInterface<V>,
+    oi: &mut OspfInterface<V>,
     nbr: &mut Neighbor<V>,
     oident: &Identity<V>,
 ) -> Option<NfsmState> {
+    use super::link::OspfNetworkType;
     let mut next_state = NfsmState::TwoWay;
 
-    // If interface is pointopoint.
-    if nbr.is_pointopoint() {
+    // P2P interfaces skip DR/BDR gating entirely: any neighbor that
+    // reaches 2-Way proceeds straight to ExStart. (RFC 2328 §10.4 —
+    // "I am a DR/BDR or my neighbor is DR/BDR" doesn't apply when
+    // there is no DR election.) `nbr.is_pointopoint()` is a stub that
+    // returns false; check the parent interface's network_type
+    // directly.
+    if oi.network_type == OspfNetworkType::PointToPoint {
         next_state = NfsmState::ExStart;
     }
 

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -332,6 +332,12 @@ module config {
             leaf enable {
               type boolean;
             }
+            leaf network-type {
+              type enumeration {
+                enum broadcast;
+                enum point-to-point;
+              }
+            }
             leaf priority {
               type uint8;
             }


### PR DESCRIPTION
## Summary

Adds operator-facing `network-type point-to-point` knob on v2 OSPF interfaces, modelled after the IS-IS YANG shape at `config.yang:865`:

```
set router ospf area 0 interface enp0s6 network-type point-to-point
```

End-to-end v2 implementation:

- **YANG** — `leaf network-type { enum {broadcast, point-to-point} }` under `/router/ospf/area/<id>/interface/<name>`.
- **`OspfNetworkType::PointToPoint`** variant + `FromStr`/`Display`. `LinkConfig::network_type: Option<...>` with `config_network_type()` getter (default Broadcast).
- **`Message::Enable`** syncs `link.network_type` from the config getter so IFSM / NFSM / Router-LSA emission all key off the operator's choice.
- **Config callback** bounces the interface (Disable+Enable) on any change so the IFSM re-enters from the right initial state.
- **`IfsmState::PointToPoint`** state added; `ospf_ifsm_interface_up` returns it when `link.is_pointopoint()`. The P2P state ignores Wait/BackupSeen/NeighborChange (no DR election) and uses the same hello-timer-only timer set as DROther/Backup/DR.
- **`OspfInterface::network_type`** threaded through so `ospf_nfsm_twoway_received` promotes any 2-Way neighbor straight to ExStart when the parent link is P2P (RFC 2328 §10.4 DR/BDR gating doesn't apply).
- **`Ospfv2::router_lsa_build`** emits Type-1 (P2p) links per Full neighbor + a Type-3 Stub for the local /N (RFC 2328 §12.4.1.1, numbered P2P). With no Full neighbor we fall back to Stub-only so the local prefix stays advertised during adjacency setup.

## Out of scope (follow-up PRs)

- **v3 parity** — same end-to-end shape for OSPFv3 (`OSPFV3_ROUTER_LSA_TYPE` P2P link emission, `build_router_intra_area_prefix_lsa` filtering, NFSM/IFSM mirroring).
- **DR-election split-brain hardening** — the operational reason to use this knob today is to *avoid* the split-brain on back-to-back links; root-cause fix for the broadcast split-brain race comes in a separate PR.

## Test plan

- [ ] Back-to-back P2P: `set router ospf area 0 interface enp0s6 network-type point-to-point` on both ends; confirm `show ip ospf interface` shows `State Point-To-Point` and `Network Type POINT-TO-POINT`; NFSM goes 2-Way -> ExStart -> Full without Wait timer.
- [ ] Router-LSA dump: each side advertises one Type-1 (P2p) link toward the peer's router-id with the interface address as link_data, plus a Type-3 Stub for the local /N. No Network-LSA is originated.
- [ ] Mid-flight network-type change: with adjacency Full on broadcast, set to point-to-point — interface bounces, adjacency reforms cleanly under P2P. Reverse direction (P2P -> broadcast) also works.
- [ ] Broadcast interfaces unchanged: existing two-router LAN topology still elects DR, originates Network-LSA, installs routes as before.
- [ ] `cargo fmt --all --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)