### PR TITLE
vtyctl: ensure show/clear output always ends with a newline

### DIFF
--- a/vtyctl/src/clear.rs
+++ b/vtyctl/src/clear.rs
@@ -53,6 +53,9 @@ pub async fn clear(host: &str, command: &str) -> Result<()> {
 
     if !reply.str.is_empty() {
         print!("{}", reply.str);
+        if !reply.str.ends_with('\n') {
+            println!();
+        }
     }
 
     Ok(())

--- a/vtyctl/src/show.rs
+++ b/vtyctl/src/show.rs
@@ -53,8 +53,15 @@ pub async fn show(host: &str, command: &str, json: bool) -> Result<()> {
 
     let mut stream = response.into_inner();
 
+    let mut last_ended_with_newline = true;
     while let Some(reply) = stream.message().await? {
         print!("{}", reply.str);
+        if !reply.str.is_empty() {
+            last_ended_with_newline = reply.str.ends_with('\n');
+        }
+    }
+    if !last_ended_with_newline {
+        println!();
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

- `vtyctl show`: track whether the last streamed chunk ends with `\n`; print a bare newline after the loop if not
- `vtyctl clear`: same guard after the single `print!` call

Both subcommands used `print!` which passes the server's bytes verbatim. If the router's show/clear handler omits a trailing newline, zsh displays a stray `%` after the command returns (the "partial line" indicator). The fix ensures `vtyctl` always leaves the terminal cursor on a fresh line regardless of what the server sends.

## Test plan

- [ ] Run `vtyctl show "show ip route"` — confirm no stray `%` after output
- [ ] Run `vtyctl clear "clear ip bgp *"` — confirm no stray `%` after output
- [ ] Run BDD feature suite — confirm terminal state clean after each test

Generated with [Claude Code](https://claude.com/claude-code)