### PR TITLE
ospf: NSSA Type-7 ingest + default-information-originate (v2)

### DIFF
--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -210,6 +210,12 @@ pub(super) fn area_nssa_translator_role_set<V: OspfVersion>(
 
 /// `/router/ospf/area/<id>/area-type` — `normal | stub | nssa`.
 /// Delete reverts to the default (`normal`).
+///
+/// Triggers `nssa_default_lsa_originate` after the area type change
+/// so the Type-7 default-LSA appears when transitioning into NSSA
+/// with `nssa-default-originate=true`, and is flushed when leaving
+/// NSSA (the helper short-circuits to flush when the area is no
+/// longer NSSA).
 fn config_ospf_area_type(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
     let area_id = parse_area_id(&args.string()?)?;
     let kind = if op.is_set() {
@@ -218,6 +224,7 @@ fn config_ospf_area_type(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Optio
         AreaTypeKind::default()
     };
     area_type_set(ospf, area_id, kind);
+    ospf.nssa_default_lsa_originate(area_id);
     Some(())
 }
 
@@ -228,6 +235,9 @@ fn config_ospf_area_no_summary(ospf: &mut Ospf, mut args: Args, op: ConfigOp) ->
     Some(())
 }
 
+/// `/router/ospf/area/<id>/nssa-default-originate`. Trigger the
+/// originator (or flush) — the helper inspects the current area
+/// type + knob value and picks the right action.
 fn config_ospf_area_nssa_default_originate(
     ospf: &mut Ospf,
     mut args: Args,
@@ -236,6 +246,7 @@ fn config_ospf_area_nssa_default_originate(
     let area_id = parse_area_id(&args.string()?)?;
     let value = op.is_set() && args.boolean()?;
     area_nssa_default_originate_set(ospf, area_id, value);
+    ospf.nssa_default_lsa_originate(area_id);
     Some(())
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -811,6 +811,92 @@ impl Ospf<Ospfv2> {
         }
     }
 
+    /// RFC 3101 §2.3 NSSA default-LSA origination. Builds a Type-7
+    /// NSSA-AS-External LSA for the default route 0.0.0.0/0 and
+    /// installs it in `area_id`'s LSDB. P-bit stays clear so the
+    /// NSSA's ABR does not translate the default into Type-5 across
+    /// the backbone — the area-internal default is the only purpose
+    /// of this LSA. Metric type 2 (E2), cost 1 by default.
+    ///
+    /// Gates on: `area_id` exists, area is NSSA, and the area's
+    /// `nssa_default_originate` knob is true. Otherwise calls
+    /// `nssa_default_lsa_flush` to clear any stale self-originated
+    /// copy.
+    pub fn nssa_default_lsa_originate(&mut self, area_id: Ipv4Addr) {
+        let area_type = match self.areas.get(area_id) {
+            Some(area) => area.area_type,
+            None => return,
+        };
+        if !area_type.is_nssa() || !area_type.nssa_default_originate {
+            self.nssa_default_lsa_flush(area_id);
+            return;
+        }
+
+        let ls_id = Ipv4Addr::UNSPECIFIED;
+        let mut lsa_header = OspfLsaHeader::new(OspfLsType::NssaAsExternal, ls_id, self.router_id);
+        // RFC 3101 §2.4 LSA header Options on Type-7: E bit MUST be
+        // clear (NSSA areas can't accept Type-5); N bit set; P bit
+        // clear for ABR-originated default per §2.3.
+        let mut options = OspfOptions::default();
+        options.set_nssa(true);
+        options.set_o(true);
+        lsa_header.options = u8::from(options);
+
+        // E1/E2 + metric. 0x80 = E2 (type-2 metric, dominant over
+        // SPF cost). Cost defaults to 1 — there's no separate YANG
+        // knob yet; a `nssa-default-originate-cost` leaf can be
+        // added later without changing this code path.
+        let body = NssaAsExternalLsa {
+            netmask: Ipv4Addr::UNSPECIFIED,
+            ext_and_tos: 0x80,
+            metric: 1,
+            forwarding_address: Ipv4Addr::UNSPECIFIED,
+            external_route_tag: 0,
+            tos_list: Vec::new(),
+        };
+        let mut lsa = OspfLsa::from(lsa_header, OspfLsp::NssaAsExternal(body));
+
+        // Preserve sequence number if re-originating.
+        if let Some(area) = self.areas.get(area_id)
+            && let Some(existing) =
+                area.lsdb
+                    .lookup_by_id(OspfLsType::NssaAsExternal, ls_id, self.router_id)
+        {
+            lsa.h.ls_seq_number = lsa
+                .h
+                .ls_seq_number
+                .max(existing.h.ls_seq_number.saturating_add(1));
+        }
+        lsa.update();
+
+        let flood_lsa = lsa.clone();
+        if let Some(area) = self.areas.get_mut(area_id) {
+            area.lsdb
+                .insert_self_originated(lsa, &self.tx, Some(area_id));
+        }
+        self.flood_self_originated_lsa(area_id, &flood_lsa);
+    }
+
+    /// Flush our self-originated Type-7 default LSA from `area_id`.
+    /// No-op if the area or LSA doesn't exist.
+    pub fn nssa_default_lsa_flush(&mut self, area_id: Ipv4Addr) {
+        let ls_id = Ipv4Addr::UNSPECIFIED;
+        let flushed = if let Some(area) = self.areas.get_mut(area_id) {
+            area.lsdb.flush_lsa(
+                OspfLsType::NssaAsExternal,
+                ls_id,
+                self.router_id,
+                &self.tx,
+                Some(area_id),
+            )
+        } else {
+            None
+        };
+        if let Some(lsa) = flushed {
+            self.flood_self_originated_lsa(area_id, &lsa);
+        }
+    }
+
     fn process_lsdb(&mut self, ev: LsdbEvent, area_id: Option<Ipv4Addr>, key: OspfLsaKey) {
         // Unpack the widened key back into v2-typed components for the
         // v2-bound match arms / method calls below.
@@ -1000,6 +1086,40 @@ impl Ospf<Ospfv2> {
                             area.lsdb
                                 .flush_lsa(ls_type, ls_id, adv_router, &self.tx, Some(area_id))
                         };
+                        if let Some(lsa) = flushed {
+                            self.flood_self_originated_lsa(area_id, &lsa);
+                        }
+                    }
+                }
+            }
+            OspfLsType::NssaAsExternal => {
+                // The only Type-7 we self-originate today is the
+                // NSSA default-LSA (ls_id 0.0.0.0). Re-originate via
+                // the same builder used at config time — it inspects
+                // the area-type + nssa_default_originate knob and
+                // either re-emits with seq# = received+1, or flushes
+                // if we no longer own it. Other ls_ids (future
+                // redistributed Type-7s) fall through to the generic
+                // flush until phase 2c lands.
+                if ls_id.is_unspecified()
+                    && let Some(area_id) = area_id
+                {
+                    tracing::info!(
+                        "[Self-Originated] Re-originating NSSA default Type-7 id={} seq={:#x}",
+                        ls_id,
+                        received_seq
+                    );
+                    self.nssa_default_lsa_originate(area_id);
+                } else {
+                    tracing::info!(
+                        "[Self-Originated] Flushing Type-7 LSA id={} (no owner)",
+                        ls_id
+                    );
+                    if let Some(area_id) = area_id {
+                        let flushed = self.areas.get_mut(area_id).and_then(|area| {
+                            area.lsdb
+                                .flush_lsa(ls_type, ls_id, adv_router, &self.tx, Some(area_id))
+                        });
                         if let Some(lsa) = flushed {
                             self.flood_self_originated_lsa(area_id, &lsa);
                         }

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -389,6 +389,13 @@ pub fn ospfv2_populate_initial_db_summary(
         ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::OpaqueAreaLocal));
     }
 
+    // RFC 3101 §2.5: Type-7 NSSA-AS-External LSAs flood with area
+    // scope inside an NSSA, so they belong in the per-area DBD
+    // summary — but only when this area is NSSA.
+    if oi.area_type.is_nssa() {
+        ospf_db_summary_add_table(nbr, oi.lsdb.values_by_type(OspfLsType::NssaAsExternal));
+    }
+
     // AS-scope LSAs included only for non-stub / non-NSSA areas.
     if oi.area_type.accepts_as_external() {
         ospf_db_summary_add_table(nbr, oi.lsdb_as.values_by_type(OspfLsType::AsExternal));

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -658,6 +658,20 @@ fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -
         );
         return LsaProcessResult::DiscardNoAck;
     }
