### PR TITLE
bdd: stabilize ttl-security symmetric reconvergence scenario

### DIFF
--- a/bdd/tests/features/bgp_ttl_security.feature
+++ b/bdd/tests/features/bgp_ttl_security.feature
@@ -55,7 +55,15 @@ Feature: BGP TTL Security / GTSM (RFC 5082)
   Scenario: Enabling ttl-security on both ends establishes the session
     Given the test topology exists
     When I apply config "z2-2.yaml" to namespace "z2"
-    And I wait 5 seconds for BGP to operate
+    # Enabling ttl-security bounces z2's session so it reconnects with the
+    # new egress TTL. z1 (unchanged) may still hold the stale connection
+    # from the asymmetric phase, on which z2 was sending below 255. Clear
+    # both so each reconnects cleanly with GTSM rather than waiting out a
+    # hold timer, then allow for the post-bounce idle-hold (~5s) plus
+    # session setup before checking.
+    And I clear namespace "z1" neighbor "192.168.0.2"
+    And I clear namespace "z2" neighbor "192.168.0.1"
+    And I wait 15 seconds for BGP to operate
     Then BGP session in "z1" to "192.168.0.2" should be "Established"
     And BGP session in "z2" to "192.168.0.1" should be "Established"
 


### PR DESCRIPTION
## Summary

Test-only follow-up to the BGP TTL-security / GTSM work. The `@bgp_ttl_security` "enable on both ends" scenario flips z2 from non-GTSM to GTSM at runtime. Applying `ttl-security` bounces z2's session (`Event::Stop` → ~5s idle-hold before reconnect) while z1 (unchanged) still held the stale asymmetric-phase connection on which z2 had been sending below TTL 255 — so z1 sat in `OpenSent` (`rcvd: 0`) and the 5s wait fired before reconvergence.

Fix: after applying z2's GTSM config, **clear both neighbors** so each reconnects cleanly with GTSM, and **wait 15s** to cover the idle-hold plus session setup.

The GTSM mechanism is unchanged; the asymmetric scenario (which exercises the ingress `min_ttl` filter) already passes. Production auto-recovers without a clear (z2's bounce FINs z1's stale connection); the clear just makes the test fast and deterministic.

## Test plan

- `@bgp_ttl_security` re-run locally: all 3 scenarios green (asymmetric down, symmetric up, teardown).
- No Rust changed (feature file only), so `fmt`/`clippy`/`test` are unaffected; CI excludes BDD.

Generated with [Claude Code](https://claude.com/claude-code)