### PR TITLE
bgp: restore OpenConfirm state per RFC 4271 §8.2.2

### DIFF
--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -819,7 +819,12 @@ pub fn fsm_bgp_open(peer: &mut Peer, packet: OpenPacket) -> State {
     // Record received capability.
     peer.cap_recv = packet.bgp_cap;
 
-    State::Established
+    // Per RFC 4271 §8.2.2, after validating the peer's OPEN we send
+    // KEEPALIVE and transition to OpenConfirm. The
+    // OpenConfirm→Established move happens when the peer's KEEPALIVE
+    // is received (handled in `fsm_bgp_keepalive`).
+    peer_send_keepalive(peer);
+    State::OpenConfirm
 }
 
 pub fn fsm_bgp_notification(peer: &mut Peer, _packet: NotificationPacket) -> State {
@@ -830,7 +835,15 @@ pub fn fsm_bgp_notification(peer: &mut Peer, _packet: NotificationPacket) -> Sta
 pub fn fsm_bgp_keepalive(peer: &mut Peer) -> State {
     peer.counter[BgpType::Keepalive as usize].rcvd += 1;
     timer::refresh_hold_timer(peer);
-    State::Established
+    match peer.state {
+        // RFC 4271 §8.2.2: KEEPALIVE in OpenConfirm completes the
+        // handshake and moves us to Established.
+        State::OpenConfirm | State::Established => State::Established,
+        // KEEPALIVE arriving in any other state is unexpected. The
+        // FSM should ignore it here rather than spuriously promote;
+        // stricter handling (tear down to Idle) is deferred.
+        other => other,
+    }
 }
 
 pub fn fsm_connected(peer: &mut Peer, stream: TcpStream) -> State {
@@ -844,7 +857,6 @@ pub fn fsm_connected(peer: &mut Peer, stream: TcpStream) -> State {
     peer.task.reader = Some(peer_start_reader(peer, read_half));
     peer.task.writer = Some(peer_start_writer(write_half, packet_rx));
     peer_send_open(peer);
-    peer_send_keepalive(peer);
     State::OpenSent
 }
 
@@ -867,7 +879,12 @@ pub fn fsm_idle_hold_timer_expires(peer: &mut Peer) -> State {
 pub fn fsm_keepalive_expires(peer: &mut Peer) -> State {
     // tracing::info!("Send keepalive {}", peer.ident);
     peer_send_keepalive(peer);
-    State::Established
+    // The keepalive *send* timer fires in both OpenConfirm and
+    // Established (it is armed by `update_open_timers` after we
+    // receive the peer's OPEN). It must not drive a transition —
+    // sending a KEEPALIVE does not promote us to Established, the
+    // peer's KEEPALIVE does.
+    peer.state
 }
 
 pub fn fsm_conn_fail(peer: &mut Peer) -> State {

--- a/zebra-rs/src/bgp/timer.rs
+++ b/zebra-rs/src/bgp/timer.rs
@@ -232,12 +232,11 @@ pub fn update_timers(peer: &mut Peer) {
             peer.timer.hold_timer = None;
             peer.timer.keepalive = None;
         }
-        OpenConfirm => {
-            peer.timer.idle_hold_timer = None;
-            peer.timer.hold_timer = None;
-            peer.timer.keepalive = None;
-        }
-        Established => {
+        OpenConfirm | Established => {
+            // Hold and keepalive timers were armed by
+            // `update_open_timers` when the peer's OPEN was received;
+            // they must keep running across OpenConfirm and Established
+            // so we keep refreshing the session.
             peer.timer.idle_hold_timer = None;
             peer.timer.connect_retry = None;
             if peer.timer.hold_timer.is_none() && peer.param.hold_time > 0 {


### PR DESCRIPTION
## Summary
- The FSM was sending KEEPALIVE eagerly in `fsm_connected` (before the peer's OPEN had been received), and then jumping `OpenSent → Established` directly on the first OPEN — collapsing `OpenConfirm` out of the ladder. That is wire-incompatible with RFC 4271 §8.2.2 and blocks proper collision detection (§6.8 keys off `OpenConfirm`).
- Now: send OPEN in `fsm_connected`, on the peer's OPEN send KEEPALIVE and transition to `OpenConfirm`, on the peer's KEEPALIVE transition to `Established`.
- `fsm_keepalive_expires` no longer drives a transition (the send-side timer firing must not promote us to Established).
- `timer::update_timers` arms hold + keepalive timers in `OpenConfirm` the same way it does in `Established`, so the handshake keeps ticking.

This is Phase 1 of the BGP collision-detection work; it's a standalone correctness fix that also unblocks the §6.8 implementation.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs` — 649 passed
- [x] Two-router session against FRR — OPEN/KEEPALIVE handshake completes, session reaches Established

🤖 Generated with [Claude Code](https://claude.com/claude-code)