### PR TITLE
bgp: subscribe to shared policy key-chain registry (PR 3/5)

### DIFF
--- a/zebra-rs/src/bgp/auth.rs
+++ b/zebra-rs/src/bgp/auth.rs
@@ -6,7 +6,6 @@
 // configuration with MD5 / AO still parses but does not enforce
 // authentication. This matches zebra-rs's Linux-primary posture.
 
-use std::collections::BTreeMap;
 use std::io;
 use std::net::IpAddr;
 
@@ -270,91 +269,29 @@ pub fn del_tcp_ao_key(_fd: i32, _peer_ip: IpAddr, _send_id: u8, _recv_id: u8) ->
 }
 
 // =========================================================
-// RFC 8177 key-chain data model used by TCP-AO (zebra-bgp-auth
-// YANG `key-chains` container).
+// TCP-AO key-chain resolution.
+//
+// The on-disk `/key-chains/...` data model lives in
+// `policy::keychain` and is pushed to BGP as `PolicyRx::KeyChain`
+// snapshots. The types below are just the BGP-side bindings that
+// translate one of those policy keys into the kernel
+// setsockopt struct.
 // =========================================================
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CryptoAlgorithm {
-    /// RFC 5926 MUST-implement: HMAC-SHA-1-96. Linux alg name
-    /// "hmac(sha1)".
-    HmacSha1,
-    /// RFC 5926 MUST-implement: AES-128-CMAC-96. Linux alg name
-    /// "cmac(aes128)".
-    AesCmacPrf128,
-    /// Other RFC 8177 identities we recognize but may not implement
-    /// in the kernel path (e.g. md5 belongs to MD5's key-chain flow
-    /// which zebra-rs does not use — tcp-md5 takes a flat password).
-    Md5,
-    HmacSha256,
-    HmacSha384,
-    HmacSha512,
-}
-
-impl CryptoAlgorithm {
-    pub fn from_identity(name: &str) -> Option<Self> {
-        // Accept both bare and prefixed forms
-        // (e.g. "hmac-sha-1" and "ietf-key-chain:hmac-sha-1").
-        let bare = name.rsplit(':').next().unwrap_or(name);
-        match bare {
-            "hmac-sha-1" => Some(Self::HmacSha1),
-            "aes-cmac-prf-128" => Some(Self::AesCmacPrf128),
-            "md5" => Some(Self::Md5),
-            "hmac-sha-256" => Some(Self::HmacSha256),
-            "hmac-sha-384" => Some(Self::HmacSha384),
-            "hmac-sha-512" => Some(Self::HmacSha512),
-            _ => None,
-        }
-    }
-
-    /// Linux kernel crypto API name passed in `tcp_ao_add.alg_name`.
-    /// Returns `None` for algorithms the kernel path does not
-    /// implement in this module.
-    pub fn linux_alg_name(&self) -> Option<&'static str> {
-        match self {
-            Self::HmacSha1 => Some("hmac(sha1)"),
-            Self::AesCmacPrf128 => Some("cmac(aes128)"),
-            Self::HmacSha256 => Some("hmac(sha256)"),
-            Self::HmacSha384 => Some("hmac(sha384)"),
-            Self::HmacSha512 => Some("hmac(sha512)"),
-            Self::Md5 => None,
-        }
-    }
-}
-
-/// One RFC 8177 key within a chain. Fields mirror zebra-bgp-auth.yang:
-/// `crypto-algorithm`, `key-string/{keystring | hexadecimal-string}`,
-/// `send-id`, `recv-id`.
-#[derive(Debug, Default, Clone)]
-pub struct Key {
-    pub crypto_algorithm: Option<CryptoAlgorithm>,
-    /// Raw key bytes. When the CLI leaf is `keystring`, this holds
-    /// the ASCII bytes; when `hexadecimal-string`, the decoded hex
-    /// bytes. Empty until set.
-    pub key_material: Vec<u8>,
-    pub send_id: Option<u8>,
-    pub recv_id: Option<u8>,
-}
-
-impl Key {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-/// Named RFC 8177 key chain. Keys are ordered by key-id.
-#[derive(Debug, Default, Clone)]
-pub struct KeyChain {
-    pub description: Option<String>,
-    pub keys: BTreeMap<u64, Key>,
-}
-
-impl KeyChain {
-    /// Pick the key to use for new connections. For this initial
-    /// implementation we take the lowest key-id. Lifetime-based
-    /// selection and in-band rollover via RNextKeyID are follow-ups.
-    pub fn active_key(&self) -> Option<&Key> {
-        self.keys.values().next()
+/// Project the shared policy algorithm enum onto the Linux crypto
+/// API name passed in `tcp_ao_add.alg_name`. Returns `None` for
+/// algorithms the kernel path doesn't implement here — `Md5` in
+/// particular belongs to TCP-MD5's flat-password flow (RFC 2385),
+/// not TCP-AO's key-chain flow, so the resolve falls through.
+pub fn tcp_ao_alg_from_policy(a: crate::policy::CryptoAlgorithm) -> Option<&'static str> {
+    use crate::policy::CryptoAlgorithm as P;
+    match a {
+        P::HmacSha1 => Some("hmac(sha1)"),
+        P::AesCmacPrf128 => Some("cmac(aes128)"),
+        P::HmacSha256 => Some("hmac(sha256)"),
+        P::HmacSha384 => Some("hmac(sha384)"),
+        P::HmacSha512 => Some("hmac(sha512)"),
+        P::Md5 => None,
     }
 }
 
@@ -393,16 +330,18 @@ pub struct ResolvedAoKey {
 
 impl AoConfig {
     /// Resolve `(key-chain name, include-tcp-options)` against the
-    /// daemon's key-chain registry. Returns `None` if the chain is
-    /// missing, has no key, or the active key lacks an algorithm,
+    /// policy-driven snapshot. Picks the lowest key-id (lifetime-
+    /// based selection + in-band rollover via RNextKeyID are
+    /// follow-ups). Returns `None` if the chain is missing, has no
+    /// key, or the chosen key lacks an algorithm BGP can speak,
     /// SendID, RecvID, or has a zero-length material.
     pub fn resolve(
         &self,
-        key_chains: &std::collections::HashMap<String, KeyChain>,
+        key_chains: &std::collections::BTreeMap<String, crate::policy::KeyChain>,
     ) -> Option<ResolvedAoKey> {
         let chain = key_chains.get(&self.key_chain)?;
-        let key = chain.active_key()?;
-        let alg_name = key.crypto_algorithm?.linux_alg_name()?;
+        let (_, key) = chain.keys.iter().next()?;
+        let alg_name = tcp_ao_alg_from_policy(key.algo?)?;
         let send_id = key.send_id?;
         let recv_id = key.recv_id?;
         if key.key_material.is_empty() {

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -10,7 +10,7 @@ use crate::policy;
 use crate::policy::com_list::*;
 use crate::rib::api::FdbEntry;
 
-use super::auth::{AoConfig, CryptoAlgorithm, Key};
+use super::auth::AoConfig;
 use super::peer::BgpTop;
 use super::route_clean;
 use super::{
@@ -1257,7 +1257,7 @@ fn config_peer_tcp_md5_encoding(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
 ///
 /// Called from every TCP-AO callback (peer-side and key-chain-side)
 /// after the change has been absorbed into `Bgp`.
-fn apply_ao_refresh_all(bgp: &mut Bgp) {
+pub(super) fn apply_ao_refresh_all(bgp: &mut Bgp) {
     let fd_v4 = bgp.listen_fd_v4;
     let fd_v6 = bgp.listen_fd_v6;
     // Snapshot key_chains to release the immutable borrow before
@@ -1340,8 +1340,16 @@ fn config_peer_tcp_ao_key_chain(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
         return None;
     };
 
-    {
+    let (peer_ident, prior, new) = {
         let peer = bgp.peers.get_mut(&addr)?;
+        let ident = peer.ident;
+        let prior = peer
+            .config
+            .transport
+            .ao_config
+            .as_ref()
+            .map(|ao| ao.key_chain.clone())
+            .filter(|s| !s.is_empty());
         if op == ConfigOp::Set {
             let chain_name = args.string()?;
             let ao = peer
@@ -1349,12 +1357,26 @@ fn config_peer_tcp_ao_key_chain(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
                 .transport
                 .ao_config
                 .get_or_insert_with(AoConfig::default);
-            ao.key_chain = chain_name;
+            ao.key_chain = chain_name.clone();
+            (ident, prior, Some(chain_name))
         } else {
             peer.config.transport.ao_config = None;
             peer.config.transport.resolved_ao_key = None;
+            (ident, prior, None)
         }
-    }
+    };
+    // Subscribe (or rebind) the peer's interest in the chain so the
+    // policy actor pushes future `PolicyRx::KeyChain` updates for it;
+    // `apply_ao_refresh_all` reconciles the live listener entries
+    // using the snapshot we already have for `Set` cases and for
+    // `Delete`s that need to del a stale MKT.
+    policy_attach_msgs(
+        &bgp.policy_tx,
+        peer_ident,
+        policy::PolicyType::KeyChain(policy::KeyChainScope::BgpNeighbor),
+        prior,
+        new,
+    );
     apply_ao_refresh_all(bgp);
     Some(())
 }
@@ -1383,136 +1405,6 @@ fn config_peer_tcp_ao_include_tcp_options(
             ao.include_tcp_options = args.boolean()?;
         } else {
             ao.include_tcp_options = true;
-        }
-    }
-    apply_ao_refresh_all(bgp);
-    Some(())
-}
-
-// ---------- Key-chain callbacks ----------
-
-fn config_key_chain(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let name = args.string()?;
-    if op == ConfigOp::Set {
-        bgp.key_chains.entry(name).or_default();
-    } else {
-        bgp.key_chains.remove(&name);
-    }
-    apply_ao_refresh_all(bgp);
-    Some(())
-}
-
-fn config_key_chain_description(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let name = args.string()?;
-    let chain = bgp.key_chains.get_mut(&name)?;
-    chain.description = if op == ConfigOp::Set {
-        Some(args.string()?)
-    } else {
-        None
-    };
-    Some(())
-}
-
-fn config_key_chain_key(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let chain_name = args.string()?;
-    let key_id = args.u64()?;
-    {
-        let chain = bgp.key_chains.get_mut(&chain_name)?;
-        if op == ConfigOp::Set {
-            chain.keys.entry(key_id).or_insert_with(Key::new);
-        } else {
-            chain.keys.remove(&key_id);
-        }
-    }
-    apply_ao_refresh_all(bgp);
-    Some(())
-}
-
-fn config_key_chain_key_crypto_algorithm(
-    bgp: &mut Bgp,
-    mut args: Args,
-    op: ConfigOp,
-) -> Option<()> {
-    let chain_name = args.string()?;
-    let key_id = args.u64()?;
-    {
-        let chain = bgp.key_chains.get_mut(&chain_name)?;
-        let key = chain.keys.get_mut(&key_id)?;
-        if op == ConfigOp::Set {
-            let algo = args.string()?;
-            key.crypto_algorithm = CryptoAlgorithm::from_identity(&algo);
-        } else {
-            key.crypto_algorithm = None;
-        }
-    }
-    apply_ao_refresh_all(bgp);
-    Some(())
-}
-
-fn config_key_chain_key_keystring(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let chain_name = args.string()?;
-    let key_id = args.u64()?;
-    {
-        let chain = bgp.key_chains.get_mut(&chain_name)?;
-        let key = chain.keys.get_mut(&key_id)?;
-        if op == ConfigOp::Set {
-            key.key_material = args.string()?.into_bytes();
-        } else {
-            key.key_material.clear();
-        }
-    }
-    apply_ao_refresh_all(bgp);
-    Some(())
-}
-
-fn config_key_chain_key_hex_string(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let chain_name = args.string()?;
-    let key_id = args.u64()?;
-    {
-        let chain = bgp.key_chains.get_mut(&chain_name)?;
-        let key = chain.keys.get_mut(&key_id)?;
-        if op == ConfigOp::Set {
-            let hex = args.string()?;
-            let cleaned: String = hex
-                .chars()
-                .filter(|c| !c.is_whitespace() && *c != ':')
-                .collect();
-            let decoded = hex::decode(&cleaned).ok()?;
-            key.key_material = decoded;
-        } else {
-            key.key_material.clear();
-        }
-    }
-    apply_ao_refresh_all(bgp);
-    Some(())
-}
-
-fn config_key_chain_key_send_id(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let chain_name = args.string()?;
-    let key_id = args.u64()?;
-    {
-        let chain = bgp.key_chains.get_mut(&chain_name)?;
-        let key = chain.keys.get_mut(&key_id)?;
-        if op == ConfigOp::Set {
-            key.send_id = Some(args.u8()?);
-        } else {
-            key.send_id = None;
-        }
-    }
-    apply_ao_refresh_all(bgp);
-    Some(())
-}
-
-fn config_key_chain_key_recv_id(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let chain_name = args.string()?;
-    let key_id = args.u64()?;
-    {
-        let chain = bgp.key_chains.get_mut(&chain_name)?;
-        let key = chain.keys.get_mut(&key_id)?;
-        if op == ConfigOp::Set {
-            key.recv_id = Some(args.u8()?);
-        } else {
-            key.recv_id = None;
         }
     }
     apply_ao_refresh_all(bgp);
@@ -1701,33 +1593,6 @@ impl Bgp {
             config_peer_tcp_ao_include_tcp_options,
         );
 
-        // Key-chains (RFC 8177) for TCP-AO.
-        self.callback_add("/key-chains/key-chain", config_key_chain);
-        self.callback_add(
-            "/key-chains/key-chain/description",
-            config_key_chain_description,
-        );
-        self.callback_add("/key-chains/key-chain/key", config_key_chain_key);
-        self.callback_add(
-            "/key-chains/key-chain/key/crypto-algorithm",
-            config_key_chain_key_crypto_algorithm,
-        );
-        self.callback_add(
-            "/key-chains/key-chain/key/key-string/keystring",
-            config_key_chain_key_keystring,
-        );
-        self.callback_add(
-            "/key-chains/key-chain/key/key-string/hexadecimal-string",
-            config_key_chain_key_hex_string,
-        );
-        self.callback_add(
-            "/key-chains/key-chain/key/send-id",
-            config_key_chain_key_send_id,
-        );
-        self.callback_add(
-            "/key-chains/key-chain/key/recv-id",
-            config_key_chain_key_recv_id,
-        );
         self.callback_peer("/afi-safi/enabled", config_afi_safi);
         self.callback_peer("/afi-safi/add-path", config_add_path);
         self.callback_peer("/afi-safi/graceful-restart/enabled", config_restart);

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -274,10 +274,13 @@ pub struct Bgp {
     // "Passive vs active side placement".
     pub listen_fd_v4: Option<std::os::fd::RawFd>,
     pub listen_fd_v6: Option<std::os::fd::RawFd>,
-    // RFC 8177 key-chain registry, indexed by chain name. Populated
-    // by config callbacks for /key-chains/... and referenced from a
-    // peer's AoConfig.key_chain leafref.
-    pub key_chains: HashMap<String, super::auth::KeyChain>,
+    /// Snapshot of `/key-chains/key-chain <name>` entries pushed
+    /// here by the policy actor via `PolicyRx::KeyChain`. The
+    /// canonical map lives in `policy::Policy`; this is the
+    /// per-neighbor-subscribed view BGP consults when resolving a
+    /// peer's `tcp-ao/key-chain <name>` leafref. Updated by
+    /// `process_policy_msg`.
+    pub key_chains: BTreeMap<String, crate::policy::KeyChain>,
 
     /// IOS-XR-style `neighbor-group` definitions
     /// (zebra-bgp-neighbor-group.yang). Phase-1 storage: each entry
@@ -506,7 +509,7 @@ impl Bgp {
             listen_err: None,
             listen_fd_v4: None,
             listen_fd_v6: None,
-            key_chains: HashMap::new(),
+            key_chains: BTreeMap::new(),
             neighbor_groups: super::neighbor_group::empty_map(),
             color_policy: super::color_policy::ColorPolicy::new(),
             flex_algo_routes: BTreeMap::new(),
@@ -1343,13 +1346,21 @@ impl Bgp {
                     InOut::Output => super::peer::apply_soft_out_peer(self, ident),
                 }
             }
-            // PR 1 skeleton: BGP doesn't subscribe to PolicyType::KeyChain
-            // yet (the per-peer `/.../tcp-ao/key-chain` callback still
-            // mutates `Bgp::key_chains` directly). Once PR 3 lands the
-            // Register/Unregister + snapshot path, this arm gains a real
-            // handler. Until then ignoring the variant keeps the match
-            // exhaustive without affecting behavior.
-            policy::PolicyRx::KeyChain { .. } => {}
+            policy::PolicyRx::KeyChain {
+                name, key_chain, ..
+            } => {
+                // Apply the snapshot delta first so any downstream
+                // resolve() sees the new state. Then reconcile the
+                // TCP-AO MKTs installed on the listening sockets so
+                // a key edit lands on the kernel before the peer's
+                // next SYN arrives.
+                if let Some(kc) = key_chain {
+                    self.key_chains.insert(name, kc);
+                } else {
+                    self.key_chains.remove(&name);
+                }
+                super::config::apply_ao_refresh_all(self);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Migrates BGP TCP-AO off its private `/key-chains/...` parser onto the policy-owned registry introduced in #928 and used by OSPF in #930. The `/key-chains` YANG paths are unchanged from the operator's view, but the data now lives once in `policy::Policy` and is pushed to BGP as `PolicyRx::KeyChain` snapshots — same shape PR 2 used for OSPF.

- Drop `callback_add(\"/key-chains/...\")` registrations and the ~140 lines of `config_key_chain_*` helpers in `bgp/config.rs`.
- Delete `bgp::auth::{CryptoAlgorithm, Key, KeyChain}` — replaced by `policy::keychain`. `AoConfig` + `ResolvedAoKey` stay (TCP-AO-specific). `AoConfig::resolve` now consumes `&BTreeMap<String, policy::KeyChain>` via a `tcp_ao_alg_from_policy` adapter (mirrors PR 2's `policy_algo_to_ospf`) so the shared algorithm enum filters down to the TCP-AO subset the kernel speaks.
- Convert `config_peer_tcp_ao_key_chain` to send `Register` / `Unregister` against the policy actor via the existing `policy_attach_msgs` helper, with the prior chain name captured before mutation so a rename `Unregister`s the right name.
- Replace the PR 1 no-op `PolicyRx::KeyChain` arm in `bgp/inst.rs:process_policy_msg` with a real handler: apply the snapshot delta, then call `apply_ao_refresh_all` (now `pub(super)`) so the listener-side MKTs reconcile before the peer's next SYN arrives.

Net diff: +78 / −263.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo build -p zebra-rs`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bin zebra-rs bgp::` (178 tests)
- [x] `cargo test -p zebra-rs --bin zebra-rs policy::` (66 tests)
- [x] `cargo test -p zebra-rs --bin zebra-rs ospf::` (19 tests — confirm PR 2 still happy alongside this change)
- [ ] CI

Generated with [Claude Code](https://claude.com/claude-code)