### PR TITLE
bfd(echo): BGP echo-mode config (single-hop eBGP)

### DIFF
--- a/book/src/ch-02-08-bgp-bfd.md
+++ b/book/src/ch-02-08-bgp-bfd.md
@@ -23,17 +23,22 @@ router bgp {
 }
 ```
 
-No top-level `bfd { }` block is required — the BFD subsystem starts
-automatically with `router bgp`.
+There is no global top-level `bfd { }` block — the BFD subsystem starts
+automatically with `router bgp`. The same `bfd {}` leaves can be set once at the
+**instance level** (`router bgp { bfd {} }`) as a default for every neighbour,
+overridden per neighbour (see [Instance-level defaults](#instance-level-defaults)).
 
 | Leaf | Type | Default | Meaning |
 |---|---|---|---|
-| `enable` | boolean | `false` | Attach (or, on `false` / delete, detach) a BFD session for this neighbour. |
-| `multihop` | boolean | *inferred* | Force the hop mode. Unset ⇒ inferred (see below). |
-| `minimum-ttl` | 1–254 | 254 | Multi-hop only: lowest accepted received TTL (RFC 5883). Ignored single-hop. |
+| `enable` | boolean | _(off)_ | Attach (or, on `false` / delete, detach) a BFD session for this neighbour. |
+| `multihop` | boolean | *inferred* | Force the hop mode. Unset ⇒ inferred (see below). Per-neighbour only. |
+| `minimum-ttl` | 1–254 | 254 | Multi-hop only: lowest accepted received TTL (RFC 5883). Ignored single-hop. Per-neighbour only. |
+| `echo-mode` | `transmit` \| `receive` \| `both` | _(off)_ | [Echo function](ch-10-00-bfd.md#echo-function) role — **single-hop only** (see [Echo](#echo)). |
+| `echo-transmit-interval` | uint (ms) | `50` | Echo TX rate (`transmit` / `both`). |
+| `echo-receive-interval` | uint (ms) | `50` | Advertised Required Min Echo RX (`receive` / `both`). |
 
-Sessions use the BFD defaults (300 ms / ×3 ⇒ ~900 ms detection); the
-timers are not currently tunable — see
+Control-packet intervals use the BFD defaults (300 ms / ×3 ⇒ ~900 ms
+detection) and are not currently tunable — see
 [Tuning intervals](ch-10-00-bfd.md#tuning-intervals) in the overview.
 
 ## Single-hop vs multi-hop — inferred by default
@@ -72,6 +77,52 @@ family); there is no separate BFD source knob. This is the address the
 BFD control packets are actually sourced from, and the one `show bfd
 peers` reports as `Local address`. Changing `update-source` on a
 BFD-enabled neighbour rebuilds the session with the new source.
+
+## Echo
+
+`echo-mode` turns on the [BFD Echo function](ch-10-00-bfd.md#echo-function) —
+but Echo is **single-hop only** (RFC 5883 multihop has no Echo), so it applies
+**only to directly-connected eBGP** (`multihop` inferred or forced `false`). On
+an iBGP or multihop-eBGP neighbour the `echo-mode` leaf is accepted but inert.
+Within that constraint it works like the OSPF/IS-IS form — `transmit` originates,
+`receive` advertises + reflects, `both` does both, via the per-interface
+`xdp-bfd-echo` helper:
+
+```
+router bgp {
+  neighbor 10.0.0.2 {        // directly-connected eBGP
+    remote-as 65002;
+    bfd {
+      enable true;
+      echo-mode both;
+      echo-transmit-interval 50;
+      echo-receive-interval 50;
+    }
+  }
+}
+```
+
+## Instance-level defaults
+
+A `bfd {}` block directly under `router bgp` supplies defaults for **every**
+neighbour; the effective value of each leaf is the per-neighbour setting if
+present, else the instance default, else the hard default. `enable true` at the
+instance level **blanket-enables** BFD on all neighbours; a per-neighbour
+`bfd { enable false }` opts one out. (`multihop` / `minimum-ttl` are
+per-neighbour only — they are not inherited.)
+
+```
+router bgp {
+  bfd {
+    enable true;          // BFD on every neighbour…
+    echo-mode receive;    // …default Echo role (single-hop neighbours)
+  }
+  neighbor 10.0.0.2 {
+    remote-as 65002;
+    bfd { echo-mode both; }   // override; inherits enable
+  }
+}
+```
 
 ## Verifying
 

--- a/book/src/ch-10-00-bfd.md
+++ b/book/src/ch-10-00-bfd.md
@@ -215,10 +215,12 @@ all sessions on that link, and stopped when the last one goes away. It needs
 raw socket); the packaged install grants these. A node with no Echo configured
 runs no helper and advertises `Required Min Echo RX Interval = 0`.
 
-Echo is enabled per attachment — on OSPF and IS-IS interfaces, where `echo-mode`
-selects the role (`transmit` / `receive` / `both`) and
-`echo-transmit-interval` / `echo-receive-interval` set the rates; see
-[OSPF BFD](ch-08-02-ospf-bfd.md#echo) and [IS-IS BFD](ch-07-03-isis-bfd.md#echo).
+Echo is enabled per attachment — on OSPF and IS-IS interfaces, and on
+single-hop eBGP neighbours, where `echo-mode` selects the role
+(`transmit` / `receive` / `both`) and `echo-transmit-interval` /
+`echo-receive-interval` set the rates; see
+[OSPF BFD](ch-08-02-ospf-bfd.md#echo), [IS-IS BFD](ch-07-03-isis-bfd.md#echo),
+and [BGP BFD](ch-02-08-bgp-bfd.md#echo).
 `show bfd peers` reports the negotiated `Echo receive interval` /
 `Echo transmission interval`.
 
@@ -243,8 +245,10 @@ native timers would allow.
   originating our own, offloaded to the `xdp-bfd-echo` XDP/eBPF helper
   (see [Echo function](#echo-function) below), with per-role
   (`transmit` / `receive` / `both`) config and an instance-level
-  `router ospf { bfd {} }` default inherited and overridden per interface.
+  `router <proto> { bfd {} }` default inherited and overridden per
+  interface / neighbour. Echo is configurable on OSPF, IS-IS, and
+  single-hop eBGP (BGP echo is inert on multihop sessions — RFC 5883 has
+  no Echo).
 - **Not yet:** configurable control-packet timers (the intervals are
-  fixed at the defaults); Echo on BGP (OSPF + IS-IS today; BGP echo is
-  single-hop-only so it awaits a decision); BFD
-  for **static routes**; per-VRF OSPF BFD.
+  fixed at the defaults); BFD for **static routes**; per-VRF OSPF BFD;
+  BFD `profile` resolution (stored, not yet applied).

--- a/docs/design/bfd-echo-plan.md
+++ b/docs/design/bfd-echo-plan.md
@@ -23,15 +23,16 @@ Tracks the BFD **Echo function** (RFC 5880 §6.4 / §6.8.5 / §6.8.8 /
 >   (advertise ⟺ `Receive|Both`, originate ⟺ `Transmit|Both`, spawn
 >   helper ⟺ `≠ Off`). The IPC is a stdin/stdout line protocol
 >   (`echo-add`/`echo-del` → helper, `echo-down` → zebra-rs).
-> - **Config (OSPF v2+v3 and IS-IS, done)** — `echo-mode
+> - **Config (OSPF v2+v3, IS-IS, BGP — done)** — `echo-mode
 >   {transmit|receive|both}` with FRR-style `echo-transmit-interval` /
 >   `echo-receive-interval`, settable at the instance level
