### PR TITLE
ospf: add adjacency-sid YANG schema + storage

### DIFF
--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -62,6 +62,14 @@ impl Ospf {
             "/area/interface/prefix-sid/absolute",
             config_ospf_interface_prefix_sid_absolute,
         );
+        self.ospf_add(
+            "/area/interface/adjacency-sid/index",
+            config_ospf_interface_adjacency_sid_index,
+        );
+        self.ospf_add(
+            "/area/interface/adjacency-sid/absolute",
+            config_ospf_interface_adjacency_sid_absolute,
+        );
         self.ospf_add("/segment-routing/mpls", config_ospf_sr_mpls);
         self.tracing_add("/fsm", config_tracing_fsm);
         self.tracing_add("/packet", config_tracing_packet);
@@ -314,6 +322,48 @@ fn config_ospf_interface_prefix_sid_absolute(
     let ifindex = link.index;
 
     ospf.ext_prefix_lsa_originate(ifindex);
+
+    Some(())
+}
+
+/// Store the Index-form Adjacency-SID for this interface. No
+/// origination here -- Extended-Link LSA emission lands in a
+/// follow-up PR; this callback is storage-only so a YANG commit
+/// validates and persists the value into `LinkConfig`.
+fn config_ospf_interface_adjacency_sid_index(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let index = args.u32()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config.adjacency_sid = Some(super::link::AdjacencySid::Index(index));
+    } else {
+        link.config.adjacency_sid = None;
+    }
+
+    Some(())
+}
+
+fn config_ospf_interface_adjacency_sid_absolute(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let absolute = args.u32()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config.adjacency_sid = Some(super::link::AdjacencySid::Absolute(absolute));
+    } else {
+        link.config.adjacency_sid = None;
+    }
 
     Some(())
 }

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -60,6 +60,14 @@ impl Ospf<Ospfv3> {
                 "/area/interface/prefix-sid/absolute",
                 config_ospfv3_interface_prefix_sid_absolute,
             ),
+            (
+                "/area/interface/adjacency-sid/index",
+                config_ospfv3_interface_adjacency_sid_index,
+            ),
+            (
+                "/area/interface/adjacency-sid/absolute",
+                config_ospfv3_interface_adjacency_sid_absolute,
+            ),
             ("/segment-routing/mpls", config_ospfv3_sr_mpls),
         ];
         for (path, cb) in entries {
@@ -274,6 +282,47 @@ fn config_ospfv3_interface_prefix_sid_absolute(
         link.config.prefix_sid = Some(super::link::PrefixSid::Absolute(absolute));
     } else {
         link.config.prefix_sid = None;
+    }
+
+    Some(())
+}
+
+/// Storage-only Adjacency-SID config callbacks. Mirror the v2
+/// pair above; LSA origination lands once OSPFv3 grows its
+/// Extended-Link Opaque-LSA equivalent (RFC 8666 E-LSA work).
+fn config_ospfv3_interface_adjacency_sid_index(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let index = args.u32()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config.adjacency_sid = Some(super::link::AdjacencySid::Index(index));
+    } else {
+        link.config.adjacency_sid = None;
+    }
+
+    Some(())
+}
+
+fn config_ospfv3_interface_adjacency_sid_absolute(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let absolute = args.u32()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config.adjacency_sid = Some(super::link::AdjacencySid::Absolute(absolute));
+    } else {
+        link.config.adjacency_sid = None;
     }
 
     Some(())

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -74,11 +74,24 @@ pub struct LinkConfig {
     pub transmit_delay: Option<u16>,
     pub mtu_ignore: bool,
     pub prefix_sid: Option<PrefixSid>,
+    pub adjacency_sid: Option<AdjacencySid>,
     pub network_type: Option<OspfNetworkType>,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub enum PrefixSid {
+    Index(u32),
+    Absolute(u32),
+}
+
+/// Per-link Adjacency-SID (RFC 8665 §6). Stored verbatim from
+/// the YANG `adjacency-sid` container; origination picks the wire
+/// encoding (Index vs. Label sub-TLV) from whichever variant is set.
+/// Kept distinct from `PrefixSid` because Adj-SIDs grow flags/weight
+/// once Phase B origination lands, while Prefix-SIDs do not.
+#[allow(dead_code)] // value read once Phase B origination lands.
+#[derive(Debug, Clone, Copy)]
+pub enum AdjacencySid {
     Index(u32),
     Absolute(u32),
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -361,6 +361,19 @@ module config {
                 type uint32;
               }
             }
+            container adjacency-sid {
+              // Per-link Adjacency-SID (RFC 8665 §6). Originated in
+              // the Extended-Link Opaque LSA (type 10 / opaque-type 8)
+              // as an AdjSid sub-TLV. Either form is allowed; the
+              // origination side picks the wire encoding from whichever
+              // leaf is set.
+              leaf index {
+                type uint32;
+              }
+              leaf absolute {
+                type uint32;
+              }
+            }
           }
         }
         container segment-routing {
@@ -493,6 +506,18 @@ module config {
               type boolean;
             }
             container prefix-sid {
+              leaf index {
+                type uint32;
+              }
+              leaf absolute {
+                type uint32;
+              }
+            }
+            container adjacency-sid {
+              // Per-link Adjacency-SID. OSPFv3 SR-MPLS carries it in
+              // the RFC 8666 Extended-Link LSA; storage-only here.
+              // Either form is allowed; the origination side picks
+              // the wire encoding from whichever leaf is set.
               leaf index {
                 type uint32;
               }


### PR DESCRIPTION
## Summary

Phase B PR2. Adds the per-interface Adjacency-SID config knob under both OSPFv2 and OSPFv3, mirroring the prefix-sid container shape introduced in #840:

\`\`\`
container adjacency-sid {
  leaf index    { type uint32; }
  leaf absolute { type uint32; }
}
\`\`\`

- **YANG** (\`config.yang\`): identical containers under \`router ospf / area / interface\` and \`router ospfv3 / area / interface\`.
- **\`LinkConfig\`** grows \`adjacency_sid: Option<AdjacencySid>\`. The new enum lives alongside \`PrefixSid\` in \`link.rs\` and intentionally keeps its own type: Adj-SIDs grow flags/weight fields once Phase B origination lands (RFC 8665 §5 AdjSidFlags + weight), while Prefix-SIDs do not. Carries \`#[allow(dead_code)]\` so clippy stays clean while the inner u32 is only written; the allow comes off when PR3 reads it during Extended-Link LSA origination.
- **Four new config callbacks** — v2 in \`config.rs\`, v3 in \`config_v3.rs\` — store the value verbatim and do nothing else.

No LSA origination, no NFSM trigger, no consumption. That keeps this PR strictly schema + storage so the YANG validates and commits a value without changing any wire behavior. PR3 wires the originator on top of #844's emit plumbing; PR4 wires consumption and ILM install.

## Test plan

- [x] \`cargo build\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p zebra-rs --bins\` — 610/610 passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)