### PR TITLE
isis: RFC 5310 generic crypto / HMAC-SHA family (Phase 4b)

### DIFF
--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -777,6 +777,15 @@ pub const ISIS_AUTH_TYPE_CLEARTEXT: u8 = 1;
 pub const ISIS_AUTH_TYPE_HMAC_MD5: u8 = 54;
 pub const ISIS_AUTH_TYPE_GENERIC: u8 = 3;
 pub const ISIS_AUTH_HMAC_MD5_LEN: usize = 16;
+/// Generic-crypto (RFC 5310) Key ID is fixed 2 bytes between the
+/// Auth-Type byte and the digest. The digest length depends on the
+/// algorithm — RFC 5310 §3.1 enumerates 20/28/32/48/64 octets for
+/// SHA-1/SHA-224/SHA-256/SHA-384/SHA-512.
+pub const ISIS_AUTH_GENERIC_KEY_ID_LEN: usize = 2;
+pub const ISIS_AUTH_HMAC_SHA1_LEN: usize = 20;
+pub const ISIS_AUTH_HMAC_SHA256_LEN: usize = 32;
+pub const ISIS_AUTH_HMAC_SHA384_LEN: usize = 48;
+pub const ISIS_AUTH_HMAC_SHA512_LEN: usize = 64;
 
 impl IsisTlvAuth {
     /// Build a placeholder Auth TLV with the digest area zero-filled.

--- a/zebra-rs/src/isis/auth.rs
+++ b/zebra-rs/src/isis/auth.rs
@@ -16,10 +16,12 @@ use std::ops::Range;
 use bytes::BytesMut;
 use hmac::{Hmac, KeyInit, Mac};
 use isis_packet::{
-    ISIS_AUTH_HMAC_MD5_LEN, ISIS_AUTH_TYPE_CLEARTEXT, ISIS_AUTH_TYPE_HMAC_MD5, IsisTlv,
-    IsisTlvAuth, IsisTlvType,
+    ISIS_AUTH_GENERIC_KEY_ID_LEN, ISIS_AUTH_HMAC_MD5_LEN, ISIS_AUTH_TYPE_CLEARTEXT,
+    ISIS_AUTH_TYPE_GENERIC, ISIS_AUTH_TYPE_HMAC_MD5, IsisTlv, IsisTlvAuth, IsisTlvType,
 };
 use md5::Md5;
+use sha1::Sha1;
+use sha2::{Sha256, Sha384, Sha512};
 
 use super::config::{IsisAuthConfig, IsisAuthType};
 
@@ -33,6 +35,51 @@ pub fn hmac_md5(key: &[u8], data: &[u8]) -> [u8; 16] {
     let mut digest = [0u8; 16];
     digest.copy_from_slice(&out[..16]);
     digest
+}
+
+/// HMAC over arbitrary data with the algorithm selected by
+/// `algo` — md5 (RFC 5304) or the RFC 5310 SHA family. Returns
+/// the variable-length digest as a Vec so the caller can compare
+/// it with whatever the wire format carries.
+pub fn hmac_for_algo(algo: IsisAuthType, key: &[u8], data: &[u8]) -> Vec<u8> {
+    match algo {
+        IsisAuthType::Text | IsisAuthType::Md5 => hmac_md5(key, data).to_vec(),
+        IsisAuthType::HmacSha1 => {
+            let mut m = <Hmac<Sha1>>::new_from_slice(key).expect("HMAC accepts any key length");
+            m.update(data);
+            m.finalize().into_bytes().to_vec()
+        }
+        IsisAuthType::HmacSha256 => {
+            let mut m = <Hmac<Sha256>>::new_from_slice(key).expect("HMAC accepts any key length");
+            m.update(data);
+            m.finalize().into_bytes().to_vec()
+        }
+        IsisAuthType::HmacSha384 => {
+            let mut m = <Hmac<Sha384>>::new_from_slice(key).expect("HMAC accepts any key length");
+            m.update(data);
+            m.finalize().into_bytes().to_vec()
+        }
+        IsisAuthType::HmacSha512 => {
+            let mut m = <Hmac<Sha512>>::new_from_slice(key).expect("HMAC accepts any key length");
+            m.update(data);
+            m.finalize().into_bytes().to_vec()
+        }
+    }
+}
+
+/// RFC 5310 §3.3 "Apad" — the value 0x878FE1F3 repeated `L/4` times
+/// where L is the digest length. The IS-IS PDU's Authentication
+/// Data field is set to Apad during the HMAC computation, then
+/// replaced with the resulting digest on the wire.
+pub fn apad(digest_len: usize) -> Vec<u8> {
+    const APAD_WORD: [u8; 4] = [0x87, 0x8F, 0xE1, 0xF3];
+    let mut out = Vec::with_capacity(digest_len);
+    while out.len() < digest_len {
+        let remaining = digest_len - out.len();
+        let take = remaining.min(APAD_WORD.len());
+        out.extend_from_slice(&APAD_WORD[..take]);
+    }
+    out
 }
 
 /// Constant-time byte comparison so a partial-match digest doesn't
@@ -52,19 +99,29 @@ pub fn digest_eq(a: &[u8], b: &[u8]) -> bool {
 /// header + 1-byte auth-type + payload), used by the SNP packer to
 /// shrink its fragmentation budget so a CSNP/PSNP stays within MTU
 /// once the TLV is appended. Returns 0 when no auth is configured.
+///
+/// Generic-crypto (RFC 5310) values are 1 (auth-type) + 2 (Key ID)
+/// + digest-length, which is bigger than RFC 5304's md5 layout.
 pub fn auth_tlv_wire_size(cfg: &IsisAuthConfig) -> usize {
-    match (cfg.password.as_ref(), cfg.auth_type) {
-        (None, _) => 0,
-        (Some(pw), IsisAuthType::Text) => 2 + 1 + pw.len(),
-        (Some(_), IsisAuthType::Md5) => 2 + 1 + ISIS_AUTH_HMAC_MD5_LEN,
+    let Some(pw) = cfg.password.as_ref() else {
+        return 0;
+    };
+    match cfg.auth_type {
+        IsisAuthType::Text => 2 + 1 + pw.len(),
+        IsisAuthType::Md5 => 2 + 1 + ISIS_AUTH_HMAC_MD5_LEN,
+        algo if algo.is_generic_crypto() => {
+            2 + 1 + ISIS_AUTH_GENERIC_KEY_ID_LEN + algo.digest_len()
+        }
+        _ => 0,
     }
 }
 
 /// Append the Authentication TLV (type 10) to `tlvs` when this scope
 /// has authentication configured. For cleartext the value is the
 /// password bytes verbatim; for HMAC-MD5 it's a zero-filled
-/// placeholder that `sign_md5_inplace` will patch in place once the
-/// digest is known. No-op when `cfg.password.is_none()`.
+/// placeholder. For RFC 5310 generic crypto, the placeholder is the
+/// Key-ID prefix followed by an Apad-filled digest area — `sign`
+/// will patch the real HMAC over the Apad bytes once computed.
 pub fn append_auth_tlv(tlvs: &mut Vec<IsisTlv>, cfg: &IsisAuthConfig) {
     let Some(pw) = cfg.password.as_deref() else {
         return;
@@ -77,28 +134,60 @@ pub fn append_auth_tlv(tlvs: &mut Vec<IsisTlv>, cfg: &IsisAuthConfig) {
         IsisAuthType::Md5 => {
             IsisTlvAuth::placeholder(ISIS_AUTH_TYPE_HMAC_MD5, ISIS_AUTH_HMAC_MD5_LEN)
         }
+        algo if algo.is_generic_crypto() => {
+            let key_id = cfg.effective_key_id();
+            let digest_len = algo.digest_len();
+            let mut value = Vec::with_capacity(ISIS_AUTH_GENERIC_KEY_ID_LEN + digest_len);
+            value.extend_from_slice(&key_id.to_be_bytes());
+            value.extend_from_slice(&apad(digest_len));
+            IsisTlvAuth {
+                auth_type: ISIS_AUTH_TYPE_GENERIC,
+                value,
+            }
+        }
+        _ => return,
     };
     tlvs.push(tlv.into());
 }
 
-/// Two-pass HMAC-MD5 sign step for Hello / SNP PDUs. Locate the
-/// Auth TLV inside the just-emitted PDU bytes, compute HMAC over
-/// the buffer (the placeholder's digest area is still zero, per
-/// RFC 5304 §3), and patch the resulting digest into place. No-op
-/// when the TLV isn't found or its digest area isn't the expected
-/// length — the caller is responsible for having added a placeholder
-/// first.
-pub fn sign_md5_inplace(buf: &mut BytesMut, tlvs_start: usize, key: &[u8]) {
+/// Two-pass HMAC sign step for Hello / SNP PDUs. Locate the Auth TLV
+/// inside the just-emitted PDU bytes, compute the HMAC over the
+/// buffer (the placeholder's digest area is already filled with
+/// zero or Apad depending on `algo`, matching RFC 5304 §3 /
+/// RFC 5310 §3.3), and patch the resulting digest into place.
+/// No-op when the TLV isn't found, the digest area length doesn't
+/// match `algo`, or `algo` isn't an HMAC algorithm.
+pub fn sign_inplace(buf: &mut BytesMut, tlvs_start: usize, algo: IsisAuthType, key: &[u8]) {
     let Some(value_range) = locate_auth_tlv(buf, tlvs_start) else {
         return;
     };
-    let digest_start = value_range.start + 1;
+    let digest_start = digest_start_for(value_range.start, algo);
     let digest_end = value_range.end;
-    if digest_end - digest_start != ISIS_AUTH_HMAC_MD5_LEN {
+    if digest_end <= digest_start {
         return;
     }
-    let digest = hmac_md5(key, buf);
+    if digest_end - digest_start != algo.digest_len() {
+        return;
+    }
+    if !matches!(algo, IsisAuthType::Md5) && !algo.is_generic_crypto() {
+        return;
+    }
+    let digest = hmac_for_algo(algo, key, buf);
     buf[digest_start..digest_end].copy_from_slice(&digest);
+}
+
+/// Byte offset where the digest area starts inside an Auth TLV's
+/// value, relative to the TLV value's first byte. For RFC 5304 the
+/// digest follows the 1-byte auth-type; for RFC 5310 it follows
+/// auth-type + 2-byte Key ID.
+fn digest_start_for(value_start: usize, algo: IsisAuthType) -> usize {
+    let header = 1usize
+        + if algo.is_generic_crypto() {
+            ISIS_AUTH_GENERIC_KEY_ID_LEN
+        } else {
+            0
+        };
+    value_start + header
 }
 
 /// LSP fixed-header offsets relative to the IS-IS discriminator
@@ -122,19 +211,26 @@ pub const LSP_TLVS_START: usize = 27;
 /// added before `IsisPacket::emit`). On exit, the Auth Value carries
 /// the HMAC and the Fletcher Checksum has been re-stamped to cover
 /// the patched bytes.
-pub fn sign_lsp_md5_inplace(buf: &mut BytesMut, key: &[u8]) {
+pub fn sign_lsp_inplace(buf: &mut BytesMut, algo: IsisAuthType, key: &[u8]) {
     let Some(value_range) = locate_auth_tlv(buf, LSP_TLVS_START) else {
         return;
     };
-    let digest_start = value_range.start + 1;
+    let digest_start = digest_start_for(value_range.start, algo);
     let digest_end = value_range.end;
-    if digest_end - digest_start != ISIS_AUTH_HMAC_MD5_LEN {
+    if digest_end <= digest_start {
+        return;
+    }
+    if digest_end - digest_start != algo.digest_len() {
+        return;
+    }
+    if !matches!(algo, IsisAuthType::Md5) && !algo.is_generic_crypto() {
         return;
     }
 
     // Compute HMAC over a copy with Remaining Lifetime + Checksum
-    // zeroed. The Auth Value bytes are already zero from the
-    // placeholder, so no additional masking is needed there.
+    // zeroed. The Auth Value bytes carry the placeholder fill
+    // (zero for md5, Apad for RFC 5310) which is what the digest
+    // is meant to be computed over per the respective RFCs.
     let mut scratch = buf.to_vec();
     for b in &mut scratch[LSP_REMAINING_LIFETIME_RANGE] {
         *b = 0;
@@ -142,7 +238,7 @@ pub fn sign_lsp_md5_inplace(buf: &mut BytesMut, key: &[u8]) {
     for b in &mut scratch[LSP_CHECKSUM_RANGE] {
         *b = 0;
     }
-    let digest = hmac_md5(key, &scratch);
+    let digest = hmac_for_algo(algo, key, &scratch);
 
     // Patch the HMAC into the live buffer at the auth-value range,
     // then re-stamp Fletcher over the bytes that now carry the
@@ -357,6 +453,7 @@ mod tests {
         let cfg = IsisAuthConfig {
             password: Some("hunter2".into()),
             auth_type: IsisAuthType::Text,
+            key_id: 0,
             send_only: false,
         };
         let tlv: IsisTlv = IsisTlvAuth {
@@ -370,6 +467,7 @@ mod tests {
         let cfg = IsisAuthConfig {
             password: Some("hunter2".into()),
             auth_type: IsisAuthType::Md5,
+            key_id: 0,
             send_only: false,
         };
         let tlv: IsisTlv =
@@ -412,7 +510,12 @@ mod tests {
         packet.emit(&mut buf);
 
         let key = b"area-key";
-        sign_md5_inplace(&mut buf, packet.length_indicator as usize, key);
+        sign_inplace(
+            &mut buf,
+            packet.length_indicator as usize,
+            IsisAuthType::Md5,
+            key,
+        );
 
         // Verify: peel out the patched digest, zero its range, recompute.
         let range = locate_auth_tlv(&buf, packet.length_indicator as usize).unwrap();
@@ -468,7 +571,7 @@ mod tests {
         packet.emit(&mut buf);
 
         let key = b"area-key";
-        sign_lsp_md5_inplace(&mut buf, key);
+        sign_lsp_inplace(&mut buf, IsisAuthType::Md5, key);
 
         // Verify mirrors the recv side: zero lifetime + checksum +
         // auth-value, recompute, compare.
@@ -561,7 +664,7 @@ mod tests {
         packet.emit(&mut buf);
 
         let key = b"domain-key";
-        sign_lsp_md5_inplace(&mut buf, key);
+        sign_lsp_inplace(&mut buf, IsisAuthType::Md5, key);
 
         let range = locate_auth_tlv(&buf, LSP_TLVS_START).unwrap();
         let digest_start = range.start + 1;
@@ -610,7 +713,12 @@ mod tests {
         packet.emit(&mut buf);
 
         let key = b"domain-key";
-        sign_md5_inplace(&mut buf, packet.length_indicator as usize, key);
+        sign_inplace(
+            &mut buf,
+            packet.length_indicator as usize,
+            IsisAuthType::Md5,
+            key,
+        );
 
         let range = locate_auth_tlv(&buf, packet.length_indicator as usize).unwrap();
         let digest_start = range.start + 1;
@@ -621,5 +729,166 @@ mod tests {
             *b = 0;
         }
         assert!(digest_eq(&hmac_md5(key, &scratch), &stored));
+    }
+
+    /// RFC 5310 §3.3: Apad is 0x878FE1F3 repeated L/4 times.
+    /// Verify the helper produces the right pattern at the digest
+    /// lengths the IS-IS auth-type table allows.
+    #[test]
+    fn apad_pattern_repeats() {
+        let p = apad(20);
+        assert_eq!(p.len(), 20);
+        assert_eq!(&p[0..4], &[0x87, 0x8F, 0xE1, 0xF3]);
+        assert_eq!(&p[16..20], &[0x87, 0x8F, 0xE1, 0xF3]);
+
+        let p = apad(64);
+        assert_eq!(p.len(), 64);
+        for chunk in p.chunks(4) {
+            assert_eq!(chunk, &[0x87, 0x8F, 0xE1, 0xF3]);
+        }
+    }
+
+    /// End-to-end HMAC-SHA256 round-trip across a real Hello PDU.
+    /// Mirrors the md5 path but with the RFC 5310 wire shape:
+    /// auth-type 3, 2-byte Key ID, 32-byte digest area filled with
+    /// Apad before the HMAC.
+    #[test]
+    fn hello_pdu_sha256_round_trip_via_helpers() {
+        use isis_packet::{
+            IsLevel, IsisHello, IsisNeighborId, IsisPacket, IsisPdu, IsisSysId, IsisTlv,
+            IsisTlvAreaAddr, IsisType,
+        };
+
+        let cfg = IsisAuthConfig {
+            password: Some("sha-key".into()),
+            auth_type: IsisAuthType::HmacSha256,
+            key_id: 42,
+            send_only: false,
+        };
+        let mut tlvs = vec![IsisTlv::AreaAddr(IsisTlvAreaAddr {
+            area_addr: vec![0x49, 0x00, 0x01],
+        })];
+        append_auth_tlv(&mut tlvs, &cfg);
+
+        let hello = IsisHello {
+            circuit_type: IsLevel::L1L2,
+            source_id: IsisSysId {
+                id: [1, 2, 3, 4, 5, 6],
+            },
+            hold_time: 30,
+            pdu_len: 0,
+            priority: 64,
+            lan_id: IsisNeighborId::default(),
+            tlvs,
+        };
+        let packet = IsisPacket::from(IsisType::L1Hello, IsisPdu::L1Hello(hello));
+        let mut buf = BytesMut::new();
+        packet.emit(&mut buf);
+
+        sign_inplace(
+            &mut buf,
+            packet.length_indicator as usize,
+            IsisAuthType::HmacSha256,
+            cfg.password.as_deref().unwrap().as_bytes(),
+        );
+
+        // Locate auth TLV value: [auth-type=3, key_id(2), digest(32)].
+        let range = locate_auth_tlv(&buf, packet.length_indicator as usize).unwrap();
+        assert_eq!(buf[range.start], ISIS_AUTH_TYPE_GENERIC);
+        let key_id = u16::from_be_bytes(buf[range.start + 1..range.start + 3].try_into().unwrap());
+        assert_eq!(key_id, 42);
+
+        let digest_start = range.start + 1 + ISIS_AUTH_GENERIC_KEY_ID_LEN;
+        let digest_end = range.end;
+        assert_eq!(digest_end - digest_start, 32);
+        let stored = buf[digest_start..digest_end].to_vec();
+        // Patched digest is no longer Apad.
+        assert_ne!(stored, apad(32));
+
+        // Verify: replace digest area with Apad, recompute HMAC,
+        // compare. Mirrors `verify_hmac` in packet.rs.
+        let mut scratch = buf.to_vec();
+        let apad32 = apad(32);
+        scratch[digest_start..digest_end].copy_from_slice(&apad32);
+        let computed = hmac_for_algo(
+            IsisAuthType::HmacSha256,
+            cfg.password.as_deref().unwrap().as_bytes(),
+            &scratch,
+        );
+        assert!(digest_eq(&computed, &stored));
+
+        // Wrong key → mismatch.
+        let bad = hmac_for_algo(IsisAuthType::HmacSha256, b"wrong", &scratch);
+        assert!(!digest_eq(&bad, &stored));
+    }
+
+    /// LSP HMAC-SHA512 round-trip — exercises the LSP-specific
+    /// lifetime+checksum zeroing and Fletcher re-stamping with the
+    /// 64-byte digest.
+    #[test]
+    fn lsp_pdu_sha512_round_trip_via_helpers() {
+        use isis_packet::{
+            IsisLsp, IsisLspId, IsisPacket, IsisPdu, IsisSysId, IsisTlv, IsisTlvAreaAddr, IsisType,
+        };
+
+        let cfg = IsisAuthConfig {
+            password: Some("lsp-sha-key".into()),
+            auth_type: IsisAuthType::HmacSha512,
+            key_id: 9,
+            send_only: false,
+        };
+        let mut tlvs = vec![IsisTlv::AreaAddr(IsisTlvAreaAddr {
+            area_addr: vec![0x49, 0x00, 0x01],
+        })];
+        append_auth_tlv(&mut tlvs, &cfg);
+        let lsp = IsisLsp {
+            pdu_len: 0,
+            hold_time: 1200,
+            lsp_id: IsisLspId::new(
+                IsisSysId {
+                    id: [1, 2, 3, 4, 5, 6],
+                },
+                0,
+                0,
+            ),
+            seq_number: 1,
+            checksum: 0,
+            types: Default::default(),
+            tlvs,
+        };
+        let packet = IsisPacket::from(IsisType::L1Lsp, IsisPdu::L1Lsp(lsp));
+        let mut buf = BytesMut::new();
+        packet.emit(&mut buf);
+
+        sign_lsp_inplace(
+            &mut buf,
+            IsisAuthType::HmacSha512,
+            cfg.password.as_deref().unwrap().as_bytes(),
+        );
+
+        let range = locate_auth_tlv(&buf, LSP_TLVS_START).unwrap();
+        let digest_start = range.start + 1 + ISIS_AUTH_GENERIC_KEY_ID_LEN;
+        let digest_end = range.end;
+        assert_eq!(digest_end - digest_start, 64);
+        let stored = buf[digest_start..digest_end].to_vec();
+
+        // Verify: Apad + zero lifetime + zero checksum, recompute.
+        let mut scratch = buf.to_vec();
+        scratch[digest_start..digest_end].copy_from_slice(&apad(64));
+        for b in &mut scratch[LSP_REMAINING_LIFETIME_RANGE] {
+            *b = 0;
+        }
+        for b in &mut scratch[LSP_CHECKSUM_RANGE] {
+            *b = 0;
+        }
+        let computed = hmac_for_algo(
+            IsisAuthType::HmacSha512,
+            cfg.password.as_deref().unwrap().as_bytes(),
+            &scratch,
+        );
+        assert!(digest_eq(&computed, &stored));
+
+        // Fletcher must validate over the patched-digest buffer.
+        assert!(isis_packet::is_valid_checksum(&buf));
     }
 }

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -67,6 +67,10 @@ impl Isis {
             config_area_password_auth_type,
         );
         self.callback_add(
+            "/router/isis/area-password/key-id",
+            config_area_password_key_id,
+        );
+        self.callback_add(
             "/router/isis/area-password/send-only",
             config_area_password_send_only,
         );
@@ -78,6 +82,10 @@ impl Isis {
         self.callback_add(
             "/router/isis/domain-password/auth-type",
             config_domain_password_auth_type,
+        );
+        self.callback_add(
+            "/router/isis/domain-password/key-id",
+            config_domain_password_key_id,
         );
         self.callback_add(
             "/router/isis/domain-password/send-only",
@@ -281,6 +289,10 @@ impl Isis {
             link::config_hello_auth_type,
         );
         self.callback_add(
+            "/router/isis/interface/hello-authentication/key-id",
+            link::config_hello_auth_key_id,
+        );
+        self.callback_add(
             "/router/isis/interface/hello-authentication/send-only",
             link::config_hello_auth_send_only,
         );
@@ -470,12 +482,9 @@ pub struct IsisRedistribute {
 }
 
 /// IS-IS Authentication algorithm selector. Maps to the TLV-10
-/// Authentication Type byte at sign/verify time:
-///   Text → 1   (ISO 10589 §9.5 cleartext)
-///   Md5  → 54  (RFC 5304 HMAC-MD5)
-/// RFC 5310 generic-crypto (auth-type 3, HMAC-SHA family) is a
-/// Phase 4b follow-on and intentionally absent from the enum so it
-/// can't be committed before the runtime supports it.
+/// Authentication Type byte (1 / 54 / 3) plus, for generic-crypto,
+/// a digest-length selector that drives both the wire format
+/// (RFC 5310 §3.1) and the HMAC primitive (sha1 / sha2 family).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, EnumString, Display)]
 pub enum IsisAuthType {
     #[default]
@@ -483,6 +492,43 @@ pub enum IsisAuthType {
     Text,
     #[strum(serialize = "md5")]
     Md5,
+    #[strum(serialize = "hmac-sha-1")]
+    HmacSha1,
+    #[strum(serialize = "hmac-sha-256")]
+    HmacSha256,
+    #[strum(serialize = "hmac-sha-384")]
+    HmacSha384,
+    #[strum(serialize = "hmac-sha-512")]
+    HmacSha512,
+}
+
+impl IsisAuthType {
+    /// True for the RFC 5310 algorithms — the wire shape carries a
+    /// 2-byte Key ID prefix between Auth-Type and the digest, and
+    /// the HMAC is computed over the PDU with the digest area
+    /// filled with Apad (not zero, as RFC 5304 specifies for MD5).
+    pub fn is_generic_crypto(self) -> bool {
+        matches!(
+            self,
+            Self::HmacSha1 | Self::HmacSha256 | Self::HmacSha384 | Self::HmacSha512
+        )
+    }
+
+    /// Length of the HMAC digest in octets, per RFC 5310 §3.1.
+    /// `Text` and `Md5` aren't generic-crypto, so they return 0 /
+    /// the MD5 digest size respectively — callers normally check
+    /// `is_generic_crypto` first.
+    pub fn digest_len(self) -> usize {
+        use isis_packet::*;
+        match self {
+            Self::Text => 0,
+            Self::Md5 => ISIS_AUTH_HMAC_MD5_LEN,
+            Self::HmacSha1 => ISIS_AUTH_HMAC_SHA1_LEN,
+            Self::HmacSha256 => ISIS_AUTH_HMAC_SHA256_LEN,
+            Self::HmacSha384 => ISIS_AUTH_HMAC_SHA384_LEN,
+            Self::HmacSha512 => ISIS_AUTH_HMAC_SHA512_LEN,
+        }
+    }
 }
 
 /// Shared shape for all three IS-IS auth scopes: instance-level
@@ -495,10 +541,31 @@ pub enum IsisAuthType {
 pub struct IsisAuthConfig {
     pub password: Option<String>,
     pub auth_type: IsisAuthType,
+    /// RFC 5310 §3.1 Key Identifier — emitted on the wire as the
+    /// 2-byte prefix on the TLV-10 value for the generic-crypto
+    /// auth-types. Ignored for `Text` and `Md5`. YANG default is 1.
+    pub key_id: u16,
     /// RFC 5304 §1 rollover hatch: sign on send, accept-any on
     /// receive. Used to drain peers from no-auth → auth without
     /// breaking adjacencies mid-rollout.
     pub send_only: bool,
+}
+
+impl IsisAuthConfig {
+    /// YANG default for the `key-id` leaf when no value has been set
+    /// (or when the auth-type doesn't carry one on the wire).
+    pub const DEFAULT_KEY_ID: u16 = 1;
+
+    /// Effective Key ID — `key_id` if non-zero (operator-set), else
+    /// the YANG default. Callers should use this when stamping or
+    /// matching the wire value.
+    pub fn effective_key_id(&self) -> u16 {
+        if self.key_id == 0 {
+            Self::DEFAULT_KEY_ID
+        } else {
+            self.key_id
+        }
+    }
 }
 
 impl IsisConfig {
@@ -657,12 +724,18 @@ fn config_hostname(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> 
 
 /// Reset an IsisAuthConfig to its YANG-default state. Used by the
 /// presence-container delete callbacks when the whole auth scope is
-/// removed, so we don't leave stale auth-type / send-only behind a
-/// vanished password.
+/// removed, so we don't leave stale auth-type / key-id / send-only
+/// behind a vanished password.
 pub fn auth_reset(cfg: &mut IsisAuthConfig) {
     cfg.password = None;
     cfg.auth_type = IsisAuthType::default();
+    cfg.key_id = 0;
     cfg.send_only = false;
+}
+
+pub fn auth_set_key_id(cfg: &mut IsisAuthConfig, args: &mut Args, op: ConfigOp) -> Option<()> {
+    cfg.key_id = if op.is_set() { args.u16()? } else { 0 };
+    Some(())
 }
 
 pub fn auth_set_password(cfg: &mut IsisAuthConfig, args: &mut Args, op: ConfigOp) -> Option<()> {
@@ -700,6 +773,10 @@ fn config_area_password_auth_type(isis: &mut Isis, mut args: Args, op: ConfigOp)
     auth_set_type(&mut isis.config.area_password, &mut args, op)
 }
 
+fn config_area_password_key_id(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    auth_set_key_id(&mut isis.config.area_password, &mut args, op)
+}
+
 fn config_area_password_send_only(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     auth_set_send_only(&mut isis.config.area_password, &mut args, op)
 }
@@ -717,6 +794,10 @@ fn config_domain_password_password(isis: &mut Isis, mut args: Args, op: ConfigOp
 
 fn config_domain_password_auth_type(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     auth_set_type(&mut isis.config.domain_password, &mut args, op)
+}
+
+fn config_domain_password_key_id(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    auth_set_key_id(&mut isis.config.domain_password, &mut args, op)
 }
 
 fn config_domain_password_send_only(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
@@ -1414,11 +1495,24 @@ mod tests {
 
     #[test]
     fn auth_type_parses_yang_enum_names() {
-        // The two enum values the YANG schema admits — the FromStr
-        // impl gates what the auth-type leaf callback will accept.
+        // The enum values the YANG schema admits — the FromStr impl
+        // gates what the auth-type leaf callback will accept. Includes
+        // the RFC 5310 SHA family added in Phase 4b.
         assert_eq!(IsisAuthType::from_str("text"), Ok(IsisAuthType::Text));
         assert_eq!(IsisAuthType::from_str("md5"), Ok(IsisAuthType::Md5));
-        assert!(IsisAuthType::from_str("hmac-sha-256").is_err());
+        assert_eq!(
+            IsisAuthType::from_str("hmac-sha-1"),
+            Ok(IsisAuthType::HmacSha1)
+        );
+        assert_eq!(
+            IsisAuthType::from_str("hmac-sha-256"),
+            Ok(IsisAuthType::HmacSha256)
+        );
+        assert_eq!(
+            IsisAuthType::from_str("hmac-sha-512"),
+            Ok(IsisAuthType::HmacSha512)
+        );
+        assert!(IsisAuthType::from_str("hmac-sha-1024").is_err());
     }
 
     #[test]
@@ -1430,12 +1524,38 @@ mod tests {
         let mut cfg = IsisAuthConfig {
             password: Some("secret".into()),
             auth_type: IsisAuthType::Md5,
+            key_id: 7,
             send_only: true,
         };
         auth_reset(&mut cfg);
         assert_eq!(cfg, IsisAuthConfig::default());
         assert!(cfg.password.is_none());
         assert_eq!(cfg.auth_type, IsisAuthType::Text);
+        assert_eq!(cfg.key_id, 0);
         assert!(!cfg.send_only);
+    }
+
+    #[test]
+    fn effective_key_id_falls_back_to_default() {
+        let mut cfg = IsisAuthConfig::default();
+        assert_eq!(cfg.effective_key_id(), 1);
+        cfg.key_id = 42;
+        assert_eq!(cfg.effective_key_id(), 42);
+    }
+
+    #[test]
+    fn auth_type_includes_generic_crypto() {
+        assert!(IsisAuthType::HmacSha1.is_generic_crypto());
+        assert!(IsisAuthType::HmacSha256.is_generic_crypto());
+        assert!(IsisAuthType::HmacSha512.is_generic_crypto());
+        assert!(!IsisAuthType::Text.is_generic_crypto());
+        assert!(!IsisAuthType::Md5.is_generic_crypto());
+
+        // Digest lengths per RFC 5310 §3.1.
+        assert_eq!(IsisAuthType::HmacSha1.digest_len(), 20);
+        assert_eq!(IsisAuthType::HmacSha256.digest_len(), 32);
+        assert_eq!(IsisAuthType::HmacSha384.digest_len(), 48);
+        assert_eq!(IsisAuthType::HmacSha512.digest_len(), 64);
+        assert_eq!(IsisAuthType::Md5.digest_len(), 16);
     }
 }

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -263,15 +263,21 @@ pub fn hello_send(link: &mut LinkTop, level: Level) -> Result<()> {
     *link.state.hello.get_mut(&level) = Some(hello);
 
     let ifindex = link.ifindex;
-    // HMAC-MD5 needs the bytes patched after serialization, so we
-    // pre-emit and send as `Packet::Bytes`. Cleartext + no-auth use
-    // the existing serialize-on-send path with `Packet::Packet`.
+    // Any HMAC algorithm (md5 or RFC 5310 SHA family) needs the
+    // bytes patched after serialization, so we pre-emit and send
+    // as `Packet::Bytes`. Cleartext + no-auth use the existing
+    // serialize-on-send path with `Packet::Packet`.
     let auth_cfg = &link.config.hello_auth;
     let outgoing = match (auth_cfg.password.as_deref(), auth_cfg.auth_type) {
-        (Some(key), IsisAuthType::Md5) => {
+        (Some(key), algo) if matches!(algo, IsisAuthType::Md5) || algo.is_generic_crypto() => {
             let mut buf = BytesMut::new();
             packet.emit(&mut buf);
-            auth::sign_md5_inplace(&mut buf, packet.length_indicator as usize, key.as_bytes());
+            auth::sign_inplace(
+                &mut buf,
+                packet.length_indicator as usize,
+                algo,
+                key.as_bytes(),
+            );
             link.state.auth_tx_signed += 1;
             Packet::Bytes(buf)
         }

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -20,7 +20,8 @@ use crate::rib::link::LinkAddr;
 use crate::rib::{Link, LinkFlagsExt, MacAddr};
 
 use super::config::{
-    self, IsisAuthConfig, IsisConfig, MtId, auth_set_password, auth_set_send_only, auth_set_type,
+    self, IsisAuthConfig, IsisConfig, MtId, auth_set_key_id, auth_set_password, auth_set_send_only,
+    auth_set_type,
 };
 use super::graph::{ReachMap, ReachMapV6};
 use super::ifsm::{self, has_level};
@@ -810,6 +811,12 @@ pub fn config_hello_auth_type(isis: &mut Isis, mut args: Args, op: ConfigOp) -> 
     let name = args.string()?;
     let link = isis.links.get_mut_by_name(&name)?;
     auth_set_type(&mut link.config.hello_auth, &mut args, op)
+}
+
+pub fn config_hello_auth_key_id(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let link = isis.links.get_mut_by_name(&name)?;
+    auth_set_key_id(&mut link.config.hello_auth, &mut args, op)
 }
 
 pub fn config_hello_auth_send_only(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -1358,15 +1358,17 @@ pub fn lsp_emit(lsp: &mut IsisLsp, level: Level, auth_cfg: &IsisAuthConfig) -> B
     let mut buf = BytesMut::new();
     packet.emit(&mut buf);
 
-    // HMAC-MD5: hash the buffer with Remaining Lifetime + Checksum
-    // + Auth Value all zeroed, patch the digest into place, then
-    // re-stamp Fletcher (which `IsisPacket::emit` already wrote
-    // covering a zero auth-value — we have to redo it with the
-    // real digest in place).
-    if matches!(auth_cfg.auth_type, IsisAuthType::Md5)
+    // HMAC sign (md5 or RFC 5310 SHA family): hash the buffer with
+    // Remaining Lifetime + Checksum + Auth Value all set to the
+    // placeholder fill (zero for md5, Apad for RFC 5310), patch the
+    // digest into place, then re-stamp Fletcher (which
+    // `IsisPacket::emit` already wrote covering the placeholder —
+    // we redo it with the real digest in place).
+    let algo = auth_cfg.auth_type;
+    if (matches!(algo, IsisAuthType::Md5) || algo.is_generic_crypto())
         && let Some(key) = auth_cfg.password.as_deref()
     {
-        auth::sign_lsp_md5_inplace(&mut buf, key.as_bytes());
+        auth::sign_lsp_inplace(&mut buf, algo, key.as_bytes());
     }
 
     // Offset for pdu_len and checksum.

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -881,10 +881,15 @@ fn sign_snp_outgoing(link: &mut LinkTop, level: Level, packet: IsisPacket) -> Pa
     link.state.auth_tx_signed += 1;
     match mode {
         IsisAuthType::Text => Packet::Packet(packet),
-        IsisAuthType::Md5 => {
+        algo => {
             let mut buf = bytes::BytesMut::new();
             packet.emit(&mut buf);
-            auth::sign_md5_inplace(&mut buf, packet.length_indicator as usize, key.as_bytes());
+            auth::sign_inplace(
+                &mut buf,
+                packet.length_indicator as usize,
+                algo,
+                key.as_bytes(),
+            );
             Packet::Bytes(buf)
         }
     }
@@ -924,6 +929,78 @@ fn pdu_auth_tlv(pdu: &IsisPdu) -> Option<&IsisTlvAuth> {
         IsisTlv::Auth(a) => Some(a),
         _ => None,
     })
+}
+
+/// Recompute the HMAC over `pdu_bytes` for one of the supported
+/// HMAC algorithms (RFC 5304 md5 or RFC 5310 sha-1/256/384/512) and
+/// compare it against the digest carried in the parsed Auth TLV.
+///
+/// Encapsulates the layout differences:
+///   * md5      — TLV value = [auth_type=54, digest(16)]; placeholder zero.
+///   * generic  — TLV value = [auth_type=3, key_id(2), digest(L)]; placeholder Apad.
+///
+/// Plus the LSP-only zeroing of Remaining Lifetime + Checksum
+/// (RFC 5304 §3 / RFC 5310 inherit) so the digest stays valid as
+/// the LSP ages and gets re-fletcher'd in flight.
+fn verify_hmac(
+    algo: IsisAuthType,
+    key: &str,
+    auth_tlv: &IsisTlvAuth,
+    pdu_bytes: &[u8],
+    tlvs_start: usize,
+    packet: &IsisPacket,
+) -> bool {
+    // Validate the wire auth-type byte matches what we expect.
+    let want_auth_type = if algo.is_generic_crypto() {
+        ISIS_AUTH_TYPE_GENERIC
+    } else {
+        ISIS_AUTH_TYPE_HMAC_MD5
+    };
+    if auth_tlv.auth_type != want_auth_type {
+        return false;
+    }
+    let header = 1 + if algo.is_generic_crypto() {
+        ISIS_AUTH_GENERIC_KEY_ID_LEN
+    } else {
+        0
+    };
+    let digest_len = algo.digest_len();
+    if auth_tlv.value.len() != header - 1 + digest_len {
+        return false;
+    }
+    let Some(value_range) = auth::locate_auth_tlv(pdu_bytes, tlvs_start) else {
+        return false;
+    };
+    let digest_start = value_range.start + header;
+    let digest_end = value_range.end;
+    if digest_end <= digest_start || digest_end - digest_start != digest_len {
+        return false;
+    }
+
+    let mut scratch = pdu_bytes.to_vec();
+    if algo.is_generic_crypto() {
+        // RFC 5310 §3.3: replace the digest area with Apad during
+        // the HMAC, not zero. The Key ID and Auth-Type stay as-is.
+        let apad = auth::apad(digest_len);
+        scratch[digest_start..digest_end].copy_from_slice(&apad);
+    } else {
+        for b in &mut scratch[digest_start..digest_end] {
+            *b = 0;
+        }
+    }
+    if packet.pdu_type.is_lsp() && scratch.len() >= auth::LSP_CHECKSUM_RANGE.end {
+        for b in &mut scratch[auth::LSP_REMAINING_LIFETIME_RANGE] {
+            *b = 0;
+        }
+        for b in &mut scratch[auth::LSP_CHECKSUM_RANGE] {
+            *b = 0;
+        }
+    }
+    let computed = auth::hmac_for_algo(algo, key.as_bytes(), &scratch);
+    // Compare against the digest portion of the parsed TLV (skip
+    // the Key ID prefix for generic-crypto).
+    let stored = &auth_tlv.value[header - 1..];
+    auth::digest_eq(&computed, stored)
 }
 
 /// Validate the Authentication TLV on an inbound Hello or SNP PDU
@@ -982,43 +1059,7 @@ fn verify_pdu_auth(
             auth_tlv.auth_type == ISIS_AUTH_TYPE_CLEARTEXT
                 && auth::digest_eq(&auth_tlv.value, key.as_bytes())
         }
-        IsisAuthType::Md5 => {
-            if auth_tlv.auth_type != ISIS_AUTH_TYPE_HMAC_MD5
-                || auth_tlv.value.len() != ISIS_AUTH_HMAC_MD5_LEN
-            {
-                false
-            } else if let Some(value_range) = auth::locate_auth_tlv(pdu_bytes, tlvs_start) {
-                let digest_start = value_range.start + 1;
-                let digest_end = value_range.end;
-                if digest_end - digest_start != ISIS_AUTH_HMAC_MD5_LEN {
-                    false
-                } else {
-                    let mut scratch = pdu_bytes.to_vec();
-                    for b in &mut scratch[digest_start..digest_end] {
-                        *b = 0;
-                    }
-                    // RFC 5304 §3: LSP HMAC is computed with
-                    // Remaining Lifetime and Checksum also zeroed so
-                    // the digest stays valid as the LSP ages and is
-                    // re-flooded with a stamped Fletcher.
-                    if packet.pdu_type.is_lsp() && scratch.len() >= auth::LSP_CHECKSUM_RANGE.end {
-                        for b in &mut scratch[auth::LSP_REMAINING_LIFETIME_RANGE] {
-                            *b = 0;
-                        }
-                        for b in &mut scratch[auth::LSP_CHECKSUM_RANGE] {
-                            *b = 0;
-                        }
-                    }
-                    let computed = auth::hmac_md5(key.as_bytes(), &scratch);
-                    auth::digest_eq(&computed, &auth_tlv.value)
-                }
-            } else {
-                // Parsed TLV exists but raw bytes don't carry it —
-                // network.rs preserves the buffer for every PDU, so
-                // this is a hard inconsistency: reject.
-                false
-            }
-        }
+        algo => verify_hmac(algo, &key, auth_tlv, pdu_bytes, tlvs_start, packet),
     };
 
     if accepted {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1002,10 +1002,23 @@ module config {
           }
           leaf auth-type {
             type enumeration {
-              enum text;  // ISO 10589 §9.5, TLV-10 auth-type 1
-              enum md5;   // RFC 5304, TLV-10 auth-type 54
+              enum text;         // ISO 10589 §9.5, TLV-10 auth-type 1
+              enum md5;          // RFC 5304, TLV-10 auth-type 54
+              enum hmac-sha-1;   // RFC 5310 generic crypto, 20-byte digest
+              enum hmac-sha-256; // RFC 5310, 32-byte digest
+              enum hmac-sha-384; // RFC 5310, 48-byte digest
+              enum hmac-sha-512; // RFC 5310, 64-byte digest
             }
             default text;
+          }
+          leaf key-id {
+            type uint16;
+            default 1;
+            description
+              "Key Identifier (RFC 5310 §3.1). Only meaningful for
+               the hmac-sha-* auth-types; embedded as the 2-byte
+               prefix on the TLV-10 value. Ignored for text and md5.
+               Receivers MUST present the same Key ID to verify.";
           }
           leaf send-only {
             type boolean;
@@ -1030,8 +1043,16 @@ module config {
             type enumeration {
               enum text;
               enum md5;
+              enum hmac-sha-1;
+              enum hmac-sha-256;
+              enum hmac-sha-384;
+              enum hmac-sha-512;
             }
             default text;
+          }
+          leaf key-id {
+            type uint16;
+            default 1;
           }
           leaf send-only {
             type boolean;
@@ -1288,8 +1309,16 @@ module config {
               type enumeration {
                 enum text;
                 enum md5;
+                enum hmac-sha-1;
+                enum hmac-sha-256;
+                enum hmac-sha-384;
+                enum hmac-sha-512;
               }
               default text;
+            }
+            leaf key-id {
+              type uint16;
+              default 1;
             }
             leaf send-only {
               type boolean;


### PR DESCRIPTION
## Summary

Phase 4b extends IS-IS authentication with **RFC 5310** generic cryptographic authentication: HMAC-SHA-1/256/384/512 and the 2-byte Key ID prefix that distinguishes the wire format from RFC 5304's HMAC-MD5. Single-key per scope for now — key-chain rotation can come later.

After this PR, the IS-IS auth feature covers everything operators normally configure: cleartext, HMAC-MD5, HMAC-SHA-1/256/384/512 — across Hello, CSNP, PSNP, and LSPs (including purges).

### Wire-format differences vs RFC 5304

| Field | RFC 5304 (md5) | RFC 5310 (generic) |
|---|---|---|
| `auth-type` byte | 54 | 3 |
| Key ID | — | 2 bytes between auth-type and digest |
| Digest area during HMAC | zero | Apad (`0x878FE1F3` repeated L/4 times) |
| Digest length | 16 | 20 / 32 / 48 / 64 |

### Code changes

- **`crates/isis-packet`** — new digest-length constants + `ISIS_AUTH_GENERIC_KEY_ID_LEN`.
- **`zebra-rs/src/isis/auth.rs`** — `hmac_for_algo(algo, key, data)` dispatches md5/sha-1/sha-256/sha-384/sha-512. `apad(len)` builds the RFC 5310 §3.3 pattern. `append_auth_tlv` / `auth_tlv_wire_size` / `sign_inplace` / `sign_lsp_inplace` all reshape around `IsisAuthType` — the old md5-only helpers are gone.
- **`zebra-rs/src/isis/packet.rs`** — `verify_pdu_auth` delegates to a new `verify_hmac` that picks the digest offset (after Key ID for generic), refills the digest area with Apad (generic) or zero (md5) in scratch, applies the LSP-only lifetime+checksum zeroing when `pdu_type.is_lsp()`, and constant-time compares.
- **`zebra-rs/src/isis/{ifsm,lsp}.rs`** — send paths dispatch on `algo.is_generic_crypto() || Md5`.
- **`zebra-rs/yang/config.yang` + `zebra-rs/src/isis/config.rs`** — `auth-type` enum gains `hmac-sha-1`/`-256`/`-384`/`-512`; new `key-id` leaf (uint16, default 1) on area-password, domain-password, hello-authentication, with three new `config_*_key_id` callbacks.

### Deliberately not in scope

- Key-chain rotation (multiple Key IDs per scope, rolled over the wire) — Phase 6.
- `show` output for the four per-link auth counters that have been ticking since 3a — Phase 5.

## Test plan

- [x] `cargo test -p zebra-rs --bin zebra-rs isis::` — 114/114 pass (5 new in `isis::auth::tests`: `auth_type_includes_generic_crypto`, `effective_key_id_falls_back_to_default`, `apad_pattern_repeats`, `hello_pdu_sha256_round_trip_via_helpers`, `lsp_pdu_sha512_round_trip_via_helpers`).
- [x] `cargo test -p isis-packet` — 43/43 pass.
- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

Generated with [Claude Code](https://claude.com/claude-code)