### PR TITLE
isis: consume per-link delay as Flex-Algo metric-type 1

### DIFF
--- a/zebra-rs/src/isis/flex_algo.rs
+++ b/zebra-rs/src/isis/flex_algo.rs
@@ -64,6 +64,27 @@ pub fn parse_asla_flex_algo_bitmap(asla: &IsisSubAsla) -> Option<ExtAdminGroup> 
     None
 }
 
+/// Extract the minimum unidirectional link delay (microseconds) from a
+/// peer-advertised ASLA sub-TLV iff the SABM marks it for the
+/// Flex-Algorithm application (X-bit). The value is the Min field of the
+/// nested Min/Max Link Delay sub-TLV (RFC 8570 §4.2) — the RFC 9350 §6
+/// metric-type 1 (min-unidir-link-delay) input. Returns `None` when the
+/// X-bit is clear or no Min/Max Link Delay sub-TLV is nested. Mirrors
+/// `parse_asla_flex_algo_bitmap` so SPF reads the same Min a sender
+/// packs via `build_link_asla`.
+pub fn parse_asla_min_delay(asla: &IsisSubAsla) -> Option<u32> {
+    let first = asla.sabm.first()?;
+    if first & SABM_FLEX_ALGO == 0 {
+        return None;
+    }
+    for sub in &asla.subs {
+        if let NeighSubTlv::MinMaxLinkDelay(d) = sub {
+            return Some(d.min_delay);
+        }
+    }
+    None
+}
+
 /// SABM byte (RFC 9479 §4.2) with the Flex-Algorithm (X-bit) set.
 /// Bit layout in the first SABM byte, MSB-first: R(7) S(6) F(5) X(4)
 /// reserved(3..0). Used as the Selective Application-specific
@@ -469,6 +490,66 @@ mod tests {
         };
         let bitmap = parse_asla_flex_algo_bitmap(&asla).expect("bitmap");
         assert_eq!(bitmap.words, vec![0x11, 0x80000000]);
+    }
+
+    #[test]
+    fn parse_asla_min_delay_returns_min_when_x_bit_set() {
+        use isis_packet::IsisSubMinMaxLinkDelay;
+        let asla = IsisSubAsla {
+            l_flag: false,
+            sabm: vec![SABM_FLEX_ALGO],
+            udabm: vec![],
+            subs: vec![NeighSubTlv::MinMaxLinkDelay(IsisSubMinMaxLinkDelay {
+                anomalous: false,
+                min_delay: 900,
+                max_delay: 1_200,
+            })],
+        };
+        assert_eq!(parse_asla_min_delay(&asla), Some(900));
+    }
+
+    #[test]
+    fn parse_asla_min_delay_returns_none_without_x_bit() {
+        use isis_packet::IsisSubMinMaxLinkDelay;
+        // SABM = [0x80] sets R-bit (RSVP-TE) but not X-bit.
+        let asla = IsisSubAsla {
+            l_flag: false,
+            sabm: vec![0x80],
+            udabm: vec![],
+            subs: vec![NeighSubTlv::MinMaxLinkDelay(IsisSubMinMaxLinkDelay {
+                anomalous: false,
+                min_delay: 900,
+                max_delay: 1_200,
+            })],
+        };
+        assert!(parse_asla_min_delay(&asla).is_none());
+    }
+
+    #[test]
+    fn parse_asla_min_delay_returns_none_without_min_max_sub() {
+        // X-bit set but only an AdminGrp nested — no Min/Max delay.
+        let asla = IsisSubAsla {
+            l_flag: false,
+            sabm: vec![SABM_FLEX_ALGO],
+            udabm: vec![],
+            subs: vec![NeighSubTlv::AdminGrp(IsisSubAdminGrp { groups: vec![0x1] })],
+        };
+        assert!(parse_asla_min_delay(&asla).is_none());
+    }
+
+    #[test]
+    fn parse_asla_min_delay_round_trips_through_build_link_asla() {
+        use isis_packet::IsisSubMinMaxLinkDelay;
+        // Producer nests Min/Max in the flex-algo ASLA; the consumer
+        // recovers the Min bit-for-bit.
+        let am = AffinityMap::new();
+        let extra = vec![NeighSubTlv::MinMaxLinkDelay(IsisSubMinMaxLinkDelay {
+            anomalous: false,
+            min_delay: 1_500,
+            max_delay: 2_000,
+        })];
+        let asla = build_link_asla(&BTreeSet::new(), &am, extra).expect("ASLA");
+        assert_eq!(parse_asla_min_delay(&asla), Some(1_500));
     }
 
     #[test]

