### PR TITLE
ospf: fix OSPFv3 runtime NSSA translator-role withdrawal

### DIFF
--- a/zebra-rs/src/config/ospf.rs
+++ b/zebra-rs/src/config/ospf.rs
@@ -47,6 +47,17 @@ pub fn despawn_ospf(config: &ConfigManager) {
 /// manager / protocol-tasks tables so it doesn't collide with a
 /// concurrent OSPFv2 instance.
 pub fn spawn_ospfv3(config: &ConfigManager) {
+    // Idempotent: `commit_config` calls this on every commit whose diff
+    // touches `router ospfv3` (a leaf change emits a `router ospfv3 …`
+    // line), but the instance must be spawned only once. Re-spawning
+    // would replace the live task — discarding its LSDB and translator
+    // state, and orphaning self-originated AS-scoped LSAs on neighbors
+    // (a translated Type-5 never gets a MaxAge). Config changes reach
+    // the running instance through its `cm` subscription, so a respawn
+    // is never needed to apply them.
+    if config.protocol_tasks.borrow().contains_key("ospfv3") {
+        return;
+    }
     let (rib_client, rib_rx) = config.subscribe_to_rib("ospfv3");
     let ctx = ProtoContext::default_table(rib_client);
     // `"ospfv3"` default label; per-VRF children get

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -6549,10 +6549,21 @@ impl Ospf<Ospfv3> {
                 }
             }
             Message::SpfSchedule(area_id) => {
-                if let Some(area_id) = area_id
-                    && let Some(area) = self.areas.get_mut(area_id)
-                {
-                    Self::ospf_spf_schedule_generic(&self.tx, area);
+                if let Some(area_id) = area_id {
+                    if let Some(area) = self.areas.get_mut(area_id) {
+                        Self::ospf_spf_schedule_generic(&self.tx, area);
+                    }
+                } else {
+                    // None = AS-scope event (Type-5 AS-External install /
+                    // MaxAge): recompute every attached area so each
+                    // area's RIB re-runs `add_as_external_routes_v3` and
+                    // installs or drops the external. Mirrors v2.
+                    let area_ids: Vec<Ipv4Addr> = self.areas.iter().map(|(id, _)| *id).collect();
+                    for id in area_ids {
+                        if let Some(area) = self.areas.get_mut(id) {
+                            Self::ospf_spf_schedule_generic(&self.tx, area);
+                        }
+                    }
                 }
             }
             Message::SpfCalc(area_id) => {

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -1405,6 +1405,7 @@ fn ospfv3_ls_upd_proc(
         }
         let cloned = lsa.clone();
         let mut area_lsa_installed = false;
+        let mut as_lsa_installed = false;
         match scope {
             Ospfv3LsaScope::Area => {
                 // Go through `insert_received_v3` so RFC 8666 §3 SR
@@ -1416,6 +1417,7 @@ fn ospfv3_ls_upd_proc(
             }
             Ospfv3LsaScope::As => {
                 oi.lsdb_as.install_lsa(cloned, oi.tx, None);
+                as_lsa_installed = true;
             }
             Ospfv3LsaScope::Link => {
                 oi.link_lsdb.install_lsa(cloned, oi.tx, Some(area_id));
@@ -1426,6 +1428,15 @@ fn ospfv3_ls_upd_proc(
         }
         if area_lsa_installed {
             let _ = oi.tx.send(Message::SpfSchedule(Some(area_id)));
+        }
+        if as_lsa_installed {
+            // AS-scoped (Type-5 AS-External, including a MaxAge
+            // withdrawal): recompute every area's RIB so the external
+            // route is installed or dropped. `None` fans out to all
+            // areas (mirrors v2's AS-external flood hook). Without this
+            // a lone Type-5 change — e.g. a translated route being
+            // withdrawn — never triggers SPF on the receiver.
+            let _ = oi.tx.send(Message::SpfSchedule(None));
         }
 
         // RFC 3101 §3 (v3 mirror of v2's phase 4a/4b hook):


### PR DESCRIPTION
## Summary

Fixes the one open follow-up from the OSPFv3 NSSA work (#1256): a runtime `nssa-translator-role` change (candidate→never) did not withdraw the already-translated Type-5 from the backbone.

### Root cause — a spurious respawn
`commit_config` calls `spawn_ospfv3` on every commit whose diff contains a `router ospfv3 …` line — and any leaf edit (e.g. `nssa-translator-role`) emits one. `spawn_ospfv3` then built a **new instance and replaced the live task**, discarding its LSDB + NSSA translator state. The translated Type-5 vanished from the old instance **without a MaxAge flood**, leaving the backbone with an un-withdrawable orphan.

### Fix (2 commits, ~37 lines)
1. **`config: don't respawn the OSPFv3 instance on every config change`** — make `spawn_ospfv3` idempotent (skip if the task exists). Config changes reach the running instance via its `cm` subscription, so a respawn is never needed; `despawn_ospfv3` still removes the task, so delete+re-add re-spawns correctly. The instance/LSDB persist, so the never-resync flushes the Type-5 directly.
2. **`ospf: reschedule SPF on OSPFv3 AS-External LSA changes`** — v3 never sent `SpfSchedule` for AS-scoped LSAs and ignored `None`; a lone Type-5 MaxAge triggered no SPF on the receiver. Mirror v2: emit `SpfSchedule(None)` on AS-scoped install + handle `None`→all-areas.

## Test plan
- `cargo fmt --check` ✓, `cargo clippy --workspace --all-targets -- -D warnings` ✓, `cargo test -p zebra-rs` ✓ (904)
- **Live (4-node netns), deterministic over 3 runs:** candidate → backbone observer has the translated Type-5; `never` → it is **withdrawn in ~12s** while the NSSA-internal router keeps its Type-7; flip back to `candidate` → it re-installs.

Note: `spawn_ospf`/`spawn_isis`/`spawn_bgp` share the same respawn-on-every-commit pattern and deserve the same idempotency — left untouched to keep this scoped to the confirmed v3 bug.

Generated with [Claude Code](https://claude.com/claude-code)