### PR TITLE
bfd: gate all task tracing behind `set bfd tracing`

### DIFF
--- a/book/src/ch-10-00-bfd.md
+++ b/book/src/ch-10-00-bfd.md
@@ -182,6 +182,34 @@ receive path is alive).
 
 Each command also accepts a trailing `json` for machine-readable output.
 
+## Tracing
+
+The BFD task is quiet by default. A single runtime flag turns on its
+diagnostic traces — session FSM transitions, control-packet handling, and
+the Echo reflector (`xdp-bfd-echo`) lifecycle:
+
+```
+set bfd tracing true     # enable
+set bfd tracing false    # disable (or: delete bfd tracing)
+```
+
+It is a runtime toggle — no restart, and no rebuild — backed by a single
+global flag, so it also covers the parts of BFD that run outside the main
+task (the socket read/write tasks and the per-interface Echo reflector
+IPC). It is not per-session or per-interface; it is on or off for the
+whole BFD task.
+
+The info- and warn-level traces appear at the **default** log level once
+the flag is on, so `set bfd tracing true` is usually enough. The more
+verbose per-packet, debug-level traces additionally need the log level
+raised (e.g. `RUST_LOG=debug`), matching their original verbosity. With
+the flag off, every BFD trace is suppressed regardless of `RUST_LOG`.
+
+This is distinct from the per-protocol BFD tracing under
+`router bgp tracing { bfd }`, `router isis tracing { bfd }`, etc., which
+trace how *that protocol* reacts to BFD events; `set bfd tracing` traces
+the BFD task itself.
+
 ## Echo function
 
 The BFD **Echo function** (RFC 5880 §6.4 / RFC 5881 §6) is a forwarding-plane

--- a/zebra-rs/src/bfd/config.rs
+++ b/zebra-rs/src/bfd/config.rs
@@ -1,11 +1,13 @@
 //! BFD session defaults.
 //!
-//! BFD has no configuration of its own: sessions are configured per-protocol
-//! (`neighbor X bfd`, `ip ospf bfd`, `isis bfd`) and created / torn down by
-//! those modules through [`super::inst::ClientReq::Subscribe`] /
+//! BFD has almost no configuration of its own: sessions are configured
+//! per-protocol (`neighbor X bfd`, `ip ospf bfd`, `isis bfd`) and created /
+//! torn down by those modules through [`super::inst::ClientReq::Subscribe`] /
 //! `Unsubscribe`. The BFD task is spawned eagerly by the first such protocol
-//! (see [`crate::config::manager`]); there is no top-level `bfd { … }` block and
-//! no `/bfd/*` config leaves, so the instance registers no config callbacks.
+//! (see [`crate::config::manager`]). The one top-level leaf it owns is
+//! `bfd { tracing }` (the conditional-tracing toggle, see [`super::trace`]),
+//! handled directly in [`super::inst::Bfd::process_cm_msg`] rather than through
+//! a callback table.
 //!
 //! The constants here are the FRR-aligned defaults every protocol-driven
 //! session starts with — see [`super::session::SessionParams::default`].

--- a/zebra-rs/src/bfd/inst.rs
+++ b/zebra-rs/src/bfd/inst.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
-use crate::config::{Args, ConfigChannel, DisplayRequest, ShowChannel, path_from_command};
+use crate::config::{
+    Args, ConfigChannel, ConfigOp, ConfigRequest, DisplayRequest, ShowChannel, path_from_command,
+};
 use crate::context::{ProtoContext, Task};
 
 use super::fsm::Event;
