### PR TITLE
offload: XDP BFD Echo reflector PoC (aya)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,14 @@ members = [
   "crates/fixedbuf",
   "bdd",
 ]
+# The offload/ tree holds XDP/eBPF PoCs built with aya. It is intentionally NOT
+# a member of this workspace: building it needs a nightly `bpfel` toolchain +
+# bpf-linker that the stable CI gate does not have. Keeping it excluded means
+# `cargo {build,clippy,test} --workspace` stays green on stable. Each PoC under
+# offload/ is its own self-contained workspace.
+exclude = [
+  "offload/*",
+]
 
 [workspace.package]
 version = "26.6.1"

--- a/docs/design/bfd-sbfd-stamp-xdp-offload-notes.md
+++ b/docs/design/bfd-sbfd-stamp-xdp-offload-notes.md
@@ -1,0 +1,274 @@
+# BFD / S-BFD / STAMP の XDP/eBPF オフロード検討メモ
+
+> zebra-rs / zebra-agent 向け技術リファレンス
+> 内容: Linux 上での BFD/Echo/S-BFD/STAMP のデータプレーンオフロード可能性、商用ルータの対応状況、ディスクリミネータ運用、実装方針
+> 注: 各社の対応状況・既定値はリリース/プラットフォーム依存。実装前に最新ドキュメントで再確認すること。
+
+---
+
+## 0. 要点サマリ（先に結論）
+
+- **純 XDP で BFD/Echo/S-BFD/STAMP を「丸ごと」実装した成熟プロジェクトは存在しない。** 最大の障害は **TX タイマー**（XDP は RX 起動のみで、自発的な周期送信ができない）。
+- **role を分けると整理できる**:
+  - **Reflector（折り返し側）= ステートレス → XDP の好適ユースケース**（`XDP_TX`）。
+  - **Originator/Sender（送出・検知側）= TX タイマーとタイムアウト検知が必要 → `bpf_timer`（5.15+）かユーザ空間が必須**。RX 検証は XDP が得意。
+- **S-BFD は SR-TE / SR Policy のパス継続性チェック用途が実態。** Initiator が能動、Reflector がステートレス。
+- **SRv6 では各社でアプローチが割れる**:
+  - **Cisco**: S-BFD は SR-MPLS/IPv4 専用。SRv6 liveness は **STAMP ベースの Performance Measurement (PM/IPM)**。
+  - **Juniper**: SRv6 TE パスに **S-BFD 対応**（IPv6 ディスクリミネータ）。
+  - **Nokia**: SRv6 Policy に **S-BFD 対応**。
+- **zebra-rs 実装方針**: 制御プレーン（Rust / aya ユーザ空間）と データプレーン（aya-ebpf / XDP）を分離。Reflector を XDP に置き、Originator/Sender 側はタイマー部分をユーザ空間 or `bpf_timer`。フル機能（高精度・認証・SRv6 encap）が要る所は **AF_XDP** に寄せる。
+
+---
+
+## 1. Linux における BFD の eBPF/XDP 実装の現状
+
+- 純 XDP/eBPF だけで完結する成熟した BFD 実装は無い。periodic TX（ms 単位の自発送信）を eBPF が起こせないのが根本問題。
+- 既存の Linux BFD はすべてユーザ空間 or カーネルモジュール:
+  - **FRRouting `bfdd`**: 事実上の標準。BGP/OSPF/IS-IS と連携。
+  - **OpenBFDD / FreeBFD / aiobfd(Python)**: スタンドアロンのユーザ空間デーモン。
+  - **kbfd**: 旧 Quagga/zebra 時代のカーネルモジュール（メンテ停止）。
+- Cilium の BGP Control Plane への BFD 追加議論でも「純 eBPF 実装の最大の障害はタイマー送信」と明記されている。
+- **XDP の現実的な使いどころ**: セッション状態と TX タイマーはユーザ空間（or `bpf_timer`）に置き、XDP は **RX 側の高速化**（BFD 制御パケットのパース・discriminator のマップ照合・detect-timer リセット・liveness 喪失の高速検知）に使う。
+
+---
+
+## 2. BFD Echo と XDP（reflector / originator の分離）
+
+BFD Echo は本質的に「ローカルが送出 → リモートのフォワーディング面が折り返し → ローカルが戻りを見て判定」。
+
+### Reflector 側 = 純 XDP で完全実装可能（最良ケース）
+- UDP 3785 宛を受けたら、宛先/送信元 MAC を入れ替えて受信 IF へ `XDP_TX` で送り返すだけ。
+- L2 折り返し（MAC スワップのみ）なら **IP/UDP チェックサム再計算も TTL デクリメントも不要**。
+- 「unaffiliated BFD echo」のリフレクタ概念に一致（BFD スタックを持たない機器の前段に小さな XDP リフレクタを置く構成が可能）。
+
+### Originator 側 = XDP 単体では不可
+- Echo の定期送出（TX）→ `bpf_timer` かユーザ空間。
+- 折り返してきた Echo の受信・検証（RX）→ XDP が得意（マップに last-seen / seq を持って照合）。
+- detect タイムアウト（戻ってこない → Down）→ タイマー起動が必要なので XDP 単体不可。
+
+### 実装メモ
+- Echo ペイロードは RFC 5880 §6.4 で **"a local matter"**（送出側裁量）。自分の discriminator + seq + 送出タイムスタンプを詰めておくと RX 側 XDP のマップ照合が安価。
+- 性能は折り返しジッタが検知タイマーの攻め具合を左右 → reflector は native モード（i40e/ice/ixgbe/mlx5 等）が望ましい。
+
+---
+
+## 3. S-BFD (Seamless BFD) 概要
+
+- **RFC 7880 (2016)。** classic BFD のハンドシェイク（Down→Init→Up の三方向）を排除した派生。
+- **事前配布された 32bit ディスクリミネータ**を使う。Initiator は対向の reflector discriminator を既知なので、ネゴ抜きで即パケット送出 → 即反射で到達性確認（1 往復で完結）。
+- **非対称な 2 役割**:
+  - **Initiator**: 能動。状態機械を持ち送出・判定。
+  - **Reflector**: ステートレス。自分の discriminator 宛パケットを受けたら my/your discriminator を入れ替えて返すだけ。
+- **ポート**: UDP 7784（S-BFD 制御） / 7785（S-BFD Echo）。※ classic は 3784/3785。
+- **用途**: オンデマンド到達性確認、**SR-TE / SR Policy のパス検証**（特定のセグメントリストに沿って流して反射を見る）。
+- **XDP 向きな理由**: reflector がステートレス（UDP 7784 一致 → your discriminator をマップ照合 → my/your 入替＋state 設定 → MAC/IP 入替 → UDP チェックサム増分更新 → `XDP_TX`）。discriminator 書換とチェックサム修正の分だけ classic echo の MAC スワップより一手間多い。
+- **関連 RFC**: 7880(コア) / 7881(IPv4/IPv6/MPLS カプセル化) / 7882(ユースケース) / 7883(IS-IS でのディスクリミネータ広告) / 7884(OSPF 拡張)。
+
+---
+
+## 4. 商用ルータの S-BFD 対応状況（SR-TE / SR Policy 文脈）
+
+> 4 社とも対応。実態は「SR-TE/SR Policy のヘッドエンドが initiator、テールが stateless reflector」。汎用リンク BFD（OSPF/IS-IS/BGP ネイバー監視）は classic BFD のまま、という住み分けが共通。
+
+| ベンダー | 対応 | 主な制約・メモ |
+|---|---|---|
+| **Cisco IOS-XE (ASR1000)** | ○ | SR-TE で S-BFD。**IPv4 のみ / シングルホップのみ**。テールが reflector |
+| **Cisco IOS-XR (NCS5500)** | ✗ | **Seamless BFD 非対応** と明記。機種差が大きい（要個別確認） |
+| **Cisco IOS-XR (ASR9000 等)** | ○ | SR-TE で sBFD reflector/initiator 設定あり |
+| **Juniper (Junos / Evolved)** | ◎ | colored/non-colored SR LSP、SR policy。23.2R1〜 S-BFD FRR（MX）。Evolved 22.4R1〜 PTX で remote discriminator 自動導出 |
+| **Nokia (SR-OS)** | ◎ | SR-TE LSP は 19.10.R1〜。**CPM-NP 必須、最小 10ms**。static/BGP SR policy 対応 |
+| **Arista (EOS)** | ○ | EOS 4.24.1F〜（SR-TE/SR Policy）。新しめのリリースで **S-BFD Hold-down Timer**（4.34/4.35/4.36F） |
+
+---
+
+## 5. SRv6 に絞った対応（Cisco / Juniper / Nokia）と End.X 監視
+
+### Cisco（IOS-XR）: SRv6 では S-BFD を使わない
+- S-BFD は **SR-MPLS / IPv4 専用**（制御パケットは順逆ともラベルスイッチ）。
+- SRv6 liveness は **Performance Measurement (PM) の liveness detection = STAMP (RFC 8762/8972) ベース**。
+  - MPLS 以外の IPv4/IPv6/SRv6 に共通適用。**loopback measurement-mode**（ヘッドエンドが宛先を自分のループバックに設定、SR ポリシーと同じカプセルで注入）。
+  - SRv6 では **SRH 内フローラベル(20bit)** で ECMP パスごとの活性を監視。
+  - 商用名 **Integrated Performance Measurement (IPM)**。STAMP 準拠、uSID ポリシー統合。
+- 背景: S-BFD(接続性) と STAMP(性能) の併用は複雑/高コスト → 統合提案 `draft-gandhi-spring-sr-enhanced-plm`。
+
+### Juniper（Junos / Evolved）: SRv6 でも S-BFD 可
+- SRv6 TE パスに S-BFD 対応:
+  - ingress: `[edit protocols bfd] sbfd local-discriminator`、SRv6 TE パス側 `bfd-liveness-detection` 配下に `sbfd remote-discriminator`。
+  - egress(responder): `sbfd local-discriminator <n> local-ipv6-address <addr>`。responder の local = ingress の remote と一致必須。
+  - IPv6 ローカルホストアドレス限定の responder 向けに `bfd-liveness-detection sbfd destination-ipv6-local-host`。
+- STAMP/TWAMP/RPM も別途あり（性能測定）。
+
+### Nokia（SR-OS）: SRv6 Policy に S-BFD
+- SRv6 Policy への Seamless BFD で「silent」やデータパス障害を高速検知。
+- アクティブポリシーのセグメントリストで S-BFD ダウン → フェイルオーバー。全 S-BFD ダウン → SRv6 最短パスへフォールバック。
+
+### 参考: Huawei / H3C
+- SRv6 TE policy に S-BFD（静的セッションのみ、remote discriminator 手動必須）。
+
+### End.X（隣接 SID）監視について（重要）
+- 上記 S-BFD/PM はいずれも **エンドツーエンドのセグメントリスト（SR ポリシー）単位**の監視。「特定 End.X SID だけを専用セッションで」という機能ではない。
+- 個々の End.X（uSID 表記では uA SID）の死活は **IGP(IS-IS) 隣接状態に従属**:
+  - リンク/隣接ダウン → IGP が End.X SID を withdraw → 保護付きなら TI-LFA バックアップへ。
+- したがって **End.X 単位の高速検知 = リンクの classic BFD ＋ IGP withdraw ＋ TI-LFA**、End.X を含む特定パスの到達性 = S-BFD/PM で端から端まで監視、という二層構成。
+- SRv6 で BFD/S-BFD の**返り経路を決定的にしたい**場合、SRH に順方向＋逆方向の SID リストを両方入れて返りパスを固定する手法あり（特定 End.X 経由パスのピンポイント監視に有効）。
+
+---
+
+## 6. ディスクリミネータの取得方法（各社）
+
+> 取得方法は大きく 3 系統: 手動設定 / IP アドレス由来 / IGP 広告による自動配布。
+
+### 標準（自動配布の土台）
+- 32bit 値、管理ドメイン内で一意（RFC 7880）。
+- **RFC 7883**: IS-IS の Router CAPABILITY TLV で広告。
+- **RFC 7884**: OSPF の Router Information (RI) TLV（**Type 11**）で広告（OSPFv2/v3）。情報変更は SPF を起こさない。
+- 上記を **BGP-LS** でコントローラへエクスポート可能。
+
+### ベンダー別
+| ベンダー | 手動 | IP 由来 | IGP 広告(7883/7884) | メモ |
+|---|---|---|---|---|
+| **Cisco IOS-XR** | ○ | ○ | （明示確認できず） | reflector: `local-discriminator {ipv4-address \| 32bit \| dynamic \| interface}`。initiator: **RTI テーブル**で宛先→remote discriminator マッピング（`remote-target ipv4 <addr>`）。IPv4 宛なら宛先アドレスをそのまま remote discriminator に使える。XRv9k は S-BFD 非対応 |
+| **Juniper** | ○ | ○ | - | Evolved 22.4R1〜 `set protocols bfd sbfd local-discriminator-ip` でトンネルエンドポイントから remote 自動導出、共通 sBFD テンプレート |
+| **Nokia SR-OS** | ○ | - | **○（最も自動化）** | 7883/7884 で IGP リンクステートに opaque 情報としてエンコード → BGP-LS でエクスポート |
+| **Huawei/H3C** | ○（必須） | ○(整数変換) | - | SRv6 でも静的のみ、remote discriminator 手動必須 |
+
+---
+
+## 7. Classic BFD Echo の片方向運用
+
+- **可能。Echo は本質的にシステム単位で独立した非対称機能。** 片側(A)だけが Echo を運用し、対向(B)は折り返しに徹する、が自然な形。
+- A の Echo は A→B→A と往復するので物理両方向を試験するが、**死活が分かるのは A だけ**。B も欲しければ B が独立に B→A→B を回す（= 2 本の独立した片方向 Echo）。
+- **ネゴシエーション上の注意 `Required Min Echo RX Interval`**:
+  - 「自分が Echo 受信(折り返し処理)をどの最小間隔まで支えられるか」を相手に伝える値。
+  - **0 = Echo 受信非対応** → 相手は Echo を送ってはいけない。
+  - 片方向 Echo 成立条件: A は Echo 有効化、B は自分の Echo は不要だが **Echo 受信サポート（非ゼロ）を広告**する必要あり。
+- **前提**: classic Echo は単独セッションではなく、**先に非同期制御セッションが Up している前提**の補助機能。Echo 活性時は制御パケットレートを下げてよい。
+- **単一ホップ専用**（RFC 5881）。マルチホップ BFD（RFC 5883）に Echo は無い。
+- → この非対称性が「originator / reflector」分離そのもの。B(折り返し) = XDP_TX 折り返しに乗る側。
+
+---
+
+## 8. FRR の BFD Echo 既定値と「分散BFD」
+
+### FRR の Echo 既定
+- **`echo-mode`（Echo 送信）= デフォルト off（無効）。**
+- `echo receive-interval`（対向 Echo の折り返し受け入れ能力）= **デフォルト 50ms（非ゼロ）**。
+  - → FRR は既定で「自分から Echo は起こさないが、相手の Echo は折り返す」reflector 的状態。
+- `show bfd peers` の既定表示は `Echo transmission interval: disabled`。
+- **FRR 固有の注意**: 分散 BFD でない限り、**Echo は対向も FRR のときだけ機能**（FRR が折り返しをソフトウェアで処理する実装都合）。商用ルータ相手に FRR Echo を当てにしない。
+- 対比: 古い classic Cisco IOS は **Echo デフォルト on**。既定の向きはベンダーで割れるので相互接続時は両端確認。
+
+### 分散 BFD（distributed BFD）とは
+2 つの意味:
+1. **一般的意味**: BFD セッションの周期送受信と検知タイマーを **ラインカード/データプレーン（ASIC/NPU）にオフロード**。RP は生成/削除と状態通知のみ。→ スケール、サブ 10ms タイマー、RP 切替/GR 中も BFD 維持。
+2. **FRR の意味**: 制御プレーン(`bfdd`) と データプレーンを分離。**独自の BFD Data Plane Protocol (`bfddp`)**（`bfdd/bfddp_packet.h`）で外部データプレーン（HW/SmartNIC/別ソフトフォワーダ/ASIC）と session 設定・状態を交換。制御は FRR、足回りは外部、という分担。
+- → zebra-rs 設計に直結: Rust 制御ロジック + XDP/eBPF データプレーン = まさに bfddp 分離の XDP 実装。Echo/S-BFD reflector の XDP オフロードはその「データプレーン側」。
+
+---
+
+## 9. TWAMP Light / STAMP の XDP オフロード実現性
+
+> STAMP = Simple Two-way Active Measurement Protocol (RFC 8762/8972)。TWAMP Light と合わせて制御チャネル省略 + Sender/Reflector の 2 役。
+
+### 結論
+- **liveness だけが目的**なら Reflector は純 XDP で十分実現可能（BFD echo reflector に近い）。
+- **正確な遅延/ロス測定**まで狙うと XDP 単体ではタイムスタンプ精度で頭打ち → HW タイムスタンプ統合か AF_XDP へ。
+
+### Reflector 側（BFD echo より一段重い）
+- やること: 受信時刻 T2 取得、Sender の Seq/Timestamp/Error Estimate を「Sender〜」フィールドへコピー、Reflector の Seq(stateless=Sender seq / stateful=マップ) と TX 時刻 T3 埋め込み、src/dst IP・port・MAC 入替、IP/UDP チェックサム増分修正、`XDP_TX`。
+- **XDP 有利な点**: Sender パケットはパディング(MBZ)を持ち、Reflector の追加フィールドがその中に収まる設計 → **パケット長を変えず in-place 上書き可**（`bpf_xdp_adjust_tail` 不要）。固定レイアウトで bounds check も素直。
+- **難所**:
+  - **タイムスタンプ精度**: RX は XDP がドライバ直後なので良好、対応ドライバなら `bpf_xdp_metadata_rx_timestamp` で HW RX 時刻。TX は `XDP_TX` で実送出前に T3 を書くため原理的誤差。HW TX タイムスタンプの反映は実用上困難。
+  - **クロックドメイン**: STAMP は NTP/PTP 形式。`bpf_ktime_get_ns` は単調時計。PHC 同期環境では HW タイムスタンプ側が正確。純 XDP は SW 時計ベース → Error Estimate で不確かさを大きめ申告。
+  - **認証(HMAC-SHA256)**: XDP データパスで非現実的 → **authenticated は XDP 不可、unauth のみ**。
+  - **TLV(RFC 8972)**: 可変長 TLV ループは verifier 制約と相性悪。Direct Measurement(統計読出)等は XDP で扱いにくい。ベース(TLV なし)はトリビアル。
+  - **SRv6 encap**: IPv6+SRH+UDP+STAMP のパース、返り経路で逆 SR Policy を積むなら `bpf_xdp_adjust_head` で SRH push（重い）。loopback モードなら通常 SRv6 フォワーディングに任せられて軽い。
+
+### Sender 側（BFD originator と同じ）
+- 周期送信 → `bpf_timer` / ユーザ空間。RX 検証と detect-timer リセットは XDP 可。遅延/ロス計算が要るならユーザ空間へ punt。
+
+### 用途別実現性
+| 用途 | 純 XDP | 備考 |
+|---|---|---|
+| liveness のみ (unauth, TLV なし, IPv4/単一ホップ IPv6) | ◎ | BFD echo reflector 並み。SW 時計で十分 |
+| 粗い遅延/ロス測定 | ○ | HW RX タイムスタンプ推奨、TX 精度は割り切り |
+| 高精度遅延(PTP 級) | △ | HW タイムスタンプ必須、TX 側に原理的誤差 |
+| authenticated / TLV リッチ / 逆 SRH encap | ✗ | AF_XDP / ハイブリッドへ |
+
+### 現実解: AF_XDP ハイブリッド
+- XDP で対象 UDP（STAMP 既定 UDP 862）だけ AF_XDP(XSK) へ redirect → ユーザ空間高速パスで書換・タイムスタンプ(PHC)・HMAC/TLV/逆 SRH encap。性能と機能の両立。
+
+### 環境注意
+- Parallels on Apple Silicon の仮想 NIC は HW タイムスタンプも native XDP metadata も期待不可 → ラボは SW 時計＋generic/native XDP 止まり前提。精度評価は実機 NIC(mlx5 等)。
+
+---
+
+## 10. aya（Rust eBPF ライブラリ）
+
+- Rust で eBPF を書くためのライブラリ/フレームワーク。**libbpf/bcc 非依存、純 Rust、syscall は libc crate のみ。**
+- **2 crate 構成**: ユーザ空間 `aya`（ロード/マップ管理/アタッチ/イベント受信）+ カーネル空間 `aya-ebpf`（旧 aya-bpf、eBPF プログラム本体）。両者でデータ構造を共有可。
+- **利点**: C ツールチェーン/カーネルヘッダ/カーネルビルド不要、ビルド高速。**BTF → CO-RE**（再コンパイル不要で別カーネルで動く）。musl リンクで単一自己完結バイナリ。ユーザ空間は tokio/async-std で async 対応。
+- 対応: XDP / TC / kprobe / tracepoint / cgroup_skb、hash map / array / ring buffer 等。
+- ドキュメント: aya-rs.dev（Aya Book）。
+- → 「ユーザ空間(aya)=制御プレーン、カーネル(aya-ebpf)=データプレーン」が分散 BFD の control/data 分離と対応。zebra-agent(nftables→eBPF) の延長で reflector データパスを追加していく形。
+
+---
+
+## 11. zebra-rs 実装に向けたまとめ・次アクション
+
+### アーキテクチャ方針
+- **制御プレーン**: zebra-rs / Rust（セッション管理、IGP/BGP クライアント通知、discriminator マッピングテーブル）。
+- **データプレーン**: aya-ebpf / XDP（reflector の折り返し、RX 検証、detect-timer リセット）。
+- **TX タイマー / タイムアウト検知**: `bpf_timer`(5.15+) かユーザ空間。
+- **フル機能（高精度測定・認証・SRv6 逆 encap）**: AF_XDP に redirect。
+
+### 相互接続の整合ポイント（discriminator）
+- reflector の local discriminator を **IPv6 ループバック由来**で持つ → Cisco/Juniper/Huawei と噛む。
+- initiator 側で **エンドポイント IP → remote discriminator マッピング表**（Cisco の RTI 相当）。
+- Nokia 流の完全自動運用に合わせるなら、**IS-IS 実装に RFC 7883 の S-BFD Discriminator sub-TLV** 送受信を追加 → BGP-LS に載せる（zebra-rs は IS-IS/BGP-LS 既にあるので自然な拡張）。
+
+### SRv6 相手別の必要実装
+- **Nokia / Juniper 相手**: SRv6 上の **S-BFD**（reflector/initiator、IPv6 discriminator）。
+- **Cisco（IOS-XR）相手の SRv6**: 先方は S-BFD を話さず **STAMP ベース PM liveness** → zebra-rs 側も **STAMP (RFC 8762/8972, TWAMP-light) responder/sender** が必要。
+  - → Nokia/Juniper 向けは S-BFD reflector の XDP オフロード、Cisco SRv6 向けは STAMP reflector を検討。
+
+### 段階的実装案（XDP/aya）
+1. **第 1 段**: unauth STAMP（or S-BFD）liveness reflector を純 XDP（in-place 書換＋`XDP_TX`）。Cisco SRv6 の loopback liveness / Nokia/Juniper の S-BFD に当てる。
+2. **第 2 段**: 精度/機能が要る所だけ AF_XDP へ redirect。
+3. 並行して originator/sender 側の TX タイマー（`bpf_timer` or ユーザ空間）と detect タイムアウト。
+
+### 未着手 / 深掘り候補
+- IS-IS RFC 7883 の Router CAPABILITY TLV 内 S-BFD Discriminator sub-TLV のエンコード仕様。
+- unauth STAMP reflector の XDP パケット書換骨子（フィールドオフセット、チェックサム増分、aya/Rust ローダ）。
+- SRv6 loopback モードでの返り経路設計。
+- FRR `bfddp` メッセージ仕様（互換にするか独自データプレーンプロトコルにするか）。
+
+---
+
+## 参考リンク（一次情報優先）
+
+### RFC / IETF
+- RFC 5880 BFD / RFC 5881 BFD for IPv4/IPv6 single-hop / RFC 5883 Multihop BFD
+- RFC 7880 Seamless BFD: https://datatracker.ietf.org/doc/html/rfc7880
+- RFC 7881 S-BFD for IPv4/IPv6/MPLS
+- RFC 7883 S-BFD Discriminators in IS-IS: https://www.rfc-editor.org/rfc/rfc7883.html
+- RFC 7884 S-BFD Discriminators in OSPF: https://www.rfc-editor.org/rfc/rfc7884.html
+- RFC 8762 STAMP / RFC 8972 STAMP Optional Extensions / RFC 8986 SRv6 Network Programming
+- draft-gandhi-spring-sr-enhanced-plm: https://datatracker.ietf.org/doc/html/draft-gandhi-spring-sr-enhanced-plm
+
+### ベンダードキュメント
+- Cisco IOS-XE S-BFD with SR: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/seg_routing/configuration/xe-17/segrt-xe-17-book/m_sr-smlsbfd-sspf.html
+- Cisco SRv6 Performance Measurement: https://www.cisco.com/c/en/us/td/docs/iosxr/cisco8000/srv6/b-srv6-configuration-guide/m-performance-measurement.html
+- Cisco IOS-XR BFD Commands (discriminator): https://www.cisco.com/c/en/us/td/docs/iosxr/ncs5500/routing/b-ncs5500-routing-cli-reference/b-ncs5500-routing-cli-reference_chapter_0111.html
+- Juniper Segment Routing LSP (S-BFD over SRv6 TE): https://www.juniper.net/documentation/us/en/software/junos/mpls/topics/topic-map/segment-routing-lsp-configuration.html
+- Juniper BFD overview: https://www.juniper.net/documentation/us/en/software/junos/high-availability/topics/topic-map/bfd.html
+- Nokia Seamless BFD for SR-TE LSPs: https://documentation.nokia.com/acg/23-7-2/books/classic-cli-part-i/c212-s-bfd.html
+- Nokia Automated S-BFD discriminator distribution: https://infocenter.nokia.com/public/7750SR225R1A/topic/com.nokia.OAM_Guide/automated_s-bfd-ai9exgsvaa.html
+- Arista EOS BFD/S-BFD: https://www.arista.com/en/um-eos/eos-bidirectional-forwarding-detection
+
+### FRR / eBPF / aya
+- FRR BFD (echo-mode 既定, distributed BFD): https://docs.frrouting.org/en/latest/bfd.html
+- FRR bfd.rst (bfddp): https://github.com/FRRouting/frr/blob/master/doc/user/bfd.rst
+- aya: https://github.com/aya-rs/aya / https://aya-rs.dev/ / https://docs.rs/aya
+- Cilium BFD 議論: https://github.com/cilium/cilium/issues/22394

