### PR TITLE
ospf-packet: extend raw-byte preservation to OSPFv3 LSAs

### DIFF
--- a/crates/ospf-packet/src/v3.rs
+++ b/crates/ospf-packet/src/v3.rs
@@ -37,7 +37,7 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 
 use bitfield_struct::bitfield;
 use byteorder::{BigEndian, ByteOrder};
-use bytes::{BufMut, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use internet_checksum::Checksum;
 use nom::IResult;
 use nom::bytes::complete::take;
@@ -2454,12 +2454,36 @@ impl Ospfv3LsBody {
 pub struct Ospfv3Lsa {
     pub h: Ospfv3LsaHeader,
     pub body: Ospfv3LsBody,
+    /// Cached on-wire bytes for byte-perfect re-flooding of transit
+    /// LSAs. Mirrors the v2 `OspfLsa.raw` field — see that struct's
+    /// docs for the rationale. Stamped by `Ospfv3LsUpdate::parse_be`
+    /// on receive; `None` for LSAs constructed via
+    /// [`Ospfv3Lsa::from`] (self-originated). The [`Self::emit`]
+    /// path uses this when present so downstream peers see the
+    /// exact bytes the originator emitted, keeping the Fletcher
+    /// checksum valid.
+    ///
+    /// [`Self::update`] clears this — any header mutation invalidates
+    /// the cached bytes.
+    pub raw: Option<Bytes>,
 }
 
 impl Ospfv3Lsa {
+    /// Construct a v3 LSA from its header and body. Sets `raw` to
+    /// `None` so the typed `emit` path runs (self-originated LSAs
+    /// recompute their checksum via `update()` and the bytes on the
+    /// wire match).
+    pub fn from(h: Ospfv3LsaHeader, body: Ospfv3LsBody) -> Self {
+        Self { h, body, raw: None }
+    }
+
     pub fn emit(&self, buf: &mut BytesMut) {
-        self.h.emit(buf);
-        self.body.emit(buf);
+        if let Some(raw) = self.raw.as_ref() {
+            buf.put_slice(raw);
+        } else {
+            self.h.emit(buf);
+            self.body.emit(buf);
+        }
     }
 
     /// Recompute `length` and `ls_checksum` after the caller
@@ -2473,7 +2497,13 @@ impl Ospfv3Lsa {
     /// the LS Age field, with the checksum field included as
     /// zero. Both versions share the same checksum offset, so
     /// the calculator is reused from the v2 codec.
+    ///
+    /// Invalidates any cached `raw` bytes — `update()` only runs
+    /// on the self-originated path, and after this call the
+    /// canonical emit is what we want on the wire.
     pub fn update(&mut self) {
+        // Mutation invalidates any cached raw bytes from receive.
+        self.raw = None;
         // 1) Length = 20-octet header + serialized body length.
         let mut body_buf = BytesMut::new();
         self.body.emit(&mut body_buf);
@@ -2499,7 +2529,7 @@ impl ParseBe<Ospfv3Lsa> for Ospfv3Lsa {
         let body_len = (h.length as usize).saturating_sub(OSPFV3_LSA_HEADER_LEN as usize);
         let (input, body_bytes) = nom::bytes::complete::take(body_len)(input)?;
         let (_, body) = Ospfv3LsBody::parse_be(body_bytes, h.ls_type)?;
-        Ok((input, Ospfv3Lsa { h, body }))
+        Ok((input, Ospfv3Lsa::from(h, body)))
     }
 }
 
@@ -2536,7 +2566,17 @@ impl ParseBe<Ospfv3LsUpdate> for Ospfv3LsUpdate {
         let (mut input, num) = be_u32(input)?;
         let mut lsas = Vec::with_capacity(num as usize);
         for _ in 0..num {
-            let (rest, lsa) = Ospfv3Lsa::parse_be(input)?;
+            // Capture the slice this LSA consumes so transit floods
+            // can re-emit it byte-for-byte — same rationale as the
+            // v2 `parse_lsas_with_raw` path. Without this, codec
+            // gaps for any v3 LSA flavor with unfamiliar TLVs would
+            // produce re-emitted bytes whose Fletcher residue is
+            // wrong against the originator-stored checksum, and
+            // downstream peers would reject the flood.
+            let start = input;
+            let (rest, mut lsa) = Ospfv3Lsa::parse_be(start)?;
+            let consumed = start.len() - rest.len();
+            lsa.raw = Some(Bytes::copy_from_slice(&start[..consumed]));
             lsas.push(lsa);
             input = rest;
         }
@@ -2691,10 +2731,12 @@ mod tests {
                 Ospfv3Lsa {
                     h: router_h.clone(),
                     body: Ospfv3LsBody::Router(router_body),
+                    raw: None,
                 },
                 Ospfv3Lsa {
                     h: net_h.clone(),
                     body: Ospfv3LsBody::Network(net_body),
+                    raw: None,
                 },
             ],
         };
@@ -2760,6 +2802,7 @@ mod tests {
             lsas: vec![Ospfv3Lsa {
                 h,
                 body: Ospfv3LsBody::Unknown(body_bytes.clone()),
+                raw: None,
             }],
         };
         let pkt = Ospfv3Packet::new(
@@ -2927,6 +2970,7 @@ mod tests {
                 length: 0,
             },
             body: Ospfv3LsBody::Router(body),
+            raw: None,
         };
         lsa.update();
 
@@ -2968,6 +3012,7 @@ mod tests {
                 length: 0,
             },
             body: Ospfv3LsBody::Router(body),
+            raw: None,
         };
 
         lsa.update();
@@ -4131,6 +4176,7 @@ mod tests {
         let lsa = Ospfv3Lsa {
             h: h.clone(),
             body: Ospfv3LsBody::Grace(body),
+            raw: None,
         };
 
         let lsu = Ospfv3LsUpdate { lsas: vec![lsa] };

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -3792,6 +3792,7 @@ impl Ospf<Ospfv3> {
                 length: 0,
             },
             body: Ospfv3LsBody::IntraAreaPrefix(body),
+            raw: None,
         };
         lsa.update();
         Some(lsa)
@@ -3881,6 +3882,7 @@ impl Ospf<Ospfv3> {
                 length: 0,
             },
             body: Ospfv3LsBody::Link(body),
+            raw: None,
         };
         lsa.update();
         Some(lsa)
@@ -3945,6 +3947,7 @@ impl Ospf<Ospfv3> {
                 length: 0,
             },
             body: Ospfv3LsBody::Network(body),
+            raw: None,
         };
         lsa.update();
         Some(lsa)
@@ -4068,6 +4071,7 @@ impl Ospf<Ospfv3> {
                 length: 0,
             },
             body: Ospfv3LsBody::Router(body),
+            raw: None,
         };
         lsa.update();
         lsa
