### PR TITLE
bfd: clear diagnostic when session comes Up (RFC 5880 §4.1)

### DIFF
--- a/zebra-rs/src/bfd/fsm.rs
+++ b/zebra-rs/src/bfd/fsm.rs
@@ -66,6 +66,13 @@ fn rx_transition(local: State, remote: State) -> Transition {
     use State::*;
     // RFC 5880 §6.8.6 — Reception of BFD Control Packets.
     // The two-axis match expresses the spec's nested if/else exactly.
+    // Transitions into / staying Up carry `Diag::None`, not `None`.
+    // RFC 5880 §4.1 defines Diagnostic as the reason for the *last*
+    // state change; coming Up is a success, so the diag must be cleared
+    // to 0. `None` here would mean "leave the existing diag untouched"
+    // (see `Session::handle_event`), which would leave a stale failure
+    // reason (e.g. NeighborSignaledSessionDown from a prior down) on the
+    // wire while the session is healthy — FRR clears it, we didn't.
     match (local, remote) {
         // Remote AdminDown — tear down unless we're already Down.
         (Down, AdminDown) => stay(Down, None),
@@ -73,16 +80,16 @@ fn rx_transition(local: State, remote: State) -> Transition {
 
         // Local Down — only Down/Init from peer makes us move.
         (Down, Down) => stay(Init, None),
-        (Down, Init) => stay(Up, None),
+        (Down, Init) => stay(Up, Some(Diag::None)),
         (Down, Up) => stay(Down, None),
 
         // Local Init — Init or Up from peer brings us Up; Down keeps us.
         (Init, Down) => stay(Init, None),
-        (Init, Init) | (Init, Up) => stay(Up, None),
+        (Init, Init) | (Init, Up) => stay(Up, Some(Diag::None)),
 
         // Local Up — only Down from peer tears us down.
         (Up, Down) => stay(Down, Some(Diag::NeighborSignaledSessionDown)),
-        (Up, Init) | (Up, Up) => stay(Up, None),
+        (Up, Init) | (Up, Up) => stay(Up, Some(Diag::None)),
 
         // Local AdminDown handled in the caller's early-return.
         (AdminDown, _) => unreachable!("AdminDown handled before rx_transition"),
@@ -120,16 +127,16 @@ mod tests {
             (Up, AdminDown, Down, Some(Diag::NeighborSignaledSessionDown)),
             // Local Down
             (Down, Down, Init, None),
-            (Down, Init, Up, None),
+            (Down, Init, Up, Some(Diag::None)),
             (Down, Up, Down, None),
             // Local Init
             (Init, Down, Init, None),
-            (Init, Init, Up, None),
-            (Init, Up, Up, None),
-            // Local Up
+            (Init, Init, Up, Some(Diag::None)),
+            (Init, Up, Up, Some(Diag::None)),
+            // Local Up — staying Up keeps the diag cleared (RFC 5880 §4.1).
             (Up, Down, Down, Some(Diag::NeighborSignaledSessionDown)),
-            (Up, Init, Up, None),
-            (Up, Up, Up, None),
+            (Up, Init, Up, Some(Diag::None)),
+            (Up, Up, Up, Some(Diag::None)),
         ];
         for &(local, remote_state, expected_state, expected_diag) in cases {
             let t = transition(local, Event::Rx { remote_state });

--- a/zebra-rs/src/bfd/session.rs
+++ b/zebra-rs/src/bfd/session.rs
@@ -465,4 +465,92 @@ mod tests {
         assert!(s.last_up.is_some());
         assert_eq!(s.stats.rx_count, 2);
     }
+
+    /// Regression: the local diagnostic must be cleared to `Diag::None`
+    /// once the session comes back Up, instead of advertising the stale
+    /// reason for the *previous* down forever (RFC 5880 §4.1). Observed
+    /// against FRR: our Up packets carried `NeighborSignaledSessionDown`
+    /// while FRR (correctly) sent `No Diagnostic`. Drives a full
+    /// Up → (peer Down) → Down → Init → Up cycle and asserts the diag is
+    /// set on the way down and cleared on the way back up — including by
+    /// a steady-state Up/Up packet.
+    #[test]
+    fn diag_cleared_when_session_returns_up() {
+        let mut t = SessionTable::new();
+        let k = key(1, 2);
+        let d = t.insert(k, SessionParams::default());
+        let s = t.get_by_disc_mut(d).unwrap();
+
+        let pkt = |state| ControlPacket {
+            state,
+            my_disc: 0xabcd,
+            ..ControlPacket::default()
+        };
+
+        // Bring the session Up (Down→Init→Up).
+        let _ = s.handle_packet(&pkt(State::Down));
+        let _ = s.handle_packet(&pkt(State::Init));
+        assert_eq!(s.local_state, State::Up);
+        assert_eq!(s.local_diag, Diag::None, "clean session has no diag");
+
+        // Peer signals Down → we go Down with the reason recorded.
+        let _ = s.handle_packet(&pkt(State::Down));
+        assert_eq!(s.local_state, State::Down);
+        assert_eq!(
+            s.local_diag,
+            Diag::NeighborSignaledSessionDown,
+            "down carries the reason",
+        );
+
+        // Re-establish: Down→Init is a no-failure transition that leaves
+        // the diag untouched (only the Up-producing arms clear it), so
+        // the stale reason still rides the transient Init packets…
+        let _ = s.handle_packet(&pkt(State::Down));
+        assert_eq!(s.local_state, State::Init);
+        assert_eq!(
+            s.local_diag,
+            Diag::NeighborSignaledSessionDown,
+            "Init still carries the prior reason (transient)",
+        );
+
+        // …and Init→Up clears it — the fix that matches FRR's behaviour.
+        let _ = s.handle_packet(&pkt(State::Init));
+        assert_eq!(s.local_state, State::Up);
+        assert_eq!(s.local_diag, Diag::None, "back Up with a clean diag");
+    }
+
+    /// A steady-state Up/Up packet (no state change, so `handle_event`
+    /// returns `None`) must still scrub a stale diagnostic — the FSM
+    /// assigns the diag before the no-change early-return. Guards the
+    /// case where the very first post-recovery packet is Up/Up.
+    #[test]
+    fn steady_state_up_scrubs_stale_diag() {
+        let mut t = SessionTable::new();
+        let k = key(1, 2);
+        let d = t.insert(k, SessionParams::default());
+        let s = t.get_by_disc_mut(d).unwrap();
+
+        // Force Up with a stale diag left over from an earlier down.
+        let _ = s.handle_packet(&ControlPacket {
+            state: State::Down,
+            my_disc: 1,
+            ..ControlPacket::default()
+        });
+        let _ = s.handle_packet(&ControlPacket {
+            state: State::Init,
+            my_disc: 1,
+            ..ControlPacket::default()
+        });
+        s.local_diag = Diag::NeighborSignaledSessionDown;
+
+        // An Up/Up packet doesn't change state (no StateChange returned)…
+        let change = s.handle_packet(&ControlPacket {
+            state: State::Up,
+            my_disc: 1,
+            ..ControlPacket::default()
+        });
+        assert!(change.is_none(), "Up/Up is not a state change");
+        // …but the diagnostic is scrubbed all the same.
+        assert_eq!(s.local_diag, Diag::None, "stale diag cleared while Up");
+    }
 }


### PR DESCRIPTION
## Summary

RFC 5880 §4.1 defines the Diagnostic field as the local system's reason for the **last** state change. Coming Up is a success, so the diag must be cleared to `0` (No Diagnostic).

The three Up-producing arms in `rx_transition` returned `new_diag = None`, which in `handle_event` means "leave the existing diag untouched." So once a session had ever gone down (e.g. `NeighborSignaledSessionDown`), it kept advertising that stale reason on **every Up packet forever**.

Observed on the wire against FRR: our Up packets carried `Diagnostic: Neighbor Signaled Session Down (0x03)` while FRR (correctly) sent `No Diagnostic (0x00)`. It's cosmetic — the Diagnostic field never drives the peer's state machine — but non-conformant and misleading in monitoring.

**Fix:** return `Some(Diag::None)` from the `(Down,Init)→Up`, `(Init,Init|Up)→Up`, and `(Up,Init|Up)→Up` arms, so the diag is scrubbed on the way up and kept clear while Up. Because `handle_event` assigns the diag before its no-change early-return, even a steady-state Up/Up packet scrubs a lingering diag — the field self-corrects on the next packet with no state change required.

## Test plan

- `cargo test -p zebra-rs bfd::` → 45 passed, 0 failed. Updated the FSM truth-table test; added two session-level regression tests:
  - `diag_cleared_when_session_returns_up` — full Up → peer-Down → Down → Init → Up cycle; diag set on the way down, cleared at Init→Up.
  - `steady_state_up_scrubs_stale_diag` — an Up/Up packet (no state change) still scrubs a stale diag.
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo fmt` applied

Generated with [Claude Code](https://claude.com/claude-code)
