### PR TITLE
ospf: VRF support (first slice) for OSPFv2 + OSPFv3

### DIFF
--- a/zebra-rs/src/config/ospf.rs
+++ b/zebra-rs/src/config/ospf.rs
@@ -7,7 +7,18 @@ use super::ConfigManager;
 pub fn spawn_ospf(config: &ConfigManager) {
     let (rib_client, rib_rx) = config.subscribe_to_rib("ospf");
     let ctx = ProtoContext::default_table(rib_client);
-    let ospf = inst::Ospf::<crate::ospf::Ospfv2>::new(ctx, rib_rx, config.policy_tx.clone());
+    // `"ospf"` is the default-instance proto label; per-VRF children
+    // get `"ospf:vrf:<name>"`. `rib_subscriber` + `config.tx` let the
+    // default task mint per-VRF RIB subscriptions and (de)register
+    // `show ip ospf vrf <name>`.
+    let ospf = inst::Ospf::<crate::ospf::Ospfv2>::new(
+        ctx,
+        rib_rx,
+        config.policy_tx.clone(),
+        "ospf".to_string(),
+        config.rib_subscriber(),
+        config.tx.clone(),
+    );
     config.subscribe("ospf", ospf.cm.tx.clone());
     config.subscribe_show("ospf", ospf.show.tx.clone());
     let task = inst::serve(ospf);
@@ -34,7 +45,16 @@ pub fn despawn_ospf(config: &ConfigManager) {
 pub fn spawn_ospfv3(config: &ConfigManager) {
     let (rib_client, rib_rx) = config.subscribe_to_rib("ospfv3");
     let ctx = ProtoContext::default_table(rib_client);
-    let ospf = inst::Ospf::<crate::ospf::Ospfv3>::new(ctx, rib_rx, config.policy_tx.clone());
+    // `"ospfv3"` default label; per-VRF children get
+    // `"ospfv3:vrf:<name>"`. See `spawn_ospf` for the rationale.
+    let ospf = inst::Ospf::<crate::ospf::Ospfv3>::new(
+        ctx,
+        rib_rx,
+        config.policy_tx.clone(),
+        "ospfv3".to_string(),
+        config.rib_subscriber(),
+        config.tx.clone(),
+    );
     config.subscribe("ospfv3", ospf.cm.tx.clone());
     config.subscribe_show("ospfv3", ospf.show.tx.clone());
     let task = inst::serve_v3(ospf);

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -26,7 +26,10 @@ use crate::rib::link::LinkAddr;
 use crate::rib::{self, Link, LinkFlagsExt, Nexthop, NexthopMulti, NexthopUni, RibType};
 use crate::spf::label_block::LabelConfig;
 use crate::{
-    config::{Args, ConfigChannel, ConfigOp, ConfigRequest, path_from_command},
+    config::{
+        Args, CommandPath, ConfigChannel, ConfigOp, ConfigRequest, RibSubscriber,
+        path_from_command, vrf_redirect_split,
+    },
     context::Task,
 };
 
@@ -225,6 +228,34 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// sender; the v3 event loop `take()`s this receiver at startup.
     /// `None` on v2.
     pub v3_recv_rx: Option<UnboundedReceiver<super::network_v6::Ospfv3Recv>>,
+
+    /// Protocol identity for name-keyed RIB / policy registrations.
+    /// `V::PROTO` (`"ospf"` / `"ospfv3"`) for the default instance,
+    /// `"<proto>:vrf:<name>"` for a per-VRF instance — so the two
+    /// don't clobber each other's rows in the name-keyed policy /
+    /// redistribute / SR registries. Route-install attribution is by
+    /// the numeric `ProtoId` in `ctx.rib`, so it is unaffected.
+    pub proto_label: String,
+    /// Send-capable RIB-subscription factory. The default instance
+    /// uses it to mint a per-VRF `RibClient` bound to the VRF's kernel
+    /// `table_id` when spawning a child; cloned into each child too.
+    pub rib_subscriber: RibSubscriber,
+    /// Sender into the config manager, for (de)registering a child's
+    /// `show ... vrf <name>` channel via `SubscribeShowVrf` /
+    /// `UnsubscribeShowVrf`. Bounded — send with `try_send`.
+    pub config_tx: tokio::sync::mpsc::Sender<crate::config::Message>,
+    /// Per-VRF buffered config (default instance only). Each
+    /// `router ospf{,v3} vrf <name> ...` line, rewritten to strip the
+    /// `vrf <name>` prefix, is appended in commit order; replayed into
+    /// a child at spawn and kept so a `VrfDel`→`VrfAdd` flap respawns
+    /// from intent. Empty for child instances.
+    pub vrf_log: BTreeMap<String, Vec<(Vec<CommandPath>, ConfigOp)>>,
+    /// Running per-VRF child tasks (default instance only), by name.
+    pub vrf_registry: BTreeMap<String, super::vrf::OspfVrfHandle>,
+    /// Kernel VRF master info from `RibRx::VrfAdd` (default instance
+    /// only): VRF name → (table_id, ifindex). A child spawns once both
+    /// config intent (`vrf_log`) and kernel info exist.
+    pub rib_known_vrfs: BTreeMap<String, (u32, u32)>,
 }
 
 // OSPF inteface structure which points out upper layer struct members.
@@ -308,6 +339,95 @@ impl<'a, V: OspfVersion> OspfInterface<'a, V> {
 // the v2-shaped tx channel) and produce `OspfInterface<V>` /
 // `&Neighbor<V>` values typed by `V`.
 impl<V: OspfVersion> Ospf<V> {
+    /// Record a rewritten per-VRF config line (default instance only).
+    /// Appends to the VRF's replay log and, if its child is already
+    /// running, forwards the line live to the child's config inbox.
+    pub(crate) fn vrf_config_record(
+        &mut self,
+        name: String,
+        rewritten: Vec<CommandPath>,
+        op: ConfigOp,
+    ) {
+        if let Some(handle) = self.vrf_registry.get(&name) {
+            let _ = handle.cm_tx.send(ConfigRequest::new(rewritten.clone(), op));
+        }
+        self.vrf_log.entry(name).or_default().push((rewritten, op));
+    }
+
+    /// `CommitEnd` fan-out for the default instance: tear down per-VRF
+    /// children whose `router ospf{,v3} vrf <name>` block was fully
+    /// deleted this commit, then forward `CommitEnd` to every surviving
+    /// live child so it runs its own commit-time reconcile.
+    pub(crate) fn vrf_commit_end(&mut self) {
+        let emptied: Vec<String> = self
+            .vrf_log
+            .iter()
+            .filter(|(_, log)| !super::vrf::vrf_log_active(log))
+            .map(|(name, _)| name.clone())
+            .collect();
+        for name in emptied {
+            self.vrf_log.remove(&name);
+            // Kernel info (`rib_known_vrfs`) is owned by VrfAdd/VrfDel,
+            // not by config — leave it so a re-added block respawns if
+            // the kernel VRF still exists.
+            if self.vrf_registry.remove(&name).is_some() {
+                super::vrf::despawn_ospf_vrf(
+                    V::PROTO,
+                    &name,
+                    &self.config_tx,
+                    &self.rib_subscriber,
+                );
+            }
+        }
+        for handle in self.vrf_registry.values() {
+            let _ = handle
+                .cm_tx
+                .send(ConfigRequest::new(Vec::new(), ConfigOp::CommitEnd));
+        }
+    }
+
+    /// Kernel VRF master appeared (or was replayed at subscribe time).
+    /// Record its `table_id`/`ifindex`, and spawn the per-VRF OSPF
+    /// child of this version if config intent exists and it isn't
+    /// already running. Default instance only.
+    pub(crate) fn vrf_add(&mut self, name: String, table_id: u32, ifindex: u32) {
+        self.rib_known_vrfs
+            .insert(name.clone(), (table_id, ifindex));
+        if self.vrf_registry.contains_key(&name) {
+            return;
+        }
+        let has_intent = self
+            .vrf_log
+            .get(&name)
+            .is_some_and(|log| super::vrf::vrf_log_active(log));
+        if !has_intent {
+            return;
+        }
+        // Clone the replay log so the spawn borrow doesn't overlap the
+        // `vrf_registry` insert below.
+        let log = self.vrf_log.get(&name).cloned().unwrap_or_default();
+        let handle = V::spawn_vrf(
+            &name,
+            table_id,
+            &self.rib_subscriber,
+            &self.config_tx,
+            &self.policy_tx,
+            &log,
+        );
+        self.vrf_registry.insert(name, handle);
+    }
+
+    /// Kernel VRF master removed. Despawn the child but KEEP its config
+    /// log so a later `VrfAdd` (master re-created) respawns from intent.
+    /// RIB reclaims the VRF's FIB table on its side. Default instance
+    /// only.
+    pub(crate) fn vrf_del(&mut self, name: String) {
+        self.rib_known_vrfs.remove(&name);
+        if self.vrf_registry.remove(&name).is_some() {
+            super::vrf::despawn_ospf_vrf(V::PROTO, &name, &self.config_tx, &self.rib_subscriber);
+        }
+    }
+
     /// Stage a flex-algo (`{V::FLEX_ALGO_PREFIX}/...`), `/affinity-map`
     /// or `/srlg/group` config leaf into its builder. The caller gates
     /// on the path prefix and returns early after this; the staged
@@ -521,12 +641,15 @@ impl Ospf<Ospfv2> {
         ctx: crate::context::ProtoContext,
         rib_rx: UnboundedReceiver<RibRx>,
         policy_tx: UnboundedSender<crate::policy::Message>,
+        proto_label: String,
+        rib_subscriber: RibSubscriber,
+        config_tx: tokio::sync::mpsc::Sender<crate::config::Message>,
     ) -> Self {
         let sock = Arc::new(AsyncFd::new(ospf_socket_ipv4(&ctx).unwrap()).unwrap());
 
         let policy_chan = crate::policy::PolicyRxChannel::new();
         let _ = policy_tx.send(crate::policy::Message::Subscribe {
-            proto: "ospf".into(),
+            proto: proto_label.clone(),
             tx: policy_chan.tx.clone(),
         });
 
@@ -578,14 +701,25 @@ impl Ospf<Ospfv2> {
             sock,
             v3_send_tx: None,
             v3_recv_rx: None,
+            proto_label,
+            rib_subscriber,
+            config_tx,
+            vrf_log: BTreeMap::new(),
+            vrf_registry: BTreeMap::new(),
+            rib_known_vrfs: BTreeMap::new(),
         };
         ospf.callback_build();
         ospf.show_build();
 
         // If a fresh graceful-restart checkpoint is on disk, replay
         // the saved state into this instance + enter restarting mode
-        // so we don't cold-start over a planned restart.
-        ospf.gr_restart_load_checkpoint();
+        // so we don't cold-start over a planned restart. Only the
+        // default instance loads it — the on-disk path is keyed by a
+        // fixed proto name (`ospf.cbor`), so a per-VRF child must not
+        // restore the default instance's state.
+        if ospf.proto_label == "ospf" {
+            ospf.gr_restart_load_checkpoint();
+        }
 
         let tx = ospf.tx.clone();
         let sock = ospf.sock.clone();
@@ -600,15 +734,26 @@ impl Ospf<Ospfv2> {
     }
 
     pub fn process_cm_msg(&mut self, msg: ConfigRequest) {
-        let (path, args) = path_from_command(&msg.paths);
-
-        // Apply the flex-algo / affinity-map / SRLG staging at the end
-        // of a commit cycle (mirrors IS-IS). Nothing else handles
-        // CommitEnd on the v2 instance today.
+        // CommitEnd: fan out to per-VRF children (run their reconcile)
+        // and prune any whose `router ospf vrf <name>` block was fully
+        // deleted, then apply this instance's own flex-algo / affinity
+        // / SRLG staging (mirrors IS-IS).
         if msg.op == ConfigOp::CommitEnd {
+            self.vrf_commit_end();
             self.commit_flex_algo_tables();
             return;
         }
+
+        // `/router/ospf/vrf/<name>/...` belongs to a per-VRF child, not
+        // the default instance. Strip the `vrf <name>` selector and
+        // buffer + forward the rewritten line; never dispatch it through
+        // the default instance's own callback table.
+        if let Some((name, rewritten)) = vrf_redirect_split(&msg.paths) {
+            self.vrf_config_record(name, rewritten, msg.op);
+            return;
+        }
+
+        let (path, args) = path_from_command(&msg.paths);
 
         // Clear ops bypass the YANG callback table — they map
         // straight to runtime side-effects (kick SPF, drop a peer,
@@ -3521,6 +3666,15 @@ impl Ospf<Ospfv2> {
             RibRx::RouteDel { rtype, routes, .. } => {
                 self.route_redist_del(rtype, routes);
             }
+            // VRF master lifecycle (default instance only): spawn /
+            // despawn the per-VRF OSPFv2 child once config intent +
+            // kernel table_id both exist.
+            RibRx::VrfAdd {
+                name,
+                table_id,
+                ifindex,
+            } => self.vrf_add(name, table_id, ifindex),
+            RibRx::VrfDel { name } => self.vrf_del(name),
             _ => {
                 //
             }
@@ -3629,12 +3783,15 @@ impl Ospf<Ospfv3> {
         ctx: crate::context::ProtoContext,
         rib_rx: UnboundedReceiver<RibRx>,
         policy_tx: UnboundedSender<crate::policy::Message>,
+        proto_label: String,
+        rib_subscriber: RibSubscriber,
+        config_tx: tokio::sync::mpsc::Sender<crate::config::Message>,
     ) -> Self {
         let sock = Arc::new(AsyncFd::new(super::socket::ospf_socket_ipv6(&ctx).unwrap()).unwrap());
 
         let policy_chan = crate::policy::PolicyRxChannel::new();
         let _ = policy_tx.send(crate::policy::Message::Subscribe {
-            proto: "ospfv3".into(),
+            proto: proto_label.clone(),
             tx: policy_chan.tx.clone(),
         });
 
@@ -3709,9 +3866,18 @@ impl Ospf<Ospfv3> {
             sock,
             v3_send_tx: Some(v3_send_tx),
             v3_recv_rx: Some(v3_recv_rx),
+            proto_label,
+            rib_subscriber,
+            config_tx,
+            vrf_log: BTreeMap::new(),
+            vrf_registry: BTreeMap::new(),
+            rib_known_vrfs: BTreeMap::new(),
         };
         ospf.callback_build();
         ospf.show_build();
+        // v3 has no on-disk GR checkpoint load today, so nothing to
+        // gate here (a per-VRF child would otherwise need the same
+        // default-instance guard the v2 path uses).
         ospf
     }
 
@@ -3720,15 +3886,25 @@ impl Ospf<Ospfv3> {
     /// `/router/ospfv3/area/interface/enable` is registered (#791-stub
     /// path); more leaves land alongside the YANG schema expansion.
     pub fn process_cm_msg(&mut self, msg: ConfigRequest) {
-        let (path, args) = path_from_command(&msg.paths);
-
-        // Apply the flex-algo / affinity-map / SRLG staging at the end
-        // of a commit cycle (mirrors the v2 sibling). Nothing else
-        // handles CommitEnd on the v3 instance today.
+        // CommitEnd: fan out to per-VRF children and prune deleted
+        // ones, then apply this instance's own staging (mirrors the v2
+        // sibling).
         if msg.op == ConfigOp::CommitEnd {
+            self.vrf_commit_end();
             self.commit_flex_algo_tables();
             return;
         }
+
+        // `/router/ospfv3/vrf/<name>/...` belongs to a per-VRF child.
+        // Strip the `vrf <name>` selector and buffer + forward the
+        // rewritten line; never dispatch it through the default
+        // instance's own callback table.
+        if let Some((name, rewritten)) = vrf_redirect_split(&msg.paths) {
+            self.vrf_config_record(name, rewritten, msg.op);
+            return;
+        }
+
+        let (path, args) = path_from_command(&msg.paths);
 
         // Clear ops bypass the YANG callback table; see the v2
         // sibling. Path-filter so the v3 instance ignores the v2
@@ -3785,6 +3961,15 @@ impl Ospf<Ospfv3> {
             RibRx::LinkDel(ifindex) => self.link_del(ifindex),
             RibRx::AddrAdd(addr) => self.addr_add(addr),
             RibRx::AddrDel(addr) => self.addr_del(addr),
+            // VRF master lifecycle (default instance only): spawn /
+            // despawn the per-VRF OSPFv3 child once config intent +
+            // kernel table_id both exist.
+            RibRx::VrfAdd {
+                name,
+                table_id,
+                ifindex,
+            } => self.vrf_add(name, table_id, ifindex),
+            RibRx::VrfDel { name } => self.vrf_del(name),
             _ => {}
         }
     }

--- a/zebra-rs/src/ospf/mod.rs
+++ b/zebra-rs/src/ospf/mod.rs
@@ -64,3 +64,5 @@ pub mod reach_map;
 pub use reach_map::*;
 
 pub mod checkpoint;
+
+pub mod vrf;

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -109,6 +109,28 @@ pub trait OspfVersion: 'static + Send + Sync + Copy + Clone + PartialEq + Eq {
     /// `{FLEX_ALGO_PREFIX}/...`.
     const FLEX_ALGO_PREFIX: &'static str;
 
+    /// Proto label base for this version — `"ospf"` (v2) or
+    /// `"ospfv3"` (v3). Used as the default instance's RIB / policy
+    /// registration name and as the prefix for per-VRF labels
+    /// (`"<PROTO>:vrf:<name>"`), which also doubles as the manager
+    /// show-channel key.
+    const PROTO: &'static str;
+
+    /// Spawn a per-VRF instance of this version and return its handle.
+    /// Dispatches the version-specific `Ospf::<Self>::new` + serve
+    /// (the generic per-VRF code can't name the concrete constructor);
+    /// the shared spawn steps — RIB subscription bound to `table_id`,
+    /// `ProtoContext::for_vrf`, show-channel registration, and config
+    /// replay — live in `crate::ospf::vrf`.
+    fn spawn_vrf(
+        name: &str,
+        table_id: u32,
+        rib_subscriber: &crate::config::RibSubscriber,
+        config_tx: &tokio::sync::mpsc::Sender<crate::config::Message>,
+        policy_tx: &tokio::sync::mpsc::UnboundedSender<crate::policy::Message>,
+        buffered: &[(Vec<crate::config::CommandPath>, crate::config::ConfigOp)],
+    ) -> crate::ospf::vrf::OspfVrfHandle;
+
     /// AllSPFRouters multicast group: 224.0.0.5 (v2) or ff02::5 (v3).
     const ALL_SPF_ROUTERS: Self::Addr;
 
@@ -333,6 +355,26 @@ impl OspfVersion for Ospfv2 {
     type LsRequest = OspfLsRequest;
     type LsRequestEntry = OspfLsRequestEntry;
     const FLEX_ALGO_PREFIX: &'static str = "/router/ospf/flex-algo";
+    const PROTO: &'static str = "ospf";
+
+    fn spawn_vrf(
+        name: &str,
+        table_id: u32,
+        rib_subscriber: &crate::config::RibSubscriber,
+        config_tx: &tokio::sync::mpsc::Sender<crate::config::Message>,
+        policy_tx: &tokio::sync::mpsc::UnboundedSender<crate::policy::Message>,
+        buffered: &[(Vec<crate::config::CommandPath>, crate::config::ConfigOp)],
+    ) -> crate::ospf::vrf::OspfVrfHandle {
+        crate::ospf::vrf::spawn_ospf_vrf_v2(
+            name,
+            table_id,
+            rib_subscriber,
+            config_tx,
+            policy_tx,
+            buffered,
+        )
+    }
+
     const ALL_SPF_ROUTERS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 5);
     const ALL_DROUTERS: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 6);
 
@@ -441,6 +483,26 @@ impl OspfVersion for Ospfv3 {
     type LsRequest = Ospfv3LsRequest;
     type LsRequestEntry = Ospfv3LsRequestEntry;
     const FLEX_ALGO_PREFIX: &'static str = "/router/ospfv3/flex-algo";
+    const PROTO: &'static str = "ospfv3";
+
+    fn spawn_vrf(
+        name: &str,
+        table_id: u32,
+        rib_subscriber: &crate::config::RibSubscriber,
+        config_tx: &tokio::sync::mpsc::Sender<crate::config::Message>,
+        policy_tx: &tokio::sync::mpsc::UnboundedSender<crate::policy::Message>,
+        buffered: &[(Vec<crate::config::CommandPath>, crate::config::ConfigOp)],
+    ) -> crate::ospf::vrf::OspfVrfHandle {
+        crate::ospf::vrf::spawn_ospf_vrf_v3(
+            name,
+            table_id,
+            rib_subscriber,
+            config_tx,
+            policy_tx,
+            buffered,
+        )
+    }
+
     /// AllSPFRouters in v3 (RFC 5340 §A.1): `ff02::5`.
     const ALL_SPF_ROUTERS: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 5);
     /// AllDRouters in v3 (RFC 5340 §A.1): `ff02::6`.

--- a/zebra-rs/src/ospf/vrf.rs
+++ b/zebra-rs/src/ospf/vrf.rs
@@ -1,0 +1,170 @@
+//! Per-VRF OSPF instance spawn / despawn (OSPFv2 + OSPFv3).
+//!
+//! Mirrors `crate::isis::vrf`: the default `router ospf` /
+//! `router ospfv3` task acts as a thin parent that forwards each
+//! `/router/ospf{,v3}/vrf/<name>/…` config line — rewritten to strip
+//! the `vrf <name>` prefix (see [`crate::config::vrf_redirect_split`])
+//! — into a full per-VRF [`Ospf`] whose existing callbacks / SPF /
+//! RIB / show paths run unchanged.
+//!
+//! Unlike IS-IS, OSPF is L3 (raw IP protocol 89) and opens its socket
+//! through [`crate::context::ProtoContext`] (`ospf_socket_ipv4/6` →
+//! `ctx.raw_socket`). So a child built with `ProtoContext::for_vrf`
+//! gets `SO_BINDTODEVICE` to the VRF master for free, and its
+//! `RibClient` is subscribed at the VRF's kernel `table_id` — that is
+//! all VRF isolation needs.
+//!
+//! `Ospf<V>` is generic over the version, but `Ospf::<V>::new` is a
+//! concrete (per-version) constructor, so the spawn is dispatched via
+//! [`crate::ospf::version::OspfVersion::spawn_vrf`] into the two
+//! concrete helpers here. A child is spawned only once both config
+//! intent (the parent's `vrf_log`) and the kernel VRF master
+//! (`RibRx::VrfAdd` → `table_id`) exist; the buffered config is
+//! replayed, then a synthetic `CommitEnd` triggers the child's
+//! commit-time reconcile.
+
+use tokio::sync::mpsc::{Sender, UnboundedSender};
+
+use crate::config::{CommandPath, ConfigOp, ConfigRequest, DisplayRequest, Message, RibSubscriber};
+use crate::context::{ProtoContext, Task};
+
+use super::inst::{self, Ospf};
+use super::version::{OspfVersion, Ospfv2, Ospfv3};
+
+/// Handle to one running per-VRF OSPF task, stashed on the parent's
+/// `vrf_registry`. Version-agnostic — only the config inbox and the
+/// task are kept.
+pub struct OspfVrfHandle {
+    /// Config inbox of the child. The parent forwards rewritten
+    /// `/router/ospf{,v3}/…` `ConfigRequest`s here (and the per-commit
+    /// `CommitEnd`).
+    pub cm_tx: UnboundedSender<ConfigRequest>,
+    /// Spawned event loop. Dropping the handle aborts it (the `Task`
+    /// runs its `AbortHandle` on `Drop`), so removing a handle from
+    /// `vrf_registry` tears the child down.
+    #[allow(dead_code)]
+    pub task: Task<()>,
+}
+
+/// True if the buffered config log still has at least one net-effect
+/// `Set` item. The parent uses this at `CommitEnd` to detect a fully
+/// deleted `router ospf{,v3} vrf <name>` block (→ tear the child
+/// down). Set/Delete are folded by a path+values key (joined
+/// `CommandPath` names), so a `Set` later cancelled by a matching
+/// `Delete` drops out.
+pub fn vrf_log_active(log: &[(Vec<CommandPath>, ConfigOp)]) -> bool {
+    let mut active: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for (paths, op) in log {
+        let key = paths
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect::<Vec<_>>()
+            .join("/");
+        match op {
+            ConfigOp::Set => {
+                active.insert(key);
+            }
+            ConfigOp::Delete => {
+                active.remove(&key);
+            }
+            _ => {}
+        }
+    }
+    !active.is_empty()
+}
+
+/// Shared tail of both version spawns: register the child's show
+/// channel (`"<proto>:vrf:<name>"`, matching the manager's
+/// `DisplayTx` key), replay the buffered config in commit order, then
+/// send one synthetic `CommitEnd` so the child reconciles once.
+fn finish_spawn(
+    proto: &str,
+    cm_tx: UnboundedSender<ConfigRequest>,
+    show_tx: UnboundedSender<DisplayRequest>,
+    task: Task<()>,
+    config_tx: &Sender<Message>,
+    buffered: &[(Vec<CommandPath>, ConfigOp)],
+) -> OspfVrfHandle {
+    let _ = config_tx.try_send(Message::SubscribeShowVrf {
+        key: proto.to_string(),
+        tx: show_tx,
+    });
+    for (paths, op) in buffered {
+        let _ = cm_tx.send(ConfigRequest::new(paths.clone(), *op));
+    }
+    let _ = cm_tx.send(ConfigRequest::new(Vec::new(), ConfigOp::CommitEnd));
+    OspfVrfHandle { cm_tx, task }
+}
+
+/// Spawn a per-VRF `Ospf<Ospfv2>` bound to the VRF's kernel `table_id`.
+pub fn spawn_ospf_vrf_v2(
+    name: &str,
+    table_id: u32,
+    rib_subscriber: &RibSubscriber,
+    config_tx: &Sender<Message>,
+    policy_tx: &UnboundedSender<crate::policy::Message>,
+    buffered: &[(Vec<CommandPath>, ConfigOp)],
+) -> OspfVrfHandle {
+    let proto = format!("{}:vrf:{}", Ospfv2::PROTO, name);
+    // Consume (don't leak) `rib_rx` — the child's event loop needs
+    // LinkAdd / AddrAdd to manage its interfaces.
+    let (rib_client, rib_rx) = rib_subscriber.subscribe_for_vrf(&proto, table_id);
+    let ctx = ProtoContext::for_vrf(rib_client, table_id, name.to_string());
+    let ospf = Ospf::<Ospfv2>::new(
+        ctx,
+        rib_rx,
+        policy_tx.clone(),
+        proto.clone(),
+        rib_subscriber.clone(),
+        config_tx.clone(),
+    );
+    let cm_tx = ospf.cm.tx.clone();
+    let show_tx = ospf.show.tx.clone();
+    let task = inst::serve(ospf);
+    tracing::info!(vrf = %name, table_id, "ospf: spawned per-VRF instance");
+    finish_spawn(&proto, cm_tx, show_tx, task, config_tx, buffered)
+}
+
+/// Spawn a per-VRF `Ospf<Ospfv3>` bound to the VRF's kernel `table_id`.
+pub fn spawn_ospf_vrf_v3(
+    name: &str,
+    table_id: u32,
+    rib_subscriber: &RibSubscriber,
+    config_tx: &Sender<Message>,
+    policy_tx: &UnboundedSender<crate::policy::Message>,
+    buffered: &[(Vec<CommandPath>, ConfigOp)],
+) -> OspfVrfHandle {
+    let proto = format!("{}:vrf:{}", Ospfv3::PROTO, name);
+    let (rib_client, rib_rx) = rib_subscriber.subscribe_for_vrf(&proto, table_id);
+    let ctx = ProtoContext::for_vrf(rib_client, table_id, name.to_string());
+    let ospf = Ospf::<Ospfv3>::new(
+        ctx,
+        rib_rx,
+        policy_tx.clone(),
+        proto.clone(),
+        rib_subscriber.clone(),
+        config_tx.clone(),
+    );
+    let cm_tx = ospf.cm.tx.clone();
+    let show_tx = ospf.show.tx.clone();
+    let task = inst::serve_v3(ospf);
+    tracing::info!(vrf = %name, table_id, "ospfv3: spawned per-VRF instance");
+    finish_spawn(&proto, cm_tx, show_tx, task, config_tx, buffered)
+}
+
+/// Tear down a per-VRF instance's manager + RIB registrations.
+/// `proto_base` is `V::PROTO` (`"ospf"` / `"ospfv3"`). The caller
+/// removes the [`OspfVrfHandle`] from `vrf_registry` separately, which
+/// drops the `Task` and aborts the event loop. The VRF's FIB routes
+/// are reclaimed by RIB's own `VrfDel` handling.
+pub fn despawn_ospf_vrf(
+    proto_base: &str,
+    name: &str,
+    config_tx: &Sender<Message>,
+    rib_subscriber: &RibSubscriber,
+) {
+    let proto = format!("{proto_base}:vrf:{name}");
+    let _ = config_tx.try_send(Message::UnsubscribeShowVrf { key: proto.clone() });
+    rib_subscriber.send_proto_cleanup(&proto);
+    tracing::info!(vrf = %name, proto = %proto, "ospf: despawned per-VRF instance");
+}

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -786,6 +786,54 @@ module config {
             }
           }
         }
+
+        list vrf {
+          // Per-VRF OSPFv2 instance. The default `router ospf` task
+          // forwards each `vrf <name> ...` line (with the `vrf <name>`
+          // prefix stripped) to a full per-VRF OSPFv2 instance whose
+          // computed routes install into the VRF's routing table. The
+          // `vrf` key is a plain string (staging-friendly, like
+          // `router static`'s per-VRF list) so the VRF need not yet
+          // exist at the top-level `vrf` list when parsed. Minimal
+          // subset (router-id / area / interface enable) for now;
+          // later work widens it toward parity with the default
+          // instance.
+          key "name";
+          leaf name {
+            type string;
+          }
+          leaf router-id {
+            type inet:ipv4-address;
+          }
+          list area {
+            key "area-id";
+            leaf area-id {
+              type union {
+                type uint32;
+                type inet:ipv4-address;
+              }
+            }
+            list interface {
+              key "if-name";
+              leaf if-name {
+                ext:dynamic "rib:interface";
+                type string;
+              }
+              leaf enable {
+                type boolean;
+              }
+              leaf network-type {
+                type enumeration {
+                  enum broadcast;
+                  enum point-to-point;
+                }
+              }
+              leaf priority {
+                type uint8;
+              }
+            }
+          }
+        }
       }
       container ospfv3 {
         // OSPFv3 (RFC 5340). Shape mirrors `container ospf` so a
@@ -1059,6 +1107,45 @@ module config {
             // the TI-LFA repair so the repair installs first. Protection
             // testing knob; see `router ospf` for the full rationale.
             presence "Install TI-LFA backup as the primary nexthop";
+          }
+        }
+
+        list vrf {
+          // Per-VRF OSPFv3 instance. See `container ospf`'s `vrf`
+          // list for the forwarding model. Minimal subset (area /
+          // interface enable); `router-id` is omitted because the v3
+          // instance has no router-id config handler today.
+          key "name";
+          leaf name {
+            type string;
+          }
+          list area {
+            key "area-id";
+            leaf area-id {
+              type union {
+                type uint32;
+                type inet:ipv4-address;
+              }
+            }
+            list interface {
+              key "if-name";
+              leaf if-name {
+                ext:dynamic "rib:interface";
+                type string;
+              }
+              leaf enable {
+                type boolean;
+              }
+              leaf network-type {
+                type enumeration {
+                  enum broadcast;
+                  enum point-to-point;
+                }
+              }
+              leaf priority {
+                type uint8;
+              }
+            }
           }
         }
       }

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -356,6 +356,45 @@ module exec {
           ext:help "OSPF graceful-restart checkpoint (on-disk state)";
           type empty;
         }
+        list vrf {
+          // Per-VRF OSPFv2 show. `show ip ospf vrf <name> <cmd>` is
+          // redirected by the config manager (it strips the
+          // `vrf <name>` selector via `vrf_redirect_split`) into the
+          // per-VRF task's show channel registered as
+          // `"ospf:vrf:<name>"`. The stripped command renders via the
+          // child's existing handlers; a bare `... vrf <name>` maps to
+          // the summary (`show ip ospf`).
+          ext:help "Per-VRF OSPFv2 instance";
+          ext:presence "Show this VRF's OSPFv2 summary";
+          key name;
+          leaf name {
+            ext:help "VRF name";
+            ext:dynamic "rib:vrf";
+            type string;
+          }
+          leaf interface {
+            ext:help "OSPF interfaces in this VRF";
+            type empty;
+          }
+          container neighbor {
+            ext:help "OSPF neighbors in this VRF";
+            presence "OSPF neighbor";
+            leaf detail {
+              type empty;
+            }
+          }
+          container database {
+            ext:help "OSPF database in this VRF";
+            presence "OSPF database";
+            leaf detail {
+              type empty;
+            }
+          }
+          leaf route {
+            ext:help "OSPF routes in this VRF";
+            type empty;
+          }
+        }
       }
     }
 
@@ -607,6 +646,43 @@ module exec {
         }
         leaf segment-routing {
           type empty;
+        }
+        list vrf {
+          // Per-VRF OSPFv3 show. `show ipv6 ospf vrf <name> <cmd>` is
+          // redirected by the config manager into the per-VRF task's
+          // show channel registered as `"ospfv3:vrf:<name>"`; the
+          // stripped command renders via the child's handlers (a bare
+          // `... vrf <name>` maps to the summary).
+          ext:help "Per-VRF OSPFv3 instance";
+          ext:presence "Show this VRF's OSPFv3 summary";
+          key name;
+          leaf name {
+            ext:help "VRF name";
+            ext:dynamic "rib:vrf";
+            type string;
+          }
+          leaf interface {
+            ext:help "OSPFv3 interfaces in this VRF";
+            type empty;
+          }
+          container neighbor {
+            ext:help "OSPFv3 neighbors in this VRF";
+            presence "OSPFv3 neighbor";
+            leaf detail {
+              type empty;
+            }
+          }
+          container database {
+            ext:help "OSPFv3 database in this VRF";
+            presence "OSPFv3 database";
+            leaf detail {
+              type empty;
+            }
+          }
+          leaf route {
+            ext:help "OSPFv3 routes in this VRF";
+            type empty;
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Makes OSPFv2 and OSPFv3 VRF-ready — a generic-over-`Ospf<V>` port of the IS-IS forward-to-full-instance design (#1110):

```
router ospf   { vrf vrf1 { router-id 10.0.0.1; area 0 { interface eth0 { enable true; } } } }
router ospfv3 { vrf vrf1 { area 0 { interface eth0 { enable true; } } } }
```

The default `router ospf` / `router ospfv3` task acts as a thin **parent**: it strips the `vrf <name>` prefix from `/router/ospf{,v3}/vrf/<name>/…` config and forwards it to a **full per-VRF `Ospf<V>`** whose existing callbacks / SPF / RIB / show paths run unchanged.

Because `Ospf<V>` is generic, the VRF fields + dispatch helpers live once on the generic `impl<V: OspfVersion>` block; per-version spawn dispatches through a new `OspfVersion::spawn_vrf` trait hook (v2→`serve`, v3→`serve_v3`) — so one PR covers both versions.

**Sockets need no change**: OSPF is L3 and `ospf_socket_ipv4/6` already open via `ctx.raw_socket()`, so a child built with `ProtoContext::for_vrf` gets `SO_BINDTODEVICE` to the VRF master automatically. VRF isolation = that bind + the per-VRF `RibClient` subscribed at the kernel `table_id`. Spawn is deferred until `RibRx::VrfAdd` delivers the `table_id`; config arriving first is buffered and replayed.

Reuses the IS-IS infra already merged in main (`RibSubscriber::send_proto_cleanup`, the `proto_cleanup` registry gate, the `CommandPath` / `vrf_redirect_split` re-exports), so there are **no RIB or config-core edits** here.

First-slice scope: YANG `list vrf` carries router-id (v2 only — v3 has no router-id handler) + area / interface enable; later PRs widen it (timers, area-type, redistribute, SR, GR, flex-algo) by adding leaves.

## Changes
- `ospf/vrf.rs` *(new)* — `OspfVrfHandle`, `spawn_ospf_vrf_v2/v3`, `despawn_ospf_vrf`, `vrf_log_active`
- `ospf/inst.rs` — `Ospf<V>` VRF state; both `new()` (+`proto_label`/`rib_subscriber`/`config_tx`; v2 checkpoint-load gated to the default instance); generic `vrf_config_record`/`vrf_commit_end`/`vrf_add`/`vrf_del`; v2+v3 `process_cm_msg` interception + `process_rib_msg` VrfAdd/VrfDel
- `ospf/version.rs` — `PROTO` const + `spawn_vrf` trait method (v2/v3 impls)
- `ospf/mod.rs`, `config/ospf.rs` — module wiring + spawn args
- `yang/config.yang` — `list vrf` under `container ospf` and `container ospfv3`
- `yang/exec.yang` — `show ip ospf vrf <name>` / `show ipv6 ospf vrf <name>` selectors

## Test plan
- `cargo fmt`, `cargo build -p zebra-rs` — clean, no warnings
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (re-run after touching changed files)
- `cargo test -p zebra-rs` — 785 passed, 0 failed, incl. `yang_load_tests` validating both YANG edits
- Live two-node / FRR validation (adjacency Up, `ip route show vrf vrf1`) — follow-up

Generated with [Claude Code](https://claude.com/claude-code)