### PR TITLE
ospf: OSPFv3 flex-algo SR-Algorithm + FAD origination

### DIFF
--- a/zebra-rs/src/ospf/flex_algo.rs
+++ b/zebra-rs/src/ospf/flex_algo.rs
@@ -9,7 +9,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use ospf_packet::{
     ExtLinkSubTlv, OSPF_SABM_FLEX_ALGO, OspfAslaSubSubTlv, OspfAslaSubTlv, OspfFadExcludeSrlg,
-    OspfFadFlags, OspfFadSubTlv, RouterInfoTlvFad,
+    OspfFadFlags, OspfFadSubTlv, Ospfv3FadExcludeSrlg, Ospfv3FadFlags, Ospfv3FadSubTlv,
+    Ospfv3FadTlv, RouterInfoTlvFad,
 };
 
 use crate::flex_algo::{
@@ -82,6 +83,75 @@ pub fn build_fad(
         }
 
         out.push(RouterInfoTlvFad {
+            flex_algorithm: algo,
+            metric_type,
+            calc_type: 0, // Only SPF defined today (RFC 9350 §5.1).
+            priority,
+            subs,
+        });
+    }
+    out
+}
+
+/// OSPFv3 sibling of `build_fad`: build the FAD TLVs (RFC 9350 §7.1)
+/// this router originates inside its E-Router-LSA. Identical constraint
+/// logic to the v2 builder — the only difference is the ospf-packet v3
+/// wire types (`Ospfv3FadTlv` etc., which use the OSPFv3 codepoints).
+pub fn build_fad_v3(
+    fa: &FlexAlgoConfig,
+    am: &AffinityMap,
+    srlg_groups: &BTreeMap<String, SrlgGroup>,
+) -> Vec<Ospfv3FadTlv> {
+    let mut out = Vec::new();
+    for (&algo, entry) in &fa.config {
+        if entry.advertise_definition != Some(true) {
+            continue;
+        }
+        let metric_type = entry.metric_type.unwrap_or(FadMetricType::Igp).wire();
+        let priority = entry.priority.unwrap_or(128);
+
+        let mut subs = Vec::new();
+
+        if !entry.exclude_any.is_empty() {
+            let group = local_link_affinity(&entry.exclude_any, am);
+            if !group.words.is_empty() {
+                subs.push(Ospfv3FadSubTlv::ExcludeAg(group));
+            }
+        }
+        if !entry.include_any.is_empty() {
+            let group = local_link_affinity(&entry.include_any, am);
+            if !group.words.is_empty() {
+                subs.push(Ospfv3FadSubTlv::IncludeAnyAg(group));
+            }
+        }
+        if !entry.include_all.is_empty() {
+            let group = local_link_affinity(&entry.include_all, am);
+            if !group.words.is_empty() {
+                subs.push(Ospfv3FadSubTlv::IncludeAllAg(group));
+            }
+        }
+        if entry.prefix_metric == Some(true) {
+            subs.push(Ospfv3FadSubTlv::Flags(Ospfv3FadFlags {
+                m_flag: true,
+                trailing: Vec::new(),
+            }));
+        }
+        if !entry.srlg_exclude.is_empty() {
+            let mut ids: Vec<u32> = entry
+                .srlg_exclude
+                .iter()
+                .filter_map(|n| srlg_groups.get(n).map(|g| g.value))
+                .collect();
+            ids.sort();
+            ids.dedup();
+            if !ids.is_empty() {
+                subs.push(Ospfv3FadSubTlv::ExcludeSrlg(Ospfv3FadExcludeSrlg {
+                    srlgs: ids,
+                }));
+            }
+        }
+
+        out.push(Ospfv3FadTlv {
             flex_algorithm: algo,
             metric_type,
             calc_type: 0, // Only SPF defined today (RFC 9350 §5.1).
@@ -254,5 +324,98 @@ mod tests {
         assert!(build_link_asla(&BTreeSet::new(), &am).is_none());
         // Referenced name not in the map → None (empty bitmap).
         assert!(build_link_asla(&affinity_set(&["ghost"]), &am).is_none());
+    }
+
+    #[test]
+    fn build_fad_v3_skips_entries_without_advertise_flag() {
+        let mut fa = FlexAlgoConfig::new("/router/ospfv3/flex-algo");
+        // Algo 128 — no advertise-definition, skipped.
+        fa.exec(
+            "/router/ospfv3/flex-algo/priority".into(),
+            args(&["128", "200"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        // Algo 129 — advertise-definition set, emitted.
+        fa.exec(
+            "/router/ospfv3/flex-algo/advertise-definition".into(),
+            args(&["129", "true"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        fa.commit();
+
+        let fads = build_fad_v3(&fa, &AffinityMap::new(), &BTreeMap::new());
+        assert_eq!(fads.len(), 1);
+        assert_eq!(fads[0].flex_algorithm, 129);
+        assert_eq!(fads[0].metric_type, FadMetricType::Igp.wire());
+        assert_eq!(fads[0].priority, 128);
+        assert!(fads[0].subs.is_empty());
+    }
+
+    #[test]
+    fn build_fad_v3_emits_exclude_ag_srlg_and_flags() {
+        use ospf_packet::Ospfv3FadSubTlv;
+
+        let mut fa = FlexAlgoConfig::new("/router/ospfv3/flex-algo");
+        for (leaf, vals) in [
+            ("/advertise-definition", &["128", "true"][..]),
+            ("/metric-type", &["128", "min-unidir-link-delay"][..]),
+            ("/affinity/exclude-any", &["128", "blue"][..]),
+            ("/srlg-exclude", &["128", "risk-a"][..]),
+            ("/prefix-metric", &["128", "true"][..]),
+        ] {
+            fa.exec(
+                format!("/router/ospfv3/flex-algo{leaf}"),
+                args(vals),
+                ConfigOp::Set,
+            )
+            .unwrap();
+        }
+        fa.commit();
+
+        let mut am = AffinityMap::new();
+        am.exec(
+            "/affinity-map/affinity/bit-position".into(),
+            args(&["blue", "4"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        am.commit();
+
+        let mut srlg = BTreeMap::new();
+        srlg.insert(
+            "risk-a".to_string(),
+            SrlgGroup {
+                name: "risk-a".into(),
+                value: 100,
+            },
+        );
+
+        let fads = build_fad_v3(&fa, &am, &srlg);
+        assert_eq!(fads.len(), 1);
+        let fad = &fads[0];
+        assert_eq!(fad.flex_algorithm, 128);
+        assert_eq!(fad.metric_type, FadMetricType::MinUnidirLinkDelay.wire());
+
+        let (mut excl, mut flags, mut srlgs) = (false, false, false);
+        for sub in &fad.subs {
+            match sub {
+                Ospfv3FadSubTlv::ExcludeAg(g) => {
+                    excl = true;
+                    assert!(g.get(4));
+                }
+                Ospfv3FadSubTlv::Flags(f) => {
+                    flags = true;
+                    assert!(f.m_flag);
+                }
+                Ospfv3FadSubTlv::ExcludeSrlg(s) => {
+                    srlgs = true;
+                    assert_eq!(s.srlgs, vec![100]);
+                }
+                other => panic!("unexpected sub: {other:?}"),
+            }
+        }
+        assert!(excl && flags && srlgs);
     }
 }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -5721,7 +5721,13 @@ impl Ospf<Ospfv3> {
         let key: super::lsdb::OspfLsaKey = (OSPFV3_E_ROUTER_LSA_TYPE, SR_INFO_LSID, self.router_id);
 
         if self.segment_routing == SegmentRoutingMode::Mpls && self.areas.get(area_id).is_some() {
-            let mut lsa = super::srmpls::e_router_v3_sr_info_lsa_build(self.router_id);
+            let algos = crate::flex_algo::sr_algorithms(&self.flex_algo);
+            let fads = super::flex_algo::build_fad_v3(
+                &self.flex_algo,
+                &self.affinity_map,
+                &self.srlg_groups,
+            );
+            let mut lsa = super::srmpls::e_router_v3_sr_info_lsa_build(self.router_id, algos, fads);
 
             if let Some(area) = self.areas.get(area_id)
                 && let Some(prev_seq) = area

--- a/zebra-rs/src/ospf/srmpls.rs
+++ b/zebra-rs/src/ospf/srmpls.rs
@@ -286,10 +286,19 @@ pub fn e_router_v3_lsa_build(
 /// configured range here.
 pub const SR_INFO_LSID: u32 = 0;
 
-pub fn e_router_v3_sr_info_lsa_build(router_id: Ipv4Addr) -> Ospfv3Lsa {
-    let sr_algo = Ospfv3ExtTlv::SrAlgorithm(Ospfv3SrAlgorithmTlv {
-        algos: vec![Algo::Spf],
-    });
+/// `algos` lists every algorithm this router participates in (regular
+/// SPF + configured flex-algos), advertised in the SR-Algorithm TLV
+/// (RFC 8666 §3.1). `fads` carries the Flexible Algorithm Definitions
+/// (RFC 9350 §7.1) this router originates — one `Ospfv3ExtTlv::Fad`
+/// each, appended after the SR capability TLVs in the same per-router
+/// E-Router-LSA (the v3 home of the FAD, mirroring how the v2 FAD rides
+/// the Router Information Opaque LSA).
+pub fn e_router_v3_sr_info_lsa_build(
+    router_id: Ipv4Addr,
+    algos: Vec<Algo>,
+    fads: Vec<Ospfv3FadTlv>,
+) -> Ospfv3Lsa {
+    let sr_algo = Ospfv3ExtTlv::SrAlgorithm(Ospfv3SrAlgorithmTlv { algos });
     let sid_range = Ospfv3ExtTlv::SidLabelRange(Ospfv3SidLabelRangeTlv {
         range: SRGB_RANGE,
         sid_label: SidLabelTlv::Label(SRGB_START),
@@ -299,9 +308,10 @@ pub fn e_router_v3_sr_info_lsa_build(router_id: Ipv4Addr) -> Ospfv3Lsa {
         sid_label: SidLabelTlv::Label(SRLB_START),
     });
 
-    let body = Ospfv3ELsaBody {
-        tlvs: vec![sr_algo, sid_range, local_block],
-    };
+    let mut tlvs = vec![sr_algo, sid_range, local_block];
+    tlvs.extend(fads.into_iter().map(Ospfv3ExtTlv::Fad));
+
+    let body = Ospfv3ELsaBody { tlvs };
 
     let mut lsa = Ospfv3Lsa {
         h: Ospfv3LsaHeader {
@@ -593,5 +603,48 @@ mod tests {
             })
             .collect();
         assert_eq!(algos, vec![Algo::FlexAlgo(128)]);
+    }
+
+    /// The OSPFv3 per-router SR-info E-Router-LSA advertises every
+    /// participating algo in the SR-Algorithm TLV and carries each
+    /// passed FAD as an `Ospfv3ExtTlv::Fad` (RFC 9350 §7.1).
+    #[test]
+    fn e_router_v3_sr_info_lsa_advertises_flex_algos_and_fads() {
+        let fad = Ospfv3FadTlv {
+            flex_algorithm: 128,
+            metric_type: 0,
+            calc_type: 0,
+            priority: 128,
+            subs: Vec::new(),
+        };
+        let lsa = e_router_v3_sr_info_lsa_build(
+            Ipv4Addr::new(10, 0, 0, 1),
+            vec![Algo::Spf, Algo::FlexAlgo(128), Algo::FlexAlgo(200)],
+            vec![fad.clone()],
+        );
+        let Ospfv3LsBody::ERouter(body) = &lsa.body else {
+            panic!("expected ERouter body");
+        };
+        let algos = body
+            .tlvs
+            .iter()
+            .find_map(|t| match t {
+                Ospfv3ExtTlv::SrAlgorithm(a) => Some(a.algos.clone()),
+                _ => None,
+            })
+            .expect("SR-Algorithm TLV present");
+        assert_eq!(
+            algos,
+            vec![Algo::Spf, Algo::FlexAlgo(128), Algo::FlexAlgo(200)]
+        );
+        let fads: Vec<_> = body
+            .tlvs
+            .iter()
+            .filter_map(|t| match t {
+                Ospfv3ExtTlv::Fad(f) => Some(f.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(fads, vec![fad]);
     }
 }


### PR DESCRIPTION
## Summary

First slice of OSPFv3 flex-algo origination (v3-3a). The per-router
SR-info E-Router-LSA now advertises flex-algo participation and the
Flexible Algorithm Definitions this router originates — the OSPFv3
analog of the v2 RI-LSA work (#1092 SR-Algorithm, #1093 FAD).

- **`e_router_v3_sr_info_lsa_build`** takes `algos: Vec<Algo>` (was a
  hardcoded `vec![Algo::Spf]`) and `fads: Vec<Ospfv3FadTlv>`. The
  SR-Algorithm TLV lists every participating algo; each FAD is appended
  as an `Ospfv3ExtTlv::Fad` after the SR capability TLVs (RFC 9350 §7.1
  homes the FAD in the E-Router-LSA).
- **`e_router_v3_sr_info_lsa_originate`** feeds it
  `crate::flex_algo::sr_algorithms(...)` + the new
  `ospf::flex_algo::build_fad_v3`, gated on SR-MPLS as before.
- **`build_fad_v3`** — OSPFv3 sibling of `build_fad`: identical
  constraint logic (exclude / include-any / include-all admin groups,
  M-flag, exclude-SRLG), emitting the v3 ospf-packet types.

Per-link ASLA (on the Router-Link TLV) and per-algo Prefix-SID (on the
E-Intra-Area-Prefix-LSA) origination follow in the next slices.

## Test plan

- `cargo test -p zebra-rs` — 3 new tests: `build_fad_v3` skip-without-
  advertise + emit-exclude/srlg/flags, and the SR-info LSA advertising
  multi-algo SR-Algorithm + FAD TLVs. All pass.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)