### PR TITLE
ospf: install self Adjacency-SID ILM entries on the local MPLS LFIB

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -4882,6 +4882,91 @@ fn add_self_prefix_sids_to_ilm(top: &Ospf, ilm: &mut BTreeMap<u32, SpfIlm>) {
     }
 }
 
+/// For every self-originated Extended-Link Opaque LSA, emit an ILM
+/// entry that pops the local Adjacency-SID label and forwards over
+/// the specific adjacency the SID identifies.
+///
+/// Per RFC 8402 §3.4.1 the Adj-SID is locally significant -- only
+/// the advertiser installs forwarding state for it. The kernel-
+/// level action is "pop and forward to neighbor on this link", so
+/// the emitted nexthop carries the neighbor's address as the via,
+/// the link's ifindex as the oif, and `adjacency: true` so
+/// `make_ilm_entry` omits the swap label (Via + Oif only on the
+/// wire, matching the implicit-null/PHP path the Prefix-SID pop
+/// uses).
+///
+/// Only P2P (link_type=1) Ext-Link LSAs are handled here.
+/// LAN-Adj-SID (RFC 8665 §6) is a follow-up.
+fn add_self_adj_sids_to_ilm(top: &Ospf, ilm: &mut BTreeMap<u32, SpfIlm>) {
+    use super::srmpls::SRGB_START;
+    use crate::ospf::lsdb::OSPF_MAX_AGE;
+
+    for (area_id, area) in top.areas.iter() {
+        let area_id = *area_id;
+        for (_, lsa) in area.lsdb.iter_by_type(OspfLsType::OpaqueAreaLocal) {
+            if lsa.data.h.ls_age >= OSPF_MAX_AGE {
+                continue;
+            }
+            if lsa.data.h.adv_router != top.router_id {
+                continue;
+            }
+            let OspfLsp::OpaqueAreaExtLink(ref el) = lsa.data.lsp else {
+                continue;
+            };
+            for tlv in &el.tlvs {
+                // P2P only -- broadcast/NBMA needs LAN-Adj-SID handling.
+                if tlv.link_type != 1 {
+                    continue;
+                }
+                let Some(link) = self_link_by_addr(top, area_id, tlv.link_data) else {
+                    continue;
+                };
+                // Find the neighbor whose router-id matches the
+                // Ext-Link TLV's link_id (P2P encoding). The neighbor
+                // is keyed in `link.nbrs` by its OSPF interface
+                // address, not by router-id, so iterate.
+                let Some(nbr_addr) = link
+                    .nbrs
+                    .values()
+                    .find(|n| n.ident.router_id == tlv.link_id)
+                    .map(|n| n.ident.prefix.addr())
+                else {
+                    continue;
+                };
+                for sub in &tlv.subs {
+                    let ExtLinkSubTlv::AdjSid(adj) = sub else {
+                        continue;
+                    };
+                    let (label, adj_index) = match adj.sid {
+                        SidLabelTlv::Label(v) => (v, v.saturating_sub(SRGB_START)),
+                        SidLabelTlv::Index(idx) => match SRGB_START.checked_add(idx) {
+                            Some(v) => (v, idx),
+                            None => continue,
+                        },
+                    };
+                    let mut nhops = BTreeMap::new();
+                    nhops.insert(
+                        nbr_addr,
+                        SpfNexthop {
+                            ifindex: link.index,
+                            adjacency: true,
+                            router_id: Some(tlv.link_id),
+                        },
+                    );
+                    ilm.insert(
+                        label,
+                        SpfIlm {
+                            nhops,
+                            ilm_type: IlmType::Adjacency(adj_index),
+                        },
+                    );
+                    break;
+                }
+            }
+        }
+    }
+}
+
 /// Apply routing updates to RIB subsystem
 fn apply_routing_updates(top: &mut Ospf, rib: PrefixMap<Ipv4Net, SpfRoute>) {
     // Build the SR-MPLS LFIB from labeled routes in the freshly
@@ -4889,6 +4974,7 @@ fn apply_routing_updates(top: &mut Ospf, rib: PrefixMap<Ipv4Net, SpfRoute>) {
     // RIB subsystem sees only the IlmAdd / IlmDel deltas.
     let mut ilm = build_ilm_from_rib(&rib);
     add_self_prefix_sids_to_ilm(top, &mut ilm);
+    add_self_adj_sids_to_ilm(top, &mut ilm);
     let ilm_diff = spf::table_diff(top.ilm.iter(), ilm.iter());
     diff_ilm_apply(&top.ctx.rib, &ilm_diff);
     top.ilm = ilm;


### PR DESCRIPTION
## Summary

Phase B PR4. Adjacency-SIDs are locally significant per RFC 8402 §3.4.1 — only the advertiser installs forwarding state for them. #846 originates the Extended-Link Opaque LSA, but without a matching local ILM entry an upstream SR-TE head-end that pushes our Adj-SID label onto a packet hits a kernel drop. Same gap that self-Prefix-SID pop closed for Prefix-SIDs (#843).

Close it with **\`add_self_adj_sids_to_ilm\`**, parallel to \`add_self_prefix_sids_to_ilm\`:

- Walk self-originated \`OpaqueAreaExtLink\` LSAs, skip MaxAge.
- For each P2P \`ExtLinkTlv\` (\`link_type == 1\`) find the local link whose interface address matches \`link_data\` via \`self_link_by_addr\`.
- Resolve the neighbor whose router-id matches \`link_id\` (the P2P encoding) to its OSPF interface address.
- Resolve the AdjSid label: Index form against the local SRGB (\`srmpls::SRGB_START\`), Label form verbatim.
- Emit an \`SpfIlm\` with one nexthop carrying \`adjacency: true\`, the neighbor's address, and the link's ifindex. The \`adjacency\` flag is what makes \`make_ilm_entry\` omit the swap label — the resulting \`IlmEntry\` is Via + Oif with no \`NewDestination\`, i.e. pop the label and forward to the neighbor on this specific link. Exactly the Adj-SID semantic.
- ILM entry type is \`IlmType::Adjacency(adj_index)\` so the show side renders it distinct from Prefix-SID Node entries.

\`apply_routing_updates\` calls the new helper right after \`add_self_prefix_sids_to_ilm\`, so the diff machinery picks up adds and deletes uniformly when the LSA appears, the neighbor changes, or the LSA ages out.

**This closes Phase B end-to-end for point-to-point.** Broadcast / NBMA support requires LAN-Adj-SID (RFC 8665 §6) and is a follow-up.

## Test plan

- [x] \`cargo build\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p zebra-rs --bins\` — 610/610 passing, no regressions
- [ ] Manual: two P2P-typed OSPFv2 routers, both with \`segment-routing mpls\` and per-link \`adjacency-sid index N\`. After adjacency reaches Full, send a packet from peer to our Adj-SID label and confirm \`ip -M route\` shows the pop entry and the packet exits the right interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)