### PR TITLE
rib: delete daemon-created VRF master devices on shutdown

### DIFF
--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -1451,7 +1451,7 @@ impl Rib {
                 // than trying to create a duplicate, which the kernel
                 // rejects with EEXIST and which would leave the VRF
                 // unusable and any pending interface binding stuck.
-                let (ifindex, table_id) = if let Some((ifindex, existing_table)) =
+                let (ifindex, table_id, owned) = if let Some((ifindex, existing_table)) =
                     self.fib_handle.vrf_index_table_by_name(&name).await
                 {
                     self.vrf_id_alloc.reserve(existing_table);
@@ -1461,7 +1461,8 @@ impl Rib {
                         ifindex,
                         existing_table
                     );
-                    (ifindex, existing_table)
+                    // Adopted, not created — leave it in place on exit.
+                    (ifindex, existing_table, false)
                 } else {
                     let Some(table_id) = self.vrf_id_alloc.allocate() else {
                         tracing::warn!("vrf_add({}) failed — id space exhausted", name);
@@ -1473,7 +1474,7 @@ impl Rib {
                         self.vrf_id_alloc.release(table_id);
                         return;
                     };
-                    (ifindex, table_id)
+                    (ifindex, table_id, true)
                 };
                 self.vrfs.insert(
                     name.clone(),
@@ -1481,6 +1482,7 @@ impl Rib {
                         name: name.clone(),
                         table_id,
                         ifindex,
+                        owned,
                         // RT sets arrive separately via
                         // `Message::VrfRouteTargets` once the VRF
                         // config builder has finished parsing
@@ -1740,6 +1742,19 @@ impl Rib {
                 }
                 for (_, vxlan) in self.vxlan.iter() {
                     self.fib_handle.vxlan_del(vxlan).await;
+                }
+                // Tear down the VRF master devices this process created
+                // (adopted ones are left for their owner). Enslaved
+                // interfaces are released back to the default VRF by the
+                // kernel automatically when the master goes.
+                let owned_vrfs: Vec<String> = self
+                    .vrfs
+                    .values()
+                    .filter(|v| v.owned)
+                    .map(|v| v.name.clone())
+                    .collect();
+                for name in owned_vrfs {
+                    self.fib_handle.vrf_del(&name).await;
                 }
                 self.cleanup_sr0_dummy().await;
                 let _ = tx.send(());

--- a/zebra-rs/src/rib/vrf/inst.rs
+++ b/zebra-rs/src/rib/vrf/inst.rs
@@ -20,6 +20,11 @@ pub struct Vrf {
     pub name: String,
     pub table_id: u32,
     pub ifindex: u32,
+    /// `true` when this process created the kernel VRF master device,
+    /// `false` when it adopted a pre-existing one (operator-created, or
+    /// a leftover from a prior run). The shutdown path only deletes the
+    /// devices it created — same ownership rule as the sr0 dummy.
+    pub owned: bool,
     pub ipv4_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
     pub ipv4_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
     pub ipv6_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,


### PR DESCRIPTION
## Summary

The graceful shutdown path (`Message::Shutdown`, sent on ctrl_c) tore down ILM / MAC / VTEP / bridge / VXLAN / sr0 state but left VRF master devices in the kernel. This deletes the ones the daemon created, so a clean exit is symmetric with startup.

- **`Vrf` gains an `owned` flag** — `true` when `vrf_add` created the kernel device, `false` when an existing one was adopted (operator-created, or a prior-run leftover via the EEXIST adoption path).
- **`VrfAdd`** sets it (`true` in the create branch, `false` in adopt).
- **Shutdown handler** deletes only `owned` VRF masters via `fib_handle.vrf_del`, mirroring the `sr0_owned` ownership rule. The kernel auto-releases enslaved interfaces back to the default VRF when the master goes.

A `SIGKILL` (or any exit that skips the handler) still leaves the device — which the adopt-on-restart logic already absorbs.

## Test plan

- [x] `cargo build -p zebra-rs`
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] `cargo fmt --all`
- [x] `cargo test -p zebra-rs --bin zebra-rs rib::` (141 passed)
- [ ] Live (not covered by CI): `make run`, configure `vrf vrf1`, confirm `ip link` shows it; ctrl_c; confirm `ip link` no longer shows `vrf1`. An *adopted* `vrf1` (pre-created with `ip link add … type vrf`) should survive the exit.

Generated with [Claude Code](https://claude.com/claude-code)