### PR TITLE
ospf: ingest v3 SR capability TLVs into Lsdb::label_map

### DIFF
--- a/zebra-rs/src/ospf/lsdb.rs
+++ b/zebra-rs/src/ospf/lsdb.rs
@@ -539,3 +539,76 @@ impl Lsdb<Ospfv2> {
         }
     }
 }
+
+impl Lsdb<super::version::Ospfv3> {
+    /// v3 sibling of `Lsdb<Ospfv2>::insert_received`. Calls
+    /// [`update_lsa_v3`] for SR-info ingest, then hands off to the
+    /// generic install path. Used by the v3 flooding code in
+    /// `packet_v3.rs` instead of bare `install_lsa`.
+    pub fn insert_received_v3(
+        &mut self,
+        ospf_lsa: Ospfv3Lsa,
+        tx: &UnboundedSender<Message<super::version::Ospfv3>>,
+        area_id: Option<Ipv4Addr>,
+    ) {
+        self.update_lsa_v3(&ospf_lsa);
+        self.install_lsa(ospf_lsa, tx, area_id);
+    }
+
+    /// Scan an inbound v3 LSA for RFC 8666 §3 SR capability TLVs
+    /// (SID/Label Range = SRGB, SR Local Block = SRLB) and update
+    /// `label_map[adv_router]` accordingly. MaxAge LSAs evict the
+    /// entry. Mirrors the v2 path's `update_lsa` for OpaqueAreaRouterInfo.
+    ///
+    /// Any E-Router-LSA can carry these top-level TLVs per RFC 8362
+    /// §3.2 nesting; we don't gate on the LS-ID convention zebra-rs
+    /// uses for its own SR-info LSA (`SR_INFO_LSID = 0`) because
+    /// foreign implementations may place the TLVs on a different
+    /// LS-ID — only the presence of the TLVs matters.
+    pub fn update_lsa_v3(&mut self, lsa: &Ospfv3Lsa) {
+        if lsa.h.ls_type != OSPFV3_E_ROUTER_LSA_TYPE {
+            return;
+        }
+        let Ospfv3LsBody::ERouter(ref body) = lsa.body else {
+            return;
+        };
+
+        let mut global = None;
+        let mut local = None;
+        for tlv in &body.tlvs {
+            match tlv {
+                Ospfv3ExtTlv::SidLabelRange(r) => {
+                    if let SidLabelTlv::Label(start) = r.sid_label {
+                        global = Some(LabelBlock::new(start, r.range));
+                    }
+                }
+                Ospfv3ExtTlv::SrLocalBlock(lb) => {
+                    if let SidLabelTlv::Label(start) = lb.sid_label {
+                        local = Some(LabelBlock::new(start, lb.range));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // Only react when this LSA actually carried SR capability
+        // TLVs. The same advertising router emits multiple
+        // E-Router-LSAs (one per link, plus one SR-info), and the
+        // per-link ones must not evict the SR-info-derived
+        // `label_map` entry.
+        if global.is_none() && local.is_none() {
+            return;
+        }
+
+        if lsa.h.ls_age == OSPF_MAX_AGE {
+            self.label_map.remove(&lsa.h.advertising_router);
+            return;
+        }
+
+        if let Some(global) = global {
+            let label_config = LabelConfig { global, local };
+            self.label_map
+                .insert(lsa.h.advertising_router, label_config);
+        }
+    }
+}

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -1312,7 +1312,11 @@ fn ospfv3_ls_upd_proc(
         let mut area_lsa_installed = false;
         match scope {
             Ospfv3LsaScope::Area => {
-                oi.lsdb.install_lsa(cloned, oi.tx, Some(area_id));
+                // Go through `insert_received_v3` so RFC 8666 §3 SR
+                // capability TLVs on E-Router-LSAs (SRGB / SRLB)
+                // update `label_map[adv_router]` before the LSA hits
+                // the LSDB. Mirrors v2's `insert_received` shape.
+                oi.lsdb.insert_received_v3(cloned, oi.tx, Some(area_id));
                 area_lsa_installed = true;
             }
             Ospfv3LsaScope::As => {


### PR DESCRIPTION
## Summary

Phase E PR-3c. Closes the SR-info round-trip on the v3 LSDB:

- PR-3a (#887) — wire codec
- PR-3b (#890) — originate
- **PR-3c (this)** — ingest into `label_map`
- PR-3d (next) — show path reads `label_map` to resolve peer Index-form SIDs

### Changes

- `Lsdb<Ospfv3>::update_lsa_v3` walks inbound E-Router-LSAs, extracts RFC 8666 §3 `SidLabelRange` (SRGB) + `SrLocalBlock` (SRLB) top-level TLVs, and updates `label_map[adv_router]`. Mirror of the v2 path's `update_lsa` for `OpaqueAreaRouterInfo`.
- Critically gates on "this LSA actually carried SR-info TLVs" before touching `label_map`. The same router emits multiple E-Router-LSAs (one per link + the SR-info one); the per-link ones must not evict the SR-info entry. MaxAge LSAs that *did* carry SR-info correctly evict.
- `Lsdb<Ospfv3>::insert_received_v3` mirrors v2's `insert_received` pattern (update_lsa then install_lsa).
- `packet_v3.rs` flooding ingest routes area-scoped LSAs through `insert_received_v3` instead of bare `install_lsa`. AS-scope and Link-scope unchanged.

Self-originated ingest is intentionally not added — the show path currently reads local SRGB/SRLB from `srmpls.rs` constants directly. PR-3d will reconsider.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd`
- [ ] On a multi-router v3 SR-MPLS topology: verify peer's SRGB/SRLB land in `label_map`; toggling peer's SR-MPLS off (MaxAge flush) evicts the entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)