### PR TITLE
fib: reconcile NexthopMap on kernel RTM_*NEXTHOP, enrich route errors

### DIFF
--- a/zebra-rs/src/fib/message.rs
+++ b/zebra-rs/src/fib/message.rs
@@ -121,6 +121,14 @@ pub enum FibMessage {
     DelAddr(FibAddr),
     NewRoute(FibRoute),
     DelRoute(FibRoute),
+    /// Kernel nexthop-object id from RTM_NEWNEXTHOP — usually the echo
+    /// of our own install; reconciled in `Rib::process_fib_msg`.
+    NewNexthop(u32),
+    /// Kernel nexthop-object id from RTM_DELNEXTHOP. Signals the kernel
+    /// dropped a nexthop (link down / gateway unreachable / manual
+    /// delete); drives `NexthopMap` reconciliation so the group gets
+    /// reinstalled.
+    DelNexthop(u32),
     NewNeighbor(FibNeighbor),
     DelNeighbor(FibNeighbor),
 }

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -42,6 +42,20 @@ use crate::rib::{
     Vxlan, link, nexthop::NexthopMember,
 };
 
+/// Pull the nexthop-object id (`NHA_ID`) out of an inbound
+/// RTM_NEWNEXTHOP / RTM_DELNEXTHOP. The id is the same value RIB hands
+/// to the kernel as the route's `Nhid`, so it indexes `NexthopMap`
+/// directly. Returns `None` for a malformed message with no id.
+fn nexthop_id_from_msg(msg: &NexthopMessage) -> Option<u32> {
+    msg.attributes.iter().find_map(|attr| {
+        if let NexthopAttribute::Id(id) = attr {
+            Some(*id)
+        } else {
+            None
+        }
+    })
+}
+
 /// Compact one-line dump of a `Nexthop` for diagnostic logging.
 /// Surfaces the fields that matter when the kernel rejects an
 /// install — `gid` (so we can spot `Nhid(0)` mistakes), per-leg
@@ -116,6 +130,11 @@ fn fmt_group_for_trace(group: &Group) -> String {
         }
     }
 }
+
+/// Modern rtnetlink multicast group for nexthop objects
+/// (`RTNLGRP_NEXTHOP`, linux/rtnetlink.h). Numbered past the legacy
+/// `RTMGRP_*` bind mask, so it's joined via `add_membership`.
+const RTNLGRP_NEXTHOP: u32 = 32;
 
 // Flip to true to re-enable IPv6 FIB install diagnostic prints.
 const DEBUG_V6: bool = false;
