### PR TITLE
bfd: show commands for session status

### DIFF
--- a/zebra-rs/src/bfd/inst.rs
+++ b/zebra-rs/src/bfd/inst.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
-use crate::config::{ConfigChannel, ConfigRequest, path_from_command};
+use crate::config::{
+    Args, ConfigChannel, ConfigRequest, DisplayRequest, ShowChannel, path_from_command,
+};
 use crate::context::{ProtoContext, Task};
 
 use super::config::{BfdConfig, Callback};
@@ -20,6 +22,11 @@ use super::timer::{InitialParams, TimerCmd, session_timer};
 /// when one process registers more than one logical client per
 /// session (rare).
 pub type ClientId = String;
+
+/// `show <path>` dispatch handler. Mirrors [`crate::ospf::ShowCallback`]
+/// and [`crate::isis`]'s equivalent: given the BFD instance, the parsed
+/// trailing [`Args`], and the JSON flag, render the response text.
+pub type ShowCallback = fn(&Bfd, Args, bool) -> Result<String, std::fmt::Error>;
 
 /// Top-level BFD instance. Owns the IPv4 single-hop UDP socket, the
 /// session table, the committed YANG config mirror, a per-session
@@ -45,6 +52,12 @@ pub struct Bfd {
     /// Config-manager subscription endpoints (the receive half drains
     /// in the event loop).
     pub cm: ConfigChannel,
+    /// `show bfd ...` subscription endpoints. The receive half drains
+    /// in the event loop and dispatches through [`Self::show_cb`].
+    pub show: ShowChannel,
+    /// Show callback table — path → handler — populated by
+    /// [`Bfd::show_build`] and consulted by [`Self::process_show_msg`].
+    pub show_cb: HashMap<String, ShowCallback>,
     /// Inbound client request channel — protocol modules send
     /// `ClientReq::Subscribe` / `Unsubscribe` here to attach to BFD
     /// sessions. Clones of the sender half are distributed via
@@ -180,6 +193,8 @@ impl Bfd {
             config: BfdConfig::default(),
             callbacks: HashMap::new(),
             cm: ConfigChannel::new(),
+            show: ShowChannel::new(),
+            show_cb: HashMap::new(),
             client_req: ClientReqChannel::new(),
             subscribers: HashMap::new(),
             main_tx,
@@ -187,6 +202,7 @@ impl Bfd {
             timer_handles: HashMap::new(),
         };
         bfd.callback_build();
+        bfd.show_build();
         Ok(bfd)
     }
 
@@ -312,6 +328,19 @@ impl Bfd {
         self.sessions.remove(key)
     }
 
+    /// Look up the show handler for `msg.paths` and invoke it. Mirrors
+    /// [`crate::ospf`]/[`crate::isis`]'s `process_show_msg`.
+    async fn process_show_msg(&self, msg: DisplayRequest) {
+        let (path, args) = path_from_command(&msg.paths);
+        if let Some(f) = self.show_cb.get(&path) {
+            let output = match f(self, args, msg.json) {
+                Ok(result) => result,
+                Err(e) => format!("Error formatting output: {}", e),
+            };
+            let _ = msg.resp.send(output).await;
+        }
+    }
+
     pub async fn event_loop(&mut self) {
         loop {
             tokio::select! {
@@ -323,6 +352,9 @@ impl Bfd {
                 },
                 Some(msg) = self.cm.rx.recv() => {
                     self.process_cm_msg(msg);
+                }
+                Some(msg) = self.show.rx.recv() => {
+                    self.process_show_msg(msg).await;
                 }
                 Some(req) = self.client_req.rx.recv() => {
                     self.process_client_req(req);

--- a/zebra-rs/src/bfd/mod.rs
+++ b/zebra-rs/src/bfd/mod.rs
@@ -1,11 +1,11 @@
 // Several surfaces remain unexercised by production until later
 // PRs: the admin-shutdown FSM events (`AdminDown` / `AdminUp` —
 // pending a "shutdown" config callback path), `TimerCmd::ResetDetect`
-// (currently subsumed by `Update`), the `Stats` counters and
-// `local_addr` (pending show-command wiring), and a handful of
-// SessionTable helpers used only by tests. One module-wide allow is
-// cleaner than peppering individual files; the lint returns
-// naturally as those production callers land.
+// (currently subsumed by `Update`), `local_addr` (used only by tests
+// that bind ephemeral ports), and a handful of SessionTable helpers
+// used only by tests. (`Stats` is now read by `show bfd counters`.)
+// One module-wide allow is cleaner than peppering individual files;
+// the lint returns naturally as those production callers land.
 #![allow(dead_code)]
 
 pub mod config;
@@ -13,6 +13,7 @@ pub mod fsm;
 pub mod inst;
 pub mod network;
 pub mod session;
+pub mod show;
 pub mod socket;
 pub mod timer;
 

--- a/zebra-rs/src/bfd/show.rs
+++ b/zebra-rs/src/bfd/show.rs
@@ -1,0 +1,575 @@
+//! `show bfd ...` command handlers.
+//!
+//! Mirrors the show-command pattern used by [`crate::ospf::show`] and
+//! [`crate::isis::show`]: [`Bfd::show_build`] registers a handler per
+//! path, the event loop dispatches through [`super::inst::Bfd`]'s
+//! `process_show_msg`, and each handler renders read-only state from
+//! the live [`super::session::SessionTable`].
+//!
+//! Three commands are exposed:
+//!   * `show bfd`              — one-line-per-session summary table.
+//!   * `show bfd peer [<addr>]`— FRR-style detailed block(s), all peers
+//!     or one when an address follows.
+//!   * `show bfd counters`     — per-session control-packet counters.
+//!
+//! Every command also accepts a trailing `json` keyword (surfaced as
+//! the `json` flag) for machine-readable output.
+
+use std::fmt::{self, Write};
+use std::time::{Duration, Instant};
+
+use bfd_packet::{Diag, State};
+use serde::Serialize;
+
+use crate::config::Args;
+
+use super::inst::{Bfd, ShowCallback};
+use super::session::{Session, SessionKey};
+
+impl Bfd {
+    fn show_add(&mut self, path: &str, cb: ShowCallback) {
+        self.show_cb.insert(path.to_string(), cb);
+    }
+
+    pub fn show_build(&mut self) {
+        self.show_add("/show/bfd", show_bfd);
+        self.show_add("/show/bfd/peer", show_bfd_peer);
+        self.show_add("/show/bfd/counters", show_bfd_counters);
+    }
+}
+
+// -----------------------------------------------------------------------
+// Formatting helpers
+// -----------------------------------------------------------------------
+
+/// Human label for a session's attachment: `multihop`, `ifN`, or `-`.
+fn iface_str(key: &SessionKey) -> String {
+    if key.multihop {
+        "multihop".to_string()
+    } else if key.ifindex == 0 {
+        "-".to_string()
+    } else {
+        format!("if{}", key.ifindex)
+    }
+}
+
+/// Microseconds → FRR-style `Nms`. BFD intervals originate as
+/// millisecond config values (stored ×1000), so this division is exact
+/// in practice.
+fn ms(us: u32) -> String {
+    format!("{}ms", us / 1000)
+}
+
+/// Seconds elapsed since `t`, or `None` if the timestamp is unset.
+fn elapsed_secs(t: Option<Instant>) -> Option<u64> {
+    t.map(|i| i.elapsed().as_secs())
+}
+
+/// `HH:MM:SS` (or `NdHHhMMm` past a day) for the brief table.
+fn format_uptime(d: Duration) -> String {
+    let secs = d.as_secs();
+    let days = secs / 86400;
+    let h = (secs % 86400) / 3600;
+    let m = (secs % 3600) / 60;
+    let s = secs % 60;
+    if days > 0 {
+        format!("{}d{:02}h{:02}m", days, h, m)
+    } else {
+        format!("{:02}:{:02}:{:02}", h, m, s)
+    }
+}
+
+/// Uptime (seconds) only while the session is Up; `None` otherwise so
+/// the brief table renders `-` for non-Up sessions.
+fn uptime_secs(s: &Session) -> Option<u64> {
+    if s.local_state == State::Up {
+        elapsed_secs(s.last_up)
+    } else {
+        None
+    }
+}
+
+/// FRR renders a clean session as `ok`; everything else by name.
+fn diag_str(d: Diag) -> String {
+    match d {
+        Diag::None => "ok".to_string(),
+        other => other.to_string(),
+    }
+}
+
+// -----------------------------------------------------------------------
+// show bfd  (summary)
+// -----------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct BfdPeerBriefJson {
+    peer: String,
+    local: String,
+    interface: String,
+    multihop: bool,
+    local_state: String,
+    remote_state: String,
+    local_discr: u32,
+    remote_discr: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    uptime_secs: Option<u64>,
+}
+
+fn brief_json(key: &SessionKey, s: &Session) -> BfdPeerBriefJson {
+    BfdPeerBriefJson {
+        peer: key.remote.to_string(),
+        local: key.local.to_string(),
+        interface: iface_str(key),
+        multihop: key.multihop,
+        local_state: s.local_state.to_string(),
+        remote_state: s.remote_state.to_string(),
+        local_discr: s.local_disc,
+        remote_discr: s.remote_disc,
+        uptime_secs: uptime_secs(s),
+    }
+}
+
+fn show_bfd(bfd: &Bfd, _args: Args, json: bool) -> Result<String, fmt::Error> {
+    if json {
+        let list: Vec<BfdPeerBriefJson> =
+            bfd.sessions.iter().map(|(k, s)| brief_json(k, s)).collect();
+        return Ok(serde_json::to_string_pretty(&list)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e)));
+    }
+
+    let mut buf = String::new();
+    if bfd.sessions.is_empty() {
+        writeln!(buf, "No BFD sessions")?;
+        return Ok(buf);
+    }
+
+    writeln!(
+        buf,
+        "{:<16} {:<8} {:<22} {:<10} Iface",
+        "Peer", "State", "Local/Remote Disc", "Uptime"
+    )?;
+    for (key, s) in bfd.sessions.iter() {
+        let disc = format!("0x{:x}/0x{:x}", s.local_disc, s.remote_disc);
+        let uptime = uptime_secs(s)
+            .map(|secs| format_uptime(Duration::from_secs(secs)))
+            .unwrap_or_else(|| "-".to_string());
+        writeln!(
+            buf,
+            "{:<16} {:<8} {:<22} {:<10} {}",
+            key.remote.to_string(),
+            s.local_state.to_string(),
+            disc,
+            uptime,
+            iface_str(key),
+        )?;
+    }
+    Ok(buf)
+}
+
+// -----------------------------------------------------------------------
+// show bfd peer [<addr>]  (detail, FRR-style)
+// -----------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct BfdPeerDetailJson {
+    peer: String,
+    local: String,
+    interface: String,
+    multihop: bool,
+    local_discr: u32,
+    remote_discr: u32,
+    local_state: String,
+    remote_state: String,
+    diagnostic: String,
+    remote_diagnostic: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    uptime_secs: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    downtime_secs: Option<u64>,
+    detect_multiplier: u8,
+    receive_interval_us: u32,
+    transmit_interval_us: u32,
+    negotiated_transmit_interval_us: u32,
+    detection_time_us: u32,
+    remote_detect_multiplier: u8,
+    remote_receive_interval_us: u32,
+    remote_transmit_interval_us: u32,
+    demand: bool,
+    remote_demand: bool,
+    rx_count: u64,
+    rx_invalid_count: u64,
+    tx_count: u64,
+    tx_failed_count: u64,
+}
+
+fn detail_json(key: &SessionKey, s: &Session) -> BfdPeerDetailJson {
+    BfdPeerDetailJson {
+        peer: key.remote.to_string(),
+        local: key.local.to_string(),
+        interface: iface_str(key),
+        multihop: key.multihop,
+        local_discr: s.local_disc,
+        remote_discr: s.remote_disc,
+        local_state: s.local_state.to_string(),
+        remote_state: s.remote_state.to_string(),
+        diagnostic: diag_str(s.local_diag),
+        remote_diagnostic: diag_str(s.remote_diag),
+        uptime_secs: (s.local_state == State::Up)
+            .then(|| elapsed_secs(s.last_up))
+            .flatten(),
+        downtime_secs: (s.local_state != State::Up)
+            .then(|| elapsed_secs(s.last_down))
+            .flatten(),
+        detect_multiplier: s.detect_mult,
+        receive_interval_us: s.required_min_rx_us,
+        transmit_interval_us: s.desired_min_tx_us,
+        negotiated_transmit_interval_us: s.tx_interval_us(),
+        detection_time_us: s.detection_time_us(),
+        remote_detect_multiplier: s.remote_detect_mult,
+        remote_receive_interval_us: s.remote_min_rx_us,
+        remote_transmit_interval_us: s.remote_min_tx_us,
+        demand: s.demand,
+        remote_demand: s.remote_demand,
+        rx_count: s.stats.rx_count,
+        rx_invalid_count: s.stats.rx_invalid_count,
+        tx_count: s.stats.tx_count,
+        tx_failed_count: s.stats.tx_failed_count,
+    }
+}
+
+/// One FRR-style indented block per session.
+fn render_detail(buf: &mut String, key: &SessionKey, s: &Session) -> fmt::Result {
+    let hop = if key.multihop {
+        "multihop"
+    } else {
+        "single-hop"
+    };
+    writeln!(buf, "    peer {} ({})", key.remote, hop)?;
+    writeln!(buf, "        ID: {}", s.local_disc)?;
+    writeln!(buf, "        Remote ID: {}", s.remote_disc)?;
+    writeln!(buf, "        Local address: {}", key.local)?;
+    writeln!(buf, "        Interface: {}", iface_str(key))?;
+    writeln!(
+        buf,
+        "        Status: {}",
+        s.local_state.to_string().to_lowercase()
+    )?;
+    // Up sessions report uptime; everything else reports time since the
+    // last down transition (omitted entirely if it never came up/down).
+    if s.local_state == State::Up {
+        if let Some(secs) = elapsed_secs(s.last_up) {
+            writeln!(buf, "        Uptime: {} second(s)", secs)?;
+        }
+    } else if let Some(secs) = elapsed_secs(s.last_down) {
+        writeln!(buf, "        Downtime: {} second(s)", secs)?;
+    }
+    writeln!(buf, "        Diagnostics: {}", diag_str(s.local_diag))?;
+    writeln!(
+        buf,
+        "        Remote diagnostics: {}",
+        diag_str(s.remote_diag)
+    )?;
+    writeln!(buf, "        Remote state: {}", s.remote_state)?;
+
+    writeln!(buf, "        Local timers:")?;
+    writeln!(buf, "            Detect-multiplier: {}", s.detect_mult)?;
+    writeln!(
+        buf,
+        "            Receive interval: {}",
+        ms(s.required_min_rx_us)
+    )?;
+    writeln!(
+        buf,
+        "            Transmission interval: {}",
+        ms(s.desired_min_tx_us)
+    )?;
+    let nego_tx = s.tx_interval_us();
+    let nego_tx = if nego_tx == 0 {
+        "suspended (peer Required Min RX = 0)".to_string()
+    } else {
+        ms(nego_tx)
+    };
+    writeln!(
+        buf,
+        "            Transmission interval (negotiated): {}",
+        nego_tx
+    )?;
+    let detect = s.detection_time_us();
+    let detect = if detect == 0 {
+        "inactive (no packet received yet)".to_string()
+    } else {
+        ms(detect)
+    };
+    writeln!(buf, "            Detection timeout: {}", detect)?;
+
+    writeln!(buf, "        Remote timers:")?;
+    writeln!(
+        buf,
+        "            Detect-multiplier: {}",
+        s.remote_detect_mult
+    )?;
+    writeln!(
+        buf,
+        "            Receive interval: {}",
+        ms(s.remote_min_rx_us)
+    )?;
+    writeln!(
+        buf,
+        "            Transmission interval: {}",
+        ms(s.remote_min_tx_us)
+    )?;
+    Ok(())
+}
+
+fn show_bfd_peer(bfd: &Bfd, mut args: Args, json: bool) -> Result<String, fmt::Error> {
+    // Optional trailing peer address narrows the output to one session.
+    let filter = args.addr();
+
+    if json {
+        let list: Vec<BfdPeerDetailJson> = bfd
+            .sessions
+            .iter()
+            .filter(|(k, _)| filter.is_none_or(|f| k.remote == f))
+            .map(|(k, s)| detail_json(k, s))
+            .collect();
+        return Ok(serde_json::to_string_pretty(&list)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e)));
+    }
+
+    let mut buf = String::new();
+    let mut found = false;
+    writeln!(buf, "BFD Peers:")?;
+    for (key, s) in bfd.sessions.iter() {
+        if filter.is_some_and(|f| key.remote != f) {
+            continue;
+        }
+        found = true;
+        render_detail(&mut buf, key, s)?;
+    }
+    if !found {
+        match filter {
+            Some(f) => writeln!(buf, "    No BFD session for peer {}", f)?,
+            None => writeln!(buf, "    No BFD sessions")?,
+        }
+    }
+    Ok(buf)
+}
+
+// -----------------------------------------------------------------------
+// show bfd counters
+// -----------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct BfdCountersJson {
+    peer: String,
+    rx_count: u64,
+    rx_invalid_count: u64,
+    tx_count: u64,
+    tx_failed_count: u64,
+}
+
+fn show_bfd_counters(bfd: &Bfd, _args: Args, json: bool) -> Result<String, fmt::Error> {
+    if json {
+        let list: Vec<BfdCountersJson> = bfd
+            .sessions
+            .iter()
+            .map(|(k, s)| BfdCountersJson {
+                peer: k.remote.to_string(),
+                rx_count: s.stats.rx_count,
+                rx_invalid_count: s.stats.rx_invalid_count,
+                tx_count: s.stats.tx_count,
+                tx_failed_count: s.stats.tx_failed_count,
+            })
+            .collect();
+        return Ok(serde_json::to_string_pretty(&list)
+            .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e)));
+    }
+
+    let mut buf = String::new();
+    if bfd.sessions.is_empty() {
+        writeln!(buf, "No BFD sessions")?;
+        return Ok(buf);
+    }
+
+    writeln!(
+        buf,
+        "{:<24} {:>12} {:>12} {:>12} {:>12}",
+        "Peer", "RX", "RX-Invalid", "TX", "TX-Failed"
+    )?;
+    for (key, s) in bfd.sessions.iter() {
+        writeln!(
+            buf,
+            "{:<24} {:>12} {:>12} {:>12} {:>12}",
+            key.remote.to_string(),
+            s.stats.rx_count,
+            s.stats.rx_invalid_count,
+            s.stats.tx_count,
+            s.stats.tx_failed_count,
+        )?;
+    }
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
+
+    use bfd_packet::{ControlPacket, State};
+
+    use super::*;
+    use crate::bfd::inst::Bfd;
+    use crate::bfd::session::SessionParams;
+    use crate::context::ProtoContext;
+
+    fn fresh_bfd() -> Bfd {
+        Bfd::new_with(
+            ProtoContext::default_table_no_rib(),
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0),
+        )
+        .expect("bind loopback")
+    }
+
+    fn key(remote: u8) -> SessionKey {
+        SessionKey {
+            local: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+            remote: IpAddr::V4(Ipv4Addr::new(10, 0, 0, remote)),
+            ifindex: 3,
+            multihop: false,
+        }
+    }
+
+    fn no_args() -> Args {
+        Args(VecDeque::new())
+    }
+
+    fn addr_args(s: &str) -> Args {
+        Args(VecDeque::from([s.to_string()]))
+    }
+
+    /// Drive the session at `k` to Up by feeding the peer's Down then
+    /// Init control packets (Down+RxDown→Init, Init+RxInit→Up; mirrors
+    /// the session.rs FSM tests). Leaves realistic remote-reported
+    /// timers behind so the detail/negotiation formulas have inputs.
+    fn bring_up(bfd: &mut Bfd, k: &SessionKey) {
+        let s = bfd.sessions.get_by_key_mut(k).unwrap();
+        let disc = s.local_disc;
+        let mk = |state| ControlPacket {
+            state,
+            my_disc: 0x2222,
+            your_disc: disc,
+            detect_mult: 3,
+            desired_min_tx_interval: 1_000_000,
+            required_min_rx_interval: 1_000_000,
+            ..ControlPacket::default()
+        };
+        let _ = s.handle_packet(&mk(State::Down));
+        let _ = s.handle_packet(&mk(State::Init));
+        assert_eq!(s.local_state, State::Up);
+    }
+
+    #[tokio::test]
+    async fn empty_table_renders_placeholder() {
+        let bfd = fresh_bfd();
+        assert!(
+            show_bfd(&bfd, no_args(), false)
+                .unwrap()
+                .contains("No BFD sessions")
+        );
+        assert!(
+            show_bfd_counters(&bfd, no_args(), false)
+                .unwrap()
+                .contains("No BFD sessions")
+        );
+        // `show bfd peer` always prints the header, then a no-sessions line.
+        let peer = show_bfd_peer(&bfd, no_args(), false).unwrap();
+        assert!(peer.contains("BFD Peers:"));
+        assert!(peer.contains("No BFD sessions"));
+    }
+
+    #[tokio::test]
+    async fn brief_lists_up_session() {
+        let mut bfd = fresh_bfd();
+        let k = key(2);
+        bfd.add_session(k, SessionParams::default());
+        bring_up(&mut bfd, &k);
+
+        let out = show_bfd(&bfd, no_args(), false).unwrap();
+        assert!(out.contains("Peer"), "header present");
+        assert!(out.contains("10.0.0.2"), "peer address");
+        assert!(out.contains("Up"), "state");
+        assert!(out.contains("if3"), "interface label");
+    }
+
+    #[tokio::test]
+    async fn peer_detail_is_frr_style() {
+        let mut bfd = fresh_bfd();
+        let k = key(2);
+        bfd.add_session(k, SessionParams::default());
+        bring_up(&mut bfd, &k);
+
+        let out = show_bfd_peer(&bfd, no_args(), false).unwrap();
+        assert!(out.contains("BFD Peers:"));
+        assert!(out.contains("peer 10.0.0.2 (single-hop)"));
+        assert!(out.contains("Status: up"));
+        assert!(out.contains("Diagnostics: ok"));
+        assert!(out.contains("Local timers:"));
+        assert!(out.contains("Remote timers:"));
+        assert!(out.contains("Detect-multiplier: 3"));
+        // Negotiated values: max(desired-tx, remote-min-rx) = 1000ms,
+        // detection = remote-mult * max(req-rx, remote-tx) = 3000ms.
+        assert!(out.contains("Transmission interval (negotiated): 1000ms"));
+        assert!(out.contains("Detection timeout: 3000ms"));
+    }
+
+    #[tokio::test]
+    async fn peer_filter_selects_one() {
+        let mut bfd = fresh_bfd();
+        bfd.add_session(key(2), SessionParams::default());
+        bfd.add_session(key(3), SessionParams::default());
+
+        let out = show_bfd_peer(&bfd, addr_args("10.0.0.2"), false).unwrap();
+        assert!(out.contains("peer 10.0.0.2"));
+        assert!(!out.contains("peer 10.0.0.3"));
+    }
+
+    #[tokio::test]
+    async fn peer_filter_miss_reports_no_session() {
+        let mut bfd = fresh_bfd();
+        bfd.add_session(key(2), SessionParams::default());
+
+        let out = show_bfd_peer(&bfd, addr_args("10.0.0.9"), false).unwrap();
+        assert!(out.contains("No BFD session for peer 10.0.0.9"));
+    }
+
+    #[tokio::test]
+    async fn brief_json_is_well_formed() {
+        let mut bfd = fresh_bfd();
+        let k = key(2);
+        bfd.add_session(k, SessionParams::default());
+        bring_up(&mut bfd, &k);
+
+        let out = show_bfd(&bfd, no_args(), true).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).expect("valid json");
+        assert!(v.is_array());
+        assert_eq!(v[0]["peer"], "10.0.0.2");
+        assert_eq!(v[0]["local_state"], "Up");
+        assert_eq!(v[0]["multihop"], false);
+    }
+
+    #[tokio::test]
+    async fn counters_reflect_received_packets() {
+        let mut bfd = fresh_bfd();
+        let k = key(2);
+        bfd.add_session(k, SessionParams::default());
+        bring_up(&mut bfd, &k); // two valid control packets handled
+
+        let out = show_bfd_counters(&bfd, no_args(), false).unwrap();
+        assert!(out.contains("RX-Invalid"));
+        assert!(out.contains("10.0.0.2"));
+
+        let v: serde_json::Value =
+            serde_json::from_str(&show_bfd_counters(&bfd, no_args(), true).unwrap()).unwrap();
+        assert_eq!(v[0]["rx_count"], 2);
+    }
+}

