### PR TITLE
isis: key-chain-based Hello authentication (+ BDD)

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -48,6 +48,10 @@ isis_l1l2:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_l1l2"
 
+isis_hello_auth_keychain:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_hello_auth_keychain"
+
 ospf_clear_neighbor:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@ospf_clear_neighbor"
@@ -100,4 +104,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation isis_fragmentation_ipv4 isis_l1_p2p isis_tilfa isis_l1l2 ospf_clear_neighbor bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation isis_fragmentation_ipv4 isis_l1_p2p isis_tilfa isis_l1l2 isis_hello_auth_keychain ospf_clear_neighbor bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE

--- a/bdd/docs/isis_hello_auth_keychain.md
+++ b/bdd/docs/isis_hello_auth_keychain.md
@@ -1,0 +1,47 @@
+# IS-IS Hello authentication via an RFC 8177 key-chain
+
+## Overview
+
+As a network operator
+I want to authenticate IS-IS Hello (IIH) PDUs on a point-to-point link
+by referencing a named key-chain (RFC 8177) instead of an inline
+password, and confirm that two zebra-rs routers sharing the same chain
+form a Level-1 adjacency and exchange dual-stack routes.
+When an interface's `hello-authentication` carries a `key-chain` leaf
+(and no inline `password`), the chain's active key is self-describing:
+it supplies the algorithm (from `crypto-algorithm`), the RFC 5310 Key
+ID, and the key material at both sign and verify time, so no `auth-type`
+leaf is needed. Both ends must define the same chain name with an
+identical key (key-id, crypto-algorithm, key-string) or the IIHs fail
+to verify and the adjacency never forms — so a formed adjacency is
+itself proof that keychain-based Hello auth round-trips correctly.
+
+## Test Topology
+
+```
+    z1 --10-- z2     point-to-point veth (10.0.1.0/30, 2001:db8:1::/64)
+
+    loopbacks: z1 -> 10.0.0.1/32  2001:db8:0:ffff::1/128
+               z2 -> 10.0.0.2/32  2001:db8:0:ffff::2/128
+```
+
+## Notes
+
+Both routers are is-type level-1 in area 49.0001. On z1 the interface
+toward z2 is "i2"; on z2 the interface toward z1 is "i1". Each carries
+`hello-authentication { key-chain ISIS-HELLO }`, where ISIS-HELLO has a
+single hmac-sha-256 key (key-id 1, key-string "zebra-isis-hello-secret").
+
+## Config Files
+
+- z1.yaml: z1 with the ISIS-HELLO chain (hmac-sha-256, key-id 1, key-string "zebra-isis-hello-secret").
+- z2.yaml: z2 with the same chain -- matches z1, so the adjacency forms.
+- z2-badkey.yaml: z2 with the chain re-keyed to a value z1 does not share (same name/key-id/algorithm), used to prove a key mismatch tears the adjacency down.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Keychain-authenticated IIH brings up the L1 adjacency | |
+| A mismatched chain key tears the adjacency down | |
+| Teardown topology | |

--- a/bdd/tests/configs/isis_hello_auth_keychain/z1.yaml
+++ b/bdd/tests/configs/isis_hello_auth_keychain/z1.yaml
@@ -1,0 +1,57 @@
+# IS-IS Hello (IIH) authentication using a named RFC 8177 key-chain.
+#
+# The per-interface `hello-authentication` block references the chain by
+# name instead of carrying an inline `password`. The chain's active key
+# is self-describing: it supplies the algorithm (from `crypto-algorithm`),
+# the RFC 5310 Key ID, and the key material at both sign and verify time.
+# So neither `auth-type` nor `key-id` needs to be repeated on the
+# interface -- the send path stamps them from the chain and the receive
+# path recovers the algorithm from the key the wire Key ID selects.
+#
+# z2 must define the same chain name with an identical key (same key-id,
+# crypto-algorithm, and key-string) for the adjacency to come up.
+
+key-chains:
+  key-chain:
+  - name: ISIS-HELLO
+    key:
+    - key-id: 1
+      crypto-algorithm: hmac-sha-256
+      key-string:
+        keystring: "zebra-isis-hello-secret"
+
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+  ipv6:
+    address: 2001:db8:0:ffff::1/128
+- if-name: i2
+  ipv4:
+    address: 10.0.1.1/30
+  ipv6:
+    address: 2001:db8:1::1/64
+
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-1
+    hostname: z1
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i2
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      # Authenticate IIH/CSNP/PSNP on this link via the ISIS-HELLO chain.
+      hello-authentication:
+        key-chain: ISIS-HELLO

