### PR TITLE
bgp: add neighbor as-override (egress AS_PATH replacement)

### DIFF
--- a/bdd/tests/configs/bgp_as_override/z1.yaml
+++ b/bdd/tests/configs/bgp_as_override/z1.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_as_override/z2-base.yaml
+++ b/bdd/tests/configs/bgp_as_override/z2-base.yaml
@@ -1,0 +1,29 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+- if-name: i2
+  ipv4:
+    address: 192.168.1.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    - remote-address: 192.168.1.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001

--- a/bdd/tests/configs/bgp_as_override/z2-override.yaml
+++ b/bdd/tests/configs/bgp_as_override/z2-override.yaml
@@ -1,0 +1,34 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+- if-name: i2
+  ipv4:
+    address: 192.168.1.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    - remote-address: 192.168.1.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      # Presence container → bare `set ... as-override`. On egress toward
+      # z3, replaces z3's AS (65001) in the AS_PATH with z2's AS (65002)
+      # before the local-AS prepend, so z3's RFC 4271 loop check accepts
+      # 10.0.0.1/32 (it sees "65002 65002" instead of "65002 65001").
+      as-override:

--- a/bdd/tests/configs/bgp_as_override/z3.yaml
+++ b/bdd/tests/configs/bgp_as_override/z3.yaml
@@ -1,0 +1,20 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.1.3/24
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.1.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.1.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/features/bgp_as_override.feature
+++ b/bdd/tests/features/bgp_as_override.feature
@@ -1,0 +1,66 @@
+@serial
+@bgp_as_override
+Feature: BGP as-override rewrites the peer AS on egress so a shared-AS neighbor accepts the route
+  As a network operator
+  I want `neighbor X as-override`
+  So a neighbor that reuses an AS already in the AS_PATH still accepts my routes.
+
+  Test Topology (a line, where z1 and z3 share AS 65001):
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐  192.168.1.0/24  ┌─────────┐
+   │   z1    │ i1────────────i1 │   z2    │ i2────────────i1 │   z3    │
+   │ AS65001 │                  │ AS65002 │                  │ AS65001 │
+   │ .0.1    │                  │.0.2 .1.2│                  │ .1.3    │
+   └─────────┘                  └─────────┘                  └─────────┘
+  ```
+
+  z1 originates 10.0.0.1/32. It reaches z2 with AS_PATH "65001". When z2
+  re-advertises it to z3 it would normally prepend its own AS, giving
+  "65002 65001"; because z3 is also AS 65001 the RFC 4271 loop check
+  drops it. With `as-override` on z2's session toward z3, z2 first
+  rewrites z3's AS (65001) in the path to its own (65002), so z3 sees
+  "65002 65002" and accepts the route. This is the send-side counterpart
+  to `allowas-in`.
+
+  Config files:
+  - z1.yaml:           z1 originates 10.0.0.1/32
+  - z3.yaml:           z3 plain (strict loop check, no allowas-in)
+  - z2-base.yaml:      z2 without as-override
+  - z2-override.yaml:  z2 with `as-override` toward 192.168.1.3
+
+  Scenario: Setup line topology and establish all sessions
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I create namespace "z3"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I connect namespace "z2" interface "i2" to namespace "z3" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2-base.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z2" to "192.168.1.3" should be "Established"
+    And BGP session in "z3" to "192.168.1.2" should be "Established"
+
+  Scenario: Without as-override the RFC 4271 loop check drops the route at z3
+    Given the test topology exists
+    # z2 has it (learned from z1), but z3 drops it because its own AS
+    # 65001 is in the AS_PATH "65002 65001".
+    Then BGP route in "z2" has "10.0.0.1/32"
+    And BGP route in "z3" does not have "10.0.0.1/32"
+
+  Scenario: as-override rewrites z3's AS on egress so z3 accepts the route
+    Given the test topology exists
+    When I apply config "z2-override.yaml" to namespace "z2"
+    # Bounce the z2<->z3 session so z2 re-advertises 10.0.0.1/32 with the
+    # overridden AS_PATH "65002 65002".
+    And I run "clear bgp ipv4 neighbor 192.168.1.3" in namespace "z2"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z3" to "192.168.1.2" should be "Established"
+    And BGP route in "z3" has "10.0.0.1/32"
+    And show command "show ip bgp neighbors" in namespace "z2" should contain "AS-Override"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -17,6 +17,7 @@
   - [Dynamic Neighbors](ch-02-01-dynamic-neighbors.md)
   - [Session Authentication (TCP MD5 / TCP-AO)](ch-02-02-tcp-authentication.md)
   - [TTL: eBGP Multihop & Security (GTSM)](ch-02-11-bgp-ttl-security.md)
+  - [AS Override](ch-02-12-bgp-as-override.md)
   - [Timer Configuration](ch-02-03-bgp-timers.md)
   - [L3VPN and Per-VRF Labels](ch-02-04-bgp-l3vpn.md)
   - [L3VPN over an SRv6 Underlay](ch-02-05-bgp-l3vpn-srv6.md)

--- a/book/src/ch-02-11-bgp-ttl-security.md
+++ b/book/src/ch-02-11-bgp-ttl-security.md
@@ -26,9 +26,11 @@ explicitly opts into `ebgp-multihop`. This is the standard safety
 behavior; without it, an eBGP peer could silently be many hops away.
 
 The egress TTL is set on the socket **before connect** on the active
-side (so the SYN already carries it) and re-affirmed after the handshake
-for the passive side. `ttl-security` precedes `ebgp-multihop`, which is
-ignored on an iBGP session (already 255).
+side (so the SYN already carries it), then re-applied after the handshake
+in `fsm_connected` — the path both roles share, which is what covers a
+passively-accepted session (it has no pre-connect step). `ttl-security`
+precedes `ebgp-multihop`, which is ignored on an iBGP session (already
+255).
 
 ## eBGP multihop
 

--- a/book/src/ch-02-12-bgp-as-override.md
+++ b/book/src/ch-02-12-bgp-as-override.md
@@ -1,0 +1,152 @@
+# BGP AS Override
+
+RFC 4271 loop prevention makes a BGP speaker **reject any route whose
+AS_PATH already contains its own AS**. That rule is correct almost
+always, but it breaks one common topology: two customer sites that reuse
+the **same AS number** behind a shared provider. A route originated at
+one site arrives at the other carrying that shared AS, trips the loop
+check, and is dropped.
+
+`neighbor X as-override` resolves this on the **advertising** side. When
+the provider re-advertises a route to such a neighbor, it first rewrites
+every occurrence of that neighbor's AS in the AS_PATH to its own AS, so
+the neighbor no longer sees its own AS and accepts the route.
+
+## The problem
+
+Consider a provider in AS 65002 with two customers, both numbered
+AS 65001:
+
+```
+ ┌─────────┐  192.168.0.0/24  ┌─────────┐  192.168.1.0/24  ┌─────────┐
+ │   ce1   │ ──────────────── │ provider│ ──────────────── │   ce2   │
+ │ AS65001 │                  │ AS65002 │                  │ AS65001 │
+ └─────────┘                  └─────────┘                  └─────────┘
+ originates                                                  must learn
+ 10.0.0.1/32                                                 10.0.0.1/32
+```
+
+`ce1` originates `10.0.0.1/32`; the provider learns it with AS_PATH
+`65001`. When the provider re-advertises it to `ce2`, it prepends its
+own AS, sending `65002 65001`. `ce2` is AS 65001, sees `65001` in the
+path, and drops the route as a loop. The two sites cannot reach each
+other even though the provider has the route.
+
+## What as-override does
+
+With `as-override` configured on the provider's session toward `ce2`,
+the egress transform changes to **replace, then prepend**:
+
+1. Replace every `65001` (the neighbor's remote-AS) in the AS_PATH with
+   `65002` (the local AS): `65001` → `65002`.
+2. Prepend the local AS as usual: `65002` → `65002 65002`.
+
+`ce2` receives `65002 65002`, finds no occurrence of its own AS 65001,
+and installs the route. The replacement happens **before** the prepend;
+doing it the other way around would leave the neighbor's AS in the path
+and re-introduce the loop.
+
+This is the send-side counterpart to `allowas-in`, which relaxes the
+same loop check on the **receiving** side. `as-override` keeps the
+neighbor's loop check strict and instead removes the offending AS before
+it ever reaches the neighbor — the originator's AS is hidden from that
+neighbor, which is exactly the intent in a shared-AS VPN/customer design.
+
+`as-override` only affects **eBGP** sessions. iBGP never prepends the
+local AS, so the knob is a no-op there and is ignored. The transform is
+applied uniformly across every address family the session carries
+(IPv4/IPv6 unicast, labeled-unicast, L3VPN, EVPN, flow-spec).
+
+## Configuration
+
+`as-override` is a per-neighbor flag. Configure it on the provider end,
+on the session toward each shared-AS customer:
+
+```yaml
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.1.3
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      as-override: null
+```
+
+`as-override: null` is the YAML spelling of a presence container — the
+key is present with no value, which the loader turns into
+`set router bgp neighbor 192.168.1.3 as-override`. The FRR / IOS-style
+CLI form is the same path:
+
+```
+set router bgp neighbor 192.168.1.3 as-override
+```
+
+Enabling `as-override` on an already-established session does not by
+itself re-send routes already in the neighbor's Adj-RIB-Out. Bounce the
+session so the provider re-advertises with the new AS_PATH:
+
+```
+clear bgp ipv4 neighbor 192.168.1.3
+```
+
+## Verification
+
+`show ip bgp neighbor <addr>` reports whether the knob is active:
+
+```
+  AS-Override enabled (outbound AS_PATH replacement)
+```
+
+On the neighbor, confirm the rewritten path arrived loop-free. `ce2`
+should now hold `10.0.0.1/32` with an AS_PATH of `65002 65002` rather
+than the rejected `65002 65001`:
+
+```
+show ip bgp 10.0.0.1/32
+```
+
+### Interaction with update-groups
+
+zebra-rs batches identical outbound work into **update-groups** and
+encodes one UPDATE for every member of a group (see the design notes in
+`docs/design/bgp-update-groups.md`). Because `as-override` rewrites the
+path using the neighbor's own remote-AS, its result is peer-specific: two
+eBGP neighbors that override **different** remote-AS values cannot share a
+single encoded UPDATE. A neighbor with `as-override` is therefore keyed
+into its own update-group, separate from non-override peers and from
+peers overriding a different AS. `show bgp update-group` makes this
+visible:
+
+```
+  Signature:
+    ...
+    AS-override target:         65001
+```
+
+A `—` in that field means the group's members do not override (the common
+case). This separation is automatic; no extra configuration is required.
+
+## Troubleshooting
+
+The usual mistake is configuring `as-override` on the **wrong end**. It
+belongs on the side that *advertises* into the shared-AS neighbor — the
+provider in the example above — not on the customer that needs to
+*accept* the route. If you control only the receiving side, the
+equivalent receive-side relaxation is `allowas-in`.
+
+If the route still does not appear after enabling `as-override`, check
+that:
+
+- the session is **eBGP** (`as-override` is ignored on iBGP);
+- the AS actually being rewritten is the neighbor's **remote-as** — only
+  occurrences equal to the configured `remote-as` of *that* session are
+  replaced; an unrelated AS deeper in the path is left untouched;
+- the session was **bounced** (`clear bgp ipv4 neighbor <addr>`) after
+  the configuration change, so the route was re-advertised under the new
+  policy.

--- a/crates/bgp-packet/src/attrs/aspath.rs
+++ b/crates/bgp-packet/src/attrs/aspath.rs
@@ -404,6 +404,23 @@ impl As4Path {
         self.update_length();
     }
 
+    /// Replace every occurrence of `from` with `to` across all segments
+    /// (sequences, sets, confederation segments). Mirrors FRR's
+    /// `aspath_replace_specific_asn`: a 1:1 substitution, so the
+    /// RFC 4271 / RFC 5065 hop count is unchanged and `length` stays
+    /// valid without recomputation. Used by per-neighbor `as-override`
+    /// on the egress path, where the AS being advertised to has its own
+    /// AS swapped out for ours so its loop check accepts the route.
+    pub fn replace_as_mut(&mut self, from: u32, to: u32) {
+        for seg in self.segs.iter_mut() {
+            for asn in seg.asn.iter_mut() {
+                if *asn == from {
+                    *asn = to;
+                }
+            }
+        }
+    }
+
     /// Try to merge two single-segment AS_SEQ paths into one segment.
     fn try_merge_single_seq(&self, other: &Self) -> Option<Self> {
         if self.segs.len() != 1 || other.segs.len() != 1 {
@@ -731,5 +748,55 @@ mod tests {
         aspath.prepend_mut(prepend);
         assert_eq!(aspath.to_string(), "2 {3} 4 5 1 {2}");
         assert_eq!(aspath.length(), 6);
+    }
+
+    #[test]
+    fn replace_as_mut_single() {
+        // The canonical `as-override` case: a one-AS path equal to the
+        // peer's remote-as is rewritten to the local AS, length intact.
+        let mut aspath: As4Path = As4Path::from_str("65001").unwrap();
+        aspath.replace_as_mut(65001, 65002);
+        assert_eq!(aspath.to_string(), "65002");
+        assert_eq!(aspath.length(), 1);
+    }
+
+    #[test]
+    fn replace_as_mut_multiple_occurrences() {
+        // Every occurrence is swapped, in every position.
+        let mut aspath: As4Path = As4Path::from_str("65001 100 65001 200 65001").unwrap();
+        aspath.replace_as_mut(65001, 65002);
+        assert_eq!(aspath.to_string(), "65002 100 65002 200 65002");
+        assert_eq!(aspath.length(), 5);
+    }
+
+    #[test]
+    fn replace_as_mut_across_segments() {
+        // Substitution reaches into AS_SET segments too; the set still
+        // counts as a single hop, so length is unchanged.
+        let mut aspath: As4Path = As4Path::from_str("65001 {65001 300}").unwrap();
+        aspath.replace_as_mut(65001, 65002);
+        assert_eq!(aspath.to_string(), "65002 {65002 300}");
+        assert_eq!(aspath.length(), 2);
+    }
+
+    #[test]
+    fn replace_as_mut_absent_is_noop() {
+        let mut aspath: As4Path = As4Path::from_str("100 200 300").unwrap();
+        aspath.replace_as_mut(65001, 65002);
+        assert_eq!(aspath.to_string(), "100 200 300");
+        assert_eq!(aspath.length(), 3);
+    }
+
+    #[test]
+    fn as_override_egress_sequence_is_replace_then_prepend() {
+        // The full egress transform applied to a route bound for a peer
+        // in AS 65001 from a local AS of 65002: replace the peer's AS
+        // first, *then* prepend the local AS. Order matters — prepending
+        // first would leave the peer's AS in the path and re-introduce
+        // the loop the override exists to avoid.
+        let mut aspath: As4Path = As4Path::from_str("65001").unwrap();
+        aspath.replace_as_mut(65001, 65002);
+        aspath.prepend_mut(As4Path::from(vec![65002]));
+        assert_eq!(aspath.to_string(), "65002 65002");
     }
 }

--- a/docs/design/bgp-update-groups.md
+++ b/docs/design/bgp-update-groups.md
@@ -85,6 +85,7 @@ Two peers belong to the same update-group for a given `(afi, safi)` iff
 | `param.local_addr` (or fallback to `bgp.router_id`) | NEXT_HOP value for eBGP / originated. |
 | `policy_list.output.name` | Outbound policy identity. |
 | `prefix_set.output.name` | Outbound prefix filter identity. |
+| `config.as_override` + `remote_as` (eBGP only) | `as-override` rewrites the peer's remote-AS to `local_as` in the egress AS_PATH; the result depends on `remote_as`, so it joins the key as `as_override_target: Some(remote_as)` (else `None`). |
 | `is_afi_safi(afi, safi)` membership | Implicit — only members of the AFI/SAFI participate in that group. |
 | `addpath_send` for `(afi, safi)` | Different framing → different group. |
 
@@ -123,10 +124,10 @@ UPDATE wire format, or are informational):
 
 Knobs that don't yet exist in zebra-rs but will join the signature when
 they land: `next-hop-self`, `next-hop-unchanged`, `send-community`
-flags (standard / extended / large), `as-override`,
-`remove-private-as`, outbound `route-map` (when separate from
-policy-list), per-peer `update-source` distinct from
-`transport.local-address`.
+flags (standard / extended / large), `remove-private-as`, outbound
+`route-map` (when separate from policy-list), per-peer `update-source`
+distinct from `transport.local-address`. (`as-override` landed and is
+now modeled as `as_override_target` — see the signature table above.)
 
 **Conservatism rule**: any outbound-affecting setting that the
 signature does not yet model forces the peer into a singleton group.
@@ -185,6 +186,7 @@ pub struct UpdateGroupSig {
     pub local_addr: Option<IpAddr>,
     pub policy_out_name: Option<String>,
     pub prefix_set_out_name: Option<String>,
+    pub as_override_target: Option<u32>, // Some(remote_as) iff as-override (eBGP)
     // Negotiated wire-format capabilities (intersection of
     // cap_send and cap_recv on Peer). Anything that changes
     // encoded UPDATE bytes belongs here:

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -528,6 +528,18 @@ fn config_allowas_in_origin(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
     Some(())
 }
 
+/// `set router bgp neighbor X as-override` — the presence container
+/// (zebra-bgp-as-override.yang). Enables egress AS_PATH override toward
+/// this neighbor (the peer's own AS is swapped for the local AS before
+/// the local-AS prepend, on every outbound eBGP UPDATE); `delete`
+/// disables it. The flag is a no-op for iBGP peers, which never prepend.
+fn config_as_override(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let peer = bgp.peers.get_mut(&addr)?;
+    peer.config.as_override = op.is_set();
+    Some(())
+}
+
 /// `set router bgp neighbor X bfd enable true|false` — flips the
 /// Reconcile this neighbor's live BFD subscription with its current
 /// `peer.config.bfd` state. Idempotent and order-independent: every
@@ -2246,6 +2258,12 @@ impl Bgp {
         self.callback_peer("/allowas-in", config_allowas_in);
         self.callback_peer("/allowas-in/count", config_allowas_in_count);
         self.callback_peer("/allowas-in/origin", config_allowas_in_origin);
+
+        // Per-neighbor as-override (zebra-bgp-as-override.yang). On the
+        // egress path toward this neighbor, replace its own AS with the
+        // local AS in the AS_PATH so its RFC 4271 loop check accepts
+        // routes that transited its AS (eBGP only).
+        self.callback_peer("/as-override", config_as_override);
     }
 }
 
@@ -2709,6 +2727,34 @@ mod bfd_wiring_tests {
         config_allowas_in_count(&mut bgp, arg_words(&["10.0.0.2", "7"]), ConfigOp::Set).unwrap();
         config_allowas_in(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
         assert_eq!(peer_allowas_in(&bgp, "10.0.0.2"), Some(AllowAsIn::Count(7)));
+    }
+
+    fn peer_as_override(bgp: &Bgp, addr: &str) -> bool {
+        bgp.peers
+            .get(&addr.parse().unwrap())
+            .unwrap()
+            .config
+            .as_override
+    }
+
+    /// `as-override` defaults off and the presence container turns it on.
+    #[tokio::test]
+    async fn as_override_set_enables() {
+        let (mut bgp, _rx) = fresh_bgp_with_bfd();
+        config_peer(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        assert!(!peer_as_override(&bgp, "10.0.0.2"));
+        config_as_override(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        assert!(peer_as_override(&bgp, "10.0.0.2"));
+    }
+
+    /// Deleting the presence container turns `as-override` back off.
+    #[tokio::test]
+    async fn as_override_delete_disables() {
+        let (mut bgp, _rx) = fresh_bgp_with_bfd();
+        config_peer(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        config_as_override(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        config_as_override(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Delete).unwrap();
+        assert!(!peer_as_override(&bgp, "10.0.0.2"));
     }
 }
 

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -337,6 +337,13 @@ pub struct PeerConfig {
     /// Per-neighbor `allowas-in` (zebra-bgp-allowas-in.yang). `None`
     /// keeps the strict RFC 4271 inbound AS_PATH loop check.
     pub allowas_in: Option<AllowAsIn>,
+    /// Per-neighbor `as-override` (zebra-bgp-as-override.yang). When
+    /// `true`, the peer's own AS is replaced with the local AS in the
+    /// AS_PATH of every outbound eBGP UPDATE (before the local-AS
+    /// prepend), so the receiver's RFC 4271 loop check accepts routes
+    /// that have transited its own AS. Ignored for iBGP peers (which do
+    /// not prepend). Default `false`.
+    pub as_override: bool,
 }
 
 impl Default for PeerConfig {
@@ -358,6 +365,7 @@ impl Default for PeerConfig {
             remote_as_inherited: false,
             bfd: PeerBfdConfig::default(),
             allowas_in: None,
+            as_override: false,
         }
     }
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -80,6 +80,28 @@ fn local_as_only_at_origin(aspath: &As4Path, local_as: u32) -> bool {
     !flat[..flat.len() - trailing].contains(&local_as)
 }
 
+/// Apply the egress AS_PATH transformation for an eBGP announcement to
+/// `peer`: an optional per-neighbor `as-override` (replace the peer's
+/// own AS with the local AS so its RFC 4271 loop check accepts a route
+/// that transited its AS), followed by the mandatory local-AS prepend.
+/// iBGP peers and routes without an AS_PATH are left untouched. The
+/// override runs *before* the prepend, mirroring FRR's
+/// `bgp_peer_as_override` (announce-check) and the later packet-build
+/// prepend. Call this at every eBGP egress site instead of prepending
+/// inline, so `as-override` is applied uniformly across address families.
+fn ebgp_egress_aspath(peer: &Peer, attrs: &mut BgpAttr) {
+    if !peer.is_ebgp() {
+        return;
+    }
+    let Some(aspath) = attrs.aspath.as_mut() else {
+        return;
+    };
+    if peer.config.as_override {
+        aspath.replace_as_mut(peer.remote_as, peer.local_as);
+    }
+    aspath.prepend_mut(As4Path::from(vec![peer.local_as]));
+}
+
 /// Build a `rib::entry::RibEntry` from the BGP best-path winner for an
 /// IPv4 unicast prefix. Returns `None` when the BGP route has no
 /// installable next-hop — VPNv4 / EVPN have their own install paths,
@@ -2448,12 +2470,7 @@ pub fn route_update_evpn(
 
     let mut attrs = (*rib.attr).clone();
 
-    if peer.is_ebgp()
-        && let Some(ref mut aspath) = attrs.aspath
-    {
-        let local_as_path = As4Path::from(vec![peer.local_as]);
-        aspath.prepend_mut(local_as_path);
-    }
+    ebgp_egress_aspath(peer, &mut attrs);
 
     if peer.is_ebgp() || rib.is_originated() {
         let nexthop: IpAddr = if let Some(ref local_addr) = peer.param.local_addr {
@@ -4838,12 +4855,7 @@ pub fn route_update_flowspec(
     out.id = if add_path { rib.local_id } else { 0 };
 
     let mut attrs = (*rib.attr).clone();
-    if peer.is_ebgp()
-        && let Some(ref mut aspath) = attrs.aspath
-    {
-        let local_as_path = As4Path::from(vec![peer.local_as]);
-        aspath.prepend_mut(local_as_path);
-    }
+    ebgp_egress_aspath(peer, &mut attrs);
     if peer.is_ibgp() && attrs.local_pref.is_none() {
         attrs.local_pref = Some(LocalPref::default());
     }
@@ -5660,12 +5672,7 @@ pub fn route_update_ipv4(
     // 1. Origin.  Pass through
 
     // 2. AS_PATH
-    if peer.is_ebgp()
-        && let Some(ref mut aspath) = attrs.aspath
-    {
-        let local_as_path = As4Path::from(vec![peer.local_as]);
-        aspath.prepend_mut(local_as_path.clone());
-    }
+    ebgp_egress_aspath(peer, &mut attrs);
 
     // 3. NEXT_HOP
     //
@@ -5792,12 +5799,7 @@ pub fn route_update_ipv6(
     let mut attrs = (*rib.attr).clone();
 
     // AS_PATH prepend for eBGP.
-    if peer.is_ebgp()
-        && let Some(ref mut aspath) = attrs.aspath
-    {
-        let local_as_path = As4Path::from(vec![peer.local_as]);
-        aspath.prepend_mut(local_as_path.clone());
-    }
+    ebgp_egress_aspath(peer, &mut attrs);
 
     // NEXT_HOP: next-hop-self for eBGP / locally-originated routes. The
     // address is the local end of this peer's (i)BGP session when it's
@@ -6049,11 +6051,7 @@ fn route_update_labelv4(
     };
     let mut attrs = (*rib.attr).clone();
 
-    if peer.is_ebgp()
-        && let Some(ref mut aspath) = attrs.aspath
-    {
-        aspath.prepend_mut(As4Path::from(vec![peer.local_as]));
-    }
+    ebgp_egress_aspath(peer, &mut attrs);
 
     // Next-hop-self for eBGP / locally-originated; otherwise keep the
     // received next-hop (next-hop-unchanged). Captured before clearing
@@ -6125,11 +6123,7 @@ fn route_update_labelv6(
     };
     let mut attrs = (*rib.attr).clone();
 
-    if peer.is_ebgp()
-        && let Some(ref mut aspath) = attrs.aspath
-    {
-        aspath.prepend_mut(As4Path::from(vec![peer.local_as]));
-    }
+    ebgp_egress_aspath(peer, &mut attrs);
 
     let needs_self = peer.is_ebgp() || rib.is_originated();
     let nhop: IpAddr = if needs_self {

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1386,6 +1386,11 @@ struct Neighbor<'a> {
     /// strict RFC 4271 inbound AS_PATH loop check.
     #[serde(skip_serializing_if = "Option::is_none")]
     allowas_in: Option<AllowAsIn>,
+    /// FRR-style `neighbor X as-override` flag
+    /// (zebra-bgp-as-override.yang). When true, the peer's own AS is
+    /// replaced with the local AS in the AS_PATH of outbound eBGP
+    /// UPDATEs (before the local-AS prepend).
+    as_override: bool,
     /// GTSM / `ttl-security` (RFC 5082): the session only accepts a
     /// directly-connected peer (received TTL 255). Mirrors
     /// `peer.config.transport.ttl_security`.
@@ -1534,6 +1539,7 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         reflector_client: peer.reflector_client,
         soft_reconfig_in: peer.config.soft_reconfig_in,
         allowas_in: peer.config.allowas_in,
+        as_override: peer.config.as_override,
         ttl_security: peer.config.transport.ttl_security,
         ebgp_multihop: peer.config.transport.ebgp_multihop,
         neighbor_group: peer.config.neighbor_group.clone(),
@@ -1629,6 +1635,10 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
             writeln!(out, "  Allowas-in: origin")?;
         }
         None => {}
+    }
+
+    if neighbor.as_override {
+        writeln!(out, "  AS-Override enabled (outbound AS_PATH replacement)")?;
     }
 
     if neighbor.ttl_security {

--- a/zebra-rs/src/bgp/show_update_group.rs
+++ b/zebra-rs/src/bgp/show_update_group.rs
@@ -38,6 +38,10 @@ struct SigView {
     local_addr: Option<String>,
     policy_out: Option<String>,
     prefix_set_out: Option<String>,
+    /// `Some(remote_as)` when `as-override` is set on the members
+    /// (eBGP only); the egress AS_PATH has that AS rewritten to the
+    /// local AS. `None` (the common case) means no override.
+    as_override_target: Option<u32>,
     capabilities: CapsView,
     signature_version: u32,
 }
@@ -121,6 +125,7 @@ fn build_view(bgp: &Bgp, afi_safi: AfiSafi, group: &UpdateGroup) -> GroupView {
             local_addr: group.sig.local_addr.map(|a| a.to_string()),
             policy_out: group.sig.policy_out_name.clone(),
             prefix_set_out: group.sig.prefix_set_out_name.clone(),
+            as_override_target: group.sig.as_override_target,
             capabilities: CapsView {
                 as4_negotiated: group.sig.as4_negotiated,
                 extended_message: group.sig.extended_message,
@@ -249,6 +254,14 @@ fn render_detail_text(view: &GroupView) -> Result<String, std::fmt::Error> {
         out,
         "    Outbound prefix-set:        {}",
         view.signature.prefix_set_out.as_deref().unwrap_or("—")
+    )?;
+    writeln!(
+        out,
+        "    AS-override target:         {}",
+        view.signature
+            .as_override_target
+            .map(|asn| asn.to_string())
+            .unwrap_or_else(|| "—".to_string())
     )?;
     writeln!(out, "    Negotiated capabilities:")?;
     writeln!(

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -41,7 +41,7 @@ use crate::context::Timer;
 
 /// Bumped whenever a new field is added to `UpdateGroupSig`. Surfaced
 /// in `show bgp update-group` so a stale view is detectable.
-pub const SIGNATURE_VERSION: u32 = 1;
+pub const SIGNATURE_VERSION: u32 = 2;
 
 /// Address families the v1 grouping logic considers. The advertise
 /// pipeline today only fans out to these three.
@@ -103,6 +103,16 @@ pub struct UpdateGroupSig {
     pub local_addr: Option<IpAddr>,
     pub policy_out_name: Option<String>,
     pub prefix_set_out_name: Option<String>,
+    /// Per-neighbor `as-override` target (zebra-bgp-as-override.yang).
+    /// `None` when off (the common case — no effect on the egress
+    /// transform). `Some(remote_as)` when on: the egress AS_PATH has
+    /// `remote_as` rewritten to `local_as` before the prepend, so two
+    /// peers may only share canonical bytes when they override the
+    /// *same* remote AS. Without this, two eBGP peers with distinct
+    /// remote-AS in one group would share a single (wrongly-overridden)
+    /// AS_PATH — the canonical-member transform assumes its output
+    /// depends only on signature fields.
+    pub as_override_target: Option<u32>,
     // Negotiated wire-format capabilities (intersection of cap_send
     // and cap_recv on the peer). Anything that changes encoded
     // UPDATE bytes belongs here.
@@ -214,6 +224,15 @@ pub fn signature_of(peer: &Peer, afi: Afi, safi: Safi) -> Option<UpdateGroupSig>
         local_addr: peer.param.local_addr.map(|s| s.ip()),
         policy_out_name,
         prefix_set_out_name,
+        // as-override rewrites the peer's own AS to ours on egress; the
+        // result depends on the peer's remote-as, so fold it into the
+        // key (eBGP only — iBGP never prepends, so the override is a
+        // no-op there and must not split iBGP groups).
+        as_override_target: if peer.is_ebgp() && peer.config.as_override {
+            Some(peer.remote_as)
+        } else {
+            None
+        },
         as4_negotiated: peer.as4,
         extended_message: peer.opt.extended_message,
         addpath_send: peer.opt.is_add_path_send(afi, safi),
@@ -936,6 +955,7 @@ mod tests {
             local_addr: None,
             policy_out_name: None,
             prefix_set_out_name: None,
+            as_override_target: None,
             as4_negotiated: true,
             extended_message: true,
             addpath_send: false,
@@ -979,6 +999,10 @@ mod tests {
 
         let mut a = base.clone();
         a.prefix_set_out_name = Some("denylist".into());
+        assert_ne!(base, a);
+
+        let mut a = base.clone();
+        a.as_override_target = Some(65002);
         assert_ne!(base, a);
 
         let mut a = base.clone();

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -84,6 +84,10 @@ module config {
     prefix zbai;
   }
 
+  import zebra-bgp-as-override {
+    prefix zbao;
+  }
+
   import zebra-bgp-timer {
     prefix zbtm;
   }

--- a/zebra-rs/yang/zebra-bgp-as-override.yang
+++ b/zebra-rs/yang/zebra-bgp-as-override.yang
@@ -1,0 +1,90 @@
+module zebra-bgp-as-override {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-as-override";
+  prefix "zbao";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "FRR-style per-neighbor `as-override` knob.
+
+     On the egress path toward an eBGP neighbor, BGP normally prepends
+     the local AS to the AS_PATH. If that neighbor's own AS already
+     appears in the path (e.g. two CE sites that share one AS behind a
+     common provider), the neighbor's RFC 4271 loop check drops the
+     route. `as-override` relaxes this on the *sending* side: every
+     occurrence of the neighbor's AS in the AS_PATH is replaced with the
+     local AS before the prepend, so the neighbor no longer sees its own
+     AS and accepts the route.
+
+       router bgp {
+         neighbor 192.168.1.3 {
+           remote-as 65001;
+           as-override;           // rewrite 65001 -> local AS on egress
+         }
+       }
+
+     This is the send-side counterpart to `allowas-in`, which relaxes
+     the same loop check on the *receiving* side. `as-override` only
+     affects eBGP sessions (iBGP never prepends).";
+
+  revision 2026-06-08 {
+    description "Initial revision.";
+    reference "FRR `neighbor X as-override`.";
+  }
+
+  grouping bgp-neighbor-as-override-extension {
+    description
+      "FRR-style `as-override` presence container on a BGP neighbor.";
+
+    container as-override {
+      ext:help "Override the neighbor's AS in outbound AS_PATH with the local AS";
+      presence "Enable as-override on the egress path toward this neighbor";
+      description
+        "When present, replace every occurrence of this neighbor's AS in
+         the AS_PATH with the local AS on outbound eBGP UPDATEs, before
+         the local-AS prepend.";
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Attach as-override to BGP neighbors in the candidate-set
+       subtree.";
+    uses bgp-neighbor-as-override-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp neighbor X as-override` is path-valid.";
+    uses bgp-neighbor-as-override-extension;
+  }
+}


