### PR TITLE
isis-packet: RFC 6232 Purge Originator Identification TLV

### DIFF
--- a/crates/isis-packet/src/disp.rs
+++ b/crates/isis-packet/src/disp.rs
@@ -184,6 +184,7 @@ impl Display for IsisTlv {
             Padding(v) => write!(f, "{}", v),
             LspEntries(v) => write!(f, "{}", v),
             Auth(v) => write!(f, "{}", v),
+            PurgeOrigId(v) => write!(f, "{}", v),
             LspBufferSize(v) => write!(f, "{}", v),
             ExtIsReach(v) => write!(f, "{}", v),
             MtIsReach(v) => write!(f, "{}", v),
@@ -209,6 +210,16 @@ impl Display for IsisTlv {
                 write!(f, "  {:?}", v.typ)
             }
         }
+    }
+}
+
+impl Display for crate::parser::IsisTlvPurgeOrigId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "  Purge Originator: {}", self.originator)?;
+        if let Some(rcv) = self.received_from {
+            write!(f, " (received from {})", rcv)?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -521,6 +521,8 @@ pub enum IsisTlv {
     LspEntries(IsisTlvLspEntries),
     #[nom(Selector = "IsisTlvType::Auth")]
     Auth(IsisTlvAuth),
+    #[nom(Selector = "IsisTlvType::PurgeOrigId")]
+    PurgeOrigId(IsisTlvPurgeOrigId),
     #[nom(Selector = "IsisTlvType::LspBufferSize")]
     LspBufferSize(IsisTlvLspBufferSize),
     #[nom(Selector = "IsisTlvType::ExtIsReach")]
@@ -593,6 +595,7 @@ impl IsisTlv {
             Padding(v) => v.tlv_emit(buf),
             LspEntries(v) => v.tlv_emit(buf),
             Auth(v) => v.tlv_emit(buf),
+            PurgeOrigId(v) => v.tlv_emit(buf),
             LspBufferSize(v) => v.tlv_emit(buf),
             ExtIsReach(v) => v.tlv_emit(buf),
             MtIsReach(v) => v.tlv_emit(buf),
@@ -993,6 +996,84 @@ impl TlvEmitter for IsisTlvHostname {
 impl From<IsisTlvHostname> for IsisTlv {
     fn from(tlv: IsisTlvHostname) -> Self {
         IsisTlv::Hostname(tlv)
+    }
+}
+
+/// RFC 6232 — Purge Originator Identification (TLV 13).
+///
+/// Carried in purge LSPs (Remaining Lifetime == 0) so receivers
+/// can attribute a phantom purge back to the IS that injected it,
+/// and optionally the upstream IS the purge was learned from.
+///
+/// Wire value:
+///   - 1 octet `Number of System IDs` (1 or 2)
+///   - 6 octets `originator` system-id
+///   - 6 octets `received_from` system-id (only when Number == 2)
+///
+/// Length on the wire is 7 (Num + originator) or 13 (Num + both).
+/// An originating IS MUST set Number == 1 with just its own
+/// system-id; a forwarding IS that receives a purge without a POI
+/// MUST add Number == 2 with (own_sysid, upstream_sysid) before
+/// re-flooding.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IsisTlvPurgeOrigId {
+    pub originator: IsisSysId,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub received_from: Option<IsisSysId>,
+}
+
+impl ParseBe<IsisTlvPurgeOrigId> for IsisTlvPurgeOrigId {
+    fn parse_be(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, num) = be_u8(input)?;
+        let (input, originator) = IsisSysId::parse_be(input)?;
+        let (input, received_from) = match num {
+            1 => (input, None),
+            2 => {
+                let (input, rcv) = IsisSysId::parse_be(input)?;
+                (input, Some(rcv))
+            }
+            _ => {
+                return Err(nom::Err::Error(nom::error::make_error(
+                    input,
+                    nom::error::ErrorKind::Verify,
+                )));
+            }
+        };
+        Ok((
+            input,
+            Self {
+                originator,
+                received_from,
+            },
+        ))
+    }
+}
+
+impl TlvEmitter for IsisTlvPurgeOrigId {
+    fn typ(&self) -> u8 {
+        IsisTlvType::PurgeOrigId.into()
+    }
+
+    fn len(&self) -> u8 {
+        // 1 byte count + 6 (originator) [+ 6 (received_from)].
+        if self.received_from.is_some() { 13 } else { 7 }
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        if let Some(rcv) = self.received_from {
+            buf.put_u8(2);
+            buf.put(&self.originator.id[..]);
+            buf.put(&rcv.id[..]);
+        } else {
+            buf.put_u8(1);
+            buf.put(&self.originator.id[..]);
+        }
+    }
+}
+
+impl From<IsisTlvPurgeOrigId> for IsisTlv {
+    fn from(tlv: IsisTlvPurgeOrigId) -> Self {
+        IsisTlv::PurgeOrigId(tlv)
     }
 }
 

--- a/crates/isis-packet/src/tlv_type.rs
+++ b/crates/isis-packet/src/tlv_type.rs
@@ -17,6 +17,13 @@ pub enum IsisTlvType {
     /// specific value (cleartext password, HMAC-MD5 digest, or RFC 5310
     /// generic-crypto Key ID + digest).
     Auth = 10,
+    /// Purge Originator Identification (RFC 6232). Carried in
+    /// purge LSPs (those with Remaining Lifetime == 0); identifies
+    /// the IS that injected the purge and optionally the upstream
+    /// IS it was received from, so operators can track a phantom
+    /// purge back to its origin instead of staring at a
+    /// systemId-anonymous zero-lifetime LSP.
+    PurgeOrigId = 13,
     LspBufferSize = 14,
     ExtIsReach = 22,
     MtIsReach = 222,
@@ -64,6 +71,7 @@ impl IsisTlvType {
                 | Padding
                 | LspEntries
                 | Auth
+                | PurgeOrigId
                 | LspBufferSize
                 | ExtIsReach
                 | MtIsReach
@@ -98,6 +106,7 @@ impl From<IsisTlvType> for u8 {
             Padding => 8,
             LspEntries => 9,
             Auth => 10,
+            PurgeOrigId => 13,
             LspBufferSize => 14,
             ExtIsReach => 22,
             MtIsReach => 222,
@@ -133,6 +142,7 @@ impl From<u8> for IsisTlvType {
             8 => Padding,
             9 => LspEntries,
             10 => Auth,
+            13 => PurgeOrigId,
             14 => LspBufferSize,
             22 => ExtIsReach,
             222 => MtIsReach,

--- a/crates/isis-packet/tests/json.rs
+++ b/crates/isis-packet/tests/json.rs
@@ -125,6 +125,81 @@ pub fn json_round_trip_test() {
     println!("All round-trip JSON serialization/deserialization tests passed!");
 }
 
+/// Wire round-trip for the RFC 6232 Purge Originator Identification
+/// TLV. Covers both the originator-only form (Number == 1, 7-octet
+/// value) and the (originator, received-from) form (Number == 2,
+/// 13-octet value), plus the malformed Number == 3 case.
+#[test]
+pub fn rfc6232_poi_round_trip() {
+    use bytes::BytesMut;
+    use isis_packet::{IsisSysId, IsisTlv, IsisTlvPurgeOrigId, IsisTlvType};
+
+    let orig = IsisSysId {
+        id: [0x00, 0x00, 0x00, 0x00, 0x00, 0x01],
+    };
+
+    // Originator-only purge.
+    let tlv = IsisTlvPurgeOrigId {
+        originator: orig,
+        received_from: None,
+    };
+    let mut buf = BytesMut::new();
+    IsisTlv::PurgeOrigId(tlv.clone()).emit(&mut buf);
+    // <type=13><length=7><num=1><6-octet sys-id>
+    assert_eq!(buf[0], u8::from(IsisTlvType::PurgeOrigId));
+    assert_eq!(buf[1], 7);
+    assert_eq!(buf[2], 1);
+    assert_eq!(&buf[3..9], &orig.id);
+    let (rest, parsed) = IsisTlv::parse_be(&buf[2..], IsisTlvType::PurgeOrigId).unwrap();
+    assert!(rest.is_empty());
+    assert!(matches!(parsed, IsisTlv::PurgeOrigId(_)));
+    if let IsisTlv::PurgeOrigId(p) = parsed {
+        assert_eq!(p, tlv);
+    }
+
+    // Forwarded purge: includes upstream system-id.
+    let upstream = IsisSysId {
+        id: [0x00, 0x00, 0x00, 0x00, 0x00, 0x02],
+    };
+    let tlv = IsisTlvPurgeOrigId {
+        originator: orig,
+        received_from: Some(upstream),
+    };
+    let mut buf = BytesMut::new();
+    IsisTlv::PurgeOrigId(tlv.clone()).emit(&mut buf);
+    assert_eq!(buf[1], 13);
+    assert_eq!(buf[2], 2);
+    assert_eq!(&buf[3..9], &orig.id);
+    assert_eq!(&buf[9..15], &upstream.id);
+    let (rest, parsed) = IsisTlv::parse_be(&buf[2..], IsisTlvType::PurgeOrigId).unwrap();
+    assert!(rest.is_empty());
+    if let IsisTlv::PurgeOrigId(p) = parsed {
+        assert_eq!(p, tlv);
+    } else {
+        panic!("expected PurgeOrigId");
+    }
+
+    // Malformed Number byte must be rejected. RFC 6232 §3 only
+    // defines values 1 and 2; anything else means "don't trust the
+    // rest of the buffer" — return a parse error rather than guess.
+    let raw_bad = [3u8, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 2];
+    assert!(IsisTlv::parse_be(&raw_bad, IsisTlvType::PurgeOrigId).is_err());
+
+    // JSON round-trip with received_from omitted (verifies the
+    // skip_serializing_if guard on the Option).
+    let serialized = serde_json::to_string(&IsisTlvPurgeOrigId {
+        originator: orig,
+        received_from: None,
+    })
+    .unwrap();
+    assert!(
+        !serialized.contains("received-from"),
+        "received-from must be elided when None; got: {serialized}"
+    );
+    let deserialized: IsisTlvPurgeOrigId = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(deserialized.received_from, None);
+}
+
 /// Wire round-trip for the RFC 8570 Performance Metric sub-TLVs.
 /// Confirms every code (33–39) survives emit → parse with its
 /// fields intact and the expected on-wire size, including the


### PR DESCRIPTION
## Summary

Add typed codec for **TLV 13 — Purge Originator Identification** (RFC 6232). It rides along on purge LSPs (`Remaining Lifetime == 0`) and identifies the IS that injected the purge plus, optionally, the upstream IS it was received from. Until now, type 13 was parsed as `IsisTlv::Unknown(13, …)` — wire bytes preserved but no field access, so operators couldn't tell from `show isis database` which router originated a flapping zero-lifetime LSP.

Wire encoding handled:
- `Number = 1` → 7-octet value: originator system-id only (the originating-IS case).
- `Number = 2` → 13-octet value: originator + received-from system-ids (the forwarding-IS case).
- Any other `Number` is rejected with a parse error rather than silently extending into the buffer.

JSON elides `received_from` when `None` (verified by test).

**Scope is codec only.** RFC 6232 §4 requires:
1. The daemon to stamp POI (Number=1, own sys-id) on every purge it originates.
2. A forwarding IS to insert POI (Number=2, own + upstream sys-id) when it re-floods a purge that arrived without one.

Both touch the LSP purge/flood paths in `zebra-rs/src/isis/lsdb.rs` and will land in a follow-up PR so this one stays small.

## Test plan
- [x] `cargo test -p isis-packet --test json` — new `rfc6232_poi_round_trip` covers Number=1, Number=2, the malformed-Number rejection, and JSON elision of `received_from`.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all` clean.
- [x] `cargo test --workspace --exclude bdd` clean.

Generated with [Claude Code](https://claude.com/claude-code)