### PR TITLE
bgp: per-neighbor Flowspec validation toggle (Phase 3c)

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -436,6 +436,20 @@ fn config_soft_reconfig_in(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
     Some(())
 }
 
+/// `set router bgp neighbor X flowspec validation true|false` — per
+/// RFC 9117, toggle whether flow specs received from this neighbor are
+/// validated against the unicast RIB before re-advertising. Defaults to
+/// enabled; `delete` (or no config) restores the default.
+fn config_flowspec_validation(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let flag = args.boolean()?;
+
+    let peer = bgp.peers.get_mut(&addr)?;
+
+    peer.config.flowspec_validation = if op.is_set() { flag } else { true };
+    Some(())
+}
+
 /// `set router bgp neighbor X bfd enable true|false` — flips the
 /// BFD attachment for this neighbor. Stores the bit on
 /// `peer.config.bfd.enable` and wires the same flip into a
@@ -1822,6 +1836,9 @@ impl Bgp {
         // Stored-mode soft-in: retain pre-policy Adj-RIB-In so `clear soft in`
         // can replay locally without sending a Route Refresh.
         self.callback_peer("/soft-reconfiguration/inbound", config_soft_reconfig_in);
+
+        // Per-neighbor Flowspec validation toggle (zebra-bgp-flowspec.yang).
+        self.callback_peer("/flowspec/validation", config_flowspec_validation);
     }
 }
 

