### PR TITLE
ospf: consume per-link delay as Flex-Algo metric-type 1

### DIFF
--- a/crates/ospf-packet/src/parser.rs
+++ b/crates/ospf-packet/src/parser.rs
@@ -2342,6 +2342,16 @@ impl OspfAslaSubTlv {
             _ => None,
         })
     }
+
+    /// Minimum unidirectional link delay (microseconds) from the Min/Max
+    /// Link Delay sub-sub-TLV (RFC 7471 §4.2), if present. This is the
+    /// RFC 9350 §6 metric-type 1 (min-unidir-link-delay) input.
+    pub fn min_unidir_delay(&self) -> Option<u32> {
+        self.subs.iter().find_map(|s| match s {
+            OspfAslaSubSubTlv::MinMaxLinkDelay(d) => Some(d.min_delay),
+            _ => None,
+        })
+    }
 }
 
 // RFC 7471 OSPFv2 TE-metric link-attribute sub-TLVs. These ride as
@@ -2995,6 +3005,8 @@ mod tests {
                 assert_eq!(a, &asla);
                 assert!(a.is_flex_algo());
                 assert_eq!(a.ext_admin_group(), Some(&admin_group(&[0, 4, 200])));
+                // No Min/Max delay sub-TLV here → no delay metric.
+                assert_eq!(a.min_unidir_delay(), None);
             }
             other => panic!("expected Asla, got {other:?}"),
         }
@@ -3042,7 +3054,12 @@ mod tests {
         let (rest, parsed) = ExtLinkLsa::parse_be(&buf).expect("parse");
         assert!(rest.is_empty(), "trailing: {rest:?}");
         match &parsed.tlvs[0].subs[0] {
-            ExtLinkSubTlv::Asla(a) => assert_eq!(a, &asla),
+            ExtLinkSubTlv::Asla(a) => {
+                assert_eq!(a, &asla);
+                // The RFC 9350 metric-type 1 accessor returns the Min
+                // delay from the Min/Max sub-TLV.
+                assert_eq!(a.min_unidir_delay(), Some(900));
+            }
             other => panic!("expected Asla, got {other:?}"),
         }
     }

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -6951,15 +6951,53 @@ fn flex_algo_link_affinity(
     map
 }
 
+/// Per-link minimum unidirectional delay (microseconds) advertised in
+/// this area's Extended-Link Opaque LSAs via the flex-algo ASLA Min/Max
+/// Link Delay sub-TLV (RFC 7471 §4.2), keyed the same way as
+/// `flex_algo_link_affinity`. Used as the SPF edge cost when a
+/// Flex-Algorithm selects metric-type 1 (min-unidir-link-delay, RFC
+/// 9350 §6).
+fn flex_algo_link_delay(area: &OspfArea) -> BTreeMap<(Ipv4Addr, Ipv4Addr, Ipv4Addr), u32> {
+    use crate::ospf::lsdb::OSPF_MAX_AGE;
+    let mut map = BTreeMap::new();
+    for (_, lsa) in area.lsdb.iter_by_type(OspfLsType::OpaqueAreaLocal) {
+        if lsa.data.h.ls_age >= OSPF_MAX_AGE {
+            continue;
+        }
+        let OspfLsp::OpaqueAreaExtLink(ref el) = lsa.data.lsp else {
+            continue;
+        };
+        let adv_router = lsa.data.h.adv_router;
+        for tlv in &el.tlvs {
+            for sub in &tlv.subs {
+                if let ExtLinkSubTlv::Asla(asla) = sub
+                    && asla.is_flex_algo()
+                    && let Some(delay) = asla.min_unidir_delay()
+                {
+                    map.insert((adv_router, tlv.link_id, tlv.link_data), delay);
+                }
+            }
+        }
+    }
+    map
+}
+
 /// Build the per-algo SPF graph for `area_id`. Mirrors `graph()` but
 /// (a) includes only routers participating in `algo` (plus self), and
 /// (b) admits each Router-LSA link only if it passes the FAD
 /// constraints in `entry` (RFC 9350 §6), the link's affinity coming
 /// from the Extended-Link ASLA join table.
 ///
