### PR TITLE
bgp-packet: BGP Labeled Unicast NLRI codec (RFC 3107 / RFC 8277)

### DIFF
--- a/crates/bgp-packet/src/attrs/mod.rs
+++ b/crates/bgp-packet/src/attrs/mod.rs
@@ -99,3 +99,6 @@ pub use nlri_flowspec::*;
 
 pub mod flowspec_action;
 pub use flowspec_action::*;
+
+pub mod nlri_labeled_unicast;
+pub use nlri_labeled_unicast::*;

--- a/crates/bgp-packet/src/attrs/mp_reach.rs
+++ b/crates/bgp-packet/src/attrs/mp_reach.rs
@@ -10,9 +10,9 @@ use nom_derive::*;
 use bytes::BufMut;
 
 use crate::{
-    Afi, AttrFlags, AttrType, EvpnRoute, FlowspecNlri, Ipv4Nlri, Ipv6Nlri, MupRoute, ParseBe,
-    ParseNlri, ParseOption, Rtcv4, Safi, Vpnv4Nexthop, Vpnv4Nlri, Vpnv6Nexthop, Vpnv6Nlri,
-    many0_complete,
+    Afi, AttrFlags, AttrType, EvpnRoute, FlowspecNlri, Ipv4Nlri, Ipv6Nlri, Labelv4Nlri,
+    Labelv6Nlri, MupRoute, ParseBe, ParseNlri, ParseOption, Rtcv4, Safi, Vpnv4Nexthop, Vpnv4Nlri,
+    Vpnv6Nexthop, Vpnv6Nlri, many0_complete,
 };
 
 use super::{AttrEmitter, RouteDistinguisher, Rtcv4Reach, Vpnv4Reach, Vpnv6Reach};
@@ -60,6 +60,20 @@ pub enum MpReachAttr {
         afi: Afi,
         updates: Vec<FlowspecNlri>,
     },
+    /// IPv4 Labeled-Unicast (RFC 3107 / RFC 8277), AFI 1, SAFI 4.
+    Labelv4 {
+        snpa: u8,
+        nhop: IpAddr,
+        updates: Vec<Labelv4Nlri>,
+    },
+    /// IPv6 Labeled-Unicast (RFC 3107 / RFC 8277), AFI 2, SAFI 4. Also
+    /// carries 6PE (RFC 4798): an IPv4 `nhop` is emitted as an
+    /// IPv4-mapped IPv6 next-hop.
+    Labelv6 {
+        snpa: u8,
+        nhop: IpAddr,
+        updates: Vec<Labelv6Nlri>,
+    },
 }
 
 impl MpReachAttr {
@@ -98,6 +112,20 @@ impl MpReachAttr {
             }
             MpReachAttr::Flowspec { afi, updates } => {
                 flowspec_attr_emit(*afi, updates, buf);
+            }
+            MpReachAttr::Labelv4 {
+                snpa,
+                nhop,
+                updates,
+            } => {
+                labelv4_attr_emit(*snpa, nhop, updates, buf);
+            }
+            MpReachAttr::Labelv6 {
+                snpa,
+                nhop,
+                updates,
+            } => {
+                labelv6_attr_emit(*snpa, nhop, updates, buf);
             }
             _ => {
                 //
@@ -278,6 +306,63 @@ impl MpReachAttr {
             let (_, updates) =
                 many0_complete(|i| Ipv6Nlri::parse_nlri(i, add_path)).parse(input)?;
             let mp_nlri = MpReachAttr::Ipv6 {
+                snpa,
+                nhop,
+                updates,
+            };
+            return Ok((input, mp_nlri));
+        }
+        if header.afi == Afi::Ip && header.safi == Safi::MplsLabel {
+            // RFC 3107 / RFC 8277 IPv4 Labeled-Unicast. The next-hop is
+            // normally IPv4 (4 octets); RFC 8950 permits an IPv6
+            // next-hop (16, or 32 carrying global || link-local — we
+            // surface the global half).
+            let (input, nhop): (&[u8], IpAddr) = match header.nhop_len {
+                4 => {
+                    let (input, addr) = be_u32(input)?;
+                    (input, IpAddr::V4(Ipv4Addr::from(addr)))
+                }
+                16 => {
+                    let (input, addr) = be_u128(input)?;
+                    (input, IpAddr::V6(Ipv6Addr::from(addr)))
+                }
+                32 => {
+                    let (input, global) = be_u128(input)?;
+                    let (input, _link_local) = be_u128(input)?;
+                    (input, IpAddr::V6(Ipv6Addr::from(global)))
+                }
+                _ => return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue))),
+            };
+            let (input, snpa) = be_u8(input)?;
+            let (_, updates) =
+                many0_complete(|i| Labelv4Nlri::parse_nlri(i, add_path)).parse(input)?;
+            let mp_nlri = MpReachAttr::Labelv4 {
+                snpa,
+                nhop,
+                updates,
+            };
+            return Ok((input, mp_nlri));
+        }
+        if header.afi == Afi::Ip6 && header.safi == Safi::MplsLabel {
+            // RFC 3107 / RFC 8277 IPv6 Labeled-Unicast, including RFC
+            // 4798 6PE where the next-hop is an IPv4-mapped IPv6 address.
+            // 16 octets, or 32 carrying global || link-local.
+            let (input, nhop): (&[u8], IpAddr) = match header.nhop_len {
+                16 => {
+                    let (input, addr) = be_u128(input)?;
+                    (input, IpAddr::V6(Ipv6Addr::from(addr)))
+                }
+                32 => {
+                    let (input, global) = be_u128(input)?;
+                    let (input, _link_local) = be_u128(input)?;
+                    (input, IpAddr::V6(Ipv6Addr::from(global)))
+                }
+                _ => return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue))),
+            };
+            let (input, snpa) = be_u8(input)?;
+            let (_, updates) =
+                many0_complete(|i| Labelv6Nlri::parse_nlri(i, add_path)).parse(input)?;
+            let mp_nlri = MpReachAttr::Labelv6 {
                 snpa,
                 nhop,
                 updates,
@@ -487,6 +572,24 @@ impl fmt::Display for MpReachAttr {
                     writeln!(f, " {afi}/flowspec {update}")?;
                 }
             }
