### PR TITLE
ospf: OSPFv3 per-link Flex-Algo affinity (ASLA)

### DIFF
--- a/zebra-rs/src/ospf/flex_algo.rs
+++ b/zebra-rs/src/ospf/flex_algo.rs
@@ -8,9 +8,10 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use ospf_packet::{
-    ExtLinkSubTlv, OSPF_SABM_FLEX_ALGO, OspfAslaSubSubTlv, OspfAslaSubTlv, OspfFadExcludeSrlg,
-    OspfFadFlags, OspfFadSubTlv, Ospfv3FadExcludeSrlg, Ospfv3FadFlags, Ospfv3FadSubTlv,
-    Ospfv3FadTlv, RouterInfoTlvFad,
+    ExtLinkSubTlv, OSPF_SABM_FLEX_ALGO, OSPFV3_SABM_FLEX_ALGO, OspfAslaSubSubTlv, OspfAslaSubTlv,
+    OspfFadExcludeSrlg, OspfFadFlags, OspfFadSubTlv, Ospfv3AslaSubSubTlv, Ospfv3AslaSubTlv,
+    Ospfv3FadExcludeSrlg, Ospfv3FadFlags, Ospfv3FadSubTlv, Ospfv3FadTlv, Ospfv3SubTlv,
+    RouterInfoTlvFad,
 };
 
 use crate::flex_algo::{
@@ -183,6 +184,23 @@ pub fn build_link_asla(affinity: &BTreeSet<String>, am: &AffinityMap) -> Option<
     }))
 }
 
