### PR TITLE
ospf: treat EADDRINUSE on multicast join as informational

### DIFF
--- a/zebra-rs/src/ospf/socket.rs
+++ b/zebra-rs/src/ospf/socket.rs
@@ -37,13 +37,29 @@ pub fn set_ipv4_pktinfo(socket: &Socket) {
     };
 }
 
+/// EADDRINUSE from `IP_ADD_MEMBERSHIP` / `IPV6_JOIN_GROUP` is the
+/// kernel telling us the (group, ifindex) is already on this
+/// socket's mc_list. That's the *desired* end state — the IFSM
+/// guard in `ospf_ifsm_interface_up` avoids the syscall when we
+/// know we're a member, but it can still fire on paths that race
+/// with `interface_down` (which currently clears the bookkeeping
+/// flag without issuing an explicit `IP_DROP_MEMBERSHIP`). Treat
+/// it as informational rather than warning the operator.
+fn is_eaddrinuse(err: &std::io::Error) -> bool {
+    err.raw_os_error() == Some(libc::EADDRINUSE)
+}
+
 pub fn ospf_join_if(socket: &AsyncFd<Socket>, ifindex: u32) {
     let maddr = Ospfv2::ALL_SPF_ROUTERS;
     if let Err(e) = socket
         .get_ref()
         .join_multicast_v4_n(&maddr, &InterfaceIndexOrAddress::Index(ifindex))
     {
-        tracing::warn!("ospf: join AllSPFRouters on ifindex {ifindex} failed: {e}");
+        if is_eaddrinuse(&e) {
+            tracing::debug!("ospf: AllSPFRouters already joined on ifindex {ifindex}");
+        } else {
+            tracing::warn!("ospf: join AllSPFRouters on ifindex {ifindex} failed: {e}");
+        }
     }
 }
 
@@ -53,7 +69,11 @@ pub fn ospf_join_alldrouters(socket: &AsyncFd<Socket>, ifindex: u32) {
         .get_ref()
         .join_multicast_v4_n(&maddr, &InterfaceIndexOrAddress::Index(ifindex))
     {
-        tracing::warn!("ospf: join AllDRouters on ifindex {ifindex} failed: {e}");
+        if is_eaddrinuse(&e) {
+            tracing::debug!("ospf: AllDRouters already joined on ifindex {ifindex}");
+        } else {
+            tracing::warn!("ospf: join AllDRouters on ifindex {ifindex} failed: {e}");
+        }
     }
 }
 
@@ -118,7 +138,11 @@ pub fn set_ipv6_pktinfo(socket: &Socket) {
 pub fn ospf_join_if_v6(socket: &AsyncFd<Socket>, ifindex: u32) {
     let maddr = Ospfv3::ALL_SPF_ROUTERS;
     if let Err(e) = socket.get_ref().join_multicast_v6(&maddr, ifindex) {
-        tracing::warn!("ospf: join AllSPFRouters (v6) on ifindex {ifindex} failed: {e}");
+        if is_eaddrinuse(&e) {
+            tracing::debug!("ospf: AllSPFRouters (v6) already joined on ifindex {ifindex}");
+        } else {
+            tracing::warn!("ospf: join AllSPFRouters (v6) on ifindex {ifindex} failed: {e}");
+        }
     }
 }
 
@@ -129,7 +153,11 @@ pub fn ospf_join_if_v6(socket: &AsyncFd<Socket>, ifindex: u32) {
 pub fn ospf_join_alldrouters_v6(socket: &AsyncFd<Socket>, ifindex: u32) {
     let maddr = Ospfv3::ALL_DROUTERS;
     if let Err(e) = socket.get_ref().join_multicast_v6(&maddr, ifindex) {
-        tracing::warn!("ospf: join AllDRouters (v6) on ifindex {ifindex} failed: {e}");
+        if is_eaddrinuse(&e) {
+            tracing::debug!("ospf: AllDRouters (v6) already joined on ifindex {ifindex}");
+        } else {
+            tracing::warn!("ospf: join AllDRouters (v6) on ifindex {ifindex} failed: {e}");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

PR #914 gated the AllSPFRouters join behind the \`multicast_memberships.all_routers()\` flag, but the warning still fires:

\`\`\`
ospf: join AllSPFRouters on ifindex 3 failed: Address already in use (os error 98)
\`\`\`

The remaining path is \`ospf_ifsm_interface_down\`: it clears \`oi.multicast_memberships = 0.into()\` (the bookkeeping flag) but never issues an explicit \`IP_DROP_MEMBERSHIP\`. After a Down→Up cycle our flag says "not a member" while the kernel still has the membership, so the next \`InterfaceUp\` re-enters the join path and the kernel returns EADDRINUSE.

EADDRINUSE on \`IP_ADD_MEMBERSHIP\` / \`IPV6_JOIN_GROUP\` is the kernel telling us the (group, ifindex) is already on this socket's \`mc_list\` — which is the *desired* end state. Demote it from \`warn\` to \`debug\` at the syscall site. The IFSM-level guard still avoids the syscall on the happy path; this just keeps the corner cases quiet.

## Coverage

Applied symmetrically to all four wrappers in \`socket.rs\`:

- \`ospf_join_if\` — v2 AllSPFRouters
- \`ospf_join_alldrouters\` — v2 AllDRouters
- \`ospf_join_if_v6\` — v3 AllSPFRouters
- \`ospf_join_alldrouters_v6\` — v3 AllDRouters

A small \`is_eaddrinuse\` helper centralizes the OS-error match so the four call sites stay mechanical mirrors of each other.

## Follow-up not in scope

The deeper fix — issuing \`IP_DROP_MEMBERSHIP\` from \`interface_down\` so the kernel and bookkeeping stay in sync — is left for a follow-up. It touches the IFSM symmetry pattern more broadly (need v2 + v3 leave helpers, and a clear decision on whether interface flap should leave or just sleep) and the silenced warning is the operator-visible symptom that needed addressing first.

## Test plan

- [x] \`cargo build -p zebra-rs\`
- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p zebra-rs --bin zebra-rs\` — 637 passed
- [ ] Manual: restart zebra-rs twice; confirm the EADDRINUSE warning no longer appears in the second run's logs.

Generated with [Claude Code](https://claude.com/claude-code)