### PR TITLE
bfd: report live Echo transmit interval in show output

### DIFF
--- a/zebra-rs/src/bfd/session.rs
+++ b/zebra-rs/src/bfd/session.rs
@@ -389,6 +389,19 @@ impl Session {
         }
     }
 
+    /// The Echo transmit interval we actually originate at, or 0 when not
+    /// originating. Mirrors the rate computed in `echo_originate_reconcile`
+    /// (§6.8.9: never faster than the peer's advertised Required Min Echo RX),
+    /// gated on `echo_originating` so `show` reports the live state rather than
+    /// the configured-but-inert rate. Used by `show`.
+    pub fn echo_transmit_interval_us(&self) -> u32 {
+        if self.echo_originating {
+            self.echo_transmit_us.max(self.remote_min_echo_rx_us).max(1)
+        } else {
+            0
+        }
+    }
+
     /// Build an outgoing BFD control packet that reflects the
     /// session's current state. The Length field and `auth_present`
     /// flag are populated by the encoder.
@@ -909,6 +922,33 @@ mod tests {
                 "advertise for {mode:?}",
             );
         }
+    }
+
+    /// `echo_transmit_interval_us` (used by `show`) reports the live rate only
+    /// while `echo_originating`, and clamps up to the peer's floor per §6.8.9.
+    /// It must read 0 — `show` prints `disabled` — when we're not originating,
+    /// even with `echo_transmit_us` configured.
+    #[test]
+    fn echo_transmit_interval_reports_live_rate() {
+        let mut t = SessionTable::new();
+        let d = t.insert(
+            key(1, 2), // single-hop IPv4
+            SessionParams {
+                echo_mode: EchoMode::Both,
+                echo_transmit_us: 50_000,
+                ..SessionParams::default()
+            },
+        );
+        let s = t.get_by_disc_mut(d).unwrap();
+        // Configured but not yet originating: inert, reads 0.
+        assert_eq!(s.echo_transmit_interval_us(), 0);
+        // Originating: report our configured rate.
+        s.echo_originating = true;
+        s.remote_min_echo_rx_us = 25_000;
+        assert_eq!(s.echo_transmit_interval_us(), 50_000);
+        // Peer's advertised floor is higher: clamp up to it (§6.8.9).
+        s.remote_min_echo_rx_us = 100_000;
+        assert_eq!(s.echo_transmit_interval_us(), 100_000);
     }
 
     /// IPv6 single-hop sessions advertise Required Min Echo RX once the

--- a/zebra-rs/src/bfd/show.rs
+++ b/zebra-rs/src/bfd/show.rs
@@ -266,7 +266,7 @@ fn detail_json(key: &SessionKey, s: &Session) -> BfdPeerDetailJson {
         negotiated_transmit_interval_us: s.tx_interval_us(),
         detection_time_us: s.detection_time_us(),
         echo_receive_interval_us: s.advertised_echo_rx_us(),
-        echo_transmission_interval_us: 0,
+        echo_transmission_interval_us: s.echo_transmit_interval_us(),
         echo_transmit_active: s.echo_originating,
         echo_receive_active: s.advertised_echo_rx_us() > 0,
         remote_detect_multiplier: s.remote_detect_mult,
@@ -354,8 +354,11 @@ fn render_detail(buf: &mut String, key: &SessionKey, s: &Session) -> fmt::Result
         "            Echo receive interval: {}",
         echo_ms(s.advertised_echo_rx_us())
     )?;
-    // Responder-only: we loop a peer's Echo back but never originate it.
-    writeln!(buf, "            Echo transmission interval: disabled")?;
+    writeln!(
+        buf,
+        "            Echo transmission interval: {}",
+        echo_ms(s.echo_transmit_interval_us())
+    )?;
 
     writeln!(buf, "        Remote timers:")?;
     writeln!(


### PR DESCRIPTION
## Summary

`show bfd peers` detail output hardcoded `Echo transmission interval: disabled` with a stale "responder-only" comment, even though Echo origination was later added via the XDP offload helper. With `echo-mode transmit|both` and the gate in `echo_originate_reconcile` satisfied (session Up, single-hop, peer advertises a non-zero Required Min Echo RX), the daemon *does* originate Echo — but the text output always read `disabled`. The structured JSON path had the same hardcoded `0` for `echo_transmission_interval_us` (though `echo_transmit_active` was already correct).

This was visible in the field: with `echo-mode both` configured on both ends and the session Up, `show bfd peers` still reported `Echo transmission interval: disabled` in Local timers.

## Changes

- Add `Session::echo_transmit_interval_us()` — gated on `echo_originating` and clamped up to the peer's advertised floor per RFC 5880 §6.8.9, mirroring the rate computed in `echo_originate_reconcile`.
- Use it in both the human-readable text path and the structured JSON path in `show.rs`, replacing the hardcoded `disabled` / `0`. `echo_ms()` already maps `0 → "disabled"`, so the output now reads `disabled` only when we are genuinely not originating.

## Test plan

- `cargo test -p zebra-rs bfd` — 89 passed (includes new `echo_transmit_interval_reports_live_rate` covering not-originating → 0, originating → configured rate, and peer-floor clamp).
- `cargo fmt --all` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.

Generated with [Claude Code](https://claude.com/claude-code)