### PR TITLE
ospf: don't unwrap inactivity-timer send in nfsm

### DIFF
--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -300,8 +300,7 @@ pub fn ospf_inactivity_timer<V: OspfVersion>(nbr: &Neighbor<V>) -> Timer {
         use NfsmEvent::*;
         let tx = tx.clone();
         async move {
-            tx.send(Message::Nfsm(ifindex, nbr_addr, InactivityTimer))
-                .unwrap();
+            let _ = tx.send(Message::Nfsm(ifindex, nbr_addr, InactivityTimer));
         }
     })
 }


### PR DESCRIPTION
## Summary
- The two sibling timer callbacks in `zebra-rs/src/ospf/nfsm.rs` (`ospf_dd_retransmit_timer` at line 259, `ospf_ls_req_retransmit_timer` at line 275) already use `let _ = tx.send(...)` so a late fire against a dropped receiver is a no-op. `ospf_inactivity_timer` (line 304) was the only hold-out and was the exact panic site observed in production.
- The structural cause (Timer outliving its parent) landed in #952. This is the belt-and-suspenders cleanup so the callback matches its siblings.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy -p zebra-rs --all-targets -- -D warnings`
- [ ] CI: fmt / clippy / test

Generated with [Claude Code](https://claude.com/claude-code)