### PR TITLE
spf: extract pc_paths_new returning paths + first_hop_links

### DIFF
--- a/zebra-rs/src/spf/calc.rs
+++ b/zebra-rs/src/spf/calc.rs
@@ -334,15 +334,16 @@ pub fn p_space_vertices(graph: &Graph, s: usize, x: &[usize]) -> BTreeSet<usize>
         .collect::<BTreeSet<_>>()
 }
 
-/// Compute the post-convergence paths from `s` to `d` while excluding
-/// every vertex in `x`. Test-only today; the TI-LFA repair-path
-/// builder consumes `spf_calc` directly.
-#[allow(dead_code)]
-pub fn pc_paths(graph: &Graph, s: usize, d: usize, x: &[usize]) -> Vec<Vec<usize>> {
-    spf_calc(graph, s, x, &SpfOpt::full_path(), &SpfDirect::Normal)
-        .remove(&d)
-        .map_or_else(Vec::new, |data| data.paths)
-}
+// Old single-output `pc_paths` is superseded by `pc_paths_new`,
+// which returns the `first_hop_links` set alongside the PC paths
+// from a single SPF call. Left commented as a reference until any
+// out-of-tree caller has migrated.
+//
+// pub fn pc_paths(graph: &Graph, s: usize, d: usize, x: &[usize]) -> Vec<Vec<usize>> {
+//     spf_calc(graph, s, x, &SpfOpt::full_path(), &SpfDirect::Normal)
+//         .remove(&d)
+//         .map_or_else(Vec::new, |data| data.paths)
+// }
 
 pub fn q_space_vertices(graph: &Graph, d: usize, x: &[usize]) -> BTreeSet<usize> {
     let spf = spf_reverse(graph, d, &SpfOpt::full_path());
@@ -520,19 +521,28 @@ pub struct RepairPath {
     pub segs: Vec<SrSegment>,
 }
 
+pub fn pc_paths_new(
+    graph: &Graph,
+    s: usize,
+    d: usize,
+    x: &[usize],
+) -> (Vec<Vec<usize>>, HashSet<(usize, u32)>) {
+    let spf = spf_calc(graph, s, x, &SpfOpt::full_path(), &SpfDirect::Normal);
+    let Some(d_path) = spf.get(&d) else {
+        return (vec![], HashSet::new());
+    };
+    let first_hop_links = d_path.first_hop_links.clone();
+    let pc_paths = d_path.paths.clone();
+
+    (pc_paths, first_hop_links)
+}
+
 pub fn tilfa(graph: &Graph, s: usize, d: usize, x: &[usize]) -> Vec<RepairPath> {
     let p_vertices = p_space_vertices(graph, s, x);
     let q_vertices = q_space_vertices(graph, d, x);
 
-    // Run the modified SPF inline so we have access to D's
-    // `first_hop_links` alongside `paths`. Going through
-    // `pc_paths()` would discard that information.
-    let modified_spf = spf_calc(graph, s, x, &SpfOpt::full_path(), &SpfDirect::Normal);
-    let Some(d_path) = modified_spf.get(&d) else {
-        return vec![];
-    };
-    let first_hop_links = d_path.first_hop_links.clone();
-    let mut pc_paths = d_path.paths.clone();
+    // Run a SPF to get PC paths.
+    let (mut pc_paths, first_hop_links) = pc_paths_new(graph, s, d, x);
 
     // PCPaths.
     let mut repair_paths = vec![];
@@ -1003,7 +1013,7 @@ mod tests {
         }
         assert_eq!(q_vertices, BTreeSet::from([]));
 
-        let pc = pc_paths(&graph, s, d, x);
+        let (pc, _) = pc_paths_new(&graph, s, d, x);
         let pc = pc.first().unwrap();
         let mut pc_vertices = Vec::<String>::new();
         for n in pc.iter() {
@@ -1012,7 +1022,7 @@ mod tests {
         }
         assert_eq!(pc_vertices, vec!["N2", "R1", "R2"]);
 
-        let mut pc = pc_paths(&graph, s, d, x);
+        let (mut pc, _) = pc_paths_new(&graph, s, d, x);
         for path in &mut pc {
             // PC path keeps D as the final vertex; make_repair_list
             // emits AdjSid(deepest_p, d) for that hop while walking
@@ -1058,7 +1068,7 @@ mod tests {
         // *  The expected post-convergence path from S to D considering the
         // failure of N1 is <N2 -> R1 -> R2 -> R3 -> D> (we are naming it
         // PCPath in this example).
-        let mut pc_paths = pc_paths(&graph, s, d, x);
+        let (mut pc_paths, _) = pc_paths_new(&graph, s, d, x);
         assert_eq!(pc_paths.len(), 1);
         let pc_path = pc_paths.first().unwrap();
         let mut pc_vertices = Vec::<String>::new();


### PR DESCRIPTION
## Summary

Refactor `tilfa()` to fetch its modified-graph SPF results through a new test-callable helper instead of inlining the SPF call and reaching into the `Path` struct directly:

```rust
pub fn pc_paths_new(graph, s, d, x) -> (Vec<Vec<usize>>, HashSet<(usize, u32)>)
```

Returns both the destination's `paths` and `first_hop_links` from one `spf_calc` call. `tilfa()` becomes a few lines shorter and the modified-SPF + first-hop-links pairing is now a named primitive that tests can use directly. The older single-output `pc_paths` is kept commented out as a reference for any out-of-tree caller mid-migration.

## Test plan
- [x] Existing `tilfa_test` migrates to `pc_paths_new` and ignores the second tuple element where it doesn't need `first_hop_links` — assertions on PC vertex order and the resulting segment list (NodeSid(R1) + 2 AdjSids) unchanged.
- [x] `tilfa_*_api` behavioural tests untouched (still assert the same RFC 9855 segment lists).
- [x] `cargo test -p zebra-rs --bin zebra-rs spf::calc::tests` — all 11 tests pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all` clean.
- [x] `cargo test --workspace --exclude bdd` clean (657 zebra-rs tests).

Generated with [Claude Code](https://claude.com/claude-code)