### PR TITLE
isis: observe peer Restart TLV per adjacency (GR 2/N)

### DIFF
--- a/zebra-rs/src/isis/adj.rs
+++ b/zebra-rs/src/isis/adj.rs
@@ -1,1 +1,78 @@
+use isis_packet::IsisTlvRestart;
+use serde::Serialize;
 
+/// Per-adjacency Graceful Restart observation (RFC 5306).
+///
+/// Phase 2 is read-only — we record the most recent Restart TLV the
+/// peer included in its IIH so an operator can confirm GR signaling
+/// over the wire, but we take no action on it. Helper-side state
+/// machine (refresh hold once, send RA, suppress adjacency teardown)
+/// arrives in Phase 3 and will extend this struct.
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct AdjGrState {
+    /// Most recent Restart TLV (type 211) received from the peer.
+    /// `None` until the peer sends an IIH that carries one.
+    pub last_seen: Option<IsisTlvRestart>,
+    /// Number of distinct restart attempts the peer has signaled with
+    /// RR=1. Edge-triggered on the 0→1 transition so the typical
+    /// 3-IIH RR retransmission burst counts once, not three times.
+    pub restart_count: u32,
+}
+
+impl AdjGrState {
+    /// Fold a fresh Restart TLV from the peer's IIH into the
+    /// observation. Increments `restart_count` only on the 0→1 RR
+    /// edge, then stores the new TLV so the next call can see the
+    /// previous state.
+    pub fn observe(&mut self, tlv: &IsisTlvRestart) {
+        let prev_rr = self.last_seen.as_ref().map(|t| t.rr()).unwrap_or(false);
+        if tlv.rr() && !prev_rr {
+            self.restart_count = self.restart_count.saturating_add(1);
+        }
+        self.last_seen = Some(tlv.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// First observation of RR=1 bumps the counter; a retransmitted RR
+    /// without an intervening RR=0 must not double-count it.
+    #[test]
+    fn restart_count_edge_triggers_on_rr() {
+        let mut gr = AdjGrState::default();
+        let mut tlv = IsisTlvRestart::default();
+        tlv.set_rr(true);
+
+        gr.observe(&tlv);
+        assert_eq!(gr.restart_count, 1);
+
+        // Same RR still set on the next IIH — no edge, no bump.
+        gr.observe(&tlv);
+        assert_eq!(gr.restart_count, 1);
+
+        // Peer clears RR (normal IIH), then signals a new restart.
+        let cleared = IsisTlvRestart::default();
+        gr.observe(&cleared);
+        assert_eq!(gr.restart_count, 1);
+        gr.observe(&tlv);
+        assert_eq!(gr.restart_count, 2);
+    }
+
+    /// last_seen reflects the most recent TLV verbatim, including
+    /// fields populated only when RA=1.
+    #[test]
+    fn last_seen_records_latest_tlv() {
+        let mut gr = AdjGrState::default();
+        let mut ra = IsisTlvRestart::default();
+        ra.set_ra(true);
+        ra.remaining_time = Some(27);
+
+        gr.observe(&ra);
+        let seen = gr.last_seen.expect("must record observation");
+        assert!(seen.ra());
+        assert!(!seen.rr());
+        assert_eq!(seen.remaining_time, Some(27));
+    }
+}

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -14,6 +14,7 @@ use crate::rib;
 use crate::rib::MacAddr;
 use crate::rib::{Locator, Sid, SidAllocationType, SidBehavior, SidContext, SidOwner};
 
+use super::adj::AdjGrState;
 use super::link::NetworkType;
 use super::nfsm::NfsmState;
 use super::{Isis, Level, Message, NeighborAddr4, NeighborAddr6};
@@ -51,6 +52,12 @@ pub struct Neighbor {
     /// allocator pass picks a function.
     pub endx_sid: Option<(u16, Ipv6Addr)>,
 
+    /// Graceful Restart observation (RFC 5306). Phase 2 records the
+    /// peer's most recent Restart TLV passively; helper-side behavior
+    /// (refresh hold once, send RA, suppress teardown) arrives in
+    /// Phase 3.
+    pub gr: AdjGrState,
+
     // For logging purpose.
     pub created: bool,
 }
@@ -82,6 +89,7 @@ impl Neighbor {
             hold_time: 0,
             network_type,
             endx_sid: None,
+            gr: AdjGrState::default(),
             created: true,
         }
     }

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -119,6 +119,13 @@ pub fn nbr_hello_interpret(
             IsisTlv::ProtoSupported(tlv) => {
                 nbr.proto = Some(tlv.clone());
             }
+            // RFC 5306 Restart TLV (type 211). Phase 2 records the
+            // observation onto the neighbor for `show isis
+            // graceful-restart` and Phase 3 helper-mode dispatch; no
+            // adjacency-state side effect yet.
+            IsisTlv::Restart(tlv) => {
+                nbr.gr.observe(tlv);
+            }
             _ => {}
         }
     }

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -43,6 +43,7 @@ impl Isis {
         self.show_add("/show/isis/dis/history", link::show_dis_history);
         self.show_add("/show/isis/neighbor", neigh::show);
         self.show_add("/show/isis/neighbor/detail", neigh::show_detail);
+        self.show_add("/show/isis/graceful-restart", show_isis_graceful_restart);
         self.show_add("/show/isis/database", show_isis_database);
         self.show_add("/show/isis/database/detail", show_isis_database_detail);
         self.show_add("/show/isis/hostname", hostname::show);
@@ -128,6 +129,107 @@ fn show_isis_summary(
         writeln!(buf, "{row}")?;
     }
 
+    Ok(buf)
+}
+
+// RFC 5306 Graceful Restart observation, per adjacency. Phase 2 is
+// read-only: the IIH receive path records whatever the peer puts in
+// its Restart TLV onto `Neighbor.gr`, and this view surfaces it so an
+// operator can confirm GR signaling reaches us before Phase 3 turns on
+// helper-mode behavior.
+#[derive(Serialize)]
+struct GrAdjJson {
+    level: u8,
+    system_id: String,
+    interface: String,
+    state: String,
+    restart_count: u32,
+    rr: bool,
+    ra: bool,
+    sa: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remaining_time: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    restarting_neighbor: Option<String>,
+}
+
+fn gr_adj_rows(isis: &Isis) -> Vec<GrAdjJson> {
+    let mut rows: Vec<GrAdjJson> = Vec::new();
+    for link in isis.links.values() {
+        for (level, nbrs) in [
+            (Level::L1, &link.state.nbrs.l1),
+            (Level::L2, &link.state.nbrs.l2),
+        ] {
+            for nbr in nbrs.values() {
+                let (rr, ra, sa, remaining, restarting) = match &nbr.gr.last_seen {
+                    Some(t) => (
+                        t.rr(),
+                        t.ra(),
+                        t.sa(),
+                        t.remaining_time,
+                        t.restarting_neighbor.map(|id| id.to_string()),
+                    ),
+                    None => (false, false, false, None, None),
+                };
+                rows.push(GrAdjJson {
+                    level: level.digit(),
+                    system_id: nbr.sys_id.to_string(),
+                    interface: isis.ifname(nbr.ifindex),
+                    state: nbr.state.to_string(),
+                    restart_count: nbr.gr.restart_count,
+                    rr,
+                    ra,
+                    sa,
+                    remaining_time: remaining,
+                    restarting_neighbor: restarting,
+                });
+            }
+        }
+    }
+    rows
+}
+
+fn show_isis_graceful_restart(
+    isis: &Isis,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let rows = gr_adj_rows(isis);
+
+    if json {
+        return Ok(serde_json::to_string(&rows).unwrap());
+    }
+
+    let mut buf = String::new();
+    writeln!(buf, "Graceful Restart (RFC 5306) — observation only")?;
+    writeln!(buf)?;
+    writeln!(
+        buf,
+        "L  System Id           Interface    State          Restarts RR RA SA Remaining"
+    )?;
+    if rows.is_empty() {
+        writeln!(buf, "(no neighbors)")?;
+        return Ok(buf);
+    }
+    for r in &rows {
+        let rem = r
+            .remaining_time
+            .map(|t| format!("{}s", t))
+            .unwrap_or_else(|| "-".to_string());
+        writeln!(
+            buf,
+            "{:<3}{:<20}{:<13}{:<15}{:<9}{:<3}{:<3}{:<3}{}",
+            r.level,
+            r.system_id,
+            r.interface,
+            r.state,
+            r.restart_count,
+            r.rr as u8,
+            r.ra as u8,
+            r.sa as u8,
+            rem,
+        )?;
+    }
     Ok(buf)
 }
 

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -383,6 +383,10 @@ module exec {
           type empty;
         }
       }
