### PR TITLE
bgp: install SR Policy SR-MPLS Binding SID (ILM)

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1824,6 +1824,17 @@ impl Bgp {
                     &selected,
                 );
             }
+            // SR Policy: the endpoint's transport rerouted; re-install
+            // the Binding-SID ILM toward the fresh next-hop.
+            NhtDep::SrPolicy { color, endpoint } => {
+                super::route::sr_policy_reconcile_mpls(
+                    &self.ctx.rib,
+                    &self.nexthop_cache,
+                    &mut self.local_rib.sr_policy,
+                    color,
+                    endpoint,
+                );
+            }
             NhtDep::V4(_) | NhtDep::V6(_) => {}
         }
     }
@@ -1875,6 +1886,9 @@ impl Bgp {
             // (the VRF FIB install is gated by transport availability in
             // the dispatch below), so just re-select.
             NhtDep::Evpn(rd, prefix) => self.local_rib.select_best_path_evpn(rd, prefix),
+            // SR Policy has no BGP best-path / advertise step; its ILM is
+            // reconciled in the dispatch below, not via `selected`.
+            NhtDep::SrPolicy { .. } => Vec::new(),
         };
 
         let mut top = super::peer::BgpTop {
@@ -2085,6 +2099,17 @@ impl Bgp {
                         }
                     }
                 }
+            }
+            // SR Policy reachability flip: (re)install or tear down the
+            // Binding-SID ILM via the endpoint's NHT resolution.
+            NhtDep::SrPolicy { color, endpoint } => {
+                super::route::sr_policy_reconcile_mpls(
+                    top.rib_client,
+                    &self.nexthop_cache,
+                    &mut top.local_rib.sr_policy,
+                    *color,
+                    *endpoint,
+                );
             }
         }
     }

--- a/zebra-rs/src/bgp/nht.rs
+++ b/zebra-rs/src/bgp/nht.rs
@@ -40,6 +40,14 @@ pub enum NhtDep {
     /// when the underlay resolves or reroutes. The `EvpnPrefix` is the
     /// RD-stripped key (its `IpPrefix` variant carries the v4/v6 net).
     Evpn(RouteDistinguisher, EvpnPrefix),
+    /// SR Policy (SAFI 73) in `local_rib.sr_policy`. The policy endpoint
+    /// is tracked so the SR-MPLS Binding-SID ILM (re)installs toward the
+    /// resolved next-hop, or is torn down, when the endpoint's
+    /// reachability or transport changes. Keyed by `<color, endpoint>`.
+    SrPolicy {
+        color: u32,
+        endpoint: IpAddr,
+    },
 }
 
 /// How a tracked next-hop's resolution changed, returned by

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -4054,6 +4054,7 @@ pub fn route_srpolicy_update(
     };
     let delta = bgp.local_rib.sr_policy.insert(key, cp);
     apply_srpolicy_fib(delta, bgp);
+    sr_policy_mpls_sync(bgp, nlri.color, nlri.endpoint);
 }
 
 /// Withdraw one SR Policy NLRI from the headend database, re-run active
@@ -4064,12 +4065,15 @@ pub fn route_srpolicy_withdraw(ident: usize, nlri: &SrPolicyNlri, bgp: &mut BgpT
             .sr_policy
             .withdraw(nlri.color, nlri.endpoint, nlri.distinguisher, ident);
     apply_srpolicy_fib(delta, bgp);
+    sr_policy_mpls_sync(bgp, nlri.color, nlri.endpoint);
 }
 
 /// Realize an SR Policy active-path change in the dataplane: remove the
 /// previous SRv6 Binding SID and/or install the new one as an
 /// End.B6.Encaps local SID (RFC 8986 §4.14) pushing the policy's
