### PR TITLE
bdd: add @bfd tag and 'make bfd' target for BFD tests

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -26,6 +26,12 @@ isis:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=20 --tags "@isis"
 
+# Run all BFD tests.
+bfd:
+	rm -rf allure-results
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=20 --tags "@bfd"
+
 isis_ipv6:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_ipv6"

--- a/bdd/tests/features/isis_bfd_ipv6_lan.feature
+++ b/bdd/tests/features/isis_bfd_ipv6_lan.feature
@@ -1,5 +1,6 @@
 @isis_bfd_ipv6_lan
 @isis
+@bfd
 Feature: IS-IS BFD over an IPv6-only LAN (broadcast) link
   As a network operator running IS-IS over IPv6-only broadcast segments
   I want BFD to protect each LAN adjacency

--- a/bdd/tests/features/isis_bfd_ipv6_p2p.feature
+++ b/bdd/tests/features/isis_bfd_ipv6_p2p.feature
@@ -1,5 +1,6 @@
 @isis_bfd_ipv6_p2p
 @isis
+@bfd
 Feature: IS-IS BFD over an IPv6-only point-to-point link
   As a network operator running IS-IS over IPv6-only links
   I want BFD to protect the point-to-point adjacency


### PR DESCRIPTION
## Summary

- Tag the two IS-IS BFD-over-IPv6 feature files (`isis_bfd_ipv6_lan`, `isis_bfd_ipv6_p2p`) with `@bfd` so the whole BFD suite can be selected as a group.
- Add a `make bfd` target in `bdd/Makefile` that runs all `@bfd`-tagged scenarios at `--concurrency=20`, mirroring the existing `make isis` target.

The `@bfd` tag is added as the third (non-scoping) feature tag. The resource-scoping first tag (`@isis_bfd_ipv6_lan` / `@isis_bfd_ipv6_p2p`) is unchanged, so BDD namespace/pid sweeping is unaffected. The existing scenario-level `@bfd_echo` sub-tag is untouched, and cucumber `--tags "@bfd"` matches exact tags (not prefixes), so there is no prefix collision.

## Test plan

- `cd bdd && make bfd` selects and runs the two BFD feature files (CI is the source of truth for full-suite results).

Generated with [Claude Code](https://claude.com/claude-code)