### PR TITLE
bgp: per-neighbor allowas-in (count/origin) with show + BDD

### DIFF
--- a/bdd/tests/configs/bgp_allowas_in/z1.yaml
+++ b/bdd/tests/configs/bgp_allowas_in/z1.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_allowas_in/z2.yaml
+++ b/bdd/tests/configs/bgp_allowas_in/z2.yaml
@@ -1,0 +1,29 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+- if-name: i2
+  ipv4:
+    address: 192.168.1.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    - remote-address: 192.168.1.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001

--- a/bdd/tests/configs/bgp_allowas_in/z3-allowas.yaml
+++ b/bdd/tests/configs/bgp_allowas_in/z3-allowas.yaml
@@ -1,0 +1,23 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.1.3/24
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.1.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.1.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      # Bare presence container → default occurrence budget of 3.
+      # (`allowas-in:` with a null value lowers to `set ... allowas-in`.)
+      allowas-in:

--- a/bdd/tests/configs/bgp_allowas_in/z3-base.yaml
+++ b/bdd/tests/configs/bgp_allowas_in/z3-base.yaml
@@ -1,0 +1,20 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.1.3/24
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.1.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.1.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/configs/bgp_allowas_in/z3-origin.yaml
+++ b/bdd/tests/configs/bgp_allowas_in/z3-origin.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.1.3/24
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.1.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.1.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      # origin mode → accept only when our AS is the route's origin.
+      # (`origin:` is a `type empty` leaf → `set ... allowas-in origin`.)
+      allowas-in:
+        origin:

