### PR TITLE
bgp: implement plain IPv6 unicast origination, advertise, receive

### DIFF
--- a/crates/bgp-packet/src/attrs/attr.rs
+++ b/crates/bgp-packet/src/attrs/attr.rs
@@ -445,6 +445,20 @@ pub fn parse_bgp_update_attribute(
                             updates,
                         });
                     }
+                    MpReachAttr::Ipv6 {
+                        snpa,
+                        nhop,
+                        updates,
+                    } => {
+                        // Native IPv6 unicast. The v6 next-hop rides on the
+                        // MP_REACH and is stamped into the attr by the
+                        // consumer in `bgp/route.rs`; just surface the NLRI.
+                        mp_update = Some(MpReachAttr::Ipv6 {
+                            snpa,
+                            nhop,
+                            updates,
+                        });
+                    }
                     _ => {
                         //
                     }

--- a/crates/bgp-packet/src/attrs/mp_reach.rs
+++ b/crates/bgp-packet/src/attrs/mp_reach.rs
@@ -328,11 +328,25 @@ impl MpReachAttr {
             return Ok((input, mp_nlri));
         }
         if header.afi == Afi::Ip6 && header.safi == Safi::Unicast {
-            if header.nhop_len != 16 {
-                return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue)));
-            }
-            let (input, nhop) = be_u128(input)?;
-            let nhop = IpAddr::V6(Ipv6Addr::from(nhop));
+            // RFC 2545 §3: the next-hop is either a 16-octet global
+            // address, or a 32-octet (global || link-local) pair. FRR and
+            // most stacks send the 32-octet form on a shared link, so
+            // accept both; the global address is used for best-path / FIB
+            // (the link-local is ignored until v6 next-hop resolution
+            // needs it).
+            let (input, nhop) = match header.nhop_len {
+                16 => {
+                    let (input, global) = be_u128(input)?;
+                    (input, Ipv6Addr::from(global))
+                }
+                32 => {
+                    let (input, global) = be_u128(input)?;
+                    let (input, _link_local) = be_u128(input)?;
+                    (input, Ipv6Addr::from(global))
+                }
+                _ => return Err(nom::Err::Error(make_error(input, ErrorKind::LengthValue))),
+            };
+            let nhop = IpAddr::V6(nhop);
             let (input, snpa) = be_u8(input)?;
             let (_, updates) =
                 many0_complete(|i| Ipv6Nlri::parse_nlri(i, add_path)).parse(input)?;
@@ -1410,6 +1424,37 @@ mod tests {
                 assert_eq!(parsed, updates);
             }
             other => panic!("expected Flowspec, got {other:?}"),
+        }
+    }
+
+    /// RFC 2545 §3: an IPv6-unicast MP_REACH may carry a 32-octet
+    /// (global || link-local) next-hop. FRR sends this form by default;
+    /// the decoder must accept it (not just the 16-octet global-only
+    /// form) and surface the global address as the next-hop.
+    #[test]
+    fn ipv6_unicast_accepts_32_octet_next_hop() {
+        let global: Ipv6Addr = "2001:db8::1".parse().unwrap();
+        let link_local: Ipv6Addr = "fe80::1".parse().unwrap();
+        let prefix: ipnet::Ipv6Net = "2001:db8:ff00:2::/64".parse().unwrap();
+
+        let mut value = BytesMut::new();
+        value.put_u16(u16::from(Afi::Ip6));
+        value.put_u8(u8::from(Safi::Unicast));
+        value.put_u8(32); // next-hop length: global || link-local
+        value.put(&global.octets()[..]);
+        value.put(&link_local.octets()[..]);
+        value.put_u8(0); // SNPA
+        crate::Ipv6Nlri { id: 0, prefix }.nlri_emit(&mut value);
+
+        let (_rest, mp) = MpReachAttr::parse_nlri_opt(&value, None)
+            .expect("32-octet IPv6 unicast next-hop must parse");
+        match mp {
+            MpReachAttr::Ipv6 { nhop, updates, .. } => {
+                assert_eq!(nhop, IpAddr::V6(global), "global address used as next-hop");
+                assert_eq!(updates.len(), 1);
+                assert_eq!(updates[0].prefix, prefix);
+            }
+            other => panic!("expected Ipv6, got {other:?}"),
         }
     }
 

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -932,6 +932,14 @@ fn config_network(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
                 bgp.route_del(network);
             }
         }
