### PR TITLE
vty: update vty/additions copyright to 2026 zebra-rs project

### DIFF
--- a/vty/additions/vty.sh
+++ b/vty/additions/vty.sh
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 zebra-rs project.
+# Copyright (C) 2026 zebra-rs project.
 #
 # This software is free software: you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as

--- a/vty/additions/vtysh.c
+++ b/vty/additions/vtysh.c
@@ -1,6 +1,6 @@
 /* vtysh.c -- zebra shell extension for bash. */
 
-/* Copyright (C) 2024 Zebra Project.
+/* Copyright (C) 2026 zebra-rs project.
 
    This file is part of GNU Bash, the Bourne Again SHell.
 

--- a/vty/additions/vtysh.h
+++ b/vty/additions/vtysh.h
@@ -1,6 +1,6 @@
 /* vtysh.h -- Zebra shell extension for bash. */
 
-/* Copyright (C) 2024 Zebra Project.
+/* Copyright (C) 2026 zebra-rs project.
 
    This file is part of GNU Bash, the Bourne Again SHell.
 


### PR DESCRIPTION
## Summary
- Bump copyright header in `vty/additions/vtysh.c`, `vtysh.h`, and `vty.sh` to "Copyright (C) 2026 zebra-rs project."
- Normalizes the older "Zebra Project" / 2024 / 2025 strings to a single current attribution.

## Test plan
- [x] Header-only change; no functional impact.
- [ ] CI gates (fmt/clippy/test) green.

Generated with [Claude Code](https://claude.com/claude-code)