### PR TITLE
isis: accept and re-flood received purges, fix purge-emit bugs

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1667,11 +1667,15 @@ impl Isis {
         // per-level Auth TLV so receivers can verify it.
         let auth_cfg = super::lsp::level_auth_cfg(top.config, level).clone();
         let resolved = super::auth::resolve_send(&auth_cfg, top.key_chains, chrono::Utc::now());
-        let _buf = lsp_emit(&mut purged_lsp, level, resolved.as_ref());
-        insert_self_originate(&mut top, level, purged_lsp, None);
+        // The encoded purge MUST be handed to `insert_self_originate`
+        // — `srm_advertise` reads `lsa.bytes` to flood, and an empty
+        // bytes vector silently drops the send. Previously the buf
+        // was discarded, so the POI stamp landed in the LSDB but
+        // never reached peers.
+        let buf = lsp_emit(&mut purged_lsp, level, resolved.as_ref());
+        insert_self_originate(&mut top, level, purged_lsp, Some(buf.to_vec()));
 
         top.lsdb.get_mut(&level).srm_set_all(top.tx, level, &lsp_id);
-        // lsp_flood(&mut top, level, &lsp_id);
     }
 
     /// ISO 10589 §7.3.16.4 wait expired for one specific fragment:

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -33,6 +33,26 @@ pub struct Lsdb {
     pub adj: BTreeMap<u32, LspFlood>,
 }
 
