### PR TITLE
bgp: route `show bgp vrf <name>` to the per-VRF instance

### DIFF
--- a/bdd/tests/features/bgp_vrf_show.feature
+++ b/bdd/tests/features/bgp_vrf_show.feature
@@ -40,6 +40,18 @@ Feature: BGP per-VRF show command
     And show command "ip bgp vrf vrf-blue" in namespace "z1" should contain "Import RTs"
     And show command "ip bgp vrf vrf-blue" in namespace "z1" should contain "Export RTs"
 
+  Scenario: Inspect vrf-blue via the `show bgp vrf` tree
+    # The new `show bgp vrf <name> [ipv4|ipv6] …` tree shares the manager
+    # redirect / fall-through plumbing with the legacy `show ip bgp vrf`
+    # tree. No per-VRF BGP task runs in this single namespace, so the
+    # bare-name form falls through to the per-VRF detail (same output as
+    # `show ip bgp vrf vrf-blue`) and the AFI forms report the miss.
+    Given the test topology exists
+    Then show command "bgp vrf" in namespace "z1" should contain "vrf-blue"
+    And show command "bgp vrf vrf-blue" in namespace "z1" should contain "Route Distinguisher: 65001:100"
+    And show command "bgp vrf vrf-blue ipv4" in namespace "z1" should contain "is not running"
+    And show command "bgp vrf vrf-blue ipv6" in namespace "z1" should contain "is not running"
+
   Scenario: Remove vrf-blue and observe row drops
     Given the test topology exists
     When I apply config "z1-1.yaml" to namespace "z1"

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -67,6 +67,14 @@ pub async fn process_vrf_show(vrf: &BgpVrf, msg: DisplayRequest) {
         "/show/ip/bgp" => show_bgp(vrf, args, msg.json),
         "/show/ip/bgp/summary" => show_bgp_summary(vrf, args, msg.json),
         "/show/ip/bgp/neighbors" => show_bgp_neighbor(vrf, args, msg.json),
+        // `show bgp vrf <name> [ipv4|ipv6] [<addr>|<prefix> [longer-prefix]]`
+        // — the manager strips the `vrf <name>` selector, so a per-VRF
+        // task sees the same `/show/bgp/…` paths as the default VRF and
+        // renders against its own Loc-RIB via [`BgpShowView`].
+        "/show/bgp" | "/show/bgp/ipv4" => show_bgp_ipv4(vrf, args, msg.json),
+        "/show/bgp/ipv4/longer-prefix" => show_bgp_ipv4_longer(vrf, args, msg.json),
+        "/show/bgp/ipv6" => show_bgp_ipv6(vrf, args, msg.json),
+        "/show/bgp/ipv6/longer-prefix" => show_bgp_ipv6_longer(vrf, args, msg.json),
         other => Ok(format!("% Unsupported per-VRF show command: {other}\n")),
     };
     let out = out.unwrap_or_else(|e| format!("Error formatting output: {e}"));
@@ -3578,5 +3586,17 @@ impl Bgp {
         self.show_add("/show/bgp/ipv4/longer-prefix", show_bgp_ipv4_longer::<Bgp>);
         self.show_add("/show/bgp/ipv6", show_bgp_ipv6::<Bgp>);
         self.show_add("/show/bgp/ipv6/longer-prefix", show_bgp_ipv6_longer::<Bgp>);
+
+        // `show bgp vrf <name> …` is normally intercepted by the manager
+        // and redirected into the per-VRF task (see `process_vrf_show`).
+        // These global handlers are the fall-through when no task is
+        // registered for `<name>`: bare `show bgp vrf` lists every VRF,
+        // and a named-but-not-running VRF reports the miss instead of
+        // leaving the request unanswered.
+        self.show_add("/show/bgp/vrf", show_bgp_vrf);
+        self.show_add("/show/bgp/vrf/ipv4", show_bgp_vrf_not_running);
+        self.show_add("/show/bgp/vrf/ipv4/longer-prefix", show_bgp_vrf_not_running);
+        self.show_add("/show/bgp/vrf/ipv6", show_bgp_vrf_not_running);
+        self.show_add("/show/bgp/vrf/ipv6/longer-prefix", show_bgp_vrf_not_running);
     }
 }

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -571,18 +571,26 @@ pub fn parse(
         }
     }
 
