### PR TITLE
bgp: add vpn/srv6/vrf/bfd tracing categories

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -23,6 +23,7 @@
   - [Route Target Constraint (RTC)](ch-02-07-bgp-rtc.md)
   - [BFD](ch-02-08-bgp-bfd.md)
   - [Route Reflector](ch-02-09-bgp-route-reflector.md)
+  - [Conditional Tracing](ch-02-10-bgp-tracing.md)
 - [IS-IS](ch-07-00-isis.md)
   - [Timer Configuration](ch-07-01-isis-timers.md)
   - [Shared Risk Link Group (SRLG)](ch-07-02-isis-srlg.md)

--- a/book/src/ch-02-10-bgp-tracing.md
+++ b/book/src/ch-02-10-bgp-tracing.md
@@ -1,0 +1,144 @@
+# BGP Conditional Tracing
+
+BGP carries a large amount of internal activity — FSM transitions, every
+protocol message, route import/export, label allocation. Logging all of
+it unconditionally would drown the log; logging none of it makes live
+troubleshooting impossible. `router bgp tracing` is the middle ground: a
+typed config block of per-**category** switches that turn detailed
+`info`-level traces on at runtime, with no rebuild and no global log-level
+change.
+
+This mirrors the IS-IS / OSPF `tracing` model — gated log macros consult a
+config struct — but with the BGP-specific category set.
+
+Every traced line is stamped `proto="bgp"` and `category="<name>"`, so the
+filtering recipes in [Protocol-Specific Logging](ch-03-03-protocol-logging.md)
+apply directly (e.g. `jq 'select(.proto=="bgp" and .category=="vpn")'`).
+
+## Two scopes, one option set
+
+The same `tracing { ... }` block attaches at two points:
+
+- **Instance-wide** — `router bgp { tracing { ... } }` applies to every
+  peer and every instance-level activity.
+- **Per-neighbour** — `router bgp { neighbor <addr> { tracing { ... } } }`
+  scopes tracing to a single session.
+
+Per-neighbour config is **additive** to the instance config: a category is
+traced for a peer if either the instance block *or* that peer's block
+enables it. Instance-only categories (`vpn`, `srv6`, `vrf`, `bfd`,
+`label`) are most useful at the instance scope, since they are not tied to
+a single session.
+
+## The `all` master switch
+
+```
+router bgp {
+  tracing {
+    all;
+  }
+}
+```
+
+`all` turns on **every** category at summary level. It does not imply
+packet `detail` — that stays opt-in (see [Packet tracing](#packet-tracing)).
+
+## Categories
+
+Each leaf is a **presence flag**: name it to enable, delete it to disable.
+Absence means the category is silent.
+
+| Category | Scope | What it traces |
+|---|---|---|
+| `fsm` | per-peer | Peer FSM state changes (Idle/Connect/Active/OpenSent/OpenConfirm/Established) and the events that drive them. |
+| `packet` | per-peer | BGP protocol messages — see [Packet tracing](#packet-tracing). |
+| `adj-in` | per-peer | Routes entering the inbound Adj-RIB (received NLRI and their disposition). |
+| `adj-out` | per-peer | Routes leaving via the outbound Adj-RIB (what is advertised after export policy). |
+| `label` | instance | MPLS label allocation / binding for labeled-unicast / L3VPN routes (dynamic label-block grants, per-VRF label assignment). |
+| `vpn` | instance | L3VPN import/export — per-VRF prefixes written to the VPNv4/VPNv6 Loc-RIB and advertised to PE/CE peers, with their RD, route-targets and label. |
+| `srv6` | instance | SRv6 locator resolution and per-VRF End.DT46 service-SID reconciliation (L3VPN over SRv6). |
+| `vrf` | instance | Per-VRF task lifecycle — spawn / respawn / despawn / shutdown, inbound-connection routing, and the staged per-VRF config observed at commit. |
+| `bfd` | instance | BGP's interaction with the BFD client — session state changes and client-readiness that drive RFC 5882 peer teardown. |
+
+> **Warnings stay on.** Tracing categories gate *diagnostic* `info`/`debug`
+> detail only. Operator-facing **warnings and errors** — missing RD,
+> dropped routes, unsupported platform, setsockopt failures — are always
+> emitted (tagged `proto="bgp"`) regardless of the tracing config, so
+> turning a category off never hides a real problem.
+
+## Packet tracing
+
+`packet` is a sub-tree, not a single flag. Each message type is a presence
+container; naming it enables tracing for that type in **both directions at
+summary level**, and two optional children refine it:
+
+| Child | Meaning |
+|---|---|
+| `detail` | Log the fully-decoded message (all attributes / NLRI / capabilities) instead of a one-line summary. |
+| `direction send` \| `receive` | Restrict to one direction. Omit for both — there is no explicit `both` value; absence means both. |
+
+The message types are `open`, `update`, `keepalive`, `notification`,
+`route-refresh`, plus `all` (a catch-all applied on top of the per-type
+toggles).
+
+```
+router bgp {
+  tracing {
+    packet {
+      open;                       // both directions, summary
+      notification { detail; }    // both directions, fully decoded
+      update { direction receive; } // received UPDATEs only
+    }
+  }
+}
+```
+
+## Examples
+
+Watch FSM and label activity instance-wide:
+
+```
+router bgp {
+  tracing {
+    fsm;
+    label;
+  }
+}
+```
+
+Debug a single flapping neighbour without touching the rest of the fleet:
+
+```
+router bgp {
+  neighbor 10.0.0.5 {
+    remote-as 65501;
+    tracing {
+      fsm;
+      packet { update { direction receive; } }
+      adj-in;
+    }
+  }
+}
+```
+
+Trace the full L3VPN-over-SRv6 control path:
+
+```
+router bgp {
+  tracing {
+    vpn;
+    srv6;
+    label;
+  }
+}
+```
+
+## Interaction with `RUST_LOG`
+
+Tracing categories are a *content* filter — they decide which sites emit —
+and the lines they emit are at `info` level. They are independent of the
+[`RUST_LOG`](ch-03-03-protocol-logging.md#protocol-specific-debug-levels)
+*level* filter: a category produces nothing unless the BGP module's level
+admits `info` (the default does). Use tracing categories to pick *what* to
+see at runtime; use `RUST_LOG` only when you need a coarser module-level
+sweep.

--- a/book/src/ch-03-03-protocol-logging.md
+++ b/book/src/ch-03-03-protocol-logging.md
@@ -59,6 +59,12 @@ isis_debug!("LSP received from {}", neighbor);
 
 ## BGP Logging
 
+BGP can additionally turn on detailed per-category traces at runtime via
+the `router bgp tracing` config block — see
+[BGP Conditional Tracing](ch-02-10-bgp-tracing.md). Those lines are tagged
+`proto="bgp"` plus a `category` field (`fsm`, `packet`, `vpn`, `srv6`,
+`vrf`, `bfd`, …), so the filters below work on them directly.
+
 BGP-related logs include protocol identification:
 
 **Common BGP Log Messages:**

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -6,6 +6,7 @@ use crate::bfd::inst::ClientReq;
 use crate::bfd::session::{EchoMode, SessionKey, SessionParams};
 use crate::bfd::socket::{BFD_MULTI_HOP_PORT, BFD_MULTIHOP_DEFAULT_MIN_TTL, BFD_SINGLE_HOP_PORT};
 use crate::bgp::InOut;
+use crate::bgp_bfd_trace;
 use crate::config::{Args, ConfigOp};
 use crate::policy;
 use crate::policy::com_list::*;
@@ -552,7 +553,8 @@ fn bfd_apply(bgp: &mut Bgp, addr: IpAddr) -> Option<()> {
 
     let Some(client_tx) = bgp.bfd_client_tx.as_ref() else {
         if enable {
-            tracing::debug!(
+            bgp_bfd_trace!(
+                bgp.tracing,
                 peer = %addr,
                 "bgp: bfd enabled but bfd_client_tx is None (BFD not yet spawned)",
             );

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -13,7 +13,10 @@ use crate::policy::com_list::CommunityListMap;
 use crate::policy::{self, PolicyRxChannel};
 use crate::rib::MacAddr;
 use crate::rib::api::{FdbEntry, RibRx};
-use crate::{bgp_fsm_trace, bgp_label_trace, bgp_packet_trace};
+use crate::{
+    bgp_bfd_trace, bgp_fsm_trace, bgp_label_trace, bgp_packet_trace, bgp_srv6_trace, bgp_vpn_trace,
+    bgp_vrf_trace,
+};
 use std::collections::{BTreeMap, HashMap};
 use std::net::{Ipv4Addr, SocketAddr};
 use tokio::net::TcpStream;
@@ -783,10 +786,10 @@ impl Bgp {
                 }
                 match new_prefix {
                     Some(prefix) => {
-                        tracing::info!(locator = %name, %prefix, "bgp: SRv6 locator resolved");
+                        bgp_srv6_trace!(self.tracing, locator = %name, %prefix, "bgp: SRv6 locator resolved");
                     }
                     None => {
-                        tracing::info!(locator = %name, "bgp: SRv6 locator withdrawn");
+                        bgp_srv6_trace!(self.tracing, locator = %name, "bgp: SRv6 locator withdrawn");
                     }
                 }
                 self.reconcile_srv6_vrfs();
@@ -901,7 +904,7 @@ impl Bgp {
         );
         self.register_vrf_show(name, &new_handle);
         self.vrf_registry.insert(name.to_string(), new_handle);
-        tracing::info!(vrf = %name, "bgp: reconciled SRv6 service SID for VRF");
+        bgp_srv6_trace!(self.tracing, vrf = %name, "bgp: reconciled SRv6 service SID for VRF");
     }
 
     /// Update the BGP router-id and propagate it to every peer's
@@ -1367,7 +1370,8 @@ impl Bgp {
         );
         self.register_vrf_show(name, &new_handle);
         self.vrf_registry.insert(name.to_string(), new_handle);
-        tracing::info!(
+        bgp_vrf_trace!(
+            self.tracing,
             vrf = %name,
             table_id,
             "bgp: respawned per-VRF task with real ProtoContext::for_vrf",
@@ -2615,7 +2619,8 @@ impl Bgp {
                     &mut self.peers,
                 );
 
-                tracing::info!(
+                bgp_vpn_trace!(
+                    self.tracing,
                     vrf = %vrf,
                     %prefix,
                     rd = %rd,
@@ -2641,7 +2646,8 @@ impl Bgp {
             }
             super::vrf::BgpGlobalMsg::WithdrawExport { vrf, prefix } => {
                 let Some(rd) = self.vrfs.get(&vrf).and_then(|cfg| cfg.rd) else {
-                    tracing::debug!(
+                    bgp_vpn_trace!(
+                        self.tracing,
                         vrf = %vrf,
                         %prefix,
                         "bgp: withdraw-export dropped — VRF has no RD configured",
@@ -2719,7 +2725,8 @@ impl Bgp {
                     &mut self.peers,
                 );
 
-                tracing::info!(
+                bgp_vpn_trace!(
+                    self.tracing,
                     vrf = %vrf,
                     %prefix,
                     rd = %rd,
@@ -2862,7 +2869,8 @@ impl Bgp {
                     &mut self.peers,
                 );
 
-                tracing::info!(
+                bgp_vpn_trace!(
+                    self.tracing,
                     vrf = %vrf,
                     %prefix,
                     rd = %rd,
@@ -2945,7 +2953,8 @@ impl Bgp {
                     &mut self.peers,
                 );
 
-                tracing::info!(
+                bgp_vpn_trace!(
+                    self.tracing,
                     vrf = %vrf,
                     %prefix,
                     rd = %rd,
@@ -3006,7 +3015,8 @@ impl Bgp {
     /// to establish.
     pub fn process_bfd_event(&mut self, event: crate::bfd::inst::BfdEvent) {
         let crate::bfd::inst::BfdEvent::StateChange { key, change } = event;
-        tracing::info!(
+        bgp_bfd_trace!(
+            self.tracing,
             ?key,
             from = %change.from,
             to = %change.to,
@@ -3028,7 +3038,11 @@ impl Bgp {
         // lookup. A missing peer means the user removed the
         // neighbor since BGP last subscribed; safe to ignore.
         let Some(peer) = self.peers.get(&key.remote) else {
-            tracing::debug!(?key, "bgp: bfd-down for unknown peer; ignoring",);
+            bgp_bfd_trace!(
+                self.tracing,
+                ?key,
+                "bgp: bfd-down for unknown peer; ignoring",
+            );
             return;
         };
         let peer_idx = peer.ident;

--- a/zebra-rs/src/bgp/tracing.rs
+++ b/zebra-rs/src/bgp/tracing.rs
@@ -127,6 +127,52 @@ macro_rules! bgp_label_trace {
     };
 }
 
+/// Conditional L3VPN import/export trace. Instance-scoped — VPN export
+/// runs off the instance Loc-RIB and fans out to every PE/CE peer, so
+/// it takes a `&BgpTracing` directly rather than a single peer.
+#[macro_export]
+macro_rules! bgp_vpn_trace {
+    ($tracing:expr, $($arg:tt)*) => {
+        if $tracing.should_trace_vpn() {
+            tracing::info!(proto = "bgp", category = "vpn", $($arg)*);
+        }
+    };
+}
+
+/// Conditional SRv6 locator / SID trace. Instance-scoped (SID
+/// resolution is keyed by locator, not a peer).
+#[macro_export]
+macro_rules! bgp_srv6_trace {
+    ($tracing:expr, $($arg:tt)*) => {
+        if $tracing.should_trace_srv6() {
+            tracing::info!(proto = "bgp", category = "srv6", $($arg)*);
+        }
+    };
+}
+
+/// Conditional per-VRF task lifecycle trace (spawn / respawn / despawn /
+/// shutdown / inbound-connection routing). Instance-scoped.
+#[macro_export]
+macro_rules! bgp_vrf_trace {
+    ($tracing:expr, $($arg:tt)*) => {
+        if $tracing.should_trace_vrf() {
+            tracing::info!(proto = "bgp", category = "vrf", $($arg)*);
+        }
+    };
+}
+
+/// Conditional BFD-interaction trace (session state changes,
+/// client-readiness). Instance-scoped — the BFD client is a single
+/// per-instance channel, not a per-peer resource.
+#[macro_export]
+macro_rules! bgp_bfd_trace {
+    ($tracing:expr, $($arg:tt)*) => {
+        if $tracing.should_trace_bfd() {
+            tracing::info!(proto = "bgp", category = "bfd", $($arg)*);
+        }
+    };
+}
+
 // ============================================================
 // BgpTracing — runtime tracing configuration
 // ============================================================
@@ -241,6 +287,10 @@ pub struct BgpTracing {
     pub label: bool,
     pub adj_in: bool,
     pub adj_out: bool,
+    pub vpn: bool,
+    pub srv6: bool,
+    pub vrf: bool,
+    pub bfd: bool,
 }
 
 impl BgpTracing {
@@ -291,6 +341,22 @@ impl BgpTracing {
 
     pub fn should_trace_adj_out(&self) -> bool {
         self.all || self.adj_out
+    }
+
+    pub fn should_trace_vpn(&self) -> bool {
+        self.all || self.vpn
+    }
+
+    pub fn should_trace_srv6(&self) -> bool {
+        self.all || self.srv6
+    }
+
+    pub fn should_trace_vrf(&self) -> bool {
+        self.all || self.vrf
+    }
+
+    pub fn should_trace_bfd(&self) -> bool {
+        self.all || self.bfd
     }
 }
 
@@ -348,6 +414,10 @@ fn apply_tracing(t: &mut BgpTracing, rest: &str, args: &mut Args, op: ConfigOp) 
         "/label" => t.label = op.is_set(),
         "/adj-in" => t.adj_in = op.is_set(),
         "/adj-out" => t.adj_out = op.is_set(),
+        "/vpn" => t.vpn = op.is_set(),
+        "/srv6" => t.srv6 = op.is_set(),
+        "/vrf" => t.vrf = op.is_set(),
+        "/bfd" => t.bfd = op.is_set(),
         other => {
             let pkt = other.strip_prefix("/packet/")?;
             let (typ, sub) = match pkt.split_once('/') {
@@ -432,6 +502,14 @@ mod tests {
         apply_tracing(&mut t, "/adj-in", &mut args(&[]), ConfigOp::Set);
         apply_tracing(&mut t, "/adj-out", &mut args(&[]), ConfigOp::Set);
         assert!(t.fsm && t.label && t.adj_in && t.adj_out);
+
+        apply_tracing(&mut t, "/vpn", &mut args(&[]), ConfigOp::Set);
+        apply_tracing(&mut t, "/srv6", &mut args(&[]), ConfigOp::Set);
+        apply_tracing(&mut t, "/vrf", &mut args(&[]), ConfigOp::Set);
+        apply_tracing(&mut t, "/bfd", &mut args(&[]), ConfigOp::Set);
+        assert!(t.vpn && t.srv6 && t.vrf && t.bfd);
+        apply_tracing(&mut t, "/vpn", &mut args(&[]), ConfigOp::Delete);
+        assert!(!t.vpn);
     }
 
     #[test]
@@ -568,6 +646,10 @@ mod tests {
         assert!(t.should_trace_label());
         assert!(t.should_trace_adj_in());
         assert!(t.should_trace_adj_out());
+        assert!(t.should_trace_vpn());
+        assert!(t.should_trace_srv6());
+        assert!(t.should_trace_vrf());
+        assert!(t.should_trace_bfd());
         // `all` is summary-level only — it does not imply detail.
         assert!(!t.packet_detail(PacketKind::Notification, Direction::Recv));
     }

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -29,6 +29,7 @@ use std::str::FromStr;
 use bgp_packet::RouteDistinguisher;
 use ipnet::{Ipv4Net, Ipv6Net};
 
+use crate::bgp_vrf_trace;
 use crate::config::{Args, ConfigOp};
 
 use super::Bgp;
@@ -387,7 +388,8 @@ pub fn log_commit_diff(bgp: &Bgp) {
         return;
     }
     for (name, cfg) in &bgp.vrfs {
-        tracing::debug!(
+        bgp_vrf_trace!(
+            bgp.tracing,
             vrf = %name,
             rd = ?cfg.rd,
             router_id = ?cfg.router_id,

--- a/zebra-rs/yang/zebra-bgp-tracing.yang
+++ b/zebra-rs/yang/zebra-bgp-tracing.yang
@@ -69,6 +69,14 @@ module zebra-bgp-tracing {
      key off set vs delete and never read a value, so `type empty` is
      the honest type here.";
 
+  revision 2026-06-06 {
+    description
+      "Add categories vpn, srv6, vrf and bfd so the conditional
+       tracing taxonomy covers the L3VPN import/export, SRv6 SID
+       resolution, per-VRF task lifecycle and BFD-interaction log
+       sites that were previously unconditional.";
+  }
+
   revision 2026-06-05 {
     description
       "Initial revision — shared instance + per-neighbor tracing
@@ -201,6 +209,41 @@ module zebra-bgp-tracing {
         description
           "Log routes leaving via the outbound Adj-RIB (what is
            advertised to the scope after export policy).";
+      }
+
+      leaf vpn {
+        ext:help "Trace L3VPN import / export";
+        type empty;
+        description
+          "Log L3VPN route import/export: per-VRF prefixes written to
+           the VPNv4 / VPNv6 Loc-RIB and advertised to PE/CE peers,
+           with their RD, route-targets and MPLS label.";
+      }
+
+      leaf srv6 {
+        ext:help "Trace SRv6 locator / SID resolution";
+        type empty;
+        description
+          "Log SRv6 locator resolution and per-VRF End.DT46 service-SID
+           reconciliation used for L3VPN over SRv6.";
+      }
+
+      leaf vrf {
+        ext:help "Trace per-VRF task lifecycle";
+        type empty;
+        description
+          "Log per-VRF BGP task lifecycle — spawn / respawn / despawn /
+           shutdown, inbound-connection routing, and the staged per-VRF
+           config observed at commit.";
+      }
+
+      leaf bfd {
+        ext:help "Trace BFD session interaction";
+        type empty;
+        description
+          "Log BGP's interaction with the BFD client — session state
+           changes and client-readiness — that drive RFC 5882 peer
+           teardown.";
       }
     }
   }


### PR DESCRIPTION
## Summary
Extends the `router bgp tracing` taxonomy with four new conditional categories so the gates cover log sites that were previously unconditional: **vpn** (L3VPN import/export), **srv6** (locator/SID resolution), **vrf** (per-VRF task lifecycle), and **bfd** (BFD-client interaction).

- **`tracing.rs`**: `vpn`/`srv6`/`vrf`/`bfd` struct fields, `should_trace_*` accessors, `apply_tracing` arms, and instance-scoped `bgp_{vpn,srv6,vrf,bfd}_trace!` macros mirroring `bgp_label_trace!`. Unit tests cover the new toggles and the `all` master switch.
- **`zebra-bgp-tracing.yang`**: four presence leaves + `revision 2026-06-06`.
- **Call sites**: converts the parent-instance info/debug sites in `inst.rs`, `config.rs`, `vrf_config.rs` to the gated macros.
- **`book/`**: new "Conditional Tracing" chapter (`ch-02-10-bgp-tracing.md`) documenting all categories — the base feature was undocumented — wired into `SUMMARY.md` and cross-linked from the protocol-logging chapter.

Deliberately deferred to follow-ups (smallest-PR-first): per-VRF task tracing propagation; converting operator-facing warns/errors to `bgp_warn!`/`bgp_error!` (kept always-on, not hidden behind a toggle); `auth`/`evpn` categories (mostly warnings); `adj-in`/`adj-out` reuse for the `route.rs` advertise/drop warnings.

## Test plan
- `cargo check -p zebra-rs` — passes
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs bgp::tracing` — 13 passed
- `cargo test -p zebra-rs yang_load` — 2 passed
- `mdbook build` — clean

Generated with [Claude Code](https://claude.com/claude-code)