### PR TITLE
isis,ospf: always withdraw a prefix even when cached nexthops are empty

### DIFF
--- a/zebra-rs/src/isis/rib.rs
+++ b/zebra-rs/src/isis/rib.rs
@@ -635,19 +635,31 @@ pub fn diff_apply<F: IsisRibFamily>(
     diff: &DiffResult<'_, F>,
     level: Level,
 ) {
+    // Mirrors `diff_apply_flex_algo`: a prefix that left the table, or
+    // changed to a route with no forwarding plane, must always be
+    // withdrawn. `rib_del` is keyed on RibType, so it is a harmless
+    // no-op when nothing is installed — but skipping it leaks a
+    // previously-installed route whose nexthops were later cleared.
+    // (An earlier V4 builder could cache empty-nexthop entries; guarding
+    // the delete on `!nhops.is_empty()` then dropped their withdrawal and
+    // orphaned the kernel FIB route.)
     for (prefix, route) in diff.only_curr.iter() {
-        if !route.nhops.is_empty() {
-            let entry = make_rib_entry::<F>(route, level);
-            rib_client.send(F::rib_del(*prefix, entry)).unwrap();
-        }
+        let entry = make_rib_entry::<F>(route, level);
+        rib_client.send(F::rib_del(*prefix, entry)).unwrap();
     }
     for (prefix, _, route) in diff.different.iter() {
-        if !route.nhops.is_empty() {
-            let entry = make_rib_entry::<F>(route, level);
+        let entry = make_rib_entry::<F>(route, level);
+        if route.nhops.is_empty() {
+            // Lost all nexthops: collapse the change to a withdrawal so
+            // the stale install is removed rather than left behind.
+            rib_client.send(F::rib_del(*prefix, entry)).unwrap();
+        } else {
             rib_client.send(F::rib_add(*prefix, entry)).unwrap();
         }
     }
     for (prefix, route) in diff.only_next.iter() {
+        // A brand-new prefix with no nexthops has nothing to install and
+        // no prior FIB state to withdraw, so it is simply skipped.
         if !route.nhops.is_empty() {
             let entry = make_rib_entry::<F>(route, level);
             rib_client.send(F::rib_add(*prefix, entry)).unwrap();
@@ -1997,6 +2009,71 @@ mod tests {
         };
         let entry = make_rib_entry(&route, Level::L2);
         assert!(matches!(entry.nexthop, rib::Nexthop::Uni(_)));
+    }
+
+    // Collect the prefixes `diff_apply` withdraws (Ipv4Del) and installs
+    // (Ipv4Add) when fed `curr`→`next`, so the empty-nexthop tests can
+    // assert on the exact messages without a live RIB task.
+    fn run_diff_apply(
+        curr: &PrefixMap<Ipv4Net, SpfRoute<V4>>,
+        next: &PrefixMap<Ipv4Net, SpfRoute<V4>>,
+    ) -> (Vec<Ipv4Net>, Vec<Ipv4Net>) {
+        use crate::rib::client::{ProtoId, RibClient};
+
+        let diff = spf::table_diff(curr.iter(), next.iter());
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let client = RibClient::new(tx, ProtoId::from_raw(1));
+        diff_apply::<V4>(&client, &diff, Level::L1);
+        drop(client); // close the channel so the drain terminates
+
+        let (mut dels, mut adds) = (vec![], vec![]);
+        while let Ok(env) = rx.try_recv() {
+            match env.msg {
+                crate::rib::Message::Ipv4Del { prefix, .. } => dels.push(prefix),
+                crate::rib::Message::Ipv4Add { prefix, .. } => adds.push(prefix),
+                _ => panic!("unexpected message variant"),
+            }
+        }
+        (dels, adds)
+    }
+
+    #[test]
+    fn diff_apply_withdraws_empty_nexthop_route() {
+        // A cached route whose nexthops were cleared still has to be
+        // withdrawn when the prefix leaves the table. Guarding the delete
+        // on `!nhops.is_empty()` once leaked the kernel FIB route here.
+        let prefix: Ipv4Net = "10.0.0.2/32".parse().unwrap();
+        let mut curr = PrefixMap::new();
+        curr.insert(prefix, spf_route(10, None, &[])); // empty nexthops
+        let next = PrefixMap::new();
+
+        let (dels, adds) = run_diff_apply(&curr, &next);
+        assert_eq!(
+            dels,
+            vec![prefix],
+            "withdrawal must fire for empty-nhop route"
+        );
+        assert!(adds.is_empty());
+    }
+
+    #[test]
+    fn diff_apply_collapses_emptied_route_to_del() {
+        // A route that changes to a no-nexthop state (in both tables, so
+        // it lands in `different`) must collapse to a withdrawal, not be
+        // skipped — otherwise the prior install lingers in the FIB.
+        let prefix: Ipv4Net = "10.0.0.2/32".parse().unwrap();
+        let mut curr = PrefixMap::new();
+        curr.insert(prefix, spf_route(10, None, &[("10.0.1.2", 2)])); // had a nexthop
+        let mut next = PrefixMap::new();
+        next.insert(prefix, spf_route(20, None, &[])); // now empty -> "different"
+
+        let (dels, adds) = run_diff_apply(&curr, &next);
+        assert_eq!(
+            dels,
+            vec![prefix],
+            "emptied route must collapse to a delete"
+        );
+        assert!(adds.is_empty(), "must not re-add a nexthop-less route");
     }
 
     #[test]

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -10297,7 +10297,7 @@ fn apply_routing_updates_v3(
 
     let diff = spf::table_diff(top.rib6.iter(), new_rib.iter());
 
-    // Withdrawals.
+    // Withdrawals: always fire, even for an empty-nexthop cached route.
     for (prefix, route) in diff.only_curr.iter() {
         let entry = make_rib6_entry(route);
         let _ = top.ctx.rib.send(rib::Message::Ipv6Del {
@@ -10305,21 +10305,31 @@ fn apply_routing_updates_v3(
             rib: entry,
         });
     }
-    // Changed.
+    // Changed: a route that lost all nexthops collapses to a withdrawal.
     for (prefix, _, route) in diff.different.iter() {
         let entry = make_rib6_entry(route);
-        let _ = top.ctx.rib.send(rib::Message::Ipv6Add {
-            prefix: *prefix,
-            rib: entry,
-        });
+        let msg = if route.nhops.is_empty() {
+            rib::Message::Ipv6Del {
+                prefix: *prefix,
+                rib: entry,
+            }
+        } else {
+            rib::Message::Ipv6Add {
+                prefix: *prefix,
+                rib: entry,
+            }
+        };
+        let _ = top.ctx.rib.send(msg);
     }
-    // New.
+    // New: nothing to install without nexthops.
     for (prefix, route) in diff.only_next.iter() {
-        let entry = make_rib6_entry(route);
-        let _ = top.ctx.rib.send(rib::Message::Ipv6Add {
-            prefix: *prefix,
-            rib: entry,
-        });
+        if !route.nhops.is_empty() {
+            let entry = make_rib6_entry(route);
+            let _ = top.ctx.rib.send(rib::Message::Ipv6Add {
+                prefix: *prefix,
+                rib: entry,
+            });
+        }
     }
 
     top.rib6 = new_rib;
@@ -10713,29 +10723,39 @@ fn build_rib_nexthop(nhops: Vec<rib::NexthopUni>) -> rib::Nexthop {
 }
 
 pub fn diff_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffResult) {
-    // Delete.
+    // Withdraw any prefix that left the table, unconditionally. `Ipv4Del`
+    // is keyed on RibType, so it is a harmless no-op when nothing is
+    // installed — but guarding it on `!nhops.is_empty()` would leak a
+    // previously-installed FIB route whose nexthops were later cleared.
+    // `build_rib_from_spf` already skips empty-nexthop destinations, so
+    // this is defense-in-depth; it mirrors the IS-IS `diff_apply` fix.
     for (prefix, route) in diff.only_curr.iter() {
-        if !route.nhops.is_empty() {
-            let rib = make_rib_entry(route);
-            let msg = rib::Message::Ipv4Del {
-                prefix: *prefix,
-                rib,
-            };
-            rib_client.send(msg).unwrap();
-        }
+        let rib = make_rib_entry(route);
+        let msg = rib::Message::Ipv4Del {
+            prefix: *prefix,
+            rib,
+        };
+        rib_client.send(msg).unwrap();
     }
-    // Add (changed).
+    // Changed: a route that lost all nexthops collapses to a withdrawal
+    // rather than being skipped (which would orphan the prior install).
     for (prefix, _, route) in diff.different.iter() {
-        if !route.nhops.is_empty() {
-            let rib = make_rib_entry(route);
-            let msg = rib::Message::Ipv4Add {
+        let rib = make_rib_entry(route);
+        let msg = if route.nhops.is_empty() {
+            rib::Message::Ipv4Del {
                 prefix: *prefix,
                 rib,
-            };
-            rib_client.send(msg).unwrap();
-        }
+            }
+        } else {
+            rib::Message::Ipv4Add {
+                prefix: *prefix,
+                rib,
+            }
+        };
+        rib_client.send(msg).unwrap();
     }
-    // Add (new).
+    // New: a brand-new nexthop-less prefix has nothing to install and no
+    // prior FIB state to withdraw, so it is simply skipped.
     for (prefix, route) in diff.only_next.iter() {
         if !route.nhops.is_empty() {
             let rib = make_rib_entry(route);
@@ -10788,23 +10808,29 @@ fn make_ilm_entry(label: u32, ilm: &SpfIlm) -> IlmEntry {
 }
 
 pub fn diff_ilm_apply(rib_client: &crate::rib::client::RibClient, diff: &DiffIlmResult) {
+    // Always withdraw a label that left the table (keyed on the incoming
+    // label, so the IlmDel is a no-op when nothing is installed). See
+    // `diff_apply` for the empty-nexthop rationale.
     for (label, ilm) in diff.only_curr.iter() {
-        if !ilm.nhops.is_empty() {
-            let msg = rib::Message::IlmDel {
-                label: *label,
-                ilm: make_ilm_entry(*label, ilm),
-            };
-            rib_client.send(msg).unwrap();
-        }
+        let msg = rib::Message::IlmDel {
+            label: *label,
+            ilm: make_ilm_entry(*label, ilm),
+        };
+        rib_client.send(msg).unwrap();
     }
     for (label, _, ilm) in diff.different.iter() {
-        if !ilm.nhops.is_empty() {
-            let msg = rib::Message::IlmAdd {
+        let msg = if ilm.nhops.is_empty() {
+            rib::Message::IlmDel {
                 label: *label,
                 ilm: make_ilm_entry(*label, ilm),
-            };
-            rib_client.send(msg).unwrap();
-        }
+            }
+        } else {
+            rib::Message::IlmAdd {
+                label: *label,
+                ilm: make_ilm_entry(*label, ilm),
+            }
+        };
+        rib_client.send(msg).unwrap();
     }
     for (label, ilm) in diff.only_next.iter() {
         if !ilm.nhops.is_empty() {
@@ -10890,23 +10916,29 @@ fn make_ilm_entry_v6(label: u32, ilm: &SpfIlmV3) -> IlmEntry {
 }
 
 pub fn diff_ilm_apply_v6(rib_client: &crate::rib::client::RibClient, diff: &DiffIlmResultV3) {
+    // Always withdraw a label that left the table (keyed on the incoming
+    // label, so the IlmDel is a no-op when nothing is installed). See
+    // `diff_apply` for the empty-nexthop rationale.
     for (label, ilm) in diff.only_curr.iter() {
-        if !ilm.nhops.is_empty() {
-            let msg = rib::Message::IlmDel {
-                label: *label,
-                ilm: make_ilm_entry_v6(*label, ilm),
-            };
-            rib_client.send(msg).unwrap();
-        }
+        let msg = rib::Message::IlmDel {
+            label: *label,
+            ilm: make_ilm_entry_v6(*label, ilm),
+        };
+        rib_client.send(msg).unwrap();
     }
     for (label, _, ilm) in diff.different.iter() {
-        if !ilm.nhops.is_empty() {
-            let msg = rib::Message::IlmAdd {
+        let msg = if ilm.nhops.is_empty() {
+            rib::Message::IlmDel {
                 label: *label,
                 ilm: make_ilm_entry_v6(*label, ilm),
-            };
-            rib_client.send(msg).unwrap();
-        }
+            }
+        } else {
+            rib::Message::IlmAdd {
+                label: *label,
+                ilm: make_ilm_entry_v6(*label, ilm),
+            }
+        };
+        rib_client.send(msg).unwrap();
     }
     for (label, ilm) in diff.only_next.iter() {
         if !ilm.nhops.is_empty() {
@@ -11500,5 +11532,95 @@ mod multi_area_tests {
         rib_insert(&mut rib, p, route(20, RouteType::InterArea));
         rib_insert(&mut rib, p, route(40, RouteType::InterArea));
         assert_eq!(rib.get(&p).unwrap().metric, 20);
+    }
+}
+
+#[cfg(test)]
+mod diff_apply_tests {
+    use super::{RouteType, SpfNexthop, SpfRoute, diff_apply};
+    use crate::rib::client::{ProtoId, RibClient};
+    use crate::spf;
+    use ipnet::Ipv4Net;
+    use prefix_trie::PrefixMap;
+    use std::collections::BTreeMap;
+    use std::net::Ipv4Addr;
+
+    fn spf_route(metric: u32, nhops: &[(&str, u32)]) -> SpfRoute {
+        let mut nh = BTreeMap::new();
+        for (addr, ifindex) in nhops {
+            nh.insert(
+                addr.parse::<Ipv4Addr>().unwrap(),
+                SpfNexthop {
+                    ifindex: *ifindex,
+                    adjacency: false,
+                    router_id: None,
+                    backup: None,
+                },
+            );
+        }
+        SpfRoute {
+            metric,
+            path_type: RouteType::IntraArea,
+            nhops: nh,
+            sid: None,
+            prefix_sid: None,
+            dest_vertex: None,
+            backup_as_primary: false,
+        }
+    }
+
+    // Returns (withdrawn prefixes, installed prefixes) emitted by
+    // `diff_apply` for `curr`→`next`, captured off an in-memory channel
+    // so no live RIB task is needed.
+    fn run_diff_apply(
+        curr: &PrefixMap<Ipv4Net, SpfRoute>,
+        next: &PrefixMap<Ipv4Net, SpfRoute>,
+    ) -> (Vec<Ipv4Net>, Vec<Ipv4Net>) {
+        let diff = spf::table_diff(curr.iter(), next.iter());
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let client = RibClient::new(tx, ProtoId::from_raw(1));
+        diff_apply(&client, &diff);
+        drop(client);
+
+        let (mut dels, mut adds) = (vec![], vec![]);
+        while let Ok(env) = rx.try_recv() {
+            match env.msg {
+                crate::rib::Message::Ipv4Del { prefix, .. } => dels.push(prefix),
+                crate::rib::Message::Ipv4Add { prefix, .. } => adds.push(prefix),
+                _ => panic!("unexpected message variant"),
+            }
+        }
+        (dels, adds)
+    }
+
+    #[test]
+    fn diff_apply_withdraws_empty_nexthop_route() {
+        // A cached route with no nexthops must still be withdrawn when its
+        // prefix leaves the table — guarding the delete on `!nhops.is_empty()`
+        // would leak the kernel FIB route (the IS-IS keychain leak class).
+        let prefix: Ipv4Net = "10.0.0.2/32".parse().unwrap();
+        let mut curr = PrefixMap::new();
+        curr.insert(prefix, spf_route(10, &[]));
+        let next = PrefixMap::new();
+
+        let (dels, adds) = run_diff_apply(&curr, &next);
+        assert_eq!(dels, vec![prefix]);
+        assert!(adds.is_empty());
+    }
+
+    #[test]
+    fn diff_apply_collapses_emptied_route_to_del() {
+        // A route that changes to a no-nexthop state (present in both
+        // tables, so it lands in `different`) must collapse to a delete,
+        // not be skipped and leave the stale install behind.
+        let prefix: Ipv4Net = "10.0.0.2/32".parse().unwrap();
+        let mut curr = PrefixMap::new();
+        curr.insert(prefix, spf_route(10, &[("10.0.1.2", 2)]));
+        let mut next = PrefixMap::new();
+        next.insert(prefix, spf_route(20, &[]));
+
+        let (dels, adds) = run_diff_apply(&curr, &next);
+        assert_eq!(dels, vec![prefix]);
+        assert!(adds.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Hardens the IS-IS **and** OSPF SPF→RIB withdrawal paths against the empty-nexthop case — the latent half of the keychain-teardown route leak diagnosed this week. Every RIB diff helper guarded its `only_curr` (withdrawal) branch on `!nhops.is_empty()`, so a route whose nexthops were cleared before it left the table never emitted its delete, leaking the kernel FIB route.

Canonical pattern, mirroring the already-correct `diff_apply_flex_algo`:
- **only_curr** → always delete (keyed on RibType / incoming label, so it's a harmless no-op when nothing is installed).
- **different** → collapse to a delete when the new route lost all nexthops, instead of skipping and leaving the stale install behind.
- **only_next** → skip; a brand-new nexthop-less prefix has nothing to install and no prior FIB state to withdraw.

### IS-IS (`isis/rib.rs`)
- `diff_apply` (generic over `IsisRibFamily`, so V4 + V6).
- This was the **active** half: the old V4 `build_rib_from_spf` cached empty-nexthop entries (fixed in `99f92a7a`); this closes the consuming side so the class can't recur.

### OSPF (`ospf/inst.rs`)
- `diff_apply` (v2 routes), `diff_ilm_apply` (v2 SR-MPLS), `diff_ilm_apply_v6` (v3 SR-MPLS); `apply_routing_updates_v3` (v3 routes) already withdrew unconditionally and is aligned for consistency.
- For OSPF this is **defense-in-depth**: the builders never produce an empty-nexthop-*map* route (each destination either `continue`s on empty nexthops — sites 8544/8907/9028/9171/9262/9811/10048 — or stamps a directly-attached `UNSPECIFIED` nexthop for self/DR stubs). So no active leak today, but the guard is the same footgun.

### Add case (asked during review)
All OSPF route/ILM **add** paths skip empty-nexthop entries too: `only_next` keeps the `!nhops.is_empty()` guard, `different` collapses an emptied route to a delete, and the builders never emit empty-map routes. So an empty-nexthop route is never installed.

## Test plan

- [x] New unit tests in `isis::rib` and `ospf::inst` for empty-nhop withdrawal + `different`→delete collapse.
- [x] `cargo test -p zebra-rs --bin zebra-rs diff_apply` — 8 passed.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)