### PR TITLE
rib: filter loopback/link-local; de-leak as_external test

### DIFF
--- a/bdd/tests/features/ospfv2_as_external.feature
+++ b/bdd/tests/features/ospfv2_as_external.feature
@@ -12,10 +12,14 @@ Feature: OSPFv2 AS-External (Type-5) LSA origination with E1 and E2 metric types
   Area 0.0.0.1: a (ABR), e (internal).
   Area 0.0.0.2: c (ABR), f (internal).
 
-  Router b is the ASBR in backbone area 0.  A secondary loopback address
-  (192.168.1.1/32) is added to b's lo after zebra-rs starts; it is NOT
-  registered under any OSPF area, so it enters the OSPF domain exclusively
-  via `redistribute connected` as a Type-5 AS-External LSA.
+  Router b is the ASBR in backbone area 0.  A connected network
+  (192.168.1.0/24) on a standalone dummy interface "cust0" is added to b
+  after zebra-rs starts.  It is NOT on any OSPF-enabled interface, so it
+  is a genuine external route — it enters the OSPF domain exclusively via
+  `redistribute connected` as a Type-5 AS-External LSA.  (An address on
+  an OSPF-enabled interface would instead be advertised as an intra-area
+  stub and summarized as a Type-3, which would win over the Type-5 and
+  mask the AS-External path being tested.)
 
   E2 metric (type 2): the installed metric equals the LSA's external metric
   (20) regardless of the observer's distance to the ASBR — the same [20]
@@ -56,24 +60,24 @@ Feature: OSPFv2 AS-External (Type-5) LSA origination with E1 and E2 metric types
     And I apply config "d.yaml" to namespace "d"
     And I apply config "e.yaml" to namespace "e"
     And I apply config "f.yaml" to namespace "f"
-    # Add a secondary loopback address that is not in the OSPF area config.
-    # This connected route becomes the external prefix redistributed as Type-5.
-    And I add address "192.168.1.1/32" to interface "lo" in namespace "b"
+    # A connected network on a non-OSPF dummy interface: a genuine
+    # external prefix redistributed as a Type-5 (not an intra-area stub).
+    And I create dummy interface "cust0" with address "192.168.1.1/24" in namespace "b"
     # Allow time for OSPF to converge, originate Type-3/4/5 LSAs, and install
     # external routes in all areas via flooding + SPF.
     And I wait 60 seconds
 
     # --- All areas install the external prefix with the E2 metric (20). ---
     # Same metric on every observer proves type-2: external-metric only.
-    Then show command "show ip ospf route" in namespace "a" should contain "192.168.1.1/32"
+    Then show command "show ip ospf route" in namespace "a" should contain "192.168.1.0/24"
     And show command "show ip ospf route" in namespace "a" should contain "[20]"
-    And show command "show ip ospf route" in namespace "c" should contain "192.168.1.1/32"
+    And show command "show ip ospf route" in namespace "c" should contain "192.168.1.0/24"
     And show command "show ip ospf route" in namespace "c" should contain "[20]"
     # e is in area 0.0.0.1 — needs Type-4 from ABR a to find ASBR b.
-    And show command "show ip ospf route" in namespace "e" should contain "192.168.1.1/32"
+    And show command "show ip ospf route" in namespace "e" should contain "192.168.1.0/24"
     And show command "show ip ospf route" in namespace "e" should contain "[20]"
     # f is in area 0.0.0.2 — needs Type-4 from ABR c to find ASBR b.
-    And show command "show ip ospf route" in namespace "f" should contain "192.168.1.1/32"
+    And show command "show ip ospf route" in namespace "f" should contain "192.168.1.0/24"
     And show command "show ip ospf route" in namespace "f" should contain "[20]"
 
     # Teardown.
@@ -118,23 +122,23 @@ Feature: OSPFv2 AS-External (Type-5) LSA origination with E1 and E2 metric types
     And I apply config "d.yaml" to namespace "d"
     And I apply config "e.yaml" to namespace "e"
     And I apply config "f.yaml" to namespace "f"
-    And I add address "192.168.1.1/32" to interface "lo" in namespace "b"
+    And I create dummy interface "cust0" with address "192.168.1.1/24" in namespace "b"
     And I wait 60 seconds
 
     # --- E1 metric varies by observer distance to ASBR b. ---
     # b is in area 0. a-b and c-b and d-b all cost 10, so cost-to-b = 10.
     # E1 metric from backbone routers = 10 (intra-cost) + 20 (ext-metric) = 30.
