### PR TITLE
bgp: install SR Policy SRv6 Binding SID (End.B6.Encaps)

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -4052,15 +4052,44 @@ pub fn route_srpolicy_update(
         color: nlri.color,
         endpoint: nlri.endpoint,
     };
-    bgp.local_rib.sr_policy.insert(key, cp);
+    let delta = bgp.local_rib.sr_policy.insert(key, cp);
+    apply_srpolicy_fib(delta, bgp);
 }
 
-/// Withdraw one SR Policy NLRI from the headend database and re-run
-/// active candidate-path selection.
+/// Withdraw one SR Policy NLRI from the headend database, re-run active
+/// candidate-path selection, and apply the dataplane delta.
 pub fn route_srpolicy_withdraw(ident: usize, nlri: &SrPolicyNlri, bgp: &mut BgpTop) {
-    bgp.local_rib
-        .sr_policy
-        .withdraw(nlri.color, nlri.endpoint, nlri.distinguisher, ident);
+    let delta =
+        bgp.local_rib
+            .sr_policy
+            .withdraw(nlri.color, nlri.endpoint, nlri.distinguisher, ident);
+    apply_srpolicy_fib(delta, bgp);
+}
+
+/// Realize an SR Policy active-path change in the dataplane: remove the
+/// previous SRv6 Binding SID and/or install the new one as an
+/// End.B6.Encaps local SID (RFC 8986 §4.14) pushing the policy's
+/// segment list. SR-MPLS Binding SIDs are a later phase.
+fn apply_srpolicy_fib(delta: super::sr_policy::SrPolicyFibDelta, bgp: &mut BgpTop) {
+    if let Some(addr) = delta.remove {
+        let _ = bgp.rib_client.send(rib::Message::SidDel { addr });
+    }
+    if let Some(install) = delta.install {
+        let sid = rib::Sid {
+            addr: install.bsid,
+            behavior: rib::SidBehavior::EndB6Encap,
+            context: rib::SidContext::None,
+            owner: rib::SidOwner::new("bgp", 0),
+            locator: String::new(),
+            allocation_type: rib::SidAllocationType::Dynamic,
+            ifindex: 0,
+            nh6: None,
+            structure: None,
+            table_id: 0,
+            segs: install.segments,
+        };
+        let _ = bgp.rib_client.send(rib::Message::SidAdd { sid });
+    }
 }
 
 /// Propagate a flow spec's selected best path to peers: re-advertise it

--- a/zebra-rs/src/bgp/sr_policy.rs
+++ b/zebra-rs/src/bgp/sr_policy.rs
@@ -15,10 +15,10 @@
 //! selection algorithm so they stay unit-testable.
 
 use std::collections::BTreeMap;
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use bgp_packet::{
-    BgpAttr, BindingSid, CommunityValue, ExtCommunitySubType, SegmentList, SrPolicyTlvs,
+    BgpAttr, BindingSid, CommunityValue, ExtCommunitySubType, Segment, SegmentList, SrPolicyTlvs,
     Srv6BindingSid,
 };
 
