### PR TITLE
bgp: negotiate IPv4/IPv6 Flowspec address families (Phase 1a)

### DIFF
--- a/zebra-rs/src/bgp/cap.rs
+++ b/zebra-rs/src/bgp/cap.rs
@@ -35,6 +35,8 @@ impl CapAfiMap {
         let mp6vpn = CapMultiProtocol::new(&Afi::Ip6, &Safi::MplsVpn);
         let mp6rtc = CapMultiProtocol::new(&Afi::Ip6, &Safi::Rtc);
         let mpevpn = CapMultiProtocol::new(&Afi::L2vpn, &Safi::Evpn);
+        let mp4fs = CapMultiProtocol::new(&Afi::Ip, &Safi::Flowspec);
+        let mp6fs = CapMultiProtocol::new(&Afi::Ip6, &Safi::Flowspec);
 
         let mut cmap = Self::default();
         cmap.entries.insert(mp4uni, SendRecv::default());
@@ -44,6 +46,8 @@ impl CapAfiMap {
         cmap.entries.insert(mp6vpn, SendRecv::default());
         cmap.entries.insert(mp6rtc, SendRecv::default());
         cmap.entries.insert(mpevpn, SendRecv::default());
+        cmap.entries.insert(mp4fs, SendRecv::default());
+        cmap.entries.insert(mp6fs, SendRecv::default());
         cmap
     }
 

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -83,6 +83,8 @@ fn afi_safi_summary_label(afi: Afi, safi: Safi) -> &'static str {
         (Afi::Ip6, Safi::MplsLabel) => "IPv6 Labeled Unicast",
         (Afi::Ip6, Safi::MplsVpn) => "VPNv6 Unicast",
         (Afi::L2vpn, Safi::Evpn) => "L2VPN EVPN",
+        (Afi::Ip, Safi::Flowspec) => "IPv4 Flowspec",
+        (Afi::Ip6, Safi::Flowspec) => "IPv6 Flowspec",
         _ => "Unknown AFI/SAFI",
     }
 }

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -132,6 +132,8 @@ impl Args {
             "evpn" => Some(AfiSafi::new(Afi::L2vpn, Safi::Evpn)),
             "rtcv4" => Some(AfiSafi::new(Afi::Ip, Safi::Rtc)),
             "rtcv6" => Some(AfiSafi::new(Afi::Ip6, Safi::Rtc)),
+            "ipv4-flowspec" => Some(AfiSafi::new(Afi::Ip, Safi::Flowspec)),
+            "ipv6-flowspec" => Some(AfiSafi::new(Afi::Ip6, Safi::Flowspec)),
             _ => None,
         }
     }
@@ -728,6 +730,17 @@ pub fn config_match(config: &Rc<Config>, input: &str, mx: &mut Match) {
 mod tests {
     use super::*;
     use crate::config::vty::CommandPath;
+
+    #[test]
+    fn afi_safi_parses_flowspec_families() {
+        let mut args = Args(["ipv4-flowspec".to_string()].into_iter().collect());
+        assert_eq!(args.afi_safi(), Some(AfiSafi::new(Afi::Ip, Safi::Flowspec)));
+        let mut args = Args(["ipv6-flowspec".to_string()].into_iter().collect());
+        assert_eq!(
+            args.afi_safi(),
+            Some(AfiSafi::new(Afi::Ip6, Safi::Flowspec))
+        );
+    }
 
     #[test]
     fn test_leaf_list_round_trip() {

--- a/zebra-rs/yang/zebra-afi-safi.yang
+++ b/zebra-rs/yang/zebra-afi-safi.yang
@@ -20,9 +20,9 @@ module zebra-afi-safi {
      an `afi-safi` list:
 
        * `afi-safi`         — the full BGP set (ipv4, ipv6, vpnv4,
-                              vpnv6, evpn, rtcv4, rtcv6). Used by
-                              `router bgp` (global + per-neighbor
-                              afi-safi).
+                              vpnv6, evpn, rtcv4, rtcv6, ipv4-flowspec,
+                              ipv6-flowspec). Used by `router bgp`
+                              (global + per-neighbor afi-safi).
        * `afi-safi-unicast` — the unicast subset (ipv4, ipv6). Used by
                               `router isis` and the per-VRF BGP afi-safi
                               (which carries the same family names).
@@ -59,6 +59,14 @@ module zebra-afi-safi {
         enum rtcv6 {
           description
             "IPv6 Route Target Constraint (AFI 2, SAFI 132).";
+        }
+        enum ipv4-flowspec {
+          description
+            "IPv4 Flow Specification (AFI 1, SAFI 133, RFC 8955).";
+        }
+        enum ipv6-flowspec {
+          description
+            "IPv6 Flow Specification (AFI 2, SAFI 133, RFC 8956).";
         }
       }
       description


### PR DESCRIPTION
Slice **1a** of Phase 1 of the BGP Flowspec series. Enables the Flow Specification (SAFI 133) address families for **capability negotiation and per-neighbor configuration**. Still control-plane only — received flow specs parse (Phase 0 codec) but fall through the existing `route.rs` catch-alls, so nothing is stored or installed yet.

## Changes
- **`zebra-afi-safi.yang`** — add `ipv4-flowspec` / `ipv6-flowspec` to the `afi-safi` enumeration so neighbors can activate the families.
- **`config Args::afi_safi`** — parse the two new family names into `(Afi::Ip | Afi::Ip6, Safi::Flowspec)`.
- **`CapAfiMap::new`** — track the IPv4/IPv6 Flowspec multiprotocol capabilities so negotiation (send/recv) is recorded and rendered.
- **`show`** — label `(Afi, Safi::Flowspec)` as "IPv4 Flowspec" / "IPv6 Flowspec" in `show ip bgp summary`.

Everything else flows through existing generic code: `neighbor X afi-safi ipv4-flowspec enabled true` advertises the MP capability in OPEN (via the `config.mp` → `BgpCap` loop in `peer.rs`), and a Flowspec summary section appears once the peer advertises it back.

## Tests
- New unit test: `Args::afi_safi` parses `ipv4-flowspec` / `ipv6-flowspec`.
- `cargo test -p zebra-rs` (bgp 213 + config) green; `yang_load_tests` pass; `cargo fmt` + `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Slicing
Phase 1 is split to keep PRs small:
- **1a (this PR):** capability negotiation + config + summary label.
- **1b (next):** Adj-RIB-In storage (`AdjRibFlowspecTable`), the `route_flowspec_update`/`_withdraw` receive path, and `show bgp ipv4/ipv6 flowspec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)