### PR TITLE
bgp: VPNv6 leak — import + local intra-router leak (3b)

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -123,14 +123,44 @@ pub(crate) fn matching_import_vrfs(
     vrf_index: &BTreeMap<String, RibKnownVrf>,
     ecom: &Option<bgp_packet::ExtCommunity>,
 ) -> Vec<String> {
-    let Some(ecom) = ecom else {
+    let route_rts = route_rts_from_ecom(ecom);
+    if route_rts.is_empty() {
         return Vec::new();
+    }
+    vrf_index
+        .iter()
+        .filter(|(_, info)| !info.import_rts_v4.is_disjoint(&route_rts))
+        .map(|(name, _)| name.clone())
+        .collect()
+}
+
+/// VPNv6 counterpart of [`matching_import_vrfs`] — intersects against
+/// each VRF's `import_rts_v6` instead of `import_rts_v4`.
+pub(crate) fn matching_import_vrfs_v6(
+    vrf_index: &BTreeMap<String, RibKnownVrf>,
+    ecom: &Option<bgp_packet::ExtCommunity>,
+) -> Vec<String> {
+    let route_rts = route_rts_from_ecom(ecom);
+    if route_rts.is_empty() {
+        return Vec::new();
+    }
+    vrf_index
+        .iter()
+        .filter(|(_, info)| !info.import_rts_v6.is_disjoint(&route_rts))
+        .map(|(name, _)| name.clone())
+        .collect()
+}
+
+/// Extract the route-target set a route carries: every extended
+/// community with RT sub-type (`low_type == 0x02`), reinterpreted as a
+/// `RouteDistinguisher` (RT and RD share the on-wire 6-octet shape).
+fn route_rts_from_ecom(
+    ecom: &Option<bgp_packet::ExtCommunity>,
+) -> std::collections::BTreeSet<bgp_packet::RouteDistinguisher> {
+    let Some(ecom) = ecom else {
+        return std::collections::BTreeSet::new();
     };
-    // Build the set of RTs the route carries: every extcomm with
-    // RT sub-type, reinterpreted as a `RouteDistinguisher` (RT and
-    // RD share the on-wire 6-octet shape).
-    let route_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher> = ecom
-        .0
+    ecom.0
         .iter()
         .filter(|v| v.low_type == 0x02)
         .map(|v| {
@@ -150,14 +180,6 @@ pub(crate) fn matching_import_vrfs(
             rd.val = v.val;
             rd
         })
-        .collect();
-    if route_rts.is_empty() {
-        return Vec::new();
-    }
-    vrf_index
-        .iter()
-        .filter(|(_, info)| !info.import_rts_v4.is_disjoint(&route_rts))
-        .map(|(name, _)| name.clone())
         .collect()
 }
 
@@ -174,6 +196,18 @@ pub(crate) fn import_targets(
     skip_vrf: Option<&str>,
 ) -> Vec<String> {
     matching_import_vrfs(vrf_index, ecom)
+        .into_iter()
+        .filter(|name| Some(name.as_str()) != skip_vrf)
+        .collect()
+}
+
+/// VPNv6 counterpart of [`import_targets`].
+pub(crate) fn import_targets_v6(
+    vrf_index: &BTreeMap<String, RibKnownVrf>,
+    ecom: &Option<bgp_packet::ExtCommunity>,
+    skip_vrf: Option<&str>,
+) -> Vec<String> {
+    matching_import_vrfs_v6(vrf_index, ecom)
         .into_iter()
         .filter(|name| Some(name.as_str()) != skip_vrf)
         .collect()
@@ -1729,9 +1763,27 @@ impl Bgp {
                 let (_, selected, _gen) = self.local_rib.update_v6vpn(rd, prefix, rib);
                 let winners = selected.len();
 
-                // NB: the local intra-router leak (fan-out into sibling
-                // VRFs whose import_rts_v6 match) is layer 3b. This
-                // handler only stores the row and advertises to PE.
+                // Local intra-router leak — the v6 analog of the VPNv4
+                // Export handler. The direct `update_v6vpn` above
+                // bypasses the `route_ipv6_update` import hook, so fan
+                // the winner into every sibling VRF whose import_rts_v6
+                // match, skipping the originating VRF (so `rt both`
+                // doesn't re-import what it just exported).
+                if let Some(winner) = selected.first() {
+                    let dispatcher = super::vrf::VrfImportDispatcher {
+                        rib_known_vrfs: &self.rib_known_vrfs,
+                        vrf_registry: &self.vrf_registry,
+                    };
+                    super::vrf::dispatch_import_v6(
+                        &dispatcher,
+                        rd,
+                        prefix,
+                        &winner.attr,
+                        0,
+                        Some(vrf.as_str()),
+                    );
+                }
+
                 let mut top = super::peer::BgpTop {
                     router_id: &self.router_id,
                     local_rib: &mut self.local_rib,
@@ -1767,8 +1819,37 @@ impl Bgp {
                 let Some(rd) = self.vrfs.get(&vrf).and_then(|cfg| cfg.rd) else {
                     return;
                 };
-                let _removed = self.local_rib.remove_v6vpn(rd, prefix, 0, 0);
+                let removed = self.local_rib.remove_v6vpn(rd, prefix, 0, 0);
                 let selected = self.local_rib.select_best_path_vpn_v6(&rd, prefix);
+
+                // Local intra-router leak, symmetric with the ExportV6
+                // handler: a surviving winner re-imports into sibling
+                // VRFs; otherwise flood a withdraw from the removed
+                // row's RTs. Skip the originating VRF.
+                {
+                    let dispatcher = super::vrf::VrfImportDispatcher {
+                        rib_known_vrfs: &self.rib_known_vrfs,
+                        vrf_registry: &self.vrf_registry,
+                    };
+                    if let Some(winner) = selected.first() {
+                        super::vrf::dispatch_import_v6(
+                            &dispatcher,
+                            rd,
+                            prefix,
+                            &winner.attr,
+                            0,
+                            Some(vrf.as_str()),
+                        );
+                    } else if let Some(gone) = removed.first() {
+                        super::vrf::dispatch_withdraw_import_v6(
+                            &dispatcher,
+                            rd,
+                            prefix,
+                            &gone.attr,
+                            Some(vrf.as_str()),
+                        );
+                    }
+                }
 
                 let mut top = super::peer::BgpTop {
                     router_id: &self.router_id,
@@ -2025,7 +2106,10 @@ mod tests {
 
         use bgp_packet::{ExtCommunity, ExtCommunityValue, RouteDistinguisher};
 
-        use super::super::{RibKnownVrf, import_targets, matching_import_vrfs};
+        use super::super::{
+            RibKnownVrf, import_targets, import_targets_v6, matching_import_vrfs,
+            matching_import_vrfs_v6,
+        };
 
         fn rt(s: &str) -> RouteDistinguisher {
             RouteDistinguisher::from_str(s).unwrap()
@@ -2048,6 +2132,21 @@ mod tests {
                 import_rts_v4,
                 export_rts_v4: BTreeSet::new(),
                 import_rts_v6: BTreeSet::new(),
+                export_rts_v6: BTreeSet::new(),
+            }
+        }
+
+        fn vrf_with_imports_v6(rts: &[&str]) -> RibKnownVrf {
+            let mut import_rts_v6 = BTreeSet::new();
+            for s in rts {
+                import_rts_v6.insert(rt(s));
+            }
+            RibKnownVrf {
+                table_id: 100,
+                ifindex: 1,
+                import_rts_v4: BTreeSet::new(),
+                export_rts_v4: BTreeSet::new(),
+                import_rts_v6,
                 export_rts_v6: BTreeSet::new(),
             }
         }
@@ -2139,6 +2238,42 @@ mod tests {
             index.insert("v1".to_string(), vrf_with_imports(&["65000:1"]));
             let ecom = Some(ExtCommunity(vec![origin]));
             assert!(matching_import_vrfs(&index, &ecom).is_empty());
+        }
+
+        #[test]
+        fn v6_matching_uses_import_rts_v6() {
+            // The v6 matcher consults `import_rts_v6`, independent of
+            // the v4 set: a route with RT 65000:9 matches the VRF that
+            // imports it under v6, not one that imports it under v4.
+            let mut index = BTreeMap::new();
+            index.insert("v4only".to_string(), vrf_with_imports(&["65000:9"]));
+            index.insert("v6only".to_string(), vrf_with_imports_v6(&["65000:9"]));
+            let ecom = Some(ExtCommunity(vec![rt_extcom("65000:9")]));
+
+            assert_eq!(
+                matching_import_vrfs_v6(&index, &ecom),
+                vec!["v6only".to_string()]
+            );
+            // And the v4 matcher sees only the v4-importing VRF.
+            assert_eq!(
+                matching_import_vrfs(&index, &ecom),
+                vec!["v4only".to_string()]
+            );
+        }
+
+        #[test]
+        fn import_targets_v6_skips_originating_vrf() {
+            // `rt both 1:1` on the v6 AF: the originating VRF is
+            // excluded on the local-leak path; a sibling that imports
+            // the same v6 RT still gets it.
+            let mut index = BTreeMap::new();
+            index.insert("v1".to_string(), vrf_with_imports_v6(&["65000:1"]));
+            index.insert("v2".to_string(), vrf_with_imports_v6(&["65000:1"]));
+            let ecom = Some(ExtCommunity(vec![rt_extcom("65000:1")]));
+
+            let mut got = import_targets_v6(&index, &ecom, Some("v1"));
+            got.sort();
+            assert_eq!(got, vec!["v2".to_string()]);
         }
     }
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2159,6 +2159,9 @@ pub fn route_ipv6_update(
     }
 
     rib.attr = bgp.attr_store.intern(attr.clone());
+    // Kept for the rd==Some import-dispatch withdraw branch (the rib
+    // itself is moved into `update_v6vpn` below); cheap Arc bump.
+    let import_attr = rib.attr.clone();
     let (_, selected, _next_id) = match rd {
         Some(rd) => bgp.local_rib.update_v6vpn(rd, nlri.prefix, rib),
         None => bgp.local_rib.update_v6(nlri.prefix, rib),
@@ -2188,6 +2191,30 @@ pub fn route_ipv6_update(
         // VPNv6 → advertise the winner to PE peers. No kernel FIB here
         // (mirrors VPNv4, which keeps its v4vpn rows out of the FIB).
         Some(rd) => {
+            // Remote VPNv6 → per-VRF import. `vrf_import` is Some only
+            // in the global task; per-VRF runtimes never receive VPNv6
+            // directly. `skip_vrf` is None — no originating local VRF
+            // on the remote ingress path.
+            if let Some(dispatcher) = bgp.vrf_import {
+                if let Some(winner) = selected.first() {
+                    super::vrf::dispatch_import_v6(
+                        dispatcher,
+                        rd,
+                        nlri.prefix,
+                        &winner.attr,
+                        0,
+                        None,
+                    );
+                } else {
+                    super::vrf::dispatch_withdraw_import_v6(
+                        dispatcher,
+                        rd,
+                        nlri.prefix,
+                        &import_attr,
+                        None,
+                    );
+                }
+            }
             if !selected.is_empty() {
                 route_advertise_to_peers_vpnv6(rd, nlri.prefix, &selected, bgp, peers);
             }
@@ -2217,8 +2244,34 @@ pub fn route_ipv6_withdraw(
 
     match rd {
         Some(rd) => {
-            let _ = bgp.local_rib.remove_v6vpn(rd, nlri.prefix, nlri.id, ident);
+            let removed = bgp.local_rib.remove_v6vpn(rd, nlri.prefix, nlri.id, ident);
             let selected = bgp.local_rib.select_best_path_vpn_v6(&rd, nlri.prefix);
+
+            // Remote VPNv6 withdraw → per-VRF import update/withdraw
+            // (global task only). A surviving winner re-imports with
+            // the new attr; otherwise flood a withdraw resolved from
+            // the removed row's RTs.
+            if let Some(dispatcher) = bgp.vrf_import {
+                if let Some(winner) = selected.first() {
+                    super::vrf::dispatch_import_v6(
+                        dispatcher,
+                        rd,
+                        nlri.prefix,
+                        &winner.attr,
+                        0,
+                        None,
+                    );
+                } else if let Some(gone) = removed.first() {
+                    super::vrf::dispatch_withdraw_import_v6(
+                        dispatcher,
+                        rd,
+                        nlri.prefix,
+                        &gone.attr,
+                        None,
+                    );
+                }
+            }
+
             // Empty `selected` → MP_UNREACH to PE peers; a replacement
             // winner → re-advertise. Both handled by the helper.
             route_advertise_to_peers_vpnv6(rd, nlri.prefix, &selected, bgp, peers);

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -250,6 +250,52 @@ pub fn dispatch_withdraw_import_v4(
     }
 }
 
+/// VPNv6 counterpart of [`dispatch_import_v4`] — fan a VPNv6 route out
+/// to every VRF whose `import_rts_v6` intersects the route's RTs
+/// (minus `skip_vrf`).
+pub fn dispatch_import_v6(
+    dispatcher: &VrfImportDispatcher<'_>,
+    rd: bgp_packet::RouteDistinguisher,
+    prefix: ipnet::Ipv6Net,
+    attr: &bgp_packet::BgpAttr,
+    label: u32,
+    skip_vrf: Option<&str>,
+) {
+    let matches =
+        super::super::inst::import_targets_v6(dispatcher.rib_known_vrfs, &attr.ecom, skip_vrf);
+    for vrf_name in matches {
+        let Some(handle) = dispatcher.vrf_registry.get(&vrf_name) else {
+            continue;
+        };
+        let _ = handle.inbox.send(BgpVrfMsg::ImportV6 {
+            rd,
+            prefix,
+            attr: attr.clone(),
+            label,
+        });
+    }
+}
+
+/// VPNv6 counterpart of [`dispatch_withdraw_import_v4`].
+pub fn dispatch_withdraw_import_v6(
+    dispatcher: &VrfImportDispatcher<'_>,
+    rd: bgp_packet::RouteDistinguisher,
+    prefix: ipnet::Ipv6Net,
+    attr: &bgp_packet::BgpAttr,
+    skip_vrf: Option<&str>,
+) {
+    let matches =
+        super::super::inst::import_targets_v6(dispatcher.rib_known_vrfs, &attr.ecom, skip_vrf);
+    for vrf_name in matches {
+        let Some(handle) = dispatcher.vrf_registry.get(&vrf_name) else {
+            continue;
+        };
+        let _ = handle
+            .inbox
+            .send(BgpVrfMsg::WithdrawImportV6 { rd, prefix });
+    }
+}
+
 impl BgpVrf {
     /// Build a `BgpVrf` and the matching inbound sender. The
     /// caller (`spawn_bgp_vrf`) keeps the `BgpVrfInbox`, hands the
@@ -545,6 +591,126 @@ impl BgpVrf {
         );
     }
 
+    /// VPNv6 counterpart of [`Self::handle_import_v4`]. Inserts the
+    /// imported route into the VRF's IPv6 unicast Loc-RIB and fans it
+    /// out to CE peers. Unlike v4 we don't pre-stamp a next-hop — the
+    /// VRF router-id is IPv4 and can't serve as a v6 next-hop, so
+    /// `route_update_ipv6` applies v6 next-hop-self (the CE-facing
+    /// session-local address) at advertise time since the row is
+    /// `Originated`. The direct Loc-RIB insert bypasses the inbound
+    /// `route_ipv6_update` path, so the VRF→global export hook never
+    /// fires for an imported route (no VPNv6 round-trip loop).
+    fn handle_import_v6(
+        &mut self,
+        rd: bgp_packet::RouteDistinguisher,
+        prefix: ipnet::Ipv6Net,
+        mut attr: bgp_packet::BgpAttr,
+        label: u32,
+    ) {
+        attr.nexthop = None;
+        let interned = self.attr_store.intern(attr);
+
+        let label_obj = if label != 0 {
+            Some(bgp_packet::Label {
+                label,
+                exp: 0,
+                bos: true,
+            })
+        } else {
+            None
+        };
+
+        let rib = super::super::route::BgpRib {
+            remote_id: 0,
+            local_id: 0,
+            attr: interned,
+            ident: 0,
+            router_id: self.router_id,
+            weight: 0,
+            typ: super::super::route::BgpRibType::Originated,
+            best_path: false,
+            best_reason: super::super::route::Reason::Default,
+            label: label_obj,
+            nexthop: None,
+            egress_ifindex_v6: None,
+            stale: false,
+            esi: None,
+        };
+
+        let (_, selected, _gen) = self.local_rib.update_v6(prefix, rib);
+        let winners = selected.len();
+
+        let mut top = super::super::peer::BgpTop {
+            router_id: &self.router_id,
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: None,
+            flex_algo_routes: None,
+            vrf_import: None,
+        };
+        super::super::route::route_advertise_to_peers_v6(
+            prefix,
+            &selected,
+            &mut top,
+            &mut self.peers,
+        );
+
+        tracing::info!(
+            vrf = %self.name,
+            %prefix,
+            rd = %rd,
+            label,
+            winners,
+            "bgp vrf: ImportV6 written to LocRIB and advertised to CE peers",
+        );
+    }
+
+    /// VPNv6 counterpart of [`Self::handle_withdraw_import`].
+    fn handle_withdraw_import_v6(
+        &mut self,
+        rd: bgp_packet::RouteDistinguisher,
+        prefix: ipnet::Ipv6Net,
+    ) {
+        let removed = self.local_rib.remove_v6(prefix, 0, 0);
+        let selected = self.local_rib.select_best_path_v6(prefix);
+        let removed_n = removed.len();
+        let winners = selected.len();
+
+        let mut top = super::super::peer::BgpTop {
+            router_id: &self.router_id,
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: None,
+            flex_algo_routes: None,
+            vrf_import: None,
+        };
+        super::super::route::route_advertise_to_peers_v6(
+            prefix,
+            &selected,
+            &mut top,
+            &mut self.peers,
+        );
+
+        tracing::info!(
+            vrf = %self.name,
+            %prefix,
+            rd = %rd,
+            removed = removed_n,
+            winners,
+            "bgp vrf: WithdrawImportV6 removed from LocRIB and withdrawn from CE peers",
+        );
+    }
+
     /// Per-task handling of cross-task messages that aren't
     /// `Shutdown`.
     fn process_global_msg(&mut self, msg: BgpVrfMsg) {
@@ -571,6 +737,17 @@ impl BgpVrf {
             }
             BgpVrfMsg::WithdrawImport { rd, prefix } => {
                 self.handle_withdraw_import(rd, prefix);
+            }
+            BgpVrfMsg::ImportV6 {
+                rd,
+                prefix,
+                attr,
+                label,
+            } => {
+                self.handle_import_v6(rd, prefix, attr, label);
+            }
+            BgpVrfMsg::WithdrawImportV6 { rd, prefix } => {
+                self.handle_withdraw_import_v6(rd, prefix);
             }
             BgpVrfMsg::Shutdown => unreachable!("handled in event_loop"),
         }

--- a/zebra-rs/src/bgp/vrf/mod.rs
+++ b/zebra-rs/src/bgp/vrf/mod.rs
@@ -23,8 +23,9 @@ pub use label::VrfLabelAllocator;
 // `msg::BgpVrfMsg` stay internal — they're constructed / consumed
 // inside `vrf::spawn` only.
 pub use inst::{
-    VrfExporter, VrfImportDispatcher, dispatch_import_v4, dispatch_withdraw_import_v4,
-    vrf_emit_export, vrf_emit_export_v6, vrf_emit_withdraw, vrf_emit_withdraw_v6,
+    VrfExporter, VrfImportDispatcher, dispatch_import_v4, dispatch_import_v6,
+    dispatch_withdraw_import_v4, dispatch_withdraw_import_v6, vrf_emit_export, vrf_emit_export_v6,
+    vrf_emit_withdraw, vrf_emit_withdraw_v6,
 };
 pub use msg::BgpGlobalMsg;
 pub use spawn::{BgpVrfHandle, compute_vrf_diff, despawn_bgp_vrf, spawn_bgp_vrf};

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -53,6 +53,22 @@ pub enum BgpVrfMsg {
         prefix: ipnet::Ipv4Net,
     },
 
+    /// VPNv6 counterpart of [`Self::ImportV4`] — a VPNv6 route whose
+    /// RT list intersects this VRF's `import_rts_v6`; inserted into
+    /// the VRF's IPv6 unicast Loc-RIB and advertised to CE peers.
+    ImportV6 {
+        rd: RouteDistinguisher,
+        prefix: ipnet::Ipv6Net,
+        attr: BgpAttr,
+        label: u32,
+    },
+
+    /// VPNv6 counterpart of [`Self::WithdrawImport`].
+    WithdrawImportV6 {
+        rd: RouteDistinguisher,
+        prefix: ipnet::Ipv6Net,
+    },
+
     /// Tear the VRF task down cleanly. The event loop exits on the
     /// next select iteration after receiving this. Used by
     /// `despawn_bgp_vrf` and during daemon shutdown.


### PR DESCRIPTION
## Summary

The finale of the VPNv6 series: VPNv6 routes now leak between BGP VRF instances via route-target import/export — the v6 analog of the VPNv4 leak (#1000). Combined with 3a's export half, the original goal — VPNv6 propagation between VRF instances and the Default Instance via RD/RT — is complete.

- **inst.rs**: `matching_import_vrfs_v6` / `import_targets_v6` (RT-extraction refactored into a shared `route_rts_from_ecom`, v4 behavior unchanged). The `ExportV6` / `WithdrawExportV6` handlers now fan the v6vpn winner into every sibling VRF whose `import_rts_v6` match — the **local intra-router leak** — skipping the originating VRF (so `rt both` doesn't self-import).
- **vrf/msg.rs**: `BgpVrfMsg::ImportV6` / `WithdrawImportV6`.
- **vrf/inst.rs**: `dispatch_import_v6` / `dispatch_withdraw_import_v6`; `handle_import_v6` / `handle_withdraw_import_v6` — insert into the VRF's IPv6 unicast Loc-RIB and advertise to CE peers. The direct Loc-RIB insert bypasses the inbound path, so an imported route never re-fires the export hook (no VPNv6 round-trip loop). No pre-stamped next-hop (the VRF router-id is IPv4); `route_update_ipv6` applies v6 next-hop-self toward CE since the row is `Originated`.
- **route.rs**: the `vrf_import` v6 hook in `route_ipv6_update` / `route_ipv6_withdraw` (rd==Some) dispatches remote VPNv6 into the matching VRFs.

Control-plane only, mirroring VPNv4: imported routes land in the VRF BGP Loc-RIB and are advertised to CE, but the dataplane label-stack install into the VRF table stays deferred. Outbound policy for v6 also stays deferred.

## Test plan

- `cargo build --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p zebra-rs bgp::` — 186 passed (+2 v6 RT-matching tests: independent v4/v6 import sets, originating-VRF skip)

Generated with [Claude Code](https://claude.com/claude-code)