### PR TITLE
rib: multi-entry ILM table with admin-distance selection

### DIFF
--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -284,6 +284,13 @@ pub enum IlmType {
     },
 }
 
+/// All ILM candidates competing for a single incoming label. Mirrors
+/// `RibEntries` for the IP table: every protocol that claims a label
+/// contributes one entry, and `ilm_next` picks the best by admin
+/// distance. At most one entry is `selected` and installed to the
+/// kernel LFIB (the kernel holds a single AF_MPLS route per label).
+pub type IlmEntries = Vec<IlmEntry>;
+
 #[derive(Default, Debug, Clone)]
 pub struct IlmEntry {
     pub rtype: RibType,
@@ -291,10 +298,12 @@ pub struct IlmEntry {
     pub nexthop: Nexthop,
     /// Administrative distance, mirroring the IP RIB convention
     /// (static 1, OSPF 110, IS-IS 115, BGP 20). Set by
-    /// `IlmEntry::new` from the owning `rtype`. Today each incoming
-    /// label has a single owner so this is informational; it becomes
-    /// the primary tie-break key once ILM RIB selection lands.
+    /// `IlmEntry::new` from the owning `rtype`. Primary tie-break key
+    /// for ILM RIB selection.
     pub distance: u8,
+    /// True for the winning candidate at this label — the one
+    /// installed to the kernel LFIB. Set by `Rib::ilm_select_sync`.
+    pub selected: bool,
 }
 
 impl IlmEntry {
@@ -304,6 +313,7 @@ impl IlmEntry {
             ilm_type: IlmType::None,
             nexthop: Nexthop::default(),
             distance: ilm_distance(rtype),
+            selected: false,
         }
     }
 }
