### PR TITLE
ospf: OSPFv3 multi-area Router-LSA + NSSA redistribute/translation

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -118,6 +118,10 @@ ospfv2_stub:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv2_stub"
 
+ospfv3_nssa:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv3_nssa"
+
 bgp_evpn_capability:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_capability"
@@ -165,4 +169,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise bgp_neighbor_group bgp_unnumbered_neighbor generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv3_nssa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise bgp_neighbor_group bgp_unnumbered_neighbor generate open docs FORCE

--- a/bdd/tests/configs/ospfv3_nssa/a.yaml
+++ b/bdd/tests/configs/ospfv3_nssa/a.yaml
@@ -1,0 +1,38 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: ethb
+  ipv6:
+    address: 2001:db8:12::1/64
+- if-name: ethc
+  ipv6:
+    address: 2001:db8:13::1/64
+- if-name: ethd
+  ipv6:
+    address: 2001:db8:14::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    area:
+    # Backbone — a is the ABR gluing the NSSA to area 0.
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+    # NSSA (0.0.0.1). a is the sole ABR, so it elects itself the
+    # RFC 5340 / RFC 3101 Type-7->Type-5 translator under the default
+    # `candidate` role, and originates a default Type-7 into the area.
+    - area-id: 0.0.0.1
+      area-type: nssa
+      nssa-default-originate: true
+      interface:
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point
+      - if-name: ethd
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_nssa/a_never.yaml
+++ b/bdd/tests/configs/ospfv3_nssa/a_never.yaml
@@ -1,0 +1,38 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: ethb
+  ipv6:
+    address: 2001:db8:12::1/64
+- if-name: ethc
+  ipv6:
+    address: 2001:db8:13::1/64
+- if-name: ethd
+  ipv6:
+    address: 2001:db8:14::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: ethb
+        enable: true
+        network-type: point-to-point
+    # nssa-translator-role = never disables Type-7->Type-5 translation
+    # on this ABR. The Type-7 still floods the NSSA, but must not leak
+    # into the backbone as a Type-5.
+    - area-id: 0.0.0.1
+      area-type: nssa
+      nssa-default-originate: true
+      nssa-translator-role: never
+      interface:
+      - if-name: ethc
+        enable: true
+        network-type: point-to-point
+      - if-name: ethd
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_nssa/b.yaml
+++ b/bdd/tests/configs/ospfv3_nssa/b.yaml
@@ -1,0 +1,21 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: etha
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    # b sits in the backbone only. It can learn the NSSA-internal
+    # external prefix only as a translated Type-5 — a Type-7 never
+    # leaves its NSSA — so b is the witness for the translator.
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_nssa/c.yaml
+++ b/bdd/tests/configs/ospfv3_nssa/c.yaml
@@ -1,0 +1,27 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: etha
+  ipv6:
+    address: 2001:db8:13::2/64
+router:
+  ospfv3:
+    router-id: 10.0.0.3
+    area:
+    # c is an internal NSSA router AND the area's ASBR: it injects a
+    # connected route into the NSSA as a Type-7 (NSSA-LSA). Being a
+    # pure ASBR (not an ABR) it sets the Type-7 P-bit (prefix-options),
+    # asking the ABR to translate. metric 20 / type-2 (E2).
+    - area-id: 0.0.0.1
+      area-type: nssa
+      redistribute:
+        connected:
+          metric: 20
+          metric-type: type-2
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/configs/ospfv3_nssa/d.yaml
+++ b/bdd/tests/configs/ospfv3_nssa/d.yaml
@@ -1,0 +1,22 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::4/128
+- if-name: etha
+  ipv6:
+    address: 2001:db8:14::2/64
+router:
+  ospfv3:
+    router-id: 10.0.0.4
+    # d is a plain internal NSSA router. It learns the external prefix
+    # straight from c's Type-7 (area-scoped flood) and the default route
+    # from the ABR's Type-7.
+    area:
+    - area-id: 0.0.0.1
+      area-type: nssa
+      interface:
+      - if-name: lo
+        enable: true
+      - if-name: etha
+        enable: true
+        network-type: point-to-point

