### PR TITLE
bgp: show bgp vrf redirection + VRF interface binding fixes

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1850,6 +1850,7 @@ mod bfd_wiring_tests {
             policy_tx,
             Some(bfd_client_tx),
             None,
+            tokio::sync::mpsc::channel(1).0,
         );
         (bgp, bfd_client_rx)
     }
@@ -1908,7 +1909,15 @@ mod bfd_wiring_tests {
     async fn enable_without_bfd_handle_is_noop() {
         let (ctx, rib_rx) = test_ctx();
         let (policy_tx, _policy_rx) = mpsc::unbounded_channel();
-        let mut bgp = Bgp::new(ctx, rib_rx, test_rib_subscriber(), policy_tx, None, None);
+        let mut bgp = Bgp::new(
+            ctx,
+            rib_rx,
+            test_rib_subscriber(),
+            policy_tx,
+            None,
+            None,
+            tokio::sync::mpsc::channel(1).0,
+        );
         config_peer(&mut bgp, arg_words(&["10.0.0.4"]), ConfigOp::Set).unwrap();
         // No bfd handle to assert against; the call must not panic.
         config_peer_bfd_enable(&mut bgp, arg_words(&["10.0.0.4", "true"]), ConfigOp::Set).unwrap();
@@ -2075,7 +2084,15 @@ mod neighbor_group_wiring_tests {
         let (ctx, rib_rx) = test_ctx();
         let (policy_tx, _policy_rx) = mpsc::unbounded_channel();
         Box::leak(Box::new(_policy_rx));
-        Bgp::new(ctx, rib_rx, test_rib_subscriber(), policy_tx, None, None)
+        Bgp::new(
+            ctx,
+            rib_rx,
+            test_rib_subscriber(),
+            policy_tx,
+            None,
+            None,
+            tokio::sync::mpsc::channel(1).0,
+        )
     }
 
     fn peer_addr() -> IpAddr {

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -226,6 +226,10 @@ pub struct Bgp {
     pub cm: ConfigChannel,
     pub show: ShowChannel,
     pub show_cb: HashMap<String, ShowCallback>,
+    /// Sender to the config manager, used to (de)register this
+    /// instance's per-VRF show channels so `show bgp vrf <name> …`
+    /// can be redirected into the matching VRF task.
+    pub manager_tx: mpsc::Sender<crate::config::Message>,
     /// Spawn-time runtime context. Bundles the `RibClient` (sends
     /// to RIB through `self.ctx.rib`) with the VRF identity the
     /// socket factories on `ctx` consult — so BGP code calls
@@ -435,6 +439,7 @@ impl Bgp {
         policy_tx: UnboundedSender<policy::Message>,
         bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
         nd_client_tx: Option<UnboundedSender<crate::nd::inst::NdClientReq>>,
+        manager_tx: mpsc::Sender<crate::config::Message>,
     ) -> Self {
         let policy_chan = PolicyRxChannel::new();
         let msg = policy::Message::Subscribe {
@@ -476,6 +481,7 @@ impl Bgp {
             cm: ConfigChannel::new(),
             show: ShowChannel::new(),
             show_cb: HashMap::new(),
+            manager_tx,
             callbacks: HashMap::new(),
             pcallbacks: HashMap::new(),
             listen_task: None,
@@ -779,12 +785,35 @@ impl Bgp {
     /// config callbacks) against [`Self::vrf_registry`] (running
     /// set): spawn the additions, despawn the removals. Called from
     /// `CommitEnd` once per commit.
+    /// Register a VRF task's show channel with the config manager so
+    /// `show bgp vrf <name> …` is redirected into it. Best-effort —
+    /// if the manager mailbox is momentarily full the redirect simply
+    /// isn't installed and the command falls back to the global view.
+    fn register_vrf_show(&self, name: &str, handle: &super::vrf::BgpVrfHandle) {
+        let _ = self
+            .manager_tx
+            .try_send(crate::config::Message::SubscribeShowVrf {
+                key: format!("bgp:vrf:{name}"),
+                tx: handle.show_tx.clone(),
+            });
+    }
+
+    /// Drop the manager's redirect entry for this VRF (despawn / respawn).
+    fn unregister_vrf_show(&self, name: &str) {
+        let _ = self
+            .manager_tx
+            .try_send(crate::config::Message::UnsubscribeShowVrf {
+                key: format!("bgp:vrf:{name}"),
+            });
+    }
+
     fn apply_vrf_commit_diff(&mut self) {
         let (to_spawn, to_despawn) = super::vrf::compute_vrf_diff(&self.vrfs, &self.vrf_registry);
 
         for name in to_despawn {
             if let Some(handle) = self.vrf_registry.remove(&name) {
                 super::vrf::despawn_bgp_vrf(&name, &handle);
+                self.unregister_vrf_show(&name);
                 // Withdraw the AF_MPLS DecapVrf ILM ahead of
                 // returning the label. The netlink delete keys off
                 // the label alone so the IlmEntry contents are
@@ -839,6 +868,7 @@ impl Bgp {
                 &self.rib_subscriber,
                 self.vrf_global_tx.clone(),
             );
+            self.register_vrf_show(&name, &handle);
             self.vrf_registry.insert(name, handle);
         }
     }
@@ -872,6 +902,7 @@ impl Bgp {
         // new handle.
         let preserved_label = if let Some(handle) = self.vrf_registry.remove(name) {
             super::vrf::despawn_bgp_vrf(name, &handle);
+            self.unregister_vrf_show(name);
             // Clear stale `peer_index` entries — the spawned task
             // is about to push fresh RegisterPeer messages.
             self.peer_index.retain(|_, owner| owner != name);
@@ -890,6 +921,7 @@ impl Bgp {
             &self.rib_subscriber,
             self.vrf_global_tx.clone(),
         );
+        self.register_vrf_show(name, &new_handle);
         self.vrf_registry.insert(name.to_string(), new_handle);
         tracing::info!(
             vrf = %name,

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -9,8 +9,67 @@ use serde::Serialize;
 use super::cap::CapAfiMap;
 use super::inst::{Bgp, ShowCallback};
 use super::peer::{Peer, PeerCounter, PeerParam, State};
+use super::peer_map::PeerMap;
+use super::route::LocalRib;
+use super::vrf::inst::BgpVrf;
 use crate::bgp::{AdjRibEvpnTable, AdjRibTable, BgpRibType, RibDirection};
 use crate::config::Args;
+use crate::config::{DisplayRequest, path_from_command};
+
+/// Read-only view of the per-instance BGP state the `show bgp …`
+/// renderers need, letting the same handlers serve both the global
+/// `Bgp` and a per-VRF `BgpVrf`.
+pub trait BgpShowView {
+    fn local_rib(&self) -> &LocalRib;
+    fn peers(&self) -> &PeerMap;
+    fn router_id(&self) -> Ipv4Addr;
+    fn asn(&self) -> u32;
+}
+
+impl BgpShowView for Bgp {
+    fn local_rib(&self) -> &LocalRib {
+        &self.local_rib
+    }
+    fn peers(&self) -> &PeerMap {
+        &self.peers
+    }
+    fn router_id(&self) -> Ipv4Addr {
+        self.router_id
+    }
+    fn asn(&self) -> u32 {
+        self.asn
+    }
+}
+
+impl BgpShowView for BgpVrf {
+    fn local_rib(&self) -> &LocalRib {
+        &self.local_rib
+    }
+    fn peers(&self) -> &PeerMap {
+        &self.peers
+    }
+    fn router_id(&self) -> Ipv4Addr {
+        self.router_id
+    }
+    fn asn(&self) -> u32 {
+        self.asn
+    }
+}
+
+/// Dispatch a `show bgp …` request (already stripped of its `vrf
+/// <name>` selector by the manager) inside a per-VRF task, rendering
+/// against that VRF's RIB/peers via [`BgpShowView`].
+pub async fn process_vrf_show(vrf: &BgpVrf, msg: DisplayRequest) {
+    let (path, args) = path_from_command(&msg.paths);
+    let out = match path.as_str() {
+        "/show/ip/bgp" => show_bgp(vrf, args, msg.json),
+        "/show/ip/bgp/summary" => show_bgp_summary(vrf, args, msg.json),
+        "/show/ip/bgp/neighbors" => show_bgp_neighbor(vrf, args, msg.json),
+        other => Ok(format!("% Unsupported per-VRF show command: {other}\n")),
+    };
+    let out = out.unwrap_or_else(|e| format!("Error formatting output: {e}"));
+    let _ = msg.resp.send(out).await;
+}
 
 /// Human-readable label for an (AFI, SAFI) pair, used as the "<label>
 /// Summary:" header in `show ip bgp summary`.
@@ -31,9 +90,9 @@ fn afi_safi_summary_label(afi: Afi, safi: Safi) -> &'static str {
 /// Collect the set of AFI/SAFIs that are configured on at least one peer,
 /// sorted deterministically by `(afi, safi)` ascending. Falls back to
 /// `[IPv4 Unicast]` when no peer has explicitly configured an AFI/SAFI.
-fn configured_afi_safis(bgp: &Bgp) -> Vec<AfiSafi> {
+fn configured_afi_safis<V: BgpShowView>(bgp: &V) -> Vec<AfiSafi> {
     let mut set: std::collections::BTreeSet<AfiSafi> = std::collections::BTreeSet::new();
-    for (_, peer) in bgp.peers.iter() {
+    for (_, peer) in bgp.peers().iter() {
         for (afi_safi, _) in peer.config.mp.0.iter() {
             set.insert(*afi_safi);
         }
@@ -45,11 +104,11 @@ fn configured_afi_safis(bgp: &Bgp) -> Vec<AfiSafi> {
 }
 
 /// Count Loc-RIB entries for a given AFI/SAFI.
-fn rib_entries_count(bgp: &Bgp, afi_safi: &AfiSafi) -> usize {
+fn rib_entries_count<V: BgpShowView>(bgp: &V, afi_safi: &AfiSafi) -> usize {
     match (afi_safi.afi, afi_safi.safi) {
-        (Afi::Ip, Safi::Unicast) => bgp.local_rib.v4.0.len(),
-        (Afi::Ip, Safi::MplsVpn) => bgp.local_rib.v4vpn.values().map(|t| t.0.len()).sum(),
-        (Afi::L2vpn, Safi::Evpn) => bgp.local_rib.evpn.values().map(|t| t.cands.len()).sum(),
+        (Afi::Ip, Safi::Unicast) => bgp.local_rib().v4.0.len(),
+        (Afi::Ip, Safi::MplsVpn) => bgp.local_rib().v4vpn.values().map(|t| t.0.len()).sum(),
+        (Afi::L2vpn, Safi::Evpn) => bgp.local_rib().evpn.values().map(|t| t.cands.len()).sum(),
         _ => 0,
     }
 }
@@ -129,20 +188,24 @@ fn write_summary_peer_row(buf: &mut String, peer: &Peer, afi: Afi, safi: Safi) -
     )
 }
 
-fn write_summary_section(buf: &mut String, bgp: &Bgp, afi_safi: AfiSafi) -> std::fmt::Result {
+fn write_summary_section<V: BgpShowView>(
+    buf: &mut String,
+    bgp: &V,
+    afi_safi: AfiSafi,
+) -> std::fmt::Result {
     let label = afi_safi_summary_label(afi_safi.afi, afi_safi.safi);
-    let router_id = if bgp.router_id.is_unspecified() {
+    let router_id = if bgp.router_id().is_unspecified() {
         "Not Configured".to_string()
     } else {
-        bgp.router_id.to_string()
+        bgp.router_id().to_string()
     };
-    let asn = if bgp.asn == 0 {
+    let asn = if bgp.asn() == 0 {
         "Not Configured".to_string()
     } else {
-        bgp.asn.to_string()
+        bgp.asn().to_string()
     };
     let rib_entries = rib_entries_count(bgp, &afi_safi);
-    let peer_count = bgp.peers.iter().count();
+    let peer_count = bgp.peers().iter().count();
 
     writeln!(buf, "{} Summary:", label)?;
     writeln!(
@@ -155,7 +218,7 @@ fn write_summary_section(buf: &mut String, bgp: &Bgp, afi_safi: AfiSafi) -> std:
     writeln!(buf)?;
 
     write_summary_header_row(buf)?;
-    for (_, peer) in bgp.peers.iter() {
+    for (_, peer) in bgp.peers().iter() {
         write_summary_peer_row(buf, peer, afi_safi.afi, afi_safi.safi)?;
     }
 
@@ -313,11 +376,15 @@ struct BgpVpnv4RouteJson {
     label: u32,
 }
 
-fn show_bgp(bgp: &Bgp, _args: Args, json: bool) -> std::result::Result<String, std::fmt::Error> {
+fn show_bgp<V: BgpShowView>(
+    bgp: &V,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
     if json {
         let mut routes: Vec<BgpRouteJson> = Vec::new();
 
-        for (key, value) in bgp.local_rib.v4.0.iter() {
+        for (key, value) in bgp.local_rib().v4.0.iter() {
             for rib in value.iter() {
                 let aspath_str = show_aspath(&rib.attr);
                 let origin_str = show_origin(&rib.attr);
@@ -358,7 +425,7 @@ fn show_bgp(bgp: &Bgp, _args: Args, json: bool) -> std::result::Result<String, s
 
     buf.push_str(SHOW_BGP_HEADER);
 
-    for (key, value) in bgp.local_rib.v4.0.iter() {
+    for (key, value) in bgp.local_rib().v4.0.iter() {
         for rib in value.iter() {
             let stale = if rib.stale { "S" } else { " " };
             let valid = "*";
@@ -1117,20 +1184,20 @@ fn show_bgp_received(
     show_adj_rib_routes(&peer.adj_in.v4.0, bgp.router_id, json)
 }
 
-fn show_bgp_summary(
-    bgp: &Bgp,
+fn show_bgp_summary<V: BgpShowView>(
+    bgp: &V,
     _args: Args,
     json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
     if json {
-        let router_id = if bgp.router_id.is_unspecified() {
+        let router_id = if bgp.router_id().is_unspecified() {
             "Not Configured".to_string()
         } else {
-            bgp.router_id.to_string()
+            bgp.router_id().to_string()
         };
 
         let mut peers = Vec::new();
-        for (_, peer) in bgp.peers.iter() {
+        for (_, peer) in bgp.peers().iter() {
             let mut msg_sent: u64 = 0;
             let mut msg_rcvd: u64 = 0;
             for counter in peer.counter.iter() {
@@ -1161,7 +1228,7 @@ fn show_bgp_summary(
 
         let summary = BgpSummaryJson {
             router_id,
-            local_as: bgp.asn,
+            local_as: bgp.asn(),
             peers,
         };
 
@@ -1171,16 +1238,16 @@ fn show_bgp_summary(
 
     let mut buf = String::new();
 
-    if bgp.peers.is_empty() {
-        let router_id = if bgp.router_id.is_unspecified() {
+    if bgp.peers().is_empty() {
+        let router_id = if bgp.router_id().is_unspecified() {
             "Not Configured".to_string()
         } else {
-            bgp.router_id.to_string()
+            bgp.router_id().to_string()
         };
-        let asn = if bgp.asn == 0 {
+        let asn = if bgp.asn() == 0 {
             "Not Configured".to_string()
         } else {
-            bgp.asn.to_string()
+            bgp.asn().to_string()
         };
         writeln!(
             buf,
@@ -1859,8 +1926,8 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
     Ok(())
 }
 
-fn show_bgp_neighbor(
-    bgp: &Bgp,
+fn show_bgp_neighbor<V: BgpShowView>(
+    bgp: &V,
     mut args: Args,
     json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
@@ -1868,7 +1935,7 @@ fn show_bgp_neighbor(
 
     if args.is_empty() {
         let mut neighbors = Vec::<Neighbor>::new();
-        for (_, peer) in bgp.peers.iter() {
+        for (_, peer) in bgp.peers().iter() {
             neighbors.push(fetch(peer));
         }
         if json {
@@ -1880,7 +1947,7 @@ fn show_bgp_neighbor(
         }
     } else {
         if let Some(addr) = args.addr() {
-            if let Some(peer) = bgp.peers.get(&addr) {
+            if let Some(peer) = bgp.peers().get(&addr) {
                 let neighbor = fetch(peer);
                 if json {
                     return Ok(serde_json::to_string_pretty(&neighbor).unwrap_or_else(|e| {
@@ -2173,6 +2240,27 @@ fn show_bgp_vrf(
         show_bgp_vrf_list_json(bgp)
     } else {
         show_bgp_vrf_list_text(bgp)
+    }
+}
+
+/// Handler for `show ip bgp vrf <name> {summary,neighbors}` reached
+/// only when the manager did *not* redirect — i.e. no per-VRF BGP task
+/// is registered for `<name>`. Running VRFs are intercepted by the
+/// manager and dispatched into their own task; this just reports the
+/// miss instead of leaving the request unanswered.
+fn show_bgp_vrf_not_running(
+    _bgp: &Bgp,
+    mut args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let name = args.string().unwrap_or_default();
+    if json {
+        Ok(format!(
+            "{{\"error\": \"BGP VRF {} is not running\"}}",
+            name
+        ))
+    } else {
+        Ok(format!("% BGP VRF {} is not running\n", name))
     }
 }
 
@@ -2519,12 +2607,12 @@ impl Bgp {
     }
 
     pub fn show_build(&mut self) {
-        self.show_add("/show/ip/bgp", show_bgp);
+        self.show_add("/show/ip/bgp", show_bgp::<Bgp>);
         self.show_add("/show/ip/bgp/vpnv4", show_bgp_vpnv4);
         self.show_add("/show/ip/bgp/vpnv4/route", show_bgp_vpnv4_route);
         self.show_add("/show/ip/bgp/route", show_bgp_route_entry);
-        self.show_add("/show/ip/bgp/summary", show_bgp_summary);
-        self.show_add("/show/ip/bgp/neighbors", show_bgp_neighbor);
+        self.show_add("/show/ip/bgp/summary", show_bgp_summary::<Bgp>);
+        self.show_add("/show/ip/bgp/neighbors", show_bgp_neighbor::<Bgp>);
         self.show_add(
             "/show/ip/bgp/neighbors/advertised-routes",
             show_bgp_advertised,
@@ -2551,6 +2639,8 @@ impl Bgp {
         // self.show_add("/show/community-list", show_community_list);
         self.show_add("/show/ip/bgp/attributes", show_bgp_attributes);
         self.show_add("/show/ip/bgp/vrf", show_bgp_vrf);
+        self.show_add("/show/ip/bgp/vrf/summary", show_bgp_vrf_not_running);
+        self.show_add("/show/ip/bgp/vrf/neighbors", show_bgp_vrf_not_running);
         self.show_add("/show/ip/bgp/neighbor-group", show_bgp_neighbor_group);
         self.show_add("/show/evpn/vni/all", show_evpn_vni_all);
         // IOS-XR style update-group observability — kept under

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -282,9 +282,11 @@ impl BgpVrf {
                     // consumer is wired yet — keeps the select!
                     // arm from livelocking.
                 }
-                _msg = self.show.rx.recv() => {
-                    // `show bgp vrf <name> ...` dispatch — same
-                    // drain rationale as above.
+                Some(msg) = self.show.rx.recv() => {
+                    // `show bgp vrf <name> …` — the manager stripped the
+                    // `vrf <name>` selector and redirected the plain
+                    // command here; render against this VRF's RIB/peers.
+                    crate::bgp::show::process_vrf_show(self, msg).await;
                 }
                 Some(msg) = self.rx.recv() => {
                     self.process_msg(msg);

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -35,6 +35,10 @@ use crate::config::RibSubscriber;
 /// [`Task`] so dropping the handle aborts the runtime cleanly.
 pub struct BgpVrfHandle {
     pub inbox: BgpVrfInbox,
+    /// Clone of the per-VRF task's show channel sender. Registered with
+    /// the config manager (`SubscribeShowVrf`) so `show bgp vrf <name>
+    /// …` is redirected into this task; deregistered on despawn.
+    pub show_tx: tokio::sync::mpsc::UnboundedSender<crate::config::DisplayRequest>,
     /// Held so dropping the handle aborts the spawned event loop
     /// even if `despawn_bgp_vrf` was never called (defence in
     /// depth — a clean teardown sends `Shutdown` first). Not
@@ -196,6 +200,10 @@ pub fn spawn_bgp_vrf(
         _ => None,
     };
 
+    // Capture the show channel before `vrf` is moved into the task, so
+    // the global instance can register it with the config manager for
+    // `show bgp vrf <name> …` redirection.
+    let show_tx = vrf.show.tx.clone();
     let task = serve_vrf(vrf);
     tracing::info!(
         vrf = %name,
@@ -210,6 +218,7 @@ pub fn spawn_bgp_vrf(
     );
     BgpVrfHandle {
         inbox,
+        show_tx,
         task,
         label,
         ilm_decap_ifindex,

--- a/zebra-rs/src/config/api.rs
+++ b/zebra-rs/src/config/api.rs
@@ -141,6 +141,10 @@ pub struct DisplayTxRequest {
 #[derive(Debug)]
 pub struct DisplayTxResponse {
     pub tx: UnboundedSender<DisplayRequest>,
+    /// When the manager rewrote the command (e.g. stripped a
+    /// `vrf <name>` selector to redirect into an instance task), the
+    /// caller must dispatch these paths instead of the original.
+    pub paths: Option<Vec<CommandPath>>,
 }
 
 #[derive(Debug)]
@@ -150,6 +154,17 @@ pub enum Message {
     Deploy(DeployRequest),
     DisplayTx(DisplayTxRequest),
     ClearTx(ClearTxRequest),
+    /// Register a per-instance (e.g. per-VRF) show channel under a
+    /// composite key like `"bgp:vrf:<name>"`, so the manager can
+    /// redirect `show <proto> vrf <name> …` into that task.
+    SubscribeShowVrf {
+        key: String,
+        tx: UnboundedSender<DisplayRequest>,
+    },
+    /// Remove a previously-registered per-instance show channel.
+    UnsubscribeShowVrf {
+        key: String,
+    },
 }
 
 #[derive(Debug)]

--- a/zebra-rs/src/config/bgp.rs
+++ b/zebra-rs/src/config/bgp.rs
@@ -23,6 +23,7 @@ pub fn spawn_bgp(config: &ConfigManager) {
         config.policy_tx.clone(),
         bfd_client_tx,
         nd_client_tx,
+        config.tx.clone(),
     );
     config.subscribe("bgp", bgp.cm.tx.clone());
     config.subscribe_show("bgp", bgp.show.tx.clone());

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -13,7 +13,7 @@ use super::nd::spawn_nd;
 use super::ospf::{despawn_ospf, despawn_ospfv3, spawn_ospf, spawn_ospfv3};
 use super::parse::State;
 use super::parse::parse;
-use super::paths::{path_try_trim, paths_str};
+use super::paths::{path_try_trim, paths_str, vrf_redirect_split};
 use super::util::trim_first_line;
 use super::vty::CommandPath;
 use super::yaml::yaml_parse;
@@ -138,6 +138,11 @@ pub struct ConfigManager {
     pub rx: Receiver<Message>,
     pub cm_clients: RefCell<HashMap<String, UnboundedSender<ConfigRequest>>>,
     pub show_clients: RefCell<HashMap<String, UnboundedSender<DisplayRequest>>>,
+    /// Per-instance show channels keyed `"<proto>:vrf:<name>"`. Populated
+    /// at runtime as protocols spawn VRF tasks (via
+    /// [`Message::SubscribeShowVrf`]); lets the manager redirect
+    /// `show <proto> vrf <name> …` into the instance task.
+    pub show_vrf_clients: RefCell<HashMap<String, UnboundedSender<DisplayRequest>>>,
     pub rib_tx: UnboundedSender<crate::rib::Message>,
     /// Inbound envelope channel toward RIB. Mints every `RibClient`
     /// handed out by [`Self::subscribe_to_rib`]; protocol-side sends
@@ -203,6 +208,7 @@ impl ConfigManager {
             rx,
             cm_clients: RefCell::new(HashMap::new()),
             show_clients: RefCell::new(HashMap::new()),
+            show_vrf_clients: RefCell::new(HashMap::new()),
             rib_tx,
             rib_inbound_tx,
             next_proto_id: std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
@@ -761,28 +767,44 @@ impl ConfigManager {
                 let _ = req.resp.send(resp);
             }
             Message::DisplayTx(req) => {
-                let tx_option = if is_bgp(&req.paths) {
-                    self.show_clients.borrow().get("bgp").cloned()
-                } else if is_ospfv3(&req.paths) {
-                    self.show_clients.borrow().get("ospfv3").cloned()
-                } else if is_ospf(&req.paths) {
-                    self.show_clients.borrow().get("ospf").cloned()
-                } else if is_isis(&req.paths) {
-                    self.show_clients.borrow().get("isis").cloned()
-                } else if is_policy(&req.paths) {
-                    self.show_clients.borrow().get("policy").cloned()
-                } else {
-                    self.show_clients.borrow().get("rib").cloned()
-                };
+                // Generic per-VRF instance redirect: `show <proto> vrf
+                // <name> …` is rewritten to `show <proto> …` and routed
+                // to the instance task's show channel when that instance
+                // has registered one. If the name doesn't resolve to a
+                // running instance, fall through to the global proto
+                // channel with the original paths (which renders the
+                // all-VRFs list / a not-running message).
+                let mut paths_override = None;
+                let mut tx_option = None;
+                if let Some((vrf, rewritten)) = vrf_redirect_split(&req.paths) {
+                    let key = format!("{}:vrf:{}", show_proto(&req.paths), vrf);
+                    if let Some(tx) = self.show_vrf_clients.borrow().get(&key).cloned() {
+                        tx_option = Some(tx);
+                        paths_override = Some(rewritten);
+                    }
+                }
+                if tx_option.is_none() {
+                    tx_option = self
+                        .show_clients
+                        .borrow()
+                        .get(show_proto(&req.paths))
+                        .cloned();
+                }
 
                 if let Some(tx) = tx_option {
                     // Protocol is initialized, send the actual handler
-                    let reply = DisplayTxResponse { tx };
+                    let reply = DisplayTxResponse {
+                        tx,
+                        paths: paths_override,
+                    };
                     let _ = req.resp.send(reply);
                 } else {
                     // Protocol is not initialized, send a fallback handler that returns an error message
                     let (fallback_tx, fallback_rx) = mpsc::unbounded_channel();
-                    let reply = DisplayTxResponse { tx: fallback_tx };
+                    let reply = DisplayTxResponse {
+                        tx: fallback_tx,
+                        paths: None,
+                    };
                     let _ = req.resp.send(reply);
 
                     // Spawn a task to handle the fallback response
@@ -818,6 +840,12 @@ impl ConfigManager {
                     output: String::new(),
                 };
                 let _ = req.resp.send(resp);
+            }
+            Message::SubscribeShowVrf { key, tx } => {
+                self.show_vrf_clients.borrow_mut().insert(key, tx);
+            }
+            Message::UnsubscribeShowVrf { key } => {
+                self.show_vrf_clients.borrow_mut().remove(&key);
             }
         }
     }
@@ -913,6 +941,26 @@ fn is_policy(paths: &[CommandPath]) -> bool {
     paths
         .iter()
         .any(|x| x.name == "prefix-set" || x.name == "community-set" || x.name == "policy")
+}
+
+/// Map a show command to the protocol name used as its `show_clients`
+/// key (and the `<proto>` half of a `"<proto>:vrf:<name>"` instance
+/// key). Mirrors the routing order in the `DisplayTx` handler — most
+/// specific first (`ospfv3` before `ospf`).
+fn show_proto(paths: &[CommandPath]) -> &'static str {
+    if is_bgp(paths) {
+        "bgp"
+    } else if is_ospfv3(paths) {
+        "ospfv3"
+    } else if is_ospf(paths) {
+        "ospf"
+    } else if is_isis(paths) {
+        "isis"
+    } else if is_policy(paths) {
+        "policy"
+    } else {
+        "rib"
+    }
 }
 
 fn run_from_exec(exec: Rc<Entry>) -> Rc<Entry> {

--- a/zebra-rs/src/config/mod.rs
+++ b/zebra-rs/src/config/mod.rs
@@ -28,7 +28,7 @@ mod paths;
 pub use paths::path_from_command;
 
 mod api;
-pub use api::{ConfigChannel, ConfigOp, ConfigRequest, DisplayRequest, ShowChannel};
+pub use api::{ConfigChannel, ConfigOp, ConfigRequest, DisplayRequest, Message, ShowChannel};
 
 mod bfd;
 mod bgp;

--- a/zebra-rs/src/config/paths.rs
+++ b/zebra-rs/src/config/paths.rs
@@ -20,6 +20,26 @@ pub fn path_try_trim(name: &str, mut paths: Vec<CommandPath>) -> Vec<CommandPath
     paths
 }
 
+/// If a show command selects a VRF instance — a `vrf` path segment
+/// immediately followed by its matched key (`… vrf <name> …`) — return
+/// the VRF name and the command with both elements removed, so the
+/// targeted instance task sees the plain command (`show bgp vrf X
+/// summary` → `show bgp summary`). Returns `None` when there is no
+/// `vrf` selector or it carries no name (bare `… vrf`), letting the
+/// caller keep the original all-VRFs behaviour.
+pub fn vrf_redirect_split(paths: &[CommandPath]) -> Option<(String, Vec<CommandPath>)> {
+    let i = paths.iter().position(|p| p.name == "vrf")?;
+    let name_path = paths.get(i + 1)?;
+    if !matches!(ymatch_enum(name_path.ymatch), YangMatch::KeyMatched) {
+        return None;
+    }
+    let name = name_path.name.clone();
+    let mut rewritten = Vec::with_capacity(paths.len() - 2);
+    rewritten.extend_from_slice(&paths[..i]);
+    rewritten.extend_from_slice(&paths[i + 2..]);
+    Some((name, rewritten))
+}
+
 pub fn path_from_command(paths: &[CommandPath]) -> (String, Args) {
     let mut output = String::new();
     let mut args = VecDeque::new();
@@ -40,4 +60,65 @@ pub fn path_from_command(paths: &[CommandPath]) -> (String, Args) {
         }
     }
     (output, Args(args))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cp(name: &str, ymatch: i32) -> CommandPath {
+        CommandPath {
+            name: name.to_string(),
+            ymatch,
+            ..Default::default()
+        }
+    }
+
+    // `show ip bgp vrf vrf1 summary` -> ("vrf1", `show ip bgp summary`).
+    #[test]
+    fn vrf_redirect_split_strips_vrf_and_name() {
+        let paths = vec![
+            cp("show", 0),
+            cp("ip", 0),
+            cp("bgp", 0),
+            cp("vrf", 2),     // Key
+            cp("vrf1", 3),    // KeyMatched
+            cp("summary", 4), // Leaf
+        ];
+        let (name, rewritten) = vrf_redirect_split(&paths).expect("should split");
+        assert_eq!(name, "vrf1");
+        let names: Vec<&str> = rewritten.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, ["show", "ip", "bgp", "summary"]);
+    }
+
+    // `show ip bgp vrf vrf1` (no trailing keyword) -> ("vrf1", `show ip bgp`).
+    #[test]
+    fn vrf_redirect_split_handles_bare_name() {
+        let paths = vec![
+            cp("show", 0),
+            cp("ip", 0),
+            cp("bgp", 0),
+            cp("vrf", 2),
+            cp("vrf1", 3),
+        ];
+        let (name, rewritten) = vrf_redirect_split(&paths).expect("should split");
+        assert_eq!(name, "vrf1");
+        let names: Vec<&str> = rewritten.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, ["show", "ip", "bgp"]);
+    }
+
+    // Bare `show ip bgp vrf` (presence, no key) is the all-VRFs list, not a
+    // redirect.
+    #[test]
+    fn vrf_redirect_split_none_without_key() {
+        let paths = vec![cp("show", 0), cp("ip", 0), cp("bgp", 0), cp("vrf", 2)];
+        assert!(vrf_redirect_split(&paths).is_none());
+    }
+
+    // A command with no `vrf` segment is never a redirect.
+    #[test]
+    fn vrf_redirect_split_none_without_vrf() {
+        let paths = vec![cp("show", 0), cp("ip", 0), cp("bgp", 0), cp("summary", 4)];
+        assert!(vrf_redirect_split(&paths).is_none());
+    }
 }

--- a/zebra-rs/src/config/serve.rs
+++ b/zebra-rs/src/config/serve.rs
@@ -453,8 +453,11 @@ impl Show for ShowService {
         self.tx.send(Message::DisplayTx(query)).await.unwrap();
         let serve = rx.await.unwrap();
         let (bus_tx, mut bus_rx) = mpsc::channel::<String>(4);
+        // The manager may rewrite the command (e.g. stripping a
+        // `vrf <name>` selector to redirect into an instance task); use
+        // its rewritten paths when present.
         let req = DisplayRequest {
-            paths: request.paths.clone(),
+            paths: serve.paths.unwrap_or_else(|| request.paths.clone()),
             json: request.json,
             resp: bus_tx.clone(),
         };

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -1558,14 +1558,17 @@ impl Rib {
                     self.pending_vrf_bind.insert(ifname.clone(), vrf.clone());
                 }
 
-                let Some(link) = self.links.values().find(|l| l.name == ifname) else {
-                    tracing::info!(
-                        "link_vrf_bind: interface {} not present yet — pending",
-                        ifname
-                    );
-                    return;
+                let (ifindex, current_master) = match self.links.values().find(|l| l.name == ifname)
+                {
+                    Some(link) => (link.index, link.master.unwrap_or(0)),
+                    None => {
+                        tracing::info!(
+                            "link_vrf_bind: interface {} not present yet — pending",
+                            ifname
+                        );
+                        return;
+                    }
                 };
-                let ifindex = link.index;
 
                 let master = match &vrf {
                     Some(vrf_name) => match self.vrfs.get(vrf_name) {
@@ -1580,6 +1583,18 @@ impl Rib {
                     },
                     None => 0,
                 };
+
+                // Only touch the kernel when the master actually changes.
+                // `pending_vrf_bind` is kept as durable desired-state (so
+                // an interface flap re-binds), which means `link_add`
+                // replays this message on every RTM_NEWLINK for the
+                // interface. Enslaving emits a burst of those (master +
+                // operstate/flag transitions), so without this guard each
+                // one re-issues a redundant `link_set_master` — log spam
+                // and a potential feedback loop.
+                if current_master == master {
+                    return;
+                }
 
                 self.fib_handle.link_set_master(ifindex, master).await;
                 tracing::info!(

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1909,6 +1909,12 @@ module config {
         type string;
       }
       leaf vrf {
+        // Highest priority among interface children so the enslave to
+        // the VRF master is applied before any address: the kernel then
+        // creates the connected route directly in the VRF table instead
+        // of in the default table (which would otherwise have to be
+        // moved on bind).
+        ext:sort "10";
         type leafref {
           path "/vrf/name";
         }

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -254,6 +254,14 @@ module exec {
             ext:dynamic "bgp:vrf";
             type string;
           }
+          leaf summary {
+            ext:help "Summary of this VRF's BGP neighbor status";
+            type empty;
+          }
+          leaf neighbors {
+            ext:help "Detailed information on this VRF's BGP neighbors";
+            type empty;
+          }
         }
         list neighbor-group {
           ext:help "BGP neighbor-group inheritance state";


### PR DESCRIPTION
## Summary

Three related VRF changes (one commit each):

1. **`show bgp vrf <name>` redirection** — `show bgp vrf <name> [summary|neighbors]` now runs inside the spawned per-VRF BGP task and renders that VRF's RIB/peers. Built on a generic, reusable rule in the config layer (`vrf_redirect_split` + a manager-side `show_vrf_clients` registry keyed `"<proto>:vrf:<name>"`, populated at runtime via `SubscribeShowVrf`/`UnsubscribeShowVrf`). The manager rewrites the path and routes to the instance channel, falling back to the global proto channel when no instance is registered. The three renderers are generic over a `BgpShowView` trait implemented by both `Bgp` and `BgpVrf`.

2. **Interface `vrf` apply order** — the interface `vrf` leaf gets the highest `ext:sort` so the enslave to the VRF master is applied before any address; the kernel then creates the connected route directly in the VRF table rather than moving it on bind.

3. **VRF bind re-bind guard** — `LinkVrfBind` now skips `link_set_master` when the link's current master already equals the target, eliminating the redundant-bind log storm (5 binds for one config line) caused by `link_add` replaying the durable `pending_vrf_bind` on every RTM_NEWLINK during enslave.

## Test plan

- [x] `cargo build -p zebra-rs`
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] `cargo fmt --all`
- [x] `cargo test -p zebra-rs --bin zebra-rs` config (115) + bgp (177) + rib (145) pass; new `vrf_redirect_split` unit tests
- [ ] Live (YANG/CLI path not covered by CI): `make run`, then `show bgp vrf vrf1 [summary|neighbors]`, confirm interface `vrf` renders/applies first, and that one `link_vrf_bind` fires instead of five

Generated with [Claude Code](https://claude.com/claude-code)