### PR TITLE
bgp: enforce ipv6 encapsulation-type + originate global SRv6 SIDs

### DIFF
--- a/book/src/ch-02-17-bgp-srv6-encapsulation-type.md
+++ b/book/src/ch-02-17-bgp-srv6-encapsulation-type.md
@@ -90,14 +90,58 @@ unicast family:
 
 The line is omitted when the knob is unset.
 
-## Status
+## Enforcement
 
-This release wires the **configuration**: the mode is parsed, validated,
-stored on the neighbor, and reported by `show`. The advertise- and
-accept-side SID filtering it describes is **not yet enforced** — the knob
-currently records intent. Enforcement (dropping SID-less IPv6 unicast
-routes on a `srv6` session, on both the receive and re-advertise paths)
-is a planned follow-up; note that the advertise side additionally depends
-on SRv6-SID origination for plain IPv6 unicast, which today exists only
-for the VPNv4 / VPNv6 families described in
-[L3VPN over an SRv6 Underlay](ch-02-05-bgp-l3vpn-srv6.md).
+The filter is applied symmetrically on a `srv6` session:
+
+- **Receive** — a plain IPv6 unicast route that arrives without an SRv6
+  service SID is dropped before it reaches the Adj-RIB-In / Loc-RIB.
+- **Advertise** — a route without an SRv6 service SID is withheld from
+  the peer (no NLRI is emitted for it).
+
+A route's SID rides in the BGP Prefix-SID attribute, so a route learned
+*with* a SID propagates through unchanged and passes the filter at the
+next `srv6` hop. `srv6-relax` and the unset default apply no filtering.
+
+## Originating SRv6 SIDs for the global IPv6 table
+
+For the local router to *advertise* its own IPv6 unicast routes
+(`network`, redistribution) to a `srv6` peer, those routes must carry a
+SID. Enable End.DT6 origination for the global (default-table) IPv6
+unicast family under `segment-routing srv6`:
+
+```yaml
+router:
+  bgp:
+    segment-routing:
+      srv6:
+        locator: LOC1
+        ipv6-unicast: null    # presence: originate an End.DT6 SID
+```
+
+```
+set router bgp segment-routing srv6 locator LOC1
+set router bgp segment-routing srv6 ipv6-unicast
+```
+
+`ipv6-unicast` is the global-table analogue of a per-VRF `encapsulation
+srv6`. When it is set and the `locator` resolves, the BGP speaker carves a
+single **End.DT6** service SID from the locator, advertises locally-
+originated IPv6 unicast routes with that SID (in the BGP Prefix-SID
+attribute) and the locator as the next-hop, and programs a `seg6local`
+End.DT6 decap into the main table. A remote PE then H.Encaps traffic to
+the locator, and the local End.DT6 decapsulates and forwards via the
+global IPv6 table. Until the `locator` resolves, origination is SID-less
+(and such routes are withheld from `srv6` peers).
+
+Routes *received* with a SID are re-advertised preserving their SID, so a
+transit router needs `ipv6-unicast` only if it also originates routes of
+its own.
+
+> The per-neighbor `encapsulation-type` (the session filter) and the
+> instance `ipv6-unicast` (SID origination) are independent: a route
+> reflector might originate nothing yet still filter, while an edge PE
+> originates SIDs that any downstream `srv6` peer then accepts.
+
+See also [L3VPN over an SRv6 Underlay](ch-02-05-bgp-l3vpn-srv6.md), which
+uses the same locator machinery to carve per-VRF End.DT46 SIDs.

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -85,6 +85,15 @@ fn config_srv6_locator(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()
     Some(())
 }
 
