### PR TITLE
ospf: rework tracing to match BGP/IS-IS (reachable, v2+v3)

### DIFF
--- a/book/src/ch-08-01-ospf-configuration.md
+++ b/book/src/ch-08-01-ospf-configuration.md
@@ -120,30 +120,55 @@ interfaces in a single step.
 
 ## Tracing and diagnostics
 
-Diagnostic tracing for OSPFv2 lives under `router ospf tracing`:
+Conditional tracing is a runtime debug switch: a category is silent
+until you name it in the config, at which point the matching log
+sites start emitting. It mirrors the BGP and IS-IS `tracing` model —
+each toggle is a *presence* flag (name it to enable, delete it to
+disable), and the gated log macros consult the live config on every
+packet, transition, and event, so categories turn on and off without
+a restart.
+
+The block is identical for both versions, attached to `router ospf`
+(OSPFv2) and `router ospfv3` (OSPFv3); the two emit `proto=ospf` and
+`proto=ospfv3` respectively so their logs stay filterable apart.
 
 ```
 router ospf {
   tracing {
-    packet hello { direction both; }
-    packet ls-update { direction send; }
-    fsm nfsm { detail true; }
-    database lsdb;
+    fsm { nfsm; }                    # neighbor FSM transitions
+    packet {
+      hello;                         # both directions, summary
+      ls-update { detail; }          # both directions, full decode
+      dd { direction receive; }      # received DBDs only
+    }
+    spf;                             # SPF calculation events
   }
+}
+
+router ospfv3 {
+  tracing { all; }                   # master switch: every category
 }
 ```
 
-| Category | Subtypes |
+| Category | Toggles |
 |---|---|
-| `packet` | `hello`, `dd`, `ls-request`, `ls-update`, `ls-ack` |
-| `event` | `lsp-originate`, `lsp-refresh`, `spf-calculation`, `adjacency`, `flooding`, `all` |
-| `fsm` | `ifsm`, `nfsm`, `all` (with optional `detail true`) |
-| `database` | `lsdb`, `spf-tree`, `rib`, `all` |
+| `all` | master switch — traces every category below |
+| `packet` | `hello`, `dd`, `ls-req`, `ls-update`, `ls-ack`, `all` |
+| `fsm` | `ifsm`, `nfsm`, `all` |
+| `spf` | SPF (shortest-path-first) calculation |
+| `lsdb` | LSA origination / installation / flooding |
 
-Each `packet` entry takes a `direction` of `send`, `receive`, or
-`both` (default `both`). FSM tracing with `detail true` logs every
-state-transition event, not just regressive transitions; useful
-during adjacency-formation debugging, noisy in steady-state.
+Each `packet` toggle is a presence container carrying two optional
+refinements: `direction` (`send` or `receive`; omit for both) and
+`detail` (log the fully decoded packet instead of a one-line
+summary). Each `fsm` toggle carries an optional `detail` that widens
+it from summary transitions to detail-level transition lines. `spf`
+and `lsdb` are bare presence leaves.
+
+Every gated line carries structured fields — `proto`, `category`
+(`packet` / `fsm` / `event`), and, for packets, `packet`,
+`direction`, and `detail` — so the output can be filtered downstream
+by protocol and category.
 
 ## Moving an interface between areas
 

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -6,7 +6,6 @@ use super::OspfLink;
 use super::area::{AreaTypeKind, ExternalMetricType, NssaTranslatorRole, RedistEntry};
 use super::ifsm::{IfsmEvent, ospf_hello_timer};
 use super::link::{NbrStateThreshold, OspfAuthMode, OspfNetworkType};
-use super::tracing::{config_tracing_fsm, config_tracing_packet};
 use super::version::{OspfVersion, Ospfv2};
 
 use crate::bfd::session::EchoMode;
@@ -21,15 +20,9 @@ pub type Callback<V = Ospfv2> = fn(&mut Ospf<V>, Args, ConfigOp) -> Option<()>;
 
 impl Ospf {
     const OSPF: &str = "/router/ospf";
-    const TRACING: &str = "/router/ospf/tracing";
 
     pub fn ospf_add(&mut self, path: &str, cb: Callback) {
         self.callbacks.insert(format!("{}{}", Self::OSPF, path), cb);
-    }
-
-    pub fn tracing_add(&mut self, path: &str, cb: Callback) {
-        self.callbacks
-            .insert(format!("{}{}", Self::TRACING, path), cb);
     }
 
     pub fn callback_build(&mut self) {
@@ -215,8 +208,11 @@ impl Ospf {
             "/graceful-restart/drain-time-ms",
             config_ospf_gr_drain_time_ms,
         );
-        self.tracing_add("/fsm", config_tracing_fsm);
-        self.tracing_add("/packet", config_tracing_packet);
+        // `/router/ospf/tracing/...` is handled by the subtree dispatcher
+        // `super::tracing::config_tracing_dispatch` (called from
+        // `process_cm_msg` for paths this callback table does not claim),
+        // not by per-node callbacks — the message-type names are YANG
+        // presence containers, so they live in the path, not in args.
     }
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -31,6 +31,7 @@ use crate::{
         path_from_command, vrf_redirect_split,
     },
     context::Task,
+    ospf_event_trace, ospf_fsm_trace,
 };
 
 use super::area::{OspfArea, OspfAreaMap};
@@ -981,6 +982,8 @@ impl Ospf<Ospfv2> {
             ospf.gr_restart_load_checkpoint();
         }
 
