### PR TITLE
bgp: rename per-VRF afi-safi ipv4-unicast/ipv6-unicast → ipv4/ipv6

### DIFF
--- a/bdd/tests/configs/bgp_vrf_vpnv4_export/z1-1.yaml
+++ b/bdd/tests/configs/bgp_vrf_vpnv4_export/z1-1.yaml
@@ -22,6 +22,6 @@ router:
     - name: vrf-blue
       rd: 65001:100
       afi-safi:
-        ipv4-unicast:
+        ipv4:
           network:
           - prefix: 10.1.0.0/24

--- a/bdd/tests/features/bgp_vrf_vpnv4_export.feature
+++ b/bdd/tests/features/bgp_vrf_vpnv4_export.feature
@@ -3,7 +3,7 @@
 Feature: BGP per-VRF VPNv4 export to a remote PE
   As a network operator
   I want to advertise a network configured under `router bgp vrf X
-  afi-safi ipv4-unicast` as a VPNv4 NLRI toward a remote PE
+  afi-safi ipv4` as a VPNv4 NLRI toward a remote PE
   Using a two-namespace topology where z1 originates the prefix
   inside vrf-blue and z2 peers with z1 over VPNv4 only.
 

--- a/book/src/ch-02-04-bgp-l3vpn.md
+++ b/book/src/ch-02-04-bgp-l3vpn.md
@@ -41,7 +41,7 @@ router bgp {
     neighbor 10.100.0.2 {
       remote-as 65001;
     }
-    afi-safi ipv4-unicast {
+    afi-safi ipv4 {
       network 192.168.5.0/24;
     }
   }
@@ -56,7 +56,7 @@ router bgp {
 | `router bgp vrf <name> rd <RD>` | Route Distinguisher for this VRF's VPN NLRI |
 | `router bgp vrf <name> label-mode per-vrf` | One MPLS label per VRF (the default) |
 | `router bgp vrf <name> neighbor <addr> remote-as <asn>` | A CE peer in the VRF |
-| `router bgp vrf <name> afi-safi ipv4-unicast network <prefix>` | Originate a local route into the VRF |
+| `router bgp vrf <name> afi-safi ipv4 network <prefix>` | Originate a local route into the VRF |
 
 `label-mode` defaults to `per-vrf`: a single label is bound to the
 whole VRF, and the egress lookup that follows the label pop happens in

--- a/book/src/ch-02-05-bgp-l3vpn-srv6.md
+++ b/book/src/ch-02-05-bgp-l3vpn-srv6.md
@@ -55,7 +55,7 @@ router bgp {
     neighbor 10.100.0.2 {
       remote-as 65001;
     }
-    afi-safi ipv4-unicast {
+    afi-safi ipv4 {
       network 192.168.5.0/24;
     }
   }

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1603,19 +1603,19 @@ impl Bgp {
             super::vrf_config::config_vrf_neighbor_enabled,
         );
         self.callback_add(
-            "/router/bgp/vrf/afi-safi/ipv4-unicast",
-            super::vrf_config::config_vrf_afi_ipv4_unicast,
+            "/router/bgp/vrf/afi-safi/ipv4",
+            super::vrf_config::config_vrf_afi_ipv4,
         );
         self.callback_add(
-            "/router/bgp/vrf/afi-safi/ipv4-unicast/network",
+            "/router/bgp/vrf/afi-safi/ipv4/network",
             super::vrf_config::config_vrf_afi_ipv4_network,
         );
         self.callback_add(
-            "/router/bgp/vrf/afi-safi/ipv6-unicast",
-            super::vrf_config::config_vrf_afi_ipv6_unicast,
+            "/router/bgp/vrf/afi-safi/ipv6",
+            super::vrf_config::config_vrf_afi_ipv6,
         );
         self.callback_add(
-            "/router/bgp/vrf/afi-safi/ipv6-unicast/network",
+            "/router/bgp/vrf/afi-safi/ipv6/network",
             super::vrf_config::config_vrf_afi_ipv6_network,
         );
 

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -286,8 +286,8 @@ pub fn config_vrf_neighbor_enabled(bgp: &mut Bgp, mut args: Args, op: ConfigOp) 
     Some(())
 }
 
-/// `set router bgp vrf <NAME> afi-safi ipv4-unicast` — presence container.
-pub fn config_vrf_afi_ipv4_unicast(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+/// `set router bgp vrf <NAME> afi-safi ipv4` — presence container.
+pub fn config_vrf_afi_ipv4(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let cfg = vrf_entry(bgp, name);
     match op {
@@ -300,7 +300,7 @@ pub fn config_vrf_afi_ipv4_unicast(bgp: &mut Bgp, mut args: Args, op: ConfigOp) 
     Some(())
 }
 
-/// `set router bgp vrf <NAME> afi-safi ipv4-unicast network <PREFIX>`.
+/// `set router bgp vrf <NAME> afi-safi ipv4 network <PREFIX>`.
 pub fn config_vrf_afi_ipv4_network(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let cfg = vrf_entry(bgp, name);
@@ -318,8 +318,8 @@ pub fn config_vrf_afi_ipv4_network(bgp: &mut Bgp, mut args: Args, op: ConfigOp) 
     Some(())
 }
 
-/// `set router bgp vrf <NAME> afi-safi ipv6-unicast` — presence container.
-pub fn config_vrf_afi_ipv6_unicast(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+/// `set router bgp vrf <NAME> afi-safi ipv6` — presence container.
+pub fn config_vrf_afi_ipv6(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let cfg = vrf_entry(bgp, name);
     match op {
@@ -332,7 +332,7 @@ pub fn config_vrf_afi_ipv6_unicast(bgp: &mut Bgp, mut args: Args, op: ConfigOp) 
     Some(())
 }
 
-/// `set router bgp vrf <NAME> afi-safi ipv6-unicast network <PREFIX>`.
+/// `set router bgp vrf <NAME> afi-safi ipv6 network <PREFIX>`.
 pub fn config_vrf_afi_ipv6_network(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     let cfg = vrf_entry(bgp, name);

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -46,10 +46,10 @@ module zebra-bgp-vrf {
              description \"CE1\";
            }
            afi-safi {
-             ipv4-unicast {
+             ipv4 {
                network 10.10.0.0/16;
              }
-             ipv6-unicast { /* same shape */ }
+             ipv6 { /* same shape */ }
            }
          }
        }
@@ -176,19 +176,18 @@ module zebra-bgp-vrf {
 
   grouping bgp-vrf-afi-safi {
     description
-      "Per-VRF address-family configuration. Only IPv4-unicast and
-       IPv6-unicast SAFIs are exposed here — VPNv4 / VPNv6 / EVPN
+      "Per-VRF address-family configuration. Only the IPv4 and IPv6
+       unicast families are exposed here — VPNv4 / VPNv6 / EVPN
        advertisements remain anchored on the top-level `router bgp`
-       block and are driven by the cross-VRF import/export pipeline
-       in step 17 / 18.
+       block and are driven by the cross-VRF import/export pipeline.
 
-       Modeled as a container of two presence containers (one per
-       SAFI) rather than a list keyed by SAFI name: the surface is
-       fixed and small, and the container shape makes path-based
-       config more ergonomic (`set ... afi-safi ipv4-unicast ...`).";
+       The family names match the IS-IS afi-safi convention (`ipv4`,
+       `ipv6`) so a VRF reads the same as `router isis`; modeled as a
+       container of two presence containers (one per family) for
+       path-based config ergonomics (`set ... afi-safi ipv4 ...`).";
     container afi-safi {
-      container ipv4-unicast {
-        presence "Enables IPv4-unicast for this VRF";
+      container ipv4 {
+        presence "Enables the IPv4 unicast family for this VRF";
         list network {
           key "prefix";
           description
@@ -201,8 +200,8 @@ module zebra-bgp-vrf {
           }
         }
       }
-      container ipv6-unicast {
-        presence "Enables IPv6-unicast for this VRF";
+      container ipv6 {
+        presence "Enables the IPv6 unicast family for this VRF";
         list network {
           key "prefix";
           leaf prefix {


### PR DESCRIPTION
## Summary

First step of migrating BGP off the borrowed (OpenConfig / IANA)
afi-safi schemas toward a zebra-owned definition: align the **per-VRF**
BGP afi-safi family names with the IS-IS convention.

`set router bgp vrf X afi-safi ipv4-unicast …` → `… afi-safi ipv4 …`
(likewise `ipv6-unicast` → `ipv6`).

- `zebra-bgp-vrf.yang`: rename the `ipv4-unicast` / `ipv6-unicast`
  presence containers to `ipv4` / `ipv6`.
- `bgp/config.rs` + `bgp/vrf_config.rs`: update the callback paths and
  handler names/docs (internal `BgpVrfConfig` field names unchanged).
- Updated the one bdd fixture/feature that used the per-VRF form
  (`bgp_vrf_vpnv4_export`) and both BGP L3VPN book chapters.

This is the **only config-breaking** part of the wider migration: the
global / neighbor afi-safi list is keyed by `ipv4`/`ipv6`/`vpnv4`/
`vpnv6`/`evpn` — already the names the zebra-owned set will use — so the
remaining steps (define `afi-safi` / `afi-safi-unicast` groupings,
re-point BGP global+neighbor and IS-IS at them, delete the IANA +
OpenConfig afi-safi identities) are name-preserving and land separately.

## Test plan

- `cargo test -p zebra-rs --bin zebra-rs bgp::` — 210 pass.
- `cargo build -p zebra-rs`, `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `make book` — clean.
- Note: the YANG path change is exercised at daemon config-load /
  bdd, which CI doesn't run; the callback paths were matched against
  the renamed YANG by inspection.

Generated with [Claude Code](https://claude.com/claude-code)