### PR TITLE
ospf: originate E-Router-LSA LAN-Adj-SID on broadcast / NBMA (v3)

### DIFF
--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -420,17 +420,58 @@ fn config_ospfv3_interface_adjacency_sid_absolute(
     Some(())
 }
 
-/// Toggle the v3 SR-MPLS enable bit and fan out to every link with
-/// a configured Prefix-SID so the matching E-Intra-Area-Prefix-LSA
-/// is originated (on enable) or flushed (on disable). Router-Info /
-/// Adj-SID origination wires onto the same toggle in follow-up PRs.
+/// Toggle the v3 SR-MPLS enable bit, manage the per-instance
+/// Adjacency-SID label pool, and fan out to every link with a
+/// configured SR-MPLS attribute so the matching E-LSAs are
+/// originated (on enable) or flushed (on disable). Mirrors v2's
+/// `config_ospf_sr_mpls`.
 fn config_ospfv3_sr_mpls(ospf: &mut Ospf<Ospfv3>, _args: Args, op: ConfigOp) -> Option<()> {
-    use super::srmpls::SegmentRoutingMode;
+    use super::srmpls::{SRLB_RANGE, SRLB_START, SegmentRoutingMode};
+    use crate::spf::label_pool::LabelPool;
     ospf.segment_routing = if op.is_set() {
         SegmentRoutingMode::Mpls
     } else {
         SegmentRoutingMode::None
     };
+
+    // Manage the per-instance Adjacency-SID label pool alongside the
+    // mode toggle. The pool is bounded by the SRLB
+    // (`srmpls::SRLB_START`..`+ SRLB_RANGE - 1`); on enable, sweep
+    // current Full neighbors and allocate labels for any not yet in
+    // `lan_adj_sids` so an SR-MPLS enable after adjacencies have
+    // already settled still produces the LAN Adj-SID LSAs.
+    if op.is_set() {
+        if ospf.local_pool.is_none() {
+            ospf.local_pool = Some(LabelPool::new(
+                SRLB_START as usize,
+                Some((SRLB_START + SRLB_RANGE - 1) as usize),
+            ));
+        }
+        let pending: Vec<(u32, std::net::Ipv4Addr)> = ospf
+            .links
+            .iter()
+            .flat_map(|(ifindex, link)| {
+                link.nbrs.iter().filter_map(move |(nbr_key, nbr)| {
+                    if nbr.state == super::nfsm::NfsmState::Full {
+                        Some((*ifindex, *nbr_key))
+                    } else {
+                        None
+                    }
+                })
+            })
+            .filter(|key| !ospf.lan_adj_sids.contains_key(key))
+            .collect();
+        for key in pending {
+            if let Some(pool) = ospf.local_pool.as_mut()
+                && let Some(label) = pool.allocate()
+            {
+                ospf.lan_adj_sids.insert(key, label as u32);
+            }
+        }
+    } else {
+        ospf.local_pool = None;
+        ospf.lan_adj_sids.clear();
+    }
 
     // Re-originate / flush E-Intra-Area-Prefix-LSAs for every link
     // with a Prefix-SID. The originator gates on the mode, so on
@@ -445,11 +486,21 @@ fn config_ospfv3_sr_mpls(ospf: &mut Ospf<Ospfv3>, _args: Args, op: ConfigOp) -> 
         ospf.ext_intra_area_prefix_v3_lsa_originate(ifindex);
     }
 
-    // Same for E-Router-LSAs (Adj-SID).
+    // Re-originate / flush E-Router-LSAs for every link with either
+    // a configured P2P adjacency-SID or any LAN Adj-SID labels just
+    // allocated above. Using both criteria covers static-config P2P
+    // and dynamic-allocation broadcast in one pass.
     let ifindexes: Vec<u32> = ospf
         .links
         .iter()
