### PR TITLE
yang: dynamic VRF-name completion for router isis/ospf/bgp vrf

### DIFF
--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -801,6 +801,7 @@ module config {
           // per-VRF surface widens.
           key "name";
           leaf name {
+            ext:dynamic "rib:vrf";
             type string;
           }
           leaf router-id {
@@ -1154,6 +1155,7 @@ module config {
           // today (so a forwarded line would be a no-op).
           key "name";
           leaf name {
+            ext:dynamic "rib:vrf";
             type string;
           }
           list area {
@@ -1979,6 +1981,7 @@ module config {
           // widens toward full parity with the default instance.
           key "name";
           leaf name {
+            ext:dynamic "rib:vrf";
             type string;
           }
           leaf net {

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -20,6 +20,10 @@ module zebra-bgp-vrf {
     prefix configure;
   }
 
+  import extension {
+    prefix ext;
+  }
+
   organization
     "zebra-rs";
 
@@ -223,6 +227,7 @@ module zebra-bgp-vrf {
          config is parsed — same staging pattern as IS-IS uses for
          `block` and `locator`.";
       leaf name {
+        ext:dynamic "rib:vrf";
         type string;
         description
           "Name of the VRF this BGP block applies to.";


### PR DESCRIPTION
## Summary

Add `ext:dynamic "rib:vrf"` to the per-VRF `name` leaf of `router ospf`, `router ospfv3`, `router isis`, and `router bgp`. The CLI now suggests existing VRF names on completion for these config commands, matching the behavior already present on the `show ... vrf` commands and the interface `vrf` binding.

The `rib:vrf` dynamic resolver (`comps_dynamic` → RIB `vrf_comps()`) was already wired up, so no Rust changes are required — this is purely a YANG schema annotation.

`zebra-bgp-vrf.yang` did not previously reference the `ext` prefix, so this also adds `import extension { prefix ext; }` to that module.

## Changes

| Command | File |
|---|---|
| `router ospf { vrf <TAB> }` | `config.yang` |
| `router ospfv3 { vrf <TAB> }` | `config.yang` |
| `router isis { vrf <TAB> }` | `config.yang` |
| `router bgp { vrf <TAB> }` | `zebra-bgp-vrf.yang` |

## Test plan

- `cargo test -p zebra-rs yang_load_tests` passes (both `configure_mode_loads` and `exec_mode_loads`) — this is the guard that actually validates the YANG, since cargo/clippy don't.

Generated with [Claude Code](https://claude.com/claude-code)