--- a/bdd/tests/features/bgp_allowas_in.feature
+++ b/bdd/tests/features/bgp_allowas_in.feature
@@ -1,0 +1,68 @@
+@serial
+@bgp_allowas_in
+Feature: BGP allowas-in relaxes the inbound AS_PATH loop check
+  As a network operator
+  I want `neighbor X allowas-in [count <1-10>|origin]`
+  So a neighbor can accept routes whose AS_PATH already contains my AS.
+
+  Test Topology (a line, where z1 and z3 share AS 65001):
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐  192.168.1.0/24  ┌─────────┐
+   │   z1    │ i1────────────i1 │   z2    │ i2────────────i1 │   z3    │
+   │ AS65001 │                  │ AS65002 │                  │ AS65001 │
+   │ .0.1    │                  │.0.2 .1.2│                  │ .1.3    │
+   └─────────┘                  └─────────┘                  └─────────┘
+  ```
+
+  z1 originates 10.0.0.1/32. It reaches z2 with AS_PATH "65001", and z2
+  re-advertises it to z3 with AS_PATH "65002 65001". Because z3 is also
+  AS 65001, the RFC 4271 inbound loop check drops it — unless z3 has
+  `allowas-in` configured on the session toward z2.
+
+  Config files:
+  - z1.yaml / z2.yaml: static line topology, z1 originates 10.0.0.1/32
+  - z3-base.yaml:    z3 without allowas-in (strict loop check)
+  - z3-allowas.yaml: z3 with bare `allowas-in` (default count 3)
+  - z3-origin.yaml:  z3 with `allowas-in origin`
+
+  Scenario: Setup line topology and establish all sessions
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I create namespace "z3"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I connect namespace "z2" interface "i2" to namespace "z3" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3-base.yaml" to namespace "z3"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z2" to "192.168.1.3" should be "Established"
+    And BGP session in "z3" to "192.168.1.2" should be "Established"
+
+  Scenario: Default RFC 4271 loop check drops the route at z3
+    Given the test topology exists
+    # z2 has it (so propagation reached the relay), but z3 drops it
+    # because its own AS 65001 is in the AS_PATH.
+    Then BGP route in "z2" has "10.0.0.1/32"
+    And BGP route in "z3" does not have "10.0.0.1/32"
+
+  Scenario: allowas-in lets z3 accept the looped route
+    Given the test topology exists
+    When I apply config "z3-allowas.yaml" to namespace "z3"
+    And I clear namespace "z3" neighbor "192.168.1.2"
+    And I wait 15 seconds for BGP to operate
+    Then BGP route in "z3" has "10.0.0.1/32"
+    And show command "show ip bgp neighbors" in namespace "z3" should contain "Allowas-in: 3 occurrence(s)"
+
+  Scenario: allowas-in origin mode accepts the route and shows in neighbor output
+    Given the test topology exists
+    When I apply config "z3-origin.yaml" to namespace "z3"
+    And I clear namespace "z3" neighbor "192.168.1.2"
+    And I wait 15 seconds for BGP to operate
+    Then BGP route in "z3" has "10.0.0.1/32"
+    And show command "show ip bgp neighbors" in namespace "z3" should contain "Allowas-in: origin"

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -18,7 +18,7 @@ use super::route_clean;
 use super::{
     Bgp,
     inst::Callback,
-    peer::{PasswordEncoding, Peer, PeerType},
+    peer::{ALLOWAS_IN_DEFAULT_COUNT, AllowAsIn, PasswordEncoding, Peer, PeerType},
     timer,
 };
 
@@ -469,6 +469,62 @@ fn config_flowspec_validation(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Op
     let peer = bgp.peers.get_mut(&addr)?;
 
     peer.config.flowspec_validation = if op.is_set() { flag } else { true };
+    Some(())
+}
+
+/// `set router bgp neighbor X allowas-in` — the presence container
+/// (zebra-bgp-allowas-in.yang). The bare form enables loop relaxation
+/// with the default occurrence budget; `delete` disables it.
+///
+/// `count` / `origin` ride their own callbacks. All three are
+/// order-independent within a commit: this handler uses `get_or_insert`
+/// so it never clobbers a `count`/`origin` that landed first, and the
+/// child handlers overwrite the default this one seeds.
+fn config_allowas_in(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let peer = bgp.peers.get_mut(&addr)?;
+
+    if op.is_set() {
+        peer.config
+            .allowas_in
+            .get_or_insert(AllowAsIn::Count(ALLOWAS_IN_DEFAULT_COUNT));
+    } else {
+        peer.config.allowas_in = None;
+    }
+    Some(())
+}
+
+/// `set router bgp neighbor X allowas-in count <1-10>`. Deleting just
+/// the count reverts to the default budget while the container stays
+/// enabled; full removal goes through [`config_allowas_in`].
+fn config_allowas_in_count(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+
+    if op.is_set() {
+        let count = args.u8()?;
+        let peer = bgp.peers.get_mut(&addr)?;
+        peer.config.allowas_in = Some(AllowAsIn::Count(count));
+    } else {
+        let peer = bgp.peers.get_mut(&addr)?;
+        if matches!(peer.config.allowas_in, Some(AllowAsIn::Count(_))) {
+            peer.config.allowas_in = Some(AllowAsIn::Count(ALLOWAS_IN_DEFAULT_COUNT));
+        }
+    }
+    Some(())
+}
+
+/// `set router bgp neighbor X allowas-in origin`. Deleting `origin`
+/// reverts to the default count budget while the container stays
+/// enabled; full removal goes through [`config_allowas_in`].
+fn config_allowas_in_origin(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let peer = bgp.peers.get_mut(&addr)?;
+
+    if op.is_set() {
+        peer.config.allowas_in = Some(AllowAsIn::Origin);
+    } else if matches!(peer.config.allowas_in, Some(AllowAsIn::Origin)) {
+        peer.config.allowas_in = Some(AllowAsIn::Count(ALLOWAS_IN_DEFAULT_COUNT));
+    }
     Some(())
 }
 
@@ -2086,6 +2142,15 @@ impl Bgp {
 
         // Per-neighbor Flowspec validation toggle (zebra-bgp-flowspec.yang).
         self.callback_peer("/flowspec/validation", config_flowspec_validation);
+
+        // Per-neighbor allowas-in (zebra-bgp-allowas-in.yang). The
+        // presence container relaxes the inbound AS_PATH loop check;
+        // `count` caps occurrences (default 3) and `origin` accepts the
+        // local AS only at the origin. `count`/`origin` are mutually
+        // exclusive via the YANG `choice`.
+        self.callback_peer("/allowas-in", config_allowas_in);
+        self.callback_peer("/allowas-in/count", config_allowas_in_count);
+        self.callback_peer("/allowas-in/origin", config_allowas_in_origin);
     }
 }
 

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -257,6 +257,26 @@ impl PeerBfdConfig {
     }
 }
 
+/// Default occurrence budget for a bare `allowas-in` (FRR parity).
+pub const ALLOWAS_IN_DEFAULT_COUNT: u8 = 3;
+
+/// Per-neighbor `allowas-in` mode (zebra-bgp-allowas-in.yang). Relaxes
+/// the RFC 4271 inbound AS_PATH loop check so routes carrying the local
+/// AS are accepted. `None` on [`PeerConfig`] means the strict check
+/// applies (the default).
+/// Serializes as `{"mode":"count","count":N}` or `{"mode":"origin"}`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(tag = "mode", content = "count", rename_all = "lowercase")]
+pub enum AllowAsIn {
+    /// Accept while the local AS appears at most this many times in the
+    /// AS_PATH (CLI `allowas-in` / `allowas-in count <1-10>`, default
+    /// [`ALLOWAS_IN_DEFAULT_COUNT`]).
+    Count(u8),
+    /// Accept only when the local AS appears solely as the originating
+    /// (right-most) AS (CLI `allowas-in origin`).
+    Origin,
+}
+
 #[derive(Debug, Clone)]
 pub struct PeerConfig {
     pub transport: PeerTransportConfig,
@@ -295,6 +315,9 @@ pub struct PeerConfig {
     pub remote_as_inherited: bool,
     /// BFD attachment for this neighbor.
     pub bfd: PeerBfdConfig,
+    /// Per-neighbor `allowas-in` (zebra-bgp-allowas-in.yang). `None`
+    /// keeps the strict RFC 4271 inbound AS_PATH loop check.
+    pub allowas_in: Option<AllowAsIn>,
 }
 
 impl Default for PeerConfig {
@@ -315,6 +338,7 @@ impl Default for PeerConfig {
             neighbor_group: None,
             remote_as_inherited: false,
             bfd: PeerBfdConfig::default(),
+            allowas_in: None,
         }
     }
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -14,7 +14,7 @@ use crate::rib::{self, MacAddr, api::FdbEntry};
 use crate::{bgp_adj_in_trace, bgp_adj_out_trace};
 
 use super::cap::CapAfiMap;
-use super::peer::{BgpTop, Event, Peer, PeerType};
+use super::peer::{AllowAsIn, BgpTop, Event, Peer, PeerType};
 use super::peer_map::PeerMap;
 use super::timer::{start_adv_timer_vpnv4, start_adv_timer_vpnv6};
 use super::{Bgp, InOut, Message};
@@ -32,6 +32,52 @@ impl BgpRibType {
     pub fn is_originated(&self) -> bool {
         *self == BgpRibType::Originated
     }
+}
+
+/// RFC 4271 inbound AS_PATH loop check, relaxed per-neighbor by
+/// `allowas-in` (zebra-bgp-allowas-in.yang). Returns `true` when the
+/// update must be dropped because the local AS appears in the AS_PATH
+/// more often than the neighbor's `allowas-in` setting permits.
+///
+/// * `None` — strict RFC 4271: any occurrence is a loop.
+/// * `Count(n)` — accept while the local AS appears at most `n` times.
+/// * `Origin` — accept only when every occurrence of the local AS is the
+///   originating (right-most) AS; a local AS in any transit position is
+///   still a loop.
+fn aspath_local_as_loop(aspath: &As4Path, local_as: u32, allow: Option<AllowAsIn>) -> bool {
+    let occurrences = aspath
+        .segs
+        .iter()
+        .flat_map(|seg| seg.asn.iter())
+        .filter(|asn| **asn == local_as)
+        .count();
+    if occurrences == 0 {
+        return false;
+    }
+    match allow {
+        None => true,
+        Some(AllowAsIn::Count(max)) => occurrences > max as usize,
+        Some(AllowAsIn::Origin) => !local_as_only_at_origin(aspath, local_as),
+    }
+}
+
+/// True when every occurrence of `local_as` is the trailing originating
+/// AS (prepends at the origin are allowed) — i.e. it never appears as a
+/// transit AS. Used by [`AllowAsIn::Origin`].
+fn local_as_only_at_origin(aspath: &As4Path, local_as: u32) -> bool {
+    let flat: Vec<u32> = aspath
+        .segs
+        .iter()
+        .flat_map(|seg| seg.asn.iter().copied())
+        .collect();
+    // The origin is the right-most ASN; it must be the local AS.
+    if flat.last() != Some(&local_as) {
+        return false;
+    }
+    // Skip the trailing run of local-AS prepends; the remaining prefix
+    // must not contain the local AS anywhere else.
+    let trailing = flat.iter().rev().take_while(|&&a| a == local_as).count();
+    !flat[..flat.len() - trailing].contains(&local_as)
 }
 
 /// Build a `rib::entry::RibEntry` from the BGP best-path winner for an
@@ -1836,16 +1882,14 @@ pub fn route_ipv4_update(
 
         // RFC 4271: Drop update if local AS appears in AS_PATH (loop detection for EBGP)
         // This prevents routing loops by detecting if the route has already passed through this AS
-        if let Some(ref aspath) = attr.aspath {
-            for segment in &aspath.segs {
-                if segment.asn.contains(&peer.local_as) {
-                    eprintln!(
-                        "Dropping update for {} from peer {} - local AS {} found in AS_PATH",
-                        nlri.prefix, peer.address, peer.local_as
-                    );
-                    return;
-                }
-            }
+        if let Some(ref aspath) = attr.aspath
+            && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
+        {
+            eprintln!(
+                "Dropping update for {} from peer {} - local AS {} found in AS_PATH",
+                nlri.prefix, peer.address, peer.local_as
+            );
+            return;
         }
 
         // RFC 4456: Drop update if ORIGINATOR_ID matches local router ID. This
@@ -3086,12 +3130,10 @@ pub fn route_ipv6_update(
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
 
         // RFC 4271 / 4456 loop detection — identical to the v4 path.
-        if let Some(ref aspath) = attr.aspath {
-            for segment in &aspath.segs {
-                if segment.asn.contains(&peer.local_as) {
-                    return;
-                }
-            }
+        if let Some(ref aspath) = attr.aspath
+            && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
+        {
+            return;
         }
         if let Some(ref originator_id) = attr.originator_id
             && originator_id.id == *bgp.router_id
@@ -3326,12 +3368,10 @@ pub fn route_labelv4_update(
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
 
         // RFC 4271 / 4456 loop detection — identical to the unicast path.
-        if let Some(ref aspath) = attr.aspath {
-            for segment in &aspath.segs {
-                if segment.asn.contains(&peer.local_as) {
-                    return;
-                }
-            }
+        if let Some(ref aspath) = attr.aspath
+            && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
+        {
+            return;
         }
         if let Some(ref originator_id) = attr.originator_id
             && originator_id.id == *bgp.router_id
@@ -3422,12 +3462,10 @@ pub fn route_labelv6_update(
     let (peer_ident, peer_router_id, typ) = {
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
 
-        if let Some(ref aspath) = attr.aspath {
-            for segment in &aspath.segs {
-                if segment.asn.contains(&peer.local_as) {
-                    return;
-                }
-            }
+        if let Some(ref aspath) = attr.aspath
+            && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
+        {
+            return;
         }
         if let Some(ref originator_id) = attr.originator_id
             && originator_id.id == *bgp.router_id
@@ -3930,12 +3968,10 @@ pub fn route_evpn_update(
     let (peer_ident, peer_router_id, typ) = {
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
 
-        if let Some(ref aspath) = attr.aspath {
-            for segment in &aspath.segs {
-                if segment.asn.contains(&peer.local_as) {
-                    return;
-                }
-            }
+        if let Some(ref aspath) = attr.aspath
+            && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
+        {
+            return;
         }
         if let Some(ref originator_id) = attr.originator_id
             && originator_id.id == *bgp.router_id
@@ -4073,12 +4109,10 @@ pub fn route_flowspec_update(
     let (peer_ident, peer_router_id, typ) = {
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
 
-        if let Some(ref aspath) = attr.aspath {
-            for segment in &aspath.segs {
-                if segment.asn.contains(&peer.local_as) {
-                    return;
-                }
-            }
+        if let Some(ref aspath) = attr.aspath
+            && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
+        {
+            return;
         }
         if let Some(ref originator_id) = attr.originator_id
             && originator_id.id == *bgp.router_id
@@ -4178,12 +4212,10 @@ pub fn route_srpolicy_update(
     // or consuming it.
     {
         let peer = peers.get_by_idx(ident).expect("peer must exist");
-        if let Some(ref aspath) = attr.aspath {
-            for segment in &aspath.segs {
-                if segment.asn.contains(&peer.local_as) {
-                    return;
-                }
-            }
+        if let Some(ref aspath) = attr.aspath
+            && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
+        {
+            return;
         }
         if let Some(ref originator_id) = attr.originator_id
             && originator_id.id == *bgp.router_id
@@ -4369,12 +4401,10 @@ pub fn route_bgpls_update(
     let (peer_ident, peer_router_id, typ) = {
         let peer = peers.get_mut_by_idx(ident).expect("peer must exist");
 
-        if let Some(ref aspath) = attr.aspath {
-            for segment in &aspath.segs {
-                if segment.asn.contains(&peer.local_as) {
-                    return;
-                }
-            }
+        if let Some(ref aspath) = attr.aspath
+            && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
+        {
+            return;
         }
         if let Some(ref originator_id) = attr.originator_id
             && originator_id.id == *bgp.router_id
@@ -10147,5 +10177,64 @@ mod tests {
         }
         // Unresolved underlay → nothing to install.
         assert!(super::build_srv6_vpn_fib_entry(sid, &[]).is_none());
+    }
+}
+
+#[cfg(test)]
+mod allowas_in_tests {
+    use std::str::FromStr;
+
+    use bgp_packet::As4Path;
+
+    use super::{AllowAsIn, aspath_local_as_loop};
+
+    const LOCAL: u32 = 65001;
+
+    fn loops(path: &str, allow: Option<AllowAsIn>) -> bool {
+        let aspath = As4Path::from_str(path).unwrap();
+        aspath_local_as_loop(&aspath, LOCAL, allow)
+    }
+
+    #[test]
+    fn strict_check_drops_any_occurrence() {
+        // No allowas-in: any appearance of the local AS is a loop.
+        assert!(!loops("65002 65003", None), "no local AS ⇒ no loop");
+        assert!(loops("65002 65001 65003", None), "transit local AS ⇒ loop");
+        assert!(loops("65002 65001", None), "origin local AS ⇒ loop");
+    }
+
+    #[test]
+    fn count_caps_occurrences() {
+        // Default budget is 3: accept ≤3, drop the 4th.
+        assert!(
+            !loops("65001 65001 65001 65002", Some(AllowAsIn::Count(3))),
+            "3 occurrences within budget 3"
+        );
+        assert!(
+            loops("65001 65001 65001 65001", Some(AllowAsIn::Count(3))),
+            "4 occurrences exceed budget 3"
+        );
+        // A tighter budget of 1.
+        assert!(!loops("65001 65002", Some(AllowAsIn::Count(1))), "1 ≤ 1");
+        assert!(
+            loops("65001 65001 65002", Some(AllowAsIn::Count(1))),
+            "2 > 1"
+        );
+        // Zero occurrences never loop, whatever the budget.
+        assert!(!loops("65002 65003", Some(AllowAsIn::Count(1))));
+    }
+
+    #[test]
+    fn origin_allows_only_at_origin() {
+        // Local AS solely as the (right-most) origin ⇒ accept.
+        assert!(!loops("65002 65003 65001", Some(AllowAsIn::Origin)));
+        // Prepends at the origin are still origin-only ⇒ accept.
+        assert!(!loops("65002 65001 65001", Some(AllowAsIn::Origin)));
+        // Local AS as a transit hop ⇒ loop.
+        assert!(loops("65001 65002 65003", Some(AllowAsIn::Origin)));
+        // Local AS at origin AND transit ⇒ loop.
+        assert!(loops("65001 65002 65001", Some(AllowAsIn::Origin)));
+        // No local AS at all ⇒ no loop.
+        assert!(!loops("65002 65003", Some(AllowAsIn::Origin)));
     }
 }

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 
 use super::cap::CapAfiMap;
 use super::inst::{Bgp, ShowCallback};
-use super::peer::{Peer, PeerCounter, PeerParam, State};
+use super::peer::{AllowAsIn, Peer, PeerCounter, PeerParam, State};
 use super::peer_map::PeerMap;
 use super::route::LocalRib;
 use super::vrf::inst::BgpVrf;
@@ -1381,6 +1381,11 @@ struct Neighbor<'a> {
     // pre-policy Adj-RIB-In is retained so `clear ... soft in` can
     // replay it locally without sending Route Refresh.
     soft_reconfig_in: bool,
+    /// FRR-style `neighbor X allowas-in` setting
+    /// (zebra-bgp-allowas-in.yang), if configured. `None` keeps the
+    /// strict RFC 4271 inbound AS_PATH loop check.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    allowas_in: Option<AllowAsIn>,
     /// Name of the IOS-XR-style `neighbor-group` this peer inherits
     /// from, if any. `remote_as_inherited` says whether the peer's
     /// `remote_as` actually came off the group (vs. an explicit
@@ -1520,6 +1525,7 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         count: HashMap::default(),
         reflector_client: peer.reflector_client,
         soft_reconfig_in: peer.config.soft_reconfig_in,
+        allowas_in: peer.config.allowas_in,
         neighbor_group: peer.config.neighbor_group.clone(),
         remote_as_inherited: peer.config.remote_as_inherited,
     };
@@ -1603,6 +1609,16 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
 
     if neighbor.soft_reconfig_in {
         writeln!(out, "  Inbound soft reconfiguration allowed")?;
+    }
+
+    match neighbor.allowas_in {
+        Some(AllowAsIn::Count(n)) => {
+            writeln!(out, "  Allowas-in: {n} occurrence(s)")?;
+        }
+        Some(AllowAsIn::Origin) => {
+            writeln!(out, "  Allowas-in: origin")?;
+        }
+        None => {}
     }
 
     if let Some(ref group) = neighbor.neighbor_group {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -80,6 +80,10 @@ module config {
     prefix zbsr;
   }
 
+  import zebra-bgp-allowas-in {
+    prefix zbai;
+  }
+
   import zebra-bgp-timer {
     prefix zbtm;
   }

--- a/zebra-rs/yang/zebra-bgp-allowas-in.yang
+++ b/zebra-rs/yang/zebra-bgp-allowas-in.yang
@@ -1,0 +1,127 @@
+module zebra-bgp-allowas-in {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-allowas-in";
+  prefix "zbai";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "FRR-style per-neighbor `allowas-in` knob.
+
+     BGP normally rejects an inbound route whose AS_PATH already
+     contains the local AS (RFC 4271 loop prevention). `allowas-in`
+     relaxes that check per neighbor:
+
+       router bgp {
+         neighbor 10.0.0.5 {
+           remote-as 65501;
+           allowas-in;              // accept up to 3 occurrences
+         }
+         neighbor 10.0.0.6 {
+           remote-as 65502;
+           allowas-in { count 5; }  // accept up to 5 occurrences
+         }
+         neighbor 10.0.0.7 {
+           remote-as 65503;
+           allowas-in { origin; }   // accept only at the origin
+         }
+       }
+
+     `count` and `origin` are mutually exclusive (`choice`). The bare
+     `allowas-in` form enables the relaxation with the default
+     occurrence budget of 3, matching FRR.
+
+     The `default 3` on the `count` leaf is documentation only: a bare
+     presence container never instantiates `count`, and libyang does
+     not carry leaf defaults into the entry tree, so the default-3
+     behaviour is applied by the BGP handler.";
+
+  revision 2026-06-07 {
+    description "Initial revision.";
+    reference "FRR `neighbor X allowas-in [(1-10)|origin]`.";
+  }
+
+  grouping bgp-neighbor-allowas-in-extension {
+    description
+      "FRR-style `allowas-in` presence container on a BGP neighbor.";
+
+    container allowas-in {
+      ext:help "Accept routes containing our own AS in the AS_PATH";
+      presence "Enable allowas-in (default occurrence count 3)";
+      description
+        "Relax the RFC 4271 inbound AS_PATH loop check for this
+         neighbor. The bare form accepts up to 3 occurrences of the
+         local AS; use `count` or `origin` to refine.";
+
+      choice mode {
+        description
+          "Occurrence budget, or origin-only mode. Mutually
+           exclusive — selecting one clears the other.";
+
+        case count {
+          leaf count {
+            ext:help "Max times our AS may appear in AS_PATH (default 3)";
+            type uint8 {
+              range "1..10";
+            }
+            default "3";
+            description
+              "Accept the route while the local AS appears at most
+               this many times in the AS_PATH. Default 3.";
+          }
+        }
+        case origin {
+          leaf origin {
+            ext:help "Accept the local AS only at the route origin";
+            type empty;
+            description
+              "Accept the route only when the local AS appears solely
+               as the originating (right-most) AS. A local AS seen in
+               any transit position is still treated as a loop.";
+          }
+        }
+      }
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Attach allowas-in to BGP neighbors in the candidate-set
+       subtree.";
+    uses bgp-neighbor-allowas-in-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp neighbor X allowas-in [...]` is path-valid.";
+    uses bgp-neighbor-allowas-in-extension;
+  }
+}