+        ospf.tracing.proto = Ospfv2::PROTO;
+
         let tx = ospf.tx.clone();
         let sock = ospf.sock.clone();
         tokio::spawn(async move {
@@ -1075,6 +1078,12 @@ impl Ospf<Ospfv2> {
 
         if let Some(f) = self.callbacks.get(&path) {
             f(self, args, msg.op);
+        } else {
+            // `/router/ospf/tracing/...` is not in the callback table —
+            // its message-type names are YANG presence containers, so a
+            // single subtree dispatcher parses the path tail. Returns
+            // `None` (ignored) for any other unmatched path.
+            super::tracing::config_tracing_dispatch(self, &path, args, msg.op);
         }
     }
 
@@ -2080,6 +2089,16 @@ impl Ospf<Ospfv2> {
         // Unpack the widened key back into v2-typed components for the
         // v2-bound match arms / method calls below.
         let (ls_type, ls_id, adv_router) = v2_lsa_key_unpack(key);
+
+        ospf_event_trace!(
+            self.tracing,
+            Lsdb,
+            event = ?ev,
+            ls_type = ?ls_type,
+            ls_id = %ls_id,
+            adv_router = %adv_router,
+            "LSDB event"
+        );
 
         // Handle SelfOriginatedReceived before borrowing lsdb, since
         // re-origination needs full &mut self access.
@@ -3840,7 +3859,20 @@ impl Ospf<Ospfv2> {
                     // refresh; the originator gates on its own
                     // preconditions and flushes when they no longer
                     // hold. P2P sees no semantic change here.
-                    if new_state.is_some_and(|s| s != prev_state) {
+                    if let Some(new) = new_state
+                        && new != prev_state
+                    {
+                        let ifname = self.links.get(&index).map(|l| l.name.clone());
+                        ospf_fsm_trace!(
+                            self.tracing,
+                            Ifsm,
+                            false,
+                            ifindex = index,
+                            interface = ifname.as_deref().unwrap_or("?"),
+                            from = ?prev_state,
+                            to = ?new,
+                            "IFSM transition"
+                        );
                         self.ext_link_lsa_originate(index);
                     }
                 }
@@ -3873,6 +3905,18 @@ impl Ospf<Ospfv2> {
                         .map(|nbr| nbr.state);
 
                     if let (Some(old_state), Some(new_state)) = (old_state, new_state) {
+                        if old_state != new_state {
+                            ospf_fsm_trace!(
+                                self.tracing,
+                                Nfsm,
+                                false,
+                                neighbor = %src,
+                                event = ?ev,
+                                from = ?old_state,
+                                to = ?new_state,
+                                "NFSM transition"
+                            );
+                        }
                         self.process_neighbor_state_change(index, src, old_state, new_state);
                         // Re-evaluate the BFD session against the configured
                         // threshold (the reconcile reads the now-current
@@ -3884,10 +3928,11 @@ impl Ospf<Ospfv2> {
             Message::HelloTimer(index) => {
                 let now = chrono::Utc::now();
                 let chains = &self.key_chains;
+                let tracing = &self.tracing;
                 let Some(link) = self.links.get_mut(&index) else {
                     return;
                 };
-                ospf_hello_send(link, chains, now);
+                ospf_hello_send(link, chains, now, tracing);
             }
             Message::Lsdb(ev, area_id, key) => {
                 self.process_lsdb(ev, area_id, key);
@@ -4244,6 +4289,7 @@ impl Ospf<Ospfv3> {
             bfd_event_tx,
             bfd_event_rx,
         };
+        ospf.tracing.proto = Ospfv3::PROTO;
         ospf.callback_build();
         ospf.show_build();
         // v3 has no on-disk GR checkpoint load today, so nothing to
@@ -4322,6 +4368,9 @@ impl Ospf<Ospfv3> {
 
         if let Some(f) = self.callbacks.get(&path) {
             f(self, args, msg.op);
+        } else {
+            // `/router/ospfv3/tracing/...` subtree — see the v2 sibling.
+            super::tracing::config_tracing_dispatch(self, &path, args, msg.op);
         }
     }
 
@@ -5648,7 +5697,20 @@ impl Ospf<Ospfv3> {
                     // refresh the LSA; the originator's own gating
                     // makes the call a no-op when the preconditions
                     // don't hold (P2P sees no semantic change).
-                    if new_state.is_some_and(|s| s != prev_state) {
+                    if let Some(new) = new_state
+                        && new != prev_state
+                    {
+                        let ifname = self.links.get(&index).map(|l| l.name.clone());
+                        ospf_fsm_trace!(
+                            self.tracing,
+                            Ifsm,
+                            false,
+                            ifindex = index,
+                            interface = ifname.as_deref().unwrap_or("?"),
+                            from = ?prev_state,
+                            to = ?new,
+                            "IFSM transition"
+                        );
                         self.e_router_v3_lsa_originate(index);
                     }
                 }
@@ -5656,13 +5718,14 @@ impl Ospf<Ospfv3> {
             Message::HelloTimer(index) => {
                 let now = chrono::Utc::now();
                 let chains = &self.key_chains;
+                let tracing = &self.tracing;
                 let Some(link) = self.links.get_mut(&index) else {
                     return;
                 };
                 let Some(tx) = self.v3_send_tx.as_ref() else {
                     return;
                 };
-                super::packet_v3::ospfv3_hello_send(link, tx, chains, now);
+                super::packet_v3::ospfv3_hello_send(link, tx, chains, now, tracing);
             }
             Message::Nfsm(index, src, ev) => {
                 let old_state = self
@@ -5690,6 +5753,18 @@ impl Ospf<Ospfv3> {
                         .map(|nbr| nbr.state);
 
                     if let (Some(old_state), Some(new_state)) = (old_state, new_state) {
+                        if old_state != new_state {
+                            ospf_fsm_trace!(
+                                self.tracing,
+                                Nfsm,
+                                false,
+                                neighbor = %src,
+                                event = ?ev,
+                                from = ?old_state,
+                                to = ?new_state,
+                                "NFSM transition"
+                            );
+                        }
                         self.process_neighbor_state_change(index, src, old_state, new_state);
                         // Re-evaluate the BFD session against the configured
                         // threshold (the reconcile reads the now-current
@@ -5752,6 +5827,13 @@ impl Ospf<Ospfv3> {
                 self.process_retransmit(ifindex, router_id);
             }
             Message::Lsdb(ev, area_id, key) => {
+                ospf_event_trace!(
+                    self.tracing,
+                    Lsdb,
+                    event = ?ev,
+                    area = ?area_id,
+                    "LSDB event"
+                );
                 // RFC 2328 §13.4: a peer flooded our own LSA back to
                 // us at a higher sequence number (typical post-restart
                 // scenario). Re-originate at an even higher seq so
@@ -6892,10 +6974,11 @@ impl Ospf<Ospfv3> {
 
         match &packet.payload {
             Ospfv3Payload::Hello(_) => {
+                let tracing = &self.tracing;
                 let Some(link) = self.links.get_mut(&ifindex) else {
                     return;
                 };
-                super::packet_v3::ospfv3_hello_recv(&our_router_id, link, &packet, &src);
+                super::packet_v3::ospfv3_hello_recv(&our_router_id, link, &packet, &src, tracing);
             }
             Ospfv3Payload::DbDesc(_) => {
                 // v3 keys neighbors by router-id, which lives on the
@@ -8936,6 +9019,13 @@ fn apply_v3_spf_result(top: &mut Ospf<Ospfv3>, output: SpfOutput) {
     } = output;
     top.spf_duration = Some(duration);
     top.spf_last = Some(last);
+    ospf_event_trace!(
+        top.tracing,
+        Spf,
+        area = %area_id,
+        duration_us = duration.as_micros() as u64,
+        "SPF calculation complete"
+    );
 
     // Per-algo IPv6 RIBs from the per-algo SPF results (top borrowed
     // immutably, so collect locally then swap the field). Single
@@ -9725,6 +9815,13 @@ fn apply_spf_result(top: &mut Ospf, output: SpfOutput) {
     } = output;
     top.spf_duration = Some(duration);
     top.spf_last = Some(last);
+    ospf_event_trace!(
+        top.tracing,
+        Spf,
+        area = %area_id,
+        duration_us = duration.as_micros() as u64,
+        "SPF calculation complete"
+    );
 
     let rib = build_rib_from_spf(top, area_id, source, &spf_result, &tilfa_result);
 

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -456,12 +456,14 @@ pub fn ospf_hello_recv(
     }
 }
 
+#[ospf_packet_handler(Hello, Send)]
 pub fn ospf_hello_send(
     oi: &mut OspfLink,
     chains: &std::collections::BTreeMap<String, crate::policy::KeyChain>,
     now: chrono::DateTime<chrono::Utc>,
+    tracing: &OspfTracing,
 ) {
-    // tracing::info!("[Hello:Send] on {} flag {}", oi.name, oi.flags.hello_sent());
+    ospf_pdu_trace!(tracing, "[Hello:Send] on {}", oi.name);
 
     let packet = ospf_hello_packet(oi, chains, now).unwrap();
     if let Err(e) = oi.ptx.send(Message::Send(packet, oi.index, None)) {
@@ -478,11 +480,18 @@ pub fn ospf_packet_db_desc_set(nbr: &mut Neighbor, dd: &mut OspfDbDesc) {
     }
 }
 
+#[ospf_packet_handler(DbDesc, Send)]
 pub fn ospf_db_desc_send(link: &mut OspfInterface, nbr: &mut Neighbor, oident: &Identity) {
     let area = link.area_id;
     let mut dd = OspfDbDesc::default();
 
-    tracing::info!("DB_DESC: send {:?}", nbr.dd.flags);
+    ospf_pdu_trace!(
+        link.tracing,
+        "[DBD:Send] to {} flags={:?} seq={}",
+        nbr.ident.prefix.addr(),
+        nbr.dd.flags,
+        nbr.dd.seqnum
+    );
 
     dd.if_mtu = link.mtu as u16;
 
@@ -517,8 +526,6 @@ pub fn ospf_db_desc_send(link: &mut OspfInterface, nbr: &mut Neighbor, oident: &
 
     let mut packet = Ospfv2Packet::new(&oident.router_id, &area, Ospfv2Payload::DbDesc(dd));
     apply_link_auth(&mut packet, &link.auth_send_ctx());
-    tracing::info!("DB_DESC: Send");
-    // tracing::info!("{}", packet);
     let _ = nbr.ptx.send(Message::Send(
         packet,
         nbr.ifindex,
@@ -532,6 +539,7 @@ pub fn ospf_packet_ls_req_set(nbr: &mut Neighbor, ls_req: &mut OspfLsRequest) {
     }
 }
 
+#[ospf_packet_handler(LsRequest, Send)]
 pub fn ospf_ls_req_send(link: &mut OspfInterface, nbr: &mut Neighbor, oident: &Identity) {
     let area = link.area_id;
     let mut ls_req = OspfLsRequest::default();
@@ -540,8 +548,12 @@ pub fn ospf_ls_req_send(link: &mut OspfInterface, nbr: &mut Neighbor, oident: &I
 
     let mut packet = Ospfv2Packet::new(&oident.router_id, &area, Ospfv2Payload::LsRequest(ls_req));
     apply_link_auth(&mut packet, &link.auth_send_ctx());
-    tracing::info!("[DB Desc:Send]");
-    tracing::info!("{}", packet);
+    ospf_pdu_trace!(
+        link.tracing,
+        "[LSReq:Send] to {} entries={}",
+        nbr.ident.prefix.addr(),
+        nbr.ls_req.len()
+    );
     nbr.ptx
         .send(Message::Send(
             packet,
@@ -622,6 +634,7 @@ fn nbr_sched_event(nbr: &Neighbor, ev: NfsmEvent) {
         .unwrap();
 }
 
+#[ospf_packet_handler(DbDesc, Recv)]
 pub fn ospf_db_desc_recv(
     oi: &mut OspfInterface,
     nbr: &mut Neighbor,
@@ -629,7 +642,7 @@ pub fn ospf_db_desc_recv(
     src: &Ipv4Addr,
 ) {
     use NfsmState::*;
-    tracing::info!("DB_DESC: Recv {}", src);
+    ospf_pdu_trace!(oi.tracing, "[DBD:Recv] from {}", src);
 
     // Get DD.
     let Ospfv2Payload::DbDesc(ref dd) = packet.payload else {
@@ -793,15 +806,21 @@ fn ospf_db_desc_resend(oi: &OspfInterface, nbr: &Neighbor) {
     ));
 }
 
+#[ospf_packet_handler(LsUpdate, Send)]
 pub fn ospf_ls_upd_send(oi: &OspfInterface, nbr: &Neighbor, lsas: Vec<OspfLsa>) {
     let area = oi.area_id;
+    ospf_pdu_trace!(
+        oi.tracing,
+        "[LSUpd:Send] to {} lsas={}",
+        nbr.ident.prefix.addr(),
+        lsas.len()
+    );
     let ls_upd = OspfLsUpdate {
         num_adv: lsas.len() as u32,
         lsas,
     };
     let mut packet = Ospfv2Packet::new(&oi.ident.router_id, &area, Ospfv2Payload::LsUpdate(ls_upd));
     apply_link_auth(&mut packet, &oi.auth_send_ctx());
-    tracing::info!("[LS Update:Send] to {}", nbr.ident.prefix.addr());
     nbr.ptx
         .send(Message::Send(
             packet,
@@ -811,12 +830,18 @@ pub fn ospf_ls_upd_send(oi: &OspfInterface, nbr: &Neighbor, lsas: Vec<OspfLsa>) 
         .unwrap();
 }
 
+#[ospf_packet_handler(LsAck, Send)]
 pub fn ospf_ls_ack_send(oi: &OspfInterface, nbr: &Neighbor, lsa_headers: Vec<OspfLsaHeader>) {
     let area = oi.area_id;
+    ospf_pdu_trace!(
+        oi.tracing,
+        "[LSAck:Send] to {} headers={}",
+        nbr.ident.prefix.addr(),
+        lsa_headers.len()
+    );
     let ls_ack = OspfLsAck { lsa_headers };
     let mut packet = Ospfv2Packet::new(&oi.ident.router_id, &area, Ospfv2Payload::LsAck(ls_ack));
     apply_link_auth(&mut packet, &oi.auth_send_ctx());
-    tracing::info!("[LS Ack:Send] to {}", nbr.ident.prefix.addr());
     nbr.ptx
         .send(Message::Send(
             packet,
@@ -828,6 +853,7 @@ pub fn ospf_ls_ack_send(oi: &OspfInterface, nbr: &Neighbor, lsa_headers: Vec<Osp
 
 // ospf_ls_req_recv -- RFC2328 Section 10.7
 // Following ref/ospfd/ospf_packet.c ospf_ls_req()
+#[ospf_packet_handler(LsRequest, Recv)]
 pub fn ospf_ls_req_recv(
     oi: &mut OspfInterface,
     nbr: &mut Neighbor,
@@ -843,8 +869,9 @@ pub fn ospf_ls_req_recv(
         return;
     };
 
-    tracing::info!(
-        "[LS Request:Recv] from {} entries={}",
+    ospf_pdu_trace!(
+        oi.tracing,
+        "[LSReq:Recv] from {} entries={}",
         src,
         ls_req.reqs.len()
     );
@@ -1298,6 +1325,7 @@ fn gr_maybe_enter_helper(oi: &mut OspfInterface, nbr: &mut Neighbor, lsa: &OspfL
     );
 }
 
+#[ospf_packet_handler(LsUpdate, Recv)]
 pub fn ospf_ls_upd_recv(
     oi: &mut OspfInterface,
     nbr: &mut Neighbor,
@@ -1312,14 +1340,20 @@ pub fn ospf_ls_upd_recv(
         return;
     };
 
-    tracing::info!("[LS Update:Recv] from {} lsas={}", src, ls_upd.lsas.len());
+    ospf_pdu_trace!(
+        oi.tracing,
+        "[LSUpd:Recv] from {} lsas={}",
+        src,
+        ls_upd.lsas.len()
+    );
 
     ospf_ls_upd_validate_proc(oi, nbr, ls_upd, src);
 }
 
 // LS Ack receive handler -- RFC 2328 Section 13.7.
+#[ospf_packet_handler(LsAck, Recv)]
 pub fn ospf_ls_ack_recv(
-    _oi: &mut OspfInterface,
+    oi: &mut OspfInterface,
     nbr: &mut Neighbor,
     packet: &Ospfv2Packet,
     src: &Ipv4Addr,
@@ -1332,8 +1366,9 @@ pub fn ospf_ls_ack_recv(
         return;
     };
 
-    tracing::info!(
-        "[LS Ack:Recv] from {} headers={}",
+    ospf_pdu_trace!(
+        oi.tracing,
+        "[LSAck:Recv] from {} headers={}",
         src,
         ls_ack.lsa_headers.len()
     );

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -7,6 +7,7 @@
 use std::net::Ipv6Addr;
 
 use ipnet::Ipv6Net;
+use ospf_macros::ospf_packet_handler;
 use ospf_packet::{
     OSPFV3_NSSA_LSA_TYPE, Ospfv3AuthTrailer, Ospfv3DbDesc, Ospfv3Hello, Ospfv3LsAck,
     Ospfv3LsRequest, Ospfv3LsRequestEntry, Ospfv3LsUpdate, Ospfv3Lsa, Ospfv3LsaHeader,
@@ -15,11 +16,13 @@ use ospf_packet::{
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::network_v6::Ospfv3Send;
+use super::tracing::OspfTracing;
 use super::version::{OspfVersion, Ospfv3};
 use super::{
     Identity, IfsmEvent, IfsmState, Message, Neighbor, NfsmEvent, NfsmState, OspfLink,
     inst::OspfInterface,
 };
+use crate::ospf_pdu_trace;
 
 /// RFC 7166 §3.5 Apad — a per-algorithm hex pattern used to fill
 /// the Authentication Data field while computing the HMAC. The
@@ -289,12 +292,15 @@ fn build_hello_packet(link: &OspfLink<Ospfv3>) -> Option<Ospfv3Packet> {
 /// Emit a Hello on `link` via the v3 send loop. Analogue of v2's
 /// `ospf_hello_send`. Returns silently if no link-local source is
 /// available yet (the link will retry on the next hello-timer fire).
+#[ospf_packet_handler(Hello, Send)]
 pub fn ospfv3_hello_send(
     link: &mut OspfLink<Ospfv3>,
     v3_send_tx: &UnboundedSender<Ospfv3Send>,
     chains: &std::collections::BTreeMap<String, crate::policy::KeyChain>,
     now: chrono::DateTime<chrono::Utc>,
+    tracing: &OspfTracing,
 ) {
+    ospf_pdu_trace!(tracing, "[Hello:Send] on {}", link.name);
     let Some(src) = link_local_src(link) else {
         tracing::debug!(
             "[v3 Hello:Send] {} has no link-local source yet, skipping",
@@ -358,15 +364,19 @@ fn hello_is_nbr_changed(nbr: &Neighbor<Ospfv3>, prev: &super::Identity<Ospfv3>) 
 /// `src` is the v6 link-local from `Ospfv3Recv`. We store it as a
 /// `/128` in the neighbor's prefix so the existing IFSM helpers
 /// that look up `nbr.ident.prefix` keep working.
+#[ospf_packet_handler(Hello, Recv)]
 pub fn ospfv3_hello_recv(
     our_router_id: &std::net::Ipv4Addr,
     oi: &mut OspfLink<Ospfv3>,
     packet: &Ospfv3Packet,
     src: &Ipv6Addr,
+    tracing: &OspfTracing,
 ) {
     if oi.is_passive() {
         return;
     }
+
+    ospf_pdu_trace!(tracing, "[Hello:Recv] on {} from {}", oi.name, src);
 
     let Ospfv3Payload::Hello(ref hello) = packet.payload else {
         return;
@@ -498,12 +508,20 @@ fn db_desc_pack(nbr: &mut Neighbor<Ospfv3>, dd: &mut Ospfv3DbDesc) {
 ///   `Ospfv3::send_db_desc` (in `version.rs`) routes here.
 /// - Destination is the neighbor's link-local v6 (a `/128` we
 ///   captured from the Hello recv). Source is our own link-local.
+#[ospf_packet_handler(DbDesc, Send)]
 pub fn ospfv3_db_desc_send(
     oi: &mut OspfInterface<Ospfv3>,
     nbr: &mut Neighbor<Ospfv3>,
     oident: &Identity<Ospfv3>,
 ) {
     let area = oi.area_id;
+    ospf_pdu_trace!(
+        oi.tracing,
+        "[DBD:Send] to {} flags={:?} seq={}",
+        nbr.ident.router_id,
+        nbr.dd.flags,
+        nbr.dd.seqnum
+    );
     let mut dd = Ospfv3DbDesc {
         if_mtu: oi.mtu as u16,
         flags: nbr.dd.flags,
@@ -728,6 +746,7 @@ fn ospfv3_db_desc_proc(
 ///   `Ipv4Addr`.
 /// - No netmask check (v3 Hello doesn't carry one; DBD MTU check
 ///   is the same).
+#[ospf_packet_handler(DbDesc, Recv)]
 pub fn ospfv3_db_desc_recv(
     oi: &mut OspfInterface<Ospfv3>,
     nbr: &mut Neighbor<Ospfv3>,
@@ -735,6 +754,8 @@ pub fn ospfv3_db_desc_recv(
     src: &Ipv6Addr,
 ) {
     use NfsmState::*;
+
+    ospf_pdu_trace!(oi.tracing, "[DBD:Recv] from {}", src);
 
     let Ospfv3Payload::DbDesc(ref dd) = packet.payload else {
         return;
@@ -861,12 +882,19 @@ fn ospfv3_packet_ls_req_set(nbr: &Neighbor<Ospfv3>, ls_req: &mut Ospfv3LsRequest
 /// LSA the peer holds but we don't (populated by
 /// `ospfv3_db_desc_proc` in #779). Sent unicast to the neighbor's
 /// link-local v6 via the dedicated v3 send channel.
+#[ospf_packet_handler(LsRequest, Send)]
 pub fn ospfv3_ls_req_send(
     oi: &mut OspfInterface<Ospfv3>,
     nbr: &mut Neighbor<Ospfv3>,
     oident: &Identity<Ospfv3>,
 ) {
     let area = oi.area_id;
+    ospf_pdu_trace!(
+        oi.tracing,
+        "[LSReq:Send] to {} entries={}",
+        nbr.ident.router_id,
+        nbr.ls_req.len()
+    );
     let mut ls_req = Ospfv3LsRequest::default();
     ospfv3_packet_ls_req_set(nbr, &mut ls_req);
 
@@ -903,12 +931,19 @@ pub fn ospfv3_ls_req_send(
 /// the given LSAs to the specified neighbor. Mirrors v2's
 /// `ospf_ls_upd_send`. Body is `num_lsa: u32` followed by the LSAs
 /// in serialized form.
+#[ospf_packet_handler(LsUpdate, Send)]
 pub fn ospfv3_ls_upd_send(
     oi: &OspfInterface<Ospfv3>,
     nbr: &Neighbor<Ospfv3>,
     lsas: Vec<Ospfv3Lsa>,
 ) {
     let area = oi.area_id;
+    ospf_pdu_trace!(
+        oi.tracing,
+        "[LSUpd:Send] to {} lsas={}",
+        nbr.ident.router_id,
+        lsas.len()
+    );
     let ls_upd = Ospfv3LsUpdate { lsas };
 
     let mut packet = Ospfv3Packet::new(oi.router_id, &area, 0, Ospfv3Payload::LsUpdate(ls_upd));
@@ -941,6 +976,7 @@ pub fn ospfv3_ls_upd_send(
 /// requested LSA we don't hold triggers `BadLSReq` (RFC 2328 §10.7),
 /// which the NFSM treats as a fatal exchange error and forces
 /// renegotiation from ExStart.
+#[ospf_packet_handler(LsRequest, Recv)]
 pub fn ospfv3_ls_req_recv(
     oi: &mut OspfInterface<Ospfv3>,
     nbr: &mut Neighbor<Ospfv3>,
@@ -957,7 +993,12 @@ pub fn ospfv3_ls_req_recv(
         return;
     };
 
-    tracing::info!("[v3 LSReq:Recv] from {} entries={}", src, ls_req.reqs.len());
+    ospf_pdu_trace!(
+        oi.tracing,
+        "[LSReq:Recv] from {} entries={}",
+        src,
+        ls_req.reqs.len()
+    );
 
     let mut lsas: Vec<Ospfv3Lsa> = Vec::new();
     for req in ls_req.reqs.iter() {
@@ -984,12 +1025,19 @@ pub fn ospfv3_ls_req_recv(
 /// Emit an OSPFv3 LS Acknowledgement packet (RFC 5340 §A.3.6)
 /// containing the supplied LSA headers. Mirrors v2's
 /// `ospf_ls_ack_send`. Unicast to the neighbor's link-local.
+#[ospf_packet_handler(LsAck, Send)]
 pub fn ospfv3_ls_ack_send(
     oi: &OspfInterface<Ospfv3>,
     nbr: &Neighbor<Ospfv3>,
     lsa_headers: Vec<Ospfv3LsaHeader>,
 ) {
     let area = oi.area_id;
+    ospf_pdu_trace!(
+        oi.tracing,
+        "[LSAck:Send] to {} headers={}",
+        nbr.ident.router_id,
+        lsa_headers.len()
+    );
     let ls_ack = Ospfv3LsAck { lsa_headers };
 
     let mut packet = Ospfv3Packet::new(oi.router_id, &area, 0, Ospfv3Payload::LsAck(ls_ack));
@@ -1021,8 +1069,9 @@ pub fn ospfv3_ls_ack_send(
 /// the matching LSA in the neighbor's retransmit list and remove
 /// it iff the ack's sequence number and checksum match what we
 /// hold. Mirrors v2's `ospf_ls_ack_recv`.
+#[ospf_packet_handler(LsAck, Recv)]
 pub fn ospfv3_ls_ack_recv(
-    _oi: &mut OspfInterface<Ospfv3>,
+    oi: &mut OspfInterface<Ospfv3>,
     nbr: &mut Neighbor<Ospfv3>,
     packet: &Ospfv3Packet,
     src: &Ipv6Addr,
@@ -1035,8 +1084,9 @@ pub fn ospfv3_ls_ack_recv(
         return;
     };
 
-    tracing::info!(
-        "[v3 LSAck:Recv] from {} headers={}",
+    ospf_pdu_trace!(
+        oi.tracing,
+        "[LSAck:Recv] from {} headers={}",
         src,
         ls_ack.lsa_headers.len()
     );
@@ -1463,6 +1513,7 @@ fn ospfv3_ls_upd_proc(
 /// `Installed` or `AckAndDiscard` contribute their header to a
 /// single direct LS Ack response. A `BadLSReq` result aborts the
 /// rest of the packet without acking.
+#[ospf_packet_handler(LsUpdate, Recv)]
 pub fn ospfv3_ls_upd_recv(
     oi: &mut OspfInterface<Ospfv3>,
     nbr: &mut Neighbor<Ospfv3>,
@@ -1477,7 +1528,12 @@ pub fn ospfv3_ls_upd_recv(
         return;
     };
 
-    tracing::info!("[v3 LSUpd:Recv] from {} lsas={}", src, ls_upd.lsas.len());
+    ospf_pdu_trace!(
+        oi.tracing,
+        "[LSUpd:Recv] from {} lsas={}",
+        src,
+        ls_upd.lsas.len()
+    );
 
     let mut ack_headers: Vec<Ospfv3LsaHeader> = Vec::new();
 

--- a/zebra-rs/src/ospf/tracing.rs
+++ b/zebra-rs/src/ospf/tracing.rs
@@ -1,203 +1,31 @@
-// OSPF-specific conditional tracing system
+// OSPF conditional tracing — consistent with BGP (zebra-bgp-tracing) and
+// IS-IS.
 //
-// This module provides a comprehensive conditional tracing system for OSPF protocol
-// that maps to YANG configuration options. It includes structures for fine-grained
-// control over packet, event, FSM, database, and segment routing tracing.
-
-// Main OSPF tracing configuration structure
-#[derive(Debug, Clone, Default)]
-pub struct OspfTracing {
-    // Enable all OSPF tracing
-    pub all: bool,
-    // Packet tracing configuration
-    pub packet: PacketTracing,
-    // FSM tracing configuration
-    pub fsm: FsmTracing,
-}
-
-// Packet tracing configuration
-#[derive(Debug, Clone, Default)]
-pub struct PacketTracing {
-    pub hello: PacketConfig,
-    pub dd: PacketConfig,
-    pub ls_req: PacketConfig,
-    pub ls_update: PacketConfig,
-    pub ls_ack: PacketConfig,
-    pub all: bool,
-}
-
-// Individual packet type configuration
-#[derive(Debug, Clone, Default)]
-pub struct PacketConfig {
-    pub enabled: bool,
-    pub direction: PacketDirection,
-}
-
-// Packet direction filter
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
-pub enum PacketDirection {
-    Send,
-    Recv,
-    #[default]
-    Both,
-}
-
-impl PacketDirection {
-    pub const fn as_str(&self) -> &'static str {
-        match self {
-            PacketDirection::Send => "Send",
-            PacketDirection::Recv => "Receive",
-            PacketDirection::Both => "Both",
-        }
-    }
-}
-
-// FSM tracing configuration
-#[derive(Debug, Clone, Default)]
-pub struct FsmTracing {
-    pub ifsm: FsmConfig,
-    pub nfsm: FsmConfig,
-    pub all: bool,
-}
-
-// Individual FSM type configuration
-#[derive(Debug, Clone, Default)]
-pub struct FsmConfig {
-    pub enabled: bool,
-    pub detail: bool,
-}
-
-use strum_macros::Display;
-
-use crate::config::{Args, ConfigOp};
+// One `OspfTracing` lives on each `Ospf<V>` instance, shared by both
+// versions by type (the `proto` field records `"ospf"` / `"ospfv3"` so
+// v2 and v3 logs stay filterable apart). The `router ospf tracing { ...
+// }` / `router ospfv3 tracing { ... }` config trees (defined in
+// `zebra-ospf-tracing.yang`) write it through `config_tracing_dispatch`;
+// the gated `ospf_*_trace!` macros below read it through the
+// `should_trace_*` accessors before emitting a `proto`-tagged
+// `tracing::info!` event.
+//
+// Categories: packet (hello/dd/ls-req/ls-update/ls-ack), fsm
+// (ifsm/nfsm), and the OSPF events spf and lsdb. Each toggle is a YANG
+// presence flag (`type empty`); per-message-type packet toggles carry
+// optional `detail` (full decode vs one-line summary) and `direction`
+// (send|receive; omit for both). This mirrors the BGP `PacketConfig`
+// shape so the two protocols' tracing reads the same.
 
 use super::Ospf;
+use super::version::OspfVersion;
+use crate::config::{Args, ConfigOp};
 
-// Packet type enumeration
-#[derive(Debug, Clone, Copy, PartialEq, Display)]
-pub enum PacketType {
-    #[strum(serialize = "hello")]
-    Hello,
-}
+// ============================================================
+// Plain proto-tagged convenience macros
+// ============================================================
 
-// FSM type enumeration
-#[derive(Debug, Clone, PartialEq)]
-pub enum FsmType {
-    Nfsm,
-}
-
-impl OspfTracing {
-    // Check if packet tracing should be enabled for given parameters
-    pub fn should_trace_packet(&self, packet_type: PacketType, direction: PacketDirection) -> bool {
-        if !self.all && !self.packet.all {
-            let config = match packet_type {
-                PacketType::Hello => &self.packet.hello,
-            };
-
-            if !config.enabled {
-                return false;
-            }
-
-            // Check direction filter
-            if config.direction != PacketDirection::Both && config.direction != direction {
-                return false;
-            }
-
-            true
-        } else {
-            true
-        }
-    }
-
-    // Check if FSM tracing should be enabled for given parameters
-    pub fn should_trace_fsm(&self, fsm_type: FsmType, detail: bool) -> bool {
-        if !self.all && !self.fsm.all {
-            let config = match fsm_type {
-                FsmType::Nfsm => &self.fsm.nfsm,
-            };
-
-            config.enabled && (!detail || config.detail)
-        } else {
-            true
-        }
-    }
-}
-
-fn parse_direction(args: &mut Args) -> PacketDirection {
-    match args.string().as_deref() {
-        Some("send") => PacketDirection::Send,
-        Some("recv") | Some("receive") => PacketDirection::Recv,
-        Some("both") | None => PacketDirection::Both,
-        Some(_) => PacketDirection::Both,
-    }
-}
-
-fn set_packet_config(config: &mut PacketConfig, op: ConfigOp, direction: PacketDirection) {
-    if op.is_set() {
-        config.enabled = true;
-        config.direction = direction;
-    } else {
-        config.enabled = false;
-        config.direction = PacketDirection::Both;
-    }
-}
-
-pub fn config_tracing_fsm(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
-    let typ = args.string()?;
-
-    match typ.as_str() {
-        "nfsm" => {
-            ospf.tracing.fsm.nfsm.enabled = op.is_set();
-        }
-        "ifsm" => {
-            ospf.tracing.fsm.ifsm.enabled = op.is_set();
-        }
-        "all" => {
-            ospf.tracing.fsm.nfsm.enabled = op.is_set();
-            ospf.tracing.fsm.ifsm.enabled = op.is_set();
-        }
-        _ => {}
-    }
-
-    Some(())
-}
-
-pub fn config_tracing_packet(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
-    let typ = args.string()?;
-    let direction = parse_direction(&mut args);
-
-    match typ.as_str() {
-        "all" => {
-            set_packet_config(&mut ospf.tracing.packet.hello, op, direction);
-            set_packet_config(&mut ospf.tracing.packet.dd, op, direction);
-            set_packet_config(&mut ospf.tracing.packet.ls_req, op, direction);
-            set_packet_config(&mut ospf.tracing.packet.ls_update, op, direction);
-            set_packet_config(&mut ospf.tracing.packet.ls_ack, op, direction);
-        }
-        "hello" => {
-            set_packet_config(&mut ospf.tracing.packet.hello, op, direction);
-        }
-        "dd" => {
-            set_packet_config(&mut ospf.tracing.packet.dd, op, direction);
-        }
-        "ls-req" => {
-            set_packet_config(&mut ospf.tracing.packet.ls_req, op, direction);
-        }
-        "ls-update" => {
-            set_packet_config(&mut ospf.tracing.packet.ls_update, op, direction);
-        }
-        "ls-ack" => {
-            set_packet_config(&mut ospf.tracing.packet.ls_ack, op, direction);
-        }
-        _ => {
-            println!("Unknown packet type: {}", typ);
-        }
-    }
-
-    Some(())
-}
-
-// Log an info-level message with proto="ospf" field
+/// Log an info-level message with `proto="ospf"`.
 #[macro_export]
 macro_rules! ospf_info {
     ($($arg:tt)*) => {
@@ -205,7 +33,7 @@ macro_rules! ospf_info {
     };
 }
 
-// Log a warning-level message with proto="ospf" field
+/// Log a warning-level message with `proto="ospf"`.
 #[macro_export]
 macro_rules! ospf_warn {
     ($($arg:tt)*) => {
@@ -213,7 +41,7 @@ macro_rules! ospf_warn {
     };
 }
 
-// Log an error-level message with proto="ospf" field
+/// Log an error-level message with `proto="ospf"`.
 #[macro_export]
 macro_rules! ospf_error {
     ($($arg:tt)*) => {
@@ -221,7 +49,7 @@ macro_rules! ospf_error {
     };
 }
 
-// Log a debug-level message with proto="ospf" field
+/// Log a debug-level message with `proto="ospf"`.
 #[macro_export]
 macro_rules! ospf_debug {
     ($($arg:tt)*) => {
@@ -229,7 +57,7 @@ macro_rules! ospf_debug {
     };
 }
 
-// Log a trace-level message with proto="ospf" field
+/// Log a trace-level message with `proto="ospf"`.
 #[macro_export]
 macro_rules! ospf_trace {
     ($($arg:tt)*) => {
@@ -237,56 +65,77 @@ macro_rules! ospf_trace {
     };
 }
 
-// Conditional packet tracing macro
+// ============================================================
+// Gated category macros
+// ============================================================
+//
+// Each takes an `expr` that resolves to an `OspfTracing` (or
+// `&OspfTracing`) — `self.tracing`, `oi.tracing`, or a threaded
+// `tracing` borrow — gates on the matching `should_trace_*`, and emits
+// `proto = <tracing>.proto` so v2 and v3 events are labelled apart.
+
+/// Conditional packet trace with explicit type + direction.
 #[macro_export]
 macro_rules! ospf_packet_trace {
-    ($tracing:expr, $packet_type:ident, $direction:ident, $level:expr, $($arg:tt)*) => {
-        if $tracing.should_trace_packet(
-            $crate::ospf::tracing::PacketType::$packet_type,
-            $crate::ospf::tracing::PacketDirection::$direction,
-            $level
-        ) {
+    ($tracing:expr, $packet_type:ident, $direction:ident, $($arg:tt)*) => {{
+        let __t = &$tracing;
+        let __ty = $crate::ospf::tracing::PacketType::$packet_type;
+        let __dir = $crate::ospf::tracing::PacketDirection::$direction;
+        if __t.should_trace_packet(__ty, __dir) {
             tracing::info!(
-                proto = "ospf",
+                proto = __t.proto,
                 category = "packet",
-                packet_type = stringify!($packet_type),
-                direction = stringify!($direction),
-                level = %$level,
+                packet = __ty.as_str(),
+                direction = __dir.as_str(),
+                detail = __t.packet_detail(__ty, __dir),
                 $($arg)*
-            )
+            );
         }
-    };
+    }};
 }
 
-// Conditional FSM tracing macro
+/// Conditional FSM-transition trace. `$fsm_type` is `Ifsm` or `Nfsm`;
+/// `$detail` flags a detail-level line (gated on the toggle's `detail`).
 #[macro_export]
 macro_rules! ospf_fsm_trace {
-    ($tracing:expr, $fsm_type:ident, $detail:expr, $($arg:tt)*) => {
-        if $tracing.should_trace_fsm(
-            $crate::ospf::tracing::FsmType::$fsm_type,
-            $detail
-        ) {
+    ($tracing:expr, $fsm_type:ident, $detail:expr, $($arg:tt)*) => {{
+        let __t = &$tracing;
+        let __detail: bool = $detail;
+        let __ty = $crate::ospf::tracing::FsmType::$fsm_type;
+        if __t.should_trace_fsm(__ty, __detail) {
             tracing::info!(
-                proto = "ospf",
+                proto = __t.proto,
                 category = "fsm",
-                fsm_type = stringify!($fsm_type),
-                detail = $detail,
+                fsm = __ty.as_str(),
+                detail = __detail,
                 $($arg)*
-            )
+            );
         }
-    };
+    }};
 }
 
-// Macro to define a packet receive handler with automatic tracing context.
-// This creates local constants for packet type and direction that can be used
-// with `ospf_pkt_trace!` macro.
-//
-// Usage:
-// ```ignore
-// ospf_pdu_handler!(Hello, Recv);
-// // Now use ospf_pkt_trace! instead of ospf_packet_trace!
-// ospf_pkt_trace!(top.tracing, &level, "[Hello] recv on {}", link.state.name);
-// ```
+/// Conditional OSPF-event trace. `$event_type` is `Spf` or `Lsdb`.
+#[macro_export]
+macro_rules! ospf_event_trace {
+    ($tracing:expr, $event_type:ident, $($arg:tt)*) => {{
+        let __t = &$tracing;
+        let __ty = $crate::ospf::tracing::EventType::$event_type;
+        if __t.should_trace_event(__ty) {
+            tracing::info!(
+                proto = __t.proto,
+                category = "event",
+                event = __ty.as_str(),
+                $($arg)*
+            );
+        }
+    }};
+}
+
+/// Inject `_OSPF_PKT_TYPE` / `_OSPF_PKT_DIR` constants for the enclosing
+/// packet handler so [`ospf_pdu_trace!`] needs no repeated type/direction
+/// arguments. The `#[ospf_packet_handler(Type, Dir)]` attribute macro
+/// (in `crates/ospf-macros`) injects the same constants; this
+/// declarative form is kept for hand-written scopes.
 #[macro_export]
 macro_rules! ospf_pdu_handler {
     ($packet_type:ident, $direction:ident) => {
@@ -297,36 +146,620 @@ macro_rules! ospf_pdu_handler {
     };
 }
 
-// Simplified packet tracing macro that uses the context defined by `ospf_pdu_handler!`.
-// Must be used after `ospf_pdu_handler!` in the same scope.
-#[macro_export]
-macro_rules! ospf_pkt_trace {
-    ($tracing:expr, $($arg:tt)*) => {
-        if $tracing.should_trace_packet(_OSPF_PKT_TYPE, _OSPF_PKT_DIR) {
-            tracing::info!(
-                proto = "ospf",
-                category = "packet",
-                packet_type = _OSPF_PKT_TYPE.as_str(),
-                direction = _OSPF_PKT_DIR.as_str(),
-                $($arg)*
-            )
-        }
-    };
-}
-
-// Simplified packet tracing macro that uses the context defined by `ospf_pdu_handler!`.
-// Must be used after `ospf_pdu_handler!` in the same scope.
+/// Conditional packet trace using the handler-injected
+/// `_OSPF_PKT_TYPE` / `_OSPF_PKT_DIR` constants. Use inside a function
+/// annotated with `#[ospf_packet_handler(Type, Dir)]` (or after
+/// `ospf_pdu_handler!`).
 #[macro_export]
 macro_rules! ospf_pdu_trace {
-    ($tracing:expr, $($arg:tt)*) => {
-        if $tracing.should_trace_packet(_OSPF_PKT_TYPE, _OSPF_PKT_DIR) {
+    ($tracing:expr, $($arg:tt)*) => {{
+        let __t = &$tracing;
+        if __t.should_trace_packet(_OSPF_PKT_TYPE, _OSPF_PKT_DIR) {
             tracing::info!(
-                proto = "ospf",
+                proto = __t.proto,
                 category = "packet",
-                packet_type = _OSPF_PKT_TYPE.to_string(),
+                packet = _OSPF_PKT_TYPE.as_str(),
                 direction = _OSPF_PKT_DIR.as_str(),
+                detail = __t.packet_detail(_OSPF_PKT_TYPE, _OSPF_PKT_DIR),
                 $($arg)*
-            )
+            );
         }
-    };
+    }};
+}
+
+// ============================================================
+// Tracing categories
+// ============================================================
+
+/// Direction filter for per-message-type tracing. The YANG `direction`
+/// leaf omitted means both, so `Both` is the default.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PacketDirection {
+    #[default]
+    Both,
+    Send,
+    Recv,
+}
+
+impl PacketDirection {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            PacketDirection::Both => "both",
+            PacketDirection::Send => "send",
+            PacketDirection::Recv => "receive",
+        }
+    }
+
+    /// Whether a message flowing in `actual` direction passes this
+    /// filter. `Both` matches either direction.
+    fn matches(self, actual: PacketDirection) -> bool {
+        self == PacketDirection::Both || self == actual
+    }
+}
+
+/// OSPF packet type. Variant names match the `#[ospf_packet_handler]`
+/// proc-macro's accepted set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PacketType {
+    Hello,
+    DbDesc,
+    LsRequest,
+    LsUpdate,
+    LsAck,
+}
+
+impl PacketType {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            PacketType::Hello => "hello",
+            PacketType::DbDesc => "dd",
+            PacketType::LsRequest => "ls-req",
+            PacketType::LsUpdate => "ls-update",
+            PacketType::LsAck => "ls-ack",
+        }
+    }
+}
+
+/// OSPF state machine, selected at an FSM trace site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FsmType {
+    Ifsm,
+    Nfsm,
+}
+
+impl FsmType {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            FsmType::Ifsm => "ifsm",
+            FsmType::Nfsm => "nfsm",
+        }
+    }
+}
+
+/// OSPF event category, selected at an event trace site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventType {
+    Spf,
+    Lsdb,
+}
+
+impl EventType {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            EventType::Spf => "spf",
+            EventType::Lsdb => "lsdb",
+        }
+    }
+}
+
+/// Per-message-type tracing toggle. `enabled` is the presence of the
+/// `packet <type>` container; `detail` and `direction` are its optional
+/// refinements.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PacketConfig {
+    pub enabled: bool,
+    pub detail: bool,
+    pub direction: PacketDirection,
+}
+
+/// Per-message-type tracing block. `all` is a catch-all applied on top
+/// of the individual per-type toggles.
+#[derive(Debug, Clone, Default)]
+pub struct PacketTracing {
+    pub all: PacketConfig,
+    pub hello: PacketConfig,
+    pub dd: PacketConfig,
+    pub ls_req: PacketConfig,
+    pub ls_update: PacketConfig,
+    pub ls_ack: PacketConfig,
+}
+
+impl PacketTracing {
+    /// Resolve a `&mut PacketConfig` by its YANG node name. `None` for an
+    /// unknown name (only reachable on a malformed path — the YANG
+    /// enumeration constrains the set).
+    fn get_mut(&mut self, name: &str) -> Option<&mut PacketConfig> {
+        Some(match name {
+            "all" => &mut self.all,
+            "hello" => &mut self.hello,
+            "dd" => &mut self.dd,
+            "ls-req" => &mut self.ls_req,
+            "ls-update" => &mut self.ls_update,
+            "ls-ack" => &mut self.ls_ack,
+            _ => return None,
+        })
+    }
+}
+
+/// Per-FSM tracing toggle.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FsmConfig {
+    pub enabled: bool,
+    pub detail: bool,
+}
+
+/// FSM tracing block. `all` is a catch-all over both state machines.
+#[derive(Debug, Clone, Default)]
+pub struct FsmTracing {
+    pub all: FsmConfig,
+    pub ifsm: FsmConfig,
+    pub nfsm: FsmConfig,
+}
+
+impl FsmTracing {
+    fn get_mut(&mut self, name: &str) -> Option<&mut FsmConfig> {
+        Some(match name {
+            "all" => &mut self.all,
+            "ifsm" => &mut self.ifsm,
+            "nfsm" => &mut self.nfsm,
+            _ => return None,
+        })
+    }
+}
+
+/// Simple presence-only event toggle (spf, lsdb).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EventConfig {
+    pub enabled: bool,
+}
+
+/// Conditional OSPF tracing configuration. One instance lives on each
+/// `Ospf<V>`; `proto` carries `V::PROTO` so the gated macros emit the
+/// version-correct `proto` field.
+#[derive(Debug, Clone)]
+pub struct OspfTracing {
+    pub proto: &'static str,
+    pub all: bool,
+    pub packet: PacketTracing,
+    pub fsm: FsmTracing,
+    pub spf: EventConfig,
+    pub lsdb: EventConfig,
+}
+
+impl Default for OspfTracing {
+    fn default() -> Self {
+        Self {
+            proto: "ospf",
+            all: false,
+            packet: PacketTracing::default(),
+            fsm: FsmTracing::default(),
+            spf: EventConfig::default(),
+            lsdb: EventConfig::default(),
+        }
+    }
+}
+
+impl OspfTracing {
+    fn packet_cfg(&self, ty: PacketType) -> &PacketConfig {
+        match ty {
+            PacketType::Hello => &self.packet.hello,
+            PacketType::DbDesc => &self.packet.dd,
+            PacketType::LsRequest => &self.packet.ls_req,
+            PacketType::LsUpdate => &self.packet.ls_update,
+            PacketType::LsAck => &self.packet.ls_ack,
+        }
+    }
+
+    /// Whether a `ty` message in `dir` should be traced. The `all` master
+    /// switch and the `packet all` catch-all both apply on top of the
+    /// per-type toggle.
+    pub fn should_trace_packet(&self, ty: PacketType, dir: PacketDirection) -> bool {
+        if self.all {
+            return true;
+        }
+        let cfg = self.packet_cfg(ty);
+        (self.packet.all.enabled && self.packet.all.direction.matches(dir))
+            || (cfg.enabled && cfg.direction.matches(dir))
+    }
+
+    /// Whether full-decode detail was requested for a `ty` message in
+    /// `dir`. Independent of the `all` master switch (which is
+    /// summary-level only).
+    pub fn packet_detail(&self, ty: PacketType, dir: PacketDirection) -> bool {
+        let cfg = self.packet_cfg(ty);
+        (self.packet.all.enabled
+            && self.packet.all.direction.matches(dir)
+            && self.packet.all.detail)
+            || (cfg.enabled && cfg.direction.matches(dir) && cfg.detail)
+    }
+
+    fn fsm_cfg(&self, ty: FsmType) -> &FsmConfig {
+        match ty {
+            FsmType::Ifsm => &self.fsm.ifsm,
+            FsmType::Nfsm => &self.fsm.nfsm,
+        }
+    }
+
+    /// Whether an FSM transition for `ty` should be traced. `detail`
+    /// gates detail-level lines on the toggle's `detail` flag; the `all`
+    /// master switch and `fsm all` catch-all both apply.
+    pub fn should_trace_fsm(&self, ty: FsmType, detail: bool) -> bool {
+        if self.all {
+            return true;
+        }
+        let cfg = self.fsm_cfg(ty);
+        let all = &self.fsm.all;
+        (all.enabled && (!detail || all.detail)) || (cfg.enabled && (!detail || cfg.detail))
+    }
+
+    /// Whether an event of `ty` (spf, lsdb) should be traced.
+    pub fn should_trace_event(&self, ty: EventType) -> bool {
+        if self.all {
+            return true;
+        }
+        match ty {
+            EventType::Spf => self.spf.enabled,
+            EventType::Lsdb => self.lsdb.enabled,
+        }
+    }
+}
+
+// ============================================================
+// Config dispatch
+// ============================================================
+
+fn parse_direction(args: &mut Args) -> PacketDirection {
+    match args.string().as_deref() {
+        Some("send") => PacketDirection::Send,
+        Some("receive") | Some("recv") => PacketDirection::Recv,
+        // Absent or any other token (incl. an explicit "both") means
+        // trace both directions.
+        _ => PacketDirection::Both,
+    }
+}
+
+/// `tracing packet <type>` — bare presence enables the type; delete
+/// clears the whole toggle (including any detail / direction).
+fn packet_set_enable(pc: &mut PacketConfig, op: ConfigOp) {
+    if op.is_set() {
+        pc.enabled = true;
+    } else {
+        *pc = PacketConfig::default();
+    }
+}
+
+/// `tracing packet <type> detail` — enabling detail implies the type is
+/// traced; delete leaves the type enabled at summary level.
+fn packet_set_detail(pc: &mut PacketConfig, op: ConfigOp) {
+    if op.is_set() {
+        pc.enabled = true;
+        pc.detail = true;
+    } else {
+        pc.detail = false;
+    }
+}
+
+/// `tracing packet <type> direction {send|receive}` — restrict the
+/// direction (and enable the type); delete reverts to both directions.
+fn packet_set_direction(pc: &mut PacketConfig, args: &mut Args, op: ConfigOp) {
+    if op.is_set() {
+        pc.enabled = true;
+        pc.direction = parse_direction(args);
+    } else {
+        pc.direction = PacketDirection::Both;
+    }
+}
+
+/// `tracing fsm <type>` — bare presence enables; delete clears.
+fn fsm_set_enable(fc: &mut FsmConfig, op: ConfigOp) {
+    if op.is_set() {
+        fc.enabled = true;
+    } else {
+        *fc = FsmConfig::default();
+    }
+}
+
+/// `tracing fsm <type> detail` — detail implies enabled; delete drops
+/// detail only.
+fn fsm_set_detail(fc: &mut FsmConfig, op: ConfigOp) {
+    if op.is_set() {
+        fc.enabled = true;
+        fc.detail = true;
+    } else {
+        fc.detail = false;
+    }
+}
+
+/// Apply one committed `…/tracing/<rest>` config line to an
+/// `OspfTracing`. `rest` is the path tail after the `tracing` node
+/// (e.g. `/all`, `/spf`, `/packet/hello`, `/packet/hello/detail`,
+/// `/fsm/nfsm`, `/fsm/nfsm/detail`); for the direction case `args` still
+/// holds the trailing send/receive value.
+fn apply_tracing(t: &mut OspfTracing, rest: &str, args: &mut Args, op: ConfigOp) -> Option<()> {
+    match rest {
+        "/all" => t.all = op.is_set(),
+        "/spf" => t.spf.enabled = op.is_set(),
+        "/lsdb" => t.lsdb.enabled = op.is_set(),
+        other => {
+            if let Some(pkt) = other.strip_prefix("/packet/") {
+                let (typ, sub) = match pkt.split_once('/') {
+                    Some((typ, sub)) => (typ, Some(sub)),
+                    None => (pkt, None),
+                };
+                let pc = t.packet.get_mut(typ)?;
+                match sub {
+                    None => packet_set_enable(pc, op),
+                    Some("detail") => packet_set_detail(pc, op),
+                    Some("direction") => packet_set_direction(pc, args, op),
+                    Some(_) => return None,
+                }
+            } else if let Some(fsm) = other.strip_prefix("/fsm/") {
+                let (typ, sub) = match fsm.split_once('/') {
+                    Some((typ, sub)) => (typ, Some(sub)),
+                    None => (fsm, None),
+                };
+                let fc = t.fsm.get_mut(typ)?;
+                match sub {
+                    None => fsm_set_enable(fc, op),
+                    Some("detail") => fsm_set_detail(fc, op),
+                    Some(_) => return None,
+                }
+            } else {
+                return None;
+            }
+        }
+    }
+    Some(())
+}
+
+/// Dispatch a committed `/router/{ospf,ospfv3}/tracing/…` Set/Delete
+/// path to this instance's `OspfTracing` and apply it.
+///
+/// Called from `Ospf::process_cm_msg` for paths the regular callback
+/// table does not claim. The per-message-type names are YANG presence
+/// containers (not list keys), so the type lives in the *path*, not in
+/// `args`; a single parser handles the whole subtree. Returns `None`
+/// (ignored) for non-tracing paths and malformed tails.
+pub fn config_tracing_dispatch<V: OspfVersion>(
+    ospf: &mut Ospf<V>,
+    path: &str,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    // Prefix is `/router/ospf/tracing` or `/router/ospfv3/tracing`,
+    // selected by the version's PROTO label.
+    let rest = path
+        .strip_prefix("/router/")?
+        .strip_prefix(V::PROTO)?
+        .strip_prefix("/tracing")?;
+    apply_tracing(&mut ospf.tracing, rest, &mut args, op)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Args, ConfigOp};
+
+    fn args(items: &[&str]) -> Args {
+        Args(items.iter().map(|s| s.to_string()).collect())
+    }
+
+    #[test]
+    fn top_level_flags_toggle_on_set_delete() {
+        let mut t = OspfTracing::default();
+
+        apply_tracing(&mut t, "/all", &mut args(&[]), ConfigOp::Set);
+        assert!(t.all);
+        apply_tracing(&mut t, "/all", &mut args(&[]), ConfigOp::Delete);
+        assert!(!t.all);
+
+        apply_tracing(&mut t, "/spf", &mut args(&[]), ConfigOp::Set);
+        apply_tracing(&mut t, "/lsdb", &mut args(&[]), ConfigOp::Set);
+        assert!(t.spf.enabled && t.lsdb.enabled);
+        apply_tracing(&mut t, "/spf", &mut args(&[]), ConfigOp::Delete);
+        assert!(!t.spf.enabled);
+    }
+
+    #[test]
+    fn packet_bare_enable_has_defaults() {
+        let mut t = OspfTracing::default();
+        apply_tracing(&mut t, "/packet/hello", &mut args(&[]), ConfigOp::Set);
+        assert!(t.packet.hello.enabled);
+        assert!(!t.packet.hello.detail);
+        assert_eq!(t.packet.hello.direction, PacketDirection::Both);
+    }
+
+    #[test]
+    fn packet_detail_and_direction_imply_enabled() {
+        let mut t = OspfTracing::default();
+        apply_tracing(
+            &mut t,
+            "/packet/ls-update/detail",
+            &mut args(&[]),
+            ConfigOp::Set,
+        );
+        assert!(t.packet.ls_update.enabled);
+        assert!(t.packet.ls_update.detail);
+
+        let mut t = OspfTracing::default();
+        apply_tracing(
+            &mut t,
+            "/packet/dd/direction",
+            &mut args(&["receive"]),
+            ConfigOp::Set,
+        );
+        assert!(t.packet.dd.enabled);
+        assert_eq!(t.packet.dd.direction, PacketDirection::Recv);
+
+        let mut t = OspfTracing::default();
+        apply_tracing(
+            &mut t,
+            "/packet/hello/direction",
+            &mut args(&["send"]),
+            ConfigOp::Set,
+        );
+        assert_eq!(t.packet.hello.direction, PacketDirection::Send);
+    }
+
+    #[test]
+    fn hyphenated_type_names_resolve() {
+        let mut t = OspfTracing::default();
+        apply_tracing(&mut t, "/packet/ls-req", &mut args(&[]), ConfigOp::Set);
+        apply_tracing(&mut t, "/packet/ls-ack", &mut args(&[]), ConfigOp::Set);
+        assert!(t.packet.ls_req.enabled && t.packet.ls_ack.enabled);
+    }
+
+    #[test]
+    fn fsm_toggles_and_detail() {
+        let mut t = OspfTracing::default();
+        apply_tracing(&mut t, "/fsm/nfsm", &mut args(&[]), ConfigOp::Set);
+        assert!(t.fsm.nfsm.enabled && !t.fsm.nfsm.detail);
+
+        apply_tracing(&mut t, "/fsm/ifsm/detail", &mut args(&[]), ConfigOp::Set);
+        assert!(t.fsm.ifsm.enabled && t.fsm.ifsm.detail);
+
+        // Deleting detail leaves the FSM enabled at summary level.
+        apply_tracing(&mut t, "/fsm/ifsm/detail", &mut args(&[]), ConfigOp::Delete);
+        assert!(t.fsm.ifsm.enabled && !t.fsm.ifsm.detail);
+    }
+
+    #[test]
+    fn delete_detail_keeps_type_delete_container_clears() {
+        let mut t = OspfTracing::default();
+        apply_tracing(
+            &mut t,
+            "/packet/hello/detail",
+            &mut args(&[]),
+            ConfigOp::Set,
+        );
+        apply_tracing(
+            &mut t,
+            "/packet/hello/direction",
+            &mut args(&["send"]),
+            ConfigOp::Set,
+        );
+        assert!(t.packet.hello.enabled && t.packet.hello.detail);
+        assert_eq!(t.packet.hello.direction, PacketDirection::Send);
+
+        apply_tracing(
+            &mut t,
+            "/packet/hello/detail",
+            &mut args(&[]),
+            ConfigOp::Delete,
+        );
+        assert!(t.packet.hello.enabled);
+        assert!(!t.packet.hello.detail);
+
+        apply_tracing(&mut t, "/packet/hello", &mut args(&[]), ConfigOp::Delete);
+        assert!(!t.packet.hello.enabled);
+        assert_eq!(t.packet.hello.direction, PacketDirection::Both);
+    }
+
+    #[test]
+    fn unknown_tail_or_type_is_ignored() {
+        let mut t = OspfTracing::default();
+        assert_eq!(
+            apply_tracing(&mut t, "/bogus", &mut args(&[]), ConfigOp::Set),
+            None
+        );
+        assert_eq!(
+            apply_tracing(&mut t, "/packet/bogus", &mut args(&[]), ConfigOp::Set),
+            None
+        );
+        assert_eq!(
+            apply_tracing(&mut t, "/packet/hello/bogus", &mut args(&[]), ConfigOp::Set),
+            None
+        );
+        assert_eq!(
+            apply_tracing(&mut t, "/fsm/bogus", &mut args(&[]), ConfigOp::Set),
+            None
+        );
+    }
+
+    // ---- read side: should_trace_* -------------------------------
+
+    #[test]
+    fn should_trace_packet_respects_direction() {
+        let mut t = OspfTracing::default();
+        apply_tracing(
+            &mut t,
+            "/packet/hello/direction",
+            &mut args(&["send"]),
+            ConfigOp::Set,
+        );
+        assert!(t.should_trace_packet(PacketType::Hello, PacketDirection::Send));
+        assert!(!t.should_trace_packet(PacketType::Hello, PacketDirection::Recv));
+        // Other types are unaffected.
+        assert!(!t.should_trace_packet(PacketType::DbDesc, PacketDirection::Send));
+    }
+
+    #[test]
+    fn should_trace_packet_both_matches_either_direction() {
+        let mut t = OspfTracing::default();
+        apply_tracing(&mut t, "/packet/ls-update", &mut args(&[]), ConfigOp::Set);
+        assert!(t.should_trace_packet(PacketType::LsUpdate, PacketDirection::Send));
+        assert!(t.should_trace_packet(PacketType::LsUpdate, PacketDirection::Recv));
+    }
+
+    #[test]
+    fn all_master_switch_traces_everything() {
+        let mut t = OspfTracing::default();
+        apply_tracing(&mut t, "/all", &mut args(&[]), ConfigOp::Set);
+        assert!(t.should_trace_packet(PacketType::LsAck, PacketDirection::Recv));
+        assert!(t.should_trace_fsm(FsmType::Nfsm, true));
+        assert!(t.should_trace_fsm(FsmType::Ifsm, false));
+        assert!(t.should_trace_event(EventType::Spf));
+        assert!(t.should_trace_event(EventType::Lsdb));
+        // `all` is summary-level only — it does not imply detail.
+        assert!(!t.packet_detail(PacketType::LsAck, PacketDirection::Recv));
+    }
+
+    #[test]
+    fn packet_all_catchall_applies_per_type() {
+        let mut t = OspfTracing::default();
+        apply_tracing(&mut t, "/packet/all", &mut args(&[]), ConfigOp::Set);
+        assert!(t.should_trace_packet(PacketType::Hello, PacketDirection::Send));
+        assert!(t.should_trace_packet(PacketType::LsAck, PacketDirection::Recv));
+    }
+
+    #[test]
+    fn fsm_detail_gating() {
+        let mut t = OspfTracing::default();
+        apply_tracing(&mut t, "/fsm/nfsm", &mut args(&[]), ConfigOp::Set);
+        // Summary line traces; detail line does not (no detail flag).
+        assert!(t.should_trace_fsm(FsmType::Nfsm, false));
+        assert!(!t.should_trace_fsm(FsmType::Nfsm, true));
+
+        apply_tracing(&mut t, "/fsm/nfsm/detail", &mut args(&[]), ConfigOp::Set);
+        assert!(t.should_trace_fsm(FsmType::Nfsm, true));
+    }
+
+    #[test]
+    fn detail_requires_matching_direction() {
+        let mut t = OspfTracing::default();
+        apply_tracing(
+            &mut t,
+            "/packet/ls-update/direction",
+            &mut args(&["receive"]),
+            ConfigOp::Set,
+        );
+        apply_tracing(
+            &mut t,
+            "/packet/ls-update/detail",
+            &mut args(&[]),
+            ConfigOp::Set,
+        );
+        assert!(t.packet_detail(PacketType::LsUpdate, PacketDirection::Recv));
+        assert!(!t.packet_detail(PacketType::LsUpdate, PacketDirection::Send));
+    }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -60,6 +60,10 @@ module config {
     prefix zob;
   }
 
+  import zebra-ospf-tracing {
+    prefix zotr;
+  }
+
   import zebra-bgp-color-policy {
     prefix zbcp;
   }

--- a/zebra-rs/yang/zebra-ospf-tracing.yang
+++ b/zebra-rs/yang/zebra-ospf-tracing.yang
@@ -1,0 +1,245 @@
+module zebra-ospf-tracing {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-ospf-tracing";
+  prefix "zotr";
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "Conditional OSPF tracing, attachable at the OSPFv2 (`router ospf`)
+     and OSPFv3 (`router ospfv3`) instances, which share one set of
+     options:
+
+       * `router ospf   tracing { ... }`
+       * `router ospfv3 tracing { ... }`
+
+     This mirrors the BGP / IS-IS `tracing` model (a typed config block
+     consulted by gated log macros, so categories can be turned on at
+     runtime without a rebuild) with the OSPF-specific category set: the
+     five OSPF packet types, the interface and neighbor state machines,
+     and the SPF / LSDB events.
+
+     Example:
+
+       router ospf {
+         tracing {
+           fsm { nfsm; }
+           packet {
+             hello;                     // both directions, summary
+             ls-update { detail; }      // both directions, decoded
+             dd { direction receive; }  // received DBDs only
+           }
+           spf;
+         }
+       }
+
+     Each leaf is a presence flag — name it to enable, delete it to
+     disable; absence means the category is silent. Enabling by presence
+     (rather than a `true` value) matches BGP / IS-IS `tracing`: the
+     config dispatch keys off set vs delete and never reads a value, so
+     `type empty` is the honest type here.";
+
+  revision 2026-06-05 {
+    description
+      "Initial revision — shared OSPFv2 / OSPFv3 tracing block (an `all`
+       master switch, fsm {ifsm,nfsm,all}, packet {hello,dd,ls-req,
+       ls-update,ls-ack,all}, spf, lsdb). Each packet message-type is a
+       presence container carrying optional `detail` and `direction`
+       (send|receive; omit for both); each fsm type carries optional
+       `detail`.";
+  }
+
+  grouping ospf-tracing-packet-options {
+    description
+      "Optional refinements shared by every per-message-type tracing
+       toggle. The enclosing container's presence is what enables
+       tracing for that message type; these children only narrow it.";
+
+    leaf detail {
+      ext:help "Decode the full packet, not just a one-line summary";
+      type empty;
+      description
+        "When present, log the fully decoded packet instead of a
+         one-line summary.";
+    }
+    leaf direction {
+      ext:help "Restrict tracing to a single direction";
+      type enumeration {
+        enum send {
+          description "Trace only transmitted packets.";
+        }
+        enum receive {
+          description "Trace only received packets.";
+        }
+      }
+      description
+        "Limit tracing to one direction. Omit to trace both send and
+         receive — there is no explicit `both` value; absence means
+         both.";
+    }
+  }
+
+  grouping ospf-tracing-fsm-options {
+    description
+      "Optional refinement shared by every per-FSM tracing toggle. The
+       enclosing container's presence enables tracing for that state
+       machine; `detail` widens it to detail-level transition lines.";
+
+    leaf detail {
+      ext:help "Log detail-level state-machine transitions";
+      type empty;
+      description
+        "When present, also log detail-level FSM transitions; otherwise
+         only summary transitions are traced.";
+    }
+  }
+
+  grouping ospf-tracing-extension {
+    description
+      "The `tracing` block shared by the OSPFv2 and OSPFv3 instances.
+       `uses` at both augment points so the two versions stay identical
+       by construction.";
+
+    container tracing {
+      ext:help "OSPF conditional tracing";
+      description
+        "Per-category OSPF log toggles, applied to this routing
+         instance (every interface and neighbor).";
+
+      leaf all {
+        ext:help "Enable every tracing category";
+        type empty;
+        description
+          "Master switch — when present, every category below is traced
+           regardless of its individual leaf.";
+      }
+
+      container fsm {
+        ext:help "Trace OSPF state-machine transitions";
+        description
+          "Per-state-machine tracing. Each state machine is a presence
+           container: naming it (e.g. `tracing fsm nfsm`) enables
+           summary transitions, and the `detail` child widens it. `all`
+           covers both state machines at once.";
+
+        container all {
+          ext:help "Trace both interface and neighbor FSMs";
+          presence "Trace every OSPF state machine";
+          uses ospf-tracing-fsm-options;
+        }
+        container ifsm {
+          ext:help "Trace the interface state machine";
+          presence "Trace interface FSM transitions";
+          uses ospf-tracing-fsm-options;
+        }
+        container nfsm {
+          ext:help "Trace the neighbor state machine";
+          presence "Trace neighbor FSM transitions";
+          uses ospf-tracing-fsm-options;
+        }
+      }
+
+      container packet {
+        ext:help "Trace OSPF protocol packets";
+        description
+          "Per-packet-type tracing. Each packet type is a presence
+           container: naming it (e.g. `tracing packet hello`) enables
+           tracing for that type in both directions at summary level,
+           and the `detail` / `direction` children refine it. `all`
+           covers every packet type at once.";
+
+        container all {
+          ext:help "Trace all OSPF packet types";
+          presence "Trace every OSPF packet type";
+          uses ospf-tracing-packet-options;
+        }
+        container hello {
+          ext:help "Trace Hello packets";
+          presence "Trace Hello packets";
+          uses ospf-tracing-packet-options;
+        }
+        container dd {
+          ext:help "Trace Database Description packets";
+          presence "Trace Database Description packets";
+          uses ospf-tracing-packet-options;
+        }
+        container ls-req {
+          ext:help "Trace Link State Request packets";
+          presence "Trace Link State Request packets";
+          uses ospf-tracing-packet-options;
+        }
+        container ls-update {
+          ext:help "Trace Link State Update packets";
+          presence "Trace Link State Update packets";
+          uses ospf-tracing-packet-options;
+        }
+        container ls-ack {
+          ext:help "Trace Link State Acknowledgment packets";
+          presence "Trace Link State Acknowledgment packets";
+          uses ospf-tracing-packet-options;
+        }
+      }
+
+      leaf spf {
+        ext:help "Trace SPF (shortest-path-first) calculation";
+        type empty;
+        description
+          "Log SPF runs (trigger, duration, route changes).";
+      }
+
+      leaf lsdb {
+        ext:help "Trace link-state database and LSA flooding";
+        type empty;
+        description
+          "Log LSA origination, installation, and flooding decisions.";
+      }
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router/config:ospf" {
+    description
+      "`router ospf tracing` in the candidate-set subtree.";
+    uses ospf-tracing-extension;
+  }
+
+  augment "/configure:delete/config:router/config:ospf" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router ospf tracing ...` is path-valid.";
+    uses ospf-tracing-extension;
+  }
+
+  augment "/configure:set/config:router/config:ospfv3" {
+    description
+      "`router ospfv3 tracing` in the candidate-set subtree.";
+    uses ospf-tracing-extension;
+  }
+
+  augment "/configure:delete/config:router/config:ospfv3" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router ospfv3 tracing ...` is path-valid.";
+    uses ospf-tracing-extension;
+  }
+}


### PR DESCRIPTION
## Summary

The OSPF tree carried a half-built, pre-standardization tracing impl that was **unreachable**: there was no YANG node for `/router/ospf/tracing`, so libyang rejected `set router ospf tracing …` and the registered callbacks never fired (the same bug BGP fixed in #1198/#1199). It also had a single working packet type, one trace site, zero OSPFv3 coverage, and hardcoded `proto="ospf"`.

This reworks it into a complete, reachable conditional-tracing feature for **both OSPFv2 and OSPFv3**, modeled on `zebra-bgp-tracing`.

### What changed
- **`ospf/tracing.rs`** — `OspfTracing` with a `proto` label (`ospf`/`ospfv3`), an `all` master switch, per-message-type packet toggles (`hello`/`dd`/`ls-req`/`ls-update`/`ls-ack`/`all`) carrying `detail` + `direction`, fsm toggles (`ifsm`/`nfsm`/`all`) with `detail`, and `spf`/`lsdb` events. Exhaustive `should_trace_*` gates; unified gated macros (`ospf_pdu_trace!`, `ospf_fsm_trace!`, `ospf_event_trace!`) emitting `proto=<version>, category=…`. Subtree `config_tracing_dispatch` replaces the orphaned list-style callbacks.
- **`zebra-ospf-tracing.yang`** (new) — a shared grouping `uses`-d at the set+delete augment points for **both** `config:ospf` and `config:ospfv3`; presence containers, `type empty` leaves. Imported from `config.yang`. Makes the command reachable + persisted in running-config.
- **`inst.rs`** — dispatcher wired into both v2 and v3 `process_cm_msg`; `proto = V::PROTO` per version; real trace sites for IFSM/NFSM transitions, SPF completion, and LSDB events on both versions.
- **`packet.rs` / `packet_v3.rs`** — all 5 packet types × send+recv gated via `#[ospf_packet_handler]` (10 sites each for v2 and v3). Always-on packet `info!` logs become opt-in gated traces (consistent with BGP/IS-IS).

### CLI (parses, tab-completes, persists)
```
router ospf {
  tracing {
    fsm { nfsm; }
    packet { hello; ls-update { detail; } dd { direction receive; } }
    spf;
  }
}
router ospfv3 { tracing { all; } }
```

### Deferred follow-ups (noted in commit)
- Per-interface tracing override (BGP-per-neighbor analog).
- Broad bare `tracing::*` → `ospf_*!` proto sweep (~152 diagnostic sites; BGP staged this separately).
- Live FRR-interop validation in a lab.

## Test plan
- `cargo build -p zebra-rs` clean, no warnings.
- `cargo clippy --workspace --all-targets -- -D warnings` exits 0.
- `cargo test -p zebra-rs ospf::` → 60 passed (incl. 13 new tracing unit tests).
- `cargo test -p zebra-rs yang_load_tests` → 2 passed (schema + both-root augments load).
- Confirmed no BDD test depends on the always-on packet log strings that became gated.

Generated with [Claude Code](https://claude.com/claude-code)