### PR TITLE
bgp: add neighbor disable-connected-check

### DIFF
--- a/bdd/tests/configs/bgp_disable_connected_check/z1-base.yaml
+++ b/bdd/tests/configs/bgp_disable_connected_check/z1-base.yaml
@@ -1,0 +1,37 @@
+# z1 (AS 65001): peers with z2 over loopbacks across the shared L2 link.
+# The link is 10.0.0.0/24 (step-assigned to the veth); the peering
+# addresses are loopbacks (10.255.0.1, 10.255.0.2) reachable only via a
+# static route, so neither sits on a directly-connected subnet. With no
+# `disable-connected-check`, the single-hop eBGP connected check holds the
+# session down even though TTL 1 would reach the L2-adjacent peer.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.1/32
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.255.0.2/32
+        nexthop:
+        - address: 10.0.0.2
+  bgp:
+    global:
+      as: 65001
+      identifier: 10.255.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.255.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      update-source: 10.255.0.1
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.1.1.1/32

--- a/bdd/tests/configs/bgp_disable_connected_check/z1-disable.yaml
+++ b/bdd/tests/configs/bgp_disable_connected_check/z1-disable.yaml
@@ -1,0 +1,36 @@
+# z1 with `disable-connected-check` added: the eBGP connected check is
+# skipped, so the loopback-to-loopback session comes up at TTL 1 (the peer
+# is one L2 hop away, so TTL 1 still reaches it). `vtyctl apply` is
+# additive, so applying this over z1-base just sets the new flag.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.1/32
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.255.0.2/32
+        nexthop:
+        - address: 10.0.0.2
+  bgp:
+    global:
+      as: 65001
+      identifier: 10.255.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.255.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      update-source: 10.255.0.1
+      disable-connected-check: null
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.1.1.1/32

--- a/bdd/tests/configs/bgp_disable_connected_check/z2-base.yaml
+++ b/bdd/tests/configs/bgp_disable_connected_check/z2-base.yaml
@@ -1,0 +1,33 @@
+# z2 (AS 65002): mirror of z1-base. Peers with z1 over loopbacks; without
+# `disable-connected-check` the connected check holds the session down.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.2/32
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.255.0.1/32
+        nexthop:
+        - address: 10.0.0.1
+  bgp:
+    global:
+      as: 65002
+      identifier: 10.255.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.255.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      update-source: 10.255.0.2
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.2.2.2/32

--- a/bdd/tests/configs/bgp_disable_connected_check/z2-disable.yaml
+++ b/bdd/tests/configs/bgp_disable_connected_check/z2-disable.yaml
@@ -1,0 +1,34 @@
+# z2 with `disable-connected-check` added (mirror of z1-disable). With both
+# ends exempt, the loopback-to-loopback eBGP session establishes at TTL 1.
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.255.0.2/32
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 10.255.0.1/32
+        nexthop:
+        - address: 10.0.0.1
+  bgp:
+    global:
+      as: 65002
+      identifier: 10.255.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 10.255.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      update-source: 10.255.0.2
+      disable-connected-check: null
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.2.2.2/32

