### PR TITLE
bgp: Labeled Unicast control plane — negotiate + Loc-RIB + advertise (SAFI 4)

### DIFF
--- a/zebra-rs/src/bgp/adj_rib.rs
+++ b/zebra-rs/src/bgp/adj_rib.rs
@@ -198,6 +198,10 @@ pub struct AdjRib<D: RibDirection> {
     pub v4: AdjRibTable<D>,
     // IPv6 unicast
     pub v6: AdjRibTable<D, Ipv6Net>,
+    // IPv4 Labeled-Unicast (SAFI 4)
+    pub v4lu: AdjRibTable<D>,
+    // IPv6 Labeled-Unicast (SAFI 4)
+    pub v6lu: AdjRibTable<D, Ipv6Net>,
     // IPv4 VPN
     pub v4vpn: BTreeMap<RouteDistinguisher, AdjRibTable<D>>,
     // IPv6 VPN
@@ -215,6 +219,8 @@ impl<D: RibDirection> AdjRib<D> {
         Self {
             v4: AdjRibTable::new(),
             v6: AdjRibTable::new(),
+            v4lu: AdjRibTable::new(),
+            v6lu: AdjRibTable::new(),
             v4vpn: BTreeMap::new(),
             v6vpn: BTreeMap::new(),
             evpn: BTreeMap::new(),
@@ -266,6 +272,24 @@ impl AdjRib<In> {
 
     pub fn remove_v6(&mut self, prefix: Ipv6Net, id: u32) -> Option<BgpRib> {
         self.v6.remove(prefix, id)
+    }
+
+    // IPv4 / IPv6 Labeled-Unicast (SAFI 4) add/remove.
+
+    pub fn add_v4lu(&mut self, prefix: Ipv4Net, route: BgpRib) -> Option<BgpRib> {
+        self.v4lu.add(prefix, route)
+    }
+
+    pub fn remove_v4lu(&mut self, prefix: Ipv4Net, id: u32) -> Option<BgpRib> {
+        self.v4lu.remove(prefix, id)
+    }
+
+    pub fn add_v6lu(&mut self, prefix: Ipv6Net, route: BgpRib) -> Option<BgpRib> {
+        self.v6lu.add(prefix, route)
+    }
+
+    pub fn remove_v6lu(&mut self, prefix: Ipv6Net, id: u32) -> Option<BgpRib> {
+        self.v6lu.remove(prefix, id)
     }
 
     pub fn add_v6vpn(
@@ -326,6 +350,8 @@ impl AdjRib<In> {
         match (afi, safi) {
             (Afi::Ip, Safi::Unicast) => self.v4.0.len(),
             (Afi::Ip6, Safi::Unicast) => self.v6.0.len(),
+            (Afi::Ip, Safi::MplsLabel) => self.v4lu.0.len(),
+            (Afi::Ip6, Safi::MplsLabel) => self.v6lu.0.len(),
             (Afi::Ip, Safi::MplsVpn) => self.v4vpn.values().map(|table| table.0.len()).sum(),
             (Afi::Ip6, Safi::MplsVpn) => self.v6vpn.values().map(|table| table.0.len()).sum(),
             (Afi::L2vpn, Safi::Evpn) => self.evpn.values().map(|table| table.0.len()).sum(),
@@ -367,6 +393,8 @@ impl AdjRib<Out> {
         match (afi, safi) {
             (Afi::Ip, Safi::Unicast) => self.v4.0.len(),
             (Afi::Ip6, Safi::Unicast) => self.v6.0.len(),
+            (Afi::Ip, Safi::MplsLabel) => self.v4lu.0.len(),
+            (Afi::Ip6, Safi::MplsLabel) => self.v6lu.0.len(),
             (Afi::Ip, Safi::MplsVpn) => self.v4vpn.values().map(|table| table.0.len()).sum(),
             (Afi::Ip6, Safi::MplsVpn) => self.v6vpn.values().map(|table| table.0.len()).sum(),
             (Afi::L2vpn, Safi::Evpn) => self.evpn.values().map(|table| table.0.len()).sum(),

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -545,13 +545,24 @@ fn config_afi_safi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
 fn config_network(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let afi_safi: AfiSafi = args.afi_safi()?;
     let network = args.v4net()?;
-    if afi_safi.afi != Afi::Ip || afi_safi.safi != Safi::Unicast {
-        return None;
-    }
-    if op.is_set() {
-        bgp.route_add(network);
-    } else {
-        bgp.route_del(network);
+    // `network` carries an ipv4-prefix, so it applies to the IPv4
+    // unicast and IPv4 Labeled-Unicast (SAFI 4) families.
+    match (afi_safi.afi, afi_safi.safi) {
+        (Afi::Ip, Safi::Unicast) => {
+            if op.is_set() {
+                bgp.route_add(network);
+            } else {
+                bgp.route_del(network);
+            }
+        }
+        (Afi::Ip, Safi::MplsLabel) => {
+            if op.is_set() {
+                bgp.route_add_label_v4(network);
+            } else {
+                bgp.route_del_label_v4(network);
+            }
+        }
+        _ => return None,
     }
     Some(())
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2878,7 +2878,10 @@ pub fn route_labelv4_update(
     }
 
     rib.attr = bgp.attr_store.intern(attr);
-    let _ = bgp.local_rib.update_v4lu(lu.nlri.prefix, rib);
+    let (_replaced, selected, _next_id) = bgp.local_rib.update_v4lu(lu.nlri.prefix, rib);
+    if !selected.is_empty() {
+        route_advertise_to_peers_labelv4(lu.nlri.prefix, &selected, bgp, peers);
+    }
 }
 
 /// Ingest a received IPv6 Labeled-Unicast (SAFI 4) route — including
@@ -2945,7 +2948,10 @@ pub fn route_labelv6_update(
     }
 
     rib.attr = bgp.attr_store.intern(attr);
-    let _ = bgp.local_rib.update_v6lu(lu.nlri.prefix, rib);
+    let (_replaced, selected, _next_id) = bgp.local_rib.update_v6lu(lu.nlri.prefix, rib);
+    if !selected.is_empty() {
+        route_advertise_to_peers_labelv6(lu.nlri.prefix, &selected, bgp, peers);
+    }
 }
 
 /// Withdraw a received IPv4 Labeled-Unicast route (MP_UNREACH or
@@ -2964,7 +2970,10 @@ pub fn route_labelv4_withdraw(
         peer.adj_in.remove_v4lu(nlri.prefix, nlri.id);
     }
     let _ = bgp.local_rib.remove_v4lu(nlri.prefix, nlri.id, ident);
-    let _ = bgp.local_rib.select_best_path_v4lu(nlri.prefix);
+    let selected = bgp.local_rib.select_best_path_v4lu(nlri.prefix);
+    // Empty `selected` → MP_UNREACH to LU peers; a replacement winner →
+    // re-advertise. Both handled by the advertise helper.
+    route_advertise_to_peers_labelv4(nlri.prefix, &selected, bgp, peers);
 }
 
 /// Withdraw a received IPv6 Labeled-Unicast route. See
@@ -2981,7 +2990,8 @@ pub fn route_labelv6_withdraw(
         peer.adj_in.remove_v6lu(nlri.prefix, nlri.id);
     }
     let _ = bgp.local_rib.remove_v6lu(nlri.prefix, nlri.id, ident);
-    let _ = bgp.local_rib.select_best_path_v6lu(nlri.prefix);
+    let selected = bgp.local_rib.select_best_path_v6lu(nlri.prefix);
+    route_advertise_to_peers_labelv6(nlri.prefix, &selected, bgp, peers);
 }
 
 pub fn route_ipv4_rtc_update(peer_id: usize, rtcv4: &Rtcv4, peers: &mut PeerMap) {
@@ -4534,6 +4544,270 @@ pub(super) fn route_advertise_to_peers_vpnv6(
     }
 }
 
+/// Extract a plain `IpAddr` from a unicast/labeled `BgpNexthop`. Returns
+/// `None` for VPN nexthops, which never appear on the LU rows.
+fn bgp_nexthop_to_ipaddr(nh: &BgpNexthop) -> Option<IpAddr> {
+    match nh {
+        BgpNexthop::Ipv4(a) => Some(IpAddr::V4(*a)),
+        BgpNexthop::Ipv6(a) => Some(IpAddr::V6(*a)),
+        BgpNexthop::Evpn(a) => Some(*a),
+        BgpNexthop::Vpnv4(_) | BgpNexthop::Vpnv6(_) => None,
+    }
+}
+
+/// Build the (NLRI, attr, next-hop, label) for advertising an IPv4
+/// Labeled-Unicast route to `peer`. Mirrors `route_update_ipv6`'s
+/// attribute handling (split-horizon, iBGP-RR gating, AS_PATH prepend,
+/// next-hop-self, LOCAL_PREF, ORIGINATOR_ID/CLUSTER_LIST) for SAFI 4.
+///
+/// The advertised label is the row's label — the received label when
+/// propagating, implicit-null (3) for self-originated FECs. The real
+/// per-prefix local label + ILM swap is Phase 5; Phase 4 installs
+/// nothing in the dataplane, so this is control-plane only.
+///
+/// `attrs.nexthop` is cleared: an MP_REACH carries the next-hop itself,
+/// and a `BgpNexthop::Ipv4` left on the attr would also emit a legacy
+/// (type-3) NEXT_HOP attribute.
+fn route_update_labelv4(
+    peer: &mut Peer,
+    prefix: &Ipv4Net,
+    rib: &BgpRib,
+    bgp: &mut BgpTop,
+    add_path: bool,
+) -> Option<(Ipv4Nlri, BgpAttr, IpAddr, Label)> {
+    if rib.ident == peer.ident {
+        return None;
+    }
+    if peer.peer_type == PeerType::IBGP
+        && rib.typ == BgpRibType::IBGP
+        && !peer.is_reflector_client()
+    {
+        return None;
+    }
+
+    let nlri = Ipv4Nlri {
+        id: if add_path { rib.local_id } else { 0 },
+        prefix: *prefix,
+    };
+    let mut attrs = (*rib.attr).clone();
+
+    if peer.is_ebgp()
+        && let Some(ref mut aspath) = attrs.aspath
+    {
+        aspath.prepend_mut(As4Path::from(vec![peer.local_as]));
+    }
+
+    // Next-hop-self for eBGP / locally-originated; otherwise keep the
+    // received next-hop (next-hop-unchanged). Captured before clearing
+    // `attrs.nexthop`.
+    let needs_self = peer.is_ebgp() || rib.is_originated();
+    let nhop: IpAddr = if needs_self {
+        // v4, or v6 for an RFC 8950 v4-over-v6 session.
+        peer.param.local_addr.as_ref().map(|a| a.ip())?
+    } else {
+        attrs.nexthop.as_ref().and_then(bgp_nexthop_to_ipaddr)?
+    };
+
+    if peer.is_ibgp() && attrs.local_pref.is_none() {
+        attrs.local_pref = Some(LocalPref::default());
+    }
+    if peer.peer_type == PeerType::IBGP
+        && rib.typ == BgpRibType::IBGP
+        && attrs.originator_id.is_none()
+    {
+        attrs.originator_id = Some(OriginatorId::new(rib.router_id));
+    }
+    if peer.peer_type == PeerType::IBGP && rib.typ == BgpRibType::IBGP {
+        if let Some(ref mut cluster_list) = attrs.cluster_list {
+            cluster_list.list.insert(0, *bgp.router_id);
+        } else {
+            let mut cluster_list = ClusterList::new();
+            cluster_list.list.push(*bgp.router_id);
+            attrs.cluster_list = Some(cluster_list);
+        }
+    }
+
+    attrs.nexthop = None;
+    let label = rib.label.unwrap_or(Label::new(3, 0, true));
+    Some((nlri, attrs, nhop, label))
+}
+
+/// IPv6 Labeled-Unicast counterpart of [`route_update_labelv4`]. For 6PE
+/// (RFC 4798), a next-hop-self over an IPv4 transport session is encoded
+/// as the IPv4-mapped IPv6 form of the local address.
+fn route_update_labelv6(
+    peer: &mut Peer,
+    prefix: &Ipv6Net,
+    rib: &BgpRib,
+    bgp: &mut BgpTop,
+    add_path: bool,
+) -> Option<(Ipv6Nlri, BgpAttr, IpAddr, Label)> {
+    if rib.ident == peer.ident {
+        return None;
+    }
+    if peer.peer_type == PeerType::IBGP
+        && rib.typ == BgpRibType::IBGP
+        && !peer.is_reflector_client()
+    {
+        return None;
+    }
+
+    let nlri = Ipv6Nlri {
+        id: if add_path { rib.local_id } else { 0 },
+        prefix: *prefix,
+    };
+    let mut attrs = (*rib.attr).clone();
+
+    if peer.is_ebgp()
+        && let Some(ref mut aspath) = attrs.aspath
+    {
+        aspath.prepend_mut(As4Path::from(vec![peer.local_as]));
+    }
+
+    let needs_self = peer.is_ebgp() || rib.is_originated();
+    let nhop: IpAddr = if needs_self {
+        match peer.param.local_addr.as_ref().map(|a| a.ip()) {
+            Some(IpAddr::V6(v6)) => IpAddr::V6(v6),
+            // 6PE (RFC 4798): IPv4 transport → IPv4-mapped IPv6 next-hop.
+            Some(IpAddr::V4(v4)) => IpAddr::V6(v4.to_ipv6_mapped()),
+            None => return None,
+        }
+    } else {
+        attrs.nexthop.as_ref().and_then(bgp_nexthop_to_ipaddr)?
+    };
+
+    if peer.is_ibgp() && attrs.local_pref.is_none() {
+        attrs.local_pref = Some(LocalPref::default());
+    }
+    if peer.peer_type == PeerType::IBGP
+        && rib.typ == BgpRibType::IBGP
+        && attrs.originator_id.is_none()
+    {
+        attrs.originator_id = Some(OriginatorId::new(rib.router_id));
+    }
+    if peer.peer_type == PeerType::IBGP && rib.typ == BgpRibType::IBGP {
+        if let Some(ref mut cluster_list) = attrs.cluster_list {
+            cluster_list.list.insert(0, *bgp.router_id);
+        } else {
+            let mut cluster_list = ClusterList::new();
+            cluster_list.list.push(*bgp.router_id);
+            attrs.cluster_list = Some(cluster_list);
+        }
+    }
+
+    attrs.nexthop = None;
+    let label = rib.label.unwrap_or(Label::new(3, 0, true));
+    Some((nlri, attrs, nhop, label))
+}
+
+/// Advertise an IPv4 Labeled-Unicast best-path change (SAFI 4) to every
+/// peer that negotiated it. Immediate per-peer send — no update-group
+/// batching yet (a future optimization; LU volumes are typically small,
+/// e.g. PE loopbacks). A `None` best-path emits MP_UNREACH to all LU
+/// peers (no Adj-RIB-Out yet, so withdraws aren't pruned to recipients —
+/// harmless, peers ignore unknown-prefix withdraws).
+pub(super) fn route_advertise_to_peers_labelv4(
+    prefix: Ipv4Net,
+    selected: &[BgpRib],
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+) {
+    let new_best = selected.last();
+    let (afi, safi) = (Afi::Ip, Safi::MplsLabel);
+
+    let peer_addrs: Vec<IpAddr> = peers
+        .iter()
+        .filter(|(_, p)| p.state.is_established())
+        .filter(|(_, p)| p.is_afi_safi(afi, safi))
+        .map(|(addr, _)| *addr)
+        .collect();
+
+    for peer_addr in peer_addrs {
+        let peer = peers.get_mut(&peer_addr).expect("peer exists");
+        match new_best {
+            Some(best) if best.ident != peer.ident => {
+                let add_path = peer.opt.is_add_path_send(afi, safi);
+                let Some((nlri, attr, nhop, label)) =
+                    route_update_labelv4(peer, &prefix, best, bgp, add_path)
+                else {
+                    continue;
+                };
+                let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+                update.bgp_attr = Some(attr);
+                update.mp_update = Some(MpReachAttr::Labelv4 {
+                    snpa: 0,
+                    nhop,
+                    updates: vec![Labelv4Nlri { label, nlri }],
+                });
+                peer.send_packet(update.into());
+            }
+            Some(_) => {
+                // Split-horizon: the source peer receives nothing.
+            }
+            None => {
+                let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+                update.mp_withdraw = Some(MpUnreachAttr::Labelv4(vec![Labelv4Nlri {
+                    label: Label::default(),
+                    nlri: Ipv4Nlri { id: 0, prefix },
+                }]));
+                peer.send_packet(update.into());
+            }
+        }
+    }
+}
+
+/// IPv6 Labeled-Unicast (incl. 6PE) advertise — the v6 counterpart of
+/// [`route_advertise_to_peers_labelv4`].
+pub(super) fn route_advertise_to_peers_labelv6(
+    prefix: Ipv6Net,
+    selected: &[BgpRib],
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+) {
+    let new_best = selected.last();
+    let (afi, safi) = (Afi::Ip6, Safi::MplsLabel);
+
+    let peer_addrs: Vec<IpAddr> = peers
+        .iter()
+        .filter(|(_, p)| p.state.is_established())
+        .filter(|(_, p)| p.is_afi_safi(afi, safi))
+        .map(|(addr, _)| *addr)
+        .collect();
+
+    for peer_addr in peer_addrs {
+        let peer = peers.get_mut(&peer_addr).expect("peer exists");
+        match new_best {
+            Some(best) if best.ident != peer.ident => {
+                let add_path = peer.opt.is_add_path_send(afi, safi);
+                let Some((nlri, attr, nhop, label)) =
+                    route_update_labelv6(peer, &prefix, best, bgp, add_path)
+                else {
+                    continue;
+                };
+                let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+                update.bgp_attr = Some(attr);
+                update.mp_update = Some(MpReachAttr::Labelv6 {
+                    snpa: 0,
+                    nhop,
+                    updates: vec![Labelv6Nlri { label, nlri }],
+                });
+                peer.send_packet(update.into());
+            }
+            Some(_) => {
+                // Split-horizon: the source peer receives nothing.
+            }
+            None => {
+                let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+                update.mp_withdraw = Some(MpUnreachAttr::Labelv6(vec![Labelv6Nlri {
+                    label: Label::default(),
+                    nlri: Ipv6Nlri { id: 0, prefix },
+                }]));
+                peer.send_packet(update.into());
+            }
+        }
+    }
+}
+
 impl Peer {
     pub fn send_packet(&self, bytes: BytesMut) {
         if let Some(ref packet_tx) = self.packet_tx
@@ -5553,6 +5827,78 @@ impl Bgp {
                 &mut bgp_ref,
                 &mut self.peers,
             );
+        }
+    }
+
+    /// Originate an IPv4 prefix into the Labeled-Unicast (SAFI 4)
+    /// Loc-RIB from a `network` statement under `afi-safi label-v4`. The
+    /// advertised label is implicit-null (3): we are the egress for this
+    /// FEC, so a labeled-unicast peer does penultimate-hop-pop and
+    /// forwards as IP to us. The real per-prefix local label + ILM swap
+    /// is Phase 5; no FIB install here (control-plane only).
+    pub fn route_add_label_v4(&mut self, prefix: Ipv4Net) {
+        let ident = ORIGINATED_PEER;
+        let attr = BgpAttr::new();
+        let mut rib = BgpRib::new(
+            ident,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            0,
+            32768,
+            &attr,
+            Some(Label::new(3, 0, true)),
+            None,
+            false,
+        );
+        let (_replaced, selected, next_id) = self.local_rib.update_v4lu(prefix, rib.clone());
+        rib.local_id = next_id;
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+        };
+
+        if !selected.is_empty() {
+            route_advertise_to_peers_labelv4(prefix, &selected, &mut bgp_ref, &mut self.peers);
+        }
+    }
+
+    pub fn route_del_label_v4(&mut self, prefix: Ipv4Net) {
+        let ident = ORIGINATED_PEER;
+        let removed = self.local_rib.remove_v4lu(prefix, 0, ident);
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+        };
+
+        let selected = bgp_ref.local_rib.select_best_path_v4lu(prefix);
+        if !selected.is_empty() || !removed.is_empty() {
+            route_advertise_to_peers_labelv4(prefix, &selected, &mut bgp_ref, &mut self.peers);
         }
     }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -934,6 +934,12 @@ pub struct LocalRib {
 
     pub v6: LocalRibTable<Ipv6Net>,
 
+    /// IPv4 / IPv6 Labeled-Unicast (SAFI 4) Loc-RIB. Same prefix key as
+    /// unicast; each `BgpRib` carries the per-prefix label.
+    pub v4lu: LocalRibTable<Ipv4Net>,
+
+    pub v6lu: LocalRibTable<Ipv6Net>,
+
     pub v4vpn: BTreeMap<RouteDistinguisher, LocalRibTable<Ipv4Net>>,
 
     pub v6vpn: BTreeMap<RouteDistinguisher, LocalRibTable<Ipv6Net>>,
@@ -995,6 +1001,32 @@ impl LocalRib {
 
     pub fn select_best_path_v6(&mut self, prefix: Ipv6Net) -> Vec<BgpRib> {
         self.v6.select_best_path(prefix)
+    }
+
+    // IPv4 / IPv6 Labeled-Unicast (SAFI 4) accessors. Same Loc-RIB
+    // engine as unicast; the per-prefix label travels on each `BgpRib`.
+    pub fn update_v4lu(&mut self, prefix: Ipv4Net, rib: BgpRib) -> (Vec<BgpRib>, Vec<BgpRib>, u32) {
+        self.v4lu.update(prefix, rib)
+    }
+
+    pub fn remove_v4lu(&mut self, prefix: Ipv4Net, id: u32, ident: usize) -> Vec<BgpRib> {
+        self.v4lu.remove(prefix, id, ident)
+    }
+
+    pub fn select_best_path_v4lu(&mut self, prefix: Ipv4Net) -> Vec<BgpRib> {
+        self.v4lu.select_best_path(prefix)
+    }
+
+    pub fn update_v6lu(&mut self, prefix: Ipv6Net, rib: BgpRib) -> (Vec<BgpRib>, Vec<BgpRib>, u32) {
+        self.v6lu.update(prefix, rib)
+    }
+
+    pub fn remove_v6lu(&mut self, prefix: Ipv6Net, id: u32, ident: usize) -> Vec<BgpRib> {
+        self.v6lu.remove(prefix, id, ident)
+    }
+
+    pub fn select_best_path_v6lu(&mut self, prefix: Ipv6Net) -> Vec<BgpRib> {
+        self.v6lu.select_best_path(prefix)
     }
 
     // VPNv6 accessors — per-RD `v6vpn` tables, mirroring the v4vpn
@@ -2775,6 +2807,183 @@ pub fn route_ipv6_withdraw(
     }
 }
 
+/// Ingest a received IPv4 Labeled-Unicast (SAFI 4) route into the
+/// `v4lu` Loc-RIB. Control-plane only: the per-prefix label is stored on
+/// the `BgpRib`, the MP_REACH next-hop is stamped into the attr so
+/// best-path / show read it, and best-path runs. NHT gating, FIB
+/// install (label-push) and peer re-advertisement land in later phases,
+/// so this mirrors the v6-unicast ingest minus those steps.
+pub fn route_labelv4_update(
+    ident: usize,
+    lu: &Labelv4Nlri,
+    nhop: IpAddr,
+    attr: &BgpAttr,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+    stale: bool,
+) {
+    let (peer_ident, peer_router_id, typ) = {
+        let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+
+        // RFC 4271 / 4456 loop detection — identical to the unicast path.
+        if let Some(ref aspath) = attr.aspath {
+            for segment in &aspath.segs {
+                if segment.asn.contains(&peer.local_as) {
+                    return;
+                }
+            }
+        }
+        if let Some(ref originator_id) = attr.originator_id
+            && originator_id.id == *bgp.router_id
+        {
+            return;
+        }
+        if let Some(ref cluster_list) = attr.cluster_list
+            && cluster_list.list.contains(bgp.router_id)
+        {
+            return;
+        }
+
+        let typ = if peer.is_ibgp() {
+            BgpRibType::IBGP
+        } else {
+            BgpRibType::EBGP
+        };
+        (peer.ident, peer.remote_id, typ)
+    };
+
+    // Stamp the MP_REACH next-hop so best-path / show read the LU
+    // next-hop rather than the (often absent) NEXT_HOP attribute.
+    let mut attr = attr.clone();
+    attr.nexthop = Some(match nhop {
+        IpAddr::V4(v4) => BgpNexthop::Ipv4(v4),
+        IpAddr::V6(v6) => BgpNexthop::Ipv6(v6),
+    });
+
+    let mut rib = BgpRib::new(
+        peer_ident,
+        peer_router_id,
+        typ,
+        lu.nlri.id,
+        0,
+        &attr,
+        Some(lu.label),
+        None,
+        stale,
+    );
+
+    {
+        let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+        peer.adj_in.add_v4lu(lu.nlri.prefix, rib.clone());
+    }
+
+    rib.attr = bgp.attr_store.intern(attr);
+    let _ = bgp.local_rib.update_v4lu(lu.nlri.prefix, rib);
+}
+
+/// Ingest a received IPv6 Labeled-Unicast (SAFI 4) route — including
+/// 6PE — into the `v6lu` Loc-RIB. See [`route_labelv4_update`].
+pub fn route_labelv6_update(
+    ident: usize,
+    lu: &Labelv6Nlri,
+    nhop: IpAddr,
+    attr: &BgpAttr,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+    stale: bool,
+) {
+    let (peer_ident, peer_router_id, typ) = {
+        let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+
+        if let Some(ref aspath) = attr.aspath {
+            for segment in &aspath.segs {
+                if segment.asn.contains(&peer.local_as) {
+                    return;
+                }
+            }
+        }
+        if let Some(ref originator_id) = attr.originator_id
+            && originator_id.id == *bgp.router_id
+        {
+            return;
+        }
+        if let Some(ref cluster_list) = attr.cluster_list
+            && cluster_list.list.contains(bgp.router_id)
+        {
+            return;
+        }
+
+        let typ = if peer.is_ibgp() {
+            BgpRibType::IBGP
+        } else {
+            BgpRibType::EBGP
+        };
+        (peer.ident, peer.remote_id, typ)
+    };
+
+    let mut attr = attr.clone();
+    attr.nexthop = Some(match nhop {
+        IpAddr::V4(v4) => BgpNexthop::Ipv4(v4),
+        IpAddr::V6(v6) => BgpNexthop::Ipv6(v6),
+    });
+
+    let mut rib = BgpRib::new(
+        peer_ident,
+        peer_router_id,
+        typ,
+        lu.nlri.id,
+        0,
+        &attr,
+        Some(lu.label),
+        None,
+        stale,
+    );
+
+    {
+        let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+        peer.adj_in.add_v6lu(lu.nlri.prefix, rib.clone());
+    }
+
+    rib.attr = bgp.attr_store.intern(attr);
+    let _ = bgp.local_rib.update_v6lu(lu.nlri.prefix, rib);
+}
+
+/// Withdraw a received IPv4 Labeled-Unicast route (MP_UNREACH or
+/// session teardown). Identity is (prefix, path-id); the on-wire label
+/// is not part of it. Removes from Adj-RIB-In and the `v4lu` Loc-RIB and
+/// recomputes best-path so `show` stays consistent.
+pub fn route_labelv4_withdraw(
+    ident: usize,
+    nlri: &Ipv4Nlri,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+    rib_in: bool,
+) {
+    if rib_in {
+        let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+        peer.adj_in.remove_v4lu(nlri.prefix, nlri.id);
+    }
+    let _ = bgp.local_rib.remove_v4lu(nlri.prefix, nlri.id, ident);
+    let _ = bgp.local_rib.select_best_path_v4lu(nlri.prefix);
+}
+
+/// Withdraw a received IPv6 Labeled-Unicast route. See
+/// [`route_labelv4_withdraw`].
+pub fn route_labelv6_withdraw(
+    ident: usize,
+    nlri: &Ipv6Nlri,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+    rib_in: bool,
+) {
+    if rib_in {
+        let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+        peer.adj_in.remove_v6lu(nlri.prefix, nlri.id);
+    }
+    let _ = bgp.local_rib.remove_v6lu(nlri.prefix, nlri.id, ident);
+    let _ = bgp.local_rib.select_best_path_v6lu(nlri.prefix);
+}
+
 pub fn route_ipv4_rtc_update(peer_id: usize, rtcv4: &Rtcv4, peers: &mut PeerMap) {
     let Some(peer) = peers.get_mut_by_idx(peer_id) else {
         return;
@@ -3449,6 +3658,28 @@ pub fn route_from_peer(
                     route_flowspec_update(peer_id, nlri, afi, bgp_attr, bgp, peers, false);
                 }
             }
+            MpReachAttr::Labelv4 {
+                snpa: _,
+                nhop,
+                updates,
+            } => {
+                // IPv4 Labeled-Unicast (SAFI 4): store each route in the
+                // v4lu Loc-RIB with its per-prefix label. The MP_REACH
+                // next-hop is authoritative.
+                for update in updates.iter() {
+                    route_labelv4_update(peer_id, update, nhop, bgp_attr, bgp, peers, false);
+                }
+            }
+            MpReachAttr::Labelv6 {
+                snpa: _,
+                nhop,
+                updates,
+            } => {
+                // IPv6 Labeled-Unicast (SAFI 4), including 6PE.
+                for update in updates.iter() {
+                    route_labelv6_update(peer_id, update, nhop, bgp_attr, bgp, peers, false);
+                }
+            }
             _ => {
                 //
             }
@@ -3526,6 +3757,28 @@ pub fn route_from_peer(
                 // An empty `withdraws` is End-of-RIB. Graceful-restart
                 // stale handling for flow specs is deferred (no Loc-RIB
                 // yet), so there is nothing to flush.
+            }
+            MpUnreachAttr::Labelv4(withdrawals) => {
+                for withdraw in withdrawals.iter() {
+                    route_labelv4_withdraw(peer_id, &withdraw.nlri, bgp, peers, true);
+                }
+            }
+            MpUnreachAttr::Labelv4Eor => {
+                let afi_safi = AfiSafi::new(Afi::Ip, Safi::MplsLabel);
+                let _ = bgp
+                    .tx
+                    .send(Message::Event(peer_id, Event::StaleTimerExipires(afi_safi)));
+            }
+            MpUnreachAttr::Labelv6(withdrawals) => {
+                for withdraw in withdrawals.iter() {
+                    route_labelv6_withdraw(peer_id, &withdraw.nlri, bgp, peers, true);
+                }
+            }
+            MpUnreachAttr::Labelv6Eor => {
+                let afi_safi = AfiSafi::new(Afi::Ip6, Safi::MplsLabel);
+                let _ = bgp
+                    .tx
+                    .send(Message::Event(peer_id, Event::StaleTimerExipires(afi_safi)));
             }
             _ => {
                 //
@@ -3768,6 +4021,47 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
     peer.cache_evpn.clear();
     peer.cache_evpn_rev.clear();
     peer.cache_evpn_timer = None;
+
+    // IPv4 / IPv6 Labeled-Unicast (SAFI 4). No LLGR handling yet —
+    // withdraw every labeled route the peer gave us and clear the
+    // Adj-RIB tables, mirroring the unicast block above.
+    let withdrawn_v4lu = {
+        let mut withdrawn: Vec<Ipv4Nlri> = vec![];
+        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+        for (prefix, ribs) in peer.adj_in.v4lu.0.iter() {
+            for rib in ribs.iter() {
+                withdrawn.push(Ipv4Nlri {
+                    id: rib.remote_id,
+                    prefix: *prefix,
+                });
+            }
+        }
+        withdrawn
+    };
+    for withdraw in withdrawn_v4lu.iter() {
+        route_labelv4_withdraw(peer_id, withdraw, bgp, peers, true);
+    }
+    let withdrawn_v6lu = {
+        let mut withdrawn: Vec<Ipv6Nlri> = vec![];
+        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+        for (prefix, ribs) in peer.adj_in.v6lu.0.iter() {
+            for rib in ribs.iter() {
+                withdrawn.push(Ipv6Nlri {
+                    id: rib.remote_id,
+                    prefix: *prefix,
+                });
+            }
+        }
+        withdrawn
+    };
+    for withdraw in withdrawn_v6lu.iter() {
+        route_labelv6_withdraw(peer_id, withdraw, bgp, peers, true);
+    }
+    let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+    peer.adj_in.v4lu.0.clear();
+    peer.adj_in.v6lu.0.clear();
+    peer.adj_out.v4lu.0.clear();
+    peer.adj_out.v6lu.0.clear();
 
     peer.cap_map = CapAfiMap::new();
     peer.cap_recv = BgpCap::default();

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -12,7 +12,7 @@ use super::peer::{Peer, PeerCounter, PeerParam, State};
 use super::peer_map::PeerMap;
 use super::route::LocalRib;
 use super::vrf::inst::BgpVrf;
-use crate::bgp::{AdjRibEvpnTable, AdjRibTable, BgpRibType, RibDirection};
+use crate::bgp::{AdjRibEvpnTable, AdjRibTable, BgpRib, BgpRibType, RibDirection};
 use crate::config::Args;
 use crate::config::{DisplayRequest, path_from_command};
 
@@ -109,6 +109,9 @@ fn configured_afi_safis<V: BgpShowView>(bgp: &V) -> Vec<AfiSafi> {
 fn rib_entries_count<V: BgpShowView>(bgp: &V, afi_safi: &AfiSafi) -> usize {
     match (afi_safi.afi, afi_safi.safi) {
         (Afi::Ip, Safi::Unicast) => bgp.local_rib().v4.0.len(),
+        (Afi::Ip6, Safi::Unicast) => bgp.local_rib().v6.0.len(),
+        (Afi::Ip, Safi::MplsLabel) => bgp.local_rib().v4lu.0.len(),
+        (Afi::Ip6, Safi::MplsLabel) => bgp.local_rib().v6lu.0.len(),
         (Afi::Ip, Safi::MplsVpn) => bgp.local_rib().v4vpn.values().map(|t| t.0.len()).sum(),
         (Afi::L2vpn, Safi::Evpn) => bgp.local_rib().evpn.values().map(|t| t.cands.len()).sum(),
         _ => 0,
@@ -463,6 +466,72 @@ fn show_bgp<V: BgpShowView>(
         }
     }
     Ok(buf)
+}
+
+/// `show ip bgp labeled-unicast` — render the IPv4 and IPv6
+/// Labeled-Unicast (SAFI 4) Loc-RIBs. Same columns as `show ip bgp`
+/// plus a Label column carrying the per-prefix MPLS label. JSON output
+/// is not yet defined (mirrors `show_bgp_evpn`); returns an empty array.
+fn show_bgp_labeled(
+    bgp: &Bgp,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    if json {
+        return Ok("[]".to_string());
+    }
+
+    let mut buf = String::new();
+    buf.push_str(SHOW_BGP_HEADER);
+
+    writeln!(buf, "IPv4 Labeled Unicast:")?;
+    for (key, value) in bgp.local_rib.v4lu.0.iter() {
+        for rib in value.iter() {
+            show_labeled_row(&mut buf, &key.to_string(), rib)?;
+        }
+    }
+    writeln!(buf, "IPv6 Labeled Unicast:")?;
+    for (key, value) in bgp.local_rib.v6lu.0.iter() {
+        for rib in value.iter() {
+            show_labeled_row(&mut buf, &key.to_string(), rib)?;
+        }
+    }
+    Ok(buf)
+}
+
+/// One labeled-unicast row: the unicast columns from `show ip bgp` plus
+/// the per-prefix label (or `-` when absent).
+fn show_labeled_row(
+    buf: &mut String,
+    prefix: &str,
+    rib: &BgpRib,
+) -> std::result::Result<(), std::fmt::Error> {
+    let stale = if rib.stale { "S" } else { " " };
+    let valid = "*";
+    let best = if rib.best_path { ">" } else { " " };
+    let internal = if rib.typ == BgpRibType::IBGP {
+        "i"
+    } else {
+        " "
+    };
+    let nexthop = show_nexthop(&rib.attr);
+    let label = rib
+        .label
+        .map(|l| l.label.to_string())
+        .unwrap_or_else(|| "-".to_string());
+    let med = show_med(&rib.attr);
+    let local_pref = show_local_pref(&rib.attr);
+    let weight = rib.weight;
+    let mut aspath = show_aspath(&rib.attr);
+    if !aspath.is_empty() {
+        aspath.push(' ');
+    }
+    let origin = show_origin(&rib.attr);
+    writeln!(
+        buf,
+        "{stale}{valid}{best}{internal} {:18} {:18} {:>8} {:>7} {:>6} {:>6} {}{}",
+        prefix, nexthop, label, med, local_pref, weight, aspath, origin,
+    )
 }
 
 fn show_bgp_vpnv4(
@@ -2751,6 +2820,7 @@ impl Bgp {
 
     pub fn show_build(&mut self) {
         self.show_add("/show/ip/bgp", show_bgp::<Bgp>);
+        self.show_add("/show/ip/bgp/labeled-unicast", show_bgp_labeled);
         self.show_add("/show/ip/bgp/vpnv4", show_bgp_vpnv4);
         self.show_add("/show/ip/bgp/vpnv4/route", show_bgp_vpnv4_route);
         self.show_add("/show/ip/bgp/route", show_bgp_route_entry);

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -127,6 +127,8 @@ impl Args {
         match item.as_str() {
             "ipv4" => Some(AfiSafi::new(Afi::Ip, Safi::Unicast)),
             "ipv6" => Some(AfiSafi::new(Afi::Ip6, Safi::Unicast)),
+            "label-v4" => Some(AfiSafi::new(Afi::Ip, Safi::MplsLabel)),
+            "label-v6" => Some(AfiSafi::new(Afi::Ip6, Safi::MplsLabel)),
             "vpnv4" => Some(AfiSafi::new(Afi::Ip, Safi::MplsVpn)),
             "vpnv6" => Some(AfiSafi::new(Afi::Ip6, Safi::MplsVpn)),
             "evpn" => Some(AfiSafi::new(Afi::L2vpn, Safi::Evpn)),

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -204,6 +204,10 @@ module exec {
             type inet:ipv4-address;
           }
         }
+        leaf labeled-unicast {
+          ext:help "BGP Labeled-Unicast (SAFI 4) RIB";
+          type empty;
+        }
         leaf evpn {
           ext:help "BGP EVPN RIB";
           type empty;

--- a/zebra-rs/yang/zebra-afi-safi.yang
+++ b/zebra-rs/yang/zebra-afi-safi.yang
@@ -19,10 +19,11 @@ module zebra-afi-safi {
      Two flavors are provided as groupings supplying the `name` key of
      an `afi-safi` list:
 
-       * `afi-safi`         — the full BGP set (ipv4, ipv6, vpnv4,
-                              vpnv6, evpn, rtcv4, rtcv6, ipv4-flowspec,
-                              ipv6-flowspec). Used by `router bgp`
-                              (global + per-neighbor afi-safi).
+       * `afi-safi`         — the full BGP set (ipv4, ipv6, label-v4,
+                              label-v6, vpnv4, vpnv6, evpn, rtcv4, rtcv6,
+                              ipv4-flowspec, ipv6-flowspec). Used by
+                              `router bgp` (global + per-neighbor
+                              afi-safi).
        * `afi-safi-unicast` — the unicast subset (ipv4, ipv6). Used by
                               `router isis` and the per-VRF BGP afi-safi
                               (which carries the same family names).
@@ -42,6 +43,15 @@ module zebra-afi-safi {
         }
         enum ipv6 {
           description "IPv6 unicast (AFI 2, SAFI 1).";
+        }
+        enum label-v4 {
+          description
+            "IPv4 Labeled Unicast (AFI 1, SAFI 4); RFC 3107 / RFC 8277.";
+        }
+        enum label-v6 {
+          description
+            "IPv6 Labeled Unicast (AFI 2, SAFI 4); RFC 3107 / RFC 8277,
+             incl. 6PE (RFC 4798).";
         }
         enum vpnv4 {
           description "MPLS-labeled VPN-IPv4 (AFI 1, SAFI 128).";


### PR DESCRIPTION
Phase 4 of BGP Labeled Unicast: emit MP_REACH/MP_UNREACH(SAFI 4) for labeled-unicast best paths and originate IPv4 labeled routes from `network`. Still control-plane only (no MPLS dataplane — Phase 5), so advertised labels are the **received label** (propagation) or **implicit-null** (self-originated).

> Stacked on #1044 → #1043 → #1042. Base is `bgp-lu-locrib`; GitHub retargets as parents merge.

## Advertise path

- `route_update_labelv4` / `route_update_labelv6` — build `(NLRI, attr, next-hop, label)` mirroring `route_update_ipv6`'s attribute handling (split-horizon, iBGP-RR gating, AS_PATH prepend, next-hop-self, LOCAL_PREF, ORIGINATOR_ID/CLUSTER_LIST). `attrs.nexthop` is cleared so the MP_REACH is the sole next-hop (no stray legacy type-3 NEXT_HOP — `attr_emit` only emits that for `BgpNexthop::Ipv4`).
- `route_advertise_to_peers_labelv4` / `_labelv6` — immediate per-peer send to peers that negotiated `(afi, MplsLabel)`; `None` best-path → MP_UNREACH. No update-group batching yet (LU volumes are small, e.g. PE loopbacks; a future optimization).
- Wired into `route_labelv4_update` / `route_labelv6_update` and the withdraw paths, so received LU routes that win best-path re-advertise (RR / inter-AS Option-C transit) — the **propagate-received** source.

## Origination sources

- **6PE (RFC 4798)**: `route_update_labelv6` encodes a next-hop-self over an IPv4 transport session as the IPv4-mapped IPv6 next-hop.
- **`network` (label-v4)**: `route_add_label_v4` / `route_del_label_v4` originate an ipv4-prefix into the v4lu Loc-RIB with implicit-null and advertise it; `config_network` dispatches `(Ip, MplsLabel)`.

## Deferred (Phase 4b)

- `network` for **label-v6** — the YANG `network` key is `ipv4-prefix` only (needs a v6 prefix).
- **redistribute-into-LU** (both AFIs) — the redistribute inject path is IPv4-unicast-only today, and the v6 redistribute path doesn't exist yet.
- The per-prefix **local label + ILM swap** for next-hop-self FECs is Phase 5.

## Tests

zebra-rs unit suite (717) + `yang_load_tests` pass; workspace `clippy --all-targets -D warnings` clean. End-to-end advertise/interop is a CI BDD / Phase-5 concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)