### PR TITLE
bdd(isis): area-wide hmac-sha-256 authentication scenario for l1_p2p

### DIFF
--- a/bdd/tests/configs/isis_l1_p2p/z1-auth.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z1-auth.yaml
@@ -1,0 +1,56 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+  ipv6:
+    address: 2001:db8:0:ffff::1/128
+- if-name: i2
+  ipv4:
+    address: 10.0.1.1/30
+  ipv6:
+    address: 2001:db8:1::1/64
+- if-name: i6
+  ipv4:
+    address: 10.0.9.1/30
+  ipv6:
+    address: 2001:db8:9::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-1
+    hostname: z1
+    area-password:
+      password: zebra-isis-secret
+      auth-type: hmac-sha-256
+      key-id: 1
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i2
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1
+    - if-name: i6
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 40
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1

--- a/bdd/tests/configs/isis_l1_p2p/z10-auth.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z10-auth.yaml
@@ -1,0 +1,56 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.10/32
+  ipv6:
+    address: 2001:db8:0:ffff::10/128
+- if-name: i9
+  ipv4:
+    address: 10.0.8.2/30
+  ipv6:
+    address: 2001:db8:8::2/64
+- if-name: i5
+  ipv4:
+    address: 10.0.13.2/30
+  ipv6:
+    address: 2001:db8:13::2/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0010.00
+    is-type: level-1
+    hostname: z10
+    area-password:
+      password: zebra-isis-secret
+      auth-type: hmac-sha-256
+      key-id: 1
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i9
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 20
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1
+    - if-name: i5
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 40
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1

--- a/bdd/tests/configs/isis_l1_p2p/z2-auth.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z2-auth.yaml
@@ -1,0 +1,73 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+  ipv6:
+    address: 2001:db8:0:ffff::2/128
+- if-name: i1
+  ipv4:
+    address: 10.0.1.2/30
+  ipv6:
+    address: 2001:db8:1::2/64
+- if-name: i3
+  ipv4:
+    address: 10.0.2.1/30
+  ipv6:
+    address: 2001:db8:2::1/64
+- if-name: i7
+  ipv4:
+    address: 10.0.10.1/30
+  ipv6:
+    address: 2001:db8:10::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-1
+    hostname: z2
+    area-password:
+      password: zebra-isis-secret
+      auth-type: hmac-sha-256
+      key-id: 1
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i1
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1
+    - if-name: i3
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1
+    - if-name: i7
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 30
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1

--- a/bdd/tests/configs/isis_l1_p2p/z3-auth.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z3-auth.yaml
@@ -1,0 +1,73 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+  ipv6:
+    address: 2001:db8:0:ffff::3/128
+- if-name: i2
+  ipv4:
+    address: 10.0.2.2/30
+  ipv6:
+    address: 2001:db8:2::2/64
+- if-name: i4
+  ipv4:
+    address: 10.0.3.1/30
+  ipv6:
+    address: 2001:db8:3::1/64
+- if-name: i8
+  ipv4:
+    address: 10.0.11.1/30
+  ipv6:
+    address: 2001:db8:11::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0003.00
+    is-type: level-1
+    hostname: z3
+    area-password:
+      password: zebra-isis-secret
+      auth-type: hmac-sha-256
+      key-id: 1
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i2
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1
+    - if-name: i4
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1
+    - if-name: i8
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 30
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1

--- a/bdd/tests/configs/isis_l1_p2p/z4-auth.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z4-auth.yaml
@@ -1,0 +1,73 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.4/32
+  ipv6:
+    address: 2001:db8:0:ffff::4/128
+- if-name: i3
+  ipv4:
+    address: 10.0.3.2/30
+  ipv6:
+    address: 2001:db8:3::2/64
+- if-name: i5
+  ipv4:
+    address: 10.0.4.1/30
+  ipv6:
+    address: 2001:db8:4::1/64
+- if-name: i9
+  ipv4:
+    address: 10.0.12.1/30
+  ipv6:
+    address: 2001:db8:12::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0004.00
+    is-type: level-1
+    hostname: z4
+    area-password:
+      password: zebra-isis-secret
+      auth-type: hmac-sha-256
+      key-id: 1
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i3
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1
+    - if-name: i5
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1
+    - if-name: i9
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 30
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1

