### PR TITLE
bfd: IPv6 support (sockets, recv/send loops, demux)

### DIFF
--- a/zebra-rs/src/bfd/inst.rs
+++ b/zebra-rs/src/bfd/inst.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
-use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::sync::Arc;
 
 use tokio::io::unix::AsyncFd;
@@ -12,9 +12,9 @@ use crate::context::{ProtoContext, Task};
 
 use super::config::{BfdConfig, Callback};
 use super::fsm::Event;
-use super::network::{WriteRequest, read_packet, write_packet};
+use super::network::{WriteRequest, read_packet, read_packet_v6, write_packet, write_packet_v6};
 use super::session::{Session, SessionKey, SessionParams, SessionTable, StateChange};
-use super::socket::{BFD_MULTI_HOP_PORT, BFD_SINGLE_HOP_PORT, bfd_socket_ipv4};
+use super::socket::{BFD_MULTI_HOP_PORT, BFD_SINGLE_HOP_PORT, bfd_socket_ipv4, bfd_socket_ipv6};
 use super::timer::{InitialParams, TimerCmd, session_timer};
 
 /// Identifier for a BFD subscriber. Conventionally the proto name
@@ -71,6 +71,11 @@ pub struct Bfd {
     subscribers: HashMap<SessionKey, BTreeMap<ClientId, UnboundedSender<BfdEvent>>>,
     main_tx: UnboundedSender<Message>,
     write_tx: UnboundedSender<WriteRequest>,
+    /// Egress channel for IPv6 sessions, drained by `write_packet_v6`
+    /// on the v6 socket. `on_tx_tick` routes by the session's remote
+    /// address family. Sends are dropped if the v6 listener never came
+    /// up (the receiver is gone) — v6 simply doesn't work in that case.
+    write_tx_v6: UnboundedSender<WriteRequest>,
     timer_handles: HashMap<SessionKey, TimerHandle>,
 }
 
