### PR TITLE
bgp: install received IPv6 SRv6 routes with H.Encaps (ingress)

### DIFF
--- a/bdd/tests/configs/bgp_srv6_redistribute/z2.yaml
+++ b/bdd/tests/configs/bgp_srv6_redistribute/z2.yaml
@@ -7,6 +7,16 @@ interface:
   ipv6:
     address: 2001:db8:12::2/64
 router:
+  # Reach z1's SRv6 locator so the received route's next-hop (the locator
+  # address) resolves via NHT — the ingress then installs the H.Encaps
+  # entry toward the SID. In a real fabric the locator is carried by the
+  # IGP; a static stand-in keeps this 2-node BGP test self-contained.
+  static:
+    ipv6:
+      route:
+      - prefix: fcbb:bbbb:1::/48
+        nexthop:
+        - address: 2001:db8:12::1
   bgp:
     global:
       as: 65002

--- a/bdd/tests/features/bgp_srv6_redistribute.feature
+++ b/bdd/tests/features/bgp_srv6_redistribute.feature
@@ -41,7 +41,7 @@ Feature: BGP IPv6 redistribute connected with SRv6 End.DT6 origination
     And I apply config "z1.yaml" to namespace "z1"
     And I apply config "z2.yaml" to namespace "z2"
     And I create dummy interface "cust0" with address "2001:db8:cafe::1/64" in namespace "z1"
-    And I wait 35 seconds
+    And I wait 40 seconds
     # Originator: the redistributed connected prefix carries the SID it
     # owns, rendered as a "Local SID" with End.DT6 behavior.
     Then show command "show bgp ipv6 2001:db8:cafe::/64" in namespace "z1" should contain "Local SID"
@@ -50,6 +50,11 @@ Feature: BGP IPv6 redistribute connected with SRv6 End.DT6 origination
     # it is in the BGP table tagged as a "Remote SID".
     And show command "show bgp ipv6 2001:db8:cafe::/64" in namespace "z2" should contain "Remote SID"
     And show command "show bgp ipv6 2001:db8:cafe::/64" in namespace "z2" should contain "End.DT6"
+    # Ingress dataplane: the received route is installed with an SRv6
+    # H.Encaps entry toward the SID (not a plain next-hop), so matched
+    # traffic is SRv6-encapsulated to the egress PE.
+    And show command "show ipv6 route 2001:db8:cafe::/64" in namespace "z2" should contain "via seg6"
+    And show command "show ipv6 route 2001:db8:cafe::/64" in namespace "z2" should contain "fcbb:bbbb:1:40::"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -435,6 +435,50 @@ fn make_bgp_rib_entry_v6(best: &BgpRib) -> Option<rib::entry::RibEntry> {
     Some(entry)
 }
 
