### PR TITLE
docs: BGP Flowspec status + leftover work

### DIFF
--- a/docs/design/bgp-flowspec-plan.md
+++ b/docs/design/bgp-flowspec-plan.md
@@ -2,15 +2,53 @@
 
 Tracks the implementation of BGP Flow Specification (RFC 8955 / 8956,
 validation per RFC 9117) for zebra-rs, covering IPv4 and IPv6 unicast
-Flowspec (AFI 1/2, SAFI 133). This document is the locked plan: it
-captures the RFC surface, how FRR/Cisco map the hard part, the
-architecture decisions, the YANG schema, and the phase-by-phase slice
-so a contributor can resume without the conversation history.
+Flowspec (AFI 1/2, SAFI 133). This document is the living plan + status:
+it captures the RFC surface, how FRR/Cisco map the hard part, the
+architecture decisions, the YANG schema, the phase-by-phase slice, and
+**what has landed vs what's left** so a contributor can resume without
+the conversation history.
 
-Read this first if you're touching `crates/bgp-packet/src/nlri_flowspec.rs`,
-the `MpReachAttr::Flowspec` / `MpUnreachAttr::Flowspec` arms, the
-`LocalRib.flowspec_v4/v6` tables, `bgp::route::route_flowspec_update`,
-the `rib::Message::Flowspec*` arms, or `zebra-rs/yang/zebra-bgp-flowspec.yang`.
+Read this first if you're touching `crates/bgp-packet/src/attrs/nlri_flowspec.rs`,
+`flowspec_action.rs`, the `MpReachAttr::Flowspec` / `MpUnreachAttr::Flowspec`
+arms, the `LocalRib.flowspec_v4/v6` tables, `bgp::route::route_flowspec_*`,
+`bgp::flowspec` (validation), or `zebra-rs/yang/zebra-bgp-flowspec.yang`.
+
+## Status (updated 2026-05-30)
+
+**The control plane is complete** for IPv4 + IPv6 unicast Flowspec
+(SAFI 133): negotiate → receive → validate (RFC 9117) → Loc-RIB
+best-path → re-advertise to peers, with a per-neighbor validation
+toggle. All slices below are merged to `main`. The dataplane (Phase 4)
+and a few validation refinements remain — see **Leftover work**.
+
+| Slice            | PR    | What landed                                                                                  |
+| ---------------- | ----- | -------------------------------------------------------------------------------------------- |
+| 0 — codec        | #1046 | `FlowspecNlri` (v4+v6 components), action ext-comms, §5.1 `Ord`, round-trip tests            |
+| 1a — capability  | #1048 | `flowspec-ipv4`/`flowspec-ipv6` family, MP capability negotiation, `show ip bgp summary` label |
+| 1b — receive     | #1050 | `AdjRibFlowspecTable`, `route_flowspec_update/withdraw`, `show ip bgp flowspec [ipv6]`        |
+| 2 — validation   | #1052 | RFC 9117 `flowspec_validate` (b.1 originator-match + b.2 AS_PATH-local), surfaced in `show`   |
+| (rename)         | #1053 | `ipv4-flowspec`→`flowspec-ipv4` (+ v6) for type-first consistency with `label-v4`            |
+| 3a — Loc-RIB     | #1056 | `LocalRibFlowspecTable` (cands+selected) + best-path; `show` reads the Loc-RIB                |
+| 3b — advertise   | #1057 | `route_advertise/withdraw_flowspec_to_peers`, gated on validity; `AdjRib<Out>` flowspec       |
+| 3c — knob        | #1058 | per-neighbor `flowspec { validation <bool> }` (`zebra-bgp-flowspec.yang`)                    |
+
+### Where the pieces live
+
+- **Codec:** `crates/bgp-packet/src/attrs/nlri_flowspec.rs` (NLRI),
+  `flowspec_action.rs` (action ext-comms), `MpReachAttr::Flowspec` /
+  `MpUnreachAttr::Flowspec` in `mp_reach.rs` / `mp_unreach.rs`.
+- **Validation:** `zebra-rs/src/bgp/flowspec.rs`
+  (`flowspec_validate`, `flowspec_validate_with_mode`).
+- **RIB + receive + advertise:** `zebra-rs/src/bgp/route.rs`
+  (`route_flowspec_*`, `LocalRibFlowspecTable`,
+  `route_advertise/withdraw_flowspec_to_peers`); `adj_rib.rs`
+  (`AdjRibFlowspecTable`).
+- **Config / YANG:** `zebra-afi-safi.yang` (family enum),
+  `zebra-bgp-flowspec.yang` (validation knob),
+  `config/configs.rs::Args::afi_safi`,
+  `bgp/config.rs::config_flowspec_validation`.
+- **Show:** `zebra-rs/src/bgp/show.rs` (`show_bgp_flowspec`),
+  `exec.yang` (`show ip bgp flowspec`).
 
 ## Locked decisions (2026-05-30)
 
