### PR TITLE
fix(isis): dynamic is-type reconfiguration and L1 area gate

### DIFF
--- a/bdd/docs/isis_fragmentation_ipv4.md
+++ b/bdd/docs/isis_fragmentation_ipv4.md
@@ -14,6 +14,11 @@ This is verified at two LSP MTUs over one topology: first a tight
 live reconfiguration of z1 — the standard 1500-byte Ethernet MTU
 (fragmentation needs 200 networks), confirming both the small-MTU
 path and that a runtime lsp-mtu-size change re-fragments correctly.
+Finally, the same topology exercises the separate transmit-side
+`lsp-mtu` knob: raising it above an interface's MTU makes the flood
+path drop z1's LSP on send (logged at warning level), which `show isis
+interface detail` flags and a receiver can prove by never learning a
+freshly-added prefix until lsp-mtu is lowered back under the MTU.
 
 ## Test Topology
 
@@ -52,4 +57,7 @@ path and that a runtime lsp-mtu-size change re-fragments correctly.
 | MTU 1500 — z2 still observes z1's self-LSP as multiple fragments | |
 | MTU 1500 — z2 reaches z1's loopback despite z1's self-LSP being fragmented | |
 | MTU 1500 — z2 installs a /32 network carried in one of z1's higher fragments | |
+| lsp-mtu above the interface MTU is flagged in show isis interface detail | |
+| lsp-mtu above the interface MTU drops z1's LSP on send so z2 never learns the new prefix | |
+| Lowering lsp-mtu under the interface MTU lets z1's LSP flood again | |
 | Teardown topology | |

--- a/bdd/docs/isis_l1l2.md
+++ b/bdd/docs/isis_l1l2.md
@@ -16,17 +16,18 @@ toward rJ is named "iJ".
 ## Test Topology
 
 ```
-        Area 49.0001  (Level-1 area)            Backbone (Level-2)
-    ┌──────────────────────────────────┐     ┌──────────────────────┐
-
-        r1 ───L1─── r2 ───L1─── r3 ════L2════ r4
-       (L1)        (L1)        (L1L2)         (L2-only)
-      lo .1        lo .2       lo .3           lo .4
-     49.0001      49.0001      49.0001         49.0000
+        Area 49.0001  (Level-1 area)        Backbone (Level-2)   Area 49.0000
+    ┌──────────────────────────────────┐  ┌──────────────────┐
+                                                                  (L1, idle)
+        r1 ───L1─── r2 ───L1─── r3 ════L2════ r4 ┄┄┄┄┄┄┄┄┄┄┄┄ r5
+       (L1)        (L1)        (L1L2)        (L2-only)         (L1-only)
+      lo .1        lo .2       lo .3          lo .4             lo .5
+     49.0001      49.0001      49.0001        49.0000           49.0000
 
     loopbacks: rI -> 10.0.0.I/32  and  2001:db8::I/128
     links:     r1-r2 10.0.12.0/30  r2-r3 10.0.23.0/30  r3-r4 10.0.34.0/30
