### PR TITLE
ospf: install OSPFv3 per-algo Prefix-SID labels to kernel MPLS ILM

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -8041,16 +8041,12 @@ fn apply_v3_spf_result(top: &mut Ospf<Ospfv3>, output: SpfOutput) {
     top.spf_duration = Some(duration);
     top.spf_last = Some(last);
 
-    apply_routing_updates_v3(top, area_id, source, &spf_result);
-
-    top.spf_result = Some(spf_result);
-    top.graph = Some(graph);
-
     // Per-algo IPv6 RIBs from the per-algo SPF results (top borrowed
     // immutably, so collect locally then swap the field). Single
     // (last-computed-area) snapshot, like `spf_result` — fine for the
     // common single-area flex-algo deployment. Mirror of v2's
-    // apply_spf_result.
+    // apply_spf_result. Built BEFORE apply_routing_updates_v3 so the
+    // ILM merge there can read `top.rib6_flex_algo`.
     let mut rib6_flex_algo = BTreeMap::new();
     for o in &flex_algos {
         let algo_rib = match &o.spf_result {
@@ -8061,8 +8057,12 @@ fn apply_v3_spf_result(top: &mut Ospf<Ospfv3>, output: SpfOutput) {
     }
     top.rib6_flex_algo = rib6_flex_algo;
 
-    // Per-algo SPF trees, for `show ipv6 ospf flex-algo`. Per-algo
-    // Prefix-SID ILM install (ilm6) is the next v3 slice.
+    apply_routing_updates_v3(top, area_id, source, &spf_result);
+
+    top.spf_result = Some(spf_result);
+    top.graph = Some(graph);
+
+    // Per-algo SPF trees, for `show ipv6 ospf flex-algo`.
     top.spf_flex_algo = flex_algos
         .into_iter()
         .map(|o| (o.algo, o.spf_result))
@@ -8547,6 +8547,18 @@ fn apply_routing_updates_v3(
     // pop and self-Adj-SID / LAN-Adj-SID pop entries are layered in
     // here, mirroring the v2 ordering.
     let mut new_ilm = build_ilm_from_rib6(&new_rib);
+    // Per-Flexible-Algorithm Prefix-SID labels (RFC 9350 §7). The label
+    // space is shared with algo-0 (Prefix-SIDs are globally unique), so
+    // the per-algo entries coexist in the single ILM map and install
+    // into the kernel MPLS LFIB alongside algo-0 via the same diff
+    // below. Per-algo IPv6 stays in-memory; only the labels forward,
+    // mirroring v2 / IS-IS. `top.rib6_flex_algo` was populated by
+    // `apply_v3_spf_result` before this call.
+    for algo_rib in top.rib6_flex_algo.values() {
+        for (label, spf_ilm) in build_ilm_from_rib6(algo_rib) {
+            new_ilm.insert(label, spf_ilm);
+        }
+    }
     add_self_prefix_sids_to_ilm_v3(top, &mut new_ilm);
     add_self_adj_sids_to_ilm_v3(top, &mut new_ilm);
     let ilm_diff = spf::table_diff(


### PR DESCRIPTION
## Summary

Final slice of OSPFv3 flex-algo (v3-4c): per-algo Prefix-SID MPLS-ILM
kernel install — the forwarding finish line. The OSPFv3 analog of the
v2 4c work (#1098). **OSPFv3 flex-algo now forwards SR-MPLS
end-to-end**, at full parity with OSPFv2.

- **`apply_routing_updates_v3`** merges each `rib6_flex_algo`'s
  `build_ilm_from_rib6` output into the `ilm6` map before the diff, so
  the per-algo Prefix-SID labels install into the kernel MPLS LFIB
  alongside algo-0. The label space is shared with algo-0 (Prefix-SIDs
  are globally unique), so the entries coexist and ride the existing
  `ilm6` diff.
- **`apply_v3_spf_result`** reordered: the per-algo `rib6_flex_algo`
  build now runs *before* `apply_routing_updates_v3` (which reads
  `top.rib6_flex_algo` for the merge), matching v2's `apply_spf_result`
  ordering.

## OSPFv3 flex-algo series (complete)

| Phase | PR | Content |
|-------|-----|---------|
| v3-1 | #1099 | FAD + ASLA codec |
| v3-2 | #1100 | config dispatch + YANG |
| v3-3a | #1101 | SR-Algorithm + FAD origination |
| v3-3b | #1102 | per-link ASLA origination |
| v3-3c | #1103 | per-algo Prefix-SID origination |
| v3-4a | #1104 | per-algo SPF compute + show |
| v3-4b | #1105 | per-algo IPv6 RIB (in-memory) |
| v3-4c | this | per-algo Prefix-SID ILM install |

## Test plan

- `cargo build -p zebra-rs` — clean.
- `cargo test -p zebra-rs ospf::` — 35 pass.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)