### PR TITLE
isis: fix bfd hold-down race + poll for neighbor teardown in BDD

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -892,6 +892,9 @@ async fn isis_neighbor_should_be_up(
 /// Negative sibling: assert NO Up adjacency at the given level on the given
 /// interface. Used to verify a Level-1 adjacency across an area boundary is
 /// (correctly) refused — the L1 common-area gate of ISO 10589 §8.4.3.
+///
+/// Polls for up to 10 seconds: the BFD-down event propagates asynchronously
+/// from the BFD task to IS-IS, so an immediate check races the teardown.
 #[then(
     expr = "isis neighbor in namespace {string} at level {int} on interface {string} should not be up"
 )]
@@ -902,7 +905,20 @@ async fn isis_neighbor_should_not_be_up(
     interface: String,
 ) {
     let scoped = world.ns(&namespace);
-    let (up, output) = isis_neighbor_up(&scoped, level, &interface).await;
+    const ATTEMPTS: u32 = 10;
+    let mut up = true;
+    let mut output = String::new();
+    for i in 0..ATTEMPTS {
+        let (u, o) = isis_neighbor_up(&scoped, level, &interface).await;
+        up = u;
+        output = o;
+        if !up {
+            break;
+        }
+        if i + 1 < ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    }
     assert!(
         !up,
         "unexpected Up L{} IS-IS adjacency on {} in {}:\n{}",

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2419,16 +2419,19 @@ impl Isis {
     /// kept subscribed (`release_bfd = false`) so it keeps probing and can
     /// detect the peer returning, at which point [`Self::process_bfd_up`]
     /// lifts the pin.
+    ///
+    /// `require_up = false`: the P2P 3-way rule may step the adjacency from
+    /// Up → Init (peer stops reporting our sys-id) before this BFD Down event
+    /// is processed. Using `require_up = true` would miss that neighbor, leave
+    /// the hold-down pin unset, and allow the adjacency to recover while BFD
+    /// is still Down.
     fn process_bfd_down(
         &mut self,
         key: &crate::bfd::session::SessionKey,
         change: &crate::bfd::session::StateChange,
     ) {
-        let Some((level, sys_id)) = self.bfd_resolve_neighbor(key, true) else {
-            tracing::debug!(
-                ?key,
-                "isis: bfd-down for unknown / non-Up neighbor; ignoring"
-            );
+        let Some((level, sys_id)) = self.bfd_resolve_neighbor(key, false) else {
+            tracing::debug!(?key, "isis: bfd-down for unknown neighbor; ignoring");
             return;
         };
         let ifindex = key.ifindex;


### PR DESCRIPTION
## Summary

Two fixes for the `isis_bfd_ipv6_p2p_echo` BDD scenarios failing at the
`isis neighbor … should not be up` step after BFD goes Down.

### 1. `process_bfd_down`: use `require_up = false`

The P2P 3-way rule can step the adjacency from Up → Init before the BFD
Down event reaches IS-IS: the peer's IIH stops reporting our sys-id (its
own BFD fired and it set its hold-down), so `hello_p2p_recv` transitions
the adjacency to Init.  With the old `require_up = true`,
`bfd_resolve_neighbor` found no Up neighbor and returned early — the
hold-down pin was never set, leaving a window for the adjacency to
recover while BFD was still Down.

Changing to `require_up = false` finds the Init-state neighbor too;
`nbr_hold_timer_expire` + `bfd_holddown.insert` then pin it correctly
regardless of which event arrives first.

### 2. BDD: `isis_neighbor_should_not_be_up` — poll for up to 10 s

The BFD Down event travels BFD task → async channel → IS-IS task.  An
immediate check could see the adjacency still Up before IS-IS processed
the event.  Now polls 10 × 1 s, consistent with how
`isis_neighbor_should_be_up` waits for adjacency formation.

## Test plan

- `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` pass locally.
- `cargo test --workspace --exclude bdd` (unit tests) unaffected.
- Manual BDD run: `make isis_bfd_ipv6_p2p_echo` — all three echo
  scenarios expected to reach the adjacency-down step without failure.

Generated with [Claude Code](https://claude.com/claude-code)