### PR TITLE
bgp: Loc-RIB ingest + show for Labeled Unicast (SAFI 4)

### DIFF
--- a/zebra-rs/src/bgp/adj_rib.rs
+++ b/zebra-rs/src/bgp/adj_rib.rs
@@ -143,6 +143,10 @@ pub struct AdjRib<D: RibDirection> {
     pub v4: AdjRibTable<D>,
     // IPv6 unicast
     pub v6: AdjRibTable<D, Ipv6Net>,
+    // IPv4 Labeled-Unicast (SAFI 4)
+    pub v4lu: AdjRibTable<D>,
+    // IPv6 Labeled-Unicast (SAFI 4)
+    pub v6lu: AdjRibTable<D, Ipv6Net>,
     // IPv4 VPN
     pub v4vpn: BTreeMap<RouteDistinguisher, AdjRibTable<D>>,
     // IPv6 VPN
@@ -156,6 +160,8 @@ impl<D: RibDirection> AdjRib<D> {
         Self {
             v4: AdjRibTable::new(),
             v6: AdjRibTable::new(),
+            v4lu: AdjRibTable::new(),
+            v6lu: AdjRibTable::new(),
             v4vpn: BTreeMap::new(),
             v6vpn: BTreeMap::new(),
             evpn: BTreeMap::new(),
@@ -207,6 +213,24 @@ impl AdjRib<In> {
         self.v6.remove(prefix, id)
     }
 
+    // IPv4 / IPv6 Labeled-Unicast (SAFI 4) add/remove.
+
+    pub fn add_v4lu(&mut self, prefix: Ipv4Net, route: BgpRib) -> Option<BgpRib> {
+        self.v4lu.add(prefix, route)
+    }
+
+    pub fn remove_v4lu(&mut self, prefix: Ipv4Net, id: u32) -> Option<BgpRib> {
+        self.v4lu.remove(prefix, id)
+    }
+
+    pub fn add_v6lu(&mut self, prefix: Ipv6Net, route: BgpRib) -> Option<BgpRib> {
+        self.v6lu.add(prefix, route)
+    }
+
+    pub fn remove_v6lu(&mut self, prefix: Ipv6Net, id: u32) -> Option<BgpRib> {
+        self.v6lu.remove(prefix, id)
+    }
+
     pub fn add_v6vpn(
         &mut self,
         rd: RouteDistinguisher,
@@ -249,6 +273,8 @@ impl AdjRib<In> {
         match (afi, safi) {
             (Afi::Ip, Safi::Unicast) => self.v4.0.len(),
             (Afi::Ip6, Safi::Unicast) => self.v6.0.len(),
+            (Afi::Ip, Safi::MplsLabel) => self.v4lu.0.len(),
+            (Afi::Ip6, Safi::MplsLabel) => self.v6lu.0.len(),
             (Afi::Ip, Safi::MplsVpn) => self.v4vpn.values().map(|table| table.0.len()).sum(),
             (Afi::Ip6, Safi::MplsVpn) => self.v6vpn.values().map(|table| table.0.len()).sum(),
             (Afi::L2vpn, Safi::Evpn) => self.evpn.values().map(|table| table.0.len()).sum(),
@@ -288,6 +314,8 @@ impl AdjRib<Out> {
         match (afi, safi) {
             (Afi::Ip, Safi::Unicast) => self.v4.0.len(),
             (Afi::Ip6, Safi::Unicast) => self.v6.0.len(),
+            (Afi::Ip, Safi::MplsLabel) => self.v4lu.0.len(),
+            (Afi::Ip6, Safi::MplsLabel) => self.v6lu.0.len(),
             (Afi::Ip, Safi::MplsVpn) => self.v4vpn.values().map(|table| table.0.len()).sum(),
             (Afi::Ip6, Safi::MplsVpn) => self.v6vpn.values().map(|table| table.0.len()).sum(),
             (Afi::L2vpn, Safi::Evpn) => self.evpn.values().map(|table| table.0.len()).sum(),

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -934,6 +934,12 @@ pub struct LocalRib {
 
     pub v6: LocalRibTable<Ipv6Net>,
 
+    /// IPv4 / IPv6 Labeled-Unicast (SAFI 4) Loc-RIB. Same prefix key as
+    /// unicast; each `BgpRib` carries the per-prefix label.
+    pub v4lu: LocalRibTable<Ipv4Net>,
+
+    pub v6lu: LocalRibTable<Ipv6Net>,
+
     pub v4vpn: BTreeMap<RouteDistinguisher, LocalRibTable<Ipv4Net>>,
 
     pub v6vpn: BTreeMap<RouteDistinguisher, LocalRibTable<Ipv6Net>>,
@@ -995,6 +1001,32 @@ impl LocalRib {
 
     pub fn select_best_path_v6(&mut self, prefix: Ipv6Net) -> Vec<BgpRib> {
         self.v6.select_best_path(prefix)
+    }
+
+    // IPv4 / IPv6 Labeled-Unicast (SAFI 4) accessors. Same Loc-RIB
+    // engine as unicast; the per-prefix label travels on each `BgpRib`.
+    pub fn update_v4lu(&mut self, prefix: Ipv4Net, rib: BgpRib) -> (Vec<BgpRib>, Vec<BgpRib>, u32) {
+        self.v4lu.update(prefix, rib)
+    }
+
+    pub fn remove_v4lu(&mut self, prefix: Ipv4Net, id: u32, ident: usize) -> Vec<BgpRib> {
+        self.v4lu.remove(prefix, id, ident)
+    }
+
+    pub fn select_best_path_v4lu(&mut self, prefix: Ipv4Net) -> Vec<BgpRib> {
+        self.v4lu.select_best_path(prefix)
+    }
+
+    pub fn update_v6lu(&mut self, prefix: Ipv6Net, rib: BgpRib) -> (Vec<BgpRib>, Vec<BgpRib>, u32) {
+        self.v6lu.update(prefix, rib)
+    }
+
+    pub fn remove_v6lu(&mut self, prefix: Ipv6Net, id: u32, ident: usize) -> Vec<BgpRib> {
+        self.v6lu.remove(prefix, id, ident)
+    }
+
+    pub fn select_best_path_v6lu(&mut self, prefix: Ipv6Net) -> Vec<BgpRib> {
+        self.v6lu.select_best_path(prefix)
     }
 
     // VPNv6 accessors — per-RD `v6vpn` tables, mirroring the v4vpn
@@ -2775,6 +2807,183 @@ pub fn route_ipv6_withdraw(
     }
 }
 
+/// Ingest a received IPv4 Labeled-Unicast (SAFI 4) route into the
+/// `v4lu` Loc-RIB. Control-plane only: the per-prefix label is stored on
+/// the `BgpRib`, the MP_REACH next-hop is stamped into the attr so
+/// best-path / show read it, and best-path runs. NHT gating, FIB
+/// install (label-push) and peer re-advertisement land in later phases,
+/// so this mirrors the v6-unicast ingest minus those steps.
+pub fn route_labelv4_update(
+    ident: usize,
+    lu: &Labelv4Nlri,
+    nhop: IpAddr,
+    attr: &BgpAttr,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+    stale: bool,
+) {
+    let (peer_ident, peer_router_id, typ) = {
+        let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+
+        // RFC 4271 / 4456 loop detection — identical to the unicast path.
+        if let Some(ref aspath) = attr.aspath {
+            for segment in &aspath.segs {
+                if segment.asn.contains(&peer.local_as) {
+                    return;
+                }
+            }
+        }
+        if let Some(ref originator_id) = attr.originator_id
+            && originator_id.id == *bgp.router_id
+        {
+            return;
+        }
+        if let Some(ref cluster_list) = attr.cluster_list
+            && cluster_list.list.contains(bgp.router_id)
+        {
+            return;
+        }
+
+        let typ = if peer.is_ibgp() {
+            BgpRibType::IBGP
+        } else {
+            BgpRibType::EBGP
+        };
+        (peer.ident, peer.remote_id, typ)
+    };
+
+    // Stamp the MP_REACH next-hop so best-path / show read the LU
+    // next-hop rather than the (often absent) NEXT_HOP attribute.
+    let mut attr = attr.clone();
+    attr.nexthop = Some(match nhop {
+        IpAddr::V4(v4) => BgpNexthop::Ipv4(v4),
+        IpAddr::V6(v6) => BgpNexthop::Ipv6(v6),
+    });
+
+    let mut rib = BgpRib::new(
+        peer_ident,
+        peer_router_id,
+        typ,
+        lu.nlri.id,
+        0,
+        &attr,
+        Some(lu.label),
+        None,
+        stale,
+    );
+
+    {
+        let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+        peer.adj_in.add_v4lu(lu.nlri.prefix, rib.clone());
+    }
+
+    rib.attr = bgp.attr_store.intern(attr);
+    let _ = bgp.local_rib.update_v4lu(lu.nlri.prefix, rib);
+}
+
+/// Ingest a received IPv6 Labeled-Unicast (SAFI 4) route — including
+/// 6PE — into the `v6lu` Loc-RIB. See [`route_labelv4_update`].
+pub fn route_labelv6_update(
+    ident: usize,
+    lu: &Labelv6Nlri,
+    nhop: IpAddr,
+    attr: &BgpAttr,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+    stale: bool,
+) {
+    let (peer_ident, peer_router_id, typ) = {
+        let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+
+        if let Some(ref aspath) = attr.aspath {
+            for segment in &aspath.segs {
+                if segment.asn.contains(&peer.local_as) {
+                    return;
+                }
+            }
+        }
+        if let Some(ref originator_id) = attr.originator_id
+            && originator_id.id == *bgp.router_id
+        {
+            return;
+        }
+        if let Some(ref cluster_list) = attr.cluster_list
+            && cluster_list.list.contains(bgp.router_id)
+        {
+            return;
+        }
+
+        let typ = if peer.is_ibgp() {
+            BgpRibType::IBGP
+        } else {
+            BgpRibType::EBGP
+        };
+        (peer.ident, peer.remote_id, typ)
+    };
+
+    let mut attr = attr.clone();
+    attr.nexthop = Some(match nhop {
+        IpAddr::V4(v4) => BgpNexthop::Ipv4(v4),
+        IpAddr::V6(v6) => BgpNexthop::Ipv6(v6),
+    });
+
+    let mut rib = BgpRib::new(
+        peer_ident,
+        peer_router_id,
+        typ,
+        lu.nlri.id,
+        0,
+        &attr,
+        Some(lu.label),
+        None,
+        stale,
+    );
+
+    {
+        let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+        peer.adj_in.add_v6lu(lu.nlri.prefix, rib.clone());
+    }
+
+    rib.attr = bgp.attr_store.intern(attr);
+    let _ = bgp.local_rib.update_v6lu(lu.nlri.prefix, rib);
+}
+
+/// Withdraw a received IPv4 Labeled-Unicast route (MP_UNREACH or
+/// session teardown). Identity is (prefix, path-id); the on-wire label
+/// is not part of it. Removes from Adj-RIB-In and the `v4lu` Loc-RIB and
+/// recomputes best-path so `show` stays consistent.
+pub fn route_labelv4_withdraw(
+    ident: usize,
+    nlri: &Ipv4Nlri,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+    rib_in: bool,
+) {
+    if rib_in {
+        let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+        peer.adj_in.remove_v4lu(nlri.prefix, nlri.id);
+    }
+    let _ = bgp.local_rib.remove_v4lu(nlri.prefix, nlri.id, ident);
+    let _ = bgp.local_rib.select_best_path_v4lu(nlri.prefix);
+}
+
+/// Withdraw a received IPv6 Labeled-Unicast route. See
+/// [`route_labelv4_withdraw`].
+pub fn route_labelv6_withdraw(
+    ident: usize,
+    nlri: &Ipv6Nlri,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+    rib_in: bool,
+) {
+    if rib_in {
+        let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+        peer.adj_in.remove_v6lu(nlri.prefix, nlri.id);
+    }
+    let _ = bgp.local_rib.remove_v6lu(nlri.prefix, nlri.id, ident);
+    let _ = bgp.local_rib.select_best_path_v6lu(nlri.prefix);
+}
+
 pub fn route_ipv4_rtc_update(peer_id: usize, rtcv4: &Rtcv4, peers: &mut PeerMap) {
     let Some(peer) = peers.get_mut_by_idx(peer_id) else {
         return;
@@ -3372,6 +3581,28 @@ pub fn route_from_peer(
                     );
                 }
             }
+            MpReachAttr::Labelv4 {
+                snpa: _,
+                nhop,
+                updates,
+            } => {
+                // IPv4 Labeled-Unicast (SAFI 4): store each route in the
+                // v4lu Loc-RIB with its per-prefix label. The MP_REACH
+                // next-hop is authoritative.
+                for update in updates.iter() {
+                    route_labelv4_update(peer_id, update, nhop, bgp_attr, bgp, peers, false);
+                }
+            }
+            MpReachAttr::Labelv6 {
+                snpa: _,
+                nhop,
+                updates,
+            } => {
+                // IPv6 Labeled-Unicast (SAFI 4), including 6PE.
+                for update in updates.iter() {
+                    route_labelv6_update(peer_id, update, nhop, bgp_attr, bgp, peers, false);
+                }
+            }
             _ => {
                 //
             }
@@ -3438,6 +3669,28 @@ pub fn route_from_peer(
             }
             MpUnreachAttr::Vpnv6Eor => {
                 let afi_safi = AfiSafi::new(Afi::Ip6, Safi::MplsVpn);
+                let _ = bgp
+                    .tx
+                    .send(Message::Event(peer_id, Event::StaleTimerExipires(afi_safi)));
+            }
+            MpUnreachAttr::Labelv4(withdrawals) => {
+                for withdraw in withdrawals.iter() {
+                    route_labelv4_withdraw(peer_id, &withdraw.nlri, bgp, peers, true);
+                }
+            }
+            MpUnreachAttr::Labelv4Eor => {
+                let afi_safi = AfiSafi::new(Afi::Ip, Safi::MplsLabel);
+                let _ = bgp
+                    .tx
+                    .send(Message::Event(peer_id, Event::StaleTimerExipires(afi_safi)));
+            }
+            MpUnreachAttr::Labelv6(withdrawals) => {
+                for withdraw in withdrawals.iter() {
+                    route_labelv6_withdraw(peer_id, &withdraw.nlri, bgp, peers, true);
+                }
+            }
+            MpUnreachAttr::Labelv6Eor => {
+                let afi_safi = AfiSafi::new(Afi::Ip6, Safi::MplsLabel);
                 let _ = bgp
                     .tx
                     .send(Message::Event(peer_id, Event::StaleTimerExipires(afi_safi)));
@@ -3683,6 +3936,47 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
     peer.cache_evpn.clear();
     peer.cache_evpn_rev.clear();
     peer.cache_evpn_timer = None;
+
+    // IPv4 / IPv6 Labeled-Unicast (SAFI 4). No LLGR handling yet —
+    // withdraw every labeled route the peer gave us and clear the
+    // Adj-RIB tables, mirroring the unicast block above.
+    let withdrawn_v4lu = {
+        let mut withdrawn: Vec<Ipv4Nlri> = vec![];
+        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+        for (prefix, ribs) in peer.adj_in.v4lu.0.iter() {
+            for rib in ribs.iter() {
+                withdrawn.push(Ipv4Nlri {
+                    id: rib.remote_id,
+                    prefix: *prefix,
+                });
+            }
+        }
+        withdrawn
+    };
+    for withdraw in withdrawn_v4lu.iter() {
+        route_labelv4_withdraw(peer_id, withdraw, bgp, peers, true);
+    }
+    let withdrawn_v6lu = {
+        let mut withdrawn: Vec<Ipv6Nlri> = vec![];
+        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+        for (prefix, ribs) in peer.adj_in.v6lu.0.iter() {
+            for rib in ribs.iter() {
+                withdrawn.push(Ipv6Nlri {
+                    id: rib.remote_id,
+                    prefix: *prefix,
+                });
+            }
+        }
+        withdrawn
+    };
+    for withdraw in withdrawn_v6lu.iter() {
+        route_labelv6_withdraw(peer_id, withdraw, bgp, peers, true);
+    }
+    let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+    peer.adj_in.v4lu.0.clear();
+    peer.adj_in.v6lu.0.clear();
+    peer.adj_out.v4lu.0.clear();
+    peer.adj_out.v6lu.0.clear();
 
     peer.cap_map = CapAfiMap::new();
     peer.cap_recv = BgpCap::default();

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -12,7 +12,7 @@ use super::peer::{Peer, PeerCounter, PeerParam, State};
 use super::peer_map::PeerMap;
 use super::route::LocalRib;
 use super::vrf::inst::BgpVrf;
-use crate::bgp::{AdjRibEvpnTable, AdjRibTable, BgpRibType, RibDirection};
+use crate::bgp::{AdjRibEvpnTable, AdjRibTable, BgpRib, BgpRibType, RibDirection};
 use crate::config::Args;
 use crate::config::{DisplayRequest, path_from_command};
 
@@ -107,6 +107,9 @@ fn configured_afi_safis<V: BgpShowView>(bgp: &V) -> Vec<AfiSafi> {
 fn rib_entries_count<V: BgpShowView>(bgp: &V, afi_safi: &AfiSafi) -> usize {
     match (afi_safi.afi, afi_safi.safi) {
         (Afi::Ip, Safi::Unicast) => bgp.local_rib().v4.0.len(),
+        (Afi::Ip6, Safi::Unicast) => bgp.local_rib().v6.0.len(),
+        (Afi::Ip, Safi::MplsLabel) => bgp.local_rib().v4lu.0.len(),
+        (Afi::Ip6, Safi::MplsLabel) => bgp.local_rib().v6lu.0.len(),
         (Afi::Ip, Safi::MplsVpn) => bgp.local_rib().v4vpn.values().map(|t| t.0.len()).sum(),
         (Afi::L2vpn, Safi::Evpn) => bgp.local_rib().evpn.values().map(|t| t.cands.len()).sum(),
         _ => 0,
@@ -461,6 +464,72 @@ fn show_bgp<V: BgpShowView>(
         }
     }
     Ok(buf)
+}
+
+/// `show ip bgp labeled-unicast` — render the IPv4 and IPv6
+/// Labeled-Unicast (SAFI 4) Loc-RIBs. Same columns as `show ip bgp`
+/// plus a Label column carrying the per-prefix MPLS label. JSON output
+/// is not yet defined (mirrors `show_bgp_evpn`); returns an empty array.
+fn show_bgp_labeled(
+    bgp: &Bgp,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    if json {
+        return Ok("[]".to_string());
+    }
+
+    let mut buf = String::new();
+    buf.push_str(SHOW_BGP_HEADER);
+
+    writeln!(buf, "IPv4 Labeled Unicast:")?;
+    for (key, value) in bgp.local_rib.v4lu.0.iter() {
+        for rib in value.iter() {
+            show_labeled_row(&mut buf, &key.to_string(), rib)?;
+        }
+    }
+    writeln!(buf, "IPv6 Labeled Unicast:")?;
+    for (key, value) in bgp.local_rib.v6lu.0.iter() {
+        for rib in value.iter() {
+            show_labeled_row(&mut buf, &key.to_string(), rib)?;
+        }
+    }
+    Ok(buf)
+}
+
+/// One labeled-unicast row: the unicast columns from `show ip bgp` plus
+/// the per-prefix label (or `-` when absent).
+fn show_labeled_row(
+    buf: &mut String,
+    prefix: &str,
+    rib: &BgpRib,
+) -> std::result::Result<(), std::fmt::Error> {
+    let stale = if rib.stale { "S" } else { " " };
+    let valid = "*";
+    let best = if rib.best_path { ">" } else { " " };
+    let internal = if rib.typ == BgpRibType::IBGP {
+        "i"
+    } else {
+        " "
+    };
+    let nexthop = show_nexthop(&rib.attr);
+    let label = rib
+        .label
+        .map(|l| l.label.to_string())
+        .unwrap_or_else(|| "-".to_string());
+    let med = show_med(&rib.attr);
+    let local_pref = show_local_pref(&rib.attr);
+    let weight = rib.weight;
+    let mut aspath = show_aspath(&rib.attr);
+    if !aspath.is_empty() {
+        aspath.push(' ');
+    }
+    let origin = show_origin(&rib.attr);
+    writeln!(
+        buf,
+        "{stale}{valid}{best}{internal} {:18} {:18} {:>8} {:>7} {:>6} {:>6} {}{}",
+        prefix, nexthop, label, med, local_pref, weight, aspath, origin,
+    )
 }
 
 fn show_bgp_vpnv4(
@@ -2611,6 +2680,7 @@ impl Bgp {
 
     pub fn show_build(&mut self) {
         self.show_add("/show/ip/bgp", show_bgp::<Bgp>);
+        self.show_add("/show/ip/bgp/labeled-unicast", show_bgp_labeled);
         self.show_add("/show/ip/bgp/vpnv4", show_bgp_vpnv4);
         self.show_add("/show/ip/bgp/vpnv4/route", show_bgp_vpnv4_route);
         self.show_add("/show/ip/bgp/route", show_bgp_route_entry);

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -204,6 +204,10 @@ module exec {
             type inet:ipv4-address;
           }
         }
+        leaf labeled-unicast {
+          ext:help "BGP Labeled-Unicast (SAFI 4) RIB";
+          type empty;
+        }
         leaf evpn {
           ext:help "BGP EVPN RIB";
           type empty;


### PR DESCRIPTION
Phase 3 of BGP Labeled Unicast: store received IPv4/IPv6 Labeled-Unicast routes in a dedicated Loc-RIB and surface them. Control-plane only — no NHT gating, no FIB install, no re-advertisement yet (Phases 4–5).

> Stacked on #1043 (config) → #1042 (codec). Base is `bgp-lu-config`; GitHub retargets as the parents merge.

## What

- **`AdjRib`**: `v4lu` / `v6lu` Adj-RIB tables (both directions) with add/remove helpers; `count()` arms for `(Ip|Ip6, MplsLabel)`.
- **`LocalRib`**: `v4lu` / `v6lu` `LocalRibTable`s + update/remove/select-best-path accessors. The best-path engine is the existing NLRI-agnostic one, so labeled routes select like unicast; the per-prefix label rides on each `BgpRib` (`BgpRib.label`).
- **`route_labelv4_update` / `route_labelv6_update`**: thin ingest mirroring the v6-unicast path (loop detection → Adj-RIB-In → stamp the MP_REACH next-hop into the attr → Loc-RIB update + best-path), minus the deferred NHT/FIB/advertise steps. `route_labelv4_withdraw` / `route_labelv6_withdraw` are the inverse.
- **Dispatch**: wire `MpReachAttr::Labelv4/Labelv6` and `MpUnreachAttr::Labelv4(Eor)/Labelv6(Eor)` into the receive/withdraw match; `route_clean` withdraws + clears the LU tables on peer-down (no LLGR yet, matching v6 unicast).
- **Observability**: `show ip bgp labeled-unicast` lists both LU Loc-RIBs with a Label column (exec.yang `leaf labeled-unicast`); summary + neighbor route counts via the new `rib_entries_count` / `AdjRib::count` arms (also fills the previously-missing v6-unicast summary count).

## Tests

zebra-rs unit suite (717) + `yang_load_tests` pass; workspace `clippy --all-targets -D warnings` clean. End-to-end forwarding/interop is exercised by later phases + CI BDD.

## Follow-ups

Advertise/originate (propagate-received, redistribute, network, 6PE next-hop) → MPLS dataplane (per-prefix label + ILM swap/pop, NHT gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)