### PR TITLE
bgp: EVPN Type-5 over SRv6 + documentation

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -18,6 +18,7 @@
   - [Timer Configuration](ch-02-03-bgp-timers.md)
   - [L3VPN and Per-VRF Labels](ch-02-04-bgp-l3vpn.md)
   - [L3VPN over an SRv6 Underlay](ch-02-05-bgp-l3vpn-srv6.md)
+  - [EVPN Type-5 (IP Prefix Routes)](ch-02-06-bgp-evpn-type5.md)
 - [IS-IS](ch-07-00-isis.md)
   - [Timer Configuration](ch-07-01-isis-timers.md)
   - [Shared Risk Link Group (SRLG)](ch-07-02-isis-srlg.md)

--- a/book/src/ch-02-06-bgp-evpn-type5.md
+++ b/book/src/ch-02-06-bgp-evpn-type5.md
@@ -1,0 +1,92 @@
+# BGP EVPN Type-5 (IP Prefix Routes)
+
+zebra-rs implements **EVPN Type-5 (IP Prefix) routes** as specified in
+RFC 9136. Type-5 carries an IP prefix across an EVPN as an L3VPN-style
+service — it is, in effect, an alternative NLRI *encoding* of the same
+per-VRF IP routing that [VPNv4 / VPNv6 L3VPN](ch-02-04-bgp-l3vpn.md)
+provides. DC fabrics commonly prefer the EVPN encoding because one
+address family (`l2vpn evpn`) then carries both the L2 service
+(Type-2 / Type-3, see VXLAN EVPN) and the L3 service (Type-5).
+
+Because Type-5 reuses the existing L3VPN control- and data-plane, the
+two ends of a VPN flow map exactly as they do for VPNv4 / VPNv6:
+
+* the **egress PE** binds a per-VRF forwarding identifier — an **MPLS
+  service label** (MPLS underlay) or an **SRv6 End.DT46 SID** (SRv6
+  underlay) — and programs a decap into the VRF table (an `RTA`
+  MPLS-`DecapVrf` ILM, or a `seg6local` End.DT46 entry);
+* the **ingress PE** imports a received Type-5 route whose route-targets
+  match a local VRF and installs it with a `{transport, service}` MPLS
+  label-push next-hop, or an SRv6 **H.Encap** next-hop toward the remote
+  SID.
+
+The forwarding identifier rides in the Type-5 NLRI's label field (MPLS)
+or in the BGP **Prefix-SID** attribute's SRv6 L3 Service TLV (SRv6,
+label 0) — the same attributes the VPNv4 / VPNv6 paths use.
+
+## Configuration
+
+Type-5 advertisement is opt-in per VRF via the **`evpn`** block, named
+to match the `evpn` address family. It reuses the VRF's existing `rd`,
+route-targets, and `encapsulation`; no separate RD / RT / VNI is
+introduced:
+
+```
+set router bgp vrf red rd 65000:100
+set router bgp vrf red encapsulation mpls
+set router bgp vrf red afi-safi ipv4 network 10.0.0.0/24
+set router bgp vrf red evpn advertise-ipv4 true
+set router bgp vrf red evpn advertise-ipv6 true
+```
+
+* `advertise-ipv4` / `advertise-ipv6` advertise the VRF's IPv4 / IPv6
+  unicast routes as EVPN Type-5 routes. Both default to `false`.
+* `rd` is required (Type-5 carries a Route Distinguisher).
+* `encapsulation {mpls|srv6}` selects the data plane, exactly as for
+  VPNv4 / VPNv6 — `mpls` uses the per-VRF service label, `srv6` uses the
+  VRF's End.DT46 SID carved from the global `segment-routing` locator.
+
+A neighbor must negotiate the L2VPN/EVPN address family to exchange
+Type-5 routes:
+
+```
+set router bgp neighbor 10.0.0.1 remote-as 65001
+set router bgp neighbor 10.0.0.1 afi-safi evpn enabled true
+```
+
+### Composition with VPNv4 / VPNv6
+
+Enabling the `evpn` block does **not** disable VPNv4 / VPNv6. A VRF with
+both an RD (for VPNv4/v6) and `evpn advertise-*` set populates both the
+VPNv4/v6 and the EVPN Loc-RIB; each peer receives only the encoding it
+negotiated — a `vpnv4` peer gets VPNv4, an `evpn` peer gets Type-5. This
+makes Type-5 additive and lets a route reflector or PE speak both during
+a migration.
+
+## Data plane
+
+| Underlay | NLRI label | BGP next-hop | Ingress install | Egress decap |
+|---|---|---|---|---|
+| **MPLS** | per-VRF service label | PE router-id | `{transport, service}` label push | MPLS `DecapVrf` ILM |
+| **SRv6** | 0 | PE locator | H.Encap to End.DT46 SID | `seg6local` End.DT46 |
+
+Both are the *same* mechanisms VPNv4 / VPNv6 already use — Type-5 simply
+arrives in a different NLRI. Recursive next-hop resolution (NHT) gates
+the install: a Type-5 route only programs the VRF FIB once its PE
+next-hop resolves over the underlay, and re-installs if that underlay
+reroutes.
+
+> **Note** — this is the **L3** EVPN service. EVPN's **L2** services
+> (Type-2 MAC/IP, Type-3 inclusive-multicast) run over VXLAN and are
+> documented separately; EVPN-over-MPLS *L2* is not supported (the Linux
+> kernel has no L2-over-MPLS data path).
+
+## Verification
+
+`show ip bgp l2vpn evpn` lists Type-5 routes with the
+`[5]:[EthTag]:[IPlen]:[IP]` prefix form alongside any Type-2 / Type-3
+routes. On the ingress PE, an imported Type-5 route appears in its VRF
+table as a normal IP route whose next-hop is the MPLS label-push (check
+`ip -f mpls route` for the per-VRF decap label) or the SRv6 H.Encap
+(`ip -6 route` shows `encap seg6 ... segs <remote-SID>`). CE-facing
+routes remain plain.

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7531,4 +7531,31 @@ mod tests {
             _ => panic!("expected Type-5 Prefix route"),
         }
     }
