### PR TITLE
feat(isis): add optional level to clear isis spf

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -771,7 +771,7 @@ impl Isis {
             return;
         }
 
-        let (path, args) = path_from_command(&msg.paths);
+        let (path, mut args) = path_from_command(&msg.paths);
 
         // Clear ops don't go through the YANG callback table — they
         // map directly to runtime side-effects (kick SPF, drop a
@@ -781,7 +781,10 @@ impl Isis {
         if msg.op == ConfigOp::Clear {
             match path.as_str() {
                 "/clear/isis/spf" => {
-                    self.clear_spf();
+                    // Bare `clear isis spf` (no arg) recalculates both
+                    // levels; `clear isis spf level-1|level-2` carries
+                    // the level as a matched enum key in `args`.
+                    self.clear_spf(args.string().as_deref());
                 }
                 "/clear/isis/checkpoint/write" => {
                     self.checkpoint_write_debug();
@@ -859,14 +862,21 @@ impl Isis {
         }
     }
 
-    /// Force-recalculate the IS-IS SPF for both L1 and L2. Mirrors
-    /// FRR's `clear isis spf` — useful when an operator wants to
-    /// re-derive the route table without waiting for the next LSDB
-    /// update or the debounce timer to fire. Levels with no SPF
-    /// state yet are no-ops on the receiver side.
-    fn clear_spf(&mut self) {
-        let _ = self.tx.send(Message::SpfCalc(Level::L1));
-        let _ = self.tx.send(Message::SpfCalc(Level::L2));
+    /// Force-recalculate the IS-IS SPF. Mirrors FRR's `clear isis
+    /// spf` — useful when an operator wants to re-derive the route
+    /// table without waiting for the next LSDB update or the debounce
+    /// timer to fire. `level` selects a single level (`level-1` /
+    /// `level-2`); `None` (the bare command) recalculates both.
+    /// Levels with no SPF state yet are no-ops on the receiver side.
+    fn clear_spf(&mut self, level: Option<&str>) {
+        let levels: &[Level] = match level {
+            Some("level-1") => &[Level::L1],
+            Some("level-2") => &[Level::L2],
+            _ => &[Level::L1, Level::L2],
+        };
+        for level in levels {
+            let _ = self.tx.send(Message::SpfCalc(*level));
+        }
     }
 
     /// Debug entry — capture the current IS-IS state and atomically

--- a/zebra-rs/yang/configure.yang
+++ b/zebra-rs/yang/configure.yang
@@ -96,12 +96,26 @@ module configure {
     ext:help "Clear operational state";
     container isis {
       ext:help "IS-IS clear actions";
-      // Force-recalculate the IS-IS SPF for both L1 and L2 instead
-      // of waiting for the next LSDB update or the debounce timer.
-      // Useful when manual diagnosis suspects a stuck route after
-      // an LSDB-side fix.
-      leaf spf {
-        type empty;
+      // Force-recalculate the IS-IS SPF instead of waiting for the
+      // next LSDB update or the debounce timer. Useful when manual
+      // diagnosis suspects a stuck route after an LSDB-side fix.
+      //
+      // Modeled as a presence list so the bare `clear isis spf` is a
+      // valid terminal (-> recalculate both L1 and L2) yet still
+      // accepts an optional `level-1`/`level-2` key (-> recalculate
+      // just that level), the same shape as `clear ospf neighbor
+      // [<router-id>]`.
+      list spf {
+        ext:help "Force SPF recalculation (bare does both levels)";
+        ext:presence "Recalculate both L1 and L2 SPF";
+        key level;
+        leaf level {
+          ext:help "Recalculate only this IS-IS level";
+          type enumeration {
+            enum level-1;
+            enum level-2;
+          }
+        }
       }
       container checkpoint {
         // Debug entry for the graceful-restart checkpoint storage


### PR DESCRIPTION
## Summary

`clear isis spf` now accepts an optional level argument:

- `clear isis spf` — recalculate SPF for **both** L1 and L2 (unchanged).
- `clear isis spf level-1` — recalculate only the level-1 SPF.
- `clear isis spf level-2` — recalculate only the level-2 SPF.

## Changes

- **`yang/configure.yang`**: changed the `spf` node from a `leaf … { type empty; }` to a presence `list` with an enum `level` key. `ext:presence` keeps the bare `clear isis spf` a valid terminal; the enum key adds the optional argument — the same shape as the existing `clear ospf neighbor [<router-id>]`.
- **`src/isis/inst.rs`**: `clear_spf` now takes `Option<&str>` and maps `None → [L1, L2]`, `Some("level-1") → [L1]`, `Some("level-2") → [L2]`, firing a `Message::SpfCalc` per selected level. The matched enum value flows in via `args` (the path stays `/clear/isis/spf`).

## Test plan

- `cargo fmt` applied.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p zebra-rs yang_load` — passes (validates the new YANG model loads; CI's YANG guard).

Generated with [Claude Code](https://claude.com/claude-code)