### PR TITLE
bdd: BDD_KEEP env var to skip teardown for inspection

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -306,8 +306,26 @@ async fn start_zebra_rs(world: &mut World, namespace: String) {
     );
 }
 
+/// When `BDD_KEEP` is set in the environment, the teardown steps
+/// (`stop zebra-rs`, `delete namespace`/`bridge`, and the clean-environment
+/// check) turn into no-ops so the daemons, namespaces, and bridge survive the
+/// run and can be inspected by hand. Use it to debug a scenario without
+/// editing the feature file: `BDD_KEEP=1 make ospf_clear_neighbor`. The next
+/// run's `Given a clean test environment` sweeps whatever was left behind, so
+/// a kept topology never leaks into a later run of the same feature.
+fn keep_topology() -> bool {
+    std::env::var_os("BDD_KEEP").is_some()
+}
+
 #[when(expr = "I stop zebra-rs in namespace {string}")]
 async fn stop_zebra_rs(world: &mut World, namespace: String) {
+    if keep_topology() {
+        println!(
+            "⏭  BDD_KEEP set — leaving zebra-rs running in namespace {}",
+            world.ns(&namespace)
+        );
+        return;
+    }
     let pid_file = world.pid_file(&namespace);
     let _ = netns::kill_pidfile(Path::new(&pid_file)).await;
     println!(
@@ -385,6 +403,10 @@ async fn run_exec_command(world: &mut World, command: String, namespace: String)
 #[when(expr = "I delete namespace {string}")]
 async fn delete_namespace(world: &mut World, namespace: String) {
     let scoped = world.ns(&namespace);
+    if keep_topology() {
+        println!("⏭  BDD_KEEP set — leaving namespace {} up", scoped);
+        return;
+    }
     netns::delete_netns(&scoped)
         .await
         .expect("Failed to delete namespace");
@@ -395,6 +417,10 @@ async fn delete_namespace(world: &mut World, namespace: String) {
 #[when(expr = "I delete bridge {string}")]
 async fn delete_bridge(world: &mut World, bridge_name: String) {
     let scoped = world.bridge(&bridge_name);
+    if keep_topology() {
+        println!("⏭  BDD_KEEP set — leaving bridge {} up", scoped);
+        return;
+    }
     netns::delete_bridge(&scoped)
         .await
         .expect("Failed to delete bridge");
@@ -841,6 +867,13 @@ async fn ilm_should_be_empty(world: &mut World, namespace: String) {
 
 #[then("the test environment should be clean")]
 async fn verify_clean_environment(world: &mut World) {
+    if keep_topology() {
+        // The teardown steps were skipped, so the namespaces/bridge/pid files
+        // are still present by design — asserting cleanliness here would
+        // falsely fail. Skip the check and leave everything for inspection.
+        println!("⏭  BDD_KEEP set — skipping clean-environment check (topology left up)");
+        return;
+    }
     let ns_prefix = format!("{}_", world.feature_tag);
     let leftover_ns = netns::list_netns_with_prefix(&ns_prefix)
         .await

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -64,6 +64,10 @@
   - [Logging Integration](ch-03-04-logging-integration.md)
   - [Logging Troubleshooting](ch-03-05-logging-troubleshooting.md)
 
+## Testing
+
+- [BDD Integration Tests](ch-11-00-bdd-tests.md)
+
 ---
 
 # Appendices

--- a/book/src/ch-11-00-bdd-tests.md
+++ b/book/src/ch-11-00-bdd-tests.md
@@ -1,0 +1,105 @@
+# BDD Integration Tests
+
+zebra-rs ships a behaviour-driven integration suite under `bdd/`. Each
+scenario builds a **real** topology of Linux network namespaces, starts
+one `zebra-rs` daemon per namespace, drives it through `vtyctl`, and
+asserts on live `show` output, route tables, and `ping` reachability —
+so the tests exercise the actual control plane and kernel forwarding,
+not a mock.
+
+The suite is written with [cucumber-rs]. Scenarios live in
+[Gherkin] `.feature` files under `bdd/tests/features/`; the step
+definitions that back them are in `bdd/tests/cucumber.rs`.
+
+[cucumber-rs]: https://github.com/cucumber-rs/cucumber
+[Gherkin]: https://cucumber.io/docs/gherkin/reference
+
+## Anatomy of a feature
+
+Every feature file opens with a tag that names it, for example
+`@ospf_clear_neighbor`. That tag is more than a label: the harness uses
+it to scope every namespace, bridge, and pid-file name it creates
+(`<tag>_o1`, `br_<hash>`, …), so different features can run side by side
+without colliding on host-global resource names.
+
+A scenario typically follows the same shape:
+
+1. `Given a clean test environment` — sweep any stale namespaces, bridges,
+   and pid files left by a crashed prior run of *this* feature.
+2. **Build** the topology — create namespaces, link them, start
+   `zebra-rs`, apply per-router config.
+3. **Assert** — `show` command contents, BGP/OSPF/IS-IS state, `ping`.
+4. **Teardown** — stop the daemons, delete the namespaces and bridge,
+   then `Then the test environment should be clean`.
+
+## Running the suite
+
+The helpers shell out to `sudo ip netns …`, so the tests need
+**passwordless `sudo`** (or to be run as root). You do *not* prefix
+`cargo test` with `sudo` yourself — the harness elevates the individual
+`ip` calls.
+
+The `bdd/Makefile` wraps the common invocations:
+
+```sh
+cd bdd
+make                       # run every feature
+make ospf_clear_neighbor   # run one feature by its make target
+```
+
+Under the hood each target is a tag filter:
+
+```sh
+cargo test --test cucumber -- --concurrency=1 --tags "@ospf_clear_neighbor"
+```
+
+`--concurrency=1` keeps scenarios serial (they manipulate host-global
+namespaces). The `--tags` expression supports `not`, `and`, and `or`, so
+you can select or exclude scenarios — e.g. `--tags "@isis_l1_p2p or
+@isis_tilfa"`.
+
+## Keeping the topology for inspection — `BDD_KEEP`
+
+By default a scenario tears its topology down at the end, even on
+failure, leaving nothing to look at. Set the **`BDD_KEEP`** environment
+variable to turn the teardown steps into no-ops so the daemons,
+namespaces, veths, and bridge survive the run:
+
+```sh
+BDD_KEEP=1 make ospf_clear_neighbor
+```
+
+With `BDD_KEEP` set, four steps are skipped (each prints a `⏭  BDD_KEEP
+set …` line instead of acting):
+
+- `I stop zebra-rs in namespace …` — the daemon keeps running,
+- `I delete namespace …` — the namespace stays up,
+- `I delete bridge …` — the bridge stays up,
+- `Then the test environment should be clean` — the cleanliness check is
+  skipped (it would otherwise fail, by design, because the topology is
+  still present).
+
+The scenario still runs to completion and its assertions still apply;
+only the cleanup is held back. Once the run finishes you can inspect the
+live topology directly — the namespaces are named `<feature-tag>_<node>`:
+
+```sh
+sudo ip netns list
+sudo ip netns exec ospf_clear_neighbor_o1 vtyctl show "show ip ospf neighbor"
+sudo ip netns exec ospf_clear_neighbor_o1 ip route
+```
+
+Per-daemon logs are written to `bdd/logs/<namespace>.log` regardless of
+`BDD_KEEP`, so they are available even on a normal run.
+
+> **Note** — a kept topology never leaks into a later run. The next run
+> of the same feature begins with `Given a clean test environment`,
+> which kills the stale pid files and deletes the prefix-matched
+> namespaces and bridge before rebuilding. You can also tear it down by
+> hand with `sudo ip netns del <feature-tag>_<node>`.
+
+`BDD_KEEP` is a coarse switch: it gates the teardown step definitions
+globally, so if a scenario ever used `delete namespace` or `stop
+zebra-rs` mid-test (rather than only as teardown) those would be
+suppressed too. In today's features those steps appear only in the
+teardown block, so the flag does exactly what its name implies.


### PR DESCRIPTION
## Summary

Adds a `BDD_KEEP` environment variable to the BDD integration harness that turns the teardown steps into no-ops, so a scenario's topology (daemons, namespaces, veths, bridge) survives the run for manual inspection — useful when debugging a passing or failing scenario without editing the feature file.

When `BDD_KEEP` is set, four step definitions print a `⏭  BDD_KEEP set …` line instead of acting:
- `I stop zebra-rs in namespace …`
- `I delete namespace …`
- `I delete bridge …`
- `Then the test environment should be clean` (skipped, since it would otherwise fail by design while the topology is still up)

The scenario still runs to completion and its assertions still apply; only cleanup is held back. The next run's `Given a clean test environment` sweeps leftovers, so a kept topology never leaks into a later run.

Also documents the BDD suite and the new flag in a new **Testing** book chapter (`ch-11-00-bdd-tests.md`).

## Test plan

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p bdd --test cucumber --no-run` — compiles
- `mdbook build` — succeeds
- Behavior is gated purely on `BDD_KEEP`; default (unset) runs are unchanged.

Generated with [Claude Code](https://claude.com/claude-code)