### PR TITLE
bgp: SRv6 L3VPN config knobs + locator subscription (Phase 3a)

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -51,6 +51,20 @@ fn config_global_hostname(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option
     Some(())
 }
 
+/// `set router bgp global srv6 locator <name>` — names the SRv6
+/// locator BGP carves per-VRF End.DT46 service SIDs from for L3VPN
+/// over SRv6 (RFC 9252). Drives the RIB locator watch; SID
+/// allocation off the resolved locator lands in a follow-up.
+fn config_global_srv6_locator(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    if op == ConfigOp::Set {
+        let name = args.string()?;
+        bgp.set_srv6_locator(Some(name));
+    } else {
+        bgp.set_srv6_locator(None);
+    }
+    Some(())
+}
+
 fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     if op == ConfigOp::Set {
@@ -1506,6 +1520,10 @@ impl Bgp {
         self.callback_add("/router/bgp/global/as", config_global_asn);
         self.callback_add("/router/bgp/global/identifier", config_global_identifier);
         self.callback_add("/router/bgp/global/hostname", config_global_hostname);
+        self.callback_add(
+            "/router/bgp/global/srv6/locator",
+            config_global_srv6_locator,
+        );
         self.callback_peer("", config_peer);
         self.callback_peer("/remote-as", config_remote_as);
         // Per-peer reference to a `neighbor-group`. Storage only —
@@ -1559,6 +1577,10 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/vrf/label-mode",
             super::vrf_config::config_vrf_label_mode,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/encapsulation",
+            super::vrf_config::config_vrf_encapsulation,
         );
         self.callback_add(
             "/router/bgp/vrf/neighbor",

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -405,6 +405,16 @@ pub struct Bgp {
     /// initial request and any on-demand extension so a burst of
     /// label-less VRFs asks the RIB label manager for only one block.
     vrf_label_request_pending: bool,
+    /// Configured global SRv6 locator name (`router bgp global srv6
+    /// locator <name>`). When set, BGP watches this locator on the
+    /// RIB and (in a follow-up) carves per-VRF End.DT46 service SIDs
+    /// from it for `encapsulation srv6` VRFs. `None` until configured.
+    pub srv6_locator_name: Option<String>,
+    /// SRv6 locator updates from the RIB segment-routing manager,
+    /// established once via `Message::SrSubscribe` in [`Self::new`].
+    /// Drained in the event loop; resolution is currently logged and
+    /// the resolved `Locator` + SID allocation land in a follow-up.
+    pub srv6_locator_rx: UnboundedReceiver<crate::rib::RibSrRx>,
     /// Inbound `:179` dispatch index — peer source IP to VRF name.
     /// Populated by [`super::vrf::BgpGlobalMsg::RegisterPeer`]
     /// each per-VRF task emits at spawn / materialise time, and
@@ -535,6 +545,11 @@ impl Bgp {
         if let Some(ref tx) = nd_client_tx {
             let _ = tx.send(crate::nd::inst::NdClientReq::SetNotifier { tx: nd_event_tx });
         }
+        // SRv6 locator subscription. Register the SR return channel
+        // once up front (mirrors IS-IS); the per-locator interest is
+        // expressed later via `SrLocatorWatch` when the operator sets
+        // `router bgp global srv6 locator <name>`.
+        let (srv6_sr_tx, srv6_locator_rx) = mpsc::unbounded_channel();
         let mut bgp = Self {
             asn: 0,
             router_id: Ipv4Addr::UNSPECIFIED,
@@ -573,6 +588,8 @@ impl Bgp {
             rib_subscriber,
             vrf_label_alloc: None,
             vrf_label_request_pending: false,
+            srv6_locator_name: None,
+            srv6_locator_rx,
             peer_index: BTreeMap::new(),
             vrf_global_tx: vrf_global_tx_init,
             vrf_global_rx: vrf_global_rx_init,
@@ -594,6 +611,13 @@ impl Bgp {
         };
         bgp.callback_build();
         bgp.show_build();
+        // One-time SR subscription so subsequent `SrLocatorWatch`
+        // requests get a return channel; the RIB replies on
+        // `srv6_locator_rx`.
+        let _ = bgp.ctx.rib.send(crate::rib::Message::SrSubscribe {
+            proto: "bgp".into(),
+            tx: srv6_sr_tx,
+        });
         bgp
     }
 
@@ -627,6 +651,57 @@ impl Bgp {
         let resolved = self.hostname();
         for (_, peer) in self.peers.iter_mut() {
             peer.local_hostname = resolved.clone();
+        }
+    }
+
+    /// Update the configured global SRv6 locator name and (un)watch it
+    /// on the RIB. Mirrors IS-IS `reconcile_locator_watch`: unwatch the
+    /// previous name, watch the new one. The resolved [`Locator`]
+    /// arrives asynchronously on [`Self::srv6_locator_rx`].
+    pub fn set_srv6_locator(&mut self, name: Option<String>) {
+        if self.srv6_locator_name == name {
+            return;
+        }
+        if let Some(prev) = self.srv6_locator_name.take() {
+            let _ = self.ctx.rib.send(crate::rib::Message::SrLocatorUnwatch {
+                proto: "bgp".into(),
+                name: prev,
+            });
+        }
+        if let Some(next) = name {
+            let _ = self.ctx.rib.send(crate::rib::Message::SrLocatorWatch {
+                proto: "bgp".into(),
+                name: next.clone(),
+            });
+            self.srv6_locator_name = Some(next);
+        }
+    }
+
+    /// Handle an SRv6 locator update from the RIB segment-routing
+    /// manager. v1 logs the resolution so operators can confirm the
+    /// configured `srv6 locator` bound to a real prefix; storing the
+    /// resolved [`Locator`] and allocating per-VRF End.DT46 service
+    /// SIDs lands in a follow-up.
+    fn process_sr_rx(&mut self, msg: crate::rib::RibSrRx) {
+        match msg {
+            crate::rib::RibSrRx::Locator { name, locator } => {
+                // Ignore stale updates for a locator we no longer watch.
+                if self.srv6_locator_name.as_deref() != Some(name.as_str()) {
+                    return;
+                }
+                match locator.as_ref().and_then(|l| l.prefix) {
+                    Some(prefix) => {
+                        tracing::info!(locator = %name, %prefix, "bgp: SRv6 locator resolved");
+                    }
+                    None => {
+                        tracing::info!(
+                            locator = %name,
+                            "bgp: SRv6 locator unresolved / withdrawn",
+                        );
+                    }
+                }
+            }
+            crate::rib::RibSrRx::Block { .. } => {}
         }
     }
 
@@ -1840,6 +1915,10 @@ impl Bgp {
                     // VRF→global fan-in: peer register / accept
                     // dispatch and Export → VPNv4/v6.
                     self.process_vrf_global_msg(msg);
+                }
+                Some(msg) = self.srv6_locator_rx.recv() => {
+                    // SRv6 locator resolution from the RIB SR manager.
+                    self.process_sr_rx(msg);
                 }
             }
         }

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -23,7 +23,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::context::{ProtoContext, Task};
 
 use super::super::inst::RibKnownVrf;
-use super::super::vrf_config::BgpVrfConfig;
+use super::super::vrf_config::{BgpVrfConfig, BgpVrfEncapsulation};
 use super::inst::{BgpVrf, BgpVrfInbox, serve_vrf};
 use super::msg::{BgpGlobalMsg, BgpVrfMsg};
 
@@ -184,8 +184,16 @@ pub fn spawn_bgp_vrf(
     // placeholder-ctx spawn skips the install; the
     // `maybe_respawn_vrf_with_kernel_ctx` path re-runs with kernel
     // info and installs the ILM then.
+    //
+    // SRv6-mode VRFs (`encapsulation srv6`) skip the MPLS decap
+    // entirely: their per-VRF End.DT46 service SID replaces the
+    // label-bound ILM (programmed in a follow-up). Guarding here keeps
+    // the kernel MPLS table clean of entries that would never be
+    // advertised.
     let ilm_decap_ifindex = match (kernel_table_id, kernel_ifindex) {
-        (Some(table_id), Some(vrf_ifindex)) if label != 0 => {
+        (Some(table_id), Some(vrf_ifindex))
+            if label != 0 && cfg.encapsulation == BgpVrfEncapsulation::Mpls =>
+        {
             let entry = crate::rib::inst::IlmEntry {
                 ilm_type: crate::rib::inst::IlmType::DecapVrf {
                     table_id,

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -57,6 +57,28 @@ impl BgpVrfLabelMode {
     }
 }
 
+/// VPN data-plane encapsulation for a VRF — mirrors `encapsulation`
+/// in zebra-bgp-vrf.yang. Default `Mpls` (RFC 4364 service label).
+/// `Srv6` (RFC 9252) binds a per-VRF End.DT46 service SID from the
+/// global `srv6 locator` instead of an MPLS label, and the PE
+/// programs a seg6local decap rather than an AF_MPLS ILM.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum BgpVrfEncapsulation {
+    #[default]
+    Mpls,
+    Srv6,
+}
+
+impl BgpVrfEncapsulation {
+    fn parse(s: &str) -> Option<Self> {
+        match s {
+            "mpls" => Some(Self::Mpls),
+            "srv6" => Some(Self::Srv6),
+            _ => None,
+        }
+    }
+}
+
 /// Per-peer attribute set for a CE peer configured under
 /// `router bgp vrf X neighbor <addr>`. Mirrors `bgp-vrf-neighbor` in
 /// zebra-bgp-vrf.yang.
@@ -105,6 +127,7 @@ pub struct BgpVrfConfig {
     pub rd: Option<RouteDistinguisher>,
     pub router_id: Option<Ipv4Addr>,
     pub label_mode: BgpVrfLabelMode,
+    pub encapsulation: BgpVrfEncapsulation,
     pub neighbors: BTreeMap<IpAddr, BgpVrfNeighborConfig>,
     pub ipv4_unicast: Option<BgpVrfAfConfig<Ipv4Net>>,
     pub ipv6_unicast: Option<BgpVrfAfConfig<Ipv6Net>>,
@@ -169,6 +192,21 @@ pub fn config_vrf_label_mode(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
             cfg.label_mode = BgpVrfLabelMode::parse(&raw)?;
         }
         ConfigOp::Delete => cfg.label_mode = BgpVrfLabelMode::default(),
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp vrf <NAME> encapsulation {mpls|srv6}`.
+pub fn config_vrf_encapsulation(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let cfg = vrf_entry(bgp, name);
+    match op {
+        ConfigOp::Set => {
+            let raw = args.string()?;
+            cfg.encapsulation = BgpVrfEncapsulation::parse(&raw)?;
+        }
+        ConfigOp::Delete => cfg.encapsulation = BgpVrfEncapsulation::default(),
         _ => {}
     }
     Some(())
@@ -363,6 +401,29 @@ mod tests {
             Some(BgpVrfLabelMode::Nexthop)
         );
         assert_eq!(BgpVrfLabelMode::parse("bogus"), None);
+    }
+
+    #[test]
+    fn encapsulation_parse_accepts_yang_enums() {
+        assert_eq!(
+            BgpVrfEncapsulation::parse("mpls"),
+            Some(BgpVrfEncapsulation::Mpls)
+        );
+        assert_eq!(
+            BgpVrfEncapsulation::parse("srv6"),
+            Some(BgpVrfEncapsulation::Srv6)
+        );
+        assert_eq!(BgpVrfEncapsulation::parse("bogus"), None);
+    }
+
+    #[test]
+    fn vrf_config_default_encapsulation_is_mpls() {
+        // YANG default is `mpls` — a VRF with no `encapsulation` leaf
+        // keeps the RFC 4364 MPLS service-label data path.
+        assert_eq!(
+            BgpVrfConfig::default().encapsulation,
+            BgpVrfEncapsulation::Mpls
+        );
     }
 
     #[test]

--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -319,6 +319,22 @@ module ietf-bgp {
              hostname is used; when neither is available the
              capability is not sent.";
         }
+        container srv6 {
+          description
+            "SRv6 parameters for BGP services over an SRv6 underlay
+             (RFC 9252).";
+          leaf locator {
+            type string;
+            description
+              "Name of the SRv6 locator this BGP speaker draws per-VRF
+               End.DT46 service SIDs from for L3VPN over SRv6. Held as
+               a plain string (staging-friendly, like the IS-IS
+               `locator` reference) and resolved against the locators
+               the RIB segment-routing manager publishes; until it
+               resolves, `encapsulation srv6` VRFs run without a
+               service SID.";
+          }
+        }
         container distance {
           description
             "Administrative distances (or preferences) assigned to

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -271,6 +271,28 @@ module zebra-bgp-vrf {
           "Label allocation strategy for VPN routes originated from
            this VRF. Consulted by the label allocator in step 19.";
       }
+      leaf encapsulation {
+        type enumeration {
+          enum mpls {
+            description
+              "MPLS encapsulation (default, RFC 4364). VPN routes
+               carry an MPLS service label and a PE pops it into the
+               VRF master device.";
+          }
+          enum srv6 {
+            description
+              "SRv6 encapsulation (RFC 9252). The VRF binds a single
+               End.DT46 service SID carved from the global `srv6
+               locator`, advertised in the BGP Prefix-SID attribute;
+               the PE decapsulates into the VRF table via seg6local.
+               Requires a resolved global `srv6 locator`.";
+          }
+        }
+        default "mpls";
+        description
+          "VPN data-plane encapsulation for routes originated from /
+           imported into this VRF.";
+      }
       uses bgp-vrf-neighbor;
       uses bgp-vrf-afi-safi;
     }


### PR DESCRIPTION
## Summary

Phase 3a of BGP L3VPN over an SRv6 underlay (RFC 9252) — the
configuration + RIB-locator plumbing, ahead of per-VRF SID allocation
(3b).

- **YANG**: global `router bgp global srv6 locator <name>` (under
  ietf-bgp `container global`) and per-VRF `encapsulation {mpls|srv6}`
  (default `mpls`) in `zebra-bgp-vrf.yang`, next to `label-mode`.
- **Config**: `BgpVrfEncapsulation` enum + `BgpVrfConfig.encapsulation`
  + `config_vrf_encapsulation`; global `config_global_srv6_locator`.
- **Locator subscription**: `Bgp` registers the SR return channel once
  at startup (`Message::SrSubscribe`) and watches/unwatches the
  configured locator via `set_srv6_locator` — mirrors IS-IS
  `reconcile_locator_watch`. Locator resolution is drained in the
  event loop (`process_sr_rx`) and logged so operators can confirm the
  `srv6 locator` bound to a real prefix.
- **Spawn**: an `encapsulation srv6` VRF **skips the MPLS DecapVrf
  ILM** — its End.DT46 service SID (a follow-up) replaces it, keeping
  the kernel MPLS table free of entries that would never be
  advertised. (Despawn already no-ops because such a VRF's
  `ilm_decap_ifindex` is `None`.)

No SID allocation yet — the resolved-locator storage, the End.DT46 SID
allocate/install, the advertise, and the ingress install land in
follow-ups (3b–5). An `encapsulation srv6` VRF currently has no service
decap until 3b.

## Test plan

- `cargo test -p zebra-rs --bin zebra-rs vrf_config::` — new
  `encapsulation_parse_accepts_yang_enums` +
  `vrf_config_default_encapsulation_is_mpls`.
- `cargo test -p zebra-rs --bin zebra-rs bgp::` — 203 pass.
- `cargo build -p zebra-rs`, `cargo clippy --workspace --all-targets -- -D warnings` — clean.

Generated with [Claude Code](https://claude.com/claude-code)