### PR TITLE
ospf: redistribute connected into NSSA Type-7 (v2)

### DIFF
--- a/zebra-rs/src/ospf/area.rs
+++ b/zebra-rs/src/ospf/area.rs
@@ -1,6 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::Ipv4Addr;
 
+use ipnet::Ipv4Net;
+
 use super::Lsdb;
 use super::task::Timer;
 use super::version::{OspfVersion, Ospfv2};
@@ -75,6 +77,57 @@ pub struct AreaType {
     pub nssa_default_originate: bool,
     pub nssa_suppress_fa: bool,
     pub nssa_translator_role: NssaTranslatorRole,
+}
+
+/// E1 vs E2 metric-type for AS-External / NSSA-AS-External LSAs.
+/// E1 (Type 1): the receiver adds SPF(originator) cost to LSA metric.
+/// E2 (Type 2, default): receiver uses LSA metric alone (SPF cost is
+/// the tiebreak only). Encoded on the wire as the E-bit (0x80) of the
+/// LSA body's `ext_and_resvd` / `ext_and_tos` byte.
+#[derive(Debug, Default, PartialEq, Clone, Copy)]
+pub enum ExternalMetricType {
+    Type1,
+    #[default]
+    Type2,
+}
+
+impl ExternalMetricType {
+    /// `"type-1"` / `"type-2"` from the YANG enum.
+    pub fn from_yang(s: &str) -> Option<Self> {
+        match s {
+            "type-1" => Some(Self::Type1),
+            "type-2" => Some(Self::Type2),
+            _ => None,
+        }
+    }
+
+    pub fn is_type_2(self) -> bool {
+        matches!(self, Self::Type2)
+    }
+}
+
+/// Per-source-proto redistribution knobs. Today only `connected`
+/// is wired (RIB subscription lives in `inst.rs`); extending to
+/// `static` is just adding another `Option<RedistEntry>` field
+/// here plus a matching YANG container + callback.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RedistEntry {
+    /// External metric to advertise. Default 20 (matches FRR).
+    pub metric: u32,
+    /// E1 (Type 1) vs E2 (Type 2). Default E2.
+    pub metric_type: ExternalMetricType,
+}
+
+impl RedistEntry {
+    pub const DEFAULT_METRIC: u32 = 20;
+}
+
+/// Per-area redistribute configuration. Sibling per source proto.
+/// `Some(entry)` = redistribute that source into this area's
+/// Type-7 LSAs; `None` = don't.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AreaRedistribute {
+    pub connected: Option<RedistEntry>,
 }
 
 impl AreaType {
@@ -174,6 +227,21 @@ pub struct OspfArea<V: OspfVersion = Ospfv2> {
     // SPF; the completion path re-fires exactly one follow-up.
     pub spf_inflight: bool,
     pub spf_pending: bool,
+
+    /// Per-area redistribute config (NSSA Type-7 source toggles).
+    /// Only consulted when `area_type` is NSSA; storage is
+    /// area-typeless because operators may toggle the redistribute
+    /// knob before flipping `area-type` and the value should
+    /// survive the order swap.
+    pub redistribute: AreaRedistribute,
+
+    /// Prefixes of redistributed connected routes that this router
+    /// has originated as Type-7 LSAs into this area. Keyed by
+    /// `prefix.network()`. Used to flush the matching Type-7s when
+    /// the redistribute knob is removed or the area leaves NSSA.
+    /// Populated/maintained by the RIB RouteAdd / RouteDel handlers
+    /// in `inst.rs`.
+    pub redist_connected_originated: BTreeSet<Ipv4Net>,
 }
 
 impl<V: OspfVersion> OspfArea<V> {
@@ -186,6 +254,8 @@ impl<V: OspfVersion> OspfArea<V> {
             spf_timer: None,
             spf_inflight: false,
             spf_pending: false,
+            redistribute: AreaRedistribute::default(),
+            redist_connected_originated: BTreeSet::new(),
         }
     }
 }

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -3,7 +3,7 @@ use std::net::Ipv4Addr;
 
 use super::Ospf;
 use super::OspfLink;
