### PR TITLE
ospf: per-interface affinity (admin-group) config (v2)

### DIFF
--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -62,6 +62,7 @@ impl Ospf {
             config_ospf_interface_network_type,
         );
         self.ospf_add("/area/interface/priority", config_ospf_interface_priority);
+        self.ospf_add("/area/interface/affinity", config_ospf_interface_affinity);
         self.ospf_add(
             "/area/interface/hello-interval",
             config_ospf_interface_hello_interval,
@@ -541,6 +542,26 @@ fn config_ospf_interface_priority(ospf: &mut Ospf, mut args: Args, op: ConfigOp)
         .tx
         .send(Message::Ifsm(ifindex, IfsmEvent::NeighborChange));
 
+    Some(())
+}
+
+// `/router/ospf/area/interface/affinity` — one call per affinity name
+// on the leaf-list. Each name references a global `/affinity-map`
+// entry; the bit positions are resolved at LSA-build time, so we only
+// stage the names here (matching the per-interface IS-IS handler).
+// Extended-Link ASLA origination from these names lands with flex-algo
+// origination (RFC 9350 §6.3); for now this is pure config staging.
+fn config_ospf_interface_affinity(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let affinity = args.string()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config.affinity.insert(affinity);
+    } else {
+        link.config.affinity.remove(&affinity);
+    }
     Some(())
 }
 

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -1,7 +1,10 @@
 use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::{collections::BTreeMap, net::Ipv4Addr};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    net::Ipv4Addr,
+};
 
 use bitfield_struct::bitfield;
 use netlink_packet_route::link::LinkFlags;
@@ -99,6 +102,12 @@ pub struct LinkConfig {
     /// (`KeyChain::active_send_key(now)`) and receive-side
     /// validation (`KeyChain::lookup_recv_key(key_id, now)`).
     pub key_chain: Option<String>,
+    /// Names of `/affinity-map` entries this link carries. Resolved to
+    /// an Extended Admin Group bitmap (RFC 7308) and advertised in the
+    /// link's ASLA sub-TLV (RFC 9492) by flex-algo origination, and
+    /// tested against each FAD's include/exclude constraints at
+    /// per-algo SPF time. Mirrors `isis::LinkConfig::affinity`.
+    pub affinity: BTreeSet<String>,
 }
 
 /// OSPFv2 per-interface authentication mode.

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -521,6 +521,13 @@ module config {
                 type uint32;
               }
             }
+            leaf-list affinity {
+              // Names of /affinity-map entries this link carries.
+              // Advertised as an Extended Admin Group bitmap inside the
+              // ASLA sub-TLV (RFC 9492) and tested against each FAD's
+              // include/exclude constraints at flex-algo SPF time.
+              type string;
+            }
           }
         }
         container segment-routing {


### PR DESCRIPTION
Phase 2c of OSPF Flex-Algorithm (RFC 9350): add the **per-link `affinity`** leaf-list for OSPFv2 — the admin-group names that resolve to a link's Extended Admin Group bitmap. Config staging only; the consumer (Extended-Link ASLA origination) lands in the origination phase.

## Changes
- `LinkConfig` gains `affinity: BTreeSet<String>` (mirrors `isis::LinkConfig::affinity`).
- `config_ospf_interface_affinity` stages each name into the link's set, registered at `/router/ospf/area/interface/affinity`.
- **YANG**: `leaf-list affinity` under the OSPF interface list; names reference the global `/affinity-map` table.

These names will be (a) advertised as an Extended Admin Group inside the link's ASLA sub-TLV (RFC 9492, codec from #1084) and (b) tested against each FAD's include/exclude constraints at per-algo SPF time.

## Verification
- `yang_load_tests` guard passes
- Full `zebra-rs` unit suite: **769 passed**, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)