### PR TITLE
isis-packet: RFC 8570 TE performance-metric sub-TLVs (33-39)

### DIFF
--- a/crates/isis-packet/src/sub/mod.rs
+++ b/crates/isis-packet/src/sub/mod.rs
@@ -20,9 +20,11 @@ pub mod cap_disp;
 
 pub mod neigh;
 pub use neigh::{
-    AdjSidFlags, IsisSubAdminGrp, IsisSubAsla, IsisSubIpv4IfAddr, IsisSubIpv4NeighAddr,
-    IsisSubIpv6IfAddr, IsisSubIpv6NeighAddr, IsisSubLanAdjSid, IsisSubSrv6EndXSid,
-    IsisSubSrv6LanEndXSid, IsisSubTeMetric, IsisTlvExtIsReach, IsisTlvExtIsReachEntry,
+    AdjSidFlags, IsisSubAdminGrp, IsisSubAsla, IsisSubAvailableBw, IsisSubBandwidthMetric,
+    IsisSubDelayVariation, IsisSubIpv4IfAddr, IsisSubIpv4NeighAddr, IsisSubIpv6IfAddr,
+    IsisSubIpv6NeighAddr, IsisSubLanAdjSid, IsisSubLinkLoss, IsisSubMinMaxLinkDelay,
+    IsisSubResidualBw, IsisSubSrv6EndXSid, IsisSubSrv6LanEndXSid, IsisSubTeMetric,
+    IsisSubUniLinkDelay, IsisSubUtilizedBw, IsisTlvExtIsReach, IsisTlvExtIsReachEntry,
     IsisTlvMtIsReach,
 };
 pub mod neigh_code;

