### PR TITLE
isis: debug-log TI-LFA segment resolution failures

### DIFF
--- a/zebra-rs/src/isis/tilfa.rs
+++ b/zebra-rs/src/isis/tilfa.rs
@@ -300,15 +300,23 @@ fn repair_segments_to_mpls_labels(
     segments: &[spf::SrSegment],
 ) -> Option<Vec<rib::Label>> {
     let mut labels = Vec::with_capacity(segments.len());
-    for seg in segments {
-        let label = match seg {
-            spf::SrSegment::NodeSid(v) => node_sid_label_for_vertex(top, level, *v)?,
+    for (idx, seg) in segments.iter().enumerate() {
+        let resolved = match seg {
+            spf::SrSegment::NodeSid(v) => node_sid_label_for_vertex(top, level, *v),
             spf::SrSegment::AdjSid(from, to, via) => {
-                adj_sid_label_for_link(top, level, *from, *to, *via)?
+                adj_sid_label_for_link(top, level, *from, *to, *via)
             }
+        };
+        let Some(label) = resolved else {
+            tracing::debug!(
+                "[tilfa] {level:?} repair segment[{idx}] {seg:?} failed to resolve to MPLS label; \
+                 dropping repair stack (partial: {labels:?})"
+            );
+            return None;
         };
         labels.push(rib::Label::Explicit(label));
     }
+    tracing::debug!("[tilfa] {level:?} repair segments resolved: {segments:?} -> {labels:?}");
     Some(labels)
 }
 

--- a/zebra-rs/src/isis/tilfa.rs
+++ b/zebra-rs/src/isis/tilfa.rs
@@ -196,17 +196,45 @@ fn resolve_sid_to_label(
 /// for the first prefix-SID sub-TLV, then resolves Index against the
 /// originator's SRGB.
 fn node_sid_label_for_vertex(top: &IsisTop, level: Level, vertex: usize) -> Option<u32> {
-    let sys_id = *top.lsp_map.get(&level).resolve(vertex)?;
-    let entries = top.reach_map.get(&level).get(&Afi::Ip).get(&sys_id)?;
+    let Some(sys_id) = top.lsp_map.get(&level).resolve(vertex).copied() else {
+        tracing::debug!(
+            "[tilfa] node_sid {level:?} vertex={vertex}: no sys_id in lsp_map (vertex not in LSDB?)"
+        );
+        return None;
+    };
+    let Some(entries) = top.reach_map.get(&level).get(&Afi::Ip).get(&sys_id) else {
+        tracing::debug!(
+            "[tilfa] node_sid {level:?} vertex={vertex} sys_id={sys_id}: \
+             reach_map has no IPv4 entries (peer didn't advertise TLV 135?)"
+        );
+        return None;
+    };
+    let mut saw_prefix_sid = false;
     for entry in entries.iter() {
         let Some(prefix_sid) = entry.prefix_sid() else {
             continue;
         };
+        saw_prefix_sid = true;
         if let Some(label) =
             resolve_sid_to_label(top, level, &sys_id, &prefix_sid.sid, SrBlockKind::Global)
         {
             return Some(label);
         }
+        tracing::debug!(
+            "[tilfa] node_sid {level:?} vertex={vertex} sys_id={sys_id}: \
+             prefix={:?} prefix_sid={:?} could not resolve against SRGB \
+             (peer's label_map block missing or index out of range)",
+            entry.prefix,
+            prefix_sid.sid,
+        );
+    }
+    if !saw_prefix_sid {
+        tracing::debug!(
+            "[tilfa] node_sid {level:?} vertex={vertex} sys_id={sys_id}: \
+             {} IPv4 reach entries scanned, none carry a Prefix-SID sub-TLV \
+             (peer not advertising prefix-SID for any loopback?)",
+            entries.len(),
+        );
     }
     None
 }


### PR DESCRIPTION
## Summary
When TI-LFA computes a repair path that doesn't appear in `show isis repair-list`, the silent failure point is `repair_segments_to_mpls_labels`: a chain of `?` operators drops the whole stack as soon as any one segment fails to resolve to an absolute MPLS label, with no signal in the log.

Two debug-only changes to make the gate self-diagnosing:

1. **`repair_segments_to_mpls_labels`** — convert each `?` into an explicit `Option` match. On failure, log the failing segment index, the abstract segment, and the partial label stack accumulated so far. On success, log the resolved `segments -> labels` mapping.
2. **`node_sid_label_for_vertex`** — split the three internal `?` calls into separate branches so the log distinguishes:
   - vertex absent from `lsp_map`
   - peer has no IPv4 reach entries (no TLV 135)
   - reach entries exist but none carry a Prefix-SID sub-TLV
   - prefix-SID exists but `resolve_sid_to_label` failed against the peer's SRGB

Field-validated this in a live run: TI-LFA produced repair paths but `show isis repair-list` was empty, the new logs pointed at "r1 advertises prefixes but no Prefix-SID sub-TLV," and confirming r1's SR config made the repair-list populate.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bin zebra-rs --no-fail-fast` (654 passed)
- [x] Live `RUST_LOG=zebra_rs::isis::tilfa=debug` run printed the expected diagnostic for a missing Prefix-SID sub-TLV.

Generated with [Claude Code](https://claude.com/claude-code)