### PR TITLE
deps: bump hmac/md-5/sha1/sha2 and prefix-trie to latest

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -25,7 +25,7 @@ regex = "1.10"
 similar = "3"
 dirs = "6"
 async-trait = "0.1"
-prefix-trie = "0.8.2"
+prefix-trie = "0.9.2"
 #prefix-trie = { git = "https://github.com/zebra-rs/prefix-trie" }
 thiserror = "2"
 tracing = "0.1"
@@ -66,10 +66,10 @@ num_enum = "0.7.5"
 nanomsg = "0.7.2"
 itertools = "0.14.0"
 dashmap = "6"
-md-5 = "0.10"
-sha1 = "0.10"
-sha2 = "0.10"
-hmac = "0.12"
+md-5 = "0.11"
+sha1 = "0.11"
+sha2 = "0.11"
+hmac = "0.13"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = { git = "https://github.com/zebra-rs/rtnetlink", rev = "2d7b1830e9bd9a049a757f0a79ccd16216450bf2" }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1572,14 +1572,14 @@ fn route_soft_out_peer_table(
             .local_rib
             .v4vpn
             .get(&rd)
-            .map(|t| t.1.iter().map(|(p, r)| (*p, r.clone())).collect())
+            .map(|t| t.1.iter().map(|(p, r)| (p, r.clone())).collect())
             .unwrap_or_default(),
         None => bgp
             .local_rib
             .v4
             .1
             .iter()
-            .map(|(p, r)| (*p, r.clone()))
+            .map(|(p, r)| (p, r.clone()))
             .collect(),
     };
 
@@ -3512,14 +3512,14 @@ pub fn route_sync_ipv4(peer: &mut Peer, bgp: &mut BgpTop) {
             .v4
             .0
             .iter()
-            .flat_map(|(prefix, ribs)| ribs.iter().map(move |rib| (*prefix, rib.clone())))
+            .flat_map(|(prefix, ribs)| ribs.iter().map(move |rib| (prefix, rib.clone())))
             .collect()
     } else {
         bgp.local_rib
             .v4
             .1
             .iter()
-            .map(|(prefix, rib)| (*prefix, rib.clone()))
+            .map(|(prefix, rib)| (prefix, rib.clone()))
             .collect()
     };
 
@@ -3568,7 +3568,7 @@ pub fn route_sync_vpnv4(peer: &mut Peer, bgp: &mut BgpTop) {
                 let routes: Vec<(Ipv4Net, BgpRib)> = table
                     .0
                     .iter()
-                    .flat_map(|(prefix, ribs)| ribs.iter().map(move |rib| (*prefix, rib.clone())))
+                    .flat_map(|(prefix, ribs)| ribs.iter().map(move |rib| (prefix, rib.clone())))
                     .collect();
                 (*rd, routes)
             })
