### PR TITLE
ospf: add `clear ospf neighbor [<addr>]` operational command

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -536,6 +536,33 @@ impl<V: OspfVersion> Ospf<V> {
         ));
     }
 
+    /// Reset OSPF adjacencies on operator request (`clear ospf
+    /// neighbor [<addr>]`). `None` resets every neighbor on every
+    /// link; `Some(a)` resets only the neighbor whose interface
+    /// address is `a` — for v2 that address is the `OspfLink.nbrs`
+    /// map key, so the match is a direct key comparison. Each reset
+    /// drives the neighbor down through the dead-timer
+    /// (`InactivityTimer`) path — the same teardown the hold-timer
+    /// and BFD-down (RFC 5882 §5) use — so Router-LSA re-origination
+    /// and SPF follow naturally.
+    fn clear_neighbor(&self, addr: Option<Ipv4Addr>) {
+        let mut targets: Vec<(u32, Ipv4Addr)> = Vec::new();
+        for (ifindex, link) in self.links.iter() {
+            for nbr_addr in link.nbrs.keys() {
+                if addr.is_none_or(|a| a == *nbr_addr) {
+                    targets.push((*ifindex, *nbr_addr));
+                }
+            }
+        }
+        for (ifindex, nbr_addr) in targets {
+            let _ = self.tx.send(Message::Nfsm(
+                ifindex,
+                nbr_addr,
+                super::nfsm::NfsmEvent::InactivityTimer,
+            ));
+        }
+    }
+
     /// Record a rewritten per-VRF config line (default instance only).
     /// Appends to the VRF's replay log and, if its child is already
     /// running, forwards the line live to the child's config inbox.
@@ -956,7 +983,7 @@ impl Ospf<Ospfv2> {
             return;
         }
 
-        let (path, args) = path_from_command(&msg.paths);
+        let (path, mut args) = path_from_command(&msg.paths);
 
         // Clear ops bypass the YANG callback table — they map
         // straight to runtime side-effects (kick SPF, drop a peer,
@@ -978,6 +1005,12 @@ impl Ospf<Ospfv2> {
                 self.gr_restart_abort();
             } else if path == "/clear/ospf/graceful-restart/commit" {
                 let _ = self.gr_restart_commit();
+            } else if path == "/clear/ospf/neighbor" {
+                // `clear ospf neighbor [<addr>]` — the bare form
+                // resets every adjacency; a trailing address resets
+                // only the neighbor at that interface IP (the v2
+                // `nbrs` map key). Empty args -> v4addr() is None.
+                self.clear_neighbor(args.v4addr());
             }
             return;
         }

--- a/zebra-rs/yang/configure.yang
+++ b/zebra-rs/yang/configure.yang
@@ -145,6 +145,29 @@ module configure {
       leaf spf {
         type empty;
       }
+      // Juniper-style `clear ospf neighbor [<addr>]`. The bare
+      // (presence) form resets every OSPFv2 adjacency on the
+      // instance; with an address it resets only the neighbor whose
+      // interface (source) IPv4 address matches -- for v2 that
+      // address is the `OspfLink.nbrs` map key (RFC 2328), so it is
+      // a direct lookup with no scan.
+      //
+      // Modeled as a presence list so the node is a valid terminal
+      // on its own (-> reset all) yet still accepts a positional key
+      // (-> reset one), the same shape as `show bgp ipv4 neighbors
+      // [<addr>]`. No `all` keyword is needed (unlike
+      // zebra-bgp-clear.yang) because the bare presence already
+      // carries the "every neighbor" meaning.
+      list neighbor {
+        ext:help "Reset OSPF adjacencies (bare resets all)";
+        ext:presence "Reset every OSPF adjacency";
+        key address;
+        leaf address {
+          ext:help "Reset only the neighbor at this interface address";
+          ext:dynamic "ospf:neighbor";
+          type inet:ipv4-address;
+        }
+      }
       container checkpoint {
         // Debug entry for the graceful-restart checkpoint storage
         // layer (Phase 5b). Becomes operator-facing once the


### PR DESCRIPTION
## Summary
Adds a Juniper-style operational command to reset OSPFv2 adjacencies on demand:

```
clear ospf neighbor            # reset every adjacency
clear ospf neighbor 10.0.1.2   # reset only the neighbor at that interface IP
```

- **YANG** (`configure.yang`): a presence `list neighbor` under `/clear/ospf`. Presence makes the bare node a valid terminal (→ reset all) while the `address` key still accepts a positional value (→ reset one) — the same shape as `show bgp ipv4 neighbors [<addr>]`, leaning on the parser's existing `YangMatch::Key && list_presence` completeness rule. No `all` keyword needed.
- **Dispatch** (`ospf/inst.rs`): the clear broadcast reaches the v2 instance as `ConfigOp::Clear`; `Ospf<Ospfv2>::process_cm_msg` gains a `/clear/ospf/neighbor` arm that reads the optional address from `args` and calls the new generic `Ospf::<V>::clear_neighbor`. The address is the `OspfLink.nbrs` map key for v2 (RFC 2328 source IP), so selection is a direct key comparison — no scan.
- **Teardown**: each target is driven down via the existing dead-timer (`InactivityTimer`) path the hold-timer and BFD-down (RFC 5882 §5) already use, so Router-LSA re-origination and SPF follow naturally.
- `ext:dynamic "ospf:neighbor"` is wired for future tab-completion; OSPF has no `ConfigOp::Completion` handler yet, so completion is a safe no-op (empty list) until that lands. `clear_neighbor` is generic over `OspfVersion` so OSPFv3 can reuse it.

## Test plan
- `cargo build -p zebra-rs` — clean
- `cargo fmt --all` — applied
- `cargo clippy --workspace --all-targets` — clean
- `cargo test -p zebra-rs --bin zebra-rs ospf` — 48/48 pass
- `cargo test -p zebra-rs --bin zebra-rs yang_load_tests` — 2/2 pass (schema loads)
- `Completion`-op path traced to a safe empty no-op (no hang/panic)

## Deferred (not blocking)
- `ospf:neighbor` tab-completion handler (pure-Rust add, no YANG change)
- OSPFv3 `clear ospfv3 neighbor <router-id>` (`clear_neighbor` already generic)
- BDD scenario (CI does not run the bdd suite)

Generated with [Claude Code](https://claude.com/claude-code)