### PR TITLE
ospf: OSPFv3 per-algo IPv6 RIB (in-memory) + show routes

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -93,6 +93,12 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// follow-up), but per-algo IPv4 does not reach the FIB (the global
     /// table has no algorithm dimension), mirroring IS-IS.
     pub rib_flex_algo: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>>,
+    /// Per-Flexible-Algorithm IPv6 RIB (OSPFv3), keyed by algo id. v6
+    /// sibling of `rib_flex_algo`: each prefix carries the per-algo SPF
+    /// nexthops + the prefix's per-algo Prefix-SID. In-memory only — the
+    /// per-algo Prefix-SID labels install into `ilm6` (a follow-up), but
+    /// per-algo IPv6 does not reach the FIB.
+    pub rib6_flex_algo: BTreeMap<u8, PrefixMap<ipnet::Ipv6Net, SpfRouteV3>>,
     pub rib: PrefixMap<Ipv4Net, SpfRoute>,
     /// MPLS LFIB shadow. Keyed by absolute incoming label, value
     /// carries the swap/pop action + the nexthops where the kernel
@@ -525,6 +531,7 @@ impl Ospf<Ospfv2> {
             graph: None,
             spf_flex_algo: BTreeMap::new(),
             rib_flex_algo: BTreeMap::new(),
+            rib6_flex_algo: BTreeMap::new(),
             rib: PrefixMap::new(),
             ilm: BTreeMap::new(),
             ilm6: BTreeMap::new(),
@@ -3652,6 +3659,7 @@ impl Ospf<Ospfv3> {
             graph: None,
             spf_flex_algo: BTreeMap::new(),
             rib_flex_algo: BTreeMap::new(),
+            rib6_flex_algo: BTreeMap::new(),
             rib: PrefixMap::new(),
             ilm: BTreeMap::new(),
             ilm6: BTreeMap::new(),
@@ -7337,6 +7345,128 @@ fn build_rib_from_flex_algo(
     rib
 }
 
+/// v6 sibling of `rib_insert`: keep the lowest-metric route for a
+/// prefix, merging nexthops on an exact metric tie (ECMP).
+fn rib6_insert(
+    rib: &mut PrefixMap<ipnet::Ipv6Net, SpfRouteV3>,
+    prefix: ipnet::Ipv6Net,
+    route: SpfRouteV3,
+) {
+    if let Some(curr) = rib.get_mut(&prefix) {
+        if curr.metric > route.metric {
+            *curr = route;
+        } else if curr.metric == route.metric {
+            for (addr, nhop) in route.nhops {
+                curr.nhops.insert(addr, nhop);
+            }
+        }
+    } else {
+        rib.insert(prefix, route);
+    }
+}
+
+/// OSPFv3 sibling of `build_rib_from_flex_algo`: build the per-algo
+/// IPv6 RIB from peer E-Intra-Area-Prefix-LSAs carrying a per-algo
+/// Prefix-SID (RFC 9350 §7). For each such prefix whose originator is
+/// reachable under `algo`'s FAD-filtered SPF (`spf_result`), resolve
+/// the Prefix-SID label against the advertiser's SRGB
+/// (`Lsdb::label_map`) and record the per-algo nexthops. Self prefixes
+/// are skipped (pushing a label onto our own /128 is nonsensical),
+/// matching `build_rib_from_flex_algo`.
+fn build_rib6_from_flex_algo(
+    top: &Ospf<Ospfv3>,
+    area_id: Ipv4Addr,
+    algo: u8,
+    spf_result: &BTreeMap<usize, spf::Path>,
+) -> PrefixMap<ipnet::Ipv6Net, SpfRouteV3> {
+    use ospf_packet::{
+        OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE, Ospfv3ExtTlv, Ospfv3LsBody, Ospfv3SubTlv,
+    };
+
+    use crate::ospf::lsdb::OSPF_MAX_AGE;
+
+    let mut rib = PrefixMap::<ipnet::Ipv6Net, SpfRouteV3>::new();
+    let Some(area) = top.areas.get(area_id) else {
+        return rib;
+    };
+
+    for ((_ls_id, adv_router), lsa) in area
+        .lsdb
+        .iter_by_raw_type(OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE)
+    {
+        if lsa.data.h.ls_age >= OSPF_MAX_AGE {
+            continue;
+        }
+        if adv_router == top.router_id {
+            continue;
+        }
+        let Ospfv3LsBody::EIntraAreaPrefix(ref body) = lsa.data.body else {
+            continue;
+        };
+        let Some(label_config) = area.lsdb.label_map.get(&adv_router) else {
+            continue;
+        };
+        // Per-algo path to the prefix's originator. Unreachable under
+        // this algo's FAD-filtered topology ⇒ not forwardable ⇒ skip.
+        let Some(origin_node) = top.lsp_map.lookup(adv_router) else {
+            continue;
+        };
+        let Some(path) = spf_result.get(&origin_node) else {
+            continue;
+        };
+        let nhops: BTreeMap<std::net::Ipv6Addr, SpfNexthopV3> = collect_v3_nexthops(top, path)
+            .into_iter()
+            .map(|(addr, ifindex)| {
+                (
+                    addr,
+                    SpfNexthopV3 {
+                        ifindex,
+                        adjacency: false,
+                    },
+                )
+            })
+            .collect();
+        if nhops.is_empty() {
+            continue;
+        }
+
+        for tlv in &body.tlvs {
+            let Ospfv3ExtTlv::IntraAreaPrefix(prefix_tlv) = tlv else {
+                continue;
+            };
+            let Some(prefix) =
+                ospfv3_prefix_to_ipv6net(prefix_tlv.prefix_length, &prefix_tlv.address_prefix)
+            else {
+                continue;
+            };
+            for sub in &prefix_tlv.subs {
+                let Ospfv3SubTlv::PrefixSid(ps) = sub else {
+                    continue;
+                };
+                if ps.algo != Algo::FlexAlgo(algo) {
+                    continue;
+                }
+                let (value, sid_label) = match ps.sid {
+                    SidLabelTlv::Label(v) => (SidLabelValue::Label(v), Some(v)),
+                    SidLabelTlv::Index(v) => (
+                        SidLabelValue::Index(v),
+                        label_config.global.start.checked_add(v),
+                    ),
+                };
+                let route = SpfRouteV3 {
+                    metric: path.cost,
+                    nhops: nhops.clone(),
+                    sid: sid_label,
+                    prefix_sid: Some((value, label_config.clone())),
+                };
+                rib6_insert(&mut rib, prefix, route);
+                break;
+            }
+        }
+    }
+    rib
+}
+
 /// Walk Type 5 (AS-External) LSAs in the AS-scoped LSDB and install
 /// external routes per RFC 2328 §16.4.
 ///
@@ -7916,8 +8046,23 @@ fn apply_v3_spf_result(top: &mut Ospf<Ospfv3>, output: SpfOutput) {
     top.spf_result = Some(spf_result);
     top.graph = Some(graph);
 
-    // Per-algo SPF trees, for `show ipv6 ospf flex-algo`. Per-algo v6
-    // RIB + Prefix-SID ILM install are the next v3 slices.
+    // Per-algo IPv6 RIBs from the per-algo SPF results (top borrowed
+    // immutably, so collect locally then swap the field). Single
+    // (last-computed-area) snapshot, like `spf_result` — fine for the
+    // common single-area flex-algo deployment. Mirror of v2's
+    // apply_spf_result.
+    let mut rib6_flex_algo = BTreeMap::new();
+    for o in &flex_algos {
+        let algo_rib = match &o.spf_result {
+            Some(spf_res) => build_rib6_from_flex_algo(top, area_id, o.algo, spf_res),
+            None => PrefixMap::new(),
+        };
+        rib6_flex_algo.insert(o.algo, algo_rib);
+    }
+    top.rib6_flex_algo = rib6_flex_algo;
+
+    // Per-algo SPF trees, for `show ipv6 ospf flex-algo`. Per-algo
+    // Prefix-SID ILM install (ilm6) is the next v3 slice.
     top.spf_flex_algo = flex_algos
         .into_iter()
         .map(|o| (o.algo, o.spf_result))

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -969,6 +969,34 @@ fn show_ospfv3_flex_algo(
             Some(None) => writeln!(buf, "  SPF: no source vertex in per-algo topology")?,
             None => writeln!(buf, "  SPF: not yet computed")?,
         }
+
+        // Per-algo v6 RIB: prefixes forwardable under this algo (those
+        // carrying a per-algo Prefix-SID), with the resolved MPLS label
+        // and the per-algo nexthops.
+        if let Some(rib) = top.rib6_flex_algo.get(algo) {
+            if rib.iter().next().is_none() {
+                writeln!(buf, "  Routes: none (no per-algo Prefix-SIDs reachable)")?;
+            } else {
+                writeln!(buf, "  Routes:")?;
+                for (prefix, route) in rib.iter() {
+                    let label = route
+                        .sid
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| "-".to_string());
+                    let nh = route
+                        .nhops
+                        .keys()
+                        .map(|a| a.to_string())
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    writeln!(
+                        buf,
+                        "    {prefix}  metric {}  label {label}  via {nh}",
+                        route.metric
+                    )?;
+                }
+            }
+        }
         writeln!(buf)?;
     }
     Ok(buf)


### PR DESCRIPTION
## Summary

Second slice of the OSPFv3 flex-algo consumer (v3-4b): build the
per-algo IPv6 RIB in memory, no kernel install yet. The OSPFv3 analog
of the v2 4b work (#1097).

- New `Ospf<V>` field `rib6_flex_algo: BTreeMap<u8, PrefixMap<Ipv6Net,
  SpfRouteV3>>` (the existing `rib_flex_algo` is IPv4-typed; v3 needs a
  v6 sibling).
- **`build_rib6_from_flex_algo`** walks peer E-Intra-Area-Prefix-LSAs,
  and for each prefix carrying a per-algo Prefix-SID whose originator is
  reachable under that algo's FAD-filtered SPF, resolves the label via
  the advertiser's SRGB (`Lsdb::label_map`) and records the per-algo
  nexthops (`collect_v3_nexthops`). Self prefixes skipped. Driven by the
  per-algo Prefix-SIDs in peer LSAs (the SR-MPLS-forwardable prefixes),
  not a stub/transit walk — mirrors `build_rib_from_flex_algo`.
- **`rib6_insert`** helper (v6 sibling of `rib_insert`): lowest-metric
  wins, ECMP merge on a tie.
- **`apply_v3_spf_result`** builds the per-algo RIBs and stores
  `rib6_flex_algo`.
- **`show ipv6 ospf flex-algo`** now lists each algo's routes
  (prefix / metric / label / nexthops).

Per-algo IPv6 stays in-memory (the global v6 table has no algorithm
dimension); only the per-algo Prefix-SID labels reach the kernel, via
`ilm6` in the final v3-4c slice.

## Test plan

- `cargo build -p zebra-rs` — clean.
- `cargo test -p zebra-rs ospf::` — 35 pass.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)