### PR TITLE
isis: fix bfd-up race when nbr removed before IIH re-creates entry

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -2449,18 +2449,49 @@ impl Isis {
         // prior hold-down pin, so set the pin afterwards.
         nbr_hold_timer_expire(&mut link, level, sys_id, false);
         link.state.bfd_holddown.get_mut(&level).insert(sys_id);
+        // Record the reverse mapping so process_bfd_up can clear the pin even
+        // if the neighbour entry is absent from `nbrs` at that point (race:
+        // BFD Up fires before the next IIH re-creates the entry).
+        link.state.bfd_holddown_nbr.insert(*key, (level, sys_id));
     }
 
     /// BFD session came Up: lift any hold-down pin for the neighbour so the
     /// next received IIH promotes its adjacency back to Up. A no-op when the
     /// neighbour was not held (e.g. the normal first-Up after adjacency form).
     fn process_bfd_up(&mut self, key: &crate::bfd::session::SessionKey) {
-        let Some((level, sys_id)) = self.bfd_resolve_neighbor(key, false) else {
-            return;
+        // Primary path: resolve via the live neighbour entry in `nbrs`.
+        let resolved = self.bfd_resolve_neighbor(key, false);
+
+        // Fallback: if the neighbour entry was removed from `nbrs` by
+        // nbr_hold_timer_expire (BFD Down → teardown) but BFD came back Up
+        // before the next IIH re-created the entry, use the reverse map that
+        // process_bfd_down recorded.
+        let (level, sys_id) = match resolved {
+            Some(pair) => pair,
+            None => {
+                let Some(link) = self.links.get_mut(&key.ifindex) else {
+                    return;
+                };
+                match link.state.bfd_holddown_nbr.remove(key) {
+                    Some(pair) => {
+                        tracing::info!(
+                            peer = %key.remote,
+                            ifindex = key.ifindex,
+                            "isis: bfd recovered via fallback map (nbr not yet re-created)",
+                        );
+                        pair
+                    }
+                    None => return,
+                }
+            }
         };
+
         let Some(link) = self.links.get_mut(&key.ifindex) else {
             return;
         };
+        // Also clean up the fallback map entry for this key (may already be
+        // gone if the fallback path above consumed it).
+        link.state.bfd_holddown_nbr.remove(key);
         if link.state.bfd_holddown.get_mut(&level).remove(&sys_id) {
             tracing::info!(
                 peer = %key.remote,

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::collections::HashMap;
 use std::collections::btree_map::Iter;
 use std::fmt::Write;
 use std::sync::Arc;
@@ -14,7 +15,7 @@ use strum_macros::{Display, EnumString};
 use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc::{self, UnboundedSender};
 
-use crate::bfd::session::EchoMode;
+use crate::bfd::session::{EchoMode, SessionKey};
 use crate::config::{Args, ConfigOp};
 use crate::context::Timer;
 use crate::isis_event_trace;
@@ -585,6 +586,14 @@ pub struct LinkState {
     // peer coming back. The entry is cleared when BFD reports the session Up
     // again, or when the neighbour is torn down for real (hold-timer expiry).
     pub bfd_holddown: Levels<BTreeSet<IsisSysId>>,
+
+    // Reverse map from BFD SessionKey → (Level, IsisSysId). Populated by
+    // process_bfd_down alongside bfd_holddown so that process_bfd_up can
+    // clear the hold-down pin even when the neighbour entry was already
+    // removed from `nbrs` by nbr_hold_timer_expire (race: BFD recovers
+    // before the next IIH re-creates the entry). Cleaned up by
+    // nbr_hold_timer_expire and process_bfd_up on use.
+    pub bfd_holddown_nbr: HashMap<SessionKey, (Level, IsisSysId)>,
 
     // DIS status.
     pub dis_status: Levels<DisStatus>,

--- a/zebra-rs/src/isis/nfsm.rs
+++ b/zebra-rs/src/isis/nfsm.rs
@@ -59,6 +59,9 @@ pub fn nbr_hold_timer_expire(
     // RFC 5882 §3.2: this adjacency is being torn down for real, so drop any
     // BFD hold-down pin for it (a no-op when none is set).
     link.state.bfd_holddown.get_mut(&level).remove(&sys_id);
+    link.state
+        .bfd_holddown_nbr
+        .retain(|_, (l, s)| *l != level || *s != sys_id);
 
     let is_p2p = link.is_p2p();
 


### PR DESCRIPTION
## Summary

- `process_bfd_down` removes the neighbour from `link.state.nbrs` (via `nbr_hold_timer_expire`) then sets the hold-down pin in `bfd_holddown`.
- If BFD recovers before the next IIH re-creates the entry (default 3 s hello interval), `bfd_resolve_neighbor` returns `None` and `process_bfd_up` silently returns — the pin is never cleared and the adjacency stays stuck at Init indefinitely.
- Fix: `process_bfd_down` now also inserts the `SessionKey → (Level, IsisSysId)` pair into a new `LinkState::bfd_holddown_nbr` fallback map. `process_bfd_up` consults this map when the primary neighbour lookup fails, clears the pin, and removes the entry. `nbr_hold_timer_expire` prunes the map on real teardown to prevent stale entries.

## Test plan

- [ ] `cargo test -p zebra-rs` — 896 tests pass, 0 failures
- [ ] `cargo fmt` — clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] BDD echo-recovery scenarios (`isis_bfd_ipv6_p2p` + `isis_bfd_ipv6_lan`) — neighbour now lifts hold-down even when BFD Up fires before the next IIH

Generated with [Claude Code](https://claude.com/claude-code)