### PR TITLE
yang: zebra-owned afi-safi for the BGP/IS-IS config tree

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1178,3 +1178,36 @@ pub fn config_format_type(config_str: &str) -> ConfigFormat {
         ConfigFormat::Yaml
     }
 }
+
+#[cfg(test)]
+mod yang_load_tests {
+    use libyang::YangStore;
+
+    /// Load the two root YANG modes (`exec`, `configure`) from the
+    /// shipped `yang/` tree exactly as `ConfigManager::init` does, so a
+    /// broken schema — an unresolved import, a bad `uses` / `when`, a
+    /// dangling identity — fails here instead of at daemon startup
+    /// (which CI's unit suite never reaches). This is the regression
+    /// guard for hand-edited YANG (afi-safi groupings, augments, ...).
+    fn load_mode(mode: &str) {
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve(mode)
+            .unwrap_or_else(|e| panic!("yang `{mode}` failed to load: {e:#}"));
+        yang.identity_resolve();
+        assert!(
+            yang.find_module(mode).is_some(),
+            "yang `{mode}` module missing after load",
+        );
+    }
+
+    #[test]
+    fn configure_mode_loads() {
+        load_mode("configure");
+    }
+
+    #[test]
+    fn exec_mode_loads() {
+        load_mode("exec");
+    }
+}

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -71,6 +71,9 @@ module config {
   import openconfig-isis-types {
     prefix isis;
   }
+  import zebra-afi-safi {
+    prefix zas;
+  }
 
   import config-static {
     prefix static;
@@ -982,12 +985,7 @@ module config {
           // 237 depending on MT). Prefix family must match the
           // afi-safi name; the callback rejects mismatches.
           key "name";
-          leaf name {
-            type enumeration {
-              enum ipv4;
-              enum ipv6;
-            }
-          }
+          uses zas:afi-safi-unicast;
           list network {
             key "prefix";
             leaf prefix {

--- a/zebra-rs/yang/ietf-bgp-common-multiprotocol@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-common-multiprotocol@2023-07-05.yang
@@ -4,8 +4,8 @@ submodule ietf-bgp-common-multiprotocol {
     prefix bgp;
   }
 
-  import iana-bgp-types {
-    prefix bt;
+  import zebra-afi-safi {
+    prefix zas;
   }
   import ietf-routing-types {
     prefix rt-types;
@@ -138,13 +138,7 @@ submodule ietf-bgp-common-multiprotocol {
   grouping mp-afi-safi-config {
     description
       "Configuration parameters used for all BGP AFI-SAFIs";
-    leaf name {
-      type identityref {
-        base bt:afi-safi-type;
-      }
-      description
-        "AFI,SAFI";
-    }
+    uses zas:afi-safi;
     leaf enabled {
       ext:sort "50";
       mandatory true;
@@ -163,7 +157,7 @@ submodule ietf-bgp-common-multiprotocol {
     // import and export policy included for the afi/safi
     uses rt-pol:apply-policy-group;
     container ipv4 {
-      when "../name = 'bt:ipv4'" {
+      when "../name = 'ipv4'" {
         description
           "Include this container for IPv4 Unicast specific
            configuration";
@@ -175,7 +169,7 @@ submodule ietf-bgp-common-multiprotocol {
       // placeholder for IPv4 unicast specific configuration
     }
     container ipv6 {
-      when "../name = 'bt:ipv6'" {
+      when "../name = 'ipv6'" {
         description
           "Include this container for IPv6 Unicast specific
            configuration";
@@ -188,7 +182,7 @@ submodule ietf-bgp-common-multiprotocol {
       // options
     }
     container vpnv4 {
-      when "../name = 'bt:vpnv4'" {
+      when "../name = 'vpnv4'" {
         description
           "Include this container for IPv4 Unicast L3VPN specific
            configuration";
@@ -200,7 +194,7 @@ submodule ietf-bgp-common-multiprotocol {
       // placeholder for IPv4 Unicast L3VPN specific config options.
     }
     container vpnv6 {
-      when "../name = 'bt:vpnv6'" {
+      when "../name = 'vpnv6'" {
         description
           "Include this container for unicast IPv6 L3VPN specific
            configuration";
@@ -213,7 +207,7 @@ submodule ietf-bgp-common-multiprotocol {
       // options
     }
     container evpn {
-      when "../name = 'bt:evpn'" {
+      when "../name = 'evpn'" {
         description
           "Include this container for BGP EVPN specific
            configuration";

--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -28,6 +28,9 @@ module ietf-bgp {
     reference
       "RFC XXXX: YANG Model for Border Gateway Protocol (BGP-4).";
   }
+  import zebra-afi-safi {
+    prefix zas;
+  }
   import ietf-inet-types {
     prefix inet;
     reference
@@ -273,13 +276,7 @@ module ietf-bgp {
         description
           "AFI,SAFI configuration available for the
                neighbor or group.";
-        leaf name {
-          type identityref {
-            base bt:afi-safi-type;
-          }
-          description
-            "AFI,SAFI";
-        }
+        uses zas:afi-safi;
 
         list network {
           key "prefix";

--- a/zebra-rs/yang/openconfig-isis-types.yang
+++ b/zebra-rs/yang/openconfig-isis-types.yang
@@ -120,68 +120,12 @@ module openconfig-isis-types {
       "Base identify type for multi-topology";
   }
 
-  identity SAFI_TYPE {
-    description
-      "Base identify type for SAFI";
-  }
-
-  identity AFI_TYPE {
-    description
-      "Base identify type for AFI";
-  }
-
-  identity AFI_SAFI_TYPE {
-    description
-      "Base identify type for AFI/SAFI";
-  }
-
-  identity IPV4_UNICAST {
-    base AFI_SAFI_TYPE;
-    description
-      "Base identify type for IPv4 Unicast address family";
-  }
-
-  identity IPV6_MULTICAST {
-    base AFI_SAFI_TYPE;
-    description
-      "Base identify type for IPv6 multicast address family";
-  }
-
-  identity IPV4_MULTICAST {
-    base AFI_SAFI_TYPE;
-    description
-      "Base identify type for IPv4 multicast address family";
-  }
-
-  identity IPV6_UNICAST {
-    base AFI_SAFI_TYPE;
-    description
-      "Base identify type for IPv6 unicast address family";
-  }
-
-  identity UNICAST {
-    base SAFI_TYPE;
-    description
-      "Base identify type for IPv4 Unicast address family";
-  }
-
-  identity MULTICAST {
-    base SAFI_TYPE;
-    description
-      "Base identify type for IPv6 multicast address family";
-  }
-
-  identity IPV4 {
-    base AFI_TYPE;
-    description
-      "Base identify type for IPv4 address family";
-  }
-
-  identity IPV6 {
-    base AFI_TYPE;
-    description
-      "Base identify type for IPv6 address family";
-  }
+  // The OpenConfig AFI_SAFI_TYPE / AFI_TYPE / SAFI_TYPE identities and
+  // their derivations (IPV4_UNICAST, IPV6_UNICAST, ...) were removed:
+  // zebra-rs defines its own afi-safi families in zebra-afi-safi.yang,
+  // and these identities were unused outside this module. The IS-IS
+  // NET (`net`), multi-topology (`MT_TYPE`) and auth (`AUTH_MODE`)
+  // types in this module are still in use and stay.
 
   identity AUTH_MODE {
     description

--- a/zebra-rs/yang/zebra-afi-safi.yang
+++ b/zebra-rs/yang/zebra-afi-safi.yang
@@ -1,0 +1,77 @@
+module zebra-afi-safi {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-afi-safi";
+  prefix "zas";
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "zebra-rs's own address-family / sub-address-family definition,
+     replacing the borrowed OpenConfig (AFI_SAFI_TYPE) and IANA
+     (iana-bgp-types:afi-safi-type) afi-safi identities for the
+     operator-facing config tree.
+
+     Two flavors are provided as groupings supplying the `name` key of
+     an `afi-safi` list:
+
+       * `afi-safi`         — the full BGP set (ipv4, ipv6, vpnv4,
+                              vpnv6, evpn). Used by `router bgp`
+                              (global + per-neighbor afi-safi).
+       * `afi-safi-unicast` — the unicast subset (ipv4, ipv6). Used by
+                              `router isis` and the per-VRF BGP afi-safi
+                              (which carries the same family names).
+
+     The family names match the strings the Rust config layer parses
+     (`Args::afi_safi`), so re-pointing a list's `name` leaf at one of
+     these groupings is name-preserving and needs no runtime change.";
+
+  grouping afi-safi {
+    description
+      "The `name` key for a BGP `afi-safi` list — the full set of
+       families zebra-rs's BGP supports.";
+    leaf name {
+      type enumeration {
+        enum ipv4 {
+          description "IPv4 unicast (AFI 1, SAFI 1).";
+        }
+        enum ipv6 {
+          description "IPv6 unicast (AFI 2, SAFI 1).";
+        }
+        enum vpnv4 {
+          description "MPLS-labeled VPN-IPv4 (AFI 1, SAFI 128).";
+        }
+        enum vpnv6 {
+          description "MPLS-labeled VPN-IPv6 (AFI 2, SAFI 128).";
+        }
+        enum evpn {
+          description "BGP EVPN (AFI 25, SAFI 70).";
+        }
+      }
+      description
+        "Address family / sub-address family this list entry configures.";
+    }
+  }
+
+  grouping afi-safi-unicast {
+    description
+      "The `name` key for a unicast-only `afi-safi` list — used by
+       IS-IS and the per-VRF BGP afi-safi.";
+    leaf name {
+      type enumeration {
+        enum ipv4 {
+          description "IPv4 unicast.";
+        }
+        enum ipv6 {
+          description "IPv6 unicast.";
+        }
+      }
+      description
+        "Address family this list entry configures.";
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Second step of the afi-safi migration (follows #1033): replace the
borrowed **OpenConfig** and **IANA** afi-safi definitions with a
zebra-owned one for the operator-facing config tree. Per the agreed
**Option 2** scope, the IANA `afi-safi-type` identities are left in
place for the non-config IETF state / policy / capability models
(`ietf-bgp-rib` / `-policy` / `-capabilities`); only the operator
config lists move to our definition.

- **New `zebra-afi-safi.yang`** — `grouping afi-safi`
  (`ipv4`/`ipv6`/`vpnv4`/`vpnv6`/`evpn`) for `router bgp`, and
  `grouping afi-safi-unicast` (`ipv4`/`ipv6`) for IS-IS and the per-VRF
  BGP families. Each supplies the `name` key of an `afi-safi` list. The
  names match the strings `Args::afi_safi` already parses, so this is
  **name-preserving — zero Rust change**.
- **Rewire the config lists**: BGP global + per-neighbor afi-safi
  (`ietf-bgp` + `ietf-bgp-common-multiprotocol`) → `uses zas:afi-safi`;
  IS-IS afi-safi (`config.yang`) → `uses zas:afi-safi-unicast`. The
  per-AF `when` guards move from the `'bt:ipv4'` identity form to the
  bare `'ipv4'` enum value, and the now-dead `iana-bgp-types` import is
  dropped from common-multiprotocol.
- **Remove the OpenConfig** `AFI_SAFI_TYPE` / `AFI_TYPE` / `SAFI_TYPE`
  identities (they were unused outside their own module).
  `openconfig-isis-types` stays — IS-IS still needs its `net` / MT /
  auth types.
- **New YANG-load smoke test** (`config::manager::yang_load_tests`):
  loads the `exec` / `configure` roots from the shipped `yang/` tree,
  so a broken schema (unresolved import, bad `uses` / `when`, dangling
  identity) fails in the unit suite instead of at daemon startup — the
  validation gap this migration exposed. It passes with these changes.

### Not in scope / follow-ups
- The IANA `afi-safi-type` identities remain (Option 2) for the
  non-config IETF models.
- The per-VRF BGP afi-safi keeps the renamed `ipv4`/`ipv6` **presence
  containers** (#1033) — same family names as `afi-safi-unicast`, but
  not literally `uses`-ing the grouping (that needs a container→list
  restructure + callback changes). Can follow up if you want true
  structural sharing.

## Test plan

- `cargo test -p zebra-rs --bin zebra-rs config::manager::yang_load_tests` — the
  `configure` + `exec` schema both load cleanly.
- `cargo test -p zebra-rs --bin zebra-rs bgp:: isis:: config::` — 210 / 132 / 119 pass.
- `cargo build -p zebra-rs`, `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- Names are preserved end-to-end; a config-load / bdd run is still the
  final word on operator configs (CI doesn't run bdd), but the new
  smoke test now covers schema validity.

Generated with [Claude Code](https://claude.com/claude-code)