### PR TITLE
bgp: add neighbor enforce-first-as (inbound first-AS check)

### DIFF
--- a/bdd/tests/configs/bgp_enforce_first_as/z1.yaml
+++ b/bdd/tests/configs/bgp_enforce_first_as/z1.yaml
@@ -1,0 +1,47 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+# Outbound policy toward z2 that prepends a *foreign* AS (65099) in front
+# of z1's own AS. zebra-rs applies the mandatory eBGP local-AS prepend
+# first (AS_PATH "65001"), then the outbound route-map prepend lands
+# 65099 left-most, so z2 receives AS_PATH "65099 65001". The left-most AS
+# is therefore NOT z1's AS — exactly the condition `enforce-first-as`
+# guards against.
+prefix-set:
+- name: ALL-V4
+  prefixes:
+  - prefix: 0.0.0.0/0
+    le: 32
+policy:
+- name: PREPEND-FOREIGN
+  entry:
+  - number: 10
+    action: permit
+    match:
+      prefix: ALL-V4
+    set:
+      as-path-prepend:
+        asn: 65099
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      policy:
+        out: PREPEND-FOREIGN
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_enforce_first_as/z2-base.yaml
+++ b/bdd/tests/configs/bgp_enforce_first_as/z2-base.yaml
@@ -1,0 +1,20 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001

--- a/bdd/tests/configs/bgp_enforce_first_as/z2-enforce.yaml
+++ b/bdd/tests/configs/bgp_enforce_first_as/z2-enforce.yaml
@@ -1,0 +1,25 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      # Presence container -> bare `set ... enforce-first-as`. After the
+      # session is bounced, z2 re-receives 10.0.0.1/32 with AS_PATH
+      # "65099 65001"; the left-most AS (65099) is not z1's AS (65001), so
+      # the inbound first-AS check drops the update.
+      enforce-first-as:

