### PR TITLE
bgp: Labeled-Unicast MPLS dataplane (Phase 5a ingress + 5b transit swap)

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -106,6 +106,7 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
+            lu_labels: None,
         };
         route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers);
         bgp.peers.remove(&addr);
@@ -523,6 +524,10 @@ fn config_afi_safi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let enabled: bool = args.boolean()?;
 
     let ipv4_unicast = key.afi == Afi::Ip && key.safi == Safi::Unicast;
+    // Enabling a Labeled-Unicast family means we may re-advertise routes
+    // with next-hop-self and need per-prefix local labels; request a
+    // dynamic label block eagerly so one is granted before routes arrive.
+    let lu_enabled = key.safi == Safi::MplsLabel && op.is_set() && enabled;
 
     let peer = bgp.peers.get_mut(&addr)?;
 
@@ -538,6 +543,9 @@ fn config_afi_safi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
         } else {
             peer.config.mp.remove(&key);
         }
+    }
+    if lu_enabled {
+        bgp.request_label_block();
     }
     Some(())
 }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -437,6 +437,12 @@ pub struct Bgp {
     /// initial request and any on-demand extension so a burst of
     /// label-less VRFs asks the RIB label manager for only one block.
     vrf_label_request_pending: bool,
+    /// Per-prefix local labels assigned to received Labeled-Unicast
+    /// (SAFI 4) routes we re-advertise with next-hop-self. Drawn from the
+    /// same dynamic pool as `vrf_label_alloc`. The label is advertised in
+    /// the NLRI and swap-programmed via an ILM (`local → received`).
+    pub lu_label_v4: std::collections::BTreeMap<ipnet::Ipv4Net, u32>,
+    pub lu_label_v6: std::collections::BTreeMap<ipnet::Ipv6Net, u32>,
     /// Configured global SRv6 locator name (`router bgp global srv6
     /// locator <name>`). When set, BGP watches this locator on the
     /// RIB and (in a follow-up) carves per-VRF End.DT46 service SIDs
@@ -629,6 +635,8 @@ impl Bgp {
             rib_subscriber,
             vrf_label_alloc: None,
             vrf_label_request_pending: false,
+            lu_label_v4: BTreeMap::new(),
+            lu_label_v6: BTreeMap::new(),
             srv6_locator_name: None,
             srv6_locator_rx,
             srv6_locator: None,
@@ -1002,6 +1010,11 @@ impl Bgp {
                     nexthop_cache: Some(&mut self.nexthop_cache),
                     vrf_transport_v4: None,
                     vrf_transport_v6: None,
+                    lu_labels: Some(super::peer::LuLabels {
+                        alloc: &mut self.vrf_label_alloc,
+                        v4: &mut self.lu_label_v4,
+                        v6: &mut self.lu_label_v6,
+                    }),
                 };
 
                 fsm(&mut bgp_ref, &mut self.peers, ident, event);
@@ -1625,7 +1638,7 @@ impl Bgp {
     /// Send a `LabelBlockRequest` to the RIB label manager unless one is
     /// already outstanding. Dedup keeps a burst of label-less VRFs from
     /// each requesting a block.
-    fn request_label_block(&mut self) {
+    pub(super) fn request_label_block(&mut self) {
         if self.vrf_label_request_pending {
             return;
         }
@@ -1879,6 +1892,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
+            lu_labels: None,
         };
         match &dep {
             NhtDep::V4(p) => {
@@ -2407,6 +2421,7 @@ impl Bgp {
                     best_path: false,
                     best_reason: super::route::Reason::Default,
                     label: label_obj,
+                    local_label: None,
                     nexthop: Some(super::route::VpnNexthop::V4(nexthop)),
                     nexthop_reachable: true,
                     egress_ifindex_v6: None,
@@ -2467,6 +2482,7 @@ impl Bgp {
                     nexthop_cache: None,
                     vrf_transport_v4: None,
                     vrf_transport_v6: None,
+                    lu_labels: None,
                 };
                 super::route::route_advertise_to_peers(
                     Some(rd),
@@ -2570,6 +2586,7 @@ impl Bgp {
                     nexthop_cache: None,
                     vrf_transport_v4: None,
                     vrf_transport_v6: None,
+                    lu_labels: None,
                 };
                 super::route::route_advertise_to_peers(
                     Some(rd),
@@ -2664,6 +2681,7 @@ impl Bgp {
                     best_path: false,
                     best_reason: super::route::Reason::Default,
                     label: label_obj,
+                    local_label: None,
                     nexthop: Some(super::route::VpnNexthop::V6(nexthop)),
                     nexthop_reachable: true,
                     egress_ifindex_v6: None,
@@ -2712,6 +2730,7 @@ impl Bgp {
                     nexthop_cache: None,
                     vrf_transport_v4: None,
                     vrf_transport_v6: None,
+                    lu_labels: None,
                 };
                 super::route::route_advertise_to_peers_vpnv6(
                     rd,
@@ -2794,6 +2813,7 @@ impl Bgp {
                     nexthop_cache: None,
                     vrf_transport_v4: None,
                     vrf_transport_v6: None,
+                    lu_labels: None,
                 };
                 super::route::route_advertise_to_peers_vpnv6(
                     rd,

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1790,6 +1790,27 @@ impl Bgp {
                     }
                 }
             }
+            // Labeled-Unicast: the next-hop's transport rerouted but it's
+            // still reachable; re-install the FIB label-push entry with
+            // the fresh transport. No re-advertise (best-path unchanged).
+            NhtDep::V4lu(p) => {
+                let selected = self.local_rib.select_best_path_v4lu(p);
+                super::route::fib_install_labelv4(
+                    &self.ctx.rib,
+                    Some(&self.nexthop_cache),
+                    p,
+                    &selected,
+                );
+            }
+            NhtDep::V6lu(p) => {
+                let selected = self.local_rib.select_best_path_v6lu(p);
+                super::route::fib_install_labelv6(
+                    &self.ctx.rib,
+                    Some(&self.nexthop_cache),
+                    p,
+                    &selected,
+                );
+            }
             NhtDep::V4(_) | NhtDep::V6(_) => {}
         }
     }
@@ -1812,6 +1833,14 @@ impl Bgp {
             NhtDep::V6(p) => {
                 self.local_rib.v6.set_nexthop_reachable(*p, nh, reachable);
                 self.local_rib.v6.select_best_path(*p)
+            }
+            NhtDep::V4lu(p) => {
+                self.local_rib.v4lu.set_nexthop_reachable(*p, nh, reachable);
+                self.local_rib.v4lu.select_best_path(*p)
+            }
+            NhtDep::V6lu(p) => {
+                self.local_rib.v6lu.set_nexthop_reachable(*p, nh, reachable);
+                self.local_rib.v6lu.select_best_path(*p)
             }
             NhtDep::V4vpn(rd, p) => {
                 self.local_rib
@@ -1866,6 +1895,38 @@ impl Bgp {
             NhtDep::V6(p) => {
                 super::route::fib_install_v6(&top, *p, &selected);
                 super::route::route_advertise_to_peers_v6(*p, &selected, &mut top, &mut self.peers);
+            }
+            // Labeled-Unicast reachability flip: re-install the FIB
+            // label-push entry (or withdraw) and re-advertise. The cache
+            // is passed directly (not via `top`, whose `nexthop_cache` is
+            // `None`) — `top`'s borrows don't include it.
+            NhtDep::V4lu(p) => {
+                super::route::fib_install_labelv4(
+                    top.rib_client,
+                    Some(&self.nexthop_cache),
+                    *p,
+                    &selected,
+                );
+                super::route::route_advertise_to_peers_labelv4(
+                    *p,
+                    &selected,
+                    &mut top,
+                    &mut self.peers,
+                );
+            }
+            NhtDep::V6lu(p) => {
+                super::route::fib_install_labelv6(
+                    top.rib_client,
+                    Some(&self.nexthop_cache),
+                    *p,
+                    &selected,
+                );
+                super::route::route_advertise_to_peers_labelv6(
+                    *p,
+                    &selected,
+                    &mut top,
+                    &mut self.peers,
+                );
             }
             NhtDep::V4vpn(rd, p) => {
                 super::route::route_advertise_to_peers(

--- a/zebra-rs/src/bgp/nht.rs
+++ b/zebra-rs/src/bgp/nht.rs
@@ -26,6 +26,13 @@ use crate::rib::nht::{NexthopResolution, ResolvedNexthop};
 pub enum NhtDep {
     V4(Ipv4Net),
     V6(Ipv6Net),
+    /// IPv4 / IPv6 Labeled-Unicast (SAFI 4) route in `local_rib.v4lu` /
+    /// `v6lu`. The BGP next-hop is tracked so the FIB label-push entry
+    /// re-installs (and best-path re-gates) when the next-hop's
+    /// reachability or transport changes — like the VPN deps, but the
+    /// route stays in the global table rather than a VRF.
+    V4lu(Ipv4Net),
+    V6lu(Ipv6Net),
     V4vpn(RouteDistinguisher, Ipv4Net),
     V6vpn(RouteDistinguisher, Ipv6Net),
     /// EVPN Type-5 (IP Prefix) route in `local_rib.evpn`. Like the

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -695,6 +695,63 @@ pub struct BgpTop<'a> {
             prefix_trie::PrefixMap<ipnet::Ipv4Net, crate::rib::api::FlexAlgoNexthop>,
         >,
     >,
+    /// BGP Labeled-Unicast (SAFI 4) local-label allocation context.
+    /// `Some` only in the receive `BgpTop` (the site that ingests
+    /// received routes); `None` in every advertise / originate / NHT
+    /// BgpTop — self-originated FECs advertise implicit-null and need no
+    /// local label. A received route advertised with next-hop-self gets
+    /// a local label here, swap-programmed via an ILM.
+    pub lu_labels: Option<LuLabels<'a>>,
+}
+
+/// Per-prefix local-label state for BGP Labeled Unicast, borrowed into
+/// the receive [`BgpTop`]. Labels are drawn from the shared dynamic-label
+/// allocator (the same pool that serves per-VRF labels).
+pub struct LuLabels<'a> {
+    pub alloc: &'a mut Option<super::vrf::VrfLabelAllocator>,
+    pub v4: &'a mut std::collections::BTreeMap<ipnet::Ipv4Net, u32>,
+    pub v6: &'a mut std::collections::BTreeMap<ipnet::Ipv6Net, u32>,
+}
+
+impl LuLabels<'_> {
+    /// Local label for an IPv4 LU prefix, allocating one on first use.
+    /// `None` if the dynamic pool is empty (the caller advertises the
+    /// received label as a fallback until a block is granted).
+    pub fn label_v4(&mut self, prefix: ipnet::Ipv4Net) -> Option<u32> {
+        if let Some(l) = self.v4.get(&prefix) {
+            return Some(*l);
+        }
+        let label = self.alloc.as_mut().and_then(|a| a.alloc())?;
+        self.v4.insert(prefix, label);
+        Some(label)
+    }
+
+    pub fn label_v6(&mut self, prefix: ipnet::Ipv6Net) -> Option<u32> {
+        if let Some(l) = self.v6.get(&prefix) {
+            return Some(*l);
+        }
+        let label = self.alloc.as_mut().and_then(|a| a.alloc())?;
+        self.v6.insert(prefix, label);
+        Some(label)
+    }
+
+    /// Release the label for a withdrawn IPv4 LU prefix; returns it so
+    /// the caller can tear down the swap ILM.
+    pub fn free_v4(&mut self, prefix: ipnet::Ipv4Net) -> Option<u32> {
+        let label = self.v4.remove(&prefix)?;
+        if let Some(a) = self.alloc.as_mut() {
+            a.free(label);
+        }
+        Some(label)
+    }
+
+    pub fn free_v6(&mut self, prefix: ipnet::Ipv6Net) -> Option<u32> {
+        let label = self.v6.remove(&prefix)?;
+        if let Some(a) = self.alloc.as_mut() {
+            a.free(label);
+        }
+        Some(label)
+    }
 }
 
 pub fn fsm_next_state(peer: &mut Peer, event: Event) -> (State, FsmEffect) {
@@ -1664,6 +1721,7 @@ pub fn apply_soft_in_peer(bgp: &mut Bgp, peer_idx: usize) {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
+            lu_labels: None,
         };
         super::route::route_soft_in_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
     } else if supports_refresh {
@@ -1700,6 +1758,7 @@ pub fn apply_soft_out_peer(bgp: &mut Bgp, peer_idx: usize) {
         nexthop_cache: None,
         vrf_transport_v4: None,
         vrf_transport_v6: None,
+        lu_labels: None,
     };
     super::route::route_soft_out_peer(peer_idx, &mut bgp_ref, &mut bgp.peers);
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -360,6 +360,85 @@ pub(super) fn fib_install_v6(bgp: &super::peer::BgpTop, prefix: Ipv6Net, selecte
     }
 }
 
+/// Choose the FIB entry for a Labeled-Unicast (SAFI 4) best-path winner.
+/// A *received* labeled route forwards toward its BGP next-hop with the
+/// received label pushed (plus any transport label stack from recursively
+/// resolving that next-hop) — exactly [`build_vpn_fib_entry`], but the
+/// transport comes from the global NHT `cache` rather than a per-VRF map.
+/// Returns `None` (→ withdraw) when:
+///   - the winner is *self-originated* (`network` / redistribute): we are
+///     the egress FEC, so the underlying connected/static/IGP route owns
+///     forwarding and BGP installs nothing; or
+///   - the next-hop hasn't resolved yet (no transport).
+fn select_fib_entry_label(
+    cache: Option<&super::nht::NexthopCache>,
+    best: &BgpRib,
+) -> Option<rib::entry::RibEntry> {
+    if best.typ == BgpRibType::Originated {
+        return None;
+    }
+    let service_label = best.label.map(|l| l.label).unwrap_or(0);
+    let transport = match (cache, super::nht::bgp_nexthop_ip(&best.attr)) {
+        (Some(c), Some(nh)) => c.transport_for(nh),
+        _ => &[][..],
+    };
+    build_vpn_fib_entry(service_label, transport)
+}
+
+/// Install / reconcile the kernel FIB for an IPv4 Labeled-Unicast prefix
+/// (ingress LSR: push the label toward the BGP next-hop). Takes the RIB
+/// client + NHT cache directly (not a `BgpTop`) so it is callable both
+/// from the receive path and from the NHT re-eval in `inst.rs`.
+pub(super) fn fib_install_labelv4(
+    rib_client: &crate::rib::client::RibClient,
+    cache: Option<&super::nht::NexthopCache>,
+    prefix: Ipv4Net,
+    selected: &[BgpRib],
+) {
+    match selected
+        .first()
+        .and_then(|b| select_fib_entry_label(cache, b))
+    {
+        Some(rib_entry) => {
+            let _ = rib_client.send(rib::Message::Ipv4Add {
+                prefix,
+                rib: rib_entry,
+            });
+        }
+        None => {
+            let mut stub = rib::entry::RibEntry::new(rib::RibType::Bgp);
+            stub.valid = false;
+            let _ = rib_client.send(rib::Message::Ipv4Del { prefix, rib: stub });
+        }
+    }
+}
+
+/// IPv6 counterpart of [`fib_install_labelv4`] (incl. 6PE — the resolved
+/// transport carries the v4/v6 egress).
+pub(super) fn fib_install_labelv6(
+    rib_client: &crate::rib::client::RibClient,
+    cache: Option<&super::nht::NexthopCache>,
+    prefix: Ipv6Net,
+    selected: &[BgpRib],
+) {
+    match selected
+        .first()
+        .and_then(|b| select_fib_entry_label(cache, b))
+    {
+        Some(rib_entry) => {
+            let _ = rib_client.send(rib::Message::Ipv6Add {
+                prefix,
+                rib: rib_entry,
+            });
+        }
+        None => {
+            let mut stub = rib::entry::RibEntry::new(rib::RibType::Bgp);
+            stub.valid = false;
+            let _ = rib_client.send(rib::Message::Ipv6Del { prefix, rib: stub });
+        }
+    }
+}
+
 /// Walk the route's Color extcomms in order, look each up in
 /// `color_policy`, LPM the next-hop against the matching per-algo
 /// shadow, return the first hit's outer label.
@@ -1090,6 +1169,25 @@ impl LocalRib {
         cands
             .into_iter()
             .flatten()
+            .filter_map(|r| super::nht::bgp_nexthop_ip(&r.attr))
+            .collect()
+    }
+
+    /// Labeled-Unicast (SAFI 4) counterparts: the distinct BGP next-hops
+    /// among the `v4lu` / `v6lu` candidates for `prefix` (for NHT untrack
+    /// after a displaced path).
+    pub fn candidate_nexthops_v4lu(&self, prefix: Ipv4Net) -> std::collections::BTreeSet<IpAddr> {
+        self.v4lu
+            .candidates(prefix)
+            .iter()
+            .filter_map(|r| super::nht::bgp_nexthop_ip(&r.attr))
+            .collect()
+    }
+
+    pub fn candidate_nexthops_v6lu(&self, prefix: Ipv6Net) -> std::collections::BTreeSet<IpAddr> {
+        self.v6lu
+            .candidates(prefix)
+            .iter()
             .filter_map(|r| super::nht::bgp_nexthop_ip(&r.attr))
             .collect()
     }
@@ -2878,7 +2976,23 @@ pub fn route_labelv4_update(
     }
 
     rib.attr = bgp.attr_store.intern(attr);
-    let (_replaced, selected, _next_id) = bgp.local_rib.update_v4lu(lu.nlri.prefix, rib);
+    // Next-Hop Tracking: gate best-path on the BGP next-hop's
+    // reachability and resolve its transport for the FIB label-push.
+    let dep = super::nht::NhtDep::V4lu(lu.nlri.prefix);
+    nht_track_received(bgp, &mut rib, dep.clone());
+    let (replaced, selected, _next_id) = bgp.local_rib.update_v4lu(lu.nlri.prefix, rib);
+    if bgp.nexthop_cache.is_some() && !replaced.is_empty() {
+        let survivor_nhs = bgp.local_rib.candidate_nexthops_v4lu(lu.nlri.prefix);
+        nht_untrack_withdrawn(bgp, &replaced, &survivor_nhs, dep);
+    }
+    // Ingress LSR: install the received label toward the resolved
+    // next-hop (no-op/withdraw for self-originated or unresolved).
+    fib_install_labelv4(
+        bgp.rib_client,
+        bgp.nexthop_cache.as_deref(),
+        lu.nlri.prefix,
+        &selected,
+    );
     if !selected.is_empty() {
         route_advertise_to_peers_labelv4(lu.nlri.prefix, &selected, bgp, peers);
     }
@@ -2948,7 +3062,19 @@ pub fn route_labelv6_update(
     }
 
     rib.attr = bgp.attr_store.intern(attr);
-    let (_replaced, selected, _next_id) = bgp.local_rib.update_v6lu(lu.nlri.prefix, rib);
+    let dep = super::nht::NhtDep::V6lu(lu.nlri.prefix);
+    nht_track_received(bgp, &mut rib, dep.clone());
+    let (replaced, selected, _next_id) = bgp.local_rib.update_v6lu(lu.nlri.prefix, rib);
+    if bgp.nexthop_cache.is_some() && !replaced.is_empty() {
+        let survivor_nhs = bgp.local_rib.candidate_nexthops_v6lu(lu.nlri.prefix);
+        nht_untrack_withdrawn(bgp, &replaced, &survivor_nhs, dep);
+    }
+    fib_install_labelv6(
+        bgp.rib_client,
+        bgp.nexthop_cache.as_deref(),
+        lu.nlri.prefix,
+        &selected,
+    );
     if !selected.is_empty() {
         route_advertise_to_peers_labelv6(lu.nlri.prefix, &selected, bgp, peers);
     }
@@ -2969,8 +3095,23 @@ pub fn route_labelv4_withdraw(
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
         peer.adj_in.remove_v4lu(nlri.prefix, nlri.id);
     }
-    let _ = bgp.local_rib.remove_v4lu(nlri.prefix, nlri.id, ident);
+    let removed = bgp.local_rib.remove_v4lu(nlri.prefix, nlri.id, ident);
+    if bgp.nexthop_cache.is_some() {
+        let survivor_nhs = bgp.local_rib.candidate_nexthops_v4lu(nlri.prefix);
+        nht_untrack_withdrawn(
+            bgp,
+            &removed,
+            &survivor_nhs,
+            super::nht::NhtDep::V4lu(nlri.prefix),
+        );
+    }
     let selected = bgp.local_rib.select_best_path_v4lu(nlri.prefix);
+    fib_install_labelv4(
+        bgp.rib_client,
+        bgp.nexthop_cache.as_deref(),
+        nlri.prefix,
+        &selected,
+    );
     // Empty `selected` → MP_UNREACH to LU peers; a replacement winner →
     // re-advertise. Both handled by the advertise helper.
     route_advertise_to_peers_labelv4(nlri.prefix, &selected, bgp, peers);
@@ -2989,8 +3130,23 @@ pub fn route_labelv6_withdraw(
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
         peer.adj_in.remove_v6lu(nlri.prefix, nlri.id);
     }
-    let _ = bgp.local_rib.remove_v6lu(nlri.prefix, nlri.id, ident);
+    let removed = bgp.local_rib.remove_v6lu(nlri.prefix, nlri.id, ident);
+    if bgp.nexthop_cache.is_some() {
+        let survivor_nhs = bgp.local_rib.candidate_nexthops_v6lu(nlri.prefix);
+        nht_untrack_withdrawn(
+            bgp,
+            &removed,
+            &survivor_nhs,
+            super::nht::NhtDep::V6lu(nlri.prefix),
+        );
+    }
     let selected = bgp.local_rib.select_best_path_v6lu(nlri.prefix);
+    fib_install_labelv6(
+        bgp.rib_client,
+        bgp.nexthop_cache.as_deref(),
+        nlri.prefix,
+        &selected,
+    );
     route_advertise_to_peers_labelv6(nlri.prefix, &selected, bgp, peers);
 }
 
@@ -5943,6 +6099,14 @@ impl Bgp {
             vrf_transport_v6: None,
         };
 
+        // Reconcile the FIB: a self-originated winner withdraws any BGP
+        // label entry (we are the egress; the source route forwards).
+        fib_install_labelv4(
+            bgp_ref.rib_client,
+            Some(&self.nexthop_cache),
+            prefix,
+            &selected,
+        );
         if !selected.is_empty() {
             route_advertise_to_peers_labelv4(prefix, &selected, &mut bgp_ref, &mut self.peers);
         }
@@ -5970,6 +6134,14 @@ impl Bgp {
         };
 
         let selected = bgp_ref.local_rib.select_best_path_v4lu(prefix);
+        // Reconcile the FIB: removing a self-originated route may reveal
+        // a received label winner that now needs its label-push entry.
+        fib_install_labelv4(
+            bgp_ref.rib_client,
+            Some(&self.nexthop_cache),
+            prefix,
+            &selected,
+        );
         if !selected.is_empty() || !removed.is_empty() {
             route_advertise_to_peers_labelv4(prefix, &selected, &mut bgp_ref, &mut self.peers);
         }
@@ -6014,6 +6186,12 @@ impl Bgp {
             vrf_transport_v6: None,
         };
 
+        fib_install_labelv6(
+            bgp_ref.rib_client,
+            Some(&self.nexthop_cache),
+            prefix,
+            &selected,
+        );
         if !selected.is_empty() {
             route_advertise_to_peers_labelv6(prefix, &selected, &mut bgp_ref, &mut self.peers);
         }
@@ -6041,6 +6219,12 @@ impl Bgp {
         };
 
         let selected = bgp_ref.local_rib.select_best_path_v6lu(prefix);
+        fib_install_labelv6(
+            bgp_ref.rib_client,
+            Some(&self.nexthop_cache),
+            prefix,
+            &selected,
+        );
         if !selected.is_empty() || !removed.is_empty() {
             route_advertise_to_peers_labelv6(prefix, &selected, &mut bgp_ref, &mut self.peers);
         }
@@ -6223,6 +6407,14 @@ impl Bgp {
             vrf_transport_v6: None,
         };
 
+        // Reconcile the FIB: a self-originated winner withdraws any BGP
+        // label entry (we are the egress; the source route forwards).
+        fib_install_labelv4(
+            bgp_ref.rib_client,
+            Some(&self.nexthop_cache),
+            prefix,
+            &selected,
+        );
         if !selected.is_empty() {
             route_advertise_to_peers_labelv4(prefix, &selected, &mut bgp_ref, &mut self.peers);
         }
@@ -6251,6 +6443,14 @@ impl Bgp {
         };
 
         let selected = bgp_ref.local_rib.select_best_path_v4lu(prefix);
+        // Reconcile the FIB: removing a self-originated route may reveal
+        // a received label winner that now needs its label-push entry.
+        fib_install_labelv4(
+            bgp_ref.rib_client,
+            Some(&self.nexthop_cache),
+            prefix,
+            &selected,
+        );
         if !selected.is_empty() || !removed.is_empty() {
             route_advertise_to_peers_labelv4(prefix, &selected, &mut bgp_ref, &mut self.peers);
         }
@@ -6299,6 +6499,12 @@ impl Bgp {
             vrf_transport_v6: None,
         };
 
+        fib_install_labelv6(
+            bgp_ref.rib_client,
+            Some(&self.nexthop_cache),
+            prefix,
+            &selected,
+        );
         if !selected.is_empty() {
             route_advertise_to_peers_labelv6(prefix, &selected, &mut bgp_ref, &mut self.peers);
         }
@@ -6327,6 +6533,12 @@ impl Bgp {
         };
 
         let selected = bgp_ref.local_rib.select_best_path_v6lu(prefix);
+        fib_install_labelv6(
+            bgp_ref.rib_client,
+            Some(&self.nexthop_cache),
+            prefix,
+            &selected,
+        );
         if !selected.is_empty() || !removed.is_empty() {
             route_advertise_to_peers_labelv6(prefix, &selected, &mut bgp_ref, &mut self.peers);
         }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -385,6 +385,89 @@ fn select_fib_entry_label(
     build_vpn_fib_entry(service_label, transport)
 }
 
+/// Program the BGP-LU transit swap ILM for `best` (a SAFI-4 best-path
+/// winner). When `best` is a *received* route we allocated a local label
+/// for, install `local → swap to [transport…, received]` toward the
+/// resolved egress so traffic a peer sends us (with our advertised local
+/// label) is forwarded down the LSP. Self-originated winners (we are the
+/// egress) carry no local label. An unresolved next-hop removes the ILM.
+/// AFI-agnostic — the ILM is keyed by the local MPLS label, not the IP
+/// prefix.
+fn reconcile_swap_ilm(
+    rib_client: &crate::rib::client::RibClient,
+    cache: Option<&super::nht::NexthopCache>,
+    best: Option<&BgpRib>,
+) {
+    let Some(best) = best else { return };
+    let Some(local) = best.local_label else {
+        return;
+    };
+    if best.typ == BgpRibType::Originated {
+        return;
+    }
+    let transport = match (cache, super::nht::bgp_nexthop_ip(&best.attr)) {
+        (Some(c), Some(nh)) => c.transport_for(nh),
+        _ => &[][..],
+    };
+    if transport.is_empty() {
+        ilm_swap_remove(rib_client, local);
+        return;
+    }
+    let service_label = best.label.map(|l| l.label).unwrap_or(0);
+    ilm_swap_install(rib_client, local, service_label, transport);
+}
+
+/// Send `Message::IlmAdd` for a swap entry at `local_label`. The outgoing
+/// label stack `[transport labels…, service_label]` rides `mpls_label`
+/// (the ILM swap field, distinct from `mpls` used by IP-route installs);
+/// the egress address/ifindex mirror [`build_vpn_fib_entry`].
+fn ilm_swap_install(
+    rib_client: &crate::rib::client::RibClient,
+    local_label: u32,
+    service_label: u32,
+    transport: &[rib::nht::ResolvedNexthop],
+) {
+    let mk_uni = |egress: &rib::nht::ResolvedNexthop| {
+        let mut uni = rib::NexthopUni::new(egress.addr, 0, Vec::new());
+        let mut labels = egress.labels.clone();
+        if service_label != 0 {
+            labels.push(service_label);
+        }
+        uni.mpls_label = labels;
+        if egress.ifindex != 0 {
+            uni.ifindex_origin = Some(egress.ifindex);
+        }
+        uni.valid = true;
+        uni
+    };
+    let nexthop = if transport.len() == 1 {
+        rib::Nexthop::Uni(mk_uni(&transport[0]))
+    } else {
+        let mut multi = rib::NexthopMulti::default();
+        for egress in transport {
+            multi.nexthops.push(mk_uni(egress));
+        }
+        rib::Nexthop::Multi(multi)
+    };
+    let mut ilm = rib::inst::IlmEntry::new(rib::RibType::Bgp);
+    ilm.ilm_type = rib::inst::IlmType::Swap;
+    ilm.nexthop = nexthop;
+    let _ = rib_client.send(rib::Message::IlmAdd {
+        label: local_label,
+        ilm,
+    });
+}
+
+/// Tear down the swap ILM at `local_label` (route withdrawn / next-hop
+/// unresolved). The RIB ignores a Del for a label it never installed.
+fn ilm_swap_remove(rib_client: &crate::rib::client::RibClient, local_label: u32) {
+    let ilm = rib::inst::IlmEntry::new(rib::RibType::Bgp);
+    let _ = rib_client.send(rib::Message::IlmDel {
+        label: local_label,
+        ilm,
+    });
+}
+
 /// Install / reconcile the kernel FIB for an IPv4 Labeled-Unicast prefix
 /// (ingress LSR: push the label toward the BGP next-hop). Takes the RIB
 /// client + NHT cache directly (not a `BgpTop`) so it is callable both
@@ -411,6 +494,7 @@ pub(super) fn fib_install_labelv4(
             let _ = rib_client.send(rib::Message::Ipv4Del { prefix, rib: stub });
         }
     }
+    reconcile_swap_ilm(rib_client, cache, selected.first());
 }
 
 /// IPv6 counterpart of [`fib_install_labelv4`] (incl. 6PE — the resolved
@@ -437,6 +521,7 @@ pub(super) fn fib_install_labelv6(
             let _ = rib_client.send(rib::Message::Ipv6Del { prefix, rib: stub });
         }
     }
+    reconcile_swap_ilm(rib_client, cache, selected.first());
 }
 
 /// Walk the route's Color extcomms in order, look each up in
@@ -509,6 +594,12 @@ pub struct BgpRib {
     pub best_reason: Reason,
     // Label.
     pub label: Option<Label>,
+    /// BGP-LU local label we allocated for this prefix (SAFI 4 only).
+    /// When set and the route is re-advertised with next-hop-self, this
+    /// label is sent in the NLRI (instead of `label`, the received one)
+    /// and an ILM swaps it to `label` toward the resolved transport.
+    /// `None` for unicast/VPN/EVPN rows and for next-hop-unchanged.
+    pub local_label: Option<u32>,
     // VPN next-hop (v4vpn / v6vpn rows); `None` for unicast rows.
     pub nexthop: Option<VpnNexthop>,
     /// Next-Hop Tracking gate: `false` when this path's BGP next-hop is
@@ -588,6 +679,7 @@ impl BgpRib {
             best_path: false,
             best_reason: Reason::NotSelected,
             label,
+            local_label: None,
             nexthop,
             nexthop_reachable: true,
             egress_ifindex_v6: None,
@@ -2980,6 +3072,14 @@ pub fn route_labelv4_update(
     // reachability and resolve its transport for the FIB label-push.
     let dep = super::nht::NhtDep::V4lu(lu.nlri.prefix);
     nht_track_received(bgp, &mut rib, dep.clone());
+    // Allocate a per-prefix local label so re-advertising with
+    // next-hop-self forwards via a swap ILM (Phase 5b). `None` when no
+    // dynamic block is granted yet — advertise the received label until
+    // then.
+    rib.local_label = bgp
+        .lu_labels
+        .as_mut()
+        .and_then(|ll| ll.label_v4(lu.nlri.prefix));
     let (replaced, selected, _next_id) = bgp.local_rib.update_v4lu(lu.nlri.prefix, rib);
     if bgp.nexthop_cache.is_some() && !replaced.is_empty() {
         let survivor_nhs = bgp.local_rib.candidate_nexthops_v4lu(lu.nlri.prefix);
@@ -3064,6 +3164,10 @@ pub fn route_labelv6_update(
     rib.attr = bgp.attr_store.intern(attr);
     let dep = super::nht::NhtDep::V6lu(lu.nlri.prefix);
     nht_track_received(bgp, &mut rib, dep.clone());
+    rib.local_label = bgp
+        .lu_labels
+        .as_mut()
+        .and_then(|ll| ll.label_v6(lu.nlri.prefix));
     let (replaced, selected, _next_id) = bgp.local_rib.update_v6lu(lu.nlri.prefix, rib);
     if bgp.nexthop_cache.is_some() && !replaced.is_empty() {
         let survivor_nhs = bgp.local_rib.candidate_nexthops_v6lu(lu.nlri.prefix);
@@ -3106,6 +3210,17 @@ pub fn route_labelv4_withdraw(
         );
     }
     let selected = bgp.local_rib.select_best_path_v4lu(nlri.prefix);
+    // Prefix fully gone: release its local label and tear down the swap
+    // ILM. (A surviving winner keeps the same per-prefix label, whose ILM
+    // `fib_install_labelv4` reconciles below.)
+    if selected.is_empty()
+        && let Some(local) = bgp
+            .lu_labels
+            .as_mut()
+            .and_then(|ll| ll.free_v4(nlri.prefix))
+    {
+        ilm_swap_remove(bgp.rib_client, local);
+    }
     fib_install_labelv4(
         bgp.rib_client,
         bgp.nexthop_cache.as_deref(),
@@ -3141,6 +3256,14 @@ pub fn route_labelv6_withdraw(
         );
     }
     let selected = bgp.local_rib.select_best_path_v6lu(nlri.prefix);
+    if selected.is_empty()
+        && let Some(local) = bgp
+            .lu_labels
+            .as_mut()
+            .and_then(|ll| ll.free_v6(nlri.prefix))
+    {
+        ilm_swap_remove(bgp.rib_client, local);
+    }
     fib_install_labelv6(
         bgp.rib_client,
         bgp.nexthop_cache.as_deref(),
@@ -4804,7 +4927,16 @@ fn route_update_labelv4(
     }
 
     attrs.nexthop = None;
-    let label = rib.label.unwrap_or(Label::new(3, 0, true));
+    // Next-hop-self makes us the forwarding hop: advertise our per-prefix
+    // local label (swap-programmed via an ILM) so a peer's labeled
+    // traffic reaches us with a label we can swap to the received one.
+    // No local label (self-originated egress, or no dynamic block yet) →
+    // implicit-null / received-label fallback. Next-hop-unchanged passes
+    // the received label through untouched.
+    let label = match (needs_self, rib.local_label) {
+        (true, Some(l)) => Label::new(l, 0, true),
+        _ => rib.label.unwrap_or(Label::new(3, 0, true)),
+    };
     Some((nlri, attrs, nhop, label))
 }
 
@@ -4872,7 +5004,16 @@ fn route_update_labelv6(
     }
 
     attrs.nexthop = None;
-    let label = rib.label.unwrap_or(Label::new(3, 0, true));
+    // Next-hop-self makes us the forwarding hop: advertise our per-prefix
+    // local label (swap-programmed via an ILM) so a peer's labeled
+    // traffic reaches us with a label we can swap to the received one.
+    // No local label (self-originated egress, or no dynamic block yet) →
+    // implicit-null / received-label fallback. Next-hop-unchanged passes
+    // the received label through untouched.
+    let label = match (needs_self, rib.local_label) {
+        (true, Some(l)) => Label::new(l, 0, true),
+        _ => rib.label.unwrap_or(Label::new(3, 0, true)),
+    };
     Some((nlri, attrs, nhop, label))
 }
 
@@ -5997,6 +6138,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
+            lu_labels: None,
         };
 
         // An originated route lacks a v4 NEXT_HOP attribute, so when
@@ -6039,6 +6181,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
+            lu_labels: None,
         };
 
         let selected = bgp_ref.local_rib.select_best_path(prefix);
@@ -6097,6 +6240,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
+            lu_labels: None,
         };
 
         // Reconcile the FIB: a self-originated winner withdraws any BGP
@@ -6131,6 +6275,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
+            lu_labels: None,
         };
 
         let selected = bgp_ref.local_rib.select_best_path_v4lu(prefix);
@@ -6184,6 +6329,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
+            lu_labels: None,
         };
 
         fib_install_labelv6(
@@ -6216,6 +6362,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
+            lu_labels: None,
         };
 
         let selected = bgp_ref.local_rib.select_best_path_v6lu(prefix);
@@ -6301,6 +6448,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
+            lu_labels: None,
         };
 
         // Same logic as `route_add`: the redistributed BGP route has
@@ -6341,6 +6489,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
+            lu_labels: None,
         };
 
         let selected = bgp_ref.local_rib.select_best_path(prefix);
@@ -6405,6 +6554,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
+            lu_labels: None,
         };
 
         // Reconcile the FIB: a self-originated winner withdraws any BGP
@@ -6440,6 +6590,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
+            lu_labels: None,
         };
 
         let selected = bgp_ref.local_rib.select_best_path_v4lu(prefix);
@@ -6497,6 +6648,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
+            lu_labels: None,
         };
 
         fib_install_labelv6(
@@ -6530,6 +6682,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
+            lu_labels: None,
         };
 
         let selected = bgp_ref.local_rib.select_best_path_v6lu(prefix);
