### PR TITLE
bdd(isis): IPv4 LSP fragmentation scenario (lsp-mtu 400 & 1500)

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -32,6 +32,10 @@ isis_fragmentation:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_fragmentation"
 
+isis_fragmentation_ipv4:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_fragmentation_ipv4"
+
 isis_l1_p2p:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_l1_p2p"
@@ -96,4 +100,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation isis_l1_p2p isis_tilfa isis_l1l2 ospf_clear_neighbor bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation isis_fragmentation_ipv4 isis_l1_p2p isis_tilfa isis_l1l2 ospf_clear_neighbor bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE

--- a/bdd/docs/isis_fragmentation_ipv4.md
+++ b/bdd/docs/isis_fragmentation_ipv4.md
@@ -1,0 +1,55 @@
+# IS-IS LSP fragmentation (IPv4) at lsp-mtu-size 400 and 1500
+
+## Overview
+
+As a network operator
+I want zebra-rs to fragment its self-originated LSP across multiple
+PDUs when the IPv4 TLV 135 (Extended IP Reachability) content exceeds
+`lsp-mtu-size`, deliver every fragment to peers via the standard
+flooding path, and have the receiver correctly merge those fragments
+back into a single logical origin so SPF can still install routes to
+the originator's loopback.
+This is verified at two LSP MTUs over one topology: first a tight
+400-byte cap (fragmentation with only 60 networks), then — after a
+live reconfiguration of z1 — the standard 1500-byte Ethernet MTU
+(fragmentation needs 200 networks), confirming both the small-MTU
+path and that a runtime lsp-mtu-size change re-fragments correctly.
+
+## Test Topology
+
+```
+  ┌────────────────────────────────────────┐
+  │                  br0                   │
+  └────────────┬───────────────┬───────────┘
+               │               │
+         10.0.1.1/24      10.0.1.2/24
+            (vz1ns)             (vz2ns)
+          ┌────┴────┐     ┌────┴────┐
+          │   z1    │     │   z2    │
+          │ 400→1500│     │         │
+          │ 60→200  │     │         │
+          └─────────┘     └─────────┘
+     lo: 10.255.0.1/32     lo: 10.255.0.2/32
+```
+
+## Config Files
+
+- z1-1.yaml: lsp-mtu-size 400 + 60 IPv4 /32 networks. Each /32 entry
+- z1-2.yaml: lsp-mtu-size 1500 + 200 IPv4 /32 networks. At the standard
+- z2-1.yaml: default config; verifies the receiver-side rebuild from a
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup fragmentation topology at lsp-mtu-size 400 | |
+| MTU 400 — lsp-mtu-size shows up in show isis summary | |
+| MTU 400 — z2 observes z1's self-LSP as multiple fragments | |
+| MTU 400 — z2 reaches z1's loopback despite z1's self-LSP being fragmented | |
+| MTU 400 — z2 installs a /32 network carried in one of z1's higher fragments | |
+| Reconfigure z1 to the standard 1500-byte LSP MTU | |
+| MTU 1500 — lsp-mtu-size shows up in show isis summary | |
+| MTU 1500 — z2 still observes z1's self-LSP as multiple fragments | |
+| MTU 1500 — z2 reaches z1's loopback despite z1's self-LSP being fragmented | |
+| MTU 1500 — z2 installs a /32 network carried in one of z1's higher fragments | |
+| Teardown topology | |

