### PR TITLE
IS-IS L1 all-P2P BDD topology + RIB level subtype

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -32,6 +32,10 @@ isis_fragmentation:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_fragmentation"
 
+isis_l1_p2p:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_l1_p2p"
+
 bgp_evpn_capability:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_capability"
@@ -75,4 +79,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation isis_l1_p2p bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE

--- a/bdd/docs/bgp_community.md
+++ b/bdd/docs/bgp_community.md
@@ -1,0 +1,50 @@
+# BGP well-known community handling (no-export, no-advertise)
+
+## Overview
+
+As a network operator
+I want to verify that the well-known communities NO_EXPORT and
+NO_ADVERTISE are honoured when re-advertising routes across eBGP
+and iBGP sessions, using a three-router topology.
+
+## Test Topology
+
+```
+  ┌──────────────────────────────────────────────────────────┐
+  │                          br0                             │
+  └─────────┬──────────────────┬──────────────────┬──────────┘
+            │                  │                  │
+       ┌────┴────┐        ┌────┴────┐        ┌────┴────┐
+       │   z1    │  eBGP  │   z2    │  iBGP  │   z3    │
+       │  (A)    │◀──────▶│  (B)    │◀──────▶│  (C)    │
+       │ AS65001 │        │ AS65002 │        │ AS65002 │
+       │192.168. │        │192.168. │        │192.168. │
+       │  0.1/24 │        │  0.2/24 │        │  0.3/24 │
+       └─────────┘        └─────────┘        └─────────┘
+```
+
+## Config Files
+
+- z1-1.yaml: A baseline — eBGP peer to B, no network advertised.
+- z1-2.yaml: A advertises 1.1.1.1/32 with no community attribute.
+- z1-3.yaml: A advertises 1.1.1.1/32 with community "no-export".
+- z1-4.yaml: A advertises 1.1.1.1/32 with community "no-advertise".
+- z2-1.yaml: B — eBGP to A, iBGP to C.
+- z3-1.yaml: C — iBGP to B only.
+- eBGP MinRouteAdvertisementInterval = 30 s
+- iBGP MinRouteAdvertisementInterval =  5 s
+- End-to-end A → B → C propagation: up to 30 + 5 = 35 s.
+- Each scenario that triggers a fresh advertisement on A waits
+
+Convergence wait-time rationale:
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish BGP sessions | |
+| A advertises 1.1.1.1/32 with no community — C receives it | |
+| A re-advertises 1.1.1.1/32 with community no-export — C still receives it | |
+| A re-advertises 1.1.1.1/32 with community no-advertise — C does NOT receive it | |
+| A reverts to plain advertisement — C receives it again | |
+| Teardown topology | |

--- a/bdd/docs/bgp_evpn_capability.md
+++ b/bdd/docs/bgp_evpn_capability.md
@@ -4,7 +4,11 @@
 
 As a network operator
 I want two zebra-rs instances to negotiate the L2VPN/EVPN multiprotocol
+capability (AFI=25 / SAFI=70) and bring an iBGP session to Established,
+so that the foundation for EVPN Type-2 / Type-3 advertisements is
+validated end-to-end before route exchange is implemented.
 No EVPN routes flow in this scenario — capability negotiation is the
+unit under test. Route exchange (Type-2 MAC/IP, Type-3 Inclusive
 Multicast) lands in follow-up features.
 
 ## Test Topology
@@ -21,6 +25,13 @@ Multicast) lands in follow-up features.
            │  0.1/24 │     │  0.2/24 │
            └─────────┘     └─────────┘
 ```
+
+## Notes
+
+Both peers enable two AFI/SAFIs:
+  - ipv4 (so the session has a fallback AF and matches the
+    established BDD pattern)
+  - evpn  (the AF this scenario is actually validating)
 
 ## Config Files
 

--- a/bdd/docs/bgp_gobgpd_etcd.md
+++ b/bdd/docs/bgp_gobgpd_etcd.md
@@ -33,6 +33,10 @@ Using a test topology with one zebra-rs RR, etcd, and 29 gobgpd RR clients
  └─────────┘  └───────────┘  └─────────┘  └───────────┘  └─────────┘  └─────────┘
 ```
 
+## Notes
+
+29 gobgpd RR clients: ese1-ese29 (see tests/configs/topology.list for IP addresses)
+
 ## Config Files
 
 - rr.yaml: AS 64512, zebra-rs RR with cluster-id 198.18.39.94, peers to all gobgpd clients

--- a/bdd/docs/bgp_gobgpd_rr.md
+++ b/bdd/docs/bgp_gobgpd_rr.md
@@ -33,6 +33,10 @@ Using a test topology with one zebra-rs RR and 29 gobgpd RR clients
  └─────────┘  └───────────┘  └─────────┘  └───────────┘  └─────────┘  └─────────┘
 ```
 
+## Notes
+
+29 gobgpd RR clients: ese1-ese29 (see tests/configs/topology.list for IP addresses)
+
 ## Config Files
 
 - rr.yaml: AS 64512, zebra-rs RR with cluster-id 198.18.39.94, peers to all gobgpd clients

--- a/bdd/docs/bgp_neighbor_group.md
+++ b/bdd/docs/bgp_neighbor_group.md
@@ -1,0 +1,44 @@
+# BGP neighbor-group inheritance end-to-end
+
+## Overview
+
+As a network operator
+I want a peer that only references a neighbor-group (no per-peer remote-as)
+to inherit the group's remote-as, establish a session, and react to
+later changes to the group's remote-as.
+This exercises the runtime path landed in PRs #758 (static-peer
+resolver), #760 (reactive sweep on group remote-as Set/Delete), and
+#762 (group-level delete cascade) through the full YAML/YANG/CLI
+stack — not just the in-memory callback wiring covered by the
+unit tests in #764.
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                   │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+```
+
+## Config Files
+
+- z1-1.yaml: AS 65001, neighbor-group "RR" with remote-as 65002,
+- z1-2.yaml: same shape, but RR's remote-as is 65099 (wrong) —
+- z2-1.yaml: plain AS 65002 peer to 192.168.0.1 remote-as 65001.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology | |
+| Inheritance — peer with only a neighbor-group reference establishes | |
+| Reactive sweep — changing the group's remote-as drops the session | |
+| Reactive sweep — restoring the group's remote-as brings it back | |
+| Teardown topology | |

--- a/bdd/docs/bgp_route_map_match.md
+++ b/bdd/docs/bgp_route_map_match.md
@@ -4,7 +4,13 @@
 
 As a network operator
 I want zebra-rs policy-list entries to filter received routes by
+as-path-set, next-hop-set, MED comparison, and origin, so that
+inbound policy can express the same conditions as IOS-XR RPL.
 All four match types are exercised against an established eBGP session
+by swapping z2's input policy and asserting which advertised prefixes
+appear in z2's RIB. z1 attaches an outbound policy that stamps MED=100
+on every advertised route so MED match scenarios have something
+deterministic to compare against.
 
 ## Test Topology
 
@@ -33,8 +39,8 @@ All four match types are exercised against an established eBGP session
 - z2-med-eq-fail.yaml: input policy `match med-eq 999` — no match.
 - z2-med-range-pass.yaml: input policy `match med-ge 50, med-le 200`
 - z2-med-range-fail.yaml: input policy `match med-ge 200` — MED=100
-- z2-nh-pass.yaml: input policy `match next-hop 192.168.0.1` — matches the peer's address
-- z2-nh-fail.yaml: input policy `match next-hop 10.10.10.10` — does not match
+- z2-nh-pass.yaml: input policy `match next-hop-set PEER-SUBNET`
+- z2-nh-fail.yaml: input policy `match next-hop-set WRONG-SUBNET`
 
 ## Test Scenarios
 
@@ -49,6 +55,6 @@ All four match types are exercised against an established eBGP session
 | match med-eq rejects routes with a different MED value | |
 | match med-ge and med-le accept routes inside the range | |
 | match med-ge rejects routes below the floor | |
-| match next-hop accepts routes whose nexthop equals the configured address | |
-| match next-hop rejects routes whose nexthop is a different address | |
+| match next-hop-set accepts routes whose nexthop is in the prefix-set | |
+| match next-hop-set rejects routes whose nexthop is outside the prefix-set | |
 | Teardown topology | |

--- a/bdd/docs/bgp_tcp_ao_auth.md
+++ b/bdd/docs/bgp_tcp_ao_auth.md
@@ -4,6 +4,8 @@
 
 As a network operator
 I want to protect a BGP session with TCP-AO using an RFC 8177 key
+chain and verify that matching MKTs on both peers establish the
+session.
 
 ## Test Topology
 
