### PR TITLE
bgp: release fully-freed label blocks back to the RIB

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -916,8 +916,17 @@ impl Bgp {
                 // can pick it back up. Reclaim before the handle
                 // drops — handle drop aborts the task but doesn't
                 // know about the allocator.
-                if let Some(alloc) = self.vrf_label_alloc.as_mut() {
+                let released: Vec<(u32, u32)> = if let Some(alloc) = self.vrf_label_alloc.as_mut() {
                     alloc.free(handle.label);
+                    // A shrinking VRF count can free a whole block;
+                    // return it to the RIB label manager.
+                    alloc.reclaim_free_blocks()
+                } else {
+                    Vec::new()
+                };
+                for (start, end) in released {
+                    self.rib_subscriber
+                        .send_label_block_release("bgp", start, end - start);
                 }
                 // Drop every `peer_index` entry that pointed at
                 // this VRF — defensive cleanup against the VRF

--- a/zebra-rs/src/bgp/vrf/label.rs
+++ b/zebra-rs/src/bgp/vrf/label.rs
@@ -110,6 +110,37 @@ impl VrfLabelAllocator {
             self.free.insert(label);
         }
     }
+
+    /// Reclaim and return every fully-unused block (one whose carved
+    /// labels are all freed), so BGP can return them to the RIB label
+    /// manager when its VRF count shrinks. Always keeps at least one
+    /// block so the allocator stays usable without an immediate
+    /// re-request. Returned `(start, end)` pairs are half-open.
+    pub fn reclaim_free_blocks(&mut self) -> Vec<(u32, u32)> {
+        let mut reclaimed = Vec::new();
+        let mut i = 0;
+        while i < self.blocks.len() {
+            // Keep at least one block — don't churn down to empty.
+            if self.blocks.len() <= 1 {
+                break;
+            }
+            let (start, next, end) = {
+                let b = &self.blocks[i];
+                (b.start, b.next, b.end)
+            };
+            // Fully unused iff every carved label is freed (an
+            // untouched block has an empty carved range → true).
+            if (start..next).all(|l| self.free.contains(&l)) {
+                self.blocks.remove(i);
+                // The released labels are no longer ours.
+                self.free.retain(|&l| !(start..end).contains(&l));
+                reclaimed.push((start, end));
+            } else {
+                i += 1;
+            }
+        }
+        reclaimed
+    }
 }
 
 impl Default for VrfLabelAllocator {
@@ -213,5 +244,31 @@ mod tests {
         a.free(501);
         assert_eq!(a.alloc(), Some(100));
         assert_eq!(a.alloc(), Some(501));
+    }
+
+    #[test]
+    fn reclaim_returns_fully_free_extra_blocks() {
+        let mut a = VrfLabelAllocator::bounded(100, 102); // [100, 102)
+        a.extend(500, 502); // [500, 502)
+        let l0 = a.alloc().unwrap(); // 100 (block 0)
+        let _l1 = a.alloc().unwrap(); // 101 (block 0 now spent, in use)
+        let l2 = a.alloc().unwrap(); // 500 (block 1)
+
+        // Both blocks have in-use labels → nothing to reclaim.
+        assert!(a.reclaim_free_blocks().is_empty());
+
+        // Free block 1's only carved label → block 1 is fully free and
+        // gets reclaimed (block 0 still in use, kept).
+        a.free(l2);
+        assert_eq!(a.reclaim_free_blocks(), vec![(500, 502)]);
+        // The released labels are no longer allocatable.
+        assert_eq!(a.alloc(), None);
+
+        // Freeing block 0's labels leaves it fully free, but it's the
+        // only block left → kept (no churn), and its labels stay reusable.
+        a.free(l0);
+        a.free(101);
+        assert!(a.reclaim_free_blocks().is_empty());
+        assert_eq!(a.alloc(), Some(100));
     }
 }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -137,6 +137,17 @@ impl RibSubscriber {
             size,
         });
     }
+
+    /// Return a previously-granted label block `[start, start+size)` to
+    /// the RIB label manager — used when a protocol's label usage
+    /// shrinks enough to free a whole block.
+    pub fn send_label_block_release(&self, proto: &str, start: u32, size: u32) {
+        let _ = self.rib_tx.send(crate::rib::Message::LabelBlockRelease {
+            proto: proto.to_string(),
+            start,
+            size,
+        });
+    }
 }
 
 pub struct ConfigManager {

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -146,12 +146,9 @@ pub enum Message {
         size: u32,
     },
     /// Return a previously-reserved label block `[start, start+size)` to
-    /// the pool. `proto_cleanup` is the backstop for a proto that exits
-    /// without releasing.
-    //
-    // `allow(dead_code)`: the live release path is `proto_cleanup`; an
-    // explicit per-block release while running is a follow-up.
-    #[allow(dead_code)]
+    /// the pool — produced by a protocol whose label usage shrank enough
+    /// to free a whole block. `proto_cleanup` is the backstop for a
+    /// proto that exits without releasing.
     LabelBlockRelease {
         proto: String,
         start: u32,


### PR DESCRIPTION
## Summary

Final follow-up of the per-VRF label-block series. The label manager already had `Message::LabelBlockRelease` + a handler, but the only producer was `proto_cleanup` (full BGP teardown). This adds the live producer: when BGP's VRF count shrinks enough to free a whole dynamic block, it returns the block to the RIB pool for other protocols.

## Changes

- **`VrfLabelAllocator::reclaim_free_blocks`** removes and returns every block whose carved labels are all freed (an untouched extension block too), keeping **at least one** block so the allocator stays usable without an immediate re-request. Reclaimed labels leave the free list.
- **Despawn producer** — on VRF despawn, after freeing the label, BGP reclaims any now-empty block and sends `Message::LabelBlockRelease` per block (new `RibSubscriber::send_label_block_release`).
- Removed the now-satisfied `#[allow(dead_code)]` on `Message::LabelBlockRelease`.

The dynamic block now both **grows** (on-demand, #1022) and **shrinks** (returning space to the RIB), closing the series.

## Test plan

- `cargo build -p zebra-rs` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p zebra-rs vrf::label` (8, incl. new `reclaim_returns_fully_free_extra_blocks`) / `bgp::` (201) / `rib::` (150) — pass.
- CI is the source of truth for the full suite.

Generated with [Claude Code](https://claude.com/claude-code)