### PR TITLE
bfd: fix IPv6 Echo XDP reflector loop with FRR (swap src/dst)

### DIFF
--- a/docs/design/bfd-sbfd-stamp-xdp-offload-notes.md
+++ b/docs/design/bfd-sbfd-stamp-xdp-offload-notes.md
@@ -46,6 +46,66 @@ BFD Echo は本質的に「ローカルが送出 → リモートのフォワー
   破棄する。したがって reflector は **TTL を 1 減算し IPv4 ヘッダチェックサムを再計算（RFC 1141:
   チェックサム += 0x0100 / 桁上げ畳み込み）する必要がある**（UDP チェックサムは TTL を含まないため
   不変）。zebra-rs の XDP reflector は実装済み・FRR `echo-mode` と相互接続検証済み。
+
+  **[2026-06-07 update — FRR Echo addressing is asymmetric across IPv4/IPv6; the
+  reflector must treat each differently. Found via a real-world IPv6 loop against
+  FRR.]** Reading the FRR source, the Echo transmit dispatch
+  (`ptm_bfd_echo_xmt_TO`, `bfdd/bfd.c:583-590`) hardcodes an `if IPv6 … else`
+  split:
+  - **IPv4 Echo** (`ptm_bfd_echo_fp_snd`) is **self-addressed**
+    (`src == dst == local`, TTL 255) and looped by the peer's **forwarding
+    plane** — the RFC 5881 model. The reflector never touches the dst (already
+    the originator), so a **MAC swap + TTL decrement** suffices. This is the path
+    already lab-validated against FRR `echo-mode` (see the 2026-06-01 note).
+  - **IPv6 Echo** (`ptm_bfd_echo_snd`, `bfd_packet.c:326`) is **peer-addressed**
+    (`src = local, dst = bfd->key.peer`, hlim 255) and looped by the peer's
+    **bfdd in software** (`bp_bfd_echo_in`): an IPv6 link-local Echo cannot be
+    forwarding-plane looped. FRR's reflect sends the frame back to the source at
+    `hlim - 1` (= 254); the originator IDs its own return by `hlim != 255`
+    (255 → re-reflect, otherwise → match by `my_discr`). That hlim distinction is
+    what stops a mutual-reflection loop.
+  - **Bug + fix:** the XDP reflector's IPv6 path must therefore swap the IPv6
+    src/dst too, not just the MACs. Without it the reflected frame keeps
+    `dst = us`, FRR's forwarding plane bounces it back, and it ping-pongs until
+    hlim 0 (observed 2026-06-07 on IS-IS IPv6 BFD vs FRR: tcpdump shows src/dst
+    unchanged, hlim decrementing, MAC flipping between the two boxes). Fix:
+    `swap_ip6` in `try_reflect_v6` (16-byte ×2 volatile byte-swap, same shape as
+    `swap_macs` to dodge the verifier's memcpy rejection). **No checksum fix-up**
+    (the UDP pseudo-header sum `src + dst` is invariant under the swap). The hlim
+    255→254 decrement stays mandatory (FRR reflects only hlim 255). A
+    self-addressed Echo (e.g. our own originator) has `src == dst`, so the swap is
+    a no-op and its return is still caught by the `OUR_LOCAL_IPS_V6` branch.
+  - **IPv4 path left unchanged (minimal):** FRR IPv4 Echo is self-addressed, so
+    `try_reflect_v4` (MAC swap + TTL decrement, no IP swap) is correct. The only
+    way IPv4 Echo is peer-addressed is the non-Linux FRR branch
+    (`#else → ptm_bfd_echo_snd`, dst = peer) or another implementation; the same
+    swap would fix that harmlessly (the swap is commutative, so neither the IPv4
+    header checksum nor the UDP pseudo-header checksum changes) but is unnecessary
+    for Linux / RFC-compliant peers.
+
+  **Cross-vendor / RFC check — is FRR's IPv6 model an industry convention? No,
+  it's FRR-specific (and contrary to RFC 5881):**
+  - **RFC 5881 §5**: Echo is **self-addressed** — the destination MUST be chosen
+    so the remote *forwards* it back ("a system implementing the Echo function
+    MUST be capable of sending packets to its own address … bypassing the normal
+    forwarding lookup"), and the source SHOULD NOT be an IPv6 link-local address.
+    FRR's IPv6 Echo violates all three (dst = peer, link-local src, software
+    reflection).
+  - **Cisco (IOS-XR)**: no IPv6 Echo at all — Echo is IPv4-only ("echo packets
+    transmitted over UDP/IPv4, port 3785"); IPv6 liveness uses async BFD. Nothing
+    to be consistent with.
+  - **Juniper (Junos 22.4R1+)**: `echo` / `echo-lite`; `echo-lite` works "without
+    requiring BFD configuration on the neighbor" = forwarding-plane (RFC
+    self-addressed), the **opposite** of FRR's "peer must run a reflector".
+  - **FRR's own docs**: "echo mode works only when the peer is also FRR" unless
+    distributed BFD — confirming the IPv6 model is a both-ends-FRR feature.
+  - **Implication**: the reflector's v4/v6 asymmetry intentionally mirrors FRR's.
+    `swap_ip6` is robust to **both** addressing models — a no-op for
+    self-addressed (RFC / Juniper echo-lite / our own originator) and a retarget
+    for peer-addressed (FRR) — so making zebra-rs an FRR-compatible IPv6 reflector
+    does not break standards-compliant peers. The old code/README premise "IPv6
+    Echo is self-addressed, so no swap needed" held only for our own originator;
+    FRR originators are peer-addressed.
 - 「unaffiliated BFD echo」のリフレクタ概念に一致（BFD スタックを持たない機器の前段に小さな XDP リフレクタを置く構成が可能）。
 
 ### Originator 側 = XDP 単体では不可

--- a/offload/xdp-bfd-echo/README.md
+++ b/offload/xdp-bfd-echo/README.md
@@ -226,10 +226,20 @@ Beyond reflecting, the helper also *originates* Echo when zebra-rs asks it to
 
 ## Limitations / follow-ups
 
-- IPv4 (EtherType 0x0800) and IPv6 (0x86DD) are both reflected/originated. The
-  IPv6 path needs no checksum fix-up on reflect (no header checksum, and the
-  self-addressed Echo's symmetric src/dst leave the UDP checksum valid); it
-  decrements the Hop Limit just as the IPv4 path decrements the TTL.
+- IPv4 (EtherType 0x0800) and IPv6 (0x86DD) are both reflected/originated, but
+  the IPv6 reflect is not a pure analogue of IPv4. IPv4 Echo is self-addressed
+  (`src == dst`) and looped by the peer's forwarding plane, so a MAC swap
+  suffices. FRR's IPv6 Echo (`ptm_bfd_echo_snd`) is **peer-addressed**
+  (`src = originator, dst = us`) and looped by FRR's bfdd in software
+  (`bp_bfd_echo_in`), so the IPv6 reflect also **swaps the IPv6 src/dst** to
+  retarget the frame at the originator — otherwise it keeps `dst = us`, the
+  originator re-forwards it, and it ping-pongs until the Hop Limit reaches 0.
+  The swap needs no checksum fix-up (no IPv6 header checksum; the UDP
+  pseudo-header sum `src + dst` is invariant under the swap; Hop Limit isn't in
+  it). The Hop Limit is decremented (255 → 254) just as the IPv4 path decrements
+  the TTL — and here that decrement is what stops the loop, since FRR reflects
+  only Hop Limit 255 and *processes* anything else as a return. A self-addressed
+  Echo (e.g. our own originator) is unaffected: the address swap is a no-op.
 - Option-less IPv4 only (IHL=5) and base IPv6 headers only (no extension
   headers); BFD Echo frames carry neither.
 - `bpf_timer` detection needs a kernel that supports it (≥ 5.15) and `CAP_BPF`;

--- a/offload/xdp-bfd-echo/ebpf/src/main.rs
+++ b/offload/xdp-bfd-echo/ebpf/src/main.rs
@@ -28,11 +28,23 @@
 //! helper polls that flag and reports `echo-down` to zebra-rs. This is the Echo
 //! *sender*'s detection offload — no userspace packet RX in steady state.
 //!
-//! Both IPv4 (EtherType 0x0800) and IPv6 (0x86DD) Echo frames are handled. The
-//! IPv6 path is the exact analogue: a 40-byte fixed header, Hop Limit in place
-//! of TTL, and — because IPv6 has no header checksum and the Echo is
-//! self-addressed (src == dst) — no checksum fix-up at all on reflect (the UDP
-//! pseudo-header is symmetric in src/dst, and Hop Limit isn't in it).
+//! Both IPv4 (EtherType 0x0800) and IPv6 (0x86DD) Echo frames are handled, but
+//! the IPv6 reflect path is NOT a pure analogue of IPv4. IPv4 Echo is
+//! *self-addressed* (src == dst == originator) and looped by the peer's
+//! forwarding plane, so reflecting it needs only a MAC swap. FRR's IPv6 Echo
+//! (`ptm_bfd_echo_snd`) is instead *peer-addressed* — src = originator, dst = us
+//! — and FRR loops the return in software (`bp_bfd_echo_in`): a link-local Echo
+//! can't be self-addressed through a forwarding hop. So on IPv6 reflect we must
+//! also swap the IPv6 source/destination, retargeting the frame at the
+//! originator (dst = originator). Without that the frame keeps dst = us, the
+//! originator's own forwarding plane bounces it back, and it ping-pongs until
+//! the Hop Limit reaches 0 (exactly the symptom seen against FRR). The swap
+//! needs no checksum fix-up: IPv6 has no header checksum, the UDP pseudo-header
+//! sum (src + dst) is invariant under the swap, and Hop Limit isn't in it. The
+//! Hop Limit is still decremented (255 -> 254) so the originator *processes* the
+//! return rather than re-reflecting it (FRR reflects only Hop Limit 255) — that
+//! decrement is what breaks the mutual-reflection loop. For our own
+//! self-addressed Echo the address swap is a harmless no-op.
 
 use aya_ebpf::{
     bindings::{bpf_timer, xdp_action},
@@ -133,6 +145,7 @@ const IP6_OFF: usize = ETH_HLEN;
 const IP6_NEXTHDR_OFF: usize = IP6_OFF + 6; // u8 Next Header
 const IP6_HOPLIMIT_OFF: usize = IP6_OFF + 7; // u8 Hop Limit
 const IP6_SRC_OFF: usize = IP6_OFF + 8; // [u8; 16] source address
+const IP6_DST_OFF: usize = IP6_OFF + 24; // [u8; 16] destination address
 const IP6_HLEN: usize = 40;
 
 /// UDP header after a 40-byte IPv6 header, and the Echo payload after it.
@@ -265,8 +278,7 @@ unsafe fn decrement_ttl(ctx: &XdpContext) -> Result<(), ()> {
 
 /// Decrement the IPv6 Hop Limit by one. Unlike IPv4 there is no header checksum
 /// to patch, and the UDP checksum is unaffected (Hop Limit is not in the
-/// pseudo-header, and the self-addressed Echo has src == dst). Returns Err on a
-/// truncated header or Hop Limit 0.
+/// pseudo-header). Returns Err on a truncated header or Hop Limit 0.
 #[inline(always)]
 unsafe fn decrement_hop_limit(ctx: &XdpContext) -> Result<(), ()> {
     let start = ctx.data();
@@ -361,6 +373,44 @@ unsafe fn swap_macs(ctx: &XdpContext) -> Result<(), ()> {
     Ok(())
 }
 
+/// Prove both 16-byte IPv6 addresses are in bounds, then swap the source and
+/// destination in place so a reflected Echo returns to its originator. Required
+/// for FRR-style *peer-addressed* IPv6 Echo (dst = us, not self-addressed):
+/// without retargeting, the reflected frame keeps dst = us and the originator's
+/// forwarding plane bounces it back, looping until the Hop Limit hits 0. The UDP
+/// checksum needs no fix-up — its IPv6 pseudo-header sum is src + dst, invariant
+/// under the swap. For a self-addressed Echo (src == dst) the swap is a no-op.
+/// Byte-by-byte at constant offsets (see [`swap_byte`]) so the copy is never
+/// lowered to a verifier-rejected memcpy.
+#[inline(always)]
+unsafe fn swap_ip6(ctx: &XdpContext) -> Result<(), ()> {
+    let start = ctx.data();
+    if start + IP6_DST_OFF + 16 > ctx.data_end() {
+        return Err(());
+    }
+    unsafe {
+        let src = (start + IP6_SRC_OFF) as *mut u8;
+        let dst = (start + IP6_DST_OFF) as *mut u8;
+        swap_byte(src, dst);
+        swap_byte(src.add(1), dst.add(1));
+        swap_byte(src.add(2), dst.add(2));
+        swap_byte(src.add(3), dst.add(3));
+        swap_byte(src.add(4), dst.add(4));
+        swap_byte(src.add(5), dst.add(5));
+        swap_byte(src.add(6), dst.add(6));
+        swap_byte(src.add(7), dst.add(7));
+        swap_byte(src.add(8), dst.add(8));
+        swap_byte(src.add(9), dst.add(9));
+        swap_byte(src.add(10), dst.add(10));
+        swap_byte(src.add(11), dst.add(11));
+        swap_byte(src.add(12), dst.add(12));
+        swap_byte(src.add(13), dst.add(13));
+        swap_byte(src.add(14), dst.add(14));
+        swap_byte(src.add(15), dst.add(15));
+    }
+    Ok(())
+}
+
 #[xdp]
 pub fn bfd_echo_reflect(ctx: XdpContext) -> u32 {
     match try_reflect(&ctx) {
@@ -430,9 +480,16 @@ fn try_reflect_v6(ctx: &XdpContext) -> Result<u32, ()> {
         return Ok(xdp_action::XDP_DROP);
     }
 
-    // Forwarding-hop loopback: decrement the Hop Limit (no header/UDP checksum
-    // fix-up needed — see decrement_hop_limit), swap MACs, bounce out.
+    // Reflect a peer's Echo back to its originator. FRR sends IPv6 Echo
+    // peer-addressed (dst = us) and loops the return in bfdd, so we retarget the
+    // frame: swap the IPv6 src/dst (no checksum fix-up — commutative in the UDP
+    // pseudo-header; see swap_ip6) AND swap MACs. The Hop Limit decrement
+    // (255 -> 254) makes the originator process the return instead of
+    // re-reflecting it (FRR reflects only Hop Limit 255) — this is what stops
+    // the ping-pong. A self-addressed Echo (src == dst) is unaffected: the
+    // address swap is a no-op.
     unsafe { decrement_hop_limit(ctx)? };
+    unsafe { swap_ip6(ctx)? };
     unsafe { swap_macs(ctx)? };
     Ok(xdp_action::XDP_TX)
 }


### PR DESCRIPTION
## Summary

FRR's IPv6 BFD Echo is **peer-addressed** (`ptm_bfd_echo_snd` sets `dst = bfd->key.peer`, hlim 255) and looped back by the peer's bfdd **in software** (`bp_bfd_echo_in`) — unlike IPv4 Echo, which is self-addressed and looped by the forwarding plane.

The XDP reflector's IPv6 path (`try_reflect_v6`) swapped only the MAC and decremented the Hop Limit, leaving `dst = us`. So FRR's own forwarding plane bounced the reflected frame straight back, and it **ping-ponged until the Hop Limit hit 0** — observed on IS-IS IPv6 BFD vs FRR (src/dst unchanged, hlim decrementing, MAC flipping between the two boxes).

## Fix

- Add `swap_ip6` to `try_reflect_v6`, retargeting a reflected Echo at its originator (`dst = originator`). 16-byte ×2 volatile byte-swap, same shape as `swap_macs` (avoids the verifier's memcpy rejection).
- **No checksum fix-up** — the UDP pseudo-header sum `src + dst` is invariant under the swap.
- The hlim **255→254 decrement stays mandatory** (FRR reflects only hlim 255; the decrement is what stops the mutual-reflection loop).
- Our own self-addressed Echo has `src == dst`, so the swap is a no-op and its return is still caught by the `OUR_LOCAL_IPS_V6` branch.
- **IPv4 reflect left unchanged** — FRR IPv4 Echo is self-addressed, so MAC swap + TTL decrement is already correct (and lab-validated).

## Docs

- Corrected the module doc + README (the old "IPv6 Echo is self-addressed" premise held only for our own originator).
- Added a design-doc note (`docs/design/bfd-sbfd-stamp-xdp-offload-notes.md` §2): the FRR IPv4/IPv6 addressing asymmetry (confirmed in `bfdd/bfd.c:583-590`) and a cross-vendor / RFC 5881 comparison — FRR's IPv6 model is FRR-specific; Cisco has no IPv6 Echo; Juniper echo-lite is forwarding-plane.

## Test plan

- `cargo build --release` of `offload/xdp-bfd-echo` (nightly + bpf-linker): eBPF object compiles and links clean.
- `cargo fmt --check` clean.
- `offload/` is excluded from the workspace, so the stable CI gate (`cargo {build,clippy,test} --workspace`) is unaffected.
- Lab re-test against FRR IPv6 Echo pending (rebuild + reinstall the `xdp-bfd-echo` helper on the zebra-rs box first — it is not auto-rebuilt).

Generated with [Claude Code](https://claude.com/claude-code)