### PR TITLE
bdd: add clear ospf neighbor scenario + book docs

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -40,6 +40,10 @@ isis_tilfa:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_tilfa"
 
+ospf_clear_neighbor:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@ospf_clear_neighbor"
+
 isis:
 	rm -rf allure-results
 	mkdir -p allure-results
@@ -88,4 +92,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation isis_l1_p2p isis_tilfa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation isis_l1_p2p isis_tilfa ospf_clear_neighbor bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE

--- a/bdd/docs/ospf_clear_neighbor.md
+++ b/bdd/docs/ospf_clear_neighbor.md
@@ -1,0 +1,29 @@
+# clear ospf neighbor resets an OSPFv2 adjacency
+
+## Overview
+
+As a network operator
+I want `clear ospf neighbor [<router-id>]` to tear an OSPFv2
+adjacency down so it re-forms from scratch — exactly like a
+dead-timer timeout — so I can force a fresh database exchange on
+demand without restarting the daemon.
+Two zebra-rs routers, o1 and o2, are joined by one point-to-point
+link and each advertise a /32 loopback into area 0.0.0.0. Once the
+adjacency is Full and the loopbacks are mutually reachable, clearing
+the neighbor must drop and rebuild the adjacency. The neighbor's
+up-time resetting is the deterministic proof that the instance was
+destroyed and re-learned rather than left untouched: had the clear
+been a no-op the up-time would keep climbing past the wait budget.
+
+## Test Topology
+
+```
+    o1 (10.0.0.1) --- 10.0.12.0/30 --- o2 (10.0.0.2)
+       eth1  point-to-point  eth2
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| clear ospf neighbor destroys and re-forms the adjacency | |

--- a/bdd/tests/configs/ospf_clear_neighbor/o1.yaml
+++ b/bdd/tests/configs/ospf_clear_neighbor/o1.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: eth1
+  ipv4:
+    address: 10.0.12.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: eth1
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospf_clear_neighbor/o2.yaml
+++ b/bdd/tests/configs/ospf_clear_neighbor/o2.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: eth2
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: eth2
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -369,6 +369,19 @@ async fn clear_bgp_neighbor(world: &mut World, namespace: String, neighbor: Stri
     );
 }
 
+/// Run an operational command (anything `vtyctl clear "<cmd>"` accepts —
+/// the `clear ...` surface) inside a namespace. Generic sibling of the
+/// BGP-specific `clear_bgp_neighbor`; used by the OSPF feature to issue
+/// `clear ospf neighbor [<router-id>]`.
+#[when(expr = "I run {string} in namespace {string}")]
+async fn run_exec_command(world: &mut World, command: String, namespace: String) {
+    let scoped = world.ns(&namespace);
+    netns::exec_in_netns(&scoped, "vtyctl", &["clear", &command])
+        .await
+        .unwrap_or_else(|e| panic!("Failed to run '{}' in {}: {}", command, scoped, e));
+    println!("✓ Ran '{}' in namespace {}", command, scoped);
+}
+
 #[when(expr = "I delete namespace {string}")]
 async fn delete_namespace(world: &mut World, namespace: String) {
     let scoped = world.ns(&namespace);
@@ -634,6 +647,90 @@ async fn show_command_not_contains(
     println!(
         "✓ show '{}' in namespace {} does not contain '{}'",
         show_cmd, scoped, needle
+    );
+}
+
+/// Parse the OSPF `show ip ospf neighbor` up-time string (the
+/// `format_uptime` output: "0m08s", "1h02m03s", "1d02h03m") into whole
+/// seconds. Any hours/days component is far past the thresholds this
+/// test uses, so the coarse conversion is sufficient.
+fn parse_ospf_uptime(s: &str) -> Option<u64> {
+    let mut secs = 0u64;
+    let mut num = String::new();
+    for ch in s.chars() {
+        if ch.is_ascii_digit() {
+            num.push(ch);
+        } else {
+            let v: u64 = num.parse().ok()?;
+            num.clear();
+            secs += match ch {
+                'd' => v * 86400,
+                'h' => v * 3600,
+                'm' => v * 60,
+                's' => v,
+                _ => return None,
+            };
+        }
+    }
+    Some(secs)
+}
+
+/// Assert an OSPFv2 neighbor's up-time is below a bound, read from
+/// `vtyctl show -j "show ip ospf neighbor"`. A freshly (re)formed
+/// adjacency has a small up-time; this is the deterministic proof that
+/// `clear ospf neighbor` actually destroyed and re-learned the
+/// neighbor instance rather than leaving it untouched (whose up-time
+/// would keep climbing past the bound).
+#[then(expr = "ospf neighbor {string} uptime in namespace {string} should be under {int} seconds")]
+async fn ospf_neighbor_uptime_under(
+    world: &mut World,
+    neighbor_id: String,
+    namespace: String,
+    max_secs: u64,
+) {
+    let scoped = world.ns(&namespace);
+    let output = netns::exec_in_netns(&scoped, "vtyctl", &["show", "-j", "show ip ospf neighbor"])
+        .await
+        .expect("Failed to run show ip ospf neighbor");
+    let nbrs: serde_json::Value = serde_json::from_str(&output).unwrap_or_else(|e| {
+        panic!(
+            "show ip ospf neighbor -j in {} was not valid JSON: {}\nfull output:\n{}",
+            scoped, e, output
+        )
+    });
+    let arr = nbrs.as_array().unwrap_or_else(|| {
+        panic!(
+            "ospf neighbor JSON in {} was not an array:\n{}",
+            scoped, output
+        )
+    });
+    let nbr = arr
+        .iter()
+        .find(|n| n.get("neighbor_id").and_then(|v| v.as_str()) == Some(neighbor_id.as_str()))
+        .unwrap_or_else(|| {
+            panic!(
+                "neighbor {} not present in {} ospf neighbor table:\n{}",
+                neighbor_id, scoped, output
+            )
+        });
+    let up = nbr
+        .get("up_time")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("neighbor {} has no up_time field:\n{}", neighbor_id, output));
+    let secs = parse_ospf_uptime(up)
+        .unwrap_or_else(|| panic!("could not parse neighbor {} up_time {:?}", neighbor_id, up));
+    assert!(
+        secs < max_secs,
+        "neighbor {} up-time {} ({}s) in {} was not under {}s — clear did not reset the adjacency",
+        neighbor_id,
+        up,
+        secs,
+        scoped,
+        max_secs
+    );
+    println!(
+        "✓ neighbor {} up-time {} (<{}s) in {}",
+        neighbor_id, up, max_secs, scoped
     );
 }
 

--- a/bdd/tests/features/ospf_clear_neighbor.feature
+++ b/bdd/tests/features/ospf_clear_neighbor.feature
@@ -1,0 +1,69 @@
+@serial
+@ospf_clear_neighbor
+Feature: clear ospf neighbor resets an OSPFv2 adjacency
+  As a network operator
+  I want `clear ospf neighbor [<router-id>]` to tear an OSPFv2
+  adjacency down so it re-forms from scratch — exactly like a
+  dead-timer timeout — so I can force a fresh database exchange on
+  demand without restarting the daemon.
+
+  Two zebra-rs routers, o1 and o2, are joined by one point-to-point
+  link and each advertise a /32 loopback into area 0.0.0.0. Once the
+  adjacency is Full and the loopbacks are mutually reachable, clearing
+  the neighbor must drop and rebuild the adjacency. The neighbor's
+  up-time resetting is the deterministic proof that the instance was
+  destroyed and re-learned rather than left untouched: had the clear
+  been a no-op the up-time would keep climbing past the wait budget.
+
+  Test Topology:
+  ```
+    o1 (10.0.0.1) --- 10.0.12.0/30 --- o2 (10.0.0.2)
+       eth1  point-to-point  eth2
+  ```
+
+  Scenario: clear ospf neighbor destroys and re-forms the adjacency
+    Given a clean test environment
+    When I create namespace "o1"
+    And I create namespace "o2"
+    And I connect namespace "o1" interface "eth1" to namespace "o2" interface "eth2"
+    And I start zebra-rs in namespace "o1"
+    And I start zebra-rs in namespace "o2"
+    And I apply config "o1.yaml" to namespace "o1"
+    And I apply config "o2.yaml" to namespace "o2"
+    # First Hello (<=10s) + DBD exchange settles well inside this; the
+    # 30s also ages the adjacency so the up-time proof below has a wide
+    # margin (a never-cleared neighbor would read ~55s at the check).
+    And I wait 30 seconds
+    # The adjacency is Full and OSPF has installed the route to o2's
+    # loopback, so the /32 is reachable end-to-end.
+    Then show command "show ip ospf neighbor" in namespace "o1" should contain "10.0.0.2"
+    And show command "show ip ospf neighbor" in namespace "o1" should contain "Full"
+    And ping from "o1" to "10.0.0.2" should succeed
+
+    # Clear the specific neighbor by its Router-ID (the "Neighbor ID"
+    # column), then let it renegotiate (next Hello <=10s + DBD, plus a
+    # margin for the SPF / LSA coalescing timers).
+    When I run "clear ospf neighbor 10.0.0.2" in namespace "o1"
+    And I wait 25 seconds
+    # It rebuilt: Full again and the loopback is reachable ...
+    Then show command "show ip ospf neighbor" in namespace "o1" should contain "Full"
+    And ping from "o1" to "10.0.0.2" should succeed
+    # ... and the up-time reset to under 35s. Had the clear been a
+    # no-op the neighbor would have aged ~55s by now (30 + 25 since it
+    # first came up), so this bound only holds if the instance was
+    # destroyed and re-learned — the deterministic teardown proof.
+    And ospf neighbor "10.0.0.2" uptime in namespace "o1" should be under 35 seconds
+
+    # The bare form (no Router-ID) clears every adjacency the same way
+    # (same kill path, id = None); verify it too recovers end-to-end.
+    When I run "clear ospf neighbor" in namespace "o1"
+    And I wait 25 seconds
+    Then show command "show ip ospf neighbor" in namespace "o1" should contain "Full"
+    And ping from "o1" to "10.0.0.2" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "o1"
+    And I stop zebra-rs in namespace "o2"
+    And I delete namespace "o1"
+    And I delete namespace "o2"
+    Then the test environment should be clean

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -28,6 +28,7 @@
 - [OSPFv2](ch-08-00-ospf.md)
   - [Configuration](ch-08-01-ospf-configuration.md)
   - [BFD](ch-08-02-ospf-bfd.md)
+  - [Clearing OSPF State](ch-08-03-ospf-clear.md)
 
 ## Failure Detection
 

--- a/book/src/ch-08-03-ospf-clear.md
+++ b/book/src/ch-08-03-ospf-clear.md
@@ -1,0 +1,96 @@
+# Clearing OSPF State
+
+OSPF exposes a small set of operational `clear` commands that act on
+the running instance without touching the configuration. They live
+under the `clear` tree (`clear ospf …` for OSPFv2, `clear ospfv3 …`
+for OSPFv3) and take effect immediately — there is no `commit`.
+
+## Resetting adjacencies — `clear ospf neighbor`
+
+```
+clear ospf   neighbor [<router-id>]
+clear ospfv3 neighbor [<router-id>]
+```
+
+Tear an OSPF adjacency down so it re-forms from scratch. This is the
+operator-driven equivalent of a dead-timer expiry: the neighbor
+instance is **destroyed**, not merely nudged. Because a live peer keeps
+sending Hellos, the adjacency is re-learned on the next Hello and walks
+the full state machine back up — `Down → Init → ExStart → Exchange →
+Loading → Full` — performing a fresh Database-Description exchange.
+Use it to force a clean re-synchronisation after a suspected
+database or SPF anomaly without restarting the daemon.
+
+The argument is the neighbor's **Router-ID** — the value shown in the
+`Neighbor ID` column of `show ip ospf neighbor` — *not* the neighbor's
+interface address:
+
+```
+zebra# show ip ospf neighbor
+Neighbor ID     Pri State      Up Time   Dead Time Address       Interface ...
+10.0.0.2         64 Full/  -   2m13s     38s       10.0.12.2     eth1 ...
+
+zebra# clear ospf neighbor 10.0.0.2
+```
+
+With **no Router-ID**, the bare form clears *every* adjacency on the
+instance:
+
+```
+clear ospf neighbor          # reset all OSPFv2 adjacencies
+```
+
+The OSPFv3 commands behave identically; for OSPFv3 the Router-ID is the
+neighbor identity shown by `show ipv6 ospf neighbor` (RFC 5340 §10
+keys neighbors by Router-ID rather than by interface address).
+
+What a clear triggers, as a side effect of the adjacency dropping and
+re-forming:
+
+- the local Router-LSA (and, on a DR, the Network-LSA) is re-originated
+  without then with the adjacency,
+- SPF re-runs, so routes learned through the neighbor are withdrawn and
+  re-installed as it bounces,
+- the DR/BDR election re-runs on multi-access links,
+- any BFD session bound to the neighbor is released and re-subscribed.
+
+Tab-completion offers the live neighbor Router-IDs:
+
+```
+zebra# clear ospf neighbor <TAB>
+10.0.0.2
+```
+
+> **Note** — clearing a neighbor is briefly traffic-affecting: routes
+> reachable only through that adjacency are withdrawn until it returns
+> to `Full`. The neighbor's up-time resets, which is the simplest way
+> to confirm the reset actually happened.
+
+## Forcing an SPF run — `clear ospf spf`
+
+```
+clear ospf   spf
+clear ospfv3 spf
+```
+
+Force an immediate shortest-path-first recomputation for every attached
+area instead of waiting for the next LSDB event or the SPF coalescing
+timer. This recomputes routes from the **current** database; it does
+not re-exchange anything with neighbours. It is useful when manual
+diagnosis suspects a stale route after an LSDB-side change.
+
+## Graceful restart — `clear ospf graceful-restart`
+
+```
+clear ospf graceful-restart begin
+clear ospf graceful-restart commit
+clear ospf graceful-restart abort
+```
+
+Stage, commit, or unstage a planned RFC 3623 graceful restart of the
+local router. `begin` floods Grace-LSAs and marks the instance
+restart-capable; `commit` writes the restart checkpoint, drains, and
+exits the process for a supervisor to restart it (kernel routes
+survive); `abort` walks the staging back without exiting. These are
+covered in the graceful-restart material; they are listed here only
+because they share the `clear ospf` tree.


### PR DESCRIPTION
## Summary
Adds a BDD scenario exercising `clear ospf neighbor` and documents the `clear ospf` / `clear ospfv3` operational commands in the book.

### BDD (`@ospf_clear_neighbor`)
- Two zebra-rs routers (o1, o2) over a point-to-point link, each advertising a /32 loopback into area 0.0.0.0. Once Full, the scenario issues `clear ospf neighbor 10.0.0.2` (by Router-ID) and the bare `clear ospf neighbor`, and verifies the adjacency drops and re-forms (Full again + loopback still pingable).
- **Deterministic teardown proof** via the neighbor's up-time: after a clear+reform it reads well under the wait budget, whereas a no-op clear would keep climbing — so the bound only holds if the instance was actually destroyed and re-learned. Wait/threshold values (30s/25s/35s) are sized for comfortable margins on both sides.
- Two reusable steps in `cucumber.rs`: `I run {string} in namespace {string}` (issue any `clear …` command) and `ospf neighbor {string} uptime in namespace {string} should be under {int} seconds` (parses `show ip ospf neighbor -j`).
- Plus o1/o2 configs, the `ospf_clear_neighbor` make target, and the generated docs entry.

### Book
- New OSPFv2 subsection "Clearing OSPF State" (`ch-08-03-ospf-clear.md`, wired into `SUMMARY.md`): `clear ospf/ospfv3 neighbor [<router-id>]` (destroy-like-timeout semantics, Router-ID keying, bare = all, side effects, tab-completion), `clear ospf/ospfv3 spf`, and the `graceful-restart` subtree.

## Test plan
- `cargo test -p bdd --test cucumber --no-run` — compiles (new steps + feature wired)
- `cargo clippy -p bdd --all-targets` — clean
- `cargo fmt --all` — applied
- `mdbook build book` — clean (new page + SUMMARY link resolve)
- OSPF config validated against a live single-node netns run (config accepted, OSPF runs P2P on eth1 in area 0, addresses assigned by zebra-rs). CI does not run the bdd suite; exercise locally with `make -C bdd ospf_clear_neighbor` (requires a current installed binary).

Generated with [Claude Code](https://claude.com/claude-code)