### PR TITLE
bgp: configure RTC via afi-safi rtcv4/rtcv6 instead of `rtc` leaf

### DIFF
--- a/bdd/tests/configs/bgp_gobgpd_rr/rr1.yaml
+++ b/bdd/tests/configs/bgp_gobgpd_rr/rr1.yaml
@@ -82,6 +82,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.37.16/28
         out: 198.18.37.16/28
@@ -93,7 +95,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.37.30
       afi-safi:
       - name: vpnv4
@@ -104,6 +105,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.37.16/28
         out: 198.18.37.16/28
@@ -115,7 +118,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.37.81
       afi-safi:
       - name: vpnv4
@@ -126,6 +128,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
@@ -137,7 +141,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.37.82
       afi-safi:
       - name: vpnv4
@@ -148,6 +151,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
@@ -159,7 +164,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.37.83
       afi-safi:
       - name: vpnv4
@@ -170,6 +174,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
@@ -181,7 +187,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.37.88
       afi-safi:
       - name: vpnv4
@@ -192,6 +197,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
@@ -203,7 +210,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.37.89
       afi-safi:
       - name: vpnv4
@@ -214,6 +220,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
@@ -225,7 +233,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.37.90
       afi-safi:
       - name: vpnv4
@@ -236,6 +243,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
@@ -247,7 +256,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.37.91
       afi-safi:
       - name: vpnv4
@@ -258,6 +266,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
@@ -269,7 +279,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.37.92
       afi-safi:
       - name: vpnv4
@@ -280,6 +289,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
@@ -291,7 +302,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.37.93
       afi-safi:
       - name: vpnv4
@@ -302,6 +312,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
@@ -313,7 +325,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.37.94
       afi-safi:
       - name: vpnv4
@@ -324,6 +335,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.37.80/28
         out: 198.18.37.80/28
@@ -335,7 +348,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.39.97
       afi-safi:
       - name: vpnv4
@@ -346,6 +358,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.39.96/28
         out: 198.18.39.96/28
@@ -357,7 +371,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.39.110
       afi-safi:
       - name: vpnv4
@@ -368,6 +381,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.39.96/28
         out: 198.18.39.96/28
@@ -379,7 +394,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.39.129
       afi-safi:
       - name: vpnv4
@@ -390,6 +404,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
@@ -401,7 +417,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.39.130
       afi-safi:
       - name: vpnv4
@@ -412,6 +427,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
@@ -423,7 +440,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.39.131
       afi-safi:
       - name: vpnv4
@@ -434,6 +450,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
@@ -445,7 +463,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.39.136
       afi-safi:
       - name: vpnv4
@@ -456,6 +473,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
@@ -467,7 +486,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.39.137
       afi-safi:
       - name: vpnv4
@@ -478,6 +496,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
@@ -489,7 +509,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.39.138
       afi-safi:
       - name: vpnv4
@@ -500,6 +519,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
@@ -511,7 +532,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.39.139
       afi-safi:
       - name: vpnv4
@@ -522,6 +542,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
@@ -533,7 +555,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.39.140
       afi-safi:
       - name: vpnv4
@@ -544,6 +565,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
@@ -555,7 +578,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.39.141
       afi-safi:
       - name: vpnv4
@@ -566,6 +588,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
@@ -577,7 +601,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.39.142
       afi-safi:
       - name: vpnv4
@@ -588,6 +611,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.39.128/28
         out: 198.18.39.128/28
@@ -599,7 +624,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.39.145
       afi-safi:
       - name: vpnv4
@@ -610,6 +634,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.39.144/28
         out: 198.18.39.144/28
@@ -621,7 +647,6 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true
     - remote-address: 198.18.39.158
       afi-safi:
       - name: vpnv4
@@ -632,6 +657,8 @@ router:
         long-lived-graceful-restart:
           enabled: true
           restart-time: 172800
+      - name: rtcv4
+        enabled: true
       policy:
         in: 198.18.39.144/28
         out: 198.18.39.144/28
@@ -643,4 +670,3 @@ router:
       route-reflector:
         client: true
         cluster-id: 198.18.39.94
-      rtc: true

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -542,19 +542,6 @@ fn config_afi_safi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     Some(())
 }
 
