### PR TITLE
ospf: fix OSPFv2/v3 adjacency formation (router-id, interface-up, DB exchange)

### DIFF
--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -270,9 +270,18 @@ pub(super) fn apply_link_enable_transition<V: OspfVersion>(
     }
 }
 
-fn config_ospf_router_id(_ospf: &mut Ospf, mut args: Args, _op: ConfigOp) -> Option<()> {
-    let _router_id = args.v4addr()?;
-    None
+fn config_ospf_router_id(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
+    let router_id = args.v4addr()?;
+    if op.is_set() {
+        // Apply the configured Router-ID to the instance, push it into
+        // every interface's `ident`, and re-originate. Previously this
+        // callback parsed the value and dropped it, so every OSPFv2
+        // instance kept the constructor default (10.0.0.1) — making all
+        // routers share one Router-ID, so each treated every neighbour's
+        // Hello as self-originated and no adjacency ever formed.
+        ospf.router_id_update(router_id);
+    }
+    Some(())
 }
 
 /// After mutating `ospf.areas[area_id].area_type`, push the new

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -38,6 +38,7 @@ impl Ospf<Ospfv3> {
     pub fn callback_build(&mut self) {
         let prefix = OSPFV3;
         let entries: &[(&str, Callback<Ospfv3>)] = &[
+            ("/router-id", config_ospfv3_router_id),
             ("/area/area-type", config_ospfv3_area_type),
             ("/area/no-summary", config_ospfv3_area_no_summary),
             (
@@ -206,6 +207,19 @@ fn config_ospfv3_area_type(ospf: &mut Ospf<Ospfv3>, mut args: Args, op: ConfigOp
     // we are an ABR with translator-role = Always or are the
     // Candidate-elected winner).
     ospf.nssa_translate_resync(area_id);
+    Some(())
+}
+
+/// `router ospfv3 { router-id ... }`. Mirrors v2's
+/// `config_ospf_router_id`: apply the configured Router-ID to the
+/// instance (and every interface's `ident`) and re-originate.
+/// Previously OSPFv3 had no per-instance Router-ID callback at all,
+/// so every v3 instance kept the constructor default 10.0.0.1.
+fn config_ospfv3_router_id(ospf: &mut Ospf<Ospfv3>, mut args: Args, op: ConfigOp) -> Option<()> {
+    let router_id = args.v4addr()?;
+    if op.is_set() {
+        ospf.router_id_update(router_id);
+    }
     Some(())
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -4249,7 +4249,7 @@ impl Ospf<Ospfv2> {
         }
     }
 
-    fn router_id_update(&mut self, router_id: Ipv4Addr) {
+    pub(super) fn router_id_update(&mut self, router_id: Ipv4Addr) {
         self.router_id = router_id;
         for (_, link) in self.links.iter_mut() {
             link.ident.router_id = router_id;
@@ -4265,9 +4265,23 @@ impl Ospf<Ospfv2> {
         let IpNet::V4(prefix) = &addr.addr else {
             return;
         };
-        let addr = OspfAddr::from(&addr, prefix);
-        link.addr.push(addr.clone());
+        let ospf_addr = OspfAddr::from(&addr, prefix);
+        link.addr.push(ospf_addr);
         link.ident.prefix = *prefix;
+
+        // If this address made an enabled-but-Down interface usable,
+        // re-fire `InterfaceUp` so the FSM can progress past the
+        // empty-`addr` short-circuit in `ospf_ifsm_interface_up`.
+        // OSPF-enable can be processed before the interface address
+        // has propagated from netlink (config commit applies both at
+        // once); without this re-fire a transit interface stays Down
+        // forever — no Hellos, no multicast join, no adjacency. v3's
+        // `addr_add` already did this; v2 was missing it.
+        if link.enabled && link.state == IfsmState::Down {
+            let _ = self
+                .tx
+                .send(Message::Ifsm(addr.ifindex, IfsmEvent::InterfaceUp));
+        }
     }
 
     fn addr_del(&mut self, addr: LinkAddr) {
@@ -5058,6 +5072,19 @@ impl Ospf<Ospfv3> {
                 .tx
                 .send(Message::Ifsm(addr.ifindex, IfsmEvent::InterfaceUp));
         }
+    }
+
+    /// Apply a configured Router-ID to this OSPFv3 instance. Mirror of
+    /// the v2 `router_id_update`; wired from `config_ospfv3_router_id`
+    /// so `router ospfv3 { router-id ... }` is honoured (previously
+    /// v3 had no per-instance Router-ID path at all and every instance
+    /// kept the constructor default 10.0.0.1).
+    pub(super) fn router_id_update(&mut self, router_id: Ipv4Addr) {
+        self.router_id = router_id;
+        for (_, link) in self.links.iter_mut() {
+            link.ident.router_id = router_id;
+        }
+        self.router_lsa_originate();
     }
 
     /// Remove an IPv6 address from the matching link's `addr` list

--- a/zebra-rs/src/ospf/packet.rs
+++ b/zebra-rs/src/ospf/packet.rs
@@ -506,6 +506,21 @@ pub fn ospf_db_desc_send(link: &mut OspfInterface, nbr: &mut Neighbor, oident: &
 
     ospf_packet_db_desc_set(nbr, &mut dd);
 
+    // RFC 2328 §10.8: the More (M) bit reflects whether further DD packets
+    // follow. `ospf_packet_db_desc_set` drains the entire DB summary into
+    // this one packet, so once `db_sum` is empty there is nothing more to
+    // send and M must be cleared — otherwise the master's
+    // `ExchangeDone` test (`!dd.flags.more() && !nbr.dd.flags.more()`) can
+    // never become true and the two routers exchange empty DD packets
+    // forever (stuck in Exchange). Only recompute outside the ExStart
+    // negotiation phase: while `init` is set the empty negotiation DD must
+    // keep M set per §10.8.
+    if !nbr.dd.flags.init() {
+        let more = !nbr.db_sum.is_empty();
+        nbr.dd.flags.set_more(more);
+        dd.flags.set_more(more);
+    }
+
     // RFC 2328 §10.8: remember the DD we sent so it can be retransmitted by
     // the master while waiting for the slave's response, or resent by the
     // slave when the master sends a duplicate.

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -537,6 +537,18 @@ pub fn ospfv3_db_desc_send(
 
     db_desc_pack(nbr, &mut dd);
 
+    // RFC 2328 §10.8 / RFC 5340 §4.2.2: the More (M) bit must be cleared
+    // once the whole DB summary has been drained, or `ExchangeDone` never
+    // fires and the neighbours exchange empty DD packets forever. Mirror
+    // of the v2 fix in `ospf_db_desc_send`; only recompute outside the
+    // ExStart negotiation phase (while `init` is set, the empty
+    // negotiation DD keeps M set).
+    if !nbr.dd.flags.init() {
+        let more = !nbr.db_sum.is_empty();
+        nbr.dd.flags.set_more(more);
+        dd.flags.set_more(more);
+    }
+
     // Remember the DD we sent so it can be retransmitted by the
     // master while waiting for the slave's response, or resent by
     // the slave when the master sends a duplicate. RFC 2328 §10.8 /


### PR DESCRIPTION
## Summary

Three pre-existing bugs prevented two zebra-rs OSPF routers from ever forming an adjacency (stuck at 0 neighbours / `Exchange`). They were masked because zebra↔FRR validation supplies a distinct Router-ID and drives the DB exchange, and **CI does not run the BDD suite** — so every OSPF BDD scenario (`ospf_clear_neighbor`, `ospfv2_multi_area`) had been failing unnoticed. Fixed symmetrically in OSPFv2 and OSPFv3.

1. **Router-ID config ignored.** `config_ospf_router_id` parsed the value and returned `None` without applying it (a long-standing stub); OSPFv3 had **no** `/router-id` callback at all. Every instance kept the constructor default `10.0.0.1`, so all routers shared one Router-ID and each dropped every neighbour's Hello as self-originated (`packet.router_id == self.router_id`). Both callbacks now call `router_id_update` (added a v3 `router_id_update`).
2. **Interface stuck Down.** v2 `addr_add` didn't re-fire `InterfaceUp` when an address arrived on an enabled interface, so a transit interface whose OSPF-enable raced ahead of address propagation stayed Down forever (no Hello timer, no AllSPFRouters join) — `ospf_ifsm_interface_up` short-circuits on `link.addr.is_empty()`. v3 already had the re-fire; ported to v2.
3. **DB exchange never completes.** `ospf_db_desc_send` / `ospfv3_db_desc_send` never cleared the More (M) bit after draining the DB summary, so the master's `ExchangeDone` test never became true and neighbours exchanged empty DD packets forever. Clear M once the summary is empty, outside the ExStart negotiation (`init`) phase.

## Test plan

- [x] `ospf_clear_neighbor` BDD scenario now reaches **Full** (verified locally).
- [ ] `ospfv2_multi_area` + `ospfv2_as_external` BDD scenarios (run locally; CI excludes BDD).
- [x] `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test -p zebra-rs ospf` (66) + `yang_load` (2) pass.

The OSPFv3 half is by-inspection consistency (identical structure to the validated v2 fix) — there is no OSPFv3 BDD test in the suite to exercise it.

Generated with [Claude Code](https://claude.com/claude-code)