### PR TITLE
isis: passive interfaces, self-Hello guard, AFI LSP re-originate

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -68,6 +68,14 @@ isis_hello_auth_keychain:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_hello_auth_keychain"
 
+isis_passive:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_passive"
+
+isis_afi_enable:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_afi_enable"
+
 # IS-IS BFD over IPv6. The `_echo` targets exercise the Echo scenarios, which
 # require the IPv6 `xdp-bfd-echo` dataplane helper (built out-of-workspace) and
 # XDP-capable namespaces; the plain targets run only the no-echo scenario.
@@ -169,4 +177,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv3_nssa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise bgp_neighbor_group bgp_unnumbered_neighbor generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv3_nssa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise bgp_neighbor_group bgp_unnumbered_neighbor generate open docs FORCE

--- a/bdd/tests/configs/isis_afi_enable/a1-lo-v6.yaml
+++ b/bdd/tests/configs/isis_afi_enable/a1-lo-v6.yaml
@@ -1,0 +1,31 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: i2
+  ipv4:
+    address: 10.0.12.1/30
+  ipv6:
+    address: 2001:db8:12::1/64
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: a1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i2
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/isis_afi_enable/a1.yaml
+++ b/bdd/tests/configs/isis_afi_enable/a1.yaml
@@ -1,0 +1,29 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: i2
+  ipv4:
+    address: 10.0.12.1/30
+  ipv6:
+    address: 2001:db8:12::1/64
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: a1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+    - if-name: i2
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/isis_afi_enable/a2.yaml
+++ b/bdd/tests/configs/isis_afi_enable/a2.yaml
@@ -1,0 +1,31 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: i1
+  ipv4:
+    address: 10.0.12.2/30
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: a2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/isis_passive/z1.yaml
+++ b/bdd/tests/configs/isis_passive/z1.yaml
@@ -1,0 +1,40 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: i2
+  ipv4:
+    address: 10.0.12.1/30
+  ipv6:
+    address: 2001:db8:12::1/64
+- if-name: i3
+  ipv4:
+    address: 10.0.13.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    is-type: level-2-only
+    hostname: z1
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i2
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i3
+      circuit-type: level-2-only
+      passive: true
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/isis_passive/z2.yaml
+++ b/bdd/tests/configs/isis_passive/z2.yaml
@@ -1,0 +1,31 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: i1
+  ipv4:
+    address: 10.0.12.2/30
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    is-type: level-2-only
+    hostname: z2
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true