@@ -13,6 +15,7 @@ use super::network::{WriteRequest, read_packet, read_packet_v6, write_packet, wr
 use super::session::{Session, SessionKey, SessionParams, SessionTable, StateChange};
 use super::socket::{BFD_MULTI_HOP_PORT, BFD_SINGLE_HOP_PORT, bfd_socket_ipv4, bfd_socket_ipv6};
 use super::timer::{InitialParams, TimerCmd, session_timer};
+use super::trace::{bfd_debug, bfd_info, bfd_warn};
 
 /// Identifier for a BFD subscriber. Conventionally the proto name
 /// ("bgp", "ospf", "isis", "static"), plus an optional disambiguator
@@ -29,8 +32,9 @@ pub type ShowCallback = fn(&Bfd, Args, bool) -> Result<String, std::fmt::Error>;
 /// session table, a per-session timer handle map, and the
 /// client-subscription registry. Read and write tasks are tokio-spawned
 /// at construction and feed the event loop via `main_tx` / `write_tx`.
-/// BFD has no config of its own; the config-manager subscription is just
-/// drained through `cm.rx`, and external clients (BGP / OSPF / IS-IS /
+/// BFD's only own config is the top-level `bfd { tracing }` flag (handled
+/// via `cm.rx` in [`Self::process_cm_msg`]); every other config-manager
+/// broadcast is drained, and external clients (BGP / OSPF / IS-IS /
 /// static) submit subscribe/unsubscribe requests through `client_req.rx`.
 pub struct Bfd {
     pub rx: UnboundedReceiver<Message>,
@@ -39,10 +43,11 @@ pub struct Bfd {
     /// that bind to ephemeral ports — `local_addr.port()` reveals the
     /// kernel-chosen value so the peer can be told where to send.
     pub local_addr: SocketAddrV4,
-    /// Config-manager subscription endpoints. BFD has no config of its own,
-    /// but it registers as a config client (so the manager can tell it is
-    /// already running and avoid a double-spawn); the receive half is just
-    /// drained in the event loop.
+    /// Config-manager subscription endpoints. BFD's only own config is the
+    /// `bfd { tracing }` flag; the receive half is processed in the event
+    /// loop ([`Self::process_cm_msg`]) and every other commit is drained.
+    /// Registering as a config client also lets the manager see BFD is
+    /// already running and avoid a double-spawn.
     pub cm: ConfigChannel,
     /// `show bfd ...` subscription endpoints. The receive half drains
     /// in the event loop and dispatches through [`Self::show_cb`].
@@ -226,7 +231,7 @@ impl Bfd {
                         read_packet(mh_sock, mh_tx, true).await;
                     });
                 }
-                Err(e) => tracing::warn!(
+                Err(e) => bfd_warn!(
                     "bfd: multihop listener on {BFD_MULTI_HOP_PORT} unavailable, \
                      single-hop only: {e}"
                 ),
@@ -257,7 +262,7 @@ impl Bfd {
                         write_packet_v6(sock6, write_rx_v6).await;
                     });
                 }
-                Err(e) => tracing::warn!(
+                Err(e) => bfd_warn!(
                     "bfd: IPv6 single-hop listener on {BFD_SINGLE_HOP_PORT} unavailable, \
                      IPv4 only: {e}"
                 ),
@@ -275,7 +280,7 @@ impl Bfd {
                         read_packet_v6(mh6, mh_tx, true).await;
                     });
                 }
-                Err(e) => tracing::warn!(
+                Err(e) => bfd_warn!(
                     "bfd: IPv6 multihop listener on {BFD_MULTI_HOP_PORT} unavailable: {e}"
                 ),
             }
