### PR TITLE
ospf: filter Opaque LSAs out of DBD summary to non-Opaque peers

### DIFF
--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -379,7 +379,17 @@ pub fn ospfv2_populate_initial_db_summary(
     ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::Network));
     ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::Summary));
     ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::SummaryAsbr));
-    ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::OpaqueAreaLocal));
+
+    // RFC 5250 §2.1: Opaque LSAs MUST NOT be flooded to a neighbor
+    // that did not advertise Opaque capability (the O-bit in the DD
+    // options). Including type-10 LSA headers in our initial DD
+    // summary to a non-Opaque peer makes the peer reject the DBD
+    // (peer marks our reply as malformed and bounces back to
+    // ExStart), which manifests as a persistent ExStart loop with
+    // SeqNumberMismatch on both sides.
+    if nbr.dd.recv.options.o() {
+        ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::OpaqueAreaLocal));
+    }
 
     // AS-scope LSAs included only for non-stub / non-NSSA areas.
     if oi.area_type == AreaType::Normal {

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -416,6 +416,13 @@ pub fn ospf_db_desc_recv(
             } else {
                 return;
             }
+            // Stash the peer's initial DD before NegotiationDone fires so
+            // that `populate_initial_db_summary` can read the peer's
+            // option flags (notably the O-bit) when deciding which LSA
+            // types to push into `db_sum`. Without this the populate
+            // call sees a default `nbr.dd.recv`, which is only filled
+            // later by `ospf_db_desc_proc`.
+            nbr.dd.recv = dd.clone();
             ospf_nfsm(oi, nbr, NfsmEvent::NegotiationDone, oi.ident);
 
             ospf_db_desc_proc(oi, nbr, dd);


### PR DESCRIPTION
## Summary

Fixes a real-world ExStart loop with persistent SeqNumberMismatch on both sides. Traced back to a clear RFC 5250 violation: \`ospfv2_populate_initial_db_summary\` unconditionally pushes every type-10 (Opaque Area-Local) LSA header into the initial DD summary.

When the peer hasn't advertised Opaque capability (no O-bit in the peer's DD options), the peer rejects the DD as malformed and bounces back to ExStart — which in turn forces us back to ExStart on the next DD via the \`init\`-in-Exchange branch. Result: stable bidirectional oscillation. Symptom in production was a /32 host adjacency stuck in ExStart/DROther across dozens of state changes, with diagnostic tracing showing peer keeps sending \`init=true\` DDs with incremented seqnums every cycle.

Two pieces:

- **\`ospf_db_desc_recv\` ExStart branch** now stashes the peer's initial DD into \`nbr.dd.recv\` before firing \`NegotiationDone\`. \`nbr.dd.recv\` was only being filled later by \`ospf_db_desc_proc\`, so the populate callback ran against a default-constructed \`OspfDbDesc\` and couldn't see the peer's actual options.
- **\`ospfv2_populate_initial_db_summary\`** gates \`OspfLsType::OpaqueAreaLocal\` on \`nbr.dd.recv.options.o()\`. Peers without the O-bit see no Opaque LSAs in our initial DD summary, which is exactly what RFC 5250 §2.1 requires — Opaque LSAs only flood between Opaque-capable peers. Peers that do advertise the O-bit continue to receive the full set, so Router Info / Extended Prefix / Extended Link LSAs keep flowing between SR-MPLS-aware nodes.

## Test plan

- [x] \`cargo build\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p zebra-rs --bins\` — 610/610 passing, no regressions
- [ ] Manual: reproduce the ExStart loop against a non-Opaque peer and confirm adjacency reaches Full
- [ ] Manual: verify two SR-MPLS nodes (both Opaque-capable) still exchange Router Info / Extended Prefix / Extended Link LSAs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)