### PR TITLE
ospf: per-interface Null / Simple-password authentication (RFC 2328 §D)

### DIFF
--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -4,7 +4,7 @@ use std::net::Ipv4Addr;
 use super::Ospf;
 use super::OspfLink;
 use super::ifsm::{IfsmEvent, ospf_hello_timer};
-use super::link::OspfNetworkType;
+use super::link::{OspfAuthMode, OspfNetworkType};
 use super::tracing::{config_tracing_fsm, config_tracing_packet};
 use super::version::{OspfVersion, Ospfv2};
 
@@ -53,6 +53,14 @@ impl Ospf {
         self.ospf_add(
             "/area/interface/mtu-ignore",
             config_ospf_interface_mtu_ignore,
+        );
+        self.ospf_add(
+            "/area/interface/authentication",
+            config_ospf_interface_authentication,
+        );
+        self.ospf_add(
+            "/area/interface/authentication-key",
+            config_ospf_interface_authentication_key,
         );
         self.ospf_add(
             "/area/interface/prefix-sid/index",
@@ -278,6 +286,57 @@ fn config_ospf_interface_mtu_ignore(ospf: &mut Ospf, mut args: Args, op: ConfigO
 
     let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
     link.config.mtu_ignore = op.is_set() && mtu_ignore;
+
+    Some(())
+}
+
+fn config_ospf_interface_authentication(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let mode = args.string()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config.auth_mode = Some(match mode.as_str() {
+            "null" => OspfAuthMode::Null,
+            "simple" => OspfAuthMode::Simple,
+            _ => return None,
+        });
+    } else {
+        link.config.auth_mode = None;
+    }
+
+    Some(())
+}
+
+fn config_ospf_interface_authentication_key(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let key = args.string()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        // RFC 2328 §D.3 caps the simple-password at 8 octets. YANG
+        // also enforces `length 1..8`; this is a belt-and-suspenders
+        // truncation in case the schema isn't loaded.
+        let bytes = key.as_bytes();
+        if bytes.is_empty() || bytes.len() > 8 {
+            return None;
+        }
+        let mut padded = [0u8; 8];
+        padded[..bytes.len()].copy_from_slice(bytes);
+        link.config.auth_key = Some(padded);
+    } else {
+        link.config.auth_key = None;
+    }
 
     Some(())
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -16,7 +16,9 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use crate::config::{DisplayRequest, ShowChannel};
 use crate::ospf::Ospfv2;
 use crate::ospf::addr::OspfAddr;
-use crate::ospf::packet::{ospf_db_desc_recv, ospf_hello_recv, ospf_hello_send};
+use crate::ospf::packet::{
+    apply_link_auth, ospf_db_desc_recv, ospf_hello_recv, ospf_hello_send, verify_link_auth,
+};
 use crate::rib::api::RibRx;
 use crate::rib::inst::{IlmEntry, IlmType};
 use crate::rib::link::LinkAddr;
@@ -152,6 +154,14 @@ pub struct OspfInterface<'a, V: OspfVersion = Ospfv2> {
     /// keys off this to decide 2-Way -> ExStart on P2P links without
     /// gating on DR/BDR.
     pub network_type: OspfNetworkType,
+    /// Snapshot of the parent link's resolved RFC 2328 §D
+    /// authentication mode. Cached here so packet builders that
+    /// only borrow `OspfInterface` (not `OspfLink`) can stamp
+    /// outbound packets without a second `links` lookup.
+    pub auth_mode: super::link::OspfAuthMode,
+    /// Snapshot of the configured simple-password key, if any.
+    /// Only consulted when `auth_mode == Simple`.
+    pub auth_key: Option<[u8; 8]>,
     pub tracing: &'a OspfTracing,
     /// v3-only outbound packet channel borrow. Carries the `Ospfv3Send`
     /// sender that the `network_v6::write_packet_v6` task consumes.
@@ -183,6 +193,8 @@ impl<V: OspfVersion> Ospf<V> {
         self.links.get_mut(&ifindex).and_then(|link| {
             let link_area = link.area;
             let retransmit_interval = link.retransmit_interval();
+            let auth_mode = link.auth_mode();
+            let auth_key = link.config.auth_key;
             self.areas.get_mut(link_area).and_then(|area| {
                 let area_type = area.area_type;
                 link.nbrs.get_mut(src).map(|nbr| {
@@ -202,6 +214,8 @@ impl<V: OspfVersion> Ospf<V> {
                             mtu_ignore: link.config.mtu_ignore,
                             retransmit_interval,
                             network_type: link.network_type,
+                            auth_mode,
+                            auth_key,
                             tracing: &self.tracing,
                             v3_send_tx: self.v3_send_tx.as_ref(),
                             link_lsdb: &mut link.lsdb,
@@ -1263,6 +1277,8 @@ impl Ospf<Ospfv2> {
             };
             let retransmit_interval = link.retransmit_interval();
             let link_state = link.state;
+            let auth_mode = link.auth_mode();
+            let auth_key = link.config.auth_key;
 
             // RFC 2328 Section 13.3 Step 2-4: DR/BDR flooding decision.
             let is_source_iface = source.is_some_and(|(src_if, _)| src_if == ifindex);
@@ -1316,8 +1332,9 @@ impl Ospf<Ospfv2> {
                     num_adv: 1,
                     lsas: vec![lsa.clone()],
                 };
-                let packet =
+                let mut packet =
                     Ospfv2Packet::new(&self.router_id, &area_id, Ospfv2Payload::LsUpdate(ls_upd));
+                apply_link_auth(&mut packet, auth_mode, auth_key);
                 tracing::info!(
                     "[Flood] Sending LSA type={:?} id={} adv={} to nbr={}",
                     lsa.h.ls_type,
@@ -1362,6 +1379,8 @@ impl Ospf<Ospfv2> {
         };
         let retransmit_interval = link.retransmit_interval();
         let area_id = link.area;
+        let auth_mode = link.auth_mode();
+        let auth_key = link.config.auth_key;
         let Some(nbr) = link.nbrs.get_mut(&addr) else {
             return;
         };
@@ -1375,7 +1394,9 @@ impl Ospf<Ospfv2> {
             num_adv: lsas.len() as u32,
             lsas,
         };
-        let packet = Ospfv2Packet::new(&self.router_id, &area_id, Ospfv2Payload::LsUpdate(ls_upd));
+        let mut packet =
+            Ospfv2Packet::new(&self.router_id, &area_id, Ospfv2Payload::LsUpdate(ls_upd));
+        apply_link_auth(&mut packet, auth_mode, auth_key);
         let _ = nbr.ptx.send(Message::Send(
             packet,
             nbr.ifindex,
@@ -1406,11 +1427,12 @@ impl Ospf<Ospfv2> {
         let Some(ref sent) = nbr.dd.sent else {
             return;
         };
-        let packet = Ospfv2Packet::new(
+        let mut packet = Ospfv2Packet::new(
             link.router_id,
             &link.area_id,
             Ospfv2Payload::DbDesc(sent.clone()),
         );
+        apply_link_auth(&mut packet, link.auth_mode, link.auth_key);
         tracing::info!("[DB Desc:Retransmit] to {} seq={:#x}", addr, sent.seqnum);
         let _ = nbr.ptx.send(Message::Send(
             packet,
@@ -1455,7 +1477,9 @@ impl Ospf<Ospfv2> {
         let ls_ack = OspfLsAck {
             lsa_headers: ack_headers,
         };
-        let packet = Ospfv2Packet::new(&self.router_id, &link.area, Ospfv2Payload::LsAck(ls_ack));
+        let mut packet =
+            Ospfv2Packet::new(&self.router_id, &link.area, Ospfv2Payload::LsAck(ls_ack));
+        apply_link_auth(&mut packet, link.auth_mode(), link.config.auth_key);
         // Send to AllSPFRouters multicast.
         let _ = link.ptx.send(Message::Send(packet, ifindex, None));
     }
@@ -1528,6 +1552,26 @@ impl Ospf<Ospfv2> {
         // Drop self-originated packets (e.g. received on loopback interface).
         if packet.router_id == self.router_id {
             return;
+        }
+
+        // RFC 2328 §D.4: AuType + auth field must match the
+        // receiving interface's configured authentication. Snapshot
+        // the link's auth state in a short borrow scope so the
+        // per-type `links.get_mut` lookups below can proceed.
+        {
+            let Some(link) = self.links.get(&index) else {
+                return;
+            };
+            if !verify_link_auth(&packet, link.auth_mode(), link.config.auth_key) {
+                tracing::debug!(
+                    "OSPFv2 auth drop on {} from {}: type={} expected={:?}",
+                    link.name,
+                    src,
+                    packet.auth_type,
+                    link.auth_mode(),
+                );
+                return;
+            }
         }
 
         match packet.typ {

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -76,6 +76,27 @@ pub struct LinkConfig {
     pub prefix_sid: Option<PrefixSid>,
     pub adjacency_sid: Option<AdjacencySid>,
     pub network_type: Option<OspfNetworkType>,
+    /// RFC 2328 §D authentication mode. `None` = inherit (Null
+    /// today, until area/instance defaults land); `Some(Null)` is
+    /// an explicit override. Cryptographic auth (Type 2) lands in
+    /// a later phase under the IETF `interface/authentication`
+    /// container.
+    pub auth_mode: Option<OspfAuthMode>,
+    /// Simple-password key, already zero-padded to the 8-octet
+    /// on-wire field. Only consulted when `auth_mode == Simple`.
+    pub auth_key: Option<[u8; 8]>,
+}
+
+/// OSPFv2 per-interface authentication mode covered by this phase.
+/// Cryptographic auth (Type 2, RFC 2328 §D.4 / RFC 5709) will
+/// appear as an additional variant in a follow-up phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OspfAuthMode {
+    /// RFC 2328 §D.2 — AuType 0, header auth field ignored.
+    Null,
+    /// RFC 2328 §D.3 — AuType 1, header auth field carries the
+    /// plain key zero-padded to 8 bytes.
+    Simple,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -269,6 +290,12 @@ impl<V: OspfVersion> OspfLink<V> {
         self.config
             .network_type
             .unwrap_or(OspfNetworkType::Broadcast)
+    }
+
+    /// Effective authentication mode for this interface. Defaults
+    /// to Null when no mode is configured — RFC 2328 §D.2.
+    pub fn auth_mode(&self) -> OspfAuthMode {
+        self.config.auth_mode.unwrap_or(OspfAuthMode::Null)
     }
 }
 

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -15,10 +15,54 @@ use crate::{
 
 use super::{
     FloodScope, Identity, IfsmEvent, IfsmState, Message, Neighbor, NfsmEvent, NfsmState, OspfLink,
-    inst::OspfInterface, lsa_flood_scope, lsdb::OSPF_MAX_AGE, lsdb::OSPF_MAX_AGE_DIFF,
-    lsdb::OSPF_MAX_LSA_SEQ, ospf_flood, ospf_flood_self_originated_lsa, ospf_is_self_originated,
-    ospf_ls_request_lookup, tracing::OspfTracing,
+    inst::OspfInterface, link::OspfAuthMode, lsa_flood_scope, lsdb::OSPF_MAX_AGE,
+    lsdb::OSPF_MAX_AGE_DIFF, lsdb::OSPF_MAX_LSA_SEQ, ospf_flood, ospf_flood_self_originated_lsa,
+    ospf_is_self_originated, ospf_ls_request_lookup, tracing::OspfTracing,
 };
+
+/// Stamp the configured authentication state into an outgoing
+/// OSPFv2 packet. `mode` and `key` come from the sending
+/// interface; callers thread them in via `OspfLink::auth_mode()` /
+/// `OspfInterface::auth_mode`. Called by every
+/// `Ospfv2Packet::new(...)` site so emit produces the right
+/// `auth_type` / `auth` shape.
+pub(super) fn apply_link_auth(packet: &mut Ospfv2Packet, mode: OspfAuthMode, key: Option<[u8; 8]>) {
+    match mode {
+        OspfAuthMode::Null => {
+            packet.auth_type = 0;
+            packet.auth = Ospfv2Auth::Null([0; 8]);
+        }
+        OspfAuthMode::Simple => {
+            packet.auth_type = 1;
+            packet.auth = Ospfv2Auth::Simple(key.unwrap_or([0; 8]));
+        }
+    }
+}
+
+/// Validate an inbound OSPFv2 packet against the receiving
+/// interface's configured authentication. RFC 2328 §D.4 requires
+/// AuType to match and, for Type 1, the simple-password to be
+/// identical. Returns `true` when the packet is acceptable; on
+/// `false` the caller drops it.
+pub(super) fn verify_link_auth(
+    packet: &Ospfv2Packet,
+    mode: OspfAuthMode,
+    key: Option<[u8; 8]>,
+) -> bool {
+    match mode {
+        OspfAuthMode::Null => packet.auth_type == 0,
+        OspfAuthMode::Simple => match (&packet.auth_type, &packet.auth) {
+            (1, Ospfv2Auth::Simple(rx)) => {
+                let expected = key.unwrap_or([0; 8]);
+                // Plain key bytes — constant-time compare is overkill
+                // for a password that already authenticates only the
+                // outer SYN-equivalent; FRR / IOS use plain compare.
+                rx == &expected
+            }
+            _ => false,
+        },
+    }
+}
 
 pub fn ospf_hello_packet(oi: &OspfLink) -> Option<Ospfv2Packet> {
     let addr = oi.addr.first()?;
@@ -38,7 +82,8 @@ pub fn ospf_hello_packet(oi: &OspfLink) -> Option<Ospfv2Packet> {
         hello.neighbors.push(nbr.ident.router_id);
     }
 
-    let packet = Ospfv2Packet::new(&oi.ident.router_id, &oi.area, Ospfv2Payload::Hello(hello));
+    let mut packet = Ospfv2Packet::new(&oi.ident.router_id, &oi.area, Ospfv2Payload::Hello(hello));
+    apply_link_auth(&mut packet, oi.auth_mode(), oi.config.auth_key);
 
     Some(packet)
 }
@@ -218,7 +263,8 @@ pub fn ospf_db_desc_send(link: &mut OspfInterface, nbr: &mut Neighbor, oident: &
         nbr.timer.db_desc = None;
     }
 
-    let packet = Ospfv2Packet::new(&oident.router_id, &area, Ospfv2Payload::DbDesc(dd));
+    let mut packet = Ospfv2Packet::new(&oident.router_id, &area, Ospfv2Payload::DbDesc(dd));
+    apply_link_auth(&mut packet, link.auth_mode, link.auth_key);
     tracing::info!("DB_DESC: Send");
     // tracing::info!("{}", packet);
     let _ = nbr.ptx.send(Message::Send(
@@ -240,7 +286,8 @@ pub fn ospf_ls_req_send(link: &mut OspfInterface, nbr: &mut Neighbor, oident: &I
 
     ospf_packet_ls_req_set(nbr, &mut ls_req);
 
-    let packet = Ospfv2Packet::new(&oident.router_id, &area, Ospfv2Payload::LsRequest(ls_req));
+    let mut packet = Ospfv2Packet::new(&oident.router_id, &area, Ospfv2Payload::LsRequest(ls_req));
+    apply_link_auth(&mut packet, link.auth_mode, link.auth_key);
     tracing::info!("[DB Desc:Send]");
     tracing::info!("{}", packet);
     nbr.ptx
@@ -481,11 +528,12 @@ fn ospf_db_desc_resend(oi: &OspfInterface, nbr: &Neighbor) {
     let Some(ref sent) = nbr.dd.sent else {
         return;
     };
-    let packet = Ospfv2Packet::new(
+    let mut packet = Ospfv2Packet::new(
         &oi.ident.router_id,
         &oi.area_id,
         Ospfv2Payload::DbDesc(sent.clone()),
     );
+    apply_link_auth(&mut packet, oi.auth_mode, oi.auth_key);
     let _ = nbr.ptx.send(Message::Send(
         packet,
         nbr.ifindex,
@@ -499,7 +547,8 @@ pub fn ospf_ls_upd_send(oi: &OspfInterface, nbr: &Neighbor, lsas: Vec<OspfLsa>) 
         num_adv: lsas.len() as u32,
         lsas,
     };
-    let packet = Ospfv2Packet::new(&oi.ident.router_id, &area, Ospfv2Payload::LsUpdate(ls_upd));
+    let mut packet = Ospfv2Packet::new(&oi.ident.router_id, &area, Ospfv2Payload::LsUpdate(ls_upd));
+    apply_link_auth(&mut packet, oi.auth_mode, oi.auth_key);
     tracing::info!("[LS Update:Send] to {}", nbr.ident.prefix.addr());
     nbr.ptx
         .send(Message::Send(
@@ -513,7 +562,8 @@ pub fn ospf_ls_upd_send(oi: &OspfInterface, nbr: &Neighbor, lsas: Vec<OspfLsa>) 
 pub fn ospf_ls_ack_send(oi: &OspfInterface, nbr: &Neighbor, lsa_headers: Vec<OspfLsaHeader>) {
     let area = oi.area_id;
     let ls_ack = OspfLsAck { lsa_headers };
-    let packet = Ospfv2Packet::new(&oi.ident.router_id, &area, Ospfv2Payload::LsAck(ls_ack));
+    let mut packet = Ospfv2Packet::new(&oi.ident.router_id, &area, Ospfv2Payload::LsAck(ls_ack));
+    apply_link_auth(&mut packet, oi.auth_mode, oi.auth_key);
     tracing::info!("[LS Ack:Send] to {}", nbr.ident.prefix.addr());
     nbr.ptx
         .send(Message::Send(
@@ -838,5 +888,75 @@ pub fn ospf_ls_ack_recv(
     }
     if nbr.ls_rxmt.is_empty() {
         nbr.timer.ls_rxmt = None;
+    }
+}
+
+#[cfg(test)]
+mod auth_tests {
+    use super::*;
+    use ospf_packet::{OspfHello, OspfOptions, Ospfv2Packet, Ospfv2Payload};
+
+    fn hello_packet() -> Ospfv2Packet {
+        let hello = OspfHello {
+            netmask: Ipv4Addr::new(255, 255, 255, 0),
+            hello_interval: 10,
+            options: OspfOptions::new().with_external(true),
+            priority: 1,
+            router_dead_interval: 40,
+            d_router: Ipv4Addr::UNSPECIFIED,
+            bd_router: Ipv4Addr::UNSPECIFIED,
+            neighbors: Vec::new(),
+        };
+        Ospfv2Packet::new(
+            &Ipv4Addr::new(1, 1, 1, 1),
+            &Ipv4Addr::UNSPECIFIED,
+            Ospfv2Payload::Hello(hello),
+        )
+    }
+
+    #[test]
+    fn apply_null_stamps_type_zero() {
+        let mut p = hello_packet();
+        apply_link_auth(&mut p, OspfAuthMode::Null, None);
+        assert_eq!(p.auth_type, 0);
+        assert!(matches!(p.auth, Ospfv2Auth::Null(_)));
+    }
+
+    #[test]
+    fn apply_simple_pads_short_key() {
+        let mut p = hello_packet();
+        let key = *b"abc\0\0\0\0\0";
+        apply_link_auth(&mut p, OspfAuthMode::Simple, Some(key));
+        assert_eq!(p.auth_type, 1);
+        match p.auth {
+            Ospfv2Auth::Simple(rx) => assert_eq!(&rx, &key),
+            other => panic!("expected Simple, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn verify_null_accepts_type_zero_only() {
+        let mut p = hello_packet();
+        apply_link_auth(&mut p, OspfAuthMode::Null, None);
+        assert!(verify_link_auth(&p, OspfAuthMode::Null, None));
+
+        apply_link_auth(&mut p, OspfAuthMode::Simple, Some(*b"x\0\0\0\0\0\0\0"));
+        assert!(!verify_link_auth(&p, OspfAuthMode::Null, None));
+    }
+
+    #[test]
+    fn verify_simple_requires_key_match() {
+        let mut p = hello_packet();
+        let key = *b"secret\0\0";
+        apply_link_auth(&mut p, OspfAuthMode::Simple, Some(key));
+
+        assert!(verify_link_auth(&p, OspfAuthMode::Simple, Some(key)));
+        assert!(!verify_link_auth(
+            &p,
+            OspfAuthMode::Simple,
+            Some(*b"other\0\0\0")
+        ));
+        // Wrong mode on the receiving side — drop.
+        assert!(!verify_link_auth(&p, OspfAuthMode::Null, None));
     }
 }

--- a/zebra-rs/yang/zebra-ospf-auth-simple.yang
+++ b/zebra-rs/yang/zebra-ospf-auth-simple.yang
@@ -1,0 +1,112 @@
+module zebra-ospf-auth-simple {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-ospf-auth-simple";
+  prefix "zoas";
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "FRR / IOS style per-interface OSPFv2 authentication. The IETF
+     `ietf-ospf` model only describes the post-RFC 5709 cryptographic
+     authentication trailer (HMAC-SHA / key-chains); it has no leaf
+     for RFC 2328 §D Type 0 (Null) or Type 1 (Simple Password).
+
+     This module fills the gap with the flat FRR-style commands:
+
+       router ospf {
+         area 0 {
+           interface eth0 {
+             authentication simple;
+             authentication-key MYPASS;
+           }
+         }
+       }
+
+     Cryptographic auth (Type 2 / RFC 5709 trailer) will land in a
+     follow-up phase under the IETF `interface/authentication`
+     container; this module covers only Types 0 and 1.";
+
+  revision 2026-05-25 {
+    description "Initial revision: OSPFv2 Null / Simple-password.";
+    reference
+      "RFC 2328 §D.2/§D.3; FRR `ip ospf authentication [null|simple]`
+       and `ip ospf authentication-key`.";
+  }
+
+  typedef ospfv2-simple-auth-mode {
+    type enumeration {
+      enum "null" {
+        description "Null authentication (RFC 2328 §D.2, AuType=0).";
+      }
+      enum "simple" {
+        description
+          "Simple-password authentication (RFC 2328 §D.3, AuType=1).
+           Key is configured via the sibling `authentication-key`
+           leaf and zero-padded to 8 bytes on the wire.";
+      }
+    }
+    description
+      "OSPFv2 authentication mode covered by this module. Type 2
+       (cryptographic) is handled by the IETF model.";
+  }
+
+  grouping ospf-interface-auth-simple-extension {
+    description
+      "FRR-style flat authentication leaves on an OSPF interface.";
+
+    leaf authentication {
+      ext:help "OSPFv2 authentication mode (null|simple)";
+      type ospfv2-simple-auth-mode;
+      description
+        "Per-interface OSPFv2 authentication mode. When absent the
+         interface inherits the area / instance default (currently
+         always Null until area-level auth lands).";
+    }
+
+    leaf authentication-key {
+      ext:help "Simple-password key (1..8 chars)";
+      type string {
+        length "1..8";
+      }
+      description
+        "Simple-password key, plain text. RFC 2328 §D.3 caps the
+         on-wire field at 8 octets; longer keys are rejected at
+         commit time rather than silently truncated.";
+      reference "RFC 2328 §D.3";
+    }
+  }
+
+  augment "/configure:set/config:router"
+        + "/config:ospf/config:area/config:interface" {
+    description
+      "Attach the flat authentication leaves to each OSPF interface
+       in the candidate-set subtree.";
+    uses ospf-interface-auth-simple-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/config:ospf/config:area/config:interface" {
+    description
+      "Same attachment in the delete subtree so
+       `delete router ospf area X interface Y authentication[-key]`
+       is path-valid.";
+    uses ospf-interface-auth-simple-extension;
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 of OSPF authentication. Adds end-to-end wiring for AuType 0 (Null) and AuType 1 (Simple password) — the two non-cryptographic modes from RFC 2328 Appendix D. Cryptographic auth (Type 2 / RFC 5709) will land in a follow-up phase under the IETF \`interface/authentication\` container.

### YANG

New \`zebra-ospf-auth-simple.yang\` mirrors the \`zebra-bgp-password.yang\` vendor-extension pattern. The IETF \`ietf-ospf\` model only describes the post-RFC 5709 trailer + key-chain shape; it has no leaf for Null/Simple, so this module fills the gap with FRR-style flat commands:

\`\`\`
router ospf {
  area 0 {
    interface eth0 {
      authentication simple;
      authentication-key MYPASS;
    }
  }
}
\`\`\`

### Runtime

- \`OspfAuthMode\` enum + \`auth_mode\` / \`auth_key\` fields on \`LinkConfig\`.
- \`OspfInterface\` carries snapshots of both so packet builders that only borrow it can stamp outbound packets without a second \`links\` lookup.
- \`apply_link_auth(packet, mode, key)\` runs at every \`Ospfv2Packet::new(...)\` site (Hello / DD / LSR / LSU / LSAck and their retransmit paths). RFC 2328 §D.3 zero-padding for short keys happens at the config callback.
- \`verify_link_auth(packet, mode, key)\` runs at the top of \`process_recv\` before per-type dispatch; mismatches drop with \`tracing::debug!\`.

## Test plan

- [x] \`cargo test -p ospf-packet\` — 14 passed.
- [x] \`cargo test -p zebra-rs --bin zebra-rs\` — 614 passed (incl. 4 new \`ospf::packet::auth_tests\`).
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --all --check\` — clean.
- [ ] Live two-router negotiation against a FRR ospfd with \`ip ospf authentication-key\` set — deferred to phase 2 setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)