### PR TITLE
ospf: leave multicast groups on interface_down

### DIFF
--- a/zebra-rs/src/ospf/ifsm.rs
+++ b/zebra-rs/src/ospf/ifsm.rs
@@ -202,7 +202,17 @@ pub fn ospf_ifsm_interface_down<V: OspfVersion>(oi: &mut OspfLink<V>) -> Option<
     oi.ident.d_router = Ipv4Addr::UNSPECIFIED;
     oi.ident.bd_router = Ipv4Addr::UNSPECIFIED;
 
-    // Reset multicast memberships.
+    // Symmetric multicast cleanup: drop kernel memberships before
+    // clearing the bookkeeping flags so the two stay consistent
+    // across a Down→Up flap. Earlier this only cleared the
+    // bitfield, which left the kernel still subscribed and made
+    // the next `interface_up` join return EADDRINUSE.
+    if oi.multicast_memberships.all_drouters() {
+        V::leave_alldrouters(&oi.sock, oi.index);
+    }
+    if oi.multicast_memberships.all_routers() {
+        V::leave_if(&oi.sock, oi.index);
+    }
     oi.multicast_memberships = 0.into();
 
     None

--- a/zebra-rs/src/ospf/socket.rs
+++ b/zebra-rs/src/ospf/socket.rs
@@ -49,6 +49,13 @@ fn is_eaddrinuse(err: &std::io::Error) -> bool {
     err.raw_os_error() == Some(libc::EADDRINUSE)
 }
 
+/// Counterpart for the leave path: the kernel returns
+/// EADDRNOTAVAIL when we're not actually a member. Demote to
+/// debug — it just means the bookkeeping and kernel agree.
+fn is_not_member(err: &std::io::Error) -> bool {
+    err.raw_os_error() == Some(libc::EADDRNOTAVAIL)
+}
+
 pub fn ospf_join_if(socket: &AsyncFd<Socket>, ifindex: u32) {
     let maddr = Ospfv2::ALL_SPF_ROUTERS;
     if let Err(e) = socket
@@ -59,6 +66,25 @@ pub fn ospf_join_if(socket: &AsyncFd<Socket>, ifindex: u32) {
             tracing::debug!("ospf: AllSPFRouters already joined on ifindex {ifindex}");
         } else {
             tracing::warn!("ospf: join AllSPFRouters on ifindex {ifindex} failed: {e}");
+        }
+    }
+}
+
+/// Leave AllSPFRouters on the given interface. Mirror of
+/// `ospf_join_if`, called from `ospf_ifsm_interface_down` so the
+/// bookkeeping in `multicast_memberships` stays in sync with
+/// kernel state. EADDRNOTAVAIL means we weren't a member — log
+/// at debug and move on.
+pub fn ospf_leave_if(socket: &AsyncFd<Socket>, ifindex: u32) {
+    let maddr = Ospfv2::ALL_SPF_ROUTERS;
+    if let Err(e) = socket
+        .get_ref()
+        .leave_multicast_v4_n(&maddr, &InterfaceIndexOrAddress::Index(ifindex))
+    {
+        if is_not_member(&e) {
+            tracing::debug!("ospf: AllSPFRouters not joined on ifindex {ifindex}");
+        } else {
+            tracing::warn!("ospf: leave AllSPFRouters on ifindex {ifindex} failed: {e}");
         }
     }
 }
@@ -83,7 +109,11 @@ pub fn ospf_leave_alldrouters(socket: &AsyncFd<Socket>, ifindex: u32) {
         .get_ref()
         .leave_multicast_v4_n(&maddr, &InterfaceIndexOrAddress::Index(ifindex))
     {
-        tracing::warn!("ospf: leave AllDRouters on ifindex {ifindex} failed: {e}");
+        if is_not_member(&e) {
+            tracing::debug!("ospf: AllDRouters not joined on ifindex {ifindex}");
+        } else {
+            tracing::warn!("ospf: leave AllDRouters on ifindex {ifindex} failed: {e}");
+        }
     }
 }
 
@@ -161,12 +191,30 @@ pub fn ospf_join_alldrouters_v6(socket: &AsyncFd<Socket>, ifindex: u32) {
     }
 }
 
