### PR TITLE
ospf: per-link ASLA on Extended-Link LSA (v2)

### DIFF
--- a/zebra-rs/src/ospf/flex_algo.rs
+++ b/zebra-rs/src/ospf/flex_algo.rs
@@ -5,9 +5,12 @@
 //! Extended-Link Opaque LSAs. Parallel to `isis::flex_algo`'s
 //! isis-packet builders.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
-use ospf_packet::{OspfFadExcludeSrlg, OspfFadFlags, OspfFadSubTlv, RouterInfoTlvFad};
+use ospf_packet::{
+    ExtLinkSubTlv, OSPF_SABM_FLEX_ALGO, OspfAslaSubSubTlv, OspfAslaSubTlv, OspfFadExcludeSrlg,
+    OspfFadFlags, OspfFadSubTlv, RouterInfoTlvFad,
+};
 
 use crate::flex_algo::{
     AffinityMap, FadMetricType, FlexAlgoConfig, SrlgGroup, local_link_affinity,
@@ -87,6 +90,27 @@ pub fn build_fad(
         });
     }
     out
+}
+
+/// Build the per-link ASLA sub-TLV (RFC 9492) carrying this link's
+/// affinity (Extended Admin Group, RFC 7308) for the Flexible
+/// Algorithm application. Returns `None` when no affinity name resolves
+/// to a bit — a zero-length admin group would be a meaningless wire
+/// artifact, so the link simply advertises no ASLA.
+///
+/// The SABM is a single 4-octet word with only the Flex-Algorithm
+/// X-bit set (`OSPF_SABM_FLEX_ALGO`, RFC 9350 §12); OSPF requires the
+/// mask length to be 0/4/8 octets (RFC 9492 §2). UDABM is empty.
+pub fn build_link_asla(affinity: &BTreeSet<String>, am: &AffinityMap) -> Option<ExtLinkSubTlv> {
+    let group = local_link_affinity(affinity, am);
+    if group.words.is_empty() {
+        return None;
+    }
+    Some(ExtLinkSubTlv::Asla(OspfAslaSubTlv {
+        sabm: vec![OSPF_SABM_FLEX_ALGO, 0, 0, 0],
+        udabm: Vec::new(),
+        subs: vec![OspfAslaSubSubTlv::ExtAdminGroup(group)],
+    }))
 }
 
 #[cfg(test)]
