### PR TITLE
isis,bgp: wire BGP-LS producer (IS-IS LSDB -> BGP Loc-RIB)

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -61,6 +61,15 @@ pub enum Message {
     /// bucket, and ship to each member with split-horizon pruning.
     FlushUpdateGroupIpv4(super::update_group::UpdateGroupId),
     FlushUpdateGroupIpv6(super::update_group::UpdateGroupId),
+    /// BGP Link-State (RFC 9552) objects produced by the local IS-IS task
+    /// and pushed over the IS-IS→BGP channel. `add` are originated into the
+    /// `bgp_ls` Loc-RIB; `withdraw` are removed. The IS-IS producer diffs
+    /// against its own last-advertised set and sends only deltas, so this
+    /// carries exactly the change for one trigger.
+    BgpLs {
+        add: Vec<bgp_packet::BgpLsNlri>,
+        withdraw: Vec<bgp_packet::BgpLsNlri>,
+    },
 }
 
 pub type Callback = fn(&mut Bgp, Args, ConfigOp) -> Option<()>;
@@ -1060,6 +1069,22 @@ impl Bgp {
                     &mut self.peers,
                     &group_id,
                 );
+            }
+            Message::BgpLs { add, withdraw } => {
+                // Locally-produced BGP-LS (IS-IS producer, RFC 9552). Store
+                // into / remove from the `bgp_ls` Loc-RIB as Originated.
+                // Re-advertisement to peers is a later phase; this records
+                // the topology so `show bgp link-state` reflects it.
+                for nlri in &withdraw {
+                    super::route::route_bgpls_withdraw_originated(nlri, &mut self.local_rib);
+                }
+                for nlri in add {
+                    super::route::route_bgpls_originate(
+                        nlri,
+                        &mut self.local_rib,
+                        &mut self.attr_store,
+                    );
+                }
             }
         }
     }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -4429,6 +4429,46 @@ pub fn route_bgpls_withdraw(ident: usize, nlri: &BgpLsNlri, bgp: &mut BgpTop, pe
     let _ = bgp.local_rib.select_best_path_bgpls(nlri);
 }
 
+/// Originate one locally-produced BGP Link-State NLRI (RFC 9552) into the
+/// `bgp_ls` Loc-RIB as a self-originated route. Used by the IS-IS producer
+/// bridge: IS-IS translates its LSDB to `BgpLsNlri`s and pushes them here.
+///
+/// Unlike `route_bgpls_update` (the receive path, which looks up a real
+/// peer), this has no neighbor — it builds an `Originated` `BgpRib` keyed by
+/// `ORIGINATED_PEER` and inserts straight into the Loc-RIB, mirroring
+/// `evpn_originate_macip`. The attributes are empty for now (NLRI-only
+/// producer); BGP-LS Attribute (type 29) enrichment is a later phase.
+/// Re-advertisement to peers is likewise deferred — this records topology so
+/// `show bgp link-state` reflects it.
+pub fn route_bgpls_originate(
+    nlri: BgpLsNlri,
+    local_rib: &mut LocalRib,
+    attr_store: &mut super::store::BgpAttrStore,
+) {
+    let attr = BgpAttr::new();
+    let mut rib = BgpRib::new(
+        ORIGINATED_PEER,
+        Ipv4Addr::UNSPECIFIED,
+        BgpRibType::Originated,
+        0,     // remote_id — BGP-LS has no AddPath
+        32768, // weight — default for locally-originated
+        &attr,
+        None, // label
+        None, // nexthop
+        false,
+    );
+    rib.attr = attr_store.intern(attr);
+    let _ = local_rib.update_bgpls(nlri, rib);
+}
+
+/// Withdraw a previously-originated BGP-LS NLRI from the `bgp_ls` Loc-RIB
+/// (the IS-IS producer no longer advertises it). Removes the
+/// `ORIGINATED_PEER` candidate and re-runs best-path selection.
+pub fn route_bgpls_withdraw_originated(nlri: &BgpLsNlri, local_rib: &mut LocalRib) {
+    local_rib.remove_bgpls(nlri, 0, ORIGINATED_PEER);
+    let _ = local_rib.select_best_path_bgpls(nlri);
+}
+
 /// Realize an SR Policy active-path change in the dataplane: remove the
 /// previous SRv6 Binding SID and/or install the new one as an
 /// End.B6.Encaps local SID (RFC 8986 §4.14) pushing the policy's

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -468,6 +468,10 @@ impl BgpVrf {
                     &group_id,
                 );
             }