--- a/bdd/tests/configs/isis_hello_auth_keychain/z2-badkey.yaml
+++ b/bdd/tests/configs/isis_hello_auth_keychain/z2-badkey.yaml
@@ -1,0 +1,50 @@
+# z2 with the ISIS-HELLO chain re-keyed to a secret that z1 does NOT
+# share. The chain name, key-id, and crypto-algorithm are unchanged --
+# only the key-string differs -- so the failure isolates a key mismatch
+# (not an algorithm or key-id mismatch). z2 now signs its IIHs with a
+# digest z1 cannot verify and rejects z1's IIHs in turn, so the
+# Hello-authenticated adjacency tears down once the hold timers expire.
+
+key-chains:
+  key-chain:
+  - name: ISIS-HELLO
+    key:
+    - key-id: 1
+      crypto-algorithm: hmac-sha-256
+      key-string:
+        keystring: "WRONG-key-not-shared-with-z1"
+
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+  ipv6:
+    address: 2001:db8:0:ffff::2/128
+- if-name: i1
+  ipv4:
+    address: 10.0.1.2/30
+  ipv6:
+    address: 2001:db8:1::2/64
+
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-1
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i1
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      hello-authentication:
+        key-chain: ISIS-HELLO

--- a/bdd/tests/configs/isis_hello_auth_keychain/z2.yaml
+++ b/bdd/tests/configs/isis_hello_auth_keychain/z2.yaml
@@ -1,0 +1,47 @@
+# Peer of z1.yaml -- same key-chain name + key material so the IIH
+# authentication TLV verifies in both directions.
+
+key-chains:
+  key-chain:
+  - name: ISIS-HELLO
+    key:
+    - key-id: 1
+      crypto-algorithm: hmac-sha-256
+      key-string:
+        keystring: "zebra-isis-hello-secret"
+
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+  ipv6:
+    address: 2001:db8:0:ffff::2/128
+- if-name: i1
+  ipv4:
+    address: 10.0.1.2/30
+  ipv6:
+    address: 2001:db8:1::2/64
+
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-1
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i1
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+      # Authenticate IIH/CSNP/PSNP on this link via the ISIS-HELLO chain.
+      hello-authentication:
+        key-chain: ISIS-HELLO