--- a/crates/isis-packet/src/sub/neigh.rs
+++ b/crates/isis-packet/src/sub/neigh.rs
@@ -173,6 +173,20 @@ pub enum IsisSubTlv {
     AdjSid(IsisSubAdjSid),
     #[nom(Selector = "IsisNeighCode::LanAdjSid")]
     LanAdjSid(IsisSubLanAdjSid),
+    #[nom(Selector = "IsisNeighCode::UniLinkDelay")]
+    UniLinkDelay(IsisSubUniLinkDelay),
+    #[nom(Selector = "IsisNeighCode::MinMaxLinkDelay")]
+    MinMaxLinkDelay(IsisSubMinMaxLinkDelay),
+    #[nom(Selector = "IsisNeighCode::DelayVariation")]
+    DelayVariation(IsisSubDelayVariation),
+    #[nom(Selector = "IsisNeighCode::LinkLoss")]
+    LinkLoss(IsisSubLinkLoss),
+    #[nom(Selector = "IsisNeighCode::ResidualBw")]
+    ResidualBw(IsisSubResidualBw),
+    #[nom(Selector = "IsisNeighCode::AvailableBw")]
+    AvailableBw(IsisSubAvailableBw),
+    #[nom(Selector = "IsisNeighCode::UtilizedBw")]
+    UtilizedBw(IsisSubUtilizedBw),
     #[nom(Selector = "IsisNeighCode::Srv6EndXSid")]
     Srv6EndXSid(IsisSubSrv6EndXSid),
     #[nom(Selector = "IsisNeighCode::Srv6LanEndXSid")]
@@ -205,6 +219,13 @@ impl IsisSubTlv {
             TeMetric(v) => v.len(),
             AdjSid(v) => v.len(),
             LanAdjSid(v) => v.len(),
+            UniLinkDelay(v) => v.len(),
+            MinMaxLinkDelay(v) => v.len(),
+            DelayVariation(v) => v.len(),
+            LinkLoss(v) => v.len(),
+            ResidualBw(v) => v.len(),
+            AvailableBw(v) => v.len(),
+            UtilizedBw(v) => v.len(),
             Srv6EndXSid(v) => v.len(),
             Srv6LanEndXSid(v) => v.len(),
             Unknown(v) => v.len,
@@ -227,6 +248,13 @@ impl IsisSubTlv {
             TeMetric(v) => v.tlv_emit(buf),
             AdjSid(v) => v.tlv_emit(buf),
             LanAdjSid(v) => v.tlv_emit(buf),
+            UniLinkDelay(v) => v.tlv_emit(buf),
+            MinMaxLinkDelay(v) => v.tlv_emit(buf),
+            DelayVariation(v) => v.tlv_emit(buf),
+            LinkLoss(v) => v.tlv_emit(buf),
+            ResidualBw(v) => v.tlv_emit(buf),
+            AvailableBw(v) => v.tlv_emit(buf),
+            UtilizedBw(v) => v.tlv_emit(buf),
             Srv6EndXSid(v) => v.tlv_emit(buf),
             Srv6LanEndXSid(v) => v.tlv_emit(buf),
             Unknown(v) => v.tlv_emit(buf),
@@ -343,6 +371,321 @@ impl TlvEmitter for IsisSubAdminGrp {
 impl From<IsisSubAdminGrp> for IsisSubTlv {
     fn from(value: IsisSubAdminGrp) -> Self {
         IsisSubTlv::AdminGrp(value)
+    }
+}
+
+/// RFC 8570 §4.1 — Unidirectional Link Delay (sub-TLV 33).
+///
+/// Wire payload is 4 octets: the high bit of byte 0 is the `A`
+/// (anomalous) flag, the next 7 bits are reserved, and the
+/// remaining 24 bits are the average one-way delay in microseconds
+/// (so the maximum representable delay is ~16.78 seconds). The
+/// `A` flag is set by the originator when the measured value
+/// crosses a configured high-water threshold and cleared again
+/// once it falls below the reuse threshold.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubUniLinkDelay {
+    pub anomalous: bool,
+    pub delay: u32,
+}
+
+impl ParseBe<IsisSubUniLinkDelay> for IsisSubUniLinkDelay {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, raw) = be_u32(input)?;
+        Ok((input, Self::from_raw(raw)))
+    }
+}
+
+impl IsisSubUniLinkDelay {
+    fn from_raw(raw: u32) -> Self {
+        Self {
+            anomalous: (raw & 0x8000_0000) != 0,
+            delay: raw & 0x00FF_FFFF,
+        }
+    }
+
+    fn to_raw(&self) -> u32 {
+        let a = if self.anomalous { 0x8000_0000 } else { 0 };
+        a | (self.delay & 0x00FF_FFFF)
+    }
+}
+
+impl TlvEmitter for IsisSubUniLinkDelay {
+    fn typ(&self) -> u8 {
+        IsisNeighCode::UniLinkDelay.into()
+    }
+    fn len(&self) -> u8 {
+        4
+    }
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u32(self.to_raw());
+    }
+}
+
+impl From<IsisSubUniLinkDelay> for IsisSubTlv {
+    fn from(v: IsisSubUniLinkDelay) -> Self {
+        IsisSubTlv::UniLinkDelay(v)
+    }
+}
+
+/// RFC 8570 §4.2 — Min/Max Unidirectional Link Delay (sub-TLV 34).
+///
+/// Wire payload is 8 octets:
+///   - byte 0 bit 7: `A` flag, bits 6..0: reserved
+///   - bytes 1..3:   24-bit Min delay (microseconds)
+///   - byte 4:       reserved
+///   - bytes 5..7:   24-bit Max delay (microseconds)
+///
+/// The single `A` flag covers both Min and Max — the originator
+/// raises it if *either* measured bound crosses the configured
+/// high-water threshold.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubMinMaxLinkDelay {
+    pub anomalous: bool,
+    pub min_delay: u32,
+    pub max_delay: u32,
+}
+
+impl ParseBe<IsisSubMinMaxLinkDelay> for IsisSubMinMaxLinkDelay {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, w0) = be_u32(input)?;
+        let (input, w1) = be_u32(input)?;
+        Ok((
+            input,
+            Self {
+                anomalous: (w0 & 0x8000_0000) != 0,
+                min_delay: w0 & 0x00FF_FFFF,
+                max_delay: w1 & 0x00FF_FFFF,
+            },
+        ))
+    }
+}
+
+impl TlvEmitter for IsisSubMinMaxLinkDelay {
+    fn typ(&self) -> u8 {
+        IsisNeighCode::MinMaxLinkDelay.into()
+    }
+    fn len(&self) -> u8 {
+        8
+    }
+    fn emit(&self, buf: &mut BytesMut) {
+        let a = if self.anomalous { 0x8000_0000 } else { 0 };
+        buf.put_u32(a | (self.min_delay & 0x00FF_FFFF));
+        buf.put_u32(self.max_delay & 0x00FF_FFFF);
+    }
+}
+
+impl From<IsisSubMinMaxLinkDelay> for IsisSubTlv {
+    fn from(v: IsisSubMinMaxLinkDelay) -> Self {
+        IsisSubTlv::MinMaxLinkDelay(v)
+    }
+}
+
+/// RFC 8570 §4.3 — Unidirectional Delay Variation (sub-TLV 35).
+///
+/// 4-octet payload: byte 0 reserved, bytes 1..3 carry a 24-bit
+/// delay-variation value in microseconds. No `A` flag — RFC 8570
+/// §3 explicitly drops it from this sub-TLV to avoid feedback
+/// loops between routing and the metric's own oscillation.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubDelayVariation {
+    pub variation: u32,
+}
+
+impl ParseBe<IsisSubDelayVariation> for IsisSubDelayVariation {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, raw) = be_u32(input)?;
+        Ok((
+            input,
+            Self {
+                variation: raw & 0x00FF_FFFF,
+            },
+        ))
+    }
+}
+
+impl TlvEmitter for IsisSubDelayVariation {
+    fn typ(&self) -> u8 {
+        IsisNeighCode::DelayVariation.into()
+    }
+    fn len(&self) -> u8 {
+        4
+    }
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u32(self.variation & 0x00FF_FFFF);
+    }
+}
+
+impl From<IsisSubDelayVariation> for IsisSubTlv {
+    fn from(v: IsisSubDelayVariation) -> Self {
+        IsisSubTlv::DelayVariation(v)
+    }
+}
+
+/// RFC 8570 §4.4 — Unidirectional Link Loss (sub-TLV 36).
+///
+/// 4-octet payload: byte 0 bit 7 = `A` flag, bits 6..0 reserved;
+/// bytes 1..3 = 24-bit loss expressed in units of 0.000003 %, so
+/// the encoded ceiling 0xFFFFFE represents ~50.331642 %. The
+/// reserved value 0xFFFFFF marks the metric as unavailable.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubLinkLoss {
+    pub anomalous: bool,
+    pub loss: u32,
+}
+
+impl ParseBe<IsisSubLinkLoss> for IsisSubLinkLoss {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, raw) = be_u32(input)?;
+        Ok((
+            input,
+            Self {
+                anomalous: (raw & 0x8000_0000) != 0,
+                loss: raw & 0x00FF_FFFF,
+            },
+        ))
+    }
+}
+
+impl TlvEmitter for IsisSubLinkLoss {
+    fn typ(&self) -> u8 {
+        IsisNeighCode::LinkLoss.into()
+    }
+    fn len(&self) -> u8 {
+        4
+    }
+    fn emit(&self, buf: &mut BytesMut) {
+        let a = if self.anomalous { 0x8000_0000 } else { 0 };
+        buf.put_u32(a | (self.loss & 0x00FF_FFFF));
+    }
+}
+
+impl From<IsisSubLinkLoss> for IsisSubTlv {
+    fn from(v: IsisSubLinkLoss) -> Self {
+        IsisSubTlv::LinkLoss(v)
+    }
+}
+
+/// RFC 8570 §4.5–4.7 — Unidirectional bandwidth metrics
+/// (Residual, Available, Utilized) share an identical wire shape:
+/// a single 32-bit IEEE 754 single-precision value in bytes/sec.
+/// No `A` flag, no reserved bits. The three are distinguished by
+/// sub-TLV code (37/38/39) and by semantic — see the per-type
+/// wrappers below.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubBandwidthMetric {
+    /// Bandwidth in bytes-per-second (IEEE 754 single-precision).
+    pub bw_bps: f32,
+}
+
+impl IsisSubBandwidthMetric {
+    fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, raw) = be_u32(input)?;
+        Ok((
+            input,
+            Self {
+                bw_bps: f32::from_bits(raw),
+            },
+        ))
+    }
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u32(self.bw_bps.to_bits());
+    }
+}
+
+/// RFC 8570 §4.5 — Unidirectional Residual Bandwidth (sub-TLV 37).
+/// Maximum bandwidth minus bandwidth currently reserved by RSVP-TE.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubResidualBw {
+    pub bw: IsisSubBandwidthMetric,
+}
+
+impl ParseBe<IsisSubResidualBw> for IsisSubResidualBw {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, bw) = IsisSubBandwidthMetric::parse(input)?;
+        Ok((input, Self { bw }))
+    }
+}
+
+impl TlvEmitter for IsisSubResidualBw {
+    fn typ(&self) -> u8 {
+        IsisNeighCode::ResidualBw.into()
+    }
+    fn len(&self) -> u8 {
+        4
+    }
+    fn emit(&self, buf: &mut BytesMut) {
+        self.bw.emit(buf);
+    }
+}
+
+impl From<IsisSubResidualBw> for IsisSubTlv {
+    fn from(v: IsisSubResidualBw) -> Self {
+        IsisSubTlv::ResidualBw(v)
+    }
+}
+
+/// RFC 8570 §4.6 — Unidirectional Available Bandwidth (sub-TLV 38).
+/// Residual minus the measured non-RSVP-TE forwarding load.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubAvailableBw {
+    pub bw: IsisSubBandwidthMetric,
+}
+
+impl ParseBe<IsisSubAvailableBw> for IsisSubAvailableBw {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, bw) = IsisSubBandwidthMetric::parse(input)?;
+        Ok((input, Self { bw }))
+    }
+}
+
+impl TlvEmitter for IsisSubAvailableBw {
+    fn typ(&self) -> u8 {
+        IsisNeighCode::AvailableBw.into()
+    }
+    fn len(&self) -> u8 {
+        4
+    }
+    fn emit(&self, buf: &mut BytesMut) {
+        self.bw.emit(buf);
+    }
+}
+
+impl From<IsisSubAvailableBw> for IsisSubTlv {
+    fn from(v: IsisSubAvailableBw) -> Self {
+        IsisSubTlv::AvailableBw(v)
+    }
+}
+
+/// RFC 8570 §4.7 — Unidirectional Utilized Bandwidth (sub-TLV 39).
+/// Actual link utilization as measured by the advertising node.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisSubUtilizedBw {
+    pub bw: IsisSubBandwidthMetric,
+}
+
+impl ParseBe<IsisSubUtilizedBw> for IsisSubUtilizedBw {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, bw) = IsisSubBandwidthMetric::parse(input)?;
+        Ok((input, Self { bw }))
+    }
+}
+
+impl TlvEmitter for IsisSubUtilizedBw {
+    fn typ(&self) -> u8 {
+        IsisNeighCode::UtilizedBw.into()
+    }
+    fn len(&self) -> u8 {
+        4
+    }
+    fn emit(&self, buf: &mut BytesMut) {
+        self.bw.emit(buf);
+    }
+}
+
+impl From<IsisSubUtilizedBw> for IsisSubTlv {
+    fn from(v: IsisSubUtilizedBw) -> Self {
+        IsisSubTlv::UtilizedBw(v)
     }
 }
 

