### PR TITLE
bdd: add teardown scenario to @bgp_allowas_in feature

### DIFF
--- a/bdd/tests/features/bgp_allowas_in.feature
+++ b/bdd/tests/features/bgp_allowas_in.feature
@@ -71,3 +71,15 @@ Feature: BGP allowas-in relaxes the inbound AS_PATH loop check
     Then BGP session in "z3" to "192.168.1.2" should be "Established"
     And BGP route in "z3" has "10.0.0.1/32"
     And show command "show ip bgp neighbors" in namespace "z3" should contain "Allowas-in: origin"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the veth
+  # pair ends it holds, so only the daemons and namespaces need teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

`bgp_allowas_in.feature` created three namespaces (z1/z2/z3, pure P2P) but never tore them down. A completed run left `bgp_allowas_in_z1/z2/z3`, their pid files, and the daemons alive on the host until the *next* run's `Given a clean test environment` swept them by prefix. It was 1 of only 5 features (of 42) that did not self-clean — the other 37 already have an explicit `Scenario: Teardown topology`.

This adds the missing teardown scenario, matching the established convention with one topology-specific difference: `bgp_allowas_in` is **pure P2P** (`I connect namespace`, no bridge), so the teardown stops the daemons and deletes all three namespaces but omits the `I delete bridge` step — deleting each namespace destroys the veth-pair ends it holds.

## Test plan

Ran `cargo test -p bdd --test cucumber -- --tags "@bgp_allowas_in"`:

- **5 scenarios (5 passed), 42 steps (42 passed)** — was 4 scenarios before.
- The start-of-run sweep reclaimed previously-leaked namespaces, all functional scenarios passed, and the new teardown's `the test environment should be clean` assertion passed.
- Post-run host check confirmed **no leftover** namespaces, pid files, veths, or `zebra-rs` processes.

(BDD is excluded from CI; verified locally against freshly `make install`-ed release binaries.)

Generated with [Claude Code](https://claude.com/claude-code)