### PR TITLE
test(isis): add static redistribution BDD feature + book chapter

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -54,6 +54,10 @@ isis_l1l2:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_l1l2"
 
+isis_redist:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_redist"
+
 isis_hello_auth_keychain:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_hello_auth_keychain"
@@ -105,4 +109,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_hello_auth_keychain ospf_clear_neighbor bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain ospf_clear_neighbor bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE

--- a/bdd/docs/isis-redist.md
+++ b/bdd/docs/isis-redist.md
@@ -1,0 +1,59 @@
+# IS-IS redistribution of static routes into a Level-1 area
+
+## Overview
+
+As a network operator
+I want a border router to redistribute a static route into IS-IS so a
+prefix that lives outside the IS-IS domain (on a host that runs no
+IS-IS) is flooded across the whole Level-1 area, installed into every
+router's RIB as an external reachability, reconverges onto a backup
+path when the primary link drops, and disappears again the moment the
+redistribution is withdrawn.
+All links are point-to-point veth pairs (network-type point-to-point)
+and every "rN" router is is-type level-1 in area 49.0001. The two
+edge hosts e1 and e2 do NOT run IS-IS — they are plain hosts wired to
+the area by a single link and a static default route.
+
+## Test Topology
+
+```
+    +----+      +----+      +----+      +----+      +----+
+    | e1 |--10--| r1 |--10--| r2 |--10--| r3 |--10--| e2 |
+    +----+      +----+      +----+      +----+      +----+
+                   \                     /
+                   10                  10
+                     \                 /
+                    +----+   10    +----+
+                    | r4 |---------| r5 |
+                    +----+         +----+
+
+    loopbacks:  rI -> 10.0.0.I/32     e1 -> 10.1.1.1/32   e2 -> 10.2.2.2/32
+    edges:      e1-r1 10.1.0.0/30     r3-e2 10.2.0.0/30
+    spine:      r1-r2 10.0.12.0/30    r2-r3 10.0.23.0/30
+    backup:     r1-r4 10.0.14.0/30    r4-r5 10.0.45.0/30   r5-r3 10.0.35.0/30
+```
+
+## Notes
+
+There are two equal-metric-per-hop paths between r1 and r3: the short
+top spine r1—r2—r3 (cost 20) and the longer bottom path
+r1—r4—r5—r3 (cost 30). The top spine is the primary; the bottom path
+is the backup the redistributed route falls onto when r1—r2 drops.
+On router rI the interface toward rJ is named "iJ"; the interface
+toward edge host eN is "ieN", and eN's interface toward its router is
+"irK". e1's loopback 10.1.1.1/32 can only enter IS-IS via
+redistribution: r1's edge link "ie1" carries an address but is not an
+IS-IS interface. r3's edge link "ie2", by contrast, IS an IS-IS
+interface so the 10.2.0.0/30 edge subnet is advertised — that gives
+r1 a route back to e2's source address for the e2 -> e1 reply path.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the topology and form IS-IS Level-1 adjacencies | |
+| r1 redistributes e1's loopback into IS-IS and it floods across the area | |
+| e2 reaches e1 end-to-end across the IS-IS domain | |
+| The redistributed route reconverges onto the backup path | |
+| Withdrawing redistribution removes e1's loopback from the area | |
+| Teardown topology | |

--- a/bdd/tests/configs/isis_redist/e1.yaml
+++ b/bdd/tests/configs/isis_redist/e1.yaml
@@ -1,0 +1,17 @@
+# e1 — an edge host that does NOT run IS-IS. It owns the loopback
+# 10.1.1.1/32 that r1 redistributes into IS-IS, and reaches the rest of
+# the network through a static default route pointing at r1 (10.1.0.1).
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.1.1.1/32
+- if-name: ir1
+  ipv4:
+    address: 10.1.0.2/30
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 0.0.0.0/0
+        nexthop:
+        - address: 10.1.0.1

