### PR TITLE
gitignore: ignore bdd typescript log artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ ref/
 allure-report/
 allure-results/
 .allure/
+typescript


### PR DESCRIPTION
## Summary
The bdd test runner emits a `typescript` file in the working tree. This adds it to `.gitignore` so it never gets accidentally committed.

## Test plan
- `.gitignore`-only change; no code paths affected.
- CI (fmt/clippy/test) should pass unchanged.

Generated with [Claude Code](https://claude.com/claude-code)