### PR TITLE
bgp: receive Flowspec into Adj-RIB-In + show (Phase 1b)

### DIFF
--- a/zebra-rs/src/bgp/adj_rib.rs
+++ b/zebra-rs/src/bgp/adj_rib.rs
@@ -136,6 +136,61 @@ impl<D: RibDirection> Default for AdjRibEvpnTable<D> {
     }
 }
 
+/// Adj-RIB-In/Out table for Flow Specification routes, keyed on
+/// `FlowspecNlri` (exact match — overlapping flow specs coexist, so no
+/// prefix trie). Mirrors `AdjRibEvpnTable<D>`; the `D` marker selects
+/// the path-id field for AddPath disambiguation.
+#[derive(Debug)]
+pub struct AdjRibFlowspecTable<D: RibDirection>(
+    pub BTreeMap<FlowspecNlri, Vec<BgpRib>>,
+    PhantomData<D>,
+);
+
+impl<D: RibDirection> AdjRibFlowspecTable<D> {
+    pub fn new() -> Self {
+        Self(BTreeMap::new(), PhantomData)
+    }
+
+    pub fn add(&mut self, nlri: FlowspecNlri, route: BgpRib) -> Option<BgpRib> {
+        let candidates = self.0.entry(nlri).or_default();
+
+        let route_id = D::get_id(&route);
+        if let Some(pos) = candidates.iter().position(|r| D::get_id(r) == route_id) {
+            let old_route = candidates[pos].clone();
+            candidates[pos] = route;
+            Some(old_route)
+        } else {
+            candidates.push(route);
+            None
+        }
+    }
+
+    pub fn remove(&mut self, nlri: &FlowspecNlri, id: u32) -> Option<BgpRib> {
+        let candidates = self.0.get_mut(nlri)?;
+
+        if let Some(pos) = candidates.iter().position(|r| D::get_id(r) == id) {
+            let removed_route = candidates.remove(pos);
+
+            if candidates.is_empty() {
+                self.0.remove(nlri);
+            }
+
+            Some(removed_route)
+        } else if id == 0 {
+            self.0.remove(nlri);
+            None
+        } else {
+            None
+        }
+    }
+}
+
+impl<D: RibDirection> Default for AdjRibFlowspecTable<D> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // BGP Adj-RIB - stores routes with direction-specific ID handling
 #[derive(Debug)]
 pub struct AdjRib<D: RibDirection> {
@@ -149,6 +204,10 @@ pub struct AdjRib<D: RibDirection> {
     pub v6vpn: BTreeMap<RouteDistinguisher, AdjRibTable<D, Ipv6Net>>,
     // EVPN, per Route Distinguisher
     pub evpn: BTreeMap<RouteDistinguisher, AdjRibEvpnTable<D>>,
+    // IPv4 Flow Specification (AFI 1, SAFI 133)
+    pub flowspec_v4: AdjRibFlowspecTable<D>,
+    // IPv6 Flow Specification (AFI 2, SAFI 133)
+    pub flowspec_v6: AdjRibFlowspecTable<D>,
 }
 
 impl<D: RibDirection> AdjRib<D> {
@@ -159,6 +218,8 @@ impl<D: RibDirection> AdjRib<D> {
             v4vpn: BTreeMap::new(),
             v6vpn: BTreeMap::new(),
             evpn: BTreeMap::new(),
+            flowspec_v4: AdjRibFlowspecTable::new(),
+            flowspec_v6: AdjRibFlowspecTable::new(),
         }
     }
 }
@@ -245,6 +306,22 @@ impl AdjRib<In> {
         self.evpn.entry(rd).or_default().remove(prefix, id)
     }
 