@@ -3581,7 +3581,7 @@ pub fn route_sync_vpnv4(peer: &mut Peer, bgp: &mut BgpTop) {
                 let routes: Vec<(Ipv4Net, BgpRib)> = table
                     .1
                     .iter()
-                    .map(|(prefix, rib)| (*prefix, rib.clone()))
+                    .map(|(prefix, rib)| (prefix, rib.clone()))
                     .collect();
                 (*rd, routes)
             })

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -298,14 +298,14 @@ pub fn diff_apply_flex_algo(
         for (prefix, _) in diff.only_curr.iter() {
             let msg = rib::Message::FlexAlgoRouteDel {
                 algo,
-                prefix: **prefix,
+                prefix: *prefix,
             };
             rib_client.send(msg).unwrap();
         }
         for (prefix, _, route) in diff.different.iter() {
             // A changed route that no longer has a usable forwarding
             // plane (lost SID or lost all nhops) collapses to a Del.
-            match make_flex_algo_route(algo, **prefix, route) {
+            match make_flex_algo_route(algo, *prefix, route) {
                 Some(r) => {
                     let msg = rib::Message::FlexAlgoRouteAdd { route: r };
                     rib_client.send(msg).unwrap();
@@ -313,14 +313,14 @@ pub fn diff_apply_flex_algo(
                 None => {
                     let msg = rib::Message::FlexAlgoRouteDel {
                         algo,
-                        prefix: **prefix,
+                        prefix: *prefix,
                     };
                     rib_client.send(msg).unwrap();
                 }
             }
         }
         for (prefix, route) in diff.only_next.iter() {
-            if let Some(r) = make_flex_algo_route(algo, **prefix, route) {
+            if let Some(r) = make_flex_algo_route(algo, *prefix, route) {
                 let msg = rib::Message::FlexAlgoRouteAdd { route: r };
                 rib_client.send(msg).unwrap();
             }
@@ -334,7 +334,7 @@ pub fn diff_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffResult)
         if !route.nhops.is_empty() {
             let rib = make_rib_entry(route);
             let msg = rib::Message::Ipv4Del {
-                prefix: **prefix,
+                prefix: *prefix,
                 rib,
             };
             rib_client.send(msg).unwrap();
@@ -345,7 +345,7 @@ pub fn diff_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffResult)
         if !route.nhops.is_empty() {
             let rib = make_rib_entry(route);
             let msg = rib::Message::Ipv4Add {
-                prefix: **prefix,
+                prefix: *prefix,
                 rib,
             };
             rib_client.send(msg).unwrap();
@@ -356,7 +356,7 @@ pub fn diff_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffResult)
         if !route.nhops.is_empty() {
             let rib = make_rib_entry(route);
             let msg = rib::Message::Ipv4Add {
-                prefix: **prefix,
+                prefix: *prefix,
                 rib,
             };
             rib_client.send(msg).unwrap();
@@ -419,7 +419,7 @@ pub fn diff_apply_v6(rib_client: &crate::rib::client::RibClient, diff: &DiffResu
         if !route.nhops.is_empty() {
             let rib = make_rib_entry_v6(route);
             let msg = rib::Message::Ipv6Del {
-                prefix: **prefix,
+                prefix: *prefix,
                 rib,
             };
             rib_client.send(msg).unwrap();
@@ -429,7 +429,7 @@ pub fn diff_apply_v6(rib_client: &crate::rib::client::RibClient, diff: &DiffResu
         if !route.nhops.is_empty() {
             let rib = make_rib_entry_v6(route);
             let msg = rib::Message::Ipv6Add {
-                prefix: **prefix,
+                prefix: *prefix,
                 rib,
             };
             rib_client.send(msg).unwrap();
@@ -439,7 +439,7 @@ pub fn diff_apply_v6(rib_client: &crate::rib::client::RibClient, diff: &DiffResu
         if !route.nhops.is_empty() {
             let rib = make_rib_entry_v6(route);
             let msg = rib::Message::Ipv6Add {
-                prefix: **prefix,
+                prefix: *prefix,
                 rib,
             };
             rib_client.send(msg).unwrap();
@@ -488,9 +488,9 @@ pub fn diff_ilm_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffIlm
     // Delete.
     for (label, ilm) in diff.only_curr.iter() {
         if !ilm.nhops.is_empty() {
-            let ilm_entry = make_ilm_entry(**label, ilm);
+            let ilm_entry = make_ilm_entry(*label, ilm);
             let msg = rib::Message::IlmDel {
-                label: **label,
+                label: *label,
                 ilm: ilm_entry,
             };
             rib_client.send(msg).unwrap();
@@ -499,9 +499,9 @@ pub fn diff_ilm_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffIlm
     // Add (changed).
     for (label, _, ilm) in diff.different.iter() {
         if !ilm.nhops.is_empty() {
-            let ilm_entry = make_ilm_entry(**label, ilm);
+            let ilm_entry = make_ilm_entry(*label, ilm);
             let msg = rib::Message::IlmAdd {
-                label: **label,
+                label: *label,
                 ilm: ilm_entry,
             };
             rib_client.send(msg).unwrap();
@@ -510,9 +510,9 @@ pub fn diff_ilm_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffIlm
     // Add (new).
     for (label, ilm) in diff.only_next.iter() {
         if !ilm.nhops.is_empty() {
-            let ilm_entry = make_ilm_entry(**label, ilm);
+            let ilm_entry = make_ilm_entry(*label, ilm);
             let msg = rib::Message::IlmAdd {
-                label: **label,
+                label: *label,
                 ilm: ilm_entry,
             };
             rib_client.send(msg).unwrap();
@@ -990,7 +990,10 @@ fn apply_routing_updates(
 ) {
     // Update MPLS ILM
     if top.config.distribute.rib {
-        let diff = spf::table_diff(top.ilm.get(&level).iter(), ilm.iter());
+        let diff = spf::table_diff(
+            top.ilm.get(&level).iter().map(|(&k, v)| (k, v)),
+            ilm.iter().map(|(&k, v)| (k, v)),
+        );
         diff_ilm_apply(top.rib_client, &diff);
     }
     *top.ilm.get_mut(&level) = ilm;

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -1237,7 +1237,7 @@ fn write_rib_v4_detail(buf: &mut String, isis: &Isis, level: &Level) -> std::fmt
     };
 
     let mut entries: Vec<_> = isis.rib.get(level).iter().collect();
-    entries.sort_by_key(|(p, _)| **p);
+    entries.sort_by_key(|(p, _)| *p);
 
     for (prefix, route) in entries {
         writeln!(buf, "{} {} [metric {}]", level_short, prefix, route.metric)?;
@@ -1259,7 +1259,7 @@ fn write_rib_v6_detail(buf: &mut String, isis: &Isis, level: &Level) -> std::fmt
     };
 
     let mut entries: Vec<_> = isis.rib_v6.get(level).iter().collect();
-    entries.sort_by_key(|(p, _)| **p);
+    entries.sort_by_key(|(p, _)| *p);
 
     for (prefix, route) in entries {
         writeln!(buf, "{} {} [metric {}]", level_short, prefix, route.metric)?;
@@ -1333,7 +1333,7 @@ fn write_rib_v4(buf: &mut String, isis: &Isis, level: &Level) -> std::fmt::Resul
     writeln!(buf, " {}", "-".repeat(total - 2))?;
 
     let mut entries: Vec<_> = isis.rib.get(level).iter().collect();
-    entries.sort_by_key(|(p, _)| **p);
+    entries.sort_by_key(|(p, _)| *p);
 
     for (prefix, route) in entries {
         if route.nhops.is_empty() {
@@ -1407,7 +1407,7 @@ fn write_rib_v6(buf: &mut String, isis: &Isis, level: &Level) -> std::fmt::Resul
     writeln!(buf, " {}", "-".repeat(total - 2))?;
 
     let mut entries: Vec<_> = isis.rib_v6.get(level).iter().collect();
-    entries.sort_by_key(|(p, _)| **p);
+    entries.sort_by_key(|(p, _)| *p);
 
     for (prefix, route) in entries {
         if route.nhops.is_empty() {

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -6970,7 +6970,10 @@ fn apply_routing_updates_v3(
     let mut new_ilm = build_ilm_from_rib6(&new_rib);
     add_self_prefix_sids_to_ilm_v3(top, &mut new_ilm);
     add_self_adj_sids_to_ilm_v3(top, &mut new_ilm);
-    let ilm_diff = spf::table_diff(top.ilm6.iter(), new_ilm.iter());
+    let ilm_diff = spf::table_diff(
+        top.ilm6.iter().map(|(&k, v)| (k, v)),
+        new_ilm.iter().map(|(&k, v)| (k, v)),
+    );
     diff_ilm_apply_v6(&top.ctx.rib, &ilm_diff);
     top.ilm6 = new_ilm;
 
@@ -6980,7 +6983,7 @@ fn apply_routing_updates_v3(
     for (prefix, route) in diff.only_curr.iter() {
         let entry = make_rib6_entry(route);
         let _ = top.ctx.rib.send(rib::Message::Ipv6Del {
-            prefix: **prefix,
+            prefix: *prefix,
             rib: entry,
         });
     }
@@ -6988,7 +6991,7 @@ fn apply_routing_updates_v3(
     for (prefix, _, route) in diff.different.iter() {
         let entry = make_rib6_entry(route);
         let _ = top.ctx.rib.send(rib::Message::Ipv6Add {
-            prefix: **prefix,
+            prefix: *prefix,
             rib: entry,
         });
     }
@@ -6996,7 +6999,7 @@ fn apply_routing_updates_v3(
     for (prefix, route) in diff.only_next.iter() {
         let entry = make_rib6_entry(route);
         let _ = top.ctx.rib.send(rib::Message::Ipv6Add {
-            prefix: **prefix,
+            prefix: *prefix,
             rib: entry,
         });
     }
@@ -7167,7 +7170,7 @@ pub fn diff_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffResult)
         if !route.nhops.is_empty() {
             let rib = make_rib_entry(route);
             let msg = rib::Message::Ipv4Del {
-                prefix: **prefix,
+                prefix: *prefix,
                 rib,
             };
             rib_client.send(msg).unwrap();
@@ -7178,7 +7181,7 @@ pub fn diff_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffResult)
         if !route.nhops.is_empty() {
             let rib = make_rib_entry(route);
             let msg = rib::Message::Ipv4Add {
-                prefix: **prefix,
+                prefix: *prefix,
                 rib,
             };
             rib_client.send(msg).unwrap();
@@ -7189,7 +7192,7 @@ pub fn diff_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffResult)
         if !route.nhops.is_empty() {
             let rib = make_rib_entry(route);
             let msg = rib::Message::Ipv4Add {
-                prefix: **prefix,
+                prefix: *prefix,
                 rib,
             };
             rib_client.send(msg).unwrap();
@@ -7240,8 +7243,8 @@ pub fn diff_ilm_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffIlm
     for (label, ilm) in diff.only_curr.iter() {
         if !ilm.nhops.is_empty() {
             let msg = rib::Message::IlmDel {
-                label: **label,
-                ilm: make_ilm_entry(**label, ilm),
+                label: *label,
+                ilm: make_ilm_entry(*label, ilm),
             };
             rib_client.send(msg).unwrap();
         }
@@ -7249,8 +7252,8 @@ pub fn diff_ilm_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffIlm
     for (label, _, ilm) in diff.different.iter() {
         if !ilm.nhops.is_empty() {
             let msg = rib::Message::IlmAdd {
-                label: **label,
-                ilm: make_ilm_entry(**label, ilm),
+                label: *label,
+                ilm: make_ilm_entry(*label, ilm),
             };
             rib_client.send(msg).unwrap();
         }
@@ -7258,8 +7261,8 @@ pub fn diff_ilm_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffIlm
     for (label, ilm) in diff.only_next.iter() {
         if !ilm.nhops.is_empty() {
             let msg = rib::Message::IlmAdd {
-                label: **label,
-                ilm: make_ilm_entry(**label, ilm),
+                label: *label,
+                ilm: make_ilm_entry(*label, ilm),
             };
             rib_client.send(msg).unwrap();
         }
@@ -7342,8 +7345,8 @@ pub fn diff_ilm_apply_v6(rib_client: &crate::rib::client::RibClient, diff: &Diff
     for (label, ilm) in diff.only_curr.iter() {
         if !ilm.nhops.is_empty() {
             let msg = rib::Message::IlmDel {
-                label: **label,
-                ilm: make_ilm_entry_v6(**label, ilm),
+                label: *label,
+                ilm: make_ilm_entry_v6(*label, ilm),
             };
             rib_client.send(msg).unwrap();
         }
@@ -7351,8 +7354,8 @@ pub fn diff_ilm_apply_v6(rib_client: &crate::rib::client::RibClient, diff: &Diff
     for (label, _, ilm) in diff.different.iter() {
         if !ilm.nhops.is_empty() {
             let msg = rib::Message::IlmAdd {
-                label: **label,
-                ilm: make_ilm_entry_v6(**label, ilm),
+                label: *label,
+                ilm: make_ilm_entry_v6(*label, ilm),
             };
             rib_client.send(msg).unwrap();
         }
@@ -7360,8 +7363,8 @@ pub fn diff_ilm_apply_v6(rib_client: &crate::rib::client::RibClient, diff: &Diff
     for (label, ilm) in diff.only_next.iter() {
         if !ilm.nhops.is_empty() {
             let msg = rib::Message::IlmAdd {
-                label: **label,
-                ilm: make_ilm_entry_v6(**label, ilm),
+                label: *label,
+                ilm: make_ilm_entry_v6(*label, ilm),
             };
             rib_client.send(msg).unwrap();
         }
@@ -7862,7 +7865,10 @@ fn apply_routing_updates(top: &mut Ospf, rib: PrefixMap<Ipv4Net, SpfRoute>) {
     let mut ilm = build_ilm_from_rib(&rib);
     add_self_prefix_sids_to_ilm(top, &mut ilm);
     add_self_adj_sids_to_ilm(top, &mut ilm);
-    let ilm_diff = spf::table_diff(top.ilm.iter(), ilm.iter());
+    let ilm_diff = spf::table_diff(
+        top.ilm.iter().map(|(&k, v)| (k, v)),
+        ilm.iter().map(|(&k, v)| (k, v)),
+    );
     diff_ilm_apply(&top.ctx.rib, &ilm_diff);
     top.ilm = ilm;
 

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -119,7 +119,7 @@ pub(super) fn apply_link_auth(packet: &mut Ospfv2Packet, ctx: &AuthSendCtx) {
 /// packet. Centralizes the algorithm dispatch so apply / verify
 /// produce the same bytes from the same inputs.
 fn compute_crypto_trailer(key: &super::link::AuthKey, packet_bytes: &[u8]) -> Vec<u8> {
-    use hmac::{Hmac, Mac};
+    use hmac::{Hmac, KeyInit, Mac};
     use md5::{Digest, Md5};
     use sha1::Sha1;
     use sha2::{Sha256, Sha384, Sha512};
@@ -138,25 +138,25 @@ fn compute_crypto_trailer(key: &super::link::AuthKey, packet_bytes: &[u8]) -> Ve
         }
         OspfCryptoAlgo::HmacSha1 => {
             let mut m =
-                <Hmac<Sha1> as Mac>::new_from_slice(&key.raw).expect("HMAC accepts any key length");
+                Hmac::<Sha1>::new_from_slice(&key.raw).expect("HMAC accepts any key length");
             m.update(packet_bytes);
             m.finalize().into_bytes().to_vec()
         }
         OspfCryptoAlgo::HmacSha256 => {
-            let mut m = <Hmac<Sha256> as Mac>::new_from_slice(&key.raw)
-                .expect("HMAC accepts any key length");
+            let mut m =
+                Hmac::<Sha256>::new_from_slice(&key.raw).expect("HMAC accepts any key length");
             m.update(packet_bytes);
             m.finalize().into_bytes().to_vec()
         }
         OspfCryptoAlgo::HmacSha384 => {
-            let mut m = <Hmac<Sha384> as Mac>::new_from_slice(&key.raw)
-                .expect("HMAC accepts any key length");
+            let mut m =
+                Hmac::<Sha384>::new_from_slice(&key.raw).expect("HMAC accepts any key length");
             m.update(packet_bytes);
             m.finalize().into_bytes().to_vec()
         }
         OspfCryptoAlgo::HmacSha512 => {
-            let mut m = <Hmac<Sha512> as Mac>::new_from_slice(&key.raw)
-                .expect("HMAC accepts any key length");
+            let mut m =
+                Hmac::<Sha512>::new_from_slice(&key.raw).expect("HMAC accepts any key length");
             m.update(packet_bytes);
             m.finalize().into_bytes().to_vec()
         }

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -42,7 +42,7 @@ fn compute_v3_trailer_digest(
     packet_bytes_with_checksum: &[u8],
     trailer_prefix_with_apad: &[u8],
 ) -> Vec<u8> {
-    use hmac::{Hmac, Mac};
+    use hmac::{Hmac, KeyInit, Mac};
     use md5::{Digest, Md5};
     use sha1::Sha1;
     use sha2::{Sha256, Sha384, Sha512};
@@ -68,31 +68,31 @@ fn compute_v3_trailer_digest(
         }
         OspfCryptoAlgo::HmacSha1 => {
             let mut m =
-                <Hmac<Sha1> as Mac>::new_from_slice(&key.raw).expect("HMAC accepts any key length");
+                Hmac::<Sha1>::new_from_slice(&key.raw).expect("HMAC accepts any key length");
             m.update(&src_bytes);
             m.update(packet_bytes_with_checksum);
             m.update(trailer_prefix_with_apad);
             m.finalize().into_bytes().to_vec()
         }
         OspfCryptoAlgo::HmacSha256 => {
-            let mut m = <Hmac<Sha256> as Mac>::new_from_slice(&key.raw)
-                .expect("HMAC accepts any key length");
+            let mut m =
+                Hmac::<Sha256>::new_from_slice(&key.raw).expect("HMAC accepts any key length");
             m.update(&src_bytes);
             m.update(packet_bytes_with_checksum);
             m.update(trailer_prefix_with_apad);
             m.finalize().into_bytes().to_vec()
         }
         OspfCryptoAlgo::HmacSha384 => {
-            let mut m = <Hmac<Sha384> as Mac>::new_from_slice(&key.raw)
-                .expect("HMAC accepts any key length");
+            let mut m =
+                Hmac::<Sha384>::new_from_slice(&key.raw).expect("HMAC accepts any key length");
             m.update(&src_bytes);
             m.update(packet_bytes_with_checksum);
             m.update(trailer_prefix_with_apad);
             m.finalize().into_bytes().to_vec()
         }
         OspfCryptoAlgo::HmacSha512 => {
-            let mut m = <Hmac<Sha512> as Mac>::new_from_slice(&key.raw)
-                .expect("HMAC accepts any key length");
+            let mut m =
+                Hmac::<Sha512>::new_from_slice(&key.raw).expect("HMAC accepts any key length");
             m.update(&src_bytes);
             m.update(packet_bytes_with_checksum);
             m.update(trailer_prefix_with_apad);

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -1056,7 +1056,7 @@ impl Rib {
             .table
             .iter()
             .filter_map(|(prefix, entries)| {
-                entries.iter().any(|e| e.rtype == rtype).then_some(*prefix)
+                entries.iter().any(|e| e.rtype == rtype).then_some(prefix)
             })
             .collect();
         for prefix in v4_prefixes {
@@ -1068,7 +1068,7 @@ impl Rib {
             .table_v6
             .iter()
             .filter_map(|(prefix, entries)| {
-                entries.iter().any(|e| e.rtype == rtype).then_some(*prefix)
+                entries.iter().any(|e| e.rtype == rtype).then_some(prefix)
             })
             .collect();
         for prefix in v6_prefixes {

--- a/zebra-rs/src/rib/redist.rs
+++ b/zebra-rs/src/rib/redist.rs
@@ -94,7 +94,7 @@ pub fn walk_v4(
             continue;
         };
         buf.push(RouteEntryV4 {
-            prefix: *prefix,
+            prefix,
             nexthop: nh4,
             subtype: entry.rsubtype.clone(),
             metric: entry.metric,
@@ -131,7 +131,7 @@ pub fn walk_v6(
             continue;
         };
         buf.push(RouteEntryV6 {
-            prefix: *prefix,
+            prefix,
             nexthop: nh6,
             subtype: entry.rsubtype.clone(),
             metric: entry.metric,

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -938,9 +938,15 @@ pub async fn ipv4_route_sync(
     table_id: u32,
     ifdown: bool,
 ) {
-    for (p, entries) in table.iter_mut() {
+    // Collect prefixes first so we don't hold the !Send `IterMut`
+    // across the `ipv4_entry_selection` await.
+    let prefixes: Vec<Ipv4Net> = table.iter().map(|(p, _)| p).collect();
+    for p in prefixes {
+        let Some(entries) = table.get_mut(&p) else {
+            continue;
+        };
         ipv4_entry_resolve(entries, nmap, ifdown);
-        ipv4_entry_selection(p, entries, None, nmap, fib, table_id, ifdown).await;
+        ipv4_entry_selection(&p, entries, None, nmap, fib, table_id, ifdown).await;
     }
 }
 
@@ -1527,9 +1533,15 @@ pub async fn ipv6_route_sync(
     fib: &FibHandle,
     table_id: u32,
 ) {
-    for (p, entries) in table.iter_mut() {
+    // Collect prefixes first so we don't hold the !Send `IterMut`
+    // across the `ipv6_entry_selection` await.
+    let prefixes: Vec<Ipv6Net> = table.iter().map(|(p, _)| p).collect();
+    for p in prefixes {
+        let Some(entries) = table.get_mut(&p) else {
+            continue;
+        };
         ipv6_entry_resolve(entries, nmap);
-        ipv6_entry_selection(p, entries, None, nmap, fib, table_id).await;
+        ipv6_entry_selection(&p, entries, None, nmap, fib, table_id).await;
     }
 }
 

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1027,7 +1027,7 @@ pub fn rib_show(rib: &Rib, _args: Args, json: bool) -> String {
 
         for (prefix, entries) in rib.table.iter() {
             for entry in entries.iter() {
-                routes.push(rib_entry_to_json(rib, prefix, entry));
+                routes.push(rib_entry_to_json(rib, &prefix, entry));
             }
         }
 
@@ -1040,7 +1040,12 @@ pub fn rib_show(rib: &Rib, _args: Args, json: bool) -> String {
 
         for (prefix, entries) in rib.table.iter() {
             for entry in entries.iter() {
-                write!(buf, "{}", rib_entry_show(rib, prefix, entry, json).unwrap()).unwrap();
+                write!(
+                    buf,
+                    "{}",
+                    rib_entry_show(rib, &prefix, entry, json).unwrap()
+                )
+                .unwrap();
             }
         }
         buf
@@ -1058,7 +1063,7 @@ pub fn rib_show_detail(rib: &Rib, args: Args, json: bool) -> String {
     let mut buf = String::new();
     for (prefix, entries) in rib.table.iter() {
         for entry in entries.iter() {
-            buf.push_str(&rib_entry_show_detail(rib, prefix, entry));
+            buf.push_str(&rib_entry_show_detail(rib, &prefix, entry));
         }
     }
     buf
@@ -1119,7 +1124,7 @@ pub fn rib6_show(rib: &Rib, _args: Args, json: bool) -> String {
 
         for (prefix, entries) in rib.table_v6.iter() {
             for entry in entries.iter() {
-                routes.push(rib_entry_to_json_v6(rib, prefix, entry));
+                routes.push(rib_entry_to_json_v6(rib, &prefix, entry));
             }
         }
 
@@ -1135,7 +1140,7 @@ pub fn rib6_show(rib: &Rib, _args: Args, json: bool) -> String {
                 write!(
                     buf,
                     "{}",
-                    rib_entry_show_v6(rib, prefix, entry, json).unwrap()
+                    rib_entry_show_v6(rib, &prefix, entry, json).unwrap()
                 )
                 .unwrap();
             }
@@ -1153,7 +1158,7 @@ pub fn rib6_show_detail(rib: &Rib, args: Args, json: bool) -> String {
     let mut buf = String::new();
     for (prefix, entries) in rib.table_v6.iter() {
         for entry in entries.iter() {
-            buf.push_str(&rib_entry_show_v6_detail(rib, prefix, entry));
+            buf.push_str(&rib_entry_show_v6_detail(rib, &prefix, entry));
         }
     }
     buf
@@ -1398,7 +1403,7 @@ fn ilm_to_json(
 fn find_route_for_nexthop<'a>(
     rib: &'a Rib,
     target_uni: &super::NexthopUni,
-) -> Option<(&'a Ipv4Net, &'a RibEntry)> {
+) -> Option<(Ipv4Net, &'a RibEntry)> {
     for (prefix, entries) in rib.table.iter() {
         for entry in entries.iter() {
             match &entry.nexthop {

--- a/zebra-rs/src/spf/diff.rs
+++ b/zebra-rs/src/spf/diff.rs
@@ -1,18 +1,22 @@
 /// Generic result for table diff operations
 #[derive(Debug)]
 pub struct TableDiffResult<'a, K, V> {
-    pub only_curr: Vec<(&'a K, &'a V)>,
-    pub only_next: Vec<(&'a K, &'a V)>,
-    pub different: Vec<(&'a K, &'a V, &'a V)>,
-    pub identical: Vec<(&'a K, &'a V)>,
+    pub only_curr: Vec<(K, &'a V)>,
+    pub only_next: Vec<(K, &'a V)>,
+    pub different: Vec<(K, &'a V, &'a V)>,
+    pub identical: Vec<(K, &'a V)>,
 }
 
-/// Generic table diff implementation using sorted iterators
-pub fn table_diff<'a, K, V, I>(curr_iter: I, next_iter: I) -> TableDiffResult<'a, K, V>
+/// Generic table diff implementation using sorted iterators.
+/// Keys are taken by value because `prefix-trie` 0.9 yields owned
+/// prefixes (which are `Copy`), and `BTreeMap` callers can adapt
+/// with `.iter().map(|(&k, v)| (k, v))`.
+pub fn table_diff<'a, K, V, I1, I2>(curr_iter: I1, next_iter: I2) -> TableDiffResult<'a, K, V>
 where
-    K: Ord,
+    K: Ord + Copy,
     V: PartialEq,
-    I: Iterator<Item = (&'a K, &'a V)>,
+    I1: Iterator<Item = (K, &'a V)>,
+    I2: Iterator<Item = (K, &'a V)>,
 {
     let mut res = TableDiffResult {
         only_curr: vec![],
@@ -27,7 +31,7 @@ where
     while let (Some(&(curr_key, curr_value)), Some(&(next_key, next_value))) =
         (curr_iter.peek(), next_iter.peek())
     {
-        match curr_key.cmp(next_key) {
+        match curr_key.cmp(&next_key) {
             std::cmp::Ordering::Less => {
                 // curr_key is only in curr
                 res.only_curr.push((curr_key, curr_value));


### PR DESCRIPTION
## Summary

- **hmac 0.12 → 0.13**, **md-5/sha1/sha2 0.10 → 0.11**: `new_from_slice` moved from `Mac` to `KeyInit` in the digest 0.11 chain. The OSPF v2/v3 auth-trailer compute is the only consumer; bring `KeyInit` into scope and drop the `<Hmac<X> as Mac>::` disambiguator.
- **prefix-trie 0.8 → 0.9**: `iter`/`iter_mut` now yield owned `(K, &V)` instead of `(&K, &V)`. Updated `spf::table_diff` to take `K: Copy + Ord` with two iterator type parameters so `BTreeMap` call sites can adapt with `.map(|(&k, v)| (k, v))` (the two adapter closures have distinct nominal types). Swept the resulting `*prefix`/`**prefix` deref and `&prefix` borrow sites across `rib/`, `bgp/`, `ospf/`, `isis/`.
- **`IterMut` `!Send` regression** in prefix-trie 0.9: iterator state now carries a `*mut MaybeUninit<T>`. `ipv{4,6}_route_sync` was holding the iterator across the FIB await inside a `tokio::spawn`'d task; reworked to collect prefixes first, then `get_mut` + await per prefix.

## Test plan

- [x] `cargo build -p zebra-rs`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bin zebra-rs` — 636 passed, 0 failed (includes all OSPF auth-trailer round-trip tests for MD5 / HMAC-SHA1/256/384/512 on v2 and v3, plus the SPF, IS-IS, BGP, RIB, and SRv6 unit suites)

Generated with [Claude Code](https://claude.com/claude-code)