--- a/offload/bfd-echo-reflector/.cargo/config.toml
+++ b/offload/bfd-echo-reflector/.cargo/config.toml
@@ -1,0 +1,4 @@
+# Attaching/detaching an XDP program needs CAP_NET_ADMIN, so `cargo run` is
+# wrapped in sudo. `-E` preserves the environment (e.g. RUST_LOG) for the binary.
+[target."cfg(all())"]
+runner = "sudo -E"

--- a/offload/bfd-echo-reflector/.gitignore
+++ b/offload/bfd-echo-reflector/.gitignore
@@ -1,0 +1,2 @@
+# The root .gitignore only anchors `/target`; ignore this nested build dir too.
+/target

--- a/offload/bfd-echo-reflector/Cargo.toml
+++ b/offload/bfd-echo-reflector/Cargo.toml
@@ -1,0 +1,37 @@
+[workspace]
+resolver = "2"
+members = ["loader", "ebpf"]
+# `cargo build` (no --workspace) builds only the userspace loader. The loader's
+# build.rs (aya-build) compiles the `ebpf` crate for the `bpfel-unknown-none`
+# target via `rustup run nightly cargo ... -Z build-std=core`, so the eBPF crate
+# must NOT be built for the host as a normal member.
+default-members = ["loader"]
+
+[workspace.package]
+license = "MIT OR Apache-2.0"
+edition = "2024"
+
+# aya is pulled from git to match the current aya-template build glue
+# (aya_build::Package / build_ebpf(.., Toolchain) API on `main`). Pin a rev here
+# if you want fully reproducible builds.
+[workspace.dependencies]
+aya = { git = "https://github.com/aya-rs/aya", default-features = false }
+aya-build = { git = "https://github.com/aya-rs/aya", default-features = false }
+aya-ebpf = { git = "https://github.com/aya-rs/aya", default-features = false }
+aya-log = { git = "https://github.com/aya-rs/aya", default-features = false }
+aya-log-ebpf = { git = "https://github.com/aya-rs/aya", default-features = false }
+
+anyhow = { version = "1", default-features = false }
+cargo_metadata = { version = "0.23.0", default-features = false }
+# clap currently needs the `std` feature to build.
+clap = { version = "4.5.20", default-features = false, features = ["std"] }
+env_logger = { version = "0.11.5", default-features = false }
+libc = { version = "0.2.159", default-features = false }
+log = { version = "0.4.22", default-features = false }
+tokio = { version = "1.40.0", default-features = false }
+which = { version = "6.0.0", default-features = false }
+
+[profile.release.package.bfd-echo-reflector-ebpf]
+debug = 2
+codegen-units = 1
+strip = false

