### PR TITLE
bfd: remove dead "bfd profile" config

### DIFF
--- a/zebra-rs/src/bfd/config.rs
+++ b/zebra-rs/src/bfd/config.rs
@@ -1,18 +1,16 @@
-//! BFD configuration model and per-leaf callback dispatcher.
+//! BFD configuration model and per-leaf callback dispatcher (empty).
 //!
-//! Mirrors the pattern used by [`crate::ospf::config`] and
-//! [`crate::isis::config`]: each YANG leaf under `/bfd/profile`
-//! registers a callback function. The config manager dispatches
-//! incoming `ConfigRequest`s by path; the callback consumes its key /
-//! value args and mutates the in-memory [`BfdConfig`] held by the
-//! [`super::inst::Bfd`] instance.
-//!
-//! Only named profiles are configured here. There is no standalone
-//! `bfd { peer }` config: live BFD sessions are created and torn down
-//! by the protocol modules (BGP / OSPF / IS-IS) through
+//! The top-level `bfd` keyword is an FRR-style enable anchor: its
+//! presence spawns the BFD task (see [`crate::config::manager`]), but
+//! it has no configuration leaves of its own. BFD sessions are
+//! configured per-protocol (`neighbor X bfd`, `ip ospf bfd`,
+//! `isis bfd`) and created / torn down by those modules through
 //! `ClientReq::Subscribe` / `Unsubscribe`.
-
-use std::collections::BTreeMap;
+//!
+//! The dispatch plumbing (the `cm` channel, [`BfdConfig`], the callback
+//! table, and [`Bfd::process_cm_msg`]) is kept as an empty shell so a
+//! future `/bfd/*` leaf can register a handler without re-wiring the
+//! instance.
 
 use crate::config::{Args, ConfigOp};
 
@@ -20,149 +18,39 @@ use super::inst::Bfd;
 
 pub type Callback = fn(&mut Bfd, Args, ConfigOp) -> Option<()>;
 
-/// Defaults aligned with FRR (compatible with RFC 5880 §6.8.1
-/// recommendations). Used when neither the peer-level override nor a
-/// referenced profile supplies a value.
+/// FRR-aligned session defaults (compatible with the RFC 5880 §6.8.1
+/// recommendations). These back [`super::session::SessionParams::default`]
+/// — the parameters every protocol-driven session is created with —
+/// not any `/bfd` config leaf.
 pub const DEFAULT_DETECT_MULT: u8 = 3;
 pub const DEFAULT_TRANSMIT_INTERVAL_MS: u32 = 300;
 pub const DEFAULT_RECEIVE_INTERVAL_MS: u32 = 300;
-pub const DEFAULT_PASSIVE_MODE: bool = false;
-pub const DEFAULT_SHUTDOWN: bool = false;
 pub const DEFAULT_MINIMUM_TTL: u8 = 254;
 
-/// A named bundle of session parameters. Peers reference profiles by
-/// name; absence of a referenced profile is *not* an error here —
-/// peer-level overrides may have set every relevant leaf already.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProfileConfig {
-    pub detect_multiplier: u8,
-    pub transmit_interval_ms: u32,
-    pub receive_interval_ms: u32,
-    pub passive_mode: bool,
-    pub shutdown: bool,
-    pub minimum_ttl: u8,
-}
-
-impl Default for ProfileConfig {
-    fn default() -> Self {
-        Self {
-            detect_multiplier: DEFAULT_DETECT_MULT,
-            transmit_interval_ms: DEFAULT_TRANSMIT_INTERVAL_MS,
-            receive_interval_ms: DEFAULT_RECEIVE_INTERVAL_MS,
-            passive_mode: DEFAULT_PASSIVE_MODE,
-            shutdown: DEFAULT_SHUTDOWN,
-            minimum_ttl: DEFAULT_MINIMUM_TTL,
-        }
-    }
-}
-
 /// In-memory mirror of the `container bfd` subtree of the committed
