### PR TITLE
bdd(isis): TI-LFA SR-MPLS fast-reroute feature

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -36,6 +36,10 @@ isis_l1_p2p:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_l1_p2p"
 
+isis_tilfa:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_tilfa"
+
 bgp_evpn_capability:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_capability"
@@ -79,4 +83,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation isis_l1_p2p bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation isis_l1_p2p isis_tilfa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE

--- a/bdd/docs/isis_tilfa.md
+++ b/bdd/docs/isis_tilfa.md
@@ -1,0 +1,47 @@
+# IS-IS TI-LFA fast-reroute over SR-MPLS
+
+## Overview
+
+As a network operator
+I want eight zebra-rs instances running IS-IS Level-2 with SR-MPLS and
+TI-LFA (RFC 9490) to pre-compute a topology-independent loop-free
+repair for the source's primary path, so that when the primary link
+fails the source still reaches the destination over the SR repair /
+post-convergence path.
+All links are point-to-point veth pairs; every router is is-type
+level-2-only with `segment-routing mpls` and `fast-reroute ti-lfa`.
+Prefix-SIDs index 100..800 resolve against the RIB's default SRGB
+(base 16000), so node s's SID is label 16100, d's is 16800, etc.
+The metrics are tuned so a simple LFA is impossible: s reaches d via
+s-n1 (cost 2); the only other neighbours (n2, n3) are equidistant /
+expensive, so protecting the s-n1 link requires an SR repair tunnel
+through the r-plane rather than a plain loop-free alternate.
+
+## Test Topology
+
+```
+                 s (10.0.0.1)
+             1 / 1 \      \ 1000
+              n1    n2     n3
+          1 / |1 \1  \1     \1000
+       d ─┘ 1 |   \    \      \
+    (10.0.0.8)│    \1000\      \
+          1 \ │     r1───────── (r1-n3 1000)
+             r3    /  \1000
+          1000\   /1   \(r1-r2 1000)
+               r2 ──────┘
+                 \1000
+                  r3 (r3-d 1)
+    s-n1 1  s-n2 1  s-n3 1000   n1-r1 1  n2-r1 1  n3-r1 1000
+    n1-r2 1 r1-r2 1000 r2-r3 1000  n1-d 1  r3-d 1
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the TI-LFA topology and confirm adjacencies + SR | |
+| SR-MPLS labels and a TI-LFA repair are installed on the source | |
+| Source reaches the destination over the primary path | |
+| Fast-reroute survives the primary link failure (s-n1) | |
+| Teardown topology | |

--- a/bdd/tests/configs/isis_tilfa/d.yaml
+++ b/bdd/tests/configs/isis_tilfa/d.yaml
@@ -28,4 +28,5 @@ router:
       metric: 1
     is-type: level-2-only
     segment-routing: mpls
+    fast-reroute: ti-lfa
     te-router-id: 10.0.0.8

--- a/bdd/tests/configs/isis_tilfa/n1.yaml
+++ b/bdd/tests/configs/isis_tilfa/n1.yaml
@@ -20,6 +20,7 @@ router:
     hostname: n1
     is-type: level-2-only
     segment-routing: mpls
+    fast-reroute: ti-lfa
     te-router-id: 10.0.0.2
     interface:
     - if-name: lo

--- a/bdd/tests/configs/isis_tilfa/n2.yaml
+++ b/bdd/tests/configs/isis_tilfa/n2.yaml
@@ -14,6 +14,7 @@ router:
     hostname: n2
     is-type: level-2-only
     segment-routing: mpls
+    fast-reroute: ti-lfa
     te-router-id: 10.0.0.3
     interface:
     - if-name: lo

--- a/bdd/tests/configs/isis_tilfa/n3.yaml
+++ b/bdd/tests/configs/isis_tilfa/n3.yaml
@@ -28,4 +28,5 @@ router:
       metric: 1000
     is-type: level-2-only
     segment-routing: mpls
+    fast-reroute: ti-lfa
     te-router-id: 10.0.0.4

--- a/bdd/tests/configs/isis_tilfa/r1.yaml
+++ b/bdd/tests/configs/isis_tilfa/r1.yaml
@@ -42,4 +42,5 @@ router:
       metric: 1000
     is-type: level-2-only
     segment-routing: mpls
+    fast-reroute: ti-lfa
     te-router-id: 10.0.0.5

--- a/bdd/tests/configs/isis_tilfa/r2.yaml
+++ b/bdd/tests/configs/isis_tilfa/r2.yaml
@@ -35,4 +35,5 @@ router:
       metric: 1000
     is-type: level-2-only
     segment-routing: mpls
+    fast-reroute: ti-lfa
     te-router-id: 10.0.0.6

--- a/bdd/tests/configs/isis_tilfa/r3.yaml
+++ b/bdd/tests/configs/isis_tilfa/r3.yaml
@@ -28,4 +28,5 @@ router:
       metric: 1
     is-type: level-2-only
     segment-routing: mpls
+    fast-reroute: ti-lfa
     te-router-id: 10.0.0.7

--- a/bdd/tests/configs/isis_tilfa/s.yaml
+++ b/bdd/tests/configs/isis_tilfa/s.yaml
@@ -35,4 +35,5 @@ router:
       metric: 1000
     is-type: level-2-only
     segment-routing: mpls
+    fast-reroute: ti-lfa
     te-router-id: 10.0.0.1

--- a/bdd/tests/features/isis_tilfa.feature
+++ b/bdd/tests/features/isis_tilfa.feature
@@ -1,0 +1,125 @@
+@serial
+@isis_tilfa
+Feature: IS-IS TI-LFA fast-reroute over SR-MPLS
+  As a network operator
+  I want eight zebra-rs instances running IS-IS Level-2 with SR-MPLS and
+  TI-LFA (RFC 9490) to pre-compute a topology-independent loop-free
+  repair for the source's primary path, so that when the primary link
+  fails the source still reaches the destination over the SR repair /
+  post-convergence path.
+
+  All links are point-to-point veth pairs; every router is is-type
+  level-2-only with `segment-routing mpls` and `fast-reroute ti-lfa`.
+  Prefix-SIDs index 100..800 resolve against the RIB's default SRGB
+  (base 16000), so node s's SID is label 16100, d's is 16800, etc.
+
+  The metrics are tuned so a simple LFA is impossible: s reaches d via
+  s-n1 (cost 2); the only other neighbours (n2, n3) are equidistant /
+  expensive, so protecting the s-n1 link requires an SR repair tunnel
+  through the r-plane rather than a plain loop-free alternate.
+
+  Test Topology (metric shown where != 1; loopback 10.0.0.X / SID X00):
+  ```
+                 s (10.0.0.1)
+             1 / 1 \      \ 1000
+              n1    n2     n3
+          1 / |1 \1  \1     \1000
+       d ─┘ 1 |   \    \      \
+    (10.0.0.8)│    \1000\      \
+          1 \ │     r1───────── (r1-n3 1000)
+             r3    /  \1000
+          1000\   /1   \(r1-r2 1000)
+               r2 ──────┘
+                 \1000
+                  r3 (r3-d 1)
+    s-n1 1  s-n2 1  s-n3 1000   n1-r1 1  n2-r1 1  n3-r1 1000
+    n1-r2 1 r1-r2 1000 r2-r3 1000  n1-d 1  r3-d 1
+  ```
+
+  Scenario: Build the TI-LFA topology and confirm adjacencies + SR
+    Given a clean test environment
+    When I create namespace "s"
+    And I create namespace "n1"
+    And I create namespace "n2"
+    And I create namespace "n3"
+    And I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "d"
+    And I connect namespace "s" interface "s-n1" to namespace "n1" interface "n1-s"
+    And I connect namespace "s" interface "s-n2" to namespace "n2" interface "n2-s"
+    And I connect namespace "s" interface "s-n3" to namespace "n3" interface "n3-s"
+    And I connect namespace "n1" interface "n1-r1" to namespace "r1" interface "r1-n1"
+    And I connect namespace "n2" interface "n2-r1" to namespace "r1" interface "r1-n2"
+    And I connect namespace "n3" interface "n3-r1" to namespace "r1" interface "r1-n3"
+    And I connect namespace "n1" interface "n1-r2" to namespace "r2" interface "r2-n1"
+    And I connect namespace "r1" interface "r1-r2" to namespace "r2" interface "r2-r1"
+    And I connect namespace "r2" interface "r2-r3" to namespace "r3" interface "r3-r2"
+    And I connect namespace "n1" interface "n1-d" to namespace "d" interface "d-n1"
+    And I connect namespace "r3" interface "r3-d" to namespace "d" interface "d-r3"
+    And I start zebra-rs in namespace "s"
+    And I start zebra-rs in namespace "n1"
+    And I start zebra-rs in namespace "n2"
+    And I start zebra-rs in namespace "n3"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I start zebra-rs in namespace "d"
+    And I apply config "s.yaml" to namespace "s"
+    And I apply config "n1.yaml" to namespace "n1"
+    And I apply config "n2.yaml" to namespace "n2"
+    And I apply config "n3.yaml" to namespace "n3"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I apply config "d.yaml" to namespace "d"
+    And I wait 10 seconds
+    # Directly-connected adjacency over s-n1, then n1's loopback over SR.
+    Then ping from "s" to "192.168.0.2" should succeed
+    And ping from "s" to "10.0.0.2" should succeed
+
+  Scenario: SR-MPLS labels and a TI-LFA repair are installed on the source
+    Given the test topology exists
+    # Prefix-SIDs resolved to labels (SR active), and the s-n1-protected
+    # routes carry a pre-computed TI-LFA repair tunnel.
+    Then show command "show isis route detail" in namespace "s" should contain "Prefix-SID:"
+    And show command "show isis route detail" in namespace "s" should contain "Backup path: TI-LFA"
+
+  Scenario: Source reaches the destination over the primary path
+    Given the test topology exists
+    # s -> d primary is s-n1-d (cost 2).
+    Then ping from "s" to "10.0.0.8" should succeed
+    And ping from "d" to "10.0.0.1" should succeed
+
+  Scenario: Fast-reroute survives the primary link failure (s-n1)
+    Given the test topology exists
+    Then ping from "s" to "10.0.0.8" should succeed
+    When I make namespace "s" interface "s-n1" down
+    And I wait 5 seconds
+    # Reachability restored over the SR repair / post-convergence path
+    # (s-n2-r1-n1-d), out a different interface than the failed s-n1.
+    Then ping from "s" to "10.0.0.8" should succeed
+    When I make namespace "s" interface "s-n1" up
+    And I wait 10 seconds
+    # Primary restored.
+    Then ping from "s" to "10.0.0.8" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "s"
+    And I stop zebra-rs in namespace "n1"
+    And I stop zebra-rs in namespace "n2"
+    And I stop zebra-rs in namespace "n3"
+    And I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I stop zebra-rs in namespace "d"
+    And I delete namespace "s"
+    And I delete namespace "n1"
+    And I delete namespace "n2"
+    And I delete namespace "n3"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "d"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

Adds `isis_tilfa.feature` — IS-IS Level-2 **TI-LFA** (RFC 9490) fast-reroute over SR-MPLS on the 8-node `s` / `n1-3` / `r1-3` / `d` topology (already-committed `isis_tilfa/` configs).

- **Enables TI-LFA** on all 8 nodes (`fast-reroute ti-lfa`) — the missing piece; SRGB comes from the RIB's default block (base 16000), so no `/segment-routing/block` config is needed.
- The metrics are tuned so a **simple LFA is impossible** (`n2`/`n3` are exactly equidistant), forcing an SR repair tunnel to protect `s`'s `s-n1` primary toward `d`.
- **Scenarios**: build + adjacency/SR reachability; assert `Prefix-SID:` and `Backup path: TI-LFA` in `show isis route detail` on `s`; `s→d` primary reachability; `s-n1` link-down fast-reroute + recovery; teardown.
- `make isis_tilfa` target; generated `docs/isis_tilfa.md`.

## Test plan

- Wiring cross-checked against the configs: all 22 interfaces across 11 links, subnets match, ping targets valid, lifecycle covers all 8 nodes.
- Dijkstra confirms the scenario: `s→d` primary cost 2 via `n1`; after `s-n1` down, cost 4 via `n2` (different egress) — failover sound; simple LFA provably fails (`3 < 3` / `1002 < 1002`) → TI-LFA repair genuinely required.
- BDD is netns + root, run locally with `cd bdd && make isis_tilfa` (outside CI by design). The `Backup path: TI-LFA` assertion exercises zebra-rs's actual TI-LFA computation for this topology.

Generated with [Claude Code](https://claude.com/claude-code)