--- a/bdd/tests/configs/isis_passive/z3.yaml
+++ b/bdd/tests/configs/isis_passive/z3.yaml
@@ -1,0 +1,27 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: i1
+  ipv4:
+    address: 10.0.13.2/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    is-type: level-2-only
+    hostname: z3
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: i1
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/isis_passive/z4.yaml
+++ b/bdd/tests/configs/isis_passive/z4.yaml
@@ -1,0 +1,36 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.4/32
+  ipv6:
+    address: 2001:db8::4/128
+- if-name: sa
+  ipv4:
+    address: 10.0.44.1/30
+- if-name: sb
+  ipv4:
+    address: 10.0.45.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0004.00
+    is-type: level-2-only
+    hostname: z4
+    interface:
+    - if-name: lo
+      circuit-type: level-2-only
+      ipv4:
+        enable: true
+      ipv6:
+        enable: true
+    - if-name: sa
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: sb
+      circuit-type: level-2-only
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/features/isis_afi_enable.feature
+++ b/bdd/tests/features/isis_afi_enable.feature
@@ -1,0 +1,69 @@
+@isis_afi_enable
+@isis
+Feature: IS-IS re-originates its LSP when an interface address-family is toggled
+  As a network operator
+  I want enabling (or disabling) an address-family on an IS-IS interface to
+  immediately update the self-originated LSP, so a newly-enabled prefix is
+  advertised without waiting for the periodic LSP refresh.
+
+  Regression: enabling IPv6 on a loopback that already had IPv4 enabled used
+  to leave the loopback's IPv6 prefix out of the LSP, because re-origination
+  only fired on a 0<->non-zero *global* protocols-supported (NLPID)
+  transition — and the global IPv6 count was already non-zero thanks to the
+  dual-stack backbone link. The fix re-originates on any per-interface AFI
+  flip.
+
+  Test Topology:
+  ```
+   a1 ───────────── a2
+   i2  10.0.12.0/30  i1
+       2001:db8:12::/64
+   lo 10.0.0.1/32      lo 10.0.0.2/32
+      2001:db8::1/128     2001:db8::2/128
+  ```
+
+  Both routers are level-2-only and the a1–a2 link is dual-stack, so the
+  global IPv6 interface count on a1 is already non-zero. a1's loopback starts
+  with **only IPv4** enabled in IS-IS; its IPv6 address exists on the kernel
+  interface but is not advertised. A later scenario enables IPv6 on a1's
+  loopback at runtime and proves a2 then learns 2001:db8::1/128.
+
+  Scenario: Build the topology — the IPv4 loopback is advertised, the IPv6 loopback is not
+    Given a clean test environment
+    When I create namespace "a1"
+    And I create namespace "a2"
+    And I connect namespace "a1" interface "i2" to namespace "a2" interface "i1"
+    And I start zebra-rs in namespace "a1"
+    And I start zebra-rs in namespace "a2"
+    And I apply config "a1.yaml" to namespace "a1"
+    And I apply config "a2.yaml" to namespace "a2"
+    And I wait 25 seconds
+    Then isis neighbor in namespace "a1" at level 2 on interface "i2" should be up
+    And isis neighbor in namespace "a2" at level 2 on interface "i1" should be up
+    # a1's loopback has IPv4 enabled, so a2 learns 10.0.0.1/32 and can reach it.
+    And show command "show ipv6 route" in namespace "a2" should not contain "2001:db8::1/128"
+    And ping from "a2" to "10.0.0.1" should succeed
+    # a1's loopback IPv6 is NOT enabled in IS-IS yet, so its /128 is absent
+    # from a2's IPv6 table and unreachable (the link's 2001:db8:12::/64 is
+    # still reachable — that interface has IPv6 enabled).
+    And ping from "a2" to "2001:db8::1" should fail
+    And ping from "a2" to "2001:db8:12::1" should succeed
+
+  Scenario: Enabling IPv6 on the loopback re-originates the LSP and advertises the prefix
+    Given the test topology exists
+    # Re-apply a1's config with one line added: `ipv6 enable true` on lo. The
+    # diff-based apply turns that single leaf on. With the fix, a1 immediately
+    # re-originates its L2 LSP carrying 2001:db8::1/128 in the IPv6
+    # Reachability TLV; a2 floods it in, runs SPF, and installs the route.
+    When I apply config "a1-lo-v6.yaml" to namespace "a1"
+    And I wait 10 seconds
+    Then show command "show ipv6 route" in namespace "a2" should contain "2001:db8::1/128"
+    And ping from "a2" to "2001:db8::1" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "a1"
+    And I stop zebra-rs in namespace "a2"
+    And I delete namespace "a1"
+    And I delete namespace "a2"
+    Then the test environment should be clean