-    // `ext:default-child` positional value. A container may name a
-    // child whose key can be typed without the child's own keyword
-    // (`show bgp 10.0.0.1` == `show bgp ipv4 10.0.0.1`). Probe that
-    // child's key in a side `Match` so the normal transition below is
-    // left untouched, then either descend into the child (the value is
-    // the winner) or fold the key's completion hints into `mx` (so
-    // `show bgp <tab>` still advertises <A.B.C.D> / <A.B.C.D/M>). IP
-    // literals never collide with the sibling keywords, so this can
-    // only fire on the value branch — no existing command regresses.
+    // `ext:default-child` positional value. A container (or a list
+    // entry, once its key is matched) may name a child whose key can be
+    // typed without the child's own keyword (`show bgp 10.0.0.1` ==
+    // `show bgp ipv4 10.0.0.1`; `show bgp vrf X 10.0.0.1` == `show bgp
+    // vrf X ipv4 10.0.0.1`). Probe that child's key in a side `Match`
+    // so the normal transition below is left untouched, then either
+    // descend into the child (the value is the winner) or fold the
+    // key's completion hints into `mx` (so `show bgp <tab>` still
+    // advertises <A.B.C.D> / <A.B.C.D/M>). `KeyMatched` covers the
+    // list-entry case: after `vrf X` the parser sits on the list node
+    // with the key consumed, so the positional value attaches to the
+    // entry's `ext:default-child`. IP literals never collide with the
+    // sibling keywords, so this can only fire on the value branch — no
+    // existing command regresses.
     if !s.set
         && !s.delete
-        && matches!(s.ymatch, YangMatch::Dir | YangMatch::DirMatched)
+        && matches!(
+            s.ymatch,
+            YangMatch::Dir | YangMatch::DirMatched | YangMatch::KeyMatched
+        )
         && let Some(child) = default_child_entry(&entry)
     {
         let mut pmx = Match::default();
@@ -937,5 +945,108 @@ mod tests {
         assert!(names.contains(&"ipv6"), "comps: {names:?}");
         assert!(names.contains(&"<A.B.C.D>"), "comps: {names:?}");
         assert!(names.contains(&"<A.B.C.D/M>"), "comps: {names:?}");
+    }
+
+    /// `show bgp vrf <name> …` mirrors the default-VRF tree: the `vrf`
+    /// list carries its own `ext:default-child "ipv4"`, so a bare
+    /// address/prefix typed after the VRF name routes into `ipv4` (the
+    /// matcher applies the positional shortcut after a list key as well
+    /// as on a plain container).
+    #[test]
+    fn show_bgp_vrf_positional_default_child() {
+        use crate::config::path_from_command;
+        let entry = exec_entry();
+
+        let cases: Vec<(&str, &str, Vec<&str>)> = vec![
+            ("show bgp vrf", "/show/bgp/vrf", vec![]),
+            ("show bgp vrf blue", "/show/bgp/vrf", vec!["blue"]),
+            ("show bgp vrf blue ipv4", "/show/bgp/vrf/ipv4", vec!["blue"]),
+            (
+                "show bgp vrf blue ipv4 10.0.0.1",
+                "/show/bgp/vrf/ipv4",
+                vec!["blue", "10.0.0.1"],
+            ),
+            (
+                "show bgp vrf blue 10.0.0.1",
+                "/show/bgp/vrf/ipv4",
+                vec!["blue", "10.0.0.1"],
+            ),
+            (
+                "show bgp vrf blue 10.0.0.0/24",
+                "/show/bgp/vrf/ipv4",
+                vec!["blue", "10.0.0.0/24"],
+            ),
+            (
+                "show bgp vrf blue 10.0.0.0/24 longer-prefix",
+                "/show/bgp/vrf/ipv4/longer-prefix",
+                vec!["blue", "10.0.0.0/24"],
+            ),
+            (
+                "show bgp vrf blue ipv4 10.0.0.0/24 longer-prefix",
+                "/show/bgp/vrf/ipv4/longer-prefix",
+                vec!["blue", "10.0.0.0/24"],
+            ),
+            ("show bgp vrf blue ipv6", "/show/bgp/vrf/ipv6", vec!["blue"]),
+            (
+                "show bgp vrf blue ipv6 2001:db8::1",
+                "/show/bgp/vrf/ipv6",
+                vec!["blue", "2001:db8::1"],
+            ),
+            (
+                "show bgp vrf blue ipv6 2001:db8::/48 longer-prefix",
+                "/show/bgp/vrf/ipv6/longer-prefix",
+                vec!["blue", "2001:db8::/48"],
+            ),
+        ];
+
+        for &(cmd, want_path, ref want_args) in &cases {
+            let (code, _comps, state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "parse `{cmd}`");
+            let (path, args) = path_from_command(&state.paths);
+            assert_eq!(path, want_path, "path for `{cmd}`");
+            let got: Vec<&str> = args.0.iter().map(|s| s.as_str()).collect();
+            assert_eq!(&got, want_args, "args for `{cmd}`");
+        }
+    }
+
+    /// After the manager strips the `vrf <name>` selector, the per-VRF
+    /// BGP task sees exactly the default-VRF `/show/bgp/…` path + value,
+    /// which is what [`crate::bgp::show::process_vrf_show`] dispatches on.
+    #[test]
+    fn show_bgp_vrf_redirect_strips_selector() {
+        use crate::config::{path_from_command, vrf_redirect_split};
+        let entry = exec_entry();
+
+        let cases: Vec<(&str, &str, Vec<&str>)> = vec![
+            ("show bgp vrf blue", "/show/bgp", vec![]),
+            ("show bgp vrf blue ipv4", "/show/bgp/ipv4", vec![]),
+            (
+                "show bgp vrf blue 10.0.0.1",
+                "/show/bgp/ipv4",
+                vec!["10.0.0.1"],
+            ),
+            (
+                "show bgp vrf blue 10.0.0.0/24 longer-prefix",
+                "/show/bgp/ipv4/longer-prefix",
+                vec!["10.0.0.0/24"],
+            ),
+            (
+                "show bgp vrf blue ipv6 2001:db8::/48 longer-prefix",
+                "/show/bgp/ipv6/longer-prefix",
+                vec!["2001:db8::/48"],
+            ),
+        ];
+
+        for &(cmd, want_path, ref want_args) in &cases {
+            let (code, _comps, state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "parse `{cmd}`");
+            let (name, rewritten) =
+                vrf_redirect_split(&state.paths).expect("vrf selector should split");
+            assert_eq!(name, "blue", "vrf name for `{cmd}`");
+            let (path, args) = path_from_command(&rewritten);
+            assert_eq!(path, want_path, "redirected path for `{cmd}`");
+            let got: Vec<&str> = args.0.iter().map(|s| s.as_str()).collect();
+            assert_eq!(&got, want_args, "redirected args for `{cmd}`");
+        }
     }
 }

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -39,6 +39,48 @@ module exec {
   }
   */
 
