### PR TITLE
isis: sign and verify Hello PDUs (Phase 3a)

### DIFF
--- a/crates/isis-packet/src/typ.rs
+++ b/crates/isis-packet/src/typ.rs
@@ -87,4 +87,11 @@ impl IsisType {
     pub fn is_lsp(&self) -> bool {
         matches!(self, IsisType::L1Lsp | IsisType::L2Lsp)
     }
+
+    pub fn is_hello(&self) -> bool {
+        matches!(
+            self,
+            IsisType::L1Hello | IsisType::L2Hello | IsisType::P2pHello
+        )
+    }
 }

--- a/zebra-rs/src/isis/auth.rs
+++ b/zebra-rs/src/isis/auth.rs
@@ -1,0 +1,231 @@
+//! HMAC-MD5 sign/verify and Auth TLV locator for IS-IS Hello PDUs.
+//!
+//! Phase 3a scope: per-link Hello (LAN + P2P) authentication. CSNP/PSNP
+//! reuse these helpers in 3b; LSP signing in Phase 4 needs additional
+//! treatment for the LSP Checksum and Remaining Lifetime fields per
+//! RFC 5304 §3.
+//!
+//! Cleartext (auth-type 1) is just bytes-in-TLV-value and doesn't
+//! need anything from this module — the send path appends the
+//! password bytes verbatim, and the verify path compares them.
+//! HMAC-MD5 (auth-type 54) is the two-pass case: emit a zero-filled
+//! placeholder, hash the whole serialized PDU, then patch the digest
+//! into the placeholder's byte range.
+
+use std::ops::Range;
+
+use hmac::{Hmac, KeyInit, Mac};
+use isis_packet::IsisTlvType;
+use md5::Md5;
+
+/// HMAC-MD5 over `data` keyed by `key` (RFC 2104 / RFC 5304 §3).
+/// Returns the 16-byte digest. `Hmac::new_from_slice` accepts any
+/// key length — internally hashed/padded to the MD5 block size.
+pub fn hmac_md5(key: &[u8], data: &[u8]) -> [u8; 16] {
+    let mut mac = <Hmac<Md5>>::new_from_slice(key).expect("HMAC accepts any key length");
+    mac.update(data);
+    let out = mac.finalize().into_bytes();
+    let mut digest = [0u8; 16];
+    digest.copy_from_slice(&out[..16]);
+    digest
+}
+
+/// Constant-time byte comparison so a partial-match digest doesn't
+/// leak timing information to an attacker probing different keys.
+pub fn digest_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Walk the TLV section starting at `tlvs_start` and return the byte
+/// range covering the Auth TLV's *value* — i.e., the auth-type byte
+/// plus the digest/password that follows. Returns `None` if no Auth
+/// TLV is present, or if a TLV header would run off the end of
+/// `pdu` (malformed input is treated as "no auth").
+///
+/// `tlvs_start` is the offset at which the first TLV header begins;
+/// for a freshly-received IS-IS PDU that's the value of the
+/// `length_indicator` field in the common header (e.g. 27 for
+/// IIH/L1Hello/L2Hello, 20 for P2P Hello, 33 for CSNP, 17 for PSNP).
+pub fn locate_auth_tlv(pdu: &[u8], tlvs_start: usize) -> Option<Range<usize>> {
+    let auth_typ = u8::from(IsisTlvType::Auth);
+    let mut i = tlvs_start;
+    while i + 2 <= pdu.len() {
+        let typ = pdu[i];
+        let len = pdu[i + 1] as usize;
+        let value_start = i + 2;
+        let value_end = value_start.checked_add(len)?;
+        if value_end > pdu.len() {
+            return None;
+        }
+        if typ == auth_typ {
+            return Some(value_start..value_end);
+        }
+        i = value_end;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// HMAC-MD5 reference vector from RFC 2202 §2 test case 1:
+    /// key = 0x0b * 16, data = "Hi There" → 9294727a3638bb1c13f48ef8158bfc9d.
+    #[test]
+    fn hmac_md5_matches_rfc2202_vector_1() {
+        let key = [0x0bu8; 16];
+        let data = b"Hi There";
+        let got = hmac_md5(&key, data);
+        let want = [
+            0x92, 0x94, 0x72, 0x7a, 0x36, 0x38, 0xbb, 0x1c, 0x13, 0xf4, 0x8e, 0xf8, 0x15, 0x8b,
+            0xfc, 0x9d,
+        ];
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn digest_eq_rejects_length_mismatch() {
+        assert!(!digest_eq(&[1, 2, 3], &[1, 2]));
+        assert!(!digest_eq(&[1, 2, 3], &[1, 2, 3, 4]));
+        assert!(digest_eq(&[1, 2, 3], &[1, 2, 3]));
+    }
+
+    #[test]
+    fn digest_eq_is_byte_exact() {
+        assert!(!digest_eq(&[1, 2, 3], &[1, 2, 4]));
+        assert!(digest_eq(&[], &[]));
+    }
+
+    /// Locator returns the byte range of the Auth TLV's value field
+    /// (auth-type + payload). Verify against a tiny hand-built PDU
+    /// with two TLVs preceding the Auth TLV so the walker has to
+    /// skip past them.
+    #[test]
+    fn locate_auth_tlv_finds_value_range() {
+        // Fake PDU header (3 bytes, not actually parsed by this
+        // helper — we just use tlvs_start=3 to skip them).
+        // Then: TLV 1 (AreaAddr) len 2, TLV 9 (LspEntries) len 0,
+        // TLV 10 (Auth) len 17 (1 byte auth-type + 16 bytes digest).
+        let mut pdu = vec![0xAA, 0xBB, 0xCC];
+        pdu.extend_from_slice(&[1, 2, 0xDE, 0xAD]); // AreaAddr
+        pdu.extend_from_slice(&[9, 0]); // empty LspEntries
+        pdu.extend_from_slice(&[10, 17, 54]); // Auth, len 17, auth-type 54
+        pdu.extend_from_slice(&[0xFFu8; 16]); // digest
+
+        let range = locate_auth_tlv(&pdu, 3).expect("auth TLV present");
+        assert_eq!(range.start, 3 + 4 + 2 + 2); // past 3-byte hdr + TLV1 + TLV9 + 2-byte Auth header
+        assert_eq!(range.len(), 17);
+        assert_eq!(pdu[range.start], 54); // auth-type byte
+    }
+
+    #[test]
+    fn locate_auth_tlv_returns_none_when_absent() {
+        let mut pdu = vec![0xAA, 0xBB, 0xCC];
+        pdu.extend_from_slice(&[1, 2, 0xDE, 0xAD]);
+        assert!(locate_auth_tlv(&pdu, 3).is_none());
+    }
+
+    #[test]
+    fn locate_auth_tlv_rejects_truncated_value() {
+        // Auth TLV header claims length 17 but value bytes are missing.
+        let mut pdu = vec![0xAA, 0xBB, 0xCC];
+        pdu.extend_from_slice(&[10, 17]); // header only
+        assert!(locate_auth_tlv(&pdu, 3).is_none());
+    }
+
+    /// End-to-end HMAC-MD5 round-trip across a real Hello PDU: emit a
+    /// Hello with a zero-filled Auth TLV placeholder, sign the
+    /// resulting bytes, then verify them by zeroing the digest area
+    /// in a copy and recomputing. Mirrors the sign side of
+    /// `ifsm::sign_hello_md5_inplace` and the verify side of
+    /// `packet::verify_hello_auth` without needing LinkTop scaffolding.
+    #[test]
+    fn hello_pdu_md5_round_trip_via_helpers() {
+        use bytes::BytesMut;
+        use isis_packet::{
+            ISIS_AUTH_HMAC_MD5_LEN, ISIS_AUTH_TYPE_HMAC_MD5, IsLevel, IsisHello, IsisNeighborId,
+            IsisPacket, IsisPdu, IsisSysId, IsisTlv, IsisTlvAreaAddr, IsisTlvAuth, IsisType,
+        };
+
+        let mut hello = IsisHello {
+            circuit_type: IsLevel::L1L2,
+            source_id: IsisSysId {
+                id: [1, 2, 3, 4, 5, 6],
+            },
+            hold_time: 30,
+            pdu_len: 0,
+            priority: 64,
+            lan_id: IsisNeighborId::default(),
+            tlvs: vec![
+                IsisTlv::AreaAddr(IsisTlvAreaAddr {
+                    area_addr: vec![0x49, 0x00, 0x01],
+                }),
+                IsisTlv::Auth(IsisTlvAuth::placeholder(
+                    ISIS_AUTH_TYPE_HMAC_MD5,
+                    ISIS_AUTH_HMAC_MD5_LEN,
+                )),
+            ],
+        };
+        let packet = IsisPacket::from(IsisType::L1Hello, IsisPdu::L1Hello(hello.clone()));
+        let mut buf = BytesMut::new();
+        packet.emit(&mut buf);
+
+        // Sign: locate the auth TLV, compute HMAC over the buffer
+        // (digest area still zero), patch the digest in.
+        let key = b"hunter2";
+        let value_range = locate_auth_tlv(&buf, packet.length_indicator as usize)
+            .expect("auth TLV must be present");
+        let digest_start = value_range.start + 1;
+        let digest_end = value_range.end;
+        let digest = hmac_md5(key, &buf);
+        buf[digest_start..digest_end].copy_from_slice(&digest);
+
+        // Verify: zero the digest area in a copy, recompute, compare
+        // against the bytes the "sender" wrote into the patched buffer.
+        let mut scratch = buf.to_vec();
+        let stored_digest = buf[digest_start..digest_end].to_vec();
+        for b in &mut scratch[digest_start..digest_end] {
+            *b = 0;
+        }
+        let recomputed = hmac_md5(key, &scratch);
+        assert!(digest_eq(&recomputed, &stored_digest));
+        // Also: the stored digest should not be all-zero anymore.
+        assert!(stored_digest.iter().any(|b| *b != 0));
+
+        // Negative: flip a digest byte, recompute → mismatch.
+        buf[digest_start] ^= 0x01;
+        let tampered_stored = buf[digest_start..digest_end].to_vec();
+        let mut scratch = buf.to_vec();
+        for b in &mut scratch[digest_start..digest_end] {
+            *b = 0;
+        }
+        let recomputed = hmac_md5(key, &scratch);
+        assert!(!digest_eq(&recomputed, &tampered_stored));
+
+        // Negative: wrong key.
+        let recomputed_wrong_key = hmac_md5(b"wrong-key", &scratch);
+        assert!(!digest_eq(&recomputed_wrong_key, &tampered_stored));
+
+        // Touch `hello` so the binding compiles cleanly under the
+        // `-D warnings` clippy gate; cloned into the packet above.
+        hello.pdu_len = 0;
+    }
+
+    /// Cleartext (auth-type 1) is a plain byte-compare; verify
+    /// matches the configured password and rejects mismatches.
+    #[test]
+    fn cleartext_password_compare() {
+        let password = b"hunter2";
+        let value = password.to_vec();
+        assert!(digest_eq(&value, password));
+        assert!(!digest_eq(&value, b"hunter3"));
+        assert!(!digest_eq(&value, b""));
+    }
+}

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -10,10 +10,13 @@ use crate::isis_pdu_trace;
 use crate::rib::MacAddr;
 use crate::rib::link_ext::LinkFlagsExt;
 
+use super::auth;
+use super::config::IsisAuthType;
 use super::link::{Afis, HelloPaddingPolicy, LinkTop, NetworkType};
 use super::lsp::{Packet, PacketMessage};
 use super::neigh::Neighbor;
 use super::{Level, Message, NfsmState};
+use bytes::BytesMut;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum IfsmEvent {
@@ -102,10 +105,39 @@ pub fn hello_generate(link: &LinkTop, level: Level) -> IsisHello {
         }
     }
     hello.tlvs.push(IsisTlvIsNeighbor { neighbors }.into());
+    // Auth TLV (Phase 3a) lives at the end of the real TLVs, *before*
+    // padding. For HMAC-MD5 it's a zero-filled placeholder that the
+    // send path patches in after the HMAC is computed; for cleartext
+    // we attach the password bytes directly and the recv side
+    // compares them as-is. Including it before padding keeps the
+    // PDU exactly at MTU (the padding helper sees the auth TLV's
+    // size when it computes the remaining budget).
+    append_auth_tlv(&mut hello.tlvs, &link.config.hello_auth);
     if link.config.hello_padding() == HelloPaddingPolicy::Always {
         hello.padding(link.state.mtu as usize);
     }
     hello
+}
+
+/// Append the Authentication TLV (type 10) to `tlvs` when this link
+/// has hello-authentication configured. For cleartext the value is
+/// the password bytes verbatim; for HMAC-MD5 it's a zero-filled
+/// placeholder that `hello_send_signed` will patch in place once
+/// the digest is known.
+fn append_auth_tlv(tlvs: &mut Vec<IsisTlv>, cfg: &super::config::IsisAuthConfig) {
+    let Some(pw) = cfg.password.as_deref() else {
+        return;
+    };
+    let tlv = match cfg.auth_type {
+        IsisAuthType::Text => IsisTlvAuth {
+            auth_type: ISIS_AUTH_TYPE_CLEARTEXT,
+            value: pw.as_bytes().to_vec(),
+        },
+        IsisAuthType::Md5 => {
+            IsisTlvAuth::placeholder(ISIS_AUTH_TYPE_HMAC_MD5, ISIS_AUTH_HMAC_MD5_LEN)
+        }
+    };
+    tlvs.push(tlv.into());
 }
 
 pub fn hello_p2p_generate(link: &LinkTop, level: Level) -> IsisP2pHello {
@@ -179,6 +211,7 @@ pub fn hello_p2p_generate(link: &LinkTop, level: Level) -> IsisP2pHello {
     };
     hello.tlvs.push(tlv.into());
 
+    append_auth_tlv(&mut hello.tlvs, &link.config.hello_auth);
     if link.config.hello_padding() == HelloPaddingPolicy::Always {
         hello.padding(link.state.mtu as usize);
     }
@@ -251,13 +284,50 @@ pub fn hello_send(link: &mut LinkTop, level: Level) -> Result<()> {
     *link.state.hello.get_mut(&level) = Some(hello);
 
     let ifindex = link.ifindex;
-    let _ = link.ptx.send(PacketMessage::Send(
-        Packet::Packet(packet),
-        ifindex,
-        level,
-        mac,
-    ));
+    // HMAC-MD5 needs the bytes patched after serialization, so we
+    // pre-emit and send as `Packet::Bytes`. Cleartext + no-auth use
+    // the existing serialize-on-send path with `Packet::Packet`.
+    let auth_cfg = &link.config.hello_auth;
+    let outgoing = match (auth_cfg.password.as_deref(), auth_cfg.auth_type) {
+        (Some(key), IsisAuthType::Md5) => {
+            let mut buf = BytesMut::new();
+            packet.emit(&mut buf);
+            sign_hello_md5_inplace(&mut buf, packet.length_indicator as usize, key.as_bytes());
+            link.state.auth_tx_signed += 1;
+            Packet::Bytes(buf)
+        }
+        _ => {
+            if auth_cfg.password.is_some() {
+                link.state.auth_tx_signed += 1;
+            }
+            Packet::Packet(packet)
+        }
+    };
+
+    let _ = link
+        .ptx
+        .send(PacketMessage::Send(outgoing, ifindex, level, mac));
     Ok(())
+}
+
+/// Locate the Auth TLV value inside the just-emitted Hello PDU and
+/// patch the HMAC-MD5 digest in place. The TLV was emitted with a
+/// zero-filled placeholder (per `append_auth_tlv`), so the HMAC is
+/// computed over the buffer exactly as it sits — RFC 5304 §3's
+/// "set the Authentication Value field to zero before computing".
+fn sign_hello_md5_inplace(buf: &mut BytesMut, tlvs_start: usize, key: &[u8]) {
+    let Some(value_range) = auth::locate_auth_tlv(buf, tlvs_start) else {
+        return;
+    };
+    // value_range covers [auth_type, payload]. The digest area is
+    // everything after the 1-byte auth_type.
+    let digest_start = value_range.start + 1;
+    let digest_end = value_range.end;
+    if digest_end - digest_start != ISIS_AUTH_HMAC_MD5_LEN {
+        return;
+    }
+    let digest = auth::hmac_md5(key, buf);
+    buf[digest_start..digest_end].copy_from_slice(&digest);
 }
 
 pub fn has_level(is_level: IsLevel, level: Level) -> bool {

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -495,6 +495,16 @@ pub struct LinkState {
     pub stats: Direction<LinkStats>,
     pub stats_unknown: u64,
 
+    /// Authentication counters (Phase 3a — Hellos only).
+    /// `tx_signed` increments whenever we attach an Auth TLV outbound.
+    /// `rx_good` / `rx_bad` count auth-TLV validate outcomes; `rx_no_auth`
+    /// counts inbound Hellos with no Auth TLV when this link has auth
+    /// configured (and is not in `send-only` mode).
+    pub auth_tx_signed: u64,
+    pub auth_rx_good: u64,
+    pub auth_rx_bad: u64,
+    pub auth_rx_no_auth: u64,
+
     // TODO: need to fix.
     pub hello: Levels<Option<IsisPdu>>,
 }

--- a/zebra-rs/src/isis/mod.rs
+++ b/zebra-rs/src/isis/mod.rs
@@ -59,3 +59,5 @@ pub mod throttle;
 pub mod affinity_map;
 
 pub mod flex_algo;
+
+pub mod auth;

--- a/zebra-rs/src/isis/network.rs
+++ b/zebra-rs/src/isis/network.rs
@@ -76,13 +76,14 @@ pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message
                     return Err(ErrorKind::UnexpectedEof.into());
                 };
 
-                if packet.1.pdu_type.is_lsp() {
-                    if !isis_packet::is_valid_checksum(&input[3..]) {
-                        return Err(ErrorKind::UnexpectedEof.into());
-                    }
-                    // Store raw packet into packet's bytes.
-                    packet.1.bytes = input[3..].to_vec();
+                if packet.1.pdu_type.is_lsp() && !isis_packet::is_valid_checksum(&input[3..]) {
+                    return Err(ErrorKind::UnexpectedEof.into());
                 }
+                // Always preserve the raw PDU bytes — the auth-verify
+                // path (Phase 3+) reads them to recompute HMAC against
+                // the exact byte sequence the peer signed, and the
+                // existing LSP install path needs them too.
+                packet.1.bytes = input[3..].to_vec();
 
                 let mac = addr.addr().map(MacAddr::from);
 

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -8,6 +8,8 @@ use isis_packet::*;
 
 use crate::bfd::session::SessionKey;
 use crate::fmt::DisplayOpt;
+use crate::isis::auth;
+use crate::isis::config::IsisAuthType;
 use crate::isis::link::DisStatus;
 use crate::isis::lsp::csnp_generate;
 use crate::isis::neigh::Neighbor;
@@ -859,6 +861,109 @@ pub fn psnp_send_pdu(link: &mut LinkTop, level: Level, pdu: IsisPsnp) {
     ));
 }
 
+/// Return the (auth_type, value) of the first Authentication TLV in
+/// the parsed Hello PDU, if any. Used by verify_hello_auth — the
+/// raw bytes are reached separately via `packet.bytes`.
+fn hello_pdu_auth_tlv(pdu: &IsisPdu) -> Option<&IsisTlvAuth> {
+    let tlvs: &[IsisTlv] = match pdu {
+        IsisPdu::L1Hello(h) | IsisPdu::L2Hello(h) => &h.tlvs,
+        IsisPdu::P2pHello(h) => &h.tlvs,
+        _ => return None,
+    };
+    tlvs.iter().find_map(|tlv| match tlv {
+        IsisTlv::Auth(a) => Some(a),
+        _ => None,
+    })
+}
+
+/// Validate the Authentication TLV on an inbound Hello PDU against
+/// the per-link `hello-authentication` config. Returns `true` to
+/// accept the PDU, `false` to drop it (and bumps the relevant
+/// counter on the link).
+///
+/// Decision matrix:
+/// - link auth not configured → accept (peer may still send auth;
+///   the TLV stays in the parsed PDU as data).
+/// - link auth configured, `send-only` true → accept regardless of
+///   inbound content (RFC 5304 §1 rollover hatch).
+/// - link auth configured, no inbound Auth TLV → drop, bump
+///   `auth_rx_no_auth`.
+/// - link auth configured, type mismatch → drop, bump `auth_rx_bad`.
+/// - cleartext (type 1) → byte-compare value against configured
+///   password; match → accept + `auth_rx_good`, else drop +
+///   `auth_rx_bad`.
+/// - HMAC-MD5 (type 54) → zero the digest in a copy of the raw
+///   bytes, recompute HMAC, constant-time compare → accept +
+///   `auth_rx_good`, else drop + `auth_rx_bad`.
+fn verify_hello_auth(
+    link: &mut super::link::LinkTop<'_>,
+    tlvs_start: usize,
+    pdu_bytes: &[u8],
+    packet: &IsisPacket,
+) -> bool {
+    let cfg = &link.config.hello_auth;
+    let Some(key) = cfg.password.as_deref() else {
+        return true; // no auth configured — accept anything
+    };
+    if cfg.send_only {
+        return true; // sign-only-on-tx rollover mode
+    }
+    let Some(auth_tlv) = hello_pdu_auth_tlv(&packet.pdu) else {
+        link.state.auth_rx_no_auth += 1;
+        tracing::warn!(
+            proto = "isis",
+            link = %link.state.name,
+            "[Hello:AuthDrop] no auth TLV from peer"
+        );
+        return false;
+    };
+
+    let accepted = match cfg.auth_type {
+        IsisAuthType::Text => {
+            auth_tlv.auth_type == ISIS_AUTH_TYPE_CLEARTEXT
+                && auth::digest_eq(&auth_tlv.value, key.as_bytes())
+        }
+        IsisAuthType::Md5 => {
+            if auth_tlv.auth_type != ISIS_AUTH_TYPE_HMAC_MD5
+                || auth_tlv.value.len() != ISIS_AUTH_HMAC_MD5_LEN
+            {
+                false
+            } else if let Some(value_range) = auth::locate_auth_tlv(pdu_bytes, tlvs_start) {
+                let digest_start = value_range.start + 1;
+                let digest_end = value_range.end;
+                if digest_end - digest_start != ISIS_AUTH_HMAC_MD5_LEN {
+                    false
+                } else {
+                    let mut scratch = pdu_bytes.to_vec();
+                    for b in &mut scratch[digest_start..digest_end] {
+                        *b = 0;
+                    }
+                    let computed = auth::hmac_md5(key.as_bytes(), &scratch);
+                    auth::digest_eq(&computed, &auth_tlv.value)
+                }
+            } else {
+                // Parsed TLV exists but raw bytes don't carry it —
+                // network.rs preserves the buffer for every PDU, so
+                // this is a hard inconsistency: reject.
+                false
+            }
+        }
+    };
+
+    if accepted {
+        link.state.auth_rx_good += 1;
+        true
+    } else {
+        link.state.auth_rx_bad += 1;
+        tracing::warn!(
+            proto = "isis",
+            link = %link.state.name,
+            "[Hello:AuthDrop] auth verification failed"
+        );
+        false
+    }
+}
+
 pub fn process_packet(
     link: &mut LinkTop,
     packet: IsisPacket,
@@ -879,6 +984,20 @@ pub fn process_packet(
     }
 
     if !link.config.enabled() {
+        return Ok(());
+    }
+
+    // Hello authentication (Phase 3a). Validated before the PDU is
+    // handed to the adjacency FSM so a mismatching peer never gets
+    // to mutate neighbor state. SNP/LSP auth lands in Phase 3b/4.
+    if packet.pdu_type.is_hello()
+        && !verify_hello_auth(
+            link,
+            packet.length_indicator as usize,
+            &packet.bytes,
+            &packet,
+        )
+    {
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary

Phase 3a of IS-IS authentication. Per-link IIH (LAN + P2P) Hellos now sign on send and verify on receive. Cleartext (TLV-10 auth-type 1) and HMAC-MD5 (auth-type 54); RFC 5310 generic-crypto stays deferred to Phase 4b. CSNP/PSNP follow in Phase 3b reusing the helpers landed here. LSP auth in Phase 4.

### Wire

- `IsisType::is_hello()` helper.

### Crypto module (`zebra-rs/src/isis/auth.rs`)

- `hmac_md5()` — RFC 5304 §3 / RFC 2104. RFC 2202 test vector covered.
- `digest_eq()` — constant-time so partial matches don't leak timing.
- `locate_auth_tlv()` — walk the TLV section and return the byte range of the Auth TLV's value (auth-type byte + payload).

### Send path

`append_auth_tlv` injects the Auth TLV at the end of the real TLVs but **before** padding, so the padding helper sees its size and the PDU lands exactly at MTU. HMAC-MD5 uses a zero-filled placeholder; `hello_send` emits to `BytesMut`, locates the TLV, computes the digest over the buffer (still has the zero placeholder per RFC 5304 §3), patches the digest in, and sends as `Packet::Bytes`. Cleartext attaches the password bytes directly and keeps the existing `Packet::Packet` send path.

### Receive path

`verify_hello_auth` runs in `process_packet` before the PDU reaches the adjacency FSM. Decision matrix:

| Link config | Inbound | Action |
|---|---|---|
| No auth | any | accept |
| Auth + `send-only` | any | accept (RFC 5304 §1 rollover hatch) |
| Auth | no Auth TLV | **drop**, bump `auth_rx_no_auth` |
| Auth | type mismatch / bad digest | **drop**, bump `auth_rx_bad` |
| Auth | match | accept, bump `auth_rx_good` |

Outbound signing bumps `auth_tx_signed` regardless of mode.

### Supporting changes

- `crates/isis-packet/src/typ.rs` — `IsisType::is_hello()`.
- `zebra-rs/src/isis/network.rs` — drop the LSP-only guard around `packet.bytes = ...` so the verify path can recompute HMAC against the exact peer-signed buffer. ~1.5KB extra copy per recv on the IS-IS socket.
- `zebra-rs/src/isis/link.rs` — four per-link counters: `auth_tx_signed`, `auth_rx_good`, `auth_rx_bad`, `auth_rx_no_auth`.

### Deliberately not in scope

- `show isis interface` / `show isis counters` surfacing of the new counters → Phase 5 (operational).
- CSNP/PSNP sign+verify → Phase 3b (separate PR, reuses everything in this one).
- LSP sign+verify → Phase 4 (LSPs need extra Checksum + Remaining Lifetime zero-ing per RFC 5304 §3).

## Test plan

- [x] `cargo test -p zebra-rs --bin zebra-rs isis::` — 104/104 pass.
  - 6 new tests in `isis::auth::tests`: HMAC-MD5 RFC 2202 vector, two `digest_eq` edge cases, three `locate_auth_tlv` cases (find, absent, truncated value), one end-to-end Hello-PDU round-trip that mirrors the actual sign/verify byte ops without LinkTop scaffolding.
- [x] `cargo test -p isis-packet` — 43/43 pass.
- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

Generated with [Claude Code](https://claude.com/claude-code)