### PR TITLE
bgp: IPv6 unicast advertise — update-group cache, flush, emit

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -54,6 +54,7 @@ pub enum Message {
     /// drain the group's pending cache, encode one UPDATE per attr
     /// bucket, and ship to each member with split-horizon pruning.
     FlushUpdateGroupIpv4(super::update_group::UpdateGroupId),
+    FlushUpdateGroupIpv6(super::update_group::UpdateGroupId),
 }
 
 pub type Callback = fn(&mut Bgp, Args, ConfigOp) -> Option<()>;
@@ -746,6 +747,13 @@ impl Bgp {
                     &mut self.attr_store,
                     &group_id,
                     &self.interface_addrs,
+                );
+            }
+            Message::FlushUpdateGroupIpv6(group_id) => {
+                super::update_group::flush_ipv6(
+                    &mut self.update_groups,
+                    &mut self.peers,
+                    &group_id,
                 );
             }
         }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2115,6 +2115,10 @@ pub fn route_ipv6_update(
     let (_, selected, _next_id) = bgp.local_rib.update_v6(nlri.prefix, rib);
 
     fib_install_v6(bgp, nlri.prefix, &selected);
+
+    if !selected.is_empty() {
+        route_advertise_to_peers_v6(nlri.prefix, &selected, bgp, peers);
+    }
 }
 
 /// IPv6 unicast withdraw — the v6 counterpart of