--- a/crates/isis-packet/src/sub/neigh_code.rs
+++ b/crates/isis-packet/src/sub/neigh_code.rs
@@ -15,6 +15,21 @@ pub enum IsisNeighCode {
     TeMetric = 18,
     AdjSid = 31,
     LanAdjSid = 32,
+    /// RFC 8570 §4.1 — Unidirectional Link Delay (4 octets, µs).
+    UniLinkDelay = 33,
+    /// RFC 8570 §4.2 — Min/Max Unidirectional Link Delay (8 octets).
+    MinMaxLinkDelay = 34,
+    /// RFC 8570 §4.3 — Unidirectional Delay Variation (4 octets, µs).
+    DelayVariation = 35,
+    /// RFC 8570 §4.4 — Unidirectional Link Loss (4 octets, 0.000003 %).
+    LinkLoss = 36,
+    /// RFC 8570 §4.5 — Unidirectional Residual Bandwidth (4 octets,
+    /// IEEE 754 single-precision, B/s).
+    ResidualBw = 37,
+    /// RFC 8570 §4.6 — Unidirectional Available Bandwidth.
+    AvailableBw = 38,
+    /// RFC 8570 §4.7 — Unidirectional Utilized Bandwidth.
+    UtilizedBw = 39,
     Srv6EndXSid = 43,
     Srv6LanEndXSid = 44,
     Unknown(u8),
@@ -33,6 +48,13 @@ impl From<IsisNeighCode> for u8 {
             TeMetric => 18,
             AdjSid => 31,
             LanAdjSid => 32,
+            UniLinkDelay => 33,
+            MinMaxLinkDelay => 34,
+            DelayVariation => 35,
+            LinkLoss => 36,
+            ResidualBw => 37,
+            AvailableBw => 38,
+            UtilizedBw => 39,
             Srv6EndXSid => 43,
             Srv6LanEndXSid => 44,
             Unknown(v) => v,
@@ -53,6 +75,13 @@ impl From<u8> for IsisNeighCode {
             18 => TeMetric,
             31 => AdjSid,
             32 => LanAdjSid,
+            33 => UniLinkDelay,
+            34 => MinMaxLinkDelay,
+            35 => DelayVariation,
+            36 => LinkLoss,
+            37 => ResidualBw,
+            38 => AvailableBw,
+            39 => UtilizedBw,
             43 => Srv6EndXSid,
             44 => Srv6LanEndXSid,
             v => Unknown(v),

--- a/crates/isis-packet/src/sub/neigh_disp.rs
+++ b/crates/isis-packet/src/sub/neigh_disp.rs
@@ -1,6 +1,10 @@
 use std::fmt::{Display, Formatter, Result};
 
-use super::neigh::{IsisSubAdjSid, IsisSubAdminGrp, IsisSubAsla, IsisSubTlv};
+use super::neigh::{
+    IsisSubAdjSid, IsisSubAdminGrp, IsisSubAsla, IsisSubAvailableBw, IsisSubDelayVariation,
+    IsisSubLinkLoss, IsisSubMinMaxLinkDelay, IsisSubResidualBw, IsisSubTlv, IsisSubUniLinkDelay,
+    IsisSubUtilizedBw,
+};
 use super::{
     AdjSidFlags, IsisSubIpv4IfAddr, IsisSubIpv4NeighAddr, IsisSubIpv6IfAddr, IsisSubIpv6NeighAddr,
     IsisSubLanAdjSid, IsisSubSrv6EndXSid, IsisSubSrv6LanEndXSid, IsisSubTeMetric,
@@ -43,11 +47,98 @@ impl Display for IsisSubTlv {
             TeMetric(v) => write!(f, "{}", v),
             AdjSid(v) => write!(f, "{}", v),
             LanAdjSid(v) => write!(f, "{}", v),
+            UniLinkDelay(v) => write!(f, "{}", v),
+            MinMaxLinkDelay(v) => write!(f, "{}", v),
+            DelayVariation(v) => write!(f, "{}", v),
+            LinkLoss(v) => write!(f, "{}", v),
+            ResidualBw(v) => write!(f, "{}", v),
+            AvailableBw(v) => write!(f, "{}", v),
+            UtilizedBw(v) => write!(f, "{}", v),
             Srv6EndXSid(v) => write!(f, "{}", v),
             Asla(v) => write!(f, "{}", v),
             Srv6LanEndXSid(v) => write!(f, "{}", v),
             Unknown(v) => write!(f, "    Unknown: ({:?})", v.code),
         }
+    }
+}
+
+fn anomalous_str(a: bool) -> &'static str {
+    if a { " (A)" } else { "" }
+}
+
+impl Display for IsisSubUniLinkDelay {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(
+            f,
+            "    Unidirectional Link Delay: {} us{}",
+            self.delay,
+            anomalous_str(self.anomalous)
+        )
+    }
+}
+
+impl Display for IsisSubMinMaxLinkDelay {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(
+            f,
+            "    Min/Max Unidirectional Link Delay: min {} us, max {} us{}",
+            self.min_delay,
+            self.max_delay,
+            anomalous_str(self.anomalous)
+        )
+    }
+}
+
+impl Display for IsisSubDelayVariation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(
+            f,
+            "    Unidirectional Delay Variation: {} us",
+            self.variation
+        )
+    }
+}
+
+impl Display for IsisSubLinkLoss {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        // RFC 8570 §4.4: encoded units are 0.000003 % per LSB.
+        let pct = self.loss as f64 * 0.000003;
+        write!(
+            f,
+            "    Unidirectional Link Loss: {:.6}%{}",
+            pct,
+            anomalous_str(self.anomalous)
+        )
+    }
+}
+
+impl Display for IsisSubResidualBw {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(
+            f,
+            "    Unidirectional Residual Bandwidth: {} B/s",
+            self.bw.bw_bps
+        )
+    }
+}
+
+impl Display for IsisSubAvailableBw {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(
+            f,
+            "    Unidirectional Available Bandwidth: {} B/s",
+            self.bw.bw_bps
+        )
+    }
+}
+
+impl Display for IsisSubUtilizedBw {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(
+            f,
+            "    Unidirectional Utilized Bandwidth: {} B/s",
+            self.bw.bw_bps
+        )
     }
 }
 

