### PR TITLE
ospf: helper-mode config + show ip ospf graceful-restart (v2)

### DIFF
--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -107,6 +107,18 @@ impl Ospf {
             config_ospf_interface_adjacency_sid_absolute,
         );
         self.ospf_add("/segment-routing/mpls", config_ospf_sr_mpls);
+        self.ospf_add(
+            "/graceful-restart/helper-enabled",
+            config_ospf_gr_helper_enabled,
+        );
+        self.ospf_add(
+            "/graceful-restart/max-grace-period",
+            config_ospf_gr_max_grace_period,
+        );
+        self.ospf_add(
+            "/graceful-restart/helper-strict-lsa-checking",
+            config_ospf_gr_helper_strict_lsa_checking,
+        );
         self.tracing_add("/fsm", config_tracing_fsm);
         self.tracing_add("/packet", config_tracing_packet);
     }
@@ -824,5 +836,37 @@ fn config_ospf_sr_mpls(ospf: &mut Ospf, _args: Args, op: ConfigOp) -> Option<()>
         ospf.ext_link_lsa_originate(ifindex);
     }
 
+    Some(())
+}
+
+/// `router ospf / graceful-restart / helper-enabled`. Toggles
+/// whether `gr_maybe_enter_helper` accepts inbound Grace LSAs.
+/// On disable, existing helpers are left intact — they'll exit on
+/// grace-period expiry or topology change as normal.
+fn config_ospf_gr_helper_enabled(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let value = if op.is_set() { args.boolean()? } else { true };
+    ospf.gr_config.helper_enabled = value;
+    Some(())
+}
+
+/// `router ospf / graceful-restart / max-grace-period`. RFC 3623
+/// §3.1 leaves the bound to the helper's policy; we enforce it at
+/// helper-entry validation.
+fn config_ospf_gr_max_grace_period(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let value = if op.is_set() { args.u32()? } else { 1800 };
+    ospf.gr_config.max_grace_period = value;
+    Some(())
+}
+
+/// `router ospf / graceful-restart / helper-strict-lsa-checking`.
+/// When false, only the restarter's own LSAs trigger
+/// topology-change exit (RFC 3623 §3.2 relaxation).
+fn config_ospf_gr_helper_strict_lsa_checking(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let value = if op.is_set() { args.boolean()? } else { true };
+    ospf.gr_config.helper_strict_lsa_checking = value;
     Some(())
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -116,6 +116,10 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     pub rib6: PrefixMap<ipnet::Ipv6Net, SpfRouteV3>,
     pub tracing: OspfTracing,
     pub segment_routing: super::srmpls::SegmentRoutingMode,
+    /// Per-instance graceful-restart helper policy (RFC 3623 §3.1).
+    /// Defaults: helper enabled, max grace 1800s, strict LSA
+    /// checking on — same as the YANG model's defaults.
+    pub gr_config: super::neigh::GracefulRestartConfig,
     pub spf_last: Option<Instant>,
     pub spf_duration: Option<Duration>,
     /// Cached snapshot of v4 routes the RIB is pushing via
@@ -181,6 +185,10 @@ pub struct OspfInterface<'a, V: OspfVersion = Ospfv2> {
     /// so every send path can `fetch_add(1)` without taking `&mut`
     /// on the surrounding `OspfLink`.
     pub md5_seq: &'a std::sync::atomic::AtomicU32,
+    /// Snapshot of the per-instance graceful-restart helper
+    /// policy. Read by `gr_maybe_enter_helper` to gate Grace-LSA
+    /// acceptance against `helper_enabled` and `max_grace_period`.
+    pub gr_config: super::neigh::GracefulRestartConfig,
     pub tracing: &'a OspfTracing,
     /// v3-only outbound packet channel borrow. Carries the `Ospfv3Send`
     /// sender that the `network_v6::write_packet_v6` task consumes.
@@ -255,6 +263,7 @@ impl<V: OspfVersion> Ospf<V> {
                             auth_key,
                             md5_key,
                             md5_seq: &link.md5_seq,
+                            gr_config: self.gr_config,
                             tracing: &self.tracing,
                             v3_send_tx: self.v3_send_tx.as_ref(),
                             link_lsdb: &mut link.lsdb,
@@ -430,6 +439,7 @@ impl Ospf<Ospfv2> {
             rib6: PrefixMap::new(),
             tracing: OspfTracing::default(),
             segment_routing: super::srmpls::SegmentRoutingMode::default(),
+            gr_config: super::neigh::GracefulRestartConfig::default(),
             spf_last: None,
             spf_duration: None,
             redist_v4: BTreeMap::new(),
@@ -1651,8 +1661,12 @@ impl Ospf<Ospfv2> {
                         }
                         _ => "restarter LSA changed from snapshot",
                     }
-                } else {
+                } else if self.gr_config.helper_strict_lsa_checking {
                     "non-restarter topology change in area"
+                } else {
+                    // Strict-LSA-checking disabled — ignore non-restarter
+                    // topology changes per `helper-strict-lsa-checking false`.
+                    continue;
                 };
                 exits.push((ifindex, nbr.ident.router_id, exit_reason));
             }
