### PR TITLE
isis: clear MPLS ILM on sr-mpls disable + SR-MPLS ILM BDD scenarios

### DIFF
--- a/bdd/docs/isis_tilfa.md
+++ b/bdd/docs/isis_tilfa.md
@@ -44,4 +44,6 @@ through the r-plane rather than a plain loop-free alternate.
 | SR-MPLS labels and a TI-LFA repair are installed on the source | |
 | Source reaches the destination over the primary path | |
 | Fast-reroute survives the primary link failure (s-n1) | |
+| no-local-prefix-sid suppresses only the local Prefix-SID in the LFIB | |
+| Deleting segment-routing mpls clears all MPLS ILM entries | |
 | Teardown topology | |

--- a/bdd/tests/configs/isis_tilfa/s-nolocal.yaml
+++ b/bdd/tests/configs/isis_tilfa/s-nolocal.yaml
@@ -1,0 +1,40 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: s-n1
+  ipv4:
+    address: 192.168.0.1/30
+- if-name: s-n2
+  ipv4:
+    address: 192.168.0.5/30
+- if-name: s-n3
+  ipv4:
+    address: 192.168.0.9/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: s
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 100
+    - if-name: s-n1
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: s-n2
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: s-n3
+      ipv4:
+        enable: true
+      metric: 1000
+    is-type: level-2-only
+    segment-routing:
+      mpls: no-local-prefix-sid
+    fast-reroute: ti-lfa
+    te-router-id: 10.0.0.1

--- a/bdd/tests/configs/isis_tilfa/s-nosr.yaml
+++ b/bdd/tests/configs/isis_tilfa/s-nosr.yaml
@@ -1,0 +1,38 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: s-n1
+  ipv4:
+    address: 192.168.0.1/30
+- if-name: s-n2
+  ipv4:
+    address: 192.168.0.5/30
+- if-name: s-n3
+  ipv4:
+    address: 192.168.0.9/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: s
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 100
+    - if-name: s-n1
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: s-n2
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: s-n3
+      ipv4:
+        enable: true
+      metric: 1000
+    is-type: level-2-only
+    fast-reroute: ti-lfa
+    te-router-id: 10.0.0.1

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -326,15 +326,17 @@ async fn apply_config(world: &mut World, config_file: String, namespace: String)
         .await
         .expect("Failed to apply config");
 
