### PR TITLE
bgp: IPv6 unicast redistribute + SRv6 End.DT6 SID in the BGP RIB

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -16,6 +16,10 @@ rr:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_basic_rr"
 
+bgp_srv6_redistribute:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_srv6_redistribute"
+
 rib_static_ipv6:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@rib_static_ipv6"

--- a/bdd/tests/configs/bgp_srv6_redistribute/z1.yaml
+++ b/bdd/tests/configs/bgp_srv6_redistribute/z1.yaml
@@ -1,0 +1,37 @@
+# z1 — SRv6-enabled eBGP speaker (AS 65001). Advertises locator LOC1 and
+# enables `segment-routing srv6 ipv6-unicast`, so the connected prefix on
+# the dummy `cust0` interface, redistributed into BGP, is originated with
+# an End.DT6 service SID carved from LOC1 (fcbb:bbbb:1::/48).
+interface:
+- if-name: i1
+  ipv6:
+    address: 2001:db8:12::1/64
+segment-routing:
+  locator:
+  - name: LOC1
+    prefix: fcbb:bbbb:1::/48
+    behavior: usid
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 10.0.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    segment-routing:
+      srv6:
+        locator: LOC1
+        ipv6-unicast: null
+    neighbor:
+    - remote-address: 2001:db8:12::2
+      remote-as: 65002
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv6
+      redistribute:
+        connected: null

--- a/bdd/tests/configs/bgp_srv6_redistribute/z2.yaml
+++ b/bdd/tests/configs/bgp_srv6_redistribute/z2.yaml
@@ -1,0 +1,25 @@
+# z2 — eBGP peer (AS 65002). Sets `encapsulation-type srv6` on the IPv6
+# unicast family toward z1, so it only accepts routes carrying an SRv6
+# service SID. The redistributed connected prefix from z1 arrives with the
+# End.DT6 SID and is installed in the BGP table as a "Remote SID".
+interface:
+- if-name: i1
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  bgp:
+    global:
+      as: 65002
+      identifier: 10.0.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 2001:db8:12::1
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv6
+        enabled: true
+        encapsulation-type: srv6

