### PR TITLE
ospf: stop setting O-bit in outgoing Hellos

### DIFF
--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -289,9 +289,13 @@ pub fn ospf_hello_packet(
     // RFC 2328 §A.2 / RFC 3101 §2.5: E-bit clear on stub/NSSA,
     // N-bit set on NSSA. Drives the per-area negotiation — a
     // neighbor whose bits differ is rejected by `ospf_hello_recv`.
+    //
+    // Deliberately NOT setting the O-bit: RFC 5250 §2.1 says it
+    // MUST NOT appear in Hello — Opaque capability is negotiated
+    // via DBD (see ospf_make_dd below) and via LSA headers. FRR
+    // logs `O-bit abuse?` when it sees one here.
     hello.options.set_external(oi.area_type.e_bit());
     hello.options.set_nssa(oi.area_type.n_bit());
-    hello.options.set_o(true);
     for (_, nbr) in oi.nbrs.iter() {
         if nbr.state == NfsmState::Down {
             continue;


### PR DESCRIPTION
## Summary

`ospf_hello_packet` was stamping `options.set_o(true)` on every outgoing Hello next to the per-area E/N bits. **RFC 5250 §2.1** explicitly forbids this:

> The O-bit MUST NOT be set in OSPFv2 Hello packets. The O-bit indicates that the originating router supports Opaque-LSA capability. […] this option is conveyed only via Database Description packets and LSA headers […]

FRR's `ospfd` enforces the check and emits one `[EC 134217741] Hello:RECV ... O-bit abuse?` warning per Hello per neighbor, which floods FRR logs whenever zebra-rs is the peer:

```
2026-05-24 08:34:26 [WARN] ospfd: [R7QG8-A7727][EC 134217741] Packet 10.0.0.1 [Hello:RECV]: O-bit abuse? on enp0s6:192.168.10.2
2026-05-24 08:34:27 [WARN] ospfd: [R7QG8-A7727][EC 134217741] Packet 10.0.0.1 [Hello:RECV]: O-bit abuse? on enp0s6:192.168.10.2
...
```

## Impact

- The DBD path already sets the O-bit (`packet.rs:486`, per RFC 5250 §2.4) — peers continue to learn our Opaque capability through the spec-mandated channel.
- Our own `ospf_hello_recv` option-mismatch gate only consults the E and N bits (`packet.rs:374-381`), so dropping the outbound set doesn't affect adjacency formation in either direction.
- Net effect: silences FRR's warning storm; Opaque-LSA exchange unchanged.

## Test plan

- [x] `cargo build -p zebra-rs`
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bin zebra-rs` — 637 passed (including the OSPF v2/v3 packet round-trip suites)

Generated with [Claude Code](https://claude.com/claude-code)