@@ -2135,6 +2139,10 @@ pub fn route_ipv6_withdraw(
     let _removed = bgp.local_rib.remove_v6(nlri.prefix, nlri.id, ident);
     let selected = bgp.local_rib.select_best_path_v6(nlri.prefix);
     fib_install_v6(bgp, nlri.prefix, &selected);
+
+    // Empty `selected` → withdraw to peers; a replacement winner →
+    // re-advertise. `route_advertise_to_peers_v6` handles both.
+    route_advertise_to_peers_v6(nlri.prefix, &selected, bgp, peers);
 }
 
 pub fn route_ipv4_rtc_update(peer_id: usize, rtcv4: &Rtcv4, peers: &mut PeerMap) {
@@ -3145,6 +3153,163 @@ pub fn route_update_ipv4(
     }
 
     Some((nlri, attrs))
+}
+
+/// IPv6 unicast outbound builder — the v6 counterpart of
+/// [`route_update_ipv4`]. Applies split-horizon and the iBGP-iBGP /
+/// route-reflector filter, fixes up AS_PATH / next-hop / LOCAL_PREF /
+/// ORIGINATOR_ID / CLUSTER_LIST, and returns `(Ipv6Nlri, BgpAttr)` for
+/// the peer or `None` to suppress.
+///
+/// Outbound policy is not applied yet for v6 (the policy engine is
+/// `Ipv4Nlri`-typed) — same deferred gap as the ingest path.
+pub fn route_update_ipv6(
+    peer: &mut Peer,
+    prefix: &Ipv6Net,
+    rib: &BgpRib,
+    bgp: &mut BgpTop,
+    add_path: bool,
+) -> Option<(Ipv6Nlri, BgpAttr)> {
+    // Split-horizon: never send a route back to its source peer.
+    if rib.ident == peer.ident {
+        return None;
+    }
+    // iBGP→iBGP: don't re-advertise iBGP-learned routes to iBGP peers
+    // unless this peer is a route-reflector client.
+    if peer.peer_type == PeerType::IBGP
+        && rib.typ == BgpRibType::IBGP
+        && !peer.is_reflector_client()
+    {
+        return None;
+    }
+
+    let nlri = Ipv6Nlri {
+        id: if add_path { rib.local_id } else { 0 },
+        prefix: *prefix,
+    };
+
+    let mut attrs = (*rib.attr).clone();
+
+    // AS_PATH prepend for eBGP.
+    if peer.is_ebgp()
+        && let Some(ref mut aspath) = attrs.aspath
+    {
+        let local_as_path = As4Path::from(vec![peer.local_as]);
+        aspath.prepend_mut(local_as_path.clone());
+    }
+
+    // NEXT_HOP: next-hop-self for eBGP / locally-originated routes. The
+    // address is the local end of this peer's (i)BGP session when it's
+    // IPv6; otherwise the route's existing v6 next-hop is preserved
+    // (next-hop-unchanged) — a v4-transport session can't carry a
+    // sensible v6 next-hop anyway.
+    let needs_self = peer.is_ebgp() || rib.is_originated();
+    if needs_self
+        && let Some(ref local_addr) = peer.param.local_addr
+        && let IpAddr::V6(local_v6) = local_addr.ip()
+    {
+        attrs.nexthop = Some(BgpNexthop::Ipv6(local_v6));
+    }
+
+    // LOCAL_PREF for iBGP.
+    if peer.is_ibgp() && attrs.local_pref.is_none() {
+        attrs.local_pref = Some(LocalPref::default());
+    }
+
+    // ORIGINATOR_ID / CLUSTER_LIST for route reflection (RFC 4456).
+    if peer.peer_type == PeerType::IBGP
+        && rib.typ == BgpRibType::IBGP
+        && attrs.originator_id.is_none()
+    {
+        attrs.originator_id = Some(OriginatorId::new(rib.router_id));
+    }
+    if peer.peer_type == PeerType::IBGP && rib.typ == BgpRibType::IBGP {
+        if let Some(ref mut cluster_list) = attrs.cluster_list {
+            cluster_list.list.insert(0, *bgp.router_id);
+        } else {
+            let mut cluster_list = ClusterList::new();
+            cluster_list.list.push(*bgp.router_id);
+            attrs.cluster_list = Some(cluster_list);
+        }
+    }
+
+    Some((nlri, attrs))
+}
+
+/// Per-peer IPv6 unicast withdraw — emit an MP_UNREACH(AFI=2, SAFI=1)
+/// for `prefix`. The v6 counterpart of [`route_withdraw_ipv4`]'s
+/// unicast arm; v6 has no legacy withdraw field.
+fn route_withdraw_ipv6(peer: &mut Peer, prefix: Ipv6Net, id: u32) {
+    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    update.mp_withdraw = Some(MpUnreachAttr::Ipv6Nlri(vec![Ipv6Nlri { id, prefix }]));
+    peer.send_packet(update.into());
+}
+
+/// IPv6 unicast advertise — the v6 counterpart of
+/// [`route_advertise_to_peers`] (unicast only). Reach winners are
+/// bucketed into the per-group `cache_ipv6` (debounce-flushed via
+/// [`super::update_group::flush_ipv6`]); a `None` best-path emits an
+/// immediate MP_UNREACH to each member.
+///
+/// The update-group post-policy memoization, Adj-RIB-Out tracking, and
+/// outbound policy that the v4 path carries are deferred for v6 (the
+/// policy engine is IPv4-typed). Without Adj-RIB-Out, a withdraw is
+/// sent to every Established v6 peer even if it never received the
+/// route — harmless (peers ignore unknown-prefix withdraws).
+pub(super) fn route_advertise_to_peers_v6(
+    prefix: Ipv6Net,
+    selected: &[BgpRib],
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+) {
+    let new_best = selected.last();
+    let (afi, safi) = (Afi::Ip6, Safi::Unicast);
+    let afi_safi = AfiSafi::new(afi, safi);
+
+    let peer_addrs: Vec<IpAddr> = peers
+        .iter()
+        .filter(|(_, p)| p.state.is_established())
+        .filter(|(_, p)| p.is_afi_safi(afi, safi))
+        .filter(|(_, p)| !p.opt.is_add_path_send(afi, safi))
+        .map(|(addr, _)| *addr)
+        .collect();
+
+    for peer_addr in peer_addrs {
+        let peer = peers.get_mut(&peer_addr).expect("peer exists");
+        let add_path = peer.opt.is_add_path_send(afi, safi);
+        let group_id = peer.update_group_id.get(&afi_safi).cloned();
+
+        match new_best {
+            Some(best) if best.ident != peer.ident => {
+                let Some((nlri, attr)) = route_update_ipv6(peer, &prefix, best, bgp, add_path)
+                else {
+                    continue;
+                };
+                let attr = bgp.attr_store.intern(attr);
+                let source_ident = best.ident;
+                if let Some(gid) = group_id
+                    && let Some(af) = bgp.update_groups.get_mut(&afi_safi)
+                    && let Some(group) = af.group_by_id_mut(&gid)
+                {
+                    super::update_group::send_ipv6(group, nlri, attr, source_ident, bgp.tx, true);
+                }
+            }
+            Some(_) => {
+                // Split-horizon: the source peer receives nothing.
+            }
+            None => {
+                // Withdraw: cancel any still-pending reach for this
+                // prefix, then emit an explicit MP_UNREACH.
+                if let Some(gid) = group_id
+                    && let Some(af) = bgp.update_groups.get_mut(&afi_safi)
+                    && let Some(group) = af.group_by_id_mut(&gid)
+                {
+                    super::update_group::cache_remove_ipv6(group, prefix, 0);
+                }
+                route_withdraw_ipv6(peer, prefix, 0);
+            }
+        }
+    }
 }
 
 impl Peer {

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -26,7 +26,8 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use bgp_packet::{
-    Afi, AfiSafi, BgpAttr, CapExtendedNextHop, Ipv4MpReachNextHop, Ipv4Nlri, Safi, UpdatePacket,
+    Afi, AfiSafi, BgpAttr, BgpNexthop, CapExtendedNextHop, Ipv4MpReachNextHop, Ipv4Nlri, Ipv6Nlri,
+    MpReachAttr, Safi, UpdatePacket,
 };
 use tokio::sync::mpsc;
 
@@ -149,6 +150,15 @@ pub struct UpdateGroup {
     /// Adv-debounce timer. Started on first send; on fire,
     /// `Bgp::serve` drains the cache and ships UPDATEs to members.
     pub cache_ipv4_timer: Option<Timer>,
+
+    // ── IPv6 unicast pending advertisement cache ──
+    //
+    // Same shape as the IPv4 cache above. IPv6 unicast has no legacy
+    // NLRI field, so every advert is an MP_REACH(AFI=2, SAFI=1); the
+    // next-hop rides in the bucket key attr (`BgpNexthop::Ipv6`).
+    pub cache_ipv6: HashMap<Arc<BgpAttr>, HashMap<Ipv6Nlri, usize>>,
+    pub cache_ipv6_rev: HashMap<Ipv6Nlri, Arc<BgpAttr>>,
+    pub cache_ipv6_timer: Option<Timer>,
 
     /// Snapshot of `Bgp::adv_interval` captured at group creation
     /// (`attach`) and refreshed by the global config callback. Used
@@ -285,6 +295,9 @@ pub fn attach(update_groups: &mut UpdateGroupMap, peers: &mut PeerMap, peer_idx:
                 cache_ipv4: HashMap::new(),
                 cache_ipv4_rev: HashMap::new(),
                 cache_ipv4_timer: None,
+                cache_ipv6: HashMap::new(),
+                cache_ipv6_rev: HashMap::new(),
+                cache_ipv6_timer: None,
                 adv_interval,
             }
         });