-        .filter(|(_, link)| link.config.adjacency_sid.is_some())
+        .filter(|(ifindex, link)| {
+            link.config.adjacency_sid.is_some()
+                || ospf
+                    .lan_adj_sids
+                    .range((**ifindex, std::net::Ipv4Addr::UNSPECIFIED)..)
+                    .next()
+                    .is_some_and(|((idx, _), _)| idx == *ifindex)
+        })
         .map(|(ifindex, _)| *ifindex)
         .collect();
     for ifindex in ifindexes {

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -2741,6 +2741,16 @@ impl Ospf<Ospfv3> {
                         self.network_intra_area_prefix_lsa_flush(index, area_id);
                         self.network_lsa_flush(index, area_id);
                     }
+                    // Re-originate the per-link SR-MPLS E-Router-LSA
+                    // on any IFSM state change. Broadcast / NBMA
+                    // links carry the DR's interface_id in the
+                    // Router-Link TLV, so a DR election outcome must
+                    // refresh the LSA; the originator's own gating
+                    // makes the call a no-op when the preconditions
+                    // don't hold (P2P sees no semantic change).
+                    if new_state.is_some_and(|s| s != prev_state) {
+                        self.e_router_v3_lsa_originate(index);
+                    }
                 }
             }
             Message::HelloTimer(index) => {
@@ -3147,50 +3157,129 @@ impl Ospf<Ospfv3> {
     }
 
     /// Originate (or flush) the OSPFv3 E-Router-LSA (RFC 8362 §3.1)
-    /// carrying an Adj-SID (RFC 8666 §6.1) for `ifindex`. v3
-    /// analogue of `Ospf<Ospfv2>::ext_link_lsa_originate`.
+    /// carrying an Adj-SID (RFC 8666 §6) for `ifindex`. v3 analogue
+    /// of `Ospf<Ospfv2>::ext_link_lsa_originate`.
     ///
-    /// Originates when SR-MPLS is on, the link is enabled, has an
-    /// `adjacency_sid` configured, network type is point-to-point,
-    /// and at least one neighbor reached Full. Flushes otherwise.
-    /// LAN-Adj-SID (broadcast / NBMA) origination lands in a
-    /// follow-up; this slice covers P2P only.
+    /// Originates when SR-MPLS is on, the link is enabled, has at
+    /// least one Full neighbor, and either of:
+    ///   * P2P link with an `adjacency_sid` configured -- one
+    ///     `AdjSid` sub-TLV with the configured value.
+    ///   * Broadcast / NBMA link with a known DR and at least one
+    ///     entry in `lan_adj_sids` -- one `LanAdjSid` sub-TLV per
+    ///     Full neighbor that has a label allocated (RFC 8666 §6.2).
+    ///
+    /// Flushes (MaxAge) otherwise. `link_state_id` is the ifindex
+    /// so the per-link LSA gets a stable key across re-originations.
     pub fn e_router_v3_lsa_originate(&mut self, ifindex: u32) {
-        use ospf_packet::OSPFV3_E_ROUTER_LSA_TYPE;
+        use ospf_packet::{OSPFV3_E_ROUTER_LSA_TYPE, Ospfv3RouterLinkType};
 
+        use super::link::OspfNetworkType;
         use super::srmpls::SegmentRoutingMode;
 
         let link_state_id = ifindex;
         let key: super::lsdb::OspfLsaKey =
             (OSPFV3_E_ROUTER_LSA_TYPE, link_state_id, self.router_id);
 
+        // Build the (area, link_type, metric, my_iid, peer_iid,
+        // peer_rid, subs) tuple if origination is warranted, else
+        // fall through to the flush path.
         let build_inputs = if self.segment_routing == SegmentRoutingMode::Mpls
             && let Some(link) = self.links.get(&ifindex)
             && link.enabled
-            && link.is_pointopoint()
-            && let Some(adjacency_sid) = link.config.adjacency_sid
-            && let Some(nbr) = link.nbrs.values().find(|n| n.state == NfsmState::Full)
+            && link.nbrs.values().any(|n| n.state == NfsmState::Full)
         {
-            Some((
-                link.area,
-                link.output_cost as u16,
-                link.interface_id,
-                nbr.interface_id,
-                nbr.ident.router_id,
-                adjacency_sid,
-            ))
+            let metric = link.output_cost as u16;
+            let my_iid = link.interface_id;
+            match link.network_type {
+                OspfNetworkType::PointToPoint => {
+                    if let Some(adjacency_sid) = link.config.adjacency_sid
+                        && let Some(nbr) = link.nbrs.values().find(|n| n.state == NfsmState::Full)
+                    {
+                        Some((
+                            link.area,
+                            Ospfv3RouterLinkType::PointToPoint,
+                            metric,
+                            my_iid,
+                            nbr.interface_id,
+                            nbr.ident.router_id,
+                            vec![super::srmpls::build_v3_p2p_adj_sub(&adjacency_sid)],
+                        ))
+                    } else {
+                        None
+                    }
+                }
+                OspfNetworkType::Broadcast | OspfNetworkType::NBMA => {
+                    let dr_router_id = link.ident.d_router;
+                    if dr_router_id == Ipv4Addr::UNSPECIFIED {
+                        // DR election not yet settled. Fall through
+                        // to the flush path so we don't keep a stale
+                        // LSA naming a `link_id` we can no longer
+                        // resolve.
+                        None
+                    } else {
+                        // The DR's interface_id is taken from its
+                        // entry in `link.nbrs` (which carries the
+                        // peer's Hello-advertised interface ID). When
+                        // we are the DR the peer-id lookup misses;
+                        // fall back to our own interface ID, mirroring
+                        // the convention in `build_router_lsa`.
+                        let dr_peer_iid = if dr_router_id == self.router_id {
+                            my_iid
+                        } else {
+                            link.nbrs
+                                .get(&dr_router_id)
+                                .map(|n| n.interface_id)
+                                .unwrap_or(my_iid)
+                        };
+                        // `lan_adj_sids` is keyed by `(ifindex, nbr_key)`
+                        // where `nbr_key` is whatever the NFSM hook
+                        // received as its `nbr_addr` argument. For v3
+                        // that's the neighbor's router-id (same key
+                        // used to index `link.nbrs`), not the v6
+                        // interface address — RFC 5340 keys v3
+                        // neighbor state machines by router-id.
+                        let subs: Vec<_> = link
+                            .nbrs
+                            .values()
+                            .filter(|n| n.state == NfsmState::Full)
+                            .filter_map(|nbr| {
+                                let label =
+                                    *self.lan_adj_sids.get(&(ifindex, nbr.ident.router_id))?;
+                                Some(super::srmpls::build_v3_lan_adj_sub(
+                                    nbr.ident.router_id,
+                                    label,
+                                ))
+                            })
+                            .collect();
+                        if subs.is_empty() {
+                            None
+                        } else {
+                            Some((
+                                link.area,
+                                Ospfv3RouterLinkType::Transit,
+                                metric,
+                                my_iid,
+                                dr_peer_iid,
+                                dr_router_id,
+                                subs,
+                            ))
+                        }
+                    }
+                }
+            }
         } else {
             None
         };
 
-        if let Some((area_id, metric, my_iid, peer_iid, peer_rid, adjacency_sid)) = build_inputs {
+        if let Some((area_id, link_type, metric, my_iid, peer_iid, peer_rid, subs)) = build_inputs {
             let mut lsa = super::srmpls::e_router_v3_lsa_build(
                 self.router_id,
+                link_type,
                 metric,
                 my_iid,
                 peer_iid,
                 peer_rid,
-                &adjacency_sid,
+                subs,
                 link_state_id,
             );
 
@@ -3269,6 +3358,23 @@ impl Ospf<Ospfv3> {
             old_state,
             new_state
         );
+
+        // Adjacency-SID label allocation. Mirrors v2 (#850): each Full
+        // adjacency claims one label out of the SRLB on transition
+        // into Full and releases it on regression. Consumed by the
+        // LAN-Adj-SID origination path (broadcast / NBMA links).
+        // No-op when SR-MPLS is disabled (no pool present).
+        if new_state == NfsmState::Full
+            && let Some(pool) = self.local_pool.as_mut()
+            && let Some(label) = pool.allocate()
+        {
+            self.lan_adj_sids.insert((ifindex, nbr_addr), label as u32);
+        } else if old_state == NfsmState::Full
+            && let Some(label) = self.lan_adj_sids.remove(&(ifindex, nbr_addr))
+            && let Some(pool) = self.local_pool.as_mut()
+        {
+            pool.release(label as usize);
+        }
 
         self.router_lsa_originate();
         // Re-originate the Router-LSA-referenced Intra-Area-Prefix-LSA

--- a/zebra-rs/src/ospf/srmpls.rs
+++ b/zebra-rs/src/ospf/srmpls.rs
@@ -179,48 +179,34 @@ pub fn build_lan_adj_sub(neighbor_id: Ipv4Addr, label: u32) -> ExtLinkSubTlv {
 }
 
 /// Build an OSPFv3 E-Router-LSA (RFC 8362 §3.1) carrying one
-/// Router-Link TLV (P2P) whose sub-TLV is an Adj-SID (RFC 8666
-/// §6.1) for a single Full neighbor.
+/// Router-Link TLV with caller-supplied sub-TLVs.
 ///
-/// Flag semantics mirror the v2 path: Index form leaves V + L
-/// clear (the index resolves against the peer's SRGB); Absolute
-/// Label sets V + L per RFC 8666 §6.1. `link_state_id` is the
-/// caller-supplied per-LSA key (ifindex by convention).
+/// `link_type` matches the v3 Router-LSA link encoding
+/// (PointToPoint, Transit, VirtualLink). `subs` is the full sub-TLV
+/// list to embed: one `AdjSid` for P2P, or one `LanAdjSid` per Full
+/// neighbor on broadcast / NBMA per RFC 8666 §6.
+///
+/// `link_state_id` is the caller-supplied per-LSA key (ifindex by
+/// convention).
 pub fn e_router_v3_lsa_build(
     router_id: Ipv4Addr,
+    link_type: Ospfv3RouterLinkType,
     metric: u16,
     our_interface_id: u32,
     neighbor_interface_id: u32,
     neighbor_router_id: Ipv4Addr,
-    adjacency_sid: &AdjacencySid,
+    subs: Vec<Ospfv3SubTlv>,
     link_state_id: u32,
 ) -> Ospfv3Lsa {
-    let (sid, flags) = match adjacency_sid {
-        AdjacencySid::Index(idx) => (SidLabelTlv::Index(*idx), AdjSidFlags::new()),
-        AdjacencySid::Absolute(label) => (
-            SidLabelTlv::Label(*label),
-            AdjSidFlags::new().with_v_flag(true).with_l_flag(true),
-        ),
-    };
-
-    let adj_sub = Ospfv3SubTlv::AdjSid(Ospfv3AdjSidSubTlv {
-        flags,
-        weight: 0,
-        sid,
-    });
-
     let link = Ospfv3RouterLsaLink::new(
-        Ospfv3RouterLinkType::PointToPoint,
+        link_type,
         metric,
         our_interface_id,
         neighbor_interface_id,
         neighbor_router_id,
     );
 
-    let router_link_tlv = Ospfv3ExtTlv::RouterLink(Ospfv3RouterLinkTlv {
-        link,
-        subs: vec![adj_sub],
-    });
+    let router_link_tlv = Ospfv3ExtTlv::RouterLink(Ospfv3RouterLinkTlv { link, subs });
 
     let body = Ospfv3ELsaBody {
         tlvs: vec![router_link_tlv],
@@ -240,6 +226,39 @@ pub fn e_router_v3_lsa_build(
     };
     lsa.update();
     lsa
+}
+
+/// Construct an OSPFv3 `Ospfv3AdjSidSubTlv` from a configured
+/// Adjacency-SID (P2P case). Flag semantics mirror the v2 path's
+/// `build_p2p_adj_sub`: Index form leaves V + L clear; Absolute
+/// Label sets V + L per RFC 8666 §6.1.
+pub fn build_v3_p2p_adj_sub(adjacency_sid: &AdjacencySid) -> Ospfv3SubTlv {
+    let (sid, flags) = match adjacency_sid {
+        AdjacencySid::Index(idx) => (SidLabelTlv::Index(*idx), AdjSidFlags::new()),
+        AdjacencySid::Absolute(label) => (
+            SidLabelTlv::Label(*label),
+            AdjSidFlags::new().with_v_flag(true).with_l_flag(true),
+        ),
+    };
+    Ospfv3SubTlv::AdjSid(Ospfv3AdjSidSubTlv {
+        flags,
+        weight: 0,
+        sid,
+    })
+}
+
+/// Construct an OSPFv3 `Ospfv3LanAdjSidSubTlv` (RFC 8666 §6.2) for
+/// a single Full neighbor on a broadcast / NBMA segment. `label` is
+/// the absolute SRLB-allocated value held in `Ospf::lan_adj_sids`.
+/// V + L flags are set unconditionally — LAN Adj-SIDs we originate
+/// are always raw labels from the local SRLB.
+pub fn build_v3_lan_adj_sub(neighbor_router_id: Ipv4Addr, label: u32) -> Ospfv3SubTlv {
+    Ospfv3SubTlv::LanAdjSid(Ospfv3LanAdjSidSubTlv {
+        flags: AdjSidFlags::new().with_v_flag(true).with_l_flag(true),
+        weight: 0,
+        neighbor_router_id,
+        sid: SidLabelTlv::Label(label),
+    })
 }
 
 /// Build an OSPFv3 E-Intra-Area-Prefix-LSA (RFC 8362 §3.7) carrying


### PR DESCRIPTION
## Summary

Phase D PR-3c. Brings v3 SR-MPLS adjacency origination to feature parity with v2 (#851). **Closes Phase D origination work**; SPF / RIB / ILM consumption lands in PR-4.

Four pieces:

- **v3 \`process_neighbor_state_change\`** now allocates / releases SRLB labels into \`Ospf::lan_adj_sids\` on Full transitions, keyed by \`(ifindex, nbr_key)\` where \`nbr_key\` is whatever the NFSM hook received as its \`nbr_addr\` argument. For v3 that's the neighbor's router-id (same key used to index \`link.nbrs\`, per RFC 5340 §4.2.2). Mirrors v2 (#850) but using the v3 keying convention.
- **\`srmpls::e_router_v3_lsa_build\`** is generalized to take a pre-built \`Vec<Ospfv3SubTlv>\` plus \`Ospfv3RouterLinkType\`, matching the v2 \`ext_link_lsa_build\` shape. The two flag conventions move into helper constructors — \`build_v3_p2p_adj_sub\` (P2P, configured Adj-SID) and \`build_v3_lan_adj_sub\` (broadcast, allocated SRLB label with V + L set).
- **\`Ospf<Ospfv3>::e_router_v3_lsa_originate\`** now dispatches on \`link.network_type\`:
  - **P2P**: unchanged behavior, one \`AdjSid\` sub-TLV with the configured value.
  - **Broadcast / NBMA**: walks Full neighbors, looks up each \`(ifindex, router_id)\` in \`lan_adj_sids\`, builds one \`LanAdjSid\` sub-TLV per neighbor with a label allocated. Router-Link TLV uses \`Ospfv3RouterLinkType::Transit\` with the DR's router-id + interface-id as the neighbor fields, falling back to our own interface-id when we are the DR (same convention as the standard Router-LSA builder). Skips if the DR is unspecified or no Full neighbor has a label yet — fall through to flush, same as v2.
- **v3 \`Message::Ifsm\`** re-originates the E-Router-LSA on any IFSM state change so DR election outcomes refresh the LSA's \`link_id\`. **\`config_ospfv3_sr_mpls\`** now manages the label pool (create on enable, drop on disable) and sweeps current Full neighbors to allocate labels for those not yet in \`lan_adj_sids\` — needed so enabling SR-MPLS after adjacencies settle still produces the LAN Adj-SID LSAs.

## Test plan

- [x] \`cargo build\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p zebra-rs --bins\` — 614/614 passing
- [ ] Manual: three OSPFv3 routers on a broadcast segment, all SR-MPLS enabled. After DR election + Full adjacencies, each router originates an E-Router-LSA with \`link_type=Transit\` carrying one \`LanAdjSid\` per Full peer; visible via parse on the peer (PR-D4 will surface in \`show ipv6 ospf database detail\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)