### PR TITLE
feat(isis): add "clear isis neighbor [SYSTEM_ID]" command

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -25,6 +25,7 @@
   - [Timer Configuration](ch-07-01-isis-timers.md)
   - [Shared Risk Link Group (SRLG)](ch-07-02-isis-srlg.md)
   - [BFD](ch-07-03-isis-bfd.md)
+  - [Clearing IS-IS State](ch-07-04-isis-clear.md)
 - [OSPFv2](ch-08-00-ospf.md)
   - [Configuration](ch-08-01-ospf-configuration.md)
   - [BFD](ch-08-02-ospf-bfd.md)

--- a/book/src/ch-07-04-isis-clear.md
+++ b/book/src/ch-07-04-isis-clear.md
@@ -1,0 +1,95 @@
+# Clearing IS-IS State
+
+IS-IS exposes a small set of operational `clear` commands that act on
+the running instance without touching the configuration. They live
+under the `clear isis …` tree and take effect immediately — there is
+no `commit`.
+
+## Resetting adjacencies — `clear isis neighbor`
+
+```
+clear isis neighbor [<system-id>]
+```
+
+Tear an IS-IS adjacency down so it re-forms from scratch. This is the
+operator-driven equivalent of a hold-timer expiry: the neighbor
+instance is **destroyed**, not merely nudged. Because a live peer keeps
+sending Hellos, the adjacency is re-learned on the next IIH and walks
+the state machine back up — `Down → Init → Up` — re-running the
+three-way handshake on point-to-point links (and DIS election on a
+LAN).
+
+The argument is the neighbor's **System ID** — the value shown in the
+`System Id` column of `show isis neighbor`, formatted `xxxx.xxxx.xxxx`:
+
+```
+zebra# show isis neighbor
+System Id           Interface   L  State         Holdtime SNPA
+0000.0000.0002      eth1        2  Up            27       2020.2020.2020
+
+zebra# clear isis neighbor 0000.0000.0002
+```
+
+With **no System ID**, the bare form clears *every* adjacency on the
+instance, across both levels:
+
+```
+clear isis neighbor          # reset all IS-IS adjacencies
+```
+
+A given System ID is matched on every interface and at both Level-1 and
+Level-2, so a neighbor reachable over parallel links or at both levels
+is reset everywhere it appears.
+
+What a clear triggers, as a side effect of the adjacency dropping and
+re-forming:
+
+- the local LSP is re-originated without then with the adjacency, and
+  the neighbour's TLV is withdrawn from the LSDB,
+- SPF re-runs, so routes learned through the neighbor are withdrawn and
+  re-installed as it bounces,
+- the DIS election re-runs on broadcast (LAN) circuits,
+- any Adjacency-SID / SRv6 End.X SID allocated for the neighbor is
+  released, and
+- any BFD session bound to the neighbor is released and re-subscribed.
+
+Tab-completion offers the live neighbor System IDs:
+
+```
+zebra# clear isis neighbor <TAB>
+0000.0000.0002
+```
+
+> **Note** — clearing a neighbor is briefly traffic-affecting: routes
+> reachable only through that adjacency are withdrawn until it returns
+> to `Up`. The neighbor's hold-time/up-time resets, which is the
+> simplest way to confirm the reset actually happened.
+
+## Forcing an SPF run — `clear isis spf`
+
+```
+clear isis spf
+```
+
+Force an immediate shortest-path-first recomputation for both Level-1
+and Level-2 instead of waiting for the next LSDB update or the SPF
+debounce timer. This recomputes routes from the **current** database;
+it does not re-exchange anything with neighbours. It is useful when
+manual diagnosis suspects a stale route after an LSDB-side change.
+
+## Graceful restart — `clear isis graceful-restart`
+
+```
+clear isis graceful-restart begin
+clear isis graceful-restart commit
+clear isis graceful-restart abort
+```
+
+Stage, commit, or unstage a planned RFC 5306 graceful restart of the
+local router. `begin` floods IIHs with the Restart TLV (RR set) and
+freezes self-LSP refresh; `commit` writes the restart checkpoint,
+drains, and exits the process for a supervisor to restart it (kernel
+routes tagged with the IS-IS RIB type survive); `abort` walks the
+staging back without exiting. These are covered in the graceful-restart
+material; they are listed here only because they share the `clear isis`
+tree.

--- a/crates/isis-packet/src/disp.rs
+++ b/crates/isis-packet/src/disp.rs
@@ -233,6 +233,29 @@ impl Display for IsisSysId {
     }
 }
 
