### PR TITLE
ospf: helper-mode topology-change exit (v2)

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1385,11 +1385,17 @@ impl Ospf<Ospfv2> {
         self.ext_link_lsa_originate(ifindex);
     }
 
-    /// Grace-period expiry handler (RFC 3623 §3.2 bullet 1). Clears
-    /// `nbr.gr_helper` and re-fires the inactivity-timer event so
-    /// the normal `ospf_nfsm_kill_nbr` path runs — by now the
-    /// neighbor really is gone.
+    /// Grace-period expiry handler (RFC 3623 §3.2 bullet 1).
     fn gr_helper_expire(&mut self, ifindex: u32, router_id: Ipv4Addr) {
+        self.gr_helper_exit(ifindex, router_id, "grace period expired");
+    }
+
+    /// Shared helper-exit path. Clears `nbr.gr_helper` and re-fires
+    /// the inactivity-timer event so the normal
+    /// `ospf_nfsm_kill_nbr` path runs — by now the neighbor really
+    /// should be gone (or about to re-adjacency-form fresh).
+    /// `reason` is a free-form string for the tracing log.
+    fn gr_helper_exit(&mut self, ifindex: u32, router_id: Ipv4Addr, reason: &str) {
         let Some(link) = self.links.get_mut(&ifindex) else {
             return;
         };
@@ -1400,15 +1406,81 @@ impl Ospf<Ospfv2> {
             return;
         }
         tracing::info!(
-            "[GR Helper] grace-period expired for nbr {} on ifindex={}, killing neighbor",
+            "[GR Helper] exit for nbr {} on ifindex={} (reason: {})",
             router_id,
-            ifindex
+            ifindex,
+            reason
         );
         let _ = self.tx.send(Message::Nfsm(
             ifindex,
             router_id,
             super::nfsm::NfsmEvent::InactivityTimer,
         ));
+    }
+
+    /// RFC 3623 §3.2 bullets 2-3 — topology-change exit. Called
+    /// from `flood_lsa_through_area` after `ospf_flood` has just
+    /// installed `lsa` into the area LSDB. For every helper-mode
+    /// neighbor in this area, decide whether the install warrants
+    /// exit:
+    ///
+    ///   - If `lsa.adv_router != restarter`: any topology-affecting
+    ///     LSA represents a change to the area outside the
+    ///     restarter, so exit.
+    ///   - If `lsa.adv_router == restarter`: compare against the
+    ///     `(seq, checksum)` we snapshotted at helper entry. Exact
+    ///     match → quiescent re-flood (no exit). Differs → the
+    ///     restarter's content / sequence changed (restart finished
+    ///     or content drifted), so exit.
+    ///
+    /// Non-topology-affecting LSAs (Opaque, AS-External, Link-LSA)
+    /// are ignored — they don't change intra-area routing.
+    fn gr_helper_check_exit(&mut self, area_id: Ipv4Addr, lsa: &OspfLsa) {
+        let topology_affecting = matches!(
+            lsa.h.ls_type,
+            OspfLsType::Router
+                | OspfLsType::Network
+                | OspfLsType::Summary
+                | OspfLsType::SummaryAsbr
+        );
+        if !topology_affecting {
+            return;
+        }
+        let key = super::lsdb::v2_lsa_key(lsa.h.ls_type, lsa.h.ls_id, lsa.h.adv_router);
+
+        let Some(area) = self.areas.get(area_id) else {
+            return;
+        };
+        let link_indices: Vec<u32> = area.links.iter().copied().collect();
+
+        let mut exits: Vec<(u32, Ipv4Addr, &'static str)> = Vec::new();
+        for ifindex in link_indices {
+            let Some(link) = self.links.get(&ifindex) else {
+                continue;
+            };
+            for (_nbr_addr, nbr) in link.nbrs.iter() {
+                let Some(helper) = nbr.gr_helper.as_ref() else {
+                    continue;
+                };
+                let exit_reason = if lsa.h.adv_router == nbr.ident.router_id {
+                    match helper.lsdb_snapshot.get(&key) {
+                        Some(&(seq, csum))
+                            if seq == lsa.h.ls_seq_number && csum == lsa.h.ls_checksum =>
+                        {
+                            // Identical re-flood — quiescent.
+                            continue;
+                        }
+                        _ => "restarter LSA changed from snapshot",
+                    }
+                } else {
+                    "non-restarter topology change in area"
+                };
+                exits.push((ifindex, nbr.ident.router_id, exit_reason));
+            }
+        }
+        for (ifindex, router_id, reason) in exits {
+            self.gr_helper_exit(ifindex, router_id, reason);
+        }
     }
 
     /// Check if we are currently the DR for the network identified by ls_id.
@@ -1437,6 +1509,13 @@ impl Ospf<Ospfv2> {
         lsa: &OspfLsa,
         source: Option<(u32, Ipv4Addr)>,
     ) {
+        // RFC 3623 §3.2 bullets 2-3 — every LSA that reaches the
+        // flood-out path was just installed in the area LSDB, so
+        // this is the choke point for the topology-change exit
+        // check. Runs before the fanout iteration so a helper exit
+        // can deconstruct any state we'd otherwise loop over.
+        self.gr_helper_check_exit(area_id, lsa);
+
         let Some(area) = self.areas.get(area_id) else {
             return;
         };

--- a/zebra-rs/src/ospf/neigh.rs
+++ b/zebra-rs/src/ospf/neigh.rs
@@ -18,24 +18,48 @@ use super::{Identity, Message, NfsmEvent, NfsmState};
 /// (`ospf_nfsm_inactivity_timer` rearms instead of killing) so the
 /// neighbor's adjacency stays Full across the restart window.
 ///
-/// Phase 2a wires entry, suppression, and grace-period-expiry exit.
-/// `reason` / `grace_period` / `entered_at` are populated here but
-/// only consumed in 2b (Router-LSA preservation) and 2c (show +
-/// strict LSDB-consistency check); the `dead_code` allow on the
-/// struct documents that.
-#[allow(dead_code)]
+/// Exit paths (RFC 3623 §3.2):
+///   - Grace-period expiry (Phase 2a — `expire_timer` fires
+///     `Message::GrHelperExpire`).
+///   - Topology change (Phase 2c-i — `gr_helper_check_exit` runs
+///     on every LSA flooded through the area; see `lsdb_snapshot`).
+///
+/// `reason`, `grace_period`, `entered_at` are populated for the
+/// show output (Phase 2c-ii) but not yet read in code, hence the
+/// field-level `dead_code` allows. `expire_timer` holds the
+/// drop-handle for the grace-period timer; Tokio's runtime is the
+/// only consumer.
 #[derive(Debug)]
 pub struct HelperState {
     /// Restart reason carried in the Grace LSA's type-2 sub-TLV.
+    #[allow(dead_code)]
     pub reason: ospf_packet::GraceRestartReason,
     /// Grace period (seconds) the restarter requested.
+    #[allow(dead_code)]
     pub grace_period: u32,
     /// When we entered helper mode.
+    #[allow(dead_code)]
     pub entered_at: Instant,
     /// Pending grace-period-expiry timer. Dropping clears it; we
     /// keep an explicit handle so re-entry (extended grace period)
     /// cancels the prior expiry cleanly.
+    #[allow(dead_code)]
     pub expire_timer: Option<Timer>,
+    /// RFC 3623 §3.2 pre-restart LSDB snapshot — for every LSA in
+    /// the helper's area whose `adv_router` is the restarting
+    /// router, we record the `(ls_seq_number, ls_checksum)` tuple
+    /// observed at the moment we entered helper. On each new LSA
+    /// install (via `flood_lsa_through_area`) we compare:
+    ///
+    ///   - A topology-affecting LSA from the restarter whose
+    ///     tuple differs from the snapshot → exit helper.
+    ///   - A topology-affecting LSA from any non-restarter →
+    ///     exit helper (some other router's adjacency / prefix
+    ///     changed in the area).
+    ///
+    /// Non-topology-affecting LSAs (Opaque, AS-External, etc.) are
+    /// ignored.
+    pub lsdb_snapshot: BTreeMap<OspfLsaKey, (u32, u16)>,
 }
 
 /// Per-neighbor protocol state.

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -899,6 +899,8 @@ pub fn ospf_ls_upd_validate_proc(
 /// must be within [1, `MAX_GRACE_PERIOD_SECS`]. Strict-LSA-checking
 /// (RFC 3623 §3.2 bullets 2-3 / LSDB snapshot) lands in Phase 2c.
 fn gr_maybe_enter_helper(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) {
+    use std::collections::BTreeMap;
+
     use super::neigh::HelperState;
     use super::task::{Timer, TimerType};
 
@@ -954,12 +956,25 @@ fn gr_maybe_enter_helper(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfL
         },
     );
 
+    // RFC 3623 §3.2 — snapshot the restarter's LSAs in the area
+    // LSDB at the moment we enter helper. `gr_helper_check_exit`
+    // diffs newly-installed LSAs against these (seq, checksum)
+    // tuples to distinguish quiescent self-refresh from a real
+    // post-restart re-origination.
+    let mut lsdb_snapshot = BTreeMap::new();
+    for (key, lsa) in oi.lsdb.tables.iter() {
+        if lsa.data.h.adv_router == router_id {
+            lsdb_snapshot.insert(*key, (lsa.data.h.ls_seq_number, lsa.data.h.ls_checksum));
+        }
+    }
+
     let previously_helping = nbr.gr_helper.is_some();
     nbr.gr_helper = Some(HelperState {
         reason,
         grace_period,
         entered_at: tokio::time::Instant::now(),
         expire_timer: Some(expire_timer),
+        lsdb_snapshot,
     });
     tracing::info!(
         "[GR Helper] {} for nbr {} on ifindex={} (grace={}s, reason={:?})",


### PR DESCRIPTION
## Summary

Phase 2c-i of OSPFv2 graceful restart (helper side). Implements RFC 3623 §3.2 bullets 2-3 — the topology-change exit conditions that bound helper duration to actual quiescence.

- **`HelperState.lsdb_snapshot`** records `(ls_seq_number, ls_checksum)` per LSA key from the restarter's pre-restart LSDB contents, captured at helper entry by iterating `oi.lsdb.tables` filtered by `adv_router == restarter`.
- **`gr_helper_check_exit`** runs at the top of `flood_lsa_through_area` — the choke point every newly-installed area-scope LSA passes through. For each helper in the area:
  - `lsa.adv_router != restarter` → exit if the LSA is topology-affecting (Router/Network/Summary/SummaryAsbr).
  - `lsa.adv_router == restarter` → compare against snapshot. Identical `(seq, checksum)` is a quiescent re-flood (no exit). Differs → exit (restart completed or content drifted).
  - Non-topology-affecting LSAs (Opaque, AS-External, Link-LSA) are ignored — they don't change intra-area routing.
- **`gr_helper_exit(reason)`** factored out of the existing `gr_helper_expire` path so the topology-change branch emits a uniform trace line.

## Test plan

- [x] `cargo fmt && cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --exclude bdd` — zero regressions.
- [ ] Real FRR-peer test of the topology-change exit (e.g. force another router on the segment to flap its Router-LSA while a helper is active) — deferred to manual validation once 2c-ii lands `show ip ospf graceful-restart` so the exit decision is inspectable.

## What's deferred to 2c-ii

- `show ip ospf graceful-restart` (per-nbr table + exit-reason history).
- YANG config-surface (`helper-enabled`, `max-grace-period`, `helper-strict-lsa-checking`) and wiring into the validator.

Generated with [Claude Code](https://claude.com/claude-code)