--- a/bdd/tests/features/isis_passive.feature
+++ b/bdd/tests/features/isis_passive.feature
@@ -1,0 +1,115 @@
+@isis_passive
+@isis
+Feature: IS-IS passive interfaces and the self-sourced-Hello guard
+  As a network operator
+  I want IS-IS to advertise a loopback / stub prefix without running the
+  Hello protocol on it, and I never want a router to form an adjacency with
+  itself when its own Hellos loop back to it.
+
+  Two independent guarantees are exercised here:
+
+  1. A loopback is implicitly passive, and an explicitly `passive` interface
+     advertises its prefixes into the LSP but sends/processes no Hello PDUs —
+     so no adjacency forms over it, while its subnet is still reachable from
+     the rest of the network.
+
+  2. The self-sourced-IIH guard: if an IIH arrives carrying this router's own
+     system-id (a loopback reflecting its own Hello, an L2 loop, or a
+     duplicate system-id), it is dropped before the neighbor table is
+     touched, so the router never peers with itself.
+
+  Test Topology:
+  ```
+        z3 (IS-IS active, but ISOLATED — z1's side of the link is passive)
+        │
+        │ z3:i1 ── 10.0.13.2/30
+        │ z1:i3 ── 10.0.13.1/30   (PASSIVE on z1)
+        │
+   z2 ══════════════ z1                 z4
+   i1   10.0.12.0/30  i2           sa ─┐  (sa<->sb are one veth pair
+   .2                 .1           sb ─┘   inside z4: a self-loop)
+
+    loopbacks: zI -> 10.0.0.I/32  and  2001:db8::I/128
+  ```
+
+  z1–z2 is an ordinary point-to-point Level-2 backbone link and forms an
+  adjacency. z1–z3 has z1 configured `passive`, so even though z3 runs IS-IS
+  actively it never hears a Hello and z3 stays isolated; z1 still advertises
+  10.0.13.0/30 so z2 can reach it. z4 is wired to itself (sa and sb are the
+  two ends of one veth pair in the same namespace) to force its own Hellos
+  back at it, exercising the self-sourced-IIH guard. Every router also runs
+  IS-IS on its loopback (network-type defaults to LAN, the configuration that
+  used to make a router peer with itself over `lo`).
+
+  All routers are level-2-only.
+
+  Scenario: Build the topology — a real adjacency forms, no router self-peers
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I create namespace "z3"
+    And I create namespace "z4"
+    And I connect namespace "z1" interface "i2" to namespace "z2" interface "i1"
+    And I connect namespace "z1" interface "i3" to namespace "z3" interface "i1"
+    And I connect namespace "z4" interface "sa" to namespace "z4" interface "sb"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I start zebra-rs in namespace "z4"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I apply config "z4.yaml" to namespace "z4"
+    And I wait 25 seconds
+    # The ordinary z1–z2 backbone adjacency comes up at Level-2.
+    Then isis neighbor in namespace "z1" at level 2 on interface "i2" should be up
+    And isis neighbor in namespace "z2" at level 2 on interface "i1" should be up
+    And show command "show isis neighbor" in namespace "z1" should contain "z2"
+    And show command "show isis neighbor" in namespace "z2" should contain "z1"
+    # But neither router forms an adjacency with ITSELF over its loopback.
+    # Before the fix, an IS-IS-enabled loopback echoes its own LAN Hellos
+    # back and the router peers with itself — its own hostname would appear
+    # in its own neighbor table.
+    And show command "show isis neighbor" in namespace "z1" should not contain "z1"
+    And show command "show isis neighbor" in namespace "z2" should not contain "z2"
+    # The loopback prefix is still advertised despite no adjacency on lo, so
+    # the two loopbacks reach each other.
+    And ping from "z1" to "10.0.0.2" should succeed
+    And ping from "z2" to "10.0.0.1" should succeed
+
+  Scenario: A passive interface forms no adjacency but still advertises its prefix
+    Given the test topology exists
+    # z1's i3 toward z3 is `passive`: z1 sends no Hellos there, so even
+    # though z3 runs IS-IS actively no adjacency forms in either direction
+    # and z3 stays isolated (it never receives a Hello to peer with).
+    Then isis neighbor in namespace "z1" at level 2 on interface "i3" should not be up
+    And show command "show isis neighbor" in namespace "z1" should not contain "z3"
+    And show command "show isis neighbor" in namespace "z3" should not contain "z1"
+    # z3 is isolated: its loopback never reaches the backbone.
+    And ping from "z2" to "10.0.0.3" should fail
+    # But the passive interface's own subnet IS advertised by z1 into the L2
+    # LSP (prefix advertisement does not depend on an adjacency). z3 is the
+    # only other router on that subnet and it is isolated, so the only way
+    # z2 can reach z1's address on it is via z1's passive advertisement.
+    And ping from "z2" to "10.0.13.1" should succeed
+
+  Scenario: A self-looped circuit never peers with itself (self-sourced-IIH guard)
+    Given the test topology exists
+    # z4's sa and sb are the two ends of one veth pair inside z4, so every
+    # Hello z4 sends out one end arrives on the other carrying z4's OWN
+    # system-id. The guard drops those before the neighbor table is touched,
+    # so z4 never forms an adjacency with itself — its hostname must not
+    # appear in its own neighbor table.
+    Then show command "show isis neighbor" in namespace "z4" should not contain "z4"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I stop zebra-rs in namespace "z4"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    And I delete namespace "z4"
+    Then the test environment should be clean

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -38,6 +38,7 @@
   - [Clearing IS-IS State](ch-07-04-isis-clear.md)
   - [LSP MTU and Fragmentation](ch-07-05-isis-lsp-mtu.md)
   - [Route Redistribution](ch-07-06-isis-redistribution.md)
