### PR TITLE
rib: add a central dynamic MPLS label-block manager

### DIFF
--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -192,6 +192,16 @@ pub enum RibRx {
         nh: IpAddr,
         resolution: super::nht::NexthopResolution,
     },
+    /// Reply to [`crate::rib::inst::Message::LabelBlockRequest`]: a
+    /// dynamic MPLS label block `[start, start+size)` reserved for the
+    /// requesting protocol. Delivered synchronously on the request.
+    //
+    // `allow(dead_code)`: the consumer (BGP) lands in the next PR.
+    #[allow(dead_code)]
+    LabelBlock {
+        start: u32,
+        size: u32,
+    },
 }
 
 impl Rib {

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -137,6 +137,28 @@ pub enum Message {
         proto: String,
         nh: std::net::IpAddr,
     },
+    /// Reserve a dynamic MPLS label block of `size` labels for `proto`
+    /// from the central [`super::label_manager::LabelManager`]. The RIB
+    /// replies synchronously with a `RibRx::LabelBlock`. Used by BGP for
+    /// L3VPN per-VRF labels (LDP / others later).
+    //
+    // `allow(dead_code)`: the producer (BGP) lands in the next PR.
+    #[allow(dead_code)]
+    LabelBlockRequest {
+        proto: String,
+        size: u32,
+    },
+    /// Return a previously-reserved label block `[start, start+size)` to
+    /// the pool. `proto_cleanup` is the backstop for a proto that exits
+    /// without releasing.
+    //
+    // `allow(dead_code)`: the producer (BGP) lands in the next PR.
+    #[allow(dead_code)]
+    LabelBlockRelease {
+        proto: String,
+        start: u32,
+        size: u32,
+    },
     /// Register an allocated SRv6 SID. Owners (IS-IS, OSPF, BGP) push
     /// one of these whenever they carve a function out of a locator;
     /// the RIB stores it for `show segment-routing srv6 sid`.
@@ -496,6 +518,10 @@ pub struct Rib {
     /// resolution. Driven by `Message::NexthopRegister`/`Unregister`
     /// and re-resolved on global-table route changes.
     pub nht: super::nht::NhtRegistry,
+
+    /// Central dynamic MPLS label-block manager. Hands out non-
+    /// overlapping label blocks to protocols (BGP L3VPN today).
+    pub label_manager: super::label_manager::LabelManager,
     pub nmap: NexthopMap,
     pub router_id: Ipv4Addr,
 
@@ -593,6 +619,7 @@ impl Rib {
             block_watch: BTreeMap::new(),
             locator_watch: BTreeMap::new(),
             nht: super::nht::NhtRegistry::default(),
+            label_manager: super::label_manager::LabelManager::new(),
             nmap: NexthopMap::default(),
             router_id: Ipv4Addr::UNSPECIFIED,
             rib_sync_timer: None,
@@ -644,6 +671,23 @@ impl Rib {
         }
         if let Some(sub) = self.client_registry.subscriber_for_proto(&proto) {
             let _ = sub.rib_rx_tx.send(RibRx::NexthopUpdate { nh, resolution });
+        }
+    }
+
+    /// Handle `Message::LabelBlockRequest`: reserve a dynamic label
+    /// block for `proto` and reply synchronously with it. An exhausted
+    /// pool gets no reply (the requester degrades to label-less); a
+    /// missing subscriber returns the block rather than stranding it.
+    fn label_block_request(&mut self, proto: String, size: u32) {
+        let Some(block) = self.label_manager.alloc(&proto, size) else {
+            tracing::warn!(%proto, size, "label block request: dynamic pool exhausted");
+            return;
+        };
+        let (start, size) = (block.start, block.end - block.start);
+        if let Some(sub) = self.client_registry.subscriber_for_proto(&proto) {
+            let _ = sub.rib_rx_tx.send(RibRx::LabelBlock { start, size });
+        } else {
+            self.label_manager.release(&proto, start, size);
         }
     }
 
@@ -1131,6 +1175,10 @@ impl Rib {
     }
 
     async fn proto_cleanup(&mut self, proto: String) {
+        // Reclaim any dynamic label blocks the protocol held — done
+        // before the rtype gate so it covers every requester.
+        self.label_manager.release_all(&proto);
+
         let rtype = match proto.as_str() {
             "bgp" => RibType::Bgp,
             "isis" => RibType::Isis,
@@ -1456,6 +1504,12 @@ impl Rib {
             }
             Message::NexthopUnregister { proto, nh } => {
                 self.nht.unregister(&proto, nh);
+            }
+            Message::LabelBlockRequest { proto, size } => {
+                self.label_block_request(proto, size);
+            }
+            Message::LabelBlockRelease { proto, start, size } => {
+                self.label_manager.release(&proto, start, size);
             }
             Message::IlmAdd { label, ilm } => {
                 self.ilm_add(label, ilm).await;

--- a/zebra-rs/src/rib/label_manager.rs
+++ b/zebra-rs/src/rib/label_manager.rs
@@ -1,0 +1,171 @@
+//! Central dynamic MPLS label-block manager.
+//!
+//! Owns the dynamic label pool — the band above the SR-MPLS ranges
+//! (SRGB default 16000..23999, SRLB 15000..15099, configured in
+//! [`crate::rib::segment_routing::block`]) — and hands out reserved
+//! blocks to protocols that need dynamically-allocated labels (BGP
+//! L3VPN per-VRF labels today; LDP and others later). A block is
+//! reserved until released; a released block is reused for a later
+//! request of the same size before the high-water mark advances.
+//! Per-protocol bookkeeping lets `proto_cleanup` reclaim every block a
+//! disabled/crashed protocol held.
+//!
+//! Keeping BGP/LDP dynamic labels in a band clear of the SR ranges
+//! avoids cross-protocol label collisions in the kernel MPLS table —
+//! something the previous per-VRF allocator (which counted up from 16)
+//! could violate at scale.
+
+use std::collections::BTreeMap;
+
+use crate::spf::label_block::LabelBlock;
+
+/// First label of the dynamic pool. Chosen well above the SR-MPLS
+/// default ranges so dynamic (BGP/LDP) labels never collide with
+/// prefix-/adjacency-SIDs. Operators configuring custom SR blocks must
+/// keep them below this floor.
+pub const DYNAMIC_START: u32 = 100_000;
+
+/// One past the last usable 20-bit MPLS label (labels are 20 bits, so
+/// `0..=0x000F_FFFF`; this exclusive end is `0x000F_FFFF + 1`).
+pub const DYNAMIC_END: u32 = 0x0010_0000;
+
+/// Hands out non-overlapping label blocks from the dynamic pool.
+#[derive(Debug)]
+pub struct LabelManager {
+    /// High-water mark — the next never-allocated label.
+    next: u32,
+    /// Released blocks, available for exact-size reuse before `next`
+    /// advances.
+    free: Vec<LabelBlock>,
+    /// Outstanding blocks per requesting protocol, for bulk release on
+    /// `proto_cleanup`.
+    by_proto: BTreeMap<String, Vec<LabelBlock>>,
+}
+
+impl Default for LabelManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LabelManager {
+    pub fn new() -> Self {
+        Self {
+            next: DYNAMIC_START,
+            free: Vec::new(),
+            by_proto: BTreeMap::new(),
+        }
+    }
+
+    /// Reserve a block of `size` labels for `proto`. A freed block of
+    /// the same size is reused before fresh space is carved off the
+    /// high-water mark. Returns `None` for a zero size or when the
+    /// dynamic pool is exhausted.
+    pub fn alloc(&mut self, proto: &str, size: u32) -> Option<LabelBlock> {
+        if size == 0 {
+            return None;
+        }
+        let block = if let Some(pos) = self.free.iter().position(|b| b.end - b.start == size) {
+            self.free.swap_remove(pos)
+        } else {
+            if self.next.checked_add(size)? > DYNAMIC_END {
+                return None;
+            }
+            let block = LabelBlock {
+                start: self.next,
+                end: self.next + size,
+            };
+            self.next += size;
+            block
+        };
+        self.by_proto
+            .entry(proto.to_string())
+            .or_default()
+            .push(block.clone());
+        Some(block)
+    }
+
+    /// Release one block previously handed to `proto`. A no-op if the
+    /// block isn't one we gave that protocol.
+    pub fn release(&mut self, proto: &str, start: u32, size: u32) {
+        let block = LabelBlock {
+            start,
+            end: start + size,
+        };
+        if let Some(blocks) = self.by_proto.get_mut(proto) {
+            if let Some(pos) = blocks.iter().position(|b| *b == block) {
+                blocks.swap_remove(pos);
+                self.free.push(block);
+            }
+            if blocks.is_empty() {
+                self.by_proto.remove(proto);
+            }
+        }
+    }
+
+    /// Release every block held by `proto` (the protocol was torn
+    /// down). The blocks return to the free list for reuse.
+    pub fn release_all(&mut self, proto: &str) {
+        if let Some(blocks) = self.by_proto.remove(proto) {
+            self.free.extend(blocks);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocs_carve_from_the_dynamic_pool_above_sr() {
+        let mut m = LabelManager::new();
+        let a = m.alloc("bgp", 1024).unwrap();
+        assert_eq!(a.start, DYNAMIC_START);
+        assert_eq!(a.end, DYNAMIC_START + 1024);
+        // Second block starts where the first ended — no overlap.
+        let b = m.alloc("bgp", 16).unwrap();
+        assert_eq!(b.start, DYNAMIC_START + 1024);
+        // Whole pool sits clear of the SR default ceiling (SRGB 23999).
+        assert!(a.start > 23999);
+    }
+
+    #[test]
+    fn release_makes_a_same_size_block_reusable() {
+        let mut m = LabelManager::new();
+        let a = m.alloc("bgp", 256).unwrap();
+        let b = m.alloc("bgp", 256).unwrap();
+        assert_ne!(a.start, b.start);
+        m.release("bgp", a.start, 256);
+        // A new 256-block reuses the freed one rather than bumping the
+        // high-water mark.
+        let c = m.alloc("bgp", 256).unwrap();
+        assert_eq!(c.start, a.start);
+        // A different size doesn't match the freed block.
+        let d = m.alloc("bgp", 128).unwrap();
+        assert_eq!(d.start, b.end);
+    }
+
+    #[test]
+    fn release_all_reclaims_every_block_of_a_proto() {
+        let mut m = LabelManager::new();
+        let a = m.alloc("bgp", 100).unwrap();
+        let _b = m.alloc("bgp", 100).unwrap();
+        m.alloc("ldp", 100).unwrap();
+        m.release_all("bgp");
+        // Both bgp blocks are now free; the next two 100-allocs reuse
+        // them (lowest-by-swap order aside, they come from `free`).
+        let c = m.alloc("isis", 100).unwrap();
+        let e = m.alloc("isis", 100).unwrap();
+        assert!([c.start, e.start].contains(&a.start));
+        // ldp's block was untouched by bgp's release_all.
+        m.release_all("ldp");
+    }
+
+    #[test]
+    fn zero_size_and_exhaustion_return_none() {
+        let mut m = LabelManager::new();
+        assert!(m.alloc("bgp", 0).is_none());
+        // A request larger than the whole pool fails.
+        assert!(m.alloc("bgp", DYNAMIC_END).is_none());
+    }
+}

--- a/zebra-rs/src/rib/mod.rs
+++ b/zebra-rs/src/rib/mod.rs
@@ -52,6 +52,8 @@ pub mod resolve;
 
 pub mod nht;
 
+pub mod label_manager;
+
 // pub mod nanomsg;
 
 pub mod router_id;


### PR DESCRIPTION
## Summary

PR2 of the per-VRF label work: an FRR-style **label manager** in the RIB that hands out non-overlapping dynamic label blocks to protocols. BGP L3VPN per-VRF labels are the first consumer (PR3); LDP and others can reuse it later.

The dynamic pool sits in a band **above the SR-MPLS ranges** (`DYNAMIC_START = 100000`, clear of SRGB 16000–23999 / SRLB 15000–15099), so dynamic labels can't collide with prefix-/adjacency-SIDs in the kernel MPLS table — a hazard the old per-VRF allocator (counting up from 16) had at scale.

## Changes

- **`rib/label_manager.rs`** — `LabelManager::{alloc, release, release_all}` over `[DYNAMIC_START, DYNAMIC_END)`, with same-size block reuse (freed blocks before the high-water mark) and per-protocol bookkeeping. Reuses the `LabelBlock {start,end}` primitive from `spf/label_block.rs`. Unit-tested: carve-above-SR, same-size reuse, `release_all`, zero-size/exhaustion.
- **Messages** — `Message::LabelBlockRequest { proto, size }` / `LabelBlockRelease { proto, start, size }`; reply `RibRx::LabelBlock { start, size }` delivered **synchronously** over the requesting proto's subscriber channel (the same `subscriber_for_proto` path `nht_register` uses). `label_block_request` returns the block if there's no subscriber (no stranding); an exhausted pool gets no reply (requester degrades to label-less).
- **`Rib::label_manager`** field; `proto_cleanup` reclaims a torn-down protocol's blocks (before its rtype gate, so it covers every requester).

No consumer yet — the `Message`/`RibRx` variants carry a temporary `#[allow(dead_code)]` (BGP produces them in PR3), the pattern used for the NHT series.

## Test plan

- `cargo build -p zebra-rs` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p zebra-rs label_manager` (4) / `rib::` (150) — pass.
- CI is the source of truth for the full suite.

Generated with [Claude Code](https://claude.com/claude-code)