### PR TITLE
ospf: NSSA Type-7→Type-5 translation (FA=0) + @ospfv2_nssa BDD

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -110,6 +110,10 @@ ospf_clear_neighbor:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@ospf_clear_neighbor"
 
+ospfv2_nssa:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv2_nssa"
+
 bgp_evpn_capability:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_capability"
@@ -153,4 +157,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE

--- a/bdd/tests/configs/ospfv2_nssa/a.yaml
+++ b/bdd/tests/configs/ospfv2_nssa/a.yaml
@@ -1,0 +1,38 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+- if-name: ethc
+  ipv4:
+    address: 10.0.13.1/30
+- if-name: ethd
+  ipv4:
+    address: 10.0.14.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    # Backbone — a is the ABR gluing the NSSA to area 0.
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+    # NSSA (0.0.0.1). a is the (sole) ABR, so it elects itself the
+    # RFC 3101 Type-7->Type-5 translator under the default `candidate`
+    # role, and originates a default Type-7 into the area.
+    - area-id: 0.0.0.1
+      area-type: nssa
+      nssa-default-originate: true
+      interface:
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point
+      - if-name: ethd
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa/b.yaml
+++ b/bdd/tests/configs/ospfv2_nssa/b.yaml
@@ -1,0 +1,22 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    # b sits in the backbone only. It must learn the NSSA-internal
+    # external prefix exclusively as a *translated* Type-5 — a Type-7
+    # never leaves its NSSA — which makes b the witness for the
+    # Type-7->Type-5 translator working end to end.
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa/c.yaml
+++ b/bdd/tests/configs/ospfv2_nssa/c.yaml
@@ -1,0 +1,29 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+- if-name: etha
+  ipv4:
+    address: 10.0.13.2/30
+router:
+  ospf:
+    router-id: 10.0.0.3
+    area:
+    # c is an internal NSSA router AND the area's ASBR: it injects a
+    # connected route into the NSSA as a Type-7 (NSSA-AS-External)
+    # LSA. Being a pure ASBR (not an ABR) it sets the Type-7 P-bit,
+    # asking the ABR to translate. metric 20 / type-2 (E2) mirror the
+    # AS-External test so the installed metric is a flat [20]
+    # everywhere.
+    - area-id: 0.0.0.1
+      area-type: nssa
+      redistribute:
+        connected:
+          metric: 20
+          metric-type: type-2
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa/d.yaml
+++ b/bdd/tests/configs/ospfv2_nssa/d.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.4/32
+- if-name: etha
+  ipv4:
+    address: 10.0.14.2/30
+router:
+  ospf:
+    router-id: 10.0.0.4
+    # d is a plain internal NSSA router. It learns the external prefix
+    # straight from c's Type-7 (area-scoped flood), the default route
+    # from the ABR's Type-7, and backbone prefixes as Type-3 summaries
+    # (NSSA still accepts inter-area summaries — it is not totally
+    # stubby here).
+    area:
+    - area-id: 0.0.0.1
+      area-type: nssa
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv2_nssa.feature
+++ b/bdd/tests/features/ospfv2_nssa.feature
@@ -1,0 +1,124 @@
+@serial
+@ospfv2_nssa
+Feature: OSPFv2 NSSA (Not-So-Stubby Area) Type-7 origination and translation
+  As a network operator
+  I want zebra-rs to support OSPFv2 NSSA areas — N-bit adjacency
+  negotiation, Type-7 (NSSA-AS-External) origination from an internal
+  ASBR, intra-NSSA Type-7 route install, the ABR's RFC 3101
+  Type-7->Type-5 translation into the rest of the OSPF domain, and a
+  default Type-7 injected by the ABR — so that an external prefix born
+  inside an NSSA is reachable both inside the area and across the
+  backbone, while the area still refuses to carry Type-5 AS-External.
+
+  Four routers, two areas. The backbone (0.0.0.0) holds the ABR a and
+  a pure backbone router b. The NSSA (0.0.0.1) hangs off a as a
+  hub-and-spoke: the ASBR c and the plain internal router d both peer
+  only with a.
+
+  Test Topology:
+  ```
+            area 0.0.0.0 (backbone)
+      b (10.0.0.2) ---- 10.0.12.0/30 ---- a (ABR, 10.0.0.1)
+                                          |  translator + default-originate
+                                  area 0.0.0.1 (NSSA)
+                       10.0.13.0/30 |        | 10.0.14.0/30
+                              etha  |        |  etha
+                         c (ASBR, 10.0.0.3)  d (10.0.0.4)
+                         redistribute        plain internal
+                         connected -> Type-7
+
+    on router X the interface toward router Y is named "ethY".
+    loopbacks: a .1  b .2  c .3  d .4  (10.0.0.X/32).
+  ```
+
+  The external prefix is a secondary loopback (192.168.1.1/32) added to
+  c's lo AFTER zebra-rs starts; it is not registered under any OSPF
+  area, so it enters OSPF only via c's per-area `redistribute connected`
+  as a Type-7. c is a pure ASBR (not an ABR), so it sets the Type-7
+  P-bit. The flood is area-scoped: d installs it directly, and the ABR
+  a — the elected (sole-ABR, default `candidate` role) NSSA translator —
+  re-originates it as a Type-5 AS-External into the backbone, where b
+  installs it. b carries no NSSA link, so a Type-5 is the only way the
+  prefix can reach it: its presence on b is the proof the translator ran.
+
+  The metric is a flat [20] (E2 / type-2) everywhere — on d (Type-7)
+  and on b (translated Type-5) alike — because E2 uses the LSA metric
+  verbatim, independent of distance to the originator.
+
+  Scenario: Internal ASBR Type-7 is installed in-area and translated to Type-5 on the backbone
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I create namespace "c"
+    And I create namespace "d"
+    # Backbone link a-b, NSSA spokes a-c and a-d.
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I connect namespace "a" interface "ethc" to namespace "c" interface "etha"
+    And I connect namespace "a" interface "ethd" to namespace "d" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I start zebra-rs in namespace "c"
+    And I start zebra-rs in namespace "d"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I apply config "c.yaml" to namespace "c"
+    And I apply config "d.yaml" to namespace "d"
+    # Secondary loopback on c: the external prefix redistributed into
+    # the NSSA as a Type-7. Not under any OSPF area, so it can only
+    # enter via `redistribute connected`.
+    And I add address "192.168.1.1/32" to interface "lo" in namespace "c"
+    # Allow Hellos + DBD on every link (N-bit must match on the NSSA
+    # links), then Type-7 origination + flood, the ABR's Type-7->Type-5
+    # translation + AS-wide flood, and SPF/route install everywhere.
+    And I wait 60 seconds
+
+    # --- Adjacencies are Full on every link (the NSSA links only come
+    #     up when the N-bit matches between a and c / a and d). ---
+    Then show command "show ip ospf neighbor" in namespace "a" should contain "Full"
+    And show command "show ip ospf neighbor" in namespace "a" should contain "10.0.0.2"
+    And show command "show ip ospf neighbor" in namespace "a" should contain "10.0.0.3"
+    And show command "show ip ospf neighbor" in namespace "a" should contain "10.0.0.4"
+    And show command "show ip ospf neighbor" in namespace "c" should contain "Full"
+    And show command "show ip ospf neighbor" in namespace "c" should contain "10.0.0.1"
+
+    # --- Type-7 inside the NSSA: d (plain internal router) installs the
+    #     external prefix straight from c's Type-7, E2 metric [20]. ---
+    And show command "show ip ospf route" in namespace "d" should contain "192.168.1.1/32"
+    And show command "show ip ospf route" in namespace "d" should contain "[20]"
+
+    # --- The headline: Type-7 -> Type-5 translation at the ABR. b is in
+    #     the backbone only, so it can learn 192.168.1.1/32 ONLY as a
+    #     translated Type-5 (the Type-7 never leaves the NSSA). Same E2
+    #     metric [20], carried verbatim across the translation. ---
+    And show command "show ip ospf route" in namespace "b" should contain "192.168.1.1/32"
+    And show command "show ip ospf route" in namespace "b" should contain "[20]"
+
+    # --- ABR default-originate: a injects a default Type-7 into the
+    #     NSSA, so both internal routers hold a 0.0.0.0/0. ---
+    And show command "show ip ospf route" in namespace "c" should contain "0.0.0.0/0"
+    And show command "show ip ospf route" in namespace "d" should contain "0.0.0.0/0"
+
+    # --- NSSA still accepts Type-3: d learns the backbone loopback as an
+    #     inter-area summary (it is not totally stubby). ---
+    And show command "show ip ospf route" in namespace "d" should contain "10.0.0.2/32"
+
+    # --- End-to-end reachability. ---
+    # Backbone host b reaches the NSSA-internal external prefix: the
+    # translated Type-5 routes b -> a, then a (which holds the Type-7
+    # route) -> c, proving translation AND forwarding.
+    And ping from "b" to "192.168.1.1" should succeed
+    # NSSA internal host d reaches the backbone loopback (inter-area),
+    # and the external prefix (intra-NSSA Type-7).
+    And ping from "d" to "10.0.0.2" should succeed
+    And ping from "d" to "192.168.1.1" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I stop zebra-rs in namespace "c"
+    And I stop zebra-rs in namespace "d"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    And I delete namespace "c"
+    And I delete namespace "d"
+    Then the test environment should be clean

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -2055,11 +2055,18 @@ impl Ospf<Ospfv2> {
     ) {
         let ls_id = prefix.network();
         let mut lsa_header = OspfLsaHeader::new(OspfLsType::NssaAsExternal, ls_id, self.router_id);
-        // RFC 3101 §2.4 LSA header Options on Type-7: E bit MUST be
-        // clear (NSSA areas can't accept Type-5); N bit set; P bit
-        // clear for ABR-originated LSAs.
+        // RFC 3101 §2.4 LSA-header Options on a Type-7: the E-bit MUST
+        // be clear (NSSA areas can't carry Type-5) and the O-bit is
+        // set. The N/P-bit (mask 0x08) is the *Propagate* bit in a
+        // Type-7 header — the very same wire bit the Hello/DBD options
+        // field calls "N". Set, it asks an NSSA ABR to translate this
+        // LSA into a Type-5; a pure NSSA ASBR sets it. An ABR clears
+        // it on its *own* Type-7s so that a peer ABR in the same NSSA
+        // never re-translates them (RFC 3101 §3.2) — which also keeps
+        // an ABR-originated default-LSA from leaking into the backbone.
+        let propagate = !self.is_abr();
         let mut options = OspfOptions::default();
-        options.set_nssa(true);
+        options.set_nssa(propagate);
         options.set_o(true);
         lsa_header.options = u8::from(options);
 
@@ -2422,10 +2429,14 @@ impl Ospf<Ospfv2> {
     /// - not self-originated — re-translating our own Type-7 would
     ///   double state for no gain
     /// - P-bit set in the source — RFC 3101 §3.2.1
-    /// - forwarding-address non-zero — FA=0 receive semantics
-    ///   aren't wired yet (the SPF receive path also skips FA!=0);
-    ///   defer FA resolution to a later cleanup that covers both
-    ///   paths together
+    ///
+    /// The forwarding address is copied verbatim into the Type-5
+    /// (RFC 3101 §3.2). A zero FA is permitted: the translated
+    /// Type-5 then also carries FA=0, so receivers reach the prefix
+    /// via the path to *this* ABR (the Type-5's advertising router),
+    /// which itself installs the Type-7 route into the NSSA — the
+    /// same FA=0 semantics `add_as_external_routes` /
+    /// `add_nssa_routes` already implement on the receive side.
     fn nssa_translate_one(&mut self, type7: &OspfLsa) -> bool {
         use crate::ospf::lsdb::OSPF_MAX_AGE;
         const P_BIT: u8 = 0x08;
@@ -2440,9 +2451,6 @@ impl Ospf<Ospfv2> {
             return false;
         }
         if (type7.h.options & P_BIT) == 0 {
-            return false;
-        }
-        if body.forwarding_address.is_unspecified() {
             return false;
         }
 
@@ -2508,12 +2516,11 @@ impl Ospf<Ospfv2> {
             if (d.h.options & P_BIT) == 0 {
                 continue;
             }
-            let OspfLsp::NssaAsExternal(ref body) = d.lsp else {
+            // Body shape is the only remaining gate; FA may be zero
+            // (see `nssa_translate_one` for the FA=0 rationale).
+            let OspfLsp::NssaAsExternal(_) = d.lsp else {
                 continue;
             };
-            if body.forwarding_address.is_unspecified() {
-                continue;
-            }
             out.insert(d.h.ls_id);
         }
         out


### PR DESCRIPTION
## Summary

Adds an OSPFv2 NSSA BDD test and fixes the control-plane gap that made the NSSA Type-7→Type-5 translator dead in any real topology.

### OSPF gap fix (`zebra-rs/src/ospf/inst.rs`)
The translator never fired: `nssa_lsa_originate_for_prefix` always emits a Type-7 with forwarding-address 0, while the translate path gated on FA ≠ 0. No FA value satisfied both the receive path (resolves FA=0 only) and translation, so a redistributed external born inside an NSSA never reached the rest of the OSPF domain.

- Drop the `FA != 0` translation gate — an FA=0 Type-7 now translates to an FA=0 Type-5; receivers resolve via the path to the translating ABR, which itself holds the Type-7 route (same FA=0 semantics the receive side already implements).
- The Type-7 P-bit and the Hello/DBD N-bit are the **same** options bit (0x08). Origination set it unconditionally; changed to `set_nssa(!is_abr())` so an ABR clears P on its own Type-7s — preventing a peer ABR from re-translating them or leaking a default into the backbone (RFC 3101 §3.2).

Deferred: FA≠0 origination + FA-based receive resolution (RFC-optimal); OSPFv3 has the identical latent gap (untouched).

### BDD test (`@ospfv2_nssa`)
Four routers, two areas. Internal NSSA ASBR `c` redistributes a connected route as a Type-7; internal router `d` installs it in-area; ABR `a` translates it to a Type-5 so backbone-only router `b` installs it. `b` has no NSSA link, so its learning the prefix is the witness that translation ran end to end. Also covers N-bit adjacency, ABR default-originate, Type-3 acceptance, and pings.

## Test plan
- `cargo build -p zebra-rs` ✓
- `cargo fmt --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓ (clean)
- `cargo test -p zebra-rs ospf` ✓ (66 passed)
- BDD `make ospfv2_nssa` — run after rebuilding/reinstalling `/usr/bin/zebra-rs` (excluded from CI)

Generated with [Claude Code](https://claude.com/claude-code)