### PR TITLE
ospf: install MPLS state for v3 Prefix-SID routes

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -87,6 +87,11 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// rebuilt ILM after each SPF run to emit `rib::Message::IlmAdd`
     /// / `IlmDel` so the kernel MPLS table tracks the SR-MPLS state.
     pub ilm: BTreeMap<u32, SpfIlm>,
+    /// v3 sibling of `ilm`. Same key (absolute label) and same role
+    /// (MPLS LFIB shadow), but the value carries v6-keyed nexthops
+    /// matching `SpfRouteV3`. Populated by `apply_routing_updates_v3`
+    /// from the v3 SR-MPLS RIB; empty on v2 instances.
+    pub ilm6: BTreeMap<u32, SpfIlmV3>,
     /// First-fit Adjacency-SID label allocator backed by the local SRLB
     /// (`srmpls::SRLB_START` .. `SRLB_START + SRLB_RANGE - 1`). Created
     /// when `segment-routing mpls` is enabled, dropped when it's
@@ -386,6 +391,7 @@ impl Ospf<Ospfv2> {
             graph: None,
             rib: PrefixMap::new(),
             ilm: BTreeMap::new(),
+            ilm6: BTreeMap::new(),
             local_pool: None,
             lan_adj_sids: BTreeMap::new(),
             rib6: PrefixMap::new(),
@@ -2100,6 +2106,7 @@ impl Ospf<Ospfv3> {
             graph: None,
             rib: PrefixMap::new(),
             ilm: BTreeMap::new(),
+            ilm6: BTreeMap::new(),
             local_pool: None,
             lan_adj_sids: BTreeMap::new(),
             rib6: PrefixMap::new(),
@@ -4238,6 +4245,16 @@ pub struct SpfNexthopV3 {
     pub ifindex: u32,
 }
 
+/// v3 sibling of `SpfIlm`. Same role -- one entry in the SR-MPLS
+/// LFIB shadow -- but the nexthop set is keyed by IPv6 link-local
+/// (matching `SpfRouteV3::nhops`) so kernel installs go out with v6
+/// `Via` and the right outgoing interface.
+#[derive(Debug, PartialEq)]
+pub struct SpfIlmV3 {
+    pub nhops: BTreeMap<std::net::Ipv6Addr, SpfNexthopV3>,
+    pub ilm_type: IlmType,
+}
+
 fn rib_insert(rib: &mut PrefixMap<Ipv4Net, SpfRoute>, prefix: Ipv4Net, route: SpfRoute) {
     if let Some(curr) = rib.get_mut(&prefix) {
         if curr.metric > route.metric {
@@ -5140,9 +5157,23 @@ fn build_rib6_from_spf(
 /// nexthop becomes `Nexthop::Uni` for single-hop routes,
 /// `Nexthop::Multi` for ECMP.
 fn make_rib6_entry(route: &SpfRouteV3) -> rib::entry::RibEntry {
+    // SR-MPLS egress imposition: if the prefix has a resolved
+    // Prefix-SID label, push it onto every nexthop as an Explicit
+    // swap label. v2's `nhop_to_nexthop_uni` additionally tags
+    // adjacency-directly-attached nexthops as `Label::Implicit`
+    // (PHP), keyed off `SpfNexthop::adjacency`. `SpfNexthopV3`
+    // doesn't carry that flag yet, so we always push Explicit --
+    // functionally correct (swap to same label) just with no PHP
+    // optimization. Adding the adjacency flag to the v3 SPF
+    // nexthop builder is a follow-up.
+    let labels: Vec<rib::Label> = match route.sid {
+        Some(sid) => vec![rib::Label::Explicit(sid)],
+        None => vec![],
+    };
     let nexthop = if route.nhops.len() == 1 {
         let (addr, nhop) = route.nhops.iter().next().unwrap();
-        let mut uni = rib::NexthopUni::new(std::net::IpAddr::V6(*addr), route.metric, vec![]);
+        let mut uni =
+            rib::NexthopUni::new(std::net::IpAddr::V6(*addr), route.metric, labels.clone());
         uni.ifindex_origin = (nhop.ifindex != 0).then_some(nhop.ifindex);
         rib::Nexthop::Uni(uni)
     } else {
@@ -5151,7 +5182,7 @@ fn make_rib6_entry(route: &SpfRouteV3) -> rib::entry::RibEntry {
             .iter()
             .map(|(addr, nhop)| {
                 let mut uni =
-                    rib::NexthopUni::new(std::net::IpAddr::V6(*addr), route.metric, vec![]);
+                    rib::NexthopUni::new(std::net::IpAddr::V6(*addr), route.metric, labels.clone());
                 uni.ifindex_origin = (nhop.ifindex != 0).then_some(nhop.ifindex);
                 uni
             })
@@ -5279,10 +5310,19 @@ fn apply_routing_updates_v3(
     spf_result: &BTreeMap<usize, spf::Path>,
 ) {
     let mut new_rib = build_rib6_from_spf(top, area_id, source, spf_result);
-    // Attach SR Prefix-SIDs to matching routes. No FIB change here --
-    // `make_rib6_entry` does not yet read these fields; D4b wires
-    // the MPLS install on top.
+    // Attach SR Prefix-SIDs to matching routes so `make_rib6_entry`
+    // pushes the label onto each nexthop (egress imposition).
     add_prefix_sids_v3(top, area_id, &mut new_rib);
+
+    // SR-MPLS LFIB shadow: build a fresh ILM from labeled routes in
+    // the new RIB, diff against `top.ilm6`, emit IlmAdd / IlmDel so
+    // the kernel MPLS table tracks our SR-MPLS state. Self-pop and
+    // self-Adj-SID install land in D4c / D4d.
+    let new_ilm = build_ilm_from_rib6(&new_rib);
+    let ilm_diff = spf::table_diff(top.ilm6.iter(), new_ilm.iter());
+    diff_ilm_apply_v6(&top.ctx.rib, &ilm_diff);
+    top.ilm6 = new_ilm;
+
     let diff = spf::table_diff(top.rib6.iter(), new_rib.iter());
 
     // Withdrawals.
@@ -5599,6 +5639,106 @@ fn build_ilm_from_rib(rib: &PrefixMap<Ipv4Net, SpfRoute>) -> BTreeMap<u32, SpfIl
         ilm.insert(
             label,
             SpfIlm {
+                nhops: route.nhops.clone(),
+                ilm_type: IlmType::Node(pfx_index),
+            },
+        );
+    }
+    ilm
+}
+
+pub type DiffIlmResultV3<'a> = spf::TableDiffResult<'a, u32, SpfIlmV3>;
+
+/// v3 sibling of `make_ilm_entry`. Same role -- render an
+/// `(incoming_label, SpfIlmV3)` pair into the `rib::IlmEntry` shape
+/// the RIB subsystem expects -- but the nexthop is v6 (matching
+/// `SpfRouteV3`). No PHP optimization yet (SpfNexthopV3 doesn't
+/// carry an adjacency flag); every nexthop pushes the incoming
+/// label as a swap label.
+fn make_ilm_entry_v6(label: u32, ilm: &SpfIlmV3) -> IlmEntry {
+    let build_uni = |addr: &std::net::Ipv6Addr, nhop: &SpfNexthopV3| -> NexthopUni {
+        let mut uni = NexthopUni {
+            addr: std::net::IpAddr::V6(*addr),
+            ifindex_origin: (nhop.ifindex != 0).then_some(nhop.ifindex),
+            ..Default::default()
+        };
+        uni.mpls_label.push(label);
+        uni
+    };
+
+    let nexthop = if ilm.nhops.len() == 1
+        && let Some((addr, nhop)) = ilm.nhops.iter().next()
+    {
+        Nexthop::Uni(build_uni(addr, nhop))
+    } else {
+        let mut multi = NexthopMulti::default();
+        for (addr, nhop) in ilm.nhops.iter() {
+            multi.nexthops.push(build_uni(addr, nhop));
+        }
+        Nexthop::Multi(multi)
+    };
+
+    IlmEntry {
+        rtype: RibType::Ospf,
+        ilm_type: ilm.ilm_type.clone(),
+        nexthop,
+    }
+}
+
+pub fn diff_ilm_apply_v6(rib_client: &crate::rib::client::RibClient, diff: &DiffIlmResultV3) {
+    for (label, ilm) in diff.only_curr.iter() {
+        if !ilm.nhops.is_empty() {
+            let msg = rib::Message::IlmDel {
+                label: **label,
+                ilm: make_ilm_entry_v6(**label, ilm),
+            };
+            rib_client.send(msg).unwrap();
+        }
+    }
+    for (label, _, ilm) in diff.different.iter() {
+        if !ilm.nhops.is_empty() {
+            let msg = rib::Message::IlmAdd {
+                label: **label,
+                ilm: make_ilm_entry_v6(**label, ilm),
+            };
+            rib_client.send(msg).unwrap();
+        }
+    }
+    for (label, ilm) in diff.only_next.iter() {
+        if !ilm.nhops.is_empty() {
+            let msg = rib::Message::IlmAdd {
+                label: **label,
+                ilm: make_ilm_entry_v6(**label, ilm),
+            };
+            rib_client.send(msg).unwrap();
+        }
+    }
+}
+
+/// v3 sibling of `build_ilm_from_rib`. Walks the freshly-built v6
+/// RIB, emits one ILM entry per labeled prefix. Incoming-label key
+/// is `SpfRouteV3::sid` (resolved against the advertising router's
+/// SRGB by `add_prefix_sids_v3`). `IlmType::Node(pfx_index)` is
+/// only used by show-side rendering; derived from `prefix_sid` so
+/// an Index-form SID renders symmetrically with its on-the-wire
+/// value.
+fn build_ilm_from_rib6(rib: &PrefixMap<ipnet::Ipv6Net, SpfRouteV3>) -> BTreeMap<u32, SpfIlmV3> {
+    let mut ilm = BTreeMap::new();
+    for (_prefix, route) in rib.iter() {
+        let Some(label) = route.sid else {
+            continue;
+        };
+        if route.nhops.is_empty() {
+            continue;
+        }
+        let pfx_index = match route.prefix_sid {
+            Some((SidLabelValue::Index(idx), _)) => idx,
+            Some((SidLabelValue::Label(lbl), ref cfg)) => lbl.saturating_sub(cfg.global.start),
+            None => 0,
+        };
+        ilm.insert(
+            label,
+            SpfIlmV3 {
                 nhops: route.nhops.clone(),
                 ilm_type: IlmType::Node(pfx_index),
             },

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -4220,6 +4220,17 @@ pub struct SpfNexthop {
 pub struct SpfRouteV3 {
     pub metric: u32,
     pub nhops: BTreeMap<std::net::Ipv6Addr, SpfNexthopV3>,
+    /// Resolved absolute MPLS label for this prefix's SR Prefix-SID,
+    /// or `None` if no E-Intra-Area-Prefix-LSA covers this prefix or
+    /// the advertising router's SRGB isn't yet known (Index-form SID
+    /// needs `label_map[adv_router]` to resolve). Populated by
+    /// `add_prefix_sids_v3` after `build_rib6_from_spf`; mirror of
+    /// v2's `SpfRoute::sid`.
+    pub sid: Option<u32>,
+    /// Raw `(SidLabelValue, LabelConfig)` pair preserved so the show
+    /// path can surface the on-the-wire SID encoding alongside the
+    /// resolved label. Mirror of v2's `SpfRoute::prefix_sid`.
+    pub prefix_sid: Option<(SidLabelValue, LabelConfig)>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -5099,6 +5110,8 @@ fn build_rib6_from_spf(
             let entry = SpfRouteV3 {
                 metric: total_metric,
                 nhops: nhops_map,
+                sid: None,
+                prefix_sid: None,
             };
             // Equal-cost: take the lowest-metric. If equal, merge
             // nexthop sets so we end up with ECMP at the same
@@ -5157,6 +5170,104 @@ fn make_rib6_entry(route: &SpfRouteV3) -> rib::entry::RibEntry {
     rib_entry
 }
 
+/// Walk every area's E-Intra-Area-Prefix-LSAs (RFC 8362 §3.7) and
+/// attach each advertised Prefix-SID (RFC 8666 §5) to the matching
+/// route already in `rib`. Mirrors v2's `add_prefix_sids`.
+///
+/// For Index-form SIDs we resolve to the absolute label via the
+/// advertising router's SRGB (`Lsdb::label_map`, populated from
+/// Router Information LSAs); Label-form SIDs are stored verbatim.
+/// MaxAge'd LSAs are skipped. Self-originated LSAs are skipped --
+/// pushing a label onto our own loopback /128 route is nonsensical
+/// (mirrors the v2 add_prefix_sids self-skip).
+///
+/// Data-population only; no FIB change here. The MPLS install lands
+/// in the D4b follow-up.
+fn add_prefix_sids_v3(
+    top: &Ospf<Ospfv3>,
+    area_id: Ipv4Addr,
+    rib: &mut PrefixMap<ipnet::Ipv6Net, SpfRouteV3>,
+) {
+    use ipnet::Ipv6Net;
+    use ospf_packet::{
+        OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE, Ospfv3ExtTlv, Ospfv3LsBody, Ospfv3SubTlv,
+        ospfv3_prefix_wire_len,
+    };
+
+    use crate::ospf::lsdb::OSPF_MAX_AGE;
+
+    let Some(area) = top.areas.get(area_id) else {
+        return;
+    };
+
+    for ((_ls_id, adv_router), lsa) in area
+        .lsdb
+        .iter_by_raw_type(OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE)
+    {
+        if lsa.data.h.ls_age >= OSPF_MAX_AGE {
+            continue;
+        }
+        if lsa.data.h.advertising_router == top.router_id {
+            continue;
+        }
+        let Ospfv3LsBody::EIntraAreaPrefix(ref body) = lsa.data.body else {
+            continue;
+        };
+        let Some(label_config) = area.lsdb.label_map.get(&adv_router) else {
+            // No SRGB known for this advertiser yet -- the matching
+            // Router Information LSA has not arrived (or carried no
+            // SidLabelRange). Index-form Prefix-SIDs would be
+            // unresolvable; Label-form would still work, but skipping
+            // here matches the v2 behavior of waiting for the SRGB.
+            continue;
+        };
+        for tlv in &body.tlvs {
+            let Ospfv3ExtTlv::IntraAreaPrefix(prefix_tlv) = tlv else {
+                continue;
+            };
+            // Reconstruct the IPv6 prefix from the wire bytes. The
+            // address_prefix vec is padded to a 4-byte boundary per
+            // RFC 5340 §A.4.1.1; rebuild a 16-byte buffer for
+            // `Ipv6Addr::from`.
+            let wire_len = ospfv3_prefix_wire_len(prefix_tlv.prefix_length);
+            if prefix_tlv.address_prefix.len() < wire_len {
+                continue;
+            }
+            let mut bytes = [0u8; 16];
+            let copy = wire_len.min(16);
+            bytes[..copy].copy_from_slice(&prefix_tlv.address_prefix[..copy]);
+            let addr = std::net::Ipv6Addr::from(bytes);
+            let Ok(prefix) = Ipv6Net::new(addr, prefix_tlv.prefix_length) else {
+                continue;
+            };
+            let prefix = prefix.trunc();
+            let Some(route) = rib.get_mut(&prefix) else {
+                continue;
+            };
+            for sub in &prefix_tlv.subs {
+                let Ospfv3SubTlv::PrefixSid(ps) = sub else {
+                    continue;
+                };
+                // `Ospfv3PrefixSidSubTlv::sid` is a `SidLabelTlv`
+                // (the wire-side enum from `packet_utils`); the
+                // `SpfRouteV3::prefix_sid` field carries the
+                // protocol-neutral `SidLabelValue`. Same trivial
+                // conversion v2's add_prefix_sids does.
+                let (value, sid_label) = match ps.sid {
+                    SidLabelTlv::Label(v) => (SidLabelValue::Label(v), Some(v)),
+                    SidLabelTlv::Index(v) => (
+                        SidLabelValue::Index(v),
+                        label_config.global.start.checked_add(v),
+                    ),
+                };
+                route.prefix_sid = Some((value, label_config.clone()));
+                route.sid = sid_label;
+                break;
+            }
+        }
+    }
+}
+
 /// Diff the freshly-built v3 RIB against the prior snapshot and
 /// emit `Ipv6Del` for prefixes only in the old, `Ipv6Add` for
 /// prefixes new or changed. Replaces `top.rib6` with `new_rib`
@@ -5167,7 +5278,11 @@ fn apply_routing_updates_v3(
     source: usize,
     spf_result: &BTreeMap<usize, spf::Path>,
 ) {
-    let new_rib = build_rib6_from_spf(top, area_id, source, spf_result);
+    let mut new_rib = build_rib6_from_spf(top, area_id, source, spf_result);
+    // Attach SR Prefix-SIDs to matching routes. No FIB change here --
+    // `make_rib6_entry` does not yet read these fields; D4b wires
+    // the MPLS install on top.
+    add_prefix_sids_v3(top, area_id, &mut new_rib);
     let diff = spf::table_diff(top.rib6.iter(), new_rib.iter());
 
     // Withdrawals.


### PR DESCRIPTION
## Summary

Phase D PR-4b. Second v3 SR-MPLS consumer step, mirroring v2's Phase A2 (#842). Builds on #868 (D4a)'s \`SpfRouteV3::sid\` populate to push egress labels onto IPv6 routes AND install the matching Prefix-SID ILM entries; together with D4a this covers transit SR-MPLS on v3.

**Stacks on #868 — review/merge that first.**

Four pieces:

- **\`SpfIlmV3\`** is the v3 sibling of \`SpfIlm\` — same role (one entry in the SR-MPLS LFIB shadow) but the nexthop set is keyed by \`Ipv6Addr\` to match \`SpfRouteV3\`. \`Ospf<V>\` grows a parallel \`ilm6: BTreeMap<u32, SpfIlmV3>\` next to the existing \`ilm\`; both fields exist on the same struct because \`Ospf<V>\` is generic, but only the active protocol populates its own.
- **\`make_rib6_entry\`** now pushes \`route.sid\` as \`rib::Label::Explicit\` onto every nexthop when set, mirroring v2's \`nhop_to_nexthop_uni\` egress imposition. Since \`SpfNexthopV3\` doesn't yet carry an adjacency flag the PHP \`Label::Implicit\` optimization is deferred — functionally correct (swap to same label) just without the optimization.
- **\`build_ilm_from_rib6\`, \`make_ilm_entry_v6\`, \`diff_ilm_apply_v6\`** are the v3 ILM-construction trio, parallel to v2's \`build_ilm_from_rib\` / \`make_ilm_entry\` / \`diff_ilm_apply\`. The IlmEntry built carries v6 \`Via\` so kernel installs go out with the right next-hop family.
- **\`apply_routing_updates_v3\`** now runs the SR populate pass, the ILM diff, and the IP RIB diff in that order. The diff machinery emits only deltas, same as v2 and IS-IS.

Self-pop (D4c) and self-Adj-SID ILM (D4d) follow next; with those v3 SR-MPLS reaches feature parity with v2.

## Test plan

- [x] \`cargo build\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p zebra-rs --bins\` — 614/614 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)