### PR TITLE
bgp: fix interface-neighbor numeric remote-as (YANG union rejected it)

### DIFF
--- a/zebra-rs/yang/zebra-bgp-interface-neighbor.yang
+++ b/zebra-rs/yang/zebra-bgp-interface-neighbor.yang
@@ -4,10 +4,6 @@ module zebra-bgp-interface-neighbor {
   namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-interface-neighbor";
   prefix "zbin";
 
-  import ietf-inet-types {
-    prefix inet;
-  }
-
   import config {
     prefix config;
   }
@@ -63,31 +59,6 @@ module zebra-bgp-interface-neighbor {
           codec is already in tree (#618); wiring it on for
           interface peers is a follow-up.";
 
-  typedef remote-as-type {
-    type union {
-      type inet:as-number;
-      type enumeration {
-        enum external {
-          description
-            "FRR-style shorthand — the remote AS is anything other
-             than the local one. Resolved at session-establishment
-             time; the session is eBGP if the OPEN's AS matches the
-             local ASN this is treated as a config error.";
-        }
-        enum internal {
-          description
-            "FRR-style shorthand — the remote AS equals the local
-             ASN. iBGP session.";
-        }
-      }
-    }
-    description
-      "Remote AS specification. Accepts either a numeric AS (matching
-       the regular `neighbor X remote-as N` form) or the FRR shorthand
-       `external` / `internal`. Unnumbered configs are noisier without
-       the shorthand.";
-  }
-
   grouping bgp-interface-neighbor-extension {
     description
       "Container hung off `router bgp`.";
@@ -118,12 +89,23 @@ module zebra-bgp-interface-neighbor {
            zebra-bgp-* augments.";
       }
       leaf remote-as {
-        type remote-as-type;
+        type string;
         description
-          "Remote AS. May be omitted if the referenced
-           `neighbor-group` carries one; otherwise mandatory at
-           session-establishment time (an unset value silently
-           prevents materialization).";
+          "Remote AS. Accepts either a numeric AS number (matching the
+           regular `neighbor X remote-as N` form) or the FRR-style
+           shorthand `external` / `internal`; the per-leaf callback
+           (`config_interface_neighbor_remote_as`) validates and
+           interprets the three forms. A plain `string` rather than a
+           `union { inet:as-number; enumeration … }` because the YANG
+           engine's union validation matches only the enumeration arm
+           and rejects the numeric arm, so the union form makes a
+           numeric `remote-as` unconfigurable.
+
+           `external` resolves the remote AS from the peer's OPEN (it
+           materializes a dormant placeholder until OPEN-side backfill
+           lands); `internal` resolves to the local ASN (iBGP). May be
+           omitted if the referenced `neighbor-group` carries one;
+           otherwise an unset value silently prevents materialization.";
       }
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to #1250. The unnumbered BDD test's **establish scenario failed** at config apply:

```
error reply: set router bgp interface-neighbor i1 remote-as 65002
```

### Root cause
The `interface-neighbor` `remote-as` leaf used a `union { inet:as-number; enumeration { external internal } }`. The YANG engine's union validation matches only the **enumeration** arm and rejects the **numeric** arm — so `remote-as external` / `internal` applied fine, but a numeric `remote-as 65002` was refused at the set/validation stage, making a working unnumbered config impossible. Reproduced directly against a local daemon (numeric and quoted-numeric both rejected; both enum forms accepted).

### Fix
Make the leaf a plain `string`. The existing `config_interface_neighbor_remote_as` callback already validates and interprets all three forms (numeric / `external` / `internal`), so it becomes the validator. Dropped the now-unused `remote-as-type` typedef and the `ietf-inet-types` import. (libyang is an external pinned fork, so fixing its union validation is out of scope.)

## Test plan
- `cargo test -p zebra-rs --bins -- yang_load` — both load tests pass (import/typedef removal is valid).
- Reproduced the rejection, applied the fix, and re-verified with a **two-namespace end-to-end bring-up** using the actual BDD configs:
  - numeric `remote-as 65002` now applies;
  - both ends reach **Established** (~14 s, after the RA initial burst);
  - IPv4 routes propagate **both ways** over the link-local session via RFC 8950 ENHE (`z2` learns `10.0.0.1/32`, `z1` learns `10.0.0.2/32`).

Note: the BDD suite is excluded from CI and run manually — re-running `make bgp_unnumbered_neighbor` needs the rebuilt daemon **and** this updated YANG deployed to the daemon's yang load path.

Generated with [Claude Code](https://claude.com/claude-code)