### PR TITLE
policy: drop PR-1 keychain skeleton scaffolding (PR 5/5)

### DIFF
--- a/docs/design/ospf-authentication-plan.md
+++ b/docs/design/ospf-authentication-plan.md
@@ -93,11 +93,14 @@ none of them are required for the locked plan to be "complete."
 - **IETF send-id / recv-id.** OSPFv2 carries a single 8-bit key-id
   per RFC 2328 §D.3; the IETF model's per-direction id distinction
   doesn't apply on the wire. BGP's TCP-AO path uses them.
-- **Cross-protocol key-chain registry.** BGP keeps its own
-  `Bgp::key_chains: HashMap<String, _>`; OSPF added a parallel
-  `Ospf::key_chains` in Phase 4 (option (B) of the design
-  discussion). Both daemons receive the same `/key-chains/...`
-  commits and update their own copies. Unification deferred.
+- **Cross-protocol key-chain registry.** Done as of PR #928 / #930.
+  The canonical `/key-chains/...` data model lives in
+  `policy::keychain`; the policy actor parses each commit once and
+  pushes per-name snapshots to OSPF / BGP / IS-IS via
+  `PolicyRx::KeyChain`. Each protocol still owns its selection
+  helpers (lowest active by lifetime, key-id-matched receive, …)
+  and projects the shared `CryptoAlgorithm` enum onto its own
+  supported subset.
 - **OSPFv3 IPsec (RFC 4552).** Out-of-process key management,
   large surface; skip until a customer asks.
 - **Live interop testing against FRR.** Every PR's test plan
@@ -191,17 +194,24 @@ OSPF payload).
 crates/ospf-packet/
   src/parser.rs                 Ospfv2Auth, Ospfv2AuthCrypto, auth_trailer, raw_body
   src/v3.rs                     Ospfv3Options::at, Ospfv3AuthTrailer, raw_body
+zebra-rs/src/policy/keychain/
+  set.rs                        Lifetime / LifetimeEnd / Key / KeyChain / CryptoAlgorithm
+  config.rs                     KeyChainSetConfig (/key-chains/... commit)
+  mod.rs                        KeyChainScope (OspfInterface / BgpNeighbor / IsisIih / …)
 zebra-rs/src/ospf/
-  key_chain.rs                  Lifetime / LifetimeEnd / OspfChainKey / OspfKeyChain
-  link.rs                       OspfAuthMode, AuthKey, OspfCryptoAlgo, LinkConfig auth fields
+  link.rs                       OspfAuthMode, AuthKey, OspfCryptoAlgo, LinkConfig auth fields,
+                                chain_key_is_send_active, policy_algo_to_ospf,
+                                resolve_active_send_key (consumes policy::KeyChain snapshot)
   packet.rs                     AuthSendCtx, apply_link_auth, verify_link_auth, KeySource,
                                 compute_crypto_trailer, constant_time_eq
   packet_v3.rs                  apply_v3_auth_trailer, verify_v3_auth_trailer,
                                 compute_v3_trailer_digest, set_at_bit, apad_bytes
   network.rs                    inbound checksum slicing (Phase 0c)
   network_v6.rs                 outbound trailer append (Phase 5)
