### PR TITLE
bgp-packet: add VPNv6 (AFI=Ip6, SAFI=MplsVpn) codec

### DIFF
--- a/crates/bgp-packet/src/attrs/mod.rs
+++ b/crates/bgp-packet/src/attrs/mod.rs
@@ -82,6 +82,9 @@ pub use nlri_ipv6::*;
 pub mod nlri_vpnv4;
 pub use nlri_vpnv4::*;
 
+pub mod nlri_vpnv6;
+pub use nlri_vpnv6::*;
+
 pub mod nlri_evpn;
 pub use nlri_evpn::*;
 

--- a/crates/bgp-packet/src/attrs/mp_reach.rs
+++ b/crates/bgp-packet/src/attrs/mp_reach.rs
@@ -10,10 +10,10 @@ use bytes::BufMut;
 
 use crate::{
     Afi, AttrFlags, AttrType, EvpnRoute, Ipv4Nlri, Ipv6Nlri, MupRoute, ParseBe, ParseNlri,
-    ParseOption, Rtcv4, Safi, Vpnv4Nexthop, Vpnv4Nlri, many0_complete,
+    ParseOption, Rtcv4, Safi, Vpnv4Nexthop, Vpnv4Nlri, Vpnv6Nexthop, Vpnv6Nlri, many0_complete,
 };
 
