### PR TITLE
ospf-packet: scaffold v2 authentication header + RFC 2328 §D trailer

### DIFF
--- a/crates/ospf-packet/src/disp.rs
+++ b/crates/ospf-packet/src/disp.rs
@@ -31,7 +31,18 @@ impl Display for Ospfv2Packet {
 
 impl Display for Ospfv2Auth {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{:x}", self.auth)
+        match self {
+            Self::Null(b) | Self::Simple(b) => write!(
+                f,
+                "{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+                b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]
+            ),
+            Self::Crypto(c) => write!(
+                f,
+                "key-id={} digest-len={} seq={}",
+                c.key_id, c.auth_data_len, c.seq
+            ),
+        }
     }
 }
 

--- a/crates/ospf-packet/src/parser.rs
+++ b/crates/ospf-packet/src/parser.rs
@@ -8,7 +8,7 @@ use internet_checksum::Checksum;
 use ipnet::Ipv4Net;
 use nom::bytes::complete::take;
 use nom::error::{ErrorKind, make_error};
-use nom::number::complete::{be_u8, be_u24, be_u32, be_u64};
+use nom::number::complete::{be_u8, be_u24, be_u32};
 use nom::{Err, IResult, Needed};
 use nom_derive::*;
 use packet_utils::{Algo, SidLabelTlv};
@@ -32,6 +32,11 @@ pub struct Ospfv2Packet {
     pub auth: Ospfv2Auth,
     #[nom(Parse = "{ |x| Ospfv2Payload::parse_enum(x, typ) }")]
     pub payload: Ospfv2Payload,
+    /// RFC 2328 §D.4 / RFC 5709 cryptographic-auth digest. Lives
+    /// after the OSPF body and is excluded from `len`. Populated by
+    /// `parse()` when `auth_type == 2`; empty otherwise.
+    #[nom(Ignore)]
+    pub auth_trailer: Vec<u8>,
 }
 
 impl Ospfv2Packet {
@@ -46,6 +51,7 @@ impl Ospfv2Packet {
             auth_type: 0,
             auth: Ospfv2Auth::default(),
             payload,
+            auth_trailer: Vec::new(),
         }
     }
 
@@ -67,7 +73,10 @@ impl Ospfv2Packet {
             LsAck(v) => v.emit(buf),
             _ => {}
         }
-        // OSPF packet length.
+        // OSPF packet length — header + body, RFC 2328 §A.3.1.
+        // RFC 2328 §D.4: the cryptographic-auth digest follows the
+        // body but is not counted in this length, so finalize the
+        // length and checksum before appending the trailer.
         let len = buf.len() as u16;
         BigEndian::write_u16(&mut buf[2..4], len);
 
@@ -76,27 +85,78 @@ impl Ospfv2Packet {
         let mut cksum = Checksum::new();
         cksum.add_bytes(buf);
         buf[CHECKSUM_RANGE].copy_from_slice(&cksum.checksum());
+
+        if !self.auth_trailer.is_empty() {
+            buf.put(&self.auth_trailer[..]);
+        }
     }
 }
 
