### PR TITLE
bgp: clean up #[allow(dead_code)] across the bgp tree

### DIFF
--- a/zebra-rs/src/bgp/color_policy.rs
+++ b/zebra-rs/src/bgp/color_policy.rs
@@ -37,7 +37,6 @@ impl ColorPolicy {
     /// `None` when no binding is configured — the caller decides
     /// whether to fall back (RFC 9256 §2.5) or treat the resolution
     /// as unreachable.
-    #[allow(dead_code)]
     pub fn flex_algo_for(&self, color: u32) -> Option<u8> {
         self.bindings.get(&color).copied()
     }

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -525,7 +525,6 @@ fn config_afi_safi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     Some(())
 }
 
-#[allow(dead_code)]
 fn config_rtc(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let afi_safi = AfiSafi::new(Afi::Ip, Safi::Rtc);
@@ -1440,12 +1439,6 @@ fn config_debug_category(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<
 
 impl Bgp {
     fn callback_peer(&mut self, path: &str, cb: Callback) {
-        let prefix = String::from("/router/bgp/neighbor");
-        self.callbacks.insert(prefix + path, cb);
-    }
-
-    #[allow(dead_code)]
-    fn callback_afi_safi(&mut self, path: &str, cb: Callback) {
         let prefix = String::from("/router/bgp/neighbor");
         self.callbacks.insert(prefix + path, cb);
     }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -16,7 +16,7 @@ use crate::rib::api::{FdbEntry, RibRx};
 use std::collections::{BTreeMap, HashMap};
 use std::net::{Ipv4Addr, SocketAddr};
 use tokio::net::TcpStream;
-use tokio::sync::mpsc::{self, Sender, UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 /// Map a `/clear/bgp/<afi>/neighbor[/soft[/in|out]]` path (from
 /// zebra-bgp-clear.yang) to the (AFI, SAFI, op) triple the BGP runtime
@@ -46,12 +46,10 @@ fn parse_clear_bgp_path(
     Some((afi, safi, op))
 }
 
-#[allow(dead_code)]
 #[derive(Debug)]
 pub enum Message {
     Event(usize, Event),
     Accept(TcpStream, SocketAddr),
-    Show(Sender<String>),
     /// Adv-debounce timer expired for an IPv4-unicast update-group:
     /// drain the group's pending cache, encode one UPDATE per attr
     /// bucket, and ship to each member with split-horizon pruning.
@@ -79,22 +77,6 @@ pub(crate) fn peer_index_register(
             new_vrf = %vrf,
             "bgp: peer address claimed by multiple VRFs; most recent wins",
         );
-    }
-}
-
-/// Drop the `peer_index` entry for `addr` iff it currently
-/// belongs to `vrf`. Guards against a stale `UnregisterPeer`
-/// arriving after the operator moved the peer to a different
-/// VRF.
-pub(crate) fn peer_index_unregister(
-    index: &mut BTreeMap<std::net::IpAddr, String>,
-    vrf: &str,
-    addr: std::net::IpAddr,
-) {
-    if let Some(owner) = index.get(&addr)
-        && owner == vrf
-    {
-        index.remove(&addr);
     }
 }
 
@@ -189,19 +171,13 @@ pub(crate) fn matching_import_vrfs(
 #[derive(Debug, Clone, Default)]
 pub struct RibKnownVrf {
     pub table_id: u32,
-    #[allow(dead_code)] // read by step 16's accept dispatcher.
     pub ifindex: u32,
-    #[allow(dead_code)] // first reader lands in step 18.
     pub import_rts_v4: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
-    #[allow(dead_code)] // first reader lands in step 17b.
     pub export_rts_v4: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
-    #[allow(dead_code)] // first reader lands in step 18.
     pub import_rts_v6: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
-    #[allow(dead_code)] // first reader lands in step 17b.
     pub export_rts_v6: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
 }
 
-#[allow(dead_code)]
 pub struct Bgp {
     pub asn: u32,
     pub router_id: Ipv4Addr,
@@ -740,9 +716,6 @@ impl Bgp {
                 } else {
                     accept(self, socket, sockaddr);
                 }
-            }
-            Message::Show(tx) => {
-                let _ = self.tx.try_send(Message::Show(tx));
             }
             Message::FlushUpdateGroupIpv4(group_id) => {
                 super::update_group::flush_ipv4(
@@ -1584,9 +1557,6 @@ impl Bgp {
             super::vrf::BgpGlobalMsg::RegisterPeer { vrf, addr } => {
                 peer_index_register(&mut self.peer_index, vrf, addr);
             }
-            super::vrf::BgpGlobalMsg::UnregisterPeer { vrf, addr } => {
-                peer_index_unregister(&mut self.peer_index, &vrf, addr);
-            }
         }
     }
 
@@ -1678,7 +1648,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::net::IpAddr;
 
-    use super::{peer_index_register, peer_index_unregister};
+    use super::peer_index_register;
 
     fn addr(s: &str) -> IpAddr {
         s.parse().unwrap()
@@ -1709,30 +1679,6 @@ mod tests {
         peer_index_register(&mut index, "vrfA".to_string(), addr("192.0.2.1"));
         assert_eq!(index.get(&addr("192.0.2.1")), Some(&"vrfA".to_string()));
         assert_eq!(index.len(), 1);
-    }
-
-    #[test]
-    fn unregister_drops_only_when_owner_matches() {
-        // Defends against a stale `UnregisterPeer` arriving from
-        // a VRF that no longer owns the address (operator moved
-        // the peer to a different VRF since).
-        let mut index: BTreeMap<IpAddr, String> = BTreeMap::new();
-        peer_index_register(&mut index, "vrfB".to_string(), addr("192.0.2.1"));
-        peer_index_unregister(&mut index, "vrfA", addr("192.0.2.1"));
-        assert_eq!(
-            index.get(&addr("192.0.2.1")),
-            Some(&"vrfB".to_string()),
-            "stale Unregister from vrfA must not strip vrfB's claim",
-        );
-        peer_index_unregister(&mut index, "vrfB", addr("192.0.2.1"));
-        assert!(index.is_empty());
-    }
-
-    #[test]
-    fn unregister_unknown_addr_is_noop() {
-        let mut index: BTreeMap<IpAddr, String> = BTreeMap::new();
-        peer_index_unregister(&mut index, "vrfA", addr("203.0.113.1"));
-        assert!(index.is_empty());
     }
 
     /// Step 17b-ii: helper that takes a `BgpAttr` and tags it with

--- a/zebra-rs/src/bgp/peer_key.rs
+++ b/zebra-rs/src/bgp/peer_key.rs
@@ -15,20 +15,7 @@ use ipnet::IpNet;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum PeerKey {
     Addr(IpAddr),
-    // Wired in by the follow-up interface-neighbor PR; defining the
-    // variant now keeps PeerMap signatures stable across that change.
-    #[allow(dead_code)]
     Interface(u32),
-}
-
-impl PeerKey {
-    #[allow(dead_code)]
-    pub fn addr(&self) -> Option<IpAddr> {
-        match self {
-            Self::Addr(a) => Some(*a),
-            Self::Interface(_) => None,
-        }
-    }
 }
 
 impl From<IpAddr> for PeerKey {
@@ -48,10 +35,8 @@ pub enum PeerOrigin {
     #[default]
     Static,
     /// Configured by interface: `neighbor IFNAME interface ...`.
-    #[allow(dead_code)]
     Interface { ifindex: u32 },
     /// Created on inbound accept by a `bgp listen range` match.
-    #[allow(dead_code)]
     Dynamic { range_prefix: IpNet },
 }
 
@@ -65,13 +50,6 @@ mod tests {
         let a: IpAddr = Ipv4Addr::new(10, 0, 0, 1).into();
         let k: PeerKey = a.into();
         assert_eq!(k, PeerKey::Addr(a));
-        assert_eq!(k.addr(), Some(a));
-    }
-
-    #[test]
-    fn peer_key_interface_has_no_addr() {
-        let k = PeerKey::Interface(42);
-        assert_eq!(k.addr(), None);
     }
 
     #[test]

--- a/zebra-rs/src/bgp/peer_map.rs
+++ b/zebra-rs/src/bgp/peer_map.rs
@@ -96,16 +96,7 @@ impl PeerMap {
             })
     }
 
-    /// Iterate over every peer regardless of key variant.
-    #[allow(dead_code)]
-    pub fn iter_all(&self) -> impl Iterator<Item = (&PeerKey, &Peer)> {
-        self.map
-            .iter()
-            .filter_map(move |(key, &idx)| self.peers[idx].as_ref().map(|peer| (key, peer)))
-    }
-
     /// Iterate every peer regardless of key variant, mutable.
-    #[allow(dead_code)]
     pub fn iter_mut_all(&mut self) -> impl Iterator<Item = (&PeerKey, &mut Peer)> {
         let map = &self.map;
         self.peers
@@ -179,7 +170,7 @@ mod tests {
         );
 
         assert_eq!(m.iter().count(), 1, "addr-only iter skips interface peer");
-        assert_eq!(m.iter_all().count(), 2, "iter_all includes both");
+        assert_eq!(m.iter_mut_all().count(), 2, "iter_mut_all includes both");
         assert_eq!(m.len(), 2);
     }
 

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -16,8 +16,6 @@ use std::net::Ipv4Addr;
 
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
-use bgp_packet::RouteDistinguisher;
-
 use crate::config::{ConfigChannel, ShowChannel};
 use crate::context::{ProtoContext, Task};
 
@@ -30,11 +28,6 @@ use super::super::update_group::UpdateGroupMap;
 use super::msg::{BgpGlobalMsg, BgpVrfMsg};
 
 /// Per-VRF BGP runtime. One task per `router bgp vrf X` block.
-///
-/// Most fields are written by `BgpVrf::new` at spawn time but
-/// don't gain a reader until later steps (15-18). The
-/// `dead_code` allow goes away as each consumer site lands.
-#[allow(dead_code)]
 pub struct BgpVrf {
     /// VRF name (matches the YANG list key under
     /// `/router/bgp/vrf/<name>`). Used in log lines, `show bgp vrf
@@ -57,11 +50,6 @@ pub struct BgpVrf {
     /// from the global Loc-RIB via [`BgpVrfMsg::ImportV4`] /
     /// [`BgpVrfMsg::ImportV6`] (step 18).
     pub local_rib: LocalRib,
-    /// Route Distinguisher prepended to VPNv4/v6 advertisements
-    /// originated from this VRF. `None` until the operator has
-    /// committed `set router bgp vrf <name> rd <RD>`; export to
-    /// the global Loc-RIB (step 17) is gated on `rd.is_some()`.
-    pub rd: Option<RouteDistinguisher>,
     /// Per-VRF BGP router-id. Defaults to the global router-id at
     /// spawn time (passed through by step 14); the operator may
     /// override via `set router bgp vrf <name> router-id <addr>`,
@@ -249,7 +237,6 @@ impl BgpVrf {
     pub fn new(
         name: String,
         ctx: ProtoContext,
-        rd: Option<RouteDistinguisher>,
         router_id: Ipv4Addr,
         asn: u32,
         label: u32,
@@ -262,7 +249,6 @@ impl BgpVrf {
             ctx,
             peers: PeerMap::new(),
             local_rib: LocalRib::default(),
-            rd,
             router_id,
             cm: ConfigChannel::new(),
             show: ShowChannel::new(),
@@ -323,39 +309,6 @@ impl BgpVrf {
         }
     }
 
-    /// Step 17b-i hook: push a freshly-elected best-path winner to
-    /// the global Bgp task as a VPNv4 export candidate. The global
-    /// side prepends the VRF's RD and tags the configured
-    /// export-RT set before inserting into `LocalRib.v4vpn`.
-    ///
-    /// Caller hands over `attr` by value — the global task
-    /// re-interns into its own `BgpAttrStore`. `label` is a per-VRF
-    /// MPLS label allocated by step 19; until that lands, callers
-    /// pass `0` and the global side logs / skips the install.
-    ///
-    /// Not yet wired into the per-VRF FSM. Step 17b-ii hooks it
-    /// to the post-best-path notification in
-    /// [`Self::process_msg`].
-    #[allow(dead_code)] // first caller lands in step 17b-ii.
-    pub fn export_best_path(&self, prefix: ipnet::Ipv4Net, attr: bgp_packet::BgpAttr, label: u32) {
-        let _ = self.global_tx.send(BgpGlobalMsg::Export {
-            vrf: self.name.clone(),
-            prefix,
-            attr,
-            label,
-        });
-    }
-
-    /// Inverse of [`Self::export_best_path`]. Tells the global
-    /// task to withdraw the matching VPNv4 advertisement.
-    #[allow(dead_code)] // first caller lands in step 17b-ii.
-    pub fn withdraw_exported(&self, prefix: ipnet::Ipv4Net) {
-        let _ = self.global_tx.send(BgpGlobalMsg::WithdrawExport {
-            vrf: self.name.clone(),
-            prefix,
-        });
-    }
-
     /// Handle a per-VRF FSM event off `self.rx`. Step 15d wires
     /// the same set the global `Bgp::process_msg` handles —
     /// minus `Accept` (passive accept lives at the global task
@@ -410,12 +363,6 @@ impl BgpVrf {
                     vrf = %self.name,
                     "bgp vrf: ignored Accept on vrf.tx (active-only path in step 15d)",
                 );
-            }
-            Message::Show(tx) => {
-                // Re-route to the global show subsystem by echoing
-                // the request back through the bounded tx. Step
-                // 20 wires `show bgp vrf <name>` properly.
-                let _ = self.tx.try_send(Message::Show(tx));
             }
             Message::FlushUpdateGroupIpv4(group_id) => {
                 super::super::update_group::flush_ipv4(
@@ -594,9 +541,6 @@ impl BgpVrf {
             } => {
                 self.handle_import_v4(rd, prefix, attr, label);
             }
-            BgpVrfMsg::ImportV6 { .. } => {
-                // v6 import lands after v4 ships.
-            }
             BgpVrfMsg::WithdrawImport { rd, prefix } => {
                 self.handle_withdraw_import(rd, prefix);
             }
@@ -642,7 +586,6 @@ mod tests {
         let (mut vrf, inbox) = BgpVrf::new(
             "vrf-test".to_string(),
             ctx,
-            None,
             Ipv4Addr::UNSPECIFIED,
             65000,
             /* label */ 16,
@@ -670,7 +613,6 @@ mod tests {
         let (mut vrf, inbox) = BgpVrf::new(
             "vrf-test2".to_string(),
             ctx,
-            None,
             Ipv4Addr::UNSPECIFIED,
             65000,
             /* label */ 16,
@@ -682,77 +624,6 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(2), vrf.event_loop())
             .await
             .expect("event_loop exits when inbox is dropped");
-    }
-
-    #[tokio::test]
-    async fn export_best_path_sends_global_msg_with_payload() {
-        // Step 17b-i invariant: `export_best_path` pushes a
-        // `BgpGlobalMsg::Export` carrying the VRF name, prefix,
-        // attr (by value), and label stub. The global instance's
-        // handler is exercised separately; here we only verify
-        // the producer side.
-        let (global_tx, mut global_rx) = unbounded_channel::<BgpGlobalMsg>();
-        let ctx = test_ctx_for_vrf(20, "vrf-export");
-        let (vrf, _inbox) = BgpVrf::new(
-            "vrf-export".to_string(),
-            ctx,
-            None,
-            Ipv4Addr::UNSPECIFIED,
-            65000,
-            /* label */ 16,
-            global_tx,
-        );
-
-        let prefix: ipnet::Ipv4Net = "10.0.0.0/24".parse().unwrap();
-        let attr = bgp_packet::BgpAttr::default();
-        vrf.export_best_path(prefix, attr.clone(), 0);
-
-        let msg = global_rx
-            .try_recv()
-            .expect("Export pushed onto global channel");
-        match msg {
-            BgpGlobalMsg::Export {
-                vrf: v,
-                prefix: p,
-                attr: a,
-                label,
-            } => {
-                assert_eq!(v, "vrf-export");
-                assert_eq!(p, prefix);
-                assert_eq!(a, attr);
-                assert_eq!(label, 0);
-            }
-            other => panic!("expected Export, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn withdraw_exported_sends_global_msg() {
-        let (global_tx, mut global_rx) = unbounded_channel::<BgpGlobalMsg>();
-        let ctx = test_ctx_for_vrf(21, "vrf-withdraw");
-        let (vrf, _inbox) = BgpVrf::new(
-            "vrf-withdraw".to_string(),
-            ctx,
-            None,
-            Ipv4Addr::UNSPECIFIED,
-            65000,
-            /* label */ 16,
-            global_tx,
-        );
-
-        let prefix: ipnet::Ipv4Net = "10.0.0.0/24".parse().unwrap();
-        vrf.withdraw_exported(prefix);
-
-        let msg = global_rx
-            .try_recv()
-            .expect("WithdrawExport pushed onto global channel");
-        match msg {
-            BgpGlobalMsg::WithdrawExport { vrf: v, prefix: p } => {
-                assert_eq!(v, "vrf-withdraw");
-                assert_eq!(p, prefix);
-            }
-            other => panic!("expected WithdrawExport, got {other:?}"),
-        }
     }
 
     #[tokio::test]

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -14,9 +14,10 @@
 //! Step 13 landed the enums with `Shutdown` and `Accept`
 //! populated; step 14 drains `BgpGlobalMsg` in the global event
 //! loop (`process_vrf_global_msg`) and uses `Shutdown` from
-//! `despawn_bgp_vrf`. Every other variant is still a stub for
-//! steps 16-18; the per-variant `#[allow(dead_code)]` on those
-//! variants will drop as each step lands its consumer.
+//! `despawn_bgp_vrf`. Step 16's accept dispatcher emits `Accept`
+//! though the per-VRF FSM driver (step 15d) doesn't yet consume
+//! the stream; the field carries an `#[allow(dead_code)]` until
+//! that lands.
 
 use std::net::SocketAddr;
 
@@ -55,17 +56,8 @@ pub enum BgpVrfMsg {
     ImportV4 {
         rd: RouteDistinguisher,
         prefix: ipnet::Ipv4Net,
-        #[allow(dead_code)] // first reader lands in step 18b.
         attr: BgpAttr,
         label: u32,
-    },
-
-    /// VPNv6 best-path import. Symmetric to [`Self::ImportV4`].
-    /// Stays a placeholder until v6 imports follow v4.
-    #[allow(dead_code)]
-    ImportV6 {
-        rd: RouteDistinguisher,
-        // step 18 fills the remaining fields.
     },
 
     /// Withdraw a previously-imported route. RD identifies the
@@ -99,10 +91,6 @@ pub enum BgpGlobalMsg {
     Export {
         vrf: String,
         prefix: Ipv4Net,
-        // First reader lands in step 17b-ii (LocRIB write). The
-        // step-17b-i handler logs the export decision but doesn't
-        // yet consume the attributes themselves.
-        #[allow(dead_code)]
         attr: BgpAttr,
         label: u32,
     },
@@ -117,12 +105,4 @@ pub enum BgpGlobalMsg {
     /// via [`BgpVrfMsg::Accept`]. Emitted by step 16's spawn
     /// site for every materialised peer.
     RegisterPeer { vrf: String, addr: std::net::IpAddr },
-
-    /// Inverse of [`Self::RegisterPeer`]. The global dispatcher
-    /// stops routing inbound connects from this IP to the VRF.
-    /// Step 16 doesn't yet emit this from VRF code (despawn
-    /// scrubs `peer_index` defensively on the global side);
-    /// step 15d's per-VRF FSM cleanup is the first emitter.
-    #[allow(dead_code)]
-    UnregisterPeer { vrf: String, addr: std::net::IpAddr },
 }

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -144,7 +144,6 @@ pub fn spawn_bgp_vrf(
     let (mut vrf, inbox) = BgpVrf::new(
         name.clone(),
         ctx,
-        cfg.rd,
         effective_router_id,
         asn,
         label,
@@ -419,7 +418,6 @@ mod tests {
         let (mut vrf, _inbox) = BgpVrf::new(
             "v1".to_string(),
             ctx,
-            None,
             Ipv4Addr::UNSPECIFIED,
             65000,
             /* label */ 16,
@@ -466,7 +464,6 @@ mod tests {
         let (mut vrf, _inbox) = BgpVrf::new(
             "v0".to_string(),
             ctx,
-            None,
             Ipv4Addr::UNSPECIFIED,
             65000,
             /* label */ 16,


### PR DESCRIPTION
## Summary
- Drop 25 `#[allow(dead_code)]` attributes whose underlying code is actively used; two attrs remain, both documented and legitimate (`BgpVrfHandle.task` Drop-only consumer, `BgpVrfMsg::Accept`'s `TcpStream` producer wired pending step-15d FSM driver).
- Delete genuinely-dead code surfaced when removing the attrs: `Message::Show` (only constructor was its own self-loop), `BgpVrfMsg::ImportV6`, `BgpGlobalMsg::UnregisterPeer` + helper + tests, `BgpVrf.rd` field + constructor arg, `BgpVrf::export_best_path` / `withdraw_exported` (the free-function `vrf_emit_*` are the production path), `PeerKey::addr()`, `PeerMap::iter_all()`.

## Test plan
- [x] `cargo check -p zebra-rs --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p zebra-rs --bins` — 652 passed, 0 failed
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)