### PR TITLE
bdd: two-PE EVPN Type-5 advertise/receive test

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -36,6 +36,10 @@ bgp_evpn_capability:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_capability"
 
+bgp_vrf_evpn_type5:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_vrf_evpn_type5"
+
 bgp_route_map_match:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_route_map_match"
@@ -71,4 +75,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation bgp_evpn_capability bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE

--- a/bdd/tests/configs/bgp_vrf_evpn_type5/z1-1.yaml
+++ b/bdd/tests/configs/bgp_vrf_evpn_type5/z1-1.yaml
@@ -1,0 +1,29 @@
+vrf:
+- name: vrf-blue
+  ipv4:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: evpn
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    vrf:
+    - name: vrf-blue
+      rd: 65001:100
+      evpn:
+        advertise-ipv4: true
+      afi-safi:
+        ipv4:
+          network:
+          - prefix: 10.1.0.0/24

--- a/bdd/tests/configs/bgp_vrf_evpn_type5/z2-1.yaml
+++ b/bdd/tests/configs/bgp_vrf_evpn_type5/z2-1.yaml
@@ -1,0 +1,23 @@
+vrf:
+- name: vrf-blue
+  ipv4:
+    route-target:
+      import:
+      - 65001:100
+      export:
+      - 65001:100
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: evpn
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    vrf:
+    - name: vrf-blue
+      rd: 65001:200

--- a/bdd/tests/features/bgp_vrf_evpn_type5.feature
+++ b/bdd/tests/features/bgp_vrf_evpn_type5.feature
@@ -1,0 +1,74 @@
+@serial
+@bgp_vrf_evpn_type5
+Feature: BGP per-VRF EVPN Type-5 (IP Prefix) advertise to a remote PE
+  As a network operator
+  I want a network configured under `router bgp vrf X afi-safi ipv4`
+  with `evpn advertise-ipv4` to be advertised as an EVPN Type-5
+  (RFC 9136 IP Prefix) route toward a remote PE
+  Using a two-namespace topology where z1 originates the prefix inside
+  vrf-blue and z2 peers with z1 over the L2VPN/EVPN address family,
+  imports the Type-5 route by matching route-target.
+
+  This is the EVPN-encoded counterpart of the VPNv4 export feature: the
+  same per-VRF state (RD, route-target, network) produces a Type-5 NLRI
+  instead of a VPNv4 NLRI, exchanged over (AFI=25 / SAFI=70).
+
+  Test Topology:
+  ```
+  ┌─────────────┐                ┌─────────────┐
+  │     z1      │   EVPN iBGP    │     z2      │
+  │  AS 65001   │ ◀────────────▶ │  AS 65001   │
+  │ vrf-blue:   │                │ vrf-blue:   │
+  │  RD 65001:  │                │  RD 65001:  │
+  │   100       │                │   200       │
+  │  RT 65001:  │                │  RT 65001:  │
+  │   100 imp/  │                │   100 imp/  │
+  │   exp       │                │   exp       │
+  │  net 10.1.  │                │             │
+  │   0.0/24    │                │             │
+  │  evpn adv-  │                │             │
+  │   ipv4      │                │             │
+  └─────────────┘                └─────────────┘
+   192.168.0.1                    192.168.0.2
+  ```
+
+  Config files:
+  - z1-1.yaml: AS 65001, vrf-blue with RD 65001:100, RT 65001:100, a
+    self-originated network 10.1.0.0/24, and `evpn advertise-ipv4 true`.
+    EVPN iBGP to z2.
+  - z2-1.yaml: AS 65001, vrf-blue with RD 65001:200, RT 65001:100
+    (matching import). EVPN iBGP to z1.
+
+  Scenario: Setup topology
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+
+  Scenario: z1 advertises the self-originated network as an EVPN Type-5 route
+    Given the test topology exists
+    Then show command "ip bgp evpn" in namespace "z1" should contain "[5]:"
+    And show command "ip bgp evpn" in namespace "z1" should contain "10.1.0.0"
+    And show command "ip bgp evpn" in namespace "z1" should contain "65001:100"
+
+  Scenario: z2 receives the EVPN Type-5 route under the originating RD
+    Given the test topology exists
+    Then show command "ip bgp evpn" in namespace "z2" should contain "[5]:"
+    And show command "ip bgp evpn" in namespace "z2" should contain "10.1.0.0"
+    And show command "ip bgp evpn" in namespace "z2" should contain "65001:100"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

Adds a two-PE bdd (cucumber) test for **EVPN Type-5 (RFC 9136)** — the EVPN-encoded counterpart of the existing `bgp_vrf_vpnv4_export` feature.

Topology: z1 (192.168.0.1) and z2 (192.168.0.2), both AS 65001, peering over the **L2VPN/EVPN** address family on a shared bridge. z1 originates `10.1.0.0/24` in `vrf-blue` (RD 65001:100, RT 65001:100) with `evpn advertise-ipv4 true`; z2 (RD 65001:200, RT 65001:100 import) receives and imports it by route-target match.

### Scenarios
- Session establishes with the EVPN AFI/SAFI on both sides.
- `show ip bgp evpn` on **z1** shows the originated Type-5 prefix (`[5]:` … `10.1.0.0`) under RD `65001:100`.
- `show ip bgp evpn` on **z2** shows the **received** Type-5 prefix under the originating RD `65001:100`.

### Files
- `bdd/tests/features/bgp_vrf_evpn_type5.feature`
- `bdd/tests/configs/bgp_vrf_evpn_type5/{z1,z2}-1.yaml`
- `bdd/Makefile` — `bgp_vrf_evpn_type5` convenience target

## Test plan
- The bdd suite runs in the **nightly** job; regular CI uses `cargo test --workspace --exclude bdd`, so this PR's CI is green on the unchanged Rust. The harness crate compiles (`cargo build -p bdd --tests`).
- Features are auto-discovered by `World::cucumber().run("tests/features")`; the config dir name matches the `@bgp_vrf_evpn_type5` tag.
- Validates the control-plane round trip (advertise + receive), mirroring the proven VPNv4 export feature's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)