### PR TITLE
isis: VRF support (first slice) — per-VRF instances under router isis vrf

### DIFF
--- a/zebra-rs/src/config/isis.rs
+++ b/zebra-rs/src/config/isis.rs
@@ -20,7 +20,20 @@ pub fn spawn_isis(config: &ConfigManager) {
     let bgp_tx = config.bgp_tx.borrow().clone();
     let (rib_client, rib_rx) = config.subscribe_to_rib("isis");
     let ctx = ProtoContext::default_table(rib_client);
-    let isis = inst::Isis::new(ctx, rib_rx, bfd_client_tx, bgp_tx, config.policy_tx.clone());
+    // `"isis"` is the default-instance proto label. Per-VRF children
+    // get `"isis:vrf:<name>"` labels when the IS-IS task spawns them.
+    // `rib_subscriber` + `config.tx` let the default task mint per-VRF
+    // RIB subscriptions and (de)register `show isis vrf <name>`.
+    let isis = inst::Isis::new(
+        ctx,
+        rib_rx,
+        bfd_client_tx,
+        bgp_tx,
+        config.policy_tx.clone(),
+        "isis".to_string(),
+        config.rib_subscriber(),
+        config.tx.clone(),
+    );
     config.subscribe("isis", isis.cm.tx.clone());
     config.subscribe_show("isis", isis.show.tx.clone());
     let task = inst::serve(isis);

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -143,6 +143,17 @@ impl RibSubscriber {
         let _ = self.rib_tx.send(crate::rib::Message::SidDel { addr });
     }
 
+    /// Send a `ProtoCleanup` for `proto` to RIB. Used at per-VRF IS-IS
+    /// despawn to drop the child's client-registry / SR / redistribute
+    /// rows; the VRF's FIB routes are reclaimed separately by RIB's
+    /// `VrfDel` handling. Rides the legacy `rib_tx` like the other
+    /// registration-time messages.
+    pub fn send_proto_cleanup(&self, proto: &str) {
+        let _ = self.rib_tx.send(crate::rib::Message::ProtoCleanup {
+            proto: proto.to_string(),
+        });
+    }
+
     /// Request a dynamic MPLS label block of `size` labels for `proto`
     /// from the RIB label manager. The RIB replies asynchronously with
     /// a `RibRx::LabelBlock` on `proto`'s subscriber channel.

--- a/zebra-rs/src/config/mod.rs
+++ b/zebra-rs/src/config/mod.rs
@@ -2,6 +2,7 @@ mod vty {
     tonic::include_proto!("vty");
 }
 pub use vty::ApplyCode;
+pub use vty::CommandPath;
 pub use vty::ExecCode;
 
 mod manager;
@@ -26,6 +27,7 @@ pub use comps::Completion;
 
 mod paths;
 pub use paths::path_from_command;
+pub use paths::vrf_redirect_split;
 
 mod api;
 pub use api::{ConfigChannel, ConfigOp, ConfigRequest, DisplayRequest, Message, ShowChannel};

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -21,7 +21,10 @@ use crate::rib::api::RibRx;
 use crate::rib::{self, MacAddr};
 use crate::spf;
 use crate::{
-    config::{Args, ConfigChannel, ConfigOp, ConfigRequest, path_from_command},
+    config::{
+        Args, CommandPath, ConfigChannel, ConfigOp, ConfigRequest, RibSubscriber,
+        path_from_command, vrf_redirect_split,
+    },
     context::ProtoContext,
 };
 
@@ -429,6 +432,34 @@ pub struct Isis {
     /// updates `key_chains` and re-originates LSPs at the affected
     /// level for area/domain-password scope changes.
     pub policy_rx: UnboundedReceiver<crate::policy::PolicyRx>,
+
+    /// Protocol identity used for name-keyed RIB / policy / SR
+    /// registrations. `"isis"` for the default instance,
+    /// `"isis:vrf:<name>"` for a per-VRF instance — so the two never
+    /// clobber each other's rows in the (name-keyed) policy / SR /
+    /// redistribute registries. Route-install attribution is by the
+    /// numeric `ProtoId` carried in `ctx.rib`, so it is unaffected.
+    pub proto_label: String,
+    /// Send-capable RIB-subscription factory. The default instance
+    /// uses it to mint a per-VRF `RibClient` bound to the VRF's kernel
+    /// `table_id` when spawning a child; cloned into each child too.
+    pub rib_subscriber: RibSubscriber,
+    /// Sender into the config manager, for (de)registering a child's
+    /// `show isis vrf <name>` channel via `SubscribeShowVrf` /
+    /// `UnsubscribeShowVrf`. Bounded — send with `try_send`.
+    pub config_tx: mpsc::Sender<crate::config::Message>,
+    /// Per-VRF buffered config (parent only). Each `router isis vrf
+    /// <name> ...` line, rewritten to strip the `vrf <name>` prefix,
+    /// is appended in commit order; replayed into a child at spawn
+    /// time and kept so a `VrfDel`→`VrfAdd` flap respawns from intent.
+    /// Empty for child instances.
+    pub vrf_log: BTreeMap<String, Vec<(Vec<CommandPath>, ConfigOp)>>,
+    /// Running per-VRF child tasks (parent only), keyed by VRF name.
+    pub vrf_registry: BTreeMap<String, super::vrf::IsisVrfHandle>,
+    /// Kernel VRF master info from `RibRx::VrfAdd` (parent only):
+    /// VRF name → (table_id, ifindex). A child spawns once both
+    /// config intent (`vrf_log`) and kernel info exist.
+    pub rib_known_vrfs: BTreeMap<String, (u32, u32)>,
 }
 
 pub struct IsisTop<'a> {
@@ -552,16 +583,20 @@ pub struct IsisTop<'a> {
 }
 
 impl Isis {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         ctx: ProtoContext,
         rib_rx: UnboundedReceiver<RibRx>,
         bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
         bgp_tx: Option<mpsc::Sender<crate::bgp::inst::Message>>,
         policy_tx: UnboundedSender<crate::policy::Message>,
+        proto_label: String,
+        rib_subscriber: RibSubscriber,
+        config_tx: mpsc::Sender<crate::config::Message>,
     ) -> Self {
         let policy_chan = crate::policy::PolicyRxChannel::new();
         let _ = policy_tx.send(crate::policy::Message::Subscribe {
-            proto: "isis".into(),
+            proto: proto_label.clone(),
             tx: policy_chan.tx.clone(),
         });
         // SR config subscription channel. One-time registration with the
@@ -570,7 +605,7 @@ impl Isis {
         // typed handle just like every other protocol-to-RIB send.
         let (sr_tx, sr_rx) = mpsc::unbounded_channel::<RibSrRx>();
         let _ = ctx.rib.send(rib::Message::SrSubscribe {
-            proto: "isis".into(),
+            proto: proto_label.clone(),
             tx: sr_tx,
         });
 
@@ -664,14 +699,24 @@ impl Isis {
                 key_chains: BTreeMap::new(),
                 policy_tx,
                 policy_rx: policy_chan.rx,
+                proto_label,
+                rib_subscriber,
+                config_tx,
+                vrf_log: BTreeMap::new(),
+                vrf_registry: BTreeMap::new(),
+                rib_known_vrfs: BTreeMap::new(),
             };
         isis.callback_build();
         isis.show_build();
         // Restart-aware boot. No-op when no checkpoint on disk
         // (cold-start). When present + fresh, restores self-LSPs +
         // sets restarting state so the first IIH on every link
-        // goes out with RR=1.
-        isis.gr_restart_load_checkpoint();
+        // goes out with RR=1. Only the default instance loads the
+        // checkpoint — the on-disk path is fixed (`isis.cbor`), so a
+        // per-VRF child must not restore the default instance's LSPs.
+        if isis.proto_label == "isis" {
+            isis.gr_restart_load_checkpoint();
+        }
         isis
     }
 
@@ -682,12 +727,28 @@ impl Isis {
     pub fn process_cm_msg(&mut self, msg: ConfigRequest) {
         // CommitEnd is the only signal IS-IS reacts to outside the
         // YANG callback table — fold the staged SRLG cache into the
-        // applied snapshot and re-originate if it moved.
+        // applied snapshot and re-originate if it moved. The default
+        // instance also fans CommitEnd out to its per-VRF children and
+        // prunes any whose `router isis vrf <name>` block was deleted.
         if msg.op == ConfigOp::CommitEnd {
+            self.vrf_commit_end();
             self.commit_srlg();
             return;
         }
         if msg.op == ConfigOp::CommitStart {
+            return;
+        }
+
+        // `/router/isis/vrf/<name>/...` belongs to a per-VRF instance,
+        // not the default one. Strip the `vrf <name>` selector and
+        // buffer the rewritten line (replayed into the child at spawn;
+        // kept for VrfDel→VrfAdd respawn); forward it live if the child
+        // is already running. The default instance never runs these
+        // through its own callback table. Only the default instance
+        // owns children — a child's paths never carry a `vrf` segment,
+        // so this is a no-op there.
+        if let Some((name, rewritten)) = vrf_redirect_split(&msg.paths) {
+            self.vrf_config_record(name, rewritten, msg.op);
             return;
         }
 
@@ -739,6 +800,43 @@ impl Isis {
 
         if let Some(f) = self.callbacks.get(&path) {
             f(self, args, msg.op);
+        }
+    }
+
+    /// Record a rewritten per-VRF config line (parent only). Appends to
+    /// the VRF's replay log and, if its child is already running,
+    /// forwards the line live to the child's config inbox.
+    fn vrf_config_record(&mut self, name: String, rewritten: Vec<CommandPath>, op: ConfigOp) {
+        if let Some(handle) = self.vrf_registry.get(&name) {
+            let _ = handle.cm_tx.send(ConfigRequest::new(rewritten.clone(), op));
+        }
+        self.vrf_log.entry(name).or_default().push((rewritten, op));
+    }
+
+    /// CommitEnd fan-out for the default instance: tear down per-VRF
+    /// children whose `router isis vrf <name>` block was fully deleted
+    /// this commit, then forward `CommitEnd` to every surviving live
+    /// child so it runs its own commit-time reconcile.
+    fn vrf_commit_end(&mut self) {
+        let emptied: Vec<String> = self
+            .vrf_log
+            .iter()
+            .filter(|(_, log)| !super::vrf::vrf_log_active(log))
+            .map(|(name, _)| name.clone())
+            .collect();
+        for name in emptied {
+            self.vrf_log.remove(&name);
+            // Kernel info (`rib_known_vrfs`) is owned by VrfAdd/VrfDel,
+            // not by config — leave it so a re-added block respawns if
+            // the kernel VRF still exists.
+            if self.vrf_registry.remove(&name).is_some() {
+                super::vrf::despawn_isis_vrf(&name, &self.config_tx, &self.rib_subscriber);
+            }
+        }
+        for handle in self.vrf_registry.values() {
+            let _ = handle
+                .cm_tx
+                .send(ConfigRequest::new(Vec::new(), ConfigOp::CommitEnd));
         }
     }
 
@@ -1248,9 +1346,66 @@ impl Isis {
             RibRx::RouteDel { rtype, routes, .. } => {
                 self.route_redist_del(rtype, routes);
             }
+            // VRF master lifecycle (default instance only — a per-VRF
+            // child's subscription is bound to its own table and never
+            // owns sub-VRFs). The kernel `table_id` lets us bind a
+            // child's RibClient so its SPF routes install into the VRF
+            // table; the spawn waits until config intent exists too.
+            RibRx::VrfAdd {
+                name,
+                table_id,
+                ifindex,
+            } => {
+                self.vrf_add(name, table_id, ifindex);
+            }
+            RibRx::VrfDel { name } => {
+                self.vrf_del(name);
+            }
             _ => {
                 //
             }
+        }
+    }
+
+    /// Kernel VRF master appeared (or was replayed at subscribe time).
+    /// Record its `table_id`/`ifindex`, and spawn the per-VRF IS-IS
+    /// child if config intent for this VRF exists and it isn't already
+    /// running. Default instance only.
+    fn vrf_add(&mut self, name: String, table_id: u32, ifindex: u32) {
+        self.rib_known_vrfs
+            .insert(name.clone(), (table_id, ifindex));
+        if self.vrf_registry.contains_key(&name) {
+            return;
+        }
+        let has_intent = self
+            .vrf_log
+            .get(&name)
+            .is_some_and(|log| super::vrf::vrf_log_active(log));
+        if !has_intent {
+            return;
+        }
+        // Clone the replay log so the spawn borrow doesn't overlap the
+        // `vrf_registry` insert below.
+        let log = self.vrf_log.get(&name).cloned().unwrap_or_default();
+        let handle = super::vrf::spawn_isis_vrf(
+            &name,
+            table_id,
+            &self.rib_subscriber,
+            &self.config_tx,
+            &self.policy_tx,
+            &log,
+        );
+        self.vrf_registry.insert(name, handle);
+    }
+
+    /// Kernel VRF master removed. Despawn the child but KEEP its config
+    /// log so a later `VrfAdd` (master re-created) respawns from intent.
+    /// RIB reclaims the VRF's FIB table on its side. Default instance
+    /// only.
+    fn vrf_del(&mut self, name: String) {
+        self.rib_known_vrfs.remove(&name);
+        if self.vrf_registry.remove(&name).is_some() {
+            super::vrf::despawn_isis_vrf(&name, &self.config_tx, &self.rib_subscriber);
         }
     }
 
@@ -2520,6 +2675,27 @@ mod bfd_wiring_tests {
         (ProtoContext::default_table(client), rib_rx)
     }
 
+    /// Parked `RibSubscriber` for `Isis::new` tests. Its receivers are
+    /// leaked so sends never trip a `SendError`.
+    fn test_rib_subscriber() -> crate::config::RibSubscriber {
+        let (rib_tx, rib_rx) = mpsc::unbounded_channel();
+        let (rib_inbound_tx, rib_inbound_rx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(rib_rx));
+        Box::leak(Box::new(rib_inbound_rx));
+        crate::config::RibSubscriber::for_test(
+            rib_tx,
+            rib_inbound_tx,
+            std::sync::Arc::new(std::sync::atomic::AtomicU32::new(1)),
+        )
+    }
+
+    /// Parked config-manager sender for `Isis::new` tests.
+    fn test_config_tx() -> mpsc::Sender<crate::config::Message> {
+        let (tx, rx) = mpsc::channel(16);
+        Box::leak(Box::new(rx));
+        tx
+    }
+
     fn fresh_isis_with_bfd() -> (Isis, mpsc::UnboundedReceiver<ClientReq>) {
         let (ctx, rib_rx) = test_ctx();
         let (bfd_client_tx, bfd_client_rx) = mpsc::unbounded_channel();
@@ -2527,7 +2703,16 @@ mod bfd_wiring_tests {
         // Park the policy_rx so the Subscribe send in `new` doesn't
         // drop and panic on its own send.
         Box::leak(Box::new(policy_rx));
-        let isis = Isis::new(ctx, rib_rx, Some(bfd_client_tx), None, policy_tx);
+        let isis = Isis::new(
+            ctx,
+            rib_rx,
+            Some(bfd_client_tx),
+            None,
+            policy_tx,
+            "isis".to_string(),
+            test_rib_subscriber(),
+            test_config_tx(),
+        );
         (isis, bfd_client_rx)
     }
 
@@ -2573,7 +2758,16 @@ mod bfd_wiring_tests {
         let (ctx, rib_rx) = test_ctx();
         let (policy_tx, policy_rx) = mpsc::unbounded_channel();
         Box::leak(Box::new(policy_rx));
-        let isis = Isis::new(ctx, rib_rx, None, None, policy_tx);
+        let isis = Isis::new(
+            ctx,
+            rib_rx,
+            None,
+            None,
+            policy_tx,
+            "isis".to_string(),
+            test_rib_subscriber(),
+            test_config_tx(),
+        );
         let key = loopback_key();
         isis.process_bfd_subscribe(key);
         isis.process_bfd_unsubscribe(key);

--- a/zebra-rs/src/isis/mod.rs
+++ b/zebra-rs/src/isis/mod.rs
@@ -64,3 +64,5 @@ pub mod flex_algo;
 pub mod auth;
 
 pub mod checkpoint;
+
+pub mod vrf;

--- a/zebra-rs/src/isis/vrf.rs
+++ b/zebra-rs/src/isis/vrf.rs
@@ -1,0 +1,153 @@
+//! Per-VRF IS-IS instance spawn / despawn.
+//!
+//! Unlike BGP — which stages a small typed `BgpVrfConfig` and
+//! materializes a subset at spawn — IS-IS reuses the **whole**
+//! [`Isis`] instance per VRF. The default `router isis` task acts as a
+//! thin parent: it forwards every `/router/isis/vrf/<name>/…` config
+//! line, rewritten to strip the `vrf <name>` prefix (see
+//! [`crate::config::vrf_redirect_split`]), into a full per-VRF `Isis`
+//! whose existing callbacks / SPF / RIB / show paths run unchanged.
+//!
+//! VRF isolation for IS-IS needs exactly one binding: the per-VRF
+//! [`RibClient`](crate::rib::client::RibClient) is subscribed at the
+//! VRF's kernel `table_id`, so SPF routes install into the VRF table.
+//! IS-IS PDUs are L2 (`AF_PACKET` bound to the physical ifindex in
+//! [`super::socket::isis_socket`]), so no `SO_BINDTODEVICE` is needed.
+//!
+//! A child is spawned only once **both** config intent exists (the
+//! parent's `vrf_log`) **and** the kernel VRF master has been created
+//! (`RibRx::VrfAdd` delivered the `table_id`). The buffered config is
+//! replayed into the fresh child, followed by one synthetic
+//! `CommitEnd` so the child runs its commit-time reconcile.
+
+use tokio::sync::mpsc::{Sender, UnboundedSender};
+
+use crate::config::{CommandPath, ConfigOp, ConfigRequest, Message, RibSubscriber};
+use crate::context::{ProtoContext, Task};
+
+use super::inst::{self, Isis};
+
+/// Handle to one running per-VRF IS-IS task, stashed on the parent's
+/// `vrf_registry`.
+pub struct IsisVrfHandle {
+    /// Config inbox of the child. The parent forwards rewritten
+    /// `/router/isis/…` `ConfigRequest`s here (and the per-commit
+    /// `CommitEnd`).
+    pub cm_tx: UnboundedSender<ConfigRequest>,
+    /// Spawned event loop. Dropping the handle aborts it (the `Task`
+    /// runs its `AbortHandle` on `Drop`), so removing a handle from
+    /// `vrf_registry` tears the child down.
+    #[allow(dead_code)]
+    pub task: Task<()>,
+}
+
+/// Per-VRF instance proto label. Distinct from the default `"isis"` so
+/// the child's name-keyed RIB / policy / SR registrations don't clobber
+/// the parent's. Route-install attribution is by numeric `ProtoId`, so
+/// it is unaffected.
+pub fn vrf_proto_label(name: &str) -> String {
+    format!("isis:vrf:{name}")
+}
+
+/// Manager show-channel registry key for a per-VRF instance — must
+/// match what the manager's `DisplayTx` handler computes from
+/// `show isis vrf <name> …` (`"<proto>:vrf:<name>"`).
+pub fn vrf_show_key(name: &str) -> String {
+    format!("isis:vrf:{name}")
+}
+
+/// True if the buffered config log still has at least one net-effect
+/// `Set` item. The parent uses this at `CommitEnd` to detect a fully
+/// deleted `router isis vrf <name>` block (→ tear the child down).
+/// Set/Delete are folded by a path+values key (joined `CommandPath`
+/// names), so a `Set` later cancelled by a matching `Delete` drops out.
+pub fn vrf_log_active(log: &[(Vec<CommandPath>, ConfigOp)]) -> bool {
+    let mut active: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for (paths, op) in log {
+        let key = paths
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect::<Vec<_>>()
+            .join("/");
+        match op {
+            ConfigOp::Set => {
+                active.insert(key);
+            }
+            ConfigOp::Delete => {
+                active.remove(&key);
+            }
+            _ => {}
+        }
+    }
+    !active.is_empty()
+}
+
+/// Build + spawn a per-VRF IS-IS task and return its handle.
+///
+/// `table_id` is the kernel routing table id RIB allocated for the VRF
+/// master (from `RibRx::VrfAdd`); the per-VRF `RibClient` is subscribed
+/// at it so route installs land in `vrf_tables[table_id]`. `buffered`
+/// is the parent's replay log for this VRF — every rewritten config
+/// line in commit order; it is replayed, then a synthetic `CommitEnd`
+/// is sent so the child reconciles.
+pub fn spawn_isis_vrf(
+    name: &str,
+    table_id: u32,
+    rib_subscriber: &RibSubscriber,
+    config_tx: &Sender<Message>,
+    policy_tx: &UnboundedSender<crate::policy::Message>,
+    buffered: &[(Vec<CommandPath>, ConfigOp)],
+) -> IsisVrfHandle {
+    let proto = vrf_proto_label(name);
+    // Per-VRF RIB subscription bound to the kernel table_id. Consume
+    // (don't leak) `rib_rx` — the child's event loop needs LinkAdd /
+    // AddrAdd to manage its interfaces.
+    let (rib_client, rib_rx) = rib_subscriber.subscribe_for_vrf(&proto, table_id);
+    let ctx = ProtoContext::for_vrf(rib_client, table_id, name.to_string());
+
+    let isis = Isis::new(
+        ctx,
+        rib_rx,
+        /* bfd_client_tx */ None,
+        /* bgp_tx */ None,
+        policy_tx.clone(),
+        proto.clone(),
+        rib_subscriber.clone(),
+        config_tx.clone(),
+    );
+    let cm_tx = isis.cm.tx.clone();
+
+    // Register the child's show channel so `show isis vrf <name> …`
+    // redirects into it (manager strips the `vrf <name>` selector).
+    let _ = config_tx.try_send(Message::SubscribeShowVrf {
+        key: vrf_show_key(name),
+        tx: isis.show.tx.clone(),
+    });
+
+    // Replay buffered config in commit order, then one synthetic
+    // CommitEnd so the child runs `commit_srlg` / reconcile once.
+    for (paths, op) in buffered {
+        let _ = cm_tx.send(ConfigRequest::new(paths.clone(), *op));
+    }
+    let _ = cm_tx.send(ConfigRequest::new(Vec::new(), ConfigOp::CommitEnd));
+
+    let task = inst::serve(isis);
+    tracing::info!(vrf = %name, table_id, "isis: spawned per-VRF instance");
+
+    IsisVrfHandle { cm_tx, task }
+}
+
+/// Tear down a per-VRF instance's manager + RIB registrations.
+///
+/// The caller removes the [`IsisVrfHandle`] from `vrf_registry`
+/// separately, which drops the `Task` and aborts the event loop. This
+/// drops the manager show channel and the RIB client / SR / redist
+/// rows (via `ProtoCleanup`). The VRF's FIB routes are reclaimed by
+/// RIB's own `VrfDel` handling when the master device disappears.
+pub fn despawn_isis_vrf(name: &str, config_tx: &Sender<Message>, rib_subscriber: &RibSubscriber) {
+    let _ = config_tx.try_send(Message::UnsubscribeShowVrf {
+        key: vrf_show_key(name),
+    });
+    rib_subscriber.send_proto_cleanup(&vrf_proto_label(name));
+    tracing::info!(vrf = %name, "isis: despawned per-VRF instance");
+}

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -1185,7 +1185,14 @@ impl Rib {
             "bgp" => RibType::Bgp,
             "isis" => RibType::Isis,
             "ospf" => RibType::Ospf,
-            _ => return,
+            // Protocols with no main-table rtype (e.g. a per-VRF
+            // instance like `"isis:vrf:<name>"`, whose routes live in
+            // `vrf_tables` and are reclaimed by `VrfDel`) still need
+            // their client-registry / SR / redistribute rows dropped.
+            _ => {
+                self.proto_unregister(&proto);
+                return;
+            }
         };
 
         let v4_prefixes: Vec<Ipv4Net> = self

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1782,6 +1782,57 @@ module config {
             }
           }
         }
+
+        list vrf {
+          // Per-VRF IS-IS instance. Mirrors the (default) top-level
+          // IS-IS config tree for each named VRF: the default
+          // `router isis` task forwards every `vrf <name> ...` line —
+          // with the `vrf <name>` prefix stripped — to a full per-VRF
+          // IS-IS instance whose computed routes install into the
+          // VRF's routing table. The `vrf` key is a plain string
+          // (staging-friendly, like `router static`'s per-VRF list)
+          // so the VRF need not yet exist at the top-level `vrf` list
+          // when this config is parsed. Only a minimal subset (net /
+          // is-type / interface enable) is exposed today; later work
+          // widens it toward full parity with the default instance.
+          key "name";
+          leaf name {
+            type string;
+          }
+          leaf net {
+            // First entry in "router isis vrf X" node (mirrors the
+            // top-level `net` sort) so forwarded config arrives
+            // system-id-first.
+            ext:sort "1";
+            type isis:net;
+          }
+          leaf is-type {
+            type enumeration {
+              enum level-1;
+              enum level-1-2;
+              enum level-2-only;
+            }
+          }
+          list interface {
+            // Last item, mirroring the top-level interface sort.
+            ext:sort "-10";
+            key "if-name";
+            leaf if-name {
+              ext:dynamic "rib:interface";
+              type string;
+            }
+            container ipv4 {
+              leaf enable {
+                type boolean;
+              }
+            }
+            container ipv6 {
+              leaf enable {
+                type boolean;
+              }
+            }
+          }
+        }
       }
       container static {
         ext:help "Static route configuration";

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -469,6 +469,47 @@ module exec {
           }
         }
       }
