### PR TITLE
rib: ProtoQuiesce for graceful-restart exit (ospf/bgp/isis)

### DIFF
--- a/zebra-rs/src/config/bgp.rs
+++ b/zebra-rs/src/config/bgp.rs
@@ -41,3 +41,19 @@ pub fn despawn_bgp(config: &ConfigManager) {
         proto: "bgp".to_string(),
     });
 }
+
+/// Graceful-restart variant of [`despawn_bgp`] (RFC 4724).
+/// Drops the protocol task + registrations but sends
+/// `ProtoQuiesce` instead of `ProtoCleanup`, so the kernel
+/// routes the BGP speaker owns stay installed while the daemon
+/// restarts. Peers in receiving-restart-helper mode mark these
+/// as "stale" until our re-advertise + End-of-RIB marker.
+#[allow(dead_code)]
+pub fn despawn_bgp_graceful(config: &ConfigManager) {
+    config.cm_clients.borrow_mut().remove("bgp");
+    config.show_clients.borrow_mut().remove("bgp");
+    config.protocol_tasks.borrow_mut().remove("bgp");
+    let _ = config.rib_tx.send(rib::Message::ProtoQuiesce {
+        proto: "bgp".to_string(),
+    });
+}

--- a/zebra-rs/src/config/isis.rs
+++ b/zebra-rs/src/config/isis.rs
@@ -32,3 +32,19 @@ pub fn despawn_isis(config: &ConfigManager) {
         proto: "isis".to_string(),
     });
 }
+
+/// Graceful-restart variant of [`despawn_isis`] (RFC 5306).
+/// Drops the protocol task + registrations but sends
+/// `ProtoQuiesce` instead of `ProtoCleanup`, so the kernel
+/// routes the IS-IS instance owns stay installed across the
+/// restart. Peers in T2/T3 helper state preserve the adjacency
+/// until our re-flood and CSNP/PSNP convergence completes.
+#[allow(dead_code)]
+pub fn despawn_isis_graceful(config: &ConfigManager) {
+    config.cm_clients.borrow_mut().remove("isis");
+    config.show_clients.borrow_mut().remove("isis");
+    config.protocol_tasks.borrow_mut().remove("isis");
+    let _ = config.rib_tx.send(rib::Message::ProtoQuiesce {
+        proto: "isis".to_string(),
+    });
+}

--- a/zebra-rs/src/config/ospf.rs
+++ b/zebra-rs/src/config/ospf.rs
@@ -26,6 +26,22 @@ pub fn despawn_ospf(config: &ConfigManager) {
     });
 }
 
+/// Graceful-restart variant of [`despawn_ospf`]. Drops the
+/// protocol task + registrations but sends `ProtoQuiesce`
+/// instead of `ProtoCleanup`, so the kernel routes the OSPFv2
+/// instance owns stay installed across the restart (RFC 3623).
+/// Caller is expected to have already flushed Grace LSAs and
+/// written the restart checkpoint.
+#[allow(dead_code)]
+pub fn despawn_ospf_graceful(config: &ConfigManager) {
+    config.cm_clients.borrow_mut().remove("ospf");
+    config.show_clients.borrow_mut().remove("ospf");
+    config.protocol_tasks.borrow_mut().remove("ospf");
+    let _ = config.rib_tx.send(rib::Message::ProtoQuiesce {
+        proto: "ospf".to_string(),
+    });
+}
+
 /// Spawn an OSPFv3 instance. Mirrors [`spawn_ospf`] but constructs
 /// `Ospf<Ospfv3>` instead of the default-typed `Ospf<Ospfv2>` and
 /// uses the `"ospfv3"` proto-name across the rib client / config
@@ -49,6 +65,18 @@ pub fn despawn_ospfv3(config: &ConfigManager) {
     config.show_clients.borrow_mut().remove("ospfv3");
     config.protocol_tasks.borrow_mut().remove("ospfv3");
     let _ = config.rib_tx.send(rib::Message::ProtoCleanup {
+        proto: "ospfv3".to_string(),
+    });
+}
+
+/// Graceful-restart variant of [`despawn_ospfv3`]. See
+/// [`despawn_ospf_graceful`] — same shape, OSPFv3 proto name.
+#[allow(dead_code)]
+pub fn despawn_ospfv3_graceful(config: &ConfigManager) {
+    config.cm_clients.borrow_mut().remove("ospfv3");
+    config.show_clients.borrow_mut().remove("ospfv3");
+    config.protocol_tasks.borrow_mut().remove("ospfv3");
+    let _ = config.rib_tx.send(rib::Message::ProtoQuiesce {
         proto: "ospfv3".to_string(),
     });
 }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -275,6 +275,19 @@ pub enum Message {
     ProtoCleanup {
         proto: String,
     },
+    /// Drop the registry / redist filters / SR watchers for a
+    /// protocol whose task is being despawned, **without**
+    /// withdrawing the routes / ILMs it owns. Used by the
+    /// graceful-restart exit path so the kernel keeps forwarding
+    /// through the proto's installed routes while the daemon
+    /// restarts (RFC 3623 for OSPF, RFC 4724 for BGP, RFC 5306 for
+    /// IS-IS). The next spawn of the same proto is expected to
+    /// reclaim ownership via its protocol-specific re-convergence
+    /// (OSPF: checkpoint replay; BGP: RIB re-walk + End-of-RIB
+    /// markers; IS-IS: T2/T3 helper completion). Idempotent.
+    ProtoQuiesce {
+        proto: String,
+    },
 }
 
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1074,19 +1087,40 @@ impl Rib {
             }
         }
 
