### PR TITLE
docs: refresh README intro, install, and Debian sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="docs/logo.svg" alt="Project Logo" width="30" height="30"> zebra-rs
 
-zebra-rs is a BGP, OSPF, and IS‑IS routing stack with SRv6, SR-MPLS, L3VPN, and EVPN extensions, written from scratch in Rust. Memory‑safe, async to the core, idempotent by design — and the first routing daemon to ship with a native MCP server for AI agents.
+zebra-rs is a BGP, OSPF, and IS‑IS routing stack with SRv6, SR-MPLS, L3VPN, and EVPN extensions, written from scratch in Rust. Memory‑safe, async to the core, idempotent by design — and the first routing daemon to ship with a native MCP server for AI agents. Project Home Page <http://zebra.rs/>.
 
 ## Install Instruction
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="docs/logo.svg" alt="Project Logo" width="30" height="30"> zebra-rs
+# <img src="docs/logo.svg" alt="Project Logo" width="25" height="25"> zebra-rs
 
 zebra-rs is a BGP, OSPF, and IS‑IS routing stack with SRv6, SR-MPLS, L3VPN, and EVPN extensions, written from scratch in Rust. Memory‑safe, async to the core, idempotent by design — and the first routing daemon to ship with a native MCP server for AI agents. Project Home Page <http://zebra.rs/>.
 
@@ -12,12 +12,6 @@ On Linux,
 sudo apt install -y protobuf-compiler
 ```
 
-On macOS,
-
-``` shell
-brew install protobuf
-```
-
 will be necessary.
 
 After that,
@@ -27,26 +21,32 @@ make all
 make install
 ```
 
-will install `zebra`, `vtysh` and `vtysh-helper` under `${HOME}/.zebra/bin` directory.
+will install `zebra`, `vty`, and `vtyctl` under the `${HOME}/.zebra/bin` directory.
 Please add
 
 ``` shell
 export PATH="${PATH}:${HOME}/.zebra/bin"
 ```
 
-to your `.bashrc` or `.zshrc` or any of your shell profile.
+to your `.bashrc`, `.zshrc`, or any other shell profile.
 
 ## Debian Package
 
-To build a Debian package, we use [`nfpm`](https://github.com/goreleaser/nfpm),
-which is written in Go. Please install Go and `nfpm` first:
-
 ``` shell
-go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+sudo apt update -y
+sudo apt upgrade -y
+sudo apt install -y protobuf-compiler bison libpam0g-dev
 ```
 
-Make sure `${GOPATH}/bin` (or `${HOME}/go/bin`) is in your `PATH`. Then from
-the `packaging/` directory:
+To build a Debian package, we use the [`nfpm`](https://github.com/goreleaser/nfpm) package builder. Install nfpm as follows:
+
+``` shell
+echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
+sudo apt update
+sudo apt install nfpm
+```
+
+Then from the `packaging/` directory:
 
 ``` shell
 cd packaging
@@ -55,71 +55,23 @@ make amd64   # or: make arm64
 
 This produces a `.deb` package for the selected architecture.
 
-## Start
-
-To try zebra, please simply launch program called `zebra`.
-
 ``` shell
-$ zebra &
+sudo dpkg -i zebra-rs_26.5.1_arm64.deb
 ```
 
-And `vtysh` is command line shell for it.
+will install zebra-rs and start the daemon.
 
 ``` shell
-$ vtysh
+vty
+ubuntu>?
+Exec commands:
+-> cli			Command line interface
+   configure		Manipulate software configuration information
+   help			Show help
+-> show			Show command
+ubuntu>show ip route
+
 ```
 
-You can play industry standard CLI with it.
+## Configuration
 
-``` shell
-$ ~ vtysh
-zebra>configure
-zebra#show
-zebra#set?
--> router		Router configuration
--> system		System configuration
-
-zebra#set router bgp
--> global
--> neighbors
--> peer-groups
--> rib
-
-zebra#set router bgp global as 100
-zebra#set router bgp global identifier 10.0.0.100
-zebra#set router bgp neighbors neighbor 10.0.0.1 pe?
-peer-as     peer-group  peer-type
-zebra#set router bgp neighbors neighbor 10.0.0.1 peer-as 200
-zebra#show
-+router {
-+    bgp {
-+        global {
-+            as 100;
-+            identifier 10.0.0.100;
-+        }
-+        neighbors {
-+            neighbor 10.0.0.1 {
-+                peer-as 200;
-+            }
-+        }
-+    }
-+}
-zebra#commit
-CM: ["router", "bgp", "global", "as", "100"]
-CM: ["router", "bgp", "global", "identifier", "10.0.0.100"]
-CM: ["router", "bgp", "neighbors", "neighbor", "10.0.0.1", "peer-as", "200"]
-zebra#show
-router {
-    bgp {
-        global {
-            as 100;
-            identifier 10.0.0.100;
-        }
-        neighbors {
-            neighbor 10.0.0.1 {
-                peer-as 200;
-            }
-        }
-    }
-}
-```


### PR DESCRIPTION
## Summary
- Add a project description sentence and a homepage autolink to the README intro.
- Shrink the inline logo to 25x25.
- Drop the macOS install snippet; the Linux \`apt\` step is now the only path.
- Rename the installed binaries to \`zebra\` / \`vty\` / \`vtyctl\` to match the current tree.
- Rewrite the Debian package section: list build deps, install \`nfpm\` from the GoReleaser apt repo (no Go toolchain needed), and show the \`dpkg -i\` step.
- Replace the old \`vtysh\` CLI walkthrough with a short \`vty\` session and an empty \`## Configuration\` section to fill in later.
- Fix grammar nits (\`under the \${HOME}/.zebra/bin directory\`, \`any other shell profile\`, \`Install nfpm as follows:\`, \`start the daemon\`).

## Test plan
- [x] No code paths affected.
- [x] README renders correctly on GitHub (autolink, inline SVG logo, code fences).

Generated with [Claude Code](https://claude.com/claude-code)