### PR TITLE
isis: restarter-side pre-restart staging (GR 5c/N)

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -145,6 +145,10 @@ impl Isis {
             "/router/isis/graceful-restart/helper-enabled",
             config_gr_helper_enabled,
         );
+        self.callback_add(
+            "/router/isis/graceful-restart/restarter-enabled",
+            config_gr_restarter_enabled,
+        );
         self.callback_add("/router/isis/multi-topology", config_mt);
         self.callback_add("/router/isis/afi-safi/network", config_network);
 
@@ -455,6 +459,15 @@ pub struct IsisConfig {
     /// still feeds `show isis graceful-restart` so operators can see
     /// what the peer sent.
     pub gr_helper_enabled: bool,
+
+    /// RFC 5306 Graceful Restart restarter-side enable
+    /// (`/router/isis/graceful-restart/restarter-enabled`). Defaults
+    /// to **false** — until Phase 5d wires the exit path,
+    /// advertising restarter capability without it would tear down
+    /// routes on every restart while still claiming GR to peers.
+    /// Gates `clear isis graceful-restart begin` and the IIH+RR
+    /// origination.
+    pub gr_restarter_enabled: bool,
 }
 
 /// AFI key for the redistribute map. Mirrors the
@@ -640,6 +653,7 @@ impl Default for IsisConfig {
             area_password: Default::default(),
             domain_password: Default::default(),
             gr_helper_enabled: true,
+            gr_restarter_enabled: false,
         }
     }
 }
@@ -1139,6 +1153,21 @@ fn config_ti_lfa(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
 fn config_gr_helper_enabled(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     let value = if op.is_set() { args.boolean()? } else { true };
     isis.config.gr_helper_enabled = value;
+    Some(())
+}
+
+/// `/router/isis/graceful-restart/restarter-enabled`. Gates
+/// `clear isis graceful-restart begin` and the IIH+RR origination.
+/// On disable while restarting, the restart state is cleared and
+/// the next periodic Hello goes out with RR=0 (same effect as
+/// `clear isis graceful-restart abort`).
+fn config_gr_restarter_enabled(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let value = if op.is_set() { args.boolean()? } else { false };
+    if !value && isis.restarting.is_some() {
+        // Toggling the knob off mid-restart unwinds the staging.
+        isis.restarting = None;
+    }
+    isis.config.gr_restarter_enabled = value;
     Some(())
 }
 

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -39,6 +39,24 @@ pub fn proto_supported(enable: &Afis<usize>) -> IsisTlvProtoSupported {
     IsisTlvProtoSupported { nlpids }
 }
 
+/// RFC 5306 §3.1 — when this instance is staged for restart, every
+/// outbound IIH carries a Restart TLV with RR=1. Remaining Time
+/// echoes the operator-requested grace period so helpers can seed
+/// their T3 from a non-zero value. Returns None when no restart is
+/// staged or when the restarter-enabled knob is off, so the IIH
+/// build path stays unchanged for normal operation.
+fn restarter_rr_tlv(link: &LinkTop) -> Option<IsisTlv> {
+    if !link.up_config.gr_restarter_enabled {
+        return None;
+    }
+    let r = link.restarting?;
+    Some(IsisTlv::Restart(IsisTlvRestart {
+        flags: ISIS_RESTART_FLAG_RR,
+        remaining_time: Some(r.grace_period_secs.min(u16::MAX as u32) as u16),
+        restarting_neighbor: None,
+    }))
+}
+
 /// RFC 5306 §3.2(b) — for every neighbor on this link/level currently
 /// observed in helper mode, produce a Restart TLV with RA=1, Remaining
 /// Time set to the actual seconds until the hold timer for that
@@ -142,6 +160,12 @@ pub fn hello_generate(link: &LinkTop, level: Level) -> IsisHello {
     }
     hello.tlvs.push(IsisTlvIsNeighbor { neighbors }.into());
 
+    // RFC 5306 §3.1 RR for this instance, if we're the staged
+    // restarter. Empty for normal operation.
+    if let Some(tlv) = restarter_rr_tlv(link) {
+        hello.tlvs.push(tlv);
+    }
+
     // RFC 5306 §3.2(b) RA reply for each helper-active neighbor at
     // this level. Empty when no peer is mid-restart, so non-GR
     // deployments pay nothing.
@@ -232,6 +256,11 @@ pub fn hello_p2p_generate(link: &LinkTop, level: Level) -> IsisP2pHello {
         }
     };
     hello.tlvs.push(tlv.into());