@@ -406,7 +416,7 @@ pub struct Rib {
     pub pending_vrf_bind: BTreeMap<String, Option<String>>,
     pub table: PrefixMap<Ipv4Net, RibEntries>,
     pub table_v6: PrefixMap<Ipv6Net, RibEntries>,
-    pub ilm: BTreeMap<u32, IlmEntry>,
+    pub ilm: BTreeMap<u32, IlmEntries>,
     /// Per-IS-IS-Flex-Algorithm IPv4 route shadow used by the
     /// BGP ↔ IS-IS Flex-Algo integration. Outer key is the algo id
     /// (128..=255); inner map mirrors the per-algo subset of IS-IS's
@@ -1070,15 +1080,21 @@ impl Rib {
                 .await;
         }
 
-        let labels: Vec<u32> = self
+        // Withdraw this protocol's contribution to every label it owns
+        // a candidate at. `ilm_del` re-selects, so a label shared with
+        // another protocol simply falls back to the surviving entry.
+        let targets: Vec<(u32, IlmEntry)> = self
             .ilm
             .iter()
-            .filter_map(|(label, e)| (e.rtype == rtype).then_some(*label))
+            .flat_map(|(label, entries)| {
+                entries
+                    .iter()
+                    .filter(|e| e.rtype == rtype)
+                    .map(move |e| (*label, e.clone()))
+            })
             .collect();
-        for label in labels {
-            if let Some(ilm) = self.ilm.get(&label).cloned() {
-                self.ilm_del(label, ilm).await;
-            }
+        for (label, entry) in targets {
+            self.ilm_del(label, entry).await;
         }
 
         self.proto_unregister(&proto);
@@ -1627,9 +1643,14 @@ impl Rib {
                 self.nmap.shutdown(&self.fib_handle).await;
                 let ilms = self.ilm.clone();
 
-                for (&label, ilm) in ilms.iter() {
-                    self.ilm_del(label, ilm.clone()).await;
+                // One AF_MPLS route per label in the kernel — delete the
+                // installed (selected) candidate for each.
+                for (&label, entries) in ilms.iter() {
+                    if let Some(installed) = entries.iter().find(|e| e.selected) {
+                        self.fib_handle.ilm_del(label, installed).await;
+                    }
                 }
+                self.ilm.clear();
                 // Clean up EVPN-installed FDB rows on externally-managed
                 // VXLAN devices BEFORE we tear down zebra-rs-managed
                 // bridges/VXLANs. For zebra-rs-managed devices the

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -626,17 +626,56 @@ impl Rib {
     /// `table_id` parameter, and the inbound dispatcher doesn't pass
     /// one for these variants.
     pub async fn ilm_add(&mut self, label: u32, ilm: IlmEntry) {
-        // Need to update ilm table.
-        self.ilm.insert(label, ilm.clone());
-
-        self.fib_handle.ilm_del(label, &ilm).await;
-        self.fib_handle.ilm_add(label, &ilm).await;
+        let prev = self.ilm_installed(label);
+        let entries = self.ilm.entry(label).or_default();
+        // One candidate per protocol: drop this protocol's previous
+        // entry before pushing the new one (mirrors `rib_replace`).
+        entries.retain(|e| e.rtype != ilm.rtype);
+        entries.push(ilm);
+        self.ilm_select_sync(label, prev).await;
     }
 
     pub async fn ilm_del(&mut self, label: u32, ilm: IlmEntry) {
-        self.ilm.remove(&label);
+        let prev = self.ilm_installed(label);
+        if let Some(entries) = self.ilm.get_mut(&label) {
+            entries.retain(|e| e.rtype != ilm.rtype);
+            if entries.is_empty() {
+                self.ilm.remove(&label);
+            }
+        }
+        self.ilm_select_sync(label, prev).await;
+    }
 
-        self.fib_handle.ilm_del(label, &ilm).await;
+    /// The candidate currently installed in the kernel LFIB for
+    /// `label` (the `selected` one), cloned so it can be handed to the
+    /// FIB delete after the in-memory Vec has been mutated.
+    fn ilm_installed(&self, label: u32) -> Option<IlmEntry> {
+        self.ilm.get(&label)?.iter().find(|e| e.selected).cloned()
+    }
+
+    /// Re-run ILM selection for `label` and reconcile the kernel LFIB.
+    /// `prev` is the entry installed before the Vec was mutated. The
+    /// kernel holds one AF_MPLS route per label, so we delete the old
+    /// install (keyed on the label) and add the new winner. Always
+    /// del+add when a winner exists so a same-protocol content change
+    /// (e.g. OSPF nexthop churn) reaches the kernel.
+    async fn ilm_select_sync(&mut self, label: u32, prev: Option<IlmEntry>) {
+        let winner = if let Some(entries) = self.ilm.get_mut(&label) {
+            let best = ilm_next(entries);
+            for (i, e) in entries.iter_mut().enumerate() {
+                e.selected = best == Some(i);
+            }
+            best.map(|i| entries[i].clone())
+        } else {
+            None
+        };
+
+        if let Some(prev) = &prev {
+            self.fib_handle.ilm_del(label, prev).await;
+        }
+        if let Some(win) = &winner {
+            self.fib_handle.ilm_add(label, win).await;
+        }
     }
 
     pub async fn make_link_up(&mut self, ifindex: u32) {
@@ -1332,6 +1371,23 @@ fn rib_next(ribs: &RibEntries) -> Option<usize> {
         .map(|(i, _)| i)
 }
 
+/// Pick the winning ILM candidate: lowest admin distance, then
+/// protocol order as a stable tie-break. ILM entries carry no metric
+/// today (no per-label cost from the producers), so distance + rtype
+/// fully disambiguates. Returns the index into `entries`, or `None`
+/// when empty.
+fn ilm_next(entries: &[IlmEntry]) -> Option<usize> {
+    entries
+        .iter()
+        .enumerate()
+        .min_by(|(_, a), (_, b)| {
+            a.distance
+                .cmp(&b.distance)
+                .then(a.rtype.u8().cmp(&b.rtype.u8()))
+        })
+        .map(|(i, _)| i)
+}
+
 // IPv6 helper functions
 
 async fn ipv6_entry_selection(
@@ -1823,6 +1879,48 @@ mod tests {
         RecoveryDecision, SuppressReason, addr_recover_decide,
     };
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn ilm_next_picks_lowest_distance() {
+        use super::IlmEntry;
+        use super::ilm_next;
+        use crate::rib::RibType;
+
+        // Empty table has no winner.
+        assert_eq!(ilm_next(&[]), None);
+
+        // A lone candidate always wins.
+        let isis = IlmEntry::new(RibType::Isis);
+        assert_eq!(ilm_next(std::slice::from_ref(&isis)), Some(0));
+
+        // OSPF (110) beats IS-IS (115) regardless of insertion order.
+        let ospf = IlmEntry::new(RibType::Ospf);
+        assert_eq!(ilm_next(&[isis.clone(), ospf.clone()]), Some(1));
+        assert_eq!(ilm_next(&[ospf, isis]), Some(0));
+
+        // Static (1) outranks BGP (20) and OSPF (110).
+        let entries = [
+            IlmEntry::new(RibType::Bgp),
+            IlmEntry::new(RibType::Static),
+            IlmEntry::new(RibType::Ospf),
+        ];
+        assert_eq!(ilm_next(&entries), Some(1));
+    }
+
+    #[test]
+    fn ilm_next_tie_breaks_on_rtype() {
+        use super::IlmEntry;
+        use super::ilm_next;
+        use crate::rib::RibType;
+
+        // Equal distance: the lower protocol code wins. Other(10).u8()
+        // = 10 < Other(20).u8() = 20, so index 1 is selected.
+        let mut a = IlmEntry::new(RibType::Other(20));
+        let mut b = IlmEntry::new(RibType::Other(10));
+        a.distance = 50;
+        b.distance = 50;
+        assert_eq!(ilm_next(&[a, b]), Some(1));
+    }
 
     #[test]
     fn first_delete_recovers() {

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1221,6 +1221,7 @@ fn rib6_show_one(rib: &Rib, prefix: &Ipv6Net, json: bool, detail: bool) -> Strin
 pub struct IlmJson {
     pub protocol: String,
     pub distance: u8,
+    pub selected: bool,
     pub local_label: u32,
     pub outgoing_label: String,
     pub prefix_or_id: String,
@@ -1237,17 +1238,19 @@ pub fn ilm_show(rib: &Rib, _args: Args, json: bool) -> String {
     if json {
         let mut entries = Vec::new();
 
-        for (label, ilm) in rib.ilm.iter() {
-            match &ilm.nexthop {
-                Nexthop::Uni(uni) => {
-                    entries.push(ilm_to_json(rib, *label, ilm, uni));
-                }
-                Nexthop::Multi(multi) => {
-                    for uni in multi.nexthops.iter() {
+        for (label, ilms) in rib.ilm.iter() {
+            for ilm in ilms.iter() {
+                match &ilm.nexthop {
+                    Nexthop::Uni(uni) => {
                         entries.push(ilm_to_json(rib, *label, ilm, uni));
                     }
+                    Nexthop::Multi(multi) => {
+                        for uni in multi.nexthops.iter() {
+                            entries.push(ilm_to_json(rib, *label, ilm, uni));
+                        }
+                    }
+                    _ => {}
                 }
-                _ => {}
             }
         }
 
@@ -1260,31 +1263,33 @@ pub fn ilm_show(rib: &Rib, _args: Args, json: bool) -> String {
         // Add header
         writeln!(
             buf,
-            "P Dist Local  Outgoing    Prefix             Outgoing     Next Hop"
+            "   P Dist Local  Outgoing    Prefix             Outgoing     Next Hop"
         )
         .unwrap();
         writeln!(
             buf,
-            "       Label  Label       or ID              Interface"
+            "          Label  Label       or ID              Interface"
         )
         .unwrap();
         writeln!(
             buf,
-            "- ---- ------ ----------- ------------------ ------------ ---------------"
+            "-- - ---- ------ ----------- ------------------ ------------ ---------------"
         )
         .unwrap();
 
-        for (label, ilm) in rib.ilm.iter() {
-            match &ilm.nexthop {
-                Nexthop::Uni(uni) => {
-                    write_ilm_entry(&mut buf, rib, *label, ilm, uni);
-                }
-                Nexthop::Multi(multi) => {
-                    for uni in multi.nexthops.iter() {
+        for (label, ilms) in rib.ilm.iter() {
+            for ilm in ilms.iter() {
+                match &ilm.nexthop {
+                    Nexthop::Uni(uni) => {
                         write_ilm_entry(&mut buf, rib, *label, ilm, uni);
                     }
+                    Nexthop::Multi(multi) => {
+                        for uni in multi.nexthops.iter() {
+                            write_ilm_entry(&mut buf, rib, *label, ilm, uni);
+                        }
+                    }
+                    _ => {}
                 }
-                _ => {}
             }
         }
 
@@ -1300,6 +1305,7 @@ fn write_ilm_entry(
     ilm: &super::inst::IlmEntry,
     uni: &super::NexthopUni,
 ) {
+    let marker = if ilm.selected { "*>" } else { "" };
     let protocol = ilm.rtype.abbrev();
     let distance = format!("{:<4}", ilm.distance);
     let local_label = format!("{:<6}", label);
@@ -1347,8 +1353,8 @@ fn write_ilm_entry(
 
     writeln!(
         buf,
-        "{} {} {} {} {:<18} {:<12} {}",
-        protocol, distance, local_label, outgoing_label, prefix_or_id, interface, next_hop
+        "{:<2} {} {} {} {} {:<18} {:<12} {}",
+        marker, protocol, distance, local_label, outgoing_label, prefix_or_id, interface, next_hop
     )
     .unwrap();
 }
@@ -1401,6 +1407,7 @@ fn ilm_to_json(
     IlmJson {
         protocol: protocol_long_name(ilm.rtype).to_string(),
         distance: ilm.distance,
+        selected: ilm.selected,
         local_label: label,
         outgoing_label,
         prefix_or_id,


### PR DESCRIPTION
## Summary
- Convert `Rib::ilm` from `BTreeMap<u32, IlmEntry>` to a Vec-per-label (`IlmEntries`), so each incoming label can hold one candidate per protocol (mirrors `RibEntries` for the IP table).
- Add `ilm_next` (best by admin distance, then `rtype` tie-break) and `ilm_select_sync`, which reconciles the kernel LFIB by deleting the previously-installed entry (keyed on the label) and installing the new winner. The kernel holds a single AF_MPLS route per label.
- `ilm_add`/`ilm_del` replace the same-`rtype` candidate and re-select, so a label claimed by two protocols **fails over** to the surviving entry instead of last-writer-wins clobbering. Single-owner behavior is unchanged.
- `proto_cleanup` withdraws the protocol's entry from every label it appears in; shutdown deletes the selected entry per label then clears.
- `show mpls ilm` lists all candidates with a `*>` selected marker and a `selected` JSON field.

This is Phase 3 (final) of extending the ILM table — multi-entry storage + RIB selection. Phases 1 (protocol code) and 2 (admin distance) are already merged.

## Test plan
- [x] `cargo build -p zebra-rs`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bins` (664 passed, incl. 2 new `ilm_next` tests)

Generated with [Claude Code](https://claude.com/claude-code)