### PR TITLE
isis: opt-in policy key-chain for area/domain/IIH auth (PR 4/5)

### DIFF
--- a/zebra-rs/src/config/isis.rs
+++ b/zebra-rs/src/config/isis.rs
@@ -14,7 +14,7 @@ pub fn spawn_isis(config: &ConfigManager) {
     let bfd_client_tx = config.bfd_client_tx.borrow().clone();
     let (rib_client, rib_rx) = config.subscribe_to_rib("isis");
     let ctx = ProtoContext::default_table(rib_client);
-    let isis = inst::Isis::new(ctx, rib_rx, bfd_client_tx);
+    let isis = inst::Isis::new(ctx, rib_rx, bfd_client_tx, config.policy_tx.clone());
     config.subscribe("isis", isis.cm.tx.clone());
     config.subscribe_show("isis", isis.show.tx.clone());
     let task = inst::serve(isis);

--- a/zebra-rs/src/isis/auth.rs
+++ b/zebra-rs/src/isis/auth.rs
@@ -25,6 +25,134 @@ use sha2::{Sha256, Sha384, Sha512};
 
 use super::config::{IsisAuthConfig, IsisAuthType};
 
+/// Fully resolved IS-IS auth send/verify parameters for one PDU.
+/// Either side composes one of these from the IsisAuthConfig and,
+/// when no inline password is set, the policy key-chain snapshot.
+#[derive(Debug, Clone)]
+pub struct ResolvedAuth {
+    pub auth_type: IsisAuthType,
+    pub key: Vec<u8>,
+    /// On-wire key-id stamped in the RFC 5310 2-byte prefix.
+    /// Ignored for `Text` / `Md5`.
+    pub key_id: u16,
+}
+
+/// Project the policy algorithm enum onto the IS-IS subset.
+/// AesCmacPrf128 belongs to TCP-AO's MUST-implement set per RFC
+/// 5926 and isn't an IS-IS algorithm, so it returns `None` and the
+/// resolve falls through (no auth on the wire).
+fn isis_algo_from_policy(a: crate::policy::CryptoAlgorithm) -> Option<IsisAuthType> {
+    use crate::policy::CryptoAlgorithm as P;
+    match a {
+        P::Md5 => Some(IsisAuthType::Md5),
+        P::HmacSha1 => Some(IsisAuthType::HmacSha1),
+        P::HmacSha256 => Some(IsisAuthType::HmacSha256),
+        P::HmacSha384 => Some(IsisAuthType::HmacSha384),
+        P::HmacSha512 => Some(IsisAuthType::HmacSha512),
+        P::AesCmacPrf128 => None,
+    }
+}
+
+/// Is this policy key usable for sending right now? RFC 8177 says a
+/// key with no algorithm or no material is mid-configuration and
+/// inactive; we also require its send-lifetime to bracket `now`.
+fn chain_key_is_send_active(k: &crate::policy::Key, now: chrono::DateTime<chrono::Utc>) -> bool {
+    k.algo.is_some() && !k.key_material.is_empty() && k.send_lifetime.is_active(now)
+}
+
+/// Same as `chain_key_is_send_active` but against accept-lifetime —
+/// gates whether a received PDU stamped with this key-id is allowed
+/// to verify.
+fn chain_key_is_accept_active(k: &crate::policy::Key, now: chrono::DateTime<chrono::Utc>) -> bool {
+    k.algo.is_some() && !k.key_material.is_empty() && k.accept_lifetime.is_active(now)
+}
+
+/// Resolve the send-side `(auth_type, key, key_id)` to use for this
+/// scope. Inline `password` always wins when set — operators of the
+/// historical simple-password setup keep their behavior, and the
+/// `key-chain` leaf is only consulted when no inline password is
+/// present. Returns `None` when neither path is configured, the
+/// chain is missing, has no active key, or the active key uses an
+/// algorithm IS-IS can't sign with.
+pub fn resolve_send(
+    cfg: &IsisAuthConfig,
+    chains: &std::collections::BTreeMap<String, crate::policy::KeyChain>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Option<ResolvedAuth> {
+    if let Some(pw) = cfg.password.as_deref() {
+        return Some(ResolvedAuth {
+            auth_type: cfg.auth_type,
+            key: pw.as_bytes().to_vec(),
+            key_id: cfg.effective_key_id(),
+        });
+    }
+    let chain_name = cfg.key_chain.as_deref()?;
+    let chain = chains.get(chain_name)?;
+    let (id, key) = chain
+        .keys
+        .iter()
+        .find(|(_, k)| chain_key_is_send_active(k, now))?;
+    let auth_type = isis_algo_from_policy(key.algo?)?;
+    // YANG key-id is uint64; the wire stamps a u16. Reject IDs that
+    // wouldn't fit so the send path doesn't silently truncate.
+    let key_id_u16: u16 = (*id).try_into().ok()?;
+    Some(ResolvedAuth {
+        auth_type,
+        key: key.key_material.clone(),
+        key_id: key_id_u16,
+    })
+}
+
+/// Resolve the receive-side key bytes for an incoming PDU.
+///
+/// Inline `password` always wins — operators of the historical
+/// simple-password setup keep their behavior, and the `key-chain`
+/// leaf is only consulted when no inline password is set. For the
+/// chain path:
+///   - generic-crypto wire types carry the sender's RFC 5310 key-id
+///     in the TLV prefix; the caller passes that as `wire_key_id`
+///     and the lookup is an exact match.
+///   - RFC 5304 MD5 doesn't carry a key-id; the caller passes
+///     `None` and the helper picks the lowest accept-active key
+///     whose algo matches `expected_mode`.
+///
+/// The chosen key's algo must match `expected_mode` so the verify
+/// path doesn't compare digests of differing lengths.
+pub fn resolve_recv(
+    cfg: &IsisAuthConfig,
+    chains: &std::collections::BTreeMap<String, crate::policy::KeyChain>,
+    expected_mode: IsisAuthType,
+    wire_key_id: Option<u16>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Option<Vec<u8>> {
+    if let Some(pw) = cfg.password.as_deref() {
+        return Some(pw.as_bytes().to_vec());
+    }
+    let chain_name = cfg.key_chain.as_deref()?;
+    let chain = chains.get(chain_name)?;
+    let key = match wire_key_id {
+        Some(id) => chain.keys.get(&u64::from(id))?,
+        None => {
+            // No wire key-id — find the lowest accept-active key
+            // whose algo matches what the wire claims.
+            chain.keys.values().find(|k| {
+                chain_key_is_accept_active(k, now)
+                    && k.algo
+                        .and_then(isis_algo_from_policy)
+                        .is_some_and(|a| a == expected_mode)
+            })?
+        }
+    };
+    if !chain_key_is_accept_active(key, now) {
+        return None;
+    }
+    let algo = isis_algo_from_policy(key.algo?)?;
+    if algo != expected_mode {
+        return None;
+    }
+    Some(key.key_material.clone())
+}
+
 /// HMAC-MD5 over `data` keyed by `key` (RFC 2104 / RFC 5304 §3).
 /// Returns the 16-byte digest. `Hmac::new_from_slice` accepts any
 /// key length — internally hashed/padded to the MD5 block size.
@@ -102,12 +230,12 @@ pub fn digest_eq(a: &[u8], b: &[u8]) -> bool {
 ///
 /// Generic-crypto (RFC 5310) values are 1 (auth-type) + 2 (Key ID)
 /// + digest-length, which is bigger than RFC 5304's md5 layout.
-pub fn auth_tlv_wire_size(cfg: &IsisAuthConfig) -> usize {
-    let Some(pw) = cfg.password.as_ref() else {
+pub fn auth_tlv_wire_size(resolved: Option<&ResolvedAuth>) -> usize {
+    let Some(r) = resolved else {
         return 0;
     };
-    match cfg.auth_type {
-        IsisAuthType::Text => 2 + 1 + pw.len(),
+    match r.auth_type {
+        IsisAuthType::Text => 2 + 1 + r.key.len(),
         IsisAuthType::Md5 => 2 + 1 + ISIS_AUTH_HMAC_MD5_LEN,
         algo if algo.is_generic_crypto() => {
             2 + 1 + ISIS_AUTH_GENERIC_KEY_ID_LEN + algo.digest_len()
@@ -122,23 +250,22 @@ pub fn auth_tlv_wire_size(cfg: &IsisAuthConfig) -> usize {
 /// placeholder. For RFC 5310 generic crypto, the placeholder is the
 /// Key-ID prefix followed by an Apad-filled digest area — `sign`
 /// will patch the real HMAC over the Apad bytes once computed.
-pub fn append_auth_tlv(tlvs: &mut Vec<IsisTlv>, cfg: &IsisAuthConfig) {
-    let Some(pw) = cfg.password.as_deref() else {
+pub fn append_auth_tlv(tlvs: &mut Vec<IsisTlv>, resolved: Option<&ResolvedAuth>) {
+    let Some(r) = resolved else {
         return;
     };
-    let tlv = match cfg.auth_type {
+    let tlv = match r.auth_type {
         IsisAuthType::Text => IsisTlvAuth {
             auth_type: ISIS_AUTH_TYPE_CLEARTEXT,
-            value: pw.as_bytes().to_vec(),
+            value: r.key.clone(),
         },
         IsisAuthType::Md5 => {
             IsisTlvAuth::placeholder(ISIS_AUTH_TYPE_HMAC_MD5, ISIS_AUTH_HMAC_MD5_LEN)
         }
         algo if algo.is_generic_crypto() => {
-            let key_id = cfg.effective_key_id();
             let digest_len = algo.digest_len();
             let mut value = Vec::with_capacity(ISIS_AUTH_GENERIC_KEY_ID_LEN + digest_len);
-            value.extend_from_slice(&key_id.to_be_bytes());
+            value.extend_from_slice(&r.key_id.to_be_bytes());
             value.extend_from_slice(&apad(digest_len));
             IsisTlvAuth {
                 auth_type: ISIS_AUTH_TYPE_GENERIC,
@@ -449,19 +576,24 @@ mod tests {
     /// configured TLV (the function the packer would build).
     #[test]
     fn auth_tlv_wire_size_matches_emit_length() {
+        let chains = std::collections::BTreeMap::new();
+        let now = chrono::Utc::now();
+
         // Cleartext: TL header (2) + auth-type (1) + password bytes.
         let cfg = IsisAuthConfig {
             password: Some("hunter2".into()),
             auth_type: IsisAuthType::Text,
             key_id: 0,
             send_only: false,
+            key_chain: None,
         };
         let tlv: IsisTlv = IsisTlvAuth {
             auth_type: ISIS_AUTH_TYPE_CLEARTEXT,
             value: b"hunter2".to_vec(),
         }
         .into();
-        assert_eq!(auth_tlv_wire_size(&cfg), tlv.wire_len());
+        let resolved = resolve_send(&cfg, &chains, now);
+        assert_eq!(auth_tlv_wire_size(resolved.as_ref()), tlv.wire_len());
 
         // HMAC-MD5: TL header (2) + auth-type (1) + 16-byte digest.
         let cfg = IsisAuthConfig {
@@ -469,14 +601,17 @@ mod tests {
             auth_type: IsisAuthType::Md5,
             key_id: 0,
             send_only: false,
+            key_chain: None,
         };
         let tlv: IsisTlv =
             IsisTlvAuth::placeholder(ISIS_AUTH_TYPE_HMAC_MD5, ISIS_AUTH_HMAC_MD5_LEN).into();
-        assert_eq!(auth_tlv_wire_size(&cfg), tlv.wire_len());
+        let resolved = resolve_send(&cfg, &chains, now);
+        assert_eq!(auth_tlv_wire_size(resolved.as_ref()), tlv.wire_len());
 
         // No auth → 0 bytes.
         let cfg = IsisAuthConfig::default();
-        assert_eq!(auth_tlv_wire_size(&cfg), 0);
+        let resolved = resolve_send(&cfg, &chains, now);
+        assert_eq!(auth_tlv_wire_size(resolved.as_ref()), 0);
     }
 
     /// End-to-end HMAC-MD5 round-trip across a real CSNP — same
@@ -764,11 +899,14 @@ mod tests {
             auth_type: IsisAuthType::HmacSha256,
             key_id: 42,
             send_only: false,
+            key_chain: None,
         };
         let mut tlvs = vec![IsisTlv::AreaAddr(IsisTlvAreaAddr {
             area_addr: vec![0x49, 0x00, 0x01],
         })];
-        append_auth_tlv(&mut tlvs, &cfg);
+        let chains = std::collections::BTreeMap::new();
+        let resolved = resolve_send(&cfg, &chains, chrono::Utc::now());
+        append_auth_tlv(&mut tlvs, resolved.as_ref());
 
         let hello = IsisHello {
             circuit_type: IsLevel::L1L2,
@@ -836,11 +974,14 @@ mod tests {
             auth_type: IsisAuthType::HmacSha512,
             key_id: 9,
             send_only: false,
+            key_chain: None,
         };
         let mut tlvs = vec![IsisTlv::AreaAddr(IsisTlvAreaAddr {
             area_addr: vec![0x49, 0x00, 0x01],
         })];
-        append_auth_tlv(&mut tlvs, &cfg);
+        let chains = std::collections::BTreeMap::new();
+        let resolved = resolve_send(&cfg, &chains, chrono::Utc::now());
+        append_auth_tlv(&mut tlvs, resolved.as_ref());
         let lsp = IsisLsp {
             pdu_len: 0,
             hold_time: 1200,

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -74,6 +74,10 @@ impl Isis {
             "/router/isis/area-password/send-only",
             config_area_password_send_only,
         );
+        self.callback_add(
+            "/router/isis/area-password/key-chain",
+            config_area_password_key_chain,
+        );
         self.callback_add("/router/isis/domain-password", config_domain_password);
         self.callback_add(
             "/router/isis/domain-password/password",
@@ -90,6 +94,10 @@ impl Isis {
         self.callback_add(
             "/router/isis/domain-password/send-only",
             config_domain_password_send_only,
+        );
+        self.callback_add(
+            "/router/isis/domain-password/key-chain",
+            config_domain_password_key_chain,
         );
         self.callback_add("/router/isis/timers/hold-time", config_hold_time);
         self.callback_add(
@@ -295,6 +303,10 @@ impl Isis {
         self.callback_add(
             "/router/isis/interface/hello-authentication/send-only",
             link::config_hello_auth_send_only,
+        );
+        self.callback_add(
+            "/router/isis/interface/hello-authentication/key-chain",
+            link::config_hello_auth_key_chain,
         );
         self.callback_add(
             "/router/isis/interface/ipv4/prefix-sid/index",
@@ -549,6 +561,13 @@ pub struct IsisAuthConfig {
     /// receive. Used to drain peers from no-auth → auth without
     /// breaking adjacencies mid-rollout.
     pub send_only: bool,
+    /// Name of a key-chain under `/key-chains/key-chain <name>`.
+    /// Only consulted when `password` is unset (inline cleartext
+    /// wins so simple-password operators don't accidentally pick
+    /// up chain-resolved bytes on the wire). The chain's active
+    /// key supplies the on-wire `(auth_type, key_id, material)`
+    /// at sign / verify time.
+    pub key_chain: Option<String>,
 }
 
 impl IsisAuthConfig {
@@ -731,6 +750,7 @@ pub fn auth_reset(cfg: &mut IsisAuthConfig) {
     cfg.auth_type = IsisAuthType::default();
     cfg.key_id = 0;
     cfg.send_only = false;
+    cfg.key_chain = None;
 }
 
 pub fn auth_set_key_id(cfg: &mut IsisAuthConfig, args: &mut Args, op: ConfigOp) -> Option<()> {
@@ -758,6 +778,63 @@ pub fn auth_set_send_only(cfg: &mut IsisAuthConfig, args: &mut Args, op: ConfigO
     Some(())
 }
 
+/// Send Unregister(prior) + Register(new) against the policy actor
+/// when the configured chain name for an IsisAuthConfig scope changes.
+/// Mirrors BGP's `policy_attach_msgs`. Always-Unregister-before-
+/// Register avoids the watcher-leak that would otherwise occur on a
+/// rename.
+pub(crate) fn auth_key_chain_attach_msgs(
+    policy_tx: &tokio::sync::mpsc::UnboundedSender<crate::policy::Message>,
+    ident: usize,
+    scope: crate::policy::KeyChainScope,
+    prior: Option<String>,
+    new: Option<String>,
+) {
+    if prior == new {
+        return;
+    }
+    let policy_type = crate::policy::PolicyType::KeyChain(scope);
+    if let Some(prior_name) = prior {
+        let _ = policy_tx.send(crate::policy::Message::Unregister {
+            proto: "isis".to_string(),
+            name: prior_name,
+            ident,
+            policy_type,
+        });
+    }
+    if let Some(new_name) = new {
+        let _ = policy_tx.send(crate::policy::Message::Register {
+            proto: "isis".to_string(),
+            name: new_name,
+            ident,
+            policy_type,
+        });
+    }
+}
+
+/// Mutate `cfg.key_chain` and fire the matching Register / Unregister
+/// against `policy_tx`. The area/domain scopes use the constant
+/// `ident` (only one chain ever attaches per scope on a given IS-IS
+/// instance); the per-interface scope passes the link's ifindex.
+pub(crate) fn auth_set_key_chain(
+    cfg: &mut IsisAuthConfig,
+    args: &mut Args,
+    op: ConfigOp,
+    policy_tx: &tokio::sync::mpsc::UnboundedSender<crate::policy::Message>,
+    ident: usize,
+    scope: crate::policy::KeyChainScope,
+) -> Option<()> {
+    let prior = cfg.key_chain.clone();
+    let new = if op.is_set() {
+        Some(args.string()?)
+    } else {
+        None
+    };
+    cfg.key_chain = new.clone();
+    auth_key_chain_attach_msgs(policy_tx, ident, scope, prior, new);
+    Some(())
+}
+
 fn config_area_password(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
     if !op.is_set() {
         auth_reset(&mut isis.config.area_password);
@@ -781,6 +858,17 @@ fn config_area_password_send_only(isis: &mut Isis, mut args: Args, op: ConfigOp)
     auth_set_send_only(&mut isis.config.area_password, &mut args, op)
 }
 
+fn config_area_password_key_chain(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    auth_set_key_chain(
+        &mut isis.config.area_password,
+        &mut args,
+        op,
+        &isis.policy_tx,
+        0,
+        crate::policy::KeyChainScope::IsisAreaPw,
+    )
+}
+
 fn config_domain_password(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
     if !op.is_set() {
         auth_reset(&mut isis.config.domain_password);
@@ -798,6 +886,17 @@ fn config_domain_password_auth_type(isis: &mut Isis, mut args: Args, op: ConfigO
 
 fn config_domain_password_key_id(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     auth_set_key_id(&mut isis.config.domain_password, &mut args, op)
+}
+
+fn config_domain_password_key_chain(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    auth_set_key_chain(
+        &mut isis.config.domain_password,
+        &mut args,
+        op,
+        &isis.policy_tx,
+        0,
+        crate::policy::KeyChainScope::IsisDomainPw,
+    )
 }
 
 fn config_domain_password_send_only(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
@@ -1526,6 +1625,7 @@ mod tests {
             auth_type: IsisAuthType::Md5,
             key_id: 7,
             send_only: true,
+            key_chain: Some("ringA".into()),
         };
         auth_reset(&mut cfg);
         assert_eq!(cfg, IsisAuthConfig::default());

--- a/zebra-rs/src/isis/flood.rs
+++ b/zebra-rs/src/isis/flood.rs
@@ -201,7 +201,8 @@ pub fn ssn_advertise(link: &mut LinkTop, level: Level) {
     // domain password; the Auth TLV is appended after the LspEntries
     // TLV and so eats into the per-fragment entry budget.
     let auth_cfg = super::lsp::level_auth_cfg(link.up_config, level);
-    let auth_size = auth::auth_tlv_wire_size(auth_cfg);
+    let resolved = auth::resolve_send(auth_cfg, link.key_chains, chrono::Utc::now());
+    let auth_size = auth::auth_tlv_wire_size(resolved.as_ref());
 
     let available_len = {
         let mut buf = BytesMut::new();
@@ -243,7 +244,7 @@ pub fn ssn_advertise(link: &mut LinkTop, level: Level) {
         entry_size += 1;
         if entry_size == entry_size_max {
             let mut psnp_tlvs: Vec<IsisTlv> = vec![tlvs.clone().into()];
-            auth::append_auth_tlv(&mut psnp_tlvs, auth_cfg);
+            auth::append_auth_tlv(&mut psnp_tlvs, resolved.as_ref());
             let psnp = IsisPsnp {
                 pdu_len: 0,
                 source_id: link.up_config.net.sys_id(),
@@ -258,7 +259,7 @@ pub fn ssn_advertise(link: &mut LinkTop, level: Level) {
     }
     if !tlvs.entries.is_empty() {
         let mut psnp_tlvs: Vec<IsisTlv> = vec![tlvs.into()];
-        auth::append_auth_tlv(&mut psnp_tlvs, auth_cfg);
+        auth::append_auth_tlv(&mut psnp_tlvs, resolved.as_ref());
         let psnp = IsisPsnp {
             pdu_len: 0,
             source_id: link.up_config.net.sys_id(),

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -112,7 +112,8 @@ pub fn hello_generate(link: &LinkTop, level: Level) -> IsisHello {
     // as-is. Including it before padding keeps the PDU exactly at MTU
     // (the padding helper sees the auth TLV's size when it computes
     // the remaining budget).
-    auth::append_auth_tlv(&mut hello.tlvs, &link.config.hello_auth);
+    let resolved = auth::resolve_send(&link.config.hello_auth, link.key_chains, chrono::Utc::now());
+    auth::append_auth_tlv(&mut hello.tlvs, resolved.as_ref());
     if link.config.hello_padding() == HelloPaddingPolicy::Always {
         hello.padding(link.state.mtu as usize);
     }
@@ -190,7 +191,8 @@ pub fn hello_p2p_generate(link: &LinkTop, level: Level) -> IsisP2pHello {
     };
     hello.tlvs.push(tlv.into());
 
-    auth::append_auth_tlv(&mut hello.tlvs, &link.config.hello_auth);
+    let resolved = auth::resolve_send(&link.config.hello_auth, link.key_chains, chrono::Utc::now());
+    auth::append_auth_tlv(&mut hello.tlvs, resolved.as_ref());
     if link.config.hello_padding() == HelloPaddingPolicy::Always {
         hello.padding(link.state.mtu as usize);
     }
@@ -267,26 +269,28 @@ pub fn hello_send(link: &mut LinkTop, level: Level) -> Result<()> {
     // bytes patched after serialization, so we pre-emit and send
     // as `Packet::Bytes`. Cleartext + no-auth use the existing
     // serialize-on-send path with `Packet::Packet`.
-    let auth_cfg = &link.config.hello_auth;
-    let outgoing = match (auth_cfg.password.as_deref(), auth_cfg.auth_type) {
-        (Some(key), algo) if matches!(algo, IsisAuthType::Md5) || algo.is_generic_crypto() => {
+    let resolved = auth::resolve_send(&link.config.hello_auth, link.key_chains, chrono::Utc::now());
+    let outgoing = match resolved {
+        Some(r) if matches!(r.auth_type, IsisAuthType::Md5) || r.auth_type.is_generic_crypto() => {
             let mut buf = BytesMut::new();
             packet.emit(&mut buf);
             auth::sign_inplace(
                 &mut buf,
                 packet.length_indicator as usize,
-                algo,
-                key.as_bytes(),
+                r.auth_type,
+                &r.key,
             );
             link.state.auth_tx_signed += 1;
             Packet::Bytes(buf)
         }
-        _ => {
-            if auth_cfg.password.is_some() {
-                link.state.auth_tx_signed += 1;
-            }
+        Some(_) => {
+            // Cleartext (text) or other non-HMAC auth-type — TLV
+            // already carries the secret bytes from `hello_generate`;
+            // nothing to patch in.
+            link.state.auth_tx_signed += 1;
             Packet::Packet(packet)
         }
+        None => Packet::Packet(packet),
     };
 
     let _ = link

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -303,6 +303,25 @@ pub struct Isis {
     /// [`Self::event_loop`]. PR 7b logs the events; PR 7c replaces
     /// the log with adjacency teardown on `BfdEvent::Down`.
     pub bfd_event_rx: UnboundedReceiver<crate::bfd::inst::BfdEvent>,
+    /// Snapshot of `/key-chains/key-chain <name>` entries the policy
+    /// actor has pushed to this IS-IS instance via
+    /// `PolicyRx::KeyChain`. The canonical map lives in
+    /// `policy::Policy`; the area-password / domain-password /
+    /// per-link `hello-authentication` scopes resolve their
+    /// `key-chain <name>` leaf against this snapshot at sign /
+    /// verify time. Inline cleartext `password` continues to win
+    /// when set — chains are the alternative for HMAC keys we
+    /// don't want sitting in the running-config.
+    pub key_chains: BTreeMap<String, crate::policy::KeyChain>,
+    /// Send half of the policy channel. Stashed so per-scope
+    /// `key-chain` config callbacks can fire Register / Unregister
+    /// without threading it through every layer.
+    pub policy_tx: UnboundedSender<crate::policy::Message>,
+    /// Receive half of the policy channel. Drained by the IS-IS
+    /// event loop and forwarded to `process_policy_msg`, which
+    /// updates `key_chains` and re-originates LSPs at the affected
+    /// level for area/domain-password scope changes.
+    pub policy_rx: UnboundedReceiver<crate::policy::PolicyRx>,
 }
 
 pub struct IsisTop<'a> {
@@ -399,6 +418,11 @@ pub struct IsisTop<'a> {
     /// 256-bit Extended Admin Group bitmap (RFC 7308).
     pub affinity_map: &'a super::affinity_map::AffinityMap,
 
+    /// Read-only snapshot of the policy-driven key-chain registry
+    /// (see `Isis::key_chains`). Sign / verify paths consult this
+    /// when an auth-scope's `key-chain` leaf is set.
+    pub key_chains: &'a std::collections::BTreeMap<String, crate::policy::KeyChain>,
+
     /// Seq-wrap wait timers (see `Isis::lsp_seq_wrap_wait`). Threaded
     /// through so `lsp_generate` can short-circuit per fragment and
     /// arm the timer without round-tripping through the event loop.
@@ -421,7 +445,13 @@ impl Isis {
         ctx: ProtoContext,
         rib_rx: UnboundedReceiver<RibRx>,
         bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
+        policy_tx: UnboundedSender<crate::policy::Message>,
     ) -> Self {
+        let policy_chan = crate::policy::PolicyRxChannel::new();
+        let _ = policy_tx.send(crate::policy::Message::Subscribe {
+            proto: "isis".into(),
+            tx: policy_chan.tx.clone(),
+        });
         // SR config subscription channel. One-time registration with the
         // RIB; subsequent SrBlockWatch / SrLocatorWatch messages drive
         // which named entries we receive updates for. Goes through the
@@ -515,6 +545,9 @@ impl Isis {
                 bfd_client_tx,
                 bfd_event_tx,
                 bfd_event_rx,
+                key_chains: BTreeMap::new(),
+                policy_tx,
+                policy_rx: policy_chan.rx,
             };
         isis.callback_build();
         isis.show_build();
@@ -903,8 +936,9 @@ impl Isis {
         }
 
         let auth_cfg = super::lsp::level_auth_cfg(top.config, level).clone();
+        let resolved = super::auth::resolve_send(&auth_cfg, top.key_chains, chrono::Utc::now());
         for mut frag in fragments {
-            let buf = lsp_emit(&mut frag, level, &auth_cfg);
+            let buf = lsp_emit(&mut frag, level, resolved.as_ref());
             let lsp_id = frag.lsp_id;
             insert_self_originate(&mut top, level, frag, Some(buf.to_vec()));
             top.lsdb.get_mut(&level).srm_set_all(top.tx, level, &lsp_id);
@@ -1002,7 +1036,8 @@ impl Isis {
         // RFC 6232: the zero-lifetime LSP still carries the
         // per-level Auth TLV so receivers can verify it.
         let auth_cfg = super::lsp::level_auth_cfg(top.config, level).clone();
-        let _buf = lsp_emit(&mut purged_lsp, level, &auth_cfg);
+        let resolved = super::auth::resolve_send(&auth_cfg, top.key_chains, chrono::Utc::now());
+        let _buf = lsp_emit(&mut purged_lsp, level, resolved.as_ref());
         insert_self_originate(&mut top, level, purged_lsp, None);
 
         top.lsdb.get_mut(&level).srm_set_all(top.tx, level, &lsp_id);
@@ -1070,8 +1105,9 @@ impl Isis {
             .unwrap_or(0);
 
         let auth_cfg = super::lsp::level_auth_cfg(top.config, level).clone();
+        let resolved = super::auth::resolve_send(&auth_cfg, top.key_chains, chrono::Utc::now());
         for mut frag in fragments {
-            let buf = lsp_emit(&mut frag, level, &auth_cfg);
+            let buf = lsp_emit(&mut frag, level, resolved.as_ref());
             let lsp_id = frag.lsp_id;
             insert_self_originate(&mut top, level, frag, Some(buf.to_vec()));
             top.lsdb.get_mut(&level).srm_set_all(top.tx, level, &lsp_id);
@@ -1185,7 +1221,52 @@ impl Isis {
                 Some(event) = self.bfd_event_rx.recv() => {
                     self.process_bfd_event(event);
                 }
+                Some(msg) = self.policy_rx.recv() => {
+                    self.process_policy_msg(msg);
+                }
             }
+        }
+    }
+
+    /// Handle a `PolicyRx` push from the policy actor. Today we only
+    /// subscribe to key-chain updates (area/domain-password and
+    /// per-link `hello-authentication`). LSP sign / verify resolve
+    /// lazily per packet, so all this needs to do is keep the
+    /// snapshot fresh and re-fire `LspOriginate` at the affected
+    /// level when an area / domain-password chain edit lands so
+    /// peers see a new signature on the next refresh without
+    /// waiting for the periodic timer.
+    fn process_policy_msg(&mut self, msg: crate::policy::PolicyRx) {
+        match msg {
+            crate::policy::PolicyRx::KeyChain {
+                name,
+                policy_type,
+                key_chain,
+                ..
+            } => {
+                if let Some(kc) = key_chain {
+                    self.key_chains.insert(name, kc);
+                } else {
+                    self.key_chains.remove(&name);
+                }
+                if let crate::policy::PolicyType::KeyChain(scope) = policy_type {
+                    use crate::policy::KeyChainScope;
+                    match scope {
+                        KeyChainScope::IsisAreaPw => {
+                            let _ = self.tx.send(Message::LspOriginate(Level::L1, None));
+                        }
+                        KeyChainScope::IsisDomainPw => {
+                            let _ = self.tx.send(Message::LspOriginate(Level::L2, None));
+                        }
+                        // IIH / non-IS-IS scopes: next hello-timer fire
+                        // (or remote subsystem) picks up the new key
+                        // lazily; no proactive event needed.
+                        _ => {}
+                    }
+                }
+            }
+            crate::policy::PolicyRx::PrefixSet { .. }
+            | crate::policy::PolicyRx::PolicyList { .. } => {}
         }
     }
 
@@ -1298,6 +1379,7 @@ impl Isis {
             srlg_groups: &self.srlg_groups,
             flex_algo: &self.flex_algo,
             affinity_map: &self.affinity_map,
+            key_chains: &self.key_chains,
             lsp_seq_wrap_wait: &mut self.lsp_seq_wrap_wait,
             lsp_placement_memory: &mut self.lsp_placement_memory,
             redist_v4: &self.redist_v4,
@@ -1335,6 +1417,7 @@ impl Isis {
             sr_locator: &self.sr_locator,
             watched_locator: &self.watched_locator,
             elib: &mut self.elib,
+            key_chains: &self.key_chains,
         })
     }
 
@@ -1701,7 +1784,11 @@ mod bfd_wiring_tests {
     fn fresh_isis_with_bfd() -> (Isis, mpsc::UnboundedReceiver<ClientReq>) {
         let (ctx, rib_rx) = test_ctx();
         let (bfd_client_tx, bfd_client_rx) = mpsc::unbounded_channel();
-        let isis = Isis::new(ctx, rib_rx, Some(bfd_client_tx));
+        let (policy_tx, policy_rx) = mpsc::unbounded_channel();
+        // Park the policy_rx so the Subscribe send in `new` doesn't
+        // drop and panic on its own send.
+        Box::leak(Box::new(policy_rx));
+        let isis = Isis::new(ctx, rib_rx, Some(bfd_client_tx), policy_tx);
         (isis, bfd_client_rx)
     }
 
@@ -1745,7 +1832,9 @@ mod bfd_wiring_tests {
     #[tokio::test]
     async fn no_bfd_handle_is_noop() {
         let (ctx, rib_rx) = test_ctx();
-        let isis = Isis::new(ctx, rib_rx, None);
+        let (policy_tx, policy_rx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(policy_rx));
+        let isis = Isis::new(ctx, rib_rx, None, policy_tx);
         let key = loopback_key();
         isis.process_bfd_subscribe(key);
         isis.process_bfd_unsubscribe(key);

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -169,6 +169,11 @@ pub struct LinkTop<'a> {
     pub sr_locator: &'a Option<crate::rib::Locator>,
     pub watched_locator: &'a Option<String>,
     pub elib: &'a mut crate::isis::srv6::ElibPool,
+    /// Read-only snapshot of the policy-driven key-chain registry
+    /// (mirrors `IsisTop::key_chains`). Hello / CSNP / PSNP sign +
+    /// verify paths consult this when the per-link
+    /// `hello-authentication` scope has a `key-chain` leaf set.
+    pub key_chains: &'a std::collections::BTreeMap<String, crate::policy::KeyChain>,
 }
 
 impl<'a> LinkTop<'a> {
@@ -823,6 +828,20 @@ pub fn config_hello_auth_send_only(isis: &mut Isis, mut args: Args, op: ConfigOp
     let name = args.string()?;
     let link = isis.links.get_mut_by_name(&name)?;
     auth_set_send_only(&mut link.config.hello_auth, &mut args, op)
+}
+
+pub fn config_hello_auth_key_chain(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let link = isis.links.get_mut_by_name(&name)?;
+    let ifindex = link.ifindex as usize;
+    crate::isis::config::auth_set_key_chain(
+        &mut link.config.hello_auth,
+        &mut args,
+        op,
+        &isis.policy_tx,
+        ifindex,
+        crate::policy::KeyChainScope::IsisIih,
+    )
 }
 
 fn config_afi_enable(isis: &mut Isis, mut args: Args, op: ConfigOp, afi: Afi) -> Option<()> {

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -648,7 +648,9 @@ pub fn refresh_lsp(top: &mut IsisTop, level: Level, key: IsisLspId) {
     if let Some(lsa) = top.lsdb.get(&level).get(&key) {
         let mut lsp = lsp_clone_with_seqno_inc(&lsa.lsp);
         let auth_cfg = crate::isis::lsp::level_auth_cfg(top.config, level).clone();
-        let buf = lsp_emit(&mut lsp, level, &auth_cfg);
+        let resolved =
+            crate::isis::auth::resolve_send(&auth_cfg, top.key_chains, chrono::Utc::now());
+        let buf = lsp_emit(&mut lsp, level, resolved.as_ref());
         let lsp_id = lsp.lsp_id;
         insert_self_originate(top, level, lsp, Some(buf.to_vec()));
         lsp_flood(top, level, &lsp_id);

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -1341,14 +1341,18 @@ fn arm_seq_wrap_freeze(top: &mut IsisTop, level: Level, lsp_id: IsisLspId) {
     top.lsp_seq_wrap_wait.get_mut(&level).insert(frag_id, timer);
 }
 
-pub fn lsp_emit(lsp: &mut IsisLsp, level: Level, auth_cfg: &IsisAuthConfig) -> BytesMut {
+pub fn lsp_emit(
+    lsp: &mut IsisLsp,
+    level: Level,
+    resolved: Option<&auth::ResolvedAuth>,
+) -> BytesMut {
     // Auth TLV (Phase 4) sits at the end of the LSP's TLV section.
     // For HMAC-MD5 it's a zero-filled placeholder that the post-emit
     // sign step patches in place; for cleartext it carries the
     // password bytes directly. Append before `IsisPacket::from` so
     // the serialized fragment size — and the Fletcher checksum
     // `IsisPacket::emit` stamps — already accounts for the TLV.
-    auth::append_auth_tlv(&mut lsp.tlvs, auth_cfg);
+    auth::append_auth_tlv(&mut lsp.tlvs, resolved);
 
     let packet = match level {
         Level::L1 => IsisPacket::from(IsisType::L1Lsp, IsisPdu::L1Lsp(lsp.clone())),
@@ -1364,11 +1368,10 @@ pub fn lsp_emit(lsp: &mut IsisLsp, level: Level, auth_cfg: &IsisAuthConfig) -> B
     // digest into place, then re-stamp Fletcher (which
     // `IsisPacket::emit` already wrote covering the placeholder —
     // we redo it with the real digest in place).
-    let algo = auth_cfg.auth_type;
-    if (matches!(algo, IsisAuthType::Md5) || algo.is_generic_crypto())
-        && let Some(key) = auth_cfg.password.as_deref()
+    if let Some(r) = resolved
+        && (matches!(r.auth_type, IsisAuthType::Md5) || r.auth_type.is_generic_crypto())
     {
-        auth::sign_lsp_inplace(&mut buf, algo, key.as_bytes());
+        auth::sign_lsp_inplace(&mut buf, r.auth_type, &r.key);
     }
 
     // Offset for pdu_len and checksum.
@@ -1391,7 +1394,8 @@ pub fn csnp_generate(link: &LinkTop, level: Level) -> Vec<IsisCsnp> {
     // TLV in each CSNP, so its on-wire size shrinks the per-fragment
     // entry budget below.
     let auth_cfg = level_auth_cfg(link.up_config, level);
-    let auth_size = auth::auth_tlv_wire_size(auth_cfg);
+    let resolved = auth::resolve_send(auth_cfg, link.key_chains, chrono::Utc::now());
+    let auth_size = auth::auth_tlv_wire_size(resolved.as_ref());
 
     // For the record, we will try to encode the packet length.
     let available_len = {
@@ -1443,7 +1447,7 @@ pub fn csnp_generate(link: &LinkTop, level: Level) -> Vec<IsisCsnp> {
         entry_size += 1;
         if entry_size == entry_size_max {
             let mut csnp_tlvs: Vec<IsisTlv> = vec![tlvs.clone().into()];
-            auth::append_auth_tlv(&mut csnp_tlvs, auth_cfg);
+            auth::append_auth_tlv(&mut csnp_tlvs, resolved.as_ref());
             let csnp = IsisCsnp {
                 pdu_len: 0,
                 source_id: link.up_config.net.sys_id(),
@@ -1461,7 +1465,7 @@ pub fn csnp_generate(link: &LinkTop, level: Level) -> Vec<IsisCsnp> {
     }
     if !tlvs.entries.is_empty() {
         let mut csnp_tlvs: Vec<IsisTlv> = vec![tlvs.into()];
-        auth::append_auth_tlv(&mut csnp_tlvs, auth_cfg);
+        auth::append_auth_tlv(&mut csnp_tlvs, resolved.as_ref());
         let csnp = IsisCsnp {
             pdu_len: 0,
             source_id: link.up_config.net.sys_id(),

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -871,15 +871,12 @@ pub fn psnp_send_pdu(link: &mut LinkTop, level: Level, pdu: IsisPsnp) {
 /// for the md5 path and `Packet::Packet` for everything else so the
 /// network writer can keep using the existing serialize-on-send code.
 fn sign_snp_outgoing(link: &mut LinkTop, level: Level, packet: IsisPacket) -> Packet {
-    let (key, mode) = {
-        let cfg = super::lsp::level_auth_cfg(link.up_config, level);
-        let Some(pw) = cfg.password.clone() else {
-            return Packet::Packet(packet);
-        };
-        (pw, cfg.auth_type)
+    let cfg = super::lsp::level_auth_cfg(link.up_config, level);
+    let Some(resolved) = auth::resolve_send(cfg, link.key_chains, chrono::Utc::now()) else {
+        return Packet::Packet(packet);
     };
     link.state.auth_tx_signed += 1;
-    match mode {
+    match resolved.auth_type {
         IsisAuthType::Text => Packet::Packet(packet),
         algo => {
             let mut buf = bytes::BytesMut::new();
@@ -888,7 +885,7 @@ fn sign_snp_outgoing(link: &mut LinkTop, level: Level, packet: IsisPacket) -> Pa
                 &mut buf,
                 packet.length_indicator as usize,
                 algo,
-                key.as_bytes(),
+                &resolved.key,
             );
             Packet::Bytes(buf)
         }
@@ -944,7 +941,7 @@ fn pdu_auth_tlv(pdu: &IsisPdu) -> Option<&IsisTlvAuth> {
 /// the LSP ages and gets re-fletcher'd in flight.
 fn verify_hmac(
     algo: IsisAuthType,
-    key: &str,
+    key: &[u8],
     auth_tlv: &IsisTlvAuth,
     pdu_bytes: &[u8],
     tlvs_start: usize,
@@ -996,7 +993,7 @@ fn verify_hmac(
             *b = 0;
         }
     }
-    let computed = auth::hmac_for_algo(algo, key.as_bytes(), &scratch);
+    let computed = auth::hmac_for_algo(algo, key, &scratch);
     // Compare against the digest portion of the parsed TLV (skip
     // the Key ID prefix for generic-crypto).
     let stored = &auth_tlv.value[header - 1..];
@@ -1029,16 +1026,18 @@ fn verify_pdu_auth(
 ) -> bool {
     // Snapshot config fields so we don't hold an immutable borrow of
     // link.config/up_config while mutating link.state.auth_rx_* below.
-    let (key, mode, send_only) = {
+    let (cfg, mode, send_only) = {
         let cfg = match scope {
             AuthScope::HelloLink => &link.config.hello_auth,
             AuthScope::AreaPassword => &link.up_config.area_password,
             AuthScope::DomainPassword => &link.up_config.domain_password,
         };
-        let Some(pw) = cfg.password.clone() else {
-            return true; // no auth configured for this scope — accept anything
-        };
-        (pw, cfg.auth_type, cfg.send_only)
+        // No password and no chain → scope is not configured for
+        // auth; accept anything.
+        if cfg.password.is_none() && cfg.key_chain.is_none() {
+            return true;
+        }
+        (cfg.clone(), cfg.auth_type, cfg.send_only)
     };
     if send_only {
         return true; // sign-only-on-tx rollover mode
@@ -1054,10 +1053,35 @@ fn verify_pdu_auth(
         return false;
     };
 
+    // Pull the on-wire RFC 5310 key-id out of the auth TLV prefix
+    // when the configured mode is generic-crypto; MD5 / Text PDUs
+    // don't carry one. The chain receive path uses this to pick the
+    // exact key the sender stamped.
+    let wire_key_id = if mode.is_generic_crypto() && auth_tlv.value.len() >= 2 {
+        Some(u16::from_be_bytes([auth_tlv.value[0], auth_tlv.value[1]]))
+    } else {
+        None
+    };
+    let Some(key) =
+        auth::resolve_recv(&cfg, link.key_chains, mode, wire_key_id, chrono::Utc::now())
+    else {
+        // Resolution failed: chain missing, no matching key-id,
+        // expired accept-lifetime, or algo mismatch. Treat as a
+        // hard reject so peers using the wrong key don't slip
+        // through.
+        link.state.auth_rx_bad += 1;
+        tracing::warn!(
+            proto = "isis",
+            link = %link.state.name,
+            pdu = ?packet.pdu_type,
+            "[AuthDrop] no usable receive key from policy registry"
+        );
+        return false;
+    };
+
     let accepted = match mode {
         IsisAuthType::Text => {
-            auth_tlv.auth_type == ISIS_AUTH_TYPE_CLEARTEXT
-                && auth::digest_eq(&auth_tlv.value, key.as_bytes())
+            auth_tlv.auth_type == ISIS_AUTH_TYPE_CLEARTEXT && auth::digest_eq(&auth_tlv.value, &key)
         }
         algo => verify_hmac(algo, &key, auth_tlv, pdu_bytes, tlvs_start, packet),
     };

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -989,16 +989,25 @@ module config {
             "Authentication key applied to Level-1 self-originated LSPs
              and SNPs (ISO 10589 §9.5 / RFC 5304 / RFC 5310). Per
              ISO 10589, L1 PDUs use the area-wide authentication string.
-             Phase 2 lands the schema and storage; the sign/verify
-             runtime arrives in Phase 4 (LSPs) and Phase 3 (SNPs are
-             carried alongside Hello auth on the link).";
+             Either `password` (inline / cleartext-friendly) or
+             `key-chain` (named RFC 8177 chain under /key-chains)
+             may carry the key — when both are set the inline
+             password wins so that simple-password operators don't
+             accidentally get chain-resolved bytes on the wire.";
 
           leaf password {
             type string;
-            mandatory true;
             description
               "Authentication key bytes. Sent cleartext on the wire
                when auth-type is text; used as the HMAC key when md5.";
+          }
+          leaf key-chain {
+            type string;
+            description
+              "Reference to a named key-chain under /key-chains.
+               Only consulted when `password` is unset. The chain's
+               active key supplies auth-type, key-id, and material
+               at sign/verify time.";
           }
           leaf auth-type {
             type enumeration {
@@ -1033,11 +1042,17 @@ module config {
           presence "L2 domain-wide IS-IS authentication";
           description
             "Authentication key applied to Level-2 self-originated LSPs
-             and SNPs. Same shape as area-password but scoped to L2.";
+             and SNPs. Same shape as area-password but scoped to L2.
+             Inline `password` wins over `key-chain` when both are set.";
 
           leaf password {
             type string;
-            mandatory true;
+          }
+          leaf key-chain {
+            type string;
+            description
+              "Reference to a named key-chain under /key-chains.
+               Only consulted when `password` is unset.";
           }
           leaf auth-type {
             type enumeration {
@@ -1299,11 +1314,17 @@ module config {
                Information TLV with auth-type 1 (text) or 54 (md5).
                Per RFC 5304 §1, send-only enables an asymmetric
                rollover where outbound is signed but inbound is
-               accepted unconditionally.";
+               accepted unconditionally. Inline `password` wins over
+               `key-chain` when both are set.";
 
             leaf password {
               type string;
-              mandatory true;
+            }
+            leaf key-chain {
+              type string;
+              description
+                "Reference to a named key-chain under /key-chains.
+                 Only consulted when `password` is unset.";
             }
             leaf auth-type {
               type enumeration {


### PR DESCRIPTION
## Summary

Lets IS-IS authentication scopes pick up an RFC 5310 key from the shared policy key-chain registry (#928) instead of (or alongside) the inline cleartext \`password\`. Per the project decision, simple password stays protocol-local — inline \`password\` always wins when set; the \`key-chain\` leaf is only consulted when no inline password is present. None of the existing inline-password deployments change behavior.

- **YANG**: drop \`mandatory true\` from \`password\` under area-password / domain-password / interface/hello-authentication and add a sibling \`leaf key-chain { type string; }\` to each.
- **Config**: \`IsisAuthConfig\` grows \`key_chain: Option<String>\`. Three new callbacks send \`Register\` / \`Unregister\` against the policy actor via a new \`auth_set_key_chain\` helper. Scope encoded as \`PolicyType::KeyChain(KeyChainScope::Isis{AreaPw|DomainPw|Iih})\`; per-link ident = \`link.ifindex\`, area/domain use ident=0 (only one chain ever attaches per scope).
- **Subscription**: \`Isis\` gains \`policy_tx\` / \`policy_rx\` / \`key_chains\` snapshot. \`spawn_isis\` threads \`policy_tx\`. \`IsisTop\` and \`LinkTop\` get a read-only \`&BTreeMap\` so sign / verify call sites have it for free.
- **Resolve helpers**: \`isis::auth\` gains \`ResolvedAuth\` plus \`resolve_send\` / \`resolve_recv\`. Send picks lowest send-active key by lifetime; receive matches by on-wire RFC 5310 key-id for generic crypto, or by lifetime for MD5 (no wire key-id). \`isis_algo_from_policy\` adapter mirrors PR 2/3 (filters out AesCmacPrf128 — TCP-AO-only).
- **Sign / verify sites**: \`auth_tlv_wire_size\` / \`append_auth_tlv\` / \`sign_inplace\` / \`verify_hmac\` all take resolved bytes now. Hellos (ifsm), CSNP/PSNP (lsp, flood, packet), LSPs (inst, lsdb) all call \`resolve_send(cfg, link.key_chains, now)\` and pass the result down. Verify path extracts the wire key-id from the auth-TLV prefix for generic crypto and calls \`resolve_recv\`.
- **Event loop**: \`process_policy_msg\` updates the snapshot on \`PolicyRx::KeyChain\` and proactively re-fires \`LspOriginate\` at L1 (area-pw) or L2 (domain-pw) so peers see the new signature without waiting for the periodic refresh. IIH scope no-ops — next hello-timer fire picks the new key lazily.

Net diff: +475 / −70.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo build -p zebra-rs\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p zebra-rs --bin zebra-rs isis::\` (116 tests)
- [x] \`cargo test -p zebra-rs --bin zebra-rs policy::\` (66 tests)
- [x] \`cargo test -p zebra-rs --bin zebra-rs ospf::\` (19 tests — confirm PR 2 still happy)
- [x] \`cargo test -p zebra-rs --bin zebra-rs bgp::\` (178 tests — confirm PR 3 still happy)
- [ ] CI

Generated with [Claude Code](https://claude.com/claude-code)