### PR TITLE
ospf: per-interface MD5 cryptographic authentication (RFC 2328 §D.4)

### DIFF
--- a/crates/ospf-packet/src/parser.rs
+++ b/crates/ospf-packet/src/parser.rs
@@ -37,6 +37,13 @@ pub struct Ospfv2Packet {
     /// `parse()` when `auth_type == 2`; empty otherwise.
     #[nom(Ignore)]
     pub auth_trailer: Vec<u8>,
+    /// On-wire bytes covered by the cryptographic-auth digest:
+    /// header (with the Crypto auth overlay) + body, i.e.
+    /// `input[..pkt_len]`. Populated by `parse()` for every packet
+    /// so receive-side verification can re-hash exactly what the
+    /// sender hashed. Empty for packets built via `new()`.
+    #[nom(Ignore)]
+    pub raw_body: Vec<u8>,
 }
 
 impl Ospfv2Packet {
@@ -52,6 +59,7 @@ impl Ospfv2Packet {
             auth: Ospfv2Auth::default(),
             payload,
             auth_trailer: Vec::new(),
+            raw_body: Vec::new(),
         }
     }
 
@@ -2155,6 +2163,10 @@ pub fn parse(input: &[u8]) -> IResult<&[u8], Ospfv2Packet> {
         return Err(Err::Error(make_error(input, ErrorKind::Verify)));
     }
     let (_, mut packet) = Ospfv2Packet::parse_be(&input[..pkt_len])?;
+    // Cache the on-wire bytes covered by the cryptographic-auth
+    // digest — receive-side verification recomputes MD5 over this
+    // exact slice + the padded key (RFC 2328 §D.4.3).
+    packet.raw_body = input[..pkt_len].to_vec();
 
     // RFC 2328 §D.4: a cryptographic-auth (type 2) packet carries
     // the digest as a trailer after the OSPF body; `auth_data_len`
@@ -2250,6 +2262,9 @@ mod tests {
             other => panic!("expected Crypto, got {:?}", other),
         }
         assert_eq!(parsed.auth_trailer, vec![0xAB; 16]);
+        // raw_body must hold the bytes that were hashed (header +
+        // body, no trailer) so verifiers can recompute the digest.
+        assert_eq!(parsed.raw_body, buf[..hdr_len].to_vec());
     }
 
     #[test]

--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -65,6 +65,7 @@ num_enum = "0.7.5"
 nanomsg = "0.7.2"
 itertools = "0.14.0"
 dashmap = "6"
+md-5 = "0.10"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = { git = "https://github.com/zebra-rs/rtnetlink", rev = "2d7b1830e9bd9a049a757f0a79ccd16216450bf2" }

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -75,6 +75,10 @@ impl Ospf {
             config_ospf_interface_authentication_key,
         );
         self.ospf_add(
+            "/area/interface/message-digest-key/md5",
+            config_ospf_interface_md5_key,
+        );
+        self.ospf_add(
             "/area/interface/prefix-sid/index",
             config_ospf_interface_prefix_sid_index,
         );
@@ -447,6 +451,7 @@ fn config_ospf_interface_authentication(
         link.config.auth_mode = Some(match mode.as_str() {
             "null" => OspfAuthMode::Null,
             "simple" => OspfAuthMode::Simple,
+            "message-digest" => OspfAuthMode::MessageDigest,
             _ => return None,
         });
     } else {
@@ -479,6 +484,34 @@ fn config_ospf_interface_authentication_key(
         link.config.auth_key = Some(padded);
     } else {
         link.config.auth_key = None;
+    }
+
+    Some(())
+}
+
+fn config_ospf_interface_md5_key(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let key_id: u8 = args.string()?.parse().ok()?;
+    if key_id == 0 {
+        return None;
+    }
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        let key = args.string()?;
+        let bytes = key.as_bytes();
+        // RFC 2328 §D.4 caps the simple MD5 key at 16 octets (the
+        // block size for the `MD5(packet || key)` construction).
+        // YANG also enforces `length 1..16`.
+        if bytes.is_empty() || bytes.len() > 16 {
+            return None;
+        }
+        let mut padded = [0u8; 16];
+        padded[..bytes.len()].copy_from_slice(bytes);
+        link.config.md5_keys.insert(key_id, padded);
+    } else {
+        link.config.md5_keys.remove(&key_id);
     }
 
     Some(())

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -17,7 +17,8 @@ use crate::config::{DisplayRequest, ShowChannel};
 use crate::ospf::Ospfv2;
 use crate::ospf::addr::OspfAddr;
 use crate::ospf::packet::{
-    apply_link_auth, ospf_db_desc_recv, ospf_hello_recv, ospf_hello_send, verify_link_auth,
+    apply_link_auth, build_auth_ctx, ospf_db_desc_recv, ospf_hello_recv, ospf_hello_send,
+    record_md5_seq, verify_link_auth,
 };
 use crate::rib::api::RibRx;
 use crate::rib::inst::{IlmEntry, IlmType};
@@ -162,6 +163,15 @@ pub struct OspfInterface<'a, V: OspfVersion = Ospfv2> {
     /// Snapshot of the configured simple-password key, if any.
     /// Only consulted when `auth_mode == Simple`.
     pub auth_key: Option<[u8; 8]>,
+    /// Snapshot of the active MD5 send key (lowest configured
+    /// key-id). `None` when `MessageDigest` is configured but no
+    /// key has been added yet.
+    pub md5_key: Option<(u8, [u8; 16])>,
+    /// Borrow of the parent link's cryptographic-auth send
+    /// counter. `AtomicU32` allows mutation through an `&` borrow
+    /// so every send path can `fetch_add(1)` without taking `&mut`
+    /// on the surrounding `OspfLink`.
+    pub md5_seq: &'a std::sync::atomic::AtomicU32,
     pub tracing: &'a OspfTracing,
     /// v3-only outbound packet channel borrow. Carries the `Ospfv3Send`
     /// sender that the `network_v6::write_packet_v6` task consumes.
