### PR TITLE
bgp: install imported VPNv6 routes into the VRF dataplane

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1322,11 +1322,10 @@ impl Bgp {
     /// Re-evaluate one dependent prefix after its next-hop's
     /// reachability flipped: refresh the candidates' gate flag, re-run
     /// best-path, then re-advertise (and, for unicast, reconcile the
-    /// FIB). For VPNv4 deps this also (re-)dispatches the per-VRF import
-    /// with the resolved transport — register-then-gate means an
+    /// FIB). For VPNv4/v6 deps this also (re-)dispatches the per-VRF
+    /// import with the resolved transport — register-then-gate means an
     /// imported route only becomes best-path here, so this is where the
-    /// VRF dataplane install is triggered. (VPNv6 re-dispatch lands with
-    /// the VPNv6 install in a follow-up.)
+    /// VRF dataplane install is triggered.
     fn nht_reeval_dep(&mut self, nh: std::net::IpAddr, reachable: bool, dep: super::nht::NhtDep) {
         use super::nht::NhtDep;
         // Refresh gate flags + re-select (mutates `local_rib`).
@@ -1435,6 +1434,33 @@ impl Bgp {
                     &mut top,
                     &mut self.peers,
                 );
+                // VPNv6 counterpart of the V4vpn arm: (re-)dispatch the
+                // VRF import with the resolved transport once the PE
+                // next-hop resolves, or withdraw on PE failure.
+                let dispatcher = super::vrf::VrfImportDispatcher {
+                    rib_known_vrfs: &self.rib_known_vrfs,
+                    vrf_registry: &self.vrf_registry,
+                };
+                if reachable && let Some(winner) = selected.first() {
+                    let label = winner.label.map(|l| l.label).unwrap_or(0);
+                    let transport = self.nexthop_cache.transport_for(nh);
+                    super::vrf::dispatch_import_v6(
+                        &dispatcher,
+                        *rd,
+                        *p,
+                        &winner.attr,
+                        label,
+                        transport,
+                        None,
+                    );
+                } else if let Some(attr) = self
+                    .local_rib
+                    .v6vpn
+                    .get(rd)
+                    .and_then(|t| t.candidate_attr(*p))
+                {
+                    super::vrf::dispatch_withdraw_import_v6(&dispatcher, *rd, *p, &attr, None);
+                }
             }
         }
     }
@@ -1932,6 +1958,8 @@ impl Bgp {
                         prefix,
                         &winner.attr,
                         0,
+                        // Local VRF-to-VRF leak: no SR-MPLS transport.
+                        &[],
                         Some(vrf.as_str()),
                     );
                 }
