### PR TITLE
ospf: stage Flex-Algorithm config (v2) — defs + global tables

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -162,6 +162,17 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// consumed by `nssa_redist_connected_resync` when origination
     /// state needs to be rebuilt (config change, area-type flip).
     pub redist_v4: BTreeMap<(crate::rib::RibType, Ipv4Net), crate::rib::RouteEntryV4>,
+    /// Staged Flexible Algorithm definitions for this instance
+    /// (`/router/ospf{,v3}/flex-algo`, RFC 9350). Shared staging engine
+    /// keyed by the version's `FLEX_ALGO_PREFIX`; origination from the
+    /// committed entries lands in a later phase.
+    pub flex_algo: crate::flex_algo::FlexAlgoConfig,
+    /// This instance's copy of the global `/affinity-map` table,
+    /// resolving affinity names to RFC 7308 admin-group bit positions.
+    /// Fed by the config broadcast; shared by all IGPs.
+    pub affinity_map: crate::flex_algo::AffinityMap,
+    /// This instance's staging of the global `/srlg` table.
+    pub srlg_config: crate::flex_algo::SrlgGroupBuilder,
     /// v3-only outbound packet channel. `Ospf<Ospfv3>::new` spawns
     /// `network_v6::write_packet_v6` consuming the matching receiver;
     /// producers of v3 outgoing packets clone this sender to push