+    // Flow Specification add/remove ------------------------------------------
+
+    pub fn add_flowspec(&mut self, afi: Afi, nlri: FlowspecNlri, route: BgpRib) -> Option<BgpRib> {
+        match afi {
+            Afi::Ip6 => self.flowspec_v6.add(nlri, route),
+            _ => self.flowspec_v4.add(nlri, route),
+        }
+    }
+
+    pub fn remove_flowspec(&mut self, afi: Afi, nlri: &FlowspecNlri, id: u32) -> Option<BgpRib> {
+        match afi {
+            Afi::Ip6 => self.flowspec_v6.remove(nlri, id),
+            _ => self.flowspec_v4.remove(nlri, id),
+        }
+    }
+
     pub fn count(&self, afi: Afi, safi: Safi) -> usize {
         match (afi, safi) {
             (Afi::Ip, Safi::Unicast) => self.v4.0.len(),
@@ -252,6 +329,8 @@ impl AdjRib<In> {
             (Afi::Ip, Safi::MplsVpn) => self.v4vpn.values().map(|table| table.0.len()).sum(),
             (Afi::Ip6, Safi::MplsVpn) => self.v6vpn.values().map(|table| table.0.len()).sum(),
             (Afi::L2vpn, Safi::Evpn) => self.evpn.values().map(|table| table.0.len()).sum(),
+            (Afi::Ip, Safi::Flowspec) => self.flowspec_v4.0.len(),
+            (Afi::Ip6, Safi::Flowspec) => self.flowspec_v6.0.len(),
             (_, _) => 0,
         }
     }
@@ -291,6 +370,8 @@ impl AdjRib<Out> {
             (Afi::Ip, Safi::MplsVpn) => self.v4vpn.values().map(|table| table.0.len()).sum(),
             (Afi::Ip6, Safi::MplsVpn) => self.v6vpn.values().map(|table| table.0.len()).sum(),
             (Afi::L2vpn, Safi::Evpn) => self.evpn.values().map(|table| table.0.len()).sum(),
+            (Afi::Ip, Safi::Flowspec) => self.flowspec_v4.0.len(),
+            (Afi::Ip6, Safi::Flowspec) => self.flowspec_v6.0.len(),
             (_, _) => 0,
         }
     }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -3236,6 +3236,78 @@ pub fn route_evpn_withdraw(ident: usize, route: &EvpnRoute, bgp: &mut BgpTop, pe
     route_evpn_export_selected(&rd, &prefix, &selected, removed.first(), bgp);
 }
 
+/// Store one received Flow Specification NLRI in the peer's Adj-RIB-In.
+///
+/// Phase 1 (receive/reflect) is control-plane only: the flow spec is
+/// kept in Adj-RIB-In so it can be shown, but it is not validated
+/// (RFC 9117 — Phase 2), not selected into a Loc-RIB or re-advertised
+/// (Phase 3), and not installed (Phase 4). Loop detection mirrors
+/// `route_evpn_update` so a route carrying our own AS / ORIGINATOR_ID /
+/// CLUSTER_LIST is dropped silently.
+pub fn route_flowspec_update(
+    ident: usize,
+    nlri: &FlowspecNlri,
+    afi: Afi,
+    attr: &BgpAttr,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+    stale: bool,
+) {
+    let id = nlri.id;
+
+    let (peer_ident, peer_router_id, typ) = {
+        let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+
+        if let Some(ref aspath) = attr.aspath {
+            for segment in &aspath.segs {
+                if segment.asn.contains(&peer.local_as) {
+                    return;
+                }
+            }
+        }
+        if let Some(ref originator_id) = attr.originator_id
+            && originator_id.id == *bgp.router_id
+        {
+            return;
+        }
+        if let Some(ref cluster_list) = attr.cluster_list
+            && cluster_list.list.contains(bgp.router_id)
+        {
+            return;
+        }
+
+        let typ = if peer.is_ibgp() {
+            BgpRibType::IBGP
+        } else {
+            BgpRibType::EBGP
+        };
+
+        (peer.ident, peer.remote_id, typ)
+    };
+
+    let mut rib = BgpRib::new(
+        peer_ident,
+        peer_router_id,
+        typ,
+        id,
+        0,    // weight
+        attr, // interned just below
+        None, // label
+        None, // nexthop — flow specs carry actions, not a next-hop
+        stale,
+    );
+    rib.attr = bgp.attr_store.intern(attr.clone());
+
+    let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+    peer.adj_in.add_flowspec(afi, nlri.clone(), rib);
+}
+
+/// Withdraw one Flow Specification NLRI from the peer's Adj-RIB-In.
+pub fn route_flowspec_withdraw(ident: usize, nlri: &FlowspecNlri, afi: Afi, peers: &mut PeerMap) {
+    let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
+    peer.adj_in.remove_flowspec(afi, nlri, nlri.id);
+}
+
 pub fn route_from_peer(
     peer_id: usize,
     packet: UpdatePacket,
@@ -3372,6 +3444,11 @@ pub fn route_from_peer(
                     );
                 }
             }
+            MpReachAttr::Flowspec { afi, updates } => {
+                for nlri in updates.iter() {
+                    route_flowspec_update(peer_id, nlri, afi, bgp_attr, bgp, peers, false);
+                }
+            }
             _ => {
                 //
             }