+
+      list vrf {
+        // Per-VRF IS-IS instance show. `show isis vrf <name> <cmd>` is
+        // redirected by the config manager (it strips the `vrf <name>`
+        // selector via `vrf_redirect_split`) into the per-VRF task's
+        // show channel registered as `"isis:vrf:<name>"`. The stripped
+        // command (`show isis <cmd>`) is rendered by the child's
+        // existing show handlers, so this list mirrors a subset of the
+        // top-level leaves above.
+        ext:help "Per-VRF IS-IS instance";
+        key name;
+        leaf name {
+          ext:help "VRF name";
+          ext:dynamic "rib:vrf";
+          type string;
+        }
+        leaf summary {
+          ext:help "IS-IS summary for this VRF";
+          type empty;
+        }
+        leaf neighbor {
+          ext:help "IS-IS neighbors in this VRF";
+          type empty;
+        }
+        leaf database {
+          ext:help "IS-IS database for this VRF";
+          type empty;
+        }
+        leaf route {
+          ext:help "IS-IS routes in this VRF";
+          type empty;
+        }
+        leaf interface {
+          ext:help "IS-IS interfaces in this VRF";
+          type empty;
+        }
+        leaf topology {
+          ext:help "IS-IS SPF tree for this VRF";
+          type empty;
+        }
+      }
     }
     container ipv6 {
       ext:help "Show IPv6 commands";


### PR DESCRIPTION
## Summary

Makes IS-IS VRF-ready. Config nests under `router isis`, mirroring BGP:

```
router isis {
  vrf vrf1 {
    net 49.0000.0000.0000.0001.00;
    is-type level-2-only;
    interface eth0 { ipv4 { enable true; } }
  }
}
```

Reuses the BGP VRF baseline primitives (`ProtoContext::for_vrf`, `subscribe_to_rib_for_vrf`, the `RibRx::VrfAdd` table-binding deferral, a per-VRF task registry, `SubscribeShowVrf` show routing) but **differs in how config reaches the instance**: instead of BGP-style typed staging, the default `router isis` task is a thin **parent** that strips the `vrf <name>` prefix from `/router/isis/vrf/<name>/…` lines and forwards them to a **full per-VRF `Isis`** whose existing callbacks / SPF / RIB / show run unchanged. IS-IS's ~770-line / ~100-callback config surface makes reuse far cheaper than re-implementing staging.

**VRF isolation = one binding (routes).** `isis_socket()` is `AF_PACKET` bound to the physical ifindex (L2), so no `SO_BINDTODEVICE` is needed; the per-VRF `RibClient` is subscribed at the kernel `table_id`, so SPF routes install into the VRF table. Spawn is **deferred until `VrfAdd`** delivers the `table_id`; config arriving first is buffered + replayed. `VrfDel` despawns but keeps intent (respawn on flap); deleting the block tears it down.

First-slice scope: YANG `list vrf` carries net / is-type / interface enable; full spawn → forward → bind → SPF → routes-into-VRF-table machinery; `show isis vrf <name> …`. Later PRs widen the per-VRF YANG (timers / SR / flex-algo / auth) — each just adds leaves.

## Changes
- `yang/config.yang` — `list vrf` under `container isis`
- `yang/exec.yang` — `show isis vrf <name> {summary,neighbor,database,route,interface,topology}`
- `src/isis/vrf.rs` *(new)* — spawn/despawn, `IsisVrfHandle`, helpers
- `src/isis/inst.rs` — `proto_label`/`rib_subscriber`/`config_tx` + VRF state; `process_cm_msg` interception; `vrf_add`/`vrf_del` in `process_rib_msg`; checkpoint-load gated to the default instance
- `src/config/{isis,manager,mod}.rs` — thread new args; `RibSubscriber::send_proto_cleanup`; re-export `CommandPath` + `vrf_redirect_split`
- `src/rib/inst.rs` — `proto_cleanup` unregisters any proto name (was gated to `{bgp,isis,ospf}`, leaked a per-VRF child's registry row on despawn)

## Test plan
- `cargo fmt`, `cargo build -p zebra-rs` — clean, no warnings
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (re-run after touching changed files)
- `cargo test -p zebra-rs` — 785 passed, 0 failed, incl. `yang_load_tests` validating both YANG edits
- Live two-node / FRR validation (routes in `ip route show vrf vrf1`, adjacency Up) — not yet done; follow-up

Generated with [Claude Code](https://claude.com/claude-code)