### PR TITLE
isis: improve Hello PDU trace logging

### DIFF
--- a/crates/isis-macros/src/lib.rs
+++ b/crates/isis-macros/src/lib.rs
@@ -13,7 +13,7 @@ use syn::{ItemFn, Token, parse_macro_input};
 /// #[isis_pdu_handler(Hello, Recv)]
 /// pub fn hello_p2p_recv(top: &mut IsisTop, packet: IsisPacket, ifindex: u32, mac: Option<MacAddr>) {
 ///     // _ISIS_PKT_TYPE and _ISIS_PKT_DIR are now available
-///     isis_pkt_trace!(top.tracing, &level, "[P2P Hello] recv on link {}", link.state.name);
+///     isis_pkt_trace!(top.tracing, &level, "[Hello P2P] recv on link {}", link.state.name);
 /// }
 /// ```
 #[proc_macro_attribute]

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -301,13 +301,23 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
 
     // Check link capability for the level.
     if !has_level(link.state.level(), level) {
-        isis_pdu_trace!(link, &level, "[Hello:Recv] Link does not have the level");
+        isis_pdu_trace!(
+            link,
+            &level,
+            "[Hello:Recv] {} Link does not have the level",
+            link.state.name
+        );
         return;
     }
 
     // Check link type.
     if !link.is_lan() {
-        isis_pdu_trace!(link, &level, "[Hello:Recv] Link type is not LAN");
+        isis_pdu_trace!(
+            link,
+            &level,
+            "[Hello:Recv] {} Link type is not LAN",
+            link.state.name
+        );
         return;
     }
 
@@ -564,25 +574,28 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
 
     // Process the Hello for each compatible level
     for level in [Level::L1, Level::L2] {
-        // Logging.
-        isis_pdu_trace!(link, &level, "[P2P Hello:Recv] on link {}", link.state.name);
-
         // Check if both sender and receiver support this level
         if !has_level(link_level, level) || !has_level(pdu_level, level) {
-            isis_pdu_trace!(
-                link,
-                &level,
-                "[P2P Hello:Recv] Link does not have enough level"
-            );
+            // Logging if level mismatch.
+            if has_level(link_level, level) || has_level(pdu_level, level) {
+                isis_pdu_trace!(
+                    link,
+                    &level,
+                    "[Hello P2P:Recv] Link level {link_level} and PDU level {pdu_level} mismatch",
+                );
+            }
             continue;
         }
+
+        // Logging.
+        isis_pdu_trace!(link, &level, "[Hello P2P:Recv] on link {}", link.state.name);
 
         // Check link type.
         if !link.is_p2p() {
             isis_pdu_trace!(
                 link,
                 &level,
-                "[P2P Hello:Recv] Link type is not point-to-point"
+                "[Hello P2P:Recv] Link type is not point-to-point"
             );
             return;
         }
@@ -596,7 +609,7 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
             isis_pdu_trace!(
                 link,
                 &level,
-                "[P2P Hello:Recv] L1 area mismatch — adjacency refused"
+                "[Hello P2P:Recv] L1 area mismatch — adjacency refused"
             );
             continue;
         }


### PR DESCRIPTION
## Summary

Improves IS-IS Hello PDU trace logging clarity:

- **LAN Hello**: include the link name in the "does not have the level" and "Link type is not LAN" rejection traces, so the log identifies which interface was rejected.
- **P2P Hello**: only emit a level-mismatch trace when the local and remote levels actually mismatch (previously logged on every level iteration), and report both `link_level` and `pdu_level` in the message. The per-iteration "on link" trace now fires only for compatible levels.
- **Tag rename**: normalize the trace tag from `[P2P Hello]` to `[Hello P2P]` for consistency across the Hello traces (including the macro doc example).

## Test plan

- `cargo fmt --all` — clean
- `cargo check -p zebra-rs` — compiles
- Trace-string-only changes; no behavioral logic change beyond logging conditions.

Generated with [Claude Code](https://claude.com/claude-code)