### PR TITLE
bgp: Inter-AS MPLS/VPN Option A (back-to-back VRFs)

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -170,6 +170,10 @@ bgp_interas_option_c:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_interas_option_c"
 
+bgp_interas_option_a:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_interas_option_a"
+
 generate:
 	rm -rf allure-report
 	allure generate
@@ -189,4 +193,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv3_nssa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise bgp_neighbor_group bgp_unnumbered_neighbor bgp_interas_option_c generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv3_nssa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise bgp_neighbor_group bgp_unnumbered_neighbor bgp_interas_option_c bgp_interas_option_a generate open docs FORCE

--- a/bdd/tests/configs/bgp_interas_option_a/asbr1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_a/asbr1.yaml
@@ -1,0 +1,64 @@
+# ASBR1 (AS 65000 border — a PE in Option A "back-to-back VRFs").
+#  - VPNv4 iBGP to PE1 over the IS-IS/SR core (the intra-AS L3VPN half).
+#  - vrf-cust holds the inter-AS link to ASBR2 (172.16.0.0/30, in the
+#    VRF, NOT in the IGP) and runs a **PE-CE eBGP session inside the VRF**
+#    to ASBR2 (remote-as 65001). Routes learned over that session are
+#    re-exported to VPNv4 toward PE1; VPNv4-imported routes are advertised
+#    to ASBR2. The VPN label terminates here — the inter-AS link carries
+#    plain IP inside vrf-cust.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.3/32
+- if-name: p1
+  ipv4:
+    address: 10.0.0.6/30
+- if-name: asbr2
+  vrf: vrf-cust
+  ipv4:
+    address: 172.16.0.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: asbr1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 3
+    - if-name: p1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      identifier: 1.1.1.3
+    neighbor:
+    - remote-address: 1.1.1.1
+      remote-as: 65000
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:2
+      neighbor:
+      - remote-address: 172.16.0.2
+        remote-as: 65001
+        enabled: true

--- a/bdd/tests/configs/bgp_interas_option_a/asbr2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_a/asbr2.yaml
@@ -1,0 +1,60 @@
+# ASBR2 (AS 65001 border — a PE in Option A). Mirror of ASBR1.
+#  - VPNv4 iBGP to PE2 over the IS-IS/SR core.
+#  - vrf-cust holds the inter-AS link to ASBR1 (172.16.0.0/30) and runs a
+#    PE-CE eBGP session inside the VRF to ASBR1 (remote-as 65000).
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.3/32
+- if-name: asbr1
+  vrf: vrf-cust
+  ipv4:
+    address: 172.16.0.2/30
+- if-name: p2
+  ipv4:
+    address: 10.0.1.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0006.00
+    hostname: asbr2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 6
+    - if-name: p2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65001
+      identifier: 2.2.2.3
+    neighbor:
+    - remote-address: 2.2.2.1
+      remote-as: 65001
+      update-source: 2.2.2.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65001:2
+      neighbor:
+      - remote-address: 172.16.0.1
+        remote-as: 65000
+        enabled: true

--- a/bdd/tests/configs/bgp_interas_option_a/ce1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_a/ce1.yaml
@@ -1,0 +1,14 @@
+# CE1 (AS 65000 customer site). A plain host: one link to PE1 and a
+# default route pointing at PE1's VRF interface. No IGP/BGP — the CE is
+# the traffic source/sink for the end-to-end L3VPN ping (CE1 -> CE2).
+interface:
+- if-name: pe1
+  ipv4:
+    address: 10.1.0.2/30
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 0.0.0.0/0
+        nexthop:
+        - address: 10.1.0.1

--- a/bdd/tests/configs/bgp_interas_option_a/ce2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_a/ce2.yaml
@@ -1,0 +1,12 @@
+# CE2 (AS 65001 customer site). Plain host, default route to PE2.
+interface:
+- if-name: pe2
+  ipv4:
+    address: 10.2.0.2/30
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 0.0.0.0/0
+        nexthop:
+        - address: 10.2.0.1

