### PR TITLE
bgp: fix GTSM session wedge after connection collision

### DIFF
--- a/bdd/tests/features/bgp_ttl_security.feature
+++ b/bdd/tests/features/bgp_ttl_security.feature
@@ -55,14 +55,19 @@ Feature: BGP TTL Security / GTSM (RFC 5082)
   Scenario: Enabling ttl-security on both ends establishes the session
     Given the test topology exists
     When I apply config "z2-2.yaml" to namespace "z2"
-    # Enabling ttl-security bounces z2's session so it reconnects with the
-    # new egress TTL. z1 (unchanged) may still hold the stale connection
-    # from the asymmetric phase, on which z2 was sending below 255. Clear
-    # both so each reconnects cleanly with GTSM rather than waiting out a
-    # hold timer, then allow for the post-bounce idle-hold (~5s) plus
-    # session setup before checking.
-    And I clear namespace "z1" neighbor "192.168.0.2"
-    And I clear namespace "z2" neighbor "192.168.0.1"
+    # Enabling ttl-security bounces z2 so it reconnects with egress TTL 255,
+    # while z1 still holds the stale connection from the asymmetric phase.
+    # Hard-reset both ends so each tears down cleanly and reconnects with
+    # GTSM, rather than waiting out a multi-minute hold timer.
+    #
+    # Use `clear bgp ipv4 neighbor <X>` (the real clear grammar) via the
+    # generic run step — NOT `I clear namespace ... neighbor`, whose
+    # `clear ip bgp neighbors <X>` does not match the grammar and is a
+    # silent no-op (see PR #1264). A clean GTSM reconnect reaches
+    # Established in ~6s once collision-teardown packets carry TTL 255
+    # (peer.rs handle_peer_connection); 15s is margin for CI.
+    And I run "clear bgp ipv4 neighbor 192.168.0.2" in namespace "z1"
+    And I run "clear bgp ipv4 neighbor 192.168.0.1" in namespace "z2"
     And I wait 15 seconds for BGP to operate
     Then BGP session in "z1" to "192.168.0.2" should be "Established"
     And BGP session in "z2" to "192.168.0.1" should be "Established"

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1884,6 +1884,28 @@ fn handle_peer_connection(
         return Some(stream);
     };
     if let Some(peer) = bgp.peers.get_mut_by_key(&key) {
+        // Pin the egress TTL on the freshly accepted socket *before* we
+        // decide its fate. For a `ttl-security` (GTSM) peer this is what
+        // lets a rejected or dropped inbound connection be torn down
+        // cleanly: the NOTIFICATION and the kernel FIN/RST that close the
+        // socket must leave at TTL 255, or the peer's `IP_MINTTL` = 255
+        // floor silently drops them and the peer never learns the
+        // connection is gone — it keeps retransmitting its OPEN into a
+        // black hole and stays wedged in OpenSent until its hold timer
+        // (minutes) expires. This bites whenever two GTSM speakers connect
+        // at once (a collision after a simultaneous restart / clear): the
+        // loser's teardown is invisible to the winner. The keep paths
+        // (`fsm_connected` / `start_collision_conn`) re-apply this together
+        // with the ingress floor, so the early set is harmless redundancy
+        // for them.
+        {
+            use std::os::fd::AsRawFd;
+            let _ = super::ttl::set_egress_ttl(
+                stream.as_raw_fd(),
+                peer.address.is_ipv4(),
+                peer.session_ttl(),
+            );
+        }
         match peer.state {
             State::Idle => {
                 // No session established yet - just drop (sends TCP RST/FIN)


### PR DESCRIPTION
## Problem

The `@bgp_ttl_security` BDD test was failing deterministically on scenario 2 (symmetric ttl-security reconnect stuck in `OpenSent`, `rcvd: 0`). Investigation uncovered **two** bugs — and that PR #1265's "wait 15s to reconverge" fix had never actually worked.

### Bug 1 — a real GTSM product bug: collision teardown dropped by `min_ttl`

When two BGP speakers connect at once (a connection collision — e.g. both ends reconnecting after a simultaneous clear/restart), the §6.8 loser is torn down via `reject_connection`/`drop` on a freshly **accepted** socket that never had its egress TTL set. Its NOTIFICATION + kernel FIN/RST therefore leave at the OS-default TTL 64. A `ttl-security` (GTSM) peer's `IP_MINTTL` = 255 floor silently drops them, so the peer never learns the connection is dead — it retransmits its OPEN into a black hole and stays wedged in `OpenSent` until its hold timer (minutes) expires. Plain eBGP recovers from the same collision in ~6s because it has no min-TTL floor; only GTSM wedges. `tcpdump` confirmed 9 RSTs at TTL 64 on the wire.

**Fix:** pin the egress TTL (`peer.session_ttl()`) on the accepted socket at the top of `handle_peer_connection`, before the keep/collide/reject/drop decision, so every teardown packet carries the session TTL. The keep paths (`fsm_connected` / `start_collision_conn`) re-apply it with the ingress floor, so it's harmless redundancy there; non-GTSM peers are unaffected.

### Bug 2 — the BDD clears were silent no-ops

Scenario 2's `I clear namespace … neighbor` step emits `clear ip bgp neighbors <X>`, which does not match the clear grammar (`/clear/bgp/<afi>/neighbor`) and is a silent no-op (same root cause as PR #1264). So the scenario only ever relied on slow natural reconvergence. Switched to `clear bgp ipv4 neighbor <X>` via the generic run step so the hard reset actually fires.

## Test plan

- `@bgp_ttl_security` BDD: **3/3 scenarios, 25/25 steps** pass (was 1 failing).
- Live: GTSM symmetric session reconverges in **~6s** after the correct hard-clear (was a 70s+ wedge).
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo fmt --all`: clean.
- 287 bgp unit tests: pass.

Generated with [Claude Code](https://claude.com/claude-code)