### PR TITLE
isis: BFD over IPv6 with hold-down gate and Echo

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -62,6 +62,25 @@ isis_hello_auth_keychain:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_hello_auth_keychain"
 
+# IS-IS BFD over IPv6. The `_echo` targets exercise the Echo scenarios, which
+# require the IPv6 `xdp-bfd-echo` dataplane helper (built out-of-workspace) and
+# XDP-capable namespaces; the plain targets run only the no-echo scenario.
+isis_bfd_ipv6_p2p:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv6_p2p and not @bfd_echo"
+
+isis_bfd_ipv6_p2p_echo:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv6_p2p and @bfd_echo"
+
+isis_bfd_ipv6_lan:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv6_lan and not @bfd_echo"
+
+isis_bfd_ipv6_lan_echo:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv6_lan and @bfd_echo"
+
 ospf_clear_neighbor:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@ospf_clear_neighbor"
@@ -109,4 +128,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain ospf_clear_neighbor bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo ospf_clear_neighbor bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE

--- a/bdd/tests/configs/isis_bfd_ipv6_lan/z1-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_lan/z1-echo-both.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::1/128
+- if-name: vz1ns
+  ipv6:
+    address: 2001:db8:1::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+    - if-name: vz1ns
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+      bfd:
+        enable: true
+        echo-mode: both

--- a/bdd/tests/configs/isis_bfd_ipv6_lan/z1-echo-tx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_lan/z1-echo-tx.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::1/128
+- if-name: vz1ns
+  ipv6:
+    address: 2001:db8:1::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+    - if-name: vz1ns
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+      bfd:
+        enable: true
+        echo-mode: transmit

--- a/bdd/tests/configs/isis_bfd_ipv6_lan/z1-noecho.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_lan/z1-noecho.yaml
@@ -1,0 +1,23 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::1/128
+- if-name: vz1ns
+  ipv6:
+    address: 2001:db8:1::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+    - if-name: vz1ns
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+      bfd:
+        enable: true

--- a/bdd/tests/configs/isis_bfd_ipv6_lan/z2-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_lan/z2-echo-both.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::2/128
+- if-name: vz2ns
+  ipv6:
+    address: 2001:db8:1::2/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+    - if-name: vz2ns
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+      bfd:
+        enable: true
+        echo-mode: both

--- a/bdd/tests/configs/isis_bfd_ipv6_lan/z2-echo-rx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_lan/z2-echo-rx.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::2/128
+- if-name: vz2ns
+  ipv6:
+    address: 2001:db8:1::2/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+    - if-name: vz2ns
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+      bfd:
+        enable: true
+        echo-mode: receive

--- a/bdd/tests/configs/isis_bfd_ipv6_lan/z2-noecho.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_lan/z2-noecho.yaml
@@ -1,0 +1,23 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::2/128
+- if-name: vz2ns
+  ipv6:
+    address: 2001:db8:1::2/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+    - if-name: vz2ns
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+      bfd:
+        enable: true

--- a/bdd/tests/configs/isis_bfd_ipv6_p2p/z1-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_p2p/z1-echo-both.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::1/128
+- if-name: i1
+  ipv6:
+    address: 2001:db8:1::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+    - if-name: i1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      ipv6:
+        enable: true
+      bfd:
+        enable: true
+        echo-mode: both

--- a/bdd/tests/configs/isis_bfd_ipv6_p2p/z1-echo-tx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_p2p/z1-echo-tx.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::1/128
+- if-name: i1
+  ipv6:
+    address: 2001:db8:1::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+    - if-name: i1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      ipv6:
+        enable: true
+      bfd:
+        enable: true
+        echo-mode: transmit

--- a/bdd/tests/configs/isis_bfd_ipv6_p2p/z1-noecho.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_p2p/z1-noecho.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::1/128
+- if-name: i1
+  ipv6:
+    address: 2001:db8:1::1/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+    - if-name: i1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      ipv6:
+        enable: true
+      bfd:
+        enable: true

--- a/bdd/tests/configs/isis_bfd_ipv6_p2p/z2-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_p2p/z2-echo-both.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::2/128
+- if-name: i1
+  ipv6:
+    address: 2001:db8:1::2/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+    - if-name: i1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      ipv6:
+        enable: true
+      bfd:
+        enable: true
+        echo-mode: both

--- a/bdd/tests/configs/isis_bfd_ipv6_p2p/z2-echo-rx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_p2p/z2-echo-rx.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::2/128
+- if-name: i1
+  ipv6:
+    address: 2001:db8:1::2/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+    - if-name: i1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      ipv6:
+        enable: true
+      bfd:
+        enable: true
+        echo-mode: receive

--- a/bdd/tests/configs/isis_bfd_ipv6_p2p/z2-noecho.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv6_p2p/z2-noecho.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8:0:ffff::2/128
+- if-name: i1
+  ipv6:
+    address: 2001:db8:1::2/64
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv6:
+        enable: true
+    - if-name: i1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      ipv6:
+        enable: true
+      bfd:
+        enable: true

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -914,6 +914,210 @@ async fn isis_neighbor_should_not_be_up(
     );
 }
 
+/// Whether a single-hop BFD session on `interface` in `scoped` has reached the
+/// Up state. Reads `show bfd peers -j`, a flat array of session objects
+/// carrying `{interface, local_state, peer, local, ...}`. Matching by
+/// `interface` rather than the peer address keeps the assertion stable for
+/// IPv6 link-local sessions, whose `fe80::` addresses are EUI-derived and not
+/// known to the test. Returns the flag plus the raw JSON for failure output.
+async fn bfd_session_up(scoped: &str, interface: &str) -> (bool, String) {
+    let output = netns::exec_in_netns(scoped, "vtyctl", &["show", "-j", "show bfd peers"])
+        .await
+        .expect("Failed to run show bfd peers");
+    let peers: Value = serde_json::from_str(&output).unwrap_or_else(|e| {
+        panic!(
+            "show bfd peers -j in {} was not valid JSON: {}\nfull output:\n{}",
+            scoped, e, output
+        )
+    });
+    let up = peers
+        .as_array()
+        .map(|arr| {
+            arr.iter().any(|p| {
+                p.get("interface").and_then(|i| i.as_str()) == Some(interface)
+                    && p.get("local_state").and_then(|s| s.as_str()) == Some("Up")
+            })
+        })
+        .unwrap_or(false);
+    (up, output)
+}
+
+/// Assert a single-hop BFD session on the given interface reaches Up. Polls for
+/// a short window so the step tolerates the session's negotiation / detection
+/// latency without the feature needing a hard-coded long wait.
+#[then(expr = "bfd session in namespace {string} on interface {string} should be up")]
+async fn bfd_session_should_be_up(world: &mut World, namespace: String, interface: String) {
+    let scoped = world.ns(&namespace);
+    const ATTEMPTS: u32 = 20;
+    let mut up = false;
+    let mut output = String::new();
+    for i in 0..ATTEMPTS {
+        let (u, o) = bfd_session_up(&scoped, &interface).await;
+        up = u;
+        output = o;
+        if up {
+            break;
+        }
+        if i + 1 < ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    }
+    assert!(
+        up,
+        "no Up BFD session on {} in {}:\n{}",
+        interface, scoped, output
+    );
+    println!("✓ BFD session on {} in {} is Up", interface, scoped);
+}
+
+/// Negative sibling: assert the BFD session on the interface is NOT Up — it has
+/// either gone Down or been torn down entirely (when IS-IS unsubscribes on
+/// adjacency teardown the session disappears from `show bfd peers`). Both
+/// satisfy "not Up". Polls until the session leaves Up so the step is robust
+/// against detection timing.
+#[then(expr = "bfd session in namespace {string} on interface {string} should be down")]
+async fn bfd_session_should_be_down(world: &mut World, namespace: String, interface: String) {
+    let scoped = world.ns(&namespace);
+    const ATTEMPTS: u32 = 20;
+    let mut up = true;
+    let mut output = String::new();
+    for i in 0..ATTEMPTS {
+        let (u, o) = bfd_session_up(&scoped, &interface).await;
+        up = u;
+        output = o;
+        if !up {
+            break;
+        }
+        if i + 1 < ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    }
+    assert!(
+        !up,
+        "BFD session on {} in {} is still Up (expected Down):\n{}",
+        interface, scoped, output
+    );
+    println!(
+        "✓ BFD session on {} in {} is not Up (as expected)",
+        interface, scoped
+    );
+}
+
+/// Assert the Echo role active on a BFD session, as reported by
+/// `show bfd peers -j`. `role` is one of `transmit` (we originate Echo),
+/// `receive` (we reflect a peer's Echo), `both`, or `off`. The JSON exposes
+/// per-session `echo_transmit_active` / `echo_receive_active` booleans
+/// (absent ⇒ false), so this stays red until the IPv6 Echo dataplane is wired.
+/// Polls because Echo activates only once the session is Up and the reflector
+/// child is confirmed running.
+#[then(expr = "bfd session in namespace {string} on interface {string} should have echo {word}")]
+async fn bfd_session_should_have_echo(
+    world: &mut World,
+    namespace: String,
+    interface: String,
+    role: String,
+) {
+    let scoped = world.ns(&namespace);
+    const ATTEMPTS: u32 = 20;
+    let mut ok = false;
+    let mut output = String::new();
+    for i in 0..ATTEMPTS {
+        output = netns::exec_in_netns(&scoped, "vtyctl", &["show", "-j", "show bfd peers"])
+            .await
+            .expect("Failed to run show bfd peers");
+        let peers: Value = serde_json::from_str(&output).unwrap_or_else(|e| {
+            panic!(
+                "show bfd peers -j in {} was not valid JSON: {}\nfull output:\n{}",
+                scoped, e, output
+            )
+        });
+        ok = peers
+            .as_array()
+            .map(|arr| {
+                arr.iter().any(|p| {
+                    if p.get("interface").and_then(|i| i.as_str()) != Some(interface.as_str()) {
+                        return false;
+                    }
+                    let tx = p
+                        .get("echo_transmit_active")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    let rx = p
+                        .get("echo_receive_active")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    match role.as_str() {
+                        "transmit" => tx && !rx,
+                        "receive" => rx && !tx,
+                        "both" => tx && rx,
+                        "off" => !tx && !rx,
+                        other => panic!(
+                            "invalid echo role '{}', expected transmit|receive|both|off",
+                            other
+                        ),
+                    }
+                })
+            })
+            .unwrap_or(false);
+        if ok {
+            break;
+        }
+        if i + 1 < ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    }
+    assert!(
+        ok,
+        "BFD session on {} in {} did not have echo '{}':\n{}",
+        interface, scoped, role, output
+    );
+    println!(
+        "✓ BFD session on {} in {} has echo '{}'",
+        interface, scoped, role
+    );
+}
+
+/// Drop inbound single-hop BFD control packets (UDP/3784) inside a namespace.
+/// The interface stays up and IS-IS hellos (L2 ISO PDUs, not IP/UDP) keep
+/// flowing, so the peer's BFD session times out while the adjacency would
+/// otherwise stay up — isolating BFD as the cause of the teardown (vs. carrier
+/// loss or the much slower IS-IS hold timer). RFC 5882 hold-down then keeps the
+/// adjacency down until the drop is removed. Per-netns ip6tables rules vanish
+/// when the namespace is deleted, so no explicit cleanup step is needed.
+///
+/// Fallback trigger (no new IS-IS state required) if ip6tables is unavailable:
+/// `tc qdisc add dev <peer-if> root netem loss 100%` on the peer's egress.
+#[when(expr = "I drop bfd control packets in namespace {string}")]
+async fn drop_bfd_control_packets(world: &mut World, namespace: String) {
+    let scoped = world.ns(&namespace);
+    netns::exec_in_netns(
+        &scoped,
+        "ip6tables",
+        &["-I", "INPUT", "-p", "udp", "--dport", "3784", "-j", "DROP"],
+    )
+    .await
+    .expect("Failed to install ip6tables BFD drop rule");
+    println!(
+        "✓ Dropping inbound BFD control packets (UDP/3784) in {}",
+        scoped
+    );
+}
+
+/// Remove the BFD-control drop rule installed by the step above, letting the
+/// session re-establish and IS-IS lift the hold-down.
+#[when(expr = "I restore bfd control packets in namespace {string}")]
+async fn restore_bfd_control_packets(world: &mut World, namespace: String) {
+    let scoped = world.ns(&namespace);
+    netns::exec_in_netns(
+        &scoped,
+        "ip6tables",
+        &["-D", "INPUT", "-p", "udp", "--dport", "3784", "-j", "DROP"],
+    )
+    .await
+    .expect("Failed to remove ip6tables BFD drop rule");
+    println!("✓ Restored BFD control packets (UDP/3784) in {}", scoped);
+}
+
 /// Parse the OSPF `show ip ospf neighbor` up-time string (the
 /// `format_uptime` output: "0m08s", "1h02m03s", "1d02h03m") into whole
 /// seconds. Any hours/days component is far past the thresholds this

