### PR TITLE
ospf: OSPFv3 flex-algo config dispatch + YANG

### DIFF
--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -84,6 +84,15 @@ impl Ospf<Ospfv3> {
                 "/area/interface/adjacency-sid/absolute",
                 config_ospfv3_interface_adjacency_sid_absolute,
             ),
+            ("/area/interface/affinity", config_ospfv3_interface_affinity),
+            (
+                "/area/interface/flex-algo-prefix-sid/index",
+                config_ospfv3_interface_flex_algo_prefix_sid_index,
+            ),
+            (
+                "/area/interface/flex-algo-prefix-sid/absolute",
+                config_ospfv3_interface_flex_algo_prefix_sid_absolute,
+            ),
             ("/segment-routing/mpls", config_ospfv3_sr_mpls),
         ];
         for (path, cb) in entries {
@@ -433,6 +442,87 @@ fn config_ospfv3_interface_adjacency_sid_absolute(
     let ifindex = link.index;
 
     ospf.e_router_v3_lsa_originate(ifindex);
+
+    Some(())
+}
+
+// `/router/ospfv3/area/interface/affinity` — one call per affinity
+// name on the leaf-list. Each name references a global `/affinity-map`
+// entry; bit positions are resolved at LSA-build time, so we only
+// stage the names here. Mirrors v2's `config_ospf_interface_affinity`
+// (the RFC 9492 ASLA origination that reads them lands with v3
+// flex-algo origination).
+fn config_ospfv3_interface_affinity(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let affinity = args.string()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config.affinity.insert(affinity);
+    } else {
+        link.config.affinity.remove(&affinity);
+    }
+    Some(())
+}
+
+// `/router/ospfv3/area/interface/flex-algo-prefix-sid/<algo>/index` —
+// per-algo Index-form Prefix-SID for this interface's prefix
+// (RFC 9350 §7). Stored keyed by algo and re-originates the
+// E-Intra-Area-Prefix-LSA. Mirrors v2's
+// `config_ospf_interface_flex_algo_prefix_sid_index`.
+fn config_ospfv3_interface_flex_algo_prefix_sid_index(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let algo = args.u8()?;
+    let index = args.u32()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config
+            .flex_algo_prefix_sids
+            .insert(algo, super::link::PrefixSid::Index(index));
+    } else {
+        link.config.flex_algo_prefix_sids.remove(&algo);
+    }
+    let ifindex = link.index;
+
+    ospf.ext_intra_area_prefix_v3_lsa_originate(ifindex);
+
+    Some(())
+}
+
+// `/router/ospfv3/area/interface/flex-algo-prefix-sid/<algo>/absolute`
+// — per-algo Absolute (label) Prefix-SID sibling of the index form.
+fn config_ospfv3_interface_flex_algo_prefix_sid_absolute(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let algo = args.u8()?;
+    let absolute = args.u32()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    if op.is_set() {
+        link.config
+            .flex_algo_prefix_sids
+            .insert(algo, super::link::PrefixSid::Absolute(absolute));
+    } else {
+        link.config.flex_algo_prefix_sids.remove(&algo);
+    }
+    let ifindex = link.index;
+
+    ospf.ext_intra_area_prefix_v3_lsa_originate(ifindex);
 
     Some(())
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -3688,6 +3688,14 @@ impl Ospf<Ospfv3> {
     pub fn process_cm_msg(&mut self, msg: ConfigRequest) {
         let (path, args) = path_from_command(&msg.paths);
 
+        // Apply the flex-algo / affinity-map / SRLG staging at the end
+        // of a commit cycle (mirrors the v2 sibling). Nothing else
+        // handles CommitEnd on the v3 instance today.
+        if msg.op == ConfigOp::CommitEnd {
+            self.commit_flex_algo_tables();
+            return;
+        }
+
         // Clear ops bypass the YANG callback table; see the v2
         // sibling. Path-filter so the v3 instance ignores the v2
         // `/clear/ospf/spf` broadcast (and vice versa).
@@ -3695,6 +3703,18 @@ impl Ospf<Ospfv3> {
             if path == "/clear/ospfv3/spf" {
                 self.clear_spf();
             }
+            return;
+        }
+
+        // Flex-algo definitions (`/router/ospfv3/flex-algo`) and the
+        // global `/affinity-map` / `/srlg` tables stage into their
+        // builders here and apply at CommitEnd; the registry callbacks
+        // below don't cover them.
+        if path.starts_with(Ospfv3::FLEX_ALGO_PREFIX)
+            || path.starts_with("/affinity-map")
+            || path.starts_with("/srlg/group")
+        {
+            self.flex_algo_table_exec(path, args, msg.op);
             return;
         }
 

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -886,6 +886,31 @@ module config {
                 type uint32;
               }
             }
+            list flex-algo-prefix-sid {
+              // Per-Flexible-Algorithm Prefix-SID for this interface's
+              // prefix (RFC 9350 §7). Emitted as an extra Prefix-SID
+              // sub-TLV (Algorithm = the keyed algo) in the
+              // E-Intra-Area-Prefix-LSA, alongside the algo-0
+              // `prefix-sid` above. Mirrors `router ospf` interface.
+              key "algo";
+              leaf algo {
+                type uint8 { range "128..255"; }
+              }
+              leaf index {
+                type uint32;
+              }
+              leaf absolute {
+                type uint32;
+              }
+            }
+            leaf-list affinity {
+              // Names of /affinity-map entries this link carries.
+              // Advertised as an Extended Admin Group bitmap inside the
+              // RFC 9492 ASLA sub-TLV on the E-Router-LSA Router-Link
+              // TLV and tested against each FAD's include/exclude
+              // constraints at flex-algo SPF time.
+              type string;
+            }
           }
         }
         container segment-routing {
@@ -906,6 +931,91 @@ module config {
               // global locator is committed — matches the IS-IS
               // staging convention (config.yang L524).
               type string;
+            }
+          }
+        }
+
+        list flex-algo {
+          // OSPFv3 Flexible Algorithm (RFC 9350 §7) definition. Shape
+          // mirrors `router ospf / flex-algo`; keyed by the on-the-wire
+          // numeric identifier (128..255). `advertise-definition true`
+          // causes this router to originate the FAD TLV in its
+          // E-Router-LSA (RFC 9350 §7.1, OSPFv3 FAD TLV 16); without it
+          // the router participates using a FAD learned from another
+          // node. At least one (preferably two) routers per area MUST
+          // advertise the definition.
+          key "algo";
+          leaf algo {
+            type uint8 { range "128..255"; }
+            description
+              "Flex-Algorithm identifier (RFC 9350 §4). 0..127 are
+               reserved by IANA; 128..255 are user-defined.";
+          }
+
+          leaf advertise-definition {
+            type boolean;
+            default false;
+            description
+              "When true, originate the FAD TLV for this algorithm in
+               the E-Router-LSA. If no router in the area advertises the
+               FAD, every participant fails to compute paths.";
+          }
+
+          leaf metric-type {
+            type enumeration {
+              enum igp;                   // FAD Metric-Type 0
+              enum min-unidir-link-delay; // FAD Metric-Type 1 (RFC 8570)
+              enum te-default;            // FAD Metric-Type 2 (RFC 5305)
+            }
+            default igp;
+          }
+
+          leaf priority {
+            // FAD Priority (RFC 9350 §6.5). Tie-breaker when more than
+            // one router originates a FAD for the same algo; higher
+            // priority wins.
+            type uint8;
+            default 128;
+          }
+
+          leaf prefix-metric {
+            // M-flag in the FAD Flags sub-TLV (RFC 9350 §6.4). When set,
+            // the computed path metric to a prefix includes the
+            // advertised Flexible Algorithm Prefix Metric.
+            type boolean;
+            default false;
+          }
+
+          container dataplane {
+            // Per-algorithm dataplane participation. OSPFv3 flex-algo
+            // forwards over SR-MPLS (per-algo Prefix-SID labels); the
+            // `ip` flag selects plain IPv6 forwarding for the algo's
+            // computed paths.
+            leaf sr-mpls { type boolean; default false; }
+            leaf ip      { type boolean; default false; }
+          }
+
+          container affinity {
+            // FAD Exclude / Include-Any / Include-All Admin Group
+            // sub-TLVs (RFC 9350 §6.2-6.4). Each leaf-list value is a
+            // name from the global /affinity-map table.
+            leaf-list include-any { type string; }
+            leaf-list include-all { type string; }
+            leaf-list exclude-any { type string; }
+          }
+
+          leaf-list srlg-exclude {
+            // FAD Exclude SRLG sub-TLV (RFC 9350 §6.5). Each entry
+            // references a /srlg/group name.
+            type string;
+          }
+
+          container fast-reroute {
+            // Per-algo TI-LFA toggle. Empty container is a no-op; the
+            // child presence container turns the per-algo TI-LFA
+            // computation on (deferred — no OSPF TI-LFA yet).
+            container ti-lfa {
+              presence "Enable Topology-Independent LFA for this flex-algo";
             }
           }
         }


