### PR TITLE
isis: add Authentication Information TLV (type 10) wire support

### DIFF
--- a/crates/isis-packet/src/disp.rs
+++ b/crates/isis-packet/src/disp.rs
@@ -3,8 +3,9 @@ use std::fmt::{Display, Formatter, Result};
 use itertools::Itertools;
 
 use crate::{
-    IsLevel, IsisCsnp, IsisHello, IsisLsp, IsisLspEntry, IsisLspId, IsisNeighborId, IsisP2pHello,
-    IsisPacket, IsisPdu, IsisProto, IsisPsnp, IsisSysId, IsisTlv, IsisTlvAreaAddr, IsisTlvHostname,
+    ISIS_AUTH_TYPE_CLEARTEXT, ISIS_AUTH_TYPE_GENERIC, ISIS_AUTH_TYPE_HMAC_MD5, IsLevel, IsisCsnp,
+    IsisHello, IsisLsp, IsisLspEntry, IsisLspId, IsisNeighborId, IsisP2pHello, IsisPacket, IsisPdu,
+    IsisProto, IsisPsnp, IsisSysId, IsisTlv, IsisTlvAreaAddr, IsisTlvAuth, IsisTlvHostname,
     IsisTlvIpv4IfAddr, IsisTlvIpv6GlobalIfAddr, IsisTlvIpv6IfAddr, IsisTlvIpv6TeRouterId,
     IsisTlvIsNeighbor, IsisTlvLspBufferSize, IsisTlvLspEntries, IsisTlvP2p3Way, IsisTlvPadding,
     IsisTlvProtoSupported, IsisTlvSrv6, IsisTlvTeRouterId, NeighborAddr, SidLabelValue,
@@ -181,6 +182,7 @@ impl Display for IsisTlv {
             IsNeighbor(v) => write!(f, "{}", v),
             Padding(v) => write!(f, "{}", v),
             LspEntries(v) => write!(f, "{}", v),
+            Auth(v) => write!(f, "{}", v),
             LspBufferSize(v) => write!(f, "{}", v),
             ExtIsReach(v) => write!(f, "{}", v),
             MtIsReach(v) => write!(f, "{}", v),
@@ -315,6 +317,24 @@ impl Display for IsisTlvLspEntries {
             write!(f, "\n{}", entry)?;
         }
         Ok(())
+    }
+}
+
+impl Display for IsisTlvAuth {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let name = match self.auth_type {
+            ISIS_AUTH_TYPE_CLEARTEXT => "cleartext",
+            ISIS_AUTH_TYPE_GENERIC => "generic-crypto",
+            ISIS_AUTH_TYPE_HMAC_MD5 => "hmac-md5",
+            _ => "unknown",
+        };
+        write!(
+            f,
+            "  Auth: type {} ({}) len {}",
+            self.auth_type,
+            name,
+            self.value.len()
+        )
     }
 }
 

--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -519,6 +519,8 @@ pub enum IsisTlv {
     Padding(IsisTlvPadding),
     #[nom(Selector = "IsisTlvType::LspEntries")]
     LspEntries(IsisTlvLspEntries),
+    #[nom(Selector = "IsisTlvType::Auth")]
+    Auth(IsisTlvAuth),
     #[nom(Selector = "IsisTlvType::LspBufferSize")]
     LspBufferSize(IsisTlvLspBufferSize),
     #[nom(Selector = "IsisTlvType::ExtIsReach")]
@@ -588,6 +590,7 @@ impl IsisTlv {
             IsNeighbor(v) => v.tlv_emit(buf),
             Padding(v) => v.tlv_emit(buf),
             LspEntries(v) => v.tlv_emit(buf),
+            Auth(v) => v.tlv_emit(buf),
             LspBufferSize(v) => v.tlv_emit(buf),
             ExtIsReach(v) => v.tlv_emit(buf),
             MtIsReach(v) => v.tlv_emit(buf),
@@ -754,6 +757,67 @@ impl TlvEmitter for IsisTlvLspEntries {
 impl From<IsisTlvLspEntries> for IsisTlv {
     fn from(tlv: IsisTlvLspEntries) -> Self {
         IsisTlv::LspEntries(tlv)
+    }
+}
+
+/// Authentication Information TLV (type 10).
+///
+/// ISO 10589 §9.5 (cleartext, auth_type=1), RFC 5304 (HMAC-MD5,
+/// auth_type=54), and RFC 5310 (generic crypto, auth_type=3 with a
+/// 2-byte Key ID prefix on the value). The value layout is intentionally
+/// modeled as `auth_type` + opaque `value` so all three forms share one
+/// struct; callers interpret `value` per the auth-type registry.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisTlvAuth {
+    pub auth_type: u8,
+    pub value: Vec<u8>,
+}
+
+pub const ISIS_AUTH_TYPE_CLEARTEXT: u8 = 1;
+pub const ISIS_AUTH_TYPE_HMAC_MD5: u8 = 54;
+pub const ISIS_AUTH_TYPE_GENERIC: u8 = 3;
+pub const ISIS_AUTH_HMAC_MD5_LEN: usize = 16;
+
+impl IsisTlvAuth {
+    /// Build a placeholder Auth TLV with the digest area zero-filled.
+    /// The signer (Phase 4) emits this into the PDU first, then computes
+    /// the HMAC over the serialized PDU and patches the digest bytes in
+    /// place — RFC 5304 §3 / RFC 5310 §3.
+    pub fn placeholder(auth_type: u8, value_len: usize) -> Self {
+        Self {
+            auth_type,
+            value: vec![0u8; value_len],
+        }
+    }
+}
+
+impl TlvEmitter for IsisTlvAuth {
+    fn typ(&self) -> u8 {
+        IsisTlvType::Auth.into()
+    }
+
+    fn len(&self) -> u8 {
+        (1 + self.value.len()).min(255) as u8
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(self.auth_type);
+        let max = self.value.len().min(254);
+        buf.put(&self.value[..max]);
+    }
+}
+
+impl ParseBe<IsisTlvAuth> for IsisTlvAuth {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, auth_type) = be_u8(input)?;
+        let value = input.to_vec();
+        Ok((&input[input.len()..], Self { auth_type, value }))
+    }
+}
+
+impl From<IsisTlvAuth> for IsisTlv {
+    fn from(tlv: IsisTlvAuth) -> Self {
+        IsisTlv::Auth(tlv)
     }
 }
 