@@ -255,6 +266,30 @@ impl<'a, V: OspfVersion> OspfInterface<'a, V> {
 // the v2-shaped tx channel) and produce `OspfInterface<V>` /
 // `&Neighbor<V>` values typed by `V`.
 impl<V: OspfVersion> Ospf<V> {
+    /// Stage a flex-algo (`{V::FLEX_ALGO_PREFIX}/...`), `/affinity-map`
+    /// or `/srlg/group` config leaf into its builder. The caller gates
+    /// on the path prefix and returns early after this; the staged
+    /// values apply at `CommitEnd` via `commit_flex_algo_tables`.
+    fn flex_algo_table_exec(&mut self, path: String, args: Args, op: ConfigOp) {
+        if path.starts_with(V::FLEX_ALGO_PREFIX) {
+            let _ = self.flex_algo.exec(path, args, op);
+        } else if path.starts_with("/affinity-map") {
+            let _ = self.affinity_map.exec(path, args, op);
+        } else if path.starts_with("/srlg/group") {
+            let _ = self.srlg_config.exec(path, args, op);
+        }
+    }
+
+    /// Apply the staged flex-algo / affinity-map / SRLG tables at the
+    /// end of a commit cycle. Origination from the committed config
+    /// (FAD / SR-Algorithm / per-link ASLA) lands in a later phase, so
+    /// there are no LSA side effects here yet.
+    fn commit_flex_algo_tables(&mut self) {
+        self.flex_algo.commit();
+        self.affinity_map.commit();
+        let _ = self.srlg_config.commit();
+    }
+
     pub fn ospf_interface<'a>(
         &'a mut self,
         ifindex: u32,
@@ -486,6 +521,9 @@ impl Ospf<Ospfv2> {
             spf_last: None,
             spf_duration: None,
             redist_v4: BTreeMap::new(),
+            flex_algo: crate::flex_algo::FlexAlgoConfig::new(Ospfv2::FLEX_ALGO_PREFIX),
+            affinity_map: crate::flex_algo::AffinityMap::new(),
+            srlg_config: crate::flex_algo::SrlgGroupBuilder::new(),
             sock,
             v3_send_tx: None,
             v3_recv_rx: None,
@@ -513,6 +551,14 @@ impl Ospf<Ospfv2> {
     pub fn process_cm_msg(&mut self, msg: ConfigRequest) {
         let (path, args) = path_from_command(&msg.paths);
 
+        // Apply the flex-algo / affinity-map / SRLG staging at the end
+        // of a commit cycle (mirrors IS-IS). Nothing else handles
+        // CommitEnd on the v2 instance today.
+        if msg.op == ConfigOp::CommitEnd {
+            self.commit_flex_algo_tables();
+            return;
+        }
+
         // Clear ops bypass the YANG callback table — they map
         // straight to runtime side-effects (kick SPF, drop a peer,
         // ...) the way `clear ip bgp` works in BGP. Other op-codes
@@ -534,6 +580,18 @@ impl Ospf<Ospfv2> {
             } else if path == "/clear/ospf/graceful-restart/commit" {
                 let _ = self.gr_restart_commit();
             }
+            return;
+        }
+
+        // Flex-algo definitions (`/router/ospf/flex-algo`) and the
+        // global `/affinity-map` / `/srlg` tables stage into their
+        // builders here and apply at CommitEnd; the registry callbacks
+        // below don't cover them.
+        if path.starts_with(Ospfv2::FLEX_ALGO_PREFIX)
+            || path.starts_with("/affinity-map")
+            || path.starts_with("/srlg/group")
+        {
+            self.flex_algo_table_exec(path, args, msg.op);
             return;
         }
 
@@ -3564,6 +3622,9 @@ impl Ospf<Ospfv3> {
             spf_last: None,
             spf_duration: None,
             redist_v4: BTreeMap::new(),
+            flex_algo: crate::flex_algo::FlexAlgoConfig::new(Ospfv3::FLEX_ALGO_PREFIX),
+            affinity_map: crate::flex_algo::AffinityMap::new(),
+            srlg_config: crate::flex_algo::SrlgGroupBuilder::new(),
             sock,
             v3_send_tx: Some(v3_send_tx),
             v3_recv_rx: Some(v3_recv_rx),

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -103,6 +103,12 @@ pub trait OspfVersion: 'static + Send + Sync + Copy + Clone + PartialEq + Eq {
     /// (RFC 2328 §A and RFC 5340 §2.3).
     const IP_PROTO: u8 = 89;
 
+    /// Config subtree carrying this version's Flexible Algorithm
+    /// definitions: `/router/ospf/flex-algo` (v2) or
+    /// `/router/ospfv3/flex-algo` (v3). Per-leaf paths are
+    /// `{FLEX_ALGO_PREFIX}/...`.
+    const FLEX_ALGO_PREFIX: &'static str;
+
     /// AllSPFRouters multicast group: 224.0.0.5 (v2) or ff02::5 (v3).
     const ALL_SPF_ROUTERS: Self::Addr;
 
@@ -326,6 +332,7 @@ impl OspfVersion for Ospfv2 {
     type Options = OspfOptions;
     type LsRequest = OspfLsRequest;
     type LsRequestEntry = OspfLsRequestEntry;
+    const FLEX_ALGO_PREFIX: &'static str = "/router/ospf/flex-algo";
     const ALL_SPF_ROUTERS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 5);
     const ALL_DROUTERS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 6);
 
@@ -433,6 +440,7 @@ impl OspfVersion for Ospfv3 {
     type Options = Ospfv3Options;
     type LsRequest = Ospfv3LsRequest;
     type LsRequestEntry = Ospfv3LsRequestEntry;
+    const FLEX_ALGO_PREFIX: &'static str = "/router/ospfv3/flex-algo";
     /// AllSPFRouters in v3 (RFC 5340 §A.1): `ff02::5`.
     const ALL_SPF_ROUTERS: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 5);
     /// AllDRouters in v3 (RFC 5340 §A.1): `ff02::6`.

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -532,6 +532,92 @@ module config {
             presence "Enable Segment Routing over MPLS dataplane";
           }
         }
+
+        list flex-algo {
+          // OSPFv2 Flexible Algorithm (RFC 9350 §6) definition. Mirrors
+          // `router isis / flex-algo`; keyed by the on-the-wire numeric
+          // identifier (128..255). `advertise-definition true` causes
+          // this router to originate the FAD TLV in its Router
+          // Information Opaque LSA (RFC 9350 §6.1, RI TLV 16); without
+          // it the router participates using a FAD learned from another
+          // node. At least one (preferably two) routers per area MUST
+          // advertise the definition.
+          key "algo";
+          leaf algo {
+            type uint8 { range "128..255"; }
+            description
+              "Flex-Algorithm identifier (RFC 9350 §4). 0..127 are
+               reserved by IANA; 128..255 are user-defined.";
+          }
+
+          leaf advertise-definition {
+            type boolean;
+            default false;
+            description
+              "When true, originate the FAD TLV for this algorithm in
+               the Router Information Opaque LSA. If no router in the
+               area advertises the FAD, every participant fails to
+               compute paths.";
+          }
+
+          leaf metric-type {
+            type enumeration {
+              enum igp;                   // FAD Metric-Type 0
+              enum min-unidir-link-delay; // FAD Metric-Type 1 (RFC 8570)
+              enum te-default;            // FAD Metric-Type 2 (RFC 5305)
+            }
+            default igp;
+          }
+
+          leaf priority {
+            // FAD Priority (RFC 9350 §6.5). Tie-breaker when more than
+            // one router originates a FAD for the same algo; higher
+            // priority wins.
+            type uint8;
+            default 128;
+          }
+
+          leaf prefix-metric {
+            // M-flag in the FAD Flags sub-TLV (RFC 9350 §6.4). When set,
+            // the computed path metric to a prefix includes the
+            // advertised Flexible Algorithm Prefix Metric.
+            type boolean;
+            default false;
+          }
+
+          container dataplane {
+            // Per-algorithm dataplane participation. OSPFv2 carries SR
+            // over MPLS only (no OSPFv2 SRv6); the `ip` flag selects
+            // plain IP forwarding for the algo's computed paths.
+            leaf sr-mpls { type boolean; default false; }
+            leaf ip      { type boolean; default false; }
+          }
+
+          container affinity {
+            // FAD Exclude / Include-Any / Include-All Admin Group
+            // sub-TLVs (RFC 9350 §6.2-6.4). Each leaf-list value is a
+            // name from the global /affinity-map table.
+            leaf-list include-any { type string; }
+            leaf-list include-all { type string; }
+            leaf-list exclude-any { type string; }
+          }
+
+          leaf-list srlg-exclude {
+            // FAD Exclude SRLG sub-TLV (RFC 9350 §6.5). Each entry
+            // references a /srlg/group name.
+            type string;
+          }
+
+          container fast-reroute {
+            // Per-algo TI-LFA toggle. Empty container is a no-op; the
+            // child presence container turns the per-algo TI-LFA
+            // computation on (deferred — no OSPF TI-LFA yet).
+            container ti-lfa {
+              presence "Enable Topology-Independent LFA for this flex-algo";
+            }
+          }
+        }
+
         container graceful-restart {
           // RFC 3623 helper-side configuration. zebra-rs is
           // helper-only today (Phase 5 restarter mode is deferred).


### PR DESCRIPTION
Phase 2b of OSPF Flex-Algorithm (RFC 9350): wire **OSPFv2** Flex-Algo configuration into the `Ospf<V>` instance. **Config-plumbing only** — origination, SPF, and show land in later phases. Builds directly on the shared `crate::flex_algo` engine (#1081/#1086/#1089).

## Changes
- `Ospf<V>` gains three config tables, all from `crate::flex_algo`: `flex_algo` (`FlexAlgoConfig`), `affinity_map` (`AffinityMap`), `srlg_config` (`SrlgGroupBuilder`).
- `OspfVersion::FLEX_ALGO_PREFIX` gives each version its config subtree (`/router/ospf/flex-algo` vs `/router/ospfv3/flex-algo`); the v2 constructor seeds `FlexAlgoConfig` with it.
- `process_cm_msg` (v2) dispatches `/router/ospf/flex-algo` + the **global** `/affinity-map` and `/srlg/group` paths into their builders and applies them at `CommitEnd` — mirrors the IS-IS staging. Two generic helpers (`flex_algo_table_exec` / `commit_flex_algo_tables`) live on `impl<V>`, so the v3 phase reuses them.
- **YANG**: add the `/router/ospf/flex-algo` list (mirrors the IS-IS shape; MPLS-only dataplane since OSPFv2 has no SRv6). Affinity/SRLG names reference the global `/affinity-map` + `/srlg` tables.

## Scope
v3 constructs the same fields (shared struct) but its `process_cm_msg` dispatch + `/router/ospfv3/flex-algo` YANG come with the v3 phase. Per-interface `affinity` (link attributes) is a follow-up (needs `LinkConfig` + interface YANG).

## Verification
- `yang_load_tests` guard passes (the new flex-algo list is valid YANG)
- Full `zebra-rs` unit suite: **769 passed**, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)