### PR TITLE
fix(isis): re-flood self-LSP when redistributed routes change

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -1514,6 +1514,17 @@ fn redist_set_presence(
         isis.config.redistribute.entry((afi, src)).or_default();
     } else {
         isis.config.redistribute.remove(&(afi, src));
+        // The RedistDel below stops future RIB updates for this
+        // (afi, src), but the RIB does not replay withdrawals for routes
+        // it already delivered. Purge the cached entries here so a later
+        // re-add of the presence container doesn't resurface stale routes
+        // before the RIB re-walks. The builder's config gate masks them
+        // from the LSP today, but the cache would otherwise drift.
+        let rtype = wire_rtype(src);
+        match afi {
+            IsisRedistAfi::Ipv4 => isis.redist_v4.retain(|(rt, _), _| *rt != rtype),
+            IsisRedistAfi::Ipv6 => isis.redist_v6.retain(|(rt, _), _| *rt != rtype),
+        }
     }
     send_redist(isis, afi, src, first_time && op.is_set());
     notify_lsp_reorigination(isis);

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1525,31 +1525,71 @@ impl Isis {
     }
 
     fn route_redist_add(&mut self, rtype: crate::rib::RibType, batch: crate::rib::RouteBatch) {
-        match batch {
+        let changed = match batch {
             crate::rib::RouteBatch::V4(entries) => {
+                let changed = !entries.is_empty();
                 for e in entries {
                     self.redist_v4.insert((rtype, e.prefix), e);
                 }
+                changed
             }
             crate::rib::RouteBatch::V6(entries) => {
+                let changed = !entries.is_empty();
                 for e in entries {
                     self.redist_v6.insert((rtype, e.prefix), e);
                 }
+                changed
             }
+        };
+        if changed {
+            self.reoriginate_self_lsps("redistribute route add");
         }
     }
 
     fn route_redist_del(&mut self, rtype: crate::rib::RibType, batch: crate::rib::RouteBatch) {
+        let mut changed = false;
         match batch {
             crate::rib::RouteBatch::V4(entries) => {
                 for e in entries {
-                    self.redist_v4.remove(&(rtype, e.prefix));
+                    if self.redist_v4.remove(&(rtype, e.prefix)).is_some() {
+                        changed = true;
+                    }
                 }
             }
             crate::rib::RouteBatch::V6(entries) => {
                 for e in entries {
-                    self.redist_v6.remove(&(rtype, e.prefix));
+                    if self.redist_v6.remove(&(rtype, e.prefix)).is_some() {
+                        changed = true;
+                    }
                 }
+            }
+        }
+        if changed {
+            self.reoriginate_self_lsps("redistribute route delete");
+        }
+    }
+
+    /// Re-originate the fragment-0 self-LSP at both levels after a state
+    /// change (e.g. a redistributed route added/withdrawn by RIB). Only
+    /// fires for a level that already holds a self-LSP — matching
+    /// `rib_router_id_update`; when no self-LSP exists yet the eventual
+    /// initial origination reads the current `redist_v{4,6}` maps. The
+    /// per-level `LspOriginate` events coalesce through the throttle, so
+    /// a bulk RIB walk collapses into a single origination run rather
+    /// than one per chunk.
+    fn reoriginate_self_lsps(&self, reason: &str) {
+        let key = IsisLspId::new(self.config.net.sys_id(), 0, 0);
+        for level in [Level::L1, Level::L2] {
+            if self.lsdb.get(&level).get(&key).is_some() {
+                isis_event_trace!(
+                    self.tracing,
+                    LspOriginate,
+                    &level,
+                    "LSP Originate {} due to {}",
+                    level,
+                    reason
+                );
+                let _ = self.tx.send(Message::LspOriginate(level, None));
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes a bug where a redistributed route (e.g. `redistribute static`) stayed in the self-originated IS-IS LSP as an Extended IP Reachability (TLV 135) entry after the route was withdrawn.

Two related gaps:

1. **No re-origination on RIB redistribute add/del.** The RIB redistribution handlers `route_redist_add` / `route_redist_del` mutated the in-memory `redist_v{4,6}` maps but never triggered LSP re-origination — unlike every other state-changing path (config callbacks via `notify_lsp_reorigination`, `rib_router_id_update`, link/adjacency changes). Withdrawing a redistributed route removed it from the map but left the stale TLV in the advertised LSP until some unrelated event happened to re-originate. The add path had the same latent gap.

   Added a guarded `reoriginate_self_lsps` helper (mirrors `rib_router_id_update`: only re-originates levels that already hold a fragment-0 self-LSP) and call it from both handlers when the map actually changed. The per-level `LspOriginate` events coalesce through the throttle, so a bulk RIB walk collapses into a single origination run.

2. **Stale redist cache on config removal.** Removing a `redistribute <source>` presence container sends `RedistDel` to the RIB and re-originates, but the RIB does not replay withdrawals for already-delivered routes, so they lingered in `redist_v{4,6}`. The builder's `config.redistribute` gate masks them from the advertised LSP, but a later re-add of the presence would resurface stale routes before the RIB re-walks. Now purge the cached entries for the `(afi, src)` being removed.

## Test plan

- `cargo build -p zebra-rs` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs isis` — 142 passed
- `cargo fmt --all` applied

Generated with [Claude Code](https://claude.com/claude-code)