-/// segment list. SR-MPLS Binding SIDs are a later phase.
+/// segment list, plus tear down an SR-MPLS Binding-SID ILM when a whole
+/// policy is withdrawn. (The live SR-MPLS install/update is driven by
+/// `sr_policy_mpls_sync` / `sr_policy_reconcile_mpls`, gated on NHT.)
 fn apply_srpolicy_fib(delta: super::sr_policy::SrPolicyFibDelta, bgp: &mut BgpTop) {
     if let Some(addr) = delta.remove {
         let _ = bgp.rib_client.send(rib::Message::SidDel { addr });
@@ -4090,6 +4094,122 @@ fn apply_srpolicy_fib(delta: super::sr_policy::SrPolicyFibDelta, bgp: &mut BgpTo
         };
         let _ = bgp.rib_client.send(rib::Message::SidAdd { sid });
     }
+    if let Some(label) = delta.mpls_remove {
+        srpolicy_ilm_remove(bgp.rib_client, label);
+    }
+}
+
+/// Track/untrack the policy endpoint with NHT and reconcile its SR-MPLS
+/// Binding-SID ILM. The ILM forwards toward the endpoint's resolved
+/// next-hop (an exact first hop for single-segment / endpoint-rooted
+/// policies; an approximation when a multi-segment list's first waypoint
+/// differs from the endpoint). Global instance only; a null endpoint
+/// (color-only policy) has nothing to resolve.
+fn sr_policy_mpls_sync(bgp: &mut BgpTop, color: u32, endpoint: IpAddr) {
+    if bgp.nexthop_cache.is_none() || endpoint.is_unspecified() {
+        return;
+    }
+    let dep = super::nht::NhtDep::SrPolicy { color, endpoint };
+    let wants = bgp.local_rib.sr_policy.wants_mpls(color, endpoint);
+
+    if wants && let Some(cache) = bgp.nexthop_cache.as_deref_mut() {
+        let (needs_register, _reachable) = cache.track(endpoint, dep.clone());
+        if needs_register {
+            let _ = bgp.rib_client.send(rib::Message::NexthopRegister {
+                proto: "bgp".to_string(),
+                nh: endpoint,
+            });
+        }
+    }
+
+    if let Some(cache) = bgp.nexthop_cache.as_deref() {
+        sr_policy_reconcile_mpls(
+            bgp.rib_client,
+            cache,
+            &mut bgp.local_rib.sr_policy,
+            color,
+            endpoint,
+        );
+    }
+
+    if !wants
+        && let Some(cache) = bgp.nexthop_cache.as_deref_mut()
+        && cache.untrack(endpoint, &dep)
+    {
+        let _ = bgp.rib_client.send(rib::Message::NexthopUnregister {
+            proto: "bgp".to_string(),
+            nh: endpoint,
+        });
+    }
+}
+
+/// Reconcile the SR-MPLS Binding-SID ILM for `<color, endpoint>` against
+/// the active path and the endpoint's NHT resolution. Callable from the
+/// receive path and from the NHT re-eval in `inst.rs`, so it takes the
+/// RIB client + cache directly rather than a `BgpTop`.
+pub(super) fn sr_policy_reconcile_mpls(
+    rib_client: &crate::rib::client::RibClient,
+    cache: &super::nht::NexthopCache,
+    db: &mut super::sr_policy::SrPolicyDb,
+    color: u32,
+    endpoint: IpAddr,
+) {
+    let reachable = !cache.transport_for(endpoint).is_empty();
+    let action = db.mpls_reconcile(color, endpoint, reachable);
+    if let Some(label) = action.remove {
+        srpolicy_ilm_remove(rib_client, label);
+    }
+    if let Some(install) = action.install {
+        srpolicy_ilm_install(
+            rib_client,
+            install.bsid,
+            &install.segments,
+            cache.transport_for(endpoint),
+        );
+    }
+}
+
+/// Install the SR-MPLS Binding-SID ILM: incoming `bsid` label → push the
+/// policy's `stack` (the explicit segment list) toward the resolved
+/// `transport` egress(es). The transport's own labels are ignored — the
+/// SR Policy stack is the explicit path; only the L2 next-hop is reused.
+fn srpolicy_ilm_install(
+    rib_client: &crate::rib::client::RibClient,
+    bsid: u32,
+    stack: &[u32],
+    transport: &[rib::nht::ResolvedNexthop],
+) {
+    if transport.is_empty() {
+        return;
+    }
+    let mk = |egress: &rib::nht::ResolvedNexthop| {
+        let mut uni = rib::NexthopUni::new(egress.addr, 0, Vec::new());
+        uni.mpls_label = stack.to_vec();
+        if egress.ifindex != 0 {
+            uni.ifindex_origin = Some(egress.ifindex);
+        }
+        uni.valid = true;
+        uni
+    };
+    let nexthop = if transport.len() == 1 {
+        rib::Nexthop::Uni(mk(&transport[0]))
+    } else {
+        let mut multi = rib::NexthopMulti::default();
+        for egress in transport {
+            multi.nexthops.push(mk(egress));
+        }
+        rib::Nexthop::Multi(multi)
+    };
+    let mut ilm = rib::inst::IlmEntry::new(rib::RibType::Bgp);
+    ilm.ilm_type = rib::inst::IlmType::Swap;
+    ilm.nexthop = nexthop;
+    let _ = rib_client.send(rib::Message::IlmAdd { label: bsid, ilm });
+}
+
+/// Tear down the SR-MPLS Binding-SID ILM at `bsid`.
+fn srpolicy_ilm_remove(rib_client: &crate::rib::client::RibClient, bsid: u32) {
+    let ilm = rib::inst::IlmEntry::new(rib::RibType::Bgp);
+    let _ = rib_client.send(rib::Message::IlmDel { label: bsid, ilm });
 }
 
 /// Propagate a flow spec's selected best path to peers: re-advertise it