+            Message::BgpLs { .. } => {
+                // BGP-LS (RFC 9552) is produced and stored only by the
+                // global BGP instance — per-VRF tasks never see it.
+            }
         }
     }
 

--- a/zebra-rs/src/config/bgp.rs
+++ b/zebra-rs/src/config/bgp.rs
@@ -25,6 +25,11 @@ pub fn spawn_bgp(config: &ConfigManager) {
         nd_client_tx,
         config.tx.clone(),
     );
+    // Hand the IS-IS task a sender into BGP so the BGP-LS producer
+    // (RFC 9552) can push Link-State add/withdraw. `spawn_isis` captures
+    // this by value, so `commit_config` pre-spawns BGP before IS-IS when
+    // both land in one commit (mirrors the `bfd_client_tx` contract).
+    *config.bgp_tx.borrow_mut() = Some(bgp.tx.clone());
     config.subscribe("bgp", bgp.cm.tx.clone());
     config.subscribe_show("bgp", bgp.show.tx.clone());
     let task = inst::serve(bgp);

--- a/zebra-rs/src/config/isis.rs
+++ b/zebra-rs/src/config/isis.rs
@@ -12,9 +12,15 @@ pub fn spawn_isis(config: &ConfigManager) {
     // (the IS-IS arm there pre-spawns BFD on the will-set flag).
     // Callers that bypass `commit_config` may still see `None`.
     let bfd_client_tx = config.bfd_client_tx.borrow().clone();
+    // BGP-LS producer (RFC 9552): the IS-IS task pushes Link-State routes
+    // to BGP over this sender. Captured by value — `None` if `router bgp`
+    // is committed after `router isis` (cross-commit), matching the
+    // `bfd_client_tx` limitation; `commit_config` pre-spawns BGP first
+    // within a single commit.
+    let bgp_tx = config.bgp_tx.borrow().clone();
     let (rib_client, rib_rx) = config.subscribe_to_rib("isis");
     let ctx = ProtoContext::default_table(rib_client);
-    let isis = inst::Isis::new(ctx, rib_rx, bfd_client_tx, config.policy_tx.clone());
+    let isis = inst::Isis::new(ctx, rib_rx, bfd_client_tx, bgp_tx, config.policy_tx.clone());
     config.subscribe("isis", isis.cm.tx.clone());
     config.subscribe_show("isis", isis.show.tx.clone());
     let task = inst::serve(isis);

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -215,6 +215,13 @@ pub struct ConfigManager {
     /// kernel rejecting a socket option, …); consumers silently skip
     /// in that case.
     pub nd_client_tx: RefCell<Option<UnboundedSender<crate::nd::inst::NdClientReq>>>,
+    /// BGP task inbox sender, captured at `spawn_bgp` time so the IS-IS
+    /// task can push BGP Link-State (RFC 9552) producer routes to BGP.
+    /// Populated by [`super::bgp::spawn_bgp`]; `None` while no BGP task
+    /// exists. `spawn_isis` captures it by value, so `commit_config`
+    /// pre-spawns BGP before IS-IS when both appear in one commit (same
+    /// by-value contract as `bfd_client_tx`).
+    pub bgp_tx: RefCell<Option<mpsc::Sender<crate::bgp::inst::Message>>>,
     pub protocol_tasks: RefCell<HashMap<String, Task<()>>>,
     /// Runtime-mutable YANG-defined service-accounts (D25). Updated by
     /// `commit_config` when `vty service-account uid N` changes; read by
@@ -245,6 +252,7 @@ impl ConfigManager {
             cm_clients: RefCell::new(HashMap::new()),
             show_clients: RefCell::new(HashMap::new()),
             show_vrf_clients: RefCell::new(HashMap::new()),
+            bgp_tx: RefCell::new(None),
             rib_tx,
             rib_inbound_tx,
             next_proto_id: std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
@@ -452,6 +460,24 @@ impl ConfigManager {
                 break;
             }
         }
+        // Same by-value capture problem for the IS-IS→BGP BGP-LS producer
+        // channel: `spawn_isis` captures `bgp_tx` by value, so if this
+        // commit will set `router bgp` we must spawn BGP before IS-IS even
+        // if `router isis` appears first in the diff.
+        let mut will_set_bgp = false;
+        for line in diff.lines() {
+            let Some(first_char) = line.chars().next() else {
+                continue;
+            };
+            if first_char != '+' {
+                continue;
+            }
+            let line = remove_first_char(line);
+            if line.starts_with("router bgp") {
+                will_set_bgp = true;
+                break;
+            }
+        }
 
         for line in diff.lines() {
             let first_char = line.chars().next().unwrap();
@@ -489,6 +515,21 @@ impl ConfigManager {
                 if !bfd && will_set_bfd {
                     bfd = true;
                     spawn_bfd(self);
+                }
+                // Pre-spawn BGP if this commit will set it, so IS-IS
+                // captures a live `bgp_tx` for the BGP-LS producer (the
+                // sender is captured by value at `spawn_isis` time).
+                if !bgp && will_set_bgp {
+                    bgp = true;
+                    if !nd {
+                        nd = true;
+                        spawn_nd(self);
+                    }
+                    if !bfd && will_set_bfd {
+                        bfd = true;
+                        spawn_bfd(self);
+                    }
+                    spawn_bgp(self);
                 }
                 spawn_isis(self);
             }

--- a/zebra-rs/src/isis/bgp_ls.rs
+++ b/zebra-rs/src/isis/bgp_ls.rs
@@ -20,12 +20,7 @@
 // prefix attributes ride in the BGP-LS Attribute (type 29) and are a later
 // phase; this slice emits NLRIs only.
 
-// Phase 6a is the translation only; the IS-IS event loop does not call
-// `lsp_to_nlris` until the producer wiring lands in 6b. `zebra-rs` is a
-// binary crate, so these not-yet-called items would trip `dead_code` under
-// CI's `-D warnings`. Allow it here with this note rather than scatter
-// per-item attributes; 6b removes the need.
-#![allow(dead_code)]
+use std::collections::BTreeSet;
 
 use bgp_packet::{
     BgpLsNlri, LsLinkDescriptor, LsLinkNlri, LsNodeDescSub, LsNodeDescriptor, LsNodeNlri,
@@ -36,6 +31,7 @@ use isis_packet::{
     IsisLsp, IsisSysId, IsisTlv, IsisTlvExtIpReachEntry, IsisTlvExtIsReachEntry,
     IsisTlvIpv6ReachEntry,
 };
+use tokio::sync::mpsc::Sender;
 
 use super::level::Level;
 
@@ -190,9 +186,123 @@ pub fn lsp_to_nlris(level: Level, lsp: &IsisLsp) -> Vec<BgpLsNlri> {
     out
 }
 
+/// Walk both IS-IS levels' LSDBs, translate every LSP to its BGP-LS NLRIs,
+/// diff the resulting set against `advertised` (what we last pushed to BGP),
+/// and send only the add/withdraw deltas over `bgp_tx`. `advertised` is
+/// updated to the new set. No-op when BGP is not wired (`bgp_tx` is `None`)
+/// or nothing changed.
+///
+/// This is the producer trigger, called from the IS-IS event loop on
+/// `SpfDone` (the LSDB is settled at that point). The diff gives RFC 9552
+/// §5.2 withdraw-old-on-change for free: an object that disappears from the
+/// LSDB (or whose descriptors change, making it a different NLRI key) shows
+/// up in `withdraw`. The two-way connectivity check on Link NLRIs is a
+/// deferred follow-up; today a link is advertised as soon as one endpoint's
+/// LSP lists the adjacency.
+pub fn produce(
+    lsdb: &super::level::Levels<super::lsdb::Lsdb>,
+    advertised: &mut BTreeSet<BgpLsNlri>,
+    bgp_tx: Option<&Sender<crate::bgp::inst::Message>>,
+) {
+    let Some(tx) = bgp_tx else {
+        return;
+    };
+
+    let mut current: BTreeSet<BgpLsNlri> = BTreeSet::new();
+    for level in [super::level::Level::L1, super::level::Level::L2] {
+        for lsa in lsdb.get(&level).values() {
+            for nlri in lsp_to_nlris(level, &lsa.lsp) {
+                current.insert(nlri);
+            }
+        }
+    }
+
+    let add: Vec<BgpLsNlri> = current.difference(advertised).cloned().collect();
+    let withdraw: Vec<BgpLsNlri> = advertised.difference(&current).cloned().collect();
+    if add.is_empty() && withdraw.is_empty() {
+        return;
+    }
+
+    // BGP's inbox is a bounded channel and the IS-IS event loop is sync, so
+    // use `try_send`. On the rare full-channel case, skip the update without
+    // touching `advertised` so the next trigger re-diffs and retries the
+    // whole delta (idempotent — add/withdraw are set operations).
+    match tx.try_send(crate::bgp::inst::Message::BgpLs { add, withdraw }) {
+        Ok(()) => *advertised = current,
+        Err(e) => {
+            tracing::warn!("bgp-ls producer: BGP inbox send failed, will retry: {e}");
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build a one-entry L2 LSDB level wrapper from a single LSP.
+    fn levels_with_l2(lsp: IsisLsp) -> crate::isis::level::Levels<crate::isis::lsdb::Lsdb> {
+        let mut l2 = crate::isis::lsdb::Lsdb::default();
+        l2.map.insert(
+            lsp.lsp_id,
+            crate::isis::lsdb::Lsa {
+                lsp,
+                originated: true,
+                hold_timer: None,
+                refresh_timer: None,
+                ifindex: 0,
+                bytes: vec![],
+                last_received: None,
+            },
+        );
+        crate::isis::level::Levels {
+            l1: crate::isis::lsdb::Lsdb::default(),
+            l2,
+        }
+    }
+
+    #[test]
+    fn produce_emits_add_then_diff_then_withdraw() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let mut advertised: std::collections::BTreeSet<BgpLsNlri> =
+            std::collections::BTreeSet::new();
+
+        // First trigger: one node LSP → one add, nothing withdrawn.
+        let levels = levels_with_l2(lsp(sysid(1), 0, 0, vec![]));
+        produce(&levels, &mut advertised, Some(&tx));
+        assert_eq!(advertised.len(), 1);
+        match rx.try_recv() {
+            Ok(crate::bgp::inst::Message::BgpLs { add, withdraw }) => {
+                assert_eq!(add.len(), 1);
+                assert!(withdraw.is_empty());
+            }
+            other => panic!("expected BgpLs add, got {other:?}"),
+        }
+
+        // Second trigger, identical LSDB: no delta, no message.
+        produce(&levels, &mut advertised, Some(&tx));
+        assert!(rx.try_recv().is_err(), "no message expected on no-op diff");
+
+        // Topology gone: the node is withdrawn.
+        let empty = crate::isis::level::Levels::<crate::isis::lsdb::Lsdb>::default();
+        produce(&empty, &mut advertised, Some(&tx));
+        assert!(advertised.is_empty());
+        match rx.try_recv() {
+            Ok(crate::bgp::inst::Message::BgpLs { add, withdraw }) => {
+                assert!(add.is_empty());
+                assert_eq!(withdraw.len(), 1);
+            }
+            other => panic!("expected BgpLs withdraw, got {other:?}"),
+        }
+    }
+
+    /// `produce` is a no-op when BGP isn't wired (`bgp_tx` is `None`).
+    #[test]
+    fn produce_noop_without_bgp() {
+        let mut advertised = std::collections::BTreeSet::new();
+        let levels = levels_with_l2(lsp(sysid(1), 0, 0, vec![]));
+        produce(&levels, &mut advertised, None);
+        assert!(advertised.is_empty());
+    }
     use isis_packet::{
         IsisLspId, IsisNeighborId, IsisTlvExtIpReach, IsisTlvExtIsReach, IsisTlvExtIsReachEntry,
     };

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -395,6 +395,14 @@ pub struct Isis {
     /// `ConfigManager::bfd_client_tx`; not refreshed if BFD respawns
     /// later (late-binding refresh is a follow-up).
     pub bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
+    /// BGP task inbox, for pushing BGP Link-State (RFC 9552) producer
+    /// routes. `None` when no BGP task exists (BGP not configured, or
+    /// configured in a later commit than `router isis`).
+    pub bgp_tx: Option<mpsc::Sender<crate::bgp::inst::Message>>,
+    /// BGP-LS objects last advertised to BGP, so the producer emits only
+    /// deltas (add/withdraw) on each SPF trigger rather than the full set
+    /// (RFC 9552 §5.2 — withdraw-old-on-change).
+    pub bgp_ls_advertised: std::collections::BTreeSet<bgp_packet::BgpLsNlri>,
     /// Sender half of the per-instance `BfdEvent` channel, cloned and
     /// handed to BFD as the `notifier` on every `Subscribe`.
     pub bfd_event_tx: UnboundedSender<crate::bfd::inst::BfdEvent>,
@@ -548,6 +556,7 @@ impl Isis {
         ctx: ProtoContext,
         rib_rx: UnboundedReceiver<RibRx>,
         bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
+        bgp_tx: Option<mpsc::Sender<crate::bgp::inst::Message>>,
         policy_tx: UnboundedSender<crate::policy::Message>,
     ) -> Self {
         let policy_chan = crate::policy::PolicyRxChannel::new();
@@ -648,6 +657,8 @@ impl Isis {
                 srlg_config: SrlgGroupBuilder::new(),
                 srlg_groups: BTreeMap::new(),
                 bfd_client_tx,
+                bgp_tx,
+                bgp_ls_advertised: std::collections::BTreeSet::new(),
                 bfd_event_tx,
                 bfd_event_rx,
                 key_chains: BTreeMap::new(),
@@ -1398,6 +1409,11 @@ impl Isis {
                 if std::mem::take(top.spf_pending.get_mut(&level)) {
                     let _ = self.tx.send(Message::SpfCalc(level));
                 }
+                // The LSDB is settled after SPF — push the BGP-LS producer's
+                // delta to BGP (RFC 9552). `top` is no longer used, so its
+                // mutable borrow of `self` has ended (NLL) and the disjoint
+                // field borrows inside `bgp_ls_produce` are free.
+                self.bgp_ls_produce();
             }
             Message::Recv(packet, ifindex, mac) => {
                 let Some(mut top) = self.link_top(ifindex) else {
@@ -1493,6 +1509,18 @@ impl Isis {
 
     /// Forward a `Subscribe` to the BFD instance with `"isis"` as the
     /// ClientId. No-op when BFD is not configured.
+    /// Drive the BGP-LS producer (RFC 9552): re-walk the LSDB, diff against
+    /// the last-advertised set, and push add/withdraw deltas to BGP. The
+    /// three field borrows are disjoint, so this `&mut self` method composes
+    /// cleanly. No-op when BGP isn't wired (`bgp_tx` is `None`).
+    fn bgp_ls_produce(&mut self) {
+        super::bgp_ls::produce(
+            &self.lsdb,
+            &mut self.bgp_ls_advertised,
+            self.bgp_tx.as_ref(),
+        );
+    }
+
     fn process_bfd_subscribe(&self, key: crate::bfd::session::SessionKey) {
         let Some(tx) = self.bfd_client_tx.as_ref() else {
             tracing::debug!(?key, "isis: bfd not configured; skipping subscribe");
@@ -2498,7 +2526,7 @@ mod bfd_wiring_tests {
         // Park the policy_rx so the Subscribe send in `new` doesn't
         // drop and panic on its own send.
         Box::leak(Box::new(policy_rx));
-        let isis = Isis::new(ctx, rib_rx, Some(bfd_client_tx), policy_tx);
+        let isis = Isis::new(ctx, rib_rx, Some(bfd_client_tx), None, policy_tx);
         (isis, bfd_client_rx)
     }
 
@@ -2544,7 +2572,7 @@ mod bfd_wiring_tests {
         let (ctx, rib_rx) = test_ctx();
         let (policy_tx, policy_rx) = mpsc::unbounded_channel();
         Box::leak(Box::new(policy_rx));
-        let isis = Isis::new(ctx, rib_rx, None, policy_tx);
+        let isis = Isis::new(ctx, rib_rx, None, None, policy_tx);
         let key = loopback_key();
         isis.process_bfd_subscribe(key);
         isis.process_bfd_unsubscribe(key);


### PR DESCRIPTION
## Summary

Phase 6b of BGP Link-State (RFC 9552) — makes the IS-IS→BGP **producer**
live. The 6a translation (`isis/bgp_ls.rs::lsp_to_nlris`, #1080) is now
driven on SPF convergence and pushed to BGP over a new IS-IS→BGP channel,
where it lands in the `bgp_ls` Loc-RIB (Phase 4) as locally-originated and
surfaces in `show bgp link-state` (Phase 5). Builds on Phases 1-5 + 6a.

### Channel wiring (mirrors the `bfd_client_tx` precedent)
- `config/manager.rs`: `ConfigManager.bgp_tx` cell (+ initializer);
  `will_set_bgp` pre-scan + pre-spawn BGP before IS-IS in `commit_config`
  (`spawn_isis` captures `bgp_tx` by value, same contract as BFD).
- `config/bgp.rs`: populate `bgp_tx` at `spawn_bgp`.
- `config/isis.rs`: capture `bgp_tx`, pass to `Isis::new`.
- `isis/inst.rs`: `Isis.bgp_tx` + `bgp_ls_advertised` (last-pushed set)
  fields; `new()` threading; `bgp_ls_produce()` method; `SpfDone` hook.

### BGP receive side
- `bgp/inst.rs`: `Message::BgpLs{add,withdraw}` + `process_msg` handler +
  span arm.
- `bgp/route.rs`: `route_bgpls_originate` / `route_bgpls_withdraw_originated`
  (`ORIGINATED_PEER` + `BgpRibType::Originated`, straight into
  `local_rib.update_bgpls` — the receive path's peer lookup can't take a
  synthetic ident).

### Producer driver (`isis/bgp_ls.rs::produce`)
Walk both levels' LSDBs, translate, diff against the advertised set, send
only add/withdraw deltas — RFC 9552 §5.2 withdraw-old-on-change for free.
Bounded BGP inbox + sync IS-IS loop → `try_send`, leaving `advertised`
untouched on a full channel so the next trigger retries. Drops 6a's
`#![allow(dead_code)]`.

### Deferred (follow-ups)
- Two-way connectivity check on Link NLRIs (advertised one-way for now).
- Re-advertisement of `bgp_ls` to BGP peers.
- BGP-LS Attribute (type 29) enrichment (Phase 7).
- Cross-commit "`router bgp` after `router isis`" leaves the producer dark
  until restart — same limitation as `bfd_client_tx`.

### Test plan
- `cargo build -p zebra-rs` — clean
- `cargo test -p isis-packet -p zebra-rs` — 1047 passed, 0 failed (incl. 2 new producer-diff tests)
- `cargo fmt --all` + `cargo clippy --workspace --all-targets -- -D warnings` — clean

Generated with [Claude Code](https://claude.com/claude-code)