### PR TITLE
ospf: originate RFC 7471 TE metrics from per-interface config

### DIFF
--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -64,6 +64,26 @@ impl Ospf {
         self.ospf_add("/area/interface/priority", config_ospf_interface_priority);
         self.ospf_add("/area/interface/affinity", config_ospf_interface_affinity);
         self.ospf_add(
+            "/area/interface/te-metric/unidirectional-delay",
+            config_ospf_interface_te_unidirectional_delay,
+        );
+        self.ospf_add(
+            "/area/interface/te-metric/min-delay",
+            config_ospf_interface_te_min_delay,
+        );
+        self.ospf_add(
+            "/area/interface/te-metric/max-delay",
+            config_ospf_interface_te_max_delay,
+        );
+        self.ospf_add(
+            "/area/interface/te-metric/delay-variation",
+            config_ospf_interface_te_delay_variation,
+        );
+        self.ospf_add(
+            "/area/interface/te-metric/loss",
+            config_ospf_interface_te_loss,
+        );
+        self.ospf_add(
             "/area/interface/hello-interval",
             config_ospf_interface_hello_interval,
         );
@@ -576,6 +596,59 @@ fn config_ospf_interface_affinity(ospf: &mut Ospf, mut args: Args, op: ConfigOp)
         link.config.affinity.remove(&affinity);
     }
     Some(())
