### PR TITLE
ospf: don't ack LSAs we discard via MinLSArrival

### DIFF
--- a/zebra-rs/src/ospf/flood.rs
+++ b/zebra-rs/src/ospf/flood.rs
@@ -1,9 +1,7 @@
-use std::time::Duration;
-
 use ospf_packet::*;
 
 use super::inst::Message;
-use super::lsdb::{LsdbEvent, OSPF_MIN_LS_ARRIVAL, OspfLsaKey, v2_lsa_key};
+use super::lsdb::{LsdbEvent, OspfLsaKey, v2_lsa_key};
 use super::task::{Timer, TimerType};
 use super::version::OspfVersion;
 use super::{Neighbor, NfsmState, inst::OspfInterface, nfsm::ospf_nfsm_check_nbr_loading};
@@ -97,25 +95,16 @@ pub fn ospf_flood_self_originated_lsa(oi: &OspfInterface, lsa: &OspfLsa) {
 }
 
 pub fn ospf_flood(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) {
+    // NB: RFC 2328 §13 step 5(a) MinLSArrival gate lives in
+    // `ospf_ls_upd_proc` (the orchestrator). Putting it here would
+    // make the discard silent — the caller would still emit a
+    // delayed Ack, the peer would prune its retransmit list, and
+    // the genuinely-newer LSA would never come around again.
     let scope = lsa_flood_scope(lsa.h.ls_type);
     let lsdb = match scope {
         FloodScope::As => &mut *oi.lsdb_as,
         _ => &mut *oi.lsdb,
     };
-
-    // MinLSArrival check: if the same LSA was installed less than 1 second ago, discard.
-    if let Some(install_time) =
-        lsdb.lookup_install_time(lsa.h.ls_type, lsa.h.ls_id, lsa.h.adv_router)
-        && install_time.elapsed() < Duration::from_secs(OSPF_MIN_LS_ARRIVAL)
-    {
-        tracing::info!(
-            "[Flood] MinLSArrival: discarding LSA type={:?} id={} adv={}",
-            lsa.h.ls_type,
-            lsa.h.ls_id,
-            lsa.h.adv_router
-        );
-        return;
-    }
 
     // RFC 2328: Install into LSDB first, then flood.
     let area_id = match scope {

--- a/zebra-rs/src/ospf/lsdb.rs
+++ b/zebra-rs/src/ospf/lsdb.rs
@@ -394,16 +394,14 @@ impl<V: OspfVersion> Lsdb<V> {
         self.tables.insert(lsa_key, lsa);
     }
 
-    /// Return the install timestamp of an LSA, if present. Now
-    /// generic.
-    pub fn lookup_install_time(
-        &self,
-        ls_type: OspfLsType,
-        ls_id: Ipv4Addr,
-        adv_router: Ipv4Addr,
-    ) -> Option<tokio::time::Instant> {
-        self.lookup_lsa(ls_type, ls_id, adv_router)
-            .map(|lsa| lsa.install_time)
+    /// Return the install timestamp of an LSA, if present.
+    /// Used by `ospf_ls_upd_proc` / `ospfv3_ls_upd_proc` step 5(a)
+    /// to enforce MinLSArrival (RFC 2328 §13 / RFC 5340 §4.5).
+    /// Both versions key off `OspfLsaKey` directly because v3's
+    /// `ls_type` is a raw `u16` (RFC 5340 §A.4.2.1) that doesn't
+    /// fit the v2-typed `OspfLsType` enum.
+    pub fn lookup_install_time_by_raw_key(&self, key: OspfLsaKey) -> Option<tokio::time::Instant> {
+        self.tables.get(&key).map(|lsa| lsa.install_time)
     }
 
     /// Re-originate an existing LSA with a bumped sequence number.

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -16,8 +16,9 @@ use crate::{
 use super::{
     FloodScope, Identity, IfsmEvent, IfsmState, Message, Neighbor, NfsmEvent, NfsmState, OspfLink,
     inst::OspfInterface, link::OspfAuthMode, lsa_flood_scope, lsdb::OSPF_MAX_AGE,
-    lsdb::OSPF_MAX_AGE_DIFF, lsdb::OSPF_MAX_LSA_SEQ, ospf_flood, ospf_flood_self_originated_lsa,
-    ospf_is_self_originated, ospf_ls_request_lookup, tracing::OspfTracing,
+    lsdb::OSPF_MAX_AGE_DIFF, lsdb::OSPF_MAX_LSA_SEQ, lsdb::OSPF_MIN_LS_ARRIVAL, ospf_flood,
+    ospf_flood_self_originated_lsa, ospf_is_self_originated, ospf_ls_request_lookup,
+    tracing::OspfTracing,
 };
 
 /// Resolved authentication state for a single outbound packet.
@@ -945,17 +946,28 @@ fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -
     }
 
     // Step 4: Look up current database copy, compute comparison result.
-    // Use lookup_lsa() to get the Lsa wrapper so we can compute current_age().
-    let (current, current_age, ret) = {
-        let db_lsa = oi
-            .lsdb
-            .lookup_lsa(lsa.h.ls_type, lsa.h.ls_id, lsa.h.adv_router);
+    // Use lookup_lsa() to get the Lsa wrapper so we can compute
+    // current_age() and capture install_time for the step-5(a)
+    // MinLSArrival check. Dispatch by scope so AS-scoped LSAs
+    // (AsExternal, OpaqueAsWide) read the AS LSDB instead of the
+    // area LSDB.
+    let (current, current_age, current_install_time, ret) = {
+        let lsdb_ref = match lsa_flood_scope(lsa.h.ls_type) {
+            FloodScope::As => &*oi.lsdb_as,
+            _ => &*oi.lsdb,
+        };
+        let db_lsa = lsdb_ref.lookup_lsa(lsa.h.ls_type, lsa.h.ls_id, lsa.h.adv_router);
         match db_lsa {
-            None => (None, 0u16, 1i32), // No current copy: received is "newer".
+            None => (None, 0u16, None, 1i32), // No current copy: received is "newer".
             Some(current_lsa) => {
                 let age = current_lsa.current_age();
                 let cmp = ospf_lsa_more_recent(&lsa.h, lsa.h.ls_age, &current_lsa.data.h, age);
-                (Some(current_lsa.data.clone()), age, cmp)
+                (
+                    Some(current_lsa.data.clone()),
+                    age,
+                    Some(current_lsa.install_time),
+                    cmp,
+                )
             }
         }
     };
@@ -974,6 +986,24 @@ fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -
 
     // Step 5: Received LSA is newer (or no current copy exists).
     if current.is_none() || ret > 0 {
+        // Step 5(a): if the DB copy was received via flooding less
+        // than MinLSArrival ago, discard the new instance WITHOUT
+        // acknowledging — the peer's retransmit timer is what makes
+        // sure we eventually pick the genuinely-newer LSA up. If we
+        // acked here the peer would prune its `ls_rxmt` and we'd
+        // hold the stale copy until the next refresh.
+        if let Some(install_time) = current_install_time
+            && install_time.elapsed() < std::time::Duration::from_secs(OSPF_MIN_LS_ARRIVAL)
+        {
+            tracing::info!(
+                "[LS Update] Step 5(a) MinLSArrival: discarding (no ack) LSA type={:?} id={} adv={} seq={:#x}",
+                lsa.h.ls_type,
+                lsa.h.ls_id,
+                lsa.h.adv_router,
+                lsa.h.ls_seq_number
+            );
+            return LsaProcessResult::DiscardNoAck;
+        }
         tracing::info!(
             "[LS Update] Installing newer LSA type={:?} id={} adv={} seq={:#x}",
             lsa.h.ls_type,

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -1265,7 +1265,7 @@ fn ospfv3_ls_upd_proc(
     lsa: &Ospfv3Lsa,
     src: &Ipv6Addr,
 ) -> LsaProcessResult {
-    use super::lsdb::{OSPF_MAX_AGE, OSPF_MAX_LSA_SEQ};
+    use super::lsdb::{OSPF_MAX_AGE, OSPF_MAX_LSA_SEQ, OSPF_MIN_LS_ARRIVAL};
 
     let h = &lsa.h;
     let scope = ospfv3_ls_type_scope(h.ls_type);
@@ -1293,19 +1293,20 @@ fn ospfv3_ls_upd_proc(
     }
 
     // Step 4: look up DB copy and compute recency comparison.
-    let (current_age, current_seq, cmp_result, have_current) = {
+    let (current_age, current_seq, current_install_time, cmp_result, have_current) = {
         let lsdb_ref = match scope {
             Ospfv3LsaScope::As => &*oi.lsdb_as,
             Ospfv3LsaScope::Link => &*oi.link_lsdb,
             _ => &*oi.lsdb,
         };
         match lsdb_ref.lookup_by_raw_key(key) {
-            None => (0u16, 0u32, 1i32, false),
+            None => (0u16, 0u32, None, 1i32, false),
             Some(curr) => {
                 let age = curr.h.ls_age;
                 let seq = curr.h.ls_seq_number;
                 let cmp = ospfv3_lsa_more_recent(h, h.ls_age, &curr.h, age);
-                (age, seq, cmp, true)
+                let install_time = lsdb_ref.lookup_install_time_by_raw_key(key);
+                (age, seq, install_time, cmp, true)
             }
         }
     };
@@ -1319,6 +1320,25 @@ fn ospfv3_ls_upd_proc(
 
     // Step 5: received LSA is newer than our copy (or we have none).
     if !have_current || cmp_result > 0 {
+        // Step 5(a): if the DB copy was received via flooding less
+        // than MinLSArrival ago, discard the new instance WITHOUT
+        // acknowledging — the peer's retransmit timer is what makes
+        // sure we eventually pick the genuinely-newer LSA up. If we
+        // acked here the peer would prune its `ls_rxmt` and we'd
+        // hold the stale copy until the next refresh. Mirror of
+        // v2's `ospf_ls_upd_proc` step 5(a).
+        if let Some(install_time) = current_install_time
+            && install_time.elapsed() < std::time::Duration::from_secs(OSPF_MIN_LS_ARRIVAL)
+        {
+            tracing::info!(
+                "[v3 LSUpd] Step 5(a) MinLSArrival: discarding (no ack) LSA type={:#x} id={} adv={} seq={:#x}",
+                h.ls_type,
+                h.link_state_id,
+                h.advertising_router,
+                h.ls_seq_number
+            );
+            return LsaProcessResult::DiscardNoAck;
+        }
         let cloned = lsa.clone();
         let mut area_lsa_installed = false;
         match scope {


### PR DESCRIPTION
## Summary

RFC 2328 §13 step 5(a) — and RFC 5340 §4.5 by inheritance — require that a new LSA which arrives within `MinLSArrival` of the DB copy's install time be discarded **without acknowledging**. We were doing the discard but still acking, which let the neighbor prune its retransmit list; the genuinely-newer LSA never came around again and we stayed pinned to the stale copy until the next periodic refresh.

## Concrete failure (with FRR peer)

FRR re-originates its Router-LSA twice in quick succession as our adjacency reaches Full:
1. once on `DeadInterval` expiry (drops us as a P2P peer → 5-link Router-LSA without backlink), and
2. once on Full (adds the P2P backlink back → 6-link Router-LSA).

The two refreshes can arrive < 1 s apart. We installed the first via the LSR/LSU exchange, then dropped the second via `ospf_flood`'s silent `MinLSArrival` `return`, then **acked it anyway**. Our LSDB held an LSA without the P2P backlink, the bidirectional check in `graph()` excluded the edge, and SPF produced an empty graph for the local router. \`clear ip ospf neighbor\` on FRR was the only way to recover.

## Fix

| File | Change |
|---|---|
| `zebra-rs/src/ospf/flood.rs` | Drop the `MinLSArrival` check from `ospf_flood` (it returned void, hiding the discard from the caller). |
| `zebra-rs/src/ospf/packet.rs` | Add the check at v2's `ospf_ls_upd_proc` step 5(a); return `DiscardNoAck` on hit. Step-4 lookup now dispatches by `lsa_flood_scope` so AS-scoped LSAs (AsExternal, OpaqueAsWide) read `lsdb_as`. |
| `zebra-rs/src/ospf/packet_v3.rs` | Add the same step-5(a) gate to `ospfv3_ls_upd_proc` (it had no MinLSArrival check at all before). v3 already dispatched by scope at step 4. |
| `zebra-rs/src/ospf/lsdb.rs` | Replace v2-typed `lookup_install_time` with `lookup_install_time_by_raw_key`; both versions use the same generic helper now. |

## Test plan

- [x] \`cargo build -p zebra-rs\`
- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p zebra-rs --bin zebra-rs\` — 637 passed
- [ ] Manual: re-run the FRR scenario from the bug report and confirm our LSDB picks up FRR's current Router-LSA (with the P2P backlink) on the first adjacency formation, with no \`clear ip ospf neighbor\` needed.

Generated with [Claude Code](https://claude.com/claude-code)