--- a/bdd/tests/features/ospfv3_nssa.feature
+++ b/bdd/tests/features/ospfv3_nssa.feature
@@ -1,0 +1,137 @@
+@serial
+@ospfv3_nssa
+Feature: OSPFv3 NSSA (Not-So-Stubby Area) Type-7 origination and translation
+  As a network operator
+  I want zebra-rs to support OSPFv3 NSSA areas — N-bit adjacency, Type-7
+  (NSSA-LSA) origination from an internal ASBR via redistribute
+  connected, intra-NSSA Type-7 route install, and the ABR's RFC 5340 /
+  RFC 3101 Type-7->Type-5 translation into the backbone — so that an IPv6
+  external prefix born inside an NSSA reaches both the area and the rest
+  of the OSPFv3 domain.
+
+  This is the IPv6 counterpart of @ospfv2_nssa. Four routers, two areas:
+  the backbone (0.0.0.0) holds the ABR a and a pure backbone router b;
+  the NSSA (0.0.0.1) hangs off a as a hub-and-spoke with the ASBR c and
+  the plain internal router d.
+
+  Test Topology:
+  ```
+            area 0.0.0.0 (backbone)
+      b (10.0.0.2) -- 2001:db8:12::/64 -- a (ABR, 10.0.0.1)
+                                          |  translator + default-originate
+                                  area 0.0.0.1 (NSSA)
+                     2001:db8:13::/64 |        | 2001:db8:14::/64
+                       c (ASBR, 10.0.0.3)      d (10.0.0.4)
+                       redistribute            plain internal
+                       connected -> Type-7
+
+    on router X the interface toward router Y is named "ethY".
+    loopbacks: 2001:db8::X/128 (X = router-id last octet).
+  ```
+
+  The external prefix is a connected network (2001:db8:dead::/64) on a
+  standalone dummy interface "cust0" on c — NOT on any OSPF-enabled
+  interface, so it is a genuine external that enters OSPFv3 only via
+  `redistribute connected` as a Type-7. c is a pure ASBR (not an ABR),
+  so it sets the Type-7 P-bit in the prefix-options. d installs it
+  directly (area-scoped flood); a — the elected (sole-ABR, default
+  `candidate` role) translator — re-originates it as a Type-5
+  AS-External into the backbone, where b installs it. b carries no NSSA
+  link, so a translated Type-5 is the only way the prefix reaches it.
+
+  Scenario: Internal ASBR Type-7 is installed in-area and translated to Type-5 on the backbone
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I create namespace "c"
+    And I create namespace "d"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I connect namespace "a" interface "ethc" to namespace "c" interface "etha"
+    And I connect namespace "a" interface "ethd" to namespace "d" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I start zebra-rs in namespace "c"
+    And I start zebra-rs in namespace "d"
+    And I apply config "a.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I apply config "c.yaml" to namespace "c"
+    And I apply config "d.yaml" to namespace "d"
+    # The external network on c's non-OSPF dummy interface — redistributed
+    # into the NSSA as a Type-7.
+    And I create dummy interface "cust0" with address "2001:db8:dead::1/64" in namespace "c"
+    And I wait 60 seconds
+
+    # --- Adjacencies are Full on every link (the NSSA links require the
+    #     N-bit to match between a and c / a and d). ---
+    Then show command "show ipv6 ospf neighbor" in namespace "a" should contain "Full"
+    And show command "show ipv6 ospf neighbor" in namespace "a" should contain "10.0.0.2"
+    And show command "show ipv6 ospf neighbor" in namespace "a" should contain "10.0.0.3"
+    And show command "show ipv6 ospf neighbor" in namespace "a" should contain "10.0.0.4"
+    And show command "show ipv6 ospf neighbor" in namespace "c" should contain "Full"
+    And show command "show ipv6 ospf neighbor" in namespace "c" should contain "10.0.0.1"
+
+    # --- Type-7 inside the NSSA: d installs the external prefix straight
+    #     from c's Type-7. ---
+    And show command "show ipv6 ospf route" in namespace "d" should contain "2001:db8:dead::/64"
+
+    # --- The headline: Type-7 -> Type-5 translation at the ABR. b is in
+    #     the backbone only, so it can learn 2001:db8:dead::/64 ONLY as a
+    #     translated Type-5 (the Type-7 never leaves the NSSA). ---
+    And show command "show ipv6 ospf route" in namespace "b" should contain "2001:db8:dead::/64"
+
+    # --- ABR default-originate: a injects a default Type-7 into the NSSA,
+    #     so both internal routers hold a ::/0. ---
+    And show command "show ipv6 ospf route" in namespace "c" should contain "::/0"
+    And show command "show ipv6 ospf route" in namespace "d" should contain "::/0"
+
+    # Teardown.
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I stop zebra-rs in namespace "c"
+    And I stop zebra-rs in namespace "d"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    And I delete namespace "c"
+    And I delete namespace "d"
+    Then the test environment should be clean
+
+  # Translator-role `never`: the ABR refuses to translate. The Type-7
+  # still floods the NSSA and d installs it, but with no translator the
+  # prefix never becomes a Type-5, so the backbone-only router never
+  # learns it. Negative control for the first scenario's translation.
+  Scenario: Translator-role never keeps the Type-7 in-area and out of the backbone
+    Given a clean test environment
+    When I create namespace "a"
+    And I create namespace "b"
+    And I create namespace "c"
+    And I create namespace "d"
+    And I connect namespace "a" interface "ethb" to namespace "b" interface "etha"
+    And I connect namespace "a" interface "ethc" to namespace "c" interface "etha"
+    And I connect namespace "a" interface "ethd" to namespace "d" interface "etha"
+    And I start zebra-rs in namespace "a"
+    And I start zebra-rs in namespace "b"
+    And I start zebra-rs in namespace "c"
+    And I start zebra-rs in namespace "d"
+    # Only a differs: nssa-translator-role = never.
+    And I apply config "a_never.yaml" to namespace "a"
+    And I apply config "b.yaml" to namespace "b"
+    And I apply config "c.yaml" to namespace "c"
+    And I apply config "d.yaml" to namespace "d"
+    And I create dummy interface "cust0" with address "2001:db8:dead::1/64" in namespace "c"
+    And I wait 60 seconds
+
+    # --- Intra-NSSA Type-7 install is unchanged: d still learns it. ---
+    Then show command "show ipv6 ospf route" in namespace "d" should contain "2001:db8:dead::/64"
+    # --- But with translation disabled the prefix never reaches the
+    #     backbone: b must NOT contain it. ---
+    And show command "show ipv6 ospf route" in namespace "b" should not contain "2001:db8:dead::/64"
+
+    When I stop zebra-rs in namespace "a"
+    And I stop zebra-rs in namespace "b"
+    And I stop zebra-rs in namespace "c"
+    And I stop zebra-rs in namespace "d"
+    And I delete namespace "a"
+    And I delete namespace "b"
+    And I delete namespace "c"
+    And I delete namespace "d"
+    Then the test environment should be clean

