### PR TITLE
bgp: Flow Specification (RFC 8955/8956) NLRI + action codec (Phase 0)

### DIFF
--- a/crates/bgp-packet/src/attrs/flowspec_action.rs
+++ b/crates/bgp-packet/src/attrs/flowspec_action.rs
@@ -1,0 +1,269 @@
+//! Flow Specification Traffic Filtering Action extended communities
+//! (RFC 8955 §7, with the IPv6 redirect noted in RFC 8956).
+//!
+//! Actions ride alongside a Flow Specification NLRI as transitive
+//! extended communities. Each is an 8-octet [`ExtCommunityValue`] whose
+//! high/low type bytes identify the action and whose 6-octet value
+//! carries the parameters. This module decodes the 8-octet forms into a
+//! typed [`FlowspecAction`] and re-encodes them.
+//!
+//! The 20-octet IPv6-address-specific `redirect-ipv6` community
+//! (RFC 8956 §4, sub-type 0x0d) uses a different on-wire container and
+//! is handled separately when the IPv6 redirect dataplane lands.
+
+use std::net::Ipv4Addr;
+
+use crate::ExtCommunityValue;
+
+// High-type bytes. 0x80 is the transitive flow-spec action range; the
+// RT-redirect form additionally uses 0x81 (IPv4) and 0x82 (4-octet AS)
+// to mirror the Route-Target community formats (RFC 8955 §7.4).
+const FS_HIGH: u8 = 0x80;
+const FS_HIGH_REDIRECT_IPV4: u8 = 0x81;
+const FS_HIGH_REDIRECT_AS4: u8 = 0x82;
+
+// Sub-type (low) bytes (RFC 8955 §7, IANA "Traffic Filtering Actions").
+const SUB_TRAFFIC_RATE_BYTES: u8 = 0x06;
+const SUB_TRAFFIC_ACTION: u8 = 0x07;
+const SUB_REDIRECT: u8 = 0x08;
+const SUB_TRAFFIC_MARKING: u8 = 0x09;
+const SUB_TRAFFIC_RATE_PACKETS: u8 = 0x0c;
+
+// Traffic-action value bits, in the least-significant octet (bit 47 is
+// the rightmost bit of the 6-octet value).
+const TA_TERMINAL: u8 = 0x01; // bit 47 'T'
+const TA_SAMPLE: u8 = 0x02; // bit 46 'S'
+
+/// A decoded Flow Specification traffic-filtering action.
+///
+/// `f32` rates are not `Eq`/`Ord`, so this type is interpretation-only
+/// (`PartialEq`) and is never used as a map key — flow specs are keyed
+/// by their NLRI, with the action set hanging off the path.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum FlowspecAction {
+    /// `traffic-rate-bytes` (0x8006): police to `rate` bytes/second.
+    /// A rate of `0.0` means discard all matching traffic.
+    TrafficRateBytes { asn: u16, rate: f32 },
+    /// `traffic-rate-packets` (0x800c): police to `rate` packets/second.
+    TrafficRatePackets { asn: u16, rate: f32 },
+    /// `traffic-action` (0x8007): terminal-action and sample flags.
+    TrafficAction { terminal: bool, sample: bool },
+    /// `rt-redirect` 2-octet AS form (0x8008): redirect to the VRF(s)
+    /// importing this Route-Target.
+    RedirectAs2 { asn: u16, value: u32 },
+    /// `rt-redirect` IPv4 form (0x8108).
+    RedirectIpv4 { addr: Ipv4Addr, value: u16 },
+    /// `rt-redirect` 4-octet AS form (0x8208).
+    RedirectAs4 { asn: u32, value: u16 },
+    /// `traffic-marking` (0x8009): rewrite the DSCP field (6 bits).
+    TrafficMarking { dscp: u8 },
+}
+
+impl ExtCommunityValue {
+    /// Decode this extended community as a Flow Specification action,
+    /// or `None` if it is not one of the 8-octet traffic-filtering
+    /// action forms.
+    pub fn as_flowspec_action(&self) -> Option<FlowspecAction> {
+        let v = &self.val;
+        match (self.high_type, self.low_type) {
+            (FS_HIGH, SUB_TRAFFIC_RATE_BYTES) => Some(FlowspecAction::TrafficRateBytes {
+                asn: u16::from_be_bytes([v[0], v[1]]),
+                rate: f32::from_be_bytes([v[2], v[3], v[4], v[5]]),
+            }),
+            (FS_HIGH, SUB_TRAFFIC_RATE_PACKETS) => Some(FlowspecAction::TrafficRatePackets {
+                asn: u16::from_be_bytes([v[0], v[1]]),
+                rate: f32::from_be_bytes([v[2], v[3], v[4], v[5]]),
+            }),
+            (FS_HIGH, SUB_TRAFFIC_ACTION) => Some(FlowspecAction::TrafficAction {
+                terminal: v[5] & TA_TERMINAL != 0,
+                sample: v[5] & TA_SAMPLE != 0,
+            }),
+            (FS_HIGH, SUB_REDIRECT) => Some(FlowspecAction::RedirectAs2 {
+                asn: u16::from_be_bytes([v[0], v[1]]),
+                value: u32::from_be_bytes([v[2], v[3], v[4], v[5]]),
+            }),
+            (FS_HIGH_REDIRECT_IPV4, SUB_REDIRECT) => Some(FlowspecAction::RedirectIpv4 {
+                addr: Ipv4Addr::new(v[0], v[1], v[2], v[3]),
+                value: u16::from_be_bytes([v[4], v[5]]),
+            }),
+            (FS_HIGH_REDIRECT_AS4, SUB_REDIRECT) => Some(FlowspecAction::RedirectAs4 {
+                asn: u32::from_be_bytes([v[0], v[1], v[2], v[3]]),
+                value: u16::from_be_bytes([v[4], v[5]]),
+            }),
+            (FS_HIGH, SUB_TRAFFIC_MARKING) => {
+                Some(FlowspecAction::TrafficMarking { dscp: v[5] & 0x3f })
+            }
+            _ => None,
+        }
+    }
+
+    /// True iff this extended community encodes a Flow Specification
+    /// traffic-filtering action.
+    pub fn is_flowspec_action(&self) -> bool {
+        self.as_flowspec_action().is_some()
+    }
+}
+
+impl From<FlowspecAction> for ExtCommunityValue {
+    fn from(action: FlowspecAction) -> Self {
+        let mut val = [0u8; 6];
+        let (high_type, low_type) = match action {
+            FlowspecAction::TrafficRateBytes { asn, rate } => {
+                val[0..2].copy_from_slice(&asn.to_be_bytes());
+                val[2..6].copy_from_slice(&rate.to_be_bytes());
+                (FS_HIGH, SUB_TRAFFIC_RATE_BYTES)
+            }
+            FlowspecAction::TrafficRatePackets { asn, rate } => {
+                val[0..2].copy_from_slice(&asn.to_be_bytes());
+                val[2..6].copy_from_slice(&rate.to_be_bytes());
+                (FS_HIGH, SUB_TRAFFIC_RATE_PACKETS)
+            }
+            FlowspecAction::TrafficAction { terminal, sample } => {
+                if terminal {
+                    val[5] |= TA_TERMINAL;
+                }
+                if sample {
+                    val[5] |= TA_SAMPLE;
+                }
+                (FS_HIGH, SUB_TRAFFIC_ACTION)
+            }
+            FlowspecAction::RedirectAs2 { asn, value } => {
+                val[0..2].copy_from_slice(&asn.to_be_bytes());
+                val[2..6].copy_from_slice(&value.to_be_bytes());
+                (FS_HIGH, SUB_REDIRECT)
+            }
+            FlowspecAction::RedirectIpv4 { addr, value } => {
+                val[0..4].copy_from_slice(&addr.octets());
+                val[4..6].copy_from_slice(&value.to_be_bytes());
+                (FS_HIGH_REDIRECT_IPV4, SUB_REDIRECT)
+            }
+            FlowspecAction::RedirectAs4 { asn, value } => {
+                val[0..4].copy_from_slice(&asn.to_be_bytes());
+                val[4..6].copy_from_slice(&value.to_be_bytes());
+                (FS_HIGH_REDIRECT_AS4, SUB_REDIRECT)
+            }
+            FlowspecAction::TrafficMarking { dscp } => {
+                val[5] = dscp & 0x3f;
+                (FS_HIGH, SUB_TRAFFIC_MARKING)
+            }
+        };
+        ExtCommunityValue {
+            high_type,
+            low_type,
+            val,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn round_trip(action: FlowspecAction) {
+        let ev: ExtCommunityValue = action.into();
+        assert!(ev.is_flowspec_action());
+        assert_eq!(ev.as_flowspec_action(), Some(action));
+    }
+
+    #[test]
+    fn traffic_rate_bytes_round_trip() {
+        round_trip(FlowspecAction::TrafficRateBytes {
+            asn: 65000,
+            rate: 1_000_000.0,
+        });
+    }
+
+    #[test]
+    fn discard_is_zero_rate() {
+        let ev: ExtCommunityValue = FlowspecAction::TrafficRateBytes { asn: 0, rate: 0.0 }.into();
+        // [0x80, 0x06, asn(2)=0, rate(4)=0.0].
+        assert_eq!(ev.high_type, 0x80);
+        assert_eq!(ev.low_type, 0x06);
+        assert_eq!(ev.val, [0u8; 6]);
+        match ev.as_flowspec_action() {
+            Some(FlowspecAction::TrafficRateBytes { rate, .. }) => assert_eq!(rate, 0.0),
+            other => panic!("expected traffic-rate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn traffic_rate_packets_round_trip() {
+        round_trip(FlowspecAction::TrafficRatePackets {
+            asn: 100,
+            rate: 500.0,
+        });
+    }
+
+    #[test]
+    fn traffic_action_flags_round_trip() {
+        for terminal in [false, true] {
+            for sample in [false, true] {
+                round_trip(FlowspecAction::TrafficAction { terminal, sample });
+            }
+        }
+    }
+
+    #[test]
+    fn traffic_action_bit_layout() {
+        let ev: ExtCommunityValue = FlowspecAction::TrafficAction {
+            terminal: true,
+            sample: true,
+        }
+        .into();
+        // Both bits live in the least-significant value octet.
+        assert_eq!(ev.val, [0, 0, 0, 0, 0, 0x03]);
+    }
+
+    #[test]
+    fn redirect_forms_round_trip() {
+        round_trip(FlowspecAction::RedirectAs2 {
+            asn: 65000,
+            value: 42,
+        });
+        round_trip(FlowspecAction::RedirectIpv4 {
+            addr: Ipv4Addr::new(192, 0, 2, 1),
+            value: 7,
+        });
+        round_trip(FlowspecAction::RedirectAs4 {
+            asn: 4_200_000_000,
+            value: 9,
+        });
+    }
+
+    #[test]
+    fn redirect_high_type_bytes() {
+        let as2: ExtCommunityValue = FlowspecAction::RedirectAs2 { asn: 1, value: 1 }.into();
+        let v4: ExtCommunityValue = FlowspecAction::RedirectIpv4 {
+            addr: Ipv4Addr::UNSPECIFIED,
+            value: 1,
+        }
+        .into();
+        let as4: ExtCommunityValue = FlowspecAction::RedirectAs4 { asn: 1, value: 1 }.into();
+        assert_eq!((as2.high_type, as2.low_type), (0x80, 0x08));
+        assert_eq!((v4.high_type, v4.low_type), (0x81, 0x08));
+        assert_eq!((as4.high_type, as4.low_type), (0x82, 0x08));
+    }
+
+    #[test]
+    fn traffic_marking_round_trip() {
+        round_trip(FlowspecAction::TrafficMarking { dscp: 46 });
+    }
+
+    #[test]
+    fn traffic_marking_masks_to_six_bits() {
+        let ev: ExtCommunityValue = FlowspecAction::TrafficMarking { dscp: 0xff }.into();
+        assert_eq!(ev.val[5], 0x3f);
+    }
+
+    #[test]
+    fn non_action_communities_return_none() {
+        // Route-Target (0x00/0x02) is not a flow-spec action.
+        let rt = ExtCommunityValue {
+            high_type: 0x00,
+            low_type: 0x02,
+            val: [0, 100, 0, 0, 0, 200],
+        };
+        assert!(!rt.is_flowspec_action());
+        assert_eq!(rt.as_flowspec_action(), None);
+    }
+}

--- a/crates/bgp-packet/src/attrs/mod.rs
+++ b/crates/bgp-packet/src/attrs/mod.rs
@@ -93,3 +93,9 @@ pub use nlri_rtcv4::*;
 
 pub mod nlri_mup;
 pub use nlri_mup::*;
+
+pub mod nlri_flowspec;
+pub use nlri_flowspec::*;
+
+pub mod flowspec_action;
+pub use flowspec_action::*;

--- a/crates/bgp-packet/src/attrs/mp_reach.rs
+++ b/crates/bgp-packet/src/attrs/mp_reach.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use bytes::BytesMut;
+use nom::bytes::complete::take;
 use nom::error::{ErrorKind, make_error};
 use nom::number::complete::{be_u8, be_u32, be_u128};
 use nom_derive::*;
@@ -9,8 +10,9 @@ use nom_derive::*;
 use bytes::BufMut;
 
 use crate::{
-    Afi, AttrFlags, AttrType, EvpnRoute, Ipv4Nlri, Ipv6Nlri, MupRoute, ParseBe, ParseNlri,
-    ParseOption, Rtcv4, Safi, Vpnv4Nexthop, Vpnv4Nlri, Vpnv6Nexthop, Vpnv6Nlri, many0_complete,
+    Afi, AttrFlags, AttrType, EvpnRoute, FlowspecNlri, Ipv4Nlri, Ipv6Nlri, MupRoute, ParseBe,
+    ParseNlri, ParseOption, Rtcv4, Safi, Vpnv4Nexthop, Vpnv4Nlri, Vpnv6Nexthop, Vpnv6Nlri,
+    many0_complete,
 };
 
 use super::{AttrEmitter, RouteDistinguisher, Rtcv4Reach, Vpnv4Reach, Vpnv6Reach};
@@ -51,6 +53,13 @@ pub enum MpReachAttr {
         nhop: IpAddr,
         updates: Vec<MupRoute>,
     },
+    /// BGP Flow Specification (RFC 8955 IPv4 / RFC 8956 IPv6), SAFI 133.
+    /// The outer AFI selects the v4 vs v6 NLRI encoding. Flow specs
+    /// carry no usable next-hop, so none is retained.
+    Flowspec {
+        afi: Afi,
+        updates: Vec<FlowspecNlri>,
+    },
 }
 
 impl MpReachAttr {
@@ -86,6 +95,9 @@ impl MpReachAttr {
                 updates,
             } => {
                 mup_attr_emit(*afi, *snpa, nhop, updates, buf);
+            }
+            MpReachAttr::Flowspec { afi, updates } => {
+                flowspec_attr_emit(*afi, updates, buf);
             }
             _ => {
                 //
@@ -356,6 +368,23 @@ impl MpReachAttr {
             let rtc_nlri = MpReachAttr::Rtcv4(nlri);
             return Ok((input, rtc_nlri));
         }
+        if (header.afi == Afi::Ip || header.afi == Afi::Ip6) && header.safi == Safi::Flowspec {
+            // RFC 8955 §4.2.2 / RFC 8956 §4: a Flow Specification
+            // MP_REACH carries no useful next-hop (the sender sets
+            // Next-Hop Length to 0). RFC 4760 §3 still mandates the
+            // Next-Hop-Length octet and the reserved (SNPA count) octet,
+            // so honour whatever length was advertised, then the
+            // reserved octet, then parse the NLRIs.
+            let (input, _nhop) = take(header.nhop_len as usize).parse(input)?;
+            let (input, _snpa) = be_u8(input)?;
+            let (input, updates) =
+                many0_complete(|i| FlowspecNlri::parse(i, add_path, header.afi)).parse(input)?;
+            let mp_nlri = MpReachAttr::Flowspec {
+                afi: header.afi,
+                updates,
+            };
+            return Ok((input, mp_nlri));
+        }
         Err(nom::Err::Error(make_error(input, ErrorKind::NoneOf)))
     }
 }
@@ -451,6 +480,11 @@ impl fmt::Display for MpReachAttr {
                         update.architecture(),
                         update.body_len()
                     )?;
+                }
+            }
+            Flowspec { afi, updates } => {
+                for update in updates.iter() {
+                    writeln!(f, " {afi}/flowspec {update}")?;
                 }
             }
             _ => {
@@ -609,6 +643,45 @@ pub(crate) fn mup_attr_emit(
     value.put_u8(0);
     for r in updates {
         r.nlri_emit(&mut value);
+    }
+
+    let len = value.len();
+    let extended = len > 255;
+    let flags = if extended {
+        AttrFlags::new().with_optional(true).with_extended(true)
+    } else {
+        AttrFlags::new().with_optional(true)
+    };
+    buf.put_u8(flags.into());
+    buf.put_u8(AttrType::MpReachNlri.into());
+    if extended {
+        buf.put_u16(len as u16);
+    } else {
+        buf.put_u8(len as u8);
+    }
+    buf.put(&value[..]);
+}
+
+/// Serialize an `MpReachAttr::Flowspec { afi, updates }` as a complete
+/// `MP_REACH_NLRI` path attribute (header + value).
+///
+/// Wire format (RFC 4760 §3 + RFC 8955 §4.2.2):
+/// ```text
+///   AFI  (2 octets) = 1 (IPv4) or 2 (IPv6)
+///   SAFI (1 octet)  = 133 (Flow Specification)
+///   Next-Hop Length (1 octet) = 0   (no next-hop for flow specs)
+///   Reserved / SNPA (1 octet) = 0
+///   NLRIs (one or more FlowspecNlri encodings)
+/// ```
+pub(crate) fn flowspec_attr_emit(afi: Afi, updates: &[FlowspecNlri], buf: &mut BytesMut) {
+    let mut value = BytesMut::new();
+    value.put_u16(u16::from(afi));
+    value.put_u8(u8::from(Safi::Flowspec));
+    // Next-Hop Length = 0 (no next-hop), then the reserved/SNPA octet.
+    value.put_u8(0);
+    value.put_u8(0);
+    for nlri in updates {
+        nlri.nlri_emit(&mut value);
     }
 
     let len = value.len();
@@ -848,6 +921,71 @@ mod tests {
                 assert_eq!(parsed, updates);
             }
             other => panic!("expected Mup, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flowspec_v4_emit_round_trips_through_parser() {
+        use crate::{FlowspecComponent, FlowspecNlri, FlowspecOp, FlowspecPrefix};
+        let updates = vec![FlowspecNlri::new(
+            Afi::Ip,
+            vec![
+                FlowspecComponent::DestinationPrefix(FlowspecPrefix::V4(
+                    "10.0.0.0/24".parse().unwrap(),
+                )),
+                FlowspecComponent::DestinationPort(vec![FlowspecOp::numeric(
+                    false, false, false, true, 80,
+                )]),
+            ],
+        )];
+        let mut buf = BytesMut::new();
+        flowspec_attr_emit(Afi::Ip, &updates, &mut buf);
+        // Strip the attr header: flags(1) + type(1) + length(1).
+        let value = &buf[3..];
+        let (_rest, mp) =
+            MpReachAttr::parse_nlri_opt(value, None).expect("emitter must round-trip");
+        match mp {
+            MpReachAttr::Flowspec {
+                afi,
+                updates: parsed,
+            } => {
+                assert_eq!(afi, Afi::Ip);
+                assert_eq!(parsed, updates);
+            }
+            other => panic!("expected Flowspec, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flowspec_v6_emit_round_trips_through_parser() {
+        use crate::{FlowspecComponent, FlowspecNlri, FlowspecOp, FlowspecPrefix};
+        let updates = vec![FlowspecNlri::new(
+            Afi::Ip6,
+            vec![
+                FlowspecComponent::DestinationPrefix(FlowspecPrefix::V6 {
+                    length: 64,
+                    offset: 0,
+                    pattern: "2001:db8::".parse::<Ipv6Addr>().unwrap().octets()[..8].to_vec(),
+                }),
+                FlowspecComponent::FlowLabel(vec![FlowspecOp::numeric(
+                    false, false, false, true, 42,
+                )]),
+            ],
+        )];
+        let mut buf = BytesMut::new();
+        flowspec_attr_emit(Afi::Ip6, &updates, &mut buf);
+        let value = &buf[3..];
+        let (_rest, mp) =
+            MpReachAttr::parse_nlri_opt(value, None).expect("emitter must round-trip");
+        match mp {
+            MpReachAttr::Flowspec {
+                afi,
+                updates: parsed,
+            } => {
+                assert_eq!(afi, Afi::Ip6);
+                assert_eq!(parsed, updates);
+            }
+            other => panic!("expected Flowspec, got {other:?}"),
         }
     }
 

--- a/crates/bgp-packet/src/attrs/mp_unreach.rs
+++ b/crates/bgp-packet/src/attrs/mp_unreach.rs
@@ -5,8 +5,8 @@ use nom::error::{ErrorKind, make_error};
 use nom_derive::*;
 
 use crate::{
-    Afi, AttrFlags, AttrType, EvpnRoute, Ipv6Nlri, MupRoute, ParseBe, ParseNlri, ParseOption,
-    Rtcv4, Rtcv4Unreach, Safi, Vpnv4Nlri, Vpnv6Nlri, many0_complete,
+    Afi, AttrFlags, AttrType, EvpnRoute, FlowspecNlri, Ipv6Nlri, MupRoute, ParseBe, ParseNlri,
+    ParseOption, Rtcv4, Rtcv4Unreach, Safi, Vpnv4Nlri, Vpnv6Nlri, many0_complete,
 };
 
 use super::{AttrEmitter, Vpnv4Unreach, Vpnv6Unreach};
@@ -37,6 +37,13 @@ pub enum MpUnreachAttr {
     Mup {
         afi: Afi,
         withdraws: Vec<MupRoute>,
+    },
+    /// BGP Flow Specification withdraws (RFC 8955 / RFC 8956), SAFI 133.
+    /// As with MUP, the outer AFI is preserved and an empty `withdraws`
+    /// list represents end-of-RIB.
+    Flowspec {
+        afi: Afi,
+        withdraws: Vec<FlowspecNlri>,
     },
 }
 
@@ -81,6 +88,9 @@ impl MpUnreachAttr {
             }
             MpUnreachAttr::Mup { afi, withdraws } => {
                 mup_unreach_attr_emit(*afi, withdraws, buf);
+            }
+            MpUnreachAttr::Flowspec { afi, withdraws } => {
+                flowspec_unreach_attr_emit(*afi, withdraws, buf);
             }
             _ => {
                 //
@@ -196,6 +206,37 @@ fn mup_unreach_attr_emit(afi: Afi, withdraws: &[MupRoute], buf: &mut BytesMut) {
     buf.put(&value[..]);
 }
 
+/// Serialize an `MpUnreachAttr::Flowspec { afi, withdraws }` (empty
+/// `withdraws` encodes an end-of-RIB marker) as a complete
+/// `MP_UNREACH_NLRI` path attribute.
+///
+/// Wire format (RFC 4760 §4 + RFC 8955 §4.2.2): AFI, SAFI=133, then the
+/// NLRI list. MP_UNREACH carries neither next-hop nor SNPA.
+fn flowspec_unreach_attr_emit(afi: Afi, withdraws: &[FlowspecNlri], buf: &mut BytesMut) {
+    let mut value = BytesMut::new();
+    value.put_u16(u16::from(afi));
+    value.put_u8(u8::from(Safi::Flowspec));
+    for w in withdraws {
+        w.nlri_emit(&mut value);
+    }
+
+    let len = value.len();
+    let extended = len > 255;
+    let flags = if extended {
+        AttrFlags::new().with_optional(true).with_extended(true)
+    } else {
+        AttrFlags::new().with_optional(true)
+    };
+    buf.put_u8(flags.into());
+    buf.put_u8(AttrType::MpUnreachNlri.into());
+    if extended {
+        buf.put_u16(len as u16);
+    } else {
+        buf.put_u8(len as u8);
+    }
+    buf.put(&value[..]);
+}
+
 impl MpUnreachAttr {
     pub fn parse_nlri_opt(input: &[u8], opt: Option<ParseOption>) -> nom::IResult<&[u8], Self> {
         // AFI + SAFI = 3.
@@ -279,6 +320,26 @@ impl MpUnreachAttr {
             let (input, rtcv4) = many0_complete(|i| Rtcv4::parse_nlri(i, add_path)).parse(input)?;
             let mp_nlri = MpUnreachAttr::Rtcv4(rtcv4);
             return Ok((input, mp_nlri));
+        }
+        if (header.afi == Afi::Ip || header.afi == Afi::Ip6) && header.safi == Safi::Flowspec {
+            if input.is_empty() {
+                return Ok((
+                    input,
+                    MpUnreachAttr::Flowspec {
+                        afi: header.afi,
+                        withdraws: vec![],
+                    },
+                ));
+            }
+            let (input, withdraws) =
+                many0_complete(|i| FlowspecNlri::parse(i, add_path, header.afi)).parse(input)?;
+            return Ok((
+                input,
+                MpUnreachAttr::Flowspec {
+                    afi: header.afi,
+                    withdraws,
+                },
+            ));
         }
         Err(nom::Err::Error(make_error(input, ErrorKind::NoneOf)))
     }
@@ -374,6 +435,15 @@ impl fmt::Display for MpUnreachAttr {
                         r.route_type(),
                         r.architecture()
                     )?;
+                }
+                Ok(())
+            }
+            Flowspec { afi, withdraws } => {
+                if withdraws.is_empty() {
+                    return writeln!(f, " EoR: {}/{}", afi, Safi::Flowspec);
+                }
+                for w in withdraws {
+                    writeln!(f, " {afi}/flowspec {w}")?;
                 }
                 Ok(())
             }
@@ -508,6 +578,52 @@ mod tests {
                 assert_eq!(parsed, withdraws);
             }
             other => panic!("expected Mup, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flowspec_unreach_emit_round_trips_through_parser() {
+        use crate::{FlowspecComponent, FlowspecNlri, FlowspecOp, FlowspecPrefix};
+        let withdraws = vec![FlowspecNlri::new(
+            Afi::Ip,
+            vec![
+                FlowspecComponent::DestinationPrefix(FlowspecPrefix::V4(
+                    "192.0.2.0/24".parse().unwrap(),
+                )),
+                FlowspecComponent::IpProtocol(vec![FlowspecOp::numeric(
+                    false, false, false, true, 6,
+                )]),
+            ],
+        )];
+        let mut buf = BytesMut::new();
+        flowspec_unreach_attr_emit(Afi::Ip, &withdraws, &mut buf);
+        let value = &buf[3..];
+        let (_rest, mp) =
+            MpUnreachAttr::parse_nlri_opt(value, None).expect("emitter must round-trip");
+        match mp {
+            MpUnreachAttr::Flowspec {
+                afi,
+                withdraws: parsed,
+            } => {
+                assert_eq!(afi, Afi::Ip);
+                assert_eq!(parsed, withdraws);
+            }
+            other => panic!("expected Flowspec, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flowspec_unreach_emit_eor_round_trips() {
+        let mut buf = BytesMut::new();
+        flowspec_unreach_attr_emit(Afi::Ip6, &[], &mut buf);
+        let value = &buf[3..];
+        let (_rest, mp) = MpUnreachAttr::parse_nlri_opt(value, None).expect("EoR must round-trip");
+        match mp {
+            MpUnreachAttr::Flowspec { afi, withdraws } => {
+                assert_eq!(afi, Afi::Ip6);
+                assert!(withdraws.is_empty());
+            }
+            other => panic!("expected Flowspec, got {other:?}"),
         }
     }
 

--- a/crates/bgp-packet/src/attrs/nlri_flowspec.rs
+++ b/crates/bgp-packet/src/attrs/nlri_flowspec.rs
@@ -1,0 +1,1000 @@
+//! BGP Flow Specification NLRI codec (RFC 8955 for IPv4, RFC 8956 for
+//! IPv6).
+//!
+//! A Flow Specification NLRI is an n-tuple of match *components* — a
+//! packet matches the spec only if it matches every component. On the
+//! wire each NLRI is `<length, value>` where `value` is a sequence of
+//! components ordered by ascending component type (RFC 8955 §4.1):
+//!
+//! ```text
+//!   +-------------------------------+
+//!   | length (1 or 2 octets)        |   value length in octets
+//!   +-------------------------------+
+//!   | component(1) | component(2) | ...
+//!   +-------------------------------+
+//! ```
+//!
+//! Component types 1 and 2 (destination / source prefix) carry an IP
+//! prefix; in IPv6 they gain an `offset` field (RFC 8956 §3.1). Types
+//! 3–13 carry a list of `{operator, value}` terms using one of two
+//! operator encodings — numeric (RFC 8955 §4.2.1.1) or bitmask
+//! (§4.2.1.2). Type 13 (Flow Label) is IPv6-only.
+//!
+//! This module is codec-only: it parses, re-emits, orders (per the
+//! §5.1 precedence rules — see [`FlowspecNlri`]'s `Ord`), and renders
+//! flow specs. Validation, RIB storage, and dataplane install live in
+//! the `zebra-rs` BGP module and land in later phases.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use bytes::{BufMut, BytesMut};
+use ipnet::{Ipv4Net, Ipv6Net};
+use nom::IResult;
+use nom::bytes::complete::take;
+use nom::error::{ErrorKind, make_error};
+use nom::number::complete::{be_u8, be_u32};
+use nom_derive::*;
+use packet_utils::safe_split_at;
+
+use crate::{Afi, nlri_psize};
+
+// Operator byte bit masks, shared by the numeric and bitmask encodings
+// (RFC 8955 §4.2.1.1 / §4.2.1.2). The high nibble carries control bits
+// common to both; the low nibble's meaning depends on the component.
+const OP_END: u8 = 0x80; // 'e': last {op,value} term in the list.
+const OP_AND: u8 = 0x40; // 'a': AND with the previous term (OR when clear).
+const OP_LEN_MASK: u8 = 0x30; // value spans `1 << ((op & 0x30) >> 4)` octets.
+// Numeric comparison bits (low nibble).
+const OP_LT: u8 = 0x04;
+const OP_GT: u8 = 0x02;
+const OP_EQ: u8 = 0x01;
+// Bitmask bits (low nibble).
+const OP_NOT: u8 = 0x02;
+const OP_MATCH: u8 = 0x01;
+
+/// Width in octets of the value following an operator byte: `1 << len`
+/// where `len` is the two-bit field at `0x30` (00→1, 01→2, 10→4, 11→8).
+fn op_value_len(op: u8) -> usize {
+    1usize << ((op & OP_LEN_MASK) >> 4)
+}
+
+/// A single `{operator, value}` term inside a numeric- or bitmask-op
+/// component list. The full operator byte is retained verbatim so the
+/// term re-emits bit-for-bit; `value` holds the right-aligned numeric
+/// value (the wire carries only the low `op_value_len(op)` octets).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FlowspecOp {
+    pub op: u8,
+    pub value: u64,
+}
+
+impl FlowspecOp {
+    /// Build a numeric term (`lt`/`gt`/`eq` combinable) with the
+    /// smallest value width that fits `value`. The end-of-list bit is
+    /// never stored — `emit_op_list` sets it on the final term — so
+    /// terms compose freely without bookkeeping.
+    pub fn numeric(and: bool, lt: bool, gt: bool, eq: bool, value: u64) -> Self {
+        let mut op = 0u8;
+        if and {
+            op |= OP_AND;
+        }
+        if lt {
+            op |= OP_LT;
+        }
+        if gt {
+            op |= OP_GT;
+        }
+        if eq {
+            op |= OP_EQ;
+        }
+        op |= len_bits_for(value);
+        Self { op, value }
+    }
+
+    /// Build a bitmask term (`not`/`match`).
+    pub fn bitmask(and: bool, not: bool, m: bool, value: u64) -> Self {
+        let mut op = 0u8;
+        if and {
+            op |= OP_AND;
+        }
+        if not {
+            op |= OP_NOT;
+        }
+        if m {
+            op |= OP_MATCH;
+        }
+        op |= len_bits_for(value);
+        Self { op, value }
+    }
+
+    fn is_end(&self) -> bool {
+        self.op & OP_END != 0
+    }
+
+    pub fn is_and(&self) -> bool {
+        self.op & OP_AND != 0
+    }
+}
+
+/// Choose the two-bit length field for the narrowest power-of-two octet
+/// width holding `value` (1, 2, 4, or 8 octets).
+fn len_bits_for(value: u64) -> u8 {
+    let bits = if value == 0 {
+        1
+    } else {
+        64 - value.leading_zeros()
+    };
+    if bits <= 8 {
+        0x00
+    } else if bits <= 16 {
+        0x10
+    } else if bits <= 32 {
+        0x20
+    } else {
+        0x30
+    }
+}
+
+fn parse_op(input: &[u8]) -> IResult<&[u8], FlowspecOp> {
+    let (input, op) = be_u8(input)?;
+    let vlen = op_value_len(op);
+    let (input, vbytes) = take(vlen).parse(input)?;
+    let mut buf = [0u8; 8];
+    buf[8 - vlen..].copy_from_slice(vbytes);
+    let value = u64::from_be_bytes(buf);
+    Ok((input, FlowspecOp { op, value }))
+}
+
+/// Parse a list of operator terms, stopping after the term whose
+/// end-of-list bit is set (or when the component slice is exhausted, so
+/// a missing end bit can't run into the next component).
+///
+/// The end bit is positional — it only ever marks the final term — so
+/// it is stripped from the stored ops to keep the in-memory form
+/// canonical (`emit_op_list` re-derives it from position). This makes
+/// equality independent of how the sender flagged the terminator.
+fn parse_op_list(mut input: &[u8]) -> IResult<&[u8], Vec<FlowspecOp>> {
+    let mut ops = Vec::new();
+    loop {
+        let (rest, op) = parse_op(input)?;
+        let end = op.is_end();
+        ops.push(FlowspecOp {
+            op: op.op & !OP_END,
+            value: op.value,
+        });
+        input = rest;
+        if end || input.is_empty() {
+            break;
+        }
+    }
+    Ok((input, ops))
+}
+
+/// Emit an operator-term list, forcing the end bit onto the final term
+/// (and clearing it elsewhere) so hand-built lists always serialise to
+/// valid wire form.
+fn emit_op_list(ops: &[FlowspecOp], buf: &mut BytesMut) {
+    let last = ops.len().saturating_sub(1);
+    for (i, o) in ops.iter().enumerate() {
+        let mut op = o.op & !OP_END;
+        if i == last {
+            op |= OP_END;
+        }
+        buf.put_u8(op);
+        let vlen = op_value_len(op);
+        let bytes = o.value.to_be_bytes();
+        buf.put(&bytes[8 - vlen..]);
+    }
+}
+
+/// Render one operator-term list. `bitmask` selects the bit semantics
+/// (`not`/`match` vs `lt`/`gt`/`eq`); terms are joined with `&` (AND)
+/// or `|` (OR) per each term's `a` bit.
+fn fmt_op_list(ops: &[FlowspecOp], bitmask: bool, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    for (i, o) in ops.iter().enumerate() {
+        if i != 0 {
+            f.write_str(if o.is_and() { "&" } else { "|" })?;
+        }
+        if bitmask {
+            if o.op & OP_NOT != 0 {
+                f.write_str("!")?;
+            }
+            if o.op & OP_MATCH != 0 {
+                f.write_str("=")?;
+            }
+            write!(f, "0x{:x}", o.value)?;
+        } else {
+            if o.op & OP_LT != 0 {
+                f.write_str("<")?;
+            }
+            if o.op & OP_GT != 0 {
+                f.write_str(">")?;
+            }
+            if o.op & OP_EQ != 0 {
+                f.write_str("=")?;
+            }
+            write!(f, "{}", o.value)?;
+        }
+    }
+    Ok(())
+}
+
+/// Destination / source prefix component value. IPv4 (RFC 8955) is a
+/// plain prefix; IPv6 (RFC 8956 §3.1) adds a bit `offset` and carries
+/// only the `length - offset` pattern bits, so the raw pattern octets
+/// are retained for exact round-tripping.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum FlowspecPrefix {
+    V4(Ipv4Net),
+    V6 {
+        length: u8,
+        offset: u8,
+        pattern: Vec<u8>,
+    },
+}
+
+impl FlowspecPrefix {
+    fn emit_value(&self, buf: &mut BytesMut) {
+        match self {
+            FlowspecPrefix::V4(net) => {
+                let len = net.prefix_len();
+                buf.put_u8(len);
+                let psize = nlri_psize(len);
+                buf.put(&net.addr().octets()[..psize]);
+            }
+            FlowspecPrefix::V6 {
+                length,
+                offset,
+                pattern,
+            } => {
+                buf.put_u8(*length);
+                buf.put_u8(*offset);
+                buf.put(&pattern[..]);
+            }
+        }
+    }
+}
+
+impl fmt::Display for FlowspecPrefix {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FlowspecPrefix::V4(net) => write!(f, "{net}"),
+            FlowspecPrefix::V6 {
+                length,
+                offset,
+                pattern,
+            } => {
+                if *offset == 0 {
+                    let mut octets = [0u8; 16];
+                    let n = pattern.len().min(16);
+                    octets[..n].copy_from_slice(&pattern[..n]);
+                    match Ipv6Net::new(Ipv6Addr::from(octets), *length) {
+                        Ok(net) => write!(f, "{net}"),
+                        Err(_) => write!(f, "len={length}/off={offset}"),
+                    }
+                } else {
+                    write!(f, "len={length}/off={offset}/0x")?;
+                    for b in pattern {
+                        write!(f, "{b:02x}")?;
+                    }
+                    Ok(())
+                }
+            }
+        }
+    }
+}
+
+fn parse_prefix(input: &[u8], afi: Afi) -> IResult<&[u8], FlowspecPrefix> {
+    match afi {
+        Afi::Ip6 => {
+            let (input, length) = be_u8(input)?;
+            if length > 128 {
+                return Err(nom::Err::Error(make_error(input, ErrorKind::Verify)));
+            }
+            let (input, offset) = be_u8(input)?;
+            if offset > length {
+                return Err(nom::Err::Error(make_error(input, ErrorKind::Verify)));
+            }
+            let psize = nlri_psize(length - offset);
+            let (input, pbytes) = take(psize).parse(input)?;
+            Ok((
+                input,
+                FlowspecPrefix::V6 {
+                    length,
+                    offset,
+                    pattern: pbytes.to_vec(),
+                },
+            ))
+        }
+        _ => {
+            let (input, length) = be_u8(input)?;
+            if length > 32 {
+                return Err(nom::Err::Error(make_error(input, ErrorKind::Verify)));
+            }
+            let psize = nlri_psize(length);
+            let (input, pbytes) = take(psize).parse(input)?;
+            let mut octets = [0u8; 4];
+            octets[..psize].copy_from_slice(pbytes);
+            let net = Ipv4Net::new(Ipv4Addr::from(octets), length)
+                .map_err(|_| nom::Err::Error(make_error(input, ErrorKind::Verify)))?;
+            Ok((input, FlowspecPrefix::V4(net)))
+        }
+    }
+}
+
+/// One Flow Specification match component (RFC 8955 Table 1 / RFC 8956).
+/// Variant order matches the component-type numbering so the derived
+/// layout reads top-to-bottom in wire order.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum FlowspecComponent {
+    /// Type 1 — Destination Prefix.
+    DestinationPrefix(FlowspecPrefix),
+    /// Type 2 — Source Prefix.
+    SourcePrefix(FlowspecPrefix),
+    /// Type 3 — IP Protocol (IPv4) / Upper-Layer Protocol (IPv6).
+    IpProtocol(Vec<FlowspecOp>),
+    /// Type 4 — Port (source or destination).
+    Port(Vec<FlowspecOp>),
+    /// Type 5 — Destination Port.
+    DestinationPort(Vec<FlowspecOp>),
+    /// Type 6 — Source Port.
+    SourcePort(Vec<FlowspecOp>),
+    /// Type 7 — ICMP / ICMPv6 Type.
+    IcmpType(Vec<FlowspecOp>),
+    /// Type 8 — ICMP / ICMPv6 Code.
+    IcmpCode(Vec<FlowspecOp>),
+    /// Type 9 — TCP Flags (bitmask).
+    TcpFlags(Vec<FlowspecOp>),
+    /// Type 10 — Packet Length.
+    PacketLength(Vec<FlowspecOp>),
+    /// Type 11 — DSCP.
+    Dscp(Vec<FlowspecOp>),
+    /// Type 12 — Fragment (bitmask).
+    Fragment(Vec<FlowspecOp>),
+    /// Type 13 — Flow Label (IPv6 only, RFC 8956 §3.1).
+    FlowLabel(Vec<FlowspecOp>),
+}
+
+impl FlowspecComponent {
+    /// Wire component-type number (1–13).
+    pub fn component_type(&self) -> u8 {
+        match self {
+            FlowspecComponent::DestinationPrefix(_) => 1,
+            FlowspecComponent::SourcePrefix(_) => 2,
+            FlowspecComponent::IpProtocol(_) => 3,
+            FlowspecComponent::Port(_) => 4,
+            FlowspecComponent::DestinationPort(_) => 5,
+            FlowspecComponent::SourcePort(_) => 6,
+            FlowspecComponent::IcmpType(_) => 7,
+            FlowspecComponent::IcmpCode(_) => 8,
+            FlowspecComponent::TcpFlags(_) => 9,
+            FlowspecComponent::PacketLength(_) => 10,
+            FlowspecComponent::Dscp(_) => 11,
+            FlowspecComponent::Fragment(_) => 12,
+            FlowspecComponent::FlowLabel(_) => 13,
+        }
+    }
+
+    /// Encode the component value only (no leading type byte).
+    fn emit_value(&self, buf: &mut BytesMut) {
+        match self {
+            FlowspecComponent::DestinationPrefix(p) | FlowspecComponent::SourcePrefix(p) => {
+                p.emit_value(buf)
+            }
+            FlowspecComponent::IpProtocol(ops)
+            | FlowspecComponent::Port(ops)
+            | FlowspecComponent::DestinationPort(ops)
+            | FlowspecComponent::SourcePort(ops)
+            | FlowspecComponent::IcmpType(ops)
+            | FlowspecComponent::IcmpCode(ops)
+            | FlowspecComponent::TcpFlags(ops)
+            | FlowspecComponent::PacketLength(ops)
+            | FlowspecComponent::Dscp(ops)
+            | FlowspecComponent::Fragment(ops)
+            | FlowspecComponent::FlowLabel(ops) => emit_op_list(ops, buf),
+        }
+    }
+
+    /// Encode the full component (type byte + value).
+    fn emit(&self, buf: &mut BytesMut) {
+        buf.put_u8(self.component_type());
+        self.emit_value(buf);
+    }
+
+    /// The component value as raw octets, used by the §5.1 precedence
+    /// comparison for non-prefix components.
+    fn value_bytes(&self) -> Vec<u8> {
+        let mut buf = BytesMut::new();
+        self.emit_value(&mut buf);
+        buf.to_vec()
+    }
+}
+
+impl fmt::Display for FlowspecComponent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FlowspecComponent::DestinationPrefix(p) => write!(f, "dst {p}"),
+            FlowspecComponent::SourcePrefix(p) => write!(f, "src {p}"),
+            FlowspecComponent::IpProtocol(ops) => {
+                f.write_str("proto ")?;
+                fmt_op_list(ops, false, f)
+            }
+            FlowspecComponent::Port(ops) => {
+                f.write_str("port ")?;
+                fmt_op_list(ops, false, f)
+            }
+            FlowspecComponent::DestinationPort(ops) => {
+                f.write_str("dport ")?;
+                fmt_op_list(ops, false, f)
+            }
+            FlowspecComponent::SourcePort(ops) => {
+                f.write_str("sport ")?;
+                fmt_op_list(ops, false, f)
+            }
+            FlowspecComponent::IcmpType(ops) => {
+                f.write_str("icmp-type ")?;
+                fmt_op_list(ops, false, f)
+            }
+            FlowspecComponent::IcmpCode(ops) => {
+                f.write_str("icmp-code ")?;
+                fmt_op_list(ops, false, f)
+            }
+            FlowspecComponent::TcpFlags(ops) => {
+                f.write_str("tcp-flags ")?;
+                fmt_op_list(ops, true, f)
+            }
+            FlowspecComponent::PacketLength(ops) => {
+                f.write_str("length ")?;
+                fmt_op_list(ops, false, f)
+            }
+            FlowspecComponent::Dscp(ops) => {
+                f.write_str("dscp ")?;
+                fmt_op_list(ops, false, f)
+            }
+            FlowspecComponent::Fragment(ops) => {
+                f.write_str("fragment ")?;
+                fmt_op_list(ops, true, f)
+            }
+            FlowspecComponent::FlowLabel(ops) => {
+                f.write_str("flow-label ")?;
+                fmt_op_list(ops, false, f)
+            }
+        }
+    }
+}
+
+fn parse_component(input: &[u8], afi: Afi) -> IResult<&[u8], FlowspecComponent> {
+    let (input, typ) = be_u8(input)?;
+    match typ {
+        1 => {
+            let (input, p) = parse_prefix(input, afi)?;
+            Ok((input, FlowspecComponent::DestinationPrefix(p)))
+        }
+        2 => {
+            let (input, p) = parse_prefix(input, afi)?;
+            Ok((input, FlowspecComponent::SourcePrefix(p)))
+        }
+        3 => {
+            let (input, ops) = parse_op_list(input)?;
+            Ok((input, FlowspecComponent::IpProtocol(ops)))
+        }
+        4 => {
+            let (input, ops) = parse_op_list(input)?;
+            Ok((input, FlowspecComponent::Port(ops)))
+        }
+        5 => {
+            let (input, ops) = parse_op_list(input)?;
+            Ok((input, FlowspecComponent::DestinationPort(ops)))
+        }
+        6 => {
+            let (input, ops) = parse_op_list(input)?;
+            Ok((input, FlowspecComponent::SourcePort(ops)))
+        }
+        7 => {
+            let (input, ops) = parse_op_list(input)?;
+            Ok((input, FlowspecComponent::IcmpType(ops)))
+        }
+        8 => {
+            let (input, ops) = parse_op_list(input)?;
+            Ok((input, FlowspecComponent::IcmpCode(ops)))
+        }
+        9 => {
+            let (input, ops) = parse_op_list(input)?;
+            Ok((input, FlowspecComponent::TcpFlags(ops)))
+        }
+        10 => {
+            let (input, ops) = parse_op_list(input)?;
+            Ok((input, FlowspecComponent::PacketLength(ops)))
+        }
+        11 => {
+            let (input, ops) = parse_op_list(input)?;
+            Ok((input, FlowspecComponent::Dscp(ops)))
+        }
+        12 => {
+            let (input, ops) = parse_op_list(input)?;
+            Ok((input, FlowspecComponent::Fragment(ops)))
+        }
+        13 => {
+            // Flow Label is IPv6-only (RFC 8956 §3.1); reject it under
+            // an IPv4 flow spec rather than silently accept.
+            if afi != Afi::Ip6 {
+                return Err(nom::Err::Error(make_error(input, ErrorKind::Verify)));
+            }
+            let (input, ops) = parse_op_list(input)?;
+            Ok((input, FlowspecComponent::FlowLabel(ops)))
+        }
+        _ => Err(nom::Err::Error(make_error(input, ErrorKind::NoneOf))),
+    }
+}
+
+/// A parsed Flow Specification NLRI: an ordered list of match
+/// components, tagged with the address family it belongs to (so a
+/// prefix-less spec still distinguishes IPv4 from IPv6) and an optional
+/// Add-Path identifier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FlowspecNlri {
+    /// RFC 7911 Add-Path identifier; 0 when Add-Path is not in use.
+    pub id: u32,
+    pub afi: Afi,
+    pub components: Vec<FlowspecComponent>,
+}
+
+impl FlowspecNlri {
+    pub fn new(afi: Afi, components: Vec<FlowspecComponent>) -> Self {
+        Self {
+            id: 0,
+            afi,
+            components,
+        }
+    }
+
+    /// Parse one Flow Specification NLRI. `afi` selects the IPv4
+    /// (RFC 8955) vs IPv6 (RFC 8956) prefix encoding and gates the
+    /// IPv6-only Flow Label component.
+    pub fn parse(input: &[u8], add_path: bool, afi: Afi) -> IResult<&[u8], FlowspecNlri> {
+        let (input, id) = if add_path { be_u32(input)? } else { (input, 0) };
+        let (input, len) = parse_length(input)?;
+        let (rest, value) = safe_split_at(input, len)?;
+        let mut value = value;
+        let mut components = Vec::new();
+        while !value.is_empty() {
+            let (next, comp) = parse_component(value, afi)?;
+            components.push(comp);
+            value = next;
+        }
+        Ok((
+            rest,
+            FlowspecNlri {
+                id,
+                afi,
+                components,
+            },
+        ))
+    }
+
+    /// Emit one Flow Specification NLRI (`<length, value>`, prefixed by
+    /// the 4-octet Add-Path id when `id != 0`). The value is buffered
+    /// first so the length field is computed from the real component
+    /// encoding.
+    pub fn nlri_emit(&self, buf: &mut BytesMut) {
+        if self.id != 0 {
+            buf.put_u32(self.id);
+        }
+        let mut value = BytesMut::new();
+        for c in &self.components {
+            c.emit(&mut value);
+        }
+        emit_length(value.len(), buf);
+        buf.put(&value[..]);
+    }
+}
+
+/// Compare two flow specs by RFC 8955 §5.1 precedence. The
+/// higher-precedence spec sorts **first** (`Ordering::Less`), so a
+/// `BTreeMap` keyed on `FlowspecNlri` iterates in the order rules must
+/// be applied in the dataplane.
+impl Ord for FlowspecNlri {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match flow_cmp(&self.components, &other.components) {
+            Ordering::Equal => {
+                // Components identical ⇒ structurally equal but for the
+                // family / Add-Path id. Tie-break so `Ord` stays
+                // consistent with the derived `Eq` (within one family
+                // `afi` is constant, so precedence is unaffected).
+                (u16::from(self.afi), self.id).cmp(&(u16::from(other.afi), other.id))
+            }
+            ord => ord,
+        }
+    }
+}
+
+impl PartialOrd for FlowspecNlri {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl fmt::Display for FlowspecNlri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (i, c) in self.components.iter().enumerate() {
+            if i != 0 {
+                f.write_str(",")?;
+            }
+            write!(f, "{c}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Walk two component lists in lockstep applying §5.1: lower component
+/// type wins; for an equal type the per-component rule decides; the
+/// spec with more components (a strict superset of conditions) is the
+/// more specific and wins when the shared prefix is equal.
+fn flow_cmp(a: &[FlowspecComponent], b: &[FlowspecComponent]) -> Ordering {
+    let mut ai = a.iter();
+    let mut bi = b.iter();
+    loop {
+        match (ai.next(), bi.next()) {
+            (None, None) => return Ordering::Equal,
+            (None, Some(_)) => return Ordering::Greater, // b is more specific
+            (Some(_), None) => return Ordering::Less,    // a is more specific
+            (Some(ca), Some(cb)) => {
+                let (ta, tb) = (ca.component_type(), cb.component_type());
+                if ta != tb {
+                    return ta.cmp(&tb); // lower type ⇒ Less ⇒ higher precedence
+                }
+                let ord = component_precedence(ca, cb);
+                if ord != Ordering::Equal {
+                    return ord;
+                }
+            }
+        }
+    }
+}
+
+/// Precedence between two components of the *same* type.
+fn component_precedence(a: &FlowspecComponent, b: &FlowspecComponent) -> Ordering {
+    use FlowspecComponent::*;
+    match (a, b) {
+        (DestinationPrefix(pa), DestinationPrefix(pb)) | (SourcePrefix(pa), SourcePrefix(pb)) => {
+            prefix_precedence(pa, pb)
+        }
+        _ => memcmp_precedence(&a.value_bytes(), &b.value_bytes()),
+    }
+}
+
+/// §5.1 string rule: compare the common prefix as a binary string
+/// (lower value ⇒ higher precedence); if the common prefix is equal the
+/// longer string is more specific and wins.
+fn memcmp_precedence(a: &[u8], b: &[u8]) -> Ordering {
+    let n = a.len().min(b.len());
+    match a[..n].cmp(&b[..n]) {
+        Ordering::Equal => b.len().cmp(&a.len()), // longer ⇒ Less ⇒ higher precedence
+        other => other,
+    }
+}
+
+/// §5.1 IP-prefix rule: precedence to the lowest IP value over the
+/// common (shorter) prefix length; if those bits are equal the more
+/// specific (longer) prefix wins.
+fn prefix_precedence(a: &FlowspecPrefix, b: &FlowspecPrefix) -> Ordering {
+    match (a, b) {
+        (FlowspecPrefix::V4(na), FlowspecPrefix::V4(nb)) => {
+            let (la, lb) = (na.prefix_len(), nb.prefix_len());
+            let common = la.min(lb);
+            let va = mask_v4(u32::from(na.addr()), common);
+            let vb = mask_v4(u32::from(nb.addr()), common);
+            match va.cmp(&vb) {
+                Ordering::Equal => lb.cmp(&la), // longer ⇒ Less ⇒ more specific
+                other => other,
+            }
+        }
+        (
+            FlowspecPrefix::V6 {
+                length: la,
+                offset: 0,
+                pattern: pa,
+            },
+            FlowspecPrefix::V6 {
+                length: lb,
+                offset: 0,
+                pattern: pb,
+            },
+        ) => {
+            let common = (*la).min(*lb);
+            let va = mask_v6(v6_from_pattern(pa), common);
+            let vb = mask_v6(v6_from_pattern(pb), common);
+            match va.cmp(&vb) {
+                Ordering::Equal => lb.cmp(la),
+                other => other,
+            }
+        }
+        // Mixed family or non-zero IPv6 offset: fall back to the binary
+        // string rule on the encoded value (total and deterministic;
+        // exact §5.1 ordering for offset prefixes is unspecified).
+        _ => {
+            let (mut ba, mut bb) = (BytesMut::new(), BytesMut::new());
+            a.emit_value(&mut ba);
+            b.emit_value(&mut bb);
+            memcmp_precedence(&ba, &bb)
+        }
+    }
+}
+
+fn mask_v4(addr: u32, len: u8) -> u32 {
+    if len == 0 {
+        0
+    } else if len >= 32 {
+        addr
+    } else {
+        addr & (u32::MAX << (32 - len))
+    }
+}
+
+fn mask_v6(addr: u128, len: u8) -> u128 {
+    if len == 0 {
+        0
+    } else if len >= 128 {
+        addr
+    } else {
+        addr & (u128::MAX << (128 - len))
+    }
+}
+
+fn v6_from_pattern(pattern: &[u8]) -> u128 {
+    let mut octets = [0u8; 16];
+    let n = pattern.len().min(16);
+    octets[..n].copy_from_slice(&pattern[..n]);
+    u128::from_be_bytes(octets)
+}
+
+/// Parse the variable-length NLRI length field (RFC 8955 §4.1): a
+/// single octet for values < 240, else a 2-octet value whose top nibble
+/// is `0xf`.
+fn parse_length(input: &[u8]) -> IResult<&[u8], usize> {
+    let (input, b0) = be_u8(input)?;
+    if b0 & 0xf0 == 0xf0 {
+        let (input, b1) = be_u8(input)?;
+        let len = (((b0 & 0x0f) as usize) << 8) | (b1 as usize);
+        Ok((input, len))
+    } else {
+        Ok((input, b0 as usize))
+    }
+}
+
+fn emit_length(len: usize, buf: &mut BytesMut) {
+    if len < 240 {
+        buf.put_u8(len as u8);
+    } else {
+        // RFC 8955 §4.1 caps the encodable length at 0xfff (4095).
+        buf.put_u8(0xf0 | ((len >> 8) as u8 & 0x0f));
+        buf.put_u8((len & 0xff) as u8);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Round-trip a flow spec through emit → parse and assert equality.
+    fn round_trip(nlri: &FlowspecNlri) {
+        let mut buf = BytesMut::new();
+        nlri.nlri_emit(&mut buf);
+        let (rest, parsed) = FlowspecNlri::parse(&buf, nlri.id != 0, nlri.afi).expect("must parse");
+        assert!(rest.is_empty(), "trailing bytes after parse");
+        assert_eq!(&parsed, nlri);
+    }
+
+    #[test]
+    fn ipv4_dst_proto_dport_round_trip() {
+        let nlri = FlowspecNlri::new(
+            Afi::Ip,
+            vec![
+                FlowspecComponent::DestinationPrefix(FlowspecPrefix::V4(
+                    "10.0.0.0/24".parse().unwrap(),
+                )),
+                FlowspecComponent::IpProtocol(vec![FlowspecOp::numeric(
+                    false, false, false, true, 6,
+                )]),
+                FlowspecComponent::DestinationPort(vec![FlowspecOp::numeric(
+                    false, false, false, true, 80,
+                )]),
+            ],
+        );
+        round_trip(&nlri);
+    }
+
+    #[test]
+    fn ipv4_port_range_two_terms_round_trip() {
+        // dport >= 1024 AND <= 2048 — two numeric terms, the second
+        // ANDed onto the first.
+        let nlri = FlowspecNlri::new(
+            Afi::Ip,
+            vec![FlowspecComponent::DestinationPort(vec![
+                FlowspecOp::numeric(false, false, true, true, 1024),
+                FlowspecOp::numeric(true, true, false, true, 2048),
+            ])],
+        );
+        round_trip(&nlri);
+    }
+
+    #[test]
+    fn ipv4_tcp_flags_bitmask_round_trip() {
+        // Match the SYN bit (0x02).
+        let nlri = FlowspecNlri::new(
+            Afi::Ip,
+            vec![FlowspecComponent::TcpFlags(vec![FlowspecOp::bitmask(
+                false, false, true, 0x02,
+            )])],
+        );
+        round_trip(&nlri);
+    }
+
+    #[test]
+    fn ipv6_dst_nextheader_flowlabel_round_trip() {
+        let nlri = FlowspecNlri::new(
+            Afi::Ip6,
+            vec![
+                FlowspecComponent::DestinationPrefix(FlowspecPrefix::V6 {
+                    length: 64,
+                    offset: 0,
+                    pattern: "2001:db8::".parse::<Ipv6Addr>().unwrap().octets()[..8].to_vec(),
+                }),
+                FlowspecComponent::IpProtocol(vec![FlowspecOp::numeric(
+                    false, false, false, true, 58,
+                )]),
+                FlowspecComponent::FlowLabel(vec![FlowspecOp::numeric(
+                    false, false, false, true, 1234,
+                )]),
+            ],
+        );
+        round_trip(&nlri);
+    }
+
+    #[test]
+    fn ipv6_prefix_with_offset_round_trips() {
+        // Offset matching is retained verbatim via the raw pattern.
+        let nlri = FlowspecNlri::new(
+            Afi::Ip6,
+            vec![FlowspecComponent::SourcePrefix(FlowspecPrefix::V6 {
+                length: 128,
+                offset: 64,
+                pattern: vec![0, 0, 0, 0, 0, 0, 0, 1],
+            })],
+        );
+        round_trip(&nlri);
+    }
+
+    #[test]
+    fn flow_label_rejected_under_ipv4() {
+        // Type 13 under an IPv4 spec must fail to parse.
+        let mut value = BytesMut::new();
+        FlowspecComponent::FlowLabel(vec![FlowspecOp::numeric(false, false, false, true, 1)])
+            .emit(&mut value);
+        let mut nlri = BytesMut::new();
+        emit_length(value.len(), &mut nlri);
+        nlri.put(&value[..]);
+        assert!(FlowspecNlri::parse(&nlri, false, Afi::Ip).is_err());
+    }
+
+    #[test]
+    fn two_octet_length_round_trips() {
+        // Build a spec whose value exceeds 240 octets, forcing the
+        // extended 2-octet length encoding. ~80 port terms × 3 octets.
+        let ops: Vec<FlowspecOp> = (0..80)
+            .map(|i| FlowspecOp::numeric(i != 0, false, false, true, 1000 + i as u64))
+            .collect();
+        let nlri = FlowspecNlri::new(Afi::Ip, vec![FlowspecComponent::DestinationPort(ops)]);
+        let mut buf = BytesMut::new();
+        nlri.nlri_emit(&mut buf);
+        // First length octet must carry the 0xf extended-length nibble.
+        assert_eq!(buf[0] & 0xf0, 0xf0, "expected 2-octet length encoding");
+        round_trip(&nlri);
+    }
+
+    #[test]
+    fn precedence_lower_type_wins() {
+        // A spec leading with a destination prefix (type 1) outranks one
+        // leading with a protocol match (type 3).
+        let a = FlowspecNlri::new(
+            Afi::Ip,
+            vec![FlowspecComponent::DestinationPrefix(FlowspecPrefix::V4(
+                "10.0.0.0/24".parse().unwrap(),
+            ))],
+        );
+        let b = FlowspecNlri::new(
+            Afi::Ip,
+            vec![FlowspecComponent::IpProtocol(vec![FlowspecOp::numeric(
+                false, false, false, true, 6,
+            )])],
+        );
+        assert!(a < b, "type 1 must outrank type 3");
+    }
+
+    #[test]
+    fn precedence_more_specific_prefix_wins() {
+        // /24 is more specific than /16 of the same network ⇒ higher
+        // precedence ⇒ sorts first.
+        let more = FlowspecNlri::new(
+            Afi::Ip,
+            vec![FlowspecComponent::DestinationPrefix(FlowspecPrefix::V4(
+                "10.0.0.0/24".parse().unwrap(),
+            ))],
+        );
+        let less = FlowspecNlri::new(
+            Afi::Ip,
+            vec![FlowspecComponent::DestinationPrefix(FlowspecPrefix::V4(
+                "10.0.0.0/16".parse().unwrap(),
+            ))],
+        );
+        assert!(more < less);
+    }
+
+    #[test]
+    fn precedence_lower_ip_value_wins() {
+        let lower = FlowspecNlri::new(
+            Afi::Ip,
+            vec![FlowspecComponent::DestinationPrefix(FlowspecPrefix::V4(
+                "10.0.0.0/24".parse().unwrap(),
+            ))],
+        );
+        let higher = FlowspecNlri::new(
+            Afi::Ip,
+            vec![FlowspecComponent::DestinationPrefix(FlowspecPrefix::V4(
+                "10.0.1.0/24".parse().unwrap(),
+            ))],
+        );
+        assert!(lower < higher);
+    }
+
+    #[test]
+    fn precedence_superset_is_more_specific() {
+        // Same leading component, but `more` adds a second condition ⇒
+        // it is the more specific spec and sorts first.
+        let dst = || {
+            FlowspecComponent::DestinationPrefix(FlowspecPrefix::V4("10.0.0.0/24".parse().unwrap()))
+        };
+        let less = FlowspecNlri::new(Afi::Ip, vec![dst()]);
+        let more = FlowspecNlri::new(
+            Afi::Ip,
+            vec![
+                dst(),
+                FlowspecComponent::IpProtocol(vec![FlowspecOp::numeric(
+                    false, false, false, true, 6,
+                )]),
+            ],
+        );
+        assert!(more < less);
+    }
+
+    #[test]
+    fn ord_consistent_with_eq() {
+        let a = FlowspecNlri::new(
+            Afi::Ip,
+            vec![FlowspecComponent::DestinationPrefix(FlowspecPrefix::V4(
+                "10.0.0.0/24".parse().unwrap(),
+            ))],
+        );
+        let b = a.clone();
+        assert_eq!(a.cmp(&b), Ordering::Equal);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn display_renders_components() {
+        let nlri = FlowspecNlri::new(
+            Afi::Ip,
+            vec![
+                FlowspecComponent::DestinationPrefix(FlowspecPrefix::V4(
+                    "10.0.0.0/24".parse().unwrap(),
+                )),
+                FlowspecComponent::DestinationPort(vec![FlowspecOp::numeric(
+                    false, false, false, true, 80,
+                )]),
+            ],
+        );
+        assert_eq!(nlri.to_string(), "dst 10.0.0.0/24,dport =80");
+    }
+}

--- a/docs/design/bgp-flowspec-plan.md
+++ b/docs/design/bgp-flowspec-plan.md
@@ -1,0 +1,291 @@
+# BGP Flowspec (IPv4 + IPv6) — Design & Phasing Plan
+
+Tracks the implementation of BGP Flow Specification (RFC 8955 / 8956,
+validation per RFC 9117) for zebra-rs, covering IPv4 and IPv6 unicast
+Flowspec (AFI 1/2, SAFI 133). This document is the locked plan: it
+captures the RFC surface, how FRR/Cisco map the hard part, the
+architecture decisions, the YANG schema, and the phase-by-phase slice
+so a contributor can resume without the conversation history.
+
+Read this first if you're touching `crates/bgp-packet/src/nlri_flowspec.rs`,
+the `MpReachAttr::Flowspec` / `MpUnreachAttr::Flowspec` arms, the
+`LocalRib.flowspec_v4/v6` tables, `bgp::route::route_flowspec_update`,
+the `rib::Message::Flowspec*` arms, or `zebra-rs/yang/zebra-bgp-flowspec.yang`.
+
+## Locked decisions (2026-05-30)
+
+| Decision        | Choice                                | Consequence                                                                 |
+| --------------- | ------------------------------------- | --------------------------------------------------------------------------- |
+| **Scope**       | IPv4 **and** IPv6 unicast (SAFI 133)  | VPN flowspec (SAFI 134), `redirect-to-VRF` dataplane deferred to a later series |
+| **Dataplane**   | Control-plane first, `tc` later       | Phases 0–3 ship receive/validate/RIB/advertise/show with **no install**; the `tc`-flower netlink southbound is a dedicated Phase 4 track (mirrors how the VPNv6-leak series shipped control-plane-only) |
+| **Origination** | Receive / reflect first               | Router consumes + re-advertises peer flowspec (RR / consumer role). Local-rule config (match+action YANG) and self-origination deferred to a later PR |
+
+Branch per phase, smallest-reviewable-PR-first (per project convention).
+
+## RFC surface
+
+| RFC      | Role                                                                    |
+| -------- | ----------------------------------------------------------------------- |
+| RFC 8955 | IPv4 Flowspec NLRI + traffic-filtering-action extended communities (obsoletes RFC 5575) |
+| RFC 8956 | IPv6 Flowspec — prefix `offset`, Flow Label (type 13), `redirect-ipv6`  |
+| RFC 9117 | Revised validation procedure (current normative validation — supersedes RFC 8955 §6) |
+
+**SAFIs:** 133 = Flowspec unicast (in scope), 134 = Flowspec L3VPN (deferred).
+
+### NLRI = ordered list of components
+
+A packet matches a flow spec only if it matches **all** components.
+Components are strictly ordered by type number on the wire; RFC 8955 §5.1
+ordering rules define **rule precedence**, which maps directly to dataplane
+filter priority (lowest type/most-specific = highest precedence = applied first).
+
+| Type | IPv4 (8955)        | IPv6 (8956) difference                          |
+| ---- | ------------------ | ----------------------------------------------- |
+| 1    | Destination Prefix | + `offset` field                                |
+| 2    | Source Prefix      | + `offset` field                                |
+| 3    | IP Protocol        | "Upper-Layer Protocol" (first non-ext Next Hdr) |
+| 4    | Port               | identical                                       |
+| 5    | Destination Port   | identical                                       |
+| 6    | Source Port        | identical                                       |
+| 7    | ICMP Type          | ICMPv6 Type                                     |
+| 8    | ICMP Code          | ICMPv6 Code                                     |
+| 9    | TCP Flags (bitmask)| identical                                       |
+| 10   | Packet Length      | identical                                       |
+| 11   | DSCP               | identical                                       |
+| 12   | Fragment (bitmask) | IPv6 fragment-header semantics                  |
+| 13   | —                  | **Flow Label** (IPv6 only)                      |
+
+Component values use two operator encodings:
+- **numeric_op** `{e, a, len, lt, gt, eq}` — ports, lengths, protocol, DSCP.
+- **bitmask_op** `{e, a, len, not, match}` — TCP flags, fragment.
+
+`e` = end-of-list, `a` = AND (else OR), `len` = value width `1<<len` octets.
+NLRI length field: 1 octet (`< 240`) or 2 octets (`0xfnnn`, up to 4095).
+
+### Actions = transitive extended communities
+
+| Hex                       | Action                | Payload                                       |
+| ------------------------- | --------------------- | --------------------------------------------- |
+| `0x8006`                  | traffic-rate-bytes    | AS(2) + IEEE-float rate, bytes/s (`0.0` = drop) |
+| `0x800c`                  | traffic-rate-packets  | rate in packets/s                             |
+| `0x8007`                  | traffic-action        | bit 47 = terminal, bit 46 = sample            |
+| `0x8008 / 0x8108 / 0x8208`| rt-redirect (AS2/IPv4/AS4) | redirect to VRF via Route-Target         |
+| `0x800d`                  | redirect-ipv6 (8956)  | IPv6-address-specific RT                       |
+| `0x8009`                  | traffic-marking       | DSCP value                                    |
+
+Normalized into a dataplane-independent action set:
+
+```rust
+enum FlowspecAction {
+    Discard,                     // traffic-rate-bytes 0.0
+    RateLimitBytes(f32),
+    RateLimitPackets(f32),
+    Sample,
+    Terminal,
+    RedirectVrf(RouteTarget),    // dataplane deferred
+    RedirectIp(IpAddr),          // dataplane deferred
+    MarkDscp(u8),
+}
+```
+
+### Validation (RFC 9117)
+
+A received flowspec is *valid* only if it embeds a destination-prefix
+component **and** the route's originator matches the best-path unicast
+route toward that destination (loosely for eBGP; iBGP / "designated
+controller" relax this). Must be **re-validated whenever unicast routes
+change** — hook the existing NHT / RIB-change notification path
+(`bgp/nht.rs`) so revalidation is event-driven, not polled. Invalid rules
+stay in Adj-RIB-In but are not installed and not re-advertised. A
+per-neighbor `validation { strict | disable }` knob covers the
+controller/iBGP relaxation case.
+
+## How FRR / Cisco do it (the lesson)
+
+- **FRR** (`bgpd` + `zebra`): control plane is ordinary MP-BGP. The
+  dataplane historically programs **ipset + iptables + `ip rule` + a
+  reserved block of policy routing tables**; the GSoC-2022 "Zebra Traffic
+  Control" work added a proper **`tc` (netlink)** southbound
+  (qdisc/filter/police). FRR supports a subset of components and an
+  "interface-set" notion for where rules apply.
+- **Cisco IOS-XR / Juniper**: identical control plane; actions expressed
+  through native frameworks (XR MQC `class-map`/`policy-map`; Juniper
+  auto-generates a firewall filter). Both do RFC validation, v4+v6,
+  redirect-to-VRF and redirect-to-nexthop.
+
+**Lesson:** the receive/advertise/RIB control plane is ~standard MP-BGP
+and reuses zebra-rs's EVPN/VPNv4 machinery almost entirely. The divergent,
+expensive, platform-specific part is **action → dataplane**, and zebra-rs
+has *zero* traffic-control southbound today. The plan therefore separates
+the cheap, high-reuse control plane from the new, large dataplane build.
+
+## Fit against current zebra-rs
+
+| Layer                                       | Status                              | Anchor                                          |
+| ------------------------------------------- | ----------------------------------- | ----------------------------------------------- |
+| `Safi::Flowspec = 133`                      | **exists**                          | `crates/bgp-packet/src/afi.rs:38`               |
+| Ext-community framework                     | **exists**, extend                  | `attrs/ext_com.rs`, `ext_com_type.rs`           |
+| MP_REACH/UNREACH AFI/SAFI dispatch          | **exists** (VPNv4/EVPN/MUP)         | `attrs/mp_reach.rs:111-361`                     |
+| Capability negotiation per family           | **generic** for any SAFI            | `caps/mp.rs`, `bgp/cap.rs:30-48`                |
+| Per-peer family enable `config.mp`          | **exists**; parser needs new names  | `bgp/peer.rs:202-209`, `config/configs.rs:125`  |
+| **Exact-match RIB** (not prefix-trie)       | **template** = `LocalRibEvpnTable`  | `bgp/route.rs:826-831, 932-943`                 |
+| Unicast Loc-RIB + NHT (for validation)      | **exists**                          | `bgp/nht.rs`                                     |
+| **tc / policer / ACL southbound**           | **does NOT exist — Phase 4 build**  | nothing in `fib/`, `rib/`                       |
+| VRF tables / l3mdev (redirect-to-VRF)       | **exists** (deferred use)           | `fib/netlink/handle.rs:1649-1717`               |
+
+Closest end-to-end template: **EVPN Type-5 series** (exact-match RIB, new
+`MpReachAttr` variant, `route_evpn_update()`) crossed with the
+**VPNv6-leak series** (control-plane-only landing, dataplane deferred).
+
+## Architecture
+
+```
+                        ┌─────────────────────────────────────────┐
+   wire  ───────────►   │ crates/bgp-packet                        │  Phase 0
+                        │  FlowspecNlri (component TLV codec, v4/v6)│
+                        │  FlowspecAction ext-comm sub-types        │
+                        │  Ord per RFC 8955 §5.1 (= filter prio)    │
+                        └───────────────┬─────────────────────────┘
+                          MpReachAttr::Flowspec / MpUnreachAttr::Flowspec
+                        ┌───────────────▼─────────────────────────┐
+                        │ zebra-rs/src/bgp                          │
+   Adj-RIB-In  ─────►   │  AdjRibFlowspecTable<D>                   │  Phase 1
+   validation  ─────►   │  validate vs unicast Loc-RIB (RFC 9117)   │  Phase 2
+   Loc-RIB     ─────►   │  LocalRib.flowspec_v4 / flowspec_v6       │  Phase 3
+   re-advertise─────►   │  update-group flush to flowspec peers     │
+                        └───────────────┬─────────────────────────┘
+                              rib::Message::Flowspec{Add,Del}  (stubbed P1-3)
+                        ┌───────────────▼─────────────────────────┐
+                        │ zebra-rs/src/rib + fib  (NEW southbound)  │  Phase 4
+                        │  tc qdisc + flower filter +               │
+                        │  police / skbedit  via netlink            │
+                        └───────────────────────────────────────────┘
+```
+
+### Codec (`crates/bgp-packet`) — Phase 0
+
+New `nlri_flowspec.rs` mirroring `nlri_vpnv4.rs` / `nlri_evpn.rs`:
+- `FlowspecComponent` enum (the 13 component types) and
+  `FlowspecNlri { components: Vec<FlowspecComponent> }`, AFI-parameterized so
+  one vec serves v4 (types 1–12) and v6 (types 1–13 with prefix `offset`).
+- `MpReachAttr::Flowspec { afi, nlri: Vec<FlowspecNlri> }` and
+  `MpUnreachAttr::Flowspec` — **no next-hop** (MP_REACH next-hop length 0).
+- Extend `ext_com_type.rs` with the `0x80xx` action sub-types + typed
+  accessors (`as_traffic_rate`, `as_traffic_action`, `as_redirect_rt`,
+  `as_traffic_marking`).
+- **`Ord` on `FlowspecNlri` per RFC 8955 §5.1** (type-ascending,
+  more-specific-prefix wins, else `memcmp`) so the `BTreeMap` iterates in
+  rule-precedence order → reusable as dataplane filter priority.
+- Round-trip parse/emit tests in `crates/bgp-packet/tests`.
+
+### RIB / control plane (`zebra-rs/src/bgp`) — Phases 1–3
+
+Follow the **EVPN exact-match pattern**, *not* `LocalRibTable<P>`
+(flowspec is not a longest-prefix lookup — overlapping rules coexist):
+- `LocalRib { … flowspec_v4: BTreeMap<FlowspecNlri, BgpRib>, flowspec_v6: … }`
+  (`route.rs:932`).
+- `AdjRibFlowspecTable<D>` paralleling `AdjRibEvpnTable<D>` (`adj_rib.rs:92`).
+- `route_flowspec_update()` / `_withdraw()` paralleling `route_evpn_update()`,
+  dispatched from `route_from_peer()` (`route.rs:3239`).
+- Best-path: no MED / AS-path install semantics — selection is "valid?" +
+  precedence (from `Ord`). Keep simple (first valid wins).
+- `cap.rs:30` `CapAfiMap::new()` gains `(Ip,133)` and `(Ip6,133)`;
+  `config/configs.rs:125` `Args::afi_safi()` gains `ipv4-flowspec` /
+  `ipv6-flowspec`; `show.rs:76` label map gets the strings.
+
+### RIB message channel — Phase 4
+
+`rib::Message` (`rib/inst.rs:32`) gains
+`FlowspecAdd { afi, nlri, actions, ifindex: Option<u32> }` /
+`FlowspecDel { afi, nlri }`, with new async `FibHandle::flowspec_install /
+uninstall`. Stubbed/logged in Phases 1–3; real `tc`-flower (qdisc + flower
+classifier + `police`/`skbedit` actions, filter `prio` from the `Ord`) in
+Phase 4. `netlink-packet-route` (the route-centric fork) lacks
+`RTM_NEW{T,Q}FILTER` / `TCA_*` and must be extended (or raw netlink used).
+VPP's classifier/ACL is the natural future high-performance target.
+
+## YANG schema
+
+Three pieces, following `zebra-bgp-evpn.yang` / `zebra-bgp-redistribute.yang`
+conventions (kebab-case module, presence containers, augment into
+`…/router/bgp/afi-safi`, validated by `yang_load_tests` in
+`config/manager.rs:1183`).
+
+**(a) Family activation** — extend `zebra-afi-safi.yang` `afi-safi` grouping
+enum with `ipv4-flowspec`, `ipv6-flowspec`; add matching arms to
+`Args::afi_safi()` (`config/configs.rs:125`). Neighbor activation then works
+unchanged via the existing per-neighbor `afi-safi/<name>/enabled` path:
+
+```
+set router bgp 65000 neighbor 10.0.0.1 afi-safi ipv4-flowspec enabled true
+set router bgp 65000 neighbor 2001:db8::1 afi-safi ipv6-flowspec enabled true
+```
+
+**(b) Per-neighbor validation knob** — augment the neighbor afi-safi:
+
+```yang
+leaf validation { type enumeration { enum strict; enum disable; } default strict; }
+```
+
+**(c) `zebra-bgp-flowspec.yang` (prefix `zbf`) — deferred to the origination
+PR.** Local rule definition (match criteria + action choice) lives here when
+self-origination lands; the receive/reflect milestones do not need it.
+Sketch retained for the later series:
+
+```yang
+container flowspec {
+  list rule {
+    key "name";
+    leaf afi { type enumeration { enum ipv4; enum ipv6; } }
+    container match {
+      leaf destination-prefix { type inet:ip-prefix; }
+      leaf source-prefix      { type inet:ip-prefix; }
+      leaf-list protocol         { type uint8; }
+      leaf-list destination-port { type string; }   // "=80", ">=1024&<=2048"
+      leaf-list source-port      { type string; }
+      leaf-list packet-length    { type string; }
+      leaf dscp       { type uint8 { range "0..63"; } }
+      leaf tcp-flags  { type string; }
+      leaf fragment   { type string; }
+      leaf flow-label { type uint32; }               // ipv6 only
+    }
+    container action {
+      choice kind {
+        leaf rate-limit-bytes   { type uint64; }     // 0 = discard
+        leaf rate-limit-packets { type uint64; }
+        leaf discard            { type empty; }
+        leaf redirect-vrf       { type string; }
+        leaf redirect-ip        { type inet:ip-address; }
+        leaf mark-dscp          { type uint8 { range "0..63"; } }
+      }
+      leaf sample { type boolean; default false; }
+    }
+  }
+}
+```
+
+`config.rs` handlers follow the `config_redistribute_*` / `config_vrf_evpn_*`
+pattern (`config.rs:1622`, `vrf_config.rs:358`) — one callback per leaf into a
+`BgpFlowspecConfig` map on `Bgp`.
+
+## Phasing (one branch / PR each)
+
+| Phase | Scope                                                                 | Reuse  | Risk   |
+| ----- | --------------------------------------------------------------------- | ------ | ------ |
+| **0** | Codec: `FlowspecNlri` (v4+v6) + action ext-comms + `Ord` + round-trip tests | high   | low    |
+| **1** | Capability + receive → Adj-RIB-In + `show bgp ipv4/ipv6 flowspec` (no install) | high   | low    |
+| **2** | RFC 9117 validation vs unicast Loc-RIB; event-driven revalidation via NHT | medium | medium |
+| **3** | Loc-RIB best-path + re-advertise (update-group flush to flowspec peers) | medium | medium |
+| **4** | Dataplane: `tc`-flower netlink southbound (the large, independent build) | none   | high   |
+
+Phases 0–3 deliver a standards-compliant, interoperable,
+route-reflector-capable Flowspec implementation, mirroring how the v6 BGP
+stack shipped control-plane-first. Phase 4 carries the real engineering risk.
+
+### Deferred (later series)
+
+- VPN flowspec (SAFI 134) + `redirect-to-VRF` dataplane (reuses existing
+  VRF/l3mdev table infra).
+- `redirect-to-IP` dataplane.
+- Local flowspec rule origination (YANG module **c** above).
+- VPP classifier/ACL southbound.


### PR DESCRIPTION
Phase 0 of the BGP Flowspec series — a **codec-only** slice in the `bgp-packet` crate. No control-plane behaviour yet; received flow specs fall through the existing `route.rs` catch-alls, so nothing is installed. The full plan lives in `docs/design/bgp-flowspec-plan.md` (added here).

## What's in this PR

**`attrs/nlri_flowspec.rs`** — the Flow Specification NLRI codec:
- `FlowspecNlri` / `FlowspecComponent` (all 13 component types) / `FlowspecPrefix` (IPv4, plus IPv6-with-`offset` per RFC 8956 §3.1) / `FlowspecOp` (numeric & bitmask operator terms).
- Parses and re-emits both the IPv4 (RFC 8955) and IPv6 (RFC 8956) encodings and the variable 1/2-octet length field.
- `Ord` implements the RFC 8955 §5.1 precedence rules (lower type wins → more-specific prefix wins → memcmp), with the higher-precedence spec sorting first so a future `BTreeMap` key iterates in dataplane-apply order.

**`attrs/flowspec_action.rs`** — `FlowspecAction` ↔ `ExtCommunityValue` for the `0x80/0x81/0x82` traffic-filtering actions: rate-bytes/packets, traffic-action (terminal + sample), rt-redirect (AS2/IPv4/AS4), traffic-marking (DSCP).

**`MpReachAttr::Flowspec` / `MpUnreachAttr::Flowspec`** — AFI 1/2 + SAFI 133 parse dispatch, emit, and Display/EoR. MP_REACH uses next-hop-length 0 plus the RFC 4760 reserved/SNPA octet (matching FRR/Cisco/Juniper).

## Two non-obvious correctness points

- The operator **end-of-list bit is positional** — it only marks the final term — so it's stripped on parse and re-derived on emit; otherwise hand-built op lists fail round-trip.
- The IPv6 prefix `offset` field is preserved verbatim (raw pattern bytes) for exact round-tripping.

## Tests

`cargo test -p bgp-packet` → **206 passed** (27 new): NLRI round-trips for v4/v6, two-octet length, port ranges, TCP-flag bitmasks, offset prefixes, §5.1 precedence ordering, action round-trips, and full MP_REACH/MP_UNREACH attribute round-trips.

`cargo fmt --all` ✓ · `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Scope / next

Per the locked plan: IPv4 + IPv6 unicast (SAFI 133); control-plane-first (tc dataplane is Phase 4); receive/reflect first. Next up is **Phase 1** — capability negotiation + receive into Adj-RIB-In + `show bgp ipv4/ipv6 flowspec` (still no install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)