+  - [Passive Interfaces](ch-07-07-isis-passive.md)
 - [OSPFv2](ch-08-00-ospf.md)
   - [Configuration](ch-08-01-ospf-configuration.md)
   - [BFD](ch-08-02-ospf-bfd.md)

--- a/book/src/ch-07-07-isis-passive.md
+++ b/book/src/ch-07-07-isis-passive.md
@@ -1,0 +1,111 @@
+# Passive Interfaces
+
+A **passive** IS-IS interface still advertises its IPv4/IPv6 prefixes
+into the router's Link State PDU, but it sends and processes **no Hello
+PDUs** — so it forms no adjacency. This is the standard way to inject a
+loopback or a stub LAN into the IS-IS topology without trying (and
+failing) to find a neighbour on it, and without wasting Hellos on a link
+that has no IS-IS peer.
+
+The classic case is a loopback. You want its address (often a `/32` or
+`/128` used as the router-id, BGP next-hop, or the anchor for a
+Prefix-SID) reachable from the whole area, which means it must appear in
+your LSP — but a loopback has no neighbour to talk to. Worse, a loopback
+*reflects every frame it transmits*: if IS-IS runs the Hello protocol on
+it, the router receives its own Hellos and would form an adjacency **with
+itself**. Marking the interface passive (loopbacks are passive
+automatically — see below) advertises the prefix while keeping the Hello
+machinery off.
+
+## Configuration
+
+`passive` is a per-interface boolean under `router isis`:
+
+```text
+router isis {
+  net 49.0000.0000.0000.0001.00;
+  interface lo {
+    ipv4 {
+      enable true;
+      prefix-sid {
+        index 100;
+      }
+    }
+  }
+  interface eth2 {
+    passive true;          // advertise eth2's subnet, run no Hellos on it
+    ipv4 {
+      enable true;
+    }
+  }
+}
+```
+
+In a YAML configuration the same knob is:
+
+```yaml
+router:
+  isis:
+    interface:
+    - if-name: eth2
+      passive: true
+      ipv4:
+        enable: true
+```
+
+What `passive` changes, and what it does not:
+
+- **No Hellos** are sent on the interface, and incoming Hellos are
+  ignored, so **no adjacency** ever forms over it.
+- The interface's prefixes **are still advertised** into the LSP. Prefix
+  advertisement is gated on the interface being IS-IS-enabled
+  (`ipv4`/`ipv6 enable`) and participating at the circuit's level — not
+  on any adjacency — so a passive circuit's subnet stays reachable from
+  the rest of the network.
+- Any Prefix-SID configured on the interface is advertised as usual.
+
+Toggling `passive` bounces the circuit: an adjacency that had formed
+while it was active is torn down, the self-LSP is re-originated, and SPF
+is re-run.
+
+## Loopbacks are implicitly passive
+
+A loopback interface is treated as passive **even when `passive` is not
+set**. Running the Hello protocol on a loopback would make the router
+peer with itself (the loopback echoes its own Hellos), which is never
+useful, so zebra-rs suppresses Hellos on every loopback and still
+advertises its prefixes. You therefore do **not** need to write `passive
+true` on `lo`; enabling IS-IS (`ipv4 { enable true; }`) is enough to get
+the loopback advertised.
+
+## The self-sourced-Hello guard
+
+Independently of the passive setting, IS-IS **drops any received Hello
+whose source system-id is the router's own**. A router must never form an
+adjacency with itself, and a self-sourced Hello can arrive in several
+ways:
+
+- a loopback (or any interface) reflecting its own Hello,
+- an L2 loop in the network looping a Hello back, or
+- a duplicate system-id misconfiguration.
+
+In all of these the Hello is discarded before the neighbour table is
+touched, so no spurious self-adjacency is ever created. This guard is a
+safety net that complements the passive/loopback Hello suppression
+above.
+
+## Verification
+
+A passive interface shows no neighbour, and a router never lists *itself*
+as a neighbour:
+
+```text
+> show isis neighbor
+System Id    Interface   L  State    Holdtime  SNPA
+z2           eth1        2  Up       27        001c.42e8.0c23
+```
+
+The passive interface (and the loopback) are absent from the neighbour
+list, and the local router's own hostname never appears there — while
+its loopback/stub prefixes are present in `show isis database` and
+reachable from peers.

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1349,4 +1349,37 @@ mod yang_load_tests {
              a silent name collision with an ietf-bgp leaf would show up here as a parse failure",
         );
     }
