### PR TITLE
bdd: OSPFv3 two-router adjacency scenario

### DIFF
--- a/bdd/tests/configs/ospfv3_adjacency/o1.yaml
+++ b/bdd/tests/configs/ospfv3_adjacency/o1.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: eth1
+  ipv6:
+    address: 2001:db8:12::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: eth1
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_adjacency/o2.yaml
+++ b/bdd/tests/configs/ospfv3_adjacency/o2.yaml
@@ -1,0 +1,18 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: eth2
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: eth2
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv3_adjacency.feature
+++ b/bdd/tests/features/ospfv3_adjacency.feature
@@ -1,0 +1,54 @@
+@serial
+@ospfv3_adjacency
+Feature: OSPFv3 two-router adjacency forms over a point-to-point link
+  As a network operator
+  I want two zebra-rs OSPFv3 routers joined by a point-to-point link to
+  progress all the way to Full and synchronise their databases, so the
+  OSPFv3 control plane is exercised router-to-router (not only against
+  an external implementation).
+
+  This is the v3 counterpart of `ospf_clear_neighbor` and guards the
+  OSPFv3 half of the adjacency-formation fixes (Router-ID config applied
+  per instance, `addr_add` re-firing InterfaceUp, and the DB-exchange
+  More-bit being cleared). Without those, two zebra-rs v3 routers share
+  the default Router-ID 10.0.0.1 and/or stall in Exchange and never reach
+  Full — a regression invisible to zebra-rs<->FRR validation and to CI
+  (which does not run the BDD suite).
+
+  Reaching Full in BOTH directions is the proof: it requires the master
+  (higher Router-ID, o2) and the slave (o1) to complete ExStart ->
+  Exchange -> Loading -> Full, which only happens when all three fixes
+  hold.
+
+  Test Topology:
+  ```
+    o1 (router-id 10.0.0.1) --- 2001:db8:12::/64 --- o2 (router-id 10.0.0.2)
+       eth1   point-to-point, area 0.0.0.0   eth2
+    loopbacks: 2001:db8::1/128 (o1)         2001:db8::2/128 (o2)
+  ```
+
+  Scenario: Two OSPFv3 routers reach Full over a point-to-point link
+    Given a clean test environment
+    When I create namespace "o1"
+    And I create namespace "o2"
+    And I connect namespace "o1" interface "eth1" to namespace "o2" interface "eth2"
+    And I start zebra-rs in namespace "o1"
+    And I start zebra-rs in namespace "o2"
+    And I apply config "o1.yaml" to namespace "o1"
+    And I apply config "o2.yaml" to namespace "o2"
+    # First Hello (<=10s) + DBD/LS exchange settles well inside this.
+    And I wait 30 seconds
+
+    # o1 (slave) sees o2 (master) Full.
+    Then show command "show ipv6 ospf neighbor" in namespace "o1" should contain "10.0.0.2"
+    And show command "show ipv6 ospf neighbor" in namespace "o1" should contain "Full"
+    # o2 (master) sees o1 (slave) Full — both ends complete the exchange.
+    And show command "show ipv6 ospf neighbor" in namespace "o2" should contain "10.0.0.1"
+    And show command "show ipv6 ospf neighbor" in namespace "o2" should contain "Full"
+
+    # Teardown.
+    When I stop zebra-rs in namespace "o1"
+    And I stop zebra-rs in namespace "o2"
+    And I delete namespace "o1"
+    And I delete namespace "o2"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

Adds the first router-to-router OSPFv3 BDD coverage — an OSPFv3 counterpart to `ospf_clear_neighbor`. Two zebra-rs routers (o1/o2) on one point-to-point link in area 0.0.0.0, IPv6-addressed, must reach **Full in both directions** (`show ipv6 ospf neighbor` shows the peer Router-ID + `Full` on each side).

Reaching Full both ways requires the master (o2) and slave (o1) to complete ExStart → Exchange → Loading → Full, which only holds with all three OSPFv3 adjacency fixes from #1240 (per-instance Router-ID applied via config, `addr_add` re-firing `InterfaceUp`, DB-exchange More-bit cleared). Those were previously exercised only against FRR, which masks the bugs because FRR supplies a distinct Router-ID and drives the exchange.

- `bdd/tests/features/ospfv3_adjacency.feature` (tag `@ospfv3_adjacency`)
- `bdd/tests/configs/ospfv3_adjacency/{o1,o2}.yaml`

Uses existing step definitions only — no `cucumber.rs` change.

## Test plan

- [x] `@ospfv3_adjacency` BDD scenario passes locally against the fixed daemon (both neighbors reach Full).
- [x] Feature tag does not prefix (or get prefixed by) any other tag — parallel-safe sweep invariant.
- [x] No Rust changes; `cargo fmt`/clippy/test unaffected (CI does not run the BDD suite).

Generated with [Claude Code](https://claude.com/claude-code)