### PR TITLE
docs: refresh README config example with current BGP schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,20 +85,24 @@ Enter configure mode with `configure`, edit the candidate, then `commit`:
 ``` shell
 ubuntu>configure
 ubuntu#set system hostname r1
-ubuntu#set router bgp 65000 router-id 10.0.0.1
-ubuntu#set router bgp 65000 neighbor 10.0.0.2 peer-as 65001
+ubuntu#set router bgp global as 65001
+ubuntu#set router bgp global identifier 10.0.0.1
+ubuntu#set router bgp neighbor 10.0.0.2 remote-as 65001
 ubuntu#commit
 r1#show running-config
 system {
-    hostname r1
+  hostname r1
 }
 router {
-    bgp 65000 {
-        router-id 10.0.0.1
-        neighbor 10.0.0.2 {
-            peer-as 65001
-        }
+  bgp {
+    global {
+      as 65001;
+      identifier 10.0.0.1;
     }
+    neighbor 10.0.0.2 {
+      remote-as 65001;
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary
- Update the README configure-mode example to match the current schema (`router bgp global as` / `router bgp neighbor <addr> remote-as`).
- Fix three issues introduced while editing:
  - input typo `reomte-as` → `remote-as`
  - output `as 65501;` corrected to `as 65001;` so it matches the `set` input
  - over-indented `remote-as` line aligned with its siblings (6 spaces, not 8)

## Test plan
- [x] No code paths affected.
- [x] README renders the corrected example on GitHub.

Generated with [Claude Code](https://claude.com/claude-code)