### PR TITLE
fix(rib): notify redistribute on resolve-path selection changes

### DIFF
--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -16,8 +16,7 @@ use crate::fib::fib_dump;
 use crate::fib::sysctl::sysctl_enable;
 use crate::fib::{FibChannel, FibHandle, FibMessage, FibNeighbor};
 use crate::rib::route::{
-    AddrRecoveryState, ipv4_nexthop_sync, ipv4_route_sync, ipv6_nexthop_sync, ipv6_route_sync,
-    nexthop_orphan_gc,
+    AddrRecoveryState, ipv4_nexthop_sync, ipv6_nexthop_sync, nexthop_orphan_gc,
 };
 use crate::rib::{Bridge, RibEntries};
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
@@ -2062,14 +2061,7 @@ impl Rib {
                     &self.fib_handle,
                 )
                 .await;
-                ipv4_route_sync(
-                    &mut self.table,
-                    &mut self.nmap,
-                    &self.fib_handle,
-                    RT_TABLE_MAIN,
-                    true,
-                )
-                .await;
+                self.ipv4_default_sync(true).await;
                 ipv6_nexthop_sync(
                     &mut self.nmap,
                     &self.table_v6,
@@ -2078,13 +2070,7 @@ impl Rib {
                     &self.fib_handle,
                 )
                 .await;
-                ipv6_route_sync(
-                    &mut self.table_v6,
-                    &mut self.nmap,
-                    &self.fib_handle,
-                    RT_TABLE_MAIN,
-                )
-                .await;
+                self.ipv6_default_sync().await;
                 self.router_id_update();
             }
             FibMessage::DelAddr(addr) => {
@@ -2108,14 +2094,7 @@ impl Rib {
                     &self.fib_handle,
                 )
                 .await;
-                ipv4_route_sync(
-                    &mut self.table,
-                    &mut self.nmap,
-                    &self.fib_handle,
-                    RT_TABLE_MAIN,
-                    true,
-                )
-                .await;
+                self.ipv4_default_sync(true).await;
                 ipv6_nexthop_sync(
                     &mut self.nmap,
                     &self.table_v6,
@@ -2124,13 +2103,7 @@ impl Rib {
                     &self.fib_handle,
                 )
                 .await;
-                ipv6_route_sync(
-                    &mut self.table_v6,
-                    &mut self.nmap,
-                    &self.fib_handle,
-                    RT_TABLE_MAIN,
-                )
-                .await;
+                self.ipv6_default_sync().await;
                 self.router_id_update();
             }
             FibMessage::NewRoute(route) => {

--- a/zebra-rs/src/rib/redist.rs
+++ b/zebra-rs/src/rib/redist.rs
@@ -2,17 +2,24 @@
 //!
 //! Owns the per-(proto, AFI, rtype) subtype filter sets, the one-shot
 //! FIB walker that pushes the current matching set at subscription
-//! time, and the steady-state delta hook that fires from
-//! `ipv{4,6}_route_{add,del}` after a mutation flips the selected
-//! entry. Self-route filtering is enforced unconditionally — a
-//! subscription whose `proto` maps to its own `rtype` is silently
-//! dropped at registration time.
+//! time, and the steady-state delta hook. Self-route filtering is
+//! enforced unconditionally — a subscription whose `proto` maps to its
+//! own `rtype` is silently dropped at registration time.
 //!
-//! Known gap: nexthop-resolution-driven selection changes that don't
-//! flow through `ipv{4,6}_route_{add,del}` (e.g. the debounced
-//! `ipv4_route_resolve` path) are not yet hooked. The initial walk
-//! at subscription time still covers those, but they won't update
-//! in steady state until a follow-up generalizes the hook.
+//! Two triggers feed the steady-state delta hook, both via
+//! `notify_v{4,6}_delta`:
+//!   - explicit route add/del — `ipv{4,6}_route_{add,del}` snapshot the
+//!     selected entry before/after the mutation;
+//!   - resolution / topology change — `ipv{4,6}_route_sync_collect`
+//!     reports per-prefix selected-entry transitions, which
+//!     `Rib::ipv{4,6}_default_sync` forwards. This closes the former
+//!     gap where a redistributed route stranded in the advertisement
+//!     after its nexthop became (un)resolvable via the debounced
+//!     resolve / link up-down / address add-del paths.
+//!
+//! Still default-table only: `notify_v{4,6}_delta` delivers to
+//! `vrf_id == 0` subscribers, so VRF-table selection changes need a
+//! separate per-VRF hook (see `notify_v4_delta`).
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
@@ -263,15 +270,10 @@ fn flush_v6(
 // ---- steady-state delta notification --------------------------------
 //
 // Called from the route_{add,del} entry points after a FIB mutation
-// has updated the selected entry. Compares the before/after selected
-// entries per subscriber and emits single-entry RouteAdd / RouteDel
-// messages for each filter row that's affected.
-//
-// Known gap: nexthop-resolution-driven selection changes that don't
-// flow through `ipv{4,6}_route_{add,del}` (e.g. the debounced
-// `ipv4_route_resolve` path) are not yet hooked. The initial walk
-// at subscription time still covers those, but they won't update
-// in steady state until the hook is generalized.
+// has updated the selected entry, and from the resolve/sync paths via
+// `selected_changed_v{4,6}` + `Rib::ipv{4,6}_default_sync`. Compares the
+// before/after selected entries per subscriber and emits single-entry
+// RouteAdd / RouteDel messages for each filter row that's affected.
 
 fn build_v4_entry(prefix: &Ipv4Net, e: &RibEntry) -> Option<RouteEntryV4> {
     let nh = first_v4_nexthop(&e.nexthop)?;
@@ -295,6 +297,38 @@ fn build_v6_entry(prefix: &Ipv6Net, e: &RibEntry) -> Option<RouteEntryV6> {
         tag: 0,
         ifindex: e.ifindex,
     })
+}
+
+/// Whether the redistribute-relevant projection of the selected entry
+/// at `prefix` differs between `before` and `after`. The resolve/sync
+/// notify hook uses this to skip no-op selection passes: it compares
+/// the owning `rtype` plus the delivered `RouteEntryV4` (the exact
+/// inputs a subscriber filter keys on — nexthop, metric, subtype,
+/// ifindex), so a recursive nexthop churn that leaves the delivered
+/// form unchanged produces no spurious withdraw/re-add, while a real
+/// select/deselect, rtype swap, or metric change does.
+pub(super) fn selected_changed_v4(
+    prefix: &Ipv4Net,
+    before: Option<&RibEntry>,
+    after: Option<&RibEntry>,
+) -> bool {
+    fn key(prefix: &Ipv4Net, e: Option<&RibEntry>) -> Option<(RibType, RouteEntryV4)> {
+        let e = e?;
+        Some((e.rtype, build_v4_entry(prefix, e)?))
+    }
+    key(prefix, before) != key(prefix, after)
+}
+
+pub(super) fn selected_changed_v6(
+    prefix: &Ipv6Net,
+    before: Option<&RibEntry>,
+    after: Option<&RibEntry>,
+) -> bool {
+    fn key(prefix: &Ipv6Net, e: Option<&RibEntry>) -> Option<(RibType, RouteEntryV6)> {
+        let e = e?;
+        Some((e.rtype, build_v6_entry(prefix, e)?))
+    }
+    key(prefix, before) != key(prefix, after)
 }
 
 /// Notify every default-VRF subscriber whose filter matches the
@@ -480,4 +514,89 @@ fn send_v6_one(tx: &UnboundedSender<RibRx>, rtype: RibType, op: WalkOp, entry: R
         },
     };
     let _ = tx.send(msg);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rib::nexthop::NexthopUni;
+    use std::net::IpAddr;
+
+    fn static_uni(addr: &str, metric: u32) -> RibEntry {
+        let mut e = RibEntry::new(RibType::Static);
+        e.metric = metric;
+        e.nexthop = Nexthop::Uni(NexthopUni::new(
+            addr.parse::<IpAddr>().unwrap(),
+            metric,
+            vec![],
+        ));
+        e
+    }
+
+    fn p() -> Ipv4Net {
+        "1.2.3.4/32".parse().unwrap()
+    }
+
+    #[test]
+    fn no_change_when_both_unselected() {
+        assert!(!selected_changed_v4(&p(), None, None));
+    }
+
+    #[test]
+    fn deselect_is_a_change() {
+        // The resolve-path strand: a redistributed route that was
+        // selected becomes unselected (nexthop unresolvable) — must be
+        // seen as a change so the withdraw reaches subscribers.
+        let before = static_uni("10.0.0.2", 0);
+        assert!(selected_changed_v4(&p(), Some(&before), None));
+    }
+
+    #[test]
+    fn select_is_a_change() {
+        let after = static_uni("10.0.0.2", 0);
+        assert!(selected_changed_v4(&p(), None, Some(&after)));
+    }
+
+    #[test]
+    fn identical_selection_is_no_change() {
+        // A no-op resolve pass over an unchanged selected route must not
+        // emit a spurious withdraw/re-add.
+        let a = static_uni("10.0.0.2", 0);
+        let b = static_uni("10.0.0.2", 0);
+        assert!(!selected_changed_v4(&p(), Some(&a), Some(&b)));
+    }
+
+    #[test]
+    fn metric_change_is_a_change() {
+        let a = static_uni("10.0.0.2", 10);
+        let b = static_uni("10.0.0.2", 20);
+        assert!(selected_changed_v4(&p(), Some(&a), Some(&b)));
+    }
+
+    #[test]
+    fn rtype_swap_is_a_change() {
+        // Same delivered nexthop/metric but a different owning protocol
+        // — subscribers filter on rtype, so this must register.
+        let a = static_uni("10.0.0.2", 10);
+        let mut b = static_uni("10.0.0.2", 10);
+        b.rtype = RibType::Ospf;
+        assert!(selected_changed_v4(&p(), Some(&a), Some(&b)));
+    }
+
+    #[test]
+    fn nexthop_change_is_a_change() {
+        let a = static_uni("10.0.0.2", 0);
+        let b = static_uni("10.0.0.3", 0);
+        assert!(selected_changed_v4(&p(), Some(&a), Some(&b)));
+    }
+
+    #[test]
+    fn link_only_nexthop_never_delivered() {
+        // A Link-only (non-deliverable) selected entry projects to None;
+        // gaining or losing it produces no redistribute delta.
+        let mut link = RibEntry::new(RibType::Static);
+        link.nexthop = Nexthop::Link(7);
+        assert!(!selected_changed_v4(&p(), Some(&link), None));
+        assert!(!selected_changed_v4(&p(), None, Some(&link)));
+    }
 }

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -359,14 +359,7 @@ impl Rib {
             &self.fib_handle,
         )
         .await;
