### PR TITLE
bfd: remove dead per-protocol `bfd profile` config

### DIFF
--- a/book/src/ch-10-00-bfd.md
+++ b/book/src/ch-10-00-bfd.md
@@ -145,11 +145,9 @@ runs with the FRR-aligned defaults (300 ms / ×3 ⇒ ~900 ms detection).
 Earlier revisions accepted a top-level `bfd { profile … }` block plus a
 per-neighbour / per-interface `profile <name>` reference, but the
 profile parameters were never resolved into the live session, so they
-had no effect on timers. The top-level block has been removed. A
-per-protocol `bfd { … profile <name>; }` leaf may still parse for
-backward compatibility, but there is nowhere to define a profile and it
-changes nothing. Configurable timers (per-protocol or via a reinstated
-profile mechanism) are a possible future addition.
+had no effect on timers. Both the top-level block and the per-protocol
+`profile` leaf have been removed. Configurable timers (per-protocol or
+via a reinstated profile mechanism) are a possible future addition.
 
 ## Verifying sessions
 
@@ -251,4 +249,4 @@ native timers would allow.
   no Echo).
 - **Not yet:** configurable control-packet timers (the intervals are
   fixed at the defaults); BFD for **static routes**; per-VRF OSPF BFD;
-  BFD `profile` resolution (stored, not yet applied).
+  a BFD `profile` mechanism.

