### PR TITLE
isis: sign and verify CSNP/PSNP PDUs (Phase 3b)

### DIFF
--- a/zebra-rs/src/isis/auth.rs
+++ b/zebra-rs/src/isis/auth.rs
@@ -1,22 +1,27 @@
-//! HMAC-MD5 sign/verify and Auth TLV locator for IS-IS Hello PDUs.
+//! HMAC-MD5 sign/verify and Auth TLV plumbing for IS-IS Hello + SNP PDUs.
 //!
-//! Phase 3a scope: per-link Hello (LAN + P2P) authentication. CSNP/PSNP
-//! reuse these helpers in 3b; LSP signing in Phase 4 needs additional
-//! treatment for the LSP Checksum and Remaining Lifetime fields per
-//! RFC 5304 §3.
+//! Phase 3a: Hellos (per-link `hello-authentication`).
+//! Phase 3b: CSNP/PSNP (per-level `area-password` / `domain-password`).
+//! Phase 4 will add LSP signing, which needs additional treatment for
+//! the LSP Checksum and Remaining Lifetime fields per RFC 5304 §3.
 //!
-//! Cleartext (auth-type 1) is just bytes-in-TLV-value and doesn't
-//! need anything from this module — the send path appends the
-//! password bytes verbatim, and the verify path compares them.
-//! HMAC-MD5 (auth-type 54) is the two-pass case: emit a zero-filled
-//! placeholder, hash the whole serialized PDU, then patch the digest
-//! into the placeholder's byte range.
+//! Cleartext (auth-type 1) is just bytes-in-TLV-value: the send path
+//! appends the password bytes verbatim, and the verify path compares
+//! them. HMAC-MD5 (auth-type 54) is the two-pass case: emit a
+//! zero-filled placeholder, hash the whole serialized PDU, then patch
+//! the digest into the placeholder's byte range.
 
 use std::ops::Range;
 
+use bytes::BytesMut;
 use hmac::{Hmac, KeyInit, Mac};
-use isis_packet::IsisTlvType;
+use isis_packet::{
+    ISIS_AUTH_HMAC_MD5_LEN, ISIS_AUTH_TYPE_CLEARTEXT, ISIS_AUTH_TYPE_HMAC_MD5, IsisTlv,
+    IsisTlvAuth, IsisTlvType,
+};
 use md5::Md5;
+
+use super::config::{IsisAuthConfig, IsisAuthType};
 
 /// HMAC-MD5 over `data` keyed by `key` (RFC 2104 / RFC 5304 §3).
 /// Returns the 16-byte digest. `Hmac::new_from_slice` accepts any
@@ -41,6 +46,58 @@ pub fn digest_eq(a: &[u8], b: &[u8]) -> bool {
         diff |= x ^ y;
     }
     diff == 0
+}
+
+/// On-wire byte cost of the Auth TLV this scope would emit (2-byte
+/// header + 1-byte auth-type + payload), used by the SNP packer to
+/// shrink its fragmentation budget so a CSNP/PSNP stays within MTU
+/// once the TLV is appended. Returns 0 when no auth is configured.
+pub fn auth_tlv_wire_size(cfg: &IsisAuthConfig) -> usize {
+    match (cfg.password.as_ref(), cfg.auth_type) {
+        (None, _) => 0,
+        (Some(pw), IsisAuthType::Text) => 2 + 1 + pw.len(),
+        (Some(_), IsisAuthType::Md5) => 2 + 1 + ISIS_AUTH_HMAC_MD5_LEN,
+    }
+}
+
+/// Append the Authentication TLV (type 10) to `tlvs` when this scope
+/// has authentication configured. For cleartext the value is the
+/// password bytes verbatim; for HMAC-MD5 it's a zero-filled
+/// placeholder that `sign_md5_inplace` will patch in place once the
+/// digest is known. No-op when `cfg.password.is_none()`.
+pub fn append_auth_tlv(tlvs: &mut Vec<IsisTlv>, cfg: &IsisAuthConfig) {
+    let Some(pw) = cfg.password.as_deref() else {
+        return;
+    };
+    let tlv = match cfg.auth_type {
+        IsisAuthType::Text => IsisTlvAuth {
+            auth_type: ISIS_AUTH_TYPE_CLEARTEXT,
+            value: pw.as_bytes().to_vec(),
+        },
+        IsisAuthType::Md5 => {
+            IsisTlvAuth::placeholder(ISIS_AUTH_TYPE_HMAC_MD5, ISIS_AUTH_HMAC_MD5_LEN)
+        }
+    };
+    tlvs.push(tlv.into());
+}
+
+/// Two-pass HMAC-MD5 sign step. Locate the Auth TLV inside the
+/// just-emitted PDU bytes, compute HMAC over the buffer (the
+/// placeholder's digest area is still zero, per RFC 5304 §3), and
+/// patch the resulting digest into place. No-op when the TLV
+/// isn't found or its digest area isn't the expected length —
+/// the caller is responsible for having added a placeholder first.
+pub fn sign_md5_inplace(buf: &mut BytesMut, tlvs_start: usize, key: &[u8]) {
+    let Some(value_range) = locate_auth_tlv(buf, tlvs_start) else {
+        return;
+    };
+    let digest_start = value_range.start + 1;
+    let digest_end = value_range.end;
+    if digest_end - digest_start != ISIS_AUTH_HMAC_MD5_LEN {
+        return;
+    }
+    let digest = hmac_md5(key, buf);
+    buf[digest_start..digest_end].copy_from_slice(&digest);
 }
 
 /// Walk the TLV section starting at `tlvs_start` and return the byte
