### PR TITLE
config: make spawn_ospf/isis/bgp idempotent

### DIFF
--- a/zebra-rs/src/config/bgp.rs
+++ b/zebra-rs/src/config/bgp.rs
@@ -4,6 +4,13 @@ use crate::rib;
 use super::ConfigManager;
 
 pub fn spawn_bgp(config: &ConfigManager) {
+    // Idempotent — see `spawn_ospfv3`. `commit_config` calls this on
+    // every commit whose diff touches `router bgp`; re-spawning would
+    // replace the live task and tear down every BGP session + Loc-RIB.
+    // Config reaches the running instance via its `cm` subscription.
+    if config.protocol_tasks.borrow().contains_key("bgp") {
+        return;
+    }
     // Capture BFD / ND client handles so per-neighbor `bfd { enable }`
     // and IPv6 unnumbered RA hand-off can submit requests later. Both
     // are guaranteed to be populated when BGP is spawned via

--- a/zebra-rs/src/config/isis.rs
+++ b/zebra-rs/src/config/isis.rs
@@ -5,6 +5,13 @@ use crate::rib;
 use super::ConfigManager;
 
 pub fn spawn_isis(config: &ConfigManager) {
+    // Idempotent — see `spawn_ospfv3`. `commit_config` calls this on
+    // every commit whose diff touches `router isis`; re-spawning would
+    // replace the live task and discard its LSDB / adjacencies. Config
+    // reaches the running instance via its `cm` subscription.
+    if config.protocol_tasks.borrow().contains_key("isis") {
+        return;
+    }
     // Capture BFD's client handle so per-interface `isis bfd` can later
     // submit Subscribe / Unsubscribe. `commit_config` spawns BFD
     // eagerly before IS-IS, so the handle is always live here —

--- a/zebra-rs/src/config/ospf.rs
+++ b/zebra-rs/src/config/ospf.rs
@@ -5,6 +5,13 @@ use crate::rib;
 use super::ConfigManager;
 
 pub fn spawn_ospf(config: &ConfigManager) {
+    // Idempotent — see `spawn_ospfv3`. `commit_config` calls this on
+    // every commit whose diff touches `router ospf`; re-spawning would
+    // replace the live task and discard its LSDB / translator state.
+    // Config reaches the running instance via its `cm` subscription.
+    if config.protocol_tasks.borrow().contains_key("ospf") {
+        return;
+    }
     let (rib_client, rib_rx) = config.subscribe_to_rib("ospf");
     let ctx = ProtoContext::default_table(rib_client);
     // `"ospf"` is the default-instance proto label; per-VRF children


### PR DESCRIPTION
## Summary

Extends the OSPFv3 fix (#1258) to the other routing protocols. `commit_config` calls `spawn_<proto>` on every commit whose diff touches `router <proto>` — and any leaf edit emits such a line — so a routine runtime config change **re-spawned** the protocol task, replacing the live instance and tearing down its LSDB / adjacencies (and, for BGP, every session + Loc-RIB).

Config changes already reach the running instance through its `cm` subscription, so a respawn is never needed to apply them; each `despawn_<proto>` still removes the `protocol_tasks` key, so a delete+re-add re-spawns correctly.

Guard each of `spawn_ospf` / `spawn_isis` / `spawn_bgp` with:
```rust
if config.protocol_tasks.borrow().contains_key("<proto>") { return; }
```

## Test plan
- `cargo fmt --check` ✓, `cargo clippy --workspace --all-targets -- -D warnings` ✓, `cargo test -p zebra-rs` ✓ (905)
- Confirmed the only callers are `commit_config` (no restart/checkpoint path relies on replacing the instance); both `spawn_bgp` call sites are `if !bgp`-gated.
- **Live (OSPFv2):** a runtime `interface cost` change now keeps the adjacency Full (uptime continues, no reset) instead of flapping the instance.

Note: `spawn_nd` / `spawn_bfd` share the same pattern and could get the same guard — left for a focused follow-up.

Generated with [Claude Code](https://claude.com/claude-code)