### PR TITLE
isis: graceful-restart helper-enabled config knob (GR 4/N)

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -141,6 +141,10 @@ impl Isis {
             config_sr_srv6_locator,
         );
         self.callback_add("/router/isis/fast-reroute/ti-lfa", config_ti_lfa);
+        self.callback_add(
+            "/router/isis/graceful-restart/helper-enabled",
+            config_gr_helper_enabled,
+        );
         self.callback_add("/router/isis/multi-topology", config_mt);
         self.callback_add("/router/isis/afi-safi/network", config_network);
 
@@ -348,7 +352,6 @@ impl Default for IsisDistribute {
     }
 }
 
-#[derive(Default)]
 pub struct IsisConfig {
     pub net: Nsap,
     pub hostname: Option<String>,
@@ -441,6 +444,17 @@ pub struct IsisConfig {
     /// Authentication for L2 self-originated LSPs and L2 SNPs.
     /// Same shape and lifecycle as `area_password`.
     pub domain_password: IsisAuthConfig,
+
+    /// RFC 5306 Graceful Restart helper-side enable
+    /// (`/router/isis/graceful-restart/helper-enabled`). Defaults to
+    /// true — helper behavior is transparent to peers that don't
+    /// speak GR and lossless to peers that do, so out-of-the-box on
+    /// matches FRR / IOS. When false, the IIH receive path treats
+    /// every Restart TLV as ignorable: hold timer always refreshes,
+    /// no RA in outbound IIH, no §3.2(b) CSNP kick. Observation
+    /// still feeds `show isis graceful-restart` so operators can see
+    /// what the peer sent.
+    pub gr_helper_enabled: bool,
 }
 
 /// AFI key for the redistribute map. Mirrors the
@@ -583,6 +597,49 @@ impl IsisAuthConfig {
             Self::DEFAULT_KEY_ID
         } else {
             self.key_id
+        }
+    }
+}
+
+impl Default for IsisConfig {
+    // Manual rather than derived because `gr_helper_enabled` defaults
+    // to `true` (matches the YANG default for
+    // `/router/isis/graceful-restart/helper-enabled` and FRR's
+    // out-of-the-box behavior). Every other field still takes
+    // `Default::default()` so adding a new field here is the same
+    // boilerplate as adding it to the derive.
+    fn default() -> Self {
+        Self {
+            net: Default::default(),
+            hostname: Default::default(),
+            is_type: Default::default(),
+            refresh_time: Default::default(),
+            hold_time: Default::default(),
+            min_lsp_arrival_time: Default::default(),
+            spf_initial_wait: Default::default(),
+            spf_secondary_wait: Default::default(),
+            spf_maximum_wait: Default::default(),
+            lsp_gen_initial_wait: Default::default(),
+            lsp_gen_secondary_wait: Default::default(),
+            lsp_gen_maximum_wait: Default::default(),
+            lsp_mtu_size: Default::default(),
+            te_router_id: Default::default(),
+            rib_router_id: Default::default(),
+            enable: Default::default(),
+            distribute: Default::default(),
+            sr_mpls_enabled: Default::default(),
+            sr_srv6_enabled: Default::default(),
+            sr_srv6_locator: Default::default(),
+            sr_srv6_flex_algo_locators: Default::default(),
+            ti_lfa_enabled: Default::default(),
+            mt_enabled: Default::default(),
+            mt_topologies: Default::default(),
+            networks_v4: Default::default(),
+            networks_v6: Default::default(),
+            redistribute: Default::default(),
+            area_password: Default::default(),
+            domain_password: Default::default(),
+            gr_helper_enabled: true,
         }
     }
 }