--- a/bdd/tests/configs/isis_fragmentation_ipv4/z1-1.yaml
+++ b/bdd/tests/configs/isis_fragmentation_ipv4/z1-1.yaml
@@ -1,0 +1,93 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.1/32
+- if-name: vz1ns
+  ipv4:
+    address: 10.0.1.1/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    # Force fragmentation with a tight LSP MTU: a 400-byte cap on each
+    # LSP PDU leaves a 373-byte TLV budget (lsp-mtu-size - 27 bytes of
+    # PDU overhead). 60 /32 networks at 9 wire bytes each (RFC 5305: 4
+    # metric + 1 control/flags + 4 prefix bytes) -> ~540 bytes of TLV
+    # 135 value, overflowing one fragment. The splitter caps each TLV
+    # 135 instance at the 255-byte length-field ceiling (3 instances
+    # here); the packer then bins those instances into LSP fragments,
+    # so z1's self-LSP spans >= 2 fragments.
+    lsp-mtu-size: 400
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 100.64.0.1/32
+      - prefix: 100.64.0.2/32
+      - prefix: 100.64.0.3/32
+      - prefix: 100.64.0.4/32
+      - prefix: 100.64.0.5/32
+      - prefix: 100.64.0.6/32
+      - prefix: 100.64.0.7/32
+      - prefix: 100.64.0.8/32
+      - prefix: 100.64.0.9/32
+      - prefix: 100.64.0.10/32
+      - prefix: 100.64.0.11/32
+      - prefix: 100.64.0.12/32
+      - prefix: 100.64.0.13/32
+      - prefix: 100.64.0.14/32
+      - prefix: 100.64.0.15/32
+      - prefix: 100.64.0.16/32
+      - prefix: 100.64.0.17/32
+      - prefix: 100.64.0.18/32
+      - prefix: 100.64.0.19/32
+      - prefix: 100.64.0.20/32
+      - prefix: 100.64.0.21/32
+      - prefix: 100.64.0.22/32
+      - prefix: 100.64.0.23/32
+      - prefix: 100.64.0.24/32
+      - prefix: 100.64.0.25/32
+      - prefix: 100.64.0.26/32
+      - prefix: 100.64.0.27/32
+      - prefix: 100.64.0.28/32
+      - prefix: 100.64.0.29/32
+      - prefix: 100.64.0.30/32
+      - prefix: 100.64.0.31/32
+      - prefix: 100.64.0.32/32
+      - prefix: 100.64.0.33/32
+      - prefix: 100.64.0.34/32
+      - prefix: 100.64.0.35/32
+      - prefix: 100.64.0.36/32
+      - prefix: 100.64.0.37/32
+      - prefix: 100.64.0.38/32
+      - prefix: 100.64.0.39/32
+      - prefix: 100.64.0.40/32
+      - prefix: 100.64.0.41/32
+      - prefix: 100.64.0.42/32
+      - prefix: 100.64.0.43/32
+      - prefix: 100.64.0.44/32
+      - prefix: 100.64.0.45/32
+      - prefix: 100.64.0.46/32
+      - prefix: 100.64.0.47/32
+      - prefix: 100.64.0.48/32
+      - prefix: 100.64.0.49/32
+      - prefix: 100.64.0.50/32
+      - prefix: 100.64.0.51/32
+      - prefix: 100.64.0.52/32
+      - prefix: 100.64.0.53/32
+      - prefix: 100.64.0.54/32
+      - prefix: 100.64.0.55/32
+      - prefix: 100.64.0.56/32
+      - prefix: 100.64.0.57/32
+      - prefix: 100.64.0.58/32
+      - prefix: 100.64.0.59/32
+      - prefix: 100.64.0.60/32
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+    - if-name: vz1ns
+      circuit-type: level-2-only
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/isis_fragmentation_ipv4/z1-2.yaml
+++ b/bdd/tests/configs/isis_fragmentation_ipv4/z1-2.yaml
@@ -1,0 +1,233 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.1/32
+- if-name: vz1ns
+  ipv4:
+    address: 10.0.1.1/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    # Force fragmentation at the standard Ethernet MTU: a 1500-byte cap
+    # on each LSP PDU leaves a 1473-byte TLV budget (lsp-mtu-size - 27
+    # bytes of PDU overhead). 200 /32 networks at 9 wire bytes each
+    # (RFC 5305: 4 metric + 1 control/flags + 4 prefix bytes) -> ~1800
+    # bytes of TLV 135 value, overflowing one fragment. The splitter
+    # caps each TLV 135 instance at the 255-byte length-field ceiling
+    # (~8 instances here); the packer then bins those instances into
+    # LSP fragments, so z1's self-LSP spans >= 2 fragments.
+    lsp-mtu-size: 1500
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 100.64.0.1/32
+      - prefix: 100.64.0.2/32
+      - prefix: 100.64.0.3/32
+      - prefix: 100.64.0.4/32
+      - prefix: 100.64.0.5/32
+      - prefix: 100.64.0.6/32
+      - prefix: 100.64.0.7/32
+      - prefix: 100.64.0.8/32
+      - prefix: 100.64.0.9/32
+      - prefix: 100.64.0.10/32
+      - prefix: 100.64.0.11/32
+      - prefix: 100.64.0.12/32
+      - prefix: 100.64.0.13/32
+      - prefix: 100.64.0.14/32
+      - prefix: 100.64.0.15/32
+      - prefix: 100.64.0.16/32
+      - prefix: 100.64.0.17/32
+      - prefix: 100.64.0.18/32
+      - prefix: 100.64.0.19/32
+      - prefix: 100.64.0.20/32
+      - prefix: 100.64.0.21/32
+      - prefix: 100.64.0.22/32
+      - prefix: 100.64.0.23/32
+      - prefix: 100.64.0.24/32
+      - prefix: 100.64.0.25/32
+      - prefix: 100.64.0.26/32
+      - prefix: 100.64.0.27/32
+      - prefix: 100.64.0.28/32
+      - prefix: 100.64.0.29/32
+      - prefix: 100.64.0.30/32
+      - prefix: 100.64.0.31/32
+      - prefix: 100.64.0.32/32
+      - prefix: 100.64.0.33/32
+      - prefix: 100.64.0.34/32
+      - prefix: 100.64.0.35/32
+      - prefix: 100.64.0.36/32
+      - prefix: 100.64.0.37/32
+      - prefix: 100.64.0.38/32
+      - prefix: 100.64.0.39/32
+      - prefix: 100.64.0.40/32
+      - prefix: 100.64.0.41/32
+      - prefix: 100.64.0.42/32
+      - prefix: 100.64.0.43/32
+      - prefix: 100.64.0.44/32
+      - prefix: 100.64.0.45/32
+      - prefix: 100.64.0.46/32
+      - prefix: 100.64.0.47/32
+      - prefix: 100.64.0.48/32
+      - prefix: 100.64.0.49/32
+      - prefix: 100.64.0.50/32
+      - prefix: 100.64.0.51/32
+      - prefix: 100.64.0.52/32
+      - prefix: 100.64.0.53/32
+      - prefix: 100.64.0.54/32
+      - prefix: 100.64.0.55/32
+      - prefix: 100.64.0.56/32
+      - prefix: 100.64.0.57/32
+      - prefix: 100.64.0.58/32
+      - prefix: 100.64.0.59/32
+      - prefix: 100.64.0.60/32
+      - prefix: 100.64.0.61/32
+      - prefix: 100.64.0.62/32
+      - prefix: 100.64.0.63/32
+      - prefix: 100.64.0.64/32
+      - prefix: 100.64.0.65/32
+      - prefix: 100.64.0.66/32
+      - prefix: 100.64.0.67/32
+      - prefix: 100.64.0.68/32
+      - prefix: 100.64.0.69/32
+      - prefix: 100.64.0.70/32
+      - prefix: 100.64.0.71/32
+      - prefix: 100.64.0.72/32
+      - prefix: 100.64.0.73/32
+      - prefix: 100.64.0.74/32
+      - prefix: 100.64.0.75/32
+      - prefix: 100.64.0.76/32
+      - prefix: 100.64.0.77/32
+      - prefix: 100.64.0.78/32
+      - prefix: 100.64.0.79/32
+      - prefix: 100.64.0.80/32
+      - prefix: 100.64.0.81/32
+      - prefix: 100.64.0.82/32
+      - prefix: 100.64.0.83/32
+      - prefix: 100.64.0.84/32
+      - prefix: 100.64.0.85/32
+      - prefix: 100.64.0.86/32
+      - prefix: 100.64.0.87/32
+      - prefix: 100.64.0.88/32
+      - prefix: 100.64.0.89/32
+      - prefix: 100.64.0.90/32
+      - prefix: 100.64.0.91/32
+      - prefix: 100.64.0.92/32
+      - prefix: 100.64.0.93/32
+      - prefix: 100.64.0.94/32
+      - prefix: 100.64.0.95/32
+      - prefix: 100.64.0.96/32
+      - prefix: 100.64.0.97/32
+      - prefix: 100.64.0.98/32
+      - prefix: 100.64.0.99/32
+      - prefix: 100.64.0.100/32
+      - prefix: 100.64.0.101/32
+      - prefix: 100.64.0.102/32
+      - prefix: 100.64.0.103/32
+      - prefix: 100.64.0.104/32
+      - prefix: 100.64.0.105/32
+      - prefix: 100.64.0.106/32
+      - prefix: 100.64.0.107/32
+      - prefix: 100.64.0.108/32
+      - prefix: 100.64.0.109/32
+      - prefix: 100.64.0.110/32
+      - prefix: 100.64.0.111/32
+      - prefix: 100.64.0.112/32
+      - prefix: 100.64.0.113/32
+      - prefix: 100.64.0.114/32
+      - prefix: 100.64.0.115/32
+      - prefix: 100.64.0.116/32
+      - prefix: 100.64.0.117/32
+      - prefix: 100.64.0.118/32
+      - prefix: 100.64.0.119/32
+      - prefix: 100.64.0.120/32
+      - prefix: 100.64.0.121/32
+      - prefix: 100.64.0.122/32
+      - prefix: 100.64.0.123/32
+      - prefix: 100.64.0.124/32
+      - prefix: 100.64.0.125/32
+      - prefix: 100.64.0.126/32
+      - prefix: 100.64.0.127/32
+      - prefix: 100.64.0.128/32
+      - prefix: 100.64.0.129/32
+      - prefix: 100.64.0.130/32
+      - prefix: 100.64.0.131/32
+      - prefix: 100.64.0.132/32
+      - prefix: 100.64.0.133/32
+      - prefix: 100.64.0.134/32
+      - prefix: 100.64.0.135/32
+      - prefix: 100.64.0.136/32
+      - prefix: 100.64.0.137/32
+      - prefix: 100.64.0.138/32
+      - prefix: 100.64.0.139/32
+      - prefix: 100.64.0.140/32
+      - prefix: 100.64.0.141/32
+      - prefix: 100.64.0.142/32
+      - prefix: 100.64.0.143/32
+      - prefix: 100.64.0.144/32
+      - prefix: 100.64.0.145/32
+      - prefix: 100.64.0.146/32
+      - prefix: 100.64.0.147/32
+      - prefix: 100.64.0.148/32
+      - prefix: 100.64.0.149/32
+      - prefix: 100.64.0.150/32
+      - prefix: 100.64.0.151/32
+      - prefix: 100.64.0.152/32
+      - prefix: 100.64.0.153/32
+      - prefix: 100.64.0.154/32
+      - prefix: 100.64.0.155/32
+      - prefix: 100.64.0.156/32
+      - prefix: 100.64.0.157/32
+      - prefix: 100.64.0.158/32
+      - prefix: 100.64.0.159/32
+      - prefix: 100.64.0.160/32
+      - prefix: 100.64.0.161/32
+      - prefix: 100.64.0.162/32
+      - prefix: 100.64.0.163/32
+      - prefix: 100.64.0.164/32
+      - prefix: 100.64.0.165/32
+      - prefix: 100.64.0.166/32
+      - prefix: 100.64.0.167/32
+      - prefix: 100.64.0.168/32
+      - prefix: 100.64.0.169/32
+      - prefix: 100.64.0.170/32
+      - prefix: 100.64.0.171/32
+      - prefix: 100.64.0.172/32
+      - prefix: 100.64.0.173/32
+      - prefix: 100.64.0.174/32
+      - prefix: 100.64.0.175/32
+      - prefix: 100.64.0.176/32
+      - prefix: 100.64.0.177/32
+      - prefix: 100.64.0.178/32
+      - prefix: 100.64.0.179/32
+      - prefix: 100.64.0.180/32
+      - prefix: 100.64.0.181/32
+      - prefix: 100.64.0.182/32
+      - prefix: 100.64.0.183/32
+      - prefix: 100.64.0.184/32
+      - prefix: 100.64.0.185/32
+      - prefix: 100.64.0.186/32
+      - prefix: 100.64.0.187/32
+      - prefix: 100.64.0.188/32
+      - prefix: 100.64.0.189/32
+      - prefix: 100.64.0.190/32
+      - prefix: 100.64.0.191/32
+      - prefix: 100.64.0.192/32
+      - prefix: 100.64.0.193/32
+      - prefix: 100.64.0.194/32
+      - prefix: 100.64.0.195/32
+      - prefix: 100.64.0.196/32
+      - prefix: 100.64.0.197/32
+      - prefix: 100.64.0.198/32
+      - prefix: 100.64.0.199/32
+      - prefix: 100.64.0.200/32
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+    - if-name: vz1ns
+      circuit-type: level-2-only
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/isis_fragmentation_ipv4/z2-1.yaml
+++ b/bdd/tests/configs/isis_fragmentation_ipv4/z2-1.yaml
@@ -1,0 +1,21 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.2/32
+- if-name: vz2ns
+  ipv4:
+    address: 10.0.1.2/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+    - if-name: vz2ns
+      circuit-type: level-2-only
+      ipv4:
+        enable: true

