### PR TITLE
bfd: support multihop sessions for BGP neighbors

### DIFF
--- a/zebra-rs/src/bfd/inst.rs
+++ b/zebra-rs/src/bfd/inst.rs
@@ -14,7 +14,7 @@ use super::config::{BfdConfig, Callback};
 use super::fsm::Event;
 use super::network::{WriteRequest, read_packet, write_packet};
 use super::session::{Session, SessionKey, SessionParams, SessionTable, StateChange};
-use super::socket::{BFD_SINGLE_HOP_PORT, bfd_socket_ipv4};
+use super::socket::{BFD_MULTI_HOP_PORT, BFD_SINGLE_HOP_PORT, bfd_socket_ipv4};
 use super::timer::{InitialParams, TimerCmd, session_timer};
 
 /// Identifier for a BFD subscriber. Conventionally the proto name
@@ -127,12 +127,16 @@ struct TimerHandle {
 
 #[derive(Debug)]
 pub enum Message {
-    /// A parsed, GTSM-validated control packet arrived.
+    /// A parsed control packet arrived. The received IP TTL is carried
+    /// up so [`Bfd::on_recv`] can enforce the per-session TTL floor
+    /// (GTSM=255 for single-hop, the configured minimum for multihop)
+    /// after the packet is demuxed to a session.
     Recv {
         packet: bfd_packet::ControlPacket,
         src: SocketAddrV4,
         dst: Option<IpAddr>,
         ifindex: u32,
+        ttl: u8,
     },
     /// Periodic transmission timer fired for `key`.
     TxTick { key: SessionKey },
@@ -185,6 +189,34 @@ impl Bfd {
         tokio::spawn(async move {
             write_packet(write_sock, write_rx).await;
         });
+
+        // Production instances also listen on the multihop port (4784,
+        // RFC 5883) so iBGP / eBGP-multihop neighbours can be tracked.
+        // Egress reuses the primary socket — `on_tx_tick` picks the
+        // destination port per session — so only a second *receive*
+        // socket is needed. Gated on the well-known bind so the
+        // ephemeral-port test instances don't fight over 4784. A bind
+        // failure here is non-fatal: single-hop still works.
+        if bind.port() == BFD_SINGLE_HOP_PORT {
+            match bfd_socket_ipv4(
+                &ctx,
+                SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, BFD_MULTI_HOP_PORT),
+            )
+            .and_then(AsyncFd::new)
+            {
+                Ok(mh_sock) => {
+                    let mh_sock = Arc::new(mh_sock);
+                    let mh_tx = main_tx.clone();
+                    tokio::spawn(async move {
+                        read_packet(mh_sock, mh_tx).await;
+                    });
+                }
+                Err(e) => tracing::warn!(
+                    "bfd: multihop listener on {BFD_MULTI_HOP_PORT} unavailable, \
+                     single-hop only: {e}"
+                ),
+            }
+        }
 
         let mut bfd = Self {
             rx,
@@ -345,8 +377,8 @@ impl Bfd {
         loop {
             tokio::select! {
                 Some(msg) = self.rx.recv() => match msg {
-                    Message::Recv { packet, src, dst, ifindex } =>
-                        self.on_recv(packet, src, dst, ifindex),
+                    Message::Recv { packet, src, dst, ifindex, ttl } =>
+                        self.on_recv(packet, src, dst, ifindex, ttl),
                     Message::TxTick { key } => self.on_tx_tick(key),
                     Message::DetectExpired { key } => self.on_detect_expired(key),
                 },
@@ -369,6 +401,7 @@ impl Bfd {
         src: SocketAddrV4,
         dst: Option<IpAddr>,
         ifindex: u32,
+        ttl: u8,
     ) {
         let lookup = if packet.your_disc != 0 {
             self.sessions.get_by_disc(packet.your_disc).map(|s| s.key)
@@ -385,6 +418,30 @@ impl Bfd {
             );
             return;
         };
+
+        // Enforce the TTL floor now that the packet is matched to a
+        // session whose hop mode we know. Single-hop sessions carry
+        // `min_ttl = 255` (RFC 5881 §5 GTSM), multihop the configured
+        // minimum (RFC 5883). A `u8` TTL can't exceed 255, so a single
+        // `<` comparison covers both: single-hop accepts only 255.
+        {
+            let session = self
+                .sessions
+                .get_by_key_mut(&key)
+                .expect("just looked up by key");
+            if ttl < session.min_ttl {
+                session.stats.rx_invalid_count += 1;
+                tracing::debug!(
+                    ?src,
+                    ?dst,
+                    ttl,
+                    min_ttl = session.min_ttl,
+                    multihop = session.key.multihop,
+                    "bfd: received TTL below floor, dropping packet",
+                );
+                return;
+            }
+        }
 
         let (change, new_tx_us, new_detect_us, new_detect_mult) = {
             let session = self
@@ -522,6 +579,63 @@ mod tests {
         let BfdEvent::StateChange { change, .. } = event;
         assert_eq!(change.from, bfd_packet::State::Down);
         assert_eq!(change.to, bfd_packet::State::Down);
+    }
+
+    /// A control packet whose received TTL is below a single-hop
+    /// session's floor (255, GTSM) is rejected in `on_recv`: the
+    /// invalid counter ticks and `handle_packet` never runs.
+    #[tokio::test]
+    async fn on_recv_drops_below_single_hop_floor() {
+        let mut bfd = fresh_bfd();
+        let key = loopback_key(8); // multihop: false ⇒ min_ttl 255
+        let (tx, _rx) = mpsc::unbounded_channel();
+        bfd.subscribe("test".into(), key, SessionParams::default(), tx);
+        let disc = bfd.sessions.get_by_key(&key).unwrap().local_disc;
+
+        let packet = bfd_packet::ControlPacket {
+            state: bfd_packet::State::Up,
+            my_disc: 0x1111_2222,
+            your_disc: disc,
+            ..bfd_packet::ControlPacket::default()
+        };
+        let src = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 8), 49152);
+        bfd.on_recv(packet, src, None, 0, 254); // single-hop requires 255
+
+        let session = bfd.sessions.get_by_key(&key).unwrap();
+        assert_eq!(session.stats.rx_invalid_count, 1);
+        assert_eq!(session.stats.rx_count, 0, "rejected before handle_packet");
+        assert_eq!(session.remote_disc, 0, "no peer discriminator learned");
+    }
+
+    /// A multihop session accepts a packet whose TTL equals its
+    /// relaxed floor — `handle_packet` runs and the peer discriminator
+    /// is learned.
+    #[tokio::test]
+    async fn on_recv_multihop_accepts_relaxed_ttl() {
+        let mut bfd = fresh_bfd();
+        let mut key = loopback_key(9);
+        key.multihop = true;
+        let params = SessionParams {
+            min_ttl: 254,
+            ..SessionParams::default()
+        };
+        let (tx, _rx) = mpsc::unbounded_channel();
+        bfd.subscribe("test".into(), key, params, tx);
+        let disc = bfd.sessions.get_by_key(&key).unwrap().local_disc;
+
+        let packet = bfd_packet::ControlPacket {
+            state: bfd_packet::State::Down,
+            my_disc: 0x3333_4444,
+            your_disc: disc,
+            ..bfd_packet::ControlPacket::default()
+        };
+        let src = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 9), 49152);
+        bfd.on_recv(packet, src, None, 0, 254); // == floor ⇒ accepted
+
+        let session = bfd.sessions.get_by_key(&key).unwrap();
+        assert_eq!(session.stats.rx_count, 1, "ttl at floor is accepted");
+        assert_eq!(session.stats.rx_invalid_count, 0);
+        assert_eq!(session.remote_disc, 0x3333_4444);
     }
 
     /// Two clients on the same key share one session; neither

--- a/zebra-rs/src/bfd/integration.rs
+++ b/zebra-rs/src/bfd/integration.rs
@@ -70,6 +70,9 @@ async fn two_instances_reach_up() {
         required_min_rx_us: 50_000,
         detect_mult: 3,
         dst_port,
+        // Loopback delivery preserves the egress TTL of 255, so the
+        // single-hop GTSM floor is satisfied.
+        min_ttl: 255,
     };
 
     bfd_a.subscribe("test".into(), loopback_key(), params(port_b), tx_a);

--- a/zebra-rs/src/bfd/network.rs
+++ b/zebra-rs/src/bfd/network.rs
@@ -12,9 +12,6 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use super::inst::Message;
 
-/// GTSM expected TTL for single-hop BFD (RFC 5881 §5).
-const GTSM_TTL: u8 = 255;
-
 /// Egress request consumed by [`write_packet`]. The event loop pushes
 /// these whenever a [`super::timer::TimerEvent::TxTick`] fires (or in
 /// future PRs, when a poll-sequence packet must be sent off-schedule).
@@ -29,9 +26,11 @@ pub struct WriteRequest {
 
 /// Async receive loop. Pulls one BFD control packet at a time off
 /// `sock`, runs structural validation via
-/// [`bfd_packet::ControlPacket::parse`], drops packets that fail GTSM
-/// (TTL < 255) with a debug log, and forwards survivors to the event
-/// loop via `tx`.
+/// [`bfd_packet::ControlPacket::parse`], and forwards survivors to the
+/// event loop via `tx`. The received IP TTL is carried up in
+/// [`Message::Recv`]; the TTL floor (GTSM=255 single-hop, configured
+/// minimum multihop) is enforced after session demux in
+/// [`super::inst::Bfd::on_recv`], because the hop mode isn't known here.
 pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message>) {
     let mut buf = [0u8; 1500];
     let mut iov = [IoSliceMut::new(&mut buf)];
@@ -66,20 +65,6 @@ pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message
                     }
                 }
 
-                if ttl != GTSM_TTL {
-                    // RFC 5881 §5: single-hop control packets MUST arrive
-                    // with TTL=255. Misconfigured peer; debug-log only
-                    // so a chatty bad neighbour can't flood the logs.
-                    tracing::debug!(
-                        ?src,
-                        ?dst,
-                        ttl,
-                        ifindex,
-                        "bfd: GTSM violation, dropping packet",
-                    );
-                    return Ok(());
-                }
-
                 let Some(payload) = msg.iovs().next() else {
                     return Err(ErrorKind::UnexpectedEof.into());
                 };
@@ -92,11 +77,15 @@ pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message
                     }
                 };
 
+                // The per-session TTL floor (GTSM for single-hop, the
+                // configured minimum for multihop) is checked after demux
+                // in `on_recv`; we can't know the hop mode at this point.
                 let _ = tx.send(Message::Recv {
                     packet,
                     src,
                     dst: dst.map(IpAddr::V4),
                     ifindex,
+                    ttl,
                 });
                 Ok(())
             })