+            Labelv4 {
+                snpa: _,
+                nhop,
+                updates,
+            } => {
+                for update in updates.iter() {
+                    writeln!(f, " {update} => {nhop}")?;
+                }
+            }
+            Labelv6 {
+                snpa: _,
+                nhop,
+                updates,
+            } => {
+                for update in updates.iter() {
+                    writeln!(f, " {update} => {nhop}")?;
+                }
+            }
             _ => {
                 //
             }
@@ -679,6 +782,102 @@ pub(crate) fn flowspec_attr_emit(afi: Afi, updates: &[FlowspecNlri], buf: &mut B
     value.put_u8(u8::from(Safi::Flowspec));
     // Next-Hop Length = 0 (no next-hop), then the reserved/SNPA octet.
     value.put_u8(0);
+    value.put_u8(0);
+    for nlri in updates {
+        nlri.nlri_emit(&mut value);
+    }
+
+    let len = value.len();
+    let extended = len > 255;
+    let flags = if extended {
+        AttrFlags::new().with_optional(true).with_extended(true)
+    } else {
+        AttrFlags::new().with_optional(true)
+    };
+    buf.put_u8(flags.into());
+    buf.put_u8(AttrType::MpReachNlri.into());
+    if extended {
+        buf.put_u16(len as u16);
+    } else {
+        buf.put_u8(len as u8);
+    }
+    buf.put(&value[..]);
+}
+
+/// Serialize an `MpReachAttr::Labelv4 { snpa, nhop, updates }` as a
+/// complete `MP_REACH_NLRI` path attribute (header + value).
+///
+/// Wire format (RFC 4760 §3 + RFC 3107 / RFC 8277):
+/// ```text
+///   AFI  (2 octets) = 1 (IPv4)
+///   SAFI (1 octet)  = 4 (MPLS Label)
+///   Nexthop Length (1 octet) = 4 (IPv4) or 16 (IPv6, RFC 8950)
+///   Nexthop Address
+///   Reserved / SNPA (1 octet) = 0
+///   NLRIs (one or more Labelv4Nlri encodings: label + prefix)
+/// ```
+pub(crate) fn labelv4_attr_emit(
+    _snpa: u8,
+    nhop: &IpAddr,
+    updates: &[Labelv4Nlri],
+    buf: &mut BytesMut,
+) {
+    let mut value = BytesMut::new();
+    value.put_u16(u16::from(Afi::Ip));
+    value.put_u8(u8::from(Safi::MplsLabel));
+    match nhop {
+        IpAddr::V4(v4) => {
+            value.put_u8(4);
+            value.put(&v4.octets()[..]);
+        }
+        IpAddr::V6(v6) => {
+            value.put_u8(16);
+            value.put(&v6.octets()[..]);
+        }
+    }
+    // Reserved / SNPA byte, always zero per RFC 4760 §3.
+    value.put_u8(0);
+    for nlri in updates {
+        nlri.nlri_emit(&mut value);
+    }
+
+    let len = value.len();
+    let extended = len > 255;
+    let flags = if extended {
+        AttrFlags::new().with_optional(true).with_extended(true)
+    } else {
+        AttrFlags::new().with_optional(true)
+    };
+    buf.put_u8(flags.into());
+    buf.put_u8(AttrType::MpReachNlri.into());
+    if extended {
+        buf.put_u16(len as u16);
+    } else {
+        buf.put_u8(len as u8);
+    }
+    buf.put(&value[..]);
+}
+
+/// Serialize an `MpReachAttr::Labelv6 { snpa, nhop, updates }` as a
+/// complete `MP_REACH_NLRI` path attribute (header + value), AFI 2 /
+/// SAFI 4. Per RFC 4798 (6PE), an IPv4 `nhop` is emitted as its
+/// IPv4-mapped IPv6 form (`::ffff:a.b.c.d`), so the next-hop is always
+/// 16 octets on the wire.
+pub(crate) fn labelv6_attr_emit(
+    _snpa: u8,
+    nhop: &IpAddr,
+    updates: &[Labelv6Nlri],
+    buf: &mut BytesMut,
+) {
+    let mut value = BytesMut::new();
+    value.put_u16(u16::from(Afi::Ip6));
+    value.put_u8(u8::from(Safi::MplsLabel));
+    value.put_u8(16);
+    match nhop {
+        IpAddr::V6(v6) => value.put(&v6.octets()[..]),
+        IpAddr::V4(v4) => value.put(&v4.to_ipv6_mapped().octets()[..]),
+    }
+    // Reserved / SNPA byte, always zero per RFC 4760 §3.
     value.put_u8(0);
     for nlri in updates {
         nlri.nlri_emit(&mut value);

--- a/crates/bgp-packet/src/attrs/mp_unreach.rs
+++ b/crates/bgp-packet/src/attrs/mp_unreach.rs
@@ -5,8 +5,9 @@ use nom::error::{ErrorKind, make_error};
 use nom_derive::*;
 
 use crate::{
-    Afi, AttrFlags, AttrType, EvpnRoute, FlowspecNlri, Ipv6Nlri, MupRoute, ParseBe, ParseNlri,
-    ParseOption, Rtcv4, Rtcv4Unreach, Safi, Vpnv4Nlri, Vpnv6Nlri, many0_complete,
+    Afi, AttrFlags, AttrType, EvpnRoute, FlowspecNlri, Ipv6Nlri, Labelv4Nlri, Labelv6Nlri,
+    MupRoute, ParseBe, ParseNlri, ParseOption, Rtcv4, Rtcv4Unreach, Safi, Vpnv4Nlri, Vpnv6Nlri,
+    many0_complete,
 };
 
 use super::{AttrEmitter, Vpnv4Unreach, Vpnv6Unreach};
@@ -45,6 +46,12 @@ pub enum MpUnreachAttr {
         afi: Afi,
         withdraws: Vec<FlowspecNlri>,
     },
+    /// IPv4 Labeled-Unicast withdrawals (RFC 3107 / RFC 8277), SAFI 4.
+    Labelv4(Vec<Labelv4Nlri>),
+    Labelv4Eor,
+    /// IPv6 Labeled-Unicast withdrawals (RFC 3107 / RFC 8277), SAFI 4.
+    Labelv6(Vec<Labelv6Nlri>),
+    Labelv6Eor,
 }
 
 impl MpUnreachAttr {
@@ -91,6 +98,18 @@ impl MpUnreachAttr {
             }
             MpUnreachAttr::Flowspec { afi, withdraws } => {
                 flowspec_unreach_attr_emit(*afi, withdraws, buf);
+            }
+            MpUnreachAttr::Labelv4(withdraws) => {
+                labelv4_unreach_attr_emit(withdraws, buf);
+            }
+            MpUnreachAttr::Labelv4Eor => {
+                labelv4_unreach_attr_emit(&[], buf);
+            }
+            MpUnreachAttr::Labelv6(withdraws) => {
+                labelv6_unreach_attr_emit(withdraws, buf);
+            }
+            MpUnreachAttr::Labelv6Eor => {
+                labelv6_unreach_attr_emit(&[], buf);
             }
             _ => {
                 //
@@ -237,6 +256,67 @@ fn flowspec_unreach_attr_emit(afi: Afi, withdraws: &[FlowspecNlri], buf: &mut By
     buf.put(&value[..]);
 }
 
+/// Serialize an `MpUnreachAttr::Labelv4(withdraws)` (or `Labelv4Eor`
+/// when `withdraws` is empty) as a complete `MP_UNREACH_NLRI` path
+/// attribute. The label is carried on the wire (RFC 3107) but ignored
+/// for identity; `Labelv4Nlri::nlri_emit` writes whatever label the
+/// withdraw entry holds.
+///
+/// Wire format (RFC 4760 §4): AFI=1, SAFI=4, then the NLRI list (empty
+/// for end-of-RIB).
+fn labelv4_unreach_attr_emit(withdraws: &[Labelv4Nlri], buf: &mut BytesMut) {
+    let mut value = BytesMut::new();
+    value.put_u16(u16::from(Afi::Ip));
+    value.put_u8(u8::from(Safi::MplsLabel));
+    for nlri in withdraws {
+        nlri.nlri_emit(&mut value);
+    }
+
+    let len = value.len();
+    let extended = len > 255;
+    let flags = if extended {
+        AttrFlags::new().with_optional(true).with_extended(true)
+    } else {
+        AttrFlags::new().with_optional(true)
+    };
+    buf.put_u8(flags.into());
+    buf.put_u8(AttrType::MpUnreachNlri.into());
+    if extended {
+        buf.put_u16(len as u16);
+    } else {
+        buf.put_u8(len as u8);
+    }
+    buf.put(&value[..]);
+}
+
+/// Serialize an `MpUnreachAttr::Labelv6(withdraws)` (or `Labelv6Eor`
+/// when empty) as a complete `MP_UNREACH_NLRI` path attribute, AFI=2,
+/// SAFI=4.
+fn labelv6_unreach_attr_emit(withdraws: &[Labelv6Nlri], buf: &mut BytesMut) {
+    let mut value = BytesMut::new();
+    value.put_u16(u16::from(Afi::Ip6));
+    value.put_u8(u8::from(Safi::MplsLabel));
+    for nlri in withdraws {
+        nlri.nlri_emit(&mut value);
+    }
+
+    let len = value.len();
+    let extended = len > 255;
+    let flags = if extended {
+        AttrFlags::new().with_optional(true).with_extended(true)
+    } else {
+        AttrFlags::new().with_optional(true)
+    };
+    buf.put_u8(flags.into());
+    buf.put_u8(AttrType::MpUnreachNlri.into());
+    if extended {
+        buf.put_u16(len as u16);
+    } else {
+        buf.put_u8(len as u8);
+    }
+    buf.put(&value[..]);
+}
+
 impl MpUnreachAttr {
     pub fn parse_nlri_opt(input: &[u8], opt: Option<ParseOption>) -> nom::IResult<&[u8], Self> {
         // AFI + SAFI = 3.
@@ -281,6 +361,22 @@ impl MpUnreachAttr {
                 many0_complete(|i| Ipv6Nlri::parse_nlri(i, add_path)).parse(input)?;
             let mp_nlri = MpUnreachAttr::Ipv6Nlri(withdrawal);
             return Ok((input, mp_nlri));
+        }
+        if header.afi == Afi::Ip && header.safi == Safi::MplsLabel {
+            if input.is_empty() {
+                return Ok((input, MpUnreachAttr::Labelv4Eor));
+            }
+            let (input, withdrawal) =
+                many0_complete(|i| Labelv4Nlri::parse_nlri(i, add_path)).parse(input)?;
+            return Ok((input, MpUnreachAttr::Labelv4(withdrawal)));
+        }
+        if header.afi == Afi::Ip6 && header.safi == Safi::MplsLabel {
+            if input.is_empty() {
+                return Ok((input, MpUnreachAttr::Labelv6Eor));
+            }
+            let (input, withdrawal) =
+                many0_complete(|i| Labelv6Nlri::parse_nlri(i, add_path)).parse(input)?;
+            return Ok((input, MpUnreachAttr::Labelv6(withdrawal)));
         }
         if header.afi == Afi::L2vpn && header.safi == Safi::Evpn {
             if input.is_empty() {
@@ -446,6 +542,24 @@ impl fmt::Display for MpUnreachAttr {
                     writeln!(f, " {afi}/flowspec {w}")?;
                 }
                 Ok(())
+            }
+            Labelv4(nlris) => {
+                for nlri in nlris.iter() {
+                    writeln!(f, " {nlri}")?;
+                }
+                Ok(())
+            }
+            Labelv4Eor => {
+                writeln!(f, " EoR: {}/{}", Afi::Ip, Safi::MplsLabel)
+            }
+            Labelv6(nlris) => {
+                for nlri in nlris.iter() {
+                    writeln!(f, " {nlri}")?;
+                }
+                Ok(())
+            }
+            Labelv6Eor => {
+                writeln!(f, " EoR: {}/{}", Afi::Ip6, Safi::MplsLabel)
             }
         }
     }

--- a/crates/bgp-packet/src/attrs/nlri_labeled_unicast.rs
+++ b/crates/bgp-packet/src/attrs/nlri_labeled_unicast.rs
@@ -1,0 +1,379 @@
+use std::fmt;
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use bytes::{BufMut, BytesMut};
+use ipnet::{Ipv4Net, Ipv6Net};
+use nom::IResult;
+use nom::bytes::complete::take;
+use nom::error::{ErrorKind, make_error};
+use nom::number::complete::{be_u8, be_u32};
+use nom_derive::*;
+
+use crate::{Ipv4Nlri, Ipv6Nlri, Label, ParseNlri, nlri_psize};
+
+// RFC 3107 / RFC 8277 Labeled-Unicast NLRI:
+//
+//   +---------------------------+
+//   | Length (1 octet, in bits) |
+//   +---------------------------+
+//   | Label (3 octets)          |  <- one or more; BGP-LU uses a single
+//   +---------------------------+     label with the bottom-of-stack bit
+//   | Prefix (variable)         |
+//   +---------------------------+
+//
+// `Length` counts the label (24 bits) plus the prefix bits, so the
+// encoding is identical to a VPNv4/VPNv6 NLRI (`nlri_vpnv4.rs`) minus
+// the 8-octet Route Distinguisher: subtract 24, not 88.
+
+/// IPv4 Labeled-Unicast NLRI (AFI 1, SAFI 4).
+#[derive(Debug, Clone)]
+pub struct Labelv4Nlri {
+    pub label: Label,
+    pub nlri: Ipv4Nlri,
+}
+
+// Identity excludes the MPLS `label`, mirroring `Vpnv4Nlri`: a route is
+// identified by its (prefix, path-id); the label is a forwarding
+// property attached to it and may not be known at every comparison site
+// (e.g. an advertise-cache removal keyed only by prefix). Hashing/eq
+// over the label too would make a default-label removal key miss the
+// cached entry advertised under its real label.
+impl PartialEq for Labelv4Nlri {
+    fn eq(&self, other: &Self) -> bool {
+        self.nlri == other.nlri
+    }
+}
+
+impl Eq for Labelv4Nlri {}
+
+impl std::hash::Hash for Labelv4Nlri {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.nlri.hash(state);
+    }
+}
+
+impl Labelv4Nlri {
+    /// Encode into an MP_REACH / MP_UNREACH NLRI list: optional 4-octet
+    /// AddPath ID, 1-octet length (`prefix_len + 24`), the 3-octet
+    /// label, then the significant prefix octets. Inverse of
+    /// [`Labelv4Nlri::parse_nlri`].
+    pub fn nlri_emit(&self, buf: &mut BytesMut) {
+        if self.nlri.id != 0 {
+            buf.put_u32(self.nlri.id);
+        }
+        let plen = self.nlri.prefix.prefix_len() + 24;
+        buf.put_u8(plen);
+        buf.put(&self.label.to_bytes()[..]);
+        let psize = nlri_psize(self.nlri.prefix.prefix_len());
+        buf.put(&self.nlri.prefix.addr().octets()[0..psize]);
+    }
+}
+
+impl ParseNlri<Labelv4Nlri> for Labelv4Nlri {
+    fn parse_nlri(input: &[u8], add_path: bool) -> IResult<&[u8], Labelv4Nlri> {
+        let (input, id) = if add_path { be_u32(input)? } else { (input, 0) };
+
+        // Length (bits) covers the 24-bit label plus the prefix.
+        let (input, mut plen) = be_u8(input)?;
+        if plen < 24 {
+            return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+        }
+        let psize = nlri_psize(plen);
+        if input.len() < psize {
+            return Err(nom::Err::Error(make_error(input, ErrorKind::Eof)));
+        }
+
+        // 3-octet MPLS label. BGP-LU advertises a single label; a deeper
+        // stack (BoS=0) is not emitted in practice, so we read exactly
+        // one and treat the rest of the length as prefix.
+        let (input, label) = take(3usize).parse(input)?;
+        let label = Label::from(label);
+
+        plen -= 24;
+        let psize = nlri_psize(plen);
+        if psize > 4 {
+            return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+        }
+        if psize > input.len() {
+            return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+        }
+
+        let mut paddr = [0u8; 4];
+        paddr[..psize].copy_from_slice(&input[..psize]);
+        let (input, _) = take(psize).parse(input)?;
+        let prefix = Ipv4Net::new(Ipv4Addr::from(paddr), plen).expect("Ipv4Net create error");
+
+        let nlri = Ipv4Nlri { id, prefix };
+        Ok((input, Labelv4Nlri { label, nlri }))
+    }
+}
+
+impl fmt::Display for Labelv4Nlri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let bos = if self.label.bos { " (BoS)" } else { "" };
+        write!(
+            f,
+            "{}:{} label: {}{}",
+            self.nlri.id, self.nlri.prefix, self.label.label, bos,
+        )
+    }
+}
+
+/// IPv6 Labeled-Unicast NLRI (AFI 2, SAFI 4). Also carries 6PE routes
+/// (RFC 4798) — the NLRI is identical; only the MP_REACH next-hop
+/// differs (an IPv4-mapped IPv6 address), which is handled at emit time.
+#[derive(Debug, Clone)]
+pub struct Labelv6Nlri {
+    pub label: Label,
+    pub nlri: Ipv6Nlri,
+}
+
+impl PartialEq for Labelv6Nlri {
+    fn eq(&self, other: &Self) -> bool {
+        self.nlri == other.nlri
+    }
+}
+
+impl Eq for Labelv6Nlri {}
+
+impl std::hash::Hash for Labelv6Nlri {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.nlri.hash(state);
+    }
+}
+
+impl Labelv6Nlri {
+    /// See [`Labelv4Nlri::nlri_emit`]; identical layout over an IPv6
+    /// prefix.
+    pub fn nlri_emit(&self, buf: &mut BytesMut) {
+        if self.nlri.id != 0 {
+            buf.put_u32(self.nlri.id);
+        }
+        let plen = self.nlri.prefix.prefix_len() + 24;
+        buf.put_u8(plen);
+        buf.put(&self.label.to_bytes()[..]);
+        let psize = nlri_psize(self.nlri.prefix.prefix_len());
+        buf.put(&self.nlri.prefix.addr().octets()[0..psize]);
+    }
+}
+
+impl ParseNlri<Labelv6Nlri> for Labelv6Nlri {
+    fn parse_nlri(input: &[u8], add_path: bool) -> IResult<&[u8], Labelv6Nlri> {
+        let (input, id) = if add_path { be_u32(input)? } else { (input, 0) };
+
+        let (input, mut plen) = be_u8(input)?;
+        if plen < 24 {
+            return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+        }
+        let psize = nlri_psize(plen);
+        if input.len() < psize {
+            return Err(nom::Err::Error(make_error(input, ErrorKind::Eof)));
+        }
+
+        let (input, label) = take(3usize).parse(input)?;
+        let label = Label::from(label);
+
+        plen -= 24;
+        let psize = nlri_psize(plen);
+        if psize > 16 {
+            return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+        }
+        if psize > input.len() {
+            return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+        }
+
+        let mut paddr = [0u8; 16];
+        paddr[..psize].copy_from_slice(&input[..psize]);
+        let (input, _) = take(psize).parse(input)?;
+        let prefix = Ipv6Net::new(Ipv6Addr::from(paddr), plen).expect("Ipv6Net create error");
+
+        let nlri = Ipv6Nlri { id, prefix };
+        Ok((input, Labelv6Nlri { label, nlri }))
+    }
+}
+
+impl fmt::Display for Labelv6Nlri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let bos = if self.label.bos { " (BoS)" } else { "" };
+        write!(
+            f,
+            "{}:{} label: {}{}",
+            self.nlri.id, self.nlri.prefix, self.label.label, bos,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+
+    use super::*;
+    use crate::{MpReachAttr, MpUnreachAttr};
+
+    fn v4(prefix: &str, label: u32) -> Labelv4Nlri {
+        Labelv4Nlri {
+            label: Label::new(label, 0, true),
+            nlri: Ipv4Nlri {
+                id: 0,
+                prefix: prefix.parse().unwrap(),
+            },
+        }
+    }
+
+    fn v6(prefix: &str, label: u32) -> Labelv6Nlri {
+        Labelv6Nlri {
+            label: Label::new(label, 0, true),
+            nlri: Ipv6Nlri {
+                id: 0,
+                prefix: prefix.parse().unwrap(),
+            },
+        }
+    }
+
+    #[test]
+    fn labelv4_reach_round_trips() {
+        let reach = MpReachAttr::Labelv4 {
+            snpa: 0,
+            nhop: "10.0.0.1".parse::<IpAddr>().unwrap(),
+            updates: vec![v4("10.1.0.0/24", 24000), v4("10.2.0.0/16", 24001)],
+        };
+        let mut buf = BytesMut::new();
+        reach.attr_emit(&mut buf);
+        // Strip the 3-byte path-attribute header (flags + type + len).
+        let (_rest, parsed) =
+            MpReachAttr::parse_nlri_opt(&buf[3..], None).expect("Labelv4 MP_REACH must parse");
+        match parsed {
+            MpReachAttr::Labelv4 { nhop, updates, .. } => {
+                assert_eq!(nhop, "10.0.0.1".parse::<IpAddr>().unwrap());
+                assert_eq!(updates.len(), 2);
+                assert_eq!(updates[0].nlri.prefix, "10.1.0.0/24".parse().unwrap());
+                assert_eq!(updates[0].label.label, 24000);
+                assert!(updates[0].label.bos);
+                assert_eq!(updates[1].nlri.prefix, "10.2.0.0/16".parse().unwrap());
+                assert_eq!(updates[1].label.label, 24001);
+            }
+            other => panic!("expected Labelv4, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn labelv4_reach_round_trips_ipv6_nexthop() {
+        // RFC 8950: IPv4 labeled-unicast advertised with an IPv6 next-hop.
+        let addr: IpAddr = "2001:db8::1".parse().unwrap();
+        let reach = MpReachAttr::Labelv4 {
+            snpa: 0,
+            nhop: addr,
+            updates: vec![v4("192.0.2.0/24", 100)],
+        };
+        let mut buf = BytesMut::new();
+        reach.attr_emit(&mut buf);
+        let (_rest, parsed) = MpReachAttr::parse_nlri_opt(&buf[3..], None).expect("parse");
+        match parsed {
+            MpReachAttr::Labelv4 { nhop, updates, .. } => {
+                assert_eq!(nhop, addr);
+                assert_eq!(updates[0].nlri.prefix, "192.0.2.0/24".parse().unwrap());
+            }
+            other => panic!("expected Labelv4, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn labelv6_reach_round_trips() {
+        let addr: IpAddr = "2001:db8::1".parse().unwrap();
+        let reach = MpReachAttr::Labelv6 {
+            snpa: 0,
+            nhop: addr,
+            updates: vec![v6("2001:db8:1::/64", 24010)],
+        };
+        let mut buf = BytesMut::new();
+        reach.attr_emit(&mut buf);
+        let (_rest, parsed) =
+            MpReachAttr::parse_nlri_opt(&buf[3..], None).expect("Labelv6 MP_REACH must parse");
+        match parsed {
+            MpReachAttr::Labelv6 { nhop, updates, .. } => {
+                assert_eq!(nhop, addr);
+                assert_eq!(updates.len(), 1);
+                assert_eq!(updates[0].nlri.prefix, "2001:db8:1::/64".parse().unwrap());
+                assert_eq!(updates[0].label.label, 24010);
+            }
+            other => panic!("expected Labelv6, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn labelv6_reach_6pe_ipv4_mapped_nexthop() {
+        // RFC 4798 (6PE): an IPv4 next-hop is encoded as its IPv4-mapped
+        // IPv6 form on the wire, and parses back as that IPv6 address.
+        let reach = MpReachAttr::Labelv6 {
+            snpa: 0,
+            nhop: "10.0.0.1".parse::<IpAddr>().unwrap(),
+            updates: vec![v6("2001:db8:5::/48", 500)],
+        };
+        let mut buf = BytesMut::new();
+        reach.attr_emit(&mut buf);
+        let (_rest, parsed) = MpReachAttr::parse_nlri_opt(&buf[3..], None).expect("parse");
+        match parsed {
+            MpReachAttr::Labelv6 { nhop, updates, .. } => {
+                let mapped: IpAddr = "::ffff:10.0.0.1".parse().unwrap();
+                assert_eq!(nhop, mapped);
+                assert_eq!(updates[0].nlri.prefix, "2001:db8:5::/48".parse().unwrap());
+            }
+            other => panic!("expected Labelv6, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn labelv4_unreach_round_trips() {
+        let unreach = MpUnreachAttr::Labelv4(vec![v4("10.9.0.0/24", 24099)]);
+        let mut buf = BytesMut::new();
+        unreach.attr_emit(&mut buf);
+        let (_rest, parsed) =
+            MpUnreachAttr::parse_nlri_opt(&buf[3..], None).expect("Labelv4 MP_UNREACH must parse");
+        match parsed {
+            MpUnreachAttr::Labelv4(w) => {
+                assert_eq!(w.len(), 1);
+                assert_eq!(w[0].nlri.prefix, "10.9.0.0/24".parse().unwrap());
+            }
+            other => panic!("expected Labelv4, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn labelv4_unreach_empty_is_eor() {
+        let mut buf = BytesMut::new();
+        MpUnreachAttr::Labelv4Eor.attr_emit(&mut buf);
+        let (_rest, parsed) =
+            MpUnreachAttr::parse_nlri_opt(&buf[3..], None).expect("Labelv4 EoR must parse");
+        assert!(matches!(parsed, MpUnreachAttr::Labelv4Eor));
+    }
+
+    #[test]
+    fn labelv6_unreach_round_trips() {
+        let unreach = MpUnreachAttr::Labelv6(vec![v6("2001:db8:9::/56", 24199)]);
+        let mut buf = BytesMut::new();
+        unreach.attr_emit(&mut buf);
+        let (_rest, parsed) =
+            MpUnreachAttr::parse_nlri_opt(&buf[3..], None).expect("Labelv6 MP_UNREACH must parse");
+        match parsed {
+            MpUnreachAttr::Labelv6(w) => {
+                assert_eq!(w.len(), 1);
+                assert_eq!(w[0].nlri.prefix, "2001:db8:9::/56".parse().unwrap());
+            }
+            other => panic!("expected Labelv6, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn identity_ignores_label() {
+        use std::collections::HashSet;
+        // Same prefix, different label → equal + same hash, so a route
+        // advertised+cached under its real label is still found and
+        // removed by a default-label key.
+        let advertised = v4("10.0.0.0/24", 80);
+        let remove_key = v4("10.0.0.0/24", 0);
+        assert_eq!(advertised, remove_key);
+        let mut set = HashSet::new();
+        set.insert(advertised);
+        assert!(set.remove(&remove_key), "default-label key matches");
+    }
+}


### PR DESCRIPTION
Phase 1 of BGP Labeled Unicast (SAFI 4) support — the wire codec, in the `bgp-packet` crate. Control-plane-first; this PR is purely the NLRI encode/decode and is independently testable.

## What

`Safi::MplsLabel = 4` already existed; this adds the NLRI types that ride it.

- **`nlri_labeled_unicast.rs`**: `Labelv4Nlri` / `Labelv6Nlri` — a 3-octet MPLS label plus an IPv4/IPv6 prefix, with `parse_nlri` + `nlri_emit`. The layout mirrors the VPNv4/VPNv6 NLRI minus the 8-octet Route Distinguisher: the length field counts the label (24 bits) plus the prefix, so we subtract 24, not 88. Identity (`PartialEq`/`Eq`/`Hash`) excludes the label — same reasoning as `Vpnv4Nlri` — so a prefix-keyed advertise-cache removal still matches an entry cached under its real label.
- **`MpReachAttr::Labelv4 / Labelv6`** and **`MpUnreachAttr::Labelv4(Eor) / Labelv6(Eor)`** variants, with decode in `parse_nlri_opt` for `(Ip, MplsLabel)` and `(Ip6, MplsLabel)`, plus matching emit helpers.
- **Next-hop**: IPv4 LU accepts a v4 (4 octets) or v6 (16/32, RFC 8950) next-hop; IPv6 LU is 16 octets, and an IPv4 next-hop is emitted as its IPv4-mapped IPv6 form for 6PE (RFC 4798).

## Tests

8 round-trip tests (v4, v6, 6PE IPv4-mapped next-hop, withdraw, EoR, label-ignored-identity). `cargo test -p bgp-packet` green; workspace `clippy --all-targets -D warnings` clean.

## Follow-ups (next phases)

YANG `label-v4`/`label-v6` + config (capability negotiation) → Loc-RIB ingest + show → advertise/originate → MPLS dataplane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)