--- a/bdd/tests/features/isis_fragmentation_ipv4.feature
+++ b/bdd/tests/features/isis_fragmentation_ipv4.feature
@@ -1,0 +1,117 @@
+@serial
+@isis_fragmentation_ipv4
+Feature: IS-IS LSP fragmentation (IPv4) at lsp-mtu-size 400 and 1500
+  As a network operator
+  I want zebra-rs to fragment its self-originated LSP across multiple
+  PDUs when the IPv4 TLV 135 (Extended IP Reachability) content exceeds
+  `lsp-mtu-size`, deliver every fragment to peers via the standard
+  flooding path, and have the receiver correctly merge those fragments
+  back into a single logical origin so SPF can still install routes to
+  the originator's loopback.
+
+  This is verified at two LSP MTUs over one topology: first a tight
+  400-byte cap (fragmentation with only 60 networks), then — after a
+  live reconfiguration of z1 — the standard 1500-byte Ethernet MTU
+  (fragmentation needs 200 networks), confirming both the small-MTU
+  path and that a runtime lsp-mtu-size change re-fragments correctly.
+
+  Test Topology:
+  ```
+  ┌────────────────────────────────────────┐
+  │                  br0                   │
+  └────────────┬───────────────┬───────────┘
+               │               │
+         10.0.1.1/24      10.0.1.2/24
+            (vz1ns)             (vz2ns)
+          ┌────┴────┐     ┌────┴────┐
+          │   z1    │     │   z2    │
+          │ 400→1500│     │         │
+          │ 60→200  │     │         │
+          └─────────┘     └─────────┘
+     lo: 10.255.0.1/32     lo: 10.255.0.2/32
+  ```
+
+  Config files:
+  - z1-1.yaml: lsp-mtu-size 400 + 60 IPv4 /32 networks. Each /32 entry
+    costs 9 wire bytes in TLV 135, so 60 entries (~540 bytes) overflow a
+    single 400-byte fragment (373-byte budget after 27 bytes of PDU
+    overhead) and force the packer to spread TLV 135 entries across
+    multiple fragments.
+  - z1-2.yaml: lsp-mtu-size 1500 + 200 IPv4 /32 networks. At the standard
+    Ethernet MTU the per-fragment budget is 1473 bytes, so 200 entries
+    (~1800 bytes) are needed to still span multiple fragments. Re-applied
+    to z1 mid-test to exercise a runtime lsp-mtu-size change.
+  - z2-1.yaml: default config; verifies the receiver-side rebuild from a
+    fragmented peer LSP works end-to-end at both MTUs.
+
+  Scenario: Setup fragmentation topology at lsp-mtu-size 400
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with loopback and veth interface on the bridge "br0"
+    And I create namespace "z2" with loopback and veth interface on the bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 20 seconds
+    Then ping from "z1" to "10.0.1.2" should succeed
+    And ping from "z2" to "10.0.1.1" should succeed
+
+  Scenario: MTU 400 — lsp-mtu-size shows up in show isis summary
+    Given the test topology exists
+    Then show command "show isis summary" in namespace "z1" should contain "LSP MTU: 400 bytes"
+
+  Scenario: MTU 400 — z2 observes z1's self-LSP as multiple fragments
+    Given the test topology exists
+    Then show command "show isis database" in namespace "z2" should contain "Fragment Summary"
+    And show command "show isis database" in namespace "z2" should contain "z1.00"
+
+  Scenario: MTU 400 — z2 reaches z1's loopback despite z1's self-LSP being fragmented
+    Given the test topology exists
+    Then ping from "z2" to "10.255.0.1" should succeed
+    And ping from "z1" to "10.255.0.2" should succeed
+
+  Scenario: MTU 400 — z2 installs a /32 network carried in one of z1's higher fragments
+    Given the test topology exists
+    # The advertised `network` prefixes aren't bound to any interface on
+    # z1, so they aren't pingable; instead assert the receiver merged the
+    # fragmented TLV 135 by checking the last /32 (placed well past
+    # fragment 0) shows up in z2's IS-IS RIB.
+    Then show command "show isis route" in namespace "z2" should contain "100.64.0.60/32"
+
+  Scenario: Reconfigure z1 to the standard 1500-byte LSP MTU
+    Given the test topology exists
+    When I apply config "z1-2.yaml" to namespace "z1"
+    And I wait 20 seconds
+    Then ping from "z1" to "10.0.1.2" should succeed
+    And ping from "z2" to "10.0.1.1" should succeed
+
+  Scenario: MTU 1500 — lsp-mtu-size shows up in show isis summary
+    Given the test topology exists
+    Then show command "show isis summary" in namespace "z1" should contain "LSP MTU: 1500 bytes"
+
+  Scenario: MTU 1500 — z2 still observes z1's self-LSP as multiple fragments
+    Given the test topology exists
+    Then show command "show isis database" in namespace "z2" should contain "Fragment Summary"
+    And show command "show isis database" in namespace "z2" should contain "z1.00"
+
+  Scenario: MTU 1500 — z2 reaches z1's loopback despite z1's self-LSP being fragmented
+    Given the test topology exists
+    Then ping from "z2" to "10.255.0.1" should succeed
+    And ping from "z1" to "10.255.0.2" should succeed
+
+  Scenario: MTU 1500 — z2 installs a /32 network carried in one of z1's higher fragments
+    Given the test topology exists
+    # After the runtime MTU change z1 now advertises 200 networks; the
+    # last /32 sits well past fragment 0, so its presence in z2's RIB
+    # proves the receiver re-merged the freshly re-fragmented LSP.
+    Then show command "show isis route" in namespace "z2" should contain "100.64.0.200/32"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

