### PR TITLE
isis: install self-originated Prefix-SID into the MPLS ILM

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -135,6 +135,10 @@ impl Isis {
         self.callback_add("/router/isis/lsp-mtu-size", config_lsp_mtu_size);
         self.callback_add("/router/isis/te-router-id", config_te_router_id);
         self.callback_add("/router/isis/segment-routing/mpls", config_sr_mpls_enable);
+        self.callback_add(
+            "/router/isis/segment-routing/mpls/local-prefix-sid",
+            config_sr_local_prefix_sid,
+        );
         self.callback_add("/router/isis/segment-routing/srv6", config_sr_srv6_enable);
         self.callback_add(
             "/router/isis/segment-routing/srv6/locator",
@@ -435,6 +439,14 @@ pub struct IsisConfig {
     /// "default" block under /segment-routing/block.
     pub sr_mpls_enabled: bool,
 
+    /// Install the local (self-originated) Prefix-SID label into the
+    /// MPLS LFIB as a pop entry (`/router/isis/segment-routing/mpls/
+    /// local-prefix-sid`). Default true — matches IOS-XR / SR-OS, which
+    /// always program the local node-SID label. When false, only remote
+    /// prefix-SIDs and adjacency-SIDs are installed. Only takes effect
+    /// while `sr_mpls_enabled` is set.
+    pub sr_local_prefix_sid: bool,
+
     /// Set when /router/isis/segment-routing/srv6 is committed.
     pub sr_srv6_enabled: bool,
 
@@ -704,6 +716,7 @@ impl Default for IsisConfig {
             enable: Default::default(),
             distribute: Default::default(),
             sr_mpls_enabled: Default::default(),
+            sr_local_prefix_sid: true,
             sr_srv6_enabled: Default::default(),
             sr_srv6_locator: Default::default(),
             sr_srv6_flex_algo_locators: Default::default(),
@@ -1140,6 +1153,17 @@ fn config_sr_mpls_enable(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<(
     // reconcile here drops the pool immediately.
     isis.reconcile_block_watch();
     isis.reconcile_local_pool();
+    Some(())
+}
+
+/// `/router/isis/segment-routing/mpls/local-prefix-sid`. Toggles
+/// installation of the local (self-originated) Prefix-SID label into
+/// the MPLS LFIB. Default true. The install itself is recomputed on the
+/// next SPF publish (`update_self_sid_ilm`), which a config commit
+/// already schedules, so no explicit reconcile is needed here.
+fn config_sr_local_prefix_sid(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let value = if op.is_set() { args.boolean()? } else { true };
+    isis.config.sr_local_prefix_sid = value;
     Some(())
 }
 

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -39,7 +39,10 @@ use super::lsp::{
     target_locator_name,
 };
 use super::nfsm::nbr_hold_timer_expire;
-use super::rib::{SpfIlm, SpfRoute, SpfRouteV6, apply_spf_result, build_spf_input, compute_spf};
+use super::rib::{
+    SpfIlm, SpfRoute, SpfRouteV6, apply_spf_result, build_spf_input, compute_spf,
+    update_self_sid_ilm,
+};
 use super::srlg::{SrlgGroup, SrlgGroupBuilder};
 use super::srmpls::IsisLabelMap;
 use super::throttle::Throttle;
@@ -239,6 +242,13 @@ pub struct Isis {
     pub rib: Levels<PrefixMap<Ipv4Net, SpfRoute>>,
     pub rib_v6: Levels<PrefixMap<Ipv6Net, SpfRouteV6>>,
     pub ilm: Levels<BTreeMap<u32, SpfIlm>>,
+    /// Currently-installed local (self-originated) Prefix-SID ILM
+    /// entries, keyed by MPLS label. Level-independent (the label is
+    /// derived from interface config + the global SR block, not per-
+    /// level SPF), so this is a single map rather than `Levels<_>`.
+    /// `rib::update_self_sid_ilm` diffs the desired set against this
+    /// after each SPF publish and reconciles the kernel LFIB.
+    pub self_sid_ilm: BTreeMap<u32, SpfIlm>,
     pub hostname: Levels<Hostname>,
     pub spf_timer: Levels<Option<Timer>>,
     pub spf_throttle: Levels<Throttle>,
@@ -653,6 +663,7 @@ impl Isis {
                 rib: Levels::<PrefixMap<Ipv4Net, SpfRoute>>::default(),
                 rib_v6: Levels::<PrefixMap<Ipv6Net, SpfRouteV6>>::default(),
                 ilm: Levels::<BTreeMap<u32, SpfIlm>>::default(),
+                self_sid_ilm: BTreeMap::new(),
                 hostname: Levels::<Hostname>::default(),
                 spf_timer: Levels::<Option<Timer>>::default(),
                 spf_throttle: Levels::<Throttle>::default(),
@@ -733,6 +744,14 @@ impl Isis {
         if msg.op == ConfigOp::CommitEnd {
             self.vrf_commit_end();
             self.commit_srlg();
+            // Reconcile the local Prefix-SID ILM against the just-committed
+            // config. This is what withdraws the pop entry when
+            // `prefix-sid` / `segment-routing mpls` / `local-prefix-sid`
+            // is removed — those handlers only mutate config state and
+            // don't schedule SPF, so the `SpfDone` reconcile alone would
+            // never see the deletion. Idempotent: a no-op when nothing
+            // self-SID-relevant changed.
+            update_self_sid_ilm(self);
             return;
         }
         if msg.op == ConfigOp::CommitStart {
@@ -1565,6 +1584,11 @@ impl Isis {
                 if std::mem::take(top.spf_pending.get_mut(&level)) {
                     let _ = self.tx.send(Message::SpfCalc(level));
                 }
+                // Reconcile the local (self-originated) Prefix-SID ILM.
+                // Level-independent (config + global SR block, not SPF),
+                // so done once here after `top`'s borrow ends rather than
+                // in the per-level apply path; idempotent across L1/L2.
+                update_self_sid_ilm(self);
                 // The LSDB is settled after SPF — push the BGP-LS producer's
                 // delta to BGP (RFC 9552). `top` is no longer used, so its
                 // mutable borrow of `self` has ended (NLL) and the disjoint

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -12,6 +12,7 @@ use super::level::Levels;
 use super::throttle::Throttle;
 use crate::context::Timer;
 use crate::rib::inst::{IlmEntry, IlmType};
+use crate::rib::link_ext::LinkFlagsExt;
 use crate::rib::{self, Nexthop, NexthopMulti, NexthopUni, RibSubType, RibType};
 use crate::spf;
 // EncapType is only used by `make_rib_entry_v6` test fixture below;
@@ -22,7 +23,7 @@ use isis_packet::srv6::EncapType;
 use super::config::MtId;
 use super::flex_algo::FlexAlgoEntry;
 use super::graph::{LspMap, graph, graph_flex_algo, graph_mt2};
-use super::inst::{IsisTop, Message};
+use super::inst::{Isis, IsisTop, Message};
 use super::level::Level;
 use super::link::{Afi, LinkTop};
 use super::lsdb::Lsdb;
@@ -1576,6 +1577,92 @@ fn build_rib_from_flex_algo(
     rib
 }
 
+/// Resolve a configured Prefix-SID value to `(label, index)` against
+/// our own SRGB. Index SIDs need the SRGB snapshot (return `None`
+/// without it); absolute-label SIDs resolve directly and derive the
+/// index for `IlmType::Node` / show output.
+fn resolve_self_sid(
+    sid: &SidLabelValue,
+    srgb: Option<&crate::spf::label_block::LabelBlock>,
+) -> Option<(u32, u32)> {
+    match sid {
+        SidLabelValue::Index(index) => srgb.map(|b| (b.start + index, *index)),
+        SidLabelValue::Label(label) => {
+            let index = srgb.map(|b| label.saturating_sub(b.start)).unwrap_or(0);
+            Some((*label, index))
+        }
+    }
+}
+
+/// Reconcile the local (self-originated) Prefix-SID ILM entries against
+/// the kernel LFIB. This is **independent of per-level SPF**: the label
+/// is derived from interface config + the global SR block, so it lives
+/// in a single map (`Isis::self_sid_ilm`), not `Levels<_>`.
+///
+/// For every loopback interface (`flags.is_loopback()`) that has IPv4
+/// enabled, a configured Prefix-SID, and a routable (non-127.0.0.0/8)
+/// address, install a **pop** entry (`adjacency: true`) so traffic that
+/// arrives carrying this node's own node-SID label is delivered locally
+/// — matching IOS-XR / SR-OS. Gated on `segment-routing mpls` plus the
+/// `local-prefix-sid` knob (default on); when either is off the desired
+/// set is empty and any previously-installed self entries are withdrawn.
+///
+/// Idempotent: safe to call on every SPF publish. `table_diff` only
+/// emits `IlmAdd`/`IlmDel` when the set actually changes.
+pub(super) fn update_self_sid_ilm(isis: &mut Isis) {
+    let mut desired: BTreeMap<u32, SpfIlm> = BTreeMap::new();
+
+    if isis.config.sr_mpls_enabled && isis.config.sr_local_prefix_sid {
+        let srgb = isis.sr_block.as_ref().and_then(|b| b.global.as_ref());
+        for (&ifindex, link) in isis.links.iter() {
+            if !link.flags.is_loopback() || !link.config.enable.v4 {
+                continue;
+            }
+            let Some(sid) = link.config.prefix_sid.as_ref() else {
+                continue;
+            };
+            let Some((label, index)) = resolve_self_sid(sid, srgb) else {
+                continue;
+            };
+            // The local delivery nexthop is the loopback's own routable
+            // IPv4 address; skip the 127.0.0.0/8 literal range.
+            let Some(addr) = link
+                .state
+                .v4addr
+                .iter()
+                .map(|p| p.addr())
+                .find(|a| !a.is_loopback())
+            else {
+                continue;
+            };
+            let mut nhops = BTreeMap::new();
+            nhops.insert(
+                addr,
+                SpfNexthop {
+                    ifindex,
+                    adjacency: true,
+                    sys_id: None,
+                    backup: None,
+                },
+            );
+            desired.insert(
+                label,
+                SpfIlm {
+                    nhops,
+                    ilm_type: IlmType::Node(index),
+                },
+            );
+        }
+    }
+
+    let diff = spf::table_diff(
+        isis.self_sid_ilm.iter().map(|(&k, v)| (k, v)),
+        desired.iter().map(|(&k, v)| (k, v)),
+    );
+    diff_ilm_apply(&isis.ctx.rib, &diff);
+    isis.self_sid_ilm = desired;
+}
+
 pub fn mpls_route(
     rib: &PrefixMap<Ipv4Net, SpfRoute>,
     ilm: &mut BTreeMap<u32, SpfIlm>,
@@ -1605,6 +1692,32 @@ pub fn mpls_route(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolve_self_sid_index_and_label() {
+        use crate::spf::label_block::LabelBlock;
+        let srgb = LabelBlock {
+            start: 16000,
+            end: 24000,
+        };
+        // Index form: label = SRGB.start + index.
+        assert_eq!(
+            resolve_self_sid(&SidLabelValue::Index(100), Some(&srgb)),
+            Some((16100, 100))
+        );
+        // Index without an SRGB snapshot can't resolve to a label.
+        assert_eq!(resolve_self_sid(&SidLabelValue::Index(100), None), None);
+        // Absolute label resolves directly; index derived from SRGB.
+        assert_eq!(
+            resolve_self_sid(&SidLabelValue::Label(16100), Some(&srgb)),
+            Some((16100, 100))
+        );
+        // Absolute label with no SRGB → index 0 (label still installs).
+        assert_eq!(
+            resolve_self_sid(&SidLabelValue::Label(16100), None),
+            Some((16100, 0))
+        );
+    }
 
     fn mk_uni(addr: &str, metric: u32) -> rib::NexthopUni {
         rib::NexthopUni::new(addr.parse().unwrap(), metric, vec![])

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1333,6 +1333,17 @@ module config {
         container segment-routing {
           container mpls {
             presence "Enable Segment Routing over MPLS dataplane";
+            leaf local-prefix-sid {
+              type boolean;
+              default true;
+              description
+                "Install the local (self-originated) Prefix-SID label
+                 into the MPLS forwarding table (LFIB) as a pop entry,
+                 so traffic that arrives carrying this node's own
+                 node-SID label is delivered locally. Default true,
+                 matching IOS-XR / SR-OS which always program the local
+                 node-SID. Only effective while SR-MPLS is enabled.";
+            }
           }
           container srv6 {
             presence "Enable Segment Routing over IPv6 dataplane";


### PR DESCRIPTION
## Summary

IS-IS installed adjacency-SID ILM entries and remote prefix-SID ILM entries, but never the router's **own** node-SID label — the self node is skipped in the RIB, so `mpls_route` never saw it. A packet arriving with our own node-SID label (no PHP, or explicit-null) had no pop entry. IOS-XR / SR-OS always program the local node-SID label as a pop; this adds the equivalent.

- **`update_self_sid_ilm`** (`rib.rs`): for each loopback interface with IPv4 enabled, a configured `prefix-sid`, and a routable (non-127/8) address, install a **pop** ILM entry (`adjacency=true`) for the resolved label (`Index → SRGB.start+i`, `Label → absolute`). Level-independent — the label comes from interface config + the global SR block, not per-level SPF — so it lives in a single `Isis::self_sid_ilm` map reconciled via `table_diff` + `diff_ilm_apply`.
- **Configurable**: gated on `segment-routing mpls` plus a new default-true knob `/router/isis/segment-routing/mpls/local-prefix-sid`.
- **Reconcile triggers**: `SpfDone` (covers SRGB-snapshot arrival + topology / loopback-address changes) and `CommitEnd` (covers config add/delete of `prefix-sid` / `sr-mpls` / the knob — those handlers don't schedule SPF, so without the `CommitEnd` trigger deleting the prefix-sid left a stale kernel ILM).

Scope: IPv4 only — the `prefix-sid` config knob is IPv4-only (matching OSPF's self-SID path). IPv6 prefix-SID-over-MPLS would be a follow-up.

## Test plan

- `cargo build -p zebra-rs`, `cargo clippy -p zebra-rs --all-targets`, `cargo fmt --check` — clean.
- `cargo test -p zebra-rs` — 841 passed (incl. new `resolve_self_sid_index_and_label`).
- `yang_load_tests` — validates the new `local-prefix-sid` leaf.
- Manual (next): on the `isis_tilfa` loopback `prefix-sid` configs, confirm the self label appears in `ip -f mpls route`, and `no … prefix-sid` withdraws it.

Generated with [Claude Code](https://claude.com/claude-code)