### PR TITLE
isis-packet: RFC 7794 IPv4/IPv6 Source Router ID sub-TLVs

### DIFF
--- a/crates/isis-packet/src/sub/mod.rs
+++ b/crates/isis-packet/src/sub/mod.rs
@@ -31,10 +31,10 @@ pub mod neigh_disp;
 
 pub mod prefix;
 pub use prefix::{
-    IsisSub2SidStructure, IsisSub2Tlv, IsisSubPrefixSid, IsisSubSrv6EndSid, IsisTlvExtIpReach,
-    IsisTlvExtIpReachEntry, IsisTlvIpv6Reach, IsisTlvIpv6ReachEntry, IsisTlvMtIpReach,
-    IsisTlvMtIpv6Reach, IsisTlvMultiTopology, IsisTlvSrv6, MultiTopologyId, PrefixSidFlags,
-    Srv6Locator,
+    IsisSub2SidStructure, IsisSub2Tlv, IsisSubIpv4SourceRouterId, IsisSubIpv6SourceRouterId,
+    IsisSubPrefixSid, IsisSubSrv6EndSid, IsisTlvExtIpReach, IsisTlvExtIpReachEntry,
+    IsisTlvIpv6Reach, IsisTlvIpv6ReachEntry, IsisTlvMtIpReach, IsisTlvMtIpv6Reach,
+    IsisTlvMultiTopology, IsisTlvSrv6, MultiTopologyId, PrefixSidFlags, Srv6Locator,
 };
 pub mod prefix_code;
 pub use prefix_code::{IsisPrefixCode, IsisSrv6SidSub2Code};

--- a/crates/isis-packet/src/sub/prefix.rs
+++ b/crates/isis-packet/src/sub/prefix.rs
@@ -23,6 +23,10 @@ pub enum IsisSubTlv {
     PrefixSid(IsisSubPrefixSid),
     #[nom(Selector = "IsisPrefixCode::Srv6EndSid")]
     Srv6EndSid(IsisSubSrv6EndSid),
+    #[nom(Selector = "IsisPrefixCode::Ipv4SourceRouterId")]
+    Ipv4SourceRouterId(IsisSubIpv4SourceRouterId),
+    #[nom(Selector = "IsisPrefixCode::Ipv6SourceRouterId")]
+    Ipv6SourceRouterId(IsisSubIpv6SourceRouterId),
     #[nom(Selector = "_")]
     Unknown(IsisSubTlvUnknown),
 }
@@ -209,6 +213,8 @@ impl IsisSubTlv {
         match self {
             PrefixSid(v) => v.len(),
             Srv6EndSid(v) => v.len(),
+            Ipv4SourceRouterId(v) => v.len(),
+            Ipv6SourceRouterId(v) => v.len(),
             Unknown(v) => v.len,
         }
     }
@@ -222,8 +228,74 @@ impl IsisSubTlv {
         match self {
             PrefixSid(v) => v.tlv_emit(buf),
             Srv6EndSid(v) => v.tlv_emit(buf),
+            Ipv4SourceRouterId(v) => v.tlv_emit(buf),
+            Ipv6SourceRouterId(v) => v.tlv_emit(buf),
             Unknown(v) => v.tlv_emit(buf),
         }
+    }
+}
+
+/// RFC 7794 §3.1 — IPv4 Source Router ID sub-TLV (type 11).
+///
+/// Carries the 32-bit IPv4 TE Router ID (TLV 134) of the router that
+/// originally advertised the enclosing prefix. The originator MAY
+/// include it on first origination; once present, an L1/L2 router
+/// leaking the prefix to another level MUST carry it across unchanged
+/// so downstream routers can attribute the prefix to its true origin
+/// rather than to the leaker.
+#[derive(Debug, NomBE, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubIpv4SourceRouterId {
+    pub router_id: Ipv4Addr,
+}
+
+impl TlvEmitter for IsisSubIpv4SourceRouterId {
+    fn typ(&self) -> u8 {
+        IsisPrefixCode::Ipv4SourceRouterId.into()
+    }
+
+    fn len(&self) -> u8 {
+        4
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put(&self.router_id.octets()[..]);
+    }
+}
+
+impl From<IsisSubIpv4SourceRouterId> for IsisSubTlv {
+    fn from(v: IsisSubIpv4SourceRouterId) -> Self {
+        IsisSubTlv::Ipv4SourceRouterId(v)
+    }
+}
+
+/// RFC 7794 §3.2 — IPv6 Source Router ID sub-TLV (type 12).
+///
+/// Carries the 128-bit IPv6 TE Router ID (TLV 140) of the prefix
+/// originator. Same leaking semantics as the IPv4 variant: optional
+/// at origination, mandatory to copy through on L1↔L2 leaks once
+/// present.
+#[derive(Debug, NomBE, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubIpv6SourceRouterId {
+    pub router_id: Ipv6Addr,
+}
+
+impl TlvEmitter for IsisSubIpv6SourceRouterId {
+    fn typ(&self) -> u8 {
+        IsisPrefixCode::Ipv6SourceRouterId.into()
+    }
+
+    fn len(&self) -> u8 {
+        16
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put(&self.router_id.octets()[..]);
+    }
+}
+
+impl From<IsisSubIpv6SourceRouterId> for IsisSubTlv {
+    fn from(v: IsisSubIpv6SourceRouterId) -> Self {
+        IsisSubTlv::Ipv6SourceRouterId(v)
     }
 }
 