--- a/bdd/tests/features/bgp_enforce_first_as.feature
+++ b/bdd/tests/features/bgp_enforce_first_as.feature
@@ -1,0 +1,72 @@
+@serial
+@bgp_enforce_first_as
+Feature: BGP enforce-first-as drops inbound updates whose AS_PATH does not start with the peer AS
+  As a network operator
+  I want `neighbor X enforce-first-as`
+  So a peer that forwards routes without prepending its own AS first is not trusted.
+
+  Test Topology (a point-to-point eBGP session):
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐
+   │   z1    │ i1────────────i1 │   z2    │
+   │ AS65001 │                  │ AS65002 │
+   │  .0.1   │                  │  .0.2   │
+   └─────────┘                  └─────────┘
+   originates 10.0.0.1/32
+  ```
+
+  z1 originates 10.0.0.1/32. It also runs an outbound route-map toward z2
+  that prepends a *foreign* AS (65099). zebra-rs applies the mandatory
+  eBGP local-AS prepend first ("65001"), then the route-map prepend lands
+  65099 left-most, so z2 receives AS_PATH "65099 65001". The left-most AS
+  is 65099, not z1's own AS 65001.
+
+  Normally z2 accepts that route (AS 65002 is not in the path, so there is
+  no loop). With `enforce-first-as` on z2's session toward z1, z2 instead
+  requires the left-most AS to be the peer's own AS (65001) and discards
+  the update because it starts with 65099.
+
+  Config files:
+  - z1.yaml:          z1 originates 10.0.0.1/32, prepends foreign AS 65099 on egress
+  - z2-base.yaml:     z2 without enforce-first-as (accepts the route)
+  - z2-enforce.yaml:  z2 with `enforce-first-as` toward 192.168.0.1
+
+  Scenario: Setup the topology and establish the session
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2-base.yaml" to namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+
+  Scenario: Without enforce-first-as z2 accepts the foreign-first-AS route
+    Given the test topology exists
+    # z2 receives 10.0.0.1/32 with AS_PATH "65099 65001". The left-most AS
+    # is 65099 (not z1's 65001), but the strict check is off, so z2 keeps it.
+    Then BGP route in "z2" has "10.0.0.1/32"
+
+  Scenario: With enforce-first-as z2 drops the route
+    Given the test topology exists
+    When I apply config "z2-enforce.yaml" to namespace "z2"
+    # Bounce the session so z2 re-receives 10.0.0.1/32 and re-runs the
+    # inbound first-AS check, which now drops it (first AS 65099 != 65001).
+    And I run "clear bgp ipv4 neighbor 192.168.0.1" in namespace "z2"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.0.1" should be "Established"
+    And BGP route in "z2" does not have "10.0.0.1/32"
+    And show command "show ip bgp neighbors" in namespace "z2" should contain "Enforce-first-AS"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the veth
+  # pair ends it holds, so only the daemons and namespaces need teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -20,6 +20,7 @@
   - [AS Override](ch-02-12-bgp-as-override.md)
   - [allowas-in (Inbound AS_PATH Loop Relaxation)](ch-02-13-bgp-allowas-in.md)
   - [Remove Private AS](ch-02-14-bgp-remove-private-as.md)
+  - [Enforce First AS](ch-02-15-bgp-enforce-first-as.md)
   - [Timer Configuration](ch-02-03-bgp-timers.md)
   - [L3VPN and Per-VRF Labels](ch-02-04-bgp-l3vpn.md)
   - [L3VPN over an SRv6 Underlay](ch-02-05-bgp-l3vpn-srv6.md)

--- a/book/src/ch-02-15-bgp-enforce-first-as.md
+++ b/book/src/ch-02-15-bgp-enforce-first-as.md
@@ -1,0 +1,139 @@
+# BGP Enforce First AS
+
+A well-behaved eBGP speaker **prepends its own AS** to the AS_PATH of
+every UPDATE it sends. The left-most (first) AS a receiver sees is
+therefore always the directly-connected peer's AS — that is the basic
+accounting that makes the path-vector loop check work.
+
+`neighbor X enforce-first-as` makes that guarantee **mandatory** on the
+receiving side. An inbound UPDATE from this eBGP neighbor is discarded
+unless its AS_PATH begins with an `AS_SEQUENCE` whose left-most AS is the
+neighbor's own AS. It defends against a misconfigured or malicious peer
+that forwards routes **without** prepending its AS, which would otherwise
+let it inject paths that bypass the normal hop-by-hop accounting (and, for
+example, pretend a route is one AS hop shorter than it really is).
+
+## What the check does
+
+For each route received from a neighbor that has `enforce-first-as`
+enabled, zebra-rs inspects the AS_PATH:
+
+- The first segment must be an `AS_SEQUENCE` (not an `AS_SET` and not a
+  confederation segment), **and**
+- its left-most AS must equal the neighbor's configured `remote-as`.
+
+If either condition fails — including an **empty or absent** AS_PATH — the
+update is dropped (treated as a withdraw). A route whose path starts with
+some other AS, or with a `{…}` AS_SET, never enters the Adj-RIB-In.
+
+The check applies to **eBGP sessions only**. iBGP never prepends the local
+AS, so an iBGP UPDATE legitimately starts with whatever AS originated or
+last-prepended the route; the knob is a no-op on iBGP peers and is
+ignored.
+
+## The problem it catches
+
+```
+ ┌─────────┐                    ┌─────────┐
+ │   z1    │ ──── eBGP ──────── │   z2    │
+ │ AS65001 │                    │ AS65002 │
+ └─────────┘                    └─────────┘
+ originates 10.0.0.1/32
+```
+
+Suppose `z1` advertises `10.0.0.1/32` to `z2` but the AS_PATH that arrives
+is `65099 65001` — the left-most AS is `65099`, not `z1`'s own `65001`
+(perhaps `z1` is a transparent box that prepended a foreign AS, or simply
+failed to prepend its own). Without `enforce-first-as`, `z2` accepts the
+path at face value. The route looks like it traverses AS 65099 first, even
+though `z2`'s actual neighbor is AS 65001.
+
+With `enforce-first-as` on `z2`'s session toward `z1`, `z2` requires the
+left-most AS to be `65001` and discards the update, because it starts with
+`65099`.
+
+## Configuration
+
+`enforce-first-as` is a per-neighbor flag. Configure it on the receiving
+end, on the session toward the peer whose first AS you want to police:
+
+```yaml
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enforce-first-as: null
+```
+
+`enforce-first-as: null` is the YAML spelling of a presence container —
+the key is present with no value, which the loader turns into
+`set router bgp neighbor 192.168.0.1 enforce-first-as`. The FRR / IOS-style
+CLI form is the same path:
+
+```
+set router bgp neighbor 192.168.0.1 enforce-first-as
+```
+
+Enabling `enforce-first-as` on an already-established session does not by
+itself re-screen routes already in the neighbor's Adj-RIB-In. Bounce the
+session so the routes are re-received and re-checked under the new policy:
+
+```
+clear bgp ipv4 neighbor 192.168.0.1
+```
+
+## Verification
+
+`show ip bgp neighbor <addr>` reports whether the knob is active:
+
+```
+  Enforce-first-AS enabled (drop inbound updates not starting with peer AS)
+```
+
+After enabling it (and bouncing the session), a route that fails the
+check simply will not appear in the table:
+
+```
+show ip bgp 10.0.0.1/32
+```
+
+## Relationship to allowas-in and as-override
+
+All three are AS_PATH knobs, but they police different things:
+
+- [`allowas-in`](ch-02-13-bgp-allowas-in.md) relaxes the inbound check for
+  the **local** AS appearing *anywhere* in the path (loop relaxation).
+- [`as-override`](ch-02-12-bgp-as-override.md) rewrites the **neighbor's**
+  AS on the *outbound* path.
+- `enforce-first-as` tightens the inbound check on the **left-most** AS:
+  it must be the neighbor's own AS.
+
+They are independent and may be combined.
+
+## Troubleshooting
+
+If routes from a peer disappear unexpectedly after enabling
+`enforce-first-as`, the peer is sending a path that does not start with its
+own AS. The most important case to recognise is a **transparent route
+server** (RFC 7947): a route server deliberately does **not** prepend its
+own AS, so every UPDATE it sends starts with a *client's* AS. Enabling
+`enforce-first-as` on a session toward a route server will drop **all** of
+its routes — do not enable it there.
+
+Other things to check:
+
+- the session is **eBGP** (`enforce-first-as` is ignored on iBGP);
+- the left-most AS really is the neighbor's **remote-as** — a leading
+  `AS_SET` (`{…}`) or confederation segment also fails the check, even if
+  it contains the right AS;
+- the session was **bounced** (`clear bgp ipv4 neighbor <addr>`) after the
+  configuration change, so the routes were re-screened under the new
+  policy.

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -606,6 +606,18 @@ fn config_remove_private_as_replace_as(bgp: &mut Bgp, mut args: Args, op: Config
     Some(())
 }
 
+/// `set router bgp neighbor X enforce-first-as` — the presence container
+/// (zebra-bgp-enforce-first-as.yang). Enables the inbound first-AS check
+/// for this neighbor (drop an eBGP UPDATE whose AS_PATH does not begin
+/// with the neighbor's own AS); `delete` disables it. The flag is a no-op
+/// for iBGP peers, which never prepend.
+fn config_enforce_first_as(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let peer = bgp.peers.get_mut(&addr)?;
+    peer.config.enforce_first_as = op.is_set();
+    Some(())
+}
+
 /// `set router bgp neighbor X bfd enable true|false` — flips the
 /// Reconcile this neighbor's live BFD subscription with its current
 /// `peer.config.bfd` state. Idempotent and order-independent: every
@@ -2341,6 +2353,12 @@ impl Bgp {
             "/remove-private-as/replace-as",
             config_remove_private_as_replace_as,
         );
+
+        // Per-neighbor enforce-first-as (zebra-bgp-enforce-first-as.yang).
+        // The presence container drops an inbound eBGP UPDATE unless the
+        // left-most AS_PATH segment begins with the neighbor's own AS
+        // (eBGP only).
+        self.callback_peer("/enforce-first-as", config_enforce_first_as);
     }
 }
 
@@ -2905,6 +2923,35 @@ mod bfd_wiring_tests {
         // Drop the whole container.
         config_remove_private_as(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Delete).unwrap();
         assert_eq!(peer_remove_private_as(&bgp, "10.0.0.2"), None);
+    }
+
+    fn peer_enforce_first_as(bgp: &Bgp, addr: &str) -> bool {
+        bgp.peers
+            .get(&addr.parse().unwrap())
+            .unwrap()
+            .config
+            .enforce_first_as
+    }
+
+    /// `enforce-first-as` defaults off and the presence container turns
+    /// it on.
+    #[tokio::test]
+    async fn enforce_first_as_set_enables() {
+        let (mut bgp, _rx) = fresh_bgp_with_bfd();
+        config_peer(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        assert!(!peer_enforce_first_as(&bgp, "10.0.0.2"));
+        config_enforce_first_as(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        assert!(peer_enforce_first_as(&bgp, "10.0.0.2"));
+    }
+
+    /// Deleting the presence container turns `enforce-first-as` back off.
+    #[tokio::test]
+    async fn enforce_first_as_delete_disables() {
+        let (mut bgp, _rx) = fresh_bgp_with_bfd();
+        config_peer(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        config_enforce_first_as(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        config_enforce_first_as(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Delete).unwrap();
+        assert!(!peer_enforce_first_as(&bgp, "10.0.0.2"));
     }
 }
 

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -370,6 +370,13 @@ pub struct PeerConfig {
     /// `replace_as`, rewrites) private ASNs from every outbound eBGP
     /// UPDATE before the local-AS prepend. Ignored for iBGP peers.
     pub remove_private_as: Option<RemovePrivateAs>,
+    /// Per-neighbor `enforce-first-as` (zebra-bgp-enforce-first-as.yang).
+    /// When `true`, an inbound UPDATE from this eBGP neighbor is dropped
+    /// unless the left-most AS_PATH segment is an AS_SEQUENCE beginning
+    /// with the neighbor's own AS (its `remote_as`). Guards against a peer
+    /// that forwards routes without prepending its AS. Ignored for iBGP
+    /// peers (which never prepend). Default `false`.
+    pub enforce_first_as: bool,
 }
 
 impl Default for PeerConfig {
@@ -393,6 +400,7 @@ impl Default for PeerConfig {
             allowas_in: None,
             as_override: false,
             remove_private_as: None,
+            enforce_first_as: false,
         }
     }
 }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -80,6 +80,35 @@ fn local_as_only_at_origin(aspath: &As4Path, local_as: u32) -> bool {
     !flat[..flat.len() - trailing].contains(&local_as)
 }
 
+/// FRR-style `enforce-first-as` (zebra-bgp-enforce-first-as.yang) inbound
+/// check. Returns `true` when the UPDATE must be dropped because the
+/// neighbor is eBGP, has `enforce-first-as` enabled, and the left-most
+/// AS_PATH segment is not an `AS_SEQUENCE` whose first ASN is the
+/// neighbor's own AS (`peer.remote_as`).
+///
+/// Always `false` for iBGP peers and when the knob is off — iBGP never
+/// prepends, so it has no first-AS guarantee to enforce.
+fn aspath_enforce_first_as_violation(peer: &Peer, aspath: Option<&As4Path>) -> bool {
+    if !peer.config.enforce_first_as || !peer.is_ebgp() {
+        return false;
+    }
+    aspath_first_as_mismatch(aspath, peer.remote_as)
+}
+
+/// True when `aspath`'s left-most segment is not an `AS_SEQUENCE` whose
+/// first ASN is `expected_as`. The pure core of
+/// [`aspath_enforce_first_as_violation`], mirroring FRR's
+/// `aspath_firstas_check`: an absent/empty AS_PATH, a leading `AS_SET`
+/// (or confederation segment), or a leading `AS_SEQUENCE` whose first ASN
+/// is not `expected_as` all count as a mismatch. Unit-tested directly,
+/// independent of `Peer` construction.
+fn aspath_first_as_mismatch(aspath: Option<&As4Path>, expected_as: u32) -> bool {
+    match aspath.and_then(|path| path.segs.front()) {
+        Some(seg) => seg.typ != AS_SEQ || seg.asn.first() != Some(&expected_as),
+        None => true,
+    }
+}
+
 /// Apply the egress AS_PATH transformation for an eBGP announcement to
 /// `peer`. Three stages run in FRR's order, all *before* the local-AS
 /// prepend (iBGP peers and routes without an AS_PATH are left
@@ -1932,6 +1961,16 @@ pub fn route_ipv4_update(
             return;
         }
 
+        // FRR enforce-first-as: drop an inbound eBGP UPDATE whose AS_PATH
+        // does not begin with this neighbor's own AS (eBGP only).
+        if aspath_enforce_first_as_violation(peer, attr.aspath.as_ref()) {
+            eprintln!(
+                "Dropping update for {} from peer {} - enforce-first-as: AS_PATH does not start with {}",
+                nlri.prefix, peer.address, peer.remote_as
+            );
+            return;
+        }
+
         // RFC 4456: Drop update if ORIGINATOR_ID matches local router ID. This
         // prevents routing loops in route reflection scenarios. This happens before
         // the route store in AdjRibIn.
@@ -3170,6 +3209,11 @@ pub fn route_ipv6_update(
         {
             return;
         }
+        // FRR enforce-first-as: drop an inbound eBGP UPDATE whose AS_PATH
+        // does not begin with this neighbor's own AS (eBGP only).
+        if aspath_enforce_first_as_violation(peer, attr.aspath.as_ref()) {
+            return;
+        }
         if let Some(ref originator_id) = attr.originator_id
             && originator_id.id == *bgp.router_id
         {
@@ -3408,6 +3452,11 @@ pub fn route_labelv4_update(
         {
             return;
         }
+        // FRR enforce-first-as: drop an inbound eBGP UPDATE whose AS_PATH
+        // does not begin with this neighbor's own AS (eBGP only).
+        if aspath_enforce_first_as_violation(peer, attr.aspath.as_ref()) {
+            return;
+        }
         if let Some(ref originator_id) = attr.originator_id
             && originator_id.id == *bgp.router_id
         {
@@ -3500,6 +3549,11 @@ pub fn route_labelv6_update(
         if let Some(ref aspath) = attr.aspath
             && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
         {
+            return;
+        }
+        // FRR enforce-first-as: drop an inbound eBGP UPDATE whose AS_PATH
+        // does not begin with this neighbor's own AS (eBGP only).
+        if aspath_enforce_first_as_violation(peer, attr.aspath.as_ref()) {
             return;
         }
         if let Some(ref originator_id) = attr.originator_id
@@ -4008,6 +4062,11 @@ pub fn route_evpn_update(
         {
             return;
         }
+        // FRR enforce-first-as: drop an inbound eBGP UPDATE whose AS_PATH
+        // does not begin with this neighbor's own AS (eBGP only).
+        if aspath_enforce_first_as_violation(peer, attr.aspath.as_ref()) {
+            return;
+        }
         if let Some(ref originator_id) = attr.originator_id
             && originator_id.id == *bgp.router_id
         {
@@ -4149,6 +4208,11 @@ pub fn route_flowspec_update(
         {
             return;
         }
+        // FRR enforce-first-as: drop an inbound eBGP UPDATE whose AS_PATH
+        // does not begin with this neighbor's own AS (eBGP only).
+        if aspath_enforce_first_as_violation(peer, attr.aspath.as_ref()) {
+            return;
+        }
         if let Some(ref originator_id) = attr.originator_id
             && originator_id.id == *bgp.router_id
         {
@@ -4250,6 +4314,11 @@ pub fn route_srpolicy_update(
         if let Some(ref aspath) = attr.aspath
             && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
         {
+            return;
+        }
+        // FRR enforce-first-as: drop an inbound eBGP UPDATE whose AS_PATH
+        // does not begin with this neighbor's own AS (eBGP only).
+        if aspath_enforce_first_as_violation(peer, attr.aspath.as_ref()) {
             return;
         }
         if let Some(ref originator_id) = attr.originator_id
@@ -4439,6 +4508,11 @@ pub fn route_bgpls_update(
         if let Some(ref aspath) = attr.aspath
             && aspath_local_as_loop(aspath, peer.local_as, peer.config.allowas_in)
         {
+            return;
+        }
+        // FRR enforce-first-as: drop an inbound eBGP UPDATE whose AS_PATH
+        // does not begin with this neighbor's own AS (eBGP only).
+        if aspath_enforce_first_as_violation(peer, attr.aspath.as_ref()) {
             return;
         }
         if let Some(ref originator_id) = attr.originator_id
@@ -10248,5 +10322,60 @@ mod allowas_in_tests {
         assert!(loops("65001 65002 65001", Some(AllowAsIn::Origin)));
         // No local AS at all ⇒ no loop.
         assert!(!loops("65002 65003", Some(AllowAsIn::Origin)));
+    }
+}
+
+#[cfg(test)]
+mod enforce_first_as_tests {
+    use std::str::FromStr;
+
+    use bgp_packet::As4Path;
+
+    use super::aspath_first_as_mismatch;
+
+    // The directly-connected eBGP peer's AS that must be left-most.
+    const PEER_AS: u32 = 65001;
+
+    fn mismatch(path: &str) -> bool {
+        let aspath = As4Path::from_str(path).unwrap();
+        aspath_first_as_mismatch(Some(&aspath), PEER_AS)
+    }
+
+    #[test]
+    fn first_as_matches_peer_as() {
+        // Left-most AS is the peer's AS ⇒ no violation.
+        assert!(!mismatch("65001"));
+        assert!(!mismatch("65001 65002 65003"));
+        // The peer prepended its own AS several times ⇒ still left-most.
+        assert!(!mismatch("65001 65001 65002"));
+    }
+
+    #[test]
+    fn first_as_differs_from_peer_as() {
+        // A foreign left-most AS ⇒ violation (the peer did not prepend
+        // its own AS first).
+        assert!(mismatch("65099 65001"));
+        assert!(mismatch("65002 65001"));
+        // The peer's AS is present but not left-most ⇒ still a violation.
+        assert!(mismatch("65003 65001 65002"));
+    }
+
+    #[test]
+    fn leading_non_sequence_segment_violates() {
+        // A leading AS_SET (`{}`) is not an AS_SEQUENCE ⇒ violation even
+        // though the set contains the peer's AS (mirrors FRR's
+        // `aspath_firstas_check`, which requires AS_SEQUENCE).
+        assert!(mismatch("{65001} 65002"));
+        // A leading confederation sequence (`[]`) likewise violates.
+        assert!(mismatch("[65001] 65002"));
+    }
+
+    #[test]
+    fn absent_or_empty_aspath_violates() {
+        // No AS_PATH at all ⇒ violation (an eBGP update must carry one).
+        assert!(aspath_first_as_mismatch(None, PEER_AS));
+        // A path whose left-most segment carries no AS ⇒ violation.
+        let empty_seq = As4Path::from(vec![]);
+        assert!(aspath_first_as_mismatch(Some(&empty_seq), PEER_AS));
     }
 }

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1397,6 +1397,11 @@ struct Neighbor<'a> {
     /// `replace_as`, rewrites) private ASNs on outbound eBGP UPDATEs.
     #[serde(skip_serializing_if = "Option::is_none")]
     remove_private_as: Option<RemovePrivateAs>,
+    /// FRR-style `neighbor X enforce-first-as` flag
+    /// (zebra-bgp-enforce-first-as.yang). When true, an inbound eBGP
+    /// UPDATE is dropped unless its AS_PATH begins with this neighbor's
+    /// own AS.
+    enforce_first_as: bool,
     /// GTSM / `ttl-security` (RFC 5082): the session only accepts a
     /// directly-connected peer (received TTL 255). Mirrors
     /// `peer.config.transport.ttl_security`.
@@ -1547,6 +1552,7 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         allowas_in: peer.config.allowas_in,
         as_override: peer.config.as_override,
         remove_private_as: peer.config.remove_private_as,
+        enforce_first_as: peer.config.enforce_first_as,
         ttl_security: peer.config.transport.ttl_security,
         ebgp_multihop: peer.config.transport.ebgp_multihop,
         neighbor_group: peer.config.neighbor_group.clone(),
@@ -1658,6 +1664,13 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
             form.push_str(" replace-AS");
         }
         writeln!(out, "  Private AS removal: {form} (outbound)")?;
+    }
+
+    if neighbor.enforce_first_as {
+        writeln!(
+            out,
+            "  Enforce-first-AS enabled (drop inbound updates not starting with peer AS)"
+        )?;
     }
 
     if neighbor.ttl_security {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -92,6 +92,10 @@ module config {
     prefix zbrpa;
   }
 
+  import zebra-bgp-enforce-first-as {
+    prefix zbef;
+  }
+
   import zebra-bgp-timer {
     prefix zbtm;
   }

--- a/zebra-rs/yang/zebra-bgp-enforce-first-as.yang
+++ b/zebra-rs/yang/zebra-bgp-enforce-first-as.yang
@@ -1,0 +1,96 @@
+module zebra-bgp-enforce-first-as {
+  yang-version "1";
+
+  namespace "urn:ietf:params:xml:ns:yang:zebra-bgp-enforce-first-as";
+  prefix "zbef";
+
+  import ietf-bgp {
+    prefix bgp;
+  }
+
+  import config {
+    prefix config;
+  }
+
+  import configure {
+    prefix configure;
+  }
+
+  import extension {
+    prefix ext;
+  }
+
+  organization
+    "zebra-rs";
+
+  contact
+    "https://github.com/zebra-rs";
+
+  description
+    "FRR-style per-neighbor `enforce-first-as` knob.
+
+     A well-behaved eBGP speaker prepends its own AS to the AS_PATH of
+     every UPDATE it sends, so the left-most AS a receiver sees is always
+     the directly-connected peer's AS. `enforce-first-as` makes that
+     guarantee mandatory: an inbound UPDATE from this eBGP neighbor is
+     discarded unless the first AS_PATH segment is an AS_SEQUENCE whose
+     left-most AS is the neighbor's own AS.
+
+       router bgp {
+         neighbor 10.0.0.5 {
+           remote-as 65501;
+           enforce-first-as;        // drop updates not starting with 65501
+         }
+       }
+
+     This guards against a misconfigured or malicious peer that forwards
+     routes without prepending its AS (the AS_PATH then starts with some
+     other AS), which would otherwise let it inject routes that bypass the
+     normal path-vector accounting. The check applies to eBGP sessions
+     only — iBGP never prepends, so the knob is a no-op there and is
+     ignored.
+
+     Do NOT enable `enforce-first-as` on a session toward a transparent
+     route server (RFC 7947): a route server deliberately does not prepend
+     its own AS, so every UPDATE would fail the check and be dropped.";
+
+  revision 2026-06-08 {
+    description "Initial revision.";
+    reference "FRR `neighbor X enforce-first-as`.";
+  }
+
+  grouping bgp-neighbor-enforce-first-as-extension {
+    description
+      "FRR-style `enforce-first-as` presence container on a BGP
+       neighbor.";
+
+    container enforce-first-as {
+      ext:help "Discard updates whose AS_PATH does not start with this neighbor's AS";
+      presence "Enable the first-AS check on inbound updates from this neighbor";
+      description
+        "When present, drop an inbound eBGP UPDATE from this neighbor
+         unless the left-most AS_PATH segment is an AS_SEQUENCE that
+         begins with the neighbor's own AS. No-op for iBGP peers.";
+    }
+  }
+
+  /* =========================================================
+   * Augments into the zebra-rs configure tree
+   * ========================================================= */
+
+  augment "/configure:set/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Attach enforce-first-as to BGP neighbors in the candidate-set
+       subtree.";
+    uses bgp-neighbor-enforce-first-as-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/bgp:bgp/bgp:neighbor" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp neighbor X enforce-first-as` is path-valid.";
+    uses bgp-neighbor-enforce-first-as-extension;
+  }
+}