-/// config. Holds the named [`ProfileConfig`] bundles; per-peer BFD
-/// sessions are driven entirely by the protocol modules (BGP / OSPF /
-/// IS-IS) via `ClientReq::Subscribe`, so there is no standalone
-/// `bfd { peer }` config here.
+/// config. Currently empty — the container has no leaves — but kept so
+/// the config-dispatch plumbing stays wired for any future `/bfd` leaf.
 #[derive(Debug, Default, Clone)]
-pub struct BfdConfig {
-    pub profiles: BTreeMap<String, ProfileConfig>,
-}
+pub struct BfdConfig {}
 
 impl Bfd {
     const BFD: &str = "/bfd";
 
+    #[allow(dead_code)]
     fn config_add(&mut self, path: &str, cb: Callback) {
         self.callbacks.insert(format!("{}{}", Self::BFD, path), cb);
     }
 
-    pub fn callback_build(&mut self) {
-        // Profile leaves
-        self.config_add("/profile/detect-multiplier", profile_detect_multiplier);
-        self.config_add("/profile/transmit-interval", profile_transmit_interval);
-        self.config_add("/profile/receive-interval", profile_receive_interval);
-        self.config_add("/profile/passive-mode", profile_passive_mode);
-        self.config_add("/profile/shutdown", profile_shutdown);
-        self.config_add("/profile/minimum-ttl", profile_minimum_ttl);
-    }
-}
-
-// -----------------------------------------------------------------------
-// Profile callbacks
-// -----------------------------------------------------------------------
-
-/// Get-or-create-on-set, remove-on-delete-and-empty.
-fn profile_mut<'a>(
-    cfg: &'a mut BfdConfig,
-    name: &str,
-    op: ConfigOp,
-) -> Option<&'a mut ProfileConfig> {
-    if op.is_set() {
-        Some(cfg.profiles.entry(name.to_string()).or_default())
-    } else {
-        cfg.profiles.get_mut(name)
-    }
-}
-
-fn profile_detect_multiplier(bfd: &mut Bfd, mut args: Args, op: ConfigOp) -> Option<()> {
-    let name = args.string()?;
-    let v = args.u8()?;
-    let p = profile_mut(&mut bfd.config, &name, op)?;
-    p.detect_multiplier = if op.is_set() { v } else { DEFAULT_DETECT_MULT };
-    Some(())
-}
-
-fn profile_transmit_interval(bfd: &mut Bfd, mut args: Args, op: ConfigOp) -> Option<()> {
-    let name = args.string()?;
-    let v = args.u32()?;
-    let p = profile_mut(&mut bfd.config, &name, op)?;
-    p.transmit_interval_ms = if op.is_set() {
-        v
-    } else {
-        DEFAULT_TRANSMIT_INTERVAL_MS
-    };
-    Some(())
-}
-
-fn profile_receive_interval(bfd: &mut Bfd, mut args: Args, op: ConfigOp) -> Option<()> {
-    let name = args.string()?;
-    let v = args.u32()?;
-    let p = profile_mut(&mut bfd.config, &name, op)?;
-    p.receive_interval_ms = if op.is_set() {
-        v
-    } else {
-        DEFAULT_RECEIVE_INTERVAL_MS
-    };
-    Some(())
-}
-
-fn profile_passive_mode(bfd: &mut Bfd, mut args: Args, op: ConfigOp) -> Option<()> {
-    let name = args.string()?;
-    let v = args.boolean()?;
-    let p = profile_mut(&mut bfd.config, &name, op)?;
-    p.passive_mode = op.is_set() && v;
-    Some(())
-}
-
-fn profile_shutdown(bfd: &mut Bfd, mut args: Args, op: ConfigOp) -> Option<()> {
-    let name = args.string()?;
-    let v = args.boolean()?;
-    let p = profile_mut(&mut bfd.config, &name, op)?;
-    p.shutdown = op.is_set() && v;
-    Some(())
-}
-
-fn profile_minimum_ttl(bfd: &mut Bfd, mut args: Args, op: ConfigOp) -> Option<()> {
-    let name = args.string()?;
-    let v = args.u8()?;
-    let p = profile_mut(&mut bfd.config, &name, op)?;
-    p.minimum_ttl = if op.is_set() { v } else { DEFAULT_MINIMUM_TTL };
-    Some(())
+    /// Register `/bfd/*` leaf callbacks. The container has no leaves
+    /// today, so this is empty; it stays as the wiring point for any
+    /// future BFD config.
+    pub fn callback_build(&mut self) {}
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::VecDeque;
     use std::net::{Ipv4Addr, SocketAddrV4};
 
-    use super::*;
     use crate::bfd::inst::Bfd;
     use crate::context::ProtoContext;
 
@@ -174,80 +62,16 @@ mod tests {
         .expect("bind loopback")
     }
 
-    fn args(parts: &[&str]) -> Args {
-        Args(
-            parts
-                .iter()
-                .map(|s| (*s).to_string())
-                .collect::<VecDeque<_>>(),
-        )
-    }
-
-    /// A configured profile lands in `bfd.config.profiles` with its
-    /// non-default leaves applied, and the unset leaves take their
-    /// documented defaults.
+    /// The `bfd` container has no config leaves: no `/bfd/*` callbacks
+    /// are registered. Per-peer and per-profile BFD config were removed;
+    /// sessions are driven by the protocol modules via
+    /// `ClientReq::Subscribe`.
     #[tokio::test]
-    async fn profile_set_then_read_back() {
-        let mut bfd = fresh_bfd();
-        profile_detect_multiplier(&mut bfd, args(&["FAST", "5"]), ConfigOp::Set);
-        profile_transmit_interval(&mut bfd, args(&["FAST", "50"]), ConfigOp::Set);
-        profile_receive_interval(&mut bfd, args(&["FAST", "75"]), ConfigOp::Set);
-
-        let p = bfd
-            .config
-            .profiles
-            .get("FAST")
-            .expect("profile inserted on first leaf");
-        assert_eq!(p.detect_multiplier, 5);
-        assert_eq!(p.transmit_interval_ms, 50);
-        assert_eq!(p.receive_interval_ms, 75);
-        // Unset leaves take ProfileConfig::default()'s values.
-        assert!(!p.passive_mode);
-        assert!(!p.shutdown);
-        assert_eq!(p.minimum_ttl, DEFAULT_MINIMUM_TTL);
-    }
-
-    /// Deleting a leaf resets it to its default value (the profile
-    /// itself stays in the map — empty-profile cleanup is the
-    /// config tree's job, not the callback's).
-    #[tokio::test]
-    async fn profile_delete_resets_leaf_to_default() {
-        let mut bfd = fresh_bfd();
-        profile_detect_multiplier(&mut bfd, args(&["CORE", "7"]), ConfigOp::Set);
-        assert_eq!(bfd.config.profiles["CORE"].detect_multiplier, 7);
-
-        profile_detect_multiplier(&mut bfd, args(&["CORE", "7"]), ConfigOp::Delete);
-        assert_eq!(
-            bfd.config.profiles["CORE"].detect_multiplier,
-            DEFAULT_DETECT_MULT,
-        );
-    }
-
-    /// `callback_build` registers exactly the profile leaves we expect
-    /// — a missing path here means a CLI verb won't reach the storage
-    /// dispatcher at runtime. Per-peer BFD config was removed; sessions
-    /// are driven by the protocol modules via `ClientReq::Subscribe`.
-    #[tokio::test]
-    async fn callback_table_covers_every_leaf() {
+    async fn no_bfd_config_callbacks_registered() {
         let bfd = fresh_bfd();
-        let expected = [
-            "/bfd/profile/detect-multiplier",
-            "/bfd/profile/transmit-interval",
-            "/bfd/profile/receive-interval",
-            "/bfd/profile/passive-mode",
-            "/bfd/profile/shutdown",
-            "/bfd/profile/minimum-ttl",
-        ];
-        for path in expected {
-            assert!(
-                bfd.callbacks.contains_key(path),
-                "callback for {path} not registered",
-            );
-        }
-        // No `/bfd/peer/*` callbacks remain.
         assert!(
-            !bfd.callbacks.keys().any(|k| k.starts_with("/bfd/peer/")),
-            "peer config callbacks must be gone",
+            bfd.callbacks.is_empty(),
+            "the bfd container has no config leaves",
         );
     }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -2319,73 +2319,14 @@ module config {
       }
     }
 
+    // The top-level `bfd` keyword is the FRR-style enable anchor: its
+    // presence spawns the BFD task (see `config/manager.rs`). BFD
+    // sessions are configured per-protocol (`neighbor X bfd`,
+    // `ip ospf bfd`, `isis bfd`), so this container has no leaves of
+    // its own.
     container bfd {
       ext:help "Bidirectional Forwarding Detection (RFC 5880)";
       presence "Enable BFD";
-
-      list profile {
-        ext:help "Named bundle of BFD session parameters";
-        key "name";
-        leaf name {
-          type string;
-        }
-        leaf detect-multiplier {
-          type uint8 {
-            range "1..255";
-          }
-          default 3;
-          description
-            "Detect multiplier (RFC 5880 §6.8.1). The peer's
-             transmission interval is multiplied by this value to
-             compute the local detection time.";
-        }
-        leaf transmit-interval {
-          type uint32 {
-            range "10..4294967";
-          }
-          units "milliseconds";
-          default 300;
-          description
-            "Desired minimum interval at which this system would
-             like to transmit control packets (RFC 5880 §6.8.7).";
-        }
-        leaf receive-interval {
-          type uint32 {
-            range "10..4294967";
-          }
-          units "milliseconds";
-          default 300;
-          description
-            "Minimum interval at which this system is willing to
-             receive control packets (RFC 5880 §6.8.7).";
-        }
-        leaf passive-mode {
-          type boolean;
-          default false;
-          description
-            "When true, the session waits for the peer to send the
-             first control packet before responding (FRR-style;
-             RFC 5880 §6.1 active vs. passive role).";
-        }
-        leaf shutdown {
-          type boolean;
-          default false;
-          description
-            "Administrative shutdown — the session stays AdminDown
-             until this is cleared.";
-        }
-        leaf minimum-ttl {
-          type uint8 {
-            range "1..254";
-          }
-          default 254;
-          description
-            "Multihop only: minimum TTL accepted on incoming control
-             packets (RFC 5883). Ignored on single-hop sessions
-             where GTSM requires TTL=255 unconditionally.";
-        }
-      }
-
     }
 
     container segment-routing {


### PR DESCRIPTION
## Summary

The named `bfd { profile <name> { ... } }` config was stored in `BfdConfig.profiles` but never resolved into live session parameters — every protocol-driven session uses `SessionParams::default()` directly. With per-peer BFD config already removed (#1137), profiles were the last dead `/bfd` config leaf, so remove them too.

Removed:
- the `list profile` YANG subtree, leaving `container bfd { presence }` as the empty FRR-style enable/spawn anchor (the BFD task is spawned on any committed line starting with `bfd`)
- the `ProfileConfig` struct, `BfdConfig.profiles` field, the six `profile_*` callbacks + `profile_mut`, their registrations, and the profile tests

Kept deliberately:
- the FRR-aligned `DEFAULT_*` constants — `DEFAULT_DETECT_MULT` / `DEFAULT_TRANSMIT_INTERVAL_MS` / `DEFAULT_RECEIVE_INTERVAL_MS` / `DEFAULT_MINIMUM_TTL` back `SessionParams::default()`. (`DEFAULT_PASSIVE_MODE` / `DEFAULT_SHUTDOWN`, used only by the removed profile leaves, are dropped.)
- the config-dispatch shell (`BfdConfig`, empty `callback_build`, the `cm` channel, `process_cm_msg`) kept empty so a future `/bfd` leaf can register without re-wiring the instance.

The `/bfd` config subtree is now empty — all BFD is configured per-protocol (`neighbor X bfd`, `ip ospf bfd`, `isis bfd`).

Net: −270 / +35 lines across 2 files.

## Test plan

- `cargo test -p zebra-rs bfd::` → 41 passed, 0 failed
- `cargo test -p zebra-rs yang_load_tests` → 2 passed, 0 failed (confirms `config.yang` still loads; the empty presence container is valid and the exec/configure command trees resolve)
- `cargo test --bin zebra-rs` → 820 passed, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo fmt` applied

Generated with [Claude Code](https://claude.com/claude-code)
