### PR TITLE
bfd: fix single-hop/multihop demux flap + 300ms default intervals

### DIFF
--- a/zebra-rs/src/bfd/session.rs
+++ b/zebra-rs/src/bfd/session.rs
@@ -51,13 +51,18 @@ pub struct SessionParams {
 
 impl Default for SessionParams {
     fn default() -> Self {
-        // Conservative defaults aligned with RFC 5880 §6.8.1
-        // (1-second intervals, ×3 detection — sub-second
-        // configurations are negotiated explicitly).
+        // Match the FRR-aligned profile constants in [`super::config`]
+        // (300 ms intervals, ×3 ⇒ 900 ms detection). A session created
+        // without a resolved `bfd profile` must not negotiate slower
+        // than the configured default would: at 1 s our `required-min-rx`
+        // dragged FRR's transmit up to 1 s and the detection time to 3 s
+        // on both ends. Sub-second rates comply with RFC 5880 §6.8.1.
+        // `min_ttl` is the single-hop GTSM floor (RFC 5881 §5); multihop
+        // callers override it to `BFD_MULTIHOP_DEFAULT_MIN_TTL`.
         Self {
-            desired_min_tx_us: 1_000_000,
-            required_min_rx_us: 1_000_000,
-            detect_mult: 3,
+            desired_min_tx_us: super::config::DEFAULT_TRANSMIT_INTERVAL_MS * 1_000,
+            required_min_rx_us: super::config::DEFAULT_RECEIVE_INTERVAL_MS * 1_000,
+            detect_mult: super::config::DEFAULT_DETECT_MULT,
             dst_port: super::socket::BFD_SINGLE_HOP_PORT,
             min_ttl: 255,
         }


### PR DESCRIPTION
## Summary

Fixes a BGP BFD session flap observed against FRR, plus a related default-interval mismatch surfaced during the investigation.

### 1. Single-hop / multihop demux collision (the flap)

Single-hop (3784) and multihop (4784) shared one receive loop and one event loop, and `Message::Recv` carried no hop type. `on_recv` / `bootstrap_lookup` matched a session on `(remote, ifindex)` alone, ignoring `key.multihop`.

When the peer ran a *failing single-hop* session to us (Down packets with `your_disc == 0`), those packets were demuxed onto our **multihop** session: they knocked it Down (`NeighborSignaledSessionDown`) and overwrote `remote_disc` with the single-hop discriminator, so our multihop TX then carried the wrong `your_disc` and the peer's multihop session reported *control detection time expired*. This reproduced exactly when zebra inferred multihop (iBGP) while FRR had a configured single-hop peer to the same neighbor.

**Fix:** tag every `Message::Recv` with the listener's hop type, filter `bootstrap_lookup` on it, and add a post-lookup `key.multihop != multihop` guard for the discriminator path (counts `rx_invalid`). New regression test `single_hop_packet_does_not_disturb_multihop_session`.

### 2. FRR-aligned default intervals

`SessionParams::default()` used 1 s tx/rx while `ProfileConfig::default()` (and FRR) use 300 ms. All protocols build live sessions from `SessionParams::default()` (profile→session wiring is still deferred), so our 1 s `required-min-rx` dragged the negotiated rate to 1 s tx / 3 s detection on both ends. `SessionParams::default()` now references the FRR-aligned `super::config::DEFAULT_*` constants so the two sources can't drift.

## Test plan

- `cargo test -p zebra-rs bfd::` → 39 passed, 0 failed
- `cargo clippy -p zebra-rs --all-targets` → 0 warnings
- `cargo fmt` applied

Generated with [Claude Code](https://claude.com/claude-code)