@@ -133,7 +138,7 @@ pub enum Message {
     /// after the packet is demuxed to a session.
     Recv {
         packet: bfd_packet::ControlPacket,
-        src: SocketAddrV4,
+        src: SocketAddr,
         dst: Option<IpAddr>,
         ifindex: u32,
         ttl: u8,
@@ -178,6 +183,7 @@ impl Bfd {
 
         let (main_tx, rx) = mpsc::unbounded_channel::<Message>();
         let (write_tx, write_rx) = mpsc::unbounded_channel::<WriteRequest>();
+        let (write_tx_v6, write_rx_v6) = mpsc::unbounded_channel::<WriteRequest>();
 
         let read_sock = sock.clone();
         let read_tx = main_tx.clone();
@@ -218,6 +224,54 @@ impl Bfd {
             }
         }
 
+        // IPv6 listeners (RFC 5881/5883 reuse the same ports on the v6
+        // transport; `IPV6_V6ONLY` keeps them off the v4 sockets). The
+        // 3784 socket is shared TX+RX (drains `write_rx_v6`); 4784 is
+        // RX-only. Non-fatal: v4 keeps working if v6 is unavailable.
+        // Gated on the well-known bind so ephemeral-port test instances
+        // don't open them.
+        if bind.port() == BFD_SINGLE_HOP_PORT {
+            match bfd_socket_ipv6(
+                &ctx,
+                SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, BFD_SINGLE_HOP_PORT, 0, 0),
+            )
+            .and_then(AsyncFd::new)
+            {
+                Ok(sock6) => {
+                    let sock6 = Arc::new(sock6);
+                    let read_sock = sock6.clone();
+                    let read_tx = main_tx.clone();
+                    tokio::spawn(async move {
+                        read_packet_v6(read_sock, read_tx).await;
+                    });
+                    tokio::spawn(async move {
+                        write_packet_v6(sock6, write_rx_v6).await;
+                    });
+                }
+                Err(e) => tracing::warn!(
+                    "bfd: IPv6 single-hop listener on {BFD_SINGLE_HOP_PORT} unavailable, \
+                     IPv4 only: {e}"
+                ),
+            }
+            match bfd_socket_ipv6(
+                &ctx,
+                SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, BFD_MULTI_HOP_PORT, 0, 0),
+            )
+            .and_then(AsyncFd::new)
+            {
+                Ok(mh6) => {
+                    let mh6 = Arc::new(mh6);
+                    let mh_tx = main_tx.clone();
+                    tokio::spawn(async move {
+                        read_packet_v6(mh6, mh_tx).await;
+                    });
+                }
+                Err(e) => tracing::warn!(
+                    "bfd: IPv6 multihop listener on {BFD_MULTI_HOP_PORT} unavailable: {e}"
+                ),
+            }
+        }
+
         let mut bfd = Self {
             rx,
             sessions: SessionTable::new(),
@@ -231,6 +285,7 @@ impl Bfd {
             subscribers: HashMap::new(),
             main_tx,
             write_tx,
+            write_tx_v6,
             timer_handles: HashMap::new(),
         };
         bfd.callback_build();
@@ -398,7 +453,7 @@ impl Bfd {
     fn on_recv(
         &mut self,
         packet: bfd_packet::ControlPacket,
-        src: SocketAddrV4,
+        src: SocketAddr,
         dst: Option<IpAddr>,
         ifindex: u32,
         ttl: u8,
@@ -478,8 +533,8 @@ impl Bfd {
     /// Linear scan — fine for the small session counts a single
     /// process maintains; an explicit (local, remote, ifindex) index
     /// can be added later if it shows up in profiles.
-    fn bootstrap_lookup(&self, src: SocketAddrV4, ifindex: u32) -> Option<SessionKey> {
-        let src_ip = IpAddr::V4(*src.ip());
+    fn bootstrap_lookup(&self, src: SocketAddr, ifindex: u32) -> Option<SessionKey> {
+        let src_ip = src.ip();
         self.sessions.iter().find_map(|(_, s)| {
             let ifindex_match = s.key.ifindex == 0 || s.key.ifindex == ifindex;
             if s.key.remote == src_ip && ifindex_match {
@@ -494,17 +549,22 @@ impl Bfd {
         let Some(session) = self.sessions.get_by_key(&key) else {
             return;
         };
-        let IpAddr::V4(remote) = session.key.remote else {
-            // IPv6 not yet supported.
-            return;
-        };
-        let dst = SocketAddrV4::new(remote, session.dst_port);
+        let dst = SocketAddr::new(session.key.remote, session.dst_port);
         let ifindex = (session.key.ifindex != 0).then_some(session.key.ifindex);
-        let _ = self.write_tx.send(WriteRequest {
+        let req = WriteRequest {
             packet: session.build_packet(),
             dst,
             ifindex,
-        });
+        };
+        // Route to the egress loop matching the destination family.
+        match session.key.remote {
+            IpAddr::V4(_) => {
+                let _ = self.write_tx.send(req);
+            }
+            IpAddr::V6(_) => {
+                let _ = self.write_tx_v6.send(req);
+            }
+        }
     }
 
     fn on_detect_expired(&mut self, key: SessionKey) {
@@ -598,7 +658,7 @@ mod tests {
             your_disc: disc,
             ..bfd_packet::ControlPacket::default()
         };
-        let src = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 8), 49152);
+        let src = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 8), 49152));
         bfd.on_recv(packet, src, None, 0, 254); // single-hop requires 255
 
         let session = bfd.sessions.get_by_key(&key).unwrap();
@@ -629,7 +689,7 @@ mod tests {
             your_disc: disc,
             ..bfd_packet::ControlPacket::default()
         };
-        let src = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 9), 49152);
+        let src = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 9), 49152));
         bfd.on_recv(packet, src, None, 0, 254); // == floor ⇒ accepted
 
         let session = bfd.sessions.get_by_key(&key).unwrap();

--- a/zebra-rs/src/bfd/network.rs
+++ b/zebra-rs/src/bfd/network.rs
@@ -1,10 +1,10 @@
 use std::io::{ErrorKind, IoSlice, IoSliceMut};
