### PR TITLE
flex-algo: store every value of affinity/srlg leaf-lists, not just the first

### DIFF
--- a/zebra-rs/src/flex_algo/config.rs
+++ b/zebra-rs/src/flex_algo/config.rs
@@ -145,7 +145,6 @@ fn config_builder(prefix: &str) -> ConfigBuilder {
     const BOOL_ERR: &str = "flex-algo boolean arg parse error";
     const U8_ERR: &str = "flex-algo u8 arg parse error";
     const ENUM_ERR: &str = "flex-algo enum arg parse error";
-    const NAME_ERR: &str = "flex-algo name arg parse error";
 
     ConfigBuilder::default()
         .path(prefix)
@@ -242,54 +241,65 @@ fn config_builder(prefix: &str) -> ConfigBuilder {
         })
         .path(&format!("{prefix}/affinity/include-any"))
         .set(|config, cache, algo, args| {
+            // A YANG leaf-list delivers every value in a single args
+            // deque (see `path_from_command`), so drain it rather than
+            // reading just the first element.
             let e = cache_get(config, cache, algo).context(CONFIG_ERR)?;
-            let name = args.string().context(NAME_ERR)?;
-            e.include_any.insert(name);
+            while let Some(name) = args.string() {
+                e.include_any.insert(name);
+            }
             Ok(())
         })
         .del(|config, cache, algo, args| {
             let e = cache_lookup(config, cache, algo).context(CONFIG_ERR)?;
-            let name = args.string().context(NAME_ERR)?;
-            e.include_any.remove(&name);
+            while let Some(name) = args.string() {
+                e.include_any.remove(&name);
+            }
             Ok(())
         })
         .path(&format!("{prefix}/affinity/include-all"))
         .set(|config, cache, algo, args| {
             let e = cache_get(config, cache, algo).context(CONFIG_ERR)?;
-            let name = args.string().context(NAME_ERR)?;
-            e.include_all.insert(name);
+            while let Some(name) = args.string() {
+                e.include_all.insert(name);
+            }
             Ok(())
         })
         .del(|config, cache, algo, args| {
             let e = cache_lookup(config, cache, algo).context(CONFIG_ERR)?;
-            let name = args.string().context(NAME_ERR)?;
-            e.include_all.remove(&name);
+            while let Some(name) = args.string() {
+                e.include_all.remove(&name);
+            }
             Ok(())
         })
         .path(&format!("{prefix}/affinity/exclude-any"))
         .set(|config, cache, algo, args| {
             let e = cache_get(config, cache, algo).context(CONFIG_ERR)?;
-            let name = args.string().context(NAME_ERR)?;
-            e.exclude_any.insert(name);
+            while let Some(name) = args.string() {
+                e.exclude_any.insert(name);
+            }
             Ok(())
         })
         .del(|config, cache, algo, args| {
             let e = cache_lookup(config, cache, algo).context(CONFIG_ERR)?;
-            let name = args.string().context(NAME_ERR)?;
-            e.exclude_any.remove(&name);
+            while let Some(name) = args.string() {
+                e.exclude_any.remove(&name);
+            }
             Ok(())
         })
         .path(&format!("{prefix}/srlg-exclude"))
         .set(|config, cache, algo, args| {
             let e = cache_get(config, cache, algo).context(CONFIG_ERR)?;
-            let name = args.string().context(NAME_ERR)?;
-            e.srlg_exclude.insert(name);
+            while let Some(name) = args.string() {
+                e.srlg_exclude.insert(name);
+            }
             Ok(())
         })
         .del(|config, cache, algo, args| {
             let e = cache_lookup(config, cache, algo).context(CONFIG_ERR)?;
-            let name = args.string().context(NAME_ERR)?;
-            e.srlg_exclude.remove(&name);
+            while let Some(name) = args.string() {
+                e.srlg_exclude.remove(&name);
+            }
             Ok(())
         })
         .path(&format!("{prefix}/fast-reroute/ti-lfa"))
