### PR TITLE
yang: quote units argument in ospf gr drain-time-ms

### DIFF
--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -499,7 +499,7 @@ module config {
             type uint32 {
               range "50..2000";
             }
-            units milliseconds;
+            units "milliseconds";
             default 200;
             description
               "Window between writing the restart checkpoint and


### PR DESCRIPTION
## Summary

- `zebra-rs/yang/config.yang:502` shipped with an unquoted `units milliseconds;` (introduced by `11bb1a83` "ospf: wire GR restart-commit exit path (v2)"). The current libyang parser rejects bare-identifier arguments with `LA(1): milliseconds (Identifier) ... at non-terminal "BasicString"`, which aborts daemon startup.
- One-character fix: quote the argument like every other `units` use in the tree.

## Note on the underlying issue

RFC 7950 §6.1.3 actually allows unquoted strings as YANG statement arguments, so the libyang parser is being stricter than the spec. A separate libyang PR (#23 → merged as `406c9c04`) fixes the grammar permanently. This change is the immediate unblock so the daemon can start today.

## Test plan

- [x] `cargo build -p zebra-rs`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bin zebra-rs` — 637 passed

Generated with [Claude Code](https://claude.com/claude-code)