### PR TITLE
chore: bump libyang rev to 89142f0e

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -19,7 +19,7 @@ tokio-stream.workspace = true
 tonic.workspace = true
 tonic-prost.workspace = true
 console-subscriber = "0.5"
-libyang = { git = "https://github.com/zebra-rs/libyang", rev = "406c9c04145e6faf956624468a613ad47798a894" }
+libyang = { git = "https://github.com/zebra-rs/libyang", rev = "89142f0e50616087e1f48fd85abd84e943f1be26" }
 #libyang = { path = "../../libyang" }
 regex = "1.10"
 similar = "3"


### PR DESCRIPTION
## Summary

Bump the pinned `libyang` revision from `406c9c04` to the latest upstream `main` HEAD (`89142f0e`).

## Test plan

- `cargo build -p zebra-rs` — compiles clean against the new revision.
- `cargo test -p zebra-rs yang_load` — both `yang_load_tests::exec_mode_loads` and `configure_mode_loads` pass, confirming the runtime YANG schema still loads with the new libyang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)