### PR TITLE
config: allow `cli format {json|terminal}` in configure mode

### DIFF
--- a/zebra-rs/src/config/commands.rs
+++ b/zebra-rs/src/config/commands.rs
@@ -57,6 +57,10 @@ pub fn configure_mode_create(entry: Rc<Entry>) -> Mode {
     mode.install_func(String::from("/load"), load);
     mode.install_func(String::from("/save"), save);
     mode.install_func(String::from("/clear/isis/spf"), clear_isis_spf);
+    // Same operator command as exec mode, so the output format can be
+    // switched without leaving the configure prompt.
+    mode.install_func(String::from("/cli/format/json"), cli_format_json);
+    mode.install_func(String::from("/cli/format/terminal"), cli_format_terminal);
     mode
 }
 

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -346,8 +346,11 @@ impl ConfigManager {
 
         let entry = self.load_mode(&mut yang, "configure")?;
         entry.dir.borrow_mut().push(run_from_exec(exec.clone()));
-        if let Some(exec_show) = show_from_exec(exec) {
+        if let Some(exec_show) = top_from_exec(&exec, "show") {
             entry.dir.borrow_mut().push(exec_show);
+        }
+        if let Some(exec_cli) = top_from_exec(&exec, "cli") {
+            entry.dir.borrow_mut().push(exec_cli);
         }
         let configure_mode = configure_mode_create(entry);
         self.modes.insert("configure".to_string(), configure_mode);
@@ -1059,9 +1062,13 @@ fn run_from_exec(exec: Rc<Entry>) -> Rc<Entry> {
     Rc::new(run)
 }
 
-fn show_from_exec(exec: Rc<Entry>) -> Option<Rc<Entry>> {
+/// Graft a top-level command container from exec mode (e.g. `show`,
+/// `cli`) into configure mode so it can be typed directly at the
+/// configure prompt — without the `run` prefix. Returns a clonable
+/// handle, or `None` if exec mode has no such container.
+fn top_from_exec(exec: &Rc<Entry>, name: &str) -> Option<Rc<Entry>> {
     for dir in exec.dir.borrow().iter() {
-        if dir.name == "show" {
+        if dir.name == name {
             return Some(dir.clone());
         }
     }


### PR DESCRIPTION
## Summary

Makes `cli format json` and `cli format terminal` usable at the
configure prompt, not just in exec mode.

In configure mode, command parsing runs against a separate entry tree
that previously had only the exec `show` container grafted in. This
change also grafts the exec `cli` container and registers the two
format handlers in `configure_mode_create`, reusing the existing
exec-mode handlers and the YANG definition in `exec.yang` (same pattern
already used to share `show version` between the two modes).

The single-purpose `show_from_exec` helper is generalized into
`top_from_exec(exec, name)` since the `cli` graft would otherwise be a
verbatim copy.

## Test plan

- `cargo build -p zebra-rs` — clean
- `cargo fmt` — applied
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs config::` — 122 passed, 0 failed
- Manual: `cli format json` / `cli format terminal` now accepted at the
  configure prompt and switch output format, matching exec-mode behavior

Generated with [Claude Code](https://claude.com/claude-code)