-use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::os::fd::AsRawFd;
 use std::sync::Arc;
 
 use bytes::BytesMut;
-use nix::sys::socket::{self, ControlMessageOwned, SockaddrIn};
+use nix::sys::socket::{self, ControlMessageOwned, SockaddrIn, SockaddrIn6};
 use socket2::Socket;
 use tokio::io::Interest;
 use tokio::io::unix::AsyncFd;
@@ -12,15 +12,16 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use super::inst::Message;
 
-/// Egress request consumed by [`write_packet`]. The event loop pushes
-/// these whenever a [`super::timer::TimerEvent::TxTick`] fires (or in
-/// future PRs, when a poll-sequence packet must be sent off-schedule).
+/// Egress request consumed by [`write_packet`] (v4) / [`write_packet_v6`]
+/// (v6). The event loop pushes these whenever a
+/// [`super::timer::TimerEvent::TxTick`] fires; `on_tx_tick` routes to the
+/// channel matching `dst`'s address family.
 #[derive(Debug)]
 pub struct WriteRequest {
     pub packet: bfd_packet::ControlPacket,
-    pub dst: SocketAddrV4,
-    /// Optional egress ifindex (sent via `IP_PKTINFO`). `None` lets
-    /// the kernel route normally.
+    pub dst: SocketAddr,
+    /// Optional egress ifindex (sent via `IP_PKTINFO` / `IPV6_PKTINFO`).
+    /// `None` lets the kernel route normally.
     pub ifindex: Option<u32>,
 }
 
@@ -49,7 +50,7 @@ pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message
                 let Some(src) = msg.address else {
                     return Err(ErrorKind::AddrNotAvailable.into());
                 };
-                let src = SocketAddrV4::new(src.ip(), src.port());
+                let src = SocketAddr::V4(SocketAddrV4::new(src.ip(), src.port()));
 
                 let mut dst: Option<Ipv4Addr> = None;
                 let mut ifindex: u32 = 0;
