### PR TITLE
isis: advertise RFC 8570 TE metrics in the Flex-Algo ASLA

### DIFF
--- a/zebra-rs/src/isis/flex_algo.rs
+++ b/zebra-rs/src/isis/flex_algo.rs
@@ -87,26 +87,41 @@ fn link_admin_group_words(affinity: &BTreeSet<String>, am: &AffinityMap) -> Vec<
 }
 
 /// Build a per-link ASLA sub-TLV (RFC 9479) carrying the link's
-/// affinity (Extended Admin Group, RFC 7308) for the Flex-Algorithm
-/// application. Returns `None` when no affinity bits resolved — a
-/// zero-byte AdminGrp inside an ASLA would be a meaningless wire
-/// artifact.
+/// affinity (Extended Admin Group, RFC 7308) and any RFC 8570 TE
+/// metrics (`extra` — delay/jitter/loss sub-TLVs) scoped to the
+/// Flex-Algorithm application. Returns `None` only when the ASLA would
+/// carry nothing: no affinity bit resolved *and* `extra` is empty.
+///
+/// The TE metrics are *also* advertised inline in TLV 22 for general
+/// RFC 8570 visibility; this copy is the application-specific one
+/// Flex-Algorithm consumes (RFC 9350 §6.3 — link attributes used by a
+/// Flex-Algorithm must be advertised via ASLA with the Flex-Algorithm
+/// application bit set).
 ///
 /// SABM is set to a single byte with only the X-bit (Flex-Algorithm,
 /// 0x10) — these link attributes apply to flex-algo SPF only. The
 /// L-flag stays cleared (modern non-legacy interpretation per
 /// RFC 9479 §4.2). UDABM is left empty: every receiver that
 /// understands ASLA understands Flex-Algorithm.
