### PR TITLE
ospf: originate v3 SR capability LSA (SR-Algorithm + SRGB + SRLB)

### DIFF
--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -507,5 +507,14 @@ fn config_ospfv3_sr_mpls(ospf: &mut Ospf<Ospfv3>, _args: Args, op: ConfigOp) -> 
         ospf.e_router_v3_lsa_originate(ifindex);
     }
 
+    // Originate (or flush, on disable) the per-area SR capability
+    // LSA carrying SR-Algorithm + SRGB + SRLB top-level TLVs so
+    // peers can decode the Index-form SIDs we advertise into
+    // absolute labels.
+    let area_ids: Vec<std::net::Ipv4Addr> = ospf.areas.iter().map(|(id, _)| *id).collect();
+    for area_id in area_ids {
+        ospf.e_router_v3_sr_info_lsa_originate(area_id);
+    }
+
     Some(())
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -4342,6 +4342,54 @@ impl Ospf<Ospfv3> {
         }
     }
 
+    /// Originate (or flush) the per-area E-Router-LSA carrying the
+    /// RFC 8666 §3 SR capability TLVs (SR-Algorithm, SID/Label Range
+    /// = SRGB, SR Local Block = SRLB) for the given area.
+    ///
+    /// Uses `SR_INFO_LSID` (= 0) as the per-LSA key so it never
+    /// collides with per-link E-Router-LSAs (which key by ifindex
+    /// ≥ 1 on Linux). Originates when `segment_routing == Mpls`;
+    /// flushes (MaxAge) otherwise. Re-origination on subsequent
+    /// calls bumps the sequence number based on the LSDB's prior
+    /// copy, matching the convention `e_router_v3_lsa_originate`
+    /// already uses for per-link LSAs.
+    pub fn e_router_v3_sr_info_lsa_originate(&mut self, area_id: Ipv4Addr) {
+        use ospf_packet::OSPFV3_E_ROUTER_LSA_TYPE;
+
+        use super::srmpls::{SR_INFO_LSID, SegmentRoutingMode};
+
+        let key: super::lsdb::OspfLsaKey = (OSPFV3_E_ROUTER_LSA_TYPE, SR_INFO_LSID, self.router_id);
+
+        if self.segment_routing == SegmentRoutingMode::Mpls && self.areas.get(area_id).is_some() {
+            let mut lsa = super::srmpls::e_router_v3_sr_info_lsa_build(self.router_id);
+
+            if let Some(area) = self.areas.get(area_id)
+                && let Some(prev_seq) = area
+                    .lsdb
+                    .lookup_by_raw_key(key)
+                    .map(|prev| prev.h.ls_seq_number)
+            {
+                lsa.h.ls_seq_number = lsa.h.ls_seq_number.max(prev_seq.saturating_add(1));
+            }
+            lsa.update();
+
+            let flood_lsa = lsa.clone();
+            if let Some(area) = self.areas.get_mut(area_id) {
+                area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
+            }
+            self.flood_self_originated_lsa(area_id, &flood_lsa);
+        } else {
+            let flushed = if let Some(area) = self.areas.get_mut(area_id) {
+                area.lsdb.flush_lsa_by_raw_key(key, &self.tx, Some(area_id))
+            } else {
+                None
+            };
+            if let Some(lsa) = flushed {
+                self.flood_self_originated_lsa(area_id, &lsa);
+            }
+        }
+    }
+
     /// Detect Full state transitions on `nbr` and re-originate the
     /// LSAs that depend on the full-adjacency set. Mirrors v2's
     /// `process_neighbor_state_change`:

--- a/zebra-rs/src/ospf/srmpls.rs
+++ b/zebra-rs/src/ospf/srmpls.rs
@@ -236,6 +236,56 @@ pub fn e_router_v3_lsa_build(
     lsa
 }
 
