### PR TITLE
ospf: originate E-Router-LSA carrying P2P Adj-SID (v3)

### DIFF
--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -293,9 +293,11 @@ fn config_ospfv3_interface_prefix_sid_absolute(
     Some(())
 }
 
-/// Storage-only Adjacency-SID config callbacks. Mirror the v2
-/// pair above; LSA origination lands once OSPFv3 grows its
-/// Extended-Link Opaque-LSA equivalent (RFC 8666 E-LSA work).
+/// Store the per-interface Adjacency-SID and re-originate the
+/// matching E-Router-LSA. Mirrors v2's
+/// `config_ospf_interface_adjacency_sid_index`. The originator
+/// gates on its own preconditions (SR-MPLS + P2P + Full neighbor),
+/// so the LSA is flushed automatically when any are unmet.
 fn config_ospfv3_interface_adjacency_sid_index(
     ospf: &mut Ospf<Ospfv3>,
     mut args: Args,
@@ -311,6 +313,9 @@ fn config_ospfv3_interface_adjacency_sid_index(
     } else {
         link.config.adjacency_sid = None;
     }
+    let ifindex = link.index;
+
+    ospf.e_router_v3_lsa_originate(ifindex);
 
     Some(())
 }
@@ -330,6 +335,9 @@ fn config_ospfv3_interface_adjacency_sid_absolute(
     } else {
         link.config.adjacency_sid = None;
     }
+    let ifindex = link.index;
+
+    ospf.e_router_v3_lsa_originate(ifindex);
 
     Some(())
 }
@@ -357,6 +365,17 @@ fn config_ospfv3_sr_mpls(ospf: &mut Ospf<Ospfv3>, _args: Args, op: ConfigOp) -> 
         .collect();
     for ifindex in ifindexes {
         ospf.ext_intra_area_prefix_v3_lsa_originate(ifindex);
+    }
+
+    // Same for E-Router-LSAs (Adj-SID).
+    let ifindexes: Vec<u32> = ospf
+        .links
+        .iter()
+        .filter(|(_, link)| link.config.adjacency_sid.is_some())
+        .map(|(ifindex, _)| *ifindex)
+        .collect();
+    for ifindex in ifindexes {
+        ospf.e_router_v3_lsa_originate(ifindex);
     }
 
     Some(())

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -3092,6 +3092,86 @@ impl Ospf<Ospfv3> {
         }
     }
 