Adds an IS-IS LSP fragmentation BDD scenario driven by IPv4
`afi-safi ipv4 network` statements (TLV 135 Extended IP Reachability),
complementing the existing IPv6 (TLV 236) `isis_fragmentation` feature.

A single two-node topology (z1↔z2 over a bridge, L2-only) verifies
fragmentation at **two LSP MTUs**:

- **lsp-mtu-size 400** — 60 `/32` networks (~540 B of TLV 135 over a
  373 B per-fragment budget) → z1's self-LSP spans ≥2 fragments.
- **lsp-mtu-size 1500** (standard Ethernet MTU) — after a live
  reconfiguration of z1 to 200 `/32` networks (~1800 B over a 1473 B
  budget) → still spans ≥2 fragments.

Each MTU case asserts:
- `LSP MTU: <N> bytes` in `show isis summary`
- a multi-fragment `Fragment Summary` (+ `z1.00`) in z2's `show isis database`
- reciprocal loopback reachability (z2 correctly merges the fragmented peer LSP for SPF)
- a high-fragment `/32` (`100.64.0.60/32` at 400, `100.64.0.200/32` at 1500) lands in z2's `show isis route`

The mid-test reconfiguration additionally exercises a **runtime
`lsp-mtu-size` change** re-fragmenting and the receiver re-merging
correctly.

Also adds the `make isis_fragmentation_ipv4` target and the generated
scenario doc.

## Test plan

- BDD is excluded from CI and not run locally per project policy; run
  on a netns-capable host with `cd bdd && make isis_fragmentation_ipv4`.
- No Rust changed (feature/config/Makefile/doc only), so fmt/clippy/test
  gates are unaffected.

Generated with [Claude Code](https://claude.com/claude-code)