### PR TITLE
isis: unify IPv4/IPv6 RIB/show code via IsisRibFamily generics

### DIFF
--- a/docs/design/isis-ipv4-ipv6-generics-remaining.md
+++ b/docs/design/isis-ipv4-ipv6-generics-remaining.md
@@ -1,0 +1,152 @@
+# IS-IS IPv4/IPv6 Generics — Remaining Items
+
+Branch: `isis-ipv4-ipv6-generics`
+
+## Completed (Items 1–9)
+
+| # | What | Files |
+|---|------|-------|
+| 1–4 | `SpfRoute<F>`, `SpfNexthop<F>`, `make_rib_entry<F>`, `diff_apply<F>`, `DiffResult<F>` | `rib.rs` |
+| 5 | `ReachMap<E>` generic + `ReachMapV4`/`ReachMapV6` aliases; manual `Default` | `graph.rs`, `inst.rs`, `lsdb.rs`, `link.rs` |
+| 6 | `summarize_frr<F>` (adds `backup_sr_len` to `IsisRibFamily`) | `show.rs`, `rib.rs` |
+| 7 | `write_rib_detail<F>` | `show.rs` |
+| 8 | `write_rib_table<F>` + `IsisRibFamilyShow` trait (`W_PREFIX`, `W_NEXTHOP`, `label_col`) | `show.rs` |
+| 9 | `write_isis_nhop_detail<F>` (`write_nhop_extra`, `write_sid_block`, `write_backup`) | `show.rs` |
+
+---
+
+## Remaining Items
+
+### Item 10 — `build_rib_from_spf` / `build_rib_from_spf_v6`
+
+**File:** `rib.rs:647` and `rib.rs:894`  
+**Difficulty:** Hard
+
+The two biggest functions in `rib.rs`. Structurally identical loop shape (walk SPF result, build nhop map, merge reach entries by metric, post-loop TI-LFA backup pass) but with these differences:
+
+| Aspect | V4 | V6 |
+|--------|----|----|
+| Extra parameter | — | `mt2_mode: bool` |
+| Reach map | `top.reach_map.get(level).get(&Afi::Ip).get(sys_id)` | `top.reach_map_v6` or `top.mt2_reach_map_v6` |
+| NLPID gating | None | `ipv6_capable_set` gate per RFC 1195 §5 (legacy mode only) |
+| Nexthop addresses | `nbr.addr4.iter()` keys | `nbr.addr6l.iter()` |
+| Prefix-SID | Full SRGB lookup → `sid`/`prefix_sid`/`no_php` | All `None` (deferred) |
+| TI-LFA backup | `build_repair_path_mpls` | `build_repair_path_srv6` |
+
+**Suggested approach:**  
+Extend `IsisRibFamily` with:
+
+```rust
+// Address iterator over the neighbor's addresses for this family.
+fn nhop_addrs<'a>(nbr: &'a Nbr) -> impl Iterator<Item = &'a Self::Addr>;
+
+// Reach entries for `sys_id` in the given reach map.
+fn reach_entries<'a>(
+    top: &'a IsisTop,
+    level: Level,
+    sys_id: &IsisSysId,
+    mt2_mode: bool,
+) -> Option<&'a Vec<…>>;
+
+// Resolve Prefix-SID to absolute label (None for V6 until SRv6 Prefix-SID lands).
+fn resolve_sid(
+    top: &IsisTop,
+    level: Level,
+    sys_id: &IsisSysId,
+    entry: &Self::TlvEntry,
+) -> (Option<u32>, Option<(SidLabelValue, LabelConfig)>, bool); // (sid, prefix_sid, no_php)
+
+// Build TI-LFA repair path.
+fn build_repair_path(
+    top: &mut IsisTop,
+    level: Level,
+    repair: &spf::RepairPath,
+) -> Option<Self::Backup>;
+```
+
+Then `build_rib_from_spf<F: IsisRibFamily>` takes an additional `mt2_mode: bool` and is
+generic over `F`.
+
+**Complication:** The NLPID gating loop (`'next_path:` with per-hop IPv6 check) is V6-only.
+The cleanest route is to move it into a family-specific `filter_path` trait method:
+```rust
+fn path_allowed(top: &IsisTop, level: Level, p: &[usize], mt2_mode: bool) -> bool;
+```
+`V4` returns `true` unconditionally; `V6` does the NLPID walk.
+
+The `TlvEntry` associated type (`IsisTlvExtIpReachEntry` vs `IsisTlvIpv6ReachEntry`) is the
+trickiest bound — both need `prefix()`, `metric()`, and optionally `prefix_sid()`.
+Either introduce a `ReachEntry` trait in `isis_packet`, or keep the entry-specific SID
+plumbing behind the `resolve_sid` trait method and pass the entry as `&dyn Any` (unclean) —
+prefer the trait.
+
+---
+
+### Item 11 — `ipv4_reach` / `ipv6_reach` in `bgp_ls.rs`
+
+**File:** `bgp_ls.rs:57` and `bgp_ls.rs:67`  
+**Difficulty:** Easy
+
+Bodies are byte-for-byte identical; only the input type differs (`Ipv4Net` vs `Ipv6Net`).
+Unify into a single `ip_reach(net: IpNet) -> LsPrefixDescriptor` using the `ipnet::IpNet`
+enum (both `Ipv4Net` and `Ipv6Net` implement `Into<IpNet>`):
+
+```rust
+fn ip_reach(net: IpNet) -> LsPrefixDescriptor {
+    let prefix_len = net.prefix_len();
+    let nbytes = prefix_len.div_ceil(8) as usize;
+    let octets: Vec<u8> = match net {
+        IpNet::V4(n) => n.network().octets().to_vec(),
+        IpNet::V6(n) => n.network().octets().to_vec(),
+    };
+    LsPrefixDescriptor::IpReachability { prefix_len, prefix: octets[..nbytes].to_vec() }
+}
+```
+
+Call sites change from `ipv4_reach(&e.prefix)` / `ipv6_reach(&e.prefix)` to
+`ip_reach(e.prefix.into())`.
+
+---
+
+### Item 12 — `ipv4_prefix_object` / `ipv6_prefix_object` in `bgp_ls.rs`
+
+**File:** `bgp_ls.rs:138` and `bgp_ls.rs:152`  
+**Difficulty:** Easy
+
+Differ only in the NLRI variant (`Ipv4Prefix` vs `Ipv6Prefix`) and the inner descriptor
+function (`ipv4_reach` → `ip_reach` after Item 11).  Can be unified once Item 11 is done:
+
+```rust
+fn prefix_object(
+    proto: LsProtocolId,
+    local: &IsisSysId,
+    net: IpNet,
+    metric: u32,
+) -> Object {
+    let nlri_variant = match net {
+        IpNet::V4(_) => |inner| BgpLsNlri::Ipv4Prefix(inner),
+        IpNet::V6(_) => |inner| BgpLsNlri::Ipv6Prefix(inner),
+    };
+    let nlri = nlri_variant(LsPrefixNlri {
+        protocol_id: proto,
+        identifier: 0,
+        local_node: node_descriptor(local),
+        prefix_descs: vec![ip_reach(net)],
+    });
+    (nlri, prefix_attr(metric))
+}
+```
+
+Items 11 and 12 are best done together in one PR since they're both in `bgp_ls.rs`.
+
+---
+
+## Suggested Order
+
+```
+Items 11+12  (bgp_ls.rs — trivial, isolated, low-risk)
+Item 10      (rib.rs — the big one; do last, needs trait extension design)
+```
+
+Item 10 is the last significant duplication.  After it lands the codebase will have a
+single generic `build_rib_from_spf<F>` that covers both address families and MT-2 mode.

--- a/zebra-rs/src/isis/bgp_ls.rs
+++ b/zebra-rs/src/isis/bgp_ls.rs
@@ -27,11 +27,8 @@ use bgp_packet::{
     BGPLS_ATTR_TE_DEFAULT_METRIC, BgpLsAttr, BgpLsNlri, LsLinkDescriptor, LsLinkNlri,
     LsNodeDescSub, LsNodeDescriptor, LsNodeNlri, LsPrefixDescriptor, LsPrefixNlri, LsProtocolId,
 };
-use ipnet::{Ipv4Net, Ipv6Net};
-use isis_packet::{
-    IsisLsp, IsisSysId, IsisTlv, IsisTlvExtIpReachEntry, IsisTlvExtIsReachEntry,
-    IsisTlvIpv6ReachEntry,
-};
+use ipnet::IpNet;
+use isis_packet::{IsisLsp, IsisSysId, IsisTlv, IsisTlvExtIsReachEntry};
 use tokio::sync::mpsc::Sender;
 
 use super::level::Level;
