### PR TITLE
bgp: add global no-fib-install for route-reflector mode

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -22,6 +22,7 @@
   - [EVPN Type-5 (IP Prefix Routes)](ch-02-06-bgp-evpn-type5.md)
   - [Route Target Constraint (RTC)](ch-02-07-bgp-rtc.md)
   - [BFD](ch-02-08-bgp-bfd.md)
+  - [Route Reflector](ch-02-09-bgp-route-reflector.md)
 - [IS-IS](ch-07-00-isis.md)
   - [Timer Configuration](ch-07-01-isis-timers.md)
   - [Shared Risk Link Group (SRLG)](ch-07-02-isis-srlg.md)

--- a/book/src/ch-02-09-bgp-route-reflector.md
+++ b/book/src/ch-02-09-bgp-route-reflector.md
@@ -1,0 +1,101 @@
+# BGP Route Reflector
+
+A route reflector (RR, RFC 4456) relaxes the iBGP full-mesh
+requirement: instead of every iBGP speaker peering with every other,
+clients peer only with the reflector, which re-advertises
+("reflects") their routes on their behalf. zebra-rs implements the
+reflection rules with two per-neighbor knobs and adds one
+instance-level knob for the common case where the reflector is *not*
+in the forwarding path.
+
+## Reflection (per neighbor)
+
+A neighbor is marked as a client, and the cluster is identified, under
+the IETF `route-reflector` container:
+
+```
+router bgp {
+  neighbor 10.0.0.1 {
+    route-reflector {
+      client true;
+      cluster-id 1.1.1.1;
+    }
+  }
+}
+```
+
+| YANG leaf | Default | Meaning |
+|---|---|---|
+| `…/neighbor/route-reflector/client` | `false` | Treat this neighbor as a reflector client. |
+| `…/neighbor/route-reflector/cluster-id` | router-id | Cluster identifier used for loop detection. |
+
+The reflection rule zebra-rs enforces is the standard one: an
+iBGP-learned route is re-advertised to a peer only when that peer is a
+reflector client (eBGP peers always receive it). Plain
+iBGP→iBGP advertisement between non-clients is suppressed, which is
+what removes the need for a full mesh.
+
+## Keeping reflected routes out of the FIB
+
+A dedicated route reflector usually sits *outside* the data path: it
+reflects routes between clients but never forwards transit traffic for
+them. On such a box, programming every selected BGP best-path into the
+kernel forwarding table is pure overhead — it consumes memory and
+netlink/FIB churn for entries no packet will ever hit, and on a large
+RR holding the full table that cost is significant.
+
+`no-fib-install` makes the instance run as a pure control-plane
+speaker:
+
+```
+router bgp {
+  global {
+    no-fib-install true;
+  }
+}
+```
+
+| YANG leaf | Default | Meaning |
+|---|---|---|
+| `/router/bgp/global/no-fib-install` | `false` | Suppress installation of selected routes into the FIB. |
+
+When enabled:
+
+- **The control plane is unchanged.** The Loc-RIB is still built,
+  best-path selection still runs, next-hop tracking still validates
+  next-hops, and routes are still reflected and advertised to peers.
+- **No forwarding entry is programmed.** IPv4 and IPv6 unicast routes,
+  and the MPLS entries behind VPN, EVPN and labeled-unicast routes,
+  are all withheld from the kernel. The suppression is applied
+  centrally on the instance's RIB client, so every address family is
+  covered by the single knob — there is no per-AFI gap to forget.
+
+This is the difference between a reflector that merely *reflects* and
+one that also tries to *forward*: with `no-fib-install` the speaker
+contributes only to the control plane.
+
+### Scope and semantics
+
+- **Instance scope.** The knob applies to the default-VRF BGP
+  instance. Per-VRF suppression (for a VPN route reflector that also
+  carries per-VRF routes) is a separate, future knob; today a non-zero
+  VRF still installs normally.
+- **Set it at startup.** The intended use is to configure
+  `no-fib-install` before sessions come up, so no forwarding entry is
+  ever programmed. The flag takes effect immediately for every
+  *subsequent* route update.
+- **Runtime toggling is not retroactive.** Turning the flag *on* does
+  not walk back and withdraw routes that were already installed while
+  it was off; those entries are removed as normal route churn
+  (withdrawals, best-path changes) flows through — withdrawals are
+  never suppressed. If you need an immediate clean slate, clear the
+  affected routes or restart the instance.
+
+### Relationship to reflection
+
+`no-fib-install` is independent of the `route-reflector` client
+configuration. A speaker can reflect without it (a reflector that is
+also a forwarding router) or enable it without marking any clients (a
+control-plane-only collector). The common route-reflector deployment
+combines the two: clients marked under `route-reflector`, and
+`no-fib-install true` so the reflector stays out of the data path.

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -52,6 +52,20 @@ fn config_global_hostname(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option
     Some(())
 }
 
