### PR TITLE
isis: gate SRv6 End.X on neighbor IPv6; rename SID owner column

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -76,6 +76,10 @@ isis_afi_enable:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@isis_afi_enable"
 
+isis_endx_ipv6:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@isis_endx_ipv6"
+
 # IS-IS BFD over IPv6. The `_echo` targets exercise the Echo scenarios, which
 # require the IPv6 `xdp-bfd-echo` dataplane helper (built out-of-workspace) and
 # XDP-capable namespaces; the plain targets run only the no-echo scenario.
@@ -177,4 +181,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv3_nssa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise bgp_neighbor_group bgp_unnumbered_neighbor generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv3_nssa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise bgp_neighbor_group bgp_unnumbered_neighbor generate open docs FORCE

--- a/bdd/tests/configs/isis_endx_ipv6/x1-v6.conf
+++ b/bdd/tests/configs/isis_endx_ipv6/x1-v6.conf
@@ -1,0 +1,48 @@
+interface lo {
+  ipv4 {
+    address 10.0.0.1/32;
+  }
+  ipv6 {
+    address 2001:db8::1/128;
+  }
+}
+interface i2 {
+  ipv4 {
+    address 10.0.12.1/30;
+  }
+  ipv6 {
+    address 2001:db8:12::1/64;
+  }
+}
+router {
+  isis {
+    net 49.0000.0000.0000.0001.00;
+    is-type level-2-only;
+    segment-routing {
+      srv6 {
+        locator LX1;
+      }
+    }
+    interface lo {
+      circuit-type level-2-only;
+      ipv4 {
+        enable true;
+      }
+    }
+    interface i2 {
+      circuit-type level-2-only;
+      network-type point-to-point;
+      ipv4 {
+        enable true;
+      }
+      ipv6 {
+        enable true;
+      }
+    }
+  }
+}
+segment-routing {
+  locator LX1 {
+    prefix fcbb:1::/64;
+  }
+}

--- a/bdd/tests/configs/isis_endx_ipv6/x1.conf
+++ b/bdd/tests/configs/isis_endx_ipv6/x1.conf
@@ -1,0 +1,45 @@
+interface lo {
+  ipv4 {
+    address 10.0.0.1/32;
+  }
+  ipv6 {
+    address 2001:db8::1/128;
+  }
+}
+interface i2 {
+  ipv4 {
+    address 10.0.12.1/30;
+  }
+  ipv6 {
+    address 2001:db8:12::1/64;
+  }
+}
+router {
+  isis {
+    net 49.0000.0000.0000.0001.00;
+    is-type level-2-only;
+    segment-routing {
+      srv6 {
+        locator LX1;
+      }
+    }
+    interface lo {
+      circuit-type level-2-only;
+      ipv4 {
+        enable true;
+      }
+    }
+    interface i2 {
+      circuit-type level-2-only;
+      network-type point-to-point;
+      ipv4 {
+        enable true;
+      }
+    }
+  }
+}
+segment-routing {
+  locator LX1 {
+    prefix fcbb:1::/64;
+  }
+}

--- a/bdd/tests/configs/isis_endx_ipv6/x2-v6.conf
+++ b/bdd/tests/configs/isis_endx_ipv6/x2-v6.conf
@@ -1,0 +1,38 @@
+interface lo {
+  ipv4 {
+    address 10.0.0.2/32;
+  }
+  ipv6 {
+    address 2001:db8::2/128;
+  }
+}
+interface i1 {
+  ipv4 {
+    address 10.0.12.2/30;
+  }
+  ipv6 {
+    address 2001:db8:12::2/64;
+  }
+}
+router {
+  isis {
+    net 49.0000.0000.0000.0002.00;
+    is-type level-2-only;
+    interface lo {
+      circuit-type level-2-only;
+      ipv4 {
+        enable true;
+      }
+    }
+    interface i1 {
+      circuit-type level-2-only;
+      network-type point-to-point;
+      ipv4 {
+        enable true;
+      }
+      ipv6 {
+        enable true;
+      }
+    }
+  }
+}