@@ -19,6 +21,10 @@ I want to protect a BGP session with TCP-AO using an RFC 8177 key
            │  0.1/24 │     │  0.2/24 │
            └─────────┘     └─────────┘
 ```
+
+## Notes
+
+Requires Linux kernel >= 6.7 on both peers.
 
 ## Config Files
 

--- a/bdd/docs/bgp_tcp_md5_auth.md
+++ b/bdd/docs/bgp_tcp_md5_auth.md
@@ -4,6 +4,7 @@
 
 As a network operator
 I want to protect a BGP session with a TCP MD5 shared secret and
+verify that mismatched secrets prevent the session from coming up.
 
 ## Test Topology
 

--- a/bdd/docs/bgp_vrf_evpn_type5.md
+++ b/bdd/docs/bgp_vrf_evpn_type5.md
@@ -1,0 +1,48 @@
+# BGP per-VRF EVPN Type-5 (IP Prefix) advertise to a remote PE
+
+## Overview
+
+As a network operator
+I want a network configured under `router bgp vrf X afi-safi ipv4`
+with `evpn advertise-ipv4` to be advertised as an EVPN Type-5
+(RFC 9136 IP Prefix) route toward a remote PE
+Using a two-namespace topology where z1 originates the prefix inside
+vrf-blue and z2 peers with z1 over the L2VPN/EVPN address family,
+imports the Type-5 route by matching route-target.
+This is the EVPN-encoded counterpart of the VPNv4 export feature: the
+same per-VRF state (RD, route-target, network) produces a Type-5 NLRI
+instead of a VPNv4 NLRI, exchanged over (AFI=25 / SAFI=70).
+
+## Test Topology
+
+```
+  ┌─────────────┐                ┌─────────────┐
+  │     z1      │   EVPN iBGP    │     z2      │
+  │  AS 65001   │ ◀────────────▶ │  AS 65001   │
+  │ vrf-blue:   │                │ vrf-blue:   │
+  │  RD 65001:  │                │  RD 65001:  │
+  │   100       │                │   200       │
+  │  RT 65001:  │                │  RT 65001:  │
+  │   100 imp/  │                │   100 imp/  │
+  │   exp       │                │   exp       │
+  │  net 10.1.  │                │             │
+  │   0.0/24    │                │             │
+  │  evpn adv-  │                │             │
+  │   ipv4      │                │             │
+  └─────────────┘                └─────────────┘
+   192.168.0.1                    192.168.0.2
+```
+
+## Config Files
+
+- z1-1.yaml: AS 65001, vrf-blue with RD 65001:100, RT 65001:100, a
+- z2-1.yaml: AS 65001, vrf-blue with RD 65001:200, RT 65001:100
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology | |
+| z1 advertises the self-originated network as an EVPN Type-5 route | |
+| z2 receives the EVPN Type-5 route under the originating RD | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_show.md
+++ b/bdd/docs/bgp_vrf_show.md
@@ -1,0 +1,33 @@
+# BGP per-VRF show command
+
+## Overview
+
+As a network operator
+I want to inspect the per-VRF state of a running zebra-rs
+Using a single-namespace topology that drives the local config
+callbacks end-to-end so `show ip bgp vrf` reports the committed
+Route Distinguisher / Route Target / MPLS label.
+
+## Test Topology
+
+```
+  ┌─────────┐
+  │   z1    │   AS 65001
+  │ 192.168 │   vrf-blue: RD 65001:100, RT 65001:100
+  │  .0.1/24│
+  └─────────┘
+```
+
+## Config Files
+
+- z1-1.yaml: baseline `router bgp` with no per-VRF block.
+- z1-2.yaml: adds top-level vrf-blue (with RT import/export) and
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology | |
+| Configure vrf-blue and observe via show | |
+| Remove vrf-blue and observe row drops | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_vpnv4_export.md
+++ b/bdd/docs/bgp_vrf_vpnv4_export.md
@@ -1,0 +1,41 @@
+# BGP per-VRF VPNv4 export to a remote PE
+
+## Overview
+
+As a network operator
+I want to advertise a network configured under `router bgp vrf X
+afi-safi ipv4` as a VPNv4 NLRI toward a remote PE
+Using a two-namespace topology where z1 originates the prefix
+inside vrf-blue and z2 peers with z1 over VPNv4 only.
+
+## Test Topology
+
+```
+  ┌─────────────┐                ┌─────────────┐
+  │     z1      │   VPNv4 iBGP   │     z2      │
+  │  AS 65001   │ ◀────────────▶ │  AS 65001   │
+  │ vrf-blue:   │                │ vrf-blue:   │
+  │  RD 65001:  │                │  RD 65001:  │
+  │   100       │                │   200       │
+  │  RT 65001:  │                │  RT 65001:  │
+  │   100 imp/  │                │   100 imp/  │
+  │   exp       │                │   exp       │
+  │  net 10.1.  │                │             │
+  │   0.0/24    │                │             │
+  └─────────────┘                └─────────────┘
+   192.168.0.1                    192.168.0.2
+```
+
+## Config Files
+
+- z1-1.yaml: AS 65001, vrf-blue with RD 65001:100, RT 65001:100,
+- z2-1.yaml: AS 65001, vrf-blue with RD 65001:200, RT 65001:100
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology | |
+| z1 advertises the self-originated network as VPNv4 | |
+| z2 receives the VPNv4 NLRI under the same RD | |
+| Teardown topology | |

--- a/bdd/docs/isis_ipv6.md
+++ b/bdd/docs/isis_ipv6.md
@@ -38,3 +38,4 @@ via a shared bridge.
 | Setup IS-IS L2 over a shared bridge and confirm the link is up | |
 | IS-IS installs reciprocal IPv6 routes to peer loopbacks | |
 | IS-IS adjacency survives a link bounce and routes recover | |
+| Teardown topology | |

--- a/bdd/docs/isis_l1_p2p.md
+++ b/bdd/docs/isis_l1_p2p.md
@@ -1,0 +1,44 @@
+# IS-IS Level-1-only over an all-point-to-point 10-router ladder
+
+## Overview
+
+As a network operator
+I want ten zebra-rs instances arranged in a 2x5 "ladder" to form IS-IS
+Level-1 adjacencies over point-to-point links, flood LSPs in a single
+area, and install dual-stack (IPv4 + IPv6) routes to every loopback,
+so that traffic follows the expected primary path, falls back out a
+different interface when the primary link drops, and load-shares across
+the two deliberate equal-cost (ECMP) diamonds.
+All links are point-to-point veth pairs (network-type point-to-point);
+every router is is-type level-1 in area 49.0001. On router zI the
+interface toward zJ is named "iJ".
+
+## Test Topology
+
+```
+    z1 --10-- z2 --10-- z3 --10-- z4 --10-- z5     top spine    (metric 10)
+    |         |         |         |         |
+    40        30        30        30        40       rungs (40 ends / 30 mid)
+    |         |         |         |         |
+    z6 --20-- z7 --20-- z8 --20-- z9 --20-- z10    bottom spine (metric 20)
+
+    loopbacks: zI -> 10.0.0.I/32  and  2001:db8:0:ffff::I/128
+```
+
+## Notes
+
+Asymmetric spines (top 10 != bottom 20) keep the topology
+primary/backup everywhere except the two end columns, where the rungs
+are bumped to 40 to create exactly two ECMP diamonds: z2<->z6 and
+z4<->z10.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the L1-only all-P2P ladder and confirm adjacencies form | |
+| L1 installs reciprocal dual-stack routes to every loopback | |
+| Primary path fails over to a different interface (z1 -> z5) | |
+| The two deliberate ECMP diamonds resolve (z2->z6 and z4->z10) | |
+| IS-IS stamps the level into the central RIB | |
+| Teardown topology | |

--- a/bdd/docs/isis_srv6.md
+++ b/bdd/docs/isis_srv6.md
@@ -42,3 +42,4 @@ in any IGP.
 | Scenario | Result |
 |----------|--------|
 | Setup the SRv6 chain and ping the far end through the SID | |
+| Teardown topology | |

--- a/bdd/src/netns.rs
+++ b/bdd/src/netns.rs
@@ -379,9 +379,16 @@ pub async fn list_pidfiles(dir: &Path, prefix: &str) -> Result<Vec<std::path::Pa
     Ok(out)
 }
 
-/// Ping an IPv6 target from inside a namespace. Returns true on success,
-/// false on failure. Errors only when the ping process itself cannot be run.
-pub async fn ping6(netns: &str, target: &str, count: u32, timeout_secs: u32) -> Result<bool> {
+/// Ping a target from inside a namespace, forcing address family via
+/// `family` (`-4` or `-6`). Returns true on success, false on failure.
+/// Errors only when the ping process itself cannot be run.
+async fn ping_family(
+    netns: &str,
+    family: &str,
+    target: &str,
+    count: u32,
+    timeout_secs: u32,
+) -> Result<bool> {
     let count_str = count.to_string();
     let timeout_str = timeout_secs.to_string();
     let output = Command::new("sudo")
@@ -390,7 +397,7 @@ pub async fn ping6(netns: &str, target: &str, count: u32, timeout_secs: u32) -> 
         .arg("exec")
         .arg(netns)
         .arg("ping")
-        .arg("-6")
+        .arg(family)
         .arg("-c")
         .arg(&count_str)
         .arg("-W")
@@ -402,4 +409,16 @@ pub async fn ping6(netns: &str, target: &str, count: u32, timeout_secs: u32) -> 
         .await
         .with_context(|| format!("Failed to ping {} from netns {}", target, netns))?;
     Ok(output.status.success())
+}
+
+/// Ping an IPv6 target from inside a namespace. Returns true on success,
+/// false on failure. Errors only when the ping process itself cannot be run.
+pub async fn ping6(netns: &str, target: &str, count: u32, timeout_secs: u32) -> Result<bool> {
+    ping_family(netns, "-6", target, count, timeout_secs).await
+}
+
+/// Ping an IPv4 target from inside a namespace. IPv4 sibling of `ping6`,
+/// used by the dual-stack IS-IS features.
+pub async fn ping4(netns: &str, target: &str, count: u32, timeout_secs: u32) -> Result<bool> {
+    ping_family(netns, "-4", target, count, timeout_secs).await
 }

--- a/bdd/tests/configs/isis_l1_p2p/z1.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z1.yaml
@@ -1,0 +1,44 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+  ipv6:
+    address: 2001:db8:0:ffff::1/128
+- if-name: i2
+  ipv4:
+    address: 10.0.1.1/30
+  ipv6:
+    address: 2001:db8:1::1/64
+- if-name: i6
+  ipv4:
+    address: 10.0.9.1/30
+  ipv6:
+    address: 2001:db8:9::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-1
+    hostname: z1
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i2
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i6
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 40
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/isis_l1_p2p/z10.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z10.yaml
@@ -1,0 +1,44 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.10/32
+  ipv6:
+    address: 2001:db8:0:ffff::10/128
+- if-name: i9
+  ipv4:
+    address: 10.0.8.2/30
+  ipv6:
+    address: 2001:db8:8::2/64
+- if-name: i5
+  ipv4:
+    address: 10.0.13.2/30
+  ipv6:
+    address: 2001:db8:13::2/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0010.00
+    is-type: level-1
+    hostname: z10
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i9
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 20
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i5
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 40
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/isis_l1_p2p/z2.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z2.yaml
@@ -1,0 +1,57 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+  ipv6:
+    address: 2001:db8:0:ffff::2/128
+- if-name: i1
+  ipv4:
+    address: 10.0.1.2/30
+  ipv6:
+    address: 2001:db8:1::2/64
+- if-name: i3
+  ipv4:
+    address: 10.0.2.1/30
+  ipv6:
+    address: 2001:db8:2::1/64
+- if-name: i7
+  ipv4:
+    address: 10.0.10.1/30
+  ipv6:
+    address: 2001:db8:10::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-1
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i1
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i3
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i7
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 30
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/isis_l1_p2p/z3.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z3.yaml
@@ -1,0 +1,57 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+  ipv6:
+    address: 2001:db8:0:ffff::3/128
+- if-name: i2
+  ipv4:
+    address: 10.0.2.2/30
+  ipv6:
+    address: 2001:db8:2::2/64
+- if-name: i4
+  ipv4:
+    address: 10.0.3.1/30
+  ipv6:
+    address: 2001:db8:3::1/64
+- if-name: i8
+  ipv4:
+    address: 10.0.11.1/30
+  ipv6:
+    address: 2001:db8:11::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0003.00
+    is-type: level-1
+    hostname: z3
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i2
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i4
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i8
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 30
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/isis_l1_p2p/z4.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z4.yaml
@@ -1,0 +1,57 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.4/32
+  ipv6:
+    address: 2001:db8:0:ffff::4/128
+- if-name: i3
+  ipv4:
+    address: 10.0.3.2/30
+  ipv6:
+    address: 2001:db8:3::2/64
+- if-name: i5
+  ipv4:
+    address: 10.0.4.1/30
+  ipv6:
+    address: 2001:db8:4::1/64
+- if-name: i9
+  ipv4:
+    address: 10.0.12.1/30
+  ipv6:
+    address: 2001:db8:12::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0004.00
+    is-type: level-1
+    hostname: z4
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i3
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i5
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i9
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 30
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/isis_l1_p2p/z5.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z5.yaml
@@ -1,0 +1,44 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.5/32
+  ipv6:
+    address: 2001:db8:0:ffff::5/128
+- if-name: i4
+  ipv4:
+    address: 10.0.4.2/30
+  ipv6:
+    address: 2001:db8:4::2/64
+- if-name: i10
+  ipv4:
+    address: 10.0.13.1/30
+  ipv6:
+    address: 2001:db8:13::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0005.00
+    is-type: level-1
+    hostname: z5
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i4
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i10
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 40
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/isis_l1_p2p/z6.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z6.yaml
@@ -1,0 +1,44 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.6/32
+  ipv6:
+    address: 2001:db8:0:ffff::6/128
+- if-name: i1
+  ipv4:
+    address: 10.0.9.2/30
+  ipv6:
+    address: 2001:db8:9::2/64
+- if-name: i7
+  ipv4:
+    address: 10.0.5.1/30
+  ipv6:
+    address: 2001:db8:5::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0006.00
+    is-type: level-1
+    hostname: z6
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i1
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 40
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i7
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 20
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/isis_l1_p2p/z7.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z7.yaml
@@ -1,0 +1,57 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.7/32
+  ipv6:
+    address: 2001:db8:0:ffff::7/128
+- if-name: i6
+  ipv4:
+    address: 10.0.5.2/30
+  ipv6:
+    address: 2001:db8:5::2/64
+- if-name: i8
+  ipv4:
+    address: 10.0.6.1/30
+  ipv6:
+    address: 2001:db8:6::1/64
+- if-name: i2
+  ipv4:
+    address: 10.0.10.2/30
+  ipv6:
+    address: 2001:db8:10::2/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0007.00
+    is-type: level-1
+    hostname: z7
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i6
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 20
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i8
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 20
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i2
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 30
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/isis_l1_p2p/z8.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z8.yaml
@@ -1,0 +1,57 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.8/32
+  ipv6:
+    address: 2001:db8:0:ffff::8/128
+- if-name: i7
+  ipv4:
+    address: 10.0.6.2/30
+  ipv6:
+    address: 2001:db8:6::2/64
+- if-name: i9
+  ipv4:
+    address: 10.0.7.1/30
+  ipv6:
+    address: 2001:db8:7::1/64
+- if-name: i3
+  ipv4:
+    address: 10.0.11.2/30
+  ipv6:
+    address: 2001:db8:11::2/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0008.00
+    is-type: level-1
+    hostname: z8
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i7
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 20
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i9
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 20
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i3
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 30
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/isis_l1_p2p/z9.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z9.yaml
@@ -1,0 +1,57 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.9/32
+  ipv6:
+    address: 2001:db8:0:ffff::9/128
+- if-name: i8
+  ipv4:
+    address: 10.0.7.2/30
+  ipv6:
+    address: 2001:db8:7::2/64
+- if-name: i10
+  ipv4:
+    address: 10.0.8.1/30
+  ipv6:
+    address: 2001:db8:8::1/64
+- if-name: i4
+  ipv4:
+    address: 10.0.12.2/30
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0009.00
+    is-type: level-1
+    hostname: z9
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i8
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 20
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i10
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 20
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i4
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 30
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/isis_tilfa/d.yaml
+++ b/bdd/tests/configs/isis_tilfa/d.yaml
@@ -1,0 +1,31 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.8/32
+- if-name: d-n1
+  ipv4:
+    address: 192.168.0.37/30
+- if-name: d-r3
+  ipv4:
+    address: 192.168.0.41/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0008.00
+    hostname: d
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 800
+    - if-name: d-n1
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: d-r3
+      ipv4:
+        enable: true
+      metric: 1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 10.0.0.8

--- a/bdd/tests/configs/isis_tilfa/n1.yaml
+++ b/bdd/tests/configs/isis_tilfa/n1.yaml
@@ -1,0 +1,45 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: n1-s
+  ipv4:
+    address: 192.168.0.2/30
+- if-name: n1-r1
+  ipv4:
+    address: 192.168.0.13/30
+- if-name: n1-r2
+  ipv4:
+    address: 192.168.0.26/30
+- if-name: n1-d
+  ipv4:
+    address: 192.168.0.38/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: n1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 10.0.0.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 200
+    - if-name: n1-s
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: n1-r1
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: n1-r2
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: n1-d
+      ipv4:
+        enable: true
+      metric: 1

--- a/bdd/tests/configs/isis_tilfa/n2.yaml
+++ b/bdd/tests/configs/isis_tilfa/n2.yaml
@@ -1,0 +1,31 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+- if-name: n2-s
+  ipv4:
+    address: 192.168.0.6/30
+- if-name: n2-r1
+  ipv4:
+    address: 192.168.0.17/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: n2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 10.0.0.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 300
+    - if-name: n2-s
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: n2-r1
+      ipv4:
+        enable: true
+      metric: 1

--- a/bdd/tests/configs/isis_tilfa/n3.yaml
+++ b/bdd/tests/configs/isis_tilfa/n3.yaml
@@ -1,0 +1,31 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.4/32
+- if-name: n3-s
+  ipv4:
+    address: 192.168.0.10/30
+- if-name: n3-r1
+  ipv4:
+    address: 192.168.0.21/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0004.00
+    hostname: n3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 400
+    - if-name: n3-s
+      ipv4:
+        enable: true
+      metric: 1000
+    - if-name: n3-r1
+      ipv4:
+        enable: true
+      metric: 1000
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 10.0.0.4

--- a/bdd/tests/configs/isis_tilfa/r1.yaml
+++ b/bdd/tests/configs/isis_tilfa/r1.yaml
@@ -1,0 +1,45 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.5/32
+- if-name: r1-n1
+  ipv4:
+    address: 192.168.0.14/30
+- if-name: r1-n2
+  ipv4:
+    address: 192.168.0.18/30
+- if-name: r1-n3
+  ipv4:
+    address: 192.168.0.22/30
+- if-name: r1-r2
+  ipv4:
+    address: 192.168.0.30/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0005.00
+    hostname: r1
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 500
+    - if-name: r1-n1
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: r1-n2
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: r1-n3
+      ipv4:
+        enable: true
+      metric: 1000
+    - if-name: r1-r2
+      ipv4:
+        enable: true
+      metric: 1000
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 10.0.0.5

--- a/bdd/tests/configs/isis_tilfa/r2.yaml
+++ b/bdd/tests/configs/isis_tilfa/r2.yaml
@@ -1,0 +1,38 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.6/32
+- if-name: r2-n1
+  ipv4:
+    address: 192.168.0.25/30
+- if-name: r2-r1
+  ipv4:
+    address: 192.168.0.29/30
+- if-name: r2-r3
+  ipv4:
+    address: 192.168.0.33/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0006.00
+    hostname: r2
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 600
+    - if-name: r2-n1
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: r2-r1
+      ipv4:
+        enable: true
+      metric: 1000
+    - if-name: r2-r3
+      ipv4:
+        enable: true
+      metric: 1000
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 10.0.0.6

--- a/bdd/tests/configs/isis_tilfa/r3.yaml
+++ b/bdd/tests/configs/isis_tilfa/r3.yaml
@@ -1,0 +1,31 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.7/32
+- if-name: r3-r2
+  ipv4:
+    address: 192.168.0.34/30
+- if-name: r3-d
+  ipv4:
+    address: 192.168.0.42/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0007.00
+    hostname: r3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 700
+    - if-name: r3-r2
+      ipv4:
+        enable: true
+      metric: 1000
+    - if-name: r3-d
+      ipv4:
+        enable: true
+      metric: 1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 10.0.0.7

--- a/bdd/tests/configs/isis_tilfa/s.yaml
+++ b/bdd/tests/configs/isis_tilfa/s.yaml
@@ -1,0 +1,38 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: s-n1
+  ipv4:
+    address: 192.168.0.1/30
+- if-name: s-n2
+  ipv4:
+    address: 192.168.0.5/30
+- if-name: s-n3
+  ipv4:
+    address: 192.168.0.9/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: s
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 100
+    - if-name: s-n1
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: s-n2
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: s-n3
+      ipv4:
+        enable: true
+      metric: 1000
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 10.0.0.1

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -246,9 +246,14 @@ async fn wait_seconds(_world: &mut World, seconds: u64) {
 #[then(expr = "ping from {string} to {string} should succeed")]
 async fn ping_should_succeed(world: &mut World, namespace: String, target: String) {
     let scoped = world.ns(&namespace);
-    let success = netns::ping6(&scoped, &target, 3, 2)
-        .await
-        .expect("ping6 failed to run");
+    // Pick the address family from the target literal so one step covers
+    // both: anything with a ':' is IPv6, otherwise IPv4.
+    let success = if target.contains(':') {
+        netns::ping6(&scoped, &target, 3, 2).await
+    } else {
+        netns::ping4(&scoped, &target, 3, 2).await
+    }
+    .expect("ping failed to run");
     assert!(
         success,
         "ping from {} to {} did not succeed",
@@ -260,9 +265,12 @@ async fn ping_should_succeed(world: &mut World, namespace: String, target: Strin
 #[then(expr = "ping from {string} to {string} should fail")]
 async fn ping_should_fail(world: &mut World, namespace: String, target: String) {
     let scoped = world.ns(&namespace);
-    let success = netns::ping6(&scoped, &target, 1, 1)
-        .await
-        .expect("ping6 failed to run");
+    let success = if target.contains(':') {
+        netns::ping6(&scoped, &target, 1, 1).await
+    } else {
+        netns::ping4(&scoped, &target, 1, 1).await
+    }
+    .expect("ping failed to run");
     assert!(
         !success,
         "ping from {} to {} unexpectedly succeeded",

--- a/bdd/tests/features/isis_l1_p2p.feature
+++ b/bdd/tests/features/isis_l1_p2p.feature
@@ -1,0 +1,156 @@
+@serial
+@isis_l1_p2p
+Feature: IS-IS Level-1-only over an all-point-to-point 10-router ladder
+  As a network operator
+  I want ten zebra-rs instances arranged in a 2x5 "ladder" to form IS-IS
+  Level-1 adjacencies over point-to-point links, flood LSPs in a single
+  area, and install dual-stack (IPv4 + IPv6) routes to every loopback,
+  so that traffic follows the expected primary path, falls back out a
+  different interface when the primary link drops, and load-shares across
+  the two deliberate equal-cost (ECMP) diamonds.
+
+  All links are point-to-point veth pairs (network-type point-to-point);
+  every router is is-type level-1 in area 49.0001. On router zI the
+  interface toward zJ is named "iJ".
+
+  Test Topology:
+  ```
+    z1 --10-- z2 --10-- z3 --10-- z4 --10-- z5     top spine    (metric 10)
+    |         |         |         |         |
+    40        30        30        30        40       rungs (40 ends / 30 mid)
+    |         |         |         |         |
+    z6 --20-- z7 --20-- z8 --20-- z9 --20-- z10    bottom spine (metric 20)
+
+    loopbacks: zI -> 10.0.0.I/32  and  2001:db8:0:ffff::I/128
+  ```
+
+  Asymmetric spines (top 10 != bottom 20) keep the topology
+  primary/backup everywhere except the two end columns, where the rungs
+  are bumped to 40 to create exactly two ECMP diamonds: z2<->z6 and
+  z4<->z10.
+
+  Scenario: Build the L1-only all-P2P ladder and confirm adjacencies form
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I create namespace "z3"
+    And I create namespace "z4"
+    And I create namespace "z5"
+    And I create namespace "z6"
+    And I create namespace "z7"
+    And I create namespace "z8"
+    And I create namespace "z9"
+    And I create namespace "z10"
+    And I connect namespace "z1" interface "i2" to namespace "z2" interface "i1"
+    And I connect namespace "z2" interface "i3" to namespace "z3" interface "i2"
+    And I connect namespace "z3" interface "i4" to namespace "z4" interface "i3"
+    And I connect namespace "z4" interface "i5" to namespace "z5" interface "i4"
+    And I connect namespace "z6" interface "i7" to namespace "z7" interface "i6"
+    And I connect namespace "z7" interface "i8" to namespace "z8" interface "i7"
+    And I connect namespace "z8" interface "i9" to namespace "z9" interface "i8"
+    And I connect namespace "z9" interface "i10" to namespace "z10" interface "i9"
+    And I connect namespace "z1" interface "i6" to namespace "z6" interface "i1"
+    And I connect namespace "z2" interface "i7" to namespace "z7" interface "i2"
+    And I connect namespace "z3" interface "i8" to namespace "z8" interface "i3"
+    And I connect namespace "z4" interface "i9" to namespace "z9" interface "i4"
+    And I connect namespace "z5" interface "i10" to namespace "z10" interface "i5"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I start zebra-rs in namespace "z4"
+    And I start zebra-rs in namespace "z5"
+    And I start zebra-rs in namespace "z6"
+    And I start zebra-rs in namespace "z7"
+    And I start zebra-rs in namespace "z8"
+    And I start zebra-rs in namespace "z9"
+    And I start zebra-rs in namespace "z10"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I apply config "z4.yaml" to namespace "z4"
+    And I apply config "z5.yaml" to namespace "z5"
+    And I apply config "z6.yaml" to namespace "z6"
+    And I apply config "z7.yaml" to namespace "z7"
+    And I apply config "z8.yaml" to namespace "z8"
+    And I apply config "z9.yaml" to namespace "z9"
+    And I apply config "z10.yaml" to namespace "z10"
+    And I wait 35 seconds
+    # Directly-connected reachability over a top-spine and a rung link,
+    # dual-stack, proving the P2P links are up and addressed.
+    Then ping from "z1" to "10.0.1.2" should succeed
+    And ping from "z1" to "2001:db8:1::2" should succeed
+    And ping from "z1" to "10.0.9.2" should succeed
+    And ping from "z6" to "2001:db8:5::2" should succeed
+
+  Scenario: L1 installs reciprocal dual-stack routes to every loopback
+    Given the test topology exists
+    # End-to-end IPv6 forwarding across the full ladder.
+    Then ping from "z1" to "2001:db8:0:ffff::10" should succeed
+    And ping from "z10" to "2001:db8:0:ffff::1" should succeed
+    And ping from "z5" to "2001:db8:0:ffff::6" should succeed
+    # End-to-end IPv4 forwarding across the full ladder.
+    And ping from "z1" to "10.0.0.10" should succeed
+    And ping from "z10" to "10.0.0.1" should succeed
+    And ping from "z5" to "10.0.0.6" should succeed
+    # The far loopbacks are present in z1's IS-IS RIB.
+    And show command "show isis route" in namespace "z1" should contain "10.0.0.5/32"
+    And show command "show isis route" in namespace "z1" should contain "10.0.0.10/32"
+
+  Scenario: Primary path fails over to a different interface (z1 -> z5)
+    Given the test topology exists
+    # Primary z1->z5 is the top spine (cost 40) egressing i2; the only
+    # alternative is the long bottom path (cost 160) egressing i6.
+    Then show command "show isis route" in namespace "z1" should contain "10.0.0.5/32"
+    And ping from "z1" to "10.0.0.5" should succeed
+    When I make namespace "z1" interface "i2" down
+    And I wait 15 seconds
+    # Reconverged onto the backup out the other interface (i6).
+    Then ping from "z1" to "10.0.0.5" should succeed
+    And ping from "z1" to "2001:db8:0:ffff::5" should succeed
+    When I make namespace "z1" interface "i2" up
+    And I wait 25 seconds
+    # Primary restored.
+    Then ping from "z1" to "10.0.0.5" should succeed
+    And ping from "z1" to "2001:db8:0:ffff::5" should succeed
+
+  Scenario: The two deliberate ECMP diamonds resolve (z2->z6 and z4->z10)
+    Given the test topology exists
+    # Left diamond: z2 reaches z6 at cost 50 via i1 (z2-z1-z6) and i7
+    # (z2-z7-z6). Right diamond: z4 reaches z10 via i5 and i9.
+    Then show command "show isis route" in namespace "z2" should contain "10.0.0.6/32"
+    And show command "show isis route" in namespace "z4" should contain "10.0.0.10/32"
+    And ping from "z2" to "10.0.0.6" should succeed
+    And ping from "z2" to "2001:db8:0:ffff::6" should succeed
+    And ping from "z4" to "10.0.0.10" should succeed
+    # Dropping one leg of the left diamond (i1) still leaves z2->z6
+    # reachable over the surviving ECMP leg (i7).
+    When I make namespace "z2" interface "i1" down
+    And I wait 10 seconds
+    Then ping from "z2" to "10.0.0.6" should succeed
+    When I make namespace "z2" interface "i1" up
+    And I wait 20 seconds
+    Then ping from "z2" to "10.0.0.6" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I stop zebra-rs in namespace "z4"
+    And I stop zebra-rs in namespace "z5"
+    And I stop zebra-rs in namespace "z6"
+    And I stop zebra-rs in namespace "z7"
+    And I stop zebra-rs in namespace "z8"
+    And I stop zebra-rs in namespace "z9"
+    And I stop zebra-rs in namespace "z10"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete namespace "z4"
+    And I delete namespace "z5"
+    And I delete namespace "z6"
+    And I delete namespace "z7"
+    And I delete namespace "z8"
+    And I delete namespace "z9"
+    And I delete namespace "z10"
+    Then the test environment should be clean

--- a/bdd/tests/features/isis_l1_p2p.feature
+++ b/bdd/tests/features/isis_l1_p2p.feature
@@ -131,6 +131,17 @@ Feature: IS-IS Level-1-only over an all-point-to-point 10-router ladder
     And I wait 20 seconds
     Then ping from "z2" to "10.0.0.6" should succeed
 
+  Scenario: IS-IS stamps the level into the central RIB
+    Given the test topology exists
+    # The IS-IS task tags each route it installs with the level it was
+    # computed at; the RIB renders that subtype as the "L1" code column
+    # in `show ip route` / `show ipv6 route` (and "level1" in the JSON
+    # subtype field). In this Level-1-only topology every IS-IS route is
+    # Level-1, so the tag must appear in both address families.
+    Then show command "show ip route" in namespace "z1" should contain "L1"
+    And show command "show ipv6 route" in namespace "z1" should contain "L1"
+    And show command "show ip route" in namespace "z10" should contain "L1"
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "z1"

--- a/docs/design/isis-bdd-topology.md
+++ b/docs/design/isis-bdd-topology.md
@@ -1,0 +1,218 @@
+# IS-IS BDD Test Topology
+
+Blueprint for the IS-IS behaviour-driven tests under `bdd/`. One 10-router
+logical graph is reused across a **3 × 3 matrix**: three level modes
+(`level-1-only`, `level-2-only`, `level-1-2 mixed`) × three link media
+(all point-to-point, all LAN/broadcast, mixed). Addressing is **dual-stack**
+(IPv4 + IPv6). This document is the source of truth the per-router config
+YAMLs and `.feature` files are generated from.
+
+## 1. The matrix
+
+|              | all P2P            | all LAN            | mixed P2P+LAN      |
+|--------------|--------------------|--------------------|--------------------|
+| **L1-only**  | `isis_l1_p2p`      | `isis_l1_lan`      | `isis_l1_mixed`    |
+| **L2-only**  | `isis_l2_p2p`      | `isis_l2_lan`      | `isis_l2_mixed`    |
+| **L1L2 mix** | `isis_l1l2_p2p`    | `isis_l1l2_lan`    | `isis_l1l2_mixed`  |
+
+Tags above double as cucumber `@feature_tag`s and the
+`bdd/tests/configs/<tag>/` directory names. The *logical graph, metrics,
+system-IDs and addressing are identical across all nine* — only `network-type`
+(per link medium), `is-type` + per-interface `circuit-type` (per level mode),
+and the NET `area` (mixed mode) change.
+
+## 2. Base graph — the "2 × 5 ladder"
+
+```
+  z1 ──10── z2 ──10── z3 ──10── z4 ──10── z5      top spine    (metric 10)
+  │         │         │         │         │
+  40        30        30        30        40       rungs        (40 ends / 30 mid)
+  │         │         │         │         │
+  z6 ──20── z7 ──20── z8 ──20── z9 ──20── z10     bottom spine (metric 20)
+```
+
+Ten zebra-rs instances, namespaces `z1`…`z10`. Every node has a clean
+**primary** path along its spine and a **backup** out a *different* interface
+via a rung — which is exactly the "primary and backup through a different
+interface" requirement, and gives deterministic interface-down failover.
+
+Asymmetric spine metrics (top 10 ≠ bottom 20) deliberately break the
+diagonal ties that an even ladder would create, so the topology is **almost
+entirely primary/backup** with just **two intentional ECMP diamonds** (§4).
+
+## 3. Nodes, interfaces, addressing (dual-stack)
+
+Interface convention: on `zI`, the link toward `zJ` is named **`iJ`**. The
+router with the smaller index owns host `.1` / `::1` on each link subnet, the
+larger owns `.2` / `::2`.
+
+### Loopbacks (ping targets)
+
+| Node | IPv4 (`lo`)   | IPv6 (`lo`)              | IS-IS system-id   |
+|------|---------------|--------------------------|-------------------|
+| z1   | 10.0.0.1/32   | 2001:db8:0:ffff::1/128   | 0000.0000.0001    |
+| z2   | 10.0.0.2/32   | 2001:db8:0:ffff::2/128   | 0000.0000.0002    |
+| z3   | 10.0.0.3/32   | 2001:db8:0:ffff::3/128   | 0000.0000.0003    |
+| z4   | 10.0.0.4/32   | 2001:db8:0:ffff::4/128   | 0000.0000.0004    |
+| z5   | 10.0.0.5/32   | 2001:db8:0:ffff::5/128   | 0000.0000.0005    |
+| z6   | 10.0.0.6/32   | 2001:db8:0:ffff::6/128   | 0000.0000.0006    |
+| z7   | 10.0.0.7/32   | 2001:db8:0:ffff::7/128   | 0000.0000.0007    |
+| z8   | 10.0.0.8/32   | 2001:db8:0:ffff::8/128   | 0000.0000.0008    |
+| z9   | 10.0.0.9/32   | 2001:db8:0:ffff::9/128   | 0000.0000.0009    |
+| z10  | 10.0.0.10/32  | 2001:db8:0:ffff::10/128  | 0000.0000.0010    |
+
+### Links (13 total)
+
+| # | Endpoints | Role        | Metric | IPv4 /30      | IPv6 /64          |
+|---|-----------|-------------|:------:|---------------|-------------------|
+| L1  | z1–z2   | top spine   | 10 | 10.0.1.0/30  | 2001:db8:1::/64  |
+| L2  | z2–z3   | top spine   | 10 | 10.0.2.0/30  | 2001:db8:2::/64  |
+| L3  | z3–z4   | top spine   | 10 | 10.0.3.0/30  | 2001:db8:3::/64  |
+| L4  | z4–z5   | top spine   | 10 | 10.0.4.0/30  | 2001:db8:4::/64  |
+| L5  | z6–z7   | bottom spine| 20 | 10.0.5.0/30  | 2001:db8:5::/64  |
+| L6  | z7–z8   | bottom spine| 20 | 10.0.6.0/30  | 2001:db8:6::/64  |
+| L7  | z8–z9   | bottom spine| 20 | 10.0.7.0/30  | 2001:db8:7::/64  |
+| L8  | z9–z10  | bottom spine| 20 | 10.0.8.0/30  | 2001:db8:8::/64  |
+| L9  | z1–z6   | **end rung**| 40 | 10.0.9.0/30  | 2001:db8:9::/64  |
+| L10 | z2–z7   | mid rung    | 30 | 10.0.10.0/30 | 2001:db8:10::/64 |
+| L11 | z3–z8   | mid rung    | 30 | 10.0.11.0/30 | 2001:db8:11::/64 |
+| L12 | z4–z9   | mid rung    | 30 | 10.0.12.0/30 | 2001:db8:12::/64 |
+| L13 | z5–z10  | **end rung**| 40 | 10.0.13.0/30 | 2001:db8:13::/64 |
+
+### Per-node interface list
+
+| Node | Interfaces (name → link)                           |
+|------|----------------------------------------------------|
+| z1   | i2→L1, i6→L9                                        |
+| z2   | i1→L1, i3→L2, i7→L10                                |
+| z3   | i2→L2, i4→L3, i8→L11                                |
+| z4   | i3→L3, i5→L4, i9→L12                                |
+| z5   | i4→L4, i10→L13                                      |
+| z6   | i1→L9, i7→L5                                        |
+| z7   | i6→L5, i8→L6, i2→L10                                |
+| z8   | i7→L6, i9→L7, i3→L11                                |
+| z9   | i8→L7, i10→L8, i4→L12                               |
+| z10  | i9→L8, i5→L13                                       |
+
+## 4. Metric plan & the two ECMP diamonds
+
+Base metrics: top spine **10**, bottom spine **20**, mid rungs **30**, **end
+rungs 40**. With this scheme there is *no* ECMP anywhere — every destination
+resolves to a single primary plus a strictly costlier backup.
+
+The two **end rungs are set to 40** (vs 30 mid) specifically to re-introduce
+**exactly two ECMP diamonds**, one at each end of the ladder:
+
+**Left diamond — z2 ↔ z6** (`{1,2,6,7}` square):
+- `z2 → z6`: via `i1` (z2-z1-z6 = 10+40 = 50) **==** via `i7` (z2-z7-z6 = 30+20 = 50) → ECMP `{i1, i7}`.
+- `z6 → z2`: via `i1` (z6-z1-z2 = 40+10 = 50) **==** via `i7` (z6-z7-z2 = 20+30 = 50) → ECMP `{i1, i7}`.
+
+**Right diamond — z4 ↔ z10** (`{4,5,9,10}` square):
+- `z4 → z10`: via `i5` (z4-z5-z10 = 10+40 = 50) **==** via `i9` (z4-z9-z10 = 30+20 = 50) → ECMP `{i5, i9}`.
+- `z10 → z4`: via `i5` (z10-z5-z4 = 40+10 = 50) **==** via `i9` (z10-z9-z4 = 20+30 = 50) → ECMP `{i5, i9}`.
+
+These are the **only** ties in the flat (L1-only / L2-only) topologies — all
+other diagonal candidates are eliminated by `top(10) ≠ bottom(20)`, and the
+ties are localized: e.g. `z3 → z6` installs a single next-hop (`i2`) and the
+ECMP only appears once traffic reaches z2. "Mixed metric" requirement is met
+by the four tiers (10/20/30/40).
+
+## 5. Expected forwarding (flat topologies)
+
+Representative assertions (destination = peer loopback):
+
+| From | To  | Primary (cost / iface) | Backup after primary iface down (cost / iface) |
+|------|-----|------------------------|------------------------------------------------|
+| z1   | z3  | 20 / `i2`              | 100 / `i6`                                     |
+| z1   | z5  | 40 / `i2`              | 120 / `i6`                                     |
+| z6   | z10 | 80 / `i7`              | 120 / `i1`                                     |
+| z3   | z8  | 30 / `i8` (rung)       | 60 / `{i2, i4}`                                |
+| z2   | z6  | **ECMP 50 / `{i1,i7}`**| n/a (dual next-hop)                            |
+| z4   | z10 | **ECMP 50 / `{i5,i9}`**| n/a (dual next-hop)                            |
+
+Costs above are from a Dijkstra over the actual link metrics. Backups are
+much costlier than primaries (a downed primary climbs back to the cheap top
+spine via the nearest rung), so the primary is unambiguously preferred and an
+interface-down event produces a clear, testable reconvergence onto a
+*different* egress interface. (`z3 → z8`'s backup is itself a 60-cost ECMP
+pair `{i2, i4}` — harmless, just noted for accuracy.)
+
+## 6. Level / area assignment per mode
+
+System-ids (§3) are constant across modes. Only NET `area`, `is-type`, and
+per-interface `circuit-type` change.
+
+- **L1-only**: single area **49.0001**; every node `is-type level-1`; every
+  interface `circuit-type level-1`. NET = `49.0001.0000.0000.000I.00`.
+- **L2-only**: single area **49.0001**; every node `is-type level-2-only`;
+  every interface `circuit-type level-2-only`. (Matches the existing
+  `isis_ipv6` feature.)
+- **L1L2 mixed**: two L1 areas joined by an L2 backbone.
+
+  | Node      | Area    | is-type        | Per-interface circuit-type            |
+  |-----------|---------|----------------|---------------------------------------|
+  | z1        | 49.0001 | level-1        | i2,i6 = level-1                       |
+  | z6        | 49.0001 | level-1        | i1,i7 = level-1                       |
+  | z2        | 49.0001 | level-1-2      | i1,i7 = level-1; i3 = level-2-only    |
+  | z7        | 49.0001 | level-1-2      | i6,i2 = level-1; i8 = level-2-only    |
+  | z3        | 49.0000 | level-2-only   | i2,i4,i8 = level-2-only               |
+  | z8        | 49.0000 | level-2-only   | i7,i9,i3 = level-2-only               |
+  | z4        | 49.0002 | level-1-2      | i3 = level-2-only; i5,i9 = level-1    |
+  | z9        | 49.0002 | level-1-2      | i8 = level-2-only; i10,i4 = level-1   |
+  | z5        | 49.0002 | level-1        | i4,i10 = level-1                      |
+  | z10       | 49.0002 | level-1        | i9,i5 = level-1                       |
+
+  - L1 area **0001** = {z1,z2,z6,z7} (intra links L1, L5, L9, L10).
+  - L1 area **0002** = {z4,z5,z9,z10} (intra links L4, L8, L12, L13).
+  - L2 backbone = {z2,z7,z3,z8,z4,z9} (links L2, L6, L3, L7, **L11** the
+    z3-z8 rung bridges top/bottom → contiguous backbone).
+  - z2/z7 (area 0001) and z4/z9 (area 0002) are the L1L2 border routers;
+    z3/z8 are pure backbone. L1 routers reach remote areas via the
+    nearest-L1L2 default route (ATT bit). The detailed inter-area path table
+    is computed at config-generation time since it follows L1 default-route
+    semantics rather than the flat SPF above.
+
+## 7. Link-medium realization per variant
+
+The logical adjacency graph is identical; only the L2 medium + IS-IS
+`network-type` differ.
+
+- **all P2P**: each of the 13 links is a direct veth pair
+  (`connect_netns_pair`), `network-type point-to-point`. **No new harness
+  step needed.**
+- **all LAN**: each link is its own 2-router bridge, `network-type lan`
+  (DIS elected + pseudonode LSP per segment).
+- **mixed**: spines (L1–L8) stay P2P; rungs (L9–L13) become LAN. (Or another
+  split — TBD; documented so assertions stay deterministic.)
+
+### Harness work this requires (tracked, not yet built)
+
+1. **New step — attach a named interface to a bridge.** Current bridge steps
+   bind exactly one veth per namespace (`v{ns}ns`); a 10-router LAN/mixed
+   topology needs `I connect namespace "zI" interface "iJ" to bridge "brX"`.
+2. ~~**New step — IPv4 ping.**~~ **DONE** (`isis_l1_p2p` slice). `ping6`/`ping4`
+   now share a `ping_family` helper in `bdd/src/netns.rs`, and the existing
+   `ping from "zI" to "<addr>" should succeed/fail` steps pick the family from
+   the target literal (`:` → IPv6, else IPv4), so one step covers dual-stack.
+3. **Generalize `the test topology exists`.** It is hard-coded to z1/z2;
+   z1/z2 still exist here so it passes, but it should check the routers a
+   scenario actually uses (or scenarios stay self-contained).
+4. IPv4 / route-table assertions can reuse the existing generic
+   `show command "..." in namespace "zI" should contain "..."` step.
+
+## 8. Open decisions
+
+- **LAN segment depth.** Baseline keeps every link a 2-router broadcast
+  segment so the graph (and therefore the §4/§5 path analysis) is *identical*
+  across all nine realizations. A 2-router segment still exercises DIS
+  election + pseudonode LSPs but not "a third router learning the segment via
+  the DIS." Promoting one or two segments to genuine ≥3-router LANs would
+  deepen DIS coverage but adds adjacencies not present in the P2P graph and
+  forks the path analysis for those variants. **Recommendation: keep 2-router
+  segments for parity; add a dedicated 3-router-LAN scenario later if deeper
+  DIS coverage is wanted.**
+- **Mixed-variant link split.** Spines-P2P / rungs-LAN (above) vs odd/even vs
+  per-row. Pick the one that best exercises a P2P↔LAN boundary on the same
+  router.
+- **Build order.** First slice = `isis_l1_p2p` (no harness change); then the
+  LAN harness step unlocks the rest of the matrix.

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -12,7 +12,7 @@ use super::level::Levels;
 use super::throttle::Throttle;
 use crate::context::Timer;
 use crate::rib::inst::{IlmEntry, IlmType};
-use crate::rib::{self, Nexthop, NexthopMulti, NexthopUni, RibType};
+use crate::rib::{self, Nexthop, NexthopMulti, NexthopUni, RibSubType, RibType};
 use crate::spf;
 // EncapType is only used by `make_rib_entry_v6` test fixture below;
 // production code paths route through `tilfa::build_repair_path_srv6`.
@@ -173,8 +173,18 @@ fn nhop_to_nexthop_uni(
     nhop
 }
 
-fn make_rib_entry(route: &SpfRoute) -> rib::entry::RibEntry {
+/// Map the IS-IS level a route was computed at onto the RIB subtype the
+/// `show ip route` / `show ipv6 route` renderers display as `L1` / `L2`.
+fn level_subtype(level: Level) -> RibSubType {
+    match level {
+        Level::L1 => RibSubType::IsisLevel1,
+        Level::L2 => RibSubType::IsisLevel2,
+    }
+}
+
+fn make_rib_entry(route: &SpfRoute, level: Level) -> rib::entry::RibEntry {
     let mut rib = rib::entry::RibEntry::new(RibType::Isis);
+    rib.rsubtype = level_subtype(level);
     rib.distance = 115;
     rib.metric = route.metric;
     // Flatten primaries and (when present) their TI-LFA repair backups
@@ -358,11 +368,11 @@ pub fn diff_apply_flex_algo(
     }
 }
 
-pub fn diff_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffResult) {
+pub fn diff_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffResult, level: Level) {
     // Delete.
     for (prefix, route) in diff.only_curr.iter() {
         if !route.nhops.is_empty() {
-            let rib = make_rib_entry(route);
+            let rib = make_rib_entry(route, level);
             let msg = rib::Message::Ipv4Del {
                 prefix: *prefix,
                 rib,
@@ -373,7 +383,7 @@ pub fn diff_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffResult)
     // Add (changed).
     for (prefix, _, route) in diff.different.iter() {
         if !route.nhops.is_empty() {
-            let rib = make_rib_entry(route);
+            let rib = make_rib_entry(route, level);
             let msg = rib::Message::Ipv4Add {
                 prefix: *prefix,
                 rib,
@@ -384,7 +394,7 @@ pub fn diff_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffResult)
     // Add (new).
     for (prefix, route) in diff.only_next.iter() {
         if !route.nhops.is_empty() {
-            let rib = make_rib_entry(route);
+            let rib = make_rib_entry(route, level);
             let msg = rib::Message::Ipv4Add {
                 prefix: *prefix,
                 rib,
@@ -416,8 +426,9 @@ fn nhop_to_nexthop_uni_v6(
     nhop
 }
 
-fn make_rib_entry_v6(route: &SpfRouteV6) -> rib::entry::RibEntry {
+fn make_rib_entry_v6(route: &SpfRouteV6, level: Level) -> rib::entry::RibEntry {
     let mut rib = rib::entry::RibEntry::new(RibType::Isis);
+    rib.rsubtype = level_subtype(level);
     rib.distance = 115;
     rib.metric = route.metric;
     let offset_metric = route.metric.saturating_add(BACKUP_METRIC_OFFSET);
@@ -450,10 +461,14 @@ fn backup_to_nexthop_uni_v6(backup: &RepairPathSrv6, metric: u32) -> rib::Nextho
     nhop
 }
 
-pub fn diff_apply_v6(rib_client: &crate::rib::client::RibClient, diff: &DiffResultV6) {
+pub fn diff_apply_v6(
+    rib_client: &crate::rib::client::RibClient,
+    diff: &DiffResultV6,
+    level: Level,
+) {
     for (prefix, route) in diff.only_curr.iter() {
         if !route.nhops.is_empty() {
-            let rib = make_rib_entry_v6(route);
+            let rib = make_rib_entry_v6(route, level);
             let msg = rib::Message::Ipv6Del {
                 prefix: *prefix,
                 rib,
@@ -463,7 +478,7 @@ pub fn diff_apply_v6(rib_client: &crate::rib::client::RibClient, diff: &DiffResu
     }
     for (prefix, _, route) in diff.different.iter() {
         if !route.nhops.is_empty() {
-            let rib = make_rib_entry_v6(route);
+            let rib = make_rib_entry_v6(route, level);
             let msg = rib::Message::Ipv6Add {
                 prefix: *prefix,
                 rib,
@@ -473,7 +488,7 @@ pub fn diff_apply_v6(rib_client: &crate::rib::client::RibClient, diff: &DiffResu
     }
     for (prefix, route) in diff.only_next.iter() {
         if !route.nhops.is_empty() {
-            let rib = make_rib_entry_v6(route);
+            let rib = make_rib_entry_v6(route, level);
             let msg = rib::Message::Ipv6Add {
                 prefix: *prefix,
                 rib,
@@ -1060,14 +1075,14 @@ fn apply_routing_updates(
     // Update IPv4 RIB
     if top.config.distribute.rib {
         let diff = spf::table_diff(top.rib.get(&level).iter(), rib.iter());
-        diff_apply(top.rib_client, &diff);
+        diff_apply(top.rib_client, &diff, level);
     }
     *top.rib.get_mut(&level) = rib;
 
     // Update IPv6 RIB
     if top.config.distribute.rib {
         let diff = spf::table_diff(top.rib_v6.get(&level).iter(), rib_v6.iter());
-        diff_apply_v6(top.rib_client, &diff);
+        diff_apply_v6(top.rib_client, &diff, level);
     }
     *top.rib_v6.get_mut(&level) = rib_v6;
 }
@@ -1868,7 +1883,7 @@ mod tests {
             dest_vertex: None,
             backup_as_primary: false,
         };
-        let entry = make_rib_entry(&route);
+        let entry = make_rib_entry(&route, Level::L2);
         assert!(matches!(entry.nexthop, rib::Nexthop::Uni(_)));
     }
 
@@ -1902,7 +1917,7 @@ mod tests {
             dest_vertex: None,
             backup_as_primary: false,
         };
-        let entry = make_rib_entry(&route);
+        let entry = make_rib_entry(&route, Level::L2);
 
         let rib::Nexthop::List(list) = &entry.nexthop else {
             panic!("expected List, got {:?}", entry.nexthop);
@@ -1953,7 +1968,7 @@ mod tests {
             dest_vertex: None,
             backup_as_primary: true,
         };
-        let entry = make_rib_entry(&route);
+        let entry = make_rib_entry(&route, Level::L2);
 
         let rib::Nexthop::List(list) = &entry.nexthop else {
             panic!("expected List, got {:?}", entry.nexthop);
@@ -2044,7 +2059,7 @@ mod tests {
             dest_vertex: None,
             backup_as_primary: false,
         };
-        let entry = make_rib_entry_v6(&route);
+        let entry = make_rib_entry_v6(&route, Level::L1);
 
         let rib::Nexthop::List(list) = &entry.nexthop else {
             panic!("expected List, got {:?}", entry.nexthop);
@@ -2057,5 +2072,53 @@ mod tests {
         assert_eq!(b.segs, vec![end_sid, endx_sid]);
         assert_eq!(b.encap_type, Some(EncapType::HEncap));
         assert!(b.mpls.is_empty());
+    }
+
+    #[test]
+    fn make_rib_entry_stamps_isis_level_subtype() {
+        // The level a route was computed at is mirrored into the RIB
+        // subtype so `show ip route` can tag the entry L1 / L2.
+        assert_eq!(level_subtype(Level::L1), RibSubType::IsisLevel1);
+        assert_eq!(level_subtype(Level::L2), RibSubType::IsisLevel2);
+
+        let route = spf_route(20, None, &[("10.0.0.1", 10)]);
+        assert_eq!(
+            make_rib_entry(&route, Level::L1).rsubtype,
+            RibSubType::IsisLevel1
+        );
+        assert_eq!(
+            make_rib_entry(&route, Level::L2).rsubtype,
+            RibSubType::IsisLevel2
+        );
+    }
+
+    #[test]
+    fn make_rib_entry_v6_stamps_isis_level_subtype() {
+        let mut nhops = BTreeMap::new();
+        nhops.insert(
+            "fe80::a:2".parse().unwrap(),
+            SpfNexthopV6 {
+                ifindex: 10,
+                adjacency: true,
+                sys_id: None,
+                backup: None,
+            },
+        );
+        let route = SpfRouteV6 {
+            metric: 20,
+            nhops,
+            sid: None,
+            prefix_sid: None,
+            dest_vertex: None,
+            backup_as_primary: false,
+        };
+        assert_eq!(
+            make_rib_entry_v6(&route, Level::L1).rsubtype,
+            RibSubType::IsisLevel1
+        );
+        assert_eq!(
+            make_rib_entry_v6(&route, Level::L2).rsubtype,
+            RibSubType::IsisLevel2
+        );
     }
 }

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -372,20 +372,10 @@ fn rib_entry_to_json_v6(rib: &Rib, prefix: &Ipv6Net, e: &RibEntry) -> RouteEntry
     }
 }
 
-// Rendering.
-
-static SHOW_IPV4_HEADER: &str = r#"Codes: K - kernel, C - connected, S - static, R - RIP, B - BGP
+static SHOW_HEADER: &str = r#"Codes: K - kernel, D - DHCP route, C - connected, S - static
        O - OSPF, IA - OSPF inter area, N1/N2 - OSPF NSSA external type 1/2
-       E1/E2 - OSPF external type 1/2 D - DHCP route
-       i - IS-IS, L1/L2 - IS-IS level-1/2, ia - IS-IS inter area
-       > - selected route, * - FIB route, S - Stale route
-
-"#;
-
-static SHOW_IPV6_HEADER: &str = r#"Codes: K - kernel, C - connected, S - static, R - RIP, B - BGP
-       O - OSPF, IA - OSPF inter area, N1/N2 - OSPF NSSA external type 1/2
-       E1/E2 - OSPF external type 1/2 D - DHCP route
-       i - IS-IS, L1/L2 - IS-IS level-1/2, ia - IS-IS inter area
+       E1/E2 - OSPF external type 1/2
+       L1/L2 - IS-IS level-1/2, ia - IS-IS inter area, B - BGP
        > - selected route, * - FIB route, S - Stale route
 
 "#;
@@ -1036,7 +1026,7 @@ pub fn rib_show(rib: &Rib, _args: Args, json: bool) -> String {
             .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize routes: {}\"}}", e))
     } else {
         let mut buf = String::new();
-        buf.push_str(SHOW_IPV4_HEADER);
+        buf.push_str(SHOW_HEADER);
 
         for (prefix, entries) in rib.table.iter() {
             for entry in entries.iter() {
@@ -1110,7 +1100,7 @@ fn rib_show_one(rib: &Rib, prefix: &Ipv4Net, json: bool, detail: bool) -> String
             buf.push_str(&rib_entry_show_detail(rib, prefix, entry));
         }
     } else {
-        buf.push_str(SHOW_IPV4_HEADER);
+        buf.push_str(SHOW_HEADER);
         for entry in entries.iter() {
             let _ = write!(buf, "{}", rib_entry_show(rib, prefix, entry, json).unwrap());
         }
@@ -1185,7 +1175,7 @@ fn rib_vrf_render(rib: &Rib, name: Option<String>, json: bool, detail: bool) -> 
                 }
             }
         } else {
-            buf.push_str(SHOW_IPV4_HEADER);
+            buf.push_str(SHOW_HEADER);
             for (prefix, entries) in tables.table.iter() {
                 for entry in entries.iter() {
                     write!(
@@ -1237,7 +1227,7 @@ fn rib6_vrf_render(rib: &Rib, name: Option<String>, json: bool, detail: bool) ->
                 }
             }
         } else {
-            buf.push_str(SHOW_IPV6_HEADER);
+            buf.push_str(SHOW_HEADER);
             for (prefix, entries) in tables.table_v6.iter() {
                 for entry in entries.iter() {
                     write!(
@@ -1288,7 +1278,7 @@ pub fn rib6_show(rib: &Rib, _args: Args, json: bool) -> String {
             .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize routes: {}\"}}", e))
     } else {
         let mut buf = String::new();
-        buf.push_str(SHOW_IPV6_HEADER);
+        buf.push_str(SHOW_HEADER);
 
         for (prefix, entries) in rib.table_v6.iter() {
             for entry in entries.iter() {
@@ -1359,7 +1349,7 @@ fn rib6_show_one(rib: &Rib, prefix: &Ipv6Net, json: bool, detail: bool) -> Strin
             buf.push_str(&rib_entry_show_v6_detail(rib, prefix, entry));
         }
     } else {
-        buf.push_str(SHOW_IPV6_HEADER);
+        buf.push_str(SHOW_HEADER);
         for entry in entries.iter() {
             let _ = write!(
                 buf,

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -123,7 +123,7 @@ pub struct RouteTable {
 // Helper function to convert RibEntry to JSON format
 fn rib_entry_to_json(rib: &Rib, prefix: &Ipv4Net, e: &RibEntry) -> RouteEntry {
     let protocol = format!("{:?}", e.rtype).to_lowercase();
-    let subtype = format!("{:?}", e.rsubtype).to_lowercase();
+    let subtype = e.rsubtype.name();
 
     let nexthops = match &e.nexthop {
         Nexthop::Link(ifindex) => {
@@ -249,7 +249,7 @@ fn rib_entry_to_json(rib: &Rib, prefix: &Ipv4Net, e: &RibEntry) -> RouteEntry {
 // Helper function to convert IPv6 RibEntry to JSON format
 fn rib_entry_to_json_v6(rib: &Rib, prefix: &Ipv6Net, e: &RibEntry) -> RouteEntry {
     let protocol = format!("{:?}", e.rtype).to_lowercase();
-    let subtype = format!("{:?}", e.rsubtype).to_lowercase();
+    let subtype = e.rsubtype.name();
 
     let nexthops = match &e.nexthop {
         Nexthop::Link(ifindex) => {
@@ -2172,5 +2172,15 @@ mod tests {
         // omits the `type ...` trailer.
         assert_eq!(subtype_long_name(&RibSubType::Default), None);
         assert_eq!(subtype_long_name(&RibSubType::Other(99)), None);
+    }
+
+    #[test]
+    fn json_subtype_name_drops_isis_prefix() {
+        use super::super::types::RibSubType;
+        // IS-IS levels render bare in the JSON `subtype` field.
+        assert_eq!(RibSubType::IsisLevel1.name(), "level1");
+        assert_eq!(RibSubType::IsisLevel2.name(), "level2");
+        // Other variants keep their lowercased debug name.
+        assert_eq!(RibSubType::Default.name(), "default");
     }
 }

--- a/zebra-rs/src/rib/types.rs
+++ b/zebra-rs/src/rib/types.rs
@@ -145,6 +145,19 @@ impl RibSubType {
             Self::Other(_) => "".to_string(),
         }
     }
+
+    /// Machine-readable name for the JSON `subtype` field. The protocol
+    /// prefix is dropped — the sibling `protocol` field already carries
+    /// it — so IS-IS levels render bare as "level1" / "level2". Other
+    /// variants keep their lowercased debug name unchanged.
+    pub fn name(&self) -> String {
+        match self {
+            Self::IsisLevel1 => "level1".to_string(),
+            Self::IsisLevel2 => "level2".to_string(),
+            Self::IsisIntraArea => "intra-area".to_string(),
+            other => format!("{other:?}").to_lowercase(),
+        }
+    }
 }
 
 // ---- redistribute messaging types ------------------------------------


### PR DESCRIPTION
## Summary

First slice of the IS-IS BDD verification matrix, plus the daemon change it surfaced.

- **BDD: IS-IS Level-1-only, all-P2P, 10-router ladder** (`isis_l1_p2p`) — dual-stack (IPv4+IPv6) 2×5 ladder, area `49.0001`, `network-type point-to-point`, mixed metrics yielding exactly two ECMP diamonds (z2↔z6, z4↔z10, Dijkstra-verified). Scenarios: adjacency, reciprocal dual-stack loopback reachability, primary→backup failover out a different interface, ECMP diamonds, RIB level tag, teardown.
- **Harness**: `ping_family`/`ping4` so the `ping from … to …` step auto-selects address family from the target (dual-stack); `make isis_l1_p2p` target.
- **TI-LFA configs** (`isis_tilfa/`) staged for the next BDD item.
- **Daemon — IS-IS level → RIB subtype**: `make_rib_entry{,_v6}` now stamp `RibSubType::IsisLevel1/IsisLevel2`, so `show ip route`/`show ipv6 route` tag IS-IS routes `L1`/`L2`. `RibSubType::name()` drops the protocol prefix so the JSON `subtype` reads `level1`/`level2`.
- **`show ip route` legend**: consolidated the IPv4/IPv6 Codes headers into one and dropped `R - RIP` (unsupported).
- **Design doc** `docs/design/isis-bdd-topology.md` — blueprint for the full 3×3 matrix.

## Test plan

- `cargo build -p zebra-rs`, `cargo clippy -p zebra-rs --all-targets`, `cargo fmt --check` — clean.
- `cargo test -p zebra-rs` — new unit tests cover v4/v6 level stamping and the `name()` rename.
- `cargo test -p bdd --no-run` — cucumber harness compiles.
- Manual: `cd bdd && make isis_l1_p2p` (root + netns) — adjacency, dual-stack reachability, failover, ECMP, and `L1` tag in `show ip route` all pass.

Generated with [Claude Code](https://claude.com/claude-code)