--- a/bdd/tests/features/bgp_srv6_redistribute.feature
+++ b/bdd/tests/features/bgp_srv6_redistribute.feature
@@ -1,0 +1,60 @@
+@bgp_srv6_redistribute
+@bgp
+Feature: BGP IPv6 redistribute connected with SRv6 End.DT6 origination
+  As a network operator
+  I want a connected IPv6 prefix redistributed into BGP on an
+  SRv6-enabled speaker to carry an SRv6 End.DT6 service SID, so a peer
+  configured for `encapsulation-type srv6` accepts it and the route
+  reaches the peer's BGP table as an SRv6 service route.
+
+  Test Topology (single point-to-point veth, eBGP over IPv6):
+  ```
+  ┌────────┐  i1 ──────── i1  ┌────────┐
+  │   z1   │──────────────────│   z2   │
+  │ AS65001│  2001:db8:12::/64│ AS65002│
+  │ LOC1   │                  │ encap- │
+  │ fcbb:1 │                  │ srv6   │
+  └────────┘                  └────────┘
+   cust0: 2001:db8:cafe::1/64 (connected, redistributed)
+  ```
+
+  - z1 advertises SRv6 locator `LOC1` (fcbb:bbbb:1::/48) and enables
+    `segment-routing srv6 ipv6-unicast`, so locally-originated IPv6
+    unicast routes carry an End.DT6 SID carved from the locator.
+  - z1 redistributes connected; the dummy `cust0` prefix
+    `2001:db8:cafe::/64` is originated into BGP with the SID stamped at
+    origination (visible as a "Local SID" in `show bgp ipv6`).
+  - z2 peers eBGP over IPv6 and sets `encapsulation-type srv6` on the
+    session, so it only accepts SID-bearing routes; the redistributed
+    prefix arrives carrying the SID (shown as a "Remote SID").
+
+  Config files (in `bdd/tests/configs/bgp_srv6_redistribute/`):
+  - z1.yaml, z2.yaml
+
+  Scenario: Redistributed connected IPv6 route carries an End.DT6 Prefix-SID
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I create dummy interface "cust0" with address "2001:db8:cafe::1/64" in namespace "z1"
+    And I wait 35 seconds
+    # Originator: the redistributed connected prefix carries the SID it
+    # owns, rendered as a "Local SID" with End.DT6 behavior.
+    Then show command "show bgp ipv6 2001:db8:cafe::/64" in namespace "z1" should contain "Local SID"
+    And show command "show bgp ipv6 2001:db8:cafe::/64" in namespace "z1" should contain "End.DT6"
+    # Receiver (encapsulation-type srv6): accepted the SID-bearing route;
+    # it is in the BGP table tagged as a "Remote SID".
+    And show command "show bgp ipv6 2001:db8:cafe::/64" in namespace "z2" should contain "Remote SID"
+    And show command "show bgp ipv6 2001:db8:cafe::/64" in namespace "z2" should contain "End.DT6"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -520,6 +520,11 @@ pub struct Bgp {
     /// locally-originated IPv6 routes without re-deriving it per route.
     /// Kept in lock-step with `srv6_ipv6_sid`.
     pub srv6_ipv6_export: Option<Srv6Ipv6Export>,
+    /// Locally-originated IPv6 unicast `network` prefixes, so they can be
+    /// re-originated (SRv6 End.DT6 SID re-stamped) when the locator
+    /// resolves after the `network` was configured. Redistributed
+    /// prefixes are tracked separately in `redist_v6`.
+    pub networks_v6: std::collections::BTreeSet<ipnet::Ipv6Net>,
     /// Inbound `:179` dispatch index — peer source IP to VRF name.
     /// Populated by [`super::vrf::BgpGlobalMsg::RegisterPeer`]
     /// each per-VRF task emits at spawn / materialise time, and
@@ -712,6 +717,7 @@ impl Bgp {
             srv6_ipv6_unicast: false,
             srv6_ipv6_sid: None,
             srv6_ipv6_export: None,
+            networks_v6: std::collections::BTreeSet::new(),
             peer_index: BTreeMap::new(),
             vrf_global_tx: vrf_global_tx_init,
             vrf_global_rx: vrf_global_rx_init,
@@ -838,6 +844,9 @@ impl Bgp {
                 // without releasing (mirrors resid_vrf), then re-install.
                 self.withdraw_srv6_ipv6_sid(false);
                 self.install_srv6_ipv6_sid();
+                // Re-stamp originated IPv6 routes now the SID exists (the
+                // route delivery may have raced ahead of locator resolution).
+                self.reoriginate_srv6_ipv6();
             }
             crate::rib::RibSrRx::Block { .. } => {}
         }
@@ -924,6 +933,7 @@ impl Bgp {
         self.srv6_ipv6_unicast = enabled;
         self.withdraw_srv6_ipv6_sid(true);
         self.install_srv6_ipv6_sid();
+        self.reoriginate_srv6_ipv6();
     }
 
     /// Withdraw the instance global-IPv6 End.DT6 SID, if installed, and
@@ -1004,6 +1014,37 @@ impl Bgp {
             sid = %addr,
             "bgp: global IPv6 unicast End.DT6 SID installed"
         );
+    }
+
+    /// Re-originate every locally-originated IPv6 unicast route (both
+    /// `network` and redistribute) so its Loc-RIB attr picks up — or
+    /// drops — the global End.DT6 Prefix-SID after a locator or
+    /// `ipv6-unicast` change.
+    /// The connected/static route delivery and the locator resolution
+    /// race, so re-stamping after the fact keeps the SID consistent
+    /// regardless of arrival order.
+    fn reoriginate_srv6_ipv6(&mut self) {
+        let networks: Vec<ipnet::Ipv6Net> = self.networks_v6.iter().copied().collect();
+        for prefix in networks {
+            self.route_add_v6(prefix);
+        }
+        let redist: Vec<(crate::rib::RibType, ipnet::Ipv6Net, u32)> = self
+            .redist_v6
+            .iter()
+            .filter_map(|((rtype, prefix), e)| {
+                let source = Self::redist_source(*rtype)?;
+                let uni = bgp_packet::AfiSafi::new(bgp_packet::Afi::Ip6, bgp_packet::Safi::Unicast);
+                if self.redistribute.contains_key(&(uni, source)) {
+                    let metric = self.redist_metric_override(uni, source).unwrap_or(e.metric);
+                    Some((*rtype, *prefix, metric))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for (rtype, prefix, metric) in redist {
+            self.route_redist_inject_v6(rtype, prefix, metric);
+        }
     }
 
     /// Respawn `name`'s per-VRF task with a freshly-allocated End.DT46
@@ -2432,8 +2473,17 @@ impl Bgp {
                     let rib_metric = e.metric;
                     self.redist_v6.insert((rtype, prefix), e);
                     let Some(source) = source else { continue };
-                    // IPv6 labeled-unicast. (IPv6 *unicast* redistribute
-                    // delivery is still storage-only — a separate gap.)
+                    // Plain IPv6 unicast. With `segment-routing srv6
+                    // ipv6-unicast` on, `route_redist_inject_v6` stamps the
+                    // End.DT6 Prefix-SID at origination.
+                    let uni = AfiSafi::new(Afi::Ip6, Safi::Unicast);
+                    if self.redistribute.contains_key(&(uni, source)) {
+                        let metric = self
+                            .redist_metric_override(uni, source)
+                            .unwrap_or(rib_metric);
+                        self.route_redist_inject_v6(rtype, prefix, metric);
+                    }
+                    // IPv6 labeled-unicast.
                     let lu = AfiSafi::new(Afi::Ip6, Safi::MplsLabel);
                     if self.redistribute.contains_key(&(lu, source)) {
                         let metric = self
@@ -2465,6 +2515,9 @@ impl Bgp {
                 for e in entries {
                     let prefix = e.prefix;
                     self.redist_v6.remove(&(rtype, prefix));
+                    // Withdraw from both v6 targets unconditionally (the
+                    // config row may already be gone), mirroring the v4 path.
+                    self.route_redist_withdraw_v6(prefix);
                     self.route_redist_withdraw_labelv6(rtype, prefix);
                 }
             }

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -6052,16 +6052,17 @@ pub fn route_update_ipv6(
     let plain_unicast = rib.nexthop.is_none();
 
     // SRv6 (global IPv6 unicast origination): a locally-originated route
-    // carries the instance End.DT6 service SID + the PE locator next-hop
-    // when `segment-routing srv6 ipv6-unicast` is enabled and the locator
-    // has resolved (`srv6_ipv6_export` is `Some`). Mirrors the per-VRF
-    // SRv6 L3VPN export but targets the main table. Received routes keep
-    // whatever SID rode in on the wire and are not re-stamped here.
+    // already carries its End.DT6 Prefix-SID from origination (it's in
+    // `rib.attr`, so `show bgp ipv6` renders a "Local SID"). On the wire
+    // it advertises the PE locator as its next-hop, so a remote PE
+    // H.Encaps to us and our End.DT6 decaps into the main table — mirrors
+    // the per-VRF SRv6 L3VPN export. Received SID-bearing routes keep
+    // their wire next-hop (they are not `is_originated`).
     if plain_unicast
         && rib.is_originated()
+        && attrs.srv6_l3_sid().is_some()
         && let Some(exp) = bgp.srv6_ipv6_export
     {
-        attrs.prefix_sid = Some(exp.prefix_sid.clone());
         attrs.nexthop = Some(BgpNexthop::Ipv6(exp.nexthop));
     }
 
@@ -7646,7 +7647,15 @@ impl Bgp {
     /// wins best `fib_install_v6` cedes the FIB entry to the underlying
     /// source (Connected / Static / IGP) rather than shadowing it.
     pub fn route_add_v6(&mut self, prefix: Ipv6Net) {
-        let attr = BgpAttr::new();
+        // Remember the network so it can be re-originated (SID re-stamped)
+        // when the SRv6 locator resolves after the `network` was added.
+        self.networks_v6.insert(prefix);
+        let mut attr = BgpAttr::new();
+        // SRv6 global IPv6 unicast: stamp the End.DT6 Prefix-SID at
+        // origination so it lands in the Loc-RIB (show "Local SID").
+        if let Some(exp) = &self.srv6_ipv6_export {
+            attr.prefix_sid = Some(exp.prefix_sid.clone());
+        }
         let rib = BgpRib::new(
             ORIGINATED_PEER,
             Ipv4Addr::UNSPECIFIED,
@@ -7687,6 +7696,7 @@ impl Bgp {
     }
 
     pub fn route_del_v6(&mut self, prefix: Ipv6Net) {
+        self.networks_v6.remove(&prefix);
         let ident = ORIGINATED_PEER;
         let removed = self.local_rib.remove_v6(prefix, 0, ident);
 
@@ -8027,6 +8037,106 @@ impl Bgp {
                 &mut bgp_ref,
                 &mut self.peers,
             );
+        }
+    }
+
+    /// Redistribute an IPv6 route into the plain IPv6 unicast Loc-RIB.
+    /// The v6-unicast sibling of [`Bgp::route_redist_inject`]: same
+    /// `redist_remote_id` discriminator and MED-from-metric. When global
+    /// SRv6 IPv6 origination is enabled (`segment-routing srv6
+    /// ipv6-unicast` + a resolved locator) the route is stamped with the
+    /// instance End.DT6 Prefix-SID at origination, so it shows as a
+    /// "Local SID" and rides every advertisement; the locator next-hop is
+    /// applied per-peer in [`route_update_ipv6`]. Like the v4 path an
+    /// originated route has no usable next-hop, so the FIB install
+    /// withdraws any BGP entry and the source protocol's RIB owns
+    /// forwarding.
+    pub fn route_redist_inject_v6(
+        &mut self,
+        rtype: crate::rib::RibType,
+        prefix: Ipv6Net,
+        metric: u32,
+    ) {
+        let ident = ORIGINATED_PEER;
+        let remote_id = Self::redist_remote_id(rtype);
+        let mut attr = BgpAttr::new();
+        attr.med = Some(bgp_packet::Med::new(metric));
+        if let Some(exp) = &self.srv6_ipv6_export {
+            attr.prefix_sid = Some(exp.prefix_sid.clone());
+        }
+        let mut rib = BgpRib::new(
+            ident,
+            Ipv4Addr::UNSPECIFIED,
+            BgpRibType::Originated,
+            remote_id,
+            32768,
+            &attr,
+            None,
+            None,
+            false,
+        );
+        let (_replaced, selected, next_id) = self.local_rib.update_v6(prefix, rib.clone());
+        rib.local_id = next_id;
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+            lu_labels: None,
+        };
+
+        fib_install_v6(&bgp_ref, prefix, &selected);
+
+        if !selected.is_empty() {
+            route_advertise_to_peers_v6(prefix, &selected, &mut bgp_ref, &mut self.peers);
+        }
+    }
+
+    /// Withdraw a redistributed IPv6 unicast route (the v6 counterpart of
+    /// [`Bgp::route_redist_withdraw`]). The v6 Loc-RIB `remove_v6` keys on
+    /// `(prefix, ident)` rather than the `remote_id` the v4 path uses, so
+    /// a prefix redistributed from more than one source shares one
+    /// originated row — acceptable for the common single-source case.
+    pub fn route_redist_withdraw_v6(&mut self, prefix: Ipv6Net) {
+        let ident = ORIGINATED_PEER;
+        let removed = self.local_rib.remove_v6(prefix, 0, ident);
+
+        let mut bgp_ref = BgpTop {
+            router_id: &self.router_id,
+            srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
+            local_rib: &mut self.local_rib,
+            tx: &self.tx,
+            rib_client: &self.ctx.rib,
+            attr_store: &mut self.attr_store,
+            update_groups: &mut self.update_groups,
+            interface_addrs: &self.interface_addrs,
+            vrf_export: None,
+            color_policy: Some(&self.color_policy),
+            flex_algo_routes: Some(&self.flex_algo_routes),
+            vrf_import: None,
+            nexthop_cache: None,
+            vrf_transport_v4: None,
+            vrf_transport_v6: None,
+            lu_labels: None,
+        };
+
+        let selected = bgp_ref.local_rib.select_best_path_v6(prefix);
+        fib_install_v6(&bgp_ref, prefix, &selected);
+
+        if !selected.is_empty() || !removed.is_empty() {
+            route_advertise_to_peers_v6(prefix, &selected, &mut bgp_ref, &mut self.peers);
         }
     }
 


### PR DESCRIPTION
## Summary

Answers a "does it really work?" double-check: `redistribute connected` on an SRv6-enabled IPv6 BGP speaker did **not** produce a RIB entry with a Prefix-SID, for two reasons this PR fixes:

1. **IPv6-unicast redistribute delivery was unimplemented** (storage-only — the V6 redistribute batch handler only injected into label-v6, never plain unicast).
2. **The SRv6 SID was egress-only** — attached per-peer at advertise time, so the originator's Loc-RIB stayed clean and `show bgp ipv6 <prefix>` showed no Local SID.

### Changes

- **`route_redist_inject_v6` / `route_redist_withdraw_v6`** — the plain IPv6-unicast redistribute path (mirrors the v4 inject + `route_del_v6` withdraw), wired into the V6 batch handlers for `Safi::Unicast`.
- **SID attached at origination** (`route_add_v6` + `route_redist_inject_v6`), so the SID lands in the Loc-RIB (`show bgp ipv6` → "Local SID") and rides every advertisement. `route_update_ipv6` now only rewrites the next-hop to the locator for originated SID routes. FIB-safe: an originated unicast route installs nothing (the source protocol owns forwarding; verified `make_bgp_rib_entry_v6` returns `None` for an unspecified next-hop).
- **Re-origination** — `networks_v6` tracking + `reoriginate_srv6_ipv6` re-stamps every originated route when the locator resolves or `ipv6-unicast` toggles, so the SID is consistent regardless of the route-delivery vs locator-resolution race.

### Live validation (new BDD `@bgp_srv6_redistribute`)

2-node eBGP-over-IPv6: z1 advertises locator `LOC1` + `segment-routing srv6 ipv6-unicast` + `redistribute connected`; z2 sets `encapsulation-type srv6`. Confirmed on a live run:

```
z1# show bgp ipv6 2001:db8:cafe::/64
    Local SID: fcbb:bbbb:1:40:: (End.DT6)
z2# show bgp ipv6 2001:db8:cafe::/64
  fcbb:bbbb:1:: (10.0.0.1), (external best) from 2001:db8:12::1
    Remote SID: fcbb:bbbb:1:40:: (End.DT6)
```

z1 also installs the `seg6local End.DT6 table main` decap. The `encapsulation-type srv6` peer accepted the SID-bearing route.

## Test plan

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `RUSTFLAGS="-D warnings" cargo test --workspace --exclude bdd` — 1454 pass
- `make -C bdd bgp_srv6_redistribute` — **2 scenarios, 20 steps pass** (after `make install`)

Generated with [Claude Code](https://claude.com/claude-code)