### PR TITLE
bgp: RFC 9252 Prefix-SID fidelity + treat-as-withdraw

### DIFF
--- a/crates/bgp-packet/src/attrs/attr.rs
+++ b/crates/bgp-packet/src/attrs/attr.rs
@@ -228,12 +228,19 @@ impl fmt::Debug for Attr {
 }
 
 impl Attr {
-    pub fn parse_attr<'a>(
-        input: &'a [u8],
-        as4: bool,
-        opt: &'a Option<ParseOption>,
-    ) -> Result<(&'a [u8], Attr), BgpParseError> {
-        // Parse the attribute flags and type code
+    /// Parse one attribute's framing — flags, type code, and length — and
+    /// split its Value off the front of `input`, returning the Value
+    /// slice plus the remaining input positioned at the next attribute.
+    ///
+    /// A framing error (truncated header, or a length that overruns the
+    /// attribute block) is unrecoverable and propagates: per RFC 7606 §4
+    /// an attribute-length error prevents parsing the rest of the
+    /// attributes and forces a session reset. Errors parsing the Value
+    /// itself are handled separately by `parse_attr_value`, which lets
+    /// the caller recover (treat-as-withdraw) where the RFC allows it.
+    fn parse_attr_header(
+        input: &[u8],
+    ) -> Result<(&[u8], AttrType, AttributeFlags, &[u8]), BgpParseError> {
         let (input, flags_byte) = be_u8(input)?;
         let flags = AttributeFlags::from_bits_truncate(flags_byte);
         let (input, attr_type_byte) = be_u8(input)?;
@@ -251,43 +258,74 @@ impl Attr {
             [0, length_bytes[0]]
         });
 
-        // Only AS_PATH or AGGREGATOR care about as4 extension
-        let as4_opt = matches!(attr_type, AttrType::AsPath | AttrType::Aggregator).then_some(as4);
-
         // Split out the payload for this attribute
         let (input, attr_payload) =
             packet_utils::safe_split_at(input, attr_len as usize).map_err(BgpParseError::from)?;
+        Ok((input, attr_type, flags, attr_payload))
+    }
+
+    /// Parse the Value of one attribute given its already-decoded framing.
+    /// A failure here is recoverable by the caller for attributes whose
+    /// RFC 7606 error action is treat-as-withdraw (see
+    /// [`attr_malformation_is_withdraw`]).
+    fn parse_attr_value(
+        attr_type: AttrType,
+        attr_payload: &[u8],
+        as4: bool,
+        opt: &Option<ParseOption>,
+    ) -> Result<Attr, BgpParseError> {
+        // Only AS_PATH or AGGREGATOR care about as4 extension
+        let as4_opt = matches!(attr_type, AttrType::AsPath | AttrType::Aggregator).then_some(as4);
 
         // Parse the attribute using the appropriate selector with error context
-        let (_, attr) = match attr_type {
+        let attr = match attr_type {
             AttrType::MpReachNlri => {
-                let (remaining, mp_reach) = MpReachAttr::parse_nlri_opt(attr_payload, opt.clone())
+                let (_, mp_reach) = MpReachAttr::parse_nlri_opt(attr_payload, opt.clone())
                     .map_err(|e| BgpParseError::AttributeParseError {
                         attr_type,
                         source: Box::new(BgpParseError::from(e)),
                     })?;
-                (remaining, Attr::MpReachNlri(mp_reach))
+                Attr::MpReachNlri(mp_reach)
             }
             AttrType::MpUnreachNlri => {
-                let (remaining, mp_unreach) =
-                    MpUnreachAttr::parse_nlri_opt(attr_payload, opt.clone()).map_err(|e| {
-                        BgpParseError::AttributeParseError {
-                            attr_type,
-                            source: Box::new(BgpParseError::from(e)),
-                        }
+                let (_, mp_unreach) = MpUnreachAttr::parse_nlri_opt(attr_payload, opt.clone())
+                    .map_err(|e| BgpParseError::AttributeParseError {
+                        attr_type,
+                        source: Box::new(BgpParseError::from(e)),
                     })?;
-                (remaining, Attr::MpUnreachNlri(mp_unreach))
+                Attr::MpUnreachNlri(mp_unreach)
             }
-            _ => Attr::parse_be(attr_payload, AttrSelector(attr_type, as4_opt)).map_err(|e| {
-                BgpParseError::AttributeParseError {
-                    attr_type,
-                    source: Box::new(BgpParseError::from(e)),
-                }
-            })?,
+            _ => {
+                Attr::parse_be(attr_payload, AttrSelector(attr_type, as4_opt))
+                    .map_err(|e| BgpParseError::AttributeParseError {
+                        attr_type,
+                        source: Box::new(BgpParseError::from(e)),
+                    })?
+                    .1
+            }
         };
+        Ok(attr)
+    }
 
+    pub fn parse_attr<'a>(
+        input: &'a [u8],
+        as4: bool,
+        opt: &'a Option<ParseOption>,
+    ) -> Result<(&'a [u8], Attr), BgpParseError> {
+        let (input, attr_type, _flags, attr_payload) = Attr::parse_attr_header(input)?;
+        let attr = Attr::parse_attr_value(attr_type, attr_payload, as4, opt)?;
         Ok((input, attr))
     }
+}
+
+/// Whether a malformed instance of `attr_type` should be handled by the
+/// RFC 7606 "treat-as-withdraw" action rather than by resetting the BGP
+/// session. The BGP Prefix-SID attribute uses treat-as-withdraw per
+/// RFC 8669 §5 and RFC 9252 §7 (a malformed SRv6 Service TLV must not
+/// tear the session down). Other attributes keep their existing
+/// (session-reset) handling.
+fn attr_malformation_is_withdraw(attr_type: AttrType) -> bool {
+    matches!(attr_type, AttrType::PrefixSid)
 }
 
 type ParsedAttributes<'a> = Result<
@@ -296,6 +334,10 @@ type ParsedAttributes<'a> = Result<
         Option<BgpAttr>,
         Option<MpReachAttr>,
         Option<MpUnreachAttr>,
+        // RFC 7606 treat-as-withdraw: set when a recoverable attribute
+        // (e.g. a malformed BGP Prefix-SID) was discarded, so the caller
+        // withdraws the UPDATE's reachable NLRI instead of installing.
+        bool,
     ),
     BgpParseError,
 >;