--- a/bdd/tests/configs/isis_redist/e2.yaml
+++ b/bdd/tests/configs/isis_redist/e2.yaml
@@ -1,0 +1,17 @@
+# e2 — an edge host that does NOT run IS-IS. It reaches the network
+# (including e1's redistributed loopback) through a static default
+# route pointing at r3 (10.2.0.1).
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.2.2.2/32
+- if-name: ir3
+  ipv4:
+    address: 10.2.0.2/30
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 0.0.0.0/0
+        nexthop:
+        - address: 10.2.0.1

--- a/bdd/tests/configs/isis_redist/r1-noredist.yaml
+++ b/bdd/tests/configs/isis_redist/r1-noredist.yaml
@@ -1,0 +1,46 @@
+# r1 with static redistribution withdrawn. Identical to r1.yaml except
+# the `afi-safi ipv4 / redistribute static` block is gone, so applying
+# this file makes the config diff DELETE the redistribution. The static
+# route to e1 stays, so e1 is still locally reachable from r1 — only the
+# IS-IS advertisement of 10.1.1.1/32 is withdrawn from the area.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ie1
+  ipv4:
+    address: 10.1.0.1/30
+- if-name: i2
+  ipv4:
+    address: 10.0.12.1/30
+- if-name: i4
+  ipv4:
+    address: 10.0.14.1/30
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.1.1.1/32
+        nexthop:
+        - address: 10.1.0.2
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-1
+    hostname: r1
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+    - if-name: i2
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: i4
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/isis_redist/r1.yaml
+++ b/bdd/tests/configs/isis_redist/r1.yaml
@@ -1,0 +1,52 @@
+# r1 — the redistributing border. It has a static route to e1's
+# loopback (10.1.1.1/32) over the non-IS-IS edge link "ie1", and
+# redistributes static into IS-IS at Level-1 so the rest of the L1
+# area learns e1's loopback. Note "ie1" carries an address but is NOT
+# an IS-IS interface, so 10.1.1.1/32 can only enter the IS-IS domain
+# via redistribution.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ie1
+  ipv4:
+    address: 10.1.0.1/30
+- if-name: i2
+  ipv4:
+    address: 10.0.12.1/30
+- if-name: i4
+  ipv4:
+    address: 10.0.14.1/30
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.1.1.1/32
+        nexthop:
+        - address: 10.1.0.2
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-1
+    hostname: r1
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        static:
+          level: level-1
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+    - if-name: i2
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: i4
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/isis_redist/r2.yaml
+++ b/bdd/tests/configs/isis_redist/r2.yaml
@@ -1,0 +1,33 @@
+# r2 — interior router on the top path r1—r2—r3.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: i1
+  ipv4:
+    address: 10.0.12.2/30
+- if-name: i3
+  ipv4:
+    address: 10.0.23.1/30
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-1
+    hostname: r2
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+    - if-name: i1
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: i3
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/isis_redist/r3.yaml
+++ b/bdd/tests/configs/isis_redist/r3.yaml
@@ -1,0 +1,46 @@
+# r3 — the far border, where e2 attaches. Its edge link "ie2" toward
+# e2 IS an IS-IS interface so the 10.2.0.0/30 edge subnet is advertised
+# into the area; that gives r1 a route back to e2's source address, so
+# the e2 -> e1 reply path resolves even though e2 itself runs no IS-IS
+# and never forms an adjacency on that link.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+- if-name: i2
+  ipv4:
+    address: 10.0.23.2/30
+- if-name: i5
+  ipv4:
+    address: 10.0.35.2/30
+- if-name: ie2
+  ipv4:
+    address: 10.2.0.1/30
+router:
+  isis:
+    net: 49.0001.0000.0000.0003.00
+    is-type: level-1
+    hostname: r3
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+    - if-name: i2
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: i5
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: ie2
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/isis_redist/r4.yaml
+++ b/bdd/tests/configs/isis_redist/r4.yaml
@@ -1,0 +1,33 @@
+# r4 — interior router on the bottom path r1—r4—r5—r3.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.4/32
+- if-name: i1
+  ipv4:
+    address: 10.0.14.2/30
+- if-name: i5
+  ipv4:
+    address: 10.0.45.1/30
+router:
+  isis:
+    net: 49.0001.0000.0000.0004.00
+    is-type: level-1
+    hostname: r4
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+    - if-name: i1
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: i5
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/isis_redist/r5.yaml
+++ b/bdd/tests/configs/isis_redist/r5.yaml
@@ -1,0 +1,33 @@
+# r5 — interior router on the bottom path r1—r4—r5—r3.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.5/32
+- if-name: i4
+  ipv4:
+    address: 10.0.45.2/30
+- if-name: i3
+  ipv4:
+    address: 10.0.35.1/30
+router:
+  isis:
+    net: 49.0001.0000.0000.0005.00
+    is-type: level-1
+    hostname: r5
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+    - if-name: i4
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: i3
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/features/isis-redist.feature
+++ b/bdd/tests/features/isis-redist.feature
@@ -1,0 +1,176 @@
+@serial
+@isis_redist
+@isis
+Feature: IS-IS redistribution of static routes into a Level-1 area
+  As a network operator
+  I want a border router to redistribute a static route into IS-IS so a
+  prefix that lives outside the IS-IS domain (on a host that runs no
+  IS-IS) is flooded across the whole Level-1 area, installed into every
+  router's RIB as an external reachability, reconverges onto a backup
+  path when the primary link drops, and disappears again the moment the
+  redistribution is withdrawn.
+
+  All links are point-to-point veth pairs (network-type point-to-point)
+  and every "rN" router is is-type level-1 in area 49.0001. The two
+  edge hosts e1 and e2 do NOT run IS-IS — they are plain hosts wired to
+  the area by a single link and a static default route.
+
+  Test Topology:
+  ```
+    +----+      +----+      +----+      +----+      +----+
+    | e1 |--10--| r1 |--10--| r2 |--10--| r3 |--10--| e2 |
+    +----+      +----+      +----+      +----+      +----+
+                   \                     /
+                   10                  10
+                     \                 /
+                    +----+   10    +----+
+                    | r4 |---------| r5 |
+                    +----+         +----+
+
+    loopbacks:  rI -> 10.0.0.I/32     e1 -> 10.1.1.1/32   e2 -> 10.2.2.2/32
+    edges:      e1-r1 10.1.0.0/30     r3-e2 10.2.0.0/30
+    spine:      r1-r2 10.0.12.0/30    r2-r3 10.0.23.0/30
+    backup:     r1-r4 10.0.14.0/30    r4-r5 10.0.45.0/30   r5-r3 10.0.35.0/30
+  ```
+
+  There are two equal-metric-per-hop paths between r1 and r3: the short
+  top spine r1—r2—r3 (cost 20) and the longer bottom path
+  r1—r4—r5—r3 (cost 30). The top spine is the primary; the bottom path
+  is the backup the redistributed route falls onto when r1—r2 drops.
+
+  On router rI the interface toward rJ is named "iJ"; the interface
+  toward edge host eN is "ieN", and eN's interface toward its router is
+  "irK". e1's loopback 10.1.1.1/32 can only enter IS-IS via
+  redistribution: r1's edge link "ie1" carries an address but is not an
+  IS-IS interface. r3's edge link "ie2", by contrast, IS an IS-IS
+  interface so the 10.2.0.0/30 edge subnet is advertised — that gives
+  r1 a route back to e2's source address for the e2 -> e1 reply path.
+
+  Scenario: Build the topology and form IS-IS Level-1 adjacencies
+    Given a clean test environment
+    When I create namespace "r1"
+    And I create namespace "r2"
+    And I create namespace "r3"
+    And I create namespace "r4"
+    And I create namespace "r5"
+    And I create namespace "e1"
+    And I create namespace "e2"
+    And I connect namespace "e1" interface "ir1" to namespace "r1" interface "ie1"
+    And I connect namespace "r1" interface "i2" to namespace "r2" interface "i1"
+    And I connect namespace "r2" interface "i3" to namespace "r3" interface "i2"
+    And I connect namespace "r3" interface "ie2" to namespace "e2" interface "ir3"
+    And I connect namespace "r1" interface "i4" to namespace "r4" interface "i1"
+    And I connect namespace "r4" interface "i5" to namespace "r5" interface "i4"
+    And I connect namespace "r5" interface "i3" to namespace "r3" interface "i5"
+    And I start zebra-rs in namespace "r1"
+    And I start zebra-rs in namespace "r2"
+    And I start zebra-rs in namespace "r3"
+    And I start zebra-rs in namespace "r4"
+    And I start zebra-rs in namespace "r5"
+    And I start zebra-rs in namespace "e1"
+    And I start zebra-rs in namespace "e2"
+    And I apply config "r1.yaml" to namespace "r1"
+    And I apply config "r2.yaml" to namespace "r2"
+    And I apply config "r3.yaml" to namespace "r3"
+    And I apply config "r4.yaml" to namespace "r4"
+    And I apply config "r5.yaml" to namespace "r5"
+    And I apply config "e1.yaml" to namespace "e1"
+    And I apply config "e2.yaml" to namespace "e2"
+    And I wait 20 seconds
+    # Edge links are up and addressed: e1 reaches r1's edge address and
+    # e2 reaches r3's edge address (neither edge host speaks IS-IS).
+    Then ping from "e1" to "10.1.0.1" should succeed
+    And ping from "e2" to "10.2.0.1" should succeed
+    # Both the primary spine and the backup path formed adjacencies. A
+    # peer renders by dynamic hostname only when its LSP was accepted,
+    # so this also proves the LSDB is exchanged on both paths.
+    And show command "show isis neighbor" in namespace "r1" should contain "r2"
+    And show command "show isis neighbor" in namespace "r1" should contain "r4"
+    And show command "show isis neighbor" in namespace "r3" should contain "r2"
+    And show command "show isis neighbor" in namespace "r3" should contain "r5"
+    And show command "show isis neighbor" in namespace "r4" should contain "r5"
+
+  Scenario: r1 redistributes e1's loopback into IS-IS and it floods across the area
+    Given the test topology exists
+    # The redistributed prefix is an external IP reachability originated
+    # by r1; every other router runs SPF against it and installs it. Its
+    # presence in `show isis route` proves the per-level SPF picked it
+    # up; in `show ip route` proves it reached the central RIB.
+    Then show command "show isis route" in namespace "r2" should contain "10.1.1.1/32"
+    And show command "show isis route" in namespace "r3" should contain "10.1.1.1/32"
+    And show command "show isis route" in namespace "r5" should contain "10.1.1.1/32"
+    And show command "show ip route" in namespace "r3" should contain "10.1.1.1/32"
+    And show command "show ip route" in namespace "r4" should contain "10.1.1.1/32"
+    # Data plane: every IS-IS router can reach e1's loopback. The reply
+    # returns to e1 via its static default route to r1, and r1 forwards
+    # back over the IS-IS-learned transit links.
+    And ping from "r2" to "10.1.1.1" should succeed
+    And ping from "r3" to "10.1.1.1" should succeed
+    And ping from "r4" to "10.1.1.1" should succeed
+    And ping from "r5" to "10.1.1.1" should succeed
+
+  Scenario: e2 reaches e1 end-to-end across the IS-IS domain
+    Given the test topology exists
+    # e2 runs no IS-IS — it only has a static default route to r3. It
+    # still reaches e1's loopback because r3 learned 10.1.1.1/32 from
+    # the redistribution and r1 learned e2's edge subnet (10.2.0.0/30)
+    # from r3's IS-IS interface, so both directions resolve.
+    Then ping from "e2" to "10.1.1.1" should succeed
+    # e2 also reaches the interior IS-IS loopbacks the same way.
+    And ping from "e2" to "10.0.0.1" should succeed
+    And ping from "e2" to "10.0.0.5" should succeed
+
+  Scenario: The redistributed route reconverges onto the backup path
+    Given the test topology exists
+    # Baseline: e2 -> e1 works over the primary spine r1—r2—r3.
+    Then ping from "e2" to "10.1.1.1" should succeed
+    # Drop the r1—r2 link. The only remaining path between r1 and r3 is
+    # the backup r1—r4—r5—r3, so the redistributed route must reconverge
+    # out r1's other interface.
+    When I make namespace "r1" interface "i2" down
+    And I wait 10 seconds
+    Then show command "show isis route" in namespace "r3" should contain "10.1.1.1/32"
+    And ping from "e2" to "10.1.1.1" should succeed
+    # Restore the primary spine; the route stays reachable.
+    When I make namespace "r1" interface "i2" up
+    And I wait 15 seconds
+    Then ping from "e2" to "10.1.1.1" should succeed
+
+  Scenario: Withdrawing redistribution removes e1's loopback from the area
+    Given the test topology exists
+    # Re-apply r1 with the `redistribute static` block removed (the
+    # static route to e1 stays). The config diff deletes the
+    # redistribution, so r1 re-originates its LSP without the external
+    # reachability and the area withdraws 10.1.1.1/32.
+    When I apply config "r1-noredist.yaml" to namespace "r1"
+    And I wait 10 seconds
+    Then show command "show isis route" in namespace "r3" should not contain "10.1.1.1/32"
+    And show command "show ip route" in namespace "r3" should not contain "10.1.1.1/32"
+    And ping from "e2" to "10.1.1.1" should fail
+    # r1 still has the local static route, so e1's loopback is reachable
+    # from r1 itself — only the IS-IS advertisement was withdrawn.
+    And ping from "r1" to "10.1.1.1" should succeed
+    # Re-enable redistribution; the area relearns the prefix and
+    # end-to-end reachability returns.
+    When I apply config "r1.yaml" to namespace "r1"
+    And I wait 10 seconds
+    Then show command "show isis route" in namespace "r3" should contain "10.1.1.1/32"
+    And ping from "e2" to "10.1.1.1" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "r1"
+    And I stop zebra-rs in namespace "r2"
+    And I stop zebra-rs in namespace "r3"
+    And I stop zebra-rs in namespace "r4"
+    And I stop zebra-rs in namespace "r5"
+    And I stop zebra-rs in namespace "e1"
+    And I stop zebra-rs in namespace "e2"
+    And I delete namespace "r1"
+    And I delete namespace "r2"
+    And I delete namespace "r3"
+    And I delete namespace "r4"
+    And I delete namespace "r5"
+    And I delete namespace "e1"
+    And I delete namespace "e2"
+    Then the test environment should be clean

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -28,6 +28,7 @@
   - [BFD](ch-07-03-isis-bfd.md)
   - [Clearing IS-IS State](ch-07-04-isis-clear.md)
   - [LSP MTU and Fragmentation](ch-07-05-isis-lsp-mtu.md)
