### PR TITLE
ospf: mirror v2 point-to-point network-type knob to OSPFv3

### DIFF
--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -14,6 +14,7 @@ use super::config::{
     parse_area_id,
 };
 use super::ifsm::{IfsmEvent, ospf_hello_timer};
+use super::link::OspfNetworkType;
 use super::version::Ospfv3;
 use super::{Message, Ospf, OspfLink};
 
@@ -30,6 +31,10 @@ impl Ospf<Ospfv3> {
         let prefix = OSPFV3;
         let entries: &[(&str, Callback<Ospfv3>)] = &[
             ("/area/interface/enable", config_ospfv3_interface_enable),
+            (
+                "/area/interface/network-type",
+                config_ospfv3_interface_network_type,
+            ),
             ("/area/interface/priority", config_ospfv3_interface_priority),
             (
                 "/area/interface/hello-interval",
@@ -85,6 +90,38 @@ fn config_ospfv3_interface_enable(
 
     let (next, next_id) = link_should_enable(link);
     apply_link_enable_transition(link, next, next_id);
+
+    Some(())
+}
+
+/// `/router/ospfv3/area/<id>/interface/<name>/network-type` — same
+/// shape as the v2 handler in `config.rs`. Stores the configured
+/// type in `LinkConfig::network_type` (shared between v2 and v3)
+/// and bounces the interface on any change so the IFSM re-enters
+/// from the correct initial state (PointToPoint vs Waiting).
+fn config_ospfv3_interface_network_type(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let network_type = args.string()?.parse::<OspfNetworkType>().ok()?;
+
+    let link: &mut OspfLink<Ospfv3> = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    let old = link.config_network_type();
+    if op.is_set() {
+        link.config.network_type = Some(network_type);
+    } else {
+        link.config.network_type = None;
+    }
+    let new = link.config_network_type();
+
+    if old != new && link.enabled {
+        let area_id = link.area_id;
+        let _ = link.tx.send(Message::Disable(link.index, area_id));
+        let _ = link.tx.send(Message::Enable(link.index, area_id));
+    }
 
     Some(())
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -2038,6 +2038,27 @@ impl Ospf<Ospfv3> {
             let cost = link.output_cost as u16;
             let my_iid = link.interface_id;
 
+            // RFC 5340 §A.4.3 link type 1: PointToPoint. One link
+            // entry per Full neighbor, naming the peer's
+            // interface-id and router-id. No DR involvement — the
+            // P2P link is its own bidirectional edge. Skipped while
+            // the adjacency is still forming so the Router-LSA
+            // doesn't carry a half-built reference.
+            if link.is_pointopoint() {
+                for nbr in link.nbrs.values() {
+                    if nbr.state != NfsmState::Full {
+                        continue;
+                    }
+                    links.push(Ospfv3RouterLsaLink::point_to_point(
+                        cost,
+                        my_iid,
+                        nbr.interface_id,
+                        nbr.ident.router_id,
+                    ));
+                }
+                continue;
+            }
+
             if matches!(link.network_type, OspfNetworkType::Broadcast) {
                 let dr_router_id = link.ident.d_router;
                 if dr_router_id == Ipv4Addr::UNSPECIFIED {
@@ -2321,6 +2342,10 @@ impl Ospf<Ospfv3> {
                 link.enabled = true;
                 link.area = area_id;
                 link.area_id = area_id;
+                // Mirror the v2 Enable arm — sync runtime
+                // network_type from config so IFSM / NFSM /
+                // Router-LSA key off the operator's choice.
+                link.network_type = link.config_network_type();
                 let area = self.areas.fetch(area_id);
                 area.links.insert(ifindex);
                 self.router_lsa_originate();

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -443,9 +443,9 @@ module config {
         // OSPFv3 (RFC 5340). Shape mirrors `container ospf` so a
         // v3 config differs from v2 only in the top-level keyword.
         // Per-interface knobs (`priority`, `hello-interval`,
-        // `dead-interval`, `retransmit-interval`, `mtu-ignore`)
-        // share semantics with their v2 counterparts; the v3
-        // callbacks live in `config_v3.rs`.
+        // `dead-interval`, `retransmit-interval`, `mtu-ignore`,
+        // `network-type`) share semantics with their v2
+        // counterparts; the v3 callbacks live in `config_v3.rs`.
         presence "Enables configuration of OSPFv3";
         leaf router-id {
           type inet:ipv4-address;
@@ -466,6 +466,12 @@ module config {
             }
             leaf enable {
               type boolean;
+            }
+            leaf network-type {
+              type enumeration {
+                enum broadcast;
+                enum point-to-point;
+              }
             }
             leaf priority {
               type uint8;


### PR DESCRIPTION
## Summary

Follow-up to PR #832 which added the v2 `network-type point-to-point` knob. The IFSM / NFSM bits already generalized cleanly to v3 (they're generic over `V: OspfVersion` and key off the per-link `OspfNetworkType` field). What was still v2-only:

- YANG leaf under `/router/ospfv3/area/interface/`
- v3 config callback (`config_v3.rs`)
- v3 `Message::Enable` syncing `link.network_type` from `config_network_type()`
- v3 Router-LSA P2P emission in `Ospfv3::build_router_lsa`

End-to-end v3 wiring:

```
set router ospfv3 area 0 interface enp0s6 network-type point-to-point
```

After enable:

- IFSM enters `PointToPoint` (skipping Waiting / DR election; shared generic path with v2).
- NFSM promotes 2-Way to ExStart immediately (RFC 5340 §4.4.4: DR/BDR gating doesn't apply on P2P; the existing `oi.network_type == PointToPoint` branch in `ospf_nfsm_twoway_received` handles both versions).
- `Ospfv3::build_router_lsa` emits one Type-1 (P2p) `Ospfv3RouterLsaLink` per Full neighbor naming the peer's interface-id + router-id (RFC 5340 §A.4.3). No Network-LSA is originated.
- `build_router_intra_area_prefix_lsa`'s existing `transit_with_adjacencies` filter already restricts the Network-ref redirect to Broadcast/NBMA segments, so v3 P2P prefixes flow through the Router-ref Intra-Area-Prefix-LSA without further plumbing.

## Test plan

- [ ] Back-to-back v3 P2P: `set router ospfv3 area 0 interface enp0s6 network-type point-to-point` on both ends; `show ipv6 ospf interface` shows `State Point-To-Point`; NFSM goes 2-Way -> ExStart -> Full without Wait timer.
- [ ] Router-LSA dump: each side advertises one Type-1 (PointToPoint) Ospfv3RouterLsaLink referencing the peer's interface-id + router-id. No Network-LSA exists for the segment.
- [ ] Intra-Area-Prefix-LSA: segment prefixes are advertised via the Router-ref variant (no Network-ref) since `transit_with_adjacencies` is false on P2P.
- [ ] Mid-flight network-type flip: with adjacency Full on broadcast, set to point-to-point — interface bounces and reforms cleanly. Reverse direction works too.
- [ ] Broadcast v3 LANs unchanged: existing DR election + Network-LSA + Network-ref Intra-Area-Prefix-LSA still work.
- [ ] `cargo fmt --all --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)