### PR TITLE
ospf: originate FAD TLV in RI LSA (v2)

### DIFF
--- a/zebra-rs/src/ospf/flex_algo.rs
+++ b/zebra-rs/src/ospf/flex_algo.rs
@@ -1,0 +1,199 @@
+//! OSPF Flexible Algorithm (RFC 9350 §6) wire builders. The
+//! protocol-neutral config model + constraint engine live in
+//! `crate::flex_algo`; this module turns the committed config into the
+//! ospf-packet TLV structs that ride in the Router Information and
+//! Extended-Link Opaque LSAs. Parallel to `isis::flex_algo`'s
+//! isis-packet builders.
+
+use std::collections::BTreeMap;
+
+use ospf_packet::{OspfFadExcludeSrlg, OspfFadFlags, OspfFadSubTlv, RouterInfoTlvFad};
+
+use crate::flex_algo::{
+    AffinityMap, FadMetricType, FlexAlgoConfig, SrlgGroup, local_link_affinity,
+};
+
+/// Build the OSPF FAD TLVs (RFC 9350 §6.1) this router originates
+/// inside the Router Information Opaque LSA — one `RouterInfoTlvFad`
+/// per `FlexAlgoConfig.config` entry with `advertise_definition ==
+/// true`. Entries with the flag absent or false stay purely local
+/// (the router still participates via the SR-Algorithm TLV, but
+/// originates no definition).
+///
+/// Affinity names resolve against `am` to RFC 7308 Extended Admin
+/// Group bit positions; SRLG names resolve against `srlg_groups` to
+/// 32-bit identifiers. Unresolved names are silently dropped (LSA-gen
+/// is best-effort), matching the IS-IS `build_fad_subs`.
+pub fn build_fad(
+    fa: &FlexAlgoConfig,
+    am: &AffinityMap,
+    srlg_groups: &BTreeMap<String, SrlgGroup>,
+) -> Vec<RouterInfoTlvFad> {
+    let mut out = Vec::new();
+    for (&algo, entry) in &fa.config {
+        if entry.advertise_definition != Some(true) {
+            continue;
+        }
+        let metric_type = entry.metric_type.unwrap_or(FadMetricType::Igp).wire();
+        let priority = entry.priority.unwrap_or(128);
+
+        let mut subs = Vec::new();
+
+        if !entry.exclude_any.is_empty() {
+            let group = local_link_affinity(&entry.exclude_any, am);
+            if !group.words.is_empty() {
+                subs.push(OspfFadSubTlv::ExcludeAg(group));
+            }
+        }
+        if !entry.include_any.is_empty() {
+            let group = local_link_affinity(&entry.include_any, am);
+            if !group.words.is_empty() {
+                subs.push(OspfFadSubTlv::IncludeAnyAg(group));
+            }
+        }
+        if !entry.include_all.is_empty() {
+            let group = local_link_affinity(&entry.include_all, am);
+            if !group.words.is_empty() {
+                subs.push(OspfFadSubTlv::IncludeAllAg(group));
+            }
+        }
+        if entry.prefix_metric == Some(true) {
+            subs.push(OspfFadSubTlv::Flags(OspfFadFlags {
+                m_flag: true,
+                trailing: Vec::new(),
+            }));
+        }
+        if !entry.srlg_exclude.is_empty() {
+            let mut ids: Vec<u32> = entry
+                .srlg_exclude
+                .iter()
+                .filter_map(|n| srlg_groups.get(n).map(|g| g.value))
+                .collect();
+            ids.sort();
+            ids.dedup();
+            if !ids.is_empty() {
+                subs.push(OspfFadSubTlv::ExcludeSrlg(OspfFadExcludeSrlg {
+                    srlgs: ids,
+                }));
+            }
+        }
+
+        out.push(RouterInfoTlvFad {
+            flex_algorithm: algo,
+            metric_type,
+            calc_type: 0, // Only SPF defined today (RFC 9350 §5.1).
+            priority,
+            subs,
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Args, ConfigOp};
+    use std::collections::VecDeque;
+
+    fn args(items: &[&str]) -> Args {
+        Args(items.iter().map(|s| s.to_string()).collect::<VecDeque<_>>())
+    }
+
+    fn set(fa: &mut FlexAlgoConfig, leaf: &str, vals: &[&str]) {
+        fa.exec(
+            format!("/router/ospf/flex-algo{leaf}"),
+            args(vals),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        fa.commit();
+    }
+
+    #[test]
+    fn build_fad_skips_entries_without_advertise_flag() {
+        let mut fa = FlexAlgoConfig::new("/router/ospf/flex-algo");
+        // Algo 128 — no advertise-definition, should be skipped.
+        set(&mut fa, "/priority", &["128", "200"]);
+        // Algo 129 — advertise-definition set, should be emitted.
+        set(&mut fa, "/advertise-definition", &["129", "true"]);
+
+        let am = AffinityMap::new();
+        let srlg = BTreeMap::new();
+        let fads = build_fad(&fa, &am, &srlg);
+        assert_eq!(fads.len(), 1);
+        assert_eq!(fads[0].flex_algorithm, 129);
+        assert_eq!(fads[0].metric_type, FadMetricType::Igp.wire());
+        assert_eq!(fads[0].priority, 128);
+        assert!(fads[0].subs.is_empty());
+    }
+
+    #[test]
+    fn build_fad_emits_exclude_ag_and_srlg_and_flags() {
+        let mut fa = FlexAlgoConfig::new("/router/ospf/flex-algo");
+        set(&mut fa, "/advertise-definition", &["128", "true"]);
+        set(&mut fa, "/metric-type", &["128", "min-unidir-link-delay"]);
+        set(&mut fa, "/affinity/exclude-any", &["128", "blue"]);
+        set(&mut fa, "/srlg-exclude", &["128", "risk-a"]);
+        set(&mut fa, "/prefix-metric", &["128", "true"]);
+
+        let mut am = AffinityMap::new();
+        am.exec(
+            "/affinity-map/affinity/bit-position".into(),
+            args(&["blue", "4"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        am.commit();
+
+        let mut srlg = BTreeMap::new();
+        srlg.insert(
+            "risk-a".to_string(),
+            SrlgGroup {
+                name: "risk-a".into(),
+                value: 100,
+            },
+        );
+
+        let fads = build_fad(&fa, &am, &srlg);
+        assert_eq!(fads.len(), 1);
+        let fad = &fads[0];
+        assert_eq!(fad.flex_algorithm, 128);
+        assert_eq!(fad.metric_type, FadMetricType::MinUnidirLinkDelay.wire());
+
+        let mut has_excl = false;
+        let mut has_flags = false;
+        let mut has_srlg = false;
+        for sub in &fad.subs {
+            match sub {
+                OspfFadSubTlv::ExcludeAg(g) => {
+                    has_excl = true;
+                    assert!(g.get(4));
+                }
+                OspfFadSubTlv::Flags(f) => {
+                    has_flags = true;
+                    assert!(f.m_flag);
+                }
+                OspfFadSubTlv::ExcludeSrlg(s) => {
+                    has_srlg = true;
+                    assert_eq!(s.srlgs, vec![100]);
+                }
+                other => panic!("unexpected sub: {other:?}"),
+            }
+        }
+        assert!(has_excl && has_flags && has_srlg);
+    }
+
+    #[test]
+    fn build_fad_drops_unresolved_affinity_names() {
+        let mut fa = FlexAlgoConfig::new("/router/ospf/flex-algo");
+        set(&mut fa, "/advertise-definition", &["128", "true"]);
+        set(&mut fa, "/affinity/exclude-any", &["128", "ghost"]);
+
+        // Empty affinity map — `ghost` resolves to nothing, so no
+        // ExcludeAg sub-TLV (a 0-byte bitmap is meaningless on wire).
+        let am = AffinityMap::new();
+        let fads = build_fad(&fa, &am, &BTreeMap::new());
+        assert_eq!(fads.len(), 1);
+        assert!(fads[0].subs.is_empty(), "got subs: {:?}", fads[0].subs);
+    }
+}

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -173,6 +173,10 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     pub affinity_map: crate::flex_algo::AffinityMap,
     /// This instance's staging of the global `/srlg` table.
     pub srlg_config: crate::flex_algo::SrlgGroupBuilder,
+    /// Applied snapshot of the global `/srlg` table (name → 32-bit
+    /// value), folded from `srlg_config` at CommitEnd. Read by FAD
+    /// origination to resolve `srlg-exclude` names.
+    pub srlg_groups: std::collections::BTreeMap<String, crate::flex_algo::SrlgGroup>,
     /// v3-only outbound packet channel. `Ospf<Ospfv3>::new` spawns
     /// `network_v6::write_packet_v6` consuming the matching receiver;
     /// producers of v3 outgoing packets clone this sender to push
@@ -287,7 +291,9 @@ impl<V: OspfVersion> Ospf<V> {
     fn commit_flex_algo_tables(&mut self) {
         self.flex_algo.commit();
         self.affinity_map.commit();
-        let _ = self.srlg_config.commit();
+        if let Some(groups) = self.srlg_config.commit() {
+            self.srlg_groups = groups;
+        }
     }
 
     pub fn ospf_interface<'a>(
@@ -524,6 +530,7 @@ impl Ospf<Ospfv2> {
             flex_algo: crate::flex_algo::FlexAlgoConfig::new(Ospfv2::FLEX_ALGO_PREFIX),
             affinity_map: crate::flex_algo::AffinityMap::new(),
             srlg_config: crate::flex_algo::SrlgGroupBuilder::new(),
+            srlg_groups: BTreeMap::new(),
             sock,
             v3_send_tx: None,
             v3_recv_rx: None,
@@ -844,7 +851,10 @@ impl Ospf<Ospfv2> {
         if self.segment_routing == SegmentRoutingMode::Mpls {
             let gr_capable = self.restarting.is_some();
             let algos = crate::flex_algo::sr_algorithms(&self.flex_algo);
-            let mut lsa = super::srmpls::router_info_lsa_build(self.router_id, gr_capable, algos);
+            let fads =
+                super::flex_algo::build_fad(&self.flex_algo, &self.affinity_map, &self.srlg_groups);
+            let mut lsa =
+                super::srmpls::router_info_lsa_build(self.router_id, gr_capable, algos, fads);
 
             // Preserve sequence number if re-originating.
             if let Some(area) = self.areas.get(AREA0)
@@ -3626,6 +3636,7 @@ impl Ospf<Ospfv3> {
             flex_algo: crate::flex_algo::FlexAlgoConfig::new(Ospfv3::FLEX_ALGO_PREFIX),
             affinity_map: crate::flex_algo::AffinityMap::new(),
             srlg_config: crate::flex_algo::SrlgGroupBuilder::new(),
+            srlg_groups: BTreeMap::new(),
             sock,
             v3_send_tx: Some(v3_send_tx),
             v3_recv_rx: Some(v3_recv_rx),

--- a/zebra-rs/src/ospf/mod.rs
+++ b/zebra-rs/src/ospf/mod.rs
@@ -54,6 +54,8 @@ pub use flood::*;
 
 pub mod srmpls;
 
+pub mod flex_algo;
+
 pub mod tracing;
 
 pub mod reach_map;

--- a/zebra-rs/src/ospf/srmpls.rs
+++ b/zebra-rs/src/ospf/srmpls.rs
@@ -26,7 +26,12 @@ pub(super) const SRLB_RANGE: u32 = 1000;
 /// restarting-router capability (RFC 3623 / RFC 7770 §2.1 bit 5).
 /// Set to `true` while `Ospf::restarting.is_some()` so helpers
 /// see us as a planned-restart originator; clear otherwise.
-pub fn router_info_lsa_build(router_id: Ipv4Addr, gr_capable: bool, algos: Vec<Algo>) -> OspfLsa {
+pub fn router_info_lsa_build(
+    router_id: Ipv4Addr,
+    gr_capable: bool,
+    algos: Vec<Algo>,
+    fads: Vec<RouterInfoTlvFad>,
+) -> OspfLsa {
     let mut tlvs = Vec::new();
 
     // Router Capabilities TLV (type 1, RFC 7770 §2.1):
@@ -57,6 +62,12 @@ pub fn router_info_lsa_build(router_id: Ipv4Addr, gr_capable: bool, algos: Vec<A
         range: SRLB_RANGE,
         sid_label: SidLabelTlv::Label(SRLB_START),
     }));
+
+    // Flexible Algorithm Definition TLVs (type 16, RFC 9350 §6.1): one
+    // per algo this router originates a FAD for (advertise-definition).
+    for fad in fads {
+        tlvs.push(RouterInfoTlv::Fad(fad));
+    }
 
     let ri_lsa = RouterInfoLsa { tlvs };
 
@@ -427,7 +438,7 @@ mod tests {
     /// and GR-helper (bit 4) set; GR-capable (bit 5) clear.
     #[test]
     fn router_info_lsa_steady_state_caps() {
-        let lsa = router_info_lsa_build(Ipv4Addr::new(10, 0, 0, 1), false, vec![Algo::Spf]);
+        let lsa = router_info_lsa_build(Ipv4Addr::new(10, 0, 0, 1), false, vec![Algo::Spf], vec![]);
         let cap = extract_caps(&lsa);
         assert!(cap.te(), "TE bit must be set");
         assert!(cap.gr_helper(), "GR helper bit must be set");
@@ -443,7 +454,7 @@ mod tests {
     /// to helpers.
     #[test]
     fn router_info_lsa_restarting_sets_gr_capable() {
-        let lsa = router_info_lsa_build(Ipv4Addr::new(10, 0, 0, 1), true, vec![Algo::Spf]);
+        let lsa = router_info_lsa_build(Ipv4Addr::new(10, 0, 0, 1), true, vec![Algo::Spf], vec![]);
         let cap = extract_caps(&lsa);
         assert!(cap.te(), "TE bit must remain set");
         assert!(cap.gr_helper(), "GR helper bit must remain set");
@@ -461,6 +472,7 @@ mod tests {
             Ipv4Addr::new(10, 0, 0, 1),
             false,
             vec![Algo::Spf, Algo::FlexAlgo(128), Algo::FlexAlgo(200)],
+            vec![],
         );
         let OspfLsp::OpaqueAreaRouterInfo(ri) = &lsa.lsp else {
             panic!("expected RouterInfo opaque LSA");
@@ -477,5 +489,35 @@ mod tests {
             algos,
             vec![Algo::Spf, Algo::FlexAlgo(128), Algo::FlexAlgo(200)]
         );
+    }
+
+    /// FAD TLVs passed to the builder ride in the RI LSA (RFC 9350 §6.1).
+    #[test]
+    fn router_info_lsa_carries_fad_tlvs() {
+        let fad = RouterInfoTlvFad {
+            flex_algorithm: 128,
+            metric_type: 0,
+            calc_type: 0,
+            priority: 128,
+            subs: Vec::new(),
+        };
+        let lsa = router_info_lsa_build(
+            Ipv4Addr::new(10, 0, 0, 1),
+            false,
+            vec![Algo::Spf, Algo::FlexAlgo(128)],
+            vec![fad.clone()],
+        );
+        let OspfLsp::OpaqueAreaRouterInfo(ri) = &lsa.lsp else {
+            panic!("expected RouterInfo opaque LSA");
+        };
+        let fads: Vec<_> = ri
+            .tlvs
+            .iter()
+            .filter_map(|tlv| match tlv {
+                RouterInfoTlv::Fad(f) => Some(f.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(fads, vec![fad]);
     }
 }


### PR DESCRIPTION
Phase 3b of OSPF Flex-Algorithm (RFC 9350): OSPFv2 now **originates a Flexible Algorithm Definition (FAD) TLV** (RFC 9350 §6.1, RI LSA type 16) for every flex-algo with `advertise-definition` set, so peers learn the algorithm's metric-type, priority and constraints. `show ip ospf database detail` renders them (the show arm shipped with the #1082 codec).

## Changes
- New `ospf::flex_algo::build_fad` — the OSPF analog of IS-IS's `build_fad_subs`, producing `RouterInfoTlvFad` over the ospf-packet types from #1082. **Affinity/SRLG constraint resolution reuses the shared** `crate::flex_algo::local_link_affinity` + the SRLG snapshot (no duplicated logic).
- `Ospf<V>` gains `srlg_groups` (the applied `/srlg` snapshot), folded from `srlg_config` at `CommitEnd` and read by `build_fad` (so it's a live field, not dead code).
- `router_info_lsa_build` takes the FAD list; `router_info_lsa_originate` passes `build_fad(&flex_algo, &affinity_map, &srlg_groups)`.

## Scope
Still gated on `segment-routing/mpls` (RI LSA only originates with SR enabled). v3 RI/FAD is the v3 phase. Per-link ASLA + per-algo Prefix-SIDs are 3c.

## Verification
- `build_fad` tests: skips non-advertise entries; emits Exclude-AG + Exclude-SRLG + M-flag; drops unresolved affinity names
- `router_info_lsa_carries_fad_tlvs`: a passed FAD rides in the RI LSA
- Full `zebra-rs` unit suite: **774 passed**, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)