### PR TITLE
isis-packet: serialize bitfield flags as named JSON fields

### DIFF
--- a/crates/isis-packet/Cargo.toml
+++ b/crates/isis-packet/Cargo.toml
@@ -17,6 +17,7 @@ ipnet = { version = "2.10", features = ["serde"] }
 itertools = "0.14.0"
 nom = "8"
 nom-derive = { git = "https://github.com/rust-bakery/nom-derive", branch = "master" }
+paste = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 strum = "0.28"

--- a/crates/isis-packet/src/flags_serde.rs
+++ b/crates/isis-packet/src/flags_serde.rs
@@ -1,0 +1,121 @@
+//! Field-decoded JSON serialization for the crate's `#[bitfield]` flag types.
+//!
+//! `bitfield-struct` rewrites each `#[bitfield(uN)]` struct into a newtype
+//! over the integer storage (`struct Flags(u8)`), turning the declared
+//! fields into accessor *methods*, not data. A derived `Serialize` therefore
+//! sees a single-field newtype and emits just the packed integer
+//! (`"flags": 64`). The impls below instead emit the decoded named fields
+//! (`{"n_flag": true, ...}`) via the getters, and read them back through the
+//! `with_*` builders — so JSON round-trips (see `tests/json.rs`) stay intact.
+//!
+//! Reserved bits are listed in a separate `reserved { ... }` group: they are
+//! omitted from the serialized output (operators don't care about padding),
+//! but are still rebuilt on deserialize via `#[serde(default)]`, so a value
+//! whose reserved bits are zero (the only valid state) round-trips exactly.
+//!
+//! Keep an entry here in sync with every `#[bitfield]` type that derives
+//! serde in this crate; the `Serialize`/`Deserialize` derives are removed
+//! from those structs so these impls are the only ones.
+
+use serde::ser::SerializeStruct;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::parser::IsisLspTypes;
+use crate::sub::cap::{RouterCapFlags, SegmentRoutingCapFlags, Srv6Flags};
+use crate::sub::neigh::AdjSidFlags;
+use crate::sub::prefix::{
+    Ipv4ControlInfo, Ipv6ControlInfo, MultiTopologyId, PrefixSidFlags, Srv6TlvFlags,
+};
+
+/// Generate field-decoded `Serialize` + `Deserialize` for a
+/// `bitfield-struct` type. Each `field: type` pair names a generated
+/// accessor (`self.field()`) and builder (`.with_field(value)`). Fields in
+/// the optional `reserved { ... }` group are not serialized but are still
+/// rebuilt on deserialize (defaulting to 0 when absent).
+macro_rules! bitfield_serde {
+    ($name:ident { $($field:ident : $ty:ty),* $(,)? }) => {
+        bitfield_serde!($name { $($field: $ty),* } reserved {});
+    };
+    (
+        $name:ident { $($field:ident : $ty:ty),* $(,)? }
+        reserved { $($rfield:ident : $rty:ty),* $(,)? }
+    ) => {
+        impl Serialize for $name {
+            fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                let mut st = serializer
+                    .serialize_struct(stringify!($name), [$(stringify!($field)),*].len())?;
+                $( st.serialize_field(stringify!($field), &self.$field())?; )*
+                st.end()
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                #[derive(Deserialize)]
+                struct Helper {
+                    $($field: $ty,)*
+                    $(#[serde(default)] $rfield: $rty,)*
+                }
+                let helper = Helper::deserialize(deserializer)?;
+                Ok(::paste::paste! {
+                    $name::new()
+                        $( .[<with_ $field>](helper.$field) )*
+                        $( .[<with_ $rfield>](helper.$rfield) )*
+                })
+            }
+        }
+    };
+}
+
+bitfield_serde!(PrefixSidFlags {
+    l_flag: bool,
+    v_flag: bool,
+    e_flag: bool,
+    p_flag: bool,
+    n_flag: bool,
+    r_flag: bool,
+} reserved { resvd: u8 });
+
+bitfield_serde!(Ipv4ControlInfo {
+    prefixlen: usize,
+    sub_tlv: bool,
+    distribution: bool,
+});
+
+bitfield_serde!(MultiTopologyId { id: u16 } reserved { resvd: u8 });
+
+bitfield_serde!(Ipv6ControlInfo {
+    sub_tlv: bool,
+    dist_internal: bool,
+    dist_up: bool,
+} reserved { resvd: usize });
+
+bitfield_serde!(Srv6TlvFlags { v_flag: u16 } reserved { resvd: u8 });
+
+bitfield_serde!(IsisLspTypes {
+    is_bits: u8,
+    ol_bits: bool,
+    att_bits: u8,
+    p_bits: bool,
+});
+
+bitfield_serde!(SegmentRoutingCapFlags {
+    v_flag: bool,
+    i_flag: bool,
+} reserved { resvd: u8 });
+
+bitfield_serde!(RouterCapFlags {
+    d_flag: bool,
+    s_flag: bool,
+} reserved { resvd: u8 });
+
+bitfield_serde!(Srv6Flags { o_flag: bool } reserved { resvd1: bool, resvd2: u16 });
+
+bitfield_serde!(AdjSidFlags {
+    p_flag: bool,
+    s_flag: bool,
+    l_flag: bool,
+    v_flag: bool,
+    b_flag: bool,
+    f_flag: bool,
+} reserved { resvd: u8 });

--- a/crates/isis-packet/src/lib.rs
+++ b/crates/isis-packet/src/lib.rs
@@ -1,6 +1,7 @@
 mod checksum;
 mod disp;
 mod error;
+mod flags_serde;
 mod nsap;
 mod padding;
 mod parser;

