### PR TITLE
bdd: IS-IS BFD over IPv4 P2P and LAN test suites

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -87,6 +87,25 @@ isis_bfd_ipv6_lan_echo:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv6_lan and @bfd_echo"
 
+# IS-IS BFD over IPv4. The `_echo` targets exercise the Echo scenarios, which
+# require the `xdp-bfd-echo` dataplane helper (built out-of-workspace) and
+# XDP-capable namespaces; the plain targets run only the no-echo scenario.
+isis_bfd_ipv4_p2p:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv4_p2p and not @bfd_echo"
+
+isis_bfd_ipv4_p2p_echo:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv4_p2p and @bfd_echo"
+
+isis_bfd_ipv4_lan:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv4_lan and not @bfd_echo"
+
+isis_bfd_ipv4_lan_echo:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_bfd_ipv4_lan and @bfd_echo"
+
 ospf_clear_neighbor:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@ospf_clear_neighbor"
@@ -134,4 +153,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo ospf_clear_neighbor bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE

--- a/bdd/tests/configs/isis_bfd_ipv4_lan/z1-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_lan/z1-echo-both.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.1/32
+- if-name: vz1ns
+  ipv4:
+    address: 10.0.1.1/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+    - if-name: vz1ns
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+      bfd:
+        enable: true
+        echo-mode: both

--- a/bdd/tests/configs/isis_bfd_ipv4_lan/z1-echo-tx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_lan/z1-echo-tx.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.1/32
+- if-name: vz1ns
+  ipv4:
+    address: 10.0.1.1/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+    - if-name: vz1ns
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+      bfd:
+        enable: true
+        echo-mode: transmit

--- a/bdd/tests/configs/isis_bfd_ipv4_lan/z1-noecho.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_lan/z1-noecho.yaml
@@ -1,0 +1,23 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.1/32
+- if-name: vz1ns
+  ipv4:
+    address: 10.0.1.1/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+    - if-name: vz1ns
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+      bfd:
+        enable: true

--- a/bdd/tests/configs/isis_bfd_ipv4_lan/z2-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_lan/z2-echo-both.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.2/32
+- if-name: vz2ns
+  ipv4:
+    address: 10.0.1.2/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+    - if-name: vz2ns
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+      bfd:
+        enable: true
+        echo-mode: both

--- a/bdd/tests/configs/isis_bfd_ipv4_lan/z2-echo-rx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_lan/z2-echo-rx.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.2/32
+- if-name: vz2ns
+  ipv4:
+    address: 10.0.1.2/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+    - if-name: vz2ns
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+      bfd:
+        enable: true
+        echo-mode: receive

--- a/bdd/tests/configs/isis_bfd_ipv4_lan/z2-noecho.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_lan/z2-noecho.yaml
@@ -1,0 +1,23 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.2/32
+- if-name: vz2ns
+  ipv4:
+    address: 10.0.1.2/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+    - if-name: vz2ns
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+      bfd:
+        enable: true

--- a/bdd/tests/configs/isis_bfd_ipv4_p2p/z1-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_p2p/z1-echo-both.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.1/32
+- if-name: i1
+  ipv4:
+    address: 10.0.1.1/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+    - if-name: i1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      ipv4:
+        enable: true
+      bfd:
+        enable: true
+        echo-mode: both

--- a/bdd/tests/configs/isis_bfd_ipv4_p2p/z1-echo-tx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_p2p/z1-echo-tx.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.1/32
+- if-name: i1
+  ipv4:
+    address: 10.0.1.1/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+    - if-name: i1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      ipv4:
+        enable: true
+      bfd:
+        enable: true
+        echo-mode: transmit

--- a/bdd/tests/configs/isis_bfd_ipv4_p2p/z1-noecho.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_p2p/z1-noecho.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.1/32
+- if-name: i1
+  ipv4:
+    address: 10.0.1.1/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+    - if-name: i1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      ipv4:
+        enable: true
+      bfd:
+        enable: true

--- a/bdd/tests/configs/isis_bfd_ipv4_p2p/z2-echo-both.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_p2p/z2-echo-both.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.2/32
+- if-name: i1
+  ipv4:
+    address: 10.0.1.2/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+    - if-name: i1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      ipv4:
+        enable: true
+      bfd:
+        enable: true
+        echo-mode: both

