### PR TITLE
bgp: rename flowspec afi-safi to flowspec-ipv4 / flowspec-ipv6

### DIFF
--- a/docs/design/bgp-flowspec-plan.md
+++ b/docs/design/bgp-flowspec-plan.md
@@ -190,8 +190,8 @@ Follow the **EVPN exact-match pattern**, *not* `LocalRibTable<P>`
 - Best-path: no MED / AS-path install semantics — selection is "valid?" +
   precedence (from `Ord`). Keep simple (first valid wins).
 - `cap.rs:30` `CapAfiMap::new()` gains `(Ip,133)` and `(Ip6,133)`;
-  `config/configs.rs:125` `Args::afi_safi()` gains `ipv4-flowspec` /
-  `ipv6-flowspec`; `show.rs:76` label map gets the strings.
+  `config/configs.rs:125` `Args::afi_safi()` gains `flowspec-ipv4` /
+  `flowspec-ipv6`; `show.rs:76` label map gets the strings.
 
 ### RIB message channel — Phase 4
 
@@ -212,13 +212,13 @@ conventions (kebab-case module, presence containers, augment into
 `config/manager.rs:1183`).
 
 **(a) Family activation** — extend `zebra-afi-safi.yang` `afi-safi` grouping
-enum with `ipv4-flowspec`, `ipv6-flowspec`; add matching arms to
+enum with `flowspec-ipv4`, `flowspec-ipv6`; add matching arms to
 `Args::afi_safi()` (`config/configs.rs:125`). Neighbor activation then works
 unchanged via the existing per-neighbor `afi-safi/<name>/enabled` path:
 
 ```
-set router bgp 65000 neighbor 10.0.0.1 afi-safi ipv4-flowspec enabled true
-set router bgp 65000 neighbor 2001:db8::1 afi-safi ipv6-flowspec enabled true
+set router bgp 65000 neighbor 10.0.0.1 afi-safi flowspec-ipv4 enabled true
+set router bgp 65000 neighbor 2001:db8::1 afi-safi flowspec-ipv6 enabled true
 ```
 
 **(b) Per-neighbor validation knob** — augment the neighbor afi-safi:

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -134,8 +134,8 @@ impl Args {
             "evpn" => Some(AfiSafi::new(Afi::L2vpn, Safi::Evpn)),
             "rtcv4" => Some(AfiSafi::new(Afi::Ip, Safi::Rtc)),
             "rtcv6" => Some(AfiSafi::new(Afi::Ip6, Safi::Rtc)),
-            "ipv4-flowspec" => Some(AfiSafi::new(Afi::Ip, Safi::Flowspec)),
-            "ipv6-flowspec" => Some(AfiSafi::new(Afi::Ip6, Safi::Flowspec)),
+            "flowspec-ipv4" => Some(AfiSafi::new(Afi::Ip, Safi::Flowspec)),
+            "flowspec-ipv6" => Some(AfiSafi::new(Afi::Ip6, Safi::Flowspec)),
             _ => None,
         }
     }
@@ -735,9 +735,9 @@ mod tests {
 
     #[test]
     fn afi_safi_parses_flowspec_families() {
-        let mut args = Args(["ipv4-flowspec".to_string()].into_iter().collect());
+        let mut args = Args(["flowspec-ipv4".to_string()].into_iter().collect());
         assert_eq!(args.afi_safi(), Some(AfiSafi::new(Afi::Ip, Safi::Flowspec)));
-        let mut args = Args(["ipv6-flowspec".to_string()].into_iter().collect());
+        let mut args = Args(["flowspec-ipv6".to_string()].into_iter().collect());
         assert_eq!(
             args.afi_safi(),
             Some(AfiSafi::new(Afi::Ip6, Safi::Flowspec))

--- a/zebra-rs/yang/zebra-afi-safi.yang
+++ b/zebra-rs/yang/zebra-afi-safi.yang
@@ -21,7 +21,7 @@ module zebra-afi-safi {
 
        * `afi-safi`         — the full BGP set (ipv4, ipv6, label-v4,
                               label-v6, vpnv4, vpnv6, evpn, rtcv4, rtcv6,
-                              ipv4-flowspec, ipv6-flowspec). Used by
+                              flowspec-ipv4, flowspec-ipv6). Used by
                               `router bgp` (global + per-neighbor
                               afi-safi).
        * `afi-safi-unicast` — the unicast subset (ipv4, ipv6). Used by
@@ -70,11 +70,11 @@ module zebra-afi-safi {
           description
             "IPv6 Route Target Constraint (AFI 2, SAFI 132).";
         }
-        enum ipv4-flowspec {
+        enum flowspec-ipv4 {
           description
             "IPv4 Flow Specification (AFI 1, SAFI 133, RFC 8955).";
         }
-        enum ipv6-flowspec {
+        enum flowspec-ipv6 {
           description
             "IPv6 Flow Specification (AFI 2, SAFI 133, RFC 8956).";
         }


### PR DESCRIPTION
Rename the Flow Specification address families from `ipv4-flowspec` / `ipv6-flowspec` to **`flowspec-ipv4` / `flowspec-ipv6`**, for consistency with the type-first afi-safi naming used elsewhere in the config tree (e.g. `label-v4` / `label-v6`).

```
set router bgp 65000 neighbor 10.0.0.1 afi-safi flowspec-ipv4 enabled true
set router bgp 65000 neighbor 2001:db8::1 afi-safi flowspec-ipv6 enabled true
```

## Changes
- **`zebra-afi-safi.yang`** — rename the two `afi-safi` enum values (and the module description list).
- **`config Args::afi_safi`** — rename the two parse arms and the unit test.
- **`docs/design/bgp-flowspec-plan.md`** — update references and the config examples.

No functional change — the `(AFI, SAFI)` mapping is identical; only the operator-facing family name changes.

## Tests
`yang_load_tests` pass; `afi_safi` parse test updated and passing; `cargo fmt` + `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)