### PR TITLE
bdd: poll show ip route for FIB cleanup in isis_hello_auth_keychain

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -712,17 +712,18 @@ async fn show_command_eventually_not_contains(
 ) {
     let scoped = world.ns(&namespace);
     // Poll until the output no longer contains the needle. This is needed
-    // when the check spans multiple layers (e.g. IS-IS RIB withdrawal must
+    // when the check spans multiple layers (e.g. an IS-IS withdrawal must
     // propagate through the zebra-rs RIB task and into the kernel FIB before
     // a subsequent ping-should-fail can pass). The common case (already gone)
     // exits on the first attempt with no added delay.
     const ATTEMPTS: u32 = 60;
     let mut still_contains = true;
+    let mut last_output = String::new();
     for i in 0..ATTEMPTS {
-        let output = netns::exec_in_netns(&scoped, "vtyctl", &["show", &show_cmd])
+        last_output = netns::exec_in_netns(&scoped, "vtyctl", &["show", &show_cmd])
             .await
             .expect("Failed to run show command");
-        if !output.contains(&needle) {
+        if !last_output.contains(&needle) {
             still_contains = false;
             break;
         }
@@ -732,8 +733,8 @@ async fn show_command_eventually_not_contains(
     }
     assert!(
         !still_contains,
-        "show '{}' in namespace {} still contained '{}' after {} attempts",
-        show_cmd, scoped, needle, ATTEMPTS
+        "show '{}' in namespace {} still contained '{}' after {} attempts\nlast output:\n{}",
+        show_cmd, scoped, needle, ATTEMPTS, last_output
     );
     println!(
         "✓ show '{}' in namespace {} does not contain '{}'",

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -699,6 +699,41 @@ async fn show_command_contains(
     );
 }
 
+/// Best-effort diagnostic snapshot for debugging a route that fails to
+/// withdraw. Gathers the IS-IS adjacency / LSDB / route views, the
+/// zebra-rs RIB, and the kernel FIB for the namespace, concatenated into
+/// one string so a failing route assertion can embed it in its panic
+/// message — which the per-feature cucumber log (`logs/<feature>.cucumber.log`
+/// under concurrent runs) captures verbatim. Each probe is best-effort;
+/// a failed command is recorded inline rather than aborting the dump.
+async fn route_failure_diagnostics(scoped: &str) -> String {
+    let mut buf = String::from("---- route-withdrawal diagnostics ----");
+    for cmd in [
+        "show isis neighbor",
+        "show isis database detail",
+        "show isis route",
+        "show ip route",
+        "show ipv6 route",
+    ] {
+        let out = match netns::exec_in_netns(scoped, "vtyctl", &["show", cmd]).await {
+            Ok(s) => s,
+            Err(e) => format!("<failed: {e}>"),
+        };
+        buf.push_str(&format!("\n===== vtyctl {cmd} =====\n{}", out.trim_end()));
+    }
+    for (label, args) in [
+        ("kernel ip route", &["route"][..]),
+        ("kernel ip -6 route", &["-6", "route"][..]),
+    ] {
+        let out = match netns::exec_in_netns(scoped, "ip", args).await {
+            Ok(s) => s,
+            Err(e) => format!("<failed: {e}>"),
+        };
+        buf.push_str(&format!("\n===== {label} =====\n{}", out.trim_end()));
+    }
+    buf
+}
+
 /// Negative sibling of `show_command_contains`: assert the `vtyctl show`
 /// output does NOT contain the given substring. Used to verify a
 /// suppressed entry is absent (e.g. the local Prefix-SID label withdrawn
@@ -731,11 +766,13 @@ async fn show_command_eventually_not_contains(
             tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
         }
     }
-    assert!(
-        !still_contains,
-        "show '{}' in namespace {} still contained '{}' after {} attempts\nlast output:\n{}",
-        show_cmd, scoped, needle, ATTEMPTS, last_output
-    );
+    if still_contains {
+        let diag = route_failure_diagnostics(&scoped).await;
+        panic!(
+            "show '{}' in namespace {} still contained '{}' after {} attempts\nlast output:\n{}\n{}",
+            show_cmd, scoped, needle, ATTEMPTS, last_output, diag
+        );
+    }
     println!(
         "✓ show '{}' in namespace {} does not contain '{}'",
         show_cmd, scoped, needle

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -703,6 +703,44 @@ async fn show_command_contains(
 /// output does NOT contain the given substring. Used to verify a
 /// suppressed entry is absent (e.g. the local Prefix-SID label withdrawn
 /// from `show mpls ilm` once `no-local-prefix-sid` is configured).
+#[then(expr = "show command {string} in namespace {string} should eventually not contain {string}")]
+async fn show_command_eventually_not_contains(
+    world: &mut World,
+    show_cmd: String,
+    namespace: String,
+    needle: String,
+) {
+    let scoped = world.ns(&namespace);
+    // Poll until the output no longer contains the needle. This is needed
+    // when the check spans multiple layers (e.g. IS-IS RIB withdrawal must
+    // propagate through the zebra-rs RIB task and into the kernel FIB before
+    // a subsequent ping-should-fail can pass). The common case (already gone)
+    // exits on the first attempt with no added delay.
+    const ATTEMPTS: u32 = 60;
+    let mut still_contains = true;
+    for i in 0..ATTEMPTS {
+        let output = netns::exec_in_netns(&scoped, "vtyctl", &["show", &show_cmd])
+            .await
+            .expect("Failed to run show command");
+        if !output.contains(&needle) {
+            still_contains = false;
+            break;
+        }
+        if i + 1 < ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    }
+    assert!(
+        !still_contains,
+        "show '{}' in namespace {} still contained '{}' after {} attempts",
+        show_cmd, scoped, needle, ATTEMPTS
+    );
+    println!(
+        "✓ show '{}' in namespace {} does not contain '{}'",
+        show_cmd, scoped, needle
+    );
+}
+
 #[then(expr = "show command {string} in namespace {string} should not contain {string}")]
 async fn show_command_not_contains(
     world: &mut World,

--- a/bdd/tests/features/isis_hello_auth_keychain.feature
+++ b/bdd/tests/features/isis_hello_auth_keychain.feature
@@ -77,11 +77,14 @@ Feature: IS-IS Hello authentication via an RFC 8177 key-chain
     And show command "show isis neighbor" in namespace "z2" should not contain "z1"
     # Forwarding over the now-unauthenticated link is broken: the
     # IS-IS-learned loopback is withdrawn and no longer reachable.
-    # Poll the main RIB (not just IS-IS's own table) so we know the RIB task
-    # has processed the withdrawal and the kernel FIB is already clean before
-    # the ping-should-fail check runs.  Under 20-way concurrent load the RIB
-    # task can lag IS-IS's own table update by tens of seconds.
-    And show command "show ip route" in namespace "z1" should eventually not contain "10.0.0.2"
+    # Assert at both layers, each polled, so a failure pinpoints where the
+    # withdrawal stalls under 20-way concurrent load: first IS-IS's own
+    # route table (SPF recompute after the adjacency drops), then the main
+    # RIB (the route the RIB task installs into the kernel FIB). Only once
+    # the RIB no longer carries the route is the FIB guaranteed clean for
+    # the ping-should-fail check.
+    And show command "show isis route" in namespace "z1" should eventually not contain "10.0.0.2/32"
+    And show command "show ip route" in namespace "z1" should eventually not contain "10.0.0.2/32"
     And ping from "z1" to "10.0.0.2" should fail
     # The link itself is fine -- the directly-connected address still
     # answers, proving it's the adjacency (not the wire) that went away.

--- a/bdd/tests/features/isis_hello_auth_keychain.feature
+++ b/bdd/tests/features/isis_hello_auth_keychain.feature
@@ -77,7 +77,11 @@ Feature: IS-IS Hello authentication via an RFC 8177 key-chain
     And show command "show isis neighbor" in namespace "z2" should not contain "z1"
     # Forwarding over the now-unauthenticated link is broken: the
     # IS-IS-learned loopback is withdrawn and no longer reachable.
-    And show command "show isis route" in namespace "z1" should not contain "10.0.0.2/32"
+    # Poll the main RIB (not just IS-IS's own table) so we know the RIB task
+    # has processed the withdrawal and the kernel FIB is already clean before
+    # the ping-should-fail check runs.  Under 20-way concurrent load the RIB
+    # task can lag IS-IS's own table update by tens of seconds.
+    And show command "show ip route" in namespace "z1" should eventually not contain "10.0.0.2"
     And ping from "z1" to "10.0.0.2" should fail
     # The link itself is fine -- the directly-connected address still
     # answers, proving it's the adjacency (not the wire) that went away.


### PR DESCRIPTION
## Summary

- `show isis route` is IS-IS's own route table, updated *before* the `Ipv4Del` message is even sent to the RIB task
- Under 20-way concurrent load the RIB task in the `isis_hello_auth_keychain` namespace can lag that update by 30+ seconds, so the kernel FIB still has the route when `ping should fail` runs
- Add `should eventually not contain` step (polls up to 60×1s) and switch the teardown check to `show ip route` (main RIB) — the main RIB is updated only *after* `fib.route_ipv4_del().await` completes, so when this check passes the kernel FIB is already clean

## Test plan

- [ ] `make isis_hello_auth_keychain` passes individually
- [ ] `cargo test --test cucumber -- --concurrency=20 --tags "@isis"` passes with all 12 features green

Generated with [Claude Code](https://claude.com/claude-code)