->   (`router ospf|isis { bfd {} }`) as a default and overridden per
->   interface *per leaf* (`{Ospf,}LinkBfdConfig::resolve`); instance
->   `enable true` blanket-enables all interfaces, a per-interface
->   `enable false` opts out. There is **no global top-level `bfd {}`**
->   container — BFD spawns eagerly with its first consumer. BGP echo
->   config is the remaining gap (single-hop eBGP only).
+>   (`router ospf|isis|bgp { bfd {} }`) as a default and overridden per
+>   interface / neighbor *per leaf*
+>   (`{Ospf,}LinkBfdConfig::resolve` / `PeerBfdConfig::resolve`); instance
+>   `enable true` blanket-enables, a per-link/neighbor `enable false` opts
+>   out. There is **no global top-level `bfd {}`** container — BFD spawns
+>   eagerly with its first consumer. BGP echo is **single-hop only**
+>   (RFC 5883 multihop has no Echo) — inert on iBGP / multihop eBGP.
 >
 > Open lab item: verify `bpf_timer`-from-XDP loads on the target kernel.
 >

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -3,7 +3,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use bgp_packet::*;
 
 use crate::bfd::inst::ClientReq;
-use crate::bfd::session::{SessionKey, SessionParams};
+use crate::bfd::session::{EchoMode, SessionKey, SessionParams};
 use crate::bfd::socket::{BFD_MULTI_HOP_PORT, BFD_MULTIHOP_DEFAULT_MIN_TTL, BFD_SINGLE_HOP_PORT};
 use crate::bgp::InOut;
 use crate::config::{Args, ConfigOp};