@@ -6664,6 +6817,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
+            lu_labels: None,
         };
 
         if !selected.is_empty() {
@@ -6780,6 +6934,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
+            lu_labels: None,
         };
 
         if !selected.is_empty() {
@@ -6883,6 +7038,7 @@ impl Bgp {
             nexthop_cache: None,
             vrf_transport_v4: None,
             vrf_transport_v6: None,
+            lu_labels: None,
         };
 
         if !selected.is_empty() {

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -434,6 +434,7 @@ impl BgpVrf {
                     nexthop_cache: None,
                     vrf_transport_v4: Some(&self.transport_v4),
                     vrf_transport_v6: Some(&self.transport_v6),
+                    lu_labels: None,
                 };
                 fsm(&mut top, &mut self.peers, ident, event);
             }
@@ -520,6 +521,7 @@ impl BgpVrf {
             best_path: false,
             best_reason: super::super::route::Reason::Default,
             label: label_obj,
+            local_label: None,
             // v4-unicast rows in LocRIB don't read the
             // Vpnv4-shaped `nexthop` slot; FIB install pulls
             // from `attr.nexthop` set above.
@@ -560,6 +562,7 @@ impl BgpVrf {
             nexthop_cache: None,
             vrf_transport_v4: Some(&self.transport_v4),
             vrf_transport_v6: Some(&self.transport_v6),
+            lu_labels: None,
         };
         super::super::route::route_advertise_to_peers(
             None,
@@ -619,6 +622,7 @@ impl BgpVrf {
             nexthop_cache: None,
             vrf_transport_v4: Some(&self.transport_v4),
             vrf_transport_v6: Some(&self.transport_v6),
+            lu_labels: None,
         };
         super::super::route::route_advertise_to_peers(
             None,
@@ -686,6 +690,7 @@ impl BgpVrf {
             best_path: false,
             best_reason: super::super::route::Reason::Default,
             label: label_obj,
+            local_label: None,
             nexthop: None,
             nexthop_reachable: true,
             egress_ifindex_v6: None,
@@ -718,6 +723,7 @@ impl BgpVrf {
             nexthop_cache: None,
             vrf_transport_v4: Some(&self.transport_v4),
             vrf_transport_v6: Some(&self.transport_v6),
+            lu_labels: None,
         };
         super::super::route::route_advertise_to_peers_v6(
             prefix,
@@ -767,6 +773,7 @@ impl BgpVrf {
             nexthop_cache: None,
             vrf_transport_v4: Some(&self.transport_v4),
             vrf_transport_v6: Some(&self.transport_v6),
+            lu_labels: None,
         };
         super::super::route::route_advertise_to_peers_v6(
             prefix,

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -373,6 +373,7 @@ fn materialize_self_originated_networks(vrf: &mut BgpVrf, cfg: &BgpVrfConfig) ->
             best_path: false,
             best_reason: super::super::route::Reason::Default,
             label: None,
+            local_label: None,
             nexthop: None,
             nexthop_reachable: true,
             egress_ifindex_v6: None,

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -1037,6 +1037,7 @@ fn fmt_ilm_type(t: &crate::rib::inst::IlmType) -> String {
         crate::rib::inst::IlmType::DecapVrf { table_id, .. } => {
             format!("Pop DecapVrf (table {})", table_id)
         }
+        crate::rib::inst::IlmType::Swap => "Swap LU".to_string(),
     }
 }
 

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -315,6 +315,13 @@ pub enum IlmType {
         table_id: u32,
         vrf_ifindex: u32,
     },
+    /// BGP Labeled-Unicast transit swap (RFC 3107 / RFC 8277): the
+    /// kernel swaps the incoming local label for the next-hop's outgoing
+    /// label stack (`nexthop.mpls_label`) and forwards toward the
+    /// resolved egress. The netlink action is the generic `NewDestination`
+    /// swap (same path as Node/Adjacency); this variant only labels the
+    /// owner for show output and ILM selection.
+    Swap,
 }
 
 /// All ILM candidates competing for a single incoming label. Mirrors

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1484,6 +1484,7 @@ fn write_ilm_entry(
             table_id,
             vrf_ifindex: _,
         } => format!("VPN Decap (tbl {:<3})", table_id),
+        super::inst::IlmType::Swap => "LU Swap".to_string(),
         super::inst::IlmType::None => {
             // Try to find a matching route for this nexthop
             if let Some((prefix, _)) = find_route_for_nexthop(rib, uni) {
@@ -1538,6 +1539,7 @@ fn ilm_to_json(
             table_id,
             vrf_ifindex: _,
         } => format!("VPN Decap (tbl {})", table_id),
+        super::inst::IlmType::Swap => "LU Swap".to_string(),
         super::inst::IlmType::None => {
             if let Some((prefix, _)) = find_route_for_nexthop(rib, uni) {
                 prefix.to_string()


### PR DESCRIPTION
Phase 5a of BGP Labeled Unicast — the **ingress-LSR dataplane**. A received labeled route now installs an IP FIB entry that forwards toward its BGP next-hop with the **received label pushed** (plus any transport label stack from recursively resolving that next-hop). This is what lets the router forward IP traffic *into* an MPLS LSP toward labeled destinations. It reuses the proven VPNv4/VPNv6 NHT + label-stack machinery — no new dataplane primitives.

> Builds on the merged control plane (#1042 + #1047 + #1054). Control-plane only until now; this is the first piece that programs MPLS forwarding.

## What

- **`NhtDep::V4lu / V6lu`** — track the BGP next-hop of a `v4lu`/`v6lu` route so best-path re-gates and the FIB re-installs on a reachability or transport change (like the VPN deps, but the route stays in the global table — no VRF).
- **`fib_install_labelv4/v6` + `select_fib_entry_label`** — build the entry via `build_vpn_fib_entry(received_label, transport)`, transport from the global NHT cache. Self-originated FECs (`network`/redistribute) install nothing (we're the egress; the source route forwards); an unresolved next-hop withdraws. Takes the RIB client + cache directly (not a `BgpTop`) so the NHT re-eval can call it too.
- **`route_labelv4/v6_update` + `_withdraw`** — register/untrack the next-hop with NHT (register-then-gate) and reconcile the FIB on each change.
- The **`network` / redistribute originators** reconcile the FIB too, so a prefix moving between originated-wins (withdraw the BGP entry) and received-wins (install the label-push) stays correct.
- **`nht_reeval_dep` / `nht_reinstall_transport`** — V4lu/V6lu arms re-select best-path and re-install when the next-hop resolves (reachability flip → also re-advertise; transport reroute → FIB-only).

## Validation

zebra-rs unit suite (728) + bgp-packet (218) + `yang_load_tests` pass; workspace `clippy --all-targets -D warnings` clean.

⚠️ **Real MPLS forwarding (the label push toward the LSP) is not exercised by the unit suite** — it needs a live FRR + kernel-MPLS run / BDD. The code mirrors the VPNv4/VPNv6 install + NHT paths that *are* FRR-validated, but the BGP-LU forwarding itself should be confirmed on a real dataplane before relying on it.

## Deferred — Phase 5b

Per-prefix local label allocation + ILM swap/pop for **next-hop-self re-advertisement** (transit/egress LSR): when we re-advertise a labeled route with NHS we must allocate a local label and install `swap(local → received)` / `pop`. Needs a new `IlmType::Swap` and a per-prefix label allocator (the central `LabelManager` already exists). Today NHS re-advertisement still sends implicit-null / the received label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)