### PR TITLE
ospf: add area-type config (stub / NSSA) with N/E-bit negotiation

### DIFF
--- a/zebra-rs/src/ospf/area.rs
+++ b/zebra-rs/src/ospf/area.rs
@@ -7,10 +7,110 @@ use super::version::{OspfVersion, Ospfv2};
 
 pub const AREA0: Ipv4Addr = Ipv4Addr::UNSPECIFIED;
 
+/// RFC 3101 §2.2 NSSA translator-role configuration knob for an
+/// NSSA ABR. `Candidate` is the default and triggers election among
+/// the area's ABRs via the Nt-bit. `Always` forces translation
+/// unconditionally; `Never` disables it. Storage-only in phase 1.
 #[derive(Debug, Default, PartialEq, Clone, Copy)]
-pub enum AreaType {
+pub enum NssaTranslatorRole {
+    #[default]
+    Candidate,
+    Always,
+    Never,
+}
+
+impl NssaTranslatorRole {
+    pub fn from_yang(s: &str) -> Option<Self> {
+        match s {
+            "candidate" => Some(Self::Candidate),
+            "always" => Some(Self::Always),
+            "never" => Some(Self::Never),
+            _ => None,
+        }
+    }
+}
+
+/// Discriminant for [`AreaType`]. Drives the option-bit (N/E)
+/// behavior on Hello/DBD; the sub-knobs in [`AreaType`] only matter
+/// for `Stub` and `Nssa`.
+#[derive(Debug, Default, PartialEq, Clone, Copy)]
+pub enum AreaTypeKind {
     #[default]
     Normal,
+    Stub,
+    Nssa,
+}
+
+impl AreaTypeKind {
+    pub fn from_yang(s: &str) -> Option<Self> {
+        match s {
+            "normal" => Some(Self::Normal),
+            "stub" => Some(Self::Stub),
+            "nssa" => Some(Self::Nssa),
+            _ => None,
+        }
+    }
+}
+
+/// Per-area type with its sub-knobs.
+///
+/// `kind` selects the area flavor; the remaining fields are
+/// configuration leaves that only take effect for matching flavors:
+/// - `no_summary` — totally-stubby / totally-NSSA: drop Type-3
+///   Summary at the ABR. Applies to `Stub` and `Nssa`.
+/// - `nssa_default_originate` — ABR originates a default Type-7
+///   into the NSSA area. Applies to `Nssa` only.
+/// - `nssa_suppress_fa` — zero the forwarding address when
+///   translating Type-7 to Type-5 (RFC 3101 §2.6). Applies to
+///   `Nssa` only.
+/// - `nssa_translator_role` — RFC 3101 §2.2 election behavior.
+///   Applies to `Nssa` only.
+///
+/// Phase 1 wires `kind` + the N-bit / E-bit negotiation; the
+/// remaining knobs are stored but not yet acted on.
+#[derive(Debug, Default, PartialEq, Clone, Copy)]
+pub struct AreaType {
+    pub kind: AreaTypeKind,
+    pub no_summary: bool,
+    pub nssa_default_originate: bool,
+    pub nssa_suppress_fa: bool,
+    pub nssa_translator_role: NssaTranslatorRole,
+}
+
+impl AreaType {
+    /// True for any flavor of stub or NSSA — AS-External LSAs are
+    /// dropped at the area boundary.
+    pub fn is_stub_or_nssa(self) -> bool {
+        !matches!(self.kind, AreaTypeKind::Normal)
+    }
+
+    /// True only for NSSA-flavored areas.
+    pub fn is_nssa(self) -> bool {
+        matches!(self.kind, AreaTypeKind::Nssa)
+    }
+
+    /// True when this area accepts and floods Type-5 AS-External
+    /// LSAs (RFC 2328 §3.6). False for stub and NSSA.
+    pub fn accepts_as_external(self) -> bool {
+        matches!(self.kind, AreaTypeKind::Normal)
+    }
+
+    /// E-bit value advertised in the OSPF Options field. Per
+    /// RFC 2328 §A.2 / RFC 3101 §2.5 the E-bit must be clear on
+    /// stub and NSSA links and set on normal links. Hello/DBD
+    /// emit reads this; recv compares against the neighbor's bit
+    /// and drops mismatches.
+    pub fn e_bit(self) -> bool {
+        self.accepts_as_external()
+    }
+
+    /// N-bit value advertised in the OSPF Options field. Per
+    /// RFC 3101 §2.5 the N-bit must be set on NSSA links and
+    /// clear elsewhere. Mismatch with a neighbor's bit on Hello
+    /// receipt drops the packet.
+    pub fn n_bit(self) -> bool {
+        self.is_nssa()
+    }
 }
 
 /// Map of OSPF area-id → `OspfArea<V>`.
@@ -56,7 +156,7 @@ pub struct OspfArea<V: OspfVersion = Ospfv2> {
     // OSPF area id.  This value may be treated as IPv4 address.
     pub id: Ipv4Addr,
 
-    // Area type (Normal, Stub, NSSA).
+    // Area type (Normal, Stub, NSSA) and its sub-knobs.
     pub area_type: AreaType,
 
     // Set of interfaces belongs to this area.

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -3,6 +3,7 @@ use std::net::Ipv4Addr;
 
 use super::Ospf;
 use super::OspfLink;
+use super::area::{AreaTypeKind, NssaTranslatorRole};
 use super::ifsm::{IfsmEvent, ospf_hello_timer};
 use super::link::OspfNetworkType;
 use super::tracing::{config_tracing_fsm, config_tracing_packet};
@@ -32,6 +33,17 @@ impl Ospf {
 
     pub fn callback_build(&mut self) {
         self.ospf_add("/router-id", config_ospf_router_id);
+        self.ospf_add("/area/area-type", config_ospf_area_type);
+        self.ospf_add("/area/no-summary", config_ospf_area_no_summary);
+        self.ospf_add(
+            "/area/nssa-default-originate",
+            config_ospf_area_nssa_default_originate,
+        );
+        self.ospf_add("/area/nssa-suppress-fa", config_ospf_area_nssa_suppress_fa);
+        self.ospf_add(
+            "/area/nssa-translator-role",
+            config_ospf_area_nssa_translator_role,
+        );
         self.ospf_add("/area/interface/enable", config_ospf_interface_enable);
         self.ospf_add(
             "/area/interface/network-type",
@@ -127,6 +139,126 @@ pub(super) fn apply_link_enable_transition<V: OspfVersion>(
 fn config_ospf_router_id(_ospf: &mut Ospf, mut args: Args, _op: ConfigOp) -> Option<()> {
     let _router_id = args.v4addr()?;
     None
+}
+
+/// After mutating `ospf.areas[area_id].area_type`, push the new
+/// value into every link's cached `area_type` so packet emit /
+/// recv can read it directly without re-borrowing `ospf.areas`.
+fn sync_area_type_to_links<V: OspfVersion>(ospf: &mut Ospf<V>, area_id: Ipv4Addr) {
+    let Some(area) = ospf.areas.get(area_id) else {
+        return;
+    };
+    let new_area_type = area.area_type;
+    let ifindexes: Vec<u32> = area.links.iter().copied().collect();
+    for ifindex in ifindexes {
+        if let Some(link) = ospf.links.get_mut(&ifindex) {
+            link.area_type = new_area_type;
+        }
+    }
+}
+
+/// Generic per-area `area-type` writer shared by v2 and v3 callbacks.
+/// Looks up (or creates) the area, updates its `area_type.kind`
+/// in-place, and leaves the sub-knobs alone — those have their own
+/// callbacks. Hello/DBD pick up the new option bits on next emit;
+/// existing neighbors with mismatched N/E bits drop out when the
+/// next Hello arrives.
+pub(super) fn area_type_set<V: OspfVersion>(
+    ospf: &mut Ospf<V>,
+    area_id: Ipv4Addr,
+    kind: AreaTypeKind,
+) {
+    ospf.areas.fetch(area_id).area_type.kind = kind;
+    sync_area_type_to_links(ospf, area_id);
+}
+
+pub(super) fn area_no_summary_set<V: OspfVersion>(
+    ospf: &mut Ospf<V>,
+    area_id: Ipv4Addr,
+    value: bool,
+) {
+    ospf.areas.fetch(area_id).area_type.no_summary = value;
+    sync_area_type_to_links(ospf, area_id);
+}
+
+pub(super) fn area_nssa_default_originate_set<V: OspfVersion>(
+    ospf: &mut Ospf<V>,
+    area_id: Ipv4Addr,
+    value: bool,
+) {
+    ospf.areas.fetch(area_id).area_type.nssa_default_originate = value;
+    sync_area_type_to_links(ospf, area_id);
+}
+
+pub(super) fn area_nssa_suppress_fa_set<V: OspfVersion>(
+    ospf: &mut Ospf<V>,
+    area_id: Ipv4Addr,
+    value: bool,
+) {
+    ospf.areas.fetch(area_id).area_type.nssa_suppress_fa = value;
+    sync_area_type_to_links(ospf, area_id);
+}
+
+pub(super) fn area_nssa_translator_role_set<V: OspfVersion>(
+    ospf: &mut Ospf<V>,
+    area_id: Ipv4Addr,
+    role: NssaTranslatorRole,
+) {
+    ospf.areas.fetch(area_id).area_type.nssa_translator_role = role;
+    sync_area_type_to_links(ospf, area_id);
+}
+
+/// `/router/ospf/area/<id>/area-type` — `normal | stub | nssa`.
+/// Delete reverts to the default (`normal`).
+fn config_ospf_area_type(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let kind = if op.is_set() {
+        AreaTypeKind::from_yang(&args.string()?)?
+    } else {
+        AreaTypeKind::default()
+    };
+    area_type_set(ospf, area_id, kind);
+    Some(())
+}
+
+fn config_ospf_area_no_summary(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let value = op.is_set() && args.boolean()?;
+    area_no_summary_set(ospf, area_id, value);
+    Some(())
+}
+
+fn config_ospf_area_nssa_default_originate(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let value = op.is_set() && args.boolean()?;
+    area_nssa_default_originate_set(ospf, area_id, value);
+    Some(())
+}
+
+fn config_ospf_area_nssa_suppress_fa(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let value = op.is_set() && args.boolean()?;
+    area_nssa_suppress_fa_set(ospf, area_id, value);
+    Some(())
+}
+
+fn config_ospf_area_nssa_translator_role(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let role = if op.is_set() {
+        NssaTranslatorRole::from_yang(&args.string()?)?
+    } else {
+        NssaTranslatorRole::default()
+    };
+    area_nssa_translator_role_set(ospf, area_id, role);
+    Some(())
 }
 
 pub(super) fn ospf_link_get_mut_by_name<'a, V: OspfVersion>(

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -9,9 +9,11 @@
 //! `ospf_link_get_mut_by_name`, `parse_area_id`, `ospf_hello_timer`)
 //! make this possible without duplication.
 
+use super::area::{AreaTypeKind, NssaTranslatorRole};
 use super::config::{
-    Callback, apply_link_enable_transition, link_should_enable, ospf_link_get_mut_by_name,
-    parse_area_id,
+    Callback, apply_link_enable_transition, area_no_summary_set, area_nssa_default_originate_set,
+    area_nssa_suppress_fa_set, area_nssa_translator_role_set, area_type_set, link_should_enable,
+    ospf_link_get_mut_by_name, parse_area_id,
 };
 use super::ifsm::{IfsmEvent, ospf_hello_timer};
 use super::link::OspfNetworkType;
@@ -30,6 +32,20 @@ impl Ospf<Ospfv3> {
     pub fn callback_build(&mut self) {
         let prefix = OSPFV3;
         let entries: &[(&str, Callback<Ospfv3>)] = &[
+            ("/area/area-type", config_ospfv3_area_type),
+            ("/area/no-summary", config_ospfv3_area_no_summary),
+            (
+                "/area/nssa-default-originate",
+                config_ospfv3_area_nssa_default_originate,
+            ),
+            (
+                "/area/nssa-suppress-fa",
+                config_ospfv3_area_nssa_suppress_fa,
+            ),
+            (
+                "/area/nssa-translator-role",
+                config_ospfv3_area_nssa_translator_role,
+            ),
             ("/area/interface/enable", config_ospfv3_interface_enable),
             (
                 "/area/interface/network-type",
@@ -74,6 +90,68 @@ impl Ospf<Ospfv3> {
             self.callbacks.insert(format!("{}{}", prefix, path), *cb);
         }
     }
+}
+
+/// `/router/ospfv3/area/<id>/area-type` — same shape as the v2
+/// sibling in `config.rs`; delegates to the shared
+/// `area_type_set` helper.
+fn config_ospfv3_area_type(ospf: &mut Ospf<Ospfv3>, mut args: Args, op: ConfigOp) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let kind = if op.is_set() {
+        AreaTypeKind::from_yang(&args.string()?)?
+    } else {
+        AreaTypeKind::default()
+    };
+    area_type_set(ospf, area_id, kind);
+    Some(())
+}
+
+fn config_ospfv3_area_no_summary(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let value = op.is_set() && args.boolean()?;
+    area_no_summary_set(ospf, area_id, value);
+    Some(())
+}
+
+fn config_ospfv3_area_nssa_default_originate(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let value = op.is_set() && args.boolean()?;
+    area_nssa_default_originate_set(ospf, area_id, value);
+    Some(())
+}
+
+fn config_ospfv3_area_nssa_suppress_fa(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let value = op.is_set() && args.boolean()?;
+    area_nssa_suppress_fa_set(ospf, area_id, value);
+    Some(())
+}
+
+fn config_ospfv3_area_nssa_translator_role(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let role = if op.is_set() {
+        NssaTranslatorRole::from_yang(&args.string()?)?
+    } else {
+        NssaTranslatorRole::default()
+    };
+    area_nssa_translator_role_set(ospf, area_id, role);
+    Some(())
 }
 
 /// Toggle the link's `enabled` state and re-evaluate the IFSM

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1266,7 +1266,7 @@ impl Ospf<Ospfv2> {
             .map(|(&id, area)| (id, area.area_type))
             .collect();
         for (area_id, area_type) in area_ids {
-            if area_type != super::area::AreaType::Normal {
+            if area_type.is_stub_or_nssa() {
                 continue;
             }
             self.flood_lsa_through_area(area_id, lsa, source);
@@ -1500,6 +1500,10 @@ impl Ospf<Ospfv2> {
                 link.network_type = link.config_network_type();
                 let area = self.areas.fetch(area_id);
                 area.links.insert(ifindex);
+                let area_type = area.area_type;
+                if let Some(link) = self.links.get_mut(&ifindex) {
+                    link.area_type = area_type;
+                }
                 self.router_lsa_originate();
                 let _ = self.tx.send(Message::Ifsm(ifindex, IfsmEvent::InterfaceUp));
             }
@@ -1516,6 +1520,7 @@ impl Ospf<Ospfv2> {
                 link.enabled = false;
                 link.area = Ipv4Addr::UNSPECIFIED;
                 link.area_id = Ipv4Addr::UNSPECIFIED;
+                link.area_type = super::area::AreaType::default();
                 let area = self.areas.fetch(area_id);
                 area.links.remove(&ifindex);
                 self.router_lsa_originate();
@@ -2544,6 +2549,10 @@ impl Ospf<Ospfv3> {
                 link.network_type = link.config_network_type();
                 let area = self.areas.fetch(area_id);
                 area.links.insert(ifindex);
+                let area_type = area.area_type;
+                if let Some(link) = self.links.get_mut(&ifindex) {
+                    link.area_type = area_type;
+                }
                 self.router_lsa_originate();
                 self.router_intra_area_prefix_lsa_originate(area_id);
                 self.link_lsa_originate(ifindex);
@@ -2565,6 +2574,7 @@ impl Ospf<Ospfv3> {
                 link.enabled = false;
                 link.area = Ipv4Addr::UNSPECIFIED;
                 link.area_id = Ipv4Addr::UNSPECIFIED;
+                link.area_type = super::area::AreaType::default();
                 let area = self.areas.fetch(area_id);
                 area.links.remove(&ifindex);
                 self.router_lsa_originate();

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -130,6 +130,12 @@ pub struct OspfLink<V: OspfVersion = Ospfv2> {
     pub addr: Vec<OspfAddr<V>>,
     pub area: Ipv4Addr,
     pub area_id: Ipv4Addr,
+    /// Cached copy of the parent area's `area_type`. Synced when the
+    /// link joins an area and whenever the area's type or sub-knobs
+    /// change (via `config::area_type_set` and siblings). Hello/DBD
+    /// emit and recv read this directly without re-borrowing
+    /// `Ospf::areas`. Default `AreaType::default()` = Normal.
+    pub area_type: super::area::AreaType,
     pub state: IfsmState,
     pub ostate: IfsmState,
     pub sock: Arc<AsyncFd<Socket>>,
@@ -190,6 +196,7 @@ where
             addr: Vec::new(),
             area: Ipv4Addr::UNSPECIFIED,
             area_id: Ipv4Addr::UNSPECIFIED,
+            area_type: super::area::AreaType::default(),
             state: IfsmState::Down,
             ostate: IfsmState::Down,
             sock,

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -373,8 +373,6 @@ pub fn ospfv2_populate_initial_db_summary(
     oi: &mut OspfInterface<Ospfv2>,
     nbr: &mut Neighbor<Ospfv2>,
 ) {
-    use super::area::AreaType;
-
     ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::Router));
     ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::Network));
     ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::Summary));
@@ -382,7 +380,7 @@ pub fn ospfv2_populate_initial_db_summary(
     ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::OpaqueAreaLocal));
 
     // AS-scope LSAs included only for non-stub / non-NSSA areas.
-    if oi.area_type == AreaType::Normal {
+    if oi.area_type.accepts_as_external() {
         ospf_db_summary_add_table(nbr, oi.lsdb_as.values_by_type(OspfLsType::AsExternal));
     }
 }
@@ -399,7 +397,6 @@ pub fn ospfv3_populate_initial_db_summary(
     oi: &mut OspfInterface<Ospfv3>,
     nbr: &mut Neighbor<Ospfv3>,
 ) {
-    use super::area::AreaType;
     use ospf_packet::{
         OSPFV3_AS_EXTERNAL_LSA_TYPE, OSPFV3_INTER_AREA_PREFIX_LSA_TYPE,
         OSPFV3_INTER_AREA_ROUTER_LSA_TYPE, OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE,
@@ -416,7 +413,7 @@ pub fn ospfv3_populate_initial_db_summary(
         ospf_db_summary_add_table(nbr, oi.lsdb.iter_by_raw_type(ls_type).map(|(_, lsa)| lsa));
     }
 
-    if oi.area_type == AreaType::Normal {
+    if oi.area_type.accepts_as_external() {
         ospf_db_summary_add_table(
             nbr,
             oi.lsdb_as

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -29,7 +29,11 @@ pub fn ospf_hello_packet(oi: &OspfLink) -> Option<Ospfv2Packet> {
         router_dead_interval: oi.dead_interval(),
         ..Default::default()
     };
-    hello.options.set_external(true);
+    // RFC 2328 §A.2 / RFC 3101 §2.5: E-bit clear on stub/NSSA,
+    // N-bit set on NSSA. Drives the per-area negotiation — a
+    // neighbor whose bits differ is rejected by `ospf_hello_recv`.
+    hello.options.set_external(oi.area_type.e_bit());
+    hello.options.set_nssa(oi.area_type.n_bit());
     hello.options.set_o(true);
     for (_, nbr) in oi.nbrs.iter() {
         if nbr.state == NfsmState::Down {
@@ -104,6 +108,23 @@ pub fn ospf_hello_recv(
             "prefixlen mismatch hello {} ifaddr {}",
             prefixlen,
             addr.prefix.prefix_len()
+        );
+        return;
+    }
+
+    // RFC 2328 §10.5 / RFC 3101 §2.5: the E-bit and N-bit in the
+    // Hello Options MUST match our local area-type, else drop the
+    // packet. An NSSA neighbor seen on a normal link (or vice
+    // versa) cannot form an adjacency.
+    if hello.options.external() != oi.area_type.e_bit()
+        || hello.options.nssa() != oi.area_type.n_bit()
+    {
+        tracing::info!(
+            "[Hello:Recv] dropping {}: option mismatch (peer E={} N={}, area {:?})",
+            src,
+            hello.options.external(),
+            hello.options.nssa(),
+            oi.area_type,
         );
         return;
     }
@@ -195,7 +216,11 @@ pub fn ospf_db_desc_send(link: &mut OspfInterface, nbr: &mut Neighbor, oident: &
 
     dd.flags = nbr.dd.flags;
     dd.seqnum = nbr.dd.seqnum;
-    dd.options.set_external(true);
+    // Mirror the per-area Hello option bits — RFC 2328 §10.6 says
+    // the DBD Options must match the area's capabilities so the
+    // negotiation done in Hello holds through the exchange.
+    dd.options.set_external(link.area_type.e_bit());
+    dd.options.set_nssa(link.area_type.n_bit());
     dd.options.set_o(true);
 
     ospf_packet_db_desc_set(nbr, &mut dd);
@@ -612,11 +637,10 @@ enum LsaProcessResult {
 
 fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -> LsaProcessResult {
     // Step 3: Discard AS-External LSAs in stub/NSSA areas.
-    use super::area::AreaType;
     if matches!(
         lsa.h.ls_type,
         OspfLsType::AsExternal | OspfLsType::SummaryAsbr
-    ) && oi.area_type != AreaType::Normal
+    ) && oi.area_type.is_stub_or_nssa()
     {
         tracing::info!(
             "[LS Update] Step 3: Discarding {:?} LSA in {:?} area: id={} adv={}",

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -43,10 +43,12 @@ fn build_hello_packet(link: &OspfLink<Ospfv3>) -> Option<Ospfv3Packet> {
     // RFC 5340 §A.2 options bits:
     // - V6 (bit 0): IPv6 routing capability.
     // - E  (bit 1): accept AS-external LSAs (normal area).
+    // - N  (bit 3): NSSA capability (RFC 3101 §2.5 inherited by v3).
     // - R  (bit 4): active router (we participate in routing).
     let mut options = Ospfv3Options::default();
     options.set_v6(true);
-    options.set_e(true);
+    options.set_e(link.area_type.e_bit());
+    options.set_n(link.area_type.n_bit());
     options.set_r(true);
 
     let mut neighbors = Vec::new();
@@ -158,6 +160,19 @@ pub fn ospfv3_hello_recv(
     let Ospfv3Payload::Hello(ref hello) = packet.payload else {
         return;
     };
+
+    // RFC 5340 inherits RFC 2328 §10.5 / RFC 3101 §2.5: drop the
+    // Hello when the peer's E or N bit disagrees with our area type.
+    if hello.options.e() != oi.area_type.e_bit() || hello.options.n() != oi.area_type.n_bit() {
+        tracing::info!(
+            "[v3 Hello:Recv] dropping {}: option mismatch (peer E={} N={}, area {:?})",
+            src,
+            hello.options.e(),
+            hello.options.n(),
+            oi.area_type,
+        );
+        return;
+    }
 
     let nbr_router_id = packet.router_id;
 
@@ -285,7 +300,10 @@ pub fn ospfv3_db_desc_send(
         ..Default::default()
     };
     dd.options.set_v6(true);
-    dd.options.set_e(true);
+    // Mirror the per-area Hello option bits — RFC 5340 inherits
+    // RFC 2328 §10.6 requiring DBD Options to match the area.
+    dd.options.set_e(oi.area_type.e_bit());
+    dd.options.set_n(oi.area_type.n_bit());
     dd.options.set_r(true);
 
     db_desc_pack(nbr, &mut dd);
@@ -904,7 +922,6 @@ fn ospfv3_ls_upd_proc(
     lsa: &Ospfv3Lsa,
     src: &Ipv6Addr,
 ) -> LsaProcessResult {
-    use super::area::AreaType;
     use super::lsdb::{OSPF_MAX_AGE, OSPF_MAX_LSA_SEQ};
 
     let h = &lsa.h;
@@ -913,7 +930,7 @@ fn ospfv3_ls_upd_proc(
     let key: super::lsdb::OspfLsaKey = (h.ls_type, h.link_state_id, h.advertising_router);
 
     // Step 3: AS-scope LSAs aren't accepted in stub / NSSA areas.
-    if scope == Ospfv3LsaScope::As && oi.area_type != AreaType::Normal {
+    if scope == Ospfv3LsaScope::As && oi.area_type.is_stub_or_nssa() {
         tracing::info!(
             "[v3 LSUpd] Step 3: discarding AS-scope LSA in {:?} area",
             oi.area_type

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -323,6 +323,53 @@ module config {
               type inet:ipv4-address;
             }
           }
+          // RFC 2328 §3.6 / RFC 3101 §2: per-area type. `normal`
+          // (default) carries the full LSDB; `stub` drops Type-5
+          // AS-External; `nssa` drops Type-5 but accepts Type-7
+          // (NSSA-AS-External). The N-bit (NSSA) and E-bit
+          // (External) in Hello/DBD options follow this knob and a
+          // mismatch with a neighbor causes Hello rejection per
+          // RFC 3101 §2.5 / RFC 2328 §10.5.
+          leaf area-type {
+            type enumeration {
+              enum normal;
+              enum stub;
+              enum nssa;
+            }
+            default normal;
+          }
+          // Totally-stubby / totally-NSSA: also drop Type-3 Summary
+          // entering this area. Only meaningful when area-type is
+          // `stub` or `nssa`.
+          leaf no-summary {
+            type boolean;
+            default false;
+          }
+          // NSSA ABR originates a default Type-7 LSA into the area
+          // (RFC 3101 §2.3). Ignored unless area-type is `nssa`.
+          leaf nssa-default-originate {
+            type boolean;
+            default false;
+          }
+          // RFC 3101 §2.6: when translating Type-7 to Type-5, zero
+          // the forwarding address. Ignored unless area-type is
+          // `nssa`.
+          leaf nssa-suppress-fa {
+            type boolean;
+            default false;
+          }
+          // RFC 3101 §2.2 translator-role for this NSSA ABR.
+          // `candidate` (default) participates in Nt-bit election;
+          // `always` translates unconditionally; `never` disables.
+          // Ignored unless area-type is `nssa`.
+          leaf nssa-translator-role {
+            type enumeration {
+              enum candidate;
+              enum always;
+              enum never;
+            }
+            default candidate;
+          }
           list interface {
             key "if-name";
             leaf if-name {
@@ -474,6 +521,38 @@ module config {
               type uint32;
               type inet:ipv4-address;
             }
+          }
+          // Per-area type. Same semantics as the v2 sibling above —
+          // see that leaf's description. Phase 1 wires the option-bit
+          // negotiation only; v3 Type-7 (0x2007) codec + handling
+          // arrives in phases 5/6.
+          leaf area-type {
+            type enumeration {
+              enum normal;
+              enum stub;
+              enum nssa;
+            }
+            default normal;
+          }
+          leaf no-summary {
+            type boolean;
+            default false;
+          }
+          leaf nssa-default-originate {
+            type boolean;
+            default false;
+          }
+          leaf nssa-suppress-fa {
+            type boolean;
+            default false;
+          }
+          leaf nssa-translator-role {
+            type enumeration {
+              enum candidate;
+              enum always;
+              enum never;
+            }
+            default candidate;
           }
           list interface {
             key "if-name";


### PR DESCRIPTION
## Summary

Phase 1 of v2+v3 NSSA support. Wires the per-area type model and the Hello/DBD Options-bit (E/N) negotiation so stub and NSSA neighbors agree on capabilities before adjacency forms. Storage-only for NSSA sub-knobs; Type-7 origination, SPF/RIB, and the ABR translator land in subsequent phases.

- `AreaType` becomes a struct (`kind` + `no_summary`, `nssa_default_originate`, `nssa_suppress_fa`, `nssa_translator_role`).
- YANG: five new leaves under each area in both `container ospf` and `container ospfv3`.
- Shared `area_*_set` helpers in `config.rs`; v2 + v3 callbacks register the new paths.
- `OspfLink` caches the active `area_type`; sync'd on config change (walk `area.links`) and on `Message::Enable` / `Disable`.
- Hello + DBD emit drive E/N bits (RFC 2328 §A.2, RFC 3101 §2.5); Hello recv drops mismatched neighbors (RFC 2328 §10.5). Mirrored on the v3 path using `Ospfv3Options::e` / `n`.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd`
- [ ] FRR interop: NSSA neighbor formation (Phase 2+)
- [ ] FRR interop: stub area dropping Type-5 (Phase 2+)

Generated with [Claude Code](https://claude.com/claude-code)