### PR TITLE
bgp: VPNv6 advertise — per-peer cache, flush, next-hop-self

### DIFF
--- a/crates/bgp-packet/src/bgp_attr.rs
+++ b/crates/bgp-packet/src/bgp_attr.rs
@@ -210,6 +210,9 @@ impl fmt::Display for BgpAttr {
                 BgpNexthop::Vpnv4(v) => {
                     writeln!(f, " Nexthop: {}", v)?;
                 }
+                BgpNexthop::Vpnv6(v) => {
+                    writeln!(f, " Nexthop: {}", v)?;
+                }
                 BgpNexthop::Evpn(v) => {
                     writeln!(f, " Nexthop: {}", v)?;
                 }

--- a/crates/bgp-packet/src/bgp_nexthop.rs
+++ b/crates/bgp-packet/src/bgp_nexthop.rs
@@ -1,11 +1,12 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use crate::Vpnv4Nexthop;
+use crate::{Vpnv4Nexthop, Vpnv6Nexthop};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum BgpNexthop {
     Ipv4(Ipv4Addr),
     Ipv6(Ipv6Addr),
     Vpnv4(Vpnv4Nexthop),
+    Vpnv6(Vpnv6Nexthop),
     Evpn(IpAddr),
 }

--- a/crates/bgp-packet/src/update.rs
+++ b/crates/bgp-packet/src/update.rs
@@ -308,6 +308,41 @@ impl UpdatePacket {
         Some(buf.get())
     }
 
+    pub fn pop_vpnv6(&mut self) -> Option<BytesMut> {
+        match &self.mp_update {
+            Some(MpReachAttr::Vpnv6(vpnv6)) if !vpnv6.updates.is_empty() => {}
+            _ => return None,
+        }
+        let mp_update = self.mp_update.as_mut().unwrap();
+
+        let mut buf = FixedBuf::new(self.max_packet_size);
+        let header: BytesMut = self.header.clone().into();
+        let _ = buf.put(&header[..]);
+
+        // No legacy IPv4 withdraw on a VPNv6 UPDATE.
+        let _ = buf.put_u16(0u16);
+
+        // Attributes length placeholder.
+        let attr_len_pos = buf.len();
+        let _ = buf.put_u16(0u16);
+
+        if let Some(bgp_attr) = &self.bgp_attr {
+            bgp_attr.attr_emit(buf.get_mut());
+        }
+
+        // MP reach (dispatches to Vpnv6Reach::attr_emit_mut, which
+        // paginates the NLRI list across calls).
+        mp_update.attr_emit_mut(buf.get_mut(), self.max_packet_size);
+
+        let attr_len: u16 = (buf.len() - attr_len_pos - 2) as u16;
+        let _ = buf.put_u16_at(attr_len_pos, attr_len);
+
+        let length: u16 = buf.len() as u16;
+        let _ = buf.put_u16_at(16, length);
+
+        Some(buf.get())
+    }
+
     pub fn pop_vpnv4(&mut self) -> Option<BytesMut> {
         match &self.mp_update {
             Some(MpReachAttr::Vpnv4(vpnv4)) if !vpnv4.updates.is_empty() => {}

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -116,6 +116,7 @@ pub enum Event {
     RouteRefreshMsg(u16, u8),
     StaleTimerExipires(AfiSafi),
     AdvTimerVpnv4Expires,
+    AdvTimerVpnv6Expires,
     AdvTimerEvpnExpires,
 }
 
@@ -424,6 +425,11 @@ pub struct Peer {
     pub first_start: bool,
     pub cache_vpnv4: HashMap<Arc<BgpAttr>, HashSet<Vpnv4Nlri>>,
     pub cache_vpnv4_rev: HashMap<Vpnv4Nlri, Arc<BgpAttr>>,
+    /// VPNv6 advertise cache — same per-attribute batching shape as
+    /// `cache_vpnv4`.
+    pub cache_vpnv6: HashMap<Arc<BgpAttr>, HashSet<Vpnv6Nlri>>,
+    pub cache_vpnv6_rev: HashMap<Vpnv6Nlri, Arc<BgpAttr>>,
+    pub cache_vpnv6_timer: Option<Timer>,
     /// EVPN advertise cache. Mirrors `cache_vpnv4` shape — NLRIs
     /// grouped by attribute so a single MP_REACH UPDATE on flush can
     /// carry every route that shares one attr set. Withdraw path uses
@@ -506,6 +512,9 @@ impl Peer {
             first_start: true,
             cache_vpnv4: HashMap::default(),
             cache_vpnv4_rev: HashMap::default(),
+            cache_vpnv6: HashMap::default(),
+            cache_vpnv6_rev: HashMap::default(),
+            cache_vpnv6_timer: None,
             cache_evpn: HashMap::default(),
             cache_evpn_rev: HashMap::default(),
             cache_vpnv4_timer: None,
@@ -698,6 +707,7 @@ pub fn fsm_next_state(peer: &mut Peer, event: Event) -> (State, FsmEffect) {
             (peer.state, FsmEffect::StaleExpire(afi_safi))
         }
         Event::AdvTimerVpnv4Expires => (fsm_adv_timer_vpnv4_expires(peer), FsmEffect::None),
+        Event::AdvTimerVpnv6Expires => (fsm_adv_timer_vpnv6_expires(peer), FsmEffect::None),
         Event::AdvTimerEvpnExpires => (fsm_adv_timer_evpn_expires(peer), FsmEffect::None),
     }
 }
@@ -772,6 +782,12 @@ pub fn fsm(bgp_ref: &mut BgpTop, peer_map: &mut PeerMap, id: usize, event: Event
 pub fn fsm_adv_timer_vpnv4_expires(peer: &mut Peer) -> State {
     peer.cache_vpnv4_timer = None;
     peer.flush_vpnv4();
+    State::Established
+}
+
+pub fn fsm_adv_timer_vpnv6_expires(peer: &mut Peer) -> State {
+    peer.cache_vpnv6_timer = None;
+    peer.flush_vpnv6();
     State::Established
 }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -15,7 +15,7 @@ use crate::rib::{self, MacAddr, api::FdbEntry};
 use super::cap::CapAfiMap;
 use super::peer::{BgpTop, Event, Peer, PeerType};
 use super::peer_map::PeerMap;
-use super::timer::start_adv_timer_vpnv4;
+use super::timer::{start_adv_timer_vpnv4, start_adv_timer_vpnv6};
 use super::{Bgp, InOut, Message};
 
 pub const ORIGINATED_PEER: usize = usize::MAX;
@@ -773,6 +773,14 @@ impl LocalRib {
         ident: usize,
     ) -> Vec<BgpRib> {
         self.v6vpn.entry(rd).or_default().remove(prefix, id, ident)
+    }
+
+    pub fn select_best_path_vpn_v6(
+        &mut self,
+        rd: &RouteDistinguisher,
+        prefix: Ipv6Net,
+    ) -> Vec<BgpRib> {
+        self.v6vpn.entry(*rd).or_default().select_best_path(prefix)
     }
 
     // EVPN dispatch ----------------------------------------------------------
@@ -2156,13 +2164,20 @@ pub fn route_ipv6_update(
         None => bgp.local_rib.update_v6(nlri.prefix, rib),
     };
 
-    // Plain v6 unicast → kernel FIB + peer advertisement. VPNv6 lives
-    // in `local_rib.v6vpn` with a deferred install/advertise path
-    // (layer 2c-ii) — skip both for `rd == Some`.
-    if rd.is_none() {
-        fib_install_v6(bgp, nlri.prefix, &selected);
-        if !selected.is_empty() {
-            route_advertise_to_peers_v6(nlri.prefix, &selected, bgp, peers);
+    match rd {
+        // Plain v6 unicast → kernel FIB + peer advertisement.
+        None => {
+            fib_install_v6(bgp, nlri.prefix, &selected);
+            if !selected.is_empty() {
+                route_advertise_to_peers_v6(nlri.prefix, &selected, bgp, peers);
+            }
+        }
+        // VPNv6 → advertise the winner to PE peers. No kernel FIB here
+        // (mirrors VPNv4, which keeps its v4vpn rows out of the FIB).
+        Some(rd) => {
+            if !selected.is_empty() {
+                route_advertise_to_peers_vpnv6(rd, nlri.prefix, &selected, bgp, peers);
+            }
         }
     }
 }
@@ -2190,6 +2205,10 @@ pub fn route_ipv6_withdraw(
     match rd {
         Some(rd) => {
             let _ = bgp.local_rib.remove_v6vpn(rd, nlri.prefix, nlri.id, ident);
+            let selected = bgp.local_rib.select_best_path_vpn_v6(&rd, nlri.prefix);
+            // Empty `selected` → MP_UNREACH to PE peers; a replacement
+            // winner → re-advertise. Both handled by the helper.
+            route_advertise_to_peers_vpnv6(rd, nlri.prefix, &selected, bgp, peers);
         }
         None => {
             let _ = bgp.local_rib.remove_v6(nlri.prefix, nlri.id, ident);
@@ -3302,7 +3321,16 @@ pub fn route_update_ipv6(
         && let Some(ref local_addr) = peer.param.local_addr
         && let IpAddr::V6(local_v6) = local_addr.ip()
     {
-        attrs.nexthop = Some(BgpNexthop::Ipv6(local_v6));
+        // VPNv6 rows carry a `VpnNexthop::V6` (the route's RD); emit a
+        // VPNv6-shaped next-hop so `flush_vpnv6` picks it up. Plain
+        // v6-unicast rows get a bare IPv6 next-hop.
+        attrs.nexthop = match rib.nexthop {
+            Some(VpnNexthop::V6(ref v6nh)) => Some(BgpNexthop::Vpnv6(Vpnv6Nexthop {
+                rd: v6nh.rd,
+                nhop: local_v6,
+            })),
+            _ => Some(BgpNexthop::Ipv6(local_v6)),
+        };
     }
 
     // LOCAL_PREF for iBGP.
@@ -3401,6 +3429,79 @@ pub(super) fn route_advertise_to_peers_v6(
                     super::update_group::cache_remove_ipv6(group, prefix, 0);
                 }
                 route_withdraw_ipv6(peer, prefix, 0);
+            }
+        }
+    }
+}
+
+/// Per-peer VPNv6 withdraw — emit an MP_UNREACH(AFI=2, SAFI=128) for
+/// `(rd, prefix)`. The v6 counterpart of the VPNv4 withdraw arm of
+/// [`route_withdraw_ipv4`].
+fn route_withdraw_vpnv6(peer: &mut Peer, rd: RouteDistinguisher, prefix: Ipv6Net, id: u32) {
+    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    let vpnv6_nlri = Vpnv6Nlri {
+        label: Label::default(),
+        rd,
+        nlri: Ipv6Nlri { id, prefix },
+    };
+    update.mp_withdraw = Some(MpUnreachAttr::Vpnv6(vec![vpnv6_nlri]));
+    peer.send_packet(update.into());
+}
+
+/// VPNv6 advertise — the v6 counterpart of the `rd.is_some()` branch
+/// of [`route_advertise_to_peers`]. Reach winners are batched into the
+/// per-peer `cache_vpnv6` (flushed via the VPNv6 adv timer); a `None`
+/// best-path emits an immediate MP_UNREACH. The next-hop-self rewrite
+/// to `BgpNexthop::Vpnv6` happens in [`route_update_ipv6`].
+///
+/// Like the v6-unicast advertise, the update-group memoization,
+/// Adj-RIB-Out tracking, and outbound policy of the v4 path are
+/// deferred for v6.
+pub(super) fn route_advertise_to_peers_vpnv6(
+    rd: RouteDistinguisher,
+    prefix: Ipv6Net,
+    selected: &[BgpRib],
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+) {
+    let new_best = selected.last();
+    let (afi, safi) = (Afi::Ip6, Safi::MplsVpn);
+
+    let peer_addrs: Vec<IpAddr> = peers
+        .iter()
+        .filter(|(_, p)| p.state.is_established())
+        .filter(|(_, p)| p.is_afi_safi(afi, safi))
+        .map(|(addr, _)| *addr)
+        .collect();
+
+    for peer_addr in peer_addrs {
+        let peer = peers.get_mut(&peer_addr).expect("peer exists");
+        match new_best {
+            Some(best) if best.ident != peer.ident => {
+                let add_path = peer.opt.is_add_path_send(afi, safi);
+                let Some((nlri, attr)) = route_update_ipv6(peer, &prefix, best, bgp, add_path)
+                else {
+                    continue;
+                };
+                let attr = bgp.attr_store.intern(attr);
+                // RTC: skip without withdrawing when the peer's
+                // route-target constraint set doesn't admit this route.
+                if !peer.rtcv4.is_empty() && !rtc_match(&peer.rtcv4, &attr.ecom) {
+                    continue;
+                }
+                let vpnv6_nlri = Vpnv6Nlri {
+                    label: best.label.unwrap_or_default(),
+                    rd,
+                    nlri,
+                };
+                peer.send_vpnv6(vpnv6_nlri, attr, true);
+            }
+            Some(_) => {
+                // Split-horizon: the source peer receives nothing.
+            }
+            None => {
+                peer.cache_remove_vpnv6(rd, prefix, 0);
+                route_withdraw_vpnv6(peer, rd, prefix, 0);
             }
         }
     }
@@ -3516,6 +3617,60 @@ impl Peer {
             }
         }
         self.cache_vpnv4_rev.clear();
+    }
+
+    // VPNv6 advertise cache — mirror of the VPNv4 trio above.
+
+    pub fn send_vpnv6(&mut self, nlri: Vpnv6Nlri, attr: Arc<BgpAttr>, timer: bool) {
+        self.cache_vpnv6
+            .entry(attr.clone())
+            .or_default()
+            .insert(nlri.clone());
+        self.cache_vpnv6_rev.insert(nlri, attr);
+        if timer && self.cache_vpnv6_timer.is_none() {
+            self.cache_vpnv6_timer = Some(start_adv_timer_vpnv6(self));
+        }
+    }
+
+    pub fn cache_remove_vpnv6(&mut self, rd: RouteDistinguisher, prefix: Ipv6Net, id: u32) {
+        let nlri = Vpnv6Nlri {
+            label: Label::default(),
+            rd,
+            nlri: Ipv6Nlri { id, prefix },
+        };
+        if let Some(attr) = self.cache_vpnv6_rev.remove(&nlri)
+            && let Some(set) = self.cache_vpnv6.get_mut(&attr)
+        {
+            set.remove(&nlri);
+            if set.is_empty() {
+                self.cache_vpnv6.remove(&attr);
+            }
+        }
+    }
+
+    pub fn flush_vpnv6(&mut self) {
+        let packet_tx = self.packet_tx.clone();
+        let max_size = self.max_packet_size();
+        for (attr, nlris) in self.cache_vpnv6.drain() {
+            let mut update = UpdatePacket::with_max_packet_size(max_size);
+
+            if let Some(BgpNexthop::Vpnv6(nhop)) = attr.nexthop.as_ref() {
+                let vpnv6reach = Vpnv6Reach {
+                    snpa: 0,
+                    nhop: nhop.clone(),
+                    updates: nlris.into_iter().collect(),
+                };
+                update.mp_update = Some(MpReachAttr::Vpnv6(vpnv6reach));
+            }
+            update.bgp_attr = Some((*attr).clone());
+
+            while let Some(bytes) = update.pop_vpnv6() {
+                if let Some(ref tx) = packet_tx {
+                    let _ = tx.send(bytes);
+                }
+            }
+        }
+        self.cache_vpnv6_rev.clear();
     }
 }
 

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -283,6 +283,7 @@ fn show_nexthop(attr: &BgpAttr) -> String {
             BgpNexthop::Ipv4(v) => v.to_string(),
             BgpNexthop::Ipv6(v) => v.to_string(),
             BgpNexthop::Vpnv4(v) => v.to_string(),
+            BgpNexthop::Vpnv6(v) => v.to_string(),
             BgpNexthop::Evpn(v) => v.to_string(),
         }
     } else {

--- a/zebra-rs/src/bgp/timer.rs
+++ b/zebra-rs/src/bgp/timer.rs
@@ -138,6 +138,11 @@ pub fn start_adv_timer_vpnv4(peer: &Peer) -> Timer {
     start_timer!(peer, secs, Event::AdvTimerVpnv4Expires)
 }
 
+pub fn start_adv_timer_vpnv6(peer: &Peer) -> Timer {
+    let secs = peer.adv_interval.secs_for(peer.peer_type);
+    start_timer!(peer, secs, Event::AdvTimerVpnv6Expires)
+}
+
 /// EVPN advertise debounce — same iBGP/eBGP cadence as the IPv4 /
 /// VPNv4 timers. Buffers a burst of FDB learns into one MP_REACH
 /// UPDATE per attribute group.


### PR DESCRIPTION
## Summary

Layer 2c-ii of the VPNv6 leak stack: the daemon now advertises VPNv6 to PE peers, completing the VPNv6 RIB (2c-i receive/store + this). A v6vpn best-path winner is batched per-peer and shipped as MP_REACH(AFI=2, SAFI=128).

- **bgp-packet**: `BgpNexthop::Vpnv6(Vpnv6Nexthop)` variant (+ Display / show arms) and `UpdatePacket::pop_vpnv6` (mirror of `pop_vpnv4`; dispatches to `Vpnv6Reach::attr_emit_mut` from the codec PR for NLRI pagination).
- **peer.rs / timer.rs**: `cache_vpnv6`/`_rev`/`_timer`, `Event::AdvTimerVpnv6Expires` + `fsm_adv_timer_vpnv6_expires`, `start_adv_timer_vpnv6` — the same debounce-flush shape as VPNv4.
- **route.rs**: `Peer::send_vpnv6`/`cache_remove_vpnv6`/`flush_vpnv6`; the VPNv6 next-hop-self branch in `route_update_ipv6` (`BgpNexthop::Vpnv6{rd, session-local v6}`); `route_withdraw_vpnv6` (MP_UNREACH) and `route_advertise_to_peers_vpnv6`, wired from the `rd == Some` arms of `route_ipv6_update` / `route_ipv6_withdraw`. RTC filtering is applied; VPNv6 stays out of the kernel FIB (mirrors VPNv4).

### Deferred for v6 (documented)
Outbound policy, update-group memoization, and Adj-RIB-Out tracking — consistent with the v6-unicast advertise path.

## Test plan

- `cargo build --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p zebra-rs bgp::` — 184 passed
- `cargo test -p bgp-packet` — 166 passed

The VPNv6 wire format is covered by the codec PR's round-trips; the advertise path mirrors the tested VPNv4 path and is best validated on a live PE-PE peering.

Generated with [Claude Code](https://claude.com/claude-code)