@@ -101,10 +102,15 @@ pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message
 /// interface; otherwise the kernel routes normally.
 pub async fn write_packet(sock: Arc<AsyncFd<Socket>>, mut rx: UnboundedReceiver<WriteRequest>) {
     while let Some(req) = rx.recv().await {
+        let SocketAddr::V4(dst) = req.dst else {
+            // Routed to the wrong (v4) loop — `on_tx_tick` shouldn't do
+            // this, but never send a v6 destination on the v4 socket.
+            continue;
+        };
         let mut buf = BytesMut::new();
         req.packet.emit(&mut buf);
         let iov = [IoSlice::new(&buf)];
-        let sockaddr: SockaddrIn = req.dst.into();
+        let sockaddr: SockaddrIn = dst.into();
 
         let pktinfo = req.ifindex.map(|ifindex| libc::in_pktinfo {
             ipi_ifindex: ifindex as i32,
@@ -135,6 +141,118 @@ pub async fn write_packet(sock: Arc<AsyncFd<Socket>>, mut rx: UnboundedReceiver<
     }
 }
 
+/// IPv6 sibling of [`read_packet`]. Recovers the received Hop Limit
+/// (via `IPV6_RECVHOPLIMIT`) and ingress ifindex (via
+/// `IPV6_RECVPKTINFO`) and forwards survivors as [`Message::Recv`] with
+/// a v6 `src`. The Hop-Limit floor is enforced after demux in
+/// [`super::inst::Bfd::on_recv`], same as v4.
+pub async fn read_packet_v6(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message>) {
+    let mut buf = [0u8; 1500];
+    let mut iov = [IoSliceMut::new(&mut buf)];
+    let mut cmsgspace = nix::cmsg_space!(libc::in6_pktinfo, libc::c_int);
+
+    loop {
+        let _ = sock
+            .async_io(Interest::READABLE, |sock| {
+                let msg = socket::recvmsg::<SockaddrIn6>(
+                    sock.as_raw_fd(),
+                    &mut iov,
+                    Some(&mut cmsgspace),
+                    socket::MsgFlags::empty(),
+                )?;
+
+                let Some(src6) = msg.address else {
+                    return Err(ErrorKind::AddrNotAvailable.into());
+                };
+                let src = SocketAddr::V6(SocketAddrV6::new(
+                    src6.ip(),
+                    src6.port(),
+                    src6.flowinfo(),
+                    src6.scope_id(),
+                ));
+
+                let mut dst: Option<Ipv6Addr> = None;
+                let mut ifindex: u32 = 0;
+                let mut hop_limit: u8 = 0;
+                for cmsg in msg.cmsgs()? {
+                    match cmsg {
+                        ControlMessageOwned::Ipv6PacketInfo(pi) => {
+                            dst = Some(Ipv6Addr::from(pi.ipi6_addr.s6_addr));
+                            ifindex = pi.ipi6_ifindex;
+                        }
+                        ControlMessageOwned::Ipv6HopLimit(v) => hop_limit = v.clamp(0, 255) as u8,
+                        _ => {}
+                    }
+                }
+
+                let Some(payload) = msg.iovs().next() else {
+                    return Err(ErrorKind::UnexpectedEof.into());
+                };
+
+                let packet = match bfd_packet::ControlPacket::parse(payload) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        tracing::debug!(?src, error = %e, "bfd: invalid control packet");
+                        return Ok(());
+                    }
+                };
+
+                let _ = tx.send(Message::Recv {
+                    packet,
+                    src,
+                    dst: dst.map(IpAddr::V6),
+                    ifindex,
+                    ttl: hop_limit,
+                });
+                Ok(())
+            })
+            .await;
+    }
+}
+
+/// IPv6 sibling of [`write_packet`]. The outgoing Hop Limit is fixed to
+/// 255 by the socket option in [`super::socket::bfd_socket_ipv6`]. When
+/// `WriteRequest::ifindex` is `Some`, an `IPV6_PKTINFO` ancillary
+/// message pins egress to that interface — mandatory for link-local
+/// destinations.
+pub async fn write_packet_v6(sock: Arc<AsyncFd<Socket>>, mut rx: UnboundedReceiver<WriteRequest>) {
+    while let Some(req) = rx.recv().await {
+        let SocketAddr::V6(dst) = req.dst else {
+            continue;
+        };
+        let mut buf = BytesMut::new();
+        req.packet.emit(&mut buf);
+        let iov = [IoSlice::new(&buf)];
+        let sockaddr: SockaddrIn6 = dst.into();
+
+        let pktinfo = req.ifindex.map(|ifindex| libc::in6_pktinfo {
+            ipi6_addr: libc::in6_addr { s6_addr: [0u8; 16] },
+            ipi6_ifindex: ifindex,
+        });
+        let cmsg_storage;
+        let cmsgs: &[socket::ControlMessage<'_>] = if let Some(ref pi) = pktinfo {
+            cmsg_storage = [socket::ControlMessage::Ipv6PacketInfo(pi)];
+            &cmsg_storage
+        } else {
+            &[]
+        };
+
+        let _ = sock
+            .async_io(Interest::WRITABLE, |sock| {
+                socket::sendmsg(
+                    sock.as_raw_fd(),
+                    &iov,
+                    cmsgs,
+                    socket::MsgFlags::empty(),
+                    Some(&sockaddr),
+                )
+                .map_err(std::io::Error::from)?;
+                Ok(())
+            })
+            .await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use bfd_packet::{ControlPacket, State};
@@ -143,7 +261,7 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::*;
-    use crate::bfd::socket::bfd_socket_ipv4;
+    use crate::bfd::socket::{bfd_socket_ipv4, bfd_socket_ipv6};
     use crate::context::ProtoContext;
 
     fn loopback_recv_socket() -> (Arc<AsyncFd<Socket>>, u16) {
@@ -151,6 +269,32 @@ mod tests {
         let sock = bfd_socket_ipv4(&ctx, SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)).unwrap();
         let port = sock.local_addr().unwrap().as_socket_ipv4().unwrap().port();
         (Arc::new(AsyncFd::new(sock).unwrap()), port)
+    }
+
+    fn loopback_recv_socket_v6() -> (Arc<AsyncFd<Socket>>, u16) {
+        let ctx = ProtoContext::default_table_no_rib();
+        let sock = bfd_socket_ipv6(&ctx, SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0)).unwrap();
+        let port = sock.local_addr().unwrap().as_socket_ipv6().unwrap().port();
+        (Arc::new(AsyncFd::new(sock).unwrap()), port)
+    }
+
+    fn send_raw_v6(buf: &[u8], dst_port: u16, hops: u32) {
+        let sock = Socket::new(
+            socket2::Domain::IPV6,
+            socket2::Type::DGRAM,
+            Some(socket2::Protocol::UDP),
+        )
+        .unwrap();
+        sock.set_unicast_hops_v6(hops).unwrap();
+        sock.bind(&SockAddr::from(SocketAddrV6::new(
+            Ipv6Addr::LOCALHOST,
+            0,
+            0,
+            0,
+        )))
+        .unwrap();
+        let dst = SocketAddrV6::new(Ipv6Addr::LOCALHOST, dst_port, 0, 0);
+        sock.send_to(buf, &SockAddr::from(dst)).unwrap();
     }
 
     fn send_raw(buf: &[u8], dst_port: u16, ttl: u32) {
@@ -228,6 +372,45 @@ mod tests {
             panic!("expected Recv, got {got:?}");
         };
         assert_eq!(ttl, 1, "received TTL is carried up, not dropped here");
+
+        read_handle.abort();
+    }
+
+    /// End-to-end IPv6 loopback: bind an ephemeral v6 receive socket via
+    /// `bfd_socket_ipv6`, send a packet over ::1 with Hop Limit=255, and
+    /// verify `read_packet_v6` delivers a `Message::Recv` with a v6 `src`
+    /// and the received hop limit carried in `ttl`.
+    #[tokio::test]
+    async fn loopback_recv_one_packet_v6() {
+        let (sock, port) = loopback_recv_socket_v6();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let read_handle = tokio::spawn(async move { read_packet_v6(sock, tx).await });
+
+        let packet = ControlPacket {
+            state: State::Down,
+            my_disc: 0x6666_7777,
+            ..ControlPacket::default()
+        };
+        let mut wire = BytesMut::new();
+        packet.emit(&mut wire);
+        send_raw_v6(&wire, port, 255);
+
+        let got = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("recv timed out")
+            .expect("channel closed");
+        let Message::Recv {
+            packet: rx_packet,
+            src,
+            ttl,
+            ..
+        } = got
+        else {
+            panic!("expected Recv, got {got:?}");
+        };
+        assert_eq!(rx_packet, packet);
+        assert!(src.is_ipv6(), "src carries the v6 family, got {src:?}");
+        assert_eq!(ttl, 255, "received hop limit is carried up");
 
         read_handle.abort();
     }

--- a/zebra-rs/src/bfd/socket.rs
+++ b/zebra-rs/src/bfd/socket.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddrV4;
+use std::net::{SocketAddrV4, SocketAddrV6};
 use std::os::fd::AsRawFd;
 use std::os::raw::c_int;
 
@@ -72,6 +72,64 @@ fn set_ipv4_pktinfo(socket: &Socket) -> std::io::Result<()> {
             socket.as_raw_fd(),
             libc::IPPROTO_IP,
             libc::IP_PKTINFO,
+            &on as *const _ as *const libc::c_void,
+            std::mem::size_of::<c_int>() as libc::socklen_t,
+        )
+    };
+    if rc < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Build an IPv6 UDP socket for BFD control packets. RFC 5881 §4 /
+/// RFC 5883 §5 use the same well-known ports on the v6 transport, so
+/// this is bound with `IPV6_V6ONLY` to avoid shadowing the v4 socket
+/// on the same port. Mirrors [`bfd_socket_ipv4`]:
+///   * send with Hop Limit = 255 (GTSM on egress);
+///   * report the received Hop Limit via `IPV6_RECVHOPLIMIT` so the
+///     receive path can enforce GTSM after demux;
+///   * report destination + ingress ifindex via `IPV6_RECVPKTINFO`
+///     so link-local sessions (which overlap across interfaces) can be
+///     demultiplexed by `(remote, ifindex)`.
+pub fn bfd_socket_ipv6(ctx: &ProtoContext, bind: SocketAddrV6) -> std::io::Result<Socket> {
+    let socket = ctx.udp_socket_unbound(Domain::IPV6)?;
+
+    socket.set_nonblocking(true)?;
+    socket.set_reuse_address(true)?;
+    socket.set_only_v6(true)?;
+    socket.set_unicast_hops_v6(255)?; // GTSM: every outgoing packet leaves with Hop Limit=255
+    set_ipv6_recvhoplimit(&socket)?;
+    set_ipv6_recvpktinfo(&socket)?;
+
+    socket.bind(&bind.into())?;
+    Ok(socket)
+}
+
+fn set_ipv6_recvhoplimit(socket: &Socket) -> std::io::Result<()> {
+    let on: c_int = 1;
+    let rc = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            libc::IPV6_RECVHOPLIMIT,
+            &on as *const _ as *const libc::c_void,
+            std::mem::size_of::<c_int>() as libc::socklen_t,
+        )
+    };
+    if rc < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn set_ipv6_recvpktinfo(socket: &Socket) -> std::io::Result<()> {
+    let on: c_int = 1;
+    let rc = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            libc::IPV6_RECVPKTINFO,
             &on as *const _ as *const libc::c_void,
             std::mem::size_of::<c_int>() as libc::socklen_t,
         )


