### PR TITLE
bdd: poll for IS-IS neighbor Up after BFD recovery

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -867,6 +867,10 @@ async fn isis_neighbor_up(scoped: &str, level: u64, interface: &str) -> (bool, S
 
 /// Assert an IS-IS adjacency at the given level on the given interface is
 /// Up — e.g. the area-independent Level-2 backbone adjacency.
+///
+/// Polls for up to 30 seconds: after BFD recovers the hold-down pin is cleared
+/// immediately, but the adjacency only promotes Init→Up on the next inbound IIH
+/// (default 3 s interval), so a single-shot check races that window.
 #[then(
     expr = "isis neighbor in namespace {string} at level {int} on interface {string} should be up"
 )]
@@ -877,7 +881,20 @@ async fn isis_neighbor_should_be_up(
     interface: String,
 ) {
     let scoped = world.ns(&namespace);
-    let (up, output) = isis_neighbor_up(&scoped, level, &interface).await;
+    const ATTEMPTS: u32 = 30;
+    let mut up = false;
+    let mut output = String::new();
+    for i in 0..ATTEMPTS {
+        let (u, o) = isis_neighbor_up(&scoped, level, &interface).await;
+        up = u;
+        output = o;
+        if up {
+            break;
+        }
+        if i + 1 < ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    }
     assert!(
         up,
         "no Up L{} IS-IS adjacency on {} in {}:\n{}",


### PR DESCRIPTION
## Summary

- `isis_neighbor_should_be_up` was a single-shot check — no retry.
- After BFD recovers, `process_bfd_up` clears the hold-down pin immediately, but the IS-IS adjacency only promotes Init→Up on the **next inbound IIH** (default 3 s interval).
- `bfd_session_should_be_up` polls and passes as soon as BFD is Up; `isis_neighbor_should_be_up` then ran immediately and caught the adjacency still in Init.
- Fix: poll up to 30 × 1 s (matching the `bfd_session_should_be_up` pattern), which closes the IIH-arrival race window.

## Test plan

- [ ] `make isis_bfd_ipv6_p2p_echo` — both echo scenarios pass (were failing with Init-state adjacency)
- [ ] `make isis_bfd_ipv6_lan_echo` — both LAN echo scenarios pass
- [ ] No-echo scenarios unaffected (they already had IS-IS Up well before the check)
- [ ] CI: fmt/clippy/test

Generated with [Claude Code](https://claude.com/claude-code)