### PR TITLE
isis: drop unreachable sr-mpls-block config plumbing

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -91,10 +91,6 @@ impl Isis {
         self.callback_add("/router/isis/lsp-mtu-size", config_lsp_mtu_size);
         self.callback_add("/router/isis/te-router-id", config_te_router_id);
         self.callback_add("/router/isis/segment-routing/mpls", config_sr_mpls_enable);
-        self.callback_add(
-            "/router/isis/segment-routing/mpls/block",
-            config_sr_mpls_block,
-        );
         self.callback_add("/router/isis/segment-routing/srv6", config_sr_srv6_enable);
         self.callback_add(
             "/router/isis/segment-routing/srv6/locator",
@@ -309,22 +305,17 @@ pub struct IsisConfig {
     pub distribute: IsisDistribute,
 
     /// Set when /router/isis/segment-routing/mpls is committed (the
-    /// presence-marked YANG container), even if no `block` is selected.
-    /// Drives whether IS-IS originates SR-MPLS Capability sub-TLVs.
+    /// presence-marked YANG container). Drives whether IS-IS originates
+    /// SR-MPLS Capability sub-TLVs and subscribes to the canonical
+    /// "default" block under /segment-routing/block.
     pub sr_mpls_enabled: bool,
-
-    /// Optional name of a block defined under the global
-    /// /segment-routing/block list. The actual SRGB / SRLB values are
-    /// looked up by name from RIB::blocks; left as a string here so the
-    /// IS-IS config can be staged before the global block is committed.
-    pub sr_mpls_block: Option<String>,
 
     /// Set when /router/isis/segment-routing/srv6 is committed.
     pub sr_srv6_enabled: bool,
 
     /// Optional name of a locator defined under the global
-    /// /segment-routing/locator list. Same staging-friendly rationale
-    /// as sr_mpls_block.
+    /// /segment-routing/locator list. Held as a string so the IS-IS
+    /// config can be staged before the global locator is committed.
     pub sr_srv6_locator: Option<String>,
 
     /// Per-Flex-Algorithm SRv6 locator bindings, from the YANG list at
@@ -681,23 +672,11 @@ fn config_sr_mpls_enable(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<(
         }
     } else {
         isis.config.sr_mpls_enabled = false;
-        isis.config.sr_mpls_block = None;
         // Drop the pool. Any labels still cached on neighbor addr4
         // entries become orphaned but stop short of producing fresh
         // MPLS installs — `nbr_hello_interpret` and `lsp_generate`
         // both gate on `local_pool`/`value.label` being present.
         isis.local_pool = None;
-    }
-    isis.reconcile_block_watch();
-    Some(())
-}
-
-fn config_sr_mpls_block(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
-    if op.is_set() {
-        let name = args.string()?;
-        isis.config.sr_mpls_block = Some(name);
-    } else {
-        isis.config.sr_mpls_block = None;
     }
     isis.reconcile_block_watch();
     Some(())

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -183,9 +183,9 @@ pub struct Isis {
     /// the watched block / locator and any subsequent updates.
     pub sr_rx: UnboundedReceiver<RibSrRx>,
 
-    /// Currently-watched block name on the RIB side. Tracked separately
-    /// from sr_mpls_block so the reconcile helper can compute Watch /
-    /// Unwatch transitions correctly.
+    /// Currently-watched block name on the RIB side. Used by the
+    /// reconcile helper to compute Watch / Unwatch transitions when
+    /// `sr_mpls_enabled` toggles.
     pub watched_block: Option<String>,
     pub watched_locator: Option<String>,
 

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -71,18 +71,14 @@ use super::nfsm::NfsmState;
 
 /// Decide which block this IS-IS instance should subscribe to.
 ///
-/// `segment-routing mpls` enabled with no explicit `block` falls back to
-/// the canonical "default" block seeded by the RIB; an explicit name takes
-/// precedence. When SR-MPLS is disabled we want no subscription at all.
+/// `segment-routing mpls` enabled subscribes to the canonical "default"
+/// block seeded by the RIB. When SR-MPLS is disabled there is no
+/// subscription.
 pub(super) fn target_block_name(cfg: &IsisConfig) -> Option<String> {
     if !cfg.sr_mpls_enabled {
         return None;
     }
-    Some(
-        cfg.sr_mpls_block
-            .clone()
-            .unwrap_or_else(|| DEFAULT_BLOCK_NAME.to_string()),
-    )
+    Some(DEFAULT_BLOCK_NAME.to_string())
 }
 
 /// Decide which locator this IS-IS instance should subscribe to.
@@ -1524,9 +1520,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn target_block_falls_back_to_default_when_unset() {
-        // SR-MPLS enabled but no explicit block configured: should
-        // subscribe to the canonical "default" block.
+    fn target_block_is_default_when_enabled() {
+        // SR-MPLS enabled subscribes to the canonical "default" block.
         let cfg = IsisConfig {
             sr_mpls_enabled: true,
             ..Default::default()
@@ -1535,24 +1530,8 @@ mod tests {
     }
 
     #[test]
-    fn target_block_uses_explicit_name_when_set() {
-        let cfg = IsisConfig {
-            sr_mpls_enabled: true,
-            sr_mpls_block: Some("custom".into()),
-            ..Default::default()
-        };
-        assert_eq!(target_block_name(&cfg), Some("custom".to_string()));
-    }
-
-    #[test]
     fn target_block_returns_none_when_mpls_disabled() {
-        // The block name on its own should never produce a watch when
-        // SR-MPLS isn't enabled — otherwise we'd subscribe to stale
-        // config left behind after disabling the container.
-        let cfg = IsisConfig {
-            sr_mpls_block: Some("custom".into()),
-            ..Default::default()
-        };
+        let cfg = IsisConfig::default();
         assert_eq!(target_block_name(&cfg), None);
     }
 


### PR DESCRIPTION
## Summary

- The `/router/isis/segment-routing/mpls/block` config path was registered as a callback in `isis/config.rs` but never exposed in the YANG schema (`yang/config.yang` L516-519 has `container mpls { presence }` with no `block` leaf). Users could not reach the field via config commits; only in-tree tests exercised it.
- Removes `IsisConfig::sr_mpls_block`, the `config_sr_mpls_block` callback, the callback registration, and the now-stale tests. `target_block_name` unconditionally returns the canonical `"default"` block when SR-MPLS is enabled.
- Aligns the IS-IS Rust surface with the existing YANG shape (bare presence container, no block selector) ahead of mirroring the same shape into OSPFv2 / OSPFv3 SR-MPLS support.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p zebra-rs --bins isis::` — 94/94 passing
- [x] Updated `target_block_name` tests still cover the enabled/disabled transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)