### PR TITLE
fib: skip kernel nh_id install for unspecified-addr nexthops

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -968,6 +968,24 @@ impl FibHandle {
                     return;
                 }
 
+                // On-link nexthops with an unspecified gateway
+                // (0.0.0.0 / ::) have no representation in the kernel
+                // nexthop table — NHA_GATEWAY can't carry the
+                // wildcard address and an interface-only nh_id needs
+                // a gateway anyway under our address_family setup.
+                // RIB only allocates these as the resolved nexthop
+                // for OSPF stub-network LSAs and other intra-segment
+                // routes that lose to the Connected route, so they
+                // never need a kernel nh_id. NexthopMap still tracks
+                // them for logical bookkeeping inside zebra-rs.
+                if uni.addr.is_unspecified() {
+                    tracing::debug!(
+                        "[nexthop_add Uni] gid={gid} skipped — addr={} is unspecified, no kernel nh_id needed",
+                        uni.addr,
+                    );
+                    return;
+                }
+
                 // Address family follows the gateway address.
                 msg.header.address_family = match uni.addr {
                     std::net::IpAddr::V4(_) => AddressFamily::Inet,
@@ -978,21 +996,16 @@ impl FibHandle {
                 let attr = NexthopAttribute::Id(uni.gid() as u32);
                 msg.attributes.push(attr);
 
-                // Gateway address. Skip NHA_GATEWAY for on-link
-                // nexthops (unspecified addr): the kernel rejects
-                // NHA_GATEWAY=0.0.0.0/:: with EINVAL — an
-                // interface-only nexthop must carry only NHA_OIF.
-                if !uni.addr.is_unspecified() {
-                    let attr = match uni.addr {
-                        std::net::IpAddr::V4(ipv4) => {
-                            NexthopAttribute::Gateway(RouteAddress::Inet(ipv4))
-                        }
-                        std::net::IpAddr::V6(ipv6) => {
-                            NexthopAttribute::Gateway(RouteAddress::Inet6(ipv6))
-                        }
-                    };
-                    msg.attributes.push(attr);
-                }
+                // Gateway address.
+                let attr = match uni.addr {
+                    std::net::IpAddr::V4(ipv4) => {
+                        NexthopAttribute::Gateway(RouteAddress::Inet(ipv4))
+                    }
+                    std::net::IpAddr::V6(ipv6) => {
+                        NexthopAttribute::Gateway(RouteAddress::Inet6(ipv6))
+                    }
+                };
+                msg.attributes.push(attr);
 
                 // Outgoing if. Origin wins over resolved; fall back to 0
                 // ("no Oif attribute") if neither was filled, which is a
@@ -1118,6 +1131,15 @@ impl FibHandle {
     pub async fn nexthop_del(&self, nexthop: &Group) {
         // Skip nexthop table management for kernels < 5.3
         if !self.use_nhid {
+            return;
+        }
+
+        // Mirror the unspecified-addr skip in nexthop_add: we never
+        // installed a kernel nh_id for these, so don't ask the
+        // kernel to delete one (it would just log ENOENT).
+        if let Group::Uni(uni) = nexthop
+            && uni.addr.is_unspecified()
+        {
             return;
         }
 


### PR DESCRIPTION
## Summary
Follow-up to #971. OSPF stub-network LSAs and similar intra-segment routes resolve into `Group::Uni{addr=0.0.0.0/::, ifindex=Some(N)}`. PR #971 tried to keep the install path and just omit `NHA_GATEWAY`, but the kernel still rejected the request: our nexthop message sets `address_family` from the gateway family, and the kernel won't accept an interface-only `nh_id` in that shape.

These nexthops are never referenced from the kernel FIB anyway — they exist only to back routes that lose to the Connected entry on the same prefix. So push the policy decision to the FIB boundary: don't materialise a kernel `nh_id` for unspecified-addr nexthops at all.

### Design
- `nexthop_add` (Uni arm): after the existing `seg6local` skip, early-return when `uni.addr.is_unspecified()`. NexthopMap still allocates `gid`/`refcnt` for in-memory bookkeeping; we just don't ask the kernel to materialise the object.
- `nexthop_del`: symmetric guard so we don't fire `RTM_DELNEXTHOP` for a `gid` the kernel never saw (would only produce an `ENOENT` log).
- Removed the `NHA_GATEWAY`-omit conditional from #971 — it's now dead code (early return runs first). Kept the gid/refcnt logging path intact.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bin zebra-rs --no-fail-fast` (654 passed)
- [ ] Live run: an OSPF stub-network LSA over a `via 0.0.0.0` ifindex no longer triggers `NewNexthop error: Invalid argument` in the log, and `ip nexthop list` shows no entry for the omitted gid. Connected route remains FIB-installed.

Generated with [Claude Code](https://claude.com/claude-code)