--- a/bdd/tests/features/isis_hello_auth_keychain.feature
+++ b/bdd/tests/features/isis_hello_auth_keychain.feature
@@ -1,0 +1,92 @@
+@serial
+@isis_hello_auth_keychain
+Feature: IS-IS Hello authentication via an RFC 8177 key-chain
+  As a network operator
+  I want to authenticate IS-IS Hello (IIH) PDUs on a point-to-point link
+  by referencing a named key-chain (RFC 8177) instead of an inline
+  password, and confirm that two zebra-rs routers sharing the same chain
+  form a Level-1 adjacency and exchange dual-stack routes.
+
+  When an interface's `hello-authentication` carries a `key-chain` leaf
+  (and no inline `password`), the chain's active key is self-describing:
+  it supplies the algorithm (from `crypto-algorithm`), the RFC 5310 Key
+  ID, and the key material at both sign and verify time, so no `auth-type`
+  leaf is needed. Both ends must define the same chain name with an
+  identical key (key-id, crypto-algorithm, key-string) or the IIHs fail
+  to verify and the adjacency never forms — so a formed adjacency is
+  itself proof that keychain-based Hello auth round-trips correctly.
+
+  Test Topology:
+  ```
+    z1 --10-- z2     point-to-point veth (10.0.1.0/30, 2001:db8:1::/64)
+
+    loopbacks: z1 -> 10.0.0.1/32  2001:db8:0:ffff::1/128
+               z2 -> 10.0.0.2/32  2001:db8:0:ffff::2/128
+  ```
+
+  Both routers are is-type level-1 in area 49.0001. On z1 the interface
+  toward z2 is "i2"; on z2 the interface toward z1 is "i1". Each carries
+  `hello-authentication { key-chain ISIS-HELLO }`, where ISIS-HELLO has a
+  single hmac-sha-256 key (key-id 1, key-string "zebra-isis-hello-secret").
+
+  Config files:
+  - z1.yaml: z1 with the ISIS-HELLO chain (hmac-sha-256, key-id 1, key-string "zebra-isis-hello-secret").
+  - z2.yaml: z2 with the same chain -- matches z1, so the adjacency forms.
+  - z2-badkey.yaml: z2 with the chain re-keyed to a value z1 does not share (same name/key-id/algorithm), used to prove a key mismatch tears the adjacency down.
+
+  Scenario: Keychain-authenticated IIH brings up the L1 adjacency
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i2" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 10 seconds
+    # IIHs are signed and verified through the ISIS-HELLO chain on both
+    # ends, so the adjacency reaches Up. The peer is rendered by its
+    # dynamic hostname, which only resolves once the peer's LSP was
+    # received — proving the adjacency formed and the LSDB synced over
+    # the authenticated link.
+    Then show command "show isis neighbor" in namespace "z1" should contain "z2"
+    And show command "show isis neighbor" in namespace "z2" should contain "z1"
+    And show command "show isis neighbor" in namespace "z1" should contain "Up"
+    # Directly-connected reachability over the authenticated link, dual-stack.
+    And ping from "z1" to "10.0.1.2" should succeed
+    And ping from "z1" to "2001:db8:1::2" should succeed
+    # Loopbacks learned via IS-IS across the authenticated adjacency.
+    And show command "show isis route" in namespace "z1" should contain "10.0.0.2/32"
+    And show command "show isis route" in namespace "z2" should contain "10.0.0.1/32"
+    And ping from "z1" to "10.0.0.2" should succeed
+    And ping from "z1" to "2001:db8:0:ffff::2" should succeed
+    And ping from "z2" to "10.0.0.1" should succeed
+
+  Scenario: A mismatched chain key tears the adjacency down
+    Given the test topology exists
+    # Re-key only z2's ISIS-HELLO chain to a secret z1 doesn't share.
+    # z2's IIHs now carry a digest z1 can't verify, and z2 rejects z1's
+    # IIHs in turn -- so neither side refreshes the other's hold timer.
+    When I apply config "z2-badkey.yaml" to namespace "z2"
+    # Wait out the ~30s hold-time (hello-interval 3s x multiplier 10) plus
+    # a margin for the SPF recompute and RIB withdrawal that follow.
+    And I wait 40 seconds
+    # The L1 adjacency expired on both ends. A dropped neighbor is removed
+    # from the table, so the peer hostname is gone from each side.
+    Then show command "show isis neighbor" in namespace "z1" should not contain "z2"
+    And show command "show isis neighbor" in namespace "z2" should not contain "z1"
+    # Forwarding over the now-unauthenticated link is broken: the
+    # IS-IS-learned loopback is withdrawn and no longer reachable.
+    And show command "show isis route" in namespace "z1" should not contain "10.0.0.2/32"
+    And ping from "z1" to "10.0.0.2" should fail
+    # The link itself is fine -- the directly-connected address still
+    # answers, proving it's the adjacency (not the wire) that went away.
+    And ping from "z1" to "10.0.1.2" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/zebra-rs/src/isis/auth.rs
+++ b/zebra-rs/src/isis/auth.rs
@@ -103,54 +103,75 @@ pub fn resolve_send(
     })
 }
 
-/// Resolve the receive-side key bytes for an incoming PDU.
+/// Resolve the verify `(algorithm, key bytes)` for an incoming PDU
+/// from its on-wire Auth TLV.
 ///
-/// Inline `password` always wins — operators of the historical
-/// simple-password setup keep their behavior, and the `key-chain`
-/// leaf is only consulted when no inline password is set. For the
-/// chain path:
-///   - generic-crypto wire types carry the sender's RFC 5310 key-id
-///     in the TLV prefix; the caller passes that as `wire_key_id`
-///     and the lookup is an exact match.
-///   - RFC 5304 MD5 doesn't carry a key-id; the caller passes
-///     `None` and the helper picks the lowest accept-active key
-///     whose algo matches `expected_mode`.
+/// Inline `password` always wins — its algorithm is the configured
+/// `auth_type` and the key is the password bytes; the `key-chain` leaf
+/// is only consulted when no inline password is set. Crucially, on the
+/// chain path the algorithm is taken from the *chain key*, not from
+/// `cfg.auth_type`: RFC 5310 puts only a Key ID on the wire (Auth-Type
+/// 3) and the SHA variant is whatever the local key bound to that Key
+/// ID says it is. This is what lets a `key-chain`-only interface (no
+/// `auth-type` leaf) verify inbound generic-crypto PDUs — send and
+/// receive both self-describe from the chain.
 ///