@@ -227,5 +284,129 @@ mod tests {
         assert!(digest_eq(&value, password));
         assert!(!digest_eq(&value, b"hunter3"));
         assert!(!digest_eq(&value, b""));
+    }
+
+    /// auth_tlv_wire_size exposes the on-wire byte count the SNP
+    /// packer subtracts from its per-fragment entry budget. Verify
+    /// it matches what `IsisTlv::wire_len()` reports for the same
+    /// configured TLV (the function the packer would build).
+    #[test]
+    fn auth_tlv_wire_size_matches_emit_length() {
+        // Cleartext: TL header (2) + auth-type (1) + password bytes.
+        let cfg = IsisAuthConfig {
+            password: Some("hunter2".into()),
+            auth_type: IsisAuthType::Text,
+            send_only: false,
+        };
+        let tlv: IsisTlv = IsisTlvAuth {
+            auth_type: ISIS_AUTH_TYPE_CLEARTEXT,
+            value: b"hunter2".to_vec(),
+        }
+        .into();
+        assert_eq!(auth_tlv_wire_size(&cfg), tlv.wire_len());
+
+        // HMAC-MD5: TL header (2) + auth-type (1) + 16-byte digest.
+        let cfg = IsisAuthConfig {
+            password: Some("hunter2".into()),
+            auth_type: IsisAuthType::Md5,
+            send_only: false,
+        };
+        let tlv: IsisTlv =
+            IsisTlvAuth::placeholder(ISIS_AUTH_TYPE_HMAC_MD5, ISIS_AUTH_HMAC_MD5_LEN).into();
+        assert_eq!(auth_tlv_wire_size(&cfg), tlv.wire_len());
+
+        // No auth → 0 bytes.
+        let cfg = IsisAuthConfig::default();
+        assert_eq!(auth_tlv_wire_size(&cfg), 0);
+    }
+
+    /// End-to-end HMAC-MD5 round-trip across a real CSNP — same
+    /// shape as the Hello test but with `length_indicator = 33`
+    /// (CSNP header is bigger).
+    #[test]
+    fn csnp_pdu_md5_round_trip_via_helpers() {
+        use isis_packet::{
+            IsisCsnp, IsisLspId, IsisPacket, IsisPdu, IsisSysId, IsisTlv, IsisTlvAuth,
+            IsisTlvLspEntries, IsisType,
+        };
+
+        let csnp = IsisCsnp {
+            pdu_len: 0,
+            source_id: IsisSysId {
+                id: [1, 2, 3, 4, 5, 6],
+            },
+            source_id_circuit: 0,
+            start: IsisLspId::start(),
+            end: IsisLspId::end(),
+            tlvs: vec![
+                IsisTlv::LspEntries(IsisTlvLspEntries::default()),
+                IsisTlv::Auth(IsisTlvAuth::placeholder(
+                    ISIS_AUTH_TYPE_HMAC_MD5,
+                    ISIS_AUTH_HMAC_MD5_LEN,
+                )),
+            ],
+        };
+        let packet = IsisPacket::from(IsisType::L1Csnp, IsisPdu::L1Csnp(csnp));
+        let mut buf = BytesMut::new();
+        packet.emit(&mut buf);
+
+        let key = b"area-key";
+        sign_md5_inplace(&mut buf, packet.length_indicator as usize, key);
+
+        // Verify: peel out the patched digest, zero its range, recompute.
+        let range = locate_auth_tlv(&buf, packet.length_indicator as usize).unwrap();
+        let digest_start = range.start + 1;
+        let digest_end = range.end;
+        let stored = buf[digest_start..digest_end].to_vec();
+        let mut scratch = buf.to_vec();
+        for b in &mut scratch[digest_start..digest_end] {
+            *b = 0;
+        }
+        assert!(digest_eq(&hmac_md5(key, &scratch), &stored));
+        assert!(stored.iter().any(|b| *b != 0));
+
+        // Wrong key → mismatch.
+        assert!(!digest_eq(&hmac_md5(b"wrong", &scratch), &stored));
+    }
+
+    /// End-to-end HMAC-MD5 round-trip across a real PSNP. Verifies
+    /// `length_indicator = 17` works the same.
+    #[test]
+    fn psnp_pdu_md5_round_trip_via_helpers() {
+        use isis_packet::{
+            IsisPacket, IsisPdu, IsisPsnp, IsisSysId, IsisTlv, IsisTlvAuth, IsisTlvLspEntries,
+            IsisType,
+        };
+
+        let psnp = IsisPsnp {
+            pdu_len: 0,
+            source_id: IsisSysId {
+                id: [9, 8, 7, 6, 5, 4],
+            },
+            source_id_circuit: 0,
+            tlvs: vec![
+                IsisTlv::LspEntries(IsisTlvLspEntries::default()),
+                IsisTlv::Auth(IsisTlvAuth::placeholder(
+                    ISIS_AUTH_TYPE_HMAC_MD5,
+                    ISIS_AUTH_HMAC_MD5_LEN,
+                )),
+            ],
+        };
+        let packet = IsisPacket::from(IsisType::L2Psnp, IsisPdu::L2Psnp(psnp));
+        let mut buf = BytesMut::new();
+        packet.emit(&mut buf);
+
+        let key = b"domain-key";
+        sign_md5_inplace(&mut buf, packet.length_indicator as usize, key);
+
+        let range = locate_auth_tlv(&buf, packet.length_indicator as usize).unwrap();
+        let digest_start = range.start + 1;
+        let digest_end = range.end;
+        let stored = buf[digest_start..digest_end].to_vec();
+        let mut scratch = buf.to_vec();
+        for b in &mut scratch[digest_start..digest_end] {
+            *b = 0;
+        }
+        assert!(digest_eq(&hmac_md5(key, &scratch), &stored));
     }
 }

