### PR TITLE
bdd(isis): add combined isis make target and sync scenario docs

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -40,6 +40,11 @@ isis_tilfa:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_tilfa"
 
+isis:
+	rm -rf allure-results
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_l1_p2p or @isis_tilfa"
+
 bgp_evpn_capability:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_capability"

--- a/bdd/docs/isis_l1_p2p.md
+++ b/bdd/docs/isis_l1_p2p.md
@@ -41,4 +41,5 @@ z4<->z10.
 | Primary path fails over to a different interface (z1 -> z5) | |
 | The two deliberate ECMP diamonds resolve (z2->z6 and z4->z10) | |
 | IS-IS stamps the level into the central RIB | |
+| Area-wide hmac-sha-256 authentication keeps the network converged | |
 | Teardown topology | |

--- a/bdd/docs/isis_tilfa.md
+++ b/bdd/docs/isis_tilfa.md
@@ -44,6 +44,7 @@ through the r-plane rather than a plain loop-free alternate.
 | SR-MPLS labels and a TI-LFA repair are installed on the source | |
 | Source reaches the destination over the primary path | |
 | Fast-reroute survives the primary link failure (s-n1) | |
+| no-php sets the P (no-PHP) flag and makes the penultimate hop swap | |
 | no-local-prefix-sid suppresses only the local Prefix-SID in the LFIB | |
 | Deleting segment-routing mpls clears all MPLS ILM entries | |
 | Teardown topology | |


### PR DESCRIPTION
## Summary
- Add an `isis` target to `bdd/Makefile` that runs both the `@isis_l1_p2p` and `@isis_tilfa` suites in a single invocation (clears `allure-results` first).
- Regenerate the two IS-IS feature docs so their scenario tables include the recently added scenarios:
  - `isis_l1_p2p`: *Area-wide hmac-sha-256 authentication keeps the network converged*
  - `isis_tilfa`: *no-php sets the P (no-PHP) flag and makes the penultimate hop swap*

## Test plan
- Docs-and-Makefile only; no Rust changes, so no build/fmt/clippy impact.
- `make -C bdd isis` runs `@isis_l1_p2p or @isis_tilfa` end-to-end (not part of CI; run locally as needed).

Generated with [Claude Code](https://claude.com/claude-code)