--- a/bdd/tests/features/bgp_disable_connected_check.feature
+++ b/bdd/tests/features/bgp_disable_connected_check.feature
@@ -1,0 +1,67 @@
+@serial
+@bgp_disable_connected_check
+Feature: BGP disable-connected-check (eBGP connected-network check)
+  As a network operator
+  I want a single-hop eBGP session over loopback addresses to be held down
+  by default (the neighbor is not on a directly-connected subnet) and to
+  come up once `disable-connected-check` is set, confirming both the check
+  and its override end-to-end.
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65002 │
+           │ 10.0.0. │     │ 10.0.0. │
+           │  1/24   │     │  2/24   │
+           │ lo .255 │     │ lo .255 │
+           │  .0.1/32│     │  .0.2/32│
+           └─────────┘     └─────────┘
+  ```
+
+  z1 and z2 are directly connected at layer 2 over br0 (10.0.0.0/24), but
+  peer eBGP using their loopbacks (10.255.0.1 ↔ 10.255.0.2), each reachable
+  only via a static route — so neither peering address is on a connected
+  subnet. A TTL-1 packet still reaches the L2-adjacent peer, so the only
+  thing standing between the two routers is the connected check.
+
+  Config files:
+  - z{1,2}-base.yaml: loopback peering, no disable-connected-check.
+  - z{1,2}-disable.yaml: same, plus `disable-connected-check`.
+
+  Scenario: The connected check holds a loopback eBGP session down
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "10.0.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "10.0.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-base.yaml" to namespace "z1"
+    And I apply config "z2-base.yaml" to namespace "z2"
+    And I wait 10 seconds for BGP to operate
+    Then BGP session in "z1" to "10.255.0.2" should not be "Established"
+    And BGP session in "z2" to "10.255.0.1" should not be "Established"
+    And BGP route in "z2" does not have "10.1.1.1/32"
+
+  Scenario: disable-connected-check brings the loopback eBGP session up
+    Given the test topology exists
+    When I apply config "z1-disable.yaml" to namespace "z1"
+    And I apply config "z2-disable.yaml" to namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z1" to "10.255.0.2" should be "Established"
+    And BGP session in "z2" to "10.255.0.1" should be "Established"
+    And BGP route in "z2" has "10.1.1.1/32"
+    And BGP route in "z1" has "10.2.2.2/32"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -22,6 +22,7 @@
   - [allowas-in (Inbound AS_PATH Loop Relaxation)](ch-02-13-bgp-allowas-in.md)
   - [Remove Private AS](ch-02-14-bgp-remove-private-as.md)
   - [Enforce First AS](ch-02-15-bgp-enforce-first-as.md)
+  - [disable-connected-check](ch-02-16-bgp-disable-connected-check.md)
   - [Timer Configuration](ch-02-03-bgp-timers.md)
   - [L3VPN and Per-VRF Labels](ch-02-04-bgp-l3vpn.md)
   - [L3VPN over an SRv6 Underlay](ch-02-05-bgp-l3vpn-srv6.md)

--- a/book/src/ch-02-16-bgp-disable-connected-check.md
+++ b/book/src/ch-02-16-bgp-disable-connected-check.md
@@ -1,0 +1,121 @@
+# BGP disable-connected-check
+
+By default an **eBGP** session is expected to be a single IP hop: the
+egress TTL is 1 (see
+[TTL: eBGP Multihop and Security](ch-02-11-bgp-ttl-security.md)) and the
+neighbor is expected to live on one of the router's directly-connected
+subnets. zebra-rs enforces the second half of that expectation with the
+**connected-network check**: before dialing a single-hop eBGP neighbor it
+verifies the neighbor's address is on a connected subnet, and holds the
+session down otherwise. `disable-connected-check` removes that
+requirement for one neighbor.
+
+## When you need it
+
+The canonical case is two routers that are **directly connected at layer
+2** but peer eBGP using addresses that are **not on the shared subnet** —
+almost always loopbacks:
+
+```
+        10.0.0.0/24 (shared link)
+ ┌─────────┐                 ┌─────────┐
+ │   R1    │─────────────────│   R2    │
+ │ lo .255 │                 │ lo .255 │
+ │  .0.1/32│                 │  .0.2/32│
+ └─────────┘                 └─────────┘
+   AS 65001                    AS 65002
+   peer 10.255.0.2  ←──────→  peer 10.255.0.1
+```
+
+R1 and R2 reach each other's loopback through a static (or IGP) route over
+the link. Because they are L2-adjacent, a TTL-1 BGP packet still arrives at
+the neighbor — no router decrements it — so **`ebgp-multihop` is not
+required and would be wrong** (it would weaken the single-hop guarantee for
+no reason). The only obstacle is the connected check, since `10.255.0.2`
+is not on R1's connected `10.0.0.0/24`. `disable-connected-check` lifts
+exactly that obstacle while leaving the TTL at 1.
+
+## What the check does
+
+The check governs **only a single-hop eBGP session** — eBGP whose egress
+TTL is 1, i.e. neither `ebgp-multihop` nor `ttl-security` is set. For such
+a peer:
+
+- If the neighbor's address falls inside one of the router's
+  directly-connected subnets (learned from interface addresses), the
+  session is dialed normally.
+- Otherwise the session is **held in `Active`**: zebra-rs does not open the
+  TCP connection. It re-evaluates whenever a connected route to the peer
+  appears, so a session that was waiting on an interface coming up dials as
+  soon as it can.
+
+The check **does not apply** to iBGP, to `ebgp-multihop` sessions, to
+`ttl-security` (GTSM) sessions, or to unnumbered / link-local peers — those
+are either intentionally multi-hop or directly attached by construction. On
+those neighbors `disable-connected-check` is a no-op.
+
+If zebra-rs has no interface-address information yet (for example very
+early in startup), the check **fails open** so a transient lack of
+knowledge never wedges a session — matching FRR's behaviour when it has no
+connectivity information from the RIB.
+
+> This mirrors FRR / Cisco IOS `neighbor X disable-connected-check`
+> (FRR also accepts the legacy spelling `enforce-multihop`). FRR gates the
+> same case through next-hop tracking; zebra-rs gates it at
+> connect-initiation, which is observably equivalent: the session stays
+> down until the neighbor is connected or the check is disabled.
+
+## Configuration
+
+`disable-connected-check` is a per-neighbor flag. Set it on the end(s)
+that dial the non-connected address; in the loopback case that is both
+ends.
+
+```yaml
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 10.255.0.1
+    neighbor:
+    - remote-address: 10.255.0.2
+      remote-as: 65002
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      update-source: 10.255.0.1
+      disable-connected-check: null
+```
+
+`disable-connected-check: null` is the YAML spelling of a `type empty`
+leaf — the key is present with no value, which the loader turns into
+`set router bgp neighbor 10.255.0.2 disable-connected-check`. The
+FRR / IOS-style CLI form is the same path:
+
+```
+set router bgp neighbor 10.255.0.2 disable-connected-check
+```
+
+`update-source` is normally configured alongside it so the session sources
+from the loopback the neighbor expects.
+
+Toggling `disable-connected-check` on a session that is already up bounces
+it (the same teardown `clear bgp <peer>` performs): enabling it lets a held
+neighbor connect, and disabling it resets a session that only came up
+because of the override.
+
+## Verification
+
+`show ip bgp neighbor <addr>` reports the active policy:
+
+```
+  Connected-network check disabled (eBGP peer may be unconnected at TTL 1)
+```
+
+A neighbor still held by the check shows a non-`Established` state (it sits
+in `Active`, never opening a connection). The classic symptom of a
+**missing** `disable-connected-check` is therefore an eBGP session to a
+loopback that never leaves `Active` even though the loopback pings: add
+`disable-connected-check` (do **not** reach for `ebgp-multihop` on a
+directly-connected peer).

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -102,6 +102,11 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
         // `propagate_instance_tracing`.
         peer.tracing_instance = bgp.tracing.clone();
         bgp.peers.insert(addr, peer);
+        // Seed `shared_network` from interface addresses learned so far so
+        // the eBGP connected check is accurate on this peer's first dial
+        // (interfaces are dumped at startup, before config). No peer is
+        // dialing yet, so no kick fires here.
+        bgp.refresh_connected();
     } else {
         let peer_idx = match bgp.peers.get(&addr) {
             Some(peer) => peer.ident,
@@ -1745,6 +1750,43 @@ pub(super) fn apply_tcp_mss_refresh_all(bgp: &mut Bgp) {
     }
 }
 
+/// `[no] router bgp neighbor <addr> disable-connected-check` — exempt a
+/// single-hop eBGP neighbor from the directly-connected-network check, so
+/// a session toward a non-connected address (typically a loopback one L2
+/// hop away) is dialed while the egress TTL stays at 1. No-op for iBGP and
+/// for multihop / GTSM sessions (the check never applies there). The flag
+/// is consulted by [`super::peer::Peer::connected_check_ok`] at
+/// connect-initiation time. Like the sibling TTL knobs, a change on a live
+/// session bounces it (`Event::Stop`, as `clear bgp ... hard` does): on
+/// enable a peer held by the check reconnects on the next start; on
+/// disable an established but non-connected session is reset (FRR's
+/// `peer_change_reset`). An Idle peer just picks it up on its first connect.
+fn config_disable_connected_check(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let want = op.is_set();
+    let (ident, bounce) = {
+        let peer = bgp.peers.get_mut(&addr)?;
+        if peer.config.transport.disable_connected_check == want {
+            // No actual change — don't disturb a live session.
+            return Some(());
+        }
+        peer.config.transport.disable_connected_check = want;
+        peer.start();
+        // Only an established / in-progress session needs an explicit
+        // bounce; bouncing an Idle peer here could race the idle-hold
+        // timer `start()` just armed and strand it. A held (Active) peer
+        // is bounced too, so it leaves Active and re-dials on the next
+        // idle-hold rather than waiting out the connect-retry backstop.
+        (peer.ident, !matches!(peer.state, super::peer::State::Idle))
+    };
+    if bounce {
+        let _ = bgp
+            .tx
+            .try_send(super::inst::Message::Event(ident, super::peer::Event::Stop));
+    }
+    Some(())
+}
+
 fn config_peer_tcp_md5_password(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = if let Some(addr) = args.v4addr() {
         IpAddr::V4(addr)
@@ -2227,6 +2269,10 @@ impl Bgp {
         // by Peer::session_ttl and applied at connect / fsm_connected.
         self.callback_peer("/ebgp-multihop", config_ebgp_multihop);
         self.callback_peer("/tcp-mss", config_tcp_mss);
+        // FRR-style `neighbor X disable-connected-check` from
+        // zebra-bgp-transport.yang. Exempts a single-hop eBGP neighbor from
+        // the directly-connected-network check (Peer::connected_check_ok).
+        self.callback_peer("/disable-connected-check", config_disable_connected_check);
         self.callback_peer("/tcp-md5/password", config_peer_tcp_md5_password);
         self.callback_peer("/tcp-md5/encoding", config_peer_tcp_md5_encoding);
         // FRR / IOS-XR flat alias from zebra-bgp-password.yang. Same
@@ -3219,6 +3265,157 @@ mod neighbor_group_wiring_tests {
         assert!(
             drain_stop_events(&mut bgp).is_empty(),
             "an Idle peer must not be bounced",
+        );
+    }
+
+    /// Build a `LinkAddr` for an interface prefix (e.g. `"10.0.0.1/24"`).
+    fn link_addr(cidr: &str) -> crate::rib::link::LinkAddr {
+        crate::rib::link::LinkAddr {
+            addr: cidr.parse().unwrap(),
+            ifindex: 2,
+            secondary: false,
+            config: false,
+            fib: true,
+        }
+    }
+
+    /// `disable-connected-check` is a `type empty` flag: Set/Delete toggle
+    /// it and a change to a live session is bounced (FRR resets the peer
+    /// on this flag); a no-op set does not bounce, an Idle peer is not
+    /// bounced.
+    #[tokio::test]
+    async fn disable_connected_check_toggles_field_and_bounces_live_session() {
+        use crate::bgp::peer::State;
+        let mut bgp = fresh_bgp();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_remote_as(&mut bgp, arg_words(&["10.0.0.1", "65001"]), ConfigOp::Set).unwrap();
+        let _ = drain_stop_events(&mut bgp);
+        bgp.peers.get_mut(&peer_addr()).unwrap().state = State::Established;
+
+        config_disable_connected_check(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        assert!(
+            bgp.peers
+                .get(&peer_addr())
+                .unwrap()
+                .config
+                .transport
+                .disable_connected_check,
+            "set must enable the flag",
+        );
+        assert_eq!(
+            drain_stop_events(&mut bgp).len(),
+            1,
+            "enabling on a live session must bounce it",
+        );
+
+        config_disable_connected_check(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "a no-op set must not bounce the session",
+        );
+
+        config_disable_connected_check(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Delete)
+            .unwrap();
+        assert!(
+            !bgp.peers
+                .get(&peer_addr())
+                .unwrap()
+                .config
+                .transport
+                .disable_connected_check,
+            "delete must clear the flag",
+        );
+        assert_eq!(
+            drain_stop_events(&mut bgp).len(),
+            1,
+            "disabling on a live session must bounce it",
+        );
+    }
+
+    /// A single-hop eBGP peer whose address is not on a connected subnet
+    /// is gated by the connected check; learning the link does not help
+    /// (the peer's loopback is off-subnet) but `disable-connected-check`
+    /// lifts the gate. With no interface knowledge the check fails open.
+    #[tokio::test]
+    async fn connected_check_gates_unconnected_single_hop_ebgp() {
+        let mut bgp = fresh_bgp();
+        bgp.asn = 65000;
+        // eBGP peer reachable only via its loopback (10.255.0.2).
+        let loop_peer = IpAddr::V4(Ipv4Addr::new(10, 255, 0, 2));
+        config_peer(&mut bgp, arg_words(&["10.255.0.2"]), ConfigOp::Set).unwrap();
+        config_remote_as(&mut bgp, arg_words(&["10.255.0.2", "65001"]), ConfigOp::Set).unwrap();
+
+        // No interface knowledge yet → fail open.
+        assert!(
+            bgp.peers.get(&loop_peer).unwrap().connected_check_ok(),
+            "with no connected-subnet knowledge the check fails open",
+        );
+
+        // Learn the directly-connected /24; the loopback peer is not in it.
+        bgp.connected_subnets.record(&link_addr("10.0.0.1/24"));
+        bgp.refresh_connected();
+        let peer = bgp.peers.get(&loop_peer).unwrap();
+        assert!(peer.is_ebgp());
+        assert!(
+            !peer.shared_network,
+            "loopback peer is not on the connected /24"
+        );
+        assert!(
+            !peer.connected_check_ok(),
+            "a single-hop eBGP peer off every connected subnet must be gated",
+        );
+
+        // The override lifts the gate.
+        config_disable_connected_check(&mut bgp, arg_words(&["10.255.0.2"]), ConfigOp::Set)
+            .unwrap();
+        assert!(
+            bgp.peers.get(&loop_peer).unwrap().connected_check_ok(),
+            "disable-connected-check exempts the peer",
+        );
+
+        // So does learning a subnet that actually covers the peer.
+        config_disable_connected_check(&mut bgp, arg_words(&["10.255.0.2"]), ConfigOp::Delete)
+            .unwrap();
+        bgp.connected_subnets.record(&link_addr("10.255.0.1/24"));
+        bgp.refresh_connected();
+        assert!(
+            bgp.peers.get(&loop_peer).unwrap().connected_check_ok(),
+            "once the peer is on a connected subnet the check passes",
+        );
+    }
+
+    /// The connected check never applies to iBGP, multihop or GTSM peers,
+    /// even when they are off every connected subnet.
+    #[tokio::test]
+    async fn connected_check_never_gates_ibgp_or_multihop() {
+        let mut bgp = fresh_bgp();
+        bgp.asn = 65000;
+        // Only a /24 link is connected; both peers below are off-subnet.
+        bgp.connected_subnets.record(&link_addr("10.0.0.1/24"));
+
+        // iBGP peer (remote-as == local) — never gated.
+        let ibgp = IpAddr::V4(Ipv4Addr::new(10, 255, 0, 9));
+        config_peer(&mut bgp, arg_words(&["10.255.0.9"]), ConfigOp::Set).unwrap();
+        config_remote_as(&mut bgp, arg_words(&["10.255.0.9", "65000"]), ConfigOp::Set).unwrap();
+
+        // eBGP peer with ebgp-multihop — never gated.
+        let mh = IpAddr::V4(Ipv4Addr::new(10, 255, 0, 8));
+        config_peer(&mut bgp, arg_words(&["10.255.0.8"]), ConfigOp::Set).unwrap();
+        config_remote_as(&mut bgp, arg_words(&["10.255.0.8", "65001"]), ConfigOp::Set).unwrap();
+        config_ebgp_multihop(&mut bgp, arg_words(&["10.255.0.8", "5"]), ConfigOp::Set).unwrap();
+
+        bgp.refresh_connected();
+        assert!(
+            !bgp.peers.get(&ibgp).unwrap().shared_network,
+            "iBGP peer is off-subnet",
+        );
+        assert!(
+            bgp.peers.get(&ibgp).unwrap().connected_check_ok(),
+            "iBGP is never subject to the connected check",
+        );
+        assert!(
+            bgp.peers.get(&mh).unwrap().connected_check_ok(),
+            "a multihop eBGP peer is never subject to the connected check",
         );
     }
 

--- a/zebra-rs/src/bgp/connected.rs
+++ b/zebra-rs/src/bgp/connected.rs
@@ -1,0 +1,166 @@
+//! Connected-subnet registry for the eBGP directly-connected-network
+//! check (`disable-connected-check`).
+//!
+//! Populated from `RibRx::AddrAdd` / `AddrDel`: every interface address
+//! contributes its *network* (the address with host bits cleared) so the
+//! BGP instance can answer "is this peer on one of our directly-connected
+//! subnets?" — FRR's `if_lookup_by_ipv4` / `shared_network`. A single-hop
+//! eBGP peer that is **not** on any connected subnet is held down unless
+//! the operator sets `disable-connected-check` (see
+//! [`super::peer::Peer::connected_check_ok`]).
+//!
+//! Subnets are reference-counted by network so two interface addresses in
+//! the same subnet (or a flapping secondary) don't prematurely drop it.
+//! The table is consulted only at connect-initiation time; an empty table
+//! (no interface knowledge yet, or a per-VRF instance not fed interface
+//! addresses) makes the check **fail open**, matching FRR's behaviour
+//! when it has no RIB connectivity information.
+
+use std::collections::BTreeMap;
+use std::net::IpAddr;
+
+use ipnet::IpNet;
+
+use crate::rib::link::LinkAddr;
+
+/// Reference-counted set of directly-connected networks.
+#[derive(Debug, Default)]
+pub struct ConnectedSubnets {
+    nets: BTreeMap<IpNet, usize>,
+}
+
+impl ConnectedSubnets {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record an interface address. The stored key is its network
+    /// (`addr.trunc()`, host bits cleared), reference-counted so several
+    /// addresses sharing one subnet coexist. A /32 or /128 host address
+    /// contributes only itself, which is exactly what we want — it does
+    /// not make a different peer "connected".
+    pub fn record(&mut self, addr: &LinkAddr) {
+        *self.nets.entry(addr.addr.trunc()).or_default() += 1;
+    }
+
+    /// Forget an interface address previously passed to [`Self::record`].
+    /// The subnet is dropped only when its last contributing address goes.
+    pub fn forget(&mut self, addr: &LinkAddr) {
+        let net = addr.addr.trunc();
+        if let Some(count) = self.nets.get_mut(&net) {
+            *count -= 1;
+            if *count == 0 {
+                self.nets.remove(&net);
+            }
+        }
+    }
+
+    /// True while no interface address is known. The connected check
+    /// fails open in this state (see the module docs).
+    pub fn is_empty(&self) -> bool {
+        self.nets.is_empty()
+    }
+
+    /// Whether `ip` falls inside one of the recorded connected subnets.
+    /// Address-family mismatches never match (an IPv4 subnet does not
+    /// cover an IPv6 address).
+    pub fn covers(&self, ip: IpAddr) -> bool {
+        self.nets.keys().any(|net| net.contains(&ip))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ipnet::{Ipv4Net, Ipv6Net};
+
+    fn v4(addr: &str, prefix: u8) -> LinkAddr {
+        let net: Ipv4Net = format!("{addr}/{prefix}").parse().unwrap();
+        LinkAddr {
+            addr: IpNet::V4(net),
+            ifindex: 1,
+            secondary: false,
+            config: false,
+            fib: true,
+        }
+    }
+
+    fn v6(addr: &str, prefix: u8) -> LinkAddr {
+        let net: Ipv6Net = format!("{addr}/{prefix}").parse().unwrap();
+        LinkAddr {
+            addr: IpNet::V6(net),
+            ifindex: 1,
+            secondary: false,
+            config: false,
+            fib: true,
+        }
+    }
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn empty_table_covers_nothing_and_reports_empty() {
+        let t = ConnectedSubnets::new();
+        assert!(t.is_empty());
+        assert!(!t.covers(ip("10.0.0.2")));
+    }
+
+    #[test]
+    fn link_subnet_covers_peer_on_subnet() {
+        let mut t = ConnectedSubnets::new();
+        t.record(&v4("10.0.0.1", 24));
+        assert!(!t.is_empty());
+        // A peer sharing the /24 is connected; the loopback two hops away
+        // is not.
+        assert!(t.covers(ip("10.0.0.2")));
+        assert!(!t.covers(ip("10.255.0.2")));
+    }
+
+    #[test]
+    fn host_address_only_covers_itself() {
+        // The classic loopback-peering case: the only interface addresses
+        // are the /24 link and a /32 loopback, and the peer's loopback is
+        // covered by neither.
+        let mut t = ConnectedSubnets::new();
+        t.record(&v4("10.0.0.1", 24));
+        t.record(&v4("10.255.0.1", 32));
+        assert!(t.covers(ip("10.0.0.9")));
+        assert!(t.covers(ip("10.255.0.1")));
+        assert!(!t.covers(ip("10.255.0.2")));
+    }
+
+    #[test]
+    fn refcount_keeps_subnet_until_last_address_gone() {
+        // Two addresses in the same /24 share one subnet key.
+        let mut t = ConnectedSubnets::new();
+        t.record(&v4("10.0.0.1", 24));
+        t.record(&v4("10.0.0.2", 24));
+        t.forget(&v4("10.0.0.1", 24));
+        assert!(
+            t.covers(ip("10.0.0.7")),
+            "subnet survives while a peer addr remains"
+        );
+        t.forget(&v4("10.0.0.2", 24));
+        assert!(!t.covers(ip("10.0.0.7")));
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn forget_unknown_is_noop() {
+        let mut t = ConnectedSubnets::new();
+        t.forget(&v4("10.0.0.1", 24));
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn ipv6_subnet_and_family_isolation() {
+        let mut t = ConnectedSubnets::new();
+        t.record(&v6("2001:db8::1", 64));
+        assert!(t.covers(ip("2001:db8::2")));
+        assert!(!t.covers(ip("2001:db8:1::2")));
+        // An IPv6 subnet never covers an IPv4 address and vice versa.
+        assert!(!t.covers(ip("10.0.0.2")));
+    }
+}

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -519,6 +519,11 @@ pub struct Bgp {
     /// in MP_REACH for IPv4-unicast advertisements on interface peers
     /// (RFC 8950). See [`super::interface_addrs`].
     pub interface_addrs: super::interface_addrs::InterfaceAddrs,
+    /// Directly-connected subnets, populated from `RibRx::AddrAdd`/`AddrDel`.
+    /// Backs the eBGP connected check: a single-hop eBGP peer whose address
+    /// is not covered here is held down unless it has `disable-connected-check`
+    /// (see [`super::connected`] and [`Self::refresh_connected`]).
+    pub connected_subnets: super::connected::ConnectedSubnets,
     /// IOS-XR-style update-groups, keyed by `(AfiSafi, signature)`.
     /// Signature + membership tracking only — the advertise pipeline
     /// does not yet share work across members. See
@@ -679,6 +684,7 @@ impl Bgp {
             vrf_global_rx: vrf_global_rx_init,
             link_index_by_name: BTreeMap::new(),
             interface_addrs: super::interface_addrs::InterfaceAddrs::new(),
+            connected_subnets: super::connected::ConnectedSubnets::new(),
             update_groups: super::update_group::empty_map(),
             tracing: super::tracing::BgpTracing::default(),
             policy_tx,
@@ -1537,6 +1543,37 @@ impl Bgp {
         Ok(())
     }
 
+    /// Recompute every peer's cached `shared_network` against the current
+    /// [`Self::connected_subnets`] and re-kick any single-hop eBGP peer
+    /// that was held by the connected check and is now on a connected
+    /// subnet. Called whenever an interface address appears or disappears
+    /// (and once per neighbor at config time). A peer that gains
+    /// connectivity while parked in Idle/Active is sent Event::Start so it
+    /// dials immediately instead of waiting out the connect-retry backstop;
+    /// established sessions are never bounced on a connectivity change.
+    pub fn refresh_connected(&mut self) {
+        use super::peer::State;
+        // Disjoint field borrows: the subnet table is read while the peer
+        // map is mutated.
+        let subnets = &self.connected_subnets;
+        let mut kicks: Vec<usize> = Vec::new();
+        for (_key, peer) in self.peers.iter_mut_all() {
+            let was = peer.shared_network;
+            peer.shared_network = subnets.is_empty() || subnets.covers(peer.address);
+            if !was
+                && peer.shared_network
+                && peer.active
+                && peer.connected_check_applies()
+                && matches!(peer.state, State::Idle | State::Active)
+            {
+                kicks.push(peer.ident);
+            }
+        }
+        for ident in kicks {
+            let _ = self.tx.try_send(Message::Event(ident, Event::Start));
+        }
+    }
+
     pub fn process_rib_msg(&mut self, msg: RibRx) {
         // println!("RIB Message {:?}", msg);
         match msg {
@@ -1550,9 +1587,13 @@ impl Bgp {
             }
             RibRx::AddrAdd(addr) => {
                 self.interface_addrs.record(&addr);
+                self.connected_subnets.record(&addr);
+                self.refresh_connected();
             }
             RibRx::AddrDel(addr) => {
                 self.interface_addrs.forget(&addr);
+                self.connected_subnets.forget(&addr);
+                self.refresh_connected();
             }
             RibRx::RouterIdUpdate(router_id) => {
                 // RIB auto-derived a router-id from interface IPv4

--- a/zebra-rs/src/bgp/mod.rs
+++ b/zebra-rs/src/bgp/mod.rs
@@ -6,6 +6,7 @@ pub use constant::*;
 
 pub mod auth;
 pub mod config;
+pub mod connected;
 pub mod dynamic_neighbors;
 pub mod interface_addrs;
 pub mod interface_neighbor;

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -203,6 +203,16 @@ pub struct PeerTransportConfig {
     /// connect, so a `clear` is needed to apply it now. See `super::mss`
     /// and `zebra-bgp-transport.yang`.
     pub tcp_mss: Option<u16>,
+    /// `disable-connected-check` (RFC 4271 operational practice). When
+    /// `false` (the default), a single-hop eBGP session — egress TTL 1,
+    /// i.e. neither `ebgp_multihop` nor `ttl_security` set — is only
+    /// dialed when the neighbor's address is on a directly-connected
+    /// subnet (FRR `shared_network`). When `true`, that requirement is
+    /// dropped so the session can reach a non-connected address (e.g. a
+    /// loopback one L2 hop away) while keeping TTL 1. Ignored for iBGP and
+    /// for multihop / GTSM sessions (they are never gated). Consulted by
+    /// [`Peer::connected_check_ok`]. See `zebra-bgp-transport.yang`.
+    pub disable_connected_check: bool,
     // TCP MD5 (RFC 2385) shared secret. When Some, installed on the
     // listening socket (for the peer's address) and on the active
     // TcpSocket before connect(). The encoding determines how the
@@ -552,6 +562,15 @@ pub struct Peer {
     /// do today).
     pub ctx: crate::context::ProtoContext,
     pub active: bool,
+    /// Cached "the neighbor's address is on one of our directly-connected
+    /// subnets" (FRR `shared_network`). Maintained by the owning instance
+    /// from interface-address events (`Bgp::refresh_connected`) rather
+    /// than recomputed in the FSM, because the active-connect decision in
+    /// [`fsm_start`] only has `&mut Peer`. Reads `true` while the instance
+    /// has no interface-address knowledge yet, so the connected check
+    /// fails open (see [`super::connected::ConnectedSubnets`]). Consulted
+    /// only by [`Peer::connected_check_ok`].
+    pub shared_network: bool,
     pub peer_type: PeerType,
     pub state: State,
     pub task: PeerTask,
@@ -677,6 +696,9 @@ impl Peer {
             origin: PeerOrigin::Static,
             scope_id: None,
             active: false,
+            // Fail open until the instance computes connectedness from
+            // interface-address events (see `shared_network`).
+            shared_network: true,
             peer_type: PeerType::IBGP,
             state: State::Idle,
             task: PeerTask::default(),
@@ -822,6 +844,33 @@ impl Peer {
             .transport
             .ebgp_multihop
             .unwrap_or(super::ttl::DEFAULT_EBGP_TTL)
+    }
+
+    /// Whether the eBGP directly-connected-network check governs this
+    /// peer. It governs exactly a single-hop eBGP session — eBGP with an
+    /// egress TTL of 1, i.e. neither `ebgp-multihop` nor `ttl-security`
+    /// (both raise the TTL and signal an intentionally non-adjacent peer)
+    /// — that the operator has not exempted with `disable-connected-check`.
+    /// iBGP, multihop/GTSM, unresolved (`0.0.0.0`/`::`) and link-local /
+    /// unnumbered peers are never governed: the last two are on-link by
+    /// construction. Mirrors FRR's `peer->sort == BGP_PEER_EBGP &&
+    /// peer->ttl == BGP_DEFAULT_TTL && !PEER_FLAG_DISABLE_CONNECTED_CHECK`.
+    pub fn connected_check_applies(&self) -> bool {
+        self.is_ebgp()
+            && self.session_ttl() == super::ttl::DEFAULT_EBGP_TTL
+            && !self.config.transport.disable_connected_check
+            && !self.address.is_unspecified()
+            && !addr_is_v6_link_local(&self.address)
+    }
+
+    /// True when the directly-connected-network check is satisfied: either
+    /// it does not apply to this peer (see [`Self::connected_check_applies`])
+    /// or the neighbor sits on one of our connected subnets
+    /// ([`Self::shared_network`], which also reads `true` when the instance
+    /// has no interface-address knowledge yet — the check fails open).
+    /// Consulted by [`fsm_start`] before dialing the peer.
+    pub fn connected_check_ok(&self) -> bool {
+        !self.connected_check_applies() || self.shared_network
     }
 
     /// Effective BFD hop mode for this neighbour: the explicit
