### PR TITLE
ospf: NSSA Type-7 ingest + default-information-originate (v3)

### DIFF
--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -94,7 +94,10 @@ impl Ospf<Ospfv3> {
 
 /// `/router/ospfv3/area/<id>/area-type` — same shape as the v2
 /// sibling in `config.rs`; delegates to the shared
-/// `area_type_set` helper.
+/// `area_type_set` helper, then triggers v3 NSSA default Type-7
+/// origination so the LSA appears on entry to NSSA and is flushed
+/// on exit (the helper short-circuits to flush when area is no
+/// longer NSSA).
 fn config_ospfv3_area_type(ospf: &mut Ospf<Ospfv3>, mut args: Args, op: ConfigOp) -> Option<()> {
     let area_id = parse_area_id(&args.string()?)?;
     let kind = if op.is_set() {
@@ -103,6 +106,7 @@ fn config_ospfv3_area_type(ospf: &mut Ospf<Ospfv3>, mut args: Args, op: ConfigOp
         AreaTypeKind::default()
     };
     area_type_set(ospf, area_id, kind);
+    ospf.nssa_default_lsa_originate(area_id);
     Some(())
 }
 
@@ -125,6 +129,10 @@ fn config_ospfv3_area_nssa_default_originate(
     let area_id = parse_area_id(&args.string()?)?;
     let value = op.is_set() && args.boolean()?;
     area_nssa_default_originate_set(ospf, area_id, value);
+    // Trigger the v3 originator (or flush) — the helper inspects
+    // the current area type + knob value and picks the right
+    // action.
+    ospf.nssa_default_lsa_originate(area_id);
     Some(())
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -3386,6 +3386,161 @@ impl Ospf<Ospfv3> {
         self.flood_self_originated_lsa(AREA0, &flood_lsa);
     }
 
+    /// v3 generic Type-7 NSSA-LSA originator. Builds an
+    /// `Ospfv3LsBody::Nssa(Ospfv3AsExternalLsa)` body for the
+    /// given v6 prefix and installs it into `area_id`'s LSDB.
+    /// `metric_type_2 = true` sets the E-bit; `fwd_addr` is
+    /// optional (encoded with the F-flag when `Some`).
+    ///
+    /// Mirror of v2's `nssa_lsa_originate_for_prefix`. Caller is
+    /// responsible for gating on area type / config; the v3
+    /// equivalents of v2's policy wrappers
+    /// (`nssa_default_lsa_originate`) sit just below.
+    ///
+    /// RFC 5340 §A.4.9: NSSA-LSA body is identical to AS-External
+    /// (§A.4.7). RFC 3101 §2.4 P-bit lives in the prefix-options
+    /// field (not the LSA header as in v2); the default-LSA
+    /// originator leaves it clear per §2.3.
+    fn nssa_lsa_originate_for_prefix_v3(
+        &mut self,
+        area_id: Ipv4Addr,
+        prefix: ipnet::Ipv6Net,
+        metric: u32,
+        metric_type_2: bool,
+        fwd_addr: Option<std::net::Ipv6Addr>,
+    ) {
+        use ospf_packet::{
+            OSPFV3_AS_EXTERNAL_FLAG_E, OSPFV3_AS_EXTERNAL_FLAG_F, OSPFV3_NSSA_LSA_TYPE,
+            Ospfv3AsExternalLsa, Ospfv3LsBody, Ospfv3LsaHeader, Ospfv3PrefixOptions,
+            ospfv3_prefix_wire_len,
+        };
+
+        // v3 LSA header: link_state_id is a 32-bit opaque value
+        // selected by the originator; for the NSSA default-LSA we
+        // use 0 (matches v2 ls_id == 0.0.0.0). For redistributed
+        // prefixes a future caller will pick something stable per
+        // RFC 5340 §A.4.7 conventions.
+        let link_state_id: u32 = if prefix.prefix_len() == 0 {
+            0
+        } else {
+            // Hash-style stable per-prefix LS-ID picker is a phase
+            // 6e concern; for now reuse the high 4 bytes of the
+            // prefix. Collisions are tolerated in this phase since
+            // only the default originator (ls_id=0) is wired here.
+            u32::from_be_bytes(prefix.network().octets()[0..4].try_into().unwrap_or([0; 4]))
+        };
+
+        let mut flags = 0u8;
+        if metric_type_2 {
+            flags |= OSPFV3_AS_EXTERNAL_FLAG_E;
+        }
+        if fwd_addr.is_some() {
+            flags |= OSPFV3_AS_EXTERNAL_FLAG_F;
+        }
+
+        // Address prefix bytes, padded to the next 4-octet boundary
+        // per RFC 5340 §A.4.1.1. `ospfv3_prefix_wire_len` gives the
+        // padded length; truncate the network bytes to that.
+        let wire_len = ospfv3_prefix_wire_len(prefix.prefix_len());
+        let mut address_prefix = vec![0u8; wire_len];
+        let net_bytes = prefix.network().octets();
+        let copy_len = wire_len.min(net_bytes.len());
+        address_prefix[..copy_len].copy_from_slice(&net_bytes[..copy_len]);
+
+        let body = Ospfv3AsExternalLsa {
+            flags,
+            metric,
+            prefix_length: prefix.prefix_len(),
+            prefix_options: Ospfv3PrefixOptions::new(),
+            referenced_ls_type: 0,
+            address_prefix,
+            forwarding_address: fwd_addr,
+            external_route_tag: None,
+            referenced_link_state_id: None,
+        };
+
+        let header = Ospfv3LsaHeader {
+            ls_age: 0,
+            ls_type: OSPFV3_NSSA_LSA_TYPE,
+            link_state_id,
+            advertising_router: self.router_id,
+            ls_seq_number: 0x8000_0001,
+            ls_checksum: 0,
+            length: 0,
+        };
+        let mut lsa = ospf_packet::Ospfv3Lsa {
+            h: header,
+            body: Ospfv3LsBody::Nssa(body),
+        };
+
+        // Preserve sequence number on refresh.
+        let key: super::lsdb::OspfLsaKey = (OSPFV3_NSSA_LSA_TYPE, link_state_id, self.router_id);
+        if let Some(area) = self.areas.get(area_id)
+            && let Some(existing) = area.lsdb.lookup_by_raw_key(key)
+        {
+            lsa.h.ls_seq_number = lsa
+                .h
+                .ls_seq_number
+                .max(existing.h.ls_seq_number.saturating_add(1));
+        }
+        lsa.update();
+
+        let flood_lsa = lsa.clone();
+        if let Some(area) = self.areas.get_mut(area_id) {
+            area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
+        }
+        self.flood_self_originated_lsa(area_id, &flood_lsa);
+    }
+
+    /// Flush a single self-originated v3 Type-7 LSA from
+    /// `area_id` keyed by the prefix-derived ls-id (0 for default).
+    fn nssa_lsa_flush_for_prefix_v3(&mut self, area_id: Ipv4Addr, prefix: ipnet::Ipv6Net) {
+        use ospf_packet::OSPFV3_NSSA_LSA_TYPE;
+        let link_state_id: u32 = if prefix.prefix_len() == 0 {
+            0
+        } else {
+            u32::from_be_bytes(prefix.network().octets()[0..4].try_into().unwrap_or([0; 4]))
+        };
+        let key: super::lsdb::OspfLsaKey = (OSPFV3_NSSA_LSA_TYPE, link_state_id, self.router_id);
+        let flushed = if let Some(area) = self.areas.get_mut(area_id) {
+            area.lsdb.flush_lsa_by_raw_key(key, &self.tx, Some(area_id))
+        } else {
+            None
+        };
+        if let Some(lsa) = flushed {
+            self.flood_self_originated_lsa(area_id, &lsa);
+        }
+    }
+
+    /// RFC 3101 §2.3 v3 NSSA default-LSA origination. Thin
+    /// wrapper around `nssa_lsa_originate_for_prefix_v3`: gates
+    /// on area type + `nssa_default_originate` knob, then
+    /// originates `::/0` with metric 1, E2, no FA.
+    pub fn nssa_default_lsa_originate(&mut self, area_id: Ipv4Addr) {
+        let area_type = match self.areas.get(area_id) {
+            Some(area) => area.area_type,
+            None => return,
+        };
+        if !area_type.is_nssa() || !area_type.nssa_default_originate {
+            self.nssa_default_lsa_flush(area_id);
+            return;
+        }
+        let default =
+            ipnet::Ipv6Net::new(std::net::Ipv6Addr::UNSPECIFIED, 0).expect("::/0 is valid");
+        self.nssa_lsa_originate_for_prefix_v3(
+            area_id, default, /* metric */ 1, /* metric_type_2 */ true,
+            /* fwd_addr */ None,
+        );
+    }
+
+    /// Flush our self-originated v3 Type-7 default LSA from
+    /// `area_id`.
+    pub fn nssa_default_lsa_flush(&mut self, area_id: Ipv4Addr) {
+        let default =
+            ipnet::Ipv6Net::new(std::net::Ipv6Addr::UNSPECIFIED, 0).expect("::/0 is valid");
+        self.nssa_lsa_flush_for_prefix_v3(area_id, default);
+    }
+
     /// Flood a v3 LSA through `area_id`, optionally exempting the
     /// source neighbor that fed it to us (RFC 2328 §13.3 Step 1c).
     /// RFC 5187 §3.2 bullets 2-3 — v3 mirror of
@@ -3840,13 +3995,13 @@ impl Ospf<Ospfv3> {
                 // RFC 2328 §13.4: a peer flooded our own LSA back to
                 // us at a higher sequence number (typical post-restart
                 // scenario). Re-originate at an even higher seq so
-                // we own the LSA again. Currently handles the three
-                // wired self-origination paths (Router-LSA,
-                // Network-LSA, Intra-Area-Prefix-LSA); other LSA
-                // types fall through.
+                // we own the LSA again. Currently handles the wired
+                // self-origination paths (Router-LSA, Network-LSA,
+                // Intra-Area-Prefix-LSA, NSSA-LSA default); other
+                // LSA types fall through.
                 use ospf_packet::{
                     OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE, OSPFV3_NETWORK_LSA_TYPE,
-                    OSPFV3_ROUTER_LSA_TYPE,
+                    OSPFV3_NSSA_LSA_TYPE, OSPFV3_ROUTER_LSA_TYPE,
                 };
                 if ev == super::lsdb::LsdbEvent::SelfOriginatedReceived {
                     let (ls_type, ls_id, _) = key;
@@ -3856,6 +4011,15 @@ impl Ospf<Ospfv3> {
                         t if t == OSPFV3_NETWORK_LSA_TYPE => self.network_lsa_originate(ls_id),
                         t if t == OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE => {
                             self.router_intra_area_prefix_lsa_originate(area)
+                        }
+                        // Only the default NSSA-LSA (link_state_id
+                        // == 0) is self-originated today. Other
+                        // ls-ids will land here once redistribute
+                        // is wired on v3 (phase 6 follow-on); for
+                        // now they're treated as no-owner and the
+                        // generic flush path handles them.
+                        t if t == OSPFV3_NSSA_LSA_TYPE && ls_id == 0 => {
+                            self.nssa_default_lsa_originate(area)
                         }
                         _ => {}
                     }

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -417,7 +417,7 @@ pub fn ospfv3_populate_initial_db_summary(
     use ospf_packet::{
         OSPFV3_AS_EXTERNAL_LSA_TYPE, OSPFV3_INTER_AREA_PREFIX_LSA_TYPE,
         OSPFV3_INTER_AREA_ROUTER_LSA_TYPE, OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE,
-        OSPFV3_NETWORK_LSA_TYPE, OSPFV3_ROUTER_LSA_TYPE,
+        OSPFV3_NETWORK_LSA_TYPE, OSPFV3_NSSA_LSA_TYPE, OSPFV3_ROUTER_LSA_TYPE,
     };
 
     for ls_type in [
@@ -428,6 +428,18 @@ pub fn ospfv3_populate_initial_db_summary(
         OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE,
     ] {
         ospf_db_summary_add_table(nbr, oi.lsdb.iter_by_raw_type(ls_type).map(|(_, lsa)| lsa));
+    }
+
+    // RFC 3101 §2.5 (inherited by v3): Type-7 NSSA-LSAs flood with
+    // area scope inside an NSSA, so they belong in the per-area DBD
+    // summary — but only when this area is NSSA.
+    if oi.area_type.is_nssa() {
+        ospf_db_summary_add_table(
+            nbr,
+            oi.lsdb
+                .iter_by_raw_type(OSPFV3_NSSA_LSA_TYPE)
+                .map(|(_, lsa)| lsa),
+        );
     }
 
     if oi.area_type.accepts_as_external() {

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -8,8 +8,9 @@ use std::net::Ipv6Addr;
 
 use ipnet::Ipv6Net;
 use ospf_packet::{
-    Ospfv3DbDesc, Ospfv3Hello, Ospfv3LsAck, Ospfv3LsRequest, Ospfv3LsRequestEntry, Ospfv3LsUpdate,
-    Ospfv3Lsa, Ospfv3LsaHeader, Ospfv3Options, Ospfv3Packet, Ospfv3Payload,
+    OSPFV3_NSSA_LSA_TYPE, Ospfv3DbDesc, Ospfv3Hello, Ospfv3LsAck, Ospfv3LsRequest,
+    Ospfv3LsRequestEntry, Ospfv3LsUpdate, Ospfv3Lsa, Ospfv3LsaHeader, Ospfv3Options, Ospfv3Packet,
+    Ospfv3Payload,
 };
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -1054,6 +1055,17 @@ fn ospfv3_ls_upd_proc(
     if scope == Ospfv3LsaScope::As && oi.area_type.is_stub_or_nssa() {
         tracing::info!(
             "[v3 LSUpd] Step 3: discarding AS-scope LSA in {:?} area",
+            oi.area_type
+        );
+        return LsaProcessResult::DiscardNoAck;
+    }
+    // RFC 3101 §2.5 (inherited by v3): Type-7 NSSA-LSAs (0x2007)
+    // are accepted only in NSSA areas. Option-bit negotiation
+    // (phase 1) usually prevents the adjacency in the first
+    // place, but defend against misconfigured peers.
+    if h.ls_type == OSPFV3_NSSA_LSA_TYPE && !oi.area_type.is_nssa() {
+        tracing::info!(
+            "[v3 LSUpd] Step 3: discarding Type-7 NSSA-LSA in {:?} area",
             oi.area_type
         );
         return LsaProcessResult::DiscardNoAck;


### PR DESCRIPTION
## Summary

Phase 6b of v2+v3 NSSA support. v3 mirror of v2's phase 2. Builds on phase 5 (\`Ospfv3LsBody::Nssa\` codec) to make Type-7 a first-class LSA in the v3 receive / database / origination paths, plus the simplest origination case — NSSA \`default-information-originate\`.

**Receive side**
- \`ospfv3_ls_upd_proc\` drops Type-7 received on Normal/Stub areas (RFC 3101 §2.5).
- \`ospfv3_populate_initial_db_summary\` adds Type-7 to the DBD summary when the area is NSSA.

**Origination side**
- New \`nssa_lsa_originate_for_prefix_v3\` + \`nssa_lsa_flush_for_prefix_v3\` build an \`Ospfv3LsBody::Nssa(Ospfv3AsExternalLsa)\` with the v3 layout — variable address_prefix, F-flag-gated FA, P-bit clear in \`prefix_options\` for the default per RFC 3101 §2.3.
- \`nssa_default_lsa_originate\` / \`nssa_default_lsa_flush\` gate on area-type + knob, call the generic builder with prefix=::/0, metric=1, E2, fwd=None.
- v3 \`config-v3.rs\` callbacks for \`area-type\` and \`nssa-default-originate\` invoke the originator.
- v3 \`process_msg\` self-originated branch handles \`OSPFV3_NSSA_LSA_TYPE\` for \`link_state_id == 0\` (default). Other ls-ids fall through to flush until v3 redistribute lands.

SPF reschedule on Type-7 install is already universal for v3 area-scope LSAs (\`packet_v3.rs:1119\`), so Type-7 inherits the trigger.

**Out of scope**: v3 Type-7 SPF/RIB (phase 6c — needs the first v3 external-route walker), v3 translator (phase 6d), v3 redistribute connected, per-area Router-LSA + Nt-bit.

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace --exclude bdd\` (no failures)
- [ ] FRR interop: configure v3 NSSA area, set \`nssa-default-originate\`, verify the Type-7 (0x2007) LSA shows up in FRR's database and floods to a peer.

Generated with [Claude Code](https://claude.com/claude-code)