### PR TITLE
isis: restarter-side commit + exit (GR 5d/N)

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -62,10 +62,15 @@ pub struct RestartingState {
     /// can take.
     pub started_at: std::time::SystemTime,
     /// Grace period requested at restart begin (seconds). Carried
-    /// in the Restart TLV's `Remaining Time` field once Phase 5d's
-    /// exit path encodes the deadline; today it's the operator-
-    /// supplied or default value the begin handler captured.
+    /// in the Restart TLV's `Remaining Time` field so helpers can
+    /// seed their T3 from a meaningful value.
     pub grace_period_secs: u32,
+    /// Drain timer armed by `gr_restart_commit`. Parked here so the
+    /// Timer's Drop doesn't cancel the wakeup before it fires. When
+    /// it fires, `Message::GrRestartExit` runs `std::process::exit
+    /// (0)` and the supervisor restarts us. `None` outside the
+    /// commit→exit window.
+    pub drain_timer: Option<crate::context::Timer>,
 }
 
 pub struct Isis {
@@ -617,9 +622,11 @@ impl Isis {
                 }
                 "/clear/isis/graceful-restart/begin" => {
                     // Default grace period 120s — matches OSPF's
-                    // operator-default. Phase 5d's `commit` will
-                    // accept an optional `period N` arg.
+                    // operator-default.
                     self.gr_restart_begin(120);
+                }
+                "/clear/isis/graceful-restart/commit" => {
+                    self.gr_restart_commit();
                 }
                 "/clear/isis/graceful-restart/abort" => {
                     self.gr_restart_abort();
@@ -713,12 +720,106 @@ impl Isis {
         self.restarting = Some(RestartingState {
             started_at: std::time::SystemTime::now(),
             grace_period_secs,
+            drain_timer: None,
         });
         tracing::info!(
             "[GR Restart] staged, grace period {}s; flooding IIH+RR on all links",
             grace_period_secs,
         );
         self.kick_hello_all_links();
+    }
+
+    /// `clear isis graceful-restart commit` — stage (if not
+    /// already staged) and execute the planned restart:
+    ///   1. Originate IIH+RR on every link (Phase 5c flood).
+    ///   2. Build a Phase 6 checkpoint and atomically write it to
+    ///      `default_path()`.
+    ///   3. Arm a `Timer::once_ms(DRAIN_MS)` parked on
+    ///      `RestartingState.drain_timer` so the IIH+RR packets
+    ///      reach the wire before the socket closes.
+    ///   4. When the timer fires, `Message::GrRestartExit` runs
+    ///      `std::process::exit(0)`. Supervisor (systemd /
+    ///      operator script) restarts the process; kernel routes
+    ///      tagged `RibType::Isis` survive because no
+    ///      `ProtoCleanup` is dispatched.
+    ///
+    /// Aborts and logs (no exit) when:
+    ///   - `restarter-enabled` is off,
+    ///   - checkpoint write fails (we'd lose seq continuity on
+    ///     restart — helpers would trip MaxSeqAdvance recovery).
+    fn gr_restart_commit(&mut self) {
+        use super::checkpoint::{IsisCheckpoint, default_path};
+        use crate::context::Timer;
+
+        // Drain default — matches OSPF's locked design. YANG knob
+        // can land in a follow-up if operators report tunnel/WAN
+        // paths needing more.
+        const DRAIN_MS: u64 = 200;
+
+        if !self.config.gr_restarter_enabled {
+            tracing::warn!(
+                "[GR Restart] commit ignored: graceful-restart restarter-enabled is false"
+            );
+            return;
+        }
+
+        // Stage if not staged. `gr_restart_begin` arms `restarting`
+        // and kicks IIH+RR; calling commit on an already-staged
+        // restart skips the begin step and just adds the
+        // checkpoint + exit on top.
+        if self.restarting.is_none() {
+            self.gr_restart_begin(120);
+        } else {
+            // Already staged — re-kick Hellos so the next outbound
+            // IIH is fresh before the drain elapses.
+            self.kick_hello_all_links();
+        }
+
+        let grace_period_secs = self
+            .restarting
+            .as_ref()
+            .map(|r| r.grace_period_secs)
+            .unwrap_or(120);
+
+        let cp = IsisCheckpoint::from_instance(self, grace_period_secs);
+        let path = default_path();
+        if let Err(e) = cp.write_to_path(&path) {
+            tracing::error!(
+                "[GR Restart] commit aborted: checkpoint write to {} failed: {}",
+                path.display(),
+                e
+            );
+            return;
+        }
+        tracing::info!(
+            "[GR Restart] committed: checkpoint at {} ({} L1 self-LSPs, {} L2 self-LSPs, {} adjacencies), drain={}ms",
+            path.display(),
+            cp.levels
+                .iter()
+                .find(|l| l.level == 1)
+                .map(|l| l.self_lsps.len())
+                .unwrap_or(0),
+            cp.levels
+                .iter()
+                .find(|l| l.level == 2)
+                .map(|l| l.self_lsps.len())
+                .unwrap_or(0),
+            cp.adjacencies.len(),
+            DRAIN_MS,
+        );
+
+        // Arm the drain timer. Parked on RestartingState so its
+        // Drop doesn't cancel the wakeup before it fires.
+        let tx = self.tx.clone();
+        let drain_timer = Timer::once_ms(DRAIN_MS, move || {
+            let tx = tx.clone();
+            async move {
+                let _ = tx.send(Message::GrRestartExit);
+            }
+        });
+        if let Some(state) = self.restarting.as_mut() {
+            state.drain_timer = Some(drain_timer);
+        }
     }
 
     /// `clear isis graceful-restart abort` — walk back a staged
@@ -1012,6 +1113,14 @@ impl Isis {
             }
             Message::BfdUnsubscribe(key) => {
                 self.process_bfd_unsubscribe(key);
+            }
+            Message::GrRestartExit => {
+                // Drain window elapsed. Per the Phase 5 design doc,
+                // we trust the supervisor (systemd / operator) to
+                // restart us. Kernel routes tagged RibType::Isis
+                // survive because no ProtoCleanup is dispatched.
+                tracing::info!("[GR Restart] drain complete; exiting process");
+                std::process::exit(0);
             }
         }
     }