--- a/bdd/tests/configs/bgp_interas_option_a/p1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_a/p1.yaml
@@ -1,0 +1,37 @@
+# P1 (AS 65000 core / transit LSR). Pure IS-IS + SR-MPLS, no BGP. Sits
+# between PE1 and ASBR1 so the intra-AS transport LSP performs a real SR
+# label swap (and PHP toward the loopbacks) rather than collapsing to a
+# single hop.
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.2/32
+- if-name: pe1
+  ipv4:
+    address: 10.0.0.2/30
+- if-name: asbr1
+  ipv4:
+    address: 10.0.0.5/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: p1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 2
+    - if-name: pe1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: asbr1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/bgp_interas_option_a/p2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_a/p2.yaml
@@ -1,0 +1,34 @@
+# P2 (AS 65001 core / transit LSR). Pure IS-IS + SR-MPLS, no BGP.
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.2/32
+- if-name: asbr2
+  ipv4:
+    address: 10.0.1.2/30
+- if-name: pe2
+  ipv4:
+    address: 10.0.1.5/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0005.00
+    hostname: p2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 5
+    - if-name: asbr2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: pe2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/bgp_interas_option_a/pe1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_a/pe1.yaml
@@ -1,0 +1,60 @@
+# PE1 (AS 65000 provider edge). Inter-AS Option A (back-to-back VRFs).
+# A normal intra-AS L3VPN PE: VPNv4 iBGP to ASBR1 over the IS-IS/SR-MPLS
+# core (loopback next-hop resolved by the IGP — no BGP-LU). vrf-cust
+# holds the CE1 link and originates the customer prefix.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: p1
+  ipv4:
+    address: 10.0.0.1/30
+- if-name: ce1
+  vrf: vrf-cust
+  ipv4:
+    address: 10.1.0.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 1
+    - if-name: p1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      identifier: 1.1.1.1
+    neighbor:
+    - remote-address: 1.1.1.3
+      remote-as: 65000
+      update-source: 1.1.1.1
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      afi-safi:
+        ipv4:
+          network:
+          - prefix: 10.1.0.0/30

--- a/bdd/tests/configs/bgp_interas_option_a/pe2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_a/pe2.yaml
@@ -1,0 +1,58 @@
+# PE2 (AS 65001 provider edge). Mirror of PE1: VPNv4 iBGP to ASBR2 over
+# the IS-IS/SR core; vrf-cust holds the CE2 link.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.1/32
+- if-name: p2
+  ipv4:
+    address: 10.0.1.6/30
+- if-name: ce2
+  vrf: vrf-cust
+  ipv4:
+    address: 10.2.0.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0004.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 4
+    - if-name: p2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65001
+      identifier: 2.2.2.1
+    neighbor:
+    - remote-address: 2.2.2.3
+      remote-as: 65001
+      update-source: 2.2.2.1
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65001:1
+      afi-safi:
+        ipv4:
+          network:
+          - prefix: 10.2.0.0/30

