### PR TITLE
bgp: use split_at_checked in ext_ipv6_com_token parser

### DIFF
--- a/crates/bgp-packet/src/attrs/ext_ipv6_com_token.rs
+++ b/crates/bgp-packet/src/attrs/ext_ipv6_com_token.rs
@@ -11,7 +11,7 @@ pub enum Token {
 
 fn parse_ipv6_value(s: &str) -> Option<(Ipv6Addr, u16)> {
     let pos = s.rfind(':')?;
-    let (addr, val) = s.split_at(pos);
+    let (addr, val) = s.split_at_checked(pos)?;
 
     // Normalize [3001:2001::] and 3001:2001::.
     let re = Regex::new(r"^\[?([^]]+)\]?$").unwrap();


### PR DESCRIPTION
## Summary
- Replace `str::split_at(pos)` with `split_at_checked(pos)?` in `parse_ipv6_value`.
- Removes a (currently unreachable) panic path and makes the safety property explicit; `parse_ipv6_value` already returns `Option`, so the failure flows through naturally.

## Test plan
- [x] `cargo fmt -p bgp-packet`
- [x] `cargo test -p bgp-packet --lib ext_ipv6_com_token` — existing `token` test passes.

Generated with [Claude Code](https://claude.com/claude-code)