### PR TITLE
ospf: surface per-area SPF offload gates in show

### DIFF
--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -499,6 +499,23 @@ fn show_ospf(
     if let Some(spf_duration) = ospf.spf_duration {
         writeln!(buf, " Last SPF duration {} usecs", spf_duration.as_micros())?;
     }
+    // Per-area offload gates. The instance-level `spf_last` /
+    // `spf_duration` above reflect the most-recent area's run
+    // (`apply_spf_result` stamps the instance fields unconditionally);
+    // the per-area inflight / pending flags below tell you which
+    // area's worker is still running and which has a queued
+    // follow-up. Always emitted (matching IS-IS's `show isis spf`
+    // banner) so the absence of inflight state is visible too.
+    if ospf.areas.iter().next().is_some() {
+        writeln!(buf, " SPF offload gates:")?;
+        for (area_id, area) in ospf.areas.iter() {
+            writeln!(
+                buf,
+                "   area {}: inflight={}, pending={}",
+                area_id, area.spf_inflight, area.spf_pending,
+            )?;
+        }
+    }
     Ok(buf)
 }
 

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -88,12 +88,24 @@ fn ls_type_name(ls_type: u16) -> &'static str {
 // ---- show ipv6 ospf (instance summary) --------------------------
 
 #[derive(Serialize)]
+struct Ospfv3AreaGateJson {
+    area_id: String,
+    spf_inflight: bool,
+    spf_pending: bool,
+}
+
+#[derive(Serialize)]
 struct Ospfv3SummaryJson {
     router_id: String,
     area_count: usize,
     link_count: usize,
     spf_last_ms_ago: Option<u128>,
     spf_duration_us: Option<u128>,
+    /// Per-area SPF-offload gates. The instance-level
+    /// `spf_last_ms_ago` / `spf_duration_us` reflect the most-recent
+    /// area's run; these tell automation which area's worker is still
+    /// in `spawn_blocking` and which has a coalesced follow-up.
+    spf_offload_gates: Vec<Ospfv3AreaGateJson>,
 }
 
 fn show_ospfv3_summary(
@@ -101,12 +113,22 @@ fn show_ospfv3_summary(
     _args: Args,
     json: bool,
 ) -> Result<String, std::fmt::Error> {
+    let spf_offload_gates: Vec<_> = top
+        .areas
+        .iter()
+        .map(|(area_id, area)| Ospfv3AreaGateJson {
+            area_id: area_id.to_string(),
+            spf_inflight: area.spf_inflight,
+            spf_pending: area.spf_pending,
+        })
+        .collect();
     let summary = Ospfv3SummaryJson {
         router_id: top.router_id.to_string(),
         area_count: top.areas.iter().count(),
         link_count: top.links.len(),
         spf_last_ms_ago: top.spf_last.map(|t| t.elapsed().as_millis()),
         spf_duration_us: top.spf_duration.map(|d| d.as_micros()),
+        spf_offload_gates,
     };
     let mut text = String::new();
     writeln!(text, "OSPFv3 Routing Process")?;
@@ -118,6 +140,16 @@ fn show_ospfv3_summary(
     }
     if let Some(us) = summary.spf_duration_us {
         writeln!(text, "  SPF duration: {} us", us)?;
+    }
+    if !summary.spf_offload_gates.is_empty() {
+        writeln!(text, "  SPF offload gates:")?;
+        for gate in &summary.spf_offload_gates {
+            writeln!(
+                text,
+                "    area {}: inflight={}, pending={}",
+                gate.area_id, gate.spf_inflight, gate.spf_pending,
+            )?;
+        }
     }
     render_or(json, &summary, text)
 }


### PR DESCRIPTION
## Summary

Companion to #902 — exposes the per-area `spf_inflight` /
`spf_pending` gates that the OSPF SPF-offload pipeline already
maintains, so operators can see which area's `spawn_blocking`
worker is in flight and which has a coalesced follow-up queued.

For OSPF the instance-level `spf_last` / `spf_duration` were
already surfaced; this PR adds the per-area dimension that was
previously dead-stored.

- `show ip ospf` (v2 text) gains a "SPF offload gates:" block under
  the existing "SPF algorithm last executed ... / Last SPF duration"
  lines. One line per area with `inflight=` / `pending=`. Suppressed
  when the router has no areas configured.
- `show ipv6 ospf` (v3, structured via `Ospfv3SummaryJson`) gains
  `spf_offload_gates: Vec<{area_id, spf_inflight, spf_pending}>` so
  automation can read the same data structured. Text rendering
  mirrors the v2 block.

UI-only — no data-collection changes. The gates were already being
maintained by `Message::SpfCalc` / `Message::SpfDone` in `ospf/inst.rs`.

The per-protocol model asymmetry is intentional: OSPF tracks
duration / last instance-wide (single most-recent figure across all
areas), IS-IS tracks them per-level. Promoting OSPF to per-area is
out of scope for this PR.

## Test plan

- [x] `cargo build -p zebra-rs`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude bdd`
- [ ] Real-run `show ip ospf` / `show ipv6 ospf` rendering

Generated with [Claude Code](https://claude.com/claude-code)