### PR TITLE
test(bdd): group Allure report tree by feature

### DIFF
--- a/bdd/allurerc.mjs
+++ b/bdd/allurerc.mjs
@@ -1,0 +1,23 @@
+// Allure 3 report configuration.
+//
+// Each cucumber feature is run in its own instance and tee'd to a separate
+// `allure-results/results-<pid>-<feature>.json` file (see tests/cucumber.rs).
+// Allure 3's cucumber-json reader, however, only tags each scenario with a
+// `feature` label (the `Feature:` name) and `tag` labels — it never emits the
+// `suite`/`parentSuite` labels that the report's tree groups on by default.
+// With no suite labels and no titlePath, the awesome plugin falls back to
+// `groupBy: []`, which dumps every scenario flat at the root, so all features
+// look merged into one undifferentiated list.
+//
+// Grouping the tree by the `feature` label restores one collapsible group per
+// feature file, which is what we want when running a whole suite (e.g. `make
+// isis`) and browsing the report feature-by-feature.
+export default {
+  plugins: {
+    awesome: {
+      options: {
+        groupBy: ["feature"],
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary

Running a whole BDD suite (e.g. `make isis`) and opening the Allure report
showed every scenario in one flat, undifferentiated list — features looked
"consolidated as a whole" even though each feature already writes its own
`allure-results/results-<pid>-<feature>.json`.

Root cause is at report-generation time, not in the result files. With
**Allure 3**, the cucumber-json reader tags each scenario with only a
`feature` label and `tag` labels — it never emits the `suite`/`parentSuite`
labels the report tree groups on by default. With no suite labels and no
`titlePath`, the `awesome` plugin's default `groupBy: []` dumps every
scenario flat at the root.

Fix: add `bdd/allurerc.mjs` setting `groupBy: ["feature"]`. Allure 3
auto-discovers this config from the `bdd/` dir where `make generate` /
`make open` run, so the report tree now renders one collapsible group per
feature file. No Makefile or harness change required.

## Test plan

Verified end-to-end against a real `allure-results` set (10 IS-IS feature
files, 66 scenarios) by running `allure generate` from `bdd/` and
inspecting the generated `tree.json`:

- **Before (default):** `root #groups: 0`, `#flat leaves: 66`
- **After (this config, auto-discovered):** `root #groups: 10` — one group
  per feature (e.g. "IS-IS IPv6 single-topology" → 4 scenarios), `0` flat
  leaves.

`allure-results/` and `allure-report/` remain gitignored; only the config
file is added.

Generated with [Claude Code](https://claude.com/claude-code)