### PR TITLE
isis: sign and verify LSPs (Phase 4)

### DIFF
--- a/zebra-rs/src/isis/auth.rs
+++ b/zebra-rs/src/isis/auth.rs
@@ -81,12 +81,13 @@ pub fn append_auth_tlv(tlvs: &mut Vec<IsisTlv>, cfg: &IsisAuthConfig) {
     tlvs.push(tlv.into());
 }
 
-/// Two-pass HMAC-MD5 sign step. Locate the Auth TLV inside the
-/// just-emitted PDU bytes, compute HMAC over the buffer (the
-/// placeholder's digest area is still zero, per RFC 5304 §3), and
-/// patch the resulting digest into place. No-op when the TLV
-/// isn't found or its digest area isn't the expected length —
-/// the caller is responsible for having added a placeholder first.
+/// Two-pass HMAC-MD5 sign step for Hello / SNP PDUs. Locate the
+/// Auth TLV inside the just-emitted PDU bytes, compute HMAC over
+/// the buffer (the placeholder's digest area is still zero, per
+/// RFC 5304 §3), and patch the resulting digest into place. No-op
+/// when the TLV isn't found or its digest area isn't the expected
+/// length — the caller is responsible for having added a placeholder
+/// first.
 pub fn sign_md5_inplace(buf: &mut BytesMut, tlvs_start: usize, key: &[u8]) {
     let Some(value_range) = locate_auth_tlv(buf, tlvs_start) else {
         return;
@@ -98,6 +99,66 @@ pub fn sign_md5_inplace(buf: &mut BytesMut, tlvs_start: usize, key: &[u8]) {
     }
     let digest = hmac_md5(key, buf);
     buf[digest_start..digest_end].copy_from_slice(&digest);
+}
+
+/// LSP fixed-header offsets relative to the IS-IS discriminator
+/// (byte 0). Per ISO 10589 §9.10 / RFC 5304 §3, HMAC for LSPs is
+/// computed with Remaining Lifetime and Fletcher Checksum zeroed.
+pub const LSP_REMAINING_LIFETIME_RANGE: std::ops::Range<usize> = 10..12;
+pub const LSP_CHECKSUM_RANGE: std::ops::Range<usize> = 24..26;
+/// First TLV byte for an LSP (length_indicator = 27).
+pub const LSP_TLVS_START: usize = 27;
+
+/// Two-pass HMAC-MD5 sign step for LSPs (RFC 5304 §3). LSPs need
+/// extra care versus Hello/SNP:
+///   1. Remaining Lifetime is zeroed during the hash so the digest
+///      stays valid as the LSP ages across the network.
+///   2. Fletcher Checksum is zeroed too — the sender stamps it
+///      *after* the HMAC is patched in, otherwise the checksum
+///      would not cover the digest bytes the receiver checks.
+///
+/// `buf` must contain a serialized LSP PDU with an Auth TLV whose
+/// digest area is zero-filled (i.e., `IsisTlvAuth::placeholder` was
+/// added before `IsisPacket::emit`). On exit, the Auth Value carries
+/// the HMAC and the Fletcher Checksum has been re-stamped to cover
+/// the patched bytes.
+pub fn sign_lsp_md5_inplace(buf: &mut BytesMut, key: &[u8]) {
+    let Some(value_range) = locate_auth_tlv(buf, LSP_TLVS_START) else {
+        return;
+    };
+    let digest_start = value_range.start + 1;
+    let digest_end = value_range.end;
+    if digest_end - digest_start != ISIS_AUTH_HMAC_MD5_LEN {
+        return;
+    }
+
+    // Compute HMAC over a copy with Remaining Lifetime + Checksum
+    // zeroed. The Auth Value bytes are already zero from the
+    // placeholder, so no additional masking is needed there.
+    let mut scratch = buf.to_vec();
+    for b in &mut scratch[LSP_REMAINING_LIFETIME_RANGE] {
+        *b = 0;
+    }
+    for b in &mut scratch[LSP_CHECKSUM_RANGE] {
+        *b = 0;
+    }
+    let digest = hmac_md5(key, &scratch);
+
+    // Patch the HMAC into the live buffer at the auth-value range,
+    // then re-stamp Fletcher over the bytes that now carry the
+    // digest. `checksum_calc` assumes the checksum field reads as
+    // zero (the existing IsisPacket::emit path satisfies that
+    // implicitly by emitting with `IsisLsp.checksum = 0`), so zero
+    // it explicitly before the recompute since the buffer already
+    // carries an emit-time stamp.
+    buf[digest_start..digest_end].copy_from_slice(&digest);
+    if buf.len() >= LSP_CHECKSUM_RANGE.end {
+        for b in &mut buf[LSP_CHECKSUM_RANGE] {
+            *b = 0;
+        }
+        let checksum = isis_packet::checksum_calc(&buf[12..]);
+        buf[LSP_CHECKSUM_RANGE].copy_from_slice(&checksum);
+    }
 }
 
 /// Walk the TLV section starting at `tlvs_start` and return the byte
@@ -367,6 +428,158 @@ mod tests {
 
         // Wrong key → mismatch.
         assert!(!digest_eq(&hmac_md5(b"wrong", &scratch), &stored));
+    }
+
+    /// LSP HMAC-MD5 round-trip. Exercises the full sign_lsp_md5_inplace
+    /// flow (zero lifetime + zero checksum + zero auth-value, HMAC,
+    /// patch, re-stamp Fletcher) and the verify-side mirror.
+    #[test]
+    fn lsp_pdu_md5_round_trip_via_helpers() {
+        use isis_packet::{
+            IsisLsp, IsisLspId, IsisPacket, IsisPdu, IsisSysId, IsisTlv, IsisTlvAreaAddr,
+            IsisTlvAuth, IsisType,
+        };
+
+        let lsp = IsisLsp {
+            pdu_len: 0,
+            hold_time: 1200,
+            lsp_id: IsisLspId::new(
+                IsisSysId {
+                    id: [1, 2, 3, 4, 5, 6],
+                },
+                0,
+                0,
+            ),
+            seq_number: 0x12,
+            checksum: 0, // emit overwrites with real Fletcher
+            types: Default::default(),
+            tlvs: vec![
+                IsisTlv::AreaAddr(IsisTlvAreaAddr {
+                    area_addr: vec![0x49, 0x00, 0x01],
+                }),
+                IsisTlv::Auth(IsisTlvAuth::placeholder(
+                    ISIS_AUTH_TYPE_HMAC_MD5,
+                    ISIS_AUTH_HMAC_MD5_LEN,
+                )),
+            ],
+        };
+        let packet = IsisPacket::from(IsisType::L1Lsp, IsisPdu::L1Lsp(lsp));
+        let mut buf = BytesMut::new();
+        packet.emit(&mut buf);
+
+        let key = b"area-key";
+        sign_lsp_md5_inplace(&mut buf, key);
+
+        // Verify mirrors the recv side: zero lifetime + checksum +
+        // auth-value, recompute, compare.
+        let range = locate_auth_tlv(&buf, LSP_TLVS_START).unwrap();
+        let digest_start = range.start + 1;
+        let digest_end = range.end;
+        let stored = buf[digest_start..digest_end].to_vec();
+
+        let mut scratch = buf.to_vec();
+        for b in &mut scratch[digest_start..digest_end] {
+            *b = 0;
+        }
+        for b in &mut scratch[LSP_REMAINING_LIFETIME_RANGE] {
+            *b = 0;
+        }
+        for b in &mut scratch[LSP_CHECKSUM_RANGE] {
+            *b = 0;
+        }
+        assert!(digest_eq(&hmac_md5(key, &scratch), &stored));
+
+        // Aging: simulate a peer decrementing the Remaining Lifetime
+        // mid-flood. Receivers zero it before HMAC, so the digest
+        // stays valid.
+        let mut aged = buf.clone();
+        aged[10..12].copy_from_slice(&100u16.to_be_bytes());
+        let mut scratch_aged = aged.to_vec();
+        for b in &mut scratch_aged[digest_start..digest_end] {
+            *b = 0;
+        }
+        for b in &mut scratch_aged[LSP_REMAINING_LIFETIME_RANGE] {
+            *b = 0;
+        }
+        for b in &mut scratch_aged[LSP_CHECKSUM_RANGE] {
+            *b = 0;
+        }
+        let recomputed_aged = hmac_md5(key, &scratch_aged);
+        assert!(
+            digest_eq(&recomputed_aged, &stored),
+            "HMAC must survive Remaining Lifetime decrement"
+        );
+
+        // Fletcher checksum must validate over the patched-digest
+        // buffer (sign_lsp_md5_inplace re-stamps it).
+        assert!(isis_packet::is_valid_checksum(&buf));
+
+        // Tampering the body invalidates the digest.
+        let mut tampered = buf.clone();
+        tampered[28] ^= 0x01; // somewhere in the AreaAddr TLV value
+        let mut scratch_t = tampered.to_vec();
+        for b in &mut scratch_t[digest_start..digest_end] {
+            *b = 0;
+        }
+        for b in &mut scratch_t[LSP_REMAINING_LIFETIME_RANGE] {
+            *b = 0;
+        }
+        for b in &mut scratch_t[LSP_CHECKSUM_RANGE] {
+            *b = 0;
+        }
+        assert!(!digest_eq(&hmac_md5(key, &scratch_t), &stored));
+    }
+
+    /// RFC 6232 purge: an LSP with Remaining Lifetime = 0 and no body
+    /// TLVs (only the Auth TLV) must still produce a verifiable HMAC.
+    #[test]
+    fn lsp_purge_md5_round_trip() {
+        use isis_packet::{
+            IsisLsp, IsisLspId, IsisPacket, IsisPdu, IsisSysId, IsisTlv, IsisTlvAuth, IsisType,
+        };
+
+        let lsp = IsisLsp {
+            pdu_len: 0,
+            hold_time: 0, // purge
+            lsp_id: IsisLspId::new(
+                IsisSysId {
+                    id: [7, 7, 7, 7, 7, 7],
+                },
+                0,
+                3,
+            ),
+            seq_number: 42,
+            checksum: 0,
+            types: Default::default(),
+            tlvs: vec![IsisTlv::Auth(IsisTlvAuth::placeholder(
+                ISIS_AUTH_TYPE_HMAC_MD5,
+                ISIS_AUTH_HMAC_MD5_LEN,
+            ))],
+        };
+        let packet = IsisPacket::from(IsisType::L2Lsp, IsisPdu::L2Lsp(lsp));
+        let mut buf = BytesMut::new();
+        packet.emit(&mut buf);
+
+        let key = b"domain-key";
+        sign_lsp_md5_inplace(&mut buf, key);
+
+        let range = locate_auth_tlv(&buf, LSP_TLVS_START).unwrap();
+        let digest_start = range.start + 1;
+        let digest_end = range.end;
+        let stored = buf[digest_start..digest_end].to_vec();
+
+        let mut scratch = buf.to_vec();
+        for b in &mut scratch[digest_start..digest_end] {
+            *b = 0;
+        }
+        for b in &mut scratch[LSP_REMAINING_LIFETIME_RANGE] {
+            *b = 0;
+        }
+        for b in &mut scratch[LSP_CHECKSUM_RANGE] {
+            *b = 0;
+        }
+        assert!(digest_eq(&hmac_md5(key, &scratch), &stored));
+        assert!(isis_packet::is_valid_checksum(&buf));
     }
 
     /// End-to-end HMAC-MD5 round-trip across a real PSNP. Verifies

--- a/zebra-rs/src/isis/flood.rs
+++ b/zebra-rs/src/isis/flood.rs
@@ -200,7 +200,7 @@ pub fn ssn_advertise(link: &mut LinkTop, level: Level) {
     // PSNPs are signed per RFC 5304 §3 with the level's area or
     // domain password; the Auth TLV is appended after the LspEntries
     // TLV and so eats into the per-fragment entry budget.
-    let auth_cfg = super::lsp::snp_auth_cfg(link.up_config, level);
+    let auth_cfg = super::lsp::level_auth_cfg(link.up_config, level);
     let auth_size = auth::auth_tlv_wire_size(auth_cfg);
 
     let available_len = {

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -902,8 +902,9 @@ impl Isis {
             );
         }
 
+        let auth_cfg = super::lsp::level_auth_cfg(top.config, level).clone();
         for mut frag in fragments {
-            let buf = lsp_emit(&mut frag, level);
+            let buf = lsp_emit(&mut frag, level, &auth_cfg);
             let lsp_id = frag.lsp_id;
             insert_self_originate(&mut top, level, frag, Some(buf.to_vec()));
             top.lsdb.get_mut(&level).srm_set_all(top.tx, level, &lsp_id);
@@ -997,8 +998,11 @@ impl Isis {
             ..Default::default()
         };
 
-        // Emit and flood the purged LSP
-        let _buf = lsp_emit(&mut purged_lsp, level);
+        // Emit and flood the purged LSP. Purge auth follows
+        // RFC 6232: the zero-lifetime LSP still carries the
+        // per-level Auth TLV so receivers can verify it.
+        let auth_cfg = super::lsp::level_auth_cfg(top.config, level).clone();
+        let _buf = lsp_emit(&mut purged_lsp, level, &auth_cfg);
         insert_self_originate(&mut top, level, purged_lsp, None);
 
         top.lsdb.get_mut(&level).srm_set_all(top.tx, level, &lsp_id);
@@ -1065,8 +1069,9 @@ impl Isis {
             .max()
             .unwrap_or(0);
 
+        let auth_cfg = super::lsp::level_auth_cfg(top.config, level).clone();
         for mut frag in fragments {
-            let buf = lsp_emit(&mut frag, level);
+            let buf = lsp_emit(&mut frag, level, &auth_cfg);
             let lsp_id = frag.lsp_id;
             insert_self_originate(&mut top, level, frag, Some(buf.to_vec()));
             top.lsdb.get_mut(&level).srm_set_all(top.tx, level, &lsp_id);

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -647,7 +647,8 @@ fn lsp_clone_with_seqno_inc(lsp: &IsisLsp) -> IsisLsp {
 pub fn refresh_lsp(top: &mut IsisTop, level: Level, key: IsisLspId) {
     if let Some(lsa) = top.lsdb.get(&level).get(&key) {
         let mut lsp = lsp_clone_with_seqno_inc(&lsa.lsp);
-        let buf = lsp_emit(&mut lsp, level);
+        let auth_cfg = crate::isis::lsp::level_auth_cfg(top.config, level).clone();
+        let buf = lsp_emit(&mut lsp, level, &auth_cfg);
         let lsp_id = lsp.lsp_id;
         insert_self_originate(top, level, lsp, Some(buf.to_vec()));
         lsp_flood(top, level, &lsp_id);

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -63,7 +63,7 @@ pub(super) fn key_for_tlv(tlv: &IsisTlv) -> Option<TlvKey> {
 }
 
 use super::auth;
-use super::config::{IsisAuthConfig, IsisConfig, MtId};
+use super::config::{IsisAuthConfig, IsisAuthType, IsisConfig, MtId};
 use super::ifsm::has_level;
 use super::inst::{IsisTop, Message};
 use super::level::Level;
@@ -1341,7 +1341,15 @@ fn arm_seq_wrap_freeze(top: &mut IsisTop, level: Level, lsp_id: IsisLspId) {
     top.lsp_seq_wrap_wait.get_mut(&level).insert(frag_id, timer);
 }
 
-pub fn lsp_emit(lsp: &mut IsisLsp, level: Level) -> BytesMut {
+pub fn lsp_emit(lsp: &mut IsisLsp, level: Level, auth_cfg: &IsisAuthConfig) -> BytesMut {
+    // Auth TLV (Phase 4) sits at the end of the LSP's TLV section.
+    // For HMAC-MD5 it's a zero-filled placeholder that the post-emit
+    // sign step patches in place; for cleartext it carries the
+    // password bytes directly. Append before `IsisPacket::from` so
+    // the serialized fragment size — and the Fletcher checksum
+    // `IsisPacket::emit` stamps — already accounts for the TLV.
+    auth::append_auth_tlv(&mut lsp.tlvs, auth_cfg);
+
     let packet = match level {
         Level::L1 => IsisPacket::from(IsisType::L1Lsp, IsisPdu::L1Lsp(lsp.clone())),
         Level::L2 => IsisPacket::from(IsisType::L2Lsp, IsisPdu::L2Lsp(lsp.clone())),
@@ -1349,6 +1357,17 @@ pub fn lsp_emit(lsp: &mut IsisLsp, level: Level) -> BytesMut {
 
     let mut buf = BytesMut::new();
     packet.emit(&mut buf);
+
+    // HMAC-MD5: hash the buffer with Remaining Lifetime + Checksum
+    // + Auth Value all zeroed, patch the digest into place, then
+    // re-stamp Fletcher (which `IsisPacket::emit` already wrote
+    // covering a zero auth-value — we have to redo it with the
+    // real digest in place).
+    if matches!(auth_cfg.auth_type, IsisAuthType::Md5)
+        && let Some(key) = auth_cfg.password.as_deref()
+    {
+        auth::sign_lsp_md5_inplace(&mut buf, key.as_bytes());
+    }
 
     // Offset for pdu_len and checksum.
     const PDU_LEN_OFFSET: usize = 8;
@@ -1369,7 +1388,7 @@ pub fn csnp_generate(link: &LinkTop, level: Level) -> Vec<IsisCsnp> {
     // (RFC 5304 §3). The Auth TLV is appended after the LspEntries
     // TLV in each CSNP, so its on-wire size shrinks the per-fragment
     // entry budget below.
-    let auth_cfg = snp_auth_cfg(link.up_config, level);
+    let auth_cfg = level_auth_cfg(link.up_config, level);
     let auth_size = auth::auth_tlv_wire_size(auth_cfg);
 
     // For the record, we will try to encode the packet length.
@@ -1461,7 +1480,7 @@ pub fn csnp_generate(link: &LinkTop, level: Level) -> Vec<IsisCsnp> {
 /// `&IsisConfig` (not `&LinkTop`) so callers that hold a disjoint
 /// mutable borrow of `link.lsdb` / `link.state` can still pull the
 /// config out via `link.up_config`.
-pub fn snp_auth_cfg(up_config: &IsisConfig, level: Level) -> &IsisAuthConfig {
+pub fn level_auth_cfg(up_config: &IsisConfig, level: Level) -> &IsisAuthConfig {
     match level {
         Level::L1 => &up_config.area_password,
         Level::L2 => &up_config.domain_password,

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -872,7 +872,7 @@ pub fn psnp_send_pdu(link: &mut LinkTop, level: Level, pdu: IsisPsnp) {
 /// network writer can keep using the existing serialize-on-send code.
 fn sign_snp_outgoing(link: &mut LinkTop, level: Level, packet: IsisPacket) -> Packet {
     let (key, mode) = {
-        let cfg = super::lsp::snp_auth_cfg(link.up_config, level);
+        let cfg = super::lsp::level_auth_cfg(link.up_config, level);
         let Some(pw) = cfg.password.clone() else {
             return Packet::Packet(packet);
         };
@@ -891,10 +891,9 @@ fn sign_snp_outgoing(link: &mut LinkTop, level: Level, packet: IsisPacket) -> Pa
 }
 
 /// Which authentication scope a given PDU type+level falls under.
-/// Hello uses the per-link `hello-authentication`; SNPs follow RFC
-/// 5304 §3 and use the area-password (L1) or domain-password (L2).
-/// LSPs share the same per-level keys as SNPs but stay out of scope
-/// here until Phase 4.
+/// Hello uses the per-link `hello-authentication`; SNPs and LSPs
+/// follow RFC 5304 §3 and use area-password (L1) or domain-password
+/// (L2) — same per-level keys.
 enum AuthScope {
     HelloLink,
     AreaPassword,
@@ -904,21 +903,21 @@ enum AuthScope {
 fn auth_scope_for(pdu_type: IsisType) -> Option<AuthScope> {
     match pdu_type {
         IsisType::L1Hello | IsisType::L2Hello | IsisType::P2pHello => Some(AuthScope::HelloLink),
-        IsisType::L1Csnp | IsisType::L1Psnp => Some(AuthScope::AreaPassword),
-        IsisType::L2Csnp | IsisType::L2Psnp => Some(AuthScope::DomainPassword),
+        IsisType::L1Csnp | IsisType::L1Psnp | IsisType::L1Lsp => Some(AuthScope::AreaPassword),
+        IsisType::L2Csnp | IsisType::L2Psnp | IsisType::L2Lsp => Some(AuthScope::DomainPassword),
         _ => None,
     }
 }
 
-/// Return the first Authentication TLV (type 10) in any Hello/SNP
-/// PDU. LSPs handled in Phase 4 — return None here so they fall
-/// through to the LSP-specific verify when that lands.
+/// Return the first Authentication TLV (type 10) in any
+/// Hello/SNP/LSP PDU.
 fn pdu_auth_tlv(pdu: &IsisPdu) -> Option<&IsisTlvAuth> {
     let tlvs: &[IsisTlv] = match pdu {
         IsisPdu::L1Hello(h) | IsisPdu::L2Hello(h) => &h.tlvs,
         IsisPdu::P2pHello(h) => &h.tlvs,
         IsisPdu::L1Csnp(c) | IsisPdu::L2Csnp(c) => &c.tlvs,
         IsisPdu::L1Psnp(p) | IsisPdu::L2Psnp(p) => &p.tlvs,
+        IsisPdu::L1Lsp(l) | IsisPdu::L2Lsp(l) => &l.tlvs,
         _ => return None,
     };
     tlvs.iter().find_map(|tlv| match tlv {
@@ -997,6 +996,18 @@ fn verify_pdu_auth(
                     let mut scratch = pdu_bytes.to_vec();
                     for b in &mut scratch[digest_start..digest_end] {
                         *b = 0;
+                    }
+                    // RFC 5304 §3: LSP HMAC is computed with
+                    // Remaining Lifetime and Checksum also zeroed so
+                    // the digest stays valid as the LSP ages and is
+                    // re-flooded with a stamped Fletcher.
+                    if packet.pdu_type.is_lsp() && scratch.len() >= auth::LSP_CHECKSUM_RANGE.end {
+                        for b in &mut scratch[auth::LSP_REMAINING_LIFETIME_RANGE] {
+                            *b = 0;
+                        }
+                        for b in &mut scratch[auth::LSP_CHECKSUM_RANGE] {
+                            *b = 0;
+                        }
                     }
                     let computed = auth::hmac_md5(key.as_bytes(), &scratch);
                     auth::digest_eq(&computed, &auth_tlv.value)


### PR DESCRIPTION
## Summary

Phase 4 of IS-IS authentication. Self-originated LSPs (including purges) now sign on emit, and inbound LSPs are verified before LSDB install. Per RFC 5304 §3, LSPs use the per-level area-password (L1) / domain-password (L2) — the same keys SNPs already use, so this PR is the third runtime consumer of the Phase 2 config schema.

After this PR, the IS-IS auth feature is **functionally complete** for cleartext + HMAC-MD5. RFC 5310 generic-crypto (HMAC-SHA family) is Phase 4b; `show` surfacing is Phase 5.

### LSP-specific HMAC details (RFC 5304 §3)

LSPs differ from Hello / SNP in two ways:

1. **Remaining Lifetime is zeroed during the hash**, so the digest stays valid as the LSP ages and is re-flooded with a fresh stamped Fletcher.
2. **Fletcher Checksum is zeroed too**, then re-stamped *after* the HMAC is patched in — otherwise the checksum wouldn't cover the digest bytes the receiver checks.

`sign_lsp_md5_inplace` in `auth.rs` encapsulates the two-pass dance. One gotcha: `checksum_calc` assumes the field reads as zero before recomputation (the existing emit path satisfies that implicitly via `IsisLsp.checksum = 0`), so the helper zeros `buf[24..26]` before recompute.

### Re-flooding correctness (no code change needed)

Existing `flood.rs` updates Remaining Lifetime via `write_hold_time` and sends cached bytes. Fletcher only covers bytes 12+ so the lifetime change at 10..12 doesn't break it; HMAC zeroes lifetime during compute, so the digest survives aging too. The flood path "just works" with signed LSPs.

### Purge auth (RFC 6232)

`process_lsp_purge` runs the purge through the same `lsp_emit` (now with auth_cfg) so the zero-lifetime LSP carries the per-level Auth TLV. Receivers verify it against the same area/domain key as the original.

### Plumbing

- `lsp_emit(lsp, level, auth_cfg)` takes the auth config; 4 call sites in inst.rs / lsdb.rs updated.
- `auth_scope_for` in `packet.rs` extended to map L1Lsp → AreaPassword, L2Lsp → DomainPassword. `pdu_auth_tlv` extended to LSP variants. `verify_pdu_auth` branches on `is_lsp()` to zero the extra ranges in the scratch.
- Renamed `snp_auth_cfg` → `level_auth_cfg` (4 call sites) since both SNPs and LSPs use the same per-level mapping.

### Deliberately not in scope

- RFC 5310 generic-crypto (HMAC-SHA family) — Phase 4b.
- `show isis interface` / `show isis counters` surfacing — Phase 5.

## Test plan

- [x] `cargo test -p zebra-rs --bin zebra-rs isis::` — 109/109 pass (2 new in `isis::auth::tests`: `lsp_pdu_md5_round_trip_via_helpers` including an aging-resistance check, `lsp_purge_md5_round_trip` for the RFC 6232 path).
- [x] `cargo test -p isis-packet` — 43/43 pass.
- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

Generated with [Claude Code](https://claude.com/claude-code)