--- a/crates/isis-packet/tests/json.rs
+++ b/crates/isis-packet/tests/json.rs
@@ -125,6 +125,118 @@ pub fn json_round_trip_test() {
     println!("All round-trip JSON serialization/deserialization tests passed!");
 }
 
+/// Wire round-trip for the RFC 8570 Performance Metric sub-TLVs.
+/// Confirms every code (33–39) survives emit → parse with its
+/// fields intact and the expected on-wire size, including the
+/// 24-bit packing of delay/loss values and the A-flag bit.
+#[test]
+pub fn rfc8570_perf_metric_round_trip() {
+    use bytes::BytesMut;
+    use isis_packet::neigh::{
+        IsisSubAvailableBw, IsisSubBandwidthMetric, IsisSubDelayVariation, IsisSubLinkLoss,
+        IsisSubMinMaxLinkDelay, IsisSubResidualBw, IsisSubTlv, IsisSubUniLinkDelay,
+        IsisSubUtilizedBw,
+    };
+
+    // Sub-TLV 33 — Unidirectional Link Delay (A flag + 24-bit delay).
+    let v = IsisSubTlv::UniLinkDelay(IsisSubUniLinkDelay {
+        anomalous: true,
+        delay: 0x00_12_34_56, // < 24 bits
+    });
+    let mut buf = BytesMut::new();
+    v.emit(&mut buf);
+    assert_eq!(buf[0], 33, "type code 33");
+    assert_eq!(buf[1], 4, "length 4");
+    // High bit of value-byte 0 carries the A flag.
+    assert_eq!(buf[2] & 0x80, 0x80);
+    let (rest, parsed) = IsisSubTlv::parse_subs(&buf).expect("parse 33");
+    assert!(rest.is_empty());
+    assert_eq!(parsed, v);
+
+    // Sub-TLV 34 — Min/Max Unidirectional Link Delay.
+    let v = IsisSubTlv::MinMaxLinkDelay(IsisSubMinMaxLinkDelay {
+        anomalous: false,
+        min_delay: 100,
+        max_delay: 500,
+    });
+    let mut buf = BytesMut::new();
+    v.emit(&mut buf);
+    assert_eq!(buf[0], 34);
+    assert_eq!(buf[1], 8, "length 8");
+    let (rest, parsed) = IsisSubTlv::parse_subs(&buf).expect("parse 34");
+    assert!(rest.is_empty());
+    assert_eq!(parsed, v);
+
+    // Sub-TLV 35 — Unidirectional Delay Variation (no A flag).
+    let v = IsisSubTlv::DelayVariation(IsisSubDelayVariation { variation: 42 });
+    let mut buf = BytesMut::new();
+    v.emit(&mut buf);
+    assert_eq!(buf[0], 35);
+    assert_eq!(buf[1], 4);
+    // High bit must NOT be set for sub-TLV 35.
+    assert_eq!(buf[2] & 0x80, 0);
+    let (rest, parsed) = IsisSubTlv::parse_subs(&buf).expect("parse 35");
+    assert!(rest.is_empty());
+    assert_eq!(parsed, v);
+
+    // Sub-TLV 36 — Unidirectional Link Loss.
+    let v = IsisSubTlv::LinkLoss(IsisSubLinkLoss {
+        anomalous: true,
+        loss: 0x00_FF_FF_FE, // RFC 8570 §4.4 ceiling that still represents a measured value.
+    });
+    let mut buf = BytesMut::new();
+    v.emit(&mut buf);
+    assert_eq!(buf[0], 36);
+    assert_eq!(buf[1], 4);
+    assert_eq!(buf[2] & 0x80, 0x80);
+    let (rest, parsed) = IsisSubTlv::parse_subs(&buf).expect("parse 36");
+    assert!(rest.is_empty());
+    assert_eq!(parsed, v);
+
+    // Sub-TLVs 37/38/39 — bandwidth metrics, IEEE float B/s.
+    let cases: [(u8, IsisSubTlv); 3] = [
+        (
+            37,
+            IsisSubTlv::ResidualBw(IsisSubResidualBw {
+                bw: IsisSubBandwidthMetric { bw_bps: 1.25e9 },
+            }),
+        ),
+        (
+            38,
+            IsisSubTlv::AvailableBw(IsisSubAvailableBw {
+                bw: IsisSubBandwidthMetric { bw_bps: 9.5e8 },
+            }),
+        ),
+        (
+            39,
+            IsisSubTlv::UtilizedBw(IsisSubUtilizedBw {
+                bw: IsisSubBandwidthMetric { bw_bps: 5.0e7 },
+            }),
+        ),
+    ];
+    for (code, v) in &cases {
+        let mut buf = BytesMut::new();
+        v.emit(&mut buf);
+        assert_eq!(buf[0], *code, "type code {code}");
+        assert_eq!(buf[1], 4, "length 4 for code {code}");
+        let (rest, parsed) = IsisSubTlv::parse_subs(&buf).expect("parse bw");
+        assert!(rest.is_empty());
+        assert_eq!(&parsed, v, "round-trip for code {code}");
+    }
+
+    // Reserved bits in code-33/-34/-35/-36 must NOT be reflected
+    // back as part of the parsed value — the parser must mask the
+    // top 8 bits when extracting the 24-bit metric.
+    let raw = [33u8, 4, 0x7F, 0xAB, 0xCD, 0xEF];
+    let (_, parsed) = IsisSubTlv::parse_subs(&raw).expect("parse with reserved bits set");
+    if let IsisSubTlv::UniLinkDelay(d) = parsed {
+        assert!(!d.anomalous);
+        assert_eq!(d.delay, 0x00AB_CDEF);
+    } else {
+        panic!("expected UniLinkDelay");
+    }
+}
+
 /// Wire round-trip for the RFC 7794 Source Router ID sub-TLVs.
 /// `IsisSubTlv::emit` writes <code, length, value>; `parse_subs` reads
 /// the same shape back. The new variants must come back as themselves,


