### PR TITLE
feat: configurable interface MTU with protocol sync

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -3,6 +3,7 @@
 [zebra-rs Routing Software](ch-00-00-introduction.md)
 - [Separation of Reachability Information and Forwarding Decision](ch-00-01-reachability-information.md)
 - [Router ID Selection](ch-00-02-router-id.md)
+- [Interface Configuration](ch-00-03-interface-configuration.md)
 
 ## Static Route
 

--- a/book/src/ch-00-03-interface-configuration.md
+++ b/book/src/ch-00-03-interface-configuration.md
@@ -1,0 +1,133 @@
+# Interface Configuration
+
+Interface attributes that are independent of any routing protocol live
+under the top-level `interface` list, keyed by the kernel interface
+name:
+
+```
+interface enp0s6 {
+  mtu 1400;
+  ipv4 {
+    address 10.0.0.1/24;
+  }
+}
+```
+
+| YANG leaf | Type | Notes |
+|---|---|---|
+| `/interface/<name>/if-name` | `string` | List key — the kernel interface name. |
+| `/interface/<name>/mtu` | `uint32` (68..65535) | Maximum transmission unit in bytes. See below. |
+| `/interface/<name>/vrf` | leafref `/vrf/name` | Enslave the interface to a VRF master device. |
+| `/interface/<name>/ipv4/address` | `inet:ipv4-prefix` | IPv4 address (with prefix length). |
+| `/interface/<name>/ipv6/address` | `inet:ipv6-prefix` | IPv6 address (with prefix length). |
+
+The list entry itself is not a separate "create interface" operation —
+it just attaches configuration to a kernel device that already exists
+(or appears later). zebra-rs does not create physical or virtual links
+from this block.
+
+## MTU
+
+The `mtu` leaf sets the interface MTU on the kernel. zebra-rs issues a
+netlink `RTM_NEWLINK` (`IFLA_MTU`) — the equivalent of
+`ip link set <name> mtu <n>`.
+
+```
+interface enp0s6 {
+  mtu 1400;
+}
+```
+
+### Default and range
+
+When `mtu` is unset, the interface keeps whatever MTU the kernel
+assigned it — typically **65536** for loopback devices and **1500**
+for everything else.
+
+The YANG schema constrains the configurable value to **68..65535**,
+which is the IPv4 lower bound (RFC 791) up to the 16-bit ceiling.
+The IPv6 minimum link MTU is **1280** (RFC 8200 §5): zebra-rs does not
+reject sub-1280 values up front, because whether they are legal depends
+on the interface's runtime state. Instead, the kernel is the authority
+— see *Apply failures* below.
+
+### Deleting the configuration
+
+Deleting the leaf restores the MTU the interface had **before** it was
+first configured (the value zebra-rs observed when it first learned the
+interface), not a hard-coded default:
+
+```
+no interface enp0s6 mtu
+```
+
+If, for example, the kernel reported 1500 when the daemon started and
+the operator configured 9000, then `no interface enp0s6 mtu` returns
+the interface to 1500.
+
+### Apply failures
+
+A value the kernel refuses — most commonly an MTU below the IPv6
+minimum of 1280 on an interface that has IPv6 enabled — is reported by
+`show interface`. The live MTU line continues to show the value the
+kernel actually has; a second line records the rejected attempt:
+
+```
+Interface: enp0s6
+  Hardware is Ethernet 52:54:00:11:22:33
+  index 2 metric 1 mtu 1500
+  MTU set to 1000 is failed due to Invalid argument (os error 22)
+  Link is Up
+  ...
+```
+
+The failure note clears automatically the next time a set on that
+interface succeeds.
+
+### Configuring before the interface exists
+
+The configured MTU is durable desired-state: it is kept even if the
+named interface is absent, and re-applied automatically when a matching
+interface appears (or re-appears after being removed and recreated).
+This makes the order of `interface` configuration and device creation
+irrelevant.
+
+## Protocol synchronisation
+
+Several protocols use the interface MTU when building packets, so a
+change must reach them rather than being a kernel-only setting:
+
+- **OSPF** stamps the Database Description packet's `Interface MTU`
+  field with it (RFC 2328 §10.6); a mismatch with a neighbour stalls
+  the adjacency in `ExStart` unless `mtu-ignore` is set.
+- **IS-IS** pads Hello PDUs up to the MTU (RFC 1195 §8) and sizes LSP
+  fragmentation against it.
+
+When the MTU of a known interface changes — whether through this
+configuration or an external `ip link set` — the RIB fans the new value
+out to every protocol that has the interface. They update their cached
+value in place, leaving adjacencies and state machines untouched, so
+the change is non-disruptive. Each protocol's interface view reflects
+the same value:
+
+```
+# show interface          → live kernel MTU
+# show ip ospf interface  → "ifindex 2, MTU 1400 bytes, BW 0 Mbit ..."
+# show isis interface detail → "Type: ..., SNPA: ..., MTU: 1400"
+```
+
+If these ever disagree it indicates the notification path was missed —
+they are sourced from one RIB-driven update, not independent reads.
+
+## Cross-reference — FRR / iproute2
+
+| zebra-rs | FRR `interface` / iproute2 |
+|---|---|
+| `interface <n> mtu <v>` | `mtu <v>` (interface) / `ip link set <n> mtu <v>` |
+| `no interface <n> mtu` | restore original — no direct FRR equivalent (FRR leaves the last value) |
+| `interface <n> ipv4 address <p>` | `ip address <p>` (interface) |
+| `interface <n> vrf <name>` | `ip link set <n> master <name>` |
+
+Note the delete semantics differ: zebra-rs restores the
+originally-observed MTU, whereas iproute2/FRR simply leave whatever was
+last set in place.

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -1750,6 +1750,29 @@ impl FibHandle {
         }
     }
 
