### PR TITLE
bgp: add neighbor remove-private-as (egress AS_PATH private-AS stripping)

### DIFF
--- a/bdd/tests/configs/bgp_remove_private_as/z1.yaml
+++ b/bdd/tests/configs/bgp_remove_private_as/z1.yaml
@@ -1,0 +1,24 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 100
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_remove_private_as/z2-base.yaml
+++ b/bdd/tests/configs/bgp_remove_private_as/z2-base.yaml
@@ -1,0 +1,29 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+- if-name: i2
+  ipv4:
+    address: 192.168.1.2/24
+router:
+  bgp:
+    global:
+      as: 100
+      identifier: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    - remote-address: 192.168.1.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 200

--- a/bdd/tests/configs/bgp_remove_private_as/z2-remove.yaml
+++ b/bdd/tests/configs/bgp_remove_private_as/z2-remove.yaml
@@ -1,0 +1,35 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+- if-name: i2
+  ipv4:
+    address: 192.168.1.2/24
+router:
+  bgp:
+    global:
+      as: 100
+      identifier: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+    - remote-address: 192.168.1.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 200
+      # Presence container → bare `set ... remove-private-as`. On egress
+      # toward z3, the AS_PATH learned from z1 is "65001" — entirely
+      # private — so the bare form strips it before z2 prepends its own
+      # AS 100. z3 receives AS_PATH "100" instead of "100 65001"; z1's
+      # private AS 65001 is hidden from z3.
+      remove-private-as:

--- a/bdd/tests/configs/bgp_remove_private_as/z3.yaml
+++ b/bdd/tests/configs/bgp_remove_private_as/z3.yaml
@@ -1,0 +1,20 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.1.3/24
+router:
+  bgp:
+    global:
+      as: 200
+      identifier: 192.168.1.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.1.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 100

