### PR TITLE
rib: place VRF interface connected route in the VRF table

### DIFF
--- a/zebra-rs/src/fib/message.rs
+++ b/zebra-rs/src/fib/message.rs
@@ -74,6 +74,11 @@ impl FibAddr {
 pub struct FibRoute {
     pub prefix: IpNet,
     pub entry: RibEntry,
+    /// Kernel routing-table id the route belongs to (`rtm_table`, or
+    /// the `RTA_TABLE` attribute for ids > 255). `RT_TABLE_MAIN` (254)
+    /// for the default table; a VRF's table id otherwise. Lets the RIB
+    /// dispatch a learned route into the matching `vrf_tables` entry.
+    pub table_id: u32,
 }
 
 /// One row from the kernel's neighbor table — covers IPv4 ARP, IPv6

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -2564,8 +2564,15 @@ pub fn route_from_msg(msg: RouteMessage) -> Option<FibRoute> {
         builder = builder.ipv4_prefix(prefix);
     }
 
+    // `rtm_table` is a single byte; ids > 255 arrive as
+    // `RT_TABLE_UNSPEC` in the header with the real id in `RTA_TABLE`.
+    let mut table_id = msg.header.table as u32;
+
     for attr in msg.attributes.into_iter() {
         match attr {
+            RouteAttribute::Table(t) => {
+                table_id = t;
+            }
             RouteAttribute::Priority(metric) => {
                 builder = builder.metric(metric);
             }
@@ -2620,7 +2627,11 @@ pub fn route_from_msg(msg: RouteMessage) -> Option<FibRoute> {
 
     let (prefix, entry) = builder.build();
 
-    let msg = FibRoute { prefix, entry };
+    let msg = FibRoute {
+        prefix,
+        entry,
+        table_id,
+    };
 
     Some(msg)
 }

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -212,7 +212,7 @@ impl Rib {
     /// `0` when the ifindex is unknown — fail-safe to default-VRF,
     /// matching the inbound dispatcher's behaviour for ghost
     /// `ProtoId`s.
-    fn ifindex_vrf_id(&self, ifindex: u32) -> u32 {
+    pub(crate) fn ifindex_vrf_id(&self, ifindex: u32) -> u32 {
         self.links
             .get(&ifindex)
             .map(|l| self.link_vrf_id(l))

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -1320,9 +1320,27 @@ impl Rib {
     /// ILM is VRF-agnostic at the kernel (single global MPLS table),
     /// so the dispatcher ignores `table_id` for those variants and
     /// the global path runs unchanged — see `Rib::ilm_add`.
+    /// A connected route belongs in the routing table of the VRF its
+    /// interface is enslaved to. Internal `Ipv4Add`/`Ipv6Add` sends
+    /// arrive with `RT_TABLE_MAIN` and carry the interface ifindex on
+    /// the entry; redirect the connected ones onto their interface's
+    /// VRF table so they land in `vrf_tables` instead of polluting the
+    /// default table. Non-connected entries and inbound envelopes that
+    /// already name a VRF table are returned unchanged.
+    fn route_table_for(&self, entry: &RibEntry, table_id: u32) -> u32 {
+        if table_id == RT_TABLE_MAIN && entry.is_connected() {
+            let vrf_id = self.ifindex_vrf_id(entry.ifindex);
+            if vrf_id != 0 {
+                return vrf_id;
+            }
+        }
+        table_id
+    }
+
     async fn process_msg(&mut self, msg: Message, table_id: u32) {
         match msg {
             Message::Ipv4Add { prefix, rib } => {
+                let table_id = self.route_table_for(&rib, table_id);
                 if table_id == RT_TABLE_MAIN {
                     self.ipv4_route_add(&prefix, rib, table_id).await;
                 } else {
@@ -1330,6 +1348,7 @@ impl Rib {
                 }
             }
             Message::Ipv4Del { prefix, rib } => {
+                let table_id = self.route_table_for(&rib, table_id);
                 if table_id == RT_TABLE_MAIN {
                     self.ipv4_route_del(&prefix, rib, table_id).await;
                 } else {
@@ -1337,6 +1356,7 @@ impl Rib {
                 }
             }
             Message::Ipv6Add { prefix, rib } => {
+                let table_id = self.route_table_for(&rib, table_id);
                 if table_id == RT_TABLE_MAIN {
                     self.ipv6_route_add(&prefix, rib, table_id).await;
                 } else {
@@ -1344,6 +1364,7 @@ impl Rib {
                 }
             }
             Message::Ipv6Del { prefix, rib } => {
+                let table_id = self.route_table_for(&rib, table_id);
                 if table_id == RT_TABLE_MAIN {
                     self.ipv6_route_del(&prefix, rib, table_id).await;
                 } else {
@@ -1921,14 +1942,25 @@ impl Rib {
             }
             FibMessage::NewRoute(route) => {
                 if let IpNet::V4(prefix) = route.prefix {
-                    self.ipv4_route_add(&prefix, route.entry, RT_TABLE_MAIN)
-                        .await;
+                    if route.table_id == RT_TABLE_MAIN {
+                        self.ipv4_route_add(&prefix, route.entry, RT_TABLE_MAIN)
+                            .await;
+                    } else if self.vrf_tables.contains_key(&route.table_id) {
+                        // A route the kernel placed in a VRF's table —
+                        // mirror it into that VRF. Tables we don't manage
+                        // are ignored rather than dumped into the default.
+                        self.ipv4_route_add_vrf(route.table_id, &prefix, route.entry);
+                    }
                 }
             }
             FibMessage::DelRoute(route) => {
                 if let IpNet::V4(prefix) = route.prefix {
-                    self.ipv4_route_del(&prefix, route.entry, RT_TABLE_MAIN)
-                        .await;
+                    if route.table_id == RT_TABLE_MAIN {
+                        self.ipv4_route_del(&prefix, route.entry, RT_TABLE_MAIN)
+                            .await;
+                    } else if self.vrf_tables.contains_key(&route.table_id) {
+                        self.ipv4_route_del_vrf(route.table_id, &prefix, route.entry);
+                    }
                 }
             }
             FibMessage::NewNexthop(id) => {

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -1917,8 +1917,24 @@ pub(super) fn vrf_ipv4_insert(
         return false;
     };
     let entries = t.table.entry(*prefix).or_default();
-    entries.push(entry);
+    vrf_entries_replace(entries, entry);
     true
+}
+
+/// Insert `entry`, first dropping any prior entry it should supersede,
+/// so a prefix fed from two sources (the daemon's connected-route
+/// synthesis and the kernel's RTM_NEWROUTE echo) — and re-notified on
+/// flaps — doesn't accumulate duplicates. Mirrors `rib_add_system`:
+/// same protocol replaces, except connected routes are keyed by
+/// interface so a multi-homed prefix keeps one entry per interface.
+fn vrf_entries_replace(entries: &mut RibEntries, entry: RibEntry) {
+    entries.retain(|e| {
+        if e.rtype != entry.rtype {
+            return true;
+        }
+        entry.is_connected() && e.ifindex != entry.ifindex
+    });
+    entries.push(entry);
 }
 
 pub(super) fn vrf_ipv4_remove(
@@ -1950,7 +1966,7 @@ pub(super) fn vrf_ipv6_insert(
         return false;
     };
     let entries = t.table_v6.entry(*prefix).or_default();
-    entries.push(entry);
+    vrf_entries_replace(entries, entry);
     true
 }
 
@@ -2260,6 +2276,39 @@ mod tests {
         vrf_ipv4_insert(&mut vrf_tables, 10, &prefix, RibEntry::new(RibType::Bgp));
         vrf_ipv4_remove(&mut vrf_tables, 10, &prefix, RibType::Bgp);
         assert!(vrf_tables.get(&10).unwrap().table.get(&prefix).is_none());
+    }
+
+    #[test]
+    fn vrf_ipv4_insert_dedups_per_protocol_and_interface() {
+        use super::super::RibType;
+        use super::super::entry::RibEntry;
+        use super::super::vrf::VrfRibTables;
+        use super::vrf_ipv4_insert;
+        use ipnet::Ipv4Net;
+        use std::collections::BTreeMap;
+
+        let mut vrf_tables: BTreeMap<u32, VrfRibTables> = BTreeMap::new();
+        vrf_tables.insert(10, VrfRibTables::new());
+        let prefix: Ipv4Net = "10.0.0.0/24".parse().unwrap();
+        let connected = |ifindex: u32| {
+            let mut e = RibEntry::new(RibType::Connected);
+            e.ifindex = ifindex;
+            e
+        };
+
+        // Two sources feed the same connected route (same interface):
+        // the second replaces the first rather than duplicating.
+        vrf_ipv4_insert(&mut vrf_tables, 10, &prefix, connected(5));
+        vrf_ipv4_insert(&mut vrf_tables, 10, &prefix, connected(5));
+        let entries = vrf_tables.get(&10).unwrap().table.get(&prefix).unwrap();
+        assert_eq!(entries.len(), 1, "same connected route dedups");
+
+        // A connected route on a different interface coexists.
+        vrf_ipv4_insert(&mut vrf_tables, 10, &prefix, connected(6));
+        // A different protocol coexists with connected.
+        vrf_ipv4_insert(&mut vrf_tables, 10, &prefix, RibEntry::new(RibType::Bgp));
+        let entries = vrf_tables.get(&10).unwrap().table.get(&prefix).unwrap();
+        assert_eq!(entries.len(), 3, "different ifindex / rtype kept");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A connected route on an interface enslaved to a VRF was always recorded in the **default** table, because the connected-route path ignored the interface's VRF and kernel-learned routes dropped their table id. This makes it land in the VRF's table instead.

- **`route_table_for`** redirects a connected `Ipv4Add`/`Ipv6Add` onto its interface's VRF table (resolved from the entry ifindex via `ifindex_vrf_id`) rather than the default table.
- **`FibRoute.table_id`** — `route_from_msg` reads `rtm_table` (and the `RTA_TABLE` attribute for ids > 255); `FibMessage::NewRoute`/`DelRoute` dispatch by it: a known VRF table → `vrf_tables`, the default table → global, other tables → ignored. Covers the kernel's auto connected route and manual `ip route … table N`.
- **Idempotent VRF inserts** — `vrf_ipv4_insert`/`vrf_ipv6_insert` replace a same-protocol entry (keyed by interface for connected) before pushing, so the daemon-synthesised and kernel-echoed copies coexist without duplicates (mirrors `rib_add_system`).

Net: a connected address on a VRF interface appears in `show ip route vrf <name>` and stays out of the default table.

## Test plan

- [x] `cargo build -p zebra-rs`
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] `cargo fmt --all`
- [x] `cargo test -p zebra-rs --bin zebra-rs rib::` (146 pass, incl. new `vrf_ipv4_insert_dedups_per_protocol_and_interface`)
- [ ] Live (not covered by CI): `make run`, then `show ip route vrf vrf1` shows `10.0.0.0/24` connected and `show ip route` no longer does

## Notes

- VRF tables still only *record* prefixes for show — no best-path/FIB-install/redistribute inside the VRF yet (existing `ipv4_route_add_vrf` limitation).
- `fib_dump` runs before VRFs are created, so VRF routes present at startup won't load until re-learned; live config is unaffected.

Generated with [Claude Code](https://claude.com/claude-code)