### PR DESCRIPTION
## Summary

Add typed codec support for the seven RFC 8570 (a.k.a. RFC 7810 + bug-fix) sub-TLVs that live under Extended IS Reachability (TLV 22 / 222):

| Code | Sub-TLV | Wire shape |
|---|---|---|
| 33 | Unidirectional Link Delay | `A`(1) + reserved(7) + delay(24-bit µs) |
| 34 | Min/Max Unidirectional Link Delay | `A` + min(24-bit) + reserved(8) + max(24-bit) |
| 35 | Unidirectional Delay Variation | reserved(8) + variation(24-bit µs), no `A` flag |
| 36 | Unidirectional Link Loss | `A` + loss(24-bit, 0.000003 %/LSB) |
| 37 | Unidirectional Residual Bandwidth | IEEE 754 single, B/s |
| 38 | Unidirectional Available Bandwidth | IEEE 754 single, B/s |
| 39 | Unidirectional Utilized Bandwidth | IEEE 754 single, B/s |

Until now these landed in `IsisSubTlv::Unknown` — bytes preserved on the wire but no field access. With this change a peer's delay-driven Flex Algo (RFC 9350 `metric_type = 1`, "Min Unidirectional Link Delay") can resolve to real numbers when we read its LSP, and operators get a real `Display` line instead of an opaque `Unknown(34)`.

Scope is **codec only** — daemon-side origination (sourcing delay/loss from the platform and stamping these on LSP entries) is a follow-up.

## Test plan
- [x] `cargo test -p isis-packet --test json` — new `rfc8570_perf_metric_round_trip` exercises all seven codes (emit → on-wire byte check → parse → equality), plus an explicit reserved-bit masking case for code 33.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all` clean.
- [x] `cargo test --workspace --exclude bdd` clean.

Generated with [Claude Code](https://claude.com/claude-code)