+}
+
+// `/router/ospf/area/interface/te-metric/*` — static RFC 7471 TE link
+// metrics. Each leaf shares this helper: parse the area-id / interface
+// name / u32 value, set or clear one `LinkTeMetric` field, then
+// re-originate the Extended-Link Opaque LSA so the metric rides in the
+// link's ASLA sub-TLV. Origination only happens when SR-MPLS is enabled
+// (see `ext_link_lsa_originate`).
+fn config_ospf_interface_te_metric(
+    ospf: &mut Ospf,
+    mut args: Args,
+    op: ConfigOp,
+    set: impl Fn(&mut super::link::LinkTeMetric, Option<u32>),
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let value = args.u32()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    set(&mut link.config.te_metric, op.is_set().then_some(value));
+    let ifindex = link.index;
+
+    ospf.ext_link_lsa_originate(ifindex);
+
+    Some(())
+}
+
+fn config_ospf_interface_te_unidirectional_delay(
+    ospf: &mut Ospf,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    config_ospf_interface_te_metric(ospf, args, op, |m, v| m.unidirectional_delay = v)
+}
+
+fn config_ospf_interface_te_min_delay(ospf: &mut Ospf, args: Args, op: ConfigOp) -> Option<()> {
+    config_ospf_interface_te_metric(ospf, args, op, |m, v| m.min_delay = v)
+}
+
+fn config_ospf_interface_te_max_delay(ospf: &mut Ospf, args: Args, op: ConfigOp) -> Option<()> {
+    config_ospf_interface_te_metric(ospf, args, op, |m, v| m.max_delay = v)
+}
+
+fn config_ospf_interface_te_delay_variation(
+    ospf: &mut Ospf,
+    args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    config_ospf_interface_te_metric(ospf, args, op, |m, v| m.delay_variation = v)
+}
+
+fn config_ospf_interface_te_loss(ospf: &mut Ospf, args: Args, op: ConfigOp) -> Option<()> {
+    config_ospf_interface_te_metric(ospf, args, op, |m, v| m.loss = v)
 }
 
 fn config_ospf_interface_hello_interval(

--- a/zebra-rs/src/ospf/flex_algo.rs
+++ b/zebra-rs/src/ospf/flex_algo.rs
@@ -164,23 +164,34 @@ pub fn build_fad_v3(
 }
 
 /// Build the per-link ASLA sub-TLV (RFC 9492) carrying this link's
-/// affinity (Extended Admin Group, RFC 7308) for the Flexible
-/// Algorithm application. Returns `None` when no affinity name resolves
-/// to a bit — a zero-length admin group would be a meaningless wire
-/// artifact, so the link simply advertises no ASLA.
+/// affinity (Extended Admin Group, RFC 7308) and any RFC 7471 TE
+/// metrics (`extra` — delay/jitter/loss link-attribute sub-sub-TLVs)
+/// for the Flexible Algorithm application. Returns `None` only when the
+/// ASLA would carry nothing: no affinity name resolves to a bit *and*
+/// `extra` is empty — an attribute-less ASLA would be a meaningless wire
+/// artifact.
 ///
 /// The SABM is a single 4-octet word with only the Flex-Algorithm
 /// X-bit set (`OSPF_SABM_FLEX_ALGO`, RFC 9350 §12); OSPF requires the
 /// mask length to be 0/4/8 octets (RFC 9492 §2). UDABM is empty.
-pub fn build_link_asla(affinity: &BTreeSet<String>, am: &AffinityMap) -> Option<ExtLinkSubTlv> {
+pub fn build_link_asla(
+    affinity: &BTreeSet<String>,
+    am: &AffinityMap,
+    extra: Vec<OspfAslaSubSubTlv>,
+) -> Option<ExtLinkSubTlv> {
     let group = local_link_affinity(affinity, am);
-    if group.words.is_empty() {
+    let mut subs = Vec::new();
+    if !group.words.is_empty() {
+        subs.push(OspfAslaSubSubTlv::ExtAdminGroup(group));
+    }
+    subs.extend(extra);
+    if subs.is_empty() {
         return None;
     }
     Some(ExtLinkSubTlv::Asla(OspfAslaSubTlv {
         sabm: vec![OSPF_SABM_FLEX_ALGO, 0, 0, 0],
         udabm: Vec::new(),
-        subs: vec![OspfAslaSubSubTlv::ExtAdminGroup(group)],
+        subs,
     }))
 }
 
@@ -325,7 +336,7 @@ mod tests {
             .unwrap();
             am.commit();
         }
-        let asla = build_link_asla(&affinity_set(&["blue", "red"]), &am).expect("ASLA");
+        let asla = build_link_asla(&affinity_set(&["blue", "red"]), &am, Vec::new()).expect("ASLA");
         let ExtLinkSubTlv::Asla(a) = &asla else {
             panic!("expected Asla, got {asla:?}");
         };
@@ -369,10 +380,37 @@ mod tests {
     #[test]
     fn build_link_asla_none_when_no_affinity_resolves() {
         let am = AffinityMap::new();
-        // No names → None.
-        assert!(build_link_asla(&BTreeSet::new(), &am).is_none());
-        // Referenced name not in the map → None (empty bitmap).
-        assert!(build_link_asla(&affinity_set(&["ghost"]), &am).is_none());
+        // No names, no extra subs → None.
+        assert!(build_link_asla(&BTreeSet::new(), &am, Vec::new()).is_none());
+        // Referenced name not in the map and no extra subs → None
+        // (empty bitmap).
+        assert!(build_link_asla(&affinity_set(&["ghost"]), &am, Vec::new()).is_none());
+    }
+
+    #[test]
+    fn build_link_asla_emits_te_metrics_without_affinity() {
+        use ospf_packet::{OspfAslaSubSubTlv, OspfSubUniLinkDelay};
+
+        let am = AffinityMap::new();
+        // No affinity at all, but a TE-metric sub-sub-TLV present: the
+        // link must still advertise an ASLA so the metric reaches peers.
+        let extra = vec![OspfAslaSubSubTlv::UniLinkDelay(OspfSubUniLinkDelay {
+            anomalous: false,
+            delay: 1_000,
+        })];
+        let asla = build_link_asla(&BTreeSet::new(), &am, extra).expect("ASLA");
+        let ExtLinkSubTlv::Asla(a) = &asla else {
+            panic!("expected Asla, got {asla:?}");
+        };
+        assert!(a.is_flex_algo(), "SABM X-bit must be set");
+        assert!(
+            a.ext_admin_group().is_none(),
+            "no affinity → no admin group"
+        );
+        assert!(matches!(
+            a.subs.as_slice(),
+            [OspfAslaSubSubTlv::UniLinkDelay(_)]
+        ));
     }
 
     #[test]

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1117,10 +1117,16 @@ impl Ospf<Ospfv2> {
         {
             let our_addr = addr.prefix.addr();
             // Per-link ASLA carrying this link's flex-algo affinity
-            // (RFC 9492 / RFC 9350 §6.3), independent of Adj-SID: a link
-            // with affinity but no Adj-SID still originates an
-            // Extended-Link LSA so peers can run the FAD constraints.
-            let asla = super::flex_algo::build_link_asla(&link.config.affinity, &self.affinity_map);
+            // (RFC 9492 / RFC 9350 §6.3) and any static RFC 7471 TE
+            // metrics, independent of Adj-SID: a link with affinity or
+            // TE metrics but no Adj-SID still originates an Extended-Link
+            // LSA so peers can run the FAD constraints / read the
+            // metrics.
+            let asla = super::flex_algo::build_link_asla(
+                &link.config.affinity,
+                &self.affinity_map,
+                link.config.te_metric.asla_sub_subs(),
+            );
             match link.network_type {
                 OspfNetworkType::PointToPoint => {
                     if let Some(nbr) = link.nbrs.values().find(|n| n.state == NfsmState::Full) {

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -8,6 +8,10 @@ use std::{
 
 use bitfield_struct::bitfield;
 use netlink_packet_route::link::LinkFlags;
+use ospf_packet::{
+    OspfAslaSubSubTlv, OspfSubDelayVariation, OspfSubLinkLoss, OspfSubMinMaxLinkDelay,
+    OspfSubUniLinkDelay,
+};
 use socket2::Socket;
 use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc::UnboundedSender;
@@ -113,6 +117,65 @@ pub struct LinkConfig {
     /// tested against each FAD's include/exclude constraints at
     /// per-algo SPF time. Mirrors `isis::LinkConfig::affinity`.
     pub affinity: BTreeSet<String>,
+    /// Static RFC 7471 TE link metrics (delay/jitter/loss) advertised in
+    /// this link's ASLA sub-TLV on the Extended-Link Opaque LSA. Mirrors
+    /// `isis::LinkConfig::te_metric`; a future TWAMP/STAMP task will
+    /// populate these dynamically.
+    pub te_metric: LinkTeMetric,
+}
+
+/// Per-interface RFC 7471 TE link metrics. All delay values are in
+/// microseconds; `loss` is the raw 24-bit RFC 7471 encoding (units of
+/// 0.000003 %). `None` means "not configured / not measured" — the
+/// corresponding sub-TLV is simply not advertised.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct LinkTeMetric {
+    pub unidirectional_delay: Option<u32>,
+    pub min_delay: Option<u32>,
+    pub max_delay: Option<u32>,
+    pub delay_variation: Option<u32>,
+    pub loss: Option<u32>,
+}
+
+impl LinkTeMetric {
+    /// Build the RFC 7471 link-attribute sub-sub-TLVs for the configured
+    /// metrics, in ascending code-point order (27/28/29/30). These ride
+    /// inside the link's ASLA sub-TLV (RFC 9492) — see
+    /// `flex_algo::build_link_asla`. The anomalous flag is always clear
+    /// for statically-configured values; the dynamic measurement task
+    /// will set it on threshold crossings.
+    ///
+    /// The Min/Max sub-TLV (28) is emitted only when *both* bounds are
+    /// configured — a half-populated bound would be a meaningless wire
+    /// artifact.
+    pub fn asla_sub_subs(&self) -> Vec<OspfAslaSubSubTlv> {
+        let mut subs = Vec::new();
+        if let Some(delay) = self.unidirectional_delay {
+            subs.push(OspfAslaSubSubTlv::UniLinkDelay(OspfSubUniLinkDelay {
+                anomalous: false,
+                delay,
+            }));
+        }
+        if let (Some(min_delay), Some(max_delay)) = (self.min_delay, self.max_delay) {
+            subs.push(OspfAslaSubSubTlv::MinMaxLinkDelay(OspfSubMinMaxLinkDelay {
+                anomalous: false,
+                min_delay,
+                max_delay,
+            }));
+        }
+        if let Some(variation) = self.delay_variation {
+            subs.push(OspfAslaSubSubTlv::DelayVariation(OspfSubDelayVariation {
+                variation,
+            }));
+        }
+        if let Some(loss) = self.loss {
+            subs.push(OspfAslaSubSubTlv::LinkLoss(OspfSubLinkLoss {
+                anomalous: false,
+                loss,
+            }));
+        }
+        subs
+    }
 }
 
 /// OSPFv2 per-interface authentication mode.
@@ -513,4 +576,60 @@ pub struct OspfLinkFlags {
     pub resvd1: bool,
     #[bits(6)]
     pub resvd2: usize,
+}
+
+#[cfg(test)]
+mod te_metric_tests {
+    use super::*;
+
+    #[test]
+    fn asla_sub_subs_emits_all_in_code_order() {
+        let m = LinkTeMetric {
+            unidirectional_delay: Some(1_000),
+            min_delay: Some(900),
+            max_delay: Some(1_200),
+            delay_variation: Some(50),
+            loss: Some(10),
+        };
+        let subs = m.asla_sub_subs();
+        assert_eq!(subs.len(), 4);
+        assert!(matches!(subs[0], OspfAslaSubSubTlv::UniLinkDelay(_)));
+        assert!(matches!(subs[1], OspfAslaSubSubTlv::MinMaxLinkDelay(_)));
+        assert!(matches!(subs[2], OspfAslaSubSubTlv::DelayVariation(_)));
+        assert!(matches!(subs[3], OspfAslaSubSubTlv::LinkLoss(_)));
+    }
+
+    #[test]
+    fn min_max_requires_both_bounds() {
+        // Only min set → no Min/Max sub-TLV.
+        let m = LinkTeMetric {
+            min_delay: Some(900),
+            ..Default::default()
+        };
+        assert!(m.asla_sub_subs().is_empty());
+
+        // Only max set → no Min/Max sub-TLV.
+        let m = LinkTeMetric {
+            max_delay: Some(1_200),
+            ..Default::default()
+        };
+        assert!(m.asla_sub_subs().is_empty());
+
+        // Both set → exactly one Min/Max sub-TLV.
+        let m = LinkTeMetric {
+            min_delay: Some(900),
+            max_delay: Some(1_200),
+            ..Default::default()
+        };
+        let subs = m.asla_sub_subs();
+        assert!(matches!(
+            subs.as_slice(),
+            [OspfAslaSubSubTlv::MinMaxLinkDelay(_)]
+        ));
+    }
+
+    #[test]
+    fn default_is_empty() {
+        assert!(LinkTeMetric::default().asla_sub_subs().is_empty());
+    }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -545,6 +545,67 @@ module config {
               // include/exclude constraints at flex-algo SPF time.
               type string;
             }
+            container te-metric {
+              ext:help "Static TE link metrics (RFC 7471) for this interface";
+              description
+                "Per-interface traffic-engineering link metrics advertised
+                 as RFC 7471 link-attribute sub-TLVs carried in this link's
+                 ASLA sub-TLV (RFC 9492) on the Extended-Link Opaque LSA —
+                 the same place flex-algo affinity is advertised, and what
+                 Flex-Algorithm metric-type 1 consumes. Origination is
+                 gated on Segment Routing over MPLS being enabled (the
+                 Extended-Link LSA is only originated then). Statically
+                 configured here; a future performance-measurement
+                 (TWAMP/STAMP) task will populate the same fields
+                 dynamically. All delay values are in microseconds.";
+
+              leaf unidirectional-delay {
+                type uint32 {
+                  range "0..16777215";
+                }
+                units "microseconds";
+                description
+                  "Average unidirectional link delay (RFC 7471 §4.1,
+                   sub-TLV 27).";
+              }
+              leaf min-delay {
+                type uint32 {
+                  range "0..16777215";
+                }
+                units "microseconds";
+                description
+                  "Minimum unidirectional link delay (RFC 7471 §4.2,
+                   sub-TLV 28). Advertised with max-delay; the Min/Max
+                   sub-TLV is emitted only when both are set.";
+              }
+              leaf max-delay {
+                type uint32 {
+                  range "0..16777215";
+                }
+                units "microseconds";
+                description
+                  "Maximum unidirectional link delay (RFC 7471 §4.2,
+                   sub-TLV 28).";
+              }
+              leaf delay-variation {
+                type uint32 {
+                  range "0..16777215";
+                }
+                units "microseconds";
+                description
+                  "Unidirectional delay variation / jitter (RFC 7471
+                   §4.3, sub-TLV 29).";
+              }
+              leaf loss {
+                type uint32 {
+                  range "0..16777214";
+                }
+                description
+                  "Unidirectional link loss (RFC 7471 §4.4, sub-TLV 30),
+                   encoded in units of 0.000003 %; the maximum 16777214
+                   (0xFFFFFE) is ~50.33 %.";
+              }
+            }
           }
         }
         container segment-routing {


### PR DESCRIPTION
## Summary

OSPF "produce" slice of the TWAMP-Light / STAMP plan (Phase 3b), consuming the RFC 7471 codec from #1119. Wires static per-interface TE-metric configuration into OSPFv2 LSA origination. The metrics ride in the same per-link **ASLA sub-TLV** (RFC 9492) on the Extended-Link Opaque LSA as flex-algo affinity — exactly where Flex-Algorithm metric-type 1 reads them. Mirrors the IS-IS produce side (#1118).

## Changes

- **link.rs**: `LinkTeMetric` struct + `te_metric` field on `LinkConfig`; `asla_sub_subs()` builds the four RFC 7471 link-attribute sub-sub-TLVs (code points 27/28/29/30; Min/Max only when both bounds are set; Anomalous clear for static config). Three unit tests.
- **flex_algo.rs**: `build_link_asla` now takes extra sub-sub-TLVs and originates an ASLA when affinity resolves **or** extra is non-empty, so a link carrying TE metrics but no affinity still advertises one.
- **inst.rs**: pass the link's TE-metric sub-sub-TLVs into `build_link_asla`.
- **config.rs**: five `/area/interface/te-metric/*` callbacks sharing a helper that sets one field and re-originates the Extended-Link LSA.
- **config.yang**: `te-metric` container under the OSPFv2 `area/interface` list.

## Known limitation

Origination remains gated on Segment Routing over MPLS being enabled (the Extended-Link Opaque LSA is only originated then) — same as flex-algo affinity today. So OSPF TE metrics currently advertise only when `segment-routing mpls` is on. Fine for the flex-algo use case; broadening that gate for standalone TE-metric advertisement is a deferred follow-up. **v2 only** — the v3 ASLA builder is untouched (v2-first cadence).

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs te_metric_tests` — 6 pass (IS-IS + new OSPF)
- `cargo test -p zebra-rs flex_algo` — 59 pass (incl. new "ASLA without affinity but with TE metric" test)
- `cargo test -p zebra-rs yang_load_tests` — 2 pass (new container parses)
- `cargo fmt --all -- --check` — clean

Not yet real-run / IOS-XR–SR-OS interop validated (deferred, consistent with prior phases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)