### PR TITLE
isis: gate IPv4 Interface Address TLV on per-interface AFI config

### DIFF
--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -122,13 +122,16 @@ pub fn hello_generate(link: &LinkTop, level: Level) -> IsisHello {
     let area_addr = link.up_config.net.area_id();
     let tlv = IsisTlvAreaAddr { area_addr };
     hello.tlvs.push(tlv.into());
-    for prefix in &link.state.v4addr {
-        hello.tlvs.push(
-            IsisTlvIpv4IfAddr {
-                addr: prefix.addr(),
-            }
-            .into(),
-        );
+
+    if link.config.enable.v4 {
+        for prefix in &link.state.v4addr {
+            hello.tlvs.push(
+                IsisTlvIpv4IfAddr {
+                    addr: prefix.addr(),
+                }
+                .into(),
+            );
+        }
     }
 
     // IPv6 Interface Address TLVs (RFC 5308 TLV 232 for link-local; non-standard
@@ -213,13 +216,15 @@ pub fn hello_p2p_generate(link: &LinkTop, level: Level) -> IsisP2pHello {
     hello.tlvs.push(tlv.into());
 
     // Add IPv4 interface addresses
-    for prefix in &link.state.v4addr {
-        hello.tlvs.push(
-            IsisTlvIpv4IfAddr {
-                addr: prefix.addr(),
-            }
-            .into(),
-        );
+    if link.config.enable.v4 {
+        for prefix in &link.state.v4addr {
+            hello.tlvs.push(
+                IsisTlvIpv4IfAddr {
+                    addr: prefix.addr(),
+                }
+                .into(),
+            );
+        }
     }
 
     // IPv6 Interface Address TLVs (RFC 5308 TLV 232 for link-local; non-standard


### PR DESCRIPTION
## Summary

The IPv4 Interface Address TLV (RFC 1195 TLV 132) in IS-IS Hello PDUs was emitted whenever the interface had an IPv4 address, regardless of whether IS-IS IPv4 was actually enabled on the circuit.

This gates the IPv4 interface-address TLV on `link.config.enable.v4` in both paths:
- `hello_generate` (LAN IIH)
- `hello_p2p_generate` (P2P IIH)

so we don't advertise an IPv4 interface address on a circuit that doesn't run IPv4. It mirrors the existing IPv6 interface-address gating on `link.config.enable.v6`, and complements the recently-landed per-interface Protocols Supported TLV (#1216).

## Test plan

- `cargo build -p zebra-rs` ✓
- `cargo fmt --all` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓ (clean)

Generated with [Claude Code](https://claude.com/claude-code)