### PR TITLE
ospf: realign v2 segment-routing knob to IS-IS shape

### DIFF
--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -62,7 +62,7 @@ impl Ospf {
             "/area/interface/prefix-sid/absolute",
             config_ospf_interface_prefix_sid_absolute,
         );
-        self.ospf_add("/segment-routing", config_ospf_segment_routing);
+        self.ospf_add("/segment-routing/mpls", config_ospf_sr_mpls);
         self.tracing_add("/fsm", config_tracing_fsm);
         self.tracing_add("/packet", config_tracing_packet);
     }
@@ -318,18 +318,13 @@ fn config_ospf_interface_prefix_sid_absolute(
     Some(())
 }
 
-fn config_ospf_segment_routing(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
-    let mode = args.string()?;
-
+fn config_ospf_sr_mpls(ospf: &mut Ospf, _args: Args, op: ConfigOp) -> Option<()> {
     use super::srmpls::SegmentRoutingMode;
-    if op.is_set() {
-        ospf.segment_routing = match mode.as_str() {
-            "mpls" => SegmentRoutingMode::Mpls,
-            _ => SegmentRoutingMode::None,
-        };
+    ospf.segment_routing = if op.is_set() {
+        SegmentRoutingMode::Mpls
     } else {
-        ospf.segment_routing = SegmentRoutingMode::None;
-    }
+        SegmentRoutingMode::None
+    };
 
     ospf.router_info_lsa_originate();
 

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -363,9 +363,13 @@ module config {
             }
           }
         }
-        leaf segment-routing {
-          type enumeration {
-            enum mpls;
+        container segment-routing {
+          // Mirrors `router isis / segment-routing` (config.yang L516).
+          // OSPFv2 carries SR over MPLS only — there is no OSPFv2 SRv6
+          // (OSPFv2 is IPv4-only on the wire); the SRv6 sibling lives
+          // under `router ospfv3 / segment-routing` instead.
+          container mpls {
+            presence "Enable Segment Routing over MPLS dataplane";
           }
         }
         container tracing {


### PR DESCRIPTION
## Summary

- Replace the OSPFv2 `leaf segment-routing { enum mpls; }` with the container shape used by IS-IS: `container segment-routing { container mpls { presence ... } }`. The on-the-wire CLI keyword is unchanged (`segment-routing mpls`); the YANG path is now `/router/ospf/segment-routing/mpls`.
- Rust callback (`ospf/config.rs`) moves from `/segment-routing` (value-parsing) to `/segment-routing/mpls` (presence). Drops the now-unused `args.string()` parse. Downstream Router-Info / Ext-Prefix LSA origination unchanged.
- OSPFv2 is IPv4-only on the wire so no `srv6` sibling. SRv6 lands under `router ospfv3 / segment-routing` later.

This is the first OSPFv2 step in the OSPF SR-MPLS effort. With this in place the OSPFv2 schema mirrors IS-IS (`config.yang` L516), and OSPFv3 SR-MPLS / SRv6 can mirror the same shape next.

**Breaking change:** the config path changes. Existing `segment-routing mpls` config must be re-entered after upgrade. The in-tree implementation is stub-only (originates LSAs but never reaches the RIB per the gap analysis), so no known production users.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p zebra-rs --bins` — 610/610 passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)