@@ -2429,6 +2443,7 @@ impl Ospf<Ospfv3> {
             rib6: PrefixMap::new(),
             tracing: OspfTracing::default(),
             segment_routing: super::srmpls::SegmentRoutingMode::default(),
+            gr_config: super::neigh::GracefulRestartConfig::default(),
             spf_last: None,
             spf_duration: None,
             redist_v4: BTreeMap::new(),

--- a/zebra-rs/src/ospf/neigh.rs
+++ b/zebra-rs/src/ospf/neigh.rs
@@ -12,6 +12,36 @@ use super::task::Timer;
 use super::version::{OspfVersion, Ospfv2};
 use super::{Identity, Message, NfsmEvent, NfsmState};
 
+/// Per-instance graceful-restart helper policy. Mirrors the YANG
+/// `router/ospf/graceful-restart` container; defaults match the
+/// IETF model (`ietf-ospf@2022-10-19.yang`).
+#[derive(Debug, Clone, Copy)]
+pub struct GracefulRestartConfig {
+    /// When false, the Grace-LSA receive path rejects every Grace
+    /// LSA — helper mode is never entered.
+    pub helper_enabled: bool,
+    /// Upper bound on the grace period we will honour (seconds).
+    /// RFC 3623 §3.1 leaves the bound to the helper.
+    pub max_grace_period: u32,
+    /// When true, any topology-affecting LSA from a non-restarter
+    /// that floods through the helper's area exits helper
+    /// immediately (RFC 3623 §3.2). When false, only the
+    /// restarter's own LSAs trigger exit — useful for noisy
+    /// environments where transient changes shouldn't cut the
+    /// restart short.
+    pub helper_strict_lsa_checking: bool,
+}
+
+impl Default for GracefulRestartConfig {
+    fn default() -> Self {
+        Self {
+            helper_enabled: true,
+            max_grace_period: 1800,
+            helper_strict_lsa_checking: true,
+        }
+    }
+}
+
 /// Graceful-restart helper bookkeeping (RFC 3623 §3.1). Populated
 /// when we accept a Grace LSA from this neighbor; absent the rest
 /// of the time. While `Some`, the inactivity timer is suppressed

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -20,13 +20,6 @@ use super::{
     ospf_is_self_originated, ospf_ls_request_lookup, tracing::OspfTracing,
 };
 
-/// Maximum grace period (seconds) we will honour as helper. RFC 3623
-/// §3.1 leaves the bound up to the helper; this matches the IETF
-/// YANG default (`max-grace-period`) and FRR's `ip ospf
-/// graceful-restart helper grace-period` default. Phase 4 exposes
-/// this as a per-instance config knob.
-const MAX_GRACE_PERIOD_SECS: u32 = 1800;
-
 /// Resolved authentication state for a single outbound packet.
 /// Built by `OspfLink::auth_send_ctx()` and
 /// `OspfInterface::auth_send_ctx()` — both pre-bump the link's
@@ -1033,6 +1026,13 @@ fn gr_maybe_enter_helper(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfL
     if lsa.h.adv_router != nbr.ident.router_id {
         return;
     }
+    if !oi.gr_config.helper_enabled {
+        tracing::info!(
+            "[GR Helper] reject Grace LSA from nbr {} (helper-enabled is false)",
+            nbr.ident.router_id
+        );
+        return;
+    }
     if nbr.state != NfsmState::Full {
         tracing::info!(
             "[GR Helper] reject Grace LSA from non-Full nbr {} (state={:?})",
@@ -1041,14 +1041,15 @@ fn gr_maybe_enter_helper(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfL
         );
         return;
     }
+    let max_grace = oi.gr_config.max_grace_period;
     let grace_period = match body.grace_period() {
-        Some(p) if p > 0 && p <= MAX_GRACE_PERIOD_SECS => p,
+        Some(p) if p > 0 && p <= max_grace => p,
         Some(p) => {
             tracing::info!(
                 "[GR Helper] reject Grace LSA from nbr {} (grace={}s out of [1, {}])",
                 nbr.ident.router_id,
                 p,
-                MAX_GRACE_PERIOD_SECS
+                max_grace
             );
             return;
         }

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -181,6 +181,7 @@ impl Ospf {
         self.show_add("/show/ip/ospf/spf", show_ospf_spf);
         self.show_add("/show/ip/ospf/graph", show_ospf_graph);
         self.show_add("/show/ip/ospf/segment-routing", show_ospf_segment_routing);
+        self.show_add("/show/ip/ospf/graceful-restart", show_ospf_graceful_restart);
     }
 }
 
@@ -1726,4 +1727,58 @@ fn show_ospf_graph(
         }
         Ok(buf)
     }
+}
+
+/// `show ip ospf graceful-restart` (RFC 3623 helper status).
+/// Renders the instance-wide policy followed by a per-neighbor
+/// table of currently-active helper sessions. Plain-text only
+/// for now — the JSON shape can land in 2c-iii alongside
+/// helper-history.
+fn show_ospf_graceful_restart(
+    ospf: &Ospf,
+    _args: Args,
+    _json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let mut buf = String::new();
+    let cfg = &ospf.gr_config;
+
+    writeln!(buf, "Graceful-restart helper configuration:")?;
+    writeln!(buf, "  Helper enabled: {}", cfg.helper_enabled)?;
+    writeln!(buf, "  Max grace period: {}s", cfg.max_grace_period)?;
+    writeln!(
+        buf,
+        "  Strict LSA checking: {}",
+        cfg.helper_strict_lsa_checking
+    )?;
+    writeln!(buf)?;
+
+    let mut any = false;
+    writeln!(
+        buf,
+        "{:<15} {:<10} {:<22} {:<14} {:<10}",
+        "Neighbor ID", "Interface", "Restart Reason", "Grace Period", "Remaining"
+    )?;
+    for (ifindex, link) in ospf.links.iter() {
+        for nbr in link.nbrs.values() {
+            let Some(helper) = nbr.gr_helper.as_ref() else {
+                continue;
+            };
+            any = true;
+            let elapsed = helper.entered_at.elapsed().as_secs() as u32;
+            let remaining = helper.grace_period.saturating_sub(elapsed);
+            writeln!(
+                buf,
+                "{:<15} {:<10} {:<22} {:<14} {:<10}",
+                nbr.ident.router_id.to_string(),
+                format!("if{}", ifindex),
+                format!("{:?}", helper.reason),
+                format!("{}s", helper.grace_period),
+                format!("{}s", remaining),
+            )?;
+        }
+    }
+    if !any {
+        writeln!(buf, "  (no active helpers)")?;
+    }
+    Ok(buf)
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -460,6 +460,42 @@ module config {
             presence "Enable Segment Routing over MPLS dataplane";
           }
         }
+        container graceful-restart {
+          // RFC 3623 helper-side configuration. zebra-rs is
+          // helper-only today (Phase 5 restarter mode is deferred).
+          // Defaults match the IETF YANG model
+          // (ietf-ospf@2022-10-19.yang) and FRR's helper defaults.
+          leaf helper-enabled {
+            type boolean;
+            default true;
+            description
+              "Accept Grace LSAs and enter helper mode. When false,
+               the Grace-LSA receive path drops every Grace LSA
+               regardless of grace-period / strict-lsa-checking
+               state.";
+          }
+          leaf max-grace-period {
+            type uint32;
+            units seconds;
+            default 1800;
+            description
+              "Upper bound on the grace period we will honour. A
+               Grace LSA requesting more than this value is
+               rejected (RFC 3623 §3.1 leaves the bound to the
+               helper's policy).";
+          }
+          leaf helper-strict-lsa-checking {
+            type boolean;
+            default true;
+            description
+              "When true, any topology-affecting LSA from a
+               non-restarter that floods through the helper's area
+               exits helper immediately (RFC 3623 §3.2). When
+               false, only the restarter's own LSAs trigger exit —
+               useful when transient changes elsewhere shouldn't
+               cut the restart short.";
+          }
+        }
         container tracing {
           leaf all {
             type boolean;

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -286,6 +286,10 @@ module exec {
         leaf segment-routing {
           type empty;
         }
+        leaf graceful-restart {
+          ext:help "OSPF graceful-restart helper status";
+          type empty;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Phase 2c-ii — closes out OSPFv2 graceful-restart helper mode functionally. Adds the YANG config-surface, threads it into the validator + topology-exit logic, and exposes inspectable runtime state.

- **YANG schema** (`config.yang`): `router/ospf/graceful-restart` container with `helper-enabled` (default true), `max-grace-period` (default 1800s, units seconds), `helper-strict-lsa-checking` (default true). Defaults match the IETF model (`ietf-ospf@2022-10-19.yang`).
- **`GracefulRestartConfig`** stored on `Ospf<V>` and snapshotted into `OspfInterface` so `gr_maybe_enter_helper` can gate Grace-LSA acceptance on `helper_enabled` and enforce `max_grace_period` per-instance (replaces the hardcoded `MAX_GRACE_PERIOD_SECS`).
- **`gr_helper_check_exit`** honours `helper_strict_lsa_checking`: when false, only restarter-originated LSAs trigger exit (non-restarter topology changes ignored — useful for noisy environments).
- **`show ip ospf graceful-restart`** (exec.yang + show.rs): prints instance policy then a per-neighbor table of active helper sessions — neighbor router-id, interface, restart reason, grace period, remaining time.

Phase 2 (v2 helper) is now functionally complete:
- 2a (#864): detection + inactivity-timer suppression.
- 2b (#867): GR-helper capability bit + LSA-invariant comments.
- 2c-i (#869): topology-change exit with LSDB snapshot.
- 2c-ii (this PR): config + show.

## Test plan

- [x] `cargo fmt && cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --exclude bdd` — zero regressions.
- [ ] FRR-peer test of helper mode end-to-end (restart FRR ospfd; verify our adjacency stays Full, route through the restarter stays installed, `show ip ospf graceful-restart` lists the helper, exit fires on grace expiry / topology change). Deferred to manual validation per `[[zebra-rs-ospf-v2-frr-validated]]` scaffolding.

## Phase 3 next

OSPFv3 helper mode mirrors the v2 shape against `packet_v3.rs` + the v3 LSA types, sharing the `HelperState` / config structs from this PR.

Generated with [Claude Code](https://claude.com/claude-code)