--- a/bdd/tests/configs/isis_l1_p2p/z5-auth.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z5-auth.yaml
@@ -1,0 +1,56 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.5/32
+  ipv6:
+    address: 2001:db8:0:ffff::5/128
+- if-name: i4
+  ipv4:
+    address: 10.0.4.2/30
+  ipv6:
+    address: 2001:db8:4::2/64
+- if-name: i10
+  ipv4:
+    address: 10.0.13.1/30
+  ipv6:
+    address: 2001:db8:13::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0005.00
+    is-type: level-1
+    hostname: z5
+    area-password:
+      password: zebra-isis-secret
+      auth-type: hmac-sha-256
+      key-id: 1
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i4
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1
+    - if-name: i10
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 40
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1

--- a/bdd/tests/configs/isis_l1_p2p/z6-auth.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z6-auth.yaml
@@ -1,0 +1,56 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.6/32
+  ipv6:
+    address: 2001:db8:0:ffff::6/128
+- if-name: i1
+  ipv4:
+    address: 10.0.9.2/30
+  ipv6:
+    address: 2001:db8:9::2/64
+- if-name: i7
+  ipv4:
+    address: 10.0.5.1/30
+  ipv6:
+    address: 2001:db8:5::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0006.00
+    is-type: level-1
+    hostname: z6
+    area-password:
+      password: zebra-isis-secret
+      auth-type: hmac-sha-256
+      key-id: 1
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i1
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 40
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1
+    - if-name: i7
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 20
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1

--- a/bdd/tests/configs/isis_l1_p2p/z7-auth.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z7-auth.yaml
@@ -1,0 +1,73 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.7/32
+  ipv6:
+    address: 2001:db8:0:ffff::7/128
+- if-name: i6
+  ipv4:
+    address: 10.0.5.2/30
+  ipv6:
+    address: 2001:db8:5::2/64
+- if-name: i8
+  ipv4:
+    address: 10.0.6.1/30
+  ipv6:
+    address: 2001:db8:6::1/64
+- if-name: i2
+  ipv4:
+    address: 10.0.10.2/30
+  ipv6:
+    address: 2001:db8:10::2/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0007.00
+    is-type: level-1
+    hostname: z7
+    area-password:
+      password: zebra-isis-secret
+      auth-type: hmac-sha-256
+      key-id: 1
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i6
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 20
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1
+    - if-name: i8
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 20
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1
+    - if-name: i2
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 30
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1

--- a/bdd/tests/configs/isis_l1_p2p/z8-auth.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z8-auth.yaml
@@ -1,0 +1,73 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.8/32
+  ipv6:
+    address: 2001:db8:0:ffff::8/128
+- if-name: i7
+  ipv4:
+    address: 10.0.6.2/30
+  ipv6:
+    address: 2001:db8:6::2/64
+- if-name: i9
+  ipv4:
+    address: 10.0.7.1/30
+  ipv6:
+    address: 2001:db8:7::1/64
+- if-name: i3
+  ipv4:
+    address: 10.0.11.2/30
+  ipv6:
+    address: 2001:db8:11::2/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0008.00
+    is-type: level-1
+    hostname: z8
+    area-password:
+      password: zebra-isis-secret
+      auth-type: hmac-sha-256
+      key-id: 1
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i7
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 20
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1
+    - if-name: i9
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 20
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1
+    - if-name: i3
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 30
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1

--- a/bdd/tests/configs/isis_l1_p2p/z9-auth.yaml
+++ b/bdd/tests/configs/isis_l1_p2p/z9-auth.yaml
@@ -1,0 +1,73 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.9/32
+  ipv6:
+    address: 2001:db8:0:ffff::9/128
+- if-name: i8
+  ipv4:
+    address: 10.0.7.2/30
+  ipv6:
+    address: 2001:db8:7::2/64
+- if-name: i10
+  ipv4:
+    address: 10.0.8.1/30
+  ipv6:
+    address: 2001:db8:8::1/64
+- if-name: i4
+  ipv4:
+    address: 10.0.12.2/30
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0009.00
+    is-type: level-1
+    hostname: z9
+    area-password:
+      password: zebra-isis-secret
+      auth-type: hmac-sha-256
+      key-id: 1
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i8
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 20
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1
+    - if-name: i10
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 20
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1
+    - if-name: i4
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 30
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        password: zebra-isis-secret
+        auth-type: hmac-sha-256
+        key-id: 1