-  inst.rs                       Ospf::key_chains storage; v2 + v3 process_recv auth verify
-  config.rs                     /area/interface/* + /key-chains/* callbacks
+  inst.rs                       Ospf::key_chains snapshot, process_policy_msg (PolicyRx::KeyChain),
+                                v2 + v3 process_recv auth verify
+  config.rs                     /area/interface/* callbacks; per-interface key-chain
+                                Register/Unregister against policy actor
 zebra-rs/yang/
   zebra-ospf-auth-simple.yang   authentication / authentication-key / key-chain
   zebra-ospf-auth-md5.yang      message-digest-key/<id>/md5

--- a/zebra-rs/src/policy/inst.rs
+++ b/zebra-rs/src/policy/inst.rs
@@ -26,9 +26,6 @@ pub enum PolicyType {
     /// demultiplex updates back to the right per-link / per-neighbor
     /// / per-IS-IS-scope container when its `process_policy_msg`
     /// handler fires. See `policy::keychain` for the registry.
-    ///
-    /// PR 1: declared but never constructed (no subscriber yet).
-    #[allow(dead_code)]
     KeyChain(KeyChainScope),
 }
 

--- a/zebra-rs/src/policy/keychain/mod.rs
+++ b/zebra-rs/src/policy/keychain/mod.rs
@@ -1,25 +1,14 @@
-// PR 1 ships the data model + commit plumbing ahead of any consumer.
-// OSPF still parses `/key-chains/...` into its own `Ospf::key_chains`
-// map (PR 2 migrates it); BGP still parses into `Bgp::key_chains`
-// (PR 3 migrates it); IS-IS doesn't reference key-chains today (PR 4).
-// Until those land, several types/variants/methods are declared but
-// not yet referenced — silence dead_code at the module root so the
-// workspace-wide `-D warnings` build stays green.
-#![allow(dead_code)]
-
 //! Shared RFC 8177 key-chain registry.
 //!
-//! This module owns the canonical `/key-chains/...` data model. Today
-//! OSPF and BGP each parse the same YANG subtree into their own
-//! `key_chains` HashMap; the consolidation goal is to make Policy the
-//! single source of truth and have protocols subscribe to the same
-//! Register / PolicyRx pattern used for prefix-set and policy-list.
-//!
-//! This file is the PR 1 skeleton: types + dispatch + commit + Syncer
-//! wiring. No protocol consumes the new path yet — OSPF and BGP keep
-//! their existing `/key-chains/...` callbacks until the per-protocol
-//! migration PRs land. With no subscribers, the new commit path is a
-//! quiet no-op, so behavior is unchanged.
+//! Owns the canonical `/key-chains/...` data model. The policy actor
+//! parses the YANG subtree once on commit and pushes per-name
+//! snapshots to subscribed protocols via `PolicyRx::KeyChain`. OSPF
+//! (per-interface `key-chain`), BGP (per-neighbor `tcp-ao/key-chain`),
+//! and IS-IS (per-scope `area-password` / `domain-password` /
+//! per-link `hello-authentication`) all consume from this registry.
+//! Each protocol carries its own selection helpers (lowest active by
+//! lifetime, key-id-matched receive, …) and projects the shared
+//! `CryptoAlgorithm` enum down to its own supported subset.
 
 pub mod set;
 pub use set::{CryptoAlgorithm, Key, KeyChain, Lifetime, LifetimeEnd};

--- a/zebra-rs/src/policy/keychain/set.rs
+++ b/zebra-rs/src/policy/keychain/set.rs
@@ -123,12 +123,6 @@ pub struct Key {
     pub accept_lifetime: Lifetime,
 }
 
-impl Key {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 /// Named RFC 8177 key chain. Keys are ordered by key-id (YANG-typed
 /// as `uint64`; individual protocols narrow to u8/u16 at resolve
 /// time).
@@ -141,10 +135,4 @@ pub struct KeyChain {
     pub description: Option<String>,
     pub keys: BTreeMap<u64, Key>,
     pub delete: bool,
-}
-
-impl KeyChain {
-    pub fn new() -> Self {
-        Self::default()
-    }
 }


### PR DESCRIPTION
## Summary

Series cleanup. The dead_code allowlists PR 1 (#928) sprinkled to keep the skeleton green ahead of consumers are no longer needed, and the OSPF auth design doc still claimed the registry was per-daemon.

- Drop `#![allow(dead_code)]` from `policy/keychain/mod.rs` root.
- Drop `#[allow(dead_code)]` on `PolicyType::KeyChain` variant.
- Remove unused `Key::new` / `KeyChain::new` helpers (callers all build via `Default::default()` or struct literals now).
- Refresh `policy/keychain/mod.rs` doc comment to describe the finished consolidated state instead of the PR-1 staging language.
- `docs/design/ospf-authentication-plan.md`: replace the "Cross-protocol key-chain registry deferred" note with a pointer to `policy::keychain`, and refresh the file-map to list `policy/keychain/*` and the new OSPF resolve helpers.

OSPF and BGP's per-daemon `key_chains` storage was already swept by #930 and #931; `ospf/key_chain.rs` and `bgp::auth::{KeyChain, Key, CryptoAlgorithm}` were deleted in those PRs.

Net diff: +28 / −44.

This closes out the 5-PR keychain consolidation series (#928, #930, #931, #932, this).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo build -p zebra-rs`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bin zebra-rs policy::` (66 tests)
- [ ] CI

Generated with [Claude Code](https://claude.com/claude-code)