### PR TITLE
feat(isis): add router isis lsp-mtu with over-MTU LSP drop

### DIFF
--- a/bdd/tests/configs/isis_fragmentation_ipv4/z1-3.yaml
+++ b/bdd/tests/configs/isis_fragmentation_ipv4/z1-3.yaml
@@ -1,0 +1,242 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.1/32
+- if-name: vz1ns
+  ipv4:
+    address: 10.0.1.1/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    # Force fragmentation at the standard Ethernet MTU: a 1500-byte cap
+    # on each LSP PDU leaves a 1473-byte TLV budget (lsp-mtu-size - 27
+    # bytes of PDU overhead). 200 /32 networks at 9 wire bytes each
+    # (RFC 5305: 4 metric + 1 control/flags + 4 prefix bytes) -> ~1800
+    # bytes of TLV 135 value, overflowing one fragment. The splitter
+    # caps each TLV 135 instance at the 255-byte length-field ceiling
+    # (~8 instances here); the packer then bins those instances into
+    # LSP fragments, so z1's self-LSP spans >= 2 fragments.
+    lsp-mtu-size: 1500
+    # Transmit-side LSP MTU deliberately raised above the 1500-byte
+    # interface MTU of vz1ns. IS-IS LSPs are flooded as a single
+    # link-layer frame, so an LSP at this size cannot fit on the wire:
+    # the flood path drops it (logged at warning level) for vz1ns. This
+    # config also adds one new network (100.64.0.201/32) so a receiver
+    # can prove the drop — the new prefix never reaches z2 while the
+    # over-MTU lsp-mtu is in effect.
+    lsp-mtu: 9000
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 100.64.0.1/32
+      - prefix: 100.64.0.2/32
+      - prefix: 100.64.0.3/32
+      - prefix: 100.64.0.4/32
+      - prefix: 100.64.0.5/32
+      - prefix: 100.64.0.6/32
+      - prefix: 100.64.0.7/32
+      - prefix: 100.64.0.8/32
+      - prefix: 100.64.0.9/32
+      - prefix: 100.64.0.10/32
+      - prefix: 100.64.0.11/32
+      - prefix: 100.64.0.12/32
+      - prefix: 100.64.0.13/32
+      - prefix: 100.64.0.14/32
+      - prefix: 100.64.0.15/32
+      - prefix: 100.64.0.16/32
+      - prefix: 100.64.0.17/32
+      - prefix: 100.64.0.18/32
+      - prefix: 100.64.0.19/32
+      - prefix: 100.64.0.20/32
+      - prefix: 100.64.0.21/32
+      - prefix: 100.64.0.22/32
+      - prefix: 100.64.0.23/32
+      - prefix: 100.64.0.24/32
+      - prefix: 100.64.0.25/32
+      - prefix: 100.64.0.26/32
+      - prefix: 100.64.0.27/32
+      - prefix: 100.64.0.28/32
+      - prefix: 100.64.0.29/32
+      - prefix: 100.64.0.30/32
+      - prefix: 100.64.0.31/32
+      - prefix: 100.64.0.32/32
+      - prefix: 100.64.0.33/32
+      - prefix: 100.64.0.34/32
+      - prefix: 100.64.0.35/32
+      - prefix: 100.64.0.36/32
+      - prefix: 100.64.0.37/32
+      - prefix: 100.64.0.38/32
+      - prefix: 100.64.0.39/32
+      - prefix: 100.64.0.40/32
+      - prefix: 100.64.0.41/32
+      - prefix: 100.64.0.42/32
+      - prefix: 100.64.0.43/32
+      - prefix: 100.64.0.44/32
+      - prefix: 100.64.0.45/32
+      - prefix: 100.64.0.46/32
+      - prefix: 100.64.0.47/32
+      - prefix: 100.64.0.48/32
+      - prefix: 100.64.0.49/32
+      - prefix: 100.64.0.50/32
+      - prefix: 100.64.0.51/32
+      - prefix: 100.64.0.52/32
+      - prefix: 100.64.0.53/32
+      - prefix: 100.64.0.54/32
+      - prefix: 100.64.0.55/32
+      - prefix: 100.64.0.56/32
+      - prefix: 100.64.0.57/32
+      - prefix: 100.64.0.58/32
+      - prefix: 100.64.0.59/32
+      - prefix: 100.64.0.60/32
+      - prefix: 100.64.0.61/32
+      - prefix: 100.64.0.62/32
+      - prefix: 100.64.0.63/32
+      - prefix: 100.64.0.64/32
+      - prefix: 100.64.0.65/32
+      - prefix: 100.64.0.66/32
+      - prefix: 100.64.0.67/32
+      - prefix: 100.64.0.68/32
+      - prefix: 100.64.0.69/32
+      - prefix: 100.64.0.70/32
+      - prefix: 100.64.0.71/32
+      - prefix: 100.64.0.72/32
+      - prefix: 100.64.0.73/32
+      - prefix: 100.64.0.74/32
+      - prefix: 100.64.0.75/32
+      - prefix: 100.64.0.76/32
+      - prefix: 100.64.0.77/32
+      - prefix: 100.64.0.78/32
+      - prefix: 100.64.0.79/32
+      - prefix: 100.64.0.80/32
+      - prefix: 100.64.0.81/32
+      - prefix: 100.64.0.82/32
+      - prefix: 100.64.0.83/32
+      - prefix: 100.64.0.84/32
+      - prefix: 100.64.0.85/32
+      - prefix: 100.64.0.86/32
+      - prefix: 100.64.0.87/32
+      - prefix: 100.64.0.88/32
+      - prefix: 100.64.0.89/32
+      - prefix: 100.64.0.90/32
+      - prefix: 100.64.0.91/32
+      - prefix: 100.64.0.92/32
+      - prefix: 100.64.0.93/32
+      - prefix: 100.64.0.94/32
+      - prefix: 100.64.0.95/32
+      - prefix: 100.64.0.96/32
+      - prefix: 100.64.0.97/32
+      - prefix: 100.64.0.98/32
+      - prefix: 100.64.0.99/32
+      - prefix: 100.64.0.100/32
+      - prefix: 100.64.0.101/32
+      - prefix: 100.64.0.102/32
+      - prefix: 100.64.0.103/32
+      - prefix: 100.64.0.104/32
+      - prefix: 100.64.0.105/32
+      - prefix: 100.64.0.106/32
+      - prefix: 100.64.0.107/32
+      - prefix: 100.64.0.108/32
+      - prefix: 100.64.0.109/32
+      - prefix: 100.64.0.110/32
+      - prefix: 100.64.0.111/32
+      - prefix: 100.64.0.112/32
+      - prefix: 100.64.0.113/32
+      - prefix: 100.64.0.114/32
+      - prefix: 100.64.0.115/32
+      - prefix: 100.64.0.116/32
+      - prefix: 100.64.0.117/32
+      - prefix: 100.64.0.118/32
+      - prefix: 100.64.0.119/32
+      - prefix: 100.64.0.120/32
+      - prefix: 100.64.0.121/32
+      - prefix: 100.64.0.122/32
+      - prefix: 100.64.0.123/32
+      - prefix: 100.64.0.124/32
+      - prefix: 100.64.0.125/32
+      - prefix: 100.64.0.126/32
+      - prefix: 100.64.0.127/32
+      - prefix: 100.64.0.128/32
+      - prefix: 100.64.0.129/32
+      - prefix: 100.64.0.130/32
+      - prefix: 100.64.0.131/32
+      - prefix: 100.64.0.132/32
+      - prefix: 100.64.0.133/32
+      - prefix: 100.64.0.134/32
+      - prefix: 100.64.0.135/32
+      - prefix: 100.64.0.136/32
+      - prefix: 100.64.0.137/32
+      - prefix: 100.64.0.138/32
+      - prefix: 100.64.0.139/32
+      - prefix: 100.64.0.140/32
+      - prefix: 100.64.0.141/32
+      - prefix: 100.64.0.142/32
+      - prefix: 100.64.0.143/32
+      - prefix: 100.64.0.144/32
+      - prefix: 100.64.0.145/32
+      - prefix: 100.64.0.146/32
+      - prefix: 100.64.0.147/32
+      - prefix: 100.64.0.148/32
+      - prefix: 100.64.0.149/32
+      - prefix: 100.64.0.150/32
+      - prefix: 100.64.0.151/32
+      - prefix: 100.64.0.152/32
+      - prefix: 100.64.0.153/32
+      - prefix: 100.64.0.154/32
+      - prefix: 100.64.0.155/32
+      - prefix: 100.64.0.156/32
+      - prefix: 100.64.0.157/32
+      - prefix: 100.64.0.158/32
+      - prefix: 100.64.0.159/32
+      - prefix: 100.64.0.160/32
+      - prefix: 100.64.0.161/32
+      - prefix: 100.64.0.162/32
+      - prefix: 100.64.0.163/32
+      - prefix: 100.64.0.164/32
+      - prefix: 100.64.0.165/32
+      - prefix: 100.64.0.166/32
+      - prefix: 100.64.0.167/32
+      - prefix: 100.64.0.168/32
+      - prefix: 100.64.0.169/32
+      - prefix: 100.64.0.170/32
+      - prefix: 100.64.0.171/32
+      - prefix: 100.64.0.172/32
+      - prefix: 100.64.0.173/32
+      - prefix: 100.64.0.174/32
+      - prefix: 100.64.0.175/32
+      - prefix: 100.64.0.176/32
+      - prefix: 100.64.0.177/32
+      - prefix: 100.64.0.178/32
+      - prefix: 100.64.0.179/32
+      - prefix: 100.64.0.180/32
+      - prefix: 100.64.0.181/32
+      - prefix: 100.64.0.182/32
+      - prefix: 100.64.0.183/32
+      - prefix: 100.64.0.184/32
+      - prefix: 100.64.0.185/32
+      - prefix: 100.64.0.186/32
+      - prefix: 100.64.0.187/32
+      - prefix: 100.64.0.188/32
+      - prefix: 100.64.0.189/32
+      - prefix: 100.64.0.190/32
+      - prefix: 100.64.0.191/32
+      - prefix: 100.64.0.192/32
+      - prefix: 100.64.0.193/32
+      - prefix: 100.64.0.194/32
+      - prefix: 100.64.0.195/32
+      - prefix: 100.64.0.196/32
+      - prefix: 100.64.0.197/32
+      - prefix: 100.64.0.198/32
+      - prefix: 100.64.0.199/32
+      - prefix: 100.64.0.200/32
+      - prefix: 100.64.0.201/32
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+    - if-name: vz1ns
+      circuit-type: level-2-only
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/isis_fragmentation_ipv4/z1-4.yaml
+++ b/bdd/tests/configs/isis_fragmentation_ipv4/z1-4.yaml
@@ -1,0 +1,239 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.1/32
+- if-name: vz1ns
+  ipv4:
+    address: 10.0.1.1/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    # Force fragmentation at the standard Ethernet MTU: a 1500-byte cap
+    # on each LSP PDU leaves a 1473-byte TLV budget (lsp-mtu-size - 27
+    # bytes of PDU overhead). 200 /32 networks at 9 wire bytes each
+    # (RFC 5305: 4 metric + 1 control/flags + 4 prefix bytes) -> ~1800
+    # bytes of TLV 135 value, overflowing one fragment. The splitter
+    # caps each TLV 135 instance at the 255-byte length-field ceiling
+    # (~8 instances here); the packer then bins those instances into
+    # LSP fragments, so z1's self-LSP spans >= 2 fragments.
+    lsp-mtu-size: 1500
+    # Recovery config for the lsp-mtu drop test: lsp-mtu is now 1400,
+    # below vz1ns's 1500-byte MTU, so z1's LSP floods normally again and
+    # z2 finally installs the 100.64.0.201/32 network that was dropped
+    # while lsp-mtu sat above the interface MTU (see z1-3.yaml).
+    lsp-mtu: 1400
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 100.64.0.1/32
+      - prefix: 100.64.0.2/32
+      - prefix: 100.64.0.3/32
+      - prefix: 100.64.0.4/32
+      - prefix: 100.64.0.5/32
+      - prefix: 100.64.0.6/32
+      - prefix: 100.64.0.7/32
+      - prefix: 100.64.0.8/32
+      - prefix: 100.64.0.9/32
+      - prefix: 100.64.0.10/32
+      - prefix: 100.64.0.11/32
+      - prefix: 100.64.0.12/32
+      - prefix: 100.64.0.13/32
+      - prefix: 100.64.0.14/32
+      - prefix: 100.64.0.15/32
+      - prefix: 100.64.0.16/32
+      - prefix: 100.64.0.17/32
+      - prefix: 100.64.0.18/32
+      - prefix: 100.64.0.19/32
+      - prefix: 100.64.0.20/32
+      - prefix: 100.64.0.21/32
+      - prefix: 100.64.0.22/32
+      - prefix: 100.64.0.23/32
+      - prefix: 100.64.0.24/32
+      - prefix: 100.64.0.25/32
+      - prefix: 100.64.0.26/32
+      - prefix: 100.64.0.27/32
+      - prefix: 100.64.0.28/32
+      - prefix: 100.64.0.29/32
+      - prefix: 100.64.0.30/32
+      - prefix: 100.64.0.31/32
+      - prefix: 100.64.0.32/32
+      - prefix: 100.64.0.33/32
+      - prefix: 100.64.0.34/32
+      - prefix: 100.64.0.35/32
+      - prefix: 100.64.0.36/32
+      - prefix: 100.64.0.37/32
+      - prefix: 100.64.0.38/32
+      - prefix: 100.64.0.39/32
+      - prefix: 100.64.0.40/32
+      - prefix: 100.64.0.41/32
+      - prefix: 100.64.0.42/32
+      - prefix: 100.64.0.43/32
+      - prefix: 100.64.0.44/32
+      - prefix: 100.64.0.45/32
+      - prefix: 100.64.0.46/32
+      - prefix: 100.64.0.47/32
+      - prefix: 100.64.0.48/32
+      - prefix: 100.64.0.49/32
+      - prefix: 100.64.0.50/32
+      - prefix: 100.64.0.51/32
+      - prefix: 100.64.0.52/32
+      - prefix: 100.64.0.53/32
+      - prefix: 100.64.0.54/32
+      - prefix: 100.64.0.55/32
+      - prefix: 100.64.0.56/32
+      - prefix: 100.64.0.57/32
+      - prefix: 100.64.0.58/32
+      - prefix: 100.64.0.59/32
+      - prefix: 100.64.0.60/32
+      - prefix: 100.64.0.61/32
+      - prefix: 100.64.0.62/32
+      - prefix: 100.64.0.63/32
+      - prefix: 100.64.0.64/32
+      - prefix: 100.64.0.65/32
+      - prefix: 100.64.0.66/32
+      - prefix: 100.64.0.67/32
+      - prefix: 100.64.0.68/32
+      - prefix: 100.64.0.69/32
+      - prefix: 100.64.0.70/32
+      - prefix: 100.64.0.71/32
+      - prefix: 100.64.0.72/32
+      - prefix: 100.64.0.73/32
+      - prefix: 100.64.0.74/32
+      - prefix: 100.64.0.75/32
+      - prefix: 100.64.0.76/32
+      - prefix: 100.64.0.77/32
+      - prefix: 100.64.0.78/32
+      - prefix: 100.64.0.79/32
+      - prefix: 100.64.0.80/32
+      - prefix: 100.64.0.81/32
+      - prefix: 100.64.0.82/32
+      - prefix: 100.64.0.83/32
+      - prefix: 100.64.0.84/32
+      - prefix: 100.64.0.85/32
+      - prefix: 100.64.0.86/32
+      - prefix: 100.64.0.87/32
+      - prefix: 100.64.0.88/32
+      - prefix: 100.64.0.89/32
+      - prefix: 100.64.0.90/32
+      - prefix: 100.64.0.91/32
+      - prefix: 100.64.0.92/32
+      - prefix: 100.64.0.93/32
+      - prefix: 100.64.0.94/32
+      - prefix: 100.64.0.95/32
+      - prefix: 100.64.0.96/32
+      - prefix: 100.64.0.97/32
+      - prefix: 100.64.0.98/32
+      - prefix: 100.64.0.99/32
+      - prefix: 100.64.0.100/32
+      - prefix: 100.64.0.101/32
+      - prefix: 100.64.0.102/32
+      - prefix: 100.64.0.103/32
+      - prefix: 100.64.0.104/32
+      - prefix: 100.64.0.105/32
+      - prefix: 100.64.0.106/32
+      - prefix: 100.64.0.107/32
+      - prefix: 100.64.0.108/32
+      - prefix: 100.64.0.109/32
+      - prefix: 100.64.0.110/32
+      - prefix: 100.64.0.111/32
+      - prefix: 100.64.0.112/32
+      - prefix: 100.64.0.113/32
+      - prefix: 100.64.0.114/32
+      - prefix: 100.64.0.115/32
+      - prefix: 100.64.0.116/32
+      - prefix: 100.64.0.117/32
+      - prefix: 100.64.0.118/32
+      - prefix: 100.64.0.119/32
+      - prefix: 100.64.0.120/32
+      - prefix: 100.64.0.121/32
+      - prefix: 100.64.0.122/32
+      - prefix: 100.64.0.123/32
+      - prefix: 100.64.0.124/32
+      - prefix: 100.64.0.125/32
+      - prefix: 100.64.0.126/32
+      - prefix: 100.64.0.127/32
+      - prefix: 100.64.0.128/32
+      - prefix: 100.64.0.129/32
+      - prefix: 100.64.0.130/32
+      - prefix: 100.64.0.131/32
+      - prefix: 100.64.0.132/32
+      - prefix: 100.64.0.133/32
+      - prefix: 100.64.0.134/32
+      - prefix: 100.64.0.135/32
+      - prefix: 100.64.0.136/32
+      - prefix: 100.64.0.137/32
+      - prefix: 100.64.0.138/32
+      - prefix: 100.64.0.139/32
+      - prefix: 100.64.0.140/32
+      - prefix: 100.64.0.141/32
+      - prefix: 100.64.0.142/32
+      - prefix: 100.64.0.143/32
+      - prefix: 100.64.0.144/32
+      - prefix: 100.64.0.145/32
+      - prefix: 100.64.0.146/32
+      - prefix: 100.64.0.147/32
+      - prefix: 100.64.0.148/32
+      - prefix: 100.64.0.149/32
+      - prefix: 100.64.0.150/32
+      - prefix: 100.64.0.151/32
+      - prefix: 100.64.0.152/32
+      - prefix: 100.64.0.153/32
+      - prefix: 100.64.0.154/32
+      - prefix: 100.64.0.155/32
+      - prefix: 100.64.0.156/32
+      - prefix: 100.64.0.157/32
+      - prefix: 100.64.0.158/32
+      - prefix: 100.64.0.159/32
+      - prefix: 100.64.0.160/32
+      - prefix: 100.64.0.161/32
+      - prefix: 100.64.0.162/32
+      - prefix: 100.64.0.163/32
+      - prefix: 100.64.0.164/32
+      - prefix: 100.64.0.165/32
+      - prefix: 100.64.0.166/32
+      - prefix: 100.64.0.167/32
+      - prefix: 100.64.0.168/32
+      - prefix: 100.64.0.169/32
+      - prefix: 100.64.0.170/32
+      - prefix: 100.64.0.171/32
+      - prefix: 100.64.0.172/32
+      - prefix: 100.64.0.173/32
+      - prefix: 100.64.0.174/32
+      - prefix: 100.64.0.175/32
+      - prefix: 100.64.0.176/32
+      - prefix: 100.64.0.177/32
+      - prefix: 100.64.0.178/32
+      - prefix: 100.64.0.179/32
+      - prefix: 100.64.0.180/32
+      - prefix: 100.64.0.181/32
+      - prefix: 100.64.0.182/32
+      - prefix: 100.64.0.183/32
+      - prefix: 100.64.0.184/32
+      - prefix: 100.64.0.185/32
+      - prefix: 100.64.0.186/32
+      - prefix: 100.64.0.187/32
+      - prefix: 100.64.0.188/32
+      - prefix: 100.64.0.189/32
+      - prefix: 100.64.0.190/32
+      - prefix: 100.64.0.191/32
+      - prefix: 100.64.0.192/32
+      - prefix: 100.64.0.193/32
+      - prefix: 100.64.0.194/32
+      - prefix: 100.64.0.195/32
+      - prefix: 100.64.0.196/32
+      - prefix: 100.64.0.197/32
+      - prefix: 100.64.0.198/32
+      - prefix: 100.64.0.199/32
+      - prefix: 100.64.0.200/32
+      - prefix: 100.64.0.201/32
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+    - if-name: vz1ns
+      circuit-type: level-2-only
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/isis_tilfa/s-lspmtu-ok.yaml
+++ b/bdd/tests/configs/isis_tilfa/s-lspmtu-ok.yaml
@@ -1,0 +1,49 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: s-n1
+  ipv4:
+    address: 192.168.0.1/30
+- if-name: s-n2
+  ipv4:
+    address: 192.168.0.5/30
+- if-name: s-n3
+  ipv4:
+    address: 192.168.0.9/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: s
+    # Recovery config for the lsp-mtu drop test: lsp-mtu is now 1400,
+    # below the 1500-byte MTU of s's links, so s's LSP floods normally
+    # again and n1 finally installs the 100.99.0.1/32 network that was
+    # dropped while lsp-mtu sat above the interface MTU (see
+    # s-lspmtu.yaml).
+    lsp-mtu: 1400
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 100.99.0.1/32
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 100
+    - if-name: s-n1
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: s-n2
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: s-n3
+      ipv4:
+        enable: true
+      metric: 1000
+    is-type: level-2-only
+    segment-routing: mpls
+    fast-reroute: ti-lfa
+    te-router-id: 10.0.0.1

