### PR TITLE
isis: no-PHP Prefix-SID installs a swap ILM, not a pop

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -656,6 +656,51 @@ async fn ilm_local_labels(scoped: &str) -> Vec<u64> {
         .unwrap_or_default()
 }
 
+/// Fetch the `outgoing_label` the ILM entry for `local_label` renders:
+/// "Pop" for a penultimate-hop PHP pop, or the numeric out-label (as a
+/// string) for a swap. Returns None when no ILM matches that incoming
+/// label. Used to distinguish PHP from no-PHP (RFC 8667 P flag) on the
+/// penultimate hop.
+async fn ilm_outgoing_label(scoped: &str, local_label: u64) -> Option<String> {
+    let output = netns::exec_in_netns(scoped, "vtyctl", &["show", "-j", "show mpls ilm"])
+        .await
+        .expect("Failed to run show mpls ilm");
+    let json: Value = serde_json::from_str(&output).expect("Failed to parse ILM JSON");
+    json.get("entries")
+        .and_then(|e| e.as_array())
+        .and_then(|arr| {
+            arr.iter()
+                .find(|e| e.get("local_label").and_then(|l| l.as_u64()) == Some(local_label))
+        })
+        .and_then(|e| e.get("outgoing_label"))
+        .and_then(|l| l.as_str())
+        .map(|s| s.to_string())
+}
+
+#[then(expr = "mpls ilm outgoing label for label {int} in namespace {string} should be {string}")]
+async fn ilm_outgoing_label_should_be(
+    world: &mut World,
+    label: u64,
+    namespace: String,
+    expected: String,
+) {
+    let scoped = world.ns(&namespace);
+    let actual = ilm_outgoing_label(&scoped, label).await;
+    assert_eq!(
+        actual.as_deref(),
+        Some(expected.as_str()),
+        "MPLS ILM in {} outgoing label for {} is {:?}, expected {:?}",
+        scoped,
+        label,
+        actual,
+        expected,
+    );
+    println!(
+        "✓ MPLS ILM in {} label {} -> outgoing {}",
+        scoped, label, expected
+    );
+}
+
 #[then(expr = "mpls ilm in namespace {string} should contain label {int}")]
 async fn ilm_should_contain_label(world: &mut World, namespace: String, label: u64) {
     let scoped = world.ns(&namespace);

--- a/bdd/tests/features/isis_tilfa.feature
+++ b/bdd/tests/features/isis_tilfa.feature
@@ -104,18 +104,24 @@ Feature: IS-IS TI-LFA fast-reroute over SR-MPLS
     # Primary restored.
     Then ping from "s" to "10.0.0.8" should succeed
 
-  Scenario: no-php sets the P (no-PHP) flag on the local Prefix-SID
+  Scenario: no-php sets the P (no-PHP) flag and makes the penultimate hop swap
     Given the test topology exists
     # By default s advertises its loopback Prefix-SID (10.0.0.1/32, SID
     # 100) with PHP in effect, so the P flag is clear everywhere in the
     # LSDB — neither Prefix-SID nor Adjacency-SID renders "P:1".
     Then show command "show isis database detail" in namespace "s" should not contain "P:1"
+    # n1 is the penultimate hop to s's loopback (label 16100); with PHP it
+    # pops the node-SID label before delivering to s.
+    And mpls ilm outgoing label for label 16100 in namespace "n1" should be "Pop"
     # Re-apply s with `no-php` under the loopback's prefix-sid.
     When I apply config "s-nophp.yaml" to namespace "s"
     And I wait 5 seconds
     # Changing no-php re-originates s's self-LSP with the P (no-PHP) flag
     # set on its loopback Prefix-SID, so the flag now shows in the LSDB.
     Then show command "show isis database detail" in namespace "s" should contain "P:1"
+    # And n1 now keeps the label (swap 16100 -> 16100) instead of popping,
+    # so s receives the labeled packet intact.
+    And mpls ilm outgoing label for label 16100 in namespace "n1" should be "16100"
 
   Scenario: no-local-prefix-sid suppresses only the local Prefix-SID in the LFIB
     Given the test topology exists

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -83,6 +83,13 @@ pub struct SpfRoute {
     pub nhops: BTreeMap<Ipv4Addr, SpfNexthop>,
     pub sid: Option<u32>,
     pub prefix_sid: Option<(SidLabelValue, LabelConfig)>,
+    /// RFC 8667 §2.1.1 P (no-PHP) flag copied from the destination's
+    /// received Prefix-SID sub-TLV. When set, the penultimate hop (the
+    /// nexthop whose `adjacency` is true) must keep the node-SID label
+    /// instead of popping it, so `make_ilm_entry` installs a swap rather
+    /// than a pop. Part of `PartialEq` so a P-flag flip re-installs the
+    /// ILM through `table_diff`.
+    pub no_php: bool,
     /// SPF vertex id this route was built from. Set by
     /// `build_rib_from_spf`; used by TI-LFA to join routes with
     /// per-destination repair candidates.
@@ -508,7 +515,10 @@ fn make_ilm_entry(label: u32, ilm: &SpfIlm) -> IlmEntry {
             ifindex_origin: (nhop.ifindex != 0).then_some(nhop.ifindex),
             ..Default::default()
         };
-        if !nhop.adjacency {
+        // Penultimate hop (`adjacency`) pops by default (PHP); a no-PHP
+        // Prefix-SID keeps the label (swap label->label) so the SID owner
+        // receives it intact.
+        if !nhop.adjacency || ilm.no_php {
             uni.mpls_label.push(label);
         }
         return IlmEntry {
@@ -524,7 +534,9 @@ fn make_ilm_entry(label: u32, ilm: &SpfIlm) -> IlmEntry {
             ifindex_origin: (nhop.ifindex != 0).then_some(nhop.ifindex),
             ..Default::default()
         };
-        if !nhop.adjacency {
+        // See the single-nexthop arm: no-PHP keeps the label even on a
+        // penultimate-hop adjacency.
+        if !nhop.adjacency || ilm.no_php {
             uni.mpls_label.push(label);
         }
         multi.nexthops.push(uni);
@@ -575,6 +587,13 @@ pub fn diff_ilm_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffIlm
 pub struct SpfIlm {
     pub nhops: BTreeMap<Ipv4Addr, SpfNexthop>,
     pub ilm_type: IlmType,
+    /// RFC 8667 §2.1.1 P (no-PHP) flag. When true, `make_ilm_entry`
+    /// keeps the label (swap) even for a penultimate-hop (`adjacency`)
+    /// nexthop instead of installing a pop, so the SID owner receives
+    /// the label intact. Only set for remote Prefix-SID ILMs whose
+    /// origin advertised P; adjacency-SID and self-SID ILMs leave it
+    /// false (PHP / local-pop semantics are unchanged).
+    pub no_php: bool,
 }
 
 /// Build ILM table with adjacency labels from SIDs
@@ -620,6 +639,8 @@ fn build_adjacency_ilm(
         let spf_ilm = SpfIlm {
             nhops,
             ilm_type: IlmType::Adjacency(adj_index),
+            // Adjacency-SID semantics are unaffected by the prefix no-PHP flag.
+            no_php: false,
         };
         ilm.insert(label, spf_ilm);
     }
@@ -739,11 +760,19 @@ fn build_rib_from_spf(
                     None
                 };
 
+                // RFC 8667 §2.1.1 P (no-PHP): when the origin asked us
+                // not to pop, the penultimate-hop ILM swaps instead.
+                let no_php = entry
+                    .prefix_sid()
+                    .map(|ps| ps.flags.p_flag())
+                    .unwrap_or(false);
+
                 let route = SpfRoute {
                     metric: nhops.cost + entry.metric,
                     nhops: spf_nhops.clone(),
                     sid,
                     prefix_sid,
+                    no_php,
                     dest_vertex: Some(*node),
                     backup_as_primary: top.config.fast_reroute_backup_as_primary,
                 };
@@ -797,6 +826,8 @@ fn build_rib_from_spf(
                         }
                         if curr.prefix_sid.is_none() && route.prefix_sid.is_some() {
                             curr.prefix_sid = route.prefix_sid;
+                            // Keep no_php aligned with the Prefix-SID we adopt.
+                            curr.no_php = route.no_php;
                         }
                     }
                     // If curr.metric < route.metric, do nothing (keep better route)
@@ -1556,6 +1587,9 @@ fn build_rib_from_flex_algo(
                 nhops: spf_nhops.clone(),
                 sid,
                 prefix_sid,
+                // `peer_algo_sid` stores only the SID value, not the
+                // Prefix-SID flags, so per-algo no-PHP isn't carried yet.
+                no_php: false,
                 dest_vertex: Some(*node),
                 backup_as_primary: top.config.fast_reroute_backup_as_primary,
             };
@@ -1660,6 +1694,9 @@ pub(super) fn update_self_sid_ilm(isis: &mut Isis) {
                 SpfIlm {
                     nhops,
                     ilm_type: IlmType::Node(index),
+                    // Self-SID ILM is always a local pop; no-PHP is about
+                    // the penultimate hop, not the owner.
+                    no_php: false,
                 },
             );
         }
@@ -1693,6 +1730,9 @@ pub fn mpls_route(
             let spf_ilm = SpfIlm {
                 nhops: route.nhops.clone(),
                 ilm_type: IlmType::Node(pfx_index),
+                // Carry the destination's no-PHP request so the
+                // penultimate-hop ILM swaps instead of popping.
+                no_php: route.no_php,
             };
             ilm.insert(sid, spf_ilm);
         }
@@ -1751,6 +1791,7 @@ mod tests {
             nhops: nh,
             sid,
             prefix_sid: None,
+            no_php: false,
             dest_vertex: None,
             backup_as_primary: false,
         }
@@ -2003,6 +2044,7 @@ mod tests {
             nhops,
             sid: None,
             prefix_sid: None,
+            no_php: false,
             dest_vertex: None,
             backup_as_primary: false,
         };
@@ -2037,6 +2079,7 @@ mod tests {
             nhops,
             sid: None,
             prefix_sid: None,
+            no_php: false,
             dest_vertex: None,
             backup_as_primary: false,
         };
@@ -2088,6 +2131,7 @@ mod tests {
             nhops,
             sid: None,
             prefix_sid: None,
+            no_php: false,
             dest_vertex: None,
             backup_as_primary: true,
         };
@@ -2243,5 +2287,39 @@ mod tests {
             make_rib_entry_v6(&route, Level::L2).rsubtype,
             RibSubType::IsisLevel2
         );
+    }
+
+    fn ilm_uni_labels(label: u32, adjacency: bool, no_php: bool) -> Vec<u32> {
+        let mut nhops = BTreeMap::new();
+        nhops.insert(
+            "10.0.0.1".parse::<Ipv4Addr>().unwrap(),
+            SpfNexthop {
+                ifindex: 10,
+                adjacency,
+                sys_id: None,
+                backup: None,
+            },
+        );
+        let ilm = SpfIlm {
+            nhops,
+            ilm_type: IlmType::Node(7),
+            no_php,
+        };
+        let entry = make_ilm_entry(label, &ilm);
+        let rib::Nexthop::Uni(uni) = &entry.nexthop else {
+            panic!("expected Uni, got {:?}", entry.nexthop);
+        };
+        uni.mpls_label.clone()
+    }
+
+    #[test]
+    fn make_ilm_entry_no_php_keeps_label_on_adjacency() {
+        // Penultimate hop (adjacency=true) pops by default: no out-label.
+        assert!(ilm_uni_labels(16800, true, false).is_empty());
+        // ...but a no-PHP Prefix-SID keeps the label (swap label->label).
+        assert_eq!(ilm_uni_labels(16800, true, true), vec![16800]);
+        // Transit hop (adjacency=false) always swaps, no-PHP or not.
+        assert_eq!(ilm_uni_labels(16800, false, false), vec![16800]);
+        assert_eq!(ilm_uni_labels(16800, false, true), vec![16800]);
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to the `no-php` config knob (#1159). The control plane already set the RFC 8667 §2.1.1 **P (no-PHP)** flag on the advertised Prefix-SID; this makes the **forwarding plane** honor it on the receiving side.

When a router is the penultimate hop to a SID owner (the nexthop's `adjacency` is true), `make_ilm_entry` installed a **pop** (PHP) unconditionally. For a Prefix-SID whose origin set P, the penultimate hop must instead **keep the label** (swap label→label) so the owner receives the labeled packet.

- Thread the received P flag: `SpfRoute.no_php` (from `entry.prefix_sid().flags.p_flag()`) → `SpfIlm.no_php` (in `mpls_route`) → `make_ilm_entry` pushes the label when `adjacency && no_php`.
- `no_php` participates in `PartialEq`, so toggling it re-installs the ILM via `table_diff`.
- Adjacency-SID and self-SID ILMs leave `no_php` false — PHP / local-pop semantics unchanged. Flex-algo Prefix-SIDs leave it false (the `peer_algo_sid` map doesn't carry flags yet).

## Test plan

- New unit test `make_ilm_entry_no_php_keeps_label_on_adjacency`: pop by default, swap on no-PHP, transit always swaps.
- Extends the `isis_tilfa` no-php BDD scenario: n1 (penultimate to s) renders `outgoing_label` `Pop` for label 16100 by default and `16100` once s sets `no-php`. Adds a reusable `mpls ilm outgoing label for label N ... should be "..."` step.
- `cargo build/test -p zebra-rs` (21 isis::rib tests green), `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p bdd --no-run` all pass locally.

Generated with [Claude Code](https://claude.com/claude-code)