### PR TITLE
bgp: order afi-safi families explicitly in CLI completion

### DIFF
--- a/zebra-rs/src/config/comps.rs
+++ b/zebra-rs/src/config/comps.rs
@@ -202,6 +202,10 @@ pub fn comps_add_all(
     s: &State,
     list_presence: bool,
 ) {
+    // Leaves/keys tagged `ext:no-sort` keep their YANG enum declaration
+    // order instead of being alphabetized below (e.g. the BGP afi-safi
+    // family list).
+    let mut no_sort = false;
     match ymatch {
         YangMatch::Dir | YangMatch::DirMatched => {
             for entry in entry.dir.borrow().iter() {
@@ -220,6 +224,7 @@ pub fn comps_add_all(
                 for subent in entry.dir.borrow().iter() {
                     if &subent.name == key {
                         comps_as_leaf(comps, subent);
+                        no_sort |= subent.extension.contains_key("ext:no-sort");
                         if let Some(dynamic) = subent.extension.get("ext:dynamic")
                             && let Some(candidates) = s.dynamic.get(dynamic)
                         {
@@ -242,6 +247,7 @@ pub fn comps_add_all(
         }
         _ => {
             comps_as_leaf(comps, entry);
+            no_sort |= entry.extension.contains_key("ext:no-sort");
             if let Some(dynamic) = entry.extension.get("ext:dynamic")
                 && let Some(candidates) = s.dynamic.get(dynamic)
             {
@@ -251,9 +257,69 @@ pub fn comps_add_all(
             }
         }
     }
-    comps.sort_by(|a, b| a.name.cmp(&b.name));
+    if !no_sort {
+        comps.sort_by(|a, b| a.name.cmp(&b.name));
+    }
 
     if ymatch_complete(ymatch, list_presence, s.delete) {
         comps_add_cr(comps);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libyang::EnumNode;
+
+    /// Build an `afi-safi`-style list entry: a list keyed on `name`
+    /// whose `name` leaf is an enumeration declared in a deliberately
+    /// non-alphabetical order. `tag_no_sort` controls whether the leaf
+    /// carries the `ext:no-sort` marker.
+    fn afi_safi_list(tag_no_sort: bool) -> Rc<Entry> {
+        let mut name_leaf = Entry::new_leaf("name".to_string());
+        let mut tn = TypeNode::new("enumeration".to_string(), YangType::Enumeration);
+        tn.enum_stmt = ["ipv4", "ipv6", "vpnv4", "vpnv6", "rtcv4", "rtcv6"]
+            .iter()
+            .map(|n| EnumNode::new((*n).to_string()))
+            .collect();
+        name_leaf.type_node = Some(tn);
+        if tag_no_sort {
+            name_leaf
+                .extension
+                .insert("ext:no-sort".to_string(), "true".to_string());
+        }
+
+        let list = Rc::new(Entry::new_list(
+            "afi-safi".to_string(),
+            vec!["name".to_string()],
+        ));
+        list.dir.borrow_mut().push(Rc::new(name_leaf));
+        list
+    }
+
+    fn key_completions(entry: &Rc<Entry>) -> Vec<String> {
+        let s = State::new();
+        let mut comps = Vec::new();
+        comps_add_all(&mut comps, YangMatch::Key, entry, &s, false);
+        comps.into_iter().map(|c| c.name).collect()
+    }
+
+    /// `ext:no-sort` keeps the enum key completions in their YANG
+    /// declaration order (the BGP afi-safi family ordering).
+    #[test]
+    fn enum_key_no_sort_preserves_declaration_order() {
+        assert_eq!(
+            key_completions(&afi_safi_list(true)),
+            vec!["ipv4", "ipv6", "vpnv4", "vpnv6", "rtcv4", "rtcv6"],
+        );
+    }
+
+    /// Without the marker the same enum is alphabetized, as before.
+    #[test]
+    fn enum_key_without_marker_is_alphabetized() {
+        assert_eq!(
+            key_completions(&afi_safi_list(false)),
+            vec!["ipv4", "ipv6", "rtcv4", "rtcv6", "vpnv4", "vpnv6"],
+        );
     }
 }

--- a/zebra-rs/yang/extension.yang
+++ b/zebra-rs/yang/extension.yang
@@ -14,6 +14,13 @@ module extension {
     argument "sort";
   }
 
+  extension no-sort {
+    description
+      "Keep CLI completion in YANG declaration order for this leaf
+       instead of alphabetizing it.";
+    argument "no-sort";
+  }
+
   extension presence {
     description "presence";
     argument "presence";

--- a/zebra-rs/yang/zebra-afi-safi.yang
+++ b/zebra-rs/yang/zebra-afi-safi.yang
@@ -19,10 +19,10 @@ module zebra-afi-safi {
      Two flavors are provided as groupings supplying the `name` key of
      an `afi-safi` list:
 
-       * `afi-safi`         — the full BGP set (ipv4, ipv6, label-v4,
-                              label-v6, vpnv4, vpnv6, evpn, rtcv4, rtcv6,
-                              flowspec-ipv4, flowspec-ipv6). Used by
-                              `router bgp` (global + per-neighbor
+       * `afi-safi`         — the full BGP set (ipv4, ipv6, vpnv4,
+                              vpnv6, rtcv4, rtcv6, evpn, label-v4,
+                              label-v6, flowspec-ipv4, flowspec-ipv6).
+                              Used by `router bgp` (global + per-neighbor
                               afi-safi).
        * `afi-safi-unicast` — the unicast subset (ipv4, ipv6). Used by
                               `router isis` and the per-VRF BGP afi-safi
@@ -37,12 +37,30 @@ module zebra-afi-safi {
       "The `name` key for a BGP `afi-safi` list — the full set of
        families zebra-rs's BGP supports.";
     leaf name {
+      ext:no-sort "true";
       type enumeration {
         enum ipv4 {
           description "IPv4 unicast (AFI 1, SAFI 1).";
         }
         enum ipv6 {
           description "IPv6 unicast (AFI 2, SAFI 1).";
+        }
+        enum vpnv4 {
+          description "MPLS-labeled VPN-IPv4 (AFI 1, SAFI 128).";
+        }
+        enum vpnv6 {
+          description "MPLS-labeled VPN-IPv6 (AFI 2, SAFI 128).";
+        }
+        enum rtcv4 {
+          description
+            "IPv4 Route Target Constraint (AFI 1, SAFI 132).";
+        }
+        enum rtcv6 {
+          description
+            "IPv6 Route Target Constraint (AFI 2, SAFI 132).";
+        }
+        enum evpn {
+          description "BGP EVPN (AFI 25, SAFI 70).";
         }
         enum label-v4 {
           description
@@ -52,23 +70,6 @@ module zebra-afi-safi {
           description
             "IPv6 Labeled Unicast (AFI 2, SAFI 4); RFC 3107 / RFC 8277,
              incl. 6PE (RFC 4798).";
-        }
-        enum vpnv4 {
-          description "MPLS-labeled VPN-IPv4 (AFI 1, SAFI 128).";
-        }
-        enum vpnv6 {
-          description "MPLS-labeled VPN-IPv6 (AFI 2, SAFI 128).";
-        }
-        enum evpn {
-          description "BGP EVPN (AFI 25, SAFI 70).";
-        }
-        enum rtcv4 {
-          description
-            "IPv4 Route Target Constraint (AFI 1, SAFI 132).";
-        }
-        enum rtcv6 {
-          description
-            "IPv6 Route Target Constraint (AFI 2, SAFI 132).";
         }
         enum flowspec-ipv4 {
           description
@@ -80,7 +81,9 @@ module zebra-afi-safi {
         }
       }
       description
-        "Address family / sub-address family this list entry configures.";
+        "Address family / sub-address family this list entry configures.
+         The `ext:no-sort` tag keeps CLI completion in this declared
+         order rather than alphabetizing it.";
     }
   }
 


### PR DESCRIPTION
## Summary

CLI tab-completion alphabetized every enum value via a blanket sort in `comps_add_all`, so the BGP `afi-safi` family list always rendered alphabetically regardless of YANG declaration order:

```
set router bgp neighbor 10.0.0.8 afi-safi ?
   evpn
   flowspec-ipv4
   flowspec-ipv6
   ipv4
   ...
```

This introduces an `ext:no-sort` leaf marker that suppresses the alphabetical sort for a single leaf, letting its enum key completions follow YANG declaration order instead. After this change:

```
set router bgp neighbor 10.0.0.8 afi-safi ?
   ipv4
   ipv6
   vpnv4
   vpnv6
   rtcv4
   rtcv6
   evpn
   label-v4
   label-v6
   flowspec-ipv4
   flowspec-ipv6
```

## How

- **`src/config/comps.rs`** — `comps_add_all` tracks a `no_sort` flag set when the completed leaf/key carries `ext:no-sort`, and skips the `comps.sort_by(...)` call in that case. Enum values are already pushed in declaration order, so they emerge as declared.
- **`yang/zebra-afi-safi.yang`** — tag the BGP `afi-safi` grouping's `name` leaf with `ext:no-sort "true";` and reorder its enum into the operator-facing order.
- **`yang/extension.yang`** — declare `extension no-sort` for consistency with the existing `sort`/`help`/`presence`/`dynamic` extensions.

No libyang change is required: `LeafStmt` already accepts unknown statements, and `leaf_entry` already funnels them into `entry.extension` — the same path `ext:help`/`ext:dynamic`/`ext:presence` use.

## Testing

- Two new unit tests in `comps.rs` lock in both behaviors (marker → declaration order; no marker → alphabetized).
- `yang_load_tests` confirms the edited schema parses with the new extension and ordering.
- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p zebra-rs --bins config::` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)