### PR TITLE
bgp: VRF v6 export to global VPNv6 (layer 3a)

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1668,6 +1668,137 @@ impl Bgp {
                     "bgp: export withdrawn from LocalRib.v4vpn and PE peers",
                 );
             }
+            super::vrf::BgpGlobalMsg::ExportV6 {
+                vrf,
+                prefix,
+                attr,
+                label,
+            } => {
+                let Some(rd) = self.vrfs.get(&vrf).and_then(|cfg| cfg.rd) else {
+                    tracing::warn!(
+                        vrf = %vrf,
+                        %prefix,
+                        "bgp: v6 export dropped — VRF has no RD configured",
+                    );
+                    return;
+                };
+                let export_rts = self
+                    .rib_known_vrfs
+                    .get(&vrf)
+                    .map(|k| k.export_rts_v6.clone())
+                    .unwrap_or_default();
+
+                let tagged = tag_attr_with_export_rts(attr, &export_rts);
+                let interned = self.attr_store.intern(tagged);
+
+                let label_obj = if label != 0 {
+                    Some(bgp_packet::Label {
+                        label,
+                        exp: 0,
+                        bos: true,
+                    })
+                } else {
+                    None
+                };
+
+                // The on-wire next-hop is rewritten per-peer in
+                // `route_update_ipv6`; only the RD carried here matters,
+                // so the address is a placeholder.
+                let nexthop = bgp_packet::Vpnv6Nexthop {
+                    rd,
+                    nhop: std::net::Ipv6Addr::UNSPECIFIED,
+                };
+
+                let rib = super::route::BgpRib {
+                    remote_id: 0,
+                    local_id: 0,
+                    attr: interned,
+                    ident: 0,
+                    router_id: self.router_id,
+                    weight: 0,
+                    typ: super::route::BgpRibType::Originated,
+                    best_path: false,
+                    best_reason: super::route::Reason::Default,
+                    label: label_obj,
+                    nexthop: Some(super::route::VpnNexthop::V6(nexthop)),
+                    egress_ifindex_v6: None,
+                    stale: false,
+                    esi: None,
+                };
+
+                let (_, selected, _gen) = self.local_rib.update_v6vpn(rd, prefix, rib);
+                let winners = selected.len();
+
+                // NB: the local intra-router leak (fan-out into sibling
+                // VRFs whose import_rts_v6 match) is layer 3b. This
+                // handler only stores the row and advertises to PE.
+                let mut top = super::peer::BgpTop {
+                    router_id: &self.router_id,
+                    local_rib: &mut self.local_rib,
+                    tx: &self.tx,
+                    rib_client: &self.ctx.rib,
+                    attr_store: &mut self.attr_store,
+                    update_groups: &mut self.update_groups,
+                    interface_addrs: &self.interface_addrs,
+                    color_policy: Some(&self.color_policy),
+                    flex_algo_routes: Some(&self.flex_algo_routes),
+                    vrf_export: None,
+                    vrf_import: None,
+                };
+                super::route::route_advertise_to_peers_vpnv6(
+                    rd,
+                    prefix,
+                    &selected,
+                    &mut top,
+                    &mut self.peers,
+                );
+
+                tracing::info!(
+                    vrf = %vrf,
+                    %prefix,
+                    rd = %rd,
+                    export_rts = export_rts.len(),
+                    label,
+                    winners,
+                    "bgp: v6 export written to LocalRib.v6vpn and advertised to PE peers",
+                );
+            }
+            super::vrf::BgpGlobalMsg::WithdrawExportV6 { vrf, prefix } => {
+                let Some(rd) = self.vrfs.get(&vrf).and_then(|cfg| cfg.rd) else {
+                    return;
+                };
+                let _removed = self.local_rib.remove_v6vpn(rd, prefix, 0, 0);
+                let selected = self.local_rib.select_best_path_vpn_v6(&rd, prefix);
+
+                let mut top = super::peer::BgpTop {
+                    router_id: &self.router_id,
+                    local_rib: &mut self.local_rib,
+                    tx: &self.tx,
+                    rib_client: &self.ctx.rib,
+                    attr_store: &mut self.attr_store,
+                    update_groups: &mut self.update_groups,
+                    interface_addrs: &self.interface_addrs,
+                    color_policy: Some(&self.color_policy),
+                    flex_algo_routes: Some(&self.flex_algo_routes),
+                    vrf_export: None,
+                    vrf_import: None,
+                };
+                super::route::route_advertise_to_peers_vpnv6(
+                    rd,
+                    prefix,
+                    &selected,
+                    &mut top,
+                    &mut self.peers,
+                );
+
+                tracing::info!(
+                    vrf = %vrf,
+                    %prefix,
+                    rd = %rd,
+                    winners = selected.len(),
+                    "bgp: v6 export withdrawn from LocalRib.v6vpn and PE peers",
+                );
+            }
             super::vrf::BgpGlobalMsg::RegisterPeer { vrf, addr } => {
                 peer_index_register(&mut self.peer_index, vrf, addr);
             }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2168,6 +2168,19 @@ pub fn route_ipv6_update(
         // Plain v6 unicast → kernel FIB + peer advertisement.
         None => {
             fib_install_v6(bgp, nlri.prefix, &selected);
+
+            // Per-VRF best-path → global VPNv6 export. Fires only
+            // inside a VRF task (`vrf_export` is Some); the global
+            // task's BgpTop has `vrf_export = None`. Empty `selected`
+            // → WithdrawExportV6 so the global v6vpn row is dropped.
+            if let Some(exporter) = bgp.vrf_export {
+                if let Some(winner) = selected.first() {
+                    super::vrf::vrf_emit_export_v6(exporter, nlri.prefix, &winner.attr);
+                } else {
+                    super::vrf::vrf_emit_withdraw_v6(exporter, nlri.prefix);
+                }
+            }
+
             if !selected.is_empty() {
                 route_advertise_to_peers_v6(nlri.prefix, &selected, bgp, peers);
             }
@@ -2214,6 +2227,17 @@ pub fn route_ipv6_withdraw(
             let _ = bgp.local_rib.remove_v6(nlri.prefix, nlri.id, ident);
             let selected = bgp.local_rib.select_best_path_v6(nlri.prefix);
             fib_install_v6(bgp, nlri.prefix, &selected);
+
+            // VRF export, symmetric with route_ipv6_update: a
+            // replacement winner re-exports; an empty result withdraws.
+            if let Some(exporter) = bgp.vrf_export {
+                if let Some(winner) = selected.first() {
+                    super::vrf::vrf_emit_export_v6(exporter, nlri.prefix, &winner.attr);
+                } else {
+                    super::vrf::vrf_emit_withdraw_v6(exporter, nlri.prefix);
+                }
+            }
+
             // Empty `selected` → withdraw to peers; a replacement
             // winner → re-advertise. Both handled by the helper.
             route_advertise_to_peers_v6(nlri.prefix, &selected, bgp, peers);

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -154,6 +154,30 @@ pub fn vrf_emit_withdraw(exporter: &VrfExporter, prefix: ipnet::Ipv4Net) {
     });
 }
 
+/// VPNv6 counterpart of [`vrf_emit_export`] — push a per-VRF IPv6
+/// unicast best-path winner up to the global task as a VPNv6 export
+/// candidate.
+pub fn vrf_emit_export_v6(
+    exporter: &VrfExporter,
+    prefix: ipnet::Ipv6Net,
+    attr: &bgp_packet::BgpAttr,
+) {
+    let _ = exporter.tx.send(BgpGlobalMsg::ExportV6 {
+        vrf: exporter.name.clone(),
+        prefix,
+        attr: attr.clone(),
+        label: exporter.label,
+    });
+}
+
+/// VPNv6 counterpart of [`vrf_emit_withdraw`].
+pub fn vrf_emit_withdraw_v6(exporter: &VrfExporter, prefix: ipnet::Ipv6Net) {
+    let _ = exporter.tx.send(BgpGlobalMsg::WithdrawExportV6 {
+        vrf: exporter.name.clone(),
+        prefix,
+    });
+}
+
 /// Inverse of [`VrfExporter`] — references the global Bgp state
 /// the shared `route_ipv4_update` path needs to fan a VPNv4
 /// route out to every importing VRF task.

--- a/zebra-rs/src/bgp/vrf/mod.rs
+++ b/zebra-rs/src/bgp/vrf/mod.rs
@@ -24,7 +24,7 @@ pub use label::VrfLabelAllocator;
 // inside `vrf::spawn` only.
 pub use inst::{
     VrfExporter, VrfImportDispatcher, dispatch_import_v4, dispatch_withdraw_import_v4,
-    vrf_emit_export, vrf_emit_withdraw,
+    vrf_emit_export, vrf_emit_export_v6, vrf_emit_withdraw, vrf_emit_withdraw_v6,
 };
 pub use msg::BgpGlobalMsg;
 pub use spawn::{BgpVrfHandle, compute_vrf_diff, despawn_bgp_vrf, spawn_bgp_vrf};

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -13,7 +13,7 @@
 
 use std::net::SocketAddr;
 
-use ipnet::Ipv4Net;
+use ipnet::{Ipv4Net, Ipv6Net};
 use tokio::net::TcpStream;
 
 use bgp_packet::{BgpAttr, RouteDistinguisher};
@@ -84,6 +84,19 @@ pub enum BgpGlobalMsg {
     /// the VPNv4 advertisement matching this VRF's RD and the
     /// given prefix.
     WithdrawExport { vrf: String, prefix: Ipv4Net },
+
+    /// VPNv6 counterpart of [`Self::Export`] — an IPv6 unicast
+    /// best-path winner in this VRF that the global task re-emits as
+    /// VPNv6 (and, once 3b lands, leaks into sibling VRFs).
+    ExportV6 {
+        vrf: String,
+        prefix: Ipv6Net,
+        attr: BgpAttr,
+        label: u32,
+    },
+
+    /// Inverse of [`Self::ExportV6`].
+    WithdrawExportV6 { vrf: String, prefix: Ipv6Net },
 
     /// Register a peer IP with the global accept dispatcher so an
     /// inbound `:179` connect from that IP is handed to this VRF


### PR DESCRIPTION
## Summary

First half of the VPNv6 leak: a per-VRF IPv6 unicast best-path winner is now exported up to the global instance, stamped with the VRF's RD + export-RTs, stored in the global v6vpn Loc-RIB, and advertised to PE peers as VPNv6. This is the v6 analog of the pre-existing VPNv4 export path.

- **vrf/msg.rs**: `BgpGlobalMsg::ExportV6` / `WithdrawExportV6`.
- **vrf/inst.rs**: `vrf_emit_export_v6` / `vrf_emit_withdraw_v6` (re-exported from the vrf module).
- **route.rs**: the `vrf_export` v6 hook in `route_ipv6_update` / `route_ipv6_withdraw` (unicast branch) — fires only inside a VRF task, pushing the CE-learned v6 winner (or a withdraw) to global.
- **inst.rs**: `process_vrf_global_msg::ExportV6` / `WithdrawExportV6` handlers — tag `export_rts_v6`, store via `update_v6vpn`, advertise to PE via `route_advertise_to_peers_vpnv6`. The on-wire next-hop is rewritten per-peer in `route_update_ipv6`, so the stored `Vpnv6Nexthop` is an RD-only placeholder.

The local intra-router leak (fan-out into sibling VRFs whose `import_rts_v6` match, with the originating-VRF skip) is layer 3b — this handler deliberately stores + PE-advertises only.

## Test plan

- `cargo build --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p zebra-rs bgp::` — 184 passed

Generated with [Claude Code](https://claude.com/claude-code)