### PR TITLE
rib: VRF interface rebind notification + adopt existing kernel VRF

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -11,8 +11,8 @@ use netlink_packet_route::address::{
     AddressAttribute, AddressHeaderFlags, AddressMessage, AddressScope,
 };
 use netlink_packet_route::link::{
-    AfSpecInet6, AfSpecUnspec, InfoData, InfoKind, InfoVxlan, LinkAttribute, LinkFlags, LinkInfo,
-    LinkLayerType, LinkMessage,
+    AfSpecInet6, AfSpecUnspec, InfoData, InfoKind, InfoVrf, InfoVxlan, LinkAttribute, LinkFlags,
+    LinkInfo, LinkLayerType, LinkMessage,
 };
 use netlink_packet_route::neighbour::{NeighbourAddress, NeighbourAttribute, NeighbourMessage};
 use netlink_packet_route::nexthop::{NexthopAttribute, NexthopFlags, NexthopGroup, NexthopMessage};
@@ -1635,6 +1635,46 @@ impl FibHandle {
         if let Err(e) = self.handle.clone().link().del(ifindex).execute().await {
             tracing::warn!("dummy_del({}) error: {}", name, e);
         }
+    }
+
+    /// Look up an existing kernel link by name and, if it is a VRF
+    /// master device, return `(ifindex, table_id)`. Returns `None` if
+    /// the link is absent or isn't a VRF. Lets the daemon adopt a VRF
+    /// master left over from a previous run (or pre-created by the
+    /// operator) instead of failing the create with EEXIST.
+    pub async fn vrf_index_table_by_name(&self, name: &str) -> Option<(u32, u32)> {
+        use futures::TryStreamExt;
+        let mut stream = self
+            .handle
+            .clone()
+            .link()
+            .get()
+            .match_name(name.to_string())
+            .execute();
+        let msg = match stream.try_next().await {
+            Ok(Some(msg)) => msg,
+            _ => return None,
+        };
+        let ifindex = msg.header.index;
+        for attr in msg.attributes.iter() {
+            let LinkAttribute::LinkInfo(infos) = attr else {
+                continue;
+            };
+            let is_vrf = infos
+                .iter()
+                .any(|i| matches!(i, LinkInfo::Kind(InfoKind::Vrf)));
+            let table = infos.iter().find_map(|i| match i {
+                LinkInfo::Data(InfoData::Vrf(data)) => data.iter().find_map(|d| match d {
+                    InfoVrf::TableId(t) => Some(*t),
+                    _ => None,
+                }),
+                _ => None,
+            });
+            if is_vrf && let Some(t) = table {
+                return Some((ifindex, t));
+            }
+        }
+        None
     }
 
     /// Create a Linux VRF master interface bound to `table_id`. Returns

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -189,7 +189,16 @@ impl Rib {
     /// slaves of non-VRF masters (e.g. bridges) — both equate to
     /// the default routing table.
     fn link_vrf_id(&self, link: &Link) -> u32 {
-        let Some(master) = link.master else {
+        self.master_vrf_id(link.master)
+    }
+
+    /// Resolve a VRF id (kernel `rtm_table` value) from a raw `master`
+    /// ifindex. Returns `0` for `None` and for masters that aren't a
+    /// known VRF device (e.g. bridges) — both equate to the default
+    /// routing table. Exposed so the link-update path can compare the
+    /// VRF id *before* and *after* a master change.
+    pub(crate) fn master_vrf_id(&self, master: Option<u32>) -> u32 {
+        let Some(master) = master else {
             return 0;
         };
         self.vrfs
@@ -212,7 +221,14 @@ impl Rib {
 
     /// Push `LinkAdd` only to subscribers bound to this link's VRF.
     pub fn api_link_add(&self, link: &Link) {
-        let vrf_id = self.link_vrf_id(link);
+        self.api_link_add_vrf(link, self.link_vrf_id(link));
+    }
+
+    /// Push `LinkAdd` to subscribers bound to an explicit `vrf_id`.
+    /// Used when an interface is re-enslaved across a VRF boundary:
+    /// the link's `master` already points at the *new* VRF, so the
+    /// target VRF must be named rather than re-derived.
+    pub fn api_link_add_vrf(&self, link: &Link, vrf_id: u32) {
         for (_, sub) in self.client_registry.iter_vrf(vrf_id) {
             let _ = sub.rib_rx_tx.send(RibRx::LinkAdd(link.clone()));
         }
@@ -237,21 +253,42 @@ impl Rib {
     /// `ifindex_vrf_id` falls back to default VRF and the message
     /// goes to the wrong subscribers.
     pub fn api_link_del(&self, ifindex: u32) {
-        let vrf_id = self.ifindex_vrf_id(ifindex);
+        self.api_link_del_vrf(ifindex, self.ifindex_vrf_id(ifindex));
+    }
+
+    /// Push `LinkDel` to subscribers bound to an explicit `vrf_id`.
+    /// Used when an interface leaves a VRF: by the time we notify, the
+    /// link's `master` already names the *new* VRF, so the *old* VRF
+    /// id must be passed in.
+    pub fn api_link_del_vrf(&self, ifindex: u32, vrf_id: u32) {
         for (_, sub) in self.client_registry.iter_vrf(vrf_id) {
             let _ = sub.rib_rx_tx.send(RibRx::LinkDel(ifindex));
         }
     }
 
     pub fn api_addr_add(&self, addr: &LinkAddr) {
-        let vrf_id = self.ifindex_vrf_id(addr.ifindex);
+        self.api_addr_add_vrf(addr, self.ifindex_vrf_id(addr.ifindex));
+    }
+
+    /// Push `AddrAdd` to subscribers bound to an explicit `vrf_id`.
+    /// Used when an interface is re-enslaved across a VRF boundary: its
+    /// addresses must be replayed to the *new* VRF's clients, which
+    /// weren't subscribed when the addresses were first learned.
+    pub fn api_addr_add_vrf(&self, addr: &LinkAddr, vrf_id: u32) {
         for (_, sub) in self.client_registry.iter_vrf(vrf_id) {
             let _ = sub.rib_rx_tx.send(RibRx::AddrAdd(addr.clone()));
         }
     }
 
     pub fn api_addr_del(&self, addr: &LinkAddr) {
-        let vrf_id = self.ifindex_vrf_id(addr.ifindex);
+        self.api_addr_del_vrf(addr, self.ifindex_vrf_id(addr.ifindex));
+    }
+
+    /// Push `AddrDel` to subscribers bound to an explicit `vrf_id`.
+    /// Used when an interface leaves a VRF: its addresses must be
+    /// withdrawn from the *old* VRF's clients, so the old VRF id must
+    /// be passed in.
+    pub fn api_addr_del_vrf(&self, addr: &LinkAddr, vrf_id: u32) {
         for (_, sub) in self.client_registry.iter_vrf(vrf_id) {
             let _ = sub.rib_rx_tx.send(RibRx::AddrDel(addr.clone()));
         }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -1423,15 +1423,36 @@ impl Rib {
                     // `ip link add` would just error.
                     return;
                 }
-                let Some(table_id) = self.vrf_id_alloc.allocate() else {
-                    tracing::warn!("vrf_add({}) failed — id space exhausted", name);
-                    return;
-                };
-                let Some(ifindex) = self.fib_handle.vrf_add(&name, table_id).await else {
-                    // Netlink rejected the create — release the id so
-                    // the next attempt isn't penalised by a leak.
-                    self.vrf_id_alloc.release(table_id);
-                    return;
+                // A VRF master of this name may already exist in the
+                // kernel — left over from a previous run that didn't
+                // clean up, or pre-created by the operator. Adopt it
+                // (taking the kernel's table id as authoritative) rather
+                // than trying to create a duplicate, which the kernel
+                // rejects with EEXIST and which would leave the VRF
+                // unusable and any pending interface binding stuck.
+                let (ifindex, table_id) = if let Some((ifindex, existing_table)) =
+                    self.fib_handle.vrf_index_table_by_name(&name).await
+                {
+                    self.vrf_id_alloc.reserve(existing_table);
+                    tracing::info!(
+                        "vrf_add: adopting existing kernel VRF {} ifindex={} table_id={}",
+                        name,
+                        ifindex,
+                        existing_table
+                    );
+                    (ifindex, existing_table)
+                } else {
+                    let Some(table_id) = self.vrf_id_alloc.allocate() else {
+                        tracing::warn!("vrf_add({}) failed — id space exhausted", name);
+                        return;
+                    };
+                    let Some(ifindex) = self.fib_handle.vrf_add(&name, table_id).await else {
+                        // Netlink rejected the create — release the id so
+                        // the next attempt isn't penalised by a leak.
+                        self.vrf_id_alloc.release(table_id);
+                        return;
+                    };
+                    (ifindex, table_id)
                 };
                 self.vrfs.insert(
                     name.clone(),

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -460,6 +460,16 @@ impl Rib {
         // calls find no entry in `vni_ifindex_map` and silently skip.
         let prev_vni: Option<u32> = self.links.get(&ifindex).and_then(|l| l.vni);
 
+        // Capture master pre-state so an existing link crossing a VRF
+        // boundary (operator `interface X vrf Y`, applied by the kernel
+        // as an RTM_NEWLINK on an already-known ifindex) can be
+        // reconciled below. `link_existed` distinguishes this from a
+        // brand-new link, whose notification is handled in the `else`
+        // branch via `api_link_add`.
+        let link_existed = self.links.contains_key(&ifindex);
+        let prev_master: Option<u32> = self.links.get(&ifindex).and_then(|l| l.master);
+        let now_master: Option<u32> = fib_link.master;
+
         if let Some(link) = self.links.get_mut(&fib_link.index) {
             // When link already exists, we are going to check interface up &
             // down event handling.
@@ -512,6 +522,41 @@ impl Rib {
 
             if !link.is_up() {
                 self.make_link_up(link.index).await;
+            }
+        }
+
+        // A master change that crosses a VRF boundary moves this
+        // interface between subscriber sets: protocol clients in the
+        // *old* VRF must see it leave (DelLink), clients in the *new*
+        // VRF must see it arrive (NewLink). The kernel reports the
+        // enslave/release as an RTM_NEWLINK on an already-known
+        // ifindex, so the new-link branch above (which fires
+        // `api_link_add`) is skipped — reconcile the move here. A
+        // master change that stays within the same VRF id (e.g. bridge
+        // enslave, where the master isn't a VRF device → id 0) is a
+        // no-op.
+        if link_existed {
+            let prev_vrf_id = self.master_vrf_id(prev_master);
+            let now_vrf_id = self.master_vrf_id(now_master);
+            if prev_vrf_id != now_vrf_id
+                && let Some(link) = self.links.get(&ifindex).cloned()
+            {
+                // Withdraw from the old VRF — addresses first, then the
+                // link — so a client tearing down per-interface state
+                // sees dependents leave before the interface itself.
+                for addr in link.addr4.iter().chain(link.addr6.iter()) {
+                    self.api_addr_del_vrf(addr, prev_vrf_id);
+                }
+                self.api_link_del_vrf(ifindex, prev_vrf_id);
+                // Announce to the new VRF — link first, then its
+                // addresses — mirroring the subscribe() dump order. The
+                // addresses were originally pushed only to the VRF the
+                // interface used to sit in, so the new VRF's clients
+                // need this replay to learn them.
+                self.api_link_add_vrf(&link, now_vrf_id);
+                for addr in link.addr4.iter().chain(link.addr6.iter()) {
+                    self.api_addr_add_vrf(addr, now_vrf_id);
+                }
             }
         }
 

--- a/zebra-rs/src/rib/vrf/alloc.rs
+++ b/zebra-rs/src/rib/vrf/alloc.rs
@@ -51,6 +51,14 @@ impl VrfIdAllocator {
     pub fn release(&mut self, id: u32) {
         self.in_use.remove(&id);
     }
+
+    /// Mark an externally-determined ID as in use so it isn't handed
+    /// out by a later `allocate`. Used when adopting a VRF master that
+    /// already exists in the kernel: its table id is the kernel's, not
+    /// one this allocator chose.
+    pub fn reserve(&mut self, id: u32) {
+        self.in_use.insert(id);
+    }
 }
 
 #[cfg(test)]
@@ -96,6 +104,15 @@ mod tests {
         }
         assert_eq!(a.allocate(), Some(256));
         assert_eq!(a.allocate(), Some(257));
+    }
+
+    #[test]
+    fn reserve_marks_id_so_allocate_skips_it() {
+        let mut a = VrfIdAllocator::new();
+        // Adopt a kernel VRF that already uses table 1.
+        a.reserve(1);
+        // The next freshly-allocated id must skip the reserved one.
+        assert_eq!(a.allocate(), Some(2));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two related fixes for VRF integration, both surfaced while wiring up `interface <X> vrf <Y>`:

- **Rebind notification.** Enslaving an interface to a VRF master is reported by the kernel as an `RTM_NEWLINK` on an already-known ifindex, so `link_add`'s existing-link branch only updated `link.master` silently. Protocol clients in the old VRF never saw the interface leave, and clients in the new VRF never saw it arrive. Now a master change that crosses a VRF id boundary withdraws the addresses then the link from the old VRF's subscribers, and announces the link then its addresses to the new VRF's subscribers (mirroring the `subscribe()` dump order). Adds `api_link_add_vrf` / `api_link_del_vrf` / `api_addr_add_vrf` / `api_addr_del_vrf` so the move can name the old/new VRF directly.

- **Adopt existing kernel VRF on restart.** When a VRF master of the configured name already exists in the kernel (leftover from a prior run, or operator pre-created), `vrf_add`'s `ip link add` failed with `EEXIST` and the `VrfAdd` handler bailed without registering the VRF — leaving any pending interface binding stuck forever. The handler now reconciles first: `vrf_index_table_by_name` reads the existing device and, if it's a VRF master, returns `(ifindex, table_id)` from `InfoVrf::TableId`; the handler adopts it (reserving the kernel's table id) rather than creating a duplicate. Adds `VrfIdAllocator::reserve`.

## Test plan

- [x] `cargo build -p zebra-rs`
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] `cargo fmt --all`
- [x] `cargo test -p zebra-rs --bin zebra-rs rib::` (145 passed, incl. new `reserve_marks_id_so_allocate_skips_it`)
- [x] Live: `make run` with a pre-existing `vrf1` now logs `vrf_add: adopting existing kernel VRF vrf1` and the `enp0s8 -> vrf1` bind succeeds (confirmed by reporter)

Generated with [Claude Code](https://claude.com/claude-code)