@@ -288,6 +307,25 @@ impl FibHandle {
         let addr = SocketAddr::new(0, mgroup_flags);
         connection.socket_mut().socket_mut().bind(&addr)?;
 
+        // RTM_NEWNEXTHOP / RTM_DELNEXTHOP aren't covered by the legacy
+        // RTMGRP_* bind mask (that only spans the first ~20 groups).
+        // Join the modern multicast group so the kernel delivers
+        // nexthop-object add/del notifications — `process_fib_msg`
+        // uses RTM_DELNEXTHOP to reconcile NexthopMap when the kernel
+        // auto-removes a nexthop (link down / gateway unreachable),
+        // which otherwise leaves our `installed` flag stale and routes
+        // failing to reinstall against a missing nh_id. Non-fatal: a
+        // kernel without nexthop-group support just won't send these.
+        if let Err(e) = connection
+            .socket_mut()
+            .socket_mut()
+            .add_membership(RTNLGRP_NEXTHOP)
+        {
+            tracing::warn!(
+                "fib: could not join RTNLGRP_NEXTHOP ({e}); nexthop reconciliation disabled"
+            );
+        }
+
         tokio::spawn(connection);
 
         let tx = rib_tx.clone();
@@ -409,7 +447,9 @@ impl FibHandle {
         while let Some(msg) = response.next().await {
             if let NetlinkPayload::Error(e) = msg.payload {
                 tracing::info!(
-                    "NewRoute error: {prefix} {e} use_nhid={} nh={}",
+                    "NewRoute error: {prefix} {e} table={table_id} rtype={:?} metric={} use_nhid={} nh={}",
+                    entry.rtype,
+                    entry.metric,
                     self.use_nhid,
                     fmt_nexthop_for_trace(nexthop),
                 );
@@ -530,7 +570,13 @@ impl FibHandle {
         let mut response = self.handle.clone().request(req).unwrap();
         while let Some(msg) = response.next().await {
             if let NetlinkPayload::Error(e) = msg.payload {
-                tracing::info!("DelRoute error: {e} {prefix}");
+                tracing::info!(
+                    "DelRoute error: {prefix} {e} table={table_id} rtype={:?} metric={} use_nhid={} nh={}",
+                    entry.rtype,
+                    entry.metric,
+                    self.use_nhid,
+                    fmt_nexthop_for_trace(nexthop),
+                );
             }
         }
     }
@@ -893,7 +939,13 @@ impl FibHandle {
             if let NetlinkPayload::Error(e) = msg.payload
                 && DEBUG_ADDR
             {
-                tracing::info!("DelRoute IPv6 error: {e} {prefix}");
+                tracing::info!(
+                    "DelRoute IPv6 error: {prefix} {e} table={table_id} rtype={:?} metric={} use_nhid={} nh={}",
+                    entry.rtype,
+                    entry.metric,
+                    self.use_nhid,
+                    fmt_nexthop_for_trace(nexthop),
+                );
             }
         }
     }
@@ -2578,6 +2630,16 @@ fn process_msg(msg: NetlinkMessage<RouteNetlinkMessage>, tx: UnboundedSender<Fib
             RouteNetlinkMessage::DelRoute(msg) => {
                 if let Some(route) = route_from_msg(msg) {
                     let _ = tx.send(FibMessage::DelRoute(route));
+                }
+            }
+            RouteNetlinkMessage::NewNexthop(msg) => {
+                if let Some(id) = nexthop_id_from_msg(&msg) {
+                    let _ = tx.send(FibMessage::NewNexthop(id));
+                }
+            }
+            RouteNetlinkMessage::DelNexthop(msg) => {
+                if let Some(id) = nexthop_id_from_msg(&msg) {
+                    let _ = tx.send(FibMessage::DelNexthop(id));
                 }
             }
             RouteNetlinkMessage::NewNeighbour(msg) => {

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -1768,6 +1768,44 @@ impl Rib {
         }
     }
 
+    /// Kernel reported a nexthop object exists (RTM_NEWNEXTHOP). This
+    /// is almost always the echo of our own install. We only keep our
+    /// view consistent for a gid we own: if we thought it uninstalled,
+    /// record that the kernel now has it so the next sync doesn't issue
+    /// a redundant add. External nexthop ids we don't track are
+    /// ignored (the gid space here is RIB-managed).
+    fn fib_nexthop_added(&mut self, id: u32) {
+        if let Some(group) = self.nmap.get_mut(id as usize)
+            && !group.is_installed()
+        {
+            group.set_installed(true);
+        }
+    }
+
+    /// Kernel reported a nexthop object was removed (RTM_DELNEXTHOP).
+    /// Linux auto-deletes a nexthop object — and every route that
+    /// referenced it — when its egress link goes down or the gateway
+    /// becomes unreachable. Without this hook our `NexthopMap` keeps
+    /// the group flagged `installed`, so the next resolve cycle skips
+    /// re-creating it and routes pointing at the now-missing nh_id fail
+    /// to install with EINVAL. Clearing `installed` lets the debounced
+    /// resolve rebuild the nexthop (and re-add its dependent routes).
+    /// Our own deletes echo back here too, but by then the group is
+    /// gone or the flag already clear, so it's a no-op.
+    fn fib_nexthop_removed(&mut self, id: u32) {
+        let cleared = self.nmap.get_mut(id as usize).is_some_and(|group| {
+            let was_installed = group.is_installed();
+            if was_installed {
+                group.set_installed(false);
+            }
+            was_installed
+        });
+        if cleared {
+            tracing::info!("fib: kernel removed nexthop id {id}; scheduling reinstall");
+            self.schedule_rib_sync();
+        }
+    }
+
     pub async fn process_fib_msg(&mut self, msg: FibMessage) {
         // println!("{:?}", msg);
         match msg {
@@ -1856,6 +1894,12 @@ impl Rib {
                     self.ipv4_route_del(&prefix, route.entry, RT_TABLE_MAIN)
                         .await;
                 }
+            }
+            FibMessage::NewNexthop(id) => {
+                self.fib_nexthop_added(id);
+            }
+            FibMessage::DelNexthop(id) => {
+                self.fib_nexthop_removed(id);
             }
             FibMessage::NewNeighbor(nbr) => {
                 let fdb_entry = fdb_entry_from_neighbor(self, &nbr);


### PR DESCRIPTION
## Summary
The kernel auto-deletes a nexthop object (and the routes referencing it) when its egress link goes down or the gateway becomes unreachable. zebra-rs never observed this — the listener only joined the legacy `RTMGRP_*` groups, which don't cover nexthop objects — so `NexthopMap` kept the group flagged `installed`. The next resolve cycle then skipped re-creating it, and routes pointing at the now-missing nh_id failed to install with `EINVAL` ("nexthop id does not exist"); stale deletes hit `ESRCH`/`ENOENT`.

- Join `RTNLGRP_NEXTHOP` (group 32) via `add_membership` (non-fatal if unsupported).
- Decode `RTM_NEWNEXTHOP`/`RTM_DELNEXTHOP` into `FibMessage::{NewNexthop,DelNexthop}(id)`.
- Reconcile in `Rib::process_fib_msg`: `DelNexthop` clears `installed` for a gid we own and schedules a resync (which rebuilds the nexthop and re-adds dependent routes); `NewNexthop` keeps our view consistent.
- Enrich `NewRoute`/`DelRoute` (v4 + v6) error logs with `table`, `rtype`, `metric`, `use_nhid` and the full nexthop summary, so an install/delete failure says which table/protocol/nexthop was involved.

Diagnosed from a real run where all failing nexthops shared `ifindex=4` after a link event.

## Test plan
- [x] `cargo build -p zebra-rs`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bins` (665 passed)
- [ ] Runtime: reconciliation is kernel/netlink behavior — needs a real link-flap on a box with SR-MPLS nexthops to confirm notifications arrive and routes recover (not unit-testable).

Generated with [Claude Code](https://claude.com/claude-code)