--- a/crates/isis-packet/src/parser.rs
+++ b/crates/isis-packet/src/parser.rs
@@ -295,7 +295,6 @@ impl From<IsisNeighborId> for IsisLspId {
 }
 
 #[bitfield(u8, debug = true)]
-#[derive(Serialize, Deserialize)]
 pub struct IsisLspTypes {
     #[bits(2)]
     pub is_bits: u8,

--- a/crates/isis-packet/src/sub/cap.rs
+++ b/crates/isis-packet/src/sub/cap.rs
@@ -77,7 +77,7 @@ impl IsisSubTlv {
 }
 
 #[bitfield(u8, debug = true)]
-#[derive(Serialize, Deserialize, PartialEq)]
+#[derive(PartialEq)]
 pub struct SegmentRoutingCapFlags {
     #[bits(6)]
     pub resvd: u8,
@@ -212,7 +212,7 @@ impl TlvEmitter for IsisSubNodeMaxSidDepth {
 }
 
 #[bitfield(u8, debug = true)]
-#[derive(Serialize, Deserialize, PartialEq)]
+#[derive(PartialEq)]
 pub struct RouterCapFlags {
     #[bits(6)]
     pub resvd: u8,
@@ -278,7 +278,7 @@ impl From<IsisTlvRouterCap> for IsisTlv {
 }
 
 #[bitfield(u16, debug = true)]
-#[derive(Serialize, Deserialize, PartialEq)]
+#[derive(PartialEq)]
 pub struct Srv6Flags {
     #[bits(14)]
     pub resvd2: u16,

--- a/crates/isis-packet/src/sub/neigh.rs
+++ b/crates/isis-packet/src/sub/neigh.rs
@@ -838,7 +838,7 @@ impl From<IsisSubTeMetric> for IsisSubTlv {
 }
 
 #[bitfield(u8, debug = true)]
-#[derive(Serialize, Deserialize, PartialEq)]
+#[derive(PartialEq)]
 pub struct AdjSidFlags {
     #[bits(2)]
     pub resvd: u8,

--- a/crates/isis-packet/src/sub/prefix.rs
+++ b/crates/isis-packet/src/sub/prefix.rs
@@ -32,7 +32,7 @@ pub enum IsisSubTlv {
 }
 
 #[bitfield(u8, debug = true)]
-#[derive(Serialize, Deserialize, PartialEq)]
+#[derive(PartialEq)]
 pub struct PrefixSidFlags {
     #[bits(2)]
     pub resvd: u8,
@@ -300,7 +300,7 @@ impl From<IsisSubIpv6SourceRouterId> for IsisSubTlv {
 }
 
 #[bitfield(u8, debug = true)]
-#[derive(Serialize, Deserialize, PartialEq)]
+#[derive(PartialEq)]
 pub struct Ipv4ControlInfo {
     #[bits(6)]
     pub prefixlen: usize,
@@ -485,7 +485,7 @@ impl From<IsisTlvIpv6Reach> for IsisTlv {
 // 12-15. The previous order produced .id()=0 for an MT 2 LSP because
 // MT ID was being read out of the reserved bits.
 #[bitfield(u16, debug = true)]
-#[derive(Serialize, Deserialize, PartialEq)]
+#[derive(PartialEq)]
 pub struct MultiTopologyId {
     #[bits(12)]
     pub id: u16,
@@ -579,7 +579,7 @@ impl From<IsisTlvMtIpv6Reach> for IsisTlv {
 }
 
 #[bitfield(u8, debug = true)]
-#[derive(Serialize, Deserialize, PartialEq)]
+#[derive(PartialEq)]
 pub struct Ipv6ControlInfo {
     #[bits(5)]
     pub resvd: usize,
@@ -742,7 +742,7 @@ impl ParseBe<IsisTlvIpv6ReachEntry> for IsisTlvIpv6ReachEntry {
 }
 
 #[bitfield(u16, debug = true)]
-#[derive(Serialize, Deserialize, PartialEq)]
+#[derive(PartialEq)]
 pub struct Srv6TlvFlags {
     #[bits(4)]
     pub resvd: u8,


### PR DESCRIPTION
## Summary

`bitfield-struct` rewrites each `#[bitfield(uN)]` into a newtype over the integer storage, so a derived `Serialize` emitted only the packed integer (e.g. `"flags": 64`) and the individual flags never appeared in JSON. This adds field-decoded `Serialize`/`Deserialize` for all 10 IS-IS bitfield types via a `bitfield_serde!` macro (new `flags_serde.rs`), and removes the derived serde from those structs.

- Flags now render as named booleans/values:
  ```json
  "flags": { "l_flag": false, "v_flag": false, "e_flag": false,
             "p_flag": false, "n_flag": true,  "r_flag": false }
  ```
- **Reserved bits hidden**: listed in a separate `reserved { }` group — omitted from output, but rebuilt on deserialize via `#[serde(default)]`, so a value with zero reserved bits round-trips exactly.
- Covers `PrefixSidFlags`, `Ipv4ControlInfo`, `MultiTopologyId`, `Ipv6ControlInfo`, `Srv6TlvFlags`, `IsisLspTypes`, `SegmentRoutingCapFlags`, `RouterCapFlags`, `Srv6Flags`, `AdjSidFlags`.

## Test plan

- `cargo test -p isis-packet` — all pass, incl. `json_round_trip_test` (serialize→deserialize equality for `IsisSubPrefixSid`).
- `cargo build -p zebra-rs`, `cargo clippy -p isis-packet -p zebra-rs --all-targets`, `cargo fmt --check` — clean.
- `cargo test -p zebra-rs` — 841 passed.

Generated with [Claude Code](https://claude.com/claude-code)