@@ -212,10 +201,12 @@ mod tests {
         read_handle.abort();
     }
 
-    /// Packets with TTL < 255 are dropped per the GTSM rule in
-    /// RFC 5881 §5. No event reaches the channel.
+    /// The TTL floor is no longer enforced in `read_packet` — it's
+    /// deferred to `on_recv`, which knows the matched session's hop
+    /// mode. So a TTL=1 packet is *forwarded*, carrying its received
+    /// TTL up for the demux layer to accept or drop.
     #[tokio::test]
-    async fn gtsm_drops_low_ttl() {
+    async fn low_ttl_forwarded_for_demux_check() {
         let (sock, port) = loopback_recv_socket();
         let (tx, mut rx) = mpsc::unbounded_channel();
         let read_handle = tokio::spawn(async move { read_packet(sock, tx).await });
@@ -229,12 +220,14 @@ mod tests {
         packet.emit(&mut wire);
         send_raw(&wire, port, 1);
 
-        let timed = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
-        assert!(
-            timed.is_err(),
-            "GTSM should have dropped the TTL=1 packet, got: {:?}",
-            timed.ok()
-        );
+        let got = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("recv timed out")
+            .expect("channel closed");
+        let Message::Recv { ttl, .. } = got else {
+            panic!("expected Recv, got {got:?}");
+        };
+        assert_eq!(ttl, 1, "received TTL is carried up, not dropped here");
 
         read_handle.abort();
     }

--- a/zebra-rs/src/bfd/session.rs
+++ b/zebra-rs/src/bfd/session.rs
@@ -36,13 +36,17 @@ pub struct SessionKey {
 /// `bfd.DetectMult`. `dst_port` is the UDP destination used when
 /// transmitting — production callers pass
 /// [`super::socket::BFD_SINGLE_HOP_PORT`] (3784) for single-hop and
-/// 4784 for multihop (RFC 5883); tests pass the peer's ephemeral port.
+/// [`super::socket::BFD_MULTI_HOP_PORT`] (4784) for multihop (RFC 5883);
+/// tests pass the peer's ephemeral port. `min_ttl` is the lowest
+/// accepted received TTL: 255 for single-hop (GTSM, RFC 5881 §5),
+/// or the configured multihop floor (RFC 5883).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SessionParams {
     pub desired_min_tx_us: u32,
     pub required_min_rx_us: u32,
     pub detect_mult: u8,
     pub dst_port: u16,
+    pub min_ttl: u8,
 }
 
 impl Default for SessionParams {
@@ -55,6 +59,7 @@ impl Default for SessionParams {
             required_min_rx_us: 1_000_000,
             detect_mult: 3,
             dst_port: super::socket::BFD_SINGLE_HOP_PORT,
+            min_ttl: 255,
         }
     }
 }
@@ -94,6 +99,12 @@ pub struct Session {
 
     /// UDP destination port to send to (3784 single-hop, 4784 multi-hop).
     pub dst_port: u16,
+
+    /// Lowest accepted received TTL. 255 for single-hop (GTSM); the
+    /// configured floor for multihop (RFC 5883). Enforced in
+    /// [`super::inst::Bfd::on_recv`] after the packet is demuxed to
+    /// this session, since the hop mode isn't known at socket-read time.
+    pub min_ttl: u8,
 
     /// Reported by the peer in the most recent control packet.
     pub remote_min_tx_us: u32,
@@ -135,6 +146,7 @@ impl Session {
             required_min_rx_us: params.required_min_rx_us,
             detect_mult: params.detect_mult,
             dst_port: params.dst_port,
+            min_ttl: params.min_ttl,
             remote_min_tx_us: 0,
             remote_min_rx_us: 0,
             remote_detect_mult: 0,

--- a/zebra-rs/src/bfd/show.rs
+++ b/zebra-rs/src/bfd/show.rs
@@ -176,6 +176,10 @@ struct BfdPeerDetailJson {
     local: String,
     interface: String,
     multihop: bool,
+    /// Minimum accepted received TTL — only meaningful (and serialized)
+    /// for multihop sessions; single-hop is GTSM (255) by definition.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    minimum_ttl: Option<u8>,
     local_discr: u32,
     remote_discr: u32,
     local_state: String,
@@ -208,6 +212,7 @@ fn detail_json(key: &SessionKey, s: &Session) -> BfdPeerDetailJson {
         local: key.local.to_string(),
         interface: iface_str(key),
         multihop: key.multihop,
+        minimum_ttl: key.multihop.then_some(s.min_ttl),
         local_discr: s.local_disc,
         remote_discr: s.remote_disc,
         local_state: s.local_state.to_string(),
@@ -249,6 +254,9 @@ fn render_detail(buf: &mut String, key: &SessionKey, s: &Session) -> fmt::Result
     writeln!(buf, "        Remote ID: {}", s.remote_disc)?;
     writeln!(buf, "        Local address: {}", key.local)?;
     writeln!(buf, "        Interface: {}", iface_str(key))?;
+    if key.multihop {
+        writeln!(buf, "        Minimum TTL: {}", s.min_ttl)?;
+    }
     writeln!(
         buf,
         "        Status: {}",

--- a/zebra-rs/src/bfd/socket.rs
+++ b/zebra-rs/src/bfd/socket.rs
@@ -9,8 +9,19 @@ use crate::context::ProtoContext;
 /// IANA-assigned UDP port for BFD single-hop control packets (RFC 5881 §4).
 pub const BFD_SINGLE_HOP_PORT: u16 = 3784;
 
+/// IANA-assigned UDP port for BFD multihop control packets (RFC 5883 §5).
+pub const BFD_MULTI_HOP_PORT: u16 = 4784;
+
+/// Default minimum accepted received TTL for a multihop session
+/// (RFC 5883). Single-hop sessions ignore this and require TTL=255
+/// unconditionally (GTSM, RFC 5881 §5). Matches FRR's `minimum-ttl`
+/// default and the equivalent IOS-XR `bfd multihop ttl-drop-threshold`.
+pub const BFD_MULTIHOP_DEFAULT_MIN_TTL: u8 = 254;
+
 /// Build an IPv4 UDP socket suitable for sending and receiving BFD
-/// single-hop control packets.
+/// control packets. Used for both the single-hop listener (3784) and
+/// the multihop listener (4784); the per-session TTL policy is enforced
+/// after demux, not on this socket.
 ///
 /// The socket is configured to:
 ///   * send with IP TTL = 255 (RFC 5881 §5, GTSM on egress);

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4,6 +4,7 @@ use bgp_packet::*;
 
 use crate::bfd::inst::ClientReq;
 use crate::bfd::session::{SessionKey, SessionParams};
+use crate::bfd::socket::{BFD_MULTI_HOP_PORT, BFD_MULTIHOP_DEFAULT_MIN_TTL, BFD_SINGLE_HOP_PORT};
 use crate::bgp::InOut;
 use crate::config::{Args, ConfigOp};
 use crate::policy;
@@ -452,60 +453,133 @@ fn config_flowspec_validation(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Op
 }
 
 /// `set router bgp neighbor X bfd enable true|false` — flips the
-/// BFD attachment for this neighbor. Stores the bit on
-/// `peer.config.bfd.enable` and wires the same flip into a
-/// `ClientReq::Subscribe` / `Unsubscribe` against the BFD instance
-/// when `bgp.bfd_client_tx` is populated.
-fn config_peer_bfd_enable(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let addr = args.addr()?;
-    let enable = args.boolean()?;
-    let new_enable = op.is_set() && enable;
-    // Stash data we need from the peer, then drop the borrow so we
-    // can touch other Bgp fields without fighting the borrow checker.
-    let local = {
-        let peer = bgp.peers.get_mut(&addr)?;
-        peer.config.bfd.enable = new_enable;
-        peer.config
+/// Reconcile this neighbor's live BFD subscription with its current
+/// `peer.config.bfd` state. Idempotent and order-independent: every
+/// `/bfd/*` callback funnels through here, so whichever leaf lands last
+/// in a commit leaves the correct session subscribed regardless of the
+/// order `enable` / `multihop` / `minimum-ttl` arrive.
+///
+/// The desired key is recomputed from scratch (local source, hop mode,
+/// remote). It's compared against `peer.bfd_session_key` — the key we
+/// actually subscribed last time — so a changed key (hop-mode flip,
+/// update-source change) unsubscribes the stale session before
+/// subscribing the new one. No leak, no duplicate.
+///
+/// `minimum-ttl` is not part of the key; changing it on an already-up
+/// session needs a bounce (BFD applies params only at session
+/// creation), consistent with how intervals / profile behave.
+fn bfd_apply(bgp: &mut Bgp, addr: IpAddr) -> Option<()> {
+    let (enable, desired_key, params) = {
+        let peer = bgp.peers.get(&addr)?;
+        let enable = peer.config.bfd.enable;
+        let local = peer
+            .config
             .transport
             .update_source
-            .unwrap_or_else(|| unspecified_for(&addr))
+            .unwrap_or_else(|| unspecified_for(&addr));
+        let multihop = peer.bfd_multihop();
+        let min_ttl = if multihop {
+            peer.config
+                .bfd
+                .minimum_ttl
+                .unwrap_or(BFD_MULTIHOP_DEFAULT_MIN_TTL)
+        } else {
+            255 // GTSM (RFC 5881 §5): single-hop accepts only TTL 255.
+        };
+        let key = SessionKey {
+            local,
+            remote: addr,
+            ifindex: 0,
+            multihop,
+        };
+        let params = SessionParams {
+            dst_port: if multihop {
+                BFD_MULTI_HOP_PORT
+            } else {
+                BFD_SINGLE_HOP_PORT
+            },
+            min_ttl,
+            // Intervals / detect-mult still come from the defaults; the
+            // peer's `bfd profile` is stored but not yet resolved (a
+            // separate follow-up needing cross-task BfdConfig access).
+            ..SessionParams::default()
+        };
+        (enable, key, params)
     };
+
+    let current = bgp.peers.get(&addr).and_then(|p| p.bfd_session_key);
+    let want = enable.then_some(desired_key);
+    if want == current {
+        return Some(()); // Already in the desired state — no churn.
+    }
+
     let Some(client_tx) = bgp.bfd_client_tx.as_ref() else {
-        if new_enable {
+        if enable {
             tracing::debug!(
                 peer = %addr,
-                "bgp: bfd enable=true but bfd_client_tx is None (BFD not yet spawned)",
+                "bgp: bfd enabled but bfd_client_tx is None (BFD not yet spawned)",
             );
         }
         return Some(());
     };
-    let key = SessionKey {
-        local,
-        remote: addr,
-        ifindex: 0,
-        multihop: false,
-    };
-    let req = if new_enable {
-        // Uses SessionParams::default() for every neighbor — the
-        // peer's `bfd profile` reference is stored but not yet read.
-        // Profile resolution against `/bfd/profile/<name>` is a
-        // follow-up that needs cross-task config access (BGP would
-        // need a snapshot of BFD's BfdConfig, or BFD has to resolve
-        // profiles internally on Subscribe).
-        ClientReq::Subscribe {
+
+    // Drop a stale subscription (key changed, or BFD turned off) before
+    // adding the new one.
+    if let Some(old) = current {
+        let _ = client_tx.send(ClientReq::Unsubscribe {
             client: "bgp".to_string(),
-            key,
-            params: SessionParams::default(),
+            key: old,
+        });
+    }
+    if enable {
+        let _ = client_tx.send(ClientReq::Subscribe {
+            client: "bgp".to_string(),
+            key: desired_key,
+            params,
             notifier: bgp.bfd_event_tx.clone(),
-        }
-    } else {
-        ClientReq::Unsubscribe {
-            client: "bgp".to_string(),
-            key,
-        }
-    };
-    let _ = client_tx.send(req);
+        });
+    }
+
+    if let Some(peer) = bgp.peers.get_mut(&addr) {
+        peer.bfd_session_key = want;
+    }
     Some(())
+}
+
+/// BFD attachment for this neighbor. Stores the bit on
+/// `peer.config.bfd.enable`, then reconciles the live subscription.
+fn config_peer_bfd_enable(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let enable = args.boolean()?;
+    {
+        let peer = bgp.peers.get_mut(&addr)?;
+        peer.config.bfd.enable = op.is_set() && enable;
+    }
+    bfd_apply(bgp, addr)
+}
+
+/// `set router bgp neighbor X bfd multihop <bool>` — explicit hop-mode
+/// override. Cleared (back to `is_ibgp()`-inference) on delete.
+fn config_peer_bfd_multihop(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let multihop = args.boolean()?;
+    {
+        let peer = bgp.peers.get_mut(&addr)?;
+        peer.config.bfd.multihop = op.is_set().then_some(multihop);
+    }
+    bfd_apply(bgp, addr)
+}
+
+/// `set router bgp neighbor X bfd minimum-ttl <1-254>` — multihop
+/// received-TTL floor (RFC 5883). Ignored for single-hop sessions.
+fn config_peer_bfd_min_ttl(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let ttl = args.u8()?;
+    {
+        let peer = bgp.peers.get_mut(&addr)?;
+        peer.config.bfd.minimum_ttl = op.is_set().then_some(ttl);
+    }
+    bfd_apply(bgp, addr)
 }
 
 /// Pick an unspecified local address whose family matches `remote`.
@@ -1741,6 +1815,8 @@ impl Bgp {
         // unsubscribe path to the BFD client API.
         self.callback_peer("/bfd/enable", config_peer_bfd_enable);
         self.callback_peer("/bfd/profile", config_peer_bfd_profile);
+        self.callback_peer("/bfd/multihop", config_peer_bfd_multihop);
+        self.callback_peer("/bfd/minimum-ttl", config_peer_bfd_min_ttl);
         self.callback_peer("/tcp-ao/key-chain", config_peer_tcp_ao_key_chain);
         self.callback_peer(
             "/tcp-ao/include-tcp-options",
@@ -1968,8 +2044,8 @@ mod bfd_wiring_tests {
         (bgp, bfd_client_rx)
     }
 
-    /// `bfd enable true` on a known neighbor sends a
-    /// `ClientReq::Subscribe` carrying the matching SessionKey.
+    /// `bfd enable true` on a known iBGP neighbor (the default peer
+    /// type) auto-infers multihop and subscribes on the 4784 port.
     #[tokio::test]
     async fn enable_sends_subscribe() {
         let (mut bgp, mut bfd_rx) = fresh_bgp_with_bfd();
@@ -1980,15 +2056,76 @@ mod bfd_wiring_tests {
 
         let req = bfd_rx.try_recv().expect("BGP must send a ClientReq");
         match req {
-            ClientReq::Subscribe { client, key, .. } => {
+            ClientReq::Subscribe {
+                client,
+                key,
+                params,
+                ..
+            } => {
                 assert_eq!(client, "bgp");
                 assert_eq!(
                     key.remote,
                     IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
                     "remote address mirrors the configured neighbor",
                 );
-                assert!(!key.multihop, "single-hop only");
+                assert!(key.multihop, "iBGP default infers multihop (FRR-style)");
+                assert_eq!(params.dst_port, BFD_MULTI_HOP_PORT);
+                assert_eq!(params.min_ttl, BFD_MULTIHOP_DEFAULT_MIN_TTL);
                 assert_eq!(key.ifindex, 0);
+            }
+            other => panic!("expected Subscribe, got {other:?}"),
+        }
+    }
+
+    /// An eBGP neighbor with no override defaults to single-hop
+    /// (port 3784, GTSM TTL floor of 255).
+    #[tokio::test]
+    async fn enable_ebgp_is_single_hop() {
+        let (mut bgp, mut bfd_rx) = fresh_bgp_with_bfd();
+        config_peer(&mut bgp, arg_words(&["10.0.0.5"]), ConfigOp::Set).unwrap();
+        let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5));
+        bgp.peers.get_mut(&addr).unwrap().peer_type = PeerType::EBGP;
+
+        config_peer_bfd_enable(&mut bgp, arg_words(&["10.0.0.5", "true"]), ConfigOp::Set).unwrap();
+        match bfd_rx.try_recv().expect("subscribe") {
+            ClientReq::Subscribe { key, params, .. } => {
+                assert!(!key.multihop, "eBGP without override is single-hop");
+                assert_eq!(params.dst_port, BFD_SINGLE_HOP_PORT);
+                assert_eq!(params.min_ttl, 255);
+            }
+            other => panic!("expected Subscribe, got {other:?}"),
+        }
+    }
+
+    /// `bfd multihop true` forces multihop even on an eBGP neighbor,
+    /// regardless of the order the leaves arrive within the commit
+    /// (enable lands first, then the override) — the stale single-hop
+    /// session is unsubscribed and replaced.
+    #[tokio::test]
+    async fn multihop_override_replaces_single_hop() {
+        let (mut bgp, mut bfd_rx) = fresh_bgp_with_bfd();
+        config_peer(&mut bgp, arg_words(&["10.0.0.6"]), ConfigOp::Set).unwrap();
+        let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 6));
+        bgp.peers.get_mut(&addr).unwrap().peer_type = PeerType::EBGP;
+
+        // enable first → transient single-hop subscribe.
+        config_peer_bfd_enable(&mut bgp, arg_words(&["10.0.0.6", "true"]), ConfigOp::Set).unwrap();
+        match bfd_rx.try_recv().expect("initial subscribe") {
+            ClientReq::Subscribe { key, .. } => assert!(!key.multihop),
+            other => panic!("expected Subscribe, got {other:?}"),
+        }
+
+        // override arrives → unsubscribe single-hop, subscribe multihop.
+        config_peer_bfd_multihop(&mut bgp, arg_words(&["10.0.0.6", "true"]), ConfigOp::Set)
+            .unwrap();
+        match bfd_rx.try_recv().expect("unsubscribe stale key") {
+            ClientReq::Unsubscribe { key, .. } => assert!(!key.multihop),
+            other => panic!("expected Unsubscribe, got {other:?}"),
+        }
+        match bfd_rx.try_recv().expect("resubscribe multihop") {
+            ClientReq::Subscribe { key, params, .. } => {
+                assert!(key.multihop);
+                assert_eq!(params.dst_port, BFD_MULTI_HOP_PORT);
             }
             other => panic!("expected Subscribe, got {other:?}"),
         }

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -20,6 +20,7 @@ use caps::CapAs4;
 use caps::CapRefresh;
 use caps::CapabilityPacket;
 
+use crate::bfd::session::SessionKey;
 use crate::bgp::cap::cap_register_recv;
 use crate::bgp::route::{route_clean, route_sync};
 use crate::bgp::{AdjRib, In, Out};
@@ -188,14 +189,24 @@ pub struct PeerTransportConfig {
 }
 
 /// Per-neighbor BFD attachment recorded from
-/// `set router bgp neighbor <addr> bfd { enable | profile }`
-/// (zebra-bgp-bfd.yang). The configuration is stored here; `enable`
-/// flips translate into subscribe / unsubscribe calls on the BFD
-/// instance via `bfd::inst::Bfd::client_req_tx`.
+/// `set router bgp neighbor <addr> bfd { enable | multihop |
+/// minimum-ttl | profile }` (zebra-bgp-bfd.yang). The configuration is
+/// stored here; `enable` flips translate into subscribe / unsubscribe
+/// calls on the BFD instance via `bfd::inst::Bfd::client_req_tx`.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct PeerBfdConfig {
     pub enable: bool,
     pub profile: Option<String>,
+    /// Hop-mode override. `None` (the default) means "infer": the
+    /// session is multihop iff the BGP session is iBGP, mirroring FRR's
+    /// `PEER_IS_MULTIHOP`. `Some(true)`/`Some(false)` force it — used
+    /// for eBGP-over-loopback until a dedicated `ebgp-multihop` knob
+    /// exists. See [`Peer::bfd_multihop`].
+    pub multihop: Option<bool>,
+    /// Multihop minimum received TTL (RFC 5883). `None` falls back to
+    /// [`crate::bfd::socket::BFD_MULTIHOP_DEFAULT_MIN_TTL`]. Ignored for
+    /// single-hop sessions (GTSM requires 255 unconditionally).
+    pub minimum_ttl: Option<u8>,
 }
 
 #[derive(Debug, Clone)]
@@ -463,6 +474,15 @@ pub struct Peer {
     /// `start_adv_timer_evpn`) so the timer-arming path doesn't need
     /// to reach back into the global `Bgp`.
     pub adv_interval: timer::AdvInterval,
+
+    /// The BFD [`SessionKey`] this peer currently has a live
+    /// subscription for, or `None` if BFD is off. Runtime bookkeeping
+    /// (not config): lets the reconcile path in `config::config_peer_bfd_*`
+    /// unsubscribe the *old* key before subscribing a new one when the
+    /// key changes (hop-mode flip, update-source change), so config
+    /// callbacks that arrive in any order within a commit never leak or
+    /// duplicate a session.
+    pub bfd_session_key: Option<SessionKey>,
 }
 
 impl Peer {
@@ -530,6 +550,7 @@ impl Peer {
             last_ao_installed: None,
             update_group_id: BTreeMap::new(),
             adv_interval: timer::AdvInterval::default(),
+            bfd_session_key: None,
         };
         peer.config
             .mp
@@ -576,6 +597,15 @@ impl Peer {
 
     pub fn is_ibgp(&self) -> bool {
         self.peer_type.is_ibgp()
+    }
+
+    /// Effective BFD hop mode for this neighbour: the explicit
+    /// `bfd multihop` override if set, else inferred from the BGP
+    /// session type (iBGP ⇒ multihop), mirroring FRR's
+    /// `PEER_IS_MULTIHOP`. eBGP-over-loopback uses the explicit
+    /// override until a dedicated `ebgp-multihop` knob exists.
+    pub fn bfd_multihop(&self) -> bool {
+        self.config.bfd.multihop.unwrap_or_else(|| self.is_ibgp())
     }
 
     pub fn is_reflector_client(&self) -> bool {
@@ -1897,20 +1927,24 @@ mod bfd_config_tests {
         assert_eq!(pc.bfd, bfd);
     }
 
-    /// Round-trip: setting enable + profile mirrors the CLI flow
-    /// (`bfd enable true; bfd profile FAST`) producing the recorded
-    /// state the BFD subscribe path reads.
+    /// Round-trip: setting enable + profile + multihop mirrors the CLI
+    /// flow (`bfd enable true; bfd profile FAST; bfd multihop true`)
+    /// producing the recorded state the BFD subscribe path reads.
     #[test]
     fn enable_and_profile_round_trip() {
         let mut pc = PeerConfig::default();
         pc.bfd.enable = true;
         pc.bfd.profile = Some("FAST".to_string());
+        pc.bfd.multihop = Some(true);
+        pc.bfd.minimum_ttl = Some(250);
 
         assert_eq!(
             pc.bfd,
             PeerBfdConfig {
                 enable: true,
                 profile: Some("FAST".to_string()),
+                multihop: Some(true),
+                minimum_ttl: Some(250),
             },
         );
     }

--- a/zebra-rs/yang/zebra-bgp-bfd.yang
+++ b/zebra-rs/yang/zebra-bgp-bfd.yang
@@ -36,6 +36,8 @@ module zebra-bgp-bfd {
            bfd {
              enable true;
              profile FAST;
+             multihop true;     // eBGP-over-loopback; iBGP infers this
+             minimum-ttl 250;
            }
          }
        }
@@ -47,6 +49,17 @@ module zebra-bgp-bfd {
      neighbor to BFD via the channel exposed by
      `bfd::inst::Bfd::client_req_tx`; a transition to Down then
      terminates the BGP session.";
+
+  revision 2026-05-31 {
+    description
+      "Add `multihop` hop-mode override and multihop `minimum-ttl`.
+       Default hop mode is inferred from the BGP session (iBGP ⇒
+       multihop), matching FRR; the override covers eBGP-over-loopback
+       until a dedicated `ebgp-multihop` knob exists.";
+    reference
+      "RFC 5883 (Multihop BFD). FRR `bfd` peer `multihop` / `minimum-ttl`.
+       Cisco IOS-XR `bfd multihop ttl-drop-threshold`.";
+  }
 
   revision 2026-05-19 {
     description "Initial revision (PR 5b — storage only).";
@@ -84,6 +97,32 @@ module zebra-bgp-bfd {
            to this neighbor's BFD session. Leafref validation will
            be added once libyang exposes cross-tree leafref
            resolution.";
+      }
+
+      leaf multihop {
+        ext:help "Force BFD hop mode for this neighbor";
+        type boolean;
+        description
+          "Explicit hop-mode override. When unset (the default), the
+           session is multihop iff the BGP session is iBGP, mirroring
+           FRR's `PEER_IS_MULTIHOP`. Set `true` for eBGP-over-loopback
+           (which neither vendor auto-detects without `ebgp-multihop`)
+           or `false` to force single-hop. Multihop uses UDP/4784 and a
+           relaxed TTL floor; single-hop uses UDP/3784 with GTSM
+           (TTL=255).";
+      }
+
+      leaf minimum-ttl {
+        ext:help "Multihop: lowest accepted received TTL";
+        type uint8 {
+          range "1..254";
+        }
+        default 254;
+        description
+          "Multihop only: minimum TTL accepted on incoming control
+           packets (RFC 5883). Ignored on single-hop sessions where
+           GTSM requires TTL=255 unconditionally. Equivalent to FRR's
+           `minimum-ttl` and IOS-XR's `bfd multihop ttl-drop-threshold`.";
       }
     }
   }


### PR DESCRIPTION
## Summary

Brings up BFD for BGP neighbors reached over multiple hops (e.g. loopback peering), which previously stayed stuck `Down` because the BGP→BFD integration hardcoded single-hop (port 3784, TTL 255 GTSM).

Hop mode is now **derived from the BGP session** — iBGP ⇒ multihop, eBGP ⇒ single-hop — mirroring FRR's `PEER_IS_MULTIHOP`. An explicit override covers eBGP-over-loopback until a dedicated `ebgp-multihop` knob exists. Cross-checked against both FRR and IOS-XR, which agree there is no `multihop` keyword on the neighbor BFD command (both infer it).

### Config

```
router bgp {
  neighbor 10.0.0.2 {
    remote-as 65501;
    update-source 10.0.0.1;
    bfd { enable true; multihop true; }   # iBGP needs no multihop line
  }
}
```

- `bfd { multihop true|false }` — explicit hop-mode override (default: inferred from `is_ibgp()`)
- `bfd { minimum-ttl <1-254> }` — multihop received-TTL floor (default 254; ignored for single-hop)

### Changes

- **socket**: `BFD_MULTI_HOP_PORT` (4784), default min-TTL (254)
- **inst**: production instances also listen on 4784 (non-fatal fallback to single-hop if the bind fails); GTSM/TTL check **relocated from `read_packet` into `on_recv`** so it honors the matched session's hop mode (`ttl < session.min_ttl`), and now increments `rx_invalid_count`
- **session**: `SessionParams`/`Session` gain `min_ttl`
- **bgp**: `bfd_apply()` reconciles the live subscription order-independently via a tracked per-peer session key — no leak / duplicate when `enable`/`multihop`/`minimum-ttl` callbacks arrive in any order within a commit; `SessionKey.multihop` + `dst_port` now wired
- **show**: `show bfd peer` reports `Minimum TTL` for multihop sessions (text + JSON)
- **yang**: `multihop` + `minimum-ttl` leaves on the neighbor `bfd` block (new revision)

### Known limits (documented in code)
- Changing `minimum-ttl` on an already-up session needs a bounce (BFD applies params only at session creation — same as intervals/`profile`).
- `profile` is still stored-not-applied (pre-existing, separate gap); IPv6 multihop receive deferred (recv path is v4-only).

## Test plan

- `cargo build -p zebra-rs` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test -p zebra-rs` — **799 passed, 0 failed** (incl. new tests: single-hop TTL-floor drop, multihop relaxed-TTL accept, TTL-forwarding, eBGP single-hop, override-replaces-single-hop)
- `yang_load_tests` — pass

Generated with [Claude Code](https://claude.com/claude-code)