+/// `set router bgp global no-fib-install <true|false>` — route reflector
+/// mode. When enabled, the instance's RIB client drops every forwarding
+/// install so selected routes stay out of the kernel FIB while the
+/// Loc-RIB and peer advertisement keep running. Flips the shared
+/// `RibClient` gate (observed by every FSM / listen / timer clone of
+/// `ctx.rib`) and mirrors the value on `Bgp` for `show`.
+fn config_global_no_fib_install(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let flag = args.boolean()?;
+    let enabled = op.is_set() && flag;
+    bgp.no_fib_install = enabled;
+    bgp.ctx.rib.set_suppress_install(enabled);
+    Some(())
+}
+
 /// `set router bgp global srv6 locator <name>` — names the SRv6
 /// locator BGP carves per-VRF End.DT46 service SIDs from for L3VPN
 /// over SRv6 (RFC 9252). Drives the RIB locator watch; SID
@@ -1736,6 +1750,10 @@ impl Bgp {
         self.callback_add("/router/bgp/global/as", config_global_asn);
         self.callback_add("/router/bgp/global/identifier", config_global_identifier);
         self.callback_add("/router/bgp/global/hostname", config_global_hostname);
+        self.callback_add(
+            "/router/bgp/global/no-fib-install",
+            config_global_no_fib_install,
+        );
         self.callback_add(
             "/router/bgp/global/srv6/locator",
             config_global_srv6_locator,

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -320,6 +320,17 @@ pub struct Bgp {
     /// to the OS hostname; if that also fails, no FQDN capability is
     /// emitted. See `Bgp::hostname()` for the resolution order.
     pub hostname: Option<String>,
+    /// `router bgp global no-fib-install`. When true, this instance's
+    /// `ctx.rib` drops every forwarding install (IPv4/IPv6 unicast plus
+    /// VPN/EVPN/labeled-unicast MPLS ILMs) so selected routes never
+    /// reach the kernel FIB. The Loc-RIB is still built and routes are
+    /// still reflected/advertised — this is the pure route-reflector
+    /// mode for a speaker out of the forwarding path. The actual gate
+    /// lives on the shared `RibClient` flag
+    /// ([`crate::rib::client::RibClient::set_suppress_install`]); this
+    /// field mirrors it for `show` / re-application. Scope is the
+    /// default-VRF instance; per-VRF suppression is a follow-up.
+    pub no_fib_install: bool,
     pub peers: PeerMap,
     /// Instance-level BFD defaults (`router bgp { bfd {} }`), inherited by
     /// every neighbor and overridden per neighbor (see
@@ -621,6 +632,7 @@ impl Bgp {
             local_fdb: BTreeMap::new(),
             local_vxlans: BTreeMap::new(),
             hostname: None,
+            no_fib_install: false,
             peers: PeerMap::new(),
             bfd: PeerBfdConfig::default(),
             tx,

--- a/zebra-rs/src/rib/client.rs
+++ b/zebra-rs/src/rib/client.rs
@@ -15,6 +15,8 @@
 //! inspect, compare, serialise, or branch on it.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::mpsc::error::SendError;
@@ -85,20 +87,53 @@ impl std::fmt::Debug for RibInbound {
 pub struct RibClient {
     inner: UnboundedSender<RibInbound>,
     proto_id: ProtoId,
+    /// When set, [`Self::send`] silently drops forwarding-install
+    /// messages (see [`Message::is_fib_install`]) so the subscriber's
+    /// selected routes never reach the kernel FIB. Control-plane
+    /// traffic — next-hop tracking, label-block requests, SR locator
+    /// watches, subscribe — is unaffected, so best-path computation and
+    /// peer advertisement keep working.
+    ///
+    /// Backed by an `Arc` so every clone of a client shares one flag:
+    /// the config callback flips it on the instance's `ctx.rib` and the
+    /// FSM / listen / timer clones that actually emit installs observe
+    /// the change. Used by BGP's `router bgp global no-fib-install` to
+    /// run a pure route reflector that is out of the forwarding path.
+    suppress_install: Arc<AtomicBool>,
 }
 
 impl RibClient {
     pub fn new(inner: UnboundedSender<RibInbound>, proto_id: ProtoId) -> Self {
-        Self { inner, proto_id }
+        Self {
+            inner,
+            proto_id,
+            suppress_install: Arc::new(AtomicBool::new(false)),
+        }
     }
 
     /// Send a `Message` to RIB, automatically wrapped in a
     /// `RibInbound` carrying this client's `proto_id`.
+    ///
+    /// When [`Self::set_suppress_install`] has been called with `true`,
+    /// forwarding-install messages are dropped here and reported as a
+    /// successful send: the subscriber's pipeline is unchanged, only the
+    /// kernel programming is elided. Withdrawals (`*Del`) are *not*
+    /// dropped, so flipping the flag on lets any later route churn clean
+    /// stale entries out of the FIB.
     pub fn send(&self, msg: Message) -> Result<(), SendError<RibInbound>> {
+        if msg.is_fib_install() && self.suppress_install.load(Ordering::Relaxed) {
+            return Ok(());
+        }
         self.inner.send(RibInbound {
             from: self.proto_id,
             msg,
         })
+    }
+
+    /// Toggle FIB-install suppression for this client and every clone
+    /// that shares its `Arc`. Idempotent.
+    pub fn set_suppress_install(&self, suppress: bool) {
+        self.suppress_install.store(suppress, Ordering::Relaxed);
     }
 }
 
@@ -393,5 +428,63 @@ mod tests {
         let env_b = inbound_rx.recv().await.unwrap();
         assert_eq!(env_a.from, ProtoId::from_raw(3));
         assert_eq!(env_b.from, ProtoId::from_raw(3));
+    }
+
+    fn ipv4_add() -> Message {
+        Message::Ipv4Add {
+            prefix: "10.0.0.0/8".parse().unwrap(),
+            rib: crate::rib::entry::RibEntry::new(crate::rib::RibType::Bgp),
+        }
+    }
+
+    fn ipv4_del() -> Message {
+        Message::Ipv4Del {
+            prefix: "10.0.0.0/8".parse().unwrap(),
+            rib: crate::rib::entry::RibEntry::new(crate::rib::RibType::Bgp),
+        }
+    }
+
+    #[tokio::test]
+    async fn suppress_install_drops_only_forwarding_installs() {
+        // Route-reflector mode: forwarding installs are dropped, but
+        // withdrawals and control-plane messages still flow so best-path
+        // and peer advertisement keep working.
+        let (inbound_tx, mut inbound_rx) = unbounded_channel::<RibInbound>();
+        let client = RibClient::new(inbound_tx, ProtoId::from_raw(1));
+        client.set_suppress_install(true);
+
+        // Dropped, but reported as a successful send.
+        client.send(ipv4_add()).expect("send reports ok");
+        // Not dropped — these must reach RIB.
+        client.send(ipv4_del()).unwrap();
+        client.send(Message::Resolve).unwrap();
+
+        let first = inbound_rx.recv().await.expect("del delivered");
+        assert!(matches!(first.msg, Message::Ipv4Del { .. }));
+        let second = inbound_rx.recv().await.expect("resolve delivered");
+        assert!(matches!(second.msg, Message::Resolve));
+        // The Ipv4Add must not be sitting in the channel.
+        assert!(inbound_rx.try_recv().is_err(), "Ipv4Add should be dropped");
+    }
+
+    #[tokio::test]
+    async fn suppress_install_flag_is_shared_across_clones() {
+        // The gate lives behind an Arc: flipping it on one handle (e.g.
+        // the config callback's `ctx.rib`) must be observed by the clone
+        // that actually emits installs (the FSM / timer copy).
+        let (inbound_tx, mut inbound_rx) = unbounded_channel::<RibInbound>();
+        let config_handle = RibClient::new(inbound_tx, ProtoId::from_raw(2));
+        let install_handle = config_handle.clone();
+
+        config_handle.set_suppress_install(true);
+        install_handle.send(ipv4_add()).unwrap();
+        assert!(inbound_rx.try_recv().is_err(), "clone observes suppression");
+
+        config_handle.set_suppress_install(false);
+        install_handle.send(ipv4_add()).unwrap();
+        assert!(
+            inbound_rx.recv().await.is_some(),
+            "clearing the flag re-enables installs"
+        );
     }
 }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -296,6 +296,20 @@ pub enum Message {
     },
 }
 
+impl Message {
+    /// Whether this message programs a forwarding entry into the kernel
+    /// FIB/LFIB. Used by [`crate::rib::client::RibClient`] to drop only
+    /// forwarding installs when a subscriber asks to stay out of the
+    /// data path (BGP route reflector `no-fib-install`); withdrawals and
+    /// every control-plane message return `false` so they still flow.
+    pub fn is_fib_install(&self) -> bool {
+        matches!(
+            self,
+            Message::Ipv4Add { .. } | Message::Ipv6Add { .. } | Message::IlmAdd { .. }
+        )
+    }
+}
+
 #[derive(Default, Debug, Clone, PartialEq)]
 pub enum IlmType {
     #[default]

--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -321,6 +321,22 @@ module ietf-bgp {
              hostname is used; when neither is available the
              capability is not sent.";
         }
+        leaf no-fib-install {
+          type boolean;
+          default "false";
+          description
+            "When true, routes selected by this BGP speaker are not
+             installed into the forwarding table (FIB). The Loc-RIB is
+             still built and routes are still reflected and advertised
+             to peers, but no kernel forwarding entry is programmed for
+             IPv4/IPv6 unicast or for VPN, EVPN and labeled-unicast
+             MPLS routes. Next-hop tracking and best-path selection are
+             unaffected. Intended for a dedicated route reflector that
+             is out of the forwarding path. Best set at startup;
+             toggling at run time applies to subsequent route updates
+             rather than retroactively withdrawing already-installed
+             entries.";
+        }
         container srv6 {
           description
             "SRv6 parameters for BGP services over an SRv6 underlay


### PR DESCRIPTION
## Summary

Adds a `router bgp global no-fib-install` knob so a BGP speaker used as a pure **route reflector** keeps its selected routes out of the kernel FIB. There was no prior option for this — the only route-reflector config was the RFC 4456 `cluster-id`/`client` reflection control, and FIB install was unconditional.

When enabled, the control plane is fully intact (Loc-RIB build, best-path selection, next-hop tracking, reflection/advertisement to peers); only forwarding programming is suppressed.

```
router bgp {
  global {
    no-fib-install true;
  }
}
```

## Design

- **Gated centrally on the instance's `RibClient`**, not at the ~28 `fib_install_*` call sites. All BGP→FIB traffic funnels through one client, so a single `Arc<AtomicBool>` flag covers IPv4/IPv6 unicast **and** the VPN/EVPN/labeled-unicast MPLS ILMs — no per-AFI gap to forget.
- Only `*Add` installs are dropped (`Message::is_fib_install`); withdrawals (`*Del`) and every control-plane message (NHT, label blocks, SR watches) still flow.
- The flag is `Arc`-shared so the config callback flips it on `ctx.rib` and the FSM/timer/listen clones that emit installs observe it.

### Scope / semantics (documented in code + book)
- **Default-VRF instance only.** With no VRF configured, no `BgpVrf` task is spawned, so every selected route installs through the gated `ctx.rib` and is fully covered. Per-VRF suppression is a follow-up.
- **Runtime toggling is not retroactive** — intended to be set at startup; enabling it later doesn't withdraw already-installed routes (they clear via normal churn).

## Changes
- `rib/client.rs` — shared suppress flag + `set_suppress_install()` + 2 unit tests
- `rib/inst.rs` — `Message::is_fib_install()`
- `bgp/inst.rs` — `Bgp::no_fib_install` mirror field
- `bgp/config.rs` — `/router/bgp/global/no-fib-install` callback
- `yang/ietf-bgp@2023-07-05.yang` — `no-fib-install` boolean leaf in `global`
- `book/` — new "BGP Route Reflector" chapter + SUMMARY entry

## Test plan
- `cargo build -p zebra-rs` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test -p zebra-rs rib::client` — 13 passed (incl. 2 new: drops only forwarding installs; flag shared across clones)
- `cargo test -p zebra-rs yang_load` — 2 passed (new YANG leaf parses)

Generated with [Claude Code](https://claude.com/claude-code)