### PR TITLE
bgp: split State and PfxRcd/Snt in show ip bgp summary

### DIFF
--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -67,7 +67,7 @@ fn peer_has_negotiated(peer: &Peer, afi: Afi, safi: Safi) -> bool {
 fn write_summary_header_row(buf: &mut String) -> std::fmt::Result {
     writeln!(
         buf,
-        "{:16}{:>1}{:>11}{:>10}{:>10}{:>9}{:>5}{:>5}{:>9}{:>13}{:>9} Hostname",
+        "{:16}{:>1}{:>11}{:>10}{:>10}{:>9}{:>5}{:>5}{:>9} {:<11} {:>10} Hostname",
         "Neighbor",
         "V",
         "AS",
@@ -77,8 +77,8 @@ fn write_summary_header_row(buf: &mut String) -> std::fmt::Result {
         "InQ",
         "OutQ",
         "Up/Down",
-        "State/PfxRcd",
-        "PfxSnt",
+        "State",
+        "PfxRcd/Snt",
     )
 }
 
@@ -93,16 +93,15 @@ fn write_summary_peer_row(buf: &mut String, peer: &Peer, afi: Afi, safi: Safi) -
     let up_down = uptime(&peer.instant);
     let negotiated = peer_has_negotiated(peer, afi, safi);
 
-    let (pfx_rcvd_str, pfx_sent_str) = if !negotiated {
-        ("NoNeg".to_string(), "NoNeg".to_string())
-    } else if peer.state != State::Established {
-        // Show the FSM state in place of the prefix count; PfxSnt is
-        // meaningless before the session is up, so render "0".
-        (peer.state.to_str().to_string(), "0".to_string())
+    let state_str = peer.state.to_str().to_string();
+    let pfx_str = if peer.state != State::Established {
+        "N/A".to_string()
+    } else if !negotiated {
+        "NoNeg".to_string()
     } else {
         let pr = peer.adj_in.count(afi, safi);
         let ps = peer.adj_out.count(afi, safi);
-        (pr.to_string(), ps.to_string())
+        format!("{}/{}", pr, ps)
     };
 
     let hostname = peer
@@ -114,7 +113,7 @@ fn write_summary_peer_row(buf: &mut String, peer: &Peer, afi: Afi, safi: Safi) -
 
     writeln!(
         buf,
-        "{:16}{:>1}{:>11}{:>10}{:>10}{:>9}{:>5}{:>5}{:>9}{:>13}{:>9} {}",
+        "{:16}{:>1}{:>11}{:>10}{:>10}{:>9}{:>5}{:>5}{:>9} {:<11} {:>10} {}",
         peer.address.to_string(),
         "4",
         peer.remote_as,
@@ -124,8 +123,8 @@ fn write_summary_peer_row(buf: &mut String, peer: &Peer, afi: Afi, safi: Safi) -
         "0", // InQ — not tracked today
         "0", // OutQ — not tracked today
         up_down,
-        pfx_rcvd_str,
-        pfx_sent_str,
+        state_str,
+        pfx_str,
         hostname,
     )
 }
@@ -2069,7 +2068,7 @@ mod summary_tests {
         let mut buf = String::new();
         write_summary_header_row(&mut buf).unwrap();
         let expected = "\
-Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Hostname\n";
+Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State       PfxRcd/Snt Hostname\n";
         assert_eq!(buf, expected);
     }
 


### PR DESCRIPTION
## Summary
- Splits the overloaded \`State/PfxRcd\` column in \`show ip bgp summary\` into two: a \`State\` column that always shows the BGP FSM state (Idle/Connect/Active/OpenSent/OpenConfirm/Established) and a \`PfxRcd/Snt\` column with combined received/sent counts.
- \`PfxRcd/Snt\` renders \`N/A\` when the session is not Established, \`NoNeg\` when Established but the AFI/SAFI was not negotiated, and \`rcvd/sent\` otherwise.
- Removes the old \`PfxSnt\` column; sent counts are now part of \`PfxRcd/Snt\`.

Example output:
\`\`\`
Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State       PfxRcd/Snt Hostname
10.0.0.2        4      65501        13         9        0    0    0 00:05:51 Established        1/0 n1
10.0.0.5        4          0         0         0        0    0    0    never Idle               N/A N/A
\`\`\`

## Test plan
- [x] \`cargo test -p zebra-rs --bin zebra-rs summary_tests\` (header layout test updated to match new column layout).
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`.
- [x] \`cargo fmt --all\`.

Generated with [Claude Code](https://claude.com/claude-code)