### PR TITLE
bgp: add neighbor tcp-mss (TCP_MAXSEG clamp)

### DIFF
--- a/bdd/tests/configs/bgp_tcp_mss/z1-1.yaml
+++ b/bdd/tests/configs/bgp_tcp_mss/z1-1.yaml
@@ -1,0 +1,13 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      tcp-mss: 500

--- a/bdd/tests/configs/bgp_tcp_mss/z2-1.yaml
+++ b/bdd/tests/configs/bgp_tcp_mss/z2-1.yaml
@@ -1,0 +1,13 @@
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      tcp-mss: 500

--- a/bdd/tests/features/bgp_tcp_mss.feature
+++ b/bdd/tests/features/bgp_tcp_mss.feature
@@ -1,0 +1,64 @@
+@serial
+@bgp_tcp_mss
+Feature: BGP TCP MSS (neighbor tcp-mss)
+  As a network operator
+  I want to cap the TCP Maximum Segment Size of a BGP session so the
+  daemon stays under a path MTU smaller than the interface MTU (a tunnel,
+  an MPLS core, a link that cannot carry full-size frames) instead of
+  stalling on a black-holed large UPDATE.
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+  ```
+
+  Config files:
+  - z1-1.yaml: AS 65001, neighbor 192.168.0.2 with `tcp-mss 500`.
+  - z2-1.yaml: AS 65002, neighbor 192.168.0.1 with `tcp-mss 500`.
+
+  `tcp-mss` is applied before the TCP handshake on both the active connect
+  socket and the listening socket, so the kernel negotiates the reduced
+  MSS. `getsockopt(TCP_MAXSEG)` reads back the negotiated value (the
+  "synced" MSS) a little below the configured one — the kernel subtracts
+  the 12-byte TCP timestamp option, so a configured 500 syncs to 488.
+  Both ends must advertise the clamp for both to read it back, which is
+  why both neighbors set `tcp-mss 500`.
+
+  Scenario: Session establishes and reports configured and synced tcp-mss
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-1.yaml" to namespace "z1"
+    And I apply config "z2-1.yaml" to namespace "z2"
+    And I wait 10 seconds for BGP to operate
+    # The clamp does not break the session: MSS 500 is well above the
+    # kernel minimum, so the eBGP session comes up normally.
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    # show bgp neighbor reports both the configured tcp-mss and the MSS
+    # the kernel actually negotiated on the live socket.
+    And show command "show ip bgp neighbors 192.168.0.2" in namespace "z1" should contain "Configured tcp-mss is 500"
+    And show command "show ip bgp neighbors 192.168.0.2" in namespace "z1" should contain "synced tcp-mss is 488"
+    And show command "show ip bgp neighbors 192.168.0.1" in namespace "z2" should contain "Configured tcp-mss is 500"
+    And show command "show ip bgp neighbors 192.168.0.1" in namespace "z2" should contain "synced tcp-mss is 488"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -17,6 +17,7 @@
   - [Dynamic Neighbors](ch-02-01-dynamic-neighbors.md)
   - [Session Authentication (TCP MD5 / TCP-AO)](ch-02-02-tcp-authentication.md)
   - [TTL: eBGP Multihop & Security (GTSM)](ch-02-11-bgp-ttl-security.md)
+  - [TCP MSS](ch-02-14-bgp-tcp-mss.md)
   - [AS Override](ch-02-12-bgp-as-override.md)
   - [allowas-in (Inbound AS_PATH Loop Relaxation)](ch-02-13-bgp-allowas-in.md)
   - [Timer Configuration](ch-02-03-bgp-timers.md)

--- a/book/src/ch-02-14-bgp-tcp-mss.md
+++ b/book/src/ch-02-14-bgp-tcp-mss.md
@@ -1,0 +1,114 @@
+# BGP TCP MSS (`tcp-mss`)
+
+BGP rides on TCP, and every TCP connection negotiates a **Maximum
+Segment Size** (MSS) — the largest payload a single segment may carry.
+By default the kernel derives it from the outgoing interface MTU (1460
+bytes on a 1500-byte Ethernet link). When the real path MTU is smaller
+than the interface MTU — a tunnel, an MPLS core, a link that cannot
+carry full-size frames — a full-size BGP segment can be black-holed, and
+the session stalls on a large UPDATE that never gets through. The
+per-neighbor `tcp-mss` knob caps the MSS so BGP segments stay within the
+path.
+
+## Configuration
+
+`tcp-mss` is a per-neighbor value in the range 1–65535 (bytes):
+
+```yaml
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      remote-as: 65002
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      tcp-mss: 500
+```
+
+The FRR / IOS-style CLI form is the same path:
+
+```
+set router bgp neighbor 192.168.0.2 tcp-mss 500
+```
+
+## How it is applied
+
+TCP negotiates the MSS once, in the SYN / SYN-ACK exchange of the
+three-way handshake. After that the kernel caches the result
+(`tp->mss_cache`) and a later change has no effect on the live
+connection. So the clamp must be installed on the socket **before** the
+handshake. zebra-rs does this in two places:
+
+- **Active side** — the value is set on the connect socket before
+  `connect(2)`, so the SYN we send advertises the reduced MSS.
+- **Passive side** — the value is set on the **listening** socket, so a
+  passively-accepted connection inherits the clamp on its SYN-ACK.
+
+A listening socket carries a single `TCP_MAXSEG` for every peer, so when
+more than one neighbor configures `tcp-mss` the daemon installs the
+**minimum** value across the configured peers of that address family on
+the listener (the active connect path still applies each peer's own
+value exactly). This matches FRR's behaviour.
+
+Because the MSS each side *advertises* bounds what the **other** side
+sends, both ends must configure `tcp-mss` for both to see a reduced
+value: your `tcp-mss` shrinks the segments your peer sends to you, and
+your peer's `tcp-mss` shrinks the segments you send to it.
+
+## Configured vs. synced
+
+`show ip bgp neighbor <addr>` reports two numbers:
+
+```
+  Configured tcp-mss is 500, synced tcp-mss is 488
+```
+
+- **Configured** is the value you set (`peer.config.transport.tcp_mss`).
+- **Synced** is the MSS the kernel actually negotiated on the live
+  socket, read back with `getsockopt(TCP_MAXSEG)`. It is shown as `0`
+  until the session reaches Established.
+
+The synced value is typically a little **below** the configured value:
+the kernel subtracts the TCP options carried in every segment, so with
+TCP timestamps enabled (the Linux default) a configured `500` syncs to
+`488` (500 − 12).
+
+The two can also differ because **a change to `tcp-mss` does not bounce
+a running session**. Like FRR, the new value takes effect on the next
+connect, so a freshly-changed neighbor may report, say, a configured
+`500` against a still-synced `1460` until you reset the session:
+
+```
+clear bgp 192.168.0.2
+```
+
+A neighbor configured before its first session comes up needs no reset —
+the clamp is already in place when the connection forms.
+
+## Verification
+
+After the session establishes, confirm the negotiated value:
+
+```
+> show ip bgp neighbor 192.168.0.2
+BGP neighbor is 192.168.0.2, remote AS 65002, local AS 65001, external link
+  ...
+  Configured tcp-mss is 500, synced tcp-mss is 488
+  ...
+```
+
+To confirm the option reached the kernel, trace the `setsockopt` calls as
+the session establishes:
+
+```
+sudo strace -e trace=setsockopt -f -p $(pgrep zebra-rs)
+```
+
+You should see a `TCP_MAXSEG` set to the configured value on the
+connection's socket (and, for a passively-accepted peer, on the
+listening socket) before the handshake completes.

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -132,6 +132,11 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
         route_clean(peer_idx, &mut bgp_ref, &mut bgp.peers);
         bgp.peers.remove(&addr);
     }
+    // Keep the shared listener's TCP MSS minimum in step with the peer
+    // set: a whole-neighbor delete may drop the peer that owned the
+    // current minimum without the per-leaf `/tcp-mss` delete firing (the
+    // same gap `clear_peer_listener_auth` covers for MD5/AO).
+    apply_tcp_mss_refresh_all(bgp);
     Some(())
 }
 
@@ -1592,6 +1597,76 @@ fn config_ebgp_multihop(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<(
     Some(())
 }
 
+/// `[no] router bgp neighbor <addr> tcp-mss <1-65535>` — cap the TCP
+/// Maximum Segment Size for this neighbor's connection. Stored on the
+/// peer (read at connect time by `peer_connect` for the active socket)
+/// and reconciled onto the shared listener via
+/// [`apply_tcp_mss_refresh_all`] so passively-accepted connections
+/// inherit the clamp. Both apply before the TCP handshake — see
+/// [`super::mss`].
+///
+/// Unlike ttl-security / ebgp-multihop, a change does **not** bounce a
+/// live session: matching FRR, the new MSS takes effect on the next
+/// connect, so `show bgp neighbor` may report a configured value that
+/// differs from the synced one until the operator resets the session
+/// (`clear bgp <peer>`). `peer.start()` covers the first-config case
+/// (a freshly created, still-Idle peer begins connecting).
+fn config_tcp_mss(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    // On delete the echoed value (if any) is irrelevant — clear it.
+    let want = if op.is_set() { Some(args.u16()?) } else { None };
+    {
+        let peer = bgp.peers.get_mut(&addr)?;
+        if peer.config.transport.tcp_mss == want {
+            // No actual change — leave the live session and listener alone.
+            return Some(());
+        }
+        peer.config.transport.tcp_mss = want;
+        peer.start();
+    }
+    apply_tcp_mss_refresh_all(bgp);
+    Some(())
+}
+
+/// Reconcile the shared BGP listener's TCP MSS. A listening socket
+/// carries a single `TCP_MAXSEG` that every passively-accepted child
+/// inherits on its SYN-ACK, so — like FRR's `bgp_tcp_mss_set` — install
+/// the **minimum** configured `tcp-mss` across this address family's
+/// peers; `0` clears it back to the kernel (path-MTU) default when no
+/// peer of that family sets one. The active connect path applies each
+/// peer's own value precisely in `peer_connect`, so only the passive
+/// path needs this shared approximation. Safe to call repeatedly; silent
+/// when a listener fd is not bound yet — `listen()` re-runs it once the
+/// bind completes.
+pub(super) fn apply_tcp_mss_refresh_all(bgp: &mut Bgp) {
+    let mut min_v4: Option<u16> = None;
+    let mut min_v6: Option<u16> = None;
+    let addrs: Vec<IpAddr> = bgp.peers.keys().copied().collect();
+    for addr in &addrs {
+        let Some(mss) = bgp.peers.get(addr).and_then(|p| p.config.transport.tcp_mss) else {
+            continue;
+        };
+        let slot = if addr.is_ipv4() {
+            &mut min_v4
+        } else {
+            &mut min_v6
+        };
+        *slot = Some(slot.map_or(mss, |cur| cur.min(mss)));
+    }
+    for (fd, min) in [(bgp.listen_fd_v4, min_v4), (bgp.listen_fd_v6, min_v6)] {
+        let Some(fd) = fd else { continue };
+        // 0 resets the user MSS to the kernel default.
+        let value = min.unwrap_or(0);
+        if let Err(e) = super::mss::set_tcp_mss(fd, value) {
+            tracing::warn!(
+                error = %e,
+                mss = value,
+                "bgp: failed to set TCP MSS on BGP listener",
+            );
+        }
+    }
+}
+
 fn config_peer_tcp_md5_password(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = if let Some(addr) = args.v4addr() {
         IpAddr::V4(addr)
@@ -2073,6 +2148,7 @@ impl Bgp {
         // zebra-bgp-transport.yang. Raises the eBGP egress TTL; resolved
         // by Peer::session_ttl and applied at connect / fsm_connected.
         self.callback_peer("/ebgp-multihop", config_ebgp_multihop);
+        self.callback_peer("/tcp-mss", config_tcp_mss);
         self.callback_peer("/tcp-md5/password", config_peer_tcp_md5_password);
         self.callback_peer("/tcp-md5/encoding", config_peer_tcp_md5_encoding);
         // FRR / IOS-XR flat alias from zebra-bgp-password.yang. Same

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1528,6 +1528,11 @@ impl Bgp {
         // because the kernel drops the incoming SYN.
         super::config::apply_md5_refresh_all(self);
         super::config::apply_ao_refresh_all(self);
+        // Reconcile the listener TCP MSS too: a `tcp-mss` callback that
+        // ran before the bind observed `listen_fd_v4/v6 = None` and could
+        // not clamp the listener, so a passively-accepted peer would
+        // otherwise negotiate the default MSS.
+        super::config::apply_tcp_mss_refresh_all(self);
 
         Ok(())
     }

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -31,6 +31,8 @@ pub mod timer;
 
 pub mod ttl;
 
+pub mod mss;
+
 pub mod policy;
 pub use policy::*;
 

--- a/zebra-rs/src/bgp/mss.rs
+++ b/zebra-rs/src/bgp/mss.rs
@@ -1,0 +1,150 @@
+// BGP per-session TCP Maximum Segment Size (MSS).
+//
+// `tcp-mss <1-65535>` caps the MSS advertised on a neighbor's TCP
+// connection (`setsockopt(TCP_MAXSEG)`), which bounds the size of every
+// BGP segment the peer sends us. Operators use it to keep BGP traffic
+// under a path MTU that is smaller than the interface MTU — a tunnel,
+// an MPLS core, or a link that cannot carry full-size frames — so the
+// session does not stall on a black-holed large UPDATE.
+//
+// Linux subtlety that dictates *where* the option is applied: the value
+// must be set on the socket **before** the TCP handshake, because
+// `getsockopt(TCP_MAXSEG)` on an established socket returns the cached,
+// already-negotiated MSS (`tp->mss_cache`) and a late `setsockopt` no
+// longer changes it. So zebra-rs sets it on:
+//   - the active connect socket, before `connect(2)` (so our SYN
+//     advertises the reduced MSS) — see `peer::peer_connect`;
+//   - the *listening* socket, so a passively-accepted child inherits the
+//     clamp on its SYN-ACK — see `config::apply_tcp_mss_refresh_all`.
+// The listener carries a single value (one socket, many peers), so the
+// reconciler installs the **minimum** `tcp-mss` across the configured
+// peers of that address family, mirroring FRR's `bgp_tcp_mss_set`.
+//
+// The "synced" MSS shown by `show bgp neighbor` is this negotiated
+// `tp->mss_cache` read back with [`get_tcp_mss`] once the session is up;
+// it is typically a little below the configured value (the kernel
+// subtracts the per-segment TCP options, e.g. 12 bytes for timestamps),
+// and it can legitimately differ from the configured value when the
+// change has not yet been applied to the live socket (a session reset is
+// needed) — exactly the FRR semantics.
+//
+// Linux-primary, matching `ttl.rs` / `bfd/socket.rs`: the libc constants
+// used here are Linux's and the daemon is built for Linux.
+
+use std::io;
+use std::os::fd::RawFd;
+use std::os::raw::c_int;
+
+/// Set the TCP Maximum Segment Size (`TCP_MAXSEG`) on a BGP socket `fd`.
+/// Apply it **before** the TCP handshake (active connect socket or
+/// listener) — see the module comment. `mss` is the configured
+/// `tcp-mss <1-65535>`.
+pub fn set_tcp_mss(fd: RawFd, mss: u16) -> io::Result<()> {
+    setsockopt_int(fd, libc::IPPROTO_TCP, libc::TCP_MAXSEG, mss as c_int)
+}
+
+/// Read back the kernel's current TCP MSS (`getsockopt(TCP_MAXSEG)`) on
+/// `fd`. On an established socket this is the negotiated `mss_cache` (the
+/// "synced" value). Returns 0 only if the kernel reports a non-positive
+/// value (e.g. a socket with no connection); the cast saturates a value
+/// above `u16::MAX` down to it (TCP MSS never approaches that).
+pub fn get_tcp_mss(fd: RawFd) -> io::Result<u16> {
+    let val = getsockopt_int(fd, libc::IPPROTO_TCP, libc::TCP_MAXSEG)?;
+    Ok(val.clamp(0, u16::MAX as c_int) as u16)
+}
+
+/// Thin `setsockopt(2)` wrapper for a single `c_int`-valued option.
+fn setsockopt_int(fd: RawFd, level: c_int, optname: c_int, value: c_int) -> io::Result<()> {
+    let rc = unsafe {
+        libc::setsockopt(
+            fd,
+            level,
+            optname,
+            &value as *const c_int as *const libc::c_void,
+            std::mem::size_of::<c_int>() as libc::socklen_t,
+        )
+    };
+    if rc < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Thin `getsockopt(2)` wrapper for a single `c_int`-valued option.
+fn getsockopt_int(fd: RawFd, level: c_int, optname: c_int) -> io::Result<c_int> {
+    let mut val: c_int = 0;
+    let mut len = std::mem::size_of::<c_int>() as libc::socklen_t;
+    let rc = unsafe {
+        libc::getsockopt(
+            fd,
+            level,
+            optname,
+            &mut val as *mut c_int as *mut libc::c_void,
+            &mut len,
+        )
+    };
+    if rc < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(val)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{TcpListener, TcpStream};
+    use std::os::fd::AsRawFd;
+
+    /// Setting `TCP_MAXSEG` before the handshake reduces the MSS the
+    /// kernel reads back on the established socket. Both ends advertise
+    /// the clamp, so both report a value at or below it (the kernel
+    /// subtracts per-segment TCP options, so it can be a little lower).
+    #[test]
+    fn set_tcp_mss_reduces_negotiated_mss() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        // The listener carries the clamp so the accepted child's SYN-ACK
+        // advertises it (mirrors the zebra-rs listener reconciler).
+        set_tcp_mss(listener.as_raw_fd(), 500).unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let client = TcpStream::connect(addr).unwrap();
+        let (server, _) = listener.accept().unwrap();
+
+        // Without any clamp loopback negotiates a very large MSS; with
+        // the 500-byte clamp on both paths each end must be well under
+        // the default ethernet MSS of 1460.
+        let client_mss = get_tcp_mss(client.as_raw_fd()).unwrap();
+        let server_mss = get_tcp_mss(server.as_raw_fd()).unwrap();
+        assert!(
+            client_mss > 0 && client_mss <= 500,
+            "client synced MSS {client_mss} must be in (0, 500]",
+        );
+        assert!(
+            server_mss > 0 && server_mss <= 500,
+            "server synced MSS {server_mss} must be in (0, 500]",
+        );
+    }
+
+    /// `set_tcp_mss` on the active socket before connect clamps that
+    /// socket's own negotiated MSS regardless of what the peer
+    /// advertises — this is what makes the active-connect path alone
+    /// enough to bound the segments we send.
+    #[test]
+    fn set_tcp_mss_on_active_socket_clamps_local() {
+        use socket2::{Domain, Socket, Type};
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let sock = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+        set_tcp_mss(sock.as_raw_fd(), 500).unwrap();
+        sock.connect(&addr.into()).unwrap();
+        let (server, _) = listener.accept().unwrap();
+
+        let local_mss = get_tcp_mss(sock.as_raw_fd()).unwrap();
+        assert!(
+            local_mss > 0 && local_mss <= 500,
+            "active socket synced MSS {local_mss} must be in (0, 500]",
+        );
+        drop(server);
+    }
+}

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -191,6 +191,18 @@ pub struct PeerTransportConfig {
     /// [`Peer::session_ttl`] and applied in [`fsm_connected`] /
     /// `peer_connect`. See `zebra-bgp-transport.yang`.
     pub ebgp_multihop: Option<u8>,
+    /// `tcp-mss <1-65535>`: cap the TCP Maximum Segment Size on this
+    /// neighbor's connection. `Some(n)` is installed on the active
+    /// connect socket before `connect(2)` (`peer_connect`) and folded
+    /// into the listener's minimum (`config::apply_tcp_mss_refresh_all`)
+    /// so a passively-accepted child inherits it; both must precede the
+    /// TCP handshake because `getsockopt(TCP_MAXSEG)` on an established
+    /// socket returns the already-negotiated MSS. `None` leaves the
+    /// kernel default (path-MTU derived). A change does not bounce a live
+    /// session — like FRR, the new value takes effect on the next
+    /// connect, so a `clear` is needed to apply it now. See `super::mss`
+    /// and `zebra-bgp-transport.yang`.
+    pub tcp_mss: Option<u16>,
     // TCP MD5 (RFC 2385) shared secret. When Some, installed on the
     // listening socket (for the peer's address) and on the active
     // TcpSocket before connect(). The encoding determines how the
@@ -596,6 +608,16 @@ pub struct Peer {
     /// two — a peer with no per-neighbor config still gets instance
     /// tracing. Mirrors the `adv_interval` snapshot pattern.
     pub tracing_instance: super::tracing::BgpTracing,
+
+    /// Negotiated TCP MSS read back from the session socket
+    /// (`getsockopt(TCP_MAXSEG)`) at [`fsm_connected`] — the "synced"
+    /// value `show bgp neighbor` reports next to the configured
+    /// `tcp-mss`. Runtime bookkeeping, not config: captured once per
+    /// connection (it is the kernel's cached `mss_cache`, fixed for the
+    /// life of the socket) and only meaningful while Established, so the
+    /// show path gates on state rather than clearing this on teardown.
+    /// `None` until the first session comes up. See [`super::mss`].
+    pub tcp_mss_synced: Option<u16>,
 }
 
 impl Peer {
@@ -666,6 +688,7 @@ impl Peer {
             bfd_session_key: None,
             tracing: super::tracing::BgpTracing::default(),
             tracing_instance: super::tracing::BgpTracing::default(),
+            tcp_mss_synced: None,
         };
         peer.config
             .mp
@@ -1351,11 +1374,33 @@ fn apply_session_ttl(peer: &Peer, stream: &TcpStream) {
     }
 }
 
+/// Read back the kernel's negotiated TCP MSS (`getsockopt(TCP_MAXSEG)`)
+/// on the freshly established `stream` and record it on the peer as the
+/// "synced" MSS shown by `show bgp neighbor`. The connection's MSS was
+/// fixed during the TCP handshake (the configured `tcp-mss` is applied
+/// pre-connect / on the listener), so one read per connection captures
+/// it for the socket's life. Best-effort: a failure leaves the previous
+/// value untouched (logged at debug).
+fn record_session_mss(peer: &mut Peer, stream: &TcpStream) {
+    use std::os::fd::AsRawFd;
+    match super::mss::get_tcp_mss(stream.as_raw_fd()) {
+        Ok(mss) => peer.tcp_mss_synced = Some(mss),
+        Err(e) => {
+            tracing::debug!(
+                peer = %peer.address,
+                error = %e,
+                "bgp: failed to read synced TCP MSS on session socket",
+            );
+        }
+    }
+}
+
 pub fn fsm_connected(peer: &mut Peer, role: Role, stream: TcpStream) -> State {
     if let Ok(local_addr) = stream.local_addr() {
         peer.param.local_addr = Some(local_addr);
     }
     apply_session_ttl(peer, &stream);
+    record_session_mss(peer, &stream);
     peer.task.connect = None;
     let (packet_tx, packet_rx) = mpsc::unbounded_channel::<BytesMut>();
     peer.packet_tx = Some(packet_tx);
@@ -1546,6 +1591,9 @@ pub fn peer_start_connection(peer: &mut Peer) -> Task<()> {
     // 255 for iBGP / ttl-security. Set on the socket before connect so
     // the SYN carries it (see `peer_connect`).
     let ttl = peer.session_ttl();
+    // `tcp-mss <1-65535>`, likewise set before connect so our SYN
+    // advertises the clamp and the kernel caches the reduced MSS.
+    let tcp_mss = peer.config.transport.tcp_mss;
     let ctx = peer.ctx.clone();
     Task::spawn(async move {
         let tx = tx.clone();
@@ -1571,6 +1619,7 @@ pub fn peer_start_connection(peer: &mut Peer) -> Task<()> {
             md5_password.as_deref(),
             ao_key,
             ttl,
+            tcp_mss,
         )
         .await;
         match result {
@@ -1593,6 +1642,7 @@ async fn peer_connect(
     md5_password: Option<&str>,
     ao_key: Option<super::auth::ResolvedAoKey>,
     ttl: u8,
+    tcp_mss: Option<u16>,
 ) -> std::io::Result<TcpStream> {
     // Address family of the source must match the remote when specified.
     if let Some(src) = update_source
@@ -1646,6 +1696,22 @@ async fn peer_connect(
             peer = %remote.ip(),
             error = %e,
             "bgp: failed to set egress TTL before connect; using OS default",
+        );
+    }
+
+    // Set the TCP MSS before connect so our SYN advertises the clamp and
+    // the kernel caches the reduced MSS on this socket — a later set on
+    // the established socket no longer changes `getsockopt(TCP_MAXSEG)`.
+    // Best-effort: a failure is logged and the connect proceeds at the
+    // path-MTU-derived default.
+    if let Some(mss) = tcp_mss
+        && let Err(e) = super::mss::set_tcp_mss(socket.as_raw_fd(), mss)
+    {
+        tracing::warn!(
+            peer = %remote.ip(),
+            error = %e,
+            mss,
+            "bgp: failed to set TCP MSS before connect; using path-MTU default",
         );
     }
 
@@ -1838,8 +1904,12 @@ fn reject_connection(stream: TcpStream, code: NotifyCode, sub_code: u8) {
 fn start_collision_conn(peer: &mut Peer, stream: TcpStream) {
     // Same TTL policy as the primary connection: if this collision conn
     // wins §6.8 resolution it is promoted to primary, so it must carry
-    // the egress TTL and (for ttl-security) the ingress floor too.
+    // the egress TTL and (for ttl-security) the ingress floor too. Record
+    // its negotiated MSS for the same reason — it negotiated the same
+    // clamp as the primary (same config, same path), so capturing here
+    // keeps the synced value correct whichever connection survives.
     apply_session_ttl(peer, &stream);
+    record_session_mss(peer, &stream);
     let (packet_tx, packet_rx) = mpsc::unbounded_channel::<BytesMut>();
     let (read_half, write_half) = stream.into_split();
     let reader = peer_start_reader(peer, ConnTag::Collision, read_half);

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1399,6 +1399,17 @@ struct Neighbor<'a> {
     /// session. Mirrors `peer.config.transport.ebgp_multihop`.
     #[serde(skip_serializing_if = "Option::is_none")]
     ebgp_multihop: Option<u8>,
+    /// `tcp-mss N`: configured TCP Maximum Segment Size for this
+    /// neighbor. Mirrors `peer.config.transport.tcp_mss`; `None` when
+    /// unset (the kernel default applies).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tcp_mss: Option<u16>,
+    /// Negotiated TCP MSS read back from the live socket (the "synced"
+    /// value). `Some` only while Established — `peer.tcp_mss_synced`
+    /// gated on session state — and serialized as 0 by the renderer
+    /// otherwise, mirroring FRR's `getsockopt`-on-a-dead-fd output.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tcp_mss_synced: Option<u16>,
     /// Name of the IOS-XR-style `neighbor-group` this peer inherits
     /// from, if any. `remote_as_inherited` says whether the peer's
     /// `remote_as` actually came off the group (vs. an explicit
@@ -1542,6 +1553,15 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         as_override: peer.config.as_override,
         ttl_security: peer.config.transport.ttl_security,
         ebgp_multihop: peer.config.transport.ebgp_multihop,
+        tcp_mss: peer.config.transport.tcp_mss,
+        // The synced MSS is only meaningful on a live socket; gate it on
+        // Established so a stale capture from a previous session isn't
+        // shown (the renderer falls back to 0, as FRR does for a dead fd).
+        tcp_mss_synced: if peer.state.to_str() == "Established" {
+            peer.tcp_mss_synced
+        } else {
+            None
+        },
         neighbor_group: peer.config.neighbor_group.clone(),
         remote_as_inherited: peer.config.remote_as_inherited,
     };
@@ -1653,6 +1673,19 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
             out,
             "  External BGP neighbor may be up to {} hops away (ebgp-multihop)",
             hops
+        )?;
+    }
+
+    // Configured `tcp-mss` plus the MSS the kernel actually negotiated on
+    // the live socket. The two can differ — a config change only takes
+    // effect on the next connect — and the synced value is 0 until the
+    // session is up. Mirrors FRR's `show ip bgp neighbor` line.
+    if let Some(mss) = neighbor.tcp_mss {
+        writeln!(
+            out,
+            "  Configured tcp-mss is {}, synced tcp-mss is {}",
+            mss,
+            neighbor.tcp_mss_synced.unwrap_or(0),
         )?;
     }
 

--- a/zebra-rs/yang/zebra-bgp-transport.yang
+++ b/zebra-rs/yang/zebra-bgp-transport.yang
@@ -52,6 +52,12 @@ module zebra-bgp-transport {
      site in `peer_connect`. Operators using the FRR vocabulary get
      the flat form without giving up the IETF tree.";
 
+  revision 2026-06-08 {
+    description
+      "Add `tcp-mss <1-65535>` per-neighbor leaf (TCP_MAXSEG clamp).";
+    reference "FRR `neighbor X tcp-mss <N>`; Cisco IOS equivalent.";
+  }
+
   revision 2026-05-05 {
     description "Initial revision.";
     reference "FRR `neighbor X update-source`; Cisco IOS equivalent.";
@@ -130,6 +136,42 @@ module zebra-bgp-transport {
          ietf-bgp-common.";
       reference
         "RFC 4271: A Border Gateway Protocol 4 (BGP-4).";
+    }
+
+    leaf tcp-mss {
+      ext:help "Cap the TCP Maximum Segment Size for this neighbor (1-65535)";
+      type uint16 {
+        range "1..65535";
+      }
+      description
+        "TCP Maximum Segment Size (`setsockopt(TCP_MAXSEG)`) for this
+         neighbor's session, in bytes. Bounds the size of every BGP
+         segment so the session stays under a path MTU smaller than the
+         interface MTU — a tunnel, an MPLS core, or a link that cannot
+         carry full-size frames — avoiding a stall on a black-holed
+         large UPDATE.
+
+         The value is applied to the socket *before* the TCP handshake:
+         on the active connect socket (so the SYN advertises the clamp)
+         and on the listening socket (so a passively-accepted connection
+         inherits it). Because a listening socket carries a single value
+         for all peers, the daemon installs the minimum `tcp-mss` across
+         the configured peers of each address family on the listener,
+         matching FRR; the active path applies each peer's own value
+         exactly.
+
+         Changing `tcp-mss` does not bounce a live session: the new value
+         takes effect on the next connect, so reset the session
+         (`clear bgp <peer>`) to apply it immediately. `show bgp neighbor`
+         reports both the configured value and the MSS the kernel actually
+         negotiated (the *synced* value), which the kernel may set a little
+         below the configured one (it subtracts per-segment TCP options).
+
+         Equivalent to `neighbor X tcp-mss <N>` in FRR / Cisco IOS, and to
+         `neighbor/transport/tcp-mss` in ietf-bgp-common.";
+      reference
+        "RFC 879: The TCP Maximum Segment Size and Related Topics.
+         RFC 4271: A Border Gateway Protocol 4 (BGP-4).";
     }
   }
 


### PR DESCRIPTION
## Summary

Adds per-neighbor `router bgp neighbor X tcp-mss <1-65535>` to cap the TCP Maximum Segment Size on a BGP session, matching FRR (`bgpd/`).

Why the clamp is set **before** the TCP handshake: `getsockopt(TCP_MAXSEG)` on an established socket returns the already-negotiated `mss_cache`, and a later `setsockopt` no longer changes it. So `tcp-mss` is installed on:
- the **active connect socket** before `connect(2)` (our SYN advertises the clamp), and
- the **shared listener** — a single `TCP_MAXSEG` per socket, so the daemon installs the per-family **minimum** across configured peers, mirroring FRR's `bgp_tcp_mss_set` — so a passively-accepted child inherits it on its SYN-ACK.

`show ip bgp neighbor X` reports the configured value and the MSS the kernel actually negotiated (read back from the live socket):

```
  Configured tcp-mss is 500, synced tcp-mss is 488