--- a/bdd/tests/configs/isis_endx_ipv6/x2.conf
+++ b/bdd/tests/configs/isis_endx_ipv6/x2.conf
@@ -1,0 +1,35 @@
+interface lo {
+  ipv4 {
+    address 10.0.0.2/32;
+  }
+  ipv6 {
+    address 2001:db8::2/128;
+  }
+}
+interface i1 {
+  ipv4 {
+    address 10.0.12.2/30;
+  }
+  ipv6 {
+    address 2001:db8:12::2/64;
+  }
+}
+router {
+  isis {
+    net 49.0000.0000.0000.0002.00;
+    is-type level-2-only;
+    interface lo {
+      circuit-type level-2-only;
+      ipv4 {
+        enable true;
+      }
+    }
+    interface i1 {
+      circuit-type level-2-only;
+      network-type point-to-point;
+      ipv4 {
+        enable true;
+      }
+    }
+  }
+}

--- a/bdd/tests/features/isis_endx_ipv6.feature
+++ b/bdd/tests/features/isis_endx_ipv6.feature
@@ -1,0 +1,73 @@
+@isis_endx_ipv6
+@isis
+Feature: IS-IS SRv6 End.X (adjacency) SID is gated on the neighbor's IPv6
+  As a network operator
+  I want an SRv6 End.X adjacency SID to be allocated only for a neighbor that
+  can actually forward IPv6 — one that advertises the IPv6 NLPID in its
+  Protocols Supported TLV AND gives us an IPv6 link-local nexthop — and I want
+  that decision re-evaluated as the neighbor's capability changes, so enabling
+  IPv6 on an already-Up adjacency starts advertising an End.X without a flap.
+
+  Test Topology:
+  ```
+   x1 ───────────────── x2
+   i2  10.0.12.0/30      i1
+       2001:db8:12::/64
+   lo 10.0.0.1/32        lo 10.0.0.2/32
+   SRv6 locator LX1
+   (fcbb:1::/64)
+  ```
+
+  x1 runs SRv6 with a classic locator, so it owns an End SID and would carve
+  an End.X for each IPv6-capable adjacency. The x1–x2 IS-IS circuit starts
+  IPv4-only (IS-IS `ipv4 enable` only), so x2 advertises no IPv6 and x1 must
+  NOT allocate an End.X for it. A later scenario enables IPv6 on the circuit;
+  x2 then advertises IPv6 and x1 allocates the End.X by re-evaluation.
+
+  This also pins the `show segment-routing srv6 sid` column rename: the owner
+  column is "Protocol" and the value is "isis" (no instance suffix).
+
+  Scenario: Build the topology — an IPv4-only neighbor gets no End.X SID
+    Given a clean test environment
+    When I create namespace "x1"
+    And I create namespace "x2"
+    And I connect namespace "x1" interface "i2" to namespace "x2" interface "i1"
+    And I start zebra-rs in namespace "x1"
+    And I start zebra-rs in namespace "x2"
+    And I apply config "x1.conf" to namespace "x1"
+    And I apply config "x2.conf" to namespace "x2"
+    And I wait 35 seconds
+    Then isis neighbor in namespace "x1" at level 2 on interface "i2" should be up
+    # x1's SRv6 is up: its locator End SID is present in the registry.
+    And show command "show segment-routing srv6 sid" in namespace "x1" should contain "End"
+    # The column rename: header is "Protocol" and the owner renders as plain
+    # "isis", not "isis(0)" (no protocol-instance support).
+    And show command "show segment-routing srv6 sid" in namespace "x1" should contain "Protocol"
+    And show command "show segment-routing srv6 sid" in namespace "x1" should contain "isis"
+    And show command "show segment-routing srv6 sid" in namespace "x1" should not contain "isis(0)"
+    # x2 is IPv4-only on this circuit, so no End.X (adjacency) SID is carved.
+    And show command "show segment-routing srv6 sid" in namespace "x1" should not contain "End.X"
+    # And nothing is advertised: x2's LSDB sees no End.X in x1's LSP.
+    And show command "show isis database detail" in namespace "x2" should not contain "SRv6 End.X SID"
+
+  Scenario: Enabling IPv6 on the neighbor re-evaluates and allocates the End.X SID
+    Given the test topology exists
+    # Turn IPv6 on for the IS-IS circuit at both ends. The diff-based apply
+    # adds `ipv6 enable true`; the adjacency stays Up. x2 now advertises the
+    # IPv6 NLPID and an IPv6 link-local, so x1 re-evaluates this neighbor,
+    # allocates an End.X SID, and re-originates its LSP.
+    When I apply config "x1-v6.conf" to namespace "x1"
+    And I apply config "x2-v6.conf" to namespace "x2"
+    And I wait 20 seconds
+    Then show command "show segment-routing srv6 sid" in namespace "x1" should contain "End.X"
+    # The LSP was re-originated (no flap), so x2 now learns the End.X SID
+    # in x1's LSP — proving the change is advertised, not just allocated.
+    And show command "show isis database detail" in namespace "x2" should contain "SRv6 End.X SID"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "x1"
+    And I stop zebra-rs in namespace "x2"
+    And I delete namespace "x1"
+    And I delete namespace "x2"
+    Then the test environment should be clean

