### PR TITLE
rib: clean up #[allow(dead_code)] across the rib tree

### DIFF
--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -2706,7 +2706,6 @@ mod tests {
     #[test]
     fn locator_row_classic_when_resolved_with_no_behavior() {
         let loc = Locator {
-            name: "LOC_N1".into(),
             prefix: Some("2001:db8:a:2::/64".parse().unwrap()),
             behavior: None,
         };
@@ -2720,7 +2719,6 @@ mod tests {
     #[test]
     fn locator_row_usid_when_resolved_with_usid_behavior() {
         let loc = Locator {
-            name: "LOC_N1".into(),
             prefix: Some("2001:db8:a:2::/64".parse().unwrap()),
             behavior: Some(LocatorBehavior::Usid),
         };
@@ -2746,7 +2744,6 @@ mod tests {
         // Locator entry exists in the global config but has no prefix
         // leaf yet. Same Down treatment as fully unresolved.
         let loc = Locator {
-            name: "LOC_N1".into(),
             prefix: None,
             behavior: None,
         };

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -62,7 +62,6 @@ pub struct FdbEntry {
     pub vxlan_local: Option<IpAddr>,
 }
 
-#[allow(dead_code)]
 pub struct RibRxChannel {
     pub tx: UnboundedSender<RibRx>,
     pub rx: UnboundedReceiver<RibRx>,
@@ -155,13 +154,11 @@ pub enum RibRx {
     // instead of N walks and N EoRs. Self-route filtering is
     // enforced by RIB before send — a subscriber whose proto maps
     // to `rtype` will never see a RouteAdd of that rtype.
-    #[allow(dead_code)]
     RouteAdd {
         rtype: RibType,
         routes: RouteBatch,
         bulk: BulkPhase,
     },
-    #[allow(dead_code)]
     RouteDel {
         rtype: RibType,
         routes: RouteBatch,
@@ -177,11 +174,9 @@ pub enum RibRx {
     // below. The colour-aware nexthop resolver (next PR) is the first
     // consumer; today the fan-out lands on every subscribed protocol
     // and they ignore it.
-    #[allow(dead_code)]
     FlexAlgoRouteAdd {
         route: FlexAlgoRoute,
     },
-    #[allow(dead_code)]
     FlexAlgoRouteDel {
         algo: u8,
         prefix: Ipv4Net,

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -95,13 +95,9 @@ pub enum Message {
     LocatorDel {
         name: String,
     },
-    // The Sr* variants below carry #[allow(dead_code)] because they're
-    // produced only by per-protocol subscribers (IS-IS lands in PR 2).
-    // Removed once PR 2 wires the IS-IS sender side.
     /// One-time per-protocol registration of the SR return channel. The
     /// channel carries `RibSrRx` updates for any block / locator the
     /// protocol later watches.
-    #[allow(dead_code)]
     SrSubscribe {
         proto: String,
         tx: UnboundedSender<RibSrRx>,
@@ -109,22 +105,18 @@ pub enum Message {
     /// Register interest in a named block. Triggers an immediate push of
     /// the current `Rib::blocks.get(name)` value (Some or None) and any
     /// subsequent updates.
-    #[allow(dead_code)]
     SrBlockWatch {
         proto: String,
         name: String,
     },
-    #[allow(dead_code)]
     SrBlockUnwatch {
         proto: String,
         name: String,
     },
-    #[allow(dead_code)]
     SrLocatorWatch {
         proto: String,
         name: String,
     },
-    #[allow(dead_code)]
     SrLocatorUnwatch {
         proto: String,
         name: String,
@@ -132,11 +124,9 @@ pub enum Message {
     /// Register an allocated SRv6 SID. Owners (IS-IS, OSPF, BGP) push
     /// one of these whenever they carve a function out of a locator;
     /// the RIB stores it for `show segment-routing srv6 sid`.
-    #[allow(dead_code)]
     SidAdd {
         sid: Sid,
     },
-    #[allow(dead_code)]
     SidDel {
         addr: std::net::Ipv6Addr,
     },
@@ -236,7 +226,6 @@ pub enum Message {
     /// future deltas for `(proto, afi, rtype)` with subtype filtered
     /// by `subtypes`. Empty `subtypes` is wildcard. Triggers a bulk
     /// replay followed by a `BulkPhase::Eor` marker.
-    #[allow(dead_code)]
     RedistAdd {
         proto: String,
         afi: super::RedistAfi,
@@ -250,7 +239,6 @@ pub enum Message {
     ///
     /// No-op on identical sets. Issuing RedistUpdate for a row that
     /// was never RedistAdd'd is treated as RedistAdd.
-    #[allow(dead_code)]
     RedistUpdate {
         proto: String,
         afi: super::RedistAfi,
@@ -261,7 +249,6 @@ pub enum Message {
     /// every currently-matched prefix (in chunks ending in
     /// `BulkPhase::Eor`) so the consumer can withdraw without having
     /// to remember its own per-filter state.
-    #[allow(dead_code)]
     RedistDel {
         proto: String,
         afi: super::RedistAfi,
@@ -1574,7 +1561,7 @@ impl Rib {
                 );
             }
             Message::BlockAdd { name, config } => {
-                let block = config.to_block(&name);
+                let block = config.to_block();
                 self.blocks.insert(name.clone(), block);
                 self.notify_block_watchers(&name);
             }
@@ -1590,7 +1577,7 @@ impl Rib {
                 self.notify_block_watchers(&name);
             }
             Message::LocatorAdd { name, config } => {
-                let locator = config.to_locator(&name);
+                let locator = config.to_locator();
                 self.locators.insert(name.clone(), locator);
                 self.notify_locator_watchers(&name);
             }

--- a/zebra-rs/src/rib/nexthop/inst.rs
+++ b/zebra-rs/src/rib/nexthop/inst.rs
@@ -136,11 +136,6 @@ pub struct NexthopList {
 #[serde(untagged)]
 pub enum NexthopMember {
     Uni(NexthopUni),
-    // Multi is constructed in tests but no production code path
-    // emits one yet — TI-LFA's "ECMP primary + per-primary repair"
-    // install will be the first real user. Drop the allow when that
-    // lands.
-    #[allow(dead_code)]
     Multi(NexthopMulti),
 }
 
@@ -196,96 +191,6 @@ pub struct NexthopMulti {
 
     // Nexthop Group id for multipath.
     pub gid: usize,
-}
-
-/// Either a single nexthop or an ECMP group at one metric. Used as
-/// the primary / backup slot inside `NexthopProtect` — restricted
-/// (vs `Nexthop`) so nested protection and protect-inside-list are
-/// disallowed by construction.
-#[derive(Debug, Clone, PartialEq, serde::Serialize)]
-#[serde(untagged)]
-#[allow(dead_code)] // wired into `Nexthop` in a follow-up commit
-pub enum NexthopPath {
-    Uni(NexthopUni),
-    Multi(NexthopMulti),
-}
-
-#[allow(dead_code)]
-impl NexthopPath {
-    pub fn metric(&self) -> u32 {
-        match self {
-            Self::Uni(u) => u.metric,
-            Self::Multi(m) => m.metric,
-        }
-    }
-
-    pub fn iter_unis(&self) -> impl Iterator<Item = &NexthopUni> + '_ {
-        match self {
-            Self::Uni(u) => std::slice::from_ref(u).iter(),
-            Self::Multi(m) => m.nexthops.iter(),
-        }
-    }
-
-    pub fn iter_unis_mut(&mut self) -> impl Iterator<Item = &mut NexthopUni> + '_ {
-        match self {
-            Self::Uni(u) => std::slice::from_mut(u).iter_mut(),
-            Self::Multi(m) => m.nexthops.iter_mut(),
-        }
-    }
-}
-
-/// IP/MPLS Fast-ReRoute (FRR): forward over `primary`; on primary
-/// link-down the kernel fails over to `backup` without waiting for
-/// the next SPF.
-///
-/// This is the slot TI-LFA repair install will fill, replacing the
-/// `BACKUP_METRIC_OFFSET` trick that currently piggybacks repair
-/// paths onto a `NexthopList` and distinguishes them by metric
-/// ordering. A dedicated variant makes the FRR relationship explicit
-/// (no metric sentinel), bounds the shape to exactly two slots, and
-/// gives the FIB installer a clear hook to emit a kernel FRR nexthop
-/// group (`NEXTHOP_GRP_TYPE_FRR`) rather than two separate
-/// metric-distinguished routes.
-///
-/// Both slots are `NexthopPath`, so ECMP-primary + ECMP-backup is
-/// expressible. The per-primary "each primary link has its own
-/// backup that excludes that link" association is *not* preserved at
-/// this level — primaries fail over collectively to backups, which
-/// matches what `build_rib_nexthop` already produces today.
-#[derive(Debug, Clone, PartialEq, serde::Serialize)]
-#[allow(dead_code)] // wired into `Nexthop` in a follow-up commit
-pub struct NexthopProtect {
-    pub primary: NexthopPath,
-    pub backup: NexthopPath,
-}
-
-#[allow(dead_code)]
-impl NexthopProtect {
-    /// Primary's metric — the route's metric for sorting / display.
-    /// Backup carries no meaningful metric in the FRR model.
-    pub fn metric(&self) -> u32 {
-        self.primary.metric()
-    }
-
-    /// Walk every `NexthopUni` leaf — primaries first, then backups.
-    pub fn iter_unis(&self) -> impl Iterator<Item = &NexthopUni> + '_ {
-        self.primary.iter_unis().chain(self.backup.iter_unis())
-    }
-
-    /// Mutable counterpart of `iter_unis`. Destructured up-front so
-    /// the borrow checker sees two disjoint mutable borrows.
-    pub fn iter_unis_mut(&mut self) -> impl Iterator<Item = &mut NexthopUni> + '_ {
-        let Self { primary, backup } = self;
-        primary.iter_unis_mut().chain(backup.iter_unis_mut())
-    }
-
-    pub fn iter_primary_unis(&self) -> impl Iterator<Item = &NexthopUni> + '_ {
-        self.primary.iter_unis()
-    }
-
-    pub fn iter_backup_unis(&self) -> impl Iterator<Item = &NexthopUni> + '_ {
-        self.backup.iter_unis()
-    }
 }
 
 #[cfg(test)]
@@ -363,87 +268,5 @@ mod tests {
         };
         let multi_member = NexthopMember::Multi(multi.clone());
         assert_eq!(multi_member.as_nexthop(), Nexthop::Multi(multi));
-    }
-
-    #[test]
-    fn protect_metric_returns_primary_metric() {
-        // The backup's "metric" is irrelevant in the FRR model;
-        // sort / display use the primary's.
-        let protect = NexthopProtect {
-            primary: NexthopPath::Uni(mk_uni("10.0.0.1", 20)),
-            backup: NexthopPath::Uni(mk_uni("10.0.0.5", 99)),
-        };
-        assert_eq!(protect.metric(), 20);
-    }
-
-    #[test]
-    fn protect_iter_unis_visits_primary_then_backup() {
-        // ECMP-primary + ECMP-backup: order is all primaries, then
-        // all backups — what the netlink FRR group emit needs.
-        let primary_multi = NexthopMulti {
-            metric: 20,
-            nexthops: vec![mk_uni("10.0.0.1", 20), mk_uni("10.0.0.2", 20)],
-            ..Default::default()
-        };
-        let backup_multi = NexthopMulti {
-            metric: 20,
-            nexthops: vec![mk_uni("10.0.0.5", 20), mk_uni("10.0.0.6", 20)],
-            ..Default::default()
-        };
-        let protect = NexthopProtect {
-            primary: NexthopPath::Multi(primary_multi),
-            backup: NexthopPath::Multi(backup_multi),
-        };
-        let addrs: Vec<_> = protect.iter_unis().map(|u| u.addr.to_string()).collect();
-        assert_eq!(addrs, vec!["10.0.0.1", "10.0.0.2", "10.0.0.5", "10.0.0.6"]);
-    }
-
-    #[test]
-    fn protect_primary_and_backup_iters_are_disjoint() {
-        let protect = NexthopProtect {
-            primary: NexthopPath::Uni(mk_uni("10.0.0.1", 20)),
-            backup: NexthopPath::Uni(mk_uni("10.0.0.5", 20)),
-        };
-        let pri: Vec<_> = protect
-            .iter_primary_unis()
-            .map(|u| u.addr.to_string())
-            .collect();
-        let bkp: Vec<_> = protect
-            .iter_backup_unis()
-            .map(|u| u.addr.to_string())
-            .collect();
-        assert_eq!(pri, vec!["10.0.0.1"]);
-        assert_eq!(bkp, vec!["10.0.0.5"]);
-    }
-
-    #[test]
-    fn protect_iter_unis_mut_writes_through_both_slots() {
-        // Resolver path will use this to set ifindex_resolved /
-        // valid on every leaf; both primary and backup must receive
-        // the updates.
-        let mut protect = NexthopProtect {
-            primary: NexthopPath::Uni(mk_uni("10.0.0.1", 20)),
-            backup: NexthopPath::Uni(mk_uni("10.0.0.5", 20)),
-        };
-        for u in protect.iter_unis_mut() {
-            u.valid = true;
-        }
-        assert!(matches!(&protect.primary, NexthopPath::Uni(u) if u.valid));
-        assert!(matches!(&protect.backup, NexthopPath::Uni(u) if u.valid));
-    }
-
-    #[test]
-    fn path_metric_and_iter_match_inner() {
-        let uni_path = NexthopPath::Uni(mk_uni("10.0.0.1", 20));
-        assert_eq!(uni_path.metric(), 20);
-        assert_eq!(uni_path.iter_unis().count(), 1);
-
-        let multi_path = NexthopPath::Multi(NexthopMulti {
-            metric: 30,
-            nexthops: vec![mk_uni("10.0.0.2", 30), mk_uni("10.0.0.3", 30)],
-            ..Default::default()
-        });
-        assert_eq!(multi_path.metric(), 30);
-        assert_eq!(multi_path.iter_unis().count(), 2);
     }
 }

--- a/zebra-rs/src/rib/segment_routing/block.rs
+++ b/zebra-rs/src/rib/segment_routing/block.rs
@@ -14,13 +14,9 @@ use crate::spf::label_block::LabelBlock;
 /// Applied snapshot of an SR-MPLS block, exported to the rest of the system
 /// once a config commit lands. `global` and `local` are populated only when
 /// both `start` and `range` were configured for the corresponding container.
-///
-/// Fields carry `#[allow(dead_code)]` until the IS-IS-side `mpls/block`
-/// handler reads them by name from `Rib::blocks`.
-#[allow(dead_code)]
+/// Keyed by name in `Rib::blocks`.
 #[derive(Debug, Default, Clone)]
 pub struct Block {
-    pub name: String,
     /// SR Global Block (SRGB) — prefix-SID label range.
     pub global: Option<LabelBlock>,
     /// SR Local Block (SRLB) — adjacency-SID label range.
@@ -42,7 +38,6 @@ impl Block {
     /// after a delete of the same name. SRGB 16000..23999 + SRLB 15000..15099.
     pub fn default_block() -> Self {
         Self {
-            name: DEFAULT_BLOCK_NAME.to_string(),
             global: Some(LabelBlock::new(DEFAULT_GLOBAL_START, DEFAULT_GLOBAL_RANGE)),
             local: Some(LabelBlock::new(DEFAULT_LOCAL_START, DEFAULT_LOCAL_RANGE)),
         }
@@ -73,7 +68,7 @@ pub struct BlockConfig {
 }
 
 impl BlockConfig {
-    pub fn to_block(&self, name: &str) -> Block {
+    pub fn to_block(&self) -> Block {
         let global = match (self.global_start, self.global_range) {
             (Some(start), Some(range)) => Some(LabelBlock::new(start, range)),
             _ => None,
@@ -82,11 +77,7 @@ impl BlockConfig {
             (Some(start), Some(range)) => Some(LabelBlock::new(start, range)),
             _ => None,
         };
-        Block {
-            name: name.to_string(),
-            global,
-            local,
-        }
+        Block { global, local }
     }
 }
 
@@ -276,7 +267,6 @@ mod tests {
     #[test]
     fn default_block_has_canonical_values() {
         let b = Block::default_block();
-        assert_eq!(b.name, DEFAULT_BLOCK_NAME);
 
         // LabelBlock stores (start, end = start + range), so verify the
         // pair through that derived shape.

--- a/zebra-rs/src/rib/segment_routing/locator.rs
+++ b/zebra-rs/src/rib/segment_routing/locator.rs
@@ -32,14 +32,9 @@ impl LocatorBehavior {
 }
 
 /// Applied snapshot of an SRv6 locator, exported to the rest of the system
-/// once a config commit lands.
-///
-/// Fields carry `#[allow(dead_code)]` until the IS-IS-side `srv6/locator`
-/// handler (next PR) reads them by name from `Rib::locators`.
-#[allow(dead_code)]
+/// once a config commit lands. Keyed by name in `Rib::locators`.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Locator {
-    pub name: String,
     pub prefix: Option<Ipv6Net>,
     pub behavior: Option<LocatorBehavior>,
 }
@@ -98,9 +93,8 @@ pub struct LocatorConfig {
 }
 
 impl LocatorConfig {
-    pub fn to_locator(&self, name: &str) -> Locator {
+    pub fn to_locator(&self) -> Locator {
         Locator {
-            name: name.to_string(),
             prefix: self.prefix,
             behavior: self.behavior.clone(),
         }
@@ -271,7 +265,6 @@ mod tests {
     #[test]
     fn node_sid_uses_prefix_network_address() {
         let loc = Locator {
-            name: "loc1".into(),
             prefix: Some("2001:db8:a:2::/64".parse().unwrap()),
             behavior: None,
         };
@@ -284,7 +277,6 @@ mod tests {
         // resolve to the canonical first address; protocols rely on
         // this to advertise a stable Node SID.
         let loc = Locator {
-            name: "loc1".into(),
             prefix: Some("2001:db8:a:2::5/64".parse().unwrap()),
             behavior: None,
         };
@@ -294,7 +286,6 @@ mod tests {
     #[test]
     fn node_sid_none_when_prefix_unset() {
         let loc = Locator {
-            name: "loc1".into(),
             prefix: None,
             behavior: None,
         };

--- a/zebra-rs/src/rib/segment_routing/mod.rs
+++ b/zebra-rs/src/rib/segment_routing/mod.rs
@@ -11,19 +11,11 @@ pub mod locator;
 pub use locator::{Locator, LocatorBehavior, LocatorBuilder, LocatorConfig};
 
 pub mod sid;
-// PR 2 wires up the IS-IS allocators that consume these types; until
-// then only the show callback reaches into `Sid` and these helper
-// types stay technically unused at the crate boundary.
-#[allow(unused_imports)]
 pub use sid::{Sid, SidAllocationType, SidBehavior, SidContext, SidOwner, SidStructure};
 
 /// Subscription-channel return type from RIB to a protocol module.
 /// `block: None` / `locator: None` signals deletion (or "doesn't exist
 /// yet" if the protocol asked for a name that hasn't been configured).
-///
-/// The variants carry `#[allow(dead_code)]` until PR 2 of this branch
-/// wires the IS-IS-side consumer that destructures them.
-#[allow(dead_code)]
 #[derive(Debug)]
 pub enum RibSrRx {
     Block {

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -13,11 +13,6 @@ use ipnet::Ipv6Net;
 /// SRv6 endpoint behavior for an allocated SID. RFC 8986 base set plus
 /// the RFC 9800 NEXT-C-SID (uSID) variants we install today; other
 /// behaviors (End.DT4, End.DT6, End.B6, ...) extend the enum.
-///
-/// `#[allow(dead_code)]` on the type until PR 2 starts populating the
-/// registry; the show callback already discriminates on every variant
-/// so no individual variant carries the attribute.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
 pub enum SidBehavior {
     /// Plain End — RFC 8986 §4.1, "node SID". The SID identifies the
@@ -94,7 +89,6 @@ impl std::error::Error for SidBehaviorParseError {}
 /// Required to install a uSID SID into the kernel because the
 /// `seg6local` NEXT-C-SID flavor needs Lblen / Nflen attributes to
 /// know what to shift; classic End / End.X don't carry one.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SidStructure {
     pub lb_bits: u8,
@@ -106,7 +100,6 @@ pub struct SidStructure {
 /// Optional context that disambiguates per-link / per-VRF SIDs. End is
 /// always `None`; End.X carries the outgoing interface name. Future
 /// per-VRF behaviors (End.DT4, End.DT6) would add a `Vrf(String)`.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SidContext {
     None,
@@ -122,22 +115,17 @@ impl fmt::Display for SidContext {
     }
 }
 
-/// How the SID's function bits were chosen. `Dynamic` is the common
-/// case (allocator picks the next free function); `Explicit` covers an
-/// operator-configured SID and is reserved for a future static-SID
-/// feature.
-#[allow(dead_code)]
+/// How the SID's function bits were chosen. Only `Dynamic` is used
+/// today (allocator picks the next free function).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SidAllocationType {
     Dynamic,
-    Explicit,
 }
 
 impl fmt::Display for SidAllocationType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Dynamic => write!(f, "dynamic"),
-            Self::Explicit => write!(f, "explicit"),
         }
     }
 }
@@ -153,7 +141,6 @@ pub struct SidOwner {
 }
 
 impl SidOwner {
-    #[allow(dead_code)] // first user lands in PR 2 (IS-IS End SID allocator)
     pub fn new(proto: impl Into<String>, instance: u32) -> Self {
         Self {
             proto: proto.into(),
@@ -178,7 +165,6 @@ impl fmt::Display for SidOwner {
 ///     output device); `nh6` is `None`.
 ///   - End.X: `ifindex` is the outgoing link, `nh6` is the IPv6 link-
 ///     local of the neighbor.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Sid {
     pub addr: Ipv6Addr,
@@ -296,6 +282,5 @@ mod tests {
         // Lower-case matches the FRR-style table in the design doc and
         // keeps the column narrow.
         assert_eq!(SidAllocationType::Dynamic.to_string(), "dynamic");
-        assert_eq!(SidAllocationType::Explicit.to_string(), "explicit");
     }
 }

--- a/zebra-rs/src/rib/types.rs
+++ b/zebra-rs/src/rib/types.rs
@@ -156,7 +156,6 @@ impl RibSubType {
 /// Address-family selector for a redistribute subscription. Kept as a
 /// thin enum (not the heavier `bgp_packet::AfiSafi`) because RIB only
 /// distinguishes IPv4 vs IPv6 for redistribution — SAFI doesn't apply.
-#[allow(dead_code)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
 pub enum RedistAfi {
     Ipv4,
@@ -168,7 +167,6 @@ pub enum RedistAfi {
 /// `Eor` marks the end of the initial walk-and-replay triggered by
 /// `RedistAdd` / `RedistUpdate`, or the final batch of withdrawals
 /// triggered by `RedistDel`.
-#[allow(dead_code)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum BulkPhase {
     More,
@@ -185,7 +183,6 @@ pub enum BulkPhase {
 /// `subtype` is per-entry (not per-message) so a wildcard
 /// subscription replays in a single pass with one final EoR, instead
 /// of N walks and N EoRs (one per subtype).
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RouteEntryV4 {
     pub prefix: ipnet::Ipv4Net,
@@ -196,7 +193,6 @@ pub struct RouteEntryV4 {
     pub ifindex: u32,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RouteEntryV6 {
     pub prefix: ipnet::Ipv6Net,
@@ -211,37 +207,14 @@ pub struct RouteEntryV6 {
 /// `RouteDel` message — keeps the inner `Vec` tight (no per-entry
 /// AFI tag, no `enum{V4(…),V6(…)}` overhead) since a single
 /// subscription is always one AFI by construction.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RouteBatch {
     V4(Vec<RouteEntryV4>),
     V6(Vec<RouteEntryV6>),
 }
 
-#[allow(dead_code)]
-impl RouteBatch {
-    pub fn len(&self) -> usize {
-        match self {
-            Self::V4(v) => v.len(),
-            Self::V6(v) => v.len(),
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    pub fn afi(&self) -> RedistAfi {
-        match self {
-            Self::V4(_) => RedistAfi::Ipv4,
-            Self::V6(_) => RedistAfi::Ipv6,
-        }
-    }
-}
-
 /// Cap per-message route count. Bounded so a slow consumer can't be
 /// blocked by one giant Vec, and so steady-state GC pressure stays
 /// flat. ~32 KiB per IPv4 batch at this size; tune later if profiles
 /// say so.
-#[allow(dead_code)]
 pub const REDIST_BATCH_MAX: usize = 1024;

--- a/zebra-rs/src/rib/vrf/inst.rs
+++ b/zebra-rs/src/rib/vrf/inst.rs
@@ -1,10 +1,7 @@
-use std::collections::BTreeMap;
-
 use ipnet::{Ipv4Net, Ipv6Net};
 use prefix_trie::PrefixMap;
 
 use crate::rib::RibEntries;
-use crate::rib::inst::IlmEntry;
 
 /// Applied state for one VRF instance.
 ///
@@ -42,17 +39,8 @@ pub struct Vrf {
 /// routes the install into the matching inner table.
 #[derive(Debug, Default)]
 pub struct VrfRibTables {
-    // Step 9's dispatcher reads these. Until then VrfAdd parks an
-    // empty `VrfRibTables` per VRF, and the unit tests below
-    // exercise construction — nothing in the bin target writes or
-    // reads the inner maps yet, so allow dead_code at the field
-    // level rather than churn it in/out across two PRs.
-    #[allow(dead_code)]
     pub table: PrefixMap<Ipv4Net, RibEntries>,
-    #[allow(dead_code)]
     pub table_v6: PrefixMap<Ipv6Net, RibEntries>,
-    #[allow(dead_code)]
-    pub ilm: BTreeMap<u32, IlmEntry>,
 }
 
 impl VrfRibTables {
@@ -70,7 +58,6 @@ mod tests {
         let t = VrfRibTables::new();
         assert!(t.table.iter().next().is_none());
         assert!(t.table_v6.iter().next().is_none());
-        assert!(t.ilm.is_empty());
     }
 
     #[test]
@@ -79,6 +66,5 @@ mod tests {
         let b = VrfRibTables::default();
         assert_eq!(a.table.iter().count(), b.table.iter().count());
         assert_eq!(a.table_v6.iter().count(), b.table_v6.iter().count());
-        assert_eq!(a.ilm.len(), b.ilm.len());
     }
 }


### PR DESCRIPTION
## Summary
- Drop 32 `#[allow(dead_code)]` attributes whose underlying code is now actively used by BGP, IS-IS, OSPF, the redist walker, or the FIB writer.
- Where the attribute hid genuinely-unused code, delete it: `RouteBatch::{len, is_empty, afi}`, `SidAllocationType::Explicit`, `Locator.name`, `Block.name`, `NexthopPath` + `NexthopProtect` (and 6 tests), `VrfRibTables.ilm`.
- Adjust `to_locator()` / `to_block()` to drop the now-redundant `name` argument (the BTreeMap key already provides it).

## Test plan
- [x] `cargo check -p zebra-rs --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p zebra-rs --bins` — 650 passed, 0 failed
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)