### PR TITLE
bgp: VRF local route leak + VPNv4 MP_REACH next-hop

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -160,6 +160,24 @@ pub(crate) fn matching_import_vrfs(
         .collect()
 }
 
+/// Compute the fan-out target VRFs for a VPNv4 route: every VRF
+/// [`matching_import_vrfs`] returns, minus `skip_vrf`. The skip
+/// excludes the VRF a locally-exported route originated from, so a
+/// VRF whose import-RT set overlaps its own export-RTs (e.g.
+/// `rt both 1:1`) doesn't re-import the route it just exported.
+/// `None` on the remote-VPNv4 ingress path (no originating local
+/// VRF).
+pub(crate) fn import_targets(
+    vrf_index: &BTreeMap<String, RibKnownVrf>,
+    ecom: &Option<bgp_packet::ExtCommunity>,
+    skip_vrf: Option<&str>,
+) -> Vec<String> {
+    matching_import_vrfs(vrf_index, ecom)
+        .into_iter()
+        .filter(|name| Some(name.as_str()) != skip_vrf)
+        .collect()
+}
+
 /// Kernel VRF master info as observed by `Bgp` via
 /// `RibRx::VrfAdd` and the matching RT sets observed via
 /// `RibRx::VrfRouteTargets`. Used by
@@ -1495,6 +1513,29 @@ impl Bgp {
                 let (_, selected, _gen) = self.local_rib.update(Some(rd), prefix, rib);
                 let selected_len = selected.len();
 
+                // Local intra-router leak. The remote-VPNv4 ingress
+                // path (`route_ipv4_update`) fans an accepted VPNv4
+                // winner out to every importing VRF; the direct
+                // `local_rib.update` above bypasses that hook, so a
+                // route exported by one local VRF would never reach a
+                // sibling VRF on the same box. Replicate the fan-out
+                // here, skipping the originating VRF so a `rt both`
+                // config doesn't re-import what it just exported.
+                if let Some(winner) = selected.first() {
+                    let dispatcher = super::vrf::VrfImportDispatcher {
+                        rib_known_vrfs: &self.rib_known_vrfs,
+                        vrf_registry: &self.vrf_registry,
+                    };
+                    super::vrf::dispatch_import_v4(
+                        &dispatcher,
+                        rd,
+                        prefix,
+                        &winner.attr,
+                        0,
+                        Some(vrf.as_str()),
+                    );
+                }
+
                 // Fan out the new VPNv4 winner to PE peers via the
                 // existing `route_advertise_to_peers` helper. The
                 // helper iterates Established peers matching
@@ -1556,6 +1597,38 @@ impl Bgp {
                 // empty `selected` triggers the Withdraw branch
                 // there (`peer.adj_out` cleanup, MP_UNREACH emit).
                 let selected = self.local_rib.select_best_path_vpn(&rd, prefix);
+
+                // Local intra-router leak, symmetric with the Export
+                // handler. If a replacement candidate survives at
+                // (rd, prefix), re-import it into sibling VRFs with
+                // the new attr; otherwise flood a withdraw using the
+                // removed row's attr to resolve the matching-VRF set.
+                // Skip the originating VRF (self-import guard).
+                {
+                    let dispatcher = super::vrf::VrfImportDispatcher {
+                        rib_known_vrfs: &self.rib_known_vrfs,
+                        vrf_registry: &self.vrf_registry,
+                    };
+                    if let Some(winner) = selected.first() {
+                        super::vrf::dispatch_import_v4(
+                            &dispatcher,
+                            rd,
+                            prefix,
+                            &winner.attr,
+                            0,
+                            Some(vrf.as_str()),
+                        );
+                    } else if let Some(gone) = removed.first() {
+                        super::vrf::dispatch_withdraw_import_v4(
+                            &dispatcher,
+                            rd,
+                            prefix,
+                            &gone.attr,
+                            Some(vrf.as_str()),
+                        );
+                    }
+                }
+
                 let mut top = super::peer::BgpTop {
                     router_id: &self.router_id,
                     local_rib: &mut self.local_rib,
@@ -1813,7 +1886,7 @@ mod tests {
 
         use bgp_packet::{ExtCommunity, ExtCommunityValue, RouteDistinguisher};
 
-        use super::super::{RibKnownVrf, matching_import_vrfs};
+        use super::super::{RibKnownVrf, import_targets, matching_import_vrfs};
 
         fn rt(s: &str) -> RouteDistinguisher {
             RouteDistinguisher::from_str(s).unwrap()
@@ -1878,6 +1951,39 @@ mod tests {
             index.insert("v2".to_string(), vrf_with_imports(&["65000:99"]));
             let ecom = Some(ExtCommunity(vec![rt_extcom("65000:99")]));
             let mut got = matching_import_vrfs(&index, &ecom);
+            got.sort();
+            assert_eq!(got, vec!["v1".to_string(), "v2".to_string()]);
+        }
+
+        #[test]
+        fn import_targets_skips_originating_vrf() {
+            // `rt both 1:1`: a route exported by v1 carries RT
+            // 65000:1, and v1 also imports 65000:1. On the
+            // local-leak path the originating VRF (v1) must be
+            // excluded so it doesn't re-import what it exported,
+            // while a sibling (v2) that imports the same RT still
+            // gets it.
+            let mut index = BTreeMap::new();
+            index.insert("v1".to_string(), vrf_with_imports(&["65000:1"]));
+            index.insert("v2".to_string(), vrf_with_imports(&["65000:1"]));
+            let ecom = Some(ExtCommunity(vec![rt_extcom("65000:1")]));
+
+            let mut got = import_targets(&index, &ecom, Some("v1"));
+            got.sort();
+            assert_eq!(got, vec!["v2".to_string()]);
+        }
+
+        #[test]
+        fn import_targets_none_skip_keeps_all_matches() {
+            // The remote-VPNv4 ingress path passes `skip_vrf: None`
+            // — no originating local VRF — so every matching VRF is
+            // a target, identical to `matching_import_vrfs`.
+            let mut index = BTreeMap::new();
+            index.insert("v1".to_string(), vrf_with_imports(&["65000:1"]));
+            index.insert("v2".to_string(), vrf_with_imports(&["65000:1"]));
+            let ecom = Some(ExtCommunity(vec![rt_extcom("65000:1")]));
+
+            let mut got = import_targets(&index, &ecom, None);
             got.sort();
             assert_eq!(got, vec!["v1".to_string(), "v2".to_string()]);
         }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -916,12 +916,12 @@ pub fn route_ipv4_update(
         && let Some(dispatcher) = bgp.vrf_import
     {
         if let Some(winner) = selected.first() {
-            super::vrf::dispatch_import_v4(dispatcher, rd, nlri.prefix, &winner.attr, 0);
+            super::vrf::dispatch_import_v4(dispatcher, rd, nlri.prefix, &winner.attr, 0, None);
         } else {
             // best-path stripped the candidate; flood withdraw
             // using the *new* attr (the one just rejected) so
             // the matching-VRF set still resolves the same way.
-            super::vrf::dispatch_withdraw_import_v4(dispatcher, rd, nlri.prefix, &rib.attr);
+            super::vrf::dispatch_withdraw_import_v4(dispatcher, rd, nlri.prefix, &rib.attr, None);
         }
     }
 
@@ -1932,9 +1932,9 @@ pub fn route_ipv4_withdraw(
         && let Some(dispatcher) = bgp.vrf_import
     {
         if let Some(winner) = selected.first() {
-            super::vrf::dispatch_import_v4(dispatcher, rd, nlri.prefix, &winner.attr, 0);
+            super::vrf::dispatch_import_v4(dispatcher, rd, nlri.prefix, &winner.attr, 0, None);
         } else if let Some(gone) = removed.first() {
-            super::vrf::dispatch_withdraw_import_v4(dispatcher, rd, nlri.prefix, &gone.attr);
+            super::vrf::dispatch_withdraw_import_v4(dispatcher, rd, nlri.prefix, &gone.attr, None);
         }
     }
     if !selected.is_empty() || !removed.is_empty() {
@@ -2865,7 +2865,23 @@ pub fn route_update_ipv4(
         } else {
             *bgp.router_id
         };
-        attrs.nexthop = Some(BgpNexthop::Ipv4(nexthop));
+        // VPNv4 rows carry the `Vpnv4Nexthop` slot (it holds the
+        // route's RD); emit an MP_REACH-shaped next-hop so
+        // `flush_vpnv4` picks it up — writing a bare `BgpNexthop::Ipv4`
+        // here would be ignored at flush time and the MP_REACH would
+        // ship with no next-hop. The address is the local end of this
+        // peer's (i)BGP session (next-hop-self toward the remote PE,
+        // identical to the v4-unicast rule), falling back to the
+        // router-id when that local address isn't IPv4. Plain
+        // v4-unicast rows (`rib.nexthop == None`) keep the bare IPv4
+        // next-hop.
+        attrs.nexthop = match rib.nexthop {
+            Some(ref vpn_nh) => Some(BgpNexthop::Vpnv4(Vpnv4Nexthop {
+                rd: vpn_nh.rd,
+                nhop: nexthop,
+            })),
+            None => Some(BgpNexthop::Ipv4(nexthop)),
+        };
     };
 
     // 4. MED - Pass through.

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -173,14 +173,23 @@ pub struct VrfImportDispatcher<'a> {
 /// `local_rib.update(Some(rd), ...)` returns. `label = 0` means
 /// "no per-VRF label" — the receiving VRF treats it the same way
 /// the Export side does (skip the install).
+///
+/// `skip_vrf` names the VRF the route originated from on the
+/// local-leak path (`process_vrf_global_msg::Export`). It's
+/// excluded from the fan-out so a VRF whose import-RT set overlaps
+/// its own export-RTs (e.g. `rt both 1:1`) doesn't re-import the
+/// route it just exported. `None` on the remote-VPNv4 ingress path
+/// (no originating local VRF).
 pub fn dispatch_import_v4(
     dispatcher: &VrfImportDispatcher<'_>,
     rd: bgp_packet::RouteDistinguisher,
     prefix: ipnet::Ipv4Net,
     attr: &bgp_packet::BgpAttr,
     label: u32,
+    skip_vrf: Option<&str>,
 ) {
-    let matches = super::super::inst::matching_import_vrfs(dispatcher.rib_known_vrfs, &attr.ecom);
+    let matches =
+        super::super::inst::import_targets(dispatcher.rib_known_vrfs, &attr.ecom, skip_vrf);
     for vrf_name in matches {
         let Some(handle) = dispatcher.vrf_registry.get(&vrf_name) else {
             continue;
@@ -197,14 +206,18 @@ pub fn dispatch_import_v4(
 /// Inverse of [`dispatch_import_v4`]. Floods
 /// `BgpVrfMsg::WithdrawImport` to every VRF whose
 /// `import_rts_v4` matches; the receiver decides whether the
-/// matching imported route is one it actually holds.
+/// matching imported route is one it actually holds. `skip_vrf`
+/// is excluded for the same self-import reason as
+/// [`dispatch_import_v4`].
 pub fn dispatch_withdraw_import_v4(
     dispatcher: &VrfImportDispatcher<'_>,
     rd: bgp_packet::RouteDistinguisher,
     prefix: ipnet::Ipv4Net,
     attr: &bgp_packet::BgpAttr,
+    skip_vrf: Option<&str>,
 ) {
-    let matches = super::super::inst::matching_import_vrfs(dispatcher.rib_known_vrfs, &attr.ecom);
+    let matches =
+        super::super::inst::import_targets(dispatcher.rib_known_vrfs, &attr.ecom, skip_vrf);
     for vrf_name in matches {
         let Some(handle) = dispatcher.vrf_registry.get(&vrf_name) else {
             continue;


### PR DESCRIPTION
## Summary

Two related BGP/MPLS L3VPN propagation fixes.

**1. Local intra-router VPNv4 leak.** The remote-VPNv4 ingress path (`route_ipv4_update`) fans an accepted VPNv4 winner out to every importing VRF, but the local-export handler (`process_vrf_global_msg::Export`) wrote straight to `local_rib` and bypassed that hook — so a route exported by one local VRF never reached a sibling VRF on the same box. The `Export` / `WithdrawExport` handlers now replicate the import fan-out. A new `skip_vrf` argument on `dispatch_import_v4` / `dispatch_withdraw_import_v4` excludes the originating VRF so an `rt both` config doesn't re-import what it just exported; the matching-minus-skip computation is factored into `import_targets()` with unit tests.

**2. VPNv4 MP_REACH next-hop.** `route_update_ipv4` wrote a bare `BgpNexthop::Ipv4` for every next-hop rewrite, but `flush_vpnv4` only emits a next-hop for `BgpNexthop::Vpnv4` — so originated VPNv4 routes shipped with no next-hop. The rewrite now builds a Vpnv4-shaped next-hop (carrying the row's RD) for VPNv4 rows, using the peer's iBGP local session address with a router-id fallback, identical to the existing v4-unicast next-hop-self rule. The MP_REACH encoder continues to zero the 8-byte RD in the next-hop field (RFC 4364).

Scope held to control-plane IPv4. Follow-ups: VPNv6 leak, dataplane label-stack install into the VRF table, RT-strip/route-policy on CE egress, RR next-hop-unchanged preserve path.

## Test plan

- `cargo build -p zebra-rs`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p zebra-rs bgp::` — 179 passed (2 new: `import_targets_skips_originating_vrf`, `import_targets_none_skip_keeps_all_matches`)
- Live PE-PE: MP_REACH now carries the local iBGP session address (was emitting no next-hop).

Generated with [Claude Code](https://claude.com/claude-code)