### PR TITLE
ospf: install self Prefix-SID pop entries on the local MPLS LFIB

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -4722,12 +4722,85 @@ fn build_ilm_from_rib(rib: &PrefixMap<Ipv4Net, SpfRoute>) -> BTreeMap<u32, SpfIl
     ilm
 }
 
+/// For every self-originated Extended-Prefix LSA in any area, emit
+/// an ILM entry that pops the local Prefix-SID label and delivers
+/// to the owning interface.
+///
+/// Needed because `srmpls.rs::ext_prefix_lsa_build` sets the NP
+/// (No-PHP) flag on Index-form Prefix-SIDs we originate. With NP=1
+/// the penultimate hop does not pop the label per RFC 8665 §5, so
+/// labeled packets reach the local kernel MPLS layer and require
+/// an explicit pop entry; without it the kernel drops them.
+///
+/// The emitted nexthop carries `adjacency: true` so `make_ilm_entry`
+/// builds an `IlmEntry` with no swap label — Via + Oif only. The
+/// kernel pops the label and forwards to the via address on the
+/// owning interface; since the via address is one of our own
+/// interface addresses, the inner packet is delivered locally.
+fn add_self_prefix_sids_to_ilm(top: &Ospf, ilm: &mut BTreeMap<u32, SpfIlm>) {
+    use super::srmpls::SRGB_START;
+    use crate::ospf::lsdb::OSPF_MAX_AGE;
+
+    for (area_id, area) in top.areas.iter() {
+        let area_id = *area_id;
+        for (_, lsa) in area.lsdb.iter_by_type(OspfLsType::OpaqueAreaLocal) {
+            if lsa.data.h.ls_age >= OSPF_MAX_AGE {
+                continue;
+            }
+            if lsa.data.h.adv_router != top.router_id {
+                continue;
+            }
+            let OspfLsp::OpaqueAreaExtPrefix(ref ep) = lsa.data.lsp else {
+                continue;
+            };
+            for tlv in &ep.tlvs {
+                let Some(link) = self_link_by_prefix(top, area_id, tlv.prefix) else {
+                    continue;
+                };
+                let Some(addr) = link.addr.first().map(|a| a.prefix.addr()) else {
+                    continue;
+                };
+                for sub in &tlv.subs {
+                    let ExtPrefixSubTlv::PrefixSid(ps) = sub else {
+                        continue;
+                    };
+                    let (label, pfx_index) = match ps.sid {
+                        SidLabelTlv::Label(v) => (v, v.saturating_sub(SRGB_START)),
+                        SidLabelTlv::Index(idx) => match SRGB_START.checked_add(idx) {
+                            Some(v) => (v, idx),
+                            None => continue,
+                        },
+                    };
+                    let mut nhops = BTreeMap::new();
+                    nhops.insert(
+                        addr,
+                        SpfNexthop {
+                            ifindex: link.index,
+                            adjacency: true,
+                            router_id: None,
+                        },
+                    );
+                    ilm.insert(
+                        label,
+                        SpfIlm {
+                            nhops,
+                            ilm_type: IlmType::Node(pfx_index),
+                        },
+                    );
+                    break;
+                }
+            }
+        }
+    }
+}
+
 /// Apply routing updates to RIB subsystem
 fn apply_routing_updates(top: &mut Ospf, rib: PrefixMap<Ipv4Net, SpfRoute>) {
     // Build the SR-MPLS LFIB from labeled routes in the freshly
     // computed RIB, then diff against the previous snapshot so the
     // RIB subsystem sees only the IlmAdd / IlmDel deltas.
-    let ilm = build_ilm_from_rib(&rib);
+    let mut ilm = build_ilm_from_rib(&rib);
+    add_self_prefix_sids_to_ilm(top, &mut ilm);
     let ilm_diff = spf::table_diff(top.ilm.iter(), ilm.iter());
     diff_ilm_apply(&top.ctx.rib, &ilm_diff);
     top.ilm = ilm;

--- a/zebra-rs/src/ospf/srmpls.rs
+++ b/zebra-rs/src/ospf/srmpls.rs
@@ -13,7 +13,7 @@ pub enum SegmentRoutingMode {
 }
 
 /// Default SRGB (Segment Routing Global Block).
-const SRGB_START: u32 = 16000;
+pub(super) const SRGB_START: u32 = 16000;
 const SRGB_RANGE: u32 = 2001;
 
 /// Default SRLB (Segment Routing Local Block).


### PR DESCRIPTION
## Summary

Closes a real correctness gap left over from #842. Phase A2 wired the transit/egress side of SR-MPLS but explicitly skipped self-originated Extended-Prefix LSAs to avoid producing nonsensical state (label push onto a directly-attached loopback route, swap-to-same-label ILM against our own /32). That left the local kernel MPLS layer without a matching ILM for our own Prefix-SID, **and** because \`srmpls::ext_prefix_lsa_build\` sets the **NP (No-PHP) flag** on Index-form Prefix-SIDs we originate, RFC 8665 §5 says the penultimate hop MUST NOT pop the label — so labeled traffic actually reaches us and gets dropped today.

Fix it with a dedicated pass:

- **\`add_self_prefix_sids_to_ilm\`** walks every area's LSDB, picks out self-originated Extended-Prefix LSAs, resolves each Index-form SID to an absolute label against the local SRGB (\`srmpls::SRGB_START\`), and looks up the owning local link via \`self_link_by_prefix\`.
- For each match it inserts an \`SpfIlm\` with a single nexthop keyed by the link's own address, \`adjacency: true\`, and the link's ifindex. The \`adjacency\` flag is what causes \`make_ilm_entry\` to omit the swap label, so the resulting \`IlmEntry\` translates to \`Via(local_addr) + Oif(local_ifindex)\` with no \`NewDestination\` — i.e. a pop, with the inner packet forwarded to one of our own addresses on the owning interface and delivered locally.
- \`apply_routing_updates\` calls the helper right after \`build_ilm_from_rib\` so the diff machinery picks up adds and deletes uniformly when the LSA appears / ages out.

\`SRGB_START\` is exported as \`pub(super)\` to keep the resolution honest while the SRGB stays hardcoded; the lookup will move to \`Lsdb::label_map[self.router_id]\` once SRGB becomes configurable (planned for Phase E).

## Test plan

- [x] \`cargo build\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p zebra-rs --bins\` — 610/610 passing
- [ ] Manual two-router topology: with \`segment-routing mpls\` on both and \`prefix-sid index N\` on each loopback, send a labeled packet from peer to our SID and confirm \`ip -M route\` shows the pop entry and a ping reaches the loopback

🤖 Generated with [Claude Code](https://claude.com/claude-code)