### PR TITLE
ospf: originate per-algo Prefix-SIDs in Extended-Prefix LSA (v2)

### DIFF
--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -117,6 +117,14 @@ impl Ospf {
             config_ospf_interface_prefix_sid_absolute,
         );
         self.ospf_add(
+            "/area/interface/flex-algo-prefix-sid/index",
+            config_ospf_interface_flex_algo_prefix_sid_index,
+        );
+        self.ospf_add(
+            "/area/interface/flex-algo-prefix-sid/absolute",
+            config_ospf_interface_flex_algo_prefix_sid_absolute,
+        );
+        self.ospf_add(
             "/area/interface/adjacency-sid/index",
             config_ospf_interface_adjacency_sid_index,
         );
@@ -868,6 +876,62 @@ fn config_ospf_interface_prefix_sid_absolute(
         link.config.prefix_sid = Some(super::link::PrefixSid::Absolute(absolute));
     } else {
         link.config.prefix_sid = None;
+    }
+    let ifindex = link.index;
+
+    ospf.ext_prefix_lsa_originate(ifindex);
+
+    Some(())
+}
+
+// `/router/ospf/area/interface/flex-algo-prefix-sid/<algo>/index` —
+// per-algo Index-form Prefix-SID for this interface's prefix
+// (RFC 9350 §7). Stored keyed by algo and re-originates the
+// Extended-Prefix Opaque LSA so the extra Prefix-SID sub-TLV appears.
+fn config_ospf_interface_flex_algo_prefix_sid_index(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let algo = args.u8()?;
+    let index = args.u32()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config
+            .flex_algo_prefix_sids
+            .insert(algo, super::link::PrefixSid::Index(index));
+    } else {
+        link.config.flex_algo_prefix_sids.remove(&algo);
+    }
+    let ifindex = link.index;
+
+    ospf.ext_prefix_lsa_originate(ifindex);
+
+    Some(())
+}
+
+// `/router/ospf/area/interface/flex-algo-prefix-sid/<algo>/absolute` —
+// per-algo Absolute (label) Prefix-SID sibling of the index form.
+fn config_ospf_interface_flex_algo_prefix_sid_absolute(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let algo = args.u8()?;
+    let absolute = args.u32()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config
+            .flex_algo_prefix_sids
+            .insert(algo, super::link::PrefixSid::Absolute(absolute));
+    } else {
+        link.config.flex_algo_prefix_sids.remove(&algo);
     }
     let ifindex = link.index;
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1045,19 +1045,26 @@ impl Ospf<Ospfv2> {
 
         let link = self.links.get(&ifindex);
         let should_originate = self.segment_routing == SegmentRoutingMode::Mpls
-            && link.is_some_and(|l| l.enabled && l.config.prefix_sid.is_some());
+            && link.is_some_and(|l| {
+                l.enabled
+                    && (l.config.prefix_sid.is_some() || !l.config.flex_algo_prefix_sids.is_empty())
+            });
 
         if should_originate {
             let link = link.unwrap();
-            let prefix_sid = link.config.prefix_sid.unwrap();
             // Use the first non-loopback address as a /32 host prefix.
             let Some(addr) = link.addr.iter().find(|a| !a.prefix.addr().is_loopback()) else {
                 return;
             };
             let prefix = ipnet::Ipv4Net::new(addr.prefix.addr(), 32).unwrap_or(addr.prefix);
 
-            let mut lsa =
-                super::srmpls::ext_prefix_lsa_build(self.router_id, prefix, &prefix_sid, opaque_id);
+            let mut lsa = super::srmpls::ext_prefix_lsa_build(
+                self.router_id,
+                prefix,
+                link.config.prefix_sid.as_ref(),
+                &link.config.flex_algo_prefix_sids,
+                opaque_id,
+            );
 
             // Preserve sequence number if re-originating.
             if let Some(area) = self.areas.get(AREA0)

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -78,6 +78,11 @@ pub struct LinkConfig {
     pub transmit_delay: Option<u16>,
     pub mtu_ignore: bool,
     pub prefix_sid: Option<PrefixSid>,
+    /// Per-Flexible-Algorithm Prefix-SIDs for this interface's prefix
+    /// (RFC 9350 §7), keyed by algo id (128..=255). Emitted as extra
+    /// Prefix-SID sub-TLVs (Algorithm = FlexAlgo(N)) in the
+    /// Extended-Prefix Opaque LSA alongside the algo-0 `prefix_sid`.
+    pub flex_algo_prefix_sids: BTreeMap<u8, PrefixSid>,
     pub adjacency_sid: Option<AdjacencySid>,
     pub network_type: Option<OspfNetworkType>,
     /// RFC 2328 §D authentication mode. `None` = inherit (Null

--- a/zebra-rs/src/ospf/srmpls.rs
+++ b/zebra-rs/src/ospf/srmpls.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::net::Ipv4Addr;
 
 use ipnet::{Ipv4Net, Ipv6Net};
@@ -82,13 +83,9 @@ pub fn router_info_lsa_build(
     lsa
 }
 
-/// Build an Extended Prefix Opaque LSA for a prefix with Prefix SID.
-pub fn ext_prefix_lsa_build(
-    router_id: Ipv4Addr,
-    prefix: Ipv4Net,
-    prefix_sid: &PrefixSid,
-    opaque_id: u32,
-) -> OspfLsa {
+/// Build one Prefix-SID sub-TLV (RFC 8665 §5 / RFC 9350 §7) for the
+/// given algorithm from a configured Prefix-SID.
+fn ext_prefix_sid_sub(algo: Algo, prefix_sid: &PrefixSid) -> ExtPrefixSubTlv {
     let (sid, flags) = match prefix_sid {
         PrefixSid::Index(idx) => (
             SidLabelTlv::Index(*idx),
@@ -99,20 +96,39 @@ pub fn ext_prefix_lsa_build(
             PrefixSidFlags::new().with_v_flag(true).with_l_flag(true),
         ),
     };
-
-    let sid_sub = ExtPrefixSidSubTlv {
+    ExtPrefixSubTlv::PrefixSid(ExtPrefixSidSubTlv {
         flags,
         mt_id: 0,
-        algo: Algo::Spf,
+        algo,
         sid,
-    };
+    })
+}
+
+/// Build an Extended Prefix Opaque LSA for a prefix, carrying the
+/// algo-0 Prefix-SID (if configured) plus a per-Flex-Algorithm
+/// Prefix-SID sub-TLV for every entry in `flex_algo_sids` (RFC 9350
+/// §7, Algorithm = FlexAlgo(N)).
+pub fn ext_prefix_lsa_build(
+    router_id: Ipv4Addr,
+    prefix: Ipv4Net,
+    prefix_sid: Option<&PrefixSid>,
+    flex_algo_sids: &BTreeMap<u8, PrefixSid>,
+    opaque_id: u32,
+) -> OspfLsa {
+    let mut subs = Vec::new();
+    if let Some(ps) = prefix_sid {
+        subs.push(ext_prefix_sid_sub(Algo::Spf, ps));
+    }
+    for (algo, sid) in flex_algo_sids {
+        subs.push(ext_prefix_sid_sub(Algo::FlexAlgo(*algo), sid));
+    }
 
     let tlv = ExtPrefixTlv {
         route_type: 1, // Intra-area.
         prefix,
         af: 0, // IPv4 unicast.
         flags: 0,
-        subs: vec![ExtPrefixSubTlv::PrefixSid(sid_sub)],
+        subs,
     };
 
     let ep_lsa = ExtPrefixLsa { tlvs: vec![tlv] };
@@ -519,5 +535,63 @@ mod tests {
             })
             .collect();
         assert_eq!(fads, vec![fad]);
+    }
+
+    /// The Extended-Prefix LSA carries the algo-0 Prefix-SID plus one
+    /// per-Flex-Algorithm Prefix-SID sub-TLV (RFC 9350 §7).
+    #[test]
+    fn ext_prefix_lsa_emits_per_algo_prefix_sids() {
+        use super::PrefixSid;
+        let prefix = "10.0.0.1/32".parse::<Ipv4Net>().unwrap();
+        let mut flex = BTreeMap::new();
+        flex.insert(128u8, PrefixSid::Index(1128));
+        flex.insert(200u8, PrefixSid::Absolute(20200));
+
+        let lsa = ext_prefix_lsa_build(
+            Ipv4Addr::new(10, 0, 0, 1),
+            prefix,
+            Some(&PrefixSid::Index(16)),
+            &flex,
+            0,
+        );
+        let OspfLsp::OpaqueAreaExtPrefix(ep) = &lsa.lsp else {
+            panic!("expected Extended-Prefix opaque LSA");
+        };
+        let algos: Vec<Algo> = ep.tlvs[0]
+            .subs
+            .iter()
+            .filter_map(|s| match s {
+                ExtPrefixSubTlv::PrefixSid(p) => Some(p.algo),
+                _ => None,
+            })
+            .collect();
+        // algo-0 (Spf) first, then the flex-algos in sorted order.
+        assert_eq!(
+            algos,
+            vec![Algo::Spf, Algo::FlexAlgo(128), Algo::FlexAlgo(200)]
+        );
+    }
+
+    /// With no algo-0 Prefix-SID, only the flex-algo sub-TLVs appear.
+    #[test]
+    fn ext_prefix_lsa_flex_algo_only() {
+        use super::PrefixSid;
+        let prefix = "10.0.0.1/32".parse::<Ipv4Net>().unwrap();
+        let mut flex = BTreeMap::new();
+        flex.insert(128u8, PrefixSid::Index(1128));
+
+        let lsa = ext_prefix_lsa_build(Ipv4Addr::new(10, 0, 0, 1), prefix, None, &flex, 0);
+        let OspfLsp::OpaqueAreaExtPrefix(ep) = &lsa.lsp else {
+            panic!("expected Extended-Prefix opaque LSA");
+        };
+        let algos: Vec<Algo> = ep.tlvs[0]
+            .subs
+            .iter()
+            .filter_map(|s| match s {
+                ExtPrefixSubTlv::PrefixSid(p) => Some(p.algo),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(algos, vec![Algo::FlexAlgo(128)]);
     }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -508,6 +508,23 @@ module config {
                 type uint32;
               }
             }
+            list flex-algo-prefix-sid {
+              // Per-Flexible-Algorithm Prefix-SID for this interface's
+              // prefix (RFC 9350 §7). Emitted as an extra Prefix-SID
+              // sub-TLV (Algorithm = the keyed algo) in the
+              // Extended-Prefix Opaque LSA, alongside the algo-0
+              // `prefix-sid` above.
+              key "algo";
+              leaf algo {
+                type uint8 { range "128..255"; }
+              }
+              leaf index {
+                type uint32;
+              }
+              leaf absolute {
+                type uint32;
+              }
+            }
             container adjacency-sid {
               // Per-link Adjacency-SID (RFC 8665 §6). Originated in
               // the Extended-Link Opaque LSA (type 10 / opaque-type 8)


### PR DESCRIPTION
Phase 3d of OSPF Flex-Algorithm (RFC 9350) — the **producer prerequisite for per-algo forwarding**. OSPFv2 can now advertise a per-Flexible-Algorithm Prefix-SID for an interface's prefix (RFC 9350 §7), emitted as an extra Prefix-SID sub-TLV (Algorithm = `FlexAlgo(N)`) in the Extended-Prefix Opaque LSA alongside the algo-0 SID.

## Why now (sequencing)
The per-algo RIB / MPLS-ILM consumer (4b) only produces routes for prefixes that carry a **per-algo Prefix-SID** (algo-N SR-MPLS needs a label at every hop — IS-IS skips prefixes without one). OSPF didn't originate those yet, so a zebra-rs-only topology would compute an empty per-algo RIB. This PR adds the producer so 4b is verifiable end-to-end.

## Changes
- `LinkConfig.flex_algo_prefix_sids: BTreeMap<u8, PrefixSid>`.
- `ext_prefix_lsa_build` refactored to take `Option<&PrefixSid>` (algo-0) + a per-algo map, emitting one Prefix-SID sub-TLV each via a shared `ext_prefix_sid_sub` helper. Origination gates on **either** an algo-0 SID or any flex-algo SID being present.
- Config callbacks at `/router/ospf/area/interface/flex-algo-prefix-sid/{index,absolute}` (keyed by algo) + YANG `list flex-algo-prefix-sid`.

## Verification
- Round-trip tests: Ext-Prefix LSA carries algo-0 + per-algo sub-TLVs (sorted), and a flex-algo-only case
- Full `zebra-rs` suite: **778 passed**; `yang_load_tests` passes
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean

## Next (4b)
Per-algo Prefix-SID ingestion (Ext-Prefix LSA `algo` field) + per-algo RIB build + per-algo Prefix-SID MPLS-ILM install — now with real SIDs to consume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)