--- a/zebra-rs/src/isis/neigh.rs
+++ b/zebra-rs/src/isis/neigh.rs
@@ -101,14 +101,57 @@ impl Neighbor {
         self.tx.send(message).unwrap();
     }
 
-    /// Make sure this neighbor has an End.X SID allocated and
-    /// registered with the RIB. Idempotent — if a SID is already
-    /// recorded, returns immediately.
+    /// Does this neighbor advertise the IPv6 NLPID (0x8E) in its
+    /// Protocols Supported TLV (RFC 1195)? An End.X SID forwards over
+    /// IPv6, so a neighbor that doesn't speak IPv6 must not get one.
+    fn advertises_ipv6(&self) -> bool {
+        let ipv6: u8 = IsisProto::Ipv6.into();
+        self.proto
+            .as_ref()
+            .is_some_and(|p| p.nlpids.contains(&ipv6))
+    }
+
+    /// Eligible for an SRv6 End.X (adjacency) SID: the neighbor both
+    /// advertises IPv6 (Protocols Supported TLV) AND has given us an
+    /// IPv6 link-local (its IPv6 IIH address TLV, TLV 232) to use as the
+    /// forwarding nexthop. Either can appear or disappear across Hellos —
+    /// an IPv4-only neighbor that later enables IPv6, or vice versa — so
+    /// `reconcile_endx_sid` re-checks this on every Hello.
+    fn endx_eligible(&self) -> bool {
+        self.advertises_ipv6() && !self.addr6l.is_empty()
+    }
+
+    /// Re-originate the self-LSP (both levels; the per-level guard in
+    /// `process_lsp_originate` drops the one this instance doesn't run)
+    /// when the adjacency is already Up, so an End.X SID allocated or
+    /// released *after* the adjacency came up reaches the LSP without
+    /// waiting for the periodic refresh. While the adjacency is still
+    /// coming up the normal Up-transition (DIS election / AdjacencyUp)
+    /// re-originates for us, so we skip the redundant emit here.
+    fn reoriginate_endx_if_up(&self) {
+        if self.state == NfsmState::Up {
+            let _ = self.tx.send(Message::LspOriginate(Level::L1, None));
+            let _ = self.tx.send(Message::LspOriginate(Level::L2, None));
+        }
+    }
+
+    /// Reconcile this neighbor's End.X (adjacency) SID against its
+    /// current eligibility ([`Neighbor::endx_eligible`]).
     ///