@@ -1136,8 +1185,34 @@ pub fn fsm_adv_timer_evpn_expires(peer: &mut Peer) -> State {
     State::Established
 }
 
+/// `fe80::/10` test (RFC 4291 §2.5.6). `Ipv6Addr::is_unicast_link_local`
+/// is still unstable, so open-code it. A link-local / unnumbered peer is
+/// directly attached by construction and is never subject to the eBGP
+/// connected check.
+fn addr_is_v6_link_local(addr: &IpAddr) -> bool {
+    matches!(addr, IpAddr::V6(a) if (a.segments()[0] & 0xffc0) == 0xfe80)
+}
+
 pub fn fsm_start(peer: &mut Peer) -> State {
     peer.first_start = false;
+    // eBGP directly-connected-network check: a single-hop eBGP peer that
+    // is not on a connected subnet must not be dialed unless the operator
+    // set `disable-connected-check`. FRR gates the same case through NHT;
+    // we hold the active connection in Active and re-evaluate on the
+    // connect-retry timer. The instance also re-kicks us with Event::Start
+    // the moment a connected route to the peer appears
+    // (`Bgp::refresh_connected`), and a relevant config change bounces the
+    // peer through its callback — so the 120s retry is only a backstop.
+    if !peer.connected_check_ok() {
+        if peer.trace_fsm() {
+            tracing::info!(
+                peer = %peer.address,
+                "bgp: holding eBGP session — neighbor is not on a connected network and disable-connected-check is off",
+            );
+        }
+        peer.timer.connect_retry = Some(timer::start_connect_retry_timer(peer));
+        return State::Active;
+    }
     peer.task.connect = Some(peer_start_connection(peer));
     State::Connect
 }

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1421,6 +1421,11 @@ struct Neighbor<'a> {
     /// otherwise, mirroring FRR's `getsockopt`-on-a-dead-fd output.
     #[serde(skip_serializing_if = "Option::is_none")]
     tcp_mss_synced: Option<u16>,