--- a/bdd/tests/configs/isis_bfd_ipv4_p2p/z2-echo-rx.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_p2p/z2-echo-rx.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.2/32
+- if-name: i1
+  ipv4:
+    address: 10.0.1.2/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+    - if-name: i1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      ipv4:
+        enable: true
+      bfd:
+        enable: true
+        echo-mode: receive

--- a/bdd/tests/configs/isis_bfd_ipv4_p2p/z2-noecho.yaml
+++ b/bdd/tests/configs/isis_bfd_ipv4_p2p/z2-noecho.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.2/32
+- if-name: i1
+  ipv4:
+    address: 10.0.1.2/24
+router:
+  isis:
+    net: 49.0001.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+    - if-name: i1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      ipv4:
+        enable: true
+      bfd:
+        enable: true

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -1218,39 +1218,48 @@ async fn bfd_session_should_have_echo(
 /// flowing, so the peer's BFD session times out while the adjacency would
 /// otherwise stay up — isolating BFD as the cause of the teardown (vs. carrier
 /// loss or the much slower IS-IS hold timer). RFC 5882 hold-down then keeps the
-/// adjacency down until the drop is removed. Per-netns ip6tables rules vanish
+/// adjacency down until the drop is removed. Per-netns iptables rules vanish
 /// when the namespace is deleted, so no explicit cleanup step is needed.
 ///
-/// Fallback trigger (no new IS-IS state required) if ip6tables is unavailable:
+/// The rule is installed for both address families (iptables for IPv4, ip6tables
+/// for IPv6) so the same step serves the IPv4 and IPv6 BFD features — a single-hop
+/// session runs over whichever family carries the link, and a rule in the family
+/// that isn't in use is simply inert.
+///
+/// Fallback trigger (no new IS-IS state required) if [ip6]tables is unavailable:
 /// `tc qdisc add dev <peer-if> root netem loss 100%` on the peer's egress.
 #[when(expr = "I drop bfd control packets in namespace {string}")]
 async fn drop_bfd_control_packets(world: &mut World, namespace: String) {
     let scoped = world.ns(&namespace);
-    netns::exec_in_netns(
-        &scoped,
-        "ip6tables",
-        &["-I", "INPUT", "-p", "udp", "--dport", "3784", "-j", "DROP"],
-    )
-    .await
-    .expect("Failed to install ip6tables BFD drop rule");
+    for tool in ["iptables", "ip6tables"] {
+        netns::exec_in_netns(
+            &scoped,
+            tool,
+            &["-I", "INPUT", "-p", "udp", "--dport", "3784", "-j", "DROP"],
+        )
+        .await
+        .unwrap_or_else(|e| panic!("Failed to install {} BFD drop rule: {}", tool, e));
+    }
     println!(
         "✓ Dropping inbound BFD control packets (UDP/3784) in {}",
         scoped
     );
 }
 
-/// Remove the BFD-control drop rule installed by the step above, letting the
-/// session re-establish and IS-IS lift the hold-down.
+/// Remove the BFD-control drop rules installed by the step above (both address
+/// families), letting the session re-establish and IS-IS lift the hold-down.
 #[when(expr = "I restore bfd control packets in namespace {string}")]
 async fn restore_bfd_control_packets(world: &mut World, namespace: String) {
     let scoped = world.ns(&namespace);
-    netns::exec_in_netns(
-        &scoped,
-        "ip6tables",
-        &["-D", "INPUT", "-p", "udp", "--dport", "3784", "-j", "DROP"],
-    )
-    .await
-    .expect("Failed to remove ip6tables BFD drop rule");
+    for tool in ["iptables", "ip6tables"] {
+        netns::exec_in_netns(
+            &scoped,
+            tool,
+            &["-D", "INPUT", "-p", "udp", "--dport", "3784", "-j", "DROP"],
+        )
+        .await
+        .unwrap_or_else(|e| panic!("Failed to remove {} BFD drop rule: {}", tool, e));
+    }
     println!("✓ Restored BFD control packets (UDP/3784) in {}", scoped);
 }
 

--- a/bdd/tests/features/isis_bfd_ipv4_lan.feature
+++ b/bdd/tests/features/isis_bfd_ipv4_lan.feature
@@ -1,0 +1,128 @@
+@isis_bfd_ipv4_lan
+@isis
+@bfd
+Feature: IS-IS BFD over an IPv4 LAN (broadcast) link
+  As a network operator running IS-IS over IPv4 broadcast segments
+  I want BFD to protect each LAN adjacency
+  So that a forwarding failure tears the adjacency down well within the IS-IS
+  hold time, and the adjacency stays down (RFC 5882 hold-down) until BFD
+  recovers — even while IIHs keep arriving.
+
+  Same intent as the point-to-point feature, but the two routers share a Linux
+  bridge (broadcast network type, DIS election). Per-neighbour single-hop BFD
+  sessions are built from each end's IPv4 interface address (TLV 132). Each
+  scenario is self-contained so the Echo scenarios arm echo-mode before the
+  session first comes up.
+
+  BFD-down is induced by dropping inbound UDP/3784 in one namespace: the link
+  stays up and IIHs (L2 ISO PDUs, not IP/UDP) keep flowing, so a fast teardown
+  is provably BFD's doing — not carrier loss, not the ~30s IS-IS hold timer.
+
+  Test Topology (shared bridge):
+  ```
+  ┌────────────────────────────────────────┐
+  │                  br0                    │
+  └────────────┬───────────────┬───────────┘
+               │               │
+          10.0.1.1/24     10.0.1.2/24
+            (vz1ns)            (vz2ns)
+          ┌────┴────┐     ┌────┴────┐
+          │   z1    │     │   z2    │
+          └─────────┘     └─────────┘
+       lo 10.255.0.1      lo 10.255.0.2
+              /32                  /32
+  ```
+
+  Scenario: BFD without Echo protects the LAN adjacency and tears it down on BFD failure
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with loopback and veth interface on the bridge "br0"
+    And I create namespace "z2" with loopback and veth interface on the bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-noecho.yaml" to namespace "z1"
+    And I apply config "z2-noecho.yaml" to namespace "z2"
+    And I wait 15 seconds
+    Then isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should be up
+    And bfd session in namespace "z1" on interface "vz1ns" should be up
+    And bfd session in namespace "z2" on interface "vz2ns" should be up
+    And ping from "z1" to "10.255.0.2" should succeed
+    # BFD-down isolation: link stays up, IIHs keep flowing.
+    When I drop bfd control packets in namespace "z2"
+    Then bfd session in namespace "z1" on interface "vz1ns" should be down
+    And isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should not be up
+    And ping from "z1" to "10.255.0.2" should fail
+    # Recovery: BFD re-establishes and IS-IS lifts the hold-down.
+    When I restore bfd control packets in namespace "z2"
+    And I wait 20 seconds
+    Then bfd session in namespace "z1" on interface "vz1ns" should be up
+    And isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should be up
+    And ping from "z1" to "10.255.0.2" should succeed
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean
+
+  @bfd_echo
+  Scenario: BFD with Echo in one direction (z1 transmit, z2 receive)
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with loopback and veth interface on the bridge "br0"
+    And I create namespace "z2" with loopback and veth interface on the bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-echo-tx.yaml" to namespace "z1"
+    And I apply config "z2-echo-rx.yaml" to namespace "z2"
+    And I wait 15 seconds
+    Then isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should be up
+    And bfd session in namespace "z1" on interface "vz1ns" should be up
+    And bfd session in namespace "z1" on interface "vz1ns" should have echo transmit
+    And bfd session in namespace "z2" on interface "vz2ns" should have echo receive
+    And ping from "z1" to "10.255.0.2" should succeed
+    When I drop bfd control packets in namespace "z2"
+    Then bfd session in namespace "z1" on interface "vz1ns" should be down
+    And isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should not be up
+    When I restore bfd control packets in namespace "z2"
+    And I wait 20 seconds
+    Then bfd session in namespace "z1" on interface "vz1ns" should be up
+    And isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should be up
+    And ping from "z1" to "10.255.0.2" should succeed
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean
+
+  @bfd_echo
+  Scenario: BFD with Echo in both directions
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with loopback and veth interface on the bridge "br0"
+    And I create namespace "z2" with loopback and veth interface on the bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-echo-both.yaml" to namespace "z1"
+    And I apply config "z2-echo-both.yaml" to namespace "z2"
+    And I wait 15 seconds
+    Then isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should be up
+    And bfd session in namespace "z1" on interface "vz1ns" should be up
+    And bfd session in namespace "z1" on interface "vz1ns" should have echo both
+    And bfd session in namespace "z2" on interface "vz2ns" should have echo both
+    And ping from "z1" to "10.255.0.2" should succeed
+    When I drop bfd control packets in namespace "z2"
+    Then bfd session in namespace "z1" on interface "vz1ns" should be down
+    And isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should not be up
+    When I restore bfd control packets in namespace "z2"
+    And I wait 20 seconds
+    Then bfd session in namespace "z1" on interface "vz1ns" should be up
+    And isis neighbor in namespace "z1" at level 2 on interface "vz1ns" should be up
+    And ping from "z1" to "10.255.0.2" should succeed
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/bdd/tests/features/isis_bfd_ipv4_p2p.feature
+++ b/bdd/tests/features/isis_bfd_ipv4_p2p.feature
@@ -1,0 +1,119 @@
+@isis_bfd_ipv4_p2p
+@isis
+@bfd
+Feature: IS-IS BFD over an IPv4 point-to-point link
+  As a network operator running IS-IS over IPv4 links
+  I want BFD to protect the point-to-point adjacency
+  So that a forwarding failure tears the adjacency down well within the IS-IS
+  hold time, and the adjacency stays down (RFC 5882 hold-down) until BFD
+  recovers — even while IIHs keep arriving.
+
+  The single-hop BFD session is built from the two ends' IPv4 interface
+  addresses (learned via TLV 132). Each scenario is self-contained (own setup
+  and teardown) so the Echo scenarios configure echo-mode before the session
+  first comes up (echo is armed at session establishment, not retrofitted).
+
+  BFD-down is induced by dropping inbound UDP/3784 in one namespace: the link
+  stays up and IIHs (L2 ISO PDUs, not IP/UDP) keep flowing, so a fast teardown
+  is provably BFD's doing — not carrier loss, not the ~30s IS-IS hold timer.
+
+  Test Topology (point-to-point veth):
+  ```
+     10.0.1.1/24                             10.0.1.2/24
+        (i1)                                   (i1)
+    ┌────┴────┐                            ┌────┴────┐
+    │   z1    │────────── P2P ─────────────│   z2    │
+    └─────────┘                            └─────────┘
+   lo 10.255.0.1/32                       lo 10.255.0.2/32
+  ```
+
+  Scenario: BFD without Echo protects the adjacency and tears it down on BFD failure
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-noecho.yaml" to namespace "z1"
+    And I apply config "z2-noecho.yaml" to namespace "z2"
+    And I wait 10 seconds
+    Then isis neighbor in namespace "z1" at level 2 on interface "i1" should be up
+    And bfd session in namespace "z1" on interface "i1" should be up
+    And bfd session in namespace "z2" on interface "i1" should be up
+    And ping from "z1" to "10.255.0.2" should succeed
+    # BFD-down isolation: link stays up, IIHs keep flowing.
+    When I drop bfd control packets in namespace "z2"
+    Then bfd session in namespace "z1" on interface "i1" should be down
+    And isis neighbor in namespace "z1" at level 2 on interface "i1" should not be up
+    And ping from "z1" to "10.255.0.2" should fail
+    # Recovery: BFD re-establishes and IS-IS lifts the hold-down.
+    When I restore bfd control packets in namespace "z2"
+    And I wait 20 seconds
+    Then bfd session in namespace "z1" on interface "i1" should be up
+    And isis neighbor in namespace "z1" at level 2 on interface "i1" should be up
+    And ping from "z1" to "10.255.0.2" should succeed
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean
+
+  @bfd_echo
+  Scenario: BFD with Echo in one direction (z1 transmit, z2 receive)
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-echo-tx.yaml" to namespace "z1"
+    And I apply config "z2-echo-rx.yaml" to namespace "z2"
+    And I wait 10 seconds
+    Then isis neighbor in namespace "z1" at level 2 on interface "i1" should be up
+    And bfd session in namespace "z1" on interface "i1" should be up
+    And bfd session in namespace "z1" on interface "i1" should have echo transmit
+    And bfd session in namespace "z2" on interface "i1" should have echo receive
+    And ping from "z1" to "10.255.0.2" should succeed
+    When I drop bfd control packets in namespace "z2"
+    Then bfd session in namespace "z1" on interface "i1" should be down
+    And isis neighbor in namespace "z1" at level 2 on interface "i1" should not be up
+    When I restore bfd control packets in namespace "z2"
+    And I wait 20 seconds
+    Then bfd session in namespace "z1" on interface "i1" should be up
+    And isis neighbor in namespace "z1" at level 2 on interface "i1" should be up
+    And ping from "z1" to "10.255.0.2" should succeed
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean
+
+  @bfd_echo
+  Scenario: BFD with Echo in both directions
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-echo-both.yaml" to namespace "z1"
+    And I apply config "z2-echo-both.yaml" to namespace "z2"
+    And I wait 10 seconds
+    Then isis neighbor in namespace "z1" at level 2 on interface "i1" should be up
+    And bfd session in namespace "z1" on interface "i1" should be up
+    And bfd session in namespace "z1" on interface "i1" should have echo both
+    And bfd session in namespace "z2" on interface "i1" should have echo both
+    And ping from "z1" to "10.255.0.2" should succeed
+    When I drop bfd control packets in namespace "z2"
+    Then bfd session in namespace "z1" on interface "i1" should be down
+    And isis neighbor in namespace "z1" at level 2 on interface "i1" should not be up
+    When I restore bfd control packets in namespace "z2"
+    And I wait 20 seconds
+    Then bfd session in namespace "z1" on interface "i1" should be up
+    And isis neighbor in namespace "z1" at level 2 on interface "i1" should be up
+    And ping from "z1" to "10.255.0.2" should succeed
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

Adds IPv4 BFD IS-IS BDD tests, mirroring the existing IPv6 P2P and LAN suites. Each feature exercises a single-hop BFD session protecting the IS-IS adjacency, with RFC 5882 hold-down on BFD failure and recovery once BFD re-establishes.

- **`isis_bfd_ipv4_p2p.feature`** (`@isis_bfd_ipv4_p2p`) — point-to-point veth; BFD session built from the two ends' IPv4 interface addresses (TLV 132).
- **`isis_bfd_ipv4_lan.feature`** (`@isis_bfd_ipv4_lan`) — shared Linux bridge (broadcast, DIS election); per-neighbour single-hop BFD.
- Each feature: 1 no-echo scenario + 2 `@bfd_echo` scenarios (echo transmit/receive and echo both).
- 12 IPv4 config YAMLs under `tests/configs/isis_bfd_ipv4_{p2p,lan}/` (`10.0.1.1/.2/24` link, `10.255.0.1/.2/32` loopbacks).
- 4 new Makefile targets (`isis_bfd_ipv4_{p2p,lan}{,_echo}`) + `.PHONY`.

## Shared-step change

The only IPv6-specific step was `drop/restore bfd control packets`, hardcoded to `ip6tables`. It now installs the UDP/3784 DROP rule for **both** address families (`iptables` + `ip6tables`) so a single step vocabulary serves the IPv4 and IPv6 features; the rule in the unused family is inert. All other steps (ping, isis-neighbor, bfd-session, echo-role, topology) were already address-family agnostic.

## Test plan

- `cargo check -p bdd --tests` — compiles clean.
- `cargo fmt -p bdd` — no changes (already formatted).
- `cargo clippy -p bdd --tests` — no warnings.
- Per repo convention the BDD suite is not run locally; CI is the source of truth. The `@bfd_echo` scenarios depend on the out-of-workspace `xdp-bfd-echo` dataplane helper (same constraint as the IPv6 echo suite) and are isolated behind the `_echo` Makefile targets.

Generated with [Claude Code](https://claude.com/claude-code)