+/// Leave `ff02::5` on the given interface. v3 mirror of
+/// `ospf_leave_if`, called from `ospf_ifsm_interface_down`.
+#[allow(dead_code)]
+pub fn ospf_leave_if_v6(socket: &AsyncFd<Socket>, ifindex: u32) {
+    let maddr = Ospfv3::ALL_SPF_ROUTERS;
+    if let Err(e) = socket.get_ref().leave_multicast_v6(&maddr, ifindex) {
+        if is_not_member(&e) {
+            tracing::debug!("ospf: AllSPFRouters (v6) not joined on ifindex {ifindex}");
+        } else {
+            tracing::warn!("ospf: leave AllSPFRouters (v6) on ifindex {ifindex} failed: {e}");
+        }
+    }
+}
+
 /// Leave `ff02::6` on the given interface. Called when the v3 FSM
 /// drops out of the DR / BDR role.
 #[allow(dead_code)]
 pub fn ospf_leave_alldrouters_v6(socket: &AsyncFd<Socket>, ifindex: u32) {
     let maddr = Ospfv3::ALL_DROUTERS;
     if let Err(e) = socket.get_ref().leave_multicast_v6(&maddr, ifindex) {
-        tracing::warn!("ospf: leave AllDRouters (v6) on ifindex {ifindex} failed: {e}");
+        if is_not_member(&e) {
+            tracing::debug!("ospf: AllDRouters (v6) not joined on ifindex {ifindex}");
+        } else {
+            tracing::warn!("ospf: leave AllDRouters (v6) on ifindex {ifindex} failed: {e}");
+        }
     }
 }

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -245,6 +245,12 @@ pub trait OspfVersion: 'static + Send + Sync + Copy + Clone + PartialEq + Eq {
     /// IFSM moves an interface out of `Down`.
     fn join_if(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32);
 
+    /// Leave the AllSPFRouters group. Mirror of `join_if`, called
+    /// from `ospf_ifsm_interface_down` so kernel membership and
+    /// `multicast_memberships` bookkeeping stay in sync across
+    /// interface flaps.
+    fn leave_if(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32);
+
     /// Join the version's AllDRouters multicast group. Called by
     /// DR-election state changes when this router becomes DR or BDR.
     fn join_alldrouters(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32);
@@ -387,6 +393,9 @@ impl OspfVersion for Ospfv2 {
     fn join_if(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32) {
         crate::ospf::socket::ospf_join_if(sock, ifindex);
     }
+    fn leave_if(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32) {
+        crate::ospf::socket::ospf_leave_if(sock, ifindex);
+    }
     fn join_alldrouters(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32) {
         crate::ospf::socket::ospf_join_alldrouters(sock, ifindex);
     }
@@ -502,6 +511,9 @@ impl OspfVersion for Ospfv3 {
     }
     fn join_if(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32) {
         crate::ospf::socket::ospf_join_if_v6(sock, ifindex);
+    }
+    fn leave_if(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32) {
+        crate::ospf::socket::ospf_leave_if_v6(sock, ifindex);
     }
     fn join_alldrouters(sock: &tokio::io::unix::AsyncFd<socket2::Socket>, ifindex: u32) {
         crate::ospf::socket::ospf_join_alldrouters_v6(sock, ifindex);


### PR DESCRIPTION
## Summary

\`ospf_ifsm_interface_down\` cleared \`oi.multicast_memberships\` to zero but never issued the matching \`IP_DROP_MEMBERSHIP\` / \`IPV6_LEAVE_GROUP\`. The kernel kept the membership; the bookkeeping said we'd dropped it. Next \`interface_up\` re-joined, the kernel returned EADDRINUSE, and we either spammed \`WARN\` (pre-#915) or silently swallowed it (post-#915).

Symmetric fix: actually leave the group(s) before clearing the bitfield, so kernel state and bookkeeping stay in lockstep. This makes the EADDRINUSE-tolerance in #915 a true defence-in-depth measure rather than a workaround.

## Changes

| File | Change |
|---|---|
| \`zebra-rs/src/ospf/socket.rs\` | New \`ospf_leave_if\` (v2) / \`ospf_leave_if_v6\` (v3) wrappers, mirror of the existing join helpers. Existing \`ospf_leave_alldrouters\` + new wrappers demote EADDRNOTAVAIL ("wasn't a member") to debug, symmetric to the EADDRINUSE handling. |
| \`zebra-rs/src/ospf/version.rs\` | \`OspfVersion::leave_if\` added to the trait; v2 / v3 impls route to the new helpers. |
| \`zebra-rs/src/ospf/ifsm.rs\` | \`ospf_ifsm_interface_down\` drops AllDRouters (if held) and AllSPFRouters (if held) before zeroing the bitfield. |

## Test plan

- [x] \`cargo build -p zebra-rs\`
- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p zebra-rs --bin zebra-rs\` — 637 passed
- [ ] Manual: bring an OSPF interface down then back up (\`ip link set enp0s6 down; sleep 2; ip link set enp0s6 up\`) and confirm:
  - \`interface_up\` doesn't see EADDRINUSE in debug logs
  - \`show ip ospf neighbor\` re-converges normally

Generated with [Claude Code](https://claude.com/claude-code)