### PR TITLE
bgp: receive + import EVPN Type-5 into VRFs (MPLS forwardable)

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1759,6 +1759,37 @@ impl Bgp {
                     );
                 }
             }
+            NhtDep::Evpn(rd, prefix) => {
+                // EVPN Type-5: the imported IP prefix's underlay
+                // rerouted; re-dispatch the VRF import with the fresh
+                // transport. Reuses the VPNv4/v6 dispatch.
+                let selected = self.local_rib.select_best_path_evpn(&rd, &prefix);
+                if let Some(winner) = selected.last()
+                    && let bgp_packet::EvpnPrefix::IpPrefix { prefix: net, .. } = &prefix
+                {
+                    let label = winner.label.map(|l| l.label).unwrap_or(0);
+                    match net {
+                        ipnet::IpNet::V4(p) => super::vrf::dispatch_import_v4(
+                            &dispatcher,
+                            rd,
+                            *p,
+                            &winner.attr,
+                            label,
+                            transport,
+                            None,
+                        ),
+                        ipnet::IpNet::V6(p) => super::vrf::dispatch_import_v6(
+                            &dispatcher,
+                            rd,
+                            *p,
+                            &winner.attr,
+                            label,
+                            transport,
+                            None,
+                        ),
+                    }
+                }
+            }
             NhtDep::V4(_) | NhtDep::V6(_) => {}
         }
     }
@@ -1798,6 +1829,10 @@ impl Bgp {
                     .set_nexthop_reachable(*p, nh, reachable);
                 self.local_rib.select_best_path_vpn_v6(rd, *p)
             }
