### PR TITLE
bgp: fix unnumbered passive accept + show, add BDD test

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -115,6 +115,10 @@ bgp_neighbor_group:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_neighbor_group"
 
+bgp_unnumbered_neighbor:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_unnumbered_neighbor"
+
 generate:
 	rm -rf allure-report
 	allure generate
@@ -134,4 +138,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo ospf_clear_neighbor bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo ospf_clear_neighbor bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise bgp_neighbor_group bgp_unnumbered_neighbor generate open docs FORCE

--- a/bdd/docs/bgp_unnumbered_neighbor.md
+++ b/bdd/docs/bgp_unnumbered_neighbor.md
@@ -1,0 +1,48 @@
+# BGP IPv6 unnumbered neighbor discovered via Router Advertisements
+
+## Overview
+
+As a network operator running BGP over IPv6-only point-to-point links
+I want a peer keyed by its outbound interface (no configured remote
+address) to be discovered from the neighbour's Router Advertisement,
+establish a session over the link-local, and carry IPv4 routes via
+RFC 8950 Extended Next Hop Encoding.
+This exercises the full unnumbered path end-to-end through the
+YAML/YANG/CLI stack — ND RA send + receive, NeighborDiscovered →
+interface-keyed Peer materialization, the active-connect over
+fe80::%ifindex AND the passive accept that binds an inbound
+link-local connection back to its interface-keyed peer (both ends
+connect actively and accept passively, so a collision must resolve
+into a single Established session), and ENHE-carried IPv4 routes.
+
+## Test Topology
+
+```
+        (i1)                                   (i1)
+    ┌────┴────┐                            ┌────┴────┐
+    │   z1    │────────── P2P ─────────────│   z2    │
+    │ AS65001 │       fe80:: <-> fe80::    │ AS65002 │
+    │ id 1.1. │                            │ id 2.2. │
+    │   1.1   │                            │   2.2   │
+    └─────────┘                            └─────────┘
+```
+
+## Config Files
+
+- z1-base.yaml / z2-base.yaml: a bare `router bgp` block — spawns ND
+- z1-full.yaml / z2-full.yaml: enable `send-advertisements` on i1,
+
+Note: the interface-keyed peer's remote address is a kernel-assigned
+link-local that the scenario can't name, so the session is asserted
+with the address-agnostic "BGP session in namespace … should
+eventually be …" step (it reads `show ip bgp neighbors`, which lists
+interface-keyed peers).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology | |
+| RA discovery establishes the unnumbered session and exchanges IPv4 routes | |
+| Removing the interface-neighbor tears the session down | |
+| Teardown topology | |

--- a/bdd/tests/configs/bgp_unnumbered_neighbor/z1-base.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_neighbor/z1-base.yaml
@@ -1,0 +1,13 @@
+# Phase 1 of the two-step bring-up: a bare `router bgp` block with no
+# neighbors. Applying this first spawns the ND subsystem (ND is spawned
+# eagerly on the first `router bgp` line) so it subscribes to the RIB
+# and learns interface i1 BEFORE the next commit enables RA on it. The
+# per-interface `send-advertisements` callback silently drops if ND
+# hasn't yet learned the link, and it is not re-evaluated on a later
+# link-add — so without this warm-up the RA-enable could lose the race
+# against the RIB link replay and never arm the transmitter.
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 1.1.1.1

--- a/bdd/tests/configs/bgp_unnumbered_neighbor/z1-full.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_neighbor/z1-full.yaml
@@ -1,0 +1,25 @@
+# Phase 2: enable Router Advertisements on i1 and declare the
+# interface-keyed (IPv6 unnumbered) neighbor. The peer is materialized
+# only when an RA is received on i1 (the peer's link-local is learned
+# from it), so RA send must be on at BOTH ends. `remote-as` is numeric
+# (not `external`) because the `external` placeholder leaves the peer
+# dormant until OPEN-side AS backfill lands. The IPv4 network is
+# advertised over the link-local session via RFC 8950 ENHE, which is
+# auto-negotiated for interface-keyed peers.
+interface:
+- if-name: i1
+  ipv6:
+    router-advertisements:
+      send-advertisements: true
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 1.1.1.1
+    interface-neighbor:
+    - interface: i1
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_unnumbered_neighbor/z2-base.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_neighbor/z2-base.yaml
@@ -1,0 +1,6 @@
+# Phase 1 for z2 — see z1-base.yaml for the warm-up rationale.
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 2.2.2.2

