### PR TITLE
rib: deliver connected routes to redistribute consumers

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -1549,6 +1549,29 @@ async fn add_address_to_interface(
     );
 }
 
+/// Create a standalone dummy interface (not wired into any OSPF/IS-IS
+/// area) and give it an address. The resulting connected route is a
+/// genuine *external* prefix for redistribution tests — unlike an
+/// address added to an OSPF-enabled interface, which OSPF advertises as
+/// an intra-area stub and would mask the redistributed external LSA.
+#[when(expr = "I create dummy interface {string} with address {string} in namespace {string}")]
+async fn create_dummy_interface(world: &mut World, iface: String, addr: String, namespace: String) {
+    let scoped = world.ns(&namespace);
+    netns::exec_in_netns(&scoped, "ip", &["link", "add", &iface, "type", "dummy"])
+        .await
+        .expect("Failed to create dummy interface");
+    netns::exec_in_netns(&scoped, "ip", &["link", "set", &iface, "up"])
+        .await
+        .expect("Failed to set dummy interface up");
+    netns::exec_in_netns(&scoped, "ip", &["addr", "add", &addr, "dev", &iface])
+        .await
+        .expect("Failed to add address to dummy interface");
+    println!(
+        "✓ Created dummy interface {} ({}) in namespace {}",
+        iface, addr, scoped
+    );
+}
+
 #[then("the test environment should be clean")]
 async fn verify_clean_environment(world: &mut World) {
     if keep_topology() {

--- a/bdd/tests/features/ospfv2_nssa.feature
+++ b/bdd/tests/features/ospfv2_nssa.feature
@@ -31,12 +31,16 @@ Feature: OSPFv2 NSSA (Not-So-Stubby Area) Type-7 origination and translation
     loopbacks: a .1  b .2  c .3  d .4  (10.0.0.X/32).
   ```
 
-  The external prefix is a secondary loopback (192.168.1.1/32) added to
-  c's lo AFTER zebra-rs starts; it is not registered under any OSPF
-  area, so it enters OSPF only via c's per-area `redistribute connected`
-  as a Type-7. c is a pure ASBR (not an ABR), so it sets the Type-7
-  P-bit. The flood is area-scoped: d installs it directly, and the ABR
-  a — the elected (sole-ABR, default `candidate` role) NSSA translator —
+  The external prefix is a connected network (192.168.1.0/24) on a
+  standalone dummy interface "cust0" added to c AFTER zebra-rs starts.
+  It is NOT on any OSPF-enabled interface, so it is a genuine external
+  route — it enters OSPF only via c's per-area `redistribute connected`
+  as a Type-7. (An address on an OSPF-enabled interface would instead be
+  advertised as an intra-area stub and summarized as a Type-3, masking
+  the Type-7 path entirely.) c is a pure ASBR (not an ABR), so it sets
+  the Type-7 P-bit. The flood is area-scoped: d installs it directly,
+  and the ABR a — the elected (sole-ABR, default `candidate` role)
+  NSSA translator —
   re-originates it as a Type-5 AS-External into the backbone, where b
   installs it. b carries no NSSA link, so a Type-5 is the only way the
   prefix can reach it: its presence on b is the proof the translator ran.
@@ -66,7 +70,7 @@ Feature: OSPFv2 NSSA (Not-So-Stubby Area) Type-7 origination and translation
     # Secondary loopback on c: the external prefix redistributed into
     # the NSSA as a Type-7. Not under any OSPF area, so it can only
     # enter via `redistribute connected`.
-    And I add address "192.168.1.1/32" to interface "lo" in namespace "c"
+    And I create dummy interface "cust0" with address "192.168.1.1/24" in namespace "c"
     # Allow Hellos + DBD on every link (N-bit must match on the NSSA
     # links), then Type-7 origination + flood, the ABR's Type-7->Type-5
     # translation + AS-wide flood, and SPF/route install everywhere.
@@ -83,14 +87,14 @@ Feature: OSPFv2 NSSA (Not-So-Stubby Area) Type-7 origination and translation
 
     # --- Type-7 inside the NSSA: d (plain internal router) installs the
     #     external prefix straight from c's Type-7, E2 metric [20]. ---
-    And show command "show ip ospf route" in namespace "d" should contain "192.168.1.1/32"
+    And show command "show ip ospf route" in namespace "d" should contain "192.168.1.0/24"
     And show command "show ip ospf route" in namespace "d" should contain "[20]"
 
     # --- The headline: Type-7 -> Type-5 translation at the ABR. b is in
-    #     the backbone only, so it can learn 192.168.1.1/32 ONLY as a
+    #     the backbone only, so it can learn 192.168.1.0/24 ONLY as a
     #     translated Type-5 (the Type-7 never leaves the NSSA). Same E2
     #     metric [20], carried verbatim across the translation. ---
-    And show command "show ip ospf route" in namespace "b" should contain "192.168.1.1/32"
+    And show command "show ip ospf route" in namespace "b" should contain "192.168.1.0/24"
     And show command "show ip ospf route" in namespace "b" should contain "[20]"
 
     # --- ABR default-originate: a injects a default Type-7 into the
@@ -146,7 +150,7 @@ Feature: OSPFv2 NSSA (Not-So-Stubby Area) Type-7 origination and translation
     And I apply config "b.yaml" to namespace "b"
     And I apply config "c.yaml" to namespace "c"
     And I apply config "d.yaml" to namespace "d"
-    And I add address "192.168.1.1/32" to interface "lo" in namespace "c"
+    And I create dummy interface "cust0" with address "192.168.1.1/24" in namespace "c"
     And I wait 60 seconds
 
     # --- The default Type-7 is still injected, so d holds a 0.0.0.0/0. ---
@@ -156,8 +160,8 @@ Feature: OSPFv2 NSSA (Not-So-Stubby Area) Type-7 origination and translation
     And show command "show ip ospf route" in namespace "d" should not contain "10.0.0.2/32"
     # --- Type-7 still floods in-area, and translation still reaches the
     #     backbone — `no-summary` touches only the inbound Type-3 path. ---
-    And show command "show ip ospf route" in namespace "d" should contain "192.168.1.1/32"
-    And show command "show ip ospf route" in namespace "b" should contain "192.168.1.1/32"
+    And show command "show ip ospf route" in namespace "d" should contain "192.168.1.0/24"
+    And show command "show ip ospf route" in namespace "b" should contain "192.168.1.0/24"
     # --- d reaches the backbone loopback purely via the default route. ---
     And ping from "d" to "10.0.0.2" should succeed
 
@@ -194,15 +198,15 @@ Feature: OSPFv2 NSSA (Not-So-Stubby Area) Type-7 origination and translation
     And I apply config "b.yaml" to namespace "b"
     And I apply config "c.yaml" to namespace "c"
     And I apply config "d.yaml" to namespace "d"
-    And I add address "192.168.1.1/32" to interface "lo" in namespace "c"
+    And I create dummy interface "cust0" with address "192.168.1.1/24" in namespace "c"
     And I wait 60 seconds
 
     # --- Intra-NSSA Type-7 install is unchanged: d still learns it. ---
-    Then show command "show ip ospf route" in namespace "d" should contain "192.168.1.1/32"
+    Then show command "show ip ospf route" in namespace "d" should contain "192.168.1.0/24"
     # --- But with translation disabled the prefix never reaches the
     #     backbone: b has no Type-5 for it and externals are not
     #     summarized as Type-3, so b must NOT contain the prefix. ---
-    And show command "show ip ospf route" in namespace "b" should not contain "192.168.1.1/32"
+    And show command "show ip ospf route" in namespace "b" should not contain "192.168.1.0/24"
 
     When I stop zebra-rs in namespace "a"
     And I stop zebra-rs in namespace "b"
@@ -238,16 +242,16 @@ Feature: OSPFv2 NSSA (Not-So-Stubby Area) Type-7 origination and translation
     And I apply config "b.yaml" to namespace "b"
     And I apply config "c_e1.yaml" to namespace "c"
     And I apply config "d.yaml" to namespace "d"
-    And I add address "192.168.1.1/32" to interface "lo" in namespace "c"
+    And I create dummy interface "cust0" with address "192.168.1.1/24" in namespace "c"
     And I wait 60 seconds
 
     # --- d: intra-NSSA Type-7, E1 metric = cost(d->c) 20 + ext 20 = 40. ---
-    Then show command "show ip ospf route" in namespace "d" should contain "192.168.1.1/32"
+    Then show command "show ip ospf route" in namespace "d" should contain "192.168.1.0/24"
     And show command "show ip ospf route" in namespace "d" should contain "[40]"
     # --- b: translated Type-5 advertised by ABR a, E1 metric =
     #     cost(b->a) 10 + ext 20 = 30. The differing metric (30 vs 40)
     #     is the proof E1's distance term survives translation. ---
-    And show command "show ip ospf route" in namespace "b" should contain "192.168.1.1/32"
+    And show command "show ip ospf route" in namespace "b" should contain "192.168.1.0/24"
     And show command "show ip ospf route" in namespace "b" should contain "[30]"
 
     When I stop zebra-rs in namespace "a"

--- a/bdd/tests/features/ospfv2_stub.feature
+++ b/bdd/tests/features/ospfv2_stub.feature
@@ -22,12 +22,14 @@ Feature: OSPFv2 stub area drops Type-5 AS-External while keeping inter-area rout
     loopbacks: a .1  b .2  c .3  (10.0.0.X/32).
   ```
 
-  b redistributes a secondary loopback (192.168.1.1/32, added after
-  start) as a Type-5 AS-External LSA. The backbone router a installs it,
-  but `flood_lsa_through_as` skips stub areas, so the Type-5 never
-  reaches c — and external prefixes are not re-advertised as Type-3
-  either. The backbone loopback 10.0.0.2/32, by contrast, IS summarized
-  into the stub as a Type-3, so c reaches it across the area boundary.
+  b redistributes a connected network (192.168.1.0/24) on a standalone
+  dummy interface "cust0" (NOT an OSPF interface, so it is a genuine
+  external — not an intra-area stub that would summarize as a Type-3) as
+  a Type-5 AS-External LSA. The backbone router a installs it, but
+  `flood_lsa_through_as` skips stub areas, so the Type-5 never reaches c
+  — and external prefixes are not re-advertised as Type-3 either. The
+  backbone loopback 10.0.0.2/32, by contrast, IS summarized into the
+  stub as a Type-3, so c reaches it across the area boundary.
 
   Scenario: Stub router learns inter-area Type-3 but never the Type-5 external
     Given a clean test environment
@@ -42,9 +44,9 @@ Feature: OSPFv2 stub area drops Type-5 AS-External while keeping inter-area rout
     And I apply config "a.yaml" to namespace "a"
     And I apply config "b.yaml" to namespace "b"
     And I apply config "c.yaml" to namespace "c"
-    # Secondary loopback on the ASBR b: the external prefix redistributed
-    # as a Type-5.
-    And I add address "192.168.1.1/32" to interface "lo" in namespace "b"
+    # External network on the ASBR b's non-OSPF dummy interface: the
+    # prefix redistributed as a Type-5.
+    And I create dummy interface "cust0" with address "192.168.1.1/24" in namespace "b"
     # Allow Hellos + DBD (E-bit must match on the stub link), Type-5
     # origination + backbone flood, Type-3 summary into the stub, and
     # SPF/route install.
@@ -59,14 +61,14 @@ Feature: OSPFv2 stub area drops Type-5 AS-External while keeping inter-area rout
     And show command "show ip ospf neighbor" in namespace "c" should contain "10.0.0.1"
 
     # --- The backbone router a installs the Type-5 external. ---
-    And show command "show ip ospf route" in namespace "a" should contain "192.168.1.1/32"
+    And show command "show ip ospf route" in namespace "a" should contain "192.168.1.0/24"
 
     # --- The stub router c learns the backbone loopback as an inter-area
     #     Type-3 summary (stub still floods Type-3 inward). ---
     And show command "show ip ospf route" in namespace "c" should contain "10.0.0.2/32"
     # --- But c must NOT learn the Type-5 external: stub areas exclude
     #     AS-External, and externals are not re-advertised as Type-3. ---
-    And show command "show ip ospf route" in namespace "c" should not contain "192.168.1.1/32"
+    And show command "show ip ospf route" in namespace "c" should not contain "192.168.1.0/24"
 
     # --- Reachability across the area boundary works (Type-3); the ABR,
     #     which holds the Type-5, reaches the external. ---

--- a/zebra-rs/src/rib/redist.rs
+++ b/zebra-rs/src/rib/redist.rs
@@ -97,9 +97,12 @@ pub fn walk_v4(
         if !deliverable(proto, entry.rtype) {
             continue;
         }
-        let Some(nh4) = first_v4_nexthop(&entry.nexthop) else {
-            continue;
-        };
+        // Connected (directly-attached) routes carry an interface-only
+        // nexthop with no gateway IP, so `first_v4_nexthop` yields None.
+        // Redistribution still wants the prefix — the consumer
+        // re-originates it with its own nexthop / forwarding address —
+        // so deliver with a 0.0.0.0 placeholder instead of dropping.
+        let nh4 = first_v4_nexthop(&entry.nexthop).unwrap_or(std::net::Ipv4Addr::UNSPECIFIED);
         buf.push(RouteEntryV4 {
             prefix,
             nexthop: nh4,
@@ -134,9 +137,9 @@ pub fn walk_v6(
         if !deliverable(proto, entry.rtype) {
             continue;
         }
-        let Some(nh6) = first_v6_nexthop(&entry.nexthop) else {
-            continue;
-        };
+        // See `walk_v4`: connected routes have no gateway IP; deliver
+        // them with a :: placeholder rather than dropping the prefix.
+        let nh6 = first_v6_nexthop(&entry.nexthop).unwrap_or(std::net::Ipv6Addr::UNSPECIFIED);
         buf.push(RouteEntryV6 {
             prefix,
             nexthop: nh6,
@@ -276,7 +279,9 @@ fn flush_v6(
 // RouteAdd / RouteDel messages for each filter row that's affected.
 
 fn build_v4_entry(prefix: &Ipv4Net, e: &RibEntry) -> Option<RouteEntryV4> {
-    let nh = first_v4_nexthop(&e.nexthop)?;
+    // Connected routes have no gateway IP (see `walk_v4`): deliver them
+    // with a 0.0.0.0 placeholder rather than dropping the prefix.
+    let nh = first_v4_nexthop(&e.nexthop).unwrap_or(std::net::Ipv4Addr::UNSPECIFIED);
     Some(RouteEntryV4 {
         prefix: *prefix,
         nexthop: nh,
@@ -288,7 +293,9 @@ fn build_v4_entry(prefix: &Ipv4Net, e: &RibEntry) -> Option<RouteEntryV4> {
 }
 
 fn build_v6_entry(prefix: &Ipv6Net, e: &RibEntry) -> Option<RouteEntryV6> {
-    let nh = first_v6_nexthop(&e.nexthop)?;
+    // Connected routes have no gateway IP (see `walk_v4`): deliver them
+    // with a :: placeholder rather than dropping the prefix.
+    let nh = first_v6_nexthop(&e.nexthop).unwrap_or(std::net::Ipv6Addr::UNSPECIFIED);
     Some(RouteEntryV6 {
         prefix: *prefix,
         nexthop: nh,
@@ -591,12 +598,24 @@ mod tests {
     }
 
     #[test]
-    fn link_only_nexthop_never_delivered() {
-        // A Link-only (non-deliverable) selected entry projects to None;
-        // gaining or losing it produces no redistribute delta.
-        let mut link = RibEntry::new(RibType::Static);
-        link.nexthop = Nexthop::Link(7);
-        assert!(!selected_changed_v4(&p(), Some(&link), None));
-        assert!(!selected_changed_v4(&p(), None, Some(&link)));
+    fn connected_link_nexthop_is_delivered_with_unspecified() {
+        // A directly-attached route (a connected route, or a static
+        // pointing out an interface) carries a Link nexthop with no
+        // gateway IP. Redistribution must still deliver the prefix —
+        // with a 0.0.0.0 placeholder nexthop — so a consumer can
+        // re-originate it. Regression guard: these routes used to be
+        // dropped, which is why `redistribute connected` produced no
+        // external LSAs (OSPF Type-5 / NSSA Type-7).
+        let mut conn = RibEntry::new(RibType::Connected);
+        conn.nexthop = Nexthop::Link(7);
+        conn.ifindex = 7;
+
+        let built = build_v4_entry(&p(), &conn).expect("connected route must be delivered");
+        assert_eq!(built.nexthop, std::net::Ipv4Addr::UNSPECIFIED);
+        assert_eq!(built.ifindex, 7);
+
+        // Gaining or losing it is therefore a redistribute change.
+        assert!(selected_changed_v4(&p(), Some(&conn), None));
+        assert!(selected_changed_v4(&p(), None, Some(&conn)));
     }
 }


### PR DESCRIPTION
## Summary

Fixes a bug where `redistribute connected` in OSPF originated **no** external LSAs at all — neither instance-level Type-5 nor per-area NSSA Type-7.

**Root cause:** a connected `RibEntry` (`rib/link.rs`) is directly attached — it has an `ifindex` but no gateway IP (`Nexthop::Link`). The RIB redistribute delivery (`walk_v4`/`walk_v6` initial replay and `build_v4_entry`/`build_v6_entry` per-route change) called `first_v4_nexthop(...)?`, which returns `None` for a gateway-less route, so **every connected route was silently dropped** and never reached the redistribute subscriber.

**Fix:** deliver such routes with a `0.0.0.0` / `::` placeholder nexthop instead of dropping them. Only gateway-less routes (connected, interface-static) are affected; consumers re-originate with their own nexthop (OSPF FA=0, BGP next-hop-self, IS-IS advertises the prefix). OSPF needed no change — origination uses only the prefix.

## BDD tests were leak-based — also fixed

`@ospfv2_nssa`/`@ospfv2_stub` put the redistributed prefix on an OSPF-enabled `lo`, so OSPF advertised it as an intra-area stub and an ABR summarized it as a Type-3 — reaching the "external" observer regardless of redistribution/translation (the leak's metrics coincidentally matched). The Type-5/Type-7 path was never actually exercised. Redesigned both to redistribute from a **non-OSPF dummy interface** (new reusable step `I create dummy interface ... with address ...`), so the connected route is a genuine external.

`@ospfv2_as_external` (pre-existing) is still leak-based — left untouched (out of scope).

## Test plan

- `cargo fmt --check` ✓, `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test -p zebra-rs` ✓ (902 passed; updated `link_only_nexthop_never_delivered` → asserts the route is now delivered)
- **Live end-to-end validation** (built binary, real netns topology, ASBR → ABR-translator → backbone-only observer):
  - default `candidate`: observer installs `203.0.113.0/24 [20]` via a genuine translated Type-5 (impossible via any leak — prefix not intra-area, observer has no NSSA link) ✓
  - `nssa-translator-role: never`: translation withdrawn, route disappears ✓
  - First time the NSSA Type-7→Type-5 translator (and the FA=0 fix from #1248) was actually exercised — both work.

Known follow-up (not in this PR): redistribute-connected now also picks up `127.0.0.0/8` (no martian filter); harmless (kernel rejects the martian FIB install) but should be filtered.

Generated with [Claude Code](https://claude.com/claude-code)