### PR TITLE
isis: add authentication config schema and storage (Phase 2)

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -55,6 +55,34 @@ impl Isis {
         self.callback_add("/router/isis/net", config_net);
         self.callback_add("/router/isis/is-type", config_is_type);
         self.callback_add("/router/isis/hostname", config_hostname);
+        // Authentication storage (Phase 2). The runtime sign/verify
+        // paths read these in Phase 3 (Hello/SNP) and Phase 4 (LSP).
+        self.callback_add("/router/isis/area-password", config_area_password);
+        self.callback_add(
+            "/router/isis/area-password/password",
+            config_area_password_password,
+        );
+        self.callback_add(
+            "/router/isis/area-password/auth-type",
+            config_area_password_auth_type,
+        );
+        self.callback_add(
+            "/router/isis/area-password/send-only",
+            config_area_password_send_only,
+        );
+        self.callback_add("/router/isis/domain-password", config_domain_password);
+        self.callback_add(
+            "/router/isis/domain-password/password",
+            config_domain_password_password,
+        );
+        self.callback_add(
+            "/router/isis/domain-password/auth-type",
+            config_domain_password_auth_type,
+        );
+        self.callback_add(
+            "/router/isis/domain-password/send-only",
+            config_domain_password_send_only,
+        );
         self.callback_add("/router/isis/timers/hold-time", config_hold_time);
         self.callback_add(
             "/router/isis/timers/lsp-refresh-interval",
@@ -238,6 +266,24 @@ impl Isis {
             "/router/isis/interface/bfd/profile",
             link::config_bfd_profile,
         );
+        // Per-interface hello-authentication (Phase 2 storage). The
+        // Hello/CSNP/PSNP sign+verify runtime lands in Phase 3.
+        self.callback_add(
+            "/router/isis/interface/hello-authentication",
+            link::config_hello_auth,
+        );
+        self.callback_add(
+            "/router/isis/interface/hello-authentication/password",
+            link::config_hello_auth_password,
+        );
+        self.callback_add(
+            "/router/isis/interface/hello-authentication/auth-type",
+            link::config_hello_auth_type,
+        );
+        self.callback_add(
+            "/router/isis/interface/hello-authentication/send-only",
+            link::config_hello_auth_send_only,
+        );
         self.callback_add(
             "/router/isis/interface/ipv4/prefix-sid/index",
             link::config_ipv4_prefix_sid_index,
@@ -361,6 +407,16 @@ pub struct IsisConfig {
     /// Storage-only today — the LSP emitter and RIB-source plumbing
     /// will read from it in a follow-up.
     pub redistribute: BTreeMap<(IsisRedistAfi, IsisRedistSource), IsisRedistribute>,
+
+    /// Authentication for L1 self-originated LSPs and L1 SNPs
+    /// (ISO 10589 §9.5 / RFC 5304 / RFC 5310). Active iff
+    /// `password.is_some()`. Storage-only in Phase 2; Phase 4 will
+    /// drive the LSP signer from this and Phase 3 the SNP path.
+    pub area_password: IsisAuthConfig,
+
+    /// Authentication for L2 self-originated LSPs and L2 SNPs.
+    /// Same shape and lifecycle as `area_password`.
+    pub domain_password: IsisAuthConfig,
 }
 
 /// AFI key for the redistribute map. Mirrors the
@@ -411,6 +467,38 @@ pub struct IsisRedistribute {
     pub metric_type: Option<IsisRedistMetricType>,
     /// Populated only when source == Ospf. Empty set means "no filter".
     pub ospf_match: BTreeSet<IsisRedistOspfMatch>,
+}
+
+/// IS-IS Authentication algorithm selector. Maps to the TLV-10
+/// Authentication Type byte at sign/verify time:
+///   Text → 1   (ISO 10589 §9.5 cleartext)
+///   Md5  → 54  (RFC 5304 HMAC-MD5)
+/// RFC 5310 generic-crypto (auth-type 3, HMAC-SHA family) is a
+/// Phase 4b follow-on and intentionally absent from the enum so it
+/// can't be committed before the runtime supports it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, EnumString, Display)]
+pub enum IsisAuthType {
+    #[default]
+    #[strum(serialize = "text")]
+    Text,
+    #[strum(serialize = "md5")]
+    Md5,
+}
+
+/// Shared shape for all three IS-IS auth scopes: instance-level
+/// area-password (L1 LSPs+SNPs), domain-password (L2 LSPs+SNPs), and
+/// per-interface hello-authentication (IIH/CSNP/PSNP). A scope is
+/// active iff `password.is_some()` — the YANG layer makes `password`
+/// mandatory inside the (presence) container, so an active scope
+/// always has a key.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct IsisAuthConfig {
+    pub password: Option<String>,
+    pub auth_type: IsisAuthType,
+    /// RFC 5304 §1 rollover hatch: sign on send, accept-any on
+    /// receive. Used to drain peers from no-auth → auth without
+    /// breaking adjacencies mid-rollout.
+    pub send_only: bool,
 }
 
 impl IsisConfig {
@@ -565,6 +653,74 @@ fn config_hostname(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> 
     }
 
     Some(())
+}
+
+/// Reset an IsisAuthConfig to its YANG-default state. Used by the
+/// presence-container delete callbacks when the whole auth scope is
+/// removed, so we don't leave stale auth-type / send-only behind a
+/// vanished password.
+pub fn auth_reset(cfg: &mut IsisAuthConfig) {
+    cfg.password = None;
+    cfg.auth_type = IsisAuthType::default();
+    cfg.send_only = false;
+}
+
+pub fn auth_set_password(cfg: &mut IsisAuthConfig, args: &mut Args, op: ConfigOp) -> Option<()> {
+    let pw = args.string()?;
+    cfg.password = op.is_set().then_some(pw);
+    Some(())
+}
+
+pub fn auth_set_type(cfg: &mut IsisAuthConfig, args: &mut Args, op: ConfigOp) -> Option<()> {
+    if op.is_set() {
+        cfg.auth_type = IsisAuthType::from_str(&args.string()?).ok()?;
+    } else {
+        cfg.auth_type = IsisAuthType::default();
+    }
+    Some(())
+}
+
+pub fn auth_set_send_only(cfg: &mut IsisAuthConfig, args: &mut Args, op: ConfigOp) -> Option<()> {
+    cfg.send_only = op.is_set() && args.boolean()?;
+    Some(())
+}
+
+fn config_area_password(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
+    if !op.is_set() {
+        auth_reset(&mut isis.config.area_password);
+    }
+    Some(())
+}
+
+fn config_area_password_password(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    auth_set_password(&mut isis.config.area_password, &mut args, op)
+}
+
+fn config_area_password_auth_type(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    auth_set_type(&mut isis.config.area_password, &mut args, op)
+}
+
+fn config_area_password_send_only(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    auth_set_send_only(&mut isis.config.area_password, &mut args, op)
+}
+
+fn config_domain_password(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
+    if !op.is_set() {
+        auth_reset(&mut isis.config.domain_password);
+    }
+    Some(())
+}
+
+fn config_domain_password_password(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    auth_set_password(&mut isis.config.domain_password, &mut args, op)
+}
+
+fn config_domain_password_auth_type(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    auth_set_type(&mut isis.config.domain_password, &mut args, op)
+}
+
+fn config_domain_password_send_only(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    auth_set_send_only(&mut isis.config.domain_password, &mut args, op)
 }
 
 fn config_hold_time(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
@@ -1260,4 +1416,36 @@ fn config_distribute_rib(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Optio
     }
 
     Some(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_type_parses_yang_enum_names() {
+        // The two enum values the YANG schema admits — the FromStr
+        // impl gates what the auth-type leaf callback will accept.
+        assert_eq!(IsisAuthType::from_str("text"), Ok(IsisAuthType::Text));
+        assert_eq!(IsisAuthType::from_str("md5"), Ok(IsisAuthType::Md5));
+        assert!(IsisAuthType::from_str("hmac-sha-256").is_err());
+    }
+
+    #[test]
+    fn auth_reset_returns_defaults() {
+        // Phase 3/4 short-circuit on `password.is_none()`. The
+        // presence-container delete path goes through auth_reset, so
+        // a stale auth-type or send-only must not survive a password
+        // removal — verified here so the contract is locked.
+        let mut cfg = IsisAuthConfig {
+            password: Some("secret".into()),
+            auth_type: IsisAuthType::Md5,
+            send_only: true,
+        };
+        auth_reset(&mut cfg);
+        assert_eq!(cfg, IsisAuthConfig::default());
+        assert!(cfg.password.is_none());
+        assert_eq!(cfg.auth_type, IsisAuthType::Text);
+        assert!(!cfg.send_only);
+    }
 }

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -19,7 +19,9 @@ use crate::isis_event_trace;
 use crate::rib::link::LinkAddr;
 use crate::rib::{Link, LinkFlagsExt, MacAddr};
 
-use super::config::{IsisConfig, MtId};
+use super::config::{
+    self, IsisAuthConfig, IsisConfig, MtId, auth_set_password, auth_set_send_only, auth_set_type,
+};
 use super::graph::{ReachMap, ReachMapV6};
 use super::ifsm::{self, has_level};
 use super::lsp::PacketMessage;
@@ -268,6 +270,12 @@ pub struct LinkConfig {
     /// `prefix_sid`. Storage-only — the LSP emitter consumes it once
     /// per-algo origination lands.
     pub ipv4_flex_algo_prefix_sids: BTreeMap<u8, SidLabelValue>,
+
+    /// Per-interface authentication for IIH / CSNP / PSNP PDUs,
+    /// from /router/isis/interface/<name>/hello-authentication.
+    /// Storage-only in Phase 2; the Hello/SNP sign+verify runtime
+    /// arrives in Phase 3. Active iff `hello_auth.is_active()`.
+    pub hello_auth: IsisAuthConfig,
 }
 
 /// IS-IS-side mirror of the YANG `bfd { enable, profile }` container.
@@ -766,6 +774,38 @@ pub fn config_bfd_profile(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Opti
     let link = isis.links.get_mut_by_name(&name)?;
     link.config.bfd.profile = op.is_set().then_some(profile);
     Some(())
+}
+
+/// `set router isis interface X hello-authentication` (presence
+/// container). The leaf callbacks below mutate fields; this one
+/// only resets the auth state when the entire container is removed
+/// so we don't leave a stale auth-type / send-only behind a
+/// vanished password.
+pub fn config_hello_auth(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let link = isis.links.get_mut_by_name(&name)?;
+    if !op.is_set() {
+        config::auth_reset(&mut link.config.hello_auth);
+    }
+    Some(())
+}
+
+pub fn config_hello_auth_password(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let link = isis.links.get_mut_by_name(&name)?;
+    auth_set_password(&mut link.config.hello_auth, &mut args, op)
+}
+
+pub fn config_hello_auth_type(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let link = isis.links.get_mut_by_name(&name)?;
+    auth_set_type(&mut link.config.hello_auth, &mut args, op)
+}
+
+pub fn config_hello_auth_send_only(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let link = isis.links.get_mut_by_name(&name)?;
+    auth_set_send_only(&mut link.config.hello_auth, &mut args, op)
 }
 
 fn config_afi_enable(isis: &mut Isis, mut args: Args, op: ConfigOp, afi: Afi) -> Option<()> {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -983,6 +983,62 @@ module config {
           type string;
         }
 
+        container area-password {
+          presence "L1 area-wide IS-IS authentication";
+          description
+            "Authentication key applied to Level-1 self-originated LSPs
+             and SNPs (ISO 10589 §9.5 / RFC 5304 / RFC 5310). Per
+             ISO 10589, L1 PDUs use the area-wide authentication string.
+             Phase 2 lands the schema and storage; the sign/verify
+             runtime arrives in Phase 4 (LSPs) and Phase 3 (SNPs are
+             carried alongside Hello auth on the link).";
+
+          leaf password {
+            type string;
+            mandatory true;
+            description
+              "Authentication key bytes. Sent cleartext on the wire
+               when auth-type is text; used as the HMAC key when md5.";
+          }
+          leaf auth-type {
+            type enumeration {
+              enum text;  // ISO 10589 §9.5, TLV-10 auth-type 1
+              enum md5;   // RFC 5304, TLV-10 auth-type 54
+            }
+            default text;
+          }
+          leaf send-only {
+            type boolean;
+            default false;
+            description
+              "Sign outbound but accept any inbound regardless of
+               digest — rollover hatch per RFC 5304 §1.";
+          }
+        }
+
+        container domain-password {
+          presence "L2 domain-wide IS-IS authentication";
+          description
+            "Authentication key applied to Level-2 self-originated LSPs
+             and SNPs. Same shape as area-password but scoped to L2.";
+
+          leaf password {
+            type string;
+            mandatory true;
+          }
+          leaf auth-type {
+            type enumeration {
+              enum text;
+              enum md5;
+            }
+            default text;
+          }
+          leaf send-only {
+            type boolean;
+            default false;
+          }
+        }
+
         container timers {
           leaf hold_time {
             type uint16;
@@ -1210,6 +1266,34 @@ module config {
             }
             leaf metric {
               type uint32;
+            }
+          }
+
+          container hello-authentication {
+            presence "Per-interface IIH/CSNP/PSNP authentication";
+            description
+              "Authentication key applied to IS-IS Hello (IIH), CSNP,
+               and PSNP PDUs sent and received on this interface. RFC
+               5304 §2 carries this in the TLV-10 Authentication
+               Information TLV with auth-type 1 (text) or 54 (md5).
+               Per RFC 5304 §1, send-only enables an asymmetric
+               rollover where outbound is signed but inbound is
+               accepted unconditionally.";
+
+            leaf password {
+              type string;
+              mandatory true;
+            }
+            leaf auth-type {
+              type enumeration {
+                enum text;
+                enum md5;
+              }
+              default text;
+            }
+            leaf send-only {
+              type boolean;
+              default false;
             }
           }
 


### PR DESCRIPTION
## Summary

Phase 2 of IS-IS authentication. **Storage-only** — YANG nodes + Rust state so operators can commit auth config; IS-IS still neither signs nor verifies (that's Phase 3 for Hello/SNP and Phase 4 for LSPs).

### Schema (`zebra-rs/yang/config.yang`)

Three presence containers, all the same shape:

- `/router/isis/area-password` — drives L1 LSP/SNP signing.
- `/router/isis/domain-password` — drives L2 LSP/SNP signing.
- `/router/isis/interface/<name>/hello-authentication` — drives per-link IIH/CSNP/PSNP signing.

Each carries:
- `password` (string, **mandatory**)
- `auth-type` (enum: `text` = ISO 10589 §9.5 cleartext, `md5` = RFC 5304 HMAC-MD5; default `text`)
- `send-only` (boolean, default `false`) — RFC 5304 §1 rollover hatch: sign outbound, accept any inbound.

A scope is active iff its container is committed (password is mandatory inside).

### Storage (`zebra-rs/src/isis/{config.rs, link.rs}`)

- `IsisAuthType { Text, Md5 }` + `IsisAuthConfig { password, auth_type, send_only }`.
- Fields: `IsisConfig::{area_password, domain_password}` and `LinkConfig::hello_auth`.
- Shared helpers `auth_reset` / `auth_set_password` / `auth_set_type` / `auth_set_send_only` so the 12 dispatch callbacks (1 container + 3 leaves × 3 scopes) stay one-liners.
- The presence-container delete path goes through `auth_reset`, so a stale auth-type or send-only never survives a password removal.

### Deliberately not in scope

- Runtime sign/verify (Phase 3 + 4).
- RFC 5310 generic-crypto (HMAC-SHA family) — the auth-type enum admits only `text|md5` so it cannot be committed before the wire layer + runtime support land in Phase 4b.
- `IsisAuthConfig::is_active()` — would have been a one-liner `password.is_some()` but clippy `-D warnings` rejects unused; Phase 3 reinstates it when the first caller exists.
- LSP re-origination triggers on auth changes — Phase 4 LSP signer adds them when it has a consumer.

## Test plan

- [x] `cargo test -p zebra-rs --bin zebra-rs isis::` — 96/96 pass (2 new: `auth_type_parses_yang_enum_names`, `auth_reset_returns_defaults` — lock the FromStr surface + reset invariant that Phase 3/4 will rely on).
- [x] `cargo test -p isis-packet` — 43/43 pass (Phase 1's auth-TLV tests unchanged).
- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

Generated with [Claude Code](https://claude.com/claude-code)