### PR TITLE
bgp: SR Policy SAFI 73 wire codec (decode-only)

### DIFF
--- a/crates/bgp-packet/src/afi.rs
+++ b/crates/bgp-packet/src/afi.rs
@@ -38,6 +38,10 @@ pub enum Safi {
     Flowspec = 133,
     #[strum(serialize = "MUP")]
     Mup = 85,
+    /// SR Policy / SR-TE Policy SAFI (RFC 9830). Used with AFI 1
+    /// (IPv4 endpoint) or AFI 2 (IPv6 endpoint).
+    #[strum(serialize = "SR Policy")]
+    SrTePolicy = 73,
     #[strum(to_string = "Unknown({0})")]
     Unknown(u8),
 }
@@ -149,6 +153,7 @@ impl From<Safi> for u8 {
             Rtc => 132,
             Flowspec => 133,
             Mup => 85,
+            SrTePolicy => 73,
             Unknown(v) => v,
         }
     }
@@ -163,6 +168,7 @@ impl From<u8> for Safi {
             4 => MplsLabel,
             7 => Encap,
             70 => Evpn,
+            73 => SrTePolicy,
             85 => Mup,
             128 => MplsVpn,
             132 => Rtc,
@@ -203,6 +209,7 @@ mod tests {
             Safi::Encap,
             Safi::Evpn,
             Safi::Mup,
+            Safi::SrTePolicy,
             Safi::MplsVpn,
             Safi::Rtc,
             Safi::Flowspec,

--- a/crates/bgp-packet/src/attrs/mod.rs
+++ b/crates/bgp-packet/src/attrs/mod.rs
@@ -105,3 +105,6 @@ pub use flowspec_action::*;
 
 pub mod nlri_labeled_unicast;
 pub use nlri_labeled_unicast::*;
+
+pub mod nlri_srpolicy;
+pub use nlri_srpolicy::*;

--- a/crates/bgp-packet/src/attrs/mp_reach.rs
+++ b/crates/bgp-packet/src/attrs/mp_reach.rs
@@ -11,8 +11,8 @@ use bytes::BufMut;
 
 use crate::{
     Afi, AttrFlags, AttrType, EvpnRoute, FlowspecNlri, Ipv4Nlri, Ipv6Nlri, Labelv4Nlri,
-    Labelv6Nlri, MupRoute, ParseBe, ParseNlri, ParseOption, Rtcv4, Rtcv6, Safi, Vpnv4Nexthop,
-    Vpnv4Nlri, Vpnv6Nexthop, Vpnv6Nlri, many0_complete,
+    Labelv6Nlri, MupRoute, ParseBe, ParseNlri, ParseOption, Rtcv4, Rtcv6, Safi, SrPolicyNlri,
+    Vpnv4Nexthop, Vpnv4Nlri, Vpnv6Nexthop, Vpnv6Nlri, many0_complete,
 };
 
 use super::{AttrEmitter, RouteDistinguisher, Rtcv4Reach, Rtcv6Reach, Vpnv4Reach, Vpnv6Reach};
@@ -75,6 +75,15 @@ pub enum MpReachAttr {
         nhop: IpAddr,
         updates: Vec<Labelv6Nlri>,
     },
+    /// BGP SR Policy (RFC 9830), SAFI 73. The outer AFI selects the
+    /// endpoint family (IPv4 vs IPv6); the candidate-path content rides
+    /// in the Tunnel Encapsulation attribute (Tunnel-Type 15), not here.
+    SrPolicy {
+        afi: Afi,
+        snpa: u8,
+        nhop: IpAddr,
+        updates: Vec<SrPolicyNlri>,
+    },
 }
 
 impl MpReachAttr {
@@ -130,6 +139,14 @@ impl MpReachAttr {
                 updates,
             } => {
                 labelv6_attr_emit(*snpa, nhop, updates, buf);
+            }
+            MpReachAttr::SrPolicy {
+                afi,
+                snpa,
+                nhop,
+                updates,
+            } => {
+                srpolicy_attr_emit(*afi, *snpa, nhop, updates, buf);
             }
             _ => {
                 //
@@ -499,6 +516,38 @@ impl MpReachAttr {
             let rtc_nlri = MpReachAttr::Rtcv6(nlri);
             return Ok((input, rtc_nlri));
         }
+        if (header.afi == Afi::Ip || header.afi == Afi::Ip6) && header.safi == Safi::SrTePolicy {
+            // RFC 9830 §2.1: the MP_REACH next-hop is a 4-octet IPv4 or
+            // 16-octet IPv6 address, independent of the SR Policy AFI.
+            // Accept the RFC 8950 32-octet (global || link-local) form
+            // too and surface the global half, mirroring the other SAFIs.
+            let (input, nhop): (&[u8], IpAddr) = match header.nhop_len {
+                4 => {
+                    let (input, addr) = be_u32(input)?;
+                    (input, IpAddr::V4(Ipv4Addr::from(addr)))
+                }
+                16 => {
+                    let (input, addr) = be_u128(input)?;
+                    (input, IpAddr::V6(Ipv6Addr::from(addr)))
+                }
+                32 => {
+                    let (input, global) = be_u128(input)?;
+                    let (input, _link_local) = be_u128(input)?;
+                    (input, IpAddr::V6(Ipv6Addr::from(global)))
+                }
+                _ => return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue))),
+            };
+            let (input, snpa) = be_u8(input)?;
+            let (input, updates) =
+                many0_complete(|i| SrPolicyNlri::parse(i, add_path, header.afi)).parse(input)?;
+            let mp_nlri = MpReachAttr::SrPolicy {
+                afi: header.afi,
+                snpa,
+                nhop,
+                updates,
+            };
+            return Ok((input, mp_nlri));
+        }
         Err(nom::Err::Error(make_error(input, ErrorKind::NoneOf)))
     }
 }
