### PR TITLE
bgp: Inter-AS MPLS/VPN Option C over SR-MPLS

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -162,6 +162,10 @@ bgp_unnumbered_neighbor:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_unnumbered_neighbor"
 
+bgp_interas_option_c:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_interas_option_c"
+
 generate:
 	rm -rf allure-report
 	allure generate
@@ -181,4 +185,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv3_nssa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise bgp_neighbor_group bgp_unnumbered_neighbor generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv3_nssa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise bgp_neighbor_group bgp_unnumbered_neighbor bgp_interas_option_c generate open docs FORCE

--- a/bdd/tests/configs/bgp_interas_option_c/asbr1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_c/asbr1.yaml
@@ -1,0 +1,56 @@
+# ASBR1 (AS 65000 border). Inter-AS Option C: NO VPN state here.
+#  - IS-IS L2 + SR-MPLS toward P1 (intra-AS transport); the inter-AS link
+#    to ASBR2 is NOT in the IGP.
+#  - eBGP labeled-unicast to ASBR2 (172.16.0.2) over the inter-AS link:
+#    exchanges PE loopback /32s with labels. MPLS BGP forwarding only.
+#  - iBGP labeled-unicast to PE1 (1.1.1.1) re-advertises the routes
+#    learned from ASBR2 with `next-hop-self` so PE1 resolves ASBR1 (via
+#    the IGP) and pushes ASBR1's swap label, not the foreign-AS next-hop.
+#    This `next-hop-self` is the knob Option C requires on this session.
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.3/32
+- if-name: p1
+  ipv4:
+    address: 10.0.0.6/30
+- if-name: asbr2
+  ipv4:
+    address: 172.16.0.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: asbr1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 3
+    - if-name: p1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      identifier: 1.1.1.3
+    neighbor:
+    - remote-address: 1.1.1.1
+      remote-as: 65000
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true
+        next-hop-self: true
+    - remote-address: 172.16.0.2
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true

--- a/bdd/tests/configs/bgp_interas_option_c/asbr2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_c/asbr2.yaml
@@ -1,0 +1,52 @@
+# ASBR2 (AS 65001 border). Mirror of ASBR1.
+#  - IS-IS L2 + SR-MPLS toward P2 (intra-AS transport); inter-AS link not
+#    in the IGP.
+#  - eBGP labeled-unicast to ASBR1 (172.16.0.1).
+#  - iBGP labeled-unicast to PE2 (2.2.2.1) with `next-hop-self`.
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.3/32
+- if-name: asbr1
+  ipv4:
+    address: 172.16.0.2/30
+- if-name: p2
+  ipv4:
+    address: 10.0.1.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0006.00
+    hostname: asbr2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 6
+    - if-name: p2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65001
+      identifier: 2.2.2.3
+    neighbor:
+    - remote-address: 2.2.2.1
+      remote-as: 65001
+      update-source: 2.2.2.3
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true
+        next-hop-self: true
+    - remote-address: 172.16.0.1
+      remote-as: 65000
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true

--- a/bdd/tests/configs/bgp_interas_option_c/ce1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_c/ce1.yaml
@@ -1,0 +1,14 @@
+# CE1 (AS 65000 customer site). A plain host: one link to PE1 and a
+# default route pointing at PE1's VRF interface. No IGP/BGP — the CE is
+# the traffic source/sink for the end-to-end L3VPN ping (CE1 -> CE2).
+interface:
+- if-name: pe1
+  ipv4:
+    address: 10.1.0.2/30
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 0.0.0.0/0
+        nexthop:
+        - address: 10.1.0.1

--- a/bdd/tests/configs/bgp_interas_option_c/ce2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_c/ce2.yaml
@@ -1,0 +1,12 @@
+# CE2 (AS 65001 customer site). Plain host, default route to PE2.
+interface:
+- if-name: pe2
+  ipv4:
+    address: 10.2.0.2/30
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 0.0.0.0/0
+        nexthop:
+        - address: 10.2.0.1

--- a/bdd/tests/configs/bgp_interas_option_c/p1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_c/p1.yaml
@@ -1,0 +1,37 @@
+# P1 (AS 65000 core / transit LSR). Pure IS-IS + SR-MPLS, no BGP. Sits
+# between PE1 and ASBR1 so the intra-AS transport LSP performs a real SR
+# label swap (and PHP toward the loopbacks) rather than collapsing to a
+# single hop.
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.2/32
+- if-name: pe1
+  ipv4:
+    address: 10.0.0.2/30
+- if-name: asbr1
+  ipv4:
+    address: 10.0.0.5/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: p1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 2
+    - if-name: pe1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: asbr1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/bgp_interas_option_c/p2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_c/p2.yaml
@@ -1,0 +1,34 @@
+# P2 (AS 65001 core / transit LSR). Pure IS-IS + SR-MPLS, no BGP.
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.2/32
+- if-name: asbr2
+  ipv4:
+    address: 10.0.1.2/30
+- if-name: pe2
+  ipv4:
+    address: 10.0.1.5/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0005.00
+    hostname: p2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 5
+    - if-name: asbr2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: pe2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/bgp_interas_option_c/pe1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_c/pe1.yaml
@@ -1,0 +1,80 @@
+# PE1 (AS 65000 provider edge). Inter-AS Option C, SR-MPLS transport.
+#  - IS-IS L2 + segment-routing mpls with the loopback Prefix-SID gives
+#    the intra-AS transport LSP to ASBR1 (via P1).
+#  - iBGP labeled-unicast to ASBR1 (1.1.1.3) learns the remote PE
+#    loopback (2.2.2.1) with a stacked BGP-LU label, and originates our
+#    own loopback (1.1.1.1/32) into BGP-LU so AS 65001 can reach us.
+#  - multihop eBGP VPNv4 directly to PE2's loopback (2.2.2.1), sourced
+#    from our loopback. The session rides the BGP-LU LSP; the VPN label
+#    sits under the BGP-LU + SR transport stack.
+#  - vrf-cust holds the customer link to CE1 and originates 10.1.0.0/30.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: p1
+  ipv4:
+    address: 10.0.0.1/30
+- if-name: ce1
+  vrf: vrf-cust
+  ipv4:
+    address: 10.1.0.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 1
+    - if-name: p1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      identifier: 1.1.1.1
+    neighbor:
+    - remote-address: 1.1.1.3
+      remote-as: 65000
+      update-source: 1.1.1.1
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true
+    - remote-address: 2.2.2.1
+      remote-as: 65001
+      ebgp-multihop: 10
+      update-source: 1.1.1.1
+      timers:
+        connect-retry-time: 3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    afi-safi:
+    - name: label-v4
+      network:
+      - prefix: 1.1.1.1/32
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      afi-safi:
+        ipv4:
+          network:
+          - prefix: 10.1.0.0/30

--- a/bdd/tests/configs/bgp_interas_option_c/pe2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_c/pe2.yaml
@@ -1,0 +1,76 @@
+# PE2 (AS 65001 provider edge). Mirror of PE1.
+#  - IS-IS L2 + SR-MPLS transport to ASBR2 (via P2).
+#  - iBGP labeled-unicast to ASBR2 (2.2.2.3); originates our loopback
+#    (2.2.2.1/32) into BGP-LU.
+#  - multihop eBGP VPNv4 to PE1's loopback (1.1.1.1), sourced from ours.
+#  - vrf-cust holds the customer link to CE2 and originates 10.2.0.0/30.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.1/32
+- if-name: p2
+  ipv4:
+    address: 10.0.1.6/30
+- if-name: ce2
+  vrf: vrf-cust
+  ipv4:
+    address: 10.2.0.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0004.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 4
+    - if-name: p2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65001
+      identifier: 2.2.2.1
+    neighbor:
+    - remote-address: 2.2.2.3
+      remote-as: 65001
+      update-source: 2.2.2.1
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true
+    - remote-address: 1.1.1.1
+      remote-as: 65000
+      ebgp-multihop: 10
+      update-source: 2.2.2.1
+      timers:
+        connect-retry-time: 3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    afi-safi:
+    - name: label-v4
+      network:
+      - prefix: 2.2.2.1/32
+    vrf:
+    - name: vrf-cust
+      rd: 65001:1
+      afi-safi:
+        ipv4:
+          network:
+          - prefix: 10.2.0.0/30