+  - [Route Redistribution](ch-07-06-isis-redistribution.md)
 - [OSPFv2](ch-08-00-ospf.md)
   - [Configuration](ch-08-01-ospf-configuration.md)
   - [BFD](ch-08-02-ospf-bfd.md)

--- a/book/src/ch-07-06-isis-redistribution.md
+++ b/book/src/ch-07-06-isis-redistribution.md
@@ -1,0 +1,194 @@
+# Route Redistribution
+
+Redistribution injects routes that IS-IS did not learn itself —
+connected interfaces, static routes, BGP, or OSPF — into the IS-IS
+link-state database as **external reachability**, so the rest of the
+area can reach a prefix that lives outside the IS-IS domain. The
+originating router advertises each redistributed prefix as an Extended
+IP Reachability entry in its own LSP; every other router runs SPF
+against it and installs it like any other IS-IS route.
+
+A typical use is an edge router that has a static route to a host (or a
+stub network) which itself runs no IS-IS. Redistributing that static
+route makes the host's prefix reachable from every router in the area
+without extending IS-IS onto the edge link.
+
+## Configuration
+
+Redistribution is configured **per address family**, under the
+`afi-safi` list of `router isis`. Each `redistribute` block is a
+presence container holding one presence container per source:
+
+```text
+router isis {
+  afi-safi ipv4 {
+    redistribute {
+      static {
+        level level-1;
+      }
+    }
+  }
+}
+```
+
+The four sources are:
+
+| Source      | Redistributes                                  |
+|---          |---                                             |
+| `connected` | Directly-connected interface prefixes          |
+| `static`    | Static routes (`router static`)                |
+| `bgp`       | BGP-learned routes                             |
+| `ospf`      | OSPF-learned routes (with an optional match)   |
+
+Enabling a source subscribes IS-IS to the matching route type in the
+central RIB; routes the RIB delivers are stored and folded into the
+self-originated LSP at the next re-origination. Removing the presence
+container unsubscribes and re-originates the LSP without those
+prefixes, withdrawing them from the area.
+
+## The `level` default — read this first
+
+Each source takes a `level` that selects which level's LSP carries the
+redistributed prefix:
+
+```text
+level {level-1 | level-2 | level-1-2}
+```
+
+The default is **`level-2`**, matching IOS-XR. This is the most common
+operational surprise: in a **Level-1-only** network, leaving `level`
+at its default means the prefix is originated into the (non-existent)
+Level-2 LSP and **never propagates**. An L1-only deployment must set
+`level level-1` explicitly:
+
+```text
+router isis {
+  is-type level-1;
+  afi-safi ipv4 {
+    redistribute {
+      static { level level-1; }
+    }
+  }
+}
+```
+
+`level-1-2` originates the prefix into both levels.
+
+## Metric and metric-type
+
+```text
+metric <0..16777215>;
+metric-type {internal | external | rib-metric-as-internal | rib-metric-as-external};
+```
+
+`metric-type` (default `internal`) selects where the advertised metric
+comes from and, for IPv6, whether the external bit is set:
+
+- `internal` / `external` — advertise the static `metric` value if one
+  is configured, otherwise fall back to the source route's RIB cost.
+- `rib-metric-as-internal` / `rib-metric-as-external` — always lift the
+  source route's RIB cost into the IS-IS metric, ignoring any `metric`
+  override.
+
+The `external` and `rib-metric-as-external` variants set the **X (up/
+down/external) bit** on the IPv6 reachability TLV (RFC 5308 §2) so a
+receiver can tell the prefix originated outside IS-IS. The IPv4
+Extended IP Reachability TLV (135) has no equivalent I/E bit, so for
+IPv4 `metric-type` only chooses the metric source — the prefix is
+carried the same way either way.
+
+## Filtering OSPF by route subtype
+
+The `ospf` source accepts a `match` filter that narrows which OSPF
+route subtypes are pulled in:
+
+```text
+router isis {
+  afi-safi ipv4 {
+    redistribute {
+      ospf {
+        level level-1;
+        match { type external; }
+      }
+    }
+  }
+}
+```
+
+`type` may list any of `internal` (intra-area + inter-area),
+`external` (Type-5 LSA external 1/2), and `nssa-external` (Type-7 NSSA
+external 1/2). An empty match (the default) pulls in every OSPF route.
+
+## Wire encoding
+
+Redistributed prefixes ride the same reachability TLVs as IS-IS's own
+interface and `network` prefixes:
+
+| Family       | TLV  | Notes                                       |
+|---           |---   |---                                          |
+| IPv4         | 135  | Extended IP Reachability (RFC 5305)         |
+| IPv6         | 236  | IPv6 Reachability (RFC 5308); X-bit per type |
+| IPv6 (MT 2)  | 237  | MT IPv6 Reachability when multi-topology is on |
+
+Because external prefixes share the TLV space with internal ones, a
+receiver does not, for IPv4, distinguish a redistributed prefix from a
+native IS-IS one purely from the wire — both resolve through normal
+SPF. Distinguishing the source is what the IPv6 X-bit provides.
+
+## Worked example
+
+A border router `r1` holds a static route to an edge host's loopback
+`10.1.1.1/32` over a link that is *not* an IS-IS interface, and
+redistributes it into a Level-1 area:
+
+```text
+router static {
+  ipv4 {
+    route 10.1.1.1/32 {
+      nexthop 10.1.0.2;
+    }
+  }
+}
+router isis {
+  net 49.0001.0000.0000.0001.00;
+  is-type level-1;
+  afi-safi ipv4 {
+    redistribute {
+      static { level level-1; }
+    }
+  }
+}
+```
+
+Every other router in area 49.0001 then learns `10.1.1.1/32` as an
+external reachability and installs it. Withdrawing the `redistribute
+static` block (leaving the static route in place) re-originates r1's
+LSP without the prefix, and the area drops the route within one SPF
+cycle — r1 still reaches the host locally through its static route.
+
+## Verification
+
+The redistributed prefix appears in the per-level IS-IS routing table
+and, once installed, in the central RIB:
+
+```text
+zebra# show isis route
+...
+L1 10.1.1.1/32 [metric 20]
+  ...
+
+zebra# show ip route
+...
+i L1 10.1.1.1/32 [115/20] via ...
+```
+
+On the originating router the prefix is reachable through the
+underlying static (or connected/BGP/OSPF) route, so it will not appear
+in that router's *IS-IS* route table — only on the routers that learned
+it from the LSP.
+
+This behaviour is exercised end-to-end by the `isis_redist` BDD feature
+(`bdd/tests/features/isis-redist.feature`), which redistributes a
+static route into a five-router Level-1 area, confirms every router
+installs it, fails it over onto a backup path, and verifies it is
+withdrawn when redistribution is removed.


