### PR TITLE
bdd: add NSSA totally-stubby/never/E1 scenarios + @ospfv2_stub feature

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -114,6 +114,10 @@ ospfv2_nssa:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv2_nssa"
 
+ospfv2_stub:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv2_stub"
+
 bgp_evpn_capability:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_capability"
@@ -157,4 +161,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE

--- a/bdd/tests/configs/ospfv2_nssa/a_never.yaml
+++ b/bdd/tests/configs/ospfv2_nssa/a_never.yaml
@@ -1,0 +1,39 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+- if-name: ethc
+  ipv4:
+    address: 10.0.13.1/30
+- if-name: ethd
+  ipv4:
+    address: 10.0.14.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+    # `nssa-translator-role: never` disables Type-7->Type-5 translation
+    # on this ABR (RFC 3101 §2.2). The Type-7 still floods the NSSA and
+    # internal routers install it, but it must NOT leak into the
+    # backbone as a Type-5.
+    - area-id: 0.0.0.1
+      area-type: nssa
+      nssa-default-originate: true
+      nssa-translator-role: never
+      interface:
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point
+      - if-name: ethd
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa/a_totally.yaml
+++ b/bdd/tests/configs/ospfv2_nssa/a_totally.yaml
@@ -1,0 +1,39 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+- if-name: ethc
+  ipv4:
+    address: 10.0.13.1/30
+- if-name: ethd
+  ipv4:
+    address: 10.0.14.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+    # Totally-NSSA: `no-summary` makes the ABR suppress every Type-3
+    # summary into the area, so the only way out is the default Type-7
+    # injected by `nssa-default-originate`. Type-7 origination and the
+    # Type-7->Type-5 translation are unaffected.
+    - area-id: 0.0.0.1
+      area-type: nssa
+      no-summary: true
+      nssa-default-originate: true
+      interface:
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point
+      - if-name: ethd
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_nssa/c_e1.yaml
+++ b/bdd/tests/configs/ospfv2_nssa/c_e1.yaml
@@ -1,0 +1,27 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+- if-name: etha
+  ipv4:
+    address: 10.0.13.2/30
+router:
+  ospf:
+    router-id: 10.0.0.3
+    area:
+    # Same internal NSSA ASBR as c.yaml, but redistributes with
+    # metric-type type-1 (E1): the installed metric is the SPF cost to
+    # the originator plus the LSA metric, so it grows with distance —
+    # unlike the flat E2 metric.
+    - area-id: 0.0.0.1
+      area-type: nssa
+      redistribute:
+        connected:
+          metric: 20
+          metric-type: type-1
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_stub/a.yaml
+++ b/bdd/tests/configs/ospfv2_stub/a.yaml
@@ -1,0 +1,30 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: ethb
+  ipv4:
+    address: 10.0.12.1/30
+- if-name: ethc
+  ipv4:
+    address: 10.0.13.1/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    area:
+    # Backbone — a is the ABR between area 0 and the stub area.
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+    # Stub (0.0.0.1): drops Type-5 AS-External (E-bit clear in
+    # Hello/DBD) but still floods inter-area Type-3 summaries inward.
+    - area-id: 0.0.0.1
+      area-type: stub
+      interface:
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_stub/b.yaml
+++ b/bdd/tests/configs/ospfv2_stub/b.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: etha
+  ipv4:
+    address: 10.0.12.2/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    # b is the backbone ASBR: it redistributes a connected route as a
+    # Type-5 AS-External LSA. That Type-5 floods the backbone (a learns
+    # it) but must be dropped at the stub boundary.
+    redistribute:
+      connected:
+        metric: 20
+        metric-type: type-2
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv2_stub/c.yaml
+++ b/bdd/tests/configs/ospfv2_stub/c.yaml
@@ -1,0 +1,22 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+- if-name: etha
+  ipv4:
+    address: 10.0.13.2/30
+router:
+  ospf:
+    router-id: 10.0.0.3
+    # c is a plain internal stub router. It learns backbone prefixes as
+    # Type-3 summaries but never sees the Type-5 external — that is the
+    # defining stub behavior.
+    area:
+    - area-id: 0.0.0.1
+      area-type: stub
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv2_nssa.feature
+++ b/bdd/tests/features/ospfv2_nssa.feature
@@ -122,3 +122,140 @@ Feature: OSPFv2 NSSA (Not-So-Stubby Area) Type-7 origination and translation
     And I delete namespace "c"
     And I delete namespace "d"
     Then the test environment should be clean
