### PR TITLE
isis: add `router isis tracing bfd` category

### DIFF
--- a/book/src/ch-07-03-isis-bfd.md
+++ b/book/src/ch-07-03-isis-bfd.md
@@ -98,3 +98,41 @@ local side is transmitting but nothing is coming back — confirm the
 neighbour also has `bfd enable` on its side of the link and that UDP
 3784 is not filtered. See the
 [overview](ch-10-00-bfd.md#verifying-sessions) for the full command set.
+
+## Tracing BFD events
+
+The IS-IS↔BFD interaction is silent by default. The `bfd` category under
+`router isis tracing` turns on its traces at runtime — no rebuild, no
+global log-level change:
+
+```
+router isis {
+  tracing {
+    bfd;
+  }
+}
+```
+
+It covers the whole BFD-driven adjacency path:
+
+- the `Subscribe` issued when an adjacency comes **Up** (and the no-op when
+  the BFD subsystem isn't wired),
+- every session **state change** reported back to IS-IS,
+- the RFC 5882 §5 adjacency **teardown** on a `Down` event,
+- the **hold-down recovery** when the session returns and the next IIH may
+  re-promote the neighbour.
+
+`bfd` is a presence flag — name it to enable, delete it to disable — and
+is part of the shared `router isis tracing` block (the same model as
+[BGP conditional tracing](ch-02-10-bgp-tracing.md)), so the master `all`
+switch enables it alongside every other category. Unlike the per-PDU
+`packet` categories there is no `level` refinement: a BFD session is keyed
+per interface and neighbour address, not per IS-IS level.
+
+Every traced line is stamped `proto="isis"`, so the
+[Protocol-Specific Logging](ch-03-03-protocol-logging.md) recipes apply —
+e.g. `jq 'select(.proto=="isis" and (.message | contains("bfd")))'`.
+
+> **Note.** This category also gates the adjacency-teardown message (the
+> RFC 5882 §5 `warn`). Enable `tracing bfd` when diagnosing why an
+> adjacency dropped on a BFD `Down`.

--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -1862,7 +1862,9 @@ impl Isis {
 
     fn process_bfd_subscribe(&self, key: crate::bfd::session::SessionKey) {
         let Some(tx) = self.bfd_client_tx.as_ref() else {
-            tracing::debug!(?key, "isis: bfd not configured; skipping subscribe");
+            if self.tracing.should_trace_bfd() {
+                tracing::debug!(?key, "isis: bfd not configured; skipping subscribe");
+            }
             return;
         };
         // Resolve the interface's effective Echo config (per-interface `bfd {}`
@@ -2394,13 +2396,15 @@ impl Isis {
     /// transition and are ignored.
     pub fn process_bfd_event(&mut self, event: crate::bfd::inst::BfdEvent) {
         let crate::bfd::inst::BfdEvent::StateChange { key, change } = event;
-        tracing::info!(
-            ?key,
-            from = %change.from,
-            to = %change.to,
-            diag = %change.diag,
-            "isis: bfd session state change",
-        );
+        if self.tracing.should_trace_bfd() {
+            tracing::info!(
+                ?key,
+                from = %change.from,
+                to = %change.to,
+                diag = %change.diag,
+                "isis: bfd session state change",
+            );
+        }
 
         if change.from == change.to {
             return;
@@ -2430,20 +2434,27 @@ impl Isis {
         change: &crate::bfd::session::StateChange,
     ) {
         let Some((level, sys_id)) = self.bfd_resolve_neighbor(key, false) else {
-            tracing::debug!(?key, "isis: bfd-down for unknown neighbor; ignoring");
+            if self.tracing.should_trace_bfd() {
+                tracing::debug!(?key, "isis: bfd-down for unknown neighbor; ignoring");
+            }
             return;
         };
         let ifindex = key.ifindex;
+        // Capture the toggle before borrowing the link — `link_top` takes
+        // `&mut self`, so `self.tracing` is unreachable while `link` is held.
+        let trace_bfd = self.tracing.should_trace_bfd();
         let Some(mut link) = self.link_top(ifindex) else {
             return;
         };
-        tracing::warn!(
-            peer = %key.remote,
-            ifindex,
-            ?level,
-            diag = %change.diag,
-            "isis: tearing down adjacency on bfd-down (RFC 5882 §5)",
-        );
+        if trace_bfd {
+            tracing::warn!(
+                peer = %key.remote,
+                ifindex,
+                ?level,
+                diag = %change.diag,
+                "isis: tearing down adjacency on bfd-down (RFC 5882 §5)",
+            );
+        }
         // Tear the adjacency but keep the BFD session probing. This clears any
         // prior hold-down pin, so set the pin afterwards.
         nbr_hold_timer_expire(&mut link, level, sys_id, false);
@@ -2473,11 +2484,13 @@ impl Isis {
                 };
                 match link.state.bfd_holddown_nbr.remove(key) {
                     Some(pair) => {
-                        tracing::info!(
-                            peer = %key.remote,
-                            ifindex = key.ifindex,
-                            "isis: bfd recovered via fallback map (nbr not yet re-created)",
-                        );
+                        if self.tracing.should_trace_bfd() {
+                            tracing::info!(
+                                peer = %key.remote,
+                                ifindex = key.ifindex,
+                                "isis: bfd recovered via fallback map (nbr not yet re-created)",
+                            );
+                        }
                         pair
                     }
                     None => return,
@@ -2491,14 +2504,16 @@ impl Isis {
         // Also clean up the fallback map entry for this key (may already be
         // gone if the fallback path above consumed it).
         link.state.bfd_holddown_nbr.remove(key);
-        if link.state.bfd_holddown.get_mut(&level).remove(&sys_id) {
+        // Lift the hold-down pin (the `remove` side-effect always runs); the
+        // next received IIH re-promotes the held (Init) neighbour.
+        let lifted = link.state.bfd_holddown.get_mut(&level).remove(&sys_id);
+        if lifted && self.tracing.should_trace_bfd() {
             tracing::info!(
                 peer = %key.remote,
                 ifindex = key.ifindex,
                 ?level,
                 "isis: bfd recovered; lifting adjacency hold-down",
             );
-            // The next received IIH re-promotes the held (Init) neighbour.
         }
     }
     pub fn top(&mut self) -> IsisTop<'_> {

--- a/zebra-rs/src/isis/tracing.rs
+++ b/zebra-rs/src/isis/tracing.rs
@@ -172,6 +172,11 @@ pub struct IsisTracing {
     pub lsp_originate: EventConfig,
     pub lsp_purge: EventConfig,
     pub lsdb: EventConfig,
+    /// IS-IS↔BFD interaction (RFC 5882): session state changes, subscribe,
+    /// adjacency teardown and hold-down recovery. A bare toggle — a BFD
+    /// session is keyed per interface and neighbor address, not per IS-IS
+    /// level, so there is no `level` refinement.
+    pub bfd: bool,
 }
 
 impl IsisTracing {
@@ -228,6 +233,13 @@ impl IsisTracing {
             DatabaseType::Lsdb => &self.lsdb,
         };
         cfg.enabled && cfg.level.matches(level)
+    }
+
+    /// Whether IS-IS↔BFD interaction (RFC 5882 session events, subscribe /
+    /// adjacency teardown / hold-down recovery) should be traced. The `all`
+    /// master switch applies on top of the `bfd` toggle.
+    pub fn should_trace_bfd(&self) -> bool {
+        self.all || self.bfd
     }
 }
 
@@ -316,11 +328,15 @@ fn event_set_level(ec: &mut EventConfig, args: &mut Args, op: ConfigOp) {
 /// `IsisTracing`. `rest` is the path tail after the `tracing` node
 /// (e.g. `/all`, `/packet/hello`, `/packet/hello/direction`,
 /// `/packet/lsp/level`, `/fsm/nfsm`, `/lsp-originate`,
-/// `/lsdb/level`); for the direction / level cases `args` still holds the
-/// trailing value.
+/// `/lsdb/level`, `/bfd`); for the direction / level cases `args` still
+/// holds the trailing value.
 fn apply_tracing(t: &mut IsisTracing, rest: &str, args: &mut Args, op: ConfigOp) -> Option<()> {
     match rest {
         "/all" => t.all = op.is_set(),
+        // `bfd` is a bare presence toggle (no level — a BFD session is not
+        // IS-IS-level-scoped), so handle it here rather than via the
+        // level-bearing event branch below.
+        "/bfd" => t.bfd = op.is_set(),
         other => {
             if let Some(pkt) = other.strip_prefix("/packet/") {
                 let (typ, sub) = match pkt.split_once('/') {
@@ -535,10 +551,26 @@ mod tests {
         assert!(t.should_trace_fsm());
         assert!(t.should_trace_event(EventType::LspOriginate, &Level::L2));
         assert!(t.should_trace_database(DatabaseType::Lsdb, &Level::L1));
+        assert!(t.should_trace_bfd());
 
         apply_tracing(&mut t, "/all", &mut args(&[]), ConfigOp::Delete);
         assert!(!t.all);
         assert!(!t.should_trace_packet(PacketType::Hello, PacketDirection::Send, &Level::L1));
+        assert!(!t.should_trace_bfd());
+    }
+
+    #[test]
+    fn bfd_toggle() {
+        let mut t = IsisTracing::default();
+        assert!(!t.should_trace_bfd());
+        apply_tracing(&mut t, "/bfd", &mut args(&[]), ConfigOp::Set);
+        assert!(t.bfd);
+        assert!(t.should_trace_bfd());
+        // bfd is independent of the other categories.
+        assert!(!t.should_trace_fsm());
+        apply_tracing(&mut t, "/bfd", &mut args(&[]), ConfigOp::Delete);
+        assert!(!t.bfd);
+        assert!(!t.should_trace_bfd());
     }
 
     #[test]

--- a/zebra-rs/yang/zebra-isis-tracing.yang
+++ b/zebra-rs/yang/zebra-isis-tracing.yang
@@ -31,9 +31,9 @@ module zebra-isis-tracing {
      consulted by gated log macros, so categories can be turned on at
      runtime without a rebuild) with the IS-IS-specific category set: the
      four PDU types, the neighbor state machine, LSP origination / purge,
-     and the link-state database. The IS-IS-specific addition over the
-     OSPF model is a functional `level` filter (level-1 / level-2) on the
-     packet and event categories.
+     the link-state database, and the BFD interaction (RFC 5882). The
+     IS-IS-specific addition over the OSPF model is a functional `level`
+     filter (level-1 / level-2) on the packet and event categories.
 
      Example:
 
@@ -52,6 +52,16 @@ module zebra-isis-tracing {
      to disable; absence means the category is silent. Enabling by
      presence (rather than a `true` value) matches OSPF / BGP `tracing`:
      the config dispatch keys off set vs delete and never reads a value.";
+
+  revision 2026-06-07 {
+    description
+      "Add the `bfd` presence container — gates IS-IS↔BFD interaction
+       traces (RFC 5882 session state changes, subscribe / adjacency
+       teardown / hold-down recovery). A bare presence flag with no
+       level refinement: a BFD session is keyed per interface and
+       neighbor address, not per IS-IS level, so a `level` filter would
+       be a no-op knob.";
+  }
 
   revision 2026-06-05 {
     description
@@ -206,6 +216,12 @@ module zebra-isis-tracing {
         ext:help "Trace the link-state database";
         presence "Trace LSDB install / flooding decisions";
         uses isis-tracing-level-options;
+      }
+      container bfd {
+        ext:help "Trace BFD interaction (RFC 5882)";
+        presence
+          "Trace IS-IS↔BFD interaction — session state changes,
+           subscribe, adjacency teardown and hold-down recovery";
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds a `bfd` category to the `router isis tracing` config tree and gates
all IS-IS↔BFD interaction trace sites behind it — consistent with the
BGP/OSPF conditional-tracing model (gated log macros consulting a typed
config block, toggled at runtime without a rebuild).

```
router isis {
  tracing {
    bfd;
  }
}
```

**Changes**
- **`zebra-isis-tracing.yang`** — new `bfd` presence container under
  `tracing` + a `2026-06-07` revision entry and description update.
  Modeled as a bare flag (no `level` refinement): a BFD session is keyed
  per interface + neighbour address, not per IS-IS level, so a level
  filter would be a no-op knob.
- **`isis/tracing.rs`** — `pub bfd: bool` on `IsisTracing`,
  `should_trace_bfd()` (`self.all || self.bfd`), a `"/bfd"` arm in
  `apply_tracing`, and a `bfd_toggle` unit test. The path reaches the
  dispatcher via the existing `config_tracing_dispatch` fallback — no
  callback-table entry needed.
- **`isis/inst.rs`** — enclose all six BFD `tracing::*!` sites
  (`process_bfd_subscribe` / `_event` / `_down` / `_up`) in
  `if …should_trace_bfd()`.
- **`book/`** — new "Tracing BFD events" section on the IS-IS BFD page.

**Note on scope:** this also gates the RFC 5882 §5 adjacency-teardown
`warn!`, so with the category off (the default) that warning is silent —
a deliberate departure from BGP's "warnings stay on" convention, called
out in the book. Easy to un-gate that one site if preferred.

## Test plan
- `cargo fmt --all` — clean
- `cargo test -p zebra-rs isis::tracing::` — 6 passed (incl. new `bfd_toggle`)
- `cargo test -p zebra-rs config::manager` (loads the real YANG dir) — 6 passed → YANG parses/loads
- `cargo clippy --workspace --all-targets -- -D warnings` — clean

Generated with [Claude Code](https://claude.com/claude-code)