### PR TITLE
ospf: originate LAN-Adj-SID LSA on broadcast / NBMA links

### DIFF
--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -395,6 +395,33 @@ fn config_ospf_sr_mpls(ospf: &mut Ospf, _args: Args, op: ConfigOp) -> Option<()>
                 Some((SRLB_START + SRLB_RANGE - 1) as usize),
             ));
         }
+        // Sweep existing Full neighbors and allocate labels for any
+        // that don't have one. Necessary when SR-MPLS is enabled after
+        // adjacencies have already reached Full -- the NFSM-driven
+        // allocation only fires on the Full transition itself, so those
+        // pre-existing adjacencies would otherwise be missing from
+        // `lan_adj_sids` and excluded from LAN Adj-SID origination.
+        let pending: Vec<(u32, std::net::Ipv4Addr)> = ospf
+            .links
+            .iter()
+            .flat_map(|(ifindex, link)| {
+                link.nbrs.values().filter_map(move |nbr| {
+                    if nbr.state == super::nfsm::NfsmState::Full {
+                        Some((*ifindex, nbr.ident.prefix.addr()))
+                    } else {
+                        None
+                    }
+                })
+            })
+            .filter(|key| !ospf.lan_adj_sids.contains_key(key))
+            .collect();
+        for key in pending {
+            if let Some(pool) = ospf.local_pool.as_mut()
+                && let Some(label) = pool.allocate()
+            {
+                ospf.lan_adj_sids.insert(key, label as u32);
+            }
+        }
     } else {
         ospf.local_pool = None;
         ospf.lan_adj_sids.clear();

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -629,13 +629,15 @@ impl Ospf<Ospfv2> {
 
     /// Originate (or flush) the Extended-Link Opaque LSA for `ifindex`.
     ///
-    /// Originates when:
-    ///   * SR-MPLS is enabled (`segment_routing == Mpls`)
-    ///   * the link is enabled and has an `adjacency_sid` configured
-    ///   * the link is point-to-point with at least one Full neighbor
+    /// Originates when SR-MPLS is enabled, the link is enabled, has at
+    /// least one Full neighbor, and either of:
+    ///   * P2P link with an `adjacency_sid` configured — one
+    ///     `AdjSidSubTlv` carrying the configured value.
+    ///   * Broadcast / NBMA link with a known DR and at least one
+    ///     entry in `lan_adj_sids` — one `LanAdjSidSubTlv` per Full
+    ///     neighbor that has a label allocated, per RFC 8665 §6.
     ///
-    /// Flushes (MaxAge) otherwise. Broadcast / NBMA support requires
-    /// LAN-Adj-SID (RFC 8665 §6) and is deferred to a follow-up.
+    /// Flushes (MaxAge) otherwise.
     ///
     /// The opaque-id is derived from the ifindex (same convention as
     /// `ext_prefix_lsa_originate`) so the per-link LSA gets a stable
@@ -647,31 +649,71 @@ impl Ospf<Ospfv2> {
         let opaque_id = ifindex & 0x00FF_FFFF;
         let ls_id = Ipv4Addr::from(((OpaqueLsaType::EXT_LINK as u32) << 24) | opaque_id);
 
-        let link = self.links.get(&ifindex);
-        let should_originate = self.segment_routing == SegmentRoutingMode::Mpls
-            && link.is_some_and(|l| {
-                l.enabled
-                    && l.config.adjacency_sid.is_some()
-                    && l.network_type == OspfNetworkType::PointToPoint
-                    && l.nbrs.values().any(|nbr| nbr.state == NfsmState::Full)
-            });
+        // Build the (link_type, link_id, link_data, subs) tuple if
+        // origination is warranted, otherwise fall through to the
+        // flush path. Returning `Option` keeps the borrow on `self`
+        // confined to this block so the install / flood code below can
+        // mutate `self.areas`.
+        let build_inputs = if self.segment_routing == SegmentRoutingMode::Mpls
+            && let Some(link) = self.links.get(&ifindex)
+            && link.enabled
+            && link.nbrs.values().any(|n| n.state == NfsmState::Full)
+            && let Some(addr) = link.addr.iter().find(|a| !a.prefix.addr().is_loopback())
+        {
+            let our_addr = addr.prefix.addr();
+            match link.network_type {
+                OspfNetworkType::PointToPoint => {
+                    if let Some(adjacency_sid) = link.config.adjacency_sid
+                        && let Some(nbr) = link.nbrs.values().find(|n| n.state == NfsmState::Full)
+                    {
+                        Some((
+                            1u8,
+                            nbr.ident.router_id,
+                            our_addr,
+                            vec![super::srmpls::build_p2p_adj_sub(&adjacency_sid)],
+                        ))
+                    } else {
+                        None
+                    }
+                }
+                OspfNetworkType::Broadcast | OspfNetworkType::NBMA => {
+                    let dr = link.ident.d_router;
+                    if dr.is_unspecified() {
+                        // DR election not yet settled. Fall through to
+                        // the flush path so we don't keep a stale LSA
+                        // pointing at a `link_id` we can no longer name.
+                        None
+                    } else {
+                        let subs: Vec<_> = link
+                            .nbrs
+                            .values()
+                            .filter(|n| n.state == NfsmState::Full)
+                            .filter_map(|nbr| {
+                                let label =
+                                    *self.lan_adj_sids.get(&(ifindex, nbr.ident.prefix.addr()))?;
+                                Some(super::srmpls::build_lan_adj_sub(nbr.ident.router_id, label))
+                            })
+                            .collect();
+                        if subs.is_empty() {
+                            // No Full neighbor has a label allocated yet.
+                            None
+                        } else {
+                            Some((2u8, dr, our_addr, subs))
+                        }
+                    }
+                }
+            }
+        } else {
+            None
+        };
 
-        if should_originate {
-            let link = link.unwrap();
-            let adjacency_sid = link.config.adjacency_sid.unwrap();
-            let Some(addr) = link.addr.iter().find(|a| !a.prefix.addr().is_loopback()) else {
-                return;
-            };
-            let Some(nbr) = link.nbrs.values().find(|n| n.state == NfsmState::Full) else {
-                return;
-            };
-
+        if let Some((link_type, link_id, link_data, subs)) = build_inputs {
             let mut lsa = super::srmpls::ext_link_lsa_build(
                 self.router_id,
-                1, // P2P -- matches RouterLsaLinkType encoding.
-                nbr.ident.router_id,
-                addr.prefix.addr(),
-                &adjacency_sid,
+                link_type,
+                link_id,
+                link_data,
+                subs,
                 opaque_id,
             );
 
@@ -1582,6 +1624,16 @@ impl Ospf<Ospfv2> {
                     let new_state = self.links.get(&index).map(|l| l.state);
                     if prev_state == IfsmState::DR && new_state != Some(IfsmState::DR) {
                         self.network_lsa_flush(index, area_id);
+                    }
+                    // Re-originate the per-link Extended-Link Opaque LSA
+                    // on any IFSM state change. For broadcast / NBMA the
+                    // `link_id` is the DR's interface address (RFC 7684
+                    // §3) so a DR election outcome must trigger a
+                    // refresh; the originator gates on its own
+                    // preconditions and flushes when they no longer
+                    // hold. P2P sees no semantic change here.
+                    if new_state.is_some_and(|s| s != prev_state) {
+                        self.ext_link_lsa_originate(index);
                     }
                 }
             }

--- a/zebra-rs/src/ospf/srmpls.rs
+++ b/zebra-rs/src/ospf/srmpls.rs
@@ -103,45 +103,31 @@ pub fn ext_prefix_lsa_build(
     lsa
 }
 
-/// Build an Extended Link Opaque LSA (RFC 7684 §3 + RFC 8665 §5)
-/// for a single link, carrying one Adjacency-SID sub-TLV.
+/// Build an Extended Link Opaque LSA (RFC 7684 §3) for a single link
+/// with caller-supplied sub-TLVs.
 ///
 /// `link_type` matches the OSPFv2 Router-LSA link_type encoding (1 =
-/// P2P, 2 = Transit broadcast/NBMA, 4 = Virtual). PR3 only originates
-/// for P2P links; broadcast / NBMA support arrives with LAN-Adj-SID.
+/// P2P, 2 = Transit broadcast / NBMA, 4 = Virtual). `subs` is the
+/// full sub-TLV list to embed: one `AdjSidSubTlv` for P2P, or one
+/// `LanAdjSidSubTlv` per Full neighbor on broadcast / NBMA per
+/// RFC 8665 §6.
 ///
-/// Flag semantics mirror the Prefix-SID build: an Index-form SID
-/// carries no value/local flags (the index is resolved against the
-/// peer's SRGB); an Absolute Label SID sets V (Value) + L (Local) to
-/// indicate a raw label per RFC 8665 §5.
+/// The `_build_p2p_adj_sub` / `_build_lan_adj_sub` helpers below
+/// take the more common Adj-SID flag conventions off the caller's
+/// hands.
 pub fn ext_link_lsa_build(
     router_id: Ipv4Addr,
     link_type: u8,
     link_id: Ipv4Addr,
     link_data: Ipv4Addr,
-    adjacency_sid: &AdjacencySid,
+    subs: Vec<ExtLinkSubTlv>,
     opaque_id: u32,
 ) -> OspfLsa {
-    let (sid, flags) = match adjacency_sid {
-        AdjacencySid::Index(idx) => (SidLabelTlv::Index(*idx), AdjSidFlags::new()),
-        AdjacencySid::Absolute(label) => (
-            SidLabelTlv::Label(*label),
-            AdjSidFlags::new().with_v_flag(true).with_l_flag(true),
-        ),
-    };
-
-    let adj_sub = AdjSidSubTlv {
-        flags,
-        mt_id: 0,
-        weight: 0,
-        sid,
-    };
-
     let tlv = ExtLinkTlv {
         link_type,
         link_id,
         link_data,
-        subs: vec![ExtLinkSubTlv::AdjSid(adj_sub)],
+        subs,
     };
 
     let el_lsa = ExtLinkLsa { tlvs: vec![tlv] };
@@ -154,4 +140,40 @@ pub fn ext_link_lsa_build(
     let mut lsa = OspfLsa::from(lsah, OspfLsp::OpaqueAreaExtLink(el_lsa));
     lsa.update();
     lsa
+}
+
+/// Construct an `AdjSidSubTlv` from a configured Adjacency-SID (P2P
+/// case). Flag semantics mirror the Prefix-SID build: Index-form
+/// carries no value/local flags (the index is resolved against the
+/// peer's SRGB); Absolute Label sets V (Value) + L (Local) per
+/// RFC 8665 §5.
+pub fn build_p2p_adj_sub(adjacency_sid: &AdjacencySid) -> ExtLinkSubTlv {
+    let (sid, flags) = match adjacency_sid {
+        AdjacencySid::Index(idx) => (SidLabelTlv::Index(*idx), AdjSidFlags::new()),
+        AdjacencySid::Absolute(label) => (
+            SidLabelTlv::Label(*label),
+            AdjSidFlags::new().with_v_flag(true).with_l_flag(true),
+        ),
+    };
+    ExtLinkSubTlv::AdjSid(AdjSidSubTlv {
+        flags,
+        mt_id: 0,
+        weight: 0,
+        sid,
+    })
+}
+
+/// Construct a `LanAdjSidSubTlv` (RFC 8665 §6) for a single Full
+/// neighbor on a broadcast / NBMA segment. `label` is the absolute
+/// SRLB-allocated value held in `Ospf::lan_adj_sids`. V + L flags
+/// are set unconditionally — LAN Adj-SIDs we originate are always
+/// in raw-Label form (drawn from our local SRLB).
+pub fn build_lan_adj_sub(neighbor_id: Ipv4Addr, label: u32) -> ExtLinkSubTlv {
+    ExtLinkSubTlv::LanAdjSid(LanAdjSidSubTlv {
+        flags: AdjSidFlags::new().with_v_flag(true).with_l_flag(true),
+        mt_id: 0,
+        weight: 0,
+        neighbor_id,
+        sid: SidLabelTlv::Label(label),
+    })
 }


### PR DESCRIPTION
## Summary

PR-2 of the LAN-Adj-SID series. Builds on #850's per-adjacency SRLB allocator to actually originate the broadcast / NBMA flavor of the Extended-Link Opaque LSA per RFC 8665 §6.

Three pieces:

- **\`srmpls::ext_link_lsa_build\`** is generalized to take a pre-built sub-TLV list instead of a single \`AdjacencySid\`. The two flag conventions move into helper constructors — \`build_p2p_adj_sub\` returns an \`AdjSidSubTlv\` from the configured static Adj-SID (P2P), \`build_lan_adj_sub\` returns a \`LanAdjSidSubTlv\` from an allocated SRLB label (LAN).
- **\`Ospf::ext_link_lsa_originate\`** now dispatches on \`link.network_type\`:
  - **P2P** → existing behavior, one \`AdjSidSubTlv\` carrying the statically configured Adj-SID. \`link_id\` = neighbor's router-id.
  - **Broadcast / NBMA** → one \`LanAdjSidSubTlv\` per Full neighbor whose \`(ifindex, interface_addr)\` has a label in \`lan_adj_sids\` (allocated by PR-1's NFSM hook). \`link_id\` = DR's interface address per RFC 7684 §3. If the DR is unspecified or no Full neighbor has a label yet, fall through to the flush path rather than emit a malformed LSA.
- **\`Message::Ifsm\`** re-originates the Extended-Link LSA on any IFSM state change. Broadcast / NBMA links carry the DR's address in their \`link_id\`, so a DR election outcome must refresh the LSA; the originator's own gating makes the call a no-op when the preconditions don't hold (P2P sees no semantic change here).
- **\`config_ospf_sr_mpls\` enable-side sweep**: walk current Full neighbors and allocate labels for any not yet in \`lan_adj_sids\`. Without this, enabling SR-MPLS after adjacencies have already reached Full leaves them unlabeled and the LAN Adj-SID path can't include them.

## Test plan

- [x] \`cargo build\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p zebra-rs --bins\` — 610/610 passing
- [ ] Manual: three OSPFv2 routers sharing a broadcast segment, all SR-MPLS enabled, no static \`adjacency-sid\` config. After DR election and adjacencies settle Full, each router originates an Ext-Link LSA with \`link_type=2\`, \`link_id\` = DR's interface, and one \`LanAdjSidSubTlv\` per peer (visible in \`show ip ospf database detail\`).

PR-3 follows with the matching self-LAN-Adj-SID ILM install so packets arriving labeled actually pop and forward to the right neighbor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)