### PR TITLE
docs: fill in Configuration section with a BGP example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,40 @@ ubuntu>show ip route
 
 ## Configuration
 
+zebra-rs keeps two configuration views:
+
+- **running config** — what the daemon is currently acting on. Only `commit` changes it.
+- **candidate config** — the editable buffer that accumulates `set` and `delete` statements until you `commit` (or `discard`) them.
+
+Enter configure mode with `configure`, edit the candidate, then `commit`:
+
+``` shell
+ubuntu>configure
+ubuntu#set system hostname r1
+ubuntu#set router bgp 65000 router-id 10.0.0.1
+ubuntu#set router bgp 65000 neighbor 10.0.0.2 peer-as 65001
+ubuntu#commit
+r1#show running-config
+system {
+    hostname r1
+}
+router {
+    bgp 65000 {
+        router-id 10.0.0.1
+        neighbor 10.0.0.2 {
+            peer-as 65001
+        }
+    }
+}
+```
+
+Other useful editing commands:
+
+| Command | Effect |
+|---|---|
+| `delete <path>` | Remove a leaf or list item from the candidate |
+| `discard` | Revert candidate back to running |
+| `load` | Re-load the on-disk config file into the candidate, then commit |
+| `save` | Write the running config to the on-disk file |
+
+The same configuration can be viewed in different formats. `show running-config formal` prints the flat `set ...` form, `show running-config json` and `show running-config yaml` print the equivalent JSON / YAML. The same trio works for `show candidate-config`.


### PR DESCRIPTION
## Summary
- Populate the previously-empty `## Configuration` section in `README.md`.
- Explain the running vs. candidate config split.
- Walk through a minimal session: enter `configure`, set `system hostname`, set a BGP router-id and one neighbor, `commit`, and `show running-config`.
- Add a quick-reference table for `delete` / `discard` / `load` / `save`, and a note that `show {running,candidate}-config` accepts `formal` / `json` / `yaml`.

Content distilled from `book/src/ch-06-02-show-config-commands.md`.

## Test plan
- [x] No code paths affected.
- [x] README renders the new section as a heading + paragraph + fenced code block + table on GitHub.

Generated with [Claude Code](https://claude.com/claude-code)