### PR DESCRIPTION
## Summary

Implements FRR-style `neighbor X as-override`. On the egress path to an eBGP neighbor, every occurrence of that neighbor's AS in the AS_PATH is replaced with the local AS **before** the local-AS prepend, so a neighbor that reuses an AS already in the path (e.g. two CE sites sharing one AS behind a provider) no longer trips its RFC 4271 loop check. It is the send-side counterpart to `allowas-in`; eBGP-only, applied across all AFI/SAFIs.

### Changes
- **`As4Path::replace_as_mut`** (bgp-packet) — mirrors FRR `aspath_replace_specific_asn`.
- **`ebgp_egress_aspath` helper** — centralizes the eBGP egress AS_PATH transform (override-then-prepend), replacing 6 duplicated prepend sites in `route.rs` (ipv4/ipv6/labelv4/labelv6/flowspec/evpn).
- **Update-group signature** — adds `as_override_target: Option<u32>` (bumps `SIGNATURE_VERSION` → 2). The update-group memoizes one canonical attr per group and shares it across members; a per-peer transform keyed on `remote_as` must shard the group or it would leak a wrong AS_PATH to members with a different remote-AS. Surfaced in `show bgp update-group` and the design doc.
- **Config / YANG** — `as_override` on `PeerConfig`, `/as-override` callback, new `zebra-bgp-as-override.yang` presence container.
- **Show** — `show ip bgp neighbors` reports `AS-Override enabled`.
- **Docs** — new book page (`ch-02-12`), plus an unrelated one-line correction to the ttl-security page (where the egress TTL is re-applied).

## Test plan
- `cargo fmt --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- aspath unit tests (replace + override-then-prepend ordering) ✓
- config callback set/delete tests ✓
- update-group `signature_fields_each_distinguish` (now covers `as_override_target`) ✓
- `yang_load_tests` (validates the new module) ✓
- 289 BGP-module unit tests, no regression from the egress refactor ✓
- `mdbook build` ✓
- BDD `@bgp_as_override` added (z1→z2→z3 line, override on z2→z3) — exercised by CI.

Generated with [Claude Code](https://claude.com/claude-code)
