### PR TITLE
bgp: BGP-LU origination — network label-v6 + redistribute into label-v4/v6

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -674,7 +674,10 @@ fn redist_afi_valid(afi_safi: &bgp_packet::AfiSafi) -> bool {
     use bgp_packet::{Afi, Safi};
     matches!(
         (afi_safi.afi, afi_safi.safi),
-        (Afi::Ip, Safi::Unicast) | (Afi::Ip6, Safi::Unicast)
+        (Afi::Ip, Safi::Unicast)
+            | (Afi::Ip6, Safi::Unicast)
+            | (Afi::Ip, Safi::MplsLabel)
+            | (Afi::Ip6, Safi::MplsLabel)
     )
 }
 

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -544,11 +544,13 @@ fn config_afi_safi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
 
 fn config_network(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let afi_safi: AfiSafi = args.afi_safi()?;
-    let network = args.v4net()?;
-    // `network` carries an ipv4-prefix, so it applies to the IPv4
-    // unicast and IPv4 Labeled-Unicast (SAFI 4) families.
+    // The `network` key is a union of ipv4-prefix / ipv6-prefix; parse it
+    // as the address family the afi-safi selects. An ipv6-prefix under a
+    // v4 family (or vice versa) fails to parse and the command is
+    // rejected, which is the desired behavior.
     match (afi_safi.afi, afi_safi.safi) {
         (Afi::Ip, Safi::Unicast) => {
+            let network = args.v4net()?;
             if op.is_set() {
                 bgp.route_add(network);
             } else {
@@ -556,10 +558,19 @@ fn config_network(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
             }
         }
         (Afi::Ip, Safi::MplsLabel) => {
+            let network = args.v4net()?;
             if op.is_set() {
                 bgp.route_add_label_v4(network);
             } else {
                 bgp.route_del_label_v4(network);
+            }
+        }
+        (Afi::Ip6, Safi::MplsLabel) => {
+            let network = args.v6net()?;
+            if op.is_set() {
+                bgp.route_add_label_v6(network);
+            } else {
+                bgp.route_del_label_v6(network);
             }
         }
         _ => return None,

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -2015,24 +2015,50 @@ impl Bgp {
     }
 
     fn route_redist_add(&mut self, rtype: crate::rib::RibType, batch: crate::rib::RouteBatch) {
+        use bgp_packet::{Afi, AfiSafi, Safi};
+        let source = Self::redist_source(rtype);
         match batch {
             crate::rib::RouteBatch::V4(entries) => {
                 for e in entries {
                     let prefix = e.prefix;
                     let rib_metric = e.metric;
                     self.redist_v4.insert((rtype, prefix), e);
-                    // Lower into Loc-RIB. Per-AFI override metric beats
-                    // the RIB cost; no override → use RIB cost as MED.
-                    let metric = self
-                        .redist_metric_v4_override(rtype, prefix)
-                        .unwrap_or(rib_metric);
-                    self.route_redist_inject(rtype, prefix, metric);
+                    let Some(source) = source else { continue };
+                    // One RIB subscription (per AFI) can feed several
+                    // configured families: inject into each that has this
+                    // (afi-safi, source) redistribute row. Per-row metric
+                    // override beats the RIB cost; else RIB cost → MED.
+                    let uni = AfiSafi::new(Afi::Ip, Safi::Unicast);
+                    if self.redistribute.contains_key(&(uni, source)) {
+                        let metric = self
+                            .redist_metric_override(uni, source)
+                            .unwrap_or(rib_metric);
+                        self.route_redist_inject(rtype, prefix, metric);
+                    }
+                    let lu = AfiSafi::new(Afi::Ip, Safi::MplsLabel);
+                    if self.redistribute.contains_key(&(lu, source)) {
+                        let metric = self
+                            .redist_metric_override(lu, source)
+                            .unwrap_or(rib_metric);
+                        self.route_redist_inject_labelv4(rtype, prefix, metric);
+                    }
                 }
             }
             crate::rib::RouteBatch::V6(entries) => {
-                // v6 stays storage-only until LocalRib grows a v6 path.
                 for e in entries {
-                    self.redist_v6.insert((rtype, e.prefix), e);
+                    let prefix = e.prefix;
+                    let rib_metric = e.metric;
+                    self.redist_v6.insert((rtype, prefix), e);
+                    let Some(source) = source else { continue };
+                    // IPv6 labeled-unicast. (IPv6 *unicast* redistribute
+                    // delivery is still storage-only — a separate gap.)
+                    let lu = AfiSafi::new(Afi::Ip6, Safi::MplsLabel);
+                    if self.redistribute.contains_key(&(lu, source)) {
+                        let metric = self
+                            .redist_metric_override(lu, source)
+                            .unwrap_or(rib_metric);
+                        self.route_redist_inject_labelv6(rtype, prefix, metric);
+                    }
                 }
             }
         }
@@ -2042,41 +2068,48 @@ impl Bgp {
         match batch {
             crate::rib::RouteBatch::V4(entries) => {
                 for e in entries {
-                    self.redist_v4.remove(&(rtype, e.prefix));
-                    self.route_redist_withdraw(rtype, e.prefix);
+                    let prefix = e.prefix;
+                    self.redist_v4.remove(&(rtype, prefix));
+                    // Withdraw from both v4 targets unconditionally: the
+                    // config row may already be gone (this RouteDel can be
+                    // the RIB's response to a RedistDel), and a withdraw of
+                    // a prefix never injected is a harmless no-op + an
+                    // ignored peer withdraw. Mirrors the v4-unicast path.
+                    self.route_redist_withdraw(rtype, prefix);
+                    self.route_redist_withdraw_labelv4(rtype, prefix);
                 }
             }
             crate::rib::RouteBatch::V6(entries) => {
-                // v6 storage-only — see route_redist_add.
                 for e in entries {
-                    self.redist_v6.remove(&(rtype, e.prefix));
+                    let prefix = e.prefix;
+                    self.redist_v6.remove(&(rtype, prefix));
+                    self.route_redist_withdraw_labelv6(rtype, prefix);
                 }
             }
         }
     }
 
-    /// Pull the `metric` static override from any `Bgp.redistribute`
-    /// row matching `(rtype, ipv4-unicast)`. Iterates because the map
-    /// is keyed by full `AfiSafi`, and we only care about the IPv4
-    /// unicast row here. `None` means "no override, use RIB cost".
-    fn redist_metric_v4_override(
-        &self,
-        rtype: crate::rib::RibType,
-        _prefix: ipnet::Ipv4Net,
-    ) -> Option<u32> {
+    /// Map a RIB route type to the `BgpRedistSource` it redistributes as,
+    /// or `None` for RIB types BGP doesn't redistribute (e.g. Kernel,
+    /// Bgp itself).
+    fn redist_source(rtype: crate::rib::RibType) -> Option<crate::bgp::config::BgpRedistSource> {
         use crate::bgp::config::BgpRedistSource;
-        use bgp_packet::{Afi, Safi};
-        let source = match rtype {
-            crate::rib::RibType::Connected => BgpRedistSource::Connected,
-            crate::rib::RibType::Static => BgpRedistSource::Static,
-            crate::rib::RibType::Isis => BgpRedistSource::Isis,
-            crate::rib::RibType::Ospf => BgpRedistSource::Ospf,
-            _ => return None,
-        };
-        let afi_safi = bgp_packet::AfiSafi {
-            afi: Afi::Ip,
-            safi: Safi::Unicast,
-        };
+        match rtype {
+            crate::rib::RibType::Connected => Some(BgpRedistSource::Connected),
+            crate::rib::RibType::Static => Some(BgpRedistSource::Static),
+            crate::rib::RibType::Isis => Some(BgpRedistSource::Isis),
+            crate::rib::RibType::Ospf => Some(BgpRedistSource::Ospf),
+            _ => None,
+        }
+    }
+
+    /// The static `metric` override for an `(afi-safi, source)`
+    /// redistribute row, or `None` (use the RIB cost as MED).
+    fn redist_metric_override(
+        &self,
+        afi_safi: bgp_packet::AfiSafi,
+        source: crate::bgp::config::BgpRedistSource,
+    ) -> Option<u32> {
         self.redistribute
             .get(&(afi_safi, source))
             .and_then(|c| c.metric)

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -6176,6 +6176,162 @@ impl Bgp {
         }
     }
 
+    /// Redistribute an IPv4 route into the label-v4 (SAFI 4) Loc-RIB.
+    /// The label-v4 sibling of [`Bgp::route_redist_inject`]: same
+    /// `redist_remote_id` discriminator and MED-from-metric, but
+    /// originates into `v4lu` with implicit-null (we are the egress FEC)
+    /// and advertises via the labelv4 path. No FIB install (control-plane
+    /// only; the per-prefix local label + ILM is Phase 5).
+    pub fn route_redist_inject_labelv4(
+        &mut self,
+        rtype: crate::rib::RibType,
+        prefix: Ipv4Net,
+        metric: u32,
+    ) {
+        let ident = ORIGINATED_PEER;
+        let remote_id = Self::redist_remote_id(rtype);
+        let mut attr = BgpAttr::new();
+        attr.med = Some(bgp_packet::Med::new(metric));
+        let mut rib = BgpRib::new(
+            ident,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            remote_id,
+            32768,
+            &attr,
+            Some(Label::new(3, 0, true)),
+            None,
+            false,
+        );
+        let (_replaced, selected, next_id) = self.local_rib.update_v4lu(prefix, rib.clone());
+        rib.local_id = next_id;
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+        };
+
+        if !selected.is_empty() {
+            route_advertise_to_peers_labelv4(prefix, &selected, &mut bgp_ref, &mut self.peers);
+        }
+    }
+
+    pub fn route_redist_withdraw_labelv4(&mut self, rtype: crate::rib::RibType, prefix: Ipv4Net) {
+        let ident = ORIGINATED_PEER;
+        let remote_id = Self::redist_remote_id(rtype);
+        let removed = self.local_rib.remove_v4lu(prefix, remote_id, ident);
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+        };
+
+        let selected = bgp_ref.local_rib.select_best_path_v4lu(prefix);
+        if !selected.is_empty() || !removed.is_empty() {
+            route_advertise_to_peers_labelv4(prefix, &selected, &mut bgp_ref, &mut self.peers);
+        }
+    }
+
+    /// Redistribute an IPv6 route into the label-v6 (SAFI 4) Loc-RIB.
+    /// The v6 counterpart of [`Bgp::route_redist_inject_labelv4`].
+    pub fn route_redist_inject_labelv6(
+        &mut self,
+        rtype: crate::rib::RibType,
+        prefix: Ipv6Net,
+        metric: u32,
+    ) {
+        let ident = ORIGINATED_PEER;
+        let remote_id = Self::redist_remote_id(rtype);
+        let mut attr = BgpAttr::new();
+        attr.med = Some(bgp_packet::Med::new(metric));
+        let mut rib = BgpRib::new(
+            ident,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            remote_id,
+            32768,
+            &attr,
+            Some(Label::new(3, 0, true)),
+            None,
+            false,
+        );
+        let (_replaced, selected, next_id) = self.local_rib.update_v6lu(prefix, rib.clone());
+        rib.local_id = next_id;
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+        };
+
+        if !selected.is_empty() {
+            route_advertise_to_peers_labelv6(prefix, &selected, &mut bgp_ref, &mut self.peers);
+        }
+    }
+
+    pub fn route_redist_withdraw_labelv6(&mut self, rtype: crate::rib::RibType, prefix: Ipv6Net) {
+        let ident = ORIGINATED_PEER;
+        let remote_id = Self::redist_remote_id(rtype);
+        let removed = self.local_rib.remove_v6lu(prefix, remote_id, ident);
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+        };
+
+        let selected = bgp_ref.local_rib.select_best_path_v6lu(prefix);
+        if !selected.is_empty() || !removed.is_empty() {
+            route_advertise_to_peers_labelv6(prefix, &selected, &mut bgp_ref, &mut self.peers);
+        }
+    }
+
     /// Originate an EVPN Type-2 (MAC/IP Advertisement) route from a
     /// kernel-learned bridge FDB entry.
     ///

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -5975,6 +5975,77 @@ impl Bgp {
         }
     }
 