--- a/bdd/tests/features/bgp_interas_option_a.feature
+++ b/bdd/tests/features/bgp_interas_option_a.feature
@@ -1,0 +1,120 @@
+@serial
+@bgp_interas_option_a
+Feature: Inter-AS MPLS/VPN Option A over SR-MPLS (RFC 4364 §10a)
+  As a service provider running L3VPN across two autonomous systems
+  I want Inter-AS Option A: the ASBRs are back-to-back PEs joined by a
+  per-VPN VRF interface, over which they run a PE-CE eBGP session inside
+  the VRF. The VPN label terminates at each ASBR — the inter-AS link
+  carries plain IP inside the VRF — and each AS runs an ordinary intra-AS
+  L3VPN (PE↔ASBR VPNv4 over an SR-MPLS core).
+
+  Test Topology (8 namespaces):
+  ```
+            AS 65000                              AS 65001
+   ce1 ── pe1 ──── p1 ──── asbr1 ─── asbr2 ──── p2 ──── pe2 ── ce2
+          lo        lo       lo  172.16  lo      lo      lo
+       1.1.1.1   1.1.1.2  1.1.1.3 .0.0/30 2.2.2.3 2.2.2.2 2.2.2.1
+   └ vrf-cust ┘          └ vrf ┘ (in VRF) └ vrf ┘       └ vrf-cust ┘
+    10.1.0.0/30                                         10.2.0.0/30
+  ```
+  - Intra-AS: IS-IS L2 + segment-routing mpls; VPNv4 iBGP PE↔ASBR over
+    the SR-MPLS core (the PE loopback next-hop is resolved by the IGP —
+    no BGP-LU). ASBR1 and PE1 are both PEs of AS 65000; likewise AS 65001.
+  - Inter-AS (asbr1↔asbr2, 172.16.0.0/30): the link is in `vrf-cust` on
+    both ASBRs (NOT in the IGP). They run a **PE-CE eBGP session inside
+    vrf-cust**. Routes learned there are re-exported to VPNv4; imported
+    VPNv4 routes are advertised over it. Plain IP on the wire.
+  - A CE→CE packet is VPN-labeled PE→ASBR, decapsulated to plain IP at
+    the ASBR, forwarded over the inter-AS VRF link, then re-labeled
+    ASBR→PE in the far AS.
+
+  Scenario: Build the Inter-AS Option A topology and bring up every session
+    Given a clean test environment
+    When I create namespace "ce1"
+    And I create namespace "pe1"
+    And I create namespace "p1"
+    And I create namespace "asbr1"
+    And I create namespace "asbr2"
+    And I create namespace "p2"
+    And I create namespace "pe2"
+    And I create namespace "ce2"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I connect namespace "pe1" interface "p1" to namespace "p1" interface "pe1"
+    And I connect namespace "p1" interface "asbr1" to namespace "asbr1" interface "p1"
+    And I connect namespace "asbr1" interface "asbr2" to namespace "asbr2" interface "asbr1"
+    And I connect namespace "asbr2" interface "p2" to namespace "p2" interface "asbr2"
+    And I connect namespace "p2" interface "pe2" to namespace "pe2" interface "p2"
+    And I connect namespace "pe2" interface "ce2" to namespace "ce2" interface "pe2"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I start zebra-rs in namespace "p1"
+    And I start zebra-rs in namespace "asbr1"
+    And I start zebra-rs in namespace "asbr2"
+    And I start zebra-rs in namespace "p2"
+    And I start zebra-rs in namespace "pe2"
+    And I start zebra-rs in namespace "ce2"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    And I apply config "p1.yaml" to namespace "p1"
+    And I apply config "asbr1.yaml" to namespace "asbr1"
+    And I apply config "asbr2.yaml" to namespace "asbr2"
+    And I apply config "p2.yaml" to namespace "p2"
+    And I apply config "pe2.yaml" to namespace "pe2"
+    And I apply config "ce2.yaml" to namespace "ce2"
+    And I wait 35 seconds for BGP to operate
+    # IS-IS SR adjacencies form the intra-AS transport.
+    Then isis neighbor in namespace "pe1" at level 2 on interface "p1" should be up
+    And isis neighbor in namespace "asbr1" at level 2 on interface "p1" should be up
+    And isis neighbor in namespace "pe2" at level 2 on interface "p2" should be up
+    And isis neighbor in namespace "asbr2" at level 2 on interface "p2" should be up
+    # Intra-AS VPNv4 iBGP PE↔ASBR in each AS.
+    And BGP session in "pe1" to "1.1.1.3" should be "Established"
+    And BGP session in "asbr1" to "1.1.1.1" should be "Established"
+    And BGP session in "pe2" to "2.2.2.3" should be "Established"
+    And BGP session in "asbr2" to "2.2.2.1" should be "Established"
+
+  Scenario: SR-MPLS transport LSPs are installed on the core P routers
+    Given the test topology exists
+    Then mpls ilm in namespace "p1" should contain label 16001
+    And mpls ilm in namespace "p1" should contain label 16003
+    And mpls ilm in namespace "p2" should contain label 16004
+    And mpls ilm in namespace "p2" should contain label 16006
+
+  Scenario: The customer prefixes cross the AS boundary via the per-VRF PE-CE eBGP
+    Given the test topology exists
+    # ASBR1's vrf-cust holds PE1's prefix (from intra-AS VPNv4) AND CE2's
+    # prefix (learned from ASBR2 over the inter-AS PE-CE eBGP, AS-path 65001).
+    Then show command "show ip route vrf vrf-cust" in namespace "asbr1" should contain "10.1.0.0/30"
+    And show command "show ip route vrf vrf-cust" in namespace "asbr1" should contain "10.2.0.0/30"
+    And show command "show ip route vrf vrf-cust" in namespace "asbr2" should contain "10.1.0.0/30"
+    And show command "show ip route vrf vrf-cust" in namespace "asbr2" should contain "10.2.0.0/30"
+
+  Scenario: Each PE imports the remote-AS customer prefix into its VRF
+    Given the test topology exists
+    Then show command "show ip route vrf vrf-cust" in namespace "pe1" should contain "10.2.0.0/30"
+    And show command "show ip route vrf vrf-cust" in namespace "pe2" should contain "10.1.0.0/30"
+
+  Scenario: End-to-end customer forwarding across the AS boundary (VPN + back-to-back VRF)
+    Given the test topology exists
+    Then ping from "ce1" to "10.2.0.2" should succeed
+    And ping from "ce2" to "10.1.0.2" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I stop zebra-rs in namespace "p1"
+    And I stop zebra-rs in namespace "asbr1"
+    And I stop zebra-rs in namespace "asbr2"
+    And I stop zebra-rs in namespace "p2"
+    And I stop zebra-rs in namespace "pe2"
+    And I stop zebra-rs in namespace "ce2"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    And I delete namespace "p1"
+    And I delete namespace "asbr1"
+    And I delete namespace "asbr2"
+    And I delete namespace "p2"
+    And I delete namespace "pe2"
+    And I delete namespace "ce2"
+    Then the test environment should be clean

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -30,6 +30,7 @@
   - [EVPN Type-5 (IP Prefix Routes)](ch-02-06-bgp-evpn-type5.md)
   - [Route Target Constraint (RTC)](ch-02-07-bgp-rtc.md)
   - [Inter-AS L3VPN](ch-02-18-bgp-interas.md)
