### PR TITLE
bgp: restore typed interface-neighbor remote-as union (libyang fix)

### DIFF
--- a/zebra-rs/Cargo.toml
+++ b/zebra-rs/Cargo.toml
@@ -19,7 +19,7 @@ tokio-stream.workspace = true
 tonic.workspace = true
 tonic-prost.workspace = true
 console-subscriber = "0.5"
-libyang = { git = "https://github.com/zebra-rs/libyang", rev = "89142f0e50616087e1f48fd85abd84e943f1be26" }
+libyang = { git = "https://github.com/zebra-rs/libyang", rev = "103b60c2d560a91d37fa26502eb3d495db1cdb99" }
 #libyang = { path = "../../libyang" }
 regex = "1.10"
 similar = "3"

--- a/zebra-rs/yang/zebra-bgp-interface-neighbor.yang
+++ b/zebra-rs/yang/zebra-bgp-interface-neighbor.yang
@@ -4,6 +4,10 @@ module zebra-bgp-interface-neighbor {
   namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-interface-neighbor";
   prefix "zbin";
 
+  import ietf-inet-types {
+    prefix inet;
+  }
+
   import config {
     prefix config;
   }
@@ -59,6 +63,31 @@ module zebra-bgp-interface-neighbor {
           codec is already in tree (#618); wiring it on for
           interface peers is a follow-up.";
 
+  typedef remote-as-type {
+    type union {
+      type inet:as-number;
+      type enumeration {
+        enum external {
+          description
+            "FRR-style shorthand — the remote AS is anything other
+             than the local one. Resolved at session-establishment
+             time; the session is eBGP if the OPEN's AS matches the
+             local ASN this is treated as a config error.";
+        }
+        enum internal {
+          description
+            "FRR-style shorthand — the remote AS equals the local
+             ASN. iBGP session.";
+        }
+      }
+    }
+    description
+      "Remote AS specification. Accepts either a numeric AS (matching
+       the regular `neighbor X remote-as N` form) or the FRR shorthand
+       `external` / `internal`. Unnumbered configs are noisier without
+       the shorthand.";
+  }
+
   grouping bgp-interface-neighbor-extension {
     description
       "Container hung off `router bgp`.";
@@ -89,23 +118,12 @@ module zebra-bgp-interface-neighbor {
            zebra-bgp-* augments.";
       }
       leaf remote-as {
-        type string;
+        type remote-as-type;
         description
-          "Remote AS. Accepts either a numeric AS number (matching the
-           regular `neighbor X remote-as N` form) or the FRR-style
-           shorthand `external` / `internal`; the per-leaf callback
-           (`config_interface_neighbor_remote_as`) validates and
-           interprets the three forms. A plain `string` rather than a
-           `union { inet:as-number; enumeration … }` because the YANG
-           engine's union validation matches only the enumeration arm
-           and rejects the numeric arm, so the union form makes a
-           numeric `remote-as` unconfigurable.
-
-           `external` resolves the remote AS from the peer's OPEN (it
-           materializes a dormant placeholder until OPEN-side backfill
-           lands); `internal` resolves to the local ASN (iBGP). May be
-           omitted if the referenced `neighbor-group` carries one;
-           otherwise an unset value silently prevents materialization.";
+          "Remote AS. May be omitted if the referenced
+           `neighbor-group` carries one; otherwise mandatory at
+           session-establishment time (an unset value silently
+           prevents materialization).";
       }
     }
   }


### PR DESCRIPTION
## Summary

Proper root-cause fix for the unnumbered BDD failure, replacing the `string` stop-gap from #1251.

The real bug was in libyang: `type_union_resolve` (the resolution path for a leaf whose type is a **typedef** whose base is a union) kept only `String`/`Union` arms and **silently dropped a Path arm resolving to a numeric type** (`inet:as-number` → `uint32`). So `remote-as external`/`internal` validated but numeric `remote-as 65002` was rejected. Fixed in **zebra-rs/libyang#25** (merged, with a regression test).

This PR:
- Bumps the pinned libyang rev to `103b60c` (the merged fix).
- Reverts the `remote-as` leaf from the `string` stop-gap (#1251) back to its proper `union { inet:as-number; enumeration { external internal } }`, restoring type checking and `external`/`internal` completion.

## Test plan
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check`, `cargo test -p zebra-rs --bins -- yang_load` — all clean.
- Verified end-to-end against a local daemon: with the typed union, `remote-as 65002`, `external`, and `internal` all apply; an invalid value (`bogusXYZ`) is refused.

Note: Cargo.lock is gitignored here; the exact `rev` pin makes the libyang resolution deterministic. As before, the BDD suite is run manually (excluded from CI) and needs the rebuilt daemon + this YANG deployed to the daemon's load path.

Generated with [Claude Code](https://claude.com/claude-code)