@@ -471,7 +471,11 @@ fn config_flowspec_validation(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Op
 fn bfd_apply(bgp: &mut Bgp, addr: IpAddr) -> Option<()> {
     let (enable, desired_key, params) = {
         let peer = bgp.peers.get(&addr)?;
-        let enable = peer.config.bfd.enable;
+        // Effective enable + Echo = the per-neighbor `bfd {}` merged over the
+        // instance-level `router bgp { bfd {} }` default (blanket enable +
+        // per-neighbor override). Hop-mode / min-ttl stay per-neighbor.
+        let eff = peer.config.bfd.resolve(&bgp.bfd);
+        let enable = eff.enable;
         let local = peer
             .config
             .transport
@@ -492,6 +496,17 @@ fn bfd_apply(bgp: &mut Bgp, addr: IpAddr) -> Option<()> {
             ifindex: 0,
             multihop,
         };
+        // Echo is single-hop only (RFC 5883 multihop has no Echo), so it's
+        // requested only for non-multihop neighbors; the BFD instance gates it
+        // further to IPv4 with a live reflector.
+        let (echo_mode, echo_rx_us, echo_tx_us) = match eff.echo_mode {
+            Some(mode) if !multihop => (
+                mode,
+                eff.echo_receive_ms.saturating_mul(1000),
+                eff.echo_transmit_ms.saturating_mul(1000),
+            ),
+            _ => (crate::bfd::session::EchoMode::Off, 0, 0),
+        };
         let params = SessionParams {
             dst_port: if multihop {
                 BFD_MULTI_HOP_PORT
@@ -499,9 +514,12 @@ fn bfd_apply(bgp: &mut Bgp, addr: IpAddr) -> Option<()> {
                 BFD_SINGLE_HOP_PORT
             },
             min_ttl,
-            // Intervals / detect-mult still come from the defaults; the
-            // peer's `bfd profile` is stored but not yet resolved (a
-            // separate follow-up needing cross-task BfdConfig access).
+            echo_mode,
+            required_min_echo_rx_us: echo_rx_us,
+            echo_transmit_us: echo_tx_us,
+            // Detect-mult still comes from the defaults; the peer's `bfd
+            // profile` is stored but not yet resolved (a separate follow-up
+            // needing cross-task BfdConfig access).
             ..SessionParams::default()
         };
         (enable, key, params)
@@ -553,7 +571,9 @@ fn config_peer_bfd_enable(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option
     let enable = args.boolean()?;
     {
         let peer = bgp.peers.get_mut(&addr)?;
-        peer.config.bfd.enable = op.is_set() && enable;
+        // `None` ⇒ inherit `router bgp { bfd { enable } }`; `Some(false)` opts
+        // this neighbor out of a blanket instance enable.
+        peer.config.bfd.enable = op.is_set().then_some(enable);
     }
     bfd_apply(bgp, addr)
 }
@@ -580,6 +600,107 @@ fn config_peer_bfd_min_ttl(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
         peer.config.bfd.minimum_ttl = op.is_set().then_some(ttl);
     }
     bfd_apply(bgp, addr)
+}
+
+/// Parse the `{transmit|receive|both}` echo-mode enum (set) → `Some(mode)`, or
+/// `None` on delete. `None`/parse-failure on a malformed value.
+fn parse_bfd_echo_mode(value: &str, op: ConfigOp) -> Option<Option<EchoMode>> {
+    if !op.is_set() {
+        return Some(None);
+    }
+    match value {
+        "transmit" => Some(Some(EchoMode::Transmit)),
+        "receive" => Some(Some(EchoMode::Receive)),
+        "both" => Some(Some(EchoMode::Both)),
+        _ => None,
+    }
+}
+
+/// `set router bgp neighbor X bfd echo-mode <transmit|receive|both>` —
+/// per-neighbor Echo role. Single-hop only (inert on multihop sessions).
+fn config_peer_bfd_echo_mode(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let value = args.string()?;
+    let mode = parse_bfd_echo_mode(&value, op)?;
+    {
+        let peer = bgp.peers.get_mut(&addr)?;
+        peer.config.bfd.echo_mode = mode;
+    }
+    bfd_apply(bgp, addr)
+}
+
+/// `set router bgp neighbor X bfd echo-transmit-interval <ms>`.
+fn config_peer_bfd_echo_tx(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let interval = args.u32()?;
+    {
+        let peer = bgp.peers.get_mut(&addr)?;
+        peer.config.bfd.echo_transmit_ms = op.is_set().then_some(interval);
+    }
+    bfd_apply(bgp, addr)
+}
+
+/// `set router bgp neighbor X bfd echo-receive-interval <ms>`.
+fn config_peer_bfd_echo_rx(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let interval = args.u32()?;
+    {
+        let peer = bgp.peers.get_mut(&addr)?;
+        peer.config.bfd.echo_receive_ms = op.is_set().then_some(interval);
+    }
+    bfd_apply(bgp, addr)
+}
+
+/// Re-reconcile BFD for every neighbor — used by the instance-level
+/// `router bgp { bfd {} }` callbacks, whose defaults (notably a blanket
+/// `enable`) affect neighbors that set nothing of their own. `bfd_apply` is a
+/// per-neighbor reconcile that diffs against the recorded session key, so this
+/// is just a fan-out.
+fn bfd_reconcile_all(bgp: &mut Bgp) {
+    let addrs: Vec<IpAddr> = bgp.peers.keys().copied().collect();
+    for addr in addrs {
+        bfd_apply(bgp, addr);
+    }
+}
+
+// ---- instance-level `router bgp { bfd { ... } }` defaults -------------------
+
+/// `router bgp bfd enable <bool>` — blanket-enable BFD on every neighbor
+/// (a per-neighbor `bfd { enable false }` opts one out).
+fn config_bgp_bfd_enable(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let enable = args.boolean()?;
+    bgp.bfd.enable = op.is_set().then_some(enable);
+    bfd_reconcile_all(bgp);
+    Some(())
+}
+
+/// `router bgp bfd profile <name>` — instance-default profile (stored only).
+fn config_bgp_bfd_profile(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let profile = args.string()?;
+    bgp.bfd.profile = op.is_set().then_some(profile);
+    Some(())
+}
+
+/// `router bgp bfd echo-mode <transmit|receive|both>` — instance default.
+fn config_bgp_bfd_echo_mode(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let value = args.string()?;
+    bgp.bfd.echo_mode = parse_bfd_echo_mode(&value, op)?;
+    bfd_reconcile_all(bgp);
+    Some(())
+}
+
+/// `router bgp bfd echo-transmit-interval <ms>` — instance default.
+fn config_bgp_bfd_echo_tx(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let interval = args.u32()?;
+    bgp.bfd.echo_transmit_ms = op.is_set().then_some(interval);
+    Some(())
+}
+
+/// `router bgp bfd echo-receive-interval <ms>` — instance default.
+fn config_bgp_bfd_echo_rx(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let interval = args.u32()?;
+    bgp.bfd.echo_receive_ms = op.is_set().then_some(interval);
+    Some(())
 }
 
 /// Pick an unspecified local address whose family matches `remote`.
@@ -1826,6 +1947,21 @@ impl Bgp {
         self.callback_peer("/bfd/profile", config_peer_bfd_profile);
         self.callback_peer("/bfd/multihop", config_peer_bfd_multihop);
         self.callback_peer("/bfd/minimum-ttl", config_peer_bfd_min_ttl);
+        self.callback_peer("/bfd/echo-mode", config_peer_bfd_echo_mode);
+        self.callback_peer("/bfd/echo-transmit-interval", config_peer_bfd_echo_tx);
+        self.callback_peer("/bfd/echo-receive-interval", config_peer_bfd_echo_rx);
+        // Instance-level `router bgp { bfd { ... } }` defaults.
+        self.callback_add("/router/bgp/bfd/enable", config_bgp_bfd_enable);
+        self.callback_add("/router/bgp/bfd/profile", config_bgp_bfd_profile);
+        self.callback_add("/router/bgp/bfd/echo-mode", config_bgp_bfd_echo_mode);
+        self.callback_add(
+            "/router/bgp/bfd/echo-transmit-interval",
+            config_bgp_bfd_echo_tx,
+        );
+        self.callback_add(
+            "/router/bgp/bfd/echo-receive-interval",
+            config_bgp_bfd_echo_rx,
+        );
         self.callback_peer("/tcp-ao/key-chain", config_peer_tcp_ao_key_chain);
         self.callback_peer(
             "/tcp-ao/include-tcp-options",
@@ -2281,7 +2417,7 @@ mod bfd_wiring_tests {
             .peers
             .get(&IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4)))
             .unwrap();
-        assert!(peer.config.bfd.enable, "config bit still flips");
+        assert_eq!(peer.config.bfd.enable, Some(true), "config bit still flips");
     }
 
     // -----------------------------------------------------------------

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1,5 +1,5 @@
 use super::BgpAttrStore;
-use super::peer::{BgpTop, Event, fsm};
+use super::peer::{BgpTop, Event, PeerBfdConfig, fsm};
 use super::peer_map::PeerMap;
 use super::route::LocalRib;
 use crate::bgp::debug::BgpDebugFlags;
@@ -320,6 +320,10 @@ pub struct Bgp {
     /// emitted. See `Bgp::hostname()` for the resolution order.
     pub hostname: Option<String>,
     pub peers: PeerMap,
+    /// Instance-level BFD defaults (`router bgp { bfd {} }`), inherited by
+    /// every neighbor and overridden per neighbor (see
+    /// [`super::peer::PeerBfdConfig::resolve`]).
+    pub bfd: PeerBfdConfig,
     /// Bounded channel for BGP events (capacity: 8192)
     pub tx: mpsc::Sender<Message>,
     pub rx: mpsc::Receiver<Message>,
@@ -614,6 +618,7 @@ impl Bgp {
             local_vxlans: BTreeMap::new(),
             hostname: None,
             peers: PeerMap::new(),
+            bfd: PeerBfdConfig::default(),
             tx,
             rx,
             local_rib: LocalRib::default(),

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -20,7 +20,7 @@ use caps::CapAs4;
 use caps::CapRefresh;
 use caps::CapabilityPacket;
 
-use crate::bfd::session::SessionKey;
+use crate::bfd::session::{EchoMode, SessionKey};
 use crate::bgp::cap::cap_register_recv;
 use crate::bgp::route::{route_clean, route_sync};
 use crate::bgp::{AdjRib, In, Out};
@@ -195,18 +195,65 @@ pub struct PeerTransportConfig {
 /// calls on the BFD instance via `bfd::inst::Bfd::client_req_tx`.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct PeerBfdConfig {
-    pub enable: bool,
+    /// Activate BFD. `None` ⇒ inherit the instance-level
+    /// `router bgp { bfd { enable } }`; `Some(false)` opts this neighbor out
+    /// of a blanket instance enable. Off if unset everywhere.
+    pub enable: Option<bool>,
     pub profile: Option<String>,
     /// Hop-mode override. `None` (the default) means "infer": the
     /// session is multihop iff the BGP session is iBGP, mirroring FRR's
     /// `PEER_IS_MULTIHOP`. `Some(true)`/`Some(false)` force it — used
     /// for eBGP-over-loopback until a dedicated `ebgp-multihop` knob
-    /// exists. See [`Peer::bfd_multihop`].
+    /// exists. See [`Peer::bfd_multihop`]. Per-neighbor only (not inherited).
     pub multihop: Option<bool>,
     /// Multihop minimum received TTL (RFC 5883). `None` falls back to
     /// [`crate::bfd::socket::BFD_MULTIHOP_DEFAULT_MIN_TTL`]. Ignored for
     /// single-hop sessions (GTSM requires 255 unconditionally).
     pub minimum_ttl: Option<u8>,
+    /// BFD Echo role (`transmit` / `receive` / `both`); `None` ⇒ inherit
+    /// (off if unset everywhere). **Single-hop only** — RFC 5883 multihop has
+    /// no Echo, so this is inert on multihop sessions (iBGP / multihop eBGP).
+    pub echo_mode: Option<EchoMode>,
+    /// Echo transmit interval (ms); `None` ⇒ [`DEFAULT_ECHO_INTERVAL_MS`].
+    pub echo_transmit_ms: Option<u32>,
+    /// Advertised Required Min Echo RX (ms); `None` ⇒
+    /// [`DEFAULT_ECHO_INTERVAL_MS`].
+    pub echo_receive_ms: Option<u32>,
+}
+
+/// FRR default Echo interval (ms) — the hard default for the Echo intervals
+/// when unset at every level.
+pub const DEFAULT_ECHO_INTERVAL_MS: u32 = 50;
+
+/// Effective BFD Echo settings for a neighbor after merging its per-neighbor
+/// `bfd {}` over the instance-level default. (Hop-mode / min-ttl are
+/// per-neighbor and not part of this merge.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolvedPeerBfd {
+    pub enable: bool,
+    pub echo_mode: Option<EchoMode>,
+    pub echo_transmit_ms: u32,
+    pub echo_receive_ms: u32,
+}
+
+impl PeerBfdConfig {
+    /// Resolve `self` (per-neighbor) over `default` (instance-level
+    /// `router bgp { bfd {} }`), per leaf, for the inheritable bits
+    /// (enable + Echo). Hop-mode / min-ttl stay per-neighbor (read directly).
+    pub fn resolve(&self, default: &PeerBfdConfig) -> ResolvedPeerBfd {
+        ResolvedPeerBfd {
+            enable: self.enable.or(default.enable).unwrap_or(false),
+            echo_mode: self.echo_mode.or(default.echo_mode),
+            echo_transmit_ms: self
+                .echo_transmit_ms
+                .or(default.echo_transmit_ms)
+                .unwrap_or(DEFAULT_ECHO_INTERVAL_MS),
+            echo_receive_ms: self
+                .echo_receive_ms
+                .or(default.echo_receive_ms)
+                .unwrap_or(DEFAULT_ECHO_INTERVAL_MS),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1914,12 +1961,13 @@ mod collision_tests {
 mod bfd_config_tests {
     use super::*;
 
-    /// PeerBfdConfig default mirrors the YANG defaults
-    /// (`enable=false`, no profile).
+    /// PeerBfdConfig default mirrors the YANG defaults (all unset ⇒
+    /// inherit; off if unset everywhere, no profile).
     #[test]
     fn default_bfd_is_disabled() {
         let bfd = PeerBfdConfig::default();
-        assert!(!bfd.enable);
+        assert!(bfd.enable.is_none());
+        assert!(!bfd.resolve(&PeerBfdConfig::default()).enable);
         assert!(bfd.profile.is_none());
 
         // Lives on PeerConfig with the same default.
@@ -1933,7 +1981,7 @@ mod bfd_config_tests {
     #[test]
     fn enable_and_profile_round_trip() {
         let mut pc = PeerConfig::default();
-        pc.bfd.enable = true;
+        pc.bfd.enable = Some(true);
         pc.bfd.profile = Some("FAST".to_string());
         pc.bfd.multihop = Some(true);
         pc.bfd.minimum_ttl = Some(250);
@@ -1941,11 +1989,38 @@ mod bfd_config_tests {
         assert_eq!(
             pc.bfd,
             PeerBfdConfig {
-                enable: true,
+                enable: Some(true),
                 profile: Some("FAST".to_string()),
                 multihop: Some(true),
                 minimum_ttl: Some(250),
+                ..PeerBfdConfig::default()
             },
         );
+    }
+
+    /// Per-neighbor Echo leaves override the instance default; unset inherit.
+    #[test]
+    fn bfd_resolve_merges_echo() {
+        let default = PeerBfdConfig {
+            enable: Some(true), // blanket
+            echo_mode: Some(EchoMode::Receive),
+            echo_transmit_ms: Some(100),
+            ..PeerBfdConfig::default()
+        };
+        let inherit = PeerBfdConfig::default().resolve(&default);
+        assert!(inherit.enable);
+        assert_eq!(inherit.echo_mode, Some(EchoMode::Receive));
+        assert_eq!(inherit.echo_transmit_ms, 100);
+        assert_eq!(inherit.echo_receive_ms, DEFAULT_ECHO_INTERVAL_MS);
+
+        let over = PeerBfdConfig {
+            enable: Some(false),
+            echo_mode: Some(EchoMode::Both),
+            ..PeerBfdConfig::default()
+        };
+        let eff = over.resolve(&default);
+        assert!(!eff.enable);
+        assert_eq!(eff.echo_mode, Some(EchoMode::Both));
+        assert_eq!(eff.echo_transmit_ms, 100); // inherits
     }
 }

--- a/zebra-rs/yang/zebra-bgp-bfd.yang
+++ b/zebra-rs/yang/zebra-bgp-bfd.yang
@@ -27,89 +27,126 @@ module zebra-bgp-bfd {
     "https://github.com/zebra-rs";
 
   description
-    "FRR-style per-neighbor BFD attachment for BGP. Adds a flat
-     `bfd` container under each BGP neighbor:
+    "FRR-style BFD attachment for BGP. A flat `bfd` container appears
+     both at the BGP instance level (a default applied to every neighbor)
+     and under each neighbor (an override):
 
        router bgp {
+         bfd {
+           enable true;          // blanket-enable all neighbors
+           echo-mode receive;    // default Echo role
+         }
          neighbor 10.0.0.5 {
            remote-as 65501;
            bfd {
              enable true;
              profile FAST;
-             multihop true;     // eBGP-over-loopback; iBGP infers this
+             multihop true;       // eBGP-over-loopback; iBGP infers this
              minimum-ttl 250;
+             echo-mode both;      // override (single-hop neighbors only)
            }
          }
        }
 
-     PR 5b stores the per-neighbor BFD configuration on
-     `peer.config.bfd` (see `bgp::peer::PeerBfdConfig`). PR 5c wires
-     these leaves to the BFD client subscription API — when
-     `enable` flips to true, the BGP code path subscribes the
-     neighbor to BFD via the channel exposed by
-     `bfd::inst::Bfd::client_req_tx`; a transition to Down then
-     terminates the BGP session.";
+     The effective value of each `bfd` leaf is the per-neighbor setting if
+     present, else the instance default, else a hard default. `enable true`
+     at the instance level activates BFD on every neighbor (a per-neighbor
+     `enable false` opts one out). Echo is **single-hop only** (RFC 5883
+     multihop has no Echo), so `echo-mode` is inert on multihop sessions
+     (iBGP and multihop eBGP). Hop-mode (`multihop`) and `minimum-ttl` are
+     per-neighbor only.";
+
+  revision 2026-06-01 {
+    description
+      "Add instance-level `router bgp { bfd {} }` defaults with
+       per-neighbor override, and single-hop `echo-mode`
+       (transmit/receive/both) + echo-transmit/receive-interval.";
+    reference
+      "RFC 5880 §6.4 (Echo). FRR bfdd echo-mode; single-hop eBGP only.";
+  }
 
   revision 2026-05-31 {
     description
-      "Add `multihop` hop-mode override and multihop `minimum-ttl`.
-       Default hop mode is inferred from the BGP session (iBGP ⇒
-       multihop), matching FRR; the override covers eBGP-over-loopback
-       until a dedicated `ebgp-multihop` knob exists.";
+      "Add `multihop` hop-mode override and multihop `minimum-ttl`.";
     reference
-      "RFC 5883 (Multihop BFD). FRR `bfd` peer `multihop` / `minimum-ttl`.
-       Cisco IOS-XR `bfd multihop ttl-drop-threshold`.";
+      "RFC 5883 (Multihop BFD). FRR `bfd` peer `multihop` / `minimum-ttl`.";
   }
 
   revision 2026-05-19 {
     description "Initial revision (PR 5b — storage only).";
     reference
-      "FRR `neighbor X bfd` / `neighbor X bfd profile P`.
-       Cisco IOS-XR `neighbor X bfd fast-detect`.
-       RFC 5880, RFC 9314.";
+      "FRR `neighbor X bfd` / `neighbor X bfd profile P`. RFC 5880, RFC 9314.";
+  }
+
+  // Leaves shared by the instance-level and per-neighbor `bfd {}` containers.
+  // No YANG `default` (absent ⇒ inherit, then a hard default in code).
+  grouping bgp-bfd-common {
+    leaf enable {
+      ext:help "Activate BFD (omit to inherit the instance default)";
+      type boolean;
+      description
+        "Activate BFD. At the instance level, `true` blanket-enables BFD
+         on every neighbor; per neighbor it overrides that default, so
+         `false` opts a single neighbor out. Absent at both levels ⇒ off.";
+    }
+    leaf profile {
+      type string;
+      description
+        "Name of a `/bfd/profile` entry whose parameters apply to the
+         session. Stored; profile resolution is a shared follow-up.";
+    }
+    leaf echo-mode {
+      ext:help "BFD Echo role (transmit | receive | both)";
+      type enumeration {
+        enum transmit { description "Originate Echo only."; }
+        enum receive { description "Advertise + reflect only."; }
+        enum both { description "Both."; }
+      }
+      description
+        "Enable the BFD Echo function (RFC 5880 §6.4). **Single-hop only**
+         — RFC 5883 multihop has no Echo, so this is inert on multihop
+         sessions (iBGP / multihop eBGP). Single-hop IPv4 only. Overrides
+         the instance default; absent ⇒ inherit (Echo off if unset).";
+    }
+    leaf echo-transmit-interval {
+      ext:help "Echo transmit interval (ms)";
+      type uint32;
+      units "milliseconds";
+      description
+        "Rate we originate Echo at (echo-mode `transmit`/`both`). Hard
+         default 50 ms when unset at every level.";
+    }
+    leaf echo-receive-interval {
+      ext:help "Advertised Required Min Echo RX Interval (ms)";
+      type uint32;
+      units "milliseconds";
+      description
+        "Advertised Required Min Echo RX (echo-mode `receive`/`both`).
+         Hard default 50 ms when unset.";
+    }
   }
 
   grouping bgp-neighbor-bfd-extension {
     description
-      "FRR-style flat `bfd { ... }` block on a BGP neighbor.";
+      "FRR-style flat `bfd { ... }` block on a BGP neighbor — overrides the
+       instance-level `bfd {}` defaults, per leaf.";
 
     container bfd {
       ext:help "BFD attachment for this neighbor";
       description
-        "When `enable` is true, BGP attaches a BFD session to this
-         neighbor. The optional `profile` selects a named bundle of
-         session parameters defined under `/bfd/profile`; without a
-         profile, BFD's own defaults are used.";
-
-      leaf enable {
-        type boolean;
-        default false;
-        description
-          "Activates the BFD session for this neighbor. Disabling
-           (or removing the `bfd` block entirely) detaches the
-           session.";
-      }
-
-      leaf profile {
-        type string;
-        description
-          "Name of a `/bfd/profile` entry whose parameters apply
-           to this neighbor's BFD session. Leafref validation will
-           be added once libyang exposes cross-tree leafref
-           resolution.";
-      }
+        "Per-neighbor BFD. Each leaf overrides the BGP instance's `bfd {}`
+         default; an unset leaf inherits it.";
+      uses bgp-bfd-common;
 
       leaf multihop {
         ext:help "Force BFD hop mode for this neighbor";
         type boolean;
         description
-          "Explicit hop-mode override. When unset (the default), the
-           session is multihop iff the BGP session is iBGP, mirroring
-           FRR's `PEER_IS_MULTIHOP`. Set `true` for eBGP-over-loopback
-           (which neither vendor auto-detects without `ebgp-multihop`)
-           or `false` to force single-hop. Multihop uses UDP/4784 and a
-           relaxed TTL floor; single-hop uses UDP/3784 with GTSM
-           (TTL=255).";
+          "Explicit hop-mode override (per-neighbor only). When unset, the
+           session is multihop iff the BGP session is iBGP, mirroring FRR's
+           `PEER_IS_MULTIHOP`. Set `true` for eBGP-over-loopback or `false`
+           to force single-hop. Multihop uses UDP/4784 and a relaxed TTL
+           floor; single-hop uses UDP/3784 with GTSM (TTL=255).";
       }
 
       leaf minimum-ttl {
@@ -119,17 +156,41 @@ module zebra-bgp-bfd {
         }
         default 254;
         description
-          "Multihop only: minimum TTL accepted on incoming control
-           packets (RFC 5883). Ignored on single-hop sessions where
-           GTSM requires TTL=255 unconditionally. Equivalent to FRR's
-           `minimum-ttl` and IOS-XR's `bfd multihop ttl-drop-threshold`.";
+          "Multihop only (per-neighbor): minimum TTL accepted on incoming
+           control packets (RFC 5883). Ignored on single-hop sessions.";
       }
+    }
+  }
+
+  grouping bgp-router-bfd-extension {
+    description
+      "Instance-level BFD defaults for a BGP instance, inherited by every
+       neighbor and overridable per neighbor.";
+
+    container bfd {
+      ext:help "BFD defaults for this BGP instance";
+      description
+        "Defaults applied to every neighbor's BFD session. `enable true`
+         here blanket-enables BFD on all neighbors; a per-neighbor
+         `bfd { enable false }` opts one out. Every leaf is overridable per
+         neighbor. (Hop-mode / minimum-ttl are per-neighbor only.)";
+      uses bgp-bfd-common;
     }
   }
 
   /* =========================================================
    * Augments into the zebra-rs configure tree
    * ========================================================= */
+
+  augment "/configure:set/config:router/bgp:bgp" {
+    description "Instance-level BFD defaults for BGP (set).";
+    uses bgp-router-bfd-extension;
+  }
+
+  augment "/configure:delete/config:router/bgp:bgp" {
+    description "Instance-level BFD defaults for BGP (delete).";
+    uses bgp-router-bfd-extension;
+  }
 
   augment "/configure:set/config:router"
         + "/bgp:bgp/bgp:neighbor" {


### PR DESCRIPTION
Completes the BFD echo-mode rollout — BGP now has the same per-neighbour
+ instance-level model as OSPF (#1147) and IS-IS (#1148), **gated to
single-hop sessions**: RFC 5883 multihop has no Echo, so `echo-mode` is
inert on iBGP and multihop eBGP (it applies only to directly-connected
eBGP).

## Config surface
- Per-neighbour `neighbor X bfd { echo-mode {transmit|receive|both};
  echo-transmit-interval; echo-receive-interval }`.
- Instance-level `router bgp { bfd {} }` default, overridden per neighbour
  *per leaf* (`PeerBfdConfig::resolve`); instance `enable true`
  blanket-enables all neighbours, a per-neighbour `enable false` opts out.
  (`multihop` / `minimum-ttl` stay per-neighbour — not inherited.)

## Plumbing
- `PeerBfdConfig` backs both levels: `enable` → `Option<bool>` + echo
  fields; `resolve()` → `ResolvedPeerBfd`.
- `bfd_apply` resolves the effective enable + Echo and sets the session's
  echo params only when `!multihop`.
- `Bgp.bfd` instance default; `bfd_reconcile_all` fans `bfd_apply` over all
  neighbours on an instance-level `bfd {}` change.
- zebra-bgp-bfd.yang: shared `bgp-bfd-common` grouping + new instance-level
  `router bgp { bfd {} }` container; per-neighbour `enable` default dropped
  (absent ⇒ inherit).

## Test plan
- `cargo test -p zebra-rs bgp::config` 16, `bgp::peer` 14 (incl. a new
  resolve test), `bfd::` 54, `yang_load_tests` 2.
- `cargo clippy --workspace --all-targets -- -D warnings` clean;
  `cargo fmt` applied; `mdbook build` clean.

Echo-mode config is now complete across OSPF (v2+v3), IS-IS, and
single-hop eBGP.

Generated with [Claude Code](https://claude.com/claude-code)