--- a/bdd/tests/configs/bgp_unnumbered_neighbor/z2-full.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_neighbor/z2-full.yaml
@@ -1,0 +1,18 @@
+# Phase 2 for z2 — mirror of z1-full.yaml with the AS numbers swapped.
+interface:
+- if-name: i1
+  ipv6:
+    router-advertisements:
+      send-advertisements: true
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 2.2.2.2
+    interface-neighbor:
+    - interface: i1
+      remote-as: 65001
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.2/32

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -546,6 +546,82 @@ async fn verify_bgp_session_not(
     );
 }
 
+/// Poll `show ip bgp neighbors` (all peers, JSON) until some peer's
+/// `state` matches `expected` (`want_match = true`) or no peer matches
+/// it (`want_match = false`). Returns `(satisfied, last_output)`.
+///
+/// Unlike [`verify_bgp_session`], this matches on state across whatever
+/// peers exist instead of by remote address — IPv6-unnumbered
+/// (`interface-neighbor`) peers are keyed by interface and their remote
+/// link-local is a kernel-assigned address the scenario can't name. The
+/// topologies that use this step have exactly one peer, so "some peer"
+/// is unambiguous. Polling (rather than a fixed wait) absorbs the RA
+/// discovery delay, which is bounded but not instant.
+async fn poll_unnumbered_session_state(
+    scoped: &str,
+    expected: &str,
+    want_match: bool,
+) -> (bool, String) {
+    const ATTEMPTS: u32 = 60;
+    let mut last = String::new();
+    for i in 0..ATTEMPTS {
+        last = netns::exec_in_netns(scoped, "vtyctl", &["show", "-j", "show ip bgp neighbors"])
+            .await
+            .expect("Failed to get BGP neighbors");
+        let matched = serde_json::from_str::<Value>(&last)
+            .ok()
+            .and_then(|v| {
+                v.as_array().map(|peers| {
+                    peers.iter().any(|peer| {
+                        peer.get("state")
+                            .and_then(|s| s.as_str())
+                            .is_some_and(|s| s.eq_ignore_ascii_case(expected))
+                    })
+                })
+            })
+            .unwrap_or(false);
+        if matched == want_match {
+            return (true, last);
+        }
+        if i + 1 < ATTEMPTS {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    }
+    (false, last)
+}
+
+#[then(expr = "BGP session in namespace {string} should eventually be {string}")]
+async fn verify_unnumbered_session_eventually(
+    world: &mut World,
+    namespace: String,
+    expected_state: String,
+) {
+    let scoped = world.ns(&namespace);
+    let (ok, last) = poll_unnumbered_session_state(&scoped, &expected_state, true).await;
+    assert!(
+        ok,
+        "no BGP peer in {} reached state {}; last neighbors output:\n{}",
+        scoped, expected_state, last
+    );
+    println!("✓ BGP session in {} reached {}", scoped, expected_state);
+}
+
+#[then(expr = "BGP session in namespace {string} should eventually not be {string}")]
+async fn verify_unnumbered_session_eventually_not(
+    world: &mut World,
+    namespace: String,
+    unexpected_state: String,
+) {
+    let scoped = world.ns(&namespace);
+    let (ok, last) = poll_unnumbered_session_state(&scoped, &unexpected_state, false).await;
+    assert!(
+        ok,
+        "a BGP peer in {} stayed in state {}; last neighbors output:\n{}",
+        scoped, unexpected_state, last
+    );
+    println!("✓ no BGP session in {} is {}", scoped, unexpected_state);
+}
+
 #[then(expr = "BGP route in {string} has {string}")]
 async fn verify_bgp_route(world: &mut World, namespace: String, expected_prefix: String) {
     let scoped = world.ns(&namespace);

--- a/bdd/tests/features/bgp_unnumbered_neighbor.feature
+++ b/bdd/tests/features/bgp_unnumbered_neighbor.feature
@@ -1,0 +1,76 @@
+@serial
+@bgp_unnumbered_neighbor
+Feature: BGP IPv6 unnumbered neighbor discovered via Router Advertisements
+  As a network operator running BGP over IPv6-only point-to-point links
+  I want a peer keyed by its outbound interface (no configured remote
+  address) to be discovered from the neighbour's Router Advertisement,
+  establish a session over the link-local, and carry IPv4 routes via
+  RFC 8950 Extended Next Hop Encoding.
+
+  This exercises the full unnumbered path end-to-end through the
+  YAML/YANG/CLI stack — ND RA send + receive, NeighborDiscovered →
+  interface-keyed Peer materialization, the active-connect over
+  fe80::%ifindex AND the passive accept that binds an inbound
+  link-local connection back to its interface-keyed peer (both ends
+  connect actively and accept passively, so a collision must resolve
+  into a single Established session), and ENHE-carried IPv4 routes.
+
+  Test Topology (point-to-point veth, link-local only — no global addrs):
+  ```
+        (i1)                                   (i1)
+    ┌────┴────┐                            ┌────┴────┐
+    │   z1    │────────── P2P ─────────────│   z2    │
+    │ AS65001 │       fe80:: <-> fe80::    │ AS65002 │
+    │ id 1.1. │                            │ id 2.2. │
+    │   1.1   │                            │   2.2   │
+    └─────────┘                            └─────────┘
+  ```
+
+  Config files:
+  - z1-base.yaml / z2-base.yaml: a bare `router bgp` block — spawns ND
+    so it learns i1 before RA is enabled (see the files for the race
+    this two-step bring-up avoids).
+  - z1-full.yaml / z2-full.yaml: enable `send-advertisements` on i1,
+    declare `interface-neighbor i1 remote-as N`, and advertise one
+    IPv4 /32 (10.0.0.1/32 from z1, 10.0.0.2/32 from z2).
+
+  Note: the interface-keyed peer's remote address is a kernel-assigned
+  link-local that the scenario can't name, so the session is asserted
+  with the address-agnostic "BGP session in namespace … should
+  eventually be …" step (it reads `show ip bgp neighbors`, which lists
+  interface-keyed peers).
+
+  Scenario: Setup topology
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-base.yaml" to namespace "z1"
+    And I apply config "z2-base.yaml" to namespace "z2"
+    And I wait 2 seconds
+
+  Scenario: RA discovery establishes the unnumbered session and exchanges IPv4 routes
+    Given the test topology exists
+    When I apply config "z1-full.yaml" to namespace "z1"
+    And I apply config "z2-full.yaml" to namespace "z2"
+    Then BGP session in namespace "z1" should eventually be "Established"
+    And BGP session in namespace "z2" should eventually be "Established"
+    And I wait 5 seconds
+    And BGP route in "z2" has "10.0.0.1/32"
+    And BGP route in "z1" has "10.0.0.2/32"
+
+  Scenario: Removing the interface-neighbor tears the session down
+    Given the test topology exists
+    When I apply config "z1-base.yaml" to namespace "z1"
+    Then BGP session in namespace "z1" should eventually not be "Established"
+    And BGP session in namespace "z2" should eventually not be "Established"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -13,7 +13,7 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use bgp_packet::*;
 
-use super::peer_key::PeerOrigin;
+use super::peer_key::{PeerKey, PeerOrigin};
 use super::peer_map::PeerMap;
 
 use caps::CapAs4;
@@ -1720,13 +1720,34 @@ fn start_collision_conn(peer: &mut Peer, stream: TcpStream) {
     let _ = packet_tx.send(bytes);
 }
 
-/// Handle incoming connection for a peer based on current BGP state
+/// Handle incoming connection for a peer based on current BGP state.
+///
+/// `scope_id` is the IPv6 scope of the accepted socket — for a
+/// link-local source it is the arrival ifindex, which is how an
+/// IPv6-unnumbered (`interface-neighbor`) peer is keyed. The lookup
+/// prefers an address-keyed peer (numbered + dynamic peers, which is
+/// every non-unnumbered case) and only falls back to the
+/// interface-keyed peer when the source has no address-keyed match —
+/// an unnumbered peer's remote link-local is never written into the
+/// address map, so an inbound connection from it would otherwise be
+/// dropped, and the session (both ends connect actively *and* accept
+/// passively) could never resolve a collision into Established.
 fn handle_peer_connection(
     bgp: &mut Bgp,
     peer_addr: IpAddr,
+    scope_id: Option<u32>,
     stream: TcpStream,
 ) -> Option<TcpStream> {
-    if let Some(peer) = bgp.peers.get_mut(&peer_addr) {
+    let key = if bgp.peers.get(&peer_addr).is_some() {
+        PeerKey::Addr(peer_addr)
+    } else if let Some(ifindex) = scope_id
+        && bgp.peers.get_by_key(&PeerKey::Interface(ifindex)).is_some()
+    {
+        PeerKey::Interface(ifindex)
+    } else {
+        return Some(stream);
+    };
+    if let Some(peer) = bgp.peers.get_mut_by_key(&key) {
         match peer.state {
             State::Idle => {
                 // No session established yet - just drop (sends TCP RST/FIN)
@@ -1776,7 +1797,16 @@ pub fn accept(bgp: &mut Bgp, stream: TcpStream, sockaddr: SocketAddr) {
         SocketAddr::V4(addr) => IpAddr::V4(*addr.ip()),
         SocketAddr::V6(addr) => IpAddr::V6(*addr.ip()),
     };
-    let mut remaining_stream = handle_peer_connection(bgp, peer_addr, stream);
+    // For an IPv6-unnumbered (`interface-neighbor`) peer the inbound
+    // connection is matched by the arrival interface, not the source
+    // address (a link-local we never recorded). The accepted socket's
+    // IPv6 sockaddr carries that ifindex as its scope_id; a non
+    // link-local source has scope_id 0 and is matched by address only.
+    let scope_id = match sockaddr {
+        SocketAddr::V6(addr) if addr.scope_id() != 0 => Some(addr.scope_id()),
+        _ => None,
+    };
+    let mut remaining_stream = handle_peer_connection(bgp, peer_addr, scope_id, stream);
 
     // Static lookup missed — try a configured listen-range. If LPM
     // hits and the per-range neighbor-group resolves to a usable
@@ -1833,7 +1863,9 @@ fn try_dynamic_accept(bgp: &mut Bgp, peer_addr: IpAddr, stream: TcpStream) -> Op
     bgp.peers.insert(peer_addr, peer);
     bgp.dynamic_peer_count += 1;
 
-    handle_peer_connection(bgp, peer_addr, stream)
+    // Dynamic (listen-range) peers are always address-keyed, so no
+    // interface scope is needed here.
+    handle_peer_connection(bgp, peer_addr, None, stream)
 }
 
 /// Replay Adj-RIB-In through the current inbound policy for `peer_idx`,

--- a/zebra-rs/src/bgp/peer_map.rs
+++ b/zebra-rs/src/bgp/peer_map.rs
@@ -96,6 +96,17 @@ impl PeerMap {
             })
     }
 
+    /// Iterate every peer regardless of key variant. Unlike
+    /// [`Self::iter`], this includes `PeerKey::Interface` (IPv6
+    /// unnumbered) peers — `show ip bgp neighbors` needs them so an
+    /// operator can observe an interface-keyed session whose remote
+    /// link-local address isn't something they can name.
+    pub fn iter_all(&self) -> impl Iterator<Item = (&PeerKey, &Peer)> {
+        self.map
+            .iter()
+            .filter_map(move |(key, &idx)| self.peers[idx].as_ref().map(|peer| (key, peer)))
+    }
+
     /// Iterate every peer regardless of key variant, mutable.
     pub fn iter_mut_all(&mut self) -> impl Iterator<Item = (&PeerKey, &mut Peer)> {
         let map = &self.map;
@@ -170,6 +181,7 @@ mod tests {
         );
 
         assert_eq!(m.iter().count(), 1, "addr-only iter skips interface peer");
+        assert_eq!(m.iter_all().count(), 2, "iter_all includes interface peer");
         assert_eq!(m.iter_mut_all().count(), 2, "iter_mut_all includes both");
         assert_eq!(m.len(), 2);
     }

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2014,7 +2014,10 @@ fn show_bgp_neighbor<V: BgpShowView>(
 
     if args.is_empty() {
         let mut neighbors = Vec::<Neighbor>::new();
-        for (_, peer) in bgp.peers().iter() {
+        // `iter_all` (not `iter`) so IPv6-unnumbered, interface-keyed
+        // peers are listed too — they're invisible to the address-keyed
+        // `iter`, and an operator has no remote address to query them by.
+        for (_, peer) in bgp.peers().iter_all() {
             neighbors.push(fetch(peer));
         }
         if json {


### PR DESCRIPTION
## Summary

The IPv6 unnumbered (`interface-neighbor`) feature was in tree but **could never reach `Established`** — reading the runtime end-to-end surfaced two control-plane gaps, both fixed here, plus the first end-to-end BDD test.

### Gap 1 — passive accept couldn't bind interface-keyed peers (the real blocker)
Both unnumbered ends connect *actively* and must also accept *passively*, but `accept()` / `handle_peer_connection()` looked peers up only by `PeerKey::Addr` (`bgp.peers.get(&peer_addr)`), never `PeerKey::Interface`. So each side dropped the other's inbound link-local connection → no session. Fix: `accept()` extracts the arrival ifindex from the accepted IPv6 sockaddr's `scope_id`, and the handler falls back to `PeerKey::Interface(scope_id)` when the address lookup misses. Collision resolution (RFC 4271 §6.8, by BGP-ID) is unchanged, so router-ids must be set and distinct.

### Gap 2 — interface peers invisible to show
`PeerMap::iter()` deliberately skips `PeerKey::Interface`, so `show ip bgp neighbors` never listed an unnumbered peer. Added an immutable `PeerMap::iter_all()` and switched the no-arg `show ip bgp neighbors` loop to it. (`show ip bgp summary` visibility left as a follow-up.)

### BDD test (`@bgp_unnumbered_neighbor`)
P2P veth `i1<->i1`, link-local only: RA discovery → session Established (address-agnostic polling step) → IPv4-over-ENHE route exchange → config-removal teardown. Non-obvious constraints baked in:
- **Two-phase apply** — ND's `send-advertisements` drops silently if it hasn't learned the link yet and never re-evaluates, so a bare `router bgp` base config pre-spawns ND before RA is enabled.
- **16 s RA initial delay** is deterministic (defaults clamp to `MAX_INITIAL_RTR_ADVERT_INTERVAL`); the polling step allows 60 s.
- **No RA re-discovery scenarios** (periodic RAs are 200–600 s apart), so teardown is via config removal.

## Test plan
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs --bins` — bgp (269) + peer_map/interface_neighbor (8) pass
- BDD cucumber test compiles; `make bgp_unnumbered_neighbor` target added. CI runs the BDD suite (the live validation).

## Follow-ups (out of scope)
- `remote-as external` still materializes dormant (`remote_as=0`, OPEN-side AS backfill not wired) — the test uses numeric `remote-as`.
- `show ip bgp summary` interface-peer visibility.

Generated with [Claude Code](https://claude.com/claude-code)