### PR TITLE
ci: rename nightly workflow to "Nightly Build"

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,4 +1,4 @@
-name: Nightly Rolling Build
+name: Nightly Build
 
 on:
   # push:
@@ -166,7 +166,7 @@ jobs:
           path: ./packaging/*.deb
 
   # =====================================================================
-  # Publish all six .deb files as a Rolling "nightly" Release
+  # Publish all six .deb files as a "nightly" Release
   # =====================================================================
   release:
     name: Publish Nightly Release
@@ -203,7 +203,7 @@ jobs:
           name: "Nightly Build"
           prerelease: true
           body: |
-            Rolling nightly build from commit ${{ github.sha }}
+            Nightly build from commit ${{ github.sha }}
 
             Built at: ${{ github.event.repository.updated_at }}
 


### PR DESCRIPTION
## Summary

Drops the "Rolling" wording from the nightly workflow for consistency
with the GitHub Release name (which already reads "Nightly Build").

- Workflow `name:` — `Nightly Rolling Build` → `Nightly Build`
- Release-job comment — `... a Rolling "nightly" Release` → `... a "nightly" Release`
- Release body line — `Rolling nightly build from commit ...` → `Nightly build from commit ...`

## Test plan

- Documentation/label-only change to `.github/workflows/nightly.yaml`; no
  job logic, triggers, or steps modified.
- YAML structure unchanged (3 string replacements).

Generated with [Claude Code](https://claude.com/claude-code)