### PR TITLE
rib: add administrative distance to ILM entries

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -792,12 +792,12 @@ impl Bgp {
                 // `rtype = Bgp` works.
                 if let Some(vrf_ifindex) = handle.ilm_decap_ifindex {
                     let entry = crate::rib::inst::IlmEntry {
-                        rtype: crate::rib::RibType::Bgp,
                         ilm_type: crate::rib::inst::IlmType::DecapVrf {
                             table_id: 0,
                             vrf_ifindex,
                         },
                         nexthop: crate::rib::Nexthop::default(),
+                        ..crate::rib::inst::IlmEntry::new(crate::rib::RibType::Bgp)
                     };
                     self.rib_subscriber.send_ilm_del(handle.label, entry);
                 }

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -183,12 +183,12 @@ pub fn spawn_bgp_vrf(
     let ilm_decap_ifindex = match (kernel_table_id, kernel_ifindex) {
         (Some(table_id), Some(vrf_ifindex)) if label != 0 => {
             let entry = crate::rib::inst::IlmEntry {
-                rtype: crate::rib::RibType::Bgp,
                 ilm_type: crate::rib::inst::IlmType::DecapVrf {
                     table_id,
                     vrf_ifindex,
                 },
                 nexthop: crate::rib::Nexthop::default(),
+                ..crate::rib::inst::IlmEntry::new(crate::rib::RibType::Bgp)
             };
             rib_subscriber.send_ilm_add(label, entry);
             Some(vrf_ifindex)

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -496,9 +496,9 @@ fn make_ilm_entry(label: u32, ilm: &SpfIlm) -> IlmEntry {
             uni.mpls_label.push(label);
         }
         return IlmEntry {
-            rtype: RibType::Isis,
             ilm_type: ilm.ilm_type.clone(),
             nexthop: Nexthop::Uni(uni),
+            ..IlmEntry::new(RibType::Isis)
         };
     }
     let mut multi = NexthopMulti::default();
@@ -514,9 +514,9 @@ fn make_ilm_entry(label: u32, ilm: &SpfIlm) -> IlmEntry {
         multi.nexthops.push(uni);
     }
     IlmEntry {
-        rtype: RibType::Isis,
         ilm_type: ilm.ilm_type.clone(),
         nexthop: Nexthop::Multi(multi),
+        ..IlmEntry::new(RibType::Isis)
     }
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -7993,9 +7993,9 @@ fn make_ilm_entry(label: u32, ilm: &SpfIlm) -> IlmEntry {
     };
 
     IlmEntry {
-        rtype: RibType::Ospf,
         ilm_type: ilm.ilm_type.clone(),
         nexthop,
+        ..IlmEntry::new(RibType::Ospf)
     }
 }
 
@@ -8095,9 +8095,9 @@ fn make_ilm_entry_v6(label: u32, ilm: &SpfIlmV3) -> IlmEntry {
     };
 
     IlmEntry {
-        rtype: RibType::Ospf,
         ilm_type: ilm.ilm_type.clone(),
         nexthop,
+        ..IlmEntry::new(RibType::Ospf)
     }
 }
 

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -289,6 +289,12 @@ pub struct IlmEntry {
     pub rtype: RibType,
     pub ilm_type: IlmType,
     pub nexthop: Nexthop,
+    /// Administrative distance, mirroring the IP RIB convention
+    /// (static 1, OSPF 110, IS-IS 115, BGP 20). Set by
+    /// `IlmEntry::new` from the owning `rtype`. Today each incoming
+    /// label has a single owner so this is informational; it becomes
+    /// the primary tie-break key once ILM RIB selection lands.
+    pub distance: u8,
 }
 
 impl IlmEntry {
@@ -297,7 +303,24 @@ impl IlmEntry {
             rtype,
             ilm_type: IlmType::None,
             nexthop: Nexthop::default(),
+            distance: ilm_distance(rtype),
         }
+    }
+}
+
+/// Default administrative distance for an ILM entry owned by `rtype`,
+/// following the same FRR/Cisco convention as the IP RIB. BGP uses the
+/// eBGP value (20); VPN decap labels are uniquely owned, so the
+/// eBGP/iBGP split doesn't apply at the LFIB.
+fn ilm_distance(rtype: RibType) -> u8 {
+    match rtype {
+        RibType::Kernel | RibType::Connected => 0,
+        RibType::Static => 1,
+        RibType::Ospf => 110,
+        RibType::Isis => 115,
+        RibType::Bgp => 20,
+        RibType::Dhcp => 254,
+        RibType::Other(_) => 255,
     }
 }
 

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1220,6 +1220,7 @@ fn rib6_show_one(rib: &Rib, prefix: &Ipv6Net, json: bool, detail: bool) -> Strin
 #[derive(Serialize)]
 pub struct IlmJson {
     pub protocol: String,
+    pub distance: u8,
     pub local_label: u32,
     pub outgoing_label: String,
     pub prefix_or_id: String,
@@ -1259,13 +1260,17 @@ pub fn ilm_show(rib: &Rib, _args: Args, json: bool) -> String {
         // Add header
         writeln!(
             buf,
-            "P Local  Outgoing    Prefix             Outgoing     Next Hop"
+            "P Dist Local  Outgoing    Prefix             Outgoing     Next Hop"
         )
         .unwrap();
-        writeln!(buf, "  Label  Label       or ID              Interface").unwrap();
         writeln!(
             buf,
-            "- ------ ----------- ------------------ ------------ ---------------"
+            "       Label  Label       or ID              Interface"
+        )
+        .unwrap();
+        writeln!(
+            buf,
+            "- ---- ------ ----------- ------------------ ------------ ---------------"
         )
         .unwrap();
 
@@ -1296,6 +1301,7 @@ fn write_ilm_entry(
     uni: &super::NexthopUni,
 ) {
     let protocol = ilm.rtype.abbrev();
+    let distance = format!("{:<4}", ilm.distance);
     let local_label = format!("{:<6}", label);
 
     // Determine outgoing label
@@ -1341,8 +1347,8 @@ fn write_ilm_entry(
 
     writeln!(
         buf,
-        "{} {} {} {:<18} {:<12} {}",
-        protocol, local_label, outgoing_label, prefix_or_id, interface, next_hop
+        "{} {} {} {} {:<18} {:<12} {}",
+        protocol, distance, local_label, outgoing_label, prefix_or_id, interface, next_hop
     )
     .unwrap();
 }
@@ -1394,6 +1400,7 @@ fn ilm_to_json(
 
     IlmJson {
         protocol: protocol_long_name(ilm.rtype).to_string(),
+        distance: ilm.distance,
         local_label: label,
         outgoing_label,
         prefix_or_id,


### PR DESCRIPTION
## Summary
- Add a `distance` field to `IlmEntry`, mirroring the IP RIB's admin-distance convention.
- `IlmEntry::new(rtype)` sets it from a single `ilm_distance` helper (static 1, OSPF 110, IS-IS 115, BGP 20); all producers (OSPF v4/v6, IS-IS, BGP VPN decap add+del) now construct through `..IlmEntry::new(rtype)` instead of duplicating literals.
- Surface distance in `show mpls ilm` (new `Dist` column) and the JSON output (`distance`).

This is Phase 2 of extending the ILM table. Distance is informational today (each incoming label has a single owner); it becomes the primary tie-break key when ILM RIB selection lands in Phase 3.

## Test plan
- [x] `cargo build -p zebra-rs`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bins` (662 passed)

Generated with [Claude Code](https://claude.com/claude-code)