+impl FromStr for IsisSysId {
+    type Err = ();
+
+    /// Parse the canonical `xxxx.xxxx.xxxx` system-id form — three
+    /// dot-separated groups of four hex digits, the exact shape
+    /// `Display` emits. Used by `clear isis neighbor <system-id>`.
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split('.').collect();
+        if parts.len() != 3 {
+            return Err(());
+        }
+        let mut id = [0u8; 6];
+        for (i, part) in parts.iter().enumerate() {
+            if part.len() != 4 {
+                return Err(());
+            }
+            id[i * 2] = u8::from_str_radix(&part[0..2], 16).map_err(|_| ())?;
+            id[i * 2 + 1] = u8::from_str_radix(&part[2..4], 16).map_err(|_| ())?;
+        }
+        Ok(IsisSysId { id })
+    }
+}
+
 impl Display for IsisNeighborId {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
@@ -471,5 +494,33 @@ impl Display for IsisTlvRestart {
             write!(f, " neighbor={}", id)?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::IsisSysId;
+
+    #[test]
+    fn sys_id_from_str_roundtrip() {
+        let id: IsisSysId = "0000.0000.0001".parse().unwrap();
+        assert_eq!(id.id, [0, 0, 0, 0, 0, 1]);
+        assert_eq!(id.to_string(), "0000.0000.0001");
+
+        let id: IsisSysId = "1921.6800.1001".parse().unwrap();
+        assert_eq!(id.id, [0x19, 0x21, 0x68, 0x00, 0x10, 0x01]);
+        assert_eq!(id.to_string(), "1921.6800.1001");
+    }
+
+    #[test]
+    fn sys_id_from_str_invalid() {
+        // Wrong group count.
+        assert!("0000.0000".parse::<IsisSysId>().is_err());
+        assert!("0000.0000.0001.0000".parse::<IsisSysId>().is_err());
+        // Wrong group width.
+        assert!("000.0000.0001".parse::<IsisSysId>().is_err());
+        assert!("00000.0000.0001".parse::<IsisSysId>().is_err());
+        // Non-hex.
+        assert!("zzzz.0000.0001".parse::<IsisSysId>().is_err());
     }
 }

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -758,6 +758,22 @@ impl Isis {
             return;
         }
 
+        // Dynamic tab-completion (`ext:dynamic "isis:<handler>"`): the
+        // manager sends the handler name as the sole path segment and
+        // waits on `msg.resp` for the candidate list. Answer directly —
+        // these are instance-level, not VRF-scoped.
+        if msg.op == ConfigOp::Completion {
+            let (path, _) = path_from_command(&msg.paths);
+            let comps = match path.as_str() {
+                "/neighbor" => self.neighbor_comps(),
+                _ => Vec::new(),
+            };
+            if let Some(resp) = msg.resp {
+                let _ = resp.send(comps);
+            }
+            return;
+        }
+
         // `/router/isis/vrf/<name>/...` belongs to a per-VRF instance,
         // not the default one. Strip the `vrf <name>` selector and
         // buffer the rewritten line (replayed into the child at spawn;
@@ -771,7 +787,7 @@ impl Isis {
             return;
         }
 
-        let (path, args) = path_from_command(&msg.paths);
+        let (path, mut args) = path_from_command(&msg.paths);
 
         // Clear ops don't go through the YANG callback table — they
         // map directly to runtime side-effects (kick SPF, drop a
@@ -782,6 +798,22 @@ impl Isis {
             match path.as_str() {
                 "/clear/isis/spf" => {
                     self.clear_spf();
+                }
+                "/clear/isis/neighbor" => {
+                    // `clear isis neighbor [<system-id>]`. The bare form
+                    // (no arg) tears down every adjacency; a trailing
+                    // `xxxx.xxxx.xxxx` system-id tears down only that
+                    // neighbor. Ignore an unparseable id rather than
+                    // falling through to "clear all" — a typo shouldn't
+                    // reset the whole instance.
+                    match args.string() {
+                        None => self.clear_neighbor(None),
+                        Some(s) => {
+                            if let Ok(sys_id) = s.parse::<IsisSysId>() {
+                                self.clear_neighbor(Some(sys_id));
+                            }
+                        }
+                    }
                 }
                 "/clear/isis/checkpoint/write" => {
                     self.checkpoint_write_debug();
@@ -867,6 +899,57 @@ impl Isis {
     fn clear_spf(&mut self) {
         let _ = self.tx.send(Message::SpfCalc(Level::L1));
         let _ = self.tx.send(Message::SpfCalc(Level::L2));
+    }
+
+    /// `clear isis neighbor [<system-id>]` — tear down adjacencies the
+    /// same way a hold-timer expiry would. With `id == None` every
+    /// adjacency on the instance is reset; with a system-id only the
+    /// neighbor(s) whose System ID matches (a neighbor can appear on
+    /// more than one link / level). We reuse the existing
+    /// `Message::Nfsm(HoldTimerExpire, …)` path — the same one the
+    /// inactivity timer fires — so the teardown (drop the adjacency,
+    /// re-originate Hello+LSP, re-elect the DIS on LAN, release
+    /// labels/SIDs, unsubscribe BFD, reschedule SPF) runs through one
+    /// code path. A live peer keeps Helloing, so the adjacency re-forms
+    /// from scratch (Down -> Up). Snapshot the targets first so the
+    /// borrow on `self.links` is released before we send (mirrors the
+    /// OSPF `clear_neighbor`).
+    fn clear_neighbor(&self, id: Option<IsisSysId>) {
+        let mut targets: Vec<(Level, u32, IsisSysId)> = Vec::new();
+        for (ifindex, link) in self.links.iter() {
+            for level in [Level::L1, Level::L2] {
+                for sys_id in link.state.nbrs.get(&level).keys() {
+                    if id.is_none_or(|want| want == *sys_id) {
+                        targets.push((level, *ifindex, *sys_id));
+                    }
+                }
+            }
+        }
+        for (level, ifindex, sys_id) in targets {
+            let _ = self.tx.send(Message::Nfsm(
+                NfsmEvent::HoldTimerExpire,
+                level,
+                ifindex,
+                sys_id,
+            ));
+        }
+    }
+
+    /// Candidate completions for `ext:dynamic "isis:neighbor"` — the
+    /// System IDs of the current adjacencies (the "System Id" column in
+    /// `show isis neighbor`), formatted `xxxx.xxxx.xxxx`. Deduped +
+    /// sorted via `BTreeSet` (a neighbor can appear on more than one
+    /// link / level).
+    fn neighbor_comps(&self) -> Vec<String> {
+        let mut ids: BTreeSet<IsisSysId> = BTreeSet::new();
+        for link in self.links.values() {
+            for level in [Level::L1, Level::L2] {
+                for sys_id in link.state.nbrs.get(&level).keys() {
+                    ids.insert(*sys_id);
+                }
+            }
+        }
+        ids.iter().map(|id| id.to_string()).collect()
     }
 
     /// Debug entry — capture the current IS-IS state and atomically

--- a/zebra-rs/yang/configure.yang
+++ b/zebra-rs/yang/configure.yang
@@ -101,6 +101,29 @@ module configure {
       leaf spf {
         type empty;
       }
+      // `clear isis neighbor [<system-id>]`. The bare (presence)
+      // form tears down every IS-IS adjacency on the instance;
+      // with a value it tears down only the neighbor whose System
+      // ID (the "System Id" column in `show isis neighbor`)
+      // matches. The teardown reuses the hold-timer-expiry path —
+      // the adjacency is dropped, Hello+LSP re-originated, the DIS
+      // re-elected on LAN, labels/SIDs released and SPF
+      // rescheduled — so a live peer's Hellos re-form it from
+      // scratch (Down -> Up). Mirrors the OSPF `clear ospf
+      // neighbor` shape: a presence list so the bare node is a
+      // valid terminal (-> reset all) yet still takes a positional
+      // key (-> reset one). The System ID is `xxxx.xxxx.xxxx`, so
+      // the arg type is a plain string.
+      list neighbor {
+        ext:help "Reset IS-IS adjacencies (bare resets all)";
+        ext:presence "Reset every IS-IS adjacency";
+        key id;
+        leaf id {
+          ext:help "Reset only the neighbor with this System ID";
+          ext:dynamic "isis:neighbor";
+          type string;
+        }
+      }
       container checkpoint {
         // Debug entry for the graceful-restart checkpoint storage
         // layer (Phase 5b of docs/design/isis-graceful-restart-


### PR DESCRIPTION
## Summary

Adds `clear isis neighbor` and `clear isis neighbor <SYSTEM_ID>`, mirroring the OSPF `clear ospf neighbor` command. With no system-id, **all** IS-IS adjacencies are cleared; with a system-id (`xxxx.xxxx.xxxx`), only the matching neighbor is cleared (across both levels).

The teardown reuses the **hold-timer-expiry path**, so it behaves exactly as if the neighbor's hold timer fired: each target is reset by sending `Message::Nfsm(HoldTimerExpire, …)` — the same event the inactivity timer sends — which drops the adjacency, re-originates Hello+LSP, re-elects the DIS on LAN, releases labels/End.X SIDs, unsubscribes BFD, and reschedules SPF. A live peer keeps Helloing, so the adjacency re-forms from scratch (Down → Up).

## Changes

- **`crates/isis-packet/src/disp.rs`** — `FromStr for IsisSysId` (the inverse of the existing `Display`), with round-trip + invalid-input unit tests.
- **`zebra-rs/yang/configure.yang`** — presence `list neighbor` under `clear/isis`, with `ext:dynamic "isis:neighbor"` tab-completion (same shape as the OSPF clear command).
- **`zebra-rs/src/isis/inst.rs`** — `ConfigOp::Completion` handler (`/neighbor` → live system-ids), `/clear/isis/neighbor` arm in the clear match (an unparseable system-id is ignored rather than falling through to clear-all), plus `clear_neighbor()` and `neighbor_comps()`. Follows the OSPF `clear_neighbor` collect-then-send pattern.

## Test plan

- `cargo build -p isis-packet` / `-p zebra-rs` — clean.
- `cargo test -p isis-packet` — new `FromStr` tests pass.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt` applied; YANG load test (`configure_mode_loads`) passes, validating the new YANG.
- bdd/integration suite left to CI.

Generated with [Claude Code](https://claude.com/claude-code)