@@ -686,6 +699,213 @@ fn encode_ipv4_update(
     out
 }
 
+// ── IPv6 unicast send / cache_remove / flush ──
+//
+// Mirror of the IPv4 block above. IPv6 unicast has no legacy NLRI
+// field, so the encode path is always MP_REACH(AFI=2, SAFI=1) and
+// there is no RFC 8950 ENHE special-case — the next-hop is a native
+// v6 address carried on the bucket-key attr.
+
+/// Bucket the `(nlri, attr, source_ident)` into the group's IPv6
+/// pending-advert cache, kicking the debounce timer if idle.
+pub fn send_ipv6(
+    group: &mut UpdateGroup,
+    nlri: Ipv6Nlri,
+    attr: Arc<BgpAttr>,
+    source_ident: usize,
+    tx: &mpsc::Sender<Message>,
+    kick_timer: bool,
+) {
+    group
+        .cache_ipv6
+        .entry(attr.clone())
+        .or_default()
+        .insert(nlri.clone(), source_ident);
+    group.cache_ipv6_rev.insert(nlri, attr);
+    if kick_timer && group.cache_ipv6_timer.is_none() {
+        let secs = group.adv_interval.secs_for(group.sig.peer_type);
+        group.cache_ipv6_timer = Some(start_adv_timer_ipv6(tx, &group.id, secs));
+    }
+}
+
+/// Remove an NLRI from the group's IPv6 pending-advert cache.
+/// Idempotent; the flush timer keeps running.
+pub fn cache_remove_ipv6(group: &mut UpdateGroup, prefix: ipnet::Ipv6Net, id: u32) {
+    let nlri = Ipv6Nlri { id, prefix };
+    if let Some(attr) = group.cache_ipv6_rev.remove(&nlri)
+        && let Some(bucket) = group.cache_ipv6.get_mut(&attr)
+    {
+        bucket.remove(&nlri);
+        if bucket.is_empty() {
+            group.cache_ipv6.remove(&attr);
+        }
+    }
+}
+
+fn start_adv_timer_ipv6(tx: &mpsc::Sender<Message>, id: &UpdateGroupId, secs: u64) -> Timer {
+    let tx = tx.clone();
+    let id = id.clone();
+    Timer::once(secs, move || {
+        let tx = tx.clone();
+        let id = id.clone();
+        async move {
+            let _ = tx.send(Message::FlushUpdateGroupIpv6(id)).await;
+        }
+    })
+}
+
+/// Drain the IPv6 cache and ship UPDATEs to every member. Called from
+/// `Bgp::serve` on `Message::FlushUpdateGroupIpv6`. Same canonical /
+/// split-horizon-pruned encoding as [`flush_ipv4`], minus the ENHE
+/// per-member next-hop step (v6 unicast next-hops are native and ride
+/// on the bucket-key attr).
+pub fn flush_ipv6(update_groups: &mut UpdateGroupMap, peers: &mut PeerMap, id: &UpdateGroupId) {
+    let afi_safi = AfiSafi::new(Afi::Ip6, Safi::Unicast);
+    let Some(af) = update_groups.get_mut(&afi_safi) else {
+        return;
+    };
+    let Some(group) = af.group_by_id_mut(id) else {
+        return;
+    };
+
+    group.cache_ipv6_timer = None;
+    let buckets: Vec<(Arc<BgpAttr>, Vec<(Ipv6Nlri, usize)>)> = group
+        .cache_ipv6
+        .drain()
+        .map(|(attr, set)| (attr, set.into_iter().collect()))
+        .collect();
+    group.cache_ipv6_rev.clear();
+    if buckets.is_empty() {
+        return;
+    }
+
+    let max_packet_size = if group.sig.extended_message {
+        bgp_packet::BGP_EXTENDED_PACKET_LEN
+    } else {
+        bgp_packet::BGP_PACKET_LEN
+    };
+    let member_idents: Vec<usize> = group.members.iter().copied().collect();
+
+    struct MemberCtx {
+        ident: usize,
+        tx: Option<mpsc::UnboundedSender<bytes::BytesMut>>,
+    }
+    let members: Vec<MemberCtx> = member_idents
+        .iter()
+        .map(|ident| MemberCtx {
+            ident: *ident,
+            tx: peers.get_by_idx(*ident).and_then(|p| p.packet_tx.clone()),
+        })
+        .collect();
+
+    for (attr, entries) in buckets {
+        let source_idents: BTreeSet<usize> = entries.iter().map(|(_, src)| *src).collect();
+        let pruned_members: Vec<usize> = member_idents
+            .iter()
+            .copied()
+            .filter(|m| source_idents.contains(m))
+            .collect();
+
+        // Canonical UPDATE: every NLRI in the bucket, sent to members
+        // that did not source any of them.
+        let canonical: Vec<Ipv6Nlri> = entries.iter().map(|(n, _)| n.clone()).collect();
+        let canonical_bytes = encode_ipv6_update(&attr, &canonical, max_packet_size);
+        let canonical_byte_total: usize = canonical_bytes.iter().map(|b| b.len()).sum();
+        if let Some(group) = af.group_by_id_mut(id) {
+            group.counters.messages_formatted += canonical_bytes.len() as u64;
+            group.counters.bytes_formatted += canonical_byte_total as u64;
+        }
+        for ctx in &members {
+            if pruned_members.contains(&ctx.ident) {
+                continue;
+            }
+            if let Some(tx) = ctx.tx.as_ref() {
+                for bytes in &canonical_bytes {
+                    let _ = tx.send(bytes.clone());
+                }
+                if let Some(group) = af.group_by_id_mut(id) {
+                    group.counters.messages_replicated += canonical_bytes.len() as u64;
+                }
+            }
+        }
+
+        // Per pruned member: the bucket minus its own sourced NLRIs.
+        for prune_ident in pruned_members {
+            let nlris: Vec<Ipv6Nlri> = entries
+                .iter()
+                .filter(|(_, src)| *src != prune_ident)
+                .map(|(n, _)| n.clone())
+                .collect();
+            if nlris.is_empty() {
+                if let Some(group) = af.group_by_id_mut(id) {
+                    group.counters.split_horizon_excluded += 1;
+                }
+                continue;
+            }
+            let pruned_bytes = encode_ipv6_update(&attr, &nlris, max_packet_size);
+            let pruned_byte_total: usize = pruned_bytes.iter().map(|b| b.len()).sum();
+            if let Some(group) = af.group_by_id_mut(id) {
+                group.counters.messages_formatted += pruned_bytes.len() as u64;
+                group.counters.bytes_formatted += pruned_byte_total as u64;
+                group.counters.split_horizon_excluded += 1;
+            }
+            if let Some(tx) = members
+                .iter()
+                .find(|c| c.ident == prune_ident)
+                .and_then(|c| c.tx.as_ref())
+            {
+                for bytes in &pruned_bytes {
+                    let _ = tx.send(bytes.clone());
+                }
+                if let Some(group) = af.group_by_id_mut(id) {
+                    group.counters.messages_replicated += pruned_bytes.len() as u64;
+                }
+            }
+        }
+    }
+}
+
+/// Encode one or more UPDATE PDUs carrying `nlris` under `attr` as
+/// MP_REACH(AFI=2, SAFI=1). The next-hop is read from `attr.nexthop`
+/// (`BgpNexthop::Ipv6`); a non-v6 next-hop degrades to the
+/// unspecified address, which the receiver drops. NLRIs are chunked
+/// so each PDU stays within `max_packet_size`.
+fn encode_ipv6_update(
+    attr: &Arc<BgpAttr>,
+    nlris: &[Ipv6Nlri],
+    max_packet_size: usize,
+) -> Vec<bytes::BytesMut> {
+    if nlris.is_empty() {
+        return Vec::new();
+    }
+    let nhop = match attr.nexthop.as_ref() {
+        Some(BgpNexthop::Ipv6(v6)) => IpAddr::V6(*v6),
+        _ => IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
+    };
+
+    // Chunk by a conservative per-NLRI worst case (4 AddPath + 1 plen
+    // + 16 prefix = 21 octets) against the packet budget minus a fixed
+    // reserve for the BGP header, path attributes, and MP_REACH fixed
+    // fields. Errs toward smaller PDUs rather than risking overflow.
+    let per_nlri_max = 21usize;
+    let reserve = 256usize;
+    let budget = max_packet_size.saturating_sub(reserve).max(per_nlri_max);
+    let chunk = (budget / per_nlri_max).max(1);
+
+    let mut out = Vec::new();
+    for nlri_chunk in nlris.chunks(chunk) {
+        let mut update = UpdatePacket::with_max_packet_size(max_packet_size);
+        update.bgp_attr = Some((**attr).clone());
+        update.mp_update = Some(MpReachAttr::Ipv6 {
+            snpa: 0,
+            nhop,
+            updates: nlri_chunk.to_vec(),
+        });
+        out.push(update.into());
+    }
+    out
+}
+
 /// Build the `Ipv4MpReachNextHop` to advertise to `peer` for an
 /// RFC 8950 IPv4-over-IPv6 UPDATE. Returns `None` when the peer
 /// has no link-local on its egress interface — without a link-local