--- a/crates/isis-packet/src/sub/prefix_code.rs
+++ b/crates/isis-packet/src/sub/prefix_code.rs
@@ -8,6 +8,10 @@ pub enum IsisPrefixCode {
     #[default]
     PrefixSid = 3,
     Srv6EndSid = 5,
+    /// RFC 7794 §3.1 — 32-bit TE Router ID of the prefix originator.
+    Ipv4SourceRouterId = 11,
+    /// RFC 7794 §3.2 — 128-bit IPv6 TE Router ID of the prefix originator.
+    Ipv6SourceRouterId = 12,
     Unknown(u8),
 }
 
@@ -17,6 +21,8 @@ impl From<IsisPrefixCode> for u8 {
         match typ {
             PrefixSid => 3,
             Srv6EndSid => 5,
+            Ipv4SourceRouterId => 11,
+            Ipv6SourceRouterId => 12,
             Unknown(v) => v,
         }
     }
@@ -28,6 +34,8 @@ impl From<u8> for IsisPrefixCode {
         match typ {
             3 => PrefixSid,
             5 => Srv6EndSid,
+            11 => Ipv4SourceRouterId,
+            12 => Ipv6SourceRouterId,
             v => Unknown(v),
         }
     }

--- a/crates/isis-packet/src/sub/prefix_disp.rs
+++ b/crates/isis-packet/src/sub/prefix_disp.rs
@@ -1,7 +1,8 @@
 use std::fmt::{Display, Formatter, Result};
 
 use super::prefix::{
-    IsisSub2SidStructure, IsisSub2Tlv, IsisSubSrv6EndSid, IsisSubTlv, PrefixSidFlags,
+    IsisSub2SidStructure, IsisSub2Tlv, IsisSubIpv4SourceRouterId, IsisSubIpv6SourceRouterId,
+    IsisSubSrv6EndSid, IsisSubTlv, PrefixSidFlags,
 };
 use super::{
     IsisSubPrefixSid, IsisTlvExtIpReach, IsisTlvExtIpReachEntry, IsisTlvIpv6Reach,
@@ -67,8 +68,22 @@ impl Display for IsisSubTlv {
         match self {
             PrefixSid(v) => write!(f, "{}", v),
             Srv6EndSid(v) => write!(f, "{}", v),
+            Ipv4SourceRouterId(v) => write!(f, "{}", v),
+            Ipv6SourceRouterId(v) => write!(f, "{}", v),
             Unknown(v) => write!(f, "Unknown: Code {}, Length {}", v.code, v.len),
         }
+    }
+}
+
+impl Display for IsisSubIpv4SourceRouterId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "   IPv4 Source Router ID: {}", self.router_id)
+    }
+}
+
+impl Display for IsisSubIpv6SourceRouterId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "   IPv6 Source Router ID: {}", self.router_id)
     }
 }
 

