### PR TITLE
test(bdd): run IS-IS suite with 10 concurrent scenarios

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -24,7 +24,7 @@ rib_static_ipv6:
 isis:
 	rm -rf allure-results
 	mkdir -p allure-results
-	cargo test --test cucumber -- --concurrency=1 --tags "@isis"
+	cargo test --test cucumber -- --concurrency=10 --tags "@isis"
 
 isis_ipv6:
 	mkdir -p allure-results


### PR DESCRIPTION
## Summary

Bump the `isis` make target from `--concurrency=1` to `--concurrency=10` so the full `@isis` tag set runs in parallel. The IS-IS BDD scenarios were made concurrency-safe in earlier work (PRs #1192/#1193), so serial execution is no longer required.

## Test plan

- CI runs the gated suites; the `@isis` BDD suite is excluded from the default CI workspace and is run manually via `make -C bdd isis`.
- Concurrency-safety invariants for IS-IS scenarios are already in place (unique veth temp names, no feature-tag prefix collisions, FIB-vs-RIB lag polling).

Generated with [Claude Code](https://claude.com/claude-code)