### PR TITLE
fix(isis): MT 2 v6 RIB nexthop link_id + refresh multi-topology test

### DIFF
--- a/bdd/tests/features/isis_multi_topology.feature
+++ b/bdd/tests/features/isis_multi_topology.feature
@@ -49,10 +49,10 @@ Feature: IS-IS multi-topology (RFC 5120)
 
   Scenario: LSPs carry the multi-topology TLVs
     Given the test topology exists
-    Then show command "show isis database detail" in namespace "z1" should contain "Multi-Topology"
-    And show command "show isis database detail" in namespace "z1" should contain "MT IPv6 Reachability (MT-ID 2)"
-    And show command "show isis database detail" in namespace "z2" should contain "Multi-Topology"
-    And show command "show isis database detail" in namespace "z2" should contain "MT IPv6 Reachability (MT-ID 2)"
+    Then show command "show isis database detail" in namespace "z1" should contain "MT Router Info: ipv6-unicast"
+    And show command "show isis database detail" in namespace "z1" should contain "MT IPv6 Reachability:"
+    And show command "show isis database detail" in namespace "z2" should contain "MT Router Info: ipv6-unicast"
+    And show command "show isis database detail" in namespace "z2" should contain "MT IPv6 Reachability:"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/zebra-rs/src/isis/graph.rs
+++ b/zebra-rs/src/isis/graph.rs
@@ -324,14 +324,37 @@ pub fn graph_mt2(
         nodes_to_process.push((neighbor_id, is_originated, lsp));
     }
 