@@ -79,6 +79,88 @@ pub struct SrPolicy {
     pub candidates: BTreeMap<CandidatePathKey, CandidatePath>,
     /// Active candidate path (RFC 9256 §2.9), if any valid path exists.
     pub active: Option<CandidatePathKey>,
+    /// SRv6 Binding SID currently programmed in the FIB for this policy
+    /// (the active path's End.B6.Encaps install). Tracked so a change of
+    /// active path tears the old one down.
+    installed: Option<Srv6Bsid>,
+}
+
+impl SrPolicy {
+    /// Diff the active path's desired SRv6 Binding-SID install against
+    /// what is currently programmed, update the record, and return the
+    /// FIB delta the caller applies via the RIB.
+    fn reconcile_fib(&mut self) -> SrPolicyFibDelta {
+        let desired = self
+            .active
+            .as_ref()
+            .and_then(|k| self.candidates.get(k))
+            .and_then(srv6_bsid);
+        let mut delta = SrPolicyFibDelta::default();
+        match (&self.installed, &desired) {
+            // Same Binding SID address: re-install only if its segment
+            // list changed (SidAdd is a replace).
+            (Some(prev), Some(new)) if prev.bsid == new.bsid => {
+                if prev.segments != new.segments {
+                    delta.install = Some(new.clone());
+                }
+            }
+            (prev, new) => {
+                delta.remove = prev.as_ref().map(|b| b.bsid);
+                delta.install = new.clone();
+            }
+        }
+        self.installed = desired;
+        delta
+    }
+}
+
+/// An SRv6 Binding SID install: the BSID address and the segment list
+/// (Type-B SIDs in forwarding order) that End.B6.Encaps pushes onto it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Srv6Bsid {
+    pub bsid: Ipv6Addr,
+    pub segments: Vec<Ipv6Addr>,
+}
+
+/// The FIB change produced by an insert/withdraw: remove an old Binding
+/// SID and/or install a new one. Both `None` means no dataplane change.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SrPolicyFibDelta {
+    pub remove: Option<Ipv6Addr>,
+    pub install: Option<Srv6Bsid>,
+}
+
+/// The SRv6 Binding-SID install an active candidate path realizes, or
+/// `None` if it isn't an installable SRv6 policy (not valid, no SRv6
+/// Binding SID, or its first segment list isn't an all-Type-B list).
+fn srv6_bsid(cp: &CandidatePath) -> Option<Srv6Bsid> {
+    if !cp.valid {
+        return None;
+    }
+    let bsid = cp
+        .srv6_binding_sid
+        .as_ref()
+        .map(|s| s.sid)
+        .or(match &cp.binding_sid {
+            Some(BindingSid::Srv6(addr)) => Some(*addr),
+            _ => None,
+        })?;
+    let first = cp.segment_lists.first()?;
+    let segments: Vec<Ipv6Addr> = first
+        .segments
+        .iter()
+        .filter_map(|seg| match seg {
+            Segment::TypeB { sid, .. } => Some(*sid),
+            _ => None,
+        })
+        .collect();
+    // Only an all-SRv6 (Type B) list maps to an End.B6.Encaps push; a
+    // mixed or SR-MPLS list is out of scope here (an SR-MPLS Binding SID
+    // is the later ILM phase).
+    if segments.is_empty() || segments.len() != first.segments.len() {
+        return None;
+    }
+    Some(Srv6Bsid { bsid, segments })
 }
 
 /// The SR Policy database (one per BGP instance, lives on the Loc-RIB).