--- a/zebra-rs/src/bfd/session.rs
+++ b/zebra-rs/src/bfd/session.rs
@@ -110,10 +110,9 @@ pub struct SessionParams {
 
 impl Default for SessionParams {
     fn default() -> Self {
-        // Match the FRR-aligned profile constants in [`super::config`]
-        // (300 ms intervals, ×3 ⇒ 900 ms detection). A session created
-        // without a resolved `bfd profile` must not negotiate slower
-        // than the configured default would: at 1 s our `required-min-rx`
+        // Match the FRR-aligned default constants in [`super::config`]
+        // (300 ms intervals, ×3 ⇒ 900 ms detection). A session must not
+        // negotiate slower than this default: at 1 s our `required-min-rx`
         // dragged FRR's transmit up to 1 s and the detection time to 3 s
         // on both ends. Sub-second rates comply with RFC 5880 §6.8.1.
         // `min_ttl` is the single-hop GTSM floor (RFC 5881 §5); multihop

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -695,13 +695,6 @@ fn config_bgp_bfd_enable(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<
     Some(())
 }
 
-/// `router bgp bfd profile <name>` — instance-default profile (stored only).
-fn config_bgp_bfd_profile(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let profile = args.string()?;
-    bgp.bfd.profile = op.is_set().then_some(profile);
-    Some(())
-}
-
 /// `router bgp bfd echo-mode <transmit|receive|both>` — instance default.
 fn config_bgp_bfd_echo_mode(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let value = args.string()?;
@@ -734,18 +727,6 @@ fn unspecified_for(remote: &IpAddr) -> IpAddr {
         IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
         IpAddr::V6(_) => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
     }
-}
-
-/// `set router bgp neighbor X bfd profile NAME` — selects the BFD
-/// profile applied when this neighbor's BFD session is created.
-/// Stored verbatim; resolution against `/bfd/profile/<name>` is
-/// the responsibility of the subscribe path.
-fn config_peer_bfd_profile(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let addr = args.addr()?;
-    let name = args.string()?;
-    let peer = bgp.peers.get_mut(&addr)?;
-    peer.config.bfd.profile = op.is_set().then_some(name);
-    Some(())
 }
 
 fn config_afi_safi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
@@ -1942,7 +1923,6 @@ impl Bgp {
         // `peer.config.bfd` and wires the runtime subscribe /
         // unsubscribe path to the BFD client API.
         self.callback_peer("/bfd/enable", config_peer_bfd_enable);
-        self.callback_peer("/bfd/profile", config_peer_bfd_profile);
         self.callback_peer("/bfd/multihop", config_peer_bfd_multihop);
         self.callback_peer("/bfd/minimum-ttl", config_peer_bfd_min_ttl);
         self.callback_peer("/bfd/echo-mode", config_peer_bfd_echo_mode);
@@ -1950,7 +1930,6 @@ impl Bgp {
         self.callback_peer("/bfd/echo-receive-interval", config_peer_bfd_echo_rx);
         // Instance-level `router bgp { bfd { ... } }` defaults.
         self.callback_add("/router/bgp/bfd/enable", config_bgp_bfd_enable);
-        self.callback_add("/router/bgp/bfd/profile", config_bgp_bfd_profile);
         self.callback_add("/router/bgp/bfd/echo-mode", config_bgp_bfd_echo_mode);
         self.callback_add(
             "/router/bgp/bfd/echo-transmit-interval",

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -192,7 +192,7 @@ pub struct PeerTransportConfig {
 
 /// Per-neighbor BFD attachment recorded from
 /// `set router bgp neighbor <addr> bfd { enable | multihop |
-/// minimum-ttl | profile }` (zebra-bgp-bfd.yang). The configuration is
+/// minimum-ttl }` (zebra-bgp-bfd.yang). The configuration is
 /// stored here; `enable` flips translate into subscribe / unsubscribe
 /// calls on the BFD instance via `bfd::inst::Bfd::client_req_tx`.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -201,7 +201,6 @@ pub struct PeerBfdConfig {
     /// `router bgp { bfd { enable } }`; `Some(false)` opts this neighbor out
     /// of a blanket instance enable. Off if unset everywhere.
     pub enable: Option<bool>,
-    pub profile: Option<String>,
     /// Hop-mode override. `None` (the default) means "infer": the
     /// session is multihop iff the BGP session is iBGP, mirroring FRR's
     /// `PEER_IS_MULTIHOP`. `Some(true)`/`Some(false)` force it — used
@@ -2037,27 +2036,25 @@ mod bfd_config_tests {
     use super::*;
 
     /// PeerBfdConfig default mirrors the YANG defaults (all unset ⇒
-    /// inherit; off if unset everywhere, no profile).
+    /// inherit; off if unset everywhere).
     #[test]
     fn default_bfd_is_disabled() {
         let bfd = PeerBfdConfig::default();
         assert!(bfd.enable.is_none());
         assert!(!bfd.resolve(&PeerBfdConfig::default()).enable);
-        assert!(bfd.profile.is_none());
 
         // Lives on PeerConfig with the same default.
         let pc = PeerConfig::default();
         assert_eq!(pc.bfd, bfd);
     }
 
-    /// Round-trip: setting enable + profile + multihop mirrors the CLI
-    /// flow (`bfd enable true; bfd profile FAST; bfd multihop true`)
+    /// Round-trip: setting enable + multihop + minimum-ttl mirrors the CLI
+    /// flow (`bfd enable true; bfd multihop true; bfd minimum-ttl 250`)
     /// producing the recorded state the BFD subscribe path reads.
     #[test]
-    fn enable_and_profile_round_trip() {
+    fn enable_and_multihop_round_trip() {
         let mut pc = PeerConfig::default();
         pc.bfd.enable = Some(true);
-        pc.bfd.profile = Some("FAST".to_string());
         pc.bfd.multihop = Some(true);
         pc.bfd.minimum_ttl = Some(250);
 
@@ -2065,7 +2062,6 @@ mod bfd_config_tests {
             pc.bfd,
             PeerBfdConfig {
                 enable: Some(true),
-                profile: Some("FAST".to_string()),
                 multihop: Some(true),
                 minimum_ttl: Some(250),
                 ..PeerBfdConfig::default()

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -281,10 +281,6 @@ impl Isis {
         // Per-interface BFD attachment.
         self.callback_add("/router/isis/interface/bfd/enable", link::config_bfd_enable);
         self.callback_add(
-            "/router/isis/interface/bfd/profile",
-            link::config_bfd_profile,
-        );
-        self.callback_add(
             "/router/isis/interface/bfd/echo-mode",
             link::config_bfd_echo_mode,
         );
@@ -298,7 +294,6 @@ impl Isis {
         );
         // Instance-level `router isis { bfd { ... } }` defaults.
         self.callback_add("/router/isis/bfd/enable", link::config_isis_bfd_enable);
-        self.callback_add("/router/isis/bfd/profile", link::config_isis_bfd_profile);
         self.callback_add(
             "/router/isis/bfd/echo-mode",
             link::config_isis_bfd_echo_mode,

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1870,8 +1870,8 @@ impl Isis {
         let _ = tx.send(crate::bfd::inst::ClientReq::Subscribe {
             client: "isis".to_string(),
             key,
-            // Profile resolution against `/bfd/profile/<name>` is still a
-            // follow-up (needs cross-task config access); only Echo is wired.
+            // Only Echo params are wired here; everything else uses the BFD
+            // session defaults.
             params: crate::bfd::session::SessionParams {
                 echo_mode,
                 required_min_echo_rx_us: echo_rx_us,

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -252,9 +252,9 @@ pub struct LinkConfig {
     pub mt_metrics: BTreeMap<MtId, u32>,
 
     /// Per-interface BFD attachment recorded from
-    /// `/router/isis/interface/<name>/bfd/{enable,profile}`. The
-    /// adjacency FSM subscribe path (on Up) and the
-    /// `BfdEvent::Down` → adjacency teardown path consume this.
+    /// `/router/isis/interface/<name>/bfd/enable`. The adjacency FSM
+    /// subscribe path (on Up) and the `BfdEvent::Down` → adjacency
+    /// teardown path consume this.
     pub bfd: LinkBfdConfig,
 
     /// SRLG group names this link belongs to (from the leaf-list at
@@ -314,7 +314,6 @@ pub struct LinkBfdConfig {
     /// interface; per-interface overrides it (`Some(false)` opts out). `None` ⇒
     /// inherit; off if unset everywhere.
     pub enable: Option<bool>,
-    pub profile: Option<String>,
     /// BFD Echo role for adjacencies on this interface
     /// (`transmit` / `receive` / `both`); `None` ⇒ inherit (off if unset
     /// everywhere). Single-hop IPv4 only — inert on IPv6-only adjacencies.
@@ -899,18 +898,6 @@ pub fn config_bfd_enable(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Optio
     Some(())
 }
 
-/// `set router isis interface X bfd profile NAME` — records the
-/// BFD profile to apply when this interface's adjacencies form a
-/// BFD session. Stored verbatim; resolution against
-/// `/bfd/profile/<name>` is the runtime subscribe path's job.
-pub fn config_bfd_profile(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
-    let name = args.string()?;
-    let profile = args.string()?;
-    let link = isis.links.get_mut_by_name(&name)?;
-    link.config.bfd.profile = op.is_set().then_some(profile);
-    Some(())
-}
-
 /// Parse the `{transmit|receive|both}` echo-mode enum (set) → `Some(mode)`, or
 /// `None` on delete. Shared by the per-interface and instance-level handlers.
 fn parse_echo_mode(value: &str, op: ConfigOp) -> Option<Option<EchoMode>> {
@@ -971,13 +958,6 @@ pub fn config_isis_bfd_enable(isis: &mut Isis, mut args: Args, op: ConfigOp) -> 
     let enable = args.boolean()?;
     isis.config.bfd.enable = op.is_set().then_some(enable);
     isis.bfd_reconcile_all();
-    Some(())
-}
-
-/// `router isis bfd profile <name>` — instance-default profile (stored only).
-pub fn config_isis_bfd_profile(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
-    let profile = args.string()?;
-    isis.config.bfd.profile = op.is_set().then_some(profile);
     Some(())
 }
 
@@ -2237,33 +2217,32 @@ mod bfd_config_tests {
     use super::*;
 
     /// LinkBfdConfig default mirrors the YANG defaults (all unset ⇒
-    /// inherit; off if unset everywhere, no profile).
+    /// inherit; off if unset everywhere).
     #[test]
     fn default_bfd_is_disabled() {
         let bfd = LinkBfdConfig::default();
         assert!(bfd.enable.is_none());
         assert!(!bfd.resolve(&LinkBfdConfig::default()).enable);
-        assert!(bfd.profile.is_none());
 
         // Lives on LinkConfig with the same default.
         let lc = LinkConfig::default();
         assert_eq!(lc.bfd, bfd);
     }
 
-    /// Round-trip: setting enable + profile mirrors the CLI flow
-    /// (`bfd enable true; bfd profile FAST`) producing the state
+    /// Round-trip: setting enable + echo-mode mirrors the CLI flow
+    /// (`bfd enable true; bfd echo-mode both`) producing the state
     /// the adjacency-FSM subscribe path reads.
     #[test]
-    fn enable_and_profile_round_trip() {
+    fn enable_round_trip() {
         let mut lc = LinkConfig::default();
         lc.bfd.enable = Some(true);
-        lc.bfd.profile = Some("FAST".to_string());
+        lc.bfd.echo_mode = Some(EchoMode::Both);
 
         assert_eq!(
             lc.bfd,
             LinkBfdConfig {
                 enable: Some(true),
-                profile: Some("FAST".to_string()),
+                echo_mode: Some(EchoMode::Both),
                 ..LinkBfdConfig::default()
             },
         );

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -56,10 +56,6 @@ impl Ospf {
             config_ospf_interface_bfd_enable,
         );
         self.ospf_add(
-            "/area/interface/bfd/profile",
-            config_ospf_interface_bfd_profile,
-        );
-        self.ospf_add(
             "/area/interface/bfd/min-neighbor-state",
             config_ospf_interface_bfd_min_neighbor_state,
         );
@@ -77,7 +73,6 @@ impl Ospf {
         );
         // Instance-level `router ospf { bfd { ... } }` defaults.
         self.ospf_add("/bfd/enable", config_ospf_bfd_enable);
-        self.ospf_add("/bfd/profile", config_ospf_bfd_profile);
         self.ospf_add(
             "/bfd/min-neighbor-state",
             config_ospf_bfd_min_neighbor_state,
@@ -760,23 +755,6 @@ pub(super) fn config_ospf_interface_bfd_enable<V: OspfVersion>(
     Some(())
 }
 
-/// `interface <if> bfd profile <name>` — stored verbatim; profile
-/// resolution into session parameters is a shared follow-up (BGP /
-/// IS-IS defer it too), so no reconcile is needed.
-pub(super) fn config_ospf_interface_bfd_profile<V: OspfVersion>(
-    ospf: &mut Ospf<V>,
-    mut args: Args,
-    op: ConfigOp,
-) -> Option<()> {
-    let _area_id = parse_area_id(&args.string()?)?;
-    let name = args.string()?;
-    let profile = args.string()?;
-
-    let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
-    link.config.bfd.profile = op.is_set().then_some(profile);
-    Some(())
-}
-
 /// `interface <if> bfd echo-mode <transmit|receive|both>` — which BFD Echo
 /// role is active on this interface (RFC 5880 §6.4): `transmit` originates,
 /// `receive` advertises + reflects, `both` does both. Single-hop IPv4 only.
@@ -886,18 +864,6 @@ pub(super) fn config_ospf_bfd_enable<V: OspfVersion>(
     let enable = args.boolean()?;
     ospf.bfd.enable = op.is_set().then_some(enable);
     ospf.bfd_reconcile_all();
-    Some(())
-}
-
-/// `router ospf bfd profile <name>` — instance-default profile. Stored only
-/// (profile resolution is a shared follow-up); no reconcile.
-pub(super) fn config_ospf_bfd_profile<V: OspfVersion>(
-    ospf: &mut Ospf<V>,
-    mut args: Args,
-    op: ConfigOp,
-) -> Option<()> {
-    let profile = args.string()?;
-    ospf.bfd.profile = op.is_set().then_some(profile);
     Some(())
 }
 

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -15,11 +15,11 @@ use super::config::{
     area_nssa_suppress_fa_set, area_nssa_translator_role_set, area_type_set,
     config_ospf_bfd_echo_mode, config_ospf_bfd_echo_receive_interval,
     config_ospf_bfd_echo_transmit_interval, config_ospf_bfd_enable,
-    config_ospf_bfd_min_neighbor_state, config_ospf_bfd_profile,
-    config_ospf_interface_bfd_echo_mode, config_ospf_interface_bfd_echo_receive_interval,
+    config_ospf_bfd_min_neighbor_state, config_ospf_interface_bfd_echo_mode,
+    config_ospf_interface_bfd_echo_receive_interval,
     config_ospf_interface_bfd_echo_transmit_interval, config_ospf_interface_bfd_enable,
-    config_ospf_interface_bfd_min_neighbor_state, config_ospf_interface_bfd_profile,
-    link_should_enable, ospf_link_get_mut_by_name, parse_area_id,
+    config_ospf_interface_bfd_min_neighbor_state, link_should_enable, ospf_link_get_mut_by_name,
+    parse_area_id,
 };
 use super::ifsm::{IfsmEvent, ospf_hello_timer};
 use super::link::OspfNetworkType;
@@ -58,10 +58,6 @@ impl Ospf<Ospfv3> {
                 config_ospf_interface_bfd_enable,
             ),
             (
-                "/area/interface/bfd/profile",
-                config_ospf_interface_bfd_profile,
-            ),
-            (
                 "/area/interface/bfd/min-neighbor-state",
                 config_ospf_interface_bfd_min_neighbor_state,
             ),
@@ -79,7 +75,6 @@ impl Ospf<Ospfv3> {
             ),
             // Instance-level `router ospfv3 { bfd { ... } }` defaults.
             ("/bfd/enable", config_ospf_bfd_enable),
-            ("/bfd/profile", config_ospf_bfd_profile),
             (
                 "/bfd/min-neighbor-state",
                 config_ospf_bfd_min_neighbor_state,

--- a/zebra-rs/src/ospf/link.rs
+++ b/zebra-rs/src/ospf/link.rs
@@ -222,7 +222,6 @@ pub struct OspfLinkBfdConfig {
     /// interface; per-interface it overrides (so `Some(false)` opts out).
     /// `None` ⇒ inherit; off if unset everywhere.
     pub enable: Option<bool>,
-    pub profile: Option<String>,
     /// Neighbor state at which the session starts/stops. `None` ⇒ inherit
     /// (hard default `TwoWay`).
     pub min_neighbor_state: Option<NbrStateThreshold>,
@@ -689,7 +688,6 @@ mod bfd_resolve_tests {
             echo_mode: Some(EchoMode::Receive),
             echo_transmit_ms: Some(100),
             echo_receive_ms: None, // → hard default 50
-            ..OspfLinkBfdConfig::default()
         };
 
         // Interface that sets nothing → inherits everything from the default.

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1247,10 +1247,6 @@ module config {
               "When true, attach BFD to every IS-IS interface's
                adjacencies (overridable per interface).";
           }
-          leaf profile {
-            ext:help "Default /bfd/profile (stored; not yet applied)";
-            type string;
-          }
           leaf echo-mode {
             ext:help "Default BFD Echo role (transmit | receive | both)";
             type enumeration {
@@ -1927,13 +1923,6 @@ module config {
                 "Activates the BFD session for adjacencies on this
                  interface. Disabling (or removing the `bfd` block)
                  detaches the session.";
-            }
-
-            leaf profile {
-              type string;
-              description
-                "Name of a `/bfd/profile` entry whose parameters
-                 apply to BFD sessions formed on this interface.";
             }
 
             leaf echo-mode {

--- a/zebra-rs/yang/zebra-bgp-bfd.yang
+++ b/zebra-rs/yang/zebra-bgp-bfd.yang
@@ -40,7 +40,6 @@ module zebra-bgp-bfd {
            remote-as 65501;
            bfd {
              enable true;
-             profile FAST;
              multihop true;       // eBGP-over-loopback; iBGP infers this
              minimum-ttl 250;
              echo-mode both;      // override (single-hop neighbors only)
@@ -88,12 +87,6 @@ module zebra-bgp-bfd {
         "Activate BFD. At the instance level, `true` blanket-enables BFD
          on every neighbor; per neighbor it overrides that default, so
          `false` opts a single neighbor out. Absent at both levels ⇒ off.";
-    }
-    leaf profile {
-      type string;
-      description
-        "Name of a `/bfd/profile` entry whose parameters apply to the
-         session. Stored; profile resolution is a shared follow-up.";
     }
     leaf echo-mode {
       ext:help "BFD Echo role (transmit | receive | both)";

--- a/zebra-rs/yang/zebra-ospf-bfd.yang
+++ b/zebra-rs/yang/zebra-ospf-bfd.yang
@@ -87,15 +87,6 @@ module zebra-ospf-bfd {
          off.";
     }
 
-    leaf profile {
-      ext:help "Named /bfd/profile to apply (stored; not yet applied)";
-      type string;
-      description
-        "Name of a BFD profile to apply to these sessions. Stored but not
-         yet resolved into session parameters — a shared follow-up across
-         BGP / IS-IS / OSPF; sessions currently use the BFD defaults.";
-    }
-
     leaf min-neighbor-state {
       ext:help "Neighbor state at which BFD starts (two-way|full)";
       type enumeration {


### PR DESCRIPTION
## Summary

Removes the inert `bfd { profile <name> }` configuration leaf from all three protocols. The leaf existed at six points — IS-IS (instance + per-interface), OSPF (instance + per-interface, v2 and v3), and BGP (instance + per-neighbor) — but only ever stored the string into a `profile: Option<String>` field that **no `resolve()` or session path read**. There is no `/bfd/profile` store to resolve it against, so it never affected a live session (the YANG even described it as "stored; not yet applied").

Removed per protocol:
- **YANG**: the `profile` leaf in `config.yang` (IS-IS ×2), `zebra-ospf-bfd.yang` (shared grouping), and `zebra-bgp-bfd.yang` (`bgp-bfd-common` grouping + the `profile FAST;` example).
- **Config plumbing**: the `config_*_bfd_profile` / `config_*_interface_bfd_profile` / `config_peer_bfd_profile` handlers, their callback registrations (incl. OSPFv3's `config_v3.rs` table + imports), and the `profile` struct fields on `LinkBfdConfig` / `OspfLinkBfdConfig` / `PeerBfdConfig`.
- **Tests/docs**: repurposed the `*_profile_round_trip` and `default_bfd_is_disabled` tests to cover the remaining leaves; refreshed stale comments (`isis/inst.rs`, `bfd/session.rs`) and the BFD book chapter (`ch-10-00-bfd.md`), which had claimed the per-protocol `profile` leaf "may still parse".

Net −122 lines. A historical FRR-citation in a YANG `revision` reference is kept (it documents the command that inspired the original revision).

## Test plan

- `cargo build -p zebra-rs` clean; `cargo test -p zebra-rs` — 895 pass (incl. YANG-load + the repurposed config tests).
- `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings` — clean (also dropped a now-`needless_update` `..default()` the removal exposed in an OSPF test).

Generated with [Claude Code](https://claude.com/claude-code)