+    /// Originate an IPv6 prefix into the Labeled-Unicast (SAFI 4) Loc-RIB
+    /// from a `network` statement under `afi-safi label-v6`. The v6
+    /// counterpart of [`Bgp::route_add_label_v4`]; advertises
+    /// implicit-null (we are the egress FEC). 6PE next-hop handling is in
+    /// the advertise path. No FIB install (control-plane only).
+    pub fn route_add_label_v6(&mut self, prefix: Ipv6Net) {
+        let ident = ORIGINATED_PEER;
+        let attr = BgpAttr::new();
+        let mut rib = BgpRib::new(
+            ident,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            0,
+            32768,
+            &attr,
+            Some(Label::new(3, 0, true)),
+            None,
+            false,
+        );
+        let (_replaced, selected, next_id) = self.local_rib.update_v6lu(prefix, rib.clone());
+        rib.local_id = next_id;
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+        };
+
+        if !selected.is_empty() {
+            route_advertise_to_peers_labelv6(prefix, &selected, &mut bgp_ref, &mut self.peers);
+        }
+    }
+
+    pub fn route_del_label_v6(&mut self, prefix: Ipv6Net) {
+        let ident = ORIGINATED_PEER;
+        let removed = self.local_rib.remove_v6lu(prefix, 0, ident);
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+        };
+
+        let selected = bgp_ref.local_rib.select_best_path_v6lu(prefix);
+        if !selected.is_empty() || !removed.is_empty() {
+            route_advertise_to_peers_labelv6(prefix, &selected, &mut bgp_ref, &mut self.peers);
+        }
+    }
+
     // ---- redistribute injection -----------------------------------
     //
     // `route_redist_inject` / `route_redist_withdraw` are siblings of