@@ -371,6 +381,28 @@ mod tests {
         assert_eq!(e.exclude_any.len(), 2);
         assert!(e.exclude_any.contains("blue"));
         assert!(e.exclude_any.contains("red"));
+    }
+
+    // Regression for the real dispatch shape: a YANG leaf-list arrives
+    // as ONE exec call with every value in the args deque (not one call
+    // per element). All values must be stored — reading just the first
+    // dropped every constraint past the first, silently breaking the
+    // flex-algo SPF affinity prune (e.g. `exclude-any [eu, transatlantic]`
+    // stored only `eu`).
+    #[test]
+    fn affinity_exclude_any_keeps_all_values_from_one_leaf_list_call() {
+        let mut fa = FlexAlgoConfig::new(P);
+        fa.exec(
+            format!("{P}/affinity/exclude-any"),
+            args(&["128", "eu", "transatlantic"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        fa.commit();
+        let e = fa.config.get(&128).unwrap();
+        assert_eq!(e.exclude_any.len(), 2);
+        assert!(e.exclude_any.contains("eu"));
+        assert!(e.exclude_any.contains("transatlantic"));
     }
 
     #[test]

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -1182,13 +1182,15 @@ pub fn config_srlg(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> 
 // Extended Admin Group bitmap (RFC 7308) inside ASLA (RFC 9479).
 pub fn config_affinity(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     let ifname = args.string()?;
-    let name = args.string()?;
-
     let link = isis.links.get_mut_by_name(&ifname)?;
-    if op.is_set() {
-        link.config.affinity.insert(name);
-    } else {
-        link.config.affinity.remove(&name);
+    // `affinity` is a leaf-list: every color arrives in one args deque,
+    // so drain it rather than reading only the first.
+    while let Some(name) = args.string() {
+        if op.is_set() {
+            link.config.affinity.insert(name);
+        } else {
+            link.config.affinity.remove(&name);
+        }
     }
     Some(())
 }

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -664,13 +664,16 @@ fn config_ospf_interface_cost(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> 
 fn config_ospf_interface_affinity(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
     let _area_id = parse_area_id(&args.string()?)?;
     let name = args.string()?;
-    let affinity = args.string()?;
 
     let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
-    if op.is_set() {
-        link.config.affinity.insert(affinity);
-    } else {
-        link.config.affinity.remove(&affinity);
+    // `affinity` is a leaf-list: every color arrives in one args deque,
+    // so drain it rather than reading only the first.
+    while let Some(affinity) = args.string() {
+        if op.is_set() {
+            link.config.affinity.insert(affinity);
+        } else {
+            link.config.affinity.remove(&affinity);
+        }
     }
     Some(())
 }

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -557,13 +557,16 @@ fn config_ospfv3_interface_affinity(
 ) -> Option<()> {
     let _area_id = parse_area_id(&args.string()?)?;
     let name = args.string()?;
-    let affinity = args.string()?;
 
     let link = ospf_link_get_mut_by_name(&mut ospf.links, &name)?;
-    if op.is_set() {
-        link.config.affinity.insert(affinity);
-    } else {
-        link.config.affinity.remove(&affinity);
+    // `affinity` is a leaf-list: every color arrives in one args deque,
+    // so drain it rather than reading only the first.
+    while let Some(affinity) = args.string() {
+        if op.is_set() {
+            link.config.affinity.insert(affinity);
+        } else {
+            link.config.affinity.remove(&affinity);
+        }
     }
     Some(())
 }


### PR DESCRIPTION
## Problem

The `isis_flexalgo` BDD scenario failed on two `exclude-any` assertions:
- `show isis flex-algo` on `ch` rendered `exclude-any=eu` instead of `exclude-any=eu,transatlantic`.
- `show isis flex-algo route algorithm 128` on `se` leaked `10.0.0.4`/`10.0.0.5` (nodes reachable only over excluded `transatlantic` links).

## Root cause

A YANG **leaf-list** serializes to one config line with all values (`config/configs.rs::list_command`) and is dispatched as a **single** callback call with every value in the `args` deque (`config/paths.rs::path_from_command`). The flex-algo affinity/srlg handlers — and the per-interface `affinity` handlers — read only one value via a single `args.string()`, so a multi-element leaf-list kept only its **first** element.

So `exclude-any [eu, transatlantic]` stored only `{eu}`: the FAD SPF affinity prune was incomplete (excluded nodes leaked into the per-algo route table) and the show output rendered a single constraint. `algo 129` on `ln` still passed because excluding just the kept first element (`transatlantic`) already isolates the EU region.

Latent because most leaf-lists (incl. all interface affinity colors in existing tests) were single-valued, the unit test called `exec` once-per-value (masking the real one-call/many-values dispatch), and CI excludes bdd.

## Fix

Drain the `args` deque in every affected handler, matching the established convention (`rib/static`, `policy/*`):
- `flex_algo/config.rs`: `include-any` / `include-all` / `exclude-any` / `srlg-exclude` (set + del) — shared by **OSPF and IS-IS**
- `isis/link.rs`, `ospf/config.rs`, `ospf/config_v3.rs`: per-interface `affinity`

Adds a regression test exercising the real one-call/many-values dispatch (fails without the fix).

## Validation

- `cargo fmt --all` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test -p zebra-rs` → 901 passed (incl. new test)
- `isis_flexalgo` BDD scenario passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)