--- a/zebra-rs/src/config/bfd.rs
+++ b/zebra-rs/src/config/bfd.rs
@@ -17,6 +17,7 @@ pub fn spawn_bfd(config: &ConfigManager) {
     match inst::Bfd::new(ProtoContext::default_table_no_rib()) {
         Ok(bfd) => {
             config.subscribe("bfd", bfd.cm.tx.clone());
+            config.subscribe_show("bfd", bfd.show.tx.clone());
             // Publish the inbound client-request handle on the
             // ConfigManager so protocol modules (BGP / OSPF / IS-IS /
             // static) can pick it up at *their* spawn time and later

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -937,6 +937,8 @@ impl ConfigManager {
                                 "OSPF"
                             } else if is_bgp(&paths) {
                                 "BGP"
+                            } else if is_bfd(&paths) {
+                                "BFD"
                             } else if is_policy(&paths) {
                                 "Policy"
                             } else {
@@ -1079,6 +1081,10 @@ fn is_isis(paths: &[CommandPath]) -> bool {
     paths.iter().any(|x| x.name == "isis")
 }
 
+fn is_bfd(paths: &[CommandPath]) -> bool {
+    paths.iter().any(|x| x.name == "bfd")
+}
+
 fn is_policy(paths: &[CommandPath]) -> bool {
     paths
         .iter()
@@ -1098,6 +1104,8 @@ fn show_proto(paths: &[CommandPath]) -> &'static str {
         "ospf"
     } else if is_isis(paths) {
         "isis"
+    } else if is_bfd(paths) {
+        "bfd"
     } else if is_policy(paths) {
         "policy"
     } else {

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -142,6 +142,23 @@ module exec {
         }
       }
     }
+    container bfd {
+      ext:help "BFD (Bidirectional Forwarding Detection) information";
+      presence "Show BFD session summary";
+      list peer {
+        ext:help "BFD peer (session) detail";
+        ext:presence "Show every peer in detail, or one peer when an address follows";
+        key address;
+        leaf address {
+          ext:help "Peer IP address (IPv4 or IPv6)";
+          type inet:ip-address;
+        }
+      }
+      leaf counters {
+        ext:help "Per-session control-packet counters";
+        type empty;
+      }
+    }
     container bgp {
       ext:help "BGP information";
       list update-group {


### PR DESCRIPTION
## Summary

BFD already maintained full session state (FSM, discriminators, negotiated timers, counters, timestamps) but had **no display path** — unlike OSPF/IS-IS/BGP it never registered a show channel. This wires BFD into the show-command infrastructure and adds the commands.

Three commands, each with a `json` variant:

| Command | Output |
|---|---|
| `show bfd` | one-line-per-session brief table |
| `show bfd peer` | FRR-style detail block for every session |
| `show bfd peer <addr>` | detail block for one peer |
| `show bfd counters` | per-session control-packet counters |

The detail block mirrors FRR (`ID` / `Remote ID`, `Status`, `Diagnostics`, `Local`/`Remote timers`); the command tree follows zebra-rs conventions (`peer` singular + optional address rather than FRR's `peers`/`peers brief`). Handlers render read-only state from the live `SessionTable`.

### Changes
- `bfd/show.rs` (new) — handlers, JSON structs, 7 unit tests
- `bfd/inst.rs` — `ShowChannel` / `show_cb` fields, `ShowCallback` type, `process_show_msg`, event-loop arm, `show_build()`
- `bfd/mod.rs` — `pub mod show;`
- `config/bfd.rs` — `subscribe_show("bfd", …)`
- `config/manager.rs` — `is_bfd()` + `show_proto`/fallback-name routing
- `yang/exec.yang` — `container bfd { list peer; leaf counters; }`

### Notes
- Sessions today come from BGP/IS-IS BFD subscriptions; standalone `bfd { peer … }` → session creation on `CommitEnd` remains a separate future step. `show bfd` reflects the live, client-driven sessions.
- Interface renders as `ifN` (ifindex); BFD holds no RIB link table for name resolution.

## Test plan
- `cargo build -p zebra-rs` — clean
- `cargo fmt` — clean
- `cargo clippy --workspace --all-targets` — clean
- `cargo test -p zebra-rs bfd` — 53 pass (incl. 7 new show tests)
- `cargo test -p zebra-rs yang_load` — `exec_mode_loads` passes (validates the new YANG container)

Generated with [Claude Code](https://claude.com/claude-code)