### PR TITLE
isis: derive SR-MPLS label bases from watched sr_block

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -661,24 +661,14 @@ fn config_lsp_mtu_size(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<
 // child leaf. libyang invokes the callback at the container path with no
 // extra args when the container is committed (set) or removed (delete).
 fn config_sr_mpls_enable(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
-    if op.is_set() {
-        isis.config.sr_mpls_enabled = true;
-        // Allocate the adjacency-SID label pool so subsequent hellos
-        // can carve labels for `IsisSubLanAdjSid` sub-TLVs. Idempotent:
-        // re-enabling without a prior disable keeps any previously
-        // handed-out labels intact.
-        if isis.local_pool.is_none() {
-            isis.local_pool = Some(crate::spf::label_pool::LabelPool::new(15000, Some(16000)));
-        }
-    } else {
-        isis.config.sr_mpls_enabled = false;
-        // Drop the pool. Any labels still cached on neighbor addr4
-        // entries become orphaned but stop short of producing fresh
-        // MPLS installs — `nbr_hello_interpret` and `lsp_generate`
-        // both gate on `local_pool`/`value.label` being present.
-        isis.local_pool = None;
-    }
+    isis.config.sr_mpls_enabled = op.is_set();
+    // The adjacency-SID label pool is derived from the watched block's
+    // SRLB and managed by `reconcile_local_pool`. On enable the pool
+    // can only materialize once the RIB hands us a block snapshot via
+    // `RibSrRx::Block` (handled inside `process_sr_rx`); on disable the
+    // reconcile here drops the pool immediately.
     isis.reconcile_block_watch();
+    isis.reconcile_local_pool();
     Some(())
 }
 

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1367,6 +1367,41 @@ impl Isis {
         }
     }
 