+      leaf graceful-restart {
+        ext:help "IS-IS Graceful Restart (RFC 5306) per-adjacency observation";
+        type empty;
+      }
       leaf hostname {
         ext:help "IS-IS hostname";
         type empty;


### PR DESCRIPTION
## Summary

Phase 2 of IS-IS Graceful Restart (RFC 5306). Adds **read-only**
detection of a peer's Restart TLV so we can confirm GR signaling
reaches us before Phase 3 turns on helper-mode behavior.

- `AdjGrState { last_seen: Option<IsisTlvRestart>, restart_count: u32 }`
  in the previously-empty `zebra-rs/src/isis/adj.rs`, with
  `observe()` that **edge-triggers** `restart_count` on the RR 0→1
  transition so a typical 3-IIH RR retransmission counts once.
- `Neighbor` carries a `gr: AdjGrState` field (default-init in
  `Neighbor::new`).
- `nbr_hello_interpret` folds `IsisTlv::Restart` into
  `nbr.gr.observe(tlv)` from both the LAN and P2P hello receive
  paths. No NFSM/hold-timer side effect yet.
- New `show isis graceful-restart` view (`/show/isis/graceful-restart`,
  registered in `exec.yang`) prints per-adjacency: level, system-id,
  interface, NFSM state, restart count, RR/RA/SA bits, remaining
  time, restarting-neighbor sys-id. JSON mode supported.

**No control-plane behavior change.** Helper-mode (refresh hold once,
send RA, suppress teardown) arrives in Phase 3 and will consume this
observation.

### Deliberate scope cuts

- No `GrMode` enum, no `t1_deadline` — both were in the Phase 2
  sketch but neither has a consumer yet; `mode` is Phase 3 territory
  and `T1` only exists when we are the restarter (Phase 6+).
- No `Display` impl for `AdjGrState` — the show callback formats
  fields directly, so an extra Display would be dead code.

## Test plan

- [x] `cargo build -p zebra-rs` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test -p isis-packet -p zebra-rs` — all pass, including
      2 new `isis::adj` tests covering the RR edge-trigger and the
      `last_seen` field.
- [ ] FRR interop check (`show isis graceful-restart` against an FRR
      restarter) — deferred until Phase 3 actually maintains the
      adjacency; today we'd just observe the TLV right before tearing
      down.

Generated with [Claude Code](https://claude.com/claude-code)