### PR TITLE
bgp: fix remove-private-as YANG collision with the IETF model

### DIFF
--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1274,4 +1274,44 @@ mod yang_load_tests {
     fn exec_mode_loads() {
         load_mode("exec");
     }
+
+    /// Regression guard for `remove-private-as`. The IETF model
+    /// (`ietf-bgp`) shipped a `remove-private-as` identityref leaf on the
+    /// neighbor whose IANA base this libyang can't resolve to a value
+    /// set, and over which a same-named augment is forbidden (RFC 7950
+    /// §7.17). zebra-rs removes that leaf from its vendored copy and owns
+    /// the name with an FRR-style presence container (all four forms:
+    /// bare, `all`, `replace-as`, `all replace-as`). This checks the
+    /// source schema directly so a regression — the IETF leaf creeping
+    /// back, a broken augment — is caught in the unit suite, not only in
+    /// the BDD.
+    #[test]
+    fn bgp_neighbor_remove_private_as_paths_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .unwrap_or_else(|e| panic!("configure failed to load: {e:#}"));
+        yang.identity_resolve();
+        let module = yang.find_module("configure").unwrap();
+        let entry = to_entry(&yang, module);
+
+        // The bare presence container and both modifier leaves must each
+        // be a valid settable path on the neighbor.
+        for cmd in [
+            "set router bgp neighbor 192.168.1.3 remove-private-as",
+            "set router bgp neighbor 192.168.1.3 remove-private-as all",
+            "set router bgp neighbor 192.168.1.3 remove-private-as replace-as",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+    }
 }

--- a/zebra-rs/yang/ietf-bgp-common@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-common@2023-07-05.yang
@@ -264,12 +264,16 @@ submodule ietf-bgp-common {
          this differs from the global BGP router autonomous system
          number.";
     }
-    leaf remove-private-as {
-      type bt:remove-private-as-option;
-      description
-        "When this leaf is specified, remove private AS numbers from
-         updates sent to peers.";
-    }
+    // remove-private-as: removed from the vendored IETF model so
+    // zebra-rs can own the name as an FRR-style presence container
+    // (zebra-bgp-remove-private-as.yang). The IANA identityref typedef
+    // (bt:remove-private-as-option) uses an unprefixed `base`, which this
+    // libyang build cannot resolve to its value set, and an augment can't
+    // add a same-named node over this leaf (RFC 7950 §7.17). zebra-rs does
+    // not implement the IANA identityref form. See the zebra module.
+    //  leaf remove-private-as {
+    //    type bt:remove-private-as-option;
+    //  }
     container route-flap-damping {
       if-feature "bt:damping";
       leaf enable {

--- a/zebra-rs/yang/zebra-bgp-remove-private-as.yang
+++ b/zebra-rs/yang/zebra-bgp-remove-private-as.yang
@@ -67,7 +67,15 @@ module zebra-bgp-remove-private-as {
 
      In every form the neighbor's own AS is preserved in the path, so
      its RFC 4271 loop check still works. `remove-private-as` only
-     affects eBGP sessions (iBGP never prepends).";
+     affects eBGP sessions (iBGP never prepends).
+
+     NOTE: the IETF model (ietf-bgp) ships a `remove-private-as`
+     identityref leaf on the neighbor. zebra-rs removes that leaf from
+     its vendored copy (it carries the IANA `all`-only options via an
+     unprefixed identityref base this libyang can't resolve, and a
+     same-named augment is forbidden by RFC 7950 §7.17) and owns the
+     name with this presence container instead, which expresses all four
+     FRR forms including the bare one.";
 
   revision 2026-06-08 {
     description "Initial revision.";


### PR DESCRIPTION
## Summary

The `remove-private-as` feature merged in #1272 **never took effect** — its `@bgp_remove_private_as` BDD fails because `set router bgp neighbor X remove-private-as` is rejected at parse time.

**Root cause.** `config.yang` pulls the IETF BGP model in via `uses "ietf-bgp:bgp"`, which already defines `remove-private-as` as an identityref **leaf** on every neighbor. RFC 7950 §7.17 forbids an augment from adding a same-named node, so libyang dropped this feature's presence container and kept the standard leaf — leaving `remove-private-as` un-settable.

**Why not implement the standard leaf instead.** This libyang build can't: the IANA `remove-private-as-option` typedef uses an *unprefixed* identityref `base`, which `type_resolve` can't resolve to a value set, so even the standard `private-as-remove-all` value fails to parse (`Nomatch`). The `deviate` body is also clipped by the grammar, so the leaf can't be removed by deviation.

**Fix.** Remove the unused, never-implemented `remove-private-as` leaf from the vendored `ietf-bgp-common@2023-07-05.yang` (commented, with rationale), so the FRR-style presence container (`zebra-bgp-remove-private-as.yang`) owns the name and expresses all four forms — bare, `all`, `replace-as`, `all replace-as`. The feature's Rust (egress transform, config callbacks, update-group signature, show) was already correct; only the schema collision blocked it.

## Changes
- `ietf-bgp-common@2023-07-05.yang` — remove the conflicting leaf (the actual fix).
- `zebra-bgp-remove-private-as.yang` — doc note explaining the collision (container structure unchanged).
- `config/manager.rs` — parse regression test asserting `remove-private-as`, `… all`, `… replace-as` are settable paths (guards against the IETF leaf returning).

## Note
This edits a dated IETF standards snapshot — the only available mechanism, since this libyang can't `deviate` the leaf away and there's no refine-to-delete. It's commented and reversible.

## Test plan
- New parse regression test: bare / `all` / `replace-as` all parse `Success`.
- `cargo fmt`; `cargo clippy --workspace --all-targets -- -D warnings` (clean).
- `cargo test -p bgp-packet` (279) + `cargo test -p zebra-rs` (929) green.
- `@bgp_remove_private_as` BDD runs in CI (now parseable end-to-end).

Generated with [Claude Code](https://claude.com/claude-code)