+
+    /// The IS-IS per-interface `passive` leaf must be a settable path.
+    /// It is hand-added to `config.yang` (no YANG generator), so a typo in
+    /// the leaf or its placement would otherwise only surface at runtime —
+    /// `load_mode` above loads the module but does not exercise the path.
+    #[test]
+    fn isis_interface_passive_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        let (code, _comps, _state) = parse(
+            "set router isis interface eth0 passive true",
+            entry,
+            None,
+            State::new(),
+        );
+        assert_eq!(
+            code,
+            ExecCode::Success,
+            "`set router isis interface <name> passive true` must be a valid settable path",
+        );
+    }
 }

--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -254,6 +254,7 @@ impl Isis {
             "/router/isis/interface/network-type",
             link::config_network_type,
         );
+        self.callback_add("/router/isis/interface/passive", link::config_passive);
         self.callback_add(
             "/router/isis/interface/hello/interval",
             link::config_hello_interval,

--- a/zebra-rs/src/isis/ifsm.rs
+++ b/zebra-rs/src/isis/ifsm.rs
@@ -8,7 +8,6 @@ use crate::isis::link::DisStatus;
 use crate::isis::network::P2P_ISS;
 use crate::isis_pdu_trace;
 use crate::rib::MacAddr;
-use crate::rib::link_ext::LinkFlagsExt;
 
 use super::auth;
 use super::config::IsisAuthType;
@@ -331,6 +330,15 @@ pub fn hello_send(link: &mut LinkTop, level: Level) -> Result<()> {
         return Ok(());
     }
 
+    // Passive circuit (operator-set `passive`, or any loopback): never
+    // emit Hellos. This is the single choke point for Hello transmission,
+    // so guarding here suppresses both the immediate send in
+    // `hello_originate` and the periodic `HelloTimerExpire` path, no
+    // matter which config callback armed them.
+    if link.is_passive() {
+        return Ok(());
+    }
+
     let hello = if link.config.network_type() == NetworkType::P2p {
         IsisPdu::P2pHello(hello_p2p_generate(link, level))
     } else {
@@ -411,6 +419,14 @@ pub fn has_level(is_level: IsLevel, level: Level) -> bool {
 }
 
 pub fn hello_originate(link: &mut LinkTop, level: Level) {
+    // Passive circuits (incl. loopbacks) run no Hello protocol: don't
+    // send, and make sure no periodic timer survives a transition into
+    // passive. `hello_send` guards too, but clearing the timer here
+    // avoids arming a no-op repeat.
+    if link.is_passive() {
+        *link.timer.hello.get_mut(&level) = None;
+        return;
+    }
     if has_level(link.state.level(), level) {
         // hello_send regenerates the PDU itself; we only send one
         // immediately and (re-)arm the periodic timer here.
@@ -420,7 +436,10 @@ pub fn hello_originate(link: &mut LinkTop, level: Level) {
 }
 
 pub fn start(link: &mut LinkTop) {
-    if link.flags.is_loopback() {
+    // Passive circuits (operator-set `passive`, or any loopback) run no
+    // Hello protocol, so there is nothing to start. Non-passive links
+    // arm Hellos per level below.
+    if link.is_passive() {
         return;
     }
     for level in [Level::L1, Level::L2] {

--- a/zebra-rs/src/isis/link.rs
+++ b/zebra-rs/src/isis/link.rs
@@ -194,6 +194,19 @@ impl<'a> LinkTop<'a> {
         !self.is_p2p()
     }
 
+    /// A passive circuit runs no Hello protocol: it advertises its
+    /// prefixes into the LSP but never sends or processes Hellos, so it
+    /// forms no adjacency. True when the operator set `passive`, and
+    /// always true for loopback interfaces (a loopback reflects its own
+    /// Hellos straight back, so running the protocol on it would form a
+    /// spurious adjacency with this router itself). The Hello send path
+    /// (`ifsm::hello_send` / `hello_originate` / `start`) and the Hello
+    /// receive path (`packet::hello_recv` / `hello_p2p_recv`) both gate
+    /// on this.
+    pub fn is_passive(&self) -> bool {
+        self.config.passive || self.flags.is_loopback()
+    }
+
     pub fn dest(&self, level: Level) -> Option<MacAddr> {
         if self.is_p2p() {
             if let Some((_, mac)) = self.state.adj.get(&level) {
@@ -223,6 +236,13 @@ pub struct LinkConfig {
 
     /// Link type one of LAN or Point-to-point.
     pub network_type: Option<NetworkType>,
+
+    /// Passive circuit (`/router/isis/interface/<name>/passive`). When
+    /// set, the interface's prefixes are still advertised into the LSP
+    /// but no Hello PDUs are sent or processed, so no adjacency forms.
+    /// `LinkTop::is_passive()` also folds in loopback interfaces, which
+    /// are implicitly passive regardless of this flag.
+    pub passive: bool,
 
     // Metric of this Link.
     pub metric: Option<u32>,
@@ -1061,27 +1081,27 @@ fn config_afi_enable(isis: &mut Isis, mut args: Args, op: ConfigOp, afi: Afi) ->
     // Currently IS-IS is enabled on this interface.
     let enabled = link.config.enabled();
 
-    // Capture the global per-AFI count before mutation so we can detect a
-    // zero ↔ non-zero transition, which is what flips the AFI's NLPID in
-    // the Protocols Supported TLV (RFC 1195) of our self-originated LSP.
-    let count_before = *isis.config.enable.get(&afi);
-
+    // The global per-AFI interface count drives the AFI's NLPID in the
+    // Protocols Supported TLV (RFC 1195) of our self-originated LSP, so
+    // keep it in step with each interface's enable. `link_afi_changed`
+    // records whether THIS interface's participation actually flipped — it
+    // gates the LSP re-origination below.
+    let mut link_afi_changed = false;
     if op.is_set() && enable {
         // Set Enable.
         if !*link.config.enable.get(&afi) {
             *link.config.enable.get_mut(&afi) = true;
             *isis.config.enable.get_mut(&afi) += 1;
+            link_afi_changed = true;
         }
     } else {
         // Set Disable.
         if *link.config.enable.get(&afi) {
             *link.config.enable.get_mut(&afi) = false;
             *isis.config.enable.get_mut(&afi) -= 1;
+            link_afi_changed = true;
         }
     }
-
-    let count_after = *isis.config.enable.get(&afi);
-    let support_changed = (count_before == 0) != (count_after == 0);
 
     if !enabled {
         if link.config.enabled() {
@@ -1097,14 +1117,25 @@ fn config_afi_enable(isis: &mut Isis, mut args: Args, op: ConfigOp, afi: Afi) ->
         }
     }
 
-    if support_changed {
+    // Re-originate the self-LSP whenever this interface's participation in
+    // the AFI flips. The prefixes carried in the IP / IPv6 Reachability
+    // TLVs depend on which interfaces have the AFI enabled (and, on a
+    // 0<->non-zero *global* transition, so does the Protocols Supported /
+    // NLPID TLV). Gating only on the global transition missed the common
+    // case — e.g. `set router isis interface lo ipv6 enable true` while
+    // another interface already carries IPv6 — leaving the loopback's IPv6
+    // prefix out of the LSP until the next periodic refresh. The per-level
+    // guard skips a level whose self-LSP hasn't been originated yet (e.g.
+    // L1 on a level-2-only instance, or before the first origination);
+    // at runtime the relevant level always exists.
+    if link_afi_changed {
         let key = IsisLspId::new(isis.config.net.sys_id(), 0, 0);
         if isis.lsdb.get(&Level::L1).get(&key).is_some() {
             isis_event_trace!(
                 isis.tracing,
                 LspOriginate,
                 &Level::L1,
-                "LSP Originate L1 due to protocols-supported change"
+                "LSP Originate L1 due to interface address-family change"
             );
             isis.tx
                 .send(Message::LspOriginate(Level::L1, None))
@@ -1115,7 +1146,7 @@ fn config_afi_enable(isis: &mut Isis, mut args: Args, op: ConfigOp, afi: Afi) ->
                 isis.tracing,
                 LspOriginate,
                 &Level::L2,
-                "LSP Originate L2 due to protocols-supported change"
+                "LSP Originate L2 due to interface address-family change"
             );
             isis.tx
                 .send(Message::LspOriginate(Level::L2, None))
@@ -1420,6 +1451,37 @@ pub fn config_network_type(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Opt
     if let Some(mut top) = isis.link_top(ifindex) {
         ifsm::hello_originate(&mut top, Level::L1);
         ifsm::hello_originate(&mut top, Level::L2);
+    }
+
+    Some(())
+}
+
+/// `set router isis interface <name> passive <bool>` — toggle a passive
+/// circuit. A passive interface keeps advertising its prefixes (the LSP
+/// build gates on `enable.v4`/`enable.v6` + level, not on any adjacency)
+/// but the Hello send/receive paths gate on `LinkTop::is_passive()`, so
+/// no Hello flows and no adjacency forms.
+///
+/// Toggling bounces the link (`link_state_down` + `link_state_up`): that
+/// drops any adjacency formed while the circuit was active — including
+/// the spurious self-adjacency a non-passive loopback creates when its
+/// own Hellos loop back — re-originates the self-LSP, and reschedules
+/// SPF. Unsetting it lets the normal Start path re-arm Hellos and rebuild
+/// adjacencies.
+pub fn config_passive(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let passive = args.boolean()?;
+
+    let (ifindex, changed) = {
+        let link = isis.links.get_mut_by_name(&name)?;
+        let old = link.config.passive;
+        link.config.passive = op.is_set() && passive;
+        (link.ifindex, old != link.config.passive)
+    };
+
+    if changed {
+        isis.link_state_down(ifindex);
+        isis.link_state_up(ifindex);
     }
 
     Some(())

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -323,6 +323,24 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
         return;
     }
 
+    // Passive circuit (operator-set `passive`, or any loopback): run no
+    // Hello protocol, so ignore inbound IIHs too — a passive interface
+    // forms no adjacency in either direction.
+    if link.is_passive() {
+        isis_pdu_trace!(link, &level, "[Hello:Recv] passive interface — ignored");
+        return;
+    }
+
+    // Self-sourced IIH guard. If the IIH's source system-id is our own,
+    // the Hello looped back to us (a loopback reflects its own frames; an
+    // L2 loop or a duplicate system-id misconfig can do the same). Never
+    // form an adjacency with ourselves — drop it before touching the
+    // neighbor table.
+    if pdu.source_id == link.up_config.net.sys_id() {
+        isis_pdu_trace!(link, &level, "[Hello:Recv] self-sourced IIH — ignored");
+        return;
+    }
+
     // Check link type.
     if !link.is_lan() {
         isis_pdu_trace!(
@@ -584,6 +602,30 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
 
     // Our manual area, for the per-level Level-1 area gate below.
     let our_area = link.up_config.net.area_id();
+
+    // Passive circuit (operator-set `passive`, or any loopback): run no
+    // Hello protocol, so ignore inbound IIHs too. Level-independent, so
+    // check once before the per-level loop.
+    if link.is_passive() {
+        isis_pdu_trace!(
+            link,
+            &Level::L2,
+            "[Hello P2P:Recv] passive interface — ignored"
+        );
+        return;
+    }
+
+    // Self-sourced IIH guard — see `hello_recv`. If the IIH's source
+    // system-id is our own, the Hello looped back to us; never form an
+    // adjacency with ourselves. Level-independent.
+    if pdu.source_id == link.up_config.net.sys_id() {
+        isis_pdu_trace!(
+            link,
+            &Level::L2,
+            "[Hello P2P:Recv] self-sourced IIH — ignored"
+        );
+        return;
+    }
 
     // Process the Hello for each compatible level
     for level in [Level::L1, Level::L2] {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1797,6 +1797,18 @@ module config {
             }
           }
 
+          leaf passive {
+            type boolean;
+            description
+              "Run this interface as a passive IS-IS circuit: its
+               IPv4/IPv6 prefixes are still advertised into the LSP,
+               but no Hello PDUs are sent or processed, so no
+               adjacency forms (not even with this router itself when
+               its own Hellos loop back). Typically set on loopbacks
+               and stub links. Loopback interfaces are implicitly
+               passive even when this leaf is unset.";
+          }
+
           leaf priority {
             type uint8;
           }
@@ -2228,6 +2240,14 @@ module config {
                 enum lan;
                 enum point-to-point;
               }
+            }
+            leaf passive {
+              type boolean;
+              description
+                "Passive IS-IS circuit: advertise the interface's
+                 prefixes but send/process no Hello PDUs (no
+                 adjacency). See the top-level interface's `passive`
+                 leaf.";
             }
             leaf priority {
               type uint8;


### PR DESCRIPTION
## Summary

Fixes the loopback "peering with itself" issue (a router formed an IS-IS
adjacency with its own system-id over `lo`) plus a related LSP
re-origination bug, all in the IS-IS interface-config path.

- **Self-sourced-Hello guard** — `hello_recv` / `hello_p2p_recv` drop any
  IIH whose source system-id is our own (loopback echo, L2 loop,
  duplicate sys-id), so a router never forms an adjacency with itself.
- **Passive interfaces** — new `/router/isis/interface/passive` leaf
  (main + VRF). A passive circuit advertises its prefixes but sends and
  processes no Hellos, so it forms no adjacency. Loopbacks are implicitly
  passive. Prefix advertisement is independent of adjacency, so the
  loopback prefix / Prefix-SID is unaffected.
- **AFI re-origination** — re-originate the self-LSP on any per-interface
  address-family enable flip, not only on the global protocols-supported
  (NLPID) transition. `set router isis interface lo ipv6 enable true` now
  advertises lo's IPv6 Reachability TLV immediately.

## Test plan

- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Unit: 153 IS-IS tests + YANG-load suite, incl. new
  `isis_interface_passive_is_settable` parse guard.
- BDD: `@isis_passive` (4 scenarios) and `@isis_afi_enable` (3 scenarios)
  pass; `@isis_l1l2` regression (10 scenarios) green.
- Docs: `book/src/ch-07-07-isis-passive.md` + SUMMARY entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)