### PR TITLE
isis: restart exit-success on neighbor-up (GR 5e-ii minimal)

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -76,11 +76,24 @@ pub struct RestartingState {
     /// - **5e-i auto-abort**: `gr_restart_load_checkpoint` arms a
     ///   `Timer::once(remaining_secs)` that fires `GrRestartAbort`
     ///   when the grace window expires without 5e-ii's exit-success
-    ///   path. Prevents the restart state from pinning indefinitely
-    ///   if 5e-ii hasn't yet shipped or its success path fails.
+    ///   path firing first.
     ///
     /// `None` outside both windows.
     pub abort_timer: Option<crate::context::Timer>,
+    /// Phase 5e-ii exit-success driver. At load time
+    /// (`gr_restart_load_checkpoint`) this is populated with the
+    /// sys-ids of every adjacency the checkpoint recorded. Each
+    /// post-restart NFSM Up transition (`Message::GrNeighborUp`)
+    /// removes the matching entry; the set going from non-empty
+    /// to empty as a result of that removal triggers
+    /// `gr_restart_exit_success`.
+    ///
+    /// Empty when no checkpoint was loaded (operator-staged
+    /// `begin` / `commit` flows) — the GrNeighborUp removal
+    /// returns `false` for an entry that wasn't there, so the
+    /// success path never fires. Operator restarts always end via
+    /// `abort` or `commit`+exit, not the success path.
+    pub pending_neighbors: std::collections::BTreeSet<IsisSysId>,
 }
 
 pub struct Isis {
@@ -819,6 +832,16 @@ impl Isis {
             }
         });
 
+        // Pending-set: drives the 5e-ii exit-success path. Each
+        // NFSM Up transition that matches a sys-id here removes it
+        // from the set; the last removal fires
+        // `gr_restart_exit_success`.
+        let pending_neighbors: std::collections::BTreeSet<isis_packet::IsisSysId> = cp
+            .adjacencies
+            .iter()
+            .map(|a| isis_packet::IsisSysId { id: a.sys_id })
+            .collect();
+
         self.restarting = Some(RestartingState {
             // Preserve original checkpoint write time so the show
             // command and helpers' grace-period view stay aligned
@@ -826,6 +849,7 @@ impl Isis {
             started_at: cp.written_at,
             grace_period_secs: cp.grace_period_secs,
             abort_timer: Some(abort_timer),
+            pending_neighbors,
         });
 
         let _ = IsisCheckpoint::delete(&path);
@@ -862,6 +886,10 @@ impl Isis {
             started_at: std::time::SystemTime::now(),
             grace_period_secs,
             abort_timer: None,
+            // Operator-staged restart — no checkpointed neighbor
+            // set. Exit-success never fires here; operator ends
+            // the restart via `abort` or `commit`+exit.
+            pending_neighbors: std::collections::BTreeSet::new(),
         });
         tracing::info!(
             "[GR Restart] staged, grace period {}s; flooding IIH+RR on all links",
@@ -963,6 +991,52 @@ impl Isis {
         if let Some(state) = self.restarting.as_mut() {
             state.abort_timer = Some(drain_timer);
         }
+    }
+
+    /// Phase 5e-ii: NFSM Up transition observed for `sys_id`.
+    /// Trim `pending_neighbors`; the last removal that empties the
+    /// set fires `gr_restart_exit_success`. Returns early when no
+    /// restart is in progress or when the sys_id wasn't part of
+    /// the loaded checkpoint (operator-staged restarts always have
+    /// an empty pending set, so the success path never fires from
+    /// them).
+    fn gr_check_exit_success(&mut self, sys_id: IsisSysId) {
+        let Some(state) = self.restarting.as_mut() else {
+            return;
+        };
+        if !state.pending_neighbors.remove(&sys_id) {
+            return;
+        }
+        if state.pending_neighbors.is_empty() {
+            self.gr_restart_exit_success();
+        }
+    }
+
+    /// Phase 5e-ii: every checkpointed neighbor is back to Up.
+    /// Clear the restart state (drops `abort_timer` via Drop so
+    /// the auto-abort safety net is cancelled), re-originate self
+    /// LSPs at `seq+1` so helpers see fresh content with the new
+    /// process's view, log success. SPF runs naturally on the
+    /// next LSDB event now that the dispatch-side gate has lifted.
+    fn gr_restart_exit_success(&mut self) {
+        let elapsed = self
+            .restarting
+            .as_ref()
+            .and_then(|s| s.started_at.elapsed().ok())
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        self.restarting = None;
+        tracing::info!(
+            "[GR Restart] exit-success: all checkpointed neighbors re-converged in ~{}s; re-originating self-LSPs at seq+1",
+            elapsed,
+        );
+        // `LspOriginate` with floor=None bumps `existing+1` per
+        // `lsp.rs:447-451`. Existing comes from the LSDB which
+        // 5e-i restored at the original seq, so the bump is +1
+        // relative to what helpers snapshotted — no MaxSeqAdvance
+        // trip, fresh content takes effect.
+        let _ = self.tx.send(Message::LspOriginate(Level::L1, None));
+        let _ = self.tx.send(Message::LspOriginate(Level::L2, None));
     }
 
     /// `clear isis graceful-restart abort` — walk back a staged
@@ -1159,6 +1233,18 @@ impl Isis {
                 link.state.nbrs.get_mut(&level).remove(&sys_id);
             }
             Message::SpfCalc(level) => {
+                // Phase 5e-ii FIB hold-back: while restarting, skip
+                // SPF entirely. Kernel routes from before the
+                // restart are still installed (despawn_isis_graceful
+                // sent ProtoQuiesce, not ProtoCleanup); recomputing
+                // and installing new routes mid-restart would
+                // partially overwrite that set with output from a
+                // possibly-stale LSDB. The exit-success path
+                // (re-originate at seq+1 + next LSDB event) drives
+                // an authoritative SPF after restart clears.
+                if self.restarting.is_some() {
+                    return;
+                }
                 // Offloaded SPF: build the graph snapshot on the main
                 // task, then dispatch Dijkstra + TI-LFA to
                 // `tokio::task::spawn_blocking`. The worker sends the
@@ -1273,6 +1359,9 @@ impl Isis {
                     "[GR Restart] grace window expired without exit-success; auto-aborting"
                 );
                 self.gr_restart_abort();
+            }
+            Message::GrNeighborUp(sys_id) => {
+                self.gr_check_exit_success(sys_id);
             }
         }
     }