+/// Build an OSPFv3 E-Router-LSA carrying only the RFC 8666 §3 SR
+/// capability TLVs (SR-Algorithm, SID/Label Range = SRGB, SR Local
+/// Block = SRLB) and no Router-Link TLV. One per area; peers read it
+/// to translate Index-form SIDs we advertise into absolute labels.
+///
+/// `link_state_id` is reserved as `SR_INFO_LSID` so it cannot collide
+/// with the per-link LSAs (whose LS-ID is the interface ifindex, ≥ 1
+/// on Linux). RFC 5340 §3.4 treats the Link State ID as router-local
+/// per LS-Type, so we own the namespace.
+///
+/// The SRGB / SRLB are advertised as absolute Label blocks (the V/L
+/// equivalent in the Sub-TLV length discriminator), matching how
+/// `srmpls.rs` already pins the local pool to hardcoded constants.
+/// When configurable SRGB / SRLB land, the builder will read the
+/// configured range here.
+pub const SR_INFO_LSID: u32 = 0;
+
+pub fn e_router_v3_sr_info_lsa_build(router_id: Ipv4Addr) -> Ospfv3Lsa {
+    let sr_algo = Ospfv3ExtTlv::SrAlgorithm(Ospfv3SrAlgorithmTlv {
+        algos: vec![Algo::Spf],
+    });
+    let sid_range = Ospfv3ExtTlv::SidLabelRange(Ospfv3SidLabelRangeTlv {
+        range: SRGB_RANGE,
+        sid_label: SidLabelTlv::Label(SRGB_START),
+    });
+    let local_block = Ospfv3ExtTlv::SrLocalBlock(Ospfv3SrLocalBlockTlv {
+        range: SRLB_RANGE,
+        sid_label: SidLabelTlv::Label(SRLB_START),
+    });
+
+    let body = Ospfv3ELsaBody {
+        tlvs: vec![sr_algo, sid_range, local_block],
+    };
+
+    let mut lsa = Ospfv3Lsa {
+        h: Ospfv3LsaHeader {
+            ls_age: 0,
+            ls_type: OSPFV3_E_ROUTER_LSA_TYPE,
+            link_state_id: SR_INFO_LSID,
+            advertising_router: router_id,
+            ls_seq_number: 0x8000_0001,
+            ls_checksum: 0,
+            length: 0,
+        },
+        body: Ospfv3LsBody::ERouter(body),
+    };
+    lsa.update();
+    lsa
+}
+
 /// Construct an OSPFv3 `Ospfv3AdjSidSubTlv` from a configured
 /// Adjacency-SID (P2P case). Flag semantics mirror the v2 path's
 /// `build_p2p_adj_sub`: Index form leaves V + L clear; Absolute


### PR DESCRIPTION
## Summary

Phase E PR-3b — builds on PR-3a wire codec. Originates one E-Router-LSA per area carrying the three RFC 8666 §3 top-level Extended TLVs (SR-Algorithm, SID/Label Range = SRGB, SR Local Block = SRLB), with no Router-Link TLV.

- New builder `e_router_v3_sr_info_lsa_build` in `srmpls.rs`
- New originate/flush `e_router_v3_sr_info_lsa_originate(area_id)` in `inst.rs`, mirroring the per-link E-Router-LSA pattern (seq# bump, flood, MaxAge flush)
- Reserved LS-ID `SR_INFO_LSID = 0` so it cannot collide with per-link E-Router-LSAs (Linux ifindex ≥ 1)
- Wired into `config_ospfv3_sr_mpls` enable/disable hook, alongside the existing E-Intra-Area-Prefix / E-Router-with-Adj-SID fan-outs

SRGB / SRLB are advertised as absolute Label blocks because the local pool is currently pinned to `srmpls.rs` constants. When configurable SRGB / SRLB lands, the builder will read from the live config.

Ingest into `Lsdb::label_map` for v3 (so peer Index-form SIDs resolve to accurate labels in show output) follows in PR-3c.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd`
- [ ] On a v3 SR-MPLS topology: peer's `show ipv6 ospf database` should show a self-originated E-Router-LSA with LS-ID 0 carrying SR-Algorithm + SRGB + SRLB TLVs; toggling SR-MPLS off should flush it

🤖 Generated with [Claude Code](https://claude.com/claude-code)