+    /// Originate (or flush) the OSPFv3 E-Router-LSA (RFC 8362 §3.1)
+    /// carrying an Adj-SID (RFC 8666 §6.1) for `ifindex`. v3
+    /// analogue of `Ospf<Ospfv2>::ext_link_lsa_originate`.
+    ///
+    /// Originates when SR-MPLS is on, the link is enabled, has an
+    /// `adjacency_sid` configured, network type is point-to-point,
+    /// and at least one neighbor reached Full. Flushes otherwise.
+    /// LAN-Adj-SID (broadcast / NBMA) origination lands in a
+    /// follow-up; this slice covers P2P only.
+    pub fn e_router_v3_lsa_originate(&mut self, ifindex: u32) {
+        use ospf_packet::OSPFV3_E_ROUTER_LSA_TYPE;
+
+        use super::srmpls::SegmentRoutingMode;
+
+        let link_state_id = ifindex;
+        let key: super::lsdb::OspfLsaKey =
+            (OSPFV3_E_ROUTER_LSA_TYPE, link_state_id, self.router_id);
+
+        let build_inputs = if self.segment_routing == SegmentRoutingMode::Mpls
+            && let Some(link) = self.links.get(&ifindex)
+            && link.enabled
+            && link.is_pointopoint()
+            && let Some(adjacency_sid) = link.config.adjacency_sid
+            && let Some(nbr) = link.nbrs.values().find(|n| n.state == NfsmState::Full)
+        {
+            Some((
+                link.area,
+                link.output_cost as u16,
+                link.interface_id,
+                nbr.interface_id,
+                nbr.ident.router_id,
+                adjacency_sid,
+            ))
+        } else {
+            None
+        };
+
+        if let Some((area_id, metric, my_iid, peer_iid, peer_rid, adjacency_sid)) = build_inputs {
+            let mut lsa = super::srmpls::e_router_v3_lsa_build(
+                self.router_id,
+                metric,
+                my_iid,
+                peer_iid,
+                peer_rid,
+                &adjacency_sid,
+                link_state_id,
+            );
+
+            if let Some(area) = self.areas.get(area_id)
+                && let Some(prev_seq) = area
+                    .lsdb
+                    .lookup_by_raw_key(key)
+                    .map(|prev| prev.h.ls_seq_number)
+            {
+                lsa.h.ls_seq_number = lsa.h.ls_seq_number.max(prev_seq.saturating_add(1));
+            }
+            lsa.update();
+
+            let flood_lsa = lsa.clone();
+            if let Some(area) = self.areas.get_mut(area_id) {
+                area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
+            }
+            self.flood_self_originated_lsa(area_id, &flood_lsa);
+        } else {
+            // Walk every area in case the link's area moved between
+            // calls -- a stale LSA must be flushed wherever it lives.
+            let area_ids: Vec<Ipv4Addr> = self.areas.iter().map(|(id, _)| *id).collect();
+            for area_id in area_ids {
+                let flushed = if let Some(area) = self.areas.get_mut(area_id) {
+                    area.lsdb.flush_lsa_by_raw_key(key, &self.tx, Some(area_id))
+                } else {
+                    None
+                };
+                if let Some(lsa) = flushed {
+                    self.flood_self_originated_lsa(area_id, &lsa);
+                }
+            }
+        }
+    }
+
     /// Detect Full state transitions on `nbr` and re-originate the
     /// LSAs that depend on the full-adjacency set. Mirrors v2's
     /// `process_neighbor_state_change`:
@@ -3159,6 +3239,12 @@ impl Ospf<Ospfv3> {
             // branch handles the gate, but it needs the call.
             self.network_intra_area_prefix_lsa_originate(ifindex);
         }
+
+        // SR-MPLS E-Router-LSA tracks the per-link P2P Adj-SID, which
+        // is only meaningful while the link has a Full neighbor.
+        // `e_router_v3_lsa_originate` flushes when no Full neighbor
+        // remains; the call is a no-op on non-P2P links.
+        self.e_router_v3_lsa_originate(ifindex);
     }
 
     /// Originate (or flush) the v3 Network-LSA for the broadcast

--- a/zebra-rs/src/ospf/srmpls.rs
+++ b/zebra-rs/src/ospf/srmpls.rs
@@ -178,6 +178,70 @@ pub fn build_lan_adj_sub(neighbor_id: Ipv4Addr, label: u32) -> ExtLinkSubTlv {
     })
 }
 