+    /// `disable-connected-check`: when true, this eBGP neighbor is exempt
+    /// from the directly-connected-network check (a non-connected address,
+    /// e.g. a loopback, may be dialed at TTL 1). Mirrors
+    /// `peer.config.transport.disable_connected_check`.
+    disable_connected_check: bool,
     /// Name of the IOS-XR-style `neighbor-group` this peer inherits
     /// from, if any. `remote_as_inherited` says whether the peer's
     /// `remote_as` actually came off the group (vs. an explicit
@@ -1575,6 +1580,7 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         } else {
             None
         },
+        disable_connected_check: peer.config.transport.disable_connected_check,
         neighbor_group: peer.config.neighbor_group.clone(),
         remote_as_inherited: peer.config.remote_as_inherited,
     };
@@ -1718,6 +1724,13 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
             "  Configured tcp-mss is {}, synced tcp-mss is {}",
             mss,
             neighbor.tcp_mss_synced.unwrap_or(0),
+        )?;
+    }
+
+    if neighbor.disable_connected_check {
+        writeln!(
+            out,
+            "  Connected-network check disabled (eBGP peer may be unconnected at TTL 1)"
         )?;
     }
 

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1314,4 +1314,39 @@ mod yang_load_tests {
             );
         }
     }
+
+    /// A new BGP-neighbor YANG knob must be a *settable* path, not just a
+    /// loadable module. Naming it the same as a leaf already present via
+    /// `uses ietf-bgp:bgp` makes the augment silently dropped (RFC 7950
+    /// §7.17), so the path parses as `Nomatch` — which `load_mode` above
+    /// would not catch. Parse the concrete `set` line and assert success.
+    #[test]
+    fn bgp_neighbor_disable_connected_check_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        let (code, _comps, _state) = parse(
+            "set router bgp neighbor 10.0.0.1 disable-connected-check",
+            entry,
+            None,
+            State::new(),
+        );
+        assert_eq!(
+            code,
+            ExecCode::Success,
+            "`set router bgp neighbor <addr> disable-connected-check` must be a valid path — \
+             a silent name collision with an ietf-bgp leaf would show up here as a parse failure",
+        );
+    }
 }

