### PR TITLE
fix(evpn): only process Unspec-family link events; del VXLAN on delete

### DIFF
--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -2702,10 +2702,16 @@ fn process_msg(msg: NetlinkMessage<RouteNetlinkMessage>, tx: UnboundedSender<Fib
     if let NetlinkPayload::InnerMessage(msg) = msg.payload {
         match msg {
             RouteNetlinkMessage::NewLink(msg) => {
+                if msg.header.interface_family != AddressFamily::Unspec {
+                    return;
+                }
                 let link = link_from_msg(msg);
                 let _ = tx.send(FibMessage::NewLink(link));
             }
             RouteNetlinkMessage::DelLink(msg) => {
+                if msg.header.interface_family != AddressFamily::Unspec {
+                    return;
+                }
                 let link = link_from_msg(msg);
                 let _ = tx.send(FibMessage::DelLink(link));
             }

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -575,16 +575,12 @@ impl Rib {
         // would land on `Link::vni` but never reach `vni_ifindex_map`,
         // and `mac_add` would silently skip every install.
         let now_vni: Option<u32> = self.links.get(&ifindex).and_then(|l| l.vni);
-        if prev_vni != now_vni {
-            if let Some(prev) = prev_vni {
-                self.fib_handle.unregister_vxlan_ifindex(prev);
-                self.api_vxlan_del(prev);
-            }
-            if let Some(new) = now_vni {
-                self.fib_handle.register_vxlan_ifindex(new, ifindex);
-                if let Some(local) = self.links.get(&ifindex).and_then(|l| l.vxlan_local) {
-                    self.api_vxlan_add(new, local);
-                }
+        if prev_vni != now_vni
+            && let Some(new) = now_vni
+        {
+            self.fib_handle.register_vxlan_ifindex(new, ifindex);
+            if let Some(local) = self.links.get(&ifindex).and_then(|l| l.vxlan_local) {
+                self.api_vxlan_add(new, local);
             }
         }
 
@@ -621,6 +617,7 @@ impl Rib {
         // message (mirrors the registration trigger in `link_add`).
         if let Some(vni) = oslink.vni {
             self.fib_handle.unregister_vxlan_ifindex(vni);
+            self.api_vxlan_del(vni);
         }
         // Notify subscribers BEFORE removing the link entry, so the
         // VRF lookup in `api_link_del` still resolves to the right


### PR DESCRIPTION
## Summary

Fix from m-asama@ginzado.co.jp for EVPN/VXLAN link handling.

- **`fib/netlink/handle.rs`**: The kernel re-emits `RTM_NEWLINK`/`RTM_DELLINK` with non-`Unspec` interface families (e.g. `AF_BRIDGE`) for VXLAN/bridge ports. Processing those pseudo-events caused spurious link add/delete churn. `process_msg` now filters to the `Unspec`-family message — the canonical link event.
- **`rib/link.rs`**: Now that link-delete fires only on real deletions, move `api_vxlan_del` into `link_delete`, and drop the prev-VNI unregister/del from the VNI-change reconciliation path, which was tearing down still-live VXLAN state on duplicate `NEWLINK` events.

## Test plan

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (collapsed the now-single nested `if let` into a let-chain after removing the prev-VNI branch)
- CI is the source of truth for the full suite.

Generated with [Claude Code](https://claude.com/claude-code)