### PR TITLE
config: add show task command (protocol + VRF)

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -775,6 +775,24 @@ impl ConfigManager {
                 let _ = req.resp.send(resp);
             }
             Message::DisplayTx(req) => {
+                // `show task` is answered by the manager itself — it owns
+                // the task registries (`protocol_tasks` plus the per-VRF
+                // show channels), which no single daemon can see.
+                if req.paths.iter().any(|p| p.name == "task") {
+                    let output = self.show_task();
+                    let (task_tx, task_rx) = mpsc::unbounded_channel();
+                    let _ = req.resp.send(DisplayTxResponse {
+                        tx: task_tx,
+                        paths: None,
+                    });
+                    tokio::spawn(async move {
+                        let mut task_rx = task_rx;
+                        if let Some(display_req) = task_rx.recv().await {
+                            let _ = display_req.resp.send(output).await;
+                        }
+                    });
+                    return;
+                }
                 // Generic per-VRF instance redirect: `show <proto> vrf
                 // <name> …` is rewritten to `show <proto> …` and routed
                 // to the instance task's show channel when that instance
@@ -856,6 +874,31 @@ impl ConfigManager {
                 self.show_vrf_clients.borrow_mut().remove(&key);
             }
         }
+    }
+
+    /// Render `show task`: every spawned task with its protocol and VRF.
+    /// Default-VRF tasks come from `protocol_tasks` (keyed by protocol);
+    /// per-VRF tasks come from the `"<proto>:vrf:<name>"` keys that
+    /// VRF-spawning daemons register via `SubscribeShowVrf`.
+    fn show_task(&self) -> String {
+        let mut rows: Vec<(String, String)> = self
+            .protocol_tasks
+            .borrow()
+            .keys()
+            .map(|proto| (proto.clone(), "default".to_string()))
+            .collect();
+        for key in self.show_vrf_clients.borrow().keys() {
+            let parts: Vec<&str> = key.splitn(3, ':').collect();
+            if parts.len() == 3 && parts[1] == "vrf" {
+                rows.push((parts[0].to_string(), parts[2].to_string()));
+            }
+        }
+        rows.sort();
+        let mut buf = format!("{:<12}  {}\n", "Protocol", "VRF");
+        for (proto, vrf) in rows {
+            buf.push_str(&format!("{proto:<12}  {vrf}\n"));
+        }
+        buf
     }
 
     /// Apply a `vty service-account uid N` change to the in-memory

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -91,6 +91,10 @@ module exec {
       ext:help "Show VRF table";
       type empty;
     }
+    leaf task {
+      ext:help "Show spawned protocol tasks and their VRF";
+      type empty;
+    }
     container l2 {
       ext:help "Show L2 / data-link information";
       presence "Show L2";


### PR DESCRIPTION
## Summary

Adds a `show task` CLI command listing every spawned task with its protocol and VRF.

The config manager owns both task registries — `protocol_tasks` (the default-VRF daemons) and the `"<proto>:vrf:<name>"` show channels that VRF-spawning daemons register via `SubscribeShowVrf` — so it answers `show task` directly rather than routing to a daemon that can only see part of the picture.

- **`exec.yang`**: a `task` leaf under the `show` container.
- **`manager.rs`**: the `DisplayTx` handler intercepts a path containing `task` and replies via a spawned responder (same pattern as the not-configured fallback), before the normal protocol routing.
- **`ConfigManager::show_task()`**: rows from `protocol_tasks` keys → `(proto, "default")` and from `show_vrf_clients` keys → `(proto, vrf)`, sorted, rendered as a `Protocol / VRF` table.

Scope note: lists the dynamically-spawned protocol daemons (bgp/ospf/ospfv3/isis/bfd/nd) plus per-VRF BGP tasks. The always-on infra tasks spawned in `main.rs` (rib, policy, config server) aren't in `protocol_tasks` and don't appear.

## Test plan

- [x] `cargo build -p zebra-rs`
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] `cargo fmt --all`
- [x] `cargo test -p zebra-rs --bin zebra-rs config::` (115 passed)
- [ ] Live (not covered by CI): `make run`, configure bgp + `vrf vrf1` under bgp, run `show task`, confirm `bgp/default`, `bgp/vrf1`, etc.

Generated with [Claude Code](https://claude.com/claude-code)