--- a/bdd/tests/features/bgp_remove_private_as.feature
+++ b/bdd/tests/features/bgp_remove_private_as.feature
@@ -1,0 +1,68 @@
+@serial
+@bgp_remove_private_as
+Feature: BGP remove-private-as strips private ASNs from the egress AS_PATH
+  As a network operator
+  I want `neighbor X remove-private-as`
+  So a downstream eBGP peer never learns the private internal AS numbers
+  of my network.
+
+  Test Topology (a line; z1 uses a private AS behind public z2):
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐  192.168.1.0/24  ┌─────────┐
+   │   z1    │ i1────────────i1 │   z2    │ i2────────────i1 │   z3    │
+   │ AS65001 │                  │ AS 100  │                  │ AS 200  │
+   │ .0.1    │                  │.0.2 .1.2│                  │ .1.3    │
+   └─────────┘                  └─────────┘                  └─────────┘
+   private AS                    public AS                    public AS
+  ```
+
+  z1 originates 10.0.0.1/32; z2 learns it with AS_PATH "65001". When z2
+  re-advertises it to z3 it normally prepends its own AS, sending
+  "100 65001" — leaking z1's private AS 65001 to z3. With
+  `remove-private-as` on z2's session toward z3, z2 strips the private
+  65001 before prepending, so z3 receives just "100". The neighbor's own
+  AS (z3's 200) would always be kept for loop prevention, but here it is
+  not in the path.
+
+  Config files:
+  - z1.yaml:          z1 (private AS 65001) originates 10.0.0.1/32
+  - z3.yaml:          z3 plain
+  - z2-base.yaml:     z2 without remove-private-as
+  - z2-remove.yaml:   z2 with `remove-private-as` toward 192.168.1.3
+
+  Scenario: Setup line topology and establish all sessions
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I create namespace "z3"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I connect namespace "z2" interface "i2" to namespace "z3" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2-base.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP session in "z2" to "192.168.1.3" should be "Established"
+    And BGP session in "z3" to "192.168.1.2" should be "Established"
+
+  Scenario: Without remove-private-as the private AS leaks to z3
+    Given the test topology exists
+    # z3 learns the route, but the AS_PATH still carries z1's private AS.
+    Then BGP route in "z3" has "10.0.0.1/32"
+    And BGP route in "z3" has "10.0.0.1/32" with "as_path" value "100 65001"
+
+  Scenario: remove-private-as strips the private AS on egress to z3
+    Given the test topology exists
+    When I apply config "z2-remove.yaml" to namespace "z2"
+    # Bounce the z2<->z3 session so z2 re-advertises 10.0.0.1/32 with the
+    # stripped AS_PATH "100".
+    And I run "clear bgp ipv4 neighbor 192.168.1.3" in namespace "z2"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z3" to "192.168.1.2" should be "Established"
+    And BGP route in "z3" has "10.0.0.1/32"
+    And BGP route in "z3" has "10.0.0.1/32" with "as_path" value "100"
+    And show command "show ip bgp neighbors" in namespace "z2" should contain "Private AS removal"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -19,6 +19,7 @@
   - [TTL: eBGP Multihop & Security (GTSM)](ch-02-11-bgp-ttl-security.md)
   - [AS Override](ch-02-12-bgp-as-override.md)
   - [allowas-in (Inbound AS_PATH Loop Relaxation)](ch-02-13-bgp-allowas-in.md)
+  - [Remove Private AS](ch-02-14-bgp-remove-private-as.md)
   - [Timer Configuration](ch-02-03-bgp-timers.md)
   - [L3VPN and Per-VRF Labels](ch-02-04-bgp-l3vpn.md)
   - [L3VPN over an SRv6 Underlay](ch-02-05-bgp-l3vpn-srv6.md)

--- a/book/src/ch-02-14-bgp-remove-private-as.md
+++ b/book/src/ch-02-14-bgp-remove-private-as.md
@@ -1,0 +1,195 @@
+# BGP Remove Private AS
+
+Private Autonomous System numbers — `64512`–`65535` (RFC 6996) and the
+32-bit range `4200000000`–`4294967294` — are meant to stay **inside** a
+network. They commonly number the customer or internal sites that sit
+behind a provider's public AS. When the provider re-advertises those
+routes to an upstream or peering neighbor, the private ASNs would
+normally travel in the AS_PATH, leaking the internal numbering and
+sometimes causing the neighbor to reject the route on a private-AS
+filter.
+
+`neighbor X remove-private-as` strips those private ASNs from the
+AS_PATH on the **advertising** side, before the local AS is prepended,
+so the neighbor only ever sees public ASNs.
+
+## The problem
+
+A provider in public AS 100 has a customer site numbered with the
+private AS 65001:
+
+```
+ ┌─────────┐  192.168.0.0/24  ┌─────────┐  192.168.1.0/24  ┌─────────┐
+ │   z1    │ ──────────────── │   z2    │ ──────────────── │   z3    │
+ │ AS65001 │                  │ AS 100  │                  │ AS 200  │
+ └─────────┘                  └─────────┘                  └─────────┘
+ private AS                    public AS                    public AS
+ originates                                                 learns it with
+ 10.0.0.1/32                                                AS_PATH "100 65001"
+```
+
+`z1` originates `10.0.0.1/32`; `z2` learns it with AS_PATH `65001`. When
+`z2` re-advertises it to `z3` it prepends its own AS, sending
+`100 65001`. `z3` now sees the customer's private AS 65001 in the path —
+information that should never have left `z2`'s network, and a path that a
+peer applying `bgp bestpath ... no-private-as` filtering may reject.
+
+## What remove-private-as does
+
+With `remove-private-as` configured on `z2`'s session toward `z3`, the
+egress transform changes to **strip, then prepend**:
+
+1. Remove every private AS from the AS_PATH (here `65001`), keeping any
+   public ASNs.
+2. Prepend the local AS as usual: the path becomes just `100`.
+
+`z3` receives `100`, with no trace of the customer's private AS.
+
+### The neighbor's own AS is always kept
+
+If the AS being stripped happens to be the **neighbor's own** AS, it is
+left in the path. Removing it could hide a genuine loop from the
+neighbor's RFC 4271 check, so — exactly like FRR — `remove-private-as`
+preserves the neighbor's AS even when it is private. (If you *want* a
+neighbor to accept a path that legitimately transited its own AS, that
+is the job of [`as-override`](ch-02-12-bgp-as-override.md), the
+send-side, or [`allowas-in`](ch-02-13-bgp-allowas-in.md), the
+receive-side relaxation.)
+
+### The four forms
+
+FRR exposes four variants, which are two orthogonal modifiers on the
+same transform:
+
+| Form | When it acts | What it does to a private AS |
+|------|--------------|------------------------------|
+| `remove-private-as`                | only when the **whole** path is private | removes it |
+| `remove-private-as all`            | on **any** path containing a private AS | removes it |
+| `remove-private-as replace-as`     | only when the whole path is private     | rewrites it to the local AS |
+| `remove-private-as all replace-as` | on any path containing a private AS     | rewrites it to the local AS |
+
+- **`all`** widens the trigger. Without it, the strip is conservative:
+  it only runs when *every* AS in the path is private, leaving any path
+  that already mixes public and private ASNs untouched. With `all`, the
+  private ASNs are stripped from a mixed path too, keeping the public
+  ones.
+- **`replace-as`** changes the action from *remove* to *substitute*:
+  each private AS is rewritten to the local AS instead of being dropped,
+  which keeps the AS_PATH length (and therefore the path-length tiebreak)
+  unchanged.
+
+`remove-private-as` only affects **eBGP** sessions. iBGP never prepends
+the local AS, so the knob is a no-op there and is ignored. The transform
+is applied uniformly across every address family the session carries
+(IPv4/IPv6 unicast, labeled-unicast, L3VPN, EVPN, flow-spec).
+
+## Configuration
+
+`remove-private-as` is a per-neighbor presence container. Configure it on
+the provider end, on the session toward the upstream/peer:
+
+```yaml
+router:
+  bgp:
+    global:
+      as: 100
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.1.3
+      remote-as: 200
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      remove-private-as:
+```
+
+`remove-private-as:` with no value is the YAML spelling of a bare
+presence container, which the loader turns into
+`set router bgp neighbor 192.168.1.3 remove-private-as`. The FRR /
+IOS-style CLI form is the same path:
+
+```
+set router bgp neighbor 192.168.1.3 remove-private-as
+```
+
+To enable the modifiers, set the corresponding leaves. In YAML:
+
+```yaml
+      remove-private-as:
+        all: null
+        replace-as: null
+```
+
+or, on the CLI, as separate `set` lines (each `set` targets one node):
+
+```
+set router bgp neighbor 192.168.1.3 remove-private-as
+set router bgp neighbor 192.168.1.3 remove-private-as all
+set router bgp neighbor 192.168.1.3 remove-private-as replace-as
+```
+
+Enabling `remove-private-as` on an already-established session does not
+by itself re-send routes already in the neighbor's Adj-RIB-Out. Bounce
+the session so the provider re-advertises with the stripped AS_PATH:
+
+```
+clear bgp ipv4 neighbor 192.168.1.3
+```
+
+## Verification
+
+`show ip bgp neighbor <addr>` reports the configured form:
+
+```
+  Private AS removal: remove-private-AS (outbound)
+```
+
+(or `remove-private-AS all replace-AS (outbound)` with both modifiers).
+
+On the neighbor, confirm the stripped path arrived. `z3` should now hold
+`10.0.0.1/32` with an AS_PATH of `100` rather than `100 65001`:
+
+```
+show ip bgp 10.0.0.1/32
+```
+
+### Interaction with update-groups
+
+zebra-rs batches identical outbound work into **update-groups** and
+encodes one UPDATE for every member of a group (see the design notes in
+`docs/design/bgp-update-groups.md`). Because the stripped AS_PATH depends
+on the modifiers in force *and* on the neighbor's own AS (which is kept),
+the result is peer-specific: two eBGP neighbors strip identically only
+when they share the same modifiers and keep the same AS. A neighbor with
+`remove-private-as` is therefore keyed into its own update-group,
+separate from peers that strip differently or not at all. `show bgp
+update-group` makes this visible:
+
+```
+  Signature:
+    ...
+    Remove-private-AS:          on (keep 200)
+```
+
+A `—` in that field means the group's members do not strip private ASNs
+(the common case). This separation is automatic; no extra configuration
+is required.
+
+## Troubleshooting
+
+If the private AS still appears at the neighbor after enabling
+`remove-private-as`, check that:
+
+- the session is **eBGP** (`remove-private-as` is ignored on iBGP);
+- the AS you expect to disappear is actually **private** — only
+  `64512`–`65535` and `4200000000`–`4294967294` are stripped; a public
+  AS is always kept;
+- the AS being stripped is **not the neighbor's own** remote-as — that
+  one is deliberately preserved for loop prevention;
+- if the path mixes public and private ASNs and nothing was stripped,
+  add the **`all`** modifier — the bare form only acts on an
+  all-private path;
+- the session was **bounced** (`clear bgp ipv4 neighbor <addr>`) after
+  the configuration change, so the route was re-advertised under the new
+  policy.

--- a/crates/bgp-packet/src/attrs/aspath.rs
+++ b/crates/bgp-packet/src/attrs/aspath.rs
@@ -20,6 +20,22 @@ pub const AS_CONFED_SET: u8 = 4;
 #[allow(dead_code)]
 pub const AS_TRANS: u16 = 23456;
 
+/// Inclusive bounds of the 16-bit private AS range (RFC 6996).
+pub const PRIVATE_AS_MIN: u32 = 64512;
+pub const PRIVATE_AS_MAX: u32 = 65535;
+
+/// Inclusive bounds of the 32-bit private AS range (RFC 6996 / IANA
+/// reserved-for-private-use; FRR's `BGP_PRIVATE_AS4_*`).
+pub const PRIVATE_AS4_MIN: u32 = 4200000000;
+pub const PRIVATE_AS4_MAX: u32 = 4294967294;
+
+/// True if `asn` falls in either the 16-bit or 32-bit private AS range.
+/// Mirrors FRR's `BGP_AS_IS_PRIVATE`. Drives `remove-private-as`.
+pub fn is_private_as(asn: u32) -> bool {
+    (PRIVATE_AS_MIN..=PRIVATE_AS_MAX).contains(&asn)
+        || (PRIVATE_AS4_MIN..=PRIVATE_AS4_MAX).contains(&asn)
+}
+
 /// Calculate AS Path segment length according to RFC 4271 and RFC 5065.
 /// - AS_SEQUENCE: Each AS number counts as 1
 /// - AS_SET: The entire set counts as 1 (regardless of size)
@@ -421,6 +437,55 @@ impl As4Path {
         }
     }
 
+    /// True iff every AS in the path is a private AS (RFC 6996 / 32-bit
+    /// IANA reserved ranges). Mirrors FRR's `aspath_private_as_check`,
+    /// including its treatment of an empty path as *not* all-private
+    /// (returns `false`). The bare `remove-private-as` form (without
+    /// `all`) only acts when this holds.
+    pub fn is_all_private(&self) -> bool {
+        let mut seen_any = false;
+        for seg in &self.segs {
+            for &asn in &seg.asn {
+                seen_any = true;
+                if !is_private_as(asn) {
+                    return false;
+                }
+            }
+        }
+        seen_any
+    }
+
+    /// Strip every private AS from all segments, except occurrences
+    /// equal to `keep` — the eBGP neighbor's own AS, retained so the
+    /// neighbor's RFC 4271 loop check still works (mirrors FRR's
+    /// `aspath_remove_private_asns`, which preserves `peer_asn`).
+    /// Segments left empty are dropped and the hop count (`length`) is
+    /// recomputed, since removing ASNs changes it. Used by
+    /// `remove-private-as` on the egress path.
+    pub fn remove_private_as_mut(&mut self, keep: u32) {
+        for seg in self.segs.iter_mut() {
+            seg.asn.retain(|&asn| !is_private_as(asn) || asn == keep);
+        }
+        self.segs.retain(|seg| !seg.asn.is_empty());
+        self.update_length();
+    }
+
+    /// Replace every private AS with `replacement` (the local AS),
+    /// except occurrences equal to `keep` — the neighbor's own AS,
+    /// preserved for loop prevention. A 1:1 substitution (mirrors FRR's
+    /// `aspath_replace_private_asns`), so the hop count is unchanged and
+    /// `length` stays valid without recomputation. Used by
+    /// `remove-private-as replace-as` on the egress path.
+    pub fn replace_private_as_mut(&mut self, replacement: u32, keep: u32) {
+        for seg in self.segs.iter_mut() {
+            for asn in seg.asn.iter_mut() {
+                if is_private_as(*asn) && *asn != keep {
+                    *asn = replacement;
+                }
+            }
+        }
+    }
+
     /// Try to merge two single-segment AS_SEQ paths into one segment.
     fn try_merge_single_seq(&self, other: &Self) -> Option<Self> {
         if self.segs.len() != 1 || other.segs.len() != 1 {
@@ -798,5 +863,100 @@ mod tests {
         aspath.replace_as_mut(65001, 65002);
         aspath.prepend_mut(As4Path::from(vec![65002]));
         assert_eq!(aspath.to_string(), "65002 65002");
+    }
+
+    #[test]
+    fn is_private_as_ranges() {
+        // 16-bit private band (RFC 6996).
+        assert!(!is_private_as(64511));
+        assert!(is_private_as(64512));
+        assert!(is_private_as(65001));
+        assert!(is_private_as(65535));
+        assert!(!is_private_as(65536));
+        // Public ASNs (65000 sits *inside* the private band, so the
+        // public sample is well clear of it).
+        assert!(!is_private_as(100));
+        assert!(!is_private_as(13335));
+        // 32-bit private band; 4294967295 (AS_TRANS-adjacent reserved) is
+        // excluded, matching FRR's upper bound of 4294967294.
+        assert!(!is_private_as(4199999999));
+        assert!(is_private_as(4200000000));
+        assert!(is_private_as(4294967294));
+        assert!(!is_private_as(4294967295));
+    }
+
+    #[test]
+    fn is_all_private_mixed_and_empty() {
+        assert!(As4Path::from_str("65001 65002").unwrap().is_all_private());
+        // A single public AS makes the path not all-private.
+        assert!(!As4Path::from_str("65001 100").unwrap().is_all_private());
+        // An empty path is not all-private (matches FRR).
+        assert!(!As4Path::new().is_all_private());
+    }
+
+    #[test]
+    fn remove_private_as_strips_and_keeps_peer() {
+        // "100 65001 200 65002" toward a peer in AS 200: both private
+        // ASNs are stripped, the public 100/200 stay, and the hop count
+        // drops from 4 to 2.
+        let mut aspath: As4Path = As4Path::from_str("100 65001 200 65002").unwrap();
+        aspath.remove_private_as_mut(200);
+        assert_eq!(aspath.to_string(), "100 200");
+        assert_eq!(aspath.length(), 2);
+
+        // The peer's own AS is preserved even though it is private, so
+        // the neighbor's loop check still fires.
+        let mut aspath: As4Path = As4Path::from_str("100 65001 65002").unwrap();
+        aspath.remove_private_as_mut(65002);
+        assert_eq!(aspath.to_string(), "100 65002");
+        assert_eq!(aspath.length(), 2);
+    }
+
+    #[test]
+    fn remove_private_as_drops_empty_segments() {
+        // An all-private path with no kept AS collapses to empty; the
+        // now-empty segment is dropped rather than emitted zero-length.
+        let mut aspath: As4Path = As4Path::from_str("65001 65002").unwrap();
+        aspath.remove_private_as_mut(100);
+        assert_eq!(aspath.to_string(), "");
+        assert_eq!(aspath.length(), 0);
+        assert!(aspath.segs.is_empty());
+    }
+
+    #[test]
+    fn remove_private_as_reaches_into_sets() {
+        // Private ASNs inside an AS_SET are stripped; a set that still
+        // has a member survives as one hop, an emptied one is dropped.
+        let mut aspath: As4Path = As4Path::from_str("100 {65001 300} 65002").unwrap();
+        aspath.remove_private_as_mut(400);
+        assert_eq!(aspath.to_string(), "100 {300}");
+        assert_eq!(aspath.length(), 2);
+    }
+
+    #[test]
+    fn replace_private_as_substitutes_keeping_peer() {
+        // "100 65001 200 65002" toward AS 200 from local AS 500: each
+        // private AS becomes 500, length is unchanged (1:1 swap).
+        let mut aspath: As4Path = As4Path::from_str("100 65001 200 65002").unwrap();
+        aspath.replace_private_as_mut(500, 200);
+        assert_eq!(aspath.to_string(), "100 500 200 500");
+        assert_eq!(aspath.length(), 4);
+
+        // The peer's own (private) AS is left as-is.
+        let mut aspath: As4Path = As4Path::from_str("65001 65002").unwrap();
+        aspath.replace_private_as_mut(500, 65002);
+        assert_eq!(aspath.to_string(), "500 65002");
+    }
+
+    #[test]
+    fn remove_private_as_egress_sequence_is_strip_then_prepend() {
+        // Full egress transform for bare `remove-private-as` toward a
+        // peer in public AS 200 from local AS 200: the all-private path
+        // "65001" is stripped to empty, then 200 is prepended, so the
+        // neighbor receives just "200" instead of "200 65001".
+        let mut aspath: As4Path = As4Path::from_str("65001").unwrap();
+        aspath.remove_private_as_mut(200);
+        aspath.prepend_mut(As4Path::from(vec![200]));
+        assert_eq!(aspath.to_string(), "200");
     }
 }

--- a/docs/design/bgp-update-groups.md
+++ b/docs/design/bgp-update-groups.md
@@ -86,6 +86,7 @@ Two peers belong to the same update-group for a given `(afi, safi)` iff
 | `policy_list.output.name` | Outbound policy identity. |
 | `prefix_set.output.name` | Outbound prefix filter identity. |
 | `config.as_override` + `remote_as` (eBGP only) | `as-override` rewrites the peer's remote-AS to `local_as` in the egress AS_PATH; the result depends on `remote_as`, so it joins the key as `as_override_target: Some(remote_as)` (else `None`). |
+| `config.remove_private_as` + `remote_as` (eBGP only) | `remove-private-as` strips (or, with `replace-as`, rewrites) private ASNs from the egress AS_PATH; the result depends on the two modifiers and on the kept AS (`remote_as`), so it joins the key as `remove_private_as: Some(RemovePrivateAsKey { all, replace_as, keep_as })` (else `None`). |
 | `is_afi_safi(afi, safi)` membership | Implicit — only members of the AFI/SAFI participate in that group. |
 | `addpath_send` for `(afi, safi)` | Different framing → different group. |
 
@@ -124,10 +125,11 @@ UPDATE wire format, or are informational):
 
 Knobs that don't yet exist in zebra-rs but will join the signature when
 they land: `next-hop-self`, `next-hop-unchanged`, `send-community`
-flags (standard / extended / large), `remove-private-as`, outbound
-`route-map` (when separate from policy-list), per-peer `update-source`
-distinct from `transport.local-address`. (`as-override` landed and is
-now modeled as `as_override_target` — see the signature table above.)
+flags (standard / extended / large), outbound `route-map` (when separate
+from policy-list), per-peer `update-source` distinct from
+`transport.local-address`. (`as-override` and `remove-private-as` have
+landed and are modeled as `as_override_target` / `remove_private_as` —
+see the signature table above.)
 
 **Conservatism rule**: any outbound-affecting setting that the
 signature does not yet model forces the peer into a singleton group.
@@ -187,6 +189,7 @@ pub struct UpdateGroupSig {
     pub policy_out_name: Option<String>,
     pub prefix_set_out_name: Option<String>,
     pub as_override_target: Option<u32>, // Some(remote_as) iff as-override (eBGP)
+    pub remove_private_as: Option<RemovePrivateAsKey>, // Some{all,replace_as,keep_as} iff remove-private-as (eBGP)
     // Negotiated wire-format capabilities (intersection of
     // cap_send and cap_recv on Peer). Anything that changes
     // encoded UPDATE bytes belongs here:

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -18,7 +18,9 @@ use super::route_clean;
 use super::{
     Bgp,
     inst::Callback,
-    peer::{ALLOWAS_IN_DEFAULT_COUNT, AllowAsIn, PasswordEncoding, Peer, PeerType},
+    peer::{
+        ALLOWAS_IN_DEFAULT_COUNT, AllowAsIn, PasswordEncoding, Peer, PeerType, RemovePrivateAs,
+    },
     timer,
 };
 
@@ -537,6 +539,70 @@ fn config_as_override(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()>
     let addr = args.addr()?;
     let peer = bgp.peers.get_mut(&addr)?;
     peer.config.as_override = op.is_set();
+    Some(())
+}
+
+/// `set router bgp neighbor X remove-private-as` — the presence
+/// container (zebra-bgp-remove-private-as.yang). Enables egress
+/// private-AS stripping toward this neighbor with both modifiers off
+/// (FRR's bare form: strip only when the whole AS_PATH is private);
+/// `delete` disables the feature entirely.
+///
+/// The `all` / `replace-as` modifiers ride their own callbacks. All
+/// three are order-independent within a commit: this handler uses
+/// `get_or_insert_with` so it never clobbers a modifier that landed
+/// first, and the child handlers seed the container if they arrive
+/// first.
+fn config_remove_private_as(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let peer = bgp.peers.get_mut(&addr)?;
+
+    if op.is_set() {
+        peer.config
+            .remove_private_as
+            .get_or_insert_with(RemovePrivateAs::default);
+    } else {
+        peer.config.remove_private_as = None;
+    }
+    Some(())
+}
+
+/// `set router bgp neighbor X remove-private-as all`. Act on a mixed
+/// public/private AS_PATH, not only an all-private one. Deleting just
+/// `all` reverts to the conditional (all-private-only) behaviour while
+/// the container stays enabled; full removal goes through
+/// [`config_remove_private_as`].
+fn config_remove_private_as_all(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let peer = bgp.peers.get_mut(&addr)?;
+
+    if op.is_set() {
+        peer.config
+            .remove_private_as
+            .get_or_insert_with(RemovePrivateAs::default)
+            .all = true;
+    } else if let Some(rpa) = peer.config.remove_private_as.as_mut() {
+        rpa.all = false;
+    }
+    Some(())
+}
+
+/// `set router bgp neighbor X remove-private-as replace-as`. Rewrite
+/// each stripped private AS to the local AS instead of dropping it.
+/// Deleting just `replace-as` reverts to dropping while the container
+/// stays enabled; full removal goes through [`config_remove_private_as`].
+fn config_remove_private_as_replace_as(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let peer = bgp.peers.get_mut(&addr)?;
+
+    if op.is_set() {
+        peer.config
+            .remove_private_as
+            .get_or_insert_with(RemovePrivateAs::default)
+            .replace_as = true;
+    } else if let Some(rpa) = peer.config.remove_private_as.as_mut() {
+        rpa.replace_as = false;
+    }
     Some(())
 }
 
@@ -2264,6 +2330,17 @@ impl Bgp {
         // local AS in the AS_PATH so its RFC 4271 loop check accepts
         // routes that transited its AS (eBGP only).
         self.callback_peer("/as-override", config_as_override);
+
+        // Per-neighbor remove-private-as (zebra-bgp-remove-private-as.yang).
+        // Strip (or, with `replace-as`, rewrite to the local AS) private
+        // ASNs from the egress AS_PATH toward this neighbor; the `all`
+        // modifier widens it from all-private-only to any path (eBGP only).
+        self.callback_peer("/remove-private-as", config_remove_private_as);
+        self.callback_peer("/remove-private-as/all", config_remove_private_as_all);
+        self.callback_peer(
+            "/remove-private-as/replace-as",
+            config_remove_private_as_replace_as,
+        );
     }
 }
 
@@ -2755,6 +2832,79 @@ mod bfd_wiring_tests {
         config_as_override(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
         config_as_override(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Delete).unwrap();
         assert!(!peer_as_override(&bgp, "10.0.0.2"));
+    }
+
+    fn peer_remove_private_as(bgp: &Bgp, addr: &str) -> Option<RemovePrivateAs> {
+        bgp.peers
+            .get(&addr.parse().unwrap())
+            .unwrap()
+            .config
+            .remove_private_as
+    }
+
+    /// The bare presence container enables the feature with both
+    /// modifiers off (FRR's plain `remove-private-AS`).
+    #[tokio::test]
+    async fn remove_private_as_set_enables_bare() {
+        let (mut bgp, _rx) = fresh_bgp_with_bfd();
+        config_peer(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        assert_eq!(peer_remove_private_as(&bgp, "10.0.0.2"), None);
+        config_remove_private_as(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        assert_eq!(
+            peer_remove_private_as(&bgp, "10.0.0.2"),
+            Some(RemovePrivateAs {
+                all: false,
+                replace_as: false
+            })
+        );
+    }
+
+    /// `all` and `replace-as` arriving in either order both land, and
+    /// neither child clobbers the other or the container. Mirrors the
+    /// order-independence the BGP commit pipeline relies on.
+    #[tokio::test]
+    async fn remove_private_as_modifiers_compose_order_independent() {
+        let (mut bgp, _rx) = fresh_bgp_with_bfd();
+        config_peer(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        // Child callbacks arrive before the container set — `get_or_insert`
+        // must seed it rather than no-op.
+        config_remove_private_as_replace_as(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set)
+            .unwrap();
+        config_remove_private_as_all(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        config_remove_private_as(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        assert_eq!(
+            peer_remove_private_as(&bgp, "10.0.0.2"),
+            Some(RemovePrivateAs {
+                all: true,
+                replace_as: true
+            })
+        );
+    }
+
+    /// Deleting a single modifier reverts just that modifier; deleting
+    /// the container disables the whole feature.
+    #[tokio::test]
+    async fn remove_private_as_partial_then_full_delete() {
+        let (mut bgp, _rx) = fresh_bgp_with_bfd();
+        config_peer(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        config_remove_private_as(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        config_remove_private_as_all(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        config_remove_private_as_replace_as(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set)
+            .unwrap();
+
+        // Drop just `all`; the container and `replace-as` stay.
+        config_remove_private_as_all(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Delete).unwrap();
+        assert_eq!(
+            peer_remove_private_as(&bgp, "10.0.0.2"),
+            Some(RemovePrivateAs {
+                all: false,
+                replace_as: true
+            })
+        );
+
+        // Drop the whole container.
+        config_remove_private_as(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Delete).unwrap();
+        assert_eq!(peer_remove_private_as(&bgp, "10.0.0.2"), None);
     }
 }
 

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -296,6 +296,27 @@ pub enum AllowAsIn {
     Origin,
 }
 
+/// Per-neighbor `remove-private-as` mode (zebra-bgp-remove-private-as.yang).
+/// FRR exposes four CLI forms; they collapse to two orthogonal
+/// modifiers on the egress AS_PATH transform (eBGP only):
+///
+/// - `all` (`false` by default): when `false` the strip only runs if the
+///   *entire* AS_PATH is private (FRR's bare `remove-private-AS`); when
+///   `true` it runs even on a mixed public/private path
+///   (`remove-private-AS all`).
+/// - `replace_as` (`false` by default): when `false` each private AS is
+///   dropped from the path; when `true` it is rewritten to the local AS
+///   instead (`remove-private-AS [all] replace-AS`).
+///
+/// In every form the neighbor's own AS is preserved so its RFC 4271 loop
+/// check still works. `None` on [`PeerConfig`] disables the feature.
+/// Serializes flat as `{"all":bool,"replace_as":bool}`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
+pub struct RemovePrivateAs {
+    pub all: bool,
+    pub replace_as: bool,
+}
+
 #[derive(Debug, Clone)]
 pub struct PeerConfig {
     pub transport: PeerTransportConfig,
@@ -344,6 +365,11 @@ pub struct PeerConfig {
     /// that have transited its own AS. Ignored for iBGP peers (which do
     /// not prepend). Default `false`.
     pub as_override: bool,
+    /// Per-neighbor `remove-private-as` (zebra-bgp-remove-private-as.yang).
+    /// `None` leaves the AS_PATH untouched; `Some` strips (or, with
+    /// `replace_as`, rewrites) private ASNs from every outbound eBGP
+    /// UPDATE before the local-AS prepend. Ignored for iBGP peers.
+    pub remove_private_as: Option<RemovePrivateAs>,
 }
 
 impl Default for PeerConfig {
@@ -366,6 +392,7 @@ impl Default for PeerConfig {
             bfd: PeerBfdConfig::default(),
             allowas_in: None,
             as_override: false,
+            remove_private_as: None,
         }
     }
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -81,14 +81,22 @@ fn local_as_only_at_origin(aspath: &As4Path, local_as: u32) -> bool {
 }
 
 /// Apply the egress AS_PATH transformation for an eBGP announcement to
-/// `peer`: an optional per-neighbor `as-override` (replace the peer's
-/// own AS with the local AS so its RFC 4271 loop check accepts a route
-/// that transited its AS), followed by the mandatory local-AS prepend.
-/// iBGP peers and routes without an AS_PATH are left untouched. The
-/// override runs *before* the prepend, mirroring FRR's
-/// `bgp_peer_as_override` (announce-check) and the later packet-build
-/// prepend. Call this at every eBGP egress site instead of prepending
-/// inline, so `as-override` is applied uniformly across address families.
+/// `peer`. Three stages run in FRR's order, all *before* the local-AS
+/// prepend (iBGP peers and routes without an AS_PATH are left
+/// untouched):
+///
+/// 1. `remove-private-as`: strip (or, with `replace-as`, rewrite to the
+///    local AS) private ASNs. The bare form only fires when the whole
+///    path is private; `all` fires on any path. The neighbor's own AS is
+///    always kept for loop prevention. Mirrors FRR's
+///    `bgp_peer_remove_private_as`.
+/// 2. `as-override`: replace the peer's own AS with the local AS so its
+///    RFC 4271 loop check accepts a route that transited its AS. Mirrors
+///    FRR's `bgp_peer_as_override`, which runs after remove-private-as.
+/// 3. the mandatory local-AS prepend.
+///
+/// Call this at every eBGP egress site instead of prepending inline, so
+/// the transforms apply uniformly across address families.
 fn ebgp_egress_aspath(peer: &Peer, attrs: &mut BgpAttr) {
     if !peer.is_ebgp() {
         return;
@@ -96,6 +104,16 @@ fn ebgp_egress_aspath(peer: &Peer, attrs: &mut BgpAttr) {
     let Some(aspath) = attrs.aspath.as_mut() else {
         return;
     };
+    if let Some(rpa) = peer.config.remove_private_as {
+        // Bare form acts only on an all-private path; `all` acts on any.
+        if rpa.all || aspath.is_all_private() {
+            if rpa.replace_as {
+                aspath.replace_private_as_mut(peer.local_as, peer.remote_as);
+            } else {
+                aspath.remove_private_as_mut(peer.remote_as);
+            }
+        }
+    }
     if peer.config.as_override {
         aspath.replace_as_mut(peer.remote_as, peer.local_as);
     }

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 
 use super::cap::CapAfiMap;
 use super::inst::{Bgp, ShowCallback};
-use super::peer::{AllowAsIn, Peer, PeerCounter, PeerParam, State};
+use super::peer::{AllowAsIn, Peer, PeerCounter, PeerParam, RemovePrivateAs, State};
 use super::peer_map::PeerMap;
 use super::route::LocalRib;
 use super::vrf::inst::BgpVrf;
@@ -1391,6 +1391,12 @@ struct Neighbor<'a> {
     /// replaced with the local AS in the AS_PATH of outbound eBGP
     /// UPDATEs (before the local-AS prepend).
     as_override: bool,
+    /// FRR-style `neighbor X remove-private-as`
+    /// (zebra-bgp-remove-private-as.yang), if configured. `None` leaves
+    /// the egress AS_PATH untouched; `Some` strips (or, with
+    /// `replace_as`, rewrites) private ASNs on outbound eBGP UPDATEs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remove_private_as: Option<RemovePrivateAs>,
     /// GTSM / `ttl-security` (RFC 5082): the session only accepts a
     /// directly-connected peer (received TTL 255). Mirrors
     /// `peer.config.transport.ttl_security`.
@@ -1540,6 +1546,7 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         soft_reconfig_in: peer.config.soft_reconfig_in,
         allowas_in: peer.config.allowas_in,
         as_override: peer.config.as_override,
+        remove_private_as: peer.config.remove_private_as,
         ttl_security: peer.config.transport.ttl_security,
         ebgp_multihop: peer.config.transport.ebgp_multihop,
         neighbor_group: peer.config.neighbor_group.clone(),
@@ -1639,6 +1646,18 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
 
     if neighbor.as_override {
         writeln!(out, "  AS-Override enabled (outbound AS_PATH replacement)")?;
+    }
+
+    if let Some(rpa) = neighbor.remove_private_as {
+        // Echo the configured form, e.g. "remove-private-AS all replace-AS".
+        let mut form = String::from("remove-private-AS");
+        if rpa.all {
+            form.push_str(" all");
+        }
+        if rpa.replace_as {
+            form.push_str(" replace-AS");
+        }
+        writeln!(out, "  Private AS removal: {form} (outbound)")?;
     }
 
     if neighbor.ttl_security {

--- a/zebra-rs/src/bgp/show_update_group.rs
+++ b/zebra-rs/src/bgp/show_update_group.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 
 use super::Bgp;
 use super::peer::PeerType;
-use super::update_group::UpdateGroup;
+use super::update_group::{RemovePrivateAsKey, UpdateGroup};
 use crate::config::Args;
 
 /// Snapshot of a single update-group used by all renderers. Built up
@@ -42,8 +42,31 @@ struct SigView {
     /// (eBGP only); the egress AS_PATH has that AS rewritten to the
     /// local AS. `None` (the common case) means no override.
     as_override_target: Option<u32>,
+    /// `Some` when `remove-private-as` is set on the members (eBGP
+    /// only): the modifiers in force and the AS kept for loop
+    /// prevention. `None` (the common case) means no stripping.
+    remove_private_as: Option<RemovePrivateAsView>,
     capabilities: CapsView,
     signature_version: u32,
+}
+
+/// Serializable view of [`RemovePrivateAsKey`] for `show bgp
+/// update-group`.
+#[derive(Debug, Serialize)]
+struct RemovePrivateAsView {
+    all: bool,
+    replace_as: bool,
+    keep_as: u32,
+}
+
+impl From<RemovePrivateAsKey> for RemovePrivateAsView {
+    fn from(k: RemovePrivateAsKey) -> Self {
+        Self {
+            all: k.all,
+            replace_as: k.replace_as,
+            keep_as: k.keep_as,
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -126,6 +149,7 @@ fn build_view(bgp: &Bgp, afi_safi: AfiSafi, group: &UpdateGroup) -> GroupView {
             policy_out: group.sig.policy_out_name.clone(),
             prefix_set_out: group.sig.prefix_set_out_name.clone(),
             as_override_target: group.sig.as_override_target,
+            remove_private_as: group.sig.remove_private_as.map(Into::into),
             capabilities: CapsView {
                 as4_negotiated: group.sig.as4_negotiated,
                 extended_message: group.sig.extended_message,
@@ -261,6 +285,24 @@ fn render_detail_text(view: &GroupView) -> Result<String, std::fmt::Error> {
         view.signature
             .as_override_target
             .map(|asn| asn.to_string())
+            .unwrap_or_else(|| "—".to_string())
+    )?;
+    writeln!(
+        out,
+        "    Remove-private-AS:          {}",
+        view.signature
+            .remove_private_as
+            .as_ref()
+            .map(|rpa| {
+                let mut s = String::from("on");
+                if rpa.all {
+                    s.push_str(" all");
+                }
+                if rpa.replace_as {
+                    s.push_str(" replace-AS");
+                }
+                format!("{s} (keep {})", rpa.keep_as)
+            })
             .unwrap_or_else(|| "—".to_string())
     )?;
     writeln!(out, "    Negotiated capabilities:")?;

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -41,7 +41,7 @@ use crate::context::Timer;
 
 /// Bumped whenever a new field is added to `UpdateGroupSig`. Surfaced
 /// in `show bgp update-group` so a stale view is detectable.
-pub const SIGNATURE_VERSION: u32 = 2;
+pub const SIGNATURE_VERSION: u32 = 3;
 
 /// Address families the v1 grouping logic considers. The advertise
 /// pipeline today only fans out to these three.
@@ -87,6 +87,23 @@ impl std::fmt::Display for UpdateGroupId {
     }
 }
 
+/// Per-neighbor `remove-private-as` egress key
+/// (zebra-bgp-remove-private-as.yang). Folded into the update-group
+/// signature because the feature rewrites the egress AS_PATH and its
+/// output depends on per-peer state: the two FRR modifiers (`all`,
+/// `replace_as`) and the neighbor's own AS (`keep_as` = remote_as),
+/// which the strip preserves for loop prevention. Two eBGP peers may
+/// therefore share canonical UPDATE bytes only when they strip the same
+/// way *and* keep the same AS — otherwise the canonical-member transform
+/// would leak one peer's stripped path to the others. `None` (the common
+/// case) means the feature is off, with no effect on the transform.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RemovePrivateAsKey {
+    pub all: bool,
+    pub replace_as: bool,
+    pub keep_as: u32,
+}
+
 /// What makes two peers eligible to share Adj-RIB-Out work.
 ///
 /// All fields here either drive the attribute transform / outbound
@@ -113,6 +130,10 @@ pub struct UpdateGroupSig {
     /// AS_PATH — the canonical-member transform assumes its output
     /// depends only on signature fields.
     pub as_override_target: Option<u32>,
+    /// Per-neighbor `remove-private-as` key (eBGP only). `None` when off
+    /// (the common case). See [`RemovePrivateAsKey`] for why the mode
+    /// and the kept AS must shard the group.
+    pub remove_private_as: Option<RemovePrivateAsKey>,
     // Negotiated wire-format capabilities (intersection of cap_send
     // and cap_recv on the peer). Anything that changes encoded
     // UPDATE bytes belongs here.
@@ -230,6 +251,19 @@ pub fn signature_of(peer: &Peer, afi: Afi, safi: Safi) -> Option<UpdateGroupSig>
         // no-op there and must not split iBGP groups).
         as_override_target: if peer.is_ebgp() && peer.config.as_override {
             Some(peer.remote_as)
+        } else {
+            None
+        },
+        // remove-private-as strips/rewrites the egress AS_PATH; its
+        // result depends on the mode and on the kept AS (this peer's
+        // remote-as), so fold both into the key (eBGP only — iBGP never
+        // prepends, so the strip is a no-op and must not split groups).
+        remove_private_as: if peer.is_ebgp() {
+            peer.config.remove_private_as.map(|rpa| RemovePrivateAsKey {
+                all: rpa.all,
+                replace_as: rpa.replace_as,
+                keep_as: peer.remote_as,
+            })
         } else {
             None
         },
@@ -956,6 +990,7 @@ mod tests {
             policy_out_name: None,
             prefix_set_out_name: None,
             as_override_target: None,
+            remove_private_as: None,
             as4_negotiated: true,
             extended_message: true,
             addpath_send: false,
@@ -1004,6 +1039,31 @@ mod tests {
         let mut a = base.clone();
         a.as_override_target = Some(65002);
         assert_ne!(base, a);
+
+        let mut a = base.clone();
+        a.remove_private_as = Some(RemovePrivateAsKey {
+            all: false,
+            replace_as: false,
+            keep_as: 65002,
+        });
+        assert_ne!(base, a);
+
+        // Same on/off state but a different mode or kept AS is still a
+        // distinct group — the egress AS_PATH would differ.
+        let mut b = a.clone();
+        b.remove_private_as = Some(RemovePrivateAsKey {
+            all: true,
+            replace_as: false,
+            keep_as: 65002,
+        });
+        assert_ne!(a, b);
+        let mut c = a.clone();
+        c.remove_private_as = Some(RemovePrivateAsKey {
+            all: false,
+            replace_as: false,
+            keep_as: 65003,
+        });
+        assert_ne!(a, c);
 
         let mut a = base.clone();
         a.as4_negotiated = false;

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -88,6 +88,10 @@ module config {
     prefix zbao;
   }
 
+  import zebra-bgp-remove-private-as {
+    prefix zbrpa;
+  }
+
   import zebra-bgp-timer {
     prefix zbtm;
   }

--- a/zebra-rs/yang/zebra-bgp-remove-private-as.yang
+++ b/zebra-rs/yang/zebra-bgp-remove-private-as.yang
@@ -1,0 +1,128 @@
+module zebra-bgp-remove-private-as {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-remove-private-as";
+  prefix "zbrpa";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "FRR-style per-neighbor `remove-private-as` knob.
+
+     On the egress path toward an eBGP neighbor, BGP normally prepends
+     the local AS to the AS_PATH and advertises every AS already in the
+     path. `remove-private-as` strips the private ASNs (RFC 6996:
+     64512-65535 and 4200000000-4294967294) from that path first, so the
+     receiver never learns the private internal AS structure of the
+     advertising network:
+
+       router bgp {
+         neighbor 192.168.1.3 {
+           remote-as 65001;
+           remove-private-as;                  // bare form
+         }
+         neighbor 192.168.1.4 {
+           remote-as 65002;
+           remove-private-as { all; }          // act on mixed paths too
+         }
+         neighbor 192.168.1.5 {
+           remote-as 65003;
+           remove-private-as { replace-as; }   // rewrite to local AS
+         }
+         neighbor 192.168.1.6 {
+           remote-as 65004;
+           remove-private-as { all; replace-as; }
+         }
+       }
+
+     Two orthogonal modifiers (matching FRR's four CLI forms):
+
+       - `all`: by default the strip runs only when the *entire*
+         AS_PATH is private; with `all` it runs on any path that
+         contains a private AS, keeping the public ASNs.
+
+       - `replace-as`: by default each private AS is removed from the
+         path; with `replace-as` it is rewritten to the local AS
+         instead, preserving the AS_PATH length.
+
+     In every form the neighbor's own AS is preserved in the path, so
+     its RFC 4271 loop check still works. `remove-private-as` only
+     affects eBGP sessions (iBGP never prepends).";
+
+  revision 2026-06-08 {
+    description "Initial revision.";
+    reference "FRR `neighbor X remove-private-AS [all] [replace-AS]`.";
+  }
+
+  grouping bgp-neighbor-remove-private-as-extension {
+    description
+      "FRR-style `remove-private-as` presence container on a BGP
+       neighbor, with optional `all` / `replace-as` modifiers.";
+
+    container remove-private-as {
+      ext:help "Remove private ASNs from the outbound AS_PATH";
+      presence "Enable remove-private-as on the egress path toward this neighbor";
+      description
+        "When present, strip private ASNs from the AS_PATH of outbound
+         eBGP UPDATEs toward this neighbor, before the local-AS prepend.
+         The bare form acts only on an all-private path.";
+
+      leaf all {
+        ext:help "Remove private ASNs even from a mixed public/private AS_PATH";
+        type empty;
+        description
+          "Act on any AS_PATH containing a private AS, not only one
+           that is entirely private.";
+      }
+
+      leaf replace-as {
+        ext:help "Replace each private ASN with the local AS instead of removing it";
+        type empty;
+        description
+          "Rewrite each stripped private AS to the local AS rather than
+           dropping it, keeping the AS_PATH length unchanged.";
+      }
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Attach remove-private-as to BGP neighbors in the candidate-set
+       subtree.";
+    uses bgp-neighbor-remove-private-as-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp neighbor X remove-private-as [...]` is
+       path-valid.";
+    uses bgp-neighbor-remove-private-as-extension;
+  }
+}


### PR DESCRIPTION
## Summary

FRR-style `neighbor X remove-private-AS [all] [replace-AS]`. On the egress path to an **eBGP** neighbor, strip private ASNs (RFC 6996 `64512–65535` and `4200000000–4294967294`) from the AS_PATH before the local-AS prepend, so a downstream peer never learns the advertising network's private internal AS structure. The neighbor's own AS is always kept for RFC 4271 loop prevention.

All four FRR forms map to two orthogonal modifiers:
- **`all`** — act on a mixed public/private path, not only an all-private one.
- **`replace-as`** — rewrite each private AS to the local AS instead of dropping it (keeps AS_PATH length).

eBGP only; applied uniformly across all AFI/SAFIs.

## Implementation

- `crates/bgp-packet/.../aspath.rs` — `is_private_as` + `As4Path::{is_all_private, remove_private_as_mut, replace_private_as_mut}`.
- `route.rs` — applied in the centralized `ebgp_egress_aspath` helper in FRR's order: **remove-private-as → as-override → local-AS prepend**.
- `peer.rs` / `config.rs` — `RemovePrivateAs{all,replace_as}` on `PeerConfig`, three order-independent callbacks.
- `update_group.rs` — folded into `UpdateGroupSig` as `remove_private_as: Option<RemovePrivateAsKey{all,replace_as,keep_as}>`; **`SIGNATURE_VERSION` 2→3**. The strip output depends on the modifiers and the kept AS, so it must shard the group (otherwise the canonical-member transform leaks a wrong AS_PATH across members).
- `show.rs` / `show_update_group.rs` — `show ip bgp neighbors` + `show bgp update-group` rendering.
- YANG: new `zebra-bgp-remove-private-as.yang` (presence container + `all`/`replace-as` empty leaves), imported in `config.yang`.
- Docs: new book page `ch-02-13-bgp-remove-private-as.md` + SUMMARY; `docs/design/bgp-update-groups.md` updated.

## Test plan

- `cargo fmt`, `cargo build` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test -p bgp-packet` — 279 pass (7 new aspath tests: ranges, all-private, strip/replace keeping peer, empty-segment drop, AS_SET reach, egress sequence).
- `cargo test -p zebra-rs` — 928 pass (new: 3 config callback tests, signature-distinctness assertions, `yang_load_tests`).
- New `@bgp_remove_private_as` BDD: z1(AS65001 private)→z2(AS100)→z3(AS200); z3's `as_path` is `100 65001` without the knob and `100` with it; `show ip bgp neighbors` reports the form. (BDD runs in CI.)

Generated with [Claude Code](https://claude.com/claude-code)