### PR TITLE
bgp: install imported VPNv4 routes into the VRF dataplane

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1296,7 +1296,7 @@ impl Bgp {
                 }
             }
             RibRx::NexthopUpdate { nh, resolution } => {
-                self.nht_handle_update(nh, resolution.reachable);
+                self.nht_handle_update(nh, &resolution);
             }
             _ => {
                 //
@@ -1304,10 +1304,16 @@ impl Bgp {
         }
     }
 
-    /// Apply a NHT resolution change: update the cached reachability and
-    /// re-evaluate every dependent prefix.
-    fn nht_handle_update(&mut self, nh: std::net::IpAddr, reachable: bool) {
-        let deps = self.nexthop_cache.update(nh, reachable);
+    /// Apply a NHT resolution change: refresh the cached resolution
+    /// (reachability + resolved transport) and re-evaluate every
+    /// dependent prefix.
+    fn nht_handle_update(
+        &mut self,
+        nh: std::net::IpAddr,
+        resolution: &crate::rib::nht::NexthopResolution,
+    ) {
+        let reachable = resolution.reachable;
+        let deps = self.nexthop_cache.update(nh, resolution);
         for dep in deps {
             self.nht_reeval_dep(nh, reachable, dep);
         }
@@ -1316,8 +1322,11 @@ impl Bgp {
     /// Re-evaluate one dependent prefix after its next-hop's
     /// reachability flipped: refresh the candidates' gate flag, re-run
     /// best-path, then re-advertise (and, for unicast, reconcile the
-    /// FIB). The per-VRF leak re-dispatch on a reachability change is a
-    /// follow-up; this handles the global advertise/FIB effect.
+    /// FIB). For VPNv4 deps this also (re-)dispatches the per-VRF import
+    /// with the resolved transport — register-then-gate means an
+    /// imported route only becomes best-path here, so this is where the
+    /// VRF dataplane install is triggered. (VPNv6 re-dispatch lands with
+    /// the VPNv6 install in a follow-up.)
     fn nht_reeval_dep(&mut self, nh: std::net::IpAddr, reachable: bool, dep: super::nht::NhtDep) {
         use super::nht::NhtDep;
         // Refresh gate flags + re-select (mutates `local_rib`).
@@ -1387,6 +1396,36 @@ impl Bgp {
                     &mut top,
                     &mut self.peers,
                 );
+                // Register-then-gate: an imported VPNv4 route only
+                // becomes (or stops being) best-path here, after the PE
+                // next-hop resolves asynchronously. (Re-)dispatch the
+                // VRF import with the now-resolved transport, or flood a
+                // withdraw if the PE went unreachable. `top`'s borrows
+                // are released after the advertise above.
+                let dispatcher = super::vrf::VrfImportDispatcher {
+                    rib_known_vrfs: &self.rib_known_vrfs,
+                    vrf_registry: &self.vrf_registry,
+                };
+                if reachable && let Some(winner) = selected.first() {
+                    let label = winner.label.map(|l| l.label).unwrap_or(0);
+                    let transport = self.nexthop_cache.transport_for(nh);
+                    super::vrf::dispatch_import_v4(
+                        &dispatcher,
+                        *rd,
+                        *p,
+                        &winner.attr,
+                        label,
+                        transport,
+                        None,
+                    );
+                } else if let Some(attr) = self
+                    .local_rib
+                    .v4vpn
+                    .get(rd)
+                    .and_then(|t| t.candidate_attr(*p))
+                {
+                    super::vrf::dispatch_withdraw_import_v4(&dispatcher, *rd, *p, &attr, None);
+                }
             }
             NhtDep::V6vpn(rd, p) => {
                 super::route::route_advertise_to_peers_vpnv6(
@@ -1679,6 +1718,10 @@ impl Bgp {
                         prefix,
                         &winner.attr,
                         0,
+                        // Local VRF-to-VRF leak carries no SR-MPLS
+                        // transport; FIB install for local-leak is out
+                        // of scope (remote-PE import is the gated path).
+                        &[],
                         Some(vrf.as_str()),
                     );
                 }
@@ -1764,6 +1807,7 @@ impl Bgp {
                             prefix,
                             &winner.attr,
                             0,
+                            &[],
                             Some(vrf.as_str()),
                         );
                     } else if let Some(gone) = removed.first() {

--- a/zebra-rs/src/bgp/nht.rs
+++ b/zebra-rs/src/bgp/nht.rs
@@ -18,6 +18,8 @@ use std::net::IpAddr;
 use bgp_packet::{BgpAttr, BgpNexthop, RouteDistinguisher};
 use ipnet::{Ipv4Net, Ipv6Net};
 
+use crate::rib::nht::{NexthopResolution, ResolvedNexthop};
+
 /// A route that depends on a tracked next-hop — enough to locate its
 /// candidates and re-run best-path on a resolution change.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -31,6 +33,11 @@ pub enum NhtDep {
 #[derive(Debug, Default)]
 pub struct NhtCacheEntry {
     pub reachable: bool,
+    /// Resolved transport egress(es) for this next-hop, from the last
+    /// `RibRx::NexthopUpdate`. Consumed by the VPN dataplane install to
+    /// build the `{service-label, transport-labels}` stack. Empty while
+    /// a registration is pending or the next-hop is unreachable.
+    pub nexthops: Vec<ResolvedNexthop>,
     pub deps: BTreeSet<NhtDep>,
 }
 
@@ -58,6 +65,7 @@ impl NexthopCache {
                 deps.insert(dep);
                 v.insert(NhtCacheEntry {
                     reachable: false,
+                    nexthops: Vec::new(),
                     deps,
                 });
                 (true, false)
@@ -65,17 +73,37 @@ impl NexthopCache {
         }
     }
 
-    /// Apply a resolution update. Returns the dependent routes to
-    /// re-evaluate — empty when `nh` isn't tracked or its reachability
-    /// is unchanged (so a no-op update costs nothing downstream).
-    pub fn update(&mut self, nh: IpAddr, reachable: bool) -> Vec<NhtDep> {
+    /// Apply a resolution update. Always refreshes the stored resolved
+    /// transport (`nexthops`) so a later re-eval installs against
+    /// current data. Returns the dependent routes to re-evaluate — only
+    /// on a reachability flip; a transport-only change (still reachable)
+    /// refreshes the cache but doesn't itself trigger re-eval (matching
+    /// the gate's reachability semantics; transport-reroute re-install
+    /// is a deferred refinement).
+    pub fn update(&mut self, nh: IpAddr, resolution: &NexthopResolution) -> Vec<NhtDep> {
         match self.entries.get_mut(&nh) {
-            Some(e) if e.reachable != reachable => {
-                e.reachable = reachable;
-                e.deps.iter().cloned().collect()
+            Some(e) => {
+                let flipped = e.reachable != resolution.reachable;
+                e.reachable = resolution.reachable;
+                e.nexthops = resolution.nexthops.clone();
+                if flipped {
+                    e.deps.iter().cloned().collect()
+                } else {
+                    Vec::new()
+                }
             }
-            _ => Vec::new(),
+            None => Vec::new(),
         }
+    }
+
+    /// The resolved transport egress(es) for `nh` — what the VPN
+    /// dataplane install pushes the service label over. Empty slice
+    /// when `nh` isn't tracked or hasn't resolved yet.
+    pub fn transport_for(&self, nh: IpAddr) -> &[ResolvedNexthop] {
+        self.entries
+            .get(&nh)
+            .map(|e| e.nexthops.as_slice())
+            .unwrap_or(&[])
     }
 }
 
@@ -108,19 +136,41 @@ mod tests {
         assert_eq!(c.track(nh, NhtDep::V4(p2)), (false, false));
     }
 
+    fn reachable(labels: Vec<u32>) -> NexthopResolution {
+        NexthopResolution {
+            reachable: true,
+            metric: 10,
+            nexthops: vec![ResolvedNexthop {
+                addr: "172.16.0.2".parse().unwrap(),
+                ifindex: 3,
+                labels,
+            }],
+        }
+    }
+
     #[test]
-    fn update_returns_deps_only_on_change() {
+    fn update_returns_deps_only_on_change_and_stores_transport() {
         let mut c = NexthopCache::default();
         let nh: IpAddr = "10.0.0.8".parse().unwrap();
         let p1: Ipv4Net = "1.0.0.0/24".parse().unwrap();
         c.track(nh, NhtDep::V4(p1));
 
-        // pending(false) -> reachable(true): change, deps returned.
-        let deps = c.update(nh, true);
+        // pending(false) -> reachable(true): change, deps returned, and
+        // the resolved transport is now retrievable.
+        let deps = c.update(nh, &reachable(vec![16800]));
         assert_eq!(deps, vec![NhtDep::V4(p1)]);
-        // same value again: no change, no deps.
-        assert!(c.update(nh, true).is_empty());
-        // unknown nexthop: no deps.
-        assert!(c.update("9.9.9.9".parse().unwrap(), false).is_empty());
+        assert_eq!(c.transport_for(nh).len(), 1);
+        assert_eq!(c.transport_for(nh)[0].labels, vec![16800]);
+        assert_eq!(c.transport_for(nh)[0].ifindex, 3);
+
+        // still reachable, transport label changed: no reachability
+        // flip → no deps, but the stored transport refreshes.
+        assert!(c.update(nh, &reachable(vec![16801])).is_empty());
+        assert_eq!(c.transport_for(nh)[0].labels, vec![16801]);
+
+        // unknown nexthop: no deps, empty transport.
+        let unknown: IpAddr = "9.9.9.9".parse().unwrap();
+        assert!(c.update(unknown, &NexthopResolution::default()).is_empty());
+        assert!(c.transport_for(unknown).is_empty());
     }
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -505,6 +505,17 @@ impl<P: Prefix + Copy> LocalRibTable<P> {
         changed
     }
 
+    /// A representative candidate's attr for `prefix`. Used by the NHT
+    /// re-eval to resolve the importing-VRF set for a VPN withdraw when
+    /// the prefix has no winner left (the gate withdrew it), so the RT
+    /// extcomms are still available.
+    pub fn candidate_attr(&self, prefix: P) -> Option<Arc<BgpAttr>> {
+        self.0
+            .get(&prefix)
+            .and_then(|c| c.first())
+            .map(|r| r.attr.clone())
+    }
+
     fn is_better(cand: &BgpRib, incb: &BgpRib) -> (bool, Reason) {
         // NHT gate: a path whose next-hop resolves is strictly better
         // than one whose next-hop is unreachable, ahead of every other
@@ -997,6 +1008,27 @@ fn nht_track_received(bgp: &mut BgpTop, rib: &mut BgpRib, dep: super::nht::NhtDe
     }
 }
 
+/// The VPN service label + resolved transport for a winning VPNv4
+/// route, for the per-VRF dataplane install. The service label rides
+/// on `winner.label` (the received NLRI label); the transport egress(es)
+/// come from the global NHT cache keyed by the remote-PE next-hop.
+/// Returns `(0, &[])` outside the global instance (no `nexthop_cache`)
+/// or when the PE next-hop hasn't resolved — yielding no FIB install.
+fn vpn_import_transport<'a>(
+    bgp: &'a BgpTop,
+    winner: &BgpRib,
+) -> (u32, &'a [rib::nht::ResolvedNexthop]) {
+    let label = winner.label.map(|l| l.label).unwrap_or(0);
+    let transport = match (
+        bgp.nexthop_cache.as_deref(),
+        super::nht::bgp_nexthop_ip(&winner.attr),
+    ) {
+        (Some(cache), Some(nh)) => cache.transport_for(nh),
+        _ => &[][..],
+    };
+    (label, transport)
+}
+
 pub fn route_ipv4_update(
     ident: usize,
     nlri: &Ipv4Nlri,
@@ -1137,7 +1169,16 @@ pub fn route_ipv4_update(
         && let Some(dispatcher) = bgp.vrf_import
     {
         if let Some(winner) = selected.first() {
-            super::vrf::dispatch_import_v4(dispatcher, rd, nlri.prefix, &winner.attr, 0, None);
+            let (label, transport) = vpn_import_transport(bgp, winner);
+            super::vrf::dispatch_import_v4(
+                dispatcher,
+                rd,
+                nlri.prefix,
+                &winner.attr,
+                label,
+                transport,
+                None,
+            );
         } else {
             // best-path stripped the candidate; flood withdraw
             // using the *new* attr (the one just rejected) so
@@ -2153,7 +2194,16 @@ pub fn route_ipv4_withdraw(
         && let Some(dispatcher) = bgp.vrf_import
     {
         if let Some(winner) = selected.first() {
-            super::vrf::dispatch_import_v4(dispatcher, rd, nlri.prefix, &winner.attr, 0, None);
+            let (label, transport) = vpn_import_transport(bgp, winner);
+            super::vrf::dispatch_import_v4(
+                dispatcher,
+                rd,
+                nlri.prefix,
+                &winner.attr,
+                label,
+                transport,
+                None,
+            );
         } else if let Some(gone) = removed.first() {
             super::vrf::dispatch_withdraw_import_v4(dispatcher, rd, nlri.prefix, &gone.attr, None);
         }

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -210,6 +210,7 @@ pub fn dispatch_import_v4(
     prefix: ipnet::Ipv4Net,
     attr: &bgp_packet::BgpAttr,
     label: u32,
+    transport: &[crate::rib::nht::ResolvedNexthop],
     skip_vrf: Option<&str>,
 ) {
     let matches =
@@ -223,8 +224,62 @@ pub fn dispatch_import_v4(
             prefix,
             attr: attr.clone(),
             label,
+            transport: transport.to_vec(),
         });
     }
+}
+
+/// Build the VRF FIB entry for an imported VPNv4 route. The label
+/// stack is transport-labels (outer, from the resolved egress) with
+/// the VPN service `label` pushed innermost (bottom of stack) — the
+/// order the netlink encoder treats as top-of-stack-first. One
+/// `NexthopUni` per resolved egress (`Multi` for transport ECMP),
+/// installed as a `Bgp` route at iBGP administrative distance (imported
+/// VPN routes arrive via MP-iBGP).
+///
+/// Returns `None` when there's no resolved transport — nothing is
+/// installable and the caller withdraws instead. The label-less
+/// baseline (`labels` empty, `service_label == 0`) yields a bare
+/// `via addr dev ifindex`.
+fn build_vpn_fib_entry(
+    service_label: u32,
+    transport: &[crate::rib::nht::ResolvedNexthop],
+) -> Option<crate::rib::entry::RibEntry> {
+    if transport.is_empty() {
+        return None;
+    }
+    let mk_uni = |egress: &crate::rib::nht::ResolvedNexthop| {
+        let mut labels: Vec<crate::rib::Label> = egress
+            .labels
+            .iter()
+            .copied()
+            .map(crate::rib::Label::Explicit)
+            .collect();
+        if service_label != 0 {
+            labels.push(crate::rib::Label::Explicit(service_label));
+        }
+        let mut uni = crate::rib::NexthopUni::new(egress.addr, 0, labels);
+        if egress.ifindex != 0 {
+            uni.ifindex_origin = Some(egress.ifindex);
+        }
+        uni.valid = true;
+        uni
+    };
+    let nexthop = if transport.len() == 1 {
+        crate::rib::Nexthop::Uni(mk_uni(&transport[0]))
+    } else {
+        let mut multi = crate::rib::NexthopMulti::default();
+        for egress in transport {
+            multi.nexthops.push(mk_uni(egress));
+        }
+        crate::rib::Nexthop::Multi(multi)
+    };
+    let mut entry = crate::rib::entry::RibEntry::new(crate::rib::RibType::Bgp);
+    entry.distance = 200;
+    entry.metric = 0;
+    entry.valid = true;
+    entry.nexthop = nexthop;
+    Some(entry)
 }
 
 /// Inverse of [`dispatch_import_v4`]. Floods
@@ -474,6 +529,7 @@ impl BgpVrf {
         prefix: ipnet::Ipv4Net,
         mut attr: bgp_packet::BgpAttr,
         label: u32,
+        transport: &[crate::rib::nht::ResolvedNexthop],
     ) {
         // Rewrite the next-hop to "self" (the VRF's router-id)
         // so CE peers receive a reachable v4 address.
@@ -547,6 +603,41 @@ impl BgpVrf {
             winners,
             "bgp vrf: ImportV4 written to LocRIB and advertised to CE peers",
         );
+
+        // VPN dataplane install. Only the global Bgp task gates the
+        // remote-PE transport and stamps `transport`; a real VRF task's
+        // `ctx.rib` is bound to the VRF table (`vrf_id != 0`), so this
+        // `Ipv4Add` auto-lands there. Install only when the imported
+        // route is the VRF best-path *and* we have a resolved
+        // transport; otherwise withdraw any stale FIB entry. The
+        // placeholder (no-kernel) context has `vrf_id == 0` — skip it
+        // so installs never leak into the default table.
+        if self.ctx.vrf_id() != 0 {
+            let imported_won = selected
+                .first()
+                .is_some_and(|w| matches!(w.typ, super::super::route::BgpRibType::Originated));
+            let entry = if imported_won {
+                build_vpn_fib_entry(label, transport)
+            } else {
+                None
+            };
+            match entry {
+                Some(rib) => {
+                    let _ = self
+                        .ctx
+                        .rib
+                        .send(crate::rib::Message::Ipv4Add { prefix, rib });
+                }
+                None => {
+                    let mut stub = crate::rib::entry::RibEntry::new(crate::rib::RibType::Bgp);
+                    stub.valid = false;
+                    let _ = self
+                        .ctx
+                        .rib
+                        .send(crate::rib::Message::Ipv4Del { prefix, rib: stub });
+                }
+            }
+        }
     }
 
     /// Drop an imported route from the per-VRF LocRIB
@@ -593,6 +684,20 @@ impl BgpVrf {
             winners,
             "bgp vrf: WithdrawImport removed from LocRIB and withdrawn from CE peers",
         );
+
+        // Remove the VRF FIB entry. WithdrawImport only arrives when the
+        // VPNv4 route truly went away (a replacement winner re-imports
+        // via ImportV4 instead), so the imported dataplane entry should
+        // go. A no-op for a never-installed prefix — the RIB ignores a
+        // Del it never saw.
+        if self.ctx.vrf_id() != 0 {
+            let mut stub = crate::rib::entry::RibEntry::new(crate::rib::RibType::Bgp);
+            stub.valid = false;
+            let _ = self
+                .ctx
+                .rib
+                .send(crate::rib::Message::Ipv4Del { prefix, rib: stub });
+        }
     }
 
     /// VPNv6 counterpart of [`Self::handle_import_v4`]. Inserts the
@@ -739,8 +844,9 @@ impl BgpVrf {
                 prefix,
                 attr,
                 label,
+                transport,
             } => {
-                self.handle_import_v4(rd, prefix, attr, label);
+                self.handle_import_v4(rd, prefix, attr, label, &transport);
             }
             BgpVrfMsg::WithdrawImport { rd, prefix } => {
                 self.handle_withdraw_import(rd, prefix);
@@ -890,6 +996,80 @@ mod tests {
                 assert_eq!(p, prefix);
             }
             other => panic!("expected WithdrawExport, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vpn_fib_entry_pushes_service_label_below_transport() {
+        use crate::rib::nht::ResolvedNexthop;
+
+        // Remote PE resolves to one on-link egress with an SR-MPLS
+        // transport label 16800; VPN service label is 24001.
+        let transport = vec![ResolvedNexthop {
+            addr: "172.16.0.2".parse().unwrap(),
+            ifindex: 5,
+            labels: vec![16800],
+        }];
+        let entry = build_vpn_fib_entry(24001, &transport).expect("installable");
+        assert_eq!(entry.rtype, crate::rib::RibType::Bgp);
+        assert_eq!(entry.distance, 200, "imported VPN routes arrive via iBGP");
+        match entry.nexthop {
+            crate::rib::Nexthop::Uni(uni) => {
+                assert_eq!(uni.addr, "172.16.0.2".parse::<std::net::IpAddr>().unwrap());
+                assert_eq!(uni.ifindex(), Some(5));
+                // Top-of-stack first: transport (outer) then service
+                // (inner / bottom of stack).
+                assert_eq!(uni.mpls_label, vec![16800, 24001]);
+            }
+            other => panic!("expected Uni nexthop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vpn_fib_entry_label_less_baseline_and_empty_transport() {
+        use crate::rib::nht::ResolvedNexthop;
+
+        // Plain-IP transport (no SR labels) still carries the VPN
+        // service label as the only (bottom-of-stack) label.
+        let transport = vec![ResolvedNexthop {
+            addr: "172.16.0.2".parse().unwrap(),
+            ifindex: 5,
+            labels: vec![],
+        }];
+        let entry = build_vpn_fib_entry(24001, &transport).expect("installable");
+        match entry.nexthop {
+            crate::rib::Nexthop::Uni(uni) => assert_eq!(uni.mpls_label, vec![24001]),
+            other => panic!("expected Uni nexthop, got {other:?}"),
+        }
+
+        // No resolved transport → nothing installable (caller withdraws).
+        assert!(build_vpn_fib_entry(24001, &[]).is_none());
+    }
+
+    #[test]
+    fn vpn_fib_entry_ecmp_builds_multi() {
+        use crate::rib::nht::ResolvedNexthop;
+
+        let transport = vec![
+            ResolvedNexthop {
+                addr: "172.16.0.2".parse().unwrap(),
+                ifindex: 5,
+                labels: vec![16800],
+            },
+            ResolvedNexthop {
+                addr: "172.16.1.2".parse().unwrap(),
+                ifindex: 6,
+                labels: vec![16801],
+            },
+        ];
+        let entry = build_vpn_fib_entry(24001, &transport).expect("installable");
+        match entry.nexthop {
+            crate::rib::Nexthop::Multi(multi) => {
+                assert_eq!(multi.nexthops.len(), 2);
+                assert_eq!(multi.nexthops[0].mpls_label, vec![16800, 24001]);
+                assert_eq!(multi.nexthops[1].mpls_label, vec![16801, 24001]);
+            }
+            other => panic!("expected Multi nexthop, got {other:?}"),
         }
     }
 }

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -18,6 +18,8 @@ use tokio::net::TcpStream;
 
 use bgp_packet::{BgpAttr, RouteDistinguisher};
 
+use crate::rib::nht::ResolvedNexthop;
+
 /// Message from the global `Bgp` task to a per-VRF [`BgpVrf`]
 /// task. The receiver lives on `BgpVrf::global_rx`.
 #[derive(Debug)]
@@ -43,6 +45,12 @@ pub enum BgpVrfMsg {
         prefix: ipnet::Ipv4Net,
         attr: BgpAttr,
         label: u32,
+        /// Resolved transport egress(es) for the remote PE next-hop,
+        /// from the global NHT cache. The per-VRF task pushes the VPN
+        /// service `label` (inner) plus each egress's transport labels
+        /// (outer) and installs the result into the VRF FIB. Empty for
+        /// a label-less / unresolved transport (no FIB install).
+        transport: Vec<ResolvedNexthop>,
     },
 
     /// Withdraw a previously-imported route. RD identifies the

--- a/zebra-rs/src/context/proto.rs
+++ b/zebra-rs/src/context/proto.rs
@@ -99,10 +99,9 @@ impl ProtoContext {
         }
     }
 
-    /// Read-only accessor for the VRF id. Only same-file tests
-    /// consult it today; the bin target reaches the field through
-    /// `maybe_bind_device` instead, so the lint requires the allow.
-    #[allow(dead_code)]
+    /// Read-only accessor for the VRF id (= the kernel `table_id`,
+    /// `0` for the default table). The per-VRF BGP import path consults
+    /// it to gate the VPN dataplane install on having a real VRF table.
     pub fn vrf_id(&self) -> u32 {
         self.vrf_id
     }


### PR DESCRIPTION
## Summary

The **originating goal** of the Next-Hop Tracking series: get remote-PE-imported L3VPN routes into the kernel dataplane. PRs #1010 (RIB NHT service) and #1011 (BGP register-then-gate consumer) built recursive next-hop resolution; the egress decap path (per-VRF label + `IlmType::DecapVrf` ILM) already existed. This PR wires the **ingress install** for VPNv4.

When a VPNv4 route is imported into a VRF, the per-VRF task now programs a FIB entry whose MPLS label stack is **{VPN service label (inner/bottom), resolved transport labels (outer)}** over the resolved transport egress. The per-VRF BGP task's rib client is VRF-bound (`subscribe_for_vrf`), so a plain `Ipv4Add` auto-targets the VRF kernel table.

## Changes

- **Cache carries transport** — `bgp::nht::NexthopCache` now stores the resolved egresses (`ResolvedNexthop`) next to reachability, exposed via `transport_for`; the `RibRx::NexthopUpdate` handler feeds it the whole resolution.
- **Message + dispatch** — `BgpVrfMsg::ImportV4` and `dispatch_import_v4` carry the resolved transport to the per-VRF task.
- **Re-eval drives the install** — register-then-gate means an imported route only becomes best-path *after* its PE next-hop resolves asynchronously, so the import dispatch is now (re-)driven from `nht_reeval_dep` (V4vpn arm): install on resolve, withdraw on PE failure.
- **Per-VRF FIB install** — `handle_import_v4` builds the `{service,transport}`-labelled entry via `build_vpn_fib_entry` (ECMP-aware `Multi`, label-less baseline supported) and installs it when the imported route is the VRF best-path *and* the task has a real VRF table (`ctx.vrf_id() != 0`); `handle_withdraw_import` removes it. Local VRF-to-VRF leak passes empty transport (no install — not the gated SR-MPLS path).

## Label stack ordering

The NHT resolver returns transport labels outermost-first; the netlink encoder treats the stack Vec as top-of-stack-first (`bottom_of_stack: i == last`). The service label is pushed last (innermost / bottom of stack), matching MPLS L3VPN forwarding. Unit-tested.

## Follow-ups (not in this PR)

- **VPNv6 install** — needs the VPNv6 NLRI label propagated through `route_ipv6_update` first, then mirror this for the V6vpn dep.
- Per-VRF best-path vs CE-route FIB arbitration (CE→FIB install doesn't exist yet).
- Transport-reroute re-install (currently only a reachability flip re-installs).
- Untrack-on-withdrawal of the BGP NHT cache (`Message::NexthopUnregister` producer).

## Test plan

- `cargo build -p zebra-rs` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p zebra-rs bgp::` (192) / `rib::` (146) / `bgp::vrf::` (18) — pass, including the new `build_vpn_fib_entry` tests (label order, label-less baseline, empty transport, ECMP) and the extended `NexthopCache` transport tests.
- CI is the source of truth for the full suite.

Generated with [Claude Code](https://claude.com/claude-code)