### PR TITLE
bgp: add `show bgp` command tree with positional IPv4 shortcut

### DIFF
--- a/bdd/tests/configs/bgp_show/z1.yaml
+++ b/bdd/tests/configs/bgp_show/z1.yaml
@@ -1,0 +1,18 @@
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.0.0/24
+      - prefix: 10.0.0.128/25
+      - prefix: 10.0.0.1/32

--- a/bdd/tests/configs/bgp_show/z2.yaml
+++ b/bdd/tests/configs/bgp_show/z2.yaml
@@ -1,0 +1,12 @@
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001

--- a/bdd/tests/features/bgp_show.feature
+++ b/bdd/tests/features/bgp_show.feature
@@ -1,0 +1,86 @@
+@serial
+@bgp_show
+Feature: BGP show command tree (show bgp ...)
+  As a network operator
+  I want the new `show bgp [ipv4|ipv6] [<addr>|<prefix> [longer-prefix]]`
+  command tree to render the BGP RIB, including the IPv4 shortcut where
+  an address or prefix is typed straight after `show bgp` (no AFI keyword).
+
+  Test Topology:
+  ```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬────────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+  ```
+
+  z1 originates a covering prefix (10.0.0.0/24), a more-specific
+  (10.0.0.128/25), and a host route (10.0.0.1/32) so the longest-match
+  and longer-prefix views have a real prefix hierarchy to display. z2 is
+  the receiver where the `show bgp ...` output is checked.
+
+  Scenario: Setup topology and establish BGP session
+    Given a clean test environment
+    When I create bridge "br0"
+    And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
+    And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 5 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+
+  Scenario: Routes propagate to z2
+    Given the test topology exists
+    When I wait 30 seconds for BGP to operate
+    Then BGP route in "z2" has "10.0.0.0/24"
+    And BGP route in "z2" has "10.0.0.128/25"
+    And BGP route in "z2" has "10.0.0.1/32"
+
+  Scenario: "show bgp" defaults to the IPv4 unicast table
+    Given the test topology exists
+    Then show command "show bgp" in namespace "z2" should contain "10.0.0.0/24"
+    And show command "show bgp" in namespace "z2" should contain "10.0.0.128/25"
+    And show command "show bgp" in namespace "z2" should contain "10.0.0.1/32"
+
+  Scenario: "show bgp ipv4" renders the same IPv4 unicast table
+    Given the test topology exists
+    Then show command "show bgp ipv4" in namespace "z2" should contain "10.0.0.0/24"
+    And show command "show bgp ipv4" in namespace "z2" should contain "10.0.0.1/32"
+
+  Scenario: "show bgp A.B.C.D" shortcut shows the longest match
+    Given the test topology exists
+    Then show command "show bgp 10.0.0.1" in namespace "z2" should contain "BGP routing table entry for 10.0.0.1/32"
+    And show command "show bgp ipv4 10.0.0.1" in namespace "z2" should contain "BGP routing table entry for 10.0.0.1/32"
+
+  Scenario: "show bgp A.B.C.D/M" shortcut shows the exact prefix
+    Given the test topology exists
+    Then show command "show bgp 10.0.0.0/24" in namespace "z2" should contain "BGP routing table entry for 10.0.0.0/24"
+    And show command "show bgp ipv4 10.0.0.0/24" in namespace "z2" should contain "BGP routing table entry for 10.0.0.0/24"
+
+  Scenario: "longer-prefix" shows the prefix and every more-specific entry
+    Given the test topology exists
+    Then show command "show bgp 10.0.0.0/24 longer-prefix" in namespace "z2" should contain "10.0.0.0/24"
+    And show command "show bgp 10.0.0.0/24 longer-prefix" in namespace "z2" should contain "10.0.0.128/25"
+    And show command "show bgp 10.0.0.0/24 longer-prefix" in namespace "z2" should contain "10.0.0.1/32"
+
+  Scenario: "show bgp ipv6" dispatches to the IPv6 unicast table
+    Given the test topology exists
+    Then show command "show bgp ipv6" in namespace "z2" should contain "Network"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete bridge "br0"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1,9 +1,11 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Write;
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use bgp_packet::*;
+use ipnet::{Ipv4Net, Ipv6Net};
+use prefix_trie::{Prefix, PrefixMap};
 use serde::Serialize;
 
 use super::cap::CapAfiMap;
@@ -386,19 +388,53 @@ struct BgpVpnv4RouteJson {
     label: u32,
 }
 
