### PR TITLE
ospf: TI-LFA fast-reroute for OSPFv2 (RFC 9490)

### DIFF
--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -133,6 +133,11 @@ impl Ospf {
             config_ospf_interface_adjacency_sid_absolute,
         );
         self.ospf_add("/segment-routing/mpls", config_ospf_sr_mpls);
+        self.ospf_add("/fast-reroute/ti-lfa", config_ospf_ti_lfa);
+        self.ospf_add(
+            "/fast-reroute/backup-as-primary",
+            config_ospf_fast_reroute_backup_as_primary,
+        );
         self.ospf_add(
             "/graceful-restart/helper-enabled",
             config_ospf_gr_helper_enabled,
@@ -985,6 +990,46 @@ fn config_ospf_interface_adjacency_sid_absolute(
 
     ospf.ext_link_lsa_originate(ifindex);
 
+    Some(())
+}
+
+/// `/router/ospf/fast-reroute/ti-lfa`. Gates the per-destination
+/// TI-LFA repair computation (RFC 9490). On a state change, kick an
+/// SPF recompute for every attached area so the RIB picks up repair
+/// paths (on enable) or drops them (on disable). No LSA re-origination
+/// is needed: the repair is a local install-side decision and changes
+/// nothing this router advertises.
+fn config_ospf_ti_lfa(ospf: &mut Ospf, _args: Args, op: ConfigOp) -> Option<()> {
+    let prev = ospf.ti_lfa_enabled;
+    ospf.ti_lfa_enabled = op.is_set();
+    if ospf.ti_lfa_enabled == prev {
+        return Some(());
+    }
+    let area_ids: Vec<Ipv4Addr> = ospf.areas.iter().map(|(id, _)| *id).collect();
+    for id in area_ids {
+        let _ = ospf.tx.send(Message::SpfCalc(id));
+    }
+    Some(())
+}
+
+/// `/router/ospf/fast-reroute/backup-as-primary`. Inverts the
+/// primary/backup metric ordering at install time. Re-run SPF so the
+/// RIB rebuilds with the swapped offset; like the ti-lfa toggle this
+/// is install-side only and needs no LSA re-origination.
+fn config_ospf_fast_reroute_backup_as_primary(
+    ospf: &mut Ospf,
+    _args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let prev = ospf.fast_reroute_backup_as_primary;
+    ospf.fast_reroute_backup_as_primary = op.is_set();
+    if ospf.fast_reroute_backup_as_primary == prev {
+        return Some(());
+    }
+    let area_ids: Vec<Ipv4Addr> = ospf.areas.iter().map(|(id, _)| *id).collect();
+    for id in area_ids {
+        let _ = ospf.tx.send(Message::SpfCalc(id));
+    }
     Some(())
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -38,6 +38,7 @@ use super::lsdb::{LsdbEvent, OspfLsaKey, seq_max, v2_lsa_key_unpack};
 use super::network::{read_packet, write_packet};
 use super::nfsm::{NfsmEvent, ospf_nfsm};
 use super::socket::ospf_socket_ipv4;
+use super::tilfa::{RepairPathMpls, build_repair_path_mpls, tilfa_repair_path};
 use super::tracing::OspfTracing;
 use super::version::{OspfVersion, Ospfv3};
 use super::{
@@ -81,6 +82,22 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     pub lsp_map: LspMap,
     pub spf_result: Option<BTreeMap<usize, Path>>,
     pub graph: Option<spf::Graph>,
+    /// `/router/ospf/fast-reroute/ti-lfa` — gates the per-destination
+    /// TI-LFA repair-path computation (RFC 9490). When off, the SPF
+    /// primary RIB still installs; only the repair backups are skipped.
+    pub ti_lfa_enabled: bool,
+    /// `/router/ospf/fast-reroute/backup-as-primary` — swap the
+    /// metric-sort so the TI-LFA repair installs ahead of the SPF
+    /// primary. A protection-testing knob; no effect when
+    /// `ti_lfa_enabled` is off (there is no repair to promote).
+    pub fast_reroute_backup_as_primary: bool,
+    /// Per-destination TI-LFA repair paths from the most recent SPF
+    /// (keyed by destination vertex id), mirror of `spf_result`'s
+    /// single-area snapshot. Produced graph-only on the SPF worker;
+    /// resolved to MPLS labels + stamped onto the RIB on the main task.
+    /// Read by `show ip ospf ti-lfa`. `None` until the first run with
+    /// TI-LFA enabled.
+    pub tilfa_result: Option<BTreeMap<usize, Vec<spf::RepairPath>>>,
     /// Per-Flexible-Algorithm SPF trees (RFC 9350), keyed by algo id
     /// (128..=255 from `flex_algo.config`). `None` for an algo whose
     /// per-algo graph had no source this cycle. Recomputed each SPF
@@ -529,6 +546,9 @@ impl Ospf<Ospfv2> {
             lsp_map: LspMap::default(),
             spf_result: None,
             graph: None,
+            ti_lfa_enabled: false,
+            fast_reroute_backup_as_primary: false,
+            tilfa_result: None,
             spf_flex_algo: BTreeMap::new(),
             rib_flex_algo: BTreeMap::new(),
             rib6_flex_algo: BTreeMap::new(),
@@ -3657,6 +3677,9 @@ impl Ospf<Ospfv3> {
             lsp_map: LspMap::default(),
             spf_result: None,
             graph: None,
+            ti_lfa_enabled: false,
+            fast_reroute_backup_as_primary: false,
+            tilfa_result: None,
             spf_flex_algo: BTreeMap::new(),
             rib_flex_algo: BTreeMap::new(),
             rib6_flex_algo: BTreeMap::new(),
@@ -6530,94 +6553,151 @@ fn graph(top: &mut Ospf, area_id: Ipv4Addr) -> (spf::Graph, Option<usize>) {
         }
     }
 
-    // Process each Router-LSA to build graph vertices and edges.
-    for (adv_router, originated, lsa_data) in &router_lsas {
-        let node_id = top.lsp_map.get(*adv_router);
+    // Map each neighbor router-id we hold a local adjacency to -> the
+    // ifindex of the interface it sits on. Used to stamp `link_id`
+    // onto the edges emitted from our own Router-LSA so TI-LFA's repair
+    // first-hop resolves back to a concrete local egress interface
+    // (mirrors IS-IS's `local_adj_to_ifindex`). Edges from other
+    // routers' LSAs carry `link_id = 0`: SPF propagates the field
+    // untouched, but only the first-hop slot of our own edges is
+    // consumed at install time. Parallel adjacencies to the same peer
+    // collapse to the last-inserted ifindex (one repair nexthop), the
+    // same trade-off IS-IS accepts.
+    let mut nbr_to_ifindex: HashMap<Ipv4Addr, u32> = HashMap::new();
+    for (ifindex, link) in top.links.iter() {
+        for (_, nbr) in link.nbrs.iter() {
+            nbr_to_ifindex.insert(nbr.ident.router_id, *ifindex);
+        }
+    }
 
+    // Pass 1: create every vertex and resolve the source. Vertices must
+    // all exist before edges are wired so pass 2 can push each edge onto
+    // both the originating vertex's `olinks` and the target's `ilinks`.
+    for (adv_router, originated, _lsa_data) in &router_lsas {
+        let node_id = top.lsp_map.get(*adv_router);
         if *originated {
             source_node = Some(node_id);
         }
-
-        let mut vertex = spf::Vertex {
+        let vertex = spf::Vertex {
             id: node_id,
             name: adv_router.to_string(),
             sys_id: adv_router.to_string(),
             ..Default::default()
         };
-
-        if let OspfLsp::Router(ref router_lsa) = lsa_data.lsp {
-            for link in &router_lsa.links {
-                match link.link_type {
-                    OspfLinkType::P2p | OspfLinkType::VirtualLink => {
-                        // Bidirectional check: peer's Router-LSA must exist
-                        // (non-MaxAge) AND carry a P2P/Virtual link back to
-                        // us. Otherwise the edge is one-way and SPF would
-                        // compute a route to a destination that can't route
-                        // back.
-                        let Some(peer_lsa) = router_lsa_by_id.get(&link.link_id) else {
-                            continue;
-                        };
-                        let has_backlink = peer_lsa.links.iter().any(|l| {
-                            matches!(l.link_type, OspfLinkType::P2p | OspfLinkType::VirtualLink)
-                                && l.link_id == *adv_router
-                        });
-                        if !has_backlink {
-                            continue;
-                        }
-                        let to_id = top.lsp_map.get(link.link_id);
-                        vertex.olinks.push(spf::Link {
-                            from: node_id,
-                            to: to_id,
-                            cost: link.tos_0_metric as u32,
-                            link_id: 0,
-                        });
-                    }
-                    OspfLinkType::Transit => {
-                        // Bidirectional check: the Network-LSA must list us
-                        // in its attached_routers; otherwise our claim of
-                        // membership doesn't match the DR's view and the
-                        // back-edge is missing.
-                        //
-                        // link_id = DR's interface IP, which is the
-                        // Network-LSA's ls_id.
-                        let Some(attached) = network_lsas.get(&link.link_id) else {
-                            continue;
-                        };
-                        if !attached.contains(adv_router) {
-                            continue;
-                        }
-                        for attached_router in attached {
-                            if *attached_router == *adv_router {
-                                continue;
-                            }
-                            // Each peer router on the network must itself
-                            // have a valid Router-LSA. Without one, the
-                            // back-link from the pseudo-node to that
-                            // router is missing.
-                            if !router_lsa_by_id.contains_key(attached_router) {
-                                continue;
-                            }
-                            let to_id = top.lsp_map.get(*attached_router);
-                            vertex.olinks.push(spf::Link {
-                                from: node_id,
-                                to: to_id,
-                                cost: link.tos_0_metric as u32,
-                                link_id: 0,
-                            });
-                        }
-                    }
-                    OspfLinkType::Stub => {
-                        // Stub (3): destination prefix, not an SPF edge.
-                        // Consumed by build_rib_from_spf.
-                    }
-                }
-            }
-        }
-
         graph.insert(node_id, vertex);
     }
 
+    // Pass 2: wire edges. Each edge is pushed onto the originating
+    // vertex's `olinks` (forward SPF, unchanged from the previous
+    // olinks-only build) and onto the target vertex's `ilinks`. The
+    // ilinks are new: TI-LFA's Q-space is a reverse SPF that walks
+    // incoming edges, which the old builder never populated.
+    for (adv_router, originated, lsa_data) in &router_lsas {
+        let node_id = top.lsp_map.get(*adv_router);
+        let OspfLsp::Router(ref router_lsa) = lsa_data.lsp else {
+            continue;
+        };
+        for link in &router_lsa.links {
+            match link.link_type {
+                OspfLinkType::P2p | OspfLinkType::VirtualLink => {
+                    // Bidirectional check: peer's Router-LSA must exist
+                    // (non-MaxAge) AND carry a P2P/Virtual link back to
+                    // us. Otherwise the edge is one-way and SPF would
+                    // compute a route to a destination that can't route
+                    // back.
+                    let Some(peer_lsa) = router_lsa_by_id.get(&link.link_id) else {
+                        continue;
+                    };
+                    let has_backlink = peer_lsa.links.iter().any(|l| {
+                        matches!(l.link_type, OspfLinkType::P2p | OspfLinkType::VirtualLink)
+                            && l.link_id == *adv_router
+                    });
+                    if !has_backlink {
+                        continue;
+                    }
+                    let to_id = top.lsp_map.get(link.link_id);
+                    let link_id = if *originated {
+                        nbr_to_ifindex.get(&link.link_id).copied().unwrap_or(0)
+                    } else {
+                        0
+                    };
+                    push_edge(
+                        &mut graph,
+                        node_id,
+                        to_id,
+                        link.tos_0_metric as u32,
+                        link_id,
+                    );
+                }
+                OspfLinkType::Transit => {
+                    // Bidirectional check: the Network-LSA must list us
+                    // in its attached_routers; otherwise our claim of
+                    // membership doesn't match the DR's view and the
+                    // back-edge is missing.
+                    //
+                    // link.link_id = DR's interface IP, which is the
+                    // Network-LSA's ls_id.
+                    let Some(attached) = network_lsas.get(&link.link_id) else {
+                        continue;
+                    };
+                    if !attached.contains(adv_router) {
+                        continue;
+                    }
+                    for attached_router in attached {
+                        if *attached_router == *adv_router {
+                            continue;
+                        }
+                        // Each peer router on the network must itself
+                        // have a valid Router-LSA. Without one, the
+                        // back-link from the pseudo-node to that
+                        // router is missing.
+                        if !router_lsa_by_id.contains_key(attached_router) {
+                            continue;
+                        }
+                        let to_id = top.lsp_map.get(*attached_router);
+                        let link_id = if *originated {
+                            nbr_to_ifindex.get(attached_router).copied().unwrap_or(0)
+                        } else {
+                            0
+                        };
+                        push_edge(
+                            &mut graph,
+                            node_id,
+                            to_id,
+                            link.tos_0_metric as u32,
+                            link_id,
+                        );
+                    }
+                }
+                OspfLinkType::Stub => {
+                    // Stub (3): destination prefix, not an SPF edge.
+                    // Consumed by build_rib_from_spf.
+                }
+            }
+        }
+    }
+
     (graph, source_node)
+}
+
+/// Push one directed SPF edge into `graph`: onto the originating
+/// vertex's `olinks` (forward SPF) and the target vertex's `ilinks`
+/// (reverse SPF for TI-LFA's Q-space). Both endpoints are expected to
+/// already exist in `graph` (created in pass 1); a missing endpoint is
+/// silently skipped, matching the previous olinks-only behavior.
+fn push_edge(graph: &mut spf::Graph, from: usize, to: usize, cost: u32, link_id: u32) {
+    let link = spf::Link {
+        from,
+        to,
+        cost,
+        link_id,
+    };
+    if let Some(v) = graph.get_mut(&from) {
+        v.olinks.push(link.clone());
+    }
+    if let Some(v) = graph.get_mut(&to) {
+        v.ilinks.push(link);
+    }
 }
 
 /// Routers in `area` that participate in Flex-Algorithm `algo` — i.e.
@@ -6822,6 +6902,23 @@ pub struct SpfRoute {
     pub nhops: BTreeMap<Ipv4Addr, SpfNexthop>,
     pub sid: Option<u32>,
     pub prefix_sid: Option<(SidLabelValue, LabelConfig)>,
+    /// SPF vertex id this route was built from (the prefix's
+    /// advertising router, or the ABR/ASBR for inter-area / external
+    /// routes). Set at build time; used by the TI-LFA second pass to
+    /// join a route with the per-destination repair computed against
+    /// that vertex's first-hop. `None` for routes that carry no
+    /// single SPF destination (e.g. per-Flex-Algo entries, which have
+    /// no TI-LFA today).
+    pub dest_vertex: Option<usize>,
+    /// Value of `fast-reroute backup-as-primary` when this route was
+    /// built. Carried on the route — rather than read globally at
+    /// install time — so it participates in the `PartialEq` that
+    /// `spf::table_diff` uses to gate RIB updates: the flag flips the
+    /// primary/backup metric in `make_rib_entry`, so two routes with
+    /// identical SPF output but a different flag install differently,
+    /// and without this field a toggle-then-recompute would diff clean
+    /// and never reach the RIB. Mirrors IS-IS's `SpfRoute`.
+    pub backup_as_primary: bool,
 }
 
 /// One entry in the SR-MPLS LFIB shadow held on `Ospf::ilm`.
@@ -6838,6 +6935,13 @@ pub struct SpfNexthop {
     pub ifindex: u32,
     pub adjacency: bool,
     pub router_id: Option<Ipv4Addr>,
+    /// TI-LFA post-convergence repair for this primary nexthop, or
+    /// `None` when TI-LFA is off, the route is ECMP, or no repair
+    /// resolved. Set only on the single primary nexthop of a RIB
+    /// route by the TI-LFA second pass in `build_rib_from_spf`;
+    /// always `None` for ILM / adjacency nexthops. `make_rib_entry`
+    /// renders it as a second NexthopUni at the backup metric offset.
+    pub backup: Option<RepairPathMpls>,
 }
 
 /// v3 RIB entry. Simpler than the v2 `SpfRoute` shape because v3
@@ -6926,6 +7030,9 @@ fn build_spf_nexthops(
                         ifindex: *ifindex,
                         adjacency: p[0] == target_id,
                         router_id: Some(*nhop_id),
+                        // Stamped by the TI-LFA second pass (single-
+                        // primary routes only); None at build time.
+                        backup: None,
                     };
                     nhops.insert(addr, nhop);
                 }
@@ -7000,6 +7107,10 @@ fn add_inter_area_routes(
             nhops,
             sid: None,
             prefix_sid: None,
+            // Protect the path to the ABR: TI-LFA's repair is computed
+            // against the first-hop toward `abr_vertex`.
+            dest_vertex: Some(abr_vertex),
+            backup_as_primary: top.fast_reroute_backup_as_primary,
         };
         rib_insert(rib, prefix, spf_route);
     }
@@ -7034,6 +7145,7 @@ fn attached_nhops(ifindex: u32) -> BTreeMap<Ipv4Addr, SpfNexthop> {
             ifindex,
             adjacency: false,
             router_id: None,
+            backup: None,
         },
     );
     nhops
@@ -7044,6 +7156,7 @@ fn build_rib_from_spf(
     area_id: Ipv4Addr,
     source: usize,
     spf_result: &BTreeMap<usize, spf::Path>,
+    tilfa_result: &BTreeMap<usize, Vec<spf::RepairPath>>,
 ) -> PrefixMap<Ipv4Net, SpfRoute> {
     let mut rib = PrefixMap::<Ipv4Net, SpfRoute>::new();
 
@@ -7120,6 +7233,8 @@ fn build_rib_from_spf(
                                         nhops: route_nhops,
                                         sid: None,
                                         prefix_sid: None,
+                                        dest_vertex: Some(*node),
+                                        backup_as_primary: top.fast_reroute_backup_as_primary,
                                     };
                                     rib_insert(&mut rib, prefix, spf_route);
                                 }
@@ -7158,6 +7273,8 @@ fn build_rib_from_spf(
                                 nhops: route_nhops,
                                 sid: None,
                                 prefix_sid: None,
+                                dest_vertex: Some(*node),
+                                backup_as_primary: top.fast_reroute_backup_as_primary,
                             };
                             rib_insert(&mut rib, prefix, spf_route);
                         }
@@ -7191,6 +7308,35 @@ fn build_rib_from_spf(
     // change here -- this only populates `SpfRoute.prefix_sid` so the
     // show command and a follow-up ILM-install pass can consume it.
     add_prefix_sids(top, area_id, &mut rib);
+
+    // TI-LFA second pass: stamp the post-convergence repair backup
+    // onto single-primary routes. ECMP routes (>1 nexthop) are
+    // skipped — the surviving ECMP legs already protect the prefix,
+    // mirroring IS-IS. `tilfa_repair_path` only emits repairs for
+    // single-primary SPF destinations, so the `dest_vertex` lookup
+    // either yields a repair built against a single protected
+    // first-hop or nothing. Resolving a repair list to an MPLS label
+    // stack needs the LSDB, which is why this runs on the main task
+    // (here) rather than on the SPF worker that produced the lists.
+    if let Some(area) = top.areas.get(area_id) {
+        for (_, route) in rib.iter_mut() {
+            if route.nhops.len() != 1 {
+                continue;
+            }
+            let Some(dest) = route.dest_vertex else {
+                continue;
+            };
+            let Some(repair) = tilfa_result.get(&dest).and_then(|paths| paths.first()) else {
+                continue;
+            };
+            let Some(backup) = build_repair_path_mpls(top, area, repair) else {
+                continue;
+            };
+            if let Some(nhop) = route.nhops.values_mut().next() {
+                nhop.backup = Some(backup);
+            }
+        }
+    }
 
     rib
 }
@@ -7336,6 +7482,11 @@ fn build_rib_from_flex_algo(
                     nhops: nhops.clone(),
                     sid: sid_label,
                     prefix_sid: Some((value, label_config.clone())),
+                    // Per-Flex-Algo routes have no TI-LFA today (the FAD
+                    // topology may not admit the algo-0 repair); leave
+                    // the repair-join fields inert.
+                    dest_vertex: None,
+                    backup_as_primary: false,
                 };
                 rib_insert(&mut rib, tlv.prefix, route);
                 break;
@@ -7538,6 +7689,9 @@ fn add_as_external_routes(
             nhops,
             sid: None,
             prefix_sid: None,
+            // Protect the path to the ASBR.
+            dest_vertex: Some(asbr_vertex),
+            backup_as_primary: top.fast_reroute_backup_as_primary,
         };
         rib_insert(rib, prefix, spf_route);
     }
