### PR TITLE
config: make spawn_bfd/nd idempotent

### DIFF
--- a/zebra-rs/src/config/bfd.rs
+++ b/zebra-rs/src/config/bfd.rs
@@ -10,6 +10,14 @@ use super::ConfigManager;
 /// channel so committed `/bfd/*` leaves reach the callback
 /// dispatcher.
 pub fn spawn_bfd(config: &ConfigManager) {
+    // Idempotent — see `spawn_ospfv3`. BFD is eager-spawned by the
+    // OSPF / IS-IS / BGP arms in `commit_config`, so it can be invoked on
+    // many commits; re-spawning would replace the live task and drop
+    // every BFD session. The published `bfd_client_tx` from the first
+    // spawn stays valid, so later protocol spawns still attach.
+    if config.protocol_tasks.borrow().contains_key("bfd") {
+        return;
+    }
     // BFD doesn't subscribe to RIB today — the `default_table_no_rib`
     // constructor builds a parked `RibClient` so the ctx still has
     // a `rib` field for uniformity with the other protocols.

--- a/zebra-rs/src/config/nd.rs
+++ b/zebra-rs/src/config/nd.rs
@@ -29,6 +29,13 @@ use super::ConfigManager;
 /// failure doesn't leave a dead `RibRx` receiver queued in RIB's
 /// inbox — RIB would panic on the link-dump send in that case.
 pub fn spawn_nd(config: &ConfigManager) {
+    // Idempotent — see `spawn_ospfv3`. Eager-spawned by the BGP arm in
+    // `commit_config`; re-spawning would replace the live task and drop
+    // ND / RA state. A socket failure below returns early without
+    // inserting the task, so a later commit retries.
+    if config.protocol_tasks.borrow().contains_key("nd") {
+        return;
+    }
     let socket = match nd_socket() {
         Ok(s) => s,
         Err(e) => {


### PR DESCRIPTION
## Summary

Completes the spawn-idempotency sweep (#1258, #1259). BFD and ND are eager-spawned by the OSPF / IS-IS / BGP arms in `commit_config`, so a routine runtime config change re-invoked them — replacing the live task and dropping every BFD session (or ND/RA state). Guard both:
```rust
if config.protocol_tasks.borrow().contains_key("<proto>") { return; }
```

The respawn-on-every-commit class is now closed across ospf / ospfv3 / isis / bgp / nd / bfd.

## Safety
- The `bfd_client_tx` / `nd_client_tx` published at the first spawn stay valid, so later protocol spawns still attach.
- `despawn_bfd` still clears the task + handle (delete+re-add re-spawns); ND has no despawn, so the guard simply makes it spawn-once.
- `spawn_nd`'s socket-failure path returns before inserting the task, so a later commit retries.

## Test plan
- `cargo fmt --check` ✓, `cargo clippy --workspace --all-targets -- -D warnings` ✓, `cargo test -p zebra-rs` ✓ (905)
- All callers are `commit_config` (no restart/checkpoint path); each spawn site is `if !proto`-gated. Mechanism is identical to the already-validated ospf/isis/bgp idempotency.

Generated with [Claude Code](https://claude.com/claude-code)