@@ -54,24 +51,14 @@ fn node_descriptor(sys_id: &IsisSysId) -> LsNodeDescriptor {
 
 /// Minimal-octet IP Reachability prefix descriptor: the prefix length in
 /// bits plus the high-order `ceil(len/8)` address octets (RFC 9552 §5.2.3).
-fn ipv4_reach(net: &Ipv4Net) -> LsPrefixDescriptor {
+fn ip_reach(net: IpNet) -> LsPrefixDescriptor {
     let prefix_len = net.prefix_len();
     let nbytes = prefix_len.div_ceil(8) as usize;
-    let octets = net.network().octets();
-    LsPrefixDescriptor::IpReachability {
-        prefix_len,
-        prefix: octets[..nbytes].to_vec(),
-    }
-}
-
-fn ipv6_reach(net: &Ipv6Net) -> LsPrefixDescriptor {
-    let prefix_len = net.prefix_len();
-    let nbytes = prefix_len.div_ceil(8) as usize;
-    let octets = net.network().octets();
-    LsPrefixDescriptor::IpReachability {
-        prefix_len,
-        prefix: octets[..nbytes].to_vec(),
-    }
+    let prefix = match net {
+        IpNet::V4(n) => n.network().octets()[..nbytes].to_vec(),
+        IpNet::V6(n) => n.network().octets()[..nbytes].to_vec(),
+    };
+    LsPrefixDescriptor::IpReachability { prefix_len, prefix }
 }
 
 /// The BGP-LS Attribute (path attribute type 29) carried alongside an NLRI.
@@ -135,28 +122,20 @@ fn link_object(proto: LsProtocolId, local: &IsisSysId, e: &IsisTlvExtIsReachEntr
     (nlri, link_attr(e))
 }
 
-fn ipv4_prefix_object(
-    proto: LsProtocolId,
-    local: &IsisSysId,
-    e: &IsisTlvExtIpReachEntry,
-) -> Object {
-    let nlri = BgpLsNlri::Ipv4Prefix(LsPrefixNlri {
+fn prefix_object(proto: LsProtocolId, local: &IsisSysId, prefix: IpNet, metric: u32) -> Object {
+    let is_v4 = matches!(prefix, IpNet::V4(_));
+    let inner = LsPrefixNlri {
         protocol_id: proto,
         identifier: 0,
         local_node: node_descriptor(local),
-        prefix_descs: vec![ipv4_reach(&e.prefix)],
-    });
-    (nlri, prefix_attr(e.metric))
-}
-
-fn ipv6_prefix_object(proto: LsProtocolId, local: &IsisSysId, e: &IsisTlvIpv6ReachEntry) -> Object {
-    let nlri = BgpLsNlri::Ipv6Prefix(LsPrefixNlri {
-        protocol_id: proto,
-        identifier: 0,
-        local_node: node_descriptor(local),
-        prefix_descs: vec![ipv6_reach(&e.prefix)],
-    });
-    (nlri, prefix_attr(e.metric))
+        prefix_descs: vec![ip_reach(prefix)],
+    };
+    let nlri = if is_v4 {
+        BgpLsNlri::Ipv4Prefix(inner)
+    } else {
+        BgpLsNlri::Ipv6Prefix(inner)
+    };
+    (nlri, prefix_attr(metric))
 }
 
 /// Translate every Link-State object implied by one IS-IS LSP into BGP-LS
@@ -196,22 +175,22 @@ pub fn lsp_to_objects(level: Level, lsp: &IsisLsp) -> Vec<Object> {
             }
             IsisTlv::ExtIpReach(t) => {
                 for e in &t.entries {
-                    out.push(ipv4_prefix_object(proto, &local, e));
+                    out.push(prefix_object(proto, &local, e.prefix.into(), e.metric));
                 }
             }
             IsisTlv::MtIpReach(t) => {
                 for e in &t.entries {
-                    out.push(ipv4_prefix_object(proto, &local, e));
+                    out.push(prefix_object(proto, &local, e.prefix.into(), e.metric));
                 }
             }
             IsisTlv::Ipv6Reach(t) => {
                 for e in &t.entries {
-                    out.push(ipv6_prefix_object(proto, &local, e));
+                    out.push(prefix_object(proto, &local, e.prefix.into(), e.metric));
                 }
             }
             IsisTlv::MtIpv6Reach(t) => {
                 for e in &t.entries {
-                    out.push(ipv6_prefix_object(proto, &local, e));
+                    out.push(prefix_object(proto, &local, e.prefix.into(), e.metric));
                 }
             }
             _ => {}
@@ -399,7 +378,8 @@ mod tests {
         assert!(advertised.is_empty());
     }
     use isis_packet::{
-        IsisLspId, IsisNeighborId, IsisTlvExtIpReach, IsisTlvExtIsReach, IsisTlvExtIsReachEntry,
+        IsisLspId, IsisNeighborId, IsisTlvExtIpReach, IsisTlvExtIpReachEntry, IsisTlvExtIsReach,
+        IsisTlvExtIsReachEntry,
     };
 
     fn sysid(last: u8) -> IsisSysId {

--- a/zebra-rs/src/isis/graph.rs
+++ b/zebra-rs/src/isis/graph.rs
@@ -13,51 +13,34 @@ use super::flex_algo::{FadMetricType, FlexAlgoEntry, link_passes_fad, local_link
 use super::inst::IsisTop;
 use super::level::Level;
 
-#[derive(Default)]
-pub struct ReachMap {
-    map: BTreeMap<IsisSysId, Vec<IsisTlvExtIpReachEntry>>,
+pub struct ReachMap<E> {
+    map: BTreeMap<IsisSysId, Vec<E>>,
 }
 
-impl ReachMap {
-    pub fn get(&self, key: &IsisSysId) -> Option<&Vec<IsisTlvExtIpReachEntry>> {
+impl<E> Default for ReachMap<E> {
+    fn default() -> Self {
+        Self {
+            map: BTreeMap::new(),
+        }
+    }
+}
+
+impl<E> ReachMap<E> {
+    pub fn get(&self, key: &IsisSysId) -> Option<&Vec<E>> {
         self.map.get(key)
     }
 
-    pub fn insert(
-        &mut self,
-        key: IsisSysId,
-        value: Vec<IsisTlvExtIpReachEntry>,
-    ) -> Option<Vec<IsisTlvExtIpReachEntry>> {
+    pub fn insert(&mut self, key: IsisSysId, value: Vec<E>) -> Option<Vec<E>> {
         self.map.insert(key, value)
     }
 
-    pub fn remove(&mut self, key: &IsisSysId) -> Option<Vec<IsisTlvExtIpReachEntry>> {
+    pub fn remove(&mut self, key: &IsisSysId) -> Option<Vec<E>> {
         self.map.remove(key)
     }
 }
 
-#[derive(Default)]
-pub struct ReachMapV6 {
-    map: BTreeMap<IsisSysId, Vec<IsisTlvIpv6ReachEntry>>,
-}
-
-impl ReachMapV6 {
-    pub fn get(&self, key: &IsisSysId) -> Option<&Vec<IsisTlvIpv6ReachEntry>> {
-        self.map.get(key)
-    }
-
-    pub fn insert(
-        &mut self,
-        key: IsisSysId,
-        value: Vec<IsisTlvIpv6ReachEntry>,
-    ) -> Option<Vec<IsisTlvIpv6ReachEntry>> {
-        self.map.insert(key, value)
-    }
-
-    pub fn remove(&mut self, key: &IsisSysId) -> Option<Vec<IsisTlvIpv6ReachEntry>> {
-        self.map.remove(key)
-    }
-}
+pub type ReachMapV4 = ReachMap<IsisTlvExtIpReachEntry>;
+pub type ReachMapV6 = ReachMap<IsisTlvIpv6ReachEntry>;
 
 /// Stable mapping between IS-IS LSP identities and the integer
 /// vertex ids used by the SPF graph. Keyed by `IsisNeighborId`

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -30,7 +30,7 @@ use crate::{
 
 use super::config::{IsisConfig, MtId};
 use super::flood;
-use super::graph::{LspMap, ReachMap, ReachMapV6};
+use super::graph::{LspMap, ReachMapV4, ReachMapV6};
 use super::ifsm::{csnp_timer, has_level};
 use super::link::{Afis, IsisLinks, LinkTop};
 use super::lsdb::insert_self_originate;
@@ -179,7 +179,7 @@ pub struct Isis {
     pub tracing: IsisTracing,
     pub lsdb: Levels<Lsdb>,
     pub lsp_map: Levels<LspMap>,
-    pub reach_map: Levels<Afis<ReachMap>>,
+    pub reach_map: Levels<Afis<ReachMapV4>>,
     pub reach_map_v6: Levels<ReachMapV6>,
 
     /// MT 2 (IPv6 unicast) IPv6 reach indexed per peer. Populated from
@@ -482,7 +482,7 @@ pub struct IsisTop<'a> {
     pub tracing: &'a IsisTracing,
     pub lsdb: &'a mut Levels<Lsdb>,
     pub lsp_map: &'a mut Levels<LspMap>,
-    pub reach_map: &'a mut Levels<Afis<ReachMap>>,
+    pub reach_map: &'a mut Levels<Afis<ReachMapV4>>,
     pub reach_map_v6: &'a mut Levels<ReachMapV6>,
     pub mt2_reach_map_v6: &'a mut Levels<ReachMapV6>,
     pub mt_membership: &'a mut Levels<BTreeMap<IsisSysId, BTreeSet<MtId>>>,
@@ -640,7 +640,7 @@ impl Isis {
                 tracing: IsisTracing::default(),
                 lsdb: Levels::<Lsdb>::default(),
                 lsp_map: Levels::<LspMap>::default(),
-                reach_map: Levels::<Afis<ReachMap>>::default(),
+                reach_map: Levels::<Afis<ReachMapV4>>::default(),
                 reach_map_v6: Levels::<ReachMapV6>::default(),
                 mt2_reach_map_v6: Levels::<ReachMapV6>::default(),
                 mt_membership: Levels::<BTreeMap<IsisSysId, BTreeSet<MtId>>>::default(),

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -40,8 +40,7 @@ use super::lsp::{
 };
 use super::nfsm::nbr_hold_timer_expire;
 use super::rib::{
-    SpfIlm, SpfRoute, SpfRouteV6, apply_spf_result, build_spf_input, compute_spf,
-    update_self_sid_ilm,
+    SpfIlm, SpfRoute, V4, V6, apply_spf_result, build_spf_input, compute_spf, update_self_sid_ilm,
 };
 use super::srlg::{SrlgGroup, SrlgGroupBuilder};
 use super::srmpls::IsisLabelMap;
@@ -239,8 +238,8 @@ pub struct Isis {
     /// not contain the algo being computed (RFC 9350 §5.2
     /// participation requirement). Cleared on peer purge.
     pub peer_algos: Levels<BTreeMap<IsisSysId, BTreeSet<u8>>>,
-    pub rib: Levels<PrefixMap<Ipv4Net, SpfRoute>>,
-    pub rib_v6: Levels<PrefixMap<Ipv6Net, SpfRouteV6>>,
+    pub rib: Levels<PrefixMap<Ipv4Net, SpfRoute<V4>>>,
+    pub rib_v6: Levels<PrefixMap<Ipv6Net, SpfRoute<V6>>>,
     pub ilm: Levels<BTreeMap<u32, SpfIlm>>,
     /// Currently-installed local (self-originated) Prefix-SID ILM
     /// entries, keyed by MPLS label. Level-independent (the label is
@@ -311,7 +310,7 @@ pub struct Isis {
     /// entries derived from these routes do install (labels are
     /// globally unique, so they merge into the same `Isis::ilm` map
     /// alongside the algo-0 entries).
-    pub rib_flex_algo: Levels<BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>>>,
+    pub rib_flex_algo: Levels<BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>>>,
 
     /// SR-update return channel from the RIB. Carries the current value of
     /// the watched block / locator and any subsequent updates.
@@ -514,8 +513,8 @@ pub struct IsisTop<'a> {
     /// rebuild path can populate it from peer Router Capability
     /// SR-Algorithms sub-TLVs.
     pub peer_algos: &'a mut Levels<BTreeMap<IsisSysId, BTreeSet<u8>>>,
-    pub rib: &'a mut Levels<PrefixMap<Ipv4Net, SpfRoute>>,
-    pub rib_v6: &'a mut Levels<PrefixMap<Ipv6Net, SpfRouteV6>>,
+    pub rib: &'a mut Levels<PrefixMap<Ipv4Net, SpfRoute<V4>>>,
+    pub rib_v6: &'a mut Levels<PrefixMap<Ipv6Net, SpfRoute<V6>>>,
     pub ilm: &'a mut Levels<BTreeMap<u32, SpfIlm>>,
     pub rib_client: &'a crate::rib::client::RibClient,
     pub hostname: &'a mut Levels<Hostname>,
@@ -545,7 +544,7 @@ pub struct IsisTop<'a> {
     /// Per-algorithm IPv4 RIB (see `Isis::rib_flex_algo`). Threaded
     /// so `apply_spf_result` can install the per-algo RIB snapshot
     /// after each SPF cycle.
-    pub rib_flex_algo: &'a mut Levels<BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>>>,
+    pub rib_flex_algo: &'a mut Levels<BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>>>,
 
     /// Read-only access to the SR snapshot the IS-IS instance is caching
     /// from RIB::SrSubscribe. lsp_generate uses these to populate the SR
@@ -660,8 +659,8 @@ impl Isis {
                     BTreeMap<IsisSysId, BTreeMap<(u8, Ipv4Net), isis_packet::SidLabelValue>>,
                 >::default(),
                 peer_algos: Levels::<BTreeMap<IsisSysId, BTreeSet<u8>>>::default(),
-                rib: Levels::<PrefixMap<Ipv4Net, SpfRoute>>::default(),
-                rib_v6: Levels::<PrefixMap<Ipv6Net, SpfRouteV6>>::default(),
+                rib: Levels::<PrefixMap<Ipv4Net, SpfRoute<V4>>>::default(),
+                rib_v6: Levels::<PrefixMap<Ipv6Net, SpfRoute<V6>>>::default(),
                 ilm: Levels::<BTreeMap<u32, SpfIlm>>::default(),
                 self_sid_ilm: BTreeMap::new(),
                 hostname: Levels::<Hostname>::default(),
@@ -688,7 +687,7 @@ impl Isis {
                 graph_flex_algo: Levels::<BTreeMap<u8, Option<spf::Graph>>>::default(),
                 spf_flex_algo: Levels::<BTreeMap<u8, Option<BTreeMap<usize, spf::Path>>>>::default(
                 ),
-                rib_flex_algo: Levels::<BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>>>::default(),
+                rib_flex_algo: Levels::<BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>>>::default(),
                 sr_rx,
                 watched_block: None,
                 watched_locator: None,

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -25,7 +25,7 @@ use super::config::{
     self, IsisAuthConfig, IsisConfig, MtId, auth_set_key_id, auth_set_password, auth_set_send_only,
     auth_set_type,
 };
-use super::graph::{ReachMap, ReachMapV6};
+use super::graph::{ReachMapV4, ReachMapV6};
 use super::ifsm::{self, has_level};
 use super::lsp::PacketMessage;
 use super::neigh::Neighbor;
@@ -134,7 +134,7 @@ pub struct LinkTop<'a> {
     pub timer: &'a mut LinkTimer,
     pub local_pool: &'a mut Option<LabelPool>,
     pub hostname: &'a mut Levels<Hostname>,
-    pub reach_map: &'a mut Levels<Afis<ReachMap>>,
+    pub reach_map: &'a mut Levels<Afis<ReachMapV4>>,
     pub reach_map_v6: &'a mut Levels<ReachMapV6>,
     pub mt2_reach_map_v6: &'a mut Levels<ReachMapV6>,
     pub mt_membership:

--- a/zebra-rs/src/isis/lsdb.rs
+++ b/zebra-rs/src/isis/lsdb.rs
@@ -15,7 +15,7 @@ use crate::isis::{
 };
 
 use super::config::MtId;
-use super::graph::{ReachMap, ReachMapV6};
+use super::graph::{ReachMapV4, ReachMapV6};
 use super::hostname::Hostname;
 use super::inst::MsgSender;
 use super::link::LinkTop;
@@ -176,7 +176,7 @@ pub struct LspCapView<'a> {
 pub(super) struct SysStateRefs<'a> {
     pub hostname: &'a mut Hostname,
     pub label_map: &'a mut IsisLabelMap,
-    pub reach_v4: &'a mut ReachMap,
+    pub reach_v4: &'a mut ReachMapV4,
     pub reach_v6: &'a mut ReachMapV6,
     pub mt_membership: &'a mut BTreeMap<IsisSysId, BTreeSet<MtId>>,
     pub mt2_reach_v6: &'a mut ReachMapV6,
@@ -799,7 +799,7 @@ mod tests {
 
         let mut hostname = Hostname::default();
         let mut label_map = IsisLabelMap::default();
-        let mut reach_v4 = ReachMap::default();
+        let mut reach_v4 = ReachMapV4::default();
         let mut reach_v6 = ReachMapV6::default();
         let mut mt_membership: BTreeMap<IsisSysId, BTreeSet<MtId>> = BTreeMap::new();
         let mut mt2_reach_v6 = ReachMapV6::default();
@@ -913,7 +913,7 @@ mod tests {
         hostname.insert_originate(me, "real".to_string());
 
         let mut label_map = IsisLabelMap::default();
-        let mut reach_v4 = ReachMap::default();
+        let mut reach_v4 = ReachMapV4::default();
         let mut reach_v6 = ReachMapV6::default();
         let mut mt_membership: BTreeMap<IsisSysId, BTreeSet<MtId>> = BTreeMap::new();
         let mut mt2_reach_v6 = ReachMapV6::default();
@@ -987,7 +987,7 @@ mod tests {
 
         let mut hostname = Hostname::default();
         let mut label_map = IsisLabelMap::default();
-        let mut reach_v4 = ReachMap::default();
+        let mut reach_v4 = ReachMapV4::default();
         let mut reach_v6 = ReachMapV6::default();
         let mut mt_membership: BTreeMap<IsisSysId, BTreeSet<MtId>> = BTreeMap::new();
         let mut mt2_reach_v6 = ReachMapV6::default();
@@ -1104,7 +1104,7 @@ mod tests {
 
         let mut hostname = Hostname::default();
         let mut label_map = IsisLabelMap::default();
-        let mut reach_v4 = ReachMap::default();
+        let mut reach_v4 = ReachMapV4::default();
         let mut reach_v6 = ReachMapV6::default();
         let mut mt_membership: BTreeMap<IsisSysId, BTreeSet<MtId>> = BTreeMap::new();
         let mut mt2_reach_v6 = ReachMapV6::default();
@@ -1203,7 +1203,7 @@ mod tests {
 
         let mut hostname = Hostname::default();
         let mut label_map = IsisLabelMap::default();
-        let mut reach_v4 = ReachMap::default();
+        let mut reach_v4 = ReachMapV4::default();
         let mut reach_v6 = ReachMapV6::default();
         let mut mt_membership: BTreeMap<IsisSysId, BTreeSet<MtId>> = BTreeMap::new();
         let mut mt2_reach_v6 = ReachMapV6::default();
@@ -1291,7 +1291,7 @@ mod tests {
 
         let mut hostname = Hostname::default();
         let mut label_map = IsisLabelMap::default();
-        let mut reach_v4 = ReachMap::default();
+        let mut reach_v4 = ReachMapV4::default();
         let mut reach_v6 = ReachMapV6::default();
         let mut mt_membership: BTreeMap<IsisSysId, BTreeSet<MtId>> = BTreeMap::new();
         let mut mt2_reach_v6 = ReachMapV6::default();

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::time::{Duration, Instant};
 
 use ipnet::{Ipv4Net, Ipv6Net};
@@ -15,7 +15,7 @@ use crate::rib::inst::{IlmEntry, IlmType};
 use crate::rib::link_ext::LinkFlagsExt;
 use crate::rib::{self, Nexthop, NexthopMulti, NexthopUni, RibSubType, RibType};
 use crate::spf;
-// EncapType is only used by `make_rib_entry_v6` test fixture below;
+// EncapType is only used by the IPv6 backup test fixture below;
 // production code paths route through `tilfa::build_repair_path_srv6`.
 #[cfg(test)]
 use isis_packet::srv6::EncapType;
@@ -32,6 +32,72 @@ use super::tilfa::{
     RepairPathMpls, RepairPathSrv6, build_repair_path_mpls, build_repair_path_srv6,
     first_router_hop_id, tilfa_repair_path,
 };
+
+/// Address-family marker — ties together the address type, prefix type, and
+/// TI-LFA backup-path type for a single IS-IS RIB family (IPv4 or IPv6).
+/// Mirrors the `StaticFamily` pattern in `rib/static/config.rs`.
+pub trait IsisRibFamily: Sized + 'static {
+    type Addr: Ord + Copy + std::fmt::Debug + PartialEq;
+    type Prefix: Ord + Copy;
+    type Backup: std::fmt::Debug + Clone + PartialEq;
+
+    fn addr_to_ip(addr: Self::Addr) -> IpAddr;
+    fn backup_to_nexthop_uni(backup: &Self::Backup, metric: u32) -> rib::NexthopUni;
+    fn rib_add(prefix: Self::Prefix, entry: crate::rib::entry::RibEntry) -> crate::rib::Message;
+    fn rib_del(prefix: Self::Prefix, entry: crate::rib::entry::RibEntry) -> crate::rib::Message;
+}
+
+pub struct V4;
+impl IsisRibFamily for V4 {
+    type Addr = Ipv4Addr;
+    type Prefix = Ipv4Net;
+    type Backup = RepairPathMpls;
+
+    fn addr_to_ip(addr: Ipv4Addr) -> IpAddr {
+        IpAddr::V4(addr)
+    }
+
+    fn backup_to_nexthop_uni(backup: &RepairPathMpls, metric: u32) -> rib::NexthopUni {
+        let mut nhop = rib::NexthopUni::new(IpAddr::V4(backup.addr), metric, backup.labels.clone());
+        nhop.ifindex_origin = (backup.ifindex != 0).then_some(backup.ifindex);
+        nhop
+    }
+
+    fn rib_add(prefix: Ipv4Net, entry: crate::rib::entry::RibEntry) -> crate::rib::Message {
+        crate::rib::Message::Ipv4Add { prefix, rib: entry }
+    }
+
+    fn rib_del(prefix: Ipv4Net, entry: crate::rib::entry::RibEntry) -> crate::rib::Message {
+        crate::rib::Message::Ipv4Del { prefix, rib: entry }
+    }
+}
+
+pub struct V6;
+impl IsisRibFamily for V6 {
+    type Addr = Ipv6Addr;
+    type Prefix = Ipv6Net;
+    type Backup = RepairPathSrv6;
+
+    fn addr_to_ip(addr: Ipv6Addr) -> IpAddr {
+        IpAddr::V6(addr)
+    }
+
+    fn backup_to_nexthop_uni(backup: &RepairPathSrv6, metric: u32) -> rib::NexthopUni {
+        let mut nhop = rib::NexthopUni::new(IpAddr::V6(backup.addr), metric, vec![]);
+        nhop.ifindex_origin = (backup.ifindex != 0).then_some(backup.ifindex);
+        nhop.segs = backup.segs.clone();
+        nhop.encap_type = Some(backup.encap);
+        nhop
+    }
+
+    fn rib_add(prefix: Ipv6Net, entry: crate::rib::entry::RibEntry) -> crate::rib::Message {
+        crate::rib::Message::Ipv6Add { prefix, rib: entry }
+    }
+
+    fn rib_del(prefix: Ipv6Net, entry: crate::rib::entry::RibEntry) -> crate::rib::Message {
+        crate::rib::Message::Ipv6Del { prefix, rib: entry }
+    }
+}
 
 fn spf_timer_ms(tx: &UnboundedSender<Message>, level: Level, ms: u64) -> Timer {
     let tx = tx.clone();
@@ -77,10 +143,13 @@ pub fn spf_schedule_top(top: &mut IsisTop, level: Level) {
     spf_schedule_inner(top.spf_timer, top.spf_throttle, top.tx, top.config, level);
 }
 
-#[derive(Debug, PartialEq)]
-pub struct SpfRoute {
+/// Per-destination IS-IS route produced by SPF. Generic over the address
+/// family via `F: IsisRibFamily`. `SpfRoute<V4>` uses `Ipv4Addr` nexthop
+/// keys and MPLS TI-LFA backups; `SpfRoute<V6>` uses `Ipv6Addr` keys and
+/// SRv6 TI-LFA backups. All other fields are address-family-independent.
+pub struct SpfRoute<F: IsisRibFamily> {
     pub metric: u32,
-    pub nhops: BTreeMap<Ipv4Addr, SpfNexthop>,
+    pub nhops: BTreeMap<F::Addr, SpfNexthop<F>>,
     pub sid: Option<u32>,
     pub prefix_sid: Option<(SidLabelValue, LabelConfig)>,
     /// RFC 8667 §2.1.1 P (no-PHP) flag copied from the destination's
@@ -88,7 +157,8 @@ pub struct SpfRoute {
     /// nexthop whose `adjacency` is true) must keep the node-SID label
     /// instead of popping it, so `make_ilm_entry` installs a swap rather
     /// than a pop. Part of `PartialEq` so a P-flag flip re-installs the
-    /// ILM through `table_diff`.
+    /// ILM through `table_diff`. Always `false` for IPv6 (SR-MPLS is
+    /// IPv4-only today).
     pub no_php: bool,
     /// SPF vertex id this route was built from. Set by
     /// `build_rib_from_spf`; used by TI-LFA to join routes with
@@ -105,45 +175,74 @@ pub struct SpfRoute {
     pub backup_as_primary: bool,
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct SpfNexthop {
+impl<F: IsisRibFamily> std::fmt::Debug for SpfRoute<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SpfRoute")
+            .field("metric", &self.metric)
+            .field("nhops", &self.nhops)
+            .field("sid", &self.sid)
+            .field("prefix_sid", &self.prefix_sid)
+            .field("no_php", &self.no_php)
+            .field("dest_vertex", &self.dest_vertex)
+            .field("backup_as_primary", &self.backup_as_primary)
+            .finish()
+    }
+}
+
+impl<F: IsisRibFamily> PartialEq for SpfRoute<F> {
+    fn eq(&self, other: &Self) -> bool {
+        self.metric == other.metric
+            && self.nhops == other.nhops
+            && self.sid == other.sid
+            && self.prefix_sid == other.prefix_sid
+            && self.no_php == other.no_php
+            && self.dest_vertex == other.dest_vertex
+            && self.backup_as_primary == other.backup_as_primary
+    }
+}
+
+/// Per-nexthop IS-IS state produced by SPF. `F::Backup` is
+/// `RepairPathMpls` for IPv4 and `RepairPathSrv6` for IPv6.
+pub struct SpfNexthop<F: IsisRibFamily> {
     pub ifindex: u32,
     pub adjacency: bool,
     pub sys_id: Option<IsisSysId>,
-    /// TI-LFA post-convergence repair for this primary nexthop. Empty
-    /// (None) until ti_lfa_compute runs and fills it in; for now no
-    /// caller sets it. Sorted-after-primary install is handled by
+    /// TI-LFA post-convergence repair for this primary nexthop. `None`
+    /// until the TI-LFA post-loop pass fills it in for single-primary
+    /// routes. Sorted-after-primary install is handled by
     /// `build_rib_nexthop` via the metric-offset convention.
-    pub backup: Option<RepairPathMpls>,
+    pub backup: Option<F::Backup>,
 }
 
-// IPv6 single-topology mirror of SpfRoute / SpfNexthop. Nexthop key is the
-// peer's IPv6 link-local address (TLV 232 from IIH); ECMP is supported by
-// keying multiple link-locals into the same SpfRouteV6.
-#[derive(Debug, PartialEq)]
-pub struct SpfRouteV6 {
-    pub metric: u32,
-    pub nhops: BTreeMap<Ipv6Addr, SpfNexthopV6>,
-    pub sid: Option<u32>,
-    pub prefix_sid: Option<(SidLabelValue, LabelConfig)>,
-    /// Same role as `SpfRoute.dest_vertex` — populated by
-    /// `build_rib_from_spf_v6` for the IPv6 repair-path join.
-    pub dest_vertex: Option<usize>,
-    /// Same role as `SpfRoute.backup_as_primary` — carried so the
-    /// flag is part of the `table_diff` equality that gates RIB
-    /// updates. See that field for the full rationale.
-    pub backup_as_primary: bool,
+impl<F: IsisRibFamily> std::fmt::Debug for SpfNexthop<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SpfNexthop")
+            .field("ifindex", &self.ifindex)
+            .field("adjacency", &self.adjacency)
+            .field("sys_id", &self.sys_id)
+            .field("backup", &self.backup)
+            .finish()
+    }
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct SpfNexthopV6 {
-    pub ifindex: u32,
-    pub adjacency: bool,
-    pub sys_id: Option<IsisSysId>,
-    /// TI-LFA post-convergence repair for this primary nexthop. The
-    /// SRv6 form carries an SRH segment list + encap mode instead of
-    /// an MPLS label stack.
-    pub backup: Option<RepairPathSrv6>,
+impl<F: IsisRibFamily> Clone for SpfNexthop<F> {
+    fn clone(&self) -> Self {
+        Self {
+            ifindex: self.ifindex,
+            adjacency: self.adjacency,
+            sys_id: self.sys_id,
+            backup: self.backup.clone(),
+        }
+    }
+}
+
+impl<F: IsisRibFamily> PartialEq for SpfNexthop<F> {
+    fn eq(&self, other: &Self) -> bool {
+        self.ifindex == other.ifindex
+            && self.adjacency == other.adjacency
+            && self.sys_id == other.sys_id
+            && self.backup == other.backup
+    }
 }
 
 /// Sort offset between the primary nhop's metric and its TI-LFA
@@ -154,14 +253,13 @@ pub struct SpfNexthopV6 {
 /// `u32::MAX` sentinels.
 pub const BACKUP_METRIC_OFFSET: u32 = 1;
 
-pub type DiffResult<'a> = spf::TableDiffResult<'a, Ipv4Net, SpfRoute>;
-pub type DiffResultV6<'a> = spf::TableDiffResult<'a, Ipv6Net, SpfRouteV6>;
+pub type DiffResult<'a, F> = spf::TableDiffResult<'a, <F as IsisRibFamily>::Prefix, SpfRoute<F>>;
 pub type DiffIlmResult<'a> = spf::TableDiffResult<'a, u32, SpfIlm>;
 
-fn nhop_to_nexthop_uni(
-    key: &Ipv4Addr,
-    route: &SpfRoute,
-    value: &SpfNexthop,
+fn nhop_to_nexthop_uni<F: IsisRibFamily>(
+    key: &F::Addr,
+    route: &SpfRoute<F>,
+    value: &SpfNexthop<F>,
     metric: u32,
 ) -> rib::NexthopUni {
     let mut mpls = vec![];
@@ -172,7 +270,7 @@ fn nhop_to_nexthop_uni(
             rib::Label::Explicit(sid)
         });
     }
-    let mut nhop = rib::NexthopUni::from(*key, metric, mpls);
+    let mut nhop = rib::NexthopUni::new(F::addr_to_ip(*key), metric, mpls);
     // IS-IS knows the egress link from the adjacency state machine —
     // record it as the origin so the RIB resolver doesn't re-derive
     // (and potentially mis-derive) the link via a recursive table
@@ -190,7 +288,7 @@ fn level_subtype(level: Level) -> RibSubType {
     }
 }
 
-fn make_rib_entry(route: &SpfRoute, level: Level) -> rib::entry::RibEntry {
+fn make_rib_entry<F: IsisRibFamily>(route: &SpfRoute<F>, level: Level) -> rib::entry::RibEntry {
     let mut rib = rib::entry::RibEntry::new(RibType::Isis);
     rib.rsubtype = level_subtype(level);
     rib.distance = 115;
@@ -214,26 +312,16 @@ fn make_rib_entry(route: &SpfRoute, level: Level) -> rib::entry::RibEntry {
         .nhops
         .iter()
         .flat_map(|(key, value)| {
-            let primary = nhop_to_nexthop_uni(key, route, value, primary_metric);
+            let primary = nhop_to_nexthop_uni::<F>(key, route, value, primary_metric);
             let backup = value
                 .backup
                 .as_ref()
-                .map(|b| backup_to_nexthop_uni(b, backup_metric));
+                .map(|b| F::backup_to_nexthop_uni(b, backup_metric));
             std::iter::once(primary).chain(backup)
         })
         .collect();
     rib.nexthop = build_rib_nexthop(nhops);
     rib
-}
-
-fn backup_to_nexthop_uni(backup: &RepairPathMpls, metric: u32) -> rib::NexthopUni {
-    let mut nhop = rib::NexthopUni::new(
-        std::net::IpAddr::V4(backup.addr),
-        metric,
-        backup.labels.clone(),
-    );
-    nhop.ifindex_origin = (backup.ifindex != 0).then_some(backup.ifindex);
-    nhop
 }
 
 // Dispatch a flat list of NexthopUni into the right rib::Nexthop
@@ -297,7 +385,7 @@ fn build_rib_nexthop(nhops: Vec<rib::NexthopUni>) -> rib::Nexthop {
 fn make_flex_algo_route(
     algo: u8,
     prefix: Ipv4Net,
-    route: &SpfRoute,
+    route: &SpfRoute<V4>,
 ) -> Option<crate::rib::api::FlexAlgoRoute> {
     let outer_label = route.sid?;
     let nexthops: Vec<crate::rib::api::FlexAlgoNexthop> = route
@@ -333,11 +421,11 @@ fn make_flex_algo_route(
 /// prefix" match what RIB already sees from algo-0.
 pub fn diff_apply_flex_algo(
     rib_client: &crate::rib::client::RibClient,
-    prev: &BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>>,
-    next: &BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>>,
+    prev: &BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>>,
+    next: &BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>>,
 ) {
     let all_algos: BTreeSet<u8> = prev.keys().chain(next.keys()).copied().collect();
-    let empty: PrefixMap<Ipv4Net, SpfRoute> = PrefixMap::new();
+    let empty: PrefixMap<Ipv4Net, SpfRoute<V4>> = PrefixMap::new();
     for algo in all_algos {
         let prev_table = prev.get(&algo).unwrap_or(&empty);
         let next_table = next.get(&algo).unwrap_or(&empty);
@@ -376,132 +464,27 @@ pub fn diff_apply_flex_algo(
     }
 }
 
-pub fn diff_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffResult, level: Level) {
-    // Delete.
-    for (prefix, route) in diff.only_curr.iter() {
-        if !route.nhops.is_empty() {
-            let rib = make_rib_entry(route, level);
-            let msg = rib::Message::Ipv4Del {
-                prefix: *prefix,
-                rib,
-            };
-            rib_client.send(msg).unwrap();
-        }
-    }
-    // Add (changed).
-    for (prefix, _, route) in diff.different.iter() {
-        if !route.nhops.is_empty() {
-            let rib = make_rib_entry(route, level);
-            let msg = rib::Message::Ipv4Add {
-                prefix: *prefix,
-                rib,
-            };
-            rib_client.send(msg).unwrap();
-        }
-    }
-    // Add (new).
-    for (prefix, route) in diff.only_next.iter() {
-        if !route.nhops.is_empty() {
-            let rib = make_rib_entry(route, level);
-            let msg = rib::Message::Ipv4Add {
-                prefix: *prefix,
-                rib,
-            };
-            rib_client.send(msg).unwrap();
-        }
-    }
-}
-
-fn nhop_to_nexthop_uni_v6(
-    key: &Ipv6Addr,
-    route: &SpfRouteV6,
-    value: &SpfNexthopV6,
-    metric: u32,
-) -> rib::NexthopUni {
-    let mut mpls = vec![];
-    if let Some(sid) = route.sid {
-        mpls.push(if value.adjacency {
-            rib::Label::Implicit(sid)
-        } else {
-            rib::Label::Explicit(sid)
-        });
-    }
-    let mut nhop = rib::NexthopUni::new(std::net::IpAddr::V6(*key), metric, mpls);
-    // IPv6 link-local nexthops can't be disambiguated by table
-    // lookup — every interface advertises fe80::/64. The adjacency
-    // already pinned the egress link, so record it as the origin.
-    nhop.ifindex_origin = (value.ifindex != 0).then_some(value.ifindex);
-    nhop
-}
-
-fn make_rib_entry_v6(route: &SpfRouteV6, level: Level) -> rib::entry::RibEntry {
-    let mut rib = rib::entry::RibEntry::new(RibType::Isis);
-    rib.rsubtype = level_subtype(level);
-    rib.distance = 115;
-    rib.metric = route.metric;
-    let offset_metric = route.metric.saturating_add(BACKUP_METRIC_OFFSET);
-    let (primary_metric, backup_metric) = if route.backup_as_primary {
-        (offset_metric, route.metric)
-    } else {
-        (route.metric, offset_metric)
-    };
-    let nhops: Vec<rib::NexthopUni> = route
-        .nhops
-        .iter()
-        .flat_map(|(key, value)| {
-            let primary = nhop_to_nexthop_uni_v6(key, route, value, primary_metric);
-            let backup = value
-                .backup
-                .as_ref()
-                .map(|b| backup_to_nexthop_uni_v6(b, backup_metric));
-            std::iter::once(primary).chain(backup)
-        })
-        .collect();
-    rib.nexthop = build_rib_nexthop(nhops);
-    rib
-}
-
-fn backup_to_nexthop_uni_v6(backup: &RepairPathSrv6, metric: u32) -> rib::NexthopUni {
-    let mut nhop = rib::NexthopUni::new(std::net::IpAddr::V6(backup.addr), metric, vec![]);
-    nhop.ifindex_origin = (backup.ifindex != 0).then_some(backup.ifindex);
-    nhop.segs = backup.segs.clone();
-    nhop.encap_type = Some(backup.encap);
-    nhop
-}
-
-pub fn diff_apply_v6(
+pub fn diff_apply<F: IsisRibFamily>(
     rib_client: &crate::rib::client::RibClient,
-    diff: &DiffResultV6,
+    diff: &DiffResult<'_, F>,
     level: Level,
 ) {
     for (prefix, route) in diff.only_curr.iter() {
         if !route.nhops.is_empty() {
-            let rib = make_rib_entry_v6(route, level);
-            let msg = rib::Message::Ipv6Del {
-                prefix: *prefix,
-                rib,
-            };
-            rib_client.send(msg).unwrap();
+            let entry = make_rib_entry::<F>(route, level);
+            rib_client.send(F::rib_del(*prefix, entry)).unwrap();
         }
     }
     for (prefix, _, route) in diff.different.iter() {
         if !route.nhops.is_empty() {
-            let rib = make_rib_entry_v6(route, level);
-            let msg = rib::Message::Ipv6Add {
-                prefix: *prefix,
-                rib,
-            };
-            rib_client.send(msg).unwrap();
+            let entry = make_rib_entry::<F>(route, level);
+            rib_client.send(F::rib_add(*prefix, entry)).unwrap();
         }
     }
     for (prefix, route) in diff.only_next.iter() {
         if !route.nhops.is_empty() {
-            let rib = make_rib_entry_v6(route, level);
-            let msg = rib::Message::Ipv6Add {
-                prefix: *prefix,
-                rib,
-            };
-            rib_client.send(msg).unwrap();
+            let entry = make_rib_entry::<F>(route, level);
+            rib_client.send(F::rib_add(*prefix, entry)).unwrap();
         }
     }
 }
@@ -511,7 +494,7 @@ fn make_ilm_entry(label: u32, ilm: &SpfIlm) -> IlmEntry {
         && let Some((&addr, nhop)) = ilm.nhops.iter().next()
     {
         let mut uni = NexthopUni {
-            addr: std::net::IpAddr::V4(addr),
+            addr: IpAddr::V4(addr),
             ifindex_origin: (nhop.ifindex != 0).then_some(nhop.ifindex),
             ..Default::default()
         };
@@ -530,7 +513,7 @@ fn make_ilm_entry(label: u32, ilm: &SpfIlm) -> IlmEntry {
     let mut multi = NexthopMulti::default();
     for (&addr, nhop) in ilm.nhops.iter() {
         let mut uni = NexthopUni {
-            addr: std::net::IpAddr::V4(addr),
+            addr: IpAddr::V4(addr),
             ifindex_origin: (nhop.ifindex != 0).then_some(nhop.ifindex),
             ..Default::default()
         };
@@ -585,7 +568,7 @@ pub fn diff_ilm_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffIlm
 }
 #[derive(Debug, PartialEq)]
 pub struct SpfIlm {
-    pub nhops: BTreeMap<Ipv4Addr, SpfNexthop>,
+    pub nhops: BTreeMap<Ipv4Addr, SpfNexthop<V4>>,
     pub ilm_type: IlmType,
     /// RFC 8667 §2.1.1 P (no-PHP) flag. When true, `make_ilm_entry`
     /// keeps the label (swap) even for a penultimate-hop (`adjacency`)
@@ -624,7 +607,7 @@ fn build_adjacency_ilm(
         for (ifindex, link) in top.links.iter() {
             if let Some(nbr) = link.state.nbrs.get(&level).get(nhop_id) {
                 for (addr, _) in nbr.addr4.iter() {
-                    let nhop = SpfNexthop {
+                    let nhop = SpfNexthop::<V4> {
                         ifindex: *ifindex,
                         adjacency: true,
                         sys_id: Some(*nhop_id),
@@ -655,8 +638,8 @@ fn build_rib_from_spf(
     source: usize,
     spf_result: &BTreeMap<usize, spf::Path>,
     tilfa_result: &BTreeMap<usize, Vec<spf::RepairPath>>,
-) -> PrefixMap<Ipv4Net, SpfRoute> {
-    let mut rib = PrefixMap::<Ipv4Net, SpfRoute>::new();
+) -> PrefixMap<Ipv4Net, SpfRoute<V4>> {
+    let mut rib = PrefixMap::<Ipv4Net, SpfRoute<V4>>::new();
 
     // Process each node in the SPF result
     for (node, nhops) in spf_result {
@@ -715,7 +698,7 @@ fn build_rib_from_spf(
                     continue;
                 };
                 for (addr, _) in nbr.addr4.iter() {
-                    let nhop = SpfNexthop {
+                    let nhop = SpfNexthop::<V4> {
                         ifindex: *link_id,
                         adjacency: *node == nhop_id,
                         sys_id: Some(nhop_sys_id),
@@ -903,8 +886,8 @@ fn build_rib_from_spf_v6(
     spf_result: &BTreeMap<usize, spf::Path>,
     tilfa_result: &BTreeMap<usize, Vec<spf::RepairPath>>,
     mt2_mode: bool,
-) -> PrefixMap<Ipv6Net, SpfRouteV6> {
-    let mut rib = PrefixMap::<Ipv6Net, SpfRouteV6>::new();
+) -> PrefixMap<Ipv6Net, SpfRoute<V6>> {
+    let mut rib = PrefixMap::<Ipv6Net, SpfRoute<V6>>::new();
 
     // NLPID gate set — only used in legacy mode.
     let ipv6_capable = if mt2_mode {
@@ -981,7 +964,7 @@ fn build_rib_from_spf_v6(
                     continue;
                 };
                 for addr in nbr.addr6l.iter() {
-                    let nhop = SpfNexthopV6 {
+                    let nhop = SpfNexthop::<V6> {
                         ifindex: *link_id,
                         adjacency: is_adjacency,
                         sys_id: Some(nhop_sys_id),
@@ -1009,11 +992,12 @@ fn build_rib_from_spf_v6(
         };
         if let Some(entries) = reach {
             for entry in entries.iter() {
-                let route = SpfRouteV6 {
+                let route = SpfRoute::<V6> {
                     metric: nhops.cost + entry.metric,
                     nhops: spf_nhops.clone(),
                     sid: None,
                     prefix_sid: None,
+                    no_php: false,
                     dest_vertex: Some(*node),
                     backup_as_primary: top.config.fast_reroute_backup_as_primary,
                 };
@@ -1082,8 +1066,8 @@ fn ipv6_capable_set(lsdb: &Lsdb) -> BTreeSet<IsisSysId> {
 fn apply_routing_updates(
     top: &mut IsisTop,
     level: Level,
-    rib: PrefixMap<Ipv4Net, SpfRoute>,
-    rib_v6: PrefixMap<Ipv6Net, SpfRouteV6>,
+    rib: PrefixMap<Ipv4Net, SpfRoute<V4>>,
+    rib_v6: PrefixMap<Ipv6Net, SpfRoute<V6>>,
     ilm: BTreeMap<u32, SpfIlm>,
 ) {
     // Update MPLS ILM
@@ -1114,7 +1098,7 @@ fn apply_routing_updates(
     // Update IPv6 RIB
     if top.config.distribute.rib {
         let diff = spf::table_diff(top.rib_v6.get(&level).iter(), rib_v6.iter());
-        diff_apply_v6(top.rib_client, &diff, level);
+        diff_apply::<V6>(top.rib_client, &diff, level);
     }
     *top.rib_v6.get_mut(&level) = rib_v6;
 }
@@ -1429,7 +1413,7 @@ pub(super) fn apply_spf_result(top: &mut IsisTop, output: SpfOutput) {
     // so stale graphs / SPFs / RIBs don't survive a delete.
     let mut new_flex_algo_graphs: BTreeMap<u8, Option<spf::Graph>> = BTreeMap::new();
     let mut new_flex_algo_spfs: BTreeMap<u8, Option<BTreeMap<usize, spf::Path>>> = BTreeMap::new();
-    let mut new_flex_algo_rib: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>> = BTreeMap::new();
+    let mut new_flex_algo_rib: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>> = BTreeMap::new();
     for FlexAlgoOutput {
         algo,
         graph: algo_graph,
@@ -1447,7 +1431,7 @@ pub(super) fn apply_spf_result(top: &mut IsisTop, output: SpfOutput) {
                 mpls_route(&r, &mut ilm, srgb);
                 r
             }
-            _ => PrefixMap::<Ipv4Net, SpfRoute>::new(),
+            _ => PrefixMap::<Ipv4Net, SpfRoute<V4>>::new(),
         };
 
         new_flex_algo_graphs.insert(algo, Some(algo_graph));
@@ -1510,8 +1494,8 @@ fn build_rib_from_flex_algo(
     algo: u8,
     source: usize,
     spf_result: &BTreeMap<usize, spf::Path>,
-) -> PrefixMap<Ipv4Net, SpfRoute> {
-    let mut rib = PrefixMap::<Ipv4Net, SpfRoute>::new();
+) -> PrefixMap<Ipv4Net, SpfRoute<V4>> {
+    let mut rib = PrefixMap::<Ipv4Net, SpfRoute<V4>>::new();
 
     for (node, nhops) in spf_result {
         if *node == source {
@@ -1546,7 +1530,7 @@ fn build_rib_from_flex_algo(
                     continue;
                 };
                 for (addr, _) in nbr.addr4.iter() {
-                    let nhop = SpfNexthop {
+                    let nhop = SpfNexthop::<V4> {
                         ifindex: *link_id,
                         adjacency: *node == nhop_id,
                         sys_id: Some(nhop_sys_id),
@@ -1682,7 +1666,7 @@ pub(super) fn update_self_sid_ilm(isis: &mut Isis) {
             let mut nhops = BTreeMap::new();
             nhops.insert(
                 addr,
-                SpfNexthop {
+                SpfNexthop::<V4> {
                     ifindex,
                     adjacency: true,
                     sys_id: None,
@@ -1711,7 +1695,7 @@ pub(super) fn update_self_sid_ilm(isis: &mut Isis) {
 }
 
 pub fn mpls_route(
-    rib: &PrefixMap<Ipv4Net, SpfRoute>,
+    rib: &PrefixMap<Ipv4Net, SpfRoute<V4>>,
     ilm: &mut BTreeMap<u32, SpfIlm>,
     srgb: Option<&crate::spf::label_block::LabelBlock>,
 ) {
@@ -1773,12 +1757,12 @@ mod tests {
         rib::NexthopUni::new(addr.parse().unwrap(), metric, vec![])
     }
 
-    fn spf_route(metric: u32, sid: Option<u32>, nhops: &[(&str, u32)]) -> SpfRoute {
+    fn spf_route(metric: u32, sid: Option<u32>, nhops: &[(&str, u32)]) -> SpfRoute<V4> {
         let mut nh = BTreeMap::new();
         for (addr, ifindex) in nhops {
             nh.insert(
                 addr.parse::<Ipv4Addr>().unwrap(),
-                super::SpfNexthop {
+                super::SpfNexthop::<V4> {
                     ifindex: *ifindex,
                     adjacency: false,
                     sys_id: None,
@@ -1786,7 +1770,7 @@ mod tests {
                 },
             );
         }
-        SpfRoute {
+        SpfRoute::<V4> {
             metric,
             nhops: nh,
             sid,
@@ -1849,7 +1833,7 @@ mod tests {
     #[test]
     fn diff_apply_flex_algo_emits_add_for_new_route() {
         let (client, mut rx) = rib_client_for_test();
-        let mut next: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>> = BTreeMap::new();
+        let mut next: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>> = BTreeMap::new();
         let mut t = PrefixMap::new();
         t.insert(
             pfx("10.0.0.1/32"),
@@ -1870,7 +1854,7 @@ mod tests {
     #[test]
     fn diff_apply_flex_algo_emits_del_for_removed_algo() {
         let (client, mut rx) = rib_client_for_test();
-        let mut prev: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>> = BTreeMap::new();
+        let mut prev: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>> = BTreeMap::new();
         let mut t = PrefixMap::new();
         t.insert(
             pfx("10.0.0.1/32"),
@@ -1896,7 +1880,7 @@ mod tests {
     #[test]
     fn diff_apply_flex_algo_changed_route_emits_single_add() {
         let (client, mut rx) = rib_client_for_test();
-        let mut prev: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>> = BTreeMap::new();
+        let mut prev: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>> = BTreeMap::new();
         let mut p = PrefixMap::new();
         p.insert(
             pfx("10.0.0.1/32"),
@@ -1904,7 +1888,7 @@ mod tests {
         );
         prev.insert(128, p);
 
-        let mut next: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>> = BTreeMap::new();
+        let mut next: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>> = BTreeMap::new();
         let mut n = PrefixMap::new();
         // Same prefix, different metric → counts as `different`.
         n.insert(
@@ -1926,7 +1910,7 @@ mod tests {
     #[test]
     fn diff_apply_flex_algo_changed_route_losing_sid_collapses_to_del() {
         let (client, mut rx) = rib_client_for_test();
-        let mut prev: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>> = BTreeMap::new();
+        let mut prev: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>> = BTreeMap::new();
         let mut p = PrefixMap::new();
         p.insert(
             pfx("10.0.0.1/32"),
@@ -1934,7 +1918,7 @@ mod tests {
         );
         prev.insert(128, p);
 
-        let mut next: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute>> = BTreeMap::new();
+        let mut next: BTreeMap<u8, PrefixMap<Ipv4Net, SpfRoute<V4>>> = BTreeMap::new();
         let mut n = PrefixMap::new();
         // Lost SID — no per-algo forwarding plane, must be a Del.
         n.insert(pfx("10.0.0.1/32"), spf_route(30, None, &[("10.0.0.5", 9)]));
@@ -2032,14 +2016,14 @@ mod tests {
         let mut nhops = BTreeMap::new();
         nhops.insert(
             "10.0.0.1".parse().unwrap(),
-            SpfNexthop {
+            SpfNexthop::<V4> {
                 ifindex: 10,
                 adjacency: true,
                 sys_id: None,
                 backup: None,
             },
         );
-        let route = SpfRoute {
+        let route = SpfRoute::<V4> {
             metric: 20,
             nhops,
             sid: None,
@@ -2063,7 +2047,7 @@ mod tests {
         let mut nhops = BTreeMap::new();
         nhops.insert(
             primary_addr,
-            SpfNexthop {
+            SpfNexthop::<V4> {
                 ifindex: 10,
                 adjacency: true,
                 sys_id: None,
@@ -2074,7 +2058,7 @@ mod tests {
                 }),
             },
         );
-        let route = SpfRoute {
+        let route = SpfRoute::<V4> {
             metric: 20,
             nhops,
             sid: None,
@@ -2115,7 +2099,7 @@ mod tests {
         let mut nhops = BTreeMap::new();
         nhops.insert(
             primary_addr,
-            SpfNexthop {
+            SpfNexthop::<V4> {
                 ifindex: 10,
                 adjacency: true,
                 sys_id: None,
@@ -2126,7 +2110,7 @@ mod tests {
                 }),
             },
         );
-        let route = SpfRoute {
+        let route = SpfRoute::<V4> {
             metric: 20,
             nhops,
             sid: None,
@@ -2170,8 +2154,8 @@ mod tests {
 
         let prefix: Ipv4Net = "10.0.0.0/24".parse().unwrap();
 
-        let mut prev: BTreeMap<Ipv4Net, SpfRoute> = BTreeMap::new();
-        let mut next: BTreeMap<Ipv4Net, SpfRoute> = BTreeMap::new();
+        let mut prev: BTreeMap<Ipv4Net, SpfRoute<V4>> = BTreeMap::new();
+        let mut next: BTreeMap<Ipv4Net, SpfRoute<V4>> = BTreeMap::new();
 
         let off = spf_route(20, None, &[("10.0.0.1", 10)]);
         let mut on = spf_route(20, None, &[("10.0.0.1", 10)]);
@@ -2206,7 +2190,7 @@ mod tests {
         let mut nhops = BTreeMap::new();
         nhops.insert(
             primary_addr,
-            SpfNexthopV6 {
+            SpfNexthop::<V6> {
                 ifindex: 10,
                 adjacency: true,
                 sys_id: None,
@@ -2218,15 +2202,16 @@ mod tests {
                 }),
             },
         );
-        let route = SpfRouteV6 {
+        let route = SpfRoute::<V6> {
             metric: 20,
             nhops,
             sid: None,
             prefix_sid: None,
+            no_php: false,
             dest_vertex: None,
             backup_as_primary: false,
         };
-        let entry = make_rib_entry_v6(&route, Level::L1);
+        let entry = make_rib_entry::<V6>(&route, Level::L1);
 
         let rib::Nexthop::List(list) = &entry.nexthop else {
             panic!("expected List, got {:?}", entry.nexthop);
@@ -2264,27 +2249,28 @@ mod tests {
         let mut nhops = BTreeMap::new();
         nhops.insert(
             "fe80::a:2".parse().unwrap(),
-            SpfNexthopV6 {
+            SpfNexthop::<V6> {
                 ifindex: 10,
                 adjacency: true,
                 sys_id: None,
                 backup: None,
             },
         );
-        let route = SpfRouteV6 {
+        let route = SpfRoute::<V6> {
             metric: 20,
             nhops,
             sid: None,
             prefix_sid: None,
+            no_php: false,
             dest_vertex: None,
             backup_as_primary: false,
         };
         assert_eq!(
-            make_rib_entry_v6(&route, Level::L1).rsubtype,
+            make_rib_entry::<V6>(&route, Level::L1).rsubtype,
             RibSubType::IsisLevel1
         );
         assert_eq!(
-            make_rib_entry_v6(&route, Level::L2).rsubtype,
+            make_rib_entry::<V6>(&route, Level::L2).rsubtype,
             RibSubType::IsisLevel2
         );
     }
@@ -2293,7 +2279,7 @@ mod tests {
         let mut nhops = BTreeMap::new();
         nhops.insert(
             "10.0.0.1".parse::<Ipv4Addr>().unwrap(),
-            SpfNexthop {
+            SpfNexthop::<V4> {
                 ifindex: 10,
                 adjacency,
                 sys_id: None,

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -27,6 +27,7 @@ use super::inst::{Isis, IsisTop, Message};
 use super::level::Level;
 use super::link::{Afi, LinkTop};
 use super::lsdb::Lsdb;
+use super::neigh::Neighbor;
 use super::srmpls::LabelConfig;
 use super::tilfa::{
     RepairPathMpls, RepairPathSrv6, build_repair_path_mpls, build_repair_path_srv6,
@@ -40,6 +41,9 @@ pub trait IsisRibFamily: Sized + 'static {
     type Addr: Ord + Copy + std::fmt::Debug + PartialEq;
     type Prefix: Ord + Copy + prefix_trie::Prefix;
     type Backup: std::fmt::Debug + Clone + PartialEq;
+    /// Concrete reach-entry type (IPv4: `IsisTlvExtIpReachEntry`,
+    /// IPv6: `IsisTlvIpv6ReachEntry`).
+    type Entry;
 
     fn addr_to_ip(addr: Self::Addr) -> IpAddr;
     fn backup_to_nexthop_uni(backup: &Self::Backup, metric: u32) -> rib::NexthopUni;
@@ -49,6 +53,45 @@ pub trait IsisRibFamily: Sized + 'static {
     /// depth for V4, SRv6 segment-list length for V6.  Used to bucket
     /// TI-LFA protection into trivial / 1-segment / N-segment tallies.
     fn backup_sr_len(backup: &Self::Backup) -> usize;
+
+    /// Collect nexthop addresses for this family from one neighbor record.
+    fn nhop_addrs(nbr: &Neighbor) -> Vec<Self::Addr>;
+
+    /// Look up the family's reach entries for `sys_id`.
+    /// `mt2_mode` selects `mt2_reach_map_v6` vs `reach_map_v6` for V6;
+    /// ignored by V4 which always reads `reach_map`.
+    fn reach_entries<'a>(
+        top: &'a IsisTop,
+        level: &Level,
+        sys_id: &IsisSysId,
+        mt2_mode: bool,
+    ) -> Option<&'a Vec<Self::Entry>>;
+
+    /// Extract the network prefix from a reach entry.
+    fn entry_prefix(e: &Self::Entry) -> Self::Prefix;
+
+    /// Extract the metric from a reach entry.
+    fn entry_metric(e: &Self::Entry) -> u32;
+
+    /// Resolve the Prefix-SID (if present) for a reach entry.
+    /// Returns `(sid_label, prefix_sid_tuple, no_php)`.
+    /// V6 always returns `(None, None, false)` until SRv6 Prefix-SID lands.
+    fn resolve_sid(
+        top: &IsisTop,
+        level: &Level,
+        sys_id: &IsisSysId,
+        e: &Self::Entry,
+    ) -> (Option<u32>, Option<(SidLabelValue, LabelConfig)>, bool);
+
+    /// Build the TI-LFA repair path for this family.
+    fn build_repair(
+        top: &mut IsisTop,
+        level: Level,
+        repair: &spf::RepairPath,
+    ) -> Option<Self::Backup>;
+
+    /// Return the canonical (host-bits-masked) form of `p`.
+    fn trunc_prefix(p: Self::Prefix) -> Self::Prefix;
 }
 
 pub struct V4;
@@ -56,6 +99,7 @@ impl IsisRibFamily for V4 {
     type Addr = Ipv4Addr;
     type Prefix = Ipv4Net;
     type Backup = RepairPathMpls;
+    type Entry = IsisTlvExtIpReachEntry;
 
     fn addr_to_ip(addr: Ipv4Addr) -> IpAddr {
         IpAddr::V4(addr)
@@ -78,6 +122,68 @@ impl IsisRibFamily for V4 {
     fn backup_sr_len(backup: &RepairPathMpls) -> usize {
         backup.labels.len()
     }
+
+    fn nhop_addrs(nbr: &Neighbor) -> Vec<Ipv4Addr> {
+        nbr.addr4.keys().copied().collect()
+    }
+
+    fn reach_entries<'a>(
+        top: &'a IsisTop,
+        level: &Level,
+        sys_id: &IsisSysId,
+        _mt2_mode: bool,
+    ) -> Option<&'a Vec<IsisTlvExtIpReachEntry>> {
+        top.reach_map.get(level).get(&Afi::Ip).get(sys_id)
+    }
+
+    fn entry_prefix(e: &IsisTlvExtIpReachEntry) -> Ipv4Net {
+        e.prefix
+    }
+
+    fn entry_metric(e: &IsisTlvExtIpReachEntry) -> u32 {
+        e.metric
+    }
+
+    fn resolve_sid(
+        top: &IsisTop,
+        level: &Level,
+        sys_id: &IsisSysId,
+        e: &IsisTlvExtIpReachEntry,
+    ) -> (Option<u32>, Option<(SidLabelValue, LabelConfig)>, bool) {
+        let sid = if let Some(prefix_sid) = e.prefix_sid() {
+            match prefix_sid.sid {
+                SidLabelValue::Index(index) => top
+                    .label_map
+                    .get(level)
+                    .get(sys_id)
+                    .map(|block| block.global.start + index),
+                SidLabelValue::Label(label) => Some(label),
+            }
+        } else {
+            None
+        };
+        let prefix_sid = if let Some(ps) = e.prefix_sid()
+            && let Some(block) = top.label_map.get(level).get(sys_id)
+        {
+            Some((ps.sid.clone(), block.clone()))
+        } else {
+            None
+        };
+        let no_php = e.prefix_sid().map(|ps| ps.flags.p_flag()).unwrap_or(false);
+        (sid, prefix_sid, no_php)
+    }
+
+    fn build_repair(
+        top: &mut IsisTop,
+        level: Level,
+        repair: &spf::RepairPath,
+    ) -> Option<RepairPathMpls> {
+        build_repair_path_mpls(top, level, repair)
+    }
+
+    fn trunc_prefix(p: Ipv4Net) -> Ipv4Net {
+        p.trunc()
+    }
 }
 
 pub struct V6;
@@ -85,6 +191,7 @@ impl IsisRibFamily for V6 {
     type Addr = Ipv6Addr;
     type Prefix = Ipv6Net;
     type Backup = RepairPathSrv6;
+    type Entry = IsisTlvIpv6ReachEntry;
 
     fn addr_to_ip(addr: Ipv6Addr) -> IpAddr {
         IpAddr::V6(addr)
@@ -108,6 +215,53 @@ impl IsisRibFamily for V6 {
 
     fn backup_sr_len(backup: &RepairPathSrv6) -> usize {
         backup.segs.len()
+    }
+
+    fn nhop_addrs(nbr: &Neighbor) -> Vec<Ipv6Addr> {
+        nbr.addr6l.clone()
+    }
+
+    fn reach_entries<'a>(
+        top: &'a IsisTop,
+        level: &Level,
+        sys_id: &IsisSysId,
+        mt2_mode: bool,
+    ) -> Option<&'a Vec<IsisTlvIpv6ReachEntry>> {
+        if mt2_mode {
+            top.mt2_reach_map_v6.get(level).get(sys_id)
+        } else {
+            top.reach_map_v6.get(level).get(sys_id)
+        }
+    }
+
+    fn entry_prefix(e: &IsisTlvIpv6ReachEntry) -> Ipv6Net {
+        e.prefix
+    }
+
+    fn entry_metric(e: &IsisTlvIpv6ReachEntry) -> u32 {
+        e.metric
+    }
+
+    fn resolve_sid(
+        _top: &IsisTop,
+        _level: &Level,
+        _sys_id: &IsisSysId,
+        _e: &IsisTlvIpv6ReachEntry,
+    ) -> (Option<u32>, Option<(SidLabelValue, LabelConfig)>, bool) {
+        // Prefix-SID plumbing for IPv6 is deferred until SRv6 IS-IS lands.
+        (None, None, false)
+    }
+
+    fn build_repair(
+        top: &mut IsisTop,
+        level: Level,
+        repair: &spf::RepairPath,
+    ) -> Option<RepairPathSrv6> {
+        build_repair_path_srv6(top, level, repair)
+    }
+
+    fn trunc_prefix(p: Ipv6Net) -> Ipv6Net {
+        p.trunc()
     }
 }
 
@@ -644,18 +798,27 @@ fn build_adjacency_ilm(
 }
 
 /// Build RIB from SPF calculation results
-fn build_rib_from_spf(
+/// Generic SPF → RIB builder.  Handles both address families through the
+/// `IsisRibFamily` trait.
+///
+/// `capability_set` gates path/node eligibility in the V6 legacy mode
+/// (RFC 1195 §5 strict NLPID check).  Pass an empty set for V4 and for
+/// V6 in MT 2 mode — an empty set disables all gating.
+///
+/// `mt2_mode` selects which reach map V6 reads (`mt2_reach_map_v6` vs
+/// `reach_map_v6`).  Ignored by V4.
+fn build_rib_from_spf<F: IsisRibFamily>(
     top: &mut IsisTop,
     level: Level,
     source: usize,
     spf_result: &BTreeMap<usize, spf::Path>,
     tilfa_result: &BTreeMap<usize, Vec<spf::RepairPath>>,
-) -> PrefixMap<Ipv4Net, SpfRoute<V4>> {
-    let mut rib = PrefixMap::<Ipv4Net, SpfRoute<V4>>::new();
+    capability_set: &BTreeSet<IsisSysId>,
+    mt2_mode: bool,
+) -> PrefixMap<F::Prefix, SpfRoute<F>> {
+    let mut rib: PrefixMap<F::Prefix, SpfRoute<F>> = PrefixMap::new();
 
-    // Process each node in the SPF result
     for (node, nhops) in spf_result {
-        // Skip self node
         if *node == source {
             continue;
         }
@@ -666,280 +829,34 @@ fn build_rib_from_spf(
             continue;
         }
 
-        // Resolve node to system ID
         let Some(sys_id) = top.lsp_map.get(&level).resolve(*node) else {
             continue;
         };
 
-        // Build nexthop map. SPF runs in full-path mode (see
-        // compute_spf), so each `p` is the full path
-        // [first_hop, ..., destination]. With pseudonodes in the graph,
-        // p[0] may be a PN whose sys-id resolves to the DIS — skip
-        // leading PN hops to land on the actual nexthop *router* before
-        // looking up neighbours.
-        //
-        // SPF stamps the chosen first-hop link's ifindex into
-        // `Path::first_hop_links` during relaxation (see spf::Link::link_id).
-        // For each path, we look up all (first_hop_vertex, link_id) entries
-        // that match p[0] — usually one, but parallel equal-cost links to
-        // the same neighbour (case P1) produce multiple, and parallel
-        // ECMP-via-different-neighbours produces one per path. This
-        // replaces the old "iterate every top.links entry and match by
-        // sys-id" loop, which silently misrouted in cases P2/P3 (parallel
-        // asymmetric metrics and P2P+LAN mix).
-        let mut spf_nhops = BTreeMap::new();
-        for p in &nhops.paths {
-            let Some(nhop_id) = first_router_hop_id(top.lsp_map.get(&level), p) else {
-                continue;
-            };
-
-            let Some(nhop_sys_id) = top.lsp_map.get(&level).resolve(nhop_id) else {
-                continue;
-            };
-            let nhop_sys_id = *nhop_sys_id;
-
-            // p[0] could be pseudonode.
-            for (_, link_id) in nhops.first_hop_links.iter().filter(|(v, _)| *v == p[0]) {
-                if *link_id == 0 {
-                    continue;
-                }
-                let Some(link) = top.links.get(link_id) else {
-                    continue;
-                };
-                let Some(nbr) = link.state.nbrs.get(&level).get(&nhop_sys_id) else {
-                    continue;
-                };
-                for (addr, _) in nbr.addr4.iter() {
-                    let nhop = SpfNexthop::<V4> {
-                        ifindex: *link_id,
-                        adjacency: *node == nhop_id,
-                        sys_id: Some(nhop_sys_id),
-                        backup: None,
-                    };
-                    spf_nhops.insert(*addr, nhop);
-                }
-            }
-        }
-
-        // TI-LFA backup stamping is deferred to a second pass after
-        // the per-destination loop completes — see the post-loop
-        // block below. Per-destination stamping was racy with the
-        // equal-metric merge: a prefix advertised by multiple
-        // destinations would end up with primary nexthops from all
-        // of them but a backup attached to only one, and that
-        // backup is useless for the multi-primary case (the remaining
-        // ECMP legs already provide protection).
-
-        // Process reachability entries for this node.
-        if let Some(entries) = top.reach_map.get(&level).get(&Afi::Ip).get(sys_id) {
-            for entry in entries.iter() {
-                let sid = if let Some(prefix_sid) = entry.prefix_sid() {
-                    match prefix_sid.sid {
-                        // Prefix SID label.
-                        SidLabelValue::Index(index) => top
-                            .label_map
-                            .get(&level)
-                            .get(sys_id)
-                            .map(|block| block.global.start + index),
-                        SidLabelValue::Label(label) => Some(label),
-                    }
-                } else {
-                    None
-                };
-
-                let prefix_sid = if let Some(prefix_sid) = entry.prefix_sid()
-                    && let Some(block) = top.label_map.get(&level).get(sys_id)
-                {
-                    Some((prefix_sid.sid.clone(), block.clone()))
-                } else {
-                    None
-                };
-
-                // RFC 8667 §2.1.1 P (no-PHP): when the origin asked us
-                // not to pop, the penultimate-hop ILM swaps instead.
-                let no_php = entry
-                    .prefix_sid()
-                    .map(|ps| ps.flags.p_flag())
-                    .unwrap_or(false);
-
-                let route = SpfRoute {
-                    metric: nhops.cost + entry.metric,
-                    nhops: spf_nhops.clone(),
-                    sid,
-                    prefix_sid,
-                    no_php,
-                    dest_vertex: Some(*node),
-                    backup_as_primary: top.config.fast_reroute_backup_as_primary,
-                };
-
-                if let Some(curr) = rib.get_mut(&entry.prefix.trunc()) {
-                    if curr.metric > route.metric {
-                        // New route has better metric, replace the existing one
-                        *curr = route;
-                    } else if curr.metric == route.metric {
-                        // Equal metric: the same prefix is advertised
-                        // by multiple destinations at equal SPF cost —
-                        // anycast / shared loopback / sibling routes.
-                        // Merging their primaries here makes this an
-                        // ECMP route at the RIB / prefix level —
-                        // distinct from intra-route ECMP within one
-                        // destination, which `spf_nhops` already
-                        // collapsed above.
-                        //
-                        // The post-loop TI-LFA backup pass skips
-                        // routes with multi-primary nhops (the typical
-                        // anycast outcome), so a backup attached to
-                        // only one sibling can't leak into the merged
-                        // RIB entry the way it did before deferral.
-                        //
-                        // Remaining metadata-merge limitations:
-                        //   - sid / prefix_sid first-wins. Index-
-                        //     encoded SIDs resolve against the
-                        //     advertising router's SRGB (see line
-                        //     ~2595); siblings with divergent SRGBs
-                        //     end up with different absolute labels
-                        //     and the subsequent labels are silently
-                        //     dropped. RFC 8667 §4 recommends anycast
-                        //     SR groups share an Index, but SRGBs
-                        //     aren't required to match across
-                        //     siblings.
-                        //   - `dest_vertex` stays at the first-merged
-                        //     node. The post-loop backup pass uses it
-                        //     to look up the repair; this is only
-                        //     load-bearing when an RIB route ends up
-                        //     single-primary (siblings whose nhops
-                        //     collapsed to one peer address via a
-                        //     shared first-hop neighbor), in which
-                        //     case every collapsed sibling protects
-                        //     against the same primary so picking
-                        //     the first sibling's repair is fine.
-                        for (addr, nhop) in route.nhops {
-                            curr.nhops.insert(addr, nhop);
-                        }
-                        if curr.sid.is_none() && route.sid.is_some() {
-                            curr.sid = route.sid;
-                        }
-                        if curr.prefix_sid.is_none() && route.prefix_sid.is_some() {
-                            curr.prefix_sid = route.prefix_sid;
-                            // Keep no_php aligned with the Prefix-SID we adopt.
-                            curr.no_php = route.no_php;
-                        }
-                    }
-                    // If curr.metric < route.metric, do nothing (keep better route)
-                } else {
-                    // No existing route, insert the new one
-                    rib.insert(entry.prefix.trunc(), route);
-                }
-            }
-        }
-    }
-
-    // Second pass: TI-LFA backup stamping.
-    //
-    // Defer until the equal-metric merge has stabilized. A prefix
-    // with multiple primary nexthops (ECMP at the RIB level)
-    // shouldn't carry a backup — the remaining ECMP legs already
-    // provide protection, and a metric-offset backup at one leg's
-    // repair address just wastes a FIB entry without adding value
-    // (the typical backup steers around the same link the surviving
-    // ECMP leg already avoids).
-    //
-    // For single-primary routes we look up the repair by
-    // `dest_vertex`. tilfa_repair_path already skips destinations
-    // with SPF-level ECMP, so the lookup either returns a repair
-    // built against a single protected first-hop (the only valid
-    // case for stamping) or nothing.
-    for (_, route) in rib.iter_mut() {
-        if route.nhops.len() != 1 {
-            continue;
-        }
-        let Some(dest) = route.dest_vertex else {
-            continue;
-        };
-        let Some(repair_paths) = tilfa_result.get(&dest) else {
-            continue;
-        };
-        let Some(repair) = repair_paths.first() else {
-            continue;
-        };
-        let Some(backup) = build_repair_path_mpls(top, level, repair) else {
-            continue;
-        };
-        if let Some(nhop) = route.nhops.values_mut().next() {
-            nhop.backup = Some(backup);
-        }
-    }
-
-    rib
-}
-
-// IPv6 RIB builder. Walks the chosen SPF tree and joins each reached
-// node's IPv6 reach entries to a nexthop map keyed by the first-hop
-// neighbor's link-local IPv6 (Neighbor::addr6l).
-//
-// `mt2_mode` controls which inputs to consume:
-//   - false (legacy / single-topology): SPF over the legacy graph,
-//     prefixes from `top.reach_map_v6` (TLV 236), with strict NLPID
-//     gating per RFC 1195 §5 — every transit node must advertise the
-//     IPv6 NLPID or its Ipv6Reach is unreachable.
-//   - true (MT 2 / RFC 5120 §3.4): SPF over the MT 2 graph
-//     (already filtered to MT-2-capable peers at graph-build time),
-//     prefixes from `top.mt2_reach_map_v6` (TLV 237). NLPID gating
-//     is redundant here — TLV 229 with MT 2 is the stricter signal —
-//     so we skip it.
-//
-// Prefix-SID / SR plumbing for IPv6 is intentionally deferred — sid
-// and prefix_sid are left None for now and can be added when SRv6
-// IS-IS support lands as a follow-up.
-fn build_rib_from_spf_v6(
-    top: &mut IsisTop,
-    level: Level,
-    source: usize,
-    spf_result: &BTreeMap<usize, spf::Path>,
-    tilfa_result: &BTreeMap<usize, Vec<spf::RepairPath>>,
-    mt2_mode: bool,
-) -> PrefixMap<Ipv6Net, SpfRoute<V6>> {
-    let mut rib = PrefixMap::<Ipv6Net, SpfRoute<V6>>::new();
-
-    // NLPID gate set — only used in legacy mode.
-    let ipv6_capable = if mt2_mode {
-        BTreeSet::new()
-    } else {
-        ipv6_capable_set(top.lsdb.get(&level))
-    };
-
-    for (node, nhops) in spf_result {
-        if *node == source {
+        // NLPID gating (V6 legacy mode only; set is empty for V4 and V6 MT2).
+        if !capability_set.is_empty() && !capability_set.contains(sys_id) {
             continue;
         }
 
-        // Skip pseudonode entries — transit-only, no IPv6 prefixes.
-        if top.lsp_map.get(&level).is_pseudo(*node) {
-            continue;
-        }
-
-        let Some(sys_id) = top.lsp_map.get(&level).resolve(*node) else {
-            continue;
-        };
-
-        // Strict NLPID gating per RFC 1195 §5 — only in legacy mode.
-        if !mt2_mode && !ipv6_capable.contains(sys_id) {
-            continue;
-        }
         // Capture SysId so later borrows of top.lsp_map don't conflict.
         let dest_sys_id = *sys_id;
 
-        // Build nexthop map keyed by the first-hop neighbor's link-local IPv6.
-        // Iterate `paths` (full path from first-hop to destination) so we can
-        // strict-gate every transit node, not just the first hop.
+        // Build nexthop map keyed by the family's first-hop address type.
+        //
+        // SPF runs in full-path mode, so each `p` is the full path
+        // [first_hop, ..., destination].  With pseudonodes in the graph,
+        // p[0] may be a PN — skip leading PN hops to land on the actual
+        // nexthop router.  SPF stamps the chosen first-hop link's ifindex
+        // into `Path::first_hop_links` during relaxation; we look up all
+        // (first_hop_vertex, link_id) entries matching p[0].
+        //
+        // In V6 legacy mode every transit node must advertise the IPv6
+        // NLPID (RFC 1195 §5).  An empty `capability_set` disables the
+        // check (V4 and V6 MT2 always pass an empty set).
         let mut spf_nhops = BTreeMap::new();
         'next_path: for p in &nhops.paths {
-            // In legacy mode, every node on the path must advertise IPv6.
-            // In MT 2 mode the graph itself is pre-filtered, so we skip.
-            // Pseudonode hops bypass the IPv6 NLPID check — they don't
-            // advertise capabilities of their own; the gating is on the
-            // attached routers.
-            if !mt2_mode {
+            // Per-path NLPID gating (V6 legacy mode only).
+            if !capability_set.is_empty() {
                 for &hop in p {
                     if top.lsp_map.get(&level).is_pseudo(hop) {
                         continue;
@@ -947,14 +864,12 @@ fn build_rib_from_spf_v6(
                     let Some(hop_sys_id) = top.lsp_map.get(&level).resolve(hop) else {
                         continue 'next_path;
                     };
-                    if !ipv6_capable.contains(hop_sys_id) {
+                    if !capability_set.contains(hop_sys_id) {
                         continue 'next_path;
                     }
                 }
             }
 
-            // Skip leading pseudonode hops to land on the actual nexthop
-            // router whose adjacency carries the link-local v6 address.
             let Some(nhop_id) = first_router_hop_id(top.lsp_map.get(&level), p) else {
                 continue;
             };
@@ -963,8 +878,7 @@ fn build_rib_from_spf_v6(
             };
             let nhop_sys_id = *nhop_sys_id;
             let is_adjacency = nhop_id == *node;
-            // Same first_hop_links-driven resolution as the IPv4 builder.
-            // See build_rib_from_spf for the design rationale.
+
             for (_, link_id) in nhops.first_hop_links.iter().filter(|(v, _)| *v == p[0]) {
                 if *link_id == 0 {
                     continue;
@@ -975,63 +889,75 @@ fn build_rib_from_spf_v6(
                 let Some(nbr) = link.state.nbrs.get(&level).get(&nhop_sys_id) else {
                     continue;
                 };
-                for addr in nbr.addr6l.iter() {
-                    let nhop = SpfNexthop::<V6> {
-                        ifindex: *link_id,
-                        adjacency: is_adjacency,
-                        sys_id: Some(nhop_sys_id),
-                        backup: None,
-                    };
-                    spf_nhops.insert(*addr, nhop);
+                for addr in F::nhop_addrs(nbr) {
+                    spf_nhops.insert(
+                        addr,
+                        SpfNexthop::<F> {
+                            ifindex: *link_id,
+                            adjacency: is_adjacency,
+                            sys_id: Some(nhop_sys_id),
+                            backup: None,
+                        },
+                    );
                 }
             }
         }
 
-        // No surviving paths after gating → don't install anything for this dest.
+        // No surviving paths after gating — skip this destination.
         if spf_nhops.is_empty() {
             continue;
         }
 
-        // TI-LFA SRv6 backup stamping is deferred to a second pass
-        // after the per-destination loop — see the post-loop block
-        // below, and `build_rib_from_spf`'s sibling comment for the
-        // rationale.
-
-        let reach = if mt2_mode {
-            top.mt2_reach_map_v6.get(&level).get(&dest_sys_id)
-        } else {
-            top.reach_map_v6.get(&level).get(&dest_sys_id)
-        };
-        if let Some(entries) = reach {
+        // TI-LFA backup stamping is deferred to the second pass below
+        // so it sees the stabilised equal-metric merge.
+        if let Some(entries) = F::reach_entries(top, &level, &dest_sys_id, mt2_mode) {
             for entry in entries.iter() {
-                let route = SpfRoute::<V6> {
-                    metric: nhops.cost + entry.metric,
+                let prefix = F::entry_prefix(entry);
+                let (sid, prefix_sid, no_php) = F::resolve_sid(top, &level, &dest_sys_id, entry);
+                let route = SpfRoute::<F> {
+                    metric: nhops.cost + F::entry_metric(entry),
                     nhops: spf_nhops.clone(),
-                    sid: None,
-                    prefix_sid: None,
-                    no_php: false,
+                    sid,
+                    prefix_sid,
+                    no_php,
                     dest_vertex: Some(*node),
                     backup_as_primary: top.config.fast_reroute_backup_as_primary,
                 };
 
-                if let Some(curr) = rib.get_mut(&entry.prefix.trunc()) {
+                let tprefix = F::trunc_prefix(prefix);
+                if let Some(curr) = rib.get_mut(&tprefix) {
                     if curr.metric > route.metric {
                         *curr = route;
                     } else if curr.metric == route.metric {
+                        // Equal metric: anycast / shared loopback / sibling
+                        // routes.  Merge primaries for ECMP at the RIB level.
+                        // The post-loop backup pass skips multi-primary routes
+                        // so a stamped backup can't leak across the merge.
+                        //
+                        // sid / prefix_sid: first-wins (see original V4
+                        // comment for the anycast SR caveats).
                         for (addr, nhop) in route.nhops {
                             curr.nhops.insert(addr, nhop);
                         }
+                        if curr.sid.is_none() && route.sid.is_some() {
+                            curr.sid = route.sid;
+                        }
+                        if curr.prefix_sid.is_none() && route.prefix_sid.is_some() {
+                            curr.prefix_sid = route.prefix_sid;
+                            curr.no_php = route.no_php;
+                        }
                     }
                 } else {
-                    rib.insert(entry.prefix.trunc(), route);
+                    rib.insert(tprefix, route);
                 }
             }
         }
     }
 
-    // Second pass: TI-LFA SRv6 backup stamping. Mirror of the v4
-    // post-loop pass — skip ECMP-at-prefix routes, stamp the
-    // dest_vertex's repair on single-primary routes.
+    // Second pass: TI-LFA backup stamping.
+    //
+    // Deferred until the equal-metric merge has stabilised.  Skip ECMP
+    // routes (the surviving legs already provide protection).
     for (_, route) in rib.iter_mut() {
         if route.nhops.len() != 1 {
             continue;
@@ -1045,7 +971,7 @@ fn build_rib_from_spf_v6(
         let Some(repair) = repair_paths.first() else {
             continue;
         };
-        let Some(backup) = build_repair_path_srv6(top, level, repair) else {
+        let Some(backup) = F::build_repair(top, level, repair) else {
             continue;
         };
         if let Some(nhop) = route.nhops.values_mut().next() {
@@ -1387,7 +1313,15 @@ pub(super) fn apply_spf_result(top: &mut IsisTop, output: SpfOutput) {
     let srgb = top.sr_block.as_ref().and_then(|b| b.global.as_ref());
 
     // IPv4 RIB.
-    let rib = build_rib_from_spf(top, level, source, &spf_result, &tilfa_result);
+    let rib = build_rib_from_spf::<V4>(
+        top,
+        level,
+        source,
+        &spf_result,
+        &tilfa_result,
+        &BTreeSet::new(),
+        false,
+    );
 
     // IPv6 RIB — either MT 2 (when enabled) or the legacy single-topology path.
     let rib_v6 = match mt2 {
@@ -1396,19 +1330,36 @@ pub(super) fn apply_spf_result(top: &mut IsisTop, output: SpfOutput) {
             spf: Some(mt2_spf),
             tilfa: mt2_tilfa,
         }) => {
-            let rib_v6 = build_rib_from_spf_v6(top, level, mt2_src, &mt2_spf, &mt2_tilfa, true);
+            let rib_v6 = build_rib_from_spf::<V6>(
+                top,
+                level,
+                mt2_src,
+                &mt2_spf,
+                &mt2_tilfa,
+                &BTreeSet::new(),
+                true,
+            );
             *top.mt2_spf_result.get_mut(&level) = Some(mt2_spf);
             rib_v6
         }
         Some(_) => {
             // MT 2 enabled but no source — clear and install nothing.
             *top.mt2_spf_result.get_mut(&level) = None;
-            PrefixMap::new()
+            PrefixMap::<Ipv6Net, SpfRoute<V6>>::new()
         }
         None => {
             // No MT 2: fall back to legacy graph + reach_map_v6 (and
             // the legacy TI-LFA result) for IPv6.
-            build_rib_from_spf_v6(top, level, source, &spf_result, &tilfa_result, false)
+            let cap_set = ipv6_capable_set(top.lsdb.get(&level));
+            build_rib_from_spf::<V6>(
+                top,
+                level,
+                source,
+                &spf_result,
+                &tilfa_result,
+                &cap_set,
+                false,
+            )
         }
     };
 

--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -38,13 +38,17 @@ use super::tilfa::{
 /// Mirrors the `StaticFamily` pattern in `rib/static/config.rs`.
 pub trait IsisRibFamily: Sized + 'static {
     type Addr: Ord + Copy + std::fmt::Debug + PartialEq;
-    type Prefix: Ord + Copy;
+    type Prefix: Ord + Copy + prefix_trie::Prefix;
     type Backup: std::fmt::Debug + Clone + PartialEq;
 
     fn addr_to_ip(addr: Self::Addr) -> IpAddr;
     fn backup_to_nexthop_uni(backup: &Self::Backup, metric: u32) -> rib::NexthopUni;
     fn rib_add(prefix: Self::Prefix, entry: crate::rib::entry::RibEntry) -> crate::rib::Message;
     fn rib_del(prefix: Self::Prefix, entry: crate::rib::entry::RibEntry) -> crate::rib::Message;
+    /// Number of SR steering segments in `backup` — MPLS label stack
+    /// depth for V4, SRv6 segment-list length for V6.  Used to bucket
+    /// TI-LFA protection into trivial / 1-segment / N-segment tallies.
+    fn backup_sr_len(backup: &Self::Backup) -> usize;
 }
 
 pub struct V4;
@@ -69,6 +73,10 @@ impl IsisRibFamily for V4 {
 
     fn rib_del(prefix: Ipv4Net, entry: crate::rib::entry::RibEntry) -> crate::rib::Message {
         crate::rib::Message::Ipv4Del { prefix, rib: entry }
+    }
+
+    fn backup_sr_len(backup: &RepairPathMpls) -> usize {
+        backup.labels.len()
     }
 }
 
@@ -96,6 +104,10 @@ impl IsisRibFamily for V6 {
 
     fn rib_del(prefix: Ipv6Net, entry: crate::rib::entry::RibEntry) -> crate::rib::Message {
         crate::rib::Message::Ipv6Del { prefix, rib: entry }
+    }
+
+    fn backup_sr_len(backup: &RepairPathSrv6) -> usize {
+        backup.segs.len()
     }
 }
 

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -714,7 +714,7 @@ fn show_isis_fast_reroute_prefix_detail(
         }
 
         for (addr, nhop) in route.nhops.iter() {
-            write_isis_nhop_v4_detail(&mut buf, isis, level, route, addr, nhop)?;
+            write_isis_nhop_detail::<V4>(&mut buf, isis, level, route, addr, nhop)?;
         }
     }
     if !found {
@@ -1103,7 +1103,7 @@ fn write_show_isis_route_text(isis: &Isis) -> std::result::Result<String, std::f
         writeln!(buf)?;
         writeln!(buf, "IS-IS {} IPv4 routing table:", level_short)?;
         writeln!(buf)?;
-        write_rib_v4(&mut buf, isis, level)?;
+        write_rib_table::<V4>(&mut buf, isis, isis.rib.get(level))?;
 
         // IPv6 SPF tree. MT 2 enabled → MT 2 SPF; legacy otherwise.
         let mt2 = mt2_v6_active(isis);
@@ -1136,7 +1136,7 @@ fn write_show_isis_route_text(isis: &Isis) -> std::result::Result<String, std::f
         writeln!(buf)?;
         writeln!(buf, "IS-IS {} IPv6 routing table:", level_short)?;
         writeln!(buf)?;
-        write_rib_v6(&mut buf, isis, level)?;
+        write_rib_table::<V6>(&mut buf, isis, isis.rib_v6.get(level))?;
     }
 
     if !wrote_any_level {
@@ -1571,17 +1571,136 @@ fn fmt_isis_srv6_segs(segs: &[std::net::Ipv6Addr]) -> String {
     format!("{{ {} }}", parts.join(", "))
 }
 
-/// Emit one nhop block for the IPv4 detail view. Walks the primary
-/// (addr + iface + neighbor hostname + SRGB), the route's
-/// prefix-SID if present, and the backup path when stamped.
-fn write_isis_nhop_v4_detail(
+/// Per-family show extensions for the RIB table and nhop-detail
+/// renderers.  Lives entirely in show.rs so rib.rs stays free of
+/// display concerns.
+trait IsisRibFamilyShow: IsisRibFamily {
+    const W_PREFIX: usize;
+    const W_NEXTHOP: usize;
+    /// Render the Label(s) column for one tabular row.
+    /// `nhop` is `None` for the no-nexthop (directly-connected) row.
+    fn label_col(route: &SpfRoute<Self>, nhop: Option<&SpfNexthop<Self>>) -> String;
+    /// Append optional suffix text (e.g. SRGB Base) after
+    /// `via addr, iface, nbr` but before the newline.
+    fn write_nhop_extra(
+        buf: &mut String,
+        isis: &Isis,
+        level: &Level,
+        nhop: &SpfNexthop<Self>,
+    ) -> std::fmt::Result;
+    /// Write the Prefix-SID block when present.
+    fn write_sid_block(
+        buf: &mut String,
+        route: &SpfRoute<Self>,
+        nhop: &SpfNexthop<Self>,
+    ) -> std::fmt::Result;
+    /// Write the backup-path stanza.
+    fn write_backup(
+        buf: &mut String,
+        isis: &Isis,
+        level: &Level,
+        nhop: &SpfNexthop<Self>,
+    ) -> std::fmt::Result;
+}
+
+impl IsisRibFamilyShow for V4 {
+    const W_PREFIX: usize = 18;
+    const W_NEXTHOP: usize = 16;
+    fn label_col(route: &SpfRoute<V4>, nhop: Option<&SpfNexthop<V4>>) -> String {
+        match (route.sid, nhop) {
+            (None, _) => "-".into(),
+            (Some(sid), None) => sid.to_string(),
+            (Some(sid), Some(nhop)) => {
+                if nhop.adjacency {
+                    format!("{} (impl-null)", sid)
+                } else {
+                    sid.to_string()
+                }
+            }
+        }
+    }
+    fn write_nhop_extra(
+        buf: &mut String,
+        isis: &Isis,
+        level: &Level,
+        nhop: &SpfNexthop<V4>,
+    ) -> std::fmt::Result {
+        if let Some(srgb) = nhop.sys_id.and_then(|s| srgb_base_for(isis, level, &s)) {
+            write!(buf, ", SRGB Base: {}", srgb)?;
+        }
+        Ok(())
+    }
+    fn write_sid_block(
+        buf: &mut String,
+        route: &SpfRoute<V4>,
+        nhop: &SpfNexthop<V4>,
+    ) -> std::fmt::Result {
+        if let Some(sid) = route.sid {
+            let tag = if nhop.adjacency { " (impl-null)" } else { "" };
+            writeln!(buf, "    Prefix-SID: {}{}", sid, tag)?;
+        }
+        Ok(())
+    }
+    fn write_backup(
+        buf: &mut String,
+        isis: &Isis,
+        level: &Level,
+        nhop: &SpfNexthop<V4>,
+    ) -> std::fmt::Result {
+        if let Some(backup) = &nhop.backup {
+            write_isis_backup_v4_detail(buf, isis, level, backup)?;
+        }
+        Ok(())
+    }
+}
+
+impl IsisRibFamilyShow for V6 {
+    const W_PREFIX: usize = 22;
+    const W_NEXTHOP: usize = 26;
+    fn label_col(_route: &SpfRoute<V6>, _nhop: Option<&SpfNexthop<V6>>) -> String {
+        "-".into()
+    }
+    fn write_nhop_extra(
+        _buf: &mut String,
+        _isis: &Isis,
+        _level: &Level,
+        _nhop: &SpfNexthop<V6>,
+    ) -> std::fmt::Result {
+        Ok(())
+    }
+    fn write_sid_block(
+        _buf: &mut String,
+        _route: &SpfRoute<V6>,
+        _nhop: &SpfNexthop<V6>,
+    ) -> std::fmt::Result {
+        Ok(())
+    }
+    fn write_backup(
+        buf: &mut String,
+        isis: &Isis,
+        level: &Level,
+        nhop: &SpfNexthop<V6>,
+    ) -> std::fmt::Result {
+        if let Some(backup) = &nhop.backup {
+            write_isis_backup_v6_detail(buf, isis, level, backup)?;
+        }
+        Ok(())
+    }
+}
+
+/// Generic nhop-detail writer for `show isis route detail`.
+fn write_isis_nhop_detail<F>(
     buf: &mut String,
     isis: &Isis,
     level: &Level,
-    route: &SpfRoute<V4>,
-    addr: &std::net::Ipv4Addr,
-    nhop: &SpfNexthop<V4>,
-) -> std::fmt::Result {
+    route: &SpfRoute<F>,
+    addr: &F::Addr,
+    nhop: &SpfNexthop<F>,
+) -> std::fmt::Result
+where
+    F: IsisRibFamilyShow,
+    F::Addr: std::fmt::Display,
+{
     let nbr_hostname = nhop
         .sys_id
         .map(|s| hostname_for(isis, level, &s))
@@ -1593,19 +1712,10 @@ fn write_isis_nhop_v4_detail(
         isis.ifname(nhop.ifindex),
         nbr_hostname
     )?;
-    if let Some(srgb) = nhop.sys_id.and_then(|s| srgb_base_for(isis, level, &s)) {
-        write!(buf, ", SRGB Base: {}", srgb)?;
-    }
+    F::write_nhop_extra(buf, isis, level, nhop)?;
     writeln!(buf)?;
-
-    if let Some(sid) = route.sid {
-        let tag = if nhop.adjacency { " (impl-null)" } else { "" };
-        writeln!(buf, "    Prefix-SID: {}{}", sid, tag)?;
-    }
-
-    if let Some(backup) = &nhop.backup {
-        write_isis_backup_v4_detail(buf, isis, level, backup)?;
-    }
+    F::write_sid_block(buf, route, nhop)?;
+    F::write_backup(buf, isis, level, nhop)?;
     Ok(())
 }
 
@@ -1648,34 +1758,6 @@ fn write_isis_backup_v4_detail(
     Ok(())
 }
 
-/// IPv6 sibling — same shape but SRH segments instead of MPLS
-/// labels.
-fn write_isis_nhop_v6_detail(
-    buf: &mut String,
-    isis: &Isis,
-    level: &Level,
-    _route: &SpfRoute<V6>,
-    addr: &std::net::Ipv6Addr,
-    nhop: &SpfNexthop<V6>,
-) -> std::fmt::Result {
-    let nbr_hostname = nhop
-        .sys_id
-        .map(|s| hostname_for(isis, level, &s))
-        .unwrap_or_else(|| "-".into());
-    writeln!(
-        buf,
-        "  via {}, {}, {}",
-        addr,
-        isis.ifname(nhop.ifindex),
-        nbr_hostname
-    )?;
-
-    if let Some(backup) = &nhop.backup {
-        write_isis_backup_v6_detail(buf, isis, level, backup)?;
-    }
-    Ok(())
-}
-
 fn write_isis_backup_v6_detail(
     buf: &mut String,
     _isis: &Isis,
@@ -1701,9 +1783,8 @@ fn write_isis_backup_v6_detail(
     Ok(())
 }
 
-/// `show isis route detail` per-level IPv4 RIB renderer. Replaces
-/// the columnar `write_rib_v4` layout with per-prefix blocks that
-/// surface TI-LFA backup paths.
+/// Per-level RIB renderer for `show isis route detail`. Emits
+/// per-prefix blocks that surface TI-LFA backup paths.
 fn write_rib_detail<F>(
     buf: &mut String,
     isis: &Isis,
@@ -1771,7 +1852,7 @@ fn write_show_isis_route_text_detail(isis: &Isis) -> std::result::Result<String,
             isis,
             level,
             isis.rib.get(level),
-            write_isis_nhop_v4_detail,
+            write_isis_nhop_detail::<V4>,
         )?;
 
         writeln!(buf)?;
@@ -1782,7 +1863,7 @@ fn write_show_isis_route_text_detail(isis: &Isis) -> std::result::Result<String,
             isis,
             level,
             isis.rib_v6.get(level),
-            write_isis_nhop_v6_detail,
+            write_isis_nhop_detail::<V6>,
         )?;
     }
 
@@ -1792,11 +1873,20 @@ fn write_show_isis_route_text_detail(isis: &Isis) -> std::result::Result<String,
     Ok(buf)
 }
 
-fn write_rib_v4(buf: &mut String, isis: &Isis, level: &Level) -> std::fmt::Result {
-    const W_PREFIX: usize = 18;
+fn write_rib_table<F>(
+    buf: &mut String,
+    isis: &Isis,
+    rib: &PrefixMap<F::Prefix, SpfRoute<F>>,
+) -> std::fmt::Result
+where
+    F: IsisRibFamilyShow,
+    F::Prefix: std::fmt::Display,
+    F::Addr: std::fmt::Display,
+{
     const W_METRIC: usize = 7;
     const W_INTERFACE: usize = 10;
-    const W_NEXTHOP: usize = 16;
+    let wp = F::W_PREFIX;
+    let wn = F::W_NEXTHOP;
 
     writeln!(
         buf,
@@ -1805,24 +1895,20 @@ fn write_rib_v4(buf: &mut String, isis: &Isis, level: &Level) -> std::fmt::Resul
         "Metric",
         "Interface",
         "Nexthop",
-        wp = W_PREFIX,
+        wp = wp,
         wm = W_METRIC,
         wi = W_INTERFACE,
-        wn = W_NEXTHOP,
+        wn = wn,
     )?;
-    let total = 1 + W_PREFIX + 1 + W_METRIC + 1 + W_INTERFACE + 1 + W_NEXTHOP + 1 + 9;
+    let total = 1 + wp + 1 + W_METRIC + 1 + W_INTERFACE + 1 + wn + 1 + 9;
     writeln!(buf, " {}", "-".repeat(total - 2))?;
 
-    let mut entries: Vec<_> = isis.rib.get(level).iter().collect();
+    let mut entries: Vec<_> = rib.iter().collect();
     entries.sort_by_key(|(p, _)| *p);
 
     for (prefix, route) in entries {
         if route.nhops.is_empty() {
-            // Locally connected / no nexthop.
-            let label = route
-                .sid
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| "-".into());
+            let label = F::label_col(route, None);
             writeln!(
                 buf,
                 " {:<wp$} {:<wm$} {:<wi$} {:<wn$} {}",
@@ -1831,23 +1917,15 @@ fn write_rib_v4(buf: &mut String, isis: &Isis, level: &Level) -> std::fmt::Resul
                 "-",
                 "-",
                 label,
-                wp = W_PREFIX,
+                wp = wp,
                 wm = W_METRIC,
                 wi = W_INTERFACE,
-                wn = W_NEXTHOP,
+                wn = wn,
             )?;
             continue;
         }
         for (addr, nhop) in route.nhops.iter() {
-            let label = if let Some(sid) = route.sid {
-                if nhop.adjacency {
-                    format!("{} (impl-null)", sid)
-                } else {
-                    sid.to_string()
-                }
-            } else {
-                "-".into()
-            };
+            let label = F::label_col(route, Some(nhop));
             writeln!(
                 buf,
                 " {:<wp$} {:<wm$} {:<wi$} {:<wn$} {}",
@@ -1856,68 +1934,10 @@ fn write_rib_v4(buf: &mut String, isis: &Isis, level: &Level) -> std::fmt::Resul
                 isis.ifname(nhop.ifindex),
                 addr,
                 label,
-                wp = W_PREFIX,
+                wp = wp,
                 wm = W_METRIC,
                 wi = W_INTERFACE,
-                wn = W_NEXTHOP,
-            )?;
-        }
-    }
-    Ok(())
-}
-
-fn write_rib_v6(buf: &mut String, isis: &Isis, level: &Level) -> std::fmt::Result {
-    const W_PREFIX: usize = 22;
-    const W_METRIC: usize = 7;
-    const W_INTERFACE: usize = 10;
-    const W_NEXTHOP: usize = 26;
-
-    writeln!(
-        buf,
-        " {:<wp$} {:<wm$} {:<wi$} {:<wn$} Label(s)",
-        "Prefix",
-        "Metric",
-        "Interface",
-        "Nexthop",
-        wp = W_PREFIX,
-        wm = W_METRIC,
-        wi = W_INTERFACE,
-        wn = W_NEXTHOP,
-    )?;
-    let total = 1 + W_PREFIX + 1 + W_METRIC + 1 + W_INTERFACE + 1 + W_NEXTHOP + 1 + 9;
-    writeln!(buf, " {}", "-".repeat(total - 2))?;
-
-    let mut entries: Vec<_> = isis.rib_v6.get(level).iter().collect();
-    entries.sort_by_key(|(p, _)| *p);
-
-    for (prefix, route) in entries {
-        if route.nhops.is_empty() {
-            writeln!(
-                buf,
-                " {:<wp$} {:<wm$} {:<wi$} {:<wn$} -",
-                prefix.to_string(),
-                route.metric,
-                "-",
-                "-",
-                wp = W_PREFIX,
-                wm = W_METRIC,
-                wi = W_INTERFACE,
-                wn = W_NEXTHOP,
-            )?;
-            continue;
-        }
-        for (addr, nhop) in route.nhops.iter() {
-            writeln!(
-                buf,
-                " {:<wp$} {:<wm$} {:<wi$} {:<wn$} -",
-                prefix.to_string(),
-                route.metric,
-                isis.ifname(nhop.ifindex),
-                addr,
-                wp = W_PREFIX,
-                wm = W_METRIC,
-                wi = W_INTERFACE,
-                wn = W_NEXTHOP,
+                wn = wn,
             )?;
         }
     }

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 
 use super::Hostname;
 use super::lsdb::Lsdb;
-use super::rib::{SpfNexthop, SpfNexthopV6, SpfRoute, SpfRouteV6};
+use super::rib::{SpfNexthop, SpfRoute, V4, V6};
 use super::tilfa::{RepairPathMpls, RepairPathSrv6};
 use super::{Isis, inst::ShowCallback};
 
@@ -1599,9 +1599,9 @@ fn write_isis_nhop_v4_detail(
     buf: &mut String,
     isis: &Isis,
     level: &Level,
-    route: &SpfRoute,
+    route: &SpfRoute<V4>,
     addr: &std::net::Ipv4Addr,
-    nhop: &SpfNexthop,
+    nhop: &SpfNexthop<V4>,
 ) -> std::fmt::Result {
     let nbr_hostname = nhop
         .sys_id
@@ -1675,9 +1675,9 @@ fn write_isis_nhop_v6_detail(
     buf: &mut String,
     isis: &Isis,
     level: &Level,
-    _route: &SpfRouteV6,
+    _route: &SpfRoute<V6>,
     addr: &std::net::Ipv6Addr,
-    nhop: &SpfNexthopV6,
+    nhop: &SpfNexthop<V6>,
 ) -> std::fmt::Result {
     let nbr_hostname = nhop
         .sys_id
@@ -2548,7 +2548,7 @@ fn label_value_str(label: &crate::rib::Label) -> String {
 fn collect_repair_rows(isis: &Isis) -> Vec<RepairRowJson> {
     let mut rows = Vec::new();
     for level in [Level::L1, Level::L2] {
-        let v4: &PrefixMap<Ipv4Net, SpfRoute> = isis.rib.get(&level);
+        let v4: &PrefixMap<Ipv4Net, SpfRoute<V4>> = isis.rib.get(&level);
         for (prefix, route) in v4.iter() {
             for (addr, nhop) in route.nhops.iter() {
                 let Some(backup) = nhop.backup.as_ref() else {
@@ -2577,7 +2577,7 @@ fn collect_repair_rows(isis: &Isis) -> Vec<RepairRowJson> {
                 });
             }
         }
-        let v6: &PrefixMap<Ipv6Net, SpfRouteV6> = isis.rib_v6.get(&level);
+        let v6: &PrefixMap<Ipv6Net, SpfRoute<V6>> = isis.rib_v6.get(&level);
         for (prefix, route) in v6.iter() {
             for (addr, nhop) in route.nhops.iter() {
                 let Some(backup) = nhop.backup.as_ref() else {

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 
 use super::Hostname;
 use super::lsdb::Lsdb;
-use super::rib::{SpfNexthop, SpfRoute, V4, V6};
+use super::rib::{IsisRibFamily, SpfNexthop, SpfRoute, V4, V6};
 use super::tilfa::{RepairPathMpls, RepairPathSrv6};
 use super::{Isis, inst::ShowCallback};
 
@@ -602,40 +602,19 @@ struct FrrSummary {
     multi_segment: usize,
 }
 
-/// Tally TI-LFA protection state across the IPv4 RIB at one level.
-fn summarize_frr_v4(isis: &Isis, level: &Level) -> FrrSummary {
+/// Tally TI-LFA protection state across one level's RIB.  The SR
+/// steering depth — MPLS label-stack depth for V4, SRv6 segment-list
+/// length for V6 — is dispatched through `F::backup_sr_len`.
+fn summarize_frr<F: IsisRibFamily>(rib: &PrefixMap<F::Prefix, SpfRoute<F>>) -> FrrSummary {
     let mut s = FrrSummary::default();
-    for (_, route) in isis.rib.get(level).iter() {
+    for (_, route) in rib.iter() {
         s.total += 1;
         let first_backup = route.nhops.values().find_map(|n| n.backup.as_ref());
         match first_backup {
             None => s.unprotected += 1,
             Some(b) => {
                 s.protected += 1;
-                match b.labels.len() {
-                    0 => s.trivial += 1,
-                    1 => s.one_segment += 1,
-                    _ => s.multi_segment += 1,
-                }
-            }
-        }
-    }
-    s
-}
-
-/// IPv6 sibling — label-stack length test is replaced by SRv6
-/// `segs` length since that's the SR steering dimension in the SRv6
-/// dataplane.
-fn summarize_frr_v6(isis: &Isis, level: &Level) -> FrrSummary {
-    let mut s = FrrSummary::default();
-    for (_, route) in isis.rib_v6.get(level).iter() {
-        s.total += 1;
-        let first_backup = route.nhops.values().find_map(|n| n.backup.as_ref());
-        match first_backup {
-            None => s.unprotected += 1,
-            Some(b) => {
-                s.protected += 1;
-                match b.segs.len() {
+                match F::backup_sr_len(b) {
                     0 => s.trivial += 1,
                     1 => s.one_segment += 1,
                     _ => s.multi_segment += 1,
@@ -672,8 +651,8 @@ fn show_isis_fast_reroute_summary(
     writeln!(buf, "Area {}:", format_area_id(&isis.config.net))?;
     let mut wrote_any = false;
     for level in &[Level::L1, Level::L2] {
-        let v4 = summarize_frr_v4(isis, level);
-        let v6 = summarize_frr_v6(isis, level);
+        let v4 = summarize_frr::<V4>(isis.rib.get(level));
+        let v6 = summarize_frr::<V6>(isis.rib_v6.get(level));
         if v4.total == 0 && v6.total == 0 {
             continue;
         }
@@ -1725,13 +1704,30 @@ fn write_isis_backup_v6_detail(
 /// `show isis route detail` per-level IPv4 RIB renderer. Replaces
 /// the columnar `write_rib_v4` layout with per-prefix blocks that
 /// surface TI-LFA backup paths.
-fn write_rib_v4_detail(buf: &mut String, isis: &Isis, level: &Level) -> std::fmt::Result {
+fn write_rib_detail<F>(
+    buf: &mut String,
+    isis: &Isis,
+    level: &Level,
+    rib: &PrefixMap<F::Prefix, SpfRoute<F>>,
+    write_nhop: fn(
+        &mut String,
+        &Isis,
+        &Level,
+        &SpfRoute<F>,
+        &F::Addr,
+        &SpfNexthop<F>,
+    ) -> std::fmt::Result,
+) -> std::fmt::Result
+where
+    F: IsisRibFamily,
+    F::Prefix: std::fmt::Display,
+{
     let level_short = match level {
         Level::L1 => "L1",
         Level::L2 => "L2",
     };
 
-    let mut entries: Vec<_> = isis.rib.get(level).iter().collect();
+    let mut entries: Vec<_> = rib.iter().collect();
     entries.sort_by_key(|(p, _)| *p);
 
     for (prefix, route) in entries {
@@ -1741,29 +1737,7 @@ fn write_rib_v4_detail(buf: &mut String, isis: &Isis, level: &Level) -> std::fmt
             continue;
         }
         for (addr, nhop) in route.nhops.iter() {
-            write_isis_nhop_v4_detail(buf, isis, level, route, addr, nhop)?;
-        }
-    }
-    Ok(())
-}
-
-fn write_rib_v6_detail(buf: &mut String, isis: &Isis, level: &Level) -> std::fmt::Result {
-    let level_short = match level {
-        Level::L1 => "L1",
-        Level::L2 => "L2",
-    };
-
-    let mut entries: Vec<_> = isis.rib_v6.get(level).iter().collect();
-    entries.sort_by_key(|(p, _)| *p);
-
-    for (prefix, route) in entries {
-        writeln!(buf, "{} {} [metric {}]", level_short, prefix, route.metric)?;
-        if route.nhops.is_empty() {
-            writeln!(buf, "  (directly connected / no nexthop)")?;
-            continue;
-        }
-        for (addr, nhop) in route.nhops.iter() {
-            write_isis_nhop_v6_detail(buf, isis, level, route, addr, nhop)?;
+            write_nhop(buf, isis, level, route, addr, nhop)?;
         }
     }
     Ok(())
@@ -1792,12 +1766,24 @@ fn write_show_isis_route_text_detail(isis: &Isis) -> std::result::Result<String,
         writeln!(buf)?;
         writeln!(buf, "IS-IS {} IPv4 routing table:", level_short)?;
         writeln!(buf)?;
-        write_rib_v4_detail(&mut buf, isis, level)?;
+        write_rib_detail::<V4>(
+            &mut buf,
+            isis,
+            level,
+            isis.rib.get(level),
+            write_isis_nhop_v4_detail,
+        )?;
 
         writeln!(buf)?;
         writeln!(buf, "IS-IS {} IPv6 routing table:", level_short)?;
         writeln!(buf)?;
-        write_rib_v6_detail(&mut buf, isis, level)?;
+        write_rib_detail::<V6>(
+            &mut buf,
+            isis,
+            level,
+            isis.rib_v6.get(level),
+            write_isis_nhop_v6_detail,
+        )?;
     }
 
     if !wrote_any {


### PR DESCRIPTION
## Summary

- **Items #1–4** (`rib.rs`): Introduce `IsisRibFamily` marker-struct trait with `V4`/`V6` impls; make `SpfRoute<F>`, `SpfNexthop<F>`, `make_rib_entry<F>`, `diff_apply<F>`, and `DiffResult<F>` generic over `F`.
- **Items #5–7** (`rib.rs`, `graph.rs`, `inst.rs`, `lsdb.rs`, `link.rs`, `show.rs`): Generic `ReachMap<E>` + `ReachMapV4`/`ReachMapV6` aliases; `summarize_frr<F>`; `write_rib_detail<F>`.
- **Items #8–9** (`show.rs`): `IsisRibFamilyShow` extension trait; replace dual `write_rib_v4`/`write_rib_v6` and dual nhop-detail helpers with `write_rib_table<F>` and `write_isis_nhop_detail<F>`.
- **Items #11–12** (`bgp_ls.rs`): Unify `ipv4_reach`/`ipv6_reach` into `ip_reach(IpNet)` and `ipv4_prefix_object`/`ipv6_prefix_object` into `prefix_object(IpNet)`.
- **Item #10** (`rib.rs`): Replace parallel `build_rib_from_spf` (V4) + `build_rib_from_spf_v6` with a single `build_rib_from_spf<F: IsisRibFamily>`. Extends the trait with `nhop_addrs`, `reach_entries`, `entry_prefix`, `entry_metric`, `resolve_sid`, `build_repair`, `trunc_prefix`. The V6 NLPID capability gate (RFC 1195 §5) is unified via a `capability_set: &BTreeSet<IsisSysId>` parameter — empty set disables gating for V4 and V6 MT2.

Net result: ~83 fewer lines, zero duplicated logic across the two address families.

## Test plan

- [x] `cargo build -p zebra-rs` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p zebra-rs` — 896 passed, 0 failed

Generated with [Claude Code](https://claude.com/claude-code)