### PR TITLE
bgp: advertise VRF routes as EVPN Type-5 (RFC 9136)

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -2148,6 +2148,11 @@ impl Bgp {
                     .get(&vrf)
                     .map(|k| k.export_rts_v4.clone())
                     .unwrap_or_default();
+                let advertise_type5 = self
+                    .vrfs
+                    .get(&vrf)
+                    .map(|c| c.evpn_advertise_v4)
+                    .unwrap_or(false);
 
                 // SRv6 L3VPN: for an `encapsulation srv6` VRF, attach
                 // the SRv6 L3 Service TLV (End.DT46 SID) and advertise
@@ -2164,6 +2169,10 @@ impl Bgp {
                 // the global instance interns it.
                 let tagged = tag_attr_with_export_rts(attr, &export_rts);
                 let interned = self.attr_store.intern(tagged);
+                // Capture the export-RT-tagged attribute (incl. any SRv6
+                // Prefix-SID) for a parallel EVPN Type-5 origination,
+                // before `interned` is moved into the VPNv4 BgpRib below.
+                let evpn_attr = advertise_type5.then(|| (*interned).clone());
 
                 // VPNv4 NLRI carries a single MPLS label per route.
                 // VRF tasks without an allocator pass `0`, which we
@@ -2280,6 +2289,20 @@ impl Bgp {
                     winners = selected_len,
                     "bgp: export written to LocalRib.v4vpn and advertised to PE peers",
                 );
+
+                // EVPN Type-5: additionally advertise this VRF prefix as
+                // an IP Prefix route reusing the same RD, export RTs,
+                // service label and (SRv6) Prefix-SID. Peer-gated by the
+                // L2VPN/EVPN AFI/SAFI, so it composes with the VPNv4 above.
+                if let Some(attr) = evpn_attr {
+                    self.evpn_originate_type5(
+                        rd,
+                        ipnet::IpNet::V4(prefix),
+                        attr,
+                        label,
+                        srv6_nexthop,
+                    );
+                }
             }
             super::vrf::BgpGlobalMsg::WithdrawExport { vrf, prefix } => {
                 let Some(rd) = self.vrfs.get(&vrf).and_then(|cfg| cfg.rd) else {
@@ -2368,6 +2391,16 @@ impl Bgp {
                     winners = selected.len(),
                     "bgp: export withdrawn from LocalRib.v4vpn and PE peers",
                 );
+
+                // Mirror the EVPN Type-5 withdrawal.
+                let advertise_type5 = self
+                    .vrfs
+                    .get(&vrf)
+                    .map(|c| c.evpn_advertise_v4)
+                    .unwrap_or(false);
+                if advertise_type5 {
+                    self.evpn_withdraw_type5(rd, ipnet::IpNet::V4(prefix));
+                }
             }
             super::vrf::BgpGlobalMsg::ExportV6 {
                 vrf,
@@ -2388,6 +2421,11 @@ impl Bgp {
                     .get(&vrf)
                     .map(|k| k.export_rts_v6.clone())
                     .unwrap_or_default();
+                let advertise_type5 = self
+                    .vrfs
+                    .get(&vrf)
+                    .map(|c| c.evpn_advertise_v6)
+                    .unwrap_or(false);
 
                 // SRv6 L3VPN (VPNv6 over an SRv6 underlay): attach the
                 // End.DT46 SID + advertise the locator next-hop; the
@@ -2397,6 +2435,7 @@ impl Bgp {
 
                 let tagged = tag_attr_with_export_rts(attr, &export_rts);
                 let interned = self.attr_store.intern(tagged);
+                let evpn_attr = advertise_type5.then(|| (*interned).clone());
 
                 let label_obj = if label != 0 && srv6_nexthop.is_none() {
                     Some(bgp_packet::Label {
@@ -2494,6 +2533,17 @@ impl Bgp {
                     winners,
                     "bgp: v6 export written to LocalRib.v6vpn and advertised to PE peers",
                 );
+
+                // EVPN Type-5 (IPv6 prefix) — composes with VPNv6 above.
+                if let Some(attr) = evpn_attr {
+                    self.evpn_originate_type5(
+                        rd,
+                        ipnet::IpNet::V6(prefix),
+                        attr,
+                        label,
+                        srv6_nexthop,
+                    );
+                }
             }
             super::vrf::BgpGlobalMsg::WithdrawExportV6 { vrf, prefix } => {
                 let Some(rd) = self.vrfs.get(&vrf).and_then(|cfg| cfg.rd) else {
@@ -2563,6 +2613,16 @@ impl Bgp {
                     winners = selected.len(),
                     "bgp: v6 export withdrawn from LocalRib.v6vpn and PE peers",
                 );
+
+                // Mirror the EVPN Type-5 (IPv6) withdrawal.
+                let advertise_type5 = self
+                    .vrfs
+                    .get(&vrf)
+                    .map(|c| c.evpn_advertise_v6)
+                    .unwrap_or(false);
+                if advertise_type5 {
+                    self.evpn_withdraw_type5(rd, ipnet::IpNet::V6(prefix));
+                }
             }
             super::vrf::BgpGlobalMsg::RegisterPeer { vrf, addr } => {
                 peer_index_register(&mut self.peer_index, vrf, addr);

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use bgp_packet::*;
 use bytes::BytesMut;
-use ipnet::{Ipv4Net, Ipv6Net};
+use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use prefix_trie::{Prefix, PrefixMap};
 
 use crate::bgp::timer::{start_adv_timer_evpn, start_stale_timer};
@@ -5396,6 +5396,99 @@ impl Bgp {
         route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
     }
 
+    /// Originate (or refresh) an EVPN Type-5 (IP Prefix) route for a
+    /// VRF route the global Export handler is re-emitting. The L3VPN
+    /// service rides exactly as it does for VPNv4/VPNv6: an MPLS
+    /// service `label` carried on the `BgpRib` (MPLS mode), or the
+    /// SRv6 L3 Service TLV already attached to `attr` by
+    /// `srv6_export_nexthop` (SRv6 mode, `label` 0). The route is
+    /// inserted into `local_rib.evpn` and advertised to peers that
+    /// negotiated the (L2vpn, Evpn) AFI/SAFI — so this composes with,
+    /// rather than replaces, the VPNv4/VPNv6 advertisement of the same
+    /// prefix.
+    ///
+    /// `attr` is the already export-RT-tagged attribute the Export
+    /// handler interned for VPNv4/VPNv6; we set the EVPN next-hop
+    /// (the PE router-id for MPLS, the locator for SRv6) and re-use it.
+    pub fn evpn_originate_type5(
+        &mut self,
+        rd: RouteDistinguisher,
+        net: IpNet,
+        mut attr: BgpAttr,
+        label: u32,
+        srv6_nexthop: Option<std::net::Ipv6Addr>,
+    ) {
+        let prefix = EvpnPrefix::IpPrefix {
+            eth_tag: 0,
+            prefix: net,
+        };
+        let nexthop = match srv6_nexthop {
+            Some(v6) => IpAddr::V6(v6),
+            None => IpAddr::V4(self.router_id),
+        };
+        attr.nexthop = Some(BgpNexthop::Evpn(nexthop));
+        // MPLS: the service label rides on the BgpRib (mirrored by the
+        // Type-5 NLRI emit in `route_update_evpn`). SRv6: label 0, the
+        // SID is in `attr.prefix_sid`.
+        let label_obj = if label != 0 && srv6_nexthop.is_none() {
+            Some(bgp_packet::Label {
+                label,
+                exp: 0,
+                bos: true,
+            })
+        } else {
+            None
+        };
+        let mut rib = BgpRib::new(
+            ORIGINATED_PEER,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            0,
+            32768,
+            &attr,
+            label_obj,
+            None,
+            false,
+        );
+        let (_replaced, selected, next_id) =
+            self.local_rib.update_evpn(rd, prefix.clone(), rib.clone());
+        rib.local_id = next_id;
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+        };
+
+        if !selected.is_empty() {
+            route_advertise_evpn_to_peers(rd, prefix, &selected, &mut bgp_ref, &mut self.peers);
+        }
+    }
+
+    /// Inverse of `evpn_originate_type5`: withdraw the EVPN Type-5
+    /// advertisement for `(rd, net)` from `local_rib.evpn` and every
+    /// EVPN peer. Called from the VRF withdraw-export handlers.
+    pub fn evpn_withdraw_type5(&mut self, rd: RouteDistinguisher, net: IpNet) {
+        let prefix = EvpnPrefix::IpPrefix {
+            eth_tag: 0,
+            prefix: net,
+        };
+        let _ = self.local_rib.remove_evpn(rd, &prefix, 0, ORIGINATED_PEER);
+        let _ = self.local_rib.select_best_path_evpn(&rd, &prefix);
+        route_withdraw_evpn_to_peers(rd, prefix, &mut self.peers);
+    }
+
     /// Originate a Type-3 (Inclusive Multicast Ethernet Tag) route
     /// for one local VTEP×VNI pair (RFC 7432 §4.3, §11.3 + RFC 8365
     /// §5.1.3). One IMET per VNI tells remote PEs "send your BUM
@@ -7350,5 +7443,47 @@ mod tests {
     fn fib_entry_v6_skipped_when_nexthop_missing() {
         let rib = bgp_rib_with_nexthop(None, super::BgpRibType::EBGP);
         assert!(super::make_bgp_rib_entry_v6(&rib).is_none());
+    }
+
+    /// The advertise/withdraw reconstruction maps an `EvpnPrefix::IpPrefix`
+    /// key back to a Type-5 wire route: same RD/eth-tag/prefix, a
+    /// family-matched unspecified gateway, label 0 (withdraw semantics),
+    /// and a zero ESI.
+    #[test]
+    fn evpn_route_from_prefix_type5_v4() {
+        use bgp_packet::{EvpnPrefix, EvpnRoute, RouteDistinguisher};
+        let rd = RouteDistinguisher::from_str("65000:100").unwrap();
+        let prefix = EvpnPrefix::IpPrefix {
+            eth_tag: 0,
+            prefix: "10.1.2.0/24".parse().unwrap(),
+        };
+        match super::evpn_route_from_prefix(&rd, &prefix, 0) {
+            EvpnRoute::Prefix(p) => {
+                assert_eq!(p.rd, rd);
+                assert_eq!(p.ether_tag, 0);
+                assert_eq!(p.prefix.to_string(), "10.1.2.0/24");
+                assert_eq!(p.gw, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+                assert_eq!(p.label, 0);
+                assert_eq!(p.esi, [0u8; 10]);
+            }
+            _ => panic!("expected Type-5 Prefix route"),
+        }
+    }
+
+    #[test]
+    fn evpn_route_from_prefix_type5_v6() {
+        use bgp_packet::{EvpnPrefix, EvpnRoute, RouteDistinguisher};
+        let rd = RouteDistinguisher::from_str("65000:200").unwrap();
+        let prefix = EvpnPrefix::IpPrefix {
+            eth_tag: 0,
+            prefix: "2001:db8::/32".parse().unwrap(),
+        };
+        match super::evpn_route_from_prefix(&rd, &prefix, 0) {
+            EvpnRoute::Prefix(p) => {
+                assert_eq!(p.prefix.to_string(), "2001:db8::/32");
+                assert_eq!(p.gw, IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED));
+            }
+            _ => panic!("expected Type-5 Prefix route"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

Phase 3 of EVPN Type-5 support — the **advertise path**.

When a VRF enables the Phase-2 knob:
```
router bgp { vrf red {
  rd 65000:100; encapsulation mpls;
  afi-safi { ipv4 { network 10.0.0.0/24; } }
  evpn { advertise-ipv4 true; advertise-ipv6 true; }
}}
```
the global `Export` / `ExportV6` handlers additionally originate an EVPN Type-5 (IP Prefix) route for each exported prefix, **alongside** the existing VPNv4/VPNv6 advertisement.

- Reuses the same per-VRF state: RD, export route-targets, MPLS service label (on the `BgpRib`) or SRv6 L3 Service TLV (`srv6_export_nexthop`, label 0).
- Fanned out via the existing EVPN peer path (`route_advertise_evpn_to_peers` → `send_evpn`/`flush_evpn`).
- Peer-gated: a peer receives Type-5 only if it negotiated `(L2vpn, Evpn)`, so this composes with VPNv4/VPNv6 rather than replacing it.
- New `Bgp::evpn_originate_type5` / `evpn_withdraw_type5` mirror `evpn_originate_macip`. No new VRF→global messages — the existing `Export`/`ExportV6`/`WithdrawExport(V6)` are reused.

## Test plan
- `cargo test -p zebra-rs evpn_route_from_prefix` — Type-5 key→wire-route reconstruction (v4 + v6) ✅
- `cargo build -p zebra-rs` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- Receive/import + end-to-end forwarding land in Phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)