+    /// Reconcile `local_pool` against the current SR-MPLS gate and the
+    /// watched block's SRLB. Creates the pool when SR-MPLS is enabled
+    /// and the RIB has handed us an SRLB; drops it otherwise.
+    ///
+    /// Idempotent: a pool that already exists is kept (alloc/release
+    /// state stays intact) even if the SRLB snapshot is re-delivered
+    /// with the same bounds. A change in SRLB bounds while SR-MPLS
+    /// stays enabled is not reflected — operators changing the block
+    /// mid-life is a follow-up concern and would invalidate every
+    /// adjacency-SID label already handed out.
+    pub fn reconcile_local_pool(&mut self) {
+        let srlb = self.sr_block.as_ref().and_then(|b| b.local.as_ref());
+        match (self.config.sr_mpls_enabled, srlb) {
+            (true, Some(srlb)) => {
+                if self.local_pool.is_none() {
+                    // LabelBlock is half-open `[start, end)`; LabelPool's
+                    // `end` is inclusive (last allocable label), hence
+                    // the `- 1`.
+                    self.local_pool = Some(LabelPool::new(
+                        srlb.start as usize,
+                        Some(srlb.end.saturating_sub(1) as usize),
+                    ));
+                }
+            }
+            _ => {
+                // Drop the pool. Any labels still cached on neighbor
+                // addr4 entries become orphaned but stop short of
+                // producing fresh MPLS installs — `nbr_hello_interpret`
+                // and `lsp_generate` both gate on `local_pool` /
+                // `value.label` being present.
+                self.local_pool = None;
+            }
+        }
+    }
+
     /// Mirror of `reconcile_block_watch` for the SRv6 locator name.
     pub fn reconcile_locator_watch(&mut self) {
         let desired = target_locator_name(&self.config);
@@ -1484,6 +1519,10 @@ impl Isis {
                     return;
                 }
                 self.sr_block = block;
+                // Pool depends on `sr_block.local`; a fresh snapshot can
+                // unlock pool creation (first-time arrival) or drop it
+                // (block went away on the RIB side).
+                self.reconcile_local_pool();
             }
             RibSrRx::Locator { name, locator } => {
                 if self.watched_locator.as_deref() != Some(name.as_str()) {

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -534,6 +534,20 @@ fn build_adjacency_ilm(
 ) -> BTreeMap<u32, SpfIlm> {
     let mut ilm = BTreeMap::new();
 
+    // Adjacency-SID labels are carved from the SRLB of the watched
+    // SR-MPLS block (the same pool `local_pool` allocates from in
+    // `nbr_hello_interpret`). The index used as `IlmType::Adjacency`
+    // is the label's offset within that SRLB. Without a snapshot the
+    // pool can't have handed out labels in the first place, so any
+    // labels here are stale — fall back to 0 instead of subtracting a
+    // bogus base.
+    let local_base = top
+        .sr_block
+        .as_ref()
+        .and_then(|b| b.local.as_ref())
+        .map(|lb| lb.start)
+        .unwrap_or(0);
+
     for (&label, nhop_id) in sids.iter() {
         let mut nhops = BTreeMap::new();
 
@@ -551,8 +565,7 @@ fn build_adjacency_ilm(
             }
         }
 
-        // TODO: Need to check local-block in RIB configuration.
-        let adj_index = label.saturating_sub(15000);
+        let adj_index = label.saturating_sub(local_base);
         let spf_ilm = SpfIlm {
             nhops,
             ilm_type: IlmType::Adjacency(adj_index),
@@ -1280,6 +1293,11 @@ pub(super) fn apply_spf_result(top: &mut IsisTop, output: SpfOutput) {
     // Build Adjacency ILM seed from the SIDs collected during graph build.
     let mut ilm = build_adjacency_ilm(top, level, &adjacency_sids);
 
+    // Our own SRGB — used to derive `IlmType::Node(index)` for prefix-
+    // SID labels we install. None when SR-MPLS is off, the watched
+    // block is unset, or the RIB hasn't delivered the snapshot yet.
+    let srgb = top.sr_block.as_ref().and_then(|b| b.global.as_ref());
+
     // IPv4 RIB.
     let rib = build_rib_from_spf(top, level, source, &spf_result, &tilfa_result);
 
@@ -1334,7 +1352,7 @@ pub(super) fn apply_spf_result(top: &mut IsisTop, output: SpfOutput) {
         let algo_rib = match (algo_source, algo_spf.as_ref()) {
             (Some(src), Some(spf_res)) => {
                 let r = build_rib_from_flex_algo(top, level, algo, src, spf_res);
-                mpls_route(&r, &mut ilm);
+                mpls_route(&r, &mut ilm, srgb);
                 r
             }
             _ => PrefixMap::<Ipv4Net, SpfRoute>::new(),
@@ -1365,7 +1383,7 @@ pub(super) fn apply_spf_result(top: &mut IsisTop, output: SpfOutput) {
 
     *top.spf_result.get_mut(&level) = Some(spf_result);
     *top.tilfa_result.get_mut(&level) = Some(tilfa_result);
-    mpls_route(&rib, &mut ilm);
+    mpls_route(&rib, &mut ilm, srgb);
     apply_routing_updates(top, level, rib, rib_v6, ilm);
 }
 
@@ -1497,15 +1515,23 @@ fn build_rib_from_flex_algo(
     rib
 }
 
-pub fn mpls_route(rib: &PrefixMap<Ipv4Net, SpfRoute>, ilm: &mut BTreeMap<u32, SpfIlm>) {
+pub fn mpls_route(
+    rib: &PrefixMap<Ipv4Net, SpfRoute>,
+    ilm: &mut BTreeMap<u32, SpfIlm>,
+    srgb: Option<&crate::spf::label_block::LabelBlock>,
+) {
     for (_prefix, route) in rib.iter() {
         if let Some(sid) = route.sid {
-            // Calculate prefix index from SID (assuming 16000 is base)
-            let pfx_index = if (16000..24000).contains(&sid) {
-                sid - 16000
-            } else {
-                0
-            };
+            // Prefix-SID labels live inside our own SRGB; the Node
+            // index is the label's offset from `global.start`. Labels
+            // outside the SRGB (or with no SRGB snapshot at all) get
+            // index 0 — the previous hardcoded `16000..24000` window
+            // silently misindexed any operator-configured SRGB the
+            // same way.
+            let pfx_index = srgb
+                .filter(|gb| (gb.start..gb.end).contains(&sid))
+                .map(|gb| sid - gb.start)
+                .unwrap_or(0);
             let spf_ilm = SpfIlm {
                 nhops: route.nhops.clone(),
                 ilm_type: IlmType::Node(pfx_index),


### PR DESCRIPTION
## Summary
- `config_sr_mpls_enable` no longer hand-rolls `LabelPool::new(15000, Some(16000))`. Pool lifecycle moves into a new `Isis::reconcile_local_pool` that creates/drops the pool against `(sr_mpls_enabled, sr_block.local)`, and is also invoked from `process_sr_rx` so the pool materializes as soon as `RibSrRx::Block` lands.
- `build_adjacency_ilm` derives the adj-index base from `top.sr_block.local.start` instead of the literal `15000`.
- `mpls_route` takes `Option<&LabelBlock>` for the SRGB and ranges against `[global.start, global.end)` instead of the literal `16000..24000`.

When `sr_block` is unknown (SR-MPLS off, block name unset, or snapshot not yet delivered) the pool is `None` and ILM indices fall back to 0 — same effective shape as the old code when the operator-configured block matched the defaults.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bins isis::` (94 passed)

Generated with [Claude Code](https://claude.com/claude-code)