### PR TITLE
isis: originate RFC 8570 TE metric sub-TLVs from per-interface config

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -325,6 +325,26 @@ impl Isis {
         self.callback_add("/router/isis/interface/srlg", link::config_srlg);
         self.callback_add("/router/isis/interface/affinity", link::config_affinity);
         self.callback_add(
+            "/router/isis/interface/te-metric/unidirectional-delay",
+            link::config_te_unidirectional_delay,
+        );
+        self.callback_add(
+            "/router/isis/interface/te-metric/min-delay",
+            link::config_te_min_delay,
+        );
+        self.callback_add(
+            "/router/isis/interface/te-metric/max-delay",
+            link::config_te_max_delay,
+        );
+        self.callback_add(
+            "/router/isis/interface/te-metric/delay-variation",
+            link::config_te_delay_variation,
+        );
+        self.callback_add(
+            "/router/isis/interface/te-metric/loss",
+            link::config_te_loss,
+        );
+        self.callback_add(
             "/router/isis/interface/ipv4/flex-algo-prefix-sid",
             link::config_ipv4_flex_algo_prefix_sid,
         );

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -5,6 +5,7 @@ use std::fmt::Write;
 use std::sync::Arc;
 
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
+use isis_packet::neigh::IsisSubTlv as NeighSubTlv;
 use isis_packet::*;
 use netlink_packet_route::link::LinkFlags;
 use serde::Serialize;
@@ -272,6 +273,14 @@ pub struct LinkConfig {
     /// `srlg_groups`.
     pub affinity: BTreeSet<String>,
 
+    /// Statically configured RFC 8570 TE link metrics (unidirectional
+    /// delay, min/max delay, delay variation, link loss) for this link,
+    /// from /router/isis/interface/<name>/te-metric. Emitted as
+    /// sub-TLVs on the link's Extended IS Reachability entry. A future
+    /// performance-measurement (TWAMP/STAMP) task will populate the
+    /// same fields dynamically.
+    pub te_metric: LinkTeMetric,
+
     /// Per-Flex-Algorithm Prefix-SID for this link's IPv4 address(es).
     /// Populated from
     /// /router/isis/interface/<name>/ipv4/flex-algo-prefix-sid[algo=N].
@@ -296,6 +305,58 @@ pub struct LinkConfig {
 pub struct LinkBfdConfig {
     pub enable: bool,
     pub profile: Option<String>,
+}
+
+/// IS-IS-side mirror of the YANG `te-metric { ... }` container — the
+/// per-interface RFC 8570 traffic-engineering link metrics. Each field
+/// is `None` until configured (or, in a later phase, measured). Delay
+/// values are in microseconds; `loss` is the 24-bit value encoded per
+/// RFC 8570 §4.4 (units of 0.000003 %).
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct LinkTeMetric {
+    pub unidirectional_delay: Option<u32>,
+    pub min_delay: Option<u32>,
+    pub max_delay: Option<u32>,
+    pub delay_variation: Option<u32>,
+    pub loss: Option<u32>,
+}
+
+impl LinkTeMetric {
+    /// RFC 8570 sub-TLVs for this link's Extended IS Reachability entry
+    /// (TLV 22, and MT IS Reach TLV 222 when multi-topology is on), in
+    /// ascending sub-TLV-code order (33, 34, 35, 36). Statically
+    /// configured values carry a clear Anomalous flag — the dynamic
+    /// measurement task will raise it on threshold crossing in a later
+    /// phase. Min/Max delay (sub-TLV 34) is emitted only when both
+    /// bounds are configured.
+    pub fn sub_tlvs(&self) -> Vec<NeighSubTlv> {
+        let mut subs = Vec::new();
+        if let Some(delay) = self.unidirectional_delay {
+            subs.push(NeighSubTlv::UniLinkDelay(IsisSubUniLinkDelay {
+                anomalous: false,
+                delay,
+            }));
+        }
+        if let (Some(min_delay), Some(max_delay)) = (self.min_delay, self.max_delay) {
+            subs.push(NeighSubTlv::MinMaxLinkDelay(IsisSubMinMaxLinkDelay {
+                anomalous: false,
+                min_delay,
+                max_delay,
+            }));
+        }
+        if let Some(variation) = self.delay_variation {
+            subs.push(NeighSubTlv::DelayVariation(IsisSubDelayVariation {
+                variation,
+            }));
+        }
+        if let Some(loss) = self.loss {
+            subs.push(NeighSubTlv::LinkLoss(IsisSubLinkLoss {
+                anomalous: false,
+                loss,
+            }));
+        }
+        subs
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, EnumString, Display)]
@@ -967,6 +1028,48 @@ pub fn config_affinity(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<
         link.config.affinity.remove(&name);
     }
     Some(())
+}
+
+// Per-link RFC 8570 TE metrics, from
+// /router/isis/interface/<ifname>/te-metric/<leaf>. libyang passes the
+// interface key then the leaf value; the value is present on delete too,
+// so the field is cleared based on `op`. Each setter re-originates both
+// levels (the level guard inside `process_lsp_originate` drops the wrong
+// level on single-level instances) so the sub-TLV change reaches peers
+// without waiting for the refresh timer.
+fn config_te_metric(
+    isis: &mut Isis,
+    mut args: Args,
+    op: ConfigOp,
+    set: impl FnOnce(&mut LinkTeMetric, Option<u32>),
+) -> Option<()> {
+    let ifname = args.string()?;
+    let value = args.u32()?;
+    let link = isis.links.get_mut_by_name(&ifname)?;
+    set(&mut link.config.te_metric, op.is_set().then_some(value));
+    let _ = isis.tx.send(Message::LspOriginate(Level::L1, None));
+    let _ = isis.tx.send(Message::LspOriginate(Level::L2, None));
+    Some(())
+}
+
+pub fn config_te_unidirectional_delay(isis: &mut Isis, args: Args, op: ConfigOp) -> Option<()> {
+    config_te_metric(isis, args, op, |t, v| t.unidirectional_delay = v)
+}
+
+pub fn config_te_min_delay(isis: &mut Isis, args: Args, op: ConfigOp) -> Option<()> {
+    config_te_metric(isis, args, op, |t, v| t.min_delay = v)
+}
+
+pub fn config_te_max_delay(isis: &mut Isis, args: Args, op: ConfigOp) -> Option<()> {
+    config_te_metric(isis, args, op, |t, v| t.max_delay = v)
+}
+
+pub fn config_te_delay_variation(isis: &mut Isis, args: Args, op: ConfigOp) -> Option<()> {
+    config_te_metric(isis, args, op, |t, v| t.delay_variation = v)
+}
+
+pub fn config_te_loss(isis: &mut Isis, args: Args, op: ConfigOp) -> Option<()> {
+    config_te_metric(isis, args, op, |t, v| t.loss = v)
 }
 
 pub fn config_metric(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
@@ -1952,5 +2055,78 @@ mod bfd_config_tests {
                 profile: Some("FAST".to_string()),
             },
         );
+    }
+}
+
+#[cfg(test)]
+mod te_metric_tests {
+    use super::*;
+
+    /// All five metrics configured → four RFC 8570 sub-TLVs emitted in
+    /// ascending code order (33, 34, 35, 36), Anomalous clear on
+    /// statically configured values.
+    #[test]
+    fn sub_tlvs_emits_all_in_code_order() {
+        let te = LinkTeMetric {
+            unidirectional_delay: Some(1000),
+            min_delay: Some(900),
+            max_delay: Some(1200),
+            delay_variation: Some(50),
+            loss: Some(333),
+        };
+        let subs = te.sub_tlvs();
+        assert_eq!(subs.len(), 4);
+        assert!(matches!(
+            subs[0],
+            NeighSubTlv::UniLinkDelay(IsisSubUniLinkDelay {
+                anomalous: false,
+                delay: 1000,
+            })
+        ));
+        assert!(matches!(
+            subs[1],
+            NeighSubTlv::MinMaxLinkDelay(IsisSubMinMaxLinkDelay {
+                anomalous: false,
+                min_delay: 900,
+                max_delay: 1200,
+            })
+        ));
+        assert!(matches!(
+            subs[2],
+            NeighSubTlv::DelayVariation(IsisSubDelayVariation { variation: 50 })
+        ));
+        assert!(matches!(
+            subs[3],
+            NeighSubTlv::LinkLoss(IsisSubLinkLoss {
+                anomalous: false,
+                loss: 333,
+            })
+        ));
+    }
+
+    /// Min/Max delay (sub-TLV 34) needs both bounds — a lone min-delay
+    /// emits nothing, both together emit one sub-TLV.
+    #[test]
+    fn min_max_requires_both_bounds() {
+        let only_min = LinkTeMetric {
+            min_delay: Some(900),
+            ..Default::default()
+        };
+        assert!(only_min.sub_tlvs().is_empty());
+
+        let both = LinkTeMetric {
+            min_delay: Some(900),
+            max_delay: Some(1200),
+            ..Default::default()
+        };
+        assert_eq!(both.sub_tlvs().len(), 1);
+    }
+
+    /// No TE metric configured → no sub-TLVs, and the default lives on
+    /// LinkConfig.
+    #[test]
+    fn default_is_empty() {
+        assert!(LinkTeMetric::default().sub_tlvs().is_empty());
+        assert_eq!(LinkConfig::default().te_metric, LinkTeMetric::default());
     }
 }

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -817,6 +817,11 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
         {
             is_reach.subs.push(neigh::IsisSubTlv::Asla(asla));
         }
