### PR TITLE
rib: best-path selection and FIB install for VRF tables

### DIFF
--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -844,7 +844,7 @@ impl Rib {
         }
 
         let uni = Self::sid_nexthop_uni(&sid);
-        let Some(group) = self.nmap.fetch(&uni) else {
+        let Some(group) = self.nmap.fetch(&uni, RT_TABLE_MAIN) else {
             tracing::warn!(
                 "[sid_install] addr={} NexthopMap::fetch returned None",
                 sid.addr
@@ -925,7 +925,7 @@ impl Rib {
         self.fib_handle.route_sid_uninstall(&sid).await;
 
         let uni = Self::sid_nexthop_uni(&sid);
-        let Some(group) = self.nmap.fetch(&uni) else {
+        let Some(group) = self.nmap.fetch(&uni, RT_TABLE_MAIN) else {
             return;
         };
         let gid = group.gid();
@@ -1344,7 +1344,7 @@ impl Rib {
                 if table_id == RT_TABLE_MAIN {
                     self.ipv4_route_add(&prefix, rib, table_id).await;
                 } else {
-                    self.ipv4_route_add_vrf(table_id, &prefix, rib);
+                    self.ipv4_route_add_vrf(table_id, &prefix, rib).await;
                 }
             }
             Message::Ipv4Del { prefix, rib } => {
@@ -1352,7 +1352,7 @@ impl Rib {
                 if table_id == RT_TABLE_MAIN {
                     self.ipv4_route_del(&prefix, rib, table_id).await;
                 } else {
-                    self.ipv4_route_del_vrf(table_id, &prefix, rib);
+                    self.ipv4_route_del_vrf(table_id, &prefix, rib).await;
                 }
             }
             Message::Ipv6Add { prefix, rib } => {
@@ -1360,7 +1360,7 @@ impl Rib {
                 if table_id == RT_TABLE_MAIN {
                     self.ipv6_route_add(&prefix, rib, table_id).await;
                 } else {
-                    self.ipv6_route_add_vrf(table_id, &prefix, rib);
+                    self.ipv6_route_add_vrf(table_id, &prefix, rib).await;
                 }
             }
             Message::Ipv6Del { prefix, rib } => {
@@ -1368,7 +1368,7 @@ impl Rib {
                 if table_id == RT_TABLE_MAIN {
                     self.ipv6_route_del(&prefix, rib, table_id).await;
                 } else {
-                    self.ipv6_route_del_vrf(table_id, &prefix, rib);
+                    self.ipv6_route_del_vrf(table_id, &prefix, rib).await;
                 }
             }
             Message::IlmAdd { label, ilm } => {
@@ -1877,7 +1877,14 @@ impl Rib {
                 // LinkAddr is already present for this address, the merge in
                 // link_addr_update will flip its `fib` flag to true.
                 self.addr_add(addr, false);
-                ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.links, &self.fib_handle).await;
+                ipv4_nexthop_sync(
+                    &mut self.nmap,
+                    &self.table,
+                    &self.vrf_tables,
+                    &self.links,
+                    &self.fib_handle,
+                )
+                .await;
                 ipv4_route_sync(
                     &mut self.table,
                     &mut self.nmap,
@@ -1889,6 +1896,7 @@ impl Rib {
                 ipv6_nexthop_sync(
                     &mut self.nmap,
                     &self.table_v6,
+                    &self.vrf_tables,
                     &self.links,
                     &self.fib_handle,
                 )
@@ -1915,7 +1923,14 @@ impl Rib {
                 }
 
                 self.addr_del(addr);
-                ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.links, &self.fib_handle).await;
+                ipv4_nexthop_sync(
+                    &mut self.nmap,
+                    &self.table,
+                    &self.vrf_tables,
+                    &self.links,
+                    &self.fib_handle,
+                )
+                .await;
                 ipv4_route_sync(
                     &mut self.table,
                     &mut self.nmap,
@@ -1927,6 +1942,7 @@ impl Rib {
                 ipv6_nexthop_sync(
                     &mut self.nmap,
                     &self.table_v6,
+                    &self.vrf_tables,
                     &self.links,
                     &self.fib_handle,
                 )
@@ -1949,7 +1965,8 @@ impl Rib {
                         // A route the kernel placed in a VRF's table —
                         // mirror it into that VRF. Tables we don't manage
                         // are ignored rather than dumped into the default.
-                        self.ipv4_route_add_vrf(route.table_id, &prefix, route.entry);
+                        self.ipv4_route_add_vrf(route.table_id, &prefix, route.entry)
+                            .await;
                     }
                 }
             }
@@ -1959,7 +1976,8 @@ impl Rib {
                         self.ipv4_route_del(&prefix, route.entry, RT_TABLE_MAIN)
                             .await;
                     } else if self.vrf_tables.contains_key(&route.table_id) {
-                        self.ipv4_route_del_vrf(route.table_id, &prefix, route.entry);
+                        self.ipv4_route_del_vrf(route.table_id, &prefix, route.entry)
+                            .await;
                     }
                 }
             }

--- a/zebra-rs/src/rib/nexthop/group.rs
+++ b/zebra-rs/src/rib/nexthop/group.rs
@@ -42,6 +42,13 @@ pub struct GroupUni {
     common: GroupCommon,
     pub addr: IpAddr,
 
+    /// Routing table this nexthop's gateway resolves against
+    /// (`RT_TABLE_MAIN` for the default table, a VRF's table id
+    /// otherwise). The same gateway address in two VRFs is a distinct
+    /// nexthop, so the `NexthopMap` keys on `(table_id, addr)` and the
+    /// periodic resolve cycle walks the table this names.
+    pub table_id: u32,
+
     /// What the source said the egress ifindex was — copied verbatim
     /// from `NexthopUni::ifindex_origin` in `GroupUni::new`. Resolution
     /// must never overwrite this.
@@ -71,7 +78,7 @@ pub struct GroupUni {
 }
 
 impl GroupUni {
-    pub fn new(gid: usize, uni: &NexthopUni) -> Self {
+    pub fn new(gid: usize, uni: &NexthopUni, table_id: u32) -> Self {
         // Carry the source's ifindex_origin straight through — IGP
         // adjacencies, seg6local installs, connected routes and
         // interface-pinned static routes all set it. The resolver is
@@ -79,6 +86,7 @@ impl GroupUni {
         Self {
             common: GroupCommon::new(gid),
             addr: uni.addr,
+            table_id,
             ifindex_origin: uni.ifindex_origin,
             ifindex_resolved: None,
             labels: uni.mpls_label.clone(),
@@ -281,7 +289,7 @@ mod tests {
             addr,
             ..Default::default()
         };
-        GroupUni::new(0, &uni)
+        GroupUni::new(0, &uni, 0)
     }
 
     fn connected_v6(ifindex: u32) -> RibEntry {
@@ -380,7 +388,7 @@ mod tests {
             ifindex_origin: Some(42),
             ..Default::default()
         };
-        let group = GroupUni::new(0, &uni);
+        let group = GroupUni::new(0, &uni, 0);
         assert_eq!(group.ifindex_origin, Some(42));
         assert_eq!(group.ifindex_resolved, None);
         assert_eq!(group.ifindex(), Some(42));
@@ -404,7 +412,7 @@ mod tests {
             ifindex_origin: Some(99), // adjacency knows it's on link 99
             ..Default::default()
         };
-        let mut group = GroupUni::new(0, &uni);
+        let mut group = GroupUni::new(0, &uni, 0);
         assert_eq!(group.ifindex_origin, Some(99));
         assert_eq!(group.ifindex_resolved, None);
 
@@ -513,7 +521,7 @@ mod tests {
             encap_type: Some(EncapType::HEncap),
             ..Default::default()
         };
-        let group = GroupUni::new(7, &uni);
+        let group = GroupUni::new(7, &uni, 0);
         assert_eq!(group.segs, segs);
         assert_eq!(group.encap_type, Some(EncapType::HEncap));
     }
@@ -527,7 +535,7 @@ mod tests {
             addr: IpAddr::V6("2001:db8::1".parse().unwrap()),
             ..Default::default()
         };
-        let group = GroupUni::new(3, &uni);
+        let group = GroupUni::new(3, &uni, 0);
         assert!(group.segs.is_empty());
         assert_eq!(group.encap_type, None);
     }

--- a/zebra-rs/src/rib/nexthop/map.rs
+++ b/zebra-rs/src/rib/nexthop/map.rs
@@ -21,7 +21,7 @@ type Seg6Key = (IpAddr, Vec<Ipv6Addr>, Option<EncapType>);
 type Seg6LocalKey = (crate::rib::SidBehavior, u32, Option<std::net::Ipv6Addr>);
 
 pub struct NexthopMap {
-    map: BTreeMap<IpAddr, usize>,
+    map: BTreeMap<(u32, IpAddr), usize>,
     set: BTreeMap<BTreeSet<(usize, u8)>, usize>,
     mpls: BTreeMap<(IpAddr, Vec<u32>), usize>,
     seg6: BTreeMap<Seg6Key, usize>,
@@ -30,8 +30,8 @@ pub struct NexthopMap {
 }
 
 impl Group {
-    pub fn from_nexthop_uni(uni: &NexthopUni, gid: usize) -> Self {
-        Group::Uni(GroupUni::new(gid, uni))
+    pub fn from_nexthop_uni(uni: &NexthopUni, gid: usize, table_id: u32) -> Self {
+        Group::Uni(GroupUni::new(gid, uni, table_id))
     }
 }
 
@@ -84,35 +84,35 @@ impl NexthopMap {
         self.groups.len()
     }
 
-    pub fn fetch_uni(&mut self, uni: &NexthopUni) -> Option<&mut Group> {
-        if let Some(&gid) = self.map.get(&uni.addr) {
+    pub fn fetch_uni(&mut self, uni: &NexthopUni, table_id: u32) -> Option<&mut Group> {
+        if let Some(&gid) = self.map.get(&(table_id, uni.addr)) {
             let entry = self.groups.get_mut(gid)?;
             if entry.is_none() {
-                *entry = Some(Group::from_nexthop_uni(uni, gid));
+                *entry = Some(Group::from_nexthop_uni(uni, gid, table_id));
             }
             return self.get_mut(gid);
         }
 
         let gid = self.new_gid();
-        let group = Group::from_nexthop_uni(uni, gid);
+        let group = Group::from_nexthop_uni(uni, gid, table_id);
 
-        self.map.insert(uni.addr, gid);
+        self.map.insert((table_id, uni.addr), gid);
         self.groups.push(Some(group));
 
         self.get_mut(gid)
     }
 
-    pub fn fetch_mpls(&mut self, uni: &NexthopUni) -> Option<&mut Group> {
+    pub fn fetch_mpls(&mut self, uni: &NexthopUni, table_id: u32) -> Option<&mut Group> {
         if let Some(&gid) = self.mpls.get(&(uni.addr, uni.mpls_label.clone())) {
             let entry = self.groups.get_mut(gid)?;
             if entry.is_none() {
-                *entry = Some(Group::from_nexthop_uni(uni, gid));
+                *entry = Some(Group::from_nexthop_uni(uni, gid, table_id));
             }
             return self.get_mut(gid);
         }
 
         let gid = self.new_gid();
-        let group = Group::from_nexthop_uni(uni, gid);
+        let group = Group::from_nexthop_uni(uni, gid, table_id);
 
         self.mpls.insert((uni.addr, uni.mpls_label.clone()), gid);
         self.groups.push(Some(group));
@@ -124,18 +124,18 @@ impl NexthopMap {
     /// nexthop. Two NexthopUnis with the same (addr, segs, encap_type) share
     /// one Group — one kernel nhid is shared across every route that uses
     /// the same SRv6 policy.
-    pub fn fetch_seg6(&mut self, uni: &NexthopUni) -> Option<&mut Group> {
+    pub fn fetch_seg6(&mut self, uni: &NexthopUni, table_id: u32) -> Option<&mut Group> {
         let key: Seg6Key = (uni.addr, uni.segs.clone(), uni.encap_type);
         if let Some(&gid) = self.seg6.get(&key) {
             let entry = self.groups.get_mut(gid)?;
             if entry.is_none() {
-                *entry = Some(Group::from_nexthop_uni(uni, gid));
+                *entry = Some(Group::from_nexthop_uni(uni, gid, table_id));
             }
             return self.get_mut(gid);
         }
 
         let gid = self.new_gid();
-        let group = Group::from_nexthop_uni(uni, gid);
+        let group = Group::from_nexthop_uni(uni, gid, table_id);
 
         self.seg6.insert(key, gid);
         self.groups.push(Some(group));
@@ -146,7 +146,7 @@ impl NexthopMap {
     /// Fetch (or create) the dedup'd nexthop entry for an SRv6 seg6local
     /// nexthop (End / End.X). Keyed on (action, oif, nh6) so two SIDs
     /// pointing at the same install target share one Group.
-    pub fn fetch_seg6local(&mut self, uni: &NexthopUni) -> Option<&mut Group> {
+    pub fn fetch_seg6local(&mut self, uni: &NexthopUni, table_id: u32) -> Option<&mut Group> {
         let action = uni.seg6local_action?;
         let nh6 = match uni.addr {
             IpAddr::V6(a) if !a.is_unspecified() => Some(a),
@@ -156,13 +156,13 @@ impl NexthopMap {
         if let Some(&gid) = self.seg6local.get(&key) {
             let entry = self.groups.get_mut(gid)?;
             if entry.is_none() {
-                *entry = Some(Group::from_nexthop_uni(uni, gid));
+                *entry = Some(Group::from_nexthop_uni(uni, gid, table_id));
             }
             return self.get_mut(gid);
         }
 
         let gid = self.new_gid();
-        let group = Group::from_nexthop_uni(uni, gid);
+        let group = Group::from_nexthop_uni(uni, gid, table_id);
 
         self.seg6local.insert(key, gid);
         self.groups.push(Some(group));
@@ -170,23 +170,23 @@ impl NexthopMap {
         self.get_mut(gid)
     }
 
-    pub fn fetch(&mut self, uni: &NexthopUni) -> Option<&mut Group> {
+    pub fn fetch(&mut self, uni: &NexthopUni, table_id: u32) -> Option<&mut Group> {
         // seg6local takes priority over plain unicast — `addr` for an
         // End SID is unspecified and would route through fetch_uni
         // otherwise, collapsing every End SID into a single shared
         // entry by accident.
         if uni.seg6local_action.is_some() {
-            self.fetch_seg6local(uni)
+            self.fetch_seg6local(uni, table_id)
         } else if !uni.segs.is_empty() {
             // SRv6 encap — the segment list is the dedup dimension,
             // and we want SRv6 nexthops in their own table so the FIB
             // nexthop_add path can emit seg6 attributes without
             // re-inspecting NexthopUni.
-            self.fetch_seg6(uni)
+            self.fetch_seg6(uni, table_id)
         } else if uni.mpls_label.is_empty() {
-            self.fetch_uni(uni)
+            self.fetch_uni(uni, table_id)
         } else {
-            self.fetch_mpls(uni)
+            self.fetch_mpls(uni, table_id)
         }
     }
 
@@ -294,8 +294,8 @@ mod tests {
             &["fcbb:bbbb:2:3:2::", "fcbb:bbbb:2:3:3::"],
             EncapType::HEncap,
         );
-        let gid_a = group_gid(nmap.fetch(&uni).expect("group"));
-        let gid_b = group_gid(nmap.fetch(&uni).expect("group"));
+        let gid_a = group_gid(nmap.fetch(&uni, 0).expect("group"));
+        let gid_b = group_gid(nmap.fetch(&uni, 0).expect("group"));
         assert_eq!(gid_a, gid_b);
     }
 
@@ -312,8 +312,8 @@ mod tests {
             &["fcbb:bbbb:2:3:2::", "fcbb:bbbb:2:3:3::"],
             EncapType::HEncap,
         );
-        let gid_one = group_gid(nmap.fetch(&one).expect("group"));
-        let gid_two = group_gid(nmap.fetch(&two).expect("group"));
+        let gid_one = group_gid(nmap.fetch(&one, 0).expect("group"));
+        let gid_two = group_gid(nmap.fetch(&two, 0).expect("group"));
         assert_ne!(gid_one, gid_two);
     }
 
@@ -333,8 +333,8 @@ mod tests {
             &["fcbb:bbbb:2:3:2::", "fcbb:bbbb:2:3:3::"],
             EncapType::HEncapRed,
         );
-        let gid_a = group_gid(nmap.fetch(&h_encap).expect("group"));
-        let gid_b = group_gid(nmap.fetch(&h_red).expect("group"));
+        let gid_a = group_gid(nmap.fetch(&h_encap, 0).expect("group"));
+        let gid_b = group_gid(nmap.fetch(&h_red, 0).expect("group"));
         assert_ne!(gid_a, gid_b);
     }
 
@@ -345,8 +345,8 @@ mod tests {
         let mut nmap = NexthopMap::default();
         let plain_a = plain_uni("2001:db8::1");
         let plain_b = plain_uni("2001:db8::1");
-        let gid_a = group_gid(nmap.fetch(&plain_a).expect("group"));
-        let gid_b = group_gid(nmap.fetch(&plain_b).expect("group"));
+        let gid_a = group_gid(nmap.fetch(&plain_a, 0).expect("group"));
+        let gid_b = group_gid(nmap.fetch(&plain_b, 0).expect("group"));
         assert_eq!(gid_a, gid_b);
 
         // The seg6 dedupe table stays empty.
@@ -354,7 +354,7 @@ mod tests {
 
         // And a Nexthop::Uni constructed from a plain uni surfaces empty
         // segs / None encap_type on the resulting GroupUni.
-        let grp = nmap.fetch(&plain_a).expect("group");
+        let grp = nmap.fetch(&plain_a, 0).expect("group");
         if let Group::Uni(uni) = grp {
             assert!(uni.segs.is_empty());
             assert_eq!(uni.encap_type, None);
@@ -371,7 +371,7 @@ mod tests {
             &["fcbb:bbbb:2:3:2::", "fcbb:bbbb:2:3:3::"],
             EncapType::HEncap,
         );
-        let grp = nmap.fetch(&uni).expect("group");
+        let grp = nmap.fetch(&uni, 0).expect("group");
         if let Group::Uni(g) = grp {
             assert_eq!(g.addr, IpAddr::V6("fcbb:bbbb:2:3:2::".parse().unwrap()));
             assert_eq!(g.segs.len(), 2);
@@ -388,7 +388,7 @@ mod tests {
         let mut nmap = NexthopMap::default();
 
         // Plain.
-        nmap.fetch(&plain_uni("2001:db8::1"));
+        nmap.fetch(&plain_uni("2001:db8::1"), 0);
         assert_eq!(nmap.map.len(), 1);
         assert!(nmap.mpls.is_empty());
         assert!(nmap.seg6.is_empty());
@@ -399,16 +399,19 @@ mod tests {
             mpls_label: vec![100, 200],
             ..Default::default()
         };
-        nmap.fetch(&mpls_uni);
+        nmap.fetch(&mpls_uni, 0);
         assert_eq!(nmap.mpls.len(), 1);
         assert!(nmap.seg6.is_empty());
 
         // SRv6.
-        nmap.fetch(&srv6_uni(
-            "fcbb:bbbb:2:3:2::",
-            &["fcbb:bbbb:2:3:2::"],
-            EncapType::HEncap,
-        ));
+        nmap.fetch(
+            &srv6_uni(
+                "fcbb:bbbb:2:3:2::",
+                &["fcbb:bbbb:2:3:2::"],
+                EncapType::HEncap,
+            ),
+            0,
+        );
         assert_eq!(nmap.seg6.len(), 1);
     }
 
@@ -436,8 +439,8 @@ mod tests {
         // dedup table should hand back the same gid both times so we
         // create only one kernel nhid.
         let mut nmap = NexthopMap::default();
-        let gid_a = group_gid(nmap.fetch(&end_uni(1)).expect("group"));
-        let gid_b = group_gid(nmap.fetch(&end_uni(1)).expect("group"));
+        let gid_a = group_gid(nmap.fetch(&end_uni(1), 0).expect("group"));
+        let gid_b = group_gid(nmap.fetch(&end_uni(1), 0).expect("group"));
         assert_eq!(gid_a, gid_b);
     }
 
@@ -446,8 +449,8 @@ mod tests {
         // Distinct adjacencies (different nh6 link-locals) must NOT
         // share an nh_id — each End.X install is its own kernel entry.
         let mut nmap = NexthopMap::default();
-        let gid_a = group_gid(nmap.fetch(&endx_uni(2, "fe80::1")).expect("group"));
-        let gid_b = group_gid(nmap.fetch(&endx_uni(2, "fe80::2")).expect("group"));
+        let gid_a = group_gid(nmap.fetch(&endx_uni(2, "fe80::1"), 0).expect("group"));
+        let gid_b = group_gid(nmap.fetch(&endx_uni(2, "fe80::2"), 0).expect("group"));
         assert_ne!(gid_a, gid_b);
     }
 
@@ -457,7 +460,7 @@ mod tests {
         // still different actions on the wire — keep them separate so
         // we don't accidentally emit one kernel encap for both.
         let mut nmap = NexthopMap::default();
-        let gid_end = group_gid(nmap.fetch(&end_uni(2)).expect("group"));
+        let gid_end = group_gid(nmap.fetch(&end_uni(2), 0).expect("group"));
         // End.X with empty/unspec nh6 is invalid in practice but the
         // dedup key must still discriminate by action so a bug-y caller
         // can't collapse the two.
@@ -467,7 +470,7 @@ mod tests {
             seg6local_action: Some(crate::rib::SidBehavior::EndX),
             ..Default::default()
         };
-        let gid_endx = group_gid(nmap.fetch(&endx).expect("group"));
+        let gid_endx = group_gid(nmap.fetch(&endx, 0).expect("group"));
         assert_ne!(gid_end, gid_endx);
     }
 
@@ -477,7 +480,7 @@ mod tests {
         // priority gate it would route through fetch_uni and pollute
         // the plain-unicast map.
         let mut nmap = NexthopMap::default();
-        nmap.fetch(&end_uni(1));
+        nmap.fetch(&end_uni(1), 0);
         assert_eq!(nmap.seg6local.len(), 1);
         assert!(nmap.map.is_empty());
         assert!(nmap.seg6.is_empty());

--- a/zebra-rs/src/rib/nexthop/show.rs
+++ b/zebra-rs/src/rib/nexthop/show.rs
@@ -72,7 +72,7 @@ mod tests {
     use std::net::IpAddr;
 
     fn mk_group(uni: NexthopUni) -> GroupUni {
-        GroupUni::new(0, &uni)
+        GroupUni::new(0, &uni, 0)
     }
 
     #[test]

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -351,7 +351,14 @@ impl Rib {
         // entries have been deselected, otherwise rib_resolve_v6
         // happily walks the still-present-but-now-invalid entries.
         // The debounced Resolve scheduled below handles that.
-        ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.links, &self.fib_handle).await;
+        ipv4_nexthop_sync(
+            &mut self.nmap,
+            &self.table,
+            &self.vrf_tables,
+            &self.links,
+            &self.fib_handle,
+        )
+        .await;
         ipv4_route_sync(
             &mut self.table,
             &mut self.nmap,
@@ -363,6 +370,7 @@ impl Rib {
         ipv6_nexthop_sync(
             &mut self.nmap,
             &self.table_v6,
+            &self.vrf_tables,
             &self.links,
             &self.fib_handle,
         )
@@ -504,7 +512,14 @@ impl Rib {
             self.addr_reinstall(ifindex, &link_name, &prefix).await;
         }
 
-        ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.links, &self.fib_handle).await;
+        ipv4_nexthop_sync(
+            &mut self.nmap,
+            &self.table,
+            &self.vrf_tables,
+            &self.links,
+            &self.fib_handle,
+        )
+        .await;
         ipv4_route_sync(
             &mut self.table,
             &mut self.nmap,
@@ -516,6 +531,7 @@ impl Rib {
         ipv6_nexthop_sync(
             &mut self.nmap,
             &self.table_v6,
+            &self.vrf_tables,
             &self.links,
             &self.fib_handle,
         )
@@ -534,46 +550,166 @@ impl Rib {
         self.schedule_rib_sync();
     }
 
-    /// Per-VRF dispatcher: route an `Ipv4Add` install into the
-    /// matching VRF prefix tree. Best-path resolution + FIB install
-    /// inside a VRF table are pending follow-ups; today the prefix
-    /// is recorded so the per-VRF show path and the future import
-    /// pipeline see it, but the kernel install is deliberately
-    /// skipped — the global nexthop map can't resolve per-VRF gw
-    /// addresses correctly without a per-VRF overlay.
-    pub fn ipv4_route_add_vrf(&mut self, table_id: u32, prefix: &Ipv4Net, entry: RibEntry) {
-        if !vrf_ipv4_insert(&mut self.vrf_tables, table_id, prefix, entry) {
-            tracing::warn!(
+    /// Per-VRF dispatcher: install an `Ipv4Add` into the VRF's routing
+    /// table with best-path selection and FIB install. Nexthops resolve
+    /// against the VRF's own table (a CE gateway is reachable via the
+    /// VRF's connected routes), and the selected protocol route is
+    /// programmed into the kernel VRF table (`table_id`). Connected
+    /// routes are already in the kernel (created on enslave), so
+    /// selection marks them installed without re-programming — see
+    /// `ipv4_entry_selection`'s non-protocol arm.
+    pub async fn ipv4_route_add_vrf(
+        &mut self,
+        table_id: u32,
+        prefix: &Ipv4Net,
+        mut entry: RibEntry,
+    ) {
+        let replace = {
+            let Some(t) = self.vrf_tables.get_mut(&table_id) else {
+                tracing::warn!(
+                    table_id,
+                    %prefix,
+                    "ipv4_route_add_vrf: vrf table not present; dropping install",
+                );
+                return;
+            };
+            if entry.is_protocol() {
+                let mut replace = rib_replace(&mut t.table, prefix, entry.rtype);
+                rib_resolve_nexthop(&mut entry, &t.table, &mut self.nmap, table_id);
+                rib_add(&mut t.table, prefix, entry);
+                replace.pop()
+            } else {
+                rib_add_system(&mut t.table, prefix, entry);
+                None
+            }
+        };
+        self.vrf_rib_selection(table_id, prefix, replace).await;
+    }
+
+    pub async fn ipv4_route_del_vrf(&mut self, table_id: u32, prefix: &Ipv4Net, entry: RibEntry) {
+        let replace = {
+            let Some(t) = self.vrf_tables.get_mut(&table_id) else {
+                return;
+            };
+            if entry.is_protocol() {
+                rib_replace(&mut t.table, prefix, entry.rtype).pop()
+            } else {
+                rib_replace_system(&mut t.table, prefix, entry).pop()
+            }
+        };
+        self.vrf_rib_selection(table_id, prefix, replace).await;
+    }
+
+    pub async fn ipv6_route_add_vrf(
+        &mut self,
+        table_id: u32,
+        prefix: &Ipv6Net,
+        mut entry: RibEntry,
+    ) {
+        let replace = {
+            let Some(t) = self.vrf_tables.get_mut(&table_id) else {
+                tracing::warn!(
+                    table_id,
+                    %prefix,
+                    "ipv6_route_add_vrf: vrf table not present; dropping install",
+                );
+                return;
+            };
+            if entry.is_protocol() {
+                let mut replace = rib_replace_v6(&mut t.table_v6, prefix, entry.rtype);
+                rib_resolve_nexthop_v6(&mut entry, &t.table_v6, &mut self.nmap, table_id);
+                rib_add_v6(&mut t.table_v6, prefix, entry);
+                replace.pop()
+            } else {
+                rib_add_system_v6(&mut t.table_v6, prefix, entry);
+                None
+            }
+        };
+        self.vrf_rib_selection_v6(table_id, prefix, replace).await;
+    }
+
+    pub async fn ipv6_route_del_vrf(&mut self, table_id: u32, prefix: &Ipv6Net, entry: RibEntry) {
+        let replace = {
+            let Some(t) = self.vrf_tables.get_mut(&table_id) else {
+                return;
+            };
+            if entry.is_protocol() {
+                rib_replace_v6(&mut t.table_v6, prefix, entry.rtype).pop()
+            } else {
+                rib_replace_system_v6(&mut t.table_v6, prefix, entry).pop()
+            }
+        };
+        self.vrf_rib_selection_v6(table_id, prefix, replace).await;
+    }
+
+    /// Best-path selection + FIB reconcile for one VRF prefix. Mirrors
+    /// [`Self::rib_selection`] but on `vrf_tables[table_id]`, passing
+    /// `table_id` so the install/withdraw targets the kernel VRF table.
+    async fn vrf_rib_selection(
+        &mut self,
+        table_id: u32,
+        prefix: &Ipv4Net,
+        replace: Option<RibEntry>,
+    ) {
+        let retry = {
+            let Some(t) = self.vrf_tables.get_mut(&table_id) else {
+                return;
+            };
+            // `rib_replace` leaves an empty `Vec` at a drained prefix
+            // (it doesn't remove the key), so the selector still runs
+            // and processes `replace`'s FIB withdraw.
+            let Some(entries) = t.table.get_mut(prefix) else {
+                return;
+            };
+            ipv4_entry_selection(
+                prefix,
+                entries,
+                replace,
+                &mut self.nmap,
+                &self.fib_handle,
                 table_id,
-                %prefix,
-                "ipv4_route_add_vrf: vrf table not present; dropping install",
-            );
+                false,
+            )
+            .await
+        };
+        if retry {
+            self.schedule_rib_sync();
         }
     }
 
-    pub fn ipv4_route_del_vrf(&mut self, table_id: u32, prefix: &Ipv4Net, entry: RibEntry) {
-        vrf_ipv4_remove(&mut self.vrf_tables, table_id, prefix, entry.rtype);
-    }
-
-    pub fn ipv6_route_add_vrf(&mut self, table_id: u32, prefix: &Ipv6Net, entry: RibEntry) {
-        if !vrf_ipv6_insert(&mut self.vrf_tables, table_id, prefix, entry) {
-            tracing::warn!(
+    async fn vrf_rib_selection_v6(
+        &mut self,
+        table_id: u32,
+        prefix: &Ipv6Net,
+        replace: Option<RibEntry>,
+    ) {
+        let retry = {
+            let Some(t) = self.vrf_tables.get_mut(&table_id) else {
+                return;
+            };
+            let Some(entries) = t.table_v6.get_mut(prefix) else {
+                return;
+            };
+            ipv6_entry_selection(
+                prefix,
+                entries,
+                replace,
+                &mut self.nmap,
+                &self.fib_handle,
                 table_id,
-                %prefix,
-                "ipv6_route_add_vrf: vrf table not present; dropping install",
-            );
+            )
+            .await
+        };
+        if retry {
+            self.schedule_rib_sync();
         }
-    }
-
-    pub fn ipv6_route_del_vrf(&mut self, table_id: u32, prefix: &Ipv6Net, entry: RibEntry) {
-        vrf_ipv6_remove(&mut self.vrf_tables, table_id, prefix, entry.rtype);
     }
 
     pub async fn ipv4_route_add(&mut self, prefix: &Ipv4Net, mut entry: RibEntry, table_id: u32) {
         let before = selected_v4(&self.table, prefix).cloned();
         if entry.is_protocol() {
             let mut replace = rib_replace(&mut self.table, prefix, entry.rtype);
-            rib_resolve_nexthop(&mut entry, &self.table, &mut self.nmap);
+            rib_resolve_nexthop(&mut entry, &self.table, &mut self.nmap, table_id);
             rib_add(&mut self.table, prefix, entry);
             self.rib_selection(prefix, replace.pop(), table_id).await;
         } else {
@@ -712,7 +848,7 @@ impl Rib {
         let before = selected_v6(&self.table_v6, prefix).cloned();
         if entry.is_protocol() {
             let mut replace = rib_replace_v6(&mut self.table_v6, prefix, entry.rtype);
-            rib_resolve_nexthop_v6(&mut entry, &self.table_v6, &mut self.nmap);
+            rib_resolve_nexthop_v6(&mut entry, &self.table_v6, &mut self.nmap, table_id);
             if DEBUG_V6 {
                 println!(
                     "[ipv6_route_add] after resolve: entry.valid={} nexthop={:?}",
@@ -767,27 +903,45 @@ impl Rib {
         ipv6_nexthop_sync(
             &mut self.nmap,
             &self.table_v6,
+            &self.vrf_tables,
             &self.links,
             &self.fib_handle,
         )
         .await;
-        let retry = ipv6_route_sync(
+        let mut retry = ipv6_route_sync(
             &mut self.table_v6,
             &mut self.nmap,
             &self.fib_handle,
             RT_TABLE_MAIN,
         )
         .await;
+        let table_ids: Vec<u32> = self.vrf_tables.keys().copied().collect();
+        for table_id in table_ids {
+            if let Some(t) = self.vrf_tables.get_mut(&table_id) {
+                retry |=
+                    ipv6_route_sync(&mut t.table_v6, &mut self.nmap, &self.fib_handle, table_id)
+                        .await;
+            }
+        }
         if retry {
             self.schedule_rib_sync();
         }
     }
 
     pub async fn ipv4_route_resolve(&mut self) {
-        ipv4_nexthop_sync(&mut self.nmap, &self.table, &self.links, &self.fib_handle).await;
+        // One nexthop sync handles every table: each group resolves
+        // against the table its `table_id` names (default or a VRF).
+        ipv4_nexthop_sync(
+            &mut self.nmap,
+            &self.table,
+            &self.vrf_tables,
+            &self.links,
+            &self.fib_handle,
+        )
+        .await;
         // `false` = not an ifdown sweep; this resolve cycle is for FIB-update
         // re-resolution, not link-down recovery.
-        let retry = ipv4_route_sync(
+        let mut retry = ipv4_route_sync(
             &mut self.table,
             &mut self.nmap,
             &self.fib_handle,
@@ -795,6 +949,22 @@ impl Rib {
             false,
         )
         .await;
+        // Re-sync each VRF table against its own kernel table id so a
+        // VRF route whose nexthop only just became resolvable gets
+        // installed.
+        let table_ids: Vec<u32> = self.vrf_tables.keys().copied().collect();
+        for table_id in table_ids {
+            if let Some(t) = self.vrf_tables.get_mut(&table_id) {
+                retry |= ipv4_route_sync(
+                    &mut t.table,
+                    &mut self.nmap,
+                    &self.fib_handle,
+                    table_id,
+                    false,
+                )
+                .await;
+            }
+        }
         // A failed install forced a nexthop recreation; arm another
         // pass so the recreated nexthop and the pending route both land.
         if retry {
@@ -881,6 +1051,7 @@ pub async fn rib_selection_ipv6(
 pub async fn ipv4_nexthop_sync(
     nmap: &mut NexthopMap,
     table: &PrefixMap<Ipv4Net, RibEntries>,
+    vrf_tables: &BTreeMap<u32, VrfRibTables>,
     links: &BTreeMap<u32, Link>,
     fib: &FibHandle,
 ) {
@@ -910,18 +1081,26 @@ pub async fn ipv4_nexthop_sync(
                 }
                 continue;
             }
-            let resolve = match uni.addr {
-                std::net::IpAddr::V4(ipv4_addr) => {
-                    rib_resolve(table, ipv4_addr, &ResolveOpt::default())
-                }
+            let ipv4_addr = match uni.addr {
+                std::net::IpAddr::V4(a) => a,
                 std::net::IpAddr::V6(_) => {
                     // IPv6 addresses should be handled by ipv6_nexthop_sync
                     continue;
                 }
             };
-
-            // Update the status of the next hop
-            let ifindex = resolve.is_valid();
+            // Resolve each gateway against the table its VRF names —
+            // a VRF nexthop's gateway lives in the VRF's connected
+            // routes, not the default table. A missing VRF table
+            // (torn down) leaves the nexthop unresolved.
+            let resolve_table = if uni.table_id == RT_TABLE_MAIN {
+                Some(table)
+            } else {
+                vrf_tables.get(&uni.table_id).map(|t| &t.table)
+            };
+            let ifindex = match resolve_table {
+                Some(rt) => rib_resolve(rt, ipv4_addr, &ResolveOpt::default()).is_valid(),
+                None => 0,
+            };
             if ifindex == 0 {
                 uni.ifindex_resolved = None;
                 uni.set_valid(false);
@@ -1192,8 +1371,9 @@ fn resolve_nexthop_uni(
     uni: &mut NexthopUni,
     nmap: &mut NexthopMap,
     table: &PrefixMap<Ipv4Net, RibEntries>,
+    table_id: u32,
 ) -> bool {
-    let Some(Group::Uni(group)) = nmap.fetch(uni) else {
+    let Some(Group::Uni(group)) = nmap.fetch(uni, table_id) else {
         return false;
     };
     if group.refcnt() == 0 {
@@ -1241,18 +1421,19 @@ fn rib_resolve_nexthop(
     entry: &mut RibEntry,
     table: &PrefixMap<Ipv4Net, RibEntries>,
     nmap: &mut NexthopMap,
+    table_id: u32,
 ) {
     // Only protocol entry.
     if !entry.is_protocol() {
         return;
     }
     if let Nexthop::Uni(uni) = &mut entry.nexthop {
-        let _ = resolve_nexthop_uni(uni, nmap, table);
+        let _ = resolve_nexthop_uni(uni, nmap, table, table_id);
     }
     if let Nexthop::Multi(multi) = &mut entry.nexthop {
         let mut set = BTreeSet::<(usize, u8)>::new();
         for uni in multi.nexthops.iter_mut() {
-            let valid = resolve_nexthop_uni(uni, nmap, table);
+            let valid = resolve_nexthop_uni(uni, nmap, table, table_id);
             if valid {
                 set.insert((uni.gid, uni.weight));
             }
@@ -1269,12 +1450,12 @@ fn rib_resolve_nexthop(
         for member in pro.nexthops.iter_mut() {
             match member {
                 NexthopMember::Uni(uni) => {
-                    let _ = resolve_nexthop_uni(uni, nmap, table);
+                    let _ = resolve_nexthop_uni(uni, nmap, table, table_id);
                 }
                 NexthopMember::Multi(multi) => {
                     let mut set = BTreeSet::<(usize, u8)>::new();
                     for uni in multi.nexthops.iter_mut() {
-                        let valid = resolve_nexthop_uni(uni, nmap, table);
+                        let valid = resolve_nexthop_uni(uni, nmap, table, table_id);
                         if valid {
                             set.insert((uni.gid, uni.weight));
                         }
@@ -1715,18 +1896,19 @@ fn rib_resolve_nexthop_v6(
     entry: &mut RibEntry,
     table: &PrefixMap<Ipv6Net, RibEntries>,
     nmap: &mut NexthopMap,
+    table_id: u32,
 ) {
     // Only protocol entry.
     if !entry.is_protocol() {
         return;
     }
     if let Nexthop::Uni(uni) = &mut entry.nexthop {
-        let _ = resolve_nexthop_uni_v6(uni, nmap, table);
+        let _ = resolve_nexthop_uni_v6(uni, nmap, table, table_id);
     }
     if let Nexthop::Multi(multi) = &mut entry.nexthop {
         let mut set = BTreeSet::<(usize, u8)>::new();
         for uni in multi.nexthops.iter_mut() {
-            let valid = resolve_nexthop_uni_v6(uni, nmap, table);
+            let valid = resolve_nexthop_uni_v6(uni, nmap, table, table_id);
             if valid {
                 set.insert((uni.gid, uni.weight));
             }
@@ -1741,12 +1923,12 @@ fn rib_resolve_nexthop_v6(
         for member in pro.nexthops.iter_mut() {
             match member {
                 NexthopMember::Uni(uni) => {
-                    let _ = resolve_nexthop_uni_v6(uni, nmap, table);
+                    let _ = resolve_nexthop_uni_v6(uni, nmap, table, table_id);
                 }
                 NexthopMember::Multi(multi) => {
                     let mut set = BTreeSet::<(usize, u8)>::new();
                     for uni in multi.nexthops.iter_mut() {
-                        let valid = resolve_nexthop_uni_v6(uni, nmap, table);
+                        let valid = resolve_nexthop_uni_v6(uni, nmap, table, table_id);
                         if valid {
                             set.insert((uni.gid, uni.weight));
                         }
@@ -1764,6 +1946,7 @@ fn resolve_nexthop_uni_v6(
     uni: &mut NexthopUni,
     nmap: &mut NexthopMap,
     table: &PrefixMap<Ipv6Net, RibEntries>,
+    table_id: u32,
 ) -> bool {
     if DEBUG_V6 {
         println!(
@@ -1771,7 +1954,7 @@ fn resolve_nexthop_uni_v6(
             uni.addr, uni.gid
         );
     }
-    let Some(Group::Uni(group)) = nmap.fetch(uni) else {
+    let Some(Group::Uni(group)) = nmap.fetch(uni, table_id) else {
         if DEBUG_V6 {
             println!("[resolve_nexthop_uni_v6] nmap.fetch returned None");
         }
@@ -1820,6 +2003,7 @@ fn resolve_nexthop_uni_v6(
 pub async fn ipv6_nexthop_sync(
     nmap: &mut NexthopMap,
     table: &PrefixMap<Ipv6Net, RibEntries>,
+    vrf_tables: &BTreeMap<u32, VrfRibTables>,
     links: &BTreeMap<u32, Link>,
     fib: &FibHandle,
 ) {
@@ -1859,14 +2043,20 @@ pub async fn ipv6_nexthop_sync(
                 }
                 continue;
             }
-            let resolve = match uni.addr {
+            let ipv6_addr = match uni.addr {
                 std::net::IpAddr::V4(_) => continue,
-                std::net::IpAddr::V6(ipv6_addr) => {
-                    rib_resolve_v6(table, ipv6_addr, &ResolveOpt::default())
-                }
+                std::net::IpAddr::V6(a) => a,
             };
-
-            let ifindex = resolve.is_valid();
+            // Resolve against the table the nexthop's VRF names.
+            let resolve_table = if uni.table_id == RT_TABLE_MAIN {
+                Some(table)
+            } else {
+                vrf_tables.get(&uni.table_id).map(|t| &t.table_v6)
+            };
+            let ifindex = match resolve_table {
+                Some(rt) => rib_resolve_v6(rt, ipv6_addr, &ResolveOpt::default()).is_valid(),
+                None => 0,
+            };
             if DEBUG_V6 {
                 println!(
                     "[ipv6_nexthop_sync] resolved ifindex={} (0 means unresolved)",
@@ -1894,100 +2084,7 @@ pub async fn ipv6_nexthop_sync(
     }
 }
 
-// ---- Per-VRF table dispatch helpers ---------------------------------
-//
-// Prefer free functions over methods on `Rib` so they can be
-// unit-tested against a plain `BTreeMap<u32, VrfRibTables>` without
-// having to construct a full `Rib` (which needs a live netlink
-// socket via `FibHandle::new`). Return `bool` so the wrappers on
-// `Rib` can log a `warn!` if the caller's VRF table id is not yet
-// in the map (a kernel `VrfAdd` parks an empty `VrfRibTables` for
-// every allocated VRF, so this should only fire for a torn-down or
-// never-created VRF).
-
 use super::vrf::VrfRibTables;
-
-pub(super) fn vrf_ipv4_insert(
-    vrf_tables: &mut BTreeMap<u32, VrfRibTables>,
-    table_id: u32,
-    prefix: &Ipv4Net,
-    entry: RibEntry,
-) -> bool {
-    let Some(t) = vrf_tables.get_mut(&table_id) else {
-        return false;
-    };
-    let entries = t.table.entry(*prefix).or_default();
-    vrf_entries_replace(entries, entry);
-    true
-}
-
-/// Insert `entry`, first dropping any prior entry it should supersede,
-/// so a prefix fed from two sources (the daemon's connected-route
-/// synthesis and the kernel's RTM_NEWROUTE echo) — and re-notified on
-/// flaps — doesn't accumulate duplicates. Mirrors `rib_add_system`:
-/// same protocol replaces, except connected routes are keyed by
-/// interface so a multi-homed prefix keeps one entry per interface.
-fn vrf_entries_replace(entries: &mut RibEntries, entry: RibEntry) {
-    entries.retain(|e| {
-        if e.rtype != entry.rtype {
-            return true;
-        }
-        entry.is_connected() && e.ifindex != entry.ifindex
-    });
-    entries.push(entry);
-}
-
-pub(super) fn vrf_ipv4_remove(
-    vrf_tables: &mut BTreeMap<u32, VrfRibTables>,
-    table_id: u32,
-    prefix: &Ipv4Net,
-    rtype: RibType,
-) {
-    let Some(t) = vrf_tables.get_mut(&table_id) else {
-        return;
-    };
-    if let Some(entries) = t.table.get_mut(prefix) {
-        if let Some(pos) = entries.iter().position(|e| e.rtype == rtype) {
-            entries.remove(pos);
-        }
-        if entries.is_empty() {
-            t.table.remove(prefix);
-        }
-    }
-}
-
-pub(super) fn vrf_ipv6_insert(
-    vrf_tables: &mut BTreeMap<u32, VrfRibTables>,
-    table_id: u32,
-    prefix: &Ipv6Net,
-    entry: RibEntry,
-) -> bool {
-    let Some(t) = vrf_tables.get_mut(&table_id) else {
-        return false;
-    };
-    let entries = t.table_v6.entry(*prefix).or_default();
-    vrf_entries_replace(entries, entry);
-    true
-}
-
-pub(super) fn vrf_ipv6_remove(
-    vrf_tables: &mut BTreeMap<u32, VrfRibTables>,
-    table_id: u32,
-    prefix: &Ipv6Net,
-    rtype: RibType,
-) {
-    let Some(t) = vrf_tables.get_mut(&table_id) else {
-        return;
-    };
-    if let Some(entries) = t.table_v6.get_mut(prefix) {
-        if let Some(pos) = entries.iter().position(|e| e.rtype == rtype) {
-            entries.remove(pos);
-        }
-        if entries.is_empty() {
-            t.table_v6.remove(prefix);
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {
@@ -2189,7 +2286,7 @@ mod tests {
 
         let mut nmap = NexthopMap::default();
         let table: PrefixMap<Ipv4Net, RibEntries> = PrefixMap::new();
-        rib_resolve_nexthop(&mut entry, &table, &mut nmap);
+        rib_resolve_nexthop(&mut entry, &table, &mut nmap, 0);
 
         let Nexthop::List(pro) = &entry.nexthop else {
             panic!("entry.nexthop should still be List");
@@ -2209,129 +2306,5 @@ mod tests {
         for leg in &multi_member.nexthops {
             assert!(leg.gid != 0, "each leg also gets a gid");
         }
-    }
-
-    /// Inbound-dispatch invariant: an install destined for a
-    /// non-default VRF lands in `vrf_tables[table_id].table`, not
-    /// in the global table. Tested at the free-function level so we
-    /// don't need to construct a `Rib` (the kernel-bound `FibHandle`
-    /// makes that impractical for unit tests).
-    #[test]
-    fn vrf_ipv4_insert_lands_in_matching_table() {
-        use super::super::entry::RibEntry;
-        use super::super::vrf::VrfRibTables;
-        use super::super::{RibEntries, RibType};
-        use super::vrf_ipv4_insert;
-        use ipnet::Ipv4Net;
-        use std::collections::BTreeMap;
-
-        let mut vrf_tables: BTreeMap<u32, VrfRibTables> = BTreeMap::new();
-        vrf_tables.insert(10, VrfRibTables::new());
-
-        let prefix: Ipv4Net = "10.0.0.0/24".parse().unwrap();
-        let entry = RibEntry::new(RibType::Bgp);
-        assert!(vrf_ipv4_insert(&mut vrf_tables, 10, &prefix, entry));
-
-        // Lands in table 10 only.
-        let t10: &RibEntries = vrf_tables
-            .get(&10)
-            .and_then(|t| t.table.get(&prefix))
-            .expect("prefix in vrf table 10");
-        assert_eq!(t10.len(), 1);
-        assert_eq!(t10[0].rtype, RibType::Bgp);
-    }
-
-    #[test]
-    fn vrf_ipv4_insert_into_missing_table_is_noop() {
-        use super::super::RibType;
-        use super::super::entry::RibEntry;
-        use super::super::vrf::VrfRibTables;
-        use super::vrf_ipv4_insert;
-        use ipnet::Ipv4Net;
-        use std::collections::BTreeMap;
-
-        // No VRF row for `table_id = 99` — caller has to tolerate
-        // it (the warn-log path in `Rib::ipv4_route_add_vrf` covers
-        // the operator-visible side).
-        let mut vrf_tables: BTreeMap<u32, VrfRibTables> = BTreeMap::new();
-        let prefix: Ipv4Net = "10.0.0.0/24".parse().unwrap();
-        let inserted = vrf_ipv4_insert(&mut vrf_tables, 99, &prefix, RibEntry::new(RibType::Bgp));
-        assert!(!inserted);
-        assert!(vrf_tables.is_empty());
-    }
-
-    #[test]
-    fn vrf_ipv4_remove_drops_prefix_when_last_entry_goes() {
-        use super::super::RibType;
-        use super::super::entry::RibEntry;
-        use super::super::vrf::VrfRibTables;
-        use super::{vrf_ipv4_insert, vrf_ipv4_remove};
-        use ipnet::Ipv4Net;
-        use std::collections::BTreeMap;
-
-        let mut vrf_tables: BTreeMap<u32, VrfRibTables> = BTreeMap::new();
-        vrf_tables.insert(10, VrfRibTables::new());
-
-        let prefix: Ipv4Net = "10.0.0.0/24".parse().unwrap();
-        vrf_ipv4_insert(&mut vrf_tables, 10, &prefix, RibEntry::new(RibType::Bgp));
-        vrf_ipv4_remove(&mut vrf_tables, 10, &prefix, RibType::Bgp);
-        assert!(vrf_tables.get(&10).unwrap().table.get(&prefix).is_none());
-    }
-
-    #[test]
-    fn vrf_ipv4_insert_dedups_per_protocol_and_interface() {
-        use super::super::RibType;
-        use super::super::entry::RibEntry;
-        use super::super::vrf::VrfRibTables;
-        use super::vrf_ipv4_insert;
-        use ipnet::Ipv4Net;
-        use std::collections::BTreeMap;
-
-        let mut vrf_tables: BTreeMap<u32, VrfRibTables> = BTreeMap::new();
-        vrf_tables.insert(10, VrfRibTables::new());
-        let prefix: Ipv4Net = "10.0.0.0/24".parse().unwrap();
-        let connected = |ifindex: u32| {
-            let mut e = RibEntry::new(RibType::Connected);
-            e.ifindex = ifindex;
-            e
-        };
-
-        // Two sources feed the same connected route (same interface):
-        // the second replaces the first rather than duplicating.
-        vrf_ipv4_insert(&mut vrf_tables, 10, &prefix, connected(5));
-        vrf_ipv4_insert(&mut vrf_tables, 10, &prefix, connected(5));
-        let entries = vrf_tables.get(&10).unwrap().table.get(&prefix).unwrap();
-        assert_eq!(entries.len(), 1, "same connected route dedups");
-
-        // A connected route on a different interface coexists.
-        vrf_ipv4_insert(&mut vrf_tables, 10, &prefix, connected(6));
-        // A different protocol coexists with connected.
-        vrf_ipv4_insert(&mut vrf_tables, 10, &prefix, RibEntry::new(RibType::Bgp));
-        let entries = vrf_tables.get(&10).unwrap().table.get(&prefix).unwrap();
-        assert_eq!(entries.len(), 3, "different ifindex / rtype kept");
-    }
-
-    #[test]
-    fn vrf_ipv6_insert_and_remove_round_trip() {
-        use super::super::RibType;
-        use super::super::entry::RibEntry;
-        use super::super::vrf::VrfRibTables;
-        use super::{vrf_ipv6_insert, vrf_ipv6_remove};
-        use ipnet::Ipv6Net;
-        use std::collections::BTreeMap;
-
-        let mut vrf_tables: BTreeMap<u32, VrfRibTables> = BTreeMap::new();
-        vrf_tables.insert(10, VrfRibTables::new());
-
-        let prefix: Ipv6Net = "2001:db8::/64".parse().unwrap();
-        assert!(vrf_ipv6_insert(
-            &mut vrf_tables,
-            10,
-            &prefix,
-            RibEntry::new(RibType::Bgp),
-        ));
-        assert!(vrf_tables.get(&10).unwrap().table_v6.get(&prefix).is_some());
-        vrf_ipv6_remove(&mut vrf_tables, 10, &prefix, RibType::Bgp);
-        assert!(vrf_tables.get(&10).unwrap().table_v6.get(&prefix).is_none());
     }
 }


### PR DESCRIPTION
## Summary

VRF routes were only *recorded* for the show path. They now go through the same best-path selection + kernel FIB install as the default table, scoped to the VRF's kernel routing table.

The blocker was nexthop resolution: a VRF gateway must resolve against the VRF's own connected routes (not the global table), while kernel nexthop ids must stay a single global space.

- **`NexthopMap` made VRF-aware (A′):** keeps one global gid/NHID space, but keys dedup on `(table_id, addr)` so the same gateway in two VRFs is a distinct nexthop, and tags each `GroupUni` with its `table_id`. The periodic `ipv4_nexthop_sync` / `ipv6_nexthop_sync` take `vrf_tables` and resolve each group against the table its id names.
- **VRF install path:** `ipv4_route_add_vrf` / `_del_vrf` (and v6) mirror the default path on `vrf_tables[table_id]` — resolve nexthops against the VRF table, run best-path selection, install/withdraw the selected protocol route into the kernel VRF table via `table_id`. Connected routes are marked installed without re-programming (the kernel created them on enslave).
- **Resolve cycle** re-syncs every VRF table so a route whose nexthop only just became reachable lands on the next pass.
- Removed the record-only `vrf_ipv4_insert`/`_remove` helpers (and their 5 tests); dedup now comes from the shared `rib_replace` / `rib_add_system`.

The default-table path is unchanged in behavior (it passes `RT_TABLE_MAIN` everywhere it used to).

## Test plan

- [x] `cargo build -p zebra-rs`
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] `cargo fmt --all`
- [x] `cargo test -p zebra-rs --bin zebra-rs` (667 passed, 0 failed)
- [ ] Live (not covered by CI): a BGP route under `vrf1` shows `*>` in `show ip bgp vrf vrf1` and appears in `ip route show table 1` with the right `via … dev …`

## Notes

- IPv4 + IPv6 both covered.
- VRF-scoped redistribution to protocol clients and the startup-dump-before-VRF gap remain deferred (separate work).

Generated with [Claude Code](https://claude.com/claude-code)