+
+    // RFC 5306 §3.1 RR for this instance, if staged for restart.
+    if let Some(tlv) = restarter_rr_tlv(link) {
+        hello.tlvs.push(tlv);
+    }
 
     // RFC 5306 §3.2(b) RA reply on P2P. Restarting Neighbor System ID
     // is unused on P2P circuits, so omit it. At most one TLV emitted

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -51,6 +51,23 @@ pub type ShowCallback = fn(&Isis, Args, bool) -> std::result::Result<String, std
 
 pub type MsgSender = UnboundedSender<Message>;
 
+/// In-progress RFC 5306 restart state. `Some` between
+/// `clear isis graceful-restart begin` and either `abort`, the
+/// `restarter-enabled` knob flipping off, or (Phase 5d+) the
+/// successful exit-restart completion.
+#[derive(Debug)]
+pub struct RestartingState {
+    /// Wall-clock at restart start. Phase 5b checkpoint freshness
+    /// and Phase 5e's T3 use this to bound how long the restart
+    /// can take.
+    pub started_at: std::time::SystemTime,
+    /// Grace period requested at restart begin (seconds). Carried
+    /// in the Restart TLV's `Remaining Time` field once Phase 5d's
+    /// exit path encodes the deadline; today it's the operator-
+    /// supplied or default value the begin handler captured.
+    pub grace_period_secs: u32,
+}
+
 pub struct Isis {
     pub tx: UnboundedSender<Message>,
     pub rx: UnboundedReceiver<Message>,
@@ -62,6 +79,15 @@ pub struct Isis {
     pub show: ShowChannel,
     pub show_cb: HashMap<String, ShowCallback>,
     pub config: IsisConfig,
+
+    /// In-progress RFC 5306 restart, if any. `None` outside a
+    /// staged restart. Read by the IIH send path to attach RR=1 to
+    /// outbound Hellos, and by the LSP refresh dispatcher to
+    /// suppress seq bumps mid-restart (RFC 5306 §3.1 forbids
+    /// re-originating at higher seq during restart — would trip
+    /// helpers' MaxSeqAdvance recovery).
+    pub restarting: Option<RestartingState>,
+
     /// Flex-Algorithm (RFC 9350) configuration tree, keyed by the
     /// numeric algorithm identifier (128..=255). Owns its own
     /// pending-cache → commit pipeline mirroring the static-route
@@ -477,6 +503,7 @@ impl Isis {
                 show: ShowChannel::new(),
                 show_cb: HashMap::new(),
                 config: IsisConfig::default(),
+                restarting: None,
                 flex_algo: super::flex_algo::FlexAlgoConfig::new(),
                 affinity_map: super::affinity_map::AffinityMap::new(),
                 tracing: IsisTracing::default(),
@@ -588,6 +615,15 @@ impl Isis {
                 "/clear/isis/checkpoint/clear" => {
                     self.checkpoint_clear_debug();
                 }
+                "/clear/isis/graceful-restart/begin" => {
+                    // Default grace period 120s — matches OSPF's
+                    // operator-default. Phase 5d's `commit` will
+                    // accept an optional `period N` arg.
+                    self.gr_restart_begin(120);
+                }
+                "/clear/isis/graceful-restart/abort" => {
+                    self.gr_restart_abort();
+                }
                 _ => {
                     //
                 }
@@ -650,6 +686,67 @@ impl Isis {
             }
             Err(e) => {
                 tracing::error!("[GR Checkpoint] write to {} failed: {}", path.display(), e);
+            }
+        }
+    }
+
+    /// `clear isis graceful-restart begin` — stage a restart per
+    /// RFC 5306 §3.1. Arms `self.restarting`, freezes self-LSP
+    /// refresh, and kicks an IIH on every link so the next
+    /// outbound Hello carries RR=1. Helpers around us see this and
+    /// enter helper mode (their Phase 3a path), replying with RA.
+    ///
+    /// Phase 5c only — no actual exit happens. `commit` (Phase 5d)
+    /// will extend this with checkpoint write + drain + despawn.
+    /// `abort` walks the staging back without exiting.
+    fn gr_restart_begin(&mut self, grace_period_secs: u32) {
+        if !self.config.gr_restarter_enabled {
+            tracing::warn!(
+                "[GR Restart] begin ignored: graceful-restart restarter-enabled is false"
+            );
+            return;
+        }
+        if self.restarting.is_some() {
+            tracing::warn!("[GR Restart] begin ignored: already restarting");
+            return;
+        }
+        self.restarting = Some(RestartingState {
+            started_at: std::time::SystemTime::now(),
+            grace_period_secs,
+        });
+        tracing::info!(
+            "[GR Restart] staged, grace period {}s; flooding IIH+RR on all links",
+            grace_period_secs,
+        );
+        self.kick_hello_all_links();
+    }
+
+    /// `clear isis graceful-restart abort` — walk back a staged
+    /// restart. Clears `self.restarting`, re-allows LSP refresh,
+    /// and kicks an IIH on every link so peers see RR=0 and exit
+    /// helper mode. No-op when no restart is staged.
+    fn gr_restart_abort(&mut self) {
+        if self.restarting.take().is_none() {
+            tracing::warn!("[GR Restart] abort: no restart staged");
+            return;
+        }
+        tracing::info!("[GR Restart] aborted; flooding IIH with RR=0");
+        self.kick_hello_all_links();
+    }
+
+    /// Fire `HelloOriginate` for every (link, level) pair so the
+    /// next IIH on every interface reflects the freshly-changed
+    /// `self.restarting` state. `hello_send`'s own `has_level`
+    /// filter drops the level the link doesn't run, so sending
+    /// both unconditionally is safe.
+    fn kick_hello_all_links(&self) {
+        for (ifindex, _) in self.links.iter() {
+            for level in [Level::L1, Level::L2] {
+                let _ = self.tx.send(Message::Ifsm(
+                    IfsmEvent::HelloOriginate,
+                    *ifindex,
+                    Some(level),
+                ));
             }
         }
     }
@@ -1241,6 +1338,16 @@ impl Isis {
 
     fn process_lsdb(&mut self, ev: LsdbEvent, level: Level, key: IsisLspId) {
         use LsdbEvent::*;
+        // RFC 5306 §3.1: during restart, we MUST NOT re-originate
+        // our self-LSPs at a higher sequence number — helpers
+        // would treat the bump as a topology change and trip their
+        // MaxSeqAdvance recovery, tearing the restart down. Skip
+        // the refresh entirely; the timer keeps ticking and the
+        // post-restart `restarting = None` path resumes normal
+        // refresh cadence on the next expiry.
+        if self.restarting.is_some() && matches!(ev, RefreshTimerExpire) {
+            return;
+        }
         let mut top = self.top();
         match ev {
             RefreshTimerExpire => {
@@ -1452,6 +1559,7 @@ impl Isis {
             tx: &self.tx,
             ptx: &link.ptx,
             up_config: &self.config,
+            restarting: self.restarting.as_ref(),
             tracing: &self.tracing,
             lsdb: &mut self.lsdb,
             flags: &link.flags,

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -125,6 +125,11 @@ pub struct LinkTop<'a> {
     pub lsdb: &'a mut Levels<Lsdb>,
     pub flags: &'a LinkFlags,
     pub up_config: &'a IsisConfig,
+    /// Snapshot of the per-instance `Isis.restarting` state. `Some`
+    /// only between `clear isis graceful-restart begin` and either
+    /// `abort` / `restarter-enabled=false` / (Phase 5d+) successful
+    /// exit. Read by the IIH send path to attach RR=1.
+    pub restarting: Option<&'a super::inst::RestartingState>,
     pub tracing: &'a IsisTracing,
     pub config: &'a LinkConfig,
     pub state: &'a mut LinkState,

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -211,7 +211,26 @@ fn show_isis_graceful_restart(
     } else {
         "DISABLED (config) — Restart TLVs observed but ignored"
     };
-    writeln!(buf, "Helper: {}", cfg_state)?;
+    writeln!(buf, "Helper:    {}", cfg_state)?;
+    // Restarter side: config + current staged-restart state. Each
+    // is independent of the helper flag — an instance can be a
+    // helper for peers while also restarting itself.
+    let restarter_cfg = if isis.config.gr_restarter_enabled {
+        "enabled (config)"
+    } else {
+        "disabled (config)"
+    };
+    write!(buf, "Restarter: {}", restarter_cfg)?;
+    if let Some(r) = isis.restarting.as_ref() {
+        let elapsed = r.started_at.elapsed().map(|d| d.as_secs()).unwrap_or(0);
+        writeln!(
+            buf,
+            " — STAGED, grace={}s, elapsed={}s",
+            r.grace_period_secs, elapsed,
+        )?;
+    } else {
+        writeln!(buf)?;
+    }
     writeln!(buf)?;
     writeln!(
         buf,

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -922,12 +922,13 @@ module config {
         }
 
         container graceful-restart {
-          // RFC 5306 helper-side configuration. zebra-rs is helper-only
-          // today; restarter-side mode (Phase 6+) needs LSDB/FIB
-          // checkpointing infrastructure that does not yet exist.
-          // Defaults match FRR: helper enabled out of the box, since
-          // helper behavior is transparent to peers that don't speak
-          // GR and lossless to peers that do.
+          // RFC 5306 helper and restarter configuration. Defaults
+          // match FRR: helper enabled out of the box (transparent /
+          // lossless), restarter OFF until the exit-wiring (Phase
+          // 5d) + restart-aware boot (5e) make the full path safe.
+          // Restarter capability advertised on the wire without the
+          // exit path would tear down routes on every restart while
+          // still claiming GR to peers — worse than no GR.
           leaf helper-enabled {
             type boolean;
             default true;
@@ -941,6 +942,18 @@ module config {
                TLV is observed for `show isis graceful-restart` but no
                adjacency-state side effects occur — IIH+RR is
                treated as any other IIH.";
+          }
+          leaf restarter-enabled {
+            type boolean;
+            default false;
+            description
+              "Allow this instance to act as the restarter side of
+               RFC 5306 graceful restart. When true, an operator-
+               triggered `clear isis graceful-restart begin` floods
+               IIH+RR on every Up interface and freezes self-LSP
+               refresh. When false, the `clear` is a no-op — until
+               the Phase 5d exit-wiring lands, advertising restarter
+               capability without it would be worse than no GR.";
           }
         }
 

--- a/zebra-rs/yang/configure.yang
+++ b/zebra-rs/yang/configure.yang
@@ -115,6 +115,21 @@ module configure {
           type empty;
         }
       }
+      container graceful-restart {
+        // RFC 5306 restarter-side staging. `begin` arms the
+        // restart state and floods IIH+RR on every Up interface;
+        // helpers around us enter helper mode and reply with RA.
+        // `abort` walks the staging back. Phase 5c only — `commit`
+        // (Phase 5d) writes the checkpoint and exits the process.
+        leaf begin {
+          ext:help "Stage a graceful restart: flood IIH+RR and freeze self-LSP refresh";
+          type empty;
+        }
+        leaf abort {
+          ext:help "Abort a staged graceful restart and resume normal operation";
+          type empty;
+        }
+      }
     }
     container ospf {
       // Force-recalculate the OSPFv2 SPF for every attached area


### PR DESCRIPTION
## Summary

Phase 5c of \`docs/design/isis-graceful-restart-restarter.md\`.
Operator-triggered pre-stage that exercises the send side of the
RFC 5306 helper handshake we already decode. **No actual exit yet
— that's 5d.**

### Behavior

\`\`\`
set router isis graceful-restart restarter-enabled true
commit
clear isis graceful-restart begin       # flood IIH+RR, freeze LSP refresh
show  isis graceful-restart              # see STAGED + per-neighbor helper activation
clear isis graceful-restart abort        # walk back; peers see RR=0
\`\`\`

Helpers around us see IIH+RR and enter helper mode (their Phase 3a
path), replying with RA. Their hold timer no longer expires on us.
Self-LSP refresh is frozen so peers don't see a seq bump that would
trip their MaxSeqAdvance recovery and tear restart down.

### Code

- **YANG**: \`graceful-restart/restarter-enabled\` leaf, **default
  false**. Restarter advertised on the wire without 5d's exit
  wiring would tear down routes on every restart while still
  claiming GR to peers — strictly worse than no GR.
- **\`IsisConfig.gr_restarter_enabled\`** + callback; toggle-off
  mid-restart unwinds the staged restart.
- **\`Isis.restarting: Option<RestartingState>\`** with
  \`started_at\` + \`grace_period_secs\`. Pre-restart freeze for
  self-LSP refresh: \`process_lsdb\`'s \`RefreshTimerExpire\` arm
  is a no-op while restarting, per RFC 5306 §3.1.
- **\`LinkTop.restarting\`** carries the borrowed state into the
  IIH build path. New \`restarter_rr_tlv\` helper in \`ifsm.rs\`
  appends \`IsisTlvRestart { RR=1, remaining_time:
  Some(grace_period_secs) }\` to outbound IIH on both LAN and P2P
  paths, positioned before the helper RA TLV and the Auth TLV so
  signed PDUs cover it.
- **\`clear isis graceful-restart {begin,abort}\`** dispatch in
  \`inst.rs\` drives a \`kick_hello_all_links\` helper that fires
  \`Message::Ifsm(HelloOriginate, ifindex, Some(level))\` for
  every (link, L1|L2) pair so the next IIH on every interface
  reflects the freshly-changed restart state.
- **\`show isis graceful-restart\`** header gains a Restarter line
  showing config flag + STAGED state + elapsed seconds.

### Deliberate scope cuts

- **No T1 retransmit timer.** Periodic Hellos already carry RR
  after \`begin\`; T1 (3s retransmit) lands with T2/T3 in Phase 5e
  where the timer triplet has shared driver code.
- **No \`commit\` (actual exit).** Phase 5d wires checkpoint write
  + drain + \`despawn_isis_graceful\`.
- **No per-link Hello-interval shortening.** RFC §3.1 allows but
  doesn't require it; current cadence is acceptable for staging.

## Test plan

- [x] \`cargo build -p zebra-rs\` — clean.
- [x] \`cargo fmt --all --check\` — clean.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` —
      clean.
- [x] \`cargo test -p zebra-rs\` — 662/662 pass.
- [ ] FRR interop: enable restarter-enabled, run \`begin\` against
      an FRR helper, confirm FRR \`show isis neighbor\` reports
      helper-mode active and our adjacency stays Up. Deferred to
      interop bench.

Generated with [Claude Code](https://claude.com/claude-code)