### PR TITLE
rib: runtime RIB/FIB tracing — replace compile-time DEBUG_* flags

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -67,6 +67,7 @@
   - [Log Output Destinations](ch-03-01-log-output-destinations.md)
   - [Log Formats](ch-03-02-log-formats.md)
   - [Protocol-Specific Logging](ch-03-03-protocol-logging.md)
+  - [RIB/FIB Tracing](ch-03-06-rib-fib-tracing.md)
   - [Logging Integration](ch-03-04-logging-integration.md)
   - [Logging Troubleshooting](ch-03-05-logging-troubleshooting.md)
 

--- a/book/src/ch-03-00-logging-overview.md
+++ b/book/src/ch-03-00-logging-overview.md
@@ -7,6 +7,7 @@ Zebra-rs provides flexible logging capabilities with multiple output destination
 - **Multiple Output Destinations**: stdout, syslog, file
 - **Multiple Formats**: terminal (human-readable), JSON, Elasticsearch-compatible
 - **Protocol-Aware Logging**: Automatic protocol field inclusion (ISIS, BGP, OSPF)
+- **Config-Driven RIB/FIB Tracing**: Runtime-toggleable trace categories under `system tracing` (see [RIB/FIB Tracing](ch-03-06-rib-fib-tracing.md))
 - **Structured Logging**: Rich metadata for filtering and analysis
 - **Fallback Mechanisms**: Automatic fallback when preferred output is unavailable
 