@@ -88,30 +170,45 @@ pub struct SrPolicyDb {
 }
 
 impl SrPolicyDb {
-    /// Insert or replace a candidate path and re-run active selection.
-    pub fn insert(&mut self, key: SrPolicyKey, cp: CandidatePath) {
+    /// Insert or replace a candidate path, re-run active selection, and
+    /// return the resulting FIB delta.
+    pub fn insert(&mut self, key: SrPolicyKey, cp: CandidatePath) -> SrPolicyFibDelta {
         let policy = self.policies.entry(key).or_default();
         let prev = policy.active.clone();
         policy.candidates.insert(cp.key.clone(), cp);
         policy.active = select_active(&policy.candidates, prev.as_ref());
+        policy.reconcile_fib()
     }
 
     /// Remove the candidate path advertised by `peer` for the NLRI
-    /// `<color, endpoint, discriminator>` and re-run selection. Drops the
-    /// whole policy when its last candidate is withdrawn.
-    pub fn withdraw(&mut self, color: u32, endpoint: IpAddr, discriminator: u32, peer: usize) {
+    /// `<color, endpoint, discriminator>`, re-run selection, and return
+    /// the FIB delta. Drops the whole policy (tearing down any installed
+    /// Binding SID) when its last candidate is withdrawn.
+    pub fn withdraw(
+        &mut self,
+        color: u32,
+        endpoint: IpAddr,
+        discriminator: u32,
+        peer: usize,
+    ) -> SrPolicyFibDelta {
         let key = SrPolicyKey { color, endpoint };
         let Some(policy) = self.policies.get_mut(&key) else {
-            return;
+            return SrPolicyFibDelta::default();
         };
         let prev = policy.active.clone();
         policy
             .candidates
             .retain(|k, cp| !(k.discriminator == discriminator && cp.peer == peer));
         if policy.candidates.is_empty() {
+            let remove = policy.installed.take().map(|b| b.bsid);
             self.policies.remove(&key);
+            SrPolicyFibDelta {
+                remove,
+                install: None,
+            }
         } else {
             policy.active = select_active(&policy.candidates, prev.as_ref());
+            policy.reconcile_fib()
         }
     }
 }
@@ -238,10 +335,34 @@ fn ipv4_route_targets(attr: &BgpAttr) -> Vec<Ipv4Addr> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bgp_packet::Segment;
 
     fn endpoint(s: &str) -> IpAddr {
         s.parse().unwrap()
+    }
+
+    fn v6(s: &str) -> Ipv6Addr {
+        s.parse().unwrap()
+    }
+
+    /// A valid SRv6 candidate path: an SRv6 Binding SID plus a one-hop
+    /// Type-B segment list.
+    fn srv6_cp(disc: u32, pref: u32, peer: usize, bsid: &str, seg: &str) -> CandidatePath {
+        let mut c = cp(20, "10.0.0.1", disc, pref, true);
+        c.peer = peer;
+        c.srv6_binding_sid = Some(Srv6BindingSid {
+            flags: 0,
+            sid: v6(bsid),
+            structure: None,
+        });
+        c.segment_lists = vec![SegmentList {
+            weight: None,
+            segments: vec![Segment::TypeB {
+                flags: 0,
+                sid: v6(seg),
+                structure: None,
+            }],
+        }];
+        c
     }
 
     fn cp(proto: u8, originator_ip: &str, disc: u32, pref: u32, valid: bool) -> CandidatePath {
@@ -385,5 +506,72 @@ mod tests {
         tlvs.segment_lists.push(SegmentList::default());
         let cp2 = candidate_path(&tlvs, (65000, endpoint("10.0.0.1")), 1, 3);
         assert!(!cp2.valid);
+    }
+
+    #[test]
+    fn srv6_policy_installs_binding_sid() {
+        let mut db = SrPolicyDb::default();
+        let key = SrPolicyKey {
+            color: 100,
+            endpoint: endpoint("10.0.0.9"),
+        };
+        let delta = db.insert(key, srv6_cp(1, 100, 1, "fc00:0:9::100", "fc00:0:2::"));
+        assert_eq!(delta.remove, None);
+        let install = delta.install.expect("install");
+        assert_eq!(install.bsid, v6("fc00:0:9::100"));
+        assert_eq!(install.segments, vec![v6("fc00:0:2::")]);
+    }
+
+    #[test]
+    fn better_path_swaps_binding_sid_then_falls_back() {
+        let mut db = SrPolicyDb::default();
+        let ep = endpoint("10.0.0.9");
+        let key = SrPolicyKey {
+            color: 100,
+            endpoint: ep,
+        };
+        db.insert(key.clone(), srv6_cp(1, 100, 1, "fc00:0:9::1", "fc00:0:2::"));
+        // A higher-preference path swaps the installed Binding SID.
+        let delta = db.insert(key, srv6_cp(2, 200, 2, "fc00:0:9::2", "fc00:0:3::"));
+        assert_eq!(delta.remove, Some(v6("fc00:0:9::1")));
+        assert_eq!(delta.install.unwrap().bsid, v6("fc00:0:9::2"));
+        // Withdrawing the winner falls back to the remaining path's BSID.
+        let delta = db.withdraw(100, ep, 2, 2);
+        assert_eq!(delta.remove, Some(v6("fc00:0:9::2")));
+        assert_eq!(delta.install.unwrap().bsid, v6("fc00:0:9::1"));
+    }
+
+    #[test]
+    fn withdrawing_last_path_removes_binding_sid() {
+        let mut db = SrPolicyDb::default();
+        let ep = endpoint("10.0.0.9");
+        let key = SrPolicyKey {
+            color: 5,
+            endpoint: ep,
+        };
+        db.insert(key.clone(), srv6_cp(1, 100, 1, "fc00:0:9::1", "fc00:0:2::"));
+        let delta = db.withdraw(5, ep, 1, 1);
+        assert_eq!(delta.remove, Some(v6("fc00:0:9::1")));
+        assert_eq!(delta.install, None);
+        assert!(!db.policies.contains_key(&key));
+    }
+
+    #[test]
+    fn sr_mpls_or_no_bsid_does_not_install() {
+        let mut db = SrPolicyDb::default();
+        let key = SrPolicyKey {
+            color: 7,
+            endpoint: endpoint("10.0.0.9"),
+        };
+        // SR-MPLS (Type A) segment, no SRv6 Binding SID → no SRv6 install.
+        let mut c = cp(20, "10.0.0.1", 1, 100, true);
+        c.segment_lists = vec![SegmentList {
+            weight: None,
+            segments: vec![Segment::TypeA {
+                flags: 0,
+                label: 16001,
+            }],
+        }];
+        assert_eq!(db.insert(key, c), SrPolicyFibDelta::default());
     }
 }

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -238,6 +238,7 @@ pub fn spawn_bgp_vrf(
             nh6: None,
             structure: None,
             table_id,
+            segs: Vec::new(),
         };
         rib_subscriber.send_sid_add(sid);
     }

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -233,6 +233,10 @@ fn sid_route_target(
         SidBehavior::EndDT4 | SidBehavior::EndDT6 | SidBehavior::EndDT46 => {
             (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr)
         }
+        // End.B6.Encaps (SR Policy Binding SID): a /128 host route in
+        // table=main; the SRH it pushes rides inside the seg6local
+        // encap, not in the route header.
+        SidBehavior::EndB6Encap => (RouteHeader::RT_TABLE_MAIN, RouteType::Unicast, 128, addr),
     }
 }
 
