### PR TITLE
bgp: per-VRF `evpn` config block (Type-5 advertise toggles)

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1618,6 +1618,14 @@ impl Bgp {
             "/router/bgp/vrf/afi-safi/ipv6/network",
             super::vrf_config::config_vrf_afi_ipv6_network,
         );
+        self.callback_add(
+            "/router/bgp/vrf/evpn/advertise-ipv4",
+            super::vrf_config::config_vrf_evpn_advertise_ipv4,
+        );
+        self.callback_add(
+            "/router/bgp/vrf/evpn/advertise-ipv6",
+            super::vrf_config::config_vrf_evpn_advertise_ipv6,
+        );
 
         // `set router bgp interface-neighbor <name> [...]`.
         self.callback_add(

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -131,6 +131,11 @@ pub struct BgpVrfConfig {
     pub neighbors: BTreeMap<IpAddr, BgpVrfNeighborConfig>,
     pub ipv4_unicast: Option<BgpVrfAfConfig<Ipv4Net>>,
     pub ipv6_unicast: Option<BgpVrfAfConfig<Ipv6Net>>,
+    /// Advertise this VRF's IPv4 routes as EVPN Type-5 (RFC 9136).
+    /// Mirrors `evpn advertise-ipv4` in zebra-bgp-vrf.yang.
+    pub evpn_advertise_v4: bool,
+    /// Advertise this VRF's IPv6 routes as EVPN Type-5 (RFC 9136).
+    pub evpn_advertise_v6: bool,
 }
 
 /// Borrow-or-create the per-VRF entry on `Bgp::vrfs`. Used by every
@@ -350,6 +355,30 @@ pub fn config_vrf_afi_ipv6_network(bgp: &mut Bgp, mut args: Args, op: ConfigOp) 
     Some(())
 }
 
+/// `set router bgp vrf <NAME> evpn advertise-ipv4 <bool>`.
+pub fn config_vrf_evpn_advertise_ipv4(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let cfg = vrf_entry(bgp, name);
+    match op {
+        ConfigOp::Set => cfg.evpn_advertise_v4 = args.boolean()?,
+        ConfigOp::Delete => cfg.evpn_advertise_v4 = false,
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp vrf <NAME> evpn advertise-ipv6 <bool>`.
+pub fn config_vrf_evpn_advertise_ipv6(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let cfg = vrf_entry(bgp, name);
+    match op {
+        ConfigOp::Set => cfg.evpn_advertise_v6 = args.boolean()?,
+        ConfigOp::Delete => cfg.evpn_advertise_v6 = false,
+        _ => {}
+    }
+    Some(())
+}
+
 /// Commit-time observation hook. Emits a single `debug!` line per
 /// VRF entry so operators can see the staged intent at the boundary
 /// where spawn / despawn logic consumes `Bgp::vrfs`.
@@ -366,6 +395,8 @@ pub fn log_commit_diff(bgp: &Bgp) {
             neighbors = cfg.neighbors.len(),
             ipv4_unicast = cfg.ipv4_unicast.is_some(),
             ipv6_unicast = cfg.ipv6_unicast.is_some(),
+            evpn_advertise_v4 = cfg.evpn_advertise_v4,
+            evpn_advertise_v6 = cfg.evpn_advertise_v6,
             "bgp: per-VRF intent staged",
         );
     }

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -292,6 +292,33 @@ module zebra-bgp-vrf {
           "VPN data-plane encapsulation for routes originated from /
            imported into this VRF.";
       }
+      container evpn {
+        description
+          "EVPN (RFC 9136 Type-5 / IP Prefix) service for this VRF.
+           When advertise-ipv4 / advertise-ipv6 is enabled, the VRF's
+           IPv4 / IPv6 unicast routes are additionally advertised as
+           EVPN Type-5 (IP Prefix) routes carrying the per-VRF RD,
+           export route-targets and encapsulation (MPLS service label
+           or SRv6 End.DT46 SID) — the same per-VRF state already used
+           for VPNv4 / VPNv6. A peer receives Type-5 only if it
+           negotiated the L2VPN/EVPN AFI/SAFI, so this composes with
+           VPNv4/VPNv6 rather than replacing it. Named to match the
+           `evpn` family in zebra-afi-safi.yang.";
+        leaf advertise-ipv4 {
+          type boolean;
+          default false;
+          description
+            "Advertise this VRF's IPv4 unicast routes as EVPN Type-5
+             (IP Prefix) routes. Requires `rd` to be set.";
+        }
+        leaf advertise-ipv6 {
+          type boolean;
+          default false;
+          description
+            "Advertise this VRF's IPv6 unicast routes as EVPN Type-5
+             (IP Prefix) routes. Requires `rd` to be set.";
+        }
+      }
       uses bgp-vrf-neighbor;
       uses bgp-vrf-afi-safi;
     }


### PR DESCRIPTION
## Summary

Phase 2 of EVPN Type-5 (RFC 9136) support — the **per-VRF config block**.

Adds a per-VRF `evpn` container to `zebra-bgp-vrf.yang` with two boolean leaves:

```
router bgp { vrf red {
  rd 65000:100;
  encapsulation mpls;
  afi-safi { ipv4 { network 10.0.0.0/24; } }
  evpn {
    advertise-ipv4 true;   # advertise VRF IPv4 routes as EVPN Type-5
    advertise-ipv6 true;
  }
}}
```

- Named `evpn` to match the afi-safi family in `zebra-afi-safi.yang`.
- Reuses the VRF's existing `rd` / route-targets / `encapsulation` — Type-5 is an additional encoding of the same per-VRF state, peer-gated by AFI/SAFI negotiation (composes with VPNv4/VPNv6, doesn't replace it).
- `BgpVrfConfig` gains `evpn_advertise_v4` / `evpn_advertise_v6`, populated by `config_vrf_evpn_advertise_ipv4` / `_ipv6` and surfaced in the per-VRF commit-diff debug line.

Config plumbing only — no advertise behavior yet (wired in Phase 3).

## Test plan
- `cargo test -p zebra-rs yang_load` — `configure` + `exec` schema load with the new container ✅
- `cargo build -p zebra-rs` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)