@@ -812,6 +1032,9 @@ mod tests {
                 cache_ipv4: HashMap::new(),
                 cache_ipv4_rev: HashMap::new(),
                 cache_ipv4_timer: None,
+                cache_ipv6: HashMap::new(),
+                cache_ipv6_rev: HashMap::new(),
+                cache_ipv6_timer: None,
                 adv_interval: AdvInterval::default(),
             },
         );

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -371,6 +371,13 @@ impl BgpVrf {
                     &self.interface_addrs,
                 );
             }
+            Message::FlushUpdateGroupIpv6(group_id) => {
+                super::super::update_group::flush_ipv6(
+                    &mut self.update_groups,
+                    &mut self.peers,
+                    &group_id,
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Layer 2b-ii-b of the VPNv6 leak stack: the daemon now advertises IPv6 unicast to peers, completing the v6 unicast pipeline (2b-i ingest + 2b-ii-a wire encode + this).

- **update_group**: per-group `cache_ipv6`/`_rev`/`_timer` plus `send_ipv6`, `cache_remove_ipv6`, `start_adv_timer_ipv6`, `flush_ipv6`, and `encode_ipv6_update`. Mirrors the v4 advertise machinery (per-attr bucketing, canonical + split-horizon-pruned encoding, debounce timer) minus the RFC 8950 ENHE per-member next-hop step — v6 next-hops are native and ride on the bucket-key attr. `encode_ipv6_update` chunks NLRIs to fit the packet budget and emits MP_REACH(AFI=2, SAFI=1) via the generic `UpdatePacket` encoder.
- **inst.rs / vrf/inst.rs**: `Message::FlushUpdateGroupIpv6` + serve handlers on both the global and per-VRF event loops.
- **route.rs**: `route_update_ipv6` (split-horizon, iBGP-iBGP/RR filter, AS_PATH prepend, v6 next-hop-self from the peer's session-local address, LOCAL_PREF, ORIGINATOR_ID/CLUSTER_LIST), `route_withdraw_ipv6` (per-peer MP_UNREACH), and `route_advertise_to_peers_v6`. Wired from `route_ipv6_update` (reach) and `route_ipv6_withdraw` (withdraw / replacement).

### Deferred for v6 (documented in code)
Outbound policy (policy engine is IPv4-typed), update-group post-policy memoization, and Adj-RIB-Out tracking — so a withdraw is sent to every Established v6 peer even if it never had the route (harmless; peers ignore unknown-prefix withdraws).

## Test plan

- `cargo build --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p zebra-rs bgp::` — 184 passed
- `cargo test -p bgp-packet` — 166 passed

The MP_REACH/UNREACH wire format is covered by the 2b-ii-a round-trip tests; `route_update_ipv6` mirrors the tested v4 builder. End-to-end advertise is best validated on a live peering.

Generated with [Claude Code](https://claude.com/claude-code)