### PR TITLE
ospf: TI-LFA fast-reroute for OSPFv3 (RFC 9490)

### DIFF
--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -94,11 +94,54 @@ impl Ospf<Ospfv3> {
                 config_ospfv3_interface_flex_algo_prefix_sid_absolute,
             ),
             ("/segment-routing/mpls", config_ospfv3_sr_mpls),
+            ("/fast-reroute/ti-lfa", config_ospfv3_ti_lfa),
+            (
+                "/fast-reroute/backup-as-primary",
+                config_ospfv3_fast_reroute_backup_as_primary,
+            ),
         ];
         for (path, cb) in entries {
             self.callbacks.insert(format!("{}{}", prefix, path), *cb);
         }
     }
+}
+
+/// `/router/ospfv3/fast-reroute/ti-lfa` — v3 sibling of the v2
+/// `config_ospf_ti_lfa`. Gates the per-destination TI-LFA repair
+/// computation (RFC 9490); on a state change, kick an SPF recompute
+/// for every area so the v6 RIB picks up or drops repair backups. No
+/// LSA re-origination — the repair is a local install-side decision.
+fn config_ospfv3_ti_lfa(ospf: &mut Ospf<Ospfv3>, _args: Args, op: ConfigOp) -> Option<()> {
+    let prev = ospf.ti_lfa_enabled;
+    ospf.ti_lfa_enabled = op.is_set();
+    if ospf.ti_lfa_enabled == prev {
+        return Some(());
+    }
+    let area_ids: Vec<std::net::Ipv4Addr> = ospf.areas.iter().map(|(id, _)| *id).collect();
+    for id in area_ids {
+        let _ = ospf.tx.send(Message::SpfCalc(id));
+    }
+    Some(())
+}
+
+/// `/router/ospfv3/fast-reroute/backup-as-primary` — v3 sibling of the
+/// v2 callback. Inverts the primary/backup metric ordering at install
+/// time; re-run SPF so the v6 RIB rebuilds with the swapped offset.
+fn config_ospfv3_fast_reroute_backup_as_primary(
+    ospf: &mut Ospf<Ospfv3>,
+    _args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let prev = ospf.fast_reroute_backup_as_primary;
+    ospf.fast_reroute_backup_as_primary = op.is_set();
+    if ospf.fast_reroute_backup_as_primary == prev {
+        return Some(());
+    }
+    let area_ids: Vec<std::net::Ipv4Addr> = ospf.areas.iter().map(|(id, _)| *id).collect();
+    for id in area_ids {
+        let _ = ospf.tx.send(Message::SpfCalc(id));
+    }
+    Some(())
 }
 
 /// `/router/ospfv3/area/<id>/area-type` — same shape as the v2

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -38,7 +38,10 @@ use super::lsdb::{LsdbEvent, OspfLsaKey, seq_max, v2_lsa_key_unpack};
 use super::network::{read_packet, write_packet};
 use super::nfsm::{NfsmEvent, ospf_nfsm};
 use super::socket::ospf_socket_ipv4;
-use super::tilfa::{RepairPathMpls, build_repair_path_mpls, tilfa_repair_path};
+use super::tilfa::{
+    RepairPathMpls, RepairPathMplsV3, build_repair_path_mpls, build_repair_path_mpls_v3,
+    tilfa_repair_path,
+};
 use super::tracing::OspfTracing;
 use super::version::{OspfVersion, Ospfv3};
 use super::{
@@ -6965,6 +6968,16 @@ pub struct SpfRouteV3 {
     /// path can surface the on-the-wire SID encoding alongside the
     /// resolved label. Mirror of v2's `SpfRoute::prefix_sid`.
     pub prefix_sid: Option<(SidLabelValue, LabelConfig)>,
+    /// SPF vertex id this route was built from (advertising router, or
+    /// ABR/ASBR for inter-area / NSSA). Set at build time; joined with
+    /// the per-destination repair in the TI-LFA second pass. `None`
+    /// for per-Flex-Algo entries (no v3 per-algo TI-LFA). Mirror of
+    /// v2's `SpfRoute::dest_vertex`.
+    pub dest_vertex: Option<usize>,
+    /// `fast-reroute backup-as-primary` at build time, carried so it
+    /// joins the `table_diff` equality that gates RIB updates. Mirror
+    /// of v2's `SpfRoute::backup_as_primary`.
+    pub backup_as_primary: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -6978,6 +6991,12 @@ pub struct SpfNexthopV3 {
     /// the SPF builder, which then triggers the standard swap
     /// (push the incoming label as the outgoing label).
     pub adjacency: bool,
+    /// TI-LFA post-convergence repair for this primary nexthop, set
+    /// only on the single primary nexthop of a RIB route by the v3
+    /// TI-LFA second pass; `None` otherwise (ILM/adjacency nexthops,
+    /// ECMP, TI-LFA off, or unresolved). v3 sibling of
+    /// `SpfNexthop::backup`.
+    pub backup: Option<RepairPathMplsV3>,
 }
 
 /// v3 sibling of `SpfIlm`. Same role -- one entry in the SR-MPLS
@@ -7573,6 +7592,7 @@ fn build_rib6_from_flex_algo(
                     SpfNexthopV3 {
                         ifindex,
                         adjacency: false,
+                        backup: None,
                     },
                 )
             })
@@ -7609,6 +7629,9 @@ fn build_rib6_from_flex_algo(
                     nhops: nhops.clone(),
                     sid: sid_label,
                     prefix_sid: Some((value, label_config.clone())),
+                    // Per-Flex-Algo routes have no TI-LFA today.
+                    dest_vertex: None,
+                    backup_as_primary: false,
                 };
                 rib6_insert(&mut rib, prefix, route);
                 break;
@@ -7841,82 +7864,101 @@ fn graph_v3(top: &mut Ospf<Ospfv3>, area_id: Ipv4Addr) -> (spf::Graph, Option<us
         }
     }
 
