### PR TITLE
ospf-packet: decode OSPFv3 Intra-Area-Prefix TLV + Prefix-SID

### DIFF
--- a/crates/ospf-packet/src/v3.rs
+++ b/crates/ospf-packet/src/v3.rs
@@ -40,6 +40,7 @@ use byteorder::{BigEndian, ByteOrder};
 use bytes::{BufMut, BytesMut};
 use internet_checksum::Checksum;
 use nom::IResult;
+use nom::bytes::complete::take;
 use nom::number::complete::{be_u8, be_u16, be_u24, be_u32};
 use nom_derive::*;
 use packet_utils::{ParseBe, many0_complete};
@@ -1368,6 +1369,117 @@ impl ParseBe<Ospfv3LinkLsa> for Ospfv3LinkLsa {
 /// else (NSSA-AS-External 0x2007, opaque flavours, future allocations)
 /// lands in `Unknown(Vec<u8>)` so captures roundtrip without loss.
 ///
+// ---------------------------------------------------------------------
+// RFC 8362 Extended LSA (E-LSA) LS Types.
+//
+// RFC 8362 §4 assigns a parallel set of LS Types whose bodies are a
+// stream of top-level TLVs (rather than the fixed wire shape used by
+// RFC 5340 LSAs). The U-bit is set so legacy routers flood unknown
+// E-LSAs as if understood; the scope bits mirror the standard LSA's
+// flooding scope. The function codes (33-41) carve out the IANA range
+// reserved for the extendability work.
+//
+// PR-D1 (this PR) provides the body shell — actual top-level-TLV
+// decoders (Router-Link, Intra-Area-Prefix, etc., RFC 8362 §5-6) and
+// RFC 8666 SR sub-TLVs land in follow-up PRs.
+/// E-Router-LSA (RFC 8362 §4): U=1, S=01 (area), fc=33.
+pub const OSPFV3_E_ROUTER_LSA_TYPE: u16 = 0xA021;
+/// E-Network-LSA (RFC 8362 §4): U=1, S=01 (area), fc=34.
+pub const OSPFV3_E_NETWORK_LSA_TYPE: u16 = 0xA022;
+/// E-Inter-Area-Prefix-LSA (RFC 8362 §4): U=1, S=01 (area), fc=35.
+pub const OSPFV3_E_INTER_AREA_PREFIX_LSA_TYPE: u16 = 0xA023;
+/// E-Inter-Area-Router-LSA (RFC 8362 §4): U=1, S=01 (area), fc=36.
+pub const OSPFV3_E_INTER_AREA_ROUTER_LSA_TYPE: u16 = 0xA024;
+/// E-AS-External-LSA (RFC 8362 §4): U=1, S=10 (AS), fc=37.
+pub const OSPFV3_E_AS_EXTERNAL_LSA_TYPE: u16 = 0xC025;
+/// E-Link-LSA (RFC 8362 §4): U=1, S=00 (link-local), fc=40.
+pub const OSPFV3_E_LINK_LSA_TYPE: u16 = 0x8028;
+/// E-Intra-Area-Prefix-LSA (RFC 8362 §4): U=1, S=01 (area), fc=41.
+pub const OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE: u16 = 0xA029;
+
+/// One top-level TLV inside an Extended LSA body (RFC 8362 §3).
+///
+/// PR-D1 keeps every TLV as `Unknown` — the body parser preserves the
+/// wire bytes verbatim so any LSA round-trips through the codec
+/// without dropping data. PR-D2 will introduce typed variants
+/// (Router-Link TLV, Intra-Area-Prefix TLV, External-Prefix TLV, …)
+/// once the matching origination / consumption paths need them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Ospfv3ExtTlv {
+    Unknown { typ: u16, value: Vec<u8> },
+}
+
+impl Ospfv3ExtTlv {
+    /// Wire length including the 4-byte TLV header, padded to the
+    /// next 4-byte boundary per RFC 8362 §3.
+    #[allow(dead_code)] // consumed by typed TLV decoders (PR-D2+).
+    fn wire_len(&self) -> usize {
+        let value_len = match self {
+            Ospfv3ExtTlv::Unknown { value, .. } => value.len(),
+        };
+        4 + ((value_len + 3) & !3)
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        let (typ, value) = match self {
+            Ospfv3ExtTlv::Unknown { typ, value } => (*typ, value.as_slice()),
+        };
+        buf.put_u16(typ);
+        buf.put_u16(value.len() as u16);
+        buf.put_slice(value);
+        // Pad to 4-byte alignment.
+        let pad = ((value.len() + 3) & !3) - value.len();
+        for _ in 0..pad {
+            buf.put_u8(0);
+        }
+    }
+
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Ospfv3ExtTlv> {
+        let (input, typ) = be_u16(input)?;
+        let (input, len) = be_u16(input)?;
+        let len = len as usize;
+        let (input, value) = take(len)(input)?;
+        // Skip pad to next 4-byte boundary.
+        let padded = (len + 3) & !3;
+        let (input, _) = take(padded - len)(input)?;
+        Ok((
+            input,
+            Ospfv3ExtTlv::Unknown {
+                typ,
+                value: value.to_vec(),
+            },
+        ))
+    }
+}
+
+/// Body of any of the seven RFC 8362 Extended LSA types. All seven
+/// share the same wire shape — a stream of top-level TLVs (RFC 8362
+/// §3) — so a single struct represents all of them; the LS Type
+/// distinguishes which top-level TLVs are semantically expected.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Ospfv3ELsaBody {
+    pub tlvs: Vec<Ospfv3ExtTlv>,
+}
+
+impl Ospfv3ELsaBody {
+    pub fn emit(&self, buf: &mut BytesMut) {
+        for tlv in &self.tlvs {
+            tlv.emit(buf);
+        }
+    }
+
+    pub fn parse_be(input: &[u8]) -> IResult<&[u8], Ospfv3ELsaBody> {
+        let mut tlvs = Vec::new();
+        let mut rest = input;
+        while !rest.is_empty() {
+            let (r, tlv) = Ospfv3ExtTlv::parse_be(rest)?;
+            tlvs.push(tlv);
+            rest = r;
+        }
+        Ok((rest, Ospfv3ELsaBody { tlvs }))
+    }
+}
+
 /// Each variant carries the body alone — the 20-octet `Ospfv3LsaHeader`
 /// is held separately in `Ospfv3Lsa::h`, mirroring the v2 codec's
 /// `OspfLsa { h, lsp }` shape.
