### PR TITLE
ospf: answer ospf:neighbor tab-completion for clear ospf neighbor

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -563,6 +563,19 @@ impl<V: OspfVersion> Ospf<V> {
         }
     }
 
+    /// Candidate completions for `ext:dynamic "ospf:neighbor"` — the
+    /// current neighbor addresses (the `OspfLink.nbrs` keys; for v2
+    /// the neighbor's interface source IP). Feeds tab-completion of
+    /// `clear ospf neighbor <addr>`. Deduped + sorted via `BTreeSet`
+    /// since the same address could appear on more than one link.
+    fn neighbor_comps(&self) -> Vec<String> {
+        let mut addrs: BTreeSet<Ipv4Addr> = BTreeSet::new();
+        for link in self.links.values() {
+            addrs.extend(link.nbrs.keys().copied());
+        }
+        addrs.iter().map(|addr| addr.to_string()).collect()
+    }
+
     /// Record a rewritten per-VRF config line (default instance only).
     /// Appends to the VRF's replay log and, if its child is already
     /// running, forwards the line live to the child's config inbox.
@@ -971,6 +984,22 @@ impl Ospf<Ospfv2> {
         if msg.op == ConfigOp::CommitEnd {
             self.vrf_commit_end();
             self.commit_flex_algo_tables();
+            return;
+        }
+
+        // Dynamic tab-completion (`ext:dynamic "ospf:<handler>"`): the
+        // manager sends the handler name as the sole path segment and
+        // waits on `msg.resp` for the candidate list. Answer directly —
+        // these are instance-level, not VRF-scoped.
+        if msg.op == ConfigOp::Completion {
+            let (path, _) = path_from_command(&msg.paths);
+            let comps = match path.as_str() {
+                "/neighbor" => self.neighbor_comps(),
+                _ => Vec::new(),
+            };
+            if let Some(resp) = msg.resp {
+                let _ = resp.send(comps);
+            }
             return;
         }
 


### PR DESCRIPTION
## Summary
Wires up the `ospf:neighbor` dynamic tab-completion that the `clear ospf neighbor <addr>` node (added in #1164) already references. OSPFv2 had no `ConfigOp::Completion` responder, so TAB returned nothing (a safe but empty no-op); now it suggests the live neighbor addresses, mirroring BGP's `peer_comps()`.

- `Ospf<Ospfv2>::process_cm_msg` gains a `ConfigOp::Completion` branch (before the VRF redirect, since completion is instance-level) that maps the manager's synthetic handler path `/neighbor` → `neighbor_comps()` and replies on `msg.resp`. Unknown handlers return an empty list; a dropped receiver is ignored (no `unwrap`).
- New generic `Ospf::<V>::neighbor_comps` collects current neighbor addresses (the `OspfLink.nbrs` keys — for v2 the neighbor interface source IP), deduped + sorted via `BTreeSet`. Generic over `OspfVersion` so a future `ospfv3:neighbor` dynamic can reuse it.

Typing an address still validates via `type inet:ipv4-address` independent of the suggestion list; this only adds TAB hints.

## Test plan
- `cargo build -p zebra-rs` — clean
- `cargo fmt --all` — applied
- `cargo clippy --workspace --all-targets` — clean
- `cargo test -p zebra-rs --bin zebra-rs ospf` — 48/48 pass
- `cargo test -p zebra-rs --bin zebra-rs yang_load_tests` — 2/2 pass

Generated with [Claude Code](https://claude.com/claude-code)