--- a/zebra-rs/src/bgp/sr_policy.rs
+++ b/zebra-rs/src/bgp/sr_policy.rs
@@ -83,9 +83,19 @@ pub struct SrPolicy {
     /// (the active path's End.B6.Encaps install). Tracked so a change of
     /// active path tears the old one down.
     installed: Option<Srv6Bsid>,
+    /// SR-MPLS Binding SID *label* currently programmed in the LFIB (the
+    /// active path's ILM). `None` when no MPLS install is live. Unlike
+    /// the SRv6 install (immediate), the MPLS ILM is gated on the
+    /// endpoint resolving via NHT, so this is set by `mpls_reconcile`.
+    installed_mpls: Option<u32>,
 }
 
 impl SrPolicy {
+    /// The active candidate path, if one is selected.
+    pub fn active_cp(&self) -> Option<&CandidatePath> {
+        self.active.as_ref().and_then(|k| self.candidates.get(k))
+    }
+
     /// Diff the active path's desired SRv6 Binding-SID install against
     /// what is currently programmed, update the record, and return the
     /// FIB delta the caller applies via the RIB.
@@ -122,12 +132,60 @@ pub struct Srv6Bsid {
     pub segments: Vec<Ipv6Addr>,
 }
 
-/// The FIB change produced by an insert/withdraw: remove an old Binding
-/// SID and/or install a new one. Both `None` means no dataplane change.
+/// The FIB change produced by an insert/withdraw. The SRv6 Binding SID
+/// install is immediate (`remove`/`install`); the SR-MPLS ILM is gated on
+/// NHT, so insert/withdraw only report `mpls_remove` — the LFIB label to
+/// tear down when a withdraw drops a whole policy (the live install/update
+/// is driven by `mpls_reconcile`). All `None` means no dataplane change.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SrPolicyFibDelta {
     pub remove: Option<Ipv6Addr>,
     pub install: Option<Srv6Bsid>,
+    pub mpls_remove: Option<u32>,
+}
+
+/// An SR-MPLS Binding SID install: the incoming BSID label and the
+/// segment list (Type-A labels, top of stack first) the ILM pushes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MplsBsid {
+    pub bsid: u32,
+    pub segments: Vec<u32>,
+}
+
+/// The SR-MPLS Binding-SID install an active candidate path realizes, or
+/// `None` if it isn't an installable SR-MPLS policy (not valid, no MPLS
+/// Binding SID, or its first segment list isn't an all-Type-A list).
+fn mpls_bsid(cp: &CandidatePath) -> Option<MplsBsid> {
+    if !cp.valid {
+        return None;
+    }
+    let bsid = match &cp.binding_sid {
+        Some(BindingSid::MplsLabel(label)) => *label,
+        _ => return None,
+    };
+    let first = cp.segment_lists.first()?;
+    let segments: Vec<u32> = first
+        .segments
+        .iter()
+        .filter_map(|seg| match seg {
+            Segment::TypeA { label, .. } => Some(*label),
+            _ => None,
+        })
+        .collect();
+    // Only an all-SR-MPLS (Type A) list maps to an ILM label push.
+    if segments.is_empty() || segments.len() != first.segments.len() {
+        return None;
+    }
+    Some(MplsBsid { bsid, segments })
+}
+
+/// The LFIB change `mpls_reconcile` wants applied: remove an old BSID
+/// label and/or install a new one. The install is realized by the caller
+/// toward the endpoint's NHT-resolved next-hop.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct MplsIlmAction {
+    pub remove: Option<u32>,
+    pub install: Option<MplsBsid>,
 }
 
 /// The SRv6 Binding-SID install an active candidate path realizes, or