@@ -668,7 +672,7 @@ impl FibHandle {
                 // Static seg6local action routes keep the legacy
                 // RT_TABLE_MAIN decap (table_id 0); per-VRF table
                 // selection arrives via the protocol SID path.
-                super::srv6::build_seg6local_attrs(action, None, None, 0)
+                super::srv6::build_seg6local_attrs(action, None, None, 0, &[])
             {
                 msg.attributes.push(encap);
                 msg.attributes.push(encap_type);
@@ -1306,9 +1310,13 @@ impl FibHandle {
         if ifindex != 0 {
             msg.attributes.push(RouteAttribute::Oif(ifindex));
         }
-        let Some((encap, encap_type)) =
-            super::srv6::build_seg6local_attrs(sid.behavior, sid.nh6, sid.structure, sid.table_id)
-        else {
+        let Some((encap, encap_type)) = super::srv6::build_seg6local_attrs(
+            sid.behavior,
+            sid.nh6,
+            sid.structure,
+            sid.table_id,
+            &sid.segs,
+        ) else {
             tracing::warn!(
                 "seg6local route encap build skipped for {} (End.X / uA without IPv6 nexthop)",
                 sid.addr

--- a/zebra-rs/src/fib/netlink/srv6.rs
+++ b/zebra-rs/src/fib/netlink/srv6.rs
@@ -37,18 +37,7 @@ pub fn build_seg6_lwtunnel(
         other => bail!("unsupported SRv6 encap type: {other}"),
     };
 
-    let n = sr_segments.len() as u8;
-    let ipv6_sr_hdr = Ipv6SrHdr {
-        nexthdr: 0,
-        hdrlen: n.saturating_mul(2),
-        typ: 4,
-        segments_left: n - 1,
-        first_segment: n - 1,
-        flags: 0,
-        tag: 0,
-        segments: sr_segments,
-        ..Default::default()
-    };
+    let ipv6_sr_hdr = build_srh(&sr_segments);
     let seg6 = Seg6IpTunnelEncap {
         mode: Seg6IpTunnelMode::Encap,
         ipv6_sr_hdr: VecIpv6SrHdr(vec![ipv6_sr_hdr]),
@@ -73,6 +62,24 @@ pub fn build_seg6_attrs(
     ))
 }
 
+// Build the SRH (`Ipv6SrHdr`) carrying `segments` in forwarding order,
+// shared by the H.Encap encap path and the End.B6.Encaps seg6local
+// push. `segments` must be non-empty (callers guarantee it).
+fn build_srh(segments: &[Ipv6Addr]) -> Ipv6SrHdr {
+    let n = segments.len() as u8;
+    Ipv6SrHdr {
+        nexthdr: 0,
+        hdrlen: n.saturating_mul(2),
+        typ: 4,
+        segments_left: n - 1,
+        first_segment: n - 1,
+        flags: 0,
+        tag: 0,
+        segments: segments.to_vec(),
+        ..Default::default()
+    }
+}
+
 // Map a SidBehavior to its kernel SEG6_LOCAL_ACTION_*. uSID variants
 // reuse the same kernel actions as their classic counterparts; the
 // NEXT-C-SID flavor rides as a separate Flavors attribute. End.DT4 /
@@ -87,6 +94,7 @@ fn seg6local_action(behavior: SidBehavior) -> Seg6LocalAction {
         SidBehavior::EndDT4 => Seg6LocalAction::EndDt4,
         SidBehavior::EndDT6 => Seg6LocalAction::EndDt6,
         SidBehavior::EndDT46 => Seg6LocalAction::EndDt46,
+        SidBehavior::EndB6Encap => Seg6LocalAction::EndB6Encap,
     }
 }
 
@@ -141,12 +149,22 @@ fn build_seg6local_lwtunnel(
     nh6: Option<Ipv6Addr>,
     structure: Option<SidStructure>,
     table_id: u32,
+    segs: &[Ipv6Addr],
 ) -> Option<Vec<RouteLwTunnelEncap>> {
     let mut attrs: Vec<RouteSeg6LocalIpTunnel> =
         vec![RouteSeg6LocalIpTunnel::Action(seg6local_action(behavior))];
     if matches!(behavior, SidBehavior::EndX | SidBehavior::UA) {
         let nh = nh6?;
         attrs.push(RouteSeg6LocalIpTunnel::Nh6(nh));
+    }
+    if matches!(behavior, SidBehavior::EndB6Encap) {
+        // `SEG6_LOCAL_SRH`: the SR Policy segment list this Binding SID
+        // encapsulates onto. No segments → nothing to push, so skip the
+        // FIB install (the registry row is harmless).
+        if segs.is_empty() {
+            return None;
+        }
+        attrs.push(RouteSeg6LocalIpTunnel::Srh(build_srh(segs)));
     }
     if matches!(behavior, SidBehavior::EndDT4 | SidBehavior::EndDT6) {
         // `SEG6_LOCAL_TABLE`: 0 maps to RT_TABLE_MAIN to preserve the
@@ -184,8 +202,9 @@ pub fn build_seg6local_attrs(
     nh6: Option<Ipv6Addr>,
     structure: Option<SidStructure>,
     table_id: u32,
+    segs: &[Ipv6Addr],
 ) -> Option<(RouteAttribute, RouteAttribute)> {
-    let encaps = build_seg6local_lwtunnel(behavior, nh6, structure, table_id)?;
+    let encaps = build_seg6local_lwtunnel(behavior, nh6, structure, table_id, segs)?;
     Some((
         RouteAttribute::Encap(encaps),
         RouteAttribute::EncapType(RouteLwEnCapType::Seg6Local),
@@ -218,8 +237,8 @@ mod tests {
     fn end_dt46_uses_vrftable_with_given_table() {
         // BGP L3VPN-over-SRv6: an End.DT46 SID decaps into the VRF's
         // kernel table via SEG6_LOCAL_VRFTABLE, never a plain table.
-        let encaps =
-            build_seg6local_lwtunnel(SidBehavior::EndDT46, None, None, 100).expect("encap built");
+        let encaps = build_seg6local_lwtunnel(SidBehavior::EndDT46, None, None, 100, &[])
+            .expect("encap built");
         assert!(
             encaps.iter().any(|e| matches!(
                 e,
@@ -237,15 +256,41 @@ mod tests {
     fn end_dt6_table_zero_maps_to_main() {
         // table_id 0 must preserve the legacy static / IS-IS default.
         let encaps =
-            build_seg6local_lwtunnel(SidBehavior::EndDT6, None, None, 0).expect("encap built");
+            build_seg6local_lwtunnel(SidBehavior::EndDT6, None, None, 0, &[]).expect("encap built");
         assert_eq!(table_attr(&encaps), Some(RouteHeader::RT_TABLE_MAIN as u32));
         assert_eq!(vrftable_attr(&encaps), None);
     }
 
     #[test]
     fn end_dt4_honors_nonzero_table() {
-        let encaps =
-            build_seg6local_lwtunnel(SidBehavior::EndDT4, None, None, 42).expect("encap built");
+        let encaps = build_seg6local_lwtunnel(SidBehavior::EndDT4, None, None, 42, &[])
+            .expect("encap built");
         assert_eq!(table_attr(&encaps), Some(42));
+    }
+
+    #[test]
+    fn end_b6_encaps_pushes_srh_segment_list() {
+        // SR Policy Binding SID: End.B6.Encaps carries the policy's
+        // segment list as a SEG6_LOCAL_SRH attribute.
+        let segs = vec!["fc00:0:2::".parse().unwrap(), "fc00:0:9::".parse().unwrap()];
+        let encaps = build_seg6local_lwtunnel(SidBehavior::EndB6Encap, None, None, 0, &segs)
+            .expect("encap built");
+        assert!(encaps.iter().any(|e| matches!(
+            e,
+            RouteLwTunnelEncap::Seg6Local(RouteSeg6LocalIpTunnel::Action(
+                Seg6LocalAction::EndB6Encap
+            ))
+        )));
+        let srh = encaps.iter().find_map(|e| match e {
+            RouteLwTunnelEncap::Seg6Local(RouteSeg6LocalIpTunnel::Srh(h)) => Some(h),
+            _ => None,
+        });
+        assert_eq!(srh.expect("SRH present").segments, segs);
+    }
+
+    #[test]
+    fn end_b6_encaps_without_segments_skips_install() {
+        // No segment list → no SRH to push → skip the FIB install.
+        assert!(build_seg6local_lwtunnel(SidBehavior::EndB6Encap, None, None, 0, &[]).is_none());
     }
 }

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2222,6 +2222,7 @@ impl Isis {
                 structure,
                 // End / uN is local-processing, no table decap.
                 table_id: 0,
+                segs: Vec::new(),
             };
             let _ = self.ctx.rib.send(rib::Message::SidAdd { sid });
             self.sr_end_sid = Some(addr);

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -160,6 +160,7 @@ impl Neighbor {
             structure,
             // End.X is a local cross-connect, not a table decap.
             table_id: 0,
+            segs: Vec::new(),
         };
         let _ = rib_client.send(rib::Message::SidAdd { sid });
         self.endx_sid = Some((function, addr));

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -45,6 +45,12 @@ pub enum SidBehavior {
     /// which is how BGP L3VPN-over-SRv6 binds a single per-VRF SID;
     /// the table-id is carried in [`Sid::table_id`].
     EndDT46,
+    /// End.B6.Encaps — RFC 8986 §4.14 (IANA codepoint 14). The SID is a
+    /// Binding SID for an SR Policy: a packet arriving with this SID is
+    /// encapsulated (outer IPv6 + SRH) onto the policy's segment list
+    /// (carried in [`Sid::segs`]) and forwarded. BGP SR Policy
+    /// (SAFI 73) installs the advertised SRv6 Binding SID this way.
+    EndB6Encap,
 }
 
 impl fmt::Display for SidBehavior {
@@ -57,6 +63,7 @@ impl fmt::Display for SidBehavior {
             Self::EndDT4 => write!(f, "End.DT4"),
             Self::EndDT6 => write!(f, "End.DT6"),
             Self::EndDT46 => write!(f, "End.DT46"),
+            Self::EndB6Encap => write!(f, "End.B6.Encaps"),
         }
     }
 }
@@ -76,6 +83,7 @@ impl FromStr for SidBehavior {
             "End.DT4" => Ok(Self::EndDT4),
             "End.DT6" => Ok(Self::EndDT6),
             "End.DT46" => Ok(Self::EndDT46),
+            "End.B6.Encaps" => Ok(Self::EndB6Encap),
             other => Err(SidBehaviorParseError(other.to_string())),
         }
     }
@@ -193,6 +201,9 @@ pub struct Sid {
     /// End.DT46 decap lands in the right VRF. Ignored by End / End.X /
     /// uN / uA.
     pub table_id: u32,
+    /// SRH segment list pushed by `End.B6.Encaps` (RFC 8986 §4.14), in
+    /// forwarding order. Empty for every other behavior.
+    pub segs: Vec<Ipv6Addr>,
 }
 
 impl Sid {
@@ -211,7 +222,10 @@ impl Sid {
             | SidBehavior::UA
             | SidBehavior::EndDT4
             | SidBehavior::EndDT6
-            | SidBehavior::EndDT46 => Ipv6Net::new(self.addr, 128).expect("/128 is always valid"),
+            | SidBehavior::EndDT46
+            | SidBehavior::EndB6Encap => {
+                Ipv6Net::new(self.addr, 128).expect("/128 is always valid")
+            }
             SidBehavior::UN => {
                 let plen = self
                     .structure

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -2017,6 +2017,7 @@ mod tests {
             nh6: None,
             structure: None,
             table_id: 0,
+            segs: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

Realizes a BGP SR Policy's active candidate path in the **SRv6 dataplane**. When the active path (selected by the PR #1065 control plane) is a valid SRv6 policy — an SRv6 Binding SID plus a Type-B (SRv6) segment list — the Binding SID is installed as an **End.B6.Encaps local SID** (RFC 8986 §4.14, IANA codepoint 14) whose `SEG6_LOCAL_SRH` carries the policy's segment list. A packet arriving with the BSID is encapsulated onto the segment list and forwarded — the realization a remote headend / PCE stitches through. The install is swapped or torn down when the active path changes or is withdrawn.

## Changes
- **`rib/segment_routing/sid.rs`**: add `SidBehavior::EndB6Encap` (Display `End.B6.Encaps`, FromStr, /128 prefix) and a `Sid.segs` field carrying the SRH segment list (empty for every other behavior).
- **`fib/netlink/srv6.rs`**: map `EndB6Encap` → `Seg6LocalAction::EndB6Encap` and emit `RouteSeg6LocalIpTunnel::Srh(..)` built from `sid.segs` (the `netlink-packet-route` `seg6` fork already supports both `SEG6_LOCAL_ACTION_END_B6_ENCAP` and `SEG6_LOCAL_SRH`). The SRH builder is factored out and shared with the existing H.Encap path.
- **`fib/netlink/handle.rs`**: `sid_route_target` maps End.B6.Encaps to a /128 main-table unicast route; thread `&sid.segs` through `build_seg6local_attrs`.
- **`bgp/sr_policy.rs`**: each policy tracks its installed BSID; `insert`/`withdraw` return a `SrPolicyFibDelta { remove, install }` reconciling the active path's desired SRv6 BSID against what's programmed.
- **`bgp/route.rs`**: `apply_srpolicy_fib` applies the delta via `rib::Message::SidAdd` / `SidDel`.

## Scope (minimal, by design)
Explicit advertised SRv6 Binding SID only; the active path's **first** segment list. **Deferred**: SR-MPLS Binding SID (an ILM phase), weighted ECMP across multiple segment lists (a single End.B6.Encaps SID is one SRH), dynamic BSID allocation, and NHT gating.

## Test plan
- `cargo test -p zebra-rs` — 747 passed (4 new `SrPolicyFibDelta` state-machine tests + 2 new seg6local SRH-emission tests), 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` (clean cache) — clean
- `cargo fmt --all --check` — clean
- Live SRv6 dataplane validation needs a kernel/topology (deferred for the whole series); the SRH bytes and the install/teardown state machine are unit-tested.

Generated with [Claude Code](https://claude.com/claude-code)