--- a/bdd/tests/features/bgp_interas_option_c.feature
+++ b/bdd/tests/features/bgp_interas_option_c.feature
@@ -1,0 +1,147 @@
+@serial
+@bgp_interas_option_c
+Feature: Inter-AS MPLS/VPN Option C over SR-MPLS (RFC 4364 §10c)
+  As a service provider running L3VPN across two autonomous systems
+  I want Inter-AS Option C: the ASBRs exchange only labeled IPv4 (BGP-LU)
+  for the PE loopbacks and hold no VPN state, while the PEs run a direct
+  multihop MP-eBGP VPNv4 session whose next-hop (the remote PE loopback)
+  is resolved across the AS boundary through the BGP-LU LSP, with SR-MPLS
+  providing the intra-AS transport.
+
+  This mirrors Cisco's "Configuration and Verification of L3 MPLS VPN
+  Inter-AS Option C" (doc 200523), streamlined to one PE + one P + one
+  ASBR per AS and a direct PE↔PE VPNv4 session (no route reflector — the
+  originating PE's next-hop-self is already the correct egress, so no
+  next-hop-unchanged is needed; the ASBR→PE iBGP-LU leg uses next-hop-self
+  instead).
+
+  Test Topology (8 namespaces):
+  ```
+            AS 65000                              AS 65001
+   ce1 --- pe1 --- p1 --- asbr1 ===== asbr2 --- p2 --- pe2 --- ce2
+  10.1.0.2 lo       lo     lo   172.16  lo       lo     lo   10.2.0.2
+        1.1.1.1 1.1.1.2 1.1.1.3 .0.0/30 2.2.2.3 2.2.2.2 2.2.2.1
+        (sid 1) (sid 2) (sid 3)         (sid 6) (sid 5) (sid 4)
+   \__vrf-cust_/                                       \_vrf-cust__/
+     10.1.0.0/30                                         10.2.0.0/30
+  ```
+  - Intra-AS: IS-IS L2 + segment-routing mpls; loopback Prefix-SIDs give
+    the transport LSP (SRGB base 16000 → labels 16001..16006). P routers
+    perform the real SR transit swap / PHP.
+  - Inter-AS (asbr1↔asbr2, 172.16.0.0/30): eBGP labeled-unicast only —
+    PE loopback /32s exchanged with labels, no IGP, no VPN state.
+  - ASBR↔PE (intra-AS): iBGP labeled-unicast with next-hop-self, so the
+    PE resolves the ASBR (via IS-IS) and pushes the ASBR's swap label.
+  - PE↔PE: multihop eBGP VPNv4 between loopbacks. The session itself
+    rides the BGP-LU LSP, so "Established" already proves end-to-end
+    labeled forwarding works before any data packet is sent.
+  - The CE↔CE ping exercises the full label stack: SR transport (outer)
+    + BGP-LU (AS crossing) + VPN (innermost).
+
+  Scenario: Build the Inter-AS Option C topology and bring up every session
+    Given a clean test environment
+    When I create namespace "ce1"
+    And I create namespace "pe1"
+    And I create namespace "p1"
+    And I create namespace "asbr1"
+    And I create namespace "asbr2"
+    And I create namespace "p2"
+    And I create namespace "pe2"
+    And I create namespace "ce2"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I connect namespace "pe1" interface "p1" to namespace "p1" interface "pe1"
+    And I connect namespace "p1" interface "asbr1" to namespace "asbr1" interface "p1"
+    And I connect namespace "asbr1" interface "asbr2" to namespace "asbr2" interface "asbr1"
+    And I connect namespace "asbr2" interface "p2" to namespace "p2" interface "asbr2"
+    And I connect namespace "p2" interface "pe2" to namespace "pe2" interface "p2"
+    And I connect namespace "pe2" interface "ce2" to namespace "ce2" interface "pe2"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I start zebra-rs in namespace "p1"
+    And I start zebra-rs in namespace "asbr1"
+    And I start zebra-rs in namespace "asbr2"
+    And I start zebra-rs in namespace "p2"
+    And I start zebra-rs in namespace "pe2"
+    And I start zebra-rs in namespace "ce2"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    And I apply config "p1.yaml" to namespace "p1"
+    And I apply config "asbr1.yaml" to namespace "asbr1"
+    And I apply config "asbr2.yaml" to namespace "asbr2"
+    And I apply config "p2.yaml" to namespace "p2"
+    And I apply config "pe2.yaml" to namespace "pe2"
+    And I apply config "ce2.yaml" to namespace "ce2"
+    And I wait 35 seconds for BGP to operate
+    # IS-IS SR adjacencies form the intra-AS transport (polls up to 30s).
+    Then isis neighbor in namespace "pe1" at level 2 on interface "p1" should be up
+    And isis neighbor in namespace "asbr1" at level 2 on interface "p1" should be up
+    And isis neighbor in namespace "pe2" at level 2 on interface "p2" should be up
+    And isis neighbor in namespace "asbr2" at level 2 on interface "p2" should be up
+    # eBGP labeled-unicast across the inter-AS link.
+    And BGP session in "asbr1" to "172.16.0.2" should be "Established"
+    And BGP session in "asbr2" to "172.16.0.1" should be "Established"
+    # iBGP labeled-unicast ASBR↔PE inside each AS.
+    And BGP session in "pe1" to "1.1.1.3" should be "Established"
+    And BGP session in "pe2" to "2.2.2.3" should be "Established"
+    # Multihop eBGP VPNv4 PE↔PE — riding the BGP-LU LSP. Establishing it
+    # already proves labeled forwarding across the AS boundary works.
+    And BGP session in "pe1" to "2.2.2.1" should be "Established"
+    And BGP session in "pe2" to "1.1.1.1" should be "Established"
+
+  Scenario: SR-MPLS transport LSPs are installed on the core P routers
+    Given the test topology exists
+    # P1 is penultimate to PE1 (sid 1 → 16001) and ASBR1 (sid 3 → 16003).
+    Then mpls ilm in namespace "p1" should contain label 16001
+    And mpls ilm in namespace "p1" should contain label 16003
+    # P2 is penultimate to PE2 (sid 4 → 16004) and ASBR2 (sid 6 → 16006).
+    And mpls ilm in namespace "p2" should contain label 16004
+    And mpls ilm in namespace "p2" should contain label 16006
+
+  Scenario: ASBRs exchange PE loopbacks via BGP labeled-unicast, holding no VPN state
+    Given the test topology exists
+    # ASBR1 originates nothing itself; it relays the local-AS PE loopback
+    # (1.1.1.1/32, from PE1) and the remote-AS PE loopback (2.2.2.1/32,
+    # from ASBR2) — both as labeled IPv4, no VPNv4.
+    Then show command "show ip bgp labeled-unicast" in namespace "asbr1" should contain "1.1.1.1/32"
+    And show command "show ip bgp labeled-unicast" in namespace "asbr1" should contain "2.2.2.1/32"
+    And show command "show ip bgp labeled-unicast" in namespace "asbr2" should contain "1.1.1.1/32"
+    And show command "show ip bgp labeled-unicast" in namespace "asbr2" should contain "2.2.2.1/32"
+
+  Scenario: Each PE learns the remote PE loopback through the BGP-LU chain
+    Given the test topology exists
+    Then show command "show ip bgp labeled-unicast" in namespace "pe1" should contain "2.2.2.1/32"
+    And show command "show ip bgp labeled-unicast" in namespace "pe2" should contain "1.1.1.1/32"
+
+  Scenario: VPNv4 customer routes are exchanged directly between the PEs
+    Given the test topology exists
+    # PE1 receives PE2's customer prefix under PE2's RD (65001:1).
+    Then show command "show ip bgp vpnv4" in namespace "pe1" should contain "10.2.0.0/30"
+    And show command "show ip bgp vpnv4" in namespace "pe1" should contain "65001:1"
+    # PE2 receives PE1's customer prefix under PE1's RD (65000:1).
+    And show command "show ip bgp vpnv4" in namespace "pe2" should contain "10.1.0.0/30"
+    And show command "show ip bgp vpnv4" in namespace "pe2" should contain "65000:1"
+
+  Scenario: End-to-end customer forwarding across the AS boundary (SR + BGP-LU + VPN)
+    Given the test topology exists
+    Then ping from "ce1" to "10.2.0.2" should succeed
+    And ping from "ce2" to "10.1.0.2" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I stop zebra-rs in namespace "p1"
+    And I stop zebra-rs in namespace "asbr1"
+    And I stop zebra-rs in namespace "asbr2"
+    And I stop zebra-rs in namespace "p2"
+    And I stop zebra-rs in namespace "pe2"
+    And I stop zebra-rs in namespace "ce2"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    And I delete namespace "p1"
+    And I delete namespace "asbr1"
+    And I delete namespace "asbr2"
+    And I delete namespace "p2"
+    And I delete namespace "pe2"
+    And I delete namespace "ce2"
+    Then the test environment should be clean

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -29,6 +29,8 @@
   - [L3VPN over an SRv6 Underlay](ch-02-05-bgp-l3vpn-srv6.md)
   - [EVPN Type-5 (IP Prefix Routes)](ch-02-06-bgp-evpn-type5.md)
   - [Route Target Constraint (RTC)](ch-02-07-bgp-rtc.md)