+    - [Option A (back-to-back VRFs)](ch-02-20-bgp-interas-option-a.md)
     - [Option C over SR-MPLS](ch-02-19-bgp-interas-option-c.md)
   - [BFD](ch-02-08-bgp-bfd.md)
   - [Route Reflector](ch-02-09-bgp-route-reflector.md)

--- a/book/src/ch-02-18-bgp-interas.md
+++ b/book/src/ch-02-18-bgp-interas.md
@@ -26,6 +26,7 @@ make the remote PE loopbacks reachable — and labeled — so a single LSP
 runs end to end and the VPN routes pass over the top, transparent to the
 ASBRs. It scales best and is the focus of this section.
 
-> **Implemented today:** Option C, with an SR-MPLS transport inside each
-> AS — see [Option C over SR-MPLS](ch-02-19-bgp-interas-option-c.md).
-> Options A and B are future work.
+> **Implemented today:** Option A
+> ([back-to-back VRFs](ch-02-20-bgp-interas-option-a.md)) and Option C
+> ([over SR-MPLS](ch-02-19-bgp-interas-option-c.md)), each with an
+> SR-MPLS transport inside the AS. Option B is future work.

--- a/book/src/ch-02-20-bgp-interas-option-a.md
+++ b/book/src/ch-02-20-bgp-interas-option-a.md
@@ -1,0 +1,189 @@
+# Inter-AS Option A (back-to-back VRFs)
+
+Option A (RFC 4364 §10a) is the simplest of the three inter-AS schemes
+and the only one with no MPLS on the inter-AS link. Each ASBR is itself
+a PE: for every VPN that must cross the boundary it holds a VRF, and the
+two ASBRs are joined by a per-VPN interface placed in that VRF. Over
+that interface they run an ordinary **PE-CE session inside the VRF** —
+each ASBR treats the other as a CE. The VPN label terminates at each
+ASBR: a packet is decapsulated to plain IP, looked up in the VRF, and
+handed to the other ASBR over the VRF interface, where the far AS
+re-imposes its own VPN label.
+
+So Option A is just two ordinary intra-AS L3VPNs stitched together by a
+plain-IP PE-CE hop. Nothing inter-AS-specific runs on the wire between
+the ASBRs.
+
+## Reference topology
+
+This is the topology exercised by the `@bgp_interas_option_a` BDD
+feature (`bdd/tests/features/bgp_interas_option_a.feature`):
+
+```
+          AS 65000                                  AS 65001
+ ce1 ── pe1 ──── p1 ──── asbr1 ─────── asbr2 ──── p2 ──── pe2 ── ce2
+        lo        lo       lo  172.16.0.0/30  lo     lo      lo
+     1.1.1.1   1.1.1.2  1.1.1.3  (in vrf-cust) 2.2.2.3 2.2.2.2 2.2.2.1
+  └ vrf-cust ┘          └ vrf-cust ┘      └ vrf-cust ┘    └ vrf-cust ┘
+   10.1.0.0/30                                            10.2.0.0/30
+```
+
+`pe1` and `asbr1` are both PEs of AS 65000 and exchange VPNv4 over the
+IS-IS / SR-MPLS core (via `p1`); likewise `asbr2`/`pe2` in AS 65001. The
+`asbr1`–`asbr2` link sits in `vrf-cust` on both sides (and is **not** in
+the IGP) and carries the inter-AS PE-CE eBGP session.
+
+## The two halves
+
+**Intra-AS L3VPN.** Identical to a single-AS deployment (see
+[L3VPN](ch-02-04-bgp-l3vpn.md)). `pe1` originates the CE1 prefix into
+`vrf-cust` and advertises it as VPNv4 to `asbr1`; the next-hop is `pe1`'s
+loopback, resolved by IS-IS over the SR-MPLS core (no BGP-LU is involved
+— both PEs are in the same AS). `asbr1` imports it into `vrf-cust`.
+
+**Inter-AS PE-CE eBGP inside the VRF.** `asbr1` and `asbr2` peer over the
+`172.16.0.0/30` link, which lives in `vrf-cust`. The session is a plain
+IPv4-unicast eBGP session, sourced and bound inside the VRF
+(`SO_BINDTODEVICE` to the VRF master, so its TCP rides the VRF table).
+Each ASBR:
+
+* **re-advertises** the routes it imported from its AS's VPNv4 over the
+  PE-CE session (with next-hop-self — the connected VRF-interface
+  address — and its AS prepended); and
+* **re-exports** the routes it learns over the PE-CE session back into
+  VPNv4 toward its own PEs.
+
+The route-targets live on the top-level `vrf` block exactly as for
+intra-AS L3VPN; a single shared RT (`65000:100` in the BDD) ties the four
+`vrf-cust` instances together.
+
+## Configuration
+
+A PE (`pe1`) is an ordinary intra-AS L3VPN PE:
+
+```yaml
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import: [65000:100]
+      export: [65000:100]
+interface:
+- if-name: ce1
+  vrf: vrf-cust
+  ipv4: { address: 10.1.0.1/30 }
+router:
+  bgp:
+    global: { as: 65000, identifier: 1.1.1.1 }
+    neighbor:
+    - remote-address: 1.1.1.3        # ASBR1, intra-AS VPNv4
+      remote-as: 65000
+      update-source: 1.1.1.1
+      enabled: true
+      afi-safi:
+      - { name: vpnv4, enabled: true }
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      afi-safi:
+        ipv4:
+          network: [ { prefix: 10.1.0.0/30 } ]
+```
+
+An ASBR (`asbr1`) adds the inter-AS link to the VRF and runs the PE-CE
+eBGP **inside the VRF block**:
+
+```yaml
+interface:
+- if-name: asbr2
+  vrf: vrf-cust
+  ipv4: { address: 172.16.0.1/30 }   # inter-AS link, in the VRF
+router:
+  bgp:
+    global: { as: 65000, identifier: 1.1.1.3 }
+    neighbor:
+    - remote-address: 1.1.1.1         # PE1, intra-AS VPNv4
+      remote-as: 65000
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - { name: vpnv4, enabled: true }
+    vrf:
+    - name: vrf-cust
+      rd: 65000:2
+      neighbor:
+      - remote-address: 172.16.0.2    # ASBR2, PE-CE eBGP inside the VRF
+        remote-as: 65001              # the other AS
+        enabled: true
+```
+
+A per-VRF neighbor needs no `afi-safi` block — it defaults to IPv4
+unicast, which is what a PE-CE session carries. The per-VRF BGP router-id
+defaults to the global identifier.
+
+## What makes the per-VRF session work
+
+A BGP session inside a VRF needs two kernel/runtime pieces that the
+single-AS L3VPN never exercised:
+
+* **`net.ipv4.tcp_l3mdev_accept = 1`** — zebra-rs runs one global,
+  unbound `:179` listener and routes each accepted connection to the
+  owning VRF task by source IP. Without this sysctl the kernel drops a
+  SYN that arrives on a VRF (l3mdev) interface (there is no listener in
+  the VRF table), and the session stays stuck in `Active`. zebra-rs now
+  sets it at startup alongside `net.vrf.strict_mode`.
+* **Per-VRF passive accept** — the per-VRF task drives both the active
+  connect and, now, the passive accept, so two per-VRF speakers (the two
+  ASBRs) resolve an RFC 4271 §6.8 collision into `Established`.
+
+## Forwarding
+
+The VPN label terminates at each ASBR; the inter-AS link carries plain
+IP inside the VRF. A packet from `ce1` to a host in `ce2`'s subnet:
+
+| Hop | Action |
+|---|---|
+| `pe1` | VRF lookup → push `[SR→asbr1, VPN]`, send over the core |
+| `p1` | SR penultimate-hop pop |
+| `asbr1` | pop the VPN label → VRF lookup → forward **plain IP** to `asbr2` over the inter-AS VRF link |
+| `asbr2` | receive plain IP in `vrf-cust` → VRF lookup → push `[SR→pe2, VPN]` |
+| `p2` | SR penultimate-hop pop |
+| `pe2` | pop the VPN label → VRF lookup → to `ce2` |
+
+## Verification
+
+The inter-AS PE-CE session is a VRF session, shown under
+`show ip bgp vrf vrf-cust summary`:
+
+```
+asbr1$ show ip bgp vrf vrf-cust summary
+Neighbor    V    AS  MsgRcvd MsgSent ... State/PfxRcd
+172.16.0.2  4 65001        3       3 ... Established 1
+```
+
+The customer prefixes appear in each `vrf-cust` table — the local-AS one
+labeled (imported from intra-AS VPNv4), the remote-AS one plain (learned
+over the PE-CE eBGP):
+
+```
+asbr1$ show ip route vrf vrf-cust
+B *> 10.1.0.0/30 [200/0] via 10.0.0.5, p1, label 16001 16   # from PE1 (VPNv4)
+B *> 10.2.0.0/30 [20/0]  via 172.16.0.2, asbr2              # from ASBR2 (PE-CE)
+C *> 172.16.0.0/30 is directly connected, asbr2
+```
+
+The remote-AS prefix reaches the far PE's VRF too, and CE-to-CE traffic
+forwards:
+
+```
+pe1$  show ip route vrf vrf-cust   # contains 10.2.0.0/30
+ce1$  ping <host in ce2's subnet>  # succeeds
+```
+
+## BDD coverage
+
+`bdd/tests/features/bgp_interas_option_a.feature` builds the eight-
+namespace topology above and asserts the IS-IS SR adjacencies, the
+SR-MPLS ILM entries, the intra-AS VPNv4 sessions, the customer prefixes
+crossing the boundary over the per-VRF PE-CE eBGP, the far-PE VRF import,
+and an end-to-end CE-to-CE ping.

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -2147,22 +2147,22 @@ fn start_collision_conn(peer: &mut Peer, stream: TcpStream) {
 /// address map, so an inbound connection from it would otherwise be
 /// dropped, and the session (both ends connect actively *and* accept
 /// passively) could never resolve a collision into Established.
-fn handle_peer_connection(
-    bgp: &mut Bgp,
+pub(super) fn handle_peer_connection(
+    peers: &mut PeerMap,
     peer_addr: IpAddr,
     scope_id: Option<u32>,
     stream: TcpStream,
 ) -> Option<TcpStream> {
-    let key = if bgp.peers.get(&peer_addr).is_some() {
+    let key = if peers.get(&peer_addr).is_some() {
         PeerKey::Addr(peer_addr)
     } else if let Some(ifindex) = scope_id
-        && bgp.peers.get_by_key(&PeerKey::Interface(ifindex)).is_some()
+        && peers.get_by_key(&PeerKey::Interface(ifindex)).is_some()
     {
         PeerKey::Interface(ifindex)
     } else {
         return Some(stream);
     };
-    if let Some(peer) = bgp.peers.get_mut_by_key(&key) {
+    if let Some(peer) = peers.get_mut_by_key(&key) {
         // Pin the egress TTL on the freshly accepted socket *before* we
         // decide its fate. For a `ttl-security` (GTSM) peer this is what
         // lets a rejected or dropped inbound connection be torn down
@@ -2243,7 +2243,7 @@ pub fn accept(bgp: &mut Bgp, stream: TcpStream, sockaddr: SocketAddr) {
         SocketAddr::V6(addr) if addr.scope_id() != 0 => Some(addr.scope_id()),
         _ => None,
     };
-    let mut remaining_stream = handle_peer_connection(bgp, peer_addr, scope_id, stream);
+    let mut remaining_stream = handle_peer_connection(&mut bgp.peers, peer_addr, scope_id, stream);
 
     // Static lookup missed — try a configured listen-range. If LPM
     // hits and the per-range neighbor-group resolves to a usable
@@ -2302,7 +2302,7 @@ fn try_dynamic_accept(bgp: &mut Bgp, peer_addr: IpAddr, stream: TcpStream) -> Op
 
     // Dynamic (listen-range) peers are always address-keyed, so no
     // interface scope is needed here.
-    handle_peer_connection(bgp, peer_addr, None, stream)
+    handle_peer_connection(&mut bgp.peers, peer_addr, None, stream)
 }
 
 /// Replay Adj-RIB-In through the current inbound policy for `peer_idx`,

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -519,7 +519,15 @@ impl BgpVrf {
             remote_id: 0,
             local_id: 0,
             attr: interned,
-            ident: 0,
+            // Originated/imported VRF rows carry the ORIGINATED_PEER
+            // sentinel, NOT 0: a literal 0 collides with the PeerMap index
+            // of whatever CE peer occupies slot 0 (a lone PE-CE peer is
+            // index 0), and the advertise-path split-horizon
+            // (`rib.ident == peer.ident`) would then silently drop this
+            // imported route toward that CE — breaking Inter-AS Option A,
+            // where the ASBR must re-advertise VPNv4-imported routes over
+            // its per-VRF PE-CE eBGP session to the other ASBR.
+            ident: super::super::route::ORIGINATED_PEER,
             router_id: self.router_id,
             weight: 0,
             typ: super::super::route::BgpRibType::Originated,
@@ -605,7 +613,9 @@ impl BgpVrf {
         rd: bgp_packet::RouteDistinguisher,
         prefix: ipnet::Ipv4Net,
     ) {
-        let removed = self.local_rib.remove(None, prefix, 0, 0);
+        let removed = self
+            .local_rib
+            .remove(None, prefix, 0, super::super::route::ORIGINATED_PEER);
         let selected = self.local_rib.select_best_path(prefix);
         let removed_n = removed.len();
         let winners = selected.len();
@@ -690,7 +700,15 @@ impl BgpVrf {
             remote_id: 0,
             local_id: 0,
             attr: interned,
-            ident: 0,
+            // Originated/imported VRF rows carry the ORIGINATED_PEER
+            // sentinel, NOT 0: a literal 0 collides with the PeerMap index
+            // of whatever CE peer occupies slot 0 (a lone PE-CE peer is
+            // index 0), and the advertise-path split-horizon
+            // (`rib.ident == peer.ident`) would then silently drop this
+            // imported route toward that CE — breaking Inter-AS Option A,
+            // where the ASBR must re-advertise VPNv4-imported routes over
+            // its per-VRF PE-CE eBGP session to the other ASBR.
+            ident: super::super::route::ORIGINATED_PEER,
             router_id: self.router_id,
             weight: 0,
             typ: super::super::route::BgpRibType::Originated,
@@ -759,7 +777,9 @@ impl BgpVrf {
         rd: bgp_packet::RouteDistinguisher,
         prefix: ipnet::Ipv6Net,
     ) {
-        let removed = self.local_rib.remove_v6(prefix, 0, 0);
+        let removed = self
+            .local_rib
+            .remove_v6(prefix, 0, super::super::route::ORIGINATED_PEER);
         let selected = self.local_rib.select_best_path_v6(prefix);
         let removed_n = removed.len();
         let winners = selected.len();
@@ -808,17 +828,36 @@ impl BgpVrf {
     /// `Shutdown`.
     fn process_global_msg(&mut self, msg: BgpVrfMsg) {
         match msg {
-            BgpVrfMsg::Accept(_, sockaddr) => {
-                // The global accept dispatcher routes inbound
-                // connections here; the per-VRF FSM driver picks
-                // up the `TcpStream` and continues. Without that
-                // wiring the stream drops at the end of this arm
-                // and the TCP connection closes.
+            BgpVrfMsg::Accept(stream, sockaddr) => {
+                // Passive accept for the per-VRF PE-CE session. The global
+                // accept dispatcher routed this inbound connection here by
+                // source IP; drive the same FSM path the global `accept`
+                // does, but against this VRF's own `peers`. The active
+                // connect path already runs the per-VRF FSM, so adding the
+                // passive side lets two per-VRF speakers (e.g. two Inter-AS
+                // MPLS/VPN Option A ASBRs peering inside a VRF) resolve a
+                // §6.8 collision into Established — without it neither side's
+                // outbound connect is ever accepted and the session is stuck.
                 tracing::debug!(
                     vrf = %self.name,
                     peer = %sockaddr.ip(),
-                    "bgp vrf: received inbound Accept",
+                    "bgp vrf: inbound Accept",
                 );
+                let peer_addr = sockaddr.ip();
+                let scope_id = match sockaddr {
+                    std::net::SocketAddr::V6(addr) if addr.scope_id() != 0 => Some(addr.scope_id()),
+                    _ => None,
+                };
+                if let Some(stream) = super::super::peer::handle_peer_connection(
+                    &mut self.peers,
+                    peer_addr,
+                    scope_id,
+                    stream,
+                ) {
+                    // No matching peer in this VRF (listen-ranges aren't
+                    // supported inside a VRF yet) — drop, closing the TCP.
+                    drop(stream);
+                }
             }
             BgpVrfMsg::ImportV4 {
                 rd,

--- a/zebra-rs/src/bgp/vrf/msg.rs
+++ b/zebra-rs/src/bgp/vrf/msg.rs
@@ -25,13 +25,11 @@ use crate::rib::nht::ResolvedNexthop;
 #[derive(Debug)]
 pub enum BgpVrfMsg {
     /// Inbound TCP connection accepted on `:179` whose source IP
-    /// matches a peer configured in this VRF. The stream is handed
-    /// off to the per-VRF runtime; until the per-VRF FSM driver
-    /// picks it up, `BgpVrf::event_loop` drops the stream silently
-    /// — the dispatch is still wired so the global instance's
-    /// accept path no longer claims connections that should belong
-    /// to a VRF.
-    Accept(#[allow(dead_code)] TcpStream, SocketAddr),
+    /// matches a peer configured in this VRF. The global accept
+    /// dispatcher hands the stream off here; `process_global_msg`
+    /// drives it through the per-VRF passive-accept FSM path
+    /// (`peer::handle_peer_connection` against the VRF's own peers).
+    Accept(TcpStream, SocketAddr),
 
     /// VPNv4 best-path import. The global Loc-RIB resolved a route
     /// whose RT list intersects this VRF's `import_rts_v4`; the

--- a/zebra-rs/src/fib/netlink/sysctl.rs
+++ b/zebra-rs/src/fib/netlink/sysctl.rs
@@ -8,6 +8,14 @@ const CTLNAMES: &[(&str, &str)] = &[
     ("net.ipv6.conf.all.keep_addr_on_down", "1"),
     ("net.ipv6.conf.default.keep_addr_on_down", "1"),
     ("net.vrf.strict_mode", "1"),
+    // Let the global unbound `:179` BGP listener accept inbound TCP
+    // connections that arrive on a VRF (l3mdev) interface. Without it the
+    // kernel drops the SYN — there is no listener in the VRF's routing
+    // table — and a per-VRF BGP peer (e.g. a PE-CE session inside a VRF,
+    // as in Inter-AS MPLS/VPN Option A) can never accept and stays stuck
+    // in Active. The accept dispatcher then routes the connection to the
+    // owning VRF task by source IP. Mirrors FRR's `bgp_vrf` enablement.
+    ("net.ipv4.tcp_l3mdev_accept", "1"),
     ("net.mpls.platform_labels", "1048575"),
 ];
 


### PR DESCRIPTION
## Summary

Implements **Inter-AS MPLS/VPN Option A** (RFC 4364 §10a — back-to-back
VRFs), with an SR-MPLS transport inside each AS. The ASBRs are back-to-back
PEs joined by a per-VPN VRF interface over which they run a **PE-CE eBGP
session inside the VRF**. The VPN label terminates at each ASBR (plain IP
on the inter-AS link); each AS is an ordinary intra-AS L3VPN (PE↔ASBR
VPNv4 over the SR-MPLS core, loopback next-hop resolved by the IGP).

The per-VRF BGP PE-CE path had never been exercised end to end; three
enablers were missing:

| Area | Fix |
|---|---|
| `fib/netlink/sysctl.rs` | Set `net.ipv4.tcp_l3mdev_accept=1` at startup so the global unbound `:179` listener accepts connections arriving on a VRF (l3mdev) interface — otherwise the SYN is dropped and a per-VRF peer stays in `Active`. |
| `bgp/peer.rs`, `bgp/vrf/inst.rs`, `bgp/vrf/msg.rs` | Drive **passive accept** in the per-VRF task: `handle_peer_connection` now takes `&mut PeerMap` and is called from the VRF task's `Accept` handler, so two per-VRF speakers resolve an RFC 4271 §6.8 collision into `Established` (active connect already worked). |
| `bgp/vrf/inst.rs` | Tag VRF-imported routes with `ORIGINATED_PEER`, not `0` — a literal `0` collides with the lone CE peer's PeerMap index 0, so split-horizon suppressed re-advertising imported VPNv4 routes over the PE-CE eBGP (same class of bug fixed for the VPNv4 export in #1295). |

Adds the `@bgp_interas_option_a` BDD feature and a book section. The
`tcp_l3mdev_accept` + passive-accept fixes make BGP-inside-a-VRF (PE-CE)
work generally, not just for Option A.

## Test plan

- `make -C bdd bgp_interas_option_a` — **6/6 scenarios, 75/75 steps**,
  including the end-to-end CE1→CE2 ping (VPN-labeled PE→ASBR, plain IP
  over the inter-AS VRF link, re-labeled ASBR→PE).
- `cargo test -p zebra-rs --bins` — **964 passed, 0 failed** (the
  `handle_peer_connection` refactor touches every accept path; no
  regressions).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `mdbook build` (book/) — clean, no broken links.

Generated with [Claude Code](https://claude.com/claude-code)
