### PR TITLE
build: copy YANG schema to /etc/zebra-rs/yang on install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,13 @@ install:
 	sudo cp target/release/vtyctl /usr/bin/vtyctl
 	sudo cp target/release/vtyhelper /usr/bin/vtyhelper
 	sudo setcap 'cap_net_bind_service=ep cap_net_admin=ep cap_net_bind_service=ep cap_net_broadcast=ep cap_net_raw=ep' /usr/bin/zebra-rs
+	# Refresh the system-wide YANG schema the daemon loads at runtime.
+	# A daemon started without --yang-path and under sudo (HOME=/root)
+	# resolves to /etc/zebra-rs/yang, so a stale copy here silently
+	# rejects newly-added config (e.g. a new neighbor knob) even though
+	# the binary supports it. Keep this in lockstep with the binaries.
+	sudo mkdir -p /etc/zebra-rs/yang
+	sudo cp zebra-rs/yang/*.yang /etc/zebra-rs/yang/
 
 # System-wide installation of vtypam to /usr/sbin with file caps.
 # Use this on production hosts; the per-user `install` target above


### PR DESCRIPTION
## Summary

`make install` copied only the release binaries to `/usr/bin`, never the YANG schema. A daemon started without `--yang-path` and under `sudo` (HOME=/root) resolves its schema directory to `/etc/zebra-rs/yang` (`main.rs` `yang_path()`: `--yang-path` → `~/.zebra-rs/yang` → `/etc/zebra-rs/yang`). A stale copy there silently **rejects newly-added config** even though the binary supports it.

This was the root cause of the `@bgp_as_override` BDD failure: `/etc/zebra-rs/yang` was missing `zebra-bgp-as-override.yang`, so the daemon rejected `set router bgp neighbor X as-override`, z2 never had the knob, and z3 never received the route. It affects **any** future config-adding feature, not just as-override, and the BDD CI workflow (which runs `make install`) hits the same gap.

Fix: refresh the system-wide YANG dir in lockstep with the binaries:

```make
sudo mkdir -p /etc/zebra-rs/yang
sudo cp zebra-rs/yang/*.yang /etc/zebra-rs/yang/
```

## Test plan

- Reproduced the failure: on the running BDD daemon, `vtyctl apply -c "set router bgp neighbor 192.168.1.3 as-override"` returned `error reply`; `/etc/zebra-rs/yang` had 76 modules vs 77 in source (missing `zebra-bgp-as-override.yang`).
- Applied the fix (copied YANG to `/etc/zebra-rs/yang`) and re-ran the feature on a clean environment: `@bgp_as_override` → **3 scenarios (3 passed)**, including z3 learning `10.0.0.1/32` and `show ip bgp neighbors` on z2 containing `AS-Override`.
- Makefile-only change; no Rust touched, so fmt/clippy/test are unaffected.

Generated with [Claude Code](https://claude.com/claude-code)
