### PR TITLE
rib: show protocol code in `show mpls ilm` output

### DIFF
--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1219,6 +1219,7 @@ fn rib6_show_one(rib: &Rib, prefix: &Ipv6Net, json: bool, detail: bool) -> Strin
 // JSON structures for MPLS ILM display
 #[derive(Serialize)]
 pub struct IlmJson {
+    pub protocol: String,
     pub local_label: u32,
     pub outgoing_label: String,
     pub prefix_or_id: String,
@@ -1258,13 +1259,13 @@ pub fn ilm_show(rib: &Rib, _args: Args, json: bool) -> String {
         // Add header
         writeln!(
             buf,
-            "Local  Outgoing    Prefix             Outgoing     Next Hop"
+            "P Local  Outgoing    Prefix             Outgoing     Next Hop"
         )
         .unwrap();
-        writeln!(buf, "Label  Label       or ID              Interface").unwrap();
+        writeln!(buf, "  Label  Label       or ID              Interface").unwrap();
         writeln!(
             buf,
-            "------ ----------- ------------------ ------------ ---------------"
+            "- ------ ----------- ------------------ ------------ ---------------"
         )
         .unwrap();
 
@@ -1294,6 +1295,7 @@ fn write_ilm_entry(
     ilm: &super::inst::IlmEntry,
     uni: &super::NexthopUni,
 ) {
+    let protocol = ilm.rtype.abbrev();
     let local_label = format!("{:<6}", label);
 
     // Determine outgoing label
@@ -1339,8 +1341,8 @@ fn write_ilm_entry(
 
     writeln!(
         buf,
-        "{} {} {:<18} {:<12} {}",
-        local_label, outgoing_label, prefix_or_id, interface, next_hop
+        "{} {} {} {:<18} {:<12} {}",
+        protocol, local_label, outgoing_label, prefix_or_id, interface, next_hop
     )
     .unwrap();
 }
@@ -1391,6 +1393,7 @@ fn ilm_to_json(
     };
 
     IlmJson {
+        protocol: protocol_long_name(ilm.rtype).to_string(),
         local_label: label,
         outgoing_label,
         prefix_or_id,


### PR DESCRIPTION
## Summary
- Surface the per-label owning protocol (already tracked on `IlmEntry.rtype`) in the MPLS ILM views.
- Text table (`show mpls ilm`) gains a single-char `P` column via `RibType::abbrev()` (S/i/O/B/...), matching `show ip route`.
- JSON output gains a full-word `protocol` field, consistent with the IP route JSON.

This is Phase 1 of extending the ILM table; no data-structure change — purely exposing existing protocol info. Later phases add administrative distance and multi-entry ILM selection.

## Test plan
- [x] `cargo build -p zebra-rs`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bins` (662 passed)

Generated with [Claude Code](https://claude.com/claude-code)