@@ -2087,8 +2176,15 @@ pub enum Message {
     /// the remaining grace window. When it fires, we run the
     /// `gr_restart_abort` path: clear `restarting`, kick Hellos
     /// with RR=0, resume normal operation. Phase 5e-ii's success
-    /// path will replace this auto-abort with proper T2/T3 drive.
+    /// path lands first when neighbors reconverge before the
+    /// window expires; this auto-abort is the safety net.
     GrRestartAbort,
+    /// Sent by the IIH receive path on every NFSM Down/Init→Up
+    /// transition. The handler trims `pending_neighbors`; the
+    /// last removal fires `gr_restart_exit_success`. Outside a
+    /// loaded-checkpoint restart, `pending_neighbors` is empty
+    /// and the message is a no-op.
+    GrNeighborUp(IsisSysId),
     /// Re-originate the self LSP at `level`. The optional seq-number
     /// floor carries §7.3.16.4 semantics: when a peer floods our own
     /// LSP back at us with a seq higher than what we hold, we must
@@ -2184,6 +2280,7 @@ impl Display for Message {
             }
             Message::GrRestartExit => write!(f, "[Message::GrRestartExit]"),
             Message::GrRestartAbort => write!(f, "[Message::GrRestartAbort]"),
+            Message::GrNeighborUp(sys_id) => write!(f, "[Message::GrNeighborUp({})]", sys_id),
         }
     }
 }

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -397,6 +397,10 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
             // XXX Adjacency(Up)
             nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
             nbr.event(Message::Ifsm(DisSelection, nbr.ifindex, Some(level)));
