### PR TITLE
bgp: draw per-VRF labels from the RIB dynamic label block

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -18,6 +18,12 @@ use std::net::{Ipv4Addr, SocketAddr};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
+/// Size of the dynamic MPLS label block BGP requests from the RIB
+/// label manager at startup, for per-VRF L3VPN labels. One label per
+/// VRF, so 1024 covers any realistic deployment; on-demand extension
+/// for larger fleets is a follow-up.
+const VRF_LABEL_BLOCK_SIZE: u32 = 1024;
+
 /// Map a `/clear/bgp/<afi>/neighbor[/soft[/in|out]]` path (from
 /// zebra-bgp-clear.yang) to the (AFI, SAFI, op) triple the BGP runtime
 /// understands. Returns None for unrecognised paths.
@@ -390,7 +396,11 @@ pub struct Bgp {
     /// `spawn_bgp_vrf` call; reclaims at despawn. The label gets
     /// stamped onto every `BgpGlobalMsg::Export` the VRF emits and
     /// drives the matching ILM Decap install on the PE.
-    pub vrf_label_alloc: super::vrf::VrfLabelAllocator,
+    /// Per-VRF label allocator, bounded to the dynamic block the RIB
+    /// label manager hands BGP at startup. `None` until that
+    /// `RibRx::LabelBlock` arrives — VRFs spawned before then take
+    /// label 0 (degraded) and are reconciled on arrival.
+    pub vrf_label_alloc: Option<super::vrf::VrfLabelAllocator>,
     /// Inbound `:179` dispatch index — peer source IP to VRF name.
     /// Populated by [`super::vrf::BgpGlobalMsg::RegisterPeer`]
     /// each per-VRF task emits at spawn / materialise time, and
@@ -557,7 +567,7 @@ impl Bgp {
             vrf_registry: BTreeMap::new(),
             rib_known_vrfs: BTreeMap::new(),
             rib_subscriber,
-            vrf_label_alloc: super::vrf::VrfLabelAllocator::new(),
+            vrf_label_alloc: None,
             peer_index: BTreeMap::new(),
             vrf_global_tx: vrf_global_tx_init,
             vrf_global_rx: vrf_global_rx_init,
@@ -901,7 +911,9 @@ impl Bgp {
                 // can pick it back up. Reclaim before the handle
                 // drops — handle drop aborts the task but doesn't
                 // know about the allocator.
-                self.vrf_label_alloc.free(handle.label);
+                if let Some(alloc) = self.vrf_label_alloc.as_mut() {
+                    alloc.free(handle.label);
+                }
                 // Drop every `peer_index` entry that pointed at
                 // this VRF — defensive cleanup against the VRF
                 // task exiting before its `UnregisterPeer`
@@ -924,7 +936,11 @@ impl Bgp {
             // effectively never fires; 0 would mean "no label"
             // downstream, which the Export handler already treats
             // as "skip label install" — a safe degradation.
-            let label = self.vrf_label_alloc.alloc().unwrap_or(0);
+            let label = self
+                .vrf_label_alloc
+                .as_mut()
+                .and_then(|a| a.alloc())
+                .unwrap_or(0);
             let handle = super::vrf::spawn_bgp_vrf(
                 name.clone(),
                 &cfg,
@@ -975,7 +991,10 @@ impl Bgp {
             self.peer_index.retain(|_, owner| owner != name);
             handle.label
         } else {
-            self.vrf_label_alloc.alloc().unwrap_or(0)
+            self.vrf_label_alloc
+                .as_mut()
+                .and_then(|a| a.alloc())
+                .unwrap_or(0)
         };
         let table_id = kernel.table_id;
         let new_handle = super::vrf::spawn_bgp_vrf(
@@ -1300,10 +1319,69 @@ impl Bgp {
             RibRx::NexthopUpdate { nh, resolution } => {
                 self.nht_handle_update(nh, &resolution);
             }
+            RibRx::LabelBlock { start, size } => {
+                self.label_block_arrived(start, size);
+            }
             _ => {
                 //
             }
         }
+    }
+
+    /// The RIB label manager granted BGP a dynamic block `[start,
+    /// start+size)`. Bind the per-VRF allocator to it, then reconcile
+    /// any VRF that spawned label-less before the block arrived:
+    /// give it a real label and respawn so it stamps exports and
+    /// installs its decap ILM.
+    fn label_block_arrived(&mut self, start: u32, size: u32) {
+        self.vrf_label_alloc = Some(super::vrf::VrfLabelAllocator::bounded(start, start + size));
+        tracing::info!(
+            start,
+            size,
+            "bgp: bound per-VRF label allocator to dynamic block"
+        );
+
+        let unlabelled: Vec<String> = self
+            .vrf_registry
+            .iter()
+            .filter(|(_, h)| h.label == 0)
+            .map(|(name, _)| name.clone())
+            .collect();
+        for name in unlabelled {
+            self.relabel_vrf(&name);
+        }
+    }
+
+    /// Respawn `name`'s per-VRF task with a freshly-allocated label.
+    /// Used to fix up a VRF that spawned with label 0 (the block hadn't
+    /// arrived yet). Mirrors [`Self::maybe_respawn_vrf_with_kernel_ctx`]
+    /// but swaps the label rather than the `ProtoContext`.
+    fn relabel_vrf(&mut self, name: &str) {
+        let Some(cfg) = self.vrfs.get(name).cloned() else {
+            return;
+        };
+        let Some(label) = self.vrf_label_alloc.as_mut().and_then(|a| a.alloc()) else {
+            return;
+        };
+        let kernel = self.rib_known_vrfs.get(name).cloned();
+        if let Some(handle) = self.vrf_registry.remove(name) {
+            super::vrf::despawn_bgp_vrf(name, &handle);
+            self.unregister_vrf_show(name);
+            self.peer_index.retain(|_, owner| owner != name);
+        }
+        let new_handle = super::vrf::spawn_bgp_vrf(
+            name.to_string(),
+            &cfg,
+            self.router_id,
+            self.asn,
+            label,
+            kernel,
+            &self.rib_subscriber,
+            self.vrf_global_tx.clone(),
+        );
+        self.register_vrf_show(name, &new_handle);
+        self.vrf_registry.insert(name.to_string(), new_handle);
+        tracing::info!(vrf = %name, label, "bgp: assigned dynamic label to VRF");
     }
 
     /// Apply a NHT resolution change: refresh the cached resolution
@@ -1671,6 +1749,13 @@ impl Bgp {
     }
 
     pub async fn event_loop(&mut self) {
+        // Request our dynamic MPLS label block from the RIB label
+        // manager up front. The reply (`RibRx::LabelBlock`) binds
+        // `vrf_label_alloc` before per-VRF tasks start asking for
+        // labels; a VRF spawned before it lands takes label 0 and is
+        // reconciled on arrival.
+        self.rib_subscriber
+            .send_label_block_request("bgp", VRF_LABEL_BLOCK_SIZE);
         if let Err(err) = self.listen().await {
             self.listen_err = Some(err);
         }

--- a/zebra-rs/src/bgp/vrf/label.rs
+++ b/zebra-rs/src/bgp/vrf/label.rs
@@ -32,33 +32,44 @@ pub const LAST_USABLE_LABEL: u32 = 0x000F_FFFF;
 /// don't bleed the space.
 #[derive(Debug)]
 pub struct VrfLabelAllocator {
-    /// Next never-allocated label. Bumped on each fresh alloc;
-    /// the free list is preferred so the counter only grows when
-    /// every freed label has already been re-issued.
+    /// Inclusive lower bound of the block this allocator draws from —
+    /// the start of the dynamic block the RIB label manager handed BGP.
+    start: u32,
+    /// Next never-allocated label within the block.
     next: u32,
+    /// Exclusive upper bound of the block.
+    end: u32,
     /// Released labels, sorted so the lowest-numbered ones come
     /// out first — predictable for tests and operator readability.
     free: BTreeSet<u32>,
 }
 
 impl VrfLabelAllocator {
-    pub fn new() -> Self {
+    /// Allocator bound to the half-open block `[start, end)` — the
+    /// dynamic block the RIB label manager reserved for BGP.
+    pub fn bounded(start: u32, end: u32) -> Self {
         Self {
-            next: FIRST_USABLE_LABEL,
+            start,
+            next: start,
+            end,
             free: BTreeSet::new(),
         }
     }
 
-    /// Hand out the next available label. Returns `None` only
-    /// when the entire 20-bit space is exhausted, which would
-    /// mean ~1M live VRFs — well past any deployment ceiling.
-    /// Callers can `expect("label space exhausted")` if they
-    /// want to assert that bound.
+    /// Unbounded over the whole usable label space — kept for tests
+    /// and as a fallback; the running BGP instance uses [`Self::bounded`]
+    /// with the RIB-allocated block.
+    pub fn new() -> Self {
+        Self::bounded(FIRST_USABLE_LABEL, LAST_USABLE_LABEL + 1)
+    }
+
+    /// Hand out the next available label, preferring reclaimed ones.
+    /// Returns `None` when the block is exhausted.
     pub fn alloc(&mut self) -> Option<u32> {
         if let Some(reused) = self.free.pop_first() {
             return Some(reused);
         }
-        if self.next > LAST_USABLE_LABEL {
+        if self.next >= self.end {
             return None;
         }
         let label = self.next;
@@ -66,15 +77,12 @@ impl VrfLabelAllocator {
         Some(label)
     }
 
-    /// Return `label` to the pool. Idempotent — double-frees are
-    /// silently ignored (the second insert into `BTreeSet` is a
-    /// no-op). Reserved labels (`< FIRST_USABLE_LABEL`) are
-    /// rejected because they were never ours to start with.
+    /// Return `label` to the pool. Idempotent. Labels outside this
+    /// allocator's block are rejected — they were never ours.
     pub fn free(&mut self, label: u32) {
-        if !(FIRST_USABLE_LABEL..=LAST_USABLE_LABEL).contains(&label) {
-            return;
+        if (self.start..self.end).contains(&label) {
+            self.free.insert(label);
         }
-        self.free.insert(label);
     }
 }
 
@@ -146,5 +154,20 @@ mod tests {
         assert_eq!(a.alloc(), Some(l));
         // No third return; counter resumes.
         assert_eq!(a.alloc(), Some(l + 1));
+    }
+
+    #[test]
+    fn bounded_allocator_stays_within_its_block() {
+        // [100, 103) — three labels.
+        let mut a = VrfLabelAllocator::bounded(100, 103);
+        assert_eq!(a.alloc(), Some(100));
+        assert_eq!(a.alloc(), Some(101));
+        assert_eq!(a.alloc(), Some(102));
+        assert_eq!(a.alloc(), None, "block exhausted");
+        a.free(101);
+        assert_eq!(a.alloc(), Some(101), "freed label reused");
+        // A label outside the block was never ours — rejected.
+        a.free(200);
+        assert_eq!(a.alloc(), None);
     }
 }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -127,6 +127,16 @@ impl RibSubscriber {
     pub fn send_ilm_del(&self, label: u32, ilm: crate::rib::inst::IlmEntry) {
         let _ = self.rib_tx.send(crate::rib::Message::IlmDel { label, ilm });
     }
+
+    /// Request a dynamic MPLS label block of `size` labels for `proto`
+    /// from the RIB label manager. The RIB replies asynchronously with
+    /// a `RibRx::LabelBlock` on `proto`'s subscriber channel.
+    pub fn send_label_block_request(&self, proto: &str, size: u32) {
+        let _ = self.rib_tx.send(crate::rib::Message::LabelBlockRequest {
+            proto: proto.to_string(),
+            size,
+        });
+    }
 }
 
 pub struct ConfigManager {

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -195,9 +195,6 @@ pub enum RibRx {
     /// Reply to [`crate::rib::inst::Message::LabelBlockRequest`]: a
     /// dynamic MPLS label block `[start, start+size)` reserved for the
     /// requesting protocol. Delivered synchronously on the request.
-    //
-    // `allow(dead_code)`: the consumer (BGP) lands in the next PR.
-    #[allow(dead_code)]
     LabelBlock {
         start: u32,
         size: u32,

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -141,9 +141,6 @@ pub enum Message {
     /// from the central [`super::label_manager::LabelManager`]. The RIB
     /// replies synchronously with a `RibRx::LabelBlock`. Used by BGP for
     /// L3VPN per-VRF labels (LDP / others later).
-    //
-    // `allow(dead_code)`: the producer (BGP) lands in the next PR.
-    #[allow(dead_code)]
     LabelBlockRequest {
         proto: String,
         size: u32,
@@ -152,7 +149,8 @@ pub enum Message {
     /// the pool. `proto_cleanup` is the backstop for a proto that exits
     /// without releasing.
     //
-    // `allow(dead_code)`: the producer (BGP) lands in the next PR.
+    // `allow(dead_code)`: the live release path is `proto_cleanup`; an
+    // explicit per-block release while running is a follow-up.
     #[allow(dead_code)]
     LabelBlockRelease {
         proto: String,


### PR DESCRIPTION
## Summary

PR3 (final) of the per-VRF label work. BGP now sources its L3VPN per-VRF labels from the central RIB label manager (PR2 #1020) instead of an unbounded counter from 16 — so the labels live in a band clear of the SR ranges and can't collide with prefix-/adjacency-SIDs in the kernel MPLS table.

## Changes

- **Bounded allocator** — `VrfLabelAllocator` is now bound to a `[start, end)` block (`bounded(start, end)`); `alloc`/`free` stay within it.
- **Request + bind** — `Bgp::vrf_label_alloc` is `Option`, `None` until the block lands. At `event_loop` start BGP sends `Message::LabelBlockRequest { "bgp", 1024 }` (new `RibSubscriber::send_label_block_request`); the `RibRx::LabelBlock` reply binds the allocator.
- **Reconcile** — a VRF spawned before the block arrives takes label 0 (the existing degraded path — no decap ILM, label-less export). On block arrival, `label_block_arrived` reconciles every label-0 VRF via `relabel_vrf`, respawning it with a real label (re-stamping exports + installing the `<label> dev <vrf> proto bgp` ILM) — mirroring `maybe_respawn_vrf_with_kernel_ctx`. Sending the request at `event_loop` start means the block normally arrives before any VRF config commit, so the reconcile is a safety net.
- Removed the now-satisfied `#[allow(dead_code)]` on `Message::LabelBlockRequest` and `RibRx::LabelBlock`.

## Follow-ups (not in this PR)

- On-demand block extension for >1024-VRF fleets (multi-block allocator).
- Explicit per-block release while running (`LabelBlockRelease` producer); the live release path today is the RIB's `proto_cleanup`.

## End-to-end (the whole feature, PRs 1019/1020/this)

A VRF's locally-generated route is advertised as VPNv4/v6 with a label drawn from the BGP dynamic block (≥ 100000, non-overlapping with SR), and the kernel shows `ip -f mpls route` → `<label> dev <vrf> proto bgp`.

## Test plan

- `cargo build -p zebra-rs` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p zebra-rs bgp::` (199) / `rib::` (150) — pass, incl. the new `bounded_allocator_stays_within_its_block`.
- CI is the source of truth for the full suite.

Generated with [Claude Code](https://claude.com/claude-code)