### PR TITLE
ospf: originate Extended-Link Opaque LSAs for v2 Adjacency-SIDs

### DIFF
--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -326,10 +326,10 @@ fn config_ospf_interface_prefix_sid_absolute(
     Some(())
 }
 
-/// Store the Index-form Adjacency-SID for this interface. No
-/// origination here -- Extended-Link LSA emission lands in a
-/// follow-up PR; this callback is storage-only so a YANG commit
-/// validates and persists the value into `LinkConfig`.
+/// Store the Index-form Adjacency-SID for this interface and re-
+/// originate the per-link Extended-Link Opaque LSA. The originator
+/// gates on SR-MPLS enabled + a Full neighbor on a P2P link, so the
+/// LSA is flushed automatically if any precondition is unmet.
 fn config_ospf_interface_adjacency_sid_index(
     ospf: &mut Ospf,
     mut args: Args,
@@ -345,6 +345,9 @@ fn config_ospf_interface_adjacency_sid_index(
     } else {
         link.config.adjacency_sid = None;
     }
+    let ifindex = link.index;
+
+    ospf.ext_link_lsa_originate(ifindex);
 
     Some(())
 }
@@ -364,6 +367,9 @@ fn config_ospf_interface_adjacency_sid_absolute(
     } else {
         link.config.adjacency_sid = None;
     }
+    let ifindex = link.index;
+
+    ospf.ext_link_lsa_originate(ifindex);
 
     Some(())
 }
@@ -387,6 +393,17 @@ fn config_ospf_sr_mpls(ospf: &mut Ospf, _args: Args, op: ConfigOp) -> Option<()>
         .collect();
     for ifindex in ifindexes {
         ospf.ext_prefix_lsa_originate(ifindex);
+    }
+
+    // Same for Extended Link LSAs (Adj-SID).
+    let ifindexes: Vec<u32> = ospf
+        .links
+        .iter()
+        .filter(|(_, link)| link.config.adjacency_sid.is_some())
+        .map(|(ifindex, _)| *ifindex)
+        .collect();
+    for ifindex in ifindexes {
+        ospf.ext_link_lsa_originate(ifindex);
     }
 
     Some(())

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -605,6 +605,89 @@ impl Ospf<Ospfv2> {
         }
     }
 