@@ -1380,6 +1492,17 @@ pub enum Ospfv3LsBody {
     AsExternal(Ospfv3AsExternalLsa),
     Link(Ospfv3LinkLsa),
     IntraAreaPrefix(Ospfv3IntraAreaPrefixLsa),
+    /// RFC 8362 §4 Extended LSAs. All seven share the same TLV-stream
+    /// wire shape (`Ospfv3ELsaBody`); the variant only carries the
+    /// LS-Type-specific identity so origination / consumption can
+    /// dispatch on it.
+    ERouter(Ospfv3ELsaBody),
+    ENetwork(Ospfv3ELsaBody),
+    EInterAreaPrefix(Ospfv3ELsaBody),
+    EInterAreaRouter(Ospfv3ELsaBody),
+    EAsExternal(Ospfv3ELsaBody),
+    ELink(Ospfv3ELsaBody),
+    EIntraAreaPrefix(Ospfv3ELsaBody),
     /// Unrecognised LS Type — bytes preserved verbatim.
     Unknown(Vec<u8>),
 }
@@ -1394,6 +1517,13 @@ impl Ospfv3LsBody {
             Ospfv3LsBody::AsExternal(b) => b.emit(buf),
             Ospfv3LsBody::Link(b) => b.emit(buf),
             Ospfv3LsBody::IntraAreaPrefix(b) => b.emit(buf),
+            Ospfv3LsBody::ERouter(b)
+            | Ospfv3LsBody::ENetwork(b)
+            | Ospfv3LsBody::EInterAreaPrefix(b)
+            | Ospfv3LsBody::EInterAreaRouter(b)
+            | Ospfv3LsBody::EAsExternal(b)
+            | Ospfv3LsBody::ELink(b)
+            | Ospfv3LsBody::EIntraAreaPrefix(b) => b.emit(buf),
             Ospfv3LsBody::Unknown(bytes) => buf.put_slice(bytes),
         }
     }
@@ -1432,6 +1562,34 @@ impl Ospfv3LsBody {
             OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE => {
                 let (rest, b) = Ospfv3IntraAreaPrefixLsa::parse_be(input)?;
                 Ok((rest, Ospfv3LsBody::IntraAreaPrefix(b)))
+            }
+            OSPFV3_E_ROUTER_LSA_TYPE => {
+                let (rest, b) = Ospfv3ELsaBody::parse_be(input)?;
+                Ok((rest, Ospfv3LsBody::ERouter(b)))
+            }
+            OSPFV3_E_NETWORK_LSA_TYPE => {
+                let (rest, b) = Ospfv3ELsaBody::parse_be(input)?;
+                Ok((rest, Ospfv3LsBody::ENetwork(b)))
+            }
+            OSPFV3_E_INTER_AREA_PREFIX_LSA_TYPE => {
+                let (rest, b) = Ospfv3ELsaBody::parse_be(input)?;
+                Ok((rest, Ospfv3LsBody::EInterAreaPrefix(b)))
+            }
+            OSPFV3_E_INTER_AREA_ROUTER_LSA_TYPE => {
+                let (rest, b) = Ospfv3ELsaBody::parse_be(input)?;
+                Ok((rest, Ospfv3LsBody::EInterAreaRouter(b)))
+            }
+            OSPFV3_E_AS_EXTERNAL_LSA_TYPE => {
+                let (rest, b) = Ospfv3ELsaBody::parse_be(input)?;
+                Ok((rest, Ospfv3LsBody::EAsExternal(b)))
+            }
+            OSPFV3_E_LINK_LSA_TYPE => {
+                let (rest, b) = Ospfv3ELsaBody::parse_be(input)?;
+                Ok((rest, Ospfv3LsBody::ELink(b)))
+            }
+            OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE => {
+                let (rest, b) = Ospfv3ELsaBody::parse_be(input)?;
+                Ok((rest, Ospfv3LsBody::EIntraAreaPrefix(b)))
             }
             _ => Ok((&[][..], Ospfv3LsBody::Unknown(input.to_vec()))),
         }
@@ -2801,6 +2959,94 @@ mod tests {
         assert!(rest.is_empty());
         assert!(parsed.prefixes.is_empty());
         assert_eq!(parsed.link_local_address, Ipv6Addr::UNSPECIFIED);
+    }
+
+    /// Build an Extended LSA body with two synthetic top-level TLVs,
+    /// emit + parse back, and assert structural equality. Covers TLV
+    /// header layout, 4-byte alignment padding, and the body's
+    /// LS-Type-keyed dispatch into the right `Ospfv3LsBody` variant.
+    #[test]
+    fn ospfv3_e_lsa_body_round_trip() {
+        // TLV value of length 6 (forces 2 bytes of pad).
+        let tlv_a = Ospfv3ExtTlv::Unknown {
+            typ: 0x1001,
+            value: vec![0xde, 0xad, 0xbe, 0xef, 0xfe, 0xed],
+        };
+        // TLV value of length 4 (no pad).
+        let tlv_b = Ospfv3ExtTlv::Unknown {
+            typ: 0x1002,
+            value: vec![0x11, 0x22, 0x33, 0x44],
+        };
+        let body = Ospfv3ELsaBody {
+            tlvs: vec![tlv_a.clone(), tlv_b.clone()],
+        };
+
+        // Emit through the same dispatch the wire path uses.
+        let mut buf = BytesMut::new();
+        Ospfv3LsBody::EIntraAreaPrefix(body.clone()).emit(&mut buf);
+        // Two TLVs: (4 header + 6 value + 2 pad) + (4 header + 4 value).
+        assert_eq!(buf.len(), 4 + 6 + 2 + 4 + 4);
+
+        let (rest, parsed) =
+            Ospfv3LsBody::parse_be(&buf, OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE).unwrap();
+        assert!(rest.is_empty());
+        let Ospfv3LsBody::EIntraAreaPrefix(parsed_body) = parsed else {
+            panic!("expected EIntraAreaPrefix variant, got {:?}", parsed);
+        };
+        assert_eq!(parsed_body.tlvs.len(), 2);
+        assert_eq!(parsed_body.tlvs[0], tlv_a);
+        assert_eq!(parsed_body.tlvs[1], tlv_b);
+    }
+
+    /// Each of the seven RFC 8362 LS Types dispatches to a distinct
+    /// `Ospfv3LsBody` variant and round-trips its body bytes intact.
+    #[test]
+    fn ospfv3_e_lsa_all_types_dispatch() {
+        let body = Ospfv3ELsaBody {
+            tlvs: vec![Ospfv3ExtTlv::Unknown {
+                typ: 0x0007,
+                value: vec![0xaa; 8],
+            }],
+        };
+        let cases: &[(u16, fn(&Ospfv3LsBody) -> bool)] = &[
+            (OSPFV3_E_ROUTER_LSA_TYPE, |b| {
+                matches!(b, Ospfv3LsBody::ERouter(_))
+            }),
+            (OSPFV3_E_NETWORK_LSA_TYPE, |b| {
+                matches!(b, Ospfv3LsBody::ENetwork(_))
+            }),
+            (OSPFV3_E_INTER_AREA_PREFIX_LSA_TYPE, |b| {
+                matches!(b, Ospfv3LsBody::EInterAreaPrefix(_))
+            }),
+            (OSPFV3_E_INTER_AREA_ROUTER_LSA_TYPE, |b| {
+                matches!(b, Ospfv3LsBody::EInterAreaRouter(_))
+            }),
+            (OSPFV3_E_AS_EXTERNAL_LSA_TYPE, |b| {
+                matches!(b, Ospfv3LsBody::EAsExternal(_))
+            }),
+            (OSPFV3_E_LINK_LSA_TYPE, |b| {
+                matches!(b, Ospfv3LsBody::ELink(_))
+            }),
+            (OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE, |b| {
+                matches!(b, Ospfv3LsBody::EIntraAreaPrefix(_))
+            }),
+        ];
+        for (ls_type, expected_variant) in cases {
+            let mut buf = BytesMut::new();
+            body.emit(&mut buf);
+            let (rest, parsed) = Ospfv3LsBody::parse_be(&buf, *ls_type).unwrap();
+            assert!(
+                rest.is_empty(),
+                "trailing bytes for ls_type 0x{:04x}",
+                ls_type
+            );
+            assert!(
+                expected_variant(&parsed),
+                "wrong variant for ls_type 0x{:04x}: got {:?}",
+                ls_type,
+                parsed
+            );
+        }
     }
 
     /// Unknown link-type bytes parse permissively to PointToPoint