@@ -1069,6 +1126,19 @@ fn config_ti_lfa(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
     // drops them (on disable) for every prefix in this instance.
     let _ = isis.tx.send(Message::SpfCalc(Level::L1));
     let _ = isis.tx.send(Message::SpfCalc(Level::L2));
+    Some(())
+}
+
+/// `/router/isis/graceful-restart/helper-enabled`. Gates the
+/// helper-mode behavior wired in Phases 3a/3b: hold-timer-refresh
+/// suppression on retransmitted RR, RA reply in outbound IIH, and the
+/// §3.2(b) CSNP+SRM kick. On disable, the IIH receive path keeps
+/// observing Restart TLVs for `show isis graceful-restart` so the
+/// signaling stays diagnosable, but no adjacency-state side effect
+/// occurs.
+fn config_gr_helper_enabled(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let value = if op.is_set() { args.boolean()? } else { true };
+    isis.config.gr_helper_enabled = value;
     Some(())
 }
 

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -44,9 +44,14 @@ pub fn proto_supported(enable: &Afis<usize>) -> IsisTlvProtoSupported {
 /// Time set to the actual seconds until the hold timer for that
 /// neighbor expires, and (LAN only) Restarting Neighbor System ID set
 /// to the restarter's System ID. `include_restarting_neighbor` is
-/// false for P2P, where the field is unused.
+/// false for P2P, where the field is unused. Returns an empty Vec
+/// when GR helper mode is disabled in config, so disabled instances
+/// never advertise themselves as helpers.
 fn helper_ra_tlvs(link: &LinkTop, level: Level, include_restarting_neighbor: bool) -> Vec<IsisTlv> {
     let mut out = Vec::new();
+    if !link.up_config.gr_helper_enabled {
+        return out;
+    }
     for nbr in link.state.nbrs.get(&level).values() {
         if !nbr.gr.helper_active {
             continue;

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -100,7 +100,10 @@ fn helper_elected_for_csnp(link: &LinkTop, level: Level) -> bool {
 /// Fire the §3.2(b) CSNP + SRM kick if elected. Idempotent on the
 /// wire — CSNP+SRM are normally periodic, this just brings them
 /// forward so the restarter's database resync starts immediately
-/// rather than after the next csnp_interval.
+/// rather than after the next csnp_interval. The caller already
+/// gates entry on `gr_helper_enabled`, so the disabled case never
+/// reaches this function; the predicate is checked anyway for the
+/// LAN election.
 fn helper_kick_csnp(link: &mut LinkTop, level: Level) {
     if !helper_elected_for_csnp(link, level) {
         return;
@@ -326,8 +329,14 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
 
     // 8.4.2.5.2 The IS shall keep a separate holding time (adjacency
     // holdingTimer) for each “Ln Intermediate System” adjacency. The
-    // Stay case is the only one that skips the refresh.
-    if helper_edge != HelperEdge::Stay {
+    // Stay case is the only one that skips the refresh — and only
+    // when GR helper mode is enabled in config; with helper disabled
+    // we refresh unconditionally so the adjacency behaves exactly
+    // like a non-GR-aware deployment.
+    let gr_enabled = link.up_config.gr_helper_enabled;
+    let helper_entered = gr_enabled && helper_edge == HelperEdge::Enter;
+    let suppress_refresh = gr_enabled && helper_edge == HelperEdge::Stay;
+    if !suppress_refresh {
         nbr.hold_timer = Some(nfsm_hold_timer(nbr, level));
     }
 
@@ -340,7 +349,6 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
     // The CSNP+SRM kick (Phase 3b) is dispatched at the bottom of the
     // function instead of here, because it needs `&mut link` and `nbr`
     // is still borrowing from `link.state.nbrs` at this point.
-    let helper_entered = helper_edge == HelperEdge::Enter;
     if helper_entered {
         nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
     }
@@ -519,8 +527,13 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
         let (_, has_my_sys_id, helper_edge) =
             nbr_hello_interpret(nbr, &pdu.tlvs, mac, sys_id, link.local_pool);
 
-        // Refresh hold timer except on Stay (RFC 5306 §3.2(a)).
-        if helper_edge != HelperEdge::Stay {
+        // Refresh hold timer except on Stay when GR helper is enabled
+        // (RFC 5306 §3.2(a)). With helper disabled in config we always
+        // refresh.
+        let gr_enabled = link.up_config.gr_helper_enabled;
+        let helper_entered = gr_enabled && helper_edge == HelperEdge::Enter;
+        let suppress_refresh = gr_enabled && helper_edge == HelperEdge::Stay;
+        if !suppress_refresh {
             nbr.hold_timer = Some(nfsm_hold_timer(nbr, level));
         }
 
@@ -529,7 +542,6 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
         // rather than waiting up to one hello_interval. CSNP+SRM kick
         // (Phase 3b) deferred to the bottom of the loop because we
         // need `&mut link` after the nbr borrow ends.
-        let helper_entered = helper_edge == HelperEdge::Enter;
         if helper_entered {
             nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
         }

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -205,6 +205,12 @@ fn show_isis_graceful_restart(
 
     let mut buf = String::new();
     writeln!(buf, "Graceful Restart (RFC 5306) — helper mode")?;
+    let cfg_state = if isis.config.gr_helper_enabled {
+        "enabled (config)"
+    } else {
+        "DISABLED (config) — Restart TLVs observed but ignored"
+    };
+    writeln!(buf, "Helper: {}", cfg_state)?;
     writeln!(buf)?;
     writeln!(
         buf,

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -921,6 +921,29 @@ module config {
           }
         }
 
+        container graceful-restart {
+          // RFC 5306 helper-side configuration. zebra-rs is helper-only
+          // today; restarter-side mode (Phase 6+) needs LSDB/FIB
+          // checkpointing infrastructure that does not yet exist.
+          // Defaults match FRR: helper enabled out of the box, since
+          // helper behavior is transparent to peers that don't speak
+          // GR and lossless to peers that do.
+          leaf helper-enabled {
+            type boolean;
+            default true;
+            description
+              "Honor a peer's Restart TLV (RFC 5306). When true, an
+               IIH with RR=1 from an Up adjacency maintains the
+               adjacency, suppresses the hold-timer refresh on
+               retransmitted RR (RFC §3.2(a)), and triggers the §3.2(b)
+               RA reply plus an immediate CSNP+SRM kick on LANs where
+               we are the elected helper. When false, every Restart
+               TLV is observed for `show isis graceful-restart` but no
+               adjacency-state side effects occur — IIH+RR is
+               treated as any other IIH.";
+          }
+        }
+
         leaf multi-topology {
           // RFC 5120 M-ISIS Multi Topology (MT). IPv6 unicast is the
           // only option used in the industry today, so the enum


### PR DESCRIPTION
## Summary

Phase 4 of IS-IS Graceful Restart (RFC 5306). Single config knob so
operators can disable helper mode without code changes.

### Config surface

```
router isis {
  graceful-restart {
    helper-enabled true;   # default
  }
}
```

`true` (default) keeps the Phase 3a/3b helper behavior on:
hold-timer-refresh suppression on retransmitted RR, RA reply in
outbound IIH, immediate CSNP+SRM kick on first RR.

`false` reverts to non-GR behavior: every Restart TLV is observed for
`show isis graceful-restart` (so signaling stays diagnosable) but no
adjacency-state side effect occurs.

### Code

- `zebra-rs/yang/config.yang` — `container graceful-restart { leaf
  helper-enabled { type boolean; default true; } }` under `router
  isis`, sibling of `fast-reroute`. Mirrors the existing OSPF
  helper-enabled pattern.
- `zebra-rs/src/isis/config.rs` — `gr_helper_enabled: bool` field on
  `IsisConfig`. Replaced `#[derive(Default)]` with a manual `Default`
  impl so this field defaults to `true`; every other field still
  takes `Default::default()`. New `config_gr_helper_enabled` callback
  reverts to `true` on delete.
- `zebra-rs/src/isis/packet.rs` — both `hello_recv` and
  `hello_p2p_recv` compute `gr_enabled = link.up_config
  .gr_helper_enabled` and gate three behaviors via `helper_entered`
  (Enter) and `suppress_refresh` (Stay): immediate IIH, CSNP+SRM
  kick, and hold-timer-refresh suppression.
- `zebra-rs/src/isis/ifsm.rs` — `helper_ra_tlvs` early-returns when
  disabled so no instance ever advertises itself as a helper.
- `zebra-rs/src/isis/show.rs` — `show isis graceful-restart` opens
  with `Helper: enabled (config)` or `Helper: DISABLED (config) —
  Restart TLVs observed but ignored`.

### Deferred (restarter-only knobs)

- `helper-only`, `t3-hold-time`, `restart-interval` — their consumers
  don't exist yet (restarter mode is Phase 6+). The YANG container
  can absorb them when restarter mode lands.

## Test plan

- [x] `cargo build -p zebra-rs` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test -p zebra-rs` — 659/659 pass.
- [ ] Manual config round-trip (`set / commit / show running-config /
      delete / commit`) — deferred to interop bench since no test
      fixture exercises the YANG callback path today.

Generated with [Claude Code](https://claude.com/claude-code)