+/// OSPFv3 sibling of `build_link_asla`: build the per-link ASLA sub-TLV
+/// (RFC 9492) that rides as an `Ospfv3SubTlv::Asla` on the E-Router-LSA
+/// Router-Link TLV. Same SABM X-bit framing and empty-bitmap guard as
+/// the v2 builder; only the wire type differs (OSPFv3 sub-TLV 11 with
+/// the Extended Admin Group sub-sub-TLV 21).
+pub fn build_link_asla_v3(affinity: &BTreeSet<String>, am: &AffinityMap) -> Option<Ospfv3SubTlv> {
+    let group = local_link_affinity(affinity, am);
+    if group.words.is_empty() {
+        return None;
+    }
+    Some(Ospfv3SubTlv::Asla(Ospfv3AslaSubTlv {
+        sabm: vec![OSPFV3_SABM_FLEX_ALGO, 0, 0, 0],
+        udabm: Vec::new(),
+        subs: vec![Ospfv3AslaSubSubTlv::ExtAdminGroup(group)],
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -315,6 +333,37 @@ mod tests {
         assert_eq!(a.sabm.len(), 4, "OSPF SABM must be 0/4/8 octets");
         let g = a.ext_admin_group().expect("admin group");
         assert!(g.get(0) && g.get(200) && !g.get(1));
+    }
+
+    #[test]
+    fn build_link_asla_v3_emits_flex_algo_admin_group() {
+        use ospf_packet::Ospfv3SubTlv;
+
+        let mut am = AffinityMap::new();
+        for (name, bit) in [("blue", "0"), ("red", "200")] {
+            am.exec(
+                "/affinity-map/affinity/bit-position".into(),
+                args(&[name, bit]),
+                ConfigOp::Set,
+            )
+            .unwrap();
+            am.commit();
+        }
+        let asla = build_link_asla_v3(&affinity_set(&["blue", "red"]), &am).expect("ASLA");
+        let Ospfv3SubTlv::Asla(a) = &asla else {
+            panic!("expected Asla, got {asla:?}");
+        };
+        assert!(a.is_flex_algo(), "SABM X-bit must be set");
+        assert_eq!(a.sabm.len(), 4, "OSPFv3 SABM must be 0/4/8 octets");
+        let g = a.ext_admin_group().expect("admin group");
+        assert!(g.get(0) && g.get(200) && !g.get(1));
+    }
+
+    #[test]
+    fn build_link_asla_v3_none_when_no_affinity_resolves() {
+        let am = AffinityMap::new();
+        assert!(build_link_asla_v3(&BTreeSet::new(), &am).is_none());
+        assert!(build_link_asla_v3(&affinity_set(&["ghost"]), &am).is_none());
     }
 
     #[test]

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -5577,20 +5577,37 @@ impl Ospf<Ospfv3> {
         {
             let metric = link.output_cost as u16;
             let my_iid = link.interface_id;
+            // Per-link Flex-Algo affinity (RFC 9492 ASLA). Rides the
+            // Router-Link TLV alongside any Adj-SID; a link with
+            // affinity but no Adj-SID still originates the TLV (so the
+            // admin-group is visible to flex-algo SPF), as long as the
+            // adjacency itself is Full — mirrors v2's broadened
+            // Ext-Link origination gate.
+            let asla =
+                super::flex_algo::build_link_asla_v3(&link.config.affinity, &self.affinity_map);
             match link.network_type {
                 OspfNetworkType::PointToPoint => {
-                    if let Some(adjacency_sid) = link.config.adjacency_sid
-                        && let Some(nbr) = link.nbrs.values().find(|n| n.state == NfsmState::Full)
-                    {
-                        Some((
-                            link.area,
-                            Ospfv3RouterLinkType::PointToPoint,
-                            metric,
-                            my_iid,
-                            nbr.interface_id,
-                            nbr.ident.router_id,
-                            vec![super::srmpls::build_v3_p2p_adj_sub(&adjacency_sid)],
-                        ))
+                    if let Some(nbr) = link.nbrs.values().find(|n| n.state == NfsmState::Full) {
+                        let mut subs = Vec::new();
+                        if let Some(adjacency_sid) = link.config.adjacency_sid {
+                            subs.push(super::srmpls::build_v3_p2p_adj_sub(&adjacency_sid));
+                        }
+                        if let Some(a) = asla.clone() {
+                            subs.push(a);
+                        }
+                        if subs.is_empty() {
+                            None
+                        } else {
+                            Some((
+                                link.area,
+                                Ospfv3RouterLinkType::PointToPoint,
+                                metric,
+                                my_iid,
+                                nbr.interface_id,
+                                nbr.ident.router_id,
+                                subs,
+                            ))
+                        }
                     } else {
                         None
                     }
@@ -5625,7 +5642,7 @@ impl Ospf<Ospfv3> {
                         // used to index `link.nbrs`), not the v6
                         // interface address — RFC 5340 keys v3
                         // neighbor state machines by router-id.
-                        let subs: Vec<_> = link
+                        let mut subs: Vec<_> = link
                             .nbrs
                             .values()
                             .filter(|n| n.state == NfsmState::Full)
@@ -5638,6 +5655,9 @@ impl Ospf<Ospfv3> {
                                 ))
                             })
                             .collect();
+                        if let Some(a) = asla.clone() {
+                            subs.push(a);
+                        }
                         if subs.is_empty() {
                             None
                         } else {


### PR DESCRIPTION
## Summary

Second slice of OSPFv3 flex-algo origination (v3-3b). Per-link affinity
now rides the E-Router-LSA Router-Link TLV as an RFC 9492 ASLA sub-TLV
— the OSPFv3 analog of the v2 Ext-Link ASLA work (#1094).

- **`build_link_asla_v3`** — OSPFv3 sibling of `build_link_asla`: same
  SABM X-bit framing and empty-bitmap guard, emitting
  `Ospfv3SubTlv::Asla` (Router-Link sub-TLV 11 + Extended Admin Group
  sub-sub-TLV 21).
- **`e_router_v3_lsa_originate`** appends the ASLA to the Router-Link
  TLV sub-TLVs in both the P2P and Broadcast/Transit branches, and
  broadens the origination gate: a link with affinity but no Adj-SID
  still originates its Router-Link TLV (so the admin-group is visible
  to flex-algo SPF), as long as the adjacency is Full — mirroring v2's
  broadened Ext-Link gate. The Full-neighbor / settled-DR requirement
  stays because the ASLA describes a real adjacency.

Per-algo Prefix-SID origination on the E-Intra-Area-Prefix-LSA is the
next and final origination slice (v3-3c).

## Test plan

- `cargo test -p zebra-rs` — 2 new tests: `build_link_asla_v3` emits the
  Flex-Algo admin group with the SABM X-bit, and returns `None` when no
  affinity name resolves. All pass.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)