### PR TITLE
rib: add SidBehavior::EndDT46 + per-VRF-table seg6local decap

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -225,11 +225,12 @@ fn sid_route_target(
             )
         }
         SidBehavior::UA => (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr),
-        // End.DT4 / End.DT6 are terminal decap+lookup actions. Same
-        // FIB shape as End.X — a /128 host route in table=main with
-        // kind=Unicast, pointed at sr0 by the static route's
-        // ifindex_origin.
-        SidBehavior::EndDT4 | SidBehavior::EndDT6 => {
+        // End.DT4 / End.DT6 / End.DT46 are terminal decap+lookup
+        // actions. Same FIB shape as End.X — a /128 host route in
+        // table=main with kind=Unicast, pointed at sr0 by the static
+        // route's ifindex_origin. (The inner decap lookup table for
+        // End.DT* rides inside the seg6local encap, not here.)
+        SidBehavior::EndDT4 | SidBehavior::EndDT6 | SidBehavior::EndDT46 => {
             (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr)
         }
     }
@@ -664,7 +665,10 @@ impl FibHandle {
                 msg.attributes.push(RouteAttribute::Oif(ifindex));
             }
             if let Some((encap, encap_type)) =
-                super::srv6::build_seg6local_attrs(action, None, None)
+                // Static seg6local action routes keep the legacy
+                // RT_TABLE_MAIN decap (table_id 0); per-VRF table
+                // selection arrives via the protocol SID path.
+                super::srv6::build_seg6local_attrs(action, None, None, 0)
             {
                 msg.attributes.push(encap);
                 msg.attributes.push(encap_type);
@@ -1303,7 +1307,7 @@ impl FibHandle {
             msg.attributes.push(RouteAttribute::Oif(ifindex));
         }
         let Some((encap, encap_type)) =
-            super::srv6::build_seg6local_attrs(sid.behavior, sid.nh6, sid.structure)
+            super::srv6::build_seg6local_attrs(sid.behavior, sid.nh6, sid.structure, sid.table_id)
         else {
             tracing::warn!(
                 "seg6local route encap build skipped for {} (End.X / uA without IPv6 nexthop)",

--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -86,6 +86,7 @@ fn seg6local_action(behavior: SidBehavior) -> Seg6LocalAction {
         SidBehavior::EndX | SidBehavior::UA => Seg6LocalAction::EndX,
         SidBehavior::EndDT4 => Seg6LocalAction::EndDt4,
         SidBehavior::EndDT6 => Seg6LocalAction::EndDt6,
+        SidBehavior::EndDT46 => Seg6LocalAction::EndDt46,
     }
 }
 
@@ -121,11 +122,13 @@ fn build_seg6local_flavors(
 // Flavors block). End.X / uA also nests Nh6 (the IPv6 nexthop).
 // End.DT4 / End.DT6 nest a Table id — `iproute2`'s `table N` keyword,
 // `SEG6_LOCAL_TABLE` on the wire — telling the kernel which IPv4 /
-// IPv6 fib to look up the decapsulated inner packet in. We default
-// to RT_TABLE_MAIN; once zebra-rs grows VRF support, the operator-
-// set table id flows through here. (End.DT46 is the dual-family
-// variant and uses `SEG6_LOCAL_VRFTABLE` instead — not modeled
-// yet.) The kernel's required oif rides on the outer route /
+// IPv6 fib to look up the decapsulated inner packet in. `table_id`
+// of 0 means RT_TABLE_MAIN (the static / IS-IS default); a non-zero
+// id (a VRF's kernel table) flows straight through. End.DT46 is the
+// dual-family variant: it carries the table as `SEG6_LOCAL_VRFTABLE`
+// (`iproute2`'s `vrftable N`) so the kernel resolves the inner v4 or
+// v6 packet in the VRF — this is the per-VRF SID BGP L3VPN-over-SRv6
+// programs. The kernel's required oif rides on the outer route /
 // nexthop message rather than inside the encap, so we don't add it
 // here.
 //
@@ -137,6 +140,7 @@ fn build_seg6local_lwtunnel(
     behavior: SidBehavior,
     nh6: Option<Ipv6Addr>,
     structure: Option<SidStructure>,
+    table_id: u32,
 ) -> Option<Vec<RouteLwTunnelEncap>> {
     let mut attrs: Vec<RouteSeg6LocalIpTunnel> =
         vec![RouteSeg6LocalIpTunnel::Action(seg6local_action(behavior))];
@@ -145,9 +149,20 @@ fn build_seg6local_lwtunnel(
         attrs.push(RouteSeg6LocalIpTunnel::Nh6(nh));
     }
     if matches!(behavior, SidBehavior::EndDT4 | SidBehavior::EndDT6) {
-        attrs.push(RouteSeg6LocalIpTunnel::Table(
-            RouteHeader::RT_TABLE_MAIN as u32,
-        ));
+        // `SEG6_LOCAL_TABLE`: 0 maps to RT_TABLE_MAIN to preserve the
+        // existing static / IS-IS terminal behavior.
+        let table = if table_id == 0 {
+            RouteHeader::RT_TABLE_MAIN as u32
+        } else {
+            table_id
+        };
+        attrs.push(RouteSeg6LocalIpTunnel::Table(table));
+    }
+    if matches!(behavior, SidBehavior::EndDT46) {
+        // `SEG6_LOCAL_VRFTABLE`: the dual-family decap resolves the
+        // inner packet in a VRF table, so it needs a real (non-MAIN)
+        // table id — BGP passes the VRF's kernel table.
+        attrs.push(RouteSeg6LocalIpTunnel::VrfTable(table_id));
     }
     if let Some(flavors) = build_seg6local_flavors(behavior, structure) {
         attrs.push(flavors);
@@ -161,13 +176,16 @@ fn build_seg6local_lwtunnel(
 }
 
 // Build seg6local route-attribute pair (Encap + EncapType) for the
-// embedded-encap route install path.
+// embedded-encap route install path. `table_id` selects the decap
+// lookup table for the End.DT* behaviors (0 = RT_TABLE_MAIN); see
+// `build_seg6local_lwtunnel`.
 pub fn build_seg6local_attrs(
     behavior: SidBehavior,
     nh6: Option<Ipv6Addr>,
     structure: Option<SidStructure>,
+    table_id: u32,
 ) -> Option<(RouteAttribute, RouteAttribute)> {
-    let encaps = build_seg6local_lwtunnel(behavior, nh6, structure)?;
+    let encaps = build_seg6local_lwtunnel(behavior, nh6, structure, table_id)?;
     Some((
         RouteAttribute::Encap(encaps),
         RouteAttribute::EncapType(RouteLwEnCapType::Seg6Local),
@@ -177,3 +195,57 @@ pub fn build_seg6local_attrs(
 // (build_seg6local_nh_attrs removed: the kernel rejects seg6local
 // lwtunnel encaps in the nexthop table, so we always embed the encap
 // on the route message via build_seg6local_attrs.)
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn table_attr(encaps: &[RouteLwTunnelEncap]) -> Option<u32> {
+        encaps.iter().find_map(|e| match e {
+            RouteLwTunnelEncap::Seg6Local(RouteSeg6LocalIpTunnel::Table(t)) => Some(*t),
+            _ => None,
+        })
+    }
+
+    fn vrftable_attr(encaps: &[RouteLwTunnelEncap]) -> Option<u32> {
+        encaps.iter().find_map(|e| match e {
+            RouteLwTunnelEncap::Seg6Local(RouteSeg6LocalIpTunnel::VrfTable(t)) => Some(*t),
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn end_dt46_uses_vrftable_with_given_table() {
+        // BGP L3VPN-over-SRv6: an End.DT46 SID decaps into the VRF's
+        // kernel table via SEG6_LOCAL_VRFTABLE, never a plain table.
+        let encaps =
+            build_seg6local_lwtunnel(SidBehavior::EndDT46, None, None, 100).expect("encap built");
+        assert!(
+            encaps.iter().any(|e| matches!(
+                e,
+                RouteLwTunnelEncap::Seg6Local(RouteSeg6LocalIpTunnel::Action(
+                    Seg6LocalAction::EndDt46
+                ))
+            )),
+            "End.DT46 action present"
+        );
+        assert_eq!(vrftable_attr(&encaps), Some(100));
+        assert_eq!(table_attr(&encaps), None, "no plain SEG6_LOCAL_TABLE");
+    }
+
+    #[test]
+    fn end_dt6_table_zero_maps_to_main() {
+        // table_id 0 must preserve the legacy static / IS-IS default.
+        let encaps =
+            build_seg6local_lwtunnel(SidBehavior::EndDT6, None, None, 0).expect("encap built");
+        assert_eq!(table_attr(&encaps), Some(RouteHeader::RT_TABLE_MAIN as u32));
+        assert_eq!(vrftable_attr(&encaps), None);
+    }
+
+    #[test]
+    fn end_dt4_honors_nonzero_table() {
+        let encaps =
+            build_seg6local_lwtunnel(SidBehavior::EndDT4, None, None, 42).expect("encap built");
+        assert_eq!(table_attr(&encaps), Some(42));
+    }
+}

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2220,6 +2220,8 @@ impl Isis {
                 ifindex: 0,
                 nh6: None,
                 structure,
+                // End / uN is local-processing, no table decap.
+                table_id: 0,
             };
             let _ = self.ctx.rib.send(rib::Message::SidAdd { sid });
             self.sr_end_sid = Some(addr);

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -158,6 +158,8 @@ impl Neighbor {
             ifindex: self.ifindex,
             nh6,
             structure,
+            // End.X is a local cross-connect, not a table decap.
+            table_id: 0,
         };
         let _ = rib_client.send(rib::Message::SidAdd { sid });
         self.endx_sid = Some((function, addr));

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -39,6 +39,12 @@ pub enum SidBehavior {
     /// End.DT6 — RFC 8986 §4.7. Decapsulates and looks up the inner
     /// IPv6 packet in a configured table. Same caveat as End.DT4.
     EndDT6,
+    /// End.DT46 — RFC 8986 §4.8. Dual-family decap: pops the outer
+    /// IPv6 / SRH and looks the inner IPv4 *or* IPv6 packet up in a
+    /// VRF table (`SEG6_LOCAL_VRFTABLE`). One SID serves both AFIs,
+    /// which is how BGP L3VPN-over-SRv6 binds a single per-VRF SID;
+    /// the table-id is carried in [`Sid::table_id`].
+    EndDT46,
 }
 
 impl fmt::Display for SidBehavior {
@@ -50,6 +56,7 @@ impl fmt::Display for SidBehavior {
             Self::UA => write!(f, "uA"),
             Self::EndDT4 => write!(f, "End.DT4"),
             Self::EndDT6 => write!(f, "End.DT6"),
+            Self::EndDT46 => write!(f, "End.DT46"),
         }
     }
 }
@@ -68,6 +75,7 @@ impl FromStr for SidBehavior {
             "uA" => Ok(Self::UA),
             "End.DT4" => Ok(Self::EndDT4),
             "End.DT6" => Ok(Self::EndDT6),
+            "End.DT46" => Ok(Self::EndDT46),
             other => Err(SidBehaviorParseError(other.to_string())),
         }
     }
@@ -178,6 +186,13 @@ pub struct Sid {
     /// Partitioning of the SID's bits. Required for `UN`/`UA`; ignored
     /// for classic `End`/`EndX` (left `None`).
     pub structure: Option<SidStructure>,
+    /// Kernel routing-table id the decap looks the inner packet up in,
+    /// for the End.DT* behaviors. `0` means `RT_TABLE_MAIN` (the
+    /// default IS-IS / static path lands inner traffic in the main
+    /// table); BGP L3VPN-over-SRv6 sets it to the VRF's table so an
+    /// End.DT46 decap lands in the right VRF. Ignored by End / End.X /
+    /// uN / uA.
+    pub table_id: u32,
 }
 
 impl Sid {
@@ -195,7 +210,8 @@ impl Sid {
             | SidBehavior::EndX
             | SidBehavior::UA
             | SidBehavior::EndDT4
-            | SidBehavior::EndDT6 => Ipv6Net::new(self.addr, 128).expect("/128 is always valid"),
+            | SidBehavior::EndDT6
+            | SidBehavior::EndDT46 => Ipv6Net::new(self.addr, 128).expect("/128 is always valid"),
             SidBehavior::UN => {
                 let plen = self
                     .structure
@@ -230,6 +246,7 @@ mod tests {
         assert_eq!(SidBehavior::EndX.to_string(), "End.X");
         assert_eq!(SidBehavior::EndDT4.to_string(), "End.DT4");
         assert_eq!(SidBehavior::EndDT6.to_string(), "End.DT6");
+        assert_eq!(SidBehavior::EndDT46.to_string(), "End.DT46");
     }
 
     #[test]
@@ -243,6 +260,7 @@ mod tests {
             SidBehavior::UA,
             SidBehavior::EndDT4,
             SidBehavior::EndDT6,
+            SidBehavior::EndDT46,
         ] {
             let s = variant.to_string();
             let parsed: SidBehavior = s.parse().expect("round-trip");

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -2014,6 +2014,7 @@ mod tests {
             ifindex: 0,
             nh6: None,
             structure: None,
+            table_id: 0,
         }
     }
 


### PR DESCRIPTION
## Summary

Phase 2 of BGP L3VPN over an SRv6 underlay (RFC 9252). Adds the SRv6
**End.DT46** endpoint behavior (RFC 8986 §4.8) — the dual-family decap
that a PE binds **one per VRF** — and threads a decap **table-id**
through the SID install so the `seg6local` route lands inner traffic in
the correct kernel table.

- **`SidBehavior::EndDT46`** in `rib/segment_routing/sid.rs` (Display /
  FromStr / `prefix()` /128). The static-route YANG `behavior` enum
  already listed `End.DT46`; this makes that value parse instead of
  erroring.
- **`Sid::table_id`** — `0` means `RT_TABLE_MAIN` (the IS-IS / static
  default, so existing SIDs are unchanged); BGP will set it to the
  VRF's kernel table.
- **Netlink** (`fib/netlink/srv6.rs`): `seg6local_action` maps
  `EndDT46 → Seg6LocalAction::EndDt46`; `build_seg6local_lwtunnel` /
  `build_seg6local_attrs` now take `table_id` — `End.DT4`/`End.DT6`
  emit `SEG6_LOCAL_TABLE` (`0 → MAIN`), `End.DT46` emits
  `SEG6_LOCAL_VRFTABLE` (`iproute2`'s `vrftable N`) for the dual-family
  VRF lookup. `sid_route_target` gives `End.DT46` the same
  `/128`-in-main outer route as the other terminal behaviors.
- Threaded `table_id` through both `build_seg6local_attrs` call sites
  (static action route = `0`, protocol SID install = `sid.table_id`)
  and stamped `0` on the IS-IS `End` / `End.X` ctors.

## Test plan

- `cargo test -p zebra-rs --bin zebra-rs fib::` — new
  `end_dt46_uses_vrftable_with_given_table`,
  `end_dt6_table_zero_maps_to_main`, `end_dt4_honors_nonzero_table`.
- `cargo test -p zebra-rs --bin zebra-rs rib:: isis::` — 150 + 132 pass
  (SidBehavior Display/FromStr round-trips include End.DT46).
- `cargo build -p zebra-rs`, `cargo clippy --workspace --all-targets -- -D warnings` — clean.

Generated with [Claude Code](https://claude.com/claude-code)