@@ -1815,6 +1924,12 @@ pub enum Message {
     Ifsm(IfsmEvent, u32, Option<Level>),
     Recv(IsisPacket, u32, Option<MacAddr>),
     Lsdb(LsdbEvent, Level, IsisLspId),
+    /// `gr_restart_commit` armed a `Timer::once_ms` for the drain
+    /// window. When it fires, this message tells the dispatcher to
+    /// run `std::process::exit(0)`. The supervisor (systemd /
+    /// operator script) restarts the process; kernel routes tagged
+    /// `RibType::Isis` survive because no `ProtoCleanup` is sent.
+    GrRestartExit,
     /// Re-originate the self LSP at `level`. The optional seq-number
     /// floor carries §7.3.16.4 semantics: when a peer floods our own
     /// LSP back at us with a seq higher than what we hold, we must
@@ -1908,6 +2023,7 @@ impl Display for Message {
             Message::LspSeqWrapClear(level, frag_id) => {
                 write!(f, "[Message::LspSeqWrapClear({}, frag={})]", level, frag_id)
             }
+            Message::GrRestartExit => write!(f, "[Message::GrRestartExit]"),
         }
     }
 }

--- a/zebra-rs/yang/configure.yang
+++ b/zebra-rs/yang/configure.yang
@@ -116,13 +116,19 @@ module configure {
         }
       }
       container graceful-restart {
-        // RFC 5306 restarter-side staging. `begin` arms the
-        // restart state and floods IIH+RR on every Up interface;
-        // helpers around us enter helper mode and reply with RA.
-        // `abort` walks the staging back. Phase 5c only — `commit`
-        // (Phase 5d) writes the checkpoint and exits the process.
+        // RFC 5306 restarter-side staging + commit. `begin` floods
+        // IIH+RR and freezes self-LSP refresh without exiting;
+        // `abort` walks the staging back. `commit` extends `begin`
+        // with a checkpoint write, a drain window, and process
+        // exit so the supervisor (systemd / operator) restarts us
+        // -- kernel routes tagged RibType::Isis survive because
+        // no ProtoCleanup is dispatched.
         leaf begin {
           ext:help "Stage a graceful restart: flood IIH+RR and freeze self-LSP refresh";
+          type empty;
+        }
+        leaf commit {
+          ext:help "Write the GR checkpoint, drain, and exit the process for supervisor-driven restart";
           type empty;
         }
         leaf abort {


### PR DESCRIPTION
## Summary

Phase 5d of \`docs/design/isis-graceful-restart-restarter.md\`.
**The restarter exit path is now wired end-to-end** — Phase 6
checkpoint storage and Phase 5c pre-restart staging come together
into an operator-runnable \`commit\`.

### End-to-end exerciser

\`\`\`
set router isis graceful-restart restarter-enabled true
commit
clear isis graceful-restart commit
# → IIH+RR floods, checkpoint /var/lib/zebra-rs/checkpoint/isis.cbor written,
#   process exits after 200ms drain. systemd / operator restarts us cold.
#   Kernel routes labeled with the IS-IS protocol id stay installed.
\`\`\`

### Code

- **New \`Message::GrRestartExit\`** + Display arm + dispatch arm.
  Handler runs \`tracing::info!(…); std::process::exit(0)\`.
  Supervisor restarts the process; kernel routes tagged
  \`RibType::Isis\` survive because no \`ProtoCleanup\` is sent on
  this path.
- **\`RestartingState.drain_timer\`** parks the \`Timer::once_ms\`
  wakeup so its Drop doesn't cancel the firing.
- **\`gr_restart_commit()\`** —
  1. Reject if \`restarter-enabled\` is off.
  2. Stage via \`gr_restart_begin(120)\` if not already staged
     (commit-without-begin is allowed); re-kick Hellos otherwise.
  3. Build \`IsisCheckpoint::from_instance\`, atomically write to
     \`default_path()\`. Bail with an error log on I/O failure —
     losing seq continuity would trip helpers' MaxSeqAdvance
     recovery, worse than no restart.
  4. Arm \`Timer::once_ms(DRAIN_MS=200, …)\` that sends
     \`GrRestartExit\`.
- **YANG** \`clear/isis/graceful-restart/commit\` leaf + dispatch
  in \`process_cm_msg\`.

### Deliberately deferred (operator demand permitting)

- **YANG \`drain-time-ms\` knob.** 200ms hardcoded const matches
  OSPF's locked default and is at the high end of imperceptible on
  LAN, with headroom for ~100ms tunnel RTTs.
- **\`SIGUSR1\` / \`SIGRTMIN+N\` handler** for \`systemctl reload\`.
  Vty is the headline; signal handler is additive.
- **Optional \`period N\` arg** on \`clear … commit\`. Grace period
  currently fixed at 120s via \`gr_restart_begin\`'s default.

## Test plan

- [x] \`cargo build -p zebra-rs\` — clean.
- [x] \`cargo fmt --all --check\` — clean.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` —
      clean.
- [x] \`cargo test -p zebra-rs\` — 662/662 pass.
- [ ] FRR interop bench: enable restarter-enabled on zebra-rs,
      run \`commit\`, confirm FRR neighbor stays Full and the new
      zebra-rs process picks up where the old left off. Requires
      Phase 5e-i (checkpoint replay on boot) for the full loop to
      close; without 5e-i, the post-restart process cold-starts
      and seq numbers reset — helpers re-flood.

Generated with [Claude Code](https://claude.com/claude-code)