### PR TITLE
bgp: advertise local VRF import-RTs via RTC, before other AFI/SAFIs

### DIFF
--- a/crates/bgp-packet/src/attrs/nlri_rtcv4.rs
+++ b/crates/bgp-packet/src/attrs/nlri_rtcv4.rs
@@ -62,12 +62,25 @@ impl AttrEmitter for Rtcv4Reach {
         buf.put(&nhop.octets()[..]);
         // SNPA
         buf.put_u8(0);
-        // Prefix.
+        // NLRI.
         if self.updates.is_empty() {
-            // XXX AddPath?
-            // buf.put_u32(1);
-            // Zero prefix length for default.
+            // Zero prefix length: the default RT membership of
+            // RFC 4684 §3.2 — "interested in all Route Targets".
             buf.put_u8(0);
+        } else {
+            // Each membership NLRI is a 96-bit prefix: the 4-octet
+            // origin-AS followed by the 8-octet Route Target extended
+            // community (RFC 4684 §4). Mirrors `Rtcv4::parse_nlri`,
+            // which reads the AddPath id (when negotiated), the
+            // prefix length, the AS, then the RT.
+            for update in self.updates.iter() {
+                if update.id != 0 {
+                    buf.put_u32(update.id);
+                }
+                buf.put_u8(96);
+                buf.put_u32(update.asn);
+                update.rt.encode(buf);
+            }
         }
     }
 }