-#[derive(Debug, Default)]
-pub struct Ospfv2Auth {
-    pub auth: u64,
+/// OSPFv2 header authentication field (8 octets), shape determined
+/// by the preceding `auth_type` (RFC 2328 Appendix D):
+/// - 0 Null — bytes are undefined; preserved for round-trip.
+/// - 1 Simple — ASCII password, zero-padded to 8 bytes.
+/// - 2 Crypto — 8-byte overlay with key-id / digest-length / seq;
+///   the digest itself follows the OSPF body as a trailer
+///   (`Ospfv2Packet::auth_trailer`).
+#[derive(Debug, Clone)]
+pub enum Ospfv2Auth {
+    Null([u8; 8]),
+    Simple([u8; 8]),
+    Crypto(Ospfv2AuthCrypto),
+}
+
+impl Default for Ospfv2Auth {
+    fn default() -> Self {
+        Self::Null([0; 8])
+    }
+}
+
+/// RFC 2328 §D.3 cryptographic-auth header overlay (8 octets):
+/// `0x0000` reserved | key_id (8b) | auth_data_len (8b) | seq (32b).
+#[derive(Debug, Clone, Default)]
+pub struct Ospfv2AuthCrypto {
+    pub key_id: u8,
+    pub auth_data_len: u8,
+    pub seq: u32,
 }
 
 impl Ospfv2Auth {
     pub fn parse_be(input: &[u8], auth_type: u16) -> IResult<&[u8], Self> {
-        if auth_type != 0 {
-            return Err(Err::Error(make_error(input, ErrorKind::Tag)));
+        let (rest, raw) = take(8usize)(input)?;
+        let bytes: [u8; 8] = raw.try_into().unwrap();
+        match auth_type {
+            0 => Ok((rest, Self::Null(bytes))),
+            1 => Ok((rest, Self::Simple(bytes))),
+            2 => {
+                let key_id = bytes[2];
+                let auth_data_len = bytes[3];
+                let seq = u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+                Ok((
+                    rest,
+                    Self::Crypto(Ospfv2AuthCrypto {
+                        key_id,
+                        auth_data_len,
+                        seq,
+                    }),
+                ))
+            }
+            _ => Err(Err::Error(make_error(input, ErrorKind::Tag))),
         }
-        let (input, auth) = be_u64(input)?;
-        Ok((input, Self { auth }))
     }
 }
 
 impl Emit for Ospfv2Auth {
     fn emit(&self, buf: &mut BytesMut) {
-        buf.put_u64(self.auth);
+        match self {
+            Self::Null(b) | Self::Simple(b) => buf.put(&b[..]),
+            Self::Crypto(c) => {
+                buf.put_u16(0);
+                buf.put_u8(c.key_id);
+                buf.put_u8(c.auth_data_len);
+                buf.put_u32(c.seq);
+            }
+        }
     }
 }
 
@@ -1884,7 +1944,130 @@ pub fn validate_checksum(input: &[u8]) -> IResult<&[u8], ()> {
 }
 
 pub fn parse(input: &[u8]) -> IResult<&[u8], Ospfv2Packet> {
-    // validate_checksum(input)?;
-    let (input, packet) = Ospfv2Packet::parse_be(input)?;
-    Ok((input, packet))
+    // Header checksum is validated by the caller (see
+    // `zebra-rs/src/ospf/network.rs::read_packet`). Re-running it
+    // here would double-cost every packet.
+    const HEADER_LEN: usize = 24;
+    const LEN_RANGE: std::ops::Range<usize> = 2..4;
+    if input.len() < HEADER_LEN {
+        return Err(Err::Error(make_error(input, ErrorKind::Verify)));
+    }
+    let pkt_len = BigEndian::read_u16(&input[LEN_RANGE]) as usize;
+    if pkt_len < HEADER_LEN || input.len() < pkt_len {
+        return Err(Err::Error(make_error(input, ErrorKind::Verify)));
+    }
+    let (_, mut packet) = Ospfv2Packet::parse_be(&input[..pkt_len])?;
+
+    // RFC 2328 §D.4: a cryptographic-auth (type 2) packet carries
+    // the digest as a trailer after the OSPF body; `auth_data_len`
+    // in the header overlay says how many bytes to consume.
+    let mut consumed = pkt_len;
+    if let Ospfv2Auth::Crypto(ref c) = packet.auth {
+        let trailer_len = c.auth_data_len as usize;
+        let trailer_end = pkt_len + trailer_len;
+        if input.len() < trailer_end {
+            return Err(Err::Error(make_error(input, ErrorKind::Verify)));
+        }
+        packet.auth_trailer = input[pkt_len..trailer_end].to_vec();
+        consumed = trailer_end;
+    }
+    Ok((&input[consumed..], packet))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn null_hello_packet() -> Ospfv2Packet {
+        let hello = OspfHello {
+            netmask: Ipv4Addr::new(255, 255, 255, 0),
+            hello_interval: 10,
+            options: OspfOptions(0).with_external(true),
+            priority: 1,
+            router_dead_interval: 40,
+            d_router: Ipv4Addr::UNSPECIFIED,
+            bd_router: Ipv4Addr::UNSPECIFIED,
+            neighbors: Vec::new(),
+        };
+        Ospfv2Packet::new(
+            &Ipv4Addr::new(1, 1, 1, 1),
+            &Ipv4Addr::new(0, 0, 0, 0),
+            Ospfv2Payload::Hello(hello),
+        )
+    }
+
+    #[test]
+    fn null_auth_roundtrip() {
+        let pkt = null_hello_packet();
+        let mut buf = BytesMut::new();
+        pkt.emit(&mut buf);
+        validate_checksum(&buf).expect("emitted checksum must verify");
+        let (rest, parsed) = parse(&buf).expect("parse must succeed");
+        assert!(rest.is_empty());
+        assert_eq!(parsed.auth_type, 0);
+        assert!(matches!(parsed.auth, Ospfv2Auth::Null(_)));
+        assert!(parsed.auth_trailer.is_empty());
+    }
+
+    #[test]
+    fn simple_password_parses_bytes() {
+        let mut pkt = null_hello_packet();
+        pkt.auth_type = 1;
+        pkt.auth = Ospfv2Auth::Simple(*b"secret\0\0");
+        let mut buf = BytesMut::new();
+        pkt.emit(&mut buf);
+        let (_, parsed) = parse(&buf).expect("parse must succeed");
+        match parsed.auth {
+            Ospfv2Auth::Simple(b) => assert_eq!(&b, b"secret\0\0"),
+            other => panic!("expected Simple, got {:?}", other),
+        }
+        assert!(parsed.auth_trailer.is_empty());
+    }
+
+    #[test]
+    fn crypto_auth_consumes_trailer() {
+        let mut pkt = null_hello_packet();
+        pkt.auth_type = 2;
+        pkt.auth = Ospfv2Auth::Crypto(Ospfv2AuthCrypto {
+            key_id: 7,
+            auth_data_len: 16,
+            seq: 0x1234_5678,
+        });
+        pkt.auth_trailer = vec![0xAB; 16];
+        let mut buf = BytesMut::new();
+        pkt.emit(&mut buf);
+
+        // The header `len` covers header+body only, trailer follows.
+        let hdr_len = BigEndian::read_u16(&buf[2..4]) as usize;
+        assert_eq!(hdr_len + 16, buf.len());
+
+        let (rest, parsed) = parse(&buf).expect("parse must succeed");
+        assert!(rest.is_empty());
+        match parsed.auth {
+            Ospfv2Auth::Crypto(c) => {
+                assert_eq!(c.key_id, 7);
+                assert_eq!(c.auth_data_len, 16);
+                assert_eq!(c.seq, 0x1234_5678);
+            }
+            other => panic!("expected Crypto, got {:?}", other),
+        }
+        assert_eq!(parsed.auth_trailer, vec![0xAB; 16]);
+    }
+
+    #[test]
+    fn parse_rejects_short_input() {
+        let buf = [0u8; 10];
+        assert!(parse(&buf).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_bogus_length() {
+        let pkt = null_hello_packet();
+        let mut buf = BytesMut::new();
+        pkt.emit(&mut buf);
+        // Lie about length — claim more than the buffer holds.
+        let bogus = (buf.len() + 1) as u16;
+        BigEndian::write_u16(&mut buf[2..4], bogus);
+        assert!(parse(&buf).is_err());
+    }
 }

--- a/rfc/ospf/rfc4552.txt
+++ b/rfc/ospf/rfc4552.txt
@@ -1,0 +1,843 @@
+
+
+
+
+
+
+Network Working Group                                           M. Gupta
+Request for Comments: 4552                               Tropos Networks
+Category: Standards Track                                       N. Melam
+                                                        Juniper Networks
+                                                               June 2006
+
+
+               Authentication/Confidentiality for OSPFv3
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2006).
+
+Abstract
+
+   This document describes means and mechanisms to provide
+   authentication/confidentiality to OSPFv3 using an IPv6 Authentication
+   Header/Encapsulating Security Payload (AH/ESP) extension header.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Gupta & Melam               Standards Track                     [Page 1]
+
+RFC 4552       Authentication/Confidentiality for OSPFv3       June 2006
+
+
+Table of Contents
+
+   1. Introduction ....................................................2
+      1.1. Conventions Used in This Document ..........................2
+   2. Transport Mode vs. Tunnel Mode ..................................3
+   3. Authentication ..................................................3
+   4. Confidentiality .................................................3
+   5. Distinguishing OSPFv3 from OSPFv2 ...............................4
+   6. IPsec Requirements ..............................................4
+   7. Key Management ..................................................5
+   8. SA Granularity and Selectors ....................................7
+   9. Virtual Links ...................................................8
+   10. Rekeying .......................................................9
+      10.1. Rekeying Procedure ........................................9
+      10.2. KeyRolloverInterval .......................................9
+      10.3. Rekeying Interval ........................................10
+   11. IPsec Protection Barrier and SPD ..............................10
+   12. Entropy of Manual Keys ........................................12
+   13. Replay Protection .............................................12
+   14. Security Considerations .......................................12
+   15. References ....................................................13
+      15.1. Normative References .....................................13
+      15.2. Informative References ...................................13
+
+1.  Introduction
+
+   OSPF (Open Shortest Path First) Version 2 [N1] defines the fields
+   AuType and Authentication in its protocol header to provide security.
+   In OSPF for IPv6 (OSPFv3) [N2], both of the authentication fields
+   were removed from OSPF headers.  OSPFv3 relies on the IPv6
+   Authentication Header (AH) and IPv6 Encapsulating Security Payload
+   (ESP) to provide integrity, authentication, and/or confidentiality.
+
+   This document describes how IPv6 AH/ESP extension headers can be used
+   to provide authentication/confidentiality to OSPFv3.
+
+   It is assumed that the reader is familiar with OSPFv3 [N2], AH [N5],
+   ESP [N4], the concept of security associations, tunnel and transport
+   mode of IPsec, and the key management options available for AH and
+   ESP (manual keying [N3] and Internet Key Exchange (IKE)[I1]).
+
+1.1.  Conventions Used in This Document
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [N7].
+
+
+
+
+
+Gupta & Melam               Standards Track                     [Page 2]
+
+RFC 4552       Authentication/Confidentiality for OSPFv3       June 2006
+
+
+2.  Transport Mode vs. Tunnel Mode
+
+   The transport mode Security Association (SA) is generally used
+   between two hosts or routers/gateways when they are acting as hosts.
+   The SA must be a tunnel mode SA if either end of the security
+   association is a router/gateway.  Two hosts MAY establish a tunnel
+   mode SA between themselves.  OSPFv3 packets are exchanged between
+   routers.  However, since the packets are locally delivered, the
+   routers assume the role of hosts in the context of tunnel mode SA.
+   All implementations conforming to this specification MUST support
+   transport mode SA to provide required IPsec security to OSPFv3
+   packets.  They MAY also support tunnel mode SA to provide required
+   IPsec security to OSPFv3 packets.
+
+3.  Authentication
+
+   Implementations conforming to this specification MUST support
+   authentication for OSPFv3.
+
+   In order to provide authentication to OSPFv3, implementations MUST
+   support ESP and MAY support AH.
+
+   If ESP in transport mode is used, it will only provide authentication
+   to OSPFv3 protocol packets excluding the IPv6 header, extension
+   headers, and options.
+
+   If AH in transport mode is used, it will provide authentication to
+   OSPFv3 protocol packets, selected portions of IPv6 header, selected
+   portions of extension headers, and selected options.
+
+   When OSPFv3 authentication is enabled,
+
+      o  OSPFv3 packets that are not protected with AH or ESP MUST be
+         silently discarded.
+
+      o  OSPFv3 packets that fail the authentication checks MUST be
+         silently discarded.
+
+4.  Confidentiality
+
+   Implementations conforming to this specification SHOULD support
+   confidentiality for OSPFv3.
+
+   If confidentiality is provided, ESP MUST be used.
+
+
+
+
+
+
+
+Gupta & Melam               Standards Track                     [Page 3]
+
+RFC 4552       Authentication/Confidentiality for OSPFv3       June 2006
+
+
+   When OSPFv3 confidentiality is enabled,
+
+      o  OSPFv3 packets that are not protected with ESP MUST be silently
+         discarded.
+
+      o  OSPFv3 packets that fail the confidentiality checks MUST be
+         silently discarded.
+
+5.  Distinguishing OSPFv3 from OSPFv2
+
+   The IP/IPv6 Protocol Type for OSPFv2 and OSPFv3 is the same (89), and
+   OSPF distinguishes them based on the OSPF header version number.
+   However, current IPsec standards do not allow using arbitrary
+   protocol-specific header fields as the selectors.  Therefore, the
+   OSPF version field in the OSPF header cannot be used to distinguish
+   OSPFv3 packets from OSPFv2 packets.  As OSPFv2 is only for IPv4 and
+   OSPFv3 is only for IPv6, the version field in the IP header can be
+   used to distinguish OSPFv3 packets from OSPFv2 packets.
+
+6.  IPsec Requirements
+
+   In order to implement this specification, the following IPsec
+   capabilities are required.
+
+   Transport mode
+      IPsec in transport mode MUST be supported. [N3]
+
+   Multiple Security Policy Databases (SPDs)
+      The implementation MUST support multiple SPDs with an SPD
+      selection function that provides an ability to choose a specific
+      SPD based on interface. [N3]
+
+   Selectors
+      The implementation MUST be able to use source address, destination
+      address, protocol, and direction as selectors in the SPD.
+
+   Interface ID tagging
+      The implementation MUST be able to tag the inbound packets with
+      the ID of the interface (physical or virtual) via which it
+      arrived. [N3]
+
+   Manual key support
+      Manually configured keys MUST be able to secure the specified
+      traffic. [N3]
+
+
+
+
+
+
+
+Gupta & Melam               Standards Track                     [Page 4]
+
+RFC 4552       Authentication/Confidentiality for OSPFv3       June 2006
+
+
+   Encryption and authentication algorithms
+      The implementation MUST NOT allow the user to choose stream
+      ciphers as the encryption algorithm for securing OSPFv3 packets
+      since the stream ciphers are not suitable for manual keys.
+
+      Except when in conflict with the above statement, the key words
+      "MUST", "MUST NOT", "REQUIRED", "SHOULD", and "SHOULD NOT" that
+      appear in the [N6] document for algorithms to be supported are to
+      be interpreted as described in [N7] for OSPFv3 support as well.
+
+   Dynamic IPsec rule configuration
+      The routing module SHOULD be able to configure, modify, and delete
+      IPsec rules on the fly.  This is needed mainly for securing
+      virtual links.
+
+   Encapsulation of ESP packet
+      IP encapsulation of ESP packets MUST be supported.  For
+      simplicity, UDP encapsulation of ESP packets SHOULD NOT be used.
+
+   Different SAs for different Differentiated Services Code Points
+      (DSCPs)
+      As per [N3], the IPsec implementation MUST support the
+      establishment and maintenance of multiple SAs with the same
+      selectors between a given sender and receiver.  This allows the
+      implementation to associate different classes of traffic with the
+      same selector values in support of Quality of Service (QoS).
+
+7.  Key Management
+
+   OSPFv3 exchanges both multicast and unicast packets.  While running
+   OSPFv3 over a broadcast interface, the authentication/confidentiality
+   required is "one to many".  Since IKE is based on the Diffie-Hellman
+   key agreement protocol and works only for two communicating parties,
+   it is not possible to use IKE for providing the required "one to
+   many" authentication/confidentiality.  This specification mandates
+   the usage of Manual Keying with current IPsec implementations.
+   Future specifications can explore the usage of protocols like
+   Kerberized Internet Negotiation of Keys/Group Secure Association Key
+   Management Protocol (KINK/GSAKMP) when they are widely available.  In
+   manual keying, SAs are statically installed on the routers and these
+   static SAs are used to authenticate/encrypt packets.
+
+   The following discussion explains that it is not scalable and is
+   practically infeasible to use different security associations for
+   inbound and outbound traffic to provide the required "one to many"
+   security.  Therefore, the implementations MUST use manually
+
+
+
+
+
+Gupta & Melam               Standards Track                     [Page 5]
+
+RFC 4552       Authentication/Confidentiality for OSPFv3       June 2006
+
+
+   configured keys with the same SA parameters (Security Parameter Index
+   (SPI), keys, etc.) for both inbound and outbound SAs (as shown in
+   Figure 3).
+
+          A                  |
+        SAa     ------------>|
+        SAb     <------------|
+                             |
+          B                  |
+        SAb     ------------>|
+        SAa     <------------|                 Figure 1
+                             |
+          C                  |
+        SAa/SAb ------------>|
+        SAa/SAb <------------|
+                             |
+                         Broadcast
+                          Network
+
+   If we consider communication between A and B in Figure 1, everything
+   seems to be fine.  A uses security association SAa for outbound
+   packets and B uses the same for inbound packets and vice versa.  Now
+   if we include C in the group and C sends a packet using SAa, then
+   only A will be able to understand it.  Similarly, if C sends a packet
+   using SAb, then only B will be able to understand it.  Since the
+   packets are multicast and they are going to be processed by both A
+   and B, there is no SA for C to use so that both A and B can
+   understand them.
+
+          A                  |
+        SAa     ------------>|
+        SAb     <------------|
+        SAc     <------------|
+                             |
+          B                  |
+        SAb     ------------>|
+        SAa     <------------|                 Figure 2
+        SAc     <------------|
+                             |
+          C                  |
+        SAc     ------------>|
+        SAa     <------------|
+        SAb     <------------|
+                             |
+                         Broadcast
+                          Network
+
+
+
+
+
+Gupta & Melam               Standards Track                     [Page 6]
+
+RFC 4552       Authentication/Confidentiality for OSPFv3       June 2006
+
+
+   The problem can be solved by configuring SAs for all the nodes on
+   every other node as shown in Figure 2.  So A, B, and C will use SAa,
+   SAb, and SAc, respectively, for outbound traffic.  Each node will
+   lookup the SA to be used based on the source (A will use SAb and SAc
+   for packets received from B and C, respectively).  This solution is
+   not scalable and practically infeasible because a large number of SAs
+   will need to be configured on each node.  Also, the addition of a
+   node in the broadcast network will require the addition of another SA
+   on every other node.
+
+         A                   |
+        SAo     ------------>|
+        SAi     <------------|
+                             |
+         B                   |
+        SAo     ------------>|
+        SAi     <------------|                 Figure 3
+                             |
+         C                   |
+        SAo     ------------>|
+        SAi     <------------|
+                             |
+                         Broadcast
+                          Network
+
+   The problem can be solved by using the same SA parameters (SPI, keys,
+   etc.) for both inbound (SAi) and outbound (SAo) SAs as shown in
+   Figure 3.
+
+8.  SA Granularity and Selectors
+
+   The user SHOULD be given the choice of sharing the same SA among
+   multiple interfaces or using a unique SA per interface.
+
+   OSPFv3 supports running multiple instances over one interface using
+   the "Instance Id" field contained in the OSPFv3 header.  As IPsec
+   does not support arbitrary fields in the protocol header to be used
+   as the selectors, it is not possible to use different SAs for
+   different OSPFv3 instances running over the same interface.
+   Therefore, all OSPFv3 instances running over the same interface will
+   have to use the same SA.  In OSPFv3 RFC terminology, SAs are per-link
+   and not per-interface.
+
+
+
+
+
+
+
+
+
+Gupta & Melam               Standards Track                     [Page 7]
+
+RFC 4552       Authentication/Confidentiality for OSPFv3       June 2006
+
+
+9.  Virtual Links
+
+   A different SA than the SA of the underlying interface MUST be
+   provided for virtual links.  Packets sent on virtual links use
+   unicast non-link local IPv6 addresses as the IPv6 source address,
+   while packets sent on other interfaces use multicast and unicast link
+   local addresses.  This difference in the IPv6 source address
+   differentiates the packets sent on virtual links from other OSPFv3
+   interface types.
+
+   As the virtual link end point IPv6 addresses are not known, it is not
+   possible to install SPD/Security Association Database (SAD) entries
+   at the time of configuration.  The virtual link end point IPv6
+   addresses are learned during the routing table computation process.
+   The packet exchange over the virtual links starts only after the
+   discovery of the end point IPv6 addresses.  In order to protect these
+   exchanges, the routing module must install the corresponding SPD/SAD
+   entries before starting these exchanges.  Note that manual SA
+   parameters are preconfigured but not installed in the SAD until the
+   end point addresses are learned.
+
+   According to the OSPFv3 RFC [N2], the virtual neighbor's IP address
+   is set to the first prefix with the "LA-bit" set from the list of
+   prefixes in intra-area-prefix-Link State Advertisements (LSAs)
+   originated by the virtual neighbor.  But when it comes to choosing
+   the source address for the packets that are sent over the virtual
+   link, the RFC [N2] simply suggests using one of the router's own
+   global IPv6 addresses.  In order to install the required security
+   rules for virtual links, the source address also needs to be
+   predictable.  Hence, routers that implement this specification MUST
+   change the way the source and destination addresses are chosen for
+   packets exchanged over virtual links when IPsec is enabled.
+
+   The first IPv6 address with the "LA-bit" set in the list of prefixes
+   advertised in intra-area-prefix-LSAs in the transit area MUST be used
+   as the source address for packets exchanged over the virtual link.
+   When multiple intra-area-prefix-LSAs are originated, they are
+   considered concatenated and are ordered by ascending Link State ID.
+
+   The first IPv6 address with the "LA-bit" set in the list of prefixes
+   received in intra-area-prefix-LSAs from the virtual neighbor in the
+   transit area MUST be used as the destination address for packets
+   exchanged over the virtual link.  When multiple intra-area-prefix-
+   LSAs are received, they are considered concatenated and are ordered
+   by ascending Link State ID.
+
+   This makes both the source and destination addresses of packets
+   exchanged over the virtual link predictable when IPsec is enabled.
+
+
+
+Gupta & Melam               Standards Track                     [Page 8]
+
+RFC 4552       Authentication/Confidentiality for OSPFv3       June 2006
+
+
+10.  Rekeying
+
+   To maintain the security of a link, the authentication and encryption
+   key values SHOULD be changed periodically.
+
+10.1.  Rekeying Procedure
+
+   The following three-step procedure SHOULD be provided to rekey the
+   routers on a link without dropping OSPFv3 protocol packets or
+   disrupting the adjacency.
+
+   (1) For every router on the link, create an additional inbound SA for
+       the interface being rekeyed using a new SPI and the new key.
+
+   (2) For every router on the link, replace the original outbound SA
+       with one using the new SPI and key values.  The SA replacement
+       operation should be atomic with respect to sending OSPFv3 packets
+       on the link so that no OSPFv3 packets are sent without
+       authentication/encryption.
+
+   (3) For every router on the link, remove the original inbound SA.
+
+   Note that all routers on the link must complete step 1 before any
+   begin step 2.  Likewise, all the routers on the link must complete
+   step 2 before any begin step 3.
+
+   One way to control the progression from one step to the next is for
+   each router to have a configurable time constant KeyRolloverInterval.
+   After the router begins step 1 on a given link, it waits for this
+   interval and then moves to step 2.  Likewise, after moving to step 2,
+   it waits for this interval and then moves to step 3.
+
+   In order to achieve smooth key transition, all routers on a link
+   should use the same value for KeyRolloverInterval and should initiate
+   the key rollover process within this time period.
+
+   At the end of this procedure, all the routers on the link will have a
+   single inbound and outbound SA for OSPFv3 with the new SPI and key
+   values.
+
+10.2.  KeyRolloverInterval
+
+   The configured value of KeyRolloverInterval should be long enough to
+   allow the administrator to change keys on all the OSPFv3 routers.  As
+   this value can vary significantly depending upon the implementation
+   and the deployment, it is left to the administrator to choose an
+   appropriate value.
+
+
+
+
+Gupta & Melam               Standards Track                     [Page 9]
+
+RFC 4552       Authentication/Confidentiality for OSPFv3       June 2006
+
+
+10.3.  Rekeying Interval
+
+   This section analyzes the security provided by manual keying and
+   recommends that the encryption and authentication keys SHOULD be
+   changed at least every 90 days.
+
+   The weakest security provided by the security mechanisms discussed in
+   this specification is when NULL encryption (for ESP) or no encryption
+   (for AH) is used with the HMAC-MD5 authentication.  Any other
+   algorithm combinations will at least be as hard to break as the ones
+   mentioned above.  This is shown by the following reasonable
+   assumptions:
+
+      o  NULL Encryption and HMAC-SHA-1 Authentication will be more
+         secure as HMAC-SHA-1 is considered to be more secure than
+         HMAC-MD5.
+
+      o  NON-NULL Encryption and NULL Authentication combination is not
+         applicable as this specification mandates authentication when
+         OSPFv3 security is enabled.
+
+      o  Data Encryption Security (DES) Encryption and HMAC-MD5
+         Authentication will be more secure because of the additional
+         security provided by DES.
+
+      o  Other encryption algorithms like 3DES and the Advanced
+         Encryption Standard (AES) will be more secure than DES.
+
+   RFC 3562 [I4] analyzes the rekeying requirements for the TCP MD5
+   signature option.  The analysis provided in RFC 3562 is also
+   applicable to this specification as the analysis is independent of
+   data patterns.
+
+11.  IPsec Protection Barrier and SPD
+
+   The IPsec protection barrier MUST be around the OSPF protocol.
+   Therefore, all the inbound and outbound OSPF traffic goes through
+   IPsec processing.
+
+   The SPD selection function MUST return an SPD with the following rule
+   for all the interfaces that have OSPFv3
+   authentication/confidentiality disabled.
+
+      No.  source       destination       protocol        action
+      1     any            any              OSPF          bypass
+
+
+
+
+
+
+Gupta & Melam               Standards Track                    [Page 10]
+
+RFC 4552       Authentication/Confidentiality for OSPFv3       June 2006
+
+
+   The SPD selection function MUST return an SPD with the following
+   rules for all the interfaces that have OSPFv3
+   authentication/confidentiality enabled.
+
+      No.  source       destination       protocol        action
+      2   fe80::/10        any             OSPF           protect
+      3   fe80::/10        any       ESP/OSPF or AH/OSPF  protect
+      4   src/128        dst/128           OSPF           protect
+      5   src/128        dst/128     ESP/OSPF or AH/OSPF  protect
+
+   For rules 2 and 4, action "protect" means encrypting/calculating
+   Integrity Check Value (ICV) and adding an ESP or AH header.  For
+   rules 3 and 5, action "protect" means decrypting/authenticating the
+   packets and stripping the ESP or AH header.
+
+   Rule 1 will bypass the OSPFv3 packets without any IPsec processing on
+   the interfaces that have OSPFv3 authentication/confidentiality
+   disabled.
+
+   Rules 2 and 4 will drop the inbound OSPFv3 packets that have not been
+   secured with ESP/AH headers.
+
+   ESP/OSPF or AH/OSPF in rules 3 and 5 mean that it is an OSPF packet
+   secured with ESP or AH.
+
+   Rules 2 and 3 are meant to secure the unicast and multicast OSPF
+   packets that are not being exchanged over the virtual links.
+
+   Rules 4 and 5 are meant to secure the packets being exchanged over
+   virtual links.  These rules are installed after learning the virtual
+   link end point IPv6 addresses.  These rules MUST be installed in the
+   SPD for the interfaces that are connected to the transit area for the
+   virtual link.  These rules MAY alternatively be installed on all the
+   interfaces.  If these rules are not installed on all the interfaces,
+   clear text or malicious OSPFv3 packets with the same source and
+   destination addresses as the virtual link end point IPv6 addresses
+   will be delivered to OSPFv3.  Though OSPFv3 drops these packets as
+   they were not received on the right interface, OSPFv3 receives some
+   clear text or malicious packets even when the security is enabled.
+   Installing these rules on all the interfaces ensures that OSPFv3 does
+   not receive these clear text or malicious packets when security is
+   enabled.  On the other hand, installing these rules on all the
+   interfaces increases the processing overhead on the interfaces where
+   there is no other IPsec processing.  The decision of whether to
+   install these rules on all the interfaces or on just the interfaces
+   that are connected to the transit area is a private decision and
+   doesn't affect the interoperability in any way.  Hence it is an
+   implementation choice.
+
+
+
+Gupta & Melam               Standards Track                    [Page 11]
+
+RFC 4552       Authentication/Confidentiality for OSPFv3       June 2006
+
+
+12.  Entropy of Manual Keys
+
+   The implementations MUST allow the administrator to configure the
+   cryptographic and authentication keys in hexadecimal format rather
+   than restricting it to a subset of ASCII characters (letters,
+   numbers, etc.).  A restricted character set will reduce key entropy
+   significantly as discussed in [I2].
+
+13.  Replay Protection
+
+   Since it is not possible using the current standards to provide
+   complete replay protection while using manual keying, the proposed
+   solution will not provide protection against replay attacks.
+
+   Detailed analysis of various vulnerabilities of the routing protocols
+   and OSPF in particular is discussed in [I3] and [I2].  The conclusion
+   is that replay of OSPF packets can cause adjacencies to be disrupted,
+   which can lead to a DoS attack on the network.  It can also cause
+   database exchange process to occur continuously thus causing CPU
+   overload as well as micro loops in the network.
+
+14.  Security Considerations
+
+   This memo discusses the use of IPsec AH and ESP headers to provide
+   security to OSPFv3 for IPv6.  Hence, security permeates throughout
+   this document.
+
+   OSPF Security Vulnerabilities Analysis [I2] identifies OSPF
+   vulnerabilities in two scenarios -- one with no authentication or
+   simple password authentication and the other with cryptographic
+   authentication.  The solution described in this specification
+   provides protection against all the vulnerabilities identified for
+   scenarios with cryptographic authentication with the following
+   exceptions:
+
+   Limitations of manual key:
+
+   This specification mandates the usage of manual keys.  The following
+   are the known limitations of the usage of manual keys.
+
+      o  As the sequence numbers cannot be negotiated, replay protection
+         cannot be provided.  This leaves OSPF insecure against all the
+         attacks that can be performed by replaying OSPF packets.
+
+      o  Manual keys are usually long lived (changing them often is a
+         tedious task).  This gives an attacker enough time to discover
+         the keys.
+
+
+
+
+Gupta & Melam               Standards Track                    [Page 12]
+
+RFC 4552       Authentication/Confidentiality for OSPFv3       June 2006
+
+
+      o  As the administrator is manually configuring the keys, there is
+         a chance that the configured keys are weak (there are known
+         weak keys for DES/3DES at least).
+
+   Impersonating attacks:
+
+   The usage of the same key on all the OSPF routers connected to a link
+   leaves them all insecure against impersonating attacks if any one of
+   the OSPF routers is compromised, malfunctioning, or misconfigured.
+
+   Detailed analysis of various vulnerabilities of routing protocols is
+   discussed in [I3].
+
+15.  References
+
+15.1.  Normative References
+
+   [N1] Moy, J., "OSPF Version 2", STD 54, RFC 2328, April 1998.
+
+   [N2] Coltun, R., Ferguson, D., and J. Moy, "OSPF for IPv6", RFC 2740,
+        December 1999.
+
+   [N3] Kent, S. and K. Seo, "Security Architecture for the Internet
+        Protocol", RFC 4301, December 2005.
+
+   [N4] Kent, S., "IP Encapsulating Security Payload (ESP)", RFC 4303,
+        December 2005.
+
+   [N5] Kent, S., "IP Authentication Header", RFC 4302, December 2005.
+
+   [N6] Eastlake 3rd, D., "Cryptographic Algorithm Implementation
+        Requirements for Encapsulating Security Payload (ESP) and
+        Authentication Header (AH)", RFC 4305, December 2005.
+
+   [N7] Bradner, S., "Key words for use in RFCs to Indicate Requirement
+        Levels", BCP 14, RFC 2119, March 1997.
+
+15.2.  Informative References
+
+   [I1] Kaufman, C., "Internet Key Exchange (IKEv2) Protocol", RFC 4306,
+        December 2005.
+
+   [I2] Jones, E. and O. Moigne, "OSPF Security Vulnerabilities
+        Analysis", Work in Progress.
+
+   [I3] Barbir, A., Murphy, S., and Y. Yang, "Generic Threats to Routing
+        Protocols", Work in Progress.
+
+
+
+
+Gupta & Melam               Standards Track                    [Page 13]
+
+RFC 4552       Authentication/Confidentiality for OSPFv3       June 2006
+
+
+   [I4] Leech, M., "Key Management Considerations for the TCP MD5
+        Signature Option", RFC 3562, July 2003.
+
+Acknowledgements
+
+   The authors would like to extend sincere thanks to Marc Solsona,
+   Janne Peltonen, John Cruz, Dhaval Shah, Abhay Roy, Paul Wells,
+   Vishwas Manral, and Sam Hartman for providing useful information and
+   critiques on this memo.  The authors would like to extend special
+   thanks to Acee Lindem for many editorial changes.
+
+   We would also like to thank members of the IPsec and OSPF WG for
+   providing valuable review comments.
+
+Authors' Addresses
+
+   Mukesh Gupta
+   Tropos Networks
+   555 Del Rey Ave
+   Sunnyvale, CA 94085
+
+   Phone: 408-331-6889
+   EMail: mukesh.gupta@tropos.com
+
+
+   Nagavenkata Suresh Melam
+   Juniper Networks
+   1194 N. Mathilda Ave
+   Sunnyvale, CA 94089
+
+   Phone: 408-505-4392
+   EMail: nmelam@juniper.net
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Gupta & Melam               Standards Track                    [Page 14]
+
+RFC 4552       Authentication/Confidentiality for OSPFv3       June 2006
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2006).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is provided by the IETF
+   Administrative Support Activity (IASA).
+
+
+
+
+
+
+
+Gupta & Melam               Standards Track                    [Page 15]
+

--- a/rfc/ospf/rfc5709.txt
+++ b/rfc/ospf/rfc5709.txt
@@ -1,0 +1,787 @@
+
+
+
+
+
+
+Network Working Group                                          M. Bhatia
+Request for Comments: 5709                                Alcatel-Lucent
+Updates: 2328                                                  V. Manral
+Category: Standards Track                                    IP Infusion
+                                                                M. Fanto
+                                                     Aegis Data Security
+                                                                R. White
+                                                               M. Barnes
+                                                           Cisco Systems
+                                                                   T. Li
+                                                                Ericsson
+                                                             R. Atkinson
+                                                        Extreme Networks
+                                                            October 2009
+
+              OSPFv2 HMAC-SHA Cryptographic Authentication
+
+Abstract
+
+   This document describes how the National Institute of Standards and
+   Technology (NIST) Secure Hash Standard family of algorithms can be
+   used with OSPF version 2's built-in, cryptographic authentication
+   mechanism.  This updates, but does not supercede, the cryptographic
+   authentication mechanism specified in RFC 2328.
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright and License Notice
+
+   Copyright (c) 2009 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the BSD License.
+
+
+
+
+Bhatia, et al.              Standards Track                     [Page 1]
+
+RFC 5709                    OSPFv2 HMAC-SHA                 October 2009
+
+
+   This document may contain material from IETF Documents or IETF
+   Contributions published or made publicly available before November
+   10, 2008.  The person(s) controlling the copyright in some of this
+   material may not have granted the IETF Trust the right to allow
+   modifications of such material outside the IETF Standards Process.
+   Without obtaining an adequate license from the person(s) controlling
+   the copyright in such materials, this document may not be modified
+   outside the IETF Standards Process, and derivative works of it may
+   not be created outside the IETF Standards Process, except to format
+   it for publication as an RFC or to translate it into languages other
+   than English.
+
+1.  Introduction
+
+   A variety of risks exist when deploying any routing protocol
+   [Bell89].  This document provides an update to OSPFv2 Cryptographic
+   Authentication, which is specified in Appendix D of RFC 2328.  This
+   document does not deprecate or supercede RFC 2328.  OSPFv2, itself,
+   is defined in RFC 2328 [RFC2328].
+
+   This document adds support for Secure Hash Algorithms (SHA) defined
+   in the US NIST Secure Hash Standard (SHS), which is defined by NIST
+   FIPS 180-2.  [FIPS-180-2] includes SHA-1, SHA-224, SHA-256, SHA-384,
+   and SHA-512.  The Hashed Message Authentication Code (HMAC)
+   authentication mode defined in NIST FIPS 198 is used [FIPS-198].
+
+   It is believed that [RFC2104] is mathematically identical to
+   [FIPS-198] and it is also believed that algorithms in [RFC4634] are
+   mathematically identical to [FIPS-180-2].
+
+   The creation of this addition to OSPFv2 was driven by operator
+   requests that they be able to use the NIST SHS family of algorithms
+   in the NIST HMAC mode, instead of being forced to use the Keyed-MD5
+   algorithm and mode with OSPFv2 Cryptographic Authentication.
+   Cryptographic matters are discussed in more detail in the Security
+   Considerations section of this document.
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+2.  Background
+
+   All OSPF protocol exchanges can be authenticated.  The OSPF packet
+   header (see Appendix A.3.1 of RFC 2328) includes an Authentication
+   Type field and 64 bits of data for use by the appropriate
+   authentication scheme (determined by the Type field).
+
+
+
+
+Bhatia, et al.              Standards Track                     [Page 2]
+
+RFC 5709                    OSPFv2 HMAC-SHA                 October 2009
+
+
+   The authentication type is configurable on a per-interface (or,
+   equivalently, on a per-network/subnet) basis.  Additional
+   authentication data is also configurable on a per-interface basis.
+
+   OSPF authentication types 0, 1, and 2 are defined by RFC 2328.  This
+   document provides an update to RFC 2328 that is only applicable to
+   Authentication Type 2, "Cryptographic Authentication".
+
+3.  Cryptographic Authentication with NIST SHS in HMAC Mode
+
+   Using this authentication type, a shared secret key is configured in
+   all routers attached to a common network/subnet.  For each OSPF
+   protocol packet, the key is used to generate/verify a "message
+   digest" that is appended to the end of the OSPF packet.  The message
+   digest is a one-way function of the OSPF protocol packet and the
+   secret key.  Since the secret key is never sent over the network in
+   the clear, protection is provided against passive attacks [RFC1704].
+
+   The algorithms used to generate and verify the message digest are
+   specified implicitly by the secret key.  This specification discusses
+   the computation of OSPFv2 Cryptographic Authentication data when any
+   of the NIST SHS family of algorithms is used in the Hashed Message
+   Authentication Code (HMAC) mode.  Please also see RFC 2328, Appendix
+   D.
+
+   With the additions in this document, the currently valid algorithms
+   (including mode) for OSPFv2 Cryptographic Authentication include:
+
+           Keyed-MD5               (defined in RFC 2328, Appendix D)
+           HMAC-SHA-1              (defined here)
+           HMAC-SHA-256            (defined here)
+           HMAC-SHA-384            (defined here)
+           HMAC-SHA-512            (defined here)
+
+   Of the above, implementations of this specification MUST include
+   support for at least:
+
+           HMAC-SHA-256
+
+   and SHOULD include support for:
+
+           HMAC-SHA-1
+
+   and SHOULD also (for backwards compatibility with existing
+   implementations and deployments) include support for:
+
+           Keyed-MD5
+
+
+
+
+Bhatia, et al.              Standards Track                     [Page 3]
+
+RFC 5709                    OSPFv2 HMAC-SHA                 October 2009
+
+
+   and MAY also include support for:
+
+           HMAC-SHA-384
+           HMAC-SHA-512
+
+   An implementation of this specification MUST allow network operators
+   to configure ANY authentication algorithm supported by that
+   implementation for use with ANY given KeyID value that is configured
+   into that OSPFv2 router.
+
+3.1.  Generating Cryptographic Authentication
+
+   The overall cryptographic authentication process defined in Appendix
+   D of RFC 2328 remains unchanged.  However, the specific cryptographic
+   details (i.e., SHA rather than MD5, HMAC rather than Keyed-Hash) are
+   defined herein.  To reduce the potential for confusion, this section
+   minimises the repetition of text from RFC 2328, Appendix D, which is
+   incorporated here by reference [RFC2328].
+
+   First, following the procedure defined in RFC 2328, Appendix D,
+   select the appropriate OSPFv2 Security Association for use with this
+   packet and set the KeyID field to the KeyID value of that OSPFv2
+   Security Association.
+
+   Second, set the Authentication Type to Cryptographic Authentication,
+   and set the Authentication Data Length field to the length (measured
+   in bytes, not bits) of the cryptographic hash that will be used.
+   When any NIST SHS algorithm is used in HMAC mode with OSPFv2
+   Cryptographic Authentication, the Authentication Data Length is equal
+   to the normal hash output length (measured in bytes) for the specific
+   NIST SHS algorithm in use.  For example, with NIST SHA-256, the
+   Authentication Data Length is 32 bytes.
+
+   Third, the 32-bit cryptographic sequence number is set in accordance
+   with the procedures in RFC 2328, Appendix D that are applicable to
+   the Cryptographic Authentication type.
+
+   Fourth, the message digest is then calculated and appended to the
+   OSPF packet, as described below in Section 3.3.  The KeyID,
+   Authentication Algorithm, and Authentication Key to be used for
+   calculating the digest are all components of the selected OSPFv2
+   Security Association.  Input to the authentication algorithm consists
+   of the OSPF packet and the secret key.
+
+
+
+
+
+
+
+
+Bhatia, et al.              Standards Track                     [Page 4]
+
+RFC 5709                    OSPFv2 HMAC-SHA                 October 2009
+
+
+3.2.  OSPFv2 Security Association
+
+   This document uses the term OSPFv2 Security Association (OSPFv2 SA)
+   to refer to the authentication key information defined in Section D.3
+   of RFC 2328.  The OSPFv2 protocol does not include an in-band
+   mechanism to create or manage OSPFv2 Security Associations.  The
+   parameters of an OSPFv2 Security Association are updated to be:
+
+   Key Identifier (KeyID)
+      This is an 8-bit unsigned value used to uniquely identify an
+      OSPFv2 SA and is configured either by the router administrator
+      (or, in the future, possibly by some key management protocol
+      specified by the IETF).  The receiver uses this to locate the
+      appropriate OSPFv2 SA to use.  The sender puts this KeyID value in
+      the OSPF packet based on the active OSPF configuration.
+
+   Authentication Algorithm
+      This indicates the authentication algorithm (and also the
+      cryptographic mode, such as HMAC) to be used.  This information
+      SHOULD never be sent over the wire in cleartext form.  At present,
+      valid values are Keyed-MD5, HMAC-SHA-1, HMAC-SHA-256, HMAC-SHA-
+      384, and HMAC-SHA-512.
+
+   Authentication Key
+      This is the cryptographic key used for cryptographic
+      authentication with this OSPFv2 SA.  This value SHOULD never be
+      sent over the wire in cleartext form.  This is noted as "K" in
+      Section 3.3 below.
+
+   Key Start Accept
+      The time that this OSPF router will accept packets that have been
+      created with this OSPF Security Association.
+
+   Key Start Generate
+      The time that this OSPF router will begin using this OSPF Security
+      Association for OSPF packet generation.
+
+   Key Stop Generate
+      The time that this OSPF router will stop using this OSPF Security
+      Association for OSPF packet generation.
+
+   Key Stop Accept
+      The time that this OSPF router will stop accepting packets
+      generated with this OSPF Security Association.
+
+   In order to achieve smooth key transition, KeyStartAccept SHOULD be
+   less than KeyStartGenerate and KeyStopGenerate SHOULD be less than
+   KeyStopAccept.  If KeyStopGenerate and KeyStopAccept are left
+
+
+
+Bhatia, et al.              Standards Track                     [Page 5]
+
+RFC 5709                    OSPFv2 HMAC-SHA                 October 2009
+
+
+   unspecified, the key's lifetime is infinite.  When a new key replaces
+   an old, the KeyStartGenerate time for the new key MUST be less than
+   or equal to the KeyStopGenerate time of the old key.
+
+   Key storage SHOULD persist across a system restart, warm or cold, to
+   avoid operational issues.  In the event that the last key associated
+   with an interface expires, it is unacceptable to revert to an
+   unauthenticated condition, and not advisable to disrupt routing.
+   Therefore, the router should send a "last Authentication Key
+   expiration" notification to the network manager and treat the key as
+   having an infinite lifetime until the lifetime is extended, the key
+   is deleted by network management, or a new key is configured.
+
+3.3.  Cryptographic Aspects
+
+   This describes the computation of the Authentication Data value when
+   any NIST SHS algorithm is used in the HMAC mode with OSPFv2
+   Cryptographic Authentication.
+
+   In the algorithm description below, the following nomenclature, which
+   is consistent with [FIPS-198], is used:
+
+      H    is the specific hashing algorithm (e.g., SHA-256).
+
+      K    is the Authentication Key for the OSPFv2 security
+           association.
+
+      Ko   is the cryptographic key used with the hash algorithm.
+
+      B    is the block size of H, measured in octets
+           rather than bits.  Note well that B is the
+           internal block size, not the hash size.
+
+              For SHA-1 and SHA-256: B == 64
+              For SHA-384 and SHA-512: B == 128
+
+      L    is the length of the hash, measured in octets
+           rather than bits.
+
+      XOR  is the exclusive-or operation.
+
+      Opad is the hexadecimal value 0x5c repeated B times.
+
+      Ipad is the hexadecimal value 0x36 repeated B times.
+
+      Apad is the hexadecimal value 0x878FE1F3 repeated (L/4) times.
+
+
+
+
+
+Bhatia, et al.              Standards Track                     [Page 6]
+
+RFC 5709                    OSPFv2 HMAC-SHA                 October 2009
+
+
+      Implementation note:
+         This definition of Apad means that Apad is always the same
+         length as the hash output.
+
+   (1) PREPARATION OF KEY
+       In this application, Ko is always L octets long.
+
+       If the Authentication Key (K) is L octets long, then Ko is equal
+       to K.  If the Authentication Key (K) is more than L octets long,
+       then Ko is set to H(K).  If the Authentication Key (K) is less
+       than L octets long, then Ko is set to the Authentication Key (K)
+       with zeros appended to the end of the Authentication Key (K),
+       such that Ko is L octets long.
+
+   (2) FIRST-HASH
+       First, the OSPFv2 packet's Authentication Trailer (which is the
+       appendage described in RFC 2328, Section D.4.3, Page 233, items
+       (6)(a) and (6)(d)) is filled with the value Apad, and the
+       Authentication Type field is set to 2.
+
+       Then, a First-Hash, also known as the inner hash, is computed as
+       follows:
+
+             First-Hash = H(Ko XOR Ipad || (OSPFv2 Packet))
+
+       Implementation Notes:
+          Note that the First-Hash above includes the Authentication
+          Trailer containing the Apad value, as well as the OSPF packet,
+          as per RFC 2328, Section D.4.3.
+
+       The definition of Apad (above) ensures it is always the same
+       length as the hash output.  This is consistent with RFC 2328.
+       The "(OSPFv2 Packet)" mentioned in the First-Hash (above) does
+       include the OSPF Authentication Trailer.
+
+       The digest length for SHA-1 is 20 bytes; for SHA-256, 32 bytes;
+       for SHA-384, 48 bytes; and for SHA-512, 64 bytes.
+
+   (3) SECOND-HASH
+       Then a Second-Hash, also known as the outer hash, is computed as
+       follows:
+
+             Second-Hash = H(Ko XOR Opad || First-Hash)
+
+
+
+
+
+
+
+
+Bhatia, et al.              Standards Track                     [Page 7]
+
+RFC 5709                    OSPFv2 HMAC-SHA                 October 2009
+
+
+   (4) RESULT
+       The resulting Second-Hash becomes the Authentication Data that is
+       sent in the Authentication Trailer of the OSPFv2 packet.  The
+       length of the Authentication Trailer is always identical to the
+       message digest size of the specific hash function H that is being
+       used.
+
+       This also means that the use of hash functions with larger output
+       sizes will also increase the size of the OSPFv2 packet as
+       transmitted on the wire.
+
+       Implementation Note:
+          RFC 2328, Appendix D specifies that the Authentication Trailer
+          is not counted in the OSPF packet's own Length field, but is
+          included in the packet's IP Length field.
+
+3.4.  Message Verification
+
+   Message verification follows the procedure defined in RFC 2328,
+   except that the cryptographic calculation of the message digest
+   follows the procedure in Section 3.3 above when any NIST SHS
+   algorithm in the HMAC mode is in use.  Kindly recall that the
+   cryptographic algorithm/mode in use is indicated implicitly by the
+   KeyID of the received OSPFv2 packet.
+
+   Implementation Notes:
+      One must save the received digest value before calculating the
+      expected digest value, so that after that calculation the received
+      value can be compared with the expected value to determine whether
+      to accept that OSPF packet.
+
+      RFC 2328, Section D.4.3 (6) (c) should be read very closely prior
+      to implementing the above.  With SHA algorithms in HMAC mode, Apad
+      is placed where the MD5 key would be put if Keyed-MD5 were in use.
+
+3.5.  Changing OSPFv2 Security Associations
+
+   Using KeyIDs makes changing the active OSPFv2 SA convenient.  An
+   implementation can choose to associate a lifetime with each OSPFv2 SA
+   and can thus automatically switch to a different OSPFv2 SA based on
+   the lifetimes of the configured OSPFv2 SA(s).
+
+   After changing the active OSPFv2 SA, the OSPF sender will use the
+   (different) KeyID value associated with the newly active OSPFv2 SA.
+   The receiver will use this new KeyID to select the appropriate (new)
+   OSPFv2 SA to use with the received OSPF packet containing the new
+   KeyID value.
+
+
+
+
+Bhatia, et al.              Standards Track                     [Page 8]
+
+RFC 5709                    OSPFv2 HMAC-SHA                 October 2009
+
+
+   Because the KeyID field is present, the receiver does not need to try
+   all configured OSPFv2 Security Associations with any received OSPFv2
+   packet.  This can mitigate some of the risks of a Denial-of-Service
+   (DoS) attack on the OSPF instance, but does not entirely prevent all
+   conceivable DoS attacks.  For example, an on-link adversary still
+   could generate OSPFv2 packets that are syntactically valid but that
+   contain invalid Authentication Data, thereby forcing the receiver(s)
+   to perform expensive cryptographic computations to discover that the
+   packets are invalid.
+
+4.  Security Considerations
+
+   This document enhances the security of the OSPFv2 routing protocol by
+   adding, to the existing OSPFv2 Cryptographic Authentication method,
+   support for the algorithms defined in the NIST Secure Hash Standard
+   (SHS) using the Hashed Message Authentication Code (HMAC) mode, and
+   by adding support for the Hashed Message Authentication Code (HMAC)
+   mode.
+
+   This provides several alternatives to the existing Keyed-MD5
+   mechanism.  There are published concerns about the overall strength
+   of the MD5 algorithm ([Dobb96a], [Dobb96b], [Wang04]).  While those
+   published concerns apply to the use of MD5 in other modes (e.g., use
+   of MD5 X.509v3/PKIX digital certificates), they are not an attack
+   upon Keyed-MD5, which is what OSPFv2 specified in RFC 2328.  There
+   are also published concerns about the SHA algorithm [Wang05] and also
+   concerns about the MD5 and SHA algorithms in the HMAC mode ([RR07],
+   [RR08]).  Separately, some organisations (e.g., the US government)
+   prefer NIST algorithms, such as the SHA family, over other algorithms
+   for local policy reasons.
+
+   The value Apad is used here primarily for consistency with IETF
+   specifications for HMAC-SHA authentication of RIPv2 SHA [RFC4822] and
+   IS-IS SHA [RFC5310] and to minimise OSPF protocol processing changes
+   in Section D.4.3 of RFC 2328 [RFC2328].
+
+   The quality of the security provided by the Cryptographic
+   Authentication option depends completely on the strength of the
+   cryptographic algorithm and cryptographic mode in use, the strength
+   of the key being used, and the correct implementation of the security
+   mechanism in all communicating OSPF implementations.  Accordingly,
+   the use of high assurance development methods is recommended.  It
+   also requires that all parties maintain the secrecy of the shared
+   secret key.  [RFC4086] provides guidance on methods for generating
+   cryptographically random bits.
+
+
+
+
+
+
+Bhatia, et al.              Standards Track                     [Page 9]
+
+RFC 5709                    OSPFv2 HMAC-SHA                 October 2009
+
+
+   This mechanism is vulnerable to a replay attack by any on-link node.
+   An on-link node could record a legitimate OSPF packet sent on the
+   link, then replay that packet at the next time the recorded OSPF
+   packet's sequence number is valid.  This replay attack could cause
+   significant routing disruptions within the OSPF domain.
+
+   Ideally, for example, to prevent the preceding attack, each OSPF
+   Security Association would be replaced by a new and different OSPF
+   Security Association before any sequence number were reused.  As of
+   the date this document was published, no form of automated key
+   management has been standardised for OSPF.  So, as of the date this
+   document was published, common operational practice has been to use
+   the same OSPF Authentication Key for very long periods of time.  This
+   operational practice is undesirable for many reasons.  Therefore, it
+   is clearly desirable to develop and standardise some automated key-
+   management mechanism for OSPF.
+
+   Because all of the currently specified algorithms use symmetric
+   cryptography, one cannot authenticate precisely which OSPF router
+   sent a given packet.  However, one can authenticate that the sender
+   knew the OSPF Security Association (including the OSPFv2 SA's
+   parameters) currently in use.
+
+   Because a routing protocol contains information that need not be kept
+   secret, privacy is not a requirement.  However, authentication of the
+   messages within the protocol is of interest in order to reduce the
+   risk of an adversary compromising the routing system by deliberately
+   injecting false information into the routing system.
+
+   The technology in this document enhances an authentication mechanism
+   for OSPFv2.  The mechanism described here is not perfect and need not
+   be perfect.  Instead, this mechanism represents a significant
+   increase in the work function of an adversary attacking OSPFv2, as
+   compared with plain-text authentication or null authentication, while
+   not causing undue implementation, deployment, or operational
+   complexity.  Denial-of-Service attacks are not generally preventable
+   in a useful networking protocol [VK83].
+
+   Because of implementation considerations, including the need for
+   backwards compatibility, this specification uses the same mechanism
+   as specified in RFC 2328 and limits itself to adding support for
+   additional cryptographic hash functions.  Also, some large network
+   operators have indicated they prefer to retain the basic mechanism
+   defined in RFC 2328, rather than migrate to IP Security, due to
+   deployment and operational considerations.  If all the OSPFv2 routers
+   supported IPsec, then IPsec tunnels could be used in lieu of this
+   mechanism [RFC4301].  This would, however, relegate the topology to
+   point-to-point adjacencies over the mesh of IPsec tunnels.
+
+
+
+Bhatia, et al.              Standards Track                    [Page 10]
+
+RFC 5709                    OSPFv2 HMAC-SHA                 October 2009
+
+
+   If a stronger authentication were believed to be required, then the
+   use of a full digital signature [RFC2154] would be an approach that
+   should be seriously considered.  Use of full digital signatures would
+   enable precise authentication of the OSPF router originating each
+   OSPF link-state advertisement, and thereby provide much stronger
+   integrity protection for the OSPF routing domain.
+
+5.  IANA Considerations
+
+   The OSPF Authentication Codes registry entry for Cryptographic
+   Authentication (Registry Code 2) has been updated to refer to this
+   document as well as to RFC 2328.
+
+6.  Acknowledgements
+
+   The authors would like to thank Bill Burr, Tim Polk, John Kelsey, and
+   Morris Dworkin of (US) NIST for review of portions of this document
+   that are directly derived from the closely related work on RIPv2
+   Cryptographic Authentication [RFC4822].
+
+   David Black, Nevil Brownlee, Acee Lindem, and Hilarie Orman (in
+   alphabetical order by last name) provided feedback on earlier
+   versions of this document.  That feedback has greatly improved both
+   the technical content and the readability of the current document.
+
+   Henrik Levkowetz's Internet Draft tools were very helpful in
+   preparing this document and are much appreciated.
+
+7.  References
+
+7.1.  Normative References
+
+   [FIPS-180-2] US National Institute of Standards & Technology, "Secure
+                Hash Standard (SHS)", FIPS PUB 180-2, August 2002.
+
+   [FIPS-198]   US National Institute of Standards & Technology, "The
+                Keyed-Hash Message Authentication Code (HMAC)", FIPS PUB
+                198, March 2002.
+
+   [RFC2119]    Bradner, S., "Key words for use in RFCs to Indicate
+                Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2328]    Moy, J., "OSPF Version 2", STD 54, RFC 2328, April 1998.
+
+
+
+
+
+
+
+
+Bhatia, et al.              Standards Track                    [Page 11]
+
+RFC 5709                    OSPFv2 HMAC-SHA                 October 2009
+
+
+7.2.  Informative References
+
+   [Bell89]     Bellovin, S., "Security Problems in the TCP/IP Protocol
+                Suite", ACM Computer Communications Review, Volume 19,
+                Number 2, pp. 32-48, April 1989.
+
+   [Dobb96a]    Dobbertin, H, "Cryptanalysis of MD5 Compress", Technical
+                Report, 2 May 1996. (Presented at the Rump Session of
+                EuroCrypt 1996.)
+
+   [Dobb96b]    Dobbertin, H, "The Status of MD5 After a Recent Attack",
+                CryptoBytes, Vol. 2, No. 2, Summer 1996.
+
+   [RFC1704]    Haller, N. and R. Atkinson, "On Internet
+                Authentication", RFC 1704, October 1994.
+
+   [RFC2104]    Krawczyk, H., Bellare, M., and R. Canetti, "HMAC:
+                Keyed-Hashing for Message Authentication", RFC 2104,
+                February 1997.
+
+   [RFC2154]    Murphy, S., Badger, M., and B. Wellington, "OSPF with
+                Digital Signatures", RFC 2154, June 1997.
+
+   [RFC4086]    Eastlake, D., 3rd, Schiller, J., and S. Crocker,
+                "Randomness Requirements for Security", BCP 106, RFC
+                4086, June 2005.
+
+   [RFC4301]    Kent, S. and K. Seo, "Security Architecture for the
+                Internet Protocol", RFC 4301, December 2005.
+
+   [RFC4634]    Eastlake 3rd, D. and T. Hansen, "US Secure Hash
+                Algorithms (SHA and HMAC-SHA)", RFC 4634, July 2006.
+
+   [RFC4822]    Atkinson, R. and M. Fanto, "RIPv2 Cryptographic
+                Authentication", RFC 4822, February 2007.
+
+   [RFC5310]    Bhatia, M., Manral, V., Li, T., Atkinson, R., White, R.,
+                and M. Fanto, "IS-IS Generic Cryptographic
+                Authentication", RFC 5310, February 2009.
+
+   [RR07]       Rechberger, C. and V. Rijmen, "On Authentication with
+                HMAC and Non-random Properties", Financial Cryptography
+                and Data Security, Lecture Notes in Computer Science,
+                Volume 4886/2008, Springer-Verlag, Berlin, December
+                2007.
+
+
+
+
+
+
+Bhatia, et al.              Standards Track                    [Page 12]
+
+RFC 5709                    OSPFv2 HMAC-SHA                 October 2009
+
+
+   [RR08]       Rechberger, C. and V. Rijmen, "New Results on NMAC/HMAC
+                when Instantiated with Popular Hash Functions", Journal
+                of Universal Computer Science, Volume 14, Number 3, pp.
+                347-376, 1 February 2008.
+
+   [VK83]       Voydock, V. and S. Kent, "Security Mechanisms in High-
+                level Networks", ACM Computing Surveys, Vol. 15, No. 2,
+                June 1983.
+
+   [Wang04]     Wang, X., et alia, "Collisions for Hash Functions MD4,
+                MD5, HAVAL-128, and RIPEMD", August 2004, IACR,
+                http://eprint.iacr.org/2004/199
+
+   [Wang05]     Wang, X., et alia, "Finding Collisions in the Full SHA-
+                1" Proceedings of Crypto 2005, Lecture Notes in Computer
+                Science, Volume 3621, pp. 17-36, Springer-Verlag,
+                Berlin, August 31, 2005.
+
+Authors' Addresses
+
+   Manav Bhatia
+   Alcatel-Lucent
+   Bangalore,
+   India
+
+   EMail: manav.bhatia@alcatel-lucent.com
+
+
+   Vishwas Manral
+   IP Infusion
+   Almora, Uttarakhand
+   India
+
+   EMail: vishwas@ipinfusion.com
+
+
+   Matthew J. Fanto
+   Aegis Data Security
+   Dearborn, MI
+   USA
+
+   EMail: mfanto@aegisdatasecurity.com
+
+
+
+
+
+
+
+
+
+Bhatia, et al.              Standards Track                    [Page 13]
+
+RFC 5709                    OSPFv2 HMAC-SHA                 October 2009
+
+
+   Russ I. White
+   Cisco Systems
+   7025 Kit Creek Road
+   P.O. Box 14987
+   RTP, NC
+   27709 USA
+
+   EMail: riw@cisco.com
+
+
+   M. Barnes
+   Cisco Systems
+   225 West Tasman Drive
+   San Jose, CA
+   95134  USA
+
+   EMail: mjbarnes@cisco.com
+
+
+   Tony Li
+   Ericsson
+   300 Holger Way
+   San Jose, CA
+   95134  USA
+
+   EMail: tony.li@tony.li
+
+
+   Randall J. Atkinson
+   Extreme Networks
+   3585 Monroe Street
+   Santa Clara, CA
+   95051  USA
+
+   Phone: +1 (408) 579-2800
+   EMail: rja@extremenetworks.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bhatia, et al.              Standards Track                    [Page 14]
+