### PR DESCRIPTION
## Summary

FRR-style `neighbor X allowas-in [count <1-10>|origin]` — relaxes the RFC 4271 inbound AS_PATH loop check per neighbor so routes carrying our own AS can be accepted.

- **YANG** (`zebra-bgp-allowas-in.yang`): a `presence` container + `choice { count uint8 1..10 (default 3) | origin (empty) }`, augmenting the set+delete neighbor subtrees; imported from `config.yang`. No libyang change — presence gives the bare form, the `count` keyword carries the value, `origin` is an empty leaf.
- **Model**: `PeerConfig.allowas_in: Option<AllowAsIn{Count(u8),Origin}>`; bare `allowas-in` defaults to `Count(3)` in the handler. Per-neighbor (applies to all AFIs), not per-AFI.
- **Runtime**: one helper `aspath_local_as_loop()` replaces the 8 duplicated inbound loop checks (v4/v6 unicast, VPNv4/6, EVPN, flowspec, RR). `origin` accepts only when the local AS is the originating (right-most) AS.
- **Show**: `show ip bgp neighbors` prints `Allowas-in: N occurrence(s)` / `Allowas-in: origin`; the enum serializes adjacently-tagged for JSON.

### CLI

```
router bgp neighbor 10.0.0.5 allowas-in            # accept up to 3 (default)
router bgp neighbor 10.0.0.5 allowas-in count 5    # accept up to 5
router bgp neighbor 10.0.0.5 allowas-in origin     # accept only at the origin
```

## Test plan

- `cargo test -p zebra-rs` — loop-math unit tests (strict / count / origin) + `configure_mode_loads` schema guard (validates the new module's imports/augments/`choice`).
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- New `@bgp_allowas_in` BDD: 3-node line where z1/z3 share AS 65001 — verifies the default loop check drops the route at z3, that `allowas-in` (and `origin`) make z3 accept it after a session clear, and the show output.

Generated with [Claude Code](https://claude.com/claude-code)