@@ -102,5 +115,58 @@ impl AttrEmitter for Rtcv4Unreach {
             // RD
             withdraw.rt.encode(buf);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The MP_REACH header `Rtcv4Reach::emit` writes before the NLRI:
+    // AFI(2) + SAFI(1) + nexthop-length(1) + nexthop(4) + SNPA(1).
+    const HEADER_LEN: usize = 9;
+
+    #[test]
+    fn membership_emit_roundtrips() {
+        // Route Target 100:1 marked as an RT (sub-type 0x02).
+        let rt = ExtCommunityValue {
+            high_type: 0x00,
+            low_type: 0x02,
+            val: [0x00, 0x64, 0x00, 0x00, 0x00, 0x01],
+        };
+        let reach = Rtcv4Reach {
+            snpa: 0,
+            nhop: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            updates: vec![Rtcv4 {
+                id: 0,
+                asn: 65001,
+                rt: rt.clone(),
+            }],
+        };
+
+        let mut buf = BytesMut::new();
+        reach.emit(&mut buf);
+
+        let (rest, parsed) = Rtcv4::parse_nlri(&buf[HEADER_LEN..], false).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(parsed.asn, 65001);
+        assert_eq!(parsed.rt, rt);
+    }
+
+    #[test]
+    fn empty_membership_emits_zero_length_default() {
+        let reach = Rtcv4Reach {
+            snpa: 0,
+            nhop: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            updates: vec![],
+        };
+
+        let mut buf = BytesMut::new();
+        reach.emit(&mut buf);
+
+        // Header followed by a single zero prefix-length octet (the
+        // RFC 4684 §3.2 default "all Route Targets" membership).
+        assert_eq!(buf.len(), HEADER_LEN + 1);
+        assert_eq!(buf[HEADER_LEN], 0);
     }
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -4940,22 +4940,46 @@ fn send_eor_vpnv4_unicast(peer: &mut Peer) {
     peer.send_packet(update.into());
 }
 
-// Send wildcard RTCv4.
-fn send_default_rtcv4_unicast(peer: &mut Peer) {
-    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+// Advertise our Route Target Constraint membership (RFC 4684): one
+// NLRI per IPv4 import Route-Target across all local VRFs, so the peer
+// only sends us the VPNv4 routes we actually import. With no local
+// import RTs the membership is empty, which emits the zero-length
+// "default" NLRI — the wildcard "send me everything" — preserving the
+// behaviour of a router that has RTC enabled but no VRFs configured.
+fn send_rtcv4_membership(peer: &mut Peer, bgp: &BgpTop) {
+    let mut updates = Vec::new();
+    if let Some(dispatcher) = bgp.vrf_import {
+        // Union the per-VRF import-RT sets so a Route-Target shared by
+        // several VRFs is advertised once.
+        let mut rts: BTreeSet<RouteDistinguisher> = BTreeSet::new();
+        for vrf in dispatcher.rib_known_vrfs.values() {
+            rts.extend(vrf.import_rts_v4.iter().copied());
+        }
+        for rt in rts {
+            // RTs are stored as RouteDistinguisher; the `From` impl sets
+            // high_type per ASN-vs-IPv4 RD but leaves the sub-type 0, so
+            // mark it as a Route Target (RFC 4360 §4, sub-type 0x02).
+            let mut val: ExtCommunityValue = rt.into();
+            val.low_type = 0x02;
+            updates.push(Rtcv4 {
+                id: 0,
+                asn: peer.local_as,
+                rt: val,
+            });
+        }
+    }
 
+    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
     let mut attrs = BgpAttr::new();
     if peer.is_ibgp() {
         attrs.local_pref = Some(LocalPref::default());
     }
     update.bgp_attr = Some(attrs);
-
-    let nlri = Rtcv4Reach {
+    update.mp_update = Some(MpReachAttr::Rtcv4(Rtcv4Reach {
         snpa: 0,
         nhop: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-        updates: vec![],
-    };
-    update.mp_update = Some(MpReachAttr::Rtcv4(nlri));
+        updates,
+    }));
     peer.send_packet(update.into());
 }
 
@@ -5031,16 +5055,21 @@ pub fn route_sync_evpn(peer: &mut Peer, bgp: &mut BgpTop) {
 
 // Called when peer has been established.
 pub fn route_sync(peer: &mut Peer, bgp: &mut BgpTop) {
-    // Advertize.
-    if peer.is_afi_safi(Afi::Ip, Safi::Unicast) {
-        route_sync_ipv4(peer, bgp);
-    }
-    // We want all RTC.
+    // RFC 4684: advertise our Route Target Constraint membership BEFORE
+    // any other AFI/SAFI, so the peer can apply RTC filtering to every
+    // route it sends us from the start of the session. The membership
+    // carries our local VRFs' import RTs (or the wildcard when none are
+    // configured); marking the RTC EoR in `peer.eor` defers our own
+    // VPNv4 advertisement until the peer has sent us its membership.
     if peer.is_afi_safi(Afi::Ip, Safi::Rtc) {
         let key = AfiSafi::new(Afi::Ip, Safi::Rtc);
         peer.eor.insert(key, true);
-        send_default_rtcv4_unicast(peer);
+        send_rtcv4_membership(peer, bgp);
         send_eor_rtcv4_unicast(peer);
+    }
+    // Advertize.
+    if peer.is_afi_safi(Afi::Ip, Safi::Unicast) {
+        route_sync_ipv4(peer, bgp);
     }
     if peer.is_afi_safi(Afi::Ip, Safi::MplsVpn) {
         let key = AfiSafi::new(Afi::Ip, Safi::Rtc);


### PR DESCRIPTION
## Summary

On session-up, `route_sync` advertised a **wildcard** Route Target Constraint membership ("send me everything") *after* IPv4 unicast, so no real RTC filtering took effect. This change makes RTC work as intended:

- **Advertise local VRF import-RTs.** `send_rtcv4_membership` builds one RTC NLRI per IPv4 import route-target, unioned across all local VRFs (`bgp.vrf_import.rib_known_vrfs[*].import_rts_v4`), so the peer only sends us the VPNv4 routes we actually import (RFC 4684). Each stored `RouteDistinguisher` is converted to a Route-Target ext-community (`low_type = 0x02`), origin-AS = `peer.local_as`.
- **Wildcard fallback.** With no local import RTs (RTC enabled but no VRFs), the membership is empty → emits the zero-length "default = all RTs" NLRI, preserving prior behavior for VRF-less routers.
- **RTC goes first.** The `(Ip, Rtc)` block is moved to the front of `route_sync`, ahead of unicast / VPNv4 / EVPN, so the peer applies RTC policy to everything it sends us from the start of the session. The VPNv4 EoR-gating (defer our own VPNv4 until the peer's RTC EoR) is unchanged.
- **Codec fix.** Implemented the previously-missing non-empty `Rtcv4Reach::emit` (96-bit prefix: origin-AS + 8-octet RT, mirroring `parse_nlri`).

**Scope:** IPv4 (rtcv4). IPv6 RTC wire path (`Rtcv6` NLRI/codec, `peer.rtcv6`, VPNv6 sync gating) is a follow-up.

## Test plan

- `cargo test -p bgp-packet` — new `membership_emit_roundtrips` + `empty_membership_emits_zero_length_default` pass.
- `cargo test -p zebra-rs` — 717 passed, 0 failed.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all` — clean.

Generated with [Claude Code](https://claude.com/claude-code)