### PR TITLE
bfd(echo): IS-IS echo-mode config (full OSPF parity)

### DIFF
--- a/book/src/ch-07-03-isis-bfd.md
+++ b/book/src/ch-07-03-isis-bfd.md
@@ -23,21 +23,67 @@ router isis {
 }
 ```
 
-No top-level `bfd { }` block is required — the BFD subsystem starts
-automatically with `router isis`.
+There is no global top-level `bfd { }` block — the BFD subsystem starts
+automatically with `router isis`. The same `bfd {}` leaves can be set once at
+the **instance level** (`router isis { bfd {} }`) as a default for every
+interface, overridden per interface (see
+[Instance-level defaults](#instance-level-defaults)).
 
 | Leaf | Type | Default | Meaning |
 |---|---|---|---|
-| `enable` | boolean | `false` | Attach (or detach) BFD for adjacencies on this interface. |
+| `enable` | boolean | _(off)_ | Attach (or detach) BFD for adjacencies on this interface. |
+| `echo-mode` | `transmit` \| `receive` \| `both` | _(off)_ | Enable the [BFD Echo function](ch-10-00-bfd.md#echo-function) on this interface's single-hop IPv4 adjacencies. |
+| `echo-transmit-interval` | uint (ms) | `50` | Rate we originate Echo at (`transmit` / `both`). |
+| `echo-receive-interval` | uint (ms) | `50` | Advertised Required Min Echo RX (`receive` / `both`). |
 
-Sessions use the BFD defaults (300 ms / ×3 ⇒ ~900 ms detection); the
-timers are not currently tunable — see
+Control-packet intervals use the BFD defaults (300 ms / ×3 ⇒ ~900 ms
+detection) and are not currently tunable — see
 [Tuning intervals](ch-10-00-bfd.md#tuning-intervals) in the overview.
 
 A session is subscribed when the adjacency comes **Up** and
-unsubscribed when it goes down. Both IPv4 and IPv6 adjacencies are
-supported; IPv6 sessions run over the interface's link-local addresses
-and are demultiplexed per interface.
+unsubscribed when it goes down.
+
+## Echo
+
+`echo-mode` turns on the [BFD Echo function](ch-10-00-bfd.md#echo-function) for
+this interface's adjacencies — single-hop **IPv4 only** (IS-IS is an L2 protocol;
+the Echo session is built from the interface's and neighbour's IPv4 addresses,
+so an IPv6-only adjacency is inert). `transmit` originates Echo + detects on the
+return; `receive` advertises + reflects (the peer detects); `both` does both —
+backed by the per-interface `xdp-bfd-echo` helper.
+
+```
+router isis {
+  interface eth0 {
+    bfd {
+      enable true;
+      echo-mode both;
+      echo-transmit-interval 50;
+      echo-receive-interval 50;
+    }
+  }
+}
+```
+
+## Instance-level defaults
+
+A `bfd {}` block directly under `router isis` supplies defaults for **every**
+interface; each leaf's effective value is the per-interface setting if present,
+else the instance default, else the hard default. `enable true` at the instance
+level **blanket-enables** BFD on all IS-IS interfaces; a per-interface
+`bfd { enable false }` opts one out.
+
+```
+router isis {
+  bfd {
+    enable true;          // BFD on every interface…
+    echo-mode receive;    // …default Echo role
+  }
+  interface eth0 {
+    bfd { echo-mode both; }   // override; inherits enable
+  }
+}
+```
 
 ## Verifying
 

--- a/book/src/ch-10-00-bfd.md
+++ b/book/src/ch-10-00-bfd.md
@@ -215,11 +215,12 @@ all sessions on that link, and stopped when the last one goes away. It needs
 raw socket); the packaged install grants these. A node with no Echo configured
 runs no helper and advertises `Required Min Echo RX Interval = 0`.
 
-Echo is enabled per attachment — today on OSPF interfaces, where `echo-mode`
+Echo is enabled per attachment — on OSPF and IS-IS interfaces, where `echo-mode`
 selects the role (`transmit` / `receive` / `both`) and
 `echo-transmit-interval` / `echo-receive-interval` set the rates; see
-[OSPF BFD](ch-08-02-ospf-bfd.md#echo). `show bfd peers` reports the negotiated
-`Echo receive interval` / `Echo transmission interval`.
+[OSPF BFD](ch-08-02-ospf-bfd.md#echo) and [IS-IS BFD](ch-07-03-isis-bfd.md#echo).
+`show bfd peers` reports the negotiated `Echo receive interval` /
+`Echo transmission interval`.
 
 ## What happens on failure
 
@@ -244,5 +245,6 @@ native timers would allow.
   (`transmit` / `receive` / `both`) config and an instance-level
   `router ospf { bfd {} }` default inherited and overridden per interface.
 - **Not yet:** configurable control-packet timers (the intervals are
-  fixed at the defaults); Echo on IS-IS and BGP (OSPF only today); BFD
+  fixed at the defaults); Echo on BGP (OSPF + IS-IS today; BGP echo is
+  single-hop-only so it awaits a decision); BFD
   for **static routes**; per-VRF OSPF BFD.

--- a/docs/design/bfd-echo-plan.md
+++ b/docs/design/bfd-echo-plan.md
@@ -23,14 +23,15 @@ Tracks the BFD **Echo function** (RFC 5880 §6.4 / §6.8.5 / §6.8.8 /
 >   (advertise ⟺ `Receive|Both`, originate ⟺ `Transmit|Both`, spawn
 >   helper ⟺ `≠ Off`). The IPC is a stdin/stdout line protocol
 >   (`echo-add`/`echo-del` → helper, `echo-down` → zebra-rs).
-> - **Config (OSPF v2+v3, done)** — `echo-mode {transmit|receive|both}`
->   with FRR-style `echo-transmit-interval` / `echo-receive-interval`,
->   settable at the OSPF instance level (`router ospf { bfd {} }`) as a
->   default and overridden per interface *per leaf*
->   (`OspfLinkBfdConfig::resolve`); instance `enable true` blanket-enables
->   all interfaces, a per-interface `enable false` opts out. There is **no
->   global top-level `bfd {}`** container — BFD spawns eagerly with its
->   first consumer. IS-IS and BGP echo config is the remaining gap.
+> - **Config (OSPF v2+v3 and IS-IS, done)** — `echo-mode
+>   {transmit|receive|both}` with FRR-style `echo-transmit-interval` /
+>   `echo-receive-interval`, settable at the instance level
+>   (`router ospf|isis { bfd {} }`) as a default and overridden per
+>   interface *per leaf* (`{Ospf,}LinkBfdConfig::resolve`); instance
+>   `enable true` blanket-enables all interfaces, a per-interface
+>   `enable false` opts out. There is **no global top-level `bfd {}`**
+>   container — BFD spawns eagerly with its first consumer. BGP echo
+>   config is the remaining gap (single-hop eBGP only).
 >
 > Open lab item: verify `bpf_timer`-from-XDP loads on the target kernel.
 >

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -292,6 +292,33 @@ impl Isis {
             "/router/isis/interface/bfd/profile",
             link::config_bfd_profile,
         );
+        self.callback_add(
+            "/router/isis/interface/bfd/echo-mode",
+            link::config_bfd_echo_mode,
+        );
+        self.callback_add(
+            "/router/isis/interface/bfd/echo-transmit-interval",
+            link::config_bfd_echo_transmit_interval,
+        );
+        self.callback_add(
+            "/router/isis/interface/bfd/echo-receive-interval",
+            link::config_bfd_echo_receive_interval,
+        );
+        // Instance-level `router isis { bfd { ... } }` defaults.
+        self.callback_add("/router/isis/bfd/enable", link::config_isis_bfd_enable);
+        self.callback_add("/router/isis/bfd/profile", link::config_isis_bfd_profile);
+        self.callback_add(
+            "/router/isis/bfd/echo-mode",
+            link::config_isis_bfd_echo_mode,
+        );
+        self.callback_add(
+            "/router/isis/bfd/echo-transmit-interval",
+            link::config_isis_bfd_echo_transmit_interval,
+        );
+        self.callback_add(
+            "/router/isis/bfd/echo-receive-interval",
+            link::config_isis_bfd_echo_receive_interval,
+        );
         // Per-interface hello-authentication.
         self.callback_add(
             "/router/isis/interface/hello-authentication",
@@ -439,6 +466,11 @@ pub struct IsisConfig {
     /// without rewiring the topology. No effect when `ti_lfa_enabled`
     /// is false (no repair gets stamped in the first place).
     pub fast_reroute_backup_as_primary: bool,
+
+    /// Instance-level BFD defaults (`router isis { bfd {} }`), inherited by
+    /// every interface and overridden per interface (see
+    /// [`super::link::LinkBfdConfig::resolve`]).
+    pub bfd: super::link::LinkBfdConfig,
 
     /// True when `/router/isis/multi-topology` carries an MT id.
     /// Drives whether IS-IS originates TLV 229 and the per-MT reach
@@ -653,6 +685,7 @@ impl Default for IsisConfig {
     // boilerplate as adding it to the derive.
     fn default() -> Self {
         Self {
+            bfd: Default::default(),
             net: Default::default(),
             hostname: Default::default(),
             is_type: Default::default(),

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1682,16 +1682,79 @@ impl Isis {
             tracing::debug!(?key, "isis: bfd not configured; skipping subscribe");
             return;
         };
+        // Resolve the interface's effective Echo config (per-interface `bfd {}`
+        // merged over the instance-level `router isis { bfd {} }` default) and
+        // pass it in the session params. The BFD instance gates Echo further to
+        // single-hop IPv4 with a live reflector, so it's inert on v6 adjacencies.
+        let eff = self
+            .links
+            .get(&key.ifindex)
+            .map(|l| l.config.bfd.resolve(&self.config.bfd))
+            .unwrap_or_else(|| super::link::LinkBfdConfig::default().resolve(&self.config.bfd));
+        let (echo_mode, echo_rx_us, echo_tx_us) = match eff.echo_mode {
+            Some(mode) => (
+                mode,
+                eff.echo_receive_ms.saturating_mul(1000),
+                eff.echo_transmit_ms.saturating_mul(1000),
+            ),
+            None => (crate::bfd::session::EchoMode::Off, 0, 0),
+        };
         let _ = tx.send(crate::bfd::inst::ClientReq::Subscribe {
             client: "isis".to_string(),
             key,
-            // Uses default params for every IS-IS adjacency.
-            // Profile resolution against `/bfd/profile/<name>` (the
-            // per-interface `bfd { profile NAME }` reference) is a
-            // follow-up that needs cross-task config access.
-            params: crate::bfd::session::SessionParams::default(),
+            // Profile resolution against `/bfd/profile/<name>` is still a
+            // follow-up (needs cross-task config access); only Echo is wired.
+            params: crate::bfd::session::SessionParams {
+                echo_mode,
+                required_min_echo_rx_us: echo_rx_us,
+                echo_transmit_us: echo_tx_us,
+                ..crate::bfd::session::SessionParams::default()
+            },
             notifier: self.bfd_event_tx.clone(),
         });
+    }
+
+    /// Re-evaluate BFD for every Up adjacency on every interface — used by the
+    /// `bfd {}` config callbacks (per-interface and instance-level), whose
+    /// changes (notably a blanket `enable`) affect adjacencies that are already
+    /// Up. Subscribe / Unsubscribe is idempotent at the BFD instance (keyed by
+    /// client+key), so we can re-drive without tracking per-adjacency state;
+    /// Echo-param changes take effect on the next session (re)establishment.
+    pub(crate) fn bfd_reconcile_all(&self) {
+        if self.bfd_client_tx.is_none() {
+            return;
+        }
+        let mut actions: Vec<(crate::bfd::session::SessionKey, bool)> = Vec::new();
+        for (ifindex, link) in self.links.iter() {
+            let enable = link.config.bfd.resolve(&self.config.bfd).enable;
+            let Some(local) = link.state.v4addr.first().map(|p| p.addr()) else {
+                continue;
+            };
+            for level in [Level::L1, Level::L2] {
+                for nbr in link.state.nbrs.get(&level).values() {
+                    if nbr.state != NfsmState::Up {
+                        continue;
+                    }
+                    let Some(remote) = nbr.addr4.keys().next().copied() else {
+                        continue;
+                    };
+                    let key = crate::bfd::session::SessionKey {
+                        local: std::net::IpAddr::V4(local),
+                        remote: std::net::IpAddr::V4(remote),
+                        ifindex: *ifindex,
+                        multihop: false,
+                    };
+                    actions.push((key, enable));
+                }
+            }
+        }
+        for (key, enable) in actions {
+            if enable {
+                self.process_bfd_subscribe(key);
+            } else {
+                self.process_bfd_unsubscribe(key);
+            }
+        }
     }
 
     /// Forward an `Unsubscribe` to the BFD instance. No-op when BFD

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -14,6 +14,7 @@ use strum_macros::{Display, EnumString};
 use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc::{self, UnboundedSender};
 
+use crate::bfd::session::EchoMode;
 use crate::config::{Args, ConfigOp};
 use crate::context::Timer;
 use crate::isis_event_trace;
@@ -297,14 +298,62 @@ pub struct LinkConfig {
     pub hello_auth: IsisAuthConfig,
 }
 
-/// IS-IS-side mirror of the YANG `bfd { enable, profile }` container.
-/// Empty defaults match the YANG schema; the adjacency FSM reads
-/// this when an adjacency reaches Up to decide whether to
-/// subscribe.
+/// IS-IS-side mirror of the YANG `bfd { ... }` container. Backs **both** the
+/// instance-level default (`router isis { bfd {} }`, `IsisConfig::bfd`) and the
+/// per-interface override (`interface X bfd {}`, `LinkConfig::bfd`); every leaf
+/// is `Option`/`None`-default so the per-interface value overrides the instance
+/// default per leaf (see [`LinkBfdConfig::resolve`]), and "unset" is
+/// distinguishable from a value. The adjacency FSM reads the *resolved* value
+/// when an adjacency reaches Up to decide whether to subscribe + with what Echo.
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct LinkBfdConfig {
-    pub enable: bool,
+    /// Activate BFD. Instance-level `Some(true)` blanket-enables every
+    /// interface; per-interface overrides it (`Some(false)` opts out). `None` ⇒
+    /// inherit; off if unset everywhere.
+    pub enable: Option<bool>,
     pub profile: Option<String>,
+    /// BFD Echo role for adjacencies on this interface
+    /// (`transmit` / `receive` / `both`); `None` ⇒ inherit (off if unset
+    /// everywhere). Single-hop IPv4 only — inert on IPv6-only adjacencies.
+    pub echo_mode: Option<EchoMode>,
+    /// Echo transmit interval (ms); `None` ⇒ [`DEFAULT_ECHO_INTERVAL_MS`].
+    pub echo_transmit_ms: Option<u32>,
+    /// Advertised Required Min Echo RX (ms); `None` ⇒
+    /// [`DEFAULT_ECHO_INTERVAL_MS`].
+    pub echo_receive_ms: Option<u32>,
+}
+
+/// FRR default Echo interval (ms) — the hard default for the transmit/receive
+/// intervals when unset at every level.
+pub const DEFAULT_ECHO_INTERVAL_MS: u32 = 50;
+
+/// Effective BFD settings for one interface after merging its per-interface
+/// `bfd {}` over the instance-level default. (IS-IS has no `min-neighbor-state`
+/// — it subscribes at adjacency Up.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolvedBfd {
+    pub enable: bool,
+    pub echo_mode: Option<EchoMode>,
+    pub echo_transmit_ms: u32,
+    pub echo_receive_ms: u32,
+}
+
+impl LinkBfdConfig {
+    /// Resolve `self` (per-interface) over `default` (instance-level), per leaf.
+    pub fn resolve(&self, default: &LinkBfdConfig) -> ResolvedBfd {
+        ResolvedBfd {
+            enable: self.enable.or(default.enable).unwrap_or(false),
+            echo_mode: self.echo_mode.or(default.echo_mode),
+            echo_transmit_ms: self
+                .echo_transmit_ms
+                .or(default.echo_transmit_ms)
+                .unwrap_or(DEFAULT_ECHO_INTERVAL_MS),
+            echo_receive_ms: self
+                .echo_receive_ms
+                .or(default.echo_receive_ms)
+                .unwrap_or(DEFAULT_ECHO_INTERVAL_MS),
+        }
+    }
 }
 
 /// IS-IS-side mirror of the YANG `te-metric { ... }` container — the
@@ -821,7 +870,10 @@ pub fn config_bfd_enable(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Optio
     let name = args.string()?;
     let enable = args.boolean()?;
     let link = isis.links.get_mut_by_name(&name)?;
-    link.config.bfd.enable = op.is_set() && enable;
+    // `None` ⇒ inherit `router isis { bfd { enable } }`; `Some(false)` opts this
+    // interface out of a blanket instance enable.
+    link.config.bfd.enable = op.is_set().then_some(enable);
+    isis.bfd_reconcile_all();
     Some(())
 }
 
@@ -834,6 +886,106 @@ pub fn config_bfd_profile(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Opti
     let profile = args.string()?;
     let link = isis.links.get_mut_by_name(&name)?;
     link.config.bfd.profile = op.is_set().then_some(profile);
+    Some(())
+}
+
+/// Parse the `{transmit|receive|both}` echo-mode enum (set) → `Some(mode)`, or
+/// `None` on delete. Shared by the per-interface and instance-level handlers.
+fn parse_echo_mode(value: &str, op: ConfigOp) -> Option<Option<EchoMode>> {
+    if !op.is_set() {
+        return Some(None);
+    }
+    match value {
+        "transmit" => Some(Some(EchoMode::Transmit)),
+        "receive" => Some(Some(EchoMode::Receive)),
+        "both" => Some(Some(EchoMode::Both)),
+        _ => None,
+    }
+}
+
+/// `interface X bfd echo-mode <transmit|receive|both>` — per-interface Echo role
+/// (RFC 5880 §6.4; single-hop IPv4). Overrides the instance default.
+pub fn config_bfd_echo_mode(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let value = args.string()?;
+    let mode = parse_echo_mode(&value, op)?;
+    let link = isis.links.get_mut_by_name(&name)?;
+    link.config.bfd.echo_mode = mode;
+    isis.bfd_reconcile_all();
+    Some(())
+}
+
+/// `interface X bfd echo-transmit-interval <ms>` — per-interface Echo TX rate.
+pub fn config_bfd_echo_transmit_interval(
+    isis: &mut Isis,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let interval = args.u32()?;
+    let link = isis.links.get_mut_by_name(&name)?;
+    link.config.bfd.echo_transmit_ms = op.is_set().then_some(interval);
+    Some(())
+}
+
+/// `interface X bfd echo-receive-interval <ms>` — per-interface advertised RX.
+pub fn config_bfd_echo_receive_interval(
+    isis: &mut Isis,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let interval = args.u32()?;
+    let link = isis.links.get_mut_by_name(&name)?;
+    link.config.bfd.echo_receive_ms = op.is_set().then_some(interval);
+    Some(())
+}
+
+// ---- instance-level `router isis { bfd { ... } }` defaults ------------------
+
+/// `router isis bfd enable <bool>` — blanket-enable BFD on every IS-IS
+/// interface (a per-interface `bfd { enable false }` opts one out).
+pub fn config_isis_bfd_enable(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let enable = args.boolean()?;
+    isis.config.bfd.enable = op.is_set().then_some(enable);
+    isis.bfd_reconcile_all();
+    Some(())
+}
+
+/// `router isis bfd profile <name>` — instance-default profile (stored only).
+pub fn config_isis_bfd_profile(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let profile = args.string()?;
+    isis.config.bfd.profile = op.is_set().then_some(profile);
+    Some(())
+}
+
+/// `router isis bfd echo-mode <transmit|receive|both>` — instance default.
+pub fn config_isis_bfd_echo_mode(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let value = args.string()?;
+    isis.config.bfd.echo_mode = parse_echo_mode(&value, op)?;
+    isis.bfd_reconcile_all();
+    Some(())
+}
+
+/// `router isis bfd echo-transmit-interval <ms>` — instance default.
+pub fn config_isis_bfd_echo_transmit_interval(
+    isis: &mut Isis,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let interval = args.u32()?;
+    isis.config.bfd.echo_transmit_ms = op.is_set().then_some(interval);
+    Some(())
+}
+
+/// `router isis bfd echo-receive-interval <ms>` — instance default.
+pub fn config_isis_bfd_echo_receive_interval(
+    isis: &mut Isis,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let interval = args.u32()?;
+    isis.config.bfd.echo_receive_ms = op.is_set().then_some(interval);
     Some(())
 }
 
@@ -2026,12 +2178,13 @@ mod auth_show_tests {
 mod bfd_config_tests {
     use super::*;
 
-    /// LinkBfdConfig default mirrors the YANG defaults
-    /// (`enable=false`, no profile).
+    /// LinkBfdConfig default mirrors the YANG defaults (all unset ⇒
+    /// inherit; off if unset everywhere, no profile).
     #[test]
     fn default_bfd_is_disabled() {
         let bfd = LinkBfdConfig::default();
-        assert!(!bfd.enable);
+        assert!(bfd.enable.is_none());
+        assert!(!bfd.resolve(&LinkBfdConfig::default()).enable);
         assert!(bfd.profile.is_none());
 
         // Lives on LinkConfig with the same default.
@@ -2045,16 +2198,44 @@ mod bfd_config_tests {
     #[test]
     fn enable_and_profile_round_trip() {
         let mut lc = LinkConfig::default();
-        lc.bfd.enable = true;
+        lc.bfd.enable = Some(true);
         lc.bfd.profile = Some("FAST".to_string());
 
         assert_eq!(
             lc.bfd,
             LinkBfdConfig {
-                enable: true,
+                enable: Some(true),
                 profile: Some("FAST".to_string()),
+                ..LinkBfdConfig::default()
             },
         );
+    }
+
+    /// Per-interface BFD leaves override the instance default; unset inherit.
+    #[test]
+    fn bfd_resolve_merges_per_leaf() {
+        let default = LinkBfdConfig {
+            enable: Some(true), // blanket
+            echo_mode: Some(EchoMode::Receive),
+            echo_transmit_ms: Some(100),
+            ..LinkBfdConfig::default()
+        };
+        // Interface sets nothing → inherits.
+        let inherit = LinkBfdConfig::default().resolve(&default);
+        assert!(inherit.enable);
+        assert_eq!(inherit.echo_mode, Some(EchoMode::Receive));
+        assert_eq!(inherit.echo_transmit_ms, 100);
+        assert_eq!(inherit.echo_receive_ms, DEFAULT_ECHO_INTERVAL_MS);
+        // Interface overrides: opt out + change role.
+        let over = LinkBfdConfig {
+            enable: Some(false),
+            echo_mode: Some(EchoMode::Both),
+            ..LinkBfdConfig::default()
+        };
+        let eff = over.resolve(&default);
+        assert!(!eff.enable);
+        assert_eq!(eff.echo_mode, Some(EchoMode::Both));
+        assert_eq!(eff.echo_transmit_ms, 100); // still inherits
     }
 }
 

--- a/zebra-rs/src/isis/nfsm.rs
+++ b/zebra-rs/src/isis/nfsm.rs
@@ -121,7 +121,7 @@ pub fn nbr_hold_timer_expire(link: &mut LinkTop, level: Level, sys_id: IsisSysId
     // packet.rs regression path that may already have sent the
     // Unsubscribe.
     if was_up
-        && link.config.bfd.enable
+        && link.config.bfd.resolve(&link.up_config.bfd).enable
         && let Some(remote) = bfd_peer_v4
         && let Some(local) = link.state.v4addr.first().map(|p| p.addr())
     {

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -31,7 +31,9 @@ fn bfd_nfsm_dispatch(
     was_up: bool,
     state: NfsmState,
 ) {
-    if !link.config.bfd.enable {
+    // Effective enable = per-interface `bfd {}` merged over the instance-level
+    // `router isis { bfd {} }` default (blanket-enable + per-interface override).
+    if !link.config.bfd.resolve(&link.up_config.bfd).enable {
         return;
     }
     let (Some(remote), Some(local)) = (peer_v4, link.state.v4addr.first().map(|p| p.addr())) else {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1279,6 +1279,49 @@ module config {
           }
         }
 
+        container bfd {
+          ext:help "BFD defaults for this IS-IS instance";
+          description
+            "Instance-level BFD defaults applied to every IS-IS
+             interface, overridable per interface. `enable true` here
+             blanket-enables BFD on all of the instance's interfaces; a
+             per-interface `bfd { enable false }` opts one out. Each leaf
+             is overridable per interface.";
+          leaf enable {
+            ext:help "Blanket-enable BFD on all IS-IS interfaces";
+            type boolean;
+            description
+              "When true, attach BFD to every IS-IS interface's
+               adjacencies (overridable per interface).";
+          }
+          leaf profile {
+            ext:help "Default /bfd/profile (stored; not yet applied)";
+            type string;
+          }
+          leaf echo-mode {
+            ext:help "Default BFD Echo role (transmit | receive | both)";
+            type enumeration {
+              enum transmit { description "Originate Echo only."; }
+              enum receive { description "Advertise + reflect only."; }
+              enum both { description "Both."; }
+            }
+            description
+              "Instance-default BFD Echo role for every interface
+               (RFC 5880 §6.4; single-hop IPv4). Overridable per
+               interface; absent ⇒ Echo off.";
+          }
+          leaf echo-transmit-interval {
+            ext:help "Default Echo transmit interval (ms)";
+            type uint32;
+            units "milliseconds";
+          }
+          leaf echo-receive-interval {
+            ext:help "Default advertised Required Min Echo RX (ms)";
+            type uint32;
+            units "milliseconds";
+          }
+        }
+
         leaf is-type {
           type enumeration {
             enum level-1;
@@ -1885,6 +1928,36 @@ module config {
               description
                 "Name of a `/bfd/profile` entry whose parameters
                  apply to BFD sessions formed on this interface.";
+            }
+
+            leaf echo-mode {
+              ext:help "BFD Echo role (transmit | receive | both)";
+              type enumeration {
+                enum transmit { description "Originate Echo only."; }
+                enum receive { description "Advertise + reflect only."; }
+                enum both { description "Both."; }
+              }
+              description
+                "Enable the BFD Echo function (RFC 5880 §6.4) on this
+                 interface's single-hop IPv4 adjacencies, choosing which
+                 half is active. Backed by the per-interface `xdp-bfd-echo`
+                 helper. Overrides the instance default; absent ⇒ inherit.";
+            }
+            leaf echo-transmit-interval {
+              ext:help "Echo transmit interval (ms)";
+              type uint32;
+              units "milliseconds";
+              description
+                "Rate we originate Echo at (echo-mode `transmit`/`both`).
+                 Hard default 50 ms when unset at every level.";
+            }
+            leaf echo-receive-interval {
+              ext:help "Advertised Required Min Echo RX Interval (ms)";
+              type uint32;
+              units "milliseconds";
+              description
+                "Advertised Required Min Echo RX (echo-mode
+                 `receive`/`both`). Hard default 50 ms when unset.";
             }
           }
 


### PR DESCRIPTION
Brings the OSPF BFD echo-mode model (merged in #1147) to IS-IS:
per-interface + instance-level `router isis { bfd {} }` with per-leaf
inheritance and blanket-enable.

## Config surface
- Per-interface `interface X bfd { echo-mode {transmit|receive|both};
  echo-transmit-interval; echo-receive-interval }`.
- Instance-level `router isis { bfd {} }` default, overridden per
  interface *per leaf* (`LinkBfdConfig::resolve`); instance `enable true`
  blanket-enables all interfaces, a per-interface `enable false` opts out.

## Plumbing
- `LinkBfdConfig` backs both levels: `enable` → `Option<bool>` + echo
  fields; `resolve()` → `ResolvedBfd` (no min-neighbor-state — IS-IS
  subscribes at adjacency Up).
- `process_bfd_subscribe` resolves the interface's effective Echo config
  into the session params (was `SessionParams::default()`).
- `bfd_reconcile_all` re-drives Subscribe/Unsubscribe for every Up
  adjacency on a `bfd {}` config change (idempotent at the BFD instance).
- Adjacency-FSM enable gate (packet.rs + nfsm.rs) uses the resolved enable.
- config.yang: echo leaves on the per-interface `bfd` container + a new
  instance-level `/router/isis/bfd` container.

Echo is single-hop IPv4 only (IS-IS keys its session from the adjacency's
v4 addresses; IPv6-only adjacencies inert), reusing the `xdp-bfd-echo`
helper and the OSPF-proven control path.

## Test plan
- `cargo test -p zebra-rs isis::` 132 (incl. a new BFD-resolve test),
  `bfd::` 54, `yang_load_tests` 2.
- `cargo clippy --workspace --all-targets -- -D warnings` clean;
  `cargo fmt` applied; `mdbook build` clean.

BGP echo (single-hop eBGP only) is the planned follow-up.

Generated with [Claude Code](https://claude.com/claude-code)