--- a/crates/isis-packet/tests/json.rs
+++ b/crates/isis-packet/tests/json.rs
@@ -105,5 +105,54 @@ pub fn json_round_trip_test() {
     let deserialized: IsisSysId = serde_json::from_str(&serialized).unwrap();
     assert_eq!(sys_id, deserialized);
 
+    // Test RFC 7794 Source Router ID sub-TLVs.
+    let v4_src = prefix::IsisSubIpv4SourceRouterId {
+        router_id: "10.0.0.1".parse().unwrap(),
+    };
+    let v4_tlv = prefix::IsisSubTlv::Ipv4SourceRouterId(v4_src);
+    let serialized = serde_json::to_string(&v4_tlv).unwrap();
+    let deserialized: prefix::IsisSubTlv = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(v4_tlv, deserialized);
+
+    let v6_src = prefix::IsisSubIpv6SourceRouterId {
+        router_id: "2001:db8::1".parse().unwrap(),
+    };
+    let v6_tlv = prefix::IsisSubTlv::Ipv6SourceRouterId(v6_src);
+    let serialized = serde_json::to_string(&v6_tlv).unwrap();
+    let deserialized: prefix::IsisSubTlv = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(v6_tlv, deserialized);
+
     println!("All round-trip JSON serialization/deserialization tests passed!");
+}
+
+/// Wire round-trip for the RFC 7794 Source Router ID sub-TLVs.
+/// `IsisSubTlv::emit` writes <code, length, value>; `parse_subs` reads
+/// the same shape back. The new variants must come back as themselves,
+/// not as `IsisSubTlv::Unknown`.
+#[test]
+pub fn source_router_id_wire_round_trip() {
+    use bytes::BytesMut;
+    use isis_packet::prefix::{IsisSubIpv4SourceRouterId, IsisSubIpv6SourceRouterId, IsisSubTlv};
+
+    let v4 = IsisSubTlv::Ipv4SourceRouterId(IsisSubIpv4SourceRouterId {
+        router_id: "10.1.2.3".parse().unwrap(),
+    });
+    let mut buf = BytesMut::new();
+    v4.emit(&mut buf);
+    // <code=11><len=4><4 octets>
+    assert_eq!(&buf[..2], &[11, 4]);
+    let (rest, parsed) = IsisSubTlv::parse_subs(&buf).expect("parse v4 source router id");
+    assert!(rest.is_empty());
+    assert_eq!(parsed, v4);
+
+    let v6 = IsisSubTlv::Ipv6SourceRouterId(IsisSubIpv6SourceRouterId {
+        router_id: "2001:db8::1".parse().unwrap(),
+    });
+    let mut buf = BytesMut::new();
+    v6.emit(&mut buf);
+    // <code=12><len=16><16 octets>
+    assert_eq!(&buf[..2], &[12, 16]);
+    let (rest, parsed) = IsisSubTlv::parse_subs(&buf).expect("parse v6 source router id");
+    assert!(rest.is_empty());
+    assert_eq!(parsed, v6);
 }


### PR DESCRIPTION
## Summary

- Add codec support for the two RFC 7794 Source Router ID sub-TLVs that live under Extended IP / IPv6 Reachability (TLVs 135/235/236/237):
  - Code **11** — IPv4 Source Router ID (4 octets, mirrors TLV 134)
  - Code **12** — IPv6 Source Router ID (16 octets, mirrors TLV 140)
- Until now these landed in `IsisSubTlv::Unknown` — preserved on the wire but with no typed accessors. The new `IsisSubIpv4SourceRouterId` / `IsisSubIpv6SourceRouterId` structs round-trip the originator's TE Router ID so a downstream router can attribute a leaked prefix to its true origin instead of the L1/L2 leaker.
- Scope is **codec only**. LSP-generator origination (when a router should emit one of these) and copy-through on L1↔L2 leaks (RFC 7794 requirement) are not in this PR.

## Test plan
- [x] `cargo test -p isis-packet --test json` — new `source_router_id_wire_round_trip` + extended `json_round_trip_test` pass.
- [x] `cargo test -p isis-packet` — 10 lib tests + 3 integration tests pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all` clean.
- [x] `cargo test --workspace --exclude bdd` clean.

Generated with [Claude Code](https://claude.com/claude-code)