+            // EVPN Type-5 best-path isn't gated on next-hop reachability
+            // (the VRF FIB install is gated by transport availability in
+            // the dispatch below), so just re-select.
+            NhtDep::Evpn(rd, prefix) => self.local_rib.select_best_path_evpn(rd, prefix),
         };
 
         let mut top = super::peer::BgpTop {
@@ -1906,6 +1941,74 @@ impl Bgp {
                     .and_then(|t| t.candidate_attr(*p))
                 {
                     super::vrf::dispatch_withdraw_import_v6(&dispatcher, *rd, *p, &attr, None);
+                }
+            }
+            NhtDep::Evpn(rd, prefix) => {
+                // EVPN Type-5 analog: advertise the re-selected best-path
+                // to peers, then (re-)dispatch the VRF import with the
+                // resolved transport, or withdraw if the PE went away.
+                if !selected.is_empty() {
+                    super::route::route_advertise_evpn_to_peers(
+                        *rd,
+                        prefix.clone(),
+                        &selected,
+                        &mut top,
+                        &mut self.peers,
+                    );
+                }
+                let dispatcher = super::vrf::VrfImportDispatcher {
+                    rib_known_vrfs: &self.rib_known_vrfs,
+                    vrf_registry: &self.vrf_registry,
+                };
+                if let bgp_packet::EvpnPrefix::IpPrefix { prefix: net, .. } = prefix
+                    && let Some(winner) = selected.last()
+                {
+                    let label = winner.label.map(|l| l.label).unwrap_or(0);
+                    let transport = self.nexthop_cache.transport_for(nh);
+                    match net {
+                        ipnet::IpNet::V4(p) => {
+                            if reachable {
+                                super::vrf::dispatch_import_v4(
+                                    &dispatcher,
+                                    *rd,
+                                    *p,
+                                    &winner.attr,
+                                    label,
+                                    transport,
+                                    None,
+                                );
+                            } else {
+                                super::vrf::dispatch_withdraw_import_v4(
+                                    &dispatcher,
+                                    *rd,
+                                    *p,
+                                    &winner.attr,
+                                    None,
+                                );
+                            }
+                        }
+                        ipnet::IpNet::V6(p) => {
+                            if reachable {
+                                super::vrf::dispatch_import_v6(
+                                    &dispatcher,
+                                    *rd,
+                                    *p,
+                                    &winner.attr,
+                                    label,
+                                    transport,
+                                    None,
+                                );
+                            } else {
+                                super::vrf::dispatch_withdraw_import_v6(
+                                    &dispatcher,
+                                    *rd,
+                                    *p,
+                                    &winner.attr,
+                                    None,
+                                );
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/zebra-rs/src/bgp/nht.rs
+++ b/zebra-rs/src/bgp/nht.rs
@@ -15,7 +15,7 @@
 use std::collections::{BTreeSet, HashMap};
 use std::net::IpAddr;
 
-use bgp_packet::{BgpAttr, BgpNexthop, RouteDistinguisher};
+use bgp_packet::{BgpAttr, BgpNexthop, EvpnPrefix, RouteDistinguisher};
 use ipnet::{Ipv4Net, Ipv6Net};
 
 use crate::rib::nht::{NexthopResolution, ResolvedNexthop};
@@ -28,6 +28,11 @@ pub enum NhtDep {
     V6(Ipv6Net),
     V4vpn(RouteDistinguisher, Ipv4Net),
     V6vpn(RouteDistinguisher, Ipv6Net),
+    /// EVPN Type-5 (IP Prefix) route in `local_rib.evpn`. Like the
+    /// VPN deps, the PE next-hop is tracked so the VRF import re-runs
+    /// when the underlay resolves or reroutes. The `EvpnPrefix` is the
+    /// RD-stripped key (its `IpPrefix` variant carries the v4/v6 net).
+    Evpn(RouteDistinguisher, EvpnPrefix),
 }
 
 /// How a tracked next-hop's resolution changed, returned by

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2989,9 +2989,19 @@ fn route_evpn_export_selected(
                     );
                 }
             }
-            EvpnPrefix::IpPrefix { .. } => {
-                // Type-5 withdrawal drives a VRF route un-import, not an
-                // FDB/MDB delete. Wired in a later phase.
+            EvpnPrefix::IpPrefix { prefix, .. } => {
+                // Type-5 withdrawal un-imports the IP prefix from matching
+                // VRFs, reusing the VPNv4/v6 withdraw dispatch.
+                if let Some(dispatcher) = bgp.vrf_import {
+                    match prefix {
+                        IpNet::V4(p) => super::vrf::dispatch_withdraw_import_v4(
+                            dispatcher, *rd, *p, &wd.attr, None,
+                        ),
+                        IpNet::V6(p) => super::vrf::dispatch_withdraw_import_v6(
+                            dispatcher, *rd, *p, &wd.attr, None,
+                        ),
+                    }
+                }
             }
         }
         return;
@@ -3053,11 +3063,24 @@ fn route_evpn_export_selected(
                 );
             }
         }
-        EvpnPrefix::IpPrefix { .. } => {
-            // Type-5 (IP Prefix) drives a VRF route import, not an FDB/MDB
-            // install. The import + dataplane path is wired in a later
-            // phase; until then a received Type-5 best-path is held in the
-            // Loc-RIB without a dataplane action.
+        EvpnPrefix::IpPrefix { prefix, .. } => {
+            // A received Type-5 best-path imports into matching VRFs
+            // exactly like a VPNv4/v6 route — reuse the same dispatch +
+            // transport + FIB machinery. Our own originated Type-5
+            // (typ Originated) is left to the VRF Export local-leak path.
+            if best.typ != BgpRibType::Originated
+                && let Some(dispatcher) = bgp.vrf_import
+            {
+                let (label, transport) = vpn_import_transport(bgp, best);
+                match prefix {
+                    IpNet::V4(p) => super::vrf::dispatch_import_v4(
+                        dispatcher, *rd, *p, &best.attr, label, transport, None,
+                    ),
+                    IpNet::V6(p) => super::vrf::dispatch_import_v6(
+                        dispatcher, *rd, *p, &best.attr, label, transport, None,
+                    ),
+                }
+            }
         }
     }
 }
@@ -3135,6 +3158,19 @@ pub fn route_evpn_update(
     if let EvpnRoute::Mac(m) = route {
         rib.esi = Some(m.esi);
     }
+    // Type-5 (IP Prefix) carries an MPLS service label in its NLRI;
+    // preserve it on the BgpRib so the VRF import (which reuses the
+    // VPNv4/v6 path) can build the label-push FIB entry. SRv6 Type-5
+    // carries label 0 + the SID in the Prefix-SID attribute.
+    if let EvpnRoute::Prefix(p) = route
+        && p.label != 0
+    {
+        rib.label = Some(bgp_packet::Label {
+            label: p.label,
+            exp: 0,
+            bos: true,
+        });
+    }
 
     // Apply input policy *after* the route is registered in
     // Adj-RIB-In (raw, pre-policy view) but *before* it enters
@@ -3151,6 +3187,15 @@ pub fn route_evpn_update(
     };
     rib.attr = bgp.attr_store.intern(decision.attr);
     rib.weight = decision.weight;
+
+    // Type-5: register the PE next-hop with NHT so the underlay
+    // resolves (transport is empty at receive — resolution is async)
+    // and a later reroute re-triggers the VRF import. Type-2/3 are
+    // VXLAN (VTEP next-hop, no transport) and are not tracked.
+    if let EvpnRoute::Prefix(_) = route {
+        let dep = super::nht::NhtDep::Evpn(rd, prefix.clone());
+        nht_track_received(bgp, &mut rib, dep);
+    }
 
     let _ = bgp.local_rib.update_evpn(rd, prefix.clone(), rib);
 


### PR DESCRIPTION
## Summary

Phase 4 of EVPN Type-5 support — the **receive + import path**, completing the MPLS data plane. A received Type-5 (IP Prefix) best-path now imports into matching VRFs and installs a label-push FIB entry.

Key insight: importing a Type-5 prefix is **identical to importing VPNv4/VPNv6** once you have `(rd, prefix, attr, label, transport)`. So this **reuses the existing import machinery verbatim** — `dispatch_import_v4/v6`, `BgpVrfMsg::ImportV4/V6`, `handle_import_v4/v6`, `build_vpn_fib_entry`, and the per-VRF `DecapVrf` ILM already installed at spawn. No new messages or handlers.

### New wiring
- `route_evpn_update` stores the Type-5 NLRI service label on the `BgpRib` (Type-2/3 unchanged) and registers the PE next-hop with NHT via a new `NhtDep::Evpn(rd, EvpnPrefix)`.
- `route_evpn_export_selected` branches `EvpnPrefix::IpPrefix` to the VRF import/withdraw dispatch (Type-2/3 still drive FDB/MDB). Our own originated Type-5 is skipped (left to the Export local-leak path).
- The NHT re-eval / transport-reroute arms handle `NhtDep::Evpn`: transport is empty at receive (resolution is async), so on reachability/transport change the VRF import is (re-)dispatched with the resolved transport, or withdrawn on PE failure.

This makes the round trip forwardable: a VRF route advertised as Type-5 (Phase 3) is imported by the remote PE into its VRF with a `{transport, service}` label stack + the per-VRF decap ILM — the SRv6 variant lands in Phase 5.

## Test plan
- `cargo build -p zebra-rs` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test -p zebra-rs bgp::` — 212 pass (no regressions) ✅
- `cargo test -p bgp-packet evpn` — 16 pass ✅
- Forwarding reuses the tested VPNv4/v6 dataplane (`build_vpn_fib_entry` label-push/ECMP tests, DecapVrf ILM); end-to-end validated in CI.

### Follow-up
Untrack the EVPN `NhtDep` on Type-5 withdrawal (a stale dep only triggers a no-op re-eval; bounded by distinct next-hops, matching the existing VPN untrack-deferral note in `nht.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)