-pub fn build_link_asla(affinity: &BTreeSet<String>, am: &AffinityMap) -> Option<IsisSubAsla> {
+pub fn build_link_asla(
+    affinity: &BTreeSet<String>,
+    am: &AffinityMap,
+    extra: Vec<NeighSubTlv>,
+) -> Option<IsisSubAsla> {
     let words = link_admin_group_words(affinity, am);
-    if words.is_empty() {
+    let mut subs = Vec::new();
+    if !words.is_empty() {
+        subs.push(NeighSubTlv::AdminGrp(IsisSubAdminGrp { groups: words }));
+    }
+    subs.extend(extra);
+    if subs.is_empty() {
         return None;
     }
     Some(IsisSubAsla {
         l_flag: false,
         sabm: vec![SABM_FLEX_ALGO],
         udabm: Vec::new(),
-        subs: vec![NeighSubTlv::AdminGrp(IsisSubAdminGrp { groups: words })],
+        subs,
     })
 }
 
@@ -470,7 +485,7 @@ mod tests {
             .unwrap();
             am.commit();
         }
-        let asla = build_link_asla(&affinity_set(&["blue", "red"]), &am).expect("ASLA");
+        let asla = build_link_asla(&affinity_set(&["blue", "red"]), &am, Vec::new()).expect("ASLA");
         let parsed = parse_asla_flex_algo_bitmap(&asla).expect("bitmap");
         // bit 0 in word 0, bit (200 - 6*32 = 8) in word 6.
         assert_eq!(parsed.words.len(), 7);
@@ -482,14 +497,14 @@ mod tests {
     #[test]
     fn build_link_asla_returns_none_for_empty_affinity() {
         let am = AffinityMap::new();
-        assert!(build_link_asla(&BTreeSet::new(), &am).is_none());
+        assert!(build_link_asla(&BTreeSet::new(), &am, Vec::new()).is_none());
     }
 
     #[test]
     fn build_link_asla_returns_none_when_all_names_unresolved() {
         let am = AffinityMap::new();
         // `blue` is referenced but the affinity-map is empty.
-        assert!(build_link_asla(&affinity_set(&["blue"]), &am).is_none());
+        assert!(build_link_asla(&affinity_set(&["blue"]), &am, Vec::new()).is_none());
     }
 
     #[test]
@@ -504,7 +519,7 @@ mod tests {
             .unwrap();
             am.commit();
         }
-        let asla = build_link_asla(&affinity_set(&["blue", "low-lat", "red"]), &am)
+        let asla = build_link_asla(&affinity_set(&["blue", "low-lat", "red"]), &am, Vec::new())
             .expect("ASLA expected");
         // L-flag clear, SABM = [0x10] (X-bit only), UDABM empty.
         assert!(!asla.l_flag);
@@ -540,7 +555,7 @@ mod tests {
             .unwrap();
             am.commit();
         }
-        let asla = build_link_asla(&affinity_set(&["a", "b", "c"]), &am).expect("ASLA");
+        let asla = build_link_asla(&affinity_set(&["a", "b", "c"]), &am, Vec::new()).expect("ASLA");
         match &asla.subs[0] {
             NeighSubTlv::AdminGrp(ag) => {
                 // bit 200 lives in word 6 (200/32=6), so we need
@@ -549,6 +564,60 @@ mod tests {
             }
             _ => panic!("expected AdminGrp"),
         }
+    }
+
+    #[test]
+    fn build_link_asla_nests_te_metrics_without_affinity() {
+        use isis_packet::{IsisSubMinMaxLinkDelay, IsisSubUniLinkDelay};
+
+        // No affinity, but delay sub-TLVs present → the ASLA is still
+        // emitted, carrying only the TE metrics (no AdminGrp).
+        let am = AffinityMap::new();
+        let extra = vec![
+            NeighSubTlv::UniLinkDelay(IsisSubUniLinkDelay {
+                anomalous: false,
+                delay: 1_000,
+            }),
+            NeighSubTlv::MinMaxLinkDelay(IsisSubMinMaxLinkDelay {
+                anomalous: false,
+                min_delay: 900,
+                max_delay: 1_200,
+            }),
+        ];
+        let asla = build_link_asla(&BTreeSet::new(), &am, extra).expect("ASLA");
+        assert_eq!(asla.sabm, vec![SABM_FLEX_ALGO]);
+        assert!(
+            !asla
+                .subs
+                .iter()
+                .any(|s| matches!(s, NeighSubTlv::AdminGrp(_))),
+            "no affinity → no AdminGrp"
+        );
+        assert!(matches!(asla.subs[0], NeighSubTlv::UniLinkDelay(_)));
+        assert!(matches!(asla.subs[1], NeighSubTlv::MinMaxLinkDelay(_)));
+    }
+
+    #[test]
+    fn build_link_asla_combines_affinity_and_te_metrics() {
+        use isis_packet::IsisSubMinMaxLinkDelay;
+
+        let mut am = AffinityMap::new();
+        am.exec(
+            "/affinity-map/affinity/bit-position".into(),
+            args(&["blue", "0"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        am.commit();
+        let extra = vec![NeighSubTlv::MinMaxLinkDelay(IsisSubMinMaxLinkDelay {
+            anomalous: false,
+            min_delay: 900,
+            max_delay: 1_200,
+        })];
+        let asla = build_link_asla(&affinity_set(&["blue"]), &am, extra).expect("ASLA");
+        // AdminGrp first (affinity), then the delay sub-TLV.
+        assert!(matches!(asla.subs[0], NeighSubTlv::AdminGrp(_)));
+        assert!(matches!(asla.subs[1], NeighSubTlv::MinMaxLinkDelay(_)));
     }
 
     #[test]

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -806,21 +806,24 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
             metric: link.config.metric(),
             subs: Vec::new(),
         };
-        // Per-link ASLA sub-TLV (RFC 9479) with the Extended Admin
-        // Group bitmap for flex-algo path computation. Only emitted
-        // when at least one affinity name resolves — receivers can
-        // intersect this bitmap with any FAD's
-        // include-any/include-all/exclude-any constraint sub-TLV to
-        // decide whether the link is in the algorithm's topology.
-        if let Some(asla) =
-            super::flex_algo::build_link_asla(&link.config.affinity, top.affinity_map)
-        {
+        // Per-link ASLA sub-TLV (RFC 9479) carrying the Extended Admin
+        // Group bitmap and the RFC 8570 TE metrics, scoped to flex-algo
+        // path computation. Receivers intersect the bitmap with any
+        // FAD's include-any/include-all/exclude-any constraint and read
+        // the delay metrics for metric-type-1 SPF (RFC 9350 §6.3). Only
+        // emitted when affinity or a TE metric is present.
+        if let Some(asla) = super::flex_algo::build_link_asla(
+            &link.config.affinity,
+            top.affinity_map,
+            link.config.te_metric.sub_tlvs(),
+        ) {
             is_reach.subs.push(neigh::IsisSubTlv::Asla(asla));
         }
         // Per-link RFC 8570 TE metrics (unidirectional / min-max delay,
-        // delay variation, link loss). Statically configured today; a
-        // TWAMP/STAMP measurement task will feed these dynamically in a
-        // later phase.
+        // delay variation, link loss), also advertised inline for
+        // general TE visibility (non-flex-algo consumers). Statically
+        // configured today; a TWAMP/STAMP measurement task will feed
+        // these dynamically in a later phase.
         is_reach.subs.extend(link.config.te_metric.sub_tlvs());
         // Neighbor
         for (_, nbr) in link.state.nbrs.get(&level).iter() {
@@ -1000,16 +1003,19 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
                 metric,
                 subs: Vec::new(),
             };
-            // Per-link ASLA carries the same affinity bitmap on the
-            // MT IS-reach entry as on the legacy TLV 22 entry —
-            // affinities are MT-agnostic in the YANG model.
-            if let Some(asla) =
-                super::flex_algo::build_link_asla(&link.config.affinity, top.affinity_map)
-            {
+            // Per-link ASLA carries the same affinity bitmap and TE
+            // metrics on the MT IS-reach entry as on the legacy TLV 22
+            // entry — both are MT-agnostic in the YANG model.
+            if let Some(asla) = super::flex_algo::build_link_asla(
+                &link.config.affinity,
+                top.affinity_map,
+                link.config.te_metric.sub_tlvs(),
+            ) {
                 entry.subs.push(neigh::IsisSubTlv::Asla(asla));
             }
-            // Same RFC 8570 TE metrics as the legacy TLV 22 entry above
-            // — link delay/loss are MT-agnostic physical properties.
+            // Same RFC 8570 TE metrics as the legacy TLV 22 entry above,
+            // also advertised inline for general TE visibility — link
+            // delay/loss are MT-agnostic physical properties.
             entry.subs.extend(link.config.te_metric.sub_tlvs());
             for (_, nbr) in link.state.nbrs.get(&level).iter() {
                 if let Some((_, sid_addr)) = nbr.endx_sid {


### PR DESCRIPTION
## Summary

Track 1a of the TWAMP-Light / STAMP plan — make IS-IS link delay Flex-Algo-consumable. IS-IS already carried flex-algo affinity inside the Application-Specific Link Attributes sub-TLV (RFC 9479), but the RFC 8570 delay/loss metrics (originated in #1118) were advertised only inline in TLV 22. **RFC 9350 §6.3** requires the link attributes a Flex-Algorithm consumes to be carried in an ASLA with the Flex-Algorithm application bit set, so a metric-type-1 SPF cannot use the inline copy. This nests the TE metrics in the flex-algo ASLA as well, keeping the inline advertisement for general (non-flex-algo) RFC 8570 visibility.

## Changes

- **flex_algo.rs**: `build_link_asla` now takes extra nested sub-TLVs and emits an ASLA when affinity resolves **or** extra is non-empty (so a link with TE metrics but no affinity still advertises one). The delay sub-TLVs reuse their RFC 8570 code points inside the ASLA — the same link-attribute registry RFC 8919/9479 nests, so no codec change.
- **lsp.rs**: both emit sites (legacy TLV 22 and MT IS-Reach TLV 222) pass the link's TE-metric sub-TLVs into the ASLA and keep the separate inline emission.

## Notes / scope

- Delay now appears twice in the LSP: inline (general RFC 8570 visibility) and in the Flex-Algo ASLA (the application-specific copy). This matches "legacy + ASLA coexist" deployments and was a deliberate choice.
- Consume side (`graph_flex_algo` reading the ASLA Min delay as the metric-type-1 SPF cost) follows in a separate change.

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs flex_algo` — 61 pass (incl. 2 new: delay-without-affinity, affinity+delay combined)
- `cargo test -p zebra-rs isis::lsp` — 10 pass
- `cargo test -p isis-packet` — pass
- `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)