@@ -312,9 +354,26 @@ pub fn parse_bgp_update_attribute(
     let mut bgp_attr = BgpAttr::default();
     let mut mp_update: Option<MpReachAttr> = None;
     let mut mp_withdraw: Option<MpUnreachAttr> = None;
+    let mut treat_as_withdraw = false;
 
     while !remaining.is_empty() {
-        let (new_remaining, attr) = Attr::parse_attr(remaining, as4, &opt)?;
+        // Parse the framing first so a Value-parse error stays recoverable:
+        // `new_remaining` already points at the next attribute.
+        let (new_remaining, attr_type, _flags, attr_payload) = Attr::parse_attr_header(remaining)?;
+        let attr = match Attr::parse_attr_value(attr_type, attr_payload, as4, &opt) {
+            Ok(attr) => attr,
+            Err(e) => {
+                if attr_malformation_is_withdraw(attr_type) {
+                    // RFC 7606 / RFC 9252 §7: discard the malformed
+                    // attribute and treat the UPDATE's reachable NLRI as
+                    // withdrawn, keeping the session up.
+                    treat_as_withdraw = true;
+                    remaining = new_remaining;
+                    continue;
+                }
+                return Err(e);
+            }
+        };
         match attr {
             Attr::Origin(v) => {
                 bgp_attr.origin = Some(v);
@@ -419,7 +478,13 @@ pub fn parse_bgp_update_attribute(
         remaining = new_remaining;
     }
 
-    Ok((input, Some(bgp_attr), mp_update, mp_withdraw))
+    Ok((
+        input,
+        Some(bgp_attr),
+        mp_update,
+        mp_withdraw,
+        treat_as_withdraw,
+    ))
 }
 
 #[cfg(test)]
@@ -435,5 +500,41 @@ mod tests {
             BgpParseError::IncompleteData { needed } => assert_eq!(needed, 4),
             other => panic!("unexpected error: {other:?}"),
         }
+    }
+
+    #[test]
+    fn malformed_prefix_sid_triggers_treat_as_withdraw_not_session_reset() {
+        // A valid ORIGIN attribute followed by a BGP Prefix-SID (type 40)
+        // whose SRv6 L3 Service TLV carries an under-length (5 < 21) SID
+        // Information sub-TLV. Per RFC 9252 §7 / RFC 8669 §5 the malformed
+        // Prefix-SID must be discarded and the UPDATE treated-as-withdraw
+        // — NOT reset the session. So the parse succeeds, ORIGIN survives,
+        // the Prefix-SID is gone, and the withdraw flag is set.
+        let mut block = vec![0x40, 0x01, 0x01, 0x00]; // ORIGIN = IGP
+        let service_value = [0x00, 0x01, 0x00, 0x05, 0x01, 0x02, 0x03, 0x04, 0x05];
+        let mut psid_value = vec![5u8, 0x00, service_value.len() as u8]; // SRv6 L3 Service TLV
+        psid_value.extend_from_slice(&service_value);
+        block.push(0xC0); // optional + transitive
+        block.push(40); // type = PrefixSid
+        block.push(psid_value.len() as u8);
+        block.extend_from_slice(&psid_value);
+
+        let len = block.len() as u16;
+        let (_, bgp_attr, mp_update, mp_withdraw, treat_as_withdraw) =
+            parse_bgp_update_attribute(&block, len, false, None).expect("must not reset session");
+        assert!(
+            treat_as_withdraw,
+            "malformed Prefix-SID must treat-as-withdraw"
+        );
+        let bgp_attr = bgp_attr.expect("attrs parsed");
+        assert!(
+            bgp_attr.origin.is_some(),
+            "ORIGIN must survive the recovery"
+        );
+        assert!(
+            bgp_attr.prefix_sid.is_none(),
+            "malformed Prefix-SID must be discarded"
+        );
+        assert!(mp_update.is_none() && mp_withdraw.is_none());
     }
 }

--- a/crates/bgp-packet/src/attrs/prefix_sid.rs
+++ b/crates/bgp-packet/src/attrs/prefix_sid.rs
@@ -15,6 +15,26 @@ pub const SRV6_BEHAVIOR_END_DT6: u16 = 0x0012;
 pub const SRV6_BEHAVIOR_END_DT4: u16 = 0x0013;
 pub const SRV6_BEHAVIOR_END_DT46: u16 = 0x0014;
 
+/// BGP Prefix-SID TLV Types (IANA "BGP Prefix-SID TLV Types", RFC 8669 /
+/// RFC 9252 §8.1).
+const PREFIX_SID_TLV_LABEL_INDEX: u8 = 1;
+const PREFIX_SID_TLV_ORIGINATOR_SRGB: u8 = 3;
+const PREFIX_SID_TLV_SRV6_L3_SERVICE: u8 = 5;
+const PREFIX_SID_TLV_SRV6_L2_SERVICE: u8 = 6;
+
+/// SRv6 Service Sub-TLV Type for the SID Information sub-TLV (RFC 9252
+/// §3.1 / §8.2).
+const SRV6_SUBTLV_SID_INFO: u8 = 1;
+/// SRv6 Service Data Sub-Sub-TLV Type for the SID Structure sub-sub-TLV
+/// (RFC 9252 §3.2.1 / §8.3).
+const SRV6_SUBSUBTLV_SID_STRUCTURE: u8 = 1;
+/// Minimum SID Information sub-TLV Value length: RESERVED1(1) + SID(16) +
+/// Flags(1) + Behavior(2) + RESERVED2(1). RFC 9252 §7 deems the sub-TLV
+/// malformed below this.
+const SRV6_SID_INFO_MIN_LEN: usize = 21;
+/// Fixed Value length of the SID Structure sub-sub-TLV (RFC 9252 §3.2.1).
+const SRV6_SID_STRUCTURE_LEN: usize = 6;
+
 /// BGP Prefix-SID path attribute (type 40, RFC 8669) plus SRv6 service
 /// extensions (RFC 9252).
 ///
@@ -57,24 +77,77 @@ pub enum PrefixSidTlv {
     Unknown { typ: u8, value: Vec<u8> },
 }
 
-/// An SRv6 Service TLV body (RFC 9252 §2): an ordered list of SRv6 SID
-/// Information sub-TLVs. The L3VPN case carries exactly one.
+/// An SRv6 Service TLV body (RFC 9252 §2): a leading RESERVED octet then
+/// an unordered list of SRv6 Service sub-TLVs. The L3VPN case carries
+/// exactly one SID Information sub-TLV.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct Srv6ServiceTlv {
+    /// Leading RESERVED octet (RFC 9252 §2). A sender MUST set it to 0; a
+    /// receiver MUST ignore it but MUST propagate it unchanged, so we
+    /// keep the received value rather than forcing 0 on re-emit.
+    pub reserved: u8,
+    /// SRv6 SID Information sub-TLVs (type 1), in receive order.
     pub sids: Vec<Srv6SidInfo>,
+    /// Sub-TLVs whose Type we don't model, preserved verbatim. RFC 9252
+    /// §2 requires unrecognized sub-TLVs to be propagated further when
+    /// the BGP next hop is unchanged. They are re-emitted after the
+    /// modelled SID sub-TLVs — the list is unordered per §2, so this is
+    /// conformant.
+    pub unknown_sub_tlvs: Vec<RawSubTlv>,
+}
+
+/// A TLV-encoded element (an SRv6 Service sub-TLV or sub-sub-TLV) whose
+/// Type this implementation does not model. `value` excludes the
+/// 3-octet `type(1) | length(2)` header. Preserved so the attribute can
+/// be re-emitted unchanged when propagated with the next hop unchanged
+/// (RFC 9252 §2).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RawSubTlv {
+    pub typ: u8,
+    pub value: Vec<u8>,
 }
 
 /// SRv6 SID Information Sub-TLV (RFC 9252 §3.1).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Srv6SidInfo {
+    /// RESERVED1 (RFC 9252 §3.1). MUST be 0 on origination; preserved
+    /// verbatim on receive for propagation.
+    pub reserved1: u8,
     /// The 16-byte SRv6 SID value (e.g. an End.DT46 SID).
     pub sid: Ipv6Addr,
     /// SRv6 Service SID Flags.
     pub flags: u8,
     /// SRv6 Endpoint Behavior (one of the `SRV6_BEHAVIOR_*` codepoints).
     pub behavior: u16,
+    /// RESERVED2 (RFC 9252 §3.1). MUST be 0 on origination; preserved
+    /// verbatim on receive for propagation.
+    pub reserved2: u8,
     /// SRv6 SID Structure Sub-Sub-TLV, when present.
     pub structure: Option<Srv6SidStructure>,
+    /// Sub-sub-TLVs whose Type we don't model, preserved verbatim
+    /// (RFC 9252 §2). Re-emitted after the SID Structure sub-sub-TLV.
+    pub unknown_sub_sub_tlvs: Vec<RawSubTlv>,
+}
+
+impl Srv6SidInfo {
+    /// Build a SID Information sub-TLV the way a producer originates it:
+    /// zeroed RESERVED octets and no unknown sub-sub-TLVs.
+    pub fn new(
+        sid: Ipv6Addr,
+        flags: u8,
+        behavior: u16,
+        structure: Option<Srv6SidStructure>,
+    ) -> Self {
+        Self {
+            reserved1: 0,
+            sid,
+            flags,
+            behavior,
+            reserved2: 0,
+            structure,
+            unknown_sub_sub_tlvs: Vec::new(),
+        }
+    }
 }
 
 /// SRv6 SID Structure Sub-Sub-TLV (RFC 9252 §3.2.1) — the bit-length
