### PR TITLE
rib: add rib:vrf dynamic completion for VRF names

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -645,6 +645,11 @@ impl ConfigManager {
         let Some(proto) = dynamics.first() else {
             return Vec::new();
         };
+        // The second half names which completion the protocol should
+        // answer (`interface`, `vrf`, `neighbor`, …). Carry it as a
+        // single synthetic path segment so the handler can dispatch —
+        // `ConfigOp::Completion` otherwise has no payload.
+        let handler = dynamics[1];
         // Clone the channel out of the RefCell borrow so the Ref is dropped
         // before we await — otherwise clippy::await_holding_refcell_ref flags
         // a potential deadlock if the borrowed value is touched elsewhere.
@@ -652,7 +657,10 @@ impl ConfigManager {
         if let Some(tx) = tx {
             let (comp_tx, comp_rx) = oneshot::channel();
             let req = ConfigRequest {
-                paths: Vec::new(),
+                paths: vec![CommandPath {
+                    name: handler.to_string(),
+                    ..Default::default()
+                }],
                 op: ConfigOp::Completion,
                 resp: Some(comp_tx),
             };

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -2063,7 +2063,13 @@ impl Rib {
                 self.locator_config.commit(self.tx.clone());
             }
             ConfigOp::Completion => {
-                msg.resp.unwrap().send(self.link_comps()).unwrap();
+                // `comps_dynamic` passes the dynamic handler name
+                // (`rib:<handler>`) as the first path segment.
+                let comps = match msg.paths.first().map(|p| p.name.as_str()) {
+                    Some("vrf") => self.vrf_comps(),
+                    _ => self.link_comps(),
+                };
+                msg.resp.unwrap().send(comps).unwrap();
             }
             ConfigOp::Clear => {
                 //

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -646,6 +646,12 @@ impl Rib {
         self.links.values().map(|link| link.name.clone()).collect()
     }
 
+    /// Completion candidates for the `rib:vrf` dynamic key — the names
+    /// of the VRFs currently applied (one per kernel master device).
+    pub fn vrf_comps(&self) -> Vec<String> {
+        self.vrfs.keys().cloned().collect()
+    }
+
     /// Add an IPv4 or IPv6 address to an interface link.
     ///
     /// This function validates the address before adding it to prevent invalid configurations:

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1915,6 +1915,7 @@ module config {
         // of in the default table (which would otherwise have to be
         // moved on bind).
         ext:sort "10";
+        ext:dynamic "rib:vrf";
         type leafref {
           path "/vrf/name";
         }

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -178,6 +178,7 @@ module exec {
           key name;
           leaf name {
             ext:help "VRF name";
+            ext:dynamic "rib:vrf";
             type string;
           }
           leaf detail {
@@ -251,7 +252,7 @@ module exec {
           ext:presence "BGP per-VRF summary table";
           key name;
           leaf name {
-            ext:dynamic "bgp:vrf";
+            ext:dynamic "rib:vrf";
             type string;
           }
           leaf summary {
@@ -468,6 +469,7 @@ module exec {
           key name;
           leaf name {
             ext:help "VRF name";
+            ext:dynamic "rib:vrf";
             type string;
           }
           leaf detail {


### PR DESCRIPTION
## Summary

`show ip route vrf <TAB>` / `interface … vrf <TAB>` couldn't complete VRF names: `comps_dynamic` used only the protocol half of a `proto:handler` dynamic key and dropped the handler, so every `rib:` key resolved to `link_comps()` (interface names). This wires VRF-name completion the same way interface completion works.

- **`comps_dynamic`** (`manager.rs`) forwards the handler name (`interface`/`vrf`/…) as a synthetic first path segment in the `Completion` request (it was previously empty).
- **RIB `Completion` handler** (`inst.rs`) dispatches on it: `vrf` → `vrf_comps()`, everything else → `link_comps()` — `rib:interface` behaviour is unchanged.
- **`Rib::vrf_comps()`** (`link.rs`) returns the applied VRF names (`self.vrfs.keys()`), mirroring `link_comps()`.
- **YANG**: `ext:dynamic "rib:vrf"` on the VRF-name leaves — `interface … vrf`, `show ip route vrf`, `show ipv6 route vrf`, and `show ip bgp vrf` (switched from `bgp:vrf`, which had wrongly completed to peer addresses).

BGP's completion handler is untouched (no regression; `bgp:vrf` is simply no longer referenced).

## Test plan

- [x] `cargo build -p zebra-rs`
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] `cargo fmt --all`
- [x] `cargo test -p zebra-rs --bin zebra-rs rib::` (141 passed)
- [ ] Live (not covered by CI): configure `vrf vrf1`, then `interface enp0s8 vrf <TAB>` and `show ip route vrf <TAB>` list `vrf1`

Generated with [Claude Code](https://claude.com/claude-code)