### PR TITLE
isis: build Protocols Supported TLV from per-interface AFI config

### DIFF
--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -28,12 +28,17 @@ pub enum IfsmEvent {
     DisSelection,
 }
 
-pub fn proto_supported(enable: &Afis<usize>) -> IsisTlvProtoSupported {
+/// Build the Protocols Supported TLV (RFC 1195 TLV 129) from the
+/// per-interface AFI configuration. The NLPIDs advertised in an IIH
+/// must reflect what *this circuit* runs, not what the instance runs
+/// somewhere else: a v4-only interface must not advertise IPv6 just
+/// because another interface in the same instance has IPv6 enabled.
+pub fn proto_supported(enable: &Afis<bool>) -> IsisTlvProtoSupported {
     let mut nlpids = vec![];
-    if enable.v4 > 0 {
+    if enable.v4 {
         nlpids.push(IsisProto::Ipv4.into());
     }
-    if enable.v6 > 0 {
+    if enable.v6 {
         nlpids.push(IsisProto::Ipv6.into());
     }
     IsisTlvProtoSupported { nlpids }
@@ -111,7 +116,7 @@ pub fn hello_generate(link: &LinkTop, level: Level) -> IsisHello {
         lan_id,
         tlvs: Vec::new(),
     };
-    let tlv = proto_supported(&link.up_config.enable);
+    let tlv = proto_supported(&link.config.enable);
     hello.tlvs.push(tlv.into());
 
     let area_addr = link.up_config.net.area_id();
@@ -199,8 +204,7 @@ pub fn hello_p2p_generate(link: &LinkTop, level: Level) -> IsisP2pHello {
         tlvs: Vec::new(),
     };
 
-    // Add protocol support TLV
-    let tlv = proto_supported(&link.up_config.enable);
+    let tlv = proto_supported(&link.config.enable);
     hello.tlvs.push(tlv.into());
 
     // Add area address TLV


### PR DESCRIPTION
## Summary

The IS-IS Protocols Supported TLV (RFC 1195 TLV 129) in Hello PDUs was built from the **instance-wide** AFI config (`link.up_config.enable`), whose `v4`/`v6` fields are *counts* of how many interfaces have each AFI enabled. As a result, a v4-only interface would still advertise IPv6 in its IIH whenever **any other** interface in the same IS-IS instance had IPv6 enabled.

This changes `proto_supported` to take the **per-interface** `Afis<bool>` (`link.config.enable`), so the advertised NLPIDs reflect what *this circuit* actually runs. It makes the NLPID advertisement consistent with the IPv6 interface-address TLVs, which were already gated on `link.config.enable.v6`.

- `proto_supported(&Afis<usize>)` → `proto_supported(&Afis<bool>)`
- Both callers — `hello_generate` (LAN IIH) and `hello_p2p_generate` (P2P IIH) — now pass `&link.config.enable`.

## Test plan

- `cargo build -p zebra-rs` ✓
- `cargo fmt --all` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓ (clean)

Generated with [Claude Code](https://claude.com/claude-code)