--- a/bdd/tests/configs/isis_tilfa/s-lspmtu.yaml
+++ b/bdd/tests/configs/isis_tilfa/s-lspmtu.yaml
@@ -1,0 +1,50 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: s-n1
+  ipv4:
+    address: 192.168.0.1/30
+- if-name: s-n2
+  ipv4:
+    address: 192.168.0.5/30
+- if-name: s-n3
+  ipv4:
+    address: 192.168.0.9/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: s
+    # Transmit-side LSP MTU raised above the 1500-byte MTU of s's
+    # point-to-point veth links. An LSP is flooded as a single
+    # link-layer frame, so one at this size cannot fit on s-n1/s-n2/s-n3
+    # and the flood path drops it (logged at warning level) on every
+    # link. The 100.99.0.1/32 network below lets a neighbor prove the
+    # drop: it never reaches n1 while the over-MTU lsp-mtu is in effect.
+    lsp-mtu: 9000
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 100.99.0.1/32
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 100
+    - if-name: s-n1
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: s-n2
+      ipv4:
+        enable: true
+      metric: 1
+    - if-name: s-n3
+      ipv4:
+        enable: true
+      metric: 1000
+    is-type: level-2-only
+    segment-routing: mpls
+    fast-reroute: ti-lfa
+    te-router-id: 10.0.0.1

