### PR TITLE
bgp: advertise the per-VRF MPLS label in VPNv4 updates

### DIFF
--- a/crates/bgp-packet/src/attrs/nlri_vpnv4.rs
+++ b/crates/bgp-packet/src/attrs/nlri_vpnv4.rs
@@ -13,11 +13,32 @@ use crate::{Afi, AttrType, Label, ParseNlri, RouteDistinguisher, Safi, nlri_psiz
 
 use super::{AttrEmitter, AttrFlags, Ipv4Nlri};
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Vpnv4Nlri {
     pub label: Label,
     pub rd: RouteDistinguisher,
     pub nlri: Ipv4Nlri,
+}
+
+// Identity excludes the MPLS `label`: a VPNv4 route is identified by its
+// (RD, prefix, path-id), and the label is a forwarding property attached
+// to it (and may not be known at every comparison site — e.g. an
+// advertise cache removal keyed by RD+prefix). Equality/hash over the
+// label too would make `cache_remove_vpnv4` (which doesn't carry the
+// label) fail to match the cached `send_vpnv4` entry.
+impl PartialEq for Vpnv4Nlri {
+    fn eq(&self, other: &Self) -> bool {
+        self.rd == other.rd && self.nlri == other.nlri
+    }
+}
+
+impl Eq for Vpnv4Nlri {}
+
+impl std::hash::Hash for Vpnv4Nlri {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.rd.hash(state);
+        self.nlri.hash(state);
+    }
 }
 
 impl ParseNlri<Vpnv4Nlri> for Vpnv4Nlri {
@@ -272,5 +293,37 @@ impl AttrEmitter for Vpnv4Unreach {
             let plen = nlri_psize(withdraw.nlri.prefix.prefix_len());
             buf.put(&withdraw.nlri.prefix.addr().octets()[0..plen]);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_ignores_label() {
+        use std::collections::HashSet;
+        let rd = RouteDistinguisher::default();
+        let nlri = Ipv4Nlri {
+            id: 0,
+            prefix: "10.0.0.0/24".parse().unwrap(),
+        };
+        // Same (RD, prefix), different label → equal + same hash, so a
+        // route advertised+cached under its real label is still found
+        // and removed by `cache_remove_vpnv4`'s default-label key.
+        let advertised = Vpnv4Nlri {
+            label: Label::new(80, 0, true),
+            rd,
+            nlri: nlri.clone(),
+        };
+        let remove_key = Vpnv4Nlri {
+            label: Label::default(),
+            rd,
+            nlri,
+        };
+        assert_eq!(advertised, remove_key);
+        let mut set = HashSet::new();
+        set.insert(advertised);
+        assert!(set.remove(&remove_key), "default-label key matches");
     }
 }

--- a/crates/bgp-packet/src/attrs/nlri_vpnv6.rs
+++ b/crates/bgp-packet/src/attrs/nlri_vpnv6.rs
@@ -13,11 +13,30 @@ use crate::{Afi, AttrType, Label, ParseNlri, RouteDistinguisher, Safi, nlri_psiz
 
 use super::{AttrEmitter, AttrFlags, Ipv6Nlri};
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Vpnv6Nlri {
     pub label: Label,
     pub rd: RouteDistinguisher,
     pub nlri: Ipv6Nlri,
+}
+
+// Identity excludes the MPLS `label` — see [`super::nlri_vpnv4::Vpnv4Nlri`].
+// A VPNv6 route is identified by (RD, prefix, path-id); the label is a
+// forwarding property, and the advertise-cache removal path
+// (`cache_remove_vpnv6`) doesn't carry it.
+impl PartialEq for Vpnv6Nlri {
+    fn eq(&self, other: &Self) -> bool {
+        self.rd == other.rd && self.nlri == other.nlri
+    }
+}
+
+impl Eq for Vpnv6Nlri {}
+
+impl std::hash::Hash for Vpnv6Nlri {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.rd.hash(state);
+        self.nlri.hash(state);
+    }
 }
 
 impl ParseNlri<Vpnv6Nlri> for Vpnv6Nlri {
@@ -392,5 +411,18 @@ mod tests {
         // label/RD reads.
         let input = [0x00u8, 0x00, 0x00, 0x00];
         assert!(Vpnv6Nlri::parse_nlri(&input, false).is_err());
+    }
+
+    #[test]
+    fn identity_ignores_label() {
+        use std::collections::HashSet;
+        // Same (RD, prefix), different label → equal, so a route cached
+        // under its real label is removed by the default-label key.
+        let advertised = nlri("65000:1", "2001:db8::/64", 80);
+        let remove_key = nlri("65000:1", "2001:db8::/64", 0);
+        assert_eq!(advertised, remove_key);
+        let mut set = HashSet::new();
+        set.insert(advertised);
+        assert!(set.remove(&remove_key));
     }
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1454,7 +1454,7 @@ fn route_advertise_to_addpath(
             peer.adj_out.add(rd, nlri.prefix, rib_clone);
             if let Some(ref rd) = rd {
                 let vpnv4_nlri = Vpnv4Nlri {
-                    label: Label::default(),
+                    label: rib.label.unwrap_or_default(),
                     rd: *rd,
                     nlri,
                 };
@@ -1664,7 +1664,7 @@ pub(super) fn route_advertise_to_peers(
                 }
                 if let Some(ref rd) = rd {
                     let vpnv4_nlri = Vpnv4Nlri {
-                        label: Label::default(),
+                        label: new_best.and_then(|b| b.label).unwrap_or_default(),
                         rd: *rd,
                         nlri,
                     };
@@ -2082,7 +2082,7 @@ fn route_soft_out_peer_table(
 
         if let Some(rd_val) = rd {
             let vpnv4_nlri = Vpnv4Nlri {
-                label: Label::default(),
+                label: rib.label.unwrap_or_default(),
                 rd: rd_val,
                 nlri,
             };
@@ -4711,13 +4711,10 @@ pub fn route_sync_vpnv4(peer: &mut Peer, bgp: &mut BgpTop) {
             // Register to AdjOut.
             rib.attr = bgp.attr_store.intern(attr);
             let arc_attr = rib.attr.clone();
+            let label = rib.label.unwrap_or_default();
             peer.adj_out.add(Some(rd), nlri.prefix, rib);
 
-            let vpnv4_nlri = Vpnv4Nlri {
-                label: Label::default(),
-                rd,
-                nlri,
-            };
+            let vpnv4_nlri = Vpnv4Nlri { label, rd, nlri };
 
             // Send the routes.
             peer.send_vpnv4(vpnv4_nlri, arc_attr, false);


### PR DESCRIPTION
## Summary

PR1 of the per-VRF label work. The per-VRF label was allocated, carried through `BgpGlobalMsg::Export`, and stored on the exported VPNv4 row's `BgpRib.label` — but the VPNv4 advertise path hardcoded `label: Label::default()` (0) at every `send_vpnv4` site, so a **remote PE never learned the label and couldn't forward**. (VPNv6 already stamped `best.label`.) This uses the advertised row's label at all four VPNv4 advertise sites.

## The latent cache bug this exposed

The advertise cache (`cache_vpnv4` / `cache_vpnv4_rev`) keys on `Vpnv4Nlri`, whose derived `Hash`/`Eq` **included the label** — but `cache_remove_vpnv4` rebuilds the removal key with `Label::default()`. It only worked because every advertise used label 0. With real labels, removal would silently miss and **leak the cache entry / stick the advertise**. The same latent bug already exists on **VPNv6** (its advertise uses the real label while `cache_remove_vpnv6` uses the default).

Fix the identity: `Vpnv4Nlri`/`Vpnv6Nlri` now hash/compare on **(RD, prefix, path-id)** only — the MPLS label is a forwarding property, not part of the route identity, and the removal path doesn't carry it. The two advertise caches are the *only* `Hash`/`Eq` consumers (verified), so this is **behavior-preserving today** (all labels were 0) and makes the cache robust to the real labels this PR introduces.

## Decap ILM

Already correct — `IlmType::DecapVrf` emits `<label> dev <vrf> proto bgp` (`RouteProtocol::Bgp` + `Oif(vrf_ifindex)`). So once the label is advertised, the VPNv4 data path is complete.

## Scope note

This is the functional bug fix, independent of the dynamic-label-block work (PR2: central RIB label manager; PR3: BGP consumes it), which follows.

## Test plan

- `cargo build -p zebra-rs` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p bgp-packet` (incl. new `identity_ignores_label` for v4 + v6) / `cargo test -p zebra-rs bgp::` (198) — pass.
- CI is the source of truth for the full suite.

Generated with [Claude Code](https://claude.com/claude-code)