--- a/bdd/tests/features/isis_bfd_ipv6_lan.feature
+++ b/bdd/tests/features/isis_bfd_ipv6_lan.feature
@@ -1,0 +1,125 @@
+@isis_bfd_ipv6_lan
+@bfd
+Feature: IS-IS BFD over an IPv6-only LAN (broadcast) link
+  As a network operator running IS-IS over IPv6-only broadcast segments
+  I want BFD to protect each LAN adjacency
+  So that a forwarding failure tears the adjacency down well within the IS-IS
+  hold time, and the adjacency stays down (RFC 5882 hold-down) until BFD
+  recovers — even while IIHs keep arriving.
+
+  Same intent as the point-to-point feature, but the two routers share a Linux
+  bridge (broadcast network type, DIS election). Per-neighbour single-hop BFD
+  sessions are built from each end's IPv6 link-local address (TLV 232). Each
+  scenario is self-contained so the Echo scenarios arm echo-mode before the
+  session first comes up.
+
+  BFD-down is induced by dropping inbound UDP/3784 in one namespace: the link
+  stays up and IIHs (L2 ISO PDUs, not IP/UDP) keep flowing, so a fast teardown
+  is provably BFD's doing — not carrier loss, not the ~30s IS-IS hold timer.
+
+  Test Topology (shared bridge):
+  ```
+  ┌────────────────────────────────────────┐
+  │                  br0                    │
+  └────────────┬───────────────┬───────────┘
+               │               │
+       2001:db8:1::1/64   2001:db8:1::2/64
+            (vz1ns)            (vz2ns)
+          ┌────┴────┐     ┌────┴────┐
+          │   z1    │     │   z2    │
+          └─────────┘     └─────────┘
+   lo 2001:db8:0:ffff::1   lo 2001:db8:0:ffff::2
+              /128                  /128
+  ```
+
+  Scenario: BFD without Echo protects the LAN adjacency and tears it down on BFD failure
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with loopback and veth interface on the bridge "br0"
+    And I create namespace "z2" with loopback and veth interface on the bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-noecho.yaml" to namespace "z1"
+    And I apply config "z2-noecho.yaml" to namespace "z2"
+    And I wait 15 seconds
+    Then isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should be up
+    And bfd session in namespace "z1" on interface "vz1ns" should be up
+    And bfd session in namespace "z2" on interface "vz2ns" should be up
+    And ping from "z1" to "2001:db8:0:ffff::2" should succeed
+    # BFD-down isolation: link stays up, IIHs keep flowing.
+    When I drop bfd control packets in namespace "z2"
+    Then bfd session in namespace "z1" on interface "vz1ns" should be down
+    And isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should not be up
+    And ping from "z1" to "2001:db8:0:ffff::2" should fail
+    # Recovery: BFD re-establishes and IS-IS lifts the hold-down.
+    When I restore bfd control packets in namespace "z2"
+    And I wait 20 seconds
+    Then bfd session in namespace "z1" on interface "vz1ns" should be up
+    And isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should be up
+    And ping from "z1" to "2001:db8:0:ffff::2" should succeed
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean
+
+  @bfd_echo
+  Scenario: BFD with Echo in one direction (z1 transmit, z2 receive)
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with loopback and veth interface on the bridge "br0"
+    And I create namespace "z2" with loopback and veth interface on the bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-echo-tx.yaml" to namespace "z1"
+    And I apply config "z2-echo-rx.yaml" to namespace "z2"
+    And I wait 15 seconds
+    Then isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should be up
+    And bfd session in namespace "z1" on interface "vz1ns" should be up
+    And bfd session in namespace "z1" on interface "vz1ns" should have echo transmit
+    And bfd session in namespace "z2" on interface "vz2ns" should have echo receive
+    And ping from "z1" to "2001:db8:0:ffff::2" should succeed
+    When I drop bfd control packets in namespace "z2"
+    Then bfd session in namespace "z1" on interface "vz1ns" should be down
+    And isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should not be up
+    When I restore bfd control packets in namespace "z2"
+    And I wait 20 seconds
+    Then bfd session in namespace "z1" on interface "vz1ns" should be up
+    And ping from "z1" to "2001:db8:0:ffff::2" should succeed
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean
+
+  @bfd_echo
+  Scenario: BFD with Echo in both directions
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with loopback and veth interface on the bridge "br0"
+    And I create namespace "z2" with loopback and veth interface on the bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-echo-both.yaml" to namespace "z1"
+    And I apply config "z2-echo-both.yaml" to namespace "z2"
+    And I wait 15 seconds
+    Then isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should be up
+    And bfd session in namespace "z1" on interface "vz1ns" should be up
+    And bfd session in namespace "z1" on interface "vz1ns" should have echo both
+    And bfd session in namespace "z2" on interface "vz2ns" should have echo both
+    And ping from "z1" to "2001:db8:0:ffff::2" should succeed
+    When I drop bfd control packets in namespace "z2"
+    Then bfd session in namespace "z1" on interface "vz1ns" should be down
+    And isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should not be up
+    When I restore bfd control packets in namespace "z2"
+    And I wait 20 seconds
+    Then bfd session in namespace "z1" on interface "vz1ns" should be up
+    And ping from "z1" to "2001:db8:0:ffff::2" should succeed
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/bdd/tests/features/isis_bfd_ipv6_p2p.feature
+++ b/bdd/tests/features/isis_bfd_ipv6_p2p.feature
@@ -1,0 +1,116 @@
+@isis_bfd_ipv6_p2p
+@bfd
+Feature: IS-IS BFD over an IPv6-only point-to-point link
+  As a network operator running IS-IS over IPv6-only links
+  I want BFD to protect the point-to-point adjacency
+  So that a forwarding failure tears the adjacency down well within the IS-IS
+  hold time, and the adjacency stays down (RFC 5882 hold-down) until BFD
+  recovers — even while IIHs keep arriving.
+
+  The single-hop BFD session is built from the two ends' IPv6 link-local
+  addresses (learned via TLV 232). Each scenario is self-contained (own setup
+  and teardown) so the Echo scenarios configure echo-mode before the session
+  first comes up (echo is armed at session establishment, not retrofitted).
+
+  BFD-down is induced by dropping inbound UDP/3784 in one namespace: the link
+  stays up and IIHs (L2 ISO PDUs, not IP/UDP) keep flowing, so a fast teardown
+  is provably BFD's doing — not carrier loss, not the ~30s IS-IS hold timer.
+
+  Test Topology (point-to-point veth):
+  ```
+   2001:db8:1::1/64                       2001:db8:1::2/64
+        (i1)                                   (i1)
+    ┌────┴────┐                            ┌────┴────┐
+    │   z1    │────────── P2P ─────────────│   z2    │
+    └─────────┘                            └─────────┘
+  lo 2001:db8:0:ffff::1/128             lo 2001:db8:0:ffff::2/128
+  ```
+
+  Scenario: BFD without Echo protects the adjacency and tears it down on BFD failure
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-noecho.yaml" to namespace "z1"
+    And I apply config "z2-noecho.yaml" to namespace "z2"
+    And I wait 10 seconds
+    Then isis neighbor in namespace "z1" at level 2 on interface "i1" should be up
+    And bfd session in namespace "z1" on interface "i1" should be up
+    And bfd session in namespace "z2" on interface "i1" should be up
+    And ping from "z1" to "2001:db8:0:ffff::2" should succeed
+    # BFD-down isolation: link stays up, IIHs keep flowing.
+    When I drop bfd control packets in namespace "z2"
+    Then bfd session in namespace "z1" on interface "i1" should be down
+    And isis neighbor in namespace "z1" at level 2 on interface "i1" should not be up
+    And ping from "z1" to "2001:db8:0:ffff::2" should fail
+    # Recovery: BFD re-establishes and IS-IS lifts the hold-down.
+    When I restore bfd control packets in namespace "z2"
+    And I wait 20 seconds
+    Then bfd session in namespace "z1" on interface "i1" should be up
+    And isis neighbor in namespace "z1" at level 2 on interface "i1" should be up
+    And ping from "z1" to "2001:db8:0:ffff::2" should succeed
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean
+
+  @bfd_echo
+  Scenario: BFD with Echo in one direction (z1 transmit, z2 receive)
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-echo-tx.yaml" to namespace "z1"
+    And I apply config "z2-echo-rx.yaml" to namespace "z2"
+    And I wait 10 seconds
+    Then isis neighbor in namespace "z1" at level 2 on interface "i1" should be up
+    And bfd session in namespace "z1" on interface "i1" should be up
+    And bfd session in namespace "z1" on interface "i1" should have echo transmit
+    And bfd session in namespace "z2" on interface "i1" should have echo receive
+    And ping from "z1" to "2001:db8:0:ffff::2" should succeed
+    When I drop bfd control packets in namespace "z2"
+    Then bfd session in namespace "z1" on interface "i1" should be down
+    And isis neighbor in namespace "z1" at level 2 on interface "i1" should not be up
+    When I restore bfd control packets in namespace "z2"
+    And I wait 20 seconds
+    Then bfd session in namespace "z1" on interface "i1" should be up
+    And ping from "z1" to "2001:db8:0:ffff::2" should succeed
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean
+
+  @bfd_echo
+  Scenario: BFD with Echo in both directions
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-echo-both.yaml" to namespace "z1"
+    And I apply config "z2-echo-both.yaml" to namespace "z2"
+    And I wait 10 seconds
+    Then isis neighbor in namespace "z1" at level 2 on interface "i1" should be up
+    And bfd session in namespace "z1" on interface "i1" should be up
+    And bfd session in namespace "z1" on interface "i1" should have echo both
+    And bfd session in namespace "z2" on interface "i1" should have echo both
+    And ping from "z1" to "2001:db8:0:ffff::2" should succeed
+    When I drop bfd control packets in namespace "z2"
+    Then bfd session in namespace "z1" on interface "i1" should be down
+    And isis neighbor in namespace "z1" at level 2 on interface "i1" should not be up
+    When I restore bfd control packets in namespace "z2"
+    And I wait 20 seconds
+    Then bfd session in namespace "z1" on interface "i1" should be up
+    And ping from "z1" to "2001:db8:0:ffff::2" should succeed
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/book/src/ch-07-03-isis-bfd.md
+++ b/book/src/ch-07-03-isis-bfd.md
@@ -32,7 +32,7 @@ interface, overridden per interface (see
 | Leaf | Type | Default | Meaning |
 |---|---|---|---|
 | `enable` | boolean | _(off)_ | Attach (or detach) BFD for adjacencies on this interface. |
-| `echo-mode` | `transmit` \| `receive` \| `both` | _(off)_ | Enable the [BFD Echo function](ch-10-00-bfd.md#echo-function) on this interface's single-hop IPv4 adjacencies. |
+| `echo-mode` | `transmit` \| `receive` \| `both` | _(off)_ | Enable the [BFD Echo function](ch-10-00-bfd.md#echo-function) on this interface's single-hop adjacencies (IPv4 or IPv6). |
 | `echo-transmit-interval` | uint (ms) | `50` | Rate we originate Echo at (`transmit` / `both`). |
 | `echo-receive-interval` | uint (ms) | `50` | Advertised Required Min Echo RX (`receive` / `both`). |
 
@@ -46,11 +46,12 @@ unsubscribed when it goes down.
 ## Echo
 
 `echo-mode` turns on the [BFD Echo function](ch-10-00-bfd.md#echo-function) for
-this interface's adjacencies — single-hop **IPv4 only** (IS-IS is an L2 protocol;
-the Echo session is built from the interface's and neighbour's IPv4 addresses,
-so an IPv6-only adjacency is inert). `transmit` originates Echo + detects on the
-return; `receive` advertises + reflects (the peer detects); `both` does both —
-backed by the per-interface `xdp-bfd-echo` helper.
+this interface's adjacencies — single-hop only. Both IPv4 and IPv6 are
+supported: the Echo session is built from the interface's and neighbour's
+addresses (an IPv6-only adjacency uses the two ends' link-locals). `transmit`
+originates Echo + detects on the return; `receive` advertises + reflects (the
+peer detects); `both` does both — backed by the per-interface `xdp-bfd-echo`
+helper, whose XDP reflector handles 0x0800 and 0x86DD frames alike.
 
 ```
 router isis {

--- a/offload/xdp-bfd-echo/README.md
+++ b/offload/xdp-bfd-echo/README.md
@@ -226,8 +226,12 @@ Beyond reflecting, the helper also *originates* Echo when zebra-rs asks it to
 
 ## Limitations / follow-ups
 
-- **IPv4 only** (EtherType 0x0800). IPv6 (0x86DD) is a follow-up.
-- Option-less IPv4 only (IHL=5); BFD Echo frames carry no IP options.
+- IPv4 (EtherType 0x0800) and IPv6 (0x86DD) are both reflected/originated. The
+  IPv6 path needs no checksum fix-up on reflect (no header checksum, and the
+  self-addressed Echo's symmetric src/dst leave the UDP checksum valid); it
+  decrements the Hop Limit just as the IPv4 path decrements the TTL.
+- Option-less IPv4 only (IHL=5) and base IPv6 headers only (no extension
+  headers); BFD Echo frames carry neither.
 - `bpf_timer` detection needs a kernel that supports it (≥ 5.15) and `CAP_BPF`;
   the responder path has no such requirement.
 - aya deps are pulled from git to match the current build glue; pin a rev for

--- a/offload/xdp-bfd-echo/ebpf/src/main.rs
+++ b/offload/xdp-bfd-echo/ebpf/src/main.rs
@@ -28,7 +28,11 @@
 //! helper polls that flag and reports `echo-down` to zebra-rs. This is the Echo
 //! *sender*'s detection offload — no userspace packet RX in steady state.
 //!
-//! First slice: IPv4 only. IPv6 (EtherType 0x86DD) is a follow-up.
+//! Both IPv4 (EtherType 0x0800) and IPv6 (0x86DD) Echo frames are handled. The
+//! IPv6 path is the exact analogue: a 40-byte fixed header, Hop Limit in place
+//! of TTL, and — because IPv6 has no header checksum and the Echo is
+//! self-addressed (src == dst) — no checksum fix-up at all on reflect (the UDP
+//! pseudo-header is symmetric in src/dst, and Hop Limit isn't in it).
 
 use aya_ebpf::{
     bindings::{bpf_timer, xdp_action},
@@ -48,6 +52,11 @@ use aya_ebpf::{
 /// pure-responder deployments.
 #[map]
 static OUR_LOCAL_IPS: HashMap<u32, u8> = HashMap::with_max_entries(256, 0);
+
+/// IPv6 analogue of [`OUR_LOCAL_IPS`], keyed by the 16-byte address (as read off
+/// the wire). Filled by the loader for sessions where we originate IPv6 Echo.
+#[map]
+static OUR_LOCAL_IPS_V6: HashMap<[u8; 16], u8> = HashMap::with_max_entries(256, 0);
 
 /// Per-session Echo detection state, keyed by our local BFD discriminator.
 ///
@@ -115,6 +124,24 @@ const PL_DISCR_OFF: usize = PAYLOAD_OFF + 4; // u32 (big-endian) our local discr
 /// ASCII "zbfd" — tags our own Echo payload.
 const ECHO_MAGIC: u32 = 0x7a62_6664;
 
+const ETHERTYPE_IPV6: u16 = 0x86DD;
+
+/// IPv6 fixed-header fields (relative to the start of the frame). Extension
+/// headers are not expected on a BFD Echo frame; a non-UDP Next Header is
+/// `XDP_PASS`ed. There is no header checksum (unlike IPv4).
+const IP6_OFF: usize = ETH_HLEN;
+const IP6_NEXTHDR_OFF: usize = IP6_OFF + 6; // u8 Next Header
+const IP6_HOPLIMIT_OFF: usize = IP6_OFF + 7; // u8 Hop Limit
+const IP6_SRC_OFF: usize = IP6_OFF + 8; // [u8; 16] source address
+const IP6_HLEN: usize = 40;
+
+/// UDP header after a 40-byte IPv6 header, and the Echo payload after it.
+const UDP6_OFF: usize = IP6_OFF + IP6_HLEN;
+const UDP6_DST_OFF: usize = UDP6_OFF + 2; // u16 (big-endian) destination port
+const PAYLOAD6_OFF: usize = UDP6_OFF + 8;
+const PL6_MAGIC_OFF: usize = PAYLOAD6_OFF; // u32 (big-endian) "zbfd"
+const PL6_DISCR_OFF: usize = PAYLOAD6_OFF + 4; // u32 (big-endian) our discriminator
+
 /// Read a `u8` at `off` bytes into the frame, after a verifier-friendly bounds
 /// check against `data_end`.
 #[inline(always)]
@@ -153,6 +180,38 @@ unsafe fn load_u32_be(ctx: &XdpContext, off: usize) -> Result<u32, ()> {
         let b2 = *((ptr + 2) as *const u8) as u32;
         let b3 = *((ptr + 3) as *const u8) as u32;
         Ok((b0 << 24) | (b1 << 16) | (b2 << 8) | b3)
+    }
+}
+
+/// Read the 16-byte IPv6 address at `off`: one bounds check, then 16
+/// constant-offset byte reads (so the verifier accepts each access against the
+/// single `+ 16` check). Octets are in wire order, ready to key
+/// [`OUR_LOCAL_IPS_V6`].
+#[inline(always)]
+unsafe fn load_ip6(ctx: &XdpContext, off: usize) -> Result<[u8; 16], ()> {
+    let ptr = ctx.data() + off;
+    if ptr + 16 > ctx.data_end() {
+        return Err(());
+    }
+    unsafe {
+        Ok([
+            *(ptr as *const u8),
+            *((ptr + 1) as *const u8),
+            *((ptr + 2) as *const u8),
+            *((ptr + 3) as *const u8),
+            *((ptr + 4) as *const u8),
+            *((ptr + 5) as *const u8),
+            *((ptr + 6) as *const u8),
+            *((ptr + 7) as *const u8),
+            *((ptr + 8) as *const u8),
+            *((ptr + 9) as *const u8),
+            *((ptr + 10) as *const u8),
+            *((ptr + 11) as *const u8),
+            *((ptr + 12) as *const u8),
+            *((ptr + 13) as *const u8),
+            *((ptr + 14) as *const u8),
+            *((ptr + 15) as *const u8),
+        ])
     }
 }
 
@@ -204,6 +263,27 @@ unsafe fn decrement_ttl(ctx: &XdpContext) -> Result<(), ()> {
     Ok(())
 }
 
+/// Decrement the IPv6 Hop Limit by one. Unlike IPv4 there is no header checksum
+/// to patch, and the UDP checksum is unaffected (Hop Limit is not in the
+/// pseudo-header, and the self-addressed Echo has src == dst). Returns Err on a
+/// truncated header or Hop Limit 0.
+#[inline(always)]
+unsafe fn decrement_hop_limit(ctx: &XdpContext) -> Result<(), ()> {
+    let start = ctx.data();
+    if start + IP6_HOPLIMIT_OFF + 1 > ctx.data_end() {
+        return Err(());
+    }
+    let hl_ptr = (start + IP6_HOPLIMIT_OFF) as *mut u8;
+    unsafe {
+        let hl = core::ptr::read_volatile(hl_ptr);
+        if hl == 0 {
+            return Err(());
+        }
+        core::ptr::write_volatile(hl_ptr, hl - 1);
+    }
+    Ok(())
+}
+
 /// `bpf_timer` callback: fires `detect_ns` after the last return, i.e. when our
 /// originated Echo stopped coming back. Runs in softirq with the timed-out map
 /// element as `value`. It is one-shot (not re-armed here), so it sets the `down`
@@ -223,12 +303,12 @@ unsafe extern "C" fn echo_timeout(_map: *mut c_void, _key: *mut c_void, value: *
 /// `Ok` lets the caller `XDP_DROP` the frame — in steady state the userspace
 /// sender never has to touch returns; the kernel times them.
 #[inline(always)]
-unsafe fn record_return(ctx: &XdpContext) -> Result<(), ()> {
-    if unsafe { load_u32_be(ctx, PL_MAGIC_OFF)? } != ECHO_MAGIC {
+unsafe fn record_return(ctx: &XdpContext, magic_off: usize, discr_off: usize) -> Result<(), ()> {
+    if unsafe { load_u32_be(ctx, magic_off)? } != ECHO_MAGIC {
         // Source is one of our IPs but the payload isn't ours — leave it alone.
         return Ok(());
     }
-    let discr = unsafe { load_u32_be(ctx, PL_DISCR_OFF)? };
+    let discr = unsafe { load_u32_be(ctx, discr_off)? };
     // Userspace seeds the entry at `echo-add`; a miss means we don't track this
     // discriminator (race or stale return) — nothing to do.
     let Some(st) = ECHO_TIMERS.get_ptr_mut(&discr) else {
@@ -258,54 +338,12 @@ unsafe fn record_return(ctx: &XdpContext) -> Result<(), ()> {
     Ok(())
 }
 
-#[xdp]
-pub fn bfd_echo_reflect(ctx: XdpContext) -> u32 {
-    match try_reflect(&ctx) {
-        Ok(action) => action,
-        // A truncated/short frame just falls through to the stack.
-        Err(()) => xdp_action::XDP_PASS,
-    }
-}
-
-fn try_reflect(ctx: &XdpContext) -> Result<u32, ()> {
-    // Ethernet II, IPv4 only for this first slice.
-    if unsafe { load_u16_be(ctx, ETH_TYPE_OFF)? } != ETHERTYPE_IPV4 {
-        return Ok(xdp_action::XDP_PASS);
-    }
-
-    // Only option-less IPv4 (IHL=5). BFD Echo frames carry no IP options; a
-    // packet with options would shift the UDP header and is left to the stack.
-    if unsafe { load_u8(ctx, IP_VER_IHL_OFF)? } != IPV4_VER_IHL_NOOPTS {
-        return Ok(xdp_action::XDP_PASS);
-    }
-    if unsafe { load_u8(ctx, IP_PROTO_OFF)? } != IPPROTO_UDP {
-        return Ok(xdp_action::XDP_PASS);
-    }
-
-    if unsafe { load_u16_be(ctx, UDP_DST_OFF)? } != BFD_ECHO_PORT {
-        return Ok(xdp_action::XDP_PASS);
-    }
-
-    // Our own originated Echo, looped back by the peer, is self-addressed to one
-    // of our local IPs. Don't re-reflect it (that loops forever) — feed the
-    // in-kernel detector (arm/re-arm this session's bpf_timer) and drop it. A
-    // peer's Echo (any other source) falls through to the reflect path below.
-    let src_ip = unsafe { load_u32_be(ctx, IP_SRC_OFF)? };
-    if unsafe { OUR_LOCAL_IPS.get(&src_ip) }.is_some() {
-        unsafe { record_return(ctx)? };
-        return Ok(xdp_action::XDP_DROP);
-    }
-
-    // Act as a forwarding hop: decrement TTL + patch the IP checksum, so the
-    // looped Echo returns to the originator at TTL 254 (RFC 5880 §6.4 Echo is
-    // looped by the remote's forwarding plane; FRR's fp-echo receiver requires
-    // exactly TTL 254 and drops anything else).
-    unsafe { decrement_ttl(ctx)? };
-
-    // Prove the full 14-byte Ethernet header (both MACs) is in bounds, then swap
-    // source/destination MAC in place and bounce the frame straight back out.
-    // Swap byte-by-byte at constant offsets (see `swap_byte`) so the copy is
-    // never lowered to a verifier-rejected memcpy.
+/// Prove the full 14-byte Ethernet header (both MACs) is in bounds, then swap
+/// source/destination MAC in place so the frame bounces straight back out.
+/// Byte-by-byte at constant offsets (see [`swap_byte`]) so the copy is never
+/// lowered to a verifier-rejected memcpy.
+#[inline(always)]
+unsafe fn swap_macs(ctx: &XdpContext) -> Result<(), ()> {
     let start = ctx.data();
     if start + ETH_HLEN > ctx.data_end() {
         return Err(());
@@ -320,10 +358,82 @@ fn try_reflect(ctx: &XdpContext) -> Result<u32, ()> {
         swap_byte(dst.add(4), src.add(4));
         swap_byte(dst.add(5), src.add(5));
     }
+    Ok(())
+}
 
-    // No per-packet logging here: aya-log in XDP is heavyweight (and overflowed
-    // its ringbuf record), and logging every reflected frame is undesirable at
-    // line rate. Reflection is observable via tcpdump / the XDP_TX action.
+#[xdp]
+pub fn bfd_echo_reflect(ctx: XdpContext) -> u32 {
+    match try_reflect(&ctx) {
+        Ok(action) => action,
+        // A truncated/short frame just falls through to the stack.
+        Err(()) => xdp_action::XDP_PASS,
+    }
+}
+
+fn try_reflect(ctx: &XdpContext) -> Result<u32, ()> {
+    match unsafe { load_u16_be(ctx, ETH_TYPE_OFF)? } {
+        ETHERTYPE_IPV4 => try_reflect_v4(ctx),
+        ETHERTYPE_IPV6 => try_reflect_v6(ctx),
+        // Anything that isn't IP — and any non-Echo UDP, including BFD *control*
+        // on 3784 — is left for the stack.
+        _ => Ok(xdp_action::XDP_PASS),
+    }
+}
+
+fn try_reflect_v4(ctx: &XdpContext) -> Result<u32, ()> {
+    // Only option-less IPv4 (IHL=5). BFD Echo frames carry no IP options; a
+    // packet with options would shift the UDP header and is left to the stack.
+    if unsafe { load_u8(ctx, IP_VER_IHL_OFF)? } != IPV4_VER_IHL_NOOPTS {
+        return Ok(xdp_action::XDP_PASS);
+    }
+    if unsafe { load_u8(ctx, IP_PROTO_OFF)? } != IPPROTO_UDP {
+        return Ok(xdp_action::XDP_PASS);
+    }
+    if unsafe { load_u16_be(ctx, UDP_DST_OFF)? } != BFD_ECHO_PORT {
+        return Ok(xdp_action::XDP_PASS);
+    }
+
+    // Our own originated Echo, looped back by the peer, is self-addressed to one
+    // of our local IPs. Don't re-reflect it (that loops forever) — feed the
+    // in-kernel detector (arm/re-arm this session's bpf_timer) and drop it. A
+    // peer's Echo (any other source) falls through to the reflect path below.
+    let src_ip = unsafe { load_u32_be(ctx, IP_SRC_OFF)? };
+    if unsafe { OUR_LOCAL_IPS.get(&src_ip) }.is_some() {
+        unsafe { record_return(ctx, PL_MAGIC_OFF, PL_DISCR_OFF)? };
+        return Ok(xdp_action::XDP_DROP);
+    }
+
+    // Act as a forwarding hop: decrement TTL + patch the IP checksum, so the
+    // looped Echo returns to the originator at TTL 254 (RFC 5880 §6.4 Echo is
+    // looped by the remote's forwarding plane; FRR's fp-echo receiver requires
+    // exactly TTL 254 and drops anything else).
+    unsafe { decrement_ttl(ctx)? };
+    unsafe { swap_macs(ctx)? };
+    Ok(xdp_action::XDP_TX)
+}
+
+fn try_reflect_v6(ctx: &XdpContext) -> Result<u32, ()> {
+    // Base IPv6 header only (no extension headers): Next Header must be UDP. A
+    // BFD Echo frame carries none, so a chained header is left for the stack.
+    if unsafe { load_u8(ctx, IP6_NEXTHDR_OFF)? } != IPPROTO_UDP {
+        return Ok(xdp_action::XDP_PASS);
+    }
+    if unsafe { load_u16_be(ctx, UDP6_DST_OFF)? } != BFD_ECHO_PORT {
+        return Ok(xdp_action::XDP_PASS);
+    }
+
+    // Our own originated Echo, looped back by the peer (self-addressed to one of
+    // our link-locals): feed the in-kernel detector and drop, don't re-reflect.
+    let src = unsafe { load_ip6(ctx, IP6_SRC_OFF)? };
+    if unsafe { OUR_LOCAL_IPS_V6.get(&src) }.is_some() {
+        unsafe { record_return(ctx, PL6_MAGIC_OFF, PL6_DISCR_OFF)? };
+        return Ok(xdp_action::XDP_DROP);
+    }
+
+    // Forwarding-hop loopback: decrement the Hop Limit (no header/UDP checksum
+    // fix-up needed — see decrement_hop_limit), swap MACs, bounce out.
+    unsafe { decrement_hop_limit(ctx)? };
+    unsafe { swap_macs(ctx)? };
     Ok(xdp_action::XDP_TX)
 }
 

--- a/offload/xdp-bfd-echo/loader/src/main.rs
+++ b/offload/xdp-bfd-echo/loader/src/main.rs
@@ -101,11 +101,15 @@ async fn main() -> anyhow::Result<()> {
         ebpf.take_map("OUR_LOCAL_IPS")
             .context("OUR_LOCAL_IPS map missing from object")?,
     )?;
+    let local_ips_v6 = aya::maps::HashMap::try_from(
+        ebpf.take_map("OUR_LOCAL_IPS_V6")
+            .context("OUR_LOCAL_IPS_V6 map missing from object")?,
+    )?;
     let timers = aya::maps::HashMap::try_from(
         ebpf.take_map("ECHO_TIMERS")
             .context("ECHO_TIMERS map missing from object")?,
     )?;
-    let mut engine = sender::EchoEngine::new(&iface, local_ips, timers)?;
+    let mut engine = sender::EchoEngine::new(&iface, local_ips, local_ips_v6, timers)?;
 
     info!("BFD Echo datapath up on {iface} (reflect + originate); Ctrl-C/SIGTERM to exit");
 

--- a/offload/xdp-bfd-echo/loader/src/sender.rs
+++ b/offload/xdp-bfd-echo/loader/src/sender.rs
@@ -25,7 +25,7 @@
 
 use std::collections::HashMap;
 use std::io::Write;
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::time::{Duration, Instant, SystemTime};
 
@@ -63,21 +63,36 @@ unsafe impl Pod for EchoState {}
 /// peer's Echo carries the peer's own opaque payload). ASCII "zbfd".
 const ECHO_MAGIC: u32 = 0x7a62_6664;
 const ETH_P_IP: u16 = 0x0800;
+const ETH_P_IPV6: u16 = 0x86DD;
 const BFD_ECHO_PORT: u16 = 3785;
 const ECHO_TTL: u8 = 255;
 const IPPROTO_UDP: u8 = 17;
 
 const ETH_HLEN: usize = 14;
 const IP_HLEN: usize = 20;
+const IP6_HLEN: usize = 40;
 const UDP_HLEN: usize = 8;
 /// `{ magic:u32, discr:u32, seq:u32, tx_ts_us:u64 }`, big-endian.
 const PAYLOAD_LEN: usize = 4 + 4 + 4 + 8;
 const FRAME_LEN: usize = ETH_HLEN + IP_HLEN + UDP_HLEN + PAYLOAD_LEN;
+/// IPv6 Echo frame length (Eth + 40-byte IPv6 header + UDP + payload).
+const FRAME6_LEN: usize = ETH_HLEN + IP6_HLEN + UDP_HLEN + PAYLOAD_LEN;
 
-/// One originating Echo session, keyed by our local discriminator.
+/// Userspace key for the eBPF `OUR_LOCAL_IPS_V6` map: a 16-byte IPv6 address in
+/// wire order. A newtype (not bare `[u8; 16]`) so we can implement `aya::Pod`.
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct In6Key([u8; 16]);
+
+// SAFETY: `#[repr(C)]`, `Copy`, plain bytes with no padding — safe to read/write
+// as raw map bytes (the `aya::Pod` contract).
+unsafe impl Pod for In6Key {}
+
+/// One originating Echo session, keyed by our local discriminator. `local` and
+/// `peer` are both IPv4 or both IPv6 (the family of the protected adjacency).
 struct EchoSession {
-    local: Ipv4Addr,
-    peer: Ipv4Addr,
+    local: IpAddr,
+    peer: IpAddr,
     peer_mac: Option<[u8; 6]>,
     tx: Duration,
     detect: Duration,
@@ -99,12 +114,14 @@ pub struct EchoEngine {
     io: Option<(OwnedFd, [u8; 6])>,
     /// Mirror of the XDP `OUR_LOCAL_IPS` map (key = `u32::from(Ipv4Addr)`).
     local_ips: BpfHashMap<MapData, u32, u8>,
+    /// IPv6 mirror: the XDP `OUR_LOCAL_IPS_V6` map (key = 16-byte address).
+    local_ips_v6: BpfHashMap<MapData, In6Key, u8>,
     /// The XDP `ECHO_TIMERS` map (key = discriminator). We seed an entry per
     /// session and poll its `down`/`armed` flags; the kernel owns the timer.
     timers: BpfHashMap<MapData, u32, EchoState>,
     /// Refcount of originating sessions per local IP (map entry added on first,
     /// removed on last).
-    ip_refs: HashMap<u32, u32>,
+    ip_refs: HashMap<IpAddr, u32>,
     sessions: HashMap<u32, EchoSession>,
 }
 
@@ -112,6 +129,7 @@ impl EchoEngine {
     pub fn new(
         iface: &str,
         local_ips: BpfHashMap<MapData, u32, u8>,
+        local_ips_v6: BpfHashMap<MapData, In6Key, u8>,
         timers: BpfHashMap<MapData, u32, EchoState>,
     ) -> Result<Self> {
         Ok(Self {
@@ -119,10 +137,40 @@ impl EchoEngine {
             iface: iface.to_string(),
             io: None,
             local_ips,
+            local_ips_v6,
             timers,
             ip_refs: HashMap::new(),
             sessions: HashMap::new(),
         })
+    }
+
+    /// Teach the XDP guard one of our source IPs (so it recognises our looped-back
+    /// Echo and drops it instead of re-reflecting). Family selects the map.
+    fn local_ip_insert(&mut self, local: IpAddr) {
+        match local {
+            IpAddr::V4(a) => {
+                if let Err(e) = self.local_ips.insert(u32::from(a), 1u8, 0) {
+                    warn!("bfd echo sender: OUR_LOCAL_IPS insert {local}: {e}");
+                }
+            }
+            IpAddr::V6(a) => {
+                if let Err(e) = self.local_ips_v6.insert(In6Key(a.octets()), 1u8, 0) {
+                    warn!("bfd echo sender: OUR_LOCAL_IPS_V6 insert {local}: {e}");
+                }
+            }
+        }
+    }
+
+    /// Forget one of our source IPs (last originating session on it went away).
+    fn local_ip_remove(&mut self, local: IpAddr) {
+        match local {
+            IpAddr::V4(a) => {
+                let _ = self.local_ips.remove(&u32::from(a));
+            }
+            IpAddr::V6(a) => {
+                let _ = self.local_ips_v6.remove(&In6Key(a.octets()));
+            }
+        }
     }
 
     /// Open the `AF_PACKET` socket on first use. Returns the raw fd + our MAC, or
@@ -163,8 +211,9 @@ impl EchoEngine {
         match it.next() {
             Some("echo-add") => {
                 let discr: u32 = it.next().context("discr")?.parse()?;
-                let local: Ipv4Addr = it.next().context("local")?.parse()?;
-                let peer: Ipv4Addr = it.next().context("peer")?.parse()?;
+                // Accept either family; `local`/`peer` must match (both v4 or v6).
+                let local: IpAddr = it.next().context("local")?.parse()?;
+                let peer: IpAddr = it.next().context("peer")?.parse()?;
                 let tx_us: u64 = it.next().context("tx-us")?.parse()?;
                 let mult: u32 = it.next().context("mult")?.parse()?;
                 self.add(discr, local, peer, tx_us, mult.max(1));
@@ -178,20 +227,18 @@ impl EchoEngine {
         Ok(())
     }
 
-    fn add(&mut self, discr: u32, local: Ipv4Addr, peer: Ipv4Addr, tx_us: u64, mult: u32) {
+    fn add(&mut self, discr: u32, local: IpAddr, peer: IpAddr, tx_us: u64, mult: u32) {
         let _ = self.io(); // open the socket lazily (logs if it can't)
         let now = Instant::now();
         let tx = Duration::from_micros(tx_us.max(1));
         let detect = tx * mult;
-        let key = u32::from(local);
         // First session on this local IP → teach the XDP guard our address.
-        let refs = self.ip_refs.entry(key).or_insert(0);
-        if *refs == 0 {
-            if let Err(e) = self.local_ips.insert(key, 1u8, 0) {
-                warn!("bfd echo sender: OUR_LOCAL_IPS insert {local}: {e}");
-            }
-        }
+        let refs = self.ip_refs.entry(local).or_insert(0);
+        let first = *refs == 0;
         *refs += 1;
+        if first {
+            self.local_ip_insert(local);
+        }
         // Seed the kernel detector. The timer stays zeroed (uninitialized) until
         // XDP arms it on the first return; the kernel re-zeroes the timer region
         // on this update regardless. `detect_ns` is the re-arm delay.
@@ -210,7 +257,7 @@ impl EchoEngine {
             EchoSession {
                 local,
                 peer,
-                peer_mac: arp_lookup(self.ifindex, peer),
+                peer_mac: lookup_mac(self.ifindex, peer),
                 tx,
                 detect,
                 next_tx: now,
@@ -223,20 +270,24 @@ impl EchoEngine {
     }
 
     fn del(&mut self, discr: u32) {
-        if let Some(s) = self.sessions.remove(&discr) {
-            // Removing the map entry frees its embedded `bpf_timer` — the kernel
-            // cancels any pending fire (`bpf_obj_free_fields`).
-            let _ = self.timers.remove(&discr);
-            let key = u32::from(s.local);
-            if let Some(refs) = self.ip_refs.get_mut(&key) {
+        let Some(s) = self.sessions.remove(&discr) else {
+            return;
+        };
+        // Removing the map entry frees its embedded `bpf_timer` — the kernel
+        // cancels any pending fire (`bpf_obj_free_fields`).
+        let _ = self.timers.remove(&discr);
+        let drop_ip = match self.ip_refs.get_mut(&s.local) {
+            Some(refs) => {
                 *refs = refs.saturating_sub(1);
-                if *refs == 0 {
-                    self.ip_refs.remove(&key);
-                    let _ = self.local_ips.remove(&key);
-                }
+                *refs == 0
             }
-            debug!("bfd echo sender: del discr={discr}");
+            None => false,
+        };
+        if drop_ip {
+            self.ip_refs.remove(&s.local);
+            self.local_ip_remove(s.local);
         }
+        debug!("bfd echo sender: del discr={discr}");
     }
 
     /// Periodic work: transmit due Echoes and poll the kernel detector. Emits
@@ -251,11 +302,25 @@ impl EchoEngine {
         for (discr, s) in self.sessions.iter_mut() {
             if now >= s.next_tx {
                 if s.peer_mac.is_none() {
-                    s.peer_mac = arp_lookup(ifindex, s.peer);
+                    s.peer_mac = lookup_mac(ifindex, s.peer);
                 }
                 if let Some(mac) = s.peer_mac {
-                    let frame = build_echo(&if_mac, &mac, s.local, *discr, s.seq, now_micros());
-                    if let Err(e) = send_frame(fd, ifindex, &mac, &frame) {
+                    // Build the self-addressed Echo for the session's family and
+                    // send it; the peer's forwarding plane (our XDP reflector at
+                    // the far end) hairpins it back inbound.
+                    let res = match s.local {
+                        IpAddr::V4(local) => {
+                            let frame =
+                                build_echo(&if_mac, &mac, local, *discr, s.seq, now_micros());
+                            send_frame(fd, ifindex, ETH_P_IP, &mac, &frame)
+                        }
+                        IpAddr::V6(local) => {
+                            let frame =
+                                build_echo_v6(&if_mac, &mac, local, *discr, s.seq, now_micros());
+                            send_frame(fd, ifindex, ETH_P_IPV6, &mac, &frame)
+                        }
+                    };
+                    if let Err(e) = res {
                         debug!("bfd echo sender: tx discr={discr}: {e}");
                     }
                     s.seq = s.seq.wrapping_add(1);
@@ -336,6 +401,52 @@ fn build_echo(
     f
 }
 
+/// IPv6 analogue of [`build_echo`]: a self-addressed Eth/IPv6/UDP Echo frame.
+/// Source and destination IP are both `local` (link-local) so the peer hairpins
+/// it back; Hop Limit 255 (decremented once on the loop). IPv6 has no header
+/// checksum; the UDP checksum is mandatory and covers the IPv6 pseudo-header.
+fn build_echo_v6(
+    if_mac: &[u8; 6],
+    dst_mac: &[u8; 6],
+    local: Ipv6Addr,
+    discr: u32,
+    seq: u32,
+    ts: u64,
+) -> [u8; FRAME6_LEN] {
+    let mut f = [0u8; FRAME6_LEN];
+    // Ethernet
+    f[0..6].copy_from_slice(dst_mac);
+    f[6..12].copy_from_slice(if_mac);
+    f[12..14].copy_from_slice(&ETH_P_IPV6.to_be_bytes());
+    // IPv6 (40-byte fixed header)
+    {
+        let ip = &mut f[ETH_HLEN..ETH_HLEN + IP6_HLEN];
+        ip[0] = 0x60; // version 6, traffic class / flow label 0
+        let payload_len = (UDP_HLEN + PAYLOAD_LEN) as u16;
+        ip[4..6].copy_from_slice(&payload_len.to_be_bytes()); // Payload Length
+        ip[6] = IPPROTO_UDP; // Next Header
+        ip[7] = ECHO_TTL; // Hop Limit (255; peer decrements on the loop)
+        ip[8..24].copy_from_slice(&local.octets()); // src
+        ip[24..40].copy_from_slice(&local.octets()); // dst (self-addressed)
+    }
+    // UDP
+    let udp_off = ETH_HLEN + IP6_HLEN;
+    let udp_len = (UDP_HLEN + PAYLOAD_LEN) as u16;
+    f[udp_off..udp_off + 2].copy_from_slice(&BFD_ECHO_PORT.to_be_bytes());
+    f[udp_off + 2..udp_off + 4].copy_from_slice(&BFD_ECHO_PORT.to_be_bytes());
+    f[udp_off + 4..udp_off + 6].copy_from_slice(&udp_len.to_be_bytes());
+    // payload
+    let pl = udp_off + UDP_HLEN;
+    f[pl..pl + 4].copy_from_slice(&ECHO_MAGIC.to_be_bytes());
+    f[pl + 4..pl + 8].copy_from_slice(&discr.to_be_bytes());
+    f[pl + 8..pl + 12].copy_from_slice(&seq.to_be_bytes());
+    f[pl + 12..pl + 20].copy_from_slice(&ts.to_be_bytes());
+    // UDP checksum (mandatory for IPv6) over pseudo-header + UDP + payload
+    let udpck = udp_checksum_v6(&local, &local, &f[udp_off..]);
+    f[udp_off + 6..udp_off + 8].copy_from_slice(&udpck.to_be_bytes());
+    f
+}
+
 /// If `frame` is one of our looped Echoes, return `(discriminator, src-ip)`.
 /// Detection moved to the kernel (XDP matches our returns), so this is now only
 /// exercised by the build/parse round-trip test below.
@@ -394,6 +505,24 @@ fn udp_checksum(src: &Ipv4Addr, dst: &Ipv4Addr, udp: &[u8]) -> u16 {
     if ck == 0 { 0xffff } else { ck }
 }
 
+/// UDP checksum over the IPv6 pseudo-header (RFC 8200 §8.1) + UDP + payload.
+/// The pseudo-header is src(16) + dst(16) + 32-bit Upper-Layer Length +
+/// 24-bit zero + Next Header(UDP). IPv6 mandates a non-zero UDP checksum.
+fn udp_checksum_v6(src: &Ipv6Addr, dst: &Ipv6Addr, udp: &[u8]) -> u16 {
+    let mut sum = 0u32;
+    for a in [src.octets(), dst.octets()] {
+        let mut i = 0;
+        while i < 16 {
+            sum += u16::from_be_bytes([a[i], a[i + 1]]) as u32;
+            i += 2;
+        }
+    }
+    sum += udp.len() as u32; // Upper-Layer Packet Length (fits in 16 bits here)
+    sum += IPPROTO_UDP as u32; // Next Header (zero-padded high bytes contribute 0)
+    let ck = checksum(udp, sum);
+    if ck == 0 { 0xffff } else { ck }
+}
+
 // ---- socket / interface helpers ------------------------------------------
 
 fn if_nametoindex(iface: &str) -> Result<u32> {
@@ -448,6 +577,47 @@ fn arp_lookup(ifindex: u32, peer: Ipv4Addr) -> Option<[u8; 6]> {
     None
 }
 
+/// Resolve `peer` → MAC for either family on this interface.
+fn lookup_mac(ifindex: u32, peer: IpAddr) -> Option<[u8; 6]> {
+    match peer {
+        IpAddr::V4(p) => arp_lookup(ifindex, p),
+        IpAddr::V6(p) => ndp_lookup(ifindex, p),
+    }
+}
+
+/// Resolve an IPv6 (link-local) `peer` → MAC from the kernel neighbour cache via
+/// `ip -6 neigh show dev <ifname>`. There is no `/proc/net` equivalent for the
+/// IPv6 neighbour table; BFD control to the peer's link-local keeps the entry
+/// warm. `None` if unresolved yet (retried on the next tick).
+fn ndp_lookup(ifindex: u32, peer: Ipv6Addr) -> Option<[u8; 6]> {
+    let dev = ifname_of(ifindex)?;
+    let out = std::process::Command::new("ip")
+        .args(["-6", "neigh", "show", "dev", &dev])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    for line in text.lines() {
+        // "<addr> lladdr <mac> <state>" (dev given, so no %zone suffix).
+        let mut it = line.split_whitespace();
+        let Some(addr) = it.next() else { continue };
+        if addr.parse::<Ipv6Addr>().ok() != Some(peer) {
+            continue;
+        }
+        while let Some(tok) = it.next() {
+            if tok == "lladdr" {
+                let mac = it.next()?;
+                if mac != "00:00:00:00:00:00" {
+                    return parse_mac(mac).ok();
+                }
+            }
+        }
+    }
+    None
+}
+
 fn ifname_of(ifindex: u32) -> Option<String> {
     let mut buf = [0u8; libc::IF_NAMESIZE];
     let p = unsafe { libc::if_indextoname(ifindex, buf.as_mut_ptr() as *mut libc::c_char) };
@@ -485,10 +655,16 @@ fn open_af_packet(ifindex: u32) -> Result<OwnedFd> {
     Ok(fd)
 }
 
-fn send_frame(fd: i32, ifindex: u32, dst_mac: &[u8; 6], frame: &[u8]) -> std::io::Result<()> {
+fn send_frame(
+    fd: i32,
+    ifindex: u32,
+    ethertype: u16,
+    dst_mac: &[u8; 6],
+    frame: &[u8],
+) -> std::io::Result<()> {
     let mut sll: libc::sockaddr_ll = unsafe { std::mem::zeroed() };
     sll.sll_family = libc::AF_PACKET as u16;
-    sll.sll_protocol = (ETH_P_IP).to_be();
+    sll.sll_protocol = ethertype.to_be();
     sll.sll_ifindex = ifindex as i32;
     sll.sll_halen = 6;
     sll.sll_addr[..6].copy_from_slice(dst_mac);
@@ -560,5 +736,45 @@ mod tests {
             parse_mac("00:1c:42:45:b2:35").unwrap(),
             [0x00, 0x1c, 0x42, 0x45, 0xb2, 0x35]
         );
+    }
+
+    #[test]
+    fn build_echo_v6_layout_and_checksum() {
+        let if_mac = [0x02, 0, 0, 0, 0, 1];
+        let peer_mac = [0x02, 0, 0, 0, 0, 2];
+        let local: Ipv6Addr = "fe80::1".parse().unwrap();
+        let mut frame = build_echo_v6(&if_mac, &peer_mac, local, 0xdead_beef, 7, 12345);
+        assert_eq!(frame.len(), FRAME6_LEN);
+        // self-addressed: dst MAC = peer, ethertype = IPv6
+        assert_eq!(&frame[0..6], &peer_mac);
+        assert_eq!(u16::from_be_bytes([frame[12], frame[13]]), ETH_P_IPV6);
+        // IPv6 header: version 6, Next Header UDP, Hop Limit 255, src==dst==local
+        assert_eq!(frame[ETH_HLEN] >> 4, 6);
+        assert_eq!(frame[ETH_HLEN + 6], IPPROTO_UDP);
+        assert_eq!(frame[ETH_HLEN + 7], ECHO_TTL);
+        assert_eq!(&frame[ETH_HLEN + 8..ETH_HLEN + 24], &local.octets());
+        assert_eq!(&frame[ETH_HLEN + 24..ETH_HLEN + 40], &local.octets());
+        let udp_off = ETH_HLEN + IP6_HLEN;
+        assert_eq!(
+            u16::from_be_bytes([frame[udp_off + 2], frame[udp_off + 3]]),
+            BFD_ECHO_PORT
+        );
+        // payload magic + discriminator
+        let pl = udp_off + UDP_HLEN;
+        assert_eq!(
+            u32::from_be_bytes([frame[pl], frame[pl + 1], frame[pl + 2], frame[pl + 3]]),
+            ECHO_MAGIC
+        );
+        assert_eq!(
+            u32::from_be_bytes([frame[pl + 4], frame[pl + 5], frame[pl + 6], frame[pl + 7]]),
+            0xdead_beef
+        );
+        // The embedded UDP checksum recomputes from the zeroed field (non-zero,
+        // as IPv6 mandates).
+        let embedded = u16::from_be_bytes([frame[udp_off + 6], frame[udp_off + 7]]);
+        assert_ne!(embedded, 0);
+        frame[udp_off + 6] = 0;
+        frame[udp_off + 7] = 0;
+        assert_eq!(udp_checksum_v6(&local, &local, &frame[udp_off..]), embedded);
     }
 }

--- a/zebra-rs/src/bfd/inst.rs
+++ b/zebra-rs/src/bfd/inst.rs
@@ -380,12 +380,13 @@ impl Bfd {
     pub fn add_session(&mut self, key: SessionKey, params: SessionParams) -> u32 {
         let disc = self.sessions.insert(key, params);
 
-        // Echo is single-hop + IPv4 only (the XDP helper handles IPv4). Any
-        // active Echo role needs the per-interface helper: `receive` reflects a
-        // peer's Echo, `transmit` sends + detects ours. Bring it up and mark the
-        // session `echo_ready` once the child is confirmed running — until then
-        // we advertise 0 (an honest promise to actually loop Echo back).
-        if !params.echo_mode.is_off() && !key.multihop && key.remote.is_ipv4() {
+        // Echo is single-hop only; both IPv4 and IPv6 are handled (the XDP helper
+        // reflects either family). Any active Echo role needs the per-interface
+        // helper: `receive` reflects a peer's Echo, `transmit` sends + detects
+        // ours. Bring it up and mark the session `echo_ready` once the child is
+        // confirmed running — until then we advertise 0 (an honest promise to
+        // actually loop Echo back).
+        if !params.echo_mode.is_off() && !key.multihop {
             self.reflectors.acquire(key.ifindex);
             let ready = self.reflectors.is_ready(key.ifindex);
             if ready && let Some(s) = self.sessions.get_by_key_mut(&key) {
@@ -430,7 +431,6 @@ impl Bfd {
         if let Some(s) = &removed
             && !s.echo_mode.is_off()
             && !s.key.multihop
-            && s.key.remote.is_ipv4()
         {
             // Stop any originator first, while the helper is still alive — the
             // release below may be the last reference and tear the child down.
@@ -710,23 +710,29 @@ impl Bfd {
     /// We originate only while the session is **Up**, our configured Echo mode
     /// transmits (`transmit`/`both`), the peer advertises a non-zero Required Min
     /// Echo RX Interval (it will loop our Echo back), it is single-hop, and both
-    /// endpoints carry a concrete IPv4 address — the helper builds a
-    /// self-addressed L2 IPv4 frame and the forwarding plane hairpins it. The
+    /// endpoints carry a concrete address (IPv4, or an IPv6 link-local) — the
+    /// helper builds a self-addressed L2 frame and the forwarding plane hairpins
+    /// it. The
     /// transmit interval is our configured `echo-transmit-interval`, clamped up
     /// to the peer's advertised floor; detection is `interval × detect_mult`.
     fn echo_originate_reconcile(&mut self, key: SessionKey) {
         let Some(s) = self.sessions.get_by_key(&key) else {
             return;
         };
-        // Echo is single-hop IPv4 only; `local` must be a concrete source the
-        // helper can stamp as src==dst on the self-addressed frame.
-        let v4 = match (s.key.local, s.key.remote) {
+        // Echo is single-hop only; `local` must be a concrete (non-unspecified)
+        // source the helper can stamp as src==dst on the self-addressed frame.
+        // Both families are supported — the helper builds a v4 or v6 frame from
+        // the addresses (an IPv6 pair uses the two ends' link-locals).
+        let pair = match (s.key.local, s.key.remote) {
             (IpAddr::V4(local), IpAddr::V4(peer)) if !s.key.multihop && !local.is_unspecified() => {
-                Some((local, peer))
+                Some((IpAddr::V4(local), IpAddr::V4(peer)))
+            }
+            (IpAddr::V6(local), IpAddr::V6(peer)) if !s.key.multihop && !local.is_unspecified() => {
+                Some((IpAddr::V6(local), IpAddr::V6(peer)))
             }
             _ => None,
         };
-        let want = v4.is_some()
+        let want = pair.is_some()
             && s.local_state == bfd_packet::State::Up
             && s.echo_mode.transmits()
             && s.remote_min_echo_rx_us > 0;
@@ -736,7 +742,7 @@ impl Bfd {
         let ifindex = s.key.ifindex;
         let discr = s.local_disc;
         if want {
-            let (local, peer) = v4.expect("want implies a concrete IPv4 pair");
+            let (local, peer) = pair.expect("want implies a concrete address pair");
             // §6.8.9: the interval MUST NOT be below the peer's advertised
             // Required Min Echo RX Interval. Send at our configured rate, but
             // never faster than the peer's floor.

--- a/zebra-rs/src/bfd/show.rs
+++ b/zebra-rs/src/bfd/show.rs
@@ -205,11 +205,18 @@ struct BfdPeerDetailJson {
     negotiated_transmit_interval_us: u32,
     detection_time_us: u32,
     /// `Required Min Echo RX Interval` we advertise (0 = disabled). Non-zero
-    /// only while the XDP reflector is up on a single-hop IPv4 session.
+    /// only while the XDP reflector is up on a single-hop session.
     echo_receive_interval_us: u32,
     /// Echo transmission interval. Always 0 — zebra-rs is responder-only
     /// (it loops a peer's Echo back but does not originate Echo).
     echo_transmission_interval_us: u32,
+    /// Echo roles currently active on this session. `echo_transmit_active` is
+    /// set while we originate Echo (`transmit`/`both`, single-hop, peer
+    /// reflecting); `echo_receive_active` while we advertise a non-zero Required
+    /// Min Echo RX with a live reflector (`receive`/`both`). Drive the
+    /// per-direction view in `show bfd peers -j`.
+    echo_transmit_active: bool,
+    echo_receive_active: bool,
     remote_detect_multiplier: u8,
     remote_receive_interval_us: u32,
     remote_transmit_interval_us: u32,
@@ -249,6 +256,8 @@ fn detail_json(key: &SessionKey, s: &Session) -> BfdPeerDetailJson {
         detection_time_us: s.detection_time_us(),
         echo_receive_interval_us: s.advertised_echo_rx_us(),
         echo_transmission_interval_us: 0,
+        echo_transmit_active: s.echo_originating,
+        echo_receive_active: s.advertised_echo_rx_us() > 0,
         remote_detect_multiplier: s.remote_detect_mult,
         remote_receive_interval_us: s.remote_min_rx_us,
         remote_transmit_interval_us: s.remote_min_tx_us,

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1671,7 +1671,9 @@ impl Isis {
                 let Some(mut link) = self.link_top(ifindex) else {
                     return;
                 };
-                nbr_hold_timer_expire(&mut link, level, sys_id);
+                // Genuine hold-timer expiry: the peer is gone, so release the
+                // BFD session too (release_bfd = true).
+                nbr_hold_timer_expire(&mut link, level, sys_id, true);
 
                 link.state.nbrs.get_mut(&level).remove(&sys_id);
             }
@@ -1893,20 +1895,28 @@ impl Isis {
         let mut actions: Vec<(crate::bfd::session::SessionKey, bool)> = Vec::new();
         for (ifindex, link) in self.links.iter() {
             let enable = link.config.bfd.resolve(&self.config.bfd).enable;
-            let Some(local) = link.state.v4addr.first().map(|p| p.addr()) else {
-                continue;
-            };
+            let local_v4 = link.state.v4addr.first().map(|p| p.addr());
+            let local_v6ll = link.state.v6laddr.first().map(|p| p.addr());
             for level in [Level::L1, Level::L2] {
                 for nbr in link.state.nbrs.get(&level).values() {
                     if nbr.state != NfsmState::Up {
                         continue;
                     }
-                    let Some(remote) = nbr.addr4.keys().next().copied() else {
+                    // v4-preferred / v6-link-local fallback, same selection as
+                    // the NFSM subscribe path (see packet::bfd_session_key).
+                    let remote_v4 = nbr.addr4.keys().next().copied();
+                    let remote_v6ll = nbr.addr6l.first().copied();
+                    let Some((local, remote)) = super::packet::bfd_session_addrs(
+                        local_v4,
+                        remote_v4,
+                        local_v6ll,
+                        remote_v6ll,
+                    ) else {
                         continue;
                     };
                     let key = crate::bfd::session::SessionKey {
-                        local: std::net::IpAddr::V4(local),
-                        remote: std::net::IpAddr::V4(remote),
+                        local,
+                        remote,
                         ifindex: *ifindex,
                         multihop: false,
                     };
@@ -2328,16 +2338,45 @@ impl Isis {
         }
     }
 
-    /// Handle a [`crate::bfd::inst::BfdEvent`] forwarded by the BFD
-    /// instance. RFC 5882 §5: a BFD signal of session Down is
-    /// treated as a path-failure indication for the IS-IS
-    /// adjacency — we drive the same cleanup path as a hold-timer
-    /// expiry (`nbr_hold_timer_expire`), which drops the neighbor
-    /// entry, re-originates the local LSP, and kicks SPF.
+    /// Resolve the `(level, sys_id)` of the neighbour a BFD session belongs to
+    /// by matching `key.remote` against the neighbour's addresses on the
+    /// session's interface — `addr4` for an IPv4 session, the link-local
+    /// `addr6l` (or global `addr6`) for an IPv6 session. `require_up` restricts
+    /// the match to Up adjacencies (the Down path only tears an Up neighbour);
+    /// the Up path passes `false` because a held neighbour sits at Init.
+    fn bfd_resolve_neighbor(
+        &self,
+        key: &crate::bfd::session::SessionKey,
+        require_up: bool,
+    ) -> Option<(Level, IsisSysId)> {
+        let link = self.links.get(&key.ifindex)?;
+        for level in [Level::L1, Level::L2] {
+            let found = link.state.nbrs.get(&level).iter().find(|(_, nbr)| {
+                if require_up && nbr.state != NfsmState::Up {
+                    return false;
+                }
+                match key.remote {
+                    std::net::IpAddr::V4(r) => nbr.addr4.contains_key(&r),
+                    std::net::IpAddr::V6(r) => {
+                        nbr.addr6l.contains(&r) || nbr.addr6.contains_key(&r)
+                    }
+                }
+            });
+            if let Some((sys_id, _)) = found {
+                return Some((level, *sys_id));
+            }
+        }
+        None
+    }
+
+    /// Handle a [`crate::bfd::inst::BfdEvent`] forwarded by the BFD instance.
+    /// RFC 5882: a session going **Down** is a path-failure for the IS-IS
+    /// adjacency — tear it down and pin it in hold-down ([`Self::process_bfd_down`]);
+    /// a session coming **Up** lifts that pin ([`Self::process_bfd_up`]).
     ///
-    /// Synthetic Down→Down events (emitted by `Bfd::subscribe` so a
-    /// new subscriber can act on the current state immediately) are
-    /// ignored — they carry no real transition.
+    /// Synthetic Down→Down events (emitted by `Bfd::subscribe` so a new
+    /// subscriber can act on the current state immediately) carry no real
+    /// transition and are ignored.
     pub fn process_bfd_event(&mut self, event: crate::bfd::inst::BfdEvent) {
         let crate::bfd::inst::BfdEvent::StateChange { key, change } = event;
         tracing::info!(
@@ -2351,48 +2390,67 @@ impl Isis {
         if change.from == change.to {
             return;
         }
-        if change.to != bfd_packet::State::Down {
-            return;
+        match change.to {
+            bfd_packet::State::Down => self.process_bfd_down(&key, &change),
+            bfd_packet::State::Up => self.process_bfd_up(&key),
+            // Init / AdminDown are not actionable for the adjacency.
+            _ => {}
         }
+    }
 
-        // SessionKey carries (local, remote, ifindex). Find the matching
-        // (level, sys_id) by scanning the link's neighbor table on both
-        // levels for an entry whose `addr4` contains `remote`.
-        let std::net::IpAddr::V4(remote_v4) = key.remote else {
-            // IPv6 sessions arrive in a later PR.
-            return;
-        };
-        let ifindex = key.ifindex;
-
-        let target = self.links.get(&ifindex).and_then(|link| {
-            for level in [Level::L1, Level::L2] {
-                if let Some((sys_id, _)) = link.state.nbrs.get(&level).iter().find(|(_, nbr)| {
-                    nbr.state == NfsmState::Up && nbr.addr4.contains_key(&remote_v4)
-                }) {
-                    return Some((level, *sys_id));
-                }
-            }
-            None
-        });
-
-        let Some((level, sys_id)) = target else {
+    /// BFD session went Down: tear the adjacency (RFC 5882 §5) and pin it in
+    /// hold-down so subsequent IIHs cannot re-promote it. The BFD session is
+    /// kept subscribed (`release_bfd = false`) so it keeps probing and can
+    /// detect the peer returning, at which point [`Self::process_bfd_up`]
+    /// lifts the pin.
+    fn process_bfd_down(
+        &mut self,
+        key: &crate::bfd::session::SessionKey,
+        change: &crate::bfd::session::StateChange,
+    ) {
+        let Some((level, sys_id)) = self.bfd_resolve_neighbor(key, true) else {
             tracing::debug!(
                 ?key,
                 "isis: bfd-down for unknown / non-Up neighbor; ignoring"
             );
             return;
         };
+        let ifindex = key.ifindex;
         let Some(mut link) = self.link_top(ifindex) else {
             return;
         };
         tracing::warn!(
-            peer = %remote_v4,
+            peer = %key.remote,
             ifindex,
             ?level,
             diag = %change.diag,
             "isis: tearing down adjacency on bfd-down (RFC 5882 §5)",
         );
-        nbr_hold_timer_expire(&mut link, level, sys_id);
+        // Tear the adjacency but keep the BFD session probing. This clears any
+        // prior hold-down pin, so set the pin afterwards.
+        nbr_hold_timer_expire(&mut link, level, sys_id, false);
+        link.state.bfd_holddown.get_mut(&level).insert(sys_id);
+    }
+
+    /// BFD session came Up: lift any hold-down pin for the neighbour so the
+    /// next received IIH promotes its adjacency back to Up. A no-op when the
+    /// neighbour was not held (e.g. the normal first-Up after adjacency form).
+    fn process_bfd_up(&mut self, key: &crate::bfd::session::SessionKey) {
+        let Some((level, sys_id)) = self.bfd_resolve_neighbor(key, false) else {
+            return;
+        };
+        let Some(link) = self.links.get_mut(&key.ifindex) else {
+            return;
+        };
+        if link.state.bfd_holddown.get_mut(&level).remove(&sys_id) {
+            tracing::info!(
+                peer = %key.remote,
+                ifindex = key.ifindex,
+                ?level,
+                "isis: bfd recovered; lifting adjacency hold-down",
+            );
+            // The next received IIH re-promotes the held (Init) neighbour.
+        }
     }
     pub fn top(&mut self) -> IsisTop<'_> {
         IsisTop {
@@ -3064,6 +3122,46 @@ mod bfd_wiring_tests {
             Ipv4Addr::new(10, 99, 99, 99),
             State::Up,
             State::Down,
+        ));
+    }
+
+    fn make_event_v6(remote: std::net::Ipv6Addr, from: State, to: State) -> BfdEvent {
+        BfdEvent::StateChange {
+            key: SessionKey {
+                local: IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
+                remote: IpAddr::V6(remote),
+                ifindex: 0,
+                multihop: false,
+            },
+            change: StateChange {
+                from,
+                to,
+                diag: Diag::None,
+            },
+        }
+    }
+
+    /// An IPv6 BFD Down for an unknown peer exercises the v6 match arm of
+    /// `bfd_resolve_neighbor` (addr6l / addr6) and is a clean no-op when no
+    /// link / nbr matches — the IPv6 analogue of the IPv4 case above.
+    #[tokio::test]
+    async fn bfd_down_for_unknown_v6_peer_is_noop() {
+        let (mut isis, _bfd_rx) = fresh_isis_with_bfd();
+        isis.process_bfd_event(make_event_v6(
+            "fe80::1".parse().unwrap(),
+            State::Up,
+            State::Down,
+        ));
+    }
+
+    /// An IPv6 BFD Up with no held neighbour lifts nothing and must not panic.
+    #[tokio::test]
+    async fn bfd_up_for_unknown_v6_peer_is_noop() {
+        let (mut isis, _bfd_rx) = fresh_isis_with_bfd();
+        isis.process_bfd_event(make_event_v6(
+            "fe80::2".parse().unwrap(),
+            State::Init,
+            State::Up,
         ));
     }
 }

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -579,6 +579,14 @@ pub struct LinkState {
     // Up neighbors.
     pub nbrs_up: Levels<u32>,
 
+    // Neighbours whose attached BFD session is currently Down (RFC 5882
+    // §3.2 hold-down). While a neighbour's system-id sits in this set the
+    // NFSM refuses to (re-)promote its adjacency to Up even though IIHs keep
+    // arriving, and the BFD session is kept subscribed so it can detect the
+    // peer coming back. The entry is cleared when BFD reports the session Up
+    // again, or when the neighbour is torn down for real (hold-timer expiry).
+    pub bfd_holddown: Levels<BTreeSet<IsisSysId>>,
+
     // DIS status.
     pub dis_status: Levels<DisStatus>,
 

--- a/zebra-rs/src/isis/nfsm.rs
+++ b/zebra-rs/src/isis/nfsm.rs
@@ -48,8 +48,17 @@ pub fn nfsm_hold_timer(nbr: &Neighbor, level: Level) -> Timer {
     })
 }
 
-pub fn nbr_hold_timer_expire(link: &mut LinkTop, level: Level, sys_id: IsisSysId) {
+pub fn nbr_hold_timer_expire(
+    link: &mut LinkTop,
+    level: Level,
+    sys_id: IsisSysId,
+    release_bfd: bool,
+) {
     use IfsmEvent::*;
+
+    // RFC 5882 §3.2: this adjacency is being torn down for real, so drop any
+    // BFD hold-down pin for it (a no-op when none is set).
+    link.state.bfd_holddown.get_mut(&level).remove(&sys_id);
 
     let is_p2p = link.is_p2p();
 
@@ -68,10 +77,11 @@ pub fn nbr_hold_timer_expire(link: &mut LinkTop, level: Level, sys_id: IsisSysId
 
     let was_up = nbr.state == NfsmState::Up;
     let ifindex = nbr.ifindex;
-    // Snapshot the peer's IPv4 so we can send a BFD Unsubscribe
-    // after dropping the nbr borrow. nbr's addr4 is about to be
-    // wiped along with the entire entry below.
+    // Snapshot the peer's IPv4 and IPv6 link-local so we can send a BFD
+    // Unsubscribe after dropping the nbr borrow. nbr's addr maps are about to
+    // be wiped along with the entire entry below.
     let bfd_peer_v4 = nbr.addr4.keys().next().copied();
+    let bfd_peer_v6ll = nbr.addr6l.first().copied();
 
     // Originate Hello and LSP.
     if is_p2p {
@@ -116,21 +126,16 @@ pub fn nbr_hold_timer_expire(link: &mut LinkTop, level: Level, sys_id: IsisSysId
         *counter = counter.saturating_sub(1);
     }
 
-    // RFC 5882 §5: if the timed-out adjacency was Up and had BFD
-    // attached, release the BFD session. Idempotent with the
-    // packet.rs regression path that may already have sent the
-    // Unsubscribe.
-    if was_up
+    // RFC 5882 §5: if the timed-out adjacency was Up and had BFD attached,
+    // release the BFD session — but only when `release_bfd` is set. The
+    // BFD-down hold-down path passes `false` so the session keeps probing and
+    // can detect the peer returning. Idempotent with the packet.rs regression
+    // path that may already have sent the Unsubscribe.
+    if release_bfd
+        && was_up
         && link.config.bfd.resolve(&link.up_config.bfd).enable
-        && let Some(remote) = bfd_peer_v4
-        && let Some(local) = link.state.v4addr.first().map(|p| p.addr())
+        && let Some(key) = super::packet::bfd_session_key(link, bfd_peer_v4, bfd_peer_v6ll)
     {
-        let key = crate::bfd::session::SessionKey {
-            local: std::net::IpAddr::V4(local),
-            remote: std::net::IpAddr::V4(remote),
-            ifindex: link.ifindex,
-            multihop: false,
-        };
         let _ = link.tx.send(Message::BfdUnsubscribe(key));
     }
 

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -20,14 +20,56 @@ use crate::isis::{IfsmEvent, Message, NfsmState};
 use crate::isis_pdu_trace;
 use crate::rib::MacAddr;
 
+/// Pick the single-hop BFD endpoint addresses for an adjacency. Prefer a
+/// shared IPv4 pair (interface address + neighbour address); fall back to
+/// IPv6 link-local (interface link-local + neighbour link-local) for an
+/// IPv6-only adjacency — matching how IS-IS forms the adjacency and how
+/// single-hop BFD/NDP address the wire. Returns `(local, remote)`, or `None`
+/// when neither family has a usable pair.
+pub(super) fn bfd_session_addrs(
+    local_v4: Option<Ipv4Addr>,
+    remote_v4: Option<Ipv4Addr>,
+    local_v6ll: Option<Ipv6Addr>,
+    remote_v6ll: Option<Ipv6Addr>,
+) -> Option<(IpAddr, IpAddr)> {
+    if let (Some(l), Some(r)) = (local_v4, remote_v4) {
+        return Some((IpAddr::V4(l), IpAddr::V4(r)));
+    }
+    if let (Some(l), Some(r)) = (local_v6ll, remote_v6ll) {
+        return Some((IpAddr::V6(l), IpAddr::V6(r)));
+    }
+    None
+}
+
+/// Build the single-hop BFD `SessionKey` for an adjacency from a snapshot of
+/// the neighbour's addresses (`peer_v4` / `peer_v6ll`, taken before the `nbr`
+/// borrow is released) and the interface's own addresses. `None` when no
+/// usable address pair exists for either family.
+pub(super) fn bfd_session_key(
+    link: &super::link::LinkTop<'_>,
+    peer_v4: Option<Ipv4Addr>,
+    peer_v6ll: Option<Ipv6Addr>,
+) -> Option<SessionKey> {
+    let local_v4 = link.state.v4addr.first().map(|p| p.addr());
+    let local_v6ll = link.state.v6laddr.first().map(|p| p.addr());
+    let (local, remote) = bfd_session_addrs(local_v4, peer_v4, local_v6ll, peer_v6ll)?;
+    Some(SessionKey {
+        local,
+        remote,
+        ifindex: link.ifindex,
+        multihop: false,
+    })
+}
+
 /// Dispatch a BFD `Subscribe` or `Unsubscribe` based on an NFSM
 /// transition, called once per Hello *after* the mutable `nbr`
-/// borrow has been released. `peer_v4` is the snapshot taken before
-/// the nbr-mutating block so we don't need to reach back into
+/// borrow has been released. `peer_v4` / `peer_v6ll` are snapshots taken
+/// before the nbr-mutating block so we don't need to reach back into
 /// `link.state.nbrs` while `link.state.v4addr` is also borrowed.
 fn bfd_nfsm_dispatch(
     link: &super::link::LinkTop<'_>,
     peer_v4: Option<Ipv4Addr>,
+    peer_v6ll: Option<Ipv6Addr>,
     was_up: bool,
     state: NfsmState,
 ) {
@@ -36,14 +78,8 @@ fn bfd_nfsm_dispatch(
     if !link.config.bfd.resolve(&link.up_config.bfd).enable {
         return;
     }
-    let (Some(remote), Some(local)) = (peer_v4, link.state.v4addr.first().map(|p| p.addr())) else {
+    let Some(key) = bfd_session_key(link, peer_v4, peer_v6ll) else {
         return;
-    };
-    let key = SessionKey {
-        local: IpAddr::V4(local),
-        remote: IpAddr::V4(remote),
-        ifindex: link.ifindex,
-        multihop: false,
     };
     let is_up = state == NfsmState::Up;
     if !was_up && is_up {
@@ -287,6 +323,13 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
         return;
     }
 
+    // RFC 5882 §3.2 BFD hold-down: while this neighbour's attached BFD
+    // session is Down we keep its adjacency from (re-)reaching Up even though
+    // IIHs keep arriving. Snapshot the flag before borrowing `nbr` from
+    // `link.state.nbrs` (that borrow lasts until the post-FSM dispatch below).
+    let held = link.config.bfd.resolve(&link.up_config.bfd).enable
+        && link.state.bfd_holddown.get(&level).contains(&pdu.source_id);
+
     // Find neighbor by system id or create a new one.
     let nbr = link
         .state
@@ -396,6 +439,9 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
     // scope and we can no longer reach back into `link.state.nbrs`
     // while link.state.v4addr is also borrowed.
     let bfd_peer_v4: Option<Ipv4Addr> = nbr.addr4.keys().next().copied();
+    // IPv6-only adjacency: the single-hop BFD session is keyed on the
+    // neighbour's link-local (learned via TLV 232) and our own link-local.
+    let bfd_peer_v6ll: Option<Ipv6Addr> = nbr.addr6l.first().copied();
 
     if state == NfsmState::Down {
         // 8.4.2.5.1
@@ -414,8 +460,10 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
         // 8.4.2.5.1
         // When R reports the local system’s SNPA address in its Level n LAN IIH PDUs, the IS shall
         // d) set the adjacency’s adjacencyState to “Up”, and
-        // e) generate an adjacencyStateChange (Up)” event.
-        if has_mac {
+        // e) generate an adjacencyStateChange (Up)” event. The `!held` guard
+        // implements RFC 5882 §3.2: a neighbour whose BFD session is Down is
+        // pinned at Init until BFD recovers, even while IIHs keep arriving.
+        if has_mac && !held {
             state = NfsmState::Up;
             if link.tracing.should_trace_fsm() {
                 tracing::info!("[NBR] {} Init -> Up", nbr.sys_id);
@@ -470,6 +518,12 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
         // tracing::info!("NFSM {} => {}", nbr.state, state);
     }
 
+    // Defensive: a held neighbour must never sit at Up (the promotion guard
+    // above already prevents Init→Up; this also covers a stale Up snapshot).
+    if held && state == NfsmState::Up {
+        state = NfsmState::Init;
+    }
+
     nbr.state = state;
 
     // Up→{Init,Down} regressed by the peer (TLV 6 no longer reports
@@ -486,7 +540,7 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
 
     // RFC 5882 §5 BFD attachment, post-FSM. nbr has been dropped so
     // we can read link.state.v4addr / link.config.bfd freely.
-    bfd_nfsm_dispatch(link, bfd_peer_v4, was_up, state);
+    bfd_nfsm_dispatch(link, bfd_peer_v4, bfd_peer_v6ll, was_up, state);
 
     // CSNP + SRM kick on first RR. Deferred to here so we can take
     // `&mut link` after the `nbr` borrow has expired.
@@ -547,6 +601,11 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
             continue;
         }
 
+        // RFC 5882 §3.2 BFD hold-down — see the LAN handler. Snapshot the flag
+        // (per level) before borrowing `nbr` from `link.state.nbrs`.
+        let held = link.config.bfd.resolve(&link.up_config.bfd).enable
+            && link.state.bfd_holddown.get(&level).contains(&pdu.source_id);
+
         // Create or update neighbor for this level
         let nbr = link
             .state
@@ -605,6 +664,7 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
         let was_up = state == NfsmState::Up;
         // Snapshot before any mut-nbr work; see LAN handler comment.
         let bfd_peer_v4: Option<Ipv4Addr> = nbr.addr4.keys().next().copied();
+        let bfd_peer_v6ll: Option<Ipv6Addr> = nbr.addr6l.first().copied();
 
         // When it is three way handshake.
         if state == NfsmState::Down {
@@ -612,8 +672,9 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
             nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
         }
 
-        // Fall down from previous.
-        if state == NfsmState::Init && has_my_sys_id {
+        // Fall down from previous. The `!held` guard pins a BFD-down
+        // neighbour at Init (RFC 5882 §3.2) until BFD recovers.
+        if state == NfsmState::Init && has_my_sys_id && !held {
             state = NfsmState::Up;
 
             // Set adjacency.
@@ -657,6 +718,11 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
             // tracing::info!("NFSM {}:{} => {}", nbr.sys_id, nbr.state, state);
         }
 
+        // Defensive: a held neighbour must never sit at Up (see LAN handler).
+        if held && state == NfsmState::Up {
+            state = NfsmState::Init;
+        }
+
         nbr.state = state;
 
         // Same fast-converge as the LAN soft-down path: re-originate
@@ -670,7 +736,7 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
         // the LAN handler — defer until after the `nbr` mutable
         // borrow is gone so we can read link.state / link.config
         // freely.
-        bfd_nfsm_dispatch(link, bfd_peer_v4, was_up, state);
+        bfd_nfsm_dispatch(link, bfd_peer_v4, bfd_peer_v6ll, was_up, state);
 
         // CSNP+SRM kick on first RR. P2P always wins the
         // helper_elected_for_csnp predicate, so this fires every


### PR DESCRIPTION
## Summary

Brings up single-hop **BFD on IPv6-only IS-IS adjacencies** — control plane + full Echo dataplane — developed TDD from new BDD scenarios. Previously IS-IS BFD was IPv4-only (the event handler early-returned on IPv6 and Echo was gated to `is_ipv4()`).

**Control plane** — select the BFD endpoint addresses v4-first, falling back to the two ends' IPv6 link-locals (`nbr.addr6l` + interface `v6laddr`); handle IPv6 BFD down/up events; generalise `bfd_reconcile_all`. Address selection is centralised in `isis::packet::{bfd_session_addrs,bfd_session_key}` (mirrors OSPF's existing v3 link-local BFD).

**RFC 5882 hold-down gate** — the old teardown was one-shot, so with IIHs still flowing IS-IS re-formed the adjacency while BFD stayed Down. Added `link.state.bfd_holddown`: on BFD-down the adjacency is torn but the session keeps probing (`nbr_hold_timer_expire(release_bfd=false)`) and the sys-id is pinned; `!held` guards at the two NFSM Up-promotion points keep it `Init` until BFD recovers, which lifts the pin. This makes the BFD-down test deterministic.

**IPv6 Echo dataplane** — lift the three shared `is_ipv4()` echo gates (also enables OSPFv3 / single-hop eBGP-v6 Echo); the `xdp-bfd-echo` eBPF gains an `0x86DD` reflect path (`OUR_LOCAL_IPS_V6` map, Hop-Limit decrement, no checksum fix-up needed — IPv6 has no header checksum and the self-addressed Echo keeps the UDP checksum valid); the loader gains `build_echo_v6` / `udp_checksum_v6` / `ndp_lookup`; `show bfd peers -j` exposes `echo_transmit_active` / `echo_receive_active`.

**BDD** — `isis_bfd_ipv6_{p2p,lan}.feature` (6 scenarios: P2P/LAN × no-echo / echo-one-way / echo-both), IPv6-only configs, new steps (`bfd session … should be up/down`, `… should have echo {word}`, `I drop/restore bfd control packets` via ip6tables), and Makefile targets. The down-test drops inbound UDP/3784 so the link stays up and IIHs keep flowing — a fast teardown is provably BFD's doing, not carrier loss or the ~30s hold timer.

## Test plan

- `cargo test -p zebra-rs` — 892 pass (incl. new IPv6 BFD-event unit tests).
- `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `offload/xdp-bfd-echo`: builds (bpf-linker + nightly), loader unit tests incl. `build_echo_v6` pass.
- BDD is excluded from CI; run manually: `cd bdd && make isis_bfd_ipv6_p2p` / `make isis_bfd_ipv6_lan` (no-echo); `make isis_bfd_ipv6_{p2p,lan}_echo` (Echo scenarios — need the installed `xdp-bfd-echo` helper + XDP-capable netns).
- Real XDP-over-veth Echo reflection/detection not validated in this environment.

Generated with [Claude Code](https://claude.com/claude-code)