+  - [Inter-AS L3VPN](ch-02-18-bgp-interas.md)
+    - [Option C over SR-MPLS](ch-02-19-bgp-interas-option-c.md)
   - [BFD](ch-02-08-bgp-bfd.md)
   - [Route Reflector](ch-02-09-bgp-route-reflector.md)
   - [Conditional Tracing](ch-02-10-bgp-tracing.md)

--- a/book/src/ch-02-18-bgp-interas.md
+++ b/book/src/ch-02-18-bgp-interas.md
@@ -1,0 +1,31 @@
+# Inter-AS L3VPN
+
+A BGP/MPLS L3VPN ([RFC 4364](https://www.rfc-editor.org/rfc/rfc4364))
+normally lives inside a single autonomous system: the PE routers run
+iBGP (directly or via a route reflector), and an IGP with an MPLS
+transport (LDP or SR-MPLS) glues the PE loopbacks together. *Inter-AS*
+L3VPN is the case where the two ends of a VPN sit in **different**
+autonomous systems — two providers, or two regions of one provider that
+run separate IGPs — and the VPN must cross the AS boundary at the
+Autonomous System Boundary Routers (ASBRs).
+
+RFC 4364 §10 describes three ways to carry VPN routes across that
+boundary:
+
+| Option | How VPN routes cross | VPN state on the ASBRs | Transport LSP |
+|---|---|---|---|
+| **A** (§10a) | back-to-back VRFs; one (sub)interface per VPN between the ASBRs | full — one VRF per VPN | terminates at each ASBR |
+| **B** (§10b) | MP-eBGP VPNv4/VPNv6 between the ASBRs | per-VPN-route (the ASBRs hold and re-advertise every VPN prefix) | terminates at each ASBR |
+| **C** (§10c) | MP-eBGP VPNv4/VPNv6 directly (multihop) between the PEs (or RRs); the ASBRs exchange only **labeled IPv4/IPv6** (BGP-LU) for the PE loopbacks | **none** — the ASBRs hold no VPN routes | a single end-to-end LSP from ingress PE to egress PE |
+
+The options trade off ASBR scaling against operational coupling. Option
+A needs no MPLS on the inter-AS link but burns a (sub)interface and a
+VRF per VPN. Option B keeps the ASBRs in the VPN control plane (and the
+VPN data plane). **Option C** pushes both out: the ASBRs only need to
+make the remote PE loopbacks reachable — and labeled — so a single LSP
+runs end to end and the VPN routes pass over the top, transparent to the
+ASBRs. It scales best and is the focus of this section.
+
+> **Implemented today:** Option C, with an SR-MPLS transport inside each
+> AS — see [Option C over SR-MPLS](ch-02-19-bgp-interas-option-c.md).
+> Options A and B are future work.

--- a/book/src/ch-02-19-bgp-interas-option-c.md
+++ b/book/src/ch-02-19-bgp-interas-option-c.md
@@ -1,0 +1,287 @@
+# Inter-AS Option C over SR-MPLS
+
+Option C (RFC 4364 §10c) keeps the ASBRs out of the VPN entirely. Three
+control planes cooperate so that a single MPLS LSP runs from the ingress
+PE to the egress PE, with the VPN routes carried directly between the
+PEs over the top:
+
+1. **Inside each AS** — an IGP with SR-MPLS (IS-IS here) makes the local
+   PE and ASBR loopbacks reachable and gives them prefix-SID labels, so
+   any two routers in the AS have a transport LSP between them.
+2. **Across the AS boundary** — the ASBRs run **eBGP labeled-unicast**
+   (BGP-LU, SAFI 4) and exchange each other's PE loopback `/32`s *with a
+   label*. No IGP and no VPN routes cross the link; the ASBRs hold no VPN
+   state.
+3. **Between the PEs** — a **multihop MP-eBGP VPNv4/VPNv6** session
+   (loopback to loopback) carries the VPN routes. Its next-hop is the
+   remote PE loopback, which the local PE reaches over the stitched
+   BGP-LU LSP from step 2.
+
+The result is an end-to-end label stack — SR transport (outer), BGP-LU
+(AS crossing), VPN service label (inner) — that the ingress PE pushes in
+one go.
+
+## Reference topology
+
+This is the topology exercised by the `@bgp_interas_option_c` BDD
+feature (`bdd/tests/features/bgp_interas_option_c.feature`):
+
+```
+          AS 65000                                  AS 65001
+ ce1 ── pe1 ──── p1 ──── asbr1 ═══════════ asbr2 ──── p2 ──── pe2 ── ce2
+        lo        lo       lo    172.16.0.0/30  lo      lo      lo
+     1.1.1.1   1.1.1.2  1.1.1.3              2.2.2.3 2.2.2.2 2.2.2.1
+     (sid 1)   (sid 2)  (sid 3)              (sid 6) (sid 5) (sid 4)
+  └ vrf-cust ┘                                            └ vrf-cust ┘
+   10.1.0.0/30                                             10.2.0.0/30
+```
+
+With the default SRGB base of `16000`, prefix-SID index `N` becomes
+label `16000+N`, so `pe2`'s loopback `2.2.2.1` is SR label `16004`,
+`asbr1`'s `1.1.1.3` is `16003`, and so on. `p1` and `p2` are pure SR
+transit LSRs (IS-IS only); the ASBRs hold no VPN routes; the customer
+prefixes live in `vrf-cust` on each PE.
+
+## SR-MPLS transport inside each AS
+
+Each PE, P, and ASBR runs IS-IS Level-2 with `segment-routing mpls` and
+a prefix-SID on its loopback. The inter-AS link is deliberately **not**
+in the IGP — it is the BGP-LU link. A PE config's IS-IS block:
+
+```yaml
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    is-type: level-2-only
+    segment-routing: mpls
+    interface:
+    - if-name: lo
+      ipv4: { enable: true, prefix-sid: { index: 1 } }
+    - if-name: p1
+      network-type: point-to-point
+      metric: 10
+      ipv4: { enable: true }
+```
+
+This gives `pe1` a transport LSP to `asbr1` (its BGP-LU peer's
+loopback), traversing `p1` with a real SR swap / penultimate-hop pop.
+See the [SRv6](ch-04-00-srv6.md) and IS-IS chapters for the segment
+routing details.
+
+## eBGP labeled-unicast between the ASBRs
+
+The ASBRs peer over the inter-AS link with the IPv4 Labeled-Unicast
+family (`label-v4`) and **originate their own AS's PE loopbacks** into
+it. Because the loopback is reached over the IGP, the ASBR allocates a
+*local* label for it and installs a swap entry (BGP-LU label → SR
+transport toward the PE); the remote ASBR learns the `/32` with that
+label.
+
+```yaml
+router:
+  bgp:
+    global:
+      as: 65000
+      identifier: 1.1.1.3
+    neighbor:
+    - remote-address: 172.16.0.2   # ASBR2, over the inter-AS link
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true
+    afi-safi:
+    - name: label-v4
+      network:
+      - prefix: 1.1.1.1/32         # advertise PE1's loopback to AS 65001
+```
+
+> Each PE typically originates its own loopback (implicit-null, since it
+> is the egress), and the ASBR re-originates it across the boundary. The
+> BDD has the PEs originate their loopbacks via `network` under the
+> global `label-v4` family; the ASBRs simply relay.
+
+## iBGP labeled-unicast ASBR → PE, with `next-hop-self`
+
+The ASBR re-advertises the routes it learned across the boundary to its
+own PEs over an iBGP-LU session. This leg needs **`next-hop-self`**: by
+default a route learned from one peer keeps its received next-hop, which
+here is the *foreign-AS* next-hop the PE cannot resolve. With
+`next-hop-self`, the ASBR advertises its own loopback as the next-hop
+and a fresh swap label, so the PE resolves the ASBR over the IGP and
+pushes the ASBR's label.
+
+```yaml
+    neighbor:
+    - remote-address: 1.1.1.1       # PE1, iBGP over loopbacks
+      remote-as: 65000
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - name: label-v4
+        enabled: true
+        next-hop-self: true
+```
+
+The CLI equivalent is:
+
+```
+set router bgp neighbor 1.1.1.1 afi-safi label-v4 next-hop-self true
+```
+
+`next-hop-self` is a per-neighbor, per-AFI/SAFI knob honored on the
+Labeled-Unicast advertise path. Without it, the PE would see the remote
+ASBR (a different AS) as the next-hop and the route would be unusable.
+
+## Multihop eBGP VPNv4 between the PEs
+
+The PEs run a direct MP-eBGP session between their loopbacks, carrying
+only the `vpnv4` family. It is multihop (`ebgp-multihop`) and sourced
+from the loopback (`update-source`); a short `connect-retry-time` lets
+it come up promptly once the BGP-LU LSP to the remote loopback exists.
+
+```yaml
+    neighbor:
+    - remote-address: 2.2.2.1       # PE2's loopback, several hops away
+      remote-as: 65001
+      ebgp-multihop: 10
+      update-source: 1.1.1.1
+      timers: { connect-retry-time: 3 }
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      afi-safi:
+        ipv4:
+          network:
+          - prefix: 10.1.0.0/30     # the customer prefix
+```
+
+The VPN route-targets live on the top-level `vrf` block, exactly as for
+intra-AS [L3VPN](ch-02-04-bgp-l3vpn.md):
+
+```yaml
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import: [65000:100]
+      export: [65000:100]
+```
+
+Because the PE *originates* its VPN route, it sets next-hop-self
+(its own loopback) — which is the correct egress — so no
+`next-hop-unchanged` is needed even though the session is eBGP. (A
+route-reflector-based Option C, where an out-of-path RR reflects VPNv4
+with `next-hop-unchanged`, is a separate design.)
+
+## The crux: resolving the VPN next-hop over the BGP-LU LSP
+
+When `pe1` receives `10.2.0.0/30` with next-hop `2.2.2.1`, that next-hop
+is **not** in any IGP — it is only reachable over the BGP-LU LSP. The
+recursive next-hop resolver therefore has to resolve a VPN next-hop
+**through a labeled BGP route**, stacking that route's label(s) under
+the VPN service label.
+
+This is the one place inter-AS forwarding differs from the intra-AS
+case. Ordinarily a BGP next-hop must resolve over the underlay (IGP /
+connected) and resolving over another BGP route is refused — it would
+risk loops. The exception is a **labeled** BGP-LU route: it *is* the
+transport, so the resolver accepts it (bounded by the recursion depth
+cap). The VPN next-hop then resolves to:
+
+```
+2.2.2.1  →  BGP-LU route (push the ASBR's swap label)
+         →  IGP/SR route to the ASBR (push the SR prefix-SID)
+         →  on-link next-hop toward P1
+```
+
+and the PE programs the VPN prefix with all three labels.
+
+## End-to-end label stack
+
+A packet from `ce1` to a host in `ce2`'s subnet, traced by the labels on
+the wire (AS 65000 → AS 65001):
+
+| Hop | Action | Stack leaving the hop |
+|---|---|---|
+| `pe1` | VRF lookup → push `[SR→asbr1, BGP-LU, VPN]` | `16003 · L_lu · L_vpn` |
+| `p1` | SR penultimate-hop pop of `16003` | `L_lu · L_vpn` |
+| `asbr1` | swap BGP-LU label toward `asbr2` | `L_lu' · L_vpn` |
+| `asbr2` | swap → push SR transport toward `pe2` | `16004 · L_vpn` |
+| `p2` | SR penultimate-hop pop of `16004` | `L_vpn` |
+| `pe2` | pop VPN label → VRF lookup → to `ce2` | *(IP)* |
+
+The transport label (SR) gets the packet to the next ASBR; the BGP-LU
+label carries it across the AS boundary to the right egress PE; the VPN
+label selects the customer VRF on that PE.
+
+## Verification
+
+**The PEs learn each other's loopback as a labeled route.** On `pe1`,
+`2.2.2.1/32` arrives over BGP-LU and installs with the stacked transport
++ BGP-LU label:
+
+```
+$ show ip route 2.2.2.1
+B  *> 2.2.2.1/32 [200/0] via 10.0.0.2, p1, label 16003 16
+
+$ ip route show 2.2.2.1
+2.2.2.1 nhid 3  encap mpls  16003/16 via 10.0.0.2 dev p1 proto bgp onlink
+```
+
+Here `16003` is the SR prefix-SID toward `asbr1` and `16` is `asbr1`'s
+BGP-LU swap label for `2.2.2.1`.
+
+**The ASBRs carry only labeled IPv4 — no VPN.** On `asbr1`:
+
+```
+$ show ip bgp labeled-unicast
+    Network            Next Hop            ...  Path
+ *>i 1.1.1.1/32         1.1.1.1             ...  i        # local PE, from PE1
+ *>  2.2.2.1/32         172.16.0.2          ...  65001 i  # remote PE, from ASBR2
+```
+
+The `label-v4` capability is negotiated on each BGP-LU session:
+
+```
+$ show ip bgp neighbor 172.16.0.2
+  ...
+    IPv4 Labeled Unicast: advertised and received
+```
+
+**The VPN routes pass directly between the PEs.** On `pe1`, the remote
+customer prefix appears under the remote PE's RD, tagged with the shared
+route-target, and the multihop session is up:
+
+```
+$ show ip bgp vpnv4
+Route Distinguisher: 65001:1
+ *>  10.2.0.0/30        2.2.2.1   ...   # rt:65000:100
+
+$ show ip bgp neighbor 2.2.2.1
+  BGP state = Established
+```
+
+That the multihop VPNv4 session reaches `Established` at all already
+proves the BGP-LU LSP forwards — its TCP rides that LSP.
+
+**End to end.** With the customer prefix imported into `vrf-cust` on
+each PE, traffic forwards across the boundary:
+
+```
+ce1$ ping <host in ce2's subnet>   # succeeds
+```
+
+## BDD coverage
+
+`bdd/tests/features/bgp_interas_option_c.feature` builds the full
+eight-namespace topology above and asserts, in order: the IS-IS SR
+adjacencies, the SR-MPLS ILM entries on the P routers, the eBGP-LU and
+iBGP-LU sessions, the BGP-LU loopback exchange across the ASBRs, the
+multihop VPNv4 session, the VPNv4 route exchange under each RD, and
+finally an end-to-end CE-to-CE ping that exercises the SR + BGP-LU + VPN
+label stack in the Linux MPLS data plane.

--- a/zebra-rs/src/bgp/cap.rs
+++ b/zebra-rs/src/bgp/cap.rs
@@ -29,9 +29,11 @@ pub struct CapAfiMap {
 impl CapAfiMap {
     pub fn new() -> Self {
         let mp4uni = CapMultiProtocol::new(&Afi::Ip, &Safi::Unicast);
+        let mp4label = CapMultiProtocol::new(&Afi::Ip, &Safi::MplsLabel);
         let mp4vpn = CapMultiProtocol::new(&Afi::Ip, &Safi::MplsVpn);
         let mp4rtc = CapMultiProtocol::new(&Afi::Ip, &Safi::Rtc);
         let mp6uni = CapMultiProtocol::new(&Afi::Ip6, &Safi::Unicast);
+        let mp6label = CapMultiProtocol::new(&Afi::Ip6, &Safi::MplsLabel);
         let mp6vpn = CapMultiProtocol::new(&Afi::Ip6, &Safi::MplsVpn);
         let mp6rtc = CapMultiProtocol::new(&Afi::Ip6, &Safi::Rtc);
         let mpevpn = CapMultiProtocol::new(&Afi::L2vpn, &Safi::Evpn);
@@ -43,9 +45,11 @@ impl CapAfiMap {
 
         let mut cmap = Self::default();
         cmap.entries.insert(mp4uni, SendRecv::default());
+        cmap.entries.insert(mp4label, SendRecv::default());
         cmap.entries.insert(mp4vpn, SendRecv::default());
         cmap.entries.insert(mp4rtc, SendRecv::default());
         cmap.entries.insert(mp6uni, SendRecv::default());
+        cmap.entries.insert(mp6label, SendRecv::default());
         cmap.entries.insert(mp6vpn, SendRecv::default());
         cmap.entries.insert(mp6rtc, SendRecv::default());
         cmap.entries.insert(mpevpn, SendRecv::default());

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -1525,6 +1525,23 @@ fn config_encapsulation_type(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
     Some(())
 }
 
+/// `set/delete router bgp neighbor <addr> afi-safi <name> next-hop-self
+/// <true|false>`. Records the per-neighbor, per-AFI/SAFI next-hop-self
+/// flag on the peer's [`PeerSubConfig`]. Honored on the Labeled-Unicast
+/// advertise paths ([`route_update_labelv4`](super::route::route_update_labelv4)
+/// / `…v6`): an Inter-AS Option C ASBR sets it on the iBGP-LU session to
+/// its PE so re-advertised eBGP-LU routes carry the ASBR as next-hop.
+fn config_next_hop_self(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    let afi_safi: AfiSafi = args.afi_safi()?;
+    let peer = bgp.peers.get_mut(&addr)?;
+
+    let value = if op.is_set() { args.boolean()? } else { false };
+    let config = peer.config.sub.entry(afi_safi).or_default();
+    config.next_hop_self = value;
+    Some(())
+}
+
 fn config_llgr(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let afi_safi: AfiSafi = args.afi_safi()?;
@@ -2357,6 +2374,7 @@ impl Bgp {
         self.callback_peer("/afi-safi/enabled", config_afi_safi);
         self.callback_peer("/afi-safi/add-path", config_add_path);
         self.callback_peer("/afi-safi/encapsulation-type", config_encapsulation_type);
+        self.callback_peer("/afi-safi/next-hop-self", config_next_hop_self);
         self.callback_peer("/afi-safi/graceful-restart/enabled", config_restart);
         self.callback_peer("/afi-safi/long-lived-graceful-restart/enabled", config_llgr);
         self.callback_peer(
@@ -3753,6 +3771,115 @@ mod neighbor_group_wiring_tests {
         assert!(
             drain_stop_events(&mut bgp).contains(&peer_ident),
             "Event::Stop must have been enqueued",
+        );
+    }
+}
+
+#[cfg(test)]
+mod afi_safi_next_hop_self_tests {
+    //! `afi-safi <name> next-hop-self` per-neighbor callback wiring
+    //! (Inter-AS MPLS/VPN Option C). `yang_load_tests` validates that the
+    //! YANG loads, but not that the callback actually records the flag on
+    //! the peer — that's asserted here. Independent test module with its
+    //! own mock channels, mirroring `bfd_wiring_tests`.
+
+    use std::collections::VecDeque;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use tokio::sync::mpsc;
+
+    use super::*;
+
+    fn arg_words(parts: &[&str]) -> Args {
+        Args(
+            parts
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect::<VecDeque<_>>(),
+        )
+    }
+
+    fn fresh_bgp() -> Bgp {
+        let (inbound_tx, _inbound_rx) = mpsc::unbounded_channel();
+        let (_rib_rx_tx, rib_rx) = mpsc::unbounded_channel();
+        let client = crate::rib::client::RibClient::new(
+            inbound_tx,
+            crate::rib::client::ProtoId::from_raw(0),
+        );
+        Box::leak(Box::new(_inbound_rx));
+        let ctx = crate::context::ProtoContext::default_table(client);
+
+        let (rib_tx, _rib_rx) = mpsc::unbounded_channel();
+        let (rib_inbound_tx, _sub_inbound_rx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(_rib_rx));
+        Box::leak(Box::new(_sub_inbound_rx));
+        let next_proto_id = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(1));
+        let subscriber =
+            crate::config::RibSubscriber::for_test(rib_tx, rib_inbound_tx, next_proto_id);
+
+        let (policy_tx, _policy_rx) = mpsc::unbounded_channel();
+        Box::leak(Box::new(_policy_rx));
+        Bgp::new(
+            ctx,
+            rib_rx,
+            subscriber,
+            policy_tx,
+            None,
+            None,
+            tokio::sync::mpsc::channel(1).0,
+        )
+    }
+
+    /// `afi-safi label-v4 next-hop-self true` records the flag for that AF
+    /// only; `delete` clears it. This is the knob an Inter-AS Option C ASBR
+    /// sets on its iBGP labeled-unicast session to the PE so re-advertised
+    /// eBGP-LU routes carry the ASBR as next-hop (`route_update_labelv4`),
+    /// not the unreachable foreign-AS next-hop.
+    #[tokio::test]
+    async fn label_v4_next_hop_self_records_per_af() {
+        let mut bgp = fresh_bgp();
+        config_peer(&mut bgp, arg_words(&["10.0.0.2"]), ConfigOp::Set).unwrap();
+        let addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+
+        // Default: off for every AF.
+        assert!(
+            !bgp.peers
+                .get(&addr)
+                .unwrap()
+                .next_hop_self(Afi::Ip, Safi::MplsLabel),
+            "next-hop-self defaults off",
+        );
+
+        config_next_hop_self(
+            &mut bgp,
+            arg_words(&["10.0.0.2", "label-v4", "true"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+
+        let peer = bgp.peers.get(&addr).unwrap();
+        assert!(
+            peer.next_hop_self(Afi::Ip, Safi::MplsLabel),
+            "label-v4 flag recorded",
+        );
+        // Scoped to the AF it was set on — label-v6 is untouched.
+        assert!(
+            !peer.next_hop_self(Afi::Ip6, Safi::MplsLabel),
+            "other AF unaffected",
+        );
+
+        config_next_hop_self(
+            &mut bgp,
+            arg_words(&["10.0.0.2", "label-v4"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        assert!(
+            !bgp.peers
+                .get(&addr)
+                .unwrap()
+                .next_hop_self(Afi::Ip, Safi::MplsLabel),
+            "delete clears the flag",
         );
     }
 }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1708,6 +1708,84 @@ impl Bgp {
         }
     }
 
+    /// Re-tag and re-advertise a VRF's locally-originated VPNv4 routes
+    /// with the current export route-targets. Called when a VRF's RT
+    /// policy is (re-)learned: the per-VRF route export can race ahead of
+    /// the `VrfRouteTargets` message (the export reads `rib_known_vrfs` at
+    /// emit time), so the `v4vpn` row can be left tagged with no export RT
+    /// and the remote PE cannot import it. Re-tagging here closes the
+    /// race — both an immediate re-advertise to established peers and any
+    /// later `route_sync_vpnv4` dump then carry the RTs. Stale RT
+    /// ecommunities are stripped first so a genuine RT reconfig replaces
+    /// rather than accumulates. IPv4 only today (VPNv6 re-tag is a
+    /// follow-up, consistent with the existing VPNv6-event-driven gaps).
+    fn retag_vrf_exports_v4(&mut self, vrf: &str) {
+        let Some(rd) = self.vrfs.get(vrf).and_then(|c| c.rd) else {
+            return;
+        };
+        let export_rts = self
+            .rib_known_vrfs
+            .get(vrf)
+            .map(|k| k.export_rts_v4.clone())
+            .unwrap_or_default();
+        // Snapshot the originated rows (clone to release the `local_rib`
+        // borrow before mutating it / `peers` below).
+        let rows: Vec<(ipnet::Ipv4Net, super::route::BgpRib)> = self
+            .local_rib
+            .v4vpn
+            .get(&rd)
+            .map(|t| {
+                t.0.iter()
+                    .filter_map(|(p, ribs)| {
+                        ribs.iter()
+                            .find(|r| r.ident == super::route::ORIGINATED_PEER)
+                            .map(|r| (p, r.clone()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        for (prefix, mut rib) in rows {
+            let mut attr = (*rib.attr).clone();
+            // Strip existing Route-Target ecoms (RFC 4360 sub-type 0x02)
+            // so a genuine RT change replaces; the race case has none.
+            if let Some(ref mut ecom) = attr.ecom {
+                ecom.0.retain(|v| v.low_type != 0x02);
+                if ecom.0.is_empty() {
+                    attr.ecom = None;
+                }
+            }
+            let tagged = tag_attr_with_export_rts(attr, &export_rts);
+            rib.attr = self.attr_store.intern(tagged);
+            let (_, selected, _) = self.local_rib.update(Some(rd), prefix, rib);
+            let mut top = super::peer::BgpTop {
+                router_id: &self.router_id,
+                srv6_ipv6_export: self.srv6_ipv6_export.as_ref(),
+                local_rib: &mut self.local_rib,
+                tx: &self.tx,
+                rib_client: &self.ctx.rib,
+                attr_store: &mut self.attr_store,
+                update_groups: &mut self.update_groups,
+                interface_addrs: &self.interface_addrs,
+                color_policy: Some(&self.color_policy),
+                flex_algo_routes: Some(&self.flex_algo_routes),
+                vrf_export: None,
+                vrf_import: None,
+                nexthop_cache: None,
+                vrf_transport_v4: None,
+                vrf_transport_v6: None,
+                lu_labels: None,
+            };
+            super::route::route_advertise_to_peers(
+                Some(rd),
+                prefix,
+                &selected,
+                super::route::ORIGINATED_PEER,
+                &mut top,
+                &mut self.peers,
+            );
+        }
+    }
+
     pub fn process_rib_msg(&mut self, msg: RibRx) {
         // println!("RIB Message {:?}", msg);
         match msg {
@@ -1819,11 +1897,20 @@ impl Bgp {
                 // them as separate messages and a slow
                 // `tokio::select!` could draw the RT message ahead
                 // of the VrfAdd).
-                let entry = self.rib_known_vrfs.entry(name).or_default();
+                let entry = self.rib_known_vrfs.entry(name.clone()).or_default();
+                let export_v4_changed = entry.export_rts_v4 != ipv4_export_rts;
                 entry.import_rts_v4 = ipv4_import_rts;
                 entry.export_rts_v4 = ipv4_export_rts;
                 entry.import_rts_v6 = ipv6_import_rts;
                 entry.export_rts_v6 = ipv6_export_rts;
+                // Close the export / RT-learning race: a per-VRF route can
+                // be exported into `v4vpn` before this RT policy lands (the
+                // export reads `rib_known_vrfs` at emit time), leaving the
+                // row with no export RT — unimportable by the remote PE.
+                // Re-tag + re-advertise the VRF's originated rows now.
+                if export_v4_changed {
+                    self.retag_vrf_exports_v4(&name);
+                }
             }
             // Redistribute deliveries from RIB — initial walk
             // (chunks ending in `bulk: Eor`) plus steady-state deltas
@@ -2725,7 +2812,16 @@ impl Bgp {
                     remote_id: 0,
                     local_id: 0,
                     attr: interned,
-                    ident: 0,
+                    // Originated (VRF-exported) routes carry the
+                    // `ORIGINATED_PEER` sentinel, NOT 0: a literal 0
+                    // collides with the PeerMap index of whichever peer
+                    // happens to occupy slot 0, and the advertise-path
+                    // split-horizon (`rib.ident == peer.ident`) would then
+                    // silently suppress this VPN route toward that peer
+                    // (e.g. an Inter-AS Option C multihop VPNv4 PE whose
+                    // session landed on slot 0). `usize::MAX` never matches
+                    // a real peer.
+                    ident: super::route::ORIGINATED_PEER,
                     router_id: self.router_id,
                     weight: 0,
                     typ: super::route::BgpRibType::Originated,
@@ -2840,11 +2936,13 @@ impl Bgp {
                     );
                     return;
                 };
-                // VRF-originated routes always carry `ident == 0`
-                // and `local_id == 0` (the values used in the
-                // matching Export); the remove path uses that
-                // tuple to identify the row.
-                let removed = self.local_rib.remove(Some(rd), prefix, 0, 0);
+                // VRF-originated routes always carry `ident ==
+                // ORIGINATED_PEER` and `local_id == 0` (the values used in
+                // the matching Export); the remove path uses that tuple to
+                // identify the row.
+                let removed =
+                    self.local_rib
+                        .remove(Some(rd), prefix, 0, super::route::ORIGINATED_PEER);
 
                 // Re-run best-path so any remaining candidate at
                 // (rd, prefix) becomes the new selected winner.
@@ -2990,7 +3088,16 @@ impl Bgp {
                     remote_id: 0,
                     local_id: 0,
                     attr: interned,
-                    ident: 0,
+                    // Originated (VRF-exported) routes carry the
+                    // `ORIGINATED_PEER` sentinel, NOT 0: a literal 0
+                    // collides with the PeerMap index of whichever peer
+                    // happens to occupy slot 0, and the advertise-path
+                    // split-horizon (`rib.ident == peer.ident`) would then
+                    // silently suppress this VPN route toward that peer
+                    // (e.g. an Inter-AS Option C multihop VPNv4 PE whose
+                    // session landed on slot 0). `usize::MAX` never matches
+                    // a real peer.
+                    ident: super::route::ORIGINATED_PEER,
                     router_id: self.router_id,
                     weight: 0,
                     typ: super::route::BgpRibType::Originated,
@@ -3083,7 +3190,9 @@ impl Bgp {
                 let Some(rd) = self.vrfs.get(&vrf).and_then(|cfg| cfg.rd) else {
                     return;
                 };
-                let removed = self.local_rib.remove_v6vpn(rd, prefix, 0, 0);
+                let removed =
+                    self.local_rib
+                        .remove_v6vpn(rd, prefix, 0, super::route::ORIGINATED_PEER);
                 let selected = self.local_rib.select_best_path_vpn_v6(&rd, prefix);
 
                 // Local intra-router leak, symmetric with the ExportV6

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -476,6 +476,15 @@ pub struct PeerSubConfig {
     /// settable under `afi-safi ipv6` (YANG `when name = 'ipv6'`).
     /// `None` = no SRv6 encapsulation mode configured for this AF.
     pub encapsulation_type: Option<AfiSafiEncapType>,
+    /// `afi-safi <name> next-hop-self` (ietf-bgp-neighbor). When `true`,
+    /// routes re-advertised to this neighbor for this AF carry our own
+    /// address as the next-hop even when they were learned from another
+    /// peer (i.e. not just for eBGP / self-originated). Required on the
+    /// iBGP labeled-unicast session an Inter-AS Option C ASBR runs toward
+    /// its PE: the PE must resolve the ASBR (not the foreign-AS next-hop)
+    /// and forward via the ASBR's swap label. Honored on the labeled-
+    /// unicast advertise paths (`route_update_labelv4` / `…v6`).
+    pub next_hop_self: bool,
 }
 
 #[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Clone, Copy)]
@@ -929,6 +938,17 @@ impl Peer {
 
     pub fn is_reflector_client(&self) -> bool {
         self.reflector_client
+    }
+
+    /// Whether `afi-safi <name> next-hop-self` is set for this neighbor in
+    /// the given address family. Forces next-hop-self on forwarded routes
+    /// (not just eBGP / self-originated) — see [`PeerSubConfig::next_hop_self`].
+    pub fn next_hop_self(&self, afi: Afi, safi: Safi) -> bool {
+        self.config
+            .sub
+            .get(&AfiSafi::new(afi, safi))
+            .map(|c| c.next_hop_self)
+            .unwrap_or(false)
     }
 
     pub fn is_afi_safi(&self, afi: Afi, safi: Safi) -> bool {

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -500,7 +500,13 @@ fn select_fib_entry_label(
     if best.typ == BgpRibType::Originated {
         return None;
     }
-    let service_label = best.label.map(|l| l.label).unwrap_or(0);
+    // A received implicit-null (label 3) means the downstream is the egress
+    // FEC and wants the label popped, not carried — forward with only the
+    // transport stack (label 3 must never appear on the wire). This is the
+    // Inter-AS Option C case: a PE originates its loopback into BGP-LU with
+    // implicit-null, and the re-originating ASBR must swap to transport-only,
+    // not transport+3. 0 already means "no service label".
+    let service_label = best.label.map(|l| l.label).filter(|&l| l != 3).unwrap_or(0);
     let transport = match (cache, super::nht::bgp_nexthop_ip(&best.attr)) {
         (Some(c), Some(nh)) => c.transport_for(nh),
         _ => &[][..],
@@ -536,7 +542,13 @@ fn reconcile_swap_ilm(
         ilm_swap_remove(rib_client, local);
         return;
     }
-    let service_label = best.label.map(|l| l.label).unwrap_or(0);
+    // A received implicit-null (label 3) means the downstream is the egress
+    // FEC and wants the label popped, not carried — forward with only the
+    // transport stack (label 3 must never appear on the wire). This is the
+    // Inter-AS Option C case: a PE originates its loopback into BGP-LU with
+    // implicit-null, and the re-originating ASBR must swap to transport-only,
+    // not transport+3. 0 already means "no service label".
+    let service_label = best.label.map(|l| l.label).filter(|&l| l != 3).unwrap_or(0);
     ilm_swap_install(rib_client, local, service_label, transport);
 }
 
@@ -6276,10 +6288,12 @@ fn route_update_labelv4(
 
     ebgp_egress_aspath(peer, &mut attrs);
 
-    // Next-hop-self for eBGP / locally-originated; otherwise keep the
-    // received next-hop (next-hop-unchanged). Captured before clearing
-    // `attrs.nexthop`.
-    let needs_self = peer.is_ebgp() || rib.is_originated();
+    // Next-hop-self for eBGP / locally-originated, or when the neighbor
+    // has `afi-safi label-v4 next-hop-self` (Inter-AS Option C ASBR → PE);
+    // otherwise keep the received next-hop (next-hop-unchanged). Captured
+    // before clearing `attrs.nexthop`.
+    let needs_self =
+        peer.is_ebgp() || rib.is_originated() || peer.next_hop_self(Afi::Ip, Safi::MplsLabel);
     let nhop: IpAddr = if needs_self {
         // v4, or v6 for an RFC 8950 v4-over-v6 session.
         peer.param.local_addr.as_ref().map(|a| a.ip())?
@@ -6348,7 +6362,8 @@ fn route_update_labelv6(
 
     ebgp_egress_aspath(peer, &mut attrs);
 
-    let needs_self = peer.is_ebgp() || rib.is_originated();
+    let needs_self =
+        peer.is_ebgp() || rib.is_originated() || peer.next_hop_self(Afi::Ip6, Safi::MplsLabel);
     let nhop: IpAddr = if needs_self {
         match peer.param.local_addr.as_ref().map(|a| a.ip()) {
             Some(IpAddr::V6(v6)) => IpAddr::V6(v6),
@@ -7497,6 +7512,75 @@ pub fn route_sync_evpn(peer: &mut Peer, bgp: &mut BgpTop) {
 }
 
 // Called when peer has been established.
+/// Dump the IPv4 Labeled-Unicast (SAFI 4) Loc-RIB to a peer that just
+/// reached Established — the labeled-unicast counterpart of
+/// [`route_sync_ipv4`]. Label-v4 is advertised event-driven and is NOT
+/// update-group batched, so its only other advertise path
+/// ([`route_advertise_to_peers_labelv4`]) fires solely on a route change.
+/// Without this establish-time dump, a prefix originated or learned
+/// *before* the peer came up is never sent — exactly the Inter-AS Option C
+/// case, where each PE originates its loopback into BGP-LU before the ASBR
+/// session is up, and each ASBR relays loopbacks it already holds. Dumps
+/// the current Loc-RIB (originated + received), so it is robust to the
+/// order sessions establish in. Best path per prefix (all paths under
+/// add-path); `route_update_labelv4` applies split-horizon / next-hop /
+/// label.
+pub fn route_sync_labelv4(peer: &mut Peer, bgp: &mut BgpTop) {
+    let add_path = peer.opt.is_add_path_send(Afi::Ip, Safi::MplsLabel);
+    let mut routes: Vec<(Ipv4Net, BgpRib)> = Vec::new();
+    for (prefix, ribs) in bgp.local_rib.v4lu.0.iter() {
+        if add_path {
+            routes.extend(ribs.iter().map(|rib| (prefix, rib.clone())));
+        } else if let Some(best) = ribs.last() {
+            routes.push((prefix, best.clone()));
+        }
+    }
+    for (prefix, best) in routes {
+        let Some((nlri, attr, nhop, label)) =
+            route_update_labelv4(peer, &prefix, &best, bgp, add_path)
+        else {
+            continue;
+        };
+        let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+        update.bgp_attr = Some(attr);
+        update.mp_update = Some(MpReachAttr::Labelv4 {
+            snpa: 0,
+            nhop,
+            updates: vec![Labelv4Nlri { label, nlri }],
+        });
+        peer.send_packet(update.into());
+    }
+}
+
+/// IPv6 Labeled-Unicast (incl. 6PE) establish-time Loc-RIB dump — the v6
+/// counterpart of [`route_sync_labelv4`].
+pub fn route_sync_labelv6(peer: &mut Peer, bgp: &mut BgpTop) {
+    let add_path = peer.opt.is_add_path_send(Afi::Ip6, Safi::MplsLabel);
+    let mut routes: Vec<(Ipv6Net, BgpRib)> = Vec::new();
+    for (prefix, ribs) in bgp.local_rib.v6lu.0.iter() {
+        if add_path {
+            routes.extend(ribs.iter().map(|rib| (prefix, rib.clone())));
+        } else if let Some(best) = ribs.last() {
+            routes.push((prefix, best.clone()));
+        }
+    }
+    for (prefix, best) in routes {
+        let Some((nlri, attr, nhop, label)) =
+            route_update_labelv6(peer, &prefix, &best, bgp, add_path)
+        else {
+            continue;
+        };
+        let mut update = UpdatePacket::with_max_packet_size(peer.max_packet_size());
+        update.bgp_attr = Some(attr);
+        update.mp_update = Some(MpReachAttr::Labelv6 {
+            snpa: 0,
+            nhop,
+            updates: vec![Labelv6Nlri { label, nlri }],
+        });
+        peer.send_packet(update.into());
+    }
+}
+
 pub fn route_sync(peer: &mut Peer, bgp: &mut BgpTop) {
     // RFC 4684: advertise our Route Target Constraint membership BEFORE
     // any other AFI/SAFI, so the peer can apply RTC filtering to every
@@ -7534,6 +7618,16 @@ pub fn route_sync(peer: &mut Peer, bgp: &mut BgpTop) {
     }
     if peer.is_afi_safi(Afi::L2vpn, Safi::Evpn) {
         route_sync_evpn(peer, bgp);
+    }
+    // SAFI 4 (RFC 3107 / 8277): dump the Labeled-Unicast Loc-RIBs. Needed
+    // because label-v4/v6 are advertised event-driven only — a route that
+    // existed before this peer came up would otherwise never be sent
+    // (e.g. an Inter-AS Option C PE loopback originated at startup).
+    if peer.is_afi_safi(Afi::Ip, Safi::MplsLabel) {
+        route_sync_labelv4(peer, bgp);
+    }
+    if peer.is_afi_safi(Afi::Ip6, Safi::MplsLabel) {
+        route_sync_labelv6(peer, bgp);
     }
     // SAFI 73: dump our locally-originated SR Policies to the new peer.
     if peer.is_afi_safi(Afi::Ip, Safi::SrTePolicy) || peer.is_afi_safi(Afi::Ip6, Safi::SrTePolicy) {

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -2033,6 +2033,18 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
         {
             writeln!(out, "    IPv6 Unicast: {}", cap.desc())?;
         }
+        let afi = CapMultiProtocol::new(&Afi::Ip, &Safi::MplsLabel);
+        if let Some(cap) = neighbor.cap_map.entries.get(&afi)
+            && (cap.send || cap.recv)
+        {
+            writeln!(out, "    IPv4 Labeled Unicast: {}", cap.desc())?;
+        }
+        let afi = CapMultiProtocol::new(&Afi::Ip6, &Safi::MplsLabel);
+        if let Some(cap) = neighbor.cap_map.entries.get(&afi)
+            && (cap.send || cap.recv)
+        {
+            writeln!(out, "    IPv6 Labeled Unicast: {}", cap.desc())?;
+        }
         let afi = CapMultiProtocol::new(&Afi::Ip, &Safi::MplsVpn);
         if let Some(cap) = neighbor.cap_map.entries.get(&afi)
             && (cap.send || cap.recv)

--- a/zebra-rs/src/bgp/timer.rs
+++ b/zebra-rs/src/bgp/timer.rs
@@ -311,14 +311,14 @@ pub mod config {
 
     pub fn connect_retry_time(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
         let addr = args.addr()?;
-        let hold_time: u16 = args.u16()?;
+        let connect_retry_time: u16 = args.u16()?;
 
         let peer = bgp.peers.get_mut(&addr)?;
 
         if op.is_set() {
-            peer.config.timer.hold_time = Some(hold_time);
+            peer.config.timer.connect_retry_time = Some(connect_retry_time);
         } else {
-            peer.config.timer.hold_time = None;
+            peer.config.timer.connect_retry_time = None;
         }
         Some(())
     }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1379,6 +1379,37 @@ mod yang_load_tests {
         }
     }
 
+    /// The per-neighbor `afi-safi <name> next-hop-self` knob is a hand-added
+    /// boolean leaf on the vendored `ietf-bgp-neighbor` afi-safi list (used
+    /// by Inter-AS MPLS/VPN Option C on the iBGP labeled-unicast session).
+    /// `load_mode` proves the module loads but not that the concrete path is
+    /// settable, so parse the `set` line for both AF and value.
+    #[test]
+    fn bgp_neighbor_afi_safi_next_hop_self_is_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router bgp neighbor 10.0.0.2 afi-safi label-v4 next-hop-self true",
+            "set router bgp neighbor 10.0.0.2 afi-safi label-v4 next-hop-self false",
+            "set router bgp neighbor 2001:db8::8 afi-safi label-v6 next-hop-self true",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "`{cmd}` must be a settable path");
+        }
+    }
+
     /// The IS-IS per-interface `passive` leaf must be a settable path.
     /// It is hand-added to `config.yang` (no YANG generator), so a typo in
     /// the leaf or its placement would otherwise only surface at runtime —

--- a/zebra-rs/src/rib/resolve.rs
+++ b/zebra-rs/src/rib/resolve.rs
@@ -92,21 +92,36 @@ fn entry_nexthop_addr(entry: &RibEntry) -> Option<IpAddr> {
     }
 }
 
+// Whether `entry`'s nexthop carries an MPLS label stack — i.e. it is a BGP
+// Labeled-Unicast (SAFI 4) transport route rather than plain BGP unicast.
+fn entry_has_mpls(entry: &RibEntry) -> bool {
+    match &entry.nexthop {
+        Nexthop::Uni(uni) => !uni.mpls.is_empty(),
+        Nexthop::Multi(multi) => multi.nexthops.iter().any(|u| !u.mpls.is_empty()),
+        _ => false,
+    }
+}
+
 // Whether an entry is allowed to act as a resolver target during recursive
 // nexthop lookup. Connected and IGP routes are always trusted; static is
-// trusted up to the depth cap; BGP is excluded because BGP next-hops should
-// resolve over the underlay (IGP / connected), not over BGP itself, and
-// allowing it would risk recursive loops. The validity check skips entries
-// that are still in the table but no longer reachable — e.g. an IS-IS
-// route whose group went invalid because its egress link is down. Without
-// this filter a recursive static would resolve through the dead route and
-// look reachable when it isn't.
+// trusted up to the depth cap. Plain BGP unicast is excluded — BGP
+// next-hops should resolve over the underlay (IGP / connected), not over
+// BGP itself, and allowing it would risk recursive loops. The one BGP
+// exception is a *labeled* (BGP Labeled-Unicast, SAFI 4) route: Inter-AS
+// MPLS/VPN Option C (RFC 4364 §10c) resolves a VPN next-hop — the remote
+// PE loopback — over the BGP-LU LSP that carries it across the AS boundary,
+// stacking the LU + transport labels under the VPN service label. The
+// recursion depth cap still bounds any loop. The validity check skips
+// entries that are still in the table but no longer reachable — e.g. an
+// IS-IS route whose group went invalid because its egress link is down.
+// Without this filter a recursive static would resolve through the dead
+// route and look reachable when it isn't.
 pub(crate) fn entry_resolvable(entry: &RibEntry) -> bool {
     entry.is_valid()
-        && matches!(
+        && (matches!(
             entry.rtype,
             RibType::Connected | RibType::Static | RibType::Ospf | RibType::Isis
-        )
+        ) || (entry.rtype == RibType::Bgp && entry_has_mpls(entry)))
 }
 
 pub fn rib_resolve(

--- a/zebra-rs/yang/ietf-bgp-neighbor@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-neighbor@2023-07-05.yang
@@ -215,6 +215,28 @@ submodule ietf-bgp-neighbor {
            exchanged). Absent = no SRv6 encapsulation filtering for the
            family.";
       }
+      leaf next-hop-self {
+        ext:sort "30";
+        type boolean;
+        description
+          "Advertise our own address as the BGP next-hop for routes sent
+           to this neighbor in this address family, even when the route
+           was learned from another peer. Equivalent to `neighbor X
+           next-hop-self` (per address-family) in FRR / Cisco IOS.
+
+           By default the next-hop is rewritten to self only for eBGP and
+           locally-originated routes; a route learned from one iBGP/eBGP
+           peer and reflected/forwarded to another keeps its received
+           next-hop. Setting this forces next-hop-self on those forwarded
+           routes too.
+
+           Required on the iBGP IPv4/IPv6 Labeled-Unicast session an
+           Inter-AS MPLS/VPN Option C ASBR runs toward its PE: the PE must
+           resolve the ASBR's loopback (reachable via the IGP) and push
+           the ASBR's swap label, not the unreachable foreign-AS next-hop
+           carried across the inter-AS eBGP-LU link. Currently honored on
+           the Labeled-Unicast (SAFI 4) advertise paths.";
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Implements **Inter-AS MPLS/VPN Option C** (RFC 4364 §10c) end to end, with
an **SR-MPLS** transport inside each AS. The ASBRs exchange only labeled
IPv4 (BGP-LU) for the PE loopbacks and hold no VPN state; the PEs run a
direct multihop MP-eBGP VPNv4 session whose next-hop (the remote PE
loopback) is resolved across the AS boundary through the BGP-LU LSP. A
CE→CE packet rides a three-label stack: SR transport (outer) + BGP-LU
(AS crossing) + VPN service label (inner).

Reaching a forwarding CE-to-CE ping surfaced **seven issues**, most of
them pre-existing gaps in the BGP-LU / L3VPN paths that had only ever
been control-plane-validated:

| Area | Fix |
|---|---|
| `bgp/cap.rs` | Register the Labeled-Unicast (SAFI 4) MP capability — it was missing from `CapAfiMap`, so `is_afi_safi(label-v4)` was always false and every BGP-LU advertise path was silently gated off (the root reason BGP-LU never forwarded live). |
| `bgp/route.rs` | Add `route_sync_labelv4/v6` (establish-time LU Loc-RIB dump; LU was event-driven only). |
| `bgp/route.rs` | Treat a received implicit-null (label 3) as "no push" in the LU swap/push. |
| `bgp/inst.rs` | Tag VRF-exported routes with `ORIGINATED_PEER`, not `0` — `0` collides with PeerMap index 0 and split-horizon suppressed VPNv4 toward that peer. |
| `bgp/inst.rs` | Re-tag + re-advertise a VRF's exported routes when its route-target policy is learned (export could race ahead of the RT message → routes with no RT). |
| `rib/resolve.rs` | Allow a **labeled** (BGP-LU) route as a recursive next-hop resolution target — the Option C crux. Plain BGP unicast stays excluded. |
| `bgp/timer.rs` | Fix `connect-retry-time` setting `hold-time` instead. |

Plus a per-neighbor **`afi-safi <name> next-hop-self`** knob (the
ASBR→PE iBGP-LU requirement), the `@bgp_interas_option_c` BDD feature
(8-namespace topology, end-to-end ping), and a book section under
"Inter-AS L3VPN".

The generic fixes (cap, route_sync, ident, RT re-tag, resolver,
connect-retry, implicit-null) fix L3VPN/BGP-LU forwarding generally, not
just Option C.

## Test plan

- `make -C bdd bgp_interas_option_c` — **7/7 scenarios, 82/82 steps**,
  including the end-to-end CE1→CE2 ping through the kernel MPLS data
  plane (SR + BGP-LU + VPN label stack).
- `cargo test -p zebra-rs --bins` — **964 passed, 0 failed** (incl. new
  `next-hop-self` parse test + YANG-load settability test).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `mdbook build` (book/) — clean, no broken links.

Generated with [Claude Code](https://claude.com/claude-code)
