### PR TITLE
src: clean up #[allow(dead_code)] across the daemon

### DIFF
--- a/zebra-rs/src/config/bgp.rs
+++ b/zebra-rs/src/config/bgp.rs
@@ -41,19 +41,3 @@ pub fn despawn_bgp(config: &ConfigManager) {
         proto: "bgp".to_string(),
     });
 }
-
-/// Graceful-restart variant of [`despawn_bgp`] (RFC 4724).
-/// Drops the protocol task + registrations but sends
-/// `ProtoQuiesce` instead of `ProtoCleanup`, so the kernel
-/// routes the BGP speaker owns stay installed while the daemon
-/// restarts. Peers in receiving-restart-helper mode mark these
-/// as "stale" until our re-advertise + End-of-RIB marker.
-#[allow(dead_code)]
-pub fn despawn_bgp_graceful(config: &ConfigManager) {
-    config.cm_clients.borrow_mut().remove("bgp");
-    config.show_clients.borrow_mut().remove("bgp");
-    config.protocol_tasks.borrow_mut().remove("bgp");
-    let _ = config.rib_tx.send(rib::Message::ProtoQuiesce {
-        proto: "bgp".to_string(),
-    });
-}

--- a/zebra-rs/src/config/commands.rs
+++ b/zebra-rs/src/config/commands.rs
@@ -106,11 +106,6 @@ fn show_version(_config: &ConfigManager) -> (ExecCode, String) {
     (ExecCode::Show, version_info.format_version())
 }
 
-#[allow(dead_code)]
-fn show_ip_route_prefix(_config: &ConfigManager) -> (ExecCode, String) {
-    (ExecCode::Show, String::from("show ip route prefix"))
-}
-
 // const CLI_CONFIGURE_MODE_PROMPT: &str = "(config)";
 const CLI_CONFIGURE_MODE_PROMPT: &str = ""; // Keep backward compatibility for now.
 

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -51,14 +51,9 @@ macro_rules! arg_parse_type {
     };
 }
 
-#[allow(dead_code)]
 impl Args {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
     }
 
     pub fn string(&mut self) -> Option<String> {

--- a/zebra-rs/src/config/ip.rs
+++ b/zebra-rs/src/config/ip.rs
@@ -110,8 +110,6 @@ pub fn match_ipv4_net(src: &str) -> (MatchType, usize) {
 // Allowed characters for normal IPv6 addresses and IPv6 prefixes with masks:
 const IPV6_ADDR_STR: &str = "0123456789abcdefABCDEF:.";
 const IPV6_PREFIX_STR: &str = "0123456789abcdefABCDEF:./";
-#[allow(dead_code)]
-const IPV6_MAX_BITLEN: i32 = 128;
 
 // State machine for parsing IPv6
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]

--- a/zebra-rs/src/config/isis.rs
+++ b/zebra-rs/src/config/isis.rs
@@ -32,19 +32,3 @@ pub fn despawn_isis(config: &ConfigManager) {
         proto: "isis".to_string(),
     });
 }
-
-/// Graceful-restart variant of [`despawn_isis`] (RFC 5306).
-/// Drops the protocol task + registrations but sends
-/// `ProtoQuiesce` instead of `ProtoCleanup`, so the kernel
-/// routes the IS-IS instance owns stay installed across the
-/// restart. Peers in T2/T3 helper state preserve the adjacency
-/// until our re-flood and CSNP/PSNP convergence completes.
-#[allow(dead_code)]
-pub fn despawn_isis_graceful(config: &ConfigManager) {
-    config.cm_clients.borrow_mut().remove("isis");
-    config.show_clients.borrow_mut().remove("isis");
-    config.protocol_tasks.borrow_mut().remove("isis");
-    let _ = config.rib_tx.send(rib::Message::ProtoQuiesce {
-        proto: "isis".to_string(),
-    });
-}