--- a/zebra-rs/src/bgp/flowspec.rs
+++ b/zebra-rs/src/bgp/flowspec.rs
@@ -34,6 +34,9 @@ pub enum FlowspecValidation {
     ValidAsPathLocal,
     /// b.1 — originator matches the best-match unicast route.
     ValidOriginatorMatch,
+    /// Validation administratively disabled for this neighbor — the
+    /// flow spec is treated as feasible without RFC 9117 checks.
+    ValidDisabled,
     /// No destination-prefix component (RFC 8955 requires one).
     InvalidNoDestPrefix,
     /// No unicast route covers the destination prefix.
@@ -44,7 +47,10 @@ pub enum FlowspecValidation {
 
 impl FlowspecValidation {
     pub fn is_valid(&self) -> bool {
-        matches!(self, Self::ValidAsPathLocal | Self::ValidOriginatorMatch)
+        matches!(
+            self,
+            Self::ValidAsPathLocal | Self::ValidOriginatorMatch | Self::ValidDisabled
+        )
     }
 }
 
@@ -53,6 +59,7 @@ impl fmt::Display for FlowspecValidation {
         let s = match self {
             Self::ValidAsPathLocal => "valid (as-path local)",
             Self::ValidOriginatorMatch => "valid (originator match)",
+            Self::ValidDisabled => "valid (validation disabled)",
             Self::InvalidNoDestPrefix => "invalid (no destination prefix)",
             Self::InvalidNoUnicastRoute => "invalid (no unicast route)",
             Self::InvalidOriginatorMismatch => "invalid (originator mismatch)",
@@ -157,6 +164,21 @@ pub fn flowspec_validate(
     }
 }
 
+/// As [`flowspec_validate`], but honours the per-neighbor validation
+/// toggle (RFC 9117 §6, configurable). When `validation_enabled` is
+/// false the flow spec is accepted without checks (trusted neighbor).
+pub fn flowspec_validate_with_mode(
+    local_rib: &LocalRib,
+    nlri: &FlowspecNlri,
+    rib: &BgpRib,
+    validation_enabled: bool,
+) -> FlowspecValidation {
+    if !validation_enabled {
+        return FlowspecValidation::ValidDisabled;
+    }
+    flowspec_validate(local_rib, nlri, rib)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -170,6 +192,45 @@ mod tests {
                 nlri.parse().unwrap(),
             ))],
         )
+    }
+
+    fn ebgp_rib(attr: &BgpAttr) -> BgpRib {
+        use super::super::route::BgpRibType;
+        BgpRib::new(
+            1,
+            std::net::Ipv4Addr::UNSPECIFIED,
+            BgpRibType::EBGP,
+            0,
+            0,
+            attr,
+            None,
+            None,
+            false,
+        )
+    }
+
+    #[test]
+    fn validate_with_mode_disabled_accepts_anything() {
+        // Validation off ⇒ feasible without any RFC 9117 check (even a
+        // flow spec with no destination prefix).
+        let local_rib = LocalRib::default();
+        let nlri = FlowspecNlri::new(Afi::Ip, vec![]);
+        let rib = ebgp_rib(&BgpAttr::default());
+        let v = flowspec_validate_with_mode(&local_rib, &nlri, &rib, false);
+        assert_eq!(v, FlowspecValidation::ValidDisabled);
+        assert!(v.is_valid());
+    }
+
+    #[test]
+    fn validate_with_mode_enabled_runs_rfc9117() {
+        // Validation on, dest prefix present, empty AS_PATH ⇒ b.2 valid.
+        let local_rib = LocalRib::default();
+        let nlri = v4_dst("10.0.0.0/24");
+        let rib = ebgp_rib(&BgpAttr::default());
+        assert_eq!(
+            flowspec_validate_with_mode(&local_rib, &nlri, &rib, true),
+            FlowspecValidation::ValidAsPathLocal
+        );
     }
 
     #[test]

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -214,6 +214,11 @@ pub struct PeerConfig {
     // bounce when the peer doesn't support RFC 2918, at the cost of
     // keeping received UPDATEs in memory.
     pub soft_reconfig_in: bool,
+    /// Per-neighbor BGP Flow Specification validation toggle (RFC 9117).
+    /// `true` (default) validates received flow specs against the
+    /// unicast RIB before re-advertising them; `false` accepts every
+    /// flow spec from this neighbor as feasible (trusted controller).
+    pub flowspec_validation: bool,
     pub timer: timer::Config,
     pub sub: BTreeMap<AfiSafi, PeerSubConfig>,
     /// Reference to a `neighbor-group` (zebra-bgp-neighbor-group.yang)
@@ -245,6 +250,7 @@ impl Default for PeerConfig {
             addpath: AfiSafis::new(),
             route_refresh: Default::default(),
             soft_reconfig_in: Default::default(),
+            flowspec_validation: true,
             timer: Default::default(),
             sub: Default::default(),
             neighbor_group: None,

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -3712,13 +3712,24 @@ fn route_flowspec_propagate(
     bgp: &mut BgpTop,
     peers: &mut PeerMap,
 ) {
-    match selected.last() {
-        Some(best) if super::flowspec::flowspec_validate(bgp.local_rib, nlri, best).is_valid() => {
-            route_advertise_flowspec_to_peers(afi, nlri, best, bgp, peers);
-        }
-        _ => {
-            route_withdraw_flowspec_to_peers(afi, nlri, peers);
-        }
+    let Some(best) = selected.last() else {
+        route_withdraw_flowspec_to_peers(afi, nlri, peers);
+        return;
+    };
+    // RFC 9117 validity, honouring the source neighbor's per-neighbor
+    // validation toggle. Invalid (or otherwise-suppressed) flow specs
+    // are withdrawn from peers rather than advertised.
+    let validation_enabled = peers
+        .get_by_idx(best.ident)
+        .map(|p| p.config.flowspec_validation)
+        .unwrap_or(true);
+    let valid =
+        super::flowspec::flowspec_validate_with_mode(bgp.local_rib, nlri, best, validation_enabled)
+            .is_valid();
+    if valid {
+        route_advertise_flowspec_to_peers(afi, nlri, best, bgp, peers);
+    } else {
+        route_withdraw_flowspec_to_peers(afi, nlri, peers);
     }
 }
 

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2236,13 +2236,18 @@ fn show_bgp_flowspec(
     // applied in the dataplane.
     for (nlri, rib) in table.selected.iter() {
         // RFC 9117 validity, computed live against the current unicast
-        // Loc-RIB (it gates re-advertise/install in later slices; here
-        // it annotates the output). `*` marks a valid flow spec.
-        let validation = super::flowspec::flowspec_validate(&bgp.local_rib, nlri, rib);
+        // Loc-RIB and honouring the source neighbor's validation toggle.
+        // `*` marks a valid flow spec.
+        let source = bgp.peers.get_by_idx(rib.ident);
+        let validation_enabled = source.map(|p| p.config.flowspec_validation).unwrap_or(true);
+        let validation = super::flowspec::flowspec_validate_with_mode(
+            &bgp.local_rib,
+            nlri,
+            rib,
+            validation_enabled,
+        );
         let mark = if validation.is_valid() { "*" } else { " " };
-        let from = bgp
-            .peers
-            .get_by_idx(rib.ident)
+        let from = source
             .map(|p| p.address.to_string())
             .unwrap_or_else(|| rib.router_id.to_string());
         writeln!(buf, " {mark} match:  {nlri}")?;

--- a/zebra-rs/yang/zebra-bgp-flowspec.yang
+++ b/zebra-rs/yang/zebra-bgp-flowspec.yang
@@ -1,0 +1,103 @@
+module zebra-bgp-flowspec {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-flowspec";
+  prefix "zbfs";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "Per-neighbor BGP Flow Specification knobs (RFC 8955 / RFC 8956,
+     validation per RFC 9117).
+
+     Currently exposes the per-neighbor validation toggle:
+
+       router bgp {
+         neighbor 10.0.0.5 {
+           remote-as 65501;
+           flowspec {
+             validation false;   // trust this neighbor's flow specs
+           }
+         }
+       }
+
+     Local flow-spec rule origination (match criteria + traffic-filtering
+     action) is a planned extension to this module.";
+
+  revision 2026-05-30 {
+    description "Initial revision: per-neighbor validation toggle.";
+    reference
+      "RFC 9117: Revised Validation Procedure for BGP Flow
+       Specifications.";
+  }
+
+  grouping bgp-neighbor-flowspec-extension {
+    description
+      "Flow Specification knobs on a BGP neighbor.";
+
+    container flowspec {
+      description
+        "BGP Flow Specification knobs for this neighbor.";
+
+      leaf validation {
+        ext:help "Validate received flow specs against the unicast RIB (RFC 9117)";
+        type boolean;
+        default "true";
+        description
+          "When true (default), flow specs received from this neighbor
+           are validated per RFC 9117: a flow spec is feasible only if
+           it embeds a destination-prefix component and either
+           originated inside our AS (empty / confederation-only
+           AS_PATH) or its originator matches the best-match unicast
+           route for the destination prefix. Flow specs that fail
+           validation are kept in the RIB but never re-advertised (and,
+           once the dataplane lands, never installed).
+
+           When false, validation is skipped and every flow spec from
+           this neighbor is treated as feasible. Use only for a trusted
+           neighbor such as a central flow-spec controller.";
+      }
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Attach flowspec knobs to BGP neighbors in the candidate-set
+       subtree.";
+    uses bgp-neighbor-flowspec-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp neighbor X flowspec validation` is
+       path-valid.";
+    uses bgp-neighbor-flowspec-extension;
+  }
+}


### PR DESCRIPTION
Slice of Phase 3c — the per-neighbor RFC 9117 **validation toggle**.

```
router bgp {
  neighbor 10.0.0.5 {
    flowspec { validation false; }   # trust this neighbor's flow specs
  }
}
```

When `false`, flow specs received from the neighbor are accepted as feasible without validation (e.g. a trusted central controller); `true` (default) keeps the RFC 9117 checks that gate re-advertise.

## Changes
- **`zebra-bgp-flowspec.yang`** (new) — module augmenting the BGP neighbor subtree (set + delete) with `flowspec/validation` (boolean, default `true`), mirroring `zebra-bgp-soft-reconfiguration.yang`.
- **`peer`** — `PeerConfig.flowspec_validation` (default `true`).
- **`config`** — `config_flowspec_validation` handler + `/flowspec/validation` neighbor callback.
- **`flowspec`** — `FlowspecValidation::ValidDisabled` + `flowspec_validate_with_mode`, which short-circuits to `ValidDisabled` when the toggle is off.
- **`route` / `show`** — the propagate (advertise gate) and `show ip bgp flowspec` paths consult the source neighbor's toggle.

## Tests
2 new flowspec unit tests (disabled-accepts-anything, enabled-runs-RFC-9117); 226 bgp tests + `yang_load_tests` + `cargo fmt` + `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Still deferred (separate slice)
- **Event-driven re-validation** when the unicast RIB changes — needs a perf-safe trigger (a naive hook re-validates all flow specs on every unicast UPDATE). Validity is currently computed at receive/withdraw and show time.
- The RFC 8955 **rule-c** (no more-specific route from a different neighboring AS) refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)