### PR TITLE
ospf-packet: serialize Extended-Link Opaque LSAs

### DIFF
--- a/crates/ospf-packet/src/parser.rs
+++ b/crates/ospf-packet/src/parser.rs
@@ -386,8 +386,10 @@ impl OspfLsa {
         Self { h, lsp }
     }
 
-    /// Emit the LSA payload to a buffer.
-    fn emit_lsp(&self, buf: &mut BytesMut) {
+    /// Emit the LSA payload (body only) to a buffer. Public so tests
+    /// can round-trip a constructed LSA without depending on the
+    /// crate-private `Emit` trait.
+    pub fn emit_lsp(&self, buf: &mut BytesMut) {
         match &self.lsp {
             OspfLsp::Router(lsp) => lsp.emit(buf),
             OspfLsp::Network(lsp) => lsp.emit(buf),
@@ -396,7 +398,7 @@ impl OspfLsa {
             OspfLsp::NssaAsExternal(lsp) => lsp.emit(buf),
             OspfLsp::OpaqueAreaRouterInfo(lsp) => lsp.emit(buf),
             OspfLsp::OpaqueAreaExtPrefix(lsp) => lsp.emit(buf),
-            OspfLsp::OpaqueAreaExtLink(_) => {}
+            OspfLsp::OpaqueAreaExtLink(lsp) => lsp.emit(buf),
             OspfLsp::Unknown(lsp) => lsp.emit(buf),
         }
     }
@@ -429,7 +431,7 @@ impl OspfLsa {
             OspfLsp::NssaAsExternal(lsp) => lsp.lsa_len(),
             OspfLsp::OpaqueAreaRouterInfo(lsp) => lsp.lsa_len(),
             OspfLsp::OpaqueAreaExtPrefix(lsp) => lsp.lsa_len(),
-            OspfLsp::OpaqueAreaExtLink(_) => 0,
+            OspfLsp::OpaqueAreaExtLink(lsp) => lsp.lsa_len(),
             OspfLsp::Unknown(lsp) => lsp.lsa_len(),
         };
         let length = lsp_len + LSA_HEADER_LEN;
@@ -1444,6 +1446,138 @@ impl ExtPrefixSidSubTlv {
         buf.put_u8(0); // reserved
         buf.put_u8(self.mt_id);
         buf.put_u8(self.algo.into());
+        match &self.sid {
+            SidLabelTlv::Label(v) => buf.put(&packet_utils::u32_u8_3(*v)[..]),
+            SidLabelTlv::Index(v) => buf.put_u32(*v),
+        }
+    }
+}
+
+// ExtLinkLsa / ExtLinkTlv / ExtLinkSubTlv / AdjSidSubTlv / LanAdjSidSubTlv
+// emit + wire-length impls. Parallel to the ExtPrefix* family above; without
+// these the top-level `Lsa::emit_lsp` / `Lsa::update` dispatchers serialize
+// an empty body for `OpaqueAreaExtLink`, so any RFC 8665 Adj-SID
+// origination would go on the wire with a zero-length payload.
+
+impl ExtLinkLsa {
+    pub fn lsa_len(&self) -> u16 {
+        self.tlvs.iter().map(|tlv| tlv.wire_len()).sum()
+    }
+
+    pub fn emit(&self, buf: &mut BytesMut) {
+        for tlv in &self.tlvs {
+            tlv.emit(buf);
+        }
+    }
+}
+
+impl ExtLinkTlv {
+    /// Total wire length including the 4-byte TLV header.
+    fn wire_len(&self) -> u16 {
+        let len = self.value_len();
+        4 + ((len + 3) & !3)
+    }
+
+    fn value_len(&self) -> u16 {
+        // link_type(1) + reserved(3) + link_id(4) + link_data(4) = 12
+        let sub_len: u16 = self.subs.iter().map(|s| s.wire_len()).sum();
+        12 + sub_len
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        let len = self.value_len();
+        buf.put_u16(1); // Extended Link TLV type.
+        buf.put_u16(len);
+        buf.put_u8(self.link_type);
+        // 3 reserved bytes.
+        buf.put_u8(0);
+        buf.put_u16(0);
+        buf.put(&self.link_id.octets()[..]);
+        buf.put(&self.link_data.octets()[..]);
+
+        for sub in &self.subs {
+            sub.emit(buf);
+        }
+
+        // Pad TLV value to 4-byte alignment.
+        let pad = ((len as usize + 3) & !3) - len as usize;
+        for _ in 0..pad {
+            buf.put_u8(0);
+        }
+    }
+}
+
+impl ExtLinkSubTlv {
+    fn wire_len(&self) -> u16 {
+        let len = self.value_len();
+        4 + ((len + 3) & !3)
+    }
+
+    fn value_len(&self) -> u16 {
+        match self {
+            ExtLinkSubTlv::AdjSid(s) => s.value_len(),
+            ExtLinkSubTlv::LanAdjSid(s) => s.value_len(),
+            ExtLinkSubTlv::Unknown(u) => u.len,
+        }
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        let (typ, len) = match self {
+            ExtLinkSubTlv::AdjSid(_) => (2u16, self.value_len()),
+            ExtLinkSubTlv::LanAdjSid(_) => (3u16, self.value_len()),
+            ExtLinkSubTlv::Unknown(u) => (u.typ, u.len),
+        };
+        buf.put_u16(typ);
+        buf.put_u16(len);
+        match self {
+            ExtLinkSubTlv::AdjSid(s) => s.emit(buf),
+            ExtLinkSubTlv::LanAdjSid(s) => s.emit(buf),
+            ExtLinkSubTlv::Unknown(u) => buf.put(&u.values[..]),
+        }
+        // Pad to 4-byte alignment.
+        let pad = ((len as usize + 3) & !3) - len as usize;
+        for _ in 0..pad {
+            buf.put_u8(0);
+        }
+    }
+}
+
+impl AdjSidSubTlv {
+    fn value_len(&self) -> u16 {
+        // flags(1) + reserved(1) + mt_id(1) + weight(1) + sid(3 or 4)
+        4 + match &self.sid {
+            SidLabelTlv::Label(_) => 3,
+            SidLabelTlv::Index(_) => 4,
+        }
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(self.flags.into());
+        buf.put_u8(0); // reserved
+        buf.put_u8(self.mt_id);
+        buf.put_u8(self.weight);
+        match &self.sid {
+            SidLabelTlv::Label(v) => buf.put(&packet_utils::u32_u8_3(*v)[..]),
+            SidLabelTlv::Index(v) => buf.put_u32(*v),
+        }
+    }
+}
+
+impl LanAdjSidSubTlv {
+    fn value_len(&self) -> u16 {
+        // flags(1) + reserved(1) + mt_id(1) + weight(1) + neighbor_id(4) + sid(3 or 4)
+        8 + match &self.sid {
+            SidLabelTlv::Label(_) => 3,
+            SidLabelTlv::Index(_) => 4,
+        }
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(self.flags.into());
+        buf.put_u8(0); // reserved
+        buf.put_u8(self.mt_id);
+        buf.put_u8(self.weight);
+        buf.put(&self.neighbor_id.octets()[..]);
         match &self.sid {
             SidLabelTlv::Label(v) => buf.put(&packet_utils::u32_u8_3(*v)[..]),
             SidLabelTlv::Index(v) => buf.put_u32(*v),

--- a/crates/ospf-packet/tests/ospfv2.rs
+++ b/crates/ospf-packet/tests/ospfv2.rs
@@ -2,6 +2,7 @@ use bytes::BytesMut;
 use hex_literal::hex;
 use nom_derive::Parse;
 use ospf_packet::*;
+use std::net::Ipv4Addr;
 
 fn parse_emit(buf: &[u8]) {
     let packet = parse(buf);
@@ -252,4 +253,78 @@ pub fn parse_unknown2() {
     assert!(rem.is_empty());
     println!("{:?}", packet);
     println!("rem len: {:?}", rem.len());
+}
+
+/// Build an Extended-Link Opaque LSA carrying both an Adj-SID and a
+/// LAN-Adj-SID sub-TLV (RFC 7684 §3, RFC 8665 §5/§6), emit it through
+/// the top-level `OspfLsa::emit` dispatch, parse the bytes back, and
+/// assert structural equality. Guards against regression on the
+/// emit/lsa_len plumbing that was previously stubbed out.
+#[test]
+pub fn ext_link_lsa_round_trip() {
+    let adj_sid = ExtLinkSubTlv::AdjSid(AdjSidSubTlv {
+        flags: AdjSidFlags::new().with_v_flag(true).with_l_flag(true),
+        mt_id: 0,
+        weight: 0,
+        sid: SidLabelTlv::Label(24001),
+    });
+    let lan_adj_sid = ExtLinkSubTlv::LanAdjSid(LanAdjSidSubTlv {
+        flags: AdjSidFlags::new().with_v_flag(true).with_l_flag(true),
+        mt_id: 0,
+        weight: 0,
+        neighbor_id: Ipv4Addr::new(10, 0, 0, 2),
+        sid: SidLabelTlv::Label(24002),
+    });
+    let tlv = ExtLinkTlv {
+        link_type: 1, // P2P
+        link_id: Ipv4Addr::new(10, 0, 0, 2),
+        link_data: Ipv4Addr::new(192, 168, 1, 1),
+        subs: vec![adj_sid, lan_adj_sid],
+    };
+    let body = ExtLinkLsa { tlvs: vec![tlv] };
+
+    // OpaqueLsaType::EXT_LINK = 8; place in the top byte of ls_id.
+    let ls_id = Ipv4Addr::from((OpaqueLsaType::EXT_LINK as u32) << 24);
+    let mut h = OspfLsaHeader::new(
+        OspfLsType::OpaqueAreaLocal,
+        ls_id,
+        Ipv4Addr::new(10, 0, 0, 1),
+    );
+    h.options = 0x42;
+    let mut lsa = OspfLsa::from(h, OspfLsp::OpaqueAreaExtLink(body));
+    lsa.update();
+
+    assert!(lsa.h.length > 20, "header length must include body");
+    assert!(
+        lsa.verify_checksum(),
+        "Fletcher checksum must verify on the emitter's own output"
+    );
+
+    let mut buf = BytesMut::new();
+    lsa.h.emit(&mut buf);
+    lsa.emit_lsp(&mut buf);
+    assert_eq!(buf.len(), lsa.h.length as usize);
+
+    let (rem, parsed) = OspfLsa::parse_be(&buf).expect("parse should succeed");
+    assert!(rem.is_empty(), "trailing bytes after Ext-Link LSA");
+    let OspfLsp::OpaqueAreaExtLink(ref parsed_body) = parsed.lsp else {
+        panic!("expected OpaqueAreaExtLink, got {:?}", parsed.lsp);
+    };
+    assert_eq!(parsed_body.tlvs.len(), 1);
+    let parsed_tlv = &parsed_body.tlvs[0];
+    assert_eq!(parsed_tlv.link_type, 1);
+    assert_eq!(parsed_tlv.link_id, Ipv4Addr::new(10, 0, 0, 2));
+    assert_eq!(parsed_tlv.link_data, Ipv4Addr::new(192, 168, 1, 1));
+    assert_eq!(parsed_tlv.subs.len(), 2);
+    match &parsed_tlv.subs[0] {
+        ExtLinkSubTlv::AdjSid(s) => assert!(matches!(s.sid, SidLabelTlv::Label(24001))),
+        other => panic!("expected AdjSid, got {:?}", other),
+    }
+    match &parsed_tlv.subs[1] {
+        ExtLinkSubTlv::LanAdjSid(s) => {
+            assert_eq!(s.neighbor_id, Ipv4Addr::new(10, 0, 0, 2));
+            assert!(matches!(s.sid, SidLabelTlv::Label(24002)));
+        }
+        other => panic!("expected LanAdjSid, got {:?}", other),
+    }
 }


### PR DESCRIPTION
## Summary

Prerequisite for Phase B (Adjacency-SID origination). The OSPFv2 Extended-Link Opaque LSA body (RFC 7684 §3, RFC 8665 §5/§6) **parsed** correctly but did not **serialize**: \`OspfLsa::emit_lsp\` had an empty arm for \`OpaqueAreaExtLink\` and \`OspfLsa::update\` returned a length of zero. Any LSA built with \`OspfLsp::OpaqueAreaExtLink(...)\` went on the wire as a bare 20-byte header — silently dropping every Adj-SID and LAN-Adj-SID sub-TLV.

Add the missing emit + length plumbing parallel to the existing \`ExtPrefix*\` family:

- **\`AdjSidSubTlv\` / \`LanAdjSidSubTlv\`** — \`value_len\` + \`emit\`. Layout matches the parsers (flags / reserved / mt_id / weight, then \`neighbor_id\` for the LAN variant, then a 3-octet Label or 4-octet Index SID per RFC 8665).
- **\`ExtLinkSubTlv\` enum** — dispatch wrapper that prepends the sub-TLV type + length header, calls into the matching variant, and pads to 4-byte alignment. Unknown sub-TLVs round-trip via the existing \`RouterInfoTlvUnknown\` carrier.
- **\`ExtLinkTlv\`** — 12-byte fixed header (link_type + 3 reserved + link_id + link_data) followed by the sub-TLV stream, with standard TLV header + 4-byte alignment.
- **\`ExtLinkLsa\`** — walks the contained \`ExtLinkTlv\`s.

Wire the new methods into \`OspfLsa::emit_lsp\` and \`OspfLsa::update\`, replacing the \`_ => {}\` / \`_ => 0\` stubs.

\`OspfLsa::emit_lsp\` becomes \`pub\` so the new integration test (\`ext_link_lsa_round_trip\`) can build a representative LSA with both Adj-SID and LAN-Adj-SID sub-TLVs, emit it through the same dispatch the wire path uses, parse the bytes back, and assert structural equality plus a verified Fletcher checksum.

## Test plan

- [x] \`cargo build\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p zebra-rs --bins\` — 610/610 passing
- [x] \`cargo test -p ospf-packet\` — 34 unit + 13 integration tests passing including the new \`ext_link_lsa_round_trip\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)