+/// Build an OSPFv3 E-Router-LSA (RFC 8362 §3.1) carrying one
+/// Router-Link TLV (P2P) whose sub-TLV is an Adj-SID (RFC 8666
+/// §6.1) for a single Full neighbor.
+///
+/// Flag semantics mirror the v2 path: Index form leaves V + L
+/// clear (the index resolves against the peer's SRGB); Absolute
+/// Label sets V + L per RFC 8666 §6.1. `link_state_id` is the
+/// caller-supplied per-LSA key (ifindex by convention).
+pub fn e_router_v3_lsa_build(
+    router_id: Ipv4Addr,
+    metric: u16,
+    our_interface_id: u32,
+    neighbor_interface_id: u32,
+    neighbor_router_id: Ipv4Addr,
+    adjacency_sid: &AdjacencySid,
+    link_state_id: u32,
+) -> Ospfv3Lsa {
+    let (sid, flags) = match adjacency_sid {
+        AdjacencySid::Index(idx) => (SidLabelTlv::Index(*idx), AdjSidFlags::new()),
+        AdjacencySid::Absolute(label) => (
+            SidLabelTlv::Label(*label),
+            AdjSidFlags::new().with_v_flag(true).with_l_flag(true),
+        ),
+    };
+
+    let adj_sub = Ospfv3SubTlv::AdjSid(Ospfv3AdjSidSubTlv {
+        flags,
+        weight: 0,
+        sid,
+    });
+
+    let link = Ospfv3RouterLsaLink::new(
+        Ospfv3RouterLinkType::PointToPoint,
+        metric,
+        our_interface_id,
+        neighbor_interface_id,
+        neighbor_router_id,
+    );
+
+    let router_link_tlv = Ospfv3ExtTlv::RouterLink(Ospfv3RouterLinkTlv {
+        link,
+        subs: vec![adj_sub],
+    });
+
+    let body = Ospfv3ELsaBody {
+        tlvs: vec![router_link_tlv],
+    };
+
+    let mut lsa = Ospfv3Lsa {
+        h: Ospfv3LsaHeader {
+            ls_age: 0,
+            ls_type: OSPFV3_E_ROUTER_LSA_TYPE,
+            link_state_id,
+            advertising_router: router_id,
+            ls_seq_number: 0x8000_0001,
+            ls_checksum: 0,
+            length: 0,
+        },
+        body: Ospfv3LsBody::ERouter(body),
+    };
+    lsa.update();
+    lsa
+}
+
 /// Build an OSPFv3 E-Intra-Area-Prefix-LSA (RFC 8362 §3.7) carrying
 /// one Intra-Area-Prefix TLV whose sub-TLV is a Prefix-SID (RFC 8666
 /// §5) for the given IPv6 prefix.


### PR DESCRIPTION
## Summary

Phase D PR-3b. Second v3 SR-MPLS origination step, mirroring v2's Phase B PR3 (#846) P2P Adjacency-SID origination. LAN-Adj-SID (broadcast / NBMA) lands in PR-3c.

Three pieces:

- **\`srmpls::e_router_v3_lsa_build\`** builds an RFC 8362 §3.1 E-Router-LSA (LS Type 0xA021) whose body is one \`Ospfv3ELsaBody\` with one \`Ospfv3RouterLinkTlv\` carrying the Router-LSA-link fixed prefix (P2P, our + peer interface IDs, peer router-id) plus a single \`Ospfv3AdjSidSubTlv\` (RFC 8666 §6.1). Flag semantics mirror the v2 path: Index form leaves V + L clear; Absolute Label sets V + L.
- **\`Ospf<Ospfv3>::e_router_v3_lsa_originate(ifindex)\`** is the symmetric counterpart to v2's \`ext_link_lsa_originate\`. Originates iff SR-MPLS is on, the link is enabled with an \`adjacency_sid\`, network type is point-to-point, and at least one neighbor reached Full. Flushes (MaxAge) otherwise. \`link_state_id\` = ifindex so the per-link LSA gets a stable key across re-originations.
- **Triggers**: v3 \`process_neighbor_state_change\` calls \`e_router_v3_lsa_originate\` on every Full transition, parallel to the existing Router-LSA re-origination. The v3 sr-mpls config callback fans out to every link with an adjacency_sid on toggle. The two v3 adjacency-sid config callbacks (index + absolute) drive origination after storing the value.

## Test plan

- [x] \`cargo build\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p zebra-rs --bins\` — 610/610 passing
- [ ] Manual: two OSPFv3 P2P routers, both with \`segment-routing mpls\` and \`adjacency-sid index N\` on the link. After adjacency reaches Full, confirm each side originates an E-Router-LSA carrying the Router-Link TLV + Adj-SID sub-TLV (visible via parse on the peer; PR-D4 will surface it in \`show ipv6 ospf database detail\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)