### PR TITLE
ospf: BFD for OSPFv3 + BFD documentation

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -20,11 +20,18 @@
   - [L3VPN over an SRv6 Underlay](ch-02-05-bgp-l3vpn-srv6.md)
   - [EVPN Type-5 (IP Prefix Routes)](ch-02-06-bgp-evpn-type5.md)
   - [Route Target Constraint (RTC)](ch-02-07-bgp-rtc.md)
+  - [BFD](ch-02-08-bgp-bfd.md)
 - [IS-IS](ch-07-00-isis.md)
   - [Timer Configuration](ch-07-01-isis-timers.md)
   - [Shared Risk Link Group (SRLG)](ch-07-02-isis-srlg.md)
+  - [BFD](ch-07-03-isis-bfd.md)
 - [OSPFv2](ch-08-00-ospf.md)
   - [Configuration](ch-08-01-ospf-configuration.md)
+  - [BFD](ch-08-02-ospf-bfd.md)
+
+## Failure Detection
+
+- [Bidirectional Forwarding Detection (BFD)](ch-10-00-bfd.md)
 
 ## Performance Measurement
 

--- a/book/src/ch-02-08-bgp-bfd.md
+++ b/book/src/ch-02-08-bgp-bfd.md
@@ -1,0 +1,83 @@
+# BGP BFD
+
+BGP attaches a [BFD](ch-10-00-bfd.md) session to a neighbour so that a
+forwarding-path failure brings the peering down in sub-second time
+rather than waiting for the BGP hold timer. When the session drops,
+BGP sends the neighbour's FSM a `Stop` (RFC 5882 §5).
+
+See the [BFD overview](ch-10-00-bfd.md) for the session model, the
+single- vs multi-hop transport, and the `show bfd` commands. This
+section covers only the BGP-side configuration.
+
+## Enabling BFD on a neighbour
+
+BFD is a flat block under the neighbour. The minimal form is just
+`enable`:
+
+```
+router bgp {
+  neighbor 10.0.0.2 {
+    remote-as 65002;
+    bfd { enable true; }
+  }
+}
+```
+
+No top-level `bfd { }` block is required — the BFD subsystem starts
+automatically with `router bgp`.
+
+| Leaf | Type | Default | Meaning |
+|---|---|---|---|
+| `enable` | boolean | `false` | Attach (or, on `false` / delete, detach) a BFD session for this neighbour. |
+| `multihop` | boolean | *inferred* | Force the hop mode. Unset ⇒ inferred (see below). |
+| `minimum-ttl` | 1–254 | 254 | Multi-hop only: lowest accepted received TTL (RFC 5883). Ignored single-hop. |
+| `profile` | string | — | Named `/bfd/profile` to apply. *Stored but not yet applied — see the overview.* |
+
+## Single-hop vs multi-hop — inferred by default
+
+BGP does **not** put a `multihop` keyword on the neighbour by default;
+it infers the hop mode from the session, mirroring FRR:
+
+- **iBGP** ⇒ multi-hop (iBGP peers are typically loopback-to-loopback).
+- **Directly-connected eBGP** ⇒ single-hop.
+
+This matches FRR's `PEER_IS_MULTIHOP` behaviour. (Cisco IOS-XR instead
+keys multi-hop off the `ebgp-multihop` setting; the two agree on the
+common directly-connected eBGP and iBGP cases.) On a point-to-point
+link the distinction is moot — the session is single-hop either way.
+
+zebra-rs does not yet have an `ebgp-multihop` knob, so **eBGP over
+loopbacks** needs the hop mode forced explicitly:
+
+```
+router bgp {
+  neighbor 10.0.0.2 {
+    remote-as 65002;
+    update-source 10.0.0.1;
+    bfd {
+      enable true;
+      multihop true;       // eBGP-over-loopback; iBGP would infer this
+      minimum-ttl 250;
+    }
+  }
+}
+```
+
+The session's local address is taken from the neighbour's
+`update-source` (falling back to an unspecified address of the right
+family); there is no separate BFD source knob.
+
+## Verifying
+
+```
+show bfd peer 10.0.0.2
+```
+
+A multi-hop session shows `(multihop)` and its `Minimum TTL`; a
+single-hop session shows `(single-hop)`. If the peer stays `Down` with
+a remote discriminator of `0x0`, confirm the far end runs BFD toward
+this router and that UDP 3784 (single-hop) or 4784 (multi-hop) is open
+on the path. See the [overview](ch-10-00-bfd.md#verifying-sessions) for
+the full command set.
+
+Both IPv4 and IPv6 neighbours are supported.

--- a/book/src/ch-07-03-isis-bfd.md
+++ b/book/src/ch-07-03-isis-bfd.md
@@ -1,0 +1,50 @@
+# IS-IS BFD
+
+IS-IS attaches a [BFD](ch-10-00-bfd.md) session to each adjacency on an
+interface so a forwarding-path failure tears the adjacency down in
+sub-second time instead of waiting for the IS-IS hold timer. On a BFD
+`Down` event the adjacency is expired through the same path as a
+hold-timer timeout (RFC 5882 §5), which re-runs SPF.
+
+See the [BFD overview](ch-10-00-bfd.md) for the session model and the
+`show bfd` commands. IS-IS adjacencies live on a shared link, so their
+BFD sessions are **always single-hop** (UDP 3784, GTSM TTL = 255) —
+there is no multi-hop knob.
+
+## Enabling BFD on an interface
+
+BFD is a flat block under the IS-IS interface:
+
+```
+router isis {
+  interface eth0 {
+    bfd { enable true; }
+  }
+}
+```
+
+No top-level `bfd { }` block is required — the BFD subsystem starts
+automatically with `router isis`.
+
+| Leaf | Type | Default | Meaning |
+|---|---|---|---|
+| `enable` | boolean | `false` | Attach (or detach) BFD for adjacencies on this interface. |
+| `profile` | string | — | Named `/bfd/profile` to apply. *Stored but not yet applied — see the overview.* |
+
+A session is subscribed when the adjacency comes **Up** and
+unsubscribed when it goes down. Both IPv4 and IPv6 adjacencies are
+supported; IPv6 sessions run over the interface's link-local addresses
+and are demultiplexed per interface.
+
+## Verifying
+
+```
+show bfd
+show bfd peer <neighbor-address>
+```
+
+If a session stays `Down` with a remote discriminator of `0x0`, the
+local side is transmitting but nothing is coming back — confirm the
+neighbour also has `bfd enable` on its side of the link and that UDP
+3784 is not filtered. See the
+[overview](ch-10-00-bfd.md#verifying-sessions) for the full command set.

--- a/book/src/ch-08-02-ospf-bfd.md
+++ b/book/src/ch-08-02-ospf-bfd.md
@@ -1,0 +1,85 @@
+# OSPF BFD
+
+OSPFv2 and OSPFv3 attach a [BFD](ch-10-00-bfd.md) session to each
+neighbour on an interface so a forwarding-path failure tears the
+adjacency down in sub-second time instead of waiting for the OSPF dead
+interval. On a BFD `Down` event the neighbour is brought down through
+the same path as a dead-timer expiry (RFC 5882 §5), which re-runs SPF.
+
+See the [BFD overview](ch-10-00-bfd.md) for the session model and the
+`show bfd` commands. OSPF neighbours are on a shared link, so their BFD
+sessions are **always single-hop** (UDP 3784, GTSM = 255) — there is no
+multi-hop knob.
+
+## Enabling BFD on an interface
+
+BFD is a flat block under the OSPF interface. The same configuration
+applies to OSPFv2 (`router ospf`) and OSPFv3 (`router ospfv3`):
+
+```
+router ospf {
+  area 0 {
+    interface eth0 {
+      bfd { enable true; }
+    }
+  }
+}
+```
+
+No top-level `bfd { }` block is required — the BFD subsystem starts
+automatically with `router ospf` / `router ospfv3`.
+
+| Leaf | Type | Default | Meaning |
+|---|---|---|---|
+| `enable` | boolean | `false` | Attach (or detach) BFD for neighbours on this interface. |
+| `min-neighbor-state` | `two-way` \| `full` | `two-way` | Neighbour state at which the session starts / stops. |
+| `profile` | string | — | Named `/bfd/profile` to apply. *Stored but not yet applied — see the overview.* |
+
+## The `min-neighbor-state` trigger
+
+This is the one OSPF-specific knob, and the two major implementations
+disagree on its default — so zebra-rs makes it configurable:
+
+- **`two-way`** (default) — start the session once the neighbour
+  reaches the 2-Way state. This is **FRR's** behaviour, and it also
+  protects DR-Other ↔ DR-Other pairs on a broadcast LAN (which never
+  progress past 2-Way).
+- **`full`** — start the session only at the Full state. This is
+  **Cisco / IOS-XR's** behaviour, which on a broadcast LAN runs BFD
+  only between a router and the DR/BDR.
+
+On a point-to-point link the distinction is moot — the neighbour goes
+straight to Full, so it is ≥ 2-Way either way.
+
+```
+router ospf {
+  area 0 {
+    interface eth0 {
+      bfd {
+        enable true;
+        min-neighbor-state full;   // Cisco-style; default is two-way
+      }
+    }
+  }
+}
+```
+
+## OSPFv3 (IPv6)
+
+OSPFv3 BFD is configured identically under `router ospfv3`. The session
+runs over the interface's IPv6 **link-local** addresses (the same
+addresses OSPFv3 sources its control packets from) and is demultiplexed
+per interface, so overlapping `fe80::` addresses on different links do
+not collide.
+
+## Verifying
+
+```
+show bfd
+show bfd peer <neighbor-address>
+```
+
+If a session stays `Down` with a remote discriminator of `0x0`, confirm
+the neighbour also has `bfd enable` on its side and that UDP 3784 is not
+filtered on the link. See the
+[overview](ch-10-00-bfd.md#verifying-sessions) for the full command set.

--- a/book/src/ch-10-00-bfd.md
+++ b/book/src/ch-10-00-bfd.md
@@ -1,0 +1,185 @@
+# Bidirectional Forwarding Detection (BFD)
+
+Bidirectional Forwarding Detection (BFD, RFC 5880) is a lightweight
+hello protocol that detects a forwarding-path failure to an adjacent
+system in **sub-second** time — far faster than the multi-second
+hold/dead timers of the routing protocols themselves. zebra-rs runs a
+single BFD subsystem that the routing protocols attach to: when a BFD
+session drops, the subsystem notifies every protocol watching that
+neighbour, and each one tears its adjacency or peering down
+immediately (RFC 5882 §5) instead of waiting for its own timer.
+
+This chapter covers the BFD subsystem as a whole — how it starts, the
+session model, the transport, and the operational `show` commands. How
+each protocol attaches BFD to a neighbour is documented in that
+protocol's own BFD section:
+
+- [BGP](ch-02-08-bgp-bfd.md) — per-neighbor, single- or multi-hop
+- [IS-IS](ch-07-03-isis-bfd.md) — per-interface, single-hop
+- [OSPFv2 / OSPFv3](ch-08-02-ospf-bfd.md) — per-interface, single-hop
+
+The implementation follows the FRR command surface and semantics where
+they align, so configurations written against FRR carry across with
+little surprise; differences from FRR and Cisco IOS-XR are called out
+where they matter.
+
+## You do not enable BFD globally
+
+There is **no global "turn BFD on" switch**. The BFD subsystem is
+spawned automatically the moment any consumer is configured — a
+`router bgp`, `router isis`, `router ospf`, or `router ospfv3` block —
+and it is always brought up *before* the protocol that uses it, so the
+order in which you type the configuration never matters. Attaching BFD
+to a neighbour is then a single per-neighbour / per-interface flag:
+
+```
+router ospf {
+  area 0 {
+    interface eth0 {
+      bfd { enable true; }
+    }
+  }
+}
+```
+
+That is the whole story for the common case. The optional top-level
+`bfd { … }` block (below) exists only to define reusable **profiles**;
+it is not required to use BFD.
+
+> This matches FRR, where `neighbor X bfd` / `ip ospf bfd` "just work"
+> without a separate global daemon switch. Earlier revisions of
+> zebra-rs required a top-level `bfd { }` block to exist first; that
+> requirement has been removed.
+
+## Session model
+
+A BFD session is keyed by the tuple **(local address, remote address,
+ifindex, hop-mode)**. Two systems each pick a random, non-zero local
+*discriminator*; once packets are flowing each end echoes the other's
+discriminator and the session is demultiplexed by discriminator on the
+fast path. The session runs a small state machine — `Down → Init → Up`
+— and reports each transition back to the attached protocols.
+
+Multiple protocols can attach to the **same** neighbour: they share one
+underlying session, and all of them are notified when it changes state.
+The session is torn down only when the last consumer detaches.
+
+Timers are negotiated from each side's *desired transmit* and *required
+receive* intervals; the detection time is `received-tx-interval ×
+detect-multiplier`. The shipped defaults are conservative:
+
+| Parameter | Default |
+|---|---|
+| Transmit interval | 1000 ms |
+| Receive interval | 1000 ms |
+| Detect multiplier | 3 |
+
+giving a ~3-second detection time out of the box. (See
+[Profiles](#profiles-not-yet-applied) for the current status of tuning
+these.)
+
+## Single-hop vs multi-hop
+
+| | Single-hop (RFC 5881) | Multi-hop (RFC 5883) |
+|---|---|---|
+| UDP port | 3784 | 4784 |
+| TTL / Hop Limit on egress | 255 | 255 |
+| Accepted received TTL | **exactly 255** (GTSM) | **≥ `minimum-ttl`** (default 254) |
+| Use | directly-connected neighbour | neighbour reached over ≥ 1 router |
+
+Single-hop sessions enforce the **GTSM** check (RFC 5082): a control
+packet that did not arrive with TTL/Hop-Limit 255 has crossed a router
+and is dropped. Multi-hop sessions relax this to a configurable floor
+so a packet that legitimately crossed a few hops is still accepted but
+a spoofed far-away packet is not.
+
+OSPF and IS-IS sessions are **always single-hop** (their neighbours are,
+by definition, on a shared link). BGP chooses per neighbour: directly
+connected eBGP is single-hop, while iBGP and eBGP-over-loopback are
+multi-hop — see the [BGP BFD](ch-02-08-bgp-bfd.md) section.
+
+## IPv4 and IPv6
+
+Both address families are supported. The subsystem listens on the v4
+and v6 transports independently (on both 3784 and 4784); IPv6
+link-local sessions — used by OSPFv3 and by IPv6 IS-IS / BGP — are
+demultiplexed per **ifindex**, since the same `fe80::` address can
+appear on several interfaces. The egress interface is pinned for
+link-local destinations so packets leave the right link.
+
+## Profiles (not yet applied)
+
+A top-level `bfd { … }` block defines named parameter **profiles** that
+a neighbour can reference by name:
+
+```
+bfd {
+  profile FAST {
+    detect-multiplier 3;
+    transmit-interval 300;   // milliseconds
+    receive-interval 300;
+    minimum-ttl 250;         // multi-hop only
+  }
+}
+```
+
+> **Current limitation.** A `profile` reference on a neighbour is
+> parsed and stored, but it is **not yet resolved into the live
+> session** — every session currently runs with the conservative
+> defaults in the table above (1000 ms / ×3). This means `show bfd
+> peer` reports 1000 ms timers regardless of the profile you select.
+> Wiring profiles through to session parameters is a shared follow-up
+> across all three protocols. Until then, the top-level block and the
+> per-neighbour `profile` leaf are accepted but have no effect on
+> timers.
+
+## Verifying sessions
+
+Three `show` commands surface BFD state:
+
+```
+show bfd                  # one-line-per-session summary table
+show bfd peer             # FRR-style detail block for every session
+show bfd peer 10.0.0.2    # detail for a single peer
+show bfd counters         # per-session control-packet counters
+```
+
+`show bfd` gives a quick health table:
+
+```
+Peer             State    Local/Remote Disc      Uptime     Iface
+10.0.0.2         Up       0xd6b24a5/0x3f0a112    00:14:22   single-hop
+```
+
+`show bfd peer [<addr>]` prints the FRR-style indented detail block —
+discriminators, status and up/down time, diagnostics, the negotiated
+local and remote timers, and (for multi-hop) the minimum TTL. A fresh
+session that has not yet heard from the peer shows `State Down` with a
+remote discriminator of `0x0`; that means the local side is
+transmitting but nothing is coming back — check that the peer also has
+BFD configured toward this router and that UDP 3784/4784 is not
+filtered on the path.
+
+`show bfd counters` shows received / transmitted control-packet counts
+per session (the RX counter is the reliable one for confirming the
+receive path is alive).
+
+Each command also accepts a trailing `json` for machine-readable output.
+
+## What happens on failure
+
+When a session transitions to `Down`, every attached protocol is
+notified and reacts as if its own liveness timer had expired
+(RFC 5882 §5): BGP sends the peer FSM a `Stop`, and OSPF / IS-IS tear
+the adjacency down via the same path as a dead-timer / hold-timer
+expiry, which re-runs SPF. Because BFD detects the failure in
+well under a second, convergence starts far sooner than the protocol's
+native timers would allow.
+
+## Status and roadmap
+
+- **Done:** single- and multi-hop, IPv4 and IPv6; BGP, IS-IS, OSPFv2
+  and OSPFv3 attachment; the three `show` commands.
+- **Not yet:** profile parameters are stored but not applied to live
+  sessions (sessions use the defaults); BFD for **static routes** is a
+  planned future phase; per-VRF OSPF BFD is not yet wired.

--- a/zebra-rs/src/ospf/version.rs
+++ b/zebra-rs/src/ospf/version.rs
@@ -571,13 +571,22 @@ impl OspfVersion for Ospfv3 {
     }
 
     fn bfd_addrs(
-        _addrs: &[crate::ospf::addr::OspfAddr<Ospfv3>],
-        _nbr: &crate::ospf::Neighbor<Ospfv3>,
+        addrs: &[crate::ospf::addr::OspfAddr<Ospfv3>],
+        nbr: &crate::ospf::Neighbor<Ospfv3>,
     ) -> Option<(std::net::IpAddr, std::net::IpAddr)> {
-        // OSPFv3 BFD runs over IPv6 link-local, which needs IPv6
-        // support in the BFD module first (a later phase). Inert until
-        // then: config is accepted but no session is created.
-        None
+        // OSPFv3 sources control packets from the interface link-local
+        // (RFC 5340 §A.1) and stores each neighbor's link-local source
+        // as a /128 in `ident.prefix`. BFD mirrors that — both
+        // endpoints are link-local, demuxed per-ifindex (the
+        // `SessionKey.ifindex` is set by the reconcile, and v6 egress
+        // is pinned to it via `IPV6_PKTINFO`). Mirrors
+        // `packet_v3::link_local_src`.
+        let local = addrs.iter().find_map(|a| {
+            let addr = a.prefix.addr();
+            addr.is_unicast_link_local().then_some(addr)
+        })?;
+        let remote = nbr.ident.prefix.addr();
+        Some((std::net::IpAddr::V6(local), std::net::IpAddr::V6(remote)))
     }
 
     fn is_declared_dr(ident: &crate::ospf::Identity<Ospfv3>) -> bool {
@@ -626,13 +635,13 @@ impl OspfVersion for Ospfv3 {
 
 #[cfg(test)]
 mod bfd_tests {
-    use super::{OspfVersion, Ospfv2};
+    use super::{OspfVersion, Ospfv2, Ospfv3};
     use crate::ospf::addr::OspfAddr;
     use crate::ospf::link::NbrStateThreshold;
     use crate::ospf::neigh::Neighbor;
     use crate::ospf::nfsm::NfsmState;
-    use ipnet::Ipv4Net;
-    use std::net::{IpAddr, Ipv4Addr};
+    use ipnet::{Ipv4Net, Ipv6Net};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use std::str::FromStr;
     use tokio::sync::mpsc;
 
@@ -664,6 +673,50 @@ mod bfd_tests {
                 IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
             )),
         );
+    }
+
+    fn v3_neighbor(remote_link_local: &str) -> Neighbor<Ospfv3> {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let (ptx, _prx) = mpsc::unbounded_channel();
+        Neighbor::<Ospfv3>::new(
+            tx,
+            5,
+            Ipv6Net::from_str(remote_link_local).unwrap(),
+            &Ipv4Addr::new(3, 3, 3, 3),
+            40,
+            ptx,
+        )
+    }
+
+    /// v3 pairs the interface's link-local with the neighbor's
+    /// link-local (its /128 in `ident.prefix`), skipping any global
+    /// address on the interface.
+    #[test]
+    fn bfd_addrs_v3_pairs_link_locals() {
+        let nbr = v3_neighbor("fe80::2/128");
+        let global = OspfAddr::<Ospfv3> {
+            prefix: Ipv6Net::from_str("2001:db8::1/64").unwrap(),
+        };
+        let link_local = OspfAddr::<Ospfv3> {
+            prefix: Ipv6Net::from_str("fe80::1/64").unwrap(),
+        };
+        assert_eq!(
+            Ospfv3::bfd_addrs(&[global, link_local], &nbr),
+            Some((
+                IpAddr::V6(Ipv6Addr::from_str("fe80::1").unwrap()),
+                IpAddr::V6(Ipv6Addr::from_str("fe80::2").unwrap()),
+            )),
+        );
+    }
+
+    /// No link-local on the interface (only a global) ⇒ no session.
+    #[test]
+    fn bfd_addrs_v3_none_without_link_local() {
+        let nbr = v3_neighbor("fe80::2/128");
+        let global = OspfAddr::<Ospfv3> {
+            prefix: Ipv6Net::from_str("2001:db8::1/64").unwrap(),
+        };
+        assert_eq!(Ospfv3::bfd_addrs(&[global], &nbr), None);
     }
 
     /// No local address on the interface ⇒ no session can be formed.


### PR DESCRIPTION
## Summary

Completes the BFD feature arc.

**Code (OSPFv3 BFD):** `Ospfv3::bfd_addrs` now returns the IPv6 link-local pair — the interface link-local (via `is_unicast_link_local()` over `link.addr`, mirroring `packet_v3::link_local_src`) and the neighbor's link-local (its `/128` in `ident.prefix`) — instead of `None`. The rest of the OSPF BFD wiring is already generic over the version (from #1126) and the IPv6 BFD transport landed in #1128, so OSPFv3 sessions now form end-to-end (single-hop, link-local, demuxed per ifindex). +2 unit tests.

**Docs (`book/`):**
- New overview chapter `ch-10-00-bfd.md` ("Bidirectional Forwarding Detection") under a new **Failure Detection** section — the no-global-enable model (eager spawn), session model, single-hop vs multi-hop + GTSM, IPv4/IPv6, the profile *stored-but-not-applied* caveat, the `show bfd` commands, and the failure→teardown behavior.
- Per-protocol BFD pages, one under each protocol in the TOC (matching the book's feature-per-sub-chapter convention):
  - `ch-02-08-bgp-bfd.md` — per-neighbor; multihop inferred from iBGP + explicit override; `minimum-ttl`
  - `ch-07-03-isis-bfd.md` — per-interface, single-hop
  - `ch-08-02-ospf-bfd.md` — per-interface, v2 + v3; the `min-neighbor-state two-way|full` trigger (FRR-vs-Cisco difference)
- `SUMMARY.md` wires in all four.

Static-route BFD is documented as a future phase (not claimed configurable, since it isn't implemented).

## Test plan
- `cargo test -p zebra-rs` — **816 passed** (incl. new `bfd_addrs_v3_pairs_link_locals` / `bfd_addrs_v3_none_without_link_local`)
- `cargo clippy --workspace --all-targets -- -D warnings` / `cargo fmt --check` — clean
- `mdbook build` — clean (no broken TOC links)

Generated with [Claude Code](https://claude.com/claude-code)