### PR TITLE
bgp: negotiate label-v4 / label-v6 afi-safi (BGP-LU capability)

### DIFF
--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -127,6 +127,8 @@ impl Args {
         match item.as_str() {
             "ipv4" => Some(AfiSafi::new(Afi::Ip, Safi::Unicast)),
             "ipv6" => Some(AfiSafi::new(Afi::Ip6, Safi::Unicast)),
+            "label-v4" => Some(AfiSafi::new(Afi::Ip, Safi::MplsLabel)),
+            "label-v6" => Some(AfiSafi::new(Afi::Ip6, Safi::MplsLabel)),
             "vpnv4" => Some(AfiSafi::new(Afi::Ip, Safi::MplsVpn)),
             "vpnv6" => Some(AfiSafi::new(Afi::Ip6, Safi::MplsVpn)),
             "evpn" => Some(AfiSafi::new(Afi::L2vpn, Safi::Evpn)),

--- a/zebra-rs/yang/zebra-afi-safi.yang
+++ b/zebra-rs/yang/zebra-afi-safi.yang
@@ -19,10 +19,10 @@ module zebra-afi-safi {
      Two flavors are provided as groupings supplying the `name` key of
      an `afi-safi` list:
 
-       * `afi-safi`         — the full BGP set (ipv4, ipv6, vpnv4,
-                              vpnv6, evpn, rtcv4, rtcv6). Used by
-                              `router bgp` (global + per-neighbor
-                              afi-safi).
+       * `afi-safi`         — the full BGP set (ipv4, ipv6, label-v4,
+                              label-v6, vpnv4, vpnv6, evpn, rtcv4,
+                              rtcv6). Used by `router bgp` (global +
+                              per-neighbor afi-safi).
        * `afi-safi-unicast` — the unicast subset (ipv4, ipv6). Used by
                               `router isis` and the per-VRF BGP afi-safi
                               (which carries the same family names).
@@ -42,6 +42,15 @@ module zebra-afi-safi {
         }
         enum ipv6 {
           description "IPv6 unicast (AFI 2, SAFI 1).";
+        }
+        enum label-v4 {
+          description
+            "IPv4 Labeled Unicast (AFI 1, SAFI 4); RFC 3107 / RFC 8277.";
+        }
+        enum label-v6 {
+          description
+            "IPv6 Labeled Unicast (AFI 2, SAFI 4); RFC 3107 / RFC 8277,
+             incl. 6PE (RFC 4798).";
         }
         enum vpnv4 {
           description "MPLS-labeled VPN-IPv4 (AFI 1, SAFI 128).";


### PR DESCRIPTION
Phase 2 of BGP Labeled Unicast (SAFI 4). Names the two families so a neighbor can enable them and the MP-BGP capability is advertised in OPEN. Control-plane only — no Loc-RIB / forwarding yet.

> Stacked on #1042 (codec). Base is `bgp-lu-codec`; GitHub will retarget to `main` once #1042 merges.

## What

- **`zebra-afi-safi.yang`**: add `label-v4` (AFI 1, SAFI 4) and `label-v6` (AFI 2, SAFI 4) to the `afi-safi` grouping enum. Both the global `router bgp afi-safi` list and the per-neighbor list `uses zas:afi-safi`, so the names are valid in both.
- **`configs.rs` `Args::afi_safi`**: map `label-v4` → `(Ip, MplsLabel)` and `label-v6` → `(Ip6, MplsLabel)`.

No other Rust changes are needed: `config_afi_safi` stores any `AfiSafi` in `peer.config.mp`, and `build_open_packet` already emits a `CapMultiProtocol` per enabled family. So

```
neighbor 10.0.0.1 {
  afi-safi label-v4 { enable true; }
  afi-safi label-v6 { enable true; }
}
```

makes the peer advertise SAFI 4 (AFI 1/2) in its OPEN.

## Tests

`yang_load_tests` (configure + exec) pass — the hand-edited YANG still loads. Workspace `clippy --all-targets -D warnings` clean.

## Follow-ups

Loc-RIB ingest + show → advertise/originate (propagate-received, redistribute, network, 6PE) → MPLS dataplane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)