### PR TITLE
isis: migrate tracing to a dedicated module (OSPF/BGP model)

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -10,9 +10,8 @@ use crate::config::{Args, ConfigOp};
 
 use super::Isis;
 use super::ifsm::has_level;
-use super::inst::{Callback, Message};
+use super::inst::Message;
 use super::link::Afis;
-use super::tracing::{PacketConfig, PacketDirection};
 use super::{Level, link};
 
 use isis_packet::IsisLspId;
@@ -44,13 +43,6 @@ impl MtId {
 }
 
 impl Isis {
-    const TRACING: &str = "/router/isis/tracing";
-
-    pub fn tracing_add(&mut self, path: &str, cb: Callback) {
-        self.callbacks
-            .insert(format!("{}{}", Self::TRACING, path), cb);
-    }
-
     pub fn callback_build(&mut self) {
         self.callback_add("/router/isis/net", config_net);
         self.callback_add("/router/isis/is-type", config_is_type);
@@ -254,11 +246,6 @@ impl Isis {
             link::config_mt_metric,
         );
         self.callback_add("/router/isis/interface/priority", link::config_priority);
-        self.tracing_add("/event", config_tracing_event);
-        self.tracing_add("/fsm", config_tracing_fsm);
-        self.tracing_add("/packet", config_tracing_packet);
-        self.tracing_add("/packet/direction", config_tracing_packet);
-        self.tracing_add("/database", config_tracing_database);
         self.callback_add(
             "/router/isis/interface/circuit-type",
             link::config_circuit_type,
@@ -1805,115 +1792,6 @@ fn config_te_router_id(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<
     } else {
         isis.config.te_router_id = None;
     }
-    Some(())
-}
-
-fn config_tracing_event(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
-    let ev = args.string()?;
-
-    match ev.as_str() {
-        "dis" => {
-            isis.tracing.event.dis.enabled = op.is_set();
-        }
-        "lsp-originate" => {
-            isis.tracing.event.lsp_originate.enabled = op.is_set();
-        }
-        _ => {
-            if op.is_set() {
-                // println!("Trace on {} (not implemented)", ev);
-            } else {
-                //println!("Trace off {} (not implemented)", ev);
-            }
-        }
-    }
-
-    Some(())
-}
-
-fn config_tracing_fsm(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
-    let typ = args.string()?;
-
-    match typ.as_str() {
-        "nfsm" => {
-            isis.tracing.fsm.nfsm.enabled = op.is_set();
-        }
-        "ifsm" => {
-            isis.tracing.fsm.ifsm.enabled = op.is_set();
-        }
-        _ => {
-            //
-        }
-    }
-
-    Some(())
-}
-
-fn parse_direction(args: &mut Args) -> PacketDirection {
-    match args.string().as_deref() {
-        Some("send") => PacketDirection::Send,
-        Some("recv") | Some("receive") => PacketDirection::Recv,
-        Some("both") | None => PacketDirection::Both,
-        Some(_) => PacketDirection::Both,
-    }
-}
-
-fn set_packet_config(config: &mut PacketConfig, op: ConfigOp, direction: PacketDirection) {
-    if op.is_set() {
-        config.enabled = true;
-        config.direction = direction;
-    } else {
-        config.enabled = false;
-        config.direction = PacketDirection::Both;
-    }
-}
-
-fn config_tracing_packet(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
-    let typ = args.string()?;
-    let direction = parse_direction(&mut args);
-
-    match typ.as_str() {
-        "all" => {
-            set_packet_config(&mut isis.tracing.packet.hello, op, direction);
-            set_packet_config(&mut isis.tracing.packet.lsp, op, direction);
-            set_packet_config(&mut isis.tracing.packet.csnp, op, direction);
-            set_packet_config(&mut isis.tracing.packet.psnp, op, direction);
-        }
-        "hello" => {
-            set_packet_config(&mut isis.tracing.packet.hello, op, direction);
-        }
-        "lsp" => {
-            set_packet_config(&mut isis.tracing.packet.lsp, op, direction);
-        }
-        "csnp" => {
-            set_packet_config(&mut isis.tracing.packet.csnp, op, direction);
-        }
-        "psnp" => {
-            set_packet_config(&mut isis.tracing.packet.psnp, op, direction);
-        }
-        _ => {
-            println!("Unknown packet type: {}", typ);
-        }
-    }
-
-    Some(())
-}
-
-fn config_tracing_database(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
-    let ev = args.string()?;
-
-    match ev.as_str() {
-        "lsdb" => {
-            isis.tracing.database.lsdb.enabled = op.is_set();
-        }
-        _ => {
-            if op.is_set() {
-                println!("Trace on {} (not implemented)", ev);
-            } else {
-                println!("Trace off {} (not implemented)", ev);
-            }
-        }
-    }
-
     Some(())
 }
 

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -528,7 +528,7 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
     }
 
     // Logging.
-    if link.tracing.fsm.nfsm.enabled {
+    if link.tracing.should_trace_fsm() {
         tracing::info!(
             "[NBR] DIS selection on {} up neighbor count {}",
             link.ifindex,
@@ -565,7 +565,7 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
         // path in hello_recv re-fires DisSelection once lan_id arrives,
         // and that run will complete the transition cleanly.
         if nbr.lan_id.is_empty() {
-            if link.tracing.fsm.nfsm.enabled {
+            if link.tracing.should_trace_fsm() {
                 tracing::info!(
                     "[NBR] DIS election: {} elected but LAN ID not yet known, deferring transition",
                     nbr.sys_id
@@ -593,7 +593,7 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
         (DisStatus::Myself, sys_id, None, reason)
     };
 
-    if link.tracing.fsm.nfsm.enabled {
+    if link.tracing.should_trace_fsm() {
         tracing::info!(
             "[NBR] DIS selection {:?} -> {:?} {}",
             old_status,
@@ -631,7 +631,7 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
             }
             DisStatus::Other => {
                 use IfsmEvent::*;
-                if link.tracing.fsm.nfsm.enabled {
+                if link.tracing.should_trace_fsm() {
                     tracing::info!(
                         "[NBR] Adjacency {:?} LAN ID {}",
                         link.state.adj.get(&level),
@@ -641,7 +641,7 @@ pub fn dis_selection(link: &mut LinkTop, level: Level) {
                 if link.state.adj.get(&level).is_none()
                     && let Some(lan_id) = lan_id
                 {
-                    if link.tracing.fsm.nfsm.enabled {
+                    if link.tracing.should_trace_fsm() {
                         tracing::info!("[NBR] Adjacency set {}", lan_id);
                     }
                     *link.state.adj.get_mut(&level) = Some((lan_id, None));

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -854,6 +854,12 @@ impl Isis {
 
         if let Some(f) = self.callbacks.get(&path) {
             f(self, args, msg.op);
+        } else if path.starts_with("/router/isis/tracing") {
+            // `/router/isis/tracing/...` is not in the callback table —
+            // its category names are YANG presence containers, so a
+            // single subtree dispatcher parses the path tail (mirrors
+            // OSPF's `config_tracing_dispatch`).
+            super::tracing::config_tracing_dispatch(self, &path, args, msg.op);
         }
     }
 

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -302,7 +302,7 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
         ));
 
     // Logging.
-    if link.tracing.fsm.nfsm.enabled {
+    if link.tracing.should_trace_fsm() {
         if nbr.created {
             tracing::info!(
                 "[NBR] {} Created on {} state {}",
@@ -404,7 +404,7 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
         // system and the source of the PDU (R) is two-way. However R shall be
         // included in future Level n LAN IIH PDUs transmitted by this system.
         state = NfsmState::Init;
-        if link.tracing.fsm.nfsm.enabled {
+        if link.tracing.should_trace_fsm() {
             tracing::info!("[NBR] {} Down -> Init", nbr.sys_id);
         }
         nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
@@ -417,7 +417,7 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
         // e) generate an adjacencyStateChange (Up)” event.
         if has_mac {
             state = NfsmState::Up;
-            if link.tracing.fsm.nfsm.enabled {
+            if link.tracing.should_trace_fsm() {
                 tracing::info!("[NBR] {} Init -> Up", nbr.sys_id);
             }
             // XXX Adjacency(Up)
@@ -438,7 +438,7 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
         // b) generate an adjacencyStateChange (Down) event.
         if !has_mac {
             state = NfsmState::Init;
-            if link.tracing.fsm.nfsm.enabled {
+            if link.tracing.should_trace_fsm() {
                 tracing::info!("[NBR] {} {} -> Init", nbr.sys_id, nbr.state);
             }
             // XXX Adjacency(Down)
@@ -455,7 +455,7 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
     // election will transition to Other and register the adjacency
     // through the normal path (no inline state mutation here).
     if nbr.is_dis() && !nbr.lan_id.is_empty() && link.state.adj.get(&level).is_none() {
-        if link.tracing.fsm.nfsm.enabled {
+        if link.tracing.should_trace_fsm() {
             tracing::info!(
                 "[NBR] Late LAN ID {} from elected DIS {} - re-running DIS selection",
                 nbr.lan_id,
@@ -617,7 +617,7 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
             state = NfsmState::Up;
 
             // Set adjacency.
-            if link.tracing.fsm.nfsm.enabled {
+            if link.tracing.should_trace_fsm() {
                 tracing::info!("[NBR] Adjacency set {}", nbr.sys_id);
             }
             *link.state.adj.get_mut(&level) =
@@ -639,7 +639,7 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
         // peer comes back (labels and End.X SID stay allocated).
         if state == NfsmState::Up && !has_my_sys_id {
             state = NfsmState::Init;
-            if link.tracing.fsm.nfsm.enabled {
+            if link.tracing.should_trace_fsm() {
                 tracing::info!(
                     "[NBR] {} Up -> Init (peer no longer reports our sys-id)",
                     nbr.sys_id

--- a/zebra-rs/src/isis/tracing.rs
+++ b/zebra-rs/src/isis/tracing.rs
@@ -1,43 +1,50 @@
-/// ISIS-specific conditional tracing system
-///
-/// This module provides a comprehensive conditional tracing system for ISIS protocol
-/// that maps to YANG configuration options. It includes structures for fine-grained
-/// control over packet, event, FSM, database, and segment routing tracing.
+//! IS-IS conditional tracing — consistent with OSPF (`zebra-ospf-tracing`)
+//! and BGP (`zebra-bgp-tracing`).
+//!
+//! The `router isis tracing { ... }` config tree (defined in
+//! `zebra-isis-tracing.yang`) is written through `config_tracing_dispatch`
+//! into the typed [`IsisTracing`] block held on the instance; gated log
+//! macros consult it via the `should_trace_*` methods, so categories can
+//! be turned on at runtime without a rebuild.
+//!
+//! The schema mirrors the OSPF model (presence containers, an `all`
+//! master switch, per-PDU `direction` refinement) with one IS-IS-specific
+//! addition: a functional `level` filter (level-1 / level-2) on the packet
+//! and event categories.
+use super::Isis;
 use super::level::Level;
+use crate::config::{Args, ConfigOp};
 
-/// Main ISIS tracing configuration structure
-#[derive(Debug, Clone, Default)]
-pub struct IsisTracing {
-    /// Packet tracing configuration
-    pub packet: PacketTracing,
-    /// Event tracing configuration
-    pub event: EventTracing,
-    /// FSM tracing configuration
-    pub fsm: FsmTracing,
-    /// Database tracing configuration
-    pub database: DatabaseTracing,
+// ============================================================
+// Tracing categories
+// ============================================================
+
+/// IS-IS level filter for per-category tracing. The YANG `level` leaf
+/// omitted means both levels, so `Both` is the default.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum TracingLevel {
+    #[default]
+    Both,
+    L1,
+    L2,
 }
 
-/// Packet tracing configuration
-#[derive(Debug, Clone, Default)]
-pub struct PacketTracing {
-    pub hello: PacketConfig,
-    pub lsp: PacketConfig,
-    pub csnp: PacketConfig,
-    pub psnp: PacketConfig,
-    pub all: bool,
+impl TracingLevel {
+    /// Whether an event at `actual` level passes this filter. `Both`
+    /// matches either level.
+    fn matches(self, actual: &Level) -> bool {
+        match self {
+            TracingLevel::Both => true,
+            TracingLevel::L1 => matches!(actual, Level::L1),
+            TracingLevel::L2 => matches!(actual, Level::L2),
+        }
+    }
 }
 
-/// Individual packet type configuration
-#[derive(Debug, Clone, Default)]
-pub struct PacketConfig {
-    pub enabled: bool,
-    pub direction: PacketDirection,
-    pub level: TracingLevel,
-}
-
-/// Packet direction filter
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+/// Direction filter for per-PDU-type tracing. The YANG `direction` leaf
+/// omitted means both, so `Both` is the default. Variant names match the
+/// `#[isis_pdu_handler]` proc-macro's accepted set (Send / Recv / Both).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum PacketDirection {
     Send,
     Recv,
@@ -53,60 +60,17 @@ impl PacketDirection {
             PacketDirection::Both => "Both",
         }
     }
+
+    /// Whether a PDU flowing in `actual` direction passes this filter.
+    /// `Both` matches either direction.
+    fn matches(self, actual: PacketDirection) -> bool {
+        self == PacketDirection::Both || self == actual
+    }
 }
 
-/// Event tracing configuration
-#[derive(Debug, Clone, Default)]
-pub struct EventTracing {
-    pub dis: EventConfig,
-    pub lsp_originate: EventConfig,
-    pub lsp_purge: EventConfig,
-    pub all: bool,
-}
-
-/// Individual event type configuration
-#[derive(Debug, Clone, Default)]
-pub struct EventConfig {
-    pub enabled: bool,
-    pub level: TracingLevel,
-}
-
-/// FSM tracing configuration
-#[derive(Debug, Clone, Default)]
-pub struct FsmTracing {
-    pub ifsm: FsmConfig,
-    pub nfsm: FsmConfig,
-}
-
-/// Individual FSM type configuration
-#[derive(Debug, Clone, Default)]
-pub struct FsmConfig {
-    pub enabled: bool,
-}
-
-/// Database tracing configuration
-#[derive(Debug, Clone, Default)]
-pub struct DatabaseTracing {
-    pub lsdb: DatabaseConfig,
-    pub all: bool,
-}
-
-/// Individual database type configuration
-#[derive(Debug, Clone, Default)]
-pub struct DatabaseConfig {
-    pub enabled: bool,
-    pub level: TracingLevel,
-}
-
-/// Tracing level filter
-#[derive(Debug, Clone, Default, PartialEq)]
-pub enum TracingLevel {
-    #[default]
-    Both,
-}
-
-/// Packet type enumeration
-#[derive(Debug, Clone, Copy, PartialEq)]
+/// IS-IS PDU type. Variant names match the `#[isis_pdu_handler]`
+/// proc-macro's accepted set (Hello / Lsp / Csnp / Psnp).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PacketType {
     Hello,
     Lsp,
@@ -125,93 +89,297 @@ impl PacketType {
     }
 }
 
-/// Event type enumeration
-#[derive(Debug, Clone, PartialEq)]
+/// IS-IS event category, selected at an event trace site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EventType {
     LspOriginate,
     LspPurge,
 }
 
-/// Database type enumeration
-#[derive(Debug, Clone, PartialEq)]
+/// IS-IS database category, selected at a database trace site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DatabaseType {
     Lsdb,
 }
 
+/// Per-PDU-type tracing toggle. `enabled` is the presence of the
+/// `packet <type>` container; `direction` and `level` are its optional
+/// refinements.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PacketConfig {
+    pub enabled: bool,
+    pub direction: PacketDirection,
+    pub level: TracingLevel,
+}
+
+/// Per-PDU-type tracing block. `all` is a catch-all applied on top of the
+/// individual per-type toggles.
+#[derive(Debug, Clone, Default)]
+pub struct PacketTracing {
+    pub all: PacketConfig,
+    pub hello: PacketConfig,
+    pub lsp: PacketConfig,
+    pub csnp: PacketConfig,
+    pub psnp: PacketConfig,
+}
+
+impl PacketTracing {
+    /// Resolve a `&mut PacketConfig` by its YANG node name. `None` for an
+    /// unknown name (only reachable on a malformed path — the YANG
+    /// presence containers constrain the set).
+    fn get_mut(&mut self, name: &str) -> Option<&mut PacketConfig> {
+        Some(match name {
+            "all" => &mut self.all,
+            "hello" => &mut self.hello,
+            "lsp" => &mut self.lsp,
+            "csnp" => &mut self.csnp,
+            "psnp" => &mut self.psnp,
+            _ => return None,
+        })
+    }
+}
+
+/// Per-FSM tracing toggle.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FsmConfig {
+    pub enabled: bool,
+}
+
+/// FSM tracing block. Only the neighbor (adjacency) FSM has trace sites
+/// today; the interface FSM toggle lands here when it grows one.
+#[derive(Debug, Clone, Default)]
+pub struct FsmTracing {
+    pub nfsm: FsmConfig,
+}
+
+/// Per-event / per-database tracing toggle. `enabled` is the presence of
+/// the category container; `level` is its optional refinement.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EventConfig {
+    pub enabled: bool,
+    pub level: TracingLevel,
+}
+
+/// Conditional IS-IS tracing configuration. One instance lives on each
+/// `Isis`; links borrow it as `&IsisTracing`.
+#[derive(Debug, Clone, Default)]
+pub struct IsisTracing {
+    /// Master switch — when set, every category is traced regardless of
+    /// its individual toggle.
+    pub all: bool,
+    pub packet: PacketTracing,
+    pub fsm: FsmTracing,
+    pub lsp_originate: EventConfig,
+    pub lsp_purge: EventConfig,
+    pub lsdb: EventConfig,
+}
+
 impl IsisTracing {
-    /// Check if packet tracing should be enabled for given parameters
-    pub fn should_trace_packet(
-        &self,
-        packet_type: PacketType,
-        direction: PacketDirection,
-        _level: &Level,
-    ) -> bool {
-        if !self.packet.all {
-            let config = match packet_type {
-                PacketType::Hello => &self.packet.hello,
-                PacketType::Lsp => &self.packet.lsp,
-                PacketType::Csnp => &self.packet.csnp,
-                PacketType::Psnp => &self.packet.psnp,
-            };
-
-            if !config.enabled {
-                return false;
-            }
-
-            // Check direction filter
-            if config.direction != PacketDirection::Both && config.direction != direction {
-                return false;
-            }
-
-            // Check level filter
-            match config.level {
-                TracingLevel::Both => true,
-            }
-        } else {
-            true
+    fn packet_cfg(&self, ty: PacketType) -> &PacketConfig {
+        match ty {
+            PacketType::Hello => &self.packet.hello,
+            PacketType::Lsp => &self.packet.lsp,
+            PacketType::Csnp => &self.packet.csnp,
+            PacketType::Psnp => &self.packet.psnp,
         }
     }
 
-    /// Check if event tracing should be enabled for given parameters
-    pub fn should_trace_event(&self, event_type: EventType, _level: &Level) -> bool {
-        if !self.event.all {
-            let config = match event_type {
-                EventType::LspOriginate => &self.event.lsp_originate,
-                EventType::LspPurge => &self.event.lsp_purge,
-            };
+    /// Whether a `ty` PDU in `dir` at `level` should be traced. The `all`
+    /// master switch and the `packet all` catch-all both apply on top of
+    /// the per-type toggle.
+    pub fn should_trace_packet(&self, ty: PacketType, dir: PacketDirection, level: &Level) -> bool {
+        if self.all {
+            return true;
+        }
+        let cfg = self.packet_cfg(ty);
+        let all = &self.packet.all;
+        (all.enabled && all.direction.matches(dir) && all.level.matches(level))
+            || (cfg.enabled && cfg.direction.matches(dir) && cfg.level.matches(level))
+    }
 
-            if !config.enabled {
-                return false;
-            }
+    /// Whether neighbor (adjacency) FSM transitions should be traced. The
+    /// `all` master switch applies on top of the `fsm nfsm` toggle.
+    pub fn should_trace_fsm(&self) -> bool {
+        self.all || self.fsm.nfsm.enabled
+    }
 
-            // Check level filter
-            match config.level {
-                TracingLevel::Both => true,
-            }
-        } else {
-            true
+    fn event_cfg(&self, ty: EventType) -> &EventConfig {
+        match ty {
+            EventType::LspOriginate => &self.lsp_originate,
+            EventType::LspPurge => &self.lsp_purge,
         }
     }
 
-    /// Check if database tracing should be enabled for given parameters
-    pub fn should_trace_database(&self, db_type: DatabaseType, _level: &Level) -> bool {
-        if !self.database.all {
-            let config = match db_type {
-                DatabaseType::Lsdb => &self.database.lsdb,
-            };
+    /// Whether an event of `ty` at `level` should be traced.
+    pub fn should_trace_event(&self, ty: EventType, level: &Level) -> bool {
+        if self.all {
+            return true;
+        }
+        let cfg = self.event_cfg(ty);
+        cfg.enabled && cfg.level.matches(level)
+    }
 
-            if !config.enabled {
-                return false;
-            }
+    /// Whether a database event of `ty` at `level` should be traced.
+    pub fn should_trace_database(&self, ty: DatabaseType, level: &Level) -> bool {
+        if self.all {
+            return true;
+        }
+        let cfg = match ty {
+            DatabaseType::Lsdb => &self.lsdb,
+        };
+        cfg.enabled && cfg.level.matches(level)
+    }
+}
 
-            // Check level filter
-            match config.level {
-                TracingLevel::Both => true,
+// ============================================================
+// Config dispatch
+// ============================================================
+
+fn parse_direction(args: &mut Args) -> PacketDirection {
+    match args.string().as_deref() {
+        Some("send") => PacketDirection::Send,
+        Some("receive") | Some("recv") => PacketDirection::Recv,
+        // Absent or any other token (incl. an explicit "both") means
+        // trace both directions.
+        _ => PacketDirection::Both,
+    }
+}
+
+fn parse_level(args: &mut Args) -> TracingLevel {
+    match args.string().as_deref() {
+        Some("level-1") => TracingLevel::L1,
+        Some("level-2") => TracingLevel::L2,
+        // Absent or any other token means trace both levels.
+        _ => TracingLevel::Both,
+    }
+}
+
+/// `tracing packet <type>` — bare presence enables the type; delete
+/// clears the whole toggle (including any direction / level).
+fn packet_set_enable(pc: &mut PacketConfig, op: ConfigOp) {
+    if op.is_set() {
+        pc.enabled = true;
+    } else {
+        *pc = PacketConfig::default();
+    }
+}
+
+/// `tracing packet <type> direction {send|receive}` — restrict the
+/// direction (and enable the type); delete reverts to both directions.
+fn packet_set_direction(pc: &mut PacketConfig, args: &mut Args, op: ConfigOp) {
+    if op.is_set() {
+        pc.enabled = true;
+        pc.direction = parse_direction(args);
+    } else {
+        pc.direction = PacketDirection::Both;
+    }
+}
+
+/// `tracing packet <type> level {level-1|level-2}` — restrict the level
+/// (and enable the type); delete reverts to both levels.
+fn packet_set_level(pc: &mut PacketConfig, args: &mut Args, op: ConfigOp) {
+    if op.is_set() {
+        pc.enabled = true;
+        pc.level = parse_level(args);
+    } else {
+        pc.level = TracingLevel::Both;
+    }
+}
+
+/// `tracing fsm nfsm` — bare presence enables; delete clears.
+fn fsm_set_enable(fc: &mut FsmConfig, op: ConfigOp) {
+    fc.enabled = op.is_set();
+}
+
+/// `tracing <event>` — bare presence enables; delete clears the whole
+/// toggle (including any level).
+fn event_set_enable(ec: &mut EventConfig, op: ConfigOp) {
+    if op.is_set() {
+        ec.enabled = true;
+    } else {
+        *ec = EventConfig::default();
+    }
+}
+
+/// `tracing <event> level {level-1|level-2}` — restrict the level (and
+/// enable the event); delete reverts to both levels.
+fn event_set_level(ec: &mut EventConfig, args: &mut Args, op: ConfigOp) {
+    if op.is_set() {
+        ec.enabled = true;
+        ec.level = parse_level(args);
+    } else {
+        ec.level = TracingLevel::Both;
+    }
+}
+
+/// Apply one committed `…/tracing/<rest>` config line to an
+/// `IsisTracing`. `rest` is the path tail after the `tracing` node
+/// (e.g. `/all`, `/packet/hello`, `/packet/hello/direction`,
+/// `/packet/lsp/level`, `/fsm/nfsm`, `/lsp-originate`,
+/// `/lsdb/level`); for the direction / level cases `args` still holds the
+/// trailing value.
+fn apply_tracing(t: &mut IsisTracing, rest: &str, args: &mut Args, op: ConfigOp) -> Option<()> {
+    match rest {
+        "/all" => t.all = op.is_set(),
+        other => {
+            if let Some(pkt) = other.strip_prefix("/packet/") {
+                let (typ, sub) = match pkt.split_once('/') {
+                    Some((typ, sub)) => (typ, Some(sub)),
+                    None => (pkt, None),
+                };
+                let pc = t.packet.get_mut(typ)?;
+                match sub {
+                    None => packet_set_enable(pc, op),
+                    Some("direction") => packet_set_direction(pc, args, op),
+                    Some("level") => packet_set_level(pc, args, op),
+                    Some(_) => return None,
+                }
+            } else if let Some(fsm) = other.strip_prefix("/fsm/") {
+                // FSM types are bare presence containers (no sub-leaves).
+                match fsm {
+                    "nfsm" => fsm_set_enable(&mut t.fsm.nfsm, op),
+                    _ => return None,
+                }
+            } else if let Some(ev) = other.strip_prefix('/') {
+                let (name, sub) = match ev.split_once('/') {
+                    Some((name, sub)) => (name, Some(sub)),
+                    None => (ev, None),
+                };
+                let ec = match name {
+                    "lsp-originate" => &mut t.lsp_originate,
+                    "lsp-purge" => &mut t.lsp_purge,
+                    "lsdb" => &mut t.lsdb,
+                    _ => return None,
+                };
+                match sub {
+                    None => event_set_enable(ec, op),
+                    Some("level") => event_set_level(ec, args, op),
+                    Some(_) => return None,
+                }
+            } else {
+                return None;
             }
-        } else {
-            true
         }
     }
+    Some(())
+}
+
+/// Dispatch a committed `/router/isis/tracing/…` Set/Delete path to this
+/// instance's `IsisTracing` and apply it.
+///
+/// Called from `Isis::process_cm_msg` for paths the regular callback
+/// table does not claim. The per-category names are YANG presence
+/// containers (not list keys), so the category lives in the *path*, not in
+/// `args`; a single parser handles the whole subtree. Returns `None`
+/// (ignored) for non-tracing paths and malformed tails.
+pub fn config_tracing_dispatch(
+    isis: &mut Isis,
+    path: &str,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let rest = path.strip_prefix("/router/isis/tracing")?;
+    apply_tracing(&mut isis.tracing, rest, &mut args, op)
 }
 
 /// Log an info-level message with proto="isis" field
@@ -313,28 +481,9 @@ macro_rules! isis_database_trace {
     };
 }
 
-/// Macro to define a packet receive handler with automatic tracing context.
-/// This creates local constants for packet type and direction that can be used
-/// with `isis_pkt_trace!` macro.
-///
-/// Usage:
-/// ```ignore
-/// isis_pdu_handler!(Hello, Recv);
-/// // Now use isis_pkt_trace! instead of isis_packet_trace!
-/// isis_pkt_trace!(top.tracing, &level, "[Hello] recv on {}", link.state.name);
-/// ```
-#[macro_export]
-macro_rules! isis_pdu_handler {
-    ($packet_type:ident, $direction:ident) => {
-        const _ISIS_PKT_TYPE: $crate::isis::tracing::PacketType =
-            $crate::isis::tracing::PacketType::$packet_type;
-        const _ISIS_PKT_DIR: $crate::isis::tracing::PacketDirection =
-            $crate::isis::tracing::PacketDirection::$direction;
-    };
-}
-
-/// Simplified packet tracing macro that uses the context defined by `isis_pdu_handler!`.
-/// Must be used after `isis_pdu_handler!` in the same scope.
+/// Simplified packet tracing macro that uses the context defined by the
+/// `#[isis_pdu_handler]` proc-macro (`_ISIS_PKT_TYPE` / `_ISIS_PKT_DIR`).
+/// Must be used in a function carrying that attribute.
 #[macro_export]
 macro_rules! isis_pkt_trace {
     ($tracing:expr, $level:expr, $($arg:tt)*) => {
@@ -351,8 +500,8 @@ macro_rules! isis_pkt_trace {
     };
 }
 
-/// Simplified packet tracing macro that uses the context defined by `isis_pdu_handler!`.
-/// Must be used after `isis_pdu_handler!` in the same scope.
+/// Like `isis_pkt_trace!` but reaches the tracing block through the
+/// `.tracing` field of `$tracing` (e.g. a link state).
 #[macro_export]
 macro_rules! isis_pdu_trace {
     ($tracing:expr, $level:expr, $($arg:tt)*) => {
@@ -367,4 +516,110 @@ macro_rules! isis_pdu_trace {
             )
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(items: &[&str]) -> Args {
+        Args(items.iter().map(|s| s.to_string()).collect())
+    }
+
+    #[test]
+    fn master_all_traces_everything() {
+        let mut t = IsisTracing::default();
+        apply_tracing(&mut t, "/all", &mut args(&[]), ConfigOp::Set);
+        assert!(t.all);
+        assert!(t.should_trace_packet(PacketType::Hello, PacketDirection::Send, &Level::L1));
+        assert!(t.should_trace_fsm());
+        assert!(t.should_trace_event(EventType::LspOriginate, &Level::L2));
+        assert!(t.should_trace_database(DatabaseType::Lsdb, &Level::L1));
+
+        apply_tracing(&mut t, "/all", &mut args(&[]), ConfigOp::Delete);
+        assert!(!t.all);
+        assert!(!t.should_trace_packet(PacketType::Hello, PacketDirection::Send, &Level::L1));
+    }
+
+    #[test]
+    fn packet_direction_and_level_filter() {
+        let mut t = IsisTracing::default();
+        // tracing packet hello direction receive
+        apply_tracing(
+            &mut t,
+            "/packet/hello/direction",
+            &mut args(&["receive"]),
+            ConfigOp::Set,
+        );
+        assert!(t.packet.hello.enabled);
+        assert!(t.should_trace_packet(PacketType::Hello, PacketDirection::Recv, &Level::L1));
+        assert!(!t.should_trace_packet(PacketType::Hello, PacketDirection::Send, &Level::L1));
+        // other PDU types unaffected
+        assert!(!t.should_trace_packet(PacketType::Lsp, PacketDirection::Recv, &Level::L1));
+
+        // tracing packet lsp level level-2
+        apply_tracing(
+            &mut t,
+            "/packet/lsp/level",
+            &mut args(&["level-2"]),
+            ConfigOp::Set,
+        );
+        assert!(t.should_trace_packet(PacketType::Lsp, PacketDirection::Both, &Level::L2));
+        assert!(!t.should_trace_packet(PacketType::Lsp, PacketDirection::Both, &Level::L1));
+    }
+
+    #[test]
+    fn packet_all_catch_all() {
+        let mut t = IsisTracing::default();
+        apply_tracing(&mut t, "/packet/all", &mut args(&[]), ConfigOp::Set);
+        for ty in [
+            PacketType::Hello,
+            PacketType::Lsp,
+            PacketType::Csnp,
+            PacketType::Psnp,
+        ] {
+            assert!(t.should_trace_packet(ty, PacketDirection::Send, &Level::L1));
+        }
+    }
+
+    #[test]
+    fn fsm_and_event_toggles() {
+        let mut t = IsisTracing::default();
+        assert!(!t.should_trace_fsm());
+        apply_tracing(&mut t, "/fsm/nfsm", &mut args(&[]), ConfigOp::Set);
+        assert!(t.should_trace_fsm());
+        apply_tracing(&mut t, "/fsm/nfsm", &mut args(&[]), ConfigOp::Delete);
+        assert!(!t.should_trace_fsm());
+
+        // event with level filter
+        apply_tracing(
+            &mut t,
+            "/lsp-originate/level",
+            &mut args(&["level-1"]),
+            ConfigOp::Set,
+        );
+        assert!(t.should_trace_event(EventType::LspOriginate, &Level::L1));
+        assert!(!t.should_trace_event(EventType::LspOriginate, &Level::L2));
+        assert!(!t.should_trace_event(EventType::LspPurge, &Level::L1));
+
+        apply_tracing(&mut t, "/lsdb", &mut args(&[]), ConfigOp::Set);
+        assert!(t.should_trace_database(DatabaseType::Lsdb, &Level::L2));
+    }
+
+    #[test]
+    fn unknown_paths_ignored() {
+        let mut t = IsisTracing::default();
+        assert_eq!(
+            apply_tracing(&mut t, "/bogus", &mut args(&[]), ConfigOp::Set),
+            None
+        );
+        assert_eq!(
+            apply_tracing(&mut t, "/packet/bogus", &mut args(&[]), ConfigOp::Set),
+            None
+        );
+        assert_eq!(
+            apply_tracing(&mut t, "/fsm/ifsm", &mut args(&[]), ConfigOp::Set),
+            None
+        );
+    }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -64,6 +64,10 @@ module config {
     prefix zotr;
   }
 
+  import zebra-isis-tracing {
+    prefix zitr;
+  }
+
   import zebra-bgp-color-policy {
     prefix zbcp;
   }
@@ -2043,121 +2047,6 @@ module config {
             // the pattern used by segment-routing `block` and
             // `locator` references above.
             type string;
-          }
-        }
-        container tracing {
-          ext:help "IS-IS debug tracing";
-          leaf all {
-            type boolean;
-            description "Enable all ISIS tracing";
-          }
-
-          list packet {
-            key "type";
-            leaf "type" {
-              type enumeration {
-                enum "hello";
-                enum "lsp";
-                enum "csnp";
-                enum "psnp";
-                enum "all";
-              }
-            }
-            leaf direction {
-              type enumeration {
-                enum "send";
-                enum "receive";
-                enum "both";
-              }
-              default "both";
-              description "Packet direction to trace";
-            }
-            leaf level {
-              type enumeration {
-                enum "level-1";
-                enum "level-2";
-                enum "both";
-              }
-              default "both";
-              description "ISIS level to trace";
-            }
-          }
-
-          list event {
-            key "type";
-            leaf "type" {
-              type enumeration {
-                enum "dis";
-                enum "lsp-originate";
-                enum "lsp-refresh";
-                enum "lsp-purge";
-                enum "spf-calculation";
-                enum "adjacency";
-                enum "flooding";
-                enum "all";
-              }
-            }
-            leaf level {
-              type enumeration {
-                enum "level-1";
-                enum "level-2";
-                enum "both";
-              }
-              default "both";
-              description "ISIS level to trace";
-            }
-          }
-
-          list fsm {
-            key "type";
-            leaf "type" {
-              type enumeration {
-                enum "ifsm";
-                enum "nfsm";
-                enum "all";
-              }
-            }
-            leaf detail {
-              type boolean;
-              default false;
-              description "Enable detailed FSM state transition tracing";
-            }
-          }
-
-          list database {
-            key "type";
-            leaf "type" {
-              type enumeration {
-                enum "lsdb";
-                enum "spf-tree";
-                enum "rib";
-                enum "all";
-              }
-            }
-            leaf level {
-              type enumeration {
-                enum "level-1";
-                enum "level-2";
-                enum "both";
-              }
-              default "both";
-              description "ISIS level to trace";
-            }
-          }
-
-          container segment-routing {
-            leaf enable {
-              type boolean;
-              description "Enable Segment Routing tracing";
-            }
-            leaf prefix-sid {
-              type boolean;
-              description "Trace prefix SID operations";
-            }
-            leaf adjacency-sid {
-              type boolean;
-              description "Trace adjacency SID operations";
-            }
           }
         }
 

--- a/zebra-rs/yang/zebra-isis-tracing.yang
+++ b/zebra-rs/yang/zebra-isis-tracing.yang
@@ -1,0 +1,229 @@
+module zebra-isis-tracing {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-isis-tracing";
+  prefix "zitr";
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "Conditional IS-IS tracing, attachable at the `router isis` instance:
+
+       * `router isis tracing { ... }`
+
+     This mirrors the OSPF / BGP `tracing` model (a typed config block
+     consulted by gated log macros, so categories can be turned on at
+     runtime without a rebuild) with the IS-IS-specific category set: the
+     four PDU types, the neighbor state machine, LSP origination / purge,
+     and the link-state database. The IS-IS-specific addition over the
+     OSPF model is a functional `level` filter (level-1 / level-2) on the
+     packet and event categories.
+
+     Example:
+
+       router isis {
+         tracing {
+           packet {
+             hello { direction receive; }   // received Hellos only
+             lsp   { level level-2; }        // L2 LSPs only
+           }
+           fsm { nfsm; }
+           lsp-originate;
+         }
+       }
+
+     Each category is a presence container — name it to enable, delete it
+     to disable; absence means the category is silent. Enabling by
+     presence (rather than a `true` value) matches OSPF / BGP `tracing`:
+     the config dispatch keys off set vs delete and never reads a value.";
+
+  revision 2026-06-05 {
+    description
+      "Initial revision — `router isis tracing` migrated out of the
+       inline config.yang container into a dedicated augment module on
+       the OSPF / BGP presence-container model. Categories: an `all`
+       master switch, packet {all,hello,lsp,csnp,psnp} (each with
+       optional direction and level), fsm {nfsm}, and the
+       lsp-originate / lsp-purge / lsdb event toggles (each with an
+       optional level). The `level` filter is functional (level-1 /
+       level-2; omit for both). Categories without a trace site in the
+       current code (interface FSM, DIS election) are intentionally
+       omitted rather than exposed as no-op knobs.";
+  }
+
+  grouping isis-tracing-packet-options {
+    description
+      "Optional refinements shared by every per-PDU-type tracing toggle.
+       The enclosing container's presence is what enables tracing for
+       that PDU type; these children only narrow it.";
+
+    leaf direction {
+      ext:help "Restrict tracing to a single direction";
+      type enumeration {
+        enum send {
+          description "Trace only transmitted PDUs.";
+        }
+        enum receive {
+          description "Trace only received PDUs.";
+        }
+      }
+      description
+        "Limit tracing to one direction. Omit to trace both send and
+         receive — there is no explicit `both` value; absence means
+         both.";
+    }
+    leaf level {
+      ext:help "Restrict tracing to a single IS-IS level";
+      type enumeration {
+        enum level-1 {
+          description "Trace only Level-1 PDUs.";
+        }
+        enum level-2 {
+          description "Trace only Level-2 PDUs.";
+        }
+      }
+      description
+        "Limit tracing to one IS-IS level. Omit to trace both levels —
+         there is no explicit `both` value; absence means both.";
+    }
+  }
+
+  grouping isis-tracing-level-options {
+    description
+      "Optional level refinement shared by the event toggles
+       (dis / lsp-originate / lsp-purge / lsdb).";
+
+    leaf level {
+      ext:help "Restrict tracing to a single IS-IS level";
+      type enumeration {
+        enum level-1 {
+          description "Trace only Level-1 events.";
+        }
+        enum level-2 {
+          description "Trace only Level-2 events.";
+        }
+      }
+      description
+        "Limit tracing to one IS-IS level. Omit for both levels.";
+    }
+  }
+
+  grouping isis-tracing-extension {
+    description
+      "The `tracing` block attached to the `router isis` instance.";
+
+    container tracing {
+      ext:help "IS-IS conditional tracing";
+      description
+        "Per-category IS-IS log toggles, applied to this routing
+         instance (every interface and neighbor).";
+
+      leaf all {
+        ext:help "Enable every tracing category";
+        type empty;
+        description
+          "Master switch — when present, every category below is traced
+           regardless of its individual toggle.";
+      }
+
+      container packet {
+        ext:help "Trace IS-IS protocol PDUs";
+        description
+          "Per-PDU-type tracing. Each PDU type is a presence container:
+           naming it (e.g. `tracing packet hello`) enables tracing for
+           that type in both directions and levels, and the `direction`
+           / `level` children refine it. `all` covers every PDU type at
+           once.";
+
+        container all {
+          ext:help "Trace all IS-IS PDU types";
+          presence "Trace every IS-IS PDU type";
+          uses isis-tracing-packet-options;
+        }
+        container hello {
+          ext:help "Trace IIH (Hello) PDUs";
+          presence "Trace Hello PDUs";
+          uses isis-tracing-packet-options;
+        }
+        container lsp {
+          ext:help "Trace Link State PDUs";
+          presence "Trace LSP PDUs";
+          uses isis-tracing-packet-options;
+        }
+        container csnp {
+          ext:help "Trace Complete SNPs";
+          presence "Trace CSNP PDUs";
+          uses isis-tracing-packet-options;
+        }
+        container psnp {
+          ext:help "Trace Partial SNPs";
+          presence "Trace PSNP PDUs";
+          uses isis-tracing-packet-options;
+        }
+      }
+
+      container fsm {
+        ext:help "Trace IS-IS neighbor state machine";
+        description
+          "Neighbor (adjacency) state-machine tracing. `nfsm` is a
+           presence container — naming it (`tracing fsm nfsm`) enables
+           adjacency transition logging. (The interface FSM has no trace
+           sites yet; add an `ifsm` toggle here when it grows one.)";
+
+        container nfsm {
+          ext:help "Trace the neighbor (adjacency) state machine";
+          presence "Trace neighbor FSM transitions";
+        }
+      }
+
+      container lsp-originate {
+        ext:help "Trace LSP origination";
+        presence "Trace self-LSP origination";
+        uses isis-tracing-level-options;
+      }
+      container lsp-purge {
+        ext:help "Trace LSP purge";
+        presence "Trace LSP purge events";
+        uses isis-tracing-level-options;
+      }
+      container lsdb {
+        ext:help "Trace the link-state database";
+        presence "Trace LSDB install / flooding decisions";
+        uses isis-tracing-level-options;
+      }
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router/config:isis" {
+    description
+      "`router isis tracing` in the candidate-set subtree.";
+    uses isis-tracing-extension;
+  }
+
+  augment "/configure:delete/config:router/config:isis" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router isis tracing ...` is path-valid.";
+    uses isis-tracing-extension;
+  }
+}


### PR DESCRIPTION
## Summary

IS-IS was the lone protocol whose `tracing` config lived inline in
`config.yang`, while OSPF, BGP, and RIB each have a dedicated
`zebra-<proto>-tracing.yang` augment built on a presence-container schema +
a subtree dispatcher + a typed `*Tracing` struct gated by `should_trace_*`.
The inline IS-IS container had also drifted: a top-level `all` with no
handler, a `level` filter that never filtered (`TracingLevel` had only a
`Both` variant), `fsm detail`, several unused `event`/`database` enum
values, and a whole `segment-routing {…}` block — all config knobs that
validated but did nothing.

This PR replaces the inline container with `zebra-isis-tracing.yang`,
mirroring the OSPF model and keeping **one IS-IS-specific extension**: a
*functional* `level` filter (level-1/level-2) on the packet and event
categories. Dispatch now runs through `tracing::config_tracing_dispatch`
(called from `Isis::process_cm_msg` for the `/router/isis/tracing`
subtree), replacing the per-leaf `tracing_add()` callback registrations.

### Honest pruning (no more no-op knobs)
Only categories backed by a real trace site are exposed:
- `packet {all,hello,lsp,csnp,psnp}` — with `direction` + functional `level`
- `fsm {nfsm}` — the only FSM with trace sites
- `lsp-originate` / `lsp-purge` / `lsdb` — with functional `level`

The interface-FSM and DIS-election toggles were **dropped** because no
code consults them (their only "reads" were the config setters this PR
deletes); keeping them would re-create the drift this change removes. A
new `all` master switch is wired through `should_trace_*`.

### CLI change (operator debug toggle only)
List-keyed → presence-container, matching OSPF/BGP. No persistent routing
state is affected.

```
# before
router isis tracing { packet hello { direction receive; } }
# after
router isis tracing { packet { hello { direction receive; level level-2; } } }
```

The 12 direct `link.tracing.fsm.nfsm.enabled` reads become
`should_trace_fsm()` so the master switch applies.

## Test plan
- `cargo build` ✅, `cargo clippy --workspace --all-targets -- -D warnings` → exit 0 ✅
- `cargo fmt --all` ✅
- 5 new `isis::tracing` unit tests (master-all, packet direction+level,
  packet-all catch-all, fsm, event level filter, unknown-path rejection) ✅
- `yang_load` tests pass with **no augment warnings** — the new module
  attaches cleanly to `config:isis` ✅
- No BDD features / example configs use the old syntax (nothing to migrate) ✅
- CI is source of truth for the full suite.

Note: `docs/design/bgp-tracing-plan.md` still describes the old
`IsisTracing` shape as BGP's reference template; left as a historical
design record.

Generated with [Claude Code](https://claude.com/claude-code)