### PR TITLE
bgp: add teardown scenario to @bgp_remove_private_as BDD

### DIFF
--- a/bdd/tests/features/bgp_remove_private_as.feature
+++ b/bdd/tests/features/bgp_remove_private_as.feature
@@ -66,3 +66,15 @@ Feature: BGP remove-private-as strips private ASNs from the egress AS_PATH
     And BGP route in "z3" has "10.0.0.1/32"
     And BGP route in "z3" has "10.0.0.1/32" with "as_path" value "100"
     And show command "show ip bgp neighbors" in namespace "z2" should contain "Private AS removal"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the veth
+  # pair it holds, so only the daemons and namespaces need teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    Then the test environment should be clean


### PR DESCRIPTION
## Summary

The `@bgp_remove_private_as` feature (merged in #1272) created the `z1`/`z2`/`z3` namespaces and daemons but never tore them down, leaking processes and namespaces to the rest of a single BDD run.

This adds a final **`Scenario: Teardown topology`** that:
- stops `zebra-rs` in each namespace,
- deletes all three namespaces (which also destroys the veth pairs — pure-P2P line topology, no bridge),
- asserts `the test environment should be clean`.

It mirrors the established `@bgp_allowas_in` teardown pattern (#1267) exactly; every step reuses an existing step definition.

## Test plan

- Gherkin-only change; all steps are reused verbatim from the passing `@bgp_allowas_in` feature.
- `@bgp_remove_private_as` BDD runs in CI.

Generated with [Claude Code](https://claude.com/claude-code)