### PR DESCRIPTION
## Summary

Adds a BDD integration test for IS-IS redistribution of static routes, plus a book chapter documenting the feature.

### Topology (`isis_redist`)

All links point-to-point, all routers Level-1 in area 49.0001:

```
e1 —10— r1 —10— r2 —10— r3 —10— e2      primary spine (r1↔r3 cost 20)
            \              /
            r4 ——10—— r5                backup path  (r1↔r3 cost 30)
```

- `r1`–`r5` run IS-IS; `e1`/`e2` are plain hosts (interface + static default route only, no `router isis`).
- `r1` has a static route to `e1`'s loopback `10.1.1.1/32` and redistributes static into IS-IS **at Level-1**.
- `r1`'s edge link to `e1` is deliberately *not* an IS-IS interface, so `10.1.1.1/32` can only enter the domain via redistribution. `r3`'s edge link to `e2` *is* an IS-IS interface so the e2 stub is advertised, giving the e2→e1 reply path a route home.

### Scenarios
1. Build topology + form Level-1 adjacencies on both paths.
2. Redistribution floods e1's loopback across the area (`show isis route` / `show ip route` + pings from every router).
3. e2 reaches e1 end-to-end across the domain.
4. The redistributed route reconverges onto the backup path when `r1—r2` drops.
5. Withdrawing the `redistribute` block removes the route from the area (local static stays).
6. Teardown.

### Docs
- New chapter `book/src/ch-07-05-isis-redistribution.md` (registered in `SUMMARY.md`): per-AFI config tree, the **`level` default = `level-2`** gotcha for L1-only networks, metric/metric-type semantics, OSPF match filter, and TLV 135/236/237 wire encoding.
- Generated `bdd/docs/isis-redist.md` companion and added a `make isis_redist` target.

## Test plan
- YAML configs validated; step phrases checked against `bdd/tests/cucumber.rs`; design cross-checked against the redistribution source (config subscription → `redist_v4` → TLV 135 emission → SPF install/withdraw).
- `mdbook build` passes.
- Full BDD suite runs in CI (not run locally per repo policy).

Generated with [Claude Code](https://claude.com/claude-code)