-/// The chosen key's algo must match `expected_mode` so the verify
-/// path doesn't compare digests of differing lengths.
+///   - generic-crypto (Auth-Type 3): read the 2-byte Key ID prefix,
+///     look the key up exactly, and verify with its algorithm. A key
+///     bound to a non-generic algorithm can't verify it.
+///   - HMAC-MD5 (Auth-Type 54): no wire Key ID; pick the lowest
+///     accept-active key whose algorithm is md5.
+///   - cleartext (Auth-Type 1): not representable by a chain key
+///     (RFC 8177 has no cleartext crypto-algorithm), so the chain path
+///     rejects it.
+///
+/// Returns `None` when no accept-active key matches — a hard reject so
+/// peers using the wrong key or algorithm don't slip through.
 pub fn resolve_recv(
     cfg: &IsisAuthConfig,
     chains: &std::collections::BTreeMap<String, crate::policy::KeyChain>,
-    expected_mode: IsisAuthType,
-    wire_key_id: Option<u16>,
+    auth_tlv: &IsisTlvAuth,
     now: chrono::DateTime<chrono::Utc>,
-) -> Option<Vec<u8>> {
+) -> Option<(IsisAuthType, Vec<u8>)> {
+    // Inline password wins; its algorithm is the configured auth-type.
     if let Some(pw) = cfg.password.as_deref() {
-        return Some(pw.as_bytes().to_vec());
+        return Some((cfg.auth_type, pw.as_bytes().to_vec()));
     }
-    let chain_name = cfg.key_chain.as_deref()?;
-    let chain = chains.get(chain_name)?;
-    let key = match wire_key_id {
-        Some(id) => chain.keys.get(&u64::from(id))?,
-        None => {
-            // No wire key-id — find the lowest accept-active key
-            // whose algo matches what the wire claims.
-            chain.keys.values().find(|k| {
-                chain_key_is_accept_active(k, now)
-                    && k.algo
-                        .and_then(isis_algo_from_policy)
-                        .is_some_and(|a| a == expected_mode)
-            })?
+    let chain = chains.get(cfg.key_chain.as_deref()?)?;
+
+    match auth_tlv.auth_type {
+        ISIS_AUTH_TYPE_GENERIC => {
+            // RFC 5310: the 2-byte Key ID prefix selects the exact key,
+            // and that key's own algorithm is the verify mode.
+            if auth_tlv.value.len() < ISIS_AUTH_GENERIC_KEY_ID_LEN {
+                return None;
+            }
+            let wire_key_id = u16::from_be_bytes([auth_tlv.value[0], auth_tlv.value[1]]);
+            let key = chain.keys.get(&u64::from(wire_key_id))?;
+            if !chain_key_is_accept_active(key, now) {
+                return None;
+            }
+            let algo = isis_algo_from_policy(key.algo?)?;
+            // A key bound to md5/cleartext can't verify a generic-crypto
+            // PDU — the digest lengths wouldn't even match.
+            if !algo.is_generic_crypto() {
+                return None;
+            }
+            Some((algo, key.key_material.clone()))
         }
-    };
-    if !chain_key_is_accept_active(key, now) {
-        return None;
+        ISIS_AUTH_TYPE_HMAC_MD5 => {
+            // RFC 5304 MD5 carries no Key ID — pick the lowest
+            // accept-active key whose algorithm is md5.
+            let key = chain.keys.values().find(|k| {
+                chain_key_is_accept_active(k, now)
+                    && k.algo.and_then(isis_algo_from_policy) == Some(IsisAuthType::Md5)
+            })?;
+            Some((IsisAuthType::Md5, key.key_material.clone()))
+        }
+        // Cleartext (Auth-Type 1) can't be carried by a chain key, and
+        // any other Auth-Type is unknown — reject.
+        _ => None,
     }
-    let algo = isis_algo_from_policy(key.algo?)?;
-    if algo != expected_mode {
-        return None;
-    }
-    Some(key.key_material.clone())
 }
 
 /// HMAC-MD5 over `data` keyed by `key` (RFC 2104 / RFC 5304 §3).
@@ -612,6 +633,106 @@ mod tests {
         let cfg = IsisAuthConfig::default();
         let resolved = resolve_send(&cfg, &chains, now);
         assert_eq!(auth_tlv_wire_size(resolved.as_ref()), 0);
+    }
+
+    /// The receive path must take the verify algorithm from the chain
+    /// key the wire Key ID selects — NOT from `cfg.auth_type`. This is
+    /// the regression guard for a key-chain-only `hello-authentication`
+    /// block: with `auth_type` left at its `Text` default, an inbound
+    /// generic-crypto (RFC 5310) PDU must still resolve to the chain
+    /// key's HMAC-SHA-256 instead of being dropped.
+    #[test]
+    fn resolve_recv_takes_algorithm_from_chain_key() {
+        use crate::policy::{CryptoAlgorithm, Key, KeyChain};
+
+        let now = chrono::Utc::now();
+        let secret = b"zebra-isis-hello-secret".to_vec();
+
+        let chain = |algo| {
+            let mut keys = std::collections::BTreeMap::new();
+            keys.insert(
+                1u64,
+                Key {
+                    algo: Some(algo),
+                    key_material: secret.clone(),
+                    ..Default::default()
+                },
+            );
+            let mut chains = std::collections::BTreeMap::new();
+            chains.insert(
+                "ISIS-HELLO".to_string(),
+                KeyChain {
+                    keys,
+                    ..Default::default()
+                },
+            );
+            chains
+        };
+        let sha_chains = chain(CryptoAlgorithm::HmacSha256);
+
+        // key-chain set, auth_type at the `Text` default (the config
+        // shape that previously dropped every inbound PDU).
+        let cfg = IsisAuthConfig {
+            password: None,
+            auth_type: IsisAuthType::Text,
+            key_id: 0,
+            send_only: false,
+            key_chain: Some("ISIS-HELLO".into()),
+        };
+
+        // Wire: generic-crypto, Key ID 1, digest bytes (content
+        // irrelevant — resolve_recv only reads the Key ID prefix).
+        let generic_tlv = |key_id: u16| IsisTlvAuth {
+            auth_type: ISIS_AUTH_TYPE_GENERIC,
+            value: {
+                let mut v = key_id.to_be_bytes().to_vec();
+                v.extend_from_slice(&[0u8; 32]);
+                v
+            },
+        };
+        let (algo, key) =
+            resolve_recv(&cfg, &sha_chains, &generic_tlv(1), now).expect("chain key resolves");
+        assert_eq!(algo, IsisAuthType::HmacSha256);
+        assert_eq!(key, secret);
+
+        // Unknown wire Key ID → no key → reject.
+        assert!(resolve_recv(&cfg, &sha_chains, &generic_tlv(7), now).is_none());
+
+        // Wire claims cleartext, but a chain key can't carry cleartext
+        // (RFC 8177 has no cleartext crypto-algorithm) → reject.
+        let cleartext_tlv = IsisTlvAuth {
+            auth_type: ISIS_AUTH_TYPE_CLEARTEXT,
+            value: b"whatever".to_vec(),
+        };
+        assert!(resolve_recv(&cfg, &sha_chains, &cleartext_tlv, now).is_none());
+
+        // A chain key bound to md5 can't verify a generic-crypto PDU.
+        let md5_chains = chain(CryptoAlgorithm::Md5);
+        assert!(resolve_recv(&cfg, &md5_chains, &generic_tlv(1), now).is_none());
+
+        // RFC 5304 MD5 wire (Auth-Type 54, no Key ID) resolves the md5
+        // chain key.
+        let md5_tlv = IsisTlvAuth {
+            auth_type: ISIS_AUTH_TYPE_HMAC_MD5,
+            value: vec![0u8; ISIS_AUTH_HMAC_MD5_LEN],
+        };
+        let (algo, key) =
+            resolve_recv(&cfg, &md5_chains, &md5_tlv, now).expect("md5 chain key resolves");
+        assert_eq!(algo, IsisAuthType::Md5);
+        assert_eq!(key, secret);
+
+        // Inline password still wins and uses the configured auth-type.
+        let inline = IsisAuthConfig {
+            password: Some("hunter2".into()),
+            auth_type: IsisAuthType::Md5,
+            key_id: 0,
+            send_only: false,
+            key_chain: None,
+        };
+        let (algo, key) =
+            resolve_recv(&inline, &sha_chains, &generic_tlv(1), now).expect("inline password");
+        assert_eq!(algo, IsisAuthType::Md5);
+        assert_eq!(key, b"hunter2");
     }
 
     /// End-to-end HMAC-MD5 round-trip across a real CSNP — same

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -1188,7 +1188,7 @@ fn verify_pdu_auth(
 ) -> bool {
     // Snapshot config fields so we don't hold an immutable borrow of
     // link.config/up_config while mutating link.state.auth_rx_* below.
-    let (cfg, mode, send_only) = {
+    let (cfg, send_only) = {
         let cfg = match scope {
             AuthScope::HelloLink => &link.config.hello_auth,
             AuthScope::AreaPassword => &link.up_config.area_password,
@@ -1199,7 +1199,7 @@ fn verify_pdu_auth(
         if cfg.password.is_none() && cfg.key_chain.is_none() {
             return true;
         }
-        (cfg.clone(), cfg.auth_type, cfg.send_only)
+        (cfg.clone(), cfg.send_only)
     };
     if send_only {
         return true; // sign-only-on-tx rollover mode
@@ -1215,17 +1215,11 @@ fn verify_pdu_auth(
         return false;
     };
 
-    // Pull the on-wire RFC 5310 key-id out of the auth TLV prefix
-    // when the configured mode is generic-crypto; MD5 / Text PDUs
-    // don't carry one. The chain receive path uses this to pick the
-    // exact key the sender stamped.
-    let wire_key_id = if mode.is_generic_crypto() && auth_tlv.value.len() >= 2 {
-        Some(u16::from_be_bytes([auth_tlv.value[0], auth_tlv.value[1]]))
-    } else {
-        None
-    };
-    let Some(key) =
-        auth::resolve_recv(&cfg, link.key_chains, mode, wire_key_id, chrono::Utc::now())
+    // The verify algorithm + key come from the chain key the sender
+    // stamped (selected by the wire Key ID / Auth-Type) for the
+    // key-chain path, or from the configured auth-type + inline
+    // password — see `auth::resolve_recv`.
+    let Some((mode, key)) = auth::resolve_recv(&cfg, link.key_chains, auth_tlv, chrono::Utc::now())
     else {
         // Resolution failed: chain missing, no matching key-id,
         // expired accept-lifetime, or algo mismatch. Treat as a


### PR DESCRIPTION
## Summary

Fixes IS-IS `hello-authentication` that references an RFC 8177 key-chain
without an explicit `auth-type` leaf, and adds a BDD scenario covering it.

**The bug:** a `key-chain`-only `hello-authentication` block never formed
adjacencies. The send path took the algorithm from the chain key
(HMAC-SHA-256) while the receive path took the expected mode from
`cfg.auth_type`, which defaulted to `text`. `resolve_recv` then found no
`text` key in the chain and dropped every inbound PDU with
`"no usable receive key from policy registry"`.

**The fix:** make the receive path self-describe from the wire like the
send path. `resolve_recv` now classifies the inbound Auth TLV by its
on-wire Auth-Type and, for RFC 5310 generic crypto, looks the chain key
up by the wire Key ID and verifies with that key's own algorithm. It
returns `(algorithm, key_material)` so the caller no longer feeds
`cfg.auth_type` into the verify. Inline-password behavior is unchanged.
This makes the documented intent (the chain key supplies auth-type,
key-id, and material at sign/verify time) actually hold.

## Changes

- `zebra-rs/src/isis/auth.rs` — `resolve_recv` rewrite + regression test
- `zebra-rs/src/isis/packet.rs` — `verify_pdu_auth` uses chain-derived `(mode, key)`
- `bdd/` — `@isis_hello_auth_keychain` feature (positive + negative scenarios), key-chain-only configs, doc, Makefile target

## Test plan

- `cargo test -p zebra-rs isis::auth` — 17 passed, incl. new `resolve_recv_takes_algorithm_from_chain_key`
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt` — applied
- BDD (`make isis_hello_auth_keychain`, root + netns) — positive scenario forms the adjacency with key-chain-only config; negative scenario tears it down on a key mismatch

Generated with [Claude Code](https://claude.com/claude-code)