--- a/zebra-rs/src/ospf/area.rs
+++ b/zebra-rs/src/ospf/area.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::Ipv4Addr;
 
-use ipnet::Ipv4Net;
+use ipnet::{Ipv4Net, Ipv6Net};
 
 use super::Lsdb;
 use super::version::{OspfVersion, Ospfv2};
@@ -243,6 +243,13 @@ pub struct OspfArea<V: OspfVersion = Ospfv2> {
     /// in `inst.rs`.
     pub redist_connected_originated: BTreeSet<Ipv4Net>,
 
+    /// v6 sibling of `redist_connected_originated`: prefixes of
+    /// redistributed connected routes this router has originated as
+    /// OSPFv3 NSSA-LSAs (Type-7) into this area. The generic
+    /// `OspfArea<V>` carries both the v4 and v6 sets; a v2 instance
+    /// only touches the v4 one and a v3 instance only the v6 one.
+    pub redist_connected_originated_v6: BTreeSet<Ipv6Net>,
+
     /// RFC 3101 §3 NSSA Type-7→Type-5 translator state. ls_ids of
     /// Type-7 LSAs in this area for which we have translated a
     /// Type-5 into `lsdb_as`. The translated Type-5's adv_router is
@@ -269,6 +276,7 @@ impl<V: OspfVersion> OspfArea<V> {
             spf_pending: false,
             redistribute: AreaRedistribute::default(),
             redist_connected_originated: BTreeSet::new(),
+            redist_connected_originated_v6: BTreeSet::new(),
             nssa_translated: BTreeSet::new(),
             asbr_summaries_originated: BTreeSet::new(),
         }

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -9,7 +9,7 @@
 //! `ospf_link_get_mut_by_name`, `parse_area_id`, `ospf_hello_timer`)
 //! make this possible without duplication.
 
-use super::area::{AreaTypeKind, NssaTranslatorRole};
+use super::area::{AreaTypeKind, ExternalMetricType, NssaTranslatorRole, RedistEntry};
 use super::config::{
     Callback, apply_link_enable_transition, area_no_summary_set, area_nssa_default_originate_set,
     area_nssa_suppress_fa_set, area_nssa_translator_role_set, area_type_set,
@@ -52,6 +52,18 @@ impl Ospf<Ospfv3> {
             (
                 "/area/nssa-translator-role",
                 config_ospfv3_area_nssa_translator_role,
+            ),
+            (
+                "/area/redistribute/connected",
+                config_ospfv3_area_redist_connected,
+            ),
+            (
+                "/area/redistribute/connected/metric",
+                config_ospfv3_area_redist_connected_metric,
+            ),
+            (
+                "/area/redistribute/connected/metric-type",
+                config_ospfv3_area_redist_connected_metric_type,
             ),
             ("/area/interface/enable", config_ospfv3_interface_enable),
             (
@@ -201,6 +213,10 @@ fn config_ospfv3_area_type(ospf: &mut Ospf<Ospfv3>, mut args: Args, op: ConfigOp
     };
     area_type_set(ospf, area_id, kind);
     ospf.nssa_default_lsa_originate(area_id);
+    // Entering / leaving NSSA flips whether redistributed connected
+    // routes are legal as Type-7s in this area — resync originates
+    // fresh on entry, flushes on exit.
+    ospf.nssa_redist_connected_resync_v3(area_id);
     // Area-type also flips whether we should be translating
     // Type-7→Type-5 for this area (phase 6d). Resync clears
     // stale Type-5s on exit and seeds fresh ones on entry (if
@@ -275,6 +291,121 @@ fn config_ospfv3_area_nssa_translator_role(
     // Role flip directly changes whether translation should be
     // happening on this router.
     ospf.nssa_translate_resync(area_id);
+    Some(())
+}
+
+/// v3 sibling of `ospf_send_redist_connected` (`config.rs`): subscribe
+/// (or unsubscribe) to RIB IPv6 connected routes for redistribution
+/// into NSSA Type-7 LSAs. Keyed by `(proto, afi, rtype)` — not per
+/// area — so multiple NSSA areas share one subscription.
+fn ospfv3_send_redist_connected(ospf: &Ospf<Ospfv3>, first_time: bool) {
+    use super::version::OspfVersion;
+    use crate::rib::{Message as RibMsg, RedistAfi, RibType};
+    // Subscribe under the v3 proto ("ospfv3"); the RIB routes redist
+    // delivery by proto, and "ospf" would land on the v2 instance.
+    let proto = Ospfv3::PROTO.to_string();
+    let afi = RedistAfi::Ipv6;
+    let rtype = RibType::Connected;
+
+    let any_enabled = ospf
+        .areas
+        .iter()
+        .any(|(_, area)| area.redistribute.connected.is_some());
+
+    let msg = if !any_enabled {
+        RibMsg::RedistDel { proto, afi, rtype }
+    } else if first_time {
+        RibMsg::RedistAdd {
+            proto,
+            afi,
+            rtype,
+            subtypes: std::collections::BTreeSet::new(),
+        }
+    } else {
+        RibMsg::RedistUpdate {
+            proto,
+            afi,
+            rtype,
+            subtypes: std::collections::BTreeSet::new(),
+        }
+    };
+    let _ = ospf.ctx.rib.send(msg);
+}
+
+/// `/router/ospfv3/area/<id>/redistribute/connected` — presence
+/// container. Mirrors v2's `config_ospf_area_redist_connected` but
+/// drives the IPv6 subscription + the v3 Type-7 resync.
+fn config_ospfv3_area_redist_connected(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+
+    let first_time = !ospf
+        .areas
+        .iter()
+        .any(|(_, area)| area.redistribute.connected.is_some());
+
+    if op.is_set() {
+        ospf.areas.fetch(area_id).redistribute.connected = Some(RedistEntry {
+            metric: RedistEntry::DEFAULT_METRIC,
+            ..Default::default()
+        });
+    } else if let Some(area) = ospf.areas.get_mut(area_id) {
+        area.redistribute.connected = None;
+    }
+
+    ospfv3_send_redist_connected(ospf, first_time && op.is_set());
+    ospf.nssa_redist_connected_resync_v3(area_id);
+    Some(())
+}
+
+/// `/router/ospfv3/area/<id>/redistribute/connected/metric`.
+fn config_ospfv3_area_redist_connected_metric(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let metric = if op.is_set() {
+        args.u32()?
+    } else {
+        RedistEntry::DEFAULT_METRIC
+    };
+    let entry = ospf
+        .areas
+        .fetch(area_id)
+        .redistribute
+        .connected
+        .get_or_insert_with(RedistEntry::default);
+    entry.metric = metric;
+    ospf.nssa_redist_connected_resync_v3(area_id);
+    Some(())
+}
+
+/// `/router/ospfv3/area/<id>/redistribute/connected/metric-type` —
+/// `type-1` / `type-2`. Re-originates the area's Type-7s (the E-bit
+/// changes per LSA).
+fn config_ospfv3_area_redist_connected_metric_type(
+    ospf: &mut Ospf<Ospfv3>,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let area_id = parse_area_id(&args.string()?)?;
+    let metric_type = if op.is_set() {
+        ExternalMetricType::from_yang(&args.string()?)?
+    } else {
+        ExternalMetricType::default()
+    };
+    let entry = ospf
+        .areas
+        .fetch(area_id)
+        .redistribute
+        .connected
+        .get_or_insert_with(RedistEntry::default);
+    entry.metric_type = metric_type;
+    ospf.nssa_redist_connected_resync_v3(area_id);
     Some(())
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -222,6 +222,11 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     /// consumed by `nssa_redist_connected_resync` when origination
     /// state needs to be rebuilt (config change, area-type flip).
     pub redist_v4: BTreeMap<(crate::rib::RibType, Ipv4Net), crate::rib::RouteEntryV4>,
+    /// v6 sibling of `redist_v4`, populated by an OSPFv3 instance from
+    /// `RedistAfi::Ipv6` `RouteAdd`/`RouteDel` and consumed by
+    /// `nssa_redist_connected_resync_v3`. The generic `Ospf<V>` carries
+    /// both maps; a v2 instance leaves this empty.
+    pub redist_v6: BTreeMap<(crate::rib::RibType, ipnet::Ipv6Net), crate::rib::RouteEntryV6>,
     /// Instance-level `redistribute connected` — originates Type-5
     /// AS-External LSAs (FA=0) for every connected route from
     /// `redist_v4`. `Some(entry)` enables origination; `None` stops it.
@@ -975,6 +980,7 @@ impl Ospf<Ospfv2> {
             spf_last: None,
             spf_duration: None,
             redist_v4: BTreeMap::new(),
+            redist_v6: BTreeMap::new(),
             redist_connected: None,
             redist_connected_originated: BTreeSet::new(),
             flex_algo: crate::flex_algo::FlexAlgoConfig::new(Ospfv2::FLEX_ALGO_PREFIX),
@@ -4911,6 +4917,7 @@ impl Ospf<Ospfv3> {
             spf_last: None,
             spf_duration: None,
             redist_v4: BTreeMap::new(),
+            redist_v6: BTreeMap::new(),
             redist_connected: None,
             redist_connected_originated: BTreeSet::new(),
             flex_algo: crate::flex_algo::FlexAlgoConfig::new(Ospfv3::FLEX_ALGO_PREFIX),
@@ -5053,7 +5060,42 @@ impl Ospf<Ospfv3> {
                 ifindex,
             } => self.vrf_add(name, table_id, ifindex),
             RibRx::VrfDel { name } => self.vrf_del(name),
+            // Redistribute delivery. Only `Connected` is subscribed
+            // (per-area NSSA redistribute connected); the handler
+            // updates the `redist_v6` cache and resyncs Type-7 LSAs in
+            // every NSSA area whose `redistribute connected` knob is set.
+            RibRx::RouteAdd { rtype, routes, .. } => self.route_redist_add(rtype, routes),
+            RibRx::RouteDel { rtype, routes, .. } => self.route_redist_del(rtype, routes),
             _ => {}
+        }
+    }
+
+    /// `RibRx::RouteAdd` handler (v3): cache the delivered IPv6
+    /// connected routes in `redist_v6`, then resync every NSSA area's
+    /// Type-7 redistribution. v4 batches never arrive for a v3
+    /// subscription.
+    fn route_redist_add(&mut self, rtype: crate::rib::RibType, batch: crate::rib::RouteBatch) {
+        if let crate::rib::RouteBatch::V6(entries) = batch {
+            for e in entries {
+                self.redist_v6.insert((rtype, e.prefix), e);
+            }
+        }
+        let area_ids: Vec<Ipv4Addr> = self.areas.iter().map(|(&id, _)| id).collect();
+        for area_id in area_ids {
+            self.nssa_redist_connected_resync_v3(area_id);
+        }
+    }
+
+    /// `RibRx::RouteDel` handler (v3). Mirror of `route_redist_add`.
+    fn route_redist_del(&mut self, rtype: crate::rib::RibType, batch: crate::rib::RouteBatch) {
+        if let crate::rib::RouteBatch::V6(entries) = batch {
+            for e in entries {
+                self.redist_v6.remove(&(rtype, e.prefix));
+            }
+        }
+        let area_ids: Vec<Ipv4Addr> = self.areas.iter().map(|(&id, _)| id).collect();
+        for area_id in area_ids {
+            self.nssa_redist_connected_resync_v3(area_id);
         }
     }
 
@@ -5415,7 +5457,7 @@ impl Ospf<Ospfv3> {
     /// Returns an `Ospfv3Lsa` with checksum + length stamped via
     /// `Ospfv3Lsa::update`. Ready to install through
     /// `Lsdb::install_originated`.
-    pub fn build_router_lsa(&self) -> ospf_packet::Ospfv3Lsa {
+    pub fn build_router_lsa(&self, area_id: Ipv4Addr) -> ospf_packet::Ospfv3Lsa {
         use ospf_packet::{
             OSPFV3_ROUTER_LSA_FLAG_B, OSPFV3_ROUTER_LSA_FLAG_E, OSPFV3_ROUTER_LSA_TYPE,
             Ospfv3LsBody, Ospfv3Lsa, Ospfv3LsaHeader, Ospfv3Options, Ospfv3RouterLsa,
@@ -5425,6 +5467,11 @@ impl Ospf<Ospfv3> {
         let mut links = Vec::new();
         for link in self.links.values() {
             if !link.enabled {
+                continue;
+            }
+            // Router-LSAs are area-scoped (RFC 5340 §3.4.3): include
+            // only the links that belong to `area_id`.
+            if link.area_id != area_id {
                 continue;
             }
             let cost = link.output_cost as u16;
@@ -5536,11 +5583,31 @@ impl Ospf<Ospfv3> {
     /// - After install, flood the LSA to every Exchange-or-later
     ///   neighbor in the area via `flood_self_originated_lsa`.
     pub fn router_lsa_originate(&mut self) {
+        // Router-LSAs are area-scoped (RFC 5340 §3.4.3): originate one
+        // per area this router has enabled links in, each carrying only
+        // that area's links. Previously hardcoded to AREA0, which left
+        // every non-backbone area without a topology LSA — so its SPF
+        // never ran and the area's routers got no routes.
+        let area_ids: BTreeSet<Ipv4Addr> = self
+            .links
+            .values()
+            .filter(|l| l.enabled)
+            .map(|l| l.area_id)
+            .collect();
+        for area_id in area_ids {
+            self.router_lsa_originate_for_area(area_id);
+        }
+    }
+
+    /// Originate this router's Router-LSA for a single `area_id` (only
+    /// that area's links) into the area's LSDB, then flood + reschedule
+    /// the area's SPF.
+    fn router_lsa_originate_for_area(&mut self, area_id: Ipv4Addr) {
         use ospf_packet::OSPFV3_ROUTER_LSA_TYPE;
-        let mut lsa = self.build_router_lsa();
+        let mut lsa = self.build_router_lsa(area_id);
 
         let key: super::lsdb::OspfLsaKey = (OSPFV3_ROUTER_LSA_TYPE, 0, self.router_id);
-        if let Some(area) = self.areas.get(AREA0) {
+        if let Some(area) = self.areas.get(area_id) {
             let current_seq = area
                 .lsdb
                 .lookup_by_raw_key(key)
@@ -5552,12 +5619,12 @@ impl Ospf<Ospfv3> {
         lsa.update();
 
         let flood_lsa = lsa.clone();
-        if let Some(area) = self.areas.get_mut(AREA0) {
-            area.lsdb.install_originated(lsa, &self.tx, Some(AREA0));
+        if let Some(area) = self.areas.get_mut(area_id) {
+            area.lsdb.install_originated(lsa, &self.tx, Some(area_id));
             Self::ospf_spf_schedule_generic(&self.tx, area);
         }
 
-        self.flood_self_originated_lsa(AREA0, &flood_lsa);
+        self.flood_self_originated_lsa(area_id, &flood_lsa);
     }
 
     /// v3 generic Type-7 NSSA-LSA originator. Builds an
@@ -5589,20 +5656,17 @@ impl Ospf<Ospfv3> {
             ospfv3_prefix_wire_len,
         };
 
+        // RFC 5340 §A.4.9 / RFC 3101 §2.4: the P-bit (Propagate) lives
+        // in the NSSA-LSA's prefix-options. A pure NSSA ASBR sets it to
+        // ask the ABR to translate; an ABR clears it on its own Type-7s
+        // (default-LSA, ABR redistribute) so a peer ABR never
+        // re-translates them. Same `!is_abr()` rule as the v2 N/P-bit.
+        let propagate = !self.is_abr();
+
         // v3 LSA header: link_state_id is a 32-bit opaque value
-        // selected by the originator; for the NSSA default-LSA we
-        // use 0 (matches v2 ls_id == 0.0.0.0). For redistributed
-        // prefixes a future caller will pick something stable per
-        // RFC 5340 §A.4.7 conventions.
-        let link_state_id: u32 = if prefix.prefix_len() == 0 {
-            0
-        } else {
-            // Hash-style stable per-prefix LS-ID picker is a phase
-            // 6e concern; for now reuse the high 4 bytes of the
-            // prefix. Collisions are tolerated in this phase since
-            // only the default originator (ls_id=0) is wired here.
-            u32::from_be_bytes(prefix.network().octets()[0..4].try_into().unwrap_or([0; 4]))
-        };
+        // selected by the originator (ls-id 0 for the NSSA default-LSA,
+        // a full-prefix hash otherwise — see `nssa_v3_ls_id`).
+        let link_state_id = nssa_v3_ls_id(&prefix);
 
         let mut flags = 0u8;
         if metric_type_2 {
@@ -5621,11 +5685,13 @@ impl Ospf<Ospfv3> {
         let copy_len = wire_len.min(net_bytes.len());
         address_prefix[..copy_len].copy_from_slice(&net_bytes[..copy_len]);
 
+        let mut prefix_options = Ospfv3PrefixOptions::new();
+        prefix_options.set_p(propagate);
         let body = Ospfv3AsExternalLsa {
             flags,
             metric,
             prefix_length: prefix.prefix_len(),
-            prefix_options: Ospfv3PrefixOptions::new(),
+            prefix_options,
             referenced_ls_type: 0,
             address_prefix,
             forwarding_address: fwd_addr,
@@ -5671,11 +5737,7 @@ impl Ospf<Ospfv3> {
     /// `area_id` keyed by the prefix-derived ls-id (0 for default).
     fn nssa_lsa_flush_for_prefix_v3(&mut self, area_id: Ipv4Addr, prefix: ipnet::Ipv6Net) {
         use ospf_packet::OSPFV3_NSSA_LSA_TYPE;
-        let link_state_id: u32 = if prefix.prefix_len() == 0 {
-            0
-        } else {
-            u32::from_be_bytes(prefix.network().octets()[0..4].try_into().unwrap_or([0; 4]))
-        };
+        let link_state_id = nssa_v3_ls_id(&prefix);
         let key: super::lsdb::OspfLsaKey = (OSPFV3_NSSA_LSA_TYPE, link_state_id, self.router_id);
         let flushed = if let Some(area) = self.areas.get_mut(area_id) {
             area.lsdb.flush_lsa_by_raw_key(key, &self.tx, Some(area_id))
@@ -5684,6 +5746,65 @@ impl Ospf<Ospfv3> {
         };
         if let Some(lsa) = flushed {
             self.flood_self_originated_lsa(area_id, &lsa);
+        }
+    }
+
+    /// v3 sibling of `nssa_redist_connected_resync`: rebuild this
+    /// area's self-originated Type-7 (NSSA-LSA) set for redistribute-
+    /// connected from the cached RIB-known v6 connected routes
+    /// (`redist_v6`). Idempotent; originates with FA=None (the
+    /// translator and `add_nssa_routes_v3` resolve via the originator /
+    /// the translating ABR) and metric / E-bit from config.
+    pub fn nssa_redist_connected_resync_v3(&mut self, area_id: Ipv4Addr) {
+        use crate::rib::RibType;
+
+        let (entry, area_type, prev_originated) = {
+            let Some(area) = self.areas.get(area_id) else {
+                return;
+            };
+            (
+                area.redistribute.connected,
+                area.area_type,
+                area.redist_connected_originated_v6.clone(),
+            )
+        };
+
+        let desired: BTreeSet<ipnet::Ipv6Net> = if area_type.is_nssa() && entry.is_some() {
+            self.redist_v6
+                .iter()
+                .filter(|((rtype, _prefix), _entry)| *rtype == RibType::Connected)
+                .map(|((_, prefix), _)| *prefix)
+                .collect()
+        } else {
+            BTreeSet::new()
+        };
+
+        for prefix in prev_originated
+            .difference(&desired)
+            .copied()
+            .collect::<Vec<_>>()
+        {
+            self.nssa_lsa_flush_for_prefix_v3(area_id, prefix);
+            if let Some(area) = self.areas.get_mut(area_id) {
+                area.redist_connected_originated_v6.remove(&prefix);
+            }
+        }
+
+        if let Some(redist_entry) = entry
+            && area_type.is_nssa()
+        {
+            for prefix in &desired {
+                self.nssa_lsa_originate_for_prefix_v3(
+                    area_id,
+                    *prefix,
+                    redist_entry.metric,
+                    redist_entry.metric_type.is_type_2(),
+                    None,
+                );
+                if let Some(area) = self.areas.get_mut(area_id) {
+                    area.redist_connected_originated_v6.insert(*prefix);
+                }
+            }
         }
     }
 
@@ -5808,9 +5929,11 @@ impl Ospf<Ospfv3> {
         if !body.prefix_options.p() {
             return false;
         }
-        if body.forwarding_address.is_none() {
-            return false;
-        }
+        // FA=None (forwarding address absent) is permitted: the
+        // translated Type-5 also carries no FA, so receivers reach the
+        // prefix via the path to this ABR, which itself installs the
+        // Type-7 route. Mirrors the v2 `nssa_translate_one` FA=0
+        // handling.
 
         let link_state_id = type7.h.link_state_id;
         // Build a Type-5 wrapping the same body — RFC 5340 §A.4.9
@@ -5875,9 +5998,7 @@ impl Ospf<Ospfv3> {
             if !body.prefix_options.p() {
                 continue;
             }
-            if body.forwarding_address.is_none() {
-                continue;
-            }
+            // FA=None is translatable (see `nssa_translate_one_v3`).
             out.insert(Ipv4Addr::from(d.h.link_state_id));
         }
         out
@@ -9960,6 +10081,13 @@ fn build_rib6_from_spf(
         }
     }
 
+    // AS-External: walk Type-5 LSAs (incl. those translated from a
+    // Type-7 by an NSSA ABR) and install via the SPF nexthop to the
+    // originating ASBR. `lsdb_as` is empty for stub / NSSA-internal
+    // routers (Type-5 isn't flooded into those areas), so this is a
+    // no-op there.
+    add_as_external_routes_v3(top, area_id, spf_result, &mut rib);
+
     // RFC 3101 §2.5 (inherited by v3): Type-7 NSSA-LSAs flood with
     // area scope, so the walk reads from `area.lsdb` and resolves
     // the originator via this area's SPF. Gated on area being NSSA;
@@ -9996,6 +10124,131 @@ fn build_rib6_from_spf(
     }
 
     rib
+}
+
+/// Walk v3 Type-5 (AS-External, 0x4005) entries in `lsdb_as` and
+/// install routes — v3 sibling of v2's `add_as_external_routes`,
+/// modelled on `add_nssa_routes_v3`. Resolves the originating ASBR
+/// (the LSA's advertising-router — for a translated Type-5, the NSSA
+/// ABR) via this area's SPF.
+///
+/// Deferred (same incremental build-out as the v2 walker): non-zero
+/// forwarding-address resolution, and the cross-area Type-4
+/// Inter-Area-Router-LSA fallback for an ASBR reachable only through
+/// another area. A backbone observer reaches a backbone ABR directly,
+/// which is the translation case this enables.
+/// Pick a stable, collision-resistant 32-bit Link-State ID for a v3
+/// NSSA / AS-External LSA covering `prefix`. RFC 5340 §A.4.7 leaves the
+/// ls-id opaque to the originator; the only requirement is per-LSA
+/// uniqueness. A high-32-bit slice of the address collides for every
+/// prefix under a common /32 (e.g. all `2001:db8::/32` networks), so
+/// hash all 16 network octets plus the prefix length (FNV-1a). ls-id 0
+/// is reserved for the NSSA default-LSA, so a zero result (and the
+/// `::/0` default) map there; any non-default prefix that hashes to 0
+/// is nudged to 1. Residual hash collisions are vanishingly unlikely
+/// for a handful of redistributed prefixes; a per-prefix counter
+/// allocator is the robust follow-up if dense collisions ever bite.
+fn nssa_v3_ls_id(prefix: &ipnet::Ipv6Net) -> u32 {
+    if prefix.prefix_len() == 0 {
+        return 0;
+    }
+    let mut h: u32 = 0x811c_9dc5;
+    for b in prefix.network().octets() {
+        h ^= b as u32;
+        h = h.wrapping_mul(0x0100_0193);
+    }
+    h ^= prefix.prefix_len() as u32;
+    h = h.wrapping_mul(0x0100_0193);
+    if h == 0 { 1 } else { h }
+}
+
+fn add_as_external_routes_v3(
+    top: &Ospf<Ospfv3>,
+    _area_id: Ipv4Addr,
+    spf_result: &BTreeMap<usize, spf::Path>,
+    rib: &mut PrefixMap<ipnet::Ipv6Net, SpfRouteV3>,
+) {
+    use crate::ospf::lsdb::OSPF_MAX_AGE;
+    use ospf_packet::{
+        OSPFV3_AS_EXTERNAL_FLAG_E, OSPFV3_AS_EXTERNAL_LSA_TYPE, OSPFV3_LS_INFINITY, Ospfv3LsBody,
+    };
+
+    for (_key, lsa) in top.lsdb_as.iter_by_raw_type(OSPFV3_AS_EXTERNAL_LSA_TYPE) {
+        if lsa.data.h.ls_age >= OSPF_MAX_AGE {
+            continue;
+        }
+        if lsa.data.h.advertising_router == top.router_id {
+            continue;
+        }
+        let Ospfv3LsBody::AsExternal(ref ext) = lsa.data.body else {
+            continue;
+        };
+        if ext.metric >= OSPFV3_LS_INFINITY {
+            continue;
+        }
+        if ext.forwarding_address.is_some() {
+            continue;
+        }
+
+        let Some(asbr_vertex) = top.lsp_map.lookup(lsa.data.h.advertising_router) else {
+            continue;
+        };
+        let Some(asbr_path) = spf_result.get(&asbr_vertex) else {
+            continue;
+        };
+
+        let is_e2 = (ext.flags & OSPFV3_AS_EXTERNAL_FLAG_E) != 0;
+        let metric = if is_e2 {
+            ext.metric
+        } else {
+            asbr_path.cost.saturating_add(ext.metric)
+        };
+
+        let Some(net) = ospfv3_prefix_to_ipv6net(ext.prefix_length, &ext.address_prefix) else {
+            continue;
+        };
+
+        let nhops = collect_v3_nexthops(top, asbr_path);
+        if nhops.is_empty() {
+            continue;
+        }
+        let nhops_map: BTreeMap<std::net::Ipv6Addr, SpfNexthopV3> = nhops
+            .into_iter()
+            .map(|(addr, ifindex)| {
+                (
+                    addr,
+                    SpfNexthopV3 {
+                        ifindex,
+                        adjacency: false,
+                        backup: None,
+                    },
+                )
+            })
+            .collect();
+
+        let entry = SpfRouteV3 {
+            metric,
+            nhops: nhops_map,
+            sid: None,
+            prefix_sid: None,
+            dest_vertex: Some(asbr_vertex),
+            backup_as_primary: top.fast_reroute_backup_as_primary,
+        };
+        match rib.get_mut(&net) {
+            None => {
+                rib.insert(net, entry);
+            }
+            Some(curr) => {
+                if curr.metric > entry.metric {
+                    *curr = entry;
+                } else if curr.metric == entry.metric {
+                    for (addr, nhop) in entry.nhops {
+                        curr.nhops.insert(addr, nhop);
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Walk v3 Type-7 (NSSA-LSA, 0x2007) entries in the area LSDB and


### PR DESCRIPTION
## Summary

Brings OSPFv3 NSSA to parity with OSPFv2 — which first required fixing a foundational OSPFv3 multi-area bug.

### 1. Per-area Router-LSA (the prerequisite fix)
`router_lsa_originate` was hardcoded to AREA0 and `build_router_lsa` walked *every* link into one LSA — a backbone-only design. A router whose links were in a non-backbone area originated its Router-LSA into 0.0.0.0, so that area never got a topology LSA, its SPF never ran, and its routers got **zero routes**. Now `build_router_lsa(area_id)` includes only that area's links, and `router_lsa_originate` emits one Router-LSA per area the router has enabled links in (RFC 5340 §3.4.3). This fixes OSPFv3 non-backbone-area routing in general, not just NSSA. (It was never exercised — the only prior v3 test was a single backbone link.)

### 2. NSSA redistribute-connected → Type-7 → Type-5 (v3 parity)
- `config_v3`: per-area `redistribute connected` callbacks; subscribe to RIB IPv6 connected under proto `ospfv3` (not `ospf`, which lands on the v2 instance).
- `inst`: `redist_v6` cache + v3 `route_redist_add`/`route_redist_del` (v3 previously dropped RouteAdd/Del); `nssa_redist_connected_resync_v3`.
- Type-7 P-bit in prefix-options on a pure ASBR (`!is_abr`), cleared on an ABR's own Type-7s (RFC 5340 §A.4.9 / RFC 3101 §2.4).
- Relaxed v3 translator FA gate (FA=None translates, resolved via the ABR) — mirrors the v2 fix.
- `add_as_external_routes_v3`: the missing v3 Type-5 receive/install (`build_rib6_from_spf` only walked Type-7).
- `nssa_v3_ls_id`: full-prefix hash for the NSSA/AS-External Link-State ID; the old high-32-bit slice collided for every prefix under a common /32.

### BDD
`@ospfv3_nssa` (IPv6 counterpart of `@ospfv2_nssa`): ASBR → ABR-translator → backbone observer + an NSSA-internal router; plus a `nssa-translator-role never` negative scenario.

## Test plan
- `cargo fmt --check` ✓, `cargo clippy --workspace --all-targets -- -D warnings` ✓, `cargo test -p zebra-rs` ✓ (904)
- **Live end-to-end (4-node netns):** candidate — internal router learns the Type-7 external + default, backbone observer installs the translated Type-5, ABR translated 21×; never (from start) — internal keeps the Type-7, backbone never gets it.

Known follow-up (not in this PR): a candidate→never *runtime* role change doesn't yet withdraw an already-translated Type-5 (never-from-start is correct, which is what the BDD tests).

Generated with [Claude Code](https://claude.com/claude-code)