+/// `set/delete router bgp segment-routing srv6 ipv6-unicast` — the
+/// presence container that enables SRv6 End.DT6 SID origination for the
+/// global IPv6 unicast table. Toggling it (re)allocates or withdraws the
+/// instance End.DT6 SID via `set_srv6_ipv6_unicast`.
+fn config_srv6_ipv6_unicast(bgp: &mut Bgp, _args: Args, op: ConfigOp) -> Option<()> {
+    bgp.set_srv6_ipv6_unicast(op == ConfigOp::Set);
+    Some(())
+}
+
 fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     if op == ConfigOp::Set {
@@ -123,6 +132,7 @@ fn config_peer(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
 
         let mut bgp_ref = BgpTop {
             router_id: &bgp.router_id,
+            srv6_ipv6_export: bgp.srv6_ipv6_export.as_ref(),
             local_rib: &mut bgp.local_rib,
             tx: &bgp.tx,
             rib_client: &bgp.ctx.rib,
@@ -1497,8 +1507,8 @@ fn config_restart(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
 /// <srv6|srv6-relax>`. Records the per-neighbor, per-AFI/SAFI SRv6
 /// encapsulation mode on the peer's [`PeerSubConfig`]. The YANG `when`
 /// guard restricts the leaf to `afi-safi ipv6`, so in practice `afi_safi`
-/// is always IPv6 unicast here. Config-only for now — see
-/// [`AfiSafiEncapType`] for the deferred advertise/accept filtering.
+/// is always IPv6 unicast here. The mode is enforced on the advertise /
+/// accept paths — see [`AfiSafiEncapType`].
 fn config_encapsulation_type(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let afi_safi: AfiSafi = args.afi_safi()?;
@@ -2121,6 +2131,10 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/segment-routing/srv6/locator",
             config_srv6_locator,
+        );
+        self.callback_add(
+            "/router/bgp/segment-routing/srv6/ipv6-unicast",
+            config_srv6_ipv6_unicast,
         );
         self.callback_peer("", config_peer);
         self.callback_peer("/remote-as", config_remote_as);

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -136,9 +136,27 @@ pub(crate) fn tag_attr_with_export_rts(
 /// an optional SID Structure sub-sub-TLV derived from the locator when
 /// known. This is the attribute an `encapsulation srv6` VRF attaches to
 /// every VPNv4 / VPNv6 route it originates.
+/// Precomputed advertise-time SRv6 data for the global IPv6 unicast
+/// table, derived from the resolved locator + the allocated End.DT6 SID.
+/// Held on [`Bgp`] and borrowed into [`super::peer::BgpTop`] so the
+/// egress path (`route_update_ipv6`) can stamp locally-originated routes
+/// with the Prefix-SID + locator next-hop without re-deriving it per
+/// route. `None` whenever `segment-routing srv6 ipv6-unicast` is off or
+/// the locator is unresolved.
+#[derive(Debug, Clone)]
+pub struct Srv6Ipv6Export {
+    /// BGP Prefix-SID attribute (SRv6 L3 Service TLV, End.DT6 SID).
+    pub prefix_sid: bgp_packet::PrefixSid,
+    /// PE locator next-hop advertised alongside the SID (the remote PE
+    /// H.Encaps to this address, then the local End.DT6 decaps into the
+    /// main table).
+    pub nexthop: std::net::Ipv6Addr,
+}
+
 fn srv6_l3_service_prefix_sid(
     sid: std::net::Ipv6Addr,
     structure: Option<crate::rib::SidStructure>,
+    behavior: u16,
 ) -> bgp_packet::PrefixSid {
     let structure = structure.map(|s| bgp_packet::Srv6SidStructure {
         locator_block_len: s.lb_bits,
@@ -151,12 +169,7 @@ fn srv6_l3_service_prefix_sid(
     bgp_packet::PrefixSid {
         tlvs: vec![bgp_packet::PrefixSidTlv::Srv6L3Service(
             bgp_packet::Srv6ServiceTlv {
-                sids: vec![bgp_packet::Srv6SidInfo::new(
-                    sid,
-                    0,
-                    bgp_packet::SRV6_BEHAVIOR_END_DT46,
-                    structure,
-                )],
+                sids: vec![bgp_packet::Srv6SidInfo::new(sid, 0, behavior, structure)],
                 ..Default::default()
             },
         )],
@@ -491,6 +504,22 @@ pub struct Bgp {
     /// SIDs carved from [`Self::srv6_locator`]. Reset when the locator
     /// prefix changes (every prior SID address is then invalid).
     pub srv6_sid_pool: super::vrf::BgpSidPool,
+    /// `segment-routing srv6 ipv6-unicast` — when `true`, the global
+    /// IPv6 unicast table originates routes with an SRv6 End.DT6 service
+    /// SID (the default-table analogue of a per-VRF `encapsulation srv6`).
+    pub srv6_ipv6_unicast: bool,
+    /// The instance End.DT6 SID for the global IPv6 unicast table:
+    /// `(addr, function)`, carved from [`Self::srv6_locator`] when
+    /// [`Self::srv6_ipv6_unicast`] is on and the locator has resolved.
+    /// `None` otherwise. The `function` is borrowed from
+    /// [`Self::srv6_sid_pool`], same as a per-VRF SID.
+    pub srv6_ipv6_sid: Option<(std::net::Ipv6Addr, u16)>,
+    /// Precomputed advertise-time data derived from
+    /// [`Self::srv6_ipv6_sid`] and the locator, borrowed into
+    /// [`super::peer::BgpTop`] so the egress path stamps
+    /// locally-originated IPv6 routes without re-deriving it per route.
+    /// Kept in lock-step with `srv6_ipv6_sid`.
+    pub srv6_ipv6_export: Option<Srv6Ipv6Export>,
     /// Inbound `:179` dispatch index — peer source IP to VRF name.
     /// Populated by [`super::vrf::BgpGlobalMsg::RegisterPeer`]
     /// each per-VRF task emits at spawn / materialise time, and
@@ -680,6 +709,9 @@ impl Bgp {
             srv6_locator_rx,
             srv6_locator: None,
             srv6_sid_pool: super::vrf::BgpSidPool::new(),
+            srv6_ipv6_unicast: false,
+            srv6_ipv6_sid: None,
+            srv6_ipv6_export: None,
             peer_index: BTreeMap::new(),
             vrf_global_tx: vrf_global_tx_init,
             vrf_global_rx: vrf_global_rx_init,
@@ -800,6 +832,12 @@ impl Bgp {
                     }
                 }
                 self.reconcile_srv6_vrfs();
+                // Re-allocate the global IPv6 unicast End.DT6 SID against
+                // the new locator prefix. `reconcile_srv6_vrfs` just
+                // reset the pool, so the old function is gone — withdraw
+                // without releasing (mirrors resid_vrf), then re-install.
+                self.withdraw_srv6_ipv6_sid(false);
+                self.install_srv6_ipv6_sid();
             }
             crate::rib::RibSrRx::Block { .. } => {}
         }
@@ -872,6 +910,100 @@ impl Bgp {
         for name in srv6_vrfs {
             self.resid_vrf(&name);
         }
+    }
+
+    /// `segment-routing srv6 ipv6-unicast` toggle. Enables or disables
+    /// End.DT6 SID origination for the global IPv6 unicast table and
+    /// reconciles the instance SID against the current locator. The pool
+    /// is *not* reset here (unlike a locator change), so a withdrawn
+    /// function is returned to the pool for reuse.
+    pub fn set_srv6_ipv6_unicast(&mut self, enabled: bool) {
+        if self.srv6_ipv6_unicast == enabled {
+            return;
+        }
+        self.srv6_ipv6_unicast = enabled;
+        self.withdraw_srv6_ipv6_sid(true);
+        self.install_srv6_ipv6_sid();
+    }
+
+    /// Withdraw the instance global-IPv6 End.DT6 SID, if installed, and
+    /// clear the precomputed export. `release` returns the function to
+    /// the SID pool — pass `false` on the locator-change path where the
+    /// caller already `reset()` the pool (the old function no longer
+    /// exists in it; releasing would corrupt the free list, same caveat
+    /// as [`Self::resid_vrf`]).
+    fn withdraw_srv6_ipv6_sid(&mut self, release: bool) {
+        if let Some((addr, function)) = self.srv6_ipv6_sid.take() {
+            self.rib_subscriber.send_sid_del(addr);
+            if release {
+                self.srv6_sid_pool.release(function);
+            }
+        }
+        self.srv6_ipv6_export = None;
+    }
+
+    /// Allocate + install the instance global-IPv6 End.DT6 SID when
+    /// `srv6_ipv6_unicast` is on and the locator has resolved, and build
+    /// the [`Srv6Ipv6Export`] the egress path stamps onto locally-
+    /// originated routes. No-op when disabled, unresolved, already
+    /// installed, or the function space is exhausted (origination then
+    /// stays SID-less until the next locator update). Unlike a per-VRF
+    /// End.DT46, the End.DT6 decaps into the main table (`table_id` 0),
+    /// which always exists — so there is no kernel-presence gate.
+    fn install_srv6_ipv6_sid(&mut self) {
+        if !self.srv6_ipv6_unicast || self.srv6_ipv6_sid.is_some() {
+            return;
+        }
+        // Snapshot locator-derived values before the mutable pool /
+        // subscriber calls so the immutable borrow doesn't conflict.
+        let (prefix, nexthop, structure, loc_name) = {
+            let Some(locator) = self.srv6_locator.as_ref() else {
+                return;
+            };
+            let (Some(prefix), Some(nexthop)) = (locator.prefix, locator.node_sid_addr()) else {
+                return;
+            };
+            (
+                prefix,
+                nexthop,
+                locator.sid_structure(),
+                self.srv6_locator_name.clone().unwrap_or_default(),
+            )
+        };
+        let Some(function) = self.srv6_sid_pool.allocate() else {
+            return;
+        };
+        let Some(addr) = crate::isis::srv6::function_addr(prefix, function) else {
+            self.srv6_sid_pool.release(function);
+            return;
+        };
+        self.rib_subscriber.send_sid_add(crate::rib::Sid {
+            addr,
+            behavior: crate::rib::SidBehavior::EndDT6,
+            context: crate::rib::SidContext::None,
+            owner: crate::rib::SidOwner::new("bgp", 0),
+            locator: loc_name,
+            allocation_type: crate::rib::SidAllocationType::Dynamic,
+            ifindex: 0,
+            nh6: None,
+            structure: None,
+            table_id: 0,
+            segs: Vec::new(),
+        });
+        self.srv6_ipv6_sid = Some((addr, function));
+        self.srv6_ipv6_export = Some(Srv6Ipv6Export {
+            prefix_sid: srv6_l3_service_prefix_sid(
+                addr,
+                structure,
+                bgp_packet::SRV6_BEHAVIOR_END_DT6,
+            ),
+            nexthop,
+        });
+        bgp_srv6_trace!(
+            self.tracing,
+            sid = %addr,
+            "bgp: global IPv6 unicast End.DT6 SID installed"
+        );
     }
 
     /// Respawn `name`'s per-VRF task with a freshly-allocated End.DT46
@@ -1062,6 +1194,7 @@ impl Bgp {
 
                 let mut bgp_ref = BgpTop {
                     router_id: &self.router_id,
+                    srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
                     local_rib: &mut self.local_rib,
                     tx: &self.tx,
                     rib_client: &self.ctx.rib,
@@ -2041,6 +2174,7 @@ impl Bgp {
 
         let mut top = super::peer::BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -2507,7 +2641,11 @@ impl Bgp {
         let (sid, _function) = self.vrf_registry.get(vrf)?.srv6_sid?;
         let locator = self.srv6_locator.as_ref()?;
         let nexthop = locator.node_sid_addr()?;
-        attr.prefix_sid = Some(srv6_l3_service_prefix_sid(sid, locator.sid_structure()));
+        attr.prefix_sid = Some(srv6_l3_service_prefix_sid(
+            sid,
+            locator.sid_structure(),
+            bgp_packet::SRV6_BEHAVIOR_END_DT46,
+        ));
         Some(nexthop)
     }
 
@@ -2642,6 +2780,7 @@ impl Bgp {
                 // loop on the export hook in `route_ipv4_update`.
                 let mut top = super::peer::BgpTop {
                     router_id: &self.router_id,
+                    srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
                     local_rib: &mut self.local_rib,
                     tx: &self.tx,
                     rib_client: &self.ctx.rib,
@@ -2748,6 +2887,7 @@ impl Bgp {
 
                 let mut top = super::peer::BgpTop {
                     router_id: &self.router_id,
+                    srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
                     local_rib: &mut self.local_rib,
                     tx: &self.tx,
                     rib_client: &self.ctx.rib,
@@ -2893,6 +3033,7 @@ impl Bgp {
 
                 let mut top = super::peer::BgpTop {
                     router_id: &self.router_id,
+                    srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
                     local_rib: &mut self.local_rib,
                     tx: &self.tx,
                     rib_client: &self.ctx.rib,
@@ -2977,6 +3118,7 @@ impl Bgp {
 
                 let mut top = super::peer::BgpTop {
                     router_id: &self.router_id,
+                    srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
                     local_rib: &mut self.local_rib,
                     tx: &self.tx,
                     rib_client: &self.ctx.rib,
@@ -3136,7 +3278,11 @@ mod tests {
             fun_bits: 16,
             arg_bits: 0,
         };
-        let ps = super::srv6_l3_service_prefix_sid(sid, Some(structure));
+        let ps = super::srv6_l3_service_prefix_sid(
+            sid,
+            Some(structure),
+            bgp_packet::SRV6_BEHAVIOR_END_DT46,
+        );
 
         // Emit the attribute body and parse it back; the SID + behavior
         // must survive so a remote PE reads End.DT46.
@@ -3150,6 +3296,41 @@ mod tests {
         assert_eq!(
             attr.srv6_l3_sid(),
             Some((sid, bgp_packet::SRV6_BEHAVIOR_END_DT46))
+        );
+    }
+
+    /// The global IPv6 unicast origination path builds the Prefix-SID
+    /// with End.DT6 (decap into the main table). Emit + parse it and
+    /// assert `srv6_l3_sid()` — the exact accessor the encapsulation-type
+    /// filter consults — reads back the SID with behavior End.DT6.
+    #[test]
+    fn srv6_l3_service_prefix_sid_round_trips_to_end_dt6() {
+        use bgp_packet::{AttrEmitter, ParseBe};
+        use bytes::BytesMut;
+
+        let sid: std::net::Ipv6Addr = "2001:db8:1:41::".parse().unwrap();
+        let structure = crate::rib::SidStructure {
+            lb_bits: 32,
+            ln_bits: 16,
+            fun_bits: 16,
+            arg_bits: 0,
+        };
+        let ps = super::srv6_l3_service_prefix_sid(
+            sid,
+            Some(structure),
+            bgp_packet::SRV6_BEHAVIOR_END_DT6,
+        );
+
+        let mut buf = BytesMut::new();
+        ps.emit(&mut buf);
+        let (_, parsed) = bgp_packet::PrefixSid::parse_be(&buf).expect("parse");
+        let attr = bgp_packet::BgpAttr {
+            prefix_sid: Some(parsed),
+            ..Default::default()
+        };
+        assert_eq!(
+            attr.srv6_l3_sid(),
+            Some((sid, bgp_packet::SRV6_BEHAVIOR_END_DT6))
         );
     }
 

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -438,9 +438,9 @@ impl Default for PeerConfig {
 /// * [`Srv6Relax`](Self::Srv6Relax) — mixed session: routes with or
 ///   without an SRv6 SID may be exchanged with this peer.
 ///
-/// Currently a recorded-intent knob — the value is parsed and stored,
-/// but the advertise/accept SID filtering is not yet enforced (the
-/// follow-up wires it into `route_update_ipv6` / `route_ipv6_update`).
+/// Enforced symmetrically in `route_ipv6_update` (accept: drop a SID-less
+/// route from a `Srv6` peer) and `route_update_ipv6` (advertise: withhold
+/// a SID-less route from a `Srv6` peer). See [`Peer::ipv6_srv6_strict`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum AfiSafiEncapType {
@@ -942,6 +942,25 @@ impl Peer {
         false
     }
 
+    /// The configured SRv6 `encapsulation-type` for this peer's IPv6
+    /// unicast family (`afi-safi ipv6 encapsulation-type`), or `None`
+    /// when unset. See [`AfiSafiEncapType`].
+    pub fn ipv6_srv6_encap(&self) -> Option<AfiSafiEncapType> {
+        self.config
+            .sub
+            .get(&AfiSafi::new(Afi::Ip6, Safi::Unicast))
+            .and_then(|s| s.encapsulation_type)
+    }
+
+    /// `true` when this peer is SRv6-strict for IPv6 unicast
+    /// (`encapsulation-type srv6`): a plain IPv6 unicast route without
+    /// an SRv6 service SID must not be advertised to / accepted from it.
+    /// `srv6-relax` and the unset default both return `false` (no
+    /// SID-presence filtering).
+    pub fn ipv6_srv6_strict(&self) -> bool {
+        matches!(self.ipv6_srv6_encap(), Some(AfiSafiEncapType::Srv6))
+    }
+
     /// IPv6 link-local next-hop to advertise in MP_REACH for
     /// IPv4-unicast NLRI once RFC 8950 Extended Next Hop is
     /// negotiated on this peer. Returns `None` for any peer that
@@ -1057,6 +1076,13 @@ pub struct BgpTop<'a> {
     /// local label. A received route advertised with next-hop-self gets
     /// a local label here, swap-programmed via an ILM.
     pub lu_labels: Option<LuLabels<'a>>,
+    /// Precomputed global-IPv6 SRv6 export data (`segment-routing srv6
+    /// ipv6-unicast`), borrowed from the owning [`super::inst::Bgp`].
+    /// `Some` only when origination is enabled and the locator has
+    /// resolved; the egress path (`route_update_ipv6`) then stamps
+    /// locally-originated routes with its End.DT6 Prefix-SID + locator
+    /// next-hop. `None` on per-VRF tasks and whenever origination is off.
+    pub srv6_ipv6_export: Option<&'a super::inst::Srv6Ipv6Export>,
 }
 
 /// Per-prefix local-label state for BGP Labeled Unicast, borrowed into
@@ -2288,6 +2314,7 @@ pub fn apply_soft_in_peer(bgp: &mut Bgp, peer_idx: usize) {
     if soft_in {
         let mut bgp_ref = BgpTop {
             router_id: &bgp.router_id,
+            srv6_ipv6_export: bgp.srv6_ipv6_export.as_ref(),
             local_rib: &mut bgp.local_rib,
             tx: &bgp.tx,
             rib_client: &bgp.ctx.rib,
@@ -2325,6 +2352,7 @@ pub fn apply_soft_out_peer(bgp: &mut Bgp, peer_idx: usize) {
     }
     let mut bgp_ref = BgpTop {
         router_id: &bgp.router_id,
+        srv6_ipv6_export: bgp.srv6_ipv6_export.as_ref(),
         local_rib: &mut bgp.local_rib,
         tx: &bgp.tx,
         rib_client: &bgp.ctx.rib,

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -3225,6 +3225,20 @@ pub fn route_ipv6_update(
             return;
         }
 
+        // encapsulation-type srv6 (accept side): a plain IPv6 unicast
+        // route from an SRv6-only peer must carry an SRv6 service SID;
+        // drop a SID-less route before it reaches the Adj-RIB-In /
+        // Loc-RIB. VPNv6 rows (rd = Some) are unaffected — they carry
+        // their own service SID and have a separate filter contract.
+        if rd.is_none() && peer.ipv6_srv6_strict() && attr.srv6_l3_sid().is_none() {
+            tracing::debug!(
+                peer = %peer.address,
+                prefix = %nlri.prefix,
+                "bgp: drop SID-less IPv6 route from encapsulation-type srv6 peer",
+            );
+            return;
+        }
+
         let typ = if peer.is_ibgp() {
             BgpRibType::IBGP
         } else {
@@ -6031,6 +6045,36 @@ pub fn route_update_ipv6(
         }
     }
 
+    // The two SRv6 hooks below apply only to plain IPv6 unicast rows.
+    // `route_update_ipv6` is shared with the VPNv6 advertise path, whose
+    // rows carry `Some(VpnNexthop::V6)`; gating on `rib.nexthop.is_none()`
+    // keeps the unicast `encapsulation-type` knob from touching VPNv6.
+    let plain_unicast = rib.nexthop.is_none();
+
+    // SRv6 (global IPv6 unicast origination): a locally-originated route
+    // carries the instance End.DT6 service SID + the PE locator next-hop
+    // when `segment-routing srv6 ipv6-unicast` is enabled and the locator
+    // has resolved (`srv6_ipv6_export` is `Some`). Mirrors the per-VRF
+    // SRv6 L3VPN export but targets the main table. Received routes keep
+    // whatever SID rode in on the wire and are not re-stamped here.
+    if plain_unicast
+        && rib.is_originated()
+        && let Some(exp) = bgp.srv6_ipv6_export
+    {
+        attrs.prefix_sid = Some(exp.prefix_sid.clone());
+        attrs.nexthop = Some(BgpNexthop::Ipv6(exp.nexthop));
+    }
+
+    // encapsulation-type srv6 (advertise side): withhold a SID-less
+    // plain IPv6 unicast route from an SRv6-only peer — it carries no
+    // SRv6 service SID for the peer to forward on. `srv6-relax`/unset
+    // peers are unaffected. Locally-originated routes get the instance
+    // End.DT6 SID attached just above (when `segment-routing srv6
+    // ipv6-unicast` is enabled), so they pass this gate.
+    if plain_unicast && peer.ipv6_srv6_strict() && attrs.srv6_l3_sid().is_none() {
+        return None;
+    }
+
     Some((nlri, attrs))
 }
 
@@ -7517,6 +7561,7 @@ impl Bgp {
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -7560,6 +7605,7 @@ impl Bgp {
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -7616,6 +7662,7 @@ impl Bgp {
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -7645,6 +7692,7 @@ impl Bgp {
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -7694,6 +7742,7 @@ impl Bgp {
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -7729,6 +7778,7 @@ impl Bgp {
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -7783,6 +7833,7 @@ impl Bgp {
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -7816,6 +7867,7 @@ impl Bgp {
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -7902,6 +7954,7 @@ impl Bgp {
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -7943,6 +7996,7 @@ impl Bgp {
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -8008,6 +8062,7 @@ impl Bgp {
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -8044,6 +8099,7 @@ impl Bgp {
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -8102,6 +8158,7 @@ impl Bgp {
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -8136,6 +8193,7 @@ impl Bgp {
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -8271,6 +8329,7 @@ impl Bgp {
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -8388,6 +8447,7 @@ impl Bgp {
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -8492,6 +8552,7 @@ impl Bgp {
 
         let mut bgp_ref = BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -417,6 +417,7 @@ impl BgpVrf {
                 };
                 let mut top = BgpTop {
                     router_id: &self.router_id,
+                    srv6_ipv6_export: None,
                     local_rib: &mut self.local_rib,
                     tx: &self.tx,
                     rib_client: &self.ctx.rib,
@@ -551,6 +552,7 @@ impl BgpVrf {
 
         let mut top = super::super::peer::BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: None,
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -613,6 +615,7 @@ impl BgpVrf {
 
         let mut top = super::super::peer::BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: None,
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -714,6 +717,7 @@ impl BgpVrf {
 
         let mut top = super::super::peer::BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: None,
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,
@@ -764,6 +768,7 @@ impl BgpVrf {
 
         let mut top = super::super::peer::BgpTop {
             router_id: &self.router_id,
+            srv6_ipv6_export: None,
             local_rib: &mut self.local_rib,
             tx: &self.tx,
             rib_client: &self.ctx.rib,

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1490,4 +1490,37 @@ mod yang_load_tests {
              and must no longer parse",
         );
     }
+
+    /// `segment-routing srv6 ipv6-unicast` is a hand-added presence
+    /// container that enables End.DT6 SID origination for the global
+    /// IPv6 unicast table. `load_mode` loads the module but does not
+    /// prove the concrete path is settable, so parse the `set` line.
+    #[test]
+    fn bgp_segment_routing_srv6_ipv6_unicast_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        let (code, _comps, _state) = parse(
+            "set router bgp segment-routing srv6 ipv6-unicast",
+            entry,
+            None,
+            State::new(),
+        );
+        assert_eq!(
+            code,
+            ExecCode::Success,
+            "`set router bgp segment-routing srv6 ipv6-unicast` must be a valid settable path",
+        );
+    }
 }

--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -445,6 +445,22 @@ module ietf-bgp {
                resolves, `encapsulation srv6` VRFs run without a
                service SID.";
           }
+          container ipv6-unicast {
+            presence
+              "Originate an SRv6 End.DT6 service SID for the global
+               IPv6 unicast table.";
+            description
+              "When present, locally-originated IPv6 unicast routes
+               (`network`, redistribution) are advertised with a BGP
+               Prefix-SID (SRv6 L3 Service TLV, RFC 9252) carrying a
+               single End.DT6 SID carved from the configured `locator`,
+               and the PE programs a seg6local End.DT6 decap into the
+               main table. The global (default-table) analogue of a
+               per-VRF `encapsulation srv6`; pairs with the per-neighbor
+               `afi-safi ipv6 encapsulation-type srv6` session filter.
+               Requires `locator` to resolve — until then origination
+               is SID-less.";
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

Builds on the per-neighbor `afi-safi ipv6 encapsulation-type {srv6|srv6-relax}` config knob (PR #1291) to make it **enforce**, and adds **SRv6 End.DT6 SID origination** for the global IPv6 unicast table so locally-originated routes can carry a SID.

### Filtering (`route.rs`)

- **Accept** (`route_ipv6_update`, `rd = None`): a plain IPv6 unicast route from a `srv6` peer with no SRv6 service SID is dropped before the Adj-RIB-In.
- **Advertise** (`route_update_ipv6`): a SID-less plain unicast route is withheld from a `srv6` peer.
- Both gated to plain unicast (`rib.nexthop.is_none()`) so the **shared VPNv6 advertise path is untouched**. `srv6-relax`/unset apply no filtering. A route learned *with* a SID propagates unchanged and passes the next `srv6` hop.

### Origination (`router bgp segment-routing srv6 ipv6-unicast`)

- New presence container — the global-table analogue of a per-VRF `encapsulation srv6`.
- Carves a single **End.DT6** SID from the configured locator, installs a `seg6local` End.DT6 decap into the **main table** (`table_id 0`), and re-allocates on locator change (reuses the per-VRF `BgpSidPool` + reconcile path).
- Locally-originated IPv6 routes are stamped with the End.DT6 Prefix-SID + locator next-hop **at egress** (`route_update_ipv6`), via a precomputed `Srv6Ipv6Export` borrowed into `BgpTop` (disjoint field-borrow, so it covers the initial-advertise and session-sync paths uniformly).

```
set router bgp segment-routing srv6 locator LOC1
set router bgp segment-routing srv6 ipv6-unicast
set router bgp neighbor 2001:db8::8 afi-safi ipv6 encapsulation-type srv6
```

### Also

- `srv6_l3_service_prefix_sid` parameterized by behavior (End.DT46 for VPN, End.DT6 for global IPv6).
- `Peer::ipv6_srv6_strict` helper.
- Book `ch-02-17` updated: enforcement + origination sections.

## Test plan

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `RUSTFLAGS="-D warnings" cargo test --workspace --exclude bdd` — 1454 pass, incl. new `srv6_l3_service_prefix_sid_round_trips_to_end_dt6` and `bgp_segment_routing_srv6_ipv6_unicast_is_settable`
- `mdbook build book` — clean

**Runtime/BDD note:** control-plane + dataplane-programming paths are unit-tested and mirror the live-validated SRv6 L3VPN machinery; a multi-node SRv6 BDD (originate → `srv6` peer accept/filter → forward) is a fast-follow.

Generated with [Claude Code](https://claude.com/claude-code)