@@ -1357,5 +1421,124 @@ mod tests {
         let mut buf = BytesMut::new();
         long.emit(&mut buf);
         assert_eq!(buf.len(), 255);
+    }
+
+    /// HMAC-MD5 Auth TLV (RFC 5304 §2): on-wire shape is
+    /// type=10, length=17 (1-byte auth-type + 16-byte digest),
+    /// auth-type=54. Round-trip through tlv_emit + parse_tlvs.
+    #[test]
+    fn auth_hmac_md5_round_trip() {
+        let digest: Vec<u8> = (0u8..16).collect();
+        let original = IsisTlvAuth {
+            auth_type: ISIS_AUTH_TYPE_HMAC_MD5,
+            value: digest.clone(),
+        };
+        let mut buf = BytesMut::new();
+        original.tlv_emit(&mut buf);
+
+        assert_eq!(buf[0], u8::from(IsisTlvType::Auth));
+        assert_eq!(buf[1], 1 + ISIS_AUTH_HMAC_MD5_LEN as u8);
+        assert_eq!(buf[2], ISIS_AUTH_TYPE_HMAC_MD5);
+        assert_eq!(&buf[3..], &digest[..]);
+
+        let (rest, tlvs) = IsisTlv::parse_tlvs(&buf).expect("parse must succeed");
+        assert!(rest.is_empty());
+        match &tlvs[0] {
+            IsisTlv::Auth(v) => {
+                assert_eq!(v.auth_type, ISIS_AUTH_TYPE_HMAC_MD5);
+                assert_eq!(v.value, digest);
+            }
+            other => panic!("expected Auth, got {:?}", other),
+        }
+    }
+
+    /// Cleartext Auth TLV (ISO 10589, auth-type 1): the value is the
+    /// raw password bytes after the auth-type byte.
+    #[test]
+    fn auth_cleartext_round_trip() {
+        let original = IsisTlvAuth {
+            auth_type: ISIS_AUTH_TYPE_CLEARTEXT,
+            value: b"hunter2".to_vec(),
+        };
+        let mut buf = BytesMut::new();
+        original.tlv_emit(&mut buf);
+
+        let (_, tlvs) = IsisTlv::parse_tlvs(&buf).expect("parse must succeed");
+        match &tlvs[0] {
+            IsisTlv::Auth(v) => {
+                assert_eq!(v.auth_type, ISIS_AUTH_TYPE_CLEARTEXT);
+                assert_eq!(v.value, b"hunter2");
+            }
+            other => panic!("expected Auth, got {:?}", other),
+        }
+    }
+
+    /// RFC 5310 generic crypto: auth-type 3, value = 2-byte Key ID +
+    /// variable-length digest. The TLV layer treats the value as
+    /// opaque bytes, so the round-trip must preserve the Key ID and
+    /// digest byte-for-byte.
+    #[test]
+    fn auth_generic_crypto_round_trip() {
+        let mut value = Vec::new();
+        value.extend_from_slice(&7u16.to_be_bytes()); // Key ID = 7
+        value.extend(0u8..20); // HMAC-SHA1 digest (20 bytes)
+        let original = IsisTlvAuth {
+            auth_type: ISIS_AUTH_TYPE_GENERIC,
+            value: value.clone(),
+        };
+        let mut buf = BytesMut::new();
+        original.tlv_emit(&mut buf);
+
+        // type(1) + len(1) + auth-type(1) + key-id(2) + digest(20) = 25
+        assert_eq!(buf.len(), 25);
+        assert_eq!(buf[1], 23);
+
+        let (_, tlvs) = IsisTlv::parse_tlvs(&buf).expect("parse must succeed");
+        match &tlvs[0] {
+            IsisTlv::Auth(v) => {
+                assert_eq!(v.auth_type, ISIS_AUTH_TYPE_GENERIC);
+                assert_eq!(v.value, value);
+            }
+            other => panic!("expected Auth, got {:?}", other),
+        }
+    }
+
+    /// Phase 4 LSP signer builds the PDU with a zero-filled placeholder,
+    /// then patches the digest in. Verify placeholder() shape and that
+    /// the emitted bytes match `[type, len, auth_type, 0x00 * N]`.
+    #[test]
+    fn auth_placeholder_is_zero_filled() {
+        let tlv = IsisTlvAuth::placeholder(ISIS_AUTH_TYPE_HMAC_MD5, ISIS_AUTH_HMAC_MD5_LEN);
+        assert_eq!(tlv.auth_type, ISIS_AUTH_TYPE_HMAC_MD5);
+        assert_eq!(tlv.value.len(), ISIS_AUTH_HMAC_MD5_LEN);
+        assert!(tlv.value.iter().all(|b| *b == 0));
+
+        let mut buf = BytesMut::new();
+        tlv.tlv_emit(&mut buf);
+        assert_eq!(buf[0], u8::from(IsisTlvType::Auth));
+        assert_eq!(buf[1], 1 + ISIS_AUTH_HMAC_MD5_LEN as u8);
+        assert_eq!(buf[2], ISIS_AUTH_TYPE_HMAC_MD5);
+        assert!(buf[3..].iter().all(|b| *b == 0));
+    }
+
+    /// An auth-type value that this crate does not recognize must
+    /// still survive parse+emit unchanged — the runtime layer is the
+    /// one that decides whether to drop the PDU.
+    #[test]
+    fn auth_unknown_auth_type_preserved() {
+        let original = IsisTlvAuth {
+            auth_type: 42, // not in the IS-IS TLV-10 registry
+            value: vec![0xDE, 0xAD, 0xBE, 0xEF],
+        };
+        let mut buf = BytesMut::new();
+        original.tlv_emit(&mut buf);
+        let (_, tlvs) = IsisTlv::parse_tlvs(&buf).expect("parse must succeed");
+        match &tlvs[0] {
+            IsisTlv::Auth(v) => {
+                assert_eq!(v.auth_type, 42);
+                assert_eq!(v.value, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+            }
+            other => panic!("expected Auth, got {:?}", other),
+        }
     }
 }

