### PR TITLE
ospf: wire GR restart-commit exit path (v2)

### DIFF
--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -180,6 +180,10 @@ impl Ospf {
             "/graceful-restart/helper-strict-lsa-checking",
             config_ospf_gr_helper_strict_lsa_checking,
         );
+        self.ospf_add(
+            "/graceful-restart/drain-time-ms",
+            config_ospf_gr_drain_time_ms,
+        );
         self.tracing_add("/fsm", config_tracing_fsm);
         self.tracing_add("/packet", config_tracing_packet);
     }
@@ -1216,5 +1220,15 @@ fn config_ospf_gr_helper_strict_lsa_checking(
 ) -> Option<()> {
     let value = if op.is_set() { args.boolean()? } else { true };
     ospf.gr_config.helper_strict_lsa_checking = value;
+    Some(())
+}
+
+/// `router ospf / graceful-restart / drain-time-ms`. Drain
+/// window between writing the restart checkpoint and exiting
+/// the process during `clear ip ospf graceful-restart commit`
+/// (Phase 5d). YANG range 50-2000ms, default 200ms.
+fn config_ospf_gr_drain_time_ms(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let value = if op.is_set() { args.u32()? } else { 200 };
+    ospf.gr_config.drain_time_ms = value.clamp(50, 2000);
     Some(())
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -499,11 +499,13 @@ impl Ospf<Ospfv2> {
                 self.checkpoint_clear_debug();
             } else if path == "/clear/ospf/graceful-restart/begin" {
                 // Default to 120s / SoftwareRestart; YANG-side
-                // optional args (period, reason) land in Phase 5d
-                // when the commit flow ships.
+                // optional args (period, reason) land alongside
+                // restart-aware boot in Phase 5e.
                 let _ = self.gr_restart_begin(120, GraceRestartReason::SoftwareRestart);
             } else if path == "/clear/ospf/graceful-restart/abort" {
                 self.gr_restart_abort();
+            } else if path == "/clear/ospf/graceful-restart/commit" {
+                let _ = self.gr_restart_commit();
             }
             return;
         }
@@ -2202,6 +2204,80 @@ impl Ospf<Ospfv2> {
         tracing::info!("[GR Restart] aborted; Grace LSAs flushed, gr_capable cleared");
     }
 
+    /// Commit a staged graceful restart (RFC 3623 §2):
+    ///
+    ///   1. Build a Phase 5b checkpoint and atomically write it
+    ///      to `/var/lib/zebra-rs/checkpoint/ospf.cbor` (or the
+    ///      `ZEBRA_OSPF_CHECKPOINT_DIR` override).
+    ///   2. Arm a drain timer for `gr_config.drain_time_ms` so
+    ///      the Grace LSAs already flooded by Phase 5c reach the
+    ///      wire.
+    ///   3. When the timer fires, `Message::GrRestartExit` runs
+    ///      `std::process::exit(0)` — the supervisor (systemd /
+    ///      operator script) is responsible for restarting us.
+    ///
+    /// Kernel routes installed by the OSPFv2 instance survive the
+    /// exit because the protocol task dies without calling
+    /// `despawn_ospf` (which fires `ProtoCleanup` / withdraws
+    /// every route). Phase 5e's restart-aware boot path reclaims
+    /// ownership of those routes via checkpoint replay.
+    ///
+    /// Returns `false` if no restart is staged or the checkpoint
+    /// write fails; the caller (vty handler) reports failure.
+    pub fn gr_restart_commit(&mut self) -> bool {
+        use super::checkpoint::{OspfCheckpoint, default_path};
+        use super::task::{Timer, TimerType};
+
+        let Some(state) = self.restarting.as_ref() else {
+            tracing::warn!("[GR Restart] commit rejected — no restart staged");
+            return false;
+        };
+        let grace_period = state.grace_period;
+        let reason: u8 = state.reason.into();
+
+        let cp = OspfCheckpoint::from_instance(self, grace_period, reason);
+        let path = default_path("ospf");
+        if let Err(e) = cp.write_to_path(&path) {
+            tracing::warn!(
+                "[GR Restart] commit aborted: checkpoint write to {} failed: {}",
+                path.display(),
+                e
+            );
+            return false;
+        }
+        tracing::info!(
+            "[GR Restart] committed: checkpoint at {} ({} areas, {} links), drain={}ms",
+            path.display(),
+            cp.areas.len(),
+            cp.links.len(),
+            self.gr_config.drain_time_ms
+        );
+
+        // Arm the drain timer. When it fires the handler in
+        // `process_msg` calls `process::exit(0)`. We don't try to
+        // tear down the runtime gracefully — that's the
+        // supervisor's job after we exit.
+        let tx = self.tx.clone();
+        let drain_ms = self.gr_config.drain_time_ms as u64;
+        let drain_timer = Timer::new(
+            std::time::Duration::from_millis(drain_ms),
+            TimerType::Once,
+            move || {
+                let tx = tx.clone();
+                async move {
+                    let _ = tx.send(Message::GrRestartExit);
+                }
+            },
+        );
+        // Park the timer on the existing RestartingState so it
+        // doesn't get dropped before firing. Replaces the
+        // auto-abort timer — committed restarts don't auto-abort.
+        if let Some(state) = self.restarting.as_mut() {
+            state.abort_timer = Some(drain_timer);
+        }
+        true
+    }
+
     /// Build a Grace LSA for `ifindex` and emit it on that
     /// interface only (link-local scope).
     ///