```

The synced value sits a little below the configured one (the kernel subtracts the 12-byte TCP timestamp option). A change does **not** bounce a live session (like FRR — it takes effect on the next connect), so the two can legitimately differ until a `clear`.

## Changes

- **YANG**: `tcp-mss` leaf (`uint16`, range `1..65535`) in `zebra-bgp-transport`.
- **`bgp/mss.rs`** (new): `set_tcp_mss` / `get_tcp_mss` (`TCP_MAXSEG`) + unit tests.
- **config**: `config_tcp_mss` stores the value and reconciles the listener (`apply_tcp_mss_refresh_all`); also reconciled on neighbor add/delete and in `listen()`.
- **peer**: `peer_connect` sets it pre-connect; the negotiated MSS is captured at `fsm_connected` / collision-conn into `tcp_mss_synced`.
- **show**: configured + synced `tcp-mss` line (text + JSON), synced gated on Established.
- **BDD**: `@bgp_tcp_mss` (two-node eBGP, both ends `tcp-mss 500`, asserts configured/synced + Established, with an explicit teardown scenario).
- **book**: `ch-02-14-bgp-tcp-mss.md` + `SUMMARY.md`.

## Test plan

- `cargo build`, `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Unit tests: `bgp::mss` 2/2, `yang_load_tests` 2/2, `bgp::` 291/0.
- BDD `@bgp_tcp_mss`: 2 scenarios / 22 steps pass; both ends Established, both show `Configured tcp-mss is 500, synced tcp-mss is 488`; namespace teardown verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)