### PR TITLE
nd: disable IPV6_MULTICAST_LOOP (router ignores its own RAs)

### DIFF
--- a/zebra-rs/src/nd/socket.rs
+++ b/zebra-rs/src/nd/socket.rs
@@ -45,6 +45,8 @@ pub enum SocketError {
     Create(io::Error),
     #[error("set IPV6_MULTICAST_HOPS=255 failed: {0}")]
     MulticastHops(io::Error),
+    #[error("set IPV6_MULTICAST_LOOP=0 failed: {0}")]
+    MulticastLoop(io::Error),
     #[error("set IPV6_UNICAST_HOPS=255 failed: {0}")]
     UnicastHops(io::Error),
     #[error("set IPV6_RECVHOPLIMIT failed: {0}")]
@@ -68,6 +70,17 @@ pub fn nd_socket() -> Result<AsyncFd<Socket>, SocketError> {
     socket.set_nonblocking(true).map_err(SocketError::Create)?;
 
     set_multicast_hops_255(&socket).map_err(SocketError::MulticastHops)?;
+    // Disable loopback of our own multicast sends. The ND engine uses
+    // this single raw socket for both RA transmit and receive; with the
+    // kernel default (loop ON) every unsolicited RA we multicast to
+    // ff02::1 is delivered straight back to us, and the receive path
+    // then emits a `NeighborDiscovered` for our *own* link-local. For
+    // BGP unnumbered that materializes a bogus peer pointing at
+    // ourselves (and, since the peer address is refreshed on each RA,
+    // the real peer races the self-RA non-deterministically) — so the
+    // session never reliably establishes. A router must not consume its
+    // own RAs; turn the loopback off.
+    set_multicast_loop_off(&socket).map_err(SocketError::MulticastLoop)?;
     set_unicast_hops_255(&socket).map_err(SocketError::UnicastHops)?;
     set_recv_hop_limit(&socket).map_err(SocketError::RecvHopLimit)?;
     set_recv_pkt_info(&socket).map_err(SocketError::RecvPktInfo)?;
@@ -87,6 +100,18 @@ fn set_multicast_hops_255(s: &Socket) -> io::Result<()> {
             s.as_raw_fd(),
             libc::IPPROTO_IPV6,
             libc::IPV6_MULTICAST_HOPS,
+            v,
+        )
+    }
+}
+
+fn set_multicast_loop_off(s: &Socket) -> io::Result<()> {
+    let v: c_int = 0;
+    unsafe {
+        setsockopt_int(
+            s.as_raw_fd(),
+            libc::IPPROTO_IPV6,
+            libc::IPV6_MULTICAST_LOOP,
             v,
         )
     }


### PR DESCRIPTION
## Summary

Final fix for the BGP unnumbered session not establishing.

The ND engine uses a single raw ICMPv6 socket for both RA **transmit** and **receive**. With the kernel default (`IPV6_MULTICAST_LOOP` ON), every unsolicited RA we multicast to `ff02::1` is looped straight back to our own receive path, which emits a `NeighborDiscovered` for **our own** link-local. For BGP unnumbered, `interface_neighbor::materialize_peer` then creates a peer pointing at *ourselves* — and because it refreshes the peer address on every RA, the real peer's RA and the self-RA race **non-deterministically**. Observed: `z2` ended up with its own link-local as the peer address and sat in `Active`, connecting to itself, so the session never established.

A router must not consume its own RAs. Set `IPV6_MULTICAST_LOOP=0` on the ND socket.

## How it was found
The unnumbered BDD's establish scenario was flaky/failing even after the config-validation fixes (#1250–#1252). A two-namespace bring-up showed `z2`'s peer address == `z2`'s own link-local, with only self↔self TCP churn on :179.

## Test plan
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- Two-namespace bring-up with the real BDD configs, using the deployed release binary launched exactly as the BDD does (no `--yang-path`, as root): **3/3 runs** reach Established (~24 s after the RA burst) and exchange IPv4 routes both ways (`z2`←`10.0.0.1/32`, `z1`←`10.0.0.2/32`). Before this fix establishment was a coin flip.

Generated with [Claude Code](https://claude.com/claude-code)