### PR TITLE
ospf: helper-mode detection + inactivity-timer suppression (v2)

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1241,6 +1241,32 @@ impl Ospf<Ospfv2> {
         self.ext_link_lsa_originate(ifindex);
     }
 
+    /// Grace-period expiry handler (RFC 3623 §3.2 bullet 1). Clears
+    /// `nbr.gr_helper` and re-fires the inactivity-timer event so
+    /// the normal `ospf_nfsm_kill_nbr` path runs — by now the
+    /// neighbor really is gone.
+    fn gr_helper_expire(&mut self, ifindex: u32, router_id: Ipv4Addr) {
+        let Some(link) = self.links.get_mut(&ifindex) else {
+            return;
+        };
+        let Some(nbr) = link.nbrs.get_mut(&router_id) else {
+            return;
+        };
+        if nbr.gr_helper.take().is_none() {
+            return;
+        }
+        tracing::info!(
+            "[GR Helper] grace-period expired for nbr {} on ifindex={}, killing neighbor",
+            router_id,
+            ifindex
+        );
+        let _ = self.tx.send(Message::Nfsm(
+            ifindex,
+            router_id,
+            super::nfsm::NfsmEvent::InactivityTimer,
+        ));
+    }
+
     /// Check if we are currently the DR for the network identified by ls_id.
     fn is_dr_for_network_lsa(&self, ls_id: Ipv4Addr) -> bool {
         for (_, link) in self.links.iter() {
@@ -1792,6 +1818,9 @@ impl Ospf<Ospfv2> {
                         let _ = self.tx.send(Message::SpfCalc(area_id));
                     }
                 }
+            }
+            Message::GrHelperExpire(ifindex, router_id) => {
+                self.gr_helper_expire(ifindex, router_id);
             }
             _ => {}
         }
@@ -3751,6 +3780,11 @@ pub enum Message<V: OspfVersion = Ospfv2> {
     /// folds back into `Ospf` on the main task. Currently only
     /// emitted by v2; v3 still runs SPF inline.
     SpfDone(Box<SpfOutput>),
+    /// Graceful-restart helper-mode grace-period expiry for
+    /// `(ifindex, nbr_router_id)`. RFC 3623 §3.2 bullet 1 — the
+    /// restarter exceeded its grace window. Exit helper and let the
+    /// normal `InactivityTimer` path tear the neighbor down.
+    GrHelperExpire(u32, Ipv4Addr),
 }
 
 use crate::spf::{self, Path};

--- a/zebra-rs/src/ospf/neigh.rs
+++ b/zebra-rs/src/ospf/neigh.rs
@@ -12,6 +12,32 @@ use super::task::Timer;
 use super::version::{OspfVersion, Ospfv2};
 use super::{Identity, Message, NfsmEvent, NfsmState};
 
+/// Graceful-restart helper bookkeeping (RFC 3623 §3.1). Populated
+/// when we accept a Grace LSA from this neighbor; absent the rest
+/// of the time. While `Some`, the inactivity timer is suppressed
+/// (`ospf_nfsm_inactivity_timer` rearms instead of killing) so the
+/// neighbor's adjacency stays Full across the restart window.
+///
+/// Phase 2a wires entry, suppression, and grace-period-expiry exit.
+/// `reason` / `grace_period` / `entered_at` are populated here but
+/// only consumed in 2b (Router-LSA preservation) and 2c (show +
+/// strict LSDB-consistency check); the `dead_code` allow on the
+/// struct documents that.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct HelperState {
+    /// Restart reason carried in the Grace LSA's type-2 sub-TLV.
+    pub reason: ospf_packet::GraceRestartReason,
+    /// Grace period (seconds) the restarter requested.
+    pub grace_period: u32,
+    /// When we entered helper mode.
+    pub entered_at: Instant,
+    /// Pending grace-period-expiry timer. Dropping clears it; we
+    /// keep an explicit handle so re-entry (extended grace period)
+    /// cancels the prior expiry cleanly.
+    pub expire_timer: Option<Timer>,
+}
+
 /// Per-neighbor protocol state.
 ///
 /// Parameterized over `V: OspfVersion` so the wire-type-carrying