@@ -2941,6 +3017,10 @@ impl Ospf<Ospfv2> {
                     "[GR Restart] auto-abort timer fired (no commit within grace period)"
                 );
                 self.gr_restart_abort();
+            }
+            Message::GrRestartExit => {
+                tracing::info!("[GR Restart] drain complete; exiting process");
+                std::process::exit(0);
             }
             Message::NssaTranslateResync(area_id) => {
                 self.nssa_translate_resync(area_id);
@@ -5753,6 +5833,12 @@ pub enum Message<V: OspfVersion = Ospfv2> {
     /// operator-driven commit (Phase 5d). Drives the same path
     /// as `clear ip ospf graceful-restart abort`.
     GrRestartAbort,
+    /// Graceful-restart commit drain complete — fired by the
+    /// short timer `gr_restart_commit` arms after writing the
+    /// checkpoint, so the Grace LSAs have time to reach the wire
+    /// before the process exits. Handler calls
+    /// `std::process::exit(0)`; the supervisor restarts us.
+    GrRestartExit,
     /// RFC 3101 NSSA Type-7→Type-5 translator resync request for
     /// `area_id`. Fired when a Type-7 LSA arrived in this NSSA, or
     /// when config (area-type / translator-role / ABR status)

--- a/zebra-rs/src/ospf/neigh.rs
+++ b/zebra-rs/src/ospf/neigh.rs
@@ -30,6 +30,12 @@ pub struct GracefulRestartConfig {
     /// environments where transient changes shouldn't cut the
     /// restart short.
     pub helper_strict_lsa_checking: bool,
+    /// Drain window (ms) between writing the restart checkpoint
+    /// and exiting the process during `clear ip ospf
+    /// graceful-restart commit`. Lets the Grace LSAs reach the
+    /// wire before the raw socket closes. Range 50-2000;
+    /// default 200ms (high end of imperceptible).
+    pub drain_time_ms: u32,
 }
 
 impl Default for GracefulRestartConfig {
@@ -38,6 +44,7 @@ impl Default for GracefulRestartConfig {
             helper_enabled: true,
             max_grace_period: 1800,
             helper_strict_lsa_checking: true,
+            drain_time_ms: 200,
         }
     }
 }

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -1760,7 +1760,7 @@ fn show_ospf_graceful_restart(
     let mut buf = String::new();
     let cfg = &ospf.gr_config;
 
-    writeln!(buf, "Graceful-restart helper configuration:")?;
+    writeln!(buf, "Graceful-restart configuration:")?;
     writeln!(buf, "  Helper enabled: {}", cfg.helper_enabled)?;
     writeln!(buf, "  Max grace period: {}s", cfg.max_grace_period)?;
     writeln!(
@@ -1768,6 +1768,16 @@ fn show_ospf_graceful_restart(
         "  Strict LSA checking: {}",
         cfg.helper_strict_lsa_checking
     )?;
+    writeln!(buf, "  Drain time: {}ms", cfg.drain_time_ms)?;
+    if let Some(ref state) = ospf.restarting {
+        writeln!(
+            buf,
+            "  Restart staged: grace={}s, reason={:?}, age={:?}",
+            state.grace_period,
+            state.reason,
+            state.entered_at.elapsed()
+        )?;
+    }
     writeln!(buf)?;
 
     let mut any = false;

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -495,6 +495,20 @@ module config {
                useful when transient changes elsewhere shouldn't
                cut the restart short.";
           }
+          leaf drain-time-ms {
+            type uint32 {
+              range "50..2000";
+            }
+            units milliseconds;
+            default 200;
+            description
+              "Window between writing the restart checkpoint and
+               exiting the process during `clear ip ospf
+               graceful-restart commit`. Picked so the Grace LSAs
+               reach the wire before the raw socket closes; 200ms
+               is the high end of imperceptible on LAN, absorbs
+               tunnel RTTs up to ~100ms.";
+          }
         }
         container tracing {
           leaf all {

--- a/zebra-rs/yang/configure.yang
+++ b/zebra-rs/yang/configure.yang
@@ -124,12 +124,18 @@ module configure {
         }
       }
       container graceful-restart {
-        // Phase 5c — stage / unstage a planned restart. `begin`
-        // floods Grace LSAs and sets `gr_capable`; `abort` walks
-        // it back. The actual exit (`commit`) lands in Phase 5d
-        // alongside checkpoint write + ProtoQuiesce.
+        // Stage / commit / unstage a planned restart.
+        // `begin` (Phase 5c) floods Grace LSAs and sets
+        // `gr_capable`; `commit` (Phase 5d) writes the
+        // checkpoint and exits the process for the
+        // supervisor to restart; `abort` walks the staging
+        // back without exiting.
         leaf begin {
           ext:help "Stage a graceful restart: flood Grace LSAs and set gr_capable";
+          type empty;
+        }
+        leaf commit {
+          ext:help "Write the GR checkpoint, drain, and exit the process";
           type empty;
         }
         leaf abort {


### PR DESCRIPTION
## Summary

Phase 5d of OSPFv2 graceful restart. Ties together Phase 5b (checkpoint storage, PR #900) and Phase 5c (begin + Grace-LSA flood, PR #904) into the actual exit path.

- **`gr_restart_commit`** — builds an `OspfCheckpoint` via `from_instance`, writes it atomically to `/var/lib/zebra-rs/checkpoint/ospf.cbor`, arms a drain timer for `gr_config.drain_time_ms`, and on fire dispatches `Message::GrRestartExit`. Handler in `process_msg` calls `std::process::exit(0)`. The supervisor (systemd / operator) restarts us; kernel routes survive because the process dies without firing `ProtoCleanup`.
- **`Message::GrRestartExit`** new variant + dispatch arm.
- **CLI**: `clear ip ospf graceful-restart commit` (Phase 5c's `begin` / `abort` already shipped).
- **`drain-time-ms` YANG knob** under `graceful-restart` (range 50-2000, default 200 per the locked design — high end of imperceptible). Lands as `gr_config.drain_time_ms`.
- **`show ip ospf graceful-restart`** now renders the drain knob and the staged-restart state when `Ospf::restarting.is_some()`.

## How it ties to the design decisions

- **Locked decision #1** (`ProtoQuiesce` new variant, not flag on `ProtoCleanup`) — used in 5a for `no router ospf` graceful-despawn. For 5d the process exits without going through `despawn_*` at all; the kernel-route survival comes from "never sent withdrawals" instead of "sent ProtoQuiesce". Different surface, same outcome.
- **Locked decision #6** (200ms drain default, 50-2000 knob range) — implemented in this PR.

## What's deferred

- **Phase 5e** — restart-aware boot: detect the checkpoint at startup, pre-populate areas / links / LSDB / neighbors from it, short-circuit NFSM for was-Full neighbors. Today the next boot still cold-starts; the checkpoint sits on disk unused. Operator-driven test of commit just verifies the process exits and the file lands; restart-side correctness comes with 5e.
- **Phase 5f** — v3 LR-bit signaling.

## Test plan

- [x] `cargo fmt && cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --exclude bdd` — zero regressions.
- [ ] Operator-driven smoke test: `clear ospf graceful-restart begin`, observe gr_capable / Grace LSAs in flight, `clear ospf graceful-restart commit`, observe checkpoint file written + process exit. Deferred to manual run with a real interface — unit-testing process::exit is tricky.

Generated with [Claude Code](https://claude.com/claude-code)