### PR TITLE
bdd: add isis neighbor check before ping in echo recovery steps

### DIFF
--- a/bdd/tests/features/isis_bfd_ipv6_lan.feature
+++ b/bdd/tests/features/isis_bfd_ipv6_lan.feature
@@ -86,6 +86,7 @@ Feature: IS-IS BFD over an IPv6-only LAN (broadcast) link
     When I restore bfd control packets in namespace "z2"
     And I wait 20 seconds
     Then bfd session in namespace "z1" on interface "vz1ns" should be up
+    And isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should be up
     And ping from "z1" to "2001:db8:0:ffff::2" should succeed
     When I stop zebra-rs in namespace "z1"
     And I stop zebra-rs in namespace "z2"
@@ -116,6 +117,7 @@ Feature: IS-IS BFD over an IPv6-only LAN (broadcast) link
     When I restore bfd control packets in namespace "z2"
     And I wait 20 seconds
     Then bfd session in namespace "z1" on interface "vz1ns" should be up
+    And isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should be up
     And ping from "z1" to "2001:db8:0:ffff::2" should succeed
     When I stop zebra-rs in namespace "z1"
     And I stop zebra-rs in namespace "z2"

--- a/bdd/tests/features/isis_bfd_ipv6_p2p.feature
+++ b/bdd/tests/features/isis_bfd_ipv6_p2p.feature
@@ -79,6 +79,7 @@ Feature: IS-IS BFD over an IPv6-only point-to-point link
     When I restore bfd control packets in namespace "z2"
     And I wait 20 seconds
     Then bfd session in namespace "z1" on interface "i1" should be up
+    And isis neighbor in namespace "z1" at level 2 on interface "i1" should be up
     And ping from "z1" to "2001:db8:0:ffff::2" should succeed
     When I stop zebra-rs in namespace "z1"
     And I stop zebra-rs in namespace "z2"
@@ -108,6 +109,7 @@ Feature: IS-IS BFD over an IPv6-only point-to-point link
     When I restore bfd control packets in namespace "z2"
     And I wait 20 seconds
     Then bfd session in namespace "z1" on interface "i1" should be up
+    And isis neighbor in namespace "z1" at level 2 on interface "i1" should be up
     And ping from "z1" to "2001:db8:0:ffff::2" should succeed
     When I stop zebra-rs in namespace "z1"
     And I stop zebra-rs in namespace "z2"


### PR DESCRIPTION
## Summary

- The BFD echo scenarios (`BFD with Echo in one direction` and `BFD with Echo in both directions`) were missing `isis neighbor should be up` in their recovery sections (after `I restore bfd control packets`).
- The no-echo scenario correctly has this check as a barrier before the ping.
- Without it, `bfd session should be up` passes (BFD recovers in ~2 s), but the ping immediately follows before IS-IS has re-formed the adjacency and installed the route to `2001:db8:0:ffff::2` (IIH interval up to 3 s after the hold-down pin is lifted).
- Fix: add `And isis neighbor ... should be up` before the ping in all four echo recovery sections (P2P one-direction, P2P both-direction, LAN one-direction, LAN both-direction).

## Test plan

- [ ] Run `make isis_bfd_ipv6_p2p_echo` — all three P2P scenarios (including echo recovery) should pass.
- [ ] Run `make isis_bfd_ipv6_lan_echo` — all three LAN scenarios should pass.
- [ ] CI `cargo test --workspace --exclude bdd` unaffected (feature files are not compiled).

Generated with [Claude Code](https://claude.com/claude-code)