@@ -3441,6 +3518,14 @@ pub fn route_from_peer(
                 let _ = bgp
                     .tx
                     .send(Message::Event(peer_id, Event::StaleTimerExipires(afi_safi)));
+            }
+            MpUnreachAttr::Flowspec { afi, withdraws } => {
+                for nlri in withdraws.iter() {
+                    route_flowspec_withdraw(peer_id, nlri, afi, peers);
+                }
+                // An empty `withdraws` is End-of-RIB. Graceful-restart
+                // stale handling for flow specs is deferred (no Loc-RIB
+                // yet), so there is nothing to flush.
             }
             _ => {
                 //

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2092,6 +2092,144 @@ fn show_bgp_evpn(
     Ok(buf)
 }
 
+/// Render the Flow Specification traffic-filtering actions carried in a
+/// path's extended communities into a compact, comma-joined string.
+/// Non-action extended communities are ignored; `-` is returned when
+/// the path carries no flow-spec action.
+fn show_flowspec_actions(attr: &BgpAttr) -> String {
+    let Some(ecom) = &attr.ecom else {
+        return String::from("-");
+    };
+    let mut parts = Vec::new();
+    for v in ecom.0.iter() {
+        let Some(action) = v.as_flowspec_action() else {
+            continue;
+        };
+        parts.push(match action {
+            FlowspecAction::TrafficRateBytes { rate, .. } => {
+                if rate == 0.0 {
+                    "discard".to_string()
+                } else {
+                    format!("rate-bytes:{rate}")
+                }
+            }
+            FlowspecAction::TrafficRatePackets { rate, .. } => format!("rate-pkts:{rate}"),
+            FlowspecAction::TrafficAction { terminal, sample } => {
+                format!("traffic-action(terminal={terminal},sample={sample})")
+            }
+            FlowspecAction::RedirectAs2 { asn, value } => format!("redirect:{asn}:{value}"),
+            FlowspecAction::RedirectIpv4 { addr, value } => format!("redirect:{addr}:{value}"),
+            FlowspecAction::RedirectAs4 { asn, value } => format!("redirect:{asn}:{value}"),
+            FlowspecAction::TrafficMarking { dscp } => format!("mark-dscp:{dscp}"),
+        });
+    }
+    if parts.is_empty() {
+        String::from("-")
+    } else {
+        parts.join(",")
+    }
+}
+
+/// `show ip bgp flowspec [ipv6]` — list the Flow Specification rules in
+/// Adj-RIB-In across all peers for the given AFI, each with its decoded
+/// traffic-filtering actions and the advertising neighbor. Phase 1 is
+/// receive-only: there is no Loc-RIB / best-path for flow specs yet, so
+/// this is the raw received view.
+fn show_bgp_flowspec(
+    bgp: &Bgp,
+    afi: Afi,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    if json {
+        return Ok(String::from("[]"));
+    }
+
+    let family = if afi == Afi::Ip6 { "IPv6" } else { "IPv4" };
+    let mut buf = String::new();
+    writeln!(buf, "{family} Flow Specification (Adj-RIB-In, received):")?;
+
+    let mut any = false;
+    for (addr, peer) in bgp.peers.iter() {
+        let table = if afi == Afi::Ip6 {
+            &peer.adj_in.flowspec_v6
+        } else {
+            &peer.adj_in.flowspec_v4
+        };
+        // BTreeMap iteration yields the flow specs in RFC 8955 §5.1
+        // precedence order (most-specific first).
+        for (nlri, ribs) in table.0.iter() {
+            for rib in ribs.iter() {
+                any = true;
+                writeln!(buf, " * match:  {nlri}")?;
+                writeln!(
+                    buf,
+                    "   action: {}   from {}",
+                    show_flowspec_actions(&rib.attr),
+                    addr
+                )?;
+            }
+        }
+    }
+    if !any {
+        writeln!(buf, "  (no flow specifications received)")?;
+    }
+    Ok(buf)
+}
+
+fn show_bgp_flowspec_v4(
+    bgp: &Bgp,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    show_bgp_flowspec(bgp, Afi::Ip, json)
+}
+
+fn show_bgp_flowspec_v6(
+    bgp: &Bgp,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    show_bgp_flowspec(bgp, Afi::Ip6, json)
+}
+
+#[cfg(test)]
+mod flowspec_show_tests {
+    use super::*;
+
+    #[test]
+    fn actions_render_discard_and_marking() {
+        let attr = BgpAttr {
+            ecom: Some(ExtCommunity(vec![
+                FlowspecAction::TrafficRateBytes { asn: 0, rate: 0.0 }.into(),
+                FlowspecAction::TrafficMarking { dscp: 46 }.into(),
+            ])),
+            ..Default::default()
+        };
+        assert_eq!(show_flowspec_actions(&attr), "discard,mark-dscp:46");
+    }
+
+    #[test]
+    fn actions_empty_renders_dash() {
+        let attr = BgpAttr::default();
+        assert_eq!(show_flowspec_actions(&attr), "-");
+    }
+
+    #[test]
+    fn actions_ignore_non_flowspec_ecom() {
+        // A Route-Target (0x00/0x02) is not a flow-spec action and must
+        // not appear in the rendered action list.
+        let attr = BgpAttr {
+            ecom: Some(ExtCommunity(vec![ExtCommunityValue {
+                high_type: 0x00,
+                low_type: 0x02,
+                val: [0, 100, 0, 0, 0, 200],
+            }])),
+            ..Default::default()
+        };
+        assert_eq!(show_flowspec_actions(&attr), "-");
+    }
+}
+
 #[cfg(test)]
 mod evpn_show_tests {
     use super::*;
@@ -2641,6 +2779,8 @@ impl Bgp {
         );
         self.show_add("/show/ip/bgp/neighbors/rtcv4", show_bgp_rtcv4);
         self.show_add("/show/ip/bgp/evpn", show_bgp_evpn);
+        self.show_add("/show/ip/bgp/flowspec", show_bgp_flowspec_v4);
+        self.show_add("/show/ip/bgp/flowspec/ipv6", show_bgp_flowspec_v6);
         // self.show_add("/show/community-list", show_community_list);
         self.show_add("/show/ip/bgp/attributes", show_bgp_attributes);
         self.show_add("/show/ip/bgp/vrf", show_bgp_vrf);

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -208,6 +208,14 @@ module exec {
           ext:help "BGP EVPN RIB";
           type empty;
         }
+        container flowspec {
+          ext:help "BGP IPv4 Flow Specification RIB";
+          presence "BGP IPv4 Flowspec RIB";
+          leaf ipv6 {
+            ext:help "BGP IPv6 Flow Specification RIB";
+            type empty;
+          }
+        }
         leaf summary {
           ext:help "BGP summary information";
           type empty;


### PR DESCRIPTION
Slice **1b** of Phase 1. Store received Flow Specification NLRIs in **Adj-RIB-In** and surface them via `show ip bgp flowspec [ipv6]`. Still control-plane only — no validation (Phase 2), no Loc-RIB / best-path or re-advertise (Phase 3), no dataplane install (Phase 4).

## Changes
- **`adj_rib`** — `AdjRibFlowspecTable<D>`, an exact-match `BTreeMap<FlowspecNlri, Vec<BgpRib>>` mirroring `AdjRibEvpnTable` (overlapping flow specs coexist, so no prefix trie). Adds `flowspec_v4` / `flowspec_v6` to `AdjRib<D>`, `add_flowspec` / `remove_flowspec` on `AdjRib<In>`, and Flowspec arms in `count()`.
- **`route`** — `route_flowspec_update` / `route_flowspec_withdraw`, wired into the previously-catch-all `MpReachAttr::Flowspec` / `MpUnreachAttr::Flowspec` arms of `route_from_peer`. Loop detection (local-AS / ORIGINATOR_ID / CLUSTER_LIST) mirrors `route_evpn_update`; the attribute is interned and the route stored in Adj-RIB-In. An empty MP_UNREACH (EoR) is a no-op (GR stale handling deferred — no Loc-RIB yet).
- **`show`** — `show ip bgp flowspec` (IPv4) and `show ip bgp flowspec ipv6` list received flow specs in RFC 8955 §5.1 precedence order (BTreeMap iteration) with their decoded traffic-filtering actions and advertising neighbor. `exec.yang` gains the `flowspec` command container (mirroring the `vpnv4` container/leaf pattern).

## Tests
- 3 new `show_flowspec_actions` formatter tests (discard + DSCP marking, empty, non-flowspec ecom ignored).
- 213 bgp unit tests green; `yang_load_tests` pass; `cargo fmt` + `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Where this leaves Phase 1
Phase 1 (capability + receive + show) is **complete** with 1a + 1b. Next is **Phase 2** — RFC 9117 validation of received flow specs against the unicast Loc-RIB, re-validated on RIB change via the existing NHT notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)