+
+    /// A Type-5 route imported over an SRv6 underlay installs an
+    /// H.Encap next-hop toward the End.DT46 service SID (no MPLS label
+    /// stack) — the shared `build_srv6_vpn_fib_entry` the EVPN import
+    /// reuses, so an SRv6-mode Type-5 forwards with zero extra code.
+    #[test]
+    fn srv6_vpn_fib_entry_encaps_to_service_sid() {
+        use crate::rib::nht::ResolvedNexthop;
+        let sid: std::net::Ipv6Addr = "2001:db8:1::100".parse().unwrap();
+        let transport = vec![ResolvedNexthop {
+            addr: "fe80::1".parse().unwrap(),
+            ifindex: 7,
+            labels: vec![],
+        }];
+        let entry = super::build_srv6_vpn_fib_entry(sid, &transport).expect("installable");
+        assert_eq!(entry.distance, 200, "imported VPN routes arrive via iBGP");
+        match entry.nexthop {
+            crate::rib::Nexthop::Uni(uni) => {
+                assert_eq!(uni.segs, vec![sid]);
+                assert_eq!(uni.encap_type, Some(isis_packet::srv6::EncapType::HEncap));
+                assert_eq!(uni.ifindex_origin, Some(7));
+            }
+            other => panic!("expected Uni nexthop, got {other:?}"),
+        }
+        // Unresolved underlay → nothing to install.
+        assert!(super::build_srv6_vpn_fib_entry(sid, &[]).is_none());
+    }
 }


### PR DESCRIPTION
## Summary

Phases 5 + 6 of EVPN Type-5, completing the series.

**Phase 5 — SRv6 variant (no new production code).** Type-5 over an SRv6 underlay already works by reuse:
- Advertise: the global Export handler calls `srv6_export_nexthop`, which attaches the SRv6 L3 Service TLV to the attr (label 0, locator next-hop); `evpn_originate_type5` carries it through.
- Import: `select_fib_entry_v4/v6` already branches on `attr.srv6_l3_sid()` → `build_srv6_vpn_fib_entry` (H.Encap toward the End.DT46 SID). A Type-5 import (which reuses the VPNv4/v6 dispatch) reaches this unchanged.

Adds a regression test locking the SRv6 FIB builder (`segs` + `HEncap` + `ifindex`, empty-transport → none).

**Phase 6 — docs.** New book chapter `ch-02-06-bgp-evpn-type5.md` (config, MPLS/SRv6 data planes, composition with VPNv4/VPNv6, verification) + SUMMARY.md entry. Type-5 renders in `show ip bgp l2vpn evpn` via the `EvpnPrefix` Display — no show-path change needed.

## Test plan
- `cargo test -p zebra-rs srv6_vpn_fib_entry` ✅
- `cargo test -p bgp-packet evpn` — 16 pass ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅

This completes EVPN Type-5 (RFC 9136) over MPLS and SRv6: PRs #1035 (codec), #1036 (config), #1037 (advertise), #1038 (receive/import), this (SRv6 + docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)