--- a/offload/bfd-echo-reflector/README.md
+++ b/offload/bfd-echo-reflector/README.md
@@ -74,38 +74,38 @@ RUST_LOG=info cargo run --release -- --iface veth0
 sudo RUST_LOG=info ./target/release/bfd-echo-reflector -i veth0
 ```
 
-It attaches in native/driver XDP if the NIC supports it, otherwise falls back to
-generic **SKB mode** (expected on virtual NICs, e.g. Parallels on Apple Silicon).
+`--mode auto` (default) attaches native/driver XDP and falls back to generic
+**SKB mode**. On **veth and virtual NICs** native XDP *attaches* but does not
+loop frames to the program, so force generic mode with **`-m skb`** there
+(`-m native` forces driver mode). Validated in SKB mode on the
+Parallels/aarch64 lab.
 
 ## Verify end-to-end (veth pair)
 
+One command (builds first if needed):
+
 ```sh
-# 1. create a veth pair and address it
-sudo ip link add veth0 type veth peer name veth1
-sudo ip link set veth0 up && sudo ip link set veth1 up
-sudo ip addr add 10.123.0.1/24 dev veth0
-sudo ip addr add 10.123.0.2/24 dev veth1
-
-# 2. attach the reflector on veth0
-RUST_LOG=info cargo run --release -- --iface veth0    # logs "attached … (generic/SKB XDP)"
-
-# 3. watch veth1 and send a UDP/3785 frame toward veth0
-sudo tcpdump -nei veth1 udp port 3785 &
-sudo python3 - <<'PY'
-from socket import socket, AF_INET, SOCK_DGRAM
-s = socket(AF_INET, SOCK_DGRAM); s.bind(("10.123.0.2", 0))
-s.sendto(b"bfd-echo-test", ("10.123.0.1", 3785))
-PY
+sudo bash scripts/veth-test.sh
 ```
 
-**Pass criteria:** the frame sent toward `veth0:3785` reappears on `veth1` with
-the Ethernet source/destination swapped and the payload intact; non-3785 traffic
-is unaffected. The reflector also prints `BFD Echo udp/3785 reflected (XDP_TX)`
-per reflected frame (via `aya-log`).
+It creates a veth pair with the **sender end in its own network namespace**,
+attaches the reflector (`-m skb`) on the root-ns end, sends 3 UDP/3785 frames
+from the namespace, and confirms a reflected frame arrives back. Expected tail:
 
-> On a veth pair, `XDP_TX` re-transmits out the same interface, i.e. toward the
-> peer end — so the sender on `veth1` sees the bounced frame. Cleanup:
-> `sudo ip link del veth0`.
+```
+PASS: BFD Echo frame reflected via XDP_TX
+      (reflector logged 3 reflect(s); 1 inbound frame(s) on bfde1)
+```
+
+The namespace is required: if both veth ends share a namespace the kernel
+delivers `10.123.0.2 -> 10.123.0.1` locally via loopback and the frame never
+crosses the wire, so the XDP hook never fires.
+
+**Pass criteria:** the sent `udp/3785` frame reappears *inbound* on the sender's
+veth with the Ethernet source/destination swapped (`tcpdump -e` shows the swap;
+it even decodes as `BFD, Echo`), and the reflector logs `BFD Echo udp/3785
+reflected (XDP_TX)`. `XDP_TX` re-transmits out the same interface, i.e. toward
+the peer end, so the sender sees the bounce.
 
 ## Limitations / next slices
 

--- a/offload/bfd-echo-reflector/README.md
+++ b/offload/bfd-echo-reflector/README.md
@@ -12,7 +12,7 @@ hairpin — no IP/UDP checksum recompute, no TTL decrement. Everything else
 This is the smallest, best-fit first piece of the broader BFD/S-BFD/STAMP XDP
 offload effort: the reflector is stateless, so it maps cleanly onto XDP. The
 originator/sender side (which needs periodic TX timers) is **not** part of this
-PoC. See `../../bfd-sbfd-stamp-xdp-offload-notes.md` and
+PoC. See `../../docs/design/bfd-sbfd-stamp-xdp-offload-notes.md` and
 `../../docs/design/bfd-echo-plan.md`.
 
 > **Status:** scaffolding + program written, **not yet compiled or run** in this

--- a/offload/bfd-echo-reflector/README.md
+++ b/offload/bfd-echo-reflector/README.md
@@ -1,0 +1,118 @@
+# bfd-echo-reflector — XDP BFD Echo reflector (PoC)
+
+A standalone proof-of-concept that reflects **BFD Echo** frames (UDP **3785**,
+RFC 5880 §6.4 / RFC 5881 §4) in the data plane using **XDP/eBPF** (via
+[aya](https://aya-rs.dev/)).
+
+A matching IPv4 UDP/3785 frame has its Ethernet source/destination MAC swapped
+and is sent straight back out the same interface (`XDP_TX`). It is a pure L2
+hairpin — no IP/UDP checksum recompute, no TTL decrement. Everything else
+(including BFD **control** on UDP/3784) is passed through untouched.
+
+This is the smallest, best-fit first piece of the broader BFD/S-BFD/STAMP XDP
+offload effort: the reflector is stateless, so it maps cleanly onto XDP. The
+originator/sender side (which needs periodic TX timers) is **not** part of this
+PoC. See `../../bfd-sbfd-stamp-xdp-offload-notes.md` and
+`../../docs/design/bfd-echo-plan.md`.
+
+> **Status:** scaffolding + program written, **not yet compiled or run** in this
+> repo — the eBPF toolchain (bpf-linker + LLVM) was not installed when it was
+> authored. Build it with the steps below and report back.
+
+## Layout
+
+```
+bfd-echo-reflector/
+├── Cargo.toml      # workspace root (own workspace; excluded from zebra-rs)
+├── .cargo/config.toml  # `cargo run` -> sudo (XDP attach needs CAP_NET_ADMIN)
+├── loader/         # userspace: load + attach the XDP program (aya)
+│   ├── build.rs    # aya-build: compiles ebpf/ for bpfel-unknown-none
+│   └── src/main.rs
+└── ebpf/           # the XDP program (no_std), built for bpfel-unknown-none
+    ├── src/lib.rs  # trivial lib target (host build-dep, cache tracking)
+    └── src/main.rs # bfd_echo_reflect: udp/3785 -> swap MAC -> XDP_TX
+```
+
+This tree is **excluded** from the top-level zebra-rs workspace
+(`exclude = ["offload/*"]`), so the stable CI gate
+(`cargo {build,clippy,test} --workspace`) never tries to build it.
+
+## Prerequisites (one-time)
+
+Kernel 5.x+ with XDP (this lab is 6.8 — fine). Then:
+
+```sh
+# 1. nightly toolchain with rust-src (aya-build invokes `rustup run nightly … -Z build-std=core`)
+rustup toolchain install nightly --component rust-src
+
+# 2. LLVM — needed to build/install bpf-linker (NEEDS sudo)
+sudo apt install -y llvm        # Debian/Ubuntu; use your distro's LLVM package otherwise
+
+# 3. bpf-linker (links the eBPF object; a few minutes to compile)
+cargo install bpf-linker
+```
+
+If `cargo install bpf-linker` fails to find LLVM, follow the platform notes in
+the [bpf-linker README](https://github.com/aya-rs/bpf-linker#installation).
+
+## Build
+
+```sh
+cd offload/bfd-echo-reflector
+cargo build --release        # build.rs compiles the eBPF object via nightly+bpf-linker
+```
+
+(`cargo build` builds only the `loader`; the eBPF crate is compiled for
+`bpfel-unknown-none` by `loader/build.rs`. Do **not** use `--workspace`.)
+
+## Run
+
+```sh
+# `cargo run` is wrapped in sudo via .cargo/config.toml
+RUST_LOG=info cargo run --release -- --iface veth0
+# or run the binary directly:
+sudo RUST_LOG=info ./target/release/bfd-echo-reflector -i veth0
+```
+
+It attaches in native/driver XDP if the NIC supports it, otherwise falls back to
+generic **SKB mode** (expected on virtual NICs, e.g. Parallels on Apple Silicon).
+
+## Verify end-to-end (veth pair)
+
+```sh
+# 1. create a veth pair and address it
+sudo ip link add veth0 type veth peer name veth1
+sudo ip link set veth0 up && sudo ip link set veth1 up
+sudo ip addr add 10.123.0.1/24 dev veth0
+sudo ip addr add 10.123.0.2/24 dev veth1
+
+# 2. attach the reflector on veth0
+RUST_LOG=info cargo run --release -- --iface veth0    # logs "attached … (generic/SKB XDP)"
+
+# 3. watch veth1 and send a UDP/3785 frame toward veth0
+sudo tcpdump -nei veth1 udp port 3785 &
+sudo python3 - <<'PY'
+from socket import socket, AF_INET, SOCK_DGRAM
+s = socket(AF_INET, SOCK_DGRAM); s.bind(("10.123.0.2", 0))
+s.sendto(b"bfd-echo-test", ("10.123.0.1", 3785))
+PY
+```
+
+**Pass criteria:** the frame sent toward `veth0:3785` reappears on `veth1` with
+the Ethernet source/destination swapped and the payload intact; non-3785 traffic
+is unaffected. The reflector also prints `BFD Echo udp/3785 reflected (XDP_TX)`
+per reflected frame (via `aya-log`).
+
+> On a veth pair, `XDP_TX` re-transmits out the same interface, i.e. toward the
+> peer end — so the sender on `veth1` sees the bounced frame. Cleanup:
+> `sudo ip link del veth0`.
+
+## Limitations / next slices
+
+- **IPv4 only** (EtherType 0x0800). IPv6 (0x86DD) is a follow-up.
+- Option-less IPv4 only (IHL=5); BFD Echo frames carry no IP options.
+- Reflector only — no originator/sender, no detect timer, no FSM wiring.
+- Not yet integrated into zebra-rs (no config, no advertising non-zero
+  `Required Min Echo RX Interval`).
+- aya deps are pulled from git to match the current build glue; pin a rev for
+  reproducible builds.

--- a/offload/bfd-echo-reflector/ebpf/Cargo.toml
+++ b/offload/bfd-echo-reflector/ebpf/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "bfd-echo-reflector-ebpf"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+aya-ebpf = { workspace = true }
+aya-log-ebpf = { workspace = true }
+
+[build-dependencies]
+# Build fails fast with a clear error if bpf-linker is not on $PATH.
+which = { workspace = true }
+
+[[bin]]
+name = "bfd-echo-reflector"
+path = "src/main.rs"
+
+# No `[profile]` here: the eBPF object is built by the loader's build.rs via
+# aya-build, which applies the `[profile.release.package.*]` settings declared in
+# the workspace root manifest.

--- a/offload/bfd-echo-reflector/ebpf/build.rs
+++ b/offload/bfd-echo-reflector/ebpf/build.rs
@@ -1,0 +1,13 @@
+use which::which;
+
+/// Building this crate has an undeclared dependency on the `bpf-linker` binary.
+/// This build script makes the failure mode obvious (a clear "not found" error
+/// instead of a confusing link failure) and asks cargo to rebuild when the
+/// resolved `bpf-linker` path changes.
+fn main() {
+    let bpf_linker = which("bpf-linker").expect(
+        "bpf-linker not found on $PATH — install it with `cargo install bpf-linker` \
+         (needs LLVM; see this crate's README)",
+    );
+    println!("cargo:rerun-if-changed={}", bpf_linker.to_str().unwrap());
+}

--- a/offload/bfd-echo-reflector/ebpf/src/lib.rs
+++ b/offload/bfd-echo-reflector/ebpf/src/lib.rs
@@ -1,0 +1,5 @@
+#![no_std]
+
+// This file exists only to provide a library target. Cargo builds it for the
+// host as a (cache-tracking) build-dependency of the loader, while aya-build
+// compiles the binary target (`src/main.rs`) for `bpfel-unknown-none`.

--- a/offload/bfd-echo-reflector/ebpf/src/main.rs
+++ b/offload/bfd-echo-reflector/ebpf/src/main.rs
@@ -1,0 +1,122 @@
+#![no_std]
+#![no_main]
+
+//! XDP BFD Echo reflector (RFC 5880 §6.4 / RFC 5881 §4).
+//!
+//! BFD Echo is a stateless data-plane "hairpin": a peer sends an Echo frame to
+//! UDP/3785 crafted so that our forwarding plane loops it straight back, and the
+//! peer alone times the round trip. This program is that loopback, done in XDP:
+//! a matching frame has its Ethernet source/destination MAC swapped and is sent
+//! back out the same interface with `XDP_TX`.
+//!
+//! It is a pure L2 reflect — no IP/UDP checksum recomputation and no TTL
+//! decrement are needed, because nothing in the IP/UDP layers changes (notes
+//! §2). Everything that is not an IPv4 UDP/3785 frame is passed through
+//! untouched, so normal traffic — including BFD *control* on UDP/3784 — is
+//! unaffected.
+//!
+//! First slice: IPv4 only. IPv6 (EtherType 0x86DD) is a follow-up.
+
+use aya_ebpf::{bindings::xdp_action, macros::xdp, programs::XdpContext};
+use aya_log_ebpf::info;
+
+/// Ethernet II header layout.
+const ETH_HLEN: usize = 14;
+const ETH_DST_OFF: usize = 0; // [u8; 6] destination MAC
+const ETH_SRC_OFF: usize = 6; // [u8; 6] source MAC
+const ETH_TYPE_OFF: usize = 12; // u16 (big-endian) EtherType
+const ETHERTYPE_IPV4: u16 = 0x0800;
+
+/// IPv4 fixed-header fields (relative to the start of the frame). Only
+/// option-less headers (IHL=5) are handled; see `try_reflect`.
+const IP_OFF: usize = ETH_HLEN;
+const IP_VER_IHL_OFF: usize = IP_OFF; // u8: high nibble = version, low = IHL
+const IP_PROTO_OFF: usize = IP_OFF + 9; // u8
+const IPPROTO_UDP: u8 = 17;
+const IPV4_VER_IHL_NOOPTS: u8 = 0x45; // version 4, IHL 5 (20-byte header)
+
+/// UDP header (assumes a 20-byte IPv4 header, i.e. IHL=5).
+const UDP_OFF: usize = IP_OFF + 20;
+const UDP_DST_OFF: usize = UDP_OFF + 2; // u16 (big-endian) destination port
+
+/// BFD Echo destination port (RFC 5881 §4). BFD control is 3784; multihop 4784.
+const BFD_ECHO_PORT: u16 = 3785;
+
+/// Read a `u8` at `off` bytes into the frame, after a verifier-friendly bounds
+/// check against `data_end`.
+#[inline(always)]
+unsafe fn load_u8(ctx: &XdpContext, off: usize) -> Result<u8, ()> {
+    let ptr = ctx.data() + off;
+    if ptr + 1 > ctx.data_end() {
+        return Err(());
+    }
+    Ok(unsafe { *(ptr as *const u8) })
+}
+
+/// Read a big-endian `u16` at `off` bytes into the frame, with bounds check.
+#[inline(always)]
+unsafe fn load_u16_be(ctx: &XdpContext, off: usize) -> Result<u16, ()> {
+    let ptr = ctx.data() + off;
+    if ptr + 2 > ctx.data_end() {
+        return Err(());
+    }
+    let hi = unsafe { *(ptr as *const u8) } as u16;
+    let lo = unsafe { *((ptr + 1) as *const u8) } as u16;
+    Ok((hi << 8) | lo)
+}
+
+#[xdp]
+pub fn bfd_echo_reflect(ctx: XdpContext) -> u32 {
+    match try_reflect(&ctx) {
+        Ok(action) => action,
+        // A truncated/short frame just falls through to the stack.
+        Err(()) => xdp_action::XDP_PASS,
+    }
+}
+
+fn try_reflect(ctx: &XdpContext) -> Result<u32, ()> {
+    // Ethernet II, IPv4 only for this first slice.
+    if unsafe { load_u16_be(ctx, ETH_TYPE_OFF)? } != ETHERTYPE_IPV4 {
+        return Ok(xdp_action::XDP_PASS);
+    }
+
+    // Only option-less IPv4 (IHL=5). BFD Echo frames carry no IP options; a
+    // packet with options would shift the UDP header and is left to the stack.
+    if unsafe { load_u8(ctx, IP_VER_IHL_OFF)? } != IPV4_VER_IHL_NOOPTS {
+        return Ok(xdp_action::XDP_PASS);
+    }
+    if unsafe { load_u8(ctx, IP_PROTO_OFF)? } != IPPROTO_UDP {
+        return Ok(xdp_action::XDP_PASS);
+    }
+
+    if unsafe { load_u16_be(ctx, UDP_DST_OFF)? } != BFD_ECHO_PORT {
+        return Ok(xdp_action::XDP_PASS);
+    }
+
+    // Prove the full 14-byte Ethernet header (both MACs) is in bounds, then swap
+    // source/destination MAC in place and bounce the frame straight back out.
+    let start = ctx.data();
+    if start + ETH_HLEN > ctx.data_end() {
+        return Err(());
+    }
+    unsafe {
+        let dst = (start + ETH_DST_OFF) as *mut [u8; 6];
+        let src = (start + ETH_SRC_OFF) as *mut [u8; 6];
+        let tmp = *dst;
+        *dst = *src;
+        *src = tmp;
+    }
+
+    info!(ctx, "BFD Echo udp/{} reflected (XDP_TX)", BFD_ECHO_PORT);
+    Ok(xdp_action::XDP_TX)
+}
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[unsafe(link_section = "license")]
+#[unsafe(no_mangle)]
+static LICENSE: [u8; 13] = *b"Dual MIT/GPL\0";

--- a/offload/bfd-echo-reflector/loader/Cargo.toml
+++ b/offload/bfd-echo-reflector/loader/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "bfd-echo-reflector"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true, default-features = true }
+aya = { workspace = true }
+aya-log = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+env_logger = { workspace = true }
+libc = { workspace = true }
+log = { workspace = true }
+tokio = { workspace = true, features = [
+    "macros",
+    "rt",
+    "rt-multi-thread",
+    "net",
+    "signal",
+] }
+
+[build-dependencies]
+anyhow = { workspace = true }
+aya-build = { workspace = true }
+cargo_metadata = { workspace = true }
+# Declared so cargo tracks the eBPF crate for cache invalidation. It is actually
+# compiled for `bpfel-unknown-none` by build.rs (aya-build), not as a normal
+# host build-dependency — see the aya-template for the rationale.
+bfd-echo-reflector-ebpf = { path = "../ebpf" }
+
+[[bin]]
+name = "bfd-echo-reflector"
+path = "src/main.rs"

--- a/offload/bfd-echo-reflector/loader/build.rs
+++ b/offload/bfd-echo-reflector/loader/build.rs
@@ -1,0 +1,31 @@
+use anyhow::{Context as _, anyhow};
+use aya_build::Toolchain;
+
+/// Compile the `bfd-echo-reflector-ebpf` crate for the `bpfel-unknown-none`
+/// target and emit the object into `OUT_DIR`, where `main.rs` embeds it via
+/// `include_bytes_aligned!`. `Toolchain::default()` resolves to `nightly`, and
+/// aya-build invokes it with `-Z build-std=core`.
+fn main() -> anyhow::Result<()> {
+    let cargo_metadata::Metadata { packages, .. } = cargo_metadata::MetadataCommand::new()
+        .no_deps()
+        .exec()
+        .context("MetadataCommand::exec")?;
+    let ebpf_package = packages
+        .into_iter()
+        .find(|cargo_metadata::Package { name, .. }| name.as_str() == "bfd-echo-reflector-ebpf")
+        .ok_or_else(|| anyhow!("bfd-echo-reflector-ebpf package not found"))?;
+    let cargo_metadata::Package {
+        name,
+        manifest_path,
+        ..
+    } = ebpf_package;
+    let ebpf_package = aya_build::Package {
+        name: name.as_str(),
+        root_dir: manifest_path
+            .parent()
+            .ok_or_else(|| anyhow!("no parent for {manifest_path}"))?
+            .as_str(),
+        ..Default::default()
+    };
+    aya_build::build_ebpf([ebpf_package], Toolchain::default())
+}

--- a/offload/bfd-echo-reflector/loader/src/main.rs
+++ b/offload/bfd-echo-reflector/loader/src/main.rs
@@ -1,0 +1,86 @@
+//! Userspace loader for the XDP BFD Echo reflector.
+//!
+//! Loads the eBPF object (embedded at build time), attaches the `bfd_echo_reflect`
+//! XDP program to the requested interface, and runs until Ctrl-C. Attachment
+//! tries native/driver mode first and falls back to generic SKB mode, which is
+//! needed on virtual NICs that lack native XDP (e.g. the Parallels/Apple-Silicon
+//! lab — see the offload notes §9).
+
+use anyhow::Context as _;
+use aya::programs::{Xdp, XdpMode};
+use clap::Parser;
+#[rustfmt::skip]
+use log::{debug, info, warn};
+use tokio::signal;
+
+#[derive(Debug, Parser)]
+#[command(about = "XDP BFD Echo (udp/3785) reflector")]
+struct Opt {
+    /// Interface to attach the reflector to.
+    #[clap(short, long, default_value = "eth0")]
+    iface: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let Opt { iface } = Opt::parse();
+    env_logger::init();
+
+    // Bump the memlock rlimit. Needed on older kernels that don't use the
+    // memcg-based accounting; see https://lwn.net/Articles/837122/.
+    let rlim = libc::rlimit {
+        rlim_cur: libc::RLIM_INFINITY,
+        rlim_max: libc::RLIM_INFINITY,
+    };
+    let ret = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlim) };
+    if ret != 0 {
+        debug!("remove limit on locked memory failed, ret is: {ret}");
+    }
+
+    // Embed the eBPF object built by build.rs and load it.
+    let mut ebpf = aya::Ebpf::load(aya::include_bytes_aligned!(concat!(
+        env!("OUT_DIR"),
+        "/bfd-echo-reflector"
+    )))?;
+
+    // Forward `info!` messages emitted by the eBPF program. Failure here is
+    // non-fatal (e.g. if all log statements are removed from the program).
+    match aya_log::EbpfLogger::init(&mut ebpf) {
+        Err(e) => warn!("failed to initialize eBPF logger: {e}"),
+        Ok(logger) => {
+            let mut logger =
+                tokio::io::unix::AsyncFd::with_interest(logger, tokio::io::Interest::READABLE)?;
+            tokio::task::spawn(async move {
+                loop {
+                    let mut guard = logger.readable_mut().await.unwrap();
+                    guard.get_inner_mut().flush();
+                    guard.clear_ready();
+                }
+            });
+        }
+    }
+
+    let program: &mut Xdp = ebpf
+        .program_mut("bfd_echo_reflect")
+        .context("XDP program 'bfd_echo_reflect' not found in object")?
+        .try_into()?;
+    program.load()?;
+
+    // Native/driver XDP first (mode 0 = let the kernel pick native; it does NOT
+    // auto-fall back to generic). On failure, retry explicitly in SKB mode.
+    match program.attach(&iface, XdpMode::default()) {
+        Ok(_) => info!("attached BFD Echo reflector to {iface} (native/driver XDP)"),
+        Err(e) => {
+            warn!("native XDP attach on {iface} failed ({e}); retrying in SKB mode");
+            program
+                .attach(&iface, XdpMode::Skb)
+                .context("failed to attach XDP program in SKB mode")?;
+            info!("attached BFD Echo reflector to {iface} (generic/SKB XDP)");
+        }
+    }
+
+    info!("reflecting BFD Echo (udp/3785) on {iface}; press Ctrl-C to exit");
+    signal::ctrl_c().await?;
+    info!("exiting; detaching XDP program");
+    Ok(())
+}

--- a/offload/bfd-echo-reflector/loader/src/main.rs
+++ b/offload/bfd-echo-reflector/loader/src/main.rs
@@ -19,11 +19,16 @@ struct Opt {
     /// Interface to attach the reflector to.
     #[clap(short, long, default_value = "eth0")]
     iface: String,
+    /// XDP attach mode: `auto` (native, fall back to SKB), `native`, or `skb`.
+    /// Use `skb` on veth / virtual NICs, where native XDP *attaches* but does
+    /// not pass frames to the program.
+    #[clap(short, long, default_value = "auto")]
+    mode: String,
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let Opt { iface } = Opt::parse();
+    let Opt { iface, mode } = Opt::parse();
     env_logger::init();
 
     // Bump the memlock rlimit. Needed on older kernels that don't use the
@@ -66,17 +71,31 @@ async fn main() -> anyhow::Result<()> {
         .try_into()?;
     program.load()?;
 
-    // Native/driver XDP first (mode 0 = let the kernel pick native; it does NOT
-    // auto-fall back to generic). On failure, retry explicitly in SKB mode.
-    match program.attach(&iface, XdpMode::default()) {
-        Ok(_) => info!("attached BFD Echo reflector to {iface} (native/driver XDP)"),
-        Err(e) => {
-            warn!("native XDP attach on {iface} failed ({e}); retrying in SKB mode");
+    match mode.as_str() {
+        "skb" => {
             program
                 .attach(&iface, XdpMode::Skb)
                 .context("failed to attach XDP program in SKB mode")?;
             info!("attached BFD Echo reflector to {iface} (generic/SKB XDP)");
         }
+        "native" => {
+            program
+                .attach(&iface, XdpMode::Driver)
+                .context("failed to attach XDP program in native/driver mode")?;
+            info!("attached BFD Echo reflector to {iface} (native/driver XDP)");
+        }
+        // auto: native first (mode 0 = let the kernel pick native; it does NOT
+        // auto-fall back to generic), then retry explicitly in SKB mode.
+        _ => match program.attach(&iface, XdpMode::default()) {
+            Ok(_) => info!("attached BFD Echo reflector to {iface} (native/driver XDP)"),
+            Err(e) => {
+                warn!("native XDP attach on {iface} failed ({e}); retrying in SKB mode");
+                program
+                    .attach(&iface, XdpMode::Skb)
+                    .context("failed to attach XDP program in SKB mode")?;
+                info!("attached BFD Echo reflector to {iface} (generic/SKB XDP)");
+            }
+        },
     }
 
     info!("reflecting BFD Echo (udp/3785) on {iface}; press Ctrl-C to exit");

--- a/offload/bfd-echo-reflector/scripts/veth-test.sh
+++ b/offload/bfd-echo-reflector/scripts/veth-test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# End-to-end load test for the XDP BFD Echo reflector.
+#
+# Why a namespace: if both veth ends live in the same netns, the kernel delivers
+# 10.123.0.2 -> 10.123.0.1 locally via loopback and never puts it on the wire,
+# so the XDP hook never fires. Putting the *sender* end in its own namespace
+# forces the frame across the veth pair and through the reflector on the other
+# end.
+#
+# Flow: sender (ns) --udp/3785--> veth-root [XDP: swap MAC, XDP_TX] --> back to
+# the sender end, where we observe it arriving *inbound* with the MACs swapped.
+#
+# Run as root:
+#   sudo bash offload/bfd-echo-reflector/scripts/veth-test.sh
+set -u
+
+NS=bfdecho-ns
+V0=bfde0            # root-ns end — reflector attaches its XDP program here
+V1=bfde1           # namespace end — the sender
+IP0=10.123.0.1
+IP1=10.123.0.2
+PORT=3785
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN="$SCRIPT_DIR/../target/release/bfd-echo-reflector"
+REFLOG=/tmp/bfde_reflector.log
+CAPOUT=/tmp/bfde_tcpdump.out
+CAPERR=/tmp/bfde_tcpdump.err
+
+REFLECTOR_PID=""
+cleanup() {
+    # SIGINT lets the loader run its normal exit path (detach XDP); deleting the
+    # veth removes the program regardless, and tears down the namespace.
+    [ -n "$REFLECTOR_PID" ] && kill -INT "$REFLECTOR_PID" 2>/dev/null
+    sleep 0.3
+    ip netns del "$NS" 2>/dev/null
+    ip link del "$V0" 2>/dev/null
+}
+trap cleanup EXIT
+
+if [ "$(id -u)" -ne 0 ]; then echo "ERROR: run as root (sudo)"; exit 1; fi
+if [ ! -x "$BIN" ]; then
+    echo "ERROR: binary not found: $BIN"
+    echo "       build it first:  (cd $SCRIPT_DIR/.. && cargo build --release)"
+    exit 1
+fi
+
+echo "== 1. fresh veth pair + namespace =="
+ip netns del "$NS" 2>/dev/null; ip link del "$V0" 2>/dev/null   # clean slate
+ip netns add "$NS"
+ip link add "$V0" type veth peer name "$V1"
+ip link set "$V1" netns "$NS"
+ip addr add "$IP0/24" dev "$V0"
+ip link set "$V0" up
+ip netns exec "$NS" ip addr add "$IP1/24" dev "$V1"
+ip netns exec "$NS" ip link set "$V1" up
+ip netns exec "$NS" ip link set lo up
+echo "   root ns: $V0 ($IP0)   |   $NS: $V1 ($IP1)"
+
+echo "== 2. attach reflector on $V0 (SKB mode — native XDP does not loop on veth) =="
+RUST_LOG=info "$BIN" -i "$V0" -m skb >"$REFLOG" 2>&1 &
+REFLECTOR_PID=$!
+sleep 2
+if ! kill -0 "$REFLECTOR_PID" 2>/dev/null; then
+    echo "ERROR: reflector exited early:"; cat "$REFLOG"; exit 1
+fi
+grep -iE 'attached|mode' "$REFLOG" | sed 's/^/   /'
+ip -d link show "$V0" | grep -io 'xdp.*' | head -1 | sed 's/^/   link: /' || true
+
+echo "== 3. capture inbound udp/$PORT on $V1, then send 3 frames =="
+# Inbound-only (-Q in) so we see ONLY the reflected frame; the sent one is outbound.
+ip netns exec "$NS" timeout 6 tcpdump -lnei "$V1" -c 1 -Q in "udp port $PORT" \
+    >"$CAPOUT" 2>"$CAPERR" &
+TCPDUMP_PID=$!
+sleep 1
+ip netns exec "$NS" python3 - <<PY
+from socket import socket, AF_INET, SOCK_DGRAM
+import time
+s = socket(AF_INET, SOCK_DGRAM); s.bind(("$IP1", 0))
+for _ in range(3):
+    s.sendto(b"bfd-echo-test", ("$IP0", $PORT)); time.sleep(0.2)
+print("   sent 3x udp/$PORT  $IP1 -> $IP0")
+PY
+wait "$TCPDUMP_PID" 2>/dev/null
+
+echo "== 4. result =="
+echo "-- reflector log --"; grep -iE 'reflected|attached' "$REFLOG" | sed 's/^/   /' || true
+echo "-- tcpdump (inbound on $V1) --"; sed 's/^/   /' "$CAPOUT"
+
+reflected_log=$(grep -c -i 'reflected' "$REFLOG" 2>/dev/null) || true
+reflected_cap=$(grep -c -i "$PORT" "$CAPOUT" 2>/dev/null) || true
+reflected_log=${reflected_log:-0}
+reflected_cap=${reflected_cap:-0}
+if [ "$reflected_cap" -ge 1 ] || [ "$reflected_log" -ge 1 ]; then
+    echo
+    echo "PASS: BFD Echo frame reflected via XDP_TX"
+    echo "      (reflector logged $reflected_log reflect(s); $reflected_cap inbound frame(s) on $V1)"
+    exit 0
+else
+    echo
+    echo "FAIL: no reflected frame observed"
+    echo "-- tcpdump stderr --"; sed 's/^/   /' "$CAPERR"
+    echo "-- full reflector log --"; sed 's/^/   /' "$REFLOG"
+    exit 2
+fi


### PR DESCRIPTION
## Summary

First, smallest slice of the BFD/S-BFD/STAMP XDP-offload effort
(`docs/design/bfd-sbfd-stamp-xdp-offload-notes.md`): a stateless **BFD Echo
reflector** in XDP/eBPF, built with [aya](https://aya-rs.dev/).

A matching IPv4 `udp/3785` frame (RFC 5880 §6.4 / RFC 5881 §4) has its Ethernet
src/dst MAC swapped and is sent straight back out the same interface (`XDP_TX`) —
a pure L2 hairpin: no IP/UDP checksum recompute, no TTL decrement. Everything
else (incl. BFD control on 3784) is `XDP_PASS`. This is the forwarding-plane
responder that `docs/design/bfd-echo-plan.md` deferred.

## Layout / CI

- `offload/bfd-echo-reflector/` is **its own cargo workspace**, kept OUT of the
  zebra-rs workspace via `exclude = ["offload/*"]` in the root `Cargo.toml`, so
  the stable CI gate (`cargo {build,clippy,test} --workspace`) never builds it
  (it needs a nightly `bpfel` toolchain + bpf-linker). Verified: root
  `cargo metadata` sees 0 offload packages.
- `ebpf/` — `no_std` XDP program `bfd_echo_reflect`, compiled for
  `bpfel-unknown-none` by the loader's `build.rs` (aya-build).
- `loader/` — aya userspace: attach to an iface, `-m/--mode auto|native|skb`,
  run until Ctrl-C.

## Test plan

- `cargo build --release` produces an ELF eBPF relocatable with an `xdp` section
  exporting `bfd_echo_reflect` (built with nightly + bpf-linker).
- **Run-validated on a veth pair** (Parallels/aarch64 lab) via
  `scripts/veth-test.sh`: a `udp/3785` frame is bounced back inbound with the
  MACs swapped (tcpdump decodes it as `BFD, Echo`) and the program logs the
  reflect. Notes baked into the script: native XDP *attaches* but won't loop on
  veth (use `-m skb`); the sender end needs its own netns or the kernel
  short-circuits via loopback.

## Scope

Reflector only; IPv4 only. No originator/sender, no detect timer, no zebra-rs
integration, no advertising non-zero `Required Min Echo RX Interval` yet.

Generated with [Claude Code](https://claude.com/claude-code)