### PR DESCRIPTION
## Summary

Adds the IPv6 transport to the BFD module. Previously BFD was IPv4-only (`bfd_socket_ipv4`, `SockaddrIn`, `on_recv`/`on_tx_tick` rejected v6), so any v6 `SessionKey` was a no-op. This makes v6 sessions work end-to-end.

- **socket:** `bfd_socket_ipv6` — `IPV6_V6ONLY` (so it doesn't shadow the v4 sockets on the same ports), Hop-Limit 255 on egress (GTSM), `IPV6_RECVHOPLIMIT` + `IPV6_RECVPKTINFO` on ingress.
- **network:** `WriteRequest.dst` → family-agnostic `SocketAddr`; new `read_packet_v6` (SockaddrIn6 + `Ipv6PacketInfo`/`Ipv6HopLimit` cmsgs, demux by `(remote, ifindex)`) and `write_packet_v6` (`IPV6_PKTINFO` pins egress ifindex — mandatory for link-local destinations); `write_packet` downcasts to V4.
- **inst:** `Message::Recv.src` → `SocketAddr`; `on_recv`/`bootstrap_lookup` generalized; `on_tx_tick` routes to the v4 or v6 write loop by remote family; new `write_tx_v6` channel; `new_with` spawns the v6 listeners (3784 RX+TX, 4784 RX) with a **non-fatal fallback** (v4 keeps working if v6 is unavailable).

The hop-limit floor check (`ttl < min_ttl` in `on_recv`) was already family-agnostic, so single-hop GTSM and multihop floors apply to v6 unchanged.

## What this unblocks
- **IPv6 BGP BFD** — BGP already builds v6 `SessionKey`s for IPv6 neighbors; they now function (single-hop and multihop).
- **OSPFv3 BFD (next phase)** — reduces to implementing `Ospfv3::bfd_addrs` (returns the link-local pair instead of `None`); the OSPF wiring is already generic.

## Test plan
- `cargo build` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo fmt --check` — clean
- `cargo test -p zebra-rs` — **814 passed** (incl. new `loopback_recv_one_packet_v6`: real `::1` socket → v6 `Message::Recv` with the hop limit carried up)

Generated with [Claude Code](https://claude.com/claude-code)