### PR TITLE
ospf: helper-mode detection + topology-change exit (v3)

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -2993,6 +2993,106 @@ impl Ospf<Ospfv3> {
 
     /// Flood a v3 LSA through `area_id`, optionally exempting the
     /// source neighbor that fed it to us (RFC 2328 §13.3 Step 1c).
+    /// RFC 5187 §3.2 bullets 2-3 — v3 mirror of
+    /// `Ospf<Ospfv2>::gr_helper_check_exit`. Called from
+    /// `flood_lsa_through_area` after each area-LSA install. For
+    /// each helper-mode neighbor in the area, decide whether the
+    /// install warrants exit:
+    ///
+    ///   - `advertising_router != restarter`: any topology-affecting
+    ///     LSA is an exit trigger when `helper_strict_lsa_checking`.
+    ///     When that knob is off (relaxed mode), non-restarter
+    ///     LSAs are ignored.
+    ///   - `advertising_router == restarter`: compare against the
+    ///     `(seq, checksum)` we snapshotted at helper entry. Exact
+    ///     match → quiescent re-flood (no exit). Differs → exit.
+    ///
+    /// Topology-affecting v3 LS Types: Router (0x2001), Network
+    /// (0x2002), Inter-Area-Prefix (0x2003), Inter-Area-Router
+    /// (0x2004), Intra-Area-Prefix (0x2009). All other LSAs (Link,
+    /// AS-External, Grace, the RFC 8362 E-LSAs) are ignored
+    /// because they don't change intra-area routing.
+    fn gr_helper_check_exit(&mut self, area_id: Ipv4Addr, lsa: &ospf_packet::Ospfv3Lsa) {
+        use ospf_packet::{
+            OSPFV3_INTER_AREA_PREFIX_LSA_TYPE, OSPFV3_INTER_AREA_ROUTER_LSA_TYPE,
+            OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE, OSPFV3_NETWORK_LSA_TYPE, OSPFV3_ROUTER_LSA_TYPE,
+        };
+
+        let topology_affecting = matches!(
+            lsa.h.ls_type,
+            OSPFV3_ROUTER_LSA_TYPE
+                | OSPFV3_NETWORK_LSA_TYPE
+                | OSPFV3_INTER_AREA_PREFIX_LSA_TYPE
+                | OSPFV3_INTER_AREA_ROUTER_LSA_TYPE
+                | OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE
+        );
+        if !topology_affecting {
+            return;
+        }
+        // v3 LSDB key shape: `(ls_type: u16, link_state_id: u32,
+        // advertising_router: Ipv4Addr)`. No conversion needed —
+        // these fields are already in their key-native form.
+        let key: super::lsdb::OspfLsaKey =
+            (lsa.h.ls_type, lsa.h.link_state_id, lsa.h.advertising_router);
+
+        let Some(area) = self.areas.get(area_id) else {
+            return;
+        };
+        let link_indices: Vec<u32> = area.links.iter().copied().collect();
+
+        let mut exits: Vec<(u32, Ipv4Addr, &'static str)> = Vec::new();
+        for ifindex in link_indices {
+            let Some(link) = self.links.get(&ifindex) else {
+                continue;
+            };
+            for nbr in link.nbrs.values() {
+                let Some(helper) = nbr.gr_helper.as_ref() else {
+                    continue;
+                };
+                let exit_reason = if lsa.h.advertising_router == nbr.ident.router_id {
+                    match helper.lsdb_snapshot.get(&key) {
+                        Some(&(seq, csum))
+                            if seq == lsa.h.ls_seq_number && csum == lsa.h.ls_checksum =>
+                        {
+                            continue;
+                        }
+                        _ => "restarter LSA changed from snapshot",
+                    }
+                } else if self.gr_config.helper_strict_lsa_checking {
+                    "non-restarter topology change in area"
+                } else {
+                    continue;
+                };
+                exits.push((ifindex, nbr.ident.router_id, exit_reason));
+            }
+        }
+        for (ifindex, router_id, reason) in exits {
+            // v3 reuses v2's gr_helper_exit body verbatim — clear
+            // helper state, fire `InactivityTimer` event so the
+            // shared NFSM kill path runs.
+            let Some(link) = self.links.get_mut(&ifindex) else {
+                continue;
+            };
+            let Some(nbr) = link.nbrs.get_mut(&router_id) else {
+                continue;
+            };
+            if nbr.gr_helper.take().is_none() {
+                continue;
+            }
+            tracing::info!(
+                "[GR Helper v3] exit for nbr {} on ifindex={} (reason: {})",
+                router_id,
+                ifindex,
+                reason
+            );
+            let _ = self.tx.send(Message::Nfsm(
+                ifindex,
+                router_id,
+                super::nfsm::NfsmEvent::InactivityTimer,
+            ));
+        }
+    }
+
     /// Mirrors v2's `flood_lsa_through_area`.
     ///
     /// `source = None` is the self-origination path: every
@@ -3015,6 +3115,14 @@ impl Ospf<Ospfv3> {
         source: Option<(u32, std::net::Ipv6Addr)>,
     ) {
         use ospf_packet::{Ospfv3LsUpdate, Ospfv3Packet, Ospfv3Payload};
+
+        // RFC 5187 §3.2 — every LSA flooded here was just installed
+        // in the area LSDB, so this is the v3 choke point for the
+        // topology-change helper exit (mirror of v2's hook in
+        // `Ospf<Ospfv2>::flood_lsa_through_area`). Runs before the
+        // fanout iteration so an exit can deconstruct any state
+        // we'd otherwise loop over.
+        self.gr_helper_check_exit(area_id, lsa);
 
         let Some(tx) = self.v3_send_tx.as_ref().cloned() else {
             return;
@@ -3358,6 +3466,9 @@ impl Ospf<Ospfv3> {
                     }
                 }
             }
+            Message::GrHelperExpire(ifindex, router_id) => {
+                self.gr_helper_expire(ifindex, router_id);
+            }
             other => {
                 tracing::debug!(
                     "v3 process_msg: unhandled variant {:?}",
@@ -3365,6 +3476,31 @@ impl Ospf<Ospfv3> {
                 );
             }
         }
+    }
+
+    /// v3 mirror of `Ospf<Ospfv2>::gr_helper_expire`. Same body —
+    /// clear `gr_helper` and re-fire `InactivityTimer` so the
+    /// shared NFSM kill path runs.
+    fn gr_helper_expire(&mut self, ifindex: u32, router_id: Ipv4Addr) {
+        let Some(link) = self.links.get_mut(&ifindex) else {
+            return;
+        };
+        let Some(nbr) = link.nbrs.get_mut(&router_id) else {
+            return;
+        };
+        if nbr.gr_helper.take().is_none() {
+            return;
+        }
+        tracing::info!(
+            "[GR Helper v3] grace-period expired for nbr {} on ifindex={}, killing neighbor",
+            router_id,
+            ifindex
+        );
+        let _ = self.tx.send(Message::Nfsm(
+            ifindex,
+            router_id,
+            super::nfsm::NfsmEvent::InactivityTimer,
+        ));
     }
 
     /// Originate this router's Link-LSA for `ifindex` into the

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -893,6 +893,127 @@ fn ospfv3_is_self_originated(oi: &OspfInterface<Ospfv3>, lsa: &Ospfv3Lsa) -> boo
     lsa.h.advertising_router == *oi.router_id
 }
 