@@ -63,6 +89,9 @@ pub struct Neighbor<V: OspfVersion = Ospfv2> {
     /// defaulted to 0.
     #[allow(dead_code)]
     pub interface_id: u32,
+    /// Graceful-restart helper state. `Some` while we are helping
+    /// this neighbor restart; `None` otherwise. See [`HelperState`].
+    pub gr_helper: Option<HelperState>,
 }
 
 #[bitfield(u8, debug = true)]
@@ -152,6 +181,7 @@ where
             last_regressive: None,
             last_regressive_reason: None,
             interface_id: 0,
+            gr_helper: None,
         };
         nbr.ident.prefix = prefix;
         nbr

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -536,6 +536,20 @@ pub fn ospf_nfsm_inactivity_timer<V: OspfVersion>(
     nbr: &mut Neighbor<V>,
     oident: &Identity<V>,
 ) -> Option<NfsmState> {
+    // RFC 3623 §3.2 — while in helper mode we treat the neighbor as
+    // if Hellos were still arriving, suppressing the dead-interval
+    // kill. Rearm the inactivity timer so we keep ticking; the
+    // grace-period expiry timer (`Message::GrHelperExpire`) is the
+    // bound that actually exits helper mode in Phase 2a.
+    // Topology-change exit conditions land in 2c.
+    if nbr.gr_helper.is_some() {
+        tracing::info!(
+            "[GR Helper] suppress inactivity-timer kill for nbr {} (still helping)",
+            nbr.ident.router_id
+        );
+        nbr.timer.inactivity = Some(ospf_inactivity_timer(nbr));
+        return None;
+    }
     ospf_nfsm_kill_nbr(oi, nbr, oident)
 }
 

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -20,6 +20,13 @@ use super::{
     ospf_is_self_originated, ospf_ls_request_lookup, tracing::OspfTracing,
 };
 
+/// Maximum grace period (seconds) we will honour as helper. RFC 3623
+/// §3.1 leaves the bound up to the helper; this matches the IETF
+/// YANG default (`max-grace-period`) and FRR's `ip ospf
+/// graceful-restart helper grace-period` default. Phase 4 exposes
+/// this as a per-instance config knob.
+const MAX_GRACE_PERIOD_SECS: u32 = 1800;
+
 /// Stamp the configured authentication state into an outgoing
 /// OSPFv2 packet. `mode` and `key` come from the sending
 /// interface; callers thread them in via `OspfLink::auth_mode()` /
@@ -748,6 +755,13 @@ fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -
         );
         ospf_flood(oi, nbr, lsa);
 