+
+  # Totally-NSSA: the ABR's `no-summary` knob suppresses every Type-3
+  # Summary into the area, so internal routers hold no inter-area
+  # specifics — only the default Type-7 the ABR injects. Type-7
+  # origination and Type-7->Type-5 translation are unaffected, proving
+  # `no-summary` narrows only the inbound-summary path.
+  Scenario: Totally-NSSA suppresses Type-3 summaries but keeps the default and translation
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I create namespace "c"
+    And I create namespace "d"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I connect namespace "a" interface "ethc" to namespace "c" interface "etha"
+    And I connect namespace "a" interface "ethd" to namespace "d" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I start zebra-rs in namespace "c"
+    And I start zebra-rs in namespace "d"
+    # Only a differs from the first scenario: it adds `no-summary`.
+    And I apply config "a_totally.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I apply config "c.yaml" to namespace "c"
+    And I apply config "d.yaml" to namespace "d"
+    And I add address "192.168.1.1/32" to interface "lo" in namespace "c"
+    And I wait 60 seconds
+
+    # --- The default Type-7 is still injected, so d holds a 0.0.0.0/0. ---
+    Then show command "show ip ospf route" in namespace "d" should contain "0.0.0.0/0"
+    # --- But the Type-3 summary for the backbone loopback is gone: in a
+    #     totally-NSSA the ABR originates no summaries into the area. ---
+    And show command "show ip ospf route" in namespace "d" should not contain "10.0.0.2/32"
+    # --- Type-7 still floods in-area, and translation still reaches the
+    #     backbone — `no-summary` touches only the inbound Type-3 path. ---
+    And show command "show ip ospf route" in namespace "d" should contain "192.168.1.1/32"
+    And show command "show ip ospf route" in namespace "b" should contain "192.168.1.1/32"
+    # --- d reaches the backbone loopback purely via the default route. ---
+    And ping from "d" to "10.0.0.2" should succeed
+
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I stop zebra-rs in namespace "c"
+    And I stop zebra-rs in namespace "d"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    And I delete namespace "c"
+    And I delete namespace "d"
+    Then the test environment should be clean
+
+  # Translator-role `never`: the ABR refuses to translate (RFC 3101
+  # §2.2). The Type-7 still floods the NSSA and internal routers install
+  # it, but with no translator the prefix never becomes a Type-5, so the
+  # backbone-only router never learns it. This is the negative control
+  # for the first scenario's translation result.
+  Scenario: Translator-role never keeps the Type-7 in-area and out of the backbone
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I create namespace "c"
+    And I create namespace "d"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I connect namespace "a" interface "ethc" to namespace "c" interface "etha"
+    And I connect namespace "a" interface "ethd" to namespace "d" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I start zebra-rs in namespace "c"
+    And I start zebra-rs in namespace "d"
+    # Only a differs: nssa-translator-role = never.
+    And I apply config "a_never.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I apply config "c.yaml" to namespace "c"
+    And I apply config "d.yaml" to namespace "d"
+    And I add address "192.168.1.1/32" to interface "lo" in namespace "c"
+    And I wait 60 seconds
+
+    # --- Intra-NSSA Type-7 install is unchanged: d still learns it. ---
+    Then show command "show ip ospf route" in namespace "d" should contain "192.168.1.1/32"
+    # --- But with translation disabled the prefix never reaches the
+    #     backbone: b has no Type-5 for it and externals are not
+    #     summarized as Type-3, so b must NOT contain the prefix. ---
+    And show command "show ip ospf route" in namespace "b" should not contain "192.168.1.1/32"
+
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I stop zebra-rs in namespace "c"
+    And I stop zebra-rs in namespace "d"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    And I delete namespace "c"
+    And I delete namespace "d"
+    Then the test environment should be clean
+
+  # E1 (type-1) metric through the NSSA and across translation. Unlike
+  # the flat E2 metric, E1 adds the SPF cost to the originator, so the
+  # installed metric grows with distance and differs by observer:
+  #   - d (intra-NSSA): cost d->c is 20 (d-a-c, 10+10), so [40] (20+20).
+  #   - b (translated Type-5, advertised by the ABR a): cost b->a is 10,
+  #     so [30] (10+20).
+  Scenario: E1 metric grows with SPF distance to the originating ASBR and the translator
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I create namespace "c"
+    And I create namespace "d"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I connect namespace "a" interface "ethc" to namespace "c" interface "etha"
+    And I connect namespace "a" interface "ethd" to namespace "d" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I start zebra-rs in namespace "c"
+    And I start zebra-rs in namespace "d"
+    # Only c differs: redistribute metric-type type-1 (E1).
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I apply config "c_e1.yaml" to namespace "c"
+    And I apply config "d.yaml" to namespace "d"
+    And I add address "192.168.1.1/32" to interface "lo" in namespace "c"
+    And I wait 60 seconds
+
+    # --- d: intra-NSSA Type-7, E1 metric = cost(d->c) 20 + ext 20 = 40. ---
+    Then show command "show ip ospf route" in namespace "d" should contain "192.168.1.1/32"
+    And show command "show ip ospf route" in namespace "d" should contain "[40]"
+    # --- b: translated Type-5 advertised by ABR a, E1 metric =
+    #     cost(b->a) 10 + ext 20 = 30. The differing metric (30 vs 40)
+    #     is the proof E1's distance term survives translation. ---
+    And show command "show ip ospf route" in namespace "b" should contain "192.168.1.1/32"
+    And show command "show ip ospf route" in namespace "b" should contain "[30]"
+
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I stop zebra-rs in namespace "c"
+    And I stop zebra-rs in namespace "d"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    And I delete namespace "c"
+    And I delete namespace "d"
+    Then the test environment should be clean