+        // Per-link RFC 8570 TE metrics (unidirectional / min-max delay,
+        // delay variation, link loss). Statically configured today; a
+        // TWAMP/STAMP measurement task will feed these dynamically in a
+        // later phase.
+        is_reach.subs.extend(link.config.te_metric.sub_tlvs());
         // Neighbor
         for (_, nbr) in link.state.nbrs.get(&level).iter() {
             for (_key, value) in nbr.addr4.iter() {
@@ -1003,6 +1008,9 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
             {
                 entry.subs.push(neigh::IsisSubTlv::Asla(asla));
             }
+            // Same RFC 8570 TE metrics as the legacy TLV 22 entry above
+            // — link delay/loss are MT-agnostic physical properties.
+            entry.subs.extend(link.config.te_metric.sub_tlvs());
             for (_, nbr) in link.state.nbrs.get(&level).iter() {
                 if let Some((_, sid_addr)) = nbr.endx_sid {
                     if nbr.network_type.is_p2p() {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1823,6 +1823,65 @@ module config {
             }
           }
 
+          container te-metric {
+            ext:help "Static TE link metrics (RFC 8570) for this interface";
+            description
+              "Per-interface traffic-engineering link metrics advertised
+               as RFC 8570 sub-TLVs on this link's Extended IS
+               Reachability entry (TLV 22, and the MT IS Reach TLV 222
+               when multi-topology is enabled). Statically configured
+               here; a future performance-measurement (TWAMP/STAMP) task
+               will populate the same fields dynamically. All delay
+               values are in microseconds.";
+
+            leaf unidirectional-delay {
+              type uint32 {
+                range "0..16777215";
+              }
+              units "microseconds";
+              description
+                "Average unidirectional link delay (RFC 8570 §4.1,
+                 sub-TLV 33).";
+            }
+            leaf min-delay {
+              type uint32 {
+                range "0..16777215";
+              }
+              units "microseconds";
+              description
+                "Minimum unidirectional link delay (RFC 8570 §4.2,
+                 sub-TLV 34). Advertised with max-delay; the Min/Max
+                 sub-TLV is emitted only when both are set.";
+            }
+            leaf max-delay {
+              type uint32 {
+                range "0..16777215";
+              }
+              units "microseconds";
+              description
+                "Maximum unidirectional link delay (RFC 8570 §4.2,
+                 sub-TLV 34).";
+            }
+            leaf delay-variation {
+              type uint32 {
+                range "0..16777215";
+              }
+              units "microseconds";
+              description
+                "Unidirectional delay variation / jitter (RFC 8570
+                 §4.3, sub-TLV 35).";
+            }
+            leaf loss {
+              type uint32 {
+                range "0..16777214";
+              }
+              description
+                "Unidirectional link loss (RFC 8570 §4.4, sub-TLV 36),
+                 encoded in units of 0.000003 %; the maximum 16777214
+                 (0xFFFFFE) is ~50.33 %.";
+            }
+          }
+
           leaf-list affinity {
             // Names of /router/isis/affinity-map entries this link
             // belongs to. The union of their bit-positions forms the


### PR DESCRIPTION
## Summary

IS-IS "produce" slice of the TWAMP-Light / STAMP plan (Phase 2). Adds static per-interface TE-metric configuration that feeds the existing RFC 8570 IS-reachability sub-TLV codec, so IS-IS advertises link delay/jitter/loss into the IGP. The dynamic STAMP measurement task (later phase) will populate the same `LinkTeMetric` fields instead of static config.

This is control-plane only — the codec, `show`, and Display impls already existed, so no codec/show changes were needed.

## Changes

- **yang/config.yang**: new `/router/isis/interface/<name>/te-metric` container with `unidirectional-delay`, `min-delay`, `max-delay`, `delay-variation` (microseconds) and `loss` (RFC 8570 0.000003% units) leaves.
- **isis/link.rs**: `LinkTeMetric` struct + field on `LinkConfig`; `sub_tlvs()` builds UniLinkDelay (33) / MinMaxLinkDelay (34) / DelayVariation (35) / LinkLoss (36) sub-TLVs. Min/Max emitted only when both bounds are set; Anomalous flag clear for static config. Five config callbacks share a `config_te_metric` helper that re-originates both levels.
- **isis/config.rs**: register the five `te-metric` callbacks.
- **isis/lsp.rs**: extend sub-TLVs at both origination sites (legacy TLV 22 and MT IS-Reach TLV 222) right after the ASLA push.

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs te_metric_tests` — 3 pass (code-order emit, min/max-requires-both, default-empty)
- `cargo test -p zebra-rs yang_load_tests` — pass (new container parses)
- `cargo fmt --all -- --check` — clean

Not yet real-run / IOS-XR–SR-OS interop validated (deferred, consistent with prior phases of this series).

🤖 Generated with [Claude Code](https://claude.com/claude-code)