-               (IPv6 2001:db8:12::/64, 2001:db8:23::/64, 2001:db8:34::/64)
+               r4-r5 10.0.45.0/30
+               (IPv6 2001:db8:NN::/64 matching each /30)
 ```
 
 ## Notes
@@ -36,6 +37,15 @@ circuit-type level-1 (same area 49.0001 as r1/r2), and its circuit toward
 r4 (i4) is circuit-type level-2-only. r3's loopback is circuit-type
 level-1-2, so 10.0.0.3/2001:db8::3 is advertised into *both* the L1 LSP
 (reachable from the area) and the L2 LSP (reachable from the backbone).
+r5 is an L1-only router in the backbone area 49.0000, wired to r4 over a
+circuit-type level-1-2 link (r4 side) — an L1L2 circuit facing a
+single-level neighbor, which exercises the per-circuit P2P three-way
+handshake (RFC 5303). It starts idle: while r4 is
+level-2-only the r4-r5 link runs L2 only, so the L1-only r5 forms no
+adjacency. The trailing scenarios promote r4 to level-1-2 (an L1 adjacency
+with r5 then forms and r4's L1 LSP floods to r5) and demote it again (r4
+purges that L1 LSP and r5 drops it) — exercising is-type-driven self-LSP
+origination and purge end-to-end across a real adjacency.
 Note on scope: zebra-rs builds each level's LSP only from prefixes whose
 circuit participates at that level — there is no automatic L1->L2 leaking
 and the ATT-bit / default-route mechanism is not implemented. So the L1
@@ -53,4 +63,8 @@ those two negative pings are the assertions to revisit.
 | The L1/L2 border runs a separate SPF and installs routes at both levels | |
 | Forwarding is confined to each level (L1 area + L2 backbone) | |
 | Levels do not leak — the L1 area and the L2 backbone stay separate | |
+| Promoting the L2-only border r4 to L1/L2 originates a self-LSP at both levels | |
+| r4's new L1 LSP floods to the L1-only r5 in the backbone area | |
+| Demoting r4 back to level-2-only purges its L1 LSP from r5 | |
+| A Level-1 adjacency is refused across the r3-r4 area boundary | |
 | Teardown topology | |

--- a/bdd/docs/isis_tilfa.md
+++ b/bdd/docs/isis_tilfa.md
@@ -47,4 +47,7 @@ through the r-plane rather than a plain loop-free alternate.
 | no-php sets the P (no-PHP) flag and makes the penultimate hop swap | |
 | no-local-prefix-sid suppresses only the local Prefix-SID in the LFIB | |
 | Deleting segment-routing mpls clears all MPLS ILM entries | |
+| lsp-mtu above the link MTU is flagged on the source's interfaces | |
+| lsp-mtu above the link MTU drops s's LSP so n1 never learns the new prefix | |
+| Lowering lsp-mtu under the link MTU lets s's LSP flood to n1 | |
 | Teardown topology | |

--- a/bdd/tests/configs/isis_l1l2/r3-backbone-l1l2.yaml
+++ b/bdd/tests/configs/isis_l1l2/r3-backbone-l1l2.yaml
@@ -1,40 +1,40 @@
 interface:
 - if-name: lo
   ipv4:
-    address: 10.0.0.4/32
+    address: 10.0.0.3/32
   ipv6:
-    address: 2001:db8::4/128
-- if-name: i3
+    address: 2001:db8::3/128
+- if-name: i2
   ipv4:
-    address: 10.0.34.2/30
+    address: 10.0.23.2/30
   ipv6:
-    address: 2001:db8:34::2/64
-- if-name: i5
+    address: 2001:db8:23::2/64
+- if-name: i4
   ipv4:
-    address: 10.0.45.1/30
+    address: 10.0.34.1/30
   ipv6:
-    address: 2001:db8:45::1/64
+    address: 2001:db8:34::1/64
 router:
   isis:
-    net: 49.0000.0000.0000.0004.00
-    is-type: level-2-only
-    hostname: r4
+    net: 49.0001.0000.0000.0003.00
+    is-type: level-1-2
+    hostname: r3
     interface:
     - if-name: lo
-      circuit-type: level-2-only
+      circuit-type: level-1-2
       ipv4:
         enable: true
       ipv6:
         enable: true
-    - if-name: i3
-      circuit-type: level-2-only
+    - if-name: i2
+      circuit-type: level-1
       network-type: point-to-point
       metric: 10
       ipv4:
         enable: true
       ipv6:
         enable: true
-    - if-name: i5
+    - if-name: i4
       circuit-type: level-1-2
       network-type: point-to-point
       metric: 10

--- a/bdd/tests/configs/isis_l1l2/r4-backbone-l1l2.yaml
+++ b/bdd/tests/configs/isis_l1l2/r4-backbone-l1l2.yaml
@@ -17,7 +17,6 @@ interface:
 router:
   isis:
     net: 49.0000.0000.0000.0004.00
-    is-type: level-2-only
     hostname: r4
     interface:
     - if-name: lo
@@ -27,7 +26,7 @@ router:
       ipv6:
         enable: true
     - if-name: i3
-      circuit-type: level-2-only
+      circuit-type: level-1-2
       network-type: point-to-point
       metric: 10
       ipv4:

--- a/bdd/tests/configs/isis_l1l2/r4-l1l2.yaml
+++ b/bdd/tests/configs/isis_l1l2/r4-l1l2.yaml
@@ -17,7 +17,6 @@ interface:
 router:
   isis:
     net: 49.0000.0000.0000.0004.00
-    is-type: level-2-only
     hostname: r4
     interface:
     - if-name: lo

--- a/bdd/tests/configs/isis_l1l2/r5.yaml
+++ b/bdd/tests/configs/isis_l1l2/r5.yaml
@@ -1,0 +1,31 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.5/32
+  ipv6:
+    address: 2001:db8::5/128
+- if-name: i4
+  ipv4:
+    address: 10.0.45.2/30
+  ipv6:
+    address: 2001:db8:45::2/64
+router:
+  isis:
+    net: 49.0000.0000.0000.0005.00
+    is-type: level-1
+    hostname: r5
+    interface:
+    - if-name: lo
+      circuit-type: level-1
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i4
+      circuit-type: level-1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -682,6 +682,219 @@ async fn show_command_not_contains(
     );
 }
 
+/// Assert the IS-IS LSDB at the given level (`L1` or `L2`) in a namespace
+/// holds at least one self-originated LSP. Reads
+/// `vtyctl show -j "show isis database"`, whose JSON is
+/// `{ "level_1": [...], "level_2": [...] }` with each entry carrying an
+/// `originated` boolean. A level-1-2 router must originate a self-LSP into
+/// BOTH databases — checking the `originated` flag in JSON is far more
+/// precise than substring-matching the text table (the hostname appears
+/// for every LSP, self-originated or learned).
+#[then(expr = "isis database in namespace {string} has a self-originated LSP at {string}")]
+async fn isis_database_self_originated(world: &mut World, namespace: String, level: String) {
+    let scoped = world.ns(&namespace);
+    let key = match level.as_str() {
+        "L1" => "level_1",
+        "L2" => "level_2",
+        other => panic!("invalid IS-IS level '{}', expected 'L1' or 'L2'", other),
+    };
+    let output = netns::exec_in_netns(&scoped, "vtyctl", &["show", "-j", "show isis database"])
+        .await
+        .expect("Failed to run show isis database");
+    let db: Value = serde_json::from_str(&output).unwrap_or_else(|e| {
+        panic!(
+            "show isis database -j in {} was not valid JSON: {}\nfull output:\n{}",
+            scoped, e, output
+        )
+    });
+    let entries = db.get(key).and_then(|v| v.as_array()).unwrap_or_else(|| {
+        panic!(
+            "show isis database -j in {} had no '{}' array:\n{}",
+            scoped, key, output
+        )
+    });
+    let has_self = entries
+        .iter()
+        .any(|e| e.get("originated").and_then(|o| o.as_bool()) == Some(true));
+    assert!(
+        has_self,
+        "IS-IS {} database in {} has no self-originated LSP:\n{}",
+        level, scoped, output
+    );
+    println!(
+        "✓ IS-IS {} database in {} has a self-originated LSP",
+        level, scoped
+    );
+}
+
+/// Map an `L1`/`L2` level label to the JSON key used by
+/// `show isis database -j` (`level_1` / `level_2`).
+fn isis_db_level_key(level: &str) -> &'static str {
+    match level {
+        "L1" => "level_1",
+        "L2" => "level_2",
+        other => panic!("invalid IS-IS level '{}', expected 'L1' or 'L2'", other),
+    }
+}
+
+/// Whether the IS-IS LSDB at `level` in `scoped` holds an LSP matching
+/// `ident` in either its `lsp_id` or its `system_id` field. Match `ident`
+/// against the originator's system-id (e.g. `0000.0000.0004`) for a check
+/// that is robust the instant the LSP is installed; the dynamic hostname
+/// in `system_id` only resolves once the peer's TLV-137 LSP has been
+/// processed, which lags adjacency formation. Returns the match flag plus
+/// the raw JSON so callers can quote it on failure.
+async fn isis_db_level_has_lsp_from(scoped: &str, level: &str, ident: &str) -> (bool, String) {
+    let key = isis_db_level_key(level);
+    let output = netns::exec_in_netns(scoped, "vtyctl", &["show", "-j", "show isis database"])
+        .await
+        .expect("Failed to run show isis database");
+    let db: Value = serde_json::from_str(&output).unwrap_or_else(|e| {
+        panic!(
+            "show isis database -j in {} was not valid JSON: {}\nfull output:\n{}",
+            scoped, e, output
+        )
+    });
+    let found = db
+        .get(key)
+        .and_then(|v| v.as_array())
+        .map(|entries| {
+            entries.iter().any(|e| {
+                ["lsp_id", "system_id"].iter().any(|field| {
+                    e.get(*field)
+                        .and_then(|s| s.as_str())
+                        .is_some_and(|s| s.contains(ident))
+                })
+            })
+        })
+        .unwrap_or(false);
+    (found, output)
+}
+
+/// Assert the IS-IS LSDB at `level` in a namespace holds an LSP from the
+/// given originator (matched by system-id or dynamic hostname). Used to
+/// confirm a flooded LSP reached this router's database.
+#[then(expr = "isis database in namespace {string} at {string} has LSP from {string}")]
+async fn isis_database_has_lsp_from(
+    world: &mut World,
+    namespace: String,
+    level: String,
+    ident: String,
+) {
+    let scoped = world.ns(&namespace);
+    let (found, output) = isis_db_level_has_lsp_from(&scoped, &level, &ident).await;
+    assert!(
+        found,
+        "IS-IS {} database in {} has no LSP from '{}':\n{}",
+        level, scoped, ident, output
+    );
+    println!(
+        "✓ IS-IS {} database in {} has LSP from '{}'",
+        level, scoped, ident
+    );
+}
+
+/// Negative sibling: assert the IS-IS LSDB at `level` holds NO LSP from
+/// the given originator. Used to confirm a purge fully evicted the peer's
+/// LSP (after the ZeroAgeLifetime hold-down, not just RemainingLifetime=0).
+#[then(expr = "isis database in namespace {string} at {string} does not have LSP from {string}")]
+async fn isis_database_not_has_lsp_from(
+    world: &mut World,
+    namespace: String,
+    level: String,
+    ident: String,
+) {
+    let scoped = world.ns(&namespace);
+    let (found, output) = isis_db_level_has_lsp_from(&scoped, &level, &ident).await;
+    assert!(
+        !found,
+        "IS-IS {} database in {} still has an LSP from '{}':\n{}",
+        level, scoped, ident, output
+    );
+    println!(
+        "✓ IS-IS {} database in {} has no LSP from '{}'",
+        level, scoped, ident
+    );
+}
+
+/// Whether an IS-IS adjacency at `level` (1/2) on `interface` in `scoped`
+/// has reached the Up state. Reads `show isis neighbor -j`, a flat array of
+/// `{system_id, interface, level, state, ...}`. Matching by (interface,
+/// level) rather than by the peer's hostname is robust: it does not depend
+/// on the dynamic hostname having propagated, and pins the assertion to the
+/// specific circuit under test. Returns the flag plus raw JSON for failures.
+async fn isis_neighbor_up(scoped: &str, level: u64, interface: &str) -> (bool, String) {
+    let output = netns::exec_in_netns(scoped, "vtyctl", &["show", "-j", "show isis neighbor"])
+        .await
+        .expect("Failed to run show isis neighbor");
+    let nbrs: Value = serde_json::from_str(&output).unwrap_or_else(|e| {
+        panic!(
+            "show isis neighbor -j in {} was not valid JSON: {}\nfull output:\n{}",
+            scoped, e, output
+        )
+    });
+    let up = nbrs
+        .as_array()
+        .map(|arr| {
+            arr.iter().any(|n| {
+                n.get("level").and_then(|l| l.as_u64()) == Some(level)
+                    && n.get("interface").and_then(|i| i.as_str()) == Some(interface)
+                    && n.get("state").and_then(|s| s.as_str()) == Some("Up")
+            })
+        })
+        .unwrap_or(false);
+    (up, output)
+}
+
+/// Assert an IS-IS adjacency at the given level on the given interface is
+/// Up — e.g. the area-independent Level-2 backbone adjacency.
+#[then(
+    expr = "isis neighbor in namespace {string} at level {int} on interface {string} should be up"
+)]
+async fn isis_neighbor_should_be_up(
+    world: &mut World,
+    namespace: String,
+    level: u64,
+    interface: String,
+) {
+    let scoped = world.ns(&namespace);
+    let (up, output) = isis_neighbor_up(&scoped, level, &interface).await;
+    assert!(
+        up,
+        "no Up L{} IS-IS adjacency on {} in {}:\n{}",
+        level, interface, scoped, output
+    );
+    println!(
+        "✓ L{} IS-IS adjacency on {} in {} is Up",
+        level, interface, scoped
+    );
+}
+
+/// Negative sibling: assert NO Up adjacency at the given level on the given
+/// interface. Used to verify a Level-1 adjacency across an area boundary is
+/// (correctly) refused — the L1 common-area gate of ISO 10589 §8.4.3.
+#[then(
+    expr = "isis neighbor in namespace {string} at level {int} on interface {string} should not be up"
+)]
+async fn isis_neighbor_should_not_be_up(
+    world: &mut World,
+    namespace: String,
+    level: u64,
+    interface: String,
+) {
+    let scoped = world.ns(&namespace);
+    let (up, output) = isis_neighbor_up(&scoped, level, &interface).await;
+    assert!(
+        !up,
+        "unexpected Up L{} IS-IS adjacency on {} in {}:\n{}",
+        level, interface, scoped, output
+    );
+    println!(
+        "✓ no Up L{} IS-IS adjacency on {} in {} (as expected)",
+        level, interface, scoped
+    );
+}
+
 /// Parse the OSPF `show ip ospf neighbor` up-time string (the
 /// `format_uptime` output: "0m08s", "1h02m03s", "1d02h03m") into whole
 /// seconds. Any hours/days component is far past the thresholds this

--- a/bdd/tests/features/isis_l1l2.feature
+++ b/bdd/tests/features/isis_l1l2.feature
@@ -15,17 +15,18 @@ Feature: IS-IS Level-1 / Level-2 interaction across an L1 area and an L2 backbon
 
   Test Topology:
   ```
