### PR TITLE
ospf: honor declared-DR precedence in election (RFC 2328 §9.4 step 3)

### DIFF
--- a/zebra-rs/src/ospf/ifsm.rs
+++ b/zebra-rs/src/ospf/ifsm.rs
@@ -228,17 +228,27 @@ pub fn ospf_dr_election_dr<V: OspfVersion>(
     bdr: Option<Identity<V>>,
     v: Vec<Identity<V>>,
 ) -> Option<Identity<V>> {
-    let _dr_candidates: Vec<_> = v
-        .clone()
-        .into_iter()
+    // RFC 2328 §9.4 step 3: if any router has declared itself DR
+    // (i.e. its Hello lists itself in the DR field), the new DR is
+    // the declared-DR candidate with the highest priority / router-id.
+    // Only if *no* router has declared itself DR does the freshly
+    // elected BDR get promoted.
+    //
+    // The previous implementation tiebroke across **all** candidates
+    // (declared or not) and ignored the precedence rule, which caused
+    // a new joiner with a higher router-id to displace an existing
+    // DR — i.e. the split-brain we kept seeing on broadcast LANs.
+    let dr_candidates: Vec<Identity<V>> = v
+        .iter()
         .filter(|ident| V::is_declared_dr(ident))
+        .cloned()
         .collect();
 
-    let mut dr = ospf_dr_election_tiebreak(v);
-
-    if dr.is_none() {
-        dr = bdr;
-    }
+    let dr = if !dr_candidates.is_empty() {
+        ospf_dr_election_tiebreak(dr_candidates)
+    } else {
+        bdr
+    };
 
     if let Some(ident) = dr {
         oi.ident.d_router = V::ident_dr_id(&ident);


### PR DESCRIPTION
## Summary

`ospf_dr_election_dr` was ignoring the "prefer declared-DR" precedence rule and tiebreaking across **all** 2-Way+ candidates by priority/router-id — `_dr_candidates` was computed and discarded (the leading underscore silenced dead-code).

Per RFC 2328 §9.4 step 3:

> If one or more of the routers have declared themselves Designated Router … the one having highest Router Priority is declared to be Designated Router. … If no routers have declared themselves Designated Router, assign the Designated Router to be the same as the newly elected Backup Designated Router.

i.e. the election must consider **only** declared-DR candidates first, and fall back to the freshly elected BDR if none qualify.

## Observable symptom — split-brain DR

- **New joiner displaces incumbent**: a new router with a higher router-id joining an established LAN segment elected itself DR instead of yielding to the existing DR.
- **Symmetric Wait-timer race**: two routers' Wait timers expire near-simultaneously; each elects itself alone; on the re-election triggered by the peer's "I am DR" Hello they re-tiebreak across all candidates and never converge. Both stay DR, each originates its own Network-LSA at its own DR address, and SPF correctly drops the peer-derived prefixes because neither side's Router-LSA references the other's pseudo-node (RFC 2328 §16.1 back-link check). User-visible: peer's `/32` loopback and segment stubs missing from `show ip ospf route`.

## What changes

- `dr_candidates` is built from the declared-DR filter, tiebreak runs within that set, fall back to `bdr` only when nobody has declared themselves DR.
- BDR election (`ospf_dr_election_bdr`) was already correct (declared-BDR filter with the right fallback) — no change.
- One function, one match-rule shape, no behavior change on segments where no split-brain ever existed.

## Convergence after the fix

| Step | A view | B view |
|------|--------|--------|
| Both Wait → both self-elect | A=DR (alone) | B=DR (alone) |
| Hellos exchange | A sees B declared-DR | B sees A declared-DR |
| Re-election | dr_candidates = [A, B], B wins (higher rid) | dr_candidates = [A, B], B wins |
| Settle | A yields → DROther | B stays DR |
| Next Hello | A says DR=B | B says DR=B |
| BDR fill-in | A declares BDR=self (only non-DR) | B sees A declared-BDR → B.bd_router=A |
| Stable | A=BDR | B=DR |

Existing split-brains (already running when the fix lands) need an interface bounce to retrigger an election — the protocol only stabilizes; it doesn't preemptively recheck.

## Test plan

- [ ] Two-router LAN, both daemons started together: confirm exactly one Network-LSA exists for the segment (advertised by the higher-router-id router) and the other side shows `State Backup`.
- [ ] Bring up a third router with a higher router-id into the established DR/BDR pair: confirm it does **not** displace the existing DR (joins as DROther; if BDR is vacant it may take BDR).
- [ ] Existing split-brain recovery: bounce one side's interface; segment converges to single DR.
- [ ] `show ip ospf route` on each peer lists the others' loopback `/32` and stub prefixes (no longer dropped by SPF back-link check).
- [ ] `cargo fmt --all --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)