@@ -174,6 +184,23 @@ pub struct OspfInterface<'a, V: OspfVersion = Ospfv2> {
     /// borrowed from `OspfLink::lsdb`; on v2 it's empty (no
     /// link-scope LSA types in RFC 2328).
     pub link_lsdb: &'a mut Lsdb<V>,
+}
+
+impl<'a, V: OspfVersion> OspfInterface<'a, V> {
+    /// Bundle the auth state needed to stamp one outbound packet.
+    /// Bumps the borrowed cryptographic-auth seq as a side effect
+    /// — mirrors `OspfLink::auth_send_ctx`.
+    pub fn auth_send_ctx(&self) -> crate::ospf::packet::AuthSendCtx {
+        let s = self
+            .md5_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        crate::ospf::packet::AuthSendCtx {
+            mode: self.auth_mode,
+            simple_key: self.auth_key,
+            md5_key: self.md5_key,
+            md5_seq: s,
+        }
+    }
 }
 
 // Version-agnostic helpers. These methods touch only generic-safe
@@ -195,6 +222,7 @@ impl<V: OspfVersion> Ospf<V> {
             let retransmit_interval = link.retransmit_interval();
             let auth_mode = link.auth_mode();
             let auth_key = link.config.auth_key;
+            let md5_key = link.active_md5_key();
             self.areas.get_mut(link_area).and_then(|area| {
                 let area_type = area.area_type;
                 link.nbrs.get_mut(src).map(|nbr| {
@@ -216,6 +244,8 @@ impl<V: OspfVersion> Ospf<V> {
                             network_type: link.network_type,
                             auth_mode,
                             auth_key,
+                            md5_key,
+                            md5_seq: &link.md5_seq,
                             tracing: &self.tracing,
                             v3_send_tx: self.v3_send_tx.as_ref(),
                             link_lsdb: &mut link.lsdb,
@@ -1528,6 +1558,8 @@ impl Ospf<Ospfv2> {
             let link_state = link.state;
             let auth_mode = link.auth_mode();
             let auth_key = link.config.auth_key;
+            let md5_key = link.active_md5_key();
+            let md5_seq_cell = &link.md5_seq;
 
             // RFC 2328 Section 13.3 Step 2-4: DR/BDR flooding decision.
             let is_source_iface = source.is_some_and(|(src_if, _)| src_if == ifindex);
@@ -1583,7 +1615,10 @@ impl Ospf<Ospfv2> {
                 };
                 let mut packet =
                     Ospfv2Packet::new(&self.router_id, &area_id, Ospfv2Payload::LsUpdate(ls_upd));
-                apply_link_auth(&mut packet, auth_mode, auth_key);
+                apply_link_auth(
+                    &mut packet,
+                    &build_auth_ctx(auth_mode, auth_key, md5_key, md5_seq_cell),
+                );
                 tracing::info!(
                     "[Flood] Sending LSA type={:?} id={} adv={} to nbr={}",
                     lsa.h.ls_type,
@@ -1630,6 +1665,8 @@ impl Ospf<Ospfv2> {
         let area_id = link.area;
         let auth_mode = link.auth_mode();
         let auth_key = link.config.auth_key;
+        let md5_key = link.active_md5_key();
+        let md5_seq_cell = &link.md5_seq;
         let Some(nbr) = link.nbrs.get_mut(&addr) else {
             return;
         };
@@ -1645,7 +1682,10 @@ impl Ospf<Ospfv2> {
         };
         let mut packet =
             Ospfv2Packet::new(&self.router_id, &area_id, Ospfv2Payload::LsUpdate(ls_upd));
-        apply_link_auth(&mut packet, auth_mode, auth_key);
+        apply_link_auth(
+            &mut packet,
+            &build_auth_ctx(auth_mode, auth_key, md5_key, md5_seq_cell),
+        );
         let _ = nbr.ptx.send(Message::Send(
             packet,
             nbr.ifindex,
@@ -1681,7 +1721,7 @@ impl Ospf<Ospfv2> {
             &link.area_id,
             Ospfv2Payload::DbDesc(sent.clone()),
         );
-        apply_link_auth(&mut packet, link.auth_mode, link.auth_key);
+        apply_link_auth(&mut packet, &link.auth_send_ctx());
         tracing::info!("[DB Desc:Retransmit] to {} seq={:#x}", addr, sent.seqnum);
         let _ = nbr.ptx.send(Message::Send(
             packet,
@@ -1728,7 +1768,7 @@ impl Ospf<Ospfv2> {
         };
         let mut packet =
             Ospfv2Packet::new(&self.router_id, &link.area, Ospfv2Payload::LsAck(ls_ack));
-        apply_link_auth(&mut packet, link.auth_mode(), link.config.auth_key);
+        apply_link_auth(&mut packet, &link.auth_send_ctx());
         // Send to AllSPFRouters multicast.
         let _ = link.ptx.send(Message::Send(packet, ifindex, None));
     }
@@ -1804,14 +1844,25 @@ impl Ospf<Ospfv2> {
         }
 
         // RFC 2328 §D.4: AuType + auth field must match the
-        // receiving interface's configured authentication. Snapshot
-        // the link's auth state in a short borrow scope so the
-        // per-type `links.get_mut` lookups below can proceed.
+        // receiving interface's configured authentication. RFC §D.5
+        // adds anti-replay for Type 2 — packets with a seq below
+        // the per-neighbor high-watermark are dropped.
         {
             let Some(link) = self.links.get(&index) else {
                 return;
             };
-            if !verify_link_auth(&packet, link.auth_mode(), link.config.auth_key) {
+            let last_seq = link
+                .nbrs
+                .get(&src)
+                .map(|n| n.auth_md5_last_seq)
+                .unwrap_or(0);
+            if !verify_link_auth(
+                &packet,
+                link.auth_mode(),
+                link.config.auth_key,
+                &link.config.md5_keys,
+                last_seq,
+            ) {
                 tracing::debug!(
                     "OSPFv2 auth drop on {} from {}: type={} expected={:?}",
                     link.name,
@@ -1829,29 +1880,39 @@ impl Ospf<Ospfv2> {
                     return;
                 };
                 ospf_hello_recv(&self.router_id, link, &packet, &src, &self.tracing);
+                // Hello creates the neighbor on first sight; stamp
+                // the accepted seq after the create so subsequent
+                // packets from this peer enforce monotonicity.
+                if let Some(nbr) = link.nbrs.get_mut(&src) {
+                    record_md5_seq(&packet, nbr);
+                }
             }
             OspfType::DbDesc => {
                 let Some((mut link, nbr)) = self.ospf_interface(index, &src) else {
                     return;
                 };
+                record_md5_seq(&packet, nbr);
                 ospf_db_desc_recv(&mut link, nbr, &packet, &src);
             }
             OspfType::LsRequest => {
                 let Some((mut link, nbr)) = self.ospf_interface(index, &src) else {
                     return;
                 };
+                record_md5_seq(&packet, nbr);
                 ospf_ls_req_recv(&mut link, nbr, &packet, &src);
             }
             OspfType::LsUpdate => {
                 let Some((mut link, nbr)) = self.ospf_interface(index, &src) else {
                     return;
                 };
+                record_md5_seq(&packet, nbr);
                 ospf_ls_upd_recv(&mut link, nbr, &packet, &src);
             }
             OspfType::LsAck => {
                 let Some((mut link, nbr)) = self.ospf_interface(index, &src) else {
                     return;
                 };
+                record_md5_seq(&packet, nbr);
                 ospf_ls_ack_recv(&mut link, nbr, &packet, &src);
             }
             OspfType::Unknown(_typ) => {

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -78,18 +78,22 @@ pub struct LinkConfig {
     pub network_type: Option<OspfNetworkType>,
     /// RFC 2328 §D authentication mode. `None` = inherit (Null
     /// today, until area/instance defaults land); `Some(Null)` is
-    /// an explicit override. Cryptographic auth (Type 2) lands in
-    /// a later phase under the IETF `interface/authentication`
-    /// container.
+    /// an explicit override.
     pub auth_mode: Option<OspfAuthMode>,
     /// Simple-password key, already zero-padded to the 8-octet
     /// on-wire field. Only consulted when `auth_mode == Simple`.
     pub auth_key: Option<[u8; 8]>,
+    /// MD5 cryptographic-auth keys keyed by key-id (RFC 2328
+    /// §D.4). Each value is the 1..16-octet ASCII key
+    /// zero-padded to 16 bytes — the on-wire format expected by
+    /// the digest computation. Only consulted when
+    /// `auth_mode == MessageDigest`.
+    pub md5_keys: BTreeMap<u8, [u8; 16]>,
 }
 
-/// OSPFv2 per-interface authentication mode covered by this phase.
-/// Cryptographic auth (Type 2, RFC 2328 §D.4 / RFC 5709) will
-/// appear as an additional variant in a follow-up phase.
+/// OSPFv2 per-interface authentication mode.
+/// RFC 5709 HMAC-SHA modes will appear as additional variants in a
+/// follow-up phase.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OspfAuthMode {
     /// RFC 2328 §D.2 — AuType 0, header auth field ignored.
@@ -97,6 +101,10 @@ pub enum OspfAuthMode {
     /// RFC 2328 §D.3 — AuType 1, header auth field carries the
     /// plain key zero-padded to 8 bytes.
     Simple,
+    /// RFC 2328 §D.4 — AuType 2, header overlay carries (key-id,
+    /// digest-length, seq) and the body is followed by a 16-byte
+    /// MD5 trailer.
+    MessageDigest,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -174,6 +182,17 @@ pub struct OspfLink<V: OspfVersion = Ospfv2> {
     pub full_nbr_count: usize,
     pub ptx: UnboundedSender<Message<V>>,
     pub config: LinkConfig,
+    /// Outbound RFC 2328 §D.4 cryptographic-auth sequence number.
+    /// Monotonically increasing per interface across the link's
+    /// lifetime; initialized to wall-clock seconds at link create
+    /// so a daemon restart still produces a strictly larger value
+    /// than the previous instance was using (RFC §D.4.3). Atomic
+    /// so `&OspfLink` send paths can `fetch_add(1)` without an
+    /// `&mut` borrow that would conflict with the surrounding
+    /// `link.nbrs.iter_mut()` flood loops, while staying `Sync`
+    /// (the show-info path borrows the parent `Ospf<V>` across
+    /// `.await`).
+    pub md5_seq: std::sync::atomic::AtomicU32,
     pub ls_ack_delayed: Vec<V::LsaHeader>,
     /// 32-bit Interface ID advertised in v3 Hellos and Router-LSA
     /// links (RFC 5340 §A.3.2 / §A.4.3). Unused by v2 (where the
@@ -235,6 +254,15 @@ where
             full_nbr_count: 0,
             ptx,
             config: LinkConfig::default(),
+            // RFC 2328 §D.4.3: seed the cryptographic-auth seq with
+            // wall-clock seconds so a daemon restart still produces
+            // a strictly larger value than the previous instance.
+            md5_seq: std::sync::atomic::AtomicU32::new(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs() as u32)
+                    .unwrap_or(0),
+            ),
             ls_ack_delayed: Vec::new(),
             interface_id: link.index,
             lsdb: super::lsdb::Lsdb::new(),
@@ -303,6 +331,35 @@ impl<V: OspfVersion> OspfLink<V> {
     /// to Null when no mode is configured — RFC 2328 §D.2.
     pub fn auth_mode(&self) -> OspfAuthMode {
         self.config.auth_mode.unwrap_or(OspfAuthMode::Null)
+    }
+
+    /// Return the active MD5 send key (lowest configured key-id)
+    /// alongside its key-id, or `None` if no keys are configured.
+    /// Key rollover (per-key send/accept lifetimes) lives in the
+    /// Phase 4 key-chain plumbing.
+    pub fn active_md5_key(&self) -> Option<(u8, [u8; 16])> {
+        self.config.md5_keys.iter().next().map(|(&id, &k)| (id, k))
+    }
+
+    /// Read and increment the per-interface cryptographic-auth
+    /// sequence number. Each outbound MD5 packet consumes one
+    /// value; wrap is u32 (the on-wire field width) so the
+    /// counter is allowed to roll over after ~136 years.
+    pub fn next_md5_seq(&self) -> u32 {
+        self.md5_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Bundle the auth state needed to stamp one outbound packet.
+    /// Bumps the cryptographic-auth seq as a side effect — call
+    /// once per packet, not once per buffer reuse.
+    pub fn auth_send_ctx(&self) -> super::packet::AuthSendCtx {
+        super::packet::AuthSendCtx {
+            mode: self.auth_mode(),
+            simple_key: self.config.auth_key,
+            md5_key: self.active_md5_key(),
+            md5_seq: self.next_md5_seq(),
+        }
     }
 }
 

--- a/zebra-rs/src/ospf/neigh.rs
+++ b/zebra-rs/src/ospf/neigh.rs
@@ -116,6 +116,11 @@ pub struct Neighbor<V: OspfVersion = Ospfv2> {
     /// Graceful-restart helper state. `Some` while we are helping
     /// this neighbor restart; `None` otherwise. See [`HelperState`].
     pub gr_helper: Option<HelperState>,
+    /// RFC 2328 §D.5 anti-replay state: highest cryptographic-auth
+    /// sequence number we've accepted from this neighbor. Inbound
+    /// packets must carry a seq ≥ this value; smaller values are
+    /// dropped as replays. Reset to 0 when the neighbor is created.
+    pub auth_md5_last_seq: u32,
 }
 
 #[bitfield(u8, debug = true)]
@@ -206,6 +211,7 @@ where
             last_regressive_reason: None,
             interface_id: 0,
             gr_helper: None,
+            auth_md5_last_seq: 0,
         };
         nbr.ident.prefix = prefix;
         nbr

--- a/zebra-rs/src/ospf/network.rs
+++ b/zebra-rs/src/ospf/network.rs
@@ -51,8 +51,21 @@ pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message
                 // RFC 2328: Header verification.
 
                 // RFC 2328: Authentication and checksum verification.
+                // For Type 2 (cryptographic) packets the on-wire
+                // form is (header + body) followed by a digest
+                // trailer; the OSPF header `len` field excludes the
+                // trailer. Slice to that length before checksumming
+                // — otherwise trailer bytes would corrupt the
+                // 1's-complement sum on any Type 2 ingress.
                 let ospf_input = &input[IPV4_HEADER_LEN..];
-                if ospf_packet::validate_checksum(ospf_input).is_err() {
+                if ospf_input.len() < 4 {
+                    return Err(ErrorKind::UnexpectedEof.into());
+                }
+                let pkt_len = u16::from_be_bytes([ospf_input[2], ospf_input[3]]) as usize;
+                if pkt_len < 24 || ospf_input.len() < pkt_len {
+                    return Err(ErrorKind::InvalidData.into());
+                }
+                if ospf_packet::validate_checksum(&ospf_input[..pkt_len]).is_err() {
                     return Err(ErrorKind::InvalidData.into());
                 }
 

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -27,48 +27,168 @@ use super::{
 /// this as a per-instance config knob.
 const MAX_GRACE_PERIOD_SECS: u32 = 1800;
 
+/// Resolved authentication state for a single outbound packet.
+/// Built by `OspfLink::auth_send_ctx()` and
+/// `OspfInterface::auth_send_ctx()` — both pre-bump the link's
+/// cryptographic-auth seq when applicable so the caller doesn't
+/// need a `&mut` on the link.
+pub(crate) struct AuthSendCtx {
+    pub mode: OspfAuthMode,
+    /// Simple-password key, zero-padded to 8 bytes.
+    pub simple_key: Option<[u8; 8]>,
+    /// Active MD5 send key as `(key-id, padded-key)`.
+    pub md5_key: Option<(u8, [u8; 16])>,
+    /// Cryptographic-auth sequence number to stamp into the
+    /// outbound packet. Already drawn from the link's counter.
+    pub md5_seq: u32,
+}
+
+/// Build an `AuthSendCtx` from already-snapshotted fields and a
+/// borrow of the seq atomic. Used by flood loops where calling
+/// `OspfLink::auth_send_ctx()` would conflict with the
+/// `nbrs.iter_mut()` borrow held over the loop body — the
+/// snapshot grabs `mode`/`simple_key`/`md5_key` once before the
+/// loop and the atomic lets us bump the seq per packet without
+/// ever reborrowing `link` for a method call.
+pub(super) fn build_auth_ctx(
+    mode: OspfAuthMode,
+    simple_key: Option<[u8; 8]>,
+    md5_key: Option<(u8, [u8; 16])>,
+    seq: &std::sync::atomic::AtomicU32,
+) -> AuthSendCtx {
+    AuthSendCtx {
+        mode,
+        simple_key,
+        md5_key,
+        md5_seq: seq.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+    }
+}
+
 /// Stamp the configured authentication state into an outgoing
-/// OSPFv2 packet. `mode` and `key` come from the sending
-/// interface; callers thread them in via `OspfLink::auth_mode()` /
-/// `OspfInterface::auth_mode`. Called by every
-/// `Ospfv2Packet::new(...)` site so emit produces the right
-/// `auth_type` / `auth` shape.
-pub(super) fn apply_link_auth(packet: &mut Ospfv2Packet, mode: OspfAuthMode, key: Option<[u8; 8]>) {
-    match mode {
+/// OSPFv2 packet. For MessageDigest, also computes and appends
+/// the 16-byte MD5 trailer per RFC 2328 §D.4.3 (the digest
+/// covers the entire header+body with the key zero-padded to 16
+/// bytes appended in the hash, but those padded bytes are not
+/// transmitted on the wire).
+pub(super) fn apply_link_auth(packet: &mut Ospfv2Packet, ctx: &AuthSendCtx) {
+    use bytes::BytesMut;
+    use md5::{Digest, Md5};
+    use ospf_packet::Ospfv2AuthCrypto;
+
+    match ctx.mode {
         OspfAuthMode::Null => {
             packet.auth_type = 0;
             packet.auth = Ospfv2Auth::Null([0; 8]);
+            packet.auth_trailer.clear();
         }
         OspfAuthMode::Simple => {
             packet.auth_type = 1;
-            packet.auth = Ospfv2Auth::Simple(key.unwrap_or([0; 8]));
+            packet.auth = Ospfv2Auth::Simple(ctx.simple_key.unwrap_or([0; 8]));
+            packet.auth_trailer.clear();
+        }
+        OspfAuthMode::MessageDigest => {
+            let (key_id, padded_key) = ctx.md5_key.unwrap_or((0, [0; 16]));
+            // Stamp the crypto header overlay (RFC 2328 §D.3).
+            packet.auth_type = 2;
+            packet.auth = Ospfv2Auth::Crypto(Ospfv2AuthCrypto {
+                key_id,
+                auth_data_len: 16,
+                seq: ctx.md5_seq,
+            });
+            // Scratch-emit the body so we can hash (body + key).
+            // The real serialization at network::write_packet does
+            // a second emit of the same bytes, plus the trailer.
+            packet.auth_trailer.clear();
+            let mut scratch = BytesMut::new();
+            packet.emit(&mut scratch);
+            // RFC 2328 §D.4.3: MD5( OSPF packet || key padded to 16 ).
+            let mut h = Md5::new();
+            h.update(&scratch);
+            h.update(padded_key);
+            let digest = h.finalize();
+            packet.auth_trailer = digest.as_slice().to_vec();
         }
     }
 }
 
 /// Validate an inbound OSPFv2 packet against the receiving
-/// interface's configured authentication. RFC 2328 §D.4 requires
-/// AuType to match and, for Type 1, the simple-password to be
-/// identical. Returns `true` when the packet is acceptable; on
-/// `false` the caller drops it.
+/// interface's configured authentication. Returns `true` when
+/// the packet is acceptable. The caller must update the per-
+/// neighbor `auth_md5_last_seq` via `record_md5_seq()` afterward
+/// to enforce replay protection (RFC 2328 §D.5).
 pub(super) fn verify_link_auth(
     packet: &Ospfv2Packet,
     mode: OspfAuthMode,
-    key: Option<[u8; 8]>,
+    simple_key: Option<[u8; 8]>,
+    md5_keys: &std::collections::BTreeMap<u8, [u8; 16]>,
+    nbr_last_seq: u32,
 ) -> bool {
+    use md5::{Digest, Md5};
+
     match mode {
         OspfAuthMode::Null => packet.auth_type == 0,
         OspfAuthMode::Simple => match (&packet.auth_type, &packet.auth) {
             (1, Ospfv2Auth::Simple(rx)) => {
-                let expected = key.unwrap_or([0; 8]);
-                // Plain key bytes — constant-time compare is overkill
-                // for a password that already authenticates only the
-                // outer SYN-equivalent; FRR / IOS use plain compare.
+                let expected = simple_key.unwrap_or([0; 8]);
                 rx == &expected
             }
             _ => false,
         },
+        OspfAuthMode::MessageDigest => {
+            let crypto = match (&packet.auth_type, &packet.auth) {
+                (2, Ospfv2Auth::Crypto(c)) => c,
+                _ => return false,
+            };
+            // RFC 2328 §D.5 replay protection — sequence number
+            // must be ≥ the highest we've already accepted. `>=`
+            // is what FRR uses (allows duplicate-ack via
+            // resends); strict `>` would also be defensible.
+            if crypto.seq < nbr_last_seq {
+                return false;
+            }
+            // Look up the key by id; reject if the sender used
+            // a key we don't know.
+            let Some(padded_key) = md5_keys.get(&crypto.key_id) else {
+                return false;
+            };
+            // Length must match what we expect for MD5.
+            if crypto.auth_data_len != 16 || packet.auth_trailer.len() != 16 {
+                return false;
+            }
+            // Recompute the digest over raw_body (the bytes the
+            // sender hashed) plus the padded key.
+            let mut h = Md5::new();
+            h.update(&packet.raw_body);
+            h.update(padded_key);
+            let expected = h.finalize();
+            // Constant-time compare — MD5 broken aside, leaking
+            // first-mismatch position to a remote sender via
+            // timing is bad form.
+            constant_time_eq(&expected, &packet.auth_trailer)
+        }
     }
+}
+
+/// Record the cryptographic-auth sequence on a neighbor after a
+/// packet has been accepted. No-op for Null / Simple packets.
+pub(super) fn record_md5_seq<V: super::version::OspfVersion>(
+    packet: &Ospfv2Packet,
+    nbr: &mut Neighbor<V>,
+) {
+    if let Ospfv2Auth::Crypto(ref c) = packet.auth {
+        nbr.auth_md5_last_seq = c.seq;
+    }
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut acc: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        acc |= x ^ y;
+    }
+    acc == 0
 }
 
 pub fn ospf_hello_packet(oi: &OspfLink) -> Option<Ospfv2Packet> {
@@ -94,7 +214,7 @@ pub fn ospf_hello_packet(oi: &OspfLink) -> Option<Ospfv2Packet> {
     }
 
     let mut packet = Ospfv2Packet::new(&oi.ident.router_id, &oi.area, Ospfv2Payload::Hello(hello));
-    apply_link_auth(&mut packet, oi.auth_mode(), oi.config.auth_key);
+    apply_link_auth(&mut packet, &oi.auth_send_ctx());
 
     Some(packet)
 }
@@ -296,7 +416,7 @@ pub fn ospf_db_desc_send(link: &mut OspfInterface, nbr: &mut Neighbor, oident: &
     }
 
     let mut packet = Ospfv2Packet::new(&oident.router_id, &area, Ospfv2Payload::DbDesc(dd));
-    apply_link_auth(&mut packet, link.auth_mode, link.auth_key);
+    apply_link_auth(&mut packet, &link.auth_send_ctx());
     tracing::info!("DB_DESC: Send");
     // tracing::info!("{}", packet);
     let _ = nbr.ptx.send(Message::Send(
@@ -319,7 +439,7 @@ pub fn ospf_ls_req_send(link: &mut OspfInterface, nbr: &mut Neighbor, oident: &I
     ospf_packet_ls_req_set(nbr, &mut ls_req);
 
     let mut packet = Ospfv2Packet::new(&oident.router_id, &area, Ospfv2Payload::LsRequest(ls_req));
-    apply_link_auth(&mut packet, link.auth_mode, link.auth_key);
+    apply_link_auth(&mut packet, &link.auth_send_ctx());
     tracing::info!("[DB Desc:Send]");
     tracing::info!("{}", packet);
     nbr.ptx
@@ -565,7 +685,7 @@ fn ospf_db_desc_resend(oi: &OspfInterface, nbr: &Neighbor) {
         &oi.area_id,
         Ospfv2Payload::DbDesc(sent.clone()),
     );
-    apply_link_auth(&mut packet, oi.auth_mode, oi.auth_key);
+    apply_link_auth(&mut packet, &oi.auth_send_ctx());
     let _ = nbr.ptx.send(Message::Send(
         packet,
         nbr.ifindex,
@@ -580,7 +700,7 @@ pub fn ospf_ls_upd_send(oi: &OspfInterface, nbr: &Neighbor, lsas: Vec<OspfLsa>) 
         lsas,
     };
     let mut packet = Ospfv2Packet::new(&oi.ident.router_id, &area, Ospfv2Payload::LsUpdate(ls_upd));
-    apply_link_auth(&mut packet, oi.auth_mode, oi.auth_key);
+    apply_link_auth(&mut packet, &oi.auth_send_ctx());
     tracing::info!("[LS Update:Send] to {}", nbr.ident.prefix.addr());
     nbr.ptx
         .send(Message::Send(
@@ -595,7 +715,7 @@ pub fn ospf_ls_ack_send(oi: &OspfInterface, nbr: &Neighbor, lsa_headers: Vec<Osp
     let area = oi.area_id;
     let ls_ack = OspfLsAck { lsa_headers };
     let mut packet = Ospfv2Packet::new(&oi.ident.router_id, &area, Ospfv2Payload::LsAck(ls_ack));
-    apply_link_auth(&mut packet, oi.auth_mode, oi.auth_key);
+    apply_link_auth(&mut packet, &oi.auth_send_ctx());
     tracing::info!("[LS Ack:Send] to {}", nbr.ident.prefix.addr());
     nbr.ptx
         .send(Message::Send(
@@ -1068,10 +1188,41 @@ mod auth_tests {
         )
     }
 
+    fn null_ctx() -> AuthSendCtx {
+        AuthSendCtx {
+            mode: OspfAuthMode::Null,
+            simple_key: None,
+            md5_key: None,
+            md5_seq: 0,
+        }
+    }
+
+    fn simple_ctx(key: [u8; 8]) -> AuthSendCtx {
+        AuthSendCtx {
+            mode: OspfAuthMode::Simple,
+            simple_key: Some(key),
+            md5_key: None,
+            md5_seq: 0,
+        }
+    }
+
+    fn md5_ctx(key_id: u8, padded: [u8; 16], seq: u32) -> AuthSendCtx {
+        AuthSendCtx {
+            mode: OspfAuthMode::MessageDigest,
+            simple_key: None,
+            md5_key: Some((key_id, padded)),
+            md5_seq: seq,
+        }
+    }
+
+    fn empty_md5_keys() -> std::collections::BTreeMap<u8, [u8; 16]> {
+        std::collections::BTreeMap::new()
+    }
+
     #[test]
     fn apply_null_stamps_type_zero() {
         let mut p = hello_packet();
-        apply_link_auth(&mut p, OspfAuthMode::Null, None);
+        apply_link_auth(&mut p, &null_ctx());
         assert_eq!(p.auth_type, 0);
         assert!(matches!(p.auth, Ospfv2Auth::Null(_)));
     }
@@ -1080,7 +1231,7 @@ mod auth_tests {
     fn apply_simple_pads_short_key() {
         let mut p = hello_packet();
         let key = *b"abc\0\0\0\0\0";
-        apply_link_auth(&mut p, OspfAuthMode::Simple, Some(key));
+        apply_link_auth(&mut p, &simple_ctx(key));
         assert_eq!(p.auth_type, 1);
         match p.auth {
             Ospfv2Auth::Simple(rx) => assert_eq!(&rx, &key),
@@ -1091,26 +1242,120 @@ mod auth_tests {
     #[test]
     fn verify_null_accepts_type_zero_only() {
         let mut p = hello_packet();
-        apply_link_auth(&mut p, OspfAuthMode::Null, None);
-        assert!(verify_link_auth(&p, OspfAuthMode::Null, None));
+        apply_link_auth(&mut p, &null_ctx());
+        assert!(verify_link_auth(
+            &p,
+            OspfAuthMode::Null,
+            None,
+            &empty_md5_keys(),
+            0
+        ));
 
-        apply_link_auth(&mut p, OspfAuthMode::Simple, Some(*b"x\0\0\0\0\0\0\0"));
-        assert!(!verify_link_auth(&p, OspfAuthMode::Null, None));
+        apply_link_auth(&mut p, &simple_ctx(*b"x\0\0\0\0\0\0\0"));
+        assert!(!verify_link_auth(
+            &p,
+            OspfAuthMode::Null,
+            None,
+            &empty_md5_keys(),
+            0
+        ));
     }
 
     #[test]
     fn verify_simple_requires_key_match() {
         let mut p = hello_packet();
         let key = *b"secret\0\0";
-        apply_link_auth(&mut p, OspfAuthMode::Simple, Some(key));
+        apply_link_auth(&mut p, &simple_ctx(key));
 
-        assert!(verify_link_auth(&p, OspfAuthMode::Simple, Some(key)));
+        assert!(verify_link_auth(
+            &p,
+            OspfAuthMode::Simple,
+            Some(key),
+            &empty_md5_keys(),
+            0
+        ));
         assert!(!verify_link_auth(
             &p,
             OspfAuthMode::Simple,
-            Some(*b"other\0\0\0")
+            Some(*b"other\0\0\0"),
+            &empty_md5_keys(),
+            0
         ));
         // Wrong mode on the receiving side — drop.
-        assert!(!verify_link_auth(&p, OspfAuthMode::Null, None));
+        assert!(!verify_link_auth(
+            &p,
+            OspfAuthMode::Null,
+            None,
+            &empty_md5_keys(),
+            0
+        ));
+    }
+
+    #[test]
+    fn md5_emit_then_parse_verifies() {
+        use bytes::BytesMut;
+        use ospf_packet::parse;
+
+        let mut p = hello_packet();
+        let mut padded = [0u8; 16];
+        padded[..6].copy_from_slice(b"secret");
+        apply_link_auth(&mut p, &md5_ctx(7, padded, 0xCAFE_BABE));
+
+        // Crypto overlay must be set on the packet.
+        match &p.auth {
+            Ospfv2Auth::Crypto(c) => {
+                assert_eq!(c.key_id, 7);
+                assert_eq!(c.auth_data_len, 16);
+                assert_eq!(c.seq, 0xCAFE_BABE);
+            }
+            other => panic!("expected Crypto, got {:?}", other),
+        }
+        assert_eq!(p.auth_trailer.len(), 16);
+
+        // Serialize + reparse to exercise the receive path.
+        let mut buf = BytesMut::new();
+        p.emit(&mut buf);
+        let (rest, parsed) = parse(&buf).expect("parse must succeed");
+        assert!(rest.is_empty());
+        assert_eq!(parsed.auth_trailer.len(), 16);
+
+        let mut keys = std::collections::BTreeMap::new();
+        keys.insert(7u8, padded);
+        // Accept with matching key + fresh seq.
+        assert!(verify_link_auth(
+            &parsed,
+            OspfAuthMode::MessageDigest,
+            None,
+            &keys,
+            0
+        ));
+        // Replay: seq below high-watermark → reject.
+        assert!(!verify_link_auth(
+            &parsed,
+            OspfAuthMode::MessageDigest,
+            None,
+            &keys,
+            0xCAFE_BABE + 1
+        ));
+        // Unknown key-id → reject.
+        let mut wrong_keys = std::collections::BTreeMap::new();
+        wrong_keys.insert(9u8, padded);
+        assert!(!verify_link_auth(
+            &parsed,
+            OspfAuthMode::MessageDigest,
+            None,
+            &wrong_keys,
+            0
+        ));
+        // Same key-id, wrong material → reject.
+        let mut bad_keys = std::collections::BTreeMap::new();
+        bad_keys.insert(7u8, [0u8; 16]);
+        assert!(!verify_link_auth(
+            &parsed,
+            OspfAuthMode::MessageDigest,
+            None,
+            &bad_keys,
+            0
+        ));
     }
 }

--- a/zebra-rs/yang/zebra-ospf-auth-md5.yang
+++ b/zebra-rs/yang/zebra-ospf-auth-md5.yang
@@ -1,0 +1,111 @@
+module zebra-ospf-auth-md5 {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-ospf-auth-md5";
+  prefix "zoam";
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "FRR / IOS style per-interface OSPFv2 cryptographic (MD5)
+     authentication (RFC 2328 §D.4). Sits alongside
+     zebra-ospf-auth-simple.yang, which covers Null and Simple
+     password (RFC 2328 §D.2 / §D.3).
+
+     The `authentication` enum from -auth-simple is repurposed:
+     `message-digest` selects MD5 cryptographic authentication, and
+     the per-key material is configured under the
+     `message-digest-key` list keyed by 8-bit key-id.
+
+       router ospf {
+         area 0 {
+           interface eth0 {
+             authentication message-digest;
+             message-digest-key 1 {
+               md5 SECRET;
+             }
+           }
+         }
+       }
+
+     HMAC-SHA generalization (RFC 5709 / 7474) and key-chains
+     (RFC 8177) land in follow-up phases under the IETF
+     `interface/authentication` container.";
+
+  revision 2026-05-25 {
+    description "Initial revision: OSPFv2 MD5 cryptographic auth.";
+    reference "RFC 2328 §D.4; FRR `ip ospf message-digest-key`.";
+  }
+
+  grouping ospf-interface-md5-extension {
+    description
+      "FRR-style cryptographic-auth leaves on an OSPF interface.";
+
+    list message-digest-key {
+      ext:help "MD5 key keyed by 1..255 key-id";
+      key "key-id";
+      description
+        "One MD5 key per key-id. The active sending key is the
+         lowest configured key-id; received packets are validated
+         against whichever key-id the sender stamped in the
+         cryptographic-auth header overlay (RFC 2328 §D.4.2).";
+
+      leaf key-id {
+        type uint8 {
+          range "1..255";
+        }
+        description
+          "MD5 key identifier carried in the packet's
+           cryptographic-auth header (RFC 2328 §D.3 figure 17).
+           Zero is reserved and rejected.";
+      }
+
+      leaf md5 {
+        ext:help "MD5 secret (1..16 octets, plain text)";
+        type string {
+          length "1..16";
+        }
+        mandatory true;
+        description
+          "MD5 shared secret in plain text. RFC 2328 §D.4 caps the
+           key at 16 octets (the MD5 block size for the simple
+           `MD5(packet || key)` construction). HMAC-SHA-flavored
+           longer keys land in a later phase under the IETF
+           cryptographic-auth container.";
+      }
+    }
+  }
+
+  augment "/configure:set/config:router"
+        + "/config:ospf/config:area/config:interface" {
+    description
+      "Attach the message-digest-key list to each OSPF interface
+       in the candidate-set subtree.";
+    uses ospf-interface-md5-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/config:ospf/config:area/config:interface" {
+    description
+      "Same attachment in the delete subtree so
+       `delete router ospf area X interface Y message-digest-key Z`
+       is path-valid.";
+    uses ospf-interface-md5-extension;
+  }
+}

--- a/zebra-rs/yang/zebra-ospf-auth-simple.yang
+++ b/zebra-rs/yang/zebra-ospf-auth-simple.yang
@@ -61,10 +61,18 @@ module zebra-ospf-auth-simple {
            Key is configured via the sibling `authentication-key`
            leaf and zero-padded to 8 bytes on the wire.";
       }
+      enum "message-digest" {
+        description
+          "Cryptographic (MD5) authentication (RFC 2328 §D.4,
+           AuType=2). Per-key material is configured via the
+           sibling `message-digest-key` list from
+           zebra-ospf-auth-md5.yang.";
+      }
     }
     description
-      "OSPFv2 authentication mode covered by this module. Type 2
-       (cryptographic) is handled by the IETF model.";
+      "OSPFv2 authentication mode. RFC 5709 HMAC-SHA modes will
+       appear under the IETF cryptographic-auth container in a
+       later phase.";
   }
 
   grouping ospf-interface-auth-simple-extension {


### PR DESCRIPTION
## Summary

Phase 2 of OSPF authentication. End-to-end AuType 2 (cryptographic MD5) per RFC 2328 §D.4 plus per-neighbor replay protection per §D.5. Pulls in \`md-5 = \"0.10\"\` (RustCrypto, pure Rust) — no other crypto crates added.

\`\`\`
router ospf {
  area 0 {
    interface eth0 {
      authentication message-digest;
      message-digest-key 1 {
        md5 SECRET;
      }
    }
  }
}
\`\`\`

## What's in

**ospf-packet:** `Ospfv2Packet::raw_body` (#[nom(Ignore)]) — `parse()` clones the hashed slice so receivers recompute MD5 without re-serializing.

**YANG:** new `zebra-ospf-auth-md5.yang` (`message-digest-key <1..255> md5 <1..16>`), `authentication` enum in `-auth-simple` gains `message-digest`.

**Runtime:**
- `OspfAuthMode::MessageDigest` + `LinkConfig::md5_keys` (key-id → 16-byte padded key) + `OspfLink::md5_seq` (`AtomicU32`, seeded from wall-clock seconds at link create per RFC §D.4.3) + `Neighbor::auth_md5_last_seq` for replay.
- `OspfInterface` snapshots active MD5 key + borrows the seq atomic.
- Apply reshape: `apply_link_auth(packet, &AuthSendCtx)` — bundle built by `OspfLink::auth_send_ctx()` / `OspfInterface::auth_send_ctx()` (which `fetch_add(1)` the seq). For MD5: stamps §D.3 overlay, scratch-emits, hashes `MD5(packet || padded-key)`, stashes the digest in `auth_trailer`.
- Verify for MD5: replay check, key-id lookup, recompute over `packet.raw_body || padded-key`, constant-time compare. `record_md5_seq` updates per-neighbor watermark on accept.
- Flood / retransmit loops use a `build_auth_ctx` helper so the snapshot + per-iteration seq bump fits inside `nbrs.iter_mut()`.

**Phase 0 follow-up (c):** `network.rs::read_packet` now slices the inbound IP payload to the OSPF header `len` before checksumming — without it, the §D.4 trailer bytes corrupt the 1's-complement sum on Type 2 ingress.

## Out of scope

- HMAC-SHA Auth Trailer (RFC 5709 / 7474) — Phase 3.
- Key chains (RFC 8177) with send/accept lifetimes & rollover — Phase 4. Active send key for now is the lowest configured key-id; receive dispatches on the sender's key-id.
- OSPFv3 Auth Trailer (RFC 7166) — Phase 5.

## Test plan

- [x] `cargo test -p ospf-packet` — 44 + 17 passed.
- [x] `cargo test -p zebra-rs --bin zebra-rs` — 615 passed (incl. 5 `ospf::packet::auth_tests` covering Null/Simple/MD5 round-trip + replay + key-id reject + wrong-material reject).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [ ] Live two-router negotiation against a FRR ospfd with `ip ospf message-digest-key` — manual verify deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)