### PR TITLE
bdd: extend ping_should_fail polling window to 30 attempts

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -293,7 +293,9 @@ async fn ping_should_fail(world: &mut World, namespace: String, target: String) 
     // the target becomes unreachable; only a target still reachable after the
     // whole window is a real failure. The common case (no route at all) fails
     // on the first probe and breaks immediately, adding no delay.
-    const ATTEMPTS: u32 = 10;
+    // 30 attempts (up to 29s) covers heavy concurrent runs (20-way) where
+    // the netlink write path is delayed well past the IS-IS RIB withdrawal.
+    const ATTEMPTS: u32 = 30;
     let mut reachable = true;
     for i in 0..ATTEMPTS {
         reachable = if is_v6 {


### PR DESCRIPTION
## Summary

- `ping_should_fail` polled up to 10 times (9 s) for kernel FIB removal after IS-IS route withdrawal
- Under 20-way concurrent feature runs (~40+ zebra-rs instances), rtnetlink write latency can exceed that window, causing `isis_hello_auth_keychain` scenario 2 to fail intermittently
- Raises `ATTEMPTS` from 10 → 30 (up to 29 s) to cover FIB-lag under concurrent load
- No delay added in the common case: the loop exits on the first failed ping

## Test plan

- [ ] `make isis_hello_auth_keychain` passes individually (as before)
- [ ] `cargo test --test cucumber -- --concurrency=20 --tags "@isis"` passes with `isis_hello_auth_keychain` no longer the one failing feature

Generated with [Claude Code](https://claude.com/claude-code)