### PR TITLE
bfd: report actual jittered TX interval in show bfd peers

### DIFF
--- a/zebra-rs/src/bfd/inst.rs
+++ b/zebra-rs/src/bfd/inst.rs
@@ -143,8 +143,10 @@ pub enum Message {
         ttl: u8,
         multihop: bool,
     },
-    /// Periodic transmission timer fired for `key`.
-    TxTick { key: SessionKey },
+    /// Periodic transmission timer fired for `key`. `actual_tx_us` is the
+    /// jittered interval (RFC 5880 §6.8.7) the timer just scheduled, stored on
+    /// the session for `show bfd peers` ("actual with jitter").
+    TxTick { key: SessionKey, actual_tx_us: u32 },
     /// Detection timer fired for `key`.
     DetectExpired { key: SessionKey },
     /// The per-interface helper reported that our originated Echo for the
@@ -462,7 +464,7 @@ impl Bfd {
                 Some(msg) = self.rx.recv() => match msg {
                     Message::Recv { packet, src, dst, ifindex, ttl, multihop } =>
                         self.on_recv(packet, src, dst, ifindex, ttl, multihop),
-                    Message::TxTick { key } => self.on_tx_tick(key),
+                    Message::TxTick { key, actual_tx_us } => self.on_tx_tick(key, actual_tx_us),
                     Message::DetectExpired { key } => self.on_detect_expired(key),
                     Message::EchoDown { discr } => self.on_echo_down(discr),
                 },
@@ -627,7 +629,13 @@ impl Bfd {
         })
     }
 