--- a/zebra-rs/src/isis/flood.rs
+++ b/zebra-rs/src/isis/flood.rs
@@ -5,7 +5,7 @@ use isis_packet::*;
 
 use crate::context::Timer;
 
-use super::{Level, LinkTop, Lsdb, Message, MsgSender, Packet, PacketMessage, psnp_send_pdu};
+use super::{Level, LinkTop, Lsdb, Message, MsgSender, Packet, PacketMessage, auth, psnp_send_pdu};
 
 #[derive(Default)]
 pub struct LspFloodMap(pub BTreeMap<IsisLspId, IsisLspEntry>);
@@ -197,6 +197,12 @@ pub fn ssn_advertise(link: &mut LinkTop, level: Level) {
     // Interface MTU.
     let mtu = link.state.mtu as usize;
 
+    // PSNPs are signed per RFC 5304 §3 with the level's area or
+    // domain password; the Auth TLV is appended after the LspEntries
+    // TLV and so eats into the per-fragment entry budget.
+    let auth_cfg = super::lsp::snp_auth_cfg(link.up_config, level);
+    let auth_size = auth::auth_tlv_wire_size(auth_cfg);
+
     let available_len = {
         let mut buf = BytesMut::new();
 
@@ -216,8 +222,10 @@ pub fn ssn_advertise(link: &mut LinkTop, level: Level) {
         let base_len = 3;
         let tlv_header_len = 2;
 
-        let total_base_len = packet_len + base_len + tlv_header_len;
-
+        let total_base_len = packet_len + base_len + tlv_header_len + auth_size;
+        if mtu <= total_base_len {
+            return;
+        }
         mtu - total_base_len
     };
 
@@ -234,11 +242,13 @@ pub fn ssn_advertise(link: &mut LinkTop, level: Level) {
 
         entry_size += 1;
         if entry_size == entry_size_max {
+            let mut psnp_tlvs: Vec<IsisTlv> = vec![tlvs.clone().into()];
+            auth::append_auth_tlv(&mut psnp_tlvs, auth_cfg);
             let psnp = IsisPsnp {
                 pdu_len: 0,
                 source_id: link.up_config.net.sys_id(),
                 source_id_circuit: 0,
-                tlvs: vec![tlvs.clone().into()],
+                tlvs: psnp_tlvs,
             };
             psnps.push(psnp);
 
@@ -247,11 +257,13 @@ pub fn ssn_advertise(link: &mut LinkTop, level: Level) {
         }
     }
     if !tlvs.entries.is_empty() {
+        let mut psnp_tlvs: Vec<IsisTlv> = vec![tlvs.into()];
+        auth::append_auth_tlv(&mut psnp_tlvs, auth_cfg);
         let psnp = IsisPsnp {
             pdu_len: 0,
             source_id: link.up_config.net.sys_id(),
             source_id_circuit: 0,
-            tlvs: vec![tlvs.into()],
+            tlvs: psnp_tlvs,
         };
         psnps.push(psnp);
     }

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -105,39 +105,18 @@ pub fn hello_generate(link: &LinkTop, level: Level) -> IsisHello {
         }
     }
     hello.tlvs.push(IsisTlvIsNeighbor { neighbors }.into());
-    // Auth TLV (Phase 3a) lives at the end of the real TLVs, *before*
-    // padding. For HMAC-MD5 it's a zero-filled placeholder that the
-    // send path patches in after the HMAC is computed; for cleartext
-    // we attach the password bytes directly and the recv side
-    // compares them as-is. Including it before padding keeps the
-    // PDU exactly at MTU (the padding helper sees the auth TLV's
-    // size when it computes the remaining budget).
-    append_auth_tlv(&mut hello.tlvs, &link.config.hello_auth);
+    // Auth TLV lives at the end of the real TLVs, *before* padding.
+    // For HMAC-MD5 it's a zero-filled placeholder that `hello_send`
+    // patches in after the HMAC is computed; for cleartext we attach
+    // the password bytes directly and the recv side compares them
+    // as-is. Including it before padding keeps the PDU exactly at MTU
+    // (the padding helper sees the auth TLV's size when it computes
+    // the remaining budget).
+    auth::append_auth_tlv(&mut hello.tlvs, &link.config.hello_auth);
     if link.config.hello_padding() == HelloPaddingPolicy::Always {
         hello.padding(link.state.mtu as usize);
     }
     hello
-}
-
-/// Append the Authentication TLV (type 10) to `tlvs` when this link
-/// has hello-authentication configured. For cleartext the value is
-/// the password bytes verbatim; for HMAC-MD5 it's a zero-filled
-/// placeholder that `hello_send_signed` will patch in place once
-/// the digest is known.
-fn append_auth_tlv(tlvs: &mut Vec<IsisTlv>, cfg: &super::config::IsisAuthConfig) {
-    let Some(pw) = cfg.password.as_deref() else {
-        return;
-    };
-    let tlv = match cfg.auth_type {
-        IsisAuthType::Text => IsisTlvAuth {
-            auth_type: ISIS_AUTH_TYPE_CLEARTEXT,
-            value: pw.as_bytes().to_vec(),
-        },
-        IsisAuthType::Md5 => {
-            IsisTlvAuth::placeholder(ISIS_AUTH_TYPE_HMAC_MD5, ISIS_AUTH_HMAC_MD5_LEN)
-        }
-    };
-    tlvs.push(tlv.into());
 }
 
 pub fn hello_p2p_generate(link: &LinkTop, level: Level) -> IsisP2pHello {
@@ -211,7 +190,7 @@ pub fn hello_p2p_generate(link: &LinkTop, level: Level) -> IsisP2pHello {
     };
     hello.tlvs.push(tlv.into());
 
-    append_auth_tlv(&mut hello.tlvs, &link.config.hello_auth);
+    auth::append_auth_tlv(&mut hello.tlvs, &link.config.hello_auth);
     if link.config.hello_padding() == HelloPaddingPolicy::Always {
         hello.padding(link.state.mtu as usize);
     }
@@ -292,7 +271,7 @@ pub fn hello_send(link: &mut LinkTop, level: Level) -> Result<()> {
         (Some(key), IsisAuthType::Md5) => {
             let mut buf = BytesMut::new();
             packet.emit(&mut buf);
-            sign_hello_md5_inplace(&mut buf, packet.length_indicator as usize, key.as_bytes());
+            auth::sign_md5_inplace(&mut buf, packet.length_indicator as usize, key.as_bytes());
             link.state.auth_tx_signed += 1;
             Packet::Bytes(buf)
         }
@@ -308,26 +287,6 @@ pub fn hello_send(link: &mut LinkTop, level: Level) -> Result<()> {
         .ptx
         .send(PacketMessage::Send(outgoing, ifindex, level, mac));
     Ok(())
-}
-
-/// Locate the Auth TLV value inside the just-emitted Hello PDU and
-/// patch the HMAC-MD5 digest in place. The TLV was emitted with a
-/// zero-filled placeholder (per `append_auth_tlv`), so the HMAC is
-/// computed over the buffer exactly as it sits — RFC 5304 §3's
-/// "set the Authentication Value field to zero before computing".
-fn sign_hello_md5_inplace(buf: &mut BytesMut, tlvs_start: usize, key: &[u8]) {
-    let Some(value_range) = auth::locate_auth_tlv(buf, tlvs_start) else {
-        return;
-    };
-    // value_range covers [auth_type, payload]. The digest area is
-    // everything after the 1-byte auth_type.
-    let digest_start = value_range.start + 1;
-    let digest_end = value_range.end;
-    if digest_end - digest_start != ISIS_AUTH_HMAC_MD5_LEN {
-        return;
-    }
-    let digest = auth::hmac_md5(key, buf);
-    buf[digest_start..digest_end].copy_from_slice(&digest);
 }
 
 pub fn has_level(is_level: IsLevel, level: Level) -> bool {

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -62,7 +62,8 @@ pub(super) fn key_for_tlv(tlv: &IsisTlv) -> Option<TlvKey> {
     }
 }
 
-use super::config::{IsisConfig, MtId};
+use super::auth;
+use super::config::{IsisAuthConfig, IsisConfig, MtId};
 use super::ifsm::has_level;
 use super::inst::{IsisTop, Message};
 use super::level::Level;
@@ -1364,6 +1365,13 @@ pub fn csnp_generate(link: &LinkTop, level: Level) -> Vec<IsisCsnp> {
     // Interface MTU.
     let mtu = link.state.mtu as usize;
 
+    // SNPs are signed with the per-level area/domain password
+    // (RFC 5304 §3). The Auth TLV is appended after the LspEntries
+    // TLV in each CSNP, so its on-wire size shrinks the per-fragment
+    // entry budget below.
+    let auth_cfg = snp_auth_cfg(link.up_config, level);
+    let auth_size = auth::auth_tlv_wire_size(auth_cfg);
+
     // For the record, we will try to encode the packet length.
     let available_len = {
         let mut buf = BytesMut::new();
@@ -1386,8 +1394,10 @@ pub fn csnp_generate(link: &LinkTop, level: Level) -> Vec<IsisCsnp> {
         let base_len = 3;
         let tlv_header_len = 2;
 
-        let total_base_len = packet_len + base_len + tlv_header_len;
-
+        let total_base_len = packet_len + base_len + tlv_header_len + auth_size;
+        if mtu <= total_base_len {
+            return vec![];
+        }
         mtu - total_base_len
     };
     // tracing::info!("[CSNP:Gen] available_len {}", available_len);
@@ -1411,13 +1421,15 @@ pub fn csnp_generate(link: &LinkTop, level: Level) -> Vec<IsisCsnp> {
 
         entry_size += 1;
         if entry_size == entry_size_max {
+            let mut csnp_tlvs: Vec<IsisTlv> = vec![tlvs.clone().into()];
+            auth::append_auth_tlv(&mut csnp_tlvs, auth_cfg);
             let csnp = IsisCsnp {
                 pdu_len: 0,
                 source_id: link.up_config.net.sys_id(),
                 source_id_circuit: 0,
                 start: start.unwrap_or(IsisLspId::start()),
                 end: lsa.lsp.lsp_id,
-                tlvs: vec![tlvs.clone().into()],
+                tlvs: csnp_tlvs,
             };
             csnps.push(csnp);
 
@@ -1427,18 +1439,33 @@ pub fn csnp_generate(link: &LinkTop, level: Level) -> Vec<IsisCsnp> {
         }
     }
     if !tlvs.entries.is_empty() {
+        let mut csnp_tlvs: Vec<IsisTlv> = vec![tlvs.into()];
+        auth::append_auth_tlv(&mut csnp_tlvs, auth_cfg);
         let csnp = IsisCsnp {
             pdu_len: 0,
             source_id: link.up_config.net.sys_id(),
             source_id_circuit: 0,
             start: start.unwrap_or(IsisLspId::start()),
             end: IsisLspId::end(),
-            tlvs: vec![tlvs.into()],
+            tlvs: csnp_tlvs,
         };
         csnps.push(csnp);
     }
 
     csnps
+}
+
+/// Per-level auth config for SNPs and (Phase 4) LSPs. RFC 5304 §3
+/// pins L1 SNPs to the area-wide string and L2 SNPs to the domain-
+/// wide string — same keys the LSPs at that level use. Takes
+/// `&IsisConfig` (not `&LinkTop`) so callers that hold a disjoint
+/// mutable borrow of `link.lsdb` / `link.state` can still pull the
+/// config out via `link.up_config`.
+pub fn snp_auth_cfg(up_config: &IsisConfig, level: Level) -> &IsisAuthConfig {
+    match level {
+        Level::L1 => &up_config.area_password,
+        Level::L2 => &up_config.domain_password,
+    }
 }
 
 pub enum PacketMessage {

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -640,8 +640,9 @@ fn csnp_send_pdu(link: &mut LinkTop, level: Level, pdu: IsisCsnp) {
         Level::L1 => IsisPacket::from(IsisType::L1Csnp, IsisPdu::L1Csnp(pdu.clone())),
         Level::L2 => IsisPacket::from(IsisType::L2Csnp, IsisPdu::L2Csnp(pdu.clone())),
     };
+    let outgoing = sign_snp_outgoing(link, level, packet);
     let _ = link.ptx.send(PacketMessage::Send(
-        Packet::Packet(packet),
+        outgoing,
         link.ifindex,
         level,
         link.dest(level),
@@ -853,21 +854,71 @@ pub fn psnp_send_pdu(link: &mut LinkTop, level: Level, pdu: IsisPsnp) {
         Level::L1 => IsisPacket::from(IsisType::L1Psnp, IsisPdu::L1Psnp(pdu.clone())),
         Level::L2 => IsisPacket::from(IsisType::L2Psnp, IsisPdu::L2Psnp(pdu.clone())),
     };
+    let outgoing = sign_snp_outgoing(link, level, packet);
     let _ = link.ptx.send(PacketMessage::Send(
-        Packet::Packet(packet),
+        outgoing,
         link.ifindex,
         level,
         link.dest(level),
     ));
 }
 
-/// Return the (auth_type, value) of the first Authentication TLV in
-/// the parsed Hello PDU, if any. Used by verify_hello_auth — the
-/// raw bytes are reached separately via `packet.bytes`.
-fn hello_pdu_auth_tlv(pdu: &IsisPdu) -> Option<&IsisTlvAuth> {
+/// Sign an outbound CSNP/PSNP per RFC 5304 §3 using the level's
+/// area/domain password. Cleartext is already in the placeholder
+/// from `csnp_generate` / `psnp_send_pdu` — we just emit it. HMAC-MD5
+/// needs the two-pass patch: emit to bytes, locate the placeholder,
+/// compute the HMAC, copy the digest into place. Returns `Packet::Bytes`
+/// for the md5 path and `Packet::Packet` for everything else so the
+/// network writer can keep using the existing serialize-on-send code.
+fn sign_snp_outgoing(link: &mut LinkTop, level: Level, packet: IsisPacket) -> Packet {
+    let (key, mode) = {
+        let cfg = super::lsp::snp_auth_cfg(link.up_config, level);
+        let Some(pw) = cfg.password.clone() else {
+            return Packet::Packet(packet);
+        };
+        (pw, cfg.auth_type)
+    };
+    link.state.auth_tx_signed += 1;
+    match mode {
+        IsisAuthType::Text => Packet::Packet(packet),
+        IsisAuthType::Md5 => {
+            let mut buf = bytes::BytesMut::new();
+            packet.emit(&mut buf);
+            auth::sign_md5_inplace(&mut buf, packet.length_indicator as usize, key.as_bytes());
+            Packet::Bytes(buf)
+        }
+    }
+}
+
+/// Which authentication scope a given PDU type+level falls under.
+/// Hello uses the per-link `hello-authentication`; SNPs follow RFC
+/// 5304 §3 and use the area-password (L1) or domain-password (L2).
+/// LSPs share the same per-level keys as SNPs but stay out of scope
+/// here until Phase 4.
+enum AuthScope {
+    HelloLink,
+    AreaPassword,
+    DomainPassword,
+}
+
+fn auth_scope_for(pdu_type: IsisType) -> Option<AuthScope> {
+    match pdu_type {
+        IsisType::L1Hello | IsisType::L2Hello | IsisType::P2pHello => Some(AuthScope::HelloLink),
+        IsisType::L1Csnp | IsisType::L1Psnp => Some(AuthScope::AreaPassword),
+        IsisType::L2Csnp | IsisType::L2Psnp => Some(AuthScope::DomainPassword),
+        _ => None,
+    }
+}
+
+/// Return the first Authentication TLV (type 10) in any Hello/SNP
+/// PDU. LSPs handled in Phase 4 — return None here so they fall
+/// through to the LSP-specific verify when that lands.
+fn pdu_auth_tlv(pdu: &IsisPdu) -> Option<&IsisTlvAuth> {
     let tlvs: &[IsisTlv] = match pdu {
         IsisPdu::L1Hello(h) | IsisPdu::L2Hello(h) => &h.tlvs,
         IsisPdu::P2pHello(h) => &h.tlvs,
+        IsisPdu::L1Csnp(c) | IsisPdu::L2Csnp(c) => &c.tlvs,
+        IsisPdu::L1Psnp(p) | IsisPdu::L2Psnp(p) => &p.tlvs,
         _ => return None,
     };
     tlvs.iter().find_map(|tlv| match tlv {
@@ -876,49 +927,58 @@ fn hello_pdu_auth_tlv(pdu: &IsisPdu) -> Option<&IsisTlvAuth> {
     })
 }
 
-/// Validate the Authentication TLV on an inbound Hello PDU against
-/// the per-link `hello-authentication` config. Returns `true` to
+/// Validate the Authentication TLV on an inbound Hello or SNP PDU
+/// against the relevant configured auth scope. Returns `true` to
 /// accept the PDU, `false` to drop it (and bumps the relevant
 /// counter on the link).
 ///
-/// Decision matrix:
-/// - link auth not configured → accept (peer may still send auth;
-///   the TLV stays in the parsed PDU as data).
-/// - link auth configured, `send-only` true → accept regardless of
-///   inbound content (RFC 5304 §1 rollover hatch).
-/// - link auth configured, no inbound Auth TLV → drop, bump
+/// Decision matrix (per RFC 5304 §1):
+/// - scope not configured → accept (peer may still send auth; the
+///   TLV remains in the parsed PDU as data).
+/// - scope configured, `send-only` true → accept regardless of
+///   inbound content (rollover hatch).
+/// - scope configured, no inbound Auth TLV → drop, bump
 ///   `auth_rx_no_auth`.
-/// - link auth configured, type mismatch → drop, bump `auth_rx_bad`.
+/// - scope configured, type mismatch → drop, bump `auth_rx_bad`.
 /// - cleartext (type 1) → byte-compare value against configured
-///   password; match → accept + `auth_rx_good`, else drop +
-///   `auth_rx_bad`.
+///   password.
 /// - HMAC-MD5 (type 54) → zero the digest in a copy of the raw
-///   bytes, recompute HMAC, constant-time compare → accept +
-///   `auth_rx_good`, else drop + `auth_rx_bad`.
-fn verify_hello_auth(
+///   bytes, recompute HMAC, constant-time compare.
+fn verify_pdu_auth(
     link: &mut super::link::LinkTop<'_>,
+    scope: AuthScope,
     tlvs_start: usize,
     pdu_bytes: &[u8],
     packet: &IsisPacket,
 ) -> bool {
-    let cfg = &link.config.hello_auth;
-    let Some(key) = cfg.password.as_deref() else {
-        return true; // no auth configured — accept anything
+    // Snapshot config fields so we don't hold an immutable borrow of
+    // link.config/up_config while mutating link.state.auth_rx_* below.
+    let (key, mode, send_only) = {
+        let cfg = match scope {
+            AuthScope::HelloLink => &link.config.hello_auth,
+            AuthScope::AreaPassword => &link.up_config.area_password,
+            AuthScope::DomainPassword => &link.up_config.domain_password,
+        };
+        let Some(pw) = cfg.password.clone() else {
+            return true; // no auth configured for this scope — accept anything
+        };
+        (pw, cfg.auth_type, cfg.send_only)
     };
-    if cfg.send_only {
+    if send_only {
         return true; // sign-only-on-tx rollover mode
     }
-    let Some(auth_tlv) = hello_pdu_auth_tlv(&packet.pdu) else {
+    let Some(auth_tlv) = pdu_auth_tlv(&packet.pdu) else {
         link.state.auth_rx_no_auth += 1;
         tracing::warn!(
             proto = "isis",
             link = %link.state.name,
-            "[Hello:AuthDrop] no auth TLV from peer"
+            pdu = ?packet.pdu_type,
+            "[AuthDrop] no auth TLV from peer"
         );
         return false;
     };
 
-    let accepted = match cfg.auth_type {
+    let accepted = match mode {
         IsisAuthType::Text => {
             auth_tlv.auth_type == ISIS_AUTH_TYPE_CLEARTEXT
                 && auth::digest_eq(&auth_tlv.value, key.as_bytes())
@@ -958,7 +1018,8 @@ fn verify_hello_auth(
         tracing::warn!(
             proto = "isis",
             link = %link.state.name,
-            "[Hello:AuthDrop] auth verification failed"
+            pdu = ?packet.pdu_type,
+            "[AuthDrop] auth verification failed"
         );
         false
     }
@@ -987,12 +1048,14 @@ pub fn process_packet(
         return Ok(());
     }
 
-    // Hello authentication (Phase 3a). Validated before the PDU is
-    // handed to the adjacency FSM so a mismatching peer never gets
-    // to mutate neighbor state. SNP/LSP auth lands in Phase 3b/4.
-    if packet.pdu_type.is_hello()
-        && !verify_hello_auth(
+    // Hello (Phase 3a) and CSNP/PSNP (Phase 3b) authentication.
+    // Validated before the parsed PDU reaches the adjacency FSM /
+    // LSDB update path so a mismatching peer never mutates state.
+    // LSPs land in Phase 4.
+    if let Some(scope) = auth_scope_for(packet.pdu_type)
+        && !verify_pdu_auth(
             link,
+            scope,
             packet.length_indicator as usize,
             &packet.bytes,
             &packet,


### PR DESCRIPTION
## Summary

Phase 3b of IS-IS authentication. CSNP + PSNP now sign on send and verify on receive. Reuses the helpers landed in Phase 3a; the only new behavior on the wire is per-level auth on SNPs.

Per RFC 5304 §3, SNPs use the **area-password (L1)** and **domain-password (L2)** — the same keys LSPs will use in Phase 4. So this PR is also the first runtime consumer of `area_password` / `domain_password` from the Phase 2 config schema.

### Shared helpers moved

`auth::append_auth_tlv` and `auth::sign_md5_inplace` moved from `ifsm.rs` into `auth.rs` so all three Hello / CSNP / PSNP send paths route through the same code. ifsm.rs's Hello path is now ~30 lines shorter and behaviorally identical.

### Fragmentation

- `csnp_generate` and the PSNP packer in `flood.rs` subtract `auth_tlv_wire_size(&IsisAuthConfig)` from their per-fragment entry budget so the appended Auth TLV keeps each PDU within MTU. HMAC-MD5 costs 19 bytes per CSNP/PSNP (~1 fewer LSP entry per fragment); cleartext is variable.

### Receive

- `verify_hello_auth` generalized to `verify_pdu_auth(scope)`.
- New `AuthScope` enum + `auth_scope_for(IsisType)` selector:
  - `HelloLink` → per-link `hello-authentication` (Hellos)
  - `AreaPassword` → instance `area-password` (L1 CSNP/PSNP)
  - `DomainPassword` → instance `domain-password` (L2 CSNP/PSNP)
  - LSPs out of scope here — Phase 4.
- `pdu_auth_tlv` extended to cover CSNP + PSNP TLV vectors.

### Borrow-checker note

`snp_auth_cfg` takes `&IsisConfig` (not `&LinkTop`) so the PSNP path in `flood.rs` — which already holds a disjoint `&mut link.lsdb` borrow at the point of access — can pull the config out via `link.up_config` without tripping the borrow checker. Same trick is used in `verify_pdu_auth` (clone password+mode into locals before mutating `link.state.auth_rx_*`).

### Deliberately not in scope

- Show output for the per-link counters — Phase 5.
- LSP sign+verify — Phase 4.
- RFC 5310 generic-crypto (HMAC-SHA family) — Phase 4b.

## Test plan

- [x] `cargo test -p zebra-rs --bin zebra-rs isis::` — 107/107 pass (3 new in `isis::auth::tests`: CSNP round-trip via helpers, PSNP round-trip via helpers, `auth_tlv_wire_size` matches `IsisTlv::wire_len`).
- [x] `cargo test -p isis-packet` — 43/43 pass.
- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

Generated with [Claude Code](https://claude.com/claude-code)