### PR TITLE
bdd: fix IS-IS BFD LAN echo scenarios

### DIFF
--- a/bdd/src/netns.rs
+++ b/bdd/src/netns.rs
@@ -403,6 +403,30 @@ pub async fn list_bridges_with_prefix(prefix: &str) -> Result<Vec<String>> {
     Ok(out)
 }
 
+/// List host-namespace veth interfaces whose names end with `suffix`.
+/// Used by the crash-recovery sweep in `clean_test_environment` to find
+/// orphaned bridge-topology host-side veths (named `{logical}_{short_id}`).
+pub async fn list_veths_with_suffix(suffix: &str) -> Result<Vec<String>> {
+    let output = Command::new("sudo")
+        .args(["ip", "-o", "link", "show", "type", "veth"])
+        .stdout(Stdio::piped())
+        .output()
+        .await
+        .context("Failed to list veth interfaces")?;
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut out = Vec::new();
+    for line in text.lines() {
+        // `ip -o link show` lines: "12: z1_4c4f5c2e: <BROADCAST,...> ..."
+        if let Some(rest) = line.split_once(": ")
+            && let Some((name, _)) = rest.1.split_once(": ")
+            && name.ends_with(suffix)
+        {
+            out.push(name.to_string());
+        }
+    }
+    Ok(out)
+}
+
 /// List PID files in `dir` whose filename starts with `prefix` and ends
 /// with `.pid`. Returns absolute paths.
 pub async fn list_pidfiles(dir: &Path, prefix: &str) -> Result<Vec<std::path::PathBuf>> {

--- a/bdd/src/netns.rs
+++ b/bdd/src/netns.rs
@@ -272,16 +272,30 @@ pub async fn spawn_in_netns(
     cmd: &str,
     args: &[&str],
 ) -> Result<tokio::process::Child> {
-    Command::new("sudo")
-        .arg("ip")
-        .arg("netns")
-        .arg("exec")
-        .arg(netns)
-        .arg(cmd)
-        .args(args)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
+    spawn_in_netns_env(netns, &[], cmd, args).await
+}
+
+/// Spawn a process in a network namespace with extra environment variables.
+///
+/// Uses `env KEY=VAL …` before the command so the variables survive the
+/// `sudo ip netns exec` chain (sudo resets the environment by default).
+pub async fn spawn_in_netns_env(
+    netns: &str,
+    env: &[(&str, &str)],
+    cmd: &str,
+    args: &[&str],
+) -> Result<tokio::process::Child> {
+    let mut c = Command::new("sudo");
+    c.arg("ip").arg("netns").arg("exec").arg(netns);
+    if !env.is_empty() {
+        c.arg("env");
+        for (k, v) in env {
+            c.arg(format!("{k}={v}"));
+        }
+    }
+    c.arg(cmd).args(args);
+    c.stdout(Stdio::null()).stderr(Stdio::null());
+    c.spawn()
         .with_context(|| format!("Failed to spawn {} in netns {}", cmd, netns))
 }
 

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -310,8 +310,11 @@ async fn start_zebra_rs(world: &mut World, namespace: String) {
     let log_file = format!("logs/{}.log", scoped);
     let pid_file = world.pid_file(&namespace);
 
-    let _child = netns::spawn_in_netns(
+    let _child = netns::spawn_in_netns_env(
         &scoped,
+        // veth interfaces (used in all BDD topologies) need SKB mode: native
+        // XDP attaches without error on veth but does not loop packets back.
+        &[("ZEBRA_XDP_BFD_ECHO_MODE", "skb")],
         "zebra-rs",
         &[
             "--log-output=file",

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -87,12 +87,8 @@ async fn clean_test_environment(world: &mut World) {
 
     // 2. Sweep stale namespaces from a crashed prior run of THIS feature.
     // Note: `ip netns del` returns in-namespace interfaces to the host
-    // namespace rather than destroying them, so host-side veths may linger.
-    // The normal-path cleanup in `delete_namespace` deletes the host veth
-    // explicitly (which also destroys the ns-side peer); for a crash-recovery
-    // sweep we accept that orphaned veths may remain — they do not block the
-    // namespace creation path since the namespace itself is gone and the
-    // per-scenario setup creates veths with unique names per-run.
+    // namespace rather than destroying them, so host-side veths may linger;
+    // step 4 below sweeps those separately.
     if let Ok(stale) = netns::list_netns_with_prefix(&ns_prefix).await {
         for ns in stale {
             let _ = netns::delete_netns(&ns).await;
@@ -104,6 +100,19 @@ async fn clean_test_environment(world: &mut World) {
     if let Ok(stale) = netns::list_bridges_with_prefix(&bridge_name).await {
         for br in stale {
             let _ = netns::delete_bridge(&br).await;
+        }
+    }
+
+    // 4. Sweep orphaned host-side veths from bridge topologies. These are
+    // named `{logical}_{short_id}` — a `_{short_id}` suffix uniquely
+    // identifies this feature's veths. A crashed prior scenario may leave
+    // them behind even after the namespace and bridge are gone, because
+    // `ip netns del` moves the ns-side veth to the host namespace rather than
+    // deleting it, and neither end is auto-removed when the bridge is deleted.
+    let veth_suffix = format!("_{}", world.short_id());
+    if let Ok(stale) = netns::list_veths_with_suffix(&veth_suffix).await {
+        for veth in stale {
+            let _ = netns::delete_veth(&veth).await;
         }
     }
 

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -85,10 +85,14 @@ async fn clean_test_environment(world: &mut World) {
         }
     }
 
-    // 2. Sweep stale namespaces from a crashed prior run of THIS
-    // feature. Deleting a netns auto-destroys its in-namespace
-    // interfaces (including the ns end of any veth pair, which by
-    // veth semantics also destroys the host end).
+    // 2. Sweep stale namespaces from a crashed prior run of THIS feature.
+    // Note: `ip netns del` returns in-namespace interfaces to the host
+    // namespace rather than destroying them, so host-side veths may linger.
+    // The normal-path cleanup in `delete_namespace` deletes the host veth
+    // explicitly (which also destroys the ns-side peer); for a crash-recovery
+    // sweep we accept that orphaned veths may remain — they do not block the
+    // namespace creation path since the namespace itself is gone and the
+    // per-scenario setup creates veths with unique names per-run.
     if let Ok(stale) = netns::list_netns_with_prefix(&ns_prefix).await {
         for ns in stale {
             let _ = netns::delete_netns(&ns).await;
@@ -431,10 +435,19 @@ async fn run_exec_command(world: &mut World, command: String, namespace: String)
 #[when(expr = "I delete namespace {string}")]
 async fn delete_namespace(world: &mut World, namespace: String) {
     let scoped = world.ns(&namespace);
+    let host_veth = world.host_veth(&namespace);
     if keep_topology() {
         println!("⏭  BDD_KEEP set — leaving namespace {} up", scoped);
         return;
     }
+    // Delete the host-side veth before deleting the namespace. Deleting one
+    // end of a veth pair removes both ends regardless of which netns each
+    // lives in, so this also destroys the ns-side peer. Without this, the
+    // ns-side veth is returned to the host namespace by `ip netns del` and
+    // both halves linger, causing "File exists" when the next scenario tries
+    // to create a veth with the same host name. No-op for P2P topologies
+    // (no host-side veth with this name exists there).
+    let _ = netns::delete_veth(&host_veth).await;
     netns::delete_netns(&scoped)
         .await
         .expect("Failed to delete namespace");


### PR DESCRIPTION
## Summary

- **Pass `ZEBRA_XDP_BFD_ECHO_MODE=skb` when spawning zebra-rs** — native XDP attaches to veth without error but does not loop echo packets back (documented in `reflector.rs`). In auto mode the XDP reflector picks native first, so BFD Echo bootstrapped then died at the 150ms detect timeout, driving a BFD-down → IS-IS hold-down cycle that continuously withdrew the loopback route and broke the ping assertion. Added `spawn_in_netns_env` to pass env vars through the `sudo ip netns exec` chain via `env(1)` (sudo resets the environment by default).

- **Delete host-side veth in `delete_namespace`** — `ip netns del` returns in-namespace interfaces to the host namespace rather than destroying them. The host-side veth (`{logical}_{short_id}`) was never in the namespace, so both halves persisted after cleanup. The next scenario's `ip link add` then failed with "File exists". Deleting the host-side veth before `ip netns del` removes both ends (veth-pair semantics).

- **Sweep orphaned host-side veths in `clean_test_environment`** — the crash-recovery sweep deleted stale namespaces and bridges but not orphaned bridge-topology veths, causing "File exists" failures on the *next* run's setup step. Added `list_veths_with_suffix` to find and delete all host-namespace veths named `*_{short_id}` at scenario start.

## Test plan

- [x] `make isis_bfd_ipv6_lan_echo` — both echo scenarios pass (tx/rx + both-directions)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt` — no diff

Generated with [Claude Code](https://claude.com/claude-code)