### PR TITLE
bfd(echo): integrate XDP reflector + advertise non-zero echo-rx (OSPFv2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,15 @@ all:
 console:
 	RUSTFLAGS="--cfg tokio_unstable" cargo run --bin zebra --release
 
+# Optional: build the XDP BFD Echo reflector (offload/). Requires a nightly
+# bpfel toolchain + bpf-linker (see offload/bfd-echo-reflector/README.md), so it
+# is kept OUT of `all`/CI, which run on stable. zebra-rs spawns this binary to
+# honour a non-zero BFD `Required Min Echo RX Interval`.
+.PHONY: bfd-echo-reflector
+bfd-echo-reflector:
+	cd offload/bfd-echo-reflector && cargo build --release
+	@echo '[built offload/bfd-echo-reflector/target/release/bfd-echo-reflector]'
+
 install:
 	mkdir -p ${HOME}/.zebra/bin
 	mkdir -p ${HOME}/.zebra/yang
@@ -22,6 +31,10 @@ ifneq ("$(wildcard target/release/vtypam)","")
 endif
 ifneq ("$(wildcard vty/vty)","")
 	cp vty/vty ${HOME}/.zebra/bin
+endif
+ifneq ("$(wildcard offload/bfd-echo-reflector/target/release/bfd-echo-reflector)","")
+	cp offload/bfd-echo-reflector/target/release/bfd-echo-reflector ${HOME}/.zebra/bin
+	@echo '[bfd-echo-reflector installed — grant caps with: sudo setcap cap_net_admin,cap_bpf=ep $${HOME}/.zebra/bin/bfd-echo-reflector]'
 endif
 	cp zebra/yang/* ${HOME}/.zebra/yang
 	touch ${HOME}/.zebra/zebra.conf
@@ -36,6 +49,16 @@ install-vtypam:
 	sudo setcap cap_dac_read_search,cap_audit_write=ep /usr/sbin/vtypam
 	@echo '[vtypam installed to /usr/sbin/vtypam with file caps]'
 	@echo '[Copy etc/pam.d/zebra-rs.example to /etc/pam.d/zebra-rs and adjust for your distro]'
+
+# System-wide installation of the XDP BFD Echo reflector to /usr/sbin with the
+# caps it needs to load/attach XDP (kernel 5.8+: cap_bpf, plus cap_net_admin).
+# zebra-rs spawns it from /usr/sbin/bfd-echo-reflector (override with
+# $ZEBRA_BFD_REFLECTOR_BIN). Build it first with `make bfd-echo-reflector`.
+.PHONY: install-bfd-echo-reflector
+install-bfd-echo-reflector:
+	sudo install -m 0755 -o root -g root offload/bfd-echo-reflector/target/release/bfd-echo-reflector /usr/sbin/bfd-echo-reflector
+	sudo setcap cap_net_admin,cap_bpf=ep /usr/sbin/bfd-echo-reflector
+	@echo '[bfd-echo-reflector installed to /usr/sbin with file caps]'
 
 doc:
 	rustdoc

--- a/offload/bfd-echo-reflector/loader/src/main.rs
+++ b/offload/bfd-echo-reflector/loader/src/main.rs
@@ -98,8 +98,16 @@ async fn main() -> anyhow::Result<()> {
         },
     }
 
-    info!("reflecting BFD Echo (udp/3785) on {iface}; press Ctrl-C to exit");
-    signal::ctrl_c().await?;
+    info!("reflecting BFD Echo (udp/3785) on {iface}; Ctrl-C or SIGTERM to exit");
+    // Wait for SIGINT (Ctrl-C) or SIGTERM. zebra-rs's reflector supervisor
+    // stops children with SIGTERM; handling it lets the XDP program detach
+    // cleanly on the way out (the link drops when `ebpf` does) instead of
+    // being left attached by an un-caught signal.
+    let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())?;
+    tokio::select! {
+        _ = signal::ctrl_c() => {}
+        _ = sigterm.recv() => {}
+    }
     info!("exiting; detaching XDP program");
     Ok(())
 }

--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -10,5 +10,13 @@ if [ -x /usr/sbin/vtypam ]; then
     setcap 'cap_dac_read_search,cap_audit_write=ep' /usr/sbin/vtypam
 fi
 
+# The XDP BFD Echo reflector (spawned by zebra-rs to honour a non-zero
+# Required Min Echo RX Interval) loads/attaches an XDP program, which needs
+# cap_bpf (kernel 5.8+) and cap_net_admin. No-op unless the package ships it
+# (it is built by the optional `make bfd-echo-reflector` target, not `all`).
+if [ -x /usr/sbin/bfd-echo-reflector ]; then
+    setcap 'cap_net_admin,cap_bpf=ep' /usr/sbin/bfd-echo-reflector
+fi
+
 sudo systemctl daemon-reload
 sudo systemctl restart zebra-rs

--- a/zebra-rs/src/bfd/inst.rs
+++ b/zebra-rs/src/bfd/inst.rs
@@ -77,6 +77,10 @@ pub struct Bfd {
     /// up (the receiver is gone) — v6 simply doesn't work in that case.
     write_tx_v6: UnboundedSender<WriteRequest>,
     timer_handles: HashMap<SessionKey, TimerHandle>,
+    /// Supervises the per-interface XDP Echo reflector child processes.
+    /// Reference-counted by the single-hop echo sessions on each ifindex
+    /// ([`Self::add_session`] / [`Self::remove_session`]).
+    reflectors: super::reflector::EchoReflectors,
 }
 
 /// Sender/receiver pair for the inbound client-request channel.
@@ -294,6 +298,7 @@ impl Bfd {
             write_tx,
             write_tx_v6,
             timer_handles: HashMap::new(),
+            reflectors: super::reflector::EchoReflectors::new(),
         };
         bfd.callback_build();
         bfd.show_build();
@@ -391,6 +396,13 @@ impl Bfd {
     pub fn add_session(&mut self, key: SessionKey, params: SessionParams) -> u32 {
         let disc = self.sessions.insert(key, params);
 
+        // Echo is single-hop only; a non-zero advertised echo-rx is a promise
+        // to loop Echo back, so bring up the per-interface XDP reflector. The
+        // advertise path stays honest by gating on `reflectors.is_ready`.
+        if params.required_min_echo_rx_us > 0 && !key.multihop {
+            self.reflectors.acquire(key.ifindex);
+        }
+
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
         let initial = InitialParams {
             // A fresh session starts Down, so the §6.8.3 slow-TX clamp
@@ -421,7 +433,16 @@ impl Bfd {
         if let Some(h) = self.timer_handles.remove(key) {
             let _ = h.cmd_tx.send(TimerCmd::Shutdown);
         }
-        self.sessions.remove(key)
+        let removed = self.sessions.remove(key);
+        // Mirror the `add_session` acquire: drop this interface's reflector
+        // reference when an echo session goes away.
+        if let Some(s) = &removed
+            && s.required_min_echo_rx_us > 0
+            && !s.key.multihop
+        {
+            self.reflectors.release(s.key.ifindex);
+        }
+        removed
     }
 
     /// Look up the show handler for `msg.paths` and invoke it. Mirrors
@@ -721,6 +742,46 @@ mod tests {
         let BfdEvent::StateChange { change, .. } = event;
         assert_eq!(change.from, bfd_packet::State::Down);
         assert_eq!(change.to, bfd_packet::State::Down);
+    }
+
+    /// A single-hop subscribe carrying a non-zero echo-rx refcounts the
+    /// per-interface Echo reflector; unsubscribing the last such session
+    /// releases it. The ifindex has no interface name here, so no child is
+    /// actually spawned — only the refcount bookkeeping is exercised.
+    #[tokio::test]
+    async fn echo_subscribe_refcounts_reflector() {
+        let mut bfd = fresh_bfd();
+        let mut key = loopback_key(20);
+        key.ifindex = 0xFFFF_FFF0; // no such interface
+        let params = SessionParams {
+            required_min_echo_rx_us: 50_000,
+            ..SessionParams::default()
+        };
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        bfd.subscribe("test".into(), key, params, tx);
+        assert_eq!(bfd.reflectors.refcount(key.ifindex), 1);
+
+        bfd.unsubscribe("test", &key);
+        assert_eq!(bfd.reflectors.refcount(key.ifindex), 0);
+    }
+
+    /// Echo is single-hop only (RFC 5883 multihop has no Echo), so a multihop
+    /// session never brings up a reflector even with echo-rx configured.
+    #[tokio::test]
+    async fn echo_multihop_does_not_refcount_reflector() {
+        let mut bfd = fresh_bfd();
+        let mut key = loopback_key(21);
+        key.ifindex = 0xFFFF_FFF1;
+        key.multihop = true;
+        let params = SessionParams {
+            required_min_echo_rx_us: 50_000,
+            ..SessionParams::default()
+        };
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        bfd.subscribe("test".into(), key, params, tx);
+        assert_eq!(bfd.reflectors.refcount(key.ifindex), 0);
     }
 
     /// A control packet whose received TTL is below a single-hop

--- a/zebra-rs/src/bfd/inst.rs
+++ b/zebra-rs/src/bfd/inst.rs
@@ -396,11 +396,17 @@ impl Bfd {
     pub fn add_session(&mut self, key: SessionKey, params: SessionParams) -> u32 {
         let disc = self.sessions.insert(key, params);
 
-        // Echo is single-hop only; a non-zero advertised echo-rx is a promise
-        // to loop Echo back, so bring up the per-interface XDP reflector. The
-        // advertise path stays honest by gating on `reflectors.is_ready`.
-        if params.required_min_echo_rx_us > 0 && !key.multihop {
+        // Echo is single-hop + IPv4 only (the XDP reflector loops IPv4). A
+        // non-zero advertised echo-rx is a promise to loop Echo back, so bring
+        // up the per-interface reflector and only mark the session `echo_ready`
+        // (the build_packet advertise gate) once the child is confirmed up —
+        // otherwise we keep advertising 0, which is honest.
+        if params.required_min_echo_rx_us > 0 && !key.multihop && key.remote.is_ipv4() {
             self.reflectors.acquire(key.ifindex);
+            let ready = self.reflectors.is_ready(key.ifindex);
+            if ready && let Some(s) = self.sessions.get_by_key_mut(&key) {
+                s.echo_ready = true;
+            }
         }
 
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
@@ -434,11 +440,13 @@ impl Bfd {
             let _ = h.cmd_tx.send(TimerCmd::Shutdown);
         }
         let removed = self.sessions.remove(key);
-        // Mirror the `add_session` acquire: drop this interface's reflector
-        // reference when an echo session goes away.
+        // Mirror the `add_session` acquire predicate exactly (the configured
+        // `required_min_echo_rx_us` is never mutated, so this stays symmetric
+        // even when the session ended up advertising 0).
         if let Some(s) = &removed
             && s.required_min_echo_rx_us > 0
             && !s.key.multihop
+            && s.key.remote.is_ipv4()
         {
             self.reflectors.release(s.key.ifindex);
         }

--- a/zebra-rs/src/bfd/integration.rs
+++ b/zebra-rs/src/bfd/integration.rs
@@ -73,6 +73,7 @@ async fn two_instances_reach_up() {
         // Loopback delivery preserves the egress TTL of 255, so the
         // single-hop GTSM floor is satisfied.
         min_ttl: 255,
+        required_min_echo_rx_us: 0,
     };
 
     bfd_a.subscribe("test".into(), loopback_key(), params(port_b), tx_a);

--- a/zebra-rs/src/bfd/mod.rs
+++ b/zebra-rs/src/bfd/mod.rs
@@ -12,6 +12,7 @@ pub mod config;
 pub mod fsm;
 pub mod inst;
 pub mod network;
+pub mod reflector;
 pub mod session;
 pub mod show;
 pub mod socket;

--- a/zebra-rs/src/bfd/reflector.rs
+++ b/zebra-rs/src/bfd/reflector.rs
@@ -1,0 +1,243 @@
+//! Per-interface XDP BFD Echo reflector supervisor.
+//!
+//! BFD Echo (RFC 5880 §6.4 / RFC 5881 §4) is a single-hop, interface-scoped
+//! data-plane hairpin: a peer sends Echo frames to UDP/3785 and our forwarding
+//! plane loops them straight back. zebra-rs provides that loopback by running
+//! the standalone `bfd-echo-reflector` XDP loader (see
+//! `offload/bfd-echo-reflector/`) as a managed child process — one per
+//! interface that has at least one single-hop session advertising Echo.
+//!
+//! Advertising a non-zero `Required Min Echo RX Interval` is a *promise to loop
+//! Echo back* (RFC 5880 §6.8.1), so the advertise path must only do so once the
+//! child for that interface is confirmed running ([`EchoReflectors::is_ready`]).
+//!
+//! Lifecycle is reference-counted by ifindex: [`EchoReflectors::acquire`] for
+//! each echo session created on an interface, [`EchoReflectors::release`] when
+//! one goes away. The child is spawned on the first reference and SIGTERM'd
+//! (graceful XDP detach) on the last.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use tokio::process::{Child, Command};
+
+/// Env override for the reflector binary path (mirrors vtypam's
+/// `ZEBRA_VTYPAM_BIN`). Falls back to the install locations.
+const BIN_ENV: &str = "ZEBRA_BFD_REFLECTOR_BIN";
+/// Env override for the XDP attach mode (`auto` | `native` | `skb`). Default
+/// `auto`; veth / virtual NICs need `skb` (native attaches but does not loop).
+const MODE_ENV: &str = "ZEBRA_BFD_REFLECTOR_MODE";
+
+/// One supervised reflector child, keyed by ifindex in [`EchoReflectors`].
+struct Reflector {
+    /// Number of single-hop echo sessions currently on this interface.
+    refcount: u32,
+    /// The child process, if it spawned. `None` when the spawn failed (e.g.
+    /// the binary is missing or the ifindex has no name) — we then stay
+    /// not-ready and keep advertising 0, which is honest.
+    child: Option<Child>,
+    ifname: String,
+}
+
+impl Reflector {
+    /// SIGTERM the child so the loader detaches its XDP program cleanly. The
+    /// `kill_on_drop(true)` set at spawn reaps it (SIGKILL) if it ignores us.
+    fn stop(&mut self) {
+        if let Some(pid) = self.child.as_ref().and_then(Child::id) {
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGTERM);
+            }
+            tracing::info!("bfd echo: stopping reflector on {}", self.ifname);
+        }
+    }
+
+    /// True while the child is still running. A child that has exited (crash,
+    /// killed externally) is not alive, so we must stop advertising Echo.
+    fn is_alive(&mut self) -> bool {
+        match &mut self.child {
+            // `try_wait` is non-blocking: `Ok(None)` => still running.
+            Some(child) => matches!(child.try_wait(), Ok(None)),
+            None => false,
+        }
+    }
+}
+
+/// Supervises the set of `bfd-echo-reflector` child processes, one per
+/// interface with active single-hop Echo sessions.
+pub struct EchoReflectors {
+    by_ifindex: HashMap<u32, Reflector>,
+    bin: PathBuf,
+    mode: String,
+}
+
+impl Default for EchoReflectors {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EchoReflectors {
+    pub fn new() -> Self {
+        Self {
+            by_ifindex: HashMap::new(),
+            bin: resolve_bin(),
+            mode: std::env::var(MODE_ENV).unwrap_or_else(|_| "auto".to_string()),
+        }
+    }
+
+    /// Note one more single-hop echo session on `ifindex`; spawn the reflector
+    /// child if this is the first.
+    pub fn acquire(&mut self, ifindex: u32) {
+        if let Some(r) = self.by_ifindex.get_mut(&ifindex) {
+            r.refcount += 1;
+            return;
+        }
+        let reflector = self.spawn(ifindex);
+        self.by_ifindex.insert(ifindex, reflector);
+    }
+
+    /// Drop one reference; stop the child when the last echo session on
+    /// `ifindex` goes away.
+    pub fn release(&mut self, ifindex: u32) {
+        let Some(r) = self.by_ifindex.get_mut(&ifindex) else {
+            return;
+        };
+        r.refcount = r.refcount.saturating_sub(1);
+        if r.refcount > 0 {
+            return;
+        }
+        // The `get_mut` borrow ended at the comparison above (NLL), so the
+        // last echo session is gone — remove the entry and stop the child.
+        if let Some(mut r) = self.by_ifindex.remove(&ifindex) {
+            r.stop();
+        }
+    }
+
+    /// Whether the reflector for `ifindex` is confirmed running — the gate for
+    /// honestly advertising a non-zero echo-rx on sessions over this interface.
+    pub fn is_ready(&mut self, ifindex: u32) -> bool {
+        self.by_ifindex
+            .get_mut(&ifindex)
+            .map(Reflector::is_alive)
+            .unwrap_or(false)
+    }
+
+    /// Number of echo sessions currently referencing `ifindex` (0 if none).
+    /// Test-only: lets the instance-level tests verify acquire/release wiring.
+    #[cfg(test)]
+    pub fn refcount(&self, ifindex: u32) -> u32 {
+        self.by_ifindex.get(&ifindex).map_or(0, |r| r.refcount)
+    }
+
+    fn spawn(&self, ifindex: u32) -> Reflector {
+        let Some(ifname) = if_indextoname(ifindex) else {
+            tracing::warn!("bfd echo: no interface name for ifindex {ifindex}; reflector off");
+            return Reflector {
+                refcount: 1,
+                child: None,
+                ifname: String::new(),
+            };
+        };
+        let child = match Command::new(&self.bin)
+            .arg("-i")
+            .arg(&ifname)
+            .arg("-m")
+            .arg(&self.mode)
+            .kill_on_drop(true)
+            .spawn()
+        {
+            Ok(child) => {
+                tracing::info!(
+                    "bfd echo: spawned reflector on {ifname} (ifindex {ifindex}, mode {})",
+                    self.mode
+                );
+                Some(child)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "bfd echo: failed to spawn {} on {ifname}: {e}",
+                    self.bin.display()
+                );
+                None
+            }
+        };
+        Reflector {
+            refcount: 1,
+            child,
+            ifname,
+        }
+    }
+}
+
+/// Resolve the reflector binary path: `$ZEBRA_BFD_REFLECTOR_BIN`, else the dev
+/// install (`make install` → `~/.zebra/bin`), else the packaged location.
+fn resolve_bin() -> PathBuf {
+    if let Some(p) = std::env::var_os(BIN_ENV) {
+        return PathBuf::from(p);
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let dev = PathBuf::from(home).join(".zebra/bin/bfd-echo-reflector");
+        if dev.exists() {
+            return dev;
+        }
+    }
+    PathBuf::from("/usr/sbin/bfd-echo-reflector")
+}
+
+/// `if_indextoname(3)` — the reflector loader attaches by interface name.
+fn if_indextoname(ifindex: u32) -> Option<String> {
+    let mut buf = [0u8; libc::IF_NAMESIZE];
+    let p = unsafe { libc::if_indextoname(ifindex, buf.as_mut_ptr() as *mut libc::c_char) };
+    if p.is_null() {
+        return None;
+    }
+    let cstr = unsafe { std::ffi::CStr::from_ptr(buf.as_ptr() as *const libc::c_char) };
+    cstr.to_str().ok().map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // An ifindex with no interface name: `spawn` resolves no name, so no child
+    // process is launched, but the refcount bookkeeping still runs. Lets us
+    // exercise acquire/release without depending on a real interface or binary.
+    const NO_SUCH_IFINDEX: u32 = 0xFFFF_FFF0;
+
+    #[test]
+    fn acquire_release_refcounts_per_ifindex() {
+        let mut r = EchoReflectors::new();
+        assert!(!r.by_ifindex.contains_key(&NO_SUCH_IFINDEX));
+
+        r.acquire(NO_SUCH_IFINDEX);
+        r.acquire(NO_SUCH_IFINDEX);
+        assert_eq!(r.by_ifindex.get(&NO_SUCH_IFINDEX).unwrap().refcount, 2);
+
+        r.release(NO_SUCH_IFINDEX);
+        assert_eq!(r.by_ifindex.get(&NO_SUCH_IFINDEX).unwrap().refcount, 1);
+
+        r.release(NO_SUCH_IFINDEX);
+        assert!(
+            !r.by_ifindex.contains_key(&NO_SUCH_IFINDEX),
+            "last release removes the entry"
+        );
+        // Failed-to-spawn (no ifname) reflector is never 'ready'.
+        assert!(!r.is_ready(NO_SUCH_IFINDEX));
+    }
+
+    #[test]
+    fn release_unknown_ifindex_is_noop() {
+        let mut r = EchoReflectors::new();
+        r.release(12345); // must not panic / underflow
+        assert!(r.by_ifindex.is_empty());
+    }
+
+    #[test]
+    fn bin_env_override_is_honoured() {
+        // SAFETY: single-threaded test; set then read immediately.
+        unsafe { std::env::set_var(BIN_ENV, "/opt/custom/bfd-echo-reflector") };
+        let r = EchoReflectors::new();
+        unsafe { std::env::remove_var(BIN_ENV) };
+        assert_eq!(r.bin, PathBuf::from("/opt/custom/bfd-echo-reflector"));
+    }
+}

--- a/zebra-rs/src/bfd/session.rs
+++ b/zebra-rs/src/bfd/session.rs
@@ -55,6 +55,13 @@ pub struct SessionParams {
     pub detect_mult: u8,
     pub dst_port: u16,
     pub min_ttl: u8,
+    /// `bfd.RequiredMinEchoRxInterval` (microseconds) to advertise.
+    /// Zero (the default) means "I will not loop Echo back" (RFC 5880
+    /// §6.8.1) — the conformant state until a responder exists. A
+    /// non-zero value is only set by a client that has the XDP Echo
+    /// reflector active on the session's interface, and is advertised
+    /// only on single-hop sessions ([`Session::build_packet`]).
+    pub required_min_echo_rx_us: u32,
 }
 
 impl Default for SessionParams {
@@ -73,6 +80,9 @@ impl Default for SessionParams {
             detect_mult: super::config::DEFAULT_DETECT_MULT,
             dst_port: super::socket::BFD_SINGLE_HOP_PORT,
             min_ttl: 255,
+            // Echo off by default — advertising non-zero is a promise to
+            // loop Echo packets back, made only once the reflector is up.
+            required_min_echo_rx_us: 0,
         }
     }
 }
@@ -117,6 +127,12 @@ pub struct Session {
     pub required_min_rx_us: u32,
     pub detect_mult: u8,
 
+    /// `bfd.RequiredMinEchoRxInterval` (microseconds) we advertise. Zero
+    /// means "do not send me Echo" (RFC 5880 §6.8.1). Only ever non-zero
+    /// on single-hop sessions whose interface has the Echo reflector
+    /// active; gated again on `!key.multihop` in [`Self::build_packet`].
+    pub required_min_echo_rx_us: u32,
+
     /// UDP destination port to send to (3784 single-hop, 4784 multi-hop).
     pub dst_port: u16,
 
@@ -130,6 +146,11 @@ pub struct Session {
     pub remote_min_tx_us: u32,
     pub remote_min_rx_us: u32,
     pub remote_detect_mult: u8,
+    /// Peer's `Required Min Echo RX Interval` (microseconds): how fast it
+    /// will loop our Echo packets back. Zero ⇒ the peer will not reflect,
+    /// so we must not send Echo to it (RFC 5880 §6.8.1). Cached for the
+    /// future sender half + `show bfd peers`; not acted on yet.
+    pub remote_min_echo_rx_us: u32,
 
     /// Demand mode flags. Always false today — wired here so the
     /// session record matches RFC §6.8.1 even though Demand
@@ -168,9 +189,11 @@ impl Session {
             detect_mult: params.detect_mult,
             dst_port: params.dst_port,
             min_ttl: params.min_ttl,
+            required_min_echo_rx_us: params.required_min_echo_rx_us,
             remote_min_tx_us: 0,
             remote_min_rx_us: 0,
             remote_detect_mult: 0,
+            remote_min_echo_rx_us: 0,
             demand: false,
             remote_demand: false,
             stats: Stats::default(),
@@ -229,6 +252,7 @@ impl Session {
         self.remote_min_tx_us = packet.desired_min_tx_interval;
         self.remote_min_rx_us = packet.required_min_rx_interval;
         self.remote_detect_mult = packet.detect_mult;
+        self.remote_min_echo_rx_us = packet.required_min_echo_rx_interval;
         self.remote_demand = packet.demand;
         // A Final (F) completes a Poll Sequence we initiated (RFC 5880
         // §6.8.7): the peer has acknowledged our changed interval, so we
@@ -297,7 +321,15 @@ impl Session {
             // including the §6.8.3 slow-TX clamp while not Up.
             desired_min_tx_interval: self.effective_desired_min_tx_us(),
             required_min_rx_interval: self.required_min_rx_us,
-            required_min_echo_rx_interval: 0,
+            // Echo is single-hop only (RFC 5881 §4; RFC 5883 multihop has
+            // no Echo), so never advertise a non-zero value on a multihop
+            // session. Otherwise advertise our configured value, which is
+            // only non-zero once the reflector is looping on this iface.
+            required_min_echo_rx_interval: if self.key.multihop {
+                0
+            } else {
+                self.required_min_echo_rx_us
+            },
             demand: self.demand,
             poll: self.poll,
             ..ControlPacket::default()
@@ -726,5 +758,58 @@ mod tests {
         });
         assert_eq!(s.local_state, State::Down);
         assert!(s.poll, "fast→slow change opens a Poll Sequence");
+    }
+
+    /// A single-hop session advertises its configured Required Min Echo
+    /// RX Interval verbatim (RFC 5880 §6.8.1 / RFC 5881 §4).
+    #[test]
+    fn echo_rx_advertised_for_single_hop() {
+        let mut t = SessionTable::new();
+        let d = t.insert(
+            key(1, 2), // key() is single-hop (multihop: false)
+            SessionParams {
+                required_min_echo_rx_us: 50_000,
+                ..SessionParams::default()
+            },
+        );
+        let s = t.get_by_disc(d).unwrap();
+        assert!(!s.key.multihop);
+        assert_eq!(s.build_packet().required_min_echo_rx_interval, 50_000);
+    }
+
+    /// Echo is single-hop only (RFC 5883 multihop has no Echo), so a
+    /// multihop session never advertises a non-zero value even when one
+    /// is configured.
+    #[test]
+    fn echo_rx_zero_on_multihop() {
+        let mut t = SessionTable::new();
+        let mut k = key(1, 2);
+        k.multihop = true;
+        let d = t.insert(
+            k,
+            SessionParams {
+                required_min_echo_rx_us: 50_000,
+                ..SessionParams::default()
+            },
+        );
+        let s = t.get_by_disc(d).unwrap();
+        assert_eq!(s.build_packet().required_min_echo_rx_interval, 0);
+    }
+
+    /// The peer's advertised Required Min Echo RX Interval is cached from
+    /// incoming control packets (for the future sender half + show).
+    #[test]
+    fn peer_echo_rx_cached() {
+        let mut t = SessionTable::new();
+        let d = t.insert(key(1, 2), SessionParams::default());
+        let s = t.get_by_disc_mut(d).unwrap();
+        assert_eq!(s.remote_min_echo_rx_us, 0);
+        let _ = s.handle_packet(&ControlPacket {
+            state: State::Down,
+            my_disc: 0xabcd,
+            required_min_echo_rx_interval: 25_000,
+            ..ControlPacket::default()
+        });
+        assert_eq!(s.remote_min_echo_rx_us, 25_000);
     }
 }

--- a/zebra-rs/src/bfd/session.rs
+++ b/zebra-rs/src/bfd/session.rs
@@ -127,11 +127,16 @@ pub struct Session {
     pub required_min_rx_us: u32,
     pub detect_mult: u8,
 
-    /// `bfd.RequiredMinEchoRxInterval` (microseconds) we advertise. Zero
-    /// means "do not send me Echo" (RFC 5880 §6.8.1). Only ever non-zero
-    /// on single-hop sessions whose interface has the Echo reflector
-    /// active; gated again on `!key.multihop` in [`Self::build_packet`].
+    /// Configured `bfd.RequiredMinEchoRxInterval` (microseconds). Zero means
+    /// "do not send me Echo" (RFC 5880 §6.8.1). Set from `SessionParams` at
+    /// creation and never mutated, so it also drives the symmetric reflector
+    /// acquire/release in the instance.
     pub required_min_echo_rx_us: u32,
+    /// Whether the per-interface XDP Echo reflector is confirmed up. The
+    /// instance sets this once the child has spawned; until then we advertise
+    /// 0 even with `required_min_echo_rx_us` configured, so the non-zero
+    /// advertisement stays an honest promise to actually loop Echo back.
+    pub echo_ready: bool,
 
     /// UDP destination port to send to (3784 single-hop, 4784 multi-hop).
     pub dst_port: u16,
@@ -190,6 +195,7 @@ impl Session {
             dst_port: params.dst_port,
             min_ttl: params.min_ttl,
             required_min_echo_rx_us: params.required_min_echo_rx_us,
+            echo_ready: false,
             remote_min_tx_us: 0,
             remote_min_rx_us: 0,
             remote_detect_mult: 0,
@@ -321,14 +327,18 @@ impl Session {
             // including the §6.8.3 slow-TX clamp while not Up.
             desired_min_tx_interval: self.effective_desired_min_tx_us(),
             required_min_rx_interval: self.required_min_rx_us,
-            // Echo is single-hop only (RFC 5881 §4; RFC 5883 multihop has
-            // no Echo), so never advertise a non-zero value on a multihop
-            // session. Otherwise advertise our configured value, which is
-            // only non-zero once the reflector is looping on this iface.
-            required_min_echo_rx_interval: if self.key.multihop {
-                0
-            } else {
+            // Advertise a non-zero echo-rx only when ALL hold: Echo is
+            // single-hop (RFC 5881 §4; RFC 5883 multihop has no Echo); the
+            // session is IPv4 (our XDP reflector loops IPv4 only); and the
+            // reflector is confirmed up (`echo_ready`) so the advertisement is
+            // an honest promise to loop Echo back.
+            required_min_echo_rx_interval: if self.echo_ready
+                && !self.key.multihop
+                && self.key.remote.is_ipv4()
+            {
                 self.required_min_echo_rx_us
+            } else {
+                0
             },
             demand: self.demand,
             poll: self.poll,
@@ -760,20 +770,25 @@ mod tests {
         assert!(s.poll, "fast→slow change opens a Poll Sequence");
     }
 
-    /// A single-hop session advertises its configured Required Min Echo
-    /// RX Interval verbatim (RFC 5880 §6.8.1 / RFC 5881 §4).
+    /// A single-hop IPv4 session advertises its configured Required Min Echo
+    /// RX Interval, but only once the reflector is ready (RFC 5880 §6.8.1 /
+    /// RFC 5881 §4): before then it advertises 0 (honest — no responder yet).
     #[test]
-    fn echo_rx_advertised_for_single_hop() {
+    fn echo_rx_advertised_only_when_ready() {
         let mut t = SessionTable::new();
         let d = t.insert(
-            key(1, 2), // key() is single-hop (multihop: false)
+            key(1, 2), // key() is single-hop (multihop: false), IPv4
             SessionParams {
                 required_min_echo_rx_us: 50_000,
                 ..SessionParams::default()
             },
         );
-        let s = t.get_by_disc(d).unwrap();
+        let s = t.get_by_disc_mut(d).unwrap();
         assert!(!s.key.multihop);
+        // Reflector not up yet → advertise 0 even though it is configured.
+        assert_eq!(s.build_packet().required_min_echo_rx_interval, 0);
+        // Instance confirms the reflector → advertise the configured value.
+        s.echo_ready = true;
         assert_eq!(s.build_packet().required_min_echo_rx_interval, 50_000);
     }
 

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -70,6 +70,14 @@ impl Ospf {
             config_ospf_interface_bfd_min_neighbor_state,
         );
         self.ospf_add(
+            "/area/interface/bfd/echo-mode",
+            config_ospf_interface_bfd_echo_mode,
+        );
+        self.ospf_add(
+            "/area/interface/bfd/echo-interval",
+            config_ospf_interface_bfd_echo_interval,
+        );
+        self.ospf_add(
             "/area/interface/network-type",
             config_ospf_interface_network_type,
         );
@@ -722,6 +730,48 @@ pub(super) fn config_ospf_interface_bfd_profile<V: OspfVersion>(
 
     let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
     link.config.bfd.profile = op.is_set().then_some(profile);
+    Some(())
+}
+
+/// `interface <if> bfd echo-mode <bool>` — advertise a non-zero Required
+/// Min Echo RX so the peer may run BFD Echo against us (single-hop, IPv4).
+/// Reconciles the link, though the value takes effect when the session is
+/// (re)established (matching how the other BFD params apply).
+pub(super) fn config_ospf_interface_bfd_echo_mode<V: OspfVersion>(
+    ospf: &mut Ospf<V>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let echo = args.boolean()?;
+
+    let ifindex = {
+        let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+        link.config.bfd.echo_mode = op.is_set() && echo;
+        link.index
+    };
+    ospf.bfd_reconcile_link(ifindex);
+    Some(())
+}
+
+/// `interface <if> bfd echo-interval <ms>` — advertised Required Min Echo
+/// RX Interval. Stored; applied when the session is (re)established.
+pub(super) fn config_ospf_interface_bfd_echo_interval<V: OspfVersion>(
+    ospf: &mut Ospf<V>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let interval = args.u32()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    link.config.bfd.echo_interval_ms = if op.is_set() {
+        interval
+    } else {
+        crate::ospf::link::DEFAULT_ECHO_INTERVAL_MS
+    };
     Some(())
 }
 

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -13,6 +13,7 @@ use super::area::{AreaTypeKind, NssaTranslatorRole};
 use super::config::{
     Callback, apply_link_enable_transition, area_no_summary_set, area_nssa_default_originate_set,
     area_nssa_suppress_fa_set, area_nssa_translator_role_set, area_type_set,
+    config_ospf_interface_bfd_echo_interval, config_ospf_interface_bfd_echo_mode,
     config_ospf_interface_bfd_enable, config_ospf_interface_bfd_min_neighbor_state,
     config_ospf_interface_bfd_profile, link_should_enable, ospf_link_get_mut_by_name,
     parse_area_id,
@@ -60,6 +61,14 @@ impl Ospf<Ospfv3> {
             (
                 "/area/interface/bfd/min-neighbor-state",
                 config_ospf_interface_bfd_min_neighbor_state,
+            ),
+            (
+                "/area/interface/bfd/echo-mode",
+                config_ospf_interface_bfd_echo_mode,
+            ),
+            (
+                "/area/interface/bfd/echo-interval",
+                config_ospf_interface_bfd_echo_interval,
             ),
             (
                 "/area/interface/network-type",

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -360,6 +360,18 @@ impl<V: OspfVersion> Ospf<V> {
     /// `profile` is stored but not yet applied (the session uses
     /// `SessionParams::default()`, matching BGP / IS-IS).
     fn bfd_reconcile_nbr(&mut self, ifindex: u32, nbr_addr: Ipv4Addr) {
+        // Configured Echo (advertised Required Min Echo RX) for this link,
+        // captured alongside the desired key. Only requested when echo-mode is
+        // on; the BFD instance further gates it to single-hop IPv4 with a live
+        // reflector, so this is inert for OSPFv3 (IPv6).
+        let echo_rx_us = self
+            .links
+            .get(&ifindex)
+            .map(|l| &l.config.bfd)
+            .filter(|bfd| bfd.echo_mode)
+            .map(|bfd| bfd.echo_interval_ms.saturating_mul(1000))
+            .unwrap_or(0);
+
         let desired = {
             let Some(link) = self.links.get(&ifindex) else {
                 return;
@@ -405,10 +417,14 @@ impl<V: OspfVersion> Ospf<V> {
             });
         }
         if let Some(key) = desired {
+            let params = crate::bfd::session::SessionParams {
+                required_min_echo_rx_us: echo_rx_us,
+                ..crate::bfd::session::SessionParams::default()
+            };
             let _ = client_tx.send(crate::bfd::inst::ClientReq::Subscribe {
                 client: V::PROTO.to_string(),
                 key,
-                params: crate::bfd::session::SessionParams::default(),
+                params,
                 notifier: self.bfd_event_tx.clone(),
             });
         }

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -208,11 +208,33 @@ impl NbrStateThreshold {
 /// min-neighbor-state }` (zebra-ospf-bfd.yang). Shared by v2 and v3.
 /// `enable` / `min-neighbor-state` flips drive Subscribe / Unsubscribe
 /// against the BFD instance via `Ospf::bfd_reconcile_link`.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+/// FRR default advertised Required Min Echo RX Interval (milliseconds).
+pub const DEFAULT_ECHO_INTERVAL_MS: u32 = 50;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OspfLinkBfdConfig {
     pub enable: bool,
     pub profile: Option<String>,
     pub min_neighbor_state: NbrStateThreshold,
+    /// FRR `echo-mode`: advertise a non-zero Required Min Echo RX so a peer
+    /// may run BFD Echo against us (single-hop, IPv4 — backed by the XDP
+    /// reflector). Off by default; honoured for OSPFv2, inert for v3 (IPv6).
+    pub echo_mode: bool,
+    /// Advertised Required Min Echo RX Interval (milliseconds). Only
+    /// meaningful when `echo_mode` is set.
+    pub echo_interval_ms: u32,
+}
+
+impl Default for OspfLinkBfdConfig {
+    fn default() -> Self {
+        Self {
+            enable: false,
+            profile: None,
+            min_neighbor_state: NbrStateThreshold::default(),
+            echo_mode: false,
+            echo_interval_ms: DEFAULT_ECHO_INTERVAL_MS,
+        }
+    }
 }
 
 /// OSPFv2 per-interface authentication mode.

--- a/zebra-rs/yang/zebra-ospf-bfd.yang
+++ b/zebra-rs/yang/zebra-ospf-bfd.yang
@@ -106,6 +106,30 @@ module zebra-ospf-bfd {
            torn down. Identical on point-to-point links, where the
            neighbor goes straight to Full.";
       }
+
+      leaf echo-mode {
+        ext:help "Advertise a non-zero Required Min Echo RX (BFD Echo)";
+        type boolean;
+        default false;
+        description
+          "When true, advertise a non-zero `Required Min Echo RX
+           Interval` on this interface's single-hop sessions so a peer
+           may run the BFD Echo function against us. zebra-rs honours
+           the promise with an XDP reflector that loops UDP/3785 frames
+           back (RFC 5880 §6.4 / RFC 5881 §4). Single-hop IPv4 only:
+           honoured for OSPFv2, accepted but inert for OSPFv3 (IPv6).
+           We do not transmit Echo ourselves (responder side only).";
+      }
+
+      leaf echo-interval {
+        ext:help "Advertised Required Min Echo RX Interval (ms)";
+        type uint32;
+        units "milliseconds";
+        default 50;
+        description
+          "Value advertised as `Required Min Echo RX Interval` when
+           `echo-mode` is true (FRR default 50 ms).";
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Integrates the merged XDP BFD Echo reflector (`offload/bfd-echo-reflector/`, #1142)
into zebra-rs so it can **honestly advertise a non-zero `Required Min Echo RX
Interval`** — a promise to loop a peer's Echo packets back, kept only while the
reflector is actually running. Responder/advertise side only; we do not transmit
Echo ourselves (the sender half needs TX timers — future work).

Control plane, in three reviewable phases:

**Phase 1 — session state** (`bfd/session.rs`)
- `SessionParams.required_min_echo_rx_us` (default 0), threaded onto `Session`.
- `handle_packet` caches the peer's echo-rx (`remote_min_echo_rx_us`).
- `build_packet` advertises it, gated to **single-hop + IPv4 + reflector-ready**.

**Phase 2 — reflector supervisor** (`bfd/reflector.rs`, new)
- `EchoReflectors` spawns one `bfd-echo-reflector` child per interface
  (`tokio::process`, vtypam-style env-path + install fallbacks; `if_indextoname`),
  reference-counted by the single-hop echo sessions on that ifindex
  (`add_session` acquire / `remove_session` release); SIGTERM stop = clean XDP
  detach. zebra-rs gains **no** aya dependency and **no** eBPF build step.
- offload loader now handles SIGTERM (graceful detach).
- Makefile: optional `bfd-echo-reflector` build (nightly+bpf-linker, **outside**
  `all`/CI) + `install-bfd-echo-reflector` (setcap `cap_net_admin,cap_bpf`);
  packaging postinstall sets the same caps if shipped.

**Phase 3 — OSPFv2 config → honest advertise** (`ospf/*`, `zebra-ospf-bfd.yang`)
- Per-interface `bfd { echo-mode; echo-interval; }` (generic v2/v3 handlers;
  default 50 ms). `bfd_reconcile_nbr` sets the echo param on the BFD subscribe.
- The advertise stays honest: non-zero only once `EchoReflectors::is_ready`
  (else 0). OSPFv3/IPv6 accepted but inert (the reflector loops IPv4 only).

## Test plan
- 52 BFD + 45 OSPF unit tests pass; `yang_load` guard passes (YANG additions
  parse); `cargo clippy --workspace --all-targets -D warnings` clean.
- Covered by unit tests: advertise gate (ready/multihop/IPv4), reflector
  refcount + acquire/release wiring, peer echo-rx caching.
- **Not yet validated end-to-end on the wire** (follow-up): OSPFv2 over a veth
  with `echo-mode`, confirming the advertised echo-rx flips 0→50000 once the
  reflector is up + a peer's UDP/3785 Echo is reflected. Needs the optional
  reflector build (`make bfd-echo-reflector`) + setcap.

## Scope / follow-ups
`show bfd peers` echo rows; FRR `echo-mode` interop; docs. Sender half (TX
timers); IS-IS / directly-connected eBGP / OSPFv3 echo-mode; IPv6 reflect.

Generated with [Claude Code](https://claude.com/claude-code)