-        Area 49.0001  (Level-1 area)            Backbone (Level-2)
-    ┌──────────────────────────────────┐     ┌──────────────────────┐
-
-        r1 ───L1─── r2 ───L1─── r3 ════L2════ r4
-       (L1)        (L1)        (L1L2)         (L2-only)
-      lo .1        lo .2       lo .3           lo .4
-     49.0001      49.0001      49.0001         49.0000
+        Area 49.0001  (Level-1 area)        Backbone (Level-2)   Area 49.0000
+    ┌──────────────────────────────────┐  ┌──────────────────┐
+                                                                  (L1, idle)
+        r1 ───L1─── r2 ───L1─── r3 ════L2════ r4 ┄┄┄┄┄┄┄┄┄┄┄┄ r5
+       (L1)        (L1)        (L1L2)        (L2-only)         (L1-only)
+      lo .1        lo .2       lo .3          lo .4             lo .5
+     49.0001      49.0001      49.0001        49.0000           49.0000
 
     loopbacks: rI -> 10.0.0.I/32  and  2001:db8::I/128
     links:     r1-r2 10.0.12.0/30  r2-r3 10.0.23.0/30  r3-r4 10.0.34.0/30
-               (IPv6 2001:db8:12::/64, 2001:db8:23::/64, 2001:db8:34::/64)
+               r4-r5 10.0.45.0/30
+               (IPv6 2001:db8:NN::/64 matching each /30)
   ```
 
   r3 is the only Level-1/Level-2 router. Its circuit toward r2 (i2) is
@@ -33,6 +34,16 @@ Feature: IS-IS Level-1 / Level-2 interaction across an L1 area and an L2 backbon
   r4 (i4) is circuit-type level-2-only. r3's loopback is circuit-type
   level-1-2, so 10.0.0.3/2001:db8::3 is advertised into *both* the L1 LSP
   (reachable from the area) and the L2 LSP (reachable from the backbone).
+
+  r5 is an L1-only router in the backbone area 49.0000, wired to r4 over a
+  circuit-type level-1-2 link (r4 side) — an L1L2 circuit facing a
+  single-level neighbor, which exercises the per-circuit P2P three-way
+  handshake (RFC 5303). It starts idle: while r4 is
+  level-2-only the r4-r5 link runs L2 only, so the L1-only r5 forms no
+  adjacency. The trailing scenarios promote r4 to level-1-2 (an L1 adjacency
+  with r5 then forms and r4's L1 LSP floods to r5) and demote it again (r4
+  purges that L1 LSP and r5 drops it) — exercising is-type-driven self-LSP
+  origination and purge end-to-end across a real adjacency.
 
   Note on scope: zebra-rs builds each level's LSP only from prefixes whose
   circuit participates at that level — there is no automatic L1->L2 leaking
@@ -48,17 +59,21 @@ Feature: IS-IS Level-1 / Level-2 interaction across an L1 area and an L2 backbon
     And I create namespace "r2"
     And I create namespace "r3"
     And I create namespace "r4"
+    And I create namespace "r5"
     And I connect namespace "r1" interface "i2" to namespace "r2" interface "i1"
     And I connect namespace "r2" interface "i3" to namespace "r3" interface "i2"
     And I connect namespace "r3" interface "i4" to namespace "r4" interface "i3"
+    And I connect namespace "r4" interface "i5" to namespace "r5" interface "i4"
     And I start zebra-rs in namespace "r1"
     And I start zebra-rs in namespace "r2"
     And I start zebra-rs in namespace "r3"
     And I start zebra-rs in namespace "r4"
+    And I start zebra-rs in namespace "r5"
     And I apply config "r1.yaml" to namespace "r1"
     And I apply config "r2.yaml" to namespace "r2"
     And I apply config "r3.yaml" to namespace "r3"
     And I apply config "r4.yaml" to namespace "r4"
+    And I apply config "r5.yaml" to namespace "r5"
     And I wait 25 seconds
     # Directly-connected reachability over the L1 access link and the L2
     # backbone link, dual-stack, proving both P2P circuits are up.
@@ -74,6 +89,11 @@ Feature: IS-IS Level-1 / Level-2 interaction across an L1 area and an L2 backbon
     And show command "show isis neighbor" in namespace "r3" should contain "r4"
     And show command "show isis neighbor" in namespace "r1" should contain "r2"
     And show command "show isis neighbor" in namespace "r4" should contain "r3"
+    # r5 is an L1-only router in the *backbone* area 49.0000, wired to r4.
+    # At setup r4 is still level-2-only, so the r4-r5 link runs L2 only while
+    # r5 speaks L1 only — the levels don't overlap, so no adjacency forms and
+    # r5 stays isolated until r4 is promoted to level-1-2 in a later scenario.
+    And show command "show isis neighbor" in namespace "r4" should not contain "r5"
 
   Scenario: The border keeps two independent Link State Databases
     Given the test topology exists
@@ -151,14 +171,81 @@ Feature: IS-IS Level-1 / Level-2 interaction across an L1 area and an L2 backbon
     And ping from "r4" to "10.0.0.1" should fail
     And ping from "r4" to "2001:db8::1" should fail
 
+  Scenario: Promoting the L2-only border r4 to L1/L2 originates a self-LSP at both levels
+    Given the test topology exists
+    # r4 starts life as `is-type level-2-only`, so it owns a single
+    # self-originated LSP — in its L2 LSDB only. Deleting the
+    # `is-type level-2-only` line falls back to the default level-1-2,
+    # which must make r4 originate a self-LSP into BOTH its L1 and its L2
+    # database. We re-apply r4's config with that one line removed; the
+    # diff-based apply deletes the is-type setting from the running config.
+    When I apply config "r4-l1l2.yaml" to namespace "r4"
+    And I wait 10 seconds
+    # JSON proof (the `originated` flag) that a self-LSP now exists at each
+    # level — the L1 self-LSP is the one the old level-2-only r4 never had.
+    Then isis database in namespace "r4" has a self-originated LSP at "L1"
+    And isis database in namespace "r4" has a self-originated LSP at "L2"
+
+  Scenario: r4's new L1 LSP floods to the L1-only r5 in the backbone area
+    Given the test topology exists
+    # r4 was promoted to level-1-2 in the previous scenario. Its i5 circuit
+    # toward r5 is circuit-type level-1-2, so now that r4 is level-1-2 the
+    # circuit runs both levels; r5 is L1-only, so they form an L1 adjacency
+    # (shared area 49.0000). This is the L1L2-circuit / single-level-neighbor
+    # case that needs the per-circuit P2P 3-way handshake to avoid flapping.
+    # r4's L1 self-LSP
+    # therefore floods to r5, landing in r5's (only) L1 database as a learned
+    # (non-self) LSP. The wait covers the dynamically-formed L1 adjacency
+    # (default 10s Hello interval → up to ~3 intervals for the P2P 3-way)
+    # plus the flood. We match r4 by its system-id 0000.0000.0004 rather than
+    # its hostname: the lsp_id is present the moment the LSP is installed,
+    # whereas the dynamic hostname only resolves after TLV 137 is processed.
+    When I wait 25 seconds
+    Then isis database in namespace "r5" at "L1" has LSP from "0000.0000.0004"
+
+  Scenario: Demoting r4 back to level-2-only purges its L1 LSP from r5
+    Given the test topology exists
+    # Re-apply the original r4 config: the only difference from the promoted
+    # config is the `is-type level-2-only` line, so the diff-based apply flips
+    # *only* is-type back (the i5 circuit-type stays level-1-2). r4 must purge
+    # its self-originated L1 LSP; the purge floods over the still-live L1
+    # adjacency to r5 before that adjacency tears down.
+    When I apply config "r4.yaml" to namespace "r4"
+    # A received purge lingers at zero RemainingLifetime for ZeroAgeLifetime
+    # (60s) before eviction, so wait past that window to prove r5 truly
+    # deleted r4's L1 LSP rather than merely holding a zero-age copy.
+    And I wait 70 seconds
+    Then isis database in namespace "r5" at "L1" does not have LSP from "0000.0000.0004"
+
+  Scenario: A Level-1 adjacency is refused across the r3-r4 area boundary
+    Given the test topology exists
+    # Widen the r3-r4 backbone to level-1-2 on both ends and bring r4 back up
+    # as a level-1-2 router, so both routers now attempt BOTH levels over the
+    # link. r3 lives in area 49.0001 and r4 in area 49.0000, so per ISO 10589
+    # §8.4.3 a Level-1 adjacency requires a common area address and must NOT
+    # form — while the Level-2 backbone adjacency, which is area-independent,
+    # still comes up. (zebra-rs currently lacks the L1 area gate, so the L1
+    # adjacency wrongly establishes and this scenario fails until it's added.)
+    When I apply config "r3-backbone-l1l2.yaml" to namespace "r3"
+    And I apply config "r4-backbone-l1l2.yaml" to namespace "r4"
+    And I wait 25 seconds
+    # The Level-2 backbone adjacency is unaffected by the area mismatch.
+    Then isis neighbor in namespace "r3" at level 2 on interface "i4" should be up
+    And isis neighbor in namespace "r4" at level 2 on interface "i3" should be up
+    # But the Level-1 adjacency must be refused on both ends (different areas).
+    And isis neighbor in namespace "r3" at level 1 on interface "i4" should not be up
+    And isis neighbor in namespace "r4" at level 1 on interface "i3" should not be up
+
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "r1"
     And I stop zebra-rs in namespace "r2"
     And I stop zebra-rs in namespace "r3"
     And I stop zebra-rs in namespace "r4"
+    And I stop zebra-rs in namespace "r5"
     And I delete namespace "r1"
     And I delete namespace "r2"
     And I delete namespace "r3"
     And I delete namespace "r4"
+    And I delete namespace "r5"
     Then the test environment should be clean

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -875,12 +875,76 @@ fn config_is_type(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
         isis.config.is_type = None;
     }
     let curr = isis.config.is_type();
-    if prev != curr {
-        for (_, link) in isis.links.iter_mut() {
-            let is_level = link::config_level_common(curr, link.config.circuit_type());
-            link.state.set_level(is_level);
+    if prev == curr {
+        return Some(());
+    }
+
+    // Re-derive each circuit's operational level from the new instance
+    // is-type and bring its per-level Hello timers in line. `set_level`
+    // only flips a field; the Hello timer is armed per level at
+    // `ifsm::start`, so a circuit that newly gains a level must arm that
+    // level's timer (otherwise its Hellos never start and the adjacency
+    // can't form — most visibly on a broadcast circuit, where each level
+    // has its own Hello PDU), and one that loses a level must drop it.
+    //
+    // We deliberately leave the LSDB `adj` entry of a lost level intact:
+    // the self-LSP purge below has to flood over that adjacency before it
+    // ages out, and the receive-side `has_level` gate (see `packet.rs`)
+    // retires the now-mismatched adjacency on its own hold timer.
+    let ifindexes: Vec<u32> = isis.links.iter().map(|(ifindex, _)| *ifindex).collect();
+    for ifindex in ifindexes {
+        let Some(mut top) = isis.link_top(ifindex) else {
+            continue;
+        };
+        let old_level = top.state.level();
+        let new_level = link::config_level_common(curr, top.config.circuit_type());
+        top.state.set_level(new_level);
+        for level in [Level::L1, Level::L2] {
+            match (has_level(old_level, level), has_level(new_level, level)) {
+                (false, true) => super::ifsm::hello_originate(&mut top, level),
+                (true, false) => {
+                    *top.timer.hello.get_mut(&level) = None;
+                    *top.state.hello.get_mut(&level) = None;
+                }
+                _ => {}
+            }
         }
     }
+
+    // The set of levels this instance participates in just changed, so
+    // the self-originated LSP set has to follow:
+    //
+    //  * A level we now participate in but didn't before (e.g. promoting
+    //    level-2-only -> level-1-2 gains L1) must originate a self-LSP.
+    //    No other trigger fires on its own — adjacencies don't form until
+    //    the circuit starts emitting that level's Hellos — so without this
+    //    the new level's LSDB would hold no self-LSP at all.
+    //
+    //  * A level we no longer participate in (e.g. demoting level-1-2 ->
+    //    level-2-only drops L1) must purge our self-originated LSP(s)
+    //    (router fragments and any pseudonode LSPs we own) so peers in
+    //    that level flush them promptly rather than holding stale
+    //    reachability until MaxAge expires.
+    let self_sys = isis.config.net.sys_id();
+    for level in [Level::L1, Level::L2] {
+        let was = has_level(prev, level);
+        let now = has_level(curr, level);
+        if now && !was {
+            let _ = isis.tx.send(Message::LspOriginate(level, None));
+        } else if was && !now {
+            let purge_ids: Vec<IsisLspId> = isis
+                .lsdb
+                .get(&level)
+                .iter()
+                .filter(|(id, lsa)| lsa.originated && id.sys_id() == self_sys)
+                .map(|(id, _)| *id)
+                .collect();
+            for lsp_id in purge_ids {
+                let _ = isis.tx.send(Message::LspPurge(level, lsp_id));
+            }
+        }
+    }
+
     Some(())
 }
 

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -239,8 +239,27 @@ pub fn hello_p2p_generate(link: &LinkTop, level: Level) -> IsisP2pHello {
         }
     }
 
-    // Three way handshake.
-    let tlv = if let Some((_, nbr)) = link.state.nbrs.get(&level).first_key_value() {
+    // Three-way handshake (RFC 5303). On a point-to-point circuit the
+    // adjacency is per-circuit, not per-level: one neighbor is reachable
+    // over the link and the P2P IIH carries a single P2P-3way TLV
+    // regardless of which level(s) the circuit runs. So look the neighbor
+    // up across both levels rather than only the firing timer's `level`.
+    //
+    // Why it matters: on an L1L2 circuit a per-level lookup makes the L2
+    // Hello (when the peer is L1-only, so there is no L2 neighbor) emit
+    // neighbor_id=None. The peer reads that as "you no longer list me" —
+    // `nbr_hello_interpret` leaves has_my_sys_id false and the Up->Init
+    // guard in `hello_p2p_recv` tears the adjacency back down — so it flaps
+    // against the L1 Hello (which does list the peer) and LSP sync never
+    // completes. Reporting the same neighbor on every level's IIH keeps the
+    // 3-way state consistent.
+    let nbr = link
+        .state
+        .nbrs
+        .get(&Level::L1)
+        .first_key_value()
+        .or_else(|| link.state.nbrs.get(&Level::L2).first_key_value());
+    let tlv = if let Some((_, nbr)) = nbr {
         IsisTlvP2p3Way {
             state: nbr.state.into(),
             circuit_id: link.ifindex,

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
-use std::collections::btree_map::{Iter, IterMut};
+use std::collections::btree_map::Iter;
 use std::fmt::Write;
 use std::sync::Arc;
 
@@ -94,10 +94,6 @@ impl IsisLinks {
 
     pub fn iter(&self) -> Iter<'_, u32, IsisLink> {
         self.map.iter()
-    }
-
-    pub fn iter_mut(&mut self) -> IterMut<'_, u32, IsisLink> {
-        self.map.iter_mut()
     }
 
     pub fn values(&self) -> std::collections::btree_map::Values<'_, u32, IsisLink> {

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -21,6 +21,7 @@ use super::inst::MsgSender;
 use super::link::LinkTop;
 use super::{
     Level, LspFlood,
+    ifsm::has_level,
     inst::IsisTop,
     link::Afi,
     lsp::{lsp_emit, lsp_flood},
@@ -676,6 +677,19 @@ fn lsp_clone_with_seqno_inc(lsp: &IsisLsp) -> IsisLsp {
 }
 
 pub fn refresh_lsp(top: &mut IsisTop, level: Level, key: IsisLspId) {
+    // A router that no longer participates in this level must not
+    // re-originate self-LSPs here. This matters right after an is-type
+    // demotion: `process_lsp_purge` floods a purge for the abandoned
+    // level and stores it with a short (~1s) refresh timer, and
+    // `insert_self_originate` re-arms that timer on every emission. Left
+    // unguarded, the first refresh would clone the purge into a fresh
+    // live LSP at a bumped sequence — un-purging it and looping every
+    // second (the seq number climbs without bound) — so peers keep our
+    // stale LSP instead of dropping it. The purge's hold timer
+    // (ZeroAgeLifetime) still evicts the local entry on schedule.
+    if !has_level(top.config.is_type(), level) {
+        return;
+    }
     if let Some(lsa) = top.lsdb.get(&level).get(&key) {
         let mut lsp = lsp_clone_with_seqno_inc(&lsa.lsp);
         let auth_cfg = crate::isis::lsp::level_auth_cfg(top.config, level).clone();

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -245,6 +245,17 @@ pub fn nbr_hello_interpret(
     (has_mac, has_my_sys_id, helper_edge)
 }
 
+/// ISO 10589 §8.4.3 / RFC 1195 §3.3: a Level-1 adjacency may form only with
+/// a neighbour that shares at least one Area Address. `our_area` is our
+/// manual area (NET-derived, AFI-prefixed); we scan the IIH's Area Address
+/// TLVs (type 1) for a match. Level-2 adjacencies are area-independent and
+/// never call this. Returns false when the neighbour advertises no area we
+/// hold — the caller then refuses the L1 adjacency.
+fn l1_area_compatible(our_area: &[u8], tlvs: &[IsisTlv]) -> bool {
+    tlvs.iter()
+        .any(|tlv| matches!(tlv, IsisTlv::AreaAddr(a) if a.area_addr.as_slice() == our_area))
+}
+
 #[isis_pdu_handler(Hello, Recv)]
 pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<MacAddr>) {
     use IfsmEvent::*;
@@ -261,6 +272,18 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
     // Check link type.
     if !link.is_lan() {
         isis_pdu_trace!(link, &level, "[Hello:Recv] Link type is not LAN");
+        return;
+    }
+
+    // ISO 10589 §8.4.3: a Level-1 adjacency requires a shared area address.
+    // Refuse the IIH (form no neighbour) when our area isn't among the
+    // sender's Area Address TLVs. Level-2 is area-independent.
+    if level == Level::L1 && !l1_area_compatible(&link.up_config.net.area_id(), &pdu.tlvs) {
+        isis_pdu_trace!(
+            link,
+            &level,
+            "[Hello:Recv] L1 area mismatch — adjacency refused"
+        );
         return;
     }
 
@@ -482,6 +505,9 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
     // P2P Hello contains circuit_type indicating what levels the sender supports
     let pdu_level = pdu.circuit_type;
 
+    // Our manual area, for the per-level Level-1 area gate below.
+    let our_area = link.up_config.net.area_id();
+
     // Process the Hello for each compatible level
     for level in [Level::L1, Level::L2] {
         // Logging.
@@ -505,6 +531,20 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
                 "[P2P Hello:Recv] Link type is not point-to-point"
             );
             return;
+        }
+
+        // ISO 10589 §8.4.3: a Level-1 adjacency requires a shared area
+        // address. Skip this level (form no L1 neighbour) when our area
+        // isn't among the sender's Area Address TLVs — even though both
+        // ends run Level-1, a Level-1 adjacency across an area boundary is
+        // invalid. Level-2 is area-independent.
+        if level == Level::L1 && !l1_area_compatible(&our_area, &pdu.tlvs) {
+            isis_pdu_trace!(
+                link,
+                &level,
+                "[P2P Hello:Recv] L1 area mismatch — adjacency refused"
+            );
+            continue;
         }
 
         // Create or update neighbor for this level


### PR DESCRIPTION
## Summary

Fixes IS-IS dynamic `is-type` reconfiguration and adds the missing Level-1
common-area gate, plus three latent adjacency/LSP bugs surfaced while building
the `isis_l1l2` coverage.

### Code (`zebra-rs/src/isis`)
- **is-type change** (`config.rs`): re-derive each circuit's operational level, then per level originate the self-LSP for a newly-active level / purge it for a dropped one / reconcile per-circuit Hello timers — without clearing the LSDB `adj` entry, so the purge still floods over the departing adjacency.
- **P2P three-way handshake** (`ifsm.rs`): build the P2p3Way TLV per-circuit, not per-level (RFC 5303). An L1L2 circuit facing a single-level neighbor no longer emits `neighbor_id=None` on the unused level and flaps.
- **`refresh_lsp`** (`lsdb.rs`): don't re-originate a self-LSP for a level the router has left, so a demotion purge isn't resurrected into a live LSP in a 1s sequence-number-climbing loop.
- **L1 area gate** (`packet.rs`): a Level-1 adjacency now requires a shared Area Address (ISO 10589 §8.4.3 / RFC 1195); different-area routers no longer wrongly form L1. Level-2 stays area-independent.

### Test (`bdd`)
Extends `isis_l1l2` with an L1-only `r5` in backbone area 49.0000 wired to r4, and scenarios that: promote r4 level-2-only→level-1-2 (self-LSP at both levels); flood r4's L1 LSP to same-area r5 then purge it on demotion (after ZeroAgeLifetime); and confirm cross-area r3↔r4 refuse a Level-1 adjacency while keeping their L2 backbone. New JSON steps match by lsp-id and by interface+level (no dynamic-hostname-timing dependence).

## Test plan
- `cargo build -p zebra-rs` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test -p zebra-rs isis::` — 137 passed
- `make isis_l1l2` (netns BDD) — all scenarios green (run locally)

Generated with [Claude Code](https://claude.com/claude-code)
