### PR TITLE
bgp: per-neighbor afi-safi ipv6 encapsulation-type knob

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -23,6 +23,7 @@
   - [Remove Private AS](ch-02-14-bgp-remove-private-as.md)
   - [Enforce First AS](ch-02-15-bgp-enforce-first-as.md)
   - [disable-connected-check](ch-02-16-bgp-disable-connected-check.md)
+  - [SRv6 Encapsulation Type (per-neighbor)](ch-02-17-bgp-srv6-encapsulation-type.md)
   - [Timer Configuration](ch-02-03-bgp-timers.md)
   - [L3VPN and Per-VRF Labels](ch-02-04-bgp-l3vpn.md)
   - [L3VPN over an SRv6 Underlay](ch-02-05-bgp-l3vpn-srv6.md)

--- a/book/src/ch-02-17-bgp-srv6-encapsulation-type.md
+++ b/book/src/ch-02-17-bgp-srv6-encapsulation-type.md
@@ -1,0 +1,103 @@
+# BGP SRv6 Encapsulation Type (per-neighbor)
+
+In an SRv6 network, an IPv6 unicast route can carry an **SRv6 service
+SID** in the BGP Prefix-SID attribute (RFC 9252 / RFC 8669) — the SID a
+remote PE programs to deliver traffic for that prefix. `encapsulation-type`
+is a per-neighbor, per-address-family knob that declares how strict the
+session is about that SID for the **IPv6 unicast** family:
+
+- **`srv6`** — *SRv6-only* peer. Only routes carrying an SRv6 service SID
+  are exchanged with the neighbor; a route without a SID is filtered out
+  on the session.
+- **`srv6-relax`** — *mixed* session. Routes with or without an SRv6 SID
+  may be exchanged with the neighbor.
+
+It is the BGP-session counterpart to the data-plane SRv6 encapsulation
+configured elsewhere (see [SRv6](ch-04-00-srv6.md) and
+[L3VPN over an SRv6 Underlay](ch-02-05-bgp-l3vpn-srv6.md)): those chapters
+cover *how* a SID is programmed into the forwarding plane, while this knob
+governs *which* IPv6 unicast routes are allowed to ride a given session
+based on whether they carry a SID.
+
+## When you need it
+
+Use `srv6` on a session that must stay SRv6-pure — for example a fabric
+where every IPv6 prefix is expected to resolve to an SRv6 SID and a
+SID-less route would represent a misconfiguration or a non-SRv6 leak that
+should not be propagated. Use `srv6-relax` on a boundary session that
+carries a mix of SRv6 and plain IPv6 unicast routes to the same peer and
+must not drop the SID-less ones.
+
+When the knob is **absent** the family behaves as ordinary IPv6 unicast:
+no SID-based filtering is applied in either direction.
+
+## Modes at a glance
+
+| Mode         | SID-bearing routes | SID-less routes |
+|--------------|--------------------|-----------------|
+| *(unset)*    | exchanged          | exchanged       |
+| `srv6`       | exchanged          | **filtered**    |
+| `srv6-relax` | exchanged          | exchanged       |
+
+`srv6-relax` differs from the unset default in *intent*: it marks the
+session as SRv6-aware (so SID-bearing routes are treated as first-class)
+while explicitly tolerating SID-less routes, whereas the unset default is
+simply SRv6-agnostic.
+
+## Configuration
+
+`encapsulation-type` lives under the neighbor's IPv6 `afi-safi` entry. The
+schema restricts it to the `ipv6` family (`when name = 'ipv6'`), so it is
+only valid there.
+
+```yaml
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 10.255.0.1
+    neighbor:
+    - remote-address: 2001:db8::8
+      remote-as: 65002
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        encapsulation-type: srv6
+```
+
+The equivalent CLI form is the same path:
+
+```
+set router bgp neighbor 2001:db8::8 afi-safi ipv6 encapsulation-type srv6
+```
+
+Replace `srv6` with `srv6-relax` for the mixed-session variant. Delete the
+leaf to return the family to the SRv6-agnostic default:
+
+```
+delete router bgp neighbor 2001:db8::8 afi-safi ipv6 encapsulation-type
+```
+
+## Verification
+
+`show ip bgp neighbor <addr>` echoes the configured mode for the IPv6
+unicast family:
+
+```
+  IPv6 Unicast encapsulation-type: srv6
+```
+
+The line is omitted when the knob is unset.
+
+## Status
+
+This release wires the **configuration**: the mode is parsed, validated,
+stored on the neighbor, and reported by `show`. The advertise- and
+accept-side SID filtering it describes is **not yet enforced** — the knob
+currently records intent. Enforcement (dropping SID-less IPv6 unicast
+routes on a `srv6` session, on both the receive and re-advertise paths)
+is a planned follow-up; note that the advertise side additionally depends
+on SRv6-SID origination for plain IPv6 unicast, which today exists only
+for the VPNv4 / VPNv6 families described in
+[L3VPN over an SRv6 Underlay](ch-02-05-bgp-l3vpn-srv6.md).

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -13,7 +13,7 @@ use crate::policy::com_list::*;
 use crate::rib::api::FdbEntry;
 
 use super::auth::AoConfig;