-    fn on_tx_tick(&self, key: SessionKey) {
+    fn on_tx_tick(&mut self, key: SessionKey, actual_tx_us: u32) {
+        // Record the jittered interval the timer just scheduled so `show bfd
+        // peers` can report it ("actual with jitter"). Separate lookups keep
+        // the mutable borrow from overlapping the `&self` send below.
+        if let Some(session) = self.sessions.get_by_key_mut(&key) {
+            session.actual_tx_us = actual_tx_us;
+        }
         if let Some(session) = self.sessions.get_by_key(&key) {
             self.send_control(session, false);
         }

--- a/zebra-rs/src/bfd/session.rs
+++ b/zebra-rs/src/bfd/session.rs
@@ -221,6 +221,14 @@ pub struct Session {
     pub demand: bool,
     pub remote_demand: bool,
 
+    /// The most recently scheduled control-packet transmission interval
+    /// (microseconds) *with* RFC 5880 §6.8.7 jitter applied — the actual gap
+    /// the per-session timer is currently counting down, reported back from the
+    /// timer task on each `TxTick`. Zero until the first tick (or while
+    /// transmission is suspended). Surfaced as "Transmission interval (actual
+    /// with jitter)" in `show bfd peers`, mirroring FRR.
+    pub actual_tx_us: u32,
+
     pub stats: Stats,
     pub created_at: Instant,
     pub last_up: Option<Instant>,
@@ -263,6 +271,7 @@ impl Session {
             remote_min_echo_rx_us: 0,
             demand: false,
             remote_demand: false,
+            actual_tx_us: 0,
             stats: Stats::default(),
             created_at: Instant::now(),
             last_up: None,

--- a/zebra-rs/src/bfd/show.rs
+++ b/zebra-rs/src/bfd/show.rs
@@ -214,6 +214,9 @@ struct BfdPeerDetailJson {
     receive_interval_us: u32,
     transmit_interval_us: u32,
     negotiated_transmit_interval_us: u32,
+    /// The most recent jittered transmit interval (RFC 5880 §6.8.7) the timer
+    /// scheduled; 0 until the first tick or while transmission is suspended.
+    actual_transmit_interval_us: u32,
     detection_time_us: u32,
     /// `Required Min Echo RX Interval` we advertise (0 = disabled). Non-zero
     /// only while the XDP reflector is up on a single-hop session.
@@ -264,6 +267,7 @@ fn detail_json(key: &SessionKey, s: &Session) -> BfdPeerDetailJson {
         receive_interval_us: s.required_min_rx_us,
         transmit_interval_us: s.desired_min_tx_us,
         negotiated_transmit_interval_us: s.tx_interval_us(),
+        actual_transmit_interval_us: s.actual_tx_us,
         detection_time_us: s.detection_time_us(),
         echo_receive_interval_us: s.advertised_echo_rx_us(),
         echo_transmission_interval_us: s.echo_transmit_interval_us(),
@@ -341,6 +345,18 @@ fn render_detail(buf: &mut String, key: &SessionKey, s: &Session) -> fmt::Result
         buf,
         "            Transmission interval (negotiated): {}",
         nego_tx
+    )?;
+    // The actual jittered gap the timer is currently counting down (RFC 5880
+    // §6.8.7). Zero until the first TxTick, or while transmission is suspended.
+    let actual_tx = if s.actual_tx_us == 0 {
+        "-".to_string()
+    } else {
+        ms(s.actual_tx_us)
+    };
+    writeln!(
+        buf,
+        "            Transmission interval (actual with jitter): {}",
+        actual_tx
     )?;
     let detect = s.detection_time_us();
     let detect = if detect == 0 {
@@ -589,6 +605,9 @@ mod tests {
         // detection = remote-mult * max(req-rx, remote-tx) = 3000ms.
         assert!(out.contains("Transmission interval (negotiated): 1000ms"));
         assert!(out.contains("Detection timeout: 3000ms"));
+        // No timer task runs in this unit test, so no TxTick has populated the
+        // jittered value yet — the line is present and renders the "-" placeholder.
+        assert!(out.contains("Transmission interval (actual with jitter): -"));
     }
 
     #[tokio::test]

--- a/zebra-rs/src/bfd/timer.rs
+++ b/zebra-rs/src/bfd/timer.rs
@@ -65,7 +65,7 @@ pub async fn session_timer(
     let mut detect_us = initial.detection_time_us;
     let mut detect_mult = initial.detect_mult.max(1);
 
-    let mut next_tx = arm_tx(tx_us, detect_mult);
+    let (mut next_tx, _) = arm_tx(tx_us, detect_mult);
     let mut detect_at = arm_detect(detect_us);
 
     loop {
@@ -79,10 +79,14 @@ pub async fn session_timer(
 
         tokio::select! {
             _ = &mut tx_sleep, if next_tx.is_some() => {
-                if event_tx.send(Message::TxTick { key }).is_err() {
+                // Re-arm first so the tick carries the jitter of the interval
+                // we are now counting down — that is the value `show bfd peers`
+                // reports as "actual with jitter" (matches FRR).
+                let (deadline, actual_tx_us) = arm_tx(tx_us, detect_mult);
+                next_tx = deadline;
+                if event_tx.send(Message::TxTick { key, actual_tx_us }).is_err() {
                     return; // event loop gone
                 }
-                next_tx = arm_tx(tx_us, detect_mult);
             }
             _ = &mut det_sleep, if detect_at.is_some() => {
                 if event_tx.send(Message::DetectExpired { key }).is_err() {
@@ -117,7 +121,8 @@ pub async fn session_timer(
                     // (0 ⇄ non-zero), since `arm_tx(0)` yields `None`.
                     if tx_interval_us != tx_us {
                         tx_us = tx_interval_us;
-                        next_tx = arm_tx(tx_us, detect_mult);
+                        // Jitter for the new interval is reported on the next tick.
+                        next_tx = arm_tx(tx_us, detect_mult).0;
                     }
                 }
                 Some(TimerCmd::ResetDetect) => {
@@ -128,14 +133,20 @@ pub async fn session_timer(
     }
 }
 
-/// Pick the next TX deadline, applying RFC 5880 §6.8.7 jitter. Zero
-/// transmission interval means the peer has suspended async transmit
-/// (`Required Min RX Interval = 0`) and we mustn't send.
-fn arm_tx(tx_us: u32, detect_mult: u8) -> Option<Instant> {
+/// Pick the next TX deadline, applying RFC 5880 §6.8.7 jitter. Returns the
+/// deadline together with the jittered interval in microseconds (so the caller
+/// can report it as "actual with jitter"). Zero transmission interval means the
+/// peer has suspended async transmit (`Required Min RX Interval = 0`) and we
+/// mustn't send — yielding `(None, 0)`.
+fn arm_tx(tx_us: u32, detect_mult: u8) -> (Option<Instant>, u32) {
     if tx_us == 0 {
-        return None;
+        return (None, 0);
     }
-    Some(Instant::now() + Duration::from_micros(jittered_tx_us(tx_us, detect_mult) as u64))
+    let jitter_us = jittered_tx_us(tx_us, detect_mult);
+    (
+        Some(Instant::now() + Duration::from_micros(jitter_us as u64)),
+        jitter_us,
+    )
 }
 
 /// Pick the next detection-time deadline. Zero means we haven't
@@ -191,8 +202,14 @@ mod tests {
     /// (peer's Required Min RX Interval = 0).
     #[test]
     fn zero_tx_disables_arm() {
-        assert!(arm_tx(0, 3).is_none());
-        assert!(arm_tx(50_000, 3).is_some());
+        // Suspended transmit yields no deadline and zero reported jitter.
+        let (deadline, jitter) = arm_tx(0, 3);
+        assert!(deadline.is_none());
+        assert_eq!(jitter, 0);
+        // A live interval yields a deadline and an in-envelope jitter.
+        let (deadline, jitter) = arm_tx(50_000, 3);
+        assert!(deadline.is_some());
+        assert!((37_500..=50_000).contains(&jitter), "jitter={jitter}");
     }
 
     /// Zero detection time leaves the detect arm un-set (no peer


### PR DESCRIPTION
## Summary

FRR's `show bfd peer` reports both the negotiated transmission interval and the actual interval currently in effect with RFC 5880 §6.8.7 jitter applied — `Transmission interval (actual with jitter): 276ms`. zebra-rs computed that jitter inside the per-session timer task and threw it away, so `show bfd peers` couldn't display it. This adds the line.

## Changes

- **`timer.rs`** — `arm_tx` now returns `(deadline, jitter_us)`; each `TxTick` carries the freshly-scheduled `actual_tx_us` (the interval the timer is now counting down).
- **`inst.rs`** — `Message::TxTick { key, actual_tx_us }`; `on_tx_tick` records it on the session.
- **`session.rs`** — new `actual_tx_us` field (0 until the first tick / while transmission is suspended).
- **`show.rs`** — renders `Transmission interval (actual with jitter): <Nms>` (or `-` when unknown) plus an `actual_transmit_interval_us` JSON field.

Output now mirrors FRR:
```
        Local timers:
            Transmission interval: 300ms
            Transmission interval (negotiated): 300ms
            Transmission interval (actual with jitter): 276ms
            Detection timeout: 900ms
```

## Scope

Control-packet TX only. zebra-rs's Echo TX runs in the out-of-process XDP helper, which jitters per packet and does not report the value back over the line protocol, so the Echo `(actual with jitter)` line is left as a follow-up (would need a new helper→daemon report).

## Test plan

- `cargo test -p zebra-rs bfd::` — 56 tests pass (incl. the existing timer `arm_tx` test updated for the tuple return, and a `show` assertion for the new line).
- `cargo fmt --check` clean.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.

Generated with [Claude Code](https://claude.com/claude-code)