### PR TITLE
isis: replace local-prefix-sid knob with no-local-prefix-sid (empty)

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -136,8 +136,8 @@ impl Isis {
         self.callback_add("/router/isis/te-router-id", config_te_router_id);
         self.callback_add("/router/isis/segment-routing/mpls", config_sr_mpls_enable);
         self.callback_add(
-            "/router/isis/segment-routing/mpls/local-prefix-sid",
-            config_sr_local_prefix_sid,
+            "/router/isis/segment-routing/mpls/no-local-prefix-sid",
+            config_sr_no_local_prefix_sid,
         );
         self.callback_add("/router/isis/segment-routing/srv6", config_sr_srv6_enable);
         self.callback_add(
@@ -439,13 +439,14 @@ pub struct IsisConfig {
     /// "default" block under /segment-routing/block.
     pub sr_mpls_enabled: bool,
 
-    /// Install the local (self-originated) Prefix-SID label into the
-    /// MPLS LFIB as a pop entry (`/router/isis/segment-routing/mpls/
-    /// local-prefix-sid`). Default true — matches IOS-XR / SR-OS, which
-    /// always program the local node-SID label. When false, only remote
-    /// prefix-SIDs and adjacency-SIDs are installed. Only takes effect
-    /// while `sr_mpls_enabled` is set.
-    pub sr_local_prefix_sid: bool,
+    /// Suppress installing the local (self-originated) Prefix-SID label
+    /// into the MPLS LFIB (`/router/isis/segment-routing/mpls/
+    /// no-local-prefix-sid`, type empty). Default false — by default the
+    /// local node-SID is installed as a pop entry, matching IOS-XR /
+    /// SR-OS. When set (leaf present), only remote prefix-SIDs and
+    /// adjacency-SIDs are installed. Only takes effect while
+    /// `sr_mpls_enabled` is set.
+    pub sr_no_local_prefix_sid: bool,
 
     /// Set when /router/isis/segment-routing/srv6 is committed.
     pub sr_srv6_enabled: bool,
@@ -716,7 +717,7 @@ impl Default for IsisConfig {
             enable: Default::default(),
             distribute: Default::default(),
             sr_mpls_enabled: Default::default(),
-            sr_local_prefix_sid: true,
+            sr_no_local_prefix_sid: false,
             sr_srv6_enabled: Default::default(),
             sr_srv6_locator: Default::default(),
             sr_srv6_flex_algo_locators: Default::default(),
@@ -1156,14 +1157,14 @@ fn config_sr_mpls_enable(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<(
     Some(())
 }
 
-/// `/router/isis/segment-routing/mpls/local-prefix-sid`. Toggles
-/// installation of the local (self-originated) Prefix-SID label into
-/// the MPLS LFIB. Default true. The install itself is recomputed on the
-/// next SPF publish (`update_self_sid_ilm`), which a config commit
-/// already schedules, so no explicit reconcile is needed here.
-fn config_sr_local_prefix_sid(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
-    let value = if op.is_set() { args.boolean()? } else { true };
-    isis.config.sr_local_prefix_sid = value;
+/// `/router/isis/segment-routing/mpls/no-local-prefix-sid` (type empty).
+/// When present, suppresses installation of the local (self-originated)
+/// Prefix-SID label into the MPLS LFIB; absent (default) installs it.
+/// The install itself is recomputed on the next reconcile
+/// (`update_self_sid_ilm`), which CommitEnd already drives, so no
+/// explicit reconcile is needed here.
+fn config_sr_no_local_prefix_sid(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<()> {
+    isis.config.sr_no_local_prefix_sid = op.is_set();
     Some(())
 }
 

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -746,11 +746,11 @@ impl Isis {
             self.commit_srlg();
             // Reconcile the local Prefix-SID ILM against the just-committed
             // config. This is what withdraws the pop entry when
-            // `prefix-sid` / `segment-routing mpls` / `local-prefix-sid`
-            // is removed — those handlers only mutate config state and
-            // don't schedule SPF, so the `SpfDone` reconcile alone would
-            // never see the deletion. Idempotent: a no-op when nothing
-            // self-SID-relevant changed.
+            // `prefix-sid` / `segment-routing mpls` is removed or
+            // `no-local-prefix-sid` is set — those handlers only mutate
+            // config state and don't schedule SPF, so the `SpfDone`
+            // reconcile alone would never see the change. Idempotent: a
+            // no-op when nothing self-SID-relevant changed.
             update_self_sid_ilm(self);
             return;
         }

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -1603,16 +1603,17 @@ fn resolve_self_sid(
 /// enabled, a configured Prefix-SID, and a routable (non-127.0.0.0/8)
 /// address, install a **pop** entry (`adjacency: true`) so traffic that
 /// arrives carrying this node's own node-SID label is delivered locally
-/// — matching IOS-XR / SR-OS. Gated on `segment-routing mpls` plus the
-/// `local-prefix-sid` knob (default on); when either is off the desired
-/// set is empty and any previously-installed self entries are withdrawn.
+/// — matching IOS-XR / SR-OS. Gated on `segment-routing mpls` and the
+/// absence of the `no-local-prefix-sid` knob; when SR-MPLS is off or
+/// `no-local-prefix-sid` is set the desired set is empty and any
+/// previously-installed self entries are withdrawn.
 ///
 /// Idempotent: safe to call on every SPF publish. `table_diff` only
 /// emits `IlmAdd`/`IlmDel` when the set actually changes.
 pub(super) fn update_self_sid_ilm(isis: &mut Isis) {
     let mut desired: BTreeMap<u32, SpfIlm> = BTreeMap::new();
 
-    if isis.config.sr_mpls_enabled && isis.config.sr_local_prefix_sid {
+    if isis.config.sr_mpls_enabled && !isis.config.sr_no_local_prefix_sid {
         let srgb = isis.sr_block.as_ref().and_then(|b| b.global.as_ref());
         for (&ifindex, link) in isis.links.iter() {
             if !link.flags.is_loopback() || !link.config.enable.v4 {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1333,16 +1333,17 @@ module config {
         container segment-routing {
           container mpls {
             presence "Enable Segment Routing over MPLS dataplane";
-            leaf local-prefix-sid {
-              type boolean;
-              default true;
+            leaf no-local-prefix-sid {
+              type empty;
               description
-                "Install the local (self-originated) Prefix-SID label
-                 into the MPLS forwarding table (LFIB) as a pop entry,
-                 so traffic that arrives carrying this node's own
-                 node-SID label is delivered locally. Default true,
-                 matching IOS-XR / SR-OS which always program the local
-                 node-SID. Only effective while SR-MPLS is enabled.";
+                "Suppress installing the local (self-originated)
+                 Prefix-SID label into the MPLS forwarding table (LFIB).
+                 By default (leaf absent) the local node-SID is installed
+                 as a pop entry so traffic arriving with this node's own
+                 node-SID label is delivered locally, matching IOS-XR /
+                 SR-OS. When present, only remote prefix-SIDs and
+                 adjacency-SIDs are installed. Only effective while
+                 SR-MPLS is enabled.";
             }
           }
           container srv6 {


### PR DESCRIPTION
## Summary

Swap the boolean `/router/isis/segment-routing/mpls/local-prefix-sid` (default true) for a negative-presence leaf **`no-local-prefix-sid`** (`type empty`). Same behaviour, cleaner CLI:

- **Default** (leaf absent): the local (self-originated) Prefix-SID is installed into the MPLS LFIB as a pop entry — matching IOS-XR / SR-OS.
- **`no-local-prefix-sid` present**: the local entry is suppressed; **remote** prefix-SIDs and adjacency-SIDs still install.

```
router isis {
  segment-routing mpls {
    no-local-prefix-sid;
  }
}
```

Changes: `config.yang` (the leaf), `IsisConfig.sr_no_local_prefix_sid` (default false) + handler from `op.is_set()`, and `update_self_sid_ilm` now gates on `!sr_no_local_prefix_sid`.

## Test plan

- `cargo build -p zebra-rs`, `cargo clippy -p zebra-rs --all-targets`, `cargo fmt --check` — clean.
- `cargo test -p zebra-rs` — 841 passed.
- `yang_load_tests` — validates the new `no-local-prefix-sid` (type empty) leaf.

Generated with [Claude Code](https://claude.com/claude-code)