--- a/bdd/tests/features/isis_fragmentation_ipv4.feature
+++ b/bdd/tests/features/isis_fragmentation_ipv4.feature
@@ -16,6 +16,12 @@ Feature: IS-IS LSP fragmentation (IPv4) at lsp-mtu-size 400 and 1500
   (fragmentation needs 200 networks), confirming both the small-MTU
   path and that a runtime lsp-mtu-size change re-fragments correctly.
 
+  Finally, the same topology exercises the separate transmit-side
+  `lsp-mtu` knob: raising it above an interface's MTU makes the flood
+  path drop z1's LSP on send (logged at warning level), which `show isis
+  interface detail` flags and a receiver can prove by never learning a
+  freshly-added prefix until lsp-mtu is lowered back under the MTU.
+
   Test Topology:
   ```
   ┌────────────────────────────────────────┐
@@ -107,6 +113,36 @@ Feature: IS-IS LSP fragmentation (IPv4) at lsp-mtu-size 400 and 1500
     # last /32 sits well past fragment 0, so its presence in z2's RIB
     # proves the receiver re-merged the freshly re-fragmented LSP.
     Then show command "show isis route" in namespace "z2" should contain "100.64.0.200/32"
+
+  Scenario: lsp-mtu above the interface MTU is flagged in show isis interface detail
+    Given the test topology exists
+    When I apply config "z1-3.yaml" to namespace "z1"
+    And I wait 15 seconds
+    # z1-3.yaml sets lsp-mtu 9000 — larger than vz1ns's 1500-byte MTU.
+    # An LSP at that size can't fit a single link-layer frame, so the
+    # interface is flagged (and LSPs are dropped on send for it).
+    Then show command "show isis interface detail" in namespace "z1" should contain "exceeds interface MTU"
+
+  Scenario: lsp-mtu above the interface MTU drops z1's LSP on send so z2 never learns the new prefix
+    Given the test topology exists
+    # z1-3.yaml also added 100.64.0.201/32, but lsp-mtu 9000 > 1500 means
+    # the re-originated LSP cannot be flooded over vz1ns and is dropped,
+    # so z2 never receives the update.
+    Then show command "show isis route" in namespace "z2" should not contain "100.64.0.201/32"
+    # Dropping the send does not purge z2's existing LSDB, so z2 still
+    # reaches z1's loopback over the LSP it learned before the change.
+    And ping from "z2" to "10.255.0.1" should succeed
+
+  Scenario: Lowering lsp-mtu under the interface MTU lets z1's LSP flood again
+    Given the test topology exists
+    When I apply config "z1-4.yaml" to namespace "z1"
+    And I wait 20 seconds
+    # z1-4.yaml drops lsp-mtu to 1400 (< 1500), so the flood path no
+    # longer drops z1's LSP and the interface is no longer flagged.
+    Then show command "show isis interface detail" in namespace "z1" should not contain "exceeds interface MTU"
+    # z2 finally installs the previously-dropped network, proving the
+    # drop was caused by the over-MTU lsp-mtu rather than anything else.
+    And show command "show isis route" in namespace "z2" should contain "100.64.0.201/32"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/isis_tilfa.feature
+++ b/bdd/tests/features/isis_tilfa.feature
@@ -154,6 +154,32 @@ Feature: IS-IS TI-LFA fast-reroute over SR-MPLS
     # and adjacency-SIDs — leaving the LFIB completely empty.
     Then mpls ilm in namespace "s" should be empty
 