-        ipv4_route_sync(
-            &mut self.table,
-            &mut self.nmap,
-            &self.fib_handle,
-            RT_TABLE_MAIN,
-            true,
-        )
-        .await;
+        self.ipv4_default_sync(true).await;
         ipv6_nexthop_sync(
             &mut self.nmap,
             &self.table_v6,
@@ -375,13 +368,7 @@ impl Rib {
             &self.fib_handle,
         )
         .await;
-        ipv6_route_sync(
-            &mut self.table_v6,
-            &mut self.nmap,
-            &self.fib_handle,
-            RT_TABLE_MAIN,
-        )
-        .await;
+        self.ipv6_default_sync().await;
         self.schedule_rib_sync();
     }
 
@@ -520,14 +507,7 @@ impl Rib {
             &self.fib_handle,
         )
         .await;
-        ipv4_route_sync(
-            &mut self.table,
-            &mut self.nmap,
-            &self.fib_handle,
-            RT_TABLE_MAIN,
-            true,
-        )
-        .await;
+        self.ipv4_default_sync(true).await;
         ipv6_nexthop_sync(
             &mut self.nmap,
             &self.table_v6,
@@ -536,13 +516,7 @@ impl Rib {
             &self.fib_handle,
         )
         .await;
-        ipv6_route_sync(
-            &mut self.table_v6,
-            &mut self.nmap,
-            &self.fib_handle,
-            RT_TABLE_MAIN,
-        )
-        .await;
+        self.ipv6_default_sync().await;
         // Mirror link_down: schedule a deferred Resolve so recursive
         // groups (e.g. a static whose first segment was unreachable
         // while the link was down) re-evaluate now that the IS-IS
@@ -899,6 +873,74 @@ impl Rib {
         self.schedule_rib_sync();
     }
 
+    /// Sync the default IPv4 table, then push any selected-entry
+    /// transitions to redistribute subscribers. This is the steady-state
+    /// hook that closes the resolve-path gap: selection changes driven by
+    /// nexthop resolution / topology churn (link up/down, address add/del,
+    /// the debounced resolve) flow to subscribers, not just explicit
+    /// route add/del. When no subscriber is registered the plain sync runs
+    /// with zero snapshot overhead.
+    pub(super) async fn ipv4_default_sync(&mut self, ifdown: bool) -> bool {
+        if self.redist_filters.is_empty() {
+            return ipv4_route_sync(
+                &mut self.table,
+                &mut self.nmap,
+                &self.fib_handle,
+                RT_TABLE_MAIN,
+                ifdown,
+            )
+            .await;
+        }
+        let (retry, deltas) = ipv4_route_sync_collect(
+            &mut self.table,
+            &mut self.nmap,
+            &self.fib_handle,
+            RT_TABLE_MAIN,
+            ifdown,
+        )
+        .await;
+        for (prefix, before, after) in deltas {
+            super::redist::notify_v4_delta(
+                &self.redist_filters,
+                &self.client_registry,
+                &prefix,
+                before.as_ref(),
+                after.as_ref(),
+            );
+        }
+        retry
+    }
+
+    /// IPv6 sibling of `ipv4_default_sync`.
+    pub(super) async fn ipv6_default_sync(&mut self) -> bool {
+        if self.redist_filters.is_empty() {
+            return ipv6_route_sync(
+                &mut self.table_v6,
+                &mut self.nmap,
+                &self.fib_handle,
+                RT_TABLE_MAIN,
+            )
+            .await;
+        }
+        let (retry, deltas) = ipv6_route_sync_collect(
+            &mut self.table_v6,
+            &mut self.nmap,
+            &self.fib_handle,
+            RT_TABLE_MAIN,
+        )
+        .await;
+        for (prefix, before, after) in deltas {
+            super::redist::notify_v6_delta(
+                &self.redist_filters,
+                &self.client_registry,
+                &prefix,
+                before.as_ref(),
+                after.as_ref(),
+            );
+        }
+        retry
+    }
+
     pub async fn ipv6_route_resolve(&mut self) {
         ipv6_nexthop_sync(
             &mut self.nmap,
@@ -908,13 +950,7 @@ impl Rib {
             &self.fib_handle,
         )
         .await;
-        let mut retry = ipv6_route_sync(
-            &mut self.table_v6,
-            &mut self.nmap,
-            &self.fib_handle,
-            RT_TABLE_MAIN,
-        )
-        .await;
+        let mut retry = self.ipv6_default_sync().await;
         let table_ids: Vec<u32> = self.vrf_tables.keys().copied().collect();
         for table_id in table_ids {
             if let Some(t) = self.vrf_tables.get_mut(&table_id) {
@@ -941,14 +977,7 @@ impl Rib {
         .await;
         // `false` = not an ifdown sweep; this resolve cycle is for FIB-update
         // re-resolution, not link-down recovery.
-        let mut retry = ipv4_route_sync(
-            &mut self.table,
-            &mut self.nmap,
-            &self.fib_handle,
-            RT_TABLE_MAIN,
-            false,
-        )
-        .await;
+        let mut retry = self.ipv4_default_sync(false).await;
         // Re-sync each VRF table against its own kernel table id so a
         // VRF route whose nexthop only just became resolvable gets
         // installed.
@@ -1170,6 +1199,13 @@ pub async fn ipv4_nexthop_sync(
     }
 }
 
+/// Per-prefix selected-entry transition produced by a sync pass:
+/// `(prefix, before, after)`. Fed to the redistribute steady-state
+/// delta hook so resolution/topology-driven selection changes reach
+/// subscribers, not just explicit route add/del.
+pub type RedistDeltaV4 = (Ipv4Net, Option<RibEntry>, Option<RibEntry>);
+pub type RedistDeltaV6 = (Ipv6Net, Option<RibEntry>, Option<RibEntry>);
+
 pub async fn ipv4_route_sync(
     table: &mut PrefixMap<Ipv4Net, RibEntries>,
     nmap: &mut NexthopMap,
@@ -1177,18 +1213,56 @@ pub async fn ipv4_route_sync(
     table_id: u32,
     ifdown: bool,
 ) -> bool {
+    ipv4_route_sync_inner(table, nmap, fib, table_id, ifdown, false)
+        .await
+        .0
+}
+
+/// Like `ipv4_route_sync` but also returns the per-prefix selected-entry
+/// transitions (so the caller can notify redistribute subscribers about
+/// resolution/topology-driven selection changes). Only the default
+/// table should collect: `notify_v4_delta` delivers to `vrf_id == 0`
+/// subscribers, so VRF-table deltas must not flow through it.
+pub async fn ipv4_route_sync_collect(
+    table: &mut PrefixMap<Ipv4Net, RibEntries>,
+    nmap: &mut NexthopMap,
+    fib: &FibHandle,
+    table_id: u32,
+    ifdown: bool,
+) -> (bool, Vec<RedistDeltaV4>) {
+    ipv4_route_sync_inner(table, nmap, fib, table_id, ifdown, true).await
+}
+
+async fn ipv4_route_sync_inner(
+    table: &mut PrefixMap<Ipv4Net, RibEntries>,
+    nmap: &mut NexthopMap,
+    fib: &FibHandle,
+    table_id: u32,
+    ifdown: bool,
+    collect: bool,
+) -> (bool, Vec<RedistDeltaV4>) {
     // Collect prefixes first so we don't hold the !Send `IterMut`
     // across the `ipv4_entry_selection` await.
     let prefixes: Vec<Ipv4Net> = table.iter().map(|(p, _)| p).collect();
     let mut retry = false;
+    let mut deltas: Vec<RedistDeltaV4> = Vec::new();
     for p in prefixes {
         let Some(entries) = table.get_mut(&p) else {
             continue;
         };
+        let before = collect
+            .then(|| entries.iter().find(|e| e.is_selected()).cloned())
+            .flatten();
         ipv4_entry_resolve(entries, nmap, ifdown);
         retry |= ipv4_entry_selection(&p, entries, None, nmap, fib, table_id, ifdown).await;
+        if collect {
+            let after = entries.iter().find(|e| e.is_selected()).cloned();
+            if super::redist::selected_changed_v4(&p, before.as_ref(), after.as_ref()) {
+                deltas.push((p, before, after));
+            }
+        }
     }
-    retry
+    (retry, deltas)
 }
 
 fn ipv4_entry_resolve(entries: &mut RibEntries, nmap: &NexthopMap, ifdown: bool) {
@@ -1871,18 +1945,51 @@ pub async fn ipv6_route_sync(
     fib: &FibHandle,
     table_id: u32,
 ) -> bool {
+    ipv6_route_sync_inner(table, nmap, fib, table_id, false)
+        .await
+        .0
+}
+
+/// IPv6 sibling of `ipv4_route_sync_collect`. See its docstring for the
+/// default-table-only collection rule.
+pub async fn ipv6_route_sync_collect(
+    table: &mut PrefixMap<Ipv6Net, RibEntries>,
+    nmap: &mut NexthopMap,
+    fib: &FibHandle,
+    table_id: u32,
+) -> (bool, Vec<RedistDeltaV6>) {
+    ipv6_route_sync_inner(table, nmap, fib, table_id, true).await
+}
+
+async fn ipv6_route_sync_inner(
+    table: &mut PrefixMap<Ipv6Net, RibEntries>,
+    nmap: &mut NexthopMap,
+    fib: &FibHandle,
+    table_id: u32,
+    collect: bool,
+) -> (bool, Vec<RedistDeltaV6>) {
     // Collect prefixes first so we don't hold the !Send `IterMut`
     // across the `ipv6_entry_selection` await.
     let prefixes: Vec<Ipv6Net> = table.iter().map(|(p, _)| p).collect();
     let mut retry = false;
+    let mut deltas: Vec<RedistDeltaV6> = Vec::new();
     for p in prefixes {
         let Some(entries) = table.get_mut(&p) else {
             continue;
         };
+        let before = collect
+            .then(|| entries.iter().find(|e| e.is_selected()).cloned())
+            .flatten();
         ipv6_entry_resolve(entries, nmap);
         retry |= ipv6_entry_selection(&p, entries, None, nmap, fib, table_id).await;
+        if collect {
+            let after = entries.iter().find(|e| e.is_selected()).cloned();
+            if super::redist::selected_changed_v6(&p, before.as_ref(), after.as_ref()) {
+                deltas.push((p, before, after));
+            }
+        }
     }
-    retry
+    (retry, deltas)
 }
 
 fn ipv6_entry_resolve(entries: &mut RibEntries, nmap: &NexthopMap) {


### PR DESCRIPTION
## Summary

Closes the documented redistribute resolve-path gap: a redistributed route (e.g. a recursive static) whose nexthop became unresolvable was deselected in a sync pass but kept being advertised by IS-IS/OSPF/BGP (stranded / black-holed); one that became resolvable only after subscribe time was never delivered until an unrelated re-origination.

The steady-state delta hook only fired from the explicit route add/del path. Selection changes driven by nexthop resolution / topology churn — the debounced `ipv{4,6}_route_resolve`, the `link_down`/`link_up` sweeps, and the `NewAddr`/`DelAddr` handlers, all routed through `ipv{4,6}_route_sync` — flipped the `selected` flag without notifying subscribers.

## Changes

- **`ipv{4,6}_route_sync_collect`** — same pass as `ipv{4,6}_route_sync` but returns the per-prefix selected-entry transitions; the plain function delegates with collection off, so its signature and all existing callers (incl. the VRF loops) are unchanged.
- **`Rib::ipv{4,6}_default_sync`** — wrap the default-table sync: with a redist subscriber registered they collect deltas and forward each to `notify_v{4,6}_delta`, else fall back to the plain sync (zero overhead). All six default-table sync sites now go through these.
- **`selected_changed_v{4,6}`** — gates each delta on a real change by comparing the owning rtype plus the delivered `RouteEntry` projection, so no-op resolve passes and recursive-nexthop churn don't emit spurious withdraw/re-add, and the explicit add/del path doesn't double-notify (the later resolve sees `before == after`).

Scope unchanged: default table only (`notify_v*_delta` targets `vrf_id == 0`); VRF-table deltas are intentionally not collected. Module docs updated to reflect the closed gap.

## Test plan

- `cargo build -p zebra-rs` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs` — 852 passed (incl. 8 new change-detector tests)
- `cargo fmt --all` applied

Generated with [Claude Code](https://claude.com/claude-code)