--- a/zebra-rs/src/config/ospf.rs
+++ b/zebra-rs/src/config/ospf.rs
@@ -26,22 +26,6 @@ pub fn despawn_ospf(config: &ConfigManager) {
     });
 }
 
-/// Graceful-restart variant of [`despawn_ospf`]. Drops the
-/// protocol task + registrations but sends `ProtoQuiesce`
-/// instead of `ProtoCleanup`, so the kernel routes the OSPFv2
-/// instance owns stay installed across the restart (RFC 3623).
-/// Caller is expected to have already flushed Grace LSAs and
-/// written the restart checkpoint.
-#[allow(dead_code)]
-pub fn despawn_ospf_graceful(config: &ConfigManager) {
-    config.cm_clients.borrow_mut().remove("ospf");
-    config.show_clients.borrow_mut().remove("ospf");
-    config.protocol_tasks.borrow_mut().remove("ospf");
-    let _ = config.rib_tx.send(rib::Message::ProtoQuiesce {
-        proto: "ospf".to_string(),
-    });
-}
-
 /// Spawn an OSPFv3 instance. Mirrors [`spawn_ospf`] but constructs
 /// `Ospf<Ospfv3>` instead of the default-typed `Ospf<Ospfv2>` and
 /// uses the `"ospfv3"` proto-name across the rib client / config
@@ -65,18 +49,6 @@ pub fn despawn_ospfv3(config: &ConfigManager) {
     config.show_clients.borrow_mut().remove("ospfv3");
     config.protocol_tasks.borrow_mut().remove("ospfv3");
     let _ = config.rib_tx.send(rib::Message::ProtoCleanup {
-        proto: "ospfv3".to_string(),
-    });
-}
-
-/// Graceful-restart variant of [`despawn_ospfv3`]. See
-/// [`despawn_ospf_graceful`] — same shape, OSPFv3 proto name.
-#[allow(dead_code)]
-pub fn despawn_ospfv3_graceful(config: &ConfigManager) {
-    config.cm_clients.borrow_mut().remove("ospfv3");
-    config.show_clients.borrow_mut().remove("ospfv3");
-    config.protocol_tasks.borrow_mut().remove("ospfv3");
-    let _ = config.rib_tx.send(rib::Message::ProtoQuiesce {
         proto: "ospfv3".to_string(),
     });
 }

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -1,7 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::sync::mpsc::{Sender, UnboundedSender};
+use tokio::sync::mpsc::Sender;
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::{StreamExt, wrappers::ReceiverStream};
 use tonic::Response;
@@ -509,7 +509,6 @@ impl Clear for ClearService {
 
 pub struct Cli {
     pub tx: mpsc::Sender<Message>,
-    pub _show_clients: HashMap<String, UnboundedSender<DisplayRequest>>,
     /// Runtime-mutable set of YANG-defined service-account uids. Shared
     /// with `ConfigManager`, which updates it on commit of
     /// `vty service-account uid N` changes (D25).
@@ -523,14 +522,8 @@ impl Cli {
     ) -> Self {
         Self {
             tx: config_tx,
-            _show_clients: HashMap::new(),
             yang_service_accounts,
         }
-    }
-
-    #[allow(dead_code)]
-    pub fn subscribe(&mut self, name: &str, tx: UnboundedSender<DisplayRequest>) {
-        self._show_clients.insert(name.to_string(), tx);
     }
 }
 

--- a/zebra-rs/src/config/session.rs
+++ b/zebra-rs/src/config/session.rs
@@ -41,11 +41,9 @@ pub type SessionKey = (u32, u32);
 /// the operator via PAM and promotes them to `Admin` for a bounded window
 /// (see [`Session::enable_expires`] / [`Session::enable_hard_deadline`]).
 /// Service accounts (Phase 4-d) start at `Admin` permanently.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Role {
     View,
-    Operator,
     Admin,
 }
 