+  Scenario: lsp-mtu above the link MTU is flagged on the source's interfaces
+    Given the test topology exists
+    # s's point-to-point links are veth pairs with the default 1500-byte
+    # MTU. s-lspmtu.yaml raises lsp-mtu to 9000, so an LSP at that size
+    # can't fit a single frame on s-n1/s-n2/s-n3; the flood path drops it
+    # (logged at warning level) and show flags each link.
+    When I apply config "s-lspmtu.yaml" to namespace "s"
+    And I wait 15 seconds
+    Then show command "show isis interface detail" in namespace "s" should contain "exceeds interface MTU"
+
+  Scenario: lsp-mtu above the link MTU drops s's LSP so n1 never learns the new prefix
+    Given the test topology exists
+    # s-lspmtu.yaml advertises 100.99.0.1/32, but with lsp-mtu over the
+    # link MTU s's LSP is dropped on every link, so n1 never receives it.
+    Then show command "show isis route" in namespace "n1" should not contain "100.99.0.1/32"
+
+  Scenario: Lowering lsp-mtu under the link MTU lets s's LSP flood to n1
+    Given the test topology exists
+    When I apply config "s-lspmtu-ok.yaml" to namespace "s"
+    And I wait 20 seconds
+    # lsp-mtu 1400 < 1500, so the flood path no longer drops s's LSP: the
+    # interfaces are no longer flagged and n1 installs the previously-
+    # dropped network, proving the drop was the over-MTU lsp-mtu.
+    Then show command "show isis interface detail" in namespace "s" should not contain "exceeds interface MTU"
+    And show command "show isis route" in namespace "n1" should contain "100.99.0.1/32"
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "s"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -27,6 +27,7 @@
   - [Shared Risk Link Group (SRLG)](ch-07-02-isis-srlg.md)
   - [BFD](ch-07-03-isis-bfd.md)
   - [Clearing IS-IS State](ch-07-04-isis-clear.md)
