### PR TITLE
policy: shared key-chain registry skeleton (PR 1/5)

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1343,6 +1343,13 @@ impl Bgp {
                     InOut::Output => super::peer::apply_soft_out_peer(self, ident),
                 }
             }
+            // PR 1 skeleton: BGP doesn't subscribe to PolicyType::KeyChain
+            // yet (the per-peer `/.../tcp-ao/key-chain` callback still
+            // mutates `Bgp::key_chains` directly). Once PR 3 lands the
+            // Register/Unregister + snapshot path, this arm gains a real
+            // handler. Until then ignoring the variant keeps the match
+            // exhaustive without affecting behavior.
+            policy::PolicyRx::KeyChain { .. } => {}
         }
     }
 

--- a/zebra-rs/src/policy/inst.rs
+++ b/zebra-rs/src/policy/inst.rs
@@ -8,8 +8,9 @@ use crate::config::{
 };
 
 use super::{
-    AsPathSetConfig, CommunitySetConfig, ExtCommunitySetConfig, LargeCommunitySetConfig,
-    PolicyConfig, PolicyList, PrefixSet, PrefixSetConfig, policy_entry_sync,
+    AsPathSetConfig, CommunitySetConfig, ExtCommunitySetConfig, KeyChain, KeyChainScope,
+    KeyChainSetConfig, LargeCommunitySetConfig, PolicyConfig, PolicyList, PrefixSet,
+    PrefixSetConfig, policy_entry_sync,
 };
 
 pub type ShowCallback = fn(&Policy, Args, bool) -> Result<String, Error>;
@@ -20,6 +21,15 @@ pub enum PolicyType {
     PrefixSetOut,
     PolicyListIn,
     PolicyListOut,
+    /// Subscription to a named `/key-chains/key-chain <name>`. The
+    /// inner `KeyChainScope` lets the subscribed protocol
+    /// demultiplex updates back to the right per-link / per-neighbor
+    /// / per-IS-IS-scope container when its `process_policy_msg`
+    /// handler fires. See `policy::keychain` for the registry.
+    ///
+    /// PR 1: declared but never constructed (no subscriber yet).
+    #[allow(dead_code)]
+    KeyChain(KeyChainScope),
 }
 
 #[derive(Debug)]
@@ -62,6 +72,16 @@ pub enum PolicyRx {
         policy_type: PolicyType,
         policy_list: Option<PolicyList>,
     },
+    /// A `/key-chains/key-chain <name>` was added, edited, or
+    /// removed. `key_chain == None` means remove. `policy_type`
+    /// always carries `PolicyType::KeyChain(scope)` so the receiver
+    /// can route the update to the right per-subsystem container.
+    KeyChain {
+        name: String,
+        ident: usize,
+        policy_type: PolicyType,
+        key_chain: Option<KeyChain>,
+    },
 }
 
 #[allow(dead_code)]
@@ -77,14 +97,33 @@ impl PolicyRxChannel {
     }
 }
 
+/// Notifications a per-set commit path fires when an entry changes.
+///
+/// Each commit phase (prefix-set, policy-list, key-chain, ...)
+/// constructs a syncer scoped to its own watch map and calls only
+/// the relevant subset of methods. Default no-op bodies let a syncer
+/// implement just the methods it needs without re-declaring the
+/// others — keeps PolicySyncer / KeyChainSyncer focused.
 pub trait Syncer {
-    fn prefix_set_update(&self, name: &str, prefix_set: &PrefixSet);
-    fn prefix_set_remove(&self, name: &str);
-    fn policy_list_update(&self, name: &str, policy_list: &PolicyList);
-    fn policy_list_remove(&self, name: &str);
+    fn prefix_set_update(&self, _name: &str, _prefix_set: &PrefixSet) {}
+    fn prefix_set_remove(&self, _name: &str) {}
+    fn policy_list_update(&self, _name: &str, _policy_list: &PolicyList) {}
+    fn policy_list_remove(&self, _name: &str) {}
+    fn key_chain_update(&self, _name: &str, _key_chain: &KeyChain) {}
+    fn key_chain_remove(&self, _name: &str) {}
 }
 
 pub struct PolicySyncer<'a> {
+    watch_map: &'a BTreeMap<String, Vec<PolicyWatch>>,
+    clients: &'a BTreeMap<String, UnboundedSender<PolicyRx>>,
+}
+
+/// `Syncer` used by the key-chain commit path. Unlike prefix-set /
+/// policy-list, key-chain watchers can come from multiple distinct
+/// `KeyChainScope`s (per-OSPF-link, per-BGP-neighbor, ...). The
+/// `policy_type` carried on each `PolicyWatch` already encodes the
+/// scope, so we just thread it through unchanged.
+pub struct KeyChainSyncer<'a> {
     watch_map: &'a BTreeMap<String, Vec<PolicyWatch>>,
     clients: &'a BTreeMap<String, UnboundedSender<PolicyRx>>,
 }
@@ -156,6 +195,40 @@ impl<'a> Syncer for PolicySyncer<'a> {
     }
 }
 