+    /// Originate (or flush) the Extended-Link Opaque LSA for `ifindex`.
+    ///
+    /// Originates when:
+    ///   * SR-MPLS is enabled (`segment_routing == Mpls`)
+    ///   * the link is enabled and has an `adjacency_sid` configured
+    ///   * the link is point-to-point with at least one Full neighbor
+    ///
+    /// Flushes (MaxAge) otherwise. Broadcast / NBMA support requires
+    /// LAN-Adj-SID (RFC 8665 §6) and is deferred to a follow-up.
+    ///
+    /// The opaque-id is derived from the ifindex (same convention as
+    /// `ext_prefix_lsa_originate`) so the per-link LSA gets a stable
+    /// `ls_id` across re-originations.
+    pub fn ext_link_lsa_originate(&mut self, ifindex: u32) {
+        use super::link::OspfNetworkType;
+        use super::srmpls::SegmentRoutingMode;
+
+        let opaque_id = ifindex & 0x00FF_FFFF;
+        let ls_id = Ipv4Addr::from(((OpaqueLsaType::EXT_LINK as u32) << 24) | opaque_id);
+
+        let link = self.links.get(&ifindex);
+        let should_originate = self.segment_routing == SegmentRoutingMode::Mpls
+            && link.is_some_and(|l| {
+                l.enabled
+                    && l.config.adjacency_sid.is_some()
+                    && l.network_type == OspfNetworkType::PointToPoint
+                    && l.nbrs.values().any(|nbr| nbr.state == NfsmState::Full)
+            });
+
+        if should_originate {
+            let link = link.unwrap();
+            let adjacency_sid = link.config.adjacency_sid.unwrap();
+            let Some(addr) = link.addr.iter().find(|a| !a.prefix.addr().is_loopback()) else {
+                return;
+            };
+            let Some(nbr) = link.nbrs.values().find(|n| n.state == NfsmState::Full) else {
+                return;
+            };
+
+            let mut lsa = super::srmpls::ext_link_lsa_build(
+                self.router_id,
+                1, // P2P -- matches RouterLsaLinkType encoding.
+                nbr.ident.router_id,
+                addr.prefix.addr(),
+                &adjacency_sid,
+                opaque_id,
+            );
+
+            if let Some(area) = self.areas.get(AREA0)
+                && let Some(existing) =
+                    area.lsdb
+                        .lookup_by_id(OspfLsType::OpaqueAreaLocal, ls_id, self.router_id)
+            {
+                lsa.h.ls_seq_number = lsa
+                    .h
+                    .ls_seq_number
+                    .max(existing.h.ls_seq_number.saturating_add(1));
+            }
+            lsa.update();
+
+            let flood_lsa = lsa.clone();
+            if let Some(area) = self.areas.get_mut(AREA0) {
+                area.lsdb.insert_self_originated(lsa, &self.tx, Some(AREA0));
+            }
+            self.flood_self_originated_lsa(AREA0, &flood_lsa);
+        } else {
+            let flushed = if let Some(area) = self.areas.get_mut(AREA0) {
+                area.lsdb.flush_lsa(
+                    OspfLsType::OpaqueAreaLocal,
+                    ls_id,
+                    self.router_id,
+                    &self.tx,
+                    Some(AREA0),
+                )
+            } else {
+                None
+            };
+            if let Some(lsa) = flushed {
+                self.flood_self_originated_lsa(AREA0, &lsa);
+            }
+        }
+    }
+
     pub fn ext_prefix_lsa_originate(&mut self, ifindex: u32) {
         use super::srmpls::SegmentRoutingMode;
 
@@ -1055,6 +1138,11 @@ impl Ospf<Ospfv2> {
         if if_state == IfsmState::DR {
             self.update_network_lsa_by_interface(ifindex);
         }
+
+        // Extended-Link Opaque LSA tracks the per-link Adj-SID, which
+        // is only meaningful while the link has a Full neighbor.
+        // `ext_link_lsa_originate` flushes when no Full neighbor remains.
+        self.ext_link_lsa_originate(ifindex);
     }
 
     /// Check if we are currently the DR for the network identified by ls_id.

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -88,8 +88,7 @@ pub enum PrefixSid {
 /// the YANG `adjacency-sid` container; origination picks the wire
 /// encoding (Index vs. Label sub-TLV) from whichever variant is set.
 /// Kept distinct from `PrefixSid` because Adj-SIDs grow flags/weight
-/// once Phase B origination lands, while Prefix-SIDs do not.
-#[allow(dead_code)] // value read once Phase B origination lands.
+/// once Phase B consumption lands, while Prefix-SIDs do not.
 #[derive(Debug, Clone, Copy)]
 pub enum AdjacencySid {
     Index(u32),

--- a/zebra-rs/src/ospf/srmpls.rs
+++ b/zebra-rs/src/ospf/srmpls.rs
@@ -3,7 +3,7 @@ use std::net::Ipv4Addr;
 use ipnet::Ipv4Net;
 use ospf_packet::*;
 
-use super::link::PrefixSid;
+use super::link::{AdjacencySid, PrefixSid};
 
 #[derive(Debug, Default, PartialEq, Clone, Copy)]
 pub enum SegmentRoutingMode {
@@ -99,6 +99,59 @@ pub fn ext_prefix_lsa_build(
     lsah.options = 0x42; // O-bit + E-bit.
 
     let mut lsa = OspfLsa::from(lsah, OspfLsp::OpaqueAreaExtPrefix(ep_lsa));
+    lsa.update();
+    lsa
+}
+
+/// Build an Extended Link Opaque LSA (RFC 7684 §3 + RFC 8665 §5)
+/// for a single link, carrying one Adjacency-SID sub-TLV.
+///
+/// `link_type` matches the OSPFv2 Router-LSA link_type encoding (1 =
+/// P2P, 2 = Transit broadcast/NBMA, 4 = Virtual). PR3 only originates
+/// for P2P links; broadcast / NBMA support arrives with LAN-Adj-SID.
+///
+/// Flag semantics mirror the Prefix-SID build: an Index-form SID
+/// carries no value/local flags (the index is resolved against the
+/// peer's SRGB); an Absolute Label SID sets V (Value) + L (Local) to
+/// indicate a raw label per RFC 8665 §5.
+pub fn ext_link_lsa_build(
+    router_id: Ipv4Addr,
+    link_type: u8,
+    link_id: Ipv4Addr,
+    link_data: Ipv4Addr,
+    adjacency_sid: &AdjacencySid,
+    opaque_id: u32,
+) -> OspfLsa {
+    let (sid, flags) = match adjacency_sid {
+        AdjacencySid::Index(idx) => (SidLabelTlv::Index(*idx), AdjSidFlags::new()),
+        AdjacencySid::Absolute(label) => (
+            SidLabelTlv::Label(*label),
+            AdjSidFlags::new().with_v_flag(true).with_l_flag(true),
+        ),
+    };
+
+    let adj_sub = AdjSidSubTlv {
+        flags,
+        mt_id: 0,
+        weight: 0,
+        sid,
+    };
+
+    let tlv = ExtLinkTlv {
+        link_type,
+        link_id,
+        link_data,
+        subs: vec![ExtLinkSubTlv::AdjSid(adj_sub)],
+    };
+
+    let el_lsa = ExtLinkLsa { tlvs: vec![tlv] };
+
+    let ls_id =
+        Ipv4Addr::from(((OpaqueLsaType::EXT_LINK as u32) << 24) | (opaque_id & 0x00FF_FFFF));
+    let mut lsah = OspfLsaHeader::new(OspfLsType::OpaqueAreaLocal, ls_id, router_id);
+    lsah.options = 0x42; // O-bit + E-bit.
+
+    let mut lsa = OspfLsa::from(lsah, OspfLsp::OpaqueAreaExtLink(el_lsa));
     lsa.update();
     lsa
 }


### PR DESCRIPTION
## Summary

Phase B PR3. Wires the per-link Adjacency-SID storage from #845 to the wire using the emit plumbing from #844.

Three pieces:

- **\`srmpls::ext_link_lsa_build\`** mirrors \`ext_prefix_lsa_build\`. Constructs an Extended-Link Opaque LSA (RFC 7684 §3) with one \`ExtLinkTlv\` (link_type / link_id / link_data) carrying a single \`AdjSidSubTlv\` (RFC 8665 §5). Flag semantics match the Prefix-SID build: Index-form SIDs ship without value/local flags, Absolute Label SIDs set V + L.
- **\`Ospf::ext_link_lsa_originate(ifindex)\`** is the symmetric counterpart to \`ext_prefix_lsa_originate\`. Originates iff SR-MPLS is on, the link is enabled with an \`adjacency_sid\`, network type is point-to-point, and there is at least one Full neighbor; flushes (MaxAge) otherwise. Uses \`lookup_by_id\` to preserve the sequence number across re-originations and floods through \`flood_self_originated_lsa\`. Broadcast / NBMA support requires LAN-Adj-SID (RFC 8665 §6) and is deferred to a follow-up.
- **Triggers**: \`process_neighbor_state_change\` calls \`ext_link_lsa_originate\` on every Full transition (either direction), parallel to the existing Router-LSA re-origination. \`config_ospf_segment_routing\` fans out to every link with an Adj-SID when SR-MPLS toggles. The per-interface \`adjacency-sid\` config callbacks lose their \"storage-only\" comment from #845 and now drive origination directly.

The \`#[allow(dead_code)]\` placeholder on \`AdjacencySid\` comes off now that \`ext_link_lsa_build\` reads both variants.

**Refresh path:** \`Lsdb::refresh_lsa\` still just bumps the sequence on the cached body; for P2P the body is stable across the Full window so a refresh that doesn't rebuild is correct. The full rebuild on every Full transition + every config commit keeps the cached body accurate. LAN-Adj-SID and the multi-neighbor refresh rebuild come with the broadcast follow-up.

## Test plan

- [x] \`cargo build\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p zebra-rs --bins\` — 610/610 passing, no regressions
- [ ] Manual: two P2P-typed OSPFv2 routers with \`segment-routing mpls\` and per-link \`adjacency-sid index N\`. After adjacency reaches Full, confirm each side originates an Ext-Link LSA carrying an AdjSid sub-TLV (visible in \`show ip ospf database detail\` on the peer once parsing/display catches up in PR4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)