+  - [LSP MTU and Fragmentation](ch-07-05-isis-lsp-mtu.md)
 - [OSPFv2](ch-08-00-ospf.md)
   - [Configuration](ch-08-01-ospf-configuration.md)
   - [BFD](ch-08-02-ospf-bfd.md)

--- a/book/src/ch-07-01-isis-timers.md
+++ b/book/src/ch-07-01-isis-timers.md
@@ -391,6 +391,7 @@ Gaps relative to IOS-XR that zebra-rs does not yet implement:
 `prc-interval` (no partial route calculation distinct from full
 SPF), `lsp-interval` (LSP send pacing), `retransmit-interval` /
 `retransmit-throttle-interval` (no periodic LSP retransmit-until-ack
-on point-to-point), `lsp-mtu` (no LSP fragmentation yet),
-`adjacency-stagger`, and BFD client integration for IS-IS
-adjacencies.
+on point-to-point), and `adjacency-stagger`. LSP sizing and
+fragmentation (IOS-XR's `lsp-mtu`) *are* implemented — see
+[LSP MTU and Fragmentation](ch-07-05-isis-lsp-mtu.md) — as is BFD
+client integration for IS-IS adjacencies (see [BFD](ch-07-03-isis-bfd.md)).

--- a/book/src/ch-07-05-isis-lsp-mtu.md
+++ b/book/src/ch-07-05-isis-lsp-mtu.md
@@ -1,0 +1,109 @@
+# IS-IS LSP MTU and Fragmentation
+
+A Link State PDU carries a router's adjacencies and reachability, and
+IS-IS floods it as a **single link-layer frame** — a PDU is never
+fragmented at the link layer the way an IP packet is. Two independent
+knobs under `router isis` govern how large an LSP may grow and what
+happens when one would not fit on the wire:
+
+- `lsp-mtu-size` — the *originating buffer size*: the largest LSP this
+  router will build for itself. When its content exceeds this, the
+  router splits the LSP into numbered fragments.
+- `lsp-mtu` — the *transmit MTU*: the largest LSP this router will send
+  on an interface. It guards against emitting a PDU larger than a link
+  can carry.
+
+## Originating buffer size — `lsp-mtu-size`
+
+`lsp-mtu-size` is the ISO 10589 `originatingLSPBufferSize`, advertised
+in TLV 14 per RFC 1195. It caps the byte length of every
+*self-originated* LSP and drives the send-side packer's fragment
+boundary. A router with more reachability than fits in one PDU spreads
+its TLVs across numbered fragments named
+`<hostname>.<pseudonode>-<fragment>` (for example `z1.00-00`,
+`z1.00-01`, …), and receivers merge those fragments back into one
+logical origin before running SPF.
+
+- **Range:** 128..16384 bytes
+- **Default:** 1492 — the originatingLSPBufferSize every IS-IS
+  implementation is required to accept (ISO 10589), and the safe value
+  on any standard Ethernet.
+
+```
+router isis
+  lsp-mtu-size 1492
+```
+
+Changing `lsp-mtu-size` at runtime re-originates the self-LSP so the
+new buffer size takes effect immediately. See the fragmentation BDD
+feature (`isis_fragmentation_ipv4`) for a worked example that fragments
+at both a tight 400-byte cap and the standard 1500-byte MTU.
+
+## Transmit MTU — `lsp-mtu`
+
+`lsp-mtu` sets the maximum byte size of an LSP PDU this router will
+transmit on an interface.
+
+- **Range:** 400..9490 bytes
+- **Default:** 1497 — fits inside a standard 1500-byte Ethernet frame,
+  so the over-MTU check below stays inert on ordinary links.
+
+Because an LSP is flooded as one link-layer frame, when `lsp-mtu`
+exceeds an interface's MTU an LSP generated at that size cannot fit on
+the wire. Rather than emit an over-sized frame that the kernel or peer
+would reject, the flood path **drops the LSP on send for that
+interface** and logs a warning:
+
+```
+[LspFlood] eth0: dropping L2 LSP flood: lsp-mtu 9000 exceeds interface MTU 1500
+```
+
+Only LSP flooding is gated — Hello, CSNP and PSNP PDUs are unaffected —
+so the **adjacency stays up** while LSP updates are withheld on the
+offending link. Dropping the send does not purge a neighbour's existing
+database; it simply prevents the over-sized update from propagating.
+Once the mismatch is resolved (lower `lsp-mtu`, or raise the interface
+MTU), the next origination or database-sync re-marks the LSP and it
+floods normally again.
+
+Raise `lsp-mtu` only on a network where every interface in the flooding
+domain has a correspondingly large (jumbo) MTU. The drop-and-warn
+behaviour then catches any interface that was accidentally left at a
+smaller MTU instead of silently black-holing the topology.
+
+```
+router isis
+  lsp-mtu 9000
+```
+
+## Showing the LSP MTU per interface
+
+`show isis interface detail` prints the effective LSP MTU for every
+enabled interface, and flags any interface whose MTU is smaller than
+`lsp-mtu` (so LSPs are being dropped on it):
+
+```
+Interface: eth0, State: Up, Active, Circuit Id: 0x01
+  Type: lan, Level: L2, SNPA: 2c:54:91:88:c9:e3, MTU: 1500
+  LSP MTU: 9000 (exceeds interface MTU 1500 - LSPs dropped on send)
+  Level-2 Information:
+    Metric: 10, Active neighbors: 1
+    ...
+```
+
+When `lsp-mtu` is at or below the interface MTU the line reads simply
+`LSP MTU: 1497` with no warning. The same `lsp_mtu` value and a
+`lsp_mtu_exceeds_interface` boolean are present in the JSON form
+(`show isis interface detail` with JSON output).
+
+## Cross-reference — IOS-XR command mapping
+
+| zebra-rs YANG | IOS-XR command |
+|---|---|
+| `lsp-mtu-size` | `lsp-mtu` (originating LSP buffer size) |
+| `lsp-mtu` | *(no direct equivalent — transmit-side over-MTU guard)* |
+
+> **Naming note.** IOS-XR's `lsp-mtu` command sets the originating LSP
+> size, which maps to zebra-rs `lsp-mtu-size`. zebra-rs's `lsp-mtu` is a
+> *separate* transmit-side guard with no exact IOS-XR analogue, so take
+> care not to conflate the two when porting configuration.

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -133,6 +133,7 @@ impl Isis {
             config_lsp_gen_maximum_wait,
         );
         self.callback_add("/router/isis/lsp-mtu-size", config_lsp_mtu_size);
+        self.callback_add("/router/isis/lsp-mtu", config_lsp_mtu);
         self.callback_add("/router/isis/te-router-id", config_te_router_id);
         self.callback_add("/router/isis/segment-routing/mpls", config_sr_mpls_enable);
         self.callback_add(
@@ -432,6 +433,15 @@ pub struct IsisConfig {
     /// drives the send-side packer's fragment boundary. Default
     /// 1492 — the universally-accepted IS-IS PDU size.
     pub lsp_mtu_size: Option<u16>,
+
+    /// Maximum byte size of an LSP PDU transmitted on an interface
+    /// (`/router/isis/lsp-mtu`). IS-IS LSPs are flooded as a single
+    /// link-layer frame and are never fragmented at the link layer, so
+    /// when `lsp_mtu` exceeds an interface's MTU the LSP cannot fit on
+    /// the wire — the send path drops it (with a warning) for that
+    /// interface. Default 1497 (fits standard 1500-byte Ethernet);
+    /// raise it on jumbo-frame domains.
+    pub lsp_mtu: Option<u16>,
     pub te_router_id: Option<Ipv4Addr>,
     pub rib_router_id: Option<Ipv4Addr>,
     pub enable: Afis<usize>,
@@ -716,6 +726,7 @@ impl Default for IsisConfig {
             lsp_gen_secondary_wait: Default::default(),
             lsp_gen_maximum_wait: Default::default(),
             lsp_mtu_size: Default::default(),
+            lsp_mtu: Default::default(),
             te_router_id: Default::default(),
             rib_router_id: Default::default(),
             enable: Default::default(),
@@ -760,6 +771,10 @@ impl IsisConfig {
     /// implementation is required to accept. Larger values are valid
     /// on links where every peer agrees, but 1492 is the safe default.
     pub const DEFAULT_LSP_MTU_SIZE: u16 = 1492;
+    /// Default transmit-side LSP MTU. 1497 fits a standard 1500-byte
+    /// Ethernet frame, so the over-MTU drop check stays inert on normal
+    /// links; operators raise it on jumbo-frame domains.
+    pub const DEFAULT_LSP_MTU: u16 = 1497;
 
     pub fn is_type(&self) -> IsLevel {
         self.is_type.unwrap_or(IsLevel::L1L2)
@@ -824,6 +839,10 @@ impl IsisConfig {
 
     pub fn lsp_mtu_size(&self) -> u16 {
         self.lsp_mtu_size.unwrap_or(Self::DEFAULT_LSP_MTU_SIZE)
+    }
+
+    pub fn lsp_mtu(&self) -> u16 {
+        self.lsp_mtu.unwrap_or(Self::DEFAULT_LSP_MTU)
     }
 
     /// True when either SR dataplane is enabled. Used to gate emission
@@ -1143,6 +1162,22 @@ fn config_lsp_mtu_size(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<
             let _ = isis.tx.send(Message::LspOriginate(level, None));
         }
     }
+    Some(())
+}
+
+/// `/router/isis/lsp-mtu` — the maximum LSP PDU size this router will
+/// transmit on an interface. The flood (SRM) send path compares this
+/// against each interface's MTU; an LSP that would exceed the link MTU
+/// is dropped rather than emitted, since IS-IS PDUs are never
+/// fragmented at the link layer. Storage-only here — the check lives in
+/// `flood::srm_advertise` and reads the value per send.
+fn config_lsp_mtu(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let size = args.u16()?;
+    isis.config.lsp_mtu = if op == ConfigOp::Set {
+        Some(size)
+    } else {
+        None
+    };
     Some(())
 }
 

--- a/zebra-rs/src/isis/flood.rs
+++ b/zebra-rs/src/isis/flood.rs
@@ -158,6 +158,32 @@ pub fn srm_advertise(top: &mut LinkTop, level: Level, ifindex: u32) {
         adj.srm.0.keys().cloned().collect()
     };
 
+    // An LSP is flooded as a single link-layer frame — IS-IS PDUs are
+    // never fragmented at the link layer. When the configured lsp-mtu
+    // is larger than this interface's MTU, an LSP generated at that
+    // size cannot fit on the wire, so drop it rather than emit a frame
+    // the kernel (or peer) will reject. The SRM flags are still cleared
+    // below so we don't busy-loop re-arming the send timer; the LSPs
+    // re-flood once the MTU mismatch is resolved and origination next
+    // marks them.
+    let lsp_mtu = top.up_config.lsp_mtu() as u32;
+    let if_mtu = top.state.mtu;
+    if lsp_mtu > if_mtu {
+        tracing::warn!(
+            "[LspFlood] {}: dropping {} LSP flood: lsp-mtu {} exceeds interface MTU {}",
+            top.state.name,
+            level,
+            lsp_mtu,
+            if_mtu
+        );
+        if let Some(adj) = top.lsdb.get_mut(&level).adj.get_mut(&ifindex) {
+            for lsp_id in &srm_entries {
+                adj.srm.0.remove(lsp_id);
+            }
+        }
+        return;
+    }
+
     // Send LSPs for each SRM entry.
     for lsp_id in srm_entries {
         let lsdb = top.lsdb.get(&level);

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -1637,6 +1637,10 @@ struct InterfaceDetailJson {
     level: String,
     snpa: Option<String>,
     mtu: u32,
+    lsp_mtu: u16,
+    /// True when `lsp_mtu` exceeds the interface MTU — LSPs are then
+    /// dropped on send for this interface (see flood::srm_advertise).
+    lsp_mtu_exceeds_interface: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     level_1_info: Option<LevelInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1809,6 +1813,8 @@ pub fn show_detail(
                     level: format!("{}", link.state.level()),
                     snpa: link.state.mac.map(|mac| mac.to_string()),
                     mtu: link.state.mtu,
+                    lsp_mtu: isis.config.lsp_mtu(),
+                    lsp_mtu_exceeds_interface: isis.config.lsp_mtu() as u32 > link.state.mtu,
                     level_1_info: None,
                     level_2_info: None,
                     authentication: build_auth_info(link),
@@ -1852,6 +1858,19 @@ pub fn show_detail(
                     link.state.mac.unwrap_or(MacAddr::from([0, 0, 0, 0, 0, 0])),
                     link.state.mtu,
                 )?;
+                // LSP MTU vs interface MTU. When lsp-mtu exceeds the
+                // interface MTU, LSPs are dropped on send (see
+                // flood::srm_advertise), so flag it here.
+                let lsp_mtu = isis.config.lsp_mtu();
+                if lsp_mtu as u32 > link.state.mtu {
+                    writeln!(
+                        buf,
+                        "  LSP MTU: {} (exceeds interface MTU {} - LSPs dropped on send)",
+                        lsp_mtu, link.state.mtu,
+                    )?;
+                } else {
+                    writeln!(buf, "  LSP MTU: {}", lsp_mtu)?;
+                }
                 if has_level(link.state.level(), Level::L1) {
                     writeln!(buf, "  Level-1 Information:")?;
                     show_detail_entry(&mut buf, link, Level::L1)?;

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1772,6 +1772,22 @@ module config {
              peer is required to accept.";
         }
 
+        leaf lsp-mtu {
+          ext:help "Maximum LSP size transmitted on an interface";
+          type uint16 {
+            range "400..9490";
+          }
+          units "bytes";
+          description
+            "Maximum byte size of an LSP PDU this router transmits. IS-IS
+             LSPs are flooded as a single link-layer frame and are never
+             fragmented at the link layer, so when lsp-mtu exceeds an
+             interface's MTU an LSP of that size cannot fit on the wire.
+             LSPs are then dropped on send for that interface (logged at
+             warning level) rather than emitted as an over-sized frame.
+             Default 1497.";
+        }
+
         list interface {
           ext:help "Per-interface IS-IS configuration";
           // Last item in "router isis" node.


### PR DESCRIPTION
## Summary

Introduces a transmit-side **`lsp-mtu`** knob (range `400-9490`, default `1497`) under `router isis`, distinct from the existing originating-buffer `lsp-mtu-size`.

IS-IS floods each LSP as a **single link-layer frame** — PDUs are never fragmented at the link layer. So when `lsp-mtu` exceeds an interface's MTU, an LSP at that size cannot fit on the wire. Rather than emit an over-sized frame, the flood path (`flood::srm_advertise`) **drops the LSP on send** for that interface and logs at **warning** level. Hello/CSNP/PSNP are unaffected, so the adjacency stays up while LSP updates are withheld.

`show isis interface detail` now prints the effective LSP MTU per interface and flags any interface whose MTU is smaller than `lsp-mtu` (both text and JSON output).

### Changes
- **YANG**: new `/router/isis/lsp-mtu` leaf (`400..9490`, units bytes).
- **config.rs**: `lsp_mtu` field + `DEFAULT_LSP_MTU = 1497` + `lsp_mtu()` getter + callback/handler.
- **flood.rs**: over-MTU drop guard with warning in `srm_advertise` (sole LSP transmit path).
- **link.rs**: `LSP MTU:` line + `(exceeds interface MTU …)` flag in `show isis interface detail`; `lsp_mtu` / `lsp_mtu_exceeds_interface` JSON fields.
- **BDD**: new scenarios in `isis_fragmentation_ipv4` (LAN) and `isis_tilfa` (p2p + SR-MPLS) — verify the show flag, the drop (a freshly-added prefix never reaches the peer), and recovery when `lsp-mtu` is lowered. Four new config files.
- **book**: new page *LSP MTU and Fragmentation* (documents both `lsp-mtu-size` and `lsp-mtu`, with an IOS-XR naming-collision note); corrects a stale "not implemented" note in the timers chapter.

## Test plan
- `cargo build -p zebra-rs` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs yang_load_tests` — pass (schema valid)
- `cargo test -p zebra-rs isis` — 142 pass
- `cargo fmt --all -- --check` — clean
- `mdbook build` — clean, no broken links
- BDD scenarios added (full suite runs in CI per repo policy)

Generated with [Claude Code](https://claude.com/claude-code)