-fn config_rtc(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let addr = args.addr()?;
-    let afi_safi = AfiSafi::new(Afi::Ip, Safi::Rtc);
-    if let Some(peer) = bgp.peers.get_mut(&addr) {
-        if op.is_set() {
-            peer.config.mp.set(afi_safi, true);
-        } else {
-            peer.config.mp.remove(&afi_safi);
-        }
-    }
-    Some(())
-}
-
 fn config_network(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let afi_safi: AfiSafi = args.afi_safi()?;
     let network = args.v4net()?;
@@ -1677,7 +1664,6 @@ impl Bgp {
             "/afi-safi/long-lived-graceful-restart/restart-time",
             config_llgr_restart_time,
         );
-        self.callback_peer("/rtc", config_rtc);
 
         // Timer configuration.
         self.timer("/hold-time", timer::config::hold_time);

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -130,6 +130,8 @@ impl Args {
             "vpnv4" => Some(AfiSafi::new(Afi::Ip, Safi::MplsVpn)),
             "vpnv6" => Some(AfiSafi::new(Afi::Ip6, Safi::MplsVpn)),
             "evpn" => Some(AfiSafi::new(Afi::L2vpn, Safi::Evpn)),
+            "rtcv4" => Some(AfiSafi::new(Afi::Ip, Safi::Rtc)),
+            "rtcv6" => Some(AfiSafi::new(Afi::Ip6, Safi::Rtc)),
             _ => None,
         }
     }

--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -430,10 +430,6 @@ module ietf-bgp {
               dynamically.";
         }
 
-        leaf rtc {
-          type boolean;
-        }
-
         leaf remote-address {
           type inet:ip-address;
           description

--- a/zebra-rs/yang/zebra-afi-safi.yang
+++ b/zebra-rs/yang/zebra-afi-safi.yang
@@ -20,8 +20,9 @@ module zebra-afi-safi {
      an `afi-safi` list:
 
        * `afi-safi`         — the full BGP set (ipv4, ipv6, vpnv4,
-                              vpnv6, evpn). Used by `router bgp`
-                              (global + per-neighbor afi-safi).
+                              vpnv6, evpn, rtcv4, rtcv6). Used by
+                              `router bgp` (global + per-neighbor
+                              afi-safi).
        * `afi-safi-unicast` — the unicast subset (ipv4, ipv6). Used by
                               `router isis` and the per-VRF BGP afi-safi
                               (which carries the same family names).
@@ -50,6 +51,14 @@ module zebra-afi-safi {
         }
         enum evpn {
           description "BGP EVPN (AFI 25, SAFI 70).";
+        }
+        enum rtcv4 {
+          description
+            "IPv4 Route Target Constraint (AFI 1, SAFI 132).";
+        }
+        enum rtcv6 {
+          description
+            "IPv6 Route Target Constraint (AFI 2, SAFI 132).";
         }
       }
       description


### PR DESCRIPTION
## Summary

Route Target Constraint (RTC) was enabled per-neighbor with a standalone boolean leaf, `router bgp neighbor ADDR rtc`. This folds it into the per-AFI/SAFI config so RTC is configured the same way as every other family, and extends it to IPv6:

```
router bgp neighbor ADDR afi-safi rtcv4 enabled true
router bgp neighbor ADDR afi-safi rtcv6 enabled true
```

## Changes

- **`zebra-afi-safi.yang`** — add `rtcv4` (AFI 1, SAFI 132) and `rtcv6` (AFI 2, SAFI 132) to the `afi-safi` enum.
- **`ietf-bgp@2023-07-05.yang`** — drop the neighbor `leaf rtc`.
- **`config/configs.rs`** — `Args::afi_safi()` maps `rtcv4 → (Ip, Rtc)` and `rtcv6 → (Ip6, Rtc)`.
- **`bgp/config.rs`** — remove the now-redundant `config_rtc` callback; the existing `afi-safi/enabled` callback handles RTC (for `rtcv4` it sets exactly the `AfiSafi(Ip, Rtc)` the old path used).
- **`bgp_gobgpd_rr/rr1.yaml`** — convert all `rtc: true` to an `rtcv4` afi-safi list entry (the only config referencing the old leaf).

## Test plan

- `cargo test -p zebra-rs yang_load_tests` — `configure`/`exec` modes load (YANG regression guard) ✅
- `cargo clippy --workspace --all-targets -- -D warnings` — clean ✅
- `cargo fmt --all` — no changes ✅

Generated with [Claude Code](https://claude.com/claude-code)