@@ -201,14 +259,62 @@ impl SrPolicyDb {
             .retain(|k, cp| !(k.discriminator == discriminator && cp.peer == peer));
         if policy.candidates.is_empty() {
             let remove = policy.installed.take().map(|b| b.bsid);
+            let mpls_remove = policy.installed_mpls.take();
             self.policies.remove(&key);
             SrPolicyFibDelta {
                 remove,
                 install: None,
+                mpls_remove,
             }
         } else {
             policy.active = select_active(&policy.candidates, prev.as_ref());
             policy.reconcile_fib()
+        }
+    }
+
+    /// Whether the policy's active path is an installable SR-MPLS policy
+    /// (so its endpoint should be NHT-tracked for the ILM install).
+    pub fn wants_mpls(&self, color: u32, endpoint: IpAddr) -> bool {
+        self.policies
+            .get(&SrPolicyKey { color, endpoint })
+            .and_then(|p| p.active_cp())
+            .and_then(mpls_bsid)
+            .is_some()
+    }
+
+    /// Reconcile the SR-MPLS Binding-SID ILM for a *live* policy against
+    /// its active path and the endpoint's reachability, updating the
+    /// recorded install. Returns the LFIB action for the caller to apply
+    /// (it owns the resolved next-hop). A no-op (and no install) when the
+    /// policy is absent — a removed policy's teardown rides
+    /// `SrPolicyFibDelta::mpls_remove` instead. `reachable` is whether the
+    /// endpoint resolved via NHT.
+    pub fn mpls_reconcile(
+        &mut self,
+        color: u32,
+        endpoint: IpAddr,
+        reachable: bool,
+    ) -> MplsIlmAction {
+        let key = SrPolicyKey { color, endpoint };
+        let Some(policy) = self.policies.get_mut(&key) else {
+            return MplsIlmAction::default();
+        };
+        let desired = policy.active_cp().and_then(mpls_bsid);
+        match desired {
+            Some(bsid) if reachable => {
+                // Replace whenever reachable (the resolved next-hop or the
+                // label stack may have changed); drop a stale label first.
+                let remove = policy.installed_mpls.filter(|old| *old != bsid.bsid);
+                policy.installed_mpls = Some(bsid.bsid);
+                MplsIlmAction {
+                    remove,
+                    install: Some(bsid),
+                }
+            }
+            _ => MplsIlmAction {
+                remove: policy.installed_mpls.take(),
+                install: None,
+            },
         }
     }
 }
@@ -573,5 +679,79 @@ mod tests {
             }],
         }];
         assert_eq!(db.insert(key, c), SrPolicyFibDelta::default());