@@ -1991,6 +2019,7 @@ impl Bgp {
                             prefix,
                             &winner.attr,
                             0,
+                            &[],
                             Some(vrf.as_str()),
                         );
                     } else if let Some(gone) = removed.first() {

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2230,6 +2230,7 @@ pub fn route_ipv6_update(
     ident: usize,
     nlri: &Ipv6Nlri,
     rd: Option<RouteDistinguisher>,
+    label: Option<Label>,
     attr: &BgpAttr,
     nexthop: Option<VpnNexthop>,
     bgp: &mut BgpTop,
@@ -2273,7 +2274,7 @@ pub fn route_ipv6_update(
         nlri.id,
         0,
         attr,
-        None,    // no label here (the VPNv6 label rides on the NLRI)
+        label,   // VPNv6 service label (None for plain v6 unicast)
         nexthop, // VpnNexthop::V6 for VPNv6 rows; None for unicast
         stale,
     );
@@ -2335,12 +2336,14 @@ pub fn route_ipv6_update(
             // on the remote ingress path.
             if let Some(dispatcher) = bgp.vrf_import {
                 if let Some(winner) = selected.first() {
+                    let (label, transport) = vpn_import_transport(bgp, winner);
                     super::vrf::dispatch_import_v6(
                         dispatcher,
                         rd,
                         nlri.prefix,
                         &winner.attr,
-                        0,
+                        label,
+                        transport,
                         None,
                     );
                 } else {
@@ -2391,12 +2394,14 @@ pub fn route_ipv6_withdraw(
             // the removed row's RTs.
             if let Some(dispatcher) = bgp.vrf_import {
                 if let Some(winner) = selected.first() {
+                    let (label, transport) = vpn_import_transport(bgp, winner);
                     super::vrf::dispatch_import_v6(
                         dispatcher,
                         rd,
                         nlri.prefix,
                         &winner.attr,
-                        0,
+                        label,
+                        transport,
                         None,
                     );
                 } else if let Some(gone) = removed.first() {
@@ -2944,7 +2949,9 @@ pub fn route_from_peer(
                     let mut attr_v6 = bgp_attr.clone();
                     attr_v6.nexthop = Some(BgpNexthop::Ipv6(nh6));
                     for update in updates.iter() {
-                        route_ipv6_update(peer_id, update, None, &attr_v6, None, bgp, peers, false);
+                        route_ipv6_update(
+                            peer_id, update, None, None, &attr_v6, None, bgp, peers, false,
+                        );
                     }
                 } else {
                     tracing::warn!(
@@ -2962,6 +2969,7 @@ pub fn route_from_peer(
                         peer_id,
                         &update.nlri,
                         Some(update.rd),
+                        Some(update.label),
                         bgp_attr,
                         Some(VpnNexthop::V6(nlri.nhop.clone())),
                         bgp,

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -314,6 +314,7 @@ pub fn dispatch_import_v6(
     prefix: ipnet::Ipv6Net,
     attr: &bgp_packet::BgpAttr,
     label: u32,
+    transport: &[crate::rib::nht::ResolvedNexthop],
     skip_vrf: Option<&str>,
 ) {
     let matches =
@@ -327,6 +328,7 @@ pub fn dispatch_import_v6(
             prefix,
             attr: attr.clone(),
             label,
+            transport: transport.to_vec(),
         });
     }
 }
@@ -715,6 +717,7 @@ impl BgpVrf {
         prefix: ipnet::Ipv6Net,
         mut attr: bgp_packet::BgpAttr,
         label: u32,
+        transport: &[crate::rib::nht::ResolvedNexthop],
     ) {
         attr.nexthop = None;
         let interned = self.attr_store.intern(attr);
@@ -779,6 +782,37 @@ impl BgpVrf {
             winners,
             "bgp vrf: ImportV6 written to LocRIB and advertised to CE peers",
         );
+
+        // VPN dataplane install — VPNv6 counterpart of
+        // `handle_import_v4`. Install when the imported route is the VRF
+        // best-path and we have a real VRF table + resolved transport;
+        // otherwise withdraw any stale FIB entry.
+        if self.ctx.vrf_id() != 0 {
+            let imported_won = selected
+                .first()
+                .is_some_and(|w| matches!(w.typ, super::super::route::BgpRibType::Originated));
+            let entry = if imported_won {
+                build_vpn_fib_entry(label, transport)
+            } else {
+                None
+            };
+            match entry {
+                Some(rib) => {
+                    let _ = self
+                        .ctx
+                        .rib
+                        .send(crate::rib::Message::Ipv6Add { prefix, rib });
+                }
+                None => {
+                    let mut stub = crate::rib::entry::RibEntry::new(crate::rib::RibType::Bgp);
+                    stub.valid = false;
+                    let _ = self
+                        .ctx
+                        .rib
+                        .send(crate::rib::Message::Ipv6Del { prefix, rib: stub });
+                }
+            }
+        }
     }
 
     /// VPNv6 counterpart of [`Self::handle_withdraw_import`].
@@ -821,6 +855,16 @@ impl BgpVrf {
             winners,
             "bgp vrf: WithdrawImportV6 removed from LocRIB and withdrawn from CE peers",
         );
+
+        // Remove the VRF FIB entry — symmetric with `handle_import_v6`.
+        if self.ctx.vrf_id() != 0 {
+            let mut stub = crate::rib::entry::RibEntry::new(crate::rib::RibType::Bgp);
+            stub.valid = false;
+            let _ = self
+                .ctx
+                .rib
+                .send(crate::rib::Message::Ipv6Del { prefix, rib: stub });
+        }
     }
 
     /// Per-task handling of cross-task messages that aren't
@@ -856,8 +900,9 @@ impl BgpVrf {
                 prefix,
                 attr,
                 label,
+                transport,
             } => {
-                self.handle_import_v6(rd, prefix, attr, label);
+                self.handle_import_v6(rd, prefix, attr, label, &transport);
             }
             BgpVrfMsg::WithdrawImportV6 { rd, prefix } => {
                 self.handle_withdraw_import_v6(rd, prefix);
@@ -1070,6 +1115,29 @@ mod tests {
                 assert_eq!(multi.nexthops[1].mpls_label, vec![16801, 24001]);
             }
             other => panic!("expected Multi nexthop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vpn_fib_entry_v6_egress() {
+        use crate::rib::nht::ResolvedNexthop;
+
+        // VPNv6: the remote PE (and thus the resolved transport egress)
+        // is an IPv6 address; the {transport,service} label stack is
+        // built the same way over the v6 next-hop.
+        let transport = vec![ResolvedNexthop {
+            addr: "2001:db8::2".parse().unwrap(),
+            ifindex: 7,
+            labels: vec![16900],
+        }];
+        let entry = build_vpn_fib_entry(24002, &transport).expect("installable");
+        match entry.nexthop {
+            crate::rib::Nexthop::Uni(uni) => {
+                assert_eq!(uni.addr, "2001:db8::2".parse::<std::net::IpAddr>().unwrap());
+                assert_eq!(uni.ifindex(), Some(7));
+                assert_eq!(uni.mpls_label, vec![16900, 24002]);
+            }
+            other => panic!("expected Uni nexthop, got {other:?}"),
         }
     }
 }

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -69,6 +69,9 @@ pub enum BgpVrfMsg {
         prefix: ipnet::Ipv6Net,
         attr: BgpAttr,
         label: u32,
+        /// Resolved transport egress(es) for the remote PE next-hop —
+        /// VPNv6 counterpart of [`Self::ImportV4`]'s `transport`.
+        transport: Vec<ResolvedNexthop>,
     },
 
     /// VPNv6 counterpart of [`Self::WithdrawImport`].


### PR DESCRIPTION
## Summary

PR3b — the **VPNv6 counterpart** of the imported-VPNv4 dataplane install (#1012). Completes the L3VPN ingress install for both address families.

## Prerequisite: propagate the VPNv6 service label

The VPNv6 NLRI service label was being dropped on receive — `route_ipv6_update` had no label parameter, so `BgpRib.label` was always `None` for VPNv6. This PR threads it through:
- `route_ipv6_update` gains `label: Option<Label>`, stored on the `BgpRib`.
- `MpReachAttr::Vpnv6` passes `Some(update.label)`; plain v6 unicast passes `None`.

## Mirror the VPNv4 install for the V6vpn dep

- **Message + dispatch** — `BgpVrfMsg::ImportV6` and `dispatch_import_v6` carry the resolved transport; the v6 receive + withdraw dispatch reuse the shared `vpn_import_transport` helper.
- **Re-eval drives the install** — `nht_reeval_dep`'s V6vpn arm (re-)dispatches the import with the resolved transport on resolve, withdraws on PE failure. Register-then-gate means the imported route only becomes best-path here.
- **Per-VRF FIB install** — `handle_import_v6` builds the `{transport,service}`-labelled entry via the shared `build_vpn_fib_entry` and sends `Ipv6Add` (auto-targets the VRF table via the VRF-bound rib client) when the imported route is the VRF best-path and the task has a real VRF table (`ctx.vrf_id() != 0`); `handle_withdraw_import_v6` sends the matching `Ipv6Del`. Local VRF-to-VRF leak passes empty transport (no install).

The entry-build and label-stack ordering logic is shared with VPNv4, so no new ordering risk.

## Follow-ups (unchanged)

- Per-VRF best-path vs CE-route FIB arbitration.
- Transport-reroute re-install (only a reachability flip re-installs).
- Untrack-on-withdrawal of the BGP NHT cache.
- Static-route NHT consumer.

## Test plan

- `cargo build -p zebra-rs` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p zebra-rs bgp::` (193) / `rib::` (146) / `bgp::vrf::` (19) — pass, including the new `vpn_fib_entry_v6_egress` test (IPv6 next-hop + label stack).
- CI is the source of truth for the full suite.

Generated with [Claude Code](https://claude.com/claude-code)