### PR TITLE
bgp: extend the per-VRF label block on demand

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -401,6 +401,10 @@ pub struct Bgp {
     /// `RibRx::LabelBlock` arrives — VRFs spawned before then take
     /// label 0 (degraded) and are reconciled on arrival.
     pub vrf_label_alloc: Option<super::vrf::VrfLabelAllocator>,
+    /// True while a `LabelBlockRequest` is outstanding — dedups the
+    /// initial request and any on-demand extension so a burst of
+    /// label-less VRFs asks the RIB label manager for only one block.
+    vrf_label_request_pending: bool,
     /// Inbound `:179` dispatch index — peer source IP to VRF name.
     /// Populated by [`super::vrf::BgpGlobalMsg::RegisterPeer`]
     /// each per-VRF task emits at spawn / materialise time, and
@@ -568,6 +572,7 @@ impl Bgp {
             rib_known_vrfs: BTreeMap::new(),
             rib_subscriber,
             vrf_label_alloc: None,
+            vrf_label_request_pending: false,
             peer_index: BTreeMap::new(),
             vrf_global_tx: vrf_global_tx_init,
             vrf_global_rx: vrf_global_rx_init,
@@ -936,11 +941,7 @@ impl Bgp {
             // effectively never fires; 0 would mean "no label"
             // downstream, which the Export handler already treats
             // as "skip label install" — a safe degradation.
-            let label = self
-                .vrf_label_alloc
-                .as_mut()
-                .and_then(|a| a.alloc())
-                .unwrap_or(0);
+            let label = self.alloc_vrf_label();
             let handle = super::vrf::spawn_bgp_vrf(
                 name.clone(),
                 &cfg,
@@ -991,10 +992,7 @@ impl Bgp {
             self.peer_index.retain(|_, owner| owner != name);
             handle.label
         } else {
-            self.vrf_label_alloc
-                .as_mut()
-                .and_then(|a| a.alloc())
-                .unwrap_or(0)
+            self.alloc_vrf_label()
         };
         let table_id = kernel.table_id;
         let new_handle = super::vrf::spawn_bgp_vrf(
@@ -1334,12 +1332,17 @@ impl Bgp {
     /// give it a real label and respawn so it stamps exports and
     /// installs its decap ILM.
     fn label_block_arrived(&mut self, start: u32, size: u32) {
-        self.vrf_label_alloc = Some(super::vrf::VrfLabelAllocator::bounded(start, start + size));
-        tracing::info!(
-            start,
-            size,
-            "bgp: bound per-VRF label allocator to dynamic block"
-        );
+        self.vrf_label_request_pending = false;
+        match self.vrf_label_alloc.as_mut() {
+            // First grant binds the allocator; later grants extend it
+            // (on-demand growth past the initial block).
+            Some(alloc) => alloc.extend(start, start + size),
+            None => {
+                self.vrf_label_alloc =
+                    Some(super::vrf::VrfLabelAllocator::bounded(start, start + size))
+            }
+        }
+        tracing::info!(start, size, "bgp: dynamic MPLS label block granted");
 
         let unlabelled: Vec<String> = self
             .vrf_registry
@@ -1350,6 +1353,35 @@ impl Bgp {
         for name in unlabelled {
             self.relabel_vrf(&name);
         }
+        // The reconcile may have outgrown this block too (a large VRF
+        // fleet). If any VRF is still label-less, ask for another.
+        if self.vrf_registry.values().any(|h| h.label == 0) {
+            self.request_label_block();
+        }
+    }
+
+    /// Send a `LabelBlockRequest` to the RIB label manager unless one is
+    /// already outstanding. Dedup keeps a burst of label-less VRFs from
+    /// each requesting a block.
+    fn request_label_block(&mut self) {
+        if self.vrf_label_request_pending {
+            return;
+        }
+        self.vrf_label_request_pending = true;
+        self.rib_subscriber
+            .send_label_block_request("bgp", VRF_LABEL_BLOCK_SIZE);
+    }
+
+    /// Allocate a per-VRF label from the dynamic block(s). When no block
+    /// is bound yet, or every block is spent, request (more) space and
+    /// return 0 — the VRF spawns label-less and is reconciled by
+    /// `label_block_arrived` once the grant lands.
+    fn alloc_vrf_label(&mut self) -> u32 {
+        if let Some(label) = self.vrf_label_alloc.as_mut().and_then(|a| a.alloc()) {
+            return label;
+        }
+        self.request_label_block();
+        0
     }
 
     /// Respawn `name`'s per-VRF task with a freshly-allocated label.
@@ -1754,8 +1786,7 @@ impl Bgp {
         // `vrf_label_alloc` before per-VRF tasks start asking for
         // labels; a VRF spawned before it lands takes label 0 and is
         // reconciled on arrival.
-        self.rib_subscriber
-            .send_label_block_request("bgp", VRF_LABEL_BLOCK_SIZE);
+        self.request_label_block();
         if let Err(err) = self.listen().await {
             self.listen_err = Some(err);
         }

--- a/zebra-rs/src/bgp/vrf/label.rs
+++ b/zebra-rs/src/bgp/vrf/label.rs
@@ -30,30 +30,50 @@ pub const LAST_USABLE_LABEL: u32 = 0x000F_FFFF;
 /// Counter-based allocator that hands out one label per VRF.
 /// Released labels are queued back onto `free` so churned VRFs
 /// don't bleed the space.
+/// One contiguous dynamic block the RIB label manager handed BGP.
+#[derive(Debug)]
+struct Block {
+    /// Inclusive lower bound.
+    start: u32,
+    /// Next never-allocated label in this block.
+    next: u32,
+    /// Exclusive upper bound.
+    end: u32,
+}
+
 #[derive(Debug)]
 pub struct VrfLabelAllocator {
-    /// Inclusive lower bound of the block this allocator draws from —
-    /// the start of the dynamic block the RIB label manager handed BGP.
-    start: u32,
-    /// Next never-allocated label within the block.
-    next: u32,
-    /// Exclusive upper bound of the block.
-    end: u32,
+    /// The dynamic blocks this allocator draws from, in grant order.
+    /// More are appended via [`Self::extend`] when BGP outgrows the
+    /// first block (an on-demand request to the RIB label manager).
+    blocks: Vec<Block>,
     /// Released labels, sorted so the lowest-numbered ones come
     /// out first — predictable for tests and operator readability.
     free: BTreeSet<u32>,
 }
 
 impl VrfLabelAllocator {
-    /// Allocator bound to the half-open block `[start, end)` — the
-    /// dynamic block the RIB label manager reserved for BGP.
+    /// Allocator seeded with the half-open block `[start, end)` — the
+    /// first dynamic block the RIB label manager reserved for BGP.
     pub fn bounded(start: u32, end: u32) -> Self {
         Self {
+            blocks: vec![Block {
+                start,
+                next: start,
+                end,
+            }],
+            free: BTreeSet::new(),
+        }
+    }
+
+    /// Append another granted block `[start, end)` (on-demand
+    /// extension when the existing blocks are spent).
+    pub fn extend(&mut self, start: u32, end: u32) {
+        self.blocks.push(Block {
             start,
             next: start,
             end,
-            free: BTreeSet::new(),
-        }
+        });
     }
 
     /// Unbounded over the whole usable label space — kept for tests
@@ -63,24 +83,30 @@ impl VrfLabelAllocator {
         Self::bounded(FIRST_USABLE_LABEL, LAST_USABLE_LABEL + 1)
     }
 
-    /// Hand out the next available label, preferring reclaimed ones.
-    /// Returns `None` when the block is exhausted.
+    /// Hand out the next available label, preferring reclaimed ones,
+    /// then the first block with room. `None` when every block is spent.
     pub fn alloc(&mut self) -> Option<u32> {
         if let Some(reused) = self.free.pop_first() {
             return Some(reused);
         }
-        if self.next >= self.end {
-            return None;
+        for block in self.blocks.iter_mut() {
+            if block.next < block.end {
+                let label = block.next;
+                block.next += 1;
+                return Some(label);
+            }
         }
-        let label = self.next;
-        self.next += 1;
-        Some(label)
+        None
     }
 
-    /// Return `label` to the pool. Idempotent. Labels outside this
-    /// allocator's block are rejected — they were never ours.
+    /// Return `label` to the pool. Idempotent. Labels outside every
+    /// block are rejected — they were never ours.
     pub fn free(&mut self, label: u32) {
-        if (self.start..self.end).contains(&label) {
+        if self
+            .blocks
+            .iter()
+            .any(|b| (b.start..b.end).contains(&label))
+        {
             self.free.insert(label);
         }
     }
@@ -169,5 +195,23 @@ mod tests {
         // A label outside the block was never ours — rejected.
         a.free(200);
         assert_eq!(a.alloc(), None);
+    }
+
+    #[test]
+    fn extend_appends_a_second_block() {
+        let mut a = VrfLabelAllocator::bounded(100, 102); // [100, 102)
+        assert_eq!(a.alloc(), Some(100));
+        assert_eq!(a.alloc(), Some(101));
+        assert_eq!(a.alloc(), None, "first block spent");
+        // On-demand extension with a fresh, disjoint block.
+        a.extend(500, 502); // [500, 502)
+        assert_eq!(a.alloc(), Some(500), "allocs from the new block");
+        assert_eq!(a.alloc(), Some(501));
+        assert_eq!(a.alloc(), None);
+        // Free works across both blocks; lowest freed comes out first.
+        a.free(100);
+        a.free(501);
+        assert_eq!(a.alloc(), Some(100));
+        assert_eq!(a.alloc(), Some(501));
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to the per-VRF label-block feature (#1021). A single 1024-label block capped BGP at 1024 VRFs; beyond that, VRFs spawned label-less with no recovery. This grows the allocation on demand.

## Changes

- **Multi-block allocator** — `VrfLabelAllocator` now holds a `Vec` of granted blocks; `extend(start, end)` appends one. `alloc` walks the blocks (after the free list); `free` accepts a label belonging to any block.
- **Deduped requests** — `Bgp` tracks `vrf_label_request_pending`. New `request_label_block` (no-op if a request is outstanding) and `alloc_vrf_label` (allocate, or request more space + return 0) replace the inline alloc at the VRF spawn/respawn sites and the startup request — so a burst of label-less VRFs triggers only one `LabelBlockRequest`.
- **Extend-on-arrival + converge** — `label_block_arrived` now *extends* the existing allocator instead of replacing it, reconciles label-less VRFs, and — if the reconcile outgrew even the new block — requests another. An arbitrarily large VRF fleet converges to fully-labelled in a bounded number of grants.

## Test plan

- `cargo build -p zebra-rs` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p zebra-rs vrf::label` (7, incl. new `extend_appends_a_second_block`) / `bgp::` (200) / `rib::` (150) — pass.
- CI is the source of truth for the full suite.

Generated with [Claude Code](https://claude.com/claude-code)