@@ -118,7 +191,7 @@ impl ParseBe<PrefixSid> for PrefixSid {
 
 fn decode_tlv(typ: u8, value: &[u8]) -> IResult<&[u8], PrefixSidTlv> {
     match typ {
-        1 => {
+        PREFIX_SID_TLV_LABEL_INDEX => {
             // Label-Index TLV: reserved(1) | flags(2) | label_index(4) = 7 octets.
             let (rest, _reserved) = be_u8(value)?;
             let (rest, flags) = be_u16(rest)?;
@@ -134,7 +207,7 @@ fn decode_tlv(typ: u8, value: &[u8]) -> IResult<&[u8], PrefixSidTlv> {
             }
             Ok((rest, PrefixSidTlv::LabelIndex { flags, label_index }))
         }
-        3 => {
+        PREFIX_SID_TLV_ORIGINATOR_SRGB => {
             // Originator-SRGB TLV: flags(2) | SRGB(6) repeating.
             let (mut rest, flags) = be_u16(value)?;
             if rest.len() % 6 != 0 {
@@ -152,13 +225,13 @@ fn decode_tlv(typ: u8, value: &[u8]) -> IResult<&[u8], PrefixSidTlv> {
             }
             Ok((rest, PrefixSidTlv::OriginatorSrgb { flags, srgbs }))
         }
-        5 => {
-            let (_, svc) = decode_srv6_service(value)?;
-            Ok((&[], PrefixSidTlv::Srv6L3Service(svc)))
+        PREFIX_SID_TLV_SRV6_L3_SERVICE => {
+            let (rest, svc) = decode_srv6_service(value)?;
+            Ok((rest, PrefixSidTlv::Srv6L3Service(svc)))
         }
-        6 => {
-            let (_, svc) = decode_srv6_service(value)?;
-            Ok((&[], PrefixSidTlv::Srv6L2Service(svc)))
+        PREFIX_SID_TLV_SRV6_L2_SERVICE => {
+            let (rest, svc) = decode_srv6_service(value)?;
+            Ok((rest, PrefixSidTlv::Srv6L2Service(svc)))
         }
         other => Ok((
             &[],
@@ -171,36 +244,58 @@ fn decode_tlv(typ: u8, value: &[u8]) -> IResult<&[u8], PrefixSidTlv> {
 }
 
 /// Decode an SRv6 Service TLV body (RFC 9252 §2): a leading RESERVED
-/// byte then SRv6 SID Information sub-TLVs. Unknown sub-/sub-sub-TLVs
-/// are skipped (we re-emit canonically), but their length is honoured
-/// so the walk stays aligned.
+/// byte then an unordered list of SRv6 Service sub-TLVs. SID Information
+/// sub-TLVs (type 1) are modelled; every other sub-TLV — and any
+/// sub-sub-TLV we don't model — is preserved verbatim so the attribute
+/// can be propagated unchanged (§2). A SID Information sub-TLV shorter
+/// than its fixed 21-octet head is malformed (§7) and fails the parse so
+/// the caller can treat-as-withdraw (RFC 7606).
 fn decode_srv6_service(value: &[u8]) -> IResult<&[u8], Srv6ServiceTlv> {
-    let (mut rest, _reserved) = be_u8(value)?;
+    let (mut rest, reserved) = be_u8(value)?;
     let mut sids = Vec::new();
+    let mut unknown_sub_tlvs = Vec::new();
     while !rest.is_empty() {
         let (r, sub_type) = be_u8(rest)?;
         let (r, sub_len) = be_u16(r)?;
         let (r, sub_val) = nom::bytes::complete::take(sub_len as usize)(r)?;
         rest = r;
-        if sub_type != 1 {
-            continue; // only SID Information sub-TLVs are modelled
+        if sub_type != SRV6_SUBTLV_SID_INFO {
+            unknown_sub_tlvs.push(RawSubTlv {
+                typ: sub_type,
+                value: sub_val.to_vec(),
+            });
+            continue;
         }
         // SID Information: RESERVED1(1) SID(16) Flags(1) Behavior(2) RESERVED2(1).
-        let (sv, _reserved1) = be_u8(sub_val)?;
+        if sub_val.len() < SRV6_SID_INFO_MIN_LEN {
+            return Err(nom::Err::Error(nom::error::make_error(
+                sub_val,
+                nom::error::ErrorKind::Verify,
+            )));
+        }
+        let (sv, reserved1) = be_u8(sub_val)?;
         let (sv, sid_bytes) = nom::bytes::complete::take(16usize)(sv)?;
         let mut octets = [0u8; 16];
         octets.copy_from_slice(sid_bytes);
         let sid = Ipv6Addr::from(octets);
         let (sv, flags) = be_u8(sv)?;
         let (sv, behavior) = be_u16(sv)?;
-        let (mut sv, _reserved2) = be_u8(sv)?;
+        let (mut sv, reserved2) = be_u8(sv)?;
         let mut structure = None;
+        let mut unknown_sub_sub_tlvs = Vec::new();
         while !sv.is_empty() {
             let (s, ss_type) = be_u8(sv)?;
             let (s, ss_len) = be_u16(s)?;
             let (s, ss_val) = nom::bytes::complete::take(ss_len as usize)(s)?;
             sv = s;
-            if ss_type == 1 && ss_val.len() >= 6 {
+            // Decode the SID Structure sub-sub-TLV only at its exact
+            // 6-octet length, and only the first instance; anything else
+            // (incl. a type-1 of a different length) is preserved
+            // verbatim rather than reinterpreted.
+            if ss_type == SRV6_SUBSUBTLV_SID_STRUCTURE
+                && ss_val.len() == SRV6_SID_STRUCTURE_LEN
+                && structure.is_none()
+            {
                 structure = Some(Srv6SidStructure {
                     locator_block_len: ss_val[0],
                     locator_node_len: ss_val[1],
@@ -209,43 +304,80 @@ fn decode_srv6_service(value: &[u8]) -> IResult<&[u8], Srv6ServiceTlv> {
                     transposition_len: ss_val[4],
                     transposition_offset: ss_val[5],
                 });
+            } else {
+                unknown_sub_sub_tlvs.push(RawSubTlv {
+                    typ: ss_type,
+                    value: ss_val.to_vec(),
+                });
             }
         }
         sids.push(Srv6SidInfo {
+            reserved1,
             sid,
             flags,
             behavior,
+            reserved2,
             structure,
+            unknown_sub_sub_tlvs,
         });
     }
-    Ok((&[], Srv6ServiceTlv { sids }))
+    Ok((
+        rest,
+        Srv6ServiceTlv {
+            reserved,
+            sids,
+            unknown_sub_tlvs,
+        },
+    ))
 }
 
 /// Encoded length of an SRv6 Service TLV body: RESERVED(1) + each SID
 /// Information sub-TLV (header 3 + 21 body + optional 9-byte structure
 /// sub-sub-TLV).
 fn srv6_service_len(svc: &Srv6ServiceTlv) -> usize {
-    let mut len = 1;
+    let mut len = 1; // RESERVED
     for sid in &svc.sids {
-        len += 3 + 21 + if sid.structure.is_some() { 9 } else { 0 };
+        len += 3 + sid_info_len(sid); // sub-TLV header + Value
+    }
+    for raw in &svc.unknown_sub_tlvs {
+        len += 3 + raw.value.len();
     }
     len
 }
 
+/// Encoded Value length of one SID Information sub-TLV: the 21-octet
+/// fixed head plus an optional SID Structure sub-sub-TLV (3 + 6) plus
+/// any preserved unknown sub-sub-TLVs.
+fn sid_info_len(sid: &Srv6SidInfo) -> usize {
+    let mut len = SRV6_SID_INFO_MIN_LEN;
+    if sid.structure.is_some() {
+        len += 3 + SRV6_SID_STRUCTURE_LEN;
+    }
+    for raw in &sid.unknown_sub_sub_tlvs {
+        len += 3 + raw.value.len();
+    }
+    len
+}
+
+fn emit_raw_sub_tlv(buf: &mut BytesMut, raw: &RawSubTlv) {
+    buf.put_u8(raw.typ);
+    buf.put_u16(raw.value.len() as u16);
+    buf.put(&raw.value[..]);
+}
+
 fn emit_srv6_service(buf: &mut BytesMut, svc: &Srv6ServiceTlv) {
-    buf.put_u8(0); // RESERVED
+    buf.put_u8(svc.reserved); // RESERVED (preserved)
     for sid in &svc.sids {
-        let sub_len = 21 + if sid.structure.is_some() { 9 } else { 0 };
-        buf.put_u8(1); // SID Information sub-TLV
-        buf.put_u16(sub_len as u16);
-        buf.put_u8(0); // RESERVED1
+        buf.put_u8(SRV6_SUBTLV_SID_INFO);
+        buf.put_u16(sid_info_len(sid) as u16);
+        buf.put_u8(sid.reserved1); // RESERVED1 (preserved)
         buf.put(&sid.sid.octets()[..]);
         buf.put_u8(sid.flags);
         buf.put_u16(sid.behavior);
-        buf.put_u8(0); // RESERVED2
+        buf.put_u8(sid.reserved2); // RESERVED2 (preserved)
         if let Some(st) = sid.structure {
-            buf.put_u8(1); // SID Structure sub-sub-TLV
-            buf.put_u16(6);
+            buf.put_u8(SRV6_SUBSUBTLV_SID_STRUCTURE);
+            buf.put_u16(SRV6_SID_STRUCTURE_LEN as u16);
             buf.put_u8(st.locator_block_len);
             buf.put_u8(st.locator_node_len);
             buf.put_u8(st.function_len);
@@ -253,6 +385,12 @@ fn emit_srv6_service(buf: &mut BytesMut, svc: &Srv6ServiceTlv) {
             buf.put_u8(st.transposition_len);
             buf.put_u8(st.transposition_offset);
         }
+        for raw in &sid.unknown_sub_sub_tlvs {
+            emit_raw_sub_tlv(buf, raw);
+        }
+    }
+    for raw in &svc.unknown_sub_tlvs {
+        emit_raw_sub_tlv(buf, raw);
     }
 }
 
@@ -471,11 +609,11 @@ mod tests {
         // L3VPN-over-SRv6 advertise shape.
         let sid = PrefixSid {
             tlvs: vec![PrefixSidTlv::Srv6L3Service(Srv6ServiceTlv {
-                sids: vec![Srv6SidInfo {
-                    sid: "2001:db8:1:1::".parse().unwrap(),
-                    flags: 0,
-                    behavior: SRV6_BEHAVIOR_END_DT46,
-                    structure: Some(Srv6SidStructure {
+                sids: vec![Srv6SidInfo::new(
+                    "2001:db8:1:1::".parse().unwrap(),
+                    0,
+                    SRV6_BEHAVIOR_END_DT46,
+                    Some(Srv6SidStructure {
                         locator_block_len: 32,
                         locator_node_len: 16,
                         function_len: 16,
@@ -483,7 +621,8 @@ mod tests {
                         transposition_len: 0,
                         transposition_offset: 0,
                     }),
-                }],
+                )],
+                ..Default::default()
             })],
         };
         let rt = round_trip(sid.clone());
@@ -505,15 +644,117 @@ mod tests {
     fn srv6_sid_without_structure_round_trips() {
         let sid = PrefixSid {
             tlvs: vec![PrefixSidTlv::Srv6L3Service(Srv6ServiceTlv {
+                sids: vec![Srv6SidInfo::new(
+                    "2001:db8::1".parse().unwrap(),
+                    0,
+                    SRV6_BEHAVIOR_END_DT4,
+                    None,
+                )],
+                ..Default::default()
+            })],
+        };
+        assert_eq!(round_trip(sid.clone()), sid);
+    }
+
+    #[test]
+    fn srv6_service_with_unknowns_struct_round_trips() {
+        // A hand-built service TLV carrying an unrecognized sub-TLV and
+        // an unrecognized sub-sub-TLV round-trips through emit→parse.
+        let sid = PrefixSid {
+            tlvs: vec![PrefixSidTlv::Srv6L3Service(Srv6ServiceTlv {
+                reserved: 0,
                 sids: vec![Srv6SidInfo {
+                    reserved1: 0,
                     sid: "2001:db8::1".parse().unwrap(),
                     flags: 0,
-                    behavior: SRV6_BEHAVIOR_END_DT4,
+                    behavior: SRV6_BEHAVIOR_END_DT46,
+                    reserved2: 0,
                     structure: None,
+                    unknown_sub_sub_tlvs: vec![RawSubTlv {
+                        typ: 7,
+                        value: vec![9, 9],
+                    }],
+                }],
+                unknown_sub_tlvs: vec![RawSubTlv {
+                    typ: 250,
+                    value: vec![1, 2, 3, 4],
                 }],
             })],
         };
         assert_eq!(round_trip(sid.clone()), sid);
+    }
+
+    #[test]
+    fn srv6_service_preserves_reserved_and_unknown_tlvs_bit_exact() {
+        // An SRv6 L3 Service TLV whose RESERVED octets are non-zero and
+        // which carries an unrecognized sub-TLV (type 9) plus an
+        // unrecognized sub-sub-TLV (type 7) inside the SID Information
+        // sub-TLV. RFC 9252 §2 requires all of this — Reserved fields
+        // included — to survive a receive→propagate (parse→emit) cycle
+        // unchanged when the next hop is unchanged.
+        let mut sid_info_value = vec![0xAA]; // RESERVED1 (non-zero)
+        sid_info_value.extend_from_slice(&[0u8; 16]); // SID
+        sid_info_value.push(0x00); // flags
+        sid_info_value.extend_from_slice(&SRV6_BEHAVIOR_END_DT46.to_be_bytes());
+        sid_info_value.push(0xBB); // RESERVED2 (non-zero)
+        sid_info_value.extend_from_slice(&[7, 0x00, 0x02, 0xDE, 0xAD]); // unknown sub-sub-TLV
+
+        let mut service_value = vec![0xCC]; // service RESERVED (non-zero)
+        service_value.push(SRV6_SUBTLV_SID_INFO);
+        service_value.extend_from_slice(&(sid_info_value.len() as u16).to_be_bytes());
+        service_value.extend_from_slice(&sid_info_value);
+        service_value.extend_from_slice(&[9, 0x00, 0x03, 1, 2, 3]); // unknown sub-TLV
+
+        let mut attr_bytes = vec![PREFIX_SID_TLV_SRV6_L3_SERVICE];
+        attr_bytes.extend_from_slice(&(service_value.len() as u16).to_be_bytes());
+        attr_bytes.extend_from_slice(&service_value);
+
+        let (rest, parsed) = PrefixSid::parse_be(&attr_bytes).expect("parse");
+        assert!(rest.is_empty());
+        match &parsed.tlvs[0] {
+            PrefixSidTlv::Srv6L3Service(svc) => {
+                assert_eq!(svc.reserved, 0xCC);
+                assert_eq!(
+                    svc.unknown_sub_tlvs,
+                    vec![RawSubTlv {
+                        typ: 9,
+                        value: vec![1, 2, 3]
+                    }]
+                );
+                let s = &svc.sids[0];
+                assert_eq!(s.reserved1, 0xAA);
+                assert_eq!(s.reserved2, 0xBB);
+                assert_eq!(
+                    s.unknown_sub_sub_tlvs,
+                    vec![RawSubTlv {
+                        typ: 7,
+                        value: vec![0xDE, 0xAD]
+                    }]
+                );
+            }
+            _ => panic!("expected SRv6 L3 Service TLV"),
+        }
+
+        let mut buf = BytesMut::new();
+        parsed.emit(&mut buf);
+        assert_eq!(buf.to_vec(), attr_bytes, "re-emit must be byte-for-byte");
+    }
+
+    #[test]
+    fn srv6_sid_info_shorter_than_21_is_rejected() {
+        // SID Information sub-TLV (type 1) with a Value length of 20, one
+        // short of the fixed 21-octet head. RFC 9252 §7 deems it
+        // malformed; the parse must fail so the caller treats-as-withdraw.
+        let mut service_value = vec![0x00]; // service RESERVED
+        service_value.push(SRV6_SUBTLV_SID_INFO);
+        service_value.extend_from_slice(&20u16.to_be_bytes());
+        service_value.extend_from_slice(&[0u8; 20]);
+
+        let mut attr_bytes = vec![PREFIX_SID_TLV_SRV6_L3_SERVICE];
+        attr_bytes.extend_from_slice(&(service_value.len() as u16).to_be_bytes());
+        attr_bytes.extend_from_slice(&service_value);
+
+        assert!(PrefixSid::parse_be(&attr_bytes).is_err());
     }
 
     #[test]

--- a/crates/bgp-packet/src/update.rs
+++ b/crates/bgp-packet/src/update.rs
@@ -42,6 +42,12 @@ pub struct UpdatePacket {
     pub mp_update: Option<MpReachAttr>,
     #[nom(Ignore)]
     pub mp_withdraw: Option<MpUnreachAttr>,
+    /// RFC 7606 treat-as-withdraw: a recoverable malformed attribute
+    /// (e.g. a malformed BGP Prefix-SID, RFC 9252 §7) was discarded
+    /// during parse, so this UPDATE's reachable NLRI must be withdrawn
+    /// rather than installed. Not a wire field.
+    #[nom(Ignore)]
+    pub treat_as_withdraw: bool,
     #[nom(Ignore)]
     max_packet_size: usize,
 }
@@ -68,6 +74,7 @@ impl Default for UpdatePacket {
             ipv4_withdraw: Vec::new(),
             mp_update: None,
             mp_withdraw: None,
+            treat_as_withdraw: false,
             max_packet_size: BGP_PACKET_LEN,
         }
     }
@@ -573,14 +580,15 @@ impl UpdatePacket {
         let (input, mut withdrawal) = parse_bgp_nlri_ipv4(input, withdraw_len, add_path)?;
         packet.ipv4_withdraw.append(&mut withdrawal);
         let (input, attr_len) = be_u16(input)?;
-        let (input, bgp_attr, mp_update, mp_withdraw) = if attr_len > 0 {
+        let (input, bgp_attr, mp_update, mp_withdraw, treat_as_withdraw) = if attr_len > 0 {
             parse_bgp_update_attribute(input, attr_len, as4, opt)?
         } else {
-            (input, None, None, None)
+            (input, None, None, None, false)
         };
         packet.bgp_attr = bgp_attr;
         packet.mp_update = mp_update;
         packet.mp_withdraw = mp_withdraw;
+        packet.treat_as_withdraw = treat_as_withdraw;
         let nlri_len = packet
             .header
             .length

--- a/docs/design/bgp-prefix-sid-rfc9252.md
+++ b/docs/design/bgp-prefix-sid-rfc9252.md
@@ -1,0 +1,183 @@
+# BGP Prefix-SID over SRv6 (RFC 9252) — Codec Hardening, Treat-as-Withdraw, and the EVPN-over-SRv6 L2 Forwarder Question
+
+Tracks the BGP Prefix-SID attribute (type 40) work for SRv6 services
+(RFC 9252, building on RFC 8669). This memo captures **what already
+existed**, **what this branch (`bgp-prefix-sid`) adds**, and — most
+importantly for anyone picking up the SRv6 **L2** service work — **why
+the L2 Service TLV producer is gated on the dataplane, not the codec.**
+
+Read this first if you're touching
+`crates/bgp-packet/src/attrs/prefix_sid.rs`, the `Attr::parse_attr*`
+machinery in `crates/bgp-packet/src/attrs/attr.rs`, the
+`UpdatePacket.treat_as_withdraw` flag, or the SRv6 service producers in
+`zebra-rs/src/bgp/{inst,route}.rs`.
+
+Related: [`bgp-mpls-vpn-plan.md`](bgp-mpls-vpn-plan.md) (the MPLS L3VPN
+path this mirrors), and the project memory note `zebra-rs-bgp-srv6-l3vpn`
+(the 5-phase L3VPN-over-SRv6 plan).
+
+## Status (2026-06-08)
+
+| Piece | Where | State |
+|-------|-------|-------|
+| Prefix-SID attribute codec (RFC 8669 Label-Index / Originator-SRGB) | `prefix_sid.rs` | in `main` (pre-existing) |
+| SRv6 **L3** Service TLV (type 5) codec | `prefix_sid.rs` | in `main` (pre-existing) |
+| SRv6 **L3** Service producer (L3VPN-over-SRv6, End.DT46) | `inst.rs::srv6_export_nexthop` | in `main` (pre-existing) |
+| **Gap 1** — propagation fidelity (preserve unknown sub-TLVs + RESERVED) | `prefix_sid.rs` | **branch `bgp-prefix-sid`** |
+| **Gap 2** — malformed detection (§7) + RFC 7606 treat-as-withdraw | `attr.rs`, `update.rs`, `route.rs` | **branch `bgp-prefix-sid`** |
+| **Gap 3** — SRv6 **L2** Service producer (EVPN over SRv6) | — | **not started — blocked on dataplane (see below)** |
+
+## Gap 1 — Propagation fidelity (RFC 9252 §2)
+
+RFC 9252 §2 requires that when a speaker re-advertises a route **with the
+next hop unchanged**, the SRv6 Service TLVs — *including any unrecognized
+sub-TLV / sub-sub-TLV types* — are propagated further, and **all RESERVED
+fields MUST be propagated unchanged**.
+
+The original codec decoded only the SID Information sub-TLV (type 1) and
+the SID Structure sub-sub-TLV (type 1), **dropped** everything else, and
+**re-emitted RESERVED octets as 0**. That breaks bit-exact propagation
+through a route reflector.
+
+Fixed in `prefix_sid.rs`:
+
+- New `RawSubTlv { typ, value }` preserves any unmodelled sub-TLV /
+  sub-sub-TLV verbatim.
+- `Srv6ServiceTlv` gained `reserved` + `unknown_sub_tlvs`;
+  `Srv6SidInfo` gained `reserved1`, `reserved2`, `unknown_sub_sub_tlvs`.
+- A `Srv6SidInfo::new(sid, flags, behavior, structure)` constructor keeps
+  producers terse (zeroed RESERVED, no unknowns) — used by the L3
+  producer in `inst.rs` and the test helper in `route.rs`.
+- Unknowns re-emit *after* the modelled fields. The sub-TLV list is
+  unordered per §2, so this is conformant (not byte-position-preserving,
+  but value- and content-preserving, which is what the RFC mandates).
+
+The SID Structure sub-sub-TLV is now decoded **only at its exact 6-octet
+length and only for the first instance**; any other length (or a second
+type-1) is preserved as a `RawSubTlv` so the round-trip stays exact.
+
+## Gap 2 — Malformed detection + RFC 7606 treat-as-withdraw
+
+### Codec (`prefix_sid.rs`)
+
+RFC 9252 §7 deems a SID Information sub-TLV malformed when its Value is
+shorter than the fixed 21-octet head (RESERVED1 + SID + Flags + Behavior
++ RESERVED2). The parser now rejects that explicitly. Semantic checks the
+RFC says are **not** malformations (unknown behavior, AL/transposition
+sanity) are deliberately *not* enforced at the codec layer — RFC 9252 §7
+says "not malformed because of failing any semantic validation."
+
+### Parse recovery (`attr.rs`)
+
+Previously **any** attribute Value-parse error propagated out of
+`parse_bgp_update_attribute` → `parse_packet` → the read loop, which
+tears the **whole BGP session** down. RFC 8669 §5 + RFC 9252 §7 (and
+RFC 7606 generally) require a malformed Prefix-SID to be
+**treat-as-withdraw**, not a session reset.
+
+`Attr::parse_attr` was split so a Value error is recoverable:
+
+- `parse_attr_header` — parses flags/type/length and splits the Value;
+  the next-attribute pointer is known **before** the Value is parsed. A
+  framing error here is still fatal (RFC 7606 §4 attribute-length error).
+- `parse_attr_value` — parses the Value; **recoverable**.
+- `attr_malformation_is_withdraw(attr_type)` — currently `true` only for
+  `PrefixSid`. Other attributes keep their existing session-reset
+  behavior (intentionally minimal — this is not a general RFC 7606
+  framework, just the slice RFC 9252 mandates).
+
+On a recoverable error the malformed attribute is discarded and a
+`treat_as_withdraw` flag is set; parsing of the remaining attributes
+continues. The flag rides on `UpdatePacket.treat_as_withdraw`
+(`#[nom(Ignore)]`, not a wire field).
+
+### Withdraw routing (`route.rs::route_from_peer` + `withdraw_mp_reach`)
+
+When `treat_as_withdraw` is set, every **reachable** NLRI in the UPDATE is
+routed through its `*_withdraw` path instead of being installed, while the
+UPDATE's explicit withdrawals are still honoured and the session stays up.
+`withdraw_mp_reach` mirrors the install match across all MP_REACH
+families (v4, VPNv4/6, EVPN, v4-over-v6, v6, labeled v4/v6, flowspec,
+SR-policy, BGP-LS); RTC and any family that cannot carry a Prefix-SID fall
+through a no-op catch-all.
+
+### Tests
+
+`prefix_sid.rs`: bit-exact preservation of RESERVED + unknown sub-/
+sub-sub-TLVs; struct round-trip with unknowns; under-length SID-info
+rejection. `attr.rs`: a malformed Prefix-SID after a valid ORIGIN yields
+`Ok(.., treat_as_withdraw=true)` with ORIGIN surviving and the Prefix-SID
+discarded (not a parse failure).
+
+## Gap 3 — SRv6 L2 Service producer: blocked on the dataplane, not the codec
+
+The SRv6 **L2** Service TLV (type 6) codec already exists. The blocker for
+a *producer* is that the EVPN L2 services it signals are **not forwardable
+by the stock Linux kernel**. This is the SRv6 mirror of the
+already-recorded fact that EVPN/MPLS **L2** forwarding needs VPP, not the
+kernel.
+
+### What the kernel `seg6local` gives us
+
+Today `zebra-rs` models only L3/transit behaviors
+(`SidBehavior` in `rib/segment_routing/sid.rs`: End, End.X, uN, uA,
+End.DT4, End.DT6, End.DT46, End.B6.Encaps), and
+`fib/netlink/srv6.rs::seg6local_action` maps them to the kernel actions.
+Mapping the mainline `SEG6_LOCAL_ACTION_*` set onto EVPN-over-SRv6
+(RFC 9252 §6):
+
+| EVPN service | RFC 9252 behavior | Mainline kernel `seg6local`? |
+|---|---|---|
+| Type-5 IP Prefix (**L3**) | End.DT4 / End.DT6 / End.DT46 | ✅ actions 7/8/16 — **already wired** |
+| VPWS point-to-point (Type-1/2) | **End.DX2** | ⚠️ decap exists (action 4 → `oif`); no native ingress L2→SRv6 encap |
+| ELAN bridged unicast (Type-2 MAC/IP) | **End.DT2U** | ❌ absent from mainline |
+| BUM flooding (Type-3 IMET) | **End.DT2M** (+ Arg.FE2 ESI filtering) | ❌ absent from mainline |
+
+Two distinct gaps for L2:
+
+1. **Egress decap** — the kernel has `End.DX2` (cross-connect to an
+   interface) but **no `End.DT2U` / `End.DT2M`**: no "decap → bridge FDB
+   lookup" and no "decap → flood to EVI bridge ports." ELAN is the common
+   EVPN case and it is simply not in the kernel.
+2. **Ingress encap** — `encap seg6` (H.Encaps) is an **L3** lwtunnel on
+   IPv6 routes. There is no native `H.Encaps.L2`: no clean,
+   control-plane-programmable way to push an Ethernet frame from an
+   attachment circuit / bridge port into SRv6. So even VPWS (End.DX2) is
+   only half-forwardable on mainline.
+
+### Forwarders that *can* do EVPN-SRv6 L2
+
+- **VPP** — has End.DT2U/DT2M/DX2 and L2 SRv6 encap. Realistic forwarder
+  for EVPN-SRv6-L2; a new VPP binary-API southbound, same shape as the
+  MPLS-L2 discussion.
+- **eBPF via `End.BPF` (action 15)** — attach a custom eBPF program as the
+  seg6local action and implement DT2U/DT2M yourself. The `offload/` XDP
+  tree makes this plausible, but it is a *custom* dataplane, not the stock
+  kernel forwarder.
+
+### Decision menu for Gap 3
+
+A kernel-targeted EVPN-over-SRv6 **L2** producer would be
+**control-plane-only** (advertise/receive the L2 Service TLV + Loc-RIB,
+but the kernel can't forward ELAN/BUM — only L3, and awkwardly
+VPWS-decap). That matches the project's control-plane-first precedent
+(Flowspec, SR-Policy, Labeled-Unicast all landed that way), but should be
+chosen deliberately:
+
+1. **Control-plane-only L2 producer** — codec + producer/consumer +
+   Loc-RIB + show; dataplane deferred to a future VPP/eBPF southbound.
+2. **Pivot to VPP/eBPF** for a forwardable L2 — much larger, new
+   southbound.
+3. **Stop at L3** — keep the value where the kernel forwards today
+   (L3VPN + EVPN Type-5, both already working); the L2 producer is a
+   future feature.
+
+## Files touched (branch `bgp-prefix-sid`)
+
+- `crates/bgp-packet/src/attrs/prefix_sid.rs` — Gap 1 + Gap 2 codec.
+- `crates/bgp-packet/src/attrs/attr.rs` — `parse_attr` split,
+  `attr_malformation_is_withdraw`, treat-as-withdraw flag threading.
+- `crates/bgp-packet/src/update.rs` — `UpdatePacket.treat_as_withdraw`.
+- `zebra-rs/src/bgp/inst.rs` — adopt `Srv6SidInfo::new`.
+- `zebra-rs/src/bgp/route.rs` — `route_from_peer` treat-as-withdraw branch
+  + `withdraw_mp_reach`.

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -151,12 +151,13 @@ fn srv6_l3_service_prefix_sid(
     bgp_packet::PrefixSid {
         tlvs: vec![bgp_packet::PrefixSidTlv::Srv6L3Service(
             bgp_packet::Srv6ServiceTlv {
-                sids: vec![bgp_packet::Srv6SidInfo {
+                sids: vec![bgp_packet::Srv6SidInfo::new(
                     sid,
-                    flags: 0,
-                    behavior: bgp_packet::SRV6_BEHAVIOR_END_DT46,
+                    0,
+                    bgp_packet::SRV6_BEHAVIOR_END_DT46,
                     structure,
-                }],
+                )],
+                ..Default::default()
             },
         )],
     }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -5037,6 +5037,80 @@ pub fn route_withdraw_flowspec_to_peers(afi: Afi, nlri: &FlowspecNlri, peers: &m
     }
 }
 
+/// Withdraw every reachable NLRI carried in an MP_REACH attribute — the
+/// RFC 7606 / RFC 9252 §7 treat-as-withdraw action taken when the
+/// UPDATE's BGP Prefix-SID attribute is malformed. Mirrors the install
+/// match in [`route_from_peer`], routing each AFI/SAFI through its
+/// `*_withdraw` path so any previously-installed copy from this peer is
+/// removed. RTC and any other family that cannot carry a Prefix-SID
+/// attribute fall through the catch-all as a no-op.
+fn withdraw_mp_reach(peer_id: usize, mp: MpReachAttr, bgp: &mut BgpTop, peers: &mut PeerMap) {
+    match mp {
+        MpReachAttr::Vpnv4(nlri) => {
+            for update in nlri.updates.iter() {
+                route_ipv4_withdraw(
+                    peer_id,
+                    &update.nlri,
+                    Some(update.rd),
+                    Some(update.label),
+                    bgp,
+                    peers,
+                    true,
+                );
+            }
+        }
+        MpReachAttr::Vpnv6(nlri) => {
+            for update in nlri.updates.iter() {
+                route_ipv6_withdraw(peer_id, &update.nlri, Some(update.rd), bgp, peers, true);
+            }
+        }
+        MpReachAttr::Evpn { updates, .. } => {
+            for route in updates.iter() {
+                route_evpn_withdraw(peer_id, route, bgp, peers);
+            }
+        }
+        MpReachAttr::Ipv4 { updates, .. } => {
+            for update in updates.iter() {
+                route_ipv4_withdraw(peer_id, update, None, None, bgp, peers, true);
+            }
+        }
+        MpReachAttr::Ipv6 { updates, .. } => {
+            for update in updates.iter() {
+                route_ipv6_withdraw(peer_id, update, None, bgp, peers, true);
+            }
+        }
+        MpReachAttr::Labelv4 { updates, .. } => {
+            for lu in updates.iter() {
+                route_labelv4_withdraw(peer_id, &lu.nlri, bgp, peers, true);
+            }
+        }
+        MpReachAttr::Labelv6 { updates, .. } => {
+            for lu in updates.iter() {
+                route_labelv6_withdraw(peer_id, &lu.nlri, bgp, peers, true);
+            }
+        }
+        MpReachAttr::Flowspec { afi, updates } => {
+            for nlri in updates.iter() {
+                route_flowspec_withdraw(peer_id, nlri, afi, bgp, peers);
+            }
+        }
+        MpReachAttr::SrPolicy { updates, .. } => {
+            for nlri in updates.iter() {
+                route_srpolicy_withdraw(peer_id, nlri, bgp, peers);
+            }
+        }
+        MpReachAttr::LinkState { updates, .. } => {
+            for nlri in updates.iter() {
+                route_bgpls_withdraw(peer_id, nlri, bgp, peers);
+            }
+        }
+        _ => {
+            // Rtcv4 / Rtcv6 and any other family that cannot carry a
+            // Prefix-SID attribute — nothing to withdraw.
+        }
+    }
+}
+
 pub fn route_from_peer(
     peer_id: usize,
     packet: UpdatePacket,
@@ -5056,7 +5130,18 @@ pub fn route_from_peer(
 
     // Convert UpdatePacket to BgpNlri.
     // let nlri = BgpNlriAttr::from(&packet);
-    if let Some(bgp_attr) = &packet.bgp_attr {
+    // RFC 7606 / RFC 9252 §7: when the UPDATE carried a malformed
+    // Prefix-SID attribute, its reachable NLRI are treat-as-withdraw —
+    // remove any installed copy from this peer instead of installing —
+    // while the UPDATE's explicit withdrawals are still honoured and the
+    // session stays up.
+    let treat_as_withdraw = packet.treat_as_withdraw;
+
+    if treat_as_withdraw {
+        for update in packet.ipv4_update.iter() {
+            route_ipv4_withdraw(peer_id, update, None, None, bgp, peers, true);
+        }
+    } else if let Some(bgp_attr) = &packet.bgp_attr {
         for update in packet.ipv4_update.iter() {
             route_ipv4_update(
                 peer_id, update, None, None, bgp_attr, None, None, bgp, peers, false,
@@ -5067,173 +5152,175 @@ pub fn route_from_peer(
     for withdraw in packet.ipv4_withdraw.iter() {
         route_ipv4_withdraw(peer_id, withdraw, None, None, bgp, peers, true);
     }
-    if let Some(mp_updates) = packet.mp_update
-        && let Some(bgp_attr) = &packet.bgp_attr
-    {
-        match mp_updates {
-            MpReachAttr::Vpnv4(nlri) => {
-                for update in nlri.updates.iter() {
-                    route_ipv4_update(
-                        peer_id,
-                        &update.nlri,
-                        Some(update.rd),
-                        Some(update.label),
-                        bgp_attr,
-                        Some(VpnNexthop::V4(nlri.nhop.clone())),
-                        None,
-                        bgp,
-                        peers,
-                        false,
-                    )
-                }
-            }
-            MpReachAttr::Rtcv4(nlri) => {
-                for update in nlri.updates.iter() {
-                    route_ipv4_rtc_update(peer_id, update, peers);
-                }
-            }
-            MpReachAttr::Rtcv6(nlri) => {
-                for update in nlri.updates.iter() {
-                    route_ipv6_rtc_update(peer_id, update, peers);
-                }
-            }
-            MpReachAttr::Evpn {
-                snpa: _,
-                nhop,
-                updates,
-            } => {
-                for route in updates.iter() {
-                    route_evpn_update(peer_id, route, nhop, bgp_attr, bgp, peers, false);
-                }
-            }
-            MpReachAttr::Ipv4 {
-                snpa: _,
-                nhop,
-                updates,
-            } => {
-                // RFC 8950 IPv4-over-IPv6: install the prefix into
-                // Loc-RIB and the FIB. The v6 next-hop in `nhop` is
-                // the remote's link-local; the receiver doesn't need
-                // it for forwarding (kernel uses the v6 onlink already
-                // discovered via ND), so we route the install via the
-                // egress ifindex of the peer that delivered the
-                // UPDATE. ENHE on a non-interface peer is unexpected —
-                // ENHE is currently only negotiated by unnumbered
-                // peers; log and drop in that case rather than fall
-                // back to a bogus install.
-                let egress_ifindex = peers.get_by_idx(peer_id).and_then(|p| p.scope_id);
-                if let Some(ifindex) = egress_ifindex {
-                    for update in updates.iter() {
+    if let Some(mp_updates) = packet.mp_update {
+        if treat_as_withdraw {
+            withdraw_mp_reach(peer_id, mp_updates, bgp, peers);
+        } else if let Some(bgp_attr) = &packet.bgp_attr {
+            match mp_updates {
+                MpReachAttr::Vpnv4(nlri) => {
+                    for update in nlri.updates.iter() {
                         route_ipv4_update(
                             peer_id,
-                            update,
-                            None,
-                            None,
+                            &update.nlri,
+                            Some(update.rd),
+                            Some(update.label),
                             bgp_attr,
+                            Some(VpnNexthop::V4(nlri.nhop.clone())),
                             None,
-                            Some(ifindex),
+                            bgp,
+                            peers,
+                            false,
+                        )
+                    }
+                }
+                MpReachAttr::Rtcv4(nlri) => {
+                    for update in nlri.updates.iter() {
+                        route_ipv4_rtc_update(peer_id, update, peers);
+                    }
+                }
+                MpReachAttr::Rtcv6(nlri) => {
+                    for update in nlri.updates.iter() {
+                        route_ipv6_rtc_update(peer_id, update, peers);
+                    }
+                }
+                MpReachAttr::Evpn {
+                    snpa: _,
+                    nhop,
+                    updates,
+                } => {
+                    for route in updates.iter() {
+                        route_evpn_update(peer_id, route, nhop, bgp_attr, bgp, peers, false);
+                    }
+                }
+                MpReachAttr::Ipv4 {
+                    snpa: _,
+                    nhop,
+                    updates,
+                } => {
+                    // RFC 8950 IPv4-over-IPv6: install the prefix into
+                    // Loc-RIB and the FIB. The v6 next-hop in `nhop` is
+                    // the remote's link-local; the receiver doesn't need
+                    // it for forwarding (kernel uses the v6 onlink already
+                    // discovered via ND), so we route the install via the
+                    // egress ifindex of the peer that delivered the
+                    // UPDATE. ENHE on a non-interface peer is unexpected —
+                    // ENHE is currently only negotiated by unnumbered
+                    // peers; log and drop in that case rather than fall
+                    // back to a bogus install.
+                    let egress_ifindex = peers.get_by_idx(peer_id).and_then(|p| p.scope_id);
+                    if let Some(ifindex) = egress_ifindex {
+                        for update in updates.iter() {
+                            route_ipv4_update(
+                                peer_id,
+                                update,
+                                None,
+                                None,
+                                bgp_attr,
+                                None,
+                                Some(ifindex),
+                                bgp,
+                                peers,
+                                false,
+                            );
+                        }
+                    } else {
+                        tracing::warn!(
+                            "RFC 8950: dropping IPv4 routes from peer {} via v6 next-hop {} — peer has no egress ifindex",
+                            peer_id,
+                            nhop,
+                        );
+                    }
+                }
+                MpReachAttr::Ipv6 {
+                    snpa: _,
+                    nhop,
+                    updates,
+                } => {
+                    // Native IPv6 unicast: the MP_REACH next-hop replaces
+                    // the (unused) v4 NEXT_HOP attribute. Stamp it into the
+                    // attr so best-path / FIB read a v6 next-hop.
+                    if let IpAddr::V6(nh6) = nhop {
+                        let mut attr_v6 = bgp_attr.clone();
+                        attr_v6.nexthop = Some(BgpNexthop::Ipv6(nh6));
+                        for update in updates.iter() {
+                            route_ipv6_update(
+                                peer_id, update, None, None, &attr_v6, None, bgp, peers, false,
+                            );
+                        }
+                    } else {
+                        tracing::warn!(
+                            "IPv6 unicast MP_REACH from peer {} carried a non-v6 next-hop {} — dropping",
+                            peer_id,
+                            nhop,
+                        );
+                    }
+                }
+                MpReachAttr::Vpnv6(nlri) => {
+                    // VPNv6: store each route under its RD in the global
+                    // v6vpn Loc-RIB, carrying the route's Vpnv6 next-hop.
+                    for update in nlri.updates.iter() {
+                        route_ipv6_update(
+                            peer_id,
+                            &update.nlri,
+                            Some(update.rd),
+                            Some(update.label),
+                            bgp_attr,
+                            Some(VpnNexthop::V6(nlri.nhop.clone())),
                             bgp,
                             peers,
                             false,
                         );
                     }
-                } else {
-                    tracing::warn!(
-                        "RFC 8950: dropping IPv4 routes from peer {} via v6 next-hop {} — peer has no egress ifindex",
-                        peer_id,
-                        nhop,
-                    );
                 }
-            }
-            MpReachAttr::Ipv6 {
-                snpa: _,
-                nhop,
-                updates,
-            } => {
-                // Native IPv6 unicast: the MP_REACH next-hop replaces
-                // the (unused) v4 NEXT_HOP attribute. Stamp it into the
-                // attr so best-path / FIB read a v6 next-hop.
-                if let IpAddr::V6(nh6) = nhop {
-                    let mut attr_v6 = bgp_attr.clone();
-                    attr_v6.nexthop = Some(BgpNexthop::Ipv6(nh6));
-                    for update in updates.iter() {
-                        route_ipv6_update(
-                            peer_id, update, None, None, &attr_v6, None, bgp, peers, false,
-                        );
+                MpReachAttr::Flowspec { afi, updates } => {
+                    for nlri in updates.iter() {
+                        route_flowspec_update(peer_id, nlri, afi, bgp_attr, bgp, peers, false);
                     }
-                } else {
-                    tracing::warn!(
-                        "IPv6 unicast MP_REACH from peer {} carried a non-v6 next-hop {} — dropping",
-                        peer_id,
-                        nhop,
-                    );
                 }
-            }
-            MpReachAttr::Vpnv6(nlri) => {
-                // VPNv6: store each route under its RD in the global
-                // v6vpn Loc-RIB, carrying the route's Vpnv6 next-hop.
-                for update in nlri.updates.iter() {
-                    route_ipv6_update(
-                        peer_id,
-                        &update.nlri,
-                        Some(update.rd),
-                        Some(update.label),
-                        bgp_attr,
-                        Some(VpnNexthop::V6(nlri.nhop.clone())),
-                        bgp,
-                        peers,
-                        false,
-                    );
+                MpReachAttr::SrPolicy { nhop, updates, .. } => {
+                    // SAFI 73: candidate-path content rides in the Tunnel
+                    // Encapsulation attribute; the NLRI endpoint carries the
+                    // AFI, so v4/v6 share one path.
+                    for nlri in updates.iter() {
+                        route_srpolicy_update(peer_id, nlri, bgp_attr, nhop, bgp, peers);
+                    }
                 }
-            }
-            MpReachAttr::Flowspec { afi, updates } => {
-                for nlri in updates.iter() {
-                    route_flowspec_update(peer_id, nlri, afi, bgp_attr, bgp, peers, false);
+                MpReachAttr::LinkState { updates, .. } => {
+                    // AFI 16388 / SAFI 71: Node/Link/Prefix objects. The
+                    // companion attributes ride in the BGP-LS Attribute
+                    // (type 29), already captured in `bgp_attr.bgp_ls`. The
+                    // MP_REACH next-hop is informational here; re-advertisement
+                    // is a later phase. The v4/v6 split lives inside the NLRI,
+                    // so a single Loc-RIB table holds every object.
+                    for nlri in updates.iter() {
+                        route_bgpls_update(peer_id, nlri, bgp_attr, bgp, peers, false);
+                    }
                 }
-            }
-            MpReachAttr::SrPolicy { nhop, updates, .. } => {
-                // SAFI 73: candidate-path content rides in the Tunnel
-                // Encapsulation attribute; the NLRI endpoint carries the
-                // AFI, so v4/v6 share one path.
-                for nlri in updates.iter() {
-                    route_srpolicy_update(peer_id, nlri, bgp_attr, nhop, bgp, peers);
+                MpReachAttr::Labelv4 {
+                    snpa: _,
+                    nhop,
+                    updates,
+                } => {
+                    // IPv4 Labeled-Unicast (SAFI 4): store each route in the
+                    // v4lu Loc-RIB with its per-prefix label. The MP_REACH
+                    // next-hop is authoritative.
+                    for update in updates.iter() {
+                        route_labelv4_update(peer_id, update, nhop, bgp_attr, bgp, peers, false);
+                    }
                 }
-            }
-            MpReachAttr::LinkState { updates, .. } => {
-                // AFI 16388 / SAFI 71: Node/Link/Prefix objects. The
-                // companion attributes ride in the BGP-LS Attribute
-                // (type 29), already captured in `bgp_attr.bgp_ls`. The
-                // MP_REACH next-hop is informational here; re-advertisement
-                // is a later phase. The v4/v6 split lives inside the NLRI,
-                // so a single Loc-RIB table holds every object.
-                for nlri in updates.iter() {
-                    route_bgpls_update(peer_id, nlri, bgp_attr, bgp, peers, false);
+                MpReachAttr::Labelv6 {
+                    snpa: _,
+                    nhop,
+                    updates,
+                } => {
+                    // IPv6 Labeled-Unicast (SAFI 4), including 6PE.
+                    for update in updates.iter() {
+                        route_labelv6_update(peer_id, update, nhop, bgp_attr, bgp, peers, false);
+                    }
                 }
-            }
-            MpReachAttr::Labelv4 {
-                snpa: _,
-                nhop,
-                updates,
-            } => {
-                // IPv4 Labeled-Unicast (SAFI 4): store each route in the
-                // v4lu Loc-RIB with its per-prefix label. The MP_REACH
-                // next-hop is authoritative.
-                for update in updates.iter() {
-                    route_labelv4_update(peer_id, update, nhop, bgp_attr, bgp, peers, false);
+                _ => {
+                    //
                 }
-            }
-            MpReachAttr::Labelv6 {
-                snpa: _,
-                nhop,
-                updates,
-            } => {
-                // IPv6 Labeled-Unicast (SAFI 4), including 6PE.
-                for update in updates.iter() {
-                    route_labelv6_update(peer_id, update, nhop, bgp_attr, bgp, peers, false);
-                }
-            }
-            _ => {
-                //
             }
         }
     }
@@ -9910,12 +9997,13 @@ mod tests {
             prefix_sid: Some(bgp_packet::PrefixSid {
                 tlvs: vec![bgp_packet::PrefixSidTlv::Srv6L3Service(
                     bgp_packet::Srv6ServiceTlv {
-                        sids: vec![bgp_packet::Srv6SidInfo {
+                        sids: vec![bgp_packet::Srv6SidInfo::new(
                             sid,
-                            flags: 0,
-                            behavior: bgp_packet::SRV6_BEHAVIOR_END_DT46,
-                            structure: None,
-                        }],
+                            0,
+                            bgp_packet::SRV6_BEHAVIOR_END_DT46,
+                            None,
+                        )],
+                        ..Default::default()
                     },
                 )],
             }),


### PR DESCRIPTION
## Summary

Hardens the BGP Prefix-SID attribute (type 40) SRv6 service codec to RFC 9252 and adds RFC 7606 treat-as-withdraw for a malformed Prefix-SID.

- **§2 propagation fidelity** — preserve unknown SRv6 service sub-TLVs / sub-sub-TLVs and all RESERVED octets verbatim, so a next-hop-unchanged re-advertisement is bit-exact. New `RawSubTlv`; `Srv6ServiceTlv` / `Srv6SidInfo` gain `reserved` + unknown lists; `Srv6SidInfo::new` keeps producers terse.
- **§7 malformed detection** — reject a SID Information sub-TLV shorter than its fixed 21-octet head.
- **RFC 7606 treat-as-withdraw** — `Attr::parse_attr` split into framing + value so a Value error is recoverable; a malformed Prefix-SID now sets `UpdatePacket.treat_as_withdraw` instead of failing the parse (which previously tore the whole BGP session down). `route_from_peer` routes every reachable NLRI through its `*_withdraw` path (`withdraw_mp_reach`) while honouring the UPDATE's explicit withdrawals and keeping the session up.
- **docs** — `docs/design/bgp-prefix-sid-rfc9252.md`, including why the SRv6 **L2** Service producer is gated on the dataplane (mainline Linux `seg6local` has no End.DT2U/End.DT2M and no native L2 ingress encap).

## Test plan

- `cargo test --workspace --exclude bdd` — green.
- `cargo clippy --workspace --all-targets` — clean.
- `cargo fmt` — applied.
- New unit tests: bit-exact preservation of RESERVED + unknown sub-/sub-sub-TLVs; struct round-trip with unknowns; under-length SID-info rejection; malformed Prefix-SID → treat-as-withdraw (ORIGIN survives, Prefix-SID discarded, session not reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)