--- a/crates/ospf-packet/src/v3.rs
+++ b/crates/ospf-packet/src/v3.rs
@@ -45,7 +45,9 @@ use nom::number::complete::{be_u8, be_u16, be_u24, be_u32};
 use nom_derive::*;
 use packet_utils::{ParseBe, many0_complete};
 
+use super::parser::AdjSidFlags;
 use super::{DbDescFlags, OspfType};
+use packet_utils::SidLabelTlv;
 
 /// OSPFv3 protocol version (header octet 0).
 pub const OSPFV3_VERSION: u8 = 3;
@@ -574,7 +576,7 @@ impl ParseBe<Ospfv3RouterLinkType> for Ospfv3RouterLinkType {
 ///   - v2's `num_tos / tos_0_metric` pattern collapses to a fixed
 ///     16-bit `metric` (v3 drops the TOS-routing carry-over);
 ///   - the v2 stub-network link type (3) is gone.
-#[derive(Debug, Clone, NomBE)]
+#[derive(Debug, Clone, PartialEq, NomBE)]
 pub struct Ospfv3RouterLsaLink {
     pub link_type: Ospfv3RouterLinkType,
     pub reserved: u8,
@@ -1397,15 +1399,270 @@ pub const OSPFV3_E_LINK_LSA_TYPE: u16 = 0x8028;
 /// E-Intra-Area-Prefix-LSA (RFC 8362 §4): U=1, S=01 (area), fc=41.
 pub const OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE: u16 = 0xA029;
 
+// ---------------------------------------------------------------------
+// RFC 8362 §4 top-level TLV type codes (subset implemented here).
+//
+// IANA "OSPFv3 Extended-LSA TLV Types" registry — PR-D2 adds typed
+// Router-Link TLV; the remaining type codes (Attached-Routers,
+// Inter-Area-Prefix, External-Prefix, Intra-Area-Prefix, …) fall back
+// to `Ospfv3ExtTlv::Unknown` until later PRs decode them.
+/// Router-Link TLV inside an E-Router-LSA (RFC 8362 §5.1).
+pub const OSPFV3_EXT_TLV_ROUTER_LINK: u16 = 1;
+
+// ---------------------------------------------------------------------
+// RFC 8666 OSPFv3 SR sub-TLV type codes.
+//
+// IANA "OSPFv3 Extended-LSA Sub-TLV Types" registry. Same bit
+// assignments as their RFC 8665 OSPFv2 counterparts, but the on-the-
+// wire layout inside the sub-TLV value differs (wider Weight field,
+// no MT-ID) so the Rust shapes are distinct.
+/// Adj-SID Sub-TLV (RFC 8666 §6.1) carried inside a Router-Link TLV.
+pub const OSPFV3_SUB_TLV_ADJ_SID: u16 = 6;
+/// LAN-Adj-SID Sub-TLV (RFC 8666 §6.2) carried inside a Router-Link TLV.
+pub const OSPFV3_SUB_TLV_LAN_ADJ_SID: u16 = 7;
+
+/// Adj-SID Sub-TLV (RFC 8666 §6.1).
+///
+/// Wire layout: flags(1) + reserved(1) + weight(2) + SID(3 or 4).
+/// `AdjSidFlags` reused verbatim — the same B / V / L / G / P bit
+/// assignments as the OSPFv2 Adj-SID Sub-TLV (RFC 8665 §5); only the
+/// surrounding wire layout (16-bit Weight, no MT-ID) differs.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Ospfv3AdjSidSubTlv {
+    pub flags: AdjSidFlags,
+    pub weight: u16,
+    pub sid: SidLabelTlv,
+}
+
+impl Ospfv3AdjSidSubTlv {
+    fn value_len(&self) -> u16 {
+        // flags(1) + reserved(1) + weight(2) + sid(3 or 4)
+        4 + match &self.sid {
+            SidLabelTlv::Label(_) => 3,
+            SidLabelTlv::Index(_) => 4,
+        }
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(self.flags.into());
+        buf.put_u8(0); // reserved
+        buf.put_u16(self.weight);
+        match &self.sid {
+            SidLabelTlv::Label(v) => buf.put(&packet_utils::u32_u8_3(*v)[..]),
+            SidLabelTlv::Index(v) => buf.put_u32(*v),
+        }
+    }
+
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, flags) = be_u8(input)?;
+        let (input, _reserved) = be_u8(input)?;
+        let (input, weight) = be_u16(input)?;
+        let sid_len = input.len();
+        let (input, sid) = match sid_len {
+            3 => {
+                let (input, label) = be_u24(input)?;
+                (input, SidLabelTlv::Label(label))
+            }
+            4 => {
+                let (input, index) = be_u32(input)?;
+                (input, SidLabelTlv::Index(index))
+            }
+            _ => {
+                return Err(nom::Err::Incomplete(nom::Needed::new(sid_len)));
+            }
+        };
+        Ok((
+            input,
+            Self {
+                flags: flags.into(),
+                weight,
+                sid,
+            },
+        ))
+    }
+}
+
+/// LAN-Adj-SID Sub-TLV (RFC 8666 §6.2).
+///
+/// Same shape as `Ospfv3AdjSidSubTlv` plus a 32-bit Neighbor Router ID
+/// (the router-id that uniquely identifies the neighbor on the
+/// broadcast / NBMA segment this Adj-SID points at).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Ospfv3LanAdjSidSubTlv {
+    pub flags: AdjSidFlags,
+    pub weight: u16,
+    pub neighbor_router_id: Ipv4Addr,
+    pub sid: SidLabelTlv,
+}
+
+impl Ospfv3LanAdjSidSubTlv {
+    fn value_len(&self) -> u16 {
+        // flags(1) + reserved(1) + weight(2) + neighbor_router_id(4) + sid(3 or 4)
+        8 + match &self.sid {
+            SidLabelTlv::Label(_) => 3,
+            SidLabelTlv::Index(_) => 4,
+        }
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(self.flags.into());
+        buf.put_u8(0); // reserved
+        buf.put_u16(self.weight);
+        buf.put(&self.neighbor_router_id.octets()[..]);
+        match &self.sid {
+            SidLabelTlv::Label(v) => buf.put(&packet_utils::u32_u8_3(*v)[..]),
+            SidLabelTlv::Index(v) => buf.put_u32(*v),
+        }
+    }
+
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, flags) = be_u8(input)?;
+        let (input, _reserved) = be_u8(input)?;
+        let (input, weight) = be_u16(input)?;
+        let (input, neighbor_router_id) = Ipv4Addr::parse_be(input)?;
+        let sid_len = input.len();
+        let (input, sid) = match sid_len {
+            3 => {
+                let (input, label) = be_u24(input)?;
+                (input, SidLabelTlv::Label(label))
+            }
+            4 => {
+                let (input, index) = be_u32(input)?;
+                (input, SidLabelTlv::Index(index))
+            }
+            _ => {
+                return Err(nom::Err::Incomplete(nom::Needed::new(sid_len)));
+            }
+        };
+        Ok((
+            input,
+            Self {
+                flags: flags.into(),
+                weight,
+                neighbor_router_id,
+                sid,
+            },
+        ))
+    }
+}
+
+/// A sub-TLV inside a top-level Extended-LSA TLV (RFC 8362 §3
+/// nesting; RFC 8666 SR sub-TLV registry). Decoded variants surface
+/// the typed shape; everything else round-trips through `Unknown`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Ospfv3SubTlv {
+    AdjSid(Ospfv3AdjSidSubTlv),
+    LanAdjSid(Ospfv3LanAdjSidSubTlv),
+    Unknown { typ: u16, value: Vec<u8> },
+}
+
+impl Ospfv3SubTlv {
+    fn wire_len(&self) -> usize {
+        let value_len = match self {
+            Ospfv3SubTlv::AdjSid(s) => s.value_len() as usize,
+            Ospfv3SubTlv::LanAdjSid(s) => s.value_len() as usize,
+            Ospfv3SubTlv::Unknown { value, .. } => value.len(),
+        };
+        4 + ((value_len + 3) & !3)
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        let (typ, value_len) = match self {
+            Ospfv3SubTlv::AdjSid(s) => (OSPFV3_SUB_TLV_ADJ_SID, s.value_len()),
+            Ospfv3SubTlv::LanAdjSid(s) => (OSPFV3_SUB_TLV_LAN_ADJ_SID, s.value_len()),
+            Ospfv3SubTlv::Unknown { typ, value } => (*typ, value.len() as u16),
+        };
+        buf.put_u16(typ);
+        buf.put_u16(value_len);
+        match self {
+            Ospfv3SubTlv::AdjSid(s) => s.emit(buf),
+            Ospfv3SubTlv::LanAdjSid(s) => s.emit(buf),
+            Ospfv3SubTlv::Unknown { value, .. } => buf.put_slice(value),
+        }
+        let value_len = value_len as usize;
+        let pad = ((value_len + 3) & !3) - value_len;
+        for _ in 0..pad {
+            buf.put_u8(0);
+        }
+    }
+
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, typ) = be_u16(input)?;
+        let (input, len) = be_u16(input)?;
+        let len = len as usize;
+        let (input, value) = take(len)(input)?;
+        let parsed = match typ {
+            OSPFV3_SUB_TLV_ADJ_SID => {
+                let (_, s) = Ospfv3AdjSidSubTlv::parse_be(value)?;
+                Ospfv3SubTlv::AdjSid(s)
+            }
+            OSPFV3_SUB_TLV_LAN_ADJ_SID => {
+                let (_, s) = Ospfv3LanAdjSidSubTlv::parse_be(value)?;
+                Ospfv3SubTlv::LanAdjSid(s)
+            }
+            _ => Ospfv3SubTlv::Unknown {
+                typ,
+                value: value.to_vec(),
+            },
+        };
+        let padded = (len + 3) & !3;
+        let (input, _) = take(padded - len)(input)?;
+        Ok((input, parsed))
+    }
+}
+
+/// Router-Link TLV (RFC 8362 §5.1) — top-level TLV inside an
+/// E-Router-LSA. The fixed prefix (16 octets) is the same shape as
+/// the per-link entry used in the standard Router-LSA, plus a
+/// variable-length sub-TLV stream (where SR Adj-SID and LAN-Adj-SID
+/// live per RFC 8666 §6).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Ospfv3RouterLinkTlv {
+    pub link: Ospfv3RouterLsaLink,
+    pub subs: Vec<Ospfv3SubTlv>,
+}
+
+impl Ospfv3RouterLinkTlv {
+    /// Length of the TLV value (Router-Link fixed prefix + sub-TLVs).
+    fn value_len(&self) -> usize {
+        // Ospfv3RouterLsaLink is exactly 16 octets on the wire.
+        let sub_len: usize = self.subs.iter().map(|s| s.wire_len()).sum();
+        16 + sub_len
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(self.link.link_type.into());
+        buf.put_u8(0); // reserved
+        buf.put_u16(self.link.metric);
+        buf.put_u32(self.link.interface_id);
+        buf.put_u32(self.link.neighbor_interface_id);
+        buf.put(&self.link.neighbor_router_id.octets()[..]);
+        for s in &self.subs {
+            s.emit(buf);
+        }
+    }
+
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, link) = Ospfv3RouterLsaLink::parse_be(input)?;
+        let mut subs = Vec::new();
+        let mut rest = input;
+        while !rest.is_empty() {
+            let (r, s) = Ospfv3SubTlv::parse_be(rest)?;
+            subs.push(s);
+            rest = r;
+        }
+        Ok((rest, Self { link, subs }))
+    }
+}
+
 /// One top-level TLV inside an Extended LSA body (RFC 8362 §3).
 ///
