### PR TITLE
ospf: advertise configured flex-algos in SR-Algorithm TLV (v2)

### DIFF
--- a/zebra-rs/src/flex_algo/config.rs
+++ b/zebra-rs/src/flex_algo/config.rs
@@ -1,10 +1,31 @@
 use std::collections::BTreeMap;
 
 use anyhow::{Context, Result, bail};
+use packet_utils::Algo;
 
 use crate::config::{Args, ConfigOp};
 
 use super::entry::FlexAlgoEntry;
+
+/// Algorithms this router advertises in the SR-Algorithm advertisement
+/// (IS-IS sub-TLV 19, RFC 8667 §3.2; OSPF RI TLV 8, RFC 8665 §3.1).
+/// `Algo::Spf` (algo 0) is always present; every flex-algo entry in
+/// `fa.config` is added as `Algo::FlexAlgo(N)` in sorted order.
+///
+/// Required by RFC 9350 §5.2 / §6: a router that originates a FAD or
+/// participates in a flex-algo MUST list that algo here. The
+/// configuration model treats *any* entry in `flex_algo.config` as
+/// participation — `advertise_definition` controls FAD origination,
+/// not participation. `Algo` is `packet_utils::Algo`, shared by the
+/// IS-IS and OSPF packet crates, so this helper serves both.
+pub fn sr_algorithms(fa: &FlexAlgoConfig) -> Vec<Algo> {
+    let mut algos = Vec::with_capacity(1 + fa.config.len());
+    algos.push(Algo::Spf);
+    for &n in fa.config.keys() {
+        algos.push(Algo::FlexAlgo(n));
+    }
+    algos
+}
 
 /// Staged Flexible Algorithm Definitions (RFC 9350) for one IGP
 /// instance, keyed by algorithm id (128..=255). Protocol-neutral: the
@@ -382,5 +403,26 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("128..=255"), "unexpected err: {err}");
+    }
+
+    #[test]
+    fn sr_algorithms_lists_spf_plus_every_configured_algo() {
+        let mut fa = FlexAlgoConfig::new(P);
+        // No flex-algos yet — should yield exactly Algo::Spf.
+        assert_eq!(sr_algorithms(&fa), vec![Algo::Spf]);
+
+        // Add two flex-algos via any leaf write (participation is
+        // implied by the entry existing, not by advertise_definition).
+        for algo in ["129", "128"] {
+            fa.exec(format!("{P}/priority"), args(&[algo, "200"]), ConfigOp::Set)
+                .unwrap();
+            fa.commit();
+        }
+        // BTreeMap iterates sorted, so flex-algos appear in 128, 129
+        // order after Spf.
+        assert_eq!(
+            sr_algorithms(&fa),
+            vec![Algo::Spf, Algo::FlexAlgo(128), Algo::FlexAlgo(129)]
+        );
     }
 }

--- a/zebra-rs/src/flex_algo/mod.rs
+++ b/zebra-rs/src/flex_algo/mod.rs
@@ -15,7 +15,7 @@ pub mod entry;
 pub mod srlg;
 
 pub use affinity_map::AffinityMap;
-pub use config::FlexAlgoConfig;
+pub use config::{FlexAlgoConfig, sr_algorithms};
 pub use constraint::{AffinityBits, link_passes_fad, local_link_affinity};
 pub use entry::{FadMetricType, FlexAlgoEntry};
 pub use srlg::{SrlgGroup, SrlgGroupBuilder};

--- a/zebra-rs/src/isis/flex_algo.rs
+++ b/zebra-rs/src/isis/flex_algo.rs
@@ -20,6 +20,7 @@ use super::srlg::SrlgGroup;
 // IS-IS callback shims below stay here.
 pub use crate::flex_algo::{
     FadMetricType, FlexAlgoConfig, FlexAlgoEntry, link_passes_fad, local_link_affinity,
+    sr_algorithms,
 };
 
 /// Extract per-algorithm Prefix-SIDs from a peer-advertised Ext IP-
@@ -123,25 +124,6 @@ pub fn build_per_algo_prefix_sids(map: &BTreeMap<u8, SidLabelValue>) -> Vec<Isis
             sid: sid.clone(),
         })
         .collect()