--- a/zebra-rs/yang/zebra-bgp-transport.yang
+++ b/zebra-rs/yang/zebra-bgp-transport.yang
@@ -54,8 +54,12 @@ module zebra-bgp-transport {
 
   revision 2026-06-08 {
     description
-      "Add `tcp-mss <1-65535>` per-neighbor leaf (TCP_MAXSEG clamp).";
-    reference "FRR `neighbor X tcp-mss <N>`; Cisco IOS equivalent.";
+      "Add `tcp-mss <1-65535>` per-neighbor leaf (TCP_MAXSEG clamp), and
+       `disable-connected-check`: let a single-hop eBGP session reach a
+       peer that is not on a directly-connected subnet (e.g. loopback
+       peering across one L2 hop) without raising the TTL.";
+    reference
+      "FRR `neighbor X tcp-mss <N>`; FRR `neighbor X disable-connected-check`.";
   }
 
   revision 2026-05-05 {
@@ -172,6 +176,39 @@ module zebra-bgp-transport {
       reference
         "RFC 879: The TCP Maximum Segment Size and Related Topics.
          RFC 4271: A Border Gateway Protocol 4 (BGP-4).";
+    }
+
+    leaf disable-connected-check {
+      ext:help "Allow a single-hop eBGP peer that is not on a connected subnet";
+      type empty;
+      description
+        "When present, skip the directly-connected-network check for this
+         eBGP neighbor.
+
+         By default a single-hop eBGP session (egress TTL 1, i.e. no
+         ebgp-multihop and no ttl-security) is only brought up when the
+         neighbor's address sits on one of the router's directly-connected
+         subnets. This is the standard safety behaviour: an eBGP peer is
+         expected to be one hop away. A session toward an address reachable
+         only through a static or learned route — most commonly a peer's
+         loopback — is therefore held down.
+
+         `disable-connected-check` removes that requirement while leaving
+         the egress TTL at 1. The intended topology is two routers that are
+         directly connected at layer 2 but peer using addresses (typically
+         loopbacks) that are not on the shared subnet: a TTL-1 packet still
+         reaches the neighbor because no router decrements it, so raising
+         the TTL with ebgp-multihop is unnecessary and would only weaken
+         the single-hop guarantee.
+
+         Enable it on the end(s) that dial the non-connected address. The
+         check applies to eBGP only; iBGP, ebgp-multihop and ttl-security
+         sessions are never gated by it, so the leaf is a no-op there.
+
+         Equivalent to `neighbor X disable-connected-check` in FRR / Cisco
+         IOS (FRR also accepts the legacy spelling `enforce-multihop`).";
+      reference
+        "RFC 4271: A Border Gateway Protocol 4 (BGP-4).";
     }
   }
 


### PR DESCRIPTION
## Summary

zebra-rs had **no** eBGP connected-network check. This adds both the check and its FRR-style override, `neighbor X disable-connected-check`.

A single-hop eBGP peer (eBGP, egress TTL 1 — no `ebgp-multihop`/`ttl-security`) is dialed only when its address sits on a directly-connected subnet; otherwise it is held in `Active`. `disable-connected-check` exempts the neighbor so a session over a non-connected address (e.g. loopback-to-loopback across one L2 hop) establishes at TTL 1 without `ebgp-multihop`.

### Changes
- **YANG**: `disable-connected-check` (`type empty`) in `zebra-bgp-transport.yang`, beside `ebgp-multihop`/`ttl-security` (no ietf-bgp collision; verified by a parse-settability test).
- **Implementation**: new `bgp/connected.rs` (`ConnectedSubnets` registry fed by `RibRx::AddrAdd`/`AddrDel`); cached `Peer.shared_network`; `Peer::connected_check_ok()` gate in `fsm_start`; `Bgp::refresh_connected()` (re-kicks held peers when connectivity appears); config callback + dispatch; `show ip bgp neighbor` line.
- **Book**: `ch-02-16-bgp-disable-connected-check.md` + SUMMARY entry.
- **BDD**: `@bgp_disable_connected_check` — check holds a loopback eBGP session down; the override brings it up and carries routes; explicit teardown.

### Design notes
- Gates the **active** connect only (`fsm_start`), matching FRR's NHT gating; returns `State::Active` (not Idle, which would wedge via the `prev==new` early-return).
- **Fail open** when no interface addresses are known, so per-VRF eBGP and the startup window don't regress. Never bounces an established session on connectivity loss — only blocks new dials.
- iBGP / multihop / GTSM / link-local-unnumbered peers are never gated.

## Test plan
- `cargo test -p zebra-rs` — 458 unit tests pass (registry, gate logic, config callback, YANG parse-settability).
- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
- BDD `@bgp_disable_connected_check` — all 3 scenarios pass on real namespaces; teardown verified clean. Existing eBGP BDDs unaffected (they peer over the connected link).

Generated with [Claude Code](https://claude.com/claude-code)