### PR TITLE
fix(isis): re-flood self-LSPs when lsp-mtu config changes

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -1169,7 +1169,7 @@ fn config_lsp_mtu_size(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<
 /// transmit on an interface. The flood (SRM) send path compares this
 /// against each interface's MTU; an LSP that would exceed the link MTU
 /// is dropped rather than emitted, since IS-IS PDUs are never
-/// fragmented at the link layer. Storage-only here — the check lives in
+/// fragmented at the link layer. The check lives in
 /// `flood::srm_advertise` and reads the value per send.
 fn config_lsp_mtu(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     let size = args.u16()?;
@@ -1178,6 +1178,21 @@ fn config_lsp_mtu(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     } else {
         None
     };
+
+    // Re-originate so the new transmit cap takes effect on the existing
+    // self-LSPs immediately. Lowering lsp-mtu back under an interface's
+    // MTU must re-flood any LSP the over-MTU value had been dropping on
+    // send (`flood::srm_advertise` clears the SRM flags on drop, so the
+    // peer never sees those LSPs until origination re-marks them).
+    // Without this trigger the recovery only happens at the next natural
+    // origination (periodic refresh, minutes away). Raising lsp-mtu has
+    // no harmful effect here — the regenerated LSP is simply dropped on
+    // send again while the value exceeds the link MTU.
+    for level in [Level::L1, Level::L2] {
+        if has_level(isis.config.is_type(), level) {
+            let _ = isis.tx.send(Message::LspOriginate(level, None));
+        }
+    }
     Some(())
 }
 


### PR DESCRIPTION
## Summary

The `/router/isis/lsp-mtu` config callback was storage-only, so lowering the transmit cap back under an interface's MTU never re-marked the self-originated LSPs for flooding. `flood::srm_advertise` clears the SRM flags whenever it drops an over-MTU LSP on send, so once an over-MTU `lsp-mtu` had suppressed an LSP, the peer never saw it again until the next natural origination (a periodic refresh, minutes away).

This PR triggers `LspOriginate` for each configured level on an `lsp-mtu` change, mirroring the existing `lsp-mtu-size` handler. Re-origination re-runs `srm_set_all`, so the moment `lsp-mtu` drops back under the link MTU the previously-dropped LSP re-floods immediately. Raising `lsp-mtu` stays harmless: the regenerated LSP is simply dropped on send again while it exceeds the link MTU.

## Bug fixed

The `isis_fragmentation_ipv4` BDD scenario "Lowering lsp-mtu under the interface MTU lets z1's LSP flood again" failed: after z1 lowered `lsp-mtu` from 9000 to 1400, z2 never learned `100.64.0.201/32` because nothing re-flooded z1's self-LSP within the test window.

## Test plan

- `cargo build -p zebra-rs` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs isis::` — 137 passed, 0 failed
- BDD `isis_fragmentation_ipv4` — verified by CI (not run locally)

Generated with [Claude Code](https://claude.com/claude-code)