@@ -447,6 +452,21 @@ impl Bfd {
 
     /// Look up the show handler for `msg.paths` and invoke it. Mirrors
     /// [`crate::ospf`]/[`crate::isis`]'s `process_show_msg`.
+    /// BFD's only own config is the top-level `bfd { tracing }` flag, which
+    /// toggles the conditional-tracing gate (see [`super::trace`]). Every
+    /// other broadcast config line is ignored. The flag is a process-global
+    /// atomic so it reaches the spawned socket / reflector tasks too.
+    fn process_cm_msg(&mut self, msg: ConfigRequest) {
+        if !matches!(msg.op, ConfigOp::Set | ConfigOp::Delete) {
+            return;
+        }
+        let (path, mut args) = path_from_command(&msg.paths);
+        if path == "/bfd/tracing" {
+            let enabled = msg.op.is_set() && args.boolean().unwrap_or(false);
+            super::trace::set(enabled);
+        }
+    }
+
     async fn process_show_msg(&self, msg: DisplayRequest) {
         let (path, args) = path_from_command(&msg.paths);
         if let Some(f) = self.show_cb.get(&path) {
@@ -468,10 +488,10 @@ impl Bfd {
                     Message::DetectExpired { key } => self.on_detect_expired(key),
                     Message::EchoDown { discr } => self.on_echo_down(discr),
                 },
-                // BFD has no config of its own — just drain the commit
-                // broadcasts so the channel doesn't back up (we register as a
-                // config client only so the manager knows BFD is running).
-                Some(_) = self.cm.rx.recv() => {}
+                // BFD's only config is the top-level `bfd { tracing }` flag;
+                // every other commit broadcast is drained here (we register as
+                // a config client so the manager knows BFD is running).
+                Some(msg) = self.cm.rx.recv() => self.process_cm_msg(msg),
                 Some(msg) = self.show.rx.recv() => {
                     self.process_show_msg(msg).await;
                 }
@@ -497,7 +517,7 @@ impl Bfd {
             self.bootstrap_lookup(src, ifindex, multihop)
         };
         let Some(key) = lookup else {
-            tracing::debug!(
+            bfd_debug!(
                 ?src,
                 ?dst,
                 ifindex,
@@ -521,7 +541,7 @@ impl Bfd {
             if let Some(session) = self.sessions.get_by_key_mut(&key) {
                 session.stats.rx_invalid_count += 1;
             }
-            tracing::debug!(
+            bfd_debug!(
                 ?src,
                 ?dst,
                 ifindex,
@@ -544,7 +564,7 @@ impl Bfd {
                 .expect("just looked up by key");
             if ttl < session.min_ttl {
                 session.stats.rx_invalid_count += 1;
-                tracing::debug!(
+                bfd_debug!(
                     ?src,
                     ?dst,
                     ttl,
@@ -770,7 +790,7 @@ impl Bfd {
     }
 
     fn notify_state_change(&self, key: SessionKey, change: StateChange) {
-        tracing::info!(
+        bfd_info!(
             ?key,
             from = %change.from,
             to = %change.to,

--- a/zebra-rs/src/bfd/mod.rs
+++ b/zebra-rs/src/bfd/mod.rs
@@ -17,6 +17,7 @@ pub mod session;
 pub mod show;
 pub mod socket;
 pub mod timer;
+pub(crate) mod trace;
 
 #[cfg(test)]
 mod integration;

--- a/zebra-rs/src/bfd/network.rs
+++ b/zebra-rs/src/bfd/network.rs
@@ -11,6 +11,7 @@ use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use super::inst::Message;
+use super::trace::bfd_debug;
 
 /// Egress request consumed by [`write_packet`] (v4) / [`write_packet_v6`]
 /// (v6). The event loop pushes these whenever a
@@ -85,7 +86,7 @@ pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<Message
                 let packet = match bfd_packet::ControlPacket::parse(payload) {
                     Ok(p) => p,
                     Err(e) => {
-                        tracing::debug!(?src, error = %e, "bfd: invalid control packet");
+                        bfd_debug!(?src, error = %e, "bfd: invalid control packet");
                         return Ok(());
                     }
                 };
@@ -221,7 +222,7 @@ pub async fn read_packet_v6(
                 let packet = match bfd_packet::ControlPacket::parse(payload) {
                     Ok(p) => p,
                     Err(e) => {
-                        tracing::debug!(?src, error = %e, "bfd: invalid control packet");
+                        bfd_debug!(?src, error = %e, "bfd: invalid control packet");
                         return Ok(());
                     }
                 };

--- a/zebra-rs/src/bfd/reflector.rs
+++ b/zebra-rs/src/bfd/reflector.rs
@@ -27,6 +27,7 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use crate::context::Task;
 
 use super::inst::Message;
+use super::trace::{bfd_debug, bfd_info, bfd_warn};
 
 /// Env override for the reflector binary path (mirrors vtypam's
 /// `ZEBRA_VTYPAM_BIN`). Falls back to the install locations.
@@ -60,7 +61,7 @@ impl Reflector {
             unsafe {
                 libc::kill(pid as libc::pid_t, libc::SIGTERM);
             }
-            tracing::info!("bfd echo: stopping reflector on {}", self.ifname);
+            bfd_info!("bfd echo: stopping reflector on {}", self.ifname);
         }
     }
 
@@ -152,7 +153,7 @@ impl EchoReflectors {
 
     fn spawn(&self, ifindex: u32) -> Reflector {
         let Some(ifname) = if_indextoname(ifindex) else {
-            tracing::warn!("bfd echo: no interface name for ifindex {ifindex}; reflector off");
+            bfd_warn!("bfd echo: no interface name for ifindex {ifindex}; reflector off");
             return Reflector {
                 refcount: 1,
                 child: None,
@@ -172,7 +173,7 @@ impl EchoReflectors {
             .spawn()
         {
             Ok(mut child) => {
-                tracing::info!(
+                bfd_info!(
                     "bfd echo: spawned reflector on {ifname} (ifindex {ifindex}, mode {})",
                     self.mode
                 );
@@ -201,7 +202,7 @@ impl EchoReflectors {
                 }
             }
             Err(e) => {
-                tracing::warn!(
+                bfd_warn!(
                     "bfd echo: failed to spawn {} on {ifname}: {e}",
                     self.bin.display()
                 );
@@ -252,7 +253,7 @@ async fn child_io(
             },
         }
     }
-    tracing::debug!("bfd echo: IPC task for {ifname} ended");
+    bfd_debug!("bfd echo: IPC task for {ifname} ended");
 }
 
 /// Parse a `echo-down <discr>` event line from the helper.

--- a/zebra-rs/src/bfd/trace.rs
+++ b/zebra-rs/src/bfd/trace.rs
@@ -1,0 +1,58 @@
+//! Conditional tracing for the BFD task.
+//!
+//! Every trace emitted under `src/bfd/` is gated behind a single runtime flag,
+//! toggled with `set bfd tracing true`. The flag is a process-global atomic so
+//! the gate works from every BFD context — the instance methods, the spawned
+//! socket read/write tasks, and the per-interface `xdp-bfd-echo` reflector IPC
+//! tasks — without threading state through each call site.
+//!
+//! Use the level-preserving macros [`bfd_info!`], [`bfd_warn!`] and
+//! [`bfd_debug!`] in place of `tracing::{info,warn,debug}!`; each expands to a
+//! no-op unless the flag is set. So `set bfd tracing true` surfaces the info /
+//! warn traces at the default log level; the debug traces additionally need
+//! the log level raised (e.g. `RUST_LOG=debug`), matching their original
+//! verbosity.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Whether `set bfd tracing true` is in effect. Defaults off.
+static BFD_TRACING: AtomicBool = AtomicBool::new(false);
+
+/// Set from the `/bfd/tracing` config handler on commit.
+pub(crate) fn set(enabled: bool) {
+    BFD_TRACING.store(enabled, Ordering::Relaxed);
+}
+
+/// Read by the `bfd_*` tracing macros before emitting.
+pub(crate) fn enabled() -> bool {
+    BFD_TRACING.load(Ordering::Relaxed)
+}
+
+/// `tracing::info!`, gated on `set bfd tracing true`.
+macro_rules! bfd_info {
+    ($($arg:tt)*) => {
+        if $crate::bfd::trace::enabled() {
+            ::tracing::info!($($arg)*);
+        }
+    };
+}
+
+/// `tracing::warn!`, gated on `set bfd tracing true`.
+macro_rules! bfd_warn {
+    ($($arg:tt)*) => {
+        if $crate::bfd::trace::enabled() {
+            ::tracing::warn!($($arg)*);
+        }
+    };
+}
+
+/// `tracing::debug!`, gated on `set bfd tracing true`.
+macro_rules! bfd_debug {
+    ($($arg:tt)*) => {
+        if $crate::bfd::trace::enabled() {
+            ::tracing::debug!($($arg)*);
+        }
+    };
+}
+
+pub(crate) use {bfd_debug, bfd_info, bfd_warn};

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1382,4 +1382,31 @@ mod yang_load_tests {
             "`set router isis interface <name> passive true` must be a valid settable path",
         );
     }
+
+    /// The top-level `bfd { tracing }` flag (conditional-tracing toggle) must
+    /// be a settable path. It's a hand-added top-level container in
+    /// `config.yang`; the BFD task reads it off the config broadcast.
+    #[test]
+    fn bfd_tracing_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        let (code, _comps, _state) = parse("set bfd tracing true", entry, None, State::new());
+        assert_eq!(
+            code,
+            ExecCode::Success,
+            "`set bfd tracing true` must be a valid settable path",
+        );
+    }
 }

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -346,6 +346,19 @@ module config {
       uses "vty:vty";
     }
 
+    container bfd {
+      ext:help "BFD (Bidirectional Forwarding Detection) configuration";
+      leaf tracing {
+        type boolean;
+        description
+          "Enable conditional tracing for the BFD task. When true, the
+           BFD task emits its info / warn / debug traces (session FSM,
+           packet handling, Echo reflector lifecycle); when false
+           (the default) they are suppressed. Runtime toggle, no
+           restart needed: `set bfd tracing true`.";
+      }
+    }
+
     container affinity-map {
       ext:help "Named affinity (admin-group) table";
       // Global named affinity table (RFC 7308 Extended Admin Group).


### PR DESCRIPTION
## Summary

Adds a single runtime flag, `set bfd tracing true`, that gates every trace
emitted by the BFD task. Off by default; toggled at runtime with no restart
or rebuild.

- New top-level `bfd { tracing }` YANG leaf. BFD already receives every
  config broadcast (it previously drained them); `inst.rs` now has a
  `process_cm_msg` that sets the flag on `/bfd/tracing`.
- New `bfd/trace.rs`: a process-global `AtomicBool` plus level-preserving
  `bfd_info!` / `bfd_warn!` / `bfd_debug!` macros — each a no-op unless the
  flag is set. Global rather than threaded because BFD also traces from the
  spawned socket read/write tasks and the per-interface `xdp-bfd-echo`
  reflector IPC task, which hold no instance handle.
- All 14 `tracing::{info,warn,debug}!` calls under `src/bfd/` replaced with
  the gated macros (level preserved).

info/warn traces appear at the default log level once enabled; the verbose
debug traces additionally need `RUST_LOG=debug`. This is distinct from the
per-protocol `router … tracing { bfd }` toggles, which trace how a protocol
reacts to BFD events; `set bfd tracing` traces the BFD task itself.

## Test plan

- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Full `cargo test --workspace --exclude bdd` passes; BFD unit tests 103/103;
  new `bfd_tracing_is_settable` YANG parse guard.
- `mdbook build` succeeds (new "Tracing" section in `ch-10-00-bfd.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)