### PR TITLE
bgp-packet: emit MP_REACH/MP_UNREACH for IPv6 unicast

### DIFF
--- a/crates/bgp-packet/src/attrs/mp_reach.rs
+++ b/crates/bgp-packet/src/attrs/mp_reach.rs
@@ -65,6 +65,13 @@ impl MpReachAttr {
             MpReachAttr::Rtcv4(nlri) => {
                 nlri.attr_emit(buf);
             }
+            MpReachAttr::Ipv6 {
+                snpa: _,
+                nhop,
+                updates,
+            } => {
+                ipv6_attr_emit(nhop, updates, buf);
+            }
             MpReachAttr::Evpn {
                 snpa,
                 nhop,
@@ -434,6 +441,54 @@ impl fmt::Debug for MpReachAttr {
 /// before writing the header — extended (2-byte) length is used when
 /// the value exceeds 255 octets, matching the convention used by
 /// `Vpnv4Reach::attr_emit_mut`.
+/// Serialize an `MpReachAttr::Ipv6 { nhop, updates }` as a complete
+/// MP_REACH_NLRI path attribute (header + value). IPv6 unicast has no
+/// legacy NLRI field, so this is the only encode path.
+///
+/// Wire format (RFC 4760 §3 + RFC 2545 §3):
+/// ```text
+///   AFI  (2) = 2 (IPv6)
+///   SAFI (1) = 1 (Unicast)
+///   Next-Hop Length (1) = 16
+///   Next-Hop (16, global IPv6)
+///   SNPA (1) = 0
+///   NLRI  (one or more Ipv6Nlri encodings)
+/// ```
+pub(crate) fn ipv6_attr_emit(nhop: &IpAddr, updates: &[Ipv6Nlri], buf: &mut BytesMut) {
+    let mut value = BytesMut::new();
+    value.put_u16(u16::from(Afi::Ip6));
+    value.put_u8(u8::from(Safi::Unicast));
+    // RFC 2545: a 16-octet global IPv6 next-hop. A v4 next-hop here is
+    // a caller bug; emit a zeroed 16-octet next-hop rather than a
+    // malformed length so the receiver drops the route cleanly.
+    value.put_u8(16);
+    match nhop {
+        IpAddr::V6(v6) => value.put(&v6.octets()[..]),
+        IpAddr::V4(_) => value.put(&[0u8; 16][..]),
+    }
+    // SNPA.
+    value.put_u8(0);
+    for nlri in updates {
+        nlri.nlri_emit(&mut value);
+    }
+
+    let len = value.len();
+    let extended = len > 255;
+    let flags = if extended {
+        AttrFlags::new().with_optional(true).with_extended(true)
+    } else {
+        AttrFlags::new().with_optional(true)
+    };
+    buf.put_u8(flags.into());
+    buf.put_u8(AttrType::MpReachNlri.into());
+    if extended {
+        buf.put_u16(len as u16);
+    } else {
+        buf.put_u8(len as u8);
+    }
+    buf.put(&value[..]);
+}
+
 pub(crate) fn evpn_attr_emit(_snpa: u8, nhop: &IpAddr, updates: &[EvpnRoute], buf: &mut BytesMut) {
     let mut value = BytesMut::new();
     value.put_u16(u16::from(Afi::L2vpn));

--- a/crates/bgp-packet/src/attrs/mp_unreach.rs
+++ b/crates/bgp-packet/src/attrs/mp_unreach.rs
@@ -63,6 +63,12 @@ impl MpUnreachAttr {
                 let attr = Vpnv6Unreach { withdraw: vec![] };
                 attr.attr_emit(buf);
             }
+            MpUnreachAttr::Ipv6Nlri(withdraws) => {
+                ipv6_unreach_attr_emit(withdraws, buf);
+            }
+            MpUnreachAttr::Ipv6Eor => {
+                ipv6_unreach_attr_emit(&[], buf);
+            }
             MpUnreachAttr::Rtcv4Eor => {
                 let attr = Rtcv4Unreach { withdraw: vec![] };
                 attr.attr_emit(buf);
@@ -98,6 +104,38 @@ impl MpUnreachAttr {
 /// header and the NLRI list. The NLRI body bytes are produced by
 /// `EvpnRoute::nlri_emit` (PR #399), the same encoder used by the
 /// MP_REACH advertise path.
+/// Serialize an `MpUnreachAttr::Ipv6Nlri(withdraws)` (or `Ipv6Eor`
+/// when `withdraws` is empty) as a complete MP_UNREACH_NLRI path
+/// attribute. IPv6 unicast withdrawals have no legacy field, so this
+/// is the only encode path.
+///
+/// Wire format (RFC 4760 §4): AFI=2, SAFI=1, then the NLRI list (empty
+/// for end-of-RIB).
+fn ipv6_unreach_attr_emit(withdraws: &[Ipv6Nlri], buf: &mut BytesMut) {
+    let mut value = BytesMut::new();
+    value.put_u16(u16::from(Afi::Ip6));
+    value.put_u8(u8::from(Safi::Unicast));
+    for nlri in withdraws {
+        nlri.nlri_emit(&mut value);
+    }
+
+    let len = value.len();
+    let extended = len > 255;
+    let flags = if extended {
+        AttrFlags::new().with_optional(true).with_extended(true)
+    } else {
+        AttrFlags::new().with_optional(true)
+    };
+    buf.put_u8(flags.into());
+    buf.put_u8(AttrType::MpUnreachNlri.into());
+    if extended {
+        buf.put_u16(len as u16);
+    } else {
+        buf.put_u8(len as u8);
+    }
+    buf.put(&value[..]);
+}
+
 fn evpn_unreach_attr_emit(withdraw: &[EvpnRoute], buf: &mut BytesMut) {
     let mut value = BytesMut::new();
     value.put_u16(u16::from(Afi::L2vpn));

--- a/crates/bgp-packet/src/attrs/nlri_ipv6.rs
+++ b/crates/bgp-packet/src/attrs/nlri_ipv6.rs
@@ -1,5 +1,6 @@
 use std::net::Ipv6Addr;
 
+use bytes::{BufMut, BytesMut};
 use ipnet::Ipv6Net;
 use nom::IResult;
 use nom::bytes::complete::take;
@@ -13,6 +14,22 @@ use crate::{ParseBe, ParseNlri, nlri_psize};
 pub struct Ipv6Nlri {
     pub id: u32,
     pub prefix: Ipv6Net,
+}
+
+impl Ipv6Nlri {
+    /// Encode this NLRI into an MP_REACH / MP_UNREACH NLRI list:
+    /// an optional 4-octet AddPath ID (only when `id != 0`), the
+    /// 1-octet prefix length, then the `ceil(plen / 8)` significant
+    /// prefix octets. Inverse of [`Ipv6Nlri::parse_nlri`].
+    pub fn nlri_emit(&self, buf: &mut BytesMut) {
+        if self.id != 0 {
+            buf.put_u32(self.id);
+        }
+        let plen = self.prefix.prefix_len();
+        buf.put_u8(plen);
+        let psize = nlri_psize(plen);
+        buf.put(&self.prefix.addr().octets()[0..psize]);
+    }
 }
 
 impl ParseNlri<Ipv6Nlri> for Ipv6Nlri {
@@ -56,9 +73,79 @@ impl ParseBe<Ipv6Net> for Ipv6Net {
 
 #[cfg(test)]
 mod tests {
+    use std::net::IpAddr;
+
+    use bytes::BytesMut;
+
     use super::Ipv6Nlri;
-    use crate::{ParseBe, ParseNlri};
+    use crate::{MpReachAttr, MpUnreachAttr, ParseBe, ParseNlri};
     use ipnet::Ipv6Net;
+
+    fn nlri(prefix: &str) -> Ipv6Nlri {
+        Ipv6Nlri {
+            id: 0,
+            prefix: prefix.parse().unwrap(),
+        }
+    }
+
+    #[test]
+    fn reach_emit_round_trips_through_parser() {
+        // Build an MP_REACH IPv6 unicast attr, emit it (header +
+        // value), strip the 3-byte path-attribute header, and parse
+        // the value back. The parser returns the pointer at the start
+        // of the NLRI section (post-`many0` remainder discarded, as on
+        // every MP_REACH path), so the `updates` are the contract.
+        let reach = MpReachAttr::Ipv6 {
+            snpa: 0,
+            nhop: "2001:db8::1".parse::<IpAddr>().unwrap(),
+            updates: vec![nlri("2001:db8:1::/64"), nlri("2001:db8:2::/48")],
+        };
+        let mut buf = BytesMut::new();
+        reach.attr_emit(&mut buf);
+        // flags(1) + type(1) + len(1) header.
+        let (_rest, parsed) =
+            MpReachAttr::parse_nlri_opt(&buf[3..], None).expect("IPv6 MP_REACH must parse");
+        match parsed {
+            MpReachAttr::Ipv6 { nhop, updates, .. } => {
+                assert_eq!(nhop, "2001:db8::1".parse::<IpAddr>().unwrap());
+                assert_eq!(updates.len(), 2);
+                assert_eq!(
+                    updates[0].prefix,
+                    "2001:db8:1::/64".parse::<Ipv6Net>().unwrap()
+                );
+                assert_eq!(
+                    updates[1].prefix,
+                    "2001:db8:2::/48".parse::<Ipv6Net>().unwrap()
+                );
+            }
+            other => panic!("expected Ipv6, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unreach_emit_round_trips_through_parser() {
+        let unreach = MpUnreachAttr::Ipv6Nlri(vec![nlri("2001:db8:3::/56")]);
+        let mut buf = BytesMut::new();
+        unreach.attr_emit(&mut buf);
+        let (_rest, parsed) =
+            MpUnreachAttr::parse_nlri_opt(&buf[3..], None).expect("IPv6 MP_UNREACH must parse");
+        match parsed {
+            MpUnreachAttr::Ipv6Nlri(w) => {
+                assert_eq!(w.len(), 1);
+                assert_eq!(w[0].prefix, "2001:db8:3::/56".parse::<Ipv6Net>().unwrap());
+            }
+            other => panic!("expected Ipv6Nlri, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unreach_emit_empty_is_eor() {
+        let mut buf = BytesMut::new();
+        MpUnreachAttr::Ipv6Eor.attr_emit(&mut buf);
+        let (_rest, parsed) =
+            MpUnreachAttr::parse_nlri_opt(&buf[3..], None).expect("IPv6 EoR must parse");
+        assert!(matches!(parsed, MpUnreachAttr::Ipv6Eor));
+    }
 
     #[test]
     fn parse_nlri_rejects_prefixlen_over_128() {


### PR DESCRIPTION
## Summary

Layer 2b-ii-a of the VPNv6 leak stack: implement the **encode** side of IPv6 unicast, previously stubbed as `_ => {}` in both `attr_emit` paths. IPv6 unicast has no legacy NLRI field, so MP_REACH/MP_UNREACH is the only wire encoding — the daemon's v6 advertise path (2b-ii-b) depends on this.

- **`Ipv6Nlri::nlri_emit`** — shared NLRI encoder (optional AddPath id, prefix length, significant prefix octets); inverse of `parse_nlri`.
- **`ipv6_attr_emit`** — MP_REACH for `(Ip6, Unicast)`: AFI/SAFI, a 16-octet RFC 2545 global next-hop, SNPA, then the NLRI list. Wired into `MpReachAttr::attr_emit`.
- **`ipv6_unreach_attr_emit`** — MP_UNREACH for `(Ip6, Unicast)` / end-of-RIB. Wired into `MpUnreachAttr::attr_emit` for both `Ipv6Nlri(..)` and `Ipv6Eor`.

The `MpReachAttr::Ipv6` / `MpUnreachAttr::Ipv6Nlri` variants already existed and are constructed on the receive path, so no dead code.

## Test plan

- `cargo build --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p bgp-packet` — 166 passed (+3: MP_REACH/MP_UNREACH IPv6 emit→parse round-trips + EoR)
- `cargo test -p zebra-rs bgp::` — 184 passed

Generated with [Claude Code](https://claude.com/claude-code)