### PR TITLE
bgp: surface all MP_REACH families on receive

### DIFF
--- a/crates/bgp-packet/src/attrs/attr.rs
+++ b/crates/bgp-packet/src/attrs/attr.rs
@@ -459,8 +459,15 @@ pub fn parse_bgp_update_attribute(
                             updates,
                         });
                     }
-                    _ => {
-                        //
+                    // Every remaining MP family — VPNv6, IPv4/IPv6
+                    // Labeled-Unicast, Flowspec, SR-Policy, Route-Target
+                    // Constraint, BGP-LS, MUP — is dispatched by
+                    // `route_from_peer`. Surface it so the UPDATE reaches the
+                    // RIB instead of being silently dropped here; the
+                    // per-family next-hop travels on the variant and is read
+                    // by the consumer (these do not stamp `bgp_attr.nexthop`).
+                    other => {
+                        mp_update = Some(other);
                     }
                 }
             }
@@ -550,5 +557,46 @@ mod tests {
             "malformed Prefix-SID must be discarded"
         );
         assert!(mp_update.is_none() && mp_withdraw.is_none());
+    }
+
+    /// Regression: every MP family beyond Vpnv4/Evpn/Ipv4/Ipv6 (here a
+    /// Flowspec MP_REACH) used to fall into the `MpReachNlri` `_ => {}`
+    /// arm and never set `mp_update`, so the UPDATE was silently dropped
+    /// before reaching the RIB. They must now surface for dispatch.
+    #[test]
+    fn mp_reach_other_family_surfaces_as_mp_update() {
+        use crate::attrs::mp_reach::flowspec_attr_emit;
+        use crate::{Afi, FlowspecComponent, FlowspecNlri, FlowspecPrefix, MpReachAttr};
+        use bytes::BytesMut;
+
+        let updates = vec![FlowspecNlri::new(
+            Afi::Ip6,
+            vec![FlowspecComponent::DestinationPrefix(FlowspecPrefix::V6 {
+                length: 64,
+                offset: 0,
+                pattern: "2001:db8::".parse::<std::net::Ipv6Addr>().unwrap().octets()[..8].to_vec(),
+            })],
+        )];
+
+        let mut block = vec![0x40, 0x01, 0x01, 0x00]; // ORIGIN = IGP
+        let mut attr = BytesMut::new();
+        flowspec_attr_emit(Afi::Ip6, &updates, &mut attr);
+        block.extend_from_slice(&attr);
+
+        let len = block.len() as u16;
+        let (_, bgp_attr, mp_update, _mp_withdraw, treat_as_withdraw) =
+            parse_bgp_update_attribute(&block, len, false, None).expect("attrs must parse");
+        assert!(!treat_as_withdraw);
+        assert!(bgp_attr.is_some());
+        match mp_update {
+            Some(MpReachAttr::Flowspec {
+                afi,
+                updates: parsed,
+            }) => {
+                assert_eq!(afi, Afi::Ip6);
+                assert_eq!(parsed, updates);
+            }
+            other => panic!("Flowspec MP_REACH must surface as mp_update, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

The UPDATE attribute parser only set `mp_update` for `Vpnv4`/`Evpn`/`Ipv4`/`Ipv6`
MP_REACH families; every other family — **VPNv6, IPv4/IPv6 Labeled-Unicast,
Flowspec, SR-Policy, Route-Target Constraint (v4/v6), BGP-LS, MUP** — fell into
the `_ => {}` arm and was **silently dropped** before `route_from_peer` could
dispatch it, even though `route_from_peer` already has receive arms for all of
them. So those families were unreachable on the wire.

This replaces the catch-all with `other => { mp_update = Some(other) }`, surfacing
the parsed NLRI for dispatch. The per-family next-hop travels on the MP_REACH
variant and is read by the consumer (`route_*_update`), so no `bgp_attr.nexthop`
stamping is needed in the parser.

(Follows the IPv6-unicast fix in #1285, which fixed the same class for `Ipv6`.)

## Test plan

- New **regression unit test** (`mp_reach_other_family_surfaces_as_mp_update`):
  a Flowspec MP_REACH now parses to `Some(mp_update)` instead of being dropped.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo test --workspace --exclude bdd` (953 daemon + 285 bgp-packet): green.

## Caveats / follow-up

- This is the **parse-layer enabler** — it unblocks reception and routes each
  family to its existing `route_from_peer` handler. Per-family **end-to-end
  interop is not yet validated** (each needs a dedicated topology/external
  speaker; some families also lack advertise-on-establish, so zebra↔zebra can't
  fully exercise them without separate advertise-side work). Best validated via
  the gobgp BDD harness.
- These handlers now process wire data they may not have seen before; a latent
  handler bug (previously masked by the silent drop) would surface here.

Generated with [Claude Code](https://claude.com/claude-code)