@@ -617,6 +666,20 @@ impl fmt::Display for MpReachAttr {
             } => {
                 for update in updates.iter() {
                     writeln!(f, " {update} => {nhop}")?;
+                }
+            }
+            SrPolicy {
+                afi,
+                snpa: _,
+                nhop,
+                updates,
+            } => {
+                for update in updates.iter() {
+                    writeln!(
+                        f,
+                        " {afi}/SR-Policy color={} endpoint={} disc={} => {nhop}",
+                        update.color, update.endpoint, update.distinguisher,
+                    )?;
                 }
             }
             _ => {
@@ -910,6 +973,63 @@ pub(crate) fn labelv6_attr_emit(
     value.put_u8(0);
     for nlri in updates {
         nlri.nlri_emit(&mut value);
+    }
+
+    let len = value.len();
+    let extended = len > 255;
+    let flags = if extended {
+        AttrFlags::new().with_optional(true).with_extended(true)
+    } else {
+        AttrFlags::new().with_optional(true)
+    };
+    buf.put_u8(flags.into());
+    buf.put_u8(AttrType::MpReachNlri.into());
+    if extended {
+        buf.put_u16(len as u16);
+    } else {
+        buf.put_u8(len as u8);
+    }
+    buf.put(&value[..]);
+}
+
+/// Serialize an `MpReachAttr::SrPolicy { afi, snpa, nhop, updates }` as
+/// a complete `MP_REACH_NLRI` path attribute (header + value).
+///
+/// Wire format (RFC 4760 §3 + RFC 9830 §2.1):
+/// ```text
+///   AFI  (2 octets) = 1 (IPv4 endpoint) or 2 (IPv6 endpoint)
+///   SAFI (1 octet)  = 73 (SR Policy)
+///   Nexthop Length (1 octet) = 4 or 16
+///   Nexthop Address
+///   Reserved / SNPA (1 octet) = 0
+///   NLRIs (zero or more SrPolicyNlri encodings)
+/// ```
+///
+/// The next-hop family follows `nhop` (`IpAddr::V4` → 4 octets,
+/// `IpAddr::V6` → 16 octets) and is independent of the SR Policy AFI.
+pub(crate) fn srpolicy_attr_emit(
+    afi: Afi,
+    _snpa: u8,
+    nhop: &IpAddr,
+    updates: &[SrPolicyNlri],
+    buf: &mut BytesMut,
+) {
+    let mut value = BytesMut::new();
+    value.put_u16(u16::from(afi));
+    value.put_u8(u8::from(Safi::SrTePolicy));
+    match nhop {
+        IpAddr::V4(v4) => {
+            value.put_u8(4);
+            value.put(&v4.octets()[..]);
+        }
+        IpAddr::V6(v6) => {
+            value.put_u8(16);
+            value.put(&v6.octets()[..]);
+        }
+    }
+    value.put_u8(0); // SNPA
+    for r in updates {
+        r.nlri_emit(&mut value, false);
     }
 
     let len = value.len();
@@ -1233,6 +1353,75 @@ mod tests {
                 MpReachAttr::parse_nlri_opt(&value, None).is_err(),
                 "expected parse error for nhop_len={bad}",
             );
+        }
+    }
+
+    #[test]
+    fn srpolicy_ipv4_emit_round_trips_through_parser() {
+        let nhop = IpAddr::V4("192.0.2.1".parse().unwrap());
+        let updates = vec![
+            SrPolicyNlri {
+                id: 0,
+                distinguisher: 1,
+                color: 100,
+                endpoint: IpAddr::V4("10.0.0.9".parse().unwrap()),
+            },
+            SrPolicyNlri {
+                id: 0,
+                distinguisher: 2,
+                color: 100,
+                endpoint: IpAddr::V4("10.0.0.10".parse().unwrap()),
+            },
+        ];
+        let mut buf = BytesMut::new();
+        srpolicy_attr_emit(Afi::Ip, 0, &nhop, &updates, &mut buf);
+        // Strip flags(1) + type(1) + length(1) header.
+        let value = &buf[3..];
+        let (_rest, mp) =
+            MpReachAttr::parse_nlri_opt(value, None).expect("emitter must round-trip");
+        match mp {
+            MpReachAttr::SrPolicy {
+                afi,
+                nhop: parsed_nhop,
+                updates: parsed,
+                ..
+            } => {
+                assert_eq!(afi, Afi::Ip);
+                assert_eq!(parsed_nhop, nhop);
+                assert_eq!(parsed, updates);
+            }
+            other => panic!("expected SrPolicy, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn srpolicy_ipv6_endpoint_with_v4_nexthop_round_trips() {
+        // SR Policy AFI (endpoint family) is independent of the
+        // next-hop family: IPv6 endpoints, IPv4 next-hop.
+        let nhop = IpAddr::V4("203.0.113.1".parse().unwrap());
+        let updates = vec![SrPolicyNlri {
+            id: 0,
+            distinguisher: 7,
+            color: 200,
+            endpoint: IpAddr::V6("2001:db8::9".parse().unwrap()),
+        }];
+        let mut buf = BytesMut::new();
+        srpolicy_attr_emit(Afi::Ip6, 0, &nhop, &updates, &mut buf);
+        let value = &buf[3..];
+        let (_rest, mp) =
+            MpReachAttr::parse_nlri_opt(value, None).expect("emitter must round-trip");
+        match mp {
+            MpReachAttr::SrPolicy {
+                afi,
+                nhop: parsed_nhop,
+                updates: parsed,
+                ..
+            } => {
+                assert_eq!(afi, Afi::Ip6);
+                assert_eq!(parsed_nhop, nhop);
+                assert_eq!(parsed, updates);
+            }
+            other => panic!("expected SrPolicy, got {other:?}"),
         }
     }
 }

--- a/crates/bgp-packet/src/attrs/mp_unreach.rs
+++ b/crates/bgp-packet/src/attrs/mp_unreach.rs
@@ -7,7 +7,7 @@ use nom_derive::*;
 use crate::{
     Afi, AttrFlags, AttrType, EvpnRoute, FlowspecNlri, Ipv6Nlri, Labelv4Nlri, Labelv6Nlri,
     MupRoute, ParseBe, ParseNlri, ParseOption, Rtcv4, Rtcv4Unreach, Rtcv6, Rtcv6Unreach, Safi,
-    Vpnv4Nlri, Vpnv6Nlri, many0_complete,
+    SrPolicyNlri, Vpnv4Nlri, Vpnv6Nlri, many0_complete,
 };
 
 use super::{AttrEmitter, Vpnv4Unreach, Vpnv6Unreach};
@@ -54,6 +54,13 @@ pub enum MpUnreachAttr {
     /// IPv6 Labeled-Unicast withdrawals (RFC 3107 / RFC 8277), SAFI 4.
     Labelv6(Vec<Labelv6Nlri>),
     Labelv6Eor,
+    /// BGP SR Policy withdraws (RFC 9830), SAFI 73. The outer AFI is
+    /// preserved so the emitter can re-encode it; an empty `withdraws`
+    /// list represents end-of-RIB.
+    SrPolicy {
+        afi: Afi,
+        withdraws: Vec<SrPolicyNlri>,
+    },
 }
 
 impl MpUnreachAttr {
@@ -116,6 +123,9 @@ impl MpUnreachAttr {
             }
             MpUnreachAttr::Labelv6Eor => {
                 labelv6_unreach_attr_emit(&[], buf);
+            }
+            MpUnreachAttr::SrPolicy { afi, withdraws } => {
+                srpolicy_unreach_attr_emit(*afi, withdraws, buf);
             }
             _ => {
                 //
@@ -323,6 +333,41 @@ fn labelv6_unreach_attr_emit(withdraws: &[Labelv6Nlri], buf: &mut BytesMut) {
     buf.put(&value[..]);
 }
 
+/// Serialize an `MpUnreachAttr::SrPolicy { afi, withdraws }` (empty
+/// `withdraws` encodes an end-of-RIB marker) as a complete
+/// `MP_UNREACH_NLRI` path attribute.
+///
+/// Wire format (RFC 4760 §4 + RFC 9830 §2.1):
+/// ```text
+///   AFI  (2 octets) = 1 (IPv4 endpoint) or 2 (IPv6 endpoint)
+///   SAFI (1 octet)  = 73 (SR Policy)
+///   Withdrawn Routes (zero or more SrPolicyNlri encodings)
+/// ```
+fn srpolicy_unreach_attr_emit(afi: Afi, withdraws: &[SrPolicyNlri], buf: &mut BytesMut) {
+    let mut value = BytesMut::new();
+    value.put_u16(u16::from(afi));
+    value.put_u8(u8::from(Safi::SrTePolicy));
+    for r in withdraws {
+        r.nlri_emit(&mut value, false);
+    }
+
+    let len = value.len();
+    let extended = len > 255;
+    let flags = if extended {
+        AttrFlags::new().with_optional(true).with_extended(true)
+    } else {
+        AttrFlags::new().with_optional(true)
+    };
+    buf.put_u8(flags.into());
+    buf.put_u8(AttrType::MpUnreachNlri.into());
+    if extended {
+        buf.put_u16(len as u16);
+    } else {
+        buf.put_u8(len as u8);
+    }
+    buf.put(&value[..]);
+}
+
 impl MpUnreachAttr {
     pub fn parse_nlri_opt(input: &[u8], opt: Option<ParseOption>) -> nom::IResult<&[u8], Self> {
         // AFI + SAFI = 3.
@@ -451,6 +496,26 @@ impl MpUnreachAttr {
             let (input, rtcv6) = many0_complete(|i| Rtcv6::parse_nlri(i, add_path)).parse(input)?;
             let mp_nlri = MpUnreachAttr::Rtcv6(rtcv6);
             return Ok((input, mp_nlri));
+        }
+        if (header.afi == Afi::Ip || header.afi == Afi::Ip6) && header.safi == Safi::SrTePolicy {
+            if input.is_empty() {
+                return Ok((
+                    input,
+                    MpUnreachAttr::SrPolicy {
+                        afi: header.afi,
+                        withdraws: vec![],
+                    },
+                ));
+            }
+            let (input, withdraws) =
+                many0_complete(|i| SrPolicyNlri::parse(i, add_path, header.afi)).parse(input)?;
+            return Ok((
+                input,
+                MpUnreachAttr::SrPolicy {
+                    afi: header.afi,
+                    withdraws,
+                },
+            ));
         }
         Err(nom::Err::Error(make_error(input, ErrorKind::NoneOf)))
     }
@@ -584,6 +649,19 @@ impl fmt::Display for MpUnreachAttr {
             }
             Labelv6Eor => {
                 writeln!(f, " EoR: {}/{}", Afi::Ip6, Safi::MplsLabel)
+            }
+            SrPolicy { afi, withdraws } => {
+                if withdraws.is_empty() {
+                    return writeln!(f, " EoR: {}/{}", afi, Safi::SrTePolicy);
+                }
+                for r in withdraws {
+                    writeln!(
+                        f,
+                        " {afi}/SR-Policy color={} endpoint={} disc={}",
+                        r.color, r.endpoint, r.distinguisher,
+                    )?;
+                }
+                Ok(())
             }
         }
     }
@@ -777,6 +855,56 @@ mod tests {
                 assert!(withdraws.is_empty());
             }
             other => panic!("expected Mup, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn srpolicy_unreach_emit_round_trips_through_parser() {
+        use std::net::IpAddr;
+        let withdraws = vec![
+            SrPolicyNlri {
+                id: 0,
+                distinguisher: 1,
+                color: 100,
+                endpoint: IpAddr::V4("10.0.0.9".parse().unwrap()),
+            },
+            SrPolicyNlri {
+                id: 0,
+                distinguisher: 2,
+                color: 100,
+                endpoint: IpAddr::V4("10.0.0.10".parse().unwrap()),
+            },
+        ];
+        let mut buf = BytesMut::new();
+        srpolicy_unreach_attr_emit(Afi::Ip, &withdraws, &mut buf);
+        // Strip header: flags(1) + type(1) + length(1).
+        let value = &buf[3..];
+        let (_rest, mp) =
+            MpUnreachAttr::parse_nlri_opt(value, None).expect("emitter must round-trip");
+        match mp {
+            MpUnreachAttr::SrPolicy {
+                afi,
+                withdraws: parsed,
+            } => {
+                assert_eq!(afi, Afi::Ip);
+                assert_eq!(parsed, withdraws);
+            }
+            other => panic!("expected SrPolicy, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn srpolicy_unreach_emit_eor_round_trips() {
+        let mut buf = BytesMut::new();
+        srpolicy_unreach_attr_emit(Afi::Ip6, &[], &mut buf);
+        let value = &buf[3..];
+        let (_rest, mp) = MpUnreachAttr::parse_nlri_opt(value, None).expect("EoR must round-trip");
+        match mp {
+            MpUnreachAttr::SrPolicy { afi, withdraws } => {
+                assert_eq!(afi, Afi::Ip6);
+                assert!(withdraws.is_empty());
+            }
+            other => panic!("expected SrPolicy, got {other:?}"),
         }
     }
 }

--- a/crates/bgp-packet/src/attrs/nlri_srpolicy.rs
+++ b/crates/bgp-packet/src/attrs/nlri_srpolicy.rs
@@ -1,0 +1,234 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use bytes::{BufMut, BytesMut};
+use nom::IResult;
+use nom::error::{ErrorKind, make_error};
+use nom::number::complete::{be_u8, be_u32, be_u128};
+
+use crate::Afi;
+
+/// SR Policy NLRI (RFC 9830 §2.1).
+///
+/// ```text
+///   +------------------+
+///   | NLRI Length      |  1 octet  — length in BITS: 96 (IPv4) / 192 (IPv6)
+///   +------------------+
+///   | Distinguisher    |  4 octets
+///   +------------------+
+///   | Color            |  4 octets
+///   +------------------+
+///   | Endpoint         |  4 octets (AFI 1) or 16 octets (AFI 2)
+///   +------------------+
+/// ```
+///
+/// The endpoint address family comes from the enclosing
+/// MP_REACH/MP_UNREACH header AFI, not from the NLRI itself — the same
+/// way BGP MUP (RFC 9833) threads the outer AFI down to
+/// `MupRoute::parse`. The candidate-path content (preference, binding
+/// SID, segment lists, …) rides in the Tunnel Encapsulation attribute
+/// (Tunnel-Type 15), decoded separately.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct SrPolicyNlri {
+    /// Add-Path identifier (0 when Add-Path is not negotiated).
+    pub id: u32,
+    /// Distinguisher — makes the NLRI unique within a `<color,
+    /// endpoint>` tuple; maps to the candidate-path discriminator
+    /// (RFC 9256 §2.5).
+    pub distinguisher: u32,
+    /// Color — non-zero on the wire (RFC 9256 §2.1); validated by the
+    /// consumer, not the codec.
+    pub color: u32,
+    /// Endpoint — IPv4 or IPv6 per the header AFI; may be the null
+    /// address (`0.0.0.0` / `::`) for a color-only policy.
+    pub endpoint: IpAddr,
+}
+
+/// NLRI Length field value (in bits) for an IPv4 endpoint: (4 + 4 + 4) * 8.
+const NLRI_LEN_BITS_V4: u8 = 96;
+/// NLRI Length field value (in bits) for an IPv6 endpoint: (4 + 4 + 16) * 8.
+const NLRI_LEN_BITS_V6: u8 = 192;
+
+impl SrPolicyNlri {
+    /// Parse one SR Policy NLRI. `afi` (from the MP header) selects the
+    /// endpoint width and the value the 1-octet Length field must carry
+    /// — RFC 9830 §2.1 mandates 96 for IPv4 and 192 for IPv6; any other
+    /// value is malformed.
+    pub fn parse(input: &[u8], add_path: bool, afi: Afi) -> IResult<&[u8], Self> {
+        let (input, id) = if add_path { be_u32(input)? } else { (input, 0) };
+        let (input, len) = be_u8(input)?;
+        let (input, distinguisher) = be_u32(input)?;
+        let (input, color) = be_u32(input)?;
+        let (input, endpoint) = match afi {
+            Afi::Ip => {
+                if len != NLRI_LEN_BITS_V4 {
+                    return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+                }
+                let (input, addr) = be_u32(input)?;
+                (input, IpAddr::V4(Ipv4Addr::from(addr)))
+            }
+            Afi::Ip6 => {
+                if len != NLRI_LEN_BITS_V6 {
+                    return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
+                }
+                let (input, addr) = be_u128(input)?;
+                (input, IpAddr::V6(Ipv6Addr::from(addr)))
+            }
+            _ => return Err(nom::Err::Error(make_error(input, ErrorKind::NoneOf))),
+        };
+        Ok((
+            input,
+            SrPolicyNlri {
+                id,
+                distinguisher,
+                color,
+                endpoint,
+            },
+        ))
+    }
+
+    /// Serialize this NLRI. The Length byte and endpoint width are
+    /// derived from the endpoint variant; the Add-Path id is prefixed
+    /// only when `add_path` is set.
+    pub fn nlri_emit(&self, buf: &mut BytesMut, add_path: bool) {
+        if add_path {
+            buf.put_u32(self.id);
+        }
+        match self.endpoint {
+            IpAddr::V4(v4) => {
+                buf.put_u8(NLRI_LEN_BITS_V4);
+                buf.put_u32(self.distinguisher);
+                buf.put_u32(self.color);
+                buf.put(&v4.octets()[..]);
+            }
+            IpAddr::V6(v6) => {
+                buf.put_u8(NLRI_LEN_BITS_V6);
+                buf.put_u32(self.distinguisher);
+                buf.put_u32(self.color);
+                buf.put(&v6.octets()[..]);
+            }
+        }
+    }
+
+    /// The AFI implied by the endpoint address family.
+    pub fn afi(&self) -> Afi {
+        match self.endpoint {
+            IpAddr::V4(_) => Afi::Ip,
+            IpAddr::V6(_) => Afi::Ip6,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v4_bytes(len: u8, dist: u32, color: u32, ep: [u8; 4]) -> Vec<u8> {
+        let mut v = vec![len];
+        v.extend_from_slice(&dist.to_be_bytes());
+        v.extend_from_slice(&color.to_be_bytes());
+        v.extend_from_slice(&ep);
+        v
+    }
+
+    #[test]
+    fn ipv4_nlri_parses() {
+        let bytes = v4_bytes(96, 1, 100, [10, 0, 0, 9]);
+        let (rest, nlri) = SrPolicyNlri::parse(&bytes, false, Afi::Ip).expect("parse");
+        assert!(rest.is_empty());
+        assert_eq!(nlri.distinguisher, 1);
+        assert_eq!(nlri.color, 100);
+        assert_eq!(nlri.endpoint, IpAddr::V4("10.0.0.9".parse().unwrap()));
+        assert_eq!(nlri.afi(), Afi::Ip);
+    }
+
+    #[test]
+    fn ipv6_nlri_parses() {
+        let ep: Ipv6Addr = "2001:db8::9".parse().unwrap();
+        let mut bytes = vec![192u8];
+        bytes.extend_from_slice(&7u32.to_be_bytes());
+        bytes.extend_from_slice(&200u32.to_be_bytes());
+        bytes.extend_from_slice(&ep.octets());
+        let (rest, nlri) = SrPolicyNlri::parse(&bytes, false, Afi::Ip6).expect("parse");
+        assert!(rest.is_empty());
+        assert_eq!(nlri.distinguisher, 7);
+        assert_eq!(nlri.color, 200);
+        assert_eq!(nlri.endpoint, IpAddr::V6(ep));
+        assert_eq!(nlri.afi(), Afi::Ip6);
+    }
+
+    #[test]
+    fn ipv4_round_trips_through_emit() {
+        let nlri = SrPolicyNlri {
+            id: 0,
+            distinguisher: 42,
+            color: 12345,
+            endpoint: IpAddr::V4("192.0.2.1".parse().unwrap()),
+        };
+        let mut buf = BytesMut::new();
+        nlri.nlri_emit(&mut buf, false);
+        let (rest, back) = SrPolicyNlri::parse(&buf, false, Afi::Ip).expect("parse");
+        assert!(rest.is_empty());
+        assert_eq!(back, nlri);
+    }
+
+    #[test]
+    fn ipv6_round_trips_through_emit() {
+        let nlri = SrPolicyNlri {
+            id: 0,
+            distinguisher: 1,
+            color: 1,
+            endpoint: IpAddr::V6("fc00::1".parse().unwrap()),
+        };
+        let mut buf = BytesMut::new();
+        nlri.nlri_emit(&mut buf, false);
+        let (rest, back) = SrPolicyNlri::parse(&buf, false, Afi::Ip6).expect("parse");
+        assert!(rest.is_empty());
+        assert_eq!(back, nlri);
+    }
+
+    #[test]
+    fn add_path_id_round_trips() {
+        let nlri = SrPolicyNlri {
+            id: 0xdead_beef,
+            distinguisher: 9,
+            color: 3,
+            endpoint: IpAddr::V4("10.1.2.3".parse().unwrap()),
+        };
+        let mut buf = BytesMut::new();
+        nlri.nlri_emit(&mut buf, true);
+        let (_rest, back) = SrPolicyNlri::parse(&buf, true, Afi::Ip).expect("parse");
+        assert_eq!(back.id, 0xdead_beef);
+        assert_eq!(back, nlri);
+    }
+
+    #[test]
+    fn ipv4_rejects_wrong_length_field() {
+        // 192 is the IPv6 length; invalid for an IPv4 endpoint.
+        let bytes = v4_bytes(192, 1, 100, [10, 0, 0, 9]);
+        assert!(SrPolicyNlri::parse(&bytes, false, Afi::Ip).is_err());
+    }
+
+    #[test]
+    fn ipv6_rejects_wrong_length_field() {
+        let ep: Ipv6Addr = "2001:db8::9".parse().unwrap();
+        let mut bytes = vec![96u8]; // IPv4 length, invalid for IPv6
+        bytes.extend_from_slice(&1u32.to_be_bytes());
+        bytes.extend_from_slice(&1u32.to_be_bytes());
+        bytes.extend_from_slice(&ep.octets());
+        assert!(SrPolicyNlri::parse(&bytes, false, Afi::Ip6).is_err());
+    }
+
+    #[test]
+    fn unknown_afi_rejected() {
+        let bytes = v4_bytes(96, 1, 100, [10, 0, 0, 9]);
+        assert!(SrPolicyNlri::parse(&bytes, false, Afi::L2vpn).is_err());
+    }
+
+    #[test]
+    fn color_only_null_endpoint_parses() {
+        // RFC 9256 §8.8.1 color-only: endpoint may be the null address.
+        let bytes = v4_bytes(96, 0, 100, [0, 0, 0, 0]);
+        let (_rest, nlri) = SrPolicyNlri::parse(&bytes, false, Afi::Ip).expect("parse");
+        assert_eq!(nlri.endpoint, IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+    }
+}

--- a/docs/design/bgp-sr-policy-plan.md
+++ b/docs/design/bgp-sr-policy-plan.md
@@ -1,0 +1,547 @@
+# BGP SR Policy (RFC 9256 / 9830 / 9831) — Implementation Plan
+
+Status: proposed (2026-05-30). Scope locked with Kunihiro: headend
+**consumer** first, **SRv6** segment dataplane first, **control-plane**
+first (receive → typed TLVs → policy DB + selection + show). Originator,
+dataplane install, and automated color steering are later phases.
+
+Branch: `bgp-sr-policy` (already created off `main`).
+
+Status note: numbers below (PR counts, file lists, byte offsets) are
+estimates to guide the work, not commitments.
+
+## Table of contents
+
+1. What we are building
+2. Standards basis — the load-bearing numbers
+3. Reference implementations (FRR / Cisco) and what they tell us
+4. Architecture overview
+5. Packet codec design (`crates/bgp-packet`)
+6. Control-plane design (`zebra-rs/src/bgp`)
+7. YANG schema proposal
+8. Show / operational model
+9. Dataplane realization (deferred — design sketch)
+10. Automated steering (deferred — design sketch)
+11. Phasing / PR plan
+12. Validation strategy
+13. Risks and open questions
+
+---
+
+## 1. What we are building
+
+BGP SR Policy distributes Segment Routing Traffic Engineering policies
+through BGP (SAFI 73). A *controller / PCE / route-reflector* originates
+policies; a *headend router* consumes them, selects the active candidate
+path per `<color, endpoint>`, programs a Binding SID, and steers
+color-tagged service traffic onto the policy.
+
+zebra-rs is a router, so the primary role is **headend consumer**. The
+feature must work for both **IPv4 and IPv6** — the address family of the
+SR Policy NLRI (AFI 1 vs AFI 2 = endpoint family) is independent of the
+segment dataplane (SR-MPLS vs SRv6) carried inside.
+
+This plan delivers, in order:
+
+- **Phase 1–3 (this body of work):** negotiate SAFI 73, parse the NLRI
+  and the SR Policy Tunnel Encapsulation sub-TLVs into typed structures,
+  store candidate paths in an SR Policy database, run RFC 9256 active
+  candidate-path selection, and expose it through `show`. No FIB install,
+  no traffic steering yet.
+- **Phase 4+ (later):** realize the active path in the dataplane (SRv6
+  first via seg6 lwtunnel + Binding SID local SID), then automated
+  steering of color-tagged unicast/VPN routes onto policies, then the
+  originator side.
+
+This mirrors the rhythm of the VPNv6-leak series and the Flowspec plan:
+land a correct, observable control plane first; attach the dataplane
+behind it.
+
+## 2. Standards basis — the load-bearing numbers
+
+| Item | Value | Source |
+|------|-------|--------|
+| SR Policy SAFI | **73** (AFI 1 = IPv4, AFI 2 = IPv6) | RFC 9830 §2.1 |
+| NLRI layout | `Length(1) ‖ Distinguisher(4) ‖ Color(4) ‖ Endpoint(4 or 16)` | RFC 9830 §2.1 |
+| NLRI Length (bits) | **96** (v4) / **192** (v6) | RFC 9830 §2.1 |
+| Next-hop | 4 or 16 octets, AFI inferred from length, *independent of policy AFI* | RFC 9830 §2.1 |
+| Carrier attribute | Tunnel Encapsulation, **path attr 23**, optional-transitive | RFC 9012 §2 |
+| Tunnel-Type | **15** (SR Policy) | RFC 9830 / IANA |
+| Sub-TLV length width | 1 octet for type ≤127, 2 octets for type ≥128 | RFC 9012 §2 |
+
+**SR Policy sub-TLVs** (inside the Tunnel-Type-15 TLV):
+
+| Type | Sub-TLV | Notes |
+|-----:|---------|-------|
+| 12 | Preference | Flags(1)+Resv(1)+Preference(4); default 100 |
+| 13 | Binding SID | Flags(1)+Resv(1)+BSID(0/4/16); S=bit0, I=bit1 |
+| 14 | ENLP | values 1=v4,2=v6,3=both,4=none |
+| 15 | Priority | Priority(1)+Resv(1); 0–255, lower=higher, default 128 |
+| 20 | SRv6 Binding SID | Flags(1)+Resv(1)+SID(16)+opt Behavior/Structure(8); S,I,B flags |
+| 128 | Segment List | Resv(1)+opt Weight+segments |
+| 129 | Candidate-Path Name | UTF-8 |
+| 130 | Policy Name | UTF-8 |
+
+**Segment List inner registry** (the codepoints ≠ the A–K letters — this
+will bite if assumed):
+
+| Code | Segment | RFC | Carries |
+|-----:|---------|-----|---------|
+| 1 | Type A | 9830 | SR-MPLS label (4 oct: 20-bit label/TC/S/TTL) |
+| 13 | Type B | 9830 | SRv6 SID (16) + opt Endpoint Behavior & SID Structure |
+| 3/4/5/6/7/8 | C/D/E/F/G/H | 9831 | IPv4/IPv6 node/interface addrs + opt SR-MPLS SID |
+| 14/15/16 | I/J/K | 9831 | IPv6 addrs + SR-Algo + opt SRv6 SID |
+| 9 | Weight | 9830 | Flags(1)+Resv(1)+Weight(4); 0 invalid, default 1 |
+| 2, 10, 11, 12 | **deprecated** | — | must be ignored if seen |
+
+**Segment flags** (Type C–K): V=bit0 (verification), A=bit1 (SR-Algo
+present), S=bit2 (SID present), B=bit3 (SRv6 behavior/structure present).
+**SRv6 Endpoint Behavior & SID Structure** (8 oct): Behavior(2)+Resv(2)+
+LB-len(1)+LN-len(1)+Fun-len(1)+Arg-len(1), four lengths sum ≤ 128.
+
+**Architecture (RFC 9256):**
+- Policy identity = `<headend, color, endpoint>`; color is non-zero u32;
+  endpoint may be null (`0.0.0.0` / `::`) for color-only policies.
+- Candidate-path identity = `<protocol-origin, originator, discriminator>`.
+  Protocol-Origin: PCEP=10, **BGP SR Policy=20**, Config=30.
+  Originator = `<ASN(4), node-address(128)>`. Discriminator = the NLRI
+  Distinguisher for BGP-sourced CPs.
+- **Active candidate-path selection** (§2.9), highest wins:
+  1. valid only → 2. highest Preference → 3. higher Protocol-Origin →
+  4. prefer existing/installed → 5. lower Originator → 6. higher
+  Discriminator.
+- Weighted ECMP across a policy's segment lists by `w / Σw`.
+
+**Distribution rules (RFC 9830 §4.2):**
+- An SR Policy update **MUST** carry NO_ADVERTISE, or ≥1 Route Target in
+  IPv4-address format, or both — else the NLRI is malformed and not given
+  to the SR Policy module.
+- If RTs are present, **≥1 RT must equal the receiver's BGP Identifier**
+  (router-id, RFC 6286) for the policy to be *usable* locally. Non-matching
+  RT updates are still valid (a route reflector forwards them) but not
+  consumed.
+
+## 3. Reference implementations
+
+**FRR — does NOT implement SAFI 73.** `lib/iana_afi.h` has no SR Policy
+SAFI; `grep SAFI_SRTE` across FRR returns nothing. FRR builds SR policies
+in **pathd** (local `segment-list` / `policy` config + PCEP as a PCC) and
+pushes them to zebra via `ZEBRA_SR_POLICY_SET`. bgpd's only SR-TE
+touchpoint is the ingress route-map `set sr-te color`, which steers
+locally-learned routes onto an already-present pathd policy. **Consequence:
+zebra-rs implementing SAFI-73 receive is net-new relative to FRR, and FRR
+cannot be used as a wire interop peer.** FRR's pathd CLI model
+(`segment-list NAME { index N mpls label L }`, `policy color C endpoint E
+{ binding-sid L; candidate-path preference P { explicit segment-list NAME |
+dynamic } }`) is, however, the de-facto config shape we mirror for the
+*originator* / local-policy phase.
+
+**Cisco IOS-XR** — full headend model: SR On-Demand Nexthop (ODN)
+auto-instantiates a policy to a BGP next-hop carrying a matching Color
+Extended Community; Automated Steering resolves a service route onto the
+policy whose `endpoint == route-nexthop` and `color == route-color`; with
+multiple colors the highest numeric color with a valid policy wins;
+Color-Only (CO) bits in the Color Extended Community flags control
+fallback (00 strict endpoint match, 01/10 progressively broader). This is
+our reference for the later steering phase and for wire validation.
+
+## 4. Architecture overview
+
+```
+        ┌──────────────────────────── crates/bgp-packet ────────────────────────────┐
+ wire → │ Safi::SrTePolicy(73) → MpReachAttr::SrPolicy{nexthop, Vec<SrPolicyNlri>}   │
+        │ TunnelEncap(attr 23, type 15) → srpolicy::SrPolicyTlvs (typed view)        │
+        └───────────────────────────────────────────────────────────────────────────┘
+                                   │ parsed UpdatePacket
+                                   ▼
+        ┌──────────────────────── zebra-rs/src/bgp ─────────────────────────────────┐
+        │ route_from_peer → route_srpolicy_update()                                  │
+        │   ├─ usability filter (NO_ADVERTISE | RT==router-id, RFC 9830 §4.2)        │
+        │   ├─ Adj-RIB-In (srpolicy table, keyed by NLRI)                            │
+        │   └─ SrPolicyDb: key <color,endpoint> → CandidatePaths                     │
+        │        └─ active-CP selection (RFC 9256 §2.9)                              │
+        │ show bgp ipv4|srv6 sr-policy  ← reads SrPolicyDb                           │
+        └───────────────────────────────────────────────────────────────────────────┘
+                                   │ active CP (segment lists, BSID)   ← PHASE 4+
+                                   ▼
+        ┌──────────────── zebra-rs/src/rib + fib (deferred) ────────────────────────┐
+        │ BSID local SID (SRv6 End.B6.Encaps via seg6local) + seg6 encap nexthop     │
+        │ color-extcomm steering resolver onto SrPolicyDb (reconcile w/ color_policy)│
+        └───────────────────────────────────────────────────────────────────────────┘
+```
+
+Module ownership:
+
+- **`crates/bgp-packet`** — `Safi::SrTePolicy`; `nlri_srpolicy.rs` NLRI
+  codec; `srpolicy.rs` typed view over the Tunnel-Type-15 sub-TLVs;
+  `MpReachAttr::SrPolicy` variant. (Generic `TunnelEncap` stays as the
+  forward-compatible/pass-through carrier; the typed layer is built on
+  top, exactly as its doc-comment anticipates.)
+- **`zebra-rs/src/bgp`** — new `sr_policy.rs` (DB + selection + config);
+  `adj_rib.rs` gains an srpolicy table; `route.rs` gains the receive
+  handler; `show.rs` gains the show commands; `cap.rs`/config gain AF
+  activation.
+- **`zebra-rs/src/rib` + `fib`** — Phase 4+ only.
+
+## 5. Packet codec design (`crates/bgp-packet`)
+
+### 5.1 SAFI
+
+`afi.rs`: add `SrTePolicy = 73` to `Safi`, plus the two `From` arms
+(`SrTePolicy => 73`, `73 => SrTePolicy`) and the round-trip test list.
+Display string `"SR Policy"`.
+
+### 5.2 NLRI codec — `attrs/nlri_srpolicy.rs`
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct SrPolicyNlri {
+    pub distinguisher: u32,
+    pub color: u32,
+    pub endpoint: IpAddr,   // v4 or v6 per MP header AFI
+}
+```
+
+`ParseNlri<SrPolicyNlri>` (matching the established trait pattern used by
+`nlri_vpnv4.rs` etc.):
+
+- read length byte; validate `== 96` (AFI 1) or `== 192` (AFI 2),
+  reject otherwise;
+- `distinguisher = be_u32`, `color = be_u32`;
+- endpoint = 4 or 16 octets driven by the AFI passed down from the
+  `MpReachHeader` (same way `MupRoute::parse` takes `afi`);
+- emit mirrors parse, length byte derived from the endpoint family.
+
+`MpReachAttr` gains `SrPolicy { nexthop: IpAddr, updates: Vec<SrPolicyNlri> }`
+and the matching `MpUnreachAttr` arm; dispatch added in
+`mp_reach.rs` / `mp_unreach.rs` for `(Ip|Ip6, SrTePolicy)`.
+
+### 5.3 Typed Tunnel sub-TLVs — `attrs/srpolicy.rs`
+
+A typed view that decodes/encodes the sub-TLVs of a Tunnel-Type-15 TLV.
+The generic `TunnelEncap` keeps storing opaque `TunnelSubTlv`s (so unknown
+sub-TLVs round-trip for reflectors); the typed layer converts to/from it.
+
+```rust
+pub struct SrPolicyTlvs {
+    pub preference: Option<u32>,
+    pub binding_sid: Option<BindingSid>,
+    pub srv6_binding_sid: Option<Srv6BindingSid>,
+    pub enlp: Option<Enlp>,
+    pub priority: Option<u8>,
+    pub segment_lists: Vec<SegmentList>,
+    pub policy_name: Option<String>,
+    pub cp_name: Option<String>,
+}
+
+pub enum BindingSid { None, MplsLabel(u32), }          // sub-TLV 13
+pub struct Srv6BindingSid {                            // sub-TLV 20
+    pub sid: Ipv6Addr,
+    pub behavior: Option<Srv6BehaviorStructure>,
+    pub flags: u8,                                     // S,I,B
+}
+pub struct SegmentList {                               // sub-TLV 128
+    pub weight: Option<u32>,                           // inner code 9
+    pub segments: Vec<Segment>,
+}
+pub enum Segment {
+    TypeA { flags: u8, label: u32 },                   // inner code 1  (SR-MPLS)
+    TypeB { flags: u8, sid: Ipv6Addr,                  // inner code 13 (SRv6)
+            behavior: Option<Srv6BehaviorStructure> },
+    Unknown { code: u8, value: Vec<u8> },              // C–K + deprecated, preserved
+}
+```
+
+**v1 implements Type A (1) and Type B (13)**; all other segment codes
+decode into `Segment::Unknown` (bytes preserved), and the deprecated codes
+2/10/11/12 are accepted-and-ignored. SRv6-first means Type B is the
+priority; Type A is cheap to add alongside. C–K are a follow-up.
+
+Validation in the codec: a Segment List mixing SR-MPLS and SRv6 is
+rejected; SRv6 behavior/structure without a SID is rejected; reserved
+fields ignored on read, zeroed on write. Round-trip tests per sub-TLV,
+following the existing `tunnel_encap.rs` test style.
+
+### 5.4 Color Extended Community accessor (for the later steering phase)
+
+`ext_com.rs` already parses extended communities. Add a typed
+accessor for type `0x030b` returning `{ color: u32, co: u8 }` (CO bits =
+top two bits of the flags octets). Not consumed until the steering phase,
+but landing it with the codec keeps the wire layer complete.
+
+## 6. Control-plane design (`zebra-rs/src/bgp/sr_policy.rs`)
+
+### 6.1 Data model
+
+```rust
+pub struct SrPolicyKey { pub color: u32, pub endpoint: IpAddr }
+
+pub struct CandidatePathKey {                 // RFC 9256 §2.2
+    pub protocol_origin: u8,                   // 20 for BGP
+    pub originator: (u32, IpAddr),             // <ASN, node-address>
+    pub discriminator: u32,                    // = NLRI distinguisher
+}
+
+pub struct CandidatePath {
+    pub key: CandidatePathKey,
+    pub preference: u32,                        // default 100
+    pub priority: u8,                           // default 128
+    pub binding_sid: Option<BindingSid>,
+    pub srv6_binding_sid: Option<Srv6BindingSid>,
+    pub enlp: Option<Enlp>,
+    pub segment_lists: Vec<SegmentList>,
+    pub name: Option<String>,
+    pub valid: bool,                            // validation result
+    pub attr: Arc<BgpAttr>,                     // for re-advertise / origin info
+}
+
+pub struct SrPolicy {
+    pub key: SrPolicyKey,
+    pub candidates: BTreeMap<CandidatePathKey, CandidatePath>,
+    pub active: Option<CandidatePathKey>,       // selection result
+}
+
+pub struct SrPolicyDb {
+    pub policies: BTreeMap<SrPolicyKey, SrPolicy>,
+}
+```
+
+`SrPolicyDb` lives on `Bgp` next to `local_rib` / `color_policy`.
+
+### 6.2 Receive path
+
+`route.rs::route_from_peer` gains an arm for `MpReachAttr::SrPolicy` →
+`route_srpolicy_update()`:
+
+1. **Usability filter (RFC 9830 §4.2):** require NO_ADVERTISE community or
+   ≥1 RT (IPv4-address format) in the attribute; if RTs present, mark
+   *usable* only when one equals `bgp.router_id`. Non-usable-but-valid
+   routes are still stored in Adj-RIB-In for reflection but excluded from
+   the `SrPolicyDb`.
+2. **Adj-RIB-In:** add `srpolicy` table to `adj_rib.rs`, keyed by
+   `SrPolicyNlri` (distinguisher, color, endpoint). Stores raw attr for
+   soft-reconfig / reflection.
+3. **Decode** the Tunnel-Type-15 TLV via `SrPolicyTlvs`, build a
+   `CandidatePath` (one NLRI = one CP; distinguisher = discriminator;
+   originator from ORIGINATOR_ID or the peer; protocol-origin = 20).
+4. **Validate** the CP (minimal in v1: at least one non-empty segment
+   list, no mixed SR-MPLS/SRv6, BSID well-formed). Mark `valid`.
+5. **Insert/update/withdraw** in `SrPolicyDb[<color,endpoint>]`,
+   re-run selection.
+
+### 6.3 Active candidate-path selection
+
+Pure function over `SrPolicy.candidates`, RFC 9256 §2.9 order: valid only
+→ max preference → max protocol-origin → incumbent (the previous `active`)
+→ min originator → max discriminator. Sets `SrPolicy.active`. Unit-tested
+against the RFC tie-break ladder.
+
+### 6.4 Capability + AF activation
+
+`Safi::SrTePolicy` flows through the existing `CapMultiProtocol` /
+`AfiSafis` machinery unchanged once the enum value and the
+`Args::afi_safi()` parser mapping exist. Per-neighbor activation reuses
+`config_afi_safi` (`/router/bgp/neighbor/afi-safi/enabled`).
+
+## 7. YANG schema proposal
+
+### 7.1 AF activation — extend `zebra-afi-safi.yang`
+
+Add two enum values to the config-facing `afi-safi` grouping so a neighbor
+can activate the family and so the capability is negotiated:
+
+```yang
+grouping afi-safi {
+  leaf name {
+    type enumeration {
+      enum ipv4; enum ipv6; enum vpnv4; enum vpnv6; enum evpn;
+      enum sr-policy-v4;   // AFI 1 / SAFI 73
+      enum sr-policy-v6;   // AFI 2 / SAFI 73
+    }
+  }
+}
+```
+
+`Args::afi_safi()` maps `sr-policy-v4 → AfiSafi(Ip, SrTePolicy)` and
+`sr-policy-v6 → AfiSafi(Ip6, SrTePolicy)`. Config to peer with a
+controller / RR:
+
+```
+router bgp 65000 {
+  neighbor 10.0.0.1 {
+    remote-as 65000;
+    afi-safi sr-policy-v4 { enabled; }
+    afi-safi sr-policy-v6 { enabled; }
+  }
+}
+```
+
+### 7.2 New module `zebra-bgp-sr-policy.yang`
+
+Follows the `zebra-bgp-color-policy.yang` pattern: a grouping augmented
+into both `/configure:set/.../bgp` and `/configure:delete/.../bgp`. For
+the consumer-first scope the config surface is intentionally small; the
+local-policy / originator config (the FRR-pathd-shaped `segment-list` +
+`policy` tree) is a documented future grouping.
+
+```yang
+grouping bgp-sr-policy-extension {
+  container sr-policy {
+    ext:help "BGP SR Policy (SAFI 73) consumer settings";
+    presence "Enable BGP SR Policy processing";
+
+    leaf headend {
+      ext:help "Headend address used as the policy headend / RT match
+                (defaults to the BGP router-id)";
+      type inet:ip-address;
+    }
+
+    container binding-sid {
+      ext:help "How a received policy's Binding SID is realized locally";
+      leaf allocation {
+        type enumeration { enum explicit; enum dynamic; }
+        default explicit;   // honour the advertised BSID; dynamic = carve locally
+      }
+    }
+
+    // FUTURE (originator / local policies, deferred): mirrors FRR pathd —
+    //   list segment-list { key name; list segment { key index;
+    //       choice type { case mpls { leaf label; }
+    //                     case srv6 { leaf sid; } } } }
+    //   list policy { key "color endpoint"; leaf binding-sid;
+    //       list candidate-path { key preference;
+    //           choice { case explicit { leaf-list segment-list; }
+    //                    case dynamic  { ... } } } }
+  }
+}
+
+augment "/configure:set/config:router/bgp:bgp"    { uses bgp-sr-policy-extension; }
+augment "/configure:delete/config:router/bgp:bgp" { uses bgp-sr-policy-extension; }
+```
+
+Rust side mirrors `color_policy.rs`: a `config_sr_policy_*` callback set
+registered in `config.rs`, staging onto `Bgp::sr_policy_config`. Remember
+`cargo`/`clippy` do not validate YANG — the `yang_load_tests` CI guard
+does, so the module must load cleanly there.
+
+## 8. Show / operational model
+
+zebra-rs `show` is hand-rolled Rust→(text|JSON), not an NMDA datastore, so
+the operational model is Rust structs serialized with serde, registered in
+`show.rs` (e.g. `show_add("/show/ip/bgp/sr-policy", ...)`). Commands:
+
+- `show bgp ipv4 sr-policy` / `show bgp ipv6 sr-policy` — one block per
+  `<color, endpoint>`: each candidate path with preference, origin,
+  discriminator, validity, the `*` active marker, BSID, and segment lists
+  (label stack or SRv6 SID list) with weights.
+- `show bgp ipv4 sr-policy detail` — adds attribute provenance (peer,
+  originator, RT/NO_ADVERTISE usability verdict).
+- `show bgp ipv4 sr-policy adj-rib-in` — raw received NLRI incl.
+  not-usable entries.
+
+Text shape (sketch):
+
+```
+SR Policy color 100 endpoint 10.0.0.9 (IPv4)
+  Candidate-path pref 200 origin BGP(20) disc 1  [active] valid
+    binding-sid: SRv6 fc00:0:9::100 (End.B6.Encaps)
+    segment-list weight 1:
+      fc00:0:2:: (Type B)
+      fc00:0:9:: (Type B)
+  Candidate-path pref 100 origin BGP(20) disc 2  valid
+    ...
+```
+
+## 9. Dataplane realization (deferred — design sketch)
+
+SRv6 first, reusing the existing SID/locator + seg6 lwtunnel machinery:
+
+- **Binding SID** for an SRv6 policy = a local SID with **End.B6.Encaps**
+  behavior (IANA SRv6 Endpoint Behavior — *confirm exact codepoint before
+  coding*). Allocate from the configured locator (when `allocation
+  dynamic`) or honour the advertised SRv6 BSID (`explicit`). Install via
+  the existing `route_sid_install` / `build_seg6local_lwtunnel` path, with
+  the encap = the active path's segment list.
+- **Segment list → forwarding**: H.Encap (default per repo's SRv6 encap
+  policy) or H.Encap.Red; `NexthopUni.segs` + `encap_type`, resolved to a
+  first-hop via NHT against the first segment / endpoint.
+- **Weighted ECMP** across segment lists → `NexthopMulti` with per-member
+  weights.
+- SR-MPLS variant (later): BSID = an ILM (incoming label) that pushes the
+  label stack; `NexthopUni.mpls_label` + `label_manager` for dynamic BSID.
+
+The active path feeds the dataplane only when the policy is *valid* and
+its first segment resolves (NHT) — same gate philosophy as the NHT series.
+
+## 10. Automated steering (deferred — design sketch)
+
+Steers color-tagged service routes (IPv4/IPv6/VPNv4/VPNv6) onto a policy:
+
+- On a received unicast/VPN route carrying a Color Extended Community,
+  resolve onto `SrPolicyDb[<color, nexthop>]`; apply CO-bit fallback
+  (00 strict, 01/10 broaden to null-endpoint / any-AF). Highest numeric
+  matching color wins.
+- The resolved policy's BSID/segment list becomes the route's forwarding
+  nexthop (hooks into `VpnNexthop` resolution + NHT, where v6/VPN nexthop
+  resolution already lives).
+- **Reconcile with the existing `color_policy` (color → flex-algo) map:**
+  both are color-keyed steering. Proposed precedence — an explicit SR
+  Policy match wins over a flex-algo binding; flex-algo is the fallback
+  when no policy exists for the color. Likely unify both under a single
+  `steering`/`color-policy` config umbrella at that time.
+
+## 11. Phasing / PR plan
+
+Small PRs, branch already `bgp-sr-policy`. `cargo fmt` + workspace clippy
+before each; CI is source of truth (don't run bdd locally).
+
+**Control-plane (this body of work):**
+
+- **PR1 — SAFI + NLRI codec.** `Safi::SrTePolicy=73`, `nlri_srpolicy.rs`,
+  `MpReachAttr/MpUnreachAttr::SrPolicy`, capability negotiation,
+  `Args::afi_safi` + `zebra-afi-safi.yang` enums. Decode-only into
+  Adj-RIB-In, no DB. Round-trip + negotiation tests.
+- **PR2 — typed sub-TLVs.** `srpolicy.rs` typed view (Preference, BSID,
+  SRv6 BSID, ENLP, Priority, Segment List with Type A + Type B, names) +
+  Color Extended Community accessor. Per-sub-TLV round-trip tests.
+- **PR3 — SR Policy DB + selection + show.** `sr_policy.rs`, usability
+  filter, validation, RFC 9256 §2.9 selection, `show bgp … sr-policy`,
+  minimal `sr-policy` config container. Selection unit tests.
+
+**Later (separate bodies of work, re-confirm direction first):**
+
+- **PR4 — SRv6 dataplane** (BSID End.B6.Encaps + seg6 encap, weighted ECMP).
+- **PR5 — SR-MPLS dataplane** (BSID ILM + label-stack push).
+- **PR6 — automated steering** (color extcomm resolver, CO bits,
+  color_policy reconciliation).
+- **PR7 — originator** (config-defined local policies advertised as SAFI
+  73, NO_ADVERTISE / RT=peer-router-id attachment) + RR pass-through.
+
+## 12. Validation strategy
+
+- **Unit / round-trip tests** in `bgp-packet` for the NLRI and every
+  sub-TLV (the codec is the highest-risk surface and FRR can't peer with
+  it).
+- **Selection tests** exercising each RFC 9256 §2.9 tie-break rung.
+- **Wire interop:** FRR is *not* usable (no SAFI 73). Validate against a
+  **Cisco IOS-XR** speaker or **a captured SAFI-73 UPDATE pcap** replayed
+  into the parser. Capture our own emitted bytes once the originator
+  lands and diff against the reference.
+- **BDD** for the receive→DB→show pipeline in CI (not run locally).
+
+## 13. Risks and open questions
+
+- **No FRR interop peer** — the single biggest risk. Mitigate with pcap
+  fixtures + IOS-XR. Get at least one real SAFI-73 capture early.
+- **Segment-List inner registry codepoints ≠ A–K letters** and several are
+  deprecated — table-drive the decode, test the deprecated codes.
+- **Endpoint/segment AFI independence** — the policy AFI (NLRI) and the
+  segment dataplane (MPLS vs SRv6) vary independently; keep them decoupled
+  in the type system (don't infer SRv6 from AFI 2).
+- **End.B6.Encaps codepoint** — confirm the exact IANA SRv6 Endpoint
+  Behavior value before the dataplane phase.
+- **Steering vs flex-algo precedence** — decide when PR6 is designed; both
+  are color-keyed and must not double-resolve.
+- **Originator scope** — confirm whether a real controller/PCE is in the
+  test topology, or whether the originator phase is purely for self-interop.
+```

--- a/zebra-rs/src/bgp/cap.rs
+++ b/zebra-rs/src/bgp/cap.rs
@@ -37,6 +37,8 @@ impl CapAfiMap {
         let mpevpn = CapMultiProtocol::new(&Afi::L2vpn, &Safi::Evpn);
         let mp4fs = CapMultiProtocol::new(&Afi::Ip, &Safi::Flowspec);
         let mp6fs = CapMultiProtocol::new(&Afi::Ip6, &Safi::Flowspec);
+        let mp4srp = CapMultiProtocol::new(&Afi::Ip, &Safi::SrTePolicy);
+        let mp6srp = CapMultiProtocol::new(&Afi::Ip6, &Safi::SrTePolicy);
 
         let mut cmap = Self::default();
         cmap.entries.insert(mp4uni, SendRecv::default());
@@ -48,6 +50,8 @@ impl CapAfiMap {
         cmap.entries.insert(mpevpn, SendRecv::default());
         cmap.entries.insert(mp4fs, SendRecv::default());
         cmap.entries.insert(mp6fs, SendRecv::default());
+        cmap.entries.insert(mp4srp, SendRecv::default());
+        cmap.entries.insert(mp6srp, SendRecv::default());
         cmap
     }
 

--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -136,6 +136,8 @@ impl Args {
             "rtcv6" => Some(AfiSafi::new(Afi::Ip6, Safi::Rtc)),
             "flowspec-ipv4" => Some(AfiSafi::new(Afi::Ip, Safi::Flowspec)),
             "flowspec-ipv6" => Some(AfiSafi::new(Afi::Ip6, Safi::Flowspec)),
+            "sr-policy-v4" => Some(AfiSafi::new(Afi::Ip, Safi::SrTePolicy)),
+            "sr-policy-v6" => Some(AfiSafi::new(Afi::Ip6, Safi::SrTePolicy)),
             _ => None,
         }
     }

--- a/zebra-rs/yang/zebra-afi-safi.yang
+++ b/zebra-rs/yang/zebra-afi-safi.yang
@@ -78,6 +78,12 @@ module zebra-afi-safi {
           description
             "IPv6 Flow Specification (AFI 2, SAFI 133, RFC 8956).";
         }
+        enum sr-policy-v4 {
+          description "BGP SR Policy with IPv4 endpoint (AFI 1, SAFI 73).";
+        }
+        enum sr-policy-v6 {
+          description "BGP SR Policy with IPv6 endpoint (AFI 2, SAFI 73).";
+        }
       }
       description
         "Address family / sub-address family this list entry configures.";


### PR DESCRIPTION
PR1 of the BGP SR Policy plan (docs/design/bgp-sr-policy-plan.md): the SAFI-73 receive/decode wire layer (IPv4 + IPv6 endpoints).

## Changes
- `afi`: `Safi::SrTePolicy = 73` (+ conversions, round-trip test)
- `nlri_srpolicy`: `SrPolicyNlri` codec (RFC 9830 §2.1) — distinguisher, color, AFI-driven IPv4/IPv6 endpoint, 96/192-bit NLRI-length validation
- `mp_reach` / `mp_unreach`: `SrPolicy` variants (+ EoR) with parse / emit / Display
- yang `zebra-afi-safi`: `sr-policy-v4` / `sr-policy-v6` enums
- config `Args::afi_safi`: map them to `AfiSafi(Ip/Ip6, SrTePolicy)`
- `cap`: SR-Policy entries in `CapAfiMap`

Capability negotiation is generic, so `afi-safi sr-policy-v4|v6` now negotiates SAFI 73. Received routes are parsed-and-ignored at the route layer for now; typed Tunnel-Encap sub-TLVs + the policy DB land in PR2/PR3.

## Test plan
- `cargo test -p bgp-packet` (231 pass, incl. SR Policy NLRI + MP_REACH/UNREACH round-trips)
- `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- `cargo fmt --all` (clean)
- `yang_load_tests` exec/configure modes load with the new enums

Generated with [Claude Code](https://claude.com/claude-code)
