### PR TITLE
ospf: BFD for OSPFv2 + eager-spawn launch-order fix

### DIFF
--- a/zebra-rs/src/config/bgp.rs
+++ b/zebra-rs/src/config/bgp.rs
@@ -7,11 +7,11 @@ pub fn spawn_bgp(config: &ConfigManager) {
     // Capture BFD / ND client handles so per-neighbor `bfd { enable }`
     // and IPv6 unnumbered RA hand-off can submit requests later. Both
     // are guaranteed to be populated when BGP is spawned via
-    // `commit_config`: the BGP arm there pre-spawns ND eagerly, and
-    // pre-spawns BFD when the same commit will set `bfd { … }`.
-    // Code paths that bypass `commit_config` and call `spawn_bgp`
-    // directly may still see `None` here; the captured-by-value
-    // contract has not changed.
+    // `commit_config`: the BGP arm there spawns ND *and* BFD eagerly,
+    // before `spawn_bgp`, so neither depends on commit order or on a
+    // top-level `bfd { … }` block. Code paths that bypass
+    // `commit_config` and call `spawn_bgp` directly may still see
+    // `None` here; the captured-by-value contract is unchanged.
     let bfd_client_tx = config.bfd_client_tx.borrow().clone();
     let nd_client_tx = config.nd_client_tx.borrow().clone();
     let (rib_client, rib_rx) = config.subscribe_to_rib("bgp");

--- a/zebra-rs/src/config/isis.rs
+++ b/zebra-rs/src/config/isis.rs
@@ -5,12 +5,12 @@ use crate::rib;
 use super::ConfigManager;
 
 pub fn spawn_isis(config: &ConfigManager) {
-    // Capture BFD's client handle so per-interface `bfd { enable }`
-    // can later submit Subscribe / Unsubscribe. `commit_config`
-    // guarantees BFD is already spawned when this commit will also
-    // set `bfd { … }`, even if `router isis` came first in the diff
-    // (the IS-IS arm there pre-spawns BFD on the will-set flag).
-    // Callers that bypass `commit_config` may still see `None`.
+    // Capture BFD's client handle so per-interface `isis bfd` can later
+    // submit Subscribe / Unsubscribe. `commit_config` spawns BFD
+    // eagerly before IS-IS, so the handle is always live here —
+    // independent of commit order and of whether a top-level
+    // `bfd { … }` block exists. Callers that bypass `commit_config`
+    // may still see `None`.
     let bfd_client_tx = config.bfd_client_tx.borrow().clone();
     // BGP-LS producer (RFC 9552): the IS-IS task pushes Link-State routes
     // to BGP over this sender. Captured by value — `None` if `router bgp`

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -451,26 +451,6 @@ impl ConfigManager {
                 nd = true;
             }
         }
-        // Pre-scan the diff so we know whether this commit will
-        // introduce a `bfd { … }` block *before* we process lines in
-        // order. Needed because BGP / IS-IS capture `bfd_client_tx`
-        // by value at spawn time; if the operator wrote `router bgp`
-        // (or `router isis`) above `bfd` in the same commit, the
-        // naive line-order spawn would hand them a `None` BFD handle.
-        let mut will_set_bfd = false;
-        for line in diff.lines() {
-            let Some(first_char) = line.chars().next() else {
-                continue;
-            };
-            if first_char != '+' {
-                continue;
-            }
-            let line = remove_first_char(line);
-            if line.starts_with("bfd") {
-                will_set_bfd = true;
-                break;
-            }
-        }
         // Same by-value capture problem for the IS-IS→BGP BGP-LS producer
         // channel: `spawn_isis` captures `bgp_tx` by value, so if this
         // commit will set `router bgp` we must spawn BGP before IS-IS even
@@ -519,11 +499,14 @@ impl ConfigManager {
             }
             if !isis && op == ConfigOp::Set && line.starts_with("router isis") {
                 isis = true;
-                // Spawn BFD first if this commit will set BFD too —
-                // `spawn_isis` captures `bfd_client_tx` by value, so
-                // IS-IS gets no handle if `bfd { … }` lands later in
-                // the same commit.
-                if !bfd && will_set_bfd {
+                // Bring BFD up before IS-IS unconditionally: `spawn_isis`
+                // captures `bfd_client_tx` by value, so IS-IS would get a
+                // stale `None` handle if BFD spawned later (a different
+                // commit, or below `router isis` in this one). Spawning it
+                // eagerly here means `isis bfd` works regardless of order
+                // and without a top-level `bfd { … }` block. Idempotent —
+                // the `bfd` flag is seeded from already-running protocols.
+                if !bfd {
                     bfd = true;
                     spawn_bfd(self);
                 }
@@ -536,10 +519,6 @@ impl ConfigManager {
                         nd = true;
                         spawn_nd(self);
                     }
-                    if !bfd && will_set_bfd {
-                        bfd = true;
-                        spawn_bfd(self);
-                    }
                     spawn_bgp(self);
                 }
                 spawn_isis(self);
@@ -547,14 +526,16 @@ impl ConfigManager {
             if !bgp && op == ConfigOp::Set && line.starts_with("router bgp") {
                 bgp = true;
                 // `spawn_bgp` captures `bfd_client_tx` *and*
-                // `nd_client_tx` by value. ND is always eager (BGP
-                // unnumbered may want it regardless of explicit RA
-                // config). BFD only if this commit will set it.
+                // `nd_client_tx` by value, so both must be live first.
+                // ND is eager (BGP unnumbered may want it regardless of
+                // explicit RA config); BFD is now eager too so a later
+                // `neighbor X bfd` works without a top-level `bfd { … }`
+                // block and regardless of commit order.
                 if !nd {
                     nd = true;
                     spawn_nd(self);
                 }
-                if !bfd && will_set_bfd {
+                if !bfd {
                     bfd = true;
                     spawn_bfd(self);
                 }
@@ -636,8 +617,14 @@ impl ConfigManager {
         }
         // BFD's top-level keyword is `bfd` (FRR-style), not
         // `router <proto>`, so it can't use `proto_in_candidate`.
+        // BFD is now spawned eagerly for BGP / IS-IS, so it must outlive
+        // a removed `bfd { … }` block as long as a consumer remains —
+        // otherwise the consumer's captured handle would dangle. Tear it
+        // down only when neither a `bfd` block nor any consumer is left.
         if self.protocol_tasks.borrow().contains_key("bfd")
             && !candidate.lines().any(|l| l.starts_with("bfd"))
+            && !proto_in_candidate("bgp")
+            && !proto_in_candidate("isis")
         {
             despawn_bfd(self);
         }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -487,6 +487,13 @@ impl ConfigManager {
             // and spawn an OSPFv2 instance for a v3 config block.
             if !ospfv3 && op == ConfigOp::Set && line.starts_with("router ospfv3") {
                 ospfv3 = true;
+                // OSPF captures `bfd_client_tx` by value at spawn, so
+                // bring BFD up first (see the IS-IS arm below for the
+                // full rationale).
+                if !bfd {
+                    bfd = true;
+                    spawn_bfd(self);
+                }
                 spawn_ospfv3(self);
             }
             if !ospf
@@ -495,6 +502,10 @@ impl ConfigManager {
                 && !line.starts_with("router ospfv3")
             {
                 ospf = true;
+                if !bfd {
+                    bfd = true;
+                    spawn_bfd(self);
+                }
                 spawn_ospf(self);
             }
             if !isis && op == ConfigOp::Set && line.starts_with("router isis") {
@@ -625,6 +636,9 @@ impl ConfigManager {
             && !candidate.lines().any(|l| l.starts_with("bfd"))
             && !proto_in_candidate("bgp")
             && !proto_in_candidate("isis")
+            // `proto_in_candidate("ospf")` prefix-matches `router ospfv3`
+            // too, so this one check covers both OSPF versions.
+            && !proto_in_candidate("ospf")
         {
             despawn_bfd(self);
         }

--- a/zebra-rs/src/config/ospf.rs
+++ b/zebra-rs/src/config/ospf.rs
@@ -11,6 +11,9 @@ pub fn spawn_ospf(config: &ConfigManager) {
     // get `"ospf:vrf:<name>"`. `rib_subscriber` + `config.tx` let the
     // default task mint per-VRF RIB subscriptions and (de)register
     // `show ip ospf vrf <name>`.
+    // BFD is eager-spawned before OSPF in `commit_config`, so this
+    // handle is live; threaded in so per-interface `bfd` can subscribe.
+    let bfd_client_tx = config.bfd_client_tx.borrow().clone();
     let ospf = inst::Ospf::<crate::ospf::Ospfv2>::new(
         ctx,
         rib_rx,
@@ -18,6 +21,7 @@ pub fn spawn_ospf(config: &ConfigManager) {
         "ospf".to_string(),
         config.rib_subscriber(),
         config.tx.clone(),
+        bfd_client_tx,
     );
     config.subscribe("ospf", ospf.cm.tx.clone());
     config.subscribe_show("ospf", ospf.show.tx.clone());
@@ -47,6 +51,7 @@ pub fn spawn_ospfv3(config: &ConfigManager) {
     let ctx = ProtoContext::default_table(rib_client);
     // `"ospfv3"` default label; per-VRF children get
     // `"ospfv3:vrf:<name>"`. See `spawn_ospf` for the rationale.
+    let bfd_client_tx = config.bfd_client_tx.borrow().clone();
     let ospf = inst::Ospf::<crate::ospf::Ospfv3>::new(
         ctx,
         rib_rx,
@@ -54,6 +59,7 @@ pub fn spawn_ospfv3(config: &ConfigManager) {
         "ospfv3".to_string(),
         config.rib_subscriber(),
         config.tx.clone(),
+        bfd_client_tx,
     );
     config.subscribe("ospfv3", ospf.cm.tx.clone());
     config.subscribe_show("ospfv3", ospf.show.tx.clone());

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -5,7 +5,7 @@ use super::Ospf;
 use super::OspfLink;
 use super::area::{AreaTypeKind, ExternalMetricType, NssaTranslatorRole, RedistEntry};
 use super::ifsm::{IfsmEvent, ospf_hello_timer};
-use super::link::{OspfAuthMode, OspfNetworkType};
+use super::link::{NbrStateThreshold, OspfAuthMode, OspfNetworkType};
 use super::tracing::{config_tracing_fsm, config_tracing_packet};
 use super::version::{OspfVersion, Ospfv2};
 
@@ -57,6 +57,18 @@ impl Ospf {
             config_ospf_area_redist_connected_metric_type,
         );
         self.ospf_add("/area/interface/enable", config_ospf_interface_enable);
+        self.ospf_add(
+            "/area/interface/bfd/enable",
+            config_ospf_interface_bfd_enable,
+        );
+        self.ospf_add(
+            "/area/interface/bfd/profile",
+            config_ospf_interface_bfd_profile,
+        );
+        self.ospf_add(
+            "/area/interface/bfd/min-neighbor-state",
+            config_ospf_interface_bfd_min_neighbor_state,
+        );
         self.ospf_add(
             "/area/interface/network-type",
             config_ospf_interface_network_type,
@@ -671,6 +683,76 @@ fn config_ospf_interface_hello_interval(
         link.timer.hello = Some(ospf_hello_timer(link));
     }
 
+    Some(())
+}
+
+/// `interface <if> bfd enable <bool>` — attach/detach BFD on this
+/// OSPF interface. Generic over `V` (shared by v2 and v3); reconciles
+/// every neighbor on the link so already-formed adjacencies pick up
+/// the change.
+pub(super) fn config_ospf_interface_bfd_enable<V: OspfVersion>(
+    ospf: &mut Ospf<V>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let enable = args.boolean()?;
+
+    let ifindex = {
+        let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+        link.config.bfd.enable = op.is_set() && enable;
+        link.index
+    };
+    ospf.bfd_reconcile_link(ifindex);
+    Some(())
+}
+
+/// `interface <if> bfd profile <name>` — stored verbatim; profile
+/// resolution into session parameters is a shared follow-up (BGP /
+/// IS-IS defer it too), so no reconcile is needed.
+pub(super) fn config_ospf_interface_bfd_profile<V: OspfVersion>(
+    ospf: &mut Ospf<V>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let profile = args.string()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    link.config.bfd.profile = op.is_set().then_some(profile);
+    Some(())
+}
+
+/// `interface <if> bfd min-neighbor-state <two-way|full>` — the NFSM
+/// state at which the session is started/torn down. Default `two-way`
+/// (FRR-style). Reconciles existing neighbors so a live flip takes
+/// effect immediately.
+pub(super) fn config_ospf_interface_bfd_min_neighbor_state<V: OspfVersion>(
+    ospf: &mut Ospf<V>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let value = args.string()?;
+
+    let threshold = if op.is_set() {
+        match value.as_str() {
+            "full" => NbrStateThreshold::Full,
+            _ => NbrStateThreshold::TwoWay,
+        }
+    } else {
+        NbrStateThreshold::default()
+    };
+
+    let ifindex = {
+        let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+        link.config.bfd.min_neighbor_state = threshold;
+        link.index
+    };
+    ospf.bfd_reconcile_link(ifindex);
     Some(())
 }
 

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -12,8 +12,10 @@
 use super::area::{AreaTypeKind, NssaTranslatorRole};
 use super::config::{
     Callback, apply_link_enable_transition, area_no_summary_set, area_nssa_default_originate_set,
-    area_nssa_suppress_fa_set, area_nssa_translator_role_set, area_type_set, link_should_enable,
-    ospf_link_get_mut_by_name, parse_area_id,
+    area_nssa_suppress_fa_set, area_nssa_translator_role_set, area_type_set,
+    config_ospf_interface_bfd_enable, config_ospf_interface_bfd_min_neighbor_state,
+    config_ospf_interface_bfd_profile, link_should_enable, ospf_link_get_mut_by_name,
+    parse_area_id,
 };
 use super::ifsm::{IfsmEvent, ospf_hello_timer};
 use super::link::OspfNetworkType;
@@ -47,6 +49,18 @@ impl Ospf<Ospfv3> {
                 config_ospfv3_area_nssa_translator_role,
             ),
             ("/area/interface/enable", config_ospfv3_interface_enable),
+            (
+                "/area/interface/bfd/enable",
+                config_ospf_interface_bfd_enable,
+            ),
+            (
+                "/area/interface/bfd/profile",
+                config_ospf_interface_bfd_profile,
+            ),
+            (
+                "/area/interface/bfd/min-neighbor-state",
+                config_ospf_interface_bfd_min_neighbor_state,
+            ),
             (
                 "/area/interface/network-type",
                 config_ospfv3_interface_network_type,

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -256,6 +256,17 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// only): VRF name → (table_id, ifindex). A child spawns once both
     /// config intent (`vrf_log`) and kernel info exist.
     pub rib_known_vrfs: BTreeMap<String, (u32, u32)>,
+
+    /// BFD client handle, captured at spawn (BFD is eager-spawned
+    /// before OSPF). `None` only if BFD failed to start. Used to
+    /// Subscribe / Unsubscribe per-neighbor single-hop sessions; see
+    /// [`Ospf::bfd_reconcile_nbr`].
+    pub bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
+    /// Notifier the BFD instance fans state-change events back on.
+    /// Cloned into every Subscribe; the matching receiver is drained by
+    /// the event loop into [`Ospf::process_bfd_event`].
+    pub bfd_event_tx: UnboundedSender<crate::bfd::inst::BfdEvent>,
+    pub bfd_event_rx: UnboundedReceiver<crate::bfd::inst::BfdEvent>,
 }
 
 // OSPF inteface structure which points out upper layer struct members.
@@ -339,6 +350,153 @@ impl<'a, V: OspfVersion> OspfInterface<'a, V> {
 // the v2-shaped tx channel) and produce `OspfInterface<V>` /
 // `&Neighbor<V>` values typed by `V`.
 impl<V: OspfVersion> Ospf<V> {
+    /// Reconcile one neighbor's BFD subscription against the interface
+    /// config and the neighbor's current NFSM state. Idempotent and
+    /// order-independent: the desired key is compared to the tracked
+    /// `nbr.bfd_session_key`, unsubscribing a stale key before
+    /// subscribing the new one (so a hop-mode/address change or a
+    /// `min-neighbor-state` flip never leaks or duplicates a session).
+    /// OSPF sessions are single-hop (directly connected neighbors); the
+    /// `profile` is stored but not yet applied (the session uses
+    /// `SessionParams::default()`, matching BGP / IS-IS).
+    fn bfd_reconcile_nbr(&mut self, ifindex: u32, nbr_addr: Ipv4Addr) {
+        let desired = {
+            let Some(link) = self.links.get(&ifindex) else {
+                return;
+            };
+            let bfd = &link.config.bfd;
+            let Some(nbr) = link.nbrs.get(&nbr_addr) else {
+                return;
+            };
+            let up = bfd.enable && nbr.state >= bfd.min_neighbor_state.as_nfsm();
+            if up {
+                V::bfd_addrs(&link.addr, nbr).map(|(local, remote)| {
+                    crate::bfd::session::SessionKey {
+                        local,
+                        remote,
+                        ifindex,
+                        multihop: false,
+                    }
+                })
+            } else {
+                None
+            }
+        };
+
+        let current = self
+            .links
+            .get(&ifindex)
+            .and_then(|l| l.nbrs.get(&nbr_addr))
+            .and_then(|n| n.bfd_session_key);
+        if desired == current {
+            return;
+        }
+
+        // Apply the delta against the BFD instance (eager-spawned, so
+        // the handle is normally live). If it's absent, leave the
+        // tracked key untouched so a later reconcile retries.
+        let Some(client_tx) = self.bfd_client_tx.as_ref() else {
+            return;
+        };
+        if let Some(old) = current {
+            let _ = client_tx.send(crate::bfd::inst::ClientReq::Unsubscribe {
+                client: V::PROTO.to_string(),
+                key: old,
+            });
+        }
+        if let Some(key) = desired {
+            let _ = client_tx.send(crate::bfd::inst::ClientReq::Subscribe {
+                client: V::PROTO.to_string(),
+                key,
+                params: crate::bfd::session::SessionParams::default(),
+                notifier: self.bfd_event_tx.clone(),
+            });
+        }
+        if let Some(nbr) = self
+            .links
+            .get_mut(&ifindex)
+            .and_then(|l| l.nbrs.get_mut(&nbr_addr))
+        {
+            nbr.bfd_session_key = desired;
+        }
+    }
+
+    /// Re-evaluate every neighbor on `ifindex` — used by the `bfd`
+    /// interface config callbacks, which can flip the subscribe state
+    /// of already-formed neighbors.
+    pub(crate) fn bfd_reconcile_link(&mut self, ifindex: u32) {
+        let nbrs: Vec<Ipv4Addr> = match self.links.get(&ifindex) {
+            Some(link) => link.nbrs.keys().copied().collect(),
+            None => return,
+        };
+        for nbr_addr in nbrs {
+            self.bfd_reconcile_nbr(ifindex, nbr_addr);
+        }
+    }
+
+    /// React to a BFD session state change. On Down, tear the matching
+    /// OSPF adjacency down via the same dead-timer (`InactivityTimer`)
+    /// path the hold-timer uses (RFC 5882 §5), and drop the
+    /// subscription. The synthetic `from == to` mirror (sent on
+    /// subscribe) and non-Down transitions are ignored.
+    pub(crate) fn process_bfd_event(&mut self, event: crate::bfd::inst::BfdEvent) {
+        let crate::bfd::inst::BfdEvent::StateChange { key, change } = event;
+        tracing::info!(
+            ?key,
+            from = %change.from,
+            to = %change.to,
+            diag = %change.diag,
+            "{}: bfd session state change",
+            V::PROTO,
+        );
+        if change.from == change.to || change.to != bfd_packet::State::Down {
+            return;
+        }
+
+        let ifindex = key.ifindex;
+        let Some(nbr_addr) = self.links.get(&ifindex).and_then(|link| {
+            link.nbrs
+                .iter()
+                .find(|(_, n)| n.bfd_session_key == Some(key))
+                .map(|(addr, _)| *addr)
+        }) else {
+            tracing::debug!(
+                ?key,
+                "{}: bfd-down for unknown neighbor; ignoring",
+                V::PROTO
+            );
+            return;
+        };
+        tracing::warn!(
+            ?key,
+            ifindex,
+            diag = %change.diag,
+            "{}: tearing down adjacency on bfd-down (RFC 5882 §5)",
+            V::PROTO,
+        );
+
+        // Drop the subscription (clear tracked key + unsubscribe), then
+        // drive the neighbor down via the dead-timer event.
+        if let Some(client_tx) = self.bfd_client_tx.as_ref() {
+            let _ = client_tx.send(crate::bfd::inst::ClientReq::Unsubscribe {
+                client: V::PROTO.to_string(),
+                key,
+            });
+        }
+        if let Some(nbr) = self
+            .links
+            .get_mut(&ifindex)
+            .and_then(|l| l.nbrs.get_mut(&nbr_addr))
+        {
+            nbr.bfd_session_key = None;
+        }
+        let _ = self.tx.send(Message::Nfsm(
+            ifindex,
+            nbr_addr,
+            super::nfsm::NfsmEvent::InactivityTimer,
+        ));
+    }
+
     /// Record a rewritten per-VRF config line (default instance only).
     /// Appends to the VRF's replay log and, if its child is already
     /// running, forwards the line live to the child's config inbox.
@@ -644,8 +802,10 @@ impl Ospf<Ospfv2> {
         proto_label: String,
         rib_subscriber: RibSubscriber,
         config_tx: tokio::sync::mpsc::Sender<crate::config::Message>,
+        bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
     ) -> Self {
         let sock = Arc::new(AsyncFd::new(ospf_socket_ipv4(&ctx).unwrap()).unwrap());
+        let (bfd_event_tx, bfd_event_rx) = mpsc::unbounded_channel();
 
         let policy_chan = crate::policy::PolicyRxChannel::new();
         let _ = policy_tx.send(crate::policy::Message::Subscribe {
@@ -707,6 +867,9 @@ impl Ospf<Ospfv2> {
             vrf_log: BTreeMap::new(),
             vrf_registry: BTreeMap::new(),
             rib_known_vrfs: BTreeMap::new(),
+            bfd_client_tx,
+            bfd_event_tx,
+            bfd_event_rx,
         };
         ospf.callback_build();
         ospf.show_build();
@@ -3526,6 +3689,10 @@ impl Ospf<Ospfv2> {
 
                 if let (Some(old_state), Some(new_state)) = (old_state, new_state) {
                     self.process_neighbor_state_change(index, src, old_state, new_state);
+                    // Re-evaluate the BFD session against the configured
+                    // threshold (the reconcile reads the now-current
+                    // neighbor state, so it covers both 2-Way and Full).
+                    self.bfd_reconcile_nbr(index, src);
                 }
             }
             Message::HelloTimer(index) => {
@@ -3723,6 +3890,9 @@ impl Ospf<Ospfv2> {
                 Some(msg) = self.policy_rx.recv() => {
                     self.process_policy_msg(msg);
                 }
+                Some(event) = self.bfd_event_rx.recv() => {
+                    self.process_bfd_event(event);
+                }
             }
         }
     }
@@ -3792,8 +3962,10 @@ impl Ospf<Ospfv3> {
         proto_label: String,
         rib_subscriber: RibSubscriber,
         config_tx: tokio::sync::mpsc::Sender<crate::config::Message>,
+        bfd_client_tx: Option<UnboundedSender<crate::bfd::inst::ClientReq>>,
     ) -> Self {
         let sock = Arc::new(AsyncFd::new(super::socket::ospf_socket_ipv6(&ctx).unwrap()).unwrap());
+        let (bfd_event_tx, bfd_event_rx) = mpsc::unbounded_channel();
 
         let policy_chan = crate::policy::PolicyRxChannel::new();
         let _ = policy_tx.send(crate::policy::Message::Subscribe {
@@ -3878,6 +4050,9 @@ impl Ospf<Ospfv3> {
             vrf_log: BTreeMap::new(),
             vrf_registry: BTreeMap::new(),
             rib_known_vrfs: BTreeMap::new(),
+            bfd_client_tx,
+            bfd_event_tx,
+            bfd_event_rx,
         };
         ospf.callback_build();
         ospf.show_build();
@@ -5297,6 +5472,10 @@ impl Ospf<Ospfv3> {
 
                 if let (Some(old_state), Some(new_state)) = (old_state, new_state) {
                     self.process_neighbor_state_change(index, src, old_state, new_state);
+                    // Re-evaluate the BFD session against the configured
+                    // threshold (the reconcile reads the now-current
+                    // neighbor state, so it covers both 2-Way and Full).
+                    self.bfd_reconcile_nbr(index, src);
                 }
             }
             Message::SpfSchedule(area_id) => {
@@ -6534,6 +6713,9 @@ impl Ospf<Ospfv3> {
                 }
                 Some(msg) = self.policy_rx.recv() => {
                     self.process_policy_msg(msg);
+                }
+                Some(event) = self.bfd_event_rx.recv() => {
+                    self.process_bfd_event(event);
                 }
             }
         }

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -20,7 +20,7 @@ use crate::rib::Link;
 
 use super::addr::OspfAddr;
 use super::version::{OspfVersion, Ospfv2};
-use super::{Identity, IfsmState, Message, Neighbor};
+use super::{Identity, IfsmState, Message, Neighbor, NfsmState};
 use crate::context::Timer;
 
 pub const OSPF_DEFAULT_PRIORITY: u8 = 64;
@@ -122,6 +122,8 @@ pub struct LinkConfig {
     /// `isis::LinkConfig::te_metric`; a future TWAMP/STAMP task will
     /// populate these dynamically.
     pub te_metric: LinkTeMetric,
+    /// Per-interface BFD attachment (zebra-ospf-bfd.yang).
+    pub bfd: OspfLinkBfdConfig,
 }
 
 /// Per-interface RFC 7471 TE link metrics. All delay values are in
@@ -176,6 +178,41 @@ impl LinkTeMetric {
         }
         subs
     }
+}
+
+/// Neighbor-state threshold at which a BFD session is started and torn
+/// down for this interface. `TwoWay` (default, FRR-style) also protects
+/// DR-Other pairs on a broadcast LAN; `Full` (Cisco/IOS-XR-style)
+/// tracks only DR/BDR adjacencies. Identical on point-to-point links,
+/// where the neighbor goes straight to Full.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NbrStateThreshold {
+    #[default]
+    TwoWay,
+    Full,
+}
+
+impl NbrStateThreshold {
+    /// The NFSM state the neighbor must reach (or fall below) for the
+    /// BFD session to be installed (or removed).
+    pub fn as_nfsm(self) -> NfsmState {
+        match self {
+            Self::TwoWay => NfsmState::TwoWay,
+            Self::Full => NfsmState::Full,
+        }
+    }
+}
+
+/// Per-interface BFD attachment recorded from
+/// `router ospf{,v3} area <a> interface <if> bfd { enable | profile |
+/// min-neighbor-state }` (zebra-ospf-bfd.yang). Shared by v2 and v3.
+/// `enable` / `min-neighbor-state` flips drive Subscribe / Unsubscribe
+/// against the BFD instance via `Ospf::bfd_reconcile_link`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct OspfLinkBfdConfig {
+    pub enable: bool,
+    pub profile: Option<String>,
+    pub min_neighbor_state: NbrStateThreshold,
 }
 
 /// OSPFv2 per-interface authentication mode.

--- a/zebra-rs/src/ospf/neigh.rs
+++ b/zebra-rs/src/ospf/neigh.rs
@@ -186,6 +186,13 @@ pub struct Neighbor<V: OspfVersion = Ospfv2> {
     /// packets must carry a seq ≥ this value; smaller values are
     /// dropped as replays. Reset to 0 when the neighbor is created.
     pub auth_md5_last_seq: u32,
+    /// The BFD [`SessionKey`](crate::bfd::session::SessionKey) this
+    /// neighbor currently has a live subscription for, or `None`.
+    /// Runtime bookkeeping (not config): lets `Ospf::bfd_reconcile_nbr`
+    /// unsubscribe the prior key before subscribing a new one when it
+    /// changes, and avoids duplicate subscribes. Mirrors the BGP
+    /// `peer.bfd_session_key` reconcile pattern.
+    pub bfd_session_key: Option<crate::bfd::session::SessionKey>,
 }
 
 #[bitfield(u8, debug = true)]
@@ -277,6 +284,7 @@ where
             interface_id: 0,
             gr_helper: None,
             auth_md5_last_seq: 0,
+            bfd_session_key: None,
         };
         nbr.ident.prefix = prefix;
         nbr

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -232,6 +232,19 @@ pub trait OspfVersion: 'static + Send + Sync + Copy + Clone + PartialEq + Eq {
     where
         Self: Sized;
 
+    /// Build the (local, remote) IP addresses for a single-hop BFD
+    /// session to `nbr` on this interface, or `None` if one can't be
+    /// formed. v2: the interface's primary IPv4 and the neighbor's
+    /// source IPv4. v3: the IPv6 link-local pair — deferred to the
+    /// IPv6-BFD phase, so it returns `None` for now (config is
+    /// accepted but inert).
+    fn bfd_addrs(
+        addrs: &[crate::ospf::addr::OspfAddr<Self>],
+        nbr: &crate::ospf::Neighbor<Self>,
+    ) -> Option<(std::net::IpAddr, std::net::IpAddr)>
+    where
+        Self: Sized;
+
     // ---- IFSM trait accessors ----------------------------------
     //
     // The IFSM is shared verbatim across v2 and v3 (RFC 5340 §4.2.1),
@@ -419,6 +432,15 @@ impl OspfVersion for Ospfv2 {
         ident.prefix.addr()
     }
 
+    fn bfd_addrs(
+        addrs: &[crate::ospf::addr::OspfAddr<Ospfv2>],
+        nbr: &crate::ospf::Neighbor<Ospfv2>,
+    ) -> Option<(std::net::IpAddr, std::net::IpAddr)> {
+        let local = addrs.first()?.prefix.addr();
+        let remote = nbr.ident.prefix.addr();
+        Some((std::net::IpAddr::V4(local), std::net::IpAddr::V4(remote)))
+    }
+
     fn is_declared_dr(ident: &crate::ospf::Identity<Ospfv2>) -> bool {
         ident.prefix.addr() == ident.d_router
     }
@@ -548,6 +570,16 @@ impl OspfVersion for Ospfv3 {
         ident.router_id
     }
 
+    fn bfd_addrs(
+        _addrs: &[crate::ospf::addr::OspfAddr<Ospfv3>],
+        _nbr: &crate::ospf::Neighbor<Ospfv3>,
+    ) -> Option<(std::net::IpAddr, std::net::IpAddr)> {
+        // OSPFv3 BFD runs over IPv6 link-local, which needs IPv6
+        // support in the BFD module first (a later phase). Inert until
+        // then: config is accepted but no session is created.
+        None
+    }
+
     fn is_declared_dr(ident: &crate::ospf::Identity<Ospfv3>) -> bool {
         ident.d_router == ident.router_id
     }
@@ -589,5 +621,78 @@ impl OspfVersion for Ospfv3 {
         nbr: &mut crate::ospf::Neighbor<Ospfv3>,
     ) {
         crate::ospf::nfsm::ospfv3_populate_initial_db_summary(oi, nbr);
+    }
+}
+
+#[cfg(test)]
+mod bfd_tests {
+    use super::{OspfVersion, Ospfv2};
+    use crate::ospf::addr::OspfAddr;
+    use crate::ospf::link::NbrStateThreshold;
+    use crate::ospf::neigh::Neighbor;
+    use crate::ospf::nfsm::NfsmState;
+    use ipnet::Ipv4Net;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::str::FromStr;
+    use tokio::sync::mpsc;
+
+    fn v2_neighbor(remote: &str) -> Neighbor<Ospfv2> {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let (ptx, _prx) = mpsc::unbounded_channel();
+        Neighbor::<Ospfv2>::new(
+            tx,
+            3,
+            Ipv4Net::from_str(remote).unwrap(),
+            &Ipv4Addr::new(2, 2, 2, 2),
+            40,
+            ptx,
+        )
+    }
+
+    /// v2 pairs the interface's primary IPv4 (local) with the
+    /// neighbor's source IPv4 (remote) for a single-hop session.
+    #[test]
+    fn bfd_addrs_v2_pairs_local_and_remote() {
+        let nbr = v2_neighbor("10.0.0.2/24");
+        let local = OspfAddr::<Ospfv2> {
+            prefix: Ipv4Net::from_str("10.0.0.1/24").unwrap(),
+        };
+        assert_eq!(
+            Ospfv2::bfd_addrs(&[local], &nbr),
+            Some((
+                IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            )),
+        );
+    }
+
+    /// No local address on the interface ⇒ no session can be formed.
+    #[test]
+    fn bfd_addrs_v2_none_without_local() {
+        let nbr = v2_neighbor("10.0.0.2/24");
+        assert_eq!(Ospfv2::bfd_addrs(&[], &nbr), None);
+    }
+
+    /// `two-way` (default) covers 2-Way and Full but not Init/Down —
+    /// the FRR-style threshold that protects DR-Other pairs.
+    #[test]
+    fn two_way_threshold_semantics() {
+        assert_eq!(NbrStateThreshold::default(), NbrStateThreshold::TwoWay);
+        let t = NbrStateThreshold::TwoWay.as_nfsm();
+        assert_eq!(t, NfsmState::TwoWay);
+        assert!(NfsmState::TwoWay >= t);
+        assert!(NfsmState::Full >= t);
+        assert!(NfsmState::Init < t);
+        assert!(NfsmState::Down < t);
+    }
+
+    /// `full` (Cisco-style) excludes 2-Way; only Full qualifies.
+    #[test]
+    fn full_threshold_semantics() {
+        let t = NbrStateThreshold::Full.as_nfsm();
+        assert_eq!(t, NfsmState::Full);
+        assert!(NfsmState::Full >= t);
+        assert!(NfsmState::Loading < t);
+        assert!(NfsmState::TwoWay < t);
     }
 }

--- a/zebra-rs/src/ospf/vrf.rs
+++ b/zebra-rs/src/ospf/vrf.rs
@@ -117,6 +117,9 @@ pub fn spawn_ospf_vrf_v2(
         proto.clone(),
         rib_subscriber.clone(),
         config_tx.clone(),
+        // Per-VRF OSPF BFD is deferred (the BFD instance is default-table
+        // only); `None` makes per-interface `bfd` inert in a VRF for now.
+        None,
     );
     let cm_tx = ospf.cm.tx.clone();
     let show_tx = ospf.show.tx.clone();
@@ -144,6 +147,8 @@ pub fn spawn_ospf_vrf_v3(
         proto.clone(),
         rib_subscriber.clone(),
         config_tx.clone(),
+        // Per-VRF OSPFv3 BFD deferred (see `spawn_ospf_vrf_v2`).
+        None,
     );
     let cm_tx = ospf.cm.tx.clone();
     let show_tx = ospf.show.tx.clone();

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -56,6 +56,10 @@ module config {
     prefix zbb;
   }
 
+  import zebra-ospf-bfd {
+    prefix zob;
+  }
+
   import zebra-bgp-color-policy {
     prefix zbcp;
   }

--- a/zebra-rs/yang/zebra-ospf-bfd.yang
+++ b/zebra-rs/yang/zebra-ospf-bfd.yang
@@ -1,0 +1,135 @@
+module zebra-ospf-bfd {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-ospf-bfd";
+  prefix "zob";
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "FRR-style per-interface BFD attachment for OSPFv2 and OSPFv3. Adds
+     a flat `bfd` container under each OSPF interface:
+
+       router ospf {
+         area 0 {
+           interface eth0 {
+             bfd {
+               enable true;
+               min-neighbor-state two-way;
+             }
+           }
+         }
+       }
+
+     When `enable` is true the OSPF instance attaches a single-hop BFD
+     session to each neighbor on the interface once it reaches the
+     configured `min-neighbor-state`; a session going Down tears the
+     adjacency down (RFC 5882 §5). OSPF neighbors are directly
+     connected, so the session is always single-hop (UDP/3784, GTSM
+     TTL=255) — there is no multihop knob.
+
+     OSPFv3 BFD runs over IPv6 link-local; the config is accepted for
+     v3 but inert until IPv6 support lands in the BFD module.";
+
+  revision 2026-05-31 {
+    description "Initial revision — per-interface BFD for OSPFv2/v3.";
+    reference
+      "RFC 5880, RFC 5881 (single-hop), RFC 5882 (failure response).
+       FRR `ip ospf bfd`; Cisco IOS-XR `bfd fast-detect` under ospf.";
+  }
+
+  grouping ospf-interface-bfd-extension {
+    description
+      "FRR-style flat `bfd { ... }` block on an OSPF interface.";
+
+    container bfd {
+      ext:help "BFD attachment for this OSPF interface";
+      description
+        "When `enable` is true, OSPF attaches a single-hop BFD session
+         to each neighbor on this interface. A session going Down
+         tears the adjacency down.";
+
+      leaf enable {
+        ext:help "Activate BFD on this interface";
+        type boolean;
+        default false;
+        description
+          "Activates BFD for neighbors on this interface. Disabling
+           (or removing the `bfd` block) detaches the sessions.";
+      }
+
+      leaf profile {
+        ext:help "Named /bfd/profile to apply (stored; not yet applied)";
+        type string;
+        description
+          "Name of a `/bfd/profile` entry whose parameters apply to
+           this interface's BFD sessions. Stored but not yet resolved
+           into session parameters — a shared follow-up across BGP /
+           IS-IS / OSPF; sessions currently use the BFD defaults.";
+      }
+
+      leaf min-neighbor-state {
+        ext:help "Neighbor state at which BFD starts (two-way|full)";
+        type enumeration {
+          enum two-way {
+            description
+              "Start/stop the session at the 2-Way neighbor state
+               (default, FRR-style). Also protects DR-Other pairs on
+               a broadcast LAN.";
+          }
+          enum full {
+            description
+              "Start/stop the session at the Full neighbor state
+               (Cisco/IOS-XR-style). Tracks only DR/BDR adjacencies
+               on a broadcast LAN.";
+          }
+        }
+        default two-way;
+        description
+          "OSPF neighbor state at which the BFD session is started and
+           torn down. Identical on point-to-point links, where the
+           neighbor goes straight to Full.";
+      }
+    }
+  }
+
+  augment "/configure:set/config:router"
+        + "/config:ospf/config:area/config:interface" {
+    description "Attach the bfd block to OSPFv2 interfaces (set).";
+    uses ospf-interface-bfd-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/config:ospf/config:area/config:interface" {
+    description "Attach the bfd block to OSPFv2 interfaces (delete).";
+    uses ospf-interface-bfd-extension;
+  }
+
+  augment "/configure:set/config:router"
+        + "/config:ospfv3/config:area/config:interface" {
+    description "Attach the bfd block to OSPFv3 interfaces (set).";
+    uses ospf-interface-bfd-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/config:ospfv3/config:area/config:interface" {
+    description "Attach the bfd block to OSPFv3 interfaces (delete).";
+    uses ospf-interface-bfd-extension;
+  }
+}


### PR DESCRIPTION
Two stacked commits.

## 1. `config: spawn BFD eagerly before BGP / IS-IS`

Fixes the BFD launch-order dependency: BGP and IS-IS capture `bfd_client_tx` by value at spawn, so if BFD spawned later (different commit, or below `router bgp`/`router isis`) the handle stayed `None` and every `neighbor X bfd` / `isis bfd` was a silent no-op. Now BFD is spawned eagerly **before** its consumers (idempotent — the `bfd` flag is seeded from already-running protocols), so the handle is always live regardless of commit order, and `neighbor X bfd` works without a top-level `bfd { }` block (matching FRR). Despawn is guarded so BFD outlives a removed `bfd { }` block while a consumer still runs.

## 2. `ospf: support BFD for OSPFv2 (configurable trigger)`

Per-interface BFD on OSPF interfaces (`zebra-ospf-bfd.yang`, generic over v2/v3):

```
router ospf {
  area 0 {
    interface eth0 {
      bfd { enable true; min-neighbor-state two-way; }
    }
  }
}
```

- **Configurable trigger:** `min-neighbor-state two-way` (default, FRR-style — covers DR-Other pairs on a LAN) or `full` (Cisco/IOS-XR-style). Identical on point-to-point links.
- **Subscribe/unsubscribe:** `Ospf::bfd_reconcile_nbr` (generic over `V`) runs from the `Nfsm` handler on every state change and from the config callbacks; tracks a per-neighbor `bfd_session_key` so flips never leak/duplicate. Single-hop key built via the new `OspfVersion::bfd_addrs` trait method.
- **Teardown:** `process_bfd_event` drives the neighbor down via the dead-timer (`InactivityTimer`) path on BFD-Down (RFC 5882 §5).
- `bfd_client_tx` threaded into `Ospf<V>::new`; BFD eager-spawned before OSPF/OSPFv3.

### Deferred (by design)
- **OSPFv3 sessions:** config is accepted but `Ospfv3::bfd_addrs` returns `None` — it needs IPv6 support in the BFD module (a later phase), then a small v3 flip. v2 is fully functional.
- Per-VRF OSPF BFD (passes `None`); OSPF-side `show` columns (sessions already appear in `show bfd` with client `ospf`); profile application (stored-only, shared follow-up); FRR interop validation.

## Test plan
- `cargo build` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo fmt --check` — clean
- `cargo test -p zebra-rs` — **813 passed** (incl. new: `bfd_addrs` v2, two-way/full threshold semantics)
- `yang_load_tests` pass (the v2 augment target is byte-identical to the merged `zebra-ospf-auth-simple`)

Generated with [Claude Code](https://claude.com/claude-code)