+            // Phase 5e-ii: drive exit-success when every
+            // checkpointed peer has come back to Up. No-op outside
+            // a loaded-checkpoint restart.
+            let _ = link.tx.send(Message::GrNeighborUp(nbr.sys_id));
         }
     } else {
         // 8.4.2.5.3
@@ -579,6 +583,9 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
 
             nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
             let _ = link.tx.send(Message::AdjacencyUp(level, nbr.ifindex));
+            // Phase 5e-ii: same exit-success trigger as the LAN
+            // path. No-op outside a loaded-checkpoint restart.
+            let _ = link.tx.send(Message::GrNeighborUp(nbr.sys_id));
         }
 
         // RFC 5303 §6.1: peer's P2P-3way TLV no longer reports our

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -223,11 +223,20 @@ fn show_isis_graceful_restart(
     write!(buf, "Restarter: {}", restarter_cfg)?;
     if let Some(r) = isis.restarting.as_ref() {
         let elapsed = r.started_at.elapsed().map(|d| d.as_secs()).unwrap_or(0);
-        writeln!(
+        write!(
             buf,
             " — STAGED, grace={}s, elapsed={}s",
             r.grace_period_secs, elapsed,
         )?;
+        // Pending neighbors: populated by 5e-i checkpoint load,
+        // drained by 5e-ii GrNeighborUp. Zero means we either
+        // never had one (operator-staged) or already cleared
+        // them all and are waiting for the next event loop turn
+        // to fire exit-success.
+        if !r.pending_neighbors.is_empty() {
+            write!(buf, ", pending: {} neighbor(s)", r.pending_neighbors.len())?;
+        }
+        writeln!(buf)?;
     } else {
         writeln!(buf)?;
     }


### PR DESCRIPTION
## Summary

Phase 5e-ii (**Minimal scope** per user-confirmed split) of
\`docs/design/isis-graceful-restart-restarter.md\`. **Closes the
restart cycle via the success path**, not just the 5e-i auto-abort
safety net.

Per the agreed Minimal scope, this slice is keyed off neighbor-up
only; T1/T2/T3 timer scaffolding, LSDB-sync gating, and OL bit on
T3 expiry are deferred. Auto-abort (5e-i) remains the safety net
for slow-converging restarts.

### End-to-end cycle now closes

\`\`\`
clear isis graceful-restart commit
  → 5c flood IIH+RR
  → 5d write checkpoint, drain, exit (despawn_isis_graceful, ProtoQuiesce)

supervisor restarts process

new boot
  → 5e-i load checkpoint, restore self-LSPs, restarting=Some, pending_neighbors populated
  → IIH+RR floods (5c send path), helpers refresh
  → NFSM Down→Init→Up for each peer; GrNeighborUp sent
  → pending_neighbors drains; last removal fires gr_restart_exit_success
  → 5e-ii: restarting=None, LspOriginate(L1|L2, None) bumps to seq+1
  → next LSDB event runs SPF (gate gone), RIB reconciles with kernel
\`\`\`

### Code

- **\`RestartingState.pending_neighbors: BTreeSet<IsisSysId>\`** —
  populated from \`AdjCheckpoint.adjacencies\` at load; empty for
  operator-staged restarts (success path never fires from those).
- **\`Message::GrNeighborUp(IsisSysId)\`** + Display + dispatch arm
  that calls \`gr_check_exit_success\`.
- **\`packet.rs\`** sends \`GrNeighborUp(nbr.sys_id)\` unconditionally
  from both NFSM Up sites (LAN \`hello_recv\` Init→Up, P2P
  \`hello_p2p_recv\` Init→Up). No-op outside a checkpoint-loaded
  restart.
- **\`Isis::gr_check_exit_success\`** — \`pending.remove(&sys_id)\`
  returns \`false\` when the sys_id isn't in the set; the
  boolean-then-empty check ensures the success path fires exactly
  once.
- **\`Isis::gr_restart_exit_success\`** — drops \`restarting\`
  (cancels \`abort_timer\` via Drop), kicks
  \`LspOriginate(L1|L2, None)\`. \`lsp.rs:447-451\` bumps
  \`existing+1\`; existing comes from the restored LSP, so the
  bump is +1 relative to what helpers snapshotted — no
  MaxSeqAdvance trip.
- **\`Message::SpfCalc\` dispatch gate**: early return when
  \`restarting.is_some()\`. FIB hold-back — kernel routes from
  before the restart stay installed (despawn used
  \`ProtoQuiesce\`); recomputing mid-restart would partially
  overwrite that set with output from a possibly-stale LSDB.
- **\`show isis graceful-restart\`** Restarter line: appends
  \`, pending: N neighbor(s)\` while the set is non-empty.

### Deliberately deferred (per the Minimal scope)

- T1 per-interface/level retransmit timer. Periodic Hellos already
  carry RR while restarting; helper's first reply ends our wait.
- T2 per-level LSDB-sync gating with "expected LSPs from first
  CSNP". Success is keyed off NFSM Up; CSNP/PSNP exchange on
  first link-up reconciles any LSDB drift naturally.
- T3 system-wide with RA-driven adjustment. 5e-i auto-abort is
  the only wall-clock bound.
- OL bit on T3 expiry. Auto-abort just clears restart; no
  overload-flagged interim period. Acceptable because FIB
  hold-back means there's no half-converged routing state to
  advertise as overloaded.
- Neighbor identity pre-population at boot. Recovery walks
  NFSM through Down→Init→Up naturally; \`AdjCheckpoint\` is
  consumed only for the pending_neighbors set membership check.

## Test plan

- [x] \`cargo build -p zebra-rs\` — clean.
- [x] \`cargo fmt --all --check\` — clean.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` —
      clean.
- [x] \`cargo test -p zebra-rs\` — 662/662 pass.
- [ ] FRR interop bench: \`commit\` on zebra-rs A, supervisor
      restarts A; confirm A logs \`[GR Restart] exit-success\` once
      adjacencies recover and FRR sees A's LSPs at the original
      seq+1 (no MaxSeqAdvance log). Deferred to interop bench.

Generated with [Claude Code](https://claude.com/claude-code)