### PR TITLE
ospf: flush self-originated Network-LSA on DR-leave (RFC 2328 §14.1)

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -943,6 +943,42 @@ impl Ospf<Ospfv2> {
         }
     }
 
+    /// Premature-age (RFC 2328 §14.1) the self-originated Network-LSA
+    /// scoped to `ifindex` and re-flood it so peers drop it. Called
+    /// from `Message::Disable` (interface going away) and from the
+    /// `Message::Ifsm` DR-leave hook (we lost the DR role through
+    /// election or network-type change) — the LSA must not outlive
+    /// our DR state on the segment, otherwise peers carry a stale
+    /// pseudo-node that contradicts our current Router-LSA.
+    ///
+    /// Mirrors v3's `network_lsa_flush` (inst.rs:2847). The LSA's
+    /// `ls_id` is the primary interface address — same value used
+    /// at origination in `update_network_lsa_by_interface`.
+    pub fn network_lsa_flush(&mut self, ifindex: u32, area_id: Ipv4Addr) {
+        let Some(link) = self.links.get(&ifindex) else {
+            return;
+        };
+        let Some(primary_addr) = link.addr.first() else {
+            return;
+        };
+        let ls_id = primary_addr.prefix.addr();
+
+        let flushed = if let Some(area) = self.areas.get_mut(area_id) {
+            area.lsdb.flush_lsa(
+                OspfLsType::Network,
+                ls_id,
+                self.router_id,
+                &self.tx,
+                Some(area_id),
+            )
+        } else {
+            None
+        };
+        if let Some(lsa) = flushed {
+            self.flood_self_originated_lsa(area_id, &lsa);
+        }
+    }
+
     fn process_neighbor_state_change(
         &mut self,
         ifindex: u32,
@@ -1348,6 +1384,12 @@ impl Ospf<Ospfv2> {
                 let _ = self.tx.send(Message::Ifsm(ifindex, IfsmEvent::InterfaceUp));
             }
             Message::Disable(ifindex, area_id) => {
+                // Flush self-originated Network-LSA *before* clearing
+                // the link's area binding so the flush helper can read
+                // through `link.addr` / `link.area` to find the LSA
+                // key. Mirrors v3's Disable handler at inst.rs:2356.
+                self.network_lsa_flush(ifindex, area_id);
+
                 let Some(link) = self.links.get_mut(&ifindex) else {
                     return;
                 };
@@ -1365,10 +1407,23 @@ impl Ospf<Ospfv2> {
                 self.process_recv(packet, src, from, index, dest).await;
             }
             Message::Ifsm(index, ev) => {
+                // Snapshot pre-state so we can detect a DR-leave
+                // transition after `ospf_ifsm` runs and flush the
+                // now-orphan Network-LSA. Without this, the
+                // self-originated Network-LSA outlives our DR role
+                // (election yield, network-type change, etc.) and
+                // pollutes peers' LSDBs until MaxAge.
+                let prev = self.links.get(&index).map(|l| (l.state, l.area_id));
                 let Some(link) = self.links.get_mut(&index) else {
                     return;
                 };
                 ospf_ifsm(link, ev);
+                if let Some((prev_state, area_id)) = prev {
+                    let new_state = self.links.get(&index).map(|l| l.state);
+                    if prev_state == IfsmState::DR && new_state != Some(IfsmState::DR) {
+                        self.network_lsa_flush(index, area_id);
+                    }
+                }
             }
             Message::Nfsm(index, src, ev) => {
                 let old_state = self
@@ -2378,10 +2433,20 @@ impl Ospf<Ospfv3> {
                     .send(Message::Ifsm(ifindex, IfsmEvent::InterfaceDown));
             }
             Message::Ifsm(index, ev) => {
+                // Same DR-leave hook as v2: premature-age the
+                // self-originated Network-LSA when the IFSM yields
+                // DR so the LSA doesn't outlive our DR role.
+                let prev = self.links.get(&index).map(|l| (l.state, l.area_id));
                 let Some(link) = self.links.get_mut(&index) else {
                     return;
                 };
                 ospf_ifsm(link, ev);
+                if let Some((prev_state, area_id)) = prev {
+                    let new_state = self.links.get(&index).map(|l| l.state);
+                    if prev_state == IfsmState::DR && new_state != Some(IfsmState::DR) {
+                        self.network_lsa_flush(index, area_id);
+                    }
+                }
             }
             Message::HelloTimer(index) => {
                 let Some(link) = self.links.get_mut(&index) else {


### PR DESCRIPTION
## Summary

Self-originated Network-LSAs could outlive the originator's DR role on the segment, polluting peers' LSDBs at the old DR address until natural MaxAge (~1 hour).

Two gaps fixed:

1. **v2 `Message::Disable` never flushed the Network-LSA.** v3's Disable already calls `network_lsa_flush` (inst.rs:2363); v2 didn't.
2. **Neither v2 nor v3 had an IFSM DR-leave hook.** The only existing flush path — `update_network_lsa_by_interface`'s `full_nbr_count == 0` branch — is itself gated by `if_state == IfsmState::DR` in `process_neighbor_state_change` (inst.rs:987), so once we're no longer DR, nothing fires.

This was visible in a real LSDB dump as an orphan Network-LSA `192.168.10.2` advertised by `10.0.0.2` at age 1491s, even though `10.0.0.2`'s current Router-LSA no longer had a Transit link referencing that pseudo-node.

## Fix

Maintains the invariant **"self-originated Network-LSA exists iff I am currently DR on the segment"**:

- New `Ospf<Ospfv2>::network_lsa_flush(ifindex, area_id)` mirroring v3's at inst.rs:2847. Premature-ages the LSA via `Lsdb::flush_lsa` and re-floods.
- v2 `Message::Disable` calls it before clearing area state (parity with v3 Disable).
- Both v2 and v3 `Message::Ifsm` snapshot pre-state, run `ospf_ifsm`, and if `prev == DR && new != DR` call `network_lsa_flush`.

The flush only retracts **our own** LSA. A stale Network-LSA advertised by a different router can only be aged out by that router (premature) or by MaxAge.

## Test plan

- [ ] Broadcast LAN, two zebra-rs routers, this side is DR. Change `network-type` to `point-to-point` on this side: the prior self-originated Network-LSA should appear at MaxAge in peers' LSDBs within seconds.
- [ ] DR election yield: bring up a third router with higher router-id; once the post-PR-#833 election promotes it to DR, this router's IFSM yields DR -> Backup, and our Network-LSA disappears from peers.
- [ ] Interface disable: `set router ospf area 0 interface <name> enable false` flushes both v2 and v3 Network-LSAs (v2 was the gap).
- [ ] No regression on normal operation: when we stay DR, the Network-LSA continues to refresh at LSRefreshTime as before.
- [ ] `cargo fmt --all --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)