### PR TITLE
isis: add prefix-sid no-php option (RFC 8667 P flag)

### DIFF
--- a/bdd/tests/configs/isis_tilfa/s-nophp.yaml
+++ b/bdd/tests/configs/isis_tilfa/s-nophp.yaml
@@ -1,0 +1,40 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: s-n1
+  ipv4:
+    address: 192.168.0.1/30
+- if-name: s-n2
+  ipv4:
+    address: 192.168.0.5/30
+- if-name: s-n3
+  ipv4:
+    address: 192.168.0.9/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: s
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 100
+          no-php:
+    - if-name: s-n1
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: s-n2
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: s-n3
+      ipv4:
+        enable: true
+      metric: 1000
+    is-type: level-2-only
+    segment-routing: mpls
+    fast-reroute: ti-lfa
+    te-router-id: 10.0.0.1

--- a/bdd/tests/features/isis_tilfa.feature
+++ b/bdd/tests/features/isis_tilfa.feature
@@ -104,6 +104,19 @@ Feature: IS-IS TI-LFA fast-reroute over SR-MPLS
     # Primary restored.
     Then ping from "s" to "10.0.0.8" should succeed
 
+  Scenario: no-php sets the P (no-PHP) flag on the local Prefix-SID
+    Given the test topology exists
+    # By default s advertises its loopback Prefix-SID (10.0.0.1/32, SID
+    # 100) with PHP in effect, so the P flag is clear everywhere in the
+    # LSDB — neither Prefix-SID nor Adjacency-SID renders "P:1".
+    Then show command "show isis database detail" in namespace "s" should not contain "P:1"
+    # Re-apply s with `no-php` under the loopback's prefix-sid.
+    When I apply config "s-nophp.yaml" to namespace "s"
+    And I wait 5 seconds
+    # Changing no-php re-originates s's self-LSP with the P (no-PHP) flag
+    # set on its loopback Prefix-SID, so the flag now shows in the LSDB.
+    Then show command "show isis database detail" in namespace "s" should contain "P:1"
+
   Scenario: no-local-prefix-sid suppresses only the local Prefix-SID in the LFIB
     Given the test topology exists
     # By default s installs its own node-SID label (SID 100 -> 16100) as a

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -352,6 +352,10 @@ impl Isis {
             "/router/isis/interface/ipv4/prefix-sid/index",
             link::config_ipv4_prefix_sid_index,
         );
+        self.callback_add(
+            "/router/isis/interface/ipv4/prefix-sid/no-php",
+            link::config_ipv4_prefix_sid_no_php,
+        );
         self.callback_add("/router/isis/interface/metric", link::config_metric);
         self.callback_add("/router/isis/interface/srlg", link::config_srlg);
         self.callback_add("/router/isis/interface/affinity", link::config_affinity);

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -241,6 +241,13 @@ pub struct LinkConfig {
 
     pub prefix_sid: Option<SidLabelValue>,
 
+    /// RFC 8667 §2.1.1 P (no-PHP) flag for the loopback Prefix-SID
+    /// (`.../ipv4/prefix-sid/no-php`, type empty). When set, the
+    /// penultimate hop must not pop this node-SID label — it forwards
+    /// the packet to us with the label intact. Only meaningful when
+    /// `prefix_sid` is configured.
+    pub prefix_sid_no_php: bool,
+
     /// Per-MT metric overrides — populated from
     /// /router/isis/interface/<name>/multi-topology/<id>/metric.
     /// Empty when no per-MT metric is configured; lookup falls back
@@ -1280,6 +1287,20 @@ pub fn config_ipv4_prefix_sid_index(isis: &mut Isis, mut args: Args, op: ConfigO
         link.config.prefix_sid = None;
     }
 
+    Some(())
+}
+
+/// `/router/isis/interface/<ifname>/ipv4/prefix-sid/no-php` (type empty).
+/// Toggles the RFC 8667 P (no-PHP) flag on the loopback Prefix-SID. The
+/// flag lives in the Prefix-SID sub-TLV of the self-LSP, so re-originate
+/// both levels on change to push it to the wire without waiting for the
+/// refresh timer.
+pub fn config_ipv4_prefix_sid_no_php(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let link = isis.links.get_mut_by_name(&name)?;
+    link.config.prefix_sid_no_php = op.is_set();
+    let _ = isis.tx.send(Message::LspOriginate(Level::L1, None));
+    let _ = isis.tx.send(Message::LspOriginate(Level::L2, None));
     Some(())
 }
 

--- a/zebra-rs/src/isis/lsp.rs
+++ b/zebra-rs/src/isis/lsp.rs
@@ -1063,11 +1063,14 @@ pub fn lsp_generate(top: &mut IsisTop, level: Level, seq_floor: Option<u32>) -> 
                 if !prefix.addr().is_loopback() {
                     let sub_tlv = if let Some(sid) = &link.config.prefix_sid {
                         let prefix_sid = IsisSubPrefixSid {
-                            // RFC 8667 §2.1.1: set the N (Node-SID) flag for
-                            // a host prefix (loopback /32) — it identifies
-                            // the originating router. A non-host prefix gets
-                            // a plain Prefix-SID with the flag clear.
-                            flags: PrefixSidFlags::new().with_n_flag(prefix.prefix_len() == 32),
+                            // RFC 8667 §2.1.1: N (Node-SID) flag for a host
+                            // prefix (loopback /32) — it identifies the
+                            // originating router; P (no-PHP) flag when the
+                            // operator asks the penultimate hop to keep the
+                            // node-SID label rather than pop it.
+                            flags: PrefixSidFlags::new()
+                                .with_n_flag(prefix.prefix_len() == 32)
+                                .with_p_flag(link.config.prefix_sid_no_php),
                             algo: Algo::Spf,
                             sid: sid.clone(),
                         };

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1833,6 +1833,15 @@ module config {
               leaf absolute {
                 type uint32;
               }
+              leaf no-php {
+                type empty;
+                description
+                  "Set the P (no-PHP) flag (RFC 8667 §2.1.1) on this
+                   Prefix-SID. When present, the penultimate hop keeps
+                   the node-SID label instead of popping it, so the
+                   label arrives at this node intact. Absent (default)
+                   leaves PHP in effect.";
+              }
             }
             list flex-algo-prefix-sid {
               // Per-Flex-Algorithm Prefix-SID for the IPv4 address(es)


### PR DESCRIPTION
## Summary

Adds a `no-php` option to the IS-IS interface IPv4 Prefix-SID config:

```
router isis interface lo ipv4 prefix-sid {
  index 100;
  no-php;
}
```

- **YANG**: new `no-php` leaf (`type empty`) under the `prefix-sid` container.
- **Origination** (`lsp.rs`): when set, the self-LSP's Prefix-SID sub-TLV carries the RFC 8667 §2.1.1 **P (no-PHP)** flag alongside the existing N flag, so the penultimate hop keeps the node-SID label instead of popping it.
- **Re-origination** (`link.rs`): toggling `no-php` sends `LspOriginate` for L1 and L2 so the flag reaches the wire immediately rather than waiting for the refresh timer.

## Test plan

- New `isis_tilfa` BDD scenario: the P flag is clear by default (`show isis database detail` does not contain `P:1`), and after applying `s-nophp.yaml` the source re-originates its self-LSP and the flag shows as `P:1`.
- `cargo build -p zebra-rs`, `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, and the `yang_load_tests` guard all pass locally.

Generated with [Claude Code](https://claude.com/claude-code)