### PR TITLE
fib: skip NHA_GATEWAY for on-link nexthops

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -978,16 +978,21 @@ impl FibHandle {
                 let attr = NexthopAttribute::Id(uni.gid() as u32);
                 msg.attributes.push(attr);
 
-                // Gateway address.
-                let attr = match uni.addr {
-                    std::net::IpAddr::V4(ipv4) => {
-                        NexthopAttribute::Gateway(RouteAddress::Inet(ipv4))
-                    }
-                    std::net::IpAddr::V6(ipv6) => {
-                        NexthopAttribute::Gateway(RouteAddress::Inet6(ipv6))
-                    }
-                };
-                msg.attributes.push(attr);
+                // Gateway address. Skip NHA_GATEWAY for on-link
+                // nexthops (unspecified addr): the kernel rejects
+                // NHA_GATEWAY=0.0.0.0/:: with EINVAL — an
+                // interface-only nexthop must carry only NHA_OIF.
+                if !uni.addr.is_unspecified() {
+                    let attr = match uni.addr {
+                        std::net::IpAddr::V4(ipv4) => {
+                            NexthopAttribute::Gateway(RouteAddress::Inet(ipv4))
+                        }
+                        std::net::IpAddr::V6(ipv6) => {
+                            NexthopAttribute::Gateway(RouteAddress::Inet6(ipv6))
+                        }
+                    };
+                    msg.attributes.push(attr);
+                }
 
                 // Outgoing if. Origin wins over resolved; fall back to 0
                 // ("no Oif attribute") if neither was filled, which is a


### PR DESCRIPTION
## Summary
Fixes a recurring `NewNexthop error: Invalid argument (os error 22)` in the netlink log when OSPF is up on a transit subnet.

OSPF originates an intra-area route for the transit subnet with next-hop set to `0.0.0.0` (the prefix is directly on the link). RIB resolves that into `Group::Uni{addr=0.0.0.0, ifindex=Some(N)}` and asks netlink to install a nexthop group. The Linux nexthop API rejects `NHA_GATEWAY=0.0.0.0` / `::` with `EINVAL` — an interface-only nexthop must carry only `NHA_OIF`.

Guard the `NHA_GATEWAY` push on `!uni.addr.is_unspecified()`. The kernel then accepts the on-link semantics and the OSPF stub-network LSA installs cleanly.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bin zebra-rs --no-fail-fast` (654 passed)
- [ ] On a live run: an OSPF stub-network LSA over a `via 0.0.0.0` ifindex no longer logs `NewNexthop error: Invalid argument` and the nexthop appears in `ip nexthop list`.

Generated with [Claude Code](https://claude.com/claude-code)