+    // RFC 3101 §2.5: Type-7 NSSA-AS-External LSAs are accepted only
+    // in NSSA areas. Drop them on Normal / Stub links — the peer
+    // shouldn't be sending them in the first place (option-bit
+    // negotiation should have prevented the adjacency), but defend
+    // against misconfigured neighbors that slip through.
+    if matches!(lsa.h.ls_type, OspfLsType::NssaAsExternal) && !oi.area_type.is_nssa() {
+        tracing::info!(
+            "[LS Update] Step 3: Discarding Type-7 LSA in {:?} area: id={} adv={}",
+            oi.area_type,
+            lsa.h.ls_id,
+            lsa.h.adv_router
+        );
+        return LsaProcessResult::DiscardNoAck;
+    }
 
     // Step 4: Look up current database copy, compute comparison result.
     // Use lookup_lsa() to get the Lsa wrapper so we can compute current_age().


### PR DESCRIPTION
## Summary

Phase 2 of v2+v3 NSSA: Type-7 NSSA-AS-External becomes a first-class LSA on the v2 receive / database / origination paths, plus the simplest origination case — NSSA `default-information-originate`.

**Receive side**
- `ospf_ls_upd_proc` drops Type-7 received on Normal/Stub areas (RFC 3101 §2.5).
- `ospfv2_populate_initial_db_summary` adds Type-7 to the DBD summary when the area is NSSA.

**Origination side**
- New `nssa_default_lsa_originate(area_id)` + `nssa_default_lsa_flush` build the Type-7 default LSA (ls_id 0.0.0.0, mask 0.0.0.0, metric-type 2, cost 1, P=0 per RFC 3101 §2.3).
- v2 callbacks `config_ospf_area_type` and `config_ospf_area_nssa_default_originate` invoke the helper, so toggling either knob triggers the right originate/flush.
- `process_self_originated_lsa` gains a NssaAsExternal branch that re-originates the default Type-7; other ls_ids fall through to flush until phase 2c.

**Out of scope**: redistribute → Type-7 (phase 2c), Type-7 SPF/RIB (phase 3), ABR Type-7→Type-5 translation (phase 4), v3 Type-7 codec (phase 5).

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --exclude bdd\`
- [ ] FRR interop: NSSA default Type-7 reaches a peer router (phase 3 SPF needed)
- [ ] FRR interop: Type-7 received on a non-NSSA link is silently dropped

Generated with [Claude Code](https://claude.com/claude-code)