### PR TITLE
ospf: make AllSPFRouters multicast join idempotent

### DIFF
--- a/zebra-rs/src/ospf/ifsm.rs
+++ b/zebra-rs/src/ospf/ifsm.rs
@@ -160,8 +160,17 @@ pub fn ospf_ifsm_interface_up<V: OspfVersion>(link: &mut OspfLink<V>) -> Option<
         return None;
     }
 
-    V::join_if(&link.sock, link.index);
-    link.multicast_memberships.set_all_routers(true);
+    // Idempotent join: `InterfaceUp` can fire twice within a single
+    // run when `Message::Enable` and the kernel-driven `link_up`
+    // path race during startup (config commit + netlink dump on an
+    // already-up interface). Re-calling `IP_ADD_MEMBERSHIP` for the
+    // same (group, ifindex) returns EADDRINUSE; the tracked flag
+    // lets us no-op the second join instead. Same pattern the DR
+    // path already uses for AllDRouters.
+    if !link.multicast_memberships.all_routers() {
+        V::join_if(&link.sock, link.index);
+        link.multicast_memberships.set_all_routers(true);
+    }
 
     // P2P interfaces skip Waiting / DR election entirely (RFC 2328
     // §10.3) — they go straight to PointToPoint and let the NFSM


### PR DESCRIPTION
## Summary

`ospf_ifsm_interface_up` called `V::join_if` unconditionally and then set `multicast_memberships.all_routers`. The flag was written but never read, so when `InterfaceUp` fired twice for the same ifindex within a single run we re-issued `IP_ADD_MEMBERSHIP` for a group we'd already joined and the kernel returned EADDRINUSE:

```
ospf: join AllSPFRouters on ifindex 3 failed: Address already in use (os error 98)
```

## Why it manifests on second-and-later runs

Two code paths can both queue `IfsmEvent::InterfaceUp` for the same ifindex within a single run:

1. **`Message::Enable`** (`inst.rs:3084-3102`) — sets `link.enabled = true`, then sends `Ifsm(InterfaceUp)`. Fires when the YANG config commits.
2. **`link_up`** (`inst.rs:330-347`) — sends `Ifsm(InterfaceUp)` when the kernel signals carrier-up, *if* `link.enabled` is already true.

On the first run, config commit usually lands after the netlink dump → `link.enabled` is false when `link_up` runs → only the later `Enable` fires `InterfaceUp` once.

On second-and-later runs, the kernel link is already up before zebra-rs starts. The netlink dump and the config commit race, and the order frequently flips: `Enable` runs first (sets `link.enabled = true`, queues `InterfaceUp`), then `link_up`'s `if link.enabled` check passes and queues a second `InterfaceUp`. Two joins → second one EADDRINUSE.

No socket-level cleanup on exit is needed — the kernel auto-drops memberships when the socket fd closes, so this is not a cross-run leak.

## Fix

Gate the join behind the already-tracked `multicast_memberships.all_routers()` flag — the same pattern the AllDRouters join in `ospf_dr_election` (`ifsm.rs:330-341`) already uses.

```rust
if !link.multicast_memberships.all_routers() {
    V::join_if(&link.sock, link.index);
    link.multicast_memberships.set_all_routers(true);
}
```

Applies to both v2 and v3 since `ospf_ifsm_interface_up` is generic over `V`.

## Test plan

- [x] \`cargo build -p zebra-rs\`
- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p zebra-rs --bin zebra-rs\` — 637 passed
- [ ] Manual: restart zebra-rs twice, confirm the EADDRINUSE warning no longer appears on the second run.

Generated with [Claude Code](https://claude.com/claude-code)