@@ -195,5 +219,40 @@ mod tests {
         let fads = build_fad(&fa, &am, &BTreeMap::new());
         assert_eq!(fads.len(), 1);
         assert!(fads[0].subs.is_empty(), "got subs: {:?}", fads[0].subs);
+    }
+
+    fn affinity_set(names: &[&str]) -> BTreeSet<String> {
+        names.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn build_link_asla_emits_flex_algo_admin_group() {
+        let mut am = AffinityMap::new();
+        for (name, bit) in [("blue", "0"), ("red", "200")] {
+            am.exec(
+                "/affinity-map/affinity/bit-position".into(),
+                args(&[name, bit]),
+                ConfigOp::Set,
+            )
+            .unwrap();
+            am.commit();
+        }
+        let asla = build_link_asla(&affinity_set(&["blue", "red"]), &am).expect("ASLA");
+        let ExtLinkSubTlv::Asla(a) = &asla else {
+            panic!("expected Asla, got {asla:?}");
+        };
+        assert!(a.is_flex_algo(), "SABM X-bit must be set");
+        assert_eq!(a.sabm.len(), 4, "OSPF SABM must be 0/4/8 octets");
+        let g = a.ext_admin_group().expect("admin group");
+        assert!(g.get(0) && g.get(200) && !g.get(1));
+    }
+
+    #[test]
+    fn build_link_asla_none_when_no_affinity_resolves() {
+        let am = AffinityMap::new();
+        // No names → None.
+        assert!(build_link_asla(&BTreeSet::new(), &am).is_none());
+        // Referenced name not in the map → None (empty bitmap).
+        assert!(build_link_asla(&affinity_set(&["ghost"]), &am).is_none());
     }
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -927,17 +927,26 @@ impl Ospf<Ospfv2> {
             && let Some(addr) = link.addr.iter().find(|a| !a.prefix.addr().is_loopback())
         {
             let our_addr = addr.prefix.addr();
+            // Per-link ASLA carrying this link's flex-algo affinity
+            // (RFC 9492 / RFC 9350 §6.3), independent of Adj-SID: a link
+            // with affinity but no Adj-SID still originates an
+            // Extended-Link LSA so peers can run the FAD constraints.
+            let asla = super::flex_algo::build_link_asla(&link.config.affinity, &self.affinity_map);
             match link.network_type {
                 OspfNetworkType::PointToPoint => {
-                    if let Some(adjacency_sid) = link.config.adjacency_sid
-                        && let Some(nbr) = link.nbrs.values().find(|n| n.state == NfsmState::Full)
-                    {
-                        Some((
-                            1u8,
-                            nbr.ident.router_id,
-                            our_addr,
-                            vec![super::srmpls::build_p2p_adj_sub(&adjacency_sid)],
-                        ))
+                    if let Some(nbr) = link.nbrs.values().find(|n| n.state == NfsmState::Full) {
+                        let mut subs = Vec::new();
+                        if let Some(adjacency_sid) = link.config.adjacency_sid {
+                            subs.push(super::srmpls::build_p2p_adj_sub(&adjacency_sid));
+                        }
+                        if let Some(asla) = asla {
+                            subs.push(asla);
+                        }
+                        if subs.is_empty() {
+                            None
+                        } else {
+                            Some((1u8, nbr.ident.router_id, our_addr, subs))
+                        }
                     } else {
                         None
                     }
@@ -950,7 +959,7 @@ impl Ospf<Ospfv2> {
                         // pointing at a `link_id` we can no longer name.
                         None
                     } else {
-                        let subs: Vec<_> = link
+                        let mut subs: Vec<_> = link
                             .nbrs
                             .values()
                             .filter(|n| n.state == NfsmState::Full)
@@ -960,8 +969,11 @@ impl Ospf<Ospfv2> {
                                 Some(super::srmpls::build_lan_adj_sub(nbr.ident.router_id, label))
                             })
                             .collect();
+                        if let Some(asla) = asla {
+                            subs.push(asla);
+                        }
                         if subs.is_empty() {
-                            // No Full neighbor has a label allocated yet.
+                            // No Adj-SID labels and no affinity yet.
                             None
                         } else {
                             Some((2u8, dr, our_addr, subs))


### PR DESCRIPTION
Phase 3c of OSPF Flex-Algorithm (RFC 9350): OSPFv2 now advertises each link's flex-algo **affinity** as an Application-Specific Link Attributes (ASLA) sub-TLV (RFC 9492) in the Extended-Link Opaque LSA, so peers can apply the FAD include/exclude constraints. Consumes the per-interface affinity staged in #1091; uses the ASLA codec from #1084.

## Changes
- New `ospf::flex_algo::build_link_asla` — resolves a link's affinity names (via the shared `local_link_affinity`) to an Extended Admin Group and wraps it in an ASLA sub-TLV with the Flex-Algo X-bit SABM (`OSPF_SABM_FLEX_ALGO`, RFC 9350 §12). Returns `None` when nothing resolves (no meaningless 0-byte admin group on the wire).
- `ext_link_lsa_originate` appends the ASLA to the link's sub-TLVs and **broadens the origination condition**: a link with affinity but no Adj-SID now originates the Extended-Link LSA (previously it required an Adj-SID / LAN Adj-SID, so the ASLA would never have been emitted). No-affinity behavior is byte-for-byte unchanged.

## Scope
Still gated on `segment-routing/mpls` (the Extended-Link LSA only originates with SR enabled — same caveat as 3a/3b). Per-algo Prefix-SIDs need new per-interface per-algo SID config and are a separate phase. v3 is the v3 phase.

## Verification
- `build_link_asla` tests: X-bit SABM + multi-word admin group emitted; `None` for empty / unresolved affinity
- Full `zebra-rs` unit suite: **776 passed**, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)