### PR TITLE
ospf: skip MinLSArrival gate for self-originated DB copies

### DIFF
--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -997,10 +997,19 @@ fn ospf_ls_upd_proc(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfLsa) -
         // sure we eventually pick the genuinely-newer LSA up. If we
         // acked here the peer would prune its `ls_rxmt` and we'd
         // hold the stale copy until the next refresh.
+        //
+        // Skip the gate when the DB copy is self-originated: it was
+        // produced by our own refresh path, not flood-received, so the
+        // §13 step-5(a) wording doesn't apply. Letting it through is
+        // what allows the §13.4 self-originated handler below to fire
+        // and bump our seq above the stale neighbor copy (otherwise we
+        // never catch up to a high-seq pre-restart LSA the neighbors
+        // still hold — especially one carrying DO_NOT_AGE).
         if let Some(install_time) = current_install_time
             && install_time.elapsed() < std::time::Duration::from_secs(OSPF_MIN_LS_ARRIVAL)
+            && !ospf_is_self_originated(oi, lsa)
         {
-            tracing::info!(
+            tracing::debug!(
                 "[LS Update] Step 5(a) MinLSArrival: discarding (no ack) LSA type={:?} id={} adv={} seq={:#x}",
                 lsa.h.ls_type,
                 lsa.h.ls_id,


### PR DESCRIPTION
## Summary
RFC 2328 §13 step 5(a) only applies when the matched DB copy was received via flooding. A self-originated DB copy was produced by our own refresh path, not flood-installed, so the gate must not fire on it — otherwise §13.4's "received self-originated newer than ours" handler at step 5(b) never gets a chance to run.

## Bug observed
After a daemon restart, neighbors that still hold a higher-seq pre-restart copy of our Router LSA (made permanent by `DO_NOT_AGE`) keep flooding it back at every refresh:

```
[LS Update] Step 5(a) MinLSArrival: discarding (no ack) LSA type=Router id=10.0.0.1 adv=10.0.0.1 seq=0x8000029
```

Local router stays stuck at seq `0x08000004` while neighbors' LSDB pins us at `0x08000029(DNA)` indefinitely. Operator-visible drift between `show ip ospf database router 10.0.0.1` on the originator vs. on neighbors.

## Fix
Skip the step-5(a) MinLSArrival gate when the DB copy is self-originated. The LSA then installs, fires `ospf_flood_self_originated_lsa`, which re-originates at `received_seq + 1` and evicts the stale neighbor copy per §13.4.

Same line: demoted the step-5(a) discard log from `info!` to `debug!` — every duplicate flood was hitting it under steady-state operation.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p zebra-rs --bins` — 649 passed
- [x] Live: after restart, local router advances seq above the stale neighbor copy and `show ip ospf database router <id>` matches across both sides
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)