--- a/book/src/ch-03-06-rib-fib-tracing.md
+++ b/book/src/ch-03-06-rib-fib-tracing.md
@@ -1,0 +1,179 @@
+# RIB/FIB Tracing
+
+The rest of this chapter covers *output* logging — where logs go
+(`--log-output`), how they are formatted (`--log-format`), and how to
+filter them after the fact. RIB/FIB tracing is a **content** filter
+instead: a typed config block that decides, at runtime, *which* internal
+RIB and FIB events are emitted in the first place — with no rebuild and
+no global log-level change.
+
+It is the runtime successor to a set of compile-time `DEBUG_*` flags that
+used to gate these same diagnostic traces (you had to edit the source and
+rebuild to turn them on). It mirrors the per-protocol tracing blocks
+([BGP](ch-02-10-bgp-tracing.md), OSPF, IS-IS) — gated log sites consult a
+config struct — but because the RIB and FIB are core infrastructure
+rather than a routing protocol, the block lives under the top-level
+`system` container:
+
+```
+system {
+  tracing {
+    rib { ... }
+    fib { ... }
+  }
+}
+```
+
+## Two planes
+
+The block is split into `rib` and `fib` to match the operator's mental
+model and the classic Juniper `routing-options` (RIB) versus
+`forwarding-options` (FIB) traceoptions split:
+
+- **`rib`** — the control-plane RIB: route table changes, best-path
+  selection, recursive nexthop resolution, redistribution, MPLS ILM,
+  static routes, interface / connected-address handling, VRF lifecycle,
+  and SRv6 SID resolution.
+- **`fib`** — the dataplane: what is programmed into the kernel over
+  netlink.
+
+`route` and `nexthop` deliberately appear on **both** planes. That is the
+single most useful split this block buys you: a route can be resolved and
+best in the RIB yet never reach the kernel, and only side-by-side
+`rib route` + `fib route` traces show where it stalled.
+
+## The `all` master switch
+
+```
+system {
+  tracing {
+    all;
+  }
+}
+```
+
+`all` turns on **every** category under both planes at summary level. It
+does not imply `detail` — that stays opt-in.
+
+## RIB categories
+
+Each leaf is a **presence flag**: name it to enable, delete it to
+disable. Absence means the category is silent.
+
+| Category | What it traces | Modifiers |
+|---|---|---|
+| `route` | IPv4/IPv6 route add and withdraw into the RIB, and best-path selection among competing entries (admin-distance / metric). | `detail` |
+| `nexthop` | Recursive nexthop resolution and Next-Hop Tracking (NHT) register / notify. | `detail` |
+| `interface` | Link up/down, MTU changes, connected-route recovery (re-installing configured addresses the kernel dropped, with external-actor flap suppression). | `detail` |
+| `srv6` | SRv6 SID resolution (End / End.X / End.DT — behavior, locator, owner, SID device, nexthop) before the SID is programmed into the FIB. | `detail` |
+| `redistribute` | Route exchange with protocol clients (BGP / IS-IS / OSPF) through the RIB client registry. | — |
+| `label` | MPLS ILM handling: local-label allocation and label-to-nexthop bindings. | — |
+| `static` | Static-route configuration processing. | — |
+| `vrf` | VRF add/delete (incl. adoption of an existing kernel VRF), per-VRF table allocation, interface-to-VRF binding. | — |
+
+## FIB categories
+
+| Category | What it traces | Modifiers |
+|---|---|---|
+| `route` | Route programming to the kernel FIB over netlink. | `detail` |
+| `nexthop` | Nexthop-group programming (`RTM_NEWNEXTHOP`). | `detail` |
+| `srv6` | SRv6 `seg6local` SID install / uninstall and the SID device. | `detail` |
+| `l2` | L2 / EVPN dataplane — a sub-tree of `bridge`, `vxlan`, `fdb`, `mdb` toggles. | (per-type) |
+| `kernel` | Raw netlink messages on the southbound socket. | `detail`, `direction` |
+| `label` | MPLS LFIB programming — ILM entries (swap / pop / php). | — |
+| `neighbor` | ARP / ND (IPv4 / IPv6 neighbor) table programming. | — |
+| `interface` | Link admin up, MTU set, dummy-device create/delete, address add/delete. | `detail` |
+| `vrf` | VRF device create/delete, enslaving an interface to a VRF master. | — |
+
+The `l2` sub-tree groups four independent toggles:
+
+```
+system tracing fib l2 bridge    # bridge device + addr-gen-mode
+system tracing fib l2 vxlan     # VXLAN device + VNI registration
+system tracing fib l2 fdb       # MAC / FDB entries (incl. EVPN-sourced)
+system tracing fib l2 mdb       # multicast forwarding database
+```
+
+> **Instrumented vs reserved.** The full category surface is defined and
+> the config round-trips for every leaf, but only the categories that
+> already have trace sites emit anything today: `rib` `route` / `nexthop`
+> / `interface` / `srv6`, and `fib` `route` / `nexthop` / `srv6` /
+> `l2 {vxlan, fdb, mdb}`. The remaining leaves (`redistribute`, `label`,
+> `static`, `vrf`, `kernel`, `neighbor`, `l2 bridge`) are accepted,
+> stored, and covered by `all` — they light up once their sites are
+> instrumented.
+
+## Modifiers
+
+**`detail`** — the verbose categories (`route`, `nexthop`, `interface`,
+`srv6` on each plane, plus `fib kernel`) take an optional `detail`.
+Without it, each event is a one-line summary; with it, the full record is
+logged.
+
+```
+system tracing rib route          // summary
+system tracing rib route detail   // fully decoded
+```
+
+**`direction`** — `fib kernel` additionally takes a `direction` of `send`
+or `receive`. `send` is what zebra-rs programs into the kernel; `receive`
+is what the kernel reports back (link up/down, address changes, routes
+owned by other daemons). Omit it for both — there is no explicit `both`
+value; absence means both.
+
+```
+system tracing fib kernel direction receive
+```
+
+> **Warnings stay on.** Tracing categories gate *diagnostic* `info` /
+> `debug` detail only. Operator-facing **warnings and errors** — a route
+> the kernel rejected, an MTU set that failed, a label pool exhausted,
+> a malformed SID install — are always emitted regardless of the tracing
+> config, so turning a category off never hides a real problem.
+
+## Examples
+
+Find where a route stalls between the RIB and the kernel:
+
+```
+system {
+  tracing {
+    rib { route; nexthop; }
+    fib { route { detail; } }
+  }
+}
+```
+
+Watch only what the kernel reports back to us (link / address / foreign
+routes), fully decoded:
+
+```
+system {
+  tracing {
+    fib { kernel { direction receive; } }
+  }
+}
+```
+
+Trace EVPN MAC programming and the SRv6 SID install path:
+
+```
+system {
+  tracing {
+    fib {
+      l2 { fdb; }
+      srv6;
+    }
+  }
+}
+```
+
+## Interaction with `RUST_LOG`
+
+RIB/FIB tracing is a *content* filter — it decides which sites emit — and
+the lines it emits are at `info` level. It is independent of the
+[`RUST_LOG`](ch-03-03-protocol-logging.md#protocol-specific-debug-levels)
+*level* filter: a category produces nothing unless the module's level
+admits `info` (the default does). Use tracing categories to pick *what*
+to see at runtime; use `RUST_LOG` only when you need a coarser
+module-level sweep.

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -9,7 +9,7 @@ use prefix_trie::{Prefix, PrefixMap};
 
 use crate::bgp::timer::{start_adv_timer_evpn, start_stale_timer};
 use crate::policy::{AsPathPrependConfig, CommunityMatcher, PolicyList, StandardMatcher};
-use crate::rib::route::DEBUG_EVPN;
+use crate::rib::tracing::fib_l2_fdb;
 use crate::rib::{self, MacAddr, api::FdbEntry};
 use crate::{bgp_adj_in_trace, bgp_adj_out_trace};
 
@@ -3644,7 +3644,7 @@ fn extract_vni_from_attr(attr: &BgpAttr) -> Option<u32> {
                     ((ec.val[3] as u32) << 16) | ((ec.val[4] as u32) << 8) | (ec.val[5] as u32);
 
                 if vni > 0 && vni < 0x1000000 {
-                    if DEBUG_EVPN {
+                    if fib_l2_fdb() {
                         tracing::info!("extract_vni_from_attr: RT yields VNI {}", vni);
                     }
                     return Some(vni);

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -36,7 +36,7 @@ use crate::fib::sysctl::sysctl_enable;
 use crate::fib::{FibAddr, FibLink, FibMessage, FibNeighbor, FibRoute};
 use crate::rib::entry::RibEntry;
 use crate::rib::inst::{IlmEntry, IlmType};
-use crate::rib::route::{DEBUG_ADDR, DEBUG_EVPN};
+use crate::rib::tracing::{fib_l2_fdb, fib_l2_mdb, fib_l2_vxlan, fib_nexthop, fib_route, fib_srv6};
 use crate::rib::{
     AddrGenMode, Bridge, Group, GroupTrait, MacAddr, Nexthop, NexthopMulti, NexthopUni, RibType,
     Vxlan, link, nexthop::NexthopMember,
@@ -135,16 +135,6 @@ fn fmt_group_for_trace(group: &Group) -> String {
 /// (`RTNLGRP_NEXTHOP`, linux/rtnetlink.h). Numbered past the legacy
 /// `RTMGRP_*` bind mask, so it's joined via `add_membership`.
 const RTNLGRP_NEXTHOP: u32 = 32;
-
-// Flip to true to re-enable IPv6 FIB install diagnostic prints.
-const DEBUG_V6: bool = false;
-
-// Flip to true to log every SRv6 SID FIB install / uninstall — the
-// pre-send netlink attribute dump for the seg6local route, the
-// nexthop-skip notice, and the rib-side resolution trace. Errors from
-// the kernel are reported regardless. Mirrored by RIB via this same
-// constant (re-exported as `crate::fib::netlink::handle::DEBUG_SID`).
-pub const DEBUG_SID: bool = false;
 
 /// Mask the lower (128 - prefix_len) bits of an IPv6 address. The
 /// kernel ignores bits past the prefix length on install, but masking
@@ -625,7 +615,7 @@ impl FibHandle {
         nexthop: &Nexthop,
         table_id: u32,
     ) -> bool {
-        if DEBUG_V6 {
+        if fib_route() {
             tracing::info!(
                 "[IPv6 route_add_uni] prefix={} prefixlen={} rtype={:?} use_nhid={}",
                 prefix,
@@ -709,7 +699,7 @@ impl FibHandle {
                 return false;
             }
             if let Nexthop::Uni(uni) = &nexthop {
-                if DEBUG_V6 {
+                if fib_route() {
                     tracing::info!(
                         "[IPv6 route_add_uni] using nhid: gid={} metric={}",
                         uni.gid,
@@ -721,7 +711,7 @@ impl FibHandle {
                 msg.attributes.push(attr);
             }
             if let Nexthop::Multi(multi) = &nexthop {
-                if DEBUG_V6 {
+                if fib_route() {
                     tracing::info!(
                         "[IPv6 route_add_uni] using nhid (multi): gid={} metric={}",
                         multi.gid,
@@ -734,7 +724,7 @@ impl FibHandle {
             }
         } else {
             if let Nexthop::Uni(uni) = &nexthop {
-                if DEBUG_V6 {
+                if fib_route() {
                     tracing::info!(
                         "[IPv6 route_add_uni] embed nexthop: addr={} ifindex={:?} metric={}",
                         uni.addr,
@@ -797,7 +787,7 @@ impl FibHandle {
             }
         }
 
-        if DEBUG_V6 {
+        if fib_route() {
             tracing::info!(
                 "[IPv6 route_add_uni] netlink request: af={:?} dest_prefix_len={} attrs={:?}",
                 msg.header.address_family,
@@ -972,7 +962,7 @@ impl FibHandle {
         let mut response = self.handle.clone().request(req).unwrap();
         while let Some(msg) = response.next().await {
             if let NetlinkPayload::Error(e) = msg.payload
-                && DEBUG_ADDR
+                && fib_route()
             {
                 tracing::info!(
                     "DelRoute IPv6 error: {prefix} {e} table={table_id} rtype={:?} metric={} use_nhid={} nh={}",
@@ -1026,7 +1016,7 @@ impl FibHandle {
                 gid = uni.gid();
                 refcnt = uni.refcnt();
 
-                if DEBUG_V6 {
+                if fib_nexthop() {
                     tracing::info!(
                         "[nexthop_add Uni] gid={} addr={} ifindex={:?} valid={} installed={}",
                         gid,
@@ -1045,7 +1035,7 @@ impl FibHandle {
                 // refcounts the logical group for dedup / cleanup
                 // bookkeeping inside zebra-rs.
                 if uni.seg6local_action.is_some() {
-                    if DEBUG_SID {
+                    if fib_srv6() {
                         tracing::info!(
                             "[nexthop_add seg6local] gid={} skipped — seg6local \
                              install rides on the route, not the nh_id",
@@ -1100,7 +1090,7 @@ impl FibHandle {
                 let attr = NexthopAttribute::Oif(uni.ifindex().unwrap_or(0));
                 msg.attributes.push(attr);
 
-                if DEBUG_V6 {
+                if fib_nexthop() {
                     tracing::info!(
                         "[nexthop_add Uni] netlink: af={:?} attrs={:?}",
                         msg.header.address_family,
@@ -1326,7 +1316,7 @@ impl FibHandle {
         msg.attributes.push(encap);
         msg.attributes.push(encap_type);
 
-        if DEBUG_SID {
+        if fib_srv6() {
             tracing::info!(
                 "[route_sid_install] addr={}/{} behavior={:?} ifindex={} nh6={:?} gid={} \
                  use_nhid={} kind={:?} protocol={:?} attrs={:?}",
@@ -1349,8 +1339,8 @@ impl FibHandle {
         while let Some(m) = response.next().await {
             if let NetlinkPayload::Error(e) = m.payload {
                 // warn level so kernel rejections show up without
-                // requiring DEBUG_SID — silent failures here are how
-                // a misshaped seg6local install slips through.
+                // requiring `system tracing fib srv6` — silent failures
+                // here are how a misshaped seg6local install slips through.
                 tracing::warn!(
                     "NewRoute SID install error: addr={} behavior={:?} \
                      prefix_len={} table={} kind={:?} ifindex={} nh6={:?} \
@@ -2051,7 +2041,7 @@ impl FibHandle {
     /// Register VXLAN interface with its VNI for FDB operations
     /// Called when a VXLAN interface is created to establish VNI→ifindex mapping
     pub fn register_vxlan_ifindex(&mut self, vni: u32, ifindex: u32) {
-        if DEBUG_EVPN {
+        if fib_l2_vxlan() {
             tracing::info!(
                 "[FIB] Registered VXLAN VNI {} with ifindex {}",
                 vni,
@@ -2063,7 +2053,7 @@ impl FibHandle {
 
     /// Unregister VXLAN interface mapping
     pub fn unregister_vxlan_ifindex(&mut self, vni: u32) {
-        if DEBUG_EVPN {
+        if fib_l2_vxlan() {
             tracing::info!("[FIB] Unregistered VXLAN VNI {}", vni);
         }
         self.vni_ifindex_map.remove(&vni);
@@ -2102,7 +2092,7 @@ impl FibHandle {
         esi: Option<[u8; 10]>,
     ) {
         let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
-            if DEBUG_EVPN {
+            if fib_l2_fdb() {
                 tracing::info!(
                     "mac_add: no local VXLAN for VNI {} — skipping (mac {})",
                     vni,
@@ -2112,7 +2102,7 @@ impl FibHandle {
             return;
         };
 
-        if DEBUG_EVPN {
+        if fib_l2_fdb() {
             tracing::info!(
                 "mac_add: VNI {} mac {} ifindex {} dst {}",
                 vni,
@@ -2168,7 +2158,7 @@ impl FibHandle {
         // will be wired when ECMP nexthop groups are supported.
         if let Some(esi_val) = esi
             && esi_val != [0u8; 10]
-            && DEBUG_EVPN
+            && fib_l2_fdb()
         {
             tracing::info!("mac_add: ESI type {} for MAC {}", esi_val[0], mac);
         }
@@ -2265,7 +2255,7 @@ impl FibHandle {
         // `unwrap_or(vni)` would have issued a stray RTM_DELNEIGH
         // against a random interface.
         let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
-            if DEBUG_EVPN {
+            if fib_l2_fdb() {
                 tracing::info!(
                     "mac_del: no local VXLAN for VNI {} — skipping (mac {})",
                     vni,
@@ -2275,7 +2265,7 @@ impl FibHandle {
             return;
         };
 
-        if DEBUG_EVPN {
+        if fib_l2_fdb() {
             tracing::info!("mac_del: VNI {} mac {} ifindex {}", vni, mac, vxlan_ifindex);
         }
 
@@ -2340,7 +2330,7 @@ impl FibHandle {
         _seq: u32,
     ) {
         let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
-            if DEBUG_EVPN {
+            if fib_l2_mdb() {
                 tracing::info!(
                     "mdb_add: no local VXLAN for VNI {} — skipping (group {})",
                     vni,
@@ -2350,7 +2340,7 @@ impl FibHandle {
             return;
         };
 
-        if DEBUG_EVPN {
+        if fib_l2_mdb() {
             tracing::info!(
                 "mdb_add: VNI {} dst {} ifindex {} (zero-MAC FDB / ingress replication)",
                 vni,
@@ -2384,7 +2374,7 @@ impl FibHandle {
     /// Counterpart of `mdb_add`; same rationale on naming.
     pub async fn mdb_del(&self, vni: u32, group: IpAddr, _source: Option<IpAddr>, _ifindex: u32) {
         let Some(&vxlan_ifindex) = self.vni_ifindex_map.get(&vni) else {
-            if DEBUG_EVPN {
+            if fib_l2_mdb() {
                 tracing::info!(
                     "mdb_del: no local VXLAN for VNI {} — skipping (group {})",
                     vni,
@@ -2394,7 +2384,7 @@ impl FibHandle {
             return;
         };
 
-        if DEBUG_EVPN {
+        if fib_l2_mdb() {
             tracing::info!(
                 "mdb_del: VNI {} dst {} ifindex {} (zero-MAC FDB / ingress replication)",
                 vni,

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -961,7 +961,7 @@ impl Rib {
         {
             sid.ifindex = ifindex;
         }
-        if crate::fib::netlink::handle::DEBUG_SID {
+        if crate::rib::tracing::rib_srv6() {
             tracing::info!(
                 "[sid_install] addr={} behavior={:?} locator={} owner={} \
                  ifindex={} (orig={}) nh6={:?}",
@@ -997,7 +997,7 @@ impl Rib {
         let gid = group.gid();
         let need_install = !group.is_installed();
         group.refcnt_inc();
-        if crate::fib::netlink::handle::DEBUG_SID {
+        if crate::rib::tracing::rib_srv6() {
             tracing::info!(
                 "[sid_install] addr={} resolved gid={} need_install={} refcnt={}",
                 sid.addr,
@@ -2198,6 +2198,8 @@ impl Rib {
                     let _ = self.block_config.exec(path, args, msg.op);
                 } else if path.as_str().starts_with("/segment-routing/locator") {
                     let _ = self.locator_config.exec(path, args, msg.op);
+                } else if path.as_str().starts_with("/system/tracing") {
+                    crate::rib::tracing::config_dispatch(&path, args, msg.op);
                 }
             }
             ConfigOp::CommitEnd => {

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -12,7 +12,7 @@ use crate::fib::os_traffic_dump;
 use crate::fib::sysctl::{sysctl_keep_addr_on_down, sysctl_mpls_enable, sysctl_seg6_enable};
 
 use super::entry::RibEntry;
-use super::route::{DEBUG_ADDR, DEBUG_EVPN};
+use super::tracing::rib_interface;
 use super::util::IpNetExt;
 use super::{LinkFlagsExt, MacAddr, Message, Rib, RibType};
 
@@ -452,7 +452,7 @@ pub fn link_addr_del(link: &mut Link, addr: LinkAddr) -> Option<()> {
 
 impl Rib {
     pub async fn link_add(&mut self, fib_link: FibLink) {
-        if DEBUG_EVPN {
+        if rib_interface() {
             tracing::info!(
                 "link_add: ifindex {} name {} vni {:?} master {:?}",
                 fib_link.index,
@@ -508,7 +508,7 @@ impl Rib {
             // down event handling.
             if link.is_up() {
                 if !fib_link.flags.is_up() {
-                    if DEBUG_ADDR {
+                    if rib_interface() {
                         tracing::info!(
                             "kernel: link {} (ifindex {}) Up => Down",
                             link.name,
@@ -522,7 +522,7 @@ impl Rib {
                     });
                 }
             } else if fib_link.flags.is_up() {
-                if DEBUG_ADDR {
+                if rib_interface() {
                     tracing::info!(
                         "kernel: link {} (ifindex {}) Down => Up; recovering connected routes",
                         link.name,

--- a/zebra-rs/src/rib/mod.rs
+++ b/zebra-rs/src/rib/mod.rs
@@ -64,6 +64,8 @@ pub use mac_addr::*;
 pub mod logging;
 pub use logging::*;
 
+pub mod tracing;
+
 pub mod bridge;
 pub use bridge::*;
 

--- a/zebra-rs/src/rib/nexthop/group.rs
+++ b/zebra-rs/src/rib/nexthop/group.rs
@@ -10,9 +10,7 @@ use crate::rib::entry::RibEntries;
 use crate::rib::resolve::{Resolve, ResolveOpt, rib_resolve, rib_resolve_v6};
 
 use super::NexthopUni;
-
-// Flip to true to re-enable IPv6 nexthop resolution diagnostic prints.
-const DEBUG_V6: bool = false;
+use crate::rib::tracing::rib_nexthop;
 
 #[derive(Debug)]
 pub enum Group {
@@ -133,7 +131,7 @@ impl GroupUni {
         // can't be disambiguated by table lookup — every interface
         // advertises fe80::/64.
         if let Some(ifindex) = self.ifindex_origin {
-            if DEBUG_V6 {
+            if rib_nexthop() {
                 println!(
                     "[GroupUni::resolve_v6] addr={} ifindex_origin={} (skipping table walk)",
                     self.addr, ifindex,
@@ -150,7 +148,7 @@ impl GroupUni {
                 // produce a real egress ifindex; the Group cares about that,
                 // not the path category.
                 Resolve::Onlink(ifindex) | Resolve::Recursive(ifindex) => {
-                    if DEBUG_V6 {
+                    if rib_nexthop() {
                         println!(
                             "[GroupUni::resolve_v6] {} -> ifindex_resolved={}",
                             ipv6_addr, ifindex
@@ -160,7 +158,7 @@ impl GroupUni {
                     self.set_valid(true);
                 }
                 Resolve::NotFound => {
-                    if DEBUG_V6 {
+                    if rib_nexthop() {
                         println!("[GroupUni::resolve_v6] {} -> NotFound", ipv6_addr);
                     }
                 }

--- a/zebra-rs/src/rib/route.rs
+++ b/zebra-rs/src/rib/route.rs
@@ -11,23 +11,11 @@ use crate::rib::{Link, LinkFlagsExt, Nexthop};
 use super::entry::RibEntry;
 use super::inst::{IlmEntry, RT_TABLE_MAIN, Rib};
 use super::nexthop::NexthopUni;
+use super::tracing::{rib_interface, rib_nexthop, rib_route};
 use super::{
     Group, GroupTrait, Message, NexthopList, NexthopMap, NexthopMember, NexthopMulti, RibEntries,
     RibType,
 };
-
-// Flip to true to re-enable IPv6 RIB/FIB diagnostic trace.
-const DEBUG_V6: bool = false;
-
-// Flip to true to re-enable IP address diagnostic trace.
-pub const DEBUG_ADDR: bool = false;
-
-// Flip to true to log EVPN-related diagnostic traces (VXLAN VNI
-// register/unregister, mac_add / mac_del / mdb_add / mdb_del,
-// link_add EVPN bridge association, BGP RT→VNI extraction). Errors
-// from the kernel are reported regardless. Imported by the FIB and
-// BGP modules so all EVPN diagnostics share one switch.
-pub const DEBUG_EVPN: bool = false;
 
 /// Hold-down policy for kernel-driven address recovery.
 ///
@@ -112,7 +100,7 @@ impl Rib {
     async fn addr_reinstall(&self, ifindex: u32, link_name: &str, addr: &IpNet) {
         match addr {
             IpNet::V4(net) => {
-                if DEBUG_ADDR {
+                if rib_interface() {
                     tracing::info!(
                         "addr_reinstall: {} re-installing IPv4 {} to kernel",
                         link_name,
@@ -129,7 +117,7 @@ impl Rib {
                 }
             }
             IpNet::V6(net) => {
-                if DEBUG_ADDR {
+                if rib_interface() {
                     tracing::info!(
                         "addr_reinstall: {} re-installing IPv6 {} to kernel",
                         link_name,
@@ -230,7 +218,7 @@ impl Rib {
                 true
             }
             RecoveryDecision::Recover => {
-                if DEBUG_ADDR {
+                if rib_interface() {
                     tracing::info!(
                         "addr_recover: {} {} kernel-deleted, still in config — \
                          re-installing (history len now {})",
@@ -374,7 +362,7 @@ impl Rib {
 
     pub async fn link_up(&mut self, ifindex: u32) {
         let Some(link) = self.links.get(&ifindex) else {
-            if DEBUG_ADDR {
+            if rib_interface() {
                 tracing::info!(
                     "link_up: ifindex {} not found in link table; skipping connected route recovery",
                     ifindex
@@ -384,7 +372,7 @@ impl Rib {
         };
         let link_name = link.name.clone();
 
-        if DEBUG_ADDR {
+        if rib_interface() {
             tracing::info!(
                 "link_up: {} (ifindex {}) recovering {} IPv4 + {} IPv6 connected addresses",
                 link_name,
@@ -405,7 +393,7 @@ impl Rib {
                 entry.ifindex = ifindex;
                 entry.set_valid(true);
 
-                if DEBUG_ADDR {
+                if rib_interface() {
                     tracing::info!(
                         "link_up: {} re-adding IPv4 connected prefix {}",
                         link_name,
@@ -434,7 +422,7 @@ impl Rib {
                 entry.ifindex = ifindex;
                 entry.set_valid(true);
 
-                if DEBUG_ADDR {
+                if rib_interface() {
                     tracing::info!(
                         "link_up: {} re-adding IPv6 connected prefix {}",
                         link_name,
@@ -795,7 +783,7 @@ impl Rib {
     }
 
     pub async fn ipv6_route_add(&mut self, prefix: &Ipv6Net, mut entry: RibEntry, table_id: u32) {
-        if DEBUG_V6 {
+        if rib_route() {
             tracing::info!(
                 "[ipv6_route_add] prefix={} rtype={:?} is_protocol={} is_connected={} valid_in={}",
                 prefix,
@@ -823,7 +811,7 @@ impl Rib {
         if entry.is_protocol() {
             let mut replace = rib_replace_v6(&mut self.table_v6, prefix, entry.rtype);
             rib_resolve_nexthop_v6(&mut entry, &self.table_v6, &mut self.nmap, table_id);
-            if DEBUG_V6 {
+            if rib_route() {
                 println!(
                     "[ipv6_route_add] after resolve: entry.valid={} nexthop={:?}",
                     entry.is_valid(),
@@ -1732,7 +1720,7 @@ async fn ipv6_entry_selection(
     fib: &FibHandle,
     table_id: u32,
 ) -> bool {
-    if DEBUG_V6 {
+    if rib_route() {
         println!(
             "[ipv6_entry_selection] prefix={} entries={} replace={}",
             prefix,
@@ -1774,7 +1762,7 @@ async fn ipv6_entry_selection(
     // New select.
     let next = rib_next(entries);
 
-    if DEBUG_V6 {
+    if rib_route() {
         println!("[ipv6_entry_selection] prev={:?} next={:?}", prev, next);
     }
 
@@ -2057,19 +2045,19 @@ fn resolve_nexthop_uni_v6(
     table: &PrefixMap<Ipv6Net, RibEntries>,
     table_id: u32,
 ) -> bool {
-    if DEBUG_V6 {
+    if rib_nexthop() {
         println!(
             "[resolve_nexthop_uni_v6] addr={} gid_before={}",
             uni.addr, uni.gid
         );
     }
     let Some(Group::Uni(group)) = nmap.fetch(uni, table_id) else {
-        if DEBUG_V6 {
+        if rib_nexthop() {
             println!("[resolve_nexthop_uni_v6] nmap.fetch returned None");
         }
         return false;
     };
-    if DEBUG_V6 {
+    if rib_nexthop() {
         println!(
             "[resolve_nexthop_uni_v6] fetched group gid={} refcnt={} valid={} ifindex={:?}",
             group.gid(),
@@ -2080,7 +2068,7 @@ fn resolve_nexthop_uni_v6(
     }
     if group.refcnt() == 0 {
         group.resolve_v6(table);
-        if DEBUG_V6 {
+        if rib_nexthop() {
             println!(
                 "[resolve_nexthop_uni_v6] after resolve_v6 valid={} ifindex={:?}",
                 group.is_valid(),
@@ -2098,7 +2086,7 @@ fn resolve_nexthop_uni_v6(
     uni.ifindex_resolved = group.ifindex_resolved;
 
     let valid = group.is_valid();
-    if DEBUG_V6 {
+    if rib_nexthop() {
         println!(
             "[resolve_nexthop_uni_v6] returning uni.gid={} uni.ifindex={:?} valid={}",
             uni.gid,
@@ -2116,12 +2104,12 @@ pub async fn ipv6_nexthop_sync(
     links: &BTreeMap<u32, Link>,
     fib: &FibHandle,
 ) {
-    if DEBUG_V6 {
+    if rib_nexthop() {
         println!("[ipv6_nexthop_sync] start; v6 table size={}", table.len());
     }
     for nhop in nmap.groups.iter_mut().flatten() {
         if let Group::Uni(uni) = nhop {
-            if DEBUG_V6 {
+            if rib_nexthop() {
                 println!(
                     "[ipv6_nexthop_sync] visiting uni gid={} addr={} ifindex={:?} valid={} installed={}",
                     uni.gid(),
@@ -2166,7 +2154,7 @@ pub async fn ipv6_nexthop_sync(
                 Some(rt) => rib_resolve_v6(rt, ipv6_addr, &ResolveOpt::default()).is_valid(),
                 None => 0,
             };
-            if DEBUG_V6 {
+            if rib_nexthop() {
                 println!(
                     "[ipv6_nexthop_sync] resolved ifindex={} (0 means unresolved)",
                     ifindex
@@ -2188,7 +2176,7 @@ pub async fn ipv6_nexthop_sync(
             }
         }
     }
-    if DEBUG_V6 {
+    if rib_nexthop() {
         println!("[ipv6_nexthop_sync] done");
     }
 }

--- a/zebra-rs/src/rib/tracing.rs
+++ b/zebra-rs/src/rib/tracing.rs
@@ -1,0 +1,313 @@
+//! Runtime RIB / FIB tracing configuration.
+//!
+//! Backs the `system tracing { rib {...} fib {...} }` config tree
+//! defined in `zebra-rib-tracing.yang`. The per-protocol tracing blocks
+//! (BGP / OSPF / IS-IS) keep their toggles on the protocol instance,
+//! because every trace site has a `Peer` / instance handle. The RIB and
+//! FIB trace sites do not: they are spread across `Rib` methods, free
+//! functions in `rib::route` / `rib::nexthop`, and `FibHandle` methods,
+//! none of which share a `self`. So the toggles live in one
+//! process-global block of atomics — the runtime successor to the old
+//! `const DEBUG_*: bool` flags that used to gate these same sites at
+//! compile time.
+//!
+//! Reads are lock-free `Relaxed` loads (cheap enough for the route /
+//! nexthop hot paths); writes happen only when `system tracing …` is
+//! committed, dispatched from [`Rib::process_cm_msg`] via
+//! [`config_dispatch`]. There is exactly one RIB per process, so a
+//! global is the honest model here — the same way the `tracing` crate's
+//! own subscriber is global.
+//!
+//! Only the categories that have a live trace site expose a reader
+//! (`rib_route`, `fib_l2_fdb`, …); the remaining leaves are still parsed
+//! and stored so the config round-trips and the `all` master switch
+//! covers them once their sites are instrumented.
+
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering::Relaxed};
+
+use crate::config::{Args, ConfigOp};
+
+/// Every `system tracing` leaf as an atomic toggle. `*_detail` mirror
+/// the optional `detail` refinement; `fib_kernel_dir` holds the
+/// `fib kernel direction` (0 = both, 1 = send, 2 = receive).
+struct State {
+    all: AtomicBool,
+
+    rib_route: AtomicBool,
+    rib_route_detail: AtomicBool,
+    rib_nexthop: AtomicBool,
+    rib_nexthop_detail: AtomicBool,
+    rib_redistribute: AtomicBool,
+    rib_label: AtomicBool,
+    rib_static: AtomicBool,
+    rib_interface: AtomicBool,
+    rib_interface_detail: AtomicBool,
+    rib_vrf: AtomicBool,
+    rib_srv6: AtomicBool,
+    rib_srv6_detail: AtomicBool,
+
+    fib_route: AtomicBool,
+    fib_route_detail: AtomicBool,
+    fib_nexthop: AtomicBool,
+    fib_nexthop_detail: AtomicBool,
+    fib_kernel: AtomicBool,
+    fib_kernel_detail: AtomicBool,
+    fib_kernel_dir: AtomicU8,
+    fib_label: AtomicBool,
+    fib_neighbor: AtomicBool,
+    fib_interface: AtomicBool,
+    fib_interface_detail: AtomicBool,
+    fib_vrf: AtomicBool,
+    fib_srv6: AtomicBool,
+    fib_srv6_detail: AtomicBool,
+    fib_l2_bridge: AtomicBool,
+    fib_l2_vxlan: AtomicBool,
+    fib_l2_fdb: AtomicBool,
+    fib_l2_mdb: AtomicBool,
+}
+
+impl State {
+    const fn new() -> Self {
+        State {
+            all: AtomicBool::new(false),
+            rib_route: AtomicBool::new(false),
+            rib_route_detail: AtomicBool::new(false),
+            rib_nexthop: AtomicBool::new(false),
+            rib_nexthop_detail: AtomicBool::new(false),
+            rib_redistribute: AtomicBool::new(false),
+            rib_label: AtomicBool::new(false),
+            rib_static: AtomicBool::new(false),
+            rib_interface: AtomicBool::new(false),
+            rib_interface_detail: AtomicBool::new(false),
+            rib_vrf: AtomicBool::new(false),
+            rib_srv6: AtomicBool::new(false),
+            rib_srv6_detail: AtomicBool::new(false),
+            fib_route: AtomicBool::new(false),
+            fib_route_detail: AtomicBool::new(false),
+            fib_nexthop: AtomicBool::new(false),
+            fib_nexthop_detail: AtomicBool::new(false),
+            fib_kernel: AtomicBool::new(false),
+            fib_kernel_detail: AtomicBool::new(false),
+            fib_kernel_dir: AtomicU8::new(0),
+            fib_label: AtomicBool::new(false),
+            fib_neighbor: AtomicBool::new(false),
+            fib_interface: AtomicBool::new(false),
+            fib_interface_detail: AtomicBool::new(false),
+            fib_vrf: AtomicBool::new(false),
+            fib_srv6: AtomicBool::new(false),
+            fib_srv6_detail: AtomicBool::new(false),
+            fib_l2_bridge: AtomicBool::new(false),
+            fib_l2_vxlan: AtomicBool::new(false),
+            fib_l2_fdb: AtomicBool::new(false),
+            fib_l2_mdb: AtomicBool::new(false),
+        }
+    }
+
+    /// A category is on when its own toggle is set, or the `all` master
+    /// switch is. `all` is summary-level only — it never implies detail.
+    #[inline]
+    fn on(&self, flag: &AtomicBool) -> bool {
+        self.all.load(Relaxed) || flag.load(Relaxed)
+    }
+
+    /// Apply one committed `…/tracing/<rest>` Set/Delete line. `rest` is
+    /// the path tail after the `tracing` node (e.g. `/rib/route`,
+    /// `/fib/kernel/direction`); for the direction case `args` still
+    /// holds the trailing send/receive token. Unknown tails are ignored
+    /// — the YANG constrains the set, so a miss only means a leaf with no
+    /// behavior yet.
+    fn apply(&self, rest: &str, args: &mut Args, op: ConfigOp) {
+        let set = op.is_set();
+        match rest {
+            "" | "/all" => self.all.store(set, Relaxed),
+
+            "/rib/route" => toggle(&self.rib_route, &self.rib_route_detail, op),
+            "/rib/route/detail" => detail(&self.rib_route, &self.rib_route_detail, op),
+            "/rib/nexthop" => toggle(&self.rib_nexthop, &self.rib_nexthop_detail, op),
+            "/rib/nexthop/detail" => detail(&self.rib_nexthop, &self.rib_nexthop_detail, op),
+            "/rib/redistribute" => self.rib_redistribute.store(set, Relaxed),
+            "/rib/label" => self.rib_label.store(set, Relaxed),
+            "/rib/static" => self.rib_static.store(set, Relaxed),
+            "/rib/interface" => toggle(&self.rib_interface, &self.rib_interface_detail, op),
+            "/rib/interface/detail" => detail(&self.rib_interface, &self.rib_interface_detail, op),
+            "/rib/vrf" => self.rib_vrf.store(set, Relaxed),
+            "/rib/srv6" => toggle(&self.rib_srv6, &self.rib_srv6_detail, op),
+            "/rib/srv6/detail" => detail(&self.rib_srv6, &self.rib_srv6_detail, op),
+
+            "/fib/route" => toggle(&self.fib_route, &self.fib_route_detail, op),
+            "/fib/route/detail" => detail(&self.fib_route, &self.fib_route_detail, op),
+            "/fib/nexthop" => toggle(&self.fib_nexthop, &self.fib_nexthop_detail, op),
+            "/fib/nexthop/detail" => detail(&self.fib_nexthop, &self.fib_nexthop_detail, op),
+            "/fib/kernel" => toggle(&self.fib_kernel, &self.fib_kernel_detail, op),
+            "/fib/kernel/detail" => detail(&self.fib_kernel, &self.fib_kernel_detail, op),
+            "/fib/kernel/direction" => direction(&self.fib_kernel, &self.fib_kernel_dir, args, op),
+            "/fib/label" => self.fib_label.store(set, Relaxed),
+            "/fib/neighbor" => self.fib_neighbor.store(set, Relaxed),
+            "/fib/interface" => toggle(&self.fib_interface, &self.fib_interface_detail, op),
+            "/fib/interface/detail" => detail(&self.fib_interface, &self.fib_interface_detail, op),
+            "/fib/vrf" => self.fib_vrf.store(set, Relaxed),
+            "/fib/srv6" => toggle(&self.fib_srv6, &self.fib_srv6_detail, op),
+            "/fib/srv6/detail" => detail(&self.fib_srv6, &self.fib_srv6_detail, op),
+            "/fib/l2/bridge" => self.fib_l2_bridge.store(set, Relaxed),
+            "/fib/l2/vxlan" => self.fib_l2_vxlan.store(set, Relaxed),
+            "/fib/l2/fdb" => self.fib_l2_fdb.store(set, Relaxed),
+            "/fib/l2/mdb" => self.fib_l2_mdb.store(set, Relaxed),
+            _ => {}
+        }
+    }
+}
+
+static STATE: State = State::new();
+
+/// `tracing <cat>` — bare presence enables the category; delete clears
+/// it, including any `detail` underneath (matching the BGP block).
+fn toggle(on: &AtomicBool, det: &AtomicBool, op: ConfigOp) {
+    if op.is_set() {
+        on.store(true, Relaxed);
+    } else {
+        on.store(false, Relaxed);
+        det.store(false, Relaxed);
+    }
+}
+
+/// `tracing <cat> detail` — enabling detail implies the category is
+/// traced; delete leaves it enabled at summary level.
+fn detail(on: &AtomicBool, det: &AtomicBool, op: ConfigOp) {
+    if op.is_set() {
+        on.store(true, Relaxed);
+        det.store(true, Relaxed);
+    } else {
+        det.store(false, Relaxed);
+    }
+}
+
+/// `tracing fib kernel direction {send|receive}` — restrict (and enable)
+/// the netlink direction; delete reverts to both.
+fn direction(on: &AtomicBool, dir: &AtomicU8, args: &mut Args, op: ConfigOp) {
+    if op.is_set() {
+        on.store(true, Relaxed);
+        let d = match args.string().as_deref() {
+            Some("send") => 1,
+            Some("receive") | Some("recv") => 2,
+            _ => 0,
+        };
+        dir.store(d, Relaxed);
+    } else {
+        dir.store(0, Relaxed);
+    }
+}
+
+/// Dispatch a committed `/system/tracing/…` Set/Delete path. Called from
+/// [`Rib::process_cm_msg`]; ignores anything outside the tracing subtree.
+pub fn config_dispatch(path: &str, mut args: Args, op: ConfigOp) {
+    if let Some(rest) = path.strip_prefix("/system/tracing") {
+        STATE.apply(rest, &mut args, op);
+    }
+}
+
+// ---- readers: one per category with a live trace site --------------
+
+pub fn rib_route() -> bool {
+    STATE.on(&STATE.rib_route)
+}
+pub fn rib_nexthop() -> bool {
+    STATE.on(&STATE.rib_nexthop)
+}
+pub fn rib_interface() -> bool {
+    STATE.on(&STATE.rib_interface)
+}
+pub fn rib_srv6() -> bool {
+    STATE.on(&STATE.rib_srv6)
+}
+pub fn fib_route() -> bool {
+    STATE.on(&STATE.fib_route)
+}
+pub fn fib_nexthop() -> bool {
+    STATE.on(&STATE.fib_nexthop)
+}
+pub fn fib_srv6() -> bool {
+    STATE.on(&STATE.fib_srv6)
+}
+pub fn fib_l2_vxlan() -> bool {
+    STATE.on(&STATE.fib_l2_vxlan)
+}
+pub fn fib_l2_fdb() -> bool {
+    STATE.on(&STATE.fib_l2_fdb)
+}
+pub fn fib_l2_mdb() -> bool {
+    STATE.on(&STATE.fib_l2_mdb)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+
+    fn args(items: &[&str]) -> Args {
+        Args(items.iter().map(|s| s.to_string()).collect::<VecDeque<_>>())
+    }
+
+    #[test]
+    fn toggle_set_delete() {
+        let s = State::new();
+        s.apply("/rib/route", &mut args(&[]), ConfigOp::Set);
+        assert!(s.on(&s.rib_route));
+        s.apply("/rib/route", &mut args(&[]), ConfigOp::Delete);
+        assert!(!s.on(&s.rib_route));
+    }
+
+    #[test]
+    fn detail_implies_enabled_and_delete_keeps_enabled() {
+        let s = State::new();
+        s.apply("/fib/route/detail", &mut args(&[]), ConfigOp::Set);
+        assert!(s.on(&s.fib_route));
+        assert!(s.fib_route_detail.load(Relaxed));
+        // Deleting detail leaves the category traced at summary level.
+        s.apply("/fib/route/detail", &mut args(&[]), ConfigOp::Delete);
+        assert!(s.on(&s.fib_route));
+        assert!(!s.fib_route_detail.load(Relaxed));
+        // Deleting the container clears the whole toggle.
+        s.apply("/fib/route/detail", &mut args(&[]), ConfigOp::Set);
+        s.apply("/fib/route", &mut args(&[]), ConfigOp::Delete);
+        assert!(!s.on(&s.fib_route));
+        assert!(!s.fib_route_detail.load(Relaxed));
+    }
+
+    #[test]
+    fn all_master_switch_lights_every_category() {
+        let s = State::new();
+        s.apply("/all", &mut args(&[]), ConfigOp::Set);
+        assert!(s.on(&s.rib_route));
+        assert!(s.on(&s.fib_l2_fdb));
+        assert!(s.on(&s.fib_srv6));
+        // `all` is summary-level only — never implies detail.
+        assert!(!s.fib_route_detail.load(Relaxed));
+        s.apply("/all", &mut args(&[]), ConfigOp::Delete);
+        assert!(!s.on(&s.rib_route));
+    }
+
+    #[test]
+    fn kernel_direction_parses_and_enables() {
+        let s = State::new();
+        s.apply(
+            "/fib/kernel/direction",
+            &mut args(&["receive"]),
+            ConfigOp::Set,
+        );
+        assert!(s.on(&s.fib_kernel));
+        assert_eq!(s.fib_kernel_dir.load(Relaxed), 2);
+        s.apply("/fib/kernel/direction", &mut args(&["send"]), ConfigOp::Set);
+        assert_eq!(s.fib_kernel_dir.load(Relaxed), 1);
+        s.apply("/fib/kernel/direction", &mut args(&[]), ConfigOp::Delete);
+        assert_eq!(s.fib_kernel_dir.load(Relaxed), 0);
+    }
+
+    #[test]
+    fn unknown_tail_ignored() {
+        let s = State::new();
+        s.apply("/bogus", &mut args(&[]), ConfigOp::Set);
+        s.apply("/rib/bogus", &mut args(&[]), ConfigOp::Set);
+        // No panic, nothing toggled.
+        assert!(!s.on(&s.rib_route));
+    }
+}


### PR DESCRIPTION
## Summary

Wires the merged `system tracing { rib {} fib {} }` schema to real behavior by replacing the four compile-time `const DEBUG_*: bool = false` flags that used to gate RIB/FIB diagnostic traces (you had to edit source + rebuild to toggle them) with runtime, config-driven checks. Plus the book page documenting it.

### Flag → category mapping

| Old `const` flag | Trace sites | → runtime reader (by context) |
|---|---|---|
| `DEBUG_V6` (3 duplicated copies) | v6 route add/resolve, nexthop | `rib_route` / `rib_nexthop` / `fib_route` / `fib_nexthop` |
| `DEBUG_ADDR` | addr reinstall/recover, link up/down, MTU | `rib_interface` (+ one v6 route-del error → `fib_route`) |
| `DEBUG_SID` | SRv6 SID install / resolve | `rib_srv6` / `fib_srv6` |
| `DEBUG_EVPN` | vxlan reg, mac/fdb, mdb (+ 1 BGP VNI site) | `fib_l2_vxlan` / `fib_l2_fdb` / `fib_l2_mdb` |

### Design

- New `rib::tracing` module: a **process-global block of `AtomicBool`s** — the honest successor to the const globals, since the trace sites span `Rib` methods, free functions in `rib::route`/`nexthop`, and `FibHandle` methods with no shared `self` (the same reason the `tracing` crate's own subscriber is global). `config_dispatch` parses `/system/tracing/*` on commit, wired into `Rib::process_cm_msg`. Reads are lock-free `Relaxed` loads on the route/nexthop hot path.
- The parsing core (`State::apply`) is factored out so it's unit-testable on a local `State` (the global itself can't be tested in parallel).
- **Default behavior is unchanged** — the atomics initialise `false`, exactly like the old consts.
- **Error-level `warn!` sites stay unconditional** — a category gates only the verbose `info`/`debug` traces beside them. Removing a category never hides a real failure.
- All six `const DEBUG_*` definitions removed.

### Note on the one BGP site

`bgp/route.rs`'s `extract_vni_from_attr` shared `DEBUG_EVPN` and already reached into `crate::rib::route` for it; it now points at `crate::rib::tracing::fib_l2_fdb()`, preserving the existing coupling direction while killing the const.

### Docs

New **RIB/FIB Tracing** page (`ch-03-06`) under Logging and Monitoring, aligned to the BGP tracing page. Includes an honest *instrumented vs reserved* callout: only `rib {route,nexthop,interface,srv6}` and `fib {route,nexthop,srv6,l2(vxlan/fdb/mdb)}` emit today; the remaining leaves are accepted/stored and covered by `all` until their sites are instrumented.

## Test plan

- `cargo build -p zebra-rs` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo fmt --all --check` ✅
- `cargo test -p zebra-rs tracing` — 31 pass (BGP + 5 new `rib::tracing` unit tests covering set/delete, detail-implies-enabled, `all` master switch, kernel direction parse, unknown-tail) ✅
- `cargo test -p zebra-rs yang_load_tests` ✅
- `mdbook build` ✅

Generated with [Claude Code](https://claude.com/claude-code)