+impl<'a> Syncer for KeyChainSyncer<'a> {
+    fn key_chain_update(&self, name: &str, key_chain: &KeyChain) {
+        if let Some(watches) = self.watch_map.get(name) {
+            for watch in watches {
+                if let Some(tx) = self.clients.get(&watch.proto) {
+                    let msg = PolicyRx::KeyChain {
+                        name: name.to_string(),
+                        ident: watch.ident,
+                        policy_type: watch.policy_type,
+                        key_chain: Some(key_chain.clone()),
+                    };
+                    let _ = tx.send(msg);
+                }
+            }
+        }
+    }
+
+    fn key_chain_remove(&self, name: &str) {
+        if let Some(watches) = self.watch_map.get(name) {
+            for watch in watches {
+                if let Some(tx) = self.clients.get(&watch.proto) {
+                    let msg = PolicyRx::KeyChain {
+                        name: name.to_string(),
+                        ident: watch.ident,
+                        policy_type: watch.policy_type,
+                        key_chain: None,
+                    };
+                    let _ = tx.send(msg);
+                }
+            }
+        }
+    }
+}
+
 pub struct Policy {
     pub tx: UnboundedSender<Message>,
     pub rx: UnboundedReceiver<Message>,
@@ -168,9 +241,15 @@ pub struct Policy {
     pub ext_community_config: ExtCommunitySetConfig,
     pub large_community_config: LargeCommunitySetConfig,
     pub as_path_config: AsPathSetConfig,
+    /// Canonical RFC 8177 key-chain registry. PR 1 stores entries
+    /// but has no subscribers — OSPF and BGP still parse
+    /// `/key-chains/...` into their own per-daemon copies. PRs 2–4
+    /// migrate each protocol onto this registry.
+    pub key_chain_config: KeyChainSetConfig,
     pub clients: BTreeMap<String, UnboundedSender<PolicyRx>>,
     pub watch_prefix: BTreeMap<String, Vec<PolicyWatch>>,
     pub watch_policy: BTreeMap<String, Vec<PolicyWatch>>,
+    pub watch_keychain: BTreeMap<String, Vec<PolicyWatch>>,
 }
 
 #[derive(Debug)]
@@ -195,9 +274,11 @@ impl Policy {
             ext_community_config: ExtCommunitySetConfig::new(),
             large_community_config: LargeCommunitySetConfig::new(),
             as_path_config: AsPathSetConfig::new(),
+            key_chain_config: KeyChainSetConfig::new(),
             clients: BTreeMap::new(),
             watch_prefix: BTreeMap::new(),
             watch_policy: BTreeMap::new(),
+            watch_keychain: BTreeMap::new(),
         };
         policy.show_build();
         policy
@@ -254,6 +335,25 @@ impl Policy {
                         };
                         self.watch_policy.entry(name).or_default().push(watch);
                     }