-use super::peer::BgpTop;
+use super::peer::{AfiSafiEncapType, BgpTop};
 use super::route_clean;
 use super::{
     Bgp,
@@ -1493,6 +1493,28 @@ fn config_restart(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     Some(())
 }
 
+/// `set/delete router bgp neighbor <addr> afi-safi <name> encapsulation-type
+/// <srv6|srv6-relax>`. Records the per-neighbor, per-AFI/SAFI SRv6
+/// encapsulation mode on the peer's [`PeerSubConfig`]. The YANG `when`
+/// guard restricts the leaf to `afi-safi ipv6`, so in practice `afi_safi`
+/// is always IPv6 unicast here. Config-only for now — see
+/// [`AfiSafiEncapType`] for the deferred advertise/accept filtering.
+fn config_encapsulation_type(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    let peer = bgp.peers.get_mut(&addr)?;
+
+    if op.is_set() {
+        let encap = AfiSafiEncapType::parse(&args.string()?)?;
+        let config = peer.config.sub.entry(afi_safi).or_default();
+        config.encapsulation_type = Some(encap);
+    } else {
+        let config = peer.config.sub.entry(afi_safi).or_default();
+        config.encapsulation_type = None;
+    }
+    Some(())
+}
+
 fn config_llgr(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let afi_safi: AfiSafi = args.afi_safi()?;
@@ -2320,6 +2342,7 @@ impl Bgp {
 
         self.callback_peer("/afi-safi/enabled", config_afi_safi);
         self.callback_peer("/afi-safi/add-path", config_add_path);
+        self.callback_peer("/afi-safi/encapsulation-type", config_encapsulation_type);
         self.callback_peer("/afi-safi/graceful-restart/enabled", config_restart);
         self.callback_peer("/afi-safi/long-lived-graceful-restart/enabled", config_llgr);
         self.callback_peer(

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -427,10 +427,55 @@ impl Default for PeerConfig {
     }
 }
 
+/// Per-neighbor, per-AFI/SAFI SRv6 encapsulation mode for the IPv6
+/// unicast family (`afi-safi ipv6 encapsulation-type` in
+/// ietf-bgp-neighbor). Selects how SRv6-SID-bearing routes are
+/// exchanged on the session:
+///
+/// * [`Srv6`](Self::Srv6) — SRv6-only peer: only routes carrying an
+///   SRv6 service SID (BGP Prefix-SID, RFC 9252) are advertised/accepted;
+///   SID-less routes are filtered out on the session.
+/// * [`Srv6Relax`](Self::Srv6Relax) — mixed session: routes with or
+///   without an SRv6 SID may be exchanged with this peer.
+///
+/// Currently a recorded-intent knob — the value is parsed and stored,
+/// but the advertise/accept SID filtering is not yet enforced (the
+/// follow-up wires it into `route_update_ipv6` / `route_ipv6_update`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AfiSafiEncapType {
+    Srv6,
+    Srv6Relax,
+}
+
+impl AfiSafiEncapType {
+    /// Parse the `encapsulation-type` enum value as it appears in the
+    /// YANG / CLI (`srv6`, `srv6-relax`).
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "srv6" => Some(Self::Srv6),
+            "srv6-relax" => Some(Self::Srv6Relax),
+            _ => None,
+        }
+    }
+
+    /// The CLI / YANG string form, for show output and round-tripping.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Srv6 => "srv6",
+            Self::Srv6Relax => "srv6-relax",
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct PeerSubConfig {
     pub graceful_restart: Option<u32>,
     pub llgr: Option<u32>,
+    /// `afi-safi <name> encapsulation-type` (ietf-bgp-neighbor). Only
+    /// settable under `afi-safi ipv6` (YANG `when name = 'ipv6'`).
+    /// `None` = no SRv6 encapsulation mode configured for this AF.
+    pub encapsulation_type: Option<AfiSafiEncapType>,
 }
 
 #[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Clone, Copy)]

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -10,7 +10,9 @@ use serde::Serialize;
 
 use super::cap::CapAfiMap;
 use super::inst::{Bgp, ShowCallback};
-use super::peer::{AllowAsIn, Peer, PeerCounter, PeerParam, RemovePrivateAs, State};
+use super::peer::{
+    AfiSafiEncapType, AllowAsIn, Peer, PeerCounter, PeerParam, RemovePrivateAs, State,
+};
 use super::peer_map::PeerMap;
 use super::route::LocalRib;
 use super::vrf::inst::BgpVrf;
@@ -1645,6 +1647,11 @@ struct Neighbor<'a> {
     /// UPDATE is dropped unless its AS_PATH begins with this neighbor's
     /// own AS.
     enforce_first_as: bool,
+    /// `afi-safi ipv6 encapsulation-type` (ietf-bgp-neighbor): the SRv6
+    /// encapsulation mode configured for the IPv6 unicast family on this
+    /// neighbor. `None` = unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    encapsulation_type_ipv6: Option<AfiSafiEncapType>,
     /// GTSM / `ttl-security` (RFC 5082): the session only accepts a
     /// directly-connected peer (received TTL 255). Mirrors
     /// `peer.config.transport.ttl_security`.
@@ -1812,6 +1819,11 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         as_override: peer.config.as_override,
         remove_private_as: peer.config.remove_private_as,
         enforce_first_as: peer.config.enforce_first_as,
+        encapsulation_type_ipv6: peer
+            .config
+            .sub
+            .get(&AfiSafi::new(Afi::Ip6, Safi::Unicast))
+            .and_then(|s| s.encapsulation_type),
         ttl_security: peer.config.transport.ttl_security,
         ebgp_multihop: peer.config.transport.ebgp_multihop,
         tcp_mss: peer.config.transport.tcp_mss,
@@ -1940,6 +1952,10 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
             out,
             "  Enforce-first-AS enabled (drop inbound updates not starting with peer AS)"
         )?;
