### PR TITLE
bgp: SR Policy route-reflector pass-through (SAFI 73)

### DIFF
--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -4030,20 +4030,23 @@ pub fn route_srpolicy_update(
     ident: usize,
     nlri: &SrPolicyNlri,
     attr: &BgpAttr,
+    nhop: IpAddr,
     bgp: &mut BgpTop,
     peers: &mut PeerMap,
 ) {
     use super::sr_policy::{self, Usability};
 
-    // RFC 9830 §4.2 distribution rules: a malformed or non-usable update
-    // is not consumed locally (reflection is a later phase).
-    if sr_policy::usability(attr, bgp.router_id) != Usability::Usable {
+    // RFC 9830 §4.2.1: an update carrying neither NO_ADVERTISE nor an
+    // IPv4-address Route Target is malformed — drop it entirely.
+    let usability = sr_policy::usability(attr, bgp.router_id);
+    if usability == Usability::Malformed {
         return;
     }
 
-    let originator = {
+    // RFC 4456 loop prevention — drop a looped update before reflecting
+    // or consuming it.
+    {
         let peer = peers.get_by_idx(ident).expect("peer must exist");
-
         if let Some(ref aspath) = attr.aspath {
             for segment in &aspath.segs {
                 if segment.asn.contains(&peer.local_as) {
@@ -4061,9 +4064,22 @@ pub fn route_srpolicy_update(
         {
             return;
         }
+    }
 
-        // RFC 9256 §2.4 originator = <ASN, node-address>: the ORIGINATOR_ID
-        // when route-reflected, else the advertising peer's router-id.
+    // Route-reflector pass-through: a valid update (usable or not) is
+    // reflected to other SAFI-73 peers per RR rules (unless NO_ADVERTISE).
+    srpolicy_reflect(ident, nlri, attr, nhop, bgp, peers);
+
+    // Consume into the local headend DB only when usable here (RFC 9830
+    // §4.2.2: an RT must match our BGP Identifier).
+    if usability != Usability::Usable {
+        return;
+    }
+
+    // RFC 9256 §2.4 originator = <ASN, node-address>: the ORIGINATOR_ID
+    // when route-reflected, else the advertising peer's router-id.
+    let originator = {
+        let peer = peers.get_by_idx(ident).expect("peer must exist");
         let node = attr
             .originator_id
             .as_ref()
@@ -4089,15 +4105,114 @@ pub fn route_srpolicy_update(
     sr_policy_mpls_sync(bgp, nlri.color, nlri.endpoint);
 }
 
-/// Withdraw one SR Policy NLRI from the headend database, re-run active
-/// candidate-path selection, and apply the dataplane delta.
-pub fn route_srpolicy_withdraw(ident: usize, nlri: &SrPolicyNlri, bgp: &mut BgpTop) {
+/// Withdraw one SR Policy NLRI from the headend database, reflect the
+/// withdrawal to other SAFI-73 peers, and apply the dataplane delta.
+pub fn route_srpolicy_withdraw(
+    ident: usize,
+    nlri: &SrPolicyNlri,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+) {
+    srpolicy_reflect_withdraw(ident, nlri, peers);
     let delta =
         bgp.local_rib
             .sr_policy
             .withdraw(nlri.color, nlri.endpoint, nlri.distinguisher, ident);
     apply_srpolicy_fib(delta, bgp);
     sr_policy_mpls_sync(bgp, nlri.color, nlri.endpoint);
+}
+
+/// Reflect a received SR Policy update to every other established
+/// SAFI-73 peer the RR rules permit (RFC 4456 / RFC 9830 §4). The
+/// received next-hop is preserved (an RR does not change it).
+fn srpolicy_reflect(
+    source_ident: usize,
+    nlri: &SrPolicyNlri,
+    attr: &BgpAttr,
+    nhop: IpAddr,
+    bgp: &mut BgpTop,
+    peers: &mut PeerMap,
+) {
+    let our_rid = *bgp.router_id;
+    let afi = nlri.afi();
+    let Some(src) = peers.get_by_idx(source_ident) else {
+        return;
+    };
+    let (source_ibgp, source_rid) = (src.is_ibgp(), src.remote_id);
+
+    let dests: Vec<IpAddr> = peers
+        .iter()
+        .filter(|(_, p)| p.ident != source_ident)
+        .filter(|(_, p)| p.state.is_established())
+        .filter(|(_, p)| p.is_afi_safi(afi, Safi::SrTePolicy))
+        .map(|(addr, _)| *addr)
+        .collect();
+    for daddr in dests {
+        let Some(peer) = peers.get_mut(&daddr) else {
+            continue;
+        };
+        let Some(out_attr) = super::sr_policy::reflect_attr(
+            attr,
+            source_ibgp,
+            source_rid,
+            peer.is_ibgp(),
+            peer.is_reflector_client(),
+            our_rid,
+        ) else {
+            continue;
+        };
+        let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+        update.mp_update = Some(MpReachAttr::SrPolicy {
+            afi,
+            snpa: 0,
+            nhop,
+            updates: vec![nlri.clone()],
+        });
+        update.bgp_attr = Some(out_attr);
+        if let Some(bytes) = update.pop_srpolicy()
+            && let Some(ref tx) = peer.packet_tx
+        {
+            let _ = tx.send(bytes);
+        }
+    }
+}
+
+/// Reflect a received SR Policy withdrawal to the RR-eligible peers.
+fn srpolicy_reflect_withdraw(source_ident: usize, nlri: &SrPolicyNlri, peers: &mut PeerMap) {
+    let afi = nlri.afi();
+    let Some(src) = peers.get_by_idx(source_ident) else {
+        return;
+    };
+    let source_ibgp = src.is_ibgp();
+    let dests: Vec<IpAddr> = peers
+        .iter()
+        .filter(|(_, p)| p.ident != source_ident)
+        .filter(|(_, p)| p.state.is_established())
+        .filter(|(_, p)| p.is_afi_safi(afi, Safi::SrTePolicy))
+        .map(|(addr, _)| *addr)
+        .collect();
+    for daddr in dests {
+        let Some(peer) = peers.get_mut(&daddr) else {
+            continue;
+        };
+        if !super::sr_policy::reflect_withdraw_to(
+            source_ibgp,
+            peer.is_ibgp(),
+            peer.is_reflector_client(),
+        ) {
+            continue;
+        }
+        let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+        update.mp_withdraw = Some(MpUnreachAttr::SrPolicy {
+            afi,
+            withdraws: vec![nlri.clone()],
+        });
+        if let Some(bytes) = update.pop_srpolicy_withdraw()
+            && let Some(ref tx) = peer.packet_tx
+        {
+            let _ = tx.send(bytes);
+        }
+    }
 }
 
 /// Realize an SR Policy active-path change in the dataplane: remove the
@@ -4673,12 +4788,12 @@ pub fn route_from_peer(
                     route_flowspec_update(peer_id, nlri, afi, bgp_attr, bgp, peers, false);
                 }
             }
-            MpReachAttr::SrPolicy { updates, .. } => {
+            MpReachAttr::SrPolicy { nhop, updates, .. } => {
                 // SAFI 73: candidate-path content rides in the Tunnel
                 // Encapsulation attribute; the NLRI endpoint carries the
                 // AFI, so v4/v6 share one path.
                 for nlri in updates.iter() {
-                    route_srpolicy_update(peer_id, nlri, bgp_attr, bgp, peers);
+                    route_srpolicy_update(peer_id, nlri, bgp_attr, nhop, bgp, peers);
                 }
             }
             MpReachAttr::Labelv4 {
@@ -4790,7 +4905,7 @@ pub fn route_from_peer(
             }
             MpUnreachAttr::SrPolicy { withdraws, .. } => {
                 for nlri in withdraws.iter() {
-                    route_srpolicy_withdraw(peer_id, nlri, bgp);
+                    route_srpolicy_withdraw(peer_id, nlri, bgp, peers);
                 }
                 // An empty `withdraws` is End-of-RIB; nothing to flush.
             }

--- a/zebra-rs/src/bgp/sr_policy.rs
+++ b/zebra-rs/src/bgp/sr_policy.rs
@@ -20,9 +20,9 @@ use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use bgp_packet::{
-    BgpAttr, BindingSid, Community, CommunityValue, ExtCommunity, ExtCommunitySubType,
-    ExtCommunityValue, Origin, Segment, SegmentList, SrPolicyNlri, SrPolicyTlvs, Srv6BindingSid,
-    TunnelEncap,
+    BgpAttr, BindingSid, ClusterList, Community, CommunityValue, ExtCommunity, ExtCommunitySubType,
+    ExtCommunityValue, Origin, OriginatorId, Segment, SegmentList, SrPolicyNlri, SrPolicyTlvs,
+    Srv6BindingSid, TunnelEncap,
 };
 
 use crate::config::{Args, ConfigOp};
@@ -751,6 +751,63 @@ pub fn config_srp_segment_srv6_sid(bgp: &mut Bgp, mut args: Args, op: ConfigOp) 
     Some(())
 }
 
+// =======================================================================
+// Route-reflector pass-through: reflect received SR Policies (SAFI 73).
+// =======================================================================
+
+/// The attribute to use when reflecting a received SR Policy update to
+/// one destination peer, or `None` if it must not be reflected to that
+/// peer.
+///
+/// - RFC 9830 §4.1: a policy carrying NO_ADVERTISE is never propagated.
+/// - RFC 4456: an iBGP-learned policy is reflected to an iBGP peer only
+///   if that peer is a route-reflector client.
+/// - On an iBGP→iBGP reflection the ORIGINATOR_ID is stamped (with the
+///   original advertiser's router-id if absent) and the local router-id
+///   is prepended to the CLUSTER_LIST.
+pub fn reflect_attr(
+    attr: &BgpAttr,
+    source_ibgp: bool,
+    source_router_id: Ipv4Addr,
+    dest_ibgp: bool,
+    dest_is_client: bool,
+    our_router_id: Ipv4Addr,
+) -> Option<BgpAttr> {
+    if attr
+        .com
+        .as_ref()
+        .is_some_and(|c| c.contains(&CommunityValue::NO_ADVERTISE.value()))
+    {
+        return None;
+    }
+    if source_ibgp && dest_ibgp && !dest_is_client {
+        return None;
+    }
+    let mut out = attr.clone();
+    if source_ibgp && dest_ibgp {
+        if out.originator_id.is_none() {
+            out.originator_id = Some(OriginatorId::new(source_router_id));
+        }
+        match out.cluster_list {
+            Some(ref mut cl) => cl.list.insert(0, our_router_id),
+            None => {
+                let mut cl = ClusterList::new();
+                cl.list.push(our_router_id);
+                out.cluster_list = Some(cl);
+            }
+        }
+    }
+    Some(out)
+}
+
+/// Whether a received SR Policy withdrawal should be reflected to a
+/// destination peer (RFC 4456 client rule; the NO_ADVERTISE check is
+/// moot for a withdraw — reflecting a never-advertised withdraw is a
+/// harmless no-op on the peer).
+pub fn reflect_withdraw_to(source_ibgp: bool, dest_ibgp: bool, dest_is_client: bool) -> bool {
+    !(source_ibgp && dest_ibgp && !dest_is_client)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1231,5 +1288,66 @@ mod tests {
             ..Default::default()
         };
         assert!(policy.advert(rid).is_none());
+    }
+
+    fn v4(s: &str) -> Ipv4Addr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn reflect_attr_suppresses_no_advertise() {
+        let attr = BgpAttr {
+            com: Some(Community(vec![CommunityValue::NO_ADVERTISE.value()])),
+            ..Default::default()
+        };
+        // NO_ADVERTISE → never reflected, regardless of peer roles.
+        assert!(reflect_attr(&attr, true, v4("2.2.2.2"), true, true, v4("1.1.1.1")).is_none());
+        assert!(reflect_attr(&attr, false, v4("2.2.2.2"), true, true, v4("1.1.1.1")).is_none());
+    }
+
+    #[test]
+    fn reflect_attr_ibgp_requires_client() {
+        let attr = BgpAttr::default();
+        // iBGP source → iBGP non-client dest: suppressed.
+        assert!(reflect_attr(&attr, true, v4("2.2.2.2"), true, false, v4("1.1.1.1")).is_none());
+        // iBGP source → iBGP client dest: reflected, with RR attrs stamped.
+        let out = reflect_attr(&attr, true, v4("2.2.2.2"), true, true, v4("1.1.1.1")).unwrap();
+        assert_eq!(out.originator_id.map(|o| o.id), Some(v4("2.2.2.2")));
+        assert_eq!(out.cluster_list.map(|c| c.list), Some(vec![v4("1.1.1.1")]));
+    }
+
+    #[test]
+    fn reflect_attr_preserves_existing_originator_and_prepends_cluster() {
+        let attr = BgpAttr {
+            originator_id: Some(OriginatorId::new(v4("9.9.9.9"))),
+            cluster_list: Some(ClusterList {
+                list: vec![v4("3.3.3.3")],
+            }),
+            ..Default::default()
+        };
+        let out = reflect_attr(&attr, true, v4("2.2.2.2"), true, true, v4("1.1.1.1")).unwrap();
+        // ORIGINATOR_ID preserved (not overwritten); our id prepended.
+        assert_eq!(out.originator_id.map(|o| o.id), Some(v4("9.9.9.9")));
+        assert_eq!(
+            out.cluster_list.map(|c| c.list),
+            Some(vec![v4("1.1.1.1"), v4("3.3.3.3")])
+        );
+    }
+
+    #[test]
+    fn reflect_attr_ebgp_source_no_rr_attrs() {
+        let attr = BgpAttr::default();
+        // eBGP source → iBGP dest: reflected without ORIGINATOR_ID /
+        // CLUSTER_LIST (it's a fresh iBGP advertisement).
+        let out = reflect_attr(&attr, false, v4("2.2.2.2"), true, false, v4("1.1.1.1")).unwrap();
+        assert!(out.originator_id.is_none());
+        assert!(out.cluster_list.is_none());
+    }
+
+    #[test]
+    fn reflect_withdraw_to_follows_client_rule() {
+        assert!(!reflect_withdraw_to(true, true, false)); // iBGP→iBGP non-client: no
+        assert!(reflect_withdraw_to(true, true, true)); // iBGP→iBGP client: yes
+        assert!(reflect_withdraw_to(false, true, false)); // eBGP→iBGP: yes
     }
 }


### PR DESCRIPTION
## Summary

Route-reflector pass-through for SR Policy (SAFI 73) — the deferred half of the originator phase. A received SR Policy update is now reflected to other SAFI-73 peers per RFC 4456 / RFC 9830 §4.

`route_srpolicy_update` is restructured to:
1. drop **malformed** updates (RFC 9830 §4.2.1: neither NO_ADVERTISE nor an IPv4-address RT),
2. drop **looped** updates (ORIGINATOR_ID == our id / CLUSTER_LIST contains us / our AS in the path),
3. **reflect** every *valid* update (usable or not) to the RR-eligible peers, then
4. **consume** locally only when usable (RFC 9830 §4.2.2: an RT matches our BGP Identifier).

A valid-but-not-locally-usable policy (RT doesn't match us) is now **reflected** rather than dropped.

## Changes
- **`sr_policy.rs`**: `reflect_attr(...)` — the per-destination decision (pure, unit-tested): NO_ADVERTISE → suppress (RFC 9830 §4.1); iBGP→iBGP only to route-reflector clients (RFC 4456); on iBGP→iBGP stamp ORIGINATOR_ID (original advertiser if absent) + prepend the local router-id to CLUSTER_LIST. Plus `reflect_withdraw_to(...)` for the withdraw client rule.
- **`route.rs`**: `srpolicy_reflect` / `srpolicy_reflect_withdraw` (per-dest gating + emit, reusing the PR7 `pop_srpolicy` path); the received **next-hop is preserved**; `nhop` is threaded through the receive dispatch + handler; withdrawals are reflected too.

## Design notes
- Mirrors the existing `route_update_ipv4` RR pattern (`Peer::reflector_client`, ORIGINATOR_ID/CLUSTER_LIST, loop-prevention) — no new RR machinery.
- **Reflect-on-receive** (no separate Adj-RIB-In / soft-reconfiguration — deferred).

## Test plan
- `cargo test -p zebra-rs` — 760 passed (5 new `reflect_attr` / `reflect_withdraw_to` decision tests), 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` (clean cache) — clean
- `cargo fmt --all --check` — clean
- Live reflection validation needs peers (deferred for the whole series); the reflect decision is unit-tested.

Generated with [Claude Code](https://claude.com/claude-code)