### PR TITLE
ospf: per-interface RFC 8177 key-chain authentication

### DIFF
--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -31,6 +31,14 @@ impl Ospf {
             .insert(format!("{}{}", Self::TRACING, path), cb);
     }
 
+    /// Register a callback against a literal config path (no
+    /// `/router/ospf` prefix). Used for shared top-level subtrees
+    /// like `/key-chains` that aren't OSPF-specific on the wire
+    /// but get a per-daemon copy of the data.
+    pub fn callback_add(&mut self, path: &str, cb: Callback) {
+        self.callbacks.insert(path.to_string(), cb);
+    }
+
     pub fn callback_build(&mut self) {
         self.ospf_add("/router-id", config_ospf_router_id);
         self.ospf_add("/area/area-type", config_ospf_area_type);
@@ -85,6 +93,43 @@ impl Ospf {
         self.ospf_add(
             "/area/interface/authentication-key",
             config_ospf_interface_authentication_key,
+        );
+        self.ospf_add("/area/interface/key-chain", config_ospf_interface_key_chain);
+        // Global /key-chains/... — OSPF keeps its own copy of the
+        // registry separate from BGP's. See `Ospf::key_chains`.
+        self.callback_add("/key-chains/key-chain", config_kc_chain);
+        self.callback_add(
+            "/key-chains/key-chain/description",
+            config_kc_chain_description,
+        );
+        self.callback_add("/key-chains/key-chain/key", config_kc_key);
+        self.callback_add(
+            "/key-chains/key-chain/key/crypto-algorithm",
+            config_kc_key_crypto_algorithm,
+        );
+        self.callback_add(
+            "/key-chains/key-chain/key/key-string/keystring",
+            config_kc_key_keystring,
+        );
+        self.callback_add(
+            "/key-chains/key-chain/key/lifetime/send-accept-lifetime/always",
+            config_kc_lifetime_always,
+        );
+        self.callback_add(
+            "/key-chains/key-chain/key/lifetime/send-accept-lifetime/start-date-time",
+            config_kc_lifetime_start,
+        );
+        self.callback_add(
+            "/key-chains/key-chain/key/lifetime/send-accept-lifetime/no-end-time",
+            config_kc_lifetime_no_end,
+        );
+        self.callback_add(
+            "/key-chains/key-chain/key/lifetime/send-accept-lifetime/end-date-time",
+            config_kc_lifetime_end_date,
+        );
+        self.callback_add(
+            "/key-chains/key-chain/key/lifetime/send-accept-lifetime/duration",
+            config_kc_lifetime_duration,
         );
         self.ospf_add(
             "/area/interface/message-digest-key/md5",
@@ -769,6 +814,205 @@ fn config_ospf_interface_crypto_key_hmac_sha_512(
     op: ConfigOp,
 ) -> Option<()> {
     install_crypto_hmac_key(ospf, args, op, super::link::OspfCryptoAlgo::HmacSha512)
+}
+
+fn config_ospf_interface_key_chain(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config.key_chain = Some(args.string()?);
+    } else {
+        link.config.key_chain = None;
+    }
+    Some(())
+}
+
+// ---------- /key-chains/... callbacks (RFC 8177) ----------
+
+fn config_kc_chain(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    if op.is_set() {
+        ospf.key_chains.entry(name).or_default();
+    } else {
+        ospf.key_chains.remove(&name);
+    }
+    Some(())
+}
+
+fn config_kc_chain_description(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let chain = ospf.key_chains.get_mut(&name)?;
+    chain.description = if op.is_set() {
+        Some(args.string()?)
+    } else {
+        None
+    };
+    Some(())
+}
+
+/// Parse the IETF YANG `key-id` (`uint64`) into the OSPF on-wire
+/// 8-bit space; key-ids outside `1..=255` are rejected at commit
+/// time. Returns the validated u8 key-id and the chain name still
+/// pending in `args`.
+fn kc_key_args(args: &mut Args) -> Option<(String, u8)> {
+    let chain_name = args.string()?;
+    let key_id_u64 = args.u64()?;
+    if !(1..=255).contains(&key_id_u64) {
+        return None;
+    }
+    Some((chain_name, key_id_u64 as u8))
+}
+
+fn config_kc_key(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let (chain_name, key_id) = kc_key_args(&mut args)?;
+    let chain = ospf.key_chains.get_mut(&chain_name)?;
+    if op.is_set() {
+        chain.keys.entry(key_id).or_default();
+    } else {
+        chain.keys.remove(&key_id);
+    }
+    Some(())
+}
+
+fn config_kc_key_crypto_algorithm(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let (chain_name, key_id) = kc_key_args(&mut args)?;
+    let chain = ospf.key_chains.get_mut(&chain_name)?;
+    let key = chain.keys.get_mut(&key_id)?;
+    if op.is_set() {
+        let name = args.string()?;
+        // `?` rejects the commit when the algorithm identityref
+        // isn't one we recognize, rather than silently leaving the
+        // key algorithm-less.
+        key.algo = Some(super::key_chain::parse_crypto_algorithm(&name)?);
+    } else {
+        key.algo = None;
+    }
+    Some(())
+}
+
+fn config_kc_key_keystring(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let (chain_name, key_id) = kc_key_args(&mut args)?;
+    let chain = ospf.key_chains.get_mut(&chain_name)?;
+    let key = chain.keys.get_mut(&key_id)?;
+    if op.is_set() {
+        key.key_material = args.string()?.into_bytes();
+    } else {
+        key.key_material.clear();
+    }
+    Some(())
+}
+
+// ---------- send-accept-lifetime/* helpers ----------
+//
+// Phase 4 covers only `send-and-accept-lifetime` (one shared
+// window). `independent-send-accept-lifetime` (separate send/accept
+// windows) is left for a follow-up — the YANG callbacks for those
+// paths aren't registered, so the libyang dispatch rejects the
+// commit instead of silently writing only one half.
+
+fn parse_yang_datetime(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|t| t.with_timezone(&chrono::Utc))
+}
+
+/// Replace the end-time half of both send + accept lifetime with
+/// `new_end`. If the lifetime is currently `Always` (no
+/// start-date-time written yet), the start defaults to UNIX_EPOCH
+/// so the bound is at least well-defined; the operator is expected
+/// to set `start-date-time` in the same commit.
+fn set_send_accept_end(
+    key: &mut super::key_chain::OspfChainKey,
+    new_end: super::key_chain::LifetimeEnd,
+) {
+    use super::key_chain::Lifetime;
+    let start = match key.send_lifetime {
+        Lifetime::Window { start, .. } => start,
+        Lifetime::Always => chrono::DateTime::UNIX_EPOCH,
+    };
+    let lt = Lifetime::Window {
+        start,
+        end: new_end,
+    };
+    key.send_lifetime = lt.clone();
+    key.accept_lifetime = lt;
+}
+
+fn config_kc_lifetime_always(ospf: &mut Ospf, mut args: Args, _op: ConfigOp) -> Option<()> {
+    use super::key_chain::Lifetime;
+    let (chain_name, key_id) = kc_key_args(&mut args)?;
+    let chain = ospf.key_chains.get_mut(&chain_name)?;
+    let key = chain.keys.get_mut(&key_id)?;
+    key.send_lifetime = Lifetime::Always;
+    key.accept_lifetime = Lifetime::Always;
+    Some(())
+}
+
+/// Set or update the `start-date-time` half of the send-accept
+/// window. Preserves an existing end-time half (the YANG `case
+/// start-end-time` lets `start-date-time` and one of
+/// `no-end-time` / `duration` / `end-date-time` be configured in
+/// any order; each callback fires independently).
+fn config_kc_lifetime_start(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    use super::key_chain::{Lifetime, LifetimeEnd};
+    let (chain_name, key_id) = kc_key_args(&mut args)?;
+    let chain = ospf.key_chains.get_mut(&chain_name)?;
+    let key = chain.keys.get_mut(&key_id)?;
+    if !op.is_set() {
+        key.send_lifetime = Lifetime::Always;
+        key.accept_lifetime = Lifetime::Always;
+        return Some(());
+    }
+    let start = parse_yang_datetime(&args.string()?)?;
+    let preserved_end = match &key.send_lifetime {
+        Lifetime::Window { end, .. } => end.clone(),
+        Lifetime::Always => LifetimeEnd::NoEnd,
+    };
+    let lt = Lifetime::Window {
+        start,
+        end: preserved_end,
+    };
+    key.send_lifetime = lt.clone();
+    key.accept_lifetime = lt;
+    Some(())
+}
+
+fn config_kc_lifetime_no_end(ospf: &mut Ospf, mut args: Args, _op: ConfigOp) -> Option<()> {
+    use super::key_chain::LifetimeEnd;
+    let (chain_name, key_id) = kc_key_args(&mut args)?;
+    let chain = ospf.key_chains.get_mut(&chain_name)?;
+    let key = chain.keys.get_mut(&key_id)?;
+    set_send_accept_end(key, LifetimeEnd::NoEnd);
+    Some(())
+}
+
+fn config_kc_lifetime_end_date(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    use super::key_chain::LifetimeEnd;
+    let (chain_name, key_id) = kc_key_args(&mut args)?;
+    let chain = ospf.key_chains.get_mut(&chain_name)?;
+    let key = chain.keys.get_mut(&key_id)?;
+    if !op.is_set() {
+        set_send_accept_end(key, LifetimeEnd::NoEnd);
+        return Some(());
+    }
+    let end = parse_yang_datetime(&args.string()?)?;
+    set_send_accept_end(key, LifetimeEnd::EndAt(end));
+    Some(())
+}
+
+fn config_kc_lifetime_duration(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    use super::key_chain::LifetimeEnd;
+    let (chain_name, key_id) = kc_key_args(&mut args)?;
+    let chain = ospf.key_chains.get_mut(&chain_name)?;
+    let key = chain.keys.get_mut(&key_id)?;
+    if !op.is_set() {
+        set_send_accept_end(key, LifetimeEnd::NoEnd);
+        return Some(());
+    }
+    let secs = args.u32()?;
+    set_send_accept_end(key, LifetimeEnd::Duration(secs));
+    Some(())
 }
 
 fn config_ospf_interface_prefix_sid_index(

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -125,6 +125,13 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// Defaults: helper enabled, max grace 1800s, strict LSA
     /// checking on — same as the YANG model's defaults.
     pub gr_config: super::neigh::GracefulRestartConfig,
+    /// RFC 8177 key-chain registry. Populated by `/key-chains/...`
+    /// config callbacks; per-interface `key-chain <name>` leaves
+    /// reference entries here. Independent of BGP's own
+    /// `Bgp::key_chains` storage — both daemons receive the same
+    /// config commits and update their own copies (Phase 4 option
+    /// (B); cross-protocol unification is a follow-up).
+    pub key_chains: HashMap<String, super::key_chain::OspfKeyChain>,
     pub spf_last: Option<Instant>,
     pub spf_duration: Option<Duration>,
     /// Cached snapshot of v4 routes the RIB is pushing via
@@ -245,7 +252,7 @@ impl<V: OspfVersion> Ospf<V> {
             let retransmit_interval = link.retransmit_interval();
             let auth_mode = link.auth_mode();
             let auth_key = link.config.auth_key;
-            let crypto_key = link.active_crypto_key();
+            let crypto_key = link.resolve_active_send_key(&self.key_chains, chrono::Utc::now());
             self.areas.get_mut(link_area).and_then(|area| {
                 let area_type = area.area_type;
                 link.nbrs.get_mut(src).map(|nbr| {
@@ -447,6 +454,7 @@ impl Ospf<Ospfv2> {
             tracing: OspfTracing::default(),
             segment_routing: super::srmpls::SegmentRoutingMode::default(),
             gr_config: super::neigh::GracefulRestartConfig::default(),
+            key_chains: HashMap::new(),
             spf_last: None,
             spf_duration: None,
             redist_v4: BTreeMap::new(),
@@ -1998,7 +2006,9 @@ impl Ospf<Ospfv2> {
             return;
         };
         let link_indices: Vec<u32> = area.links.iter().copied().collect();
+        let now = chrono::Utc::now();
         for ifindex in link_indices {
+            let chains = &self.key_chains;
             let Some(link) = self.links.get_mut(&ifindex) else {
                 continue;
             };
@@ -2006,7 +2016,7 @@ impl Ospf<Ospfv2> {
             let link_state = link.state;
             let auth_mode = link.auth_mode();
             let auth_key = link.config.auth_key;
-            let crypto_key = link.active_crypto_key();
+            let crypto_key = link.resolve_active_send_key(chains, now);
             let md5_seq_cell = &link.md5_seq;
 
             // RFC 2328 Section 13.3 Step 2-4: DR/BDR flooding decision.
@@ -2106,6 +2116,8 @@ impl Ospf<Ospfv2> {
 
     /// Handle retransmit timer firing for a neighbor.
     fn process_retransmit(&mut self, ifindex: u32, addr: Ipv4Addr) {
+        let now = chrono::Utc::now();
+        let chains = &self.key_chains;
         let Some(link) = self.links.get_mut(&ifindex) else {
             return;
         };
@@ -2113,7 +2125,7 @@ impl Ospf<Ospfv2> {
         let area_id = link.area;
         let auth_mode = link.auth_mode();
         let auth_key = link.config.auth_key;
-        let crypto_key = link.active_crypto_key();
+        let crypto_key = link.resolve_active_send_key(chains, now);
         let md5_seq_cell = &link.md5_seq;
         let Some(nbr) = link.nbrs.get_mut(&addr) else {
             return;
@@ -2197,6 +2209,8 @@ impl Ospf<Ospfv2> {
 
     /// Handle delayed ack timer firing for an interface.
     fn process_delayed_ack(&mut self, ifindex: u32) {
+        let now = chrono::Utc::now();
+        let chains = &self.key_chains;
         let Some(link) = self.links.get_mut(&ifindex) else {
             return;
         };
@@ -2216,7 +2230,7 @@ impl Ospf<Ospfv2> {
         };
         let mut packet =
             Ospfv2Packet::new(&self.router_id, &link.area, Ospfv2Payload::LsAck(ls_ack));
-        apply_link_auth(&mut packet, &link.auth_send_ctx());
+        apply_link_auth(&mut packet, &link.auth_send_ctx(chains, now));
         // Send to AllSPFRouters multicast.
         let _ = link.ptx.send(Message::Send(packet, ifindex, None));
     }
@@ -2296,6 +2310,8 @@ impl Ospf<Ospfv2> {
         // adds anti-replay for Type 2 — packets with a seq below
         // the per-neighbor high-watermark are dropped.
         {
+            let chains = &self.key_chains;
+            let now = chrono::Utc::now();
             let Some(link) = self.links.get(&index) else {
                 return;
             };
@@ -2304,11 +2320,29 @@ impl Ospf<Ospfv2> {
                 .get(&src)
                 .map(|n| n.auth_md5_last_seq)
                 .unwrap_or(0);
+            // Build the key source: chain takes precedence when the
+            // interface names one; otherwise the per-interface
+            // `crypto_keys` map serves Phase 2/3 configurations.
+            let key_source = match link.config.key_chain.as_deref() {
+                Some(name) => match chains.get(name) {
+                    Some(c) => crate::ospf::packet::KeySource::Chain { chain: c, now },
+                    None => {
+                        tracing::debug!(
+                            "OSPFv2 auth drop on {} from {}: chain `{}` not configured",
+                            link.name,
+                            src,
+                            name
+                        );
+                        return;
+                    }
+                },
+                None => crate::ospf::packet::KeySource::PerIface(&link.config.crypto_keys),
+            };
             if !verify_link_auth(
                 &packet,
                 link.auth_mode(),
                 link.config.auth_key,
-                &link.config.crypto_keys,
+                &key_source,
                 last_seq,
             ) {
                 tracing::debug!(
@@ -2476,10 +2510,12 @@ impl Ospf<Ospfv2> {
                 }
             }
             Message::HelloTimer(index) => {
+                let now = chrono::Utc::now();
+                let chains = &self.key_chains;
                 let Some(link) = self.links.get_mut(&index) else {
                     return;
                 };
-                ospf_hello_send(link);
+                ospf_hello_send(link, chains, now);
             }
             Message::Lsdb(ev, area_id, key) => {
                 self.process_lsdb(ev, area_id, key);
@@ -2742,6 +2778,7 @@ impl Ospf<Ospfv3> {
             tracing: OspfTracing::default(),
             segment_routing: super::srmpls::SegmentRoutingMode::default(),
             gr_config: super::neigh::GracefulRestartConfig::default(),
+            key_chains: HashMap::new(),
             spf_last: None,
             spf_duration: None,
             redist_v4: BTreeMap::new(),

--- a/zebra-rs/src/ospf/key_chain.rs
+++ b/zebra-rs/src/ospf/key_chain.rs
@@ -1,0 +1,305 @@
+//! RFC 8177 key-chain data model for OSPFv2 cryptographic
+//! authentication (Phase 4 of OSPF authentication).
+//!
+//! OSPF keeps its own in-memory registry separate from BGP's: both
+//! daemons listen to `/key-chains/...` config commits and update
+//! their own `key_chains: HashMap<String, _>` storage. The
+//! per-interface `key-chain <name>` leaf references an entry here;
+//! when set it supersedes the per-interface
+//! `message-digest-key` / `crypto-key` lists for both send-side
+//! selection and receive-side validation.
+//!
+//! Lifetimes follow IETF `ietf-key-chain@2017-06-15.yang`. Each key
+//! carries a `send-lifetime` and `accept-lifetime`. The IETF
+//! `send-and-accept-lifetime` shorthand (one window shared by both)
+//! lowers to two identical `Lifetime` values at commit time.
+//!
+//! Send-id / recv-id are intentionally ignored — OSPFv2's
+//! cryptographic-auth header carries a single 8-bit key-id field
+//! that both endpoints share (RFC 2328 §D.3), so the IETF
+//! per-direction id distinction doesn't apply.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Duration, Utc};
+
+use super::link::OspfCryptoAlgo;
+
+/// End of a lifetime window — IETF `choice end-time` collapsed to
+/// the cases we actually parse (the YANG `infinite` / `duration` /
+/// `end-date-time` choices).
+///
+/// The `NoEnd` default applies only while a key is being
+/// incrementally configured; the YANG `end-time` choice is
+/// mandatory once `start-date-time` is set.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub enum LifetimeEnd {
+    /// `no-end-time` was set — key stays active forever after start.
+    #[default]
+    NoEnd,
+    /// `duration` (seconds from start).
+    Duration(u32),
+    /// `end-date-time` — explicit absolute end.
+    EndAt(DateTime<Utc>),
+}
+
+/// Send-lifetime / accept-lifetime window. IETF YANG models this as
+/// an outer `choice lifetime { case always | case start-end-time }`.
+/// `Always` is the natural default when neither `always` nor
+/// `start-date-time` has been configured for a key.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub enum Lifetime {
+    /// `case always { leaf always { type empty; } }` — matches any
+    /// time, the RFC 8177 "no time bounds" shorthand.
+    #[default]
+    Always,
+    /// `case start-end-time { leaf start-date-time; choice end-time; }`.
+    Window {
+        start: DateTime<Utc>,
+        end: LifetimeEnd,
+    },
+}
+
+impl Lifetime {
+    /// Is `now` inside this lifetime window?
+    pub fn is_active(&self, now: DateTime<Utc>) -> bool {
+        match self {
+            Self::Always => true,
+            Self::Window { start, end } => {
+                if now < *start {
+                    return false;
+                }
+                match end {
+                    LifetimeEnd::NoEnd => true,
+                    LifetimeEnd::EndAt(t) => now < *t,
+                    LifetimeEnd::Duration(secs) => {
+                        let limit = *start + Duration::seconds(i64::from(*secs));
+                        now < limit
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// One key inside an RFC 8177 chain. `algo` is `Option` because the
+/// YANG `crypto-algorithm` leaf is set incrementally — a key may
+/// exist transiently with `key-string` written but no algorithm yet.
+/// Send / accept resolution treats algorithm-less keys as inactive.
+#[derive(Debug, Clone, Default)]
+pub struct OspfChainKey {
+    pub algo: Option<OspfCryptoAlgo>,
+    /// Raw key bytes. ASCII when the YANG leaf is `keystring`.
+    pub key_material: Vec<u8>,
+    pub send_lifetime: Lifetime,
+    pub accept_lifetime: Lifetime,
+}
+
+impl OspfChainKey {
+    pub fn is_send_active(&self, now: DateTime<Utc>) -> bool {
+        self.algo.is_some() && !self.key_material.is_empty() && self.send_lifetime.is_active(now)
+    }
+
+    pub fn is_accept_active(&self, now: DateTime<Utc>) -> bool {
+        self.algo.is_some() && !self.key_material.is_empty() && self.accept_lifetime.is_active(now)
+    }
+}
+
+/// One named RFC 8177 key chain. Keys are ordered by key-id; send
+/// selection scans low-to-high until an active key is found.
+#[derive(Debug, Clone, Default)]
+pub struct OspfKeyChain {
+    pub description: Option<String>,
+    pub keys: BTreeMap<u8, OspfChainKey>,
+}
+
+impl OspfKeyChain {
+    /// Active send key (lowest key-id whose send-lifetime contains
+    /// `now` and which has a usable algorithm + material). `None`
+    /// when the chain is empty, mid-configuration, or fully expired.
+    pub fn active_send_key(&self, now: DateTime<Utc>) -> Option<(u8, &OspfChainKey)> {
+        self.keys
+            .iter()
+            .find(|(_, k)| k.is_send_active(now))
+            .map(|(&id, k)| (id, k))
+    }
+
+    /// Look up the key the sender stamped (`key_id`) for receive-side
+    /// validation. Returns the key only if its accept-lifetime
+    /// contains `now`.
+    pub fn lookup_recv_key(&self, key_id: u8, now: DateTime<Utc>) -> Option<&OspfChainKey> {
+        self.keys.get(&key_id).filter(|k| k.is_accept_active(now))
+    }
+}
+
+/// Parse the IETF `crypto-algorithm` identityref (e.g. `"md5"`,
+/// `"hmac-sha-256"`, optionally prefixed `"ietf-key-chain:..."`)
+/// into the OSPF-side enum. Algorithms outside the RFC 5709 +
+/// keyed-MD5 set yield `None` — operators get a config error
+/// rather than silently picking a different algorithm.
+pub fn parse_crypto_algorithm(name: &str) -> Option<OspfCryptoAlgo> {
+    let bare = name.rsplit(':').next().unwrap_or(name);
+    match bare {
+        "md5" => Some(OspfCryptoAlgo::Md5),
+        "hmac-sha-1" => Some(OspfCryptoAlgo::HmacSha1),
+        "hmac-sha-256" => Some(OspfCryptoAlgo::HmacSha256),
+        "hmac-sha-384" => Some(OspfCryptoAlgo::HmacSha384),
+        "hmac-sha-512" => Some(OspfCryptoAlgo::HmacSha512),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn ts(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn always_lifetime_always_active() {
+        assert!(Lifetime::Always.is_active(Utc.timestamp_opt(0, 0).unwrap()));
+        assert!(Lifetime::Always.is_active(Utc::now()));
+    }
+
+    #[test]
+    fn window_no_end_open_ended() {
+        let lt = Lifetime::Window {
+            start: ts("2026-01-01T00:00:00Z"),
+            end: LifetimeEnd::NoEnd,
+        };
+        assert!(!lt.is_active(ts("2025-12-31T23:59:59Z")));
+        assert!(lt.is_active(ts("2026-01-01T00:00:00Z")));
+        assert!(lt.is_active(ts("3000-01-01T00:00:00Z")));
+    }
+
+    #[test]
+    fn window_explicit_end() {
+        let lt = Lifetime::Window {
+            start: ts("2026-01-01T00:00:00Z"),
+            end: LifetimeEnd::EndAt(ts("2026-02-01T00:00:00Z")),
+        };
+        assert!(!lt.is_active(ts("2025-12-31T00:00:00Z")));
+        assert!(lt.is_active(ts("2026-01-15T00:00:00Z")));
+        assert!(!lt.is_active(ts("2026-02-01T00:00:00Z")));
+        assert!(!lt.is_active(ts("2026-02-02T00:00:00Z")));
+    }
+
+    #[test]
+    fn window_duration_derived_end() {
+        let lt = Lifetime::Window {
+            start: ts("2026-01-01T00:00:00Z"),
+            end: LifetimeEnd::Duration(60),
+        };
+        assert!(lt.is_active(ts("2026-01-01T00:00:30Z")));
+        assert!(!lt.is_active(ts("2026-01-01T00:01:00Z")));
+    }
+
+    #[test]
+    fn active_send_picks_lowest_active_key() {
+        let mut chain = OspfKeyChain::default();
+        // Key 1 expired, key 2 active, key 3 not-yet-active.
+        chain.keys.insert(
+            1,
+            OspfChainKey {
+                algo: Some(OspfCryptoAlgo::HmacSha256),
+                key_material: b"k1".to_vec(),
+                send_lifetime: Lifetime::Window {
+                    start: ts("2026-01-01T00:00:00Z"),
+                    end: LifetimeEnd::EndAt(ts("2026-01-02T00:00:00Z")),
+                },
+                accept_lifetime: Lifetime::Always,
+            },
+        );
+        chain.keys.insert(
+            2,
+            OspfChainKey {
+                algo: Some(OspfCryptoAlgo::HmacSha256),
+                key_material: b"k2".to_vec(),
+                send_lifetime: Lifetime::Window {
+                    start: ts("2026-01-02T00:00:00Z"),
+                    end: LifetimeEnd::NoEnd,
+                },
+                accept_lifetime: Lifetime::Always,
+            },
+        );
+        chain.keys.insert(
+            3,
+            OspfChainKey {
+                algo: Some(OspfCryptoAlgo::HmacSha256),
+                key_material: b"k3".to_vec(),
+                send_lifetime: Lifetime::Window {
+                    start: ts("2027-01-01T00:00:00Z"),
+                    end: LifetimeEnd::NoEnd,
+                },
+                accept_lifetime: Lifetime::Always,
+            },
+        );
+
+        let (id, _) = chain
+            .active_send_key(ts("2026-06-01T00:00:00Z"))
+            .expect("key 2 should be active");
+        assert_eq!(id, 2);
+    }
+
+    #[test]
+    fn lookup_recv_gates_on_accept_lifetime() {
+        let mut chain = OspfKeyChain::default();
+        chain.keys.insert(
+            7,
+            OspfChainKey {
+                algo: Some(OspfCryptoAlgo::HmacSha256),
+                key_material: b"shared".to_vec(),
+                send_lifetime: Lifetime::Always,
+                accept_lifetime: Lifetime::Window {
+                    start: ts("2026-01-01T00:00:00Z"),
+                    end: LifetimeEnd::EndAt(ts("2026-02-01T00:00:00Z")),
+                },
+            },
+        );
+        assert!(
+            chain
+                .lookup_recv_key(7, ts("2026-01-15T00:00:00Z"))
+                .is_some()
+        );
+        assert!(
+            chain
+                .lookup_recv_key(7, ts("2026-02-15T00:00:00Z"))
+                .is_none()
+        );
+        // Unknown key-id never matches.
+        assert!(
+            chain
+                .lookup_recv_key(8, ts("2026-01-15T00:00:00Z"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn algo_without_material_is_inactive() {
+        let key = OspfChainKey {
+            algo: Some(OspfCryptoAlgo::HmacSha256),
+            key_material: Vec::new(),
+            send_lifetime: Lifetime::Always,
+            accept_lifetime: Lifetime::Always,
+        };
+        assert!(!key.is_send_active(Utc::now()));
+        assert!(!key.is_accept_active(Utc::now()));
+    }
+
+    #[test]
+    fn parse_algorithm_accepts_bare_and_prefixed() {
+        assert_eq!(parse_crypto_algorithm("md5"), Some(OspfCryptoAlgo::Md5));
+        assert_eq!(
+            parse_crypto_algorithm("hmac-sha-256"),
+            Some(OspfCryptoAlgo::HmacSha256)
+        );
+        assert_eq!(
+            parse_crypto_algorithm("ietf-key-chain:hmac-sha-512"),
+            Some(OspfCryptoAlgo::HmacSha512)
+        );
+        assert_eq!(parse_crypto_algorithm("unknown-algo"), None);
+    }
+}

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -86,12 +86,18 @@ pub struct LinkConfig {
     /// Cryptographic-auth keys keyed by key-id (RFC 2328 §D.4
     /// for keyed-MD5, RFC 5709 for HMAC-SHA). Each entry carries
     /// the algorithm and the raw secret. Only consulted when
-    /// `auth_mode == MessageDigest`. Populated by either the
-    /// `message-digest-key` callback (MD5 entries) or the
-    /// `crypto-key` callback (HMAC-SHA entries) — the two paths
-    /// share this single keyring and using the same key-id from
-    /// both is a config error.
+    /// `auth_mode == MessageDigest` AND `key_chain` is unset.
+    /// Populated by either the `message-digest-key` callback
+    /// (MD5 entries) or the `crypto-key` callback (HMAC-SHA
+    /// entries) — the two paths share this single keyring and
+    /// using the same key-id from both is a config error.
     pub crypto_keys: BTreeMap<u8, AuthKey>,
+    /// RFC 8177 key-chain name (see `/key-chains` callbacks).
+    /// When set and `auth_mode == MessageDigest`, the chain
+    /// supersedes `crypto_keys` for both send-side selection
+    /// (`KeyChain::active_send_key(now)`) and receive-side
+    /// validation (`KeyChain::lookup_recv_key(key_id, now)`).
+    pub key_chain: Option<String>,
 }
 
 /// OSPFv2 per-interface authentication mode.
@@ -377,17 +383,42 @@ impl<V: OspfVersion> OspfLink<V> {
         self.config.auth_mode.unwrap_or(OspfAuthMode::Null)
     }
 
-    /// Return the active crypto-auth send key (lowest configured
-    /// key-id across both MD5 and HMAC-SHA entries) alongside its
-    /// key-id, or `None` if no keys are configured. Key rollover
-    /// (per-key send/accept lifetimes) lives in the Phase 4
-    /// key-chain plumbing.
+    /// Per-interface crypto-key fallback used when no key-chain is
+    /// configured (or when the configured chain is missing /
+    /// expired). Lowest configured key-id across MD5 + HMAC-SHA
+    /// entries.
     pub fn active_crypto_key(&self) -> Option<(u8, AuthKey)> {
         self.config
             .crypto_keys
             .iter()
             .next()
             .map(|(&id, k)| (id, k.clone()))
+    }
+
+    /// Resolve the active send key — chain-aware. If `key_chain` is
+    /// set, look it up and use `KeyChain::active_send_key(now)`;
+    /// otherwise fall back to the per-interface `crypto_keys` map.
+    /// Returns `None` if a chain is named but missing or has no
+    /// active key — peers will reject our zero-trailer packets,
+    /// which is a louder failure than silently picking a stale key.
+    pub fn resolve_active_send_key(
+        &self,
+        chains: &std::collections::HashMap<String, super::key_chain::OspfKeyChain>,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Option<(u8, AuthKey)> {
+        if let Some(name) = &self.config.key_chain {
+            let chain = chains.get(name)?;
+            let (id, ck) = chain.active_send_key(now)?;
+            let algo = ck.algo?;
+            return Some((
+                id,
+                AuthKey {
+                    algo,
+                    raw: ck.key_material.clone(),
+                },
+            ));
+        }
+        self.active_crypto_key()
     }
 
     /// Read and increment the per-interface cryptographic-auth
@@ -402,11 +433,15 @@ impl<V: OspfVersion> OspfLink<V> {
     /// Bundle the auth state needed to stamp one outbound packet.
     /// Bumps the cryptographic-auth seq as a side effect — call
     /// once per packet, not once per buffer reuse.
-    pub fn auth_send_ctx(&self) -> super::packet::AuthSendCtx {
+    pub fn auth_send_ctx(
+        &self,
+        chains: &std::collections::HashMap<String, super::key_chain::OspfKeyChain>,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> super::packet::AuthSendCtx {
         super::packet::AuthSendCtx {
             mode: self.auth_mode(),
             simple_key: self.config.auth_key,
-            crypto_key: self.active_crypto_key(),
+            crypto_key: self.resolve_active_send_key(chains, now),
             md5_seq: self.next_md5_seq(),
         }
     }

--- a/zebra-rs/src/ospf/mod.rs
+++ b/zebra-rs/src/ospf/mod.rs
@@ -55,6 +55,8 @@ pub use lsa::*;
 pub mod flood;
 pub use flood::*;
 
+pub mod key_chain;
+
 pub mod srmpls;
 
 pub mod tracing;

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -168,11 +168,36 @@ fn compute_crypto_trailer(key: &super::link::AuthKey, packet_bytes: &[u8]) -> Ve
 /// the packet is acceptable. The caller must update the per-
 /// neighbor `auth_md5_last_seq` via `record_md5_seq()` afterward
 /// to enforce replay protection (RFC 2328 §D.5 / RFC 7474).
+/// Where receive-side key lookup pulls its key material from.
+/// Per-interface map is the Phase 2/3 path; key-chain is Phase 4.
+pub(super) enum KeySource<'a> {
+    PerIface(&'a std::collections::BTreeMap<u8, super::link::AuthKey>),
+    Chain {
+        chain: &'a super::key_chain::OspfKeyChain,
+        now: chrono::DateTime<chrono::Utc>,
+    },
+}
+
+impl<'a> KeySource<'a> {
+    fn lookup(&self, key_id: u8) -> Option<super::link::AuthKey> {
+        match self {
+            Self::PerIface(m) => m.get(&key_id).cloned(),
+            Self::Chain { chain, now } => {
+                let ck = chain.lookup_recv_key(key_id, *now)?;
+                Some(super::link::AuthKey {
+                    algo: ck.algo?,
+                    raw: ck.key_material.clone(),
+                })
+            }
+        }
+    }
+}
+
 pub(super) fn verify_link_auth(
     packet: &Ospfv2Packet,
     mode: OspfAuthMode,
     simple_key: Option<[u8; 8]>,
-    crypto_keys: &std::collections::BTreeMap<u8, super::link::AuthKey>,
+    key_source: &KeySource<'_>,
     nbr_last_seq: u32,
 ) -> bool {
     match mode {
@@ -197,8 +222,9 @@ pub(super) fn verify_link_auth(
                 return false;
             }
             // Look up the key by id; reject if the sender used
-            // a key we don't know.
-            let Some(key) = crypto_keys.get(&crypto.key_id) else {
+            // a key we don't know or one whose accept-lifetime
+            // has elapsed (chain path).
+            let Some(key) = key_source.lookup(crypto.key_id) else {
                 return false;
             };
             // The on-wire trailer length must match what our
@@ -213,7 +239,7 @@ pub(super) fn verify_link_auth(
             }
             // Recompute the digest over raw_body (the bytes the
             // sender hashed) using our configured key + algo.
-            let expected = compute_crypto_trailer(key, &packet.raw_body);
+            let expected = compute_crypto_trailer(&key, &packet.raw_body);
             // Constant-time compare — leaking first-mismatch
             // position to a remote sender via timing is bad form.
             constant_time_eq(&expected, &packet.auth_trailer)
@@ -243,7 +269,11 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     acc == 0
 }
 
-pub fn ospf_hello_packet(oi: &OspfLink) -> Option<Ospfv2Packet> {
+pub fn ospf_hello_packet(
+    oi: &OspfLink,
+    chains: &std::collections::HashMap<String, super::key_chain::OspfKeyChain>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Option<Ospfv2Packet> {
     let addr = oi.addr.first()?;
     let mut hello = OspfHello {
         netmask: addr.prefix.netmask(),
@@ -266,7 +296,7 @@ pub fn ospf_hello_packet(oi: &OspfLink) -> Option<Ospfv2Packet> {
     }
 
     let mut packet = Ospfv2Packet::new(&oi.ident.router_id, &oi.area, Ospfv2Payload::Hello(hello));
-    apply_link_auth(&mut packet, &oi.auth_send_ctx());
+    apply_link_auth(&mut packet, &oi.auth_send_ctx(chains, now));
 
     Some(packet)
 }
@@ -412,10 +442,14 @@ pub fn ospf_hello_recv(
     }
 }
 
-pub fn ospf_hello_send(oi: &mut OspfLink) {
+pub fn ospf_hello_send(
+    oi: &mut OspfLink,
+    chains: &std::collections::HashMap<String, super::key_chain::OspfKeyChain>,
+    now: chrono::DateTime<chrono::Utc>,
+) {
     // tracing::info!("[Hello:Send] on {} flag {}", oi.name, oi.flags.hello_sent());
 
-    let packet = ospf_hello_packet(oi).unwrap();
+    let packet = ospf_hello_packet(oi, chains, now).unwrap();
     if let Err(e) = oi.ptx.send(Message::Send(packet, oi.index, None)) {
         tracing::warn!("[Hello:Send] channel send failed: {}", e);
         return;
@@ -1326,7 +1360,7 @@ mod auth_tests {
             &p,
             OspfAuthMode::Null,
             None,
-            &empty_keys(),
+            &KeySource::PerIface(&empty_keys()),
             0
         ));
 
@@ -1335,7 +1369,7 @@ mod auth_tests {
             &p,
             OspfAuthMode::Null,
             None,
-            &empty_keys(),
+            &KeySource::PerIface(&empty_keys()),
             0
         ));
     }
@@ -1350,14 +1384,14 @@ mod auth_tests {
             &p,
             OspfAuthMode::Simple,
             Some(key),
-            &empty_keys(),
+            &KeySource::PerIface(&empty_keys()),
             0
         ));
         assert!(!verify_link_auth(
             &p,
             OspfAuthMode::Simple,
             Some(*b"other\0\0\0"),
-            &empty_keys(),
+            &KeySource::PerIface(&empty_keys()),
             0
         ));
         // Wrong mode on the receiving side — drop.
@@ -1365,7 +1399,7 @@ mod auth_tests {
             &p,
             OspfAuthMode::Null,
             None,
-            &empty_keys(),
+            &KeySource::PerIface(&empty_keys()),
             0
         ));
     }
@@ -1409,7 +1443,7 @@ mod auth_tests {
             &parsed,
             OspfAuthMode::MessageDigest,
             None,
-            &keys,
+            &KeySource::PerIface(&keys),
             0
         ));
         // Replay: seq below high-watermark → reject.
@@ -1417,7 +1451,7 @@ mod auth_tests {
             &parsed,
             OspfAuthMode::MessageDigest,
             None,
-            &keys,
+            &KeySource::PerIface(&keys),
             seq + 1
         ));
         // Unknown key-id → reject.
@@ -1427,7 +1461,7 @@ mod auth_tests {
             &parsed,
             OspfAuthMode::MessageDigest,
             None,
-            &wrong_keys,
+            &KeySource::PerIface(&wrong_keys),
             0
         ));
         // Same key-id, wrong material → reject.
@@ -1443,7 +1477,7 @@ mod auth_tests {
             &parsed,
             OspfAuthMode::MessageDigest,
             None,
-            &bad,
+            &KeySource::PerIface(&bad),
             0
         ));
     }
@@ -1485,6 +1519,77 @@ mod auth_tests {
         ));
     }
 
+    /// Verify a chain-sourced inbound packet honours the
+    /// accept-lifetime window — the same key-id outside the
+    /// window must be rejected even when the digest would
+    /// otherwise match.
+    #[test]
+    fn chain_recv_rejects_outside_accept_lifetime() {
+        use bytes::BytesMut;
+        use chrono::{TimeZone, Utc};
+        use ospf_packet::parse;
+
+        use super::super::key_chain::{Lifetime, LifetimeEnd, OspfChainKey, OspfKeyChain};
+
+        let key_id: u8 = 5;
+        let key_bytes = b"chain-secret".to_vec();
+        let mut p = hello_packet();
+        apply_link_auth(
+            &mut p,
+            &crypto_ctx(
+                key_id,
+                super::super::link::AuthKey {
+                    algo: super::super::link::OspfCryptoAlgo::HmacSha256,
+                    raw: key_bytes.clone(),
+                },
+                0xDEAD_BEEF,
+            ),
+        );
+        let mut buf = BytesMut::new();
+        p.emit(&mut buf);
+        let (_, parsed) = parse(&buf).expect("parse must succeed");
+
+        let mut chain = OspfKeyChain::default();
+        chain.keys.insert(
+            key_id,
+            OspfChainKey {
+                algo: Some(super::super::link::OspfCryptoAlgo::HmacSha256),
+                key_material: key_bytes,
+                send_lifetime: Lifetime::Always,
+                accept_lifetime: Lifetime::Window {
+                    start: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+                    end: LifetimeEnd::EndAt(Utc.with_ymd_and_hms(2026, 2, 1, 0, 0, 0).unwrap()),
+                },
+            },
+        );
+
+        let inside = Utc.with_ymd_and_hms(2026, 1, 15, 0, 0, 0).unwrap();
+        let outside = Utc.with_ymd_and_hms(2030, 1, 1, 0, 0, 0).unwrap();
+
+        // Accept within window.
+        assert!(verify_link_auth(
+            &parsed,
+            OspfAuthMode::MessageDigest,
+            None,
+            &KeySource::Chain {
+                chain: &chain,
+                now: inside,
+            },
+            0
+        ));
+        // Reject when the accept-lifetime has elapsed.
+        assert!(!verify_link_auth(
+            &parsed,
+            OspfAuthMode::MessageDigest,
+            None,
+            &KeySource::Chain {
+                chain: &chain,
+                now: outside,
+            },
+            0
+        ));
+    }
+
     /// If we apply with one algorithm and the receiver configured a
     /// different algorithm for the same key-id, verify must reject —
     /// both because the wire trailer length won't match and as a
@@ -1517,7 +1622,7 @@ mod auth_tests {
             &parsed,
             OspfAuthMode::MessageDigest,
             None,
-            &keys,
+            &KeySource::PerIface(&keys),
             0
         ));
     }

--- a/zebra-rs/yang/zebra-ospf-auth-simple.yang
+++ b/zebra-rs/yang/zebra-ospf-auth-simple.yang
@@ -99,6 +99,20 @@ module zebra-ospf-auth-simple {
          commit time rather than silently truncated.";
       reference "RFC 2328 §D.3";
     }
+
+    leaf key-chain {
+      ext:help "RFC 8177 key chain name";
+      type string;
+      description
+        "Name of a key chain defined under /key-chains/key-chain.
+         When set and `authentication` is `message-digest`, the
+         chain supersedes per-interface `message-digest-key` /
+         `crypto-key` entries: send-side uses the chain's
+         currently active key (lowest key-id whose send-lifetime
+         contains now); receive-side validates the sender's
+         key-id against the chain's accept-lifetime window.";
+      reference "RFC 8177";
+    }
   }
 
   augment "/configure:set/config:router"


### PR DESCRIPTION
## Summary

Phase 4 of OSPF authentication. Adds lifetime-aware key selection backed by IETF `ietf-key-chain` semantics. When an interface references a key chain, send-side picks the lowest-key-id key whose send-lifetime contains "now" and receive-side validates the sender's key-id against the chain's accept-lifetime window. Phase 2/3 per-interface `message-digest-key` / `crypto-key` paths remain as the fallback when no chain is referenced.

\`\`\`
key-chains {
  key-chain core {
    key 1 {
      crypto-algorithm hmac-sha-256;
      key-string { keystring SECRET; }
      lifetime {
        send-accept-lifetime {
          start-date-time 2026-01-01T00:00:00Z;
          end-date-time   2026-02-01T00:00:00Z;
        }
      }
    }
    key 2 {
      crypto-algorithm hmac-sha-256;
      key-string { keystring NEXT; }
      lifetime {
        send-accept-lifetime {
          start-date-time 2026-02-01T00:00:00Z;
          no-end-time;
        }
      }
    }
  }
}
router ospf {
  area 0 { interface eth0 { authentication message-digest; key-chain core; } }
}
\`\`\`

## Architecture

OSPF keeps its own registry (`Ospf::key_chains`) separate from BGP's existing `Bgp::key_chains` storage — both daemons receive the same `/key-chains/...` config commits and update their own copies (option **(B)** of the Phase 4 design discussion). Cross-protocol registry unification is left for a follow-up; the goal of this PR was getting OSPF onto the named-chain model without touching BGP.

## What's in

- **New `ospf::key_chain` module:** `OspfKeyChain` / `OspfChainKey` / `Lifetime` (Always | Window) / `LifetimeEnd` (NoEnd | Duration | EndAt). `active_send_key(now)` for send, `lookup_recv_key(key_id, now)` for verify.
- **`LinkConfig::key_chain: Option<String>`** + per-interface `key-chain` YANG leaf.
- **`OspfLink::resolve_active_send_key(chains, now)`** — chain-aware send-key resolver; falls back to the per-interface `crypto_keys` map when no chain is set; returns `None` when a named chain is missing/expired (peer rejects the zero-trailer packet — louder than a stale key).
- **`verify_link_auth(..., &KeySource, ...)`** — `KeySource::PerIface` vs `KeySource::Chain { chain, now }`. Chain variant calls `lookup_recv_key` so receive enforces the accept-lifetime automatically.
- **Config callbacks at `/key-chains/...`** for: chain CRUD, description, key CRUD (u8 key-id), crypto-algorithm (parses IETF identityref bare + `ietf-key-chain:` prefixed), keystring, send-accept-lifetime always | start-date-time | no-end-time | end-date-time | duration.

## Out of scope (follow-ups)

- `independent-send-accept-lifetime` (separate send + accept windows) — YANG dispatch rejects since no callback registered.
- `accept-tolerance` (RFC 8177 §4.4 clock-skew window).
- `hexadecimal-string` key form.
- IETF send-id / recv-id (OSPFv2 carries one key-id per RFC 2328 §D.3).
- Cross-protocol unification of BGP + OSPF key-chain registries.

## Test plan

- [x] `cargo test -p ospf-packet` — 44 + 17 passed.
- [x] `cargo test -p zebra-rs --bin zebra-rs` — 630 passed (8 new `key_chain::tests`, 1 new `chain_recv_rejects_outside_accept_lifetime` in `auth_tests`).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [ ] Live two-router negotiation with overlapping send-lifetime keys driving rollover — manual verify deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)