--- a/crates/isis-packet/src/tlv_type.rs
+++ b/crates/isis-packet/src/tlv_type.rs
@@ -12,6 +12,11 @@ pub enum IsisTlvType {
     IsNeighbor = 6,
     Padding = 8,
     LspEntries = 9,
+    /// Authentication Information (ISO 10589 §9.5 / RFC 5304 / RFC 5310).
+    /// Carries an Authentication Type byte followed by an algorithm-
+    /// specific value (cleartext password, HMAC-MD5 digest, or RFC 5310
+    /// generic-crypto Key ID + digest).
+    Auth = 10,
     LspBufferSize = 14,
     ExtIsReach = 22,
     MtIsReach = 222,
@@ -54,6 +59,7 @@ impl IsisTlvType {
                 | IsNeighbor
                 | Padding
                 | LspEntries
+                | Auth
                 | LspBufferSize
                 | ExtIsReach
                 | MtIsReach
@@ -86,6 +92,7 @@ impl From<IsisTlvType> for u8 {
             IsNeighbor => 6,
             Padding => 8,
             LspEntries => 9,
+            Auth => 10,
             LspBufferSize => 14,
             ExtIsReach => 22,
             MtIsReach => 222,
@@ -119,6 +126,7 @@ impl From<u8> for IsisTlvType {
             6 => IsNeighbor,
             8 => Padding,
             9 => LspEntries,
+            10 => Auth,
             14 => LspBufferSize,
             22 => ExtIsReach,
             222 => MtIsReach,

--- a/rfc/isis/rfc5304.txt
+++ b/rfc/isis/rfc5304.txt
@@ -1,0 +1,619 @@
+
+
+
+
+
+
+Network Working Group                                              T. Li
+Request for Comments: 5304                        Redback Networks, Inc.
+Obsoletes: 3567                                              R. Atkinson
+Updates: 1195                                     Extreme Networks, Inc.
+Category: Standards Track                                   October 2008
+
+
+                   IS-IS Cryptographic Authentication
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Abstract
+
+   This document describes the authentication of Intermediate System to
+   Intermediate System (IS-IS) Protocol Data Units (PDUs) using the
+   Hashed Message Authentication Codes - Message Digest 5 (HMAC-MD5)
+   algorithm as found in RFC 2104.  IS-IS is specified in International
+   Standards Organization (ISO) 10589, with extensions to support
+   Internet Protocol version 4 (IPv4) described in RFC 1195.  The base
+   specification includes an authentication mechanism that allows for
+   multiple authentication algorithms.  The base specification only
+   specifies the algorithm for cleartext passwords.  This document
+   replaces RFC 3567.
+
+   This document proposes an extension to that specification that allows
+   the use of the HMAC-MD5 authentication algorithm to be used in
+   conjunction with the existing authentication mechanisms.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Li & Atkinson               Standards Track                     [Page 1]
+
+RFC 5304           IS-IS Cryptographic Authentication       October 2008
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . . . 3
+   2.  Authentication Procedures . . . . . . . . . . . . . . . . . . . 3
+     2.1.  Implementation Considerations . . . . . . . . . . . . . . . 5
+   3.  Security Considerations . . . . . . . . . . . . . . . . . . . . 5
+     3.1.  Security Limitations  . . . . . . . . . . . . . . . . . . . 5
+     3.2.  Assurance . . . . . . . . . . . . . . . . . . . . . . . . . 6
+     3.3.  Key Configuration . . . . . . . . . . . . . . . . . . . . . 6
+     3.4.  Other Considerations  . . . . . . . . . . . . . . . . . . . 7
+     3.5.  Future Directions . . . . . . . . . . . . . . . . . . . . . 7
+   4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . . . 7
+   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . 8
+   6.  References  . . . . . . . . . . . . . . . . . . . . . . . . . . 8
+     6.1.  Normative References  . . . . . . . . . . . . . . . . . . . 8
+     6.2.  Informative References  . . . . . . . . . . . . . . . . . . 9
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Li & Atkinson               Standards Track                     [Page 2]
+
+RFC 5304           IS-IS Cryptographic Authentication       October 2008
+
+
+1.  Introduction
+
+   The IS-IS protocol, as specified in [ISO-10589], provides for the
+   authentication of Link State Protocol Data Units (LSPs) through the
+   inclusion of authentication information as part of the LSP.  This
+   authentication information is encoded as a Type-Length-Value (TLV)
+   tuple.  The use of IS-IS for IPv4 networks is described in [RFC1195].
+
+   The type of the TLV is specified as 10.  The length of the TLV is
+   variable.  The value of the TLV depends on the authentication
+   algorithm and related secrets being used.  The first octet of the
+   value is used to specify the authentication type.  Type 0 is
+   reserved, type 1 indicates a cleartext password, and type 255 is used
+   for routing domain private authentication methods.  The remainder of
+   the TLV value is known as the Authentication Value.
+
+   This document extends the above situation by allocating a new
+   authentication type for HMAC-MD5 and specifying the algorithms for
+   the computation of the Authentication Value.  This document also
+   describes modifications to the base protocol to ensure that the
+   authentication mechanisms described in this document are effective.
+
+   This document is a publication of the IS-IS Working Group within the
+   IETF.  This document replaces [RFC3567], which is an Informational
+   RFC.  This document is on the Standards Track.  This document has
+   revised Section 3, with the significant addition of a discussion of
+   recent attacks on MD5 in Section 3.2.  This document has also added a
+   substantive "IANA Considerations" section to create a missing
+   codepoint registry.
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+2.  Authentication Procedures
+
+   The authentication type used for HMAC-MD5 is 54 (0x36).  The length
+   of the Authentication Value for HMAC-MD5 is 16, and the length field
+   in the TLV is 17.
+
+   The HMAC-MD5 algorithm requires a key K and text T as input
+   [RFC2104].  The key K is the password for the PDU type, as specified
+   in ISO 10589.  The text T is the IS-IS PDU to be authenticated with
+   the Authentication Value field (inside of the Authentication
+   Information TLV) set to zero.  Note that the Authentication Type is
+   set to 54 and the length of the TLV is set to 17 before
+   authentication is computed.  When LSPs are authenticated, the
+
+
+
+
+Li & Atkinson               Standards Track                     [Page 3]
+
+RFC 5304           IS-IS Cryptographic Authentication       October 2008
+
+
+   Checksum and Remaining Lifetime fields are set to zero (0) before
+   authentication is computed.  The result of the algorithm is placed in
+   the Authentication Value field.
+
+   When calculating the HMAC-MD5 result for Sequence Number PDUs, Level
+   1 Sequence Number PDUs SHALL use the Area Authentication string as in
+   Level 1 Link State PDUs.  Level 2 Sequence Number PDUs SHALL use the
+   domain authentication string as in Level 2 Link State PDUs.  IS-IS
+   Hello PDUs SHALL use the Link Level Authentication String, which MAY
+   be different from that of Link State PDUs.  The HMAC-MD5 result for
+   the IS-IS Hello PDUs SHALL be calculated after the packet is padded
+   to the MTU size, if padding is not disabled.  Implementations that
+   support the optional checksum for the Sequence Number PDUs and IS-IS
+   Hello PDUs MUST NOT include the Checksum TLV.
+
+   To authenticate an incoming PDU, a system should save the values of
+   the Authentication Value field, the Checksum field, and the Remaining
+   Lifetime field, set these fields to zero, compute authentication, and
+   then restore the values of these fields.
+
+   An implementation that implements HMAC-MD5 authentication and
+   receives HMAC-MD5 Authentication Information MUST discard the PDU if
+   the Authentication Value is incorrect.
+
+   An implementation MAY have a transition mode where it includes HMAC-
+   MD5 Authentication Information in PDUs but does not verify the HMAC-
+   MD5 Authentication Information.  This is a transition aid for
+   networks in the process of deploying authentication.
+
+   An implementation MAY check a set of passwords when verifying the
+   Authentication Value.  This provides a mechanism for incrementally
+   changing passwords in a network.
+
+   An implementation that does not implement HMAC-MD5 authentication MAY
+   accept a PDU that contains the HMAC-MD5 Authentication Type.  ISes
+   (routers) that implement HMAC-MD5 authentication and initiate LSP
+   purges MUST remove the body of the LSP and add the authentication
+   TLV.  ISes implementing HMAC-MD5 authentication MUST NOT accept
+   unauthenticated purges.  ISes MUST NOT accept purges that contain
+   TLVs other than the authentication TLV.  These restrictions are
+   necessary to prevent a hostile system from receiving an LSP, setting
+   the Remaining Lifetime field to zero, and flooding it, thereby
+   initiating a purge without knowing the authentication password.
+
+
+
+
+
+
+
+
+Li & Atkinson               Standards Track                     [Page 4]
+
+RFC 5304           IS-IS Cryptographic Authentication       October 2008
+
+
+2.1.  Implementation Considerations
+
+   There is an implementation issue that occurs just after password
+   rollover on an IS-IS router and that might benefit from additional
+   commentary.  Immediately after password rollover on the router, the
+   router or IS-IS process may restart.  If this happens, this causes
+   the LSP Sequence Number to restart from the value 1 using the new
+   password.  However, neighbors will reject those new LSPs because the
+   Sequence Number is smaller.  The router cannot increase its own LSP
+   Sequence Number because it fails to authenticate its own old LSP that
+   neighbors keep sending to it.  So the router cannot update its LSP
+   Sequence Number to its neighbors until all the neighbors time out all
+   of the original LSPs.  One possible solution to this problem is for
+   the IS-IS process to detect if any inbound LSP with an authentication
+   failure has the local System ID and also has a higher Sequence Number
+   than the IS-IS process has.  In this event, the IS-IS process SHOULD
+   increase its own LSP Sequence Number accordingly and re-flood the
+   LSPs.  However, as this scenario could also be triggered by an active
+   attack by an adversary, it is recommended that a counter be kept on
+   this case to mitigate the risk from such an attack.
+
+3.  Security Considerations
+
+   This document enhances the security of the IS-IS routing protocol.
+   Because a routing protocol contains information that need not be kept
+   secret, privacy is not a requirement.  However, authentication of the
+   messages within the protocol is of interest in order to reduce the
+   risk of an adversary compromising the routing system by deliberately
+   injecting false information into that system.
+
+3.1.  Security Limitations
+
+   The technology in this document provides an authentication mechanism
+   for IS-IS.  The mechanism described here is not perfect and does not
+   need to be perfect.  Instead, this mechanism represents a significant
+   increase in the work function of an adversary attacking the IS-IS
+   protocol, while not causing undue implementation, deployment, or
+   operational complexity.  It provides improved security against
+   passive attacks, as defined in [RFC1704], when compared to cleartext
+   password authentication.
+
+   This mechanism does not prevent replay attacks; however, in most
+   cases, such attacks would trigger existing mechanisms in the IS-IS
+   protocol that would effectively reject old information.  Denial-of-
+   service attacks are not generally preventable in a useful networking
+   protocol [DoS].
+
+
+
+
+
+Li & Atkinson               Standards Track                     [Page 5]
+
+RFC 5304           IS-IS Cryptographic Authentication       October 2008
+
+
+   The mechanisms in this document do not provide protection against
+   compromised, malfunctioning, or misconfigured routers.  Such routers
+   can, either accidentally or deliberately, cause malfunctions that
+   affect the whole routing domain.  The reader is encouraged to consult
+   [RFC4593] for a more comprehensive description of threats to routing
+   protocols.
+
+3.2.  Assurance
+
+   Users need to understand that the quality of the security provided by
+   this mechanism depends completely on the strength of the implemented
+   authentication algorithms, the strength of the key being used, and
+   the correct implementation of the security mechanism in all
+   communicating IS-IS implementations.  This mechanism also depends on
+   the IS-IS Authentication Key being kept confidential by all parties.
+   If any of these are incorrect or insufficiently secure, then no real
+   security will be provided to the users of this mechanism.
+
+   Since Dobbertin's attacks on MD5 [Dobb96a] [Dobb96b] [Dobb98] were
+   first published a dozen years ago, there have been growing concerns
+   about the effectiveness of the compression function within MD5.  More
+   recent work by Wang and Yu [WY05] accentuates these concerns.
+   However, despite these research results, there are no published
+   attacks at present on either Keyed-MD5 or HMAC-MD5.  A recent paper
+   by Bellare [Bell06a] [Bell06b] provides new proofs for the security
+   of HMAC that require fewer assumptions than previous published proofs
+   for HMAC.  Those proofs indicate that the published issues with MD5
+   (and separately with SHA-1) do not create an attack on HMAC-MD5 (or
+   HMAC SHA-1).  Most recently, Fouque and others [FLN07] have published
+   new attacks on NMAC-MD4, HMAC-MD4, and NMAC-MD5.  However, their
+   attacks are non-trivial computationally, and they have not found an
+   equivalent attack on HMAC-MD5.  So, despite the published issues with
+   the MD5 algorithm, there is currently no published attack that
+   applies to HMAC-MD5 as used in this IS-IS specification.  As with any
+   cryptographic technique, there is the possibility of the discovery of
+   future attacks against this mechanism.
+
+3.3.  Key Configuration
+
+   It should be noted that the key configuration mechanism of routers
+   may restrict the possible keys that may be used between peers.  It is
+   strongly recommended that an implementation be able to support, at
+   minimum, a key composed of a string of printable ASCII of 80 bytes or
+   less, as this is current practice.
+
+
+
+
+
+
+
+Li & Atkinson               Standards Track                     [Page 6]
+
+RFC 5304           IS-IS Cryptographic Authentication       October 2008
+
+
+3.4.  Other Considerations
+
+   Changes to the authentication mechanism described here (primarily: to
+   add a Key-ID field such as that of OSPFv2 and RIPv2) were considered
+   at some length, but ultimately were rejected.  The mechanism here was
+   already widely implemented in 1999.  As of this writing, this
+   mechanism is fairly widely deployed within the users interested in
+   cryptographic authentication of IS-IS.  The improvement provided by
+   the proposed revised mechanism was not large enough to justify the
+   change, given the installed base and lack of operator interest in
+   deploying a revised mechanism.
+
+   If and when a key management protocol appears that is both widely
+   implemented and easily deployed to secure routing protocols such as
+   IS-IS, a different authentication mechanism that is designed for use
+   with that key management schema could be added if desired.
+
+3.5.  Future Directions
+
+   If a stronger authentication were believed to be required, then the
+   use of a full digital signature [RFC2154] would be an approach that
+   should be seriously considered.  It was rejected for this purpose at
+   this time because the computational burden of full digital signatures
+   is believed to be much higher than is reasonable, given the current
+   threat environment in operational commercial networks.
+
+   If and when additional authentication mechanisms are defined (for
+   example, to provide a cryptographically stronger hash function), it
+   will also be necessary to define mechanisms that allow graceful
+   transition from the existing mechanisms (as defined in this document)
+   to any future mechanism.
+
+4.  IANA Considerations
+
+   IANA has created a new codepoint registry to administer the
+   Authentication Type codepoints for TLV 10.  This registry is part of
+   the existing IS-IS codepoints registry as established by [RFC3563]
+   and [RFC3359].  This registry is managed using the Designated Expert
+   policy as described in [RFC5226] and is called "IS-IS Authentication
+   Type Codes for TLV 10".
+
+   The values in the "IS-IS Authentication Type Codes for TLV 10"
+   registry should be recorded in decimal and should only be approved
+   after a designated expert, appointed by the IESG area director, has
+   been consulted.  The intention is that any allocation will be
+   accompanied by a published RFC.  However, the designated expert can
+   approve allocations once it seems clear that an RFC will be
+   published, allowing for the allocation of values prior to the
+
+
+
+Li & Atkinson               Standards Track                     [Page 7]
+
+RFC 5304           IS-IS Cryptographic Authentication       October 2008
+
+
+   document being approved for publication as an RFC.  New items should
+   be documented in a publicly and freely available specification.  We
+   should also allow external specifications to allocate and use the
+   IS-IS Authentication Type Codes maintained by this registry.
+
+   Initial values for the "IS-IS Authentication Type Codes for TLV 10"
+   registry are given below; future assignments are to be made through
+   Expert Review.  Assignments consist of an authentication type name
+   and its associated value.
+
+   +---------------------------------------------+-------+-------------+
+   | Authentication Type Code                    | Value | Reference   |
+   +---------------------------------------------+-------+-------------+
+   | Reserved                                    | 0     | [ISO-10589] |
+   | Cleartext Password                          | 1     | [ISO-10589] |
+   | ISO 10589 Reserved                          | 2     | [ISO-10589] |
+   | HMAC-MD5 Authentication                     | 54    | RFC 5304    |
+   | Routeing Domain private authentication      | 255   | [ISO-10589] |
+   | method                                      |       |             |
+   +---------------------------------------------+-------+-------------+
+
+5.  Acknowledgements
+
+   The authors would like to thank (in alphabetical order) Stephen
+   Farrell, Dave Katz, Steven Luong, Tony Przygienda, Nai-Ming Shen, and
+   Henk Smit for their comments and suggestions on this document.
+
+6.  References
+
+6.1.  Normative References
+
+   [ISO-10589]  ISO, "Intermediate System to Intermediate System intra-
+                domain routeing information exchange protocol for use in
+                conjunction with the protocol for providing the
+                connectionless-mode network service (ISO 8473)",
+                International Standard 10589:2002, Second Edition, 2002.
+
+   [RFC2104]    Krawczyk, H., Bellare, M., and R. Canetti, "HMAC: Keyed-
+                Hashing for Message Authentication", RFC 2104,
+                February 1997.
+
+   [RFC2119]    Bradner, S., "Key words for use in RFCs to Indicate
+                Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+
+
+
+
+
+
+
+Li & Atkinson               Standards Track                     [Page 8]
+
+RFC 5304           IS-IS Cryptographic Authentication       October 2008
+
+
+6.2.  Informative References
+
+   [Bell06a]    Bellare, M., "New Proofs for NMAC and HMAC: Security
+                without Collision-Resistance", Preliminary Version, in
+                Proceedings of Crypto 2006, Lecture Notes in Computer
+                Science, Vol. 4117, August 2006.
+
+   [Bell06b]    Bellare, M., "New Proofs for NMAC and HMAC: Security
+                without Collision-Resistance", August 2006, <http://
+                www-cse.ucsd.edu/users/mihir/papers/hmac-new.html>.
+
+   [DoS]        Voydock, V. and S. Kent, "Security Mechanisms in High-
+                level Networks", ACM Computing Surveys Vol. 15, No. 2,
+                June 1983.
+
+   [Dobb96a]    Dobbertin, H., "Cryptanalysis of MD5 Compress",
+                EuroCrypt Rump Session 1996, May 1996.
+
+   [Dobb96b]    Dobbertin, H., "The Status of MD5 After a Recent
+                Attack", CryptoBytes, Vol. 2, No. 2, 1996.
+
+   [Dobb98]     Dobbertin, H., "Cryptanalysis of MD4", Journal of
+                Cryptology, Vol. 11, No. 4, 1998.
+
+   [FLN07]      Fouque, P., Leurent, G., and P. Nguyen, "Full Key-
+                Recovery Attacks on HMAC/NMAC-MD5 and NMAC-MD5",
+                Proceedings of Crypto 2007, August 2007.
+
+   [RFC1195]    Callon, R., "Use of OSI IS-IS for routing in TCP/IP and
+                dual environments", RFC 1195, December 1990.
+
+   [RFC1704]    Haller, N. and R. Atkinson, "On Internet
+                Authentication", RFC 1704, October 1994.
+
+   [RFC2154]    Murphy, S., Badger, M., and B. Wellington, "OSPF with
+                Digital Signatures", RFC 2154, June 1997.
+
+   [RFC3359]    Przygienda, T., "Reserved Type, Length and Value (TLV)
+                Codepoints in Intermediate System to Intermediate
+                System", RFC 3359, August 2002.
+
+   [RFC3563]    Zinin, A., "Cooperative Agreement Between the ISOC/IETF
+                and ISO/IEC Joint Technical Committee 1/Sub Committee 6
+                (JTC1/SC6) on IS-IS Routing Protocol Development",
+                RFC 3563, July 2003.
+
+
+
+
+
+
+Li & Atkinson               Standards Track                     [Page 9]
+
+RFC 5304           IS-IS Cryptographic Authentication       October 2008
+
+
+   [RFC3567]    Li, T. and R. Atkinson, "Intermediate System to
+                Intermediate System (IS-IS) Cryptographic
+                Authentication", RFC 3567, July 2003.
+
+   [RFC4593]    Barbir, A., Murphy, S., and Y. Yang, "Generic Threats to
+                Routing Protocols", RFC 4593, October 2006.
+
+   [RFC5226]    Narten, T. and H. Alvestrand, "Guidelines for Writing an
+                IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+                May 2008.
+
+   [WY05]       Wang, X. and H. Yu, "How to Break MD5 and Other Hash
+                Functions", Proceedings of EuroCrypt 2005, Lecture Notes
+                in Computer Science, Vol. 3494, 2005.
+
+Authors' Addresses
+
+   Tony Li
+   Redback Networks, Inc.
+   300 Holger Way
+   San Jose, CA  95134
+   USA
+
+   Phone: +1 408 750 5160
+   EMail: tony.li@tony.li
+
+
+   R. Atkinson
+   Extreme Networks, Inc.
+   3585 Monroe St.
+   Santa Clara, CA  95051
+   USA
+
+   Phone: +1 408 579 2800
+   EMail: rja@extremenetworks.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Li & Atkinson               Standards Track                    [Page 10]
+
+RFC 5304           IS-IS Cryptographic Authentication       October 2008
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2008).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+
+
+
+
+
+
+
+
+
+
+
+Li & Atkinson               Standards Track                    [Page 11]
+

--- a/rfc/isis/rfc5310.txt
+++ b/rfc/isis/rfc5310.txt
@@ -1,0 +1,675 @@
+
+
+
+
+
+
+Network Working Group                                          M. Bhatia
+Request for Comments: 5310                                Alcatel-Lucent
+Category: Standards Track                                      V. Manral
+                                                             IP Infusion
+                                                                   T. Li
+                                                   Redback Networks Inc.
+                                                             R. Atkinson
+                                                        Extreme Networks
+                                                                R. White
+                                                           Cisco Systems
+                                                                M. Fanto
+                                                     Aegis Data Security
+                                                           February 2009
+
+
+               IS-IS Generic Cryptographic Authentication
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (c) 2009 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents (http://trustee.ietf.org/
+   license-info) in effect on the date of publication of this document.
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.
+
+Abstract
+
+   This document proposes an extension to Intermediate System to
+   Intermediate System (IS-IS) to allow the use of any cryptographic
+   authentication algorithm in addition to the already-documented
+   authentication schemes, described in the base specification and RFC
+   5304.  IS-IS is specified in International Standards Organization
+   (ISO) 10589, with extensions to support Internet Protocol version 4
+   (IPv4) described in RFC 1195.
+
+
+
+
+
+
+Bhatia, et al.              Standards Track                     [Page 1]
+
+RFC 5310          IS-IS Generic Crypto Authentication      February 2009
+
+
+   Although this document has been written specifically for using the
+   Hashed Message Authentication Code (HMAC) construct along with the
+   Secure Hash Algorithm (SHA) family of cryptographic hash functions,
+   the method described in this document is generic and can be used to
+   extend IS-IS to support any cryptographic hash function in the
+   future.
+
+Table of Contents
+
+   1. Introduction ....................................................2
+      1.1. Conventions Used in This Document ..........................3
+   2. IS-IS Security Association ......................................3
+   3. Authentication Procedures .......................................4
+      3.1. Authentication TLV .........................................4
+      3.2. Authentication Process .....................................5
+      3.3. Cryptographic Aspects ......................................5
+      3.4. Procedures at the Sending Side .............................7
+      3.5. Procedure at the Receiving Side ............................8
+   4. Security Considerations .........................................8
+   5. Acknowledgments .................................................9
+   6. IANA Considerations ............................................10
+   7. References .....................................................10
+      7.1. Normative References ......................................10
+      7.2. Informative References ....................................11
+
+1.  Introduction
+
+   The Intermediate System to Intermediate System (IS-IS) specification
+   ([ISO], [RFC1195]) allows for authentication of its Protocol Data
+   Units (PDUs) via the authentication TLV 10 that is carried as a part
+   of the PDU.  The base specification has provision for only cleartext
+   passwords and RFC 5304 [RFC5304] augments this to provide the
+   capability to use Hashed Message Authentication Code - Message Digest
+   5 (HMAC-MD5) authentication for its PDUs.
+
+   The first octet of the value field of TLV 10 specifies the type of
+   authentication to be carried out.  Type 0 is reserved, Type 1
+   indicates a cleartext password, Type 54 indicates HMAC MD5, and Type
+   255 is used for routing domain private authentication methods.  The
+   remainder of the value field contains the actual authentication data,
+   determined by the value of the authentication type.
+
+   This document proposes a new authentication type to be carried in TLV
+   10, called the generic cryptographic authentication (CRYPTO_AUTH).
+   This can be used to specify any authentication algorithm for
+   authenticating and verifying IS-IS PDUs.
+
+
+
+
+
+Bhatia, et al.              Standards Track                     [Page 2]
+
+RFC 5310          IS-IS Generic Crypto Authentication      February 2009
+
+
+   This document also explains how HMAC-SHA authentication can be used
+   in IS-IS.
+
+   By definition, HMAC ([RFC2104], [FIPS-198]) requires a cryptographic
+   hash function.  We propose to use any one of SHA-1, SHA-224, SHA-256,
+   SHA-384, or SHA-512 [FIPS-180-3] to authenticate the IS-IS PDUs.
+
+   We propose to do away with the per-interface keys and instead have
+   Key IDs that map to unique IS-IS Security Associations (SAs).
+
+   While at the time of this writing there are no openly published
+   attacks on the HMAC-MD5 mechanism, some reports ([Dobb96a],
+   [Dobb96b]) create concern about the ultimate strength of the MD5
+   cryptographic hash function.
+
+   The mechanism described in this document does not provide
+   confidentiality, since PDUs are sent in the clear.  However, the
+   objective of a routing protocol is to advertise the routing topology,
+   and confidentiality is not normally required for routing protocols.
+
+1.1.  Conventions Used in This Document
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+2.  IS-IS Security Association
+
+   An IS-IS Security Association contains a set of parameters shared
+   between any two legitimate IS-IS speakers.
+
+   Parameters associated with an IS-IS SA:
+
+   o  Key Identifier (Key ID): This is a two-octet unsigned integer used
+      to uniquely identify an IS-IS SA, as manually configured by the
+      network operator.
+
+      The receiver determines the active SA by looking at the Key ID
+      field in the incoming PDU.
+
+      The sender, based on the active configuration, selects the
+      Security Association to use and puts the correct Key ID value
+      associated with the Security Association in the IS-IS PDU.  If
+      multiple valid and active IS-IS Security Associations exist for a
+      given outbound interface at the time an IS-IS PDU is sent, the
+      sender may use any of those Security Associations to protect the
+      packet.
+
+
+
+
+Bhatia, et al.              Standards Track                     [Page 3]
+
+RFC 5310          IS-IS Generic Crypto Authentication      February 2009
+
+
+      Using Key IDs makes changing keys while maintaining protocol
+      operation convenient.  Each Key ID specifies two independent
+      parts: the authentication protocol and the authentication key,
+      explained below.  Normally, an implementation would allow the
+      network operator to configure a set of keys in a key chain, with
+      each key in the chain having a fixed lifetime.  The actual
+      operation of these mechanisms is outside the scope of this
+      document.
+
+      Note that each Key ID can indicate a key with a different
+      authentication protocol.  This allows multiple authentication
+      mechanisms to be used at various times without disrupting an IS-IS
+      peering, including the introduction of new authentication
+      mechanisms.
+
+   o  Authentication Algorithm: This signifies the authentication
+      algorithm to be used with the IS-IS SA.  This information is never
+      sent in cleartext over the wire.  Because this information is not
+      sent on the wire, the implementer chooses an implementation-
+      specific representation for this information.  At present, the
+      following values are possible: HMAC-SHA-1, HMAC-SHA-224, HMAC-SHA-
+      256, HMAC-SHA-384, and HMAC-SHA-512.
+
+   o  Authentication Key: This value denotes the cryptographic
+      authentication key associated with the IS-IS SA.  The length of
+      this key is variable and depends upon the authentication algorithm
+      specified by the IS-IS SA.
+
+3.  Authentication Procedures
+
+3.1.  Authentication TLV
+
+   A new authentication code, 3, indicates that the CRYPTO_AUTH
+   mechanism described in this document is in use and is inserted in the
+   first octet of the existing IS-IS Authentication TLV (10).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bhatia, et al.              Standards Track                     [Page 4]
+
+RFC 5310          IS-IS Generic Crypto Authentication      February 2009
+
+
+                      0                   1
+                      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6
+                      +-+-+-+-+-+-+-+-+
+                      |    Type 10    |
+                      +-+-+-+-+-+-+-+-+
+                      |    Length     |
+                      +-+-+-+-+-+-+-+-+
+                      |  Auth Type 3  |
+                      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+                      |     Key ID                    |
+                      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-|
+                      |                               |
+                      +                               +
+                      | Authentication Data (Variable)|
+                      +                               +
+                      |                               |
+                      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                                 Figure 1
+
+3.2.  Authentication Process
+
+   When calculating the CRYPTO_AUTH result for Sequence Number PDUs,
+   Level 1 Sequence Number PDUs SHALL use the Area Authentication
+   string, as in Level 1 Link State PDUs.  Level 2 Sequence Number PDUs
+   shall use the domain authentication string, as in Level 2 Link State
+   PDUs.
+
+   IS-IS HELLO PDUs SHALL use the Link Level Authentication string,
+   which MAY be different from that of Link State PDUs.  The CRYPTO_AUTH
+   result for the IS-IS HELLO PDUs SHALL be calculated after the PDU is
+   padded to the MTU size, if padding is not disabled.  Implementations
+   that support the optional checksum for the Sequence Number PDUs and
+   IS-IS HELLO PDUs MUST NOT include the Checksum TLV.
+
+3.3.  Cryptographic Aspects
+
+   In the algorithm description below, the following nomenclature, which
+   is consistent with [FIPS-198] is used:
+
+
+    H    is the specific hashing algorithm (e.g., SHA-256).
+    K    is the password for the PDU type as per the International
+         Standard ISO/IEC 10589 [ISO].
+    Ko   is the cryptographic key used with the hash algorithm.
+
+
+
+
+
+
+Bhatia, et al.              Standards Track                     [Page 5]
+
+RFC 5310          IS-IS Generic Crypto Authentication      February 2009
+
+
+    B    is the block size of H, measured in octets rather than bits.
+         Note that B is the internal block size, not the hash size.
+              For SHA-1 and SHA-256:   B == 64
+              For SHA-384 and SHA-512: B == 128
+
+    L    is the length of the hash, measured in octets rather than bits.
+
+    XOR  is the exclusive-or operation.
+
+    Opad is the hexadecimal value 0x5c repeated B times.
+    Ipad is the hexadecimal value 0x36 repeated B times.
+    Apad is the hexadecimal value 0x878FE1F3 repeated (L/4) times.
+
+   (1)  Preparation of the Key
+
+        In this application, Ko is always L octets long.
+
+        If the Authentication Key (K) is L octets long, then Ko is equal
+        to K.  If the Authentication Key (K) is more than L octets long,
+        then Ko is set to H(K).  If the Authentication Key (K) is less
+        than L octets long, then Ko is set to the Authentication Key (K)
+        with zeros appended to the end of the Authentication Key (K)
+        such that Ko is L octets long.
+
+   (2)  First Hash
+
+        First, the IS-IS packet's Authentication Data field is filled
+        with the value Apad, and the Authentication Type field is set to
+        0x3.
+
+        Then, a first hash, also known as the inner hash, is computed as
+        follows:
+
+                 First-Hash = H(Ko XOR Ipad || (IS-IS PDU))
+
+   (3)  Second Hash
+
+        Then a second hash, also known as the outer hash, is computed as
+        follows:
+
+                 Second-Hash = H(Ko XOR Opad || First-Hash)
+
+
+
+
+
+
+
+
+
+
+Bhatia, et al.              Standards Track                     [Page 6]
+
+RFC 5310          IS-IS Generic Crypto Authentication      February 2009
+
+
+   (4)  Result
+
+        The resulting second hash becomes the authentication data that
+        is sent in the Authentication Data field of the IS-IS PDU.  The
+        length of the Authentication Data field is always identical to
+        the message digest size of the specific hash function H that is
+        being used.
+
+        This also means that the use of hash functions with larger
+        output sizes will also increase the size of the IS-IS PDU as
+        transmitted on the wire.
+
+3.4.  Procedures at the Sending Side
+
+   An appropriate IS-IS SA is selected for use with an outgoing IS-IS
+   PDU.  This is done based on the active key at that instant.  If IS-IS
+   is unable to find an active key, then the PDU is discarded.
+
+   If IS-IS is able to find the active key, then the key provides the
+   authentication algorithm (HMAC-SHA-1, HMAC-SHA-224, HMAC-SHA-256,
+   HMAC-SHA-384, or HMAC-SHA-512) that needs to be applied on the PDU.
+
+   An implementation MUST fill the authentication type and the length
+   before the authentication data is computed.  The authentication data
+   is computed as explained in the previous section.  The length of the
+   TLV is set as per the authentication algorithm that is being used.
+
+   The length is set to 23 for HMAC-SHA-1, 31 for HMAC-SHA-224, 35 for
+   HMAC-SHA-256, 51 for HMAC-SHA-384, and 67 for HMAC-SHA-512.  Note
+   that two octets have been added to account for the Key ID and one
+   octet for the authentication type.
+
+   The Key ID is filled.
+
+   The Checksum and Remaining Lifetime fields are set to zero for the
+   Link State Packets (LSPs) before authentication is calculated.
+
+   The result of the authentication algorithm is placed in the
+   authentication data, following the Key ID.
+
+   The authentication data for the IS-IS IIH PDUs MUST be computed after
+   the IS-IS Hello (IIH) has been padded to the MTU size, if padding is
+   not explicitly disabled.
+
+
+
+
+
+
+
+
+Bhatia, et al.              Standards Track                     [Page 7]
+
+RFC 5310          IS-IS Generic Crypto Authentication      February 2009
+
+
+3.5.  Procedure at the Receiving Side
+
+   The appropriate IS-IS SA is identified by looking at the Key ID from
+   the Authentication TLV 10 from the incoming IS-IS PDU.
+
+   Authentication-algorithm-dependent processing needs to be performed,
+   using the algorithm specified by the appropriate IS-IS SA for the
+   received packet.
+
+   Before an implementation performs any processing, it needs to save
+   the values of the Authentication Value, the Checksum, and the
+   Remaining Lifetime fields.
+
+   It should then set the Authentication Value field with Apad and the
+   Checksum and Remaining Lifetime fields with zero before the
+   authentication data is computed.  The calculated data is compared
+   with the received authentication data in the PDU, and the PDU is
+   discarded if the two do not match.  In such a case, an error event
+   SHOULD be logged.
+
+   An implementation MAY have a transition mode where it includes
+   CRYPTO_AUTH information in the PDUs but does not verify this
+   information.  This is provided as a transition aid for networks in
+   the process of migrating to the new CRYPTO_AUTH-based authentication
+   schemes.
+
+4.  Security Considerations
+
+   This document proposes extensions to IS-IS that make it more secure
+   than what it is today.  It does not provide confidentiality as a
+   routing protocol contains information that does not need to be kept
+   secret.  It does, however, provide means to authenticate the sender
+   of the PDUs, which is of interest to us.
+
+   It should be noted that authentication method described in this
+   document is not being used to authenticate the specific originator of
+   a PDU, but is rather being used to confirm that the PDU has indeed
+   been issued by an intermediate system that had access to either the
+   area or domain password, depending upon the kind of PDU it is.
+
+   The mechanism described here is not perfect and does not need to be
+   perfect.  Instead, this mechanism represents a significant increase
+   in the work function of an adversary attacking the IS-IS protocol,
+   while not causing undue implementation, deployment, or operational
+   complexity.
+
+
+
+
+
+
+Bhatia, et al.              Standards Track                     [Page 8]
+
+RFC 5310          IS-IS Generic Crypto Authentication      February 2009
+
+
+   The mechanism detailed in this document does not protect IS-IS
+   against replay attacks.  An adversary could in theory replay old IIHs
+   and bring down the adjacency [CRYPTO] or replay old Complete Sequence
+   Number PDUs (CSNPs) and Partial Sequence Number PDUs (PSNPs) that
+   would cause a flood of LSPs in the network.  Using some sort of
+   crypto sequence numbers in IS-IS IIHs and CSNP/PSNPs is an option to
+   solve this problem.  Discussing this is beyond the scope of this
+   document.
+
+   This document states that the remaining lifetime of the LSP MUST be
+   set to zero before computing the authentication, thus this field is
+   not authenticated.  This field is excluded so that the LSPs may be
+   aged by the ISes in between, without requiring re-computation of the
+   authentication data.  This can be exploited by an attacker.
+
+   There is a transition mode suggested where routers can ignore the
+   CRYPTO_AUTH information carried in the PDUs.  The operator must
+   ensure that this mode is only used when migrating to the new
+   CRYPTO_AUTH-based authentication scheme, as this leaves the router
+   vulnerable to an attack.
+
+   To ensure greater security, the keys used should be changed
+   periodically, and implementations MUST be able to store and use more
+   than one key at the same time.  Operators should ensure that the
+   authentication key is never sent over the network in cleartext via
+   any protocol.  Care should also be taken to ensure that the selected
+   key is unpredictable, avoiding any keys known to be weak for the
+   algorithm in use.  [RFC4086] contains helpful information on both key
+   generation techniques and cryptographic randomness.
+
+   It should be noted that the cryptographic strength of the HMAC
+   depends upon the cryptographic strength of the underlying hash
+   function and on the size and quality of the key.
+
+   If a stronger authentication were believed to be required, then the
+   use of a full digital signature [RFC2154] would be an approach that
+   should be seriously considered.  It was rejected for this purpose at
+   this time because the computational burden of full digital signatures
+   is believed to be much higher than is reasonable given the current
+   threat environment in operational commercial networks.
+
+5.  Acknowledgments
+
+   The authors would like to thank Hugo Krawczyk, Arjen K. Lenstra (Bell
+   Labs), and Eric Grosse (Bell Labs) for educating us on some of the
+   finer points related to Crypto Mathematics.
+
+
+
+
+
+Bhatia, et al.              Standards Track                     [Page 9]
+
+RFC 5310          IS-IS Generic Crypto Authentication      February 2009
+
+
+   We would also like to thank Bill Burr, Tim Polk, John Kelsey, and
+   Morris Dworkin of (US) NIST for review of portions of this document
+   that are directly derived from the closely related work on RIPv2
+   Cryptographic Authentication [RFC4822].
+
+   We would also like to mention Alfred Hoenes for his careful and
+   detailed review during the last call.
+
+   Lastly, we would like to acknowledge Brian and Stephen Eisenberg for
+   their continued support.
+
+6.  IANA Considerations
+
+   IANA has registered the value for the CRYPTO_AUTH method in the
+   "IS-IS Authentication Type Codes for TLV 10" subregistry established
+   by [RFC5304].  The value 3 denotes the CRYPTO_AUTH mechanism for
+   authenticating IS-IS PDUs.
+
+    +--------------------------------------------+-------+-------------+
+    | Authentication Type Code                   | Value | Reference   |
+    +--------------------------------------------+-------+-------------+
+    | Cryptographic Authentication (CRYPTO_AUTH) |   3   |  [RFC5310]  |
+    +--------------------------------------------+-------+-------------+
+
+7.  References
+
+7.1.  Normative References
+
+   [FIPS-180-3]  US National Institute of Standards & Technology,
+                 "Secure Hash Standard (SHS)", FIPS PUB 180-3,
+                 October 2008.
+
+   [FIPS-198]    US National Institute of Standards & Technology, "The
+                 Keyed-Hash Message Authentication Code (HMAC)", FIPS
+                 PUB 198, March 2002.
+
+   [ISO]         "Intermediate system to Intermediate system routeing
+                 information exchange protocol for use in conjunction
+                 with the Protocol for providing the Connectionless-mode
+                 Network Service (ISO 8473)", ISO/IEC 10589:1992.
+
+   [RFC1195]     Callon, R., "Use of OSI IS-IS for routing in TCP/IP and
+                 dual environments", RFC 1195, December 1990.
+
+   [RFC2104]     Krawczk, H., "HMAC: Keyed-Hashing for Message
+                 Authentication", RFC 2104, February 1997.
+
+
+
+
+
+Bhatia, et al.              Standards Track                    [Page 10]
+
+RFC 5310          IS-IS Generic Crypto Authentication      February 2009
+
+
+   [RFC2119]     Bradner, S., "Key words for use in RFCs to Indicate
+                 Requirement Levels", BCP 14, RFC 2119, February 2001.
+
+   [RFC5304]     Li, T. and R. Atkinson, "Intermediate System to
+                 Intermediate System (IS-IS) Cryptographic
+                 Authentication", RFC 5304, October 2008.
+
+7.2.  Informative References
+
+   [CRYPTO]      Vishwas, M., White, R., and M. Bhatia, "Issues with
+                 existing Cryptographic Protection Methods for Routing
+                 Protocols", Work in Progress, February 2008.
+
+   [Dobb96a]     Dobbertin, H., "Cryptanalysis of MD5 Compress",
+                 Technical Report, May 1996.
+
+   [Dobb96b]     Dobbertin, H., "The Status of MD5 After a Recent
+                 Attack", Cryptobytes, Volume 2, No 2, Summer 1996.
+
+   [RFC2154]     Murphy, S., Badger, M., and B. Wellington, "OSPF with
+                 Digital Signatures", RFC 2154, June 1997.
+
+   [RFC4086]     Eastlake, D., Schiller, J., and S. Crocker, "Randomness
+                 Requirements for Security", RFC 4086, June 2005.
+
+   [RFC4822]     Atkinson, R. and M. Fanto, "RIPv2 Cryptographic
+                 Authentication", RFC 4822, February 2007.
+
+Authors' Addresses
+
+   Manav Bhatia
+   Alcatel-Lucent
+   Bangalore,
+   India
+
+   EMail: manav@alcatel-lucent.com
+
+
+   Vishwas Manral
+   IP Infusion
+   Almora, Uttarakhand
+   India
+
+   EMail: vishwas@ipinfusion.com
+
+
+
+
+
+
+
+Bhatia, et al.              Standards Track                    [Page 11]
+
+RFC 5310          IS-IS Generic Crypto Authentication      February 2009
+
+
+   Tony Li
+   Redback Networks Inc.
+   300 Holger Way
+   San Jose, CA  95134
+   USA
+
+   EMail: tony.li@tony.li
+
+
+   Randall J. Atkinson
+   Extreme Networks
+   3585  Monroe Street
+   Santa Clara, CA  95051
+   USA
+
+   EMail: rja@extremenetworks.com
+
+
+   Russ White
+   Cisco Systems
+   RTP North Carolina
+   USA
+
+   EMail: riw@cisco.com
+
+
+   Matthew J. Fanto
+   Aegis Data Security
+   Dearborn, MI
+   USA
+
+   EMail: mfanto@aegisdatasecurity.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bhatia, et al.              Standards Track                    [Page 12]
+


### PR DESCRIPTION
## Summary

Phase 1 of IS-IS authentication. Pure wire-layer changes in `isis-packet` so the parser stops bucketing TLV 10 as `Unknown` and the emitter can produce auth-bearing PDUs. **No runtime behavior change** — IS-IS still neither validates nor signs.

- `IsisTlvType::Auth = 10` registered (and recognized by `is_known()`).
- New `IsisTlvAuth { auth_type, value }` with `ParseBe` / `TlvEmitter` / `From<IsisTlvAuth> for IsisTlv` / `Display`. One struct covers all three on-wire shapes (cleartext per ISO 10589, HMAC-MD5 per RFC 5304, generic crypto per RFC 5310 with its 2-byte Key ID prefix) by treating the value as opaque bytes — the Phase 4 signer interprets per `auth_type`.
- Constants `ISIS_AUTH_TYPE_{CLEARTEXT,GENERIC,HMAC_MD5}` and `ISIS_AUTH_HMAC_MD5_LEN`.
- `IsisTlvAuth::placeholder(auth_type, value_len)` — zero-filled constructor for the two-pass sign flow (RFC 5304 §3 / RFC 5310 §3).
- RFCs 5304 and 5310 added under `rfc/isis/`.

Deliberately **not** in scope here (deferred to the phase that needs it):
- The "locate auth TLV in serialized PDU and patch digest in place" helper — Phase 4 LSP signer will be the first real caller.
- Config schema and per-PDU sign/verify runtime — Phases 2/3/4.

## Test plan

- [x] `cargo test -p isis-packet` — 43/43 lib tests pass (5 new): HMAC-MD5 round-trip, cleartext round-trip, RFC 5310 generic-crypto round-trip, `placeholder()` zero-fill shape, unknown `auth_type` byte preserved through parse+emit.
- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

Generated with [Claude Code](https://claude.com/claude-code)