### PR TITLE
isis: set the N (Node-SID) flag on self-originated Prefix-SIDs

### DIFF
--- a/zebra-rs/src/isis/flex_algo.rs
+++ b/zebra-rs/src/isis/flex_algo.rs
@@ -4,7 +4,7 @@ use isis_packet::neigh::IsisSubTlv as NeighSubTlv;
 use isis_packet::{
     Algo, ExtAdminGroup, FadSubTlv, IsisSubAdminGrp, IsisSubAsla, IsisSubFadExcludeAg,
     IsisSubFadExcludeSrlg, IsisSubFadFlags, IsisSubFadIncludeAllAg, IsisSubFadIncludeAnyAg,
-    IsisSubFlexAlgoDef, IsisSubPrefixSid, SidLabelValue,
+    IsisSubFlexAlgoDef, IsisSubPrefixSid, PrefixSidFlags, SidLabelValue,
 };
 
 use crate::config::{Args, ConfigOp};
@@ -152,10 +152,15 @@ pub fn build_link_asla(
 /// Algorithm field set to the flex-algo id. Iteration order matches
 /// the BTreeMap (ascending algo id) so the wire byte sequence is
 /// deterministic.
-pub fn build_per_algo_prefix_sids(map: &BTreeMap<u8, SidLabelValue>) -> Vec<IsisSubPrefixSid> {
+pub fn build_per_algo_prefix_sids(
+    map: &BTreeMap<u8, SidLabelValue>,
+    node: bool,
+) -> Vec<IsisSubPrefixSid> {
     map.iter()
         .map(|(&algo, sid)| IsisSubPrefixSid {
-            flags: 0.into(),
+            // A per-algo Prefix-SID on a host prefix is a node-SID too
+            // (RFC 9350 §7 + RFC 8667 §2.1.1): mirror the algo-0 N flag.
+            flags: PrefixSidFlags::new().with_n_flag(node),
             algo: Algo::FlexAlgo(algo),
             sid: sid.clone(),
         })
@@ -343,7 +348,7 @@ mod tests {
     #[test]
     fn build_per_algo_prefix_sids_empty_map_yields_empty_vec() {
         let map: BTreeMap<u8, SidLabelValue> = BTreeMap::new();
-        assert!(build_per_algo_prefix_sids(&map).is_empty());
+        assert!(build_per_algo_prefix_sids(&map, true).is_empty());
     }
 
     #[test]
@@ -351,13 +356,21 @@ mod tests {
         let mut map: BTreeMap<u8, SidLabelValue> = BTreeMap::new();
         map.insert(129, SidLabelValue::Index(1129));
         map.insert(128, SidLabelValue::Index(1128));
-        let sids = build_per_algo_prefix_sids(&map);
+        let sids = build_per_algo_prefix_sids(&map, true);
         assert_eq!(sids.len(), 2);
         // BTreeMap iterates ascending → algo 128 first, 129 second.
         assert_eq!(sids[0].algo, Algo::FlexAlgo(128));
         assert_eq!(sids[0].sid, SidLabelValue::Index(1128));
         assert_eq!(sids[1].algo, Algo::FlexAlgo(129));
         assert_eq!(sids[1].sid, SidLabelValue::Index(1129));
+        // Host-prefix per-algo Prefix-SIDs carry the N (Node-SID) flag;
+        // a non-host prefix leaves it clear.
+        assert!(sids.iter().all(|s| s.flags.n_flag()));
+        assert!(
+            build_per_algo_prefix_sids(&map, false)
+                .iter()
+                .all(|s| !s.flags.n_flag())
+        );
     }
 
     #[test]
@@ -365,7 +378,7 @@ mod tests {
         let mut map: BTreeMap<u8, SidLabelValue> = BTreeMap::new();
         map.insert(128, SidLabelValue::Index(42));
         map.insert(129, SidLabelValue::Label(20128));
-        let sids = build_per_algo_prefix_sids(&map);
+        let sids = build_per_algo_prefix_sids(&map, true);
         assert_eq!(sids[0].sid, SidLabelValue::Index(42));
         assert_eq!(sids[1].sid, SidLabelValue::Label(20128));
     }
@@ -420,7 +433,7 @@ mod tests {
         let mut map: BTreeMap<u8, SidLabelValue> = BTreeMap::new();
         map.insert(128, SidLabelValue::Index(1128));
         map.insert(129, SidLabelValue::Label(20129));
-        let sids = build_per_algo_prefix_sids(&map);
+        let sids = build_per_algo_prefix_sids(&map, true);
         // Wrap each into the entry, then pull back via the parser.
         let entry = isis_packet::IsisTlvExtIpReachEntry {
             metric: 10,

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -1063,7 +1063,11 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
                 if !prefix.addr().is_loopback() {
                     let sub_tlv = if let Some(sid) = &link.config.prefix_sid {
                         let prefix_sid = IsisSubPrefixSid {
-                            flags: 0.into(),
+                            // RFC 8667 §2.1.1: set the N (Node-SID) flag for
+                            // a host prefix (loopback /32) — it identifies
+                            // the originating router. A non-host prefix gets
+                            // a plain Prefix-SID with the flag clear.
+                            flags: PrefixSidFlags::new().with_n_flag(prefix.prefix_len() == 32),
                             algo: Algo::Spf,
                             sid: sid.clone(),
                         };
@@ -1079,6 +1083,7 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
                     // for this prefix from a single TLV.
                     let per_algo_sids = super::flex_algo::build_per_algo_prefix_sids(
                         &link.config.ipv4_flex_algo_prefix_sids,
+                        prefix.prefix_len() == 32,
                     );
                     let has_subs = sub_tlv.is_some() || !per_algo_sids.is_empty();
                     let flags = Ipv4ControlInfo::new()


### PR DESCRIPTION
## Summary

Self-originated Prefix-SIDs were emitted with `flags = 0`, so the **N (Node-SID) flag** was clear on the loopback node-SID. Per RFC 8667 §2.1.1 the N-flag identifies the prefix as the originating router and is set on a host (loopback) prefix.

- **`lsp.rs`** — the algo-0 Prefix-SID now sets N for a `/32` host prefix: `PrefixSidFlags::new().with_n_flag(prefix.prefix_len() == 32)`.
- **`flex_algo.rs`** — `build_per_algo_prefix_sids` takes a `node` arg and mirrors the N-flag onto each per-algo Prefix-SID (RFC 9350 §7); the `lsp.rs` caller passes `prefix.prefix_len() == 32`. A unit test asserts N is set for node prefixes and clear otherwise.

**No leak-path change:** the L1↔L2 leak Prefix-SID construction sites are all test fixtures — there is no real Prefix-SID re-advertisement path in the code.

Combined with the now-merged decoded-flag JSON (#1157), `show` renders it as:
```json
"flags": { "l_flag": false, "v_flag": false, "e_flag": false,
           "p_flag": false, "n_flag": true, "r_flag": false }
```

## Test plan

- `cargo test -p zebra-rs` — 841 passed (incl. the new per-algo N-flag assertions).
- `cargo build -p zebra-rs`, `cargo clippy -p zebra-rs`, `cargo fmt --check` — clean.

Generated with [Claude Code](https://claude.com/claude-code)