-use super::area::{AreaTypeKind, NssaTranslatorRole};
+use super::area::{AreaTypeKind, ExternalMetricType, NssaTranslatorRole, RedistEntry};
 use super::ifsm::{IfsmEvent, ospf_hello_timer};
 use super::link::{OspfAuthMode, OspfNetworkType};
 use super::tracing::{config_tracing_fsm, config_tracing_packet};
@@ -43,6 +43,18 @@ impl Ospf {
         self.ospf_add(
             "/area/nssa-translator-role",
             config_ospf_area_nssa_translator_role,
+        );
+        self.ospf_add(
+            "/area/redistribute/connected",
+            config_ospf_area_redist_connected,
+        );
+        self.ospf_add(
+            "/area/redistribute/connected/metric",
+            config_ospf_area_redist_connected_metric,
+        );
+        self.ospf_add(
+            "/area/redistribute/connected/metric-type",
+            config_ospf_area_redist_connected_metric_type,
         );
         self.ospf_add("/area/interface/enable", config_ospf_interface_enable);
         self.ospf_add(
@@ -233,6 +245,10 @@ fn config_ospf_area_type(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Optio
     };
     area_type_set(ospf, area_id, kind);
     ospf.nssa_default_lsa_originate(area_id);
+    // Area-type transition flips whether redistributed Type-7s
+    // are legal in this area — resync (originate fresh on
+    // entry-to-NSSA, flush on exit).
+    ospf.nssa_redist_connected_resync(area_id);
     Some(())
 }
 
@@ -277,6 +293,128 @@ fn config_ospf_area_nssa_translator_role(
         NssaTranslatorRole::default()
     };
     area_nssa_translator_role_set(ospf, area_id, role);
+    Some(())
+}
+
+/// Send the appropriate RIB Redist message for the current state
+/// of this area's `connected` redistribute knob. Mirrors IS-IS's
+/// `send_redist` (`isis/config.rs:887`):
+///   - knob removed from any NSSA area on this router → RedistDel
+///   - knob present, first time across all NSSA areas → RedistAdd
+///   - knob present, subsequent edit → RedistUpdate (no-op for
+///     connected since subtypes are wildcard, but kept for
+///     symmetry with future static / bgp sources)
+///
+/// RIB subscription is keyed by `(proto, afi, rtype)` — not per
+/// area — so multiple NSSA areas with `redistribute connected`
+/// share a single subscription. `any_connected_enabled` decides
+/// whether the subscription should exist at all.
+fn ospf_send_redist_connected(ospf: &Ospf, first_time: bool) {
+    use crate::rib::{Message as RibMsg, RedistAfi, RibType};
+    let proto = "ospf".to_string();
+    let afi = RedistAfi::Ipv4;
+    let rtype = RibType::Connected;
+
+    let any_enabled = ospf
+        .areas
+        .iter()
+        .any(|(_, area)| area.redistribute.connected.is_some());
+
+    let msg = if !any_enabled {
+        RibMsg::RedistDel { proto, afi, rtype }
+    } else if first_time {
+        RibMsg::RedistAdd {
+            proto,
+            afi,
+            rtype,
+            subtypes: std::collections::BTreeSet::new(),
+        }
+    } else {
+        RibMsg::RedistUpdate {
+            proto,
+            afi,
+            rtype,
+            subtypes: std::collections::BTreeSet::new(),
+        }
+    };
+    let _ = ospf.ctx.rib.send(msg);
+}
+
+/// `/router/ospf/area/<id>/redistribute/connected` — presence
+/// container. On Set: create the area's `RedistEntry` with
+/// defaults (metric 20, E2) and (re)originate Type-7 LSAs for
+/// every connected route the RIB has already pushed. On Delete:
+/// drop the entry and flush our self-originated Type-7s that
+/// belong to this area.
+fn config_ospf_area_redist_connected(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+
+    // Was this the only NSSA area subscribed (or none yet)?
+    let first_time = !ospf
+        .areas
+        .iter()
+        .any(|(_, area)| area.redistribute.connected.is_some());
+
+    if op.is_set() {
+        ospf.areas.fetch(area_id).redistribute.connected = Some(RedistEntry {
+            metric: RedistEntry::DEFAULT_METRIC,
+            ..Default::default()
+        });
+    } else if let Some(area) = ospf.areas.get_mut(area_id) {
+        area.redistribute.connected = None;
+    }
+
+    ospf_send_redist_connected(ospf, first_time && op.is_set());
+    ospf.nssa_redist_connected_resync(area_id);
+    Some(())
+}
+
+/// `/router/ospf/area/<id>/redistribute/connected/metric`.
+/// Consumer-side override; no RIB resubscribe needed.
+fn config_ospf_area_redist_connected_metric(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let metric = if op.is_set() {
+        args.u32()?
+    } else {
+        RedistEntry::DEFAULT_METRIC
+    };
+    let entry = ospf
+        .areas
+        .fetch(area_id)
+        .redistribute
+        .connected
+        .get_or_insert_with(RedistEntry::default);
+    entry.metric = metric;
+    ospf.nssa_redist_connected_resync(area_id);
+    Some(())
+}
+
+/// `/router/ospf/area/<id>/redistribute/connected/metric-type` —
+/// `type-1` / `type-2`. Re-originates all Type-7s for the area
+/// since the E-bit changes per-LSA.
+fn config_ospf_area_redist_connected_metric_type(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let metric_type = if op.is_set() {
+        ExternalMetricType::from_yang(&args.string()?)?
+    } else {
+        ExternalMetricType::default()
+    };
+    let entry = ospf
+        .areas
+        .fetch(area_id)
+        .redistribute
+        .connected
+        .get_or_insert_with(RedistEntry::default);
+    entry.metric_type = metric_type;
+    ospf.nssa_redist_connected_resync(area_id);
     Some(())
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::net::Ipv4Addr;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -117,6 +117,15 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     pub segment_routing: super::srmpls::SegmentRoutingMode,
     pub spf_last: Option<Instant>,
     pub spf_duration: Option<Duration>,
+    /// Cached snapshot of v4 routes the RIB is pushing via
+    /// `RedistAdd` subscriptions. Keyed by `(rtype, prefix)`. Today
+    /// only `RibType::Connected` is subscribed (per-area
+    /// `redistribute connected` under NSSA); future static / bgp
+    /// sources add their rtype to the same map. Updated by
+    /// `process_rib_msg`'s `RouteAdd` / `RouteDel` handlers and
+    /// consumed by `nssa_redist_connected_resync` when origination
+    /// state needs to be rebuilt (config change, area-type flip).
+    pub redist_v4: BTreeMap<(crate::rib::RibType, Ipv4Net), crate::rib::RouteEntryV4>,
     /// v3-only outbound packet channel. `Ospf<Ospfv3>::new` spawns
     /// `network_v6::write_packet_v6` consuming the matching receiver;
     /// producers of v3 outgoing packets (the v3 IFSM/NFSM, once they
@@ -393,6 +402,7 @@ impl Ospf<Ospfv2> {
             segment_routing: super::srmpls::SegmentRoutingMode::default(),
             spf_last: None,
             spf_duration: None,
+            redist_v4: BTreeMap::new(),
             sock,
             v3_send_tx: None,
             v3_recv_rx: None,
@@ -836,46 +846,47 @@ impl Ospf<Ospfv2> {
         }
     }
 
-    /// RFC 3101 §2.3 NSSA default-LSA origination. Builds a Type-7
-    /// NSSA-AS-External LSA for the default route 0.0.0.0/0 and
-    /// installs it in `area_id`'s LSDB. P-bit stays clear so the
-    /// NSSA's ABR does not translate the default into Type-5 across
-    /// the backbone — the area-internal default is the only purpose
-    /// of this LSA. Metric type 2 (E2), cost 1 by default.
+    /// Generic Type-7 NSSA-AS-External originator. Builds a Type-7
+    /// LSA for `prefix` and installs it in `area_id`'s LSDB.
     ///
-    /// Gates on: `area_id` exists, area is NSSA, and the area's
-    /// `nssa_default_originate` knob is true. Otherwise calls
-    /// `nssa_default_lsa_flush` to clear any stale self-originated
-    /// copy.
-    pub fn nssa_default_lsa_originate(&mut self, area_id: Ipv4Addr) {
-        let area_type = match self.areas.get(area_id) {
-            Some(area) => area.area_type,
-            None => return,
-        };
-        if !area_type.is_nssa() || !area_type.nssa_default_originate {
-            self.nssa_default_lsa_flush(area_id);
-            return;
-        }
-
-        let ls_id = Ipv4Addr::UNSPECIFIED;
+    /// `prefix` carries both the network address and mask; ls_id is
+    /// the prefix's network address (RFC 2328 §12.4.4 inherited by
+    /// RFC 3101). `metric_type_2 = true` sets the E-bit (E2 — metric
+    /// dominant over SPF cost); false = E1 (added to SPF cost on the
+    /// receiver). `fwd_addr = 0.0.0.0` defers FA-based path
+    /// selection on the receiver; RFC 3101 §2.5 step 5 FA
+    /// resolution lands in a follow-up.
+    ///
+    /// Caller is responsible for gating on area type / config; this
+    /// helper does not check whether origination is appropriate. The
+    /// per-prefix entry points
+    /// (`nssa_default_lsa_originate`,
+    ///  `nssa_redist_connected_originate_one`) own the policy
+    /// decision before invoking this builder.
+    fn nssa_lsa_originate_for_prefix(
+        &mut self,
+        area_id: Ipv4Addr,
+        prefix: Ipv4Net,
+        metric: u32,
+        metric_type_2: bool,
+        fwd_addr: Ipv4Addr,
+    ) {
+        let ls_id = prefix.network();
         let mut lsa_header = OspfLsaHeader::new(OspfLsType::NssaAsExternal, ls_id, self.router_id);
         // RFC 3101 §2.4 LSA header Options on Type-7: E bit MUST be
         // clear (NSSA areas can't accept Type-5); N bit set; P bit
-        // clear for ABR-originated default per §2.3.
+        // clear for ABR-originated LSAs (translation knob lands in
+        // phase 4).
         let mut options = OspfOptions::default();
         options.set_nssa(true);
         options.set_o(true);
         lsa_header.options = u8::from(options);
 
-        // E1/E2 + metric. 0x80 = E2 (type-2 metric, dominant over
-        // SPF cost). Cost defaults to 1 — there's no separate YANG
-        // knob yet; a `nssa-default-originate-cost` leaf can be
-        // added later without changing this code path.
         let body = NssaAsExternalLsa {
-            netmask: Ipv4Addr::UNSPECIFIED,
-            ext_and_tos: 0x80,
-            metric: 1,
-            forwarding_address: Ipv4Addr::UNSPECIFIED,
+            netmask: prefix.netmask(),
+            ext_and_tos: if metric_type_2 { 0x80 } else { 0x00 },
+            metric,
+            forwarding_address: fwd_addr,
             external_route_tag: 0,
             tos_list: Vec::new(),
         };
@@ -902,10 +913,11 @@ impl Ospf<Ospfv2> {
         self.flood_self_originated_lsa(area_id, &flood_lsa);
     }
 
-    /// Flush our self-originated Type-7 default LSA from `area_id`.
-    /// No-op if the area or LSA doesn't exist.
-    pub fn nssa_default_lsa_flush(&mut self, area_id: Ipv4Addr) {
-        let ls_id = Ipv4Addr::UNSPECIFIED;
+    /// Flush a single self-originated Type-7 LSA from `area_id`
+    /// keyed by `prefix.network()` as ls_id. No-op if the area or
+    /// LSA doesn't exist.
+    fn nssa_lsa_flush_for_prefix(&mut self, area_id: Ipv4Addr, prefix: Ipv4Net) {
+        let ls_id = prefix.network();
         let flushed = if let Some(area) = self.areas.get_mut(area_id) {
             area.lsdb.flush_lsa(
                 OspfLsType::NssaAsExternal,
@@ -919,6 +931,143 @@ impl Ospf<Ospfv2> {
         };
         if let Some(lsa) = flushed {
             self.flood_self_originated_lsa(area_id, &lsa);
+        }
+    }
+
+    /// RFC 3101 §2.3 NSSA default-LSA origination. Thin wrapper
+    /// around `nssa_lsa_originate_for_prefix` that gates on area
+    /// type + `nssa_default_originate` knob and calls the generic
+    /// builder with prefix=0.0.0.0/0, metric=1, E2, fwd=0.
+    pub fn nssa_default_lsa_originate(&mut self, area_id: Ipv4Addr) {
+        let area_type = match self.areas.get(area_id) {
+            Some(area) => area.area_type,
+            None => return,
+        };
+        if !area_type.is_nssa() || !area_type.nssa_default_originate {
+            self.nssa_default_lsa_flush(area_id);
+            return;
+        }
+        let default = Ipv4Net::new(Ipv4Addr::UNSPECIFIED, 0).expect("0.0.0.0/0 is valid");
+        self.nssa_lsa_originate_for_prefix(
+            area_id,
+            default,
+            /* metric */ 1,
+            /* metric_type_2 */ true,
+            /* fwd_addr */ Ipv4Addr::UNSPECIFIED,
+        );
+    }
+
+    /// Flush our self-originated Type-7 default LSA from `area_id`.
+    pub fn nssa_default_lsa_flush(&mut self, area_id: Ipv4Addr) {
+        let default = Ipv4Net::new(Ipv4Addr::UNSPECIFIED, 0).expect("0.0.0.0/0 is valid");
+        self.nssa_lsa_flush_for_prefix(area_id, default);
+    }
+
+    /// Rebuild this area's self-originated Type-7 LSAs for
+    /// redistribute-connected from the cached RIB-known v4 connected
+    /// routes (`self.redist_v4`).
+    ///
+    /// Idempotent: walks the cache and the previously-originated set,
+    /// originates any missing Type-7s (or refreshes them — metric /
+    /// metric-type may have changed) and flushes any stale ones.
+    /// Called by:
+    ///   - `RouteAdd` / `RouteDel` event from RIB (cache changed)
+    ///   - redistribute-connected presence / metric / metric-type
+    ///     config change
+    ///   - area-type set (entering or leaving NSSA)
+    pub fn nssa_redist_connected_resync(&mut self, area_id: Ipv4Addr) {
+        use crate::rib::RibType;
+
+        // Snapshot inputs to avoid holding a borrow across the
+        // originate / flush calls (both take `&mut self`).
+        let (entry, area_type, prev_originated) = {
+            let Some(area) = self.areas.get(area_id) else {
+                return;
+            };
+            (
+                area.redistribute.connected,
+                area.area_type,
+                area.redist_connected_originated.clone(),
+            )
+        };
+
+        // Compute the desired set of prefixes we should be
+        // originating right now.
+        let desired: BTreeSet<Ipv4Net> = if area_type.is_nssa()
+            && let Some(_e) = entry
+        {
+            self.redist_v4
+                .iter()
+                .filter(|((rtype, _prefix), _entry)| *rtype == RibType::Connected)
+                .map(|((_, prefix), _)| *prefix)
+                .collect()
+        } else {
+            BTreeSet::new()
+        };
+
+        // Flush previously-originated prefixes that are no longer
+        // desired.
+        for prefix in prev_originated
+            .difference(&desired)
+            .copied()
+            .collect::<Vec<_>>()
+        {
+            self.nssa_lsa_flush_for_prefix(area_id, prefix);
+            if let Some(area) = self.areas.get_mut(area_id) {
+                area.redist_connected_originated.remove(&prefix);
+            }
+        }
+
+        // Re-originate all currently desired prefixes — covers
+        // both first-time origination and refresh after a metric /
+        // metric-type change.
+        if let Some(redist_entry) = entry
+            && area_type.is_nssa()
+        {
+            for prefix in &desired {
+                self.nssa_lsa_originate_for_prefix(
+                    area_id,
+                    *prefix,
+                    redist_entry.metric,
+                    redist_entry.metric_type.is_type_2(),
+                    Ipv4Addr::UNSPECIFIED,
+                );
+                if let Some(area) = self.areas.get_mut(area_id) {
+                    area.redist_connected_originated.insert(*prefix);
+                }
+            }
+        }
+    }
+
+    /// `RibRx::RouteAdd` handler. Update the cache, then nudge
+    /// every NSSA area to resync. Per-area filtering happens inside
+    /// `nssa_redist_connected_resync`.
+    fn route_redist_add(&mut self, rtype: crate::rib::RibType, batch: crate::rib::RouteBatch) {
+        if let crate::rib::RouteBatch::V4(entries) = batch {
+            for e in entries {
+                self.redist_v4.insert((rtype, e.prefix), e);
+            }
+        }
+        // v6 batches arrive only for v3 subscriptions, which this
+        // v2 instance doesn't issue today.
+
+        let area_ids: Vec<Ipv4Addr> = self.areas.iter().map(|(&id, _)| id).collect();
+        for area_id in area_ids {
+            self.nssa_redist_connected_resync(area_id);
+        }
+    }
+
+    /// `RibRx::RouteDel` handler. Mirror of `route_redist_add`.
+    fn route_redist_del(&mut self, rtype: crate::rib::RibType, batch: crate::rib::RouteBatch) {
+        if let crate::rib::RouteBatch::V4(entries) = batch {
+            for e in entries {
+                self.redist_v4.remove(&(rtype, e.prefix));
+            }
+        }
+
+        let area_ids: Vec<Ipv4Addr> = self.areas.iter().map(|(&id, _)| id).collect();
+        for area_id in area_ids {
+            self.nssa_redist_connected_resync(area_id);
         }
     }
 
@@ -1993,6 +2142,17 @@ impl Ospf<Ospfv2> {
             RibRx::AddrDel(addr) => {
                 self.addr_del(addr);
             }
+            // Redistribute delivery. Today only `Connected` is
+            // subscribed (per-area NSSA redistribute connected); the
+            // handler updates the cache and resyncs Type-7 LSAs in
+            // every NSSA area whose `redistribute connected` knob
+            // is set.
+            RibRx::RouteAdd { rtype, routes, .. } => {
+                self.route_redist_add(rtype, routes);
+            }
+            RibRx::RouteDel { rtype, routes, .. } => {
+                self.route_redist_del(rtype, routes);
+            }
             _ => {
                 //
             }
@@ -2131,6 +2291,7 @@ impl Ospf<Ospfv3> {
             segment_routing: super::srmpls::SegmentRoutingMode::default(),
             spf_last: None,
             spf_duration: None,
+            redist_v4: BTreeMap::new(),
             sock,
             v3_send_tx: Some(v3_send_tx),
             v3_recv_rx: Some(v3_recv_rx),

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -370,6 +370,34 @@ module config {
             }
             default candidate;
           }
+          // Per-NSSA-area redistribute knobs. Type-7 LSAs are
+          // area-scoped, so the source proto is selected per area
+          // (an operator may inject `connected` into one NSSA and
+          // not another). Each sibling container is a presence node
+          // — its existence enables redistribution of that source.
+          // Ignored unless area-type is `nssa`. The metric and
+          // metric-type leaves are consumer-side overrides: metric
+          // defaults to 20 (matching FRR), metric-type defaults to
+          // 2 (E2). Type-1 (E1) lifts the SPF cost to the originator
+          // and adds the LSA metric; Type-2 uses LSA metric alone.
+          container redistribute {
+            container connected {
+              presence "Redistribute connected routes into Type-7";
+              leaf metric {
+                type uint32 {
+                  range "0..16777214";
+                }
+                default 20;
+              }
+              leaf metric-type {
+                type enumeration {
+                  enum type-1;
+                  enum type-2;
+                }
+                default type-2;
+              }
+            }
+          }
           list interface {
             key "if-name";
             leaf if-name {
@@ -553,6 +581,28 @@ module config {
               enum never;
             }
             default candidate;
+          }
+          // Same shape as the v2 sibling above. Storage-only on v3
+          // until phase 5/6 lights up Type-0x2007 origination — the
+          // schema lives here today so v3 callers don't see a
+          // schema drift between v2 and v3 NSSA config surfaces.
+          container redistribute {
+            container connected {
+              presence "Redistribute connected routes into Type-7";
+              leaf metric {
+                type uint32 {
+                  range "0..16777214";
+                }
+                default 20;
+              }
+              leaf metric-type {
+                type enumeration {
+                  enum type-1;
+                  enum type-2;
+                }
+                default type-2;
+              }
+            }
           }
           list interface {
             key "if-name";


### PR DESCRIPTION
## Summary

Phase 2c.1 + 2c.2 of v2+v3 NSSA support. Per-area \`redistribute connected\` knob under NSSA areas, with a generic Type-7 LSA builder that the default-originate path now also delegates to. End-to-end loop: configure NSSA + redistribute connected, and a neighbor router's RIB receives every connected prefix on this router as Type-7 NSSA-AS-External.

**Generic Type-7 builder (2c.1)**
- New \`nssa_lsa_originate_for_prefix(area_id, prefix, metric, metric_type_2, fwd_addr)\` + \`nssa_lsa_flush_for_prefix\`. ls_id is \`prefix.network()\` (RFC 2328 §12.4.4).
- \`nssa_default_lsa_originate\` is now a thin wrapper that delegates with prefix=0.0.0.0/0, metric=1, E2 — phase-2 behavior preserved.

**YANG + storage**
- Per-area \`container redistribute / container connected\` (presence) with \`metric\` (default 20) and \`metric-type\` (\`type-1\` / \`type-2\`, default \`type-2\`). Added to both \`container ospf\` and \`container ospfv3\`; v3 storage-only until phase 5/6.
- \`AreaRedistribute\`, \`RedistEntry\`, \`ExternalMetricType\` in \`area.rs\`.
- Per-area \`redist_connected_originated: BTreeSet<Ipv4Net>\` for flush bookkeeping.

**RIB subscription (2c.2)**
- \`Ospf.redist_v4\` cache mirrors IS-IS's pattern.
- \`ospf_send_redist_connected\` emits \`RedistAdd / RedistUpdate / RedistDel\` based on whether any NSSA area on this router has the knob set. Single subscription shared across NSSA areas.
- \`process_rib_msg\` handles \`RouteAdd / RouteDel\`, updates the cache, calls \`nssa_redist_connected_resync\` per area.

**Resync semantics**
- \`nssa_redist_connected_resync(area_id)\` compares the cached connected set against the area's previously-originated tracking set; flushes stale Type-7s, originates new / refreshed ones. Idempotent.
- Hooked into: area-type config change, redistribute/connected presence + sub-leaf changes, every RouteAdd/RouteDel.

**Out of scope**: static / bgp redistribute sources (phase 2c.3), prefix-collision handling (different masks, same network address), v3 origination (phase 5/6).

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --exclude bdd\`
- [ ] FRR interop: two-router NSSA with \`redistribute connected\` on one; verify each connected prefix appears as N1/N2 in the peer's \`show ip route\`
- [ ] Toggle the redistribute knob on/off; verify Type-7s appear and flush cleanly

Generated with [Claude Code](https://claude.com/claude-code)