+/// RFC 5187 §3.1 helper-entry gate (v3 mirror of v2's
+/// `gr_maybe_enter_helper` in packet.rs). Called from
+/// `ospfv3_ls_upd_proc` after a Grace LSA from this neighbor has
+/// been installed in the link-scope LSDB.
+///
+/// Same checks as v2: the LSA must be the v3 Grace-LSA type
+/// (`OSPFV3_GRACE_LSA_TYPE = 0x000B`), `advertising_router` must
+/// match the neighbor, helper-mode must be enabled by config, the
+/// neighbor must currently be Full, and the grace period must be
+/// within `[1, gr_config.max_grace_period]`.
+///
+/// On accept: arm the one-shot expiry timer, snapshot the
+/// restarter's pre-restart LSAs from the area LSDB (so
+/// `gr_helper_check_exit` in `impl Ospf<Ospfv3>` can run the
+/// topology-change exit), and stash the resulting `HelperState`
+/// on the neighbor.
+fn gr_maybe_enter_helper_v3(
+    oi: &mut OspfInterface<Ospfv3>,
+    nbr: &mut Neighbor<Ospfv3>,
+    lsa: &Ospfv3Lsa,
+) {
+    use std::collections::BTreeMap;
+
+    use ospf_packet::{GraceRestartReason, OSPFV3_GRACE_LSA_TYPE, Ospfv3LsBody};
+
+    use super::neigh::HelperState;
+    use super::task::{Timer, TimerType};
+
+    if lsa.h.ls_type != OSPFV3_GRACE_LSA_TYPE {
+        return;
+    }
+    let Ospfv3LsBody::Grace(ref body) = lsa.body else {
+        return;
+    };
+    if lsa.h.advertising_router != nbr.ident.router_id {
+        return;
+    }
+    if !oi.gr_config.helper_enabled {
+        tracing::info!(
+            "[GR Helper v3] reject Grace LSA from nbr {} (helper-enabled is false)",
+            nbr.ident.router_id
+        );
+        return;
+    }
+    if nbr.state != NfsmState::Full {
+        tracing::info!(
+            "[GR Helper v3] reject Grace LSA from non-Full nbr {} (state={:?})",
+            nbr.ident.router_id,
+            nbr.state
+        );
+        return;
+    }
+    let max_grace = oi.gr_config.max_grace_period;
+    let grace_period = match body.grace_period() {
+        Some(p) if p > 0 && p <= max_grace => p,
+        Some(p) => {
+            tracing::info!(
+                "[GR Helper v3] reject Grace LSA from nbr {} (grace={}s out of [1, {}])",
+                nbr.ident.router_id,
+                p,
+                max_grace
+            );
+            return;
+        }
+        None => {
+            tracing::info!(
+                "[GR Helper v3] reject Grace LSA from nbr {} (no GracePeriod TLV)",
+                nbr.ident.router_id
+            );
+            return;
+        }
+    };
+    let reason = body.reason().unwrap_or(GraceRestartReason::Unknown);
+
+    let ifindex = nbr.ifindex;
+    let router_id = nbr.ident.router_id;
+    let tx = oi.tx.clone();
+    let expire_timer = Timer::new(
+        Timer::second(grace_period as u64),
+        TimerType::Once,
+        move || {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send(Message::GrHelperExpire(ifindex, router_id));
+            }
+        },
+    );
+
+    // RFC 5187 §3.2 snapshot — same shape as v2. Captures the
+    // `(ls_seq_number, ls_checksum)` of every restarter-originated
+    // LSA in the area LSDB at helper entry, so the v3
+    // `gr_helper_check_exit` can diff later installs.
+    let mut lsdb_snapshot = BTreeMap::new();
+    for (key, lsa) in oi.lsdb.tables.iter() {
+        if lsa.data.h.advertising_router == router_id {
+            lsdb_snapshot.insert(*key, (lsa.data.h.ls_seq_number, lsa.data.h.ls_checksum));
+        }
+    }
+
+    let previously_helping = nbr.gr_helper.is_some();
+    nbr.gr_helper = Some(HelperState {
+        reason,
+        grace_period,
+        entered_at: tokio::time::Instant::now(),
+        expire_timer: Some(expire_timer),
+        lsdb_snapshot,
+    });
+    tracing::info!(
+        "[GR Helper v3] {} for nbr {} on ifindex={} (grace={}s, reason={:?})",
+        if previously_helping {
+            "extend"
+        } else {
+            "enter"
+        },
+        router_id,
+        ifindex,
+        grace_period,
+        reason
+    );
+}
+
 /// RFC 2328 §13.1 per-LSA processing result.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LsaProcessResult {