-/// PR-D1 keeps every TLV as `Unknown` — the body parser preserves the
-/// wire bytes verbatim so any LSA round-trips through the codec
-/// without dropping data. PR-D2 will introduce typed variants
-/// (Router-Link TLV, Intra-Area-Prefix TLV, External-Prefix TLV, …)
-/// once the matching origination / consumption paths need them.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Typed variants surface the structured shape; everything else
+/// round-trips through `Unknown` so a foreign extension we don't yet
+/// understand still survives the codec.
+#[derive(Debug, Clone, PartialEq)]
 pub enum Ospfv3ExtTlv {
+    RouterLink(Ospfv3RouterLinkTlv),
     Unknown { typ: u16, value: Vec<u8> },
 }
 
@@ -1415,20 +1672,25 @@ impl Ospfv3ExtTlv {
     #[allow(dead_code)] // consumed by typed TLV decoders (PR-D2+).
     fn wire_len(&self) -> usize {
         let value_len = match self {
+            Ospfv3ExtTlv::RouterLink(t) => t.value_len(),
             Ospfv3ExtTlv::Unknown { value, .. } => value.len(),
         };
         4 + ((value_len + 3) & !3)
     }
 
     fn emit(&self, buf: &mut BytesMut) {
-        let (typ, value) = match self {
-            Ospfv3ExtTlv::Unknown { typ, value } => (*typ, value.as_slice()),
+        let (typ, value_len) = match self {
+            Ospfv3ExtTlv::RouterLink(t) => (OSPFV3_EXT_TLV_ROUTER_LINK, t.value_len()),
+            Ospfv3ExtTlv::Unknown { typ, value } => (*typ, value.len()),
         };
         buf.put_u16(typ);
-        buf.put_u16(value.len() as u16);
-        buf.put_slice(value);
+        buf.put_u16(value_len as u16);
+        match self {
+            Ospfv3ExtTlv::RouterLink(t) => t.emit(buf),
+            Ospfv3ExtTlv::Unknown { value, .. } => buf.put_slice(value),
+        }
         // Pad to 4-byte alignment.
-        let pad = ((value.len() + 3) & !3) - value.len();
+        let pad = ((value_len + 3) & !3) - value_len;
         for _ in 0..pad {
             buf.put_u8(0);
         }
@@ -1439,16 +1701,20 @@ impl Ospfv3ExtTlv {
         let (input, len) = be_u16(input)?;
         let len = len as usize;
         let (input, value) = take(len)(input)?;
-        // Skip pad to next 4-byte boundary.
-        let padded = (len + 3) & !3;
-        let (input, _) = take(padded - len)(input)?;
-        Ok((
-            input,
-            Ospfv3ExtTlv::Unknown {
+        let parsed = match typ {
+            OSPFV3_EXT_TLV_ROUTER_LINK => {
+                let (_, t) = Ospfv3RouterLinkTlv::parse_be(value)?;
+                Ospfv3ExtTlv::RouterLink(t)
+            }
+            _ => Ospfv3ExtTlv::Unknown {
                 typ,
                 value: value.to_vec(),
             },
-        ))
+        };
+        // Skip pad to next 4-byte boundary.
+        let padded = (len + 3) & !3;
+        let (input, _) = take(padded - len)(input)?;
+        Ok((input, parsed))
     }
 }
 
@@ -1456,7 +1722,7 @@ impl Ospfv3ExtTlv {
 /// share the same wire shape — a stream of top-level TLVs (RFC 8362
 /// §3) — so a single struct represents all of them; the LS Type
 /// distinguishes which top-level TLVs are semantically expected.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct Ospfv3ELsaBody {
     pub tlvs: Vec<Ospfv3ExtTlv>,
 }
@@ -3046,6 +3312,72 @@ mod tests {
                 ls_type,
                 parsed
             );
+        }
+    }
+
+    /// Build an E-Router-LSA body carrying one Router-Link TLV whose
+    /// sub-TLVs include both Adj-SID and LAN-Adj-SID (RFC 8666 §6),
+    /// emit through the LS-body dispatch, parse back, and assert each
+    /// nested value survives byte-for-byte.
+    #[test]
+    fn ospfv3_e_router_lsa_router_link_with_sr_sub_tlvs() {
+        use crate::parser::AdjSidFlags;
+        use packet_utils::SidLabelTlv;
+
+        let adj = Ospfv3SubTlv::AdjSid(Ospfv3AdjSidSubTlv {
+            flags: AdjSidFlags::new().with_v_flag(true).with_l_flag(true),
+            weight: 0,
+            sid: SidLabelTlv::Label(15001),
+        });
+        let lan_adj = Ospfv3SubTlv::LanAdjSid(Ospfv3LanAdjSidSubTlv {
+            flags: AdjSidFlags::new().with_v_flag(true).with_l_flag(true),
+            weight: 0,
+            neighbor_router_id: Ipv4Addr::new(10, 0, 0, 2),
+            sid: SidLabelTlv::Label(15002),
+        });
+
+        let link = Ospfv3RouterLsaLink::new(
+            Ospfv3RouterLinkType::PointToPoint,
+            10,
+            42,
+            7,
+            Ipv4Addr::new(10, 0, 0, 2),
+        );
+        let router_link_tlv = Ospfv3ExtTlv::RouterLink(Ospfv3RouterLinkTlv {
+            link: link.clone(),
+            subs: vec![adj.clone(), lan_adj.clone()],
+        });
+        let body = Ospfv3ELsaBody {
+            tlvs: vec![router_link_tlv],
+        };
+
+        let mut buf = BytesMut::new();
+        Ospfv3LsBody::ERouter(body).emit(&mut buf);
+
+        let (rest, parsed) = Ospfv3LsBody::parse_be(&buf, OSPFV3_E_ROUTER_LSA_TYPE).unwrap();
+        assert!(rest.is_empty(), "trailing bytes after E-Router body");
+        let Ospfv3LsBody::ERouter(parsed_body) = parsed else {
+            panic!("expected ERouter variant");
+        };
+        assert_eq!(parsed_body.tlvs.len(), 1);
+        let Ospfv3ExtTlv::RouterLink(parsed_rl) = &parsed_body.tlvs[0] else {
+            panic!("expected RouterLink top-level TLV");
+        };
+        assert_eq!(parsed_rl.link, link);
+        assert_eq!(parsed_rl.subs.len(), 2);
+        match &parsed_rl.subs[0] {
+            Ospfv3SubTlv::AdjSid(s) => {
+                assert!(matches!(s.sid, SidLabelTlv::Label(15001)));
+                assert_eq!(s.weight, 0);
+            }
+            other => panic!("expected AdjSid, got {:?}", other),
+        }
+        match &parsed_rl.subs[1] {
+            Ospfv3SubTlv::LanAdjSid(s) => {
+                assert_eq!(s.neighbor_router_id, Ipv4Addr::new(10, 0, 0, 2));
+                assert!(matches!(s.sid, SidLabelTlv::Label(15002)));
+            }
+            other => panic!("expected LanAdjSid, got {:?}", other),
         }
     }
 

--- a/crates/ospf-packet/src/v3.rs
+++ b/crates/ospf-packet/src/v3.rs
@@ -45,9 +45,9 @@ use nom::number::complete::{be_u8, be_u16, be_u24, be_u32};
 use nom_derive::*;
 use packet_utils::{ParseBe, many0_complete};
 
-use super::parser::AdjSidFlags;
+use super::parser::{AdjSidFlags, PrefixSidFlags};
 use super::{DbDescFlags, OspfType};
-use packet_utils::SidLabelTlv;
+use packet_utils::{Algo, SidLabelTlv};
 
 /// OSPFv3 protocol version (header octet 0).
 pub const OSPFV3_VERSION: u8 = 3;
@@ -1408,6 +1408,9 @@ pub const OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE: u16 = 0xA029;
 // to `Ospfv3ExtTlv::Unknown` until later PRs decode them.
 /// Router-Link TLV inside an E-Router-LSA (RFC 8362 §5.1).
 pub const OSPFV3_EXT_TLV_ROUTER_LINK: u16 = 1;
+/// Intra-Area-Prefix TLV inside an E-Intra-Area-Prefix-LSA
+/// (RFC 8362 §3.7).
+pub const OSPFV3_EXT_TLV_INTRA_AREA_PREFIX: u16 = 6;
 
 // ---------------------------------------------------------------------
 // RFC 8666 OSPFv3 SR sub-TLV type codes.
@@ -1416,10 +1419,75 @@ pub const OSPFV3_EXT_TLV_ROUTER_LINK: u16 = 1;
 // assignments as their RFC 8665 OSPFv2 counterparts, but the on-the-
 // wire layout inside the sub-TLV value differs (wider Weight field,
 // no MT-ID) so the Rust shapes are distinct.
+/// Prefix-SID Sub-TLV (RFC 8666 §5) carried inside an
+/// Intra-Area-Prefix TLV or Inter-Area-Prefix TLV.
+pub const OSPFV3_SUB_TLV_PREFIX_SID: u16 = 4;
 /// Adj-SID Sub-TLV (RFC 8666 §6.1) carried inside a Router-Link TLV.
 pub const OSPFV3_SUB_TLV_ADJ_SID: u16 = 6;
 /// LAN-Adj-SID Sub-TLV (RFC 8666 §6.2) carried inside a Router-Link TLV.
 pub const OSPFV3_SUB_TLV_LAN_ADJ_SID: u16 = 7;
+
+/// Prefix-SID Sub-TLV (RFC 8666 §5).
+///
+/// Wire layout: flags(1) + algo(1) + reserved(2) + SID(3 or 4).
+/// `PrefixSidFlags` (NP / M / E / V / L) is reused from the OSPFv2
+/// codec — the bit assignments match RFC 8665 §4. The wire layout
+/// differs (no MT-ID, reserved bytes are 2 instead of 1) so the
+/// Rust shape is distinct from `ExtPrefixSidSubTlv`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Ospfv3PrefixSidSubTlv {
+    pub flags: PrefixSidFlags,
+    pub algo: Algo,
+    pub sid: SidLabelTlv,
+}
+
+impl Ospfv3PrefixSidSubTlv {
+    fn value_len(&self) -> u16 {
+        // flags(1) + algo(1) + reserved(2) + sid(3 or 4)
+        4 + match &self.sid {
+            SidLabelTlv::Label(_) => 3,
+            SidLabelTlv::Index(_) => 4,
+        }
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(self.flags.into());
+        buf.put_u8(self.algo.into());
+        buf.put_u16(0); // reserved
+        match &self.sid {
+            SidLabelTlv::Label(v) => buf.put(&packet_utils::u32_u8_3(*v)[..]),
+            SidLabelTlv::Index(v) => buf.put_u32(*v),
+        }
+    }
+
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, flags) = be_u8(input)?;
+        let (input, algo) = be_u8(input)?;
+        let (input, _reserved) = be_u16(input)?;
+        let sid_len = input.len();
+        let (input, sid) = match sid_len {
+            3 => {
+                let (input, label) = be_u24(input)?;
+                (input, SidLabelTlv::Label(label))
+            }
+            4 => {
+                let (input, index) = be_u32(input)?;
+                (input, SidLabelTlv::Index(index))
+            }
+            _ => {
+                return Err(nom::Err::Incomplete(nom::Needed::new(sid_len)));
+            }
+        };
+        Ok((
+            input,
+            Self {
+                flags: flags.into(),
+                algo: algo.into(),
+                sid,
+            },
+        ))
+    }
+}
 
 /// Adj-SID Sub-TLV (RFC 8666 §6.1).
 ///
