### PR TITLE
fib: self-heal stale nexthops and reconcile live RTM_*NEXTHOP

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -308,22 +308,21 @@ impl FibHandle {
         connection.socket_mut().socket_mut().bind(&addr)?;
 
         // RTM_NEWNEXTHOP / RTM_DELNEXTHOP aren't covered by the legacy
-        // RTMGRP_* bind mask (that only spans the first ~20 groups).
-        // Join the modern multicast group so the kernel delivers
-        // nexthop-object add/del notifications — `process_fib_msg`
-        // uses RTM_DELNEXTHOP to reconcile NexthopMap when the kernel
-        // auto-removes a nexthop (link down / gateway unreachable),
-        // which otherwise leaves our `installed` flag stale and routes
-        // failing to reinstall against a missing nh_id. Non-fatal: a
-        // kernel without nexthop-group support just won't send these.
-        if let Err(e) = connection
+        // RTMGRP_* bind mask (it only spans the first ~20 groups). Join
+        // the modern multicast group so the kernel delivers nexthop
+        // add/del notifications — `process_fib_msg` uses RTM_DELNEXTHOP
+        // to reconcile NexthopMap when the kernel drops a nexthop. Needs
+        // netlink-packet-route's group-nexthop decode fix (see the
+        // `decodes_rtm_newnexthop_group` test). Non-fatal on join error.
+        match connection
             .socket_mut()
             .socket_mut()
             .add_membership(RTNLGRP_NEXTHOP)
         {
-            tracing::warn!(
+            Ok(()) => tracing::info!("fib: joined RTNLGRP_NEXTHOP for nexthop reconciliation"),
+            Err(e) => tracing::warn!(
                 "fib: could not join RTNLGRP_NEXTHOP ({e}); nexthop reconciliation disabled"
-            );
+            ),
         }
 
         tokio::spawn(connection);
@@ -360,7 +359,7 @@ impl FibHandle {
         entry: &RibEntry,
         nexthop: &Nexthop,
         table_id: u32,
-    ) {
+    ) -> bool {
         let mut msg = RouteMessage::default();
         msg.header.address_family = AddressFamily::Inet;
         msg.header.destination_prefix_length = prefix.prefix_len();
@@ -443,9 +442,17 @@ impl FibHandle {
             fmt_nexthop_for_trace(nexthop),
         );
 
+        let mut ok = true;
         let mut response = self.handle.clone().request(req).unwrap();
         while let Some(msg) = response.next().await {
             if let NetlinkPayload::Error(e) = msg.payload {
+                // EEXIST means the route is already in the FIB — treat it
+                // as installed. Otherwise the self-heal would keep
+                // re-adding it every resolve cycle, forever.
+                if e.to_io().raw_os_error() == Some(libc::EEXIST) {
+                    continue;
+                }
+                ok = false;
                 tracing::info!(
                     "NewRoute error: {prefix} {e} table={table_id} rtype={:?} metric={} use_nhid={} nh={}",
                     entry.rtype,
@@ -455,30 +462,35 @@ impl FibHandle {
                 );
             }
         }
+        ok
     }
 
-    pub async fn route_ipv4_add(&self, prefix: &Ipv4Net, entry: &RibEntry, table_id: u32) {
+    /// Returns whether the route ended up in the kernel FIB. `true` also
+    /// covers EEXIST (already present). `false` means a real netlink
+    /// error — commonly EINVAL "nexthop id does not exist" when use_nhid
+    /// points at a nexthop the kernel silently dropped on link down. The
+    /// caller leaves the route's `fib` flag
+    /// clear and forces the nexthop's recreation so the next resolve
+    /// pass re-adds it.
+    pub async fn route_ipv4_add(&self, prefix: &Ipv4Net, entry: &RibEntry, table_id: u32) -> bool {
         if !entry.is_protocol() {
-            return;
+            return true;
         }
         match &entry.nexthop {
-            Nexthop::Uni(_) => {
+            Nexthop::Uni(_) | Nexthop::Multi(_) => {
                 self.route_ipv4_add_uni(prefix, entry, &entry.nexthop, table_id)
-                    .await;
-            }
-            Nexthop::Multi(_) => {
-                self.route_ipv4_add_uni(prefix, entry, &entry.nexthop, table_id)
-                    .await;
+                    .await
             }
             Nexthop::List(pro) => {
+                let mut ok = true;
                 for member in pro.nexthops.iter() {
-                    self.route_ipv4_add_uni(prefix, entry, &member.as_nexthop(), table_id)
+                    ok &= self
+                        .route_ipv4_add_uni(prefix, entry, &member.as_nexthop(), table_id)
                         .await;
                 }
+                ok
             }
-            _ => {
-                //
-            }
+            _ => true,
         }
     }
 
@@ -607,7 +619,7 @@ impl FibHandle {
         entry: &RibEntry,
         nexthop: &Nexthop,
         table_id: u32,
-    ) {
+    ) -> bool {
         if DEBUG_V6 {
             tracing::info!(
                 "[IPv6 route_add_uni] prefix={} prefixlen={} rtype={:?} use_nhid={}",
@@ -661,15 +673,17 @@ impl FibHandle {
 
             let mut req = NetlinkMessage::from(RouteNetlinkMessage::NewRoute(msg));
             req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE;
+            let mut ok = true;
             let mut response = self.handle.clone().request(req).unwrap();
             while let Some(m) = response.next().await {
                 if let NetlinkPayload::Error(e) = m.payload {
+                    ok = false;
                     tracing::warn!(
                         "NewRoute seg6local install error: prefix={prefix} action={action:?} err={e}"
                     );
                 }
             }
-            return;
+            return ok;
         }
 
         if self.use_nhid {
@@ -684,7 +698,7 @@ impl FibHandle {
                     "RTM_NEWROUTE v6 skipped for {prefix}: nexthop gid is 0 (would Nhid(0) -> ENODEV); nh={}",
                     fmt_nexthop_for_trace(nexthop),
                 );
-                return;
+                return false;
             }
             if let Nexthop::Uni(uni) = &nexthop {
                 if DEBUG_V6 {
@@ -750,7 +764,7 @@ impl FibHandle {
                         }
                         Err(e) => {
                             tracing::warn!("SRv6 embedded encap build failed for {prefix}: {e:#}");
-                            return;
+                            return false;
                         }
                     }
                 }
@@ -796,9 +810,16 @@ impl FibHandle {
             fmt_nexthop_for_trace(nexthop),
         );
 
+        let mut ok = true;
         let mut response = self.handle.clone().request(req).unwrap();
         while let Some(msg) = response.next().await {
             if let NetlinkPayload::Error(e) = msg.payload {
+                // EEXIST means the route is already in the FIB — treat it
+                // as installed so the self-heal doesn't re-add it forever.
+                if e.to_io().raw_os_error() == Some(libc::EEXIST) {
+                    continue;
+                }
+                ok = false;
                 tracing::info!(
                     "NewRoute IPv6 error: {prefix} {e} use_nhid={} nh={}",
                     self.use_nhid,
@@ -806,24 +827,30 @@ impl FibHandle {
                 );
             }
         }
+        ok
     }
 
-    pub async fn route_ipv6_add(&self, prefix: &Ipv6Net, entry: &RibEntry, table_id: u32) {
+    /// IPv6 sibling of [`Self::route_ipv4_add`]; returns whether the
+    /// kernel accepted the install.
+    pub async fn route_ipv6_add(&self, prefix: &Ipv6Net, entry: &RibEntry, table_id: u32) -> bool {
         if !entry.is_protocol() {
-            return;
+            return true;
         }
         match &entry.nexthop {
             Nexthop::Uni(_) | Nexthop::Multi(_) => {
                 self.route_ipv6_add_uni(prefix, entry, &entry.nexthop, table_id)
-                    .await;
+                    .await
             }
             Nexthop::List(pro) => {
+                let mut ok = true;
                 for member in pro.nexthops.iter() {
-                    self.route_ipv6_add_uni(prefix, entry, &member.as_nexthop(), table_id)
+                    ok &= self
+                        .route_ipv6_add_uni(prefix, entry, &member.as_nexthop(), table_id)
                         .await;
                 }
+                ok
             }
-            _ => {}
+            _ => true,
         }
     }
 
@@ -1161,20 +1188,25 @@ impl FibHandle {
                         group_summary,
                     );
                 }
+                // Non-error payloads here are mostly the RTNLGRP_NEXTHOP
+                // multicast echoes the kernel delivers on the shared
+                // socket while our request is in flight — not real
+                // responses. Keep them at debug so steady-state churn
+                // doesn't flood the log.
                 NetlinkPayload::Done(m) => {
-                    tracing::info!("NewNexthop done {m:?}");
+                    tracing::debug!("NewNexthop done {m:?}");
                 }
                 NetlinkPayload::InnerMessage(e) => {
-                    tracing::info!("NewNexthop inner message {:?}", e);
+                    tracing::debug!("NewNexthop inner message {:?}", e);
                 }
                 NetlinkPayload::Noop => {
-                    tracing::info!("NewNexthop noop");
+                    tracing::debug!("NewNexthop noop");
                 }
                 NetlinkPayload::Overrun(e) => {
-                    tracing::info!("NewNexthop Overrun {:?}", e);
+                    tracing::debug!("NewNexthop Overrun {:?}", e);
                 }
                 _ => {
-                    tracing::info!("NewNexthop other return");
+                    tracing::debug!("NewNexthop other return");
                 }
             }
         }
@@ -2665,6 +2697,29 @@ fn process_msg(msg: NetlinkMessage<RouteNetlinkMessage>, tx: UnboundedSender<Fib
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Guards the netlink-packet-route group-nexthop decode fix our
+    // RTNLGRP_NEXTHOP reconciliation depends on. These are the exact
+    // bytes of a kernel group notification (RTM_NEWNEXTHOP, id 15,
+    // mpath, members {2, 7}) that the unfixed library dropped with
+    // "failed to decode packet ... type 104". If this fails, the dep
+    // regressed and reconciliation is silently broken again.
+    #[test]
+    fn decodes_rtm_newnexthop_group() {
+        let bytes: &[u8] = &[
+            0x3c, 0x00, 0x00, 0x00, 0x68, 0x00, 0x05, 0x05, 0x59, 0x00, 0x00, 0x00, 0xff, 0x1f,
+            0x00, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x01, 0x00,
+            0x0f, 0x00, 0x00, 0x00, 0x06, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x14, 0x00,
+            0x02, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ];
+        let parsed = netlink_packet_core::NetlinkMessage::<RouteNetlinkMessage>::deserialize(bytes);
+        assert!(
+            parsed.is_ok(),
+            "RTM_NEWNEXTHOP decode regressed: {:?}",
+            parsed.err()
+        );
+    }
 
     #[test]
     fn set_route_table_uses_rtm_table_byte_for_ids_under_256() {

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -771,20 +771,23 @@ impl Rib {
             &self.fib_handle,
         )
         .await;
-        ipv6_route_sync(
+        let retry = ipv6_route_sync(
             &mut self.table_v6,
             &mut self.nmap,
             &self.fib_handle,
             RT_TABLE_MAIN,
         )
         .await;
+        if retry {
+            self.schedule_rib_sync();
+        }
     }
 
     pub async fn ipv4_route_resolve(&mut self) {
         ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.links, &self.fib_handle).await;
         // `false` = not an ifdown sweep; this resolve cycle is for FIB-update
         // re-resolution, not link-down recovery.
-        ipv4_route_sync(
+        let retry = ipv4_route_sync(
             &mut self.table,
             &mut self.nmap,
             &self.fib_handle,
@@ -792,6 +795,11 @@ impl Rib {
             false,
         )
         .await;
+        // A failed install forced a nexthop recreation; arm another
+        // pass so the recreated nexthop and the pending route both land.
+        if retry {
+            self.schedule_rib_sync();
+        }
     }
 
     pub async fn rib_selection(
@@ -803,7 +811,7 @@ impl Rib {
         let Some(entries) = self.table.get_mut(prefix) else {
             return;
         };
-        ipv4_entry_selection(
+        let retry = ipv4_entry_selection(
             prefix,
             entries,
             replace,
@@ -813,6 +821,9 @@ impl Rib {
             false,
         )
         .await;
+        if retry {
+            self.schedule_rib_sync();
+        }
     }
 
     pub async fn rib_selection_v6(
@@ -824,7 +835,7 @@ impl Rib {
         let Some(entries) = self.table_v6.get_mut(prefix) else {
             return;
         };
-        ipv6_entry_selection(
+        let retry = ipv6_entry_selection(
             prefix,
             entries,
             replace,
@@ -833,6 +844,9 @@ impl Rib {
             table_id,
         )
         .await;
+        if retry {
+            self.schedule_rib_sync();
+        }
     }
 }
 
@@ -843,11 +857,11 @@ pub async fn rib_selection_ipv4(
     nmap: &mut NexthopMap,
     fib: &FibHandle,
     table_id: u32,
-) {
+) -> bool {
     let Some(entries) = table.get_mut(prefix) else {
-        return;
+        return false;
     };
-    ipv4_entry_selection(prefix, entries, replace, nmap, fib, table_id, true).await;
+    ipv4_entry_selection(prefix, entries, replace, nmap, fib, table_id, true).await
 }
 
 pub async fn rib_selection_ipv6(
@@ -857,11 +871,11 @@ pub async fn rib_selection_ipv6(
     nmap: &mut NexthopMap,
     fib: &FibHandle,
     table_id: u32,
-) {
+) -> bool {
     let Some(entries) = table.get_mut(prefix) else {
-        return;
+        return false;
     };
-    ipv6_entry_selection(prefix, entries, replace, nmap, fib, table_id).await;
+    ipv6_entry_selection(prefix, entries, replace, nmap, fib, table_id).await
 }
 
 pub async fn ipv4_nexthop_sync(
@@ -958,7 +972,12 @@ pub async fn ipv4_nexthop_sync(
                     fib.nexthop_add(&Group::Multi(multi.clone())).await;
                 } else if multi.valid != set {
                     // Update.
-                    println!("XXX NexthopMulti Update {:?} -> {:?}", multi.valid, set);
+                    tracing::debug!(
+                        "NexthopMulti update gid={} {:?} -> {:?}",
+                        multi.gid(),
+                        multi.valid,
+                        set
+                    );
                     multi.valid = set;
                     fib.nexthop_add(&Group::Multi(multi.clone())).await;
                 } else {
@@ -976,17 +995,19 @@ pub async fn ipv4_route_sync(
     fib: &FibHandle,
     table_id: u32,
     ifdown: bool,
-) {
+) -> bool {
     // Collect prefixes first so we don't hold the !Send `IterMut`
     // across the `ipv4_entry_selection` await.
     let prefixes: Vec<Ipv4Net> = table.iter().map(|(p, _)| p).collect();
+    let mut retry = false;
     for p in prefixes {
         let Some(entries) = table.get_mut(&p) else {
             continue;
         };
         ipv4_entry_resolve(entries, nmap, ifdown);
-        ipv4_entry_selection(&p, entries, None, nmap, fib, table_id, ifdown).await;
+        retry |= ipv4_entry_selection(&p, entries, None, nmap, fib, table_id, ifdown).await;
     }
+    retry
 }
 
 fn ipv4_entry_resolve(entries: &mut RibEntries, nmap: &NexthopMap, ifdown: bool) {
@@ -997,6 +1018,10 @@ fn ipv4_entry_resolve(entries: &mut RibEntries, nmap: &NexthopMap, ifdown: bool)
     }
 }
 
+/// Returns `true` when a route install came back from the kernel as a
+/// failure and we forced a nexthop recreation — the caller should
+/// schedule another resolve pass so the recreated nexthop and the
+/// pending route both land.
 async fn ipv4_entry_selection(
     prefix: &Ipv4Net,
     entries: &mut RibEntries,
@@ -1005,7 +1030,7 @@ async fn ipv4_entry_selection(
     fib: &FibHandle,
     table_id: u32,
     ifdown: bool,
-) {
+) -> bool {
     if let Some(mut replace) = replace
         && replace.is_protocol()
     {
@@ -1016,45 +1041,97 @@ async fn ipv4_entry_selection(
     }
     // Selected.
     let prev = rib_prev(entries);
-
-    // New select.
-    if ifdown {
-        // println!("P: {}", prefix);
-        // for e in entries.iter() {
-        //     println!(
-        //         "E: {:?} distance {} metric {} valid {}",
-        //         e.rtype, e.distance, e.metric, e.valid
-        //     )
-        // }
-    }
-
     let next = rib_next(entries);
 
     if prev == next {
-        return;
-    }
-    if ifdown {
-        // println!("Change: {} prev: {:?} next: {:?}", prefix, prev, next);
+        // No selection change. The selected route may still be missing
+        // from the FIB — the kernel drops routes (and their nexthops)
+        // on link down without an RTM_DELROUTE, leaving it selected but
+        // `fib == false`. Re-add it once its nexthop is resolvable.
+        // Skip during an ifdown sweep (the route is on its way out).
+        if !ifdown && let Some(idx) = next {
+            let e = entries.get_mut(idx).unwrap();
+            if e.is_protocol() && e.is_valid() && !e.is_fib() {
+                e.nexthop_sync(nmap, fib).await;
+                let ok = fib.route_ipv4_add(prefix, e, table_id).await;
+                e.set_fib(ok);
+                if !ok {
+                    nexthop_force_reinstall(&e.nexthop, nmap);
+                    return true;
+                }
+            }
+        }
+        return false;
     }
     if let Some(prev) = prev {
         let prev = entries.get_mut(prev).unwrap();
         prev.set_selected(false);
-        if ifdown {
-            // println!("Remove: {}", prefix);
-        } else {
+        if !ifdown {
             fib.route_ipv4_del(prefix, prev, table_id).await;
         }
         prev.set_fib(false);
     }
+    let mut retry = false;
     if let Some(next) = next {
         let next = entries.get_mut(next).unwrap();
         next.set_selected(true);
 
         if next.is_protocol() {
             next.nexthop_sync(nmap, fib).await;
-            fib.route_ipv4_add(prefix, next, table_id).await;
+            let ok = fib.route_ipv4_add(prefix, next, table_id).await;
+            next.set_fib(ok);
+            if !ok {
+                nexthop_force_reinstall(&next.nexthop, nmap);
+                retry = true;
+            }
+        } else {
+            next.set_fib(true);
         }
-        next.set_fib(true);
+    }
+    retry
+}
+
+/// Drop our "installed" belief for an entry's nexthop so the next
+/// `*_nexthop_sync` recreates it in the kernel. Used when a route
+/// install comes back as an error — the most common cause is the
+/// kernel having silently dropped the nexthop object on link down, so
+/// the route's `Nhid` now points at nothing. A Uni group is
+/// reinstalled while `!installed`; a Multi group while `!valid`, so
+/// clear the flag the relevant sync loop watches.
+fn nexthop_force_reinstall(nexthop: &Nexthop, nmap: &mut NexthopMap) {
+    fn force(nmap: &mut NexthopMap, gid: usize) {
+        if let Some(group) = nmap.get_mut(gid) {
+            match group {
+                Group::Uni(_) => group.set_installed(false),
+                Group::Multi(_) => {
+                    group.set_valid(false);
+                    group.set_installed(false);
+                }
+            }
+        }
+    }
+    match nexthop {
+        Nexthop::Uni(uni) => force(nmap, uni.gid),
+        Nexthop::Multi(multi) => {
+            force(nmap, multi.gid);
+            for uni in &multi.nexthops {
+                force(nmap, uni.gid);
+            }
+        }
+        Nexthop::List(list) => {
+            for member in &list.nexthops {
+                match member {
+                    NexthopMember::Uni(uni) => force(nmap, uni.gid),
+                    NexthopMember::Multi(multi) => {
+                        force(nmap, multi.gid);
+                        for uni in &multi.nexthops {
+                            force(nmap, uni.gid);
+                        }
+                    }
+                }
+            }
+        }
+        _ => {}
     }
 }
 
@@ -1397,7 +1474,7 @@ async fn ipv6_entry_selection(
     nmap: &mut NexthopMap,
     fib: &FibHandle,
     table_id: u32,
-) {
+) -> bool {
     if DEBUG_V6 {
         println!(
             "[ipv6_entry_selection] prefix={} entries={} replace={}",
@@ -1431,7 +1508,7 @@ async fn ipv6_entry_selection(
             entry.set_selected(on);
             entry.set_fib(on);
         }
-        return;
+        return false;
     }
 
     // Selected.
@@ -1445,7 +1522,21 @@ async fn ipv6_entry_selection(
     }
 
     if prev == next {
-        return;
+        // No selection change — re-add a selected route the kernel
+        // dropped on link down (no RTM_DELROUTE), once it resolves.
+        if let Some(idx) = next {
+            let e = entries.get_mut(idx).unwrap();
+            if e.is_protocol() && e.is_valid() && !e.is_fib() {
+                e.nexthop_sync(nmap, fib).await;
+                let ok = fib.route_ipv6_add(prefix, e, table_id).await;
+                e.set_fib(ok);
+                if !ok {
+                    nexthop_force_reinstall(&e.nexthop, nmap);
+                    return true;
+                }
+            }
+        }
+        return false;
     }
     if let Some(prev) = prev {
         let prev = entries.get_mut(prev).unwrap();
@@ -1454,16 +1545,24 @@ async fn ipv6_entry_selection(
         fib.route_ipv6_del(prefix, prev, table_id).await;
         prev.set_fib(false);
     }
+    let mut retry = false;
     if let Some(next) = next {
         let next = entries.get_mut(next).unwrap();
         next.set_selected(true);
 
         if next.is_protocol() {
             next.nexthop_sync(nmap, fib).await;
-            fib.route_ipv6_add(prefix, next, table_id).await;
+            let ok = fib.route_ipv6_add(prefix, next, table_id).await;
+            next.set_fib(ok);
+            if !ok {
+                nexthop_force_reinstall(&next.nexthop, nmap);
+                retry = true;
+            }
+        } else {
+            next.set_fib(true);
         }
-        next.set_fib(true);
     }
+    retry
 }
 
 fn rib_add_v6(table: &mut PrefixMap<Ipv6Net, RibEntries>, prefix: &Ipv6Net, entry: RibEntry) {
@@ -1588,17 +1687,19 @@ pub async fn ipv6_route_sync(
     nmap: &mut NexthopMap,
     fib: &FibHandle,
     table_id: u32,
-) {
+) -> bool {
     // Collect prefixes first so we don't hold the !Send `IterMut`
     // across the `ipv6_entry_selection` await.
     let prefixes: Vec<Ipv6Net> = table.iter().map(|(p, _)| p).collect();
+    let mut retry = false;
     for p in prefixes {
         let Some(entries) = table.get_mut(&p) else {
             continue;
         };
         ipv6_entry_resolve(entries, nmap);
-        ipv6_entry_selection(&p, entries, None, nmap, fib, table_id).await;
+        retry |= ipv6_entry_selection(&p, entries, None, nmap, fib, table_id).await;
     }
+    retry
 }
 
 fn ipv6_entry_resolve(entries: &mut RibEntries, nmap: &NexthopMap) {


### PR DESCRIPTION
## Summary
Builds on the netlink-packet-route group-nexthop decode fix (pushed to the `seg6` fork branch).

- **Reconciliation live**: re-enable the `RTNLGRP_NEXTHOP` subscription so `RTM_DELNEXTHOP` drives `NexthopMap` reconciliation. Adds `decodes_rtm_newnexthop_group` as a guard against a dependency regression.
- **Self-heal (no notifications needed)**: route installs now report the kernel result. On a genuine failure (e.g. EINVAL "nexthop id does not exist") the entry's nexthop is force-recreated and the route re-added on the next resolve. A selected-but-uninstalled route is re-added even without a selection change, so a route the kernel silently purged on link-down (where it sends **no** netlink delete) recovers.
- **EEXIST = installed**: treat EEXIST as already-present so the self-heal can't re-add a route forever (fixes an observed infinite re-install loop).
- **Logging**: enrich `NewRoute`/`DelRoute` errors with table/rtype/metric/nexthop; drop the noisy `nexthop_add` response echoes (our own RTNLGRP_NEXTHOP multicast) to `debug`.

Background: the kernel does not emit `RTM_DELROUTE`/`RTM_DELNEXTHOP` on an interface-down flush, so reconciliation alone can't recover those — the self-heal covers that path.

## Test plan
- [x] `cargo build -p zebra-rs`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rs --bins` (666 passed, incl. `decodes_rtm_newnexthop_group`)
- [x] `/security-review` — no findings
- [ ] Runtime: confirm `joined RTNLGRP_NEXTHOP` at startup, no more `type 104` decode errors, and that a real link flap recovers routes (needs the SR-MPLS box)

Generated with [Claude Code](https://claude.com/claude-code)