### PR TITLE
deps: bump libyang to include unquoted-string fix

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -19,7 +19,7 @@ tokio-stream.workspace = true
 tonic.workspace = true
 tonic-prost.workspace = true
 console-subscriber = "0.5"
-libyang = { git = "https://github.com/zebra-rs/libyang", rev = "afe164df37bfb1137bb50088d80b2b515d749903" }
+libyang = { git = "https://github.com/zebra-rs/libyang", rev = "406c9c04145e6faf956624468a613ad47798a894" }
 #libyang = { path = "../../libyang" }
 regex = "1.10"
 similar = "3"


### PR DESCRIPTION
## Summary

Pulls in [zebra-rs/libyang#23](https://github.com/zebra-rs/libyang/pull/23) (merge commit `406c9c04`), which extends `Ystring` to accept the unquoted-identifier form per RFC 7950 §6.1.3.

Before this bump, every `Ystring` consumer in the YANG grammar (`units`, `error-message`, `presence`, `must`, `path`, `pattern`, `organization`, `contact`, `description`, `reference`, `when`) silently required quoted arguments and rejected RFC-valid YANG modules with errors like \`LA(1): <ident> ... at non-terminal "BasicString"\`. \`DefaultStmt\` already accepted the bare form via a separate \`AsciiNoSemicolon\` path, so the gap was inconsistent.

Already-quoted \`units\` lines in \`zebra-rs/yang/\` continue to parse unchanged; this just stops the bare-identifier form from breaking the daemon (as happened with the unquoted \`units milliseconds;\` introduced by \`11bb1a83\`, fixed by PR #909 as a workaround).

## Test plan

- [x] \`cargo build -p zebra-rs\`
- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p zebra-rs --bin zebra-rs\` — 637 passed

Generated with [Claude Code](https://claude.com/claude-code)