### PR TITLE
bdd: add teardown scenario to @bgp_as_override

### DIFF
--- a/bdd/tests/features/bgp_as_override.feature
+++ b/bdd/tests/features/bgp_as_override.feature
@@ -64,3 +64,15 @@ Feature: BGP as-override rewrites the peer AS on egress so a shared-AS neighbor 
     Then BGP session in "z3" to "192.168.1.2" should be "Established"
     And BGP route in "z3" has "10.0.0.1/32"
     And show command "show ip bgp neighbors" in namespace "z2" should contain "AS-Override"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the veth
+  # pair ends it holds, so only the daemons and namespaces need teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

`bgp_as_override.feature` was missing the `Scenario: Teardown topology` that every other BGP feature ends with (`bgp_allowas_in`, `bgp_ttl_security`, …). A run therefore left its z1/z2/z3 daemons and namespaces alive, which blocks the *next* run's `Given a clean test environment` — that step refuses to clobber a live pid file (a safety against concurrent runs of the same feature).

Mirrors `bgp_allowas_in` exactly (identical pure-P2P, 3-namespace topology, no bridge): stop `zebra-rs` in z1/z2/z3, delete the three namespaces, and assert the environment is clean.

## Test plan

- Ran `@bgp_as_override` locally: **4 scenarios (4 passed)**, the new Teardown scenario stops all daemons and deletes all namespaces.
- Verified afterward: **no leftover namespaces, daemons, or pid files** — a subsequent run is no longer blocked.
- Feature-file only; no Rust touched.

Generated with [Claude Code](https://claude.com/claude-code)