@@ -4198,6 +4202,7 @@ impl Ospf<Ospfv3> {
         let mut lsa = ospf_packet::Ospfv3Lsa {
             h: header,
             body: Ospfv3LsBody::Nssa(body),
+            raw: None,
         };
 
         // Preserve sequence number on refresh.
@@ -4380,6 +4385,7 @@ impl Ospf<Ospfv3> {
         let mut new_lsa = Ospfv3Lsa {
             h: header,
             body: Ospfv3LsBody::AsExternal(translated_body),
+            raw: None,
         };
 
         // Preserve sequence number on refresh.
@@ -5882,6 +5888,7 @@ impl Ospf<Ospfv3> {
                 length: 0,
             },
             body: Ospfv3LsBody::IntraAreaPrefix(body),
+            raw: None,
         };
         lsa.update();
         Some(lsa)

--- a/zebra-rs/src/ospf/srmpls.rs
+++ b/zebra-rs/src/ospf/srmpls.rs
@@ -236,6 +236,7 @@ pub fn e_router_v3_lsa_build(
             length: 0,
         },
         body: Ospfv3LsBody::ERouter(body),
+        raw: None,
     };
     lsa.update();
     lsa
@@ -286,6 +287,7 @@ pub fn e_router_v3_sr_info_lsa_build(router_id: Ipv4Addr) -> Ospfv3Lsa {
             length: 0,
         },
         body: Ospfv3LsBody::ERouter(body),
+        raw: None,
     };
     lsa.update();
     lsa
@@ -398,6 +400,7 @@ pub fn ext_intra_area_prefix_v3_lsa_build(
             length: 0,
         },
         body: Ospfv3LsBody::EIntraAreaPrefix(body),
+        raw: None,
     };
     lsa.update();
     lsa


### PR DESCRIPTION
## Summary
Mirror the v2 transit-flood fix (#957) for `Ospfv3Lsa`. Same root cause and fix shape — our typed parser isn't byte-perfect for every v3 LSA flavor (the codec for E-Router, E-Intra-Area-Prefix, Grace, and `Unknown` bodies may not round-trip TLVs we don't fully model), so re-flooding a transit LSA via the typed `emit()` path produces bytes whose Fletcher residue disagrees with the originator-stamped checksum and downstream peers reject it.

## Patch
- `Ospfv3Lsa.raw: Option<Bytes>` cache.
- `Ospfv3Lsa::from(h, body)` constructor that sets `raw: None` (self-originated path).
- `Ospfv3Lsa::emit()` puts `raw` on the wire when present, falls back to typed emit otherwise.
- `Ospfv3Lsa::update()` clears `raw` (header mutation invalidates the cache).
- `Ospfv3LsUpdate::parse_be` stamps `raw` from each LSA's consumed slice, mirroring v2's `parse_lsas_with_raw`.
- Every existing struct-literal `Ospfv3Lsa { h, body }` callsite (15 across `srmpls.rs`, `inst.rs`, and v3 tests) gains `raw: None`.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p zebra-rs --bins` — 649 passed
- [x] `cargo test -p ospf-packet` — 63 passed
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)