### PR TITLE
isis: surface SPF offload telemetry in show isis spf

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -151,6 +151,16 @@ pub struct Isis {
     /// one follow-up `Message::SpfCalc(level)` so coalesced LSDB
     /// changes during the run still get observed.
     pub spf_pending: Levels<bool>,
+    /// Wall-clock time the most recent `compute_spf` for `level` spent
+    /// running Dijkstra + TI-LFA, written by `apply_spf_result` from
+    /// `SpfOutput::duration`. None until the first SPF completes for
+    /// the level. Surfaced by `show isis spf`.
+    pub spf_duration: Levels<Option<std::time::Duration>>,
+    /// `Instant` at which the most recent `compute_spf` for `level`
+    /// finished, written by `apply_spf_result` from `SpfOutput::last`.
+    /// None until the first SPF completes for the level. Surfaced by
+    /// `show isis spf` as "Last SPF: N s ago".
+    pub spf_last: Levels<Option<std::time::Instant>>,
     /// LSP-gen coalescing slot. None means no run is currently pending;
     /// Some(Timer) means a LspGenFire is armed and additional
     /// LspOriginate events will fold into the same run.
@@ -344,6 +354,10 @@ pub struct IsisTop<'a> {
     pub spf_inflight: &'a mut Levels<bool>,
     /// Pending latch for the SPF offload — see `Isis::spf_pending`.
     pub spf_pending: &'a mut Levels<bool>,
+    /// Last SPF duration per level — see `Isis::spf_duration`.
+    pub spf_duration: &'a mut Levels<Option<std::time::Duration>>,
+    /// Last SPF completion instant per level — see `Isis::spf_last`.
+    pub spf_last: &'a mut Levels<Option<std::time::Instant>>,
     pub graph: &'a mut Levels<Option<spf::Graph>>,
     pub spf_result: &'a mut Levels<Option<BTreeMap<usize, spf::Path>>>,
     pub tilfa_result: &'a mut Levels<Option<BTreeMap<usize, Vec<spf::RepairPath>>>>,
@@ -465,6 +479,8 @@ impl Isis {
                 spf_throttle: Levels::<Throttle>::default(),
                 spf_inflight: Levels::<bool>::default(),
                 spf_pending: Levels::<bool>::default(),
+                spf_duration: Levels::<Option<std::time::Duration>>::default(),
+                spf_last: Levels::<Option<std::time::Instant>>::default(),
                 lsp_gen_timer: Levels::<Option<Timer>>::default(),
                 lsp_gen_throttle: Levels::<Throttle>::default(),
                 lsp_gen_pending_floor: Levels::<Option<u32>>::default(),
@@ -1261,6 +1277,8 @@ impl Isis {
             spf_throttle: &mut self.spf_throttle,
             spf_inflight: &mut self.spf_inflight,
             spf_pending: &mut self.spf_pending,
+            spf_duration: &mut self.spf_duration,
+            spf_last: &mut self.spf_last,
             graph: &mut self.graph,
             spf_result: &mut self.spf_result,
             tilfa_result: &mut self.tilfa_result,

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::{Ipv4Addr, Ipv6Addr};
+use std::time::{Duration, Instant};
 
 use ipnet::{Ipv4Net, Ipv6Net};
 use isis_packet::*;
@@ -1054,6 +1055,14 @@ pub struct SpfOutput {
     tilfa_result: BTreeMap<usize, Vec<spf::RepairPath>>,
     mt2: Option<Mt2Output>,
     flex_algos: Vec<FlexAlgoOutput>,
+    /// Wall-clock time `compute_spf` spent running Dijkstra + TI-LFA.
+    /// Sampled with `Instant::now()` before / after the work; carries
+    /// across the channel to `apply_spf_result`, which stashes it on
+    /// `IsisTop::spf_duration[level]` for `show isis spf`.
+    duration: Duration,
+    /// `Instant` at which the SPF run finished (end of `compute_spf`).
+    /// Used by `show isis spf` to render "Last SPF: N s ago".
+    last: Instant,
 }
 
 struct Mt2Output {
@@ -1168,6 +1177,11 @@ pub(super) fn compute_spf(input: SpfInput) -> SpfOutput {
         mt2,
         flex_algos,
     } = input;
+    // Wall-clock window spans every Dijkstra + every TI-LFA call, so
+    // the figure reflects the cost the offload worker actually paid —
+    // not just the legacy SPF. `apply_spf_result` runs on the main
+    // task and is *not* counted; that's RIB-publish work, not compute.
+    let start = Instant::now();
 
     // Legacy SPF. Full-path mode so the legacy v6 builder can apply
     // RFC 1195 §5 strict NLPID gating across every transit node.
@@ -1220,6 +1234,9 @@ pub(super) fn compute_spf(input: SpfInput) -> SpfOutput {
         )
         .collect();
 
+    let last = Instant::now();
+    let duration = last.duration_since(start);
+
     SpfOutput {
         level,
         source,
@@ -1228,6 +1245,8 @@ pub(super) fn compute_spf(input: SpfInput) -> SpfOutput {
         tilfa_result,
         mt2,
         flex_algos,
+        duration,
+        last,
     }
 }
 
@@ -1244,7 +1263,16 @@ pub(super) fn apply_spf_result(top: &mut IsisTop, output: SpfOutput) {
         tilfa_result,
         mt2,
         flex_algos,
+        duration,
+        last,
     } = output;
+
+    // Stash the compute window on `IsisTop` so `show isis spf` can
+    // render "Last SPF: N s ago, took M μs" per level. Done early so
+    // the stamps reflect "SPF finished" not "RIB-publish finished" —
+    // the RIB-publish work below isn't counted in `duration`.
+    *top.spf_duration.get_mut(&level) = Some(duration);
+    *top.spf_last.get_mut(&level) = Some(last);
 
     // Build Adjacency ILM seed from the SIDs collected during graph build.
     let mut ilm = build_adjacency_ilm(top, level, &adjacency_sids);

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -2353,6 +2353,69 @@ fn write_spf_status_banner(isis: &Isis, buf: &mut String) {
         if sr_mpls { "on" } else { "off" },
         if sr_srv6 { "on" } else { "off" },
     );
+
+    // Per-level SPF telemetry. Sourced from the offload pipeline:
+    //   * inflight / pending → SpfCalc/SpfDone gates in `inst.rs`
+    //   * duration / last    → stamped by `compute_spf` (wall-clock
+    //                          across Dijkstra + TI-LFA) and copied
+    //                          onto `IsisTop` by `apply_spf_result`.
+    let _ = writeln!(buf, "SPF stats:");
+    for level in [Level::L1, Level::L2] {
+        let inflight = *isis.spf_inflight.get(&level);
+        let pending = *isis.spf_pending.get(&level);
+        match (isis.spf_last.get(&level), isis.spf_duration.get(&level)) {
+            (Some(last), Some(duration)) => {
+                let _ = writeln!(
+                    buf,
+                    "  {}: last {} ago, took {}, inflight={}, pending={}",
+                    level,
+                    format_duration_ago(last.elapsed()),
+                    format_compute_duration(*duration),
+                    inflight,
+                    pending,
+                );
+            }
+            _ => {
+                let _ = writeln!(
+                    buf,
+                    "  {}: never run, inflight={}, pending={}",
+                    level, inflight, pending,
+                );
+            }
+        }
+    }
+}
+
+/// Format an elapsed wall-clock interval ("how long ago"). Switches
+/// units so the figure stays in 1..=999 wherever possible — typical
+/// IS-IS SPFs run many times per minute under churn, so sub-second
+/// precision matters; long-quiet networks land in minutes.
+fn format_duration_ago(d: std::time::Duration) -> String {
+    let secs = d.as_secs();
+    if secs >= 60 {
+        format!("{}m{}s", secs / 60, secs % 60)
+    } else if secs > 0 {
+        format!("{}.{:03}s", secs, d.subsec_millis())
+    } else {
+        let ms = d.subsec_millis();
+        if ms > 0 {
+            format!("{}ms", ms)
+        } else {
+            format!("{}μs", d.subsec_micros())
+        }
+    }
+}
+
+/// Format the duration `compute_spf` itself spent — typically tens
+/// of μs for tiny topologies, sub-millisecond for the labs we test
+/// against, into the millisecond range only for large fabrics.
+fn format_compute_duration(d: std::time::Duration) -> String {
+    let micros = d.as_micros();
+    if micros >= 1_000 {
+        format!("{}.{:03}ms", micros / 1_000, micros % 1_000)
+    } else {
+        format!("{}μs", micros)
+    }
 }
 
 /// `show isis flex-algo` — summary of configured FADs, peer-


### PR DESCRIPTION
## Summary

Surfaces per-level SPF state in `show isis spf` — `spf_inflight`,
`spf_pending`, plus new `spf_duration` / `spf_last` stamps for the
most recent compute window.

- `SpfOutput` regains `duration: Duration` and `last: Instant`;
  `compute_spf` stamps them with `Instant::now()` before / after the
  full Dijkstra + TI-LFA window so the figure reflects what the
  `spawn_blocking` worker actually paid. RIB-publish work in
  `apply_spf_result` is intentionally **not** counted.
- `Isis` gains `spf_duration: Levels<Option<Duration>>` and
  `spf_last: Levels<Option<Instant>>`; both threaded through
  `IsisTop`. Written by `apply_spf_result` from `SpfOutput`.
- `write_spf_status_banner` in `isis/show.rs` emits a per-level block:

  ```
  SPF stats:
    L1: last 1.234s ago, took 850μs, inflight=false, pending=false
    L2: never run, inflight=false, pending=false
  ```

  Two helpers (`format_duration_ago`, `format_compute_duration`)
  keep units readable across the μs..minutes range.

No behavior change to the SPF pipeline itself — only new data
collection and a richer show output. PR-B will add the equivalent
inflight/pending lines to OSPF's existing `show ip ospf` / OSPFv3
JSON summary.

## Test plan

- [x] `cargo build -p zebra-rs`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd`
- [ ] Real-run `show isis spf` rendering

Generated with [Claude Code](https://claude.com/claude-code)