+/// SRv6 ingress for a *received* plain IPv6 unicast route carrying an
+/// SRv6 L3 service SID (RFC 9252 / RFC 8669). The SRv6 counterpart of
+/// [`make_bgp_rib_entry_v6`]: same BGP next-hop + distance/metric, but the
+/// next-hop gets `segs = [sid]` + an H.Encaps seg6 encap, so matched
+/// traffic is SRv6-encapsulated (outer IPv6 DA = the SID) toward the
+/// egress PE that owns the SID. The BGP next-hop is the underlay egress —
+/// exactly the next-hop a plain entry installs `via`, only with the seg6
+/// encap attached (the kernel forwards the encapped packet on toward the
+/// SID's locator). Returns `None` when the best path lacks a usable v6
+/// next-hop. Self-originated routes never reach here (they carry
+/// `nexthop = None` and install nothing).
+fn make_bgp_srv6_encap_entry_v6(
+    best: &BgpRib,
+    sid: std::net::Ipv6Addr,
+) -> Option<rib::entry::RibEntry> {
+    let distance = match best.typ {
+        BgpRibType::EBGP => 20,
+        BgpRibType::IBGP | BgpRibType::Originated => 200,
+    };
+    let metric = best.attr.med.as_ref().map(|m| m.med).unwrap_or(0);
+
+    let nh = match best.attr.nexthop.as_ref()? {
+        BgpNexthop::Ipv6(addr) => *addr,
+        _ => return None,
+    };
+    if nh.is_unspecified() {
+        return None;
+    }
+
+    let mut uni = rib::NexthopUni::new(IpAddr::V6(nh), 0, Vec::new());
+    uni.segs = vec![sid];
+    uni.encap_type = Some(isis_packet::srv6::EncapType::HEncap);
+    uni.metric = metric;
+    uni.weight = 1;
+    uni.valid = true;
+
+    let mut entry = rib::entry::RibEntry::new(rib::RibType::Bgp);
+    entry.distance = distance;
+    entry.metric = metric;
+    entry.valid = true;
+    entry.nexthop = rib::Nexthop::Uni(uni);
+    Some(entry)
+}
+
 /// IPv6 counterpart of [`select_fib_entry_v4`].
 fn select_fib_entry_v6(
     best: &BgpRib,
@@ -450,6 +494,14 @@ fn select_fib_entry_v6(
     }
     if is_vpn_fib_winner(best, transport) {
         build_vpn_fib_entry(best.label.map(|l| l.label).unwrap_or(0), transport.unwrap())
+    } else if let Some((sid, _behavior)) = best.attr.srv6_l3_sid() {
+        // A *received* plain IPv6 unicast route carrying an SRv6 L3
+        // service SID installs an H.Encaps entry toward the SID instead
+        // of a plain next-hop entry, so matched traffic is SRv6-
+        // encapsulated to the egress PE. (The `Originated` + SID case is
+        // VPNv6-over-SRv6, handled above; this is the global-table,
+        // non-VPN ingress.)
+        make_bgp_srv6_encap_entry_v6(best, sid)
     } else {
         make_bgp_rib_entry_v6(best)
     }


### PR DESCRIPTION
## Summary

Fixes a reported bug: a **received** plain IPv6 unicast route carrying an SRv6 Prefix-SID was installed as a **plain** next-hop FIB entry — the SID was dropped, so traffic forwarded unencapsulated instead of SRv6-encapsulated to the egress PE.

```
# before (bug):
B  *> 2001:db8:ff00:5::/64 via 2001:db8::8, enp0s6        ← no encap
# after:
B  *> 2001:db8:cafe::/64   via seg6 [fcbb:bbbb:1:40::], i1 ← H.Encaps
```

### Root cause

`select_fib_entry_v6`'s SRv6 H.Encaps branch was gated on `BgpRibType::Originated` (the VPNv6-over-SRv6 *import* case). A route **received** from a peer (iBGP/eBGP) is not `Originated`, so it fell through to the plain next-hop builder (`make_bgp_rib_entry_v6`) and the SID never reached the dataplane.

### Fix

Add `make_bgp_srv6_encap_entry_v6` — the SRv6 counterpart of `make_bgp_rib_entry_v6`: same BGP next-hop + distance/metric, but the next-hop carries `segs = [sid]` + an H.Encaps seg6 encap. `select_fib_entry_v6` selects it for any received SID-bearing plain v6 unicast winner. The BGP next-hop is the underlay egress — exactly the next-hop a plain entry installs `via`, only with the encap attached (consistent with how `make_bgp_rib_entry_v6` installs an on-link/`onlink` next-hop).

### Validation (extended `@bgp_srv6_redistribute` BDD)

z2 (the receiver) now installs the H.Encaps entry. Confirmed live:
```
z2# show ipv6 route 2001:db8:cafe::/64
B  *> 2001:db8:cafe::/64 [20/0] via seg6 [fcbb:bbbb:1:40::], i1
z2# ip -6 route
2001:db8:cafe::/64 encap seg6 mode encap segs 1 [ fcbb:bbbb:1:40:: ] via fcbb:bbbb:1:: dev i1 proto bgp
```
z2 carries a static stand-in for the IGP-advertised locator so the next-hop resolves; new feature assertions check `via seg6` + the SID.

## Test plan

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `RUSTFLAGS="-D warnings" cargo test --workspace --exclude bdd` — 1454 pass
- `make -C bdd bgp_srv6_redistribute` — **2 scenarios, 22 steps pass**

Generated with [Claude Code](https://claude.com/claude-code)