### PR DESCRIPTION
## Summary

Second OSPFv3 phase (v3-2) of RFC 9350 Flexible Algorithm support:
config plumbing. Routes OSPFv3 flex-algo config through the shared
`crate::flex_algo` engine and `Ospf<V>` fields already in place — no
new data structures.

- **`Ospfv3::process_cm_msg`** now stages `/router/ospfv3/flex-algo`,
  global `/affinity-map`, and `/srlg/group` into their builders and
  applies them at `CommitEnd` via the generic `flex_algo_table_exec` /
  `commit_flex_algo_tables` helpers (the v3 instance handled no
  CommitEnd before).
- **`config_v3.rs`** gains three interface callbacks mirrored from v2:
  `/area/interface/affinity` and
  `/area/interface/flex-algo-prefix-sid/{index,absolute}`. `LinkConfig`
  is shared with v2, so the staged fields already exist; the per-algo
  Prefix-SID callbacks re-originate the E-Intra-Area-Prefix-LSA.
- **`config.yang`** ospfv3: instance-level `flex-algo` list matching
  `router ospf` (advertise-definition / metric-type / priority /
  prefix-metric / dataplane / affinity / srlg-exclude / fast-reroute),
  plus interface `flex-algo-prefix-sid` list and `affinity` leaf-list.

Config staging only. The v3 origination that reads these (FAD TLV in
the E-Router-LSA, ASLA on the Router-Link TLV, per-algo Prefix-SID in
the E-Intra-Area-Prefix-LSA) lands in the next phase (v3-3).

## Test plan

- `cargo test -p zebra-rs yang_load` — the config.yang additions parse
  (2 tests pass).
- `cargo build -p zebra-rs` — clean (dispatch + callbacks compile).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)