+/// ISO 10589 §7.3.16.4 ZeroAgeLifetime. A purged LSP (Remaining
+/// Lifetime == 0) must stay in the LSDB for this long before being
+/// evicted, so the SRM/SSN machinery has time to flood it to peers
+/// and acknowledge it. Arming `hold_timer` for `hold_time == 0`
+/// directly would otherwise evict the entry before `srm_advertise`
+/// could read its bytes.
+const ZERO_AGE_LIFETIME: u16 = 60;
+
+/// Number of seconds the LSDB should hold an entry whose
+/// Remaining Lifetime came across the wire as 0. Returns the
+/// ZeroAgeLifetime safety window so the LSP survives long enough
+/// to reach peers; otherwise returns the value untouched.
+fn hold_timer_secs(hold_time: u16) -> u16 {
+    if hold_time == 0 {
+        ZERO_AGE_LIFETIME
+    } else {
+        hold_time
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum LsdbEvent {
     RefreshTimerExpire,
@@ -517,7 +537,10 @@ pub fn insert_lsp(top: &mut LinkTop, level: Level, lsp: IsisLsp, bytes: Vec<u8>)
     let mut lsa = Lsa::new(lsp);
     lsa.ifindex = top.ifindex;
     lsa.bytes = bytes;
-    lsa.hold_timer = Some(hold_timer(top.tx, level, key, hold_time));
+    // Purges (hold_time == 0) must linger for ZeroAgeLifetime so the
+    // SRM flood can read their bytes before the entry is evicted —
+    // see `hold_timer_secs`.
+    lsa.hold_timer = Some(hold_timer(top.tx, level, key, hold_timer_secs(hold_time)));
     lsa.last_received = Some(Instant::now());
 
     let prev = top.lsdb.get_mut(&level).map.insert(key, lsa);
@@ -564,11 +587,19 @@ pub fn insert_self_originate(
     let mut lsa = Lsa::new(lsp);
     lsa.originated = true;
 
-    lsa.hold_timer = Some(hold_timer(top.tx, level, key, lsa.lsp.hold_time));
+    // Same ZeroAgeLifetime treatment as `insert_lsp` for self-
+    // originated purges — `process_lsp_purge` calls in here with
+    // hold_time == 0, and the entry must survive long enough for
+    // `srm_advertise` to flood its bytes to peers.
+    lsa.hold_timer = Some(hold_timer(
+        top.tx,
+        level,
+        key,
+        hold_timer_secs(lsa.lsp.hold_time),
+    ));
 
     let mut refresh_time = top.config.refresh_time();
 
-    const ZERO_AGE_LIFETIME: u16 = 60;
     const MIN_LSP_TRANS_INTERVAL: u16 = 5;
     const DEFAULT_REFRESH_TIME: u16 = 15 * 60;
 
@@ -665,6 +696,30 @@ mod tests {
     use isis_packet::prefix::Ipv4ControlInfo;
 
     use super::*;
+
+    /// ISO 10589 §7.3.16.4: a purge (Remaining Lifetime == 0) must
+    /// linger in the LSDB for ZeroAgeLifetime so the SRM flood can
+    /// read its bytes before eviction. Without this, `hold_timer`
+    /// armed at 0 fires before `srm_advertise` and the purge is
+    /// silently dropped.
+    #[test]
+    fn purge_hold_timer_uses_zero_age_lifetime() {
+        assert_eq!(
+            hold_timer_secs(0),
+            ZERO_AGE_LIFETIME,
+            "hold_time == 0 must be remapped to ZeroAgeLifetime"
+        );
+        assert_eq!(
+            hold_timer_secs(900),
+            900,
+            "non-zero hold_time must pass through untouched"
+        );
+        assert_eq!(
+            hold_timer_secs(1),
+            1,
+            "tiny non-zero hold_time must pass through untouched"
+        );
+    }
 
     fn sys(b: u8) -> IsisSysId {
         IsisSysId {

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -895,11 +895,18 @@ pub fn lsp_recv(link: &mut LinkTop, level: Level, lsp: IsisLsp, bytes: Vec<u8>) 
         return;
     }
 
-    // Purge the LSP.
-    if lsp.hold_time == 0 {
-        // lsdb::remove_lsp_link(top, level, lsp.lsp_id);
-        return;
-    }
+    // Purges (`hold_time == 0`) flow through the same §7.3.15.1
+    // decision tree as a normal LSP: seq comparison decides whether
+    // we install + re-flood (Greater/None), ack (Equal), or
+    // counter-flood our own newer copy (Less). The LSDB hold-timer
+    // for hold_time == 0 is mapped to ZeroAgeLifetime by
+    // `lsdb::hold_timer_secs` so the SRM flood has time to read
+    // bytes before eviction.
+    //
+    // is_self semantics (§7.3.16.4) carry over verbatim — a peer
+    // purging our LSP at higher seq triggers a re-originate at
+    // recv_seq+1 just like any other "peer holds our LSP at higher
+    // seq" case, which is the right outcome.
 
     // Detect self-originated LSPs (regular self LSP at pseudo_id 0,
     // or any pseudonode LSP we originated as DIS — both share our


### PR DESCRIPTION
## Summary

Receive-side purge handling was a no-op: `lsp_recv` early-returned on `hold_time == 0`, so peer purges never entered the LSDB and never propagated onward. Removing the early return alone wouldn't have helped — investigating found two pre-existing bugs that would silently drop purges anyway:

**Bug A — self-originated purges weren't reaching peers.** `process_lsp_purge` (touched most recently in #978) discarded the encoded LSP with `let _buf = lsp_emit(...)` and passed `bytes=None` into `insert_self_originate`. `srm_advertise` gates on `if !lsa.bytes.is_empty()` (`flood.rs:167`), so the POI-stamped purges from #978 only updated the local LSDB and never went out on the wire.

**Bug B — hold_timer(0) evicted the entry before SRM had a chance to flood.** Both `hold_timer` and `srm_timer` use `Timer::once(0)` for purges. They land on the same event loop, but the hold timer is armed first (in `insert_*`), so `HoldTimerExpire → remove_lsp` runs before `srm_advertise`, which then does `lsdb.get(&lsp_id)` and finds nothing. ISO 10589 §7.3.16.4 wants ZeroAgeLifetime (~60s) of linger before eviction. `lsdb.rs:571` already defined the constant but only used it for refresh-time clamping.

All three fixes are bundled because none of them are independently observable — fixing only one leaves the purge path still broken.

### Changes

- **`zebra-rs/src/isis/lsdb.rs`** — promote `ZERO_AGE_LIFETIME = 60` to module scope, add `hold_timer_secs()` helper, apply it in both `insert_lsp` (peer-originated path) and `insert_self_originate` (self-originated path).
- **`zebra-rs/src/isis/inst.rs`** — `process_lsp_purge` no longer discards the encoded LSP; pass `Some(buf.to_vec())` so `lsa.bytes` is populated.
- **`zebra-rs/src/isis/packet.rs`** — drop the `hold_time == 0` early return. Purges now flow through the same §7.3.15.1 decision tree as any other LSP (Greater/None → install + re-flood, Equal → SSN ack on P2P, Less → counter-flood our newer copy). The existing `is_self` re-originate branch already does the right thing for §7.3.16.4 (peer purging our own LSP).

### What's deferred

POI `Number=2` insertion on forward (RFC 6232 §3 forwarding-IS case) — requires re-emit, checksum recompute, and auth re-sign when the received purge lacks POI. The verbatim re-flood done here is the right baseline; the POI-insert layer is straightforward to add on top once this lands.

## Test plan
- [x] New `purge_hold_timer_uses_zero_age_lifetime` test pins the ZeroAgeLifetime mapping (hold_time=0 → 60s, other values pass through).
- [x] Existing `purge_poi_tests` from #978 continue to pass — the POI codec round-trip is unchanged.
- [x] `cargo test --workspace --exclude bdd` — 657 zebra-rs tests pass (was 656; +1).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all` clean.

Generated with [Claude Code](https://claude.com/claude-code)