### PR TITLE
docs: shrink README logo to 30x30

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="docs/logo.png" alt="Project Logo" width="50" height="50" align="middle"> zebra-rs
+# <img src="docs/logo.png" alt="Project Logo" width="30" height="30" align="middle"> zebra-rs
 
 zebra-rs is a BGP, OSPF, and IS‑IS routing stack with SRv6, SR-MPLS, L3VPN, and EVPN extensions, written from scratch in Rust. Memory‑safe, async to the core, idempotent by design — and the first routing daemon to ship with a native MCP server for AI agents.
 


### PR DESCRIPTION
## Summary
- Reduce the inline README logo from 50x50 to 30x30 so it sits more proportionally next to the title.

## Test plan
- [x] No code paths affected.
- [x] README still renders the inline logo next to `zebra-rs`.

Generated with [Claude Code](https://claude.com/claude-code)