+    }
+
+    /// A valid SR-MPLS candidate path: an MPLS Binding SID label plus a
+    /// one-hop Type-A label stack.
+    fn mpls_cp(disc: u32, pref: u32, peer: usize, bsid: u32, label: u32) -> CandidatePath {
+        let mut c = cp(20, "10.0.0.1", disc, pref, true);
+        c.peer = peer;
+        c.binding_sid = Some(BindingSid::MplsLabel(bsid));
+        c.segment_lists = vec![SegmentList {
+            weight: None,
+            segments: vec![Segment::TypeA { flags: 0, label }],
+        }];
+        c
+    }
+
+    #[test]
+    fn mpls_reconcile_gates_install_on_reachability() {
+        let mut db = SrPolicyDb::default();
+        let ep = endpoint("10.0.0.9");
+        let key = SrPolicyKey {
+            color: 100,
+            endpoint: ep,
+        };
+        db.insert(key, mpls_cp(1, 100, 1, 1000, 16001));
+
+        // Endpoint unresolved → no install yet.
+        assert_eq!(db.mpls_reconcile(100, ep, false), MplsIlmAction::default());
+        // Endpoint resolves → install the BSID ILM.
+        let action = db.mpls_reconcile(100, ep, true);
+        assert_eq!(action.remove, None);
+        assert_eq!(
+            action.install,
+            Some(MplsBsid {
+                bsid: 1000,
+                segments: vec![16001],
+            })
+        );
+        // Endpoint goes unreachable → tear the ILM down.
+        let action = db.mpls_reconcile(100, ep, false);
+        assert_eq!(action.remove, Some(1000));
+        assert_eq!(action.install, None);
+    }
+
+    #[test]
+    fn mpls_reconcile_swaps_label_when_active_path_changes() {
+        let mut db = SrPolicyDb::default();
+        let ep = endpoint("10.0.0.9");
+        let key = SrPolicyKey {
+            color: 100,
+            endpoint: ep,
+        };
+        db.insert(key.clone(), mpls_cp(1, 100, 1, 1000, 16001));
+        assert_eq!(db.mpls_reconcile(100, ep, true).install.unwrap().bsid, 1000);
+        // A higher-preference path with a different BSID label wins.
+        db.insert(key, mpls_cp(2, 200, 2, 2000, 16002));
+        let action = db.mpls_reconcile(100, ep, true);
+        assert_eq!(action.remove, Some(1000));
+        assert_eq!(action.install.unwrap().bsid, 2000);
+    }
+
+    #[test]
+    fn withdrawing_mpls_policy_reports_label_to_remove() {
+        let mut db = SrPolicyDb::default();
+        let ep = endpoint("10.0.0.9");
+        let key = SrPolicyKey {
+            color: 9,
+            endpoint: ep,
+        };
+        db.insert(key, mpls_cp(1, 100, 1, 1000, 16001));
+        // Install it (records installed_mpls).
+        assert!(db.mpls_reconcile(9, ep, true).install.is_some());
+        // Withdrawing the last path reports the LFIB label to tear down.
+        let delta = db.withdraw(9, ep, 1, 1);
+        assert_eq!(delta.mpls_remove, Some(1000));
     }
 }


### PR DESCRIPTION
## Summary

Realizes an SR Policy's active **SR-MPLS** candidate path in the dataplane — the SR-MPLS counterpart of the SRv6 End.B6.Encaps install (#1066). When the active path has an MPLS Binding SID plus a Type-A (SR-MPLS) segment list, the Binding SID is installed as an **MPLS ILM** that pushes the policy's label stack and forwards toward the endpoint's NHT-resolved next-hop.

### The first-hop problem & how it's resolved
Unlike a seg6local SID (where the kernel does the outer lookup), an MPLS ILM needs an explicit resolved next-hop, and BGP can't derive the first hop from a bare SR-MPLS label. So the **policy endpoint is tracked via BGP's NHT cache** (new `NhtDep::SrPolicy { color, endpoint }`) and the ILM forwards toward the resolved endpoint next-hop:
- **Exact** for single-segment / endpoint-rooted policies (the dominant controller case: a one-label policy steering onto an egress).
- A **documented approximation** when a multi-segment list's first waypoint differs from the endpoint.

The SR Policy label stack is the explicit path, so the endpoint's transport labels are *not* prepended — only its L2 next-hop is reused.

### Changes
- **`sr_policy.rs`**: `mpls_bsid(cp)` extracts the MPLS BSID + Type-A stack; `installed_mpls` tracks the live LFIB label; `mpls_reconcile(color, endpoint, reachable)` returns the LFIB action; `SrPolicyFibDelta.mpls_remove` tears the ILM down on full withdrawal.
- **`nht.rs`**: new `NhtDep::SrPolicy { color, endpoint }`.
- **`route.rs`**: `sr_policy_mpls_sync` (NHT track/register → reconcile → untrack) runs after each receive; `sr_policy_reconcile_mpls` builds the `IlmEntry` (Swap, `mpls_label` = the explicit stack) toward `transport_for(endpoint)` and `IlmAdd`/`IlmDel`s.
- **`inst.rs`**: `NhtDep::SrPolicy` dispatched on both reachability flips and transport reroutes.

## Scope
Endpoint-resolved via NHT; advertised MPLS Binding SID + the active path's first segment list. (SRv6 BSID install was #1066; weighted ECMP, dynamic allocation, and a proper label→node first-hop remain deferred.)

## Test plan
- `cargo test -p zebra-rs` — 750 passed (3 new MPLS reconcile/gating unit tests), 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` (clean cache) — clean
- `cargo fmt --all --check` — clean
- Live MPLS dataplane validation needs a topology (deferred for the whole series); the reconcile/gating state machine is unit-tested.

Generated with [Claude Code](https://claude.com/claude-code)