-    /// Skipped silently when the locator isn't resolved (no prefix to
-    /// derive a SID from) or when ELIB is exhausted; the next Hello
-    /// re-tries with whatever state has changed since.
-    pub fn ensure_endx_sid(
+    /// - Eligible but no SID yet → allocate one and register it with the
+    ///   RIB. Skipped silently when the locator isn't resolved (no prefix
+    ///   to derive a SID from) or when ELIB is exhausted; the next Hello
+    ///   retries with whatever state changed since.
+    /// - Not eligible but a SID is held (the neighbor stopped advertising
+    ///   IPv6, or withdrew its IPv6 link-local) → release it so our LSP
+    ///   stops advertising an End.X we have no IPv6 nexthop to forward
+    ///   over.
+    ///
+    /// Called on every Hello (after `nbr_hello_interpret` refreshes the
+    /// neighbor's protocols / addresses), so a change in the neighbor's
+    /// IPv6 capability is picked up at the next Hello and, if the
+    /// adjacency is Up, the LSP re-originated immediately.
+    pub fn reconcile_endx_sid(
         &mut self,
         ifname: &str,
         sr_locator: &Option<Locator>,
@@ -116,6 +159,17 @@ impl Neighbor {
         elib: &mut ElibPool,
         rib_client: &crate::rib::client::RibClient,
     ) {
+        if !self.endx_eligible() {
+            // No IPv6 forwarding path to this neighbor (no IPv6 in its
+            // Protocols Supported TLV, or no IPv6 link-local in its
+            // Hello). Drop any SID we previously allocated.
+            if self.endx_sid.is_some() {
+                self.release_endx_sid(elib, rib_client);
+                self.reoriginate_endx_if_up();
+            }
+            return;
+        }
+
         if self.endx_sid.is_some() {
             return;
         }
@@ -137,12 +191,9 @@ impl Neighbor {
             elib.release(function);
             return;
         };
-        // End.X needs an IPv6 nexthop — by convention the neighbor's
-        // link-local from its IPv6 IIH address TLV. If we haven't
-        // heard one yet (IPv4-only deployment, or Hellos arrived
-        // before the IPv6 addr exchange), the SID still registers so
-        // the LSP advertises the capability, but `nh6: None` will
-        // tell the FIB to skip the seg6local install.
+        // End.X forwards to the neighbor's IPv6 link-local (from its
+        // IPv6 IIH address TLV). `endx_eligible` guarantees `addr6l` is
+        // non-empty, so this nexthop is always present here.
         let nh6 = self.addr6l.first().copied();
         let (behavior, structure) = match locator.behavior {
             Some(crate::rib::LocatorBehavior::Usid) => (SidBehavior::UA, locator.sid_structure()),
@@ -164,6 +215,7 @@ impl Neighbor {
         };
         let _ = rib_client.send(rib::Message::SidAdd { sid });
         self.endx_sid = Some((function, addr));
+        self.reoriginate_endx_if_up();
     }
 
     /// Release the neighbor's End.X SID, sending a SidDel and freeing
@@ -450,4 +502,50 @@ pub fn show_detail(
     }
 
     Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_neighbor() -> Neighbor {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        Neighbor::new(tx, 1, NetworkType::P2p, IsisSysId::default(), None)
+    }
+
+    // SRv6 End.X eligibility: a neighbor needs BOTH the IPv6 NLPID in its
+    // Protocols Supported TLV AND an IPv6 link-local (the forwarding
+    // nexthop) before we carve it an End.X SID.
+    #[test]
+    fn endx_eligible_requires_ipv6_proto_and_linklocal() {
+        let v4: u8 = IsisProto::Ipv4.into();
+        let v6: u8 = IsisProto::Ipv6.into();
+        let ll: Ipv6Addr = "fe80::1".parse().unwrap();
+
+        // Nothing learned yet.
+        let mut nbr = test_neighbor();
+        assert!(!nbr.endx_eligible());
+
+        // IPv6 in protocols but no link-local nexthop → not eligible.
+        nbr.proto = Some(IsisTlvProtoSupported {
+            nlpids: vec![v4, v6],
+        });
+        assert!(!nbr.endx_eligible());
+
+        // Link-local present but protocols are IPv4-only → not eligible.
+        nbr.proto = Some(IsisTlvProtoSupported { nlpids: vec![v4] });
+        nbr.addr6l = vec![ll];
+        assert!(!nbr.endx_eligible());
+
+        // Both present → eligible.
+        nbr.proto = Some(IsisTlvProtoSupported {
+            nlpids: vec![v4, v6],
+        });
+        assert!(nbr.endx_eligible());
+
+        // Losing IPv6 from the protocols (peer disabled IPv6) drops
+        // eligibility again — the re-evaluation path that releases a SID.
+        nbr.proto = Some(IsisTlvProtoSupported { nlpids: vec![v4] });
+        assert!(!nbr.endx_eligible());
+    }
 }

--- a/zebra-rs/src/isis/packet.rs
+++ b/zebra-rs/src/isis/packet.rs
@@ -462,7 +462,7 @@ pub fn hello_recv(link: &mut LinkTop, level: Level, pdu: IsisHello, mac: Option<
     if helper_entered {
         nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
     }
-    nbr.ensure_endx_sid(
+    nbr.reconcile_endx_sid(
         &ifname,
         link.sr_locator,
         link.watched_locator,
@@ -719,7 +719,7 @@ pub fn hello_p2p_recv(link: &mut LinkTop, pdu: IsisP2pHello, mac: Option<MacAddr
         if helper_entered {
             nbr.event(Message::Ifsm(HelloOriginate, nbr.ifindex, Some(level)));
         }
-        nbr.ensure_endx_sid(
+        nbr.reconcile_endx_sid(
             &ifname,
             link.sr_locator,
             link.watched_locator,

--- a/zebra-rs/src/rib/segment_routing/sid.rs
+++ b/zebra-rs/src/rib/segment_routing/sid.rs
@@ -146,10 +146,11 @@ impl fmt::Display for SidAllocationType {
     }
 }
 
-/// Owner of a SID, rendered as "isis(0)" / "bgp(0)" in the show table.
-/// The instance number gives operators a hook for future multi-instance
-/// support (separate L1 / L2 IS-IS instances, multiple BGP VRFs, ...);
-/// today every protocol passes 0.
+/// Owner of a SID, rendered by the protocol name alone ("isis" / "bgp")
+/// in the show table. The instance number is retained as a hook for
+/// future multi-instance support (separate L1 / L2 IS-IS instances,
+/// multiple BGP VRFs, ...) but is not displayed today — every protocol
+/// passes 0 and there is no protocol-instance support yet.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SidOwner {
     pub proto: String,
@@ -167,7 +168,10 @@ impl SidOwner {
 
 impl fmt::Display for SidOwner {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}({})", self.proto, self.instance)
+        // Protocol name only. zebra-rs has no protocol-instance support
+        // (`instance` is always 0), so an `isis(0)`-style suffix would be
+        // noise in `show segment-routing srv6 sid` and the install logs.
+        write!(f, "{}", self.proto)
     }
 }
 
@@ -304,9 +308,10 @@ mod tests {
     }
 
     #[test]
-    fn owner_renders_with_instance_in_parens() {
-        assert_eq!(SidOwner::new("isis", 0).to_string(), "isis(0)");
-        assert_eq!(SidOwner::new("bgp", 1).to_string(), "bgp(1)");
+    fn owner_renders_protocol_name_only() {
+        // No protocol-instance support, so the instance is not shown.
+        assert_eq!(SidOwner::new("isis", 0).to_string(), "isis");
+        assert_eq!(SidOwner::new("bgp", 1).to_string(), "bgp");
     }
 
     #[test]

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1793,7 +1793,7 @@ fn sid_show_text(sids: &std::collections::BTreeMap<std::net::Ipv6Addr, super::Si
         sid = "SID",
         behavior = "Behavior",
         context = "Context",
-        owner = "Daemon/Instance",
+        owner = "Protocol",
         loc = "Locator",
         alloc = "AllocationType",
         sid_w = SID_COL,
@@ -2026,7 +2026,9 @@ mod tests {
             body[1]
         );
         for line in &body {
-            assert!(line.contains("isis(0)"));
+            // Protocol name only — no `isis(0)` instance suffix.
+            assert!(line.contains("isis"));
+            assert!(!line.contains("isis(0)"));
             assert!(line.contains("LOC_N1"));
             assert!(line.contains("dynamic"));
         }


### PR DESCRIPTION
## Summary

Two SRv6-SID changes in the IS-IS path.

- **Gate SRv6 End.X on the neighbor's IPv6.** `ensure_endx_sid` →
  `reconcile_endx_sid` (neigh.rs). An End.X (adjacency) SID is allocated
  only when the neighbor can actually forward IPv6 — it advertises the
  IPv6 NLPID in its Protocols Supported TLV **and** offers an IPv6
  link-local (the End.X nexthop). It is **released** when eligibility is
  lost, and re-checked on every Hello, so enabling/disabling IPv6 on a
  neighbor is picked up at the next Hello. When the SID changes on an
  already-Up adjacency the self-LSP is re-originated (`reoriginate_endx_if_up`)
  so the change is advertised without a flap. Previously an End.X was
  carved for every adjacency, including IPv4-only neighbors (registered
  with `nh6: None`).

- **`show segment-routing srv6 sid` column rename.** Header
  `Daemon/Instance` → `Protocol`, and `SidOwner`'s Display drops the
  always-zero instance (`isis(0)` → `isis`) — zebra-rs has no
  protocol-instance support.

## Test plan

- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Unit: 154 IS-IS tests incl. new `endx_eligible_requires_ipv6_proto_and_linklocal`;
  SID-show tests updated for the rename.
- BDD `@isis_endx_ipv6` (3 scenarios): an IPv4-only neighbor gets no
  End.X (SID registry **and** the peer's LSDB); enabling IPv6 on the
  circuit allocates the End.X and floods it to the peer
  (`SRv6 End.X SID` appears in the peer's `show isis database detail`);
  the renamed `Protocol` / `isis` (not `isis(0)`) output is asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)