+    }
+
+    if let Some(encap) = neighbor.encapsulation_type_ipv6 {
+        writeln!(out, "  IPv6 Unicast encapsulation-type: {}", encap.as_str())?;
     }
 
     if neighbor.ttl_security {

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1350,6 +1350,35 @@ mod yang_load_tests {
         );
     }
 
+    /// The per-neighbor `afi-safi ipv6 encapsulation-type` knob is a
+    /// hand-added leaf on the vendored `ietf-bgp-neighbor` afi-safi list.
+    /// `load_mode` proves the module loads but not that the concrete path
+    /// is settable, so parse the `set` line for both enum values.
+    #[test]
+    fn bgp_neighbor_afi_safi_encapsulation_type_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router bgp neighbor 2001:db8::8 afi-safi ipv6 encapsulation-type srv6",
+            "set router bgp neighbor 2001:db8::8 afi-safi ipv6 encapsulation-type srv6-relax",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{cmd}` must be a settable path");
+        }
+    }
+
     /// The IS-IS per-interface `passive` leaf must be a settable path.
     /// It is hand-added to `config.yang` (no YANG generator), so a typo in
     /// the leaf or its placement would otherwise only surface at runtime —

--- a/zebra-rs/yang/ietf-bgp-neighbor@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-neighbor@2023-07-05.yang
@@ -187,6 +187,34 @@ submodule ietf-bgp-neighbor {
           enum send-receive;
         }
       }
+      leaf encapsulation-type {
+        when "../name = 'ipv6'" {
+          description
+            "SRv6 encapsulation only applies to the IPv6 unicast
+             family.";
+        }
+        ext:sort "20";
+        type enumeration {
+          enum srv6 {
+            description
+              "SRv6-only peer. Only routes carrying an SRv6 service SID
+               (BGP Prefix-SID attribute, RFC 9252) are advertised to /
+               accepted from this neighbor; routes without a SID are
+               filtered out on the session.";
+          }
+          enum srv6-relax {
+            description
+              "Mixed session. Routes with or without an SRv6 service SID
+               may be advertised to / accepted from this neighbor.";
+          }
+        }
+        description
+          "Per-neighbor SRv6 encapsulation mode for the IPv6 unicast
+           family. `srv6` makes the session SRv6-strict (SID-less routes
+           filtered), `srv6-relax` SRv6-relaxed (SID-less routes still
+           exchanged). Absent = no SRv6 encapsulation filtering for the
+           family.";
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a per-neighbor, per-address-family `encapsulation-type {srv6|srv6-relax}` knob under a neighbor's `afi-safi ipv6` block — a per-session SRv6 mode declaring how strict the session is about the SRv6 service SID (BGP Prefix-SID, RFC 9252) on IPv6 unicast routes:

- **`srv6`** — SRv6-only peer: SID-less routes are filtered out on the session.
- **`srv6-relax`** — mixed session: routes with or without a SID are exchanged.

```
set router bgp neighbor 2001:db8::8 afi-safi ipv6 encapsulation-type srv6
```

### Scope: configuration plumbing only

This lands the **config plumbing**: the value is parsed, validated, stored on the peer (`PeerSubConfig.encapsulation_type`), and reported by `show ip bgp neighbor`. The advertise/accept SID filtering it describes is **not yet enforced** — it is a planned follow-up that additionally depends on SRv6-SID origination for plain IPv6 unicast (which today exists only for VPNv4/VPNv6). The book chapter documents this status explicitly.

### Changes

- **YANG** (`ietf-bgp-neighbor`): `encapsulation-type` leaf on the neighbor afi-safi list, restricted to the ipv6 family via `when name = 'ipv6'`.
- **bgp/peer.rs**: `AfiSafiEncapType` enum (`srv6`/`srv6-relax`) + `PeerSubConfig.encapsulation_type` field.
- **bgp/config.rs**: `config_encapsulation_type` callback + registration.
- **bgp/show.rs**: rendered in `show ip bgp neighbor <addr>` detail.
- **config/manager.rs**: parse test in `yang_load_tests` (the CI guard for YANG settability).
- **book**: new chapter `ch-02-17-bgp-srv6-encapsulation-type.md`.

## Test plan

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `RUSTFLAGS="-D warnings" cargo test --workspace --exclude bdd` — all pass (incl. new `bgp_neighbor_afi_safi_encapsulation_type_is_settable`)
- `mdbook build book` — builds clean

Generated with [Claude Code](https://claude.com/claude-code)