### PR TITLE
bdd(isis): wait 10s for no-php ILM swap to converge

### DIFF
--- a/bdd/tests/features/isis_tilfa.feature
+++ b/bdd/tests/features/isis_tilfa.feature
@@ -115,7 +115,11 @@ Feature: IS-IS TI-LFA fast-reroute over SR-MPLS
     And mpls ilm outgoing label for label 16100 in namespace "n1" should be "Pop"
     # Re-apply s with `no-php` under the loopback's prefix-sid.
     When I apply config "s-nophp.yaml" to namespace "s"
-    And I wait 5 seconds
+    # 10s, not the usual 5s: the LSP-generation throttle (IOS-XR-style
+    # backoff, 5000ms secondary/maximum) can delay s's re-origination by
+    # up to ~5s, then the change still has to flood to n1 and drive n1's
+    # SPF + ILM rebuild. 5s lands right on that edge and flakes.
+    And I wait 10 seconds
     # Changing no-php re-originates s's self-LSP with the P (no-PHP) flag
     # set on its loopback Prefix-SID, so the flag now shows in the LSDB.
     Then show command "show isis database detail" in namespace "s" should contain "P:1"


### PR DESCRIPTION
## Summary

Fixes a timing flake in the `isis_tilfa` **no-php** scenario added alongside #1160. The scenario asserted that n1 (penultimate hop to s) flips its ILM for label 16100 from `Pop` to a swap (`16100`) within 5s of applying `no-php` to s.

That 5s lands on a timing edge: s's **LSP-generation throttle** (IOS-XR-style exponential backoff, `5000ms` secondary/maximum) can delay re-origination by up to ~5s, after which the change still has to flood to n1 and drive n1's SPF + ILM rebuild. The ILM update arrives at ~5.2s — just after the check.

## Root cause confirmed empirically

A minimal 2-node (s↔n1) repro with the **installed** binary showed:
- before no-php: n1 LSDB `... P:0 ...`, ILM 16100 `outgoing_label: "Pop"`
- after no-php (8s): n1 LSDB `... P:1 ...`, ILM 16100 `outgoing_label: "16100"` ✅

So the #1160 forwarding fix is correct; only the test cadence was too tight. Bumped the wait to 10s with a comment explaining the LSP-gen backoff so it isn't trimmed back later.

## Test plan

- 2-node repro reproduces Pop→swap reliably by ~8s; 10s gives margin for CI load.
- No code change; `.feature`-only.

Generated with [Claude Code](https://claude.com/claude-code)