-    // `vtyctl apply` exits 0 even when the server rejects the config —
-    // it prints `error: <command>` (or `applied`) to stdout and returns.
-    // Without this check, a silently-rejected config would let the
-    // scenario continue past the apply step and fail later at a ping or
-    // a show with no obvious cause. Bail loudly with the offending line
-    // so the failure is diagnosable from the cucumber log alone.
+    // `vtyctl apply` exits 0 even when the server rejects the config: it
+    // prints `applied` on success, or `error reply: <command>` for the
+    // first command the server refused. Without this check a silently-
+    // rejected config would let the scenario continue past the apply
+    // step and fail later at a ping or a show with no obvious cause.
+    // Match on `error` so both `error:` and `error reply:` are caught;
+    // no successful apply output contains the word. Bail loudly with the
+    // offending line so the failure is diagnosable from the log alone.
     let trimmed = stdout.trim();
     assert!(
-        !trimmed.starts_with("error:"),
+        !trimmed.contains("error"),
         "vtyctl apply rejected {} in namespace {}: {}",
         config_file,
         scoped,
@@ -604,6 +606,95 @@ async fn show_command_contains(
         "✓ show '{}' in namespace {} contains '{}'",
         show_cmd, scoped, needle
     );
+}
+
+/// Negative sibling of `show_command_contains`: assert the `vtyctl show`
+/// output does NOT contain the given substring. Used to verify a
+/// suppressed entry is absent (e.g. the local Prefix-SID label withdrawn
+/// from `show mpls ilm` once `no-local-prefix-sid` is configured).
+#[then(expr = "show command {string} in namespace {string} should not contain {string}")]
+async fn show_command_not_contains(
+    world: &mut World,
+    show_cmd: String,
+    namespace: String,
+    needle: String,
+) {
+    let scoped = world.ns(&namespace);
+    let output = netns::exec_in_netns(&scoped, "vtyctl", &["show", &show_cmd])
+        .await
+        .expect("Failed to run show command");
+    assert!(
+        !output.contains(&needle),
+        "show '{}' in namespace {} unexpectedly contained '{}'\nfull output:\n{}",
+        show_cmd,
+        scoped,
+        needle,
+        output,
+    );
+    println!(
+        "✓ show '{}' in namespace {} does not contain '{}'",
+        show_cmd, scoped, needle
+    );
+}
+
+/// Fetch the local labels installed in the MPLS LFIB of `scoped` via
+/// `vtyctl show -j "show mpls ilm"` (JSON is far more robust than
+/// substring-matching the text table — a bare "16100" could appear as an
+/// outgoing label, a metric, or an address octet).
+async fn ilm_local_labels(scoped: &str) -> Vec<u64> {
+    let output = netns::exec_in_netns(scoped, "vtyctl", &["show", "-j", "show mpls ilm"])
+        .await
+        .expect("Failed to run show mpls ilm");
+    let json: Value = serde_json::from_str(&output).expect("Failed to parse ILM JSON");
+    json.get("entries")
+        .and_then(|e| e.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|e| e.get("local_label").and_then(|l| l.as_u64()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[then(expr = "mpls ilm in namespace {string} should contain label {int}")]
+async fn ilm_should_contain_label(world: &mut World, namespace: String, label: u64) {
+    let scoped = world.ns(&namespace);
+    let labels = ilm_local_labels(&scoped).await;
+    assert!(
+        labels.contains(&label),
+        "MPLS ILM in {} does not contain label {} (have {:?})",
+        scoped,
+        label,
+        labels,
+    );
+    println!("✓ MPLS ILM in {} contains label {}", scoped, label);
+}
+
+#[then(expr = "mpls ilm in namespace {string} should not contain label {int}")]
+async fn ilm_should_not_contain_label(world: &mut World, namespace: String, label: u64) {
+    let scoped = world.ns(&namespace);
+    let labels = ilm_local_labels(&scoped).await;
+    assert!(
+        !labels.contains(&label),
+        "MPLS ILM in {} unexpectedly contains label {} (have {:?})",
+        scoped,
+        label,
+        labels,
+    );
+    println!("✓ MPLS ILM in {} does not contain label {}", scoped, label);
+}
+
+#[then(expr = "mpls ilm in namespace {string} should be empty")]
+async fn ilm_should_be_empty(world: &mut World, namespace: String) {
+    let scoped = world.ns(&namespace);
+    let labels = ilm_local_labels(&scoped).await;
+    assert!(
+        labels.is_empty(),
+        "MPLS ILM in {} is not empty, has labels {:?}",
+        scoped,
+        labels,
+    );
+    println!("✓ MPLS ILM in {} is empty", scoped);
 }
 
 #[then("the test environment should be clean")]

--- a/bdd/tests/features/isis_tilfa.feature
+++ b/bdd/tests/features/isis_tilfa.feature
@@ -104,6 +104,32 @@ Feature: IS-IS TI-LFA fast-reroute over SR-MPLS
     # Primary restored.
     Then ping from "s" to "10.0.0.8" should succeed
 
+  Scenario: no-local-prefix-sid suppresses only the local Prefix-SID in the LFIB
+    Given the test topology exists
+    # By default s installs its own node-SID label (SID 100 -> 16100) as a
+    # local pop entry, alongside remote node-SIDs (e.g. d's SID 800 -> 16800).
+    Then mpls ilm in namespace "s" should contain label 16100
+    And mpls ilm in namespace "s" should contain label 16800
+    # Re-apply s with `no-local-prefix-sid` under segment-routing mpls.
+    When I apply config "s-nolocal.yaml" to namespace "s"
+    And I wait 5 seconds
+    # The local label is withdrawn from the LFIB; the remote one stays.
+    Then mpls ilm in namespace "s" should not contain label 16100
+    And mpls ilm in namespace "s" should contain label 16800
+
+  Scenario: Deleting segment-routing mpls clears all MPLS ILM entries
+    Given the test topology exists
+    # s still has remote node-SID labels installed (n1 SID 200 -> 16200,
+    # d SID 800 -> 16800).
+    Then mpls ilm in namespace "s" should contain label 16200
+    And mpls ilm in namespace "s" should contain label 16800
+    # Remove `segment-routing mpls` from s entirely.
+    When I apply config "s-nosr.yaml" to namespace "s"
+    And I wait 5 seconds
+    # Disabling SR-MPLS must withdraw every MPLS ILM entry — prefix-SIDs
+    # and adjacency-SIDs — leaving the LFIB completely empty.
+    Then mpls ilm in namespace "s" should be empty
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "s"

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -1154,6 +1154,15 @@ fn config_sr_mpls_enable(isis: &mut Isis, _args: Args, op: ConfigOp) -> Option<(
     // reconcile here drops the pool immediately.
     isis.reconcile_block_watch();
     isis.reconcile_local_pool();
+    // Toggling SR-MPLS changes what we install in the MPLS LFIB, but
+    // neither handler above schedules SPF. Recompute both levels so
+    // `apply_spf_result` reconciles the per-level ILM — in particular,
+    // disabling withdraws every adjacency-/prefix-SID entry (the self
+    // Prefix-SID is already handled by `update_self_sid_ilm` at
+    // CommitEnd, but the remote prefix-SID and adjacency-SID entries
+    // are only reconciled on an SPF pass).
+    let _ = isis.tx.send(Message::SpfCalc(Level::L1));
+    let _ = isis.tx.send(Message::SpfCalc(Level::L2));
     Some(())
 }
 

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -1445,6 +1445,15 @@ pub(super) fn apply_spf_result(top: &mut IsisTop, output: SpfOutput) {
     *top.spf_result.get_mut(&level) = Some(spf_result);
     *top.tilfa_result.get_mut(&level) = Some(tilfa_result);
     mpls_route(&rib, &mut ilm, srgb);
+    // SR-MPLS forwarding gates the whole MPLS LFIB. Prefix-SID labels
+    // resolve from peers' advertisements (`label_map` / reach-map),
+    // independent of our own SR state, so without this an SPF pass after
+    // `no segment-routing mpls` would happily re-install remote
+    // prefix-SID and adjacency-SID entries. Dropping the desired set
+    // here makes `apply_routing_updates` withdraw every ILM entry.
+    if !top.config.sr_mpls_enabled {
+        ilm.clear();
+    }
     apply_routing_updates(top, level, rib, rib_v6, ilm);
 }
 


### PR DESCRIPTION
## Summary

A daemon fix plus two BDD scenarios (verified against the MPLS LFIB via JSON) for SR-MPLS local-prefix-SID handling on the `isis_tilfa` topology.

**Daemon fix** — deleting `segment-routing mpls` left the per-level ILM (remote prefix-SID + adjacency-SID entries) stranded in the kernel LFIB. The config handler flipped `sr_mpls_enabled` and dropped the block/pool but scheduled no SPF, and the per-level ILM is reconciled only in `apply_spf_result`. Now:
- `config_sr_mpls_enable` schedules SPF for both levels on toggle.
- `apply_spf_result` clears the ILM when `sr_mpls_enabled` is false — load-bearing, since remote prefix-SID labels resolve from *peers'* advertisements (independent of our local SR state), so a bare re-SPF would re-install them.

**BDD scenarios** (`isis_tilfa.feature`):
- `no-local-prefix-sid` suppresses only the local Prefix-SID pop entry (16100 withdrawn, remote 16800 stays).
- Deleting `segment-routing mpls` clears the whole LFIB (`entries` empty).

**Harness**:
- `apply config` now fails on `error reply:` (not just `error:`), so a server-rejected config blows up at the apply step with the offending command instead of masking as a later assertion failure.
- New JSON ILM steps parsing `show mpls ilm -j`: `mpls ilm in namespace X should contain label N / should not contain label N / should be empty`.

## Test plan

- `cargo test -p zebra-rs` — 841 passed; `cargo clippy` / `cargo fmt --check` clean; bdd harness compiles.
- `cd bdd && make isis_tilfa` (root + netns; run with the freshly-installed daemon) — all 7 scenarios pass.

Generated with [Claude Code](https://claude.com/claude-code)