### PR TITLE
ci(nightly): re-enable daily schedule trigger

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -3,8 +3,8 @@ name: Nightly Rolling Build
 on:
   # push:
   #  branches: [main]
-  # schedule:
-  #  - cron: '0 18 * * *'    # 03:00 JST (UTC 18:00)
+  schedule:
+    - cron: '0 18 * * *'    # 03:00 JST (UTC 18:00)
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Re-enable the daily `schedule` cron for the Nightly Rolling Build, now that the resolute (ubuntu:26.04) container's LLVM 18 toolchain step is fixed (#1195) and a full `workflow_dispatch` run is green end-to-end.

- Uncomment `schedule: - cron: '0 18 * * *'` (UTC 18:00 = 03:00 JST daily).
- `workflow_dispatch` retained for manual runs.
- `push: branches: [main]` left commented (out of scope — that would build on every merge to main).

Note: scheduled triggers only fire from the default branch, so this takes effect once merged to `main`.

## Test plan

- [x] `yaml.safe_load` parses; active triggers are `schedule` + `workflow_dispatch`
- [x] Manual `workflow_dispatch` run 27002132587 succeeded (all 7 jobs incl. both resolute container jobs) — validates the workflow the cron will invoke

Generated with [Claude Code](https://claude.com/claude-code)