+        (Afi::Ip6, Safi::Unicast) => {
+            let network = args.v6net()?;
+            if op.is_set() {
+                bgp.route_add_v6(network);
+            } else {
+                bgp.route_del_v6(network);
+            }
+        }
         (Afi::Ip, Safi::MplsLabel) => {
             let network = args.v4net()?;
             if op.is_set() {

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -7161,6 +7161,51 @@ pub fn route_sync_ipv4(peer: &mut Peer, bgp: &mut BgpTop) {
     send_eor_ipv4_unicast(peer);
 }
 
+/// Dump the global IPv6-unicast Loc-RIB to a newly-established peer —
+/// the v6 counterpart of [`route_sync_ipv4`]. Outbound policy is not
+/// applied on the v6-unicast path yet (consistent with the event-driven
+/// `route_advertise_to_peers_v6`); next-hop-self and eBGP AS_PATH
+/// prepend happen inside `route_update_ipv6`.
+pub fn route_sync_ipv6(peer: &mut Peer, bgp: &mut BgpTop) {
+    let add_path = peer.opt.is_add_path_send(Afi::Ip6, Safi::Unicast);
+
+    // Collect first to avoid borrowing `bgp.local_rib` across the loop.
+    let routes: Vec<(Ipv6Net, BgpRib)> = if add_path {
+        bgp.local_rib
+            .v6
+            .0
+            .iter()
+            .flat_map(|(prefix, ribs)| ribs.iter().map(move |rib| (prefix, rib.clone())))
+            .collect()
+    } else {
+        bgp.local_rib
+            .v6
+            .1
+            .iter()
+            .map(|(prefix, rib)| (prefix, rib.clone()))
+            .collect()
+    };
+
+    // Single-peer dump (see `send_ipv6_direct`): accumulate per shared
+    // attr-set and emit straight to this peer rather than through the
+    // group cache. No Adj-RIB-Out registration — v6-unicast `adj_out`
+    // tracking isn't wired (the event-driven `route_advertise_to_peers_v6`
+    // skips it too); revisit when `show bgp neighbors <X> advertised-routes`
+    // grows v6 support.
+    let mut entries: Vec<(Arc<BgpAttr>, Ipv6Nlri)> = Vec::new();
+    for (prefix, rib) in routes {
+        let Some((nlri, attr)) = route_update_ipv6(peer, &prefix, &rib, bgp, add_path) else {
+            continue;
+        };
+        let arc_attr = bgp.attr_store.intern(attr);
+        entries.push((arc_attr, nlri));
+    }
+    super::update_group::send_ipv6_direct(peer, entries);
+
+    // End-of-RIB marker for IPv6 Unicast.
+    send_eor_ipv6_unicast(peer);
+}
+
 pub fn route_sync_vpnv4(peer: &mut Peer, bgp: &mut BgpTop) {
     let add_path = peer.opt.is_add_path_send(Afi::Ip, Safi::MplsVpn);
 
@@ -7232,6 +7277,14 @@ pub fn route_sync_vpnv4(peer: &mut Peer, bgp: &mut BgpTop) {
 // Send End-of-RIB marker for IPv4 Unicast.
 fn send_eor_ipv4_unicast(peer: &mut Peer) {
     let update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    peer.send_packet(update.into());
+}
+
+// Send End-of-RIB marker for IPv6 Unicast: an empty MP_UNREACH(AFI=2,
+// SAFI=1), per RFC 4724 §2 (only IPv4 unicast uses the bare empty UPDATE).
+fn send_eor_ipv6_unicast(peer: &mut Peer) {
+    let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+    update.mp_withdraw = Some(MpUnreachAttr::Ipv6Eor);
     peer.send_packet(update.into());
 }
 
@@ -7426,6 +7479,9 @@ pub fn route_sync(peer: &mut Peer, bgp: &mut BgpTop) {
     if peer.is_afi_safi(Afi::Ip, Safi::Unicast) {
         route_sync_ipv4(peer, bgp);
     }
+    if peer.is_afi_safi(Afi::Ip6, Safi::Unicast) {
+        route_sync_ipv6(peer, bgp);
+    }
     if peer.is_afi_safi(Afi::Ip, Safi::MplsVpn) {
         let key = AfiSafi::new(Afi::Ip, Safi::Rtc);
         if !peer.eor.contains_key(&key) {
@@ -7535,6 +7591,81 @@ impl Bgp {
                 &mut bgp_ref,
                 &mut self.peers,
             );
+        }
+    }
+
+    /// Originate an IPv6 prefix into the global v6 unicast Loc-RIB from
+    /// a `network` statement under `afi-safi ipv6`. The v6 counterpart
+    /// of [`Self::route_add`]: weight 32768, no NEXT_HOP, so when it
+    /// wins best `fib_install_v6` cedes the FIB entry to the underlying
+    /// source (Connected / Static / IGP) rather than shadowing it.
+    pub fn route_add_v6(&mut self, prefix: Ipv6Net) {
+        let attr = BgpAttr::new();
+        let rib = BgpRib::new(
+            ORIGINATED_PEER,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            0,
+            32768,
+            &attr,
+            None,
+            None,
+            false,
+        );
+        let (_replaced, selected, _next_id) = self.local_rib.update_v6(prefix, rib);
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+            lu_labels: None,
+        };
+
+        fib_install_v6(&bgp_ref, prefix, &selected);
+
+        if !selected.is_empty() {
+            route_advertise_to_peers_v6(prefix, &selected, &mut bgp_ref, &mut self.peers);
+        }
+    }
+
+    pub fn route_del_v6(&mut self, prefix: Ipv6Net) {
+        let ident = ORIGINATED_PEER;
+        let removed = self.local_rib.remove_v6(prefix, 0, ident);
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+            lu_labels: None,
+        };
+
+        let selected = bgp_ref.local_rib.select_best_path_v6(prefix);
+        fib_install_v6(&bgp_ref, prefix, &selected);
+
+        if !selected.is_empty() || !removed.is_empty() {
+            route_advertise_to_peers_v6(prefix, &selected, &mut bgp_ref, &mut self.peers);
         }
     }
 

--- a/zebra-rs/src/bgp/update_group.rs
+++ b/zebra-rs/src/bgp/update_group.rs
@@ -959,6 +959,34 @@ fn encode_ipv6_update(
     out
 }
 
+/// Single-peer IPv6-unicast send, the v6 counterpart of
+/// [`send_ipv4_direct`]. Used by `route_sync_ipv6` on session establish:
+/// the per-group cache would fan out to every member and double-send to
+/// peers that already hold these routes, so the sync accumulates per
+/// shared attr-set and emits straight to the one new peer. The next-hop
+/// rides on the bucket-key attr (set to next-hop-self by
+/// `route_update_ipv6`), so there is no ENHE step.
+pub(super) fn send_ipv6_direct(peer: &Peer, entries: Vec<(Arc<BgpAttr>, Ipv6Nlri)>) {
+    if entries.is_empty() {
+        return;
+    }
+    let mut buckets: HashMap<Arc<BgpAttr>, Vec<Ipv6Nlri>> = HashMap::new();
+    for (attr, nlri) in entries {
+        buckets.entry(attr).or_default().push(nlri);
+    }
+    let max_packet_size = if peer.opt.extended_message {
+        bgp_packet::BGP_EXTENDED_PACKET_LEN
+    } else {
+        bgp_packet::BGP_PACKET_LEN
+    };
+    for (attr, nlris) in buckets {
+        let bytes_list = encode_ipv6_update(&attr, &nlris, max_packet_size);
+        for buf in bytes_list {
+            peer.send_packet(buf);
+        }
+    }
+}
+
 /// Build the `Ipv4MpReachNextHop` to advertise to `peer` for an
 /// RFC 8950 IPv4-over-IPv6 UPDATE. Returns `None` when the peer
 /// has no link-local on its egress interface — without a link-local


### PR DESCRIPTION
## Summary

Plain IPv6 unicast (SAFI 1) was only partially implemented, so `show bgp ipv6`
was always empty even with an Established, IPv6-Unicast-negotiated session. This
completes it across all three planes:

- **Origination** — `network <v6>` under `afi-safi ipv6` now originates into the
  v6 Loc-RIB. `config_network` had no `(Ip6,Unicast)` arm and no originator
  existed; added `route_add_v6`/`route_del_v6` mirroring the v4 `route_add`/`route_del`.
- **Advertise** — originated/received v6 routes are now advertised when a session
  comes up. `route_sync` had no v6-unicast branch; added `route_sync_ipv6` +
  `send_ipv6_direct` + `send_eor_ipv6_unicast` and dispatch them from `route_sync`.
- **Receive** — MP_REACH(AFI=2, SAFI=1) UPDATEs are now processed:
  - the attribute parser surfaced only Vpnv4/Evpn/Ipv4 as `mp_update`;
    `MpReachAttr::Ipv6` fell into `_ => {}` and was silently dropped — added the arm.
  - the v6-unicast MP_REACH decoder hard-rejected `nhop_len != 16`, but RFC 2545
    allows a 32-octet (global ‖ link-local) next-hop, which **FRR sends by
    default** — now accepts 16 or 32 and uses the global address.

## Test plan

- **End-to-end live** (zebra-rs ↔ zebra-rs eBGP over IPv6): origination →
  advertise-on-establish → receive → best-path → **kernel FIB install**, verified
  via `show bgp ipv6`, `show ip bgp summary` (PfxRcd), and
  `ip -6 route … proto bgp`.
- New **unit test** in `bgp-packet` covers the 32-octet next-hop decode (the FRR
  interop path).
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo test --workspace --exclude bdd`: all green.

## Follow-ups (not in this PR)

- The same attribute-parser `_ => {}` still drops **VPNv6, labeled-unicast,
  Flowspec, SR-Policy, MUP, RTC** on receive (only Vpnv4/Evpn/Ipv4 and now Ipv6
  are surfaced) — likely control-plane-only code that was never wire-validated.
- FRR interop (32-octet next-hop + SRv6 Prefix-SID) is covered by code + unit
  test; worth confirming against a live FRR peer.

Generated with [Claude Code](https://claude.com/claude-code)