--- a/bdd/tests/features/ospfv2_stub.feature
+++ b/bdd/tests/features/ospfv2_stub.feature
@@ -1,0 +1,83 @@
+@serial
+@ospfv2_stub
+Feature: OSPFv2 stub area drops Type-5 AS-External while keeping inter-area routes
+  As a network operator
+  I want zebra-rs to support OSPFv2 stub areas — E-bit adjacency
+  negotiation, AS-External (Type-5) LSAs excluded from the area, and
+  inter-area Type-3 summaries still flooded in — so that a stub router
+  learns inter-area destinations but is shielded from the external LSDB.
+
+  Three routers, two areas. The backbone (0.0.0.0) holds the ABR a and
+  the ASBR b; the stub (0.0.0.1) holds the internal router c hanging
+  off a.
+
+  Test Topology:
+  ```
+        area 0.0.0.0 (backbone)              area 0.0.0.1 (stub)
+    b (ASBR, 10.0.0.2) -- 10.0.12.0/30 -- a (ABR, 10.0.0.1) -- 10.0.13.0/30 -- c (10.0.0.3)
+    redistribute connected                                                      internal
+    -> Type-5
+
+    on router X the interface toward router Y is named "ethY".
+    loopbacks: a .1  b .2  c .3  (10.0.0.X/32).
+  ```
+
+  b redistributes a secondary loopback (192.168.1.1/32, added after
+  start) as a Type-5 AS-External LSA. The backbone router a installs it,
+  but `flood_lsa_through_as` skips stub areas, so the Type-5 never
+  reaches c — and external prefixes are not re-advertised as Type-3
+  either. The backbone loopback 10.0.0.2/32, by contrast, IS summarized
+  into the stub as a Type-3, so c reaches it across the area boundary.
+
+  Scenario: Stub router learns inter-area Type-3 but never the Type-5 external
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I create namespace "c"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I connect namespace "a" interface "ethc" to namespace "c" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I start zebra-rs in namespace "c"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I apply config "c.yaml" to namespace "c"
+    # Secondary loopback on the ASBR b: the external prefix redistributed
+    # as a Type-5.
+    And I add address "192.168.1.1/32" to interface "lo" in namespace "b"
+    # Allow Hellos + DBD (E-bit must match on the stub link), Type-5
+    # origination + backbone flood, Type-3 summary into the stub, and
+    # SPF/route install.
+    And I wait 60 seconds
+
+    # --- Adjacencies are Full (the stub link only comes up when the
+    #     E-bit matches between a and c). ---
+    Then show command "show ip ospf neighbor" in namespace "a" should contain "Full"
+    And show command "show ip ospf neighbor" in namespace "a" should contain "10.0.0.2"
+    And show command "show ip ospf neighbor" in namespace "a" should contain "10.0.0.3"
+    And show command "show ip ospf neighbor" in namespace "c" should contain "Full"
+    And show command "show ip ospf neighbor" in namespace "c" should contain "10.0.0.1"
+
+    # --- The backbone router a installs the Type-5 external. ---
+    And show command "show ip ospf route" in namespace "a" should contain "192.168.1.1/32"
+
+    # --- The stub router c learns the backbone loopback as an inter-area
+    #     Type-3 summary (stub still floods Type-3 inward). ---
+    And show command "show ip ospf route" in namespace "c" should contain "10.0.0.2/32"
+    # --- But c must NOT learn the Type-5 external: stub areas exclude
+    #     AS-External, and externals are not re-advertised as Type-3. ---
+    And show command "show ip ospf route" in namespace "c" should not contain "192.168.1.1/32"
+
+    # --- Reachability across the area boundary works (Type-3); the ABR,
+    #     which holds the Type-5, reaches the external. ---
+    And ping from "c" to "10.0.0.2" should succeed
+    And ping from "a" to "192.168.1.1" should succeed
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I stop zebra-rs in namespace "c"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    And I delete namespace "c"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