+        // RFC 3623 §3.1: a Grace LSA from a Full neighbor advertising
+        // its own router-id is the trigger to enter helper mode. Run
+        // this check after flooding so the LSA itself still propagates
+        // (RFC 3623 §A.3); helper-policy gating + strict LSDB checks
+        // land in Phase 2c.
+        gr_maybe_enter_helper(oi, nbr, lsa);
+
         // RFC 2328 Section 13.4: Self-originated LSA check.
         if ospf_is_self_originated(oi, lsa) {
             tracing::info!(
@@ -858,6 +872,93 @@ pub fn ospf_ls_upd_validate_proc(
         let msg = Message::DelayedAckQueue(nbr.ifindex, delayed_ack_headers);
         let _ = oi.tx.send(msg);
     }
+}
+
+/// RFC 3623 §3.1 helper-entry gate. Called from `ospf_ls_upd_proc`
+/// after a newer LSA is flooded — if that LSA is a Grace LSA
+/// advertised by the sender (a Full neighbor), set the per-neighbor
+/// `gr_helper` state and arm the grace-period expiry timer.
+///
+/// Phase 2a does the minimum-viable check: the sender must be Full,
+/// the LSA's advertising-router must match the neighbor (i.e. the
+/// neighbor is announcing its own restart), and the grace period
+/// must be within [1, `MAX_GRACE_PERIOD_SECS`]. Strict-LSA-checking
+/// (RFC 3623 §3.2 bullets 2-3 / LSDB snapshot) lands in Phase 2c.
+fn gr_maybe_enter_helper(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) {
+    use super::neigh::HelperState;
+    use super::task::{Timer, TimerType};
+
+    if lsa.h.ls_type != OspfLsType::OpaqueLinkLocal {
+        return;
+    }
+    let OspfLsp::OpaqueLinkLocalGrace(ref body) = lsa.lsp else {
+        return;
+    };
+    if lsa.h.adv_router != nbr.ident.router_id {
+        return;
+    }
+    if nbr.state != NfsmState::Full {
+        tracing::info!(
+            "[GR Helper] reject Grace LSA from non-Full nbr {} (state={:?})",
+            nbr.ident.router_id,
+            nbr.state
+        );
+        return;
+    }
+    let grace_period = match body.grace_period() {
+        Some(p) if p > 0 && p <= MAX_GRACE_PERIOD_SECS => p,
+        Some(p) => {
+            tracing::info!(
+                "[GR Helper] reject Grace LSA from nbr {} (grace={}s out of [1, {}])",
+                nbr.ident.router_id,
+                p,
+                MAX_GRACE_PERIOD_SECS
+            );
+            return;
+        }
+        None => {
+            tracing::info!(
+                "[GR Helper] reject Grace LSA from nbr {} (no GracePeriod TLV)",
+                nbr.ident.router_id
+            );
+            return;
+        }
+    };
+    let reason = body.reason().unwrap_or(GraceRestartReason::Unknown);
+
+    let ifindex = nbr.ifindex;
+    let router_id = nbr.ident.router_id;
+    let tx = oi.tx.clone();
+    let expire_timer = Timer::new(
+        Timer::second(grace_period as u64),
+        TimerType::Once,
+        move || {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send(Message::GrHelperExpire(ifindex, router_id));
+            }
+        },
+    );
+
+    let previously_helping = nbr.gr_helper.is_some();
+    nbr.gr_helper = Some(HelperState {
+        reason,
+        grace_period,
+        entered_at: tokio::time::Instant::now(),
+        expire_timer: Some(expire_timer),
+    });
+    tracing::info!(
+        "[GR Helper] {} for nbr {} on ifindex={} (grace={}s, reason={:?})",
+        if previously_helping {
+            "extend"
+        } else {
+            "enter"
+        },
+        router_id,
+        ifindex,
+        grace_period,
+        reason
+    );
 }
 
 pub fn ospf_ls_upd_recv(


### PR DESCRIPTION
## Summary

Phase 2a of OSPFv2 graceful restart (helper side) — first slice of the helper FSM, following the codec landed in #861. Pinned by docs/design/ospf-graceful-restart-plan.md.

- `HelperState` added to `Neighbor` (zebra-rs/src/ospf/neigh.rs) — populated when we accept a Grace LSA from this neighbor.
- `gr_maybe_enter_helper` (zebra-rs/src/ospf/packet.rs) — RFC 3623 §3.1 entry gate. Triggered from `ospf_ls_upd_proc` after a newer Grace LSA is flooded. Validates: sender is Full, `adv_router == nbr.router_id`, grace period ∈ [1, 1800s]. On accept: arms a one-shot grace-period expiry timer.
- `ospf_nfsm_inactivity_timer` (zebra-rs/src/ospf/nfsm.rs) — while `gr_helper.is_some()`, rearm the inactivity timer instead of running `ospf_nfsm_kill_nbr`. Adjacency stays Full across the dead-interval window.
- `Message::GrHelperExpire` + `Ospf::gr_helper_expire` (zebra-rs/src/ospf/inst.rs) — grace-period expiry clears the helper state and re-injects `NfsmEvent::InactivityTimer` so the normal kill path runs.

## What's deferred to 2b / 2c

- Router-LSA / Network-LSA must still list the helper-mode neighbor (Phase 2b). Today, Router-LSA origination re-runs on Full transitions only, and we suppress the Full→Down transition during helper, so the existing adjacency advertisement is implicitly preserved — but no explicit guard exists in the LSA origination path yet.
- The `gr_helper` capability bit is still unset in `srmpls.rs:router_info_lsa_build` (Phase 2b).
- Strict-LSA-checking + topology-change exit conditions (RFC 3623 §3.2 bullets 2-3) are Phase 2c.
- `show ip ospf graceful-restart` + YANG config-surface are Phase 2c.

The `dead_code` allow on `HelperState` documents the `reason` / `grace_period` / `entered_at` fields as written-now-consumed-later in 2b/2c.

## Test plan

- [x] `cargo fmt && cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --exclude bdd` — zero failures.
- [ ] Two-router FRR-peer test (Phase 2 exit criterion per the plan): restarting FRR neighbor should not flap our adjacency. Deferred to a manual run once Phase 2b lands (Router-LSA guard needed for the assertion to be meaningful).

Generated with [Claude Code](https://claude.com/claude-code)