### PR TITLE
bgp: consume RIB Next-Hop Tracking to gate best-path on resolution

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -89,6 +89,7 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
             color_policy: Some(&bgp.color_policy),
             flex_algo_routes: Some(&bgp.flex_algo_routes),
             vrf_import: None,
+            nexthop_cache: None,
         };
         route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers);
         bgp.peers.remove(&addr);

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -291,6 +291,9 @@ pub struct Bgp {
     /// table or a future VRF instance.
     pub ctx: ProtoContext,
     pub rib_rx: UnboundedReceiver<RibRx>,
+    /// Next-Hop Tracking cache (global instance only). Populated by the
+    /// received-route path and updated by `RibRx::NexthopUpdate`.
+    pub nexthop_cache: super::nht::NexthopCache,
     pub callbacks: HashMap<String, Callback>,
     pub pcallbacks: HashMap<String, PCallback>,
     /// BGP Local RIB (Loc-RIB) for best path selection
@@ -531,6 +534,7 @@ impl Bgp {
             local_rib: LocalRib::default(),
             ctx,
             rib_rx,
+            nexthop_cache: super::nht::NexthopCache::default(),
             cm: ConfigChannel::new(),
             show: ShowChannel::new(),
             show_cb: HashMap::new(),
@@ -744,6 +748,7 @@ impl Bgp {
                     color_policy: Some(&self.color_policy),
                     flex_algo_routes: Some(&self.flex_algo_routes),
                     vrf_import: Some(&import_dispatcher),
+                    nexthop_cache: Some(&mut self.nexthop_cache),
                 };
 
                 fsm(&mut bgp_ref, &mut self.peers, ident, event);
@@ -1290,8 +1295,107 @@ impl Bgp {
                     self.flex_algo_routes.remove(&algo);
                 }
             }
+            RibRx::NexthopUpdate { nh, resolution } => {
+                self.nht_handle_update(nh, resolution.reachable);
+            }
             _ => {
                 //
+            }
+        }
+    }
+
+    /// Apply a NHT resolution change: update the cached reachability and
+    /// re-evaluate every dependent prefix.
+    fn nht_handle_update(&mut self, nh: std::net::IpAddr, reachable: bool) {
+        let deps = self.nexthop_cache.update(nh, reachable);
+        for dep in deps {
+            self.nht_reeval_dep(nh, reachable, dep);
+        }
+    }
+
+    /// Re-evaluate one dependent prefix after its next-hop's
+    /// reachability flipped: refresh the candidates' gate flag, re-run
+    /// best-path, then re-advertise (and, for unicast, reconcile the
+    /// FIB). The per-VRF leak re-dispatch on a reachability change is a
+    /// follow-up; this handles the global advertise/FIB effect.
+    fn nht_reeval_dep(&mut self, nh: std::net::IpAddr, reachable: bool, dep: super::nht::NhtDep) {
+        use super::nht::NhtDep;
+        // Refresh gate flags + re-select (mutates `local_rib`).
+        let selected = match &dep {
+            NhtDep::V4(p) => {
+                self.local_rib.v4.set_nexthop_reachable(*p, nh, reachable);
+                self.local_rib.v4.select_best_path(*p)
+            }
+            NhtDep::V6(p) => {
+                self.local_rib.v6.set_nexthop_reachable(*p, nh, reachable);
+                self.local_rib.v6.select_best_path(*p)
+            }
+            NhtDep::V4vpn(rd, p) => {
+                self.local_rib
+                    .v4vpn
+                    .entry(*rd)
+                    .or_default()
+                    .set_nexthop_reachable(*p, nh, reachable);
+                self.local_rib.select_best_path_vpn(rd, *p)
+            }
+            NhtDep::V6vpn(rd, p) => {
+                self.local_rib
+                    .v6vpn
+                    .entry(*rd)
+                    .or_default()
+                    .set_nexthop_reachable(*p, nh, reachable);
+                self.local_rib.select_best_path_vpn_v6(rd, *p)
+            }
+        };
+
+        let mut top = super::peer::BgpTop {
+            router_id: &self.router_id,
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_export: None,
+            vrf_import: None,
+            nexthop_cache: None,
+        };
+        match &dep {
+            NhtDep::V4(p) => {
+                super::route::fib_install_v4(&top, *p, &selected);
+                super::route::route_advertise_to_peers(
+                    None,
+                    *p,
+                    &selected,
+                    0,
+                    &mut top,
+                    &mut self.peers,
+                );
+            }
+            NhtDep::V6(p) => {
+                super::route::fib_install_v6(&top, *p, &selected);
+                super::route::route_advertise_to_peers_v6(*p, &selected, &mut top, &mut self.peers);
+            }
+            NhtDep::V4vpn(rd, p) => {
+                super::route::route_advertise_to_peers(
+                    Some(*rd),
+                    *p,
+                    &selected,
+                    0,
+                    &mut top,
+                    &mut self.peers,
+                );
+            }
+            NhtDep::V6vpn(rd, p) => {
+                super::route::route_advertise_to_peers_vpnv6(
+                    *rd,
+                    *p,
+                    &selected,
+                    &mut top,
+                    &mut self.peers,
+                );
             }
         }
     }