-    for (adv_router, originated, lsa_data) in &router_lsas {
-        let node_id = top.lsp_map.get(*adv_router);
+    // Map each neighbor router-id we hold a local adjacency to -> the
+    // ifindex of its interface, so edges from our own Router-LSA carry
+    // a usable `link_id` for TI-LFA's repair first-hop (mirrors the v2
+    // graph builder). v3 keys `link.nbrs` by router-id and learns the
+    // ifindex from the adjacency.
+    let mut nbr_to_ifindex: std::collections::HashMap<Ipv4Addr, u32> =
+        std::collections::HashMap::new();
+    for link in top.links.values() {
+        for nbr in link.nbrs.values() {
+            nbr_to_ifindex.insert(nbr.ident.router_id, nbr.ifindex);
+        }
+    }
 
+    // Pass 1: create every vertex and resolve the source. All vertices
+    // must exist before pass 2 wires edges onto both endpoints.
+    for (adv_router, originated, _lsa_data) in &router_lsas {
+        let node_id = top.lsp_map.get(*adv_router);
         if *originated {
             source_node = Some(node_id);
         }
-
-        let mut vertex = spf::Vertex {
+        let vertex = spf::Vertex {
             id: node_id,
             name: adv_router.to_string(),
             sys_id: adv_router.to_string(),
             ..Default::default()
         };
+        graph.insert(node_id, vertex);
+    }
 
-        if let Ospfv3LsBody::Router(ref router_body) = lsa_data.body {
-            for link in &router_body.links {
-                use ospf_packet::Ospfv3RouterLinkType;
-                match link.link_type {
-                    Ospfv3RouterLinkType::PointToPoint | Ospfv3RouterLinkType::VirtualLink => {
-                        // Bidirectional check: peer's Router-LSA
-                        // must exist (non-MaxAge) AND carry a
-                        // matching link back to us.
-                        let Some(peer_lsa) = router_lsa_by_id.get(&link.neighbor_router_id) else {
-                            continue;
-                        };
-                        let has_backlink = peer_lsa.links.iter().any(|l| {
-                            matches!(
-                                l.link_type,
-                                Ospfv3RouterLinkType::PointToPoint
-                                    | Ospfv3RouterLinkType::VirtualLink
-                            ) && l.neighbor_router_id == *adv_router
-                        });
-                        if !has_backlink {
-                            continue;
-                        }
-                        let to_id = top.lsp_map.get(link.neighbor_router_id);
-                        vertex.olinks.push(spf::Link {
-                            from: node_id,
-                            to: to_id,
-                            cost: link.metric as u32,
-                            link_id: 0,
-                        });
+    // Pass 2: wire edges onto the originator's `olinks` (forward SPF,
+    // unchanged) and the target's `ilinks` (reverse SPF for TI-LFA's
+    // Q-space — new, previously unpopulated).
+    for (adv_router, originated, lsa_data) in &router_lsas {
+        let node_id = top.lsp_map.get(*adv_router);
+        let Ospfv3LsBody::Router(ref router_body) = lsa_data.body else {
+            continue;
+        };
+        for link in &router_body.links {
+            use ospf_packet::Ospfv3RouterLinkType;
+            match link.link_type {
+                Ospfv3RouterLinkType::PointToPoint | Ospfv3RouterLinkType::VirtualLink => {
+                    // Bidirectional check: peer's Router-LSA must exist
+                    // (non-MaxAge) AND carry a matching link back to us.
+                    let Some(peer_lsa) = router_lsa_by_id.get(&link.neighbor_router_id) else {
+                        continue;
+                    };
+                    let has_backlink = peer_lsa.links.iter().any(|l| {
+                        matches!(
+                            l.link_type,
+                            Ospfv3RouterLinkType::PointToPoint | Ospfv3RouterLinkType::VirtualLink
+                        ) && l.neighbor_router_id == *adv_router
+                    });
+                    if !has_backlink {
+                        continue;
                     }
-                    Ospfv3RouterLinkType::Transit => {
-                        // Bidirectional check: Network-LSA must list
-                        // us in attached_routers. Key is the DR's
-                        // (interface_id, router_id) from the
-                        // Router-LSA link's
-                        // (neighbor_interface_id, neighbor_router_id).
-                        let net_key = (link.neighbor_interface_id, link.neighbor_router_id);
-                        let Some(attached) = network_lsas.get(&net_key) else {
+                    let to_id = top.lsp_map.get(link.neighbor_router_id);
+                    let link_id = if *originated {
+                        nbr_to_ifindex
+                            .get(&link.neighbor_router_id)
+                            .copied()
+                            .unwrap_or(0)
+                    } else {
+                        0
+                    };
+                    push_edge(&mut graph, node_id, to_id, link.metric as u32, link_id);
+                }
+                Ospfv3RouterLinkType::Transit => {
+                    // Bidirectional check: Network-LSA must list us in
+                    // attached_routers. Key is the DR's
+                    // (interface_id, router_id) from the Router-LSA
+                    // link's (neighbor_interface_id, neighbor_router_id).
+                    let net_key = (link.neighbor_interface_id, link.neighbor_router_id);
+                    let Some(attached) = network_lsas.get(&net_key) else {
+                        continue;
+                    };
+                    if !attached.iter().any(|r| r == adv_router) {
+                        continue;
+                    }
+                    // Edges to every other attached router (excluding
+                    // self) at the link's metric.
+                    for peer in attached {
+                        if peer == adv_router {
                             continue;
+                        }
+                        let to_id = top.lsp_map.get(*peer);
+                        let link_id = if *originated {
+                            nbr_to_ifindex.get(peer).copied().unwrap_or(0)
+                        } else {
+                            0
                         };
-                        if !attached.iter().any(|r| r == adv_router) {
-                            continue;
-                        }
-                        // Add edges to every other attached router
-                        // (excluding self) at the link's metric.
-                        for peer in attached {
-                            if peer == adv_router {
-                                continue;
-                            }
-                            let to_id = top.lsp_map.get(*peer);
-                            vertex.olinks.push(spf::Link {
-                                from: node_id,
-                                to: to_id,
-                                cost: link.metric as u32,
-                                link_id: 0,
-                            });
-                        }
+                        push_edge(&mut graph, node_id, to_id, link.metric as u32, link_id);
                     }
                 }
             }
         }
-
-        graph.insert(node_id, vertex);
     }
 
     (graph, source_node)
@@ -8177,10 +8219,7 @@ fn build_v3_spf_input(top: &mut Ospf<Ospfv3>, area_id: Ipv4Addr) -> Option<SpfIn
         area_id,
         graph,
         source,
-        // OSPFv3 TI-LFA is a follow-up: the v3 SPF graph (`graph_v3`)
-        // does not yet carry reverse edges (ilinks) for Q-space, so
-        // keep the repair computation off for v3 instances.
-        ti_lfa_enabled: false,
+        ti_lfa_enabled: top.ti_lfa_enabled,
         flex_algos,
     })
 }
@@ -8195,9 +8234,7 @@ fn apply_v3_spf_result(top: &mut Ospf<Ospfv3>, output: SpfOutput) {
         graph,
         source,
         spf_result,
-        // OSPFv3 TI-LFA is a follow-up; v3 SPF input keeps it disabled
-        // so this is always empty. Ignore it here.
-        tilfa_result: _,
+        tilfa_result,
         duration,
         last,
         flex_algos,
@@ -8221,10 +8258,11 @@ fn apply_v3_spf_result(top: &mut Ospf<Ospfv3>, output: SpfOutput) {
     }
     top.rib6_flex_algo = rib6_flex_algo;
 
-    apply_routing_updates_v3(top, area_id, source, &spf_result);
+    apply_routing_updates_v3(top, area_id, source, &spf_result, &tilfa_result);
 
     top.spf_result = Some(spf_result);
     top.graph = Some(graph);
+    top.tilfa_result = Some(tilfa_result);
 
     // Per-algo SPF trees, for `show ipv6 ospf flex-algo`.
     top.spf_flex_algo = flex_algos
@@ -8264,6 +8302,7 @@ fn build_rib6_from_spf(
     area_id: Ipv4Addr,
     source: usize,
     spf_result: &BTreeMap<usize, spf::Path>,
+    tilfa_result: &BTreeMap<usize, Vec<spf::RepairPath>>,
 ) -> PrefixMap<ipnet::Ipv6Net, SpfRouteV3> {
     use crate::ospf::lsdb::OSPF_MAX_AGE;
     use ospf_packet::{OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE, OSPFV3_NETWORK_LSA_TYPE, Ospfv3LsBody};
@@ -8307,6 +8346,7 @@ fn build_rib6_from_spf(
                         SpfNexthopV3 {
                             ifindex,
                             adjacency: false,
+                            backup: None,
                         },
                     )
                 })
@@ -8349,6 +8389,7 @@ fn build_rib6_from_spf(
                     SpfNexthopV3 {
                         ifindex: link.index,
                         adjacency: false,
+                        backup: None,
                     },
                 );
                 (
@@ -8378,6 +8419,7 @@ fn build_rib6_from_spf(
                     SpfNexthopV3 {
                         ifindex: link.index,
                         adjacency: false,
+                        backup: None,
                     },
                 );
                 (prefix.metric as u32, nhops_map)
@@ -8388,6 +8430,8 @@ fn build_rib6_from_spf(
                 nhops: nhops_map,
                 sid: None,
                 prefix_sid: None,
+                dest_vertex: Some(ref_vertex),
+                backup_as_primary: top.fast_reroute_backup_as_primary,
             };
             // Equal-cost: take the lowest-metric. If equal, merge
             // nexthop sets so we end up with ECMP at the same
@@ -8417,6 +8461,31 @@ fn build_rib6_from_spf(
         && area.area_type.is_nssa()
     {
         add_nssa_routes_v3(top, area_id, spf_result, &mut rib);
+    }
+
+    // TI-LFA second pass: stamp the post-convergence repair backup onto
+    // single-primary routes (ECMP skipped — surviving legs already
+    // protect). v3 sibling of the v2 second pass in `build_rib_from_spf`;
+    // resolving a repair list to SR-MPLS labels needs the LSDB, so it
+    // runs here on the main task rather than on the SPF worker.
+    if let Some(area) = top.areas.get(area_id) {
+        for (_, route) in rib.iter_mut() {
+            if route.nhops.len() != 1 {
+                continue;
+            }
+            let Some(dest) = route.dest_vertex else {
+                continue;
+            };
+            let Some(repair) = tilfa_result.get(&dest).and_then(|paths| paths.first()) else {
+                continue;
+            };
+            let Some(backup) = build_repair_path_mpls_v3(top, area, repair) else {
+                continue;
+            };
+            if let Some(nhop) = route.nhops.values_mut().next() {
+                nhop.backup = Some(backup);
+            }
+        }
     }
 
     rib
@@ -8514,6 +8583,7 @@ fn add_nssa_routes_v3(
                     SpfNexthopV3 {
                         ifindex,
                         adjacency: false,
+                        backup: None,
                     },
                 )
             })
@@ -8524,6 +8594,9 @@ fn add_nssa_routes_v3(
             nhops: nhops_map,
             sid: None,
             prefix_sid: None,
+            // Protect the path to the NSSA originator (ASBR).
+            dest_vertex: Some(originator_vertex),
+            backup_as_primary: top.fast_reroute_backup_as_primary,
         };
         // Equal-cost merge — same shape as the intra-area insert
         // above in `build_rib6_from_spf`.
@@ -8544,51 +8617,67 @@ fn add_nssa_routes_v3(
     }
 }
 
-/// Build a `rib::entry::RibEntry` from a `SpfRouteV3`. The
-/// nexthop becomes `Nexthop::Uni` for single-hop routes,
-/// `Nexthop::Multi` for ECMP.
-fn make_rib6_entry(route: &SpfRouteV3) -> rib::entry::RibEntry {
-    // SR-MPLS egress imposition: if the prefix has a resolved
-    // Prefix-SID label, push it onto every nexthop as an Explicit
-    // swap label. v2's `nhop_to_nexthop_uni` additionally tags
-    // adjacency-directly-attached nexthops as `Label::Implicit`
-    // (PHP), keyed off `SpfNexthop::adjacency`. `SpfNexthopV3`
-    // doesn't carry that flag yet, so we always push Explicit --
-    // functionally correct (swap to same label) just with no PHP
-    // optimization. Adding the adjacency flag to the v3 SPF
-    // nexthop builder is a follow-up.
+/// One v3 primary nexthop as a `NexthopUni` at `metric`, with the
+/// prefix-SID label (if any) pushed as an Explicit swap. `SpfNexthopV3`
+/// doesn't carry the adjacency/PHP flag in its label form yet, so we
+/// always push Explicit — functionally correct (swap to same label),
+/// just no PHP optimization. v3 sibling of `nhop_to_nexthop_uni`.
+fn nhop_v3_to_nexthop_uni(
+    addr: &std::net::Ipv6Addr,
+    route: &SpfRouteV3,
+    nhop: &SpfNexthopV3,
+    metric: u32,
+) -> rib::NexthopUni {
     let labels: Vec<rib::Label> = match route.sid {
         Some(sid) => vec![rib::Label::Explicit(sid)],
         None => vec![],
     };
-    let nexthop = if route.nhops.len() == 1 {
-        let (addr, nhop) = route.nhops.iter().next().unwrap();
-        let mut uni =
-            rib::NexthopUni::new(std::net::IpAddr::V6(*addr), route.metric, labels.clone());
-        uni.ifindex_origin = (nhop.ifindex != 0).then_some(nhop.ifindex);
-        rib::Nexthop::Uni(uni)
+    let mut uni = rib::NexthopUni::new(std::net::IpAddr::V6(*addr), metric, labels);
+    uni.ifindex_origin = (nhop.ifindex != 0).then_some(nhop.ifindex);
+    uni
+}
+
+/// A v3 TI-LFA repair as a backup `NexthopUni`: the repair's v6
+/// link-local, the resolved SR-MPLS label stack, and the egress
+/// ifindex, at `metric`. v3 sibling of `backup_to_nexthop_uni`.
+fn backup_v3_to_nexthop_uni(backup: &RepairPathMplsV3, metric: u32) -> rib::NexthopUni {
+    let mut uni = rib::NexthopUni::new(
+        std::net::IpAddr::V6(backup.addr),
+        metric,
+        backup.labels.clone(),
+    );
+    uni.ifindex_origin = (backup.ifindex != 0).then_some(backup.ifindex);
+    uni
+}
+
+/// Build a `rib::entry::RibEntry` from a `SpfRouteV3`. Flattens the
+/// primaries and (when present) their TI-LFA repair backups into one
+/// Vec at distinct metrics; `build_rib_nexthop` groups by metric and
+/// dispatches Uni / Multi / List. Mirrors v2's `make_rib_entry`.
+fn make_rib6_entry(route: &SpfRouteV3) -> rib::entry::RibEntry {
+    let offset_metric = route.metric.saturating_add(BACKUP_METRIC_OFFSET);
+    let (primary_metric, backup_metric) = if route.backup_as_primary {
+        (offset_metric, route.metric)
     } else {
-        let nexthops: Vec<rib::NexthopUni> = route
-            .nhops
-            .iter()
-            .map(|(addr, nhop)| {
-                let mut uni =
-                    rib::NexthopUni::new(std::net::IpAddr::V6(*addr), route.metric, labels.clone());
-                uni.ifindex_origin = (nhop.ifindex != 0).then_some(nhop.ifindex);
-                uni
-            })
-            .collect();
-        rib::Nexthop::Multi(rib::NexthopMulti {
-            metric: route.metric,
-            nexthops,
-            ..Default::default()
-        })
+        (route.metric, offset_metric)
     };
+    let nhops: Vec<rib::NexthopUni> = route
+        .nhops
+        .iter()
+        .flat_map(|(addr, nhop)| {
+            let primary = nhop_v3_to_nexthop_uni(addr, route, nhop, primary_metric);
+            let backup = nhop
+                .backup
+                .as_ref()
+                .map(|b| backup_v3_to_nexthop_uni(b, backup_metric));
+            std::iter::once(primary).chain(backup)
+        })
+        .collect();
 
     let mut rib_entry = rib::entry::RibEntry::new(RibType::Ospf);
     rib_entry.distance = 110;
     rib_entry.metric = route.metric;
-    rib_entry.nexthop = nexthop;
+    rib_entry.nexthop = build_rib_nexthop(nhops);
     rib_entry
 }
 
@@ -8699,8 +8788,9 @@ fn apply_routing_updates_v3(
     area_id: Ipv4Addr,
     source: usize,
     spf_result: &BTreeMap<usize, spf::Path>,
+    tilfa_result: &BTreeMap<usize, Vec<spf::RepairPath>>,
 ) {
-    let mut new_rib = build_rib6_from_spf(top, area_id, source, spf_result);
+    let mut new_rib = build_rib6_from_spf(top, area_id, source, spf_result, tilfa_result);
     // Attach SR Prefix-SIDs to matching routes so `make_rib6_entry`
     // pushes the label onto each nexthop (egress imposition).
     add_prefix_sids_v3(top, area_id, &mut new_rib);
@@ -9509,6 +9599,7 @@ fn add_self_prefix_sids_to_ilm_v3(top: &Ospf<Ospfv3>, ilm: &mut BTreeMap<u32, Sp
                         SpfNexthopV3 {
                             ifindex: link.index,
                             adjacency: true,
+                            backup: None,
                         },
                     );
                     ilm.insert(
@@ -9586,6 +9677,7 @@ fn add_self_adj_sids_to_ilm_v3(top: &Ospf<Ospfv3>, ilm: &mut BTreeMap<u32, SpfIl
             SpfNexthopV3 {
                 ifindex,
                 adjacency: true,
+                backup: None,
             },
         );
         ilm.insert(

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -44,6 +44,9 @@ impl Ospf<Ospfv3> {
             ("/route", show_ospfv3_route),
             ("/spf", show_ospfv3_spf),
             ("/graph", show_ospfv3_graph),
+            ("/ti-lfa", show_ospfv3_tilfa),
+            ("/repair-list", show_ospfv3_repair_list),
+            ("/repair-list/detail", show_ospfv3_repair_list_detail),
             ("/segment-routing", show_ospfv3_segment_routing),
             ("/flex-algo", show_ospfv3_flex_algo),
         ];
@@ -84,6 +87,278 @@ fn ls_type_name(ls_type: u16) -> &'static str {
         OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE => "Intra-Area-Prefix-LSA",
         _ => "Unknown",
     }
+}
+
+// ---- TI-LFA (RFC 9490) ------------------------------------------
+// `show ipv6 ospf ti-lfa` (graph-level per-destination repair lists)
+// and `show ipv6 ospf repair-list` (repair backups installed on the
+// v6 RIB). v3 siblings of the v2 handlers in `show.rs`.
+
+fn label_value_str_v3(label: &crate::rib::Label) -> String {
+    match label {
+        crate::rib::Label::Implicit(l) => format!("{l} (implicit-null)"),
+        crate::rib::Label::Explicit(l) => format!("{l}"),
+    }
+}
+
+fn vertex_name_v3(graph: &crate::spf::Graph, id: usize) -> String {
+    graph
+        .get(&id)
+        .map(|v| v.name.clone())
+        .unwrap_or_else(|| format!("v{id}"))
+}
+
+fn format_sr_segment_v3(graph: &crate::spf::Graph, seg: &crate::spf::SrSegment) -> String {
+    match seg {
+        crate::spf::SrSegment::NodeSid(v) => {
+            format!("Node-SID {} (vertex {})", vertex_name_v3(graph, *v), v)
+        }
+        crate::spf::SrSegment::AdjSid(from, to, _via) => format!(
+            "Adj-SID {} -> {} (vertex {} -> {})",
+            vertex_name_v3(graph, *from),
+            vertex_name_v3(graph, *to),
+            from,
+            to,
+        ),
+    }
+}
+
+#[derive(Serialize)]
+struct RepairSegmentV3Json {
+    kind: &'static str,
+    value: String,
+}
+
+#[derive(Serialize)]
+struct RepairRowV3Json {
+    prefix: String,
+    primary_nexthop: String,
+    primary_ifindex: u32,
+    primary_metric: u32,
+    repair_nexthop: String,
+    repair_ifindex: u32,
+    repair_metric: u32,
+    segments: Vec<RepairSegmentV3Json>,
+}
+
+#[derive(Serialize)]
+struct RepairListV3Json {
+    routes: Vec<RepairRowV3Json>,
+}
+
+fn collect_ospfv3_repair_rows(top: &Ospf<Ospfv3>) -> Vec<RepairRowV3Json> {
+    let mut rows = Vec::new();
+    for (prefix, route) in top.rib6.iter() {
+        for (addr, nhop) in route.nhops.iter() {
+            let Some(backup) = nhop.backup.as_ref() else {
+                continue;
+            };
+            let segments = backup
+                .labels
+                .iter()
+                .map(|label| RepairSegmentV3Json {
+                    kind: "sr-mpls",
+                    value: label_value_str_v3(label),
+                })
+                .collect();
+            rows.push(RepairRowV3Json {
+                prefix: prefix.to_string(),
+                primary_nexthop: addr.to_string(),
+                primary_ifindex: nhop.ifindex,
+                primary_metric: route.metric,
+                repair_nexthop: backup.addr.to_string(),
+                repair_ifindex: backup.ifindex,
+                repair_metric: route
+                    .metric
+                    .saturating_add(super::inst::BACKUP_METRIC_OFFSET),
+                segments,
+            });
+        }
+    }
+    rows
+}
+
+fn show_ospfv3_repair_list(
+    top: &Ospf<Ospfv3>,
+    _args: Args,
+    json: bool,
+) -> Result<String, std::fmt::Error> {
+    let rows = collect_ospfv3_repair_rows(top);
+    if json {
+        return Ok(
+            serde_json::to_string_pretty(&RepairListV3Json { routes: rows })
+                .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}")),
+        );
+    }
+    let mut buf = String::new();
+    if rows.is_empty() {
+        writeln!(buf, "(no TI-LFA repair-list entries)")?;
+        return Ok(buf);
+    }
+    writeln!(
+        buf,
+        "{:<30} {:<26} {:<26} Segments",
+        "Prefix", "Primary via", "Repair via",
+    )?;
+    for row in &rows {
+        let segs: Vec<String> = row.segments.iter().map(|s| s.value.clone()).collect();
+        writeln!(
+            buf,
+            "{:<30} {:<26} {:<26} [{}]",
+            row.prefix,
+            row.primary_nexthop,
+            row.repair_nexthop,
+            segs.join(", "),
+        )?;
+    }
+    Ok(buf)
+}
+
+fn show_ospfv3_repair_list_detail(
+    top: &Ospf<Ospfv3>,
+    _args: Args,
+    json: bool,
+) -> Result<String, std::fmt::Error> {
+    let rows = collect_ospfv3_repair_rows(top);
+    if json {
+        return Ok(
+            serde_json::to_string_pretty(&RepairListV3Json { routes: rows })
+                .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}")),
+        );
+    }
+    let mut buf = String::new();
+    if rows.is_empty() {
+        writeln!(buf, "(no TI-LFA repair-list entries)")?;
+        return Ok(buf);
+    }
+    for row in &rows {
+        writeln!(buf, "{}", row.prefix)?;
+        writeln!(
+            buf,
+            "  Primary: via {} (ifindex {}), metric {}",
+            row.primary_nexthop, row.primary_ifindex, row.primary_metric,
+        )?;
+        writeln!(
+            buf,
+            "  Repair:  via {} (ifindex {}), metric {}",
+            row.repair_nexthop, row.repair_ifindex, row.repair_metric,
+        )?;
+        if row.segments.is_empty() {
+            writeln!(buf, "    (trivial repair, no SR segments)")?;
+        } else {
+            for seg in &row.segments {
+                writeln!(buf, "    {} {}", seg.kind, seg.value)?;
+            }
+        }
+    }
+    Ok(buf)
+}
+
+#[derive(Serialize)]
+struct TilfaV3SegmentJson {
+    kind: &'static str,
+    description: String,
+}
+
+#[derive(Serialize)]
+struct TilfaV3RepairJson {
+    first_hop: String,
+    first_hop_vertex: usize,
+    first_hop_link_id: u32,
+    segments: Vec<TilfaV3SegmentJson>,
+}
+
+#[derive(Serialize)]
+struct TilfaV3DestJson {
+    destination: String,
+    destination_vertex: usize,
+    repairs: Vec<TilfaV3RepairJson>,
+}
+
+#[derive(Serialize)]
+struct TilfaV3Json {
+    destinations: Vec<TilfaV3DestJson>,
+}
+
+fn show_ospfv3_tilfa(
+    top: &Ospf<Ospfv3>,
+    _args: Args,
+    json: bool,
+) -> Result<String, std::fmt::Error> {
+    let graph = top.graph.as_ref();
+    let tilfa = top.tilfa_result.as_ref();
+
+    if json {
+        let destinations = match (graph, tilfa) {
+            (Some(g), Some(t)) => t
+                .iter()
+                .map(|(dest, repairs)| TilfaV3DestJson {
+                    destination: vertex_name_v3(g, *dest),
+                    destination_vertex: *dest,
+                    repairs: repairs
+                        .iter()
+                        .map(|rp| TilfaV3RepairJson {
+                            first_hop: vertex_name_v3(g, rp.first_hop),
+                            first_hop_vertex: rp.first_hop,
+                            first_hop_link_id: rp.first_hop_link_id,
+                            segments: rp
+                                .segs
+                                .iter()
+                                .map(|seg| TilfaV3SegmentJson {
+                                    kind: match seg {
+                                        crate::spf::SrSegment::NodeSid(_) => "node-sid",
+                                        crate::spf::SrSegment::AdjSid(..) => "adj-sid",
+                                    },
+                                    description: format_sr_segment_v3(g, seg),
+                                })
+                                .collect(),
+                        })
+                        .collect(),
+                })
+                .collect(),
+            _ => Vec::new(),
+        };
+        return Ok(serde_json::to_string_pretty(&TilfaV3Json { destinations })
+            .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}")));
+    }
+
+    let mut buf = String::new();
+    let (Some(graph), Some(tilfa)) = (graph, tilfa) else {
+        writeln!(buf, "(no TI-LFA repair paths computed)")?;
+        return Ok(buf);
+    };
+    if tilfa.is_empty() {
+        writeln!(buf, "(no TI-LFA repair paths computed)")?;
+        return Ok(buf);
+    }
+    writeln!(buf, "OSPFv3 TI-LFA repair paths:")?;
+    for (dest, repairs) in tilfa.iter() {
+        writeln!(
+            buf,
+            "  Destination {} (vertex {})",
+            vertex_name_v3(graph, *dest),
+            dest,
+        )?;
+        for (i, rp) in repairs.iter().enumerate() {
+            writeln!(
+                buf,
+                "    [{}] first-hop {} (vertex {}, link_id {})",
+                i,
+                vertex_name_v3(graph, rp.first_hop),
+                rp.first_hop,
+                rp.first_hop_link_id,
+            )?;
+            if rp.segs.is_empty() {
+                writeln!(buf, "        segments: (none — direct repair)")?;
+            } else {
+                writeln!(buf, "        segments:")?;
+                for seg in &rp.segs {
+                    writeln!(buf, "          {}", format_sr_segment_v3(graph, seg))?;
+                }
+            }
+        }
+    }
+    Ok(buf)
 }
 
 // ---- show ipv6 ospf (instance summary) --------------------------

--- a/zebra-rs/src/ospf/tilfa.rs
+++ b/zebra-rs/src/ospf/tilfa.rs
@@ -15,9 +15,13 @@
 //! segment is a plain `(from, to)` pair.
 
 use std::collections::BTreeMap;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
-use ospf_packet::{Algo, ExtLinkSubTlv, ExtPrefixSubTlv, OspfLsType, OspfLsp, SidLabelTlv};
+use ospf_packet::{
+    Algo, ExtLinkSubTlv, ExtPrefixSubTlv, OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE,
+    OSPFV3_E_ROUTER_LSA_TYPE, OspfLsType, OspfLsp, Ospfv3ExtTlv, Ospfv3LsBody,
+    Ospfv3RouterLinkType, Ospfv3SubTlv, SidLabelTlv,
+};
 
 use crate::rib;
 use crate::spf;
@@ -26,6 +30,7 @@ use crate::spf::label_block::LabelConfig;
 use super::area::OspfArea;
 use super::inst::Ospf;
 use super::lsdb::OSPF_MAX_AGE;
+use super::version::Ospfv3;
 
 /// TI-LFA SR-MPLS repair path: the post-convergence first-hop egress
 /// (ifindex + neighbor address) plus the MPLS label stack that steers
@@ -245,6 +250,178 @@ fn adj_sid_label_for_link(
                     for sub in &tlv.subs {
                         if let ExtLinkSubTlv::LanAdjSid(lan) = sub
                             && lan.neighbor_id == to_router
+                        {
+                            return resolve_sid(&lan.sid, srgb);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    None
+}
+
+// =====================================================================
+// OSPFv3 (RFC 5340) — SR-MPLS repair resolution.
+//
+// Same shape as the v2 functions above, but the SR data lives in v3's
+// extended LSAs: Node-SIDs in E-Intra-Area-Prefix LSAs (RFC 8362 §3.7 /
+// RFC 8666), Adj-SIDs in E-Router-LSA RouterLink TLVs. Next-hops are
+// IPv6 link-locals resolved by neighbor router-id (mirrors
+// `collect_v3_nexthops`). The graph-level `tilfa_repair_path` above is
+// protocol-agnostic and reused for v3 unchanged.
+// =====================================================================
+
+/// v3 sibling of [`RepairPathMpls`]: the post-convergence first-hop
+/// egress (ifindex + neighbor link-local) plus the SR-MPLS label stack.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RepairPathMplsV3 {
+    pub ifindex: u32,
+    pub addr: Ipv6Addr,
+    pub labels: Vec<rib::Label>,
+}
+
+/// v3 sibling of [`build_repair_path_mpls`]. Resolves the SR segment
+/// list to an MPLS label stack from v3's extended LSAs and pins the
+/// post-convergence first-hop's IPv6 link-local egress.
+pub(super) fn build_repair_path_mpls_v3(
+    top: &Ospf<Ospfv3>,
+    area: &OspfArea<Ospfv3>,
+    rp: &spf::RepairPath,
+) -> Option<RepairPathMplsV3> {
+    let labels = repair_segments_to_mpls_labels_v3(top, area, &rp.segs)?;
+    let first_hop_router = *top.lsp_map.resolve(rp.first_hop)?;
+    let (ifindex, addr) = resolve_first_hop_egress_v3(top, first_hop_router)?;
+    Some(RepairPathMplsV3 {
+        ifindex,
+        addr,
+        labels,
+    })
+}
+
+/// Resolve the repair's first-hop egress to (ifindex, link-local addr).
+/// v3 keys neighbors by router-id and learns the egress from the
+/// adjacency, so — unlike v2 — `first_hop_link_id` isn't consulted;
+/// this mirrors `collect_v3_nexthops`.
+fn resolve_first_hop_egress_v3(
+    top: &Ospf<Ospfv3>,
+    first_hop_router: Ipv4Addr,
+) -> Option<(u32, Ipv6Addr)> {
+    for link in top.links.values() {
+        if let Some(nbr) = link.nbrs.get(&first_hop_router) {
+            let ll = nbr.ident.prefix.addr();
+            if !ll.is_unspecified() {
+                return Some((nbr.ifindex, ll));
+            }
+        }
+    }
+    None
+}
+
+fn repair_segments_to_mpls_labels_v3(
+    top: &Ospf<Ospfv3>,
+    area: &OspfArea<Ospfv3>,
+    segments: &[spf::SrSegment],
+) -> Option<Vec<rib::Label>> {
+    let mut labels = Vec::with_capacity(segments.len());
+    for seg in segments {
+        let resolved = match seg {
+            spf::SrSegment::NodeSid(v) => node_sid_label_for_vertex_v3(top, area, *v),
+            spf::SrSegment::AdjSid(from, to, _via) => {
+                adj_sid_label_for_link_v3(top, area, *from, *to)
+            }
+        };
+        labels.push(rib::Label::Explicit(resolved?));
+    }
+    Some(labels)
+}
+
+/// v3 Node-SID lookup: scan the vertex router's E-Intra-Area-Prefix
+/// LSAs for a base-algo (SPF) Prefix-SID, preferring a host (/128)
+/// prefix (the loopback / Node-SID). Index-form SIDs resolve against
+/// the advertiser's SRGB.
+fn node_sid_label_for_vertex_v3(
+    top: &Ospf<Ospfv3>,
+    area: &OspfArea<Ospfv3>,
+    vertex: usize,
+) -> Option<u32> {
+    let router_id = *top.lsp_map.resolve(vertex)?;
+    let srgb = area.lsdb.label_map.get(&router_id);
+
+    let mut fallback: Option<u32> = None;
+    for ((_ls_id, adv_router), lsa) in area
+        .lsdb
+        .iter_by_raw_type(OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE)
+    {
+        if lsa.data.h.ls_age >= OSPF_MAX_AGE || adv_router != router_id {
+            continue;
+        }
+        let Ospfv3LsBody::EIntraAreaPrefix(ref body) = lsa.data.body else {
+            continue;
+        };
+        for tlv in &body.tlvs {
+            let Ospfv3ExtTlv::IntraAreaPrefix(prefix_tlv) = tlv else {
+                continue;
+            };
+            for sub in &prefix_tlv.subs {
+                let Ospfv3SubTlv::PrefixSid(ps) = sub else {
+                    continue;
+                };
+                if ps.algo != Algo::Spf {
+                    continue;
+                }
+                let Some(label) = resolve_sid(&ps.sid, srgb) else {
+                    continue;
+                };
+                if prefix_tlv.prefix_length == 128 {
+                    return Some(label);
+                }
+                fallback.get_or_insert(label);
+            }
+        }
+    }
+    fallback
+}
+
+/// v3 Adj-SID lookup: scan `from`'s E-Router-LSAs (one per interface)
+/// for the RouterLink toward `to` and take its Adj-SID / LAN-Adj-SID.
+fn adj_sid_label_for_link_v3(
+    top: &Ospf<Ospfv3>,
+    area: &OspfArea<Ospfv3>,
+    from_vertex: usize,
+    to_vertex: usize,
+) -> Option<u32> {
+    let from_router = *top.lsp_map.resolve(from_vertex)?;
+    let to_router = *top.lsp_map.resolve(to_vertex)?;
+    let srgb = area.lsdb.label_map.get(&from_router);
+
+    for ((_ls_id, adv_router), lsa) in area.lsdb.iter_by_raw_type(OSPFV3_E_ROUTER_LSA_TYPE) {
+        if lsa.data.h.ls_age >= OSPF_MAX_AGE || adv_router != from_router {
+            continue;
+        }
+        let Ospfv3LsBody::ERouter(ref body) = lsa.data.body else {
+            continue;
+        };
+        for tlv in &body.tlvs {
+            let Ospfv3ExtTlv::RouterLink(rl) = tlv else {
+                continue;
+            };
+            match rl.link.link_type {
+                Ospfv3RouterLinkType::PointToPoint => {
+                    if rl.link.neighbor_router_id != to_router {
+                        continue;
+                    }
+                    for sub in &rl.subs {
+                        if let Ospfv3SubTlv::AdjSid(adj) = sub {
+                            return resolve_sid(&adj.sid, srgb);
+                        }
+                    }
+                }
+                Ospfv3RouterLinkType::Transit => {
+                    for sub in &rl.subs {
+                        if let Ospfv3SubTlv::LanAdjSid(lan) = sub
+                            && lan.neighbor_router_id == to_router
                         {
                             return resolve_sid(&lan.sid, srgb);
                         }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1037,10 +1037,28 @@ module config {
           container fast-reroute {
             // Per-algo TI-LFA toggle. Empty container is a no-op; the
             // child presence container turns the per-algo TI-LFA
-            // computation on (deferred — no OSPF TI-LFA yet).
+            // computation on (deferred — no OSPF per-algo TI-LFA yet).
             container ti-lfa {
               presence "Enable Topology-Independent LFA for this flex-algo";
             }
+          }
+        }
+
+        container fast-reroute {
+          // OSPFv3 fast-reroute mechanisms (RFC 7490 LFA family).
+          // Same shape as `router ospf / fast-reroute`; the repair is
+          // expressed as SR-MPLS labels, so segment-routing/mpls must
+          // also be enabled for the dataplane install.
+          container ti-lfa {
+            // Topology-Independent Loop-Free Alternate (TI-LFA,
+            // RFC 9490). Post-convergence repair over the v3 LSDB.
+            presence "Enable Topology-Independent LFA (TI-LFA)";
+          }
+          container backup-as-primary {
+            // Swap the metric-sort offset between the SPF primary and
+            // the TI-LFA repair so the repair installs first. Protection
+            // testing knob; see `router ospf` for the full rationale.
+            presence "Install TI-LFA backup as the primary nexthop";
           }
         }
       }

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -548,6 +548,18 @@ module exec {
         leaf spf {
           type empty;
         }
+        leaf ti-lfa {
+          ext:help "OSPFv3 TI-LFA per-destination repair paths (graph-level view)";
+          type empty;
+        }
+        container repair-list {
+          ext:help "OSPFv3 TI-LFA repair-list";
+          presence "OSPFv3 repair-list";
+          leaf detail {
+            ext:help "OSPFv3 repair-list detail (per-segment label breakdown)";
+            type empty;
+          }
+        }
         leaf flex-algo {
           ext:help "OSPFv3 Flexible Algorithm (RFC 9350) state";
           type empty;


### PR DESCRIPTION
## Summary

Extends Topology-Independent LFA (TI-LFA, RFC 9490) to **OSPFv3** — the follow-up to the OSPFv2 work in #1109. OSPFv2 and OSPFv3 are now at parity (SR-MPLS control plane + kernel FIB install).

The graph-level algorithm reuses the protocol-agnostic `spf::tilfa` and the shared `tilfa_repair_path` unchanged — the shared `compute_spf` already populates `Path::nexthops` under `SpfOpt::default()`, so it works for v3 as-is. Only label resolution and the v6 RIB stamping are v3-specific.

Config:
```
router ospfv3 {
  fast-reroute ti-lfa
  fast-reroute backup-as-primary
}
```
Inspect:
```
show ipv6 ospf ti-lfa
show ipv6 ospf repair-list [detail]
```

## Changes

- **`graph_v3()`** — two-pass build populating `ilinks` (Q-space reverse SPF) and stamping `link_id = ifindex` on source-router edges, mirroring the v2 graph (shares the `push_edge` helper). Forward SPF unchanged.
- **`tilfa.rs`** — v3 label resolution: `RepairPathMplsV3` (v6 neighbor addr), Node-SIDs from **E-Intra-Area-Prefix LSAs** (base-algo, preferring /128), Adj-SIDs from **E-Router-LSA RouterLink TLVs**. First-hop egress resolves by neighbor router-id to the v6 link-local (mirrors `collect_v3_nexthops`).
- **SPF/RIB/FIB** — `build_v3_spf_input` passes `top.ti_lfa_enabled`; `SpfNexthopV3` gains `backup`, `SpfRouteV3` gains `dest_vertex` + `backup_as_primary`; `build_rib6_from_spf` second pass stamps repairs onto single-primary intra-area / NSSA routes; `make_rib6_entry` emits the backup at `route.metric + BACKUP_METRIC_OFFSET` (reusing v2's `build_rib_nexthop`), installing into the kernel FIB.
- **Config** — `/router/ospfv3/fast-reroute/{ti-lfa,backup-as-primary}` presence containers + callbacks in `config_v3.rs`.
- **Show** — `show ipv6 ospf ti-lfa` + `show ipv6 ospf repair-list [detail]`, text + JSON.

SRv6 repair for v3 is a further follow-up (v3 currently forwards SR-MPLS).

## Test plan

- `cargo fmt` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs --bins` — **785 passed, 0 failed**
- YANG load guard (`exec` + `configure`) — passes

Generated with [Claude Code](https://claude.com/claude-code)