### PR TITLE
yang: quote units argument in ospf max-grace-period

### DIFF
--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -476,7 +476,7 @@ module config {
           }
           leaf max-grace-period {
             type uint32;
-            units seconds;
+            units "seconds";
             default 1800;
             description
               "Upper bound on the grace period we will honour. A


### PR DESCRIPTION
## Summary
- libyang's parser rejects an unquoted identifier as the argument to `units`, so `units seconds;` at `zebra-rs/yang/config.yang:479` failed to parse and prevented the daemon from starting.
- Quoting brings this leaf in line with every other `units` in the file (all already use `"seconds"`, `"milliseconds"`, `"bytes"`, etc.).

## Test plan
- [x] `make run` — daemon reaches `zebra-rs started` with no `ParserError`.

Generated with [Claude Code](https://claude.com/claude-code)