--- a/rfc/ospf/rfc7166.txt
+++ b/rfc/ospf/rfc7166.txt
@@ -1,0 +1,1291 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                         M. Bhatia
+Request for Comments: 7166                                Alcatel-Lucent
+Obsoletes: 6506                                                V. Manral
+Category: Standards Track                                    Ionos Corp.
+ISSN: 2070-1721                                                A. Lindem
+                                                                Ericsson
+                                                              March 2014
+
+
+              Supporting Authentication Trailer for OSPFv3
+
+Abstract
+
+   Currently, OSPF for IPv6 (OSPFv3) uses IPsec as the only mechanism
+   for authenticating protocol packets.  This behavior is different from
+   authentication mechanisms present in other routing protocols (OSPFv2,
+   Intermediate System to Intermediate System (IS-IS), RIP, and Routing
+   Information Protocol Next Generation (RIPng)).  In some environments,
+   it has been found that IPsec is difficult to configure and maintain
+   and thus cannot be used.  This document defines an alternative
+   mechanism to authenticate OSPFv3 protocol packets so that OSPFv3 does
+   not depend only upon IPsec for authentication.
+
+   The OSPFv3 Authentication Trailer was originally defined in RFC 6506.
+   This document obsoletes RFC 6506 by providing a revised definition,
+   including clarifications and refinements of the procedures.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7166.
+
+
+
+
+
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                    [Page 1]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+Copyright Notice
+
+   Copyright (c) 2014 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1. Introduction ....................................................3
+      1.1. Requirements ...............................................4
+      1.2. Summary of Changes from RFC 6506 ...........................4
+   2. Proposed Solution ...............................................5
+      2.1. AT-Bit in Options Field ....................................5
+      2.2. Basic Operation ............................................6
+      2.3. IPv6 Source Address Protection .............................6
+   3. OSPFv3 Security Association .....................................7
+   4. Authentication Procedure ........................................9
+      4.1. Authentication Trailer .....................................9
+           4.1.1. Sequence Number Wrap ...............................11
+      4.2. OSPFv3 Header Checksum and LLS Data Block Checksum ........11
+      4.3. Cryptographic Authentication Procedure ....................12
+      4.4. Cross-Protocol Attack Mitigation ..........................12
+      4.5. Cryptographic Aspects .....................................12
+      4.6. Message Verification ......................................15
+   5. Migration and Backward Compatibility ...........................16
+   6. Security Considerations ........................................17
+   7. IANA Considerations ............................................18
+   8. References .....................................................19
+      8.1. Normative References ......................................19
+      8.2. Informative References ....................................19
+   Appendix A. Acknowledgments .......................................22
+
+
+
+
+
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                    [Page 2]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+1.  Introduction
+
+   Unlike Open Shortest Path First version 2 (OSPFv2) [RFC2328], OSPF
+   for IPv6 (OSPFv3) [RFC5340] does not include the AuType and
+   Authentication fields in its headers for authenticating protocol
+   packets.  Instead, OSPFv3 relies on the IPsec protocols
+   Authentication Header (AH) [RFC4302] and Encapsulating Security
+   Payload (ESP) [RFC4303] to provide integrity, authentication, and/or
+   confidentiality.
+
+   [RFC4552] describes how IPv6 AH and ESP extension headers can be used
+   to provide authentication and/or confidentiality to OSPFv3.
+
+   However, there are some environments, e.g., Mobile Ad Hoc Networks
+   (MANETs), where IPsec is difficult to configure and maintain; this
+   mechanism cannot be used in such environments.
+
+   [RFC4552] discusses, at length, the reasoning behind using manually
+   configured keys, rather than some automated key management protocol
+   such as Internet Key Exchange version 2 (IKEv2) [RFC5996].  The
+   primary problem is the lack of a suitable key management mechanism,
+   as OSPFv3 adjacencies are formed on a one-to-many basis and most key
+   management mechanisms are designed for a one-to-one communication
+   model.  This forces the system administrator to use manually
+   configured Security Associations (SAs) and cryptographic keys to
+   provide the authentication and, if desired, confidentiality services.
+
+   Regarding replay protection, [RFC4552] states that:
+
+      Since it is not possible using the current standards to provide
+      complete replay protection while using manual keying, the proposed
+      solution will not provide protection against replay attacks.
+
+   Since there is no replay protection provided, there are a number of
+   vulnerabilities in OSPFv3 that have been discussed in [RFC6039].
+
+   While techniques exist to identify ESP-NULL packets [RFC5879], these
+   techniques are generally not implemented in the data planes of OSPFv3
+   routers.  This makes it very difficult for implementations to examine
+   OSPFv3 packets and prioritize certain OSPFv3 packet types, e.g.,
+   Hello packets, over the other types.
+
+   This document defines a mechanism that works similarly to OSPFv2
+   [RFC5709] to provide authentication to OSPFv3 packets and solves the
+   problems related to replay protection and deterministically
+   disambiguating different OSPFv3 packets as described above.
+
+
+
+
+
+Bhatia, et al.               Standards Track                    [Page 3]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+   This document adds support for the Secure Hash Algorithms (SHAs)
+   defined in the US NIST Secure Hash Standard (SHS), which is specified
+   by NIST FIPS 180-4.  [FIPS-180-4] includes SHA-1, SHA-224, SHA-256,
+   SHA-384, and SHA-512.  The Hashed Message Authentication Code (HMAC)
+   authentication mode defined in NIST FIPS 198-1 [FIPS-198-1] is used.
+
+1.1.  Requirements
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+1.2.  Summary of Changes from RFC 6506
+
+   This document includes the following changes from RFC 6506 [RFC6506]:
+
+   1. Sections 2.2 and 4.2 explicitly state that the Link-Local
+      Signaling (LLS) block checksum calculation is omitted when an
+      OSPFv3 Authentication Trailer is used for OSPFv3 authentication.
+      The LLS data block is included in the authentication digest
+      calculation, and computation of a checksum is unnecessary.
+      Clarification of this issue was documented in an erratum.
+
+   2. Section 3 previously recommended usage of an expired key for
+      transmitted OSPFv3 packets when no valid keys existed.  This
+      statement has been removed.
+
+   3. Section 4.5 includes a correction to the key preparation to use
+      the Protocol-Specific Authentication Key (Ks) rather than the
+      Authentication Key (K) as the initial key (Ko).  This problem was
+      also documented in an erratum.
+
+   4. Section 4.5 also includes a discussion of the choice of key length
+      to be the hash length (L) rather than the block size (B).  The
+      discussion of this choice was included to clarify an issue raised
+      in a rejected erratum.
+
+   5. Sections 4.1 and 4.6 indicate that sequence number checking is
+      dependent on OSPFv3 packet type in order to account for packet
+      prioritization as specified in [RFC4222].  This was an omission
+      from RFC 6506 [RFC6506].
+
+   6. Section 4.6 explicitly states that OSPFv3 packets with a
+      nonexistent or expired Security Association (SA) will be dropped.
+
+   7. Section 5 includes guidance on the precise actions required for an
+      OSPFv3 router providing a backward-compatible transition mode.
+
+
+
+
+Bhatia, et al.               Standards Track                    [Page 4]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+2.  Proposed Solution
+
+   To perform non-IPsec Cryptographic Authentication, OSPFv3 routers
+   append a special data block, henceforth referred to as the
+   Authentication Trailer, to the end of the OSPFv3 packets.  The length
+   of the Authentication Trailer is not included in the length of the
+   OSPFv3 packet but is included in the IPv6 payload length, as shown in
+   Figure 1.
+
+    +---------------------+ --              --  +----------------------+
+    | IPv6 Payload Length | ^               ^   | IPv6 Payload Length  |
+    | PL = OL + LL        | |               |   | PL = OL + LL + AL    |
+    |                     | v               v   |                      |
+    +---------------------+ --              --  +----------------------+
+    | OSPFv3 Header       | ^               ^   | OSPFv3 Header        |
+    | Length = OL         | |               |   | Length = OL          |
+    |                     | |    OSPFv3     |   |                      |
+    |.....................| |    Packet     |   |......................|
+    |                     | |    Length     |   |                      |
+    | OSPFv3 Packet       | |               |   | OSPFv3 Packet        |
+    |                     | v               v   |                      |
+    +---------------------+ --              --  +----------------------+
+    |                     | ^               ^   |                      |
+    | Optional LLS        | |    LLS Data   |   | Optional LLS         |
+    | LL = LLS Data       | |    Block      |   | LL = LLS Data        |
+    |      Block Length   | v    Length     v   |      Block Length    |
+    +---------------------+ --              --  +----------------------+
+                                            ^   |                      |
+                       AL = PL - (OL + LL)  |   | Authentication       |
+                                            |   | AL = Fixed Trailer + |
+                                            v   |      Digest Length   |
+                                            --  +----------------------+
+
+                Figure 1: Authentication Trailer in OSPFv3
+
+   The presence of the Link-Local Signaling (LLS) [RFC5613] block is
+   determined by the L-bit setting in the OSPFv3 Options field in OSPFv3
+   Hello and Database Description packets.  If present, the LLS data
+   block is included along with the OSPFv3 packet in the Cryptographic
+   Authentication computation.
+
+2.1.  AT-Bit in Options Field
+
+   RFC 6506 introduced the AT-bit ("AT" stands for "Authentication
+   Trailer") into the OSPFv3 Options field.  OSPFv3 routers MUST set the
+   AT-bit in OSPFv3 Hello and Database Description packets to indicate
+   that all the packets on this link will include an Authentication
+   Trailer.  For OSPFv3 Hello and Database Description packets, the
+
+
+
+Bhatia, et al.               Standards Track                    [Page 5]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+   AT-bit indicates that the AT is present.  For other OSPFv3 packet
+   types, the OSPFv3 AT-bit setting from the OSPFv3 Hello/Database
+   Description setting is preserved in the OSPFv3 neighbor data
+   structure.  OSPFv3 packet types that don't include an OSPFv3 Options
+   field will use the setting from the neighbor data structure to
+   determine whether or not the AT is expected.
+
+            0                   1                      2
+            0 1 2 3 4 5 6 7 8 9 0 1 2 3  4 5  6 7 8  9 0 1  2 3
+           +-+-+-+-+-+-+-+-+-+-+-+-+-+--+-+--+-+-+--+-+-+--+-+--+
+           | | | | | | | | | | | | | |AT|L|AF|*|*|DC|R|N|MC|E|V6|
+           +-+-+-+-+-+-+-+-+-+-+-+-+-+--+-+--+-+-+--+-+-+--+-+--+
+
+                      Figure 2: OSPFv3 Options Field
+
+   The AT-bit, as shown in the figure above, MUST be set in all OSPFv3
+   Hello and Database Description packets that contain an Authentication
+   Trailer.
+
+2.2.  Basic Operation
+
+   The procedure followed for computing the Authentication Trailer is
+   much the same as those described in [RFC5709] and [RFC2328].  One
+   difference is that the LLS data block, if present, is included in the
+   Cryptographic Authentication computation.
+
+   The way the authentication data is carried in the Authentication
+   Trailer is very similar to how it is done in the case of [RFC2328].
+   The only difference between the OSPFv2 Authentication Trailer and the
+   OSPFv3 Authentication Trailer is that information in addition to the
+   message digest is included.  The additional information in the OSPFv3
+   Authentication Trailer is included in the message digest computation
+   and is therefore protected by OSPFv3 Cryptographic Authentication as
+   described herein.
+
+   Consistent with OSPFv2 Cryptographic Authentication [RFC2328] and
+   Link-Local Signaling Cryptographic Authentication [RFC5613], checksum
+   calculation and verification are omitted for both the OSPFv3 header
+   checksum and the LLS data block when the OSPFv3 authentication
+   mechanism described in this specification is used.
+
+2.3.  IPv6 Source Address Protection
+
+   While OSPFv3 always uses the Router ID to identify OSPFv3 neighbors,
+   the IPv6 source address is learned from OSPFv3 Hello packets and
+   copied into the neighbor data structure [RFC5340].  Hence, OSPFv3 is
+   susceptible to Man-in-the-Middle attacks where the IPv6 source
+   address is modified.  To thwart such attacks, the IPv6 source address
+
+
+
+Bhatia, et al.               Standards Track                    [Page 6]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+   will be included in the message digest calculation and protected by
+   OSPFv3 authentication.  Refer to Section 4.5 for details.  This is
+   different than the procedure specified in [RFC5709] but consistent
+   with [MANUAL-KEY].
+
+3.  OSPFv3 Security Association
+
+   An OSPFv3 Security Association (SA) contains a set of parameters
+   shared between any two legitimate OSPFv3 speakers.
+
+   Parameters associated with an OSPFv3 SA are as follows:
+
+   o  Security Association Identifier (SA ID)
+
+      This is a 16-bit unsigned integer used to uniquely identify an
+      OSPFv3 SA, as manually configured by the network operator.
+
+      The receiver determines the active SA by looking at the SA ID
+      field in the incoming protocol packet.
+
+      The sender, based on the active configuration, selects an SA to
+      use and puts the correct Key ID value associated with the SA in
+      the OSPFv3 protocol packet.  If multiple valid and active OSPFv3
+      SAs exist for a given interface, the sender may use any of those
+      SAs to protect the packet.
+
+      Using SA IDs makes changing keys while maintaining protocol
+      operation convenient.  Each SA ID specifies two independent parts:
+      the authentication algorithm and the Authentication Key, as
+      explained below.
+
+      Normally, an implementation would allow the network operator to
+      configure a set of keys in a key chain, with each key in the chain
+      having a fixed lifetime.  The actual operation of these mechanisms
+      is outside the scope of this document.
+
+      Note that each SA ID can indicate a key with a different
+      authentication algorithm.  This allows the introduction of new
+      authentication mechanisms without disrupting existing OSPFv3
+      adjacencies.
+
+   o  Authentication Algorithm
+
+      This signifies the authentication algorithm to be used with this
+      OSPFv3 SA.  This information is never sent in clear text over the
+      wire.  Because this information is not sent on the wire, the
+      implementer chooses an implementation-specific representation for
+      this information.
+
+
+
+Bhatia, et al.               Standards Track                    [Page 7]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+      Currently, the following algorithms are supported:
+
+      *  HMAC-SHA-1,
+
+      *  HMAC-SHA-256,
+
+      *  HMAC-SHA-384, and
+
+      *  HMAC-SHA-512.
+
+   o  Authentication Key
+
+      This value denotes the Cryptographic Authentication Key associated
+      with this OSPFv3 SA.  The length of this key is variable and
+      depends upon the authentication algorithm specified by the
+      OSPFv3 SA.
+
+   o  KeyStartAccept
+
+      This value indicates the time that this OSPFv3 router will accept
+      packets that have been created with this OSPFv3 SA.
+
+   o  KeyStartGenerate
+
+      This value indicates the time that this OSPFv3 router will begin
+      using this OSPFv3 SA for OSPFv3 packet generation.
+
+   o  KeyStopGenerate
+
+      This value indicates the time that this OSPFv3 router will stop
+      using this OSPFv3 SA for OSPFv3 packet generation.
+
+   o  KeyStopAccept
+
+      This value indicates the time that this OSPFv3 router will stop
+      accepting packets generated with this OSPFv3 SA.
+
+      In order to achieve smooth key transition, KeyStartAccept SHOULD
+      be less than KeyStartGenerate, and KeyStopGenerate SHOULD be less
+      than KeyStopAccept.  If KeyStartGenerate or KeyStartAccept is left
+      unspecified, the time will default to 0, and the key will be used
+      immediately.  If KeyStopGenerate or KeyStopAccept is left
+      unspecified, the time will default to infinity, and the key's
+      lifetime will be infinite.  When a new key replaces an old key,
+      the KeyStartGenerate time for the new key MUST be less than or
+      equal to the KeyStopGenerate time of the old key.
+
+
+
+
+
+Bhatia, et al.               Standards Track                    [Page 8]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+      Key storage SHOULD persist across a system restart, warm or cold,
+      to avoid operational issues.  In the event that the last key
+      associated with an interface expires, the network operator SHOULD
+      be notified, and the OSPFv3 packet MUST NOT be transmitted
+      unauthenticated.
+
+4.  Authentication Procedure
+
+4.1.  Authentication Trailer
+
+   The Authentication Trailer that is appended to the OSPFv3 protocol
+   packet is described below:
+
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |      Authentication Type      |        Auth Data Len          |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |           Reserved            |   Security Association ID     |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |           Cryptographic Sequence Number (High-Order 32 Bits)  |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |           Cryptographic Sequence Number (Low-Order 32 Bits)   |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                                                               |
+    |                Authentication Data (Variable)                 |
+    ~                                                               ~
+    |                                                               |
+    |                                                               |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                  Figure 3: Authentication Trailer Format
+
+   The various fields in the Authentication Trailer are as follows:
+
+   o  Authentication Type
+
+      This 16-bit field identifies the type of authentication.  The
+      following values are defined in this specification:
+
+         0 - Reserved.
+         1 - HMAC Cryptographic Authentication as described herein.
+
+   o  Auth Data Len
+
+      This is the length in octets of the Authentication Trailer (AT),
+      including both the 16-octet fixed header and the variable-length
+      message digest.
+
+
+
+Bhatia, et al.               Standards Track                    [Page 9]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+   o  Reserved
+
+      This field is reserved.  It SHOULD be set to 0 when sending
+      protocol packets and MUST be ignored when receiving protocol
+      packets.
+
+   o  Security Association Identifier (SA ID)
+
+      This 16-bit field maps to the authentication algorithm and the
+      secret key used to create the message digest appended to the
+      OSPFv3 protocol packet.
+
+      Though the SA ID implies the algorithm, the HMAC output size
+      should not be used by implementers as an implicit hint, because
+      additional algorithms may be defined in the future that have the
+      same output size.
+
+   o  Cryptographic Sequence Number
+
+      This is a 64-bit strictly increasing sequence number that is used
+      to guard against replay attacks.  The 64-bit sequence number MUST
+      be incremented for every OSPFv3 packet sent by the OSPFv3 router.
+      Upon reception, the sequence number MUST be greater than the
+      sequence number in the last accepted OSPFv3 packet of the same
+      OSPFv3 packet type from the sending OSPFv3 neighbor.  Otherwise,
+      the OSPFv3 packet is considered a replayed packet and dropped.
+      OSPFv3 packets of different types may arrive out of order if they
+      are prioritized as recommended in [RFC4222].
+
+      OSPFv3 routers implementing this specification MUST use available
+      mechanisms to preserve the sequence number's strictly increasing
+      property for the deployed life of the OSPFv3 router (including
+      cold restarts).  One mechanism for accomplishing this would be to
+      use the high-order 32 bits of the sequence number as a wrap/boot
+      count that is incremented anytime the OSPFv3 router loses its
+      sequence number state.  Sequence number wrap is described in
+      Section 4.1.1.
+
+   o  Authentication Data
+
+      This field contains variable data that is carrying the digest for
+      the protocol packet and optional LLS data block.
+
+
+
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                   [Page 10]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+4.1.1.  Sequence Number Wrap
+
+   When incrementing the sequence number for each transmitted OSPFv3
+   packet, the sequence number should be treated as an unsigned 64-bit
+   value.  If the lower-order 32-bit value wraps, the higher-order
+   32-bit value should be incremented and saved in non-volatile storage.
+   If by some chance the OSPFv3 router is deployed long enough that
+   there is a possibility that the 64-bit sequence number may wrap, all
+   keys, independent of their key distribution mechanism, MUST be reset
+   to avoid the possibility of replay attacks.  Once the keys have been
+   changed, the higher-order sequence number can be reset to 0 and saved
+   to non-volatile storage.
+
+4.2.  OSPFv3 Header Checksum and LLS Data Block Checksum
+
+   Both the checksum calculation and verification are omitted for the
+   OSPFv3 header checksum and the LLS data block checksum [RFC5613] when
+   the OSPFv3 authentication mechanism described in this specification
+   is used.  This implies the following:
+
+   o  For OSPFv3 packets to be transmitted, the OSPFv3 header checksum
+      computation is omitted, and the OSPFv3 header checksum SHOULD be
+      set to 0 prior to computation of the OSPFv3 Authentication Trailer
+      message digest.
+
+   o  For OSPFv3 packets including an LLS data block to be transmitted,
+      the OSPFv3 LLS data block checksum computation is omitted, and the
+      OSPFv3 LLS data block checksum SHOULD be set to 0 prior to
+      computation of the OSPFv3 Authentication Trailer message digest.
+
+   o  For received OSPFv3 packets including an OSPFv3 Authentication
+      Trailer, OSPFv3 header checksum verification MUST be omitted.
+      However, if the OSPFv3 packet does include a non-zero OSPFv3
+      header checksum, it will not be modified by the receiver and will
+      simply be included in the OSPFv3 Authentication Trailer message
+      digest verification.
+
+   o  For received OSPFv3 packets including an LLS data block and OSPFv3
+      Authentication Trailer, LLS data block checksum verification MUST
+      be omitted.  However, if the OSPFv3 packet does include an LLS
+      data block with a non-zero checksum, it will not be modified by
+      the receiver and will simply be included in the OSPFv3
+      Authentication Trailer message digest verification.
+
+
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                   [Page 11]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+4.3.  Cryptographic Authentication Procedure
+
+   As noted earlier, the SA ID maps to the authentication algorithm and
+   the secret key used to generate and verify the message digest.  This
+   specification discusses the computation of OSPFv3 Cryptographic
+   Authentication data when any of the NIST SHS family of algorithms is
+   used in the Hashed Message Authentication Code (HMAC) mode.
+
+   The currently valid algorithms (including mode) for OSPFv3
+   Cryptographic Authentication include:
+
+   o  HMAC-SHA-1,
+
+   o  HMAC-SHA-256,
+
+   o  HMAC-SHA-384, and
+
+   o  HMAC-SHA-512.
+
+   Of the above, implementations of this specification MUST include
+   support for at least HMAC-SHA-256 and SHOULD include support for
+   HMAC-SHA-1 and MAY also include support for HMAC-SHA-384 and
+   HMAC-SHA-512.
+
+   Implementations of this specification MUST use HMAC-SHA-256 as the
+   default authentication algorithm.
+
+4.4.  Cross-Protocol Attack Mitigation
+
+   In order to prevent cross-protocol replay attacks for protocols
+   sharing common keys, the two-octet OSPFv3 Cryptographic Protocol ID
+   is appended to the Authentication Key prior to use.  Other protocols
+   using Cryptographic Authentication as specified herein MUST similarly
+   append their respective Cryptographic Protocol IDs to their keys in
+   this step.  Refer to the IANA Considerations (Section 7).
+
+4.5.  Cryptographic Aspects
+
+   In the algorithm description below, the following nomenclature, which
+   is consistent with [FIPS-198-1], is used:
+
+   H is the specific hashing algorithm (e.g., SHA-256).
+
+   K is the Authentication Key from the OSPFv3 Security Association.
+
+   Ks is a Protocol-Specific Authentication Key obtained by appending
+   Authentication Key (K) with the two-octet OSPFv3 Cryptographic
+   Protocol ID.
+
+
+
+Bhatia, et al.               Standards Track                   [Page 12]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+   Ko is the cryptographic key used with the hash algorithm.
+
+   B is the block size of H, measured in octets rather than bits.  Note
+   that B is the internal block size, not the hash size.
+
+      For SHA-1 and SHA-256: B == 64
+
+      For SHA-384 and SHA-512: B == 128
+
+   L is the length of the hash, measured in octets rather than bits.
+
+   XOR is the exclusive-or operation.
+
+   Opad is the hexadecimal value 0x5c repeated B times.
+
+   Ipad is the hexadecimal value 0x36 repeated B times.
+
+   Apad is a value that is the same length as the hash output or message
+   digest.  The first 16 octets contain the IPv6 source address followed
+   by the hexadecimal value 0x878FE1F3 repeated (L-16)/4 times.  This
+   implies that hash output is always a length of at least 16 octets.
+
+   1. Preparation of the Key
+
+      The OSPFv3 Cryptographic Protocol ID is appended to the
+      Authentication Key (K), yielding a Protocol-Specific
+      Authentication Key (Ks).  In this application, Ko is always
+      L octets long.  While [RFC2104] supports a key that is up to
+      B octets long, this application uses L as the Ks length consistent
+      with [RFC4822], [RFC5310], and [RFC5709].  According to
+      [FIPS-198-1], Section 3, keys greater than L octets do not
+      significantly increase the function strength.  Ks is computed as
+      follows:
+
+         If Ks is L octets long, then Ko is equal to Ks.  If Ks is more
+         than L octets long, then Ko is set to H(Ks).  If Ks is less
+         than L octets long, then Ko is set to the value of Ks, with
+         zeros appended to the end of Ks such that Ko is L octets long.
+
+   2. First-Hash
+
+      First, the OSPFv3 packet's Authentication Data field in the
+      Authentication Trailer is filled with the value Apad.  This is
+      very similar to the appendage described in [RFC2328],
+      Appendix D.4.3, Items (6)(a) and (6)(d)).
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                   [Page 13]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+      Then, a First-Hash, also known as the inner hash, is computed as
+      follows:
+
+         First-Hash = H(Ko XOR Ipad || (OSPFv3 Packet))
+
+         When XORing Ko and Ipad, Ko will be padded with zeros to the
+         length of Ipad.
+
+         Implementation Note: The First-Hash above includes the
+         Authentication Trailer as well as the OSPFv3 packet as per
+         [RFC2328], Appendix D.4.3, and the LLS data block, if present
+         [RFC5613].
+
+      The definition of Apad (above) ensures that it is always the same
+      length as the hash output.  This is consistent with RFC 2328.
+      Note that the "(OSPFv3 Packet)" referenced in the First-Hash
+      function above includes both the optional LLS data block and the
+      OSPFv3 Authentication Trailer.
+
+      The digest length for SHA-1 is 20 octets; for SHA-256, 32 octets;
+      for SHA-384, 48 octets; and for SHA-512, 64 octets.
+
+   3. Second-Hash
+
+      Then a Second-Hash, also known as the outer hash, is computed as
+      follows:
+
+         Second-Hash = H(Ko XOR Opad || First-Hash)
+
+         When XORing Ko and Opad, Ko will be padded with zeros to the
+         length of Opad.
+
+   4. Result
+
+      The resulting Second-Hash becomes the authentication data that is
+      sent in the Authentication Trailer of the OSPFv3 packet.  The
+      length of the authentication data is always identical to the
+      message digest size of the specific hash function H that is
+      being used.
+
+      This also means that the use of hash functions with larger output
+      sizes will also increase the size of the OSPFv3 packet as
+      transmitted on the wire.
+
+
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                   [Page 14]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+         Implementation Note: [RFC2328], Appendix D specifies that the
+         Authentication Trailer is not counted in the OSPF packet's own
+         Length field but is included in the packet's IP Length field.
+         Similar to this, the Authentication Trailer is not included in
+         the OSPFv3 header length but is included in the IPv6 header
+         payload length.
+
+4.6.  Message Verification
+
+   A router would determine that OSPFv3 is using an Authentication
+   Trailer (AT) by examining the AT-bit in the Options field in the
+   OSPFv3 header for Hello and Database Description packets.  The
+   specification in the Hello and Database Description options indicates
+   that other OSPFv3 packets will include the Authentication Trailer.
+
+   The AT is accessed using the OSPFv3 packet header length to access
+   the data after the OSPFv3 packet and, if an LLS data block [RFC5613]
+   is present, using the LLS data block length to access the data after
+   the LLS data block.  The L-bit in the OSPFv3 options in Hello and
+   Database Description packets is examined to determine if an LLS data
+   block is present.  If an LLS data block is present (as specified by
+   the L-bit), it is included along with the OSPFv3 Hello or Database
+   Description packet in the Cryptographic Authentication computation.
+
+   Due to the placement of the AT following the LLS data block and the
+   fact that the LLS data block is included in the Cryptographic
+   Authentication computation, OSPFv3 routers supporting this
+   specification MUST minimally support examining the L-bit in the
+   OSPFv3 options and using the length in the LLS data block to access
+   the AT.  It is RECOMMENDED that OSPFv3 routers supporting this
+   specification fully support OSPFv3 Link-Local Signaling [RFC5613].
+
+   If usage of the AT, as specified herein, is configured for an OSPFv3
+   link, OSPFv3 Hello and Database Description packets with the AT-bit
+   clear in the options will be dropped.  All OSPFv3 packet types will
+   be dropped if the AT is configured for the link and the IPv6 header
+   length is less than the amount necessary to include an Authentication
+   Trailer.
+
+   The receiving interface's OSPFv3 SA is located using the SA ID in the
+   received AT.  If the SA is not found, or if the SA is not valid for
+   reception (i.e., current time < KeyStartAccept or
+   current time >= KeyStopAccept), the OSPFv3 packet is dropped.
+
+   If the cryptographic sequence number in the AT is less than or equal
+   to the last sequence number in the last OSPFv3 packet of the same
+   OSPFv3 type successfully received from the neighbor, the OSPFv3
+
+
+
+
+Bhatia, et al.               Standards Track                   [Page 15]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+   packet MUST be dropped, and an error event SHOULD be logged.  OSPFv3
+   packets of different types may arrive out of order if they are
+   prioritized as recommended in [RFC4222].
+
+   Authentication-algorithm-dependent processing needs to be performed,
+   using the algorithm specified by the appropriate OSPFv3 SA for the
+   received packet.
+
+   Before an implementation performs any processing, it needs to save
+   the values of the Authentication Data field from the Authentication
+   Trailer appended to the OSPFv3 packet.
+
+   It should then set the Authentication Data field with Apad before the
+   authentication data is computed (as described in Section 4.5).  The
+   calculated data is compared with the received authentication data in
+   the Authentication Trailer.  If the two do not match, the packet MUST
+   be discarded, and an error event SHOULD be logged.
+
+   After the OSPFv3 packet has been successfully authenticated,
+   implementations MUST store the 64-bit cryptographic sequence number
+   for each OSPFv3 packet type received from the neighbor.  The saved
+   cryptographic sequence numbers will be used for replay checking for
+   subsequent packets received from the neighbor.
+
+5.  Migration and Backward Compatibility
+
+   All OSPFv3 routers participating on a link SHOULD be migrated to
+   OSPFv3 authentication at the same time.  As with OSPFv2
+   authentication, a mismatch in the SA ID, Authentication Type, or
+   message digest will result in failure to form an adjacency.  For
+   multi-access links, communities of OSPFv3 routers could be migrated
+   using different Interface Instance IDs.  However, at least one router
+   would need to form adjacencies between both the OSPFv3 routers
+   including and not including the Authentication Trailer.  This would
+   result in sub-optimal routing as well as added complexity and is only
+   recommended in cases where authentication is desired on the link and
+   migrating all the routers on the link at the same time isn't
+   feasible.
+
+   In support of uninterrupted deployment, an OSPFv3 router implementing
+   this specification MAY implement a transition mode where it includes
+   the Authentication Trailer in transmitted packets but does not verify
+   this information in received packets.  This is provided as a
+
+
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                   [Page 16]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+   transition aid for networks in the process of migrating to the
+   authentication mechanism described in this specification.  More
+   specifically:
+
+   1. OSPFv3 routers in transition mode will include the OSPFv3
+      Authentication Trailer in transmitted packets and set the AT-bit
+      in the Options field of transmitted Hello and Database Description
+      packets.  OSPFv3 routers receiving these packets and not having
+      authentication configured will ignore the Authentication Trailer
+      and AT-bit.
+
+   2. OSPFv3 routers in transition mode will also calculate and set the
+      OSPFv3 header checksum and the LLS data block checksum in
+      transmitted packets so that they will not be dropped by OSPFv3
+      routers without authentication configured.
+
+   3. OSPFv3 routers in transition mode will authenticate received
+      packets that either have the AT-bit set in the Options field for
+      Hello or Database Description packets or are from a neighbor that
+      previously set the AT-bit in the Options field of successfully
+      authenticated Hello and Database Description packets.
+
+   4. OSPFv3 routers in transition mode will also accept packets without
+      the Options field AT-bit set in Hello and Database Description
+      packets.  These packets will be assumed to be from OSPFv3 routers
+      without authentication configured, and they will not be
+      authenticated.  Additionally, the OSPFv3 header checksum and LLS
+      data block checksum will be validated.
+
+6.  Security Considerations
+
+   This document proposes extensions to OSPFv3 that would make it more
+   secure than OSPFv3 as defined in [RFC5340].  It does not provide
+   confidentiality, as a routing protocol contains information that does
+   not need to be kept secret.  It does, however, provide means to
+   authenticate the sender of packets that are of interest.  It
+   addresses all the security issues that have been identified in
+   [RFC6039] and [RFC6506].
+
+   It should be noted that the authentication method described in this
+   document is not being used to authenticate the specific originator of
+   a packet but rather is being used to confirm that the packet has
+   indeed been issued by a router that has access to the
+   Authentication Key.
+
+   Deployments SHOULD use sufficiently long and random values for the
+   Authentication Key so that guessing and other cryptographic attacks
+   on the key are not feasible in their environments.  Furthermore, it
+
+
+
+Bhatia, et al.               Standards Track                   [Page 17]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+   is RECOMMENDED that Authentication Keys incorporate at least 128
+   pseudorandom bits to minimize the risk of such attacks.  In support
+   of these recommendations, management systems SHOULD support
+   hexadecimal input of Authentication Keys.
+
+   Deployments that support a transitionary state but interoperate with
+   routers that do not support this authentication method may be exposed
+   to unauthenticated data during the transition period.
+
+   The mechanism described herein is not perfect and does not need to be
+   perfect.  Instead, this mechanism represents a significant increase
+   in the effort required for an adversary to successfully attack the
+   OSPFv3 protocol, while not causing undue implementation, deployment,
+   or operational complexity.
+
+   Refer to [RFC4552] for additional considerations on manual keying.
+
+7.  IANA Considerations
+
+   This document obsoletes RFC 6506; thus, IANA has updated the
+   references in existing registries that pointed to RFC 6506 to point
+   to this document.  This is the only IANA action requested by this
+   document.
+
+   IANA previously allocated the AT-bit (0x000400) in the "OSPFv3
+   Options (24 bits)" registry as described in Section 2.1.
+
+   IANA previously created the "Open Shortest Path First v3 (OSPFv3)
+   Authentication Trailer Options" registry.  This registry includes the
+   "OSPFv3 Authentication Types" registry, which defines valid values
+   for the Authentication Type field in the OSPFv3 Authentication
+   Trailer.  The registration procedure is Standards Action [RFC5226].
+
+           +-------------+-----------------------------------+
+           |Value        | Designation                       |
+           +-------------+-----------------------------------+
+           | 0           | Reserved                          |
+           |             |                                   |
+           | 1           | HMAC Cryptographic Authentication |
+           |             |                                   |
+           | 2-65535     | Unassigned                        |
+           +-------------+-----------------------------------+
+
+                        OSPFv3 Authentication Types
+
+   Finally, IANA previously created the "Keying and Authentication for
+   Routing Protocols (KARP) Parameters" registry.  This registry
+   includes the "Cryptographic Protocol ID" registry, which provides
+
+
+
+Bhatia, et al.               Standards Track                   [Page 18]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+   unique protocol-specific values for cryptographic applications,
+   including but not limited to prevention of cross-protocol replay
+   attacks.  Values can be assigned for both native IPv4/IPv6 protocols
+   and UDP/TCP protocols.  The registration procedure is Standards
+   Action.
+
+                  +-------------+----------------------+
+                  | Value/Range | Designation          |
+                  +-------------+----------------------+
+                  | 0           | Reserved             |
+                  |             |                      |
+                  | 1           | OSPFv3               |
+                  |             |                      |
+                  | 2-65535     | Unassigned           |
+                  +-------------+----------------------+
+
+                         Cryptographic Protocol ID
+
+8.  References
+
+8.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2328]  Moy, J., "OSPF Version 2", STD 54, RFC 2328, April 1998.
+
+   [RFC5340]  Coltun, R., Ferguson, D., Moy, J., and A. Lindem, "OSPF
+              for IPv6", RFC 5340, July 2008.
+
+   [RFC5709]  Bhatia, M., Manral, V., Fanto, M., White, R., Barnes, M.,
+              Li, T., and R. Atkinson, "OSPFv2 HMAC-SHA Cryptographic
+              Authentication", RFC 5709, October 2009.
+
+8.2.  Informative References
+
+   [FIPS-180-4]
+              US National Institute of Standards and Technology, "Secure
+              Hash Standard (SHS)", FIPS PUB 180-4, March 2012.
+
+   [FIPS-198-1]
+              US National Institute of Standards and Technology, "The
+              Keyed-Hash Message Authentication Code (HMAC)", FIPS
+              PUB 198-1, July 2008.
+
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                   [Page 19]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+   [MANUAL-KEY]
+              Bhatia, M., Hartman, S., and D. Zhang, "Security Extension
+              for OSPFv2 when using Manual Key Management", Work in
+              Progress, February 2011.
+
+   [RFC2104]  Krawczyk, H., Bellare, M., and R. Canetti, "HMAC: Keyed-
+              Hashing for Message Authentication", RFC 2104,
+              February 1997.
+
+   [RFC4222]  Choudhury, G., Ed., "Prioritized Treatment of Specific
+              OSPF Version 2 Packets and Congestion Avoidance", BCP 112,
+              RFC 4222, October 2005.
+
+   [RFC4302]  Kent, S., "IP Authentication Header", RFC 4302,
+              December 2005.
+
+   [RFC4303]  Kent, S., "IP Encapsulating Security Payload (ESP)",
+              RFC 4303, December 2005.
+
+   [RFC4552]  Gupta, M. and N. Melam, "Authentication/Confidentiality
+              for OSPFv3", RFC 4552, June 2006.
+
+   [RFC4822]  Atkinson, R. and M. Fanto, "RIPv2 Cryptographic
+              Authentication", RFC 4822, February 2007.
+
+   [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
+              IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+              May 2008.
+
+   [RFC5310]  Bhatia, M., Manral, V., Li, T., Atkinson, R., White, R.,
+              and M. Fanto, "IS-IS Generic Cryptographic
+              Authentication", RFC 5310, February 2009.
+
+   [RFC5613]  Zinin, A., Roy, A., Nguyen, L., Friedman, B., and D.
+              Yeung, "OSPF Link-Local Signaling", RFC 5613, August 2009.
+
+   [RFC5879]  Kivinen, T. and D. McDonald, "Heuristics for Detecting
+              ESP-NULL Packets", RFC 5879, May 2010.
+
+   [RFC5996]  Kaufman, C., Hoffman, P., Nir, Y., and P. Eronen,
+              "Internet Key Exchange Protocol Version 2 (IKEv2)",
+              RFC 5996, September 2010.
+
+
+
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                   [Page 20]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+   [RFC6039]  Manral, V., Bhatia, M., Jaeggli, J., and R. White, "Issues
+              with Existing Cryptographic Protection Methods for Routing
+              Protocols", RFC 6039, October 2010.
+
+   [RFC6506]  Bhatia, M., Manral, V., and A. Lindem, "Supporting
+              Authentication Trailer for OSPFv3", RFC 6506,
+              February 2012.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                   [Page 21]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+Appendix A.  Acknowledgments
+
+   First and foremost, thanks to the US National Institute of Standards
+   and Technology for their work on the SHA [FIPS-180-4] and HMAC
+   [FIPS-198-1].
+
+   Thanks also need to go to the authors of the HMAC-SHA authentication
+   RFCs, including [RFC4822], [RFC5310], and [RFC5709].  The basic
+   HMAC-SHA procedures were originally described by Ran Atkinson in
+   [RFC4822].
+
+   Also, thanks to Ran Atkinson for help in the analysis of RFC 6506
+   errata.
+
+   Thanks to Srinivasan K L and Marek Karasek for their identification
+   and submission of RFC 6506 errata.
+
+   Thanks to Sam Hartman for discussions on replay mitigation and the
+   use of a 64-bit strictly increasing sequence number.  Also, thanks to
+   Sam for comments during IETF last call with respect to the OSPFv3 SA
+   and the sharing of keys between protocols.
+
+   Thanks to Michael Barnes for numerous comments and strong input on
+   the coverage of LLS by the Authentication Trailer (AT).
+
+   Thanks to Marek Karasek for providing the specifics with respect to
+   backward-compatible transition mode.
+
+   Thanks to Michael Dubrovskiy and Anton Smirnov for comments on
+   document revisions.
+
+   Thanks to Rajesh Shetty for numerous comments, including the
+   suggestion to include an Authentication Type field in the
+   Authentication Trailer for extendibility.
+
+   Thanks to Uma Chunduri for suggesting that we may want to protect the
+   IPv6 source address even though OSPFv3 uses the Router ID for
+   neighbor identification.
+
+   Thanks to Srinivasan K L, Shraddha H, Alan Davey, Russ White, Stan
+   Ratliff, and Glen Kent for their support and review comments.
+
+   Thanks to Alia Atlas for comments made under the purview of the
+   Routing Directorate review.
+
+   Thanks to Stephen Farrell for comments during the IESG review.
+   Stephen was also involved in the discussion of cross-protocol
+   attacks.
+
+
+
+Bhatia, et al.               Standards Track                   [Page 22]
+
+RFC 7166            Authentication Trailer for OSPFv3         March 2014
+
+
+   Thanks to Brian Carpenter for comments made during the Gen-ART
+   review.
+
+   Thanks to Victor Kuarsingh for the OPS-DIR review.
+
+   Thanks to Brian Weis for the SEC-DIR review.
+
+Authors' Addresses
+
+   Manav Bhatia
+   Alcatel-Lucent
+   Bangalore
+   India
+
+   EMail: manav.bhatia@alcatel-lucent.com
+
+
+   Vishwas Manral
+   Ionos Corp.
+   4100 Moorpark Ave.
+   San Jose, CA  95117
+   USA
+
+   EMail: vishwas@ionosnetworks.com
+
+
+   Acee Lindem
+   Ericsson
+   301 Midenhall Way
+   Cary, NC  27513
+   USA
+
+   EMail: acee.lindem@ericsson.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                   [Page 23]
+

--- a/rfc/ospf/rfc7474.txt
+++ b/rfc/ospf/rfc7474.txt
@@ -1,0 +1,787 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                         M. Bhatia
+Request for Comments: 7474                                Ionos Networks
+Updates: 2328, 5709                                           S. Hartman
+Category: Standards Track                              Painless Security
+ISSN: 2070-1721                                                 D. Zhang
+                                           Huawei Technologies Co., Ltd.
+                                                          A. Lindem, Ed.
+                                                                   Cisco
+                                                              April 2015
+
+
+     Security Extension for OSPFv2 When Using Manual Key Management
+
+Abstract
+
+   The current OSPFv2 cryptographic authentication mechanism as defined
+   in RFCs 2328 and 5709 is vulnerable to both inter-session and intra-
+   session replay attacks when using manual keying.  Additionally, the
+   existing cryptographic authentication mechanism does not cover the IP
+   header.  This omission can be exploited to carry out various types of
+   attacks.
+
+   This document defines changes to the authentication sequence number
+   mechanism that will protect OSPFv2 from both inter-session and intra-
+   session replay attacks when using manual keys for securing OSPFv2
+   protocol packets.  Additionally, we also describe some changes in the
+   cryptographic hash computation that will eliminate attacks resulting
+   from OSPFv2 not protecting the IP header.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7474.
+
+
+
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                    [Page 1]
+
+RFC 7474               OSPF Manual Key Management             April 2015
+
+
+Copyright Notice
+
+   Copyright (c) 2015 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+     1.1.  Requirements Language . . . . . . . . . . . . . . . . . .   4
+   2.  Replay Protection Using Extended Sequence Numbers . . . . . .   4
+   3.  OSPF Packet Extensions  . . . . . . . . . . . . . . . . . . .   5
+   4.  OSPF Packet Key Selection . . . . . . . . . . . . . . . . . .   6
+     4.1.  Key Selection for Unicast OSPF Packet Transmission  . . .   7
+     4.2.  Key Selection for Multicast OSPF Packet Transmission  . .   8
+     4.3.  Key Selection for OSPF Packet Reception . . . . . . . . .   8
+   5.  Securing the IP Header  . . . . . . . . . . . . . . . . . . .   9
+   6.  Mitigating Cross-Protocol Attacks . . . . . . . . . . . . . .  10
+   7.  Backward Compatibility  . . . . . . . . . . . . . . . . . . .  11
+   8.  Security Considerations . . . . . . . . . . . . . . . . . . .  11
+   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  12
+   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  12
+     10.1.  Normative References . . . . . . . . . . . . . . . . . .  12
+     10.2.  Informative References . . . . . . . . . . . . . . . . .  12
+   Acknowledgments . . . . . . . . . . . . . . . . . . . . . . . . .  14
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  14
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                    [Page 2]
+
+RFC 7474               OSPF Manual Key Management             April 2015
+
+
+1.  Introduction
+
+   The OSPFv2 cryptographic authentication mechanism as described in
+   [RFC2328] uses per-packet sequence numbers to provide protection
+   against replay attacks.  The sequence numbers increase monotonically
+   so that attempts to replay stale packets can be thwarted.  The
+   sequence number values are maintained as a part of neighbor adjacency
+   state.  Therefore, if an adjacency is taken down, the associated
+   sequence numbers get reinitialized and neighbor adjacency formation
+   starts over again.  Additionally, the cryptographic authentication
+   mechanism does not specify how to deal with the rollover of a
+   sequence number when its value wraps.  These omissions can be
+   exploited by attackers to implement various replay attacks
+   ([RFC6039]).  In order to address these issues, we define extensions
+   to the authentication sequence number mechanism.
+
+   The cryptographic authentication as described in [RFC2328] and later
+   updated in [RFC5709] does not include the IP header.  This omission
+   can be exploited to launch several attacks as the source address in
+   the IP header is not protected.  The OSPF specification, for
+   broadcast and NBMA (Non-Broadcast Multi-Access) networks, requires
+   implementations to use the source address in the IP header to
+   determine the neighbor from which the packet was received.  Changing
+   the IP source address of a packet to a conflicting IP address can be
+   exploited to produce a number of denial-of-service attacks [RFC6039].
+   If the packet is interpreted as coming from a different neighbor, the
+   received sequence number state for that neighbor may be incorrectly
+   updated.  This attack may disrupt communication with a legitimate
+   neighbor.  Hello packets may be reflected to cause a neighbor to
+   appear to have one-way communication.  Additionally, Database
+   Description packets may be reflected in cases where the per-packet
+   sequence numbers are sufficiently divergent in order to disrupt an
+   adjacency [RFC6863].  This is the IP-layer issue described in point
+   18 in Section 4 of [RFC6862].
+
+   [RFC2328] states that implementations MUST offer keyed MD5
+   authentication.  It is likely that this will be deprecated in favor
+   of the stronger algorithms described in [RFC5709] and required in
+   [RFC6094].
+
+   This document defines a few simple changes to the cryptographic
+   authentication mechanism, as currently described in [RFC5709], to
+   prevent such IP-layer attacks.
+
+
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                    [Page 3]
+
+RFC 7474               OSPF Manual Key Management             April 2015
+
+
+1.1.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+   When used in lowercase, these words convey their typical use in
+   common language, and are not to be interpreted as described in RFC
+   2119 [RFC2119].
+
+2.  Replay Protection Using Extended Sequence Numbers
+
+   In order to provide replay protection against both inter-session and
+   intra-session replay attacks, the OSPFv2 sequence number is expanded
+   to 64 bits with the least significant 32-bit value containing a
+   strictly increasing sequence number and the most significant 32-bit
+   value containing the boot count.  OSPFv2 implementations are required
+   to retain the boot count in non-volatile storage for the deployment
+   life of the OSPF router.  The requirement to preserve the boot count
+   is also placed on SNMP agents by the SNMPv3 security architecture
+   (refer to snmpEngineBoots in Section 2.2 of [RFC3414]).
+
+   Since there is no room in the OSPFv2 packet for a 64-bit sequence
+   number, it will occupy the 8 octets following the OSPFv2 packet and
+   MUST be included when calculating the OSPFv2 packet digest.  These
+   additional 8 octets are not included in the OSPFv2 packet header
+   length but are included in the OSPFv2 header Authentication Data
+   length and the IPv4 packet header length.
+
+   The lower-order 32-bit sequence number MUST be incremented for every
+   OSPF packet sent by the OSPF router.  Upon reception, the sequence
+   number MUST be greater than the sequence number in the last OSPF
+   packet of that type accepted from the sending OSPF neighbor.
+   Otherwise, the OSPF packet is considered a replayed packet and
+   dropped.  OSPF packets of different types may arrive out of order if
+   they are prioritized as recommended in [RFC4222].
+
+   OSPF routers implementing this specification MUST use available
+   mechanisms to preserve the sequence number's strictly increasing
+   property for the deployed life of the OSPFv2 router (including cold
+   restarts).  This is achieved by maintaining a boot count in non-
+   volatile storage and incrementing it each time the OSPF router loses
+   its prior sequence number state.  The SNMPv3 snmpEngineBoots variable
+   [RFC3414] MAY be used for this purpose.  However, maintaining a
+   separate boot count solely for OSPF sequence numbers has the
+   advantage of decoupling SNMP reinitialization and OSPF
+   reinitialization.  Also, in the rare event that the lower-order
+
+
+
+
+Bhatia, et al.               Standards Track                    [Page 4]
+
+RFC 7474               OSPF Manual Key Management             April 2015
+
+
+   32-bit sequence number wraps, the boot count can be incremented to
+   preserve the strictly increasing property of the aggregate sequence
+   number.  Hence, a separate OSPF boot count is RECOMMENDED.
+
+3.  OSPF Packet Extensions
+
+   The OSPF packet header includes an authentication type field, and 64
+   bits of data for use by the appropriate authentication scheme
+   (determined by the type field).  Authentication types 0, 1, and 2 are
+   defined [RFC2328].  This section defines Authentication type 3.
+
+   When using this authentication scheme, the 64-bit Authentication
+   field (as defined in Appendix D.3 of [RFC2328]) in the OSPF packet
+   header (as defined in Appendix A.3.1 of [RFC2328] and [RFC6549]) is
+   changed as shown in Figure 1.  The sequence number is removed and the
+   Key ID is extended to 32 bits and moved to the former position of the
+   sequence number.
+
+   Additionally, the 64-bit sequence number is moved to the first 64
+   bits following the OSPFv2 packet and is protected by the
+   authentication digest.  These additional 64 bits or 8 octets are
+   included in the IP header length but not the OSPF header packet
+   length.
+
+   Finally, the 0 field at the start of the OSPFv2 header authentication
+   is extended from 16 bits to 24 bits.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                    [Page 5]
+
+RFC 7474               OSPF Manual Key Management             April 2015
+
+
+        0                   1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |  Version #  |     Type        |       Packet length           |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                          Router ID                            |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                           Area ID                             |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |           Checksum            | Instance ID   |  AuType       |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                               0               | Auth Data Len |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                         Key ID                                |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                                                               |
+       |                   OSPF Protocol Packet                        |
+       ~                                                               ~
+       |                                                               |
+       |                                                               |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |     Sequence Number (Boot Count)                              |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |     Sequence Number (Strictly Increasing Packet Counter)      |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                                                               |
+       ~                Authentication Data                            ~
+       |                                                               |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+           Figure 1: Extended Sequence Number Packet Extensions
+
+4.  OSPF Packet Key Selection
+
+   This section describes how this security solution selects long-lived
+   keys from key tables.  [RFC7210].  In this context, we are selecting
+   the key and corresponding Security Association (SA) as defined in
+   Section 3.2 of [RFC5709].  Generally, a key used for OSPFv2 packet
+   authentication should satisfy the following requirements:
+
+   o  For packet transmission, the key validity interval as defined by
+      SendLifetimeStart and SendLifetimeEnd must include the current
+      time.
+
+   o  For packet reception, the key validity interval as defined by
+      AcceptLifetimeStart and AcceptLifetimeEnd must include the current
+      time.
+
+
+
+
+Bhatia, et al.               Standards Track                    [Page 6]
+
+RFC 7474               OSPF Manual Key Management             April 2015
+
+
+   o  The key must be valid for the desired security algorithm.
+
+   In the remainder of this section, additional requirements for keys
+   are enumerated for different scenarios.
+
+4.1.  Key Selection for Unicast OSPF Packet Transmission
+
+   Assume that a router R1 tries to send a unicast OSPF packet from its
+   interface I1 to the interface I2 of a remote router R2 using security
+   protocol P via interface I at time T.  First, consider the
+   circumstances where R1 and R2 are not connected with a virtual link.
+   R1 then needs to select a long-lived symmetric key from its key
+   table.  Because the key should be shared by both R1 and R2 to protect
+   the communication between I1 and I2, the key should satisfy the
+   following requirements:
+
+   o  The Peers field contains the area ID or, if no key containing the
+      area ID is present, the string "all".
+
+   o  The Direction field is either "out" or "both".
+
+   o  The Interfaces field matches I1 or "all".
+
+   o  If multiple keys match the Interface field, keys that explicitly
+      match I1 should be preferred over keys matching "all".  If there
+      are still multiple keys that match, the key with the most recent
+      SendLifetimeStart will be selected.  This will facilitate graceful
+      key rollover.
+
+   o  The Key ID field in the OSPFv2 header (refer to Figure 1) will be
+      set to the selected key's LocalKeyName.
+
+   When R1 and R2 are connected to a virtual link, the Peers field must
+   identify the virtual endpoint rather than the virtual link.  Since
+   there may be virtual links to the same router, the transit area ID
+   must be part of the identifier.  Hence, the key should satisfy the
+   following requirements:
+
+   o  The Peers field includes both the virtual endpoint's OSPF router
+      ID and the transit area ID for the virtual link in the form of the
+      transit area ID, followed by a colon, followed by the router ID.
+      If no such key exists, then a key with the Peers field set to the
+      transit area ID is used, followed by a key with the Peers field
+      set to "all".
+
+   o  The Interfaces field is not used for key selection on virtual
+      links.
+
+
+
+
+Bhatia, et al.               Standards Track                    [Page 7]
+
+RFC 7474               OSPF Manual Key Management             April 2015
+
+
+   o  The Direction field is either "out" or "both".
+
+   o  If multiple keys match the Peers field, keys that explicitly match
+      the router ID should be preferred, followed by keys with a transit
+      area specified, followed by keys with the Peers field set to
+      "all".  If there are still multiple keys that match, the key with
+      the most recent SendLifetimeStart will be selected.  This will
+      facilitate graceful key rollover.
+
+   o  The Key ID field in the OSPFv2 header (refer to Figure 1) will be
+      set to the selected key's LocalKeyName.
+
+4.2.  Key Selection for Multicast OSPF Packet Transmission
+
+   If a router R1 sends an OSPF packet from its interface I1 to a
+   multicast address (i.e., AllSPFRouters or AllDRouters), it needs to
+   select a key according to the following requirements:
+
+   o  First, try a key with the Peers field containing the area ID to
+      which the interface belongs.  If no key exists, try a key with the
+      Peers field "all".
+
+   o  The Interfaces field matches the interface over which the packet
+      is sent or "all".
+
+   o  The Direction field is either "out" or "both".
+
+   o  If multiple keys match the Interface field, keys that explicitly
+      match I1 should be preferred over keys matching "all".  If there
+      are still multiple keys that match, the key with the most resent
+      SendLifetimeStart will be selected.  This will facilitate graceful
+      key rollover.
+
+   o  The Key ID field in the OSPFv2 header (refer to Figure 1) will be
+      set to the selected key's LocalKeyName.
+
+4.3.  Key Selection for OSPF Packet Reception
+
+   When cryptographic authentication is used, the ID of the
+   authentication key is included in the authentication field of the
+   OSPF packet header.  Using this Key ID, it is straight forward for a
+   receiver to locate the corresponding key.  The simple requirements
+   are:
+
+   o  The interface on which the key was received is associated with the
+      key's interface.
+
+
+
+
+
+Bhatia, et al.               Standards Track                    [Page 8]
+
+RFC 7474               OSPF Manual Key Management             April 2015
+
+
+   o  The Key ID obtained from the OSPFv2 packet header corresponds to
+      the neighbor's PeerKeyName.  Since OSPFv2 keys are symmetric, the
+      LocalKeyName and PeerKeyName for OSPFv2 keys will be identical.
+      Hence, the Key ID will be used to select the correct local key.
+
+   o  The Direction field is either "in" or "both".
+
+   o  The Peers field matches as described in Sections Section 4.1 and
+      Section 4.2.
+
+5.  Securing the IP Header
+
+   This document updates the definition of the Apad constant, as it is
+   defined in [RFC5709], to include the IP source address from the IP
+   header of the OSPFv2 protocol packet.  The overall cryptographic
+   authentication process defined in [RFC5709] remains unchanged.  To
+   reduce the potential for confusion, this section minimizes the
+   repetition of text from RFC 5709 [RFC5709].  The changes are:
+
+   RFC 5709, Section 3.3 describes how the cryptographic authentication
+   must be computed.  In RFC 5709, the First-Hash includes the OSPF
+   packet and Authentication Trailer.  With this specification, the
+   64-bit sequence number will be included in the First-Hash along with
+   the Authentication Trailer and OSPF packet.
+
+   RFC 5709, Section 3.3 also requires the OSPFv2 packet's
+   Authentication Trailer (which is the appendage described in RFC 2328,
+   Appendix D.4.3, page 233, items (6)(a) and (6)(d)) to be filled with
+   the value Apad.  Apad is a hexadecimal constant with the value
+   0x878FE1F3 repeated (L/4) times, where L is the length of the hash
+   being used and is measured in octets rather than bits.
+
+   OSPF routers sending OSPF packets must initialize the first 4 octets
+   of Apad to the value of the IP source address that would be used when
+   sending the OSPFv2 packet.  The remainder of Apad will contain the
+   value 0x878FE1F3 repeated (L - 4)/4 times, where L is the length of
+   the hash, measured in octets.  The basic idea is to incorporate the
+   IP source address from the IP header in the cryptographic
+   authentication computation so that any change of IP source address in
+   a replayed packet can be detected.
+
+   When an OSPF packet is received, implementations MUST initialize the
+   first 4 octets of Apad to the IP source address from the IP header of
+   the incoming OSPFv2 packet.  The remainder of Apad will contain the
+   value 0x878FE1F3 repeated (L - 4)/4 times, where L is the length of
+   the hash, measured in octets.  Besides changing the value of Apad,
+   this document does not introduce any other changes to the
+   authentication mechanism described in [RFC5709].  This would prevent
+
+
+
+Bhatia, et al.               Standards Track                    [Page 9]
+
+RFC 7474               OSPF Manual Key Management             April 2015
+
+
+   all attacks where a rogue OSPF router changes the IP source address
+   of an OSPFv2 packet and replays it on the same multi-access interface
+   or another interface since the IP source address is now included in
+   the cryptographic hash computation and modification would result in
+   the OSPFv2 packet being dropped due to an authentication failure.
+
+6.  Mitigating Cross-Protocol Attacks
+
+   In order to prevent cross-protocol replay attacks for protocols
+   sharing common keys, the two-octet OSPFv2 Cryptographic Protocol ID
+   is appended to the authentication key prior to use.  Refer to the
+   IANA Considerations (Section 9).
+
+   [RFC5709], Section 3.3 describes the mechanism to prepare the key
+   used in the hash computation.  This document updates the text under
+   "(1) PREPARATION OF KEY" as follows:
+
+      The OSPFv2 Cryptographic Protocol ID is appended to the
+      Authentication Key (K) yielding a Protocol-Specific Authentication
+      Key (Ks).  In this application, Ko is always L octets long.  While
+      [RFC2104] supports a key that is up to B octets long, this
+      application uses L as the Ks length consistent with [RFC4822],
+      [RFC5310], and [RFC5709].  According to [FIPS-198], Section 3,
+      keys greater than L octets do not significantly increase the
+      function strength.  Ks is computed as follows:
+
+      If the Protocol-Specific Authentication Key (Ks) is L octets long,
+      then Ko is equal to Ks.  If the Protocol-Specific Authentication
+      Key (Ks) is more than L octets long, then Ko is set to H(Ks).  If
+      the Protocol-Specific Authentication Key (Ks) is less than L
+      octets long, then Ko is set to the Protocol-Specific
+      Authentication Key (Ks) with zeros appended to the end of the
+      Protocol-Specific Authentication Key (Ks) such that Ko is L octets
+      long.
+
+   Once the cryptographic key (Ko) used with the hash algorithm is
+   derived, the rest of the authentication mechanism described in
+   [RFC5709] remains unchanged other than one detail that was
+   unspecified.  When XORing Ko and Ipad of Opad, Ko MUST be padded with
+   zeros to the length of Ipad or Opad.  It is expected that
+   implementations of [RFC5709] perform this padding implicitly.
+
+
+
+
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                   [Page 10]
+
+RFC 7474               OSPF Manual Key Management             April 2015
+
+
+7.  Backward Compatibility
+
+   This security extension uses a new authentication type, AuType in the
+   OSPFv2 header (refer to Figure 1).  When an OSPFv2 packet is received
+   and the AuType doesn't match the configured authentication type for
+   the interface, the OSPFv2 packet will be dropped as specified in RFC
+   2328 [RFC2328].  This guarantees backward-compatible behavior
+   consistent with any other authentication type mismatch.
+
+8.  Security Considerations
+
+   This document rectifies the manual key management procedure that
+   currently exists within OSPFv2, as part of Phase 1 of the KARP
+   Working Group.  Therefore, only the OSPFv2 manual key management
+   mechanism is considered.  Any solution that takes advantage of the
+   automatic key management mechanism is beyond the scope of this
+   document.
+
+   The described sequence number extension offers most of the benefits
+   of more complicated mechanisms without their attendant challenges.
+   There are, however, a couple drawbacks to this approach.  First, it
+   requires the OSPF implementation to be able to save its boot count in
+   non-volatile storage.  If the non-volatile storage is ever repaired
+   or upgraded such that the contents are lost or the OSPFv2 router is
+   replaced, the authentication keys MUST be changed to prevent replay
+   attacks.
+
+   Second, if a router is taken out of service completely (either
+   intentionally or due to a persistent failure), the potential exists
+   for reestablishment of an OSPFv2 adjacency by replaying the entire
+   OSPFv2 session establishment.  However, this scenario is extremely
+   unlikely, since it would imply an identical OSPFv2 adjacency
+   formation packet exchange.  Without adjacency formation, the replay
+   of OSPFv2 hello packets alone for an OSPFv2 router that has been
+   taken out of service should not result in any serious attack, as the
+   only consequence is superfluous processing.  Of course, this attack
+   could also be thwarted by changing the relevant manual keys.
+
+   This document also provides a solution to prevent certain denial-of-
+   service attacks that can be launched by changing the source address
+   in the IP header of an OSPFv2 protocol packet.
+
+   Using a single crypto sequence number can leave the router vulnerable
+   to a replay attack where it uses the same source IP address on two
+   different point-to-point unnumbered links.  In such environments
+   where an attacker can actively tap the point-to-point links, it's
+   recommended that the user employ different keys on each of those
+   unnumbered IP interfaces.
+
+
+
+Bhatia, et al.               Standards Track                   [Page 11]
+
+RFC 7474               OSPF Manual Key Management             April 2015
+
+
+9.  IANA Considerations
+
+   This document registers a new code point from the "OSPF Shortest Path
+   First (OSPF) Authentication Codes" registry:
+
+   o  3 - Cryptographic Authentication with Extended Sequence Numbers.
+
+   This document also registers a new code point from the
+   "Authentication Cryptographic Protocol ID" registry defined under
+   "Keying and Authentication for Routing Protocols (KARP) Parameters":
+
+   o  3 - OSPFv2.
+
+10.  References
+
+10.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997,
+              <http://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC2328]  Moy, J., "OSPF Version 2", STD 54, RFC 2328, April 1998,
+              <http://www.rfc-editor.org/info/rfc2328>.
+
+   [RFC5709]  Bhatia, M., Manral, V., Fanto, M., White, R., Barnes, M.,
+              Li, T., and R. Atkinson, "OSPFv2 HMAC-SHA Cryptographic
+              Authentication", RFC 5709, October 2009,
+              <http://www.rfc-editor.org/info/rfc5709>.
+
+10.2.  Informative References
+
+   [FIPS-198]
+              US National Institute of Standards and Technology, "The
+              Keyed-Hash Message Authentication Code (HMAC)", FIPS PUB
+              198-1, July 2008.
+
+   [RFC2104]  Krawczyk, H., Bellare, M., and R. Canetti, "HMAC: Keyed-
+              Hashing for Message Authentication", RFC 2104, February
+              1997, <http://www.rfc-editor.org/info/rfc2104>.
+
+   [RFC3414]  Blumenthal, U. and B. Wijnen, "User-based Security Model
+              (USM) for version 3 of the Simple Network Management
+              Protocol (SNMPv3)", STD 62, RFC 3414, December 2002,
+              <http://www.rfc-editor.org/info/rfc3414>.
+
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                   [Page 12]
+
+RFC 7474               OSPF Manual Key Management             April 2015
+
+
+   [RFC4222]  Choudhury, G., Ed., "Prioritized Treatment of Specific
+              OSPF Version 2 Packets and Congestion Avoidance", BCP 112,
+              RFC 4222, October 2005,
+              <http://www.rfc-editor.org/info/rfc4222>.
+
+   [RFC4822]  Atkinson, R. and M. Fanto, "RIPv2 Cryptographic
+              Authentication", RFC 4822, February 2007,
+              <http://www.rfc-editor.org/info/rfc4822>.
+
+   [RFC5310]  Bhatia, M., Manral, V., Li, T., Atkinson, R., White, R.,
+              and M. Fanto, "IS-IS Generic Cryptographic
+              Authentication", RFC 5310, February 2009,
+              <http://www.rfc-editor.org/info/rfc5310>.
+
+   [RFC6039]  Manral, V., Bhatia, M., Jaeggli, J., and R. White, "Issues
+              with Existing Cryptographic Protection Methods for Routing
+              Protocols", RFC 6039, October 2010,
+              <http://www.rfc-editor.org/info/rfc6039>.
+
+   [RFC6094]  Bhatia, M. and V. Manral, "Summary of Cryptographic
+              Authentication Algorithm Implementation Requirements for
+              Routing Protocols", RFC 6094, February 2011,
+              <http://www.rfc-editor.org/info/rfc6094>.
+
+   [RFC6549]  Lindem, A., Roy, A., and S. Mirtorabi, "OSPFv2 Multi-
+              Instance Extensions", RFC 6549, March 2012,
+              <http://www.rfc-editor.org/info/rfc6549>.
+
+   [RFC6862]  Lebovitz, G., Bhatia, M., and B. Weis, "Keying and
+              Authentication for Routing Protocols (KARP) Overview,
+              Threats, and Requirements", RFC 6862, March 2013,
+              <http://www.rfc-editor.org/info/rfc6862>.
+
+   [RFC6863]  Hartman, S. and D. Zhang, "Analysis of OSPF Security
+              According to the Keying and Authentication for Routing
+              Protocols (KARP) Design Guide", RFC 6863, March 2013,
+              <http://www.rfc-editor.org/info/rfc6863>.
+
+   [RFC7210]  Housley, R., Polk, T., Hartman, S., and D. Zhang,
+              "Database of Long-Lived Symmetric Cryptographic Keys", RFC
+              7210, April 2014,
+              <http://www.rfc-editor.org/info/rfc7210>.
+
+
+
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                   [Page 13]
+
+RFC 7474               OSPF Manual Key Management             April 2015
+
+
+Acknowledgments
+
+   Thanks to Ran Atkinson for help in the analysis of errata for RFC
+   6506, which led to clarifications in this document.
+
+   Thanks to Gabi Nakibly for pointing out a possible attack on P2P
+   links.
+
+   Thanks to Suresh Krishnan for comments made during the Gen-Art
+   review.  In particular, thanks for pointing out an ambiguity in the
+   initialization of Apad.
+
+   Thanks to Shaun Cooley for the security directorate review.
+
+   Thanks to Adrian Farrel for comments during the IESG last call.
+
+Authors' Addresses
+
+   Manav Bhatia
+   Ionos Networks
+   Bangalore
+   India
+
+   EMail: manav@ionosnetworks.com
+
+
+   Sam Hartman
+   Painless Security
+
+   EMail: hartmans-ietf@mit.edu
+
+
+   Dacheng Zhang
+   Huawei Technologies Co., Ltd.
+   Beijing
+   China
+
+   EMail: dacheng.zhang@gmail.com
+
+
+   Acee Lindem (editor)
+   Cisco
+   United States
+
+   EMail: acee@cisco.com
+
+
+
+
+
+
+Bhatia, et al.               Standards Track                   [Page 14]
+

--- a/rfc/ospf/rfc8177.txt
+++ b/rfc/ospf/rfc8177.txt
@@ -1,0 +1,1403 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                    A. Lindem, Ed.
+Request for Comments: 8177                                 Cisco Systems
+Category: Standards Track                                          Y. Qu
+ISSN: 2070-1721                                                   Huawei
+                                                                D. Yeung
+                                                             Arrcus, Inc
+                                                                 I. Chen
+                                                                   Jabil
+                                                                J. Zhang
+                                                        Juniper Networks
+                                                               June 2017
+
+
+                     YANG Data Model for Key Chains
+
+Abstract
+
+   This document describes the key chain YANG data model.  Key chains
+   are commonly used for routing protocol authentication and other
+   applications requiring symmetric keys.  A key chain is a list
+   containing one or more elements containing a Key ID, key string,
+   send/accept lifetimes, and the associated authentication or
+   encryption algorithm.  By properly overlapping the send and accept
+   lifetimes of multiple key chain elements, key strings and algorithms
+   may be gracefully updated.  By representing them in a YANG data
+   model, key distribution can be automated.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 7841.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc8177.
+
+
+
+
+
+
+
+
+
+
+
+Lindem, et al.               Standards Track                    [Page 1]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+Copyright Notice
+
+   Copyright (c) 2017 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+     1.1.  Requirements Notation . . . . . . . . . . . . . . . . . .   3
+     1.2.  Tree Diagrams . . . . . . . . . . . . . . . . . . . . . .   3
+   2.  Problem Statement . . . . . . . . . . . . . . . . . . . . . .   4
+     2.1.  Applicability . . . . . . . . . . . . . . . . . . . . . .   4
+     2.2.  Graceful Key Rollover Using Key Chains  . . . . . . . . .   4
+   3.  Design of the Key Chain Model . . . . . . . . . . . . . . . .   5
+     3.1.  Key Chain Operational State . . . . . . . . . . . . . . .   6
+     3.2.  Key Chain Model Features  . . . . . . . . . . . . . . . .   6
+     3.3.  Key Chain Model Tree  . . . . . . . . . . . . . . . . . .   7
+   4.  Key Chain YANG Model  . . . . . . . . . . . . . . . . . . . .   8
+   5.  Security Considerations . . . . . . . . . . . . . . . . . . .  16
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  17
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  18
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . .  18
+     7.2.  Informative References  . . . . . . . . . . . . . . . . .  19
+   Appendix A.  Examples . . . . . . . . . . . . . . . . . . . . . .  21
+     A.1.  Simple Key Chain with an Always Valid Single Key  . . . .  21
+     A.2.  Key Chain with Keys Having Different Lifetimes  . . . . .  21
+     A.3.  Key Chain with Independent Send and Accept Lifetimes  . .  23
+   Contributors  . . . . . . . . . . . . . . . . . . . . . . . . . .  24
+   Acknowledgments . . . . . . . . . . . . . . . . . . . . . . . . .  24
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  25
+
+
+
+
+
+
+
+
+
+
+
+Lindem, et al.               Standards Track                    [Page 2]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+1.  Introduction
+
+   This document describes the key chain YANG [YANG-1.1] data model.
+   Key chains are commonly used for routing protocol authentication and
+   other applications requiring symmetric keys.  A key chain is a list
+   containing one or more elements containing a Key ID, key string,
+   send/accept lifetimes, and the associated authentication or
+   encryption algorithm.  By properly overlapping the send and accept
+   lifetimes of multiple key chain elements, key strings and algorithms
+   may be gracefully updated.  By representing them in a YANG data
+   model, key distribution can be automated.
+
+   In some applications, the protocols do not use the key chain element
+   key directly, but rather a key derivation function is used to derive
+   a short-lived key from the key chain element key (e.g., the master
+   keys used in [TCP-AO]).
+
+1.1.  Requirements Notation
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in
+   BCP 14 [KEYWORDS] [KEYWORDS-UPD] when, and only when, they appear in
+   all capitals, as shown here.
+
+1.2.  Tree Diagrams
+
+   A simplified graphical representation of the complete data tree is
+   presented in Section 3.3.  The following tree notation is used.
+
+   o  Brackets "[" and "]" enclose YANG list keys.  These YANG list keys
+      should not be confused with the key chain keys.
+
+   o  Curly braces "{" and "}" contain names of optional features that
+      make the corresponding node conditional.
+
+   o  Abbreviations before data node names: "rw" means configuration
+      (read-write), "ro" means state data (read-only), "-x" means RPC
+      operations, and "-n" means notifications.
+
+   o  Symbols after data node names: "?" means an optional node, "!"
+      denotes a container with presence, and "*" denotes a "list" or
+      "leaf-list".
+
+   o  Parentheses enclose choice and case nodes, and case nodes are also
+      marked with a colon (":").
+
+
+
+
+
+Lindem, et al.               Standards Track                    [Page 3]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+   o  Ellipsis ("...") stands for contents of subtrees that are not
+      shown.
+
+2.  Problem Statement
+
+   This document describes a YANG [YANG-1.1] data model for key chains.
+   Key chains have been implemented and deployed by a large percentage
+   of network equipment vendors.  Providing a standard YANG model will
+   facilitate automated key distribution and non-disruptive key
+   rollover.  This will aid in tightening the security of the core
+   routing infrastructure as recommended in [IAB-REPORT].
+
+   A key chain is a list containing one or more elements containing a
+   Key ID, key string, send/accept lifetimes, and the associated
+   authentication or encryption algorithm.  A key chain can be used by
+   any service or application requiring authentication or encryption
+   using symmetric keys.  In essence, the key chain is a reusable key
+   policy that can be referenced wherever it is required.  The key chain
+   construct has been implemented by most networking vendors and
+   deployed in many networks.
+
+   A conceptual representation of a crypto key table is described in
+   [CRYPTO-KEYTABLE].  The crypto key table includes keys as well as
+   their corresponding lifetimes and algorithms.  Additionally, the key
+   table includes key selection criteria and is designed for a
+   deployment model where the details of the applications or services
+   requiring authentication or encryption permeate into the key
+   database.  The YANG key chain model described herein doesn't include
+   key selection criteria or support this deployment model.  At the same
+   time, it does not preclude it.  [YANG-CRYPTO-KEYTABLE] describes
+   augmentations to the key chain YANG model in support of key selection
+   criteria.
+
+2.1.  Applicability
+
+   Other YANG modules may reference ietf-key-chain YANG module key-chain
+   names for authentication and encryption applications.  A YANG type
+   has been provided to facilitate reference to the key-chain name
+   without having to specify the complete YANG XML Path Language (XPath)
+   expression.
+
+2.2.  Graceful Key Rollover Using Key Chains
+
+   Key chains may be used to gracefully update the key string and/or
+   algorithm used by an application for authentication or encryption.
+   To achieve graceful key rollover, the receiver MAY accept all the
+
+
+
+
+
+Lindem, et al.               Standards Track                    [Page 4]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+   keys that have a valid accept lifetime, and the sender MAY send the
+   key with the most recent send lifetime.  One scenario for
+   facilitating key rollover is to:
+
+   1.  Distribute a key chain with a new key to all the routers or other
+       network devices in the domain of that key chain.  The new key's
+       accept lifetime should be such that it is accepted during the key
+       rollover period.  The send lifetime should be a time in the
+       future when it can be assured that all the routers in the domain
+       of that key are upgraded.  This will have no immediate impact on
+       the keys used for transmission.
+
+   2.  Assure that all the network devices have been updated with the
+       updated key chain and that their system times are roughly
+       synchronized.  The system times of devices within an
+       administrative domain are commonly synchronized (e.g., using the
+       Network Time Protocol (NTP) [NTP-PROTO]).  This also may be
+       automated.
+
+   3.  When the send lifetime of the new key becomes valid, the network
+       devices within the domain of that key chain will use the new key
+       for transmissions.
+
+   4.  At some point in the future, a new key chain with the old key
+       removed may be distributed to the network devices within the
+       domain of the key chain.  However, this may be deferred until the
+       next key rollover.  If this is done, the key chain will always
+       include two keys: either the current and future key (during key
+       rollovers) or the current and previous keys (between key
+       rollovers).
+
+   Since the most recent send lifetime is defined as the one with the
+   latest start-time, specification of "always" will prevent using the
+   graceful key rollover technique described above.  Other key
+   configuration and usage scenarios are possible, but these are beyond
+   the scope of this document.
+
+3.  Design of the Key Chain Model
+
+   The ietf-key-chain module contains a list of one or more keys indexed
+   by a Key ID.  For some applications (e.g., OSPFv3 [OSPFV3-AUTH]), the
+   Key ID is used to identify the key chain key to be used.  In addition
+   to the Key ID, each key chain key includes a key string and a
+   cryptographic algorithm.  Optionally, the key chain keys include
+   send/accept lifetimes.  If the send/accept lifetime is unspecified,
+   the key is always considered valid.
+
+
+
+
+
+Lindem, et al.               Standards Track                    [Page 5]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+   Note that different key values for transmission versus acceptance may
+   be supported with multiple key chain elements.  The key used for
+   transmission will have a valid send-lifetime and invalid accept-
+   lifetime (e.g., has an end-time equal to the start-time).  The key
+   used for acceptance will have a valid accept-lifetime and invalid
+   send-lifetime.
+
+   Due to the differences in key chain implementations across various
+   vendors, some of the data elements are optional.  Finally, the crypto
+   algorithm identities are provided for reuse when configuring legacy
+   authentication and encryption not using key chains.
+
+   A key chain is identified by a unique name within the scope of the
+   network device.  The "key-chain-ref" typedef SHOULD be used by other
+   YANG modules when they need to reference a configured key chain.
+
+3.1.  Key Chain Operational State
+
+   The key chain operational state is included in the same tree as key
+   chain configuration consistent with Network Management Datastore
+   Architecture [NMDA].  The timestamp of the last key chain
+   modification is also maintained in the operational state.
+   Additionally, the operational state includes an indication of whether
+   or not a key chain key is valid for transmission or acceptance.
+
+3.2.  Key Chain Model Features
+
+   Features are used to handle differences between vendor
+   implementations.  For example, not all vendors support configuration
+   of an acceptance tolerance or configuration of key strings in
+   hexadecimal.  They are also used to support security requirements
+   (e.g., TCP-AO algorithms [TCP-AO-ALGORITHMS]) not yet implemented by
+   vendors or implemented by only a single vendor.
+
+   It is common for an entity with sufficient permissions to read and
+   store a device's configuration, which would include the contents of
+   this model.  To avoid unnecessarily seeing and storing the keys in
+   cleartext, this model provides the aes-key-wrap feature.  More
+   details are described in the Security Considerations (Section 5).
+
+
+
+
+
+
+
+
+
+
+
+
+Lindem, et al.               Standards Track                    [Page 6]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+3.3.  Key Chain Model Tree
+
+   +--rw key-chains
+      +--rw key-chain* [name]
+      |  +--rw name                       string
+      |  +--rw description?               string
+      |  +--rw accept-tolerance {accept-tolerance}?
+      |  |  +--rw duration?   uint32
+      |  +--ro last-modified-timestamp?   yang:date-and-time
+      |  +--rw key* [key-id]
+      |     +--rw key-id                    uint64
+      |     +--rw lifetime
+      |     |  +--rw (lifetime)?
+      |     |     +--:(send-and-accept-lifetime)
+      |     |     |  +--rw send-accept-lifetime
+      |     |     |     +--rw (lifetime)?
+      |     |     |        +--:(always)
+      |     |     |        |  +--rw always?            empty
+      |     |     |        +--:(start-end-time)
+      |     |     |           +--rw start-date-time?
+      |     |     |           |       yang:date-and-time
+      |     |     |           +--rw (end-time)?
+      |     |     |              +--:(infinite)
+      |     |     |              |  +--rw no-end-time?       empty
+      |     |     |              +--:(duration)
+      |     |     |              |  +--rw duration?          uint32
+      |     |     |              +--:(end-date-time)
+      |     |     |                 +--rw end-date-time?
+      |     |     |                         yang:date-and-time
+      |     |     +--:(independent-send-accept-lifetime)
+      |     |        |   {independent-send-accept-lifetime}?
+      |     |        +--rw send-lifetime
+      |     |        |  +--rw (lifetime)?
+      |     |        |     +--:(always)
+      |     |        |     |  +--rw always?            empty
+      |     |        |     +--:(start-end-time)
+      |     |        |        +--rw start-date-time?
+      |     |        |        |       yang:date-and-time
+      |     |        |        +--rw (end-time)?
+      |     |        |           +--:(infinite)
+      |     |        |           |  +--rw no-end-time?       empty
+      |     |        |           +--:(duration)
+      |     |        |           |  +--rw duration?          uint32
+      |     |        |           +--:(end-date-time)
+      |     |        |              +--rw end-date-time?
+      |     |        |                      yang:date-and-time
+      |     |        +--rw accept-lifetime
+      |     |           +--rw (lifetime)?
+
+
+
+Lindem, et al.               Standards Track                    [Page 7]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+      |     |              +--:(always)
+      |     |              |  +--rw always?            empty
+      |     |              +--:(start-end-time)
+      |     |                 +--rw start-date-time?
+      |     |                 |       yang:date-and-time
+      |     |                 +--rw (end-time)?
+      |     |                    +--:(infinite)
+      |     |                    |  +--rw no-end-time?       empty
+      |     |                    +--:(duration)
+      |     |                    |  +--rw duration?          uint32
+      |     |                    +--:(end-date-time)
+      |     |                       +--rw end-date-time?
+      |     |                               yang:date-and-time
+      |     +--rw crypto-algorithm identityref
+      |     +--rw key-string
+      |     |  +--rw (key-string-style)?
+      |     |     +--:(keystring)
+      |     |     |  +--rw keystring?            string
+      |     |     +--:(hexadecimal) {hex-key-string}?
+      |     |        +--rw hexadecimal-string?   yang:hex-string
+      |     +--ro send-lifetime-active?     boolean
+      |     +--ro accept-lifetime-active?   boolean
+      +--rw aes-key-wrap {aes-key-wrap}?
+         +--rw enable?   boolean
+
+4.  Key Chain YANG Model
+
+   <CODE BEGINS> file "ietf-key-chain@2017-06-15.yang"
+   module ietf-key-chain {
+     yang-version 1.1;
+     namespace "urn:ietf:params:xml:ns:yang:ietf-key-chain";
+     prefix key-chain;
+
+     import ietf-yang-types {
+       prefix yang;
+     }
+     import ietf-netconf-acm {
+       prefix nacm;
+     }
+
+     organization
+       "IETF RTGWG - Routing Area Working Group";
+     contact
+       "WG Web:   <https://datatracker.ietf.org/group/rtgwg>
+        WG List:  <mailto:rtgwg@ietf.org>
+
+        Editor: Acee Lindem
+                <mailto:acee@cisco.com>
+
+
+
+Lindem, et al.               Standards Track                    [Page 8]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+                Yingzhen Qu
+                <mailto:yingzhen.qu@huawei.com>
+                Derek Yeung
+                <mailto:derek@arrcus.com>
+                Ing-Wher Chen
+                <mailto:Ing-Wher_Chen@jabail.com>
+                Jeffrey Zhang
+                <mailto:zzhang@juniper.net>";
+
+     description
+       "This YANG module defines the generic configuration
+        data for key chains.  It is intended that the module
+        will be extended by vendors to define vendor-specific
+        key chain configuration parameters.
+
+        Copyright (c) 2017 IETF Trust and the persons identified as
+        authors of the code.  All rights reserved.
+
+        Redistribution and use in source and binary forms, with or
+        without modification, is permitted pursuant to, and subject
+        to the license terms contained in, the Simplified BSD License
+        set forth in Section 4.c of the IETF Trust's Legal Provisions
+        Relating to IETF Documents
+        (http://trustee.ietf.org/license-info).
+
+        This version of this YANG module is part of RFC 8177;
+        see the RFC itself for full legal notices.";
+
+     reference "RFC 8177";
+
+     revision 2017-06-15 {
+       description
+         "Initial RFC Revision";
+       reference "RFC 8177: YANG Data Model for Key Chains";
+     }
+
+     feature hex-key-string {
+       description
+         "Support hexadecimal key string.";
+     }
+
+     feature accept-tolerance {
+       description
+         "Support the tolerance or acceptance limit.";
+     }
+
+     feature independent-send-accept-lifetime {
+       description
+
+
+
+Lindem, et al.               Standards Track                    [Page 9]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+         "Support for independent send and accept key lifetimes.";
+     }
+
+     feature crypto-hmac-sha-1-12 {
+       description
+         "Support for TCP HMAC-SHA-1 12-byte digest hack.";
+     }
+
+     feature cleartext {
+       description
+         "Support for cleartext algorithm.  Usage is
+          NOT RECOMMENDED.";
+     }
+
+     feature aes-cmac-prf-128 {
+       description
+         "Support for AES Cipher-based Message Authentication
+          Code Pseudorandom Function.";
+     }
+
+     feature aes-key-wrap {
+       description
+         "Support for Advanced Encryption Standard (AES) Key Wrap.";
+     }
+
+     feature replay-protection-only {
+       description
+         "Provide replay protection without any authentication
+          as required by protocols such as Bidirectional
+          Forwarding Detection (BFD).";
+     }
+     identity crypto-algorithm {
+       description
+         "Base identity of cryptographic algorithm options.";
+     }
+
+     identity hmac-sha-1-12 {
+       base crypto-algorithm;
+       if-feature "crypto-hmac-sha-1-12";
+       description
+         "The HMAC-SHA1-12 algorithm.";
+     }
+
+     identity aes-cmac-prf-128 {
+       base crypto-algorithm;
+       if-feature "aes-cmac-prf-128";
+       description
+         "The AES-CMAC-PRF-128 algorithm - required by
+
+
+
+Lindem, et al.               Standards Track                   [Page 10]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+          RFC 5926 for TCP-AO key derivation functions.";
+     }
+
+     identity md5 {
+       base crypto-algorithm;
+       description
+         "The MD5 algorithm.";
+     }
+
+     identity sha-1 {
+       base crypto-algorithm;
+       description
+         "The SHA-1 algorithm.";
+     }
+
+     identity hmac-sha-1 {
+       base crypto-algorithm;
+       description
+         "HMAC-SHA-1 authentication algorithm.";
+     }
+
+     identity hmac-sha-256 {
+       base crypto-algorithm;
+       description
+         "HMAC-SHA-256 authentication algorithm.";
+     }
+
+     identity hmac-sha-384 {
+       base crypto-algorithm;
+       description
+         "HMAC-SHA-384 authentication algorithm.";
+     }
+
+     identity hmac-sha-512 {
+       base crypto-algorithm;
+       description
+         "HMAC-SHA-512 authentication algorithm.";
+     }
+
+     identity cleartext {
+       base crypto-algorithm;
+       if-feature "cleartext";
+       description
+         "cleartext.";
+     }
+
+     identity replay-protection-only {
+       base crypto-algorithm;
+
+
+
+Lindem, et al.               Standards Track                   [Page 11]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+       if-feature "replay-protection-only";
+       description
+         "Provide replay protection without any authentication as
+          required by protocols such as Bidirectional Forwarding
+          Detection (BFD).";
+     }
+
+     typedef key-chain-ref {
+       type leafref {
+         path
+         "/key-chain:key-chains/key-chain:key-chain/key-chain:name";
+       }
+       description
+         "This type is used by data models that need to reference
+          configured key chains.";
+     }
+
+     grouping lifetime {
+       description
+         "Key lifetime specification.";
+       choice lifetime {
+         default "always";
+         description
+           "Options for specifying key accept or send lifetimes";
+         case always {
+           leaf always {
+             type empty;
+             description
+               "Indicates key lifetime is always valid.";
+           }
+         }
+         case start-end-time {
+           leaf start-date-time {
+             type yang:date-and-time;
+             description
+               "Start time.";
+           }
+           choice end-time {
+             default "infinite";
+             description
+               "End-time setting.";
+             case infinite {
+               leaf no-end-time {
+                 type empty;
+                 description
+                   "Indicates key lifetime end-time is infinite.";
+               }
+             }
+
+
+
+Lindem, et al.               Standards Track                   [Page 12]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+             case duration {
+               leaf duration {
+                 type uint32 {
+                   range "1..2147483646";
+                 }
+                 units "seconds";
+                 description
+                   "Key lifetime duration, in seconds";
+               }
+             }
+             case end-date-time {
+               leaf end-date-time {
+                 type yang:date-and-time;
+                 description
+                   "End time.";
+               }
+             }
+           }
+         }
+       }
+     }
+
+     container key-chains {
+       description
+         "All configured key-chains on the device.";
+       list key-chain {
+         key "name";
+         description
+           "List of key-chains.";
+         leaf name {
+           type string;
+           description
+             "Name of the key-chain.";
+         }
+         leaf description {
+           type string;
+           description
+             "A description of the key-chain";
+         }
+         container accept-tolerance {
+           if-feature "accept-tolerance";
+           description
+             "Tolerance for key lifetime acceptance (seconds).";
+           leaf duration {
+             type uint32;
+             units "seconds";
+             default "0";
+             description
+
+
+
+Lindem, et al.               Standards Track                   [Page 13]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+               "Tolerance range, in seconds.";
+           }
+         }
+         leaf last-modified-timestamp {
+           type yang:date-and-time;
+           config false;
+           description
+             "Timestamp of the most recent update to the key-chain";
+         }
+         list key {
+           key "key-id";
+           description
+             "Single key in key chain.";
+           leaf key-id {
+             type uint64;
+             description
+               "Numeric value uniquely identifying the key";
+           }
+           container lifetime {
+             description
+               "Specify a key's lifetime.";
+             choice lifetime {
+               description
+                 "Options for specification of send and accept
+                  lifetimes.";
+               case send-and-accept-lifetime {
+                 description
+                   "Send and accept key have the same lifetime.";
+                 container send-accept-lifetime {
+                   description
+                     "Single lifetime specification for both
+                      send and accept lifetimes.";
+                   uses lifetime;
+                 }
+               }
+               case independent-send-accept-lifetime {
+                 if-feature "independent-send-accept-lifetime";
+                 description
+                   "Independent send and accept key lifetimes.";
+                 container send-lifetime {
+                   description
+                     "Separate lifetime specification for send
+                      lifetime.";
+                   uses lifetime;
+                 }
+                 container accept-lifetime {
+                   description
+                     "Separate lifetime specification for accept
+
+
+
+Lindem, et al.               Standards Track                   [Page 14]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+                      lifetime.";
+                   uses lifetime;
+                 }
+               }
+             }
+           }
+           leaf crypto-algorithm {
+             type identityref {
+               base crypto-algorithm;
+             }
+             mandatory true;
+             description
+               "Cryptographic algorithm associated with key.";
+           }
+           container key-string {
+             description
+               "The key string.";
+             nacm:default-deny-all;
+             choice key-string-style {
+               description
+                 "Key string styles";
+                case keystring {
+                  leaf keystring {
+                   type string;
+                   description
+                     "Key string in ASCII format.";
+                 }
+               }
+               case hexadecimal {
+                 if-feature "hex-key-string";
+                 leaf hexadecimal-string {
+                   type yang:hex-string;
+                   description
+                     "Key in hexadecimal string format.  When compared
+                      to ASCII, specification in hexadecimal affords
+                      greater key entropy with the same number of
+                      internal key-string octets.  Additionally, it
+                      discourages usage of well-known words or
+                      numbers.";
+                 }
+               }
+             }
+           }
+           leaf send-lifetime-active {
+             type boolean;
+             config false;
+             description
+               "Indicates if the send lifetime of the
+
+
+
+Lindem, et al.               Standards Track                   [Page 15]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+                key-chain key is currently active.";
+              }
+           leaf accept-lifetime-active {
+             type boolean;
+             config false;
+             description
+               "Indicates if the accept lifetime of the
+                key-chain key is currently active.";
+           }
+         }
+       }
+       container aes-key-wrap {
+         if-feature "aes-key-wrap";
+         description
+           "AES Key Wrap encryption for key-chain key-strings.  The
+            encrypted key-strings are encoded as hexadecimal key
+            strings using the hex-key-string leaf.";
+         leaf enable {
+           type boolean;
+           default "false";
+           description
+             "Enable AES Key Wrap encryption.";
+         }
+       }
+     }
+   }
+   <CODE ENDS>
+
+5.  Security Considerations
+
+   The YANG module defined in this document is designed to be accessed
+   via network management protocols such as NETCONF [NETCONF] or
+   RESTCONF [RESTCONF].  The lowest NETCONF layer is the secure
+   transport layer, and the mandatory-to-implement secure transport is
+   Secure Shell (SSH) [NETCONF-SSH].  The lowest RESTCONF layer is
+   HTTPS, and the mandatory-to-implement secure transport is TLS [TLS].
+
+   The NETCONF access control model [NETCONF-ACM] provides the means to
+   restrict access for particular NETCONF or RESTCONF users to a pre-
+   configured subset of all available NETCONF or RESTCONF protocol
+   operations and content.  The key strings are not accessible by
+   default, and NETCONF access control model [NETCONF-ACM] rules are
+   required to configure or retrieve them.
+
+   When configured, the key strings can be encrypted using the AES Key
+   Wrap algorithm [AES-KEY-WRAP].  The AES key-encryption key (KEK) is
+   not included in the YANG model and must be set or derived independent
+   of key chain configuration.  When AES key encryption is used, the
+
+
+
+Lindem, et al.               Standards Track                   [Page 16]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+   hex-key-string feature is also required since the encrypted keys will
+   contain characters that are not representable in the YANG string
+   built-in type [YANG-1.1].  It is RECOMMENDED that key strings be
+   encrypted using AES key encryption to prevent key chains from being
+   retrieved and stored with the key strings in cleartext.  This
+   recommendation is independent of the access protection that is
+   availed from the NETCONF access control model (NACM) [NETCONF-ACM].
+
+   The cleartext algorithm is included as a YANG feature.  Usage is NOT
+   RECOMMENDED except in cases where the application and device have no
+   other alternative (e.g., a legacy network device that must
+   authenticate packets at intervals of 10 milliseconds or less for many
+   peers using Bidirectional Forwarding Detection [BFD]).  Keys used
+   with the cleartext algorithm are considered insecure and SHOULD NOT
+   be reused with more secure algorithms.
+
+   Similarly, the MD5 and SHA-1 algorithms have been proven to be
+   insecure ([Dobb96a], [Dobb96b], and [SHA-SEC-CON]), and usage is NOT
+   RECOMMENDED.  Usage should be confined to deployments where it is
+   required for backward compatibility.
+
+   Implementations with keys provided via this model should store them
+   using best current security practices.
+
+6.  IANA Considerations
+
+   This document registers a URI in the "IETF XML Registry"
+   [XML-REGISTRY].  It follows the format in [XML-REGISTRY].
+
+      URI: urn:ietf:params:xml:ns:yang:ietf-key-chain
+      Registrant Contact: The IESG.
+      XML: N/A, the requested URI is an XML namespace.
+
+   This document registers a YANG module in the "YANG Module Names"
+   registry [YANG-1.0].
+
+      name: ietf-key-chain
+      namespace: urn:ietf:params:xml:ns:yang:ietf-key-chain
+      prefix: key-chain
+      reference: RFC 8177
+
+
+
+
+
+
+
+
+
+
+
+Lindem, et al.               Standards Track                   [Page 17]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+7.  References
+
+7.1.  Normative References
+
+   [KEYWORDS]
+              Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <http://www.rfc-editor.org/info/rfc2119>.
+
+   [KEYWORDS-UPD]
+              Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <http://www.rfc-editor.org/info/rfc8174>.
+
+   [NETCONF]  Enns, R., Ed., Bjorklund, M., Ed., Schoenwaelder, J., Ed.,
+              and A. Bierman, Ed., "Network Configuration Protocol
+              (NETCONF)", RFC 6241, DOI 10.17487/RFC6241, June 2011,
+              <http://www.rfc-editor.org/info/rfc6241>.
+
+   [NETCONF-ACM]
+              Bierman, A. and M. Bjorklund, "Network Configuration
+              Protocol (NETCONF) Access Control Model", RFC 6536,
+              DOI 10.17487/RFC6536, March 2012,
+              <http://www.rfc-editor.org/info/rfc6536>.
+
+   [NETCONF-SSH]
+              Wasserman, M., "Using the NETCONF Protocol over Secure
+              Shell (SSH)", RFC 6242, DOI 10.17487/RFC6242, June 2011,
+              <http://www.rfc-editor.org/info/rfc6242>.
+
+   [RESTCONF]
+              Bierman, A., Bjorklund, M., and K. Watsen, "RESTCONF
+              Protocol", RFC 8040, DOI 10.17487/RFC8040, January 2017,
+              <http://www.rfc-editor.org/info/rfc8040>.
+
+   [TLS]      Dierks, T. and E. Rescorla, "The Transport Layer Security
+              (TLS) Protocol Version 1.2", RFC 5246,
+              DOI 10.17487/RFC5246, August 2008,
+              <http://www.rfc-editor.org/info/rfc5246>.
+
+   [XML-REGISTRY]
+              Mealling, M., "The IETF XML Registry", BCP 81, RFC 3688,
+              DOI 10.17487/RFC3688, January 2004,
+              <http://www.rfc-editor.org/info/rfc3688>.
+
+
+
+
+
+
+Lindem, et al.               Standards Track                   [Page 18]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+   [YANG-1.0]
+              Bjorklund, M., Ed., "YANG - A Data Modeling Language for
+              the Network Configuration Protocol (NETCONF)", RFC 6020,
+              DOI 10.17487/RFC6020, October 2010,
+              <http://www.rfc-editor.org/info/rfc6020>.
+
+   [YANG-1.1]
+              Bjorklund, M., Ed., "The YANG 1.1 Data Modeling Language",
+              RFC 7950, DOI 10.17487/RFC7950, August 2016,
+              <http://www.rfc-editor.org/info/rfc7950>.
+
+7.2.  Informative References
+
+   [AES-KEY-WRAP]
+              Housley, R. and M. Dworkin, "Advanced Encryption Standard
+              (AES) Key Wrap with Padding Algorithm", RFC 5649,
+              DOI 10.17487/RFC5649, September 2009,
+              <http://www.rfc-editor.org/info/rfc5649>.
+
+   [BFD]      Katz, D. and D. Ward, "Bidirectional Forwarding Detection
+              (BFD)", RFC 5880, DOI 10.17487/RFC5880, June 2010,
+              <http://www.rfc-editor.org/info/rfc5880>.
+
+   [CRYPTO-KEYTABLE]
+              Housley, R., Polk, T., Hartman, S., and D. Zhang,
+              "Database of Long-Lived Symmetric Cryptographic Keys",
+              RFC 7210, DOI 10.17487/RFC7210, April 2014,
+              <http://www.rfc-editor.org/info/rfc7210>.
+
+   [Dobb96a]  Dobbertin, H., "Cryptanalysis of MD5 Compress", Technical
+              Report Presented at the Rump Session of EuroCrypt '96, May
+              1996.
+
+   [Dobb96b]  Dobbertin, H., "The Status of MD5 After a Recent Attack",
+              CryptoBytes, Vol. 2, No. 2, Summer 1996.
+
+   [IAB-REPORT]
+              Andersson, L., Davies, E., and L. Zhang, "Report from the
+              IAB workshop on Unwanted Traffic March 9-10, 2006",
+              RFC 4948, DOI 10.17487/RFC4948, August 2007,
+              <http://www.rfc-editor.org/info/rfc4948>.
+
+   [NMDA]     Bjorklund, M., Schoenwaelder, J., Shafer, P., Watsen, K.,
+              and R. Wilton, "Network Management Datastore
+              Architecture", Work in Progress, draft-ietf-netmod-
+              revised-datastores-02, May 2017.
+
+
+
+
+
+Lindem, et al.               Standards Track                   [Page 19]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+   [NTP-PROTO]
+              Mills, D., Martin, J., Ed., Burbank, J., and W. Kasch,
+              "Network Time Protocol Version 4: Protocol and Algorithms
+              Specification", RFC 5905, DOI 10.17487/RFC5905, June 2010,
+              <http://www.rfc-editor.org/info/rfc5905>.
+
+   [OSPFV3-AUTH]
+              Bhatia, M., Manral, V., and A. Lindem, "Supporting
+              Authentication Trailer for OSPFv3", RFC 7166,
+              DOI 10.17487/RFC7166, March 2014,
+              <http://www.rfc-editor.org/info/rfc7166>.
+
+   [SHA-SEC-CON]
+              Polk, T., Chen, L., Turner, S., and P. Hoffman, "Security
+              Considerations for the SHA-0 and SHA-1 Message-Digest
+              Algorithms", RFC 6194, DOI 10.17487/RFC6194, March 2011,
+              <http://www.rfc-editor.org/info/rfc6194>.
+
+   [TCP-AO]   Touch, J., Mankin, A., and R. Bonica, "The TCP
+              Authentication Option", RFC 5925, DOI 10.17487/RFC5925,
+              June 2010, <http://www.rfc-editor.org/info/rfc5925>.
+
+   [TCP-AO-ALGORITHMS]
+              Lebovitz, G. and E. Rescorla, "Cryptographic Algorithms
+              for the TCP Authentication Option (TCP-AO)", RFC 5926,
+              DOI 10.17487/RFC5926, June 2010,
+              <http://www.rfc-editor.org/info/rfc5926>.
+
+   [YANG-CRYPTO-KEYTABLE]
+              Chen, I., "YANG Data Model for RFC 7210 Key Table", Work
+              in Progress, draft-chen-rtg-key-table-yang-00, March 2015.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Lindem, et al.               Standards Track                   [Page 20]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+Appendix A.  Examples
+
+A.1.  Simple Key Chain with an Always Valid Single Key
+
+   <?xml version="1.0" encoding="utf-8"?>
+   <data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+     <key-chains xmlns="urn:ietf:params:xml:ns:yang:ietf-key-chain">
+       <key-chain>
+         <name>keychain-no-end-time</name>
+         <description>
+           A key chain with a single key that is always valid for
+           transmission and reception.
+         </description>
+         <key>
+           <key-id>100</key-id>
+           <lifetime>
+             <send-accept-lifetime>
+               <always/>
+             </send-accept-lifetime>
+           </lifetime>
+           <crypto-algorithm>hmac-sha-256</crypto-algorithm>
+           <key-string>
+             <keystring>keystring_in_ascii_100</keystring>
+           </key-string>
+         </key>
+       </key-chain>
+     </key-chains>
+   </data>
+
+A.2.  Key Chain with Keys Having Different Lifetimes
+
+   <?xml version="1.0" encoding="utf-8"?>
+   <data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+     <key-chains xmlns="urn:ietf:params:xml:ns:yang:ietf-key-chain">
+       <key-chain>
+         <name>keychain2</name>
+         <description>
+           A key chain where each key contains a different send time
+           and accept time and a different algorithm illustrating
+           algorithm agility.
+         </description>
+         <key>
+           <key-id>35</key-id>
+           <lifetime>
+             <send-lifetime>
+               <start-date-time>2017-01-01T00:00:00Z</start-date-time>
+               <end-date-time>2017-02-01T00:00:00Z</end-date-time>
+             </send-lifetime>
+
+
+
+Lindem, et al.               Standards Track                   [Page 21]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+             <accept-lifetime>
+               <start-date-time>2016-12-31T23:59:55Z</start-date-time>
+               <end-date-time>2017-02-01T00:00:05Z</end-date-time>
+             </accept-lifetime>
+           </lifetime>
+           <crypto-algorithm>hmac-sha-256</crypto-algorithm>
+           <key-string>
+             <keystring>keystring_in_ascii_35</keystring>
+           </key-string>
+         </key>
+         <key>
+           <key-id>36</key-id>
+           <lifetime>
+             <send-lifetime>
+               <start-date-time>2017-02-01T00:00:00Z</start-date-time>
+               <end-date-time>2017-03-01T00:00:00Z</end-date-time>
+             </send-lifetime>
+             <accept-lifetime>
+               <start-date-time>2017-01-31T23:59:55Z</start-date-time>
+               <end-date-time>2017-03-01T00:00:05Z</end-date-time>
+             </accept-lifetime>
+           </lifetime>
+           <crypto-algorithm>hmac-sha-512</crypto-algorithm>
+           <key-string>
+             <hexadecimal-string>fe:ed:be:af:36</hexadecimal-string>
+           </key-string>
+         </key>
+       </key-chain>
+     </key-chains>
+   </data>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Lindem, et al.               Standards Track                   [Page 22]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+A.3.  Key Chain with Independent Send and Accept Lifetimes
+
+   <?xml version="1.0" encoding="utf-8"?>
+   <data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+     <key-chains xmlns="urn:ietf:params:xml:ns:yang:ietf-key-chain">
+       <key-chain>
+         <name>keychain2</name>
+         <description>
+           A key chain where each key contains different send times
+           and accept times.
+         </description>
+         <key>
+           <key-id>35</key-id>
+           <lifetime>
+             <send-lifetime>
+               <start-date-time>2017-01-01T00:00:00Z</start-date-time>
+               <end-date-time>2017-02-01T00:00:00Z</end-date-time>
+             </send-lifetime>
+             <accept-lifetime>
+               <start-date-time>2016-12-31T23:59:55Z</start-date-time>
+               <end-date-time>2017-02-01T00:00:05Z</end-date-time>
+             </accept-lifetime>
+           </lifetime>
+           <crypto-algorithm>hmac-sha-256</crypto-algorithm>
+           <key-string>
+             <keystring>keystring_in_ascii_35</keystring>
+           </key-string>
+         </key>
+         <key>
+           <key-id>36</key-id>
+           <lifetime>
+             <send-lifetime>
+               <start-date-time>2017-02-01T00:00:00Z</start-date-time>
+               <end-date-time>2017-03-01T00:00:00Z</end-date-time>
+             </send-lifetime>
+             <accept-lifetime>
+               <start-date-time>2017-01-31T23:59:55Z</start-date-time>
+               <end-date-time>2017-03-01T00:00:05Z</end-date-time>
+             </accept-lifetime>
+           </lifetime>
+           <crypto-algorithm>hmac-sha-256</crypto-algorithm>
+           <key-string>
+             <hexadecimal-string>fe:ed:be:af:36</hexadecimal-string>
+           </key-string>
+         </key>
+       </key-chain>
+     </key-chains>
+   </data>
+
+
+
+Lindem, et al.               Standards Track                   [Page 23]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+Contributors
+
+   Yi Yang
+   SockRate
+
+   Email: yi.yang@sockrate.com
+
+Acknowledgments
+
+   Thanks to Brian Weis for fruitful discussions on security
+   requirements.
+
+   Thanks to Ines Robles for Routing Directorate QA review comments.
+
+   Thanks to Ladislav Lhotka for YANG Doctor comments.
+
+   Thanks to Martin Bjorklund for additional YANG Doctor comments.
+
+   Thanks to Tom Petch for comments during IETF last call.
+
+   Thanks to Matthew Miller for comments made during the Gen-ART review.
+
+   Thanks to Vincent Roca for comments made during the Security
+   Directorate review.
+
+   Thanks to Warren Kumari, Ben Campbell, Adam Roach, and Benoit Claise
+   for comments received during the IESG review.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Lindem, et al.               Standards Track                   [Page 24]
+
+RFC 8177                     YANG Key Chain                    June 2017
+
+
+Authors' Addresses
+
+   Acee Lindem (editor)
+   Cisco Systems
+   301 Midenhall Way
+   Cary, NC  27513
+   United States of America
+
+   Email: acee@cisco.com
+
+
+   Yingzhen Qu
+   Huawei
+
+   Email: yingzhen.qu@huawei.com
+
+
+   Derek Yeung
+   Arrcus, Inc
+
+   Email: derek@arrcus.com
+
+
+   Ing-Wher Chen
+   Jabil
+
+   Email: Ing-Wher_Chen@jabil.com
+
+
+   Jeffrey Zhang
+   Juniper Networks
+   10 Technology Park Drive
+   Westford, MA  01886
+   United States of America
+
+   Email: zzhang@juniper.net
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Lindem, et al.               Standards Track                   [Page 25]
+


### PR DESCRIPTION
## Summary

Phase 0 of OSPF authentication — scaffolding only, no MAC verification yet.

- Reshape `Ospfv2Auth` from a fixed `u64` into an enum keyed by `auth_type`: `Null` / `Simple` carry the raw 8 bytes; `Crypto` carries the RFC 2328 §D.3 header overlay (key-id, auth-data-len, seq). The parser previously rejected any non-zero `auth_type`; it now accepts types 0/1/2.
- Add `Ospfv2Packet::auth_trailer` (parser-side `#[nom(Ignore)]` field). The top-level `parse()` wrapper now peeks the header `len`, slices the input so the trailer doesn't bleed into payload parsers (e.g. `OspfHello::neighbors`), and consumes `auth_data_len` trailer bytes when `auth_type == 2`. `emit()` finalizes header length + checksum before appending the trailer so RFC 2328 §D.4 "length excludes digest" semantics hold.
- Drop the dead commented `validate_checksum` call from `parse()` — checksum verification already runs at the network layer (`zebra-rs/src/ospf/network.rs::read_packet`). Phase 2 will need the network side to bound the slice to header `len` before real Type 2 packets can be accepted (the trailer bytes would otherwise change the checksum).
- Drop RFCs 4552, 5709, 7166, 7474, 8177 into `rfc/ospf/` for the follow-up phases.

## Test plan

- [x] `cargo test -p ospf-packet` — 5 new tests (null round-trip, simple-password parse, crypto trailer consume, short input, bogus length) + 39 existing.
- [x] `cargo test --workspace` — all green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)