-/// Local FAD config (`entry`) drives the constraints — no multi-router
-/// FAD election yet (matches IS-IS). Metric is IGP only; SRLG-exclude
-/// is not enforced; both are deferred exactly as on the IS-IS side.
+/// Edge cost follows the FAD metric-type (RFC 9350 §5.1): metric-type 1
+/// (min-unidir-link-delay) uses the per-link Min delay from the
+/// Extended-Link ASLA, and a link with no delay advertised is pruned
+/// (RFC 9350 §15 — a link missing the selected metric MUST NOT be used).
+/// All other metric-types (IGP, and the not-yet-supported TE-default)
+/// fall back to the IGP `tos_0_metric`.
+///
+/// Local FAD config (`entry`) drives the constraints and metric-type —
+/// no multi-router FAD election yet (matches IS-IS). SRLG-exclude is not
+/// enforced; deferred exactly as on the IS-IS side.
 fn graph_flex_algo(
     top: &mut Ospf,
     area_id: Ipv4Addr,
@@ -6977,6 +7015,16 @@ fn graph_flex_algo(
 
     let participants = flex_algo_participants(area, algo);
     let link_affinity = flex_algo_link_affinity(area);
+
+    // RFC 9350 §5.1 metric-type 1 routes on per-link delay instead of
+    // the IGP cost. Build the delay join table only for that metric-type
+    // — the IGP path never consults it.
+    let use_delay = entry.metric_type == Some(crate::flex_algo::FadMetricType::MinUnidirLinkDelay);
+    let link_delay = if use_delay {
+        flex_algo_link_delay(area)
+    } else {
+        BTreeMap::new()
+    };
 
     // Router-LSAs of participating routers (self always kept — it is
     // the SPF source).
@@ -7030,6 +7078,17 @@ fn graph_flex_algo(
                 if !crate::flex_algo::link_passes_fad(affinity, entry, &top.affinity_map) {
                     continue;
                 }
+                // Edge cost per the FAD metric-type. With a delay metric,
+                // a link advertising no Min delay is pruned (RFC 9350
+                // §15); otherwise the IGP cost is used.
+                let cost = if use_delay {
+                    match link_delay.get(&(*adv_router, link.link_id, link.link_data)) {
+                        Some(&d) => d,
+                        None => continue,
+                    }
+                } else {
+                    link.tos_0_metric as u32
+                };
                 match link.link_type {
                     OspfLinkType::P2p | OspfLinkType::VirtualLink => {
                         if !participants.contains(&link.link_id) {
@@ -7049,7 +7108,7 @@ fn graph_flex_algo(
                         vertex.olinks.push(spf::Link {
                             from: node_id,
                             to: to_id,
-                            cost: link.tos_0_metric as u32,
+                            cost,
                             link_id: 0,
                         });
                     }
@@ -7074,7 +7133,7 @@ fn graph_flex_algo(
                             vertex.olinks.push(spf::Link {
                                 from: node_id,
                                 to: to_id,
-                                cost: link.tos_0_metric as u32,
+                                cost,
                                 link_id: 0,
                             });
                         }


### PR DESCRIPTION
## Summary

Final OSPF slice of the TWAMP-Light / STAMP plan (Phase 4). OSPFv2 per-algo SPF now routes on per-link delay when a Flexible Algorithm selects metric-type 1 (min-unidir-link-delay, RFC 9350 §6), consuming the RFC 7471 metrics originated in #1119/#1121. This closes the OSPF half of the IGP path end-to-end: **codec → produce → consume**.

## Changes

- **ospf-packet**: `OspfAslaSubTlv::min_unidir_delay()` accessor returns the Min value from the Min/Max Link Delay sub-sub-TLV (RFC 7471 §4.2), mirroring `ext_admin_group()`. Two ASLA round-trip tests assert it.
- **inst.rs**: `flex_algo_link_delay()` builds a per-link delay join table (keyed like `flex_algo_link_affinity`). `graph_flex_algo` uses the delay as the edge cost when the FAD metric-type is min-unidir-link-delay, **pruning any link that advertises no delay** (RFC 9350 §15 — a link missing the selected metric MUST NOT be used). IGP and the not-yet-supported TE-default keep the IGP `tos_0_metric`. Applied to both P2p and Transit edges.

## Notes / scope

- Local FAD config drives the metric-type (no multi-router FAD election yet, matching IS-IS).
- `show ip ospf flex-algo` already prints `Metric-Type:`, so the computed costs are self-describing — no show change.
- **v2 only** — the v3 `graph_flex_algo` sibling is untouched (v2-first cadence).
- End-to-end SPF behavior is deferred to real-run validation; there's no graph-test scaffolding in inst.rs, consistent with prior phases.

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p ospf-packet` — 72 pass (incl. the extended `min_unidir_delay()` assertions)
- `cargo test -p zebra-rs flex_algo` — 59 pass
- `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)