### PR TITLE
ospf: per-adjacency SRLB label pool (LAN-Adj-SID prep)

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -668,7 +668,7 @@ fn config_sr_mpls_enable(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<(
         // re-enabling without a prior disable keeps any previously
         // handed-out labels intact.
         if isis.local_pool.is_none() {
-            isis.local_pool = Some(super::LabelPool::new(15000, Some(16000)));
+            isis.local_pool = Some(crate::spf::label_pool::LabelPool::new(15000, Some(16000)));
         }
     } else {
         isis.config.sr_mpls_enabled = false;

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -43,7 +43,8 @@ use super::throttle::Throttle;
 use super::{
     Hostname, IfsmEvent, Lsdb, LsdbEvent, NfsmEvent, NfsmState, csnp_send, srm_set_for_all_lsp,
 };
-use super::{LabelPool, Level, Levels, process_packet};
+use super::{Level, Levels, process_packet};
+use crate::spf::label_pool::LabelPool;
 
 pub type Callback = fn(&mut Isis, Args, ConfigOp) -> Option<()>;
 pub type ShowCallback = fn(&Isis, Args, bool) -> std::result::Result<String, std::fmt::Error>;

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -28,7 +28,8 @@ use super::network::{read_packet, write_packet};
 use super::socket::isis_socket;
 use super::srmpls::IsisLabelMap;
 use super::tracing::IsisTracing;
-use super::{Hostname, IfsmEvent, Isis, LabelPool, Level, Levels, Lsdb, Message};
+use super::{Hostname, IfsmEvent, Isis, Level, Levels, Lsdb, Message};
+use crate::spf::label_pool::LabelPool;
 
 #[derive(Debug, Default)]
 pub struct LinkTimer {

--- a/zebra-rs/src/isis/mod.rs
+++ b/zebra-rs/src/isis/mod.rs
@@ -41,9 +41,6 @@ pub use lsdb::{Lsdb, LsdbEvent};
 pub mod hostname;
 pub use hostname::Hostname;
 
-pub mod labelpool;
-pub use labelpool::*;
-
 pub mod tracing;
 
 pub mod flood;

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -48,12 +48,13 @@ fn bfd_nfsm_dispatch(
     }
 }
 
+use super::Level;
 use super::flood;
 use super::ifsm::has_level;
 use super::link::{LinkTop, NetworkType};
 use super::lsdb;
 use super::lsp::{Packet, PacketMessage};
-use super::{LabelPool, Level};
+use crate::spf::label_pool::LabelPool;
 
 #[derive(Debug)]
 pub struct NeighborAddr4 {

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -375,12 +375,30 @@ fn config_ospf_interface_adjacency_sid_absolute(
 }
 
 fn config_ospf_sr_mpls(ospf: &mut Ospf, _args: Args, op: ConfigOp) -> Option<()> {
-    use super::srmpls::SegmentRoutingMode;
+    use super::srmpls::{SRLB_RANGE, SRLB_START, SegmentRoutingMode};
+    use crate::spf::label_pool::LabelPool;
     ospf.segment_routing = if op.is_set() {
         SegmentRoutingMode::Mpls
     } else {
         SegmentRoutingMode::None
     };
+
+    // Manage the per-instance Adjacency-SID label pool alongside the
+    // mode toggle, mirroring IS-IS (`isis/config.rs::config_sr_mpls_enable`).
+    // The pool is bounded by the SRLB (15000..16000 by default) so any
+    // re-enable that happens before existing adjacencies regress will
+    // simply hand out fresh labels without colliding with stale ones.
+    if op.is_set() {
+        if ospf.local_pool.is_none() {
+            ospf.local_pool = Some(LabelPool::new(
+                SRLB_START as usize,
+                Some((SRLB_START + SRLB_RANGE - 1) as usize),
+            ));
+        }
+    } else {
+        ospf.local_pool = None;
+        ospf.lan_adj_sids.clear();
+    }
 
     ospf.router_info_lsa_originate();
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -85,6 +85,26 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// rebuilt ILM after each SPF run to emit `rib::Message::IlmAdd`
     /// / `IlmDel` so the kernel MPLS table tracks the SR-MPLS state.
     pub ilm: BTreeMap<u32, SpfIlm>,
+    /// First-fit Adjacency-SID label allocator backed by the local SRLB
+    /// (`srmpls::SRLB_START` .. `SRLB_START + SRLB_RANGE - 1`). Created
+    /// when `segment-routing mpls` is enabled, dropped when it's
+    /// disabled. Each Full adjacency claims one label from the pool on
+    /// transition into Full and releases it on regression; the
+    /// `(ifindex, neighbor_router_id) -> label` mapping is held in
+    /// `lan_adj_sids` below so origination and ILM install can read it.
+    pub local_pool: Option<crate::spf::label_pool::LabelPool>,
+    /// Per-adjacency Adjacency-SID label map. Keyed by
+    /// `(ifindex, neighbor_interface_addr)`; the value is the absolute
+    /// label allocated from `local_pool` on the corresponding NFSM
+    /// Full transition. Keyed on the interface address (not the
+    /// router-id) because the address is always available even when
+    /// the `Neighbor` struct has just been removed by an inactivity
+    /// kill — the origination side resolves the address back to a
+    /// router-id at LSA build time.
+    /// Used to drive LAN Adj-SID origination on broadcast/NBMA links
+    /// (RFC 8665 §6) and the matching local ILM install. Cleared when
+    /// SR-MPLS is disabled.
+    pub lan_adj_sids: BTreeMap<(u32, Ipv4Addr), u32>,
     /// v3 IPv6 RIB shadow. Populated by
     /// `apply_routing_updates_v3` after each SPF run; diffed
     /// against the next computation so we only emit
@@ -352,6 +372,8 @@ impl Ospf<Ospfv2> {
             graph: None,
             rib: PrefixMap::new(),
             ilm: BTreeMap::new(),
+            local_pool: None,
+            lan_adj_sids: BTreeMap::new(),
             rib6: PrefixMap::new(),
             tracing: OspfTracing::default(),
             segment_routing: super::srmpls::SegmentRoutingMode::default(),
@@ -1131,6 +1153,24 @@ impl Ospf<Ospfv2> {
             new_state
         );
 
+        // Adjacency-SID label allocation. Each Full adjacency claims
+        // one label out of the SRLB on transition into Full and
+        // releases it on regression. The label is consumed by LAN
+        // Adj-SID origination (broadcast / NBMA links) and the matching
+        // local ILM install. Pool is only present when SR-MPLS is
+        // enabled, so this is a no-op otherwise.
+        if new_state == NfsmState::Full
+            && let Some(pool) = self.local_pool.as_mut()
+            && let Some(label) = pool.allocate()
+        {
+            self.lan_adj_sids.insert((ifindex, nbr_addr), label as u32);
+        } else if old_state == NfsmState::Full
+            && let Some(label) = self.lan_adj_sids.remove(&(ifindex, nbr_addr))
+            && let Some(pool) = self.local_pool.as_mut()
+        {
+            pool.release(label as usize);
+        }
+
         // Router-LSA must be re-originated whenever Full adjacency count changes.
         self.router_lsa_originate();
 
@@ -1810,6 +1850,8 @@ impl Ospf<Ospfv3> {
             graph: None,
             rib: PrefixMap::new(),
             ilm: BTreeMap::new(),
+            local_pool: None,
+            lan_adj_sids: BTreeMap::new(),
             rib6: PrefixMap::new(),
             tracing: OspfTracing::default(),
             segment_routing: super::srmpls::SegmentRoutingMode::default(),

--- a/zebra-rs/src/ospf/srmpls.rs
+++ b/zebra-rs/src/ospf/srmpls.rs
@@ -17,8 +17,8 @@ pub(super) const SRGB_START: u32 = 16000;
 const SRGB_RANGE: u32 = 2001;
 
 /// Default SRLB (Segment Routing Local Block).
-const SRLB_START: u32 = 15000;
-const SRLB_RANGE: u32 = 1000;
+pub(super) const SRLB_START: u32 = 15000;
+pub(super) const SRLB_RANGE: u32 = 1000;
 
 /// Build a Router Information Opaque LSA for SR-MPLS.
 pub fn router_info_lsa_build(router_id: Ipv4Addr) -> OspfLsa {

--- a/zebra-rs/src/spf/label_pool.rs
+++ b/zebra-rs/src/spf/label_pool.rs
@@ -1,5 +1,13 @@
 use bit_vec::BitVec;
 
+/// First-fit allocator for an inclusive label range `[begin, end]`.
+///
+/// Backs the per-instance Adjacency-SID label allocator for both IS-IS
+/// and OSPF SR-MPLS: each Full adjacency claims one label out of the
+/// SRLB on transition into Full and releases it on regression. Freed
+/// indices land in `free_list` so the next allocation reuses the
+/// lowest-numbered slot — keeps labels visually close to `begin`
+/// even after churn.
 pub struct LabelPool {
     begin: usize,
     end: Option<usize>,

--- a/zebra-rs/src/spf/mod.rs
+++ b/zebra-rs/src/spf/mod.rs
@@ -5,3 +5,5 @@ pub mod diff;
 pub use diff::*;
 
 pub mod label_block;
+
+pub mod label_pool;


### PR DESCRIPTION
## Summary

First of three PRs adding LAN-Adj-SID (RFC 8665 §6) support for broadcast and NBMA networks. This PR puts the allocator in place without changing any wire behavior; PR-2 will originate the LAN Adj-SID LSA on top of it, PR-3 will wire the matching local ILM install.

- **LabelPool moves out of isis/ into a shared location** (\`zebra-rs/src/spf/label_pool.rs\`) alongside the already-shared \`LabelMap\`, since OSPF now needs the same first-fit SRLB allocator. The struct itself is unchanged; only the path moves (\`crate::isis::LabelPool\` → \`crate::spf::label_pool::LabelPool\`). The four IS-IS consumers (\`inst.rs\`, \`link.rs\`, \`packet.rs\`, \`config.rs\`) update their \`use\` paths.
- **OSPF grows two fields on \`Ospf<V>\`:**
  - \`local_pool: Option<LabelPool>\` — first-fit allocator backed by the local SRLB (\`srmpls::SRLB_START\` .. \`+ SRLB_RANGE - 1\`, 15000..16000 by default). Created when \`segment-routing mpls\` is enabled in \`config_ospf_sr_mpls\`, dropped when it's disabled — mirroring \`isis/config.rs::config_sr_mpls_enable\`.
  - \`lan_adj_sids: BTreeMap<(u32, Ipv4Addr), u32>\` — per-adjacency label table keyed by \`(ifindex, neighbor_interface_addr)\`. Keyed on the interface address (not the router-id) because the address survives an inactivity kill even after the \`Neighbor\` struct is gone; the origination side will resolve the address back to a router-id at LSA-build time.
- **\`process_neighbor_state_change\` is the allocation site**: every transition into Full claims one label out of the pool; every transition out releases it. No-op when SR-MPLS is disabled (no pool present).
- \`SRLB_START\` / \`SRLB_RANGE\` are exported \`pub(super)\` so the config callback can size the pool without hardcoding the numbers a second time.

## Test plan

- [x] \`cargo build\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p zebra-rs --bins\` — 610/610 passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)