Broadens OSPFv2 area-type BDD coverage on top of the merged `@ospfv2_nssa` test (#1248). No production code changes — feature/config files + Makefile only.

### `@ospfv2_nssa` — 3 new scenarios (same 4-router topology, one knob each)
- **Totally-NSSA (`no-summary`)**: ABR suppresses every Type-3 into the area; `d` does NOT learn `10.0.0.2/32`, DOES hold the `0.0.0.0/0` default Type-7, and reaches the backbone via the default. Type-7 origination + translation still work.
- **Translator-role `never`**: negative control for translation — `d` still installs the in-area Type-7, but backbone router `b` must NOT learn it (no Type-5 produced; externals aren't summarized as Type-3).
- **E1 (`type-1`) metric**: metric grows with SPF distance and survives translation — `d` sees `[40]` (cost 20 to ASBR + 20), `b` sees `[30]` (cost 10 to translating ABR + 20).

Adds `a_totally.yaml`, `a_never.yaml`, `c_e1.yaml` (rest reuse existing per-router configs).

### `@ospfv2_stub` — new feature
ABR `a`, backbone ASBR `b` (redistributes a connected route as a Type-5), internal stub router `c`. The Type-5 floods the backbone (`a` installs it) but `flood_lsa_through_as` skips stub areas, so `c` never learns it — while still learning the backbone loopback as a Type-3. Asserts E-bit adjacency, `a`'s Type-5 install, `c`'s Type-3 install, `c`'s absence of the external, and inter-area reachability.

Adds `tests/configs/ospfv2_stub/{a,b,c}.yaml` and `make ospfv2_stub`.

## Test plan
- No Rust changed → CI fmt/clippy/test unaffected (green by construction).
- BDD is excluded from CI; run on demand after rebuilding/reinstalling `/usr/bin/zebra-rs`:
  - `make ospfv2_nssa` (now 4 scenarios)
  - `make ospfv2_stub`

Generated with [Claude Code](https://claude.com/claude-code)