### PR TITLE
context: abort Timer's inner task on Drop

### DIFF
--- a/zebra-rs/src/context/task.rs
+++ b/zebra-rs/src/context/task.rs
@@ -32,6 +32,13 @@ pub struct Timer {
     tx: UnboundedSender<TimerMessage>,
     duration: Duration,              // Store the timer duration
     last_reset: Arc<Mutex<Instant>>, // Track the last reset time
+    join_handle: task::JoinHandle<()>,
+}
+
+impl Drop for Timer {
+    fn drop(&mut self) {
+        self.join_handle.abort();
+    }
 }
 
 #[derive(Debug)]
@@ -66,7 +73,7 @@ impl Timer {
         let last_reset = Arc::new(Mutex::new(Instant::now()));
 
         let last_reset_clone = last_reset.clone();
-        tokio::spawn(async move {
+        let join_handle = tokio::spawn(async move {
             let mut interval = tokio::time::interval(duration);
             if typ != TimerType::ImmediateRepeat {
                 _ = interval.tick().await;
@@ -102,6 +109,7 @@ impl Timer {
             tx,
             duration,
             last_reset,
+            join_handle,
         }
     }
 


### PR DESCRIPTION
## Summary
- `Timer::new` spawned its driver task and dropped the `JoinHandle`, so the task only terminated via its internal `rx.recv() == None` arm — which races with `interval.tick()` in the same `select!`. When a `Timer` was dropped just as the interval expired, the callback fired once against a parent that had already gone away.
- This is the structural cause of the OSPF inactivity-timer panic at `zebra-rs/src/ospf/nfsm.rs:304`. `despawn_ospf` aborts the OSPF `event_loop` (`Task<T>` aborts on `Drop`), so `Ospf::rx` is dropped — but per-neighbor `Timer` tasks captured a clone of the now-orphaned sender and kept firing for up to one full interval, panicking on `tx.send(...).unwrap()`.
- Store the `JoinHandle` on `Timer` and abort it on `Drop`, mirroring `Task<T>`. Dropping a `Timer` now synchronously cancels its driver task — including any in-flight `(cb)().await` — so detached callbacks can no longer outlive the structure that armed them.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo build -p zebra-rs`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] CI: fmt / clippy / test

Generated with [Claude Code](https://claude.com/claude-code)