@@ -65,16 +63,13 @@ pub struct SessionContext {
 /// Phase 1 added the identity and timing fields. Phase 4-a added the RBAC
 /// (`role`) and enable-state fields. Phase 4-c adds `username` (resolved
 /// once at session creation) and wires the consumption logic.
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct Session {
-    pub uid: u32,
     pub bash_pid: u32,
     /// Resolved via `getpwuid_r` at session creation. `None` only when the
     /// lookup failed (uid not in passwd db); in that case enable cannot
     /// run and admin operations fail closed.
     pub username: Option<String>,
-    pub created: Instant,
     pub last_active: Instant,
     /// Current authorization role. Defaults to `View`.
     pub role: Role,
@@ -100,13 +95,11 @@ pub const ENABLE_IDLE_TTL: Duration = Duration::from_secs(15 * 60);
 pub const ENABLE_HARD_CAP: Duration = Duration::from_secs(4 * 60 * 60);
 
 impl Session {
-    fn new(uid: u32, bash_pid: u32, username: Option<String>) -> Self {
+    fn new(bash_pid: u32, username: Option<String>) -> Self {
         let now = Instant::now();
         Self {
-            uid,
             bash_pid,
             username,
-            created: now,
             last_active: now,
             role: Role::View,
             enabled: false,
@@ -260,7 +253,7 @@ impl SessionTable {
         }
 
         let username = reader.resolve_username(peer_uid);
-        let mut session = Session::new(peer_uid, ppid_u32, username);
+        let mut session = Session::new(ppid_u32, username);
         // Permanent-admin uids: root (D20) and any uid in the
         // service-account allow-list (D21/D25). Both bypass enable and
         // have no deadlines. The yang set is consulted via the same
@@ -408,10 +401,8 @@ impl SessionTable {
         self.sessions.insert(
             key,
             Session {
-                uid: key.0,
                 bash_pid: key.1,
                 username: None,
-                created: last_active,
                 last_active,
                 role: Role::View,
                 enabled: false,
@@ -758,7 +749,6 @@ mod tests {
         assert!(is_new);
         assert_eq!(table.len(), 1);
         let sess = table.get(&key).unwrap();
-        assert_eq!(sess.uid, 1000);
         assert_eq!(sess.bash_pid, 1000);
         // Non-root sessions start as View, not enabled.
         assert_eq!(sess.role, Role::View);

--- a/zebra-rs/src/context/proto.rs
+++ b/zebra-rs/src/context/proto.rs
@@ -28,7 +28,7 @@ use std::net::SocketAddr;
 use std::os::fd::AsRawFd;
 
 use socket2::{Domain, Protocol, Socket, Type};
-use tokio::net::{TcpListener, TcpSocket, UdpSocket};
+use tokio::net::{TcpListener, TcpSocket};
 
 use crate::rib::client::RibClient;
 
@@ -95,10 +95,6 @@ impl ProtoContext {
     /// `vrf_ifname` so the resulting socket lands in the matching
     /// kernel routing table.
     ///
-    /// First production caller arrives in a step-15 follow-up
-    /// that wires per-VRF [`RibClient`] subscriptions. Until then
-    /// [`Self::for_vrf_no_rib`] is the spawn-side entry point.
-    #[allow(dead_code)]
     pub fn for_vrf(rib: RibClient, vrf_id: u32, vrf_ifname: String) -> Self {
         debug_assert!(
             vrf_id != 0,
@@ -111,27 +107,10 @@ impl ProtoContext {
         }
     }
 
-    /// VRF-attached counterpart to [`Self::default_table_no_rib`].
-    /// Retained because tests construct contexts without a real
-    /// `RibClient`; production now goes through [`Self::for_vrf`]
-    /// since the per-VRF `RibClient` subscription landed.
+    /// Read-only accessor for the VRF id. Only same-file tests
+    /// consult it today; the bin target reaches the field through
+    /// `maybe_bind_device` instead, so the lint requires the allow.
     #[allow(dead_code)]
-    pub fn for_vrf_no_rib(vrf_id: u32, vrf_ifname: String) -> Self {
-        debug_assert!(
-            vrf_id != 0,
-            "ProtoContext::for_vrf_no_rib requires a non-zero vrf_id"
-        );
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        Box::leak(Box::new(rx));
-        let rib = RibClient::new(tx, crate::rib::client::ProtoId::from_raw(u32::MAX));
-        Self {
-            vrf_id,
-            vrf_ifname: Some(vrf_ifname),
-            rib,
-        }
-    }
-
-    #[allow(dead_code)] // first reader lands in step 8 (per-VRF table dispatch).
     pub fn vrf_id(&self) -> u32 {
         self.vrf_id
     }
@@ -194,26 +173,6 @@ impl ProtoContext {
         TcpListener::from_std(std_listener)
     }
 
-    /// Bound UDP socket — convenience wrapper. Used by callers that
-    /// only need a simple bound `tokio::net::UdpSocket` and no
-    /// further per-socket setsockopt configuration. Internally
-    /// builds an unbound socket via [`Self::udp_socket_unbound`],
-    /// applies `SO_REUSEADDR`, binds, sets non-blocking, and
-    /// converts to the tokio type.
-    #[allow(dead_code)] // first caller lands when a VRF-aware UDP protocol arrives.
-    pub async fn udp_socket(&self, addr: SocketAddr) -> io::Result<UdpSocket> {
-        let domain = match addr {
-            SocketAddr::V4(_) => Domain::IPV4,
-            SocketAddr::V6(_) => Domain::IPV6,
-        };
-        let sock = self.udp_socket_unbound(domain)?;
-        sock.set_reuse_address(true)?;
-        sock.bind(&addr.into())?;
-        let std_sock: std::net::UdpSocket = sock.into();
-        std_sock.set_nonblocking(true)?;
-        UdpSocket::from_std(std_sock)
-    }
-
     /// Unbound DGRAM UDP socket pre-`SO_BINDTODEVICE`-applied.
     /// Returned as `socket2::Socket` so the caller can configure
     /// further setsockopts (`IP_TTL`, `IP_RECVTTL`, `IP_PKTINFO`,
@@ -230,7 +189,6 @@ impl ProtoContext {
     /// Caller still does any further `setsockopt` it needs (`IP_HDRINCL`,
     /// `IP_PKTINFO`, multicast joins). Returned as `socket2::Socket`
     /// so protocols can keep using `AsyncFd` to drive it.
-    #[allow(dead_code)] // OSPF / IS-IS migration in step 6 is the first caller.
     pub fn raw_socket(&self, domain: Domain, protocol: Protocol) -> io::Result<Socket> {
         let sock = Socket::new(domain, Type::RAW, Some(protocol))?;
         self.maybe_bind_device(&sock)?;
@@ -372,18 +330,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn udp_socket_on_ephemeral_port_succeeds() {
-        let ctx = ProtoContext::default_table(test_rib_client());
-        let sock = ctx
-            .udp_socket("127.0.0.1:0".parse().unwrap())
-            .await
-            .expect("udp bind on ephemeral port");
-        let local = sock.local_addr().expect("local_addr");
-        assert!(local.port() != 0);
-        assert!(local.ip().is_loopback());
-    }
-
-    #[tokio::test]
     async fn tcp_listen_v6_only_succeeds_on_localhost() {
         let ctx = ProtoContext::default_table(test_rib_client());
         let listener = ctx
@@ -477,12 +423,5 @@ mod tests {
         let observed = std::str::from_utf8(&buf[..len.saturating_sub(1) as usize])
             .expect("ifname is valid utf-8");
         assert_eq!(observed, "lo");
-    }
-
-    #[test]
-    fn for_vrf_no_rib_records_id_and_ifname() {
-        let ctx = ProtoContext::for_vrf_no_rib(17, "vrf-test".to_string());
-        assert_eq!(ctx.vrf_id(), 17);
-        assert_eq!(ctx.vrf_ifname.as_deref(), Some("vrf-test"));
     }
 }

--- a/zebra-rs/src/fib/macos.rs
+++ b/zebra-rs/src/fib/macos.rs
@@ -36,7 +36,6 @@ impl FibHandle {
         }
     }
 
-    #[allow(dead_code)]
     pub async fn route_ipv4_del(&self, dest: &Ipv4Net, entry: &RibEntry, _table_id: u32) {
         if let Some(nexthop) = entry.nexthops.first() {
             let route = Route::new(IpAddr::V4(dest.addr()), dest.prefix_len())

--- a/zebra-rs/src/fib/message.rs
+++ b/zebra-rs/src/fib/message.rs
@@ -63,7 +63,6 @@ pub struct FibAddr {
 }
 
 impl FibAddr {
-    #[allow(dead_code)]
     pub fn new() -> FibAddr {
         Self {
             ..Default::default()

--- a/zebra-rs/src/isis/affinity_map.rs
+++ b/zebra-rs/src/isis/affinity_map.rs
@@ -59,7 +59,6 @@ impl AffinityMap {
     /// Bit position currently committed for `name`, if any. Used at
     /// LSP-build time to assemble the per-link 256-bit Extended Admin
     /// Group bitmap from the names attached to each link.
-    #[allow(dead_code)]
     pub fn bit(&self, name: &str) -> Option<u16> {
         self.config.get(name).and_then(|e| e.bit_position)
     }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -262,19 +262,6 @@ pub enum Message {
     ProtoCleanup {
         proto: String,
     },
-    /// Drop the registry / redist filters / SR watchers for a
-    /// protocol whose task is being despawned, **without**
-    /// withdrawing the routes / ILMs it owns. Used by the
-    /// graceful-restart exit path so the kernel keeps forwarding
-    /// through the proto's installed routes while the daemon
-    /// restarts (RFC 3623 for OSPF, RFC 4724 for BGP, RFC 5306 for
-    /// IS-IS). The next spawn of the same proto is expected to
-    /// reclaim ownership via its protocol-specific re-convergence
-    /// (OSPF: checkpoint replay; BGP: RIB re-walk + End-of-RIB
-    /// markers; IS-IS: T2/T3 helper completion). Idempotent.
-    ProtoQuiesce {
-        proto: String,
-    },
 }
 
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1078,10 +1065,8 @@ impl Rib {
     }
 
     /// Drop the per-protocol registry / redist filters / SR
-    /// watchers without touching the FIB. Used by both
-    /// `proto_cleanup` (after withdrawing routes) and
-    /// `proto_quiesce` (which deliberately leaves routes
-    /// installed for graceful restart).
+    /// watchers without touching the FIB. Used by
+    /// `proto_cleanup` after withdrawing routes.
     fn proto_unregister(&mut self, proto: &str) {
         if let Some(proto_id) = self.client_registry.find_by_proto(proto) {
             self.client_registry.unregister(proto_id);
@@ -1094,20 +1079,6 @@ impl Rib {
         for watchers in self.locator_watch.values_mut() {
             watchers.remove(proto);
         }
-    }
-
-    /// `ProtoQuiesce` handler — RFC 3623 / 4724 / 5306
-    /// graceful-restart exit. The protocol task is going down
-    /// (planned restart), but the kernel routes / ILMs it owns
-    /// MUST stay installed so the data plane keeps forwarding.
-    /// Same registry / filter teardown as `proto_cleanup` minus
-    /// the route + ILM withdrawal pass.
-    ///
-    /// `proto` is validated only as a name lookup (no `rtype`
-    /// match required — quiesce is protocol-agnostic, and an
-    /// unknown name is a no-op).
-    fn proto_quiesce(&mut self, proto: &str) {
-        self.proto_unregister(proto);
     }
 
     // ---- redistribute subscription handlers ------------------------
@@ -1700,9 +1671,6 @@ impl Rib {
             }
             Message::ProtoCleanup { proto } => {
                 self.proto_cleanup(proto).await;
-            }
-            Message::ProtoQuiesce { proto } => {
-                self.proto_quiesce(&proto);
             }
             Message::MacAdd {
                 vni,

--- a/zebra-rs/src/spf/calc.rs
+++ b/zebra-rs/src/spf/calc.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
@@ -12,12 +11,7 @@ pub struct SpfOpt {
     pub _srv6: bool,
 }
 
-#[allow(dead_code)]
 impl SpfOpt {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub fn full_path() -> Self {
         Self {
             full_path: true,
@@ -47,7 +41,6 @@ pub struct Vertex {
     pub ilinks: Vec<Link>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum SpfDirect {
     Normal,
@@ -58,7 +51,8 @@ impl Vertex {
     /// Construct a Vertex representing a real routing system
     /// (IS-IS Node / OSPF router). `sys_id` defaults to `name` —
     /// callers with distinct hostname vs sys-id should use a
-    /// struct literal instead.
+    /// struct literal instead. Test-only today; production code
+    /// (isis/graph.rs) builds vertices via struct literals.
     #[allow(dead_code)]
     pub fn new_node(name: &str, id: usize) -> Self {
         Self {
@@ -72,6 +66,7 @@ impl Vertex {
     }
 
     /// Construct a Vertex representing an IS-IS LAN pseudonode.
+    /// Test-only today.
     #[allow(dead_code)]
     pub fn new_pseudo_node(name: &str, id: usize) -> Self {
         Self {
@@ -84,7 +79,6 @@ impl Vertex {
         }
     }
 
-    #[allow(dead_code)]
     pub fn is_pseudo_node(&self) -> bool {
         self.vtype == VertexType::PseudoNode
     }
@@ -95,11 +89,6 @@ impl Vertex {
         } else {
             &self.ilinks
         }
-    }
-
-    #[allow(dead_code)]
-    pub fn is_disabled(&self) -> bool {
-        false
     }
 }
 
@@ -119,6 +108,9 @@ pub struct Link {
 }
 
 impl Link {
+    /// Test-only constructor with implicit `link_id = 0`. Production
+    /// graph builders call [`Self::with_id`] directly so the rib-builder
+    /// can resolve back to a specific ifindex.
     #[allow(dead_code)]
     pub fn new(from: usize, to: usize, cost: u32) -> Self {
         Self {
@@ -129,7 +121,6 @@ impl Link {
         }
     }
 
-    #[allow(dead_code)]
     pub fn with_id(from: usize, to: usize, cost: u32, link_id: u32) -> Self {
         Self {
             from,
@@ -158,13 +149,6 @@ impl PartialOrd for Path {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Eq, PartialEq, Clone)] // Added Clone for easier conversion
-pub enum Paths {
-    Full(Vec<Vec<usize>>),
-    Nexthop(HashSet<Vec<usize>>),
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)] // Added Clone for easier conversion
@@ -350,6 +334,16 @@ pub fn p_space_vertices(graph: &Graph, s: usize, x: &[usize]) -> HashSet<usize> 
         .collect::<HashSet<_>>()
 }
 
+/// Compute the post-convergence paths from `s` to `d` while excluding
+/// every vertex in `x`. Test-only today; the TI-LFA repair-path
+/// builder consumes `spf_calc` directly.
+#[allow(dead_code)]
+pub fn pc_paths(graph: &Graph, s: usize, d: usize, x: &[usize]) -> Vec<Vec<usize>> {
+    spf_calc(graph, s, x, &SpfOpt::full_path(), &SpfDirect::Normal)
+        .remove(&d)
+        .map_or_else(Vec::new, |data| data.paths)
+}
+
 pub fn q_space_vertices(graph: &Graph, d: usize, x: &[usize]) -> HashSet<usize> {
     let spf = spf_reverse(graph, d, &SpfOpt::full_path());
 
@@ -362,12 +356,6 @@ pub fn q_space_vertices(graph: &Graph, d: usize, x: &[usize]) -> HashSet<usize> 
             if has_valid_paths { Some(*vertex) } else { None }
         })
         .collect::<HashSet<_>>()
-}
-
-pub fn pc_paths(graph: &Graph, s: usize, d: usize, x: &[usize]) -> Vec<Vec<usize>> {
-    spf_calc(graph, s, x, &SpfOpt::full_path(), &SpfDirect::Normal)
-        .remove(&d)
-        .map_or_else(Vec::new, |data| data.paths)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -522,23 +510,6 @@ pub fn make_repair_list(
     sr_segments
 }
 
-pub fn repair_list_print(graph: &Graph, repair_list: &Vec<SrSegment>) {
-    let name = |id: &usize| graph.get(id).map(|n| n.name.as_str()).unwrap_or("?");
-    for list in repair_list {
-        match list {
-            SrSegment::NodeSid(nid) => {
-                print!("NodeSid({}) ", name(nid));
-            }
-            SrSegment::AdjSid(from, to, None) => {
-                print!("AdjSid({}, {}) ", name(from), name(to));
-            }
-            SrSegment::AdjSid(from, to, Some(via)) => {
-                print!("AdjSid({}, {}, via {}) ", name(from), name(to), name(via));
-            }
-        }
-    }
-}
-
 #[derive(Debug)]
 pub struct RepairPath {
     /// Immediate nexthop node id on the post-convergence path —
@@ -628,24 +599,6 @@ pub fn tilfa(graph: &Graph, s: usize, d: usize, x: &[usize]) -> Vec<RepairPath> 
         repair_paths.push(repair_path);
     }
     repair_paths
-}
-
-pub fn disp(spf: &BTreeMap<usize, Path>, full_path: bool) {
-    if full_path {
-        for (vertex, path) in spf {
-            println!("vertex: {} nexthops: {}", vertex, path.paths.len());
-            for p in &path.paths {
-                println!("  metric {} path {:?}", path.cost, p);
-            }
-        }
-    } else {
-        for (vertex, nhops) in spf {
-            println!("vertex: {} nexthops: {}", vertex, nhops.nexthops.len());
-            for p in &nhops.nexthops {
-                println!("  metric {} path {:?}", nhops.cost, p);
-            }
-        }
-    }
 }
 
 use std::fmt::Write;
@@ -795,7 +748,7 @@ mod tests {
         }
 
         // SPF with nexthop tracking mode.
-        let mut opt = SpfOpt::new();
+        let mut opt = SpfOpt::default();
         let tree = spf(&graph, 0, &opt);
 
         // vertex:0 nexthops: 1


### PR DESCRIPTION
## Summary
- Drop ~20 stale `#[allow(dead_code)]` attrs across `config/`, `context/`, `fib/`, `isis/`, `ospf/`, `spf/`, and `rib/`.
- Delete the now-unused code those attrs were hiding:
  - Graceful-restart despawn variants (`despawn_{bgp,isis,ospf,ospfv3}_graceful`) and their cascade: `Message::ProtoQuiesce` variant + handler + `proto_quiesce` helper (no producers left).
  - `show_ip_route_prefix` stub, `IPV6_MAX_BITLEN`, `Args::len()`.
  - `Cli._show_clients` field + `subscribe()` method.
  - `Role::Operator` variant; `Session::uid` and `Session::created` fields.
  - `ProtoContext::for_vrf_no_rib` + matching test; `ProtoContext::udp_socket` + matching test.
  - `spf::{repair_list_print, disp, SpfOpt::new}`; spf/calc.rs module-level `#![allow(dead_code)]` + 9 redundant per-item attrs collapsed.
- 9 documented allows remain across the entire src/: Drop-held timers/tasks and cross-target test helpers where the bin-target dead_code lint doesn't see the test users.

## Test plan
- [x] `cargo check -p zebra-rs --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p zebra-rs --bins` — 649 passed, 0 failed
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)