+                    PolicyType::KeyChain(_) => {
+                        if let Some(kc) = self.key_chain_config.config.get(&name)
+                            && let Some(tx) = self.clients.get(&proto)
+                        {
+                            let msg = PolicyRx::KeyChain {
+                                name: name.clone(),
+                                ident,
+                                policy_type,
+                                key_chain: Some(kc.clone()),
+                            };
+                            let _ = tx.send(msg);
+                        }
+                        let watch = PolicyWatch {
+                            proto,
+                            ident,
+                            policy_type,
+                        };
+                        self.watch_keychain.entry(name).or_default().push(watch);
+                    }
                 }
             }
             Message::Unregister {
@@ -265,6 +365,7 @@ impl Policy {
                 let map = match policy_type {
                     PolicyType::PrefixSetIn | PolicyType::PrefixSetOut => &mut self.watch_prefix,
                     PolicyType::PolicyListIn | PolicyType::PolicyListOut => &mut self.watch_policy,
+                    PolicyType::KeyChain(_) => &mut self.watch_keychain,
                 };
                 if let Some(watches) = map.get_mut(&name) {
                     watches.retain(|w| {
@@ -294,6 +395,8 @@ impl Policy {
                     let _ = self.large_community_config.exec(path, args, msg.op);
                 } else if path.as_str().starts_with("/as-path-set") {
                     let _ = self.as_path_config.exec(path, args, msg.op);
+                } else if path.as_str().starts_with("/key-chains") {
+                    let _ = self.key_chain_config.exec(path, args, msg.op);
                 }
             }
             ConfigOp::CommitEnd => {
@@ -326,6 +429,18 @@ impl Policy {
                     &mut self.prefix_config.config,
                     &mut self.prefix_config.cache,
                     syncer,
+                );
+                // Sync key-chain. No cascade: key-chains aren't
+                // referenced from any other policy entity, so a chain
+                // edit only fans out to its direct subscribers.
+                let kc_syncer = KeyChainSyncer {
+                    watch_map: &self.watch_keychain,
+                    clients: &self.clients,
+                };
+                KeyChainSetConfig::commit(
+                    &mut self.key_chain_config.config,
+                    &mut self.key_chain_config.cache,
+                    kc_syncer,
                 );
                 // Sync community-set.
                 self.community_config.commit();

--- a/zebra-rs/src/policy/keychain/config.rs
+++ b/zebra-rs/src/policy/keychain/config.rs
@@ -1,0 +1,593 @@
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+
+use crate::config::{Args, ConfigOp};
+
+use super::{CryptoAlgorithm, Key, KeyChain, Lifetime, LifetimeEnd};
+
+#[derive(Default)]
+pub struct KeyChainSetConfig {
+    pub config: BTreeMap<String, KeyChain>,
+    pub cache: BTreeMap<String, KeyChain>,
+    builder: ConfigBuilder,
+}
+
+impl KeyChainSetConfig {
+    pub fn new() -> Self {
+        Self {
+            config: BTreeMap::new(),
+            cache: BTreeMap::new(),
+            builder: ConfigBuilder::new(),
+        }
+    }
+
+    pub fn exec(&mut self, path: String, mut args: Args, op: ConfigOp) -> Result<()> {
+        const CONFIG_ERR: &str = "missing config handler";
+        const KEY_CHAIN_NAME_ERR: &str = "missing key-chain name arg";
+
+        let handler = self
+            .builder
+            .map
+            .get(&(path.to_string(), op))
+            .context(CONFIG_ERR)?;
+
+        let name = args.string().context(KEY_CHAIN_NAME_ERR)?;
+
+        handler(&mut self.config, &mut self.cache, &name, &mut args)
+    }
+
+    /// Drain the per-commit cache into the canonical map, firing
+    /// `key_chain_update` / `key_chain_remove` on the supplied
+    /// `Syncer`. Mirrors `PrefixSetConfig::commit`.
+    pub fn commit<S: crate::policy::Syncer>(
+        config: &mut BTreeMap<String, KeyChain>,
+        cache: &mut BTreeMap<String, KeyChain>,
+        syncer: S,
+    ) {
+        while let Some((name, kc)) = cache.pop_first() {
+            if kc.delete {
+                syncer.key_chain_remove(&name);
+                config.remove(&name);
+            } else {
+                syncer.key_chain_update(&name, &kc);
+                config.insert(name, kc);
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct ConfigBuilder {
+    path: String,
+    map: BTreeMap<(String, ConfigOp), Handler>,
+}
+
+type Handler = fn(
+    config: &mut BTreeMap<String, KeyChain>,
+    cache: &mut BTreeMap<String, KeyChain>,
+    name: &String,
+    args: &mut Args,
+) -> Result<()>;
+
+fn config_get(map: &BTreeMap<String, KeyChain>, name: &String) -> KeyChain {
+    map.get(name).cloned().unwrap_or_default()
+}
+
+fn config_lookup(map: &BTreeMap<String, KeyChain>, name: &String) -> Option<KeyChain> {
+    map.get(name).cloned()
+}
+
+/// Fetch-or-create the cache entry, seeded from the canonical map.
+/// Used for SET handlers: a new chain or a new leaf inside an existing
+/// chain both want a writeable entry.
+fn cache_get<'a>(
+    config: &'a BTreeMap<String, KeyChain>,
+    cache: &'a mut BTreeMap<String, KeyChain>,
+    name: &'a String,
+) -> Option<&'a mut KeyChain> {
+    if !cache.contains_key(name) {
+        cache.insert(name.to_string(), config_get(config, name));
+    }
+    cache.get_mut(name)
+}
+
+/// Fetch the cache entry, seeded from the canonical map *only if*
+/// it already exists there. Used for DELETE handlers — deleting a
+/// child of a chain that never existed should fail loudly rather
+/// than implicitly resurrect it.
+fn cache_lookup<'a>(
+    config: &'a BTreeMap<String, KeyChain>,
+    cache: &'a mut BTreeMap<String, KeyChain>,
+    name: &'a String,
+) -> Option<&'a mut KeyChain> {
+    if !cache.contains_key(name) {
+        cache.insert(name.to_string(), config_lookup(config, name)?);
+    }
+    let entry = cache.get_mut(name)?;
+    if entry.delete { None } else { Some(entry) }
+}
+
+fn parse_yang_datetime(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|t| t.with_timezone(&chrono::Utc))
+}
+
+/// Replace the end-time half of both send + accept lifetime with
+/// `new_end`. Mirrors the OSPF helper this PR will eventually
+/// supersede: the YANG `case start-end-time` lets `start-date-time`
+/// and one of `no-end-time` / `duration` / `end-date-time` arrive in
+/// any order; if `Always` is still in place we default the start to
+/// UNIX_EPOCH so the bound is well-defined.
+fn set_send_accept_end(key: &mut Key, new_end: LifetimeEnd) {
+    let start = match key.send_lifetime {
+        Lifetime::Window { start, .. } => start,
+        Lifetime::Always => chrono::DateTime::UNIX_EPOCH,
+    };
+    let lt = Lifetime::Window {
+        start,
+        end: new_end,
+    };
+    key.send_lifetime = lt.clone();
+    key.accept_lifetime = lt;
+}
+
+impl ConfigBuilder {
+    pub fn new() -> Self {
+        const CONFIG_ERR: &str = "missing config";
+        const KEY_ID_ERR: &str = "missing key-id";
+        const VALUE_ERR: &str = "missing value";
+
+        ConfigBuilder::default()
+            // /key-chains/key-chain {name}
+            .path("/key-chain")
+            .set(|config, cache, name, _args| {
+                let _ = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                if let Some(kc) = cache.get_mut(name) {
+                    kc.delete = true;
+                } else {
+                    let mut kc = config_lookup(config, name).context(CONFIG_ERR)?;
+                    kc.delete = true;
+                    cache.insert(name.to_string(), kc);
+                }
+                Ok(())
+            })
+            // /key-chains/key-chain {name}/description
+            .path("/key-chain/description")
+            .set(|config, cache, name, args| {
+                let desc = args.string().context(VALUE_ERR)?;
+                let kc = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                kc.description = Some(desc);
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                let kc = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                kc.description = None;
+                Ok(())
+            })
+            // /key-chains/key-chain {name}/key {key-id}
+            .path("/key-chain/key")
+            .set(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let kc = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                kc.keys.entry(key_id).or_default();
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let kc = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                kc.keys.remove(&key_id);
+                Ok(())
+            })
+            // /key-chains/key-chain {name}/key {key-id}/crypto-algorithm
+            .path("/key-chain/key/crypto-algorithm")
+            .set(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let algo_name = args.string().context(VALUE_ERR)?;
+                let kc = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                let key = kc.keys.entry(key_id).or_default();
+                key.algo = CryptoAlgorithm::from_identity(&algo_name);
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let kc = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                if let Some(k) = kc.keys.get_mut(&key_id) {
+                    k.algo = None;
+                }
+                Ok(())
+            })
+            // /key-chains/key-chain {name}/key {key-id}/key-string/keystring
+            .path("/key-chain/key/key-string/keystring")
+            .set(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let s = args.string().context(VALUE_ERR)?;
+                let kc = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                let key = kc.keys.entry(key_id).or_default();
+                key.key_material = s.into_bytes();
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let kc = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                if let Some(k) = kc.keys.get_mut(&key_id) {
+                    k.key_material.clear();
+                }
+                Ok(())
+            })
+            // /key-chains/key-chain {name}/key {key-id}/key-string/hexadecimal-string
+            .path("/key-chain/key/key-string/hexadecimal-string")
+            .set(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let hex_in = args.string().context(VALUE_ERR)?;
+                let cleaned: String = hex_in
+                    .chars()
+                    .filter(|c| !c.is_whitespace() && *c != ':')
+                    .collect();
+                // Mirror BGP's existing behavior: a malformed hex
+                // string drops silently so the rest of the commit
+                // still applies. The YANG layer is expected to do
+                // the strict validation.
+                let Ok(decoded) = hex::decode(&cleaned) else {
+                    return Ok(());
+                };
+                let kc = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                let key = kc.keys.entry(key_id).or_default();
+                key.key_material = decoded;
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let kc = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                if let Some(k) = kc.keys.get_mut(&key_id) {
+                    k.key_material.clear();
+                }
+                Ok(())
+            })
+            // /key-chains/key-chain {name}/key {key-id}/send-id
+            .path("/key-chain/key/send-id")
+            .set(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let v = args.u8().context(VALUE_ERR)?;
+                let kc = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                let key = kc.keys.entry(key_id).or_default();
+                key.send_id = Some(v);
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let kc = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                if let Some(k) = kc.keys.get_mut(&key_id) {
+                    k.send_id = None;
+                }
+                Ok(())
+            })
+            // /key-chains/key-chain {name}/key {key-id}/recv-id
+            .path("/key-chain/key/recv-id")
+            .set(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let v = args.u8().context(VALUE_ERR)?;
+                let kc = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                let key = kc.keys.entry(key_id).or_default();
+                key.recv_id = Some(v);
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let kc = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                if let Some(k) = kc.keys.get_mut(&key_id) {
+                    k.recv_id = None;
+                }
+                Ok(())
+            })
+            // /key-chains/key-chain {name}/key {key-id}/lifetime/send-accept-lifetime/always
+            .path("/key-chain/key/lifetime/send-accept-lifetime/always")
+            .set(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let kc = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                let key = kc.keys.entry(key_id).or_default();
+                key.send_lifetime = Lifetime::Always;
+                key.accept_lifetime = Lifetime::Always;
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let kc = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                if let Some(k) = kc.keys.get_mut(&key_id) {
+                    k.send_lifetime = Lifetime::Always;
+                    k.accept_lifetime = Lifetime::Always;
+                }
+                Ok(())
+            })
+            // /key-chains/key-chain {name}/key {key-id}/lifetime/send-accept-lifetime/start-date-time
+            .path("/key-chain/key/lifetime/send-accept-lifetime/start-date-time")
+            .set(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let ts = args.string().context(VALUE_ERR)?;
+                let start = parse_yang_datetime(&ts).context(VALUE_ERR)?;
+                let kc = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                let key = kc.keys.entry(key_id).or_default();
+                let preserved_end = match &key.send_lifetime {
+                    Lifetime::Window { end, .. } => end.clone(),
+                    Lifetime::Always => LifetimeEnd::NoEnd,
+                };
+                let lt = Lifetime::Window {
+                    start,
+                    end: preserved_end,
+                };
+                key.send_lifetime = lt.clone();
+                key.accept_lifetime = lt;
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let kc = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                if let Some(k) = kc.keys.get_mut(&key_id) {
+                    k.send_lifetime = Lifetime::Always;
+                    k.accept_lifetime = Lifetime::Always;
+                }
+                Ok(())
+            })
+            // /key-chains/key-chain {name}/key {key-id}/lifetime/send-accept-lifetime/no-end-time
+            .path("/key-chain/key/lifetime/send-accept-lifetime/no-end-time")
+            .set(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let kc = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                let key = kc.keys.entry(key_id).or_default();
+                set_send_accept_end(key, LifetimeEnd::NoEnd);
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let kc = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                if let Some(k) = kc.keys.get_mut(&key_id) {
+                    set_send_accept_end(k, LifetimeEnd::NoEnd);
+                }
+                Ok(())
+            })
+            // /key-chains/key-chain {name}/key {key-id}/lifetime/send-accept-lifetime/end-date-time
+            .path("/key-chain/key/lifetime/send-accept-lifetime/end-date-time")
+            .set(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let ts = args.string().context(VALUE_ERR)?;
+                let end = parse_yang_datetime(&ts).context(VALUE_ERR)?;
+                let kc = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                let key = kc.keys.entry(key_id).or_default();
+                set_send_accept_end(key, LifetimeEnd::EndAt(end));
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let kc = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                if let Some(k) = kc.keys.get_mut(&key_id) {
+                    set_send_accept_end(k, LifetimeEnd::NoEnd);
+                }
+                Ok(())
+            })
+            // /key-chains/key-chain {name}/key {key-id}/lifetime/send-accept-lifetime/duration
+            .path("/key-chain/key/lifetime/send-accept-lifetime/duration")
+            .set(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let secs = args.u32().context(VALUE_ERR)?;
+                let kc = cache_get(config, cache, name).context(CONFIG_ERR)?;
+                let key = kc.keys.entry(key_id).or_default();
+                set_send_accept_end(key, LifetimeEnd::Duration(secs));
+                Ok(())
+            })
+            .del(|config, cache, name, args| {
+                let key_id = args.u64().context(KEY_ID_ERR)?;
+                let kc = cache_lookup(config, cache, name).context(CONFIG_ERR)?;
+                if let Some(k) = kc.keys.get_mut(&key_id) {
+                    set_send_accept_end(k, LifetimeEnd::NoEnd);
+                }
+                Ok(())
+            })
+    }
+
+    pub fn path(mut self, path: &str) -> Self {
+        let prefix = "/key-chains";
+        self.path = format!("{prefix}{path}");
+        self
+    }
+
+    pub fn set(mut self, func: Handler) -> Self {
+        self.map.insert((self.path.clone(), ConfigOp::Set), func);
+        self
+    }
+
+    pub fn del(mut self, func: Handler) -> Self {
+        self.map.insert((self.path.clone(), ConfigOp::Delete), func);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::collections::VecDeque;
+
+    use super::*;
+    use crate::policy::{KeyChain, PolicyList, PrefixSet, Syncer};
+
+    fn args(parts: &[&str]) -> Args {
+        Args(parts.iter().map(|s| s.to_string()).collect::<VecDeque<_>>())
+    }
+
+    #[derive(Default)]
+    struct CollectingSyncer {
+        updates: RefCell<Vec<(String, KeyChain)>>,
+        removes: RefCell<Vec<String>>,
+    }
+
+    impl Syncer for CollectingSyncer {
+        fn prefix_set_update(&self, _: &str, _: &PrefixSet) {}
+        fn prefix_set_remove(&self, _: &str) {}
+        fn policy_list_update(&self, _: &str, _: &PolicyList) {}
+        fn policy_list_remove(&self, _: &str) {}
+        fn key_chain_update(&self, name: &str, kc: &KeyChain) {
+            self.updates
+                .borrow_mut()
+                .push((name.to_string(), kc.clone()));
+        }
+        fn key_chain_remove(&self, name: &str) {
+            self.removes.borrow_mut().push(name.to_string());
+        }
+    }
+
+    fn commit(cfg: &mut KeyChainSetConfig) -> CollectingSyncer {
+        let syncer = CollectingSyncer::default();
+        KeyChainSetConfig::commit(&mut cfg.config, &mut cfg.cache, &syncer);
+        syncer
+    }
+
+    impl Syncer for &CollectingSyncer {
+        fn key_chain_update(&self, name: &str, kc: &KeyChain) {
+            (*self).key_chain_update(name, kc)
+        }
+        fn key_chain_remove(&self, name: &str) {
+            (*self).key_chain_remove(name)
+        }
+    }
+
+    /// Setting a `/key-chains/key-chain` root then a leaf
+    /// underneath should land a single populated entry in the
+    /// canonical map and fire one Syncer update.
+    #[test]
+    fn create_then_set_keystring_lands_one_update() {
+        let mut cfg = KeyChainSetConfig::new();
+        cfg.exec(
+            "/key-chains/key-chain".into(),
+            args(&["chain1"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        cfg.exec(
+            "/key-chains/key-chain/key".into(),
+            args(&["chain1", "1"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        cfg.exec(
+            "/key-chains/key-chain/key/crypto-algorithm".into(),
+            args(&["chain1", "1", "hmac-sha-256"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        cfg.exec(
+            "/key-chains/key-chain/key/key-string/keystring".into(),
+            args(&["chain1", "1", "secret"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+
+        let s = commit(&mut cfg);
+        assert!(s.removes.borrow().is_empty());
+        let updates = s.updates.borrow();
+        assert_eq!(updates.len(), 1);
+        let (name, kc) = &updates[0];
+        assert_eq!(name, "chain1");
+        let key = kc.keys.get(&1).unwrap();
+        assert_eq!(key.algo, Some(CryptoAlgorithm::HmacSha256));
+        assert_eq!(key.key_material, b"secret");
+        assert!(cfg.config.contains_key("chain1"));
+        assert!(cfg.cache.is_empty(), "cache must drain on commit");
+    }
+
+    /// Deleting the chain root collapses cleanly into one
+    /// Syncer remove notification, and removes the entry from
+    /// the canonical map.
+    #[test]
+    fn delete_chain_fires_remove_and_drops_entry() {
+        let mut cfg = KeyChainSetConfig::new();
+        cfg.exec(
+            "/key-chains/key-chain".into(),
+            args(&["chain1"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        let _ = commit(&mut cfg);
+        assert!(cfg.config.contains_key("chain1"));
+
+        cfg.exec(
+            "/key-chains/key-chain".into(),
+            args(&["chain1"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        let s = commit(&mut cfg);
+        assert_eq!(*s.removes.borrow(), vec!["chain1".to_string()]);
+        assert!(s.updates.borrow().is_empty());
+        assert!(!cfg.config.contains_key("chain1"));
+    }
+
+    /// hexadecimal-string variant decodes hex into raw bytes.
+    #[test]
+    fn hex_string_decodes_into_key_material() {
+        let mut cfg = KeyChainSetConfig::new();
+        cfg.exec("/key-chains/key-chain".into(), args(&["c"]), ConfigOp::Set)
+            .unwrap();
+        cfg.exec(
+            "/key-chains/key-chain/key".into(),
+            args(&["c", "1"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        cfg.exec(
+            "/key-chains/key-chain/key/key-string/hexadecimal-string".into(),
+            args(&["c", "1", "deadbeef"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        let _ = commit(&mut cfg);
+        let key = cfg.config.get("c").unwrap().keys.get(&1).unwrap();
+        assert_eq!(key.key_material, vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    /// start-date-time + duration arriving in two separate handler
+    /// calls (the YANG callbacks fire independently) compose into a
+    /// single Window lifetime — the `set_send_accept_end` helper
+    /// must preserve the prior start when only the end changes.
+    #[test]
+    fn start_then_duration_compose_into_window() {
+        let mut cfg = KeyChainSetConfig::new();
+        cfg.exec("/key-chains/key-chain".into(), args(&["c"]), ConfigOp::Set)
+            .unwrap();
+        cfg.exec(
+            "/key-chains/key-chain/key".into(),
+            args(&["c", "1"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        cfg.exec(
+            "/key-chains/key-chain/key/lifetime/send-accept-lifetime/start-date-time".into(),
+            args(&["c", "1", "2026-01-01T00:00:00Z"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        cfg.exec(
+            "/key-chains/key-chain/key/lifetime/send-accept-lifetime/duration".into(),
+            args(&["c", "1", "3600"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        let _ = commit(&mut cfg);
+        let key = cfg.config.get("c").unwrap().keys.get(&1).unwrap();
+        match &key.send_lifetime {
+            Lifetime::Window {
+                start,
+                end: LifetimeEnd::Duration(secs),
+            } => {
+                assert_eq!(start.to_rfc3339(), "2026-01-01T00:00:00+00:00");
+                assert_eq!(*secs, 3600);
+            }
+            other => panic!("expected Window+Duration, got {other:?}"),
+        }
+        // send and accept lifetimes are kept in lockstep by the
+        // send-accept-lifetime YANG choice.
+        assert_eq!(key.send_lifetime, key.accept_lifetime);
+    }
+}

--- a/zebra-rs/src/policy/keychain/mod.rs
+++ b/zebra-rs/src/policy/keychain/mod.rs
@@ -1,0 +1,48 @@
+// PR 1 ships the data model + commit plumbing ahead of any consumer.
+// OSPF still parses `/key-chains/...` into its own `Ospf::key_chains`
+// map (PR 2 migrates it); BGP still parses into `Bgp::key_chains`
+// (PR 3 migrates it); IS-IS doesn't reference key-chains today (PR 4).
+// Until those land, several types/variants/methods are declared but
+// not yet referenced — silence dead_code at the module root so the
+// workspace-wide `-D warnings` build stays green.
+#![allow(dead_code)]
+
+//! Shared RFC 8177 key-chain registry.
+//!
+//! This module owns the canonical `/key-chains/...` data model. Today
+//! OSPF and BGP each parse the same YANG subtree into their own
+//! `key_chains` HashMap; the consolidation goal is to make Policy the
+//! single source of truth and have protocols subscribe to the same
+//! Register / PolicyRx pattern used for prefix-set and policy-list.
+//!
+//! This file is the PR 1 skeleton: types + dispatch + commit + Syncer
+//! wiring. No protocol consumes the new path yet — OSPF and BGP keep
+//! their existing `/key-chains/...` callbacks until the per-protocol
+//! migration PRs land. With no subscribers, the new commit path is a
+//! quiet no-op, so behavior is unchanged.
+
+pub mod set;
+pub use set::{CryptoAlgorithm, Key, KeyChain, Lifetime, LifetimeEnd};
+
+pub mod config;
+pub use config::KeyChainSetConfig;
+
+pub mod show;
+
+/// Where a key-chain is referenced from. Carried in
+/// `PolicyType::KeyChain` so a subscriber receiving a `PolicyRx::KeyChain`
+/// can demultiplex updates back to the right per-protocol container
+/// (per-link, per-neighbor, per-IS-IS-scope) using its own `ident`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyChainScope {
+    /// OSPFv2/v3 per-interface `key-chain <name>` leaf.
+    OspfInterface,
+    /// BGP per-neighbor `tcp-ao/key-chain <name>` leaf.
+    BgpNeighbor,
+    /// IS-IS per-interface `hello-authentication/key-chain <name>`.
+    IsisIih,
+    /// IS-IS `/router/isis/area-password/key-chain <name>`.
+    IsisAreaPw,
+    /// IS-IS `/router/isis/domain-password/key-chain <name>`.
+    IsisDomainPw,
+}

--- a/zebra-rs/src/policy/keychain/set.rs
+++ b/zebra-rs/src/policy/keychain/set.rs
@@ -1,0 +1,150 @@
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Duration, Utc};
+
+/// RFC 8177 `crypto-algorithm` identityref values that have an actual
+/// consumer in zebra-rs today. Union of OSPFv2 (RFC 5709 + keyed-MD5)
+/// and BGP TCP-AO (RFC 5926). Protocols filter to their supported
+/// subset at resolve time — selecting an unsupported algorithm yields
+/// a runtime "no usable key" rather than a config-time error so that
+/// a shared chain can carry algorithms used by only one daemon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CryptoAlgorithm {
+    /// Keyed-MD5 (RFC 2328 §D.4 for OSPF; not used by BGP's TCP-AO
+    /// kernel path — BGP MD5 takes a flat password).
+    Md5,
+    /// HMAC-SHA-1-96. RFC 5926 MUST-implement for TCP-AO; RFC 5709
+    /// for OSPFv2.
+    HmacSha1,
+    /// HMAC-SHA-256.
+    HmacSha256,
+    /// HMAC-SHA-384.
+    HmacSha384,
+    /// HMAC-SHA-512.
+    HmacSha512,
+    /// AES-128-CMAC-96. RFC 5926 MUST-implement for TCP-AO.
+    AesCmacPrf128,
+}
+
+impl CryptoAlgorithm {
+    /// Parse the IETF `crypto-algorithm` identityref. Accepts both
+    /// bare (`"hmac-sha-1"`) and prefixed (`"ietf-key-chain:hmac-sha-1"`)
+    /// forms — the libyang dispatch may deliver either depending on
+    /// how the user typed it.
+    pub fn from_identity(name: &str) -> Option<Self> {
+        let bare = name.rsplit(':').next().unwrap_or(name);
+        match bare {
+            "md5" => Some(Self::Md5),
+            "hmac-sha-1" => Some(Self::HmacSha1),
+            "hmac-sha-256" => Some(Self::HmacSha256),
+            "hmac-sha-384" => Some(Self::HmacSha384),
+            "hmac-sha-512" => Some(Self::HmacSha512),
+            "aes-cmac-prf-128" => Some(Self::AesCmacPrf128),
+            _ => None,
+        }
+    }
+}
+
+/// End of a lifetime window — IETF `choice end-time` collapsed to the
+/// cases we actually parse from YANG (`infinite` / `duration` /
+/// `end-date-time`). `NoEnd` is the default while a key is being
+/// incrementally configured; the YANG layer makes `end-time`
+/// mandatory once `start-date-time` is set.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub enum LifetimeEnd {
+    /// `no-end-time` — key stays active forever after start.
+    #[default]
+    NoEnd,
+    /// `duration` (seconds from start).
+    Duration(u32),
+    /// `end-date-time` — explicit absolute end.
+    EndAt(DateTime<Utc>),
+}
+
+/// Send-lifetime / accept-lifetime window. IETF YANG models this as
+/// an outer `choice lifetime { case always | case start-end-time }`.
+/// `Always` is the natural default when neither `always` nor
+/// `start-date-time` has been configured.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub enum Lifetime {
+    /// `case always { leaf always { type empty; } }` — matches any
+    /// time, the RFC 8177 "no time bounds" shorthand.
+    #[default]
+    Always,
+    /// `case start-end-time { leaf start-date-time; choice end-time; }`.
+    Window {
+        start: DateTime<Utc>,
+        end: LifetimeEnd,
+    },
+}
+
+impl Lifetime {
+    /// Is `now` inside this lifetime window?
+    pub fn is_active(&self, now: DateTime<Utc>) -> bool {
+        match self {
+            Self::Always => true,
+            Self::Window { start, end } => {
+                if now < *start {
+                    return false;
+                }
+                match end {
+                    LifetimeEnd::NoEnd => true,
+                    LifetimeEnd::EndAt(t) => now < *t,
+                    LifetimeEnd::Duration(secs) => {
+                        let limit = *start + Duration::seconds(i64::from(*secs));
+                        now < limit
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// One key inside a chain. `algo` is `Option` because the YANG
+/// `crypto-algorithm` leaf is set incrementally — a key may exist
+/// transiently with `key-string` written but no algorithm yet, and
+/// protocol-side resolution should treat algorithm-less keys as
+/// unusable rather than crashing on `unwrap`.
+///
+/// `send_id`/`recv_id` are RFC 5925 §3.1 (TCP-AO) / RFC 5310 §3.1
+/// (IS-IS generic-crypto) Key IDs. OSPFv2 carries an 8-bit key-id
+/// in the cryptographic-auth header that doubles as both send and
+/// receive identifier, so it ignores these fields and uses the
+/// chain-level key-id key directly.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Key {
+    pub algo: Option<CryptoAlgorithm>,
+    /// Raw key bytes. ASCII when the YANG leaf is `keystring`,
+    /// hex-decoded when it's `hexadecimal-string`. Empty until set.
+    pub key_material: Vec<u8>,
+    pub send_id: Option<u8>,
+    pub recv_id: Option<u8>,
+    pub send_lifetime: Lifetime,
+    pub accept_lifetime: Lifetime,
+}
+
+impl Key {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Named RFC 8177 key chain. Keys are ordered by key-id (YANG-typed
+/// as `uint64`; individual protocols narrow to u8/u16 at resolve
+/// time).
+///
+/// `delete` is the cache-pattern flag inherited from the prefix-set /
+/// community-set modules: the commit step inspects it to decide
+/// whether to remove or insert the entry into the canonical map.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct KeyChain {
+    pub description: Option<String>,
+    pub keys: BTreeMap<u64, Key>,
+    pub delete: bool,
+}
+
+impl KeyChain {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/zebra-rs/src/policy/keychain/show.rs
+++ b/zebra-rs/src/policy/keychain/show.rs
@@ -1,0 +1,81 @@
+use std::fmt::Write;
+
+use anyhow::{Context, Error};
+
+use crate::config::Args;
+use crate::policy::Policy;
+
+use super::{CryptoAlgorithm, Lifetime, LifetimeEnd};
+
+pub fn key_chains(policy: &Policy, _args: Args, _json: bool) -> Result<String, Error> {
+    let mut buf = String::new();
+    for (name, kc) in policy.key_chain_config.config.iter() {
+        write_chain(&mut buf, name, kc)?;
+    }
+    Ok(buf)
+}
+
+pub fn key_chain_name(policy: &Policy, mut args: Args, _json: bool) -> Result<String, Error> {
+    let name = args.string().context("missing key-chain name")?;
+    let kc = policy
+        .key_chain_config
+        .config
+        .get(&name)
+        .context(format!("key-chain '{}' not found", name))?;
+    let mut buf = String::new();
+    write_chain(&mut buf, &name, kc)?;
+    Ok(buf)
+}
+
+fn write_chain(buf: &mut String, name: &str, kc: &super::KeyChain) -> Result<(), std::fmt::Error> {
+    writeln!(buf, "key-chain: {}", name)?;
+    if let Some(desc) = &kc.description {
+        writeln!(buf, "  description: {}", desc)?;
+    }
+    for (id, key) in kc.keys.iter() {
+        writeln!(buf, "  key {}:", id)?;
+        if let Some(algo) = key.algo {
+            writeln!(buf, "    algo: {}", algo_name(algo))?;
+        }
+        writeln!(buf, "    key-bytes: {}", key.key_material.len())?;
+        if let Some(s) = key.send_id {
+            writeln!(buf, "    send-id: {}", s)?;
+        }
+        if let Some(r) = key.recv_id {
+            writeln!(buf, "    recv-id: {}", r)?;
+        }
+        writeln!(
+            buf,
+            "    send-lifetime: {}",
+            fmt_lifetime(&key.send_lifetime)
+        )?;
+        writeln!(
+            buf,
+            "    accept-lifetime: {}",
+            fmt_lifetime(&key.accept_lifetime)
+        )?;
+    }
+    Ok(())
+}
+
+fn algo_name(a: CryptoAlgorithm) -> &'static str {
+    match a {
+        CryptoAlgorithm::Md5 => "md5",
+        CryptoAlgorithm::HmacSha1 => "hmac-sha-1",
+        CryptoAlgorithm::HmacSha256 => "hmac-sha-256",
+        CryptoAlgorithm::HmacSha384 => "hmac-sha-384",
+        CryptoAlgorithm::HmacSha512 => "hmac-sha-512",
+        CryptoAlgorithm::AesCmacPrf128 => "aes-cmac-prf-128",
+    }
+}
+
+fn fmt_lifetime(lt: &Lifetime) -> String {
+    match lt {
+        Lifetime::Always => "always".to_string(),
+        Lifetime::Window { start, end } => match end {
+            LifetimeEnd::NoEnd => format!("{} → no-end", start),
+            LifetimeEnd::Duration(s) => format!("{} +{}s", start, s),
+            LifetimeEnd::EndAt(t) => format!("{} → {}", start, t),
+        },
+    }
+}

--- a/zebra-rs/src/policy/mod.rs
+++ b/zebra-rs/src/policy/mod.rs
@@ -28,4 +28,7 @@ pub use large_community::*;
 pub mod aspath;
 pub use aspath::*;
 
+pub mod keychain;
+pub use keychain::{KeyChain, KeyChainScope, KeyChainSetConfig};
+
 pub mod show;

--- a/zebra-rs/src/policy/show.rs
+++ b/zebra-rs/src/policy/show.rs
@@ -4,6 +4,7 @@ use crate::policy::inst::ShowCallback;
 use super::aspath;
 use super::community;
 use super::ext_community;
+use super::keychain;
 use super::large_community;
 use super::policy_list;
 use super::prefix;
@@ -40,5 +41,7 @@ impl Policy {
         );
         self.show_add("/show/as-path-set", aspath::show::as_path_set);
         self.show_add("/show/as-path-set/name", aspath::show::as_path_set_name);
+        self.show_add("/show/key-chains", keychain::show::key_chains);
+        self.show_add("/show/key-chains/name", keychain::show::key_chain_name);
     }
 }


### PR DESCRIPTION
## Summary

First step of consolidating the `/key-chains/...` data model that OSPF and BGP currently parse into two separate per-daemon maps. Lands the canonical registry inside `policy/` behind the existing Subscribe / Register / PolicyRx pattern (mirrors `prefix-set`) so PRs 2/3/4 can migrate OSPF, BGP, and IS-IS onto it without further plumbing churn.

- `policy::keychain::{KeyChain, Key, Lifetime, LifetimeEnd, CryptoAlgorithm, KeyChainScope}` unify the OSPF + BGP data model (algorithm union, lifetime windows, send/recv IDs).
- `KeyChainSetConfig` parses every leaf currently handled by `ospf/config.rs` + `bgp/config.rs` (superset).
- `PolicyType::KeyChain(scope)`, `PolicyRx::KeyChain`, `Syncer` trait defaults, `KeyChainSyncer`, and `Policy::watch_keychain` round out the `Policy` actor; `/key-chains` paths now route through `Policy`'s `exec`/`commit_end` and fan out only to subscribed protocols.
- Nothing subscribes yet, so OSPF and BGP continue to maintain `Ospf::key_chains` / `Bgp::key_chains` via their existing callbacks. Behavior is unchanged — this PR just makes the next ones small.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo build -p zebra-rs`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bin zebra-rs policy::` (62 prior + 4 new keychain tests, all green)
- [ ] CI

Generated with [Claude Code](https://claude.com/claude-code)