@@ -268,24 +306,75 @@ container flowspec {
 pattern (`config.rs:1622`, `vrf_config.rs:358`) — one callback per leaf into a
 `BgpFlowspecConfig` map on `Bgp`.
 
-## Phasing (one branch / PR each)
+## Phasing (status)
 
-| Phase | Scope                                                                 | Reuse  | Risk   |
-| ----- | --------------------------------------------------------------------- | ------ | ------ |
-| **0** | Codec: `FlowspecNlri` (v4+v6) + action ext-comms + `Ord` + round-trip tests | high   | low    |
-| **1** | Capability + receive → Adj-RIB-In + `show bgp ipv4/ipv6 flowspec` (no install) | high   | low    |
-| **2** | RFC 9117 validation vs unicast Loc-RIB; event-driven revalidation via NHT | medium | medium |
-| **3** | Loc-RIB best-path + re-advertise (update-group flush to flowspec peers) | medium | medium |
-| **4** | Dataplane: `tc`-flower netlink southbound (the large, independent build) | none   | high   |
+| Phase     | Scope                                                              | Status                                           |
+| --------- | ------------------------------------------------------------------ | ------------------------------------------------ |
+| 0         | Codec: `FlowspecNlri` (v4+v6) + action ext-comms + `Ord` + tests   | ✅ merged (#1046)                                |
+| 1a / 1b   | Capability + receive → Adj-RIB-In + `show ip bgp flowspec`         | ✅ merged (#1048, #1050)                         |
+| 2         | RFC 9117 validation vs unicast Loc-RIB                             | ✅ merged (#1052) — computed live, see leftovers |
+| 3a/3b/3c  | Loc-RIB best-path + re-advertise + per-neighbor validation knob    | ✅ merged (#1056, #1057, #1058)                  |
+| 4         | Dataplane: `tc`-flower netlink southbound                          | ⬜ not started (the large, isolated build)       |
 
 Phases 0–3 deliver a standards-compliant, interoperable,
-route-reflector-capable Flowspec implementation, mirroring how the v6 BGP
-stack shipped control-plane-first. Phase 4 carries the real engineering risk.
+route-reflector-capable Flowspec **control plane**, mirroring how the v6
+BGP stack shipped control-plane-first. Phase 4 carries the real
+engineering risk.
+
+## Leftover work
+
+### Control-plane refinements (Phase 3 leftovers)
+
+1. **Event-driven re-validation.** RFC 9117 validity is currently
+   computed at receive/withdraw and at `show` time (see
+   `route_flowspec_propagate` and `show_bgp_flowspec`). A flow spec that
+   arrives *before* its covering unicast route — or whose covering route
+   later changes originator or disappears — is not automatically
+   re-evaluated, so its advertised state can go stale. Needs a
+   **perf-safe trigger**: a naive hook in the unicast update path would
+   re-validate every flow spec on every unicast UPDATE (O(N) per route
+   during full-table convergence). Options: a prefix-indexed reverse map
+   (flow specs keyed by covering prefix), debounced re-validation at
+   convergence / unicast EoR, or piggybacking the NHT notification
+   machinery. `flowspec_validate_with_mode` is built to be reused by the
+   trigger.
+2. **RFC 8955 rule-c.** The "no more-specific unicast route received
+   from a different neighboring AS than the best-match route" check is
+   not implemented. Self-contained addition to `flowspec_validate` (scan
+   the unicast RIB under the destination prefix); low value in common
+   deployments, no YANG/config impact.
+
+### Phase 4 — dataplane (`tc`-flower southbound)
+
+The big, isolated build. zebra-rs has **no** traffic-control southbound
+today, and the `netlink-packet-route` fork lacks `RTM_NEW{T,Q}FILTER` /
+`TCA_*`.
+
+- Add `rib::Message::FlowspecAdd { afi, nlri, actions, ifindex }` /
+  `FlowspecDel` (`rib/inst.rs`) and async `FibHandle::flowspec_install /
+  uninstall` (`fib/netlink/`). Stub/log until the southbound lands; the
+  hook point is `route_flowspec_propagate` (alongside the advertise).
+- Map the normalized `FlowspecAction` set → a `tc` **flower** classifier
+  (matching the flow spec components) plus actions: `police` (rate-limit
+  / drop), `skbedit`/`pedit` (DSCP marking), `mirred` / route (redirect).
+  Filter `prio` comes from the §5.1 `Ord` so rules apply in precedence
+  order.
+- Extend the `netlink-packet-route` fork (or use raw netlink) for the tc
+  message types and attributes.
+- `redirect-to-VRF` reuses the existing VRF / l3mdev table infra
+  (`fib/netlink/handle.rs`).
+- VPP's classifier/ACL is the natural future high-performance target.
 
 ### Deferred (later series)
 
-- VPN flowspec (SAFI 134) + `redirect-to-VRF` dataplane (reuses existing
-  VRF/l3mdev table infra).
-- `redirect-to-IP` dataplane.
-- Local flowspec rule origination (YANG module **c** above).
+- **VPN flowspec** (SAFI 134) + `redirect-to-VRF` propagation (`Safi`
+  enum needs a `FlowspecVpn = 134` variant).
+- **`redirect-to-IP`** / RFC 8956 `redirect-ipv6` (a 20-octet
+  IPv6-address-specific community, not yet decoded — see
+  `flowspec_action.rs`).
+- **Local flow-spec rule origination** (operator-configured match +
+  action) — planned extension to `zebra-bgp-flowspec.yang`.
+- **Add-path / update-group batching** for flowspec advertise (current
+  send is one NLRI per UPDATE, direct via `send_flowspec_one`).
+- **JSON** output for `show ip bgp flowspec` (returns `[]` today).
 - VPP classifier/ACL southbound.


### PR DESCRIPTION
Updates `docs/design/bgp-flowspec-plan.md` from a forward plan into a **living status doc**, since the control plane is now complete and we're pausing before the dataplane.

## What it records
- **Status table** of the merged slices — Phases 0–3c (PRs #1046, #1048, #1050, #1052, #1053, #1056, #1057, #1058): the full control plane (negotiate → receive → validate per RFC 9117 → Loc-RIB best-path → re-advertise, plus the per-neighbor validation toggle) for IPv4 + IPv6 unicast Flowspec.
- **"Where the pieces live"** map (codec / validation / RIB / config-YANG / show).
- **Leftover work**, in priority order:
  - *Phase 3 refinements:* event-driven re-validation (with the perf-safe-trigger note) and the RFC 8955 rule-c check.
  - *Phase 4:* the `tc`-flower dataplane southbound design (the large, isolated build).
  - *Deferred:* VPN flowspec (SAFI 134), `redirect-ipv6`/redirect-to-IP, local rule origination, update-group batching, `show` JSON, VPP.

Doc-only — no code or YANG change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)