--- a/bdd/tests/features/isis_l1_p2p.feature
+++ b/bdd/tests/features/isis_l1_p2p.feature
@@ -142,6 +142,41 @@ Feature: IS-IS Level-1-only over an all-point-to-point 10-router ladder
     And show command "show ipv6 route" in namespace "z1" should contain "L1"
     And show command "show ip route" in namespace "z10" should contain "L1"
 
+  Scenario: Area-wide hmac-sha-256 authentication keeps the network converged
+    Given the test topology exists
+    # Re-apply every router with matching hmac-sha-256 keys: an
+    # area-password signs Level-1 LSPs + SNPs (ISO 10589 / RFC 5310) and
+    # per-link hello-authentication signs the IIHs. The same key-id 1 /
+    # secret is used everywhere, so every adjacency, LSP and SNP verifies.
+    # Adding the key to both ends within a few seconds never exceeds the
+    # 30s hold-time, so adjacencies ride through the rollover without a
+    # bounce (a node with no key configured still accepts a signed PDU).
+    When I apply config "z1-auth.yaml" to namespace "z1"
+    And I apply config "z2-auth.yaml" to namespace "z2"
+    And I apply config "z3-auth.yaml" to namespace "z3"
+    And I apply config "z4-auth.yaml" to namespace "z4"
+    And I apply config "z5-auth.yaml" to namespace "z5"
+    And I apply config "z6-auth.yaml" to namespace "z6"
+    And I apply config "z7-auth.yaml" to namespace "z7"
+    And I apply config "z8-auth.yaml" to namespace "z8"
+    And I apply config "z9-auth.yaml" to namespace "z9"
+    And I apply config "z10-auth.yaml" to namespace "z10"
+    And I wait 12 seconds
+    # Auth is active: the instance summary reports the L1 area-password mode.
+    Then show command "show isis summary" in namespace "z1" should contain "Area-password (L1): mode hmac-sha-256"
+    And show command "show isis summary" in namespace "z10" should contain "Area-password (L1): mode hmac-sha-256"
+    # IIH auth verified: z1's two adjacencies (z2 over i2, z6 over i6) are
+    # still Up. The peer renders by dynamic hostname, which only resolves
+    # when the peer's LSP was accepted — so this also proves LSP auth.
+    And show command "show isis neighbor" in namespace "z1" should contain "z2"
+    And show command "show isis neighbor" in namespace "z1" should contain "z6"
+    # LSP + SNP auth verified across the area, so the far loopbacks still
+    # resolve and end-to-end dual-stack forwarding still works.
+    And show command "show isis route" in namespace "z1" should contain "10.0.0.10/32"
+    And ping from "z1" to "10.0.0.10" should succeed
+    And ping from "z1" to "2001:db8:0:ffff::10" should succeed
+    And ping from "z10" to "10.0.0.1" should succeed
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "z1"


### PR DESCRIPTION
## Summary

Adds an authentication scenario to the `isis_l1_p2p` feature. It re-applies all ten ladder routers with matching **hmac-sha-256** keys:

- **area-password** (signs Level-1 LSPs + SNPs, ISO 10589 / RFC 5310)
- per-link **hello-authentication** (signs IIHs)
- shared secret, `key-id 1` everywhere

then verifies the network stays converged with auth active:

- `show isis summary` reports `Area-password (L1): mode hmac-sha-256` (auth configured/active),
- z1's adjacencies to z2/z6 are still **Up** and the peers resolve by dynamic hostname — proving IIH auth (adjacency) **and** LSP auth (hostname TLV accepted),
- the far loopbacks remain in the IS-IS RIB and end-to-end dual-stack forwarding still works — proving LSP + SNP auth verify across the whole area.

Adding the key to both ends of each link within the sequential-apply window never exceeds the 30s hold-time (a node with no key still accepts a signed PDU), so adjacencies ride through the rollover without a bounce.

## Validation

The full 10-node scenario runs under `make isis_l1_p2p` (bdd suite, not gated by CI). Before landing I validated both code paths with a 2-node netns harness against the installed binary:

- **cold start with auth**: adjacency forms Up, `show isis summary` shows the area-password mode, ping to the peer loopback works.
- **re-apply auth onto a live adjacency** (the path this scenario exercises): adjacency stays Up (holdtime kept refreshing, no reset), route persists, ping works.

Reuses existing BDD steps; adds `z{1..10}-auth.yaml`. No Rust changes.

Generated with [Claude Code](https://claude.com/claude-code)