### PR TITLE
ospf: mirror v2 SR knobs onto OSPFv3 (schema + prefix-sid/sr-mpls)

### DIFF
--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -52,6 +52,15 @@ impl Ospf<Ospfv3> {
                 "/area/interface/mtu-ignore",
                 config_ospfv3_interface_mtu_ignore,
             ),
+            (
+                "/area/interface/prefix-sid/index",
+                config_ospfv3_interface_prefix_sid_index,
+            ),
+            (
+                "/area/interface/prefix-sid/absolute",
+                config_ospfv3_interface_prefix_sid_absolute,
+            ),
+            ("/segment-routing/mpls", config_ospfv3_sr_mpls),
         ];
         for (path, cb) in entries {
             self.callbacks.insert(format!("{}{}", prefix, path), *cb);
@@ -224,5 +233,62 @@ fn config_ospfv3_interface_mtu_ignore(
     let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
     link.config.mtu_ignore = op.is_set() && mtu_ignore;
 
+    Some(())
+}
+
+/// Record the per-interface Prefix-SID index. Mirrors v2's
+/// `config_ospf_interface_prefix_sid_index` but stops at storing the
+/// value in `link.config.prefix_sid` — v3 has no Extended Prefix
+/// Opaque LSA equivalent yet (RFC 8666 E-LSAs are not implemented),
+/// so there is no LSA to re-originate here.
+fn config_ospfv3_interface_prefix_sid_index(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let index = args.u32()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config.prefix_sid = Some(super::link::PrefixSid::Index(index));
+    } else {
+        link.config.prefix_sid = None;
+    }
+
+    Some(())
+}
+
+fn config_ospfv3_interface_prefix_sid_absolute(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let absolute = args.u32()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config.prefix_sid = Some(super::link::PrefixSid::Absolute(absolute));
+    } else {
+        link.config.prefix_sid = None;
+    }
+
+    Some(())
+}
+
+/// Toggle the v3 SR-MPLS enable bit. Mirrors v2's `config_ospf_sr_mpls`
+/// but stops at flipping `segment_routing` — v3 has no Router-Info /
+/// Extended-Prefix Opaque LSA origination yet, so there is nothing
+/// downstream to re-originate.
+fn config_ospfv3_sr_mpls(ospf: &mut Ospf<Ospfv3>, _args: Args, op: ConfigOp) -> Option<()> {
+    use super::srmpls::SegmentRoutingMode;
+    ospf.segment_routing = if op.is_set() {
+        SegmentRoutingMode::Mpls
+    } else {
+        SegmentRoutingMode::None
+    };
     Some(())
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -492,6 +492,35 @@ module config {
             leaf mtu-ignore {
               type boolean;
             }
+            container prefix-sid {
+              leaf index {
+                type uint32;
+              }
+              leaf absolute {
+                type uint32;
+              }
+            }
+          }
+        }
+        container segment-routing {
+          // Mirrors `router isis / segment-routing` (config.yang L516).
+          // OSPFv3 carries SR over both dataplanes: MPLS (RFC 8666 via
+          // E-LSAs) and SRv6 (RFC 9513). The `mpls` and `srv6` sibling
+          // containers match the IS-IS shape so operators see a uniform
+          // CLI surface across protocols.
+          container mpls {
+            presence "Enable Segment Routing over MPLS dataplane";
+          }
+          container srv6 {
+            presence "Enable Segment Routing over IPv6 dataplane";
+            leaf locator {
+              // Name of a locator defined under the global
+              // /segment-routing/locator list. Held as a string (not a
+              // leafref) so an OSPFv3 config can be staged before the
+              // global locator is committed — matches the IS-IS
+              // staging convention (config.yang L524).
+              type string;
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

- Brings the IS-IS-shaped `segment-routing` container to OSPFv3 and adds the per-interface `prefix-sid` container OSPFv3 was missing entirely. Closes the v2/v3 surface gap on the SR config side ahead of OSPFv3 SR LSA origination work.
- YANG: new per-interface `container prefix-sid { leaf index; leaf absolute; }` under `router ospfv3 / area / interface`, plus top-level `container segment-routing { container mpls; container srv6 { leaf locator; } }`. OSPFv3 carries SR over both MPLS (RFC 8666 via E-LSAs) and SRv6 (RFC 9513), so both siblings are present — matches IS-IS (`config.yang` L516).
- Rust: three callbacks registered in `config_v3.rs` for `/area/interface/prefix-sid/index`, `/area/interface/prefix-sid/absolute`, `/segment-routing/mpls`. Each writes the existing shared field on `LinkConfig` / `Ospf<V>` and stops there — v3 has no Router-Info / Extended-Prefix Opaque LSA equivalent yet (the gap analysis flagged the RFC 8666 E-LSA bodies are absent entirely from `Ospfv3LsBody`), so there is no downstream LSA to re-originate.

**Deferred:** `/segment-routing/srv6` and `.../locator` callbacks are intentionally not registered here. They need new fields on `Ospf<V>` (`sr_srv6_enabled`, `sr_srv6_locator`) and a watch into the global `/segment-routing/locator` list — a bigger structural change that belongs with the SRv6 LSA work. The YANG paths are accepted (stored in the datastore) but no Rust code consumes them yet.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p zebra-rs --bins` — 610/610 passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)