-use super::{AttrEmitter, RouteDistinguisher, Rtcv4Reach, Vpnv4Reach};
+use super::{AttrEmitter, RouteDistinguisher, Rtcv4Reach, Vpnv4Reach, Vpnv6Reach};
 
 #[derive(Clone, Debug, NomBE)]
 pub struct MpReachHeader {
@@ -35,6 +35,7 @@ pub enum MpReachAttr {
         updates: Vec<Ipv6Nlri>,
     },
     Vpnv4(Vpnv4Reach),
+    Vpnv6(Vpnv6Reach),
     Evpn {
         snpa: u8,
         nhop: IpAddr,
@@ -56,6 +57,9 @@ impl MpReachAttr {
     pub fn attr_emit(&self, buf: &mut BytesMut) {
         match self {
             MpReachAttr::Vpnv4(nlri) => {
+                nlri.attr_emit(buf);
+            }
+            MpReachAttr::Vpnv6(nlri) => {
                 nlri.attr_emit(buf);
             }
             MpReachAttr::Rtcv4(nlri) => {
@@ -85,6 +89,9 @@ impl MpReachAttr {
     pub fn attr_emit_mut(&mut self, buf: &mut BytesMut, max_size: usize) {
         match self {
             MpReachAttr::Vpnv4(attr) => {
+                attr.attr_emit_mut(buf, max_size);
+            }
+            MpReachAttr::Vpnv6(attr) => {
                 attr.attr_emit_mut(buf, max_size);
             }
             _ => {
@@ -119,6 +126,49 @@ impl MpReachAttr {
                 updates,
             };
             let mp_nlri = MpReachAttr::Vpnv4(nlri);
+            return Ok((input, mp_nlri));
+        }
+        if header.afi == Afi::Ip6 && header.safi == Safi::MplsVpn {
+            // VPNv6 next-hop (RFC 4659 §3.2): an 8-octet RD (always
+            // zero on the wire) followed by the IPv6 address. The
+            // 48-octet form carries global || link-local, each with its
+            // own zero RD (RFC 8950 style); surface the global half.
+            let (input, nhop) = match header.nhop_len {
+                24 => {
+                    let (input, rd) = RouteDistinguisher::parse_be(input)?;
+                    let (input, addr) = be_u128(input)?;
+                    (
+                        input,
+                        Vpnv6Nexthop {
+                            rd,
+                            nhop: Ipv6Addr::from(addr),
+                        },
+                    )
+                }
+                48 => {
+                    let (input, rd) = RouteDistinguisher::parse_be(input)?;
+                    let (input, global) = be_u128(input)?;
+                    let (input, _ll_rd) = RouteDistinguisher::parse_be(input)?;
+                    let (input, _link_local) = be_u128(input)?;
+                    (
+                        input,
+                        Vpnv6Nexthop {
+                            rd,
+                            nhop: Ipv6Addr::from(global),
+                        },
+                    )
+                }
+                _ => return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue))),
+            };
+            let (input, snpa) = be_u8(input)?;
+            let (_, updates) =
+                many0_complete(|i| Vpnv6Nlri::parse_nlri(i, add_path)).parse(input)?;
+            let nlri = Vpnv6Reach {
+                snpa,
+                nhop,
+                updates,
+            };
+            let mp_nlri = MpReachAttr::Vpnv6(nlri);
             return Ok((input, mp_nlri));
         }
         if header.afi == Afi::Ip && header.safi == Safi::Unicast {
@@ -293,6 +343,15 @@ impl fmt::Display for MpReachAttr {
                 }
             }
             Vpnv4(nlri) => {
+                for update in nlri.updates.iter() {
+                    writeln!(
+                        f,
+                        " {}:[{}]:{}",
+                        update.nlri.id, update.rd, update.nlri.prefix,
+                    )?;
+                }
+            }
+            Vpnv6(nlri) => {
                 for update in nlri.updates.iter() {
                     writeln!(
                         f,

--- a/crates/bgp-packet/src/attrs/mp_unreach.rs
+++ b/crates/bgp-packet/src/attrs/mp_unreach.rs
@@ -6,10 +6,10 @@ use nom_derive::*;
 
 use crate::{
     Afi, AttrFlags, AttrType, EvpnRoute, Ipv6Nlri, MupRoute, ParseBe, ParseNlri, ParseOption,
-    Rtcv4, Rtcv4Unreach, Safi, Vpnv4Nlri, many0_complete,
+    Rtcv4, Rtcv4Unreach, Safi, Vpnv4Nlri, Vpnv6Nlri, many0_complete,
 };
 
-use super::{AttrEmitter, Vpnv4Unreach};
+use super::{AttrEmitter, Vpnv4Unreach, Vpnv6Unreach};
 
 #[derive(Clone, Debug, NomBE)]
 pub struct MpUnreachHeader {
@@ -25,8 +25,8 @@ pub enum MpUnreachAttr {
     Ipv6Eor,
     Vpnv4(Vec<Vpnv4Nlri>),
     Vpnv4Eor,
-    // Vpnv6,
-    // Vpnv6Eor,
+    Vpnv6(Vec<Vpnv6Nlri>),
+    Vpnv6Eor,
     Evpn(Vec<EvpnRoute>),
     EvpnEor,
     Rtcv4(Vec<Rtcv4>),
@@ -51,6 +51,16 @@ impl MpUnreachAttr {
             }
             MpUnreachAttr::Vpnv4Eor => {
                 let attr = Vpnv4Unreach { withdraw: vec![] };
+                attr.attr_emit(buf);
+            }
+            MpUnreachAttr::Vpnv6(withdraw) => {
+                let attr = Vpnv6Unreach {
+                    withdraw: withdraw.clone(),
+                };
+                attr.attr_emit(buf);
+            }
+            MpUnreachAttr::Vpnv6Eor => {
+                let attr = Vpnv6Unreach { withdraw: vec![] };
                 attr.attr_emit(buf);
             }
             MpUnreachAttr::Rtcv4Eor => {
@@ -173,6 +183,16 @@ impl MpUnreachAttr {
             let mp_nlri = MpUnreachAttr::Vpnv4(withdrawal);
             return Ok((input, mp_nlri));
         }
+        if header.afi == Afi::Ip6 && header.safi == Safi::MplsVpn {
+            if input.is_empty() {
+                let mp_nlri = MpUnreachAttr::Vpnv6Eor;
+                return Ok((input, mp_nlri));
+            }
+            let (input, withdrawal) =
+                many0_complete(|i| Vpnv6Nlri::parse_nlri(i, add_path)).parse(input)?;
+            let mp_nlri = MpUnreachAttr::Vpnv6(withdrawal);
+            return Ok((input, mp_nlri));
+        }
         if header.afi == Afi::Ip6 && header.safi == Safi::Unicast {
             if input.is_empty() {
                 let mp_nlri = MpUnreachAttr::Ipv6Eor;
@@ -256,6 +276,15 @@ impl fmt::Display for MpUnreachAttr {
             }
             Vpnv4Eor => {
                 writeln!(f, " EoR: {}/{}", Afi::Ip, Safi::MplsVpn)
+            }
+            Vpnv6(vpnv6_nlris) => {
+                for vpnv6 in vpnv6_nlris.iter() {
+                    writeln!(f, " {}:{}:{}", vpnv6.nlri.id, vpnv6.rd, vpnv6.nlri.prefix)?;
+                }
+                Ok(())
+            }
+            Vpnv6Eor => {
+                writeln!(f, " EoR: {}/{}", Afi::Ip6, Safi::MplsVpn)
             }
             Evpn(evpn_routes) => {
                 for evpn in evpn_routes.iter() {

--- a/crates/bgp-packet/src/attrs/nlri_ipv6.rs
+++ b/crates/bgp-packet/src/attrs/nlri_ipv6.rs
@@ -9,7 +9,7 @@ use nom_derive::*;
 
 use crate::{ParseBe, ParseNlri, nlri_psize};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct Ipv6Nlri {
     pub id: u32,
     pub prefix: Ipv6Net,

--- a/crates/bgp-packet/src/attrs/nlri_vpnv6.rs
+++ b/crates/bgp-packet/src/attrs/nlri_vpnv6.rs
@@ -1,0 +1,396 @@
+use std::fmt;
+use std::net::Ipv6Addr;
+
+use bytes::{BufMut, BytesMut};
+use ipnet::Ipv6Net;
+use nom::IResult;
+use nom::bytes::complete::take;
+use nom::error::{ErrorKind, make_error};
+use nom::number::complete::{be_u8, be_u32};
+use nom_derive::*;
+
+use crate::{Afi, AttrType, Label, ParseNlri, RouteDistinguisher, Safi, nlri_psize};
+
+use super::{AttrEmitter, AttrFlags, Ipv6Nlri};
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct Vpnv6Nlri {
+    pub label: Label,
+    pub rd: RouteDistinguisher,
+    pub nlri: Ipv6Nlri,
+}
+
+impl ParseNlri<Vpnv6Nlri> for Vpnv6Nlri {
+    fn parse_nlri(input: &[u8], add_path: bool) -> IResult<&[u8], Vpnv6Nlri> {
+        let (input, id) = if add_path { be_u32(input)? } else { (input, 0) };
+
+        // MPLS Label (3 octets) + RD (8 octets) + IPv6 Prefix (0-16 octets).
+        let (input, mut plen) = be_u8(input)?;
+
+        // Validate plen >= 88 (label 24 + RD 64) before parsing label and RD.
+        if plen < 88 {
+            return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+        }
+
+        let psize = nlri_psize(plen);
+        if input.len() < psize {
+            return Err(nom::Err::Error(make_error(input, ErrorKind::Eof)));
+        }
+        // MPLS Label.
+        let (input, label) = take(3usize).parse(input)?;
+        let label = Label::from(label);
+
+        // RD.
+        let (input, rd) = RouteDistinguisher::parse_be(input)?;
+
+        // Adjust plen to MPLS Label and Route Distinguisher.
+        plen -= 88;
+        let psize = nlri_psize(plen);
+
+        if psize > 16 {
+            // Prefix size must be 0..=16 (the `> 16` bound also rejects
+            // any `plen > 128`, keeping `Ipv6Net::new` below infallible).
+            return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+        }
+        if psize > input.len() {
+            // Prefix size must be same or smaller than remaining input buffer.
+            return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+        }
+
+        // IPv6 prefix.
+        let mut paddr = [0u8; 16];
+        paddr[..psize].copy_from_slice(&input[..psize]);
+        let (input, _) = take(psize).parse(input)?;
+        let prefix = Ipv6Net::new(Ipv6Addr::from(paddr), plen).expect("Ipv6Net create error");
+
+        let nlri = Ipv6Nlri { id, prefix };
+
+        let vpnv6 = Vpnv6Nlri { label, rd, nlri };
+
+        Ok((input, vpnv6))
+    }
+}
+
+impl fmt::Display for Vpnv6Nlri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let bos = if self.label.bos { "(BoS)" } else { "" };
+        write!(
+            f,
+            "VPNv6 [{}]:[{}]{} label: {} {}",
+            self.rd, self.nlri.id, self.nlri.prefix, self.label.label, bos,
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Vpnv6Nexthop {
+    pub rd: RouteDistinguisher,
+    pub nhop: Ipv6Addr,
+}
+
+impl fmt::Display for Vpnv6Nexthop {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}]:{}", self.rd, self.nhop)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Vpnv6Reach {
+    pub snpa: u8,
+    pub nhop: Vpnv6Nexthop,
+    pub updates: Vec<Vpnv6Nlri>,
+}
+
+impl AttrEmitter for Vpnv6Reach {
+    fn attr_type(&self) -> AttrType {
+        AttrType::MpReachNlri
+    }
+
+    fn attr_flags(&self) -> AttrFlags {
+        AttrFlags::new().with_optional(true)
+    }
+
+    fn len(&self) -> Option<usize> {
+        None
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        // AFI/SAFI.
+        buf.put_u16(u16::from(Afi::Ip6));
+        buf.put_u8(u8::from(Safi::MplsVpn));
+        // Nexthop
+        buf.put_u8(24); // Nexthop length.  RD(8)+IPv6 Nexthop(16);
+        // Nexthop RD.
+        let rd = [0u8; 8];
+        buf.put(&rd[..]);
+        // Nexthop.
+        buf.put(&self.nhop.nhop.octets()[..]);
+        // SNPA
+        buf.put_u8(0);
+        // Prefix.
+        for update in self.updates.iter() {
+            // AddPath
+            if update.nlri.id != 0 {
+                buf.put_u32(update.nlri.id);
+            }
+            // Plen
+            let plen = update.nlri.prefix.prefix_len() + 88;
+            buf.put_u8(plen);
+            // Label
+            buf.put(&update.label.to_bytes()[..]);
+            // RD
+            buf.put_u16(update.rd.typ as u16);
+            buf.put(&update.rd.val[..]);
+            // Prefix
+            let plen = nlri_psize(update.nlri.prefix.prefix_len());
+            buf.put(&update.nlri.prefix.addr().octets()[0..plen]);
+        }
+    }
+}
+
+impl Vpnv6Reach {
+    pub fn attr_emit_mut(&mut self, buf: &mut BytesMut, max_size: usize) {
+        let flags = self.attr_flags();
+        let attr_type = self.attr_type();
+        let emit_header = |buf: &mut BytesMut, len: usize, extended: bool| {
+            if extended {
+                buf.put_u8(flags.with_extended(true).into());
+                buf.put_u8(attr_type.into());
+                buf.put_u16(len as u16);
+            } else {
+                buf.put_u8(flags.into());
+                buf.put_u8(attr_type.into());
+                buf.put_u8(len as u8);
+            }
+        };
+
+        if let Some(len) = self.len() {
+            // Length is known.
+            let extended = len > 255;
+            emit_header(buf, len, extended);
+            self.emit_mut(buf, max_size);
+        } else {
+            // Buffer the attribute to determine its length.
+            let mut attr_buf = BytesMut::new();
+            self.emit_mut(&mut attr_buf, max_size);
+            let len = attr_buf.len();
+            let extended = len > 255;
+            emit_header(buf, len, extended);
+            buf.put(&attr_buf[..]);
+        }
+    }
+
+    fn emit_mut(&mut self, buf: &mut BytesMut, max_size: usize) {
+        // AFI/SAFI.
+        buf.put_u16(u16::from(Afi::Ip6));
+        buf.put_u8(u8::from(Safi::MplsVpn));
+        // Nexthop
+        buf.put_u8(24); // Nexthop length.  RD(8)+IPv6 Nexthop(16);
+        // Nexthop RD.
+        let rd = [0u8; 8];
+        buf.put(&rd[..]);
+        // Nexthop.
+        buf.put(&self.nhop.nhop.octets()[..]);
+        // SNPA
+        buf.put_u8(0);
+
+        // Prefix.
+        while let Some(update) = self.updates.pop() {
+            // Need to check remaining buffer size.
+            let mut nlri_len: usize = 0;
+            if update.nlri.id != 0 {
+                nlri_len += 4;
+            }
+            // Plen.
+            nlri_len += 1;
+            // Label.
+            nlri_len += 4;
+            // RD.
+            nlri_len += 8;
+            // Prefix.
+            nlri_len += nlri_psize(update.nlri.prefix.prefix_len());
+
+            if nlri_len + buf.len() > max_size {
+                self.updates.push(update);
+                return;
+            }
+
+            // AddPath
+            if update.nlri.id != 0 {
+                buf.put_u32(update.nlri.id);
+            }
+            // Plen
+            let plen = update.nlri.prefix.prefix_len() + 88;
+            buf.put_u8(plen);
+            // Label
+            buf.put(&update.label.to_bytes()[..]);
+            // RD
+            buf.put_u16(update.rd.typ as u16);
+            buf.put(&update.rd.val[..]);
+            // Prefix
+            let plen = nlri_psize(update.nlri.prefix.prefix_len());
+            buf.put(&update.nlri.prefix.addr().octets()[0..plen]);
+        }
+    }
+}
+
+pub struct Vpnv6Unreach {
+    pub withdraw: Vec<Vpnv6Nlri>,
+}
+
+impl AttrEmitter for Vpnv6Unreach {
+    fn attr_type(&self) -> AttrType {
+        AttrType::MpUnreachNlri
+    }
+
+    fn attr_flags(&self) -> AttrFlags {
+        AttrFlags::new().with_optional(true)
+    }
+
+    fn len(&self) -> Option<usize> {
+        None
+    }
+
+    fn emit(&self, buf: &mut BytesMut) {
+        // AFI/SAFI.
+        buf.put_u16(u16::from(Afi::Ip6));
+        buf.put_u8(u8::from(Safi::MplsVpn));
+        // Prefix.
+        for withdraw in self.withdraw.iter() {
+            // AddPath
+            if withdraw.nlri.id != 0 {
+                buf.put_u32(withdraw.nlri.id);
+            }
+            // Plen
+            let plen = withdraw.nlri.prefix.prefix_len() + 88;
+            buf.put_u8(plen);
+            // Label
+            buf.put(&withdraw.label.to_bytes()[..]);
+            // RD
+            buf.put_u16(withdraw.rd.typ as u16);
+            buf.put(&withdraw.rd.val[..]);
+            // Prefix
+            let plen = nlri_psize(withdraw.nlri.prefix.prefix_len());
+            buf.put(&withdraw.nlri.prefix.addr().octets()[0..plen]);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use crate::Ipv6Nlri;
+
+    fn nlri(rd: &str, prefix: &str, label: u32) -> Vpnv6Nlri {
+        Vpnv6Nlri {
+            label: Label {
+                label,
+                exp: 0,
+                bos: true,
+            },
+            rd: RouteDistinguisher::from_str(rd).unwrap(),
+            nlri: Ipv6Nlri {
+                id: 0,
+                prefix: prefix.parse().unwrap(),
+            },
+        }
+    }
+
+    #[test]
+    fn reach_round_trips_through_parser() {
+        // Emit a Vpnv6Reach, strip the attribute header, and parse the
+        // value back through the MP_REACH VPNv6 path.
+        let reach = Vpnv6Reach {
+            snpa: 0,
+            nhop: Vpnv6Nexthop {
+                rd: RouteDistinguisher::from_str("65000:1").unwrap(),
+                nhop: "2001:db8::1".parse().unwrap(),
+            },
+            updates: vec![
+                nlri("65000:1", "2001:db8:1::/64", 100),
+                nlri("65000:1", "2001:db8:2::/48", 200),
+            ],
+        };
+
+        let mut buf = BytesMut::new();
+        reach.emit(&mut buf);
+
+        // emit() writes the MP_REACH value (AFI/SAFI/nexthop/SNPA/NLRI)
+        // without the path-attribute header, which is exactly what
+        // `parse_nlri_opt` expects after MpReachHeader. Note the
+        // MP_REACH parser returns the input positioned at the start of
+        // the NLRI section (the post-`many0` remainder is discarded, as
+        // on the Vpnv4 path), so the returned pointer is intentionally
+        // non-empty — the parsed `updates` are the contract here.
+        let (_rest, parsed) =
+            crate::MpReachAttr::parse_nlri_opt(&buf, None).expect("VPNv6 MP_REACH must parse");
+
+        match parsed {
+            crate::MpReachAttr::Vpnv6(r) => {
+                assert_eq!(r.nhop.nhop, "2001:db8::1".parse::<Ipv6Addr>().unwrap());
+                assert_eq!(r.updates.len(), 2);
+                // Order is preserved by the iterator-based emit().
+                assert_eq!(
+                    r.updates[0].nlri.prefix,
+                    "2001:db8:1::/64".parse::<Ipv6Net>().unwrap()
+                );
+                assert_eq!(r.updates[0].label.label, 100);
+                assert_eq!(
+                    r.updates[0].rd,
+                    RouteDistinguisher::from_str("65000:1").unwrap()
+                );
+                assert_eq!(
+                    r.updates[1].nlri.prefix,
+                    "2001:db8:2::/48".parse::<Ipv6Net>().unwrap()
+                );
+                assert_eq!(r.updates[1].label.label, 200);
+            }
+            other => panic!("expected Vpnv6, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unreach_round_trips_through_parser() {
+        let unreach = Vpnv6Unreach {
+            withdraw: vec![nlri("65001:7", "2001:db8:3::/56", 0)],
+        };
+        let mut buf = BytesMut::new();
+        unreach.emit(&mut buf);
+
+        let (rest, parsed) =
+            crate::MpUnreachAttr::parse_nlri_opt(&buf, None).expect("VPNv6 MP_UNREACH must parse");
+        assert!(rest.is_empty());
+        match parsed {
+            crate::MpUnreachAttr::Vpnv6(w) => {
+                assert_eq!(w.len(), 1);
+                assert_eq!(
+                    w[0].nlri.prefix,
+                    "2001:db8:3::/56".parse::<Ipv6Net>().unwrap()
+                );
+                assert_eq!(w[0].rd, RouteDistinguisher::from_str("65001:7").unwrap());
+            }
+            other => panic!("expected Vpnv6, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unreach_empty_is_eor() {
+        // AFI(Ip6) + SAFI(MplsVpn) with no NLRI bytes is an EoR marker.
+        let mut buf = BytesMut::new();
+        buf.put_u16(u16::from(Afi::Ip6));
+        buf.put_u8(u8::from(Safi::MplsVpn));
+        let (_rest, parsed) =
+            crate::MpUnreachAttr::parse_nlri_opt(&buf, None).expect("EoR must parse");
+        assert!(matches!(parsed, crate::MpUnreachAttr::Vpnv6Eor));
+    }
+
+    #[test]
+    fn parse_rejects_plen_below_label_rd_floor() {
+        // plen < 88 (less than label+RD) must be rejected before the
+        // label/RD reads.
+        let input = [0x00u8, 0x00, 0x00, 0x00];
+        assert!(Vpnv6Nlri::parse_nlri(&input, false).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

First layer of the VPNv6 leak stack: the packet codec, which was entirely absent (only a commented-out `// Vpnv6` placeholder in `mp_unreach.rs`). This unblocks the IPv6 Loc-RIB and leak-plumbing layers that follow.

- **`nlri_vpnv6.rs`** (new): `Vpnv6Nlri` (label + RD + IPv6 prefix), `Vpnv6Nexthop` (RD + `Ipv6Addr`), `Vpnv6Reach` (MP_REACH emitter + paginating `attr_emit_mut`), `Vpnv6Unreach` (MP_UNREACH emitter). Mirrors the Vpnv4 codec; prefix parse is bounded to 0..=16 octets and the `psize > 16` guard keeps `Ipv6Net::new` infallible.
- **`MpReachAttr::Vpnv6`**: new variant + parse branch for `(Ip6, MplsVpn)`. Next-hop is the RFC 4659 8-octet-RD ‖ IPv6 (24-byte) form; the 48-byte global ‖ link-local form (RFC 8950) is parsed with the global half surfaced. Emit hardcodes a zeroed 8-byte RD in the next-hop, matching the Vpnv4 wire form. Display + emit dispatch wired.
- **`MpUnreachAttr::Vpnv6` / `Vpnv6Eor`**: variants + parse branch + emit + Display.
- **`Ipv6Nlri`** gains `Hash/Eq/PartialEq` (needed by `Vpnv6Nlri`, same as `Ipv4Nlri` already had).

The daemon's MP_REACH/UNREACH match arms have catch-alls, so the new variants compile without behavior change — received VPNv6 is parsed into the enum but still dropped at dispatch (no v6 RIB yet). That's wired up in layers 2–3.

## Test plan

- `cargo build --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p bgp-packet` — 163 passed (4 new: reach/unreach round-trips, EoR, plen-floor reject)
- `cargo test -p zebra-rs bgp::` — 179 passed

Generated with [Claude Code](https://claude.com/claude-code)