--- a/zebra-rs/src/isis/graph.rs
+++ b/zebra-rs/src/isis/graph.rs
@@ -9,7 +9,7 @@ use isis_packet::{
 use crate::spf;
 
 use super::config::MtId;
-use super::flex_algo::{FlexAlgoEntry, link_passes_fad, local_link_affinity};
+use super::flex_algo::{FadMetricType, FlexAlgoEntry, link_passes_fad, local_link_affinity};
 use super::inst::IsisTop;
 use super::level::Level;
 
@@ -498,9 +498,12 @@ fn process_neighbor_link_mt2(
 ///     cached. `entry.srlg_exclude` is read but produces no effect; a
 ///     `tracing::warn` would be reasonable but is left to the
 ///     scheduler layer.
-///   - **Metric type:** IGP only. `entry.metric_type ==
-///     MinUnidirLinkDelay` or `TeDefault` falls back to IGP with no
-///     warning (TODO when those metric caches arrive).
+///   - **Metric type (§5.1):** `MinUnidirLinkDelay` (metric-type 1)
+///     routes on per-link Min delay — local links from
+///     `LinkConfig::te_metric.min_delay`, peer links from the Min/Max
+///     Link Delay sub-TLV in the link's flex-algo ASLA. A link that
+///     advertises no delay is pruned (RFC 9350 §15). IGP (and the
+///     not-yet-supported TeDefault) use the reach entry's IGP metric.
 pub fn graph_flex_algo(
     top: &mut IsisTop,
     level: Level,
@@ -606,6 +609,34 @@ pub fn graph_flex_algo(
                     continue;
                 }
 
+                // Edge cost per the FAD metric-type (RFC 9350 §5.1).
+                // metric-type 1 routes on the link's Min delay: local
+                // links from current config, peer links from the
+                // flex-algo ASLA's Min/Max Link Delay sub-TLV. A link
+                // that advertises no delay is pruned (RFC 9350 §15).
+                // Everything else uses the reach entry's IGP metric.
+                let cost = if entry.metric_type == Some(FadMetricType::MinUnidirLinkDelay) {
+                    let delay = if source_sys_id == self_sys_id {
+                        local_adj_to_ifindex
+                            .get(&entry_reach.neighbor_id)
+                            .and_then(|ifx| top.links.get(ifx))
+                            .and_then(|link| link.config.te_metric.min_delay)
+                    } else {
+                        entry_reach.subs.iter().find_map(|sub| match sub {
+                            neigh::IsisSubTlv::Asla(asla) => {
+                                super::flex_algo::parse_asla_min_delay(asla)
+                            }
+                            _ => None,
+                        })
+                    };
+                    match delay {
+                        Some(d) => d,
+                        None => continue,
+                    }
+                } else {
+                    entry_reach.metric
+                };
+
                 let to_id = top
                     .lsp_map
                     .get_mut(&level)
@@ -620,7 +651,7 @@ pub fn graph_flex_algo(
                     0
                 };
 
-                let link = spf::Link::with_id(node_id, to_id, entry_reach.metric, link_id);
+                let link = spf::Link::with_id(node_id, to_id, cost, link_id);
                 if let Some(from) = graph.get_mut(&node_id) {
                     from.olinks.push(link.clone());
                 }


### PR DESCRIPTION
## Summary

Track 1b of the TWAMP-Light / STAMP plan — completes the IS-IS half of the IGP path (codec → produce → consume) and brings it level with OSPF. IS-IS per-algo SPF now routes on per-link delay when a Flexible Algorithm selects metric-type 1 (min-unidir-link-delay, RFC 9350 §6), consuming the Min delay carried in the flex-algo ASLA (#1123).

The Min delay is read **inline** from the reach entry's sub-TLVs during graph build — the cloned LSP carries the flex-algo ASLA at SPF time, so no parallel `peer_link_delay` join table is needed (affinity uses one for historical reasons; the underlying data is identical).

## Changes

- **flex_algo.rs**: `parse_asla_min_delay()` returns the Min field of the nested Min/Max Link Delay sub-TLV when the ASLA's SABM marks it for the Flex-Algorithm application, mirroring `parse_asla_flex_algo_bitmap`.
- **graph.rs**: `graph_flex_algo` computes the edge cost from the FAD metric-type — metric-type 1 uses the link's Min delay (local links from `LinkConfig::te_metric.min_delay`, peer links from the ASLA), and a link advertising no delay is **pruned** (RFC 9350 §15). IGP and the not-yet-supported TE-default keep the reach entry's IGP metric.

## Notes / scope

- Local FAD config drives the metric-type (no multi-router FAD election yet — matches OSPF).
- End-to-end SPF behavior is deferred to real-run validation (no graph-test scaffolding in this module, consistent with the OSPF side).
- TE-default metric-type remains a follow-up.

## Test plan

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs flex_algo` — 65 pass (incl. 4 new `parse_asla_min_delay` tests)
- `cargo test -p zebra-rs isis::` — 131 pass
- `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)