+    // Same local-adjacency → ifindex map as graph(). Used to stamp
+    // link_id = ifindex onto the first-hop edges emitted from our own
+    // router LSP so build_rib_from_spf_v6 can resolve each MT 2 nexthop
+    // back to a local interface. Without it every MT 2 edge would carry
+    // link_id = 0, which the v6 rib-builder skips — leaving the MT 2
+    // IPv6 RIB empty. For LAN adjacencies the key is the
+    // (DIS_sys_id, pseudo_id) of the pseudonode.
+    let mut local_adj_to_ifindex: BTreeMap<IsisNeighborId, u32> = BTreeMap::new();
+    for (ifindex, link) in top.links.iter() {
+        if let Some((adj, _)) = link.state.adj.get(&level) {
+            local_adj_to_ifindex.insert(*adj, *ifindex);
+        }
+    }
+
     for (neighbor_id, is_originated, lsp) in nodes_to_process {
         let node_id = top.lsp_map.get_mut(&level).get(&neighbor_id);
         // Same source rule as graph(): only set when our own router
         // LSP is processed, never a pseudonode we may have originated.
-        if is_originated && !lsp.lsp_id.is_pseudo() {
+        let own_router_lsp = is_originated && !lsp.lsp_id.is_pseudo();
+        if own_router_lsp {
             source_node = Some(node_id);
         }
-        let vertex = create_graph_vertex_mt2(top, level, node_id, &neighbor_id, &lsp);
+        let vertex = create_graph_vertex_mt2(
+            top,
+            level,
+            node_id,
+            &neighbor_id,
+            &lsp,
+            own_router_lsp,
+            &local_adj_to_ifindex,
+        );
         graph.insert(node_id, vertex);
     }
 
@@ -344,6 +367,8 @@ fn create_graph_vertex_mt2(
     node_id: usize,
     neighbor_id: &IsisNeighborId,
     lsp: &IsisLsp,
+    own_router_lsp: bool,
+    local_adj_to_ifindex: &BTreeMap<IsisNeighborId, u32>,
 ) -> spf::Vertex {
     let sys_id = neighbor_id.sys_id();
     let is_pseudo = lsp.lsp_id.is_pseudo();
@@ -376,7 +401,15 @@ fn create_graph_vertex_mt2(
         ..Default::default()
     };
 
-    process_outgoing_links_mt2(top, level, node_id, lsp, &mut vertex.olinks);
+    process_outgoing_links_mt2(
+        top,
+        level,
+        node_id,
+        lsp,
+        own_router_lsp,
+        local_adj_to_ifindex,
+        &mut vertex.olinks,
+    );
 
     vertex
 }
@@ -386,6 +419,8 @@ fn process_outgoing_links_mt2(
     level: Level,
     from_id: usize,
     lsp: &IsisLsp,
+    own_router_lsp: bool,
+    local_adj_to_ifindex: &BTreeMap<IsisNeighborId, u32>,
     links: &mut Vec<spf::Link>,
 ) {
     if lsp.lsp_id.is_pseudo() {
@@ -427,7 +462,15 @@ fn process_outgoing_links_mt2(
             && mt_reach.mt.id() == 2
         {
             for entry in &mt_reach.entries {
-                process_neighbor_link_mt2(top, level, from_id, entry, links);
+                process_neighbor_link_mt2(
+                    top,
+                    level,
+                    from_id,
+                    entry,
+                    own_router_lsp,
+                    local_adj_to_ifindex,
+                    links,
+                );
             }
         }
     }
@@ -438,6 +481,8 @@ fn process_neighbor_link_mt2(
     level: Level,
     from_id: usize,
     entry: &IsisTlvExtIsReachEntry,
+    own_router_lsp: bool,
+    local_adj_to_ifindex: &BTreeMap<IsisNeighborId, u32>,
     links: &mut Vec<spf::Link>,
 ) {
     let neighbor_lsp_id: IsisLspId = entry.neighbor_id.into();
@@ -466,6 +511,19 @@ fn process_neighbor_link_mt2(
         }
     }
 
+    // link_id is meaningful only for edges out of our own router LSP —
+    // the SPF's first-hop slot the v6 rib-builder resolves to a local
+    // interface. Edges from other routers' LSPs carry link_id = 0.
+    // Mirrors graph()'s legacy ExtIsReach handling.
+    let link_id = if own_router_lsp {
+        local_adj_to_ifindex
+            .get(&entry.neighbor_id)
+            .copied()
+            .unwrap_or(0)
+    } else {
+        0
+    };
+
     let to_id = top
         .lsp_map
         .get_mut(&level)
@@ -474,7 +532,7 @@ fn process_neighbor_link_mt2(
         from: from_id,
         to: to_id,
         cost: entry.metric,
-        link_id: 0,
+        link_id,
     });
 }
 


### PR DESCRIPTION
## Summary

Fixes both failures in the `@isis_multi_topology` BDD feature. Both were pre-existing (since the test landed in `db6fe4c6`), not regressions — the feature isn't run in CI (bdd is excluded), so they went unnoticed.

### 1. MT 2 IPv6 routes were never installed (the real bug)
`graph_mt2()` hardcoded `link_id: 0` on every edge. The v6 rib-builder (`build_rib_from_spf_v6`) resolves each nexthop's link-local address via SPF's `first_hop_links` and **skips any entry with `link_id == 0`** (`rib.rs`: `if *link_id == 0 { continue; }`). So `spf_nhops` stayed empty for every destination, the MT 2 IPv6 RIB was built empty, and no reciprocal loopback routes were installed — end-to-end IPv6 over the MT 2 path was unreachable even though TLV 222/229/237 were exchanged correctly.

**Fix:** mirror the proven legacy `graph()` path — build a `local_adj_to_ifindex` map and stamp `link_id = ifindex` onto the first-hop edges that come out of our own router LSP (other routers' edges keep `0`). Threaded `own_router_lsp` + the map down through `create_graph_vertex_mt2` → `process_outgoing_links_mt2` → `process_neighbor_link_mt2`. For a LAN adjacency the MtIsReach `neighbor_id` is the pseudonode's NeighborId — exactly the key `local_adj_to_ifindex` uses — so it resolves to the right local interface.

### 2. Stale `show isis database detail` assertions
The "LSPs carry the multi-topology TLVs" assertions were written 35 min before `ab9492fd` refined the MT TLV display to `MT Router Info: <topology>` and inline `MT IPv6 Reachability: <prefix> (Metric: N) <topology>` (dropping the old `Multi-Topology` / `(MT-ID 2)` labels). Point them at the current output.

## Test plan

- `cargo fmt --all` — clean
- `cargo build -p zebra-rs` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs isis::` — 137 passed, 0 failed
- BDD `@isis_multi_topology` not run in CI; the routing fix matches the working legacy broadcast path. Recommend a local re-run of `--tags "@isis_multi_topology"` to confirm the ping + show scenarios go green.

Generated with [Claude Code](https://claude.com/claude-code)