-        // Drop the registry row + every parallel name-keyed table
-        // (`redist_filters`, `sr_clients`, watcher sets).
-        if let Some(proto_id) = self.client_registry.find_by_proto(&proto) {
+        self.proto_unregister(&proto);
+    }
+
+    /// Drop the per-protocol registry / redist filters / SR
+    /// watchers without touching the FIB. Used by both
+    /// `proto_cleanup` (after withdrawing routes) and
+    /// `proto_quiesce` (which deliberately leaves routes
+    /// installed for graceful restart).
+    fn proto_unregister(&mut self, proto: &str) {
+        if let Some(proto_id) = self.client_registry.find_by_proto(proto) {
             self.client_registry.unregister(proto_id);
         }
-        self.redist_filters.remove(&proto);
-        self.sr_clients.remove(&proto);
+        self.redist_filters.remove(proto);
+        self.sr_clients.remove(proto);
         for watchers in self.block_watch.values_mut() {
-            watchers.remove(&proto);
+            watchers.remove(proto);
         }
         for watchers in self.locator_watch.values_mut() {
-            watchers.remove(&proto);
+            watchers.remove(proto);
         }
+    }
+
+    /// `ProtoQuiesce` handler — RFC 3623 / 4724 / 5306
+    /// graceful-restart exit. The protocol task is going down
+    /// (planned restart), but the kernel routes / ILMs it owns
+    /// MUST stay installed so the data plane keeps forwarding.
+    /// Same registry / filter teardown as `proto_cleanup` minus
+    /// the route + ILM withdrawal pass.
+    ///
+    /// `proto` is validated only as a name lookup (no `rtype`
+    /// match required — quiesce is protocol-agnostic, and an
+    /// unknown name is a no-op).
+    fn proto_quiesce(&mut self, proto: &str) {
+        self.proto_unregister(proto);
     }
 
     // ---- redistribute subscription handlers ------------------------
@@ -1679,6 +1713,9 @@ impl Rib {
             }
             Message::ProtoCleanup { proto } => {
                 self.proto_cleanup(proto).await;
+            }
+            Message::ProtoQuiesce { proto } => {
+                self.proto_quiesce(&proto);
             }
             Message::MacAdd {
                 vni,


### PR DESCRIPTION
## Summary

Phase 5a of OSPF graceful restart — generalized to BGP + IS-IS so the same RIB primitive serves all three protocols' GR exit paths. Locks the design decision from the [restarter scoping doc](docs/design/ospf-graceful-restart-restarter.md) (PR #883, item 1): new `ProtoQuiesce` message variant, not a flag on `ProtoCleanup`.

**Why protocol-agnostic from day one.** The "don't withdraw routes on protocol despawn" semantics are identical for OSPF (RFC 3623), BGP (RFC 4724), and IS-IS (RFC 5306). The protocol-specific behavior — Grace LSA flooding / End-of-RIB markers / T2/T3 helper signaling — happens above the RIB layer. The RIB's job is just to keep the kernel routes labeled with the protocol's `rtype` after the daemon despawns. BGP already has the GR capability negotiation surface (`RestartValue`, `LlgrValue`, per-AFI/SAFI `graceful_restart` timers in `peer.rs:225`), so `ProtoQuiesce` is the missing primitive that lets BGP GR ship its restarter side too.

## What's in this PR

- **`rib::Message::ProtoQuiesce { proto }`** — new variant. Same payload as `ProtoCleanup`. Documents the three RFCs in the doc-comment.
- **`Rib::proto_unregister(proto)`** — factored helper containing the registry / redist-filter / SR-watcher teardown shared between cleanup and quiesce. `proto_cleanup` calls it after withdrawing routes / ILMs; `proto_quiesce` calls it alone.
- **`despawn_*_graceful` companions** added to `config/ospf.rs`, `config/bgp.rs`, `config/isis.rs`. The existing `despawn_*` functions (called from `manager.rs` on `no router X`) stay on `ProtoCleanup`. The graceful entries are `#[allow(dead_code)]` until 5b/5d (OSPF) and the BGP-GR-exit PR import them.

## What's deferred

- Wiring any protocol's actual GR-exit path to the graceful variant — that's per-protocol scoping.
- Operator-visible CLI / signal trigger surface — OSPF lands it in 5c.
- The reclaim-routes-on-respawn side. The RIB layer's job is just to NOT delete on quiesce; re-adoption is the protocol's job (OSPF: checkpoint replay in 5e; BGP: RIB re-walk + EoR; IS-IS: T2/T3 helper completion).

## Test plan

- [x] `cargo fmt && cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --exclude bdd` — zero regressions.
- [ ] Verify end-to-end that kernel routes survive a `despawn_*_graceful` call: deferred to OSPF 5d (where the path is actually exercised) and to the BGP-GR-exit PR.

Generated with [Claude Code](https://claude.com/claude-code)