@@ -1547,6 +1651,7 @@ impl Bgp {
                     best_reason: super::route::Reason::Default,
                     label: label_obj,
                     nexthop: Some(super::route::VpnNexthop::V4(nexthop)),
+                    nexthop_reachable: true,
                     egress_ifindex_v6: None,
                     stale: false,
                     esi: None,
@@ -1598,6 +1703,7 @@ impl Bgp {
                     flex_algo_routes: Some(&self.flex_algo_routes),
                     vrf_export: None,
                     vrf_import: None,
+                    nexthop_cache: None,
                 };
                 super::route::route_advertise_to_peers(
                     Some(rd),
@@ -1683,6 +1789,7 @@ impl Bgp {
                     flex_algo_routes: Some(&self.flex_algo_routes),
                     vrf_export: None,
                     vrf_import: None,
+                    nexthop_cache: None,
                 };
                 super::route::route_advertise_to_peers(
                     Some(rd),
@@ -1755,6 +1862,7 @@ impl Bgp {
                     best_reason: super::route::Reason::Default,
                     label: label_obj,
                     nexthop: Some(super::route::VpnNexthop::V6(nexthop)),
+                    nexthop_reachable: true,
                     egress_ifindex_v6: None,
                     stale: false,
                     esi: None,
@@ -1796,6 +1904,7 @@ impl Bgp {
                     flex_algo_routes: Some(&self.flex_algo_routes),
                     vrf_export: None,
                     vrf_import: None,
+                    nexthop_cache: None,
                 };
                 super::route::route_advertise_to_peers_vpnv6(
                     rd,
@@ -1863,6 +1972,7 @@ impl Bgp {
                     flex_algo_routes: Some(&self.flex_algo_routes),
                     vrf_export: None,
                     vrf_import: None,
+                    nexthop_cache: None,
                 };
                 super::route::route_advertise_to_peers_vpnv6(
                     rd,

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -35,6 +35,8 @@ pub use policy::*;
 pub mod route;
 pub use route::*;
 
+pub mod nht;
+
 pub mod adj_rib;
 pub use adj_rib::*;
 

--- a/zebra-rs/src/bgp/nht.rs
+++ b/zebra-rs/src/bgp/nht.rs
@@ -1,0 +1,126 @@
+//! BGP-side Next-Hop Tracking cache.
+//!
+//! Deduplicates per-nexthop registrations against the RIB NHT service
+//! ([`crate::rib::nht`]): one registration per distinct BGP next-hop,
+//! with the set of dependent routes recorded so a `RibRx::NexthopUpdate`
+//! can re-evaluate exactly the affected prefixes. The cached
+//! `reachable` flag feeds the best-path gate via `BgpRib.nexthop_reachable`.
+//!
+//! Scope: the global `Bgp` instance (it owns the `rib_rx` stream);
+//! per-VRF tasks pass `None` and don't gate (their CE next-hops resolve
+//! directly in the VRF). Cache cleanup on route withdrawal (untrack) is
+//! a follow-up — registrations persist for the life of the process,
+//! bounded by the number of distinct next-hops seen.
+
+use std::collections::{BTreeSet, HashMap};
+use std::net::IpAddr;
+
+use bgp_packet::{BgpAttr, BgpNexthop, RouteDistinguisher};
+use ipnet::{Ipv4Net, Ipv6Net};
+
+/// A route that depends on a tracked next-hop — enough to locate its
+/// candidates and re-run best-path on a resolution change.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum NhtDep {
+    V4(Ipv4Net),
+    V6(Ipv6Net),
+    V4vpn(RouteDistinguisher, Ipv4Net),
+    V6vpn(RouteDistinguisher, Ipv6Net),
+}
+
+#[derive(Debug, Default)]
+pub struct NhtCacheEntry {
+    pub reachable: bool,
+    pub deps: BTreeSet<NhtDep>,
+}
+
+/// Per-instance BGP next-hop cache.
+#[derive(Debug, Default)]
+pub struct NexthopCache {
+    pub entries: HashMap<IpAddr, NhtCacheEntry>,
+}
+
+impl NexthopCache {
+    /// Record that `dep` uses `nh`. Returns `(needs_register,
+    /// reachable_now)`: `needs_register` is true on the first sighting
+    /// of `nh` (the caller registers it with the RIB), and
+    /// `reachable_now` is the current cached reachability (`false`
+    /// while a fresh registration is pending — register-then-gate).
+    pub fn track(&mut self, nh: IpAddr, dep: NhtDep) -> (bool, bool) {
+        use std::collections::hash_map::Entry;
+        match self.entries.entry(nh) {
+            Entry::Occupied(mut e) => {
+                e.get_mut().deps.insert(dep);
+                (false, e.get().reachable)
+            }
+            Entry::Vacant(v) => {
+                let mut deps = BTreeSet::new();
+                deps.insert(dep);
+                v.insert(NhtCacheEntry {
+                    reachable: false,
+                    deps,
+                });
+                (true, false)
+            }
+        }
+    }
+
+    /// Apply a resolution update. Returns the dependent routes to
+    /// re-evaluate — empty when `nh` isn't tracked or its reachability
+    /// is unchanged (so a no-op update costs nothing downstream).
+    pub fn update(&mut self, nh: IpAddr, reachable: bool) -> Vec<NhtDep> {
+        match self.entries.get_mut(&nh) {
+            Some(e) if e.reachable != reachable => {
+                e.reachable = reachable;
+                e.deps.iter().cloned().collect()
+            }
+            _ => Vec::new(),
+        }
+    }
+}
+
+/// The IPv4/IPv6 address of a BGP attribute's next-hop, for tracking.
+/// `None` when the attribute carries no next-hop.
+pub fn bgp_nexthop_ip(attr: &BgpAttr) -> Option<IpAddr> {
+    match attr.nexthop.as_ref()? {
+        BgpNexthop::Ipv4(a) => Some(IpAddr::V4(*a)),
+        BgpNexthop::Ipv6(a) => Some(IpAddr::V6(*a)),
+        BgpNexthop::Vpnv4(v) => Some(IpAddr::V4(v.nhop)),
+        BgpNexthop::Vpnv6(v) => Some(IpAddr::V6(v.nhop)),
+        BgpNexthop::Evpn(ip) => Some(*ip),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn track_dedups_and_reports_register_on_first_sight() {
+        let mut c = NexthopCache::default();
+        let nh: IpAddr = "10.0.0.8".parse().unwrap();
+        let p1: Ipv4Net = "1.0.0.0/24".parse().unwrap();
+        let p2: Ipv4Net = "2.0.0.0/24".parse().unwrap();
+
+        // First sighting → register, pending-unreachable.
+        assert_eq!(c.track(nh, NhtDep::V4(p1)), (true, false));
+        // Second route, same nexthop → no re-register, still pending.
+        assert_eq!(c.track(nh, NhtDep::V4(p2)), (false, false));
+    }
+
+    #[test]
+    fn update_returns_deps_only_on_change() {
+        let mut c = NexthopCache::default();
+        let nh: IpAddr = "10.0.0.8".parse().unwrap();
+        let p1: Ipv4Net = "1.0.0.0/24".parse().unwrap();
+        c.track(nh, NhtDep::V4(p1));
+
+        // pending(false) -> reachable(true): change, deps returned.
+        let deps = c.update(nh, true);
+        assert_eq!(deps, vec![NhtDep::V4(p1)]);
+        // same value again: no change, no deps.
+        assert!(c.update(nh, true).is_empty());
+        // unknown nexthop: no deps.
+        assert!(c.update("9.9.9.9".parse().unwrap(), false).is_empty());
+    }
+}

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -662,6 +662,13 @@ pub struct BgpTop<'a> {
     /// `BgpVrfMsg::ImportV4`. `None` inside per-VRF tasks (they
     /// never receive VPNv4 NLRI directly).
     pub vrf_import: Option<&'a super::vrf::VrfImportDispatcher<'a>>,
+    /// Next-Hop Tracking cache. `Some(...)` only in the global `Bgp`
+    /// task (it owns the `rib_rx` stream that delivers
+    /// `RibRx::NexthopUpdate`); the received-route path registers
+    /// next-hops here and gates best-path on their resolution. `None`
+    /// in per-VRF tasks and the local-origination/advertise BgpTops
+    /// (no gating there).
+    pub nexthop_cache: Option<&'a mut super::nht::NexthopCache>,
     /// Colour-aware nexthop resolver inputs. Optional because
     /// per-VRF BGP runtimes don't carry them today — Color →
     /// Flex-Algo binding is a default-VRF concept; per-VRF support
@@ -1640,6 +1647,7 @@ pub fn apply_soft_in_peer(bgp: &mut Bgp, peer_idx: usize) {
             color_policy: Some(&bgp.color_policy),
             flex_algo_routes: Some(&bgp.flex_algo_routes),
             vrf_import: None,
+            nexthop_cache: None,
         };
         super::route::route_soft_in_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
     } else if supports_refresh {
@@ -1673,6 +1681,7 @@ pub fn apply_soft_out_peer(bgp: &mut Bgp, peer_idx: usize) {
         color_policy: Some(&bgp.color_policy),
         flex_algo_routes: Some(&bgp.flex_algo_routes),
         vrf_import: None,
+        nexthop_cache: None,
     };
     super::route::route_soft_out_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -92,7 +92,7 @@ fn make_bgp_rib_entry_v4(best: &BgpRib) -> Option<rib::entry::RibEntry> {
 ///
 /// VPNv4 / EVPN take their own install paths; this helper is for
 /// plain IPv4 unicast only.
-fn fib_install_v4(bgp: &super::peer::BgpTop, prefix: Ipv4Net, selected: &[BgpRib]) {
+pub(super) fn fib_install_v4(bgp: &super::peer::BgpTop, prefix: Ipv4Net, selected: &[BgpRib]) {
     let installable = selected.first().and_then(make_bgp_rib_entry_v4);
     match installable {
         Some(mut rib_entry) => {
@@ -166,7 +166,7 @@ fn make_bgp_rib_entry_v6(best: &BgpRib) -> Option<rib::entry::RibEntry> {
 /// IPv6 counterpart of [`fib_install_v4`]: reconcile the kernel FIB
 /// for an IPv6 unicast prefix against the best-path outcome. Plain v6
 /// unicast only — VPNv6 will take its own install path (layer 2c+).
-fn fib_install_v6(bgp: &super::peer::BgpTop, prefix: Ipv6Net, selected: &[BgpRib]) {
+pub(super) fn fib_install_v6(bgp: &super::peer::BgpTop, prefix: Ipv6Net, selected: &[BgpRib]) {
     match selected.first().and_then(make_bgp_rib_entry_v6) {
         Some(rib_entry) => {
             let _ = bgp.rib_client.send(rib::Message::Ipv6Add {
@@ -256,6 +256,14 @@ pub struct BgpRib {
     pub label: Option<Label>,
     // VPN next-hop (v4vpn / v6vpn rows); `None` for unicast rows.
     pub nexthop: Option<VpnNexthop>,
+    /// Next-Hop Tracking gate: `false` when this path's BGP next-hop is
+    /// registered for resolution but not (yet) reachable in the RIB.
+    /// Best-path treats a reachable path as strictly better than an
+    /// unreachable one, and a prefix whose best path is unreachable is
+    /// withdrawn. Defaults to `true` — locally-originated and
+    /// not-yet-tracked paths are never gated; `route_*_update` lowers
+    /// it from the `Bgp` nexthop cache for received routes.
+    pub nexthop_reachable: bool,
     /// RFC 8950 IPv4-over-IPv6: when the route was received via
     /// MP_REACH(AFI=1) with an IPv6 next-hop, this is the local egress
     /// ifindex (the interface where we received the UPDATE). FIB
@@ -272,6 +280,7 @@ pub struct BgpRib {
 #[derive(Debug, Clone, Copy)]
 pub enum Reason {
     Default,
+    NexthopUnreachable,
     Llgr,
     Weight,
     Originated,
@@ -287,6 +296,7 @@ impl std::fmt::Display for Reason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Reason::Default => write!(f, "Default selection (no other candidate)"),
+            Reason::NexthopUnreachable => write!(f, "next-hop unreachable"),
             Reason::Llgr => write!(f, "llgr-stale"),
             Reason::Weight => write!(f, "weight"),
             Reason::Originated => write!(f, "self originated route"),
@@ -324,6 +334,7 @@ impl BgpRib {
             best_reason: Reason::NotSelected,
             label,
             nexthop,
+            nexthop_reachable: true,
             egress_ifindex_v6: None,
             stale,
             esi: None,
@@ -457,13 +468,51 @@ impl<P: Prefix + Copy> LocalRibTable<P> {
             cands[best_index].clone()
         };
 
+        // NHT gate: if even the best candidate's next-hop is
+        // unreachable, every candidate is (a reachable one would have
+        // won) — the prefix has no usable path, so withdraw it.
+        if !best.nexthop_reachable {
+            self.1.remove(&prefix);
+            return selected;
+        }
+
         self.1.insert(prefix, best.clone());
         selected.push(best);
 
         selected
     }
 
+    /// Set `nexthop_reachable` on every candidate at `prefix` whose BGP
+    /// next-hop equals `nh`. Returns true if any candidate changed (the
+    /// caller then re-runs `select_best_path`). Used by the NHT update
+    /// path when a tracked next-hop's reachability flips.
+    pub fn set_nexthop_reachable(
+        &mut self,
+        prefix: P,
+        nh: std::net::IpAddr,
+        reachable: bool,
+    ) -> bool {
+        let Some(cands) = self.0.get_mut(&prefix) else {
+            return false;
+        };
+        let mut changed = false;
+        for c in cands.iter_mut() {
+            if super::nht::bgp_nexthop_ip(&c.attr) == Some(nh) && c.nexthop_reachable != reachable {
+                c.nexthop_reachable = reachable;
+                changed = true;
+            }
+        }
+        changed
+    }
+
     fn is_better(cand: &BgpRib, incb: &BgpRib) -> (bool, Reason) {
+        // NHT gate: a path whose next-hop resolves is strictly better
+        // than one whose next-hop is unreachable, ahead of every other
+        // attribute. (Both-unreachable falls through; `select_best_path`
+        // withdraws the prefix if even the winner is unreachable.)
+        if cand.nexthop_reachable != incb.nexthop_reachable {
+            return (cand.nexthop_reachable, Reason::NexthopUnreachable);
+        }
         if cand.stale != incb.stale {
             return (!cand.stale, Reason::Llgr);
         }
@@ -925,6 +974,29 @@ pub fn route_apply_policy_out(
     })
 }
 
+/// Next-Hop Tracking for a received route: register its BGP next-hop
+/// with the RIB on first sight, record `dep` so a resolution change
+/// re-evaluates this prefix, and lower `rib.nexthop_reachable` from the
+/// cache (`false` while a fresh registration is pending — best-path
+/// then holds the path until the first `NexthopUpdate`). No-op outside
+/// the global instance, where `bgp.nexthop_cache` is `None`.
+fn nht_track_received(bgp: &mut BgpTop, rib: &mut BgpRib, dep: super::nht::NhtDep) {
+    let Some(cache) = bgp.nexthop_cache.as_deref_mut() else {
+        return;
+    };
+    let Some(nh) = super::nht::bgp_nexthop_ip(&rib.attr) else {
+        return;
+    };
+    let (needs_register, reachable) = cache.track(nh, dep);
+    rib.nexthop_reachable = reachable;
+    if needs_register {
+        let _ = bgp.rib_client.send(rib::Message::NexthopRegister {
+            proto: "bgp".to_string(),
+            nh,
+        });
+    }
+}
+
 pub fn route_ipv4_update(
     ident: usize,
     nlri: &Ipv4Nlri,
@@ -1029,6 +1101,14 @@ pub fn route_ipv4_update(
     };
     rib.attr = bgp.attr_store.intern(decision.attr);
     rib.weight = decision.weight;
+    nht_track_received(
+        bgp,
+        &mut rib,
+        match rd {
+            Some(rd) => super::nht::NhtDep::V4vpn(rd, nlri.prefix),
+            None => super::nht::NhtDep::V4(nlri.prefix),
+        },
+    );
     let (_, selected, next_id) = bgp.local_rib.update(rd, nlri.prefix, rib.clone());
 
     // Per-VRF best-path → global VPNv4 export. The hook only
@@ -2159,6 +2239,14 @@ pub fn route_ipv6_update(
     }
 
     rib.attr = bgp.attr_store.intern(attr.clone());
+    nht_track_received(
+        bgp,
+        &mut rib,
+        match rd {
+            Some(rd) => super::nht::NhtDep::V6vpn(rd, nlri.prefix),
+            None => super::nht::NhtDep::V6(nlri.prefix),
+        },
+    );
     // Kept for the rd==Some import-dispatch withdraw branch (the rib
     // itself is moved into `update_v6vpn` below); cheap Arc bump.
     let import_attr = rib.attr.clone();
@@ -4515,6 +4603,7 @@ impl Bgp {
             color_policy: Some(&self.color_policy),
             flex_algo_routes: Some(&self.flex_algo_routes),
             vrf_import: None,
+            nexthop_cache: None,
         };
 
         // An originated route lacks a v4 NEXT_HOP attribute, so when
@@ -4554,6 +4643,7 @@ impl Bgp {
             color_policy: Some(&self.color_policy),
             flex_algo_routes: Some(&self.flex_algo_routes),
             vrf_import: None,
+            nexthop_cache: None,
         };
 
         let selected = bgp_ref.local_rib.select_best_path(prefix);
@@ -4642,6 +4732,7 @@ impl Bgp {
             color_policy: Some(&self.color_policy),
             flex_algo_routes: Some(&self.flex_algo_routes),
             vrf_import: None,
+            nexthop_cache: None,
         };
 
         // Same logic as `route_add`: the redistributed BGP route has
@@ -4679,6 +4770,7 @@ impl Bgp {
             color_policy: Some(&self.color_policy),
             flex_algo_routes: Some(&self.flex_algo_routes),
             vrf_import: None,
+            nexthop_cache: None,
         };
 
         let selected = bgp_ref.local_rib.select_best_path(prefix);
@@ -4815,6 +4907,7 @@ impl Bgp {
             color_policy: Some(&self.color_policy),
             flex_algo_routes: Some(&self.flex_algo_routes),
             vrf_import: None,
+            nexthop_cache: None,
         };
 
         if !selected.is_empty() {
@@ -4938,6 +5031,7 @@ impl Bgp {
             color_policy: Some(&self.color_policy),
             flex_algo_routes: Some(&self.flex_algo_routes),
             vrf_import: None,
+            nexthop_cache: None,
         };
 
         if !selected.is_empty() {
@@ -6360,6 +6454,43 @@ mod tests {
             None,
             false,
         )
+    }
+
+    #[test]
+    fn nht_gate_prefers_reachable_and_withdraws_when_all_unreachable() {
+        use super::{BgpRib, BgpRibType, LocalRibTable};
+        let attr = BgpAttr::default();
+        let prefix: Ipv4Net = "10.0.0.0/24".parse().unwrap();
+        let mk = |id: u32, weight: u32, reachable: bool| {
+            let mut r = BgpRib::new(
+                id as usize,
+                Ipv4Addr::new(10, 0, 0, id as u8),
+                BgpRibType::IBGP,
+                0,
+                weight,
+                &attr,
+                None,
+                None,
+                false,
+            );
+            r.remote_id = id;
+            r.nexthop_reachable = reachable;
+            r
+        };
+
+        let mut t: LocalRibTable<Ipv4Net> = LocalRibTable::default();
+        // A: unreachable next-hop but higher weight (would win without
+        // the gate). B: reachable, lower weight.
+        t.update(prefix, mk(1, 100, false));
+        let (_, selected, _) = t.update(prefix, mk(2, 10, true));
+        assert_eq!(selected.len(), 1);
+        assert!(selected[0].nexthop_reachable);
+        assert_eq!(selected[0].remote_id, 2, "reachable path wins over weight");
+
+        // Now B's next-hop also goes unreachable → no usable path →
+        // the prefix is withdrawn.
+        let (_, selected, _) = t.update(prefix, mk(2, 10, false));
+        assert!(selected.is_empty(), "all-unreachable → withdraw");
     }
 
     #[test]

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -415,6 +415,7 @@ impl BgpVrf {
                     // Per-VRF tasks never receive VPNv4 NLRI directly,
                     // so no import dispatcher to thread through.
                     vrf_import: None,
+                    nexthop_cache: None,
                 };
                 fsm(&mut top, &mut self.peers, ident, event);
             }
@@ -504,6 +505,7 @@ impl BgpVrf {
             // Vpnv4-shaped `nexthop` slot; FIB install pulls
             // from `attr.nexthop` set above.
             nexthop: None,
+            nexthop_reachable: true,
             egress_ifindex_v6: None,
             stale: false,
             esi: None,
@@ -526,6 +528,7 @@ impl BgpVrf {
             color_policy: None,
             flex_algo_routes: None,
             vrf_import: None,
+            nexthop_cache: None,
         };
         super::super::route::route_advertise_to_peers(
             None,
@@ -571,6 +574,7 @@ impl BgpVrf {
             color_policy: None,
             flex_algo_routes: None,
             vrf_import: None,
+            nexthop_cache: None,
         };
         super::super::route::route_advertise_to_peers(
             None,
@@ -632,6 +636,7 @@ impl BgpVrf {
             best_reason: super::super::route::Reason::Default,
             label: label_obj,
             nexthop: None,
+            nexthop_reachable: true,
             egress_ifindex_v6: None,
             stale: false,
             esi: None,
@@ -652,6 +657,7 @@ impl BgpVrf {
             color_policy: None,
             flex_algo_routes: None,
             vrf_import: None,
+            nexthop_cache: None,
         };
         super::super::route::route_advertise_to_peers_v6(
             prefix,
@@ -693,6 +699,7 @@ impl BgpVrf {
             color_policy: None,
             flex_algo_routes: None,
             vrf_import: None,
+            nexthop_cache: None,
         };
         super::super::route::route_advertise_to_peers_v6(
             prefix,

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -325,6 +325,7 @@ fn materialize_self_originated_networks(vrf: &mut BgpVrf, cfg: &BgpVrfConfig) ->
             best_reason: super::super::route::Reason::Default,
             label: None,
             nexthop: None,
+            nexthop_reachable: true,
             egress_ifindex_v6: None,
             stale: false,
             esi: None,

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -126,17 +126,16 @@ pub enum Message {
     /// back to `proto` and subsequent updates whenever the covering
     /// route changes. Registrations are deduplicated + refcounted per
     /// nexthop in `Rib::nht`.
-    //
-    // `allow(dead_code)`: the handler is wired and tested, but the
-    // producers (BGP / static clients via `RibClient`) land in the
-    // next PR — remove the allow then.
-    #[allow(dead_code)]
     NexthopRegister {
         proto: String,
         nh: std::net::IpAddr,
     },
     /// Drop `proto`'s interest in `nh`; the tracking entry is removed
     /// once its last watcher unregisters.
+    //
+    // `allow(dead_code)`: the handler is wired and tested, but the
+    // producer (untrack-on-withdrawal in the BGP/static clients) is a
+    // follow-up — remove the allow then.
     #[allow(dead_code)]
     NexthopUnregister {
         proto: String,


### PR DESCRIPTION
## Summary

Second PR in the Next-Hop Tracking (NHT) series. PR #1010 added the
RIB-side NHT service (register a next-hop → synchronous resolution →
async updates on change). This PR wires BGP up as its first consumer
with **register-then-gate** semantics: a received route's path is held
out of best-path until its next-hop first resolves, so we never
advertise (or FIB-install) a route whose next-hop is unreachable.

This is the recursive-resolution prerequisite for the imported-VPN
dataplane install (PR3).

## Changes

- **Gate flag** — `BgpRib.nexthop_reachable` (default `true`; locally
  originated / not-yet-tracked paths are never gated). `is_better`
  ranks a reachable path strictly above an unreachable one ahead of all
  other attributes; `select_best_path` withdraws a prefix whose even
  best path is unreachable.
- **`bgp::nht::NexthopCache`** — per-instance dedup of registrations
  against the RIB (one register per distinct next-hop) plus a reverse
  index of dependent routes (`NhtDep::{V4,V6,V4vpn,V6vpn}`) for targeted
  re-evaluation. Scoped to the global `Bgp` instance; per-VRF tasks pass
  `None` and don't gate.
- **Producers** — `route_{ipv4,ipv6}_update` track each received
  route's next-hop and send `Message::NexthopRegister` on first sight.
- **Re-eval** — the `RibRx::NexthopUpdate` handler re-evaluates exactly
  the dependent prefixes: refresh candidate gate flags, re-run
  best-path, re-advertise (and reconcile the FIB for unicast).

## Follow-ups (not in this PR)

- Per-VRF leak re-dispatch on a reachability change.
- Untrack-on-withdrawal cache cleanup (`Message::NexthopUnregister`).
- The VPN dataplane install consuming the resolved transport label stack.

## Test plan

- `cargo build -p zebra-rs` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p zebra-rs bgp::` (189) / `rib::` (146) — pass, including
  the new `nht_gate_prefers_reachable_and_withdraws_when_all_unreachable`
  unit test and the 8 NHT cache/service tests.
- CI is the source of truth for the full suite.

Generated with [Claude Code](https://claude.com/claude-code)