+    /// Set the MTU of `ifindex` via `RTM_NEWLINK` carrying
+    /// `IFLA_MTU`. Mirrors `ip link set <link> mtu <n>`. Returns the
+    /// kernel error on rejection (e.g. EINVAL when the value is below
+    /// the IPv6 minimum of 1280 on a v6-enabled link) so the caller can
+    /// surface the reason; the success path relies on the kernel's
+    /// echoed `RTM_NEWLINK` to update the cached `Link::mtu`.
+    pub async fn link_set_mtu(&self, ifindex: u32, mtu: u32) -> anyhow::Result<()> {
+        let mut msg = LinkMessage::default();
+        msg.header.index = ifindex;
+        msg.attributes.push(LinkAttribute::Mtu(mtu));
+
+        let mut req = NetlinkMessage::from(RouteNetlinkMessage::NewLink(msg));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK;
+
+        let mut response = self.handle.clone().request(req)?;
+        while let Some(m) = response.next().await {
+            if let NetlinkPayload::Error(e) = m.payload {
+                return Err(anyhow::anyhow!("{}", e));
+            }
+        }
+        Ok(())
+    }
+
     pub async fn addr_add_ipv4(
         &self,
         ifindex: u32,

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1343,6 +1343,9 @@ impl Isis {
             RibRx::LinkDown(ifindex) => {
                 self.link_state_down(ifindex);
             }
+            RibRx::LinkMtu { ifindex, mtu } => {
+                self.link_mtu(ifindex, mtu);
+            }
             RibRx::AddrAdd(addr) => {
                 // isis_info!("Isis::AddrAdd {}", addr.addr);
                 self.addr_add(addr);

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -721,6 +721,17 @@ impl Isis {
         }
     }
 
+    /// Refresh the cached interface MTU after a kernel/operator MTU
+    /// change. IS-IS uses it for hello padding (RFC 1195 §8) and LSP
+    /// fragmentation sizing, and renders it in `show isis interface`.
+    /// Those all read the live `state.mtu`, so updating it in place is
+    /// enough — adjacencies stay up.
+    pub fn link_mtu(&mut self, ifindex: u32, mtu: u32) {
+        if let Some(link) = self.links.get_mut(&ifindex) {
+            link.state.mtu = mtu;
+        }
+    }
+
     /// React to a kernel-side link-down event. Adjacencies on this
     /// link can't continue — packets stop flowing the moment IFF_UP
     /// drops — so tear them down immediately rather than ride out
@@ -1625,6 +1636,7 @@ struct InterfaceDetailJson {
     network_type: String,
     level: String,
     snpa: Option<String>,
+    mtu: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     level_1_info: Option<LevelInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1796,6 +1808,7 @@ pub fn show_detail(
                     network_type: format!("{}", link.config.network_type()),
                     level: format!("{}", link.state.level()),
                     snpa: link.state.mac.map(|mac| mac.to_string()),
+                    mtu: link.state.mtu,
                     level_1_info: None,
                     level_2_info: None,
                     authentication: build_auth_info(link),
@@ -1833,10 +1846,11 @@ pub fn show_detail(
                 )?;
                 writeln!(
                     buf,
-                    "  Type: {}, Level: {}, SNPA: {}",
+                    "  Type: {}, Level: {}, SNPA: {}, MTU: {}",
                     link.config.network_type(),
                     link.state.level(),
                     link.state.mac.unwrap_or(MacAddr::from([0, 0, 0, 0, 0, 0])),
+                    link.state.mtu,
                 )?;
                 if has_level(link.state.level(), Level::L1) {
                     writeln!(buf, "  Level-1 Information:")?;

--- a/zebra-rs/src/nd/engine.rs
+++ b/zebra-rs/src/nd/engine.rs
@@ -195,6 +195,7 @@ mod tests {
             index,
             name: name.to_string(),
             mtu: 1500,
+            original_mtu: 1500,
             metric: 1,
             flags: LinkFlags::default(),
             link_type: LinkType::Ethernet,
@@ -205,6 +206,7 @@ mod tests {
             master: None,
             vni: None,
             vxlan_local: None,
+            mtu_error: None,
         }
     }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -814,6 +814,16 @@ impl<V: OspfVersion> Ospf<V> {
         }
     }
 
+    /// The kernel MTU of an interface changed. Refresh the cached
+    /// value used to stamp the DD packet's `if_mtu` (RFC 2328 §10.6 MTU
+    /// mismatch) and shown by `show ip[v6] ospf interface`. Shared by
+    /// v2 and v3; updating in place keeps the IFSM/adjacency untouched.
+    fn link_mtu(&mut self, ifindex: u32, mtu: u32) {
+        if let Some(link) = self.links.get_mut(&ifindex) {
+            link.mtu = mtu;
+        }
+    }
+
     /// The kernel link is gone. If OSPF was enabled on it, fire
     /// `Disable` so the IFSM tears the adjacency down, then drop
     /// the link from `self.links`. Shared by v2 and v3.
@@ -3998,6 +4008,9 @@ impl Ospf<Ospfv2> {
             RibRx::LinkDel(ifindex) => {
                 self.link_del(ifindex);
             }
+            RibRx::LinkMtu { ifindex, mtu } => {
+                self.link_mtu(ifindex, mtu);
+            }
             RibRx::AddrAdd(addr) => {
                 self.addr_add(addr);
             }
@@ -4338,6 +4351,7 @@ impl Ospf<Ospfv3> {
             RibRx::LinkUp(ifindex) => self.link_up(ifindex),
             RibRx::LinkDown(ifindex) => self.link_down(ifindex),
             RibRx::LinkDel(ifindex) => self.link_del(ifindex),
+            RibRx::LinkMtu { ifindex, mtu } => self.link_mtu(ifindex, mtu),
             RibRx::AddrAdd(addr) => self.addr_add(addr),
             RibRx::AddrDel(addr) => self.addr_del(addr),
             // VRF master lifecycle (default instance only): spawn /

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -85,6 +85,17 @@ pub enum RibRx {
     /// `LinkDown` (operational down) — `LinkDel` is permanent for
     /// this ifindex.
     LinkDel(u32),
+    /// The MTU of an already-known link changed (operator
+    /// `interface X mtu N`, or an external `ip link set`). Protocol
+    /// modules cache MTU per interface for packet generation (OSPF DD
+    /// `if_mtu`, IS-IS hello padding / LSP fragmentation) and for their
+    /// own `show <proto> interface`; they update that cached value in
+    /// place rather than rebuilding link state, so adjacencies/FSMs are
+    /// untouched.
+    LinkMtu {
+        ifindex: u32,
+        mtu: u32,
+    },
     AddrAdd(LinkAddr),
     AddrDel(LinkAddr),
     RouterIdUpdate(Ipv4Addr),
@@ -264,6 +275,14 @@ impl Rib {
         let vrf_id = self.ifindex_vrf_id(ifindex);
         for (_, sub) in self.client_registry.iter_vrf(vrf_id) {
             let _ = sub.rib_rx_tx.send(RibRx::LinkDown(ifindex));
+        }
+    }
+
+    /// Push an MTU change to subscribers bound to this link's VRF.
+    pub fn api_link_mtu(&self, ifindex: u32, mtu: u32) {
+        let vrf_id = self.ifindex_vrf_id(ifindex);
+        for (_, sub) in self.client_registry.iter_vrf(vrf_id) {
+            let _ = sub.rib_rx_tx.send(RibRx::LinkMtu { ifindex, mtu });
         }
     }
 

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -460,6 +460,12 @@ pub struct Rib {
     /// when a missing interface or VRF master appears later, and clears
     /// the entry once the netlink call succeeds.
     pub pending_vrf_bind: BTreeMap<String, Option<String>>,
+    /// Operator-configured interface MTU, keyed by ifname. This is the
+    /// durable desired-state for `set interface <name> mtu <n>`: it is
+    /// applied to the kernel when set, replayed when a matching link
+    /// (re)appears, and on delete reverts the kernel to the link's
+    /// originally-observed MTU (`Link::original_mtu`).
+    pub mtu_config: BTreeMap<String, u32>,
     pub table: PrefixMap<Ipv4Net, RibEntries>,
     pub table_v6: PrefixMap<Ipv6Net, RibEntries>,
     pub ilm: BTreeMap<u32, IlmEntries>,
@@ -590,6 +596,7 @@ impl Rib {
             vrf_tables: BTreeMap::new(),
             vrf_id_alloc: VrfIdAllocator::new(),
             pending_vrf_bind: BTreeMap::new(),
+            mtu_config: BTreeMap::new(),
             table: PrefixMap::new(),
             table_v6: PrefixMap::new(),
             ilm: BTreeMap::new(),

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -31,6 +31,14 @@ pub struct Link {
     pub index: u32,
     pub name: String,
     pub mtu: u32,
+    /// MTU the kernel reported when this link was first observed,
+    /// before any operator-configured MTU was applied. Captured once in
+    /// `Link::from` and never updated thereafter, so it survives our own
+    /// `link_set_mtu` echoing back. Restored when the operator deletes
+    /// `interface <name> mtu`. Internal bookkeeping — not part of any
+    /// `show` output, so it stays out of the serialized form.
+    #[serde(skip)]
+    pub original_mtu: u32,
     pub metric: u32,
     #[serde(with = "linkflags_serde")]
     pub flags: LinkFlags,
@@ -50,6 +58,14 @@ pub struct Link {
     /// on VXLAN links. Used as the BGP MP_REACH nexthop for EVPN
     /// advertisements per RFC 8365 §5.1.3.
     pub vxlan_local: Option<std::net::IpAddr>,
+    /// Last failure reason from applying the operator-configured MTU
+    /// (`mtu_config` keyed by name on `Rib`). `None` once a set
+    /// succeeds. Rendered by `show interface` so a kernel rejection
+    /// (e.g. an MTU below the IPv6 minimum of 1280 on a v6-enabled
+    /// link) is visible to the operator. Display-only — the live MTU
+    /// is always whatever the kernel reports in `mtu`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mtu_error: Option<String>,
 }
 
 impl Link {
@@ -58,6 +74,7 @@ impl Link {
             index: link.index,
             name: link.name.to_owned(),
             mtu: link.mtu,
+            original_mtu: link.mtu,
             metric: 1,
             flags: link.flags,
             link_type: link.link_type,
@@ -68,6 +85,7 @@ impl Link {
             master: link.master,
             vni: link.vni,
             vxlan_local: link.vxlan_local,
+            mtu_error: None,
         }
     }
 
@@ -150,6 +168,9 @@ fn link_info_show(rib: &Rib, link: &Link, buf: &mut String, cb: &impl Fn(&String
         link.index, link.metric, link.mtu
     )
     .unwrap();
+    if let Some(err) = &link.mtu_error {
+        writeln!(buf, "  {}", err).unwrap();
+    }
     write!(
         buf,
         "  Link is {}",
@@ -196,6 +217,8 @@ pub struct InterfaceDetailed {
     pub index: u32,
     pub metric: u32,
     pub mtu: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mtu_error: Option<String>,
     pub link_status: String,
     pub flags: String,
     pub vrf_binding: String,
@@ -322,6 +345,7 @@ fn link_to_detailed_json(rib: &Rib, link: &Link) -> InterfaceDetailed {
         index: link.index,
         metric: link.metric,
         mtu: link.mtu,
+        mtu_error: link.mtu_error.clone(),
         link_status: if link.is_up() {
             "Up".to_string()
         } else {
@@ -460,6 +484,15 @@ impl Rib {
         // calls find no entry in `vni_ifindex_map` and silently skip.
         let prev_vni: Option<u32> = self.links.get(&ifindex).and_then(|l| l.vni);
 
+        // Capture MTU pre-state and the incoming value so a change on an
+        // already-known link (operator `interface X mtu N`, or an
+        // external `ip link set ... mtu`) can be fanned out to protocol
+        // modules that cache it for packet generation (OSPF DD if_mtu,
+        // IS-IS hello padding). `prev_mtu` is None for a brand-new link —
+        // its mtu rides along on `api_link_add` instead.
+        let prev_mtu: Option<u32> = self.links.get(&ifindex).map(|l| l.mtu);
+        let new_mtu: u32 = fib_link.mtu;
+
         // Capture master pre-state so an existing link crossing a VRF
         // boundary (operator `interface X vrf Y`, applied by the kernel
         // as an RTM_NEWLINK on an already-known ifindex) can be
@@ -508,6 +541,11 @@ impl Rib {
             // FDB resolution gets the right bridge.
             link.master = fib_link.master;
             link.vni = fib_link.vni;
+            // Adopt the kernel's current MTU (it may have changed since
+            // we last saw this link — our own `link_set_mtu` echoes back
+            // here, as does an external `ip link set`). The fan-out to
+            // protocols happens after the borrow is released, below.
+            link.mtu = fib_link.mtu;
         } else {
             let link = Link::from(fib_link);
             let _ = sysctl_mpls_enable(&link.name);
@@ -520,9 +558,45 @@ impl Rib {
             // post-block reconciliation below (covers both new-link
             // and existing-link paths uniformly).
 
+            // Replay an operator-configured MTU for a freshly-appeared
+            // link (config-before-interface, or interface re-created).
+            // Only re-issue when the live value differs; the kernel's
+            // echoed RTM_NEWLINK then updates the cached mtu. Scoped to
+            // the new-link branch so plain RTM_NEWLINK echoes don't
+            // re-attempt a previously-rejected set on every event.
+            if let Some(&mtu) = self.mtu_config.get(&link.name)
+                && mtu != link.mtu
+            {
+                let ifindex = link.index;
+                let name = link.name.clone();
+                match self.fib_handle.link_set_mtu(ifindex, mtu).await {
+                    Ok(()) => {
+                        if let Some(l) = self.links.get_mut(&ifindex) {
+                            l.mtu_error = None;
+                        }
+                    }
+                    Err(e) => {
+                        if let Some(l) = self.links.get_mut(&ifindex) {
+                            l.mtu_error = Some(format!("MTU set to {mtu} is failed due to {e}"));
+                        }
+                        tracing::warn!("link_set_mtu({name}, {mtu}) failed: {e}");
+                    }
+                }
+            }
+
             if !link.is_up() {
                 self.make_link_up(link.index).await;
             }
+        }
+
+        // Fan out an MTU change on an already-known link to protocol
+        // subscribers. `prev_mtu` is Some only when the link existed
+        // before this call; a brand-new link carried its mtu on the
+        // `api_link_add` above, so this fires only on genuine changes.
+        if let Some(prev) = prev_mtu
+            && prev != new_mtu
+        {
+            self.api_link_mtu(ifindex, new_mtu);
         }
 
         // A master change that crosses a VRF boundary moves this
@@ -965,6 +1039,64 @@ pub async fn link_config_exec(
             None
         };
         let _ = rib.tx.send(Message::LinkVrfBind { ifname, vrf });
+    } else if path == "/interface/mtu" {
+        // `set interface X mtu N`    → record desired MTU and apply it.
+        // `delete interface X mtu`   → drop the desired MTU and restore
+        // the per-type kernel default (65536 loopback / 1500 otherwise).
+        //
+        // The configured value is durable desired-state in
+        // `rib.mtu_config` (keyed by name) so it survives the interface
+        // disappearing and is replayed by `link_add` when it returns.
+        // We only *issue* the netlink set here; the kernel's echoed
+        // RTM_NEWLINK updates the cached `Link::mtu` (and fans the
+        // change out to protocols) via `link_add`. A rejected set
+        // produces no echo, so we capture the reason in `Link::mtu_error`
+        // for `show interface`.
+        if op.is_set() {
+            let mtu = args.u32().context("missing mtu value")?;
+            rib.mtu_config.insert(ifname.clone(), mtu);
+            if let Some(ifindex) = link_lookup(rib, ifname.clone()) {
+                match rib.fib_handle.link_set_mtu(ifindex, mtu).await {
+                    Ok(()) => {
+                        if let Some(link) = rib.links.get_mut(&ifindex) {
+                            link.mtu_error = None;
+                        }
+                    }
+                    Err(e) => {
+                        if let Some(link) = rib.links.get_mut(&ifindex) {
+                            link.mtu_error = Some(format!("MTU set to {mtu} is failed due to {e}"));
+                        }
+                        tracing::warn!("link_set_mtu({ifname}, {mtu}) failed: {e}");
+                    }
+                }
+            }
+        } else {
+            // Drain a trailing value token if the delete carried one.
+            let _ = args.u32();
+            rib.mtu_config.remove(&ifname);
+            if let Some(ifindex) = link_lookup(rib, ifname.clone()) {
+                // Restore the MTU the kernel reported when we first
+                // observed this link, before any operator MTU was
+                // applied (see `Link::original_mtu`).
+                let original = rib.links.get(&ifindex).map(|l| l.original_mtu);
+                if let Some(original) = original {
+                    match rib.fib_handle.link_set_mtu(ifindex, original).await {
+                        Ok(()) => {
+                            if let Some(link) = rib.links.get_mut(&ifindex) {
+                                link.mtu_error = None;
+                            }
+                        }
+                        Err(e) => {
+                            if let Some(link) = rib.links.get_mut(&ifindex) {
+                                link.mtu_error =
+                                    Some(format!("MTU set to {original} is failed due to {e}"));
+                            }
+                            tracing::warn!("link_set_mtu({ifname}, {original}) failed: {e}");
+                        }
+                    }
+                }
+            }
+        }
     }
     Ok(())
 }
@@ -1061,6 +1193,7 @@ mod tests {
             index: 1,
             name: "test0".to_string(),
             mtu: 1500,
+            original_mtu: 1500,
             metric: 1,
             flags: LinkFlags::empty(),
             link_type: LinkType::Ethernet,
@@ -1071,6 +1204,7 @@ mod tests {
             master: None,
             vni: None,
             vxlan_local: None,
+            mtu_error: None,
         }
     }
 

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -2607,6 +2607,19 @@ module config {
            Omitted means the interface lives in the default routing
            instance.";
       }
+      leaf mtu {
+        ext:help "Maximum transmission unit in bytes";
+        type uint32 {
+          range "68..65535";
+        }
+        description
+          "Operator-set interface MTU. When unset the interface keeps
+           the MTU the kernel assigned it (typically 65536 for loopback,
+           1500 otherwise); deleting this leaf restores that originally-
+           observed value. The IPv6 minimum is 1280, so setting a smaller
+           MTU on an interface with IPv6 enabled is rejected by the
+           kernel and reported by `show interface`.";
+      }
       container ipv4 {
         leaf address {
           type inet:ipv4-prefix;


### PR DESCRIPTION
## Summary

Adds `interface <name> { mtu <n>; }` configuration end-to-end:

- **Config + YANG**: new `mtu` leaf on the `interface` list, range `68..65535`.
- **Netlink**: new `link_set_mtu` (`RTM_NEWLINK`/`IFLA_MTU`) — the only place that *writes* MTU to the kernel (previously read-only).
- **Default / delete**: when unset the kernel-assigned MTU applies (65536 loopback / 1500 otherwise); deleting the leaf restores the MTU the interface had when first observed (`Link::original_mtu`), not a hard-coded default.
- **IPv6 minimum (1280)**: left to the kernel. A rejected set produces no netlink echo, so the reason is captured in `Link::mtu_error` and rendered by `show interface` as `MTU set to <n> is failed due to <reason>`.
- **Durable desired-state**: configured MTU is kept in a name-keyed `mtu_config` map and replayed when the interface (re)appears — config order vs. device creation is irrelevant.
- **Protocol sync**: an MTU change on a known link is fanned out via a new `RibRx::LinkMtu`. OSPF (v2+v3) and IS-IS update their cached per-link MTU in place (no link rebuild — adjacencies/FSMs untouched), keeping DD `if_mtu` / IS-IS hello padding and `show <proto> interface` consistent with the kernel. `show isis interface detail` now displays MTU (OSPF already did).
- **Docs**: new "Interface Configuration" chapter in `book/`.

## Test plan

- `cargo build -p zebra-rs` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all` — applied
- `cargo test -p zebra-rs` — 844 passed / 0 failed (incl. the `configure_mode_loads` YANG guard)
- `mdbook build` — clean
- bdd/integration not run locally — left to CI

Generated with [Claude Code](https://claude.com/claude-code)