@@ -7626,6 +7780,9 @@ fn add_nssa_routes(
             nhops,
             sid: None,
             prefix_sid: None,
+            // Protect the path to the NSSA originator (ASBR).
+            dest_vertex: Some(originator_vertex),
+            backup_as_primary: top.fast_reroute_backup_as_primary,
         };
         rib_insert(rib, prefix, spf_route);
     }
@@ -8020,6 +8177,10 @@ fn build_v3_spf_input(top: &mut Ospf<Ospfv3>, area_id: Ipv4Addr) -> Option<SpfIn
         area_id,
         graph,
         source,
+        // OSPFv3 TI-LFA is a follow-up: the v3 SPF graph (`graph_v3`)
+        // does not yet carry reverse edges (ilinks) for Q-space, so
+        // keep the repair computation off for v3 instances.
+        ti_lfa_enabled: false,
         flex_algos,
     })
 }
@@ -8034,6 +8195,9 @@ fn apply_v3_spf_result(top: &mut Ospf<Ospfv3>, output: SpfOutput) {
         graph,
         source,
         spf_result,
+        // OSPFv3 TI-LFA is a follow-up; v3 SPF input keeps it disabled
+        // so this is always empty. Ignore it here.
+        tilfa_result: _,
         duration,
         last,
         flex_algos,
@@ -8635,6 +8799,9 @@ struct SpfInput {
     area_id: Ipv4Addr,
     graph: spf::Graph,
     source: usize,
+    /// `/router/ospf/fast-reroute/ti-lfa` snapshot. Gates the
+    /// graph-only TI-LFA repair computation on the worker.
+    ti_lfa_enabled: bool,
     /// One per configured Flex-Algorithm: its FAD-filtered graph and
     /// source vertex (None if the algo's graph had no source).
     flex_algos: Vec<FlexAlgoSpfInput>,
@@ -8654,6 +8821,11 @@ pub struct SpfOutput {
     graph: spf::Graph,
     source: usize,
     spf_result: BTreeMap<usize, spf::Path>,
+    /// Per-destination TI-LFA repair lists (keyed by destination vertex
+    /// id), computed graph-only on the worker. Empty when TI-LFA is
+    /// disabled. Resolved to MPLS labels + stamped onto the RIB on the
+    /// main task in `apply_spf_result`.
+    tilfa_result: BTreeMap<usize, Vec<spf::RepairPath>>,
     duration: Duration,
     last: Instant,
     flex_algos: Vec<FlexAlgoSpfOutput>,
@@ -8696,6 +8868,7 @@ fn build_spf_input(top: &mut Ospf, area_id: Ipv4Addr) -> Option<SpfInput> {
         area_id,
         graph,
         source,
+        ti_lfa_enabled: top.ti_lfa_enabled,
         flex_algos,
     })
 }
@@ -8707,10 +8880,22 @@ fn compute_spf(input: SpfInput) -> SpfOutput {
         area_id,
         graph,
         source,
+        ti_lfa_enabled,
         flex_algos,
     } = input;
     let start = Instant::now();
     let spf_result = spf::spf(&graph, source, &spf::SpfOpt::default());
+
+    // TI-LFA repair lists, graph-only. Gated on `fast-reroute ti-lfa`;
+    // when off, the SPF primary RIB still installs — only the repair
+    // backups are skipped. Resolution to MPLS labels happens on the
+    // main task in `apply_spf_result` (it needs the LSDB).
+    let tilfa_result = if ti_lfa_enabled {
+        tilfa_repair_path(&graph, source, &spf_result)
+    } else {
+        BTreeMap::new()
+    };
+
     let flex_algos = flex_algos
         .into_iter()
         .map(
@@ -8731,6 +8916,7 @@ fn compute_spf(input: SpfInput) -> SpfOutput {
         graph,
         source,
         spf_result,
+        tilfa_result,
         duration,
         last,
         flex_algos,
@@ -8747,6 +8933,7 @@ fn apply_spf_result(top: &mut Ospf, output: SpfOutput) {
         graph,
         source,
         spf_result,
+        tilfa_result,
         duration,
         last,
         flex_algos,
@@ -8754,11 +8941,14 @@ fn apply_spf_result(top: &mut Ospf, output: SpfOutput) {
     top.spf_duration = Some(duration);
     top.spf_last = Some(last);
 
-    let rib = build_rib_from_spf(top, area_id, source, &spf_result);
+    let rib = build_rib_from_spf(top, area_id, source, &spf_result, &tilfa_result);
 
-    // Store the SPF result and graph in OSPF instance.
+    // Store the SPF result, graph, and TI-LFA repair lists on the
+    // instance (single last-computed-area snapshot, like spf_result).
+    // `show ip ospf ti-lfa` renders tilfa_result against graph.
     top.spf_result = Some(spf_result);
     top.graph = Some(graph);
+    top.tilfa_result = Some(tilfa_result);
 
     // Build the per-algo RIBs from the per-algo SPF results (top is
     // borrowed immutably here, so collect into a local map first, then
@@ -8787,7 +8977,19 @@ fn apply_spf_result(top: &mut Ospf, output: SpfOutput) {
 
 pub type DiffResult<'a> = spf::TableDiffResult<'a, Ipv4Net, SpfRoute>;
 
-fn nhop_to_nexthop_uni(key: &Ipv4Addr, route: &SpfRoute, value: &SpfNexthop) -> rib::NexthopUni {
+/// Sort offset between a primary nexthop's metric and its TI-LFA
+/// backup's metric inside the rendered `Nexthop`. RIB-internal only —
+/// it never reaches the wire; it just governs the metric-sort that
+/// keeps the primary at `.nexthops[0]`. Mirrors IS-IS's
+/// `BACKUP_METRIC_OFFSET`.
+pub const BACKUP_METRIC_OFFSET: u32 = 1;
+
+fn nhop_to_nexthop_uni(
+    key: &Ipv4Addr,
+    route: &SpfRoute,
+    value: &SpfNexthop,
+    metric: u32,
+) -> rib::NexthopUni {
     let mut mpls = vec![];
     if let Some(sid) = route.sid {
         mpls.push(if value.adjacency {
@@ -8796,7 +8998,7 @@ fn nhop_to_nexthop_uni(key: &Ipv4Addr, route: &SpfRoute, value: &SpfNexthop) -> 
             rib::Label::Explicit(sid)
         });
     }
-    let mut nhop = rib::NexthopUni::from(*key, route.metric, mpls);
+    let mut nhop = rib::NexthopUni::from(*key, metric, mpls);
     // OSPF, like IS-IS, learns the egress link from the adjacency
     // state machine, so record it as the origin and let the RIB
     // resolver leave it alone. 0 means "no usable adjacency ifindex"
@@ -8805,31 +9007,103 @@ fn nhop_to_nexthop_uni(key: &Ipv4Addr, route: &SpfRoute, value: &SpfNexthop) -> 
     nhop
 }
 
+/// Render a TI-LFA repair into a backup `NexthopUni`: the repair's
+/// neighbor address, the resolved SR-MPLS label stack, and the chosen
+/// egress ifindex, installed at `metric` (primary.metric + offset, or
+/// swapped under backup-as-primary). Mirrors IS-IS.
+fn backup_to_nexthop_uni(backup: &RepairPathMpls, metric: u32) -> rib::NexthopUni {
+    let mut nhop = rib::NexthopUni::new(
+        std::net::IpAddr::V4(backup.addr),
+        metric,
+        backup.labels.clone(),
+    );
+    nhop.ifindex_origin = (backup.ifindex != 0).then_some(backup.ifindex);
+    nhop
+}
+
 fn make_rib_entry(route: &SpfRoute) -> rib::entry::RibEntry {
     let mut rib = rib::entry::RibEntry::new(RibType::Ospf);
     rib.distance = 110;
     rib.metric = route.metric;
 
-    rib.nexthop = if route.nhops.len() == 1 {
-        if let Some((key, value)) = route.nhops.iter().next() {
-            rib::Nexthop::Uni(nhop_to_nexthop_uni(key, route, value))
-        } else {
-            rib::Nexthop::default()
-        }
+    // Flatten primaries and (when present) their TI-LFA repair backups
+    // into one Vec at distinct metrics; `build_rib_nexthop` groups by
+    // metric and dispatches Uni / Multi / List from there.
+    //
+    // `backup_as_primary` flips the offset: when set, the repair
+    // installs at route.metric (sorted first) and the SPF primary at
+    // route.metric + offset. The flag is read off the route (stamped at
+    // build time) so the value rendered matches what `table_diff` saw.
+    let offset_metric = route.metric.saturating_add(BACKUP_METRIC_OFFSET);
+    let (primary_metric, backup_metric) = if route.backup_as_primary {
+        (offset_metric, route.metric)
     } else {
-        let multi = rib::NexthopMulti {
-            metric: route.metric,
-            nexthops: route
-                .nhops
-                .iter()
-                .map(|(key, value)| nhop_to_nexthop_uni(key, route, value))
-                .collect(),
-            ..Default::default()
-        };
-        rib::Nexthop::Multi(multi)
+        (route.metric, offset_metric)
     };
+    let nhops: Vec<rib::NexthopUni> = route
+        .nhops
+        .iter()
+        .flat_map(|(key, value)| {
+            let primary = nhop_to_nexthop_uni(key, route, value, primary_metric);
+            let backup = value
+                .backup
+                .as_ref()
+                .map(|b| backup_to_nexthop_uni(b, backup_metric));
+            std::iter::once(primary).chain(backup)
+        })
+        .collect();
+    rib.nexthop = build_rib_nexthop(nhops);
 
     rib
+}
+
+// Dispatch a flat list of NexthopUni into the right rib::Nexthop
+// variant. Group nhops by metric (BTreeMap iter is ascending), then:
+//
+//   - 0 groups          -> Nexthop::default()
+//   - 1 group, 1 nhop   -> Nexthop::Uni
+//   - 1 group, N nhops  -> Nexthop::Multi (ECMP)
+//   - >1 groups         -> Nexthop::List, one member per metric.
+//
+// Mirrors IS-IS's `build_rib_nexthop`. With TI-LFA off every nhop sits
+// at route.metric, so only the first three arms fire; a stamped backup
+// adds a second metric group and produces a List (primary then repair).
+fn build_rib_nexthop(nhops: Vec<rib::NexthopUni>) -> rib::Nexthop {
+    if nhops.is_empty() {
+        return rib::Nexthop::default();
+    }
+    let mut groups: BTreeMap<u32, Vec<rib::NexthopUni>> = BTreeMap::new();
+    for n in nhops {
+        groups.entry(n.metric).or_default().push(n);
+    }
+    if groups.len() == 1 {
+        let (metric, mut grp) = groups.into_iter().next().unwrap();
+        if grp.len() == 1 {
+            rib::Nexthop::Uni(grp.pop().unwrap())
+        } else {
+            rib::Nexthop::Multi(rib::NexthopMulti {
+                metric,
+                nexthops: grp,
+                ..Default::default()
+            })
+        }
+    } else {
+        let members: Vec<_> = groups
+            .into_iter()
+            .map(|(metric, mut grp)| {
+                if grp.len() == 1 {
+                    rib::NexthopMember::Uni(grp.pop().unwrap())
+                } else {
+                    rib::NexthopMember::Multi(rib::NexthopMulti {
+                        metric,
+                        nexthops: grp,
+                        ..Default::default()
+                    })
+                }
+            })
+            .collect();
+        rib::Nexthop::List(rib::NexthopList { nexthops: members })
+    }
 }
 
 pub fn diff_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffResult) {
@@ -9127,6 +9401,7 @@ fn add_self_prefix_sids_to_ilm(top: &Ospf, ilm: &mut BTreeMap<u32, SpfIlm>) {
                             ifindex: link.index,
                             adjacency: true,
                             router_id: None,
+                            backup: None,
                         },
                     );
                     ilm.insert(
@@ -9449,6 +9724,7 @@ fn add_self_adj_sids_to_ilm(top: &Ospf, ilm: &mut BTreeMap<u32, SpfIlm>) {
                 ifindex,
                 adjacency: true,
                 router_id: Some(neighbor_router_id),
+                backup: None,
             },
         );
         ilm.insert(

--- a/zebra-rs/src/ospf/mod.rs
+++ b/zebra-rs/src/ospf/mod.rs
@@ -54,6 +54,8 @@ pub use flood::*;
 
 pub mod srmpls;
 
+pub mod tilfa;
+
 pub mod flex_algo;
 
 pub mod tracing;

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -181,6 +181,12 @@ impl Ospf {
         self.show_add("/show/ip/ospf/spf", show_ospf_spf);
         self.show_add("/show/ip/ospf/flex-algo", show_ospf_flex_algo);
         self.show_add("/show/ip/ospf/graph", show_ospf_graph);
+        self.show_add("/show/ip/ospf/ti-lfa", show_ospf_tilfa);
+        self.show_add("/show/ip/ospf/repair-list", show_ospf_repair_list);
+        self.show_add(
+            "/show/ip/ospf/repair-list/detail",
+            show_ospf_repair_list_detail,
+        );
         self.show_add("/show/ip/ospf/segment-routing", show_ospf_segment_routing);
         self.show_add("/show/ip/ospf/graceful-restart", show_ospf_graceful_restart);
         self.show_add("/show/ip/ospf/checkpoint", show_ospf_checkpoint);
@@ -1952,6 +1958,294 @@ fn show_ospf_graph(
         }
         Ok(buf)
     }
+}
+
+// ---------------------------------------------------------------------
+// TI-LFA (RFC 9490) show commands: `show ip ospf ti-lfa` (graph-level
+// per-destination repair lists) and `show ip ospf repair-list` (the
+// repair backups actually stamped onto the installed RIB).
+// ---------------------------------------------------------------------
+
+fn label_value_str(label: &crate::rib::Label) -> String {
+    match label {
+        crate::rib::Label::Implicit(l) => format!("{l} (implicit-null)"),
+        crate::rib::Label::Explicit(l) => format!("{l}"),
+    }
+}
+
+fn ospf_vertex_name(graph: &spf::Graph, id: usize) -> String {
+    graph
+        .get(&id)
+        .map(|v| v.name.clone())
+        .unwrap_or_else(|| format!("v{id}"))
+}
+
+fn format_ospf_sr_segment(graph: &spf::Graph, seg: &spf::SrSegment) -> String {
+    match seg {
+        spf::SrSegment::NodeSid(v) => {
+            format!("Node-SID {} (vertex {})", ospf_vertex_name(graph, *v), v)
+        }
+        // OSPF has no LAN pseudonode in the graph, so `via` is always None.
+        spf::SrSegment::AdjSid(from, to, _via) => format!(
+            "Adj-SID {} -> {} (vertex {} -> {})",
+            ospf_vertex_name(graph, *from),
+            ospf_vertex_name(graph, *to),
+            from,
+            to,
+        ),
+    }
+}
+
+#[derive(Serialize)]
+struct RepairSegmentJson {
+    kind: &'static str,
+    value: String,
+}
+
+#[derive(Serialize)]
+struct RepairRowJson {
+    prefix: String,
+    primary_nexthop: String,
+    primary_ifindex: u32,
+    primary_metric: u32,
+    repair_nexthop: String,
+    repair_ifindex: u32,
+    repair_metric: u32,
+    segments: Vec<RepairSegmentJson>,
+}
+
+#[derive(Serialize)]
+struct RepairListJson {
+    routes: Vec<RepairRowJson>,
+}
+
+/// Walk the installed v4 RIB and collect every prefix whose primary
+/// nexthop carries a stamped TI-LFA repair backup. One row per
+/// (prefix, backed-up nexthop).
+fn collect_ospf_repair_rows(ospf: &Ospf) -> Vec<RepairRowJson> {
+    let mut rows = Vec::new();
+    for (prefix, route) in ospf.rib.iter() {
+        for (addr, nhop) in route.nhops.iter() {
+            let Some(backup) = nhop.backup.as_ref() else {
+                continue;
+            };
+            let segments = backup
+                .labels
+                .iter()
+                .map(|label| RepairSegmentJson {
+                    kind: "sr-mpls",
+                    value: label_value_str(label),
+                })
+                .collect();
+            rows.push(RepairRowJson {
+                prefix: prefix.to_string(),
+                primary_nexthop: addr.to_string(),
+                primary_ifindex: nhop.ifindex,
+                primary_metric: route.metric,
+                repair_nexthop: backup.addr.to_string(),
+                repair_ifindex: backup.ifindex,
+                repair_metric: route
+                    .metric
+                    .saturating_add(super::inst::BACKUP_METRIC_OFFSET),
+                segments,
+            });
+        }
+    }
+    rows
+}
+
+/// `show ip ospf repair-list` — the TI-LFA repair backups installed on
+/// the RIB, one line per protected prefix with its primary and repair
+/// next-hops and the SR-MPLS repair label stack.
+fn show_ospf_repair_list(
+    ospf: &Ospf,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let rows = collect_ospf_repair_rows(ospf);
+    if json {
+        return Ok(
+            serde_json::to_string_pretty(&RepairListJson { routes: rows })
+                .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}")),
+        );
+    }
+    let mut buf = String::new();
+    if rows.is_empty() {
+        writeln!(buf, "(no TI-LFA repair-list entries)")?;
+        return Ok(buf);
+    }
+    writeln!(
+        buf,
+        "{:<22} {:<18} {:<18} Segments",
+        "Prefix", "Primary via", "Repair via",
+    )?;
+    for row in &rows {
+        let segs: Vec<String> = row.segments.iter().map(|s| s.value.clone()).collect();
+        writeln!(
+            buf,
+            "{:<22} {:<18} {:<18} [{}]",
+            row.prefix,
+            row.primary_nexthop,
+            row.repair_nexthop,
+            segs.join(", "),
+        )?;
+    }
+    Ok(buf)
+}
+
+/// `show ip ospf repair-list detail` — same rows as `repair-list`, but
+/// expanded with per-segment label breakdown and the egress ifindex /
+/// metric of each leg.
+fn show_ospf_repair_list_detail(
+    ospf: &Ospf,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let rows = collect_ospf_repair_rows(ospf);
+    if json {
+        return Ok(
+            serde_json::to_string_pretty(&RepairListJson { routes: rows })
+                .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}")),
+        );
+    }
+    let mut buf = String::new();
+    if rows.is_empty() {
+        writeln!(buf, "(no TI-LFA repair-list entries)")?;
+        return Ok(buf);
+    }
+    for row in &rows {
+        writeln!(buf, "{}", row.prefix)?;
+        writeln!(
+            buf,
+            "  Primary: via {} (ifindex {}), metric {}",
+            row.primary_nexthop, row.primary_ifindex, row.primary_metric,
+        )?;
+        writeln!(
+            buf,
+            "  Repair:  via {} (ifindex {}), metric {}",
+            row.repair_nexthop, row.repair_ifindex, row.repair_metric,
+        )?;
+        if row.segments.is_empty() {
+            writeln!(buf, "    (trivial repair, no SR segments)")?;
+        } else {
+            for seg in &row.segments {
+                writeln!(buf, "    {} {}", seg.kind, seg.value)?;
+            }
+        }
+    }
+    Ok(buf)
+}
+
+#[derive(Serialize)]
+struct TilfaSegmentJson {
+    kind: &'static str,
+    description: String,
+}
+
+#[derive(Serialize)]
+struct TilfaRepairJson {
+    first_hop: String,
+    first_hop_vertex: usize,
+    first_hop_link_id: u32,
+    segments: Vec<TilfaSegmentJson>,
+}
+
+#[derive(Serialize)]
+struct TilfaDestJson {
+    destination: String,
+    destination_vertex: usize,
+    repairs: Vec<TilfaRepairJson>,
+}
+
+#[derive(Serialize)]
+struct TilfaJson {
+    destinations: Vec<TilfaDestJson>,
+}
+
+/// `show ip ospf ti-lfa` — the graph-level per-destination repair
+/// paths from the most recent SPF (before RIB stamping), each as a
+/// first-hop plus the SR segment list. Useful for confirming the
+/// algorithm produced a repair even when label resolution later
+/// dropped it (e.g. a peer not advertising the needed Prefix-SID).
+fn show_ospf_tilfa(
+    ospf: &Ospf,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let graph = ospf.graph.as_ref();
+    let tilfa = ospf.tilfa_result.as_ref();
+
+    if json {
+        let destinations = match (graph, tilfa) {
+            (Some(g), Some(t)) => t
+                .iter()
+                .map(|(dest, repairs)| TilfaDestJson {
+                    destination: ospf_vertex_name(g, *dest),
+                    destination_vertex: *dest,
+                    repairs: repairs
+                        .iter()
+                        .map(|rp| TilfaRepairJson {
+                            first_hop: ospf_vertex_name(g, rp.first_hop),
+                            first_hop_vertex: rp.first_hop,
+                            first_hop_link_id: rp.first_hop_link_id,
+                            segments: rp
+                                .segs
+                                .iter()
+                                .map(|seg| TilfaSegmentJson {
+                                    kind: match seg {
+                                        spf::SrSegment::NodeSid(_) => "node-sid",
+                                        spf::SrSegment::AdjSid(..) => "adj-sid",
+                                    },
+                                    description: format_ospf_sr_segment(g, seg),
+                                })
+                                .collect(),
+                        })
+                        .collect(),
+                })
+                .collect(),
+            _ => Vec::new(),
+        };
+        return Ok(serde_json::to_string_pretty(&TilfaJson { destinations })
+            .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}")));
+    }
+
+    let mut buf = String::new();
+    let (Some(graph), Some(tilfa)) = (graph, tilfa) else {
+        writeln!(buf, "(no TI-LFA repair paths computed)")?;
+        return Ok(buf);
+    };
+    if tilfa.is_empty() {
+        writeln!(buf, "(no TI-LFA repair paths computed)")?;
+        return Ok(buf);
+    }
+    writeln!(buf, "OSPF TI-LFA repair paths:")?;
+    for (dest, repairs) in tilfa.iter() {
+        writeln!(
+            buf,
+            "  Destination {} (vertex {})",
+            ospf_vertex_name(graph, *dest),
+            dest,
+        )?;
+        for (i, rp) in repairs.iter().enumerate() {
+            writeln!(
+                buf,
+                "    [{}] first-hop {} (vertex {}, link_id {})",
+                i,
+                ospf_vertex_name(graph, rp.first_hop),
+                rp.first_hop,
+                rp.first_hop_link_id,
+            )?;
+            if rp.segs.is_empty() {
+                writeln!(buf, "        segments: (none — direct repair)")?;
+            } else {
+                writeln!(buf, "        segments:")?;
+                for seg in &rp.segs {
+                    writeln!(buf, "          {}", format_ospf_sr_segment(graph, seg))?;
+                }
+            }
+        }
+    }
+    Ok(buf)
 }
 
 /// `show ip ospf graceful-restart` (RFC 3623 helper status).

--- a/zebra-rs/src/ospf/tilfa.rs
+++ b/zebra-rs/src/ospf/tilfa.rs
@@ -1,0 +1,258 @@
+//! OSPFv2 TI-LFA (Topology-Independent Loop-Free Alternate, RFC 9490)
+//! repair-path resolution.
+//!
+//! The post-convergence repair *list* (a sequence of Node-SID /
+//! Adj-SID segments) is computed graph-only by [`tilfa_repair_path`]
+//! on the SPF worker — it mirrors the IS-IS path and reuses the
+//! protocol-agnostic [`crate::spf::tilfa`]. Turning those segments
+//! into an installable SR-MPLS label stack ([`build_repair_path_mpls`])
+//! needs the LSDB (peer SRGBs, Extended-Prefix / Extended-Link Opaque
+//! LSAs) and so runs on the main task during RIB build.
+//!
+//! Unlike IS-IS, OSPF collapses a transit network into a direct mesh
+//! of router→router edges (there is no pseudonode vertex in the SPF
+//! graph), so there is no LAN-pseudonode handling and every Adj-SID
+//! segment is a plain `(from, to)` pair.
+
+use std::collections::BTreeMap;
+use std::net::Ipv4Addr;
+
+use ospf_packet::{Algo, ExtLinkSubTlv, ExtPrefixSubTlv, OspfLsType, OspfLsp, SidLabelTlv};
+
+use crate::rib;
+use crate::spf;
+use crate::spf::label_block::LabelConfig;
+
+use super::area::OspfArea;
+use super::inst::Ospf;
+use super::lsdb::OSPF_MAX_AGE;
+
+/// TI-LFA SR-MPLS repair path: the post-convergence first-hop egress
+/// (ifindex + neighbor address) plus the MPLS label stack that steers
+/// the packet along the repair. Stamped onto `SpfNexthop.backup`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RepairPathMpls {
+    pub ifindex: u32,
+    pub addr: Ipv4Addr,
+    pub labels: Vec<rib::Label>,
+}
+
+/// Per-destination TI-LFA repair computation (graph-only). For every
+/// destination in `spf_result` other than the source that has a single
+/// primary first-hop (SPF-level ECMP is skipped — the remaining legs
+/// already protect the prefix), call [`spf::tilfa`] to compute the
+/// post-convergence repair list, protecting against the first-hop node
+/// (`X`). The returned map is keyed by destination vertex id.
+///
+/// Runs on the SPF worker, so it borrows nothing but the graph and the
+/// SPF result. The graph must carry `ilinks` (reverse edges) — the
+/// OSPF graph builder populates them for exactly this Q-space step.
+pub(super) fn tilfa_repair_path(
+    graph: &spf::Graph,
+    source: usize,
+    spf_result: &BTreeMap<usize, spf::Path>,
+) -> BTreeMap<usize, Vec<spf::RepairPath>> {
+    let mut tilfa_result = BTreeMap::new();
+    for (d, path) in spf_result.iter() {
+        if *d == source {
+            continue;
+        }
+        // ECMP at the SPF level is skipped. Under `SpfOpt::default()`
+        // the per-destination `nexthops` set holds one `[first_hop]`
+        // entry per equal-cost first hop, so a length != 1 means ECMP
+        // (or an unreachable destination with an empty set).
+        if path.nexthops.len() != 1 {
+            continue;
+        }
+        // X — the protected element: the single primary first-hop node.
+        // `spf::tilfa` returns an empty vec when `d == x` (the
+        // destination *is* the protected neighbor), so that case
+        // self-skips below.
+        let Some(&x) = path.nexthops.iter().next().and_then(|seq| seq.first()) else {
+            continue;
+        };
+        let repair_paths = spf::tilfa(graph, source, *d, &[x]);
+        if !repair_paths.is_empty() {
+            tilfa_result.insert(*d, repair_paths);
+        }
+    }
+    tilfa_result
+}
+
+/// Translate a graph-level `spf::RepairPath` into the FIB-ready
+/// `RepairPathMpls`: resolve the SR segment list to an absolute MPLS
+/// label stack and pin the post-convergence first-hop's local egress
+/// (ifindex from `first_hop_link_id`, address from the link's neighbor
+/// table). Returns `None` when any segment fails to resolve or when
+/// the first-hop has no usable address — a partial stack is refused
+/// because a divergent label path would silently misroute.
+pub(super) fn build_repair_path_mpls(
+    top: &Ospf,
+    area: &OspfArea,
+    rp: &spf::RepairPath,
+) -> Option<RepairPathMpls> {
+    let labels = repair_segments_to_mpls_labels(top, area, &rp.segs)?;
+
+    let first_hop_router = *top.lsp_map.resolve(rp.first_hop)?;
+    let (ifindex, addr) = resolve_first_hop_egress(top, rp.first_hop_link_id, first_hop_router)?;
+
+    Some(RepairPathMpls {
+        ifindex,
+        addr,
+        labels,
+    })
+}
+
+/// Resolve the repair's first-hop egress to (ifindex, neighbor addr).
+/// The post-convergence SPF stamped the chosen edge's `link_id` (our
+/// local ifindex) onto `first_hop_link_id`; we look up that link and
+/// find the neighbor whose router-id is the first-hop router. Falls
+/// back to scanning every link when `first_hop_link_id` is 0 (the edge
+/// carried no ifindex — e.g. the first hop wasn't reached over one of
+/// our own stamped edges).
+fn resolve_first_hop_egress(
+    top: &Ospf,
+    first_hop_link_id: u32,
+    first_hop_router: Ipv4Addr,
+) -> Option<(u32, Ipv4Addr)> {
+    if first_hop_link_id != 0
+        && let Some(link) = top.links.get(&first_hop_link_id)
+        && let Some(addr) = link
+            .nbrs
+            .values()
+            .find(|n| n.ident.router_id == first_hop_router)
+            .map(|n| n.ident.prefix.addr())
+    {
+        return Some((first_hop_link_id, addr));
+    }
+    top.links.iter().find_map(|(ifindex, link)| {
+        link.nbrs
+            .values()
+            .find(|n| n.ident.router_id == first_hop_router)
+            .map(|n| (*ifindex, n.ident.prefix.addr()))
+    })
+}
+
+/// Resolve a TI-LFA repair list into an MPLS label stack. Returns
+/// `None` when any segment fails to resolve — a partial stack is
+/// refused, matching IS-IS.
+fn repair_segments_to_mpls_labels(
+    top: &Ospf,
+    area: &OspfArea,
+    segments: &[spf::SrSegment],
+) -> Option<Vec<rib::Label>> {
+    let mut labels = Vec::with_capacity(segments.len());
+    for seg in segments {
+        let resolved = match seg {
+            spf::SrSegment::NodeSid(v) => node_sid_label_for_vertex(top, area, *v),
+            // OSPF has no LAN pseudonode in the SPF graph, so `via` is
+            // always None and an Adj-SID is a plain (from, to) lookup.
+            spf::SrSegment::AdjSid(from, to, _via) => adj_sid_label_for_link(top, area, *from, *to),
+        };
+        labels.push(rib::Label::Explicit(resolved?));
+    }
+    Some(labels)
+}
+
+/// Resolve a peer-advertised SID to an absolute MPLS label. `Label`
+/// SIDs are absolute on the wire; `Index` SIDs resolve against the
+/// originator's SRGB (`global.start + index`).
+fn resolve_sid(sid: &SidLabelTlv, srgb: Option<&LabelConfig>) -> Option<u32> {
+    match sid {
+        SidLabelTlv::Label(v) => Some(*v),
+        SidLabelTlv::Index(idx) => srgb?.global.start.checked_add(*idx),
+    }
+}
+
+/// Look up `vertex`'s base-algo (SPF) Prefix-SID as an absolute MPLS
+/// label. Scans the Extended-Prefix Opaque LSAs originated by the
+/// vertex's router for an algo-0 Prefix-SID, preferring a host (/32)
+/// prefix (the node's loopback / Node-SID). Resolves Index-form SIDs
+/// against that router's SRGB held in `Lsdb::label_map`.
+fn node_sid_label_for_vertex(top: &Ospf, area: &OspfArea, vertex: usize) -> Option<u32> {
+    let router_id = *top.lsp_map.resolve(vertex)?;
+    let srgb = area.lsdb.label_map.get(&router_id);
+
+    let mut fallback: Option<u32> = None;
+    for (_, lsa) in area.lsdb.iter_by_type(OspfLsType::OpaqueAreaLocal) {
+        if lsa.data.h.ls_age >= OSPF_MAX_AGE || lsa.data.h.adv_router != router_id {
+            continue;
+        }
+        let OspfLsp::OpaqueAreaExtPrefix(ref ep) = lsa.data.lsp else {
+            continue;
+        };
+        for tlv in &ep.tlvs {
+            for sub in &tlv.subs {
+                let ExtPrefixSubTlv::PrefixSid(ps) = sub else {
+                    continue;
+                };
+                if ps.algo != Algo::Spf {
+                    continue;
+                }
+                let Some(label) = resolve_sid(&ps.sid, srgb) else {
+                    continue;
+                };
+                // Prefer the host route (loopback /32) — that's the
+                // Node-SID. Keep the first resolvable algo-0 SID as a
+                // fallback for advertisers that don't tag a /32.
+                if tlv.prefix.prefix_len() == 32 {
+                    return Some(label);
+                }
+                fallback.get_or_insert(label);
+            }
+        }
+    }
+    fallback
+}
+
+/// Look up the Adjacency-SID `from` advertises for the link toward
+/// `to`, as an absolute MPLS label. Scans `from`'s Extended-Link
+/// Opaque LSAs: P2P links (link_type 1) match on `link_id == to`'s
+/// router-id; LAN links (link_type 2) match a LanAdjSid whose
+/// `neighbor_id == to`'s router-id.
+fn adj_sid_label_for_link(
+    top: &Ospf,
+    area: &OspfArea,
+    from_vertex: usize,
+    to_vertex: usize,
+) -> Option<u32> {
+    let from_router = *top.lsp_map.resolve(from_vertex)?;
+    let to_router = *top.lsp_map.resolve(to_vertex)?;
+    let srgb = area.lsdb.label_map.get(&from_router);
+
+    for (_, lsa) in area.lsdb.iter_by_type(OspfLsType::OpaqueAreaLocal) {
+        if lsa.data.h.ls_age >= OSPF_MAX_AGE || lsa.data.h.adv_router != from_router {
+            continue;
+        }
+        let OspfLsp::OpaqueAreaExtLink(ref el) = lsa.data.lsp else {
+            continue;
+        };
+        for tlv in &el.tlvs {
+            match tlv.link_type {
+                // P2P: link_id is the neighbor's router-id.
+                1 => {
+                    if tlv.link_id != to_router {
+                        continue;
+                    }
+                    for sub in &tlv.subs {
+                        if let ExtLinkSubTlv::AdjSid(adj) = sub {
+                            return resolve_sid(&adj.sid, srgb);
+                        }
+                    }
+                }
+                // Broadcast / NBMA: one LanAdjSid sub-TLV per neighbor.
+                2 => {
+                    for sub in &tlv.subs {
+                        if let ExtLinkSubTlv::LanAdjSid(lan) = sub
+                            && lan.neighbor_id == to_router
+                        {
+                            return resolve_sid(&lan.sid, srgb);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    None
+}

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -635,10 +635,34 @@ module config {
           container fast-reroute {
             // Per-algo TI-LFA toggle. Empty container is a no-op; the
             // child presence container turns the per-algo TI-LFA
-            // computation on (deferred — no OSPF TI-LFA yet).
+            // computation on (deferred — no OSPF per-algo TI-LFA yet).
             container ti-lfa {
               presence "Enable Topology-Independent LFA for this flex-algo";
             }
+          }
+        }
+
+        container fast-reroute {
+          // OSPFv2 fast-reroute mechanisms (RFC 7490 LFA family).
+          // Empty container is a no-op; the per-mechanism child
+          // presence containers turn features on. Shape mirrors
+          // `router isis / fast-reroute`.
+          container ti-lfa {
+            // Topology-Independent Loop-Free Alternate (TI-LFA,
+            // RFC 9490). Computes a post-convergence repair path
+            // expressed as SR-MPLS labels, so segment-routing/mpls
+            // must also be enabled for the repair to install in the
+            // dataplane.
+            presence "Enable Topology-Independent LFA (TI-LFA)";
+          }
+          container backup-as-primary {
+            // Swap the metric-sort offset between the SPF primary
+            // nexthop and the TI-LFA repair: the repair installs at
+            // route.metric (sorted first) and the primary installs at
+            // route.metric + BACKUP_METRIC_OFFSET. Lets operators pin
+            // traffic onto the TI-LFA path for protection testing
+            // without rewiring the topology.
+            presence "Install TI-LFA backup as the primary nexthop";
           }
         }
 

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -329,6 +329,18 @@ module exec {
         leaf spf {
           type empty;
         }
+        leaf ti-lfa {
+          ext:help "OSPF TI-LFA per-destination repair paths (graph-level view)";
+          type empty;
+        }
+        container repair-list {
+          ext:help "OSPF TI-LFA repair-list";
+          presence "OSPF repair-list";
+          leaf detail {
+            ext:help "OSPF repair-list detail (per-segment label breakdown)";
+            type empty;
+          }
+        }
         leaf flex-algo {
           ext:help "OSPF Flexible Algorithm (RFC 9350) state";
           type empty;


### PR DESCRIPTION
## Summary

Adds Topology-Independent LFA (TI-LFA, RFC 9490) fast-reroute to **OSPFv2**, mirroring the IS-IS implementation and reusing the protocol-agnostic `spf::tilfa` core. OSPFv3 is intentionally deferred to a follow-up PR (its SPF graph has no reverse edges yet).

Config:
```
router ospf {
  fast-reroute ti-lfa
  fast-reroute backup-as-primary   # optional, protection-testing knob
}
```
Inspect:
```
show ip ospf ti-lfa            # graph-level per-destination repair paths
show ip ospf repair-list       # repair backups stamped onto the RIB
show ip ospf repair-list detail
```

## Changes

- **`graph()` foundation** — two-pass build so every edge populates the originator's `olinks` *and* the target's `ilinks` (TI-LFA's Q-space is a reverse SPF over `ilinks`, which the prior olinks-only build never populated). Source-router edges are stamped `link_id = ifindex` so a repair's first-hop resolves to a concrete local egress. Forward SPF unchanged.
- **`ospf/tilfa.rs` (new)** — `tilfa_repair_path()` runs graph-only on the SPF worker (skips source + SPF-level ECMP), protecting against the primary first-hop node. `build_repair_path_mpls()` resolves the SR segment list to an MPLS label stack on the main task (needs the LSDB): Node-SIDs from Extended-Prefix LSAs + the advertiser SRGB, Adj-SIDs from Extended-Link LSAs. No pseudonode handling — OSPF collapses transit nets to a router mesh.
- **SPF/RIB/FIB** — `ti_lfa_enabled` threads into `SpfInput`; `tilfa_result` rides `SpfOutput`. `SpfRoute` gains `dest_vertex` + `backup_as_primary`; `SpfNexthop` gains `backup`. A second pass in `build_rib_from_spf` stamps repairs onto single-primary intra-area / inter-area / external / NSSA routes; `make_rib_entry` emits the backup as a second nexthop at `route.metric + BACKUP_METRIC_OFFSET` (swapped under `backup-as-primary`), installing into the kernel FIB.
- **Config** — `/router/ospf/fast-reroute/{ti-lfa,backup-as-primary}` presence containers, generic `Ospf<V>` fields, callbacks that recompute SPF per area on toggle.
- **Show** — `show ip ospf ti-lfa` and `show ip ospf repair-list [detail]`, text + JSON.

## Test plan

- `cargo fmt` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs --bins` — **785 passed, 0 failed**
- YANG load guard (`exec` + `configure` modes) — passes

Generated with [Claude Code](https://claude.com/claude-code)