### PR TITLE
bgp: SR Policy originator (config-defined local policies, SAFI 73)

### DIFF
--- a/crates/bgp-packet/src/update.rs
+++ b/crates/bgp-packet/src/update.rs
@@ -308,6 +308,78 @@ impl UpdatePacket {
         Some(buf.get())
     }
 
+    /// Serialize an SR Policy (SAFI 73, RFC 9830) MP_REACH UPDATE for
+    /// the originator. Mirrors [`pop_evpn`](Self::pop_evpn): emits the
+    /// path attributes (incl. the Tunnel-Type-15 Tunnel Encapsulation
+    /// attribute and NO_ADVERTISE / Route Target) followed by the
+    /// MP_REACH NLRI, and drains `updates` so a second call returns
+    /// `None`.
+    pub fn pop_srpolicy(&mut self) -> Option<BytesMut> {
+        let (afi, snpa, nhop, updates) = match &self.mp_update {
+            Some(MpReachAttr::SrPolicy {
+                afi,
+                snpa,
+                nhop,
+                updates,
+            }) if !updates.is_empty() => (*afi, *snpa, *nhop, updates.clone()),
+            _ => return None,
+        };
+
+        let mut buf = FixedBuf::new(self.max_packet_size);
+        let header: BytesMut = self.header.clone().into();
+        let _ = buf.put(&header[..]);
+        let _ = buf.put_u16(0u16); // no IPv4 withdraw
+
+        let attr_len_pos = buf.len();
+        let _ = buf.put_u16(0u16); // placeholder
+
+        if let Some(bgp_attr) = &self.bgp_attr {
+            bgp_attr.attr_emit(buf.get_mut());
+        }
+        super::attrs::mp_reach::srpolicy_attr_emit(afi, snpa, &nhop, &updates, buf.get_mut());
+
+        let attr_len: u16 = (buf.len() - attr_len_pos - 2) as u16;
+        let _ = buf.put_u16_at(attr_len_pos, attr_len);
+        let length: u16 = buf.len() as u16;
+        let _ = buf.put_u16_at(16, length);
+
+        if let Some(MpReachAttr::SrPolicy { updates, .. }) = self.mp_update.as_mut() {
+            updates.clear();
+        }
+        Some(buf.get())
+    }
+
+    /// Serialize an SR Policy MP_UNREACH (withdraw) UPDATE. Drains
+    /// `withdraws` so a second call returns `None`.
+    pub fn pop_srpolicy_withdraw(&mut self) -> Option<BytesMut> {
+        match &self.mp_withdraw {
+            Some(MpUnreachAttr::SrPolicy { withdraws, .. }) if !withdraws.is_empty() => {}
+            _ => return None,
+        }
+
+        let mut buf = FixedBuf::new(self.max_packet_size);
+        let header: BytesMut = self.header.clone().into();
+        let _ = buf.put(&header[..]);
+        let _ = buf.put_u16(0u16); // no IPv4 withdraw
+
+        let attr_len_pos = buf.len();
+        let _ = buf.put_u16(0u16); // placeholder
+
+        if let Some(mp) = &self.mp_withdraw {
+            mp.attr_emit(buf.get_mut());
+        }
+
+        let attr_len: u16 = (buf.len() - attr_len_pos - 2) as u16;
+        let _ = buf.put_u16_at(attr_len_pos, attr_len);
+        let length: u16 = buf.len() as u16;
+        let _ = buf.put_u16_at(16, length);
+
+        if let Some(MpUnreachAttr::SrPolicy { withdraws, .. }) = self.mp_withdraw.as_mut() {
+            withdraws.clear();
+        }
+        Some(buf.get())
+    }
+
     pub fn pop_vpnv6(&mut self) -> Option<BytesMut> {
         match &self.mp_update {
             Some(MpReachAttr::Vpnv6(vpnv6)) if !vpnv6.updates.is_empty() => {}

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1598,6 +1598,50 @@ impl Bgp {
             "/router/bgp/color-policy/color/flex-algorithm",
             super::color_policy::config_color_flex_algorithm,
         );
+        // `set router bgp sr-policy policy <NAME> [...]`
+        // (zebra-bgp-sr-policy.yang). Locally-originated SR Policies,
+        // advertised as SAFI 73; callbacks stage onto
+        // `Bgp::local_rib.sr_policy_local` and re-advertise.
+        self.callback_add(
+            "/router/bgp/sr-policy/policy",
+            super::sr_policy::config_srp_policy,
+        );
+        self.callback_add(
+            "/router/bgp/sr-policy/policy/color",
+            super::sr_policy::config_srp_color,
+        );
+        self.callback_add(
+            "/router/bgp/sr-policy/policy/endpoint",
+            super::sr_policy::config_srp_endpoint,
+        );
+        self.callback_add(
+            "/router/bgp/sr-policy/policy/preference",
+            super::sr_policy::config_srp_preference,
+        );
+        self.callback_add(
+            "/router/bgp/sr-policy/policy/binding-sid-label",
+            super::sr_policy::config_srp_binding_sid_label,
+        );
+        self.callback_add(
+            "/router/bgp/sr-policy/policy/binding-sid-sid",
+            super::sr_policy::config_srp_binding_sid_sid,
+        );
+        self.callback_add(
+            "/router/bgp/sr-policy/policy/route-target",
+            super::sr_policy::config_srp_route_target,
+        );
+        self.callback_add(
+            "/router/bgp/sr-policy/policy/segment",
+            super::sr_policy::config_srp_segment,
+        );
+        self.callback_add(
+            "/router/bgp/sr-policy/policy/segment/mpls-label",
+            super::sr_policy::config_srp_segment_mpls_label,
+        );
+        self.callback_add(
+            "/router/bgp/sr-policy/policy/segment/srv6-sid",
+            super::sr_policy::config_srp_segment_srv6_sid,
+        );
         // `set router bgp vrf <name> [...]` (zebra-bgp-vrf.yang).
         // The callbacks populate `Bgp::vrfs`; the CommitEnd hook in
         // `process_cm_msg` emits a debug log per VRF entry and

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1258,6 +1258,12 @@ pub struct LocalRib {
     /// `<color, endpoint>` (the endpoint's family is the NLRI AFI, so a
     /// single table holds both IPv4 and IPv6 policies).
     pub sr_policy: super::sr_policy::SrPolicyDb,
+
+    /// Locally-configured SR Policies to originate as SAFI 73
+    /// (zebra-bgp-sr-policy.yang). Lives here so both the config
+    /// callbacks (`&mut Bgp`) and the establish-time advertise
+    /// (`BgpTop`) reach it without threading a new `BgpTop` field.
+    pub sr_policy_local: super::sr_policy::LocalSrPolicies,
 }
 
 impl LocalRib {
@@ -4125,6 +4131,136 @@ fn apply_srpolicy_fib(delta: super::sr_policy::SrPolicyFibDelta, bgp: &mut BgpTo
     }
 }
 
+// =======================================================================
+// Originator: advertise locally-configured SR Policies as SAFI 73.
+// =======================================================================
+
+/// Re-evaluate a locally-configured SR Policy after a config edit and
+/// (re)advertise it to SAFI-73 peers, or withdraw it if it is no longer
+/// complete. Called from the `sr-policy` config callbacks.
+pub(super) fn srpolicy_origin_sync(bgp: &mut Bgp, name: &str) {
+    let router_id = bgp.router_id;
+    // Resolve to an owned action first so the `local_rib` borrow is
+    // released before we touch `peers`.
+    let action: Option<Result<(SrPolicyNlri, BgpAttr), SrPolicyNlri>> = bgp
+        .local_rib
+        .sr_policy_local
+        .policies
+        .get(name)
+        .map(|p| match p.advert(router_id) {
+            Some(pair) => Ok(pair),
+            None => Err(p.nlri(router_id)),
+        })
+        .map(|r| match r {
+            Ok(pair) => Ok(pair),
+            // Incomplete: withdraw if an NLRI can still be formed.
+            Err(Some(nlri)) => Err(nlri),
+            Err(None) => Err(SrPolicyNlri {
+                id: 0,
+                distinguisher: 0,
+                color: 0,
+                endpoint: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            }),
+        });
+    match action {
+        Some(Ok((nlri, attr))) => srpolicy_origin_reach(bgp, nlri, attr),
+        // A synthetic all-zero NLRI means "nothing was ever advertisable"
+        // — color/endpoint unset — so there is nothing to withdraw.
+        Some(Err(nlri)) if nlri.color != 0 => srpolicy_origin_withdraw(bgp, nlri),
+        _ => {}
+    }
+}
+
+/// Addresses of established peers that negotiated SAFI 73 for `afi`.
+fn srpolicy_peer_addrs(bgp: &Bgp, afi: Afi) -> Vec<IpAddr> {
+    bgp.peers
+        .iter()
+        .filter(|(_, p)| p.state.is_established())
+        .filter(|(_, p)| p.is_afi_safi(afi, Safi::SrTePolicy))
+        .map(|(addr, _)| *addr)
+        .collect()
+}
+
+/// Advertise one local SR Policy NLRI + attribute to every established
+/// SAFI-73 peer of the endpoint's family (direct emit, no Adj-RIB-Out).
+pub(super) fn srpolicy_origin_reach(bgp: &mut Bgp, nlri: SrPolicyNlri, attr: BgpAttr) {
+    let afi = nlri.afi();
+    let nhop = IpAddr::V4(bgp.router_id);
+    for paddr in srpolicy_peer_addrs(bgp, afi) {
+        let Some(peer) = bgp.peers.get_mut(&paddr) else {
+            continue;
+        };
+        let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+        update.mp_update = Some(MpReachAttr::SrPolicy {
+            afi,
+            snpa: 0,
+            nhop,
+            updates: vec![nlri.clone()],
+        });
+        update.bgp_attr = Some(attr.clone());
+        if let Some(bytes) = update.pop_srpolicy()
+            && let Some(ref tx) = peer.packet_tx
+        {
+            let _ = tx.send(bytes);
+        }
+    }
+}
+
+/// Withdraw one local SR Policy NLRI from every established SAFI-73 peer.
+pub(super) fn srpolicy_origin_withdraw(bgp: &mut Bgp, nlri: SrPolicyNlri) {
+    let afi = nlri.afi();
+    for paddr in srpolicy_peer_addrs(bgp, afi) {
+        let Some(peer) = bgp.peers.get_mut(&paddr) else {
+            continue;
+        };
+        let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+        update.mp_withdraw = Some(MpUnreachAttr::SrPolicy {
+            afi,
+            withdraws: vec![nlri.clone()],
+        });
+        if let Some(bytes) = update.pop_srpolicy_withdraw()
+            && let Some(ref tx) = peer.packet_tx
+        {
+            let _ = tx.send(bytes);
+        }
+    }
+}
+
+/// On peer establishment, advertise every complete local SR Policy to
+/// the new peer (the SAFI-73 analogue of `route_sync_evpn`).
+pub fn route_sync_srpolicy(peer: &mut Peer, bgp: &BgpTop) {
+    let router_id = *bgp.router_id;
+    let max = peer.max_packet_size();
+    let adverts: Vec<(Afi, SrPolicyNlri, BgpAttr)> = bgp
+        .local_rib
+        .sr_policy_local
+        .policies
+        .values()
+        .filter_map(|p| {
+            p.advert(router_id)
+                .map(|(nlri, attr)| (nlri.afi(), nlri, attr))
+        })
+        .collect();
+    for (afi, nlri, attr) in adverts {
+        if !peer.is_afi_safi(afi, Safi::SrTePolicy) {
+            continue;
+        }
+        let mut update = UpdatePacket::with_max_packet_size(max);
+        update.mp_update = Some(MpReachAttr::SrPolicy {
+            afi,
+            snpa: 0,
+            nhop: IpAddr::V4(router_id),
+            updates: vec![nlri],
+        });
+        update.bgp_attr = Some(attr);
+        if let Some(bytes) = update.pop_srpolicy()
+            && let Some(ref tx) = peer.packet_tx
+        {
+            let _ = tx.send(bytes);
+        }
+    }
+}
+
 /// Track/untrack the policy endpoint with NHT and reconcile its SR-MPLS
 /// Binding-SID ILM. The ILM forwards toward the endpoint's resolved
 /// next-hop (an exact first hop for single-segment / endpoint-rooted
@@ -6694,6 +6830,10 @@ pub fn route_sync(peer: &mut Peer, bgp: &mut BgpTop) {
     }
     if peer.is_afi_safi(Afi::L2vpn, Safi::Evpn) {
         route_sync_evpn(peer, bgp);
+    }
+    // SAFI 73: dump our locally-originated SR Policies to the new peer.
+    if peer.is_afi_safi(Afi::Ip, Safi::SrTePolicy) || peer.is_afi_safi(Afi::Ip6, Safi::SrTePolicy) {
+        route_sync_srpolicy(peer, bgp);
     }
 }
 

--- a/zebra-rs/src/bgp/sr_policy.rs
+++ b/zebra-rs/src/bgp/sr_policy.rs
@@ -20,9 +20,14 @@ use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use bgp_packet::{
-    BgpAttr, BindingSid, CommunityValue, ExtCommunitySubType, Segment, SegmentList, SrPolicyTlvs,
-    Srv6BindingSid,
+    BgpAttr, BindingSid, Community, CommunityValue, ExtCommunity, ExtCommunitySubType,
+    ExtCommunityValue, Origin, Segment, SegmentList, SrPolicyNlri, SrPolicyTlvs, Srv6BindingSid,
+    TunnelEncap,
 };
+
+use crate::config::{Args, ConfigOp};
+
+use super::Bgp;
 
 /// Protocol-Origin value for a BGP-distributed SR Policy candidate path
 /// (RFC 9256 §2.3, Table 1).
@@ -500,6 +505,252 @@ fn ipv4_route_targets(attr: &BgpAttr) -> Vec<Ipv4Addr> {
     out
 }
 
+// =======================================================================
+// Originator: locally-configured SR Policies advertised as SAFI 73.
+// =======================================================================
+
+/// Locally-configured SR Policies (zebra-bgp-sr-policy.yang), keyed by
+/// the configuration name.
+#[derive(Clone, Debug, Default)]
+pub struct LocalSrPolicies {
+    pub policies: BTreeMap<String, LocalSrPolicy>,
+}
+
+/// One configured local SR Policy. Fields are `Option` because the
+/// config arrives leaf-by-leaf; a policy is only advertised once
+/// [`LocalSrPolicy::advert`] can build a complete NLRI + attribute.
+#[derive(Clone, Debug, Default)]
+pub struct LocalSrPolicy {
+    pub color: Option<u32>,
+    pub endpoint: Option<IpAddr>,
+    pub preference: Option<u32>,
+    pub binding_sid_label: Option<u32>,
+    pub binding_sid_sid: Option<Ipv6Addr>,
+    pub route_target: Option<Ipv4Addr>,
+    pub segments: BTreeMap<u32, LocalSegment>,
+}
+
+/// One explicit segment of a local policy (exactly one of the two is set
+/// for a usable segment).
+#[derive(Clone, Debug, Default)]
+pub struct LocalSegment {
+    pub mpls_label: Option<u32>,
+    pub srv6_sid: Option<Ipv6Addr>,
+}
+
+impl LocalSrPolicy {
+    /// The NLRI for this policy, if its color and endpoint are set. The
+    /// distinguisher is the originating router-id (RFC 9830 §2.1 — it
+    /// only needs to make the NLRI unique within `<color, endpoint>`).
+    pub fn nlri(&self, router_id: Ipv4Addr) -> Option<SrPolicyNlri> {
+        Some(SrPolicyNlri {
+            id: 0,
+            distinguisher: u32::from(router_id),
+            color: self.color?,
+            endpoint: self.endpoint?,
+        })
+    }
+
+    /// Build the `(NLRI, attribute)` to advertise this policy, or `None`
+    /// if it isn't complete (needs color, endpoint, and an all-one-type
+    /// segment list). The attribute carries the Tunnel-Type-15 encoding
+    /// plus, per RFC 9830 §4.1, an IPv4-address Route Target when one is
+    /// configured, else the NO_ADVERTISE community.
+    pub fn advert(&self, router_id: Ipv4Addr) -> Option<(SrPolicyNlri, BgpAttr)> {
+        let nlri = self.nlri(router_id)?;
+
+        // Segments, in ascending index order; reject mixed / empty lists.
+        let mut segments = Vec::new();
+        for seg in self.segments.values() {
+            if let Some(label) = seg.mpls_label {
+                segments.push(Segment::TypeA { flags: 0, label });
+            } else if let Some(sid) = seg.srv6_sid {
+                segments.push(Segment::TypeB {
+                    flags: 0,
+                    sid,
+                    structure: None,
+                });
+            } else {
+                return None;
+            }
+        }
+        if segments.is_empty() {
+            return None;
+        }
+        let has_a = segments.iter().any(|s| matches!(s, Segment::TypeA { .. }));
+        let has_b = segments.iter().any(|s| matches!(s, Segment::TypeB { .. }));
+        if has_a && has_b {
+            return None;
+        }
+
+        let tlvs = SrPolicyTlvs {
+            preference: Some(self.preference.unwrap_or(DEFAULT_PREFERENCE)),
+            binding_sid: self.binding_sid_label.map(BindingSid::MplsLabel),
+            srv6_binding_sid: self.binding_sid_sid.map(|sid| Srv6BindingSid {
+                flags: 0,
+                sid,
+                structure: None,
+            }),
+            enlp: None,
+            priority: None,
+            segment_lists: vec![SegmentList {
+                weight: None,
+                segments,
+            }],
+            policy_name: None,
+            cp_name: None,
+            unknown: Vec::new(),
+        };
+
+        let mut attr = BgpAttr {
+            origin: Some(Origin::Igp),
+            tunnel_encap: Some(TunnelEncap {
+                tunnels: vec![tlvs.to_tunnel()],
+            }),
+            ..Default::default()
+        };
+        // RFC 9830 §4.1: a Route Target identifies the intended
+        // headend(s); without one, NO_ADVERTISE keeps the policy local.
+        match self.route_target {
+            Some(rt) => attr.ecom = Some(ExtCommunity(vec![ipv4_route_target(rt)])),
+            None => attr.com = Some(Community(vec![CommunityValue::NO_ADVERTISE.value()])),
+        }
+        Some((nlri, attr))
+    }
+}
+
+/// An IPv4-address-format Route Target extended community (RFC 4360 §4
+/// type 0x01, sub-type Route Target) with local-administrator 0.
+fn ipv4_route_target(addr: Ipv4Addr) -> ExtCommunityValue {
+    let mut val = [0u8; 6];
+    val[0..4].copy_from_slice(&addr.octets());
+    ExtCommunityValue {
+        high_type: 0x01,
+        low_type: ExtCommunitySubType::RouteTarget as u8,
+        val,
+    }
+}
+
+// --- config callbacks (zebra-bgp-sr-policy.yang) ---------------------
+
+fn local_policy<'a>(bgp: &'a mut Bgp, name: &str) -> &'a mut LocalSrPolicy {
+    bgp.local_rib
+        .sr_policy_local
+        .policies
+        .entry(name.to_string())
+        .or_default()
+}
+
+/// `set router bgp sr-policy policy <NAME>` — ensure the entry exists;
+/// `delete` removes it and withdraws any advertised NLRI.
+pub fn config_srp_policy(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    match op {
+        ConfigOp::Set => {
+            local_policy(bgp, &name);
+        }
+        ConfigOp::Delete => {
+            if let Some(policy) = bgp.local_rib.sr_policy_local.policies.remove(&name)
+                && let Some(nlri) = policy.nlri(bgp.router_id)
+            {
+                super::route::srpolicy_origin_withdraw(bgp, nlri);
+            }
+        }
+        _ => {}
+    }
+    Some(())
+}
+
+/// Generic leaf setter: mutate the named policy, then re-sync the
+/// dataplane advertisement.
+fn config_srp_leaf<F>(bgp: &mut Bgp, name: &str, f: F) -> Option<()>
+where
+    F: FnOnce(&mut LocalSrPolicy),
+{
+    f(local_policy(bgp, name));
+    super::route::srpolicy_origin_sync(bgp, name);
+    Some(())
+}
+
+pub fn config_srp_color(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let value = op.is_set().then(|| args.u32()).flatten();
+    config_srp_leaf(bgp, &name, |p| p.color = value)
+}
+
+pub fn config_srp_endpoint(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let value = op.is_set().then(|| args.addr()).flatten();
+    config_srp_leaf(bgp, &name, |p| p.endpoint = value)
+}
+
+pub fn config_srp_preference(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let value = op.is_set().then(|| args.u32()).flatten();
+    config_srp_leaf(bgp, &name, |p| p.preference = value)
+}
+
+pub fn config_srp_binding_sid_label(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let value = op.is_set().then(|| args.u32()).flatten();
+    config_srp_leaf(bgp, &name, |p| p.binding_sid_label = value)
+}
+
+pub fn config_srp_binding_sid_sid(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let value = op.is_set().then(|| args.v6addr()).flatten();
+    config_srp_leaf(bgp, &name, |p| p.binding_sid_sid = value)
+}
+
+pub fn config_srp_route_target(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let value = op.is_set().then(|| args.v4addr()).flatten();
+    config_srp_leaf(bgp, &name, |p| p.route_target = value)
+}
+
+/// `set router bgp sr-policy policy <NAME> segment <INDEX>` presence.
+pub fn config_srp_segment(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let index = args.u32()?;
+    match op {
+        ConfigOp::Set => {
+            local_policy(bgp, &name).segments.entry(index).or_default();
+        }
+        ConfigOp::Delete => {
+            local_policy(bgp, &name).segments.remove(&index);
+        }
+        _ => {}
+    }
+    super::route::srpolicy_origin_sync(bgp, &name);
+    Some(())
+}
+
+pub fn config_srp_segment_mpls_label(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let index = args.u32()?;
+    let value = op.is_set().then(|| args.u32()).flatten();
+    local_policy(bgp, &name)
+        .segments
+        .entry(index)
+        .or_default()
+        .mpls_label = value;
+    super::route::srpolicy_origin_sync(bgp, &name);
+    Some(())
+}
+
+pub fn config_srp_segment_srv6_sid(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let index = args.u32()?;
+    let value = op.is_set().then(|| args.v6addr()).flatten();
+    local_policy(bgp, &name)
+        .segments
+        .entry(index)
+        .or_default()
+        .srv6_sid = value;
+    super::route::srpolicy_origin_sync(bgp, &name);
+    Some(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -864,5 +1115,121 @@ mod tests {
         assert_eq!(db.steer_mpls(200, nh, 0b01), None);
         // CO=11 is reserved → treated as 00 (exact only) → no match.
         assert_eq!(db.steer_mpls(100, nh, 0b11), None);
+    }
+
+    #[test]
+    fn local_policy_advert_builds_nlri_and_tunnel() {
+        let rid: Ipv4Addr = "1.1.1.1".parse().unwrap();
+        let mut policy = LocalSrPolicy {
+            color: Some(100),
+            endpoint: Some(endpoint("10.0.0.9")),
+            preference: Some(200),
+            binding_sid_label: Some(16100),
+            ..Default::default()
+        };
+        // Incomplete (no segments) → not advertisable.
+        assert!(policy.advert(rid).is_none());
+
+        policy.segments.insert(
+            1,
+            LocalSegment {
+                mpls_label: Some(16002),
+                srv6_sid: None,
+            },
+        );
+        policy.segments.insert(
+            2,
+            LocalSegment {
+                mpls_label: Some(16009),
+                srv6_sid: None,
+            },
+        );
+
+        let (nlri, attr) = policy.advert(rid).expect("advertisable");
+        assert_eq!(nlri.color, 100);
+        assert_eq!(nlri.endpoint, endpoint("10.0.0.9"));
+        assert_eq!(nlri.distinguisher, u32::from(rid));
+        // No route-target → NO_ADVERTISE attached, no ext-comms.
+        assert!(
+            attr.com
+                .as_ref()
+                .is_some_and(|c| c.contains(&CommunityValue::NO_ADVERTISE.value()))
+        );
+        assert!(attr.ecom.is_none());
+        // The Tunnel-Type-15 attribute decodes back to the policy content.
+        let te = attr.tunnel_encap.expect("tunnel encap");
+        let tlvs = bgp_packet::sr_policy_tlvs(&te)
+            .expect("type 15")
+            .expect("decode");
+        assert_eq!(tlvs.preference, Some(200));
+        assert_eq!(tlvs.binding_sid, Some(BindingSid::MplsLabel(16100)));
+        assert_eq!(tlvs.segment_lists.len(), 1);
+        assert_eq!(
+            tlvs.segment_lists[0].segments,
+            vec![
+                Segment::TypeA {
+                    flags: 0,
+                    label: 16002
+                },
+                Segment::TypeA {
+                    flags: 0,
+                    label: 16009
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn local_policy_advert_route_target_replaces_no_advertise() {
+        let rid: Ipv4Addr = "1.1.1.1".parse().unwrap();
+        let policy = LocalSrPolicy {
+            color: Some(7),
+            endpoint: Some(endpoint("2001:db8::9")),
+            route_target: Some("10.0.0.1".parse().unwrap()),
+            segments: BTreeMap::from([(
+                1,
+                LocalSegment {
+                    mpls_label: None,
+                    srv6_sid: Some("fc00:0:9::".parse().unwrap()),
+                },
+            )]),
+            ..Default::default()
+        };
+        let (nlri, attr) = policy.advert(rid).expect("advertisable");
+        assert_eq!(nlri.afi(), bgp_packet::Afi::Ip6);
+        // RT present → no NO_ADVERTISE; one IPv4-address-format RT.
+        assert!(attr.com.is_none());
+        let ecom = attr.ecom.expect("ext-comm");
+        assert_eq!(ecom.0.len(), 1);
+        assert_eq!(ecom.0[0].high_type, 0x01);
+        assert_eq!(ecom.0[0].low_type, ExtCommunitySubType::RouteTarget as u8);
+        assert_eq!(&ecom.0[0].val[0..4], &[10, 0, 0, 1]);
+    }
+
+    #[test]
+    fn local_policy_advert_rejects_mixed_segments() {
+        let rid: Ipv4Addr = "1.1.1.1".parse().unwrap();
+        let policy = LocalSrPolicy {
+            color: Some(1),
+            endpoint: Some(endpoint("10.0.0.9")),
+            segments: BTreeMap::from([
+                (
+                    1,
+                    LocalSegment {
+                        mpls_label: Some(16002),
+                        srv6_sid: None,
+                    },
+                ),
+                (
+                    2,
+                    LocalSegment {
+                        mpls_label: None,
+                        srv6_sid: Some("fc00::1".parse().unwrap()),
+                    },
+                ),
+            ]),
+            ..Default::default()
+        };
+        assert!(policy.advert(rid).is_none());
     }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -60,6 +60,10 @@ module config {
     prefix zbcp;
   }
 
+  import zebra-bgp-sr-policy {
+    prefix zbsp;
+  }
+
   import zebra-bgp-soft-reconfiguration {
     prefix zbsr;
   }

--- a/zebra-rs/yang/zebra-bgp-sr-policy.yang
+++ b/zebra-rs/yang/zebra-bgp-sr-policy.yang
@@ -1,0 +1,149 @@
+module zebra-bgp-sr-policy {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-sr-policy";
+  prefix "zbsp";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "Locally-originated BGP SR Policies (SAFI 73, RFC 9830). Each
+     configured policy is advertised to SR-Policy peers as an SR Policy
+     NLRI plus a Tunnel Encapsulation attribute (Tunnel-Type 15)
+     carrying the Preference, Binding SID, and an explicit Segment List.
+
+     A policy is advertised once it is complete (a color, an endpoint,
+     and at least one segment). When a `route-target` is configured it
+     is attached as an IPv4-address-format Route Target (RFC 9830 §4.1);
+     otherwise the NO_ADVERTISE community is attached so the policy stays
+     between directly-connected speakers.
+
+     Example:
+
+       router bgp 65000 {
+         sr-policy {
+           policy GREEN {
+             color 100;
+             endpoint 10.0.0.9;
+             preference 200;
+             binding-sid-label 16100;
+             segment 1 { mpls-label 16002; }
+             segment 2 { mpls-label 16009; }
+           }
+         }
+       }";
+
+  revision 2026-05-30 {
+    description
+      "Initial revision — config-defined local SR Policies advertised
+       as SAFI 73. Flat shape (one explicit segment list per policy);
+       the candidate-path / named-segment-list tree is a follow-up.";
+    reference
+      "RFC 9830 (Advertising SR Policies in BGP),
+       RFC 9256 (SR Policy Architecture).";
+  }
+
+  grouping bgp-sr-policy-extension {
+    description
+      "Container `sr-policy` under the BGP top-level holding the
+       locally-originated policies, keyed by a configuration name.";
+
+    container sr-policy {
+      ext:help "Locally-originated BGP SR Policies (SAFI 73)";
+      presence "Configure local SR Policies";
+
+      list policy {
+        ext:help "A local SR Policy, advertised as SAFI 73";
+        key name;
+        leaf name {
+          ext:help "Policy configuration name";
+          type string;
+        }
+        leaf color {
+          ext:help "Policy color (RFC 9256 §2.1, non-zero)";
+          type uint32;
+        }
+        leaf endpoint {
+          ext:help "Policy endpoint (IPv4 or IPv6; selects the NLRI AFI)";
+          type inet:ip-address;
+        }
+        leaf preference {
+          ext:help "Candidate-path preference (RFC 9256 default 100)";
+          type uint32;
+        }
+        leaf binding-sid-label {
+          ext:help "SR-MPLS Binding SID (MPLS label)";
+          type uint32;
+        }
+        leaf binding-sid-sid {
+          ext:help "SRv6 Binding SID";
+          type inet:ipv6-address;
+        }
+        leaf route-target {
+          ext:help "IPv4-address-format Route Target identifying the
+                    intended headend(s); when absent, NO_ADVERTISE is
+                    attached instead (RFC 9830 §4.1)";
+          type inet:ipv4-address;
+        }
+        list segment {
+          ext:help "Explicit segment, imposed in ascending index order";
+          key index;
+          leaf index {
+            ext:help "Segment position in the list";
+            type uint32;
+          }
+          leaf mpls-label {
+            ext:help "SR-MPLS label (Segment Type A)";
+            type uint32;
+          }
+          leaf srv6-sid {
+            ext:help "SRv6 SID (Segment Type B)";
+            type inet:ipv6-address;
+          }
+        }
+      }
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router/bgp:bgp" {
+    description
+      "Attach the sr-policy block to the BGP top-level in the
+       candidate-set subtree.";
+    uses bgp-sr-policy-extension;
+  }
+
+  augment "/configure:delete/config:router/bgp:bgp" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp sr-policy policy NAME ...` is path-valid.";
+    uses bgp-sr-policy-extension;
+  }
+}


### PR DESCRIPTION
## Summary

The SR Policy **originator**: locally-configured policies advertised as SAFI 73 (RFC 9830) — the last phase of the SR Policy series.

A new `zebra-bgp-sr-policy.yang` config tree defines policies under `router bgp sr-policy`:

```
router bgp 65000 {
  sr-policy {
    policy GREEN {
      color 100;
      endpoint 10.0.0.9;
      preference 200;
      binding-sid-label 16100;
      segment 1 { mpls-label 16002; }
      segment 2 { mpls-label 16009; }
    }
  }
}
```

A *complete* policy (color + endpoint + an all-one-type segment list) is advertised to SAFI-73 peers as an **SR Policy NLRI + a Tunnel-Type-15 Tunnel Encapsulation attribute** (built via `SrPolicyTlvs::to_tunnel`), with an IPv4-address-format **Route Target** when configured, else **NO_ADVERTISE** (RFC 9830 §4.1).

## Changes
- **`zebra-bgp-sr-policy.yang`** (new) + `config.yang` import: name-keyed `policy` with an index-keyed `segment` list (SR-MPLS label or SRv6 SID per segment).
- **`sr_policy.rs`**: `LocalSrPolicies`/`LocalSrPolicy` model (on `LocalRib`), `advert()` builds the NLRI+attr, and the `config_srp_*` callbacks stage edits + re-sync.
- **`update.rs`**: `pop_srpolicy` / `pop_srpolicy_withdraw` (mirror `pop_evpn`).
- **`route.rs`**: `srpolicy_origin_sync`/`reach`/`withdraw` (advertise on config-set, withdraw on delete/incomplete) + `route_sync_srpolicy` hooked into `route_sync` (dump on peer establish).
- **`config.rs`**: register the `sr-policy` callbacks.

## Design notes
- Local policies live on **`LocalRib`** so both config (`&mut Bgp`) and the establish-dump (`BgpTop`) reach them — **no `BgpTop` churn**. Emission is a **direct `packet_tx` send** (no Adj-RIB-Out cache/timer), so **`peer.rs` is untouched**.
- Distinguisher = the router-id (RFC 9830 §2.1 only needs uniqueness within `<color, endpoint>`).

## Scope (minimal, confirmed)
Flat per-policy config + advertise; one explicit segment list per policy. **Deferred**: the candidate-path / named-segment-list tree and route-reflector pass-through (adj-rib-in + reflect).

## Test plan
- `cargo test -p zebra-rs` — 755 passed (3 new `advert` build tests), 0 failed
- `cargo test -p bgp-packet` — passed; YANG load tests pass (new module loads)
- `cargo clippy --workspace --all-targets -- -D warnings` (clean cache) — clean
- `cargo fmt --all --check` — clean
- Live advertise validation needs a peer (deferred for the whole series); the build + serialization are unit-tested.

Generated with [Claude Code](https://claude.com/claude-code)