### PR TITLE
bgp: gate label-block-granted trace on tracing label

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1709,8 +1709,12 @@ impl Bgp {
                     Some(super::vrf::VrfLabelAllocator::bounded(start, start + size))
             }
         }
-        // Condition "bgp tracing label".
-        tracing::info!(start, size, "bgp: dynamic MPLS label block granted");
+        bgp_label_trace!(
+            self.tracing,
+            start,
+            size,
+            "bgp: dynamic MPLS label block granted"
+        );
 
         let unlabelled: Vec<String> = self
             .vrf_registry


### PR DESCRIPTION
## Summary
- Route the "dynamic MPLS label block granted" log in `label_block_arrived` through the existing `bgp_label_trace!` macro instead of an unconditional `tracing::info!`.
- The trace now honors the `router bgp tracing label` condition (true when either `tracing all` or `tracing label` is configured) and carries the `proto = "bgp", category = "label"` fields, matching the per-VRF label trace site at `inst.rs:1791`.

## Test plan
- `cargo check -p zebra-rs` — passes
- `cargo fmt` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean

Generated with [Claude Code](https://claude.com/claude-code)