### PR TITLE
ospf: make OSPFv2 interface cost configurable

### DIFF
--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -5,7 +5,7 @@ use super::Ospf;
 use super::OspfLink;
 use super::area::{AreaTypeKind, ExternalMetricType, NssaTranslatorRole, RedistEntry};
 use super::ifsm::{IfsmEvent, ospf_hello_timer};
-use super::link::{NbrStateThreshold, OspfAuthMode, OspfNetworkType};
+use super::link::{NbrStateThreshold, OSPF_DEFAULT_OUTPUT_COST, OspfAuthMode, OspfNetworkType};
 use super::version::{OspfVersion, Ospfv2};
 
 use crate::bfd::session::EchoMode;
@@ -96,6 +96,7 @@ impl Ospf {
             config_ospf_interface_network_type,
         );
         self.ospf_add("/area/interface/priority", config_ospf_interface_priority);
+        self.ospf_add("/area/interface/cost", config_ospf_interface_cost);
         self.ospf_add("/area/interface/affinity", config_ospf_interface_affinity);
         self.ospf_add(
             "/area/interface/te-metric/unidirectional-delay",
@@ -611,6 +612,30 @@ fn config_ospf_interface_priority(ospf: &mut Ospf, mut args: Args, op: ConfigOp)
     let _ = link
         .tx
         .send(Message::Ifsm(ifindex, IfsmEvent::NeighborChange));
+
+    Some(())
+}
+
+/// `/router/ospf/area/<id>/interface/<name>/cost` — RFC 2328 §C.3
+/// interface output cost, i.e. the metric stamped on this link in the
+/// Router-LSA (and the SPF edge weight). Stored straight into
+/// `link.output_cost`; clearing restores the protocol default (10).
+/// Because the metric rides in every attached area's Router-LSA,
+/// re-originate — which re-emits one Router-LSA per area and schedules
+/// that area's SPF — so the new cost takes effect immediately.
+fn config_ospf_interface_cost(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let _area_id = parse_area_id(&args.string()?)?;
+    let name = args.string()?;
+    let cost = args.u16()?;
+
+    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
+    link.output_cost = if op.is_set() {
+        cost as u32
+    } else {
+        OSPF_DEFAULT_OUTPUT_COST
+    };
+
+    ospf.router_lsa_originate();
 
     Some(())
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -508,6 +508,11 @@ module config {
             leaf priority {
               type uint8;
             }
+            leaf cost {
+              // RFC 2328 §C.3 interface output cost (Router-LSA link
+              // metric / SPF edge weight). 16-bit; default 10.
+              type uint16;
+            }
             leaf hello-interval {
               type uint16;
             }


### PR DESCRIPTION
## Summary

OSPFv2 interface output cost was hardcoded to `OSPF_DEFAULT_OUTPUT_COST` (10): the `ietf-ospf` *state* model exposed a `cost` leaf but the config-facing YANG + dispatch had none. Adds `/router/ospf/area/<id>/interface/<name>/cost` (uint16) and `config_ospf_interface_cost`, which writes `link.output_cost` and re-originates the Router-LSA (per attached area) so the metric takes effect immediately. VRF/OSPFv3 cost reuse the same callback shape (their config YANG lacks the leaf — follow-up).

Part of the OSPFv2 multi-area / ABR series (Phase 2). Phase 1 (#1211, per-area Router-LSA) already merged.

(Recreated against `main` after the stacked base branch was deleted on Phase 1 merge.)

Generated with [Claude Code](https://claude.com/claude-code)