### PR TITLE
bgp: move srv6 locator config to segment-routing container

### DIFF
--- a/book/src/ch-02-05-bgp-l3vpn-srv6.md
+++ b/book/src/ch-02-05-bgp-l3vpn-srv6.md
@@ -30,8 +30,9 @@ An SRv6 L3VPN PE on zebra-rs touches three configuration trees:
 * the global **`segment-routing` locator** supplies the IPv6 prefix that
   per-VRF service SIDs are carved from (the same locators IS-IS
   advertises into the SR domain);
-* the global **`router bgp ... srv6 locator`** names which locator BGP
-  draws its service SIDs from;
+* the **`router bgp segment-routing srv6 locator`** names which locator
+  BGP draws its service SIDs from (mirrors `router isis segment-routing
+  srv6 locator`; BGP has no SR-MPLS sibling);
 * the per-VRF **`encapsulation srv6`** opts a VRF into the SRv6 data
   plane (the default is `mpls`).
 
@@ -45,6 +46,8 @@ segment-routing {
 router bgp {
   global {
     as 65000;
+  }
+  segment-routing {
     srv6 {
       locator LOC1;
     }
@@ -74,7 +77,7 @@ vrf vrf1 {
 | Config | Meaning |
 |---|---|
 | `segment-routing locator <name> prefix <p>` | An IPv6 locator prefix SIDs are carved from |
-| `router bgp global srv6 locator <name>` | The locator BGP carves per-VRF End.DT46 SIDs from |
+| `router bgp segment-routing srv6 locator <name>` | The locator BGP carves per-VRF End.DT46 SIDs from |
 | `router bgp vrf <name> encapsulation srv6` | Use the SRv6 data plane for this VRF (default `mpls`) |
 | `router bgp vrf <name> rd <RD>` | Route Distinguisher for this VRF's VPN NLRI |
 | `vrf <name> {ipv4,ipv6} route-target import/export <RT>` | Which VPN routes land in / leave the VRF |

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -69,11 +69,13 @@ fn config_global_no_fib_install(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
     Some(())
 }
 
-/// `set router bgp global srv6 locator <name>` — names the SRv6
-/// locator BGP carves per-VRF End.DT46 service SIDs from for L3VPN
-/// over SRv6 (RFC 9252). Drives the RIB locator watch; SID
-/// allocation off the resolved locator lands in a follow-up.
-fn config_global_srv6_locator(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+/// `set router bgp segment-routing srv6 locator <name>` — names the
+/// SRv6 locator BGP carves per-VRF End.DT46 service SIDs from for
+/// L3VPN over SRv6 (RFC 9252). Mirrors `router isis / segment-routing
+/// / srv6 / locator`; BGP has no SR-MPLS knob, so there is no `mpls`
+/// sibling. Drives the RIB locator watch (`set_srv6_locator`), which
+/// in turn reconciles every `encapsulation srv6` VRF's service SID.
+fn config_srv6_locator(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     if op == ConfigOp::Set {
         let name = args.string()?;
         bgp.set_srv6_locator(Some(name));
@@ -2095,8 +2097,8 @@ impl Bgp {
             config_global_no_fib_install,
         );
         self.callback_add(
-            "/router/bgp/global/srv6/locator",
-            config_global_srv6_locator,
+            "/router/bgp/segment-routing/srv6/locator",
+            config_srv6_locator,
         );
         self.callback_peer("", config_peer);
         self.callback_peer("/remote-as", config_remote_as);

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -472,8 +472,8 @@ pub struct Bgp {
     /// the NLRI and swap-programmed via an ILM (`local → received`).
     pub lu_label_v4: std::collections::BTreeMap<ipnet::Ipv4Net, u32>,
     pub lu_label_v6: std::collections::BTreeMap<ipnet::Ipv6Net, u32>,
-    /// Configured global SRv6 locator name (`router bgp global srv6
-    /// locator <name>`). When set, BGP watches this locator on the
+    /// Configured SRv6 locator name (`router bgp segment-routing
+    /// srv6 locator <name>`). When set, BGP watches this locator on the
     /// RIB and (in a follow-up) carves per-VRF End.DT46 service SIDs
     /// from it for `encapsulation srv6` VRFs. `None` until configured.
     pub srv6_locator_name: Option<String>,
@@ -632,7 +632,7 @@ impl Bgp {
         // SRv6 locator subscription. Register the SR return channel
         // once up front (mirrors IS-IS); the per-locator interest is
         // expressed later via `SrLocatorWatch` when the operator sets
-        // `router bgp global srv6 locator <name>`.
+        // `router bgp segment-routing srv6 locator <name>`.
         let (srv6_sr_tx, srv6_locator_rx) = mpsc::unbounded_channel();
         let mut bgp = Self {
             asn: 0,

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -61,8 +61,8 @@ impl BgpVrfLabelMode {
 /// VPN data-plane encapsulation for a VRF — mirrors `encapsulation`
 /// in zebra-bgp-vrf.yang. Default `Mpls` (RFC 4364 service label).
 /// `Srv6` (RFC 9252) binds a per-VRF End.DT46 service SID from the
-/// global `srv6 locator` instead of an MPLS label, and the PE
-/// programs a seg6local decap rather than an AF_MPLS ILM.
+/// `segment-routing srv6 locator` instead of an MPLS label, and the
+/// PE programs a seg6local decap rather than an AF_MPLS ILM.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum BgpVrfEncapsulation {
     #[default]

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1409,4 +1409,56 @@ mod yang_load_tests {
             "`set bfd tracing true` must be a valid settable path",
         );
     }
+
+    /// The BGP SRv6 service-SID locator lives at `router bgp
+    /// segment-routing srv6 locator <name>` (mirroring `router isis
+    /// segment-routing srv6 locator`; BGP has no SR-MPLS sibling). It is a
+    /// hand-added container on the vendored `ietf-bgp` `container bgp`
+    /// grouping, so a misplacement would only surface at runtime —
+    /// `load_mode` loads the module but does not exercise the path. Assert
+    /// the new path is settable and that the former `global / srv6 /
+    /// locator` location is gone (so a future re-add would be caught).
+    #[test]
+    fn bgp_segment_routing_srv6_locator_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        let (code, _comps, _state) = parse(
+            "set router bgp segment-routing srv6 locator LOC1",
+            entry.clone(),
+            None,
+            State::new(),
+        );
+        assert_eq!(
+            code,
+            ExecCode::Success,
+            "`set router bgp segment-routing srv6 locator <name>` must be a valid settable path",
+        );
+
+        // The locator moved out of `global`; the old path must no longer
+        // resolve, or operators would have two redundant ways to set it.
+        let (old_code, _comps, _state) = parse(
+            "set router bgp global srv6 locator LOC1",
+            entry,
+            None,
+            State::new(),
+        );
+        assert_ne!(
+            old_code,
+            ExecCode::Success,
+            "`set router bgp global srv6 locator <name>` was relocated to segment-routing \
+             and must no longer parse",
+        );
+    }
 }

--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -337,22 +337,6 @@ module ietf-bgp {
              rather than retroactively withdrawing already-installed
              entries.";
         }
-        container srv6 {
-          description
-            "SRv6 parameters for BGP services over an SRv6 underlay
-             (RFC 9252).";
-          leaf locator {
-            type string;
-            description
-              "Name of the SRv6 locator this BGP speaker draws per-VRF
-               End.DT46 service SIDs from for L3VPN over SRv6. Held as
-               a plain string (staging-friendly, like the IS-IS
-               `locator` reference) and resolved against the locators
-               the RIB segment-routing manager publishes; until it
-               resolves, `encapsulation srv6` VRFs run without a
-               service SID.";
-          }
-        }
         container distance {
           description
             "Administrative distances (or preferences) assigned to
@@ -436,6 +420,32 @@ module ietf-bgp {
         }
         uses rt-pol:apply-policy-group;
         uses state;
+      }
+
+      container segment-routing {
+        ext:help "Segment Routing (SRv6) configuration";
+        description
+          "Segment Routing parameters for BGP services. BGP supports
+           only the SRv6 dataplane — there is no SR-MPLS knob here —
+           so this container carries a single `srv6` child, mirroring
+           `router isis / segment-routing` (config.yang) minus the
+           `mpls` sibling.";
+        container srv6 {
+          description
+            "SRv6 parameters for BGP services over an SRv6 underlay
+             (RFC 9252).";
+          leaf locator {
+            type string;
+            description
+              "Name of the SRv6 locator this BGP speaker draws per-VRF
+               End.DT46 service SIDs from for L3VPN over SRv6. Held as
+               a plain string (staging-friendly, like the IS-IS
+               `locator` reference) and resolved against the locators
+               the RIB segment-routing manager publishes; until it
+               resolves, `encapsulation srv6` VRFs run without a
+               service SID.";
+          }
+        }
       }
 
       list neighbor {


### PR DESCRIPTION
## Summary

Relocates the BGP SRv6 service-SID locator reference from `router bgp global srv6 locator <name>` to `router bgp segment-routing srv6 locator <name>`, mirroring the IS-IS structure (`router isis segment-routing srv6 locator`). BGP has no SR-MPLS dataplane, so the new `segment-routing` container carries only an `srv6` child — no `mpls` sibling.

```
router bgp {
  segment-routing {
    srv6 {
      locator S;
    }
  }
}
```

The underlying L3VPN-over-SRv6 machinery (locator watch, per-VRF End.DT46 SID allocation, Prefix-SID advertisement, H.Encap install) is **unchanged** — only the config entry point moves. The handler still calls `bgp.set_srv6_locator(...)`; it is renamed `config_global_srv6_locator` → `config_srv6_locator`.

The former `global / srv6 / locator` path is **removed** (no alias) — the feature is new/unreleased and a redundant second path would be confusing.

### Changes
- **`ietf-bgp@2023-07-05.yang`**: removed `srv6` from `container global`; added a top-level `container segment-routing { srv6 { locator } }` sibling of `global`.
- **`bgp/config.rs`**: callback path + handler rename.
- **`bgp/inst.rs`, `bgp/vrf_config.rs`**: comment path references.
- **`config/manager.rs`**: new parse-guard test `bgp_segment_routing_srv6_locator_is_settable` (asserts new path settable + old path gone).
- **`book/src/ch-02-05-bgp-l3vpn-srv6.md`**: config example, bullet, table row.

## Test plan
- `cargo fmt` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --exclude bdd` — 0 failed (957 passed in the main binary), incl. the new parse-guard test

Note: this SRv6 L3VPN path is control-plane-complete but not yet two-PE runtime-validated; this change is purely the config-entry relocation and does not alter that forwarding pipeline.

Generated with [Claude Code](https://claude.com/claude-code)