### PR TITLE
ospf: advertise GR-helper bit + document v2 LSA invariant

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -477,6 +477,17 @@ impl Ospf<Ospfv2> {
         false
     }
 
+    /// Build the v2 Router-LSA body from current interface + neighbor
+    /// state.
+    ///
+    /// GR-helper invariant (RFC 3623 §3.1): adjacencies to neighbors
+    /// in helper mode must keep appearing in this LSA exactly as
+    /// they did when the link was Full. Phase 2a's
+    /// `ospf_nfsm_inactivity_timer` suppression keeps `nbr.state`
+    /// stuck at `Full` while we're helping, so the `state ==
+    /// NfsmState::Full` filters below honour the invariant
+    /// implicitly — do not switch them to a tighter "still receiving
+    /// Hellos" check without re-establishing equivalence here.
     fn router_lsa_build(&self) -> RouterLsa {
         let mut router_lsa = RouterLsa::default();
 
@@ -1173,6 +1184,19 @@ impl Ospf<Ospfv2> {
         self.router_lsa_originate_with_min_seq(Some(min_seq));
     }
 
+    /// Re-originate or flush the v2 Network-LSA for the broadcast
+    /// segment on `ifindex` (DR-only origination).
+    ///
+    /// GR-helper invariant (RFC 3623 §3.1): when we are DR and a
+    /// neighbor on this segment is in helper mode, that neighbor
+    /// must continue appearing in the `attached_routers` list, and
+    /// the segment's `full_nbr_count` must continue counting it.
+    /// Phase 2a's inactivity-timer suppression keeps `nbr.state` at
+    /// `Full` throughout helper, so the `state == Full` filter
+    /// below honours both invariants implicitly; in particular the
+    /// `full_nbr_count == 0` branch (which would flush the
+    /// Network-LSA per RFC 2328 §14.1) does not fire while a
+    /// helper-mode neighbor remains.
     fn update_network_lsa_by_interface(&mut self, ifindex: u32) {
         let (area_id, ls_id, netmask, attached_routers, full_nbr_count) = {
             let Some(link) = self.links.get_mut(&ifindex) else {

--- a/zebra-rs/src/ospf/srmpls.rs
+++ b/zebra-rs/src/ospf/srmpls.rs
@@ -24,8 +24,16 @@ pub(super) const SRLB_RANGE: u32 = 1000;
 pub fn router_info_lsa_build(router_id: Ipv4Addr) -> OspfLsa {
     let mut tlvs = Vec::new();
 
-    // Router Capabilities TLV (type 1): TE support (bit 3).
-    let caps = RouterCapability::new().with_te(true);
+    // Router Capabilities TLV (type 1, RFC 7770 §2.1):
+    //   - bit 3 (te)         — Traffic Engineering support.
+    //   - bit 4 (gr_helper)  — Graceful Restart helper-mode capable
+    //                          (RFC 3623). zebra-rs supports helper
+    //                          unconditionally today; Phase 4 will
+    //                          gate this on the YANG knob
+    //                          `graceful-restart/helper-enabled`.
+    // `gr_capable` (bit 5) stays clear — we do not yet originate
+    // Grace LSAs as a restarter (Phase 5 deferred).
+    let caps = RouterCapability::new().with_te(true).with_gr_helper(true);
     tlvs.push(RouterInfoTlv::RouterInfo(RouterInfoTlvCap { caps }));
 
     // SR Algorithm TLV (type 8): SPF (algorithm 0).
@@ -319,4 +327,33 @@ pub fn ext_intra_area_prefix_v3_lsa_build(
     };
     lsa.update();
     lsa
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// RFC 7770 §2.1 capability bits in the originated Router-Info
+    /// Opaque LSA: TE (bit 3) and GR-helper (bit 4) set;
+    /// GR-capable (bit 5) clear because zebra-rs is helper-only
+    /// (Phase 5 deferred).
+    #[test]
+    fn router_info_lsa_advertises_te_and_gr_helper() {
+        let lsa = router_info_lsa_build(Ipv4Addr::new(10, 0, 0, 1));
+        let OspfLsp::OpaqueAreaRouterInfo(ref ri) = lsa.lsp else {
+            panic!("expected OpaqueAreaRouterInfo, got {:?}", lsa.lsp);
+        };
+        let cap = ri
+            .tlvs
+            .iter()
+            .find_map(|t| match t {
+                RouterInfoTlv::RouterInfo(c) => Some(c.caps),
+                _ => None,
+            })
+            .expect("Router Capabilities TLV must be present");
+        assert!(cap.te(), "TE bit must be set");
+        assert!(cap.gr_helper(), "GR helper bit must be set");
+        assert!(!cap.gr_capable(), "GR restarter bit must remain clear");
+        assert!(!cap.stub(), "stub bit must remain clear");
+    }
 }


### PR DESCRIPTION
## Summary

Phase 2b of OSPFv2 graceful restart (helper side) — much smaller than the planned ~250 LoC because Phase 2a's inactivity-timer suppression already keeps `nbr.state` at Full while we're helping, which means the existing `state == NfsmState::Full` filters in Router-LSA / Network-LSA origination preserve the helper adjacency implicitly.

- **`router_info_lsa_build` (srmpls.rs)** now sets the RFC 7770 §2.1 `gr_helper` bit (bit 4) on the Router Capabilities TLV. The `gr_capable` (restarter) bit stays clear — zebra-rs is helper-only today; Phase 5 (restarting-router mode) is deferred.
- **Unit test** pins the bit pattern (TE + gr_helper set, gr_capable clear) so a future Router-Info builder change can't silently drop the helper bit.
- **Invariant comments** on `router_lsa_build` and `update_network_lsa_by_interface` documenting the RFC 3623 §3.1 contract: helper-mode neighbors must continue appearing in Router-LSA link records and the Network-LSA's `attached_routers` list, and the `full_nbr_count == 0` flush branch (RFC 2328 §14.1) must not fire while a helper-mode neighbor remains. Today this is satisfied by 2a's state suppression — the comments warn off any future tightening to a "still receiving Hellos" check that would break the invariant without re-establishing equivalence.

Note: the Router-Info LSA is currently only originated when SR-MPLS is enabled. Advertising the helper bit on non-SR deployments would need a separate refactor to originate Router-Info unconditionally; FRR's GR detection does not require the bit (it keys off the Grace LSA exchange) so this is not a blocker for interop testing.

## What's deferred to 2c

- Strict-LSA-checking + topology-change exit conditions (RFC 3623 §3.2 bullets 2-3).
- `show ip ospf graceful-restart` and YANG config-surface (`helper-enabled`, `max-grace-period`, `helper-strict-lsa-checking`).

## Test plan

- [x] `cargo fmt && cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --exclude bdd` — new `router_info_lsa_advertises_te_and_gr_helper` passes; zero regressions.

Generated with [Claude Code](https://claude.com/claude-code)