### PR TITLE
bgp: per-VRF End.DT46 SID allocation + seg6local decap (Phase 3b)

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -412,9 +412,18 @@ pub struct Bgp {
     pub srv6_locator_name: Option<String>,
     /// SRv6 locator updates from the RIB segment-routing manager,
     /// established once via `Message::SrSubscribe` in [`Self::new`].
-    /// Drained in the event loop; resolution is currently logged and
-    /// the resolved `Locator` + SID allocation land in a follow-up.
+    /// Drained in the event loop; resolution drives per-VRF End.DT46
+    /// SID (re)allocation.
     pub srv6_locator_rx: UnboundedReceiver<crate::rib::RibSrRx>,
+    /// Resolved [`crate::rib::Locator`] for [`Self::srv6_locator_name`],
+    /// `None` until it resolves (or after withdrawal). `encapsulation
+    /// srv6` VRFs carve their per-VRF End.DT46 SID from this locator's
+    /// prefix; a prefix change re-seeds the pool and re-allocates.
+    pub srv6_locator: Option<crate::rib::Locator>,
+    /// First-fit function allocator for the per-VRF End.DT46 service
+    /// SIDs carved from [`Self::srv6_locator`]. Reset when the locator
+    /// prefix changes (every prior SID address is then invalid).
+    pub srv6_sid_pool: super::vrf::BgpSidPool,
     /// Inbound `:179` dispatch index — peer source IP to VRF name.
     /// Populated by [`super::vrf::BgpGlobalMsg::RegisterPeer`]
     /// each per-VRF task emits at spawn / materialise time, and
@@ -590,6 +599,8 @@ impl Bgp {
             vrf_label_request_pending: false,
             srv6_locator_name: None,
             srv6_locator_rx,
+            srv6_locator: None,
+            srv6_sid_pool: super::vrf::BgpSidPool::new(),
             peer_index: BTreeMap::new(),
             vrf_global_tx: vrf_global_tx_init,
             vrf_global_rx: vrf_global_rx_init,
@@ -678,10 +689,10 @@ impl Bgp {
     }
 
     /// Handle an SRv6 locator update from the RIB segment-routing
-    /// manager. v1 logs the resolution so operators can confirm the
-    /// configured `srv6 locator` bound to a real prefix; storing the
-    /// resolved [`Locator`] and allocating per-VRF End.DT46 service
-    /// SIDs lands in a follow-up.
+    /// manager. Stores the resolved [`crate::rib::Locator`] and, when
+    /// the usable *prefix* changes (resolved / withdrawn / moved),
+    /// re-seeds the SID pool and re-allocates every `encapsulation
+    /// srv6` VRF's End.DT46 service SID so it tracks the new locator.
     fn process_sr_rx(&mut self, msg: crate::rib::RibSrRx) {
         match msg {
             crate::rib::RibSrRx::Locator { name, locator } => {
@@ -689,20 +700,138 @@ impl Bgp {
                 if self.srv6_locator_name.as_deref() != Some(name.as_str()) {
                     return;
                 }
-                match locator.as_ref().and_then(|l| l.prefix) {
+                let new_prefix = locator.as_ref().and_then(|l| l.prefix);
+                let old_prefix = self.srv6_locator.as_ref().and_then(|l| l.prefix);
+                // Always store the latest (behavior may change without
+                // the prefix moving), but only reconcile SIDs on a
+                // material prefix change — the RIB re-sends the same
+                // locator on every watcher add, and a needless respawn
+                // would bounce CE sessions.
+                self.srv6_locator = locator;
+                if new_prefix == old_prefix {
+                    return;
+                }
+                match new_prefix {
                     Some(prefix) => {
                         tracing::info!(locator = %name, %prefix, "bgp: SRv6 locator resolved");
                     }
                     None => {
-                        tracing::info!(
-                            locator = %name,
-                            "bgp: SRv6 locator unresolved / withdrawn",
-                        );
+                        tracing::info!(locator = %name, "bgp: SRv6 locator withdrawn");
                     }
                 }
+                self.reconcile_srv6_vrfs();
             }
             crate::rib::RibSrRx::Block { .. } => {}
         }
+    }
+
+    /// Is `name` configured as an `encapsulation srv6` VRF?
+    fn is_srv6_vrf(&self, name: &str) -> bool {
+        self.vrfs.get(name).map(|c| c.encapsulation)
+            == Some(super::vrf_config::BgpVrfEncapsulation::Srv6)
+    }
+
+    /// Allocate a per-VRF End.DT46 service SID from the resolved
+    /// locator. `None` when the VRF isn't srv6-mode, the locator hasn't
+    /// resolved, or the function space is exhausted — the VRF then
+    /// spawns SID-less and is reconciled on the next locator update.
+    fn alloc_vrf_sid(
+        &mut self,
+        cfg: &super::vrf_config::BgpVrfConfig,
+    ) -> Option<super::vrf::Srv6VrfSid> {
+        if cfg.encapsulation != super::vrf_config::BgpVrfEncapsulation::Srv6 {
+            return None;
+        }
+        let loc_name = self.srv6_locator_name.clone()?;
+        let prefix = self.srv6_locator.as_ref().and_then(|l| l.prefix)?;
+        let function = self.srv6_sid_pool.allocate()?;
+        match crate::isis::srv6::function_addr(prefix, function) {
+            Some(addr) => Some(super::vrf::Srv6VrfSid {
+                addr,
+                function,
+                locator: loc_name,
+            }),
+            None => {
+                // Prefix too long to carry a 16-bit function — give the
+                // function back so it isn't leaked.
+                self.srv6_sid_pool.release(function);
+                None
+            }
+        }
+    }
+
+    /// Rebuild a [`super::vrf::Srv6VrfSid`] from a handle's preserved
+    /// `(addr, function)` so a relabel / kernel-ctx respawn re-installs
+    /// the *same* SID rather than churning the address.
+    fn preserved_srv6(
+        &self,
+        sid: Option<(std::net::Ipv6Addr, u16)>,
+    ) -> Option<super::vrf::Srv6VrfSid> {
+        let loc = self.srv6_locator_name.clone().unwrap_or_default();
+        sid.map(|(addr, function)| super::vrf::Srv6VrfSid {
+            addr,
+            function,
+            locator: loc.clone(),
+        })
+    }
+
+    /// Re-seed the SID pool and re-allocate every running srv6 VRF's
+    /// End.DT46 SID against the current locator. Driven by
+    /// [`Self::process_sr_rx`] on a locator prefix change.
+    fn reconcile_srv6_vrfs(&mut self) {
+        // The locator prefix moved, so every previously-issued function
+        // maps to a now-invalid address. Throw the pool away and
+        // re-allocate from the base under the new prefix.
+        self.srv6_sid_pool.reset();
+        let srv6_vrfs: Vec<String> = self
+            .vrf_registry
+            .keys()
+            .filter(|name| self.is_srv6_vrf(name))
+            .cloned()
+            .collect();
+        for name in srv6_vrfs {
+            self.resid_vrf(&name);
+        }
+    }
+
+    /// Respawn `name`'s per-VRF task with a freshly-allocated End.DT46
+    /// SID (or none, if the locator is now unresolved). Withdraws the
+    /// old SID first. Mirrors [`Self::relabel_vrf`] but swaps the
+    /// service SID rather than the MPLS label. Assumes the SID pool was
+    /// already reset by the caller, so it does not free the old
+    /// function (it no longer exists in the pool).
+    fn resid_vrf(&mut self, name: &str) {
+        let Some(cfg) = self.vrfs.get(name).cloned() else {
+            return;
+        };
+        let preserved_label = if let Some(handle) = self.vrf_registry.remove(name) {
+            super::vrf::despawn_bgp_vrf(name, &handle);
+            self.unregister_vrf_show(name);
+            self.peer_index.retain(|_, owner| owner != name);
+            // Withdraw the stale SID by its (old-prefix) address.
+            if let Some((addr, _function)) = handle.srv6_sid {
+                self.rib_subscriber.send_sid_del(addr);
+            }
+            handle.label
+        } else {
+            return;
+        };
+        let kernel = self.rib_known_vrfs.get(name).cloned();
+        let srv6 = self.alloc_vrf_sid(&cfg);
+        let new_handle = super::vrf::spawn_bgp_vrf(
+            name.to_string(),
+            &cfg,
+            self.router_id,
+            self.asn,
+            preserved_label,
+            kernel,
+            &self.rib_subscriber,
+            srv6,
+            self.vrf_global_tx.clone(),
+        );
+        self.register_vrf_show(name, &new_handle);
+        self.vrf_registry.insert(name.to_string(), new_handle);
+        tracing::info!(vrf = %name, "bgp: reconciled SRv6 service SID for VRF");
     }
 
     /// Update the BGP router-id and propagate it to every peer's
@@ -1003,6 +1132,12 @@ impl Bgp {
                     self.rib_subscriber
                         .send_label_block_release("bgp", start, end - start);
                 }
+                // Withdraw the SRv6 End.DT46 service SID and return its
+                // function to the pool (srv6-mode VRFs only).
+                if let Some((addr, function)) = handle.srv6_sid {
+                    self.rib_subscriber.send_sid_del(addr);
+                    self.srv6_sid_pool.release(function);
+                }
                 // Drop every `peer_index` entry that pointed at
                 // this VRF — defensive cleanup against the VRF
                 // task exiting before its `UnregisterPeer`
@@ -1026,6 +1161,10 @@ impl Bgp {
             // downstream, which the Export handler already treats
             // as "skip label install" — a safe degradation.
             let label = self.alloc_vrf_label();
+            // Allocate the per-VRF End.DT46 service SID for srv6-mode
+            // VRFs (None for MPLS-mode, or srv6 before the locator
+            // resolves — reconciled on the next locator update).
+            let srv6 = self.alloc_vrf_sid(&cfg);
             let handle = super::vrf::spawn_bgp_vrf(
                 name.clone(),
                 &cfg,
@@ -1034,6 +1173,7 @@ impl Bgp {
                 label,
                 kernel,
                 &self.rib_subscriber,
+                srv6,
                 self.vrf_global_tx.clone(),
             );
             self.register_vrf_show(&name, &handle);
@@ -1068,16 +1208,21 @@ impl Bgp {
         // the respawn stays addressable from any PE that already
         // cached it; the original allocation stays held on the
         // new handle.
-        let preserved_label = if let Some(handle) = self.vrf_registry.remove(name) {
+        let (preserved_label, preserved_sid) = if let Some(handle) = self.vrf_registry.remove(name)
+        {
             super::vrf::despawn_bgp_vrf(name, &handle);
             self.unregister_vrf_show(name);
             // Clear stale `peer_index` entries — the spawned task
             // is about to push fresh RegisterPeer messages.
             self.peer_index.retain(|_, owner| owner != name);
-            handle.label
+            (handle.label, handle.srv6_sid)
         } else {
-            self.alloc_vrf_label()
+            (self.alloc_vrf_label(), None)
         };
+        // Preserve the same End.DT46 SID across the respawn so a PE that
+        // already learned it stays valid; this respawn is what actually
+        // installs the decap, now that the kernel table id is known.
+        let srv6 = self.preserved_srv6(preserved_sid);
         let table_id = kernel.table_id;
         let new_handle = super::vrf::spawn_bgp_vrf(
             name.to_string(),
@@ -1087,6 +1232,7 @@ impl Bgp {
             preserved_label,
             Some(kernel),
             &self.rib_subscriber,
+            srv6,
             self.vrf_global_tx.clone(),
         );
         self.register_vrf_show(name, &new_handle);
@@ -1480,11 +1626,17 @@ impl Bgp {
             return;
         };
         let kernel = self.rib_known_vrfs.get(name).cloned();
-        if let Some(handle) = self.vrf_registry.remove(name) {
+        let preserved_sid = if let Some(handle) = self.vrf_registry.remove(name) {
             super::vrf::despawn_bgp_vrf(name, &handle);
             self.unregister_vrf_show(name);
             self.peer_index.retain(|_, owner| owner != name);
-        }
+            handle.srv6_sid
+        } else {
+            None
+        };
+        // A relabel swaps only the MPLS label; the End.DT46 SID (for an
+        // srv6-mode VRF) is preserved and re-installed unchanged.
+        let srv6 = self.preserved_srv6(preserved_sid);
         let new_handle = super::vrf::spawn_bgp_vrf(
             name.to_string(),
             &cfg,
@@ -1493,6 +1645,7 @@ impl Bgp {
             label,
             kernel,
             &self.rib_subscriber,
+            srv6,
             self.vrf_global_tx.clone(),
         );
         self.register_vrf_show(name, &new_handle);

--- a/zebra-rs/src/bgp/vrf/mod.rs
+++ b/zebra-rs/src/bgp/vrf/mod.rs
@@ -14,9 +14,11 @@
 pub mod inst;
 pub mod label;
 pub mod msg;
+pub mod sid;
 pub mod spawn;
 
 pub use label::VrfLabelAllocator;
+pub use sid::{BgpSidPool, Srv6VrfSid};
 
 // External consumers (`Bgp` field types, `process_vrf_global_msg`)
 // only reach for the names below. `inst::{BgpVrf, serve_vrf}` and

--- a/zebra-rs/src/bgp/vrf/sid.rs
+++ b/zebra-rs/src/bgp/vrf/sid.rs
@@ -14,6 +14,14 @@ use std::net::Ipv6Addr;
 pub const BGP_SID_FIRST: u16 = 0x0040;
 pub const BGP_SID_LAST: u16 = 0xDFFF;
 
+// Compile-time invariant: the BGP service-SID band must stay below the
+// IS-IS ELIB range (and above function 0, the node SID) so a shared
+// locator can never collide a BGP End.DT46 function with an IS-IS
+// End.X function. A runtime `assert!` over consts would just be
+// `clippy::assertions_on_constants`, so guard it at compile time.
+#[allow(clippy::assertions_on_constants)]
+const _: () = assert!(BGP_SID_FIRST > 0 && BGP_SID_LAST < crate::isis::srv6::ELIB_FIRST);
+
 /// First-fit allocator over the BGP service-SID function band. Stable
 /// across individual allocs / frees (a freed function is reused,
 /// keeping `show` output steady) but reset wholesale when the
@@ -110,13 +118,5 @@ mod tests {
         let _ = pool.allocate();
         pool.reset();
         assert_eq!(pool.allocate(), Some(BGP_SID_FIRST));
-    }
-
-    #[test]
-    fn band_sits_below_the_isis_elib_range() {
-        // The whole BGP band must stay under ELIB_FIRST (0xE000) so a
-        // shared locator can't collide BGP DT46 with IS-IS End.X.
-        assert!(BGP_SID_LAST < crate::isis::srv6::ELIB_FIRST);
-        assert!(BGP_SID_FIRST > 0); // never the node SID (function 0)
     }
 }

--- a/zebra-rs/src/bgp/vrf/sid.rs
+++ b/zebra-rs/src/bgp/vrf/sid.rs
@@ -1,0 +1,122 @@
+//! BGP-side SRv6 SID function pool for per-VRF End.DT46 service SIDs.
+//!
+//! Mirrors [`crate::isis::srv6::ElibPool`] but carves from a
+//! BGP-specific function band *below* the IS-IS ELIB range. If BGP and
+//! IS-IS happen to draw SIDs from the same locator, a BGP per-VRF
+//! End.DT46 function can then never collide with an IS-IS End.X
+//! adjacency function (those start at `0xE000`). Function 0 is the
+//! locator's node-SID address, so we start at `0x0040` and leave
+//! `0x0001..0x003F` for static / operator-reserved service SIDs.
+
+use std::collections::BTreeSet;
+use std::net::Ipv6Addr;
+
+pub const BGP_SID_FIRST: u16 = 0x0040;
+pub const BGP_SID_LAST: u16 = 0xDFFF;
+
+/// First-fit allocator over the BGP service-SID function band. Stable
+/// across individual allocs / frees (a freed function is reused,
+/// keeping `show` output steady) but reset wholesale when the
+/// underlying locator prefix changes — every prior SID address is then
+/// invalid.
+#[derive(Debug, Default)]
+pub struct BgpSidPool {
+    used: BTreeSet<u16>,
+}
+
+impl BgpSidPool {
+    pub fn new() -> Self {
+        Self {
+            used: BTreeSet::new(),
+        }
+    }
+
+    /// Take the lowest free function. `None` when the band is exhausted
+    /// (`0xDFFF - 0x0040` entries — far past any realistic VRF count,
+    /// but bounded so allocation never spins forever).
+    pub fn allocate(&mut self) -> Option<u16> {
+        let mut candidate = BGP_SID_FIRST;
+        for &used in self.used.iter() {
+            if used != candidate {
+                break;
+            }
+            if candidate == BGP_SID_LAST {
+                return None;
+            }
+            candidate += 1;
+        }
+        self.used.insert(candidate);
+        Some(candidate)
+    }
+
+    pub fn release(&mut self, function: u16) {
+        self.used.remove(&function);
+    }
+
+    /// Drop every allocation. Used when the locator prefix changes —
+    /// every previously-issued End.DT46 address is invalidated, so the
+    /// pool starts fresh and each VRF re-allocates under the new prefix.
+    pub fn reset(&mut self) {
+        self.used.clear();
+    }
+
+    #[cfg(test)]
+    pub fn is_used(&self, function: u16) -> bool {
+        self.used.contains(&function)
+    }
+}
+
+/// SRv6 egress-decap inputs threaded into a per-VRF spawn for an
+/// `encapsulation srv6` VRF: the allocated End.DT46 SID address, the
+/// locator function that produced it (preserved across kernel-ctx /
+/// relabel respawns, freed back to [`BgpSidPool`] at despawn), and the
+/// source locator name for the RIB SID-registry row. `None` (the whole
+/// option) means MPLS mode, or an srv6 VRF spawned before its locator
+/// resolved.
+#[derive(Debug, Clone)]
+pub struct Srv6VrfSid {
+    pub addr: Ipv6Addr,
+    pub function: u16,
+    pub locator: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocate_starts_at_first_and_is_stable() {
+        let mut pool = BgpSidPool::new();
+        assert_eq!(pool.allocate(), Some(BGP_SID_FIRST));
+        assert_eq!(pool.allocate(), Some(BGP_SID_FIRST + 1));
+        assert_eq!(pool.allocate(), Some(BGP_SID_FIRST + 2));
+    }
+
+    #[test]
+    fn release_lets_the_function_be_reused() {
+        let mut pool = BgpSidPool::new();
+        let a = pool.allocate().unwrap();
+        let b = pool.allocate().unwrap();
+        pool.release(a);
+        // Lowest-free returns the just-freed `a`, not a third value.
+        assert_eq!(pool.allocate(), Some(a));
+        assert!(pool.is_used(b));
+    }
+
+    #[test]
+    fn reset_clears_all_allocations() {
+        let mut pool = BgpSidPool::new();
+        let _ = pool.allocate();
+        let _ = pool.allocate();
+        pool.reset();
+        assert_eq!(pool.allocate(), Some(BGP_SID_FIRST));
+    }
+
+    #[test]
+    fn band_sits_below_the_isis_elib_range() {
+        // The whole BGP band must stay under ELIB_FIRST (0xE000) so a
+        // shared locator can't collide BGP DT46 with IS-IS End.X.
+        assert!(BGP_SID_LAST < crate::isis::srv6::ELIB_FIRST);
+        assert!(BGP_SID_FIRST > 0); // never the node SID (function 0)
+    }
+}

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -17,6 +17,7 @@
 //! [`crate::rib::client::ClientRegistry`].
 
 use std::collections::BTreeMap;
+use std::net::Ipv6Addr;
 
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -26,6 +27,7 @@ use super::super::inst::RibKnownVrf;
 use super::super::vrf_config::{BgpVrfConfig, BgpVrfEncapsulation};
 use super::inst::{BgpVrf, BgpVrfInbox, serve_vrf};
 use super::msg::{BgpGlobalMsg, BgpVrfMsg};
+use super::sid::Srv6VrfSid;
 
 use crate::config::RibSubscriber;
 
@@ -59,6 +61,13 @@ pub struct BgpVrfHandle {
     /// `maybe_respawn_vrf_with_kernel_ctx` after the kernel VRF
     /// appears installs the ILM.
     pub ilm_decap_ifindex: Option<u32>,
+    /// SRv6 End.DT46 service SID `(addr, locator-function)` allocated
+    /// for an `encapsulation srv6` VRF. The function is preserved
+    /// across kernel-ctx / relabel respawns and freed back to
+    /// `Bgp::srv6_sid_pool` at despawn; the addr drives the
+    /// `Message::SidDel` withdrawal. `None` for MPLS-mode VRFs and for
+    /// srv6 VRFs spawned before their locator resolved.
+    pub srv6_sid: Option<(Ipv6Addr, u16)>,
 }
 
 /// Pure diff: which VRF names need to be spawned (in `desired`
@@ -111,6 +120,7 @@ pub fn spawn_bgp_vrf(
     label: u32,
     kernel: Option<RibKnownVrf>,
     rib_subscriber: &RibSubscriber,
+    srv6: Option<Srv6VrfSid>,
     global_tx: UnboundedSender<BgpGlobalMsg>,
 ) -> BgpVrfHandle {
     // Snapshot for logging + ILM install so we can move
@@ -208,6 +218,35 @@ pub fn spawn_bgp_vrf(
         _ => None,
     };
 
+    // SRv6 egress decap: program the per-VRF End.DT46 service SID into
+    // the VRF's kernel table via a seg6local `End.DT46 vrftable`. Like
+    // the MPLS ILM this is gated on kernel info (the decap needs the
+    // VRF table id); a placeholder-ctx spawn defers to
+    // `maybe_respawn_vrf_with_kernel_ctx`, which re-runs with the
+    // preserved SID once the kernel VRF appears. The 16-byte SID is the
+    // full address (no transposition); `ifindex: 0` lets the RIB
+    // resolve a loopback oif, the same as IS-IS End / uN.
+    if let (Some(s), Some(table_id)) = (srv6.as_ref(), kernel_table_id) {
+        let sid = crate::rib::Sid {
+            addr: s.addr,
+            behavior: crate::rib::SidBehavior::EndDT46,
+            context: crate::rib::SidContext::None,
+            owner: crate::rib::SidOwner::new("bgp", 0),
+            locator: s.locator.clone(),
+            allocation_type: crate::rib::SidAllocationType::Dynamic,
+            ifindex: 0,
+            nh6: None,
+            structure: None,
+            table_id,
+        };
+        rib_subscriber.send_sid_add(sid);
+    }
+    // Keep the SID `(addr, function)` on the handle whether or not it
+    // was installed this spawn — the function must be freed at despawn
+    // and the addr withdrawn, and a placeholder spawn re-installs it on
+    // respawn.
+    let srv6_sid = srv6.as_ref().map(|s| (s.addr, s.function));
+
     // Capture the show channel before `vrf` is moved into the task, so
     // the global instance can register it with the config manager for
     // `show bgp vrf <name> …` redirection.
@@ -220,6 +259,7 @@ pub fn spawn_bgp_vrf(
         table_id = ?kernel_table_id,
         label,
         ilm_installed = ilm_decap_ifindex.is_some(),
+        srv6_sid = ?srv6_sid.map(|(addr, _)| addr),
         peers = peer_count,
         networks = network_count,
         "bgp: spawned per-VRF task",
@@ -230,6 +270,7 @@ pub fn spawn_bgp_vrf(
         task,
         label,
         ilm_decap_ifindex,
+        srv6_sid,
     }
 }
 
@@ -398,6 +439,7 @@ mod tests {
             /* label */ 16,
             None,
             &subscriber,
+            /* srv6 */ None,
             global_tx,
         )
     }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -128,6 +128,21 @@ impl RibSubscriber {
         let _ = self.rib_tx.send(crate::rib::Message::IlmDel { label, ilm });
     }
 
+    /// Install an SRv6 SID via the RIB SID registry — the per-VRF BGP
+    /// spawn site uses this to program an `encapsulation srv6` VRF's
+    /// End.DT46 seg6local decap into the VRF table. Like
+    /// [`Self::send_ilm_add`], a SID install is a global RIB mutation,
+    /// so it rides the legacy `rib_tx` channel.
+    pub fn send_sid_add(&self, sid: crate::rib::Sid) {
+        let _ = self.rib_tx.send(crate::rib::Message::SidAdd { sid });
+    }
+
+    /// Withdraw a previously-installed SID by its address — the inverse
+    /// of [`Self::send_sid_add`], used at despawn / locator-change.
+    pub fn send_sid_del(&self, addr: std::net::Ipv6Addr) {
+        let _ = self.rib_tx.send(crate::rib::Message::SidDel { addr });
+    }
+
     /// Request a dynamic MPLS label block of `size` labels for `proto`
     /// from the RIB label manager. The RIB replies asynchronously with
     /// a `RibRx::LabelBlock` on `proto`'s subscriber channel.


### PR DESCRIPTION
## Summary

Phase 3b of BGP L3VPN over an SRv6 underlay (RFC 9252) — allocate and
program the per-VRF SRv6 service SID, completing the **egress (decap)**
side. An `encapsulation srv6` VRF now binds one **End.DT46** SID carved
from the global `srv6 locator` and the PE programs a seg6local
`End.DT46 vrftable <id>` decap into the VRF table.

- **`bgp/vrf/sid.rs`**: `BgpSidPool` — a first-fit function allocator
  (mirrors `isis::srv6::ElibPool`) carving from a BGP band
  `0x0040..0xDFFF`, **below** the IS-IS ELIB range (`0xE000`) so a
  shared locator can't collide a BGP End.DT46 function with an IS-IS
  End.X function. Plus `Srv6VrfSid`, the spawn-input bundle.
- **`RibSubscriber::send_sid_add/del`** (mirror `send_ilm_add`).
- **`Bgp`** now stores the resolved `Locator` — `process_sr_rx` keeps it
  and reconciles on a prefix change — and a `BgpSidPool`.
  `alloc_vrf_sid` carves an End.DT46 address via
  `isis::srv6::function_addr`.
- **`spawn_bgp_vrf`** installs the End.DT46 SID into the VRF's kernel
  table (`Sid { behavior: EndDT46, table_id, .. }` → `send_sid_add`),
  **gated on kernel info exactly like the MPLS ILM** — so it's
  (re)installed by `maybe_respawn_vrf_with_kernel_ctx` once the VRF
  table id is known. The `(addr, function)` rides on `BgpVrfHandle`.
- **Lifecycle**: despawn withdraws the SID + frees the function;
  relabel / kernel-ctx respawns preserve the same SID; a locator prefix
  change re-seeds the pool and re-allocates every srv6 VRF
  (`reconcile_srv6_vrfs` / `resid_vrf`, mirroring `relabel_vrf`).

### Known gap (follow-up)

Deleting the global `srv6 locator` config while srv6 VRFs are live does
not get a RIB locator withdrawal, so their SIDs persist until
reconfigured. The advertise (Prefix-SID attr + IPv6 next-hop) and the
ingress H.Encap install are Phases 4-5.

## Test plan

- `cargo test -p zebra-rs --bin zebra-rs bgp::vrf::sid` — `BgpSidPool`
  allocate-from-base / reuse-after-release / reset, and the
  band-below-ELIB + non-zero-base invariant.
- `cargo test -p zebra-rs --bin zebra-rs bgp:: rib:: isis::` — 207 / 150
  / 132 pass.
- `cargo build -p zebra-rs`, `cargo clippy --workspace --all-targets -- -D warnings` — clean.

Runtime validation (egress): a `router bgp vrf X encapsulation srv6`
with a resolved global `srv6 locator` programs a
`seg6local action End.DT46 vrftable <table>` entry reachable at the
SID address; despawn / locator-change reconciles it.

Generated with [Claude Code](https://claude.com/claude-code)