### PR TITLE
ospf: flush v3 Network-ref Intra-Area-Prefix-LSA on DR-leave

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -2435,7 +2435,12 @@ impl Ospf<Ospfv3> {
             Message::Ifsm(index, ev) => {
                 // Same DR-leave hook as v2: premature-age the
                 // self-originated Network-LSA when the IFSM yields
-                // DR so the LSA doesn't outlive our DR role.
+                // DR so the LSA doesn't outlive our DR role. v3
+                // additionally flushes the Network-ref
+                // Intra-Area-Prefix-LSA (RFC 5340 §A.4.10 — only
+                // the DR originates it; on yield it would otherwise
+                // dangle referencing the now-MaxAged Network-LSA's
+                // (ls_id, adv_router) until natural MaxAge).
                 let prev = self.links.get(&index).map(|l| (l.state, l.area_id));
                 let Some(link) = self.links.get_mut(&index) else {
                     return;
@@ -2444,6 +2449,7 @@ impl Ospf<Ospfv3> {
                 if let Some((prev_state, area_id)) = prev {
                     let new_state = self.links.get(&index).map(|l| l.state);
                     if prev_state == IfsmState::DR && new_state != Some(IfsmState::DR) {
+                        self.network_intra_area_prefix_lsa_flush(index, area_id);
                         self.network_lsa_flush(index, area_id);
                     }
                 }


### PR DESCRIPTION
## Summary

Follow-up to PR #835. The new v3 IFSM DR-leave hook flushed the Network-LSA but not the Network-ref Intra-Area-Prefix-LSA. Per RFC 5340 §A.4.10 only the DR originates the Network-ref variant, so on DR-yield it would dangle referencing the now-MaxAged Network-LSA's `(ls_id, adv_router)` for ~1 hour until natural MaxAge.

v3's `Disable` handler already flushes both (inst.rs:2417-2418); the IFSM DR-leave hook now does the same so the network-type-change / interface-bounce path and the pure-election-yield path have identical cleanup semantics.

Functionally low impact — the dangling IAPLSA contributes nothing to SPF (back-link check fails once the Network-LSA is gone) — but LSDB cleanliness keeps the invariant honest.

## Test plan

- [ ] Two v3 routers on a broadcast LAN, this side is DR with at least one non-link-local IPv6 prefix configured. Bring up a third router with higher router-id; once the post-PR-#833 election promotes it to DR, this side yields DR -> Backup. Confirm both the Network-LSA *and* the Network-ref Intra-Area-Prefix-LSA disappear from peers' LSDBs (both at MaxAge in the flood).
- [ ] No regression: when we stay DR, both LSAs continue to refresh at LSRefreshTime.
- [ ] v2 unaffected (the v2 path has no Network-ref IAPLSA concept).
- [ ] `cargo fmt --all --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)