### PR TITLE
feat(cli): add ext:help to clear isis/ospf/ospfv3 subcommands

### DIFF
--- a/zebra-rs/yang/configure.yang
+++ b/zebra-rs/yang/configure.yang
@@ -93,7 +93,9 @@ module configure {
   }
 
   container clear {
+    ext:help "Clear operational state";
     container isis {
+      ext:help "IS-IS clear actions";
       // Force-recalculate the IS-IS SPF for both L1 and L2 instead
       // of waiting for the next LSDB update or the debounce timer.
       // Useful when manual diagnosis suspects a stuck route after
@@ -138,6 +140,7 @@ module configure {
       }
     }
     container ospf {
+      ext:help "OSPFv2 clear actions";
       // Force-recalculate the OSPFv2 SPF for every attached area
       // instead of waiting for the next LSDB event or the 1-second
       // coalescing timer. Mirrors FRR's `clear ip ospf process`
@@ -204,6 +207,7 @@ module configure {
       }
     }
     container ospfv3 {
+      ext:help "OSPFv3 clear actions";
       // Force-recalculate the OSPFv3 SPF for every attached area.
       // Sibling of `clear ospf spf` for the v3 instance.
       leaf spf {


### PR DESCRIPTION
## Summary

`clear ?` only showed help text for the `bgp` subcommand because its
siblings carried no `ext:help`. This adds help strings so all four
clear targets are documented:

```
clear ?
  bgp            BGP clear actions
  isis           IS-IS clear actions
  ospf           OSPFv2 clear actions
  ospfv3         OSPFv3 clear actions
```

The parent `clear` container also gains an `ext:help` ("Clear
operational state") so it is documented in the top-level `?` listing.

## Changes

- `zebra-rs/yang/configure.yang`: add `ext:help` to the `clear`, `clear
  isis`, `clear ospf`, and `clear ospfv3` containers.

## Test plan

- `cargo test -p zebra-rs --bins yang_load_tests` — both
  `configure_mode_loads` and `exec_mode_loads` pass (YANG isn't
  validated by cargo/clippy, so this is the relevant guard).

Generated with [Claude Code](https://claude.com/claude-code)