+  // IPv4/IPv6 unicast Loc-RIB selectors shared by the default-VRF
+  // `show bgp …` tree and the per-VRF `show bgp vrf <name> …` tree. A
+  // bare address does a longest-match lookup; a prefix matches exactly;
+  // `longer-prefix` widens it to equal-or-more-specific.
+  grouping bgp-show-afi-rib {
+    list ipv4 {
+      ext:help "BGP IPv4 unicast RIB";
+      ext:presence "BGP IPv4 unicast RIB (all prefixes)";
+      key value;
+      leaf value {
+        ext:help "Address (routes containing it) or prefix (exact match)";
+        // A bare address does a longest-match lookup (routes that
+        // contain it); a prefix matches exactly. The handler tells
+        // them apart by the presence of `/M`.
+        type union {
+          type inet:ipv4-address;
+          type inet:ipv4-prefix;
+        }
+      }
+      leaf longer-prefix {
+        ext:help "Prefixes equal to or more specific than the given prefix";
+        type empty;
+      }
+    }
+    list ipv6 {
+      ext:help "BGP IPv6 unicast RIB";
+      ext:presence "BGP IPv6 unicast RIB (all prefixes)";
+      key value;
+      leaf value {
+        ext:help "Address (routes containing it) or prefix (exact match)";
+        type union {
+          type inet:ipv6-address;
+          type inet:ipv6-prefix;
+        }
+      }
+      leaf longer-prefix {
+        ext:help "Prefixes equal to or more specific than the given prefix";
+        type empty;
+      }
+    }
+  }
+
   container show {
     ext:help "Show command";
     presence "Show command";
@@ -166,41 +208,7 @@ module exec {
       // routed into `ipv4` by the matcher via `ext:default-child`.
       ext:default-child "ipv4";
       presence "BGP IPv4 unicast RIB (same as `show bgp ipv4`)";
-      list ipv4 {
-        ext:help "BGP IPv4 unicast RIB";
-        ext:presence "BGP IPv4 unicast RIB (all prefixes)";
-        key value;
-        leaf value {
-          ext:help "Address (routes containing it) or prefix (exact match)";
-          // A bare address does a longest-match lookup (routes that
-          // contain it); a prefix matches exactly. The handler tells
-          // them apart by the presence of `/M`.
-          type union {
-            type inet:ipv4-address;
-            type inet:ipv4-prefix;
-          }
-        }
-        leaf longer-prefix {
-          ext:help "Prefixes equal to or more specific than the given prefix";
-          type empty;
-        }
-      }
-      list ipv6 {
-        ext:help "BGP IPv6 unicast RIB";
-        ext:presence "BGP IPv6 unicast RIB (all prefixes)";
-        key value;
-        leaf value {
-          ext:help "Address (routes containing it) or prefix (exact match)";
-          type union {
-            type inet:ipv6-address;
-            type inet:ipv6-prefix;
-          }
-        }
-        leaf longer-prefix {
-          ext:help "Prefixes equal to or more specific than the given prefix";
-          type empty;
-        }
-      }
+      uses bgp-show-afi-rib;
       list update-group {
         ext:help "BGP update-groups (IOS-XR style)";
         ext:presence "BGP update-group summary";
@@ -210,6 +218,23 @@ module exec {
           ext:dynamic "bgp:update-group";
           type string;
         }
+      }
+      list vrf {
+        ext:help "Per-VRF BGP RIB";
+        ext:presence "BGP per-VRF summary table";
+        // Same positional shortcut as the parent `bgp` container: a
+        // bare address/prefix after the VRF name (`show bgp vrf X
+        // A.B.C.D`) is routed into this list's `ipv4` child. The
+        // matcher applies `ext:default-child` after a list key is
+        // matched as well as on a plain container.
+        ext:default-child "ipv4";
+        key name;
+        leaf name {
+          ext:help "VRF name";
+          ext:dynamic "rib:vrf";
+          type string;
+        }
+        uses bgp-show-afi-rib;
       }
     }
     container ip {


### PR DESCRIPTION
## Summary

Adds the per-VRF arm of the `show bgp …` tree so the following nine forms are dispatched to the VRF's BGP instance, mirroring the default-VRF tree:

- `show bgp vrf VRF`
- `show bgp vrf VRF A.B.C.D`
- `show bgp vrf VRF A.B.C.D/M [longer-prefix]`
- `show bgp vrf VRF ipv4 [A.B.C.D | A.B.C.D/M [longer-prefix]]`
- `show bgp vrf VRF ipv6 [X:X::X:X | X:X::X:X/M [longer-prefix]]`

### How it works
`show bgp vrf blue ipv4 10.0.0.1` → parse → `[show, bgp, vrf, blue, ipv4, 10.0.0.1]` → `vrf_redirect_split` strips the selector → rewritten `[show, bgp, ipv4, 10.0.0.1]` → routed to the `bgp:vrf:blue` show channel → `process_vrf_show("/show/bgp/ipv4", ["10.0.0.1"])` → `show_bgp_ipv4` longest-match against the VRF Loc-RIB. When no per-VRF task is registered, it falls through to global handlers (all-VRFs list / "not running").

### Changes
- **exec.yang**: extract the ipv4/ipv6 selector lists into a shared `grouping bgp-show-afi-rib` (used by both the `show bgp` container and a new per-VRF `vrf` list); give the `vrf` list its own `ext:default-child "ipv4"`.
- **parse.rs**: let the `ext:default-child` positional shortcut also fire in `KeyMatched` state, so a bare address/prefix typed right after the VRF name attaches to the list entry's `ipv4` child — same shortcut `show bgp 10.0.0.1` already has. Gated by the entry carrying `ext:default-child`, so no existing command regresses.
- **show.rs**: dispatch `/show/bgp[/ipv4|/ipv6][/longer-prefix]` in `process_vrf_show` (via the `BgpShowView`-generic renderers) and register global fall-through handlers for `/show/bgp/vrf/*`.

The manager redirect plumbing (`vrf_redirect_split` + `show_vrf_clients["bgp:vrf:<name>"]`) is unchanged and reused — it already serves `show ip bgp vrf <name> summary`.

## Test plan
- New parser tests cover every form: grammar (`show_bgp_vrf_positional_default_child`) + redirect contract (`show_bgp_vrf_redirect_strips_selector`).
- Full `zebra-rs` unit suite green (958 passed), including `exec_mode_loads` (YANG-load guard).
- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Added a `show bgp vrf` scenario to `bgp_vrf_show.feature` (BDD is excluded from CI; verify via manual BDD run).

Generated with [Claude Code](https://claude.com/claude-code)