### PR DESCRIPTION
## Summary

FRR-style `neighbor X enforce-first-as`: discard an inbound **eBGP** UPDATE unless its AS_PATH's left-most segment is an `AS_SEQUENCE` whose first ASN is the neighbor's own AS (its `remote-as`). This guards against a peer that forwards routes without prepending its AS (e.g. a transparent box), which would otherwise bypass the normal path-vector accounting. eBGP-only — a no-op on iBGP, which never prepends.

Empty/absent AS_PATH, a leading `AS_SET`, or a confederation segment all fail the check, matching FRR's `aspath_firstas_check` (`bgp_attr.c` / `bgp_aspath.c`).

## Changes

- **YANG** — new `zebra-bgp-enforce-first-as.yang`, a `presence` container augmenting the set + delete neighbor subtrees, imported from `config.yang`. Mirrors the `as-override` presence-container model; no libyang change.
- **Model** — `PeerConfig.enforce_first_as: bool` (default false); `config.rs` `/enforce-first-as` callback.
- **Runtime** — `aspath_enforce_first_as_violation()` (with a pure, unit-testable core `aspath_first_as_mismatch()`) called at the **8 inbound AS_PATH-check sites** next to `aspath_local_as_loop` (v4/v6 unicast, labeled-unicast v4/v6, EVPN, flow-spec, SR-policy, BGP-LS).
- **show** — `show ip bgp neighbors` renders `Enforce-first-AS enabled (...)`.
- **book** — new `ch-02-14-bgp-enforce-first-as.md` + SUMMARY entry.

## Test plan

- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- Unit tests: 6 new (route.rs first-AS math + config.rs set/delete callbacks); full `bgp::` suite (295) green; `configure_mode_loads` confirms the new YANG loads.
- **BDD** `@bgp_enforce_first_as` (2-node eBGP, z1 prepends foreign AS 65099 on egress so z2 receives `65099 65001`): default-accept vs enforce-first-as-drop + show output, with an explicit teardown scenario. Ran `make install` then the feature locally — **4 scenarios pass, no leaked namespaces/processes/veths**.

Generated with [Claude Code](https://claude.com/claude-code)