-fn show_bgp<V: BgpShowView>(
-    bgp: &V,
-    _args: Args,
+/// One Loc-RIB row in `show bgp` table format. Shared by the full
+/// table dump and the `longer-prefix` filter so both render identically.
+fn write_bgp_route_line(
+    buf: &mut String,
+    prefix: &str,
+    rib: &BgpRib,
+) -> std::result::Result<(), std::fmt::Error> {
+    let stale = if rib.stale { "S" } else { " " };
+    let valid = "*";
+    let best = if rib.best_path { ">" } else { " " };
+    let internal = if rib.typ == BgpRibType::IBGP {
+        "i"
+    } else {
+        " "
+    };
+    let nexthop = show_nexthop(&rib.attr);
+    let med = show_med(&rib.attr);
+    let local_pref = show_local_pref(&rib.attr);
+    let weight = rib.weight;
+    let mut aspath = show_aspath(&rib.attr);
+    if !aspath.is_empty() {
+        aspath.push(' ');
+    }
+    let origin = show_origin(&rib.attr);
+    writeln!(
+        buf,
+        "{stale}{valid}{best}{internal} {:18} {:18} {:>7} {:>6} {:>6} {}{}",
+        prefix, nexthop, med, local_pref, weight, aspath, origin,
+    )
+}
+
+/// Render a unicast Loc-RIB (IPv4 or IPv6) in `show bgp` table format,
+/// or as a JSON array when `json` is set. Family-agnostic: keyed only
+/// on the prefix's `Display` and the family-neutral `BgpRib`/`BgpAttr`.
+fn render_unicast_table<P>(
+    table: &PrefixMap<P, Vec<BgpRib>>,
     json: bool,
-) -> std::result::Result<String, std::fmt::Error> {
+) -> std::result::Result<String, std::fmt::Error>
+where
+    P: Prefix + std::fmt::Display,
+{
     if json {
         let mut routes: Vec<BgpRouteJson> = Vec::new();
-
-        for (key, value) in bgp.local_rib().v4.0.iter() {
+        for (key, value) in table.iter() {
             for rib in value.iter() {
                 let aspath_str = show_aspath(&rib.attr);
                 let origin_str = show_origin(&rib.attr);
-
                 routes.push(BgpRouteJson {
                     prefix: key.to_string(),
                     valid: true,
@@ -432,42 +468,24 @@ fn show_bgp<V: BgpShowView>(
     }
 
     let mut buf = String::new();
-
     buf.push_str(SHOW_BGP_HEADER);
-
-    for (key, value) in bgp.local_rib().v4.0.iter() {
+    for (key, value) in table.iter() {
         for rib in value.iter() {
-            let stale = if rib.stale { "S" } else { " " };
-            let valid = "*";
-            let best = if rib.best_path { ">" } else { " " };
-            let internal = if rib.typ == BgpRibType::IBGP {
-                "i"
-            } else {
-                " "
-            };
-            let nexthop = show_nexthop(&rib.attr);
-            let med = show_med(&rib.attr);
-            let local_pref = show_local_pref(&rib.attr);
-            let weight = rib.weight;
-            let mut aspath = show_aspath(&rib.attr);
-            if !aspath.is_empty() {
-                aspath.push(' ');
-            }
-            let origin = show_origin(&rib.attr);
-            writeln!(
-                buf,
-                "{stale}{valid}{best}{internal} {:18} {:18} {:>7} {:>6} {:>6} {}{}",
-                key.to_string(),
-                nexthop,
-                med,
-                local_pref,
-                weight,
-                aspath,
-                origin,
-            )?;
+            write_bgp_route_line(&mut buf, &key.to_string(), rib)?;
         }
     }
     Ok(buf)
+}
+
+/// `show ip bgp` — IPv4 unicast Loc-RIB (legacy tree). The new
+/// `show bgp [ipv4]` tree shares the same renderer via
+/// [`render_unicast_table`].
+fn show_bgp<V: BgpShowView>(
+    bgp: &V,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    render_unicast_table(&bgp.local_rib().v4.0, json)
 }
 
 /// `show ip bgp labeled-unicast` — render the IPv4 and IPv6
@@ -1001,116 +1019,255 @@ fn show_bgp_vpnv4_route(
     Ok(out)
 }
 
+/// IOS-XR-style detail block for one prefix's path set. Shared by the
+/// address (longest-match) and exact-prefix lookups across both
+/// families — family-neutral, keyed only on the prefix `Display` and
+/// the family-agnostic `BgpRib`/`BgpAttr`.
+fn write_bgp_entry_detail<V: BgpShowView>(
+    out: &mut String,
+    bgp: &V,
+    prefix: &str,
+    ribs: &[BgpRib],
+) -> std::result::Result<(), std::fmt::Error> {
+    writeln!(out, "BGP routing table entry for {}", prefix)?;
+    writeln!(out, "Paths: ({} available)", ribs.len())?;
+    for rib in ribs.iter() {
+        // Display path identifier and router ID
+        let best_marker = if rib.best_path { " best" } else { "" };
+        let internal_marker = if rib.typ == BgpRibType::IBGP {
+            "internal"
+        } else {
+            "external"
+        };
+
+        let from_addr = bgp
+            .peers()
+            .addr_of(rib.ident)
+            .map(|a| a.to_string())
+            .unwrap_or_else(|| "self".to_string());
+        writeln!(
+            out,
+            "  {} ({}), ({}{}) from {}",
+            show_nexthop(&rib.attr),
+            rib.router_id,
+            internal_marker,
+            best_marker,
+            from_addr
+        )?;
+
+        // Display origin
+        let origin_str = if let Some(origin) = &rib.attr.origin {
+            match origin {
+                Origin::Igp => "IGP",
+                Origin::Egp => "EGP",
+                Origin::Incomplete => "incomplete",
+            }
+        } else {
+            "incomplete"
+        };
+
+        // Build attribute line
+        let mut attr_parts = vec![format!("Origin {}", origin_str)];
+
+        if let Some(med) = &rib.attr.med {
+            attr_parts.push(format!("metric {}", med.med));
+        }
+
+        if let Some(local_pref) = &rib.attr.local_pref {
+            attr_parts.push(format!("localpref {}", local_pref.local_pref));
+        }
+
+        writeln!(out, "    {}", attr_parts.join(", "))?;
+
+        // Display AS path if present
+        if let Some(aspath) = &rib.attr.aspath
+            && !aspath.segs.is_empty()
+        {
+            writeln!(out, "    AS path: {}", aspath)?;
+        }
+
+        // Display route reflection attributes if present (RFC 4456)
+        if let Some(originator_id) = &rib.attr.originator_id {
+            write!(out, "    Originator: {}", originator_id.id)?;
+
+            if let Some(cluster_list) = &rib.attr.cluster_list {
+                write!(out, ", Cluster list: ")?;
+                let cluster_ids: Vec<String> =
+                    cluster_list.list.iter().map(|id| id.to_string()).collect();
+                write!(out, "{}", cluster_ids.join(" "))?;
+            }
+            writeln!(out)?;
+        } else if let Some(cluster_list) = &rib.attr.cluster_list {
+            // Cluster list without originator (shouldn't normally happen, but handle it)
+            write!(out, "    Cluster list: ")?;
+            let cluster_ids: Vec<String> =
+                cluster_list.list.iter().map(|id| id.to_string()).collect();
+            writeln!(out, "{}", cluster_ids.join(" "))?;
+        }
+
+        // Surface BGP Color extended communities (RFC 9012 §4.3)
+        // and the BGP Prefix-SID Label-Index (RFC 8669 §3.1).
+        // The future color-aware nexthop resolver consumes these;
+        // surfacing here gives operators visibility before the
+        // resolver lands.
+        let colors: Vec<String> = rib
+            .attr
+            .colors()
+            .map(|c| format!("{} (CO={})", c.color, c.co_bits()))
+            .collect();
+        if !colors.is_empty() {
+            writeln!(out, "    Color: {}", colors.join(", "))?;
+        }
+        if let Some(li) = rib.attr.prefix_sid_label_index() {
+            writeln!(out, "    Prefix-SID Label-Index: {}", li)?;
+        }
+
+        writeln!(out)?;
+    }
+    Ok(())
+}
+
+/// `show ip bgp <A.B.C.D>` (legacy tree) — longest-match detail for one
+/// IPv4 address. The new `show bgp [ipv4] …` tree reuses
+/// [`write_bgp_entry_detail`] via [`show_bgp_ipv4`].
 fn show_bgp_route_entry(
     bgp: &Bgp,
     mut args: Args,
     _json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
     let mut out = String::new();
-
     let addr = match args.v4addr() {
         Some(addr) => addr,
         None => return Ok(String::from("% No BGP route exists")),
     };
-    let host = addr.to_host_prefix();
-    if let Some(ribs) = bgp.local_rib.v4.0.get_lpm(&host) {
-        writeln!(out, "BGP routing table entry for {}", ribs.0)?;
-        writeln!(out, "Paths: ({} available)", ribs.1.len())?;
-        for rib in ribs.1.iter() {
-            // Display path identifier and router ID
-            let best_marker = if rib.best_path { " best" } else { "" };
-            let internal_marker = if rib.typ == BgpRibType::IBGP {
-                "internal"
-            } else {
-                "external"
-            };
+    if let Some((prefix, ribs)) = bgp.local_rib.v4.0.get_lpm(&addr.to_host_prefix()) {
+        write_bgp_entry_detail(&mut out, bgp, &prefix.to_string(), ribs)?;
+    }
+    Ok(out)
+}
 
-            let from_addr = bgp
-                .peers
-                .addr_of(rib.ident)
-                .map(|a| a.to_string())
-                .unwrap_or_else(|| "self".to_string());
-            writeln!(
-                out,
-                "  {} ({}), ({}{}) from {}",
-                show_nexthop(&rib.attr),
-                rib.router_id,
-                internal_marker,
-                best_marker,
-                from_addr
-            )?;
-
-            // Display origin
-            let origin_str = if let Some(origin) = &rib.attr.origin {
-                match origin {
-                    Origin::Igp => "IGP",
-                    Origin::Egp => "EGP",
-                    Origin::Incomplete => "incomplete",
+/// `show bgp` / `show bgp ipv4 [A.B.C.D | A.B.C.D/M]` — IPv4 unicast.
+/// No value dumps the whole Loc-RIB; an address shows the longest
+/// match (the routes that contain it); a prefix shows that exact entry.
+fn show_bgp_ipv4<V: BgpShowView>(
+    bgp: &V,
+    mut args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let Some(tok) = args.string() else {
+        return render_unicast_table(&bgp.local_rib().v4.0, json);
+    };
+    let mut out = String::new();
+    if tok.contains('/') {
+        match tok.parse::<Ipv4Net>() {
+            Ok(net) => {
+                if let Some(ribs) = bgp.local_rib().v4.0.get(&net) {
+                    write_bgp_entry_detail(&mut out, bgp, &net.to_string(), ribs)?;
                 }
-            } else {
-                "incomplete"
-            };
-
-            // Build attribute line
-            let mut attr_parts = vec![format!("Origin {}", origin_str)];
-
-            if let Some(med) = &rib.attr.med {
-                attr_parts.push(format!("metric {}", med.med));
             }
-
-            if let Some(local_pref) = &rib.attr.local_pref {
-                attr_parts.push(format!("localpref {}", local_pref.local_pref));
-            }
-
-            writeln!(out, "    {}", attr_parts.join(", "))?;
-
-            // Display AS path if present
-            if let Some(aspath) = &rib.attr.aspath
-                && !aspath.segs.is_empty()
-            {
-                writeln!(out, "    AS path: {}", aspath)?;
-            }
-
-            // Display route reflection attributes if present (RFC 4456)
-            if let Some(originator_id) = &rib.attr.originator_id {
-                write!(out, "    Originator: {}", originator_id.id)?;
-
-                if let Some(cluster_list) = &rib.attr.cluster_list {
-                    write!(out, ", Cluster list: ")?;
-                    let cluster_ids: Vec<String> =
-                        cluster_list.list.iter().map(|id| id.to_string()).collect();
-                    write!(out, "{}", cluster_ids.join(" "))?;
+            Err(_) => writeln!(out, "% Malformed IPv4 prefix: {tok}")?,
+        }
+    } else {
+        match tok.parse::<Ipv4Addr>() {
+            Ok(addr) => {
+                if let Some((prefix, ribs)) = bgp.local_rib().v4.0.get_lpm(&addr.to_host_prefix()) {
+                    write_bgp_entry_detail(&mut out, bgp, &prefix.to_string(), ribs)?;
                 }
-                writeln!(out)?;
-            } else if let Some(cluster_list) = &rib.attr.cluster_list {
-                // Cluster list without originator (shouldn't normally happen, but handle it)
-                write!(out, "    Cluster list: ")?;
-                let cluster_ids: Vec<String> =
-                    cluster_list.list.iter().map(|id| id.to_string()).collect();
-                writeln!(out, "{}", cluster_ids.join(" "))?;
             }
-
-            // Surface BGP Color extended communities (RFC 9012 §4.3)
-            // and the BGP Prefix-SID Label-Index (RFC 8669 §3.1).
-            // The future color-aware nexthop resolver consumes these;
-            // surfacing here gives operators visibility before the
-            // resolver lands.
-            let colors: Vec<String> = rib
-                .attr
-                .colors()
-                .map(|c| format!("{} (CO={})", c.color, c.co_bits()))
-                .collect();
-            if !colors.is_empty() {
-                writeln!(out, "    Color: {}", colors.join(", "))?;
-            }
-            if let Some(li) = rib.attr.prefix_sid_label_index() {
-                writeln!(out, "    Prefix-SID Label-Index: {}", li)?;
-            }
-
-            writeln!(out)?;
+            Err(_) => writeln!(out, "% Malformed IPv4 address: {tok}")?,
         }
     }
+    Ok(out)
+}
 
+/// `show bgp ipv4 A.B.C.D/M longer-prefix` — the prefix and every more
+/// specific entry (equal-or-longer), in table format.
+fn show_bgp_ipv4_longer<V: BgpShowView>(
+    bgp: &V,
+    mut args: Args,
+    _json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let mut out = String::new();
+    let Some(tok) = args.string() else {
+        return Ok(String::from("% Specify an IPv4 prefix\n"));
+    };
+    let net = if tok.contains('/') {
+        tok.parse::<Ipv4Net>().ok()
+    } else {
+        tok.parse::<Ipv4Addr>().ok().map(|a| a.to_host_prefix())
+    };
+    let Some(net) = net else {
+        writeln!(out, "% Malformed IPv4 prefix: {tok}")?;
+        return Ok(out);
+    };
+    out.push_str(SHOW_BGP_HEADER);
+    for (prefix, ribs) in bgp.local_rib().v4.0.children(&net) {
+        for rib in ribs.iter() {
+            write_bgp_route_line(&mut out, &prefix.to_string(), rib)?;
+        }
+    }
+    Ok(out)
+}
+
+/// `show bgp ipv6 [X:X::X:X | X:X::X:X/M]` — IPv6 unicast sibling of
+/// [`show_bgp_ipv4`].
+fn show_bgp_ipv6<V: BgpShowView>(
+    bgp: &V,
+    mut args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let Some(tok) = args.string() else {
+        return render_unicast_table(&bgp.local_rib().v6.0, json);
+    };
+    let mut out = String::new();
+    if tok.contains('/') {
+        match tok.parse::<Ipv6Net>() {
+            Ok(net) => {
+                if let Some(ribs) = bgp.local_rib().v6.0.get(&net) {
+                    write_bgp_entry_detail(&mut out, bgp, &net.to_string(), ribs)?;
+                }
+            }
+            Err(_) => writeln!(out, "% Malformed IPv6 prefix: {tok}")?,
+        }
+    } else {
+        match tok.parse::<Ipv6Addr>() {
+            Ok(addr) => {
+                if let Some((prefix, ribs)) = bgp.local_rib().v6.0.get_lpm(&addr.to_host_prefix()) {
+                    write_bgp_entry_detail(&mut out, bgp, &prefix.to_string(), ribs)?;
+                }
+            }
+            Err(_) => writeln!(out, "% Malformed IPv6 address: {tok}")?,
+        }
+    }
+    Ok(out)
+}
+
+/// `show bgp ipv6 X:X::X:X/M longer-prefix` — IPv6 sibling of
+/// [`show_bgp_ipv4_longer`].
+fn show_bgp_ipv6_longer<V: BgpShowView>(
+    bgp: &V,
+    mut args: Args,
+    _json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    let mut out = String::new();
+    let Some(tok) = args.string() else {
+        return Ok(String::from("% Specify an IPv6 prefix\n"));
+    };
+    let net = if tok.contains('/') {
+        tok.parse::<Ipv6Net>().ok()
+    } else {
+        tok.parse::<Ipv6Addr>().ok().map(|a| a.to_host_prefix())
+    };
+    let Some(net) = net else {
+        writeln!(out, "% Malformed IPv6 prefix: {tok}")?;
+        return Ok(out);
+    };
+    out.push_str(SHOW_BGP_HEADER);
+    for (prefix, ribs) in bgp.local_rib().v6.0.children(&net) {
+        for rib in ribs.iter() {
+            write_bgp_route_line(&mut out, &prefix.to_string(), rib)?;
+        }
+    }
     Ok(out)
 }
 
@@ -3214,5 +3371,16 @@ impl Bgp {
             "/show/bgp/update-group",
             super::show_update_group::show_bgp_update_group,
         );
+
+        // New `show bgp [ipv4|ipv6] [<addr>|<prefix> [longer-prefix]]`
+        // tree. `show bgp` with no AFI is IPv4 unicast; a bare address
+        // or prefix after `bgp` is routed here by the `ext:default-child
+        // "ipv4"` matcher, so `/show/bgp` and `/show/bgp/ipv4` share one
+        // handler.
+        self.show_add("/show/bgp", show_bgp_ipv4::<Bgp>);
+        self.show_add("/show/bgp/ipv4", show_bgp_ipv4::<Bgp>);
+        self.show_add("/show/bgp/ipv4/longer-prefix", show_bgp_ipv4_longer::<Bgp>);
+        self.show_add("/show/bgp/ipv6", show_bgp_ipv6::<Bgp>);
+        self.show_add("/show/bgp/ipv6/longer-prefix", show_bgp_ipv6_longer::<Bgp>);
     }
 }

--- a/zebra-rs/src/config/comps.rs
+++ b/zebra-rs/src/config/comps.rs
@@ -195,6 +195,40 @@ fn comps_as_leaf(comps: &mut Vec<Completion>, entry: &Rc<Entry>) {
     comps.push(comps_as_key(entry));
 }
 
+/// Emit the positional completion hints contributed by a container's
+/// `ext:default-child`. The named child's key may be typed without the
+/// child's own keyword (`show bgp <tab>` -> `<A.B.C.D>` / `<A.B.C.D/M>`),
+/// so surface that key's type hint(s) next to the child keywords. A
+/// union key contributes one hint per arm.
+fn comps_default_child_key(comps: &mut Vec<Completion>, parent: &Rc<Entry>) {
+    let Some(name) = parent.extension.get("ext:default-child") else {
+        return;
+    };
+    let dir = parent.dir.borrow();
+    let Some(child) = dir.iter().find(|e| &e.name == name) else {
+        return;
+    };
+    let Some(key) = child.key.first() else {
+        return;
+    };
+    let child_dir = child.dir.borrow();
+    let Some(key_leaf) = child_dir.iter().find(|e| &e.name == key) else {
+        return;
+    };
+    let Some(node) = &key_leaf.type_node else {
+        return;
+    };
+    if node.kind == YangType::Union {
+        for n in node.union.iter() {
+            let kind = ytype_from_typedef(&n.typedef).unwrap_or(n.kind);
+            comps.push(Completion::new_name(ytype_str(&kind)));
+        }
+    } else {
+        let kind = ytype_from_typedef(&node.typedef).unwrap_or(node.kind);
+        comps.push(Completion::new_name(ytype_str(&kind)));
+    }
+}
+
 pub fn comps_add_all(
     comps: &mut Vec<Completion>,
     ymatch: YangMatch,
@@ -211,6 +245,7 @@ pub fn comps_add_all(
             for entry in entry.dir.borrow().iter() {
                 comps.push(centry(entry));
             }
+            comps_default_child_key(comps, entry);
         }
         YangMatch::KeyMatched => {
             for e in entry.dir.borrow().iter() {

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -450,6 +450,24 @@ fn entry_match_key_matched(entry: &Rc<Entry>, str: &str, m: &mut Match) {
     }
 }
 
+/// Resolve a container's `ext:default-child` to the child entry it
+/// names. That child's key may be supplied positionally — without
+/// typing the child's own keyword (see [`parse`]).
+fn default_child_entry(entry: &Rc<Entry>) -> Option<Rc<Entry>> {
+    let name = entry.extension.get("ext:default-child")?;
+    entry.dir.borrow().iter().find(|e| &e.name == name).cloned()
+}
+
+/// Type-match `input` against the first key of `child` (the
+/// `ext:default-child`), recording the match and its completion hints
+/// in `m`. Used both to decide a positional descent and to surface the
+/// key's hints (`<A.B.C.D>`, …) during completion.
+fn entry_match_default_key(child: &Rc<Entry>, input: &str, m: &mut Match, s: &mut State) {
+    if let Some(key_leaf) = entry_key(child, 0) {
+        entry_match_type(&key_leaf, input, m, s);
+    }
+}
+
 fn ymatch_next(entry: &Rc<Entry>, ymatch: YangMatch) -> YangMatch {
     match ymatch {
         YangMatch::Dir | YangMatch::DirMatched | YangMatch::KeyMatched => {
@@ -551,6 +569,39 @@ pub fn parse(
         YangMatch::LeafMatched => {
             // Nothing to do.
         }
+    }
+
+    // `ext:default-child` positional value. A container may name a
+    // child whose key can be typed without the child's own keyword
+    // (`show bgp 10.0.0.1` == `show bgp ipv4 10.0.0.1`). Probe that
+    // child's key in a side `Match` so the normal transition below is
+    // left untouched, then either descend into the child (the value is
+    // the winner) or fold the key's completion hints into `mx` (so
+    // `show bgp <tab>` still advertises <A.B.C.D> / <A.B.C.D/M>). IP
+    // literals never collide with the sibling keywords, so this can
+    // only fire on the value branch — no existing command regresses.
+    if !s.set
+        && !s.delete
+        && matches!(s.ymatch, YangMatch::Dir | YangMatch::DirMatched)
+        && let Some(child) = default_child_entry(&entry)
+    {
+        let mut pmx = Match::default();
+        entry_match_default_key(&child, input, &mut pmx, &mut s);
+        if pmx.matched_type >= MatchType::Partial && pmx.matched_type > mx.matched_type {
+            // Inject a zero-width synthetic step for the child name (no
+            // input consumed) and re-parse the same token as the child's
+            // key. The resulting path/args are identical to the explicit
+            // `... <child> <value>` form.
+            s.paths.push(CommandPath {
+                name: child.name.clone(),
+                ymatch: YangMatch::Key.into(),
+                ..Default::default()
+            });
+            s.ymatch = YangMatch::Key;
+            s.index = 0;
+            return parse(input, child, config, s);
+        }
+        comps_append(&mut pmx.comps, &mut mx.comps);
     }
 
     // "delete" overwrite entry completion with config completion.
@@ -800,5 +851,91 @@ mod tests {
         let pat = r"[a-fA-F0-9]{2}(\.[a-fA-F0-9]{4}){3,9}\.[a-fA-F0-9]{2}";
         let (m, _) = match_regexp("not-an-nsap", pat);
         assert_eq!(m, MatchType::None);
+    }
+
+    /// Build the operational-mode (`exec`) entry tree from the real
+    /// YANG so the positional `show bgp …` grammar is exercised end to
+    /// end — the `ext:default-child` matcher feature plus the schema.
+    fn exec_entry() -> Rc<Entry> {
+        use libyang::{YangStore, to_entry};
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("exec").expect("exec mode loads");
+        yang.identity_resolve();
+        let module = yang.find_module("exec").expect("exec module present");
+        to_entry(&yang, module)
+    }
+
+    /// `ext:default-child "ipv4"` lets an address/prefix be typed right
+    /// after `show bgp`; the explicit `show bgp ipv4 …` form parses to
+    /// the very same path + args. `longer-prefix` rides along as a
+    /// trailing keyword, and keyword children (`update-group`) are not
+    /// swallowed by the positional fallback.
+    #[test]
+    fn show_bgp_positional_default_child() {
+        use crate::config::path_from_command;
+        let entry = exec_entry();
+
+        let cases: Vec<(&str, &str, Vec<&str>)> = vec![
+            ("show bgp", "/show/bgp", vec![]),
+            ("show bgp ipv4", "/show/bgp/ipv4", vec![]),
+            ("show bgp ipv4 10.0.0.1", "/show/bgp/ipv4", vec!["10.0.0.1"]),
+            ("show bgp 10.0.0.1", "/show/bgp/ipv4", vec!["10.0.0.1"]),
+            (
+                "show bgp 10.0.0.0/24",
+                "/show/bgp/ipv4",
+                vec!["10.0.0.0/24"],
+            ),
+            (
+                "show bgp 10.0.0.0/24 longer-prefix",
+                "/show/bgp/ipv4/longer-prefix",
+                vec!["10.0.0.0/24"],
+            ),
+            (
+                "show bgp ipv6 2001:db8::1",
+                "/show/bgp/ipv6",
+                vec!["2001:db8::1"],
+            ),
+            (
+                "show bgp ipv6 2001:db8::/48 longer-prefix",
+                "/show/bgp/ipv6/longer-prefix",
+                vec!["2001:db8::/48"],
+            ),
+            ("show bgp update-group", "/show/bgp/update-group", vec![]),
+        ];
+
+        for &(cmd, want_path, ref want_args) in &cases {
+            let (code, _comps, state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "parse `{cmd}`");
+            let (path, args) = path_from_command(&state.paths);
+            assert_eq!(path, want_path, "path for `{cmd}`");
+            let got: Vec<&str> = args.0.iter().map(|s| s.as_str()).collect();
+            assert_eq!(&got, want_args, "args for `{cmd}`");
+        }
+    }
+
+    /// The positional shortcut is IPv4-only (`ext:default-child
+    /// "ipv4"`): a bare IPv6 literal after `show bgp` is not a command —
+    /// IPv6 must be reached through the explicit `ipv6` keyword.
+    #[test]
+    fn show_bgp_positional_is_ipv4_only() {
+        let entry = exec_entry();
+        for cmd in ["show bgp 2001:db8::1", "show bgp 2001:db8::/48"] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_ne!(code, ExecCode::Success, "`{cmd}` must not be a command");
+        }
+    }
+
+    /// `show bgp <tab>` advertises both the AFI keywords and the
+    /// positional value hints contributed by `ext:default-child`.
+    #[test]
+    fn show_bgp_completion_offers_positional_hint() {
+        let entry = exec_entry();
+        let (_code, comps, _state) = parse("show bgp ", entry, None, State::new());
+        let names: Vec<&str> = comps.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"ipv4"), "comps: {names:?}");
+        assert!(names.contains(&"ipv6"), "comps: {names:?}");
+        assert!(names.contains(&"<A.B.C.D>"), "comps: {names:?}");
+        assert!(names.contains(&"<A.B.C.D/M>"), "comps: {names:?}");
     }
 }

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -161,6 +161,46 @@ module exec {
     }
     container bgp {
       ext:help "BGP information";
+      // `show bgp` with no AFI keyword is IPv4 unicast. A bare address
+      // or prefix typed straight after `bgp` (`show bgp A.B.C.D`) is
+      // routed into `ipv4` by the matcher via `ext:default-child`.
+      ext:default-child "ipv4";
+      presence "BGP IPv4 unicast RIB (same as `show bgp ipv4`)";
+      list ipv4 {
+        ext:help "BGP IPv4 unicast RIB";
+        ext:presence "BGP IPv4 unicast RIB (all prefixes)";
+        key value;
+        leaf value {
+          ext:help "Address (routes containing it) or prefix (exact match)";
+          // A bare address does a longest-match lookup (routes that
+          // contain it); a prefix matches exactly. The handler tells
+          // them apart by the presence of `/M`.
+          type union {
+            type inet:ipv4-address;
+            type inet:ipv4-prefix;
+          }
+        }
+        leaf longer-prefix {
+          ext:help "Prefixes equal to or more specific than the given prefix";
+          type empty;
+        }
+      }
+      list ipv6 {
+        ext:help "BGP IPv6 unicast RIB";
+        ext:presence "BGP IPv6 unicast RIB (all prefixes)";
+        key value;
+        leaf value {
+          ext:help "Address (routes containing it) or prefix (exact match)";
+          type union {
+            type inet:ipv6-address;
+            type inet:ipv6-prefix;
+          }
+        }
+        leaf longer-prefix {
+          ext:help "Prefixes equal to or more specific than the given prefix";
+          type empty;
+        }
+      }
       list update-group {
         ext:help "BGP update-groups (IOS-XR style)";
         ext:presence "BGP update-group summary";

--- a/zebra-rs/yang/extension.yang
+++ b/zebra-rs/yang/extension.yang
@@ -30,4 +30,15 @@ module extension {
     description "dyanamic completion";
     argument "dynamic";
   }
+
+  extension default-child {
+    description
+      "Names a child of this container whose key may be supplied
+       positionally — without typing the child's own keyword. When no
+       sibling keyword matches the input but it type-matches the named
+       child's key, the CLI matcher descends into that child as if its
+       keyword had been typed (e.g. `show bgp A.B.C.D` is rewritten to
+       `show bgp ipv4 A.B.C.D`). The argument is the child node name.";
+    argument "default-child";
+  }
 }


### PR DESCRIPTION
## Summary

Adds a new `show bgp [ipv4|ipv6] [<addr>|<prefix> [longer-prefix]]` command
tree alongside the existing `show ip bgp` (which is unchanged and stays).

- `show bgp` ≡ `show bgp ipv4` — the IPv4 unicast Loc-RIB table.
- An **address** does a longest-match lookup (routes containing it); a
  **prefix** matches exactly; **`longer-prefix`** lists the equal-or-more-specific
  entries.
- A bare IPv4 address/prefix may be typed straight after `show bgp`
  (`show bgp 10.0.0.1`) via a new **reusable `ext:default-child` YANG extension**:
  when no child keyword matches the input, the CLI matcher type-matches the
  named child's key and descends as if its keyword had been typed — so the
  shortcut parses identically to `show bgp ipv4 …`. IPv6 needs the explicit
  `ipv6` keyword (the shortcut is IPv4-only, by design).
- The IPv4/IPv6 handlers share family-generic renderers refactored out of the
  legacy `show ip bgp` path; that path's output is byte-identical.

No libyang change was needed — the parser feature reads a marker captured by
libyang's existing generic extension handling.

## Test plan

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --exclude bdd` — pass, including new `parse` unit
  tests (path+args for every form, IPv4-only guard, completion hint) and
  `yang_load`
- New `@bgp_show` BDD — 9 scenarios pass live (eBGP z1→z2; asserts the table,
  the positional address/prefix shortcut, longest-match, exact prefix,
  `longer-prefix`, and `show bgp ipv6` dispatch), ending with the mandated
  topology teardown

Generated with [Claude Code](https://claude.com/claude-code)
