### PR TITLE
bgp: arbitrate VRF FIB between imported VPN and CE routes

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -90,6 +90,8 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
             flex_algo_routes: Some(&bgp.flex_algo_routes),
             vrf_import: None,
             nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
         };
         route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers);
         bgp.peers.remove(&addr);

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -749,6 +749,8 @@ impl Bgp {
                     flex_algo_routes: Some(&self.flex_algo_routes),
                     vrf_import: Some(&import_dispatcher),
                     nexthop_cache: Some(&mut self.nexthop_cache),
+                    vrf_transport_v4: None,
+                    vrf_transport_v6: None,
                 };
 
                 fsm(&mut bgp_ref, &mut self.peers, ident, event);
@@ -1369,6 +1371,8 @@ impl Bgp {
             vrf_export: None,
             vrf_import: None,
             nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
         };
         match &dep {
             NhtDep::V4(p) => {
@@ -1773,6 +1777,8 @@ impl Bgp {
                     vrf_export: None,
                     vrf_import: None,
                     nexthop_cache: None,
+                    vrf_transport_v4: None,
+                    vrf_transport_v6: None,
                 };
                 super::route::route_advertise_to_peers(
                     Some(rd),
@@ -1860,6 +1866,8 @@ impl Bgp {
                     vrf_export: None,
                     vrf_import: None,
                     nexthop_cache: None,
+                    vrf_transport_v4: None,
+                    vrf_transport_v6: None,
                 };
                 super::route::route_advertise_to_peers(
                     Some(rd),
@@ -1977,6 +1985,8 @@ impl Bgp {
                     vrf_export: None,
                     vrf_import: None,
                     nexthop_cache: None,
+                    vrf_transport_v4: None,
+                    vrf_transport_v6: None,
                 };
                 super::route::route_advertise_to_peers_vpnv6(
                     rd,
@@ -2046,6 +2056,8 @@ impl Bgp {
                     vrf_export: None,
                     vrf_import: None,
                     nexthop_cache: None,
+                    vrf_transport_v4: None,
+                    vrf_transport_v6: None,
                 };
                 super::route::route_advertise_to_peers_vpnv6(
                     rd,

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -669,6 +669,18 @@ pub struct BgpTop<'a> {
     /// in per-VRF tasks and the local-origination/advertise BgpTops
     /// (no gating there).
     pub nexthop_cache: Option<&'a mut super::nht::NexthopCache>,
+    /// Per-VRF imported-route transport maps, keyed by prefix. `Some`
+    /// only inside a `BgpVrf` task; they let `fib_install_v4`/`v6`
+    /// program an imported VPN winner's `{transport,service}` labelled
+    /// tunnel entry instead of the plain next-hop entry, so CE-learned
+    /// and imported routes arbitrate through one install path. `None`
+    /// on the global instance (plain unicast / VPN take other paths).
+    pub vrf_transport_v4: Option<
+        &'a std::collections::BTreeMap<ipnet::Ipv4Net, Vec<crate::rib::nht::ResolvedNexthop>>,
+    >,
+    pub vrf_transport_v6: Option<
+        &'a std::collections::BTreeMap<ipnet::Ipv6Net, Vec<crate::rib::nht::ResolvedNexthop>>,
+    >,
     /// Colour-aware nexthop resolver inputs. Optional because
     /// per-VRF BGP runtimes don't carry them today — Color →
     /// Flex-Algo binding is a default-VRF concept; per-VRF support
@@ -1648,6 +1660,8 @@ pub fn apply_soft_in_peer(bgp: &mut Bgp, peer_idx: usize) {
             flex_algo_routes: Some(&bgp.flex_algo_routes),
             vrf_import: None,
             nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
         };
         super::route::route_soft_in_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
     } else if supports_refresh {
@@ -1682,6 +1696,8 @@ pub fn apply_soft_out_peer(bgp: &mut Bgp, peer_idx: usize) {
         flex_algo_routes: Some(&bgp.flex_algo_routes),
         vrf_import: None,
         nexthop_cache: None,
+        vrf_transport_v4: None,
+        vrf_transport_v6: None,
     };
     super::route::route_soft_out_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -85,22 +85,108 @@ fn make_bgp_rib_entry_v4(best: &BgpRib) -> Option<rib::entry::RibEntry> {
     Some(entry)
 }
 
+/// Build the VRF FIB entry for an imported VPN route. The label stack
+/// is transport-labels (outer, from the resolved egress) with the VPN
+/// service `service_label` pushed innermost (bottom of stack) — the
+/// order the netlink encoder treats as top-of-stack-first. One
+/// `NexthopUni` per resolved egress (`Multi` for transport ECMP),
+/// installed as a `Bgp` route at iBGP administrative distance (imported
+/// VPN routes arrive via MP-iBGP). Address-family-agnostic: the egress
+/// `addr` is v4 for VPNv4 and v6 for VPNv6.
+///
+/// Returns `None` when there's no resolved transport — nothing is
+/// installable and the caller withdraws instead. The label-less
+/// baseline (`labels` empty, `service_label == 0`) yields a bare
+/// `via addr dev ifindex`.
+fn build_vpn_fib_entry(
+    service_label: u32,
+    transport: &[rib::nht::ResolvedNexthop],
+) -> Option<rib::entry::RibEntry> {
+    if transport.is_empty() {
+        return None;
+    }
+    let mk_uni = |egress: &rib::nht::ResolvedNexthop| {
+        let mut labels: Vec<rib::Label> = egress
+            .labels
+            .iter()
+            .copied()
+            .map(rib::Label::Explicit)
+            .collect();
+        if service_label != 0 {
+            labels.push(rib::Label::Explicit(service_label));
+        }
+        let mut uni = rib::NexthopUni::new(egress.addr, 0, labels);
+        if egress.ifindex != 0 {
+            uni.ifindex_origin = Some(egress.ifindex);
+        }
+        uni.valid = true;
+        uni
+    };
+    let nexthop = if transport.len() == 1 {
+        rib::Nexthop::Uni(mk_uni(&transport[0]))
+    } else {
+        let mut multi = rib::NexthopMulti::default();
+        for egress in transport {
+            multi.nexthops.push(mk_uni(egress));
+        }
+        rib::Nexthop::Multi(multi)
+    };
+    let mut entry = rib::entry::RibEntry::new(rib::RibType::Bgp);
+    entry.distance = 200;
+    entry.metric = 0;
+    entry.valid = true;
+    entry.nexthop = nexthop;
+    Some(entry)
+}
+
+/// Whether `best` should install as a labelled VPN tunnel entry: an
+/// imported route (`Originated`) for which the VRF holds a resolved
+/// `transport`. `transport` is `None` outside a VRF (global instance),
+/// so this is always `false` there.
+fn is_vpn_fib_winner(best: &BgpRib, transport: Option<&[rib::nht::ResolvedNexthop]>) -> bool {
+    best.typ == BgpRibType::Originated && transport.is_some_and(|t| !t.is_empty())
+}
+
+/// Choose the IPv4 FIB entry for a best-path winner in a (possibly VRF)
+/// context. An imported VPN winner installs the `{transport,service}`
+/// labelled tunnel entry; a CE-learned / locally-originated / global
+/// route installs the plain next-hop entry. `transport` is `None`
+/// outside a VRF, so this reduces to `make_bgp_rib_entry_v4`.
+fn select_fib_entry_v4(
+    best: &BgpRib,
+    transport: Option<&[rib::nht::ResolvedNexthop]>,
+) -> Option<rib::entry::RibEntry> {
+    if is_vpn_fib_winner(best, transport) {
+        build_vpn_fib_entry(best.label.map(|l| l.label).unwrap_or(0), transport.unwrap())
+    } else {
+        make_bgp_rib_entry_v4(best)
+    }
+}
+
 /// Reconcile the kernel FIB state for `prefix` with the BGP best-path
 /// outcome. `selected` is the `select_best_path` return: at most one
 /// `BgpRib` after best-path selection. Empty means every candidate
 /// just disappeared — emit a withdraw.
 ///
-/// VPNv4 / EVPN take their own install paths; this helper is for
-/// plain IPv4 unicast only.
+/// In a per-VRF task this is the single install path for `rd == None`
+/// winners: imported VPN routes (carried in `bgp.vrf_transport_v4`)
+/// install their labelled tunnel entry, CE-learned routes install the
+/// plain next-hop entry, so whichever wins best-path is programmed
+/// correctly. On the global instance `vrf_transport_v4` is `None`, so
+/// this is plain IPv4 unicast install (VPNv4 / EVPN take other paths).
 pub(super) fn fib_install_v4(bgp: &super::peer::BgpTop, prefix: Ipv4Net, selected: &[BgpRib]) {
-    let installable = selected.first().and_then(make_bgp_rib_entry_v4);
-    match installable {
+    let transport = bgp
+        .vrf_transport_v4
+        .and_then(|m| m.get(&prefix))
+        .map(|v| v.as_slice());
+    let best = selected.first();
+    let entry = best.and_then(|b| select_fib_entry_v4(b, transport));
+    match entry {
         Some(mut rib_entry) => {
-            // Colour-aware Flex-Algo label push. When the route
-            // carries a Color extcomm bound to a configured IS-IS
-            // Flex-Algorithm, append the per-algo outer MPLS label
-            // IS-IS published via RIB.
-            if let Some(best) = selected.first()
+            // Colour-aware Flex-Algo label push — plain-path only; a
+            // VPN tunnel entry already carries its full label stack.
+            if let Some(best) = best
+                && !is_vpn_fib_winner(best, transport)
                 && let Some(BgpNexthop::Ipv4(nh)) = best.attr.nexthop.as_ref()
                 && let Some(label) = resolve_flex_algo_label(bgp, &best.attr, *nh)
                 && let rib::Nexthop::Uni(ref mut uni) = rib_entry.nexthop
@@ -163,11 +249,30 @@ fn make_bgp_rib_entry_v6(best: &BgpRib) -> Option<rib::entry::RibEntry> {
     Some(entry)
 }
 
-/// IPv6 counterpart of [`fib_install_v4`]: reconcile the kernel FIB
-/// for an IPv6 unicast prefix against the best-path outcome. Plain v6
-/// unicast only — VPNv6 will take its own install path (layer 2c+).
+/// IPv6 counterpart of [`select_fib_entry_v4`].
+fn select_fib_entry_v6(
+    best: &BgpRib,
+    transport: Option<&[rib::nht::ResolvedNexthop]>,
+) -> Option<rib::entry::RibEntry> {
+    if is_vpn_fib_winner(best, transport) {
+        build_vpn_fib_entry(best.label.map(|l| l.label).unwrap_or(0), transport.unwrap())
+    } else {
+        make_bgp_rib_entry_v6(best)
+    }
+}
+
+/// IPv6 counterpart of [`fib_install_v4`]: the single install path for
+/// `rd == None` v6 winners in a VRF (imported VPNv6 labelled entry vs
+/// CE plain entry), and plain v6 unicast install on the global instance.
 pub(super) fn fib_install_v6(bgp: &super::peer::BgpTop, prefix: Ipv6Net, selected: &[BgpRib]) {
-    match selected.first().and_then(make_bgp_rib_entry_v6) {
+    let transport = bgp
+        .vrf_transport_v6
+        .and_then(|m| m.get(&prefix))
+        .map(|v| v.as_slice());
+    match selected
+        .first()
+        .and_then(|b| select_fib_entry_v6(b, transport))
+    {
         Some(rib_entry) => {
             let _ = bgp.rib_client.send(rib::Message::Ipv6Add {
                 prefix,
@@ -4662,6 +4767,8 @@ impl Bgp {
             flex_algo_routes: Some(&self.flex_algo_routes),
             vrf_import: None,
             nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
         };
 
         // An originated route lacks a v4 NEXT_HOP attribute, so when
@@ -4702,6 +4809,8 @@ impl Bgp {
             flex_algo_routes: Some(&self.flex_algo_routes),
             vrf_import: None,
             nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
         };
 
         let selected = bgp_ref.local_rib.select_best_path(prefix);
@@ -4791,6 +4900,8 @@ impl Bgp {
             flex_algo_routes: Some(&self.flex_algo_routes),
             vrf_import: None,
             nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
         };
 
         // Same logic as `route_add`: the redistributed BGP route has
@@ -4829,6 +4940,8 @@ impl Bgp {
             flex_algo_routes: Some(&self.flex_algo_routes),
             vrf_import: None,
             nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
         };
 
         let selected = bgp_ref.local_rib.select_best_path(prefix);
@@ -4966,6 +5079,8 @@ impl Bgp {
             flex_algo_routes: Some(&self.flex_algo_routes),
             vrf_import: None,
             nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
         };
 
         if !selected.is_empty() {
@@ -5090,6 +5205,8 @@ impl Bgp {
             flex_algo_routes: Some(&self.flex_algo_routes),
             vrf_import: None,
             nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
         };
 
         if !selected.is_empty() {
@@ -6591,6 +6708,166 @@ mod tests {
     fn fib_entry_skipped_when_nexthop_missing() {
         let rib = bgp_rib_with_nexthop(None, super::BgpRibType::EBGP);
         assert!(super::make_bgp_rib_entry_v4(&rib).is_none());
+    }
+
+    // --- VRF FIB arbitration: select_fib_entry_v4 -----------------------
+
+    #[test]
+    fn select_fib_entry_v4_imported_with_transport_is_labelled() {
+        use crate::rib::nht::ResolvedNexthop;
+        // Imported (`Originated`) row: its `attr.nexthop` was rewritten
+        // to the VRF router-id (ignored here), the service label rides
+        // on `.label`, and the transport map supplies the real egress.
+        let mut rib = bgp_rib_with_nexthop(
+            Some(BgpNexthop::Ipv4(Ipv4Addr::new(10, 255, 0, 1))),
+            super::BgpRibType::Originated,
+        );
+        rib.label = Some(bgp_packet::Label {
+            label: 24001,
+            exp: 0,
+            bos: true,
+        });
+        let transport = vec![ResolvedNexthop {
+            addr: "172.16.0.2".parse().unwrap(),
+            ifindex: 5,
+            labels: vec![16800],
+        }];
+        let entry = super::select_fib_entry_v4(&rib, Some(&transport)).expect("labelled");
+        match entry.nexthop {
+            crate::rib::Nexthop::Uni(uni) => {
+                assert_eq!(uni.addr, "172.16.0.2".parse::<IpAddr>().unwrap());
+                assert_eq!(uni.ifindex(), Some(5));
+                assert_eq!(uni.mpls_label, vec![16800, 24001]);
+            }
+            other => panic!("expected Uni, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn select_fib_entry_v4_ce_winner_is_plain_even_with_transport() {
+        use crate::rib::nht::ResolvedNexthop;
+        // A CE (EBGP) winner installs the plain next-hop entry even when
+        // the prefix also has an imported transport — the arbitration
+        // guarantee that CE routes are never mis-labelled.
+        let rib = bgp_rib_with_nexthop(
+            Some(BgpNexthop::Ipv4(Ipv4Addr::new(192, 0, 2, 1))),
+            super::BgpRibType::EBGP,
+        );
+        let transport = vec![ResolvedNexthop {
+            addr: "172.16.0.2".parse().unwrap(),
+            ifindex: 5,
+            labels: vec![16800],
+        }];
+        let entry = super::select_fib_entry_v4(&rib, Some(&transport)).expect("plain");
+        match entry.nexthop {
+            crate::rib::Nexthop::Uni(uni) => {
+                assert_eq!(uni.addr, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)));
+                assert!(uni.mpls_label.is_empty(), "CE route carries no VPN labels");
+            }
+            other => panic!("expected Uni, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn select_fib_entry_v4_originated_without_transport_is_plain() {
+        // `Originated` but absent from the transport map (a locally-
+        // originated VRF route, not an import) → plain path, no self-loop.
+        let rib = bgp_rib_with_nexthop(
+            Some(BgpNexthop::Ipv4(Ipv4Addr::new(192, 0, 2, 9))),
+            super::BgpRibType::Originated,
+        );
+        let entry = super::select_fib_entry_v4(&rib, None).expect("plain");
+        match entry.nexthop {
+            crate::rib::Nexthop::Uni(uni) => {
+                assert_eq!(uni.addr, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 9)));
+                assert!(uni.mpls_label.is_empty());
+            }
+            other => panic!("expected Uni, got {other:?}"),
+        }
+    }
+
+    // --- build_vpn_fib_entry (moved from bgp/vrf/inst.rs) ----------------
+
+    #[test]
+    fn vpn_fib_entry_pushes_service_label_below_transport() {
+        use crate::rib::nht::ResolvedNexthop;
+        let transport = vec![ResolvedNexthop {
+            addr: "172.16.0.2".parse().unwrap(),
+            ifindex: 5,
+            labels: vec![16800],
+        }];
+        let entry = super::build_vpn_fib_entry(24001, &transport).expect("installable");
+        assert_eq!(entry.distance, 200, "imported VPN routes arrive via iBGP");
+        match entry.nexthop {
+            crate::rib::Nexthop::Uni(uni) => {
+                assert_eq!(uni.addr, "172.16.0.2".parse::<IpAddr>().unwrap());
+                assert_eq!(uni.ifindex(), Some(5));
+                // Top-of-stack first: transport (outer) then service (bottom).
+                assert_eq!(uni.mpls_label, vec![16800, 24001]);
+            }
+            other => panic!("expected Uni nexthop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vpn_fib_entry_label_less_baseline_and_empty_transport() {
+        use crate::rib::nht::ResolvedNexthop;
+        let transport = vec![ResolvedNexthop {
+            addr: "172.16.0.2".parse().unwrap(),
+            ifindex: 5,
+            labels: vec![],
+        }];
+        let entry = super::build_vpn_fib_entry(24001, &transport).expect("installable");
+        match entry.nexthop {
+            crate::rib::Nexthop::Uni(uni) => assert_eq!(uni.mpls_label, vec![24001]),
+            other => panic!("expected Uni nexthop, got {other:?}"),
+        }
+        assert!(super::build_vpn_fib_entry(24001, &[]).is_none());
+    }
+
+    #[test]
+    fn vpn_fib_entry_ecmp_builds_multi() {
+        use crate::rib::nht::ResolvedNexthop;
+        let transport = vec![
+            ResolvedNexthop {
+                addr: "172.16.0.2".parse().unwrap(),
+                ifindex: 5,
+                labels: vec![16800],
+            },
+            ResolvedNexthop {
+                addr: "172.16.1.2".parse().unwrap(),
+                ifindex: 6,
+                labels: vec![16801],
+            },
+        ];
+        let entry = super::build_vpn_fib_entry(24001, &transport).expect("installable");
+        match entry.nexthop {
+            crate::rib::Nexthop::Multi(multi) => {
+                assert_eq!(multi.nexthops.len(), 2);
+                assert_eq!(multi.nexthops[0].mpls_label, vec![16800, 24001]);
+                assert_eq!(multi.nexthops[1].mpls_label, vec![16801, 24001]);
+            }
+            other => panic!("expected Multi nexthop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vpn_fib_entry_v6_egress() {
+        use crate::rib::nht::ResolvedNexthop;
+        let transport = vec![ResolvedNexthop {
+            addr: "2001:db8::2".parse().unwrap(),
+            ifindex: 7,
+            labels: vec![16900],
+        }];
+        let entry = super::build_vpn_fib_entry(24002, &transport).expect("installable");
+        match entry.nexthop {
+            crate::rib::Nexthop::Uni(uni) => {
+                assert_eq!(uni.addr, "2001:db8::2".parse::<IpAddr>().unwrap());
+                assert_eq!(uni.ifindex(), Some(7));
+                assert_eq!(uni.mpls_label, vec![16900, 24002]);
+            }
+            other => panic!("expected Uni nexthop, got {other:?}"),
+        }
     }
 
     #[test]

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -97,6 +97,16 @@ pub struct BgpVrf {
     /// Threaded through `BgpTop` so the FSM driver compiles even
     /// though no path here populates it today.
     pub interface_addrs: InterfaceAddrs,
+    /// Resolved transport for currently-imported VPN prefixes, keyed by
+    /// prefix. Populated by `handle_import_v4`/`v6` (and cleared on
+    /// withdraw); read by `fib_install_v4`/`v6` (via `BgpTop`) so an
+    /// imported VPN winner installs its `{transport,service}` labelled
+    /// tunnel entry while CE routes install plain entries — one FIB
+    /// install path arbitrating both.
+    pub transport_v4:
+        std::collections::BTreeMap<ipnet::Ipv4Net, Vec<crate::rib::nht::ResolvedNexthop>>,
+    pub transport_v6:
+        std::collections::BTreeMap<ipnet::Ipv6Net, Vec<crate::rib::nht::ResolvedNexthop>>,
 }
 
 /// Sender side of the per-VRF inbound channel — handed back to
@@ -229,59 +239,6 @@ pub fn dispatch_import_v4(
     }
 }
 
-/// Build the VRF FIB entry for an imported VPNv4 route. The label
-/// stack is transport-labels (outer, from the resolved egress) with
-/// the VPN service `label` pushed innermost (bottom of stack) — the
-/// order the netlink encoder treats as top-of-stack-first. One
-/// `NexthopUni` per resolved egress (`Multi` for transport ECMP),
-/// installed as a `Bgp` route at iBGP administrative distance (imported
-/// VPN routes arrive via MP-iBGP).
-///
-/// Returns `None` when there's no resolved transport — nothing is
-/// installable and the caller withdraws instead. The label-less
-/// baseline (`labels` empty, `service_label == 0`) yields a bare
-/// `via addr dev ifindex`.
-fn build_vpn_fib_entry(
-    service_label: u32,
-    transport: &[crate::rib::nht::ResolvedNexthop],
-) -> Option<crate::rib::entry::RibEntry> {
-    if transport.is_empty() {
-        return None;
-    }
-    let mk_uni = |egress: &crate::rib::nht::ResolvedNexthop| {
-        let mut labels: Vec<crate::rib::Label> = egress
-            .labels
-            .iter()
-            .copied()
-            .map(crate::rib::Label::Explicit)
-            .collect();
-        if service_label != 0 {
-            labels.push(crate::rib::Label::Explicit(service_label));
-        }
-        let mut uni = crate::rib::NexthopUni::new(egress.addr, 0, labels);
-        if egress.ifindex != 0 {
-            uni.ifindex_origin = Some(egress.ifindex);
-        }
-        uni.valid = true;
-        uni
-    };
-    let nexthop = if transport.len() == 1 {
-        crate::rib::Nexthop::Uni(mk_uni(&transport[0]))
-    } else {
-        let mut multi = crate::rib::NexthopMulti::default();
-        for egress in transport {
-            multi.nexthops.push(mk_uni(egress));
-        }
-        crate::rib::Nexthop::Multi(multi)
-    };
-    let mut entry = crate::rib::entry::RibEntry::new(crate::rib::RibType::Bgp);
-    entry.distance = 200;
-    entry.metric = 0;
-    entry.valid = true;
-    entry.nexthop = nexthop;
-    Some(entry)
-}
-
 /// Inverse of [`dispatch_import_v4`]. Floods
 /// `BgpVrfMsg::WithdrawImport` to every VRF whose
 /// `import_rts_v4` matches; the receiver decides whether the
@@ -386,6 +343,8 @@ impl BgpVrf {
             attr_store: BgpAttrStore::new(),
             update_groups: super::super::update_group::empty_map(),
             interface_addrs: InterfaceAddrs::new(),
+            transport_v4: std::collections::BTreeMap::new(),
+            transport_v6: std::collections::BTreeMap::new(),
         };
         (vrf, inbox_tx)
     }
@@ -473,6 +432,8 @@ impl BgpVrf {
                     // so no import dispatcher to thread through.
                     vrf_import: None,
                     nexthop_cache: None,
+                    vrf_transport_v4: Some(&self.transport_v4),
+                    vrf_transport_v6: Some(&self.transport_v6),
                 };
                 fsm(&mut top, &mut self.peers, ident, event);
             }
@@ -572,6 +533,16 @@ impl BgpVrf {
         let (_, selected, _gen) = self.local_rib.update(None, prefix, rib);
         let winners = selected.len();
 
+        // Persist the resolved transport for this prefix so `fib_install`
+        // builds the labelled tunnel entry whenever the imported route
+        // wins best-path — now, or after a competing CE route later
+        // withdraws. An empty transport (unresolved) clears it.
+        if transport.is_empty() {
+            self.transport_v4.remove(&prefix);
+        } else {
+            self.transport_v4.insert(prefix, transport.to_vec());
+        }
+
         let mut top = super::super::peer::BgpTop {
             router_id: &self.router_id,
             local_rib: &mut self.local_rib,
@@ -587,6 +558,8 @@ impl BgpVrf {
             flex_algo_routes: None,
             vrf_import: None,
             nexthop_cache: None,
+            vrf_transport_v4: Some(&self.transport_v4),
+            vrf_transport_v6: Some(&self.transport_v6),
         };
         super::super::route::route_advertise_to_peers(
             None,
@@ -597,6 +570,14 @@ impl BgpVrf {
             &mut self.peers,
         );
 
+        // Single VRF FIB install path: `fib_install_v4` programs the
+        // current best-path winner — the imported route's labelled
+        // tunnel entry (via `vrf_transport_v4`) when it wins, or a CE
+        // route's plain entry when that wins, or a withdraw when
+        // neither. The VRF-bound `ctx.rib` lands it in the VRF table;
+        // a placeholder (no-kernel) context's parked client no-ops.
+        super::super::route::fib_install_v4(&top, prefix, &selected);
+
         tracing::info!(
             vrf = %self.name,
             %prefix,
@@ -605,41 +586,6 @@ impl BgpVrf {
             winners,
             "bgp vrf: ImportV4 written to LocRIB and advertised to CE peers",
         );
-
-        // VPN dataplane install. Only the global Bgp task gates the
-        // remote-PE transport and stamps `transport`; a real VRF task's
-        // `ctx.rib` is bound to the VRF table (`vrf_id != 0`), so this
-        // `Ipv4Add` auto-lands there. Install only when the imported
-        // route is the VRF best-path *and* we have a resolved
-        // transport; otherwise withdraw any stale FIB entry. The
-        // placeholder (no-kernel) context has `vrf_id == 0` — skip it
-        // so installs never leak into the default table.
-        if self.ctx.vrf_id() != 0 {
-            let imported_won = selected
-                .first()
-                .is_some_and(|w| matches!(w.typ, super::super::route::BgpRibType::Originated));
-            let entry = if imported_won {
-                build_vpn_fib_entry(label, transport)
-            } else {
-                None
-            };
-            match entry {
-                Some(rib) => {
-                    let _ = self
-                        .ctx
-                        .rib
-                        .send(crate::rib::Message::Ipv4Add { prefix, rib });
-                }
-                None => {
-                    let mut stub = crate::rib::entry::RibEntry::new(crate::rib::RibType::Bgp);
-                    stub.valid = false;
-                    let _ = self
-                        .ctx
-                        .rib
-                        .send(crate::rib::Message::Ipv4Del { prefix, rib: stub });
-                }
-            }
-        }
     }
 
     /// Drop an imported route from the per-VRF LocRIB
@@ -655,6 +601,9 @@ impl BgpVrf {
         let removed_n = removed.len();
         let winners = selected.len();
 
+        // The imported route is gone, so drop its stored transport.
+        self.transport_v4.remove(&prefix);
+
         let mut top = super::super::peer::BgpTop {
             router_id: &self.router_id,
             local_rib: &mut self.local_rib,
@@ -668,6 +617,8 @@ impl BgpVrf {
             flex_algo_routes: None,
             vrf_import: None,
             nexthop_cache: None,
+            vrf_transport_v4: Some(&self.transport_v4),
+            vrf_transport_v6: Some(&self.transport_v6),
         };
         super::super::route::route_advertise_to_peers(
             None,
@@ -678,6 +629,12 @@ impl BgpVrf {
             &mut self.peers,
         );
 
+        // Reconcile the VRF FIB against the *new* best-path. If a CE
+        // route was runner-up it now wins and gets installed; if there's
+        // no winner left, `fib_install_v4` emits the withdraw. (The old
+        // code unconditionally deleted, dropping a now-winning CE route.)
+        super::super::route::fib_install_v4(&top, prefix, &selected);
+
         tracing::info!(
             vrf = %self.name,
             %prefix,
@@ -686,20 +643,6 @@ impl BgpVrf {
             winners,
             "bgp vrf: WithdrawImport removed from LocRIB and withdrawn from CE peers",
         );
-
-        // Remove the VRF FIB entry. WithdrawImport only arrives when the
-        // VPNv4 route truly went away (a replacement winner re-imports
-        // via ImportV4 instead), so the imported dataplane entry should
-        // go. A no-op for a never-installed prefix — the RIB ignores a
-        // Del it never saw.
-        if self.ctx.vrf_id() != 0 {
-            let mut stub = crate::rib::entry::RibEntry::new(crate::rib::RibType::Bgp);
-            stub.valid = false;
-            let _ = self
-                .ctx
-                .rib
-                .send(crate::rib::Message::Ipv4Del { prefix, rib: stub });
-        }
     }
 
     /// VPNv6 counterpart of [`Self::handle_import_v4`]. Inserts the
@@ -753,6 +696,13 @@ impl BgpVrf {
         let (_, selected, _gen) = self.local_rib.update_v6(prefix, rib);
         let winners = selected.len();
 
+        // Persist the resolved transport (see `handle_import_v4`).
+        if transport.is_empty() {
+            self.transport_v6.remove(&prefix);
+        } else {
+            self.transport_v6.insert(prefix, transport.to_vec());
+        }
+
         let mut top = super::super::peer::BgpTop {
             router_id: &self.router_id,
             local_rib: &mut self.local_rib,
@@ -766,6 +716,8 @@ impl BgpVrf {
             flex_algo_routes: None,
             vrf_import: None,
             nexthop_cache: None,
+            vrf_transport_v4: Some(&self.transport_v4),
+            vrf_transport_v6: Some(&self.transport_v6),
         };
         super::super::route::route_advertise_to_peers_v6(
             prefix,
@@ -773,6 +725,9 @@ impl BgpVrf {
             &mut top,
             &mut self.peers,
         );
+
+        // Single VRF FIB install path (see `handle_import_v4`).
+        super::super::route::fib_install_v6(&top, prefix, &selected);
 
         tracing::info!(
             vrf = %self.name,
@@ -782,37 +737,6 @@ impl BgpVrf {
             winners,
             "bgp vrf: ImportV6 written to LocRIB and advertised to CE peers",
         );
-
-        // VPN dataplane install — VPNv6 counterpart of
-        // `handle_import_v4`. Install when the imported route is the VRF
-        // best-path and we have a real VRF table + resolved transport;
-        // otherwise withdraw any stale FIB entry.
-        if self.ctx.vrf_id() != 0 {
-            let imported_won = selected
-                .first()
-                .is_some_and(|w| matches!(w.typ, super::super::route::BgpRibType::Originated));
-            let entry = if imported_won {
-                build_vpn_fib_entry(label, transport)
-            } else {
-                None
-            };
-            match entry {
-                Some(rib) => {
-                    let _ = self
-                        .ctx
-                        .rib
-                        .send(crate::rib::Message::Ipv6Add { prefix, rib });
-                }
-                None => {
-                    let mut stub = crate::rib::entry::RibEntry::new(crate::rib::RibType::Bgp);
-                    stub.valid = false;
-                    let _ = self
-                        .ctx
-                        .rib
-                        .send(crate::rib::Message::Ipv6Del { prefix, rib: stub });
-                }
-            }
-        }
     }
 
     /// VPNv6 counterpart of [`Self::handle_withdraw_import`].
@@ -826,6 +750,8 @@ impl BgpVrf {
         let removed_n = removed.len();
         let winners = selected.len();
 
+        self.transport_v6.remove(&prefix);
+
         let mut top = super::super::peer::BgpTop {
             router_id: &self.router_id,
             local_rib: &mut self.local_rib,
@@ -839,6 +765,8 @@ impl BgpVrf {
             flex_algo_routes: None,
             vrf_import: None,
             nexthop_cache: None,
+            vrf_transport_v4: Some(&self.transport_v4),
+            vrf_transport_v6: Some(&self.transport_v6),
         };
         super::super::route::route_advertise_to_peers_v6(
             prefix,
@@ -846,6 +774,9 @@ impl BgpVrf {
             &mut top,
             &mut self.peers,
         );
+
+        // Reconcile against the new best-path (see `handle_withdraw_import`).
+        super::super::route::fib_install_v6(&top, prefix, &selected);
 
         tracing::info!(
             vrf = %self.name,
@@ -855,16 +786,6 @@ impl BgpVrf {
             winners,
             "bgp vrf: WithdrawImportV6 removed from LocRIB and withdrawn from CE peers",
         );
-
-        // Remove the VRF FIB entry — symmetric with `handle_import_v6`.
-        if self.ctx.vrf_id() != 0 {
-            let mut stub = crate::rib::entry::RibEntry::new(crate::rib::RibType::Bgp);
-            stub.valid = false;
-            let _ = self
-                .ctx
-                .rib
-                .send(crate::rib::Message::Ipv6Del { prefix, rib: stub });
-        }
     }
 
     /// Per-task handling of cross-task messages that aren't
@@ -1041,103 +962,6 @@ mod tests {
                 assert_eq!(p, prefix);
             }
             other => panic!("expected WithdrawExport, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn vpn_fib_entry_pushes_service_label_below_transport() {
-        use crate::rib::nht::ResolvedNexthop;
-
-        // Remote PE resolves to one on-link egress with an SR-MPLS
-        // transport label 16800; VPN service label is 24001.
-        let transport = vec![ResolvedNexthop {
-            addr: "172.16.0.2".parse().unwrap(),
-            ifindex: 5,
-            labels: vec![16800],
-        }];
-        let entry = build_vpn_fib_entry(24001, &transport).expect("installable");
-        assert_eq!(entry.rtype, crate::rib::RibType::Bgp);
-        assert_eq!(entry.distance, 200, "imported VPN routes arrive via iBGP");
-        match entry.nexthop {
-            crate::rib::Nexthop::Uni(uni) => {
-                assert_eq!(uni.addr, "172.16.0.2".parse::<std::net::IpAddr>().unwrap());
-                assert_eq!(uni.ifindex(), Some(5));
-                // Top-of-stack first: transport (outer) then service
-                // (inner / bottom of stack).
-                assert_eq!(uni.mpls_label, vec![16800, 24001]);
-            }
-            other => panic!("expected Uni nexthop, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn vpn_fib_entry_label_less_baseline_and_empty_transport() {
-        use crate::rib::nht::ResolvedNexthop;
-
-        // Plain-IP transport (no SR labels) still carries the VPN
-        // service label as the only (bottom-of-stack) label.
-        let transport = vec![ResolvedNexthop {
-            addr: "172.16.0.2".parse().unwrap(),
-            ifindex: 5,
-            labels: vec![],
-        }];
-        let entry = build_vpn_fib_entry(24001, &transport).expect("installable");
-        match entry.nexthop {
-            crate::rib::Nexthop::Uni(uni) => assert_eq!(uni.mpls_label, vec![24001]),
-            other => panic!("expected Uni nexthop, got {other:?}"),
-        }
-
-        // No resolved transport → nothing installable (caller withdraws).
-        assert!(build_vpn_fib_entry(24001, &[]).is_none());
-    }
-
-    #[test]
-    fn vpn_fib_entry_ecmp_builds_multi() {
-        use crate::rib::nht::ResolvedNexthop;
-
-        let transport = vec![
-            ResolvedNexthop {
-                addr: "172.16.0.2".parse().unwrap(),
-                ifindex: 5,
-                labels: vec![16800],
-            },
-            ResolvedNexthop {
-                addr: "172.16.1.2".parse().unwrap(),
-                ifindex: 6,
-                labels: vec![16801],
-            },
-        ];
-        let entry = build_vpn_fib_entry(24001, &transport).expect("installable");
-        match entry.nexthop {
-            crate::rib::Nexthop::Multi(multi) => {
-                assert_eq!(multi.nexthops.len(), 2);
-                assert_eq!(multi.nexthops[0].mpls_label, vec![16800, 24001]);
-                assert_eq!(multi.nexthops[1].mpls_label, vec![16801, 24001]);
-            }
-            other => panic!("expected Multi nexthop, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn vpn_fib_entry_v6_egress() {
-        use crate::rib::nht::ResolvedNexthop;
-
-        // VPNv6: the remote PE (and thus the resolved transport egress)
-        // is an IPv6 address; the {transport,service} label stack is
-        // built the same way over the v6 next-hop.
-        let transport = vec![ResolvedNexthop {
-            addr: "2001:db8::2".parse().unwrap(),
-            ifindex: 7,
-            labels: vec![16900],
-        }];
-        let entry = build_vpn_fib_entry(24002, &transport).expect("installable");
-        match entry.nexthop {
-            crate::rib::Nexthop::Uni(uni) => {
-                assert_eq!(uni.addr, "2001:db8::2".parse::<std::net::IpAddr>().unwrap());
-                assert_eq!(uni.ifindex(), Some(7));
-                assert_eq!(uni.mpls_label, vec![16900, 24002]);
-            }
-            other => panic!("expected Uni nexthop, got {other:?}"),
         }
     }
 }

--- a/zebra-rs/src/context/proto.rs
+++ b/zebra-rs/src/context/proto.rs
@@ -100,8 +100,10 @@ impl ProtoContext {
     }
 
     /// Read-only accessor for the VRF id (= the kernel `table_id`,
-    /// `0` for the default table). The per-VRF BGP import path consults
-    /// it to gate the VPN dataplane install on having a real VRF table.
+    /// `0` for the default table). Only same-file tests consult it
+    /// today; the bin target reaches the field through
+    /// `maybe_bind_device` instead, so the lint requires the allow.
+    #[allow(dead_code)]
     pub fn vrf_id(&self) -> u32 {
         self.vrf_id
     }


### PR DESCRIPTION
## Summary

Imported VPN routes and CE-learned routes share a per-VRF Loc-RIB (`rd=None`), so best-path is unified — but the two FIB install paths **clobbered each other**:

1. **Bogus self-nexthop.** `fib_install_v4`/`v6` (the CE path, fired on every `rd=None` update) built the entry via `make_bgp_rib_entry`, which for an imported winner read its *rewritten* next-hop (the VRF router-id) and installed a self-loop entry, overwriting the correct labelled tunnel entry.
2. **Withdraw clobbers CE winner.** `handle_withdraw_import` unconditionally `Ipv4Del`'d, even when a CE route was now the best-path winner.
3. **Transport not persisted.** The resolved transport was never stored, so an imported winner couldn't be re-installed after a competing CE route withdrew.

## Fix: one transport-aware install path

- `BgpVrf` gains `transport_v4`/`transport_v6` maps (prefix → resolved transport), populated by `handle_import_*` and cleared on withdraw, threaded into the shared route pipeline via new `BgpTop` `vrf_transport_v4`/`v6` fields (`None` on the global instance — same mechanical churn as the NHT cache).
- `fib_install_v4`/`v6` pick the entry via `select_fib_entry_*`: an imported (`Originated`) winner **with a stored transport** installs the `{transport,service}` labelled tunnel entry (`build_vpn_fib_entry`, moved here from `vrf/inst.rs`); a CE / locally-originated / global winner installs the plain next-hop entry (the Flex-Algo label push stays plain-path only). **Map membership is the precise discriminator**, so a local-originate `Originated` route still takes the plain path — no self-loop.
- `handle_import_*` / `handle_withdraw_import_*` now funnel through `fib_install_*` instead of bespoke installs, so whichever route wins best-path is always programmed correctly.

## Arbitration outcomes (now correct)

| Scenario | Before | After |
|---|---|---|
| Imported wins, CE update arrives | self-loop entry clobbers labelled | `fib_install` re-derives the labelled entry |
| Imported withdrawn, CE runner-up | FIB entry deleted, CE lost | CE plain entry installed |
| CE withdrawn, imported runner-up | imported never re-installed | imported labelled entry re-installed from stored transport |

## Test plan

- `cargo build -p zebra-rs` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p zebra-rs bgp::` (196) / `rib::` (146) / `bgp::vrf::` (15) — pass, including new `select_fib_entry_v4_*` tests (imported→labelled, CE-winner→plain even with transport present, originated-without-transport→plain) and the relocated `build_vpn_fib_entry` tests.
- CI is the source of truth for the full suite.

Generated with [Claude Code](https://claude.com/claude-code)