--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -281,7 +281,12 @@ module ietf-bgp {
         list network {
           key "prefix";
           leaf prefix {
-            type inet:ipv4-prefix;
+            // IPv4 prefix for ipv4 / label-v4 families; IPv6 prefix for
+            // label-v6. The Rust config layer parses per the afi-safi.
+            type union {
+              type inet:ipv4-prefix;
+              type inet:ipv6-prefix;
+            }
           }
         }
       }


### PR DESCRIPTION
Phase 4b of BGP Labeled Unicast: the deferred origination sources, so an operator can fully originate labeled routes (not just propagate received ones). Builds on the merged control plane (#1042 + #1047). Still control-plane only — self-originated FECs advertise implicit-null; the MPLS dataplane is Phase 5.

Two commits:

## 1. `network` for label-v6
- `route_add_label_v6` / `route_del_label_v6` — originate an IPv6 prefix into the `v6lu` Loc-RIB with implicit-null and advertise via the labelv6 path (which already does 6PE next-hop encoding).
- `config_network` parses the prefix per the afi-safi (`v4net` for ipv4/label-v4, `v6net` for label-v6).
- `ietf-bgp.yang`: the `network` key becomes a `union` of ipv4-prefix / ipv6-prefix.

## 2. redistribute into label-v4 / label-v6
- `redist_afi_valid` accepts `(Ip, MplsLabel)` / `(Ip6, MplsLabel)` (`wire_afi` already maps both to the v4/v6 RIB subscription).
- `route_redist_inject_labelv4/labelv6` (+ `_withdraw_*`) originate into `v4lu`/`v6lu` with implicit-null, MED from the source metric, advertised via labelv4/labelv6. No FIB install (Phase 5).
- `route_redist_add` now lets one RIB subscription (per AFI) feed **multiple configured families** — each incoming connected/static/IGP route is injected into every table whose `(afi-safi, source)` redistribute row exists (so the same route can land in `ipv4` **and** `label-v4`). This also **fixes a latent bug**: the v4-unicast inject is now gated on `(ipv4, source)` being configured, so a label-v4-only redistribute no longer wrongly injects into the unicast table. V6 batches (previously storage-only) now feed `label-v6`.
- `route_redist_del` withdraws from the v4/v4lu (and v6lu) targets unconditionally (a RouteDel can be the RIB's response to a RedistDel after the config row is gone; withdrawing a never-injected prefix is a harmless no-op). Mirrors the v4-unicast pattern.
- Refactor: `redist_source` + `redist_metric_override(afi_safi, source)` replace the v4-only `redist_metric_v4_override`.

## Config

```
router bgp {
  afi-safi label-v4 { network 10.0.0.0/24; redistribute connected; }
  afi-safi label-v6 { network 2001:db8::/48; redistribute static; }
}
```

## Out of scope

IPv6 **unicast** redistribute delivery stays storage-only (a separate pre-existing gap, untouched here). The per-prefix local label + ILM swap for next-hop-self FECs is Phase 5.

## Tests

zebra-rs unit suite (721) + `yang_load_tests` pass; workspace `clippy --all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)