### PR TITLE
rib: GC orphan kernel nexthop objects on re-resolve

### DIFF
--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -17,6 +17,7 @@ use crate::fib::sysctl::sysctl_enable;
 use crate::fib::{FibChannel, FibHandle, FibMessage, FibNeighbor};
 use crate::rib::route::{
     AddrRecoveryState, ipv4_nexthop_sync, ipv4_route_sync, ipv6_nexthop_sync, ipv6_route_sync,
+    nexthop_orphan_gc,
 };
 use crate::rib::{Bridge, RibEntries};
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
@@ -1860,6 +1861,12 @@ impl Rib {
                 self.rib_sync_timer = None;
                 self.ipv4_route_resolve().await;
                 self.ipv6_route_resolve().await;
+                // After both families' routes have been (re)selected and
+                // any now-invalid ones withdrawn, drop the kernel
+                // nexthop objects for recursive groups that went
+                // unresolvable — safe to delete only now that nothing
+                // references them.
+                nexthop_orphan_gc(&mut self.nmap, &self.fib_handle).await;
             }
             Message::Subscribe {
                 proto_id,

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -1104,10 +1104,12 @@ pub async fn ipv4_nexthop_sync(
             if ifindex == 0 {
                 uni.ifindex_resolved = None;
                 uni.set_valid(false);
-                if uni.is_installed() {
-                    uni.set_installed(false);
-                    // XXX fib.nexthop_del(&Group::Uni(uni.clone())).await;
-                }
+                // Keep `installed`: the kernel nexthop object still
+                // exists. `nexthop_orphan_gc` removes it *after*
+                // `ipv4_route_sync` has withdrawn the routes that
+                // referenced it — deleting a still-referenced nexthop
+                // would cascade-remove those routes out from under the
+                // route sync.
             } else {
                 uni.ifindex_resolved = Some(ifindex);
                 uni.set_valid(true);
@@ -2066,9 +2068,9 @@ pub async fn ipv6_nexthop_sync(
             if ifindex == 0 {
                 uni.ifindex_resolved = None;
                 uni.set_valid(false);
-                if uni.is_installed() {
-                    uni.set_installed(false);
-                }
+                // Keep `installed`; `nexthop_orphan_gc` removes the
+                // kernel object after `ipv6_route_sync` (see the v4
+                // path for the ordering rationale).
             } else {
                 uni.ifindex_resolved = Some(ifindex);
                 uni.set_valid(true);
@@ -2081,6 +2083,25 @@ pub async fn ipv6_nexthop_sync(
     }
     if DEBUG_V6 {
         println!("[ipv6_nexthop_sync] done");
+    }
+}
+
+/// Remove kernel nexthop objects for recursive `Uni` groups that went
+/// unresolvable (`!valid` but still `installed`). MUST run after the
+/// IPv4 **and** IPv6 route syncs have withdrawn every route that
+/// referenced them: a nexthop object can't be deleted while a route
+/// still points at it without the kernel cascade-removing that route.
+/// Address-family-agnostic — the kernel object is keyed by `gid`, so a
+/// single pass over `nmap.groups` covers both families.
+pub async fn nexthop_orphan_gc(nmap: &mut NexthopMap, fib: &FibHandle) {
+    for nhop in nmap.groups.iter_mut().flatten() {
+        if let Group::Uni(uni) = nhop
+            && !uni.is_valid()
+            && uni.is_installed()
+        {
+            fib.nexthop_del(&Group::Uni(uni.clone())).await;
+            uni.set_installed(false);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Narrow correctness fix surfaced while scoping the static-route NHT consumer. When a recursive `Uni` nexthop group becomes unresolvable (its covering route is withdrawn/changed), `ipv4_nexthop_sync`/`ipv6_nexthop_sync` marked it invalid but left the **kernel nexthop object** behind — the FIB delete was a long-standing `// XXX`. The *route* is correctly withdrawn by the route sync; only the nexthop object leaked as an orphan.

## Why it wasn't a one-line uncomment

The delete couldn't just be uncommented in `*_nexthop_sync`: that runs **before** `*_route_sync`, so the object is still route-referenced at that point. Deleting a referenced nexthop makes the kernel cascade-remove those routes out from under the route sync.

## Fix (order-safe by construction)

- On a recursive group going unresolvable, **keep `installed` set** — it truthfully reflects that the kernel object still exists.
- Add `nexthop_orphan_gc`, run from the `Message::Resolve` handler **after** both `ipv4_route_resolve` and `ipv6_route_resolve` have withdrawn every now-invalid route. It deletes the kernel object for any `Uni` group that is `!valid` but still `installed`, then clears the flag. By the time it runs, nothing references the object.

Scoped to `Uni` groups (the static-on-static recursive case). `Multi` groups don't maintain the `installed` flag and keep their existing behaviour (noted as a follow-up).

## Context

This is the surviving gap from the "static-route NHT consumer" item: recursive static-on-static re-resolution itself **already works** via the existing debounced `Message::Resolve` → `*_nexthop_sync` + `*_route_sync` machinery (re-resolves recursive groups and re-installs/withdraws routes). The only missing piece was cleaning up the orphan nexthop object, which this addresses.

## Test plan

- `cargo build -p zebra-rs` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p zebra-rs rib::` (146) + nexthop (54) — pass, no regressions.
- The change is validated by the ordering argument + unit/build/clippy; the netlink delete itself is exercised at runtime / in CI (FIB lifecycle isn't unit-testable locally).

Generated with [Claude Code](https://claude.com/claude-code)