-    Then show command "show ip ospf route" in namespace "a" should contain "192.168.1.1/32"
+    Then show command "show ip ospf route" in namespace "a" should contain "192.168.1.0/24"
     And show command "show ip ospf route" in namespace "a" should contain "[30]"
     And show command "show ip ospf route" in namespace "c" should contain "[30]"
     And show command "show ip ospf route" in namespace "d" should contain "[30]"
     # e reaches b via a (cost 10) + Type-4 from a (a's SPF cost to b = 10) = 20.
     # E1 metric from e = 20 + 20 = 40.
-    And show command "show ip ospf route" in namespace "e" should contain "192.168.1.1/32"
+    And show command "show ip ospf route" in namespace "e" should contain "192.168.1.0/24"
     And show command "show ip ospf route" in namespace "e" should contain "[40]"
     # f reaches b via c (cost 10) + Type-4 from c (c's SPF cost to b = 10) = 20.
     # E1 metric from f = 20 + 20 = 40.
-    And show command "show ip ospf route" in namespace "f" should contain "192.168.1.1/32"
+    And show command "show ip ospf route" in namespace "f" should contain "192.168.1.0/24"
     And show command "show ip ospf route" in namespace "f" should contain "[40]"
 
     # Teardown.

--- a/zebra-rs/src/rib/redist.rs
+++ b/zebra-rs/src/rib/redist.rs
@@ -97,6 +97,9 @@ pub fn walk_v4(
         if !deliverable(proto, entry.rtype) {
             continue;
         }
+        if !redistributable_v4(&prefix) {
+            continue;
+        }
         // Connected (directly-attached) routes carry an interface-only
         // nexthop with no gateway IP, so `first_v4_nexthop` yields None.
         // Redistribution still wants the prefix — the consumer
@@ -137,6 +140,9 @@ pub fn walk_v6(
         if !deliverable(proto, entry.rtype) {
             continue;
         }
+        if !redistributable_v6(&prefix) {
+            continue;
+        }
         // See `walk_v4`: connected routes have no gateway IP; deliver
         // them with a :: placeholder rather than dropping the prefix.
         let nh6 = first_v6_nexthop(&entry.nexthop).unwrap_or(std::net::Ipv6Addr::UNSPECIFIED);
@@ -166,6 +172,28 @@ fn pick_entry<'a>(
     entries.iter().find(|e| {
         e.is_selected() && e.rtype == rtype && subtype_matches(subtype_filter, &e.rsubtype)
     })
+}
+
+/// True when a prefix is eligible for redistribution into a routing
+/// protocol. Loopback (127.0.0.0/8) and link-local (169.254.0.0/16)
+/// addresses appear as connected routes but must never be advertised —
+/// they're not routable beyond the local host. Mirrors the Router-LSA
+/// builder's 127.x skip, but here it also guards Type-5 / NSSA Type-7
+/// origination and every other redistribute consumer.
+fn redistributable_v4(prefix: &Ipv4Net) -> bool {
+    let a = prefix.addr();
+    !a.is_loopback() && !a.is_link_local()
+}
+
+/// IPv6 sibling of [`redistributable_v4`]: excludes loopback (::1/128)
+/// and link-local (fe80::/10). Every interface carries an fe80::/64
+/// connected route, so skipping link-local also keeps a flood of
+/// per-interface junk out of redistribution.
+fn redistributable_v6(prefix: &Ipv6Net) -> bool {
+    let a = prefix.addr();
+    let o = a.octets();
+    let link_local = o[0] == 0xfe && (o[1] & 0xc0) == 0x80;
+    !a.is_loopback() && !link_local
 }
 
 /// Resolve the first IPv4 nexthop address from a Nexthop. Returns
@@ -279,6 +307,9 @@ fn flush_v6(
 // RouteAdd / RouteDel messages for each filter row that's affected.
 
 fn build_v4_entry(prefix: &Ipv4Net, e: &RibEntry) -> Option<RouteEntryV4> {
+    if !redistributable_v4(prefix) {
+        return None;
+    }
     // Connected routes have no gateway IP (see `walk_v4`): deliver them
     // with a 0.0.0.0 placeholder rather than dropping the prefix.
     let nh = first_v4_nexthop(&e.nexthop).unwrap_or(std::net::Ipv4Addr::UNSPECIFIED);
@@ -293,6 +324,9 @@ fn build_v4_entry(prefix: &Ipv4Net, e: &RibEntry) -> Option<RouteEntryV4> {
 }
 
 fn build_v6_entry(prefix: &Ipv6Net, e: &RibEntry) -> Option<RouteEntryV6> {
+    if !redistributable_v6(prefix) {
+        return None;
+    }
     // Connected routes have no gateway IP (see `walk_v4`): deliver them
     // with a :: placeholder rather than dropping the prefix.
     let nh = first_v6_nexthop(&e.nexthop).unwrap_or(std::net::Ipv6Addr::UNSPECIFIED);
@@ -617,5 +651,32 @@ mod tests {
         // Gaining or losing it is therefore a redistribute change.
         assert!(selected_changed_v4(&p(), Some(&conn), None));
         assert!(selected_changed_v4(&p(), None, Some(&conn)));
+    }
+
+    #[test]
+    fn loopback_and_link_local_are_not_redistributed() {
+        // Loopback (127/8) and link-local (169.254/16) appear as
+        // connected routes but must never be redistributed — they are
+        // not routable beyond the local host.
+        let mut conn = RibEntry::new(RibType::Connected);
+        conn.nexthop = Nexthop::Link(1);
+        conn.ifindex = 1;
+
+        let lo: Ipv4Net = "127.0.0.0/8".parse().unwrap();
+        let ll: Ipv4Net = "169.254.0.0/16".parse().unwrap();
+        assert!(build_v4_entry(&lo, &conn).is_none());
+        assert!(build_v4_entry(&ll, &conn).is_none());
+        assert!(!selected_changed_v4(&lo, None, Some(&conn)));
+
+        // A normal connected prefix is still delivered.
+        let ok: Ipv4Net = "203.0.113.0/24".parse().unwrap();
+        assert!(build_v4_entry(&ok, &conn).is_some());
+    }
+
+    #[test]
+    fn v6_loopback_and_link_local_are_not_redistributed() {
+        assert!(!redistributable_v6(&"::1/128".parse().unwrap()));
+        assert!(!redistributable_v6(&"fe80::/64".parse().unwrap()));
+        assert!(redistributable_v6(&"2001:db8::/64".parse().unwrap()));
     }
 }


### PR DESCRIPTION
## Summary

Two follow-ups to the redistribute-connected fix (#1254).

### rib: never redistribute loopback or link-local prefixes
Now that connected routes are delivered to redistribute consumers, the loopback (`127.0.0.0/8`) and link-local (`169.254.0.0/16`, `fe80::/10`) connected routes every host carries would leak into OSPF Type-5 / NSSA Type-7, BGP, and IS-IS. They're not routable beyond the local host and must never be advertised — the Router-LSA builder already skips `127.x`; this applies the same rule to all redistribution, in the RIB delivery path (`redistributable_v4`/`_v6` guarding `walk_v4`/`walk_v6` and `build_v4_entry`/`build_v6_entry`). Skipping v6 link-local also keeps the per-interface `fe80::/64` routes out. Validated live: a real external is still redistributed as a Type-7 while `127.0.0.0/8` is not.

### bdd: redistribute a genuine external in @ospfv2_as_external
Same de-leak as `@ospfv2_nssa`/`@ospfv2_stub`: the redistributed prefix sat on b's OSPF-enabled `lo`, so OSPF advertised it as an intra-area stub and the ABRs summarized it as a Type-3 — which beat the Type-5 and reached the observers regardless of redistribution (E2 matched by luck, E1 was masked). Move the external to a standalone dummy interface `cust0` (`192.168.1.0/24`, not in any OSPF area) so it is a genuine Type-5 AS-External; the E1/E2 metric assertions ([20]/[30]/[40]) now reflect real external routes.

## Test plan
- `cargo fmt --check` ✓, `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test -p zebra-rs` ✓ (904 passed; +2 filter unit tests)
- Live: single-daemon redistribute now originates a Type-7 for a real external but NOT for `127.0.0.0/8`.

Note: OSPFv3 NSSA is not yet at parity (no v6 redistribute-connected origination; v3 translator has the FA=0 gap + P-bit never set) — tracked as a separate feature, not in this PR.

Generated with [Claude Code](https://claude.com/claude-code)