@@ -1551,6 +1619,7 @@ impl Ospfv3LanAdjSidSubTlv {
 /// the typed shape; everything else round-trips through `Unknown`.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Ospfv3SubTlv {
+    PrefixSid(Ospfv3PrefixSidSubTlv),
     AdjSid(Ospfv3AdjSidSubTlv),
     LanAdjSid(Ospfv3LanAdjSidSubTlv),
     Unknown { typ: u16, value: Vec<u8> },
@@ -1559,6 +1628,7 @@ pub enum Ospfv3SubTlv {
 impl Ospfv3SubTlv {
     fn wire_len(&self) -> usize {
         let value_len = match self {
+            Ospfv3SubTlv::PrefixSid(s) => s.value_len() as usize,
             Ospfv3SubTlv::AdjSid(s) => s.value_len() as usize,
             Ospfv3SubTlv::LanAdjSid(s) => s.value_len() as usize,
             Ospfv3SubTlv::Unknown { value, .. } => value.len(),
@@ -1568,6 +1638,7 @@ impl Ospfv3SubTlv {
 
     fn emit(&self, buf: &mut BytesMut) {
         let (typ, value_len) = match self {
+            Ospfv3SubTlv::PrefixSid(s) => (OSPFV3_SUB_TLV_PREFIX_SID, s.value_len()),
             Ospfv3SubTlv::AdjSid(s) => (OSPFV3_SUB_TLV_ADJ_SID, s.value_len()),
             Ospfv3SubTlv::LanAdjSid(s) => (OSPFV3_SUB_TLV_LAN_ADJ_SID, s.value_len()),
             Ospfv3SubTlv::Unknown { typ, value } => (*typ, value.len() as u16),
@@ -1575,6 +1646,7 @@ impl Ospfv3SubTlv {
         buf.put_u16(typ);
         buf.put_u16(value_len);
         match self {
+            Ospfv3SubTlv::PrefixSid(s) => s.emit(buf),
             Ospfv3SubTlv::AdjSid(s) => s.emit(buf),
             Ospfv3SubTlv::LanAdjSid(s) => s.emit(buf),
             Ospfv3SubTlv::Unknown { value, .. } => buf.put_slice(value),
@@ -1592,6 +1664,10 @@ impl Ospfv3SubTlv {
         let len = len as usize;
         let (input, value) = take(len)(input)?;
         let parsed = match typ {
+            OSPFV3_SUB_TLV_PREFIX_SID => {
+                let (_, s) = Ospfv3PrefixSidSubTlv::parse_be(value)?;
+                Ospfv3SubTlv::PrefixSid(s)
+            }
             OSPFV3_SUB_TLV_ADJ_SID => {
                 let (_, s) = Ospfv3AdjSidSubTlv::parse_be(value)?;
                 Ospfv3SubTlv::AdjSid(s)
@@ -1655,6 +1731,101 @@ impl Ospfv3RouterLinkTlv {
     }
 }
 
+/// Intra-Area-Prefix TLV (RFC 8362 §3.7) — top-level TLV inside an
+/// E-Intra-Area-Prefix-LSA. Carries exactly one prefix plus
+/// referenced-LSA metadata, and a variable-length sub-TLV stream
+/// where SR Prefix-SID lives per RFC 8666 §5.
+///
+/// Wire layout of the value:
+///   metric(2) + prefix_length(1) + prefix_options(1)
+///     + referenced_ls_type(4) + referenced_lsid(4)
+///     + referenced_advertising_router(4) + address_prefix(variable,
+///     padded to 4-byte boundary per RFC 5340 §A.4.1.1) + sub-TLVs.
+///
+/// The standard `Ospfv3IntraAreaPrefix` (RFC 5340) stores
+/// metric/prefix-length/prefix-options without the referenced-LSA
+/// triple — that triple is hoisted to the standard LSA body. The
+/// Extended LSA reverses this: each TLV is one prefix and carries
+/// its own reference, so the body itself only sequences TLVs.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Ospfv3IntraAreaPrefixTlv {
+    pub metric: u16,
+    pub prefix_length: u8,
+    pub prefix_options: Ospfv3PrefixOptions,
+    /// 32-bit field carrying the 16-bit OSPFv3 LS Type in the lower
+    /// half; upper 16 bits are reserved and emitted as zero. RFC 8362
+    /// shows this as a full 32-bit row even though the LS Type is
+    /// itself a 16-bit value — keeping the field as `u32` avoids
+    /// ambiguity about endianness or padding placement.
+    pub referenced_ls_type: u32,
+    pub referenced_link_state_id: u32,
+    pub referenced_advertising_router: Ipv4Addr,
+    pub address_prefix: Vec<u8>,
+    pub subs: Vec<Ospfv3SubTlv>,
+}
+
+impl Ospfv3IntraAreaPrefixTlv {
+    fn value_len(&self) -> usize {
+        // 2 + 1 + 1 + 4 + 4 + 4 = 16 fixed octets.
+        let prefix_wire = ospfv3_prefix_wire_len(self.prefix_length);
+        let sub_len: usize = self.subs.iter().map(|s| s.wire_len()).sum();
+        16 + prefix_wire + sub_len
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u16(self.metric);
+        buf.put_u8(self.prefix_length);
+        buf.put_u8(self.prefix_options.into_bits());
+        buf.put_u32(self.referenced_ls_type);
+        buf.put_u32(self.referenced_link_state_id);
+        buf.put(&self.referenced_advertising_router.octets()[..]);
+        let prefix_wire = ospfv3_prefix_wire_len(self.prefix_length);
+        // Caller is responsible for sizing `address_prefix` to the
+        // wire length implied by `prefix_length`. If shorter, pad
+        // with zeros; if longer, truncate -- both keep the on-wire
+        // shape valid even when the caller mis-sized the buffer.
+        let copy = self.address_prefix.len().min(prefix_wire);
+        buf.put_slice(&self.address_prefix[..copy]);
+        for _ in copy..prefix_wire {
+            buf.put_u8(0);
+        }
+        for s in &self.subs {
+            s.emit(buf);
+        }
+    }
+
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, metric) = be_u16(input)?;
+        let (input, prefix_length) = be_u8(input)?;
+        let (input, prefix_options_byte) = be_u8(input)?;
+        let (input, referenced_ls_type) = be_u32(input)?;
+        let (input, referenced_link_state_id) = be_u32(input)?;
+        let (input, referenced_advertising_router) = Ipv4Addr::parse_be(input)?;
+        let wire_len = ospfv3_prefix_wire_len(prefix_length);
+        let (input, prefix_bytes) = take(wire_len)(input)?;
+        let mut subs = Vec::new();
+        let mut rest = input;
+        while !rest.is_empty() {
+            let (r, s) = Ospfv3SubTlv::parse_be(rest)?;
+            subs.push(s);
+            rest = r;
+        }
+        Ok((
+            rest,
+            Self {
+                metric,
+                prefix_length,
+                prefix_options: Ospfv3PrefixOptions::from_bits(prefix_options_byte),
+                referenced_ls_type,
+                referenced_link_state_id,
+                referenced_advertising_router,
+                address_prefix: prefix_bytes.to_vec(),
+                subs,
+            },
+        ))
+    }
+}
+
 /// One top-level TLV inside an Extended LSA body (RFC 8362 §3).
 ///
 /// Typed variants surface the structured shape; everything else
@@ -1663,6 +1834,7 @@ impl Ospfv3RouterLinkTlv {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Ospfv3ExtTlv {
     RouterLink(Ospfv3RouterLinkTlv),
+    IntraAreaPrefix(Ospfv3IntraAreaPrefixTlv),
     Unknown { typ: u16, value: Vec<u8> },
 }
 
@@ -1673,6 +1845,7 @@ impl Ospfv3ExtTlv {
     fn wire_len(&self) -> usize {
         let value_len = match self {
             Ospfv3ExtTlv::RouterLink(t) => t.value_len(),
+            Ospfv3ExtTlv::IntraAreaPrefix(t) => t.value_len(),
             Ospfv3ExtTlv::Unknown { value, .. } => value.len(),
         };
         4 + ((value_len + 3) & !3)
@@ -1681,12 +1854,14 @@ impl Ospfv3ExtTlv {
     fn emit(&self, buf: &mut BytesMut) {
         let (typ, value_len) = match self {
             Ospfv3ExtTlv::RouterLink(t) => (OSPFV3_EXT_TLV_ROUTER_LINK, t.value_len()),
+            Ospfv3ExtTlv::IntraAreaPrefix(t) => (OSPFV3_EXT_TLV_INTRA_AREA_PREFIX, t.value_len()),
             Ospfv3ExtTlv::Unknown { typ, value } => (*typ, value.len()),
         };
         buf.put_u16(typ);
         buf.put_u16(value_len as u16);
         match self {
             Ospfv3ExtTlv::RouterLink(t) => t.emit(buf),
+            Ospfv3ExtTlv::IntraAreaPrefix(t) => t.emit(buf),
             Ospfv3ExtTlv::Unknown { value, .. } => buf.put_slice(value),
         }
         // Pad to 4-byte alignment.
@@ -1705,6 +1880,10 @@ impl Ospfv3ExtTlv {
             OSPFV3_EXT_TLV_ROUTER_LINK => {
                 let (_, t) = Ospfv3RouterLinkTlv::parse_be(value)?;
                 Ospfv3ExtTlv::RouterLink(t)
+            }
+            OSPFV3_EXT_TLV_INTRA_AREA_PREFIX => {
+                let (_, t) = Ospfv3IntraAreaPrefixTlv::parse_be(value)?;
+                Ospfv3ExtTlv::IntraAreaPrefix(t)
             }
             _ => Ospfv3ExtTlv::Unknown {
                 typ,
@@ -3378,6 +3557,80 @@ mod tests {
                 assert!(matches!(s.sid, SidLabelTlv::Label(15002)));
             }
             other => panic!("expected LanAdjSid, got {:?}", other),
+        }
+    }
+
+    /// Build an E-Intra-Area-Prefix-LSA body carrying one
+    /// Intra-Area-Prefix TLV whose sub-TLV is a Prefix-SID
+    /// (RFC 8666 §5) in Index form, emit through the LS-body
+    /// dispatch, parse back, and assert every nested value
+    /// survives byte-for-byte. Exercises both the new top-level
+    /// TLV shape and the new sub-TLV variant.
+    #[test]
+    fn ospfv3_e_intra_area_prefix_lsa_with_prefix_sid() {
+        use packet_utils::{Algo, SidLabelTlv};
+
+        use crate::parser::PrefixSidFlags;
+
+        let prefix_sid = Ospfv3SubTlv::PrefixSid(Ospfv3PrefixSidSubTlv {
+            flags: PrefixSidFlags::new().with_np_flag(true),
+            algo: Algo::Spf,
+            sid: SidLabelTlv::Index(200),
+        });
+
+        // /128 host prefix — 16-byte wire length.
+        let address_prefix = vec![
+            0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x01,
+        ];
+
+        let prefix_tlv = Ospfv3ExtTlv::IntraAreaPrefix(Ospfv3IntraAreaPrefixTlv {
+            metric: 10,
+            prefix_length: 128,
+            prefix_options: Ospfv3PrefixOptions::default(),
+            referenced_ls_type: OSPFV3_ROUTER_LSA_TYPE as u32,
+            referenced_link_state_id: 0,
+            referenced_advertising_router: Ipv4Addr::new(10, 0, 0, 1),
+            address_prefix: address_prefix.clone(),
+            subs: vec![prefix_sid],
+        });
+
+        let body = Ospfv3ELsaBody {
+            tlvs: vec![prefix_tlv],
+        };
+
+        let mut buf = BytesMut::new();
+        Ospfv3LsBody::EIntraAreaPrefix(body).emit(&mut buf);
+
+        let (rest, parsed) =
+            Ospfv3LsBody::parse_be(&buf, OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE).unwrap();
+        assert!(
+            rest.is_empty(),
+            "trailing bytes after E-Intra-Area-Prefix body"
+        );
+        let Ospfv3LsBody::EIntraAreaPrefix(parsed_body) = parsed else {
+            panic!("expected EIntraAreaPrefix variant");
+        };
+        assert_eq!(parsed_body.tlvs.len(), 1);
+        let Ospfv3ExtTlv::IntraAreaPrefix(parsed_tlv) = &parsed_body.tlvs[0] else {
+            panic!("expected IntraAreaPrefix top-level TLV");
+        };
+        assert_eq!(parsed_tlv.metric, 10);
+        assert_eq!(parsed_tlv.prefix_length, 128);
+        assert_eq!(parsed_tlv.referenced_ls_type, OSPFV3_ROUTER_LSA_TYPE as u32);
+        assert_eq!(
+            parsed_tlv.referenced_advertising_router,
+            Ipv4Addr::new(10, 0, 0, 1)
+        );
+        assert_eq!(parsed_tlv.address_prefix, address_prefix);
+        assert_eq!(parsed_tlv.subs.len(), 1);
+        match &parsed_tlv.subs[0] {
+            Ospfv3SubTlv::PrefixSid(s) => {
+                assert!(matches!(s.sid, SidLabelTlv::Index(200)));
+                assert!(s.flags.np_flag());
+                assert!(matches!(s.algo, Algo::Spf));
+            }
+            other => panic!("expected PrefixSid, got {:?}", other),
         }
     }
 

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -580,6 +580,23 @@ fn write_lsa_detail(
                 )?;
             }
         }
+        // RFC 8362 Extended LSAs — for now we only know the TLV
+        // count. Top-level TLV decoders (Router-Link, Intra-Area-Prefix,
+        // …) land in the SR-MPLS consumption follow-up; render a brief
+        // summary until then.
+        Ospfv3LsBody::ERouter(b)
+        | Ospfv3LsBody::ENetwork(b)
+        | Ospfv3LsBody::EInterAreaPrefix(b)
+        | Ospfv3LsBody::EInterAreaRouter(b)
+        | Ospfv3LsBody::EAsExternal(b)
+        | Ospfv3LsBody::ELink(b)
+        | Ospfv3LsBody::EIntraAreaPrefix(b) => {
+            writeln!(
+                out,
+                "  Extended LSA body, {} top-level TLV(s)",
+                b.tlvs.len()
+            )?;
+        }
         Ospfv3LsBody::Unknown(bytes) => {
             writeln!(out, "  (Unrecognized LSA body, {} bytes)", bytes.len())?;
         }


### PR DESCRIPTION
## Summary

Phase D PR-2b. Companion slice to #854: where #854 covered E-Router-LSA Adj-SID encoding, this PR covers E-Intra-Area-Prefix-LSA Prefix-SID encoding. With both merged, PR-D3 has typed shapes for the full SR-MPLS origination path — Prefix-SIDs on loopback prefixes and Adj-SIDs on each adjacency.

**Stacks on #854 (which stacks on #853). Review/merge #853 and #854 first.**

Two new wire types, parser-crate only:

- **\`Ospfv3PrefixSidSubTlv\`** (RFC 8666 §5, sub-TLV type 4) — flags(1) + algo(1) + reserved(2) + SID(3 or 4). Reuses \`PrefixSidFlags\` (NP / M / E / V / L) and \`Algo\` from the OSPFv2 codec; the bit assignments match RFC 8665 §4. The wire layout differs (no MT-ID, reserved bytes are 2 instead of 1) so the Rust shape is distinct from \`ExtPrefixSidSubTlv\`.
- **\`Ospfv3IntraAreaPrefixTlv\`** (RFC 8362 §3.7, top-level TLV type 6) — 16 octets of fixed prefix (metric + prefix-length + prefix-options + referenced LS Type/LSID/Adv Router) + the variable-length address-prefix block (padded to 4-byte boundary per RFC 5340 §A.4.1.1) + a sub-TLV stream where SR Prefix-SID lives per RFC 8666 §5.

  Unlike the standard \`Ospfv3IntraAreaPrefixLsa\` body (RFC 5340 §A.4.10), here each TLV represents exactly one prefix and carries its own referenced-LSA triple, so the body just sequences TLVs.

  \`referenced_ls_type\` is modeled as \`u32\` — RFC 8362 §3.7 shows the field spanning a full 32-bit row even though the OSPFv3 LS Type is logically 16 bits; the upper 16 bits are reserved and emitted as zero.

\`Ospfv3SubTlv\` and \`Ospfv3ExtTlv\` grow \`PrefixSid\` and \`IntraAreaPrefix\` variants respectively; the dispatchers route sub-TLV type 4 and top-level TLV type 6 there. Foreign types still round-trip through \`Unknown\`.

One new round-trip test builds an E-Intra-Area-Prefix-LSA carrying an Intra-Area-Prefix TLV with a Prefix-SID sub-TLV in Index form over a /128 host prefix, emits through the LS-body dispatch, parses back, and asserts every nested field survives.

## Test plan

- [x] \`cargo build\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p zebra-rs --bins\` — 610/610 passing
- [x] \`cargo test -p ospf-packet ospfv3_e\` — 4/4 passing (the three from D1/D2 + this PR's E-Intra-Area-Prefix-LSA with Prefix-SID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)