@@ -985,6 +1106,13 @@ fn ospfv3_ls_upd_proc(
         if area_lsa_installed {
             let _ = oi.tx.send(Message::SpfSchedule(Some(area_id)));
         }
+
+        // RFC 5187 §3.1: a Grace LSA from a Full neighbor advertising
+        // its own router-id is the trigger to enter helper mode. Like
+        // v2's `gr_maybe_enter_helper`, this runs after the LSA has
+        // been installed so the standard flood machinery still
+        // propagates it on the link.
+        gr_maybe_enter_helper_v3(oi, nbr, lsa);
 
         // RFC 2328 §13.3: re-flood the LSA to every other
         // Exchange-or-later neighbor in the area, exempting the


### PR DESCRIPTION
## Summary

Phase 3-i — OSPFv3 mirror of the v2 helper plumbing landed in #864 (detection + inactivity suppression) and #869 (topology-change exit). The shared structs (`HelperState`, `GracefulRestartConfig`) and the inactivity-timer suppression in `ospf_nfsm_inactivity_timer<V>` already work for v3 generically, so this PR is the v3-specific wire detection + flood-path hook only.

- **`gr_maybe_enter_helper_v3`** in `packet_v3.rs` — invoked from `ospfv3_ls_upd_proc` after a newer LSA is installed. Same validation as v2: LSA must be `OSPFV3_GRACE_LSA_TYPE` (0x000B), `advertising_router == nbr.router_id`, helper-mode enabled by config, neighbor Full, grace period in `[1, max_grace_period]`. On accept: arm the one-shot expiry timer, snapshot restarter's LSAs from the area LSDB.
- **`Ospf<Ospfv3>::gr_helper_check_exit`** — called at the top of v3's `flood_lsa_through_area`. Same exit logic as v2; the topology-affecting LSA filter uses v3 codes (Router 0x2001, Network 0x2002, Inter-Area-Prefix 0x2003, Inter-Area-Router 0x2004, Intra-Area-Prefix 0x2009). Link / AS-External / Grace / E-LSAs are ignored — they don't change intra-area routing.
- **`Ospf<Ospfv3>::gr_helper_expire`** + `Message::GrHelperExpire` dispatch arm in v3 `process_msg` — verbatim mirror so grace-period expiry runs the kill path on v3 neighbors too.

`show ip ospf graceful-restart` from Phase 2c-ii iterates `self.links` generically; it will print v3 helper state once the v3 CLI plumbing lands. No new show code here.

## Test plan

- [x] `cargo fmt && cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --exclude bdd` — zero regressions.
- [ ] FRR ospf6d-peer test of helper mode end-to-end (deferred to manual validation; the v3 driver is `#[allow(dead_code)]` until `main.rs` learns to spawn it).

## What's next

This closes the planned Phase 3 work — there's no 3-ii equivalent of v2's 2c-ii because the config + show plumbing is already V-generic. Per the design doc, the next slice would be Phase 5 (restarting-router mode), which has been explicitly deferred since it requires LSDB / route-table checkpointing infrastructure that doesn't exist in zebra-rs today.

Generated with [Claude Code](https://claude.com/claude-code)