-}
-
-/// Algorithms this router advertises in the SR Algorithm sub-TLV
-/// (RFC 8667 §3.2, sub-TLV 19). `Algo::Spf` (algo 0) is always
-/// present; every flex-algo entry in `fa.config` is added as
-/// `Algo::FlexAlgo(N)` in sorted order.
-///
-/// Required by RFC 9350 §5.2: a router that originates a FAD or
-/// participates in a flex-algo MUST list that algo here. The
-/// configuration model treats *any* entry in `flex_algo.config` as
-/// participation — `advertise_definition` controls FAD origination,
-/// not participation.
-pub fn sr_algorithms(fa: &FlexAlgoConfig) -> Vec<Algo> {
-    let mut algos = Vec::with_capacity(1 + fa.config.len());
-    algos.push(Algo::Spf);
-    for &n in fa.config.keys() {
-        algos.push(Algo::FlexAlgo(n));
-    }
-    algos
 }
 
 /// Build the FAD sub-TLVs (RFC 9350 §5.1) this router will originate
@@ -567,32 +549,6 @@ mod tests {
             }
             _ => panic!("expected AdminGrp"),
         }
-    }
-
-    #[test]
-    fn sr_algorithms_lists_spf_plus_every_configured_algo() {
-        let mut fa = FlexAlgoConfig::new("/router/isis/flex-algo");
-        // No flex-algos yet — should yield exactly Algo::Spf.
-        assert_eq!(sr_algorithms(&fa), vec![Algo::Spf]);
-
-        // Add two flex-algos via any leaf write (priority is fine —
-        // participation is implied by the entry existing, not by
-        // advertise_definition).
-        for algo in ["129", "128"] {
-            fa.exec(
-                "/router/isis/flex-algo/priority".into(),
-                args(&[algo, "200"]),
-                ConfigOp::Set,
-            )
-            .unwrap();
-            fa.commit();
-        }
-        // BTreeMap iterates sorted, so flex-algos appear in 128, 129
-        // order after Spf.
-        assert_eq!(
-            sr_algorithms(&fa),
-            vec![Algo::Spf, Algo::FlexAlgo(128), Algo::FlexAlgo(129)]
-        );
     }
 
     #[test]

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -843,7 +843,8 @@ impl Ospf<Ospfv2> {
 
         if self.segment_routing == SegmentRoutingMode::Mpls {
             let gr_capable = self.restarting.is_some();
-            let mut lsa = super::srmpls::router_info_lsa_build(self.router_id, gr_capable);
+            let algos = crate::flex_algo::sr_algorithms(&self.flex_algo);
+            let mut lsa = super::srmpls::router_info_lsa_build(self.router_id, gr_capable, algos);
 
             // Preserve sequence number if re-originating.
             if let Some(area) = self.areas.get(AREA0)

--- a/zebra-rs/src/ospf/srmpls.rs
+++ b/zebra-rs/src/ospf/srmpls.rs
@@ -26,7 +26,7 @@ pub(super) const SRLB_RANGE: u32 = 1000;
 /// restarting-router capability (RFC 3623 / RFC 7770 §2.1 bit 5).
 /// Set to `true` while `Ospf::restarting.is_some()` so helpers
 /// see us as a planned-restart originator; clear otherwise.
-pub fn router_info_lsa_build(router_id: Ipv4Addr, gr_capable: bool) -> OspfLsa {
+pub fn router_info_lsa_build(router_id: Ipv4Addr, gr_capable: bool, algos: Vec<Algo>) -> OspfLsa {
     let mut tlvs = Vec::new();
 
     // Router Capabilities TLV (type 1, RFC 7770 §2.1):
@@ -41,10 +41,10 @@ pub fn router_info_lsa_build(router_id: Ipv4Addr, gr_capable: bool) -> OspfLsa {
         .with_gr_capable(gr_capable);
     tlvs.push(RouterInfoTlv::RouterInfo(RouterInfoTlvCap { caps }));
 
-    // SR Algorithm TLV (type 8): SPF (algorithm 0).
-    tlvs.push(RouterInfoTlv::Algo(RouterInfoTlvAlgo {
-        algos: vec![Algo::Spf],
-    }));
+    // SR Algorithm TLV (type 8, RFC 8665 §3.1): SPF (algorithm 0) plus
+    // every configured Flexible Algorithm (RFC 9350 §6). The caller
+    // passes `flex_algo::sr_algorithms(&ospf.flex_algo)`.
+    tlvs.push(RouterInfoTlv::Algo(RouterInfoTlvAlgo { algos }));
 
     // SID/Label Range TLV (type 9): Global block.
     tlvs.push(RouterInfoTlv::SidLabelRnage(RouterInfoTlvSidLabelRange {
@@ -427,7 +427,7 @@ mod tests {
     /// and GR-helper (bit 4) set; GR-capable (bit 5) clear.
     #[test]
     fn router_info_lsa_steady_state_caps() {
-        let lsa = router_info_lsa_build(Ipv4Addr::new(10, 0, 0, 1), false);
+        let lsa = router_info_lsa_build(Ipv4Addr::new(10, 0, 0, 1), false, vec![Algo::Spf]);
         let cap = extract_caps(&lsa);
         assert!(cap.te(), "TE bit must be set");
         assert!(cap.gr_helper(), "GR helper bit must be set");
@@ -443,13 +443,39 @@ mod tests {
     /// to helpers.
     #[test]
     fn router_info_lsa_restarting_sets_gr_capable() {
-        let lsa = router_info_lsa_build(Ipv4Addr::new(10, 0, 0, 1), true);
+        let lsa = router_info_lsa_build(Ipv4Addr::new(10, 0, 0, 1), true, vec![Algo::Spf]);
         let cap = extract_caps(&lsa);
         assert!(cap.te(), "TE bit must remain set");
         assert!(cap.gr_helper(), "GR helper bit must remain set");
         assert!(
             cap.gr_capable(),
             "GR restarter bit must be set while restarting"
+        );
+    }
+
+    /// The SR-Algorithm TLV (type 8) carries the configured Flexible
+    /// Algorithms after SPF (RFC 9350 §6).
+    #[test]
+    fn router_info_lsa_advertises_configured_flex_algos() {
+        let lsa = router_info_lsa_build(
+            Ipv4Addr::new(10, 0, 0, 1),
+            false,
+            vec![Algo::Spf, Algo::FlexAlgo(128), Algo::FlexAlgo(200)],
+        );
+        let OspfLsp::OpaqueAreaRouterInfo(ri) = &lsa.lsp else {
+            panic!("expected RouterInfo opaque LSA");
+        };
+        let algos = ri
+            .tlvs
+            .iter()
+            .find_map(|tlv| match tlv {
+                RouterInfoTlv::Algo(a) => Some(a.algos.clone()),
+                _ => None,
+            })
+            .expect("SR-Algorithm TLV present");
+        assert_eq!(
+            algos,
+            vec![Algo::Spf, Algo::FlexAlgo(128), Algo::FlexAlgo(200)]
         );
     }
 }


### PR DESCRIPTION
Phase 3a of OSPF Flex-Algorithm (RFC 9350) — the **first on-the-wire flex-algo behavior**. The OSPFv2 Router Information LSA's SR-Algorithm TLV (type 8) was hardcoded to `Algo::Spf`; it now lists SPF **plus every configured Flexible Algorithm** (RFC 9350 §6), so peers see this router participate in the algos.

## Changes
- Move `sr_algorithms()` to `crate::flex_algo`. It operates only on the shared `FlexAlgoConfig` + `packet_utils::Algo` — which **both** isis-packet and ospf-packet re-export — so a single helper serves both IGPs. IS-IS re-exports it (no behavior change there).
- `router_info_lsa_build` takes the algo list; `router_info_lsa_originate` passes `flex_algo::sr_algorithms(&self.flex_algo)`.

## Scope / notes
- Still gated on `segment-routing/mpls` (the RI LSA only originates when SR is enabled). Originating the RI LSA for IP-dataplane-only flex-algo is a later refinement; FAD origination (3b) and per-link ASLA (3c) follow and also live in the RI / Extended-Link LSAs.
- v3's SR-info LSA still hardcodes `Algo::Spf` — wired in the v3 phase.

## Verification
- New test asserts the SR-Algorithm TLV carries the configured algos (SPF + 128 + 200)
- Full `zebra-rs` unit suite: **770 passed**, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)