### PR TITLE
bgp: Inter-AS MPLS/VPN Option B (VPNv4 between ASBRs)

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -174,6 +174,10 @@ bgp_interas_option_a:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_interas_option_a"
 
+bgp_interas_option_b:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_interas_option_b"
+
 generate:
 	rm -rf allure-report
 	allure generate
@@ -193,4 +197,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv3_nssa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise bgp_neighbor_group bgp_unnumbered_neighbor bgp_interas_option_c bgp_interas_option_a generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv3_nssa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise bgp_neighbor_group bgp_unnumbered_neighbor bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b generate open docs FORCE

--- a/bdd/tests/configs/bgp_interas_option_b/asbr1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_b/asbr1.yaml
@@ -1,0 +1,67 @@
+# ASBR1 (AS 65000 border — Inter-AS MPLS/VPN Option B).
+#  - VPNv4 iBGP to PE1 (1.1.1.1) over the IS-IS/SR core, with
+#    `next-hop-self`: a VPNv4 route re-advertised from AS 65001 must reach
+#    PE1 carrying ASBR1's IGP-reachable loopback (and ASBR1's swap label),
+#    not the unreachable inter-AS link address ASBR2 set as next-hop.
+#  - eBGP VPNv4 to ASBR2 (172.16.0.2, remote-as 65001) directly over the
+#    inter-AS link. ASBR1 holds NO VRF: received VPNv4 routes live in the
+#    global v4vpn RIB and are re-advertised with a freshly allocated local
+#    label + a swap ILM (our label -> received label, toward the original
+#    next-hop), so the VPN crosses the AS boundary by a label switch.
+#  - The inter-AS link (172.16.0.0/30) is in the GLOBAL table, NOT the IGP.
+#    MPLS input is auto-enabled on every link, so it forwards labelled
+#    VPNv4 packets between the ASBRs.
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.3/32
+- if-name: p1
+  ipv4:
+    address: 10.0.0.6/30
+- if-name: asbr2
+  ipv4:
+    address: 172.16.0.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: asbr1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 3
+    - if-name: p1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      identifier: 1.1.1.3
+    # Lower the MRAI so the transit VPNv4 route crosses the eBGP boundary
+    # (default 30s) and is re-advertised to PE1 promptly — the four-hop
+    # PE2->ASBR2->ASBR1->PE1 chain otherwise converges past the test wait.
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 1.1.1.1
+      remote-as: 65000
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+        next-hop-self: true
+    - remote-address: 172.16.0.2
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true

--- a/bdd/tests/configs/bgp_interas_option_b/asbr2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_b/asbr2.yaml
@@ -1,0 +1,60 @@
+# ASBR2 (AS 65001 border — Inter-AS Option B). Mirror of ASBR1.
+#  - VPNv4 iBGP to PE2 (2.2.2.1) over the IS-IS/SR core, with
+#    `next-hop-self` (same reason as ASBR1).
+#  - eBGP VPNv4 to ASBR1 (172.16.0.1, remote-as 65000) over the inter-AS
+#    link. No VRF: received VPNv4 routes are re-advertised with a fresh
+#    local label + swap ILM.
+#  - The inter-AS link (172.16.0.0/30) is in the GLOBAL table, NOT the IGP.
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.3/32
+- if-name: asbr1
+  ipv4:
+    address: 172.16.0.2/30
+- if-name: p2
+  ipv4:
+    address: 10.0.1.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0006.00
+    hostname: asbr2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 6
+    - if-name: p2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65001
+      identifier: 2.2.2.3
+    # Lower the MRAI so the transit VPNv4 route crosses the eBGP boundary
+    # (default 30s) and is re-advertised to PE2 promptly (see ASBR1).
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 2.2.2.1
+      remote-as: 65001
+      update-source: 2.2.2.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+        next-hop-self: true
+    - remote-address: 172.16.0.1
+      remote-as: 65000
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true

--- a/bdd/tests/configs/bgp_interas_option_b/ce1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_b/ce1.yaml
@@ -1,0 +1,14 @@
+# CE1 (AS 65000 customer site). A plain host: one link to PE1 and a
+# default route pointing at PE1's VRF interface. No IGP/BGP — the CE is
+# the traffic source/sink for the end-to-end L3VPN ping (CE1 -> CE2).
+interface:
+- if-name: pe1
+  ipv4:
+    address: 10.1.0.2/30
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 0.0.0.0/0
+        nexthop:
+        - address: 10.1.0.1

--- a/bdd/tests/configs/bgp_interas_option_b/ce2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_b/ce2.yaml
@@ -1,0 +1,12 @@
+# CE2 (AS 65001 customer site). Plain host, default route to PE2.
+interface:
+- if-name: pe2
+  ipv4:
+    address: 10.2.0.2/30
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 0.0.0.0/0
+        nexthop:
+        - address: 10.2.0.1

--- a/bdd/tests/configs/bgp_interas_option_b/p1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_b/p1.yaml
@@ -1,0 +1,37 @@
+# P1 (AS 65000 core / transit LSR). Pure IS-IS + SR-MPLS, no BGP. Sits
+# between PE1 and ASBR1 so the intra-AS transport LSP performs a real SR
+# label swap (and PHP toward the loopbacks) rather than collapsing to a
+# single hop.
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.2/32
+- if-name: pe1
+  ipv4:
+    address: 10.0.0.2/30
+- if-name: asbr1
+  ipv4:
+    address: 10.0.0.5/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: p1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 2
+    - if-name: pe1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: asbr1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/bgp_interas_option_b/p2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_b/p2.yaml
@@ -1,0 +1,34 @@
+# P2 (AS 65001 core / transit LSR). Pure IS-IS + SR-MPLS, no BGP.
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.2/32
+- if-name: asbr2
+  ipv4:
+    address: 10.0.1.2/30
+- if-name: pe2
+  ipv4:
+    address: 10.0.1.5/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0005.00
+    hostname: p2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 5
+    - if-name: asbr2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: pe2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/bgp_interas_option_b/pe1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_b/pe1.yaml
@@ -1,0 +1,63 @@
+# PE1 (AS 65000 provider edge). Inter-AS Option B (VPNv4 between ASBRs).
+# A normal intra-AS L3VPN PE: VPNv4 iBGP to ASBR1 over the IS-IS/SR-MPLS
+# core (loopback next-hop resolved by the IGP — no BGP-LU). vrf-cust
+# holds the CE1 link and originates the customer prefix. PE1 is unaware
+# of the AS boundary: ASBR1 re-advertises PE1's routes into AS 65001 and
+# advertises AS 65001's routes back with next-hop-self (so PE1 always
+# sees an IGP-reachable next-hop).
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: p1
+  ipv4:
+    address: 10.0.0.1/30
+- if-name: ce1
+  vrf: vrf-cust
+  ipv4:
+    address: 10.1.0.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 1
+    - if-name: p1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      identifier: 1.1.1.1
+    neighbor:
+    - remote-address: 1.1.1.3
+      remote-as: 65000
+      update-source: 1.1.1.1
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      afi-safi:
+        ipv4:
+          network:
+          - prefix: 10.1.0.0/30

--- a/bdd/tests/configs/bgp_interas_option_b/pe2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_b/pe2.yaml
@@ -1,0 +1,58 @@
+# PE2 (AS 65001 provider edge). Inter-AS Option B, mirror of PE1: VPNv4
+# iBGP to ASBR2 over the IS-IS/SR core; vrf-cust holds the CE2 link.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.1/32
+- if-name: p2
+  ipv4:
+    address: 10.0.1.6/30
+- if-name: ce2
+  vrf: vrf-cust
+  ipv4:
+    address: 10.2.0.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0004.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 4
+    - if-name: p2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65001
+      identifier: 2.2.2.1
+    neighbor:
+    - remote-address: 2.2.2.3
+      remote-as: 65001
+      update-source: 2.2.2.1
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65001:1
+      afi-safi:
+        ipv4:
+          network:
+          - prefix: 10.2.0.0/30

--- a/bdd/tests/features/bgp_interas_option_b.feature
+++ b/bdd/tests/features/bgp_interas_option_b.feature
@@ -1,0 +1,125 @@
+@serial
+@bgp_interas_option_b
+Feature: Inter-AS MPLS/VPN Option B over SR-MPLS (RFC 4364 §10b)
+  As a service provider running L3VPN across two autonomous systems
+  I want Inter-AS Option B: the ASBRs exchange VPNv4 routes directly over
+  a single-hop MP-eBGP session and re-advertise them with next-hop-self,
+  allocating a fresh local label and a swap ILM for each, so the VPN
+  crosses the AS boundary as a label switch — the ASBRs hold every VPN
+  route but no VRF, and the inter-AS link carries labelled VPNv4 packets.
+
+  Test Topology (8 namespaces):
+  ```
+            AS 65000                                AS 65001
+   ce1 ── pe1 ──── p1 ──── asbr1 ════════ asbr2 ──── p2 ──── pe2 ── ce2
+          lo        lo       lo  172.16.0.0/30 lo      lo      lo
+       1.1.1.1   1.1.1.2  1.1.1.3  (global)   2.2.2.3 2.2.2.2 2.2.2.1
+   └ vrf-cust ┘                                            └ vrf-cust ┘
+    10.1.0.0/30                                            10.2.0.0/30
+  ```
+  - Intra-AS: IS-IS L2 + segment-routing mpls; VPNv4 iBGP PE↔ASBR over
+    the SR-MPLS core (the PE loopback next-hop is resolved by the IGP —
+    no BGP-LU).
+  - Inter-AS (asbr1↔asbr2, 172.16.0.0/30): a single-hop **MP-eBGP VPNv4**
+    session over a link in the GLOBAL table (NOT the IGP). The ASBRs run
+    NO VRF: a received VPNv4 route sits in the global v4vpn RIB and is
+    re-advertised with next-hop-self, a freshly allocated local label and
+    a swap ILM (our label → received label, toward the original next-hop).
+  - A CE→CE packet is VPN-labelled PE→ASBR over the SR core; the ASBR
+    swaps the VPN label and forwards a single labelled packet across the
+    inter-AS link; the far ASBR swaps again over its SR core to the egress
+    PE, which pops and delivers plain IP to the CE.
+
+  Scenario: Build the Inter-AS Option B topology and bring up every session
+    Given a clean test environment
+    When I create namespace "ce1"
+    And I create namespace "pe1"
+    And I create namespace "p1"
+    And I create namespace "asbr1"
+    And I create namespace "asbr2"
+    And I create namespace "p2"
+    And I create namespace "pe2"
+    And I create namespace "ce2"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I connect namespace "pe1" interface "p1" to namespace "p1" interface "pe1"
+    And I connect namespace "p1" interface "asbr1" to namespace "asbr1" interface "p1"
+    And I connect namespace "asbr1" interface "asbr2" to namespace "asbr2" interface "asbr1"
+    And I connect namespace "asbr2" interface "p2" to namespace "p2" interface "asbr2"
+    And I connect namespace "p2" interface "pe2" to namespace "pe2" interface "p2"
+    And I connect namespace "pe2" interface "ce2" to namespace "ce2" interface "pe2"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I start zebra-rs in namespace "p1"
+    And I start zebra-rs in namespace "asbr1"
+    And I start zebra-rs in namespace "asbr2"
+    And I start zebra-rs in namespace "p2"
+    And I start zebra-rs in namespace "pe2"
+    And I start zebra-rs in namespace "ce2"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    And I apply config "p1.yaml" to namespace "p1"
+    And I apply config "asbr1.yaml" to namespace "asbr1"
+    And I apply config "asbr2.yaml" to namespace "asbr2"
+    And I apply config "p2.yaml" to namespace "p2"
+    And I apply config "pe2.yaml" to namespace "pe2"
+    And I apply config "ce2.yaml" to namespace "ce2"
+    And I wait 35 seconds for BGP to operate
+    # IS-IS SR adjacencies form the intra-AS transport.
+    Then isis neighbor in namespace "pe1" at level 2 on interface "p1" should be up
+    And isis neighbor in namespace "asbr1" at level 2 on interface "p1" should be up
+    And isis neighbor in namespace "pe2" at level 2 on interface "p2" should be up
+    And isis neighbor in namespace "asbr2" at level 2 on interface "p2" should be up
+    # Intra-AS VPNv4 iBGP PE↔ASBR in each AS.
+    And BGP session in "pe1" to "1.1.1.3" should be "Established"
+    And BGP session in "asbr1" to "1.1.1.1" should be "Established"
+    And BGP session in "pe2" to "2.2.2.3" should be "Established"
+    And BGP session in "asbr2" to "2.2.2.1" should be "Established"
+    # Inter-AS single-hop MP-eBGP VPNv4 between the ASBRs.
+    And BGP session in "asbr1" to "172.16.0.2" should be "Established"
+    And BGP session in "asbr2" to "172.16.0.1" should be "Established"
+
+  Scenario: SR-MPLS transport LSPs are installed on the core P routers
+    Given the test topology exists
+    Then mpls ilm in namespace "p1" should contain label 16001
+    And mpls ilm in namespace "p1" should contain label 16003
+    And mpls ilm in namespace "p2" should contain label 16004
+    And mpls ilm in namespace "p2" should contain label 16006
+
+  Scenario: The ASBRs hold every VPN prefix in the global VPNv4 table (no VRF)
+    Given the test topology exists
+    # ASBR1 learns 10.1.0.0/30 from PE1 (intra-AS VPNv4) and 10.2.0.0/30
+    # from ASBR2 (inter-AS eBGP VPNv4); ASBR2 mirrors. Neither runs a VRF.
+    Then show command "show ip bgp vpnv4" in namespace "asbr1" should contain "10.1.0.0/30"
+    And show command "show ip bgp vpnv4" in namespace "asbr1" should contain "10.2.0.0/30"
+    And show command "show ip bgp vpnv4" in namespace "asbr2" should contain "10.1.0.0/30"
+    And show command "show ip bgp vpnv4" in namespace "asbr2" should contain "10.2.0.0/30"
+
+  Scenario: Each PE imports the remote-AS customer prefix into its VRF
+    Given the test topology exists
+    Then show command "show ip route vrf vrf-cust" in namespace "pe1" should contain "10.2.0.0/30"
+    And show command "show ip route vrf vrf-cust" in namespace "pe2" should contain "10.1.0.0/30"
+
+  Scenario: End-to-end customer forwarding across the AS boundary (VPNv4 label swap)
+    Given the test topology exists
+    Then ping from "ce1" to "10.2.0.2" should succeed
+    And ping from "ce2" to "10.1.0.2" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I stop zebra-rs in namespace "p1"
+    And I stop zebra-rs in namespace "asbr1"
+    And I stop zebra-rs in namespace "asbr2"
+    And I stop zebra-rs in namespace "p2"
+    And I stop zebra-rs in namespace "pe2"
+    And I stop zebra-rs in namespace "ce2"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    And I delete namespace "p1"
+    And I delete namespace "asbr1"
+    And I delete namespace "asbr2"
+    And I delete namespace "p2"
+    And I delete namespace "pe2"
+    And I delete namespace "ce2"
+    Then the test environment should be clean

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -31,6 +31,7 @@
   - [Route Target Constraint (RTC)](ch-02-07-bgp-rtc.md)
   - [Inter-AS L3VPN](ch-02-18-bgp-interas.md)
     - [Option A (back-to-back VRFs)](ch-02-20-bgp-interas-option-a.md)
+    - [Option B (VPNv4 between ASBRs)](ch-02-21-bgp-interas-option-b.md)
     - [Option C over SR-MPLS](ch-02-19-bgp-interas-option-c.md)
   - [BFD](ch-02-08-bgp-bfd.md)
   - [Route Reflector](ch-02-09-bgp-route-reflector.md)

--- a/book/src/ch-02-18-bgp-interas.md
+++ b/book/src/ch-02-18-bgp-interas.md
@@ -21,12 +21,14 @@ boundary:
 The options trade off ASBR scaling against operational coupling. Option
 A needs no MPLS on the inter-AS link but burns a (sub)interface and a
 VRF per VPN. Option B keeps the ASBRs in the VPN control plane (and the
-VPN data plane). **Option C** pushes both out: the ASBRs only need to
-make the remote PE loopbacks reachable — and labeled — so a single LSP
-runs end to end and the VPN routes pass over the top, transparent to the
-ASBRs. It scales best and is the focus of this section.
+VPN data plane) but needs no per-VPN VRF — the ASBRs hold every VPN route
+in their global VPNv4 table and label-swap it across the boundary.
+**Option C** pushes both out: the ASBRs only need to make the remote PE
+loopbacks reachable — and labeled — so a single LSP runs end to end and
+the VPN routes pass over the top, transparent to the ASBRs.
 
-> **Implemented today:** Option A
-> ([back-to-back VRFs](ch-02-20-bgp-interas-option-a.md)) and Option C
-> ([over SR-MPLS](ch-02-19-bgp-interas-option-c.md)), each with an
-> SR-MPLS transport inside the AS. Option B is future work.
+> **Implemented today:** all three —
+> [Option A](ch-02-20-bgp-interas-option-a.md) (back-to-back VRFs),
+> [Option B](ch-02-21-bgp-interas-option-b.md) (VPNv4 between ASBRs), and
+> [Option C](ch-02-19-bgp-interas-option-c.md) (BGP-LU between ASBRs) —
+> each with an SR-MPLS transport inside the AS.

--- a/book/src/ch-02-21-bgp-interas-option-b.md
+++ b/book/src/ch-02-21-bgp-interas-option-b.md
@@ -1,0 +1,233 @@
+# Inter-AS Option B (VPNv4 between ASBRs)
+
+Option B (RFC 4364 §10b) carries the VPN across the boundary in the
+control plane: the two ASBRs run an **MP-eBGP VPNv4/VPNv6 session
+directly with each other** and exchange the VPN routes themselves. Unlike
+Option A, an Option B ASBR holds **no VRF** — every VPN route sits in its
+global VPNv4 table and is re-advertised onward. Unlike Option C, the
+ASBRs *do* hold (and re-advertise) every VPN prefix, so they stay in the
+VPN control plane but not in any single VPN's VRF.
+
+The data plane is pure MPLS. When an ASBR re-advertises a received VPNv4
+route it sets **next-hop-self** and allocates a **fresh local VPN label**,
+installing a label-swap entry (`our label → the received label`) toward
+the route's original next-hop. A customer packet therefore crosses the
+inter-AS link as a single labelled MPLS packet, is label-swapped at each
+ASBR, and is re-labelled onto the far AS's SR-MPLS core — the VPN label
+is rewritten hop-by-hop but never stripped to plain IP.
+
+## Reference topology
+
+This is the topology exercised by the `@bgp_interas_option_b` BDD
+feature (`bdd/tests/features/bgp_interas_option_b.feature`):
+
+```
+          AS 65000                                  AS 65001
+ ce1 ── pe1 ──── p1 ──── asbr1 ═══════ asbr2 ──── p2 ──── pe2 ── ce2
+        lo        lo       lo  172.16.0.0/30  lo     lo      lo
+     1.1.1.1   1.1.1.2  1.1.1.3   (global)   2.2.2.3 2.2.2.2 2.2.2.1
+  └ vrf-cust ┘          (no VRF)            (no VRF)        └ vrf-cust ┘
+   10.1.0.0/30                                            10.2.0.0/30
+```
+
+`pe1` exchanges VPNv4 with `asbr1` over the IS-IS / SR-MPLS core (via
+`p1`); likewise `pe2`/`asbr2` in AS 65001. The `asbr1`–`asbr2` link sits
+in the **global** table (it is **not** in the IGP) and carries a
+single-hop MP-eBGP VPNv4 session. The `═══` marks that the inter-AS link
+forwards labelled MPLS, not plain IP.
+
+## The two halves
+
+**Intra-AS L3VPN.** Identical to a single-AS deployment (see
+[L3VPN](ch-02-04-bgp-l3vpn.md)). `pe1` originates the CE1 prefix into
+`vrf-cust` and advertises it as VPNv4 to `asbr1`; the next-hop is `pe1`'s
+loopback, resolved by IS-IS over the SR-MPLS core. The PE is completely
+unaware of the AS boundary.
+
+**Inter-AS MP-eBGP VPNv4.** `asbr1` and `asbr2` peer over the
+`172.16.0.0/30` link with a `vpnv4`-enabled eBGP session. The ASBR has no
+VRF, so a received VPNv4 route is held in the global VPNv4 Loc-RIB and
+re-advertised:
+
+* over the eBGP session to the other ASBR (eBGP rewrites the next-hop to
+  self automatically); and
+* over the iBGP session to its own PE, where **`next-hop-self` must be
+  set** — by default an iBGP speaker keeps the eBGP route's received
+  next-hop (the far ASBR's inter-AS address), which the PE cannot
+  resolve. Next-hop-self replaces it with the ASBR's IGP-reachable
+  loopback.
+
+In both cases the ASBR allocates a new local VPN label and swaps it to
+the received label (see *Transit label swap* below). The route-targets
+are carried transparently end to end; the PEs filter on import exactly as
+in a single-AS L3VPN (a shared `65000:100` in the BDD).
+
+## Configuration
+
+A PE (`pe1`) is an ordinary intra-AS L3VPN PE — byte-for-byte the same as
+the Option A PE; it never knows the boundary exists:
+
+```yaml
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import: [65000:100]
+      export: [65000:100]
+interface:
+- if-name: ce1
+  vrf: vrf-cust
+  ipv4: { address: 10.1.0.1/30 }
+router:
+  bgp:
+    global: { as: 65000, identifier: 1.1.1.1 }
+    neighbor:
+    - remote-address: 1.1.1.3        # ASBR1, intra-AS VPNv4
+      remote-as: 65000
+      update-source: 1.1.1.1
+      enabled: true
+      afi-safi:
+      - { name: vpnv4, enabled: true }
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      afi-safi:
+        ipv4:
+          network: [ { prefix: 10.1.0.0/30 } ]
+```
+
+An ASBR (`asbr1`) has **no VRF**. The inter-AS link is a plain global
+interface, and the eBGP neighbour carries `vpnv4`. The iBGP neighbour to
+the PE sets `next-hop-self`:
+
+```yaml
+interface:
+- if-name: asbr2
+  ipv4: { address: 172.16.0.1/30 }   # inter-AS link, GLOBAL table
+router:
+  bgp:
+    global: { as: 65000, identifier: 1.1.1.3 }
+    neighbor:
+    - remote-address: 1.1.1.1          # PE1, intra-AS VPNv4
+      remote-as: 65000
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+        next-hop-self: true            # rewrite NH for re-advertised eBGP routes
+    - remote-address: 172.16.0.2       # ASBR2, single-hop eBGP VPNv4
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - { name: vpnv4, enabled: true }
+```
+
+No MPLS knob is needed on the inter-AS link: zebra-rs enables
+`net.mpls.conf.<if>.input` on every interface it discovers (and sets
+`net.mpls.platform_labels` at startup), so the link forwards labelled
+packets out of the box.
+
+## Next-hop-self on the VPNv4 advertise path
+
+`afi-safi <name> next-hop-self` is the same per-neighbour knob introduced
+for the Inter-AS Option C ASBR→PE Labeled-Unicast session; for Option B it
+is honoured on the **VPNv4** advertise path. By default the VPNv4
+next-hop is rewritten to self only for eBGP and locally-originated routes;
+an eBGP route reflected onward to an iBGP PE keeps its received next-hop.
+Setting the knob forces self on that forwarded route, so the PE always
+sees an IGP-reachable next-hop and resolves the transport over its
+SR-MPLS core.
+
+## Transit label swap
+
+Because the ASBR rewrites the next-hop, it can no longer advertise the
+*received* VPN label — a peer that sends traffic to it would arrive with a
+label the ASBR has no forwarding entry for. Instead, for each received
+VPNv4 route the ASBR:
+
+1. **allocates a per-`(RD, prefix)` local label** from the dynamic label
+   block (the same pool used for per-VRF and Labeled-Unicast labels);
+2. **advertises that local label** in the VPNv4 NLRI to any peer it
+   rewrites the next-hop toward; and
+3. **installs a swap ILM**: `local label → [transport…, received label]`,
+   where the transport stack is the SR-MPLS path to the route's original
+   next-hop (empty when that next-hop is directly connected, as on the
+   inter-AS link).
+
+The dynamic label block is requested as soon as a `vpnv4`/`vpnv6` family
+is enabled on any neighbour — a transit ASBR has no VRF to trigger it
+otherwise. This is the same swap machinery the Labeled-Unicast transit
+path uses; here it is keyed by `(RD, prefix)` because the same IP prefix
+can appear in many VPNs.
+
+> **MPLS label-stack encoding fix.** The kernel ILM encoder previously
+> emitted one `RTA_NEWDST` netlink attribute per outgoing label, so a
+> duplicate attribute overwrote the earlier one and only the last label
+> survived. A swap-and-push (`local → [SR-transport, VPN]`) therefore lost
+> its transport label and the packet was dropped at the next P router.
+> The encoder now packs the whole stack into a single `RTA_NEWDST` with
+> the bottom-of-stack bit set only on the innermost label — matching the
+> IP-route encap path. This fix is required for any multi-label swap ILM,
+> not just Option B.
+
+## Forwarding
+
+Every hop carries an MPLS label; the VPN label is swapped at each ASBR. A
+packet from `ce1` to a host in `ce2`'s subnet (a route originated by
+`pe2`):
+
+| Hop | Action |
+|---|---|
+| `pe1` | VRF lookup → push `[SR→asbr1, ASBR1-VPN]`, send over the core |
+| `p1` | SR penultimate-hop pop → `[ASBR1-VPN]` |
+| `asbr1` | swap `ASBR1-VPN → ASBR2-VPN`, send the **single** label to `asbr2` over the inter-AS link |
+| `asbr2` | swap `ASBR2-VPN → [SR→pe2, PE2-VPN]` onto the AS 65001 core |
+| `p2` | SR penultimate-hop pop → `[PE2-VPN]` |
+| `pe2` | pop the VPN label → VRF lookup → to `ce2` |
+
+The inter-AS link carries exactly one label (the ASBRs are directly
+connected, so no transport label is needed there); the intra-AS legs
+carry two (SR transport + VPN).
+
+## Verification
+
+Each ASBR holds every VPN prefix in its **global** VPNv4 table — the
+local-AS one learned from its PE, the remote-AS one from the other ASBR
+(note the AS path):
+
+```
+asbr1$ show ip bgp vpnv4
+Route Distinguisher: 65000:1
+ *>i 10.1.0.0/30   1.1.1.1      ...   i        # from PE1 (intra-AS VPNv4)
+Route Distinguisher: 65001:1
+ *>  10.2.0.0/30   172.16.0.2   ...   65001 i  # from ASBR2 (inter-AS eBGP)
+```
+
+The swap ILM shows the local label switching to the next label, with the
+SR transport pushed on the multi-hop leg:
+
+```
+asbr2$ ip -f mpls route
+17 as to 16004/16 via inet 10.0.1.2 dev p2     # 10.2 → SR→pe2 + VPN label
+16 as to 16        via inet 172.16.0.1 dev asbr1 # 10.1 → asbr1 (direct, 1 label)
+```
+
+The remote-AS prefix reaches the far PE's VRF (with `next-hop-self` the
+next-hop is the ASBR loopback, resolved by the IGP), and CE-to-CE traffic
+forwards:
+
+```
+pe1$  show ip route vrf vrf-cust    # B *> 10.2.0.0/30 via … label <SR→asbr1> <VPN>
+ce1$  ping <host in ce2's subnet>   # succeeds
+```
+
+## BDD coverage
+
+`bdd/tests/features/bgp_interas_option_b.feature` builds the eight-
+namespace topology above and asserts the IS-IS SR adjacencies, the
+SR-MPLS ILM entries, the intra-AS VPNv4 sessions, the single-hop inter-AS
+eBGP VPNv4 sessions, every VPN prefix in both ASBRs' global VPNv4 tables,
+the far-PE VRF import, and an end-to-end CE-to-CE ping in both directions.
+The ASBRs lower their MRAI so the four-hop VPNv4 propagation converges
+promptly.

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -903,10 +903,14 @@ fn config_afi_safi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let enabled: bool = args.boolean()?;
 
     let ipv4_unicast = key.afi == Afi::Ip && key.safi == Safi::Unicast;
-    // Enabling a Labeled-Unicast family means we may re-advertise routes
-    // with next-hop-self and need per-prefix local labels; request a
-    // dynamic label block eagerly so one is granted before routes arrive.
-    let lu_enabled = key.safi == Safi::MplsLabel && op.is_set() && enabled;
+    // Enabling a Labeled-Unicast or VPN family means we may re-advertise
+    // routes with next-hop-self and need per-prefix local labels (the
+    // Inter-AS Option B/C transit case); request a dynamic label block
+    // eagerly so one is granted before routes arrive. A PE with a VRF
+    // already requests the block on VRF config — this also covers a
+    // transit ASBR that runs VPNv4 with no VRF of its own.
+    let label_block_needed =
+        matches!(key.safi, Safi::MplsLabel | Safi::MplsVpn) && op.is_set() && enabled;
 
     let peer = bgp.peers.get_mut(&addr)?;
 
@@ -923,7 +927,7 @@ fn config_afi_safi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
             peer.config.mp.remove(&key);
         }
     }
-    if lu_enabled {
+    if label_block_needed {
         bgp.request_label_block();
     }
     Some(())
@@ -1529,8 +1533,12 @@ fn config_encapsulation_type(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
 /// <true|false>`. Records the per-neighbor, per-AFI/SAFI next-hop-self
 /// flag on the peer's [`PeerSubConfig`]. Honored on the Labeled-Unicast
 /// advertise paths ([`route_update_labelv4`](super::route::route_update_labelv4)
-/// / `…v6`): an Inter-AS Option C ASBR sets it on the iBGP-LU session to
-/// its PE so re-advertised eBGP-LU routes carry the ASBR as next-hop.
+/// / `…v6`) and on the VPNv4 advertise path
+/// ([`route_update_ipv4`](super::route::route_update_ipv4)): an Inter-AS
+/// Option C ASBR sets it on the iBGP-LU session to its PE so re-advertised
+/// eBGP-LU routes carry the ASBR as next-hop; an Option B ASBR sets it on
+/// the iBGP-VPNv4 session for the same reason (the re-advertised route also
+/// gets a fresh local label + swap ILM).
 fn config_next_hop_self(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let afi_safi: AfiSafi = args.afi_safi()?;

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -485,6 +485,12 @@ pub struct Bgp {
     /// the NLRI and swap-programmed via an ILM (`local → received`).
     pub lu_label_v4: std::collections::BTreeMap<ipnet::Ipv4Net, u32>,
     pub lu_label_v6: std::collections::BTreeMap<ipnet::Ipv6Net, u32>,
+    /// Per-`(RD, prefix)` local labels for received VPNv4 (SAFI 128)
+    /// routes we re-advertise with next-hop-self — the Inter-AS Option B
+    /// transit case. Same dynamic pool; the label is advertised in the
+    /// VPNv4 NLRI and swap-programmed via an ILM (`local → received`).
+    pub vpn_label_v4:
+        std::collections::BTreeMap<(bgp_packet::RouteDistinguisher, ipnet::Ipv4Net), u32>,
     /// Configured SRv6 locator name (`router bgp segment-routing
     /// srv6 locator <name>`). When set, BGP watches this locator on the
     /// RIB and (in a follow-up) carves per-VRF End.DT46 service SIDs
@@ -710,6 +716,7 @@ impl Bgp {
             vrf_label_request_pending: false,
             lu_label_v4: BTreeMap::new(),
             lu_label_v6: BTreeMap::new(),
+            vpn_label_v4: BTreeMap::new(),
             srv6_locator_name: None,
             srv6_locator_rx,
             srv6_locator: None,
@@ -1253,6 +1260,7 @@ impl Bgp {
                         alloc: &mut self.vrf_label_alloc,
                         v4: &mut self.lu_label_v4,
                         v6: &mut self.lu_label_v6,
+                        vpn_v4: &mut self.vpn_label_v4,
                     }),
                 };
 
@@ -2165,6 +2173,13 @@ impl Bgp {
                         None,
                     );
                 }
+                // Inter-AS Option B transit: re-program the swap ILM for our
+                // advertised local label toward the rerouted transport.
+                super::route::reconcile_swap_ilm(
+                    &self.ctx.rib,
+                    Some(&self.nexthop_cache),
+                    selected.first(),
+                );
             }
             NhtDep::V6vpn(rd, p) => {
                 let selected = self.local_rib.select_best_path_vpn_v6(&rd, p);
@@ -2405,6 +2420,14 @@ impl Bgp {
                 {
                     super::vrf::dispatch_withdraw_import_v4(&dispatcher, *rd, *p, &attr, None);
                 }
+                // Inter-AS Option B transit: (re-)install the swap ILM for
+                // our advertised local label now that the next-hop's
+                // transport resolved, or tear it down if it went away.
+                super::route::reconcile_swap_ilm(
+                    &self.ctx.rib,
+                    Some(&self.nexthop_cache),
+                    selected.first(),
+                );
             }
             NhtDep::V6vpn(rd, p) => {
                 super::route::route_advertise_to_peers_vpnv6(

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1112,6 +1112,13 @@ pub struct LuLabels<'a> {
     pub alloc: &'a mut Option<super::vrf::VrfLabelAllocator>,
     pub v4: &'a mut std::collections::BTreeMap<ipnet::Ipv4Net, u32>,
     pub v6: &'a mut std::collections::BTreeMap<ipnet::Ipv6Net, u32>,
+    /// Per-`(RD, prefix)` local labels for received VPNv4 (SAFI 128)
+    /// routes — the Inter-AS Option B transit case. A transit ASBR that
+    /// re-advertises a VPNv4 route with next-hop-self advertises this
+    /// label and swap-programs it (our label → received label) via an
+    /// ILM, so the VPN crosses the AS boundary on MPLS. The RD is part
+    /// of the key because the same IP prefix can live in many VPNs.
+    pub vpn_v4: &'a mut std::collections::BTreeMap<(RouteDistinguisher, ipnet::Ipv4Net), u32>,
 }
 
 impl LuLabels<'_> {
@@ -1124,6 +1131,29 @@ impl LuLabels<'_> {
         }
         let label = self.alloc.as_mut().and_then(|a| a.alloc())?;
         self.v4.insert(prefix, label);
+        Some(label)
+    }
+
+    /// Local label for a received VPNv4 `(RD, prefix)`, allocating one on
+    /// first use. Mirrors [`label_v4`](Self::label_v4); `None` until a
+    /// dynamic block is granted (the caller advertises the received
+    /// label until then).
+    pub fn label_vpn_v4(&mut self, rd: RouteDistinguisher, prefix: ipnet::Ipv4Net) -> Option<u32> {
+        if let Some(l) = self.vpn_v4.get(&(rd, prefix)) {
+            return Some(*l);
+        }
+        let label = self.alloc.as_mut().and_then(|a| a.alloc())?;
+        self.vpn_v4.insert((rd, prefix), label);
+        Some(label)
+    }
+
+    /// Release the label for a withdrawn VPNv4 `(RD, prefix)`; returns it
+    /// so the caller can tear down the swap ILM.
+    pub fn free_vpn_v4(&mut self, rd: RouteDistinguisher, prefix: ipnet::Ipv4Net) -> Option<u32> {
+        let label = self.vpn_v4.remove(&(rd, prefix))?;
+        if let Some(a) = self.alloc.as_mut() {
+            a.free(label);
+        }
         Some(label)
     }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -574,7 +574,7 @@ fn select_fib_entry_label(
 /// egress) carry no local label. An unresolved next-hop removes the ILM.
 /// AFI-agnostic — the ILM is keyed by the local MPLS label, not the IP
 /// prefix.
-fn reconcile_swap_ilm(
+pub(super) fn reconcile_swap_ilm(
     rib_client: &crate::rib::client::RibClient,
     cache: Option<&super::nht::NexthopCache>,
     best: Option<&BgpRib>,
@@ -2114,6 +2114,18 @@ pub fn route_ipv4_update(
         None => super::nht::NhtDep::V4(nlri.prefix),
     };
     nht_track_received(bgp, &mut rib, dep.clone());
+    // VPNv4 transit (Inter-AS Option B): allocate a per-(RD,prefix) local
+    // label. A received VPNv4 route is never self-originated, so it is
+    // always a transit FEC; if we later re-advertise it with next-hop-self
+    // (eBGP, or iBGP+next-hop-self), the peer sends us this label and the
+    // swap ILM below forwards it down the LSP. `None` until a dynamic block
+    // is granted (advertise the received label as a fallback until then).
+    if let Some(rd) = rd {
+        rib.local_label = bgp
+            .lu_labels
+            .as_mut()
+            .and_then(|ll| ll.label_vpn_v4(rd, nlri.prefix));
+    }
     let (replaced, selected, next_id) = bgp.local_rib.update(rd, nlri.prefix, rib.clone());
     // If this update changed the path's next-hop, the displaced row's
     // old next-hop is no longer tracked by it; release it (unless
@@ -2170,10 +2182,19 @@ pub fn route_ipv4_update(
     }
 
     // Plain IPv4 unicast best-path winners are installed to the kernel
-    // FIB via RIB. VPNv4 lives in `local_rib.v4vpn` and has its own
-    // (still-deferred) install path, so gate on rd==None.
+    // FIB via RIB. VPNv4 lives in `local_rib.v4vpn`; a transit ASBR with
+    // no importing VRF installs no IP route, but it does program a swap
+    // ILM for the local label it advertises with next-hop-self (Inter-AS
+    // Option B) — `reconcile_swap_ilm` is a no-op when no local label was
+    // allocated or the next-hop hasn't resolved yet.
     if rd.is_none() {
         fib_install_v4(bgp, nlri.prefix, &selected);
+    } else {
+        reconcile_swap_ilm(
+            bgp.rib_client,
+            bgp.nexthop_cache.as_deref(),
+            selected.first(),
+        );
     }
 
     // Advertise to peers if best path changed.
@@ -2243,7 +2264,7 @@ fn route_advertise_to_addpath(
             peer.adj_out.add(rd, nlri.prefix, rib_clone);
             if let Some(ref rd) = rd {
                 let vpnv4_nlri = Vpnv4Nlri {
-                    label: rib.label.unwrap_or_default(),
+                    label: vpnv4_service_label(peer, rib),
                     rd: *rd,
                     nlri,
                 };
@@ -2454,7 +2475,9 @@ pub(super) fn route_advertise_to_peers(
                 }
                 if let Some(ref rd) = rd {
                     let vpnv4_nlri = Vpnv4Nlri {
-                        label: new_best.and_then(|b| b.label).unwrap_or_default(),
+                        label: new_best
+                            .map(|b| vpnv4_service_label(peer, b))
+                            .unwrap_or_default(),
                         rd: *rd,
                         nlri,
                     };
@@ -2905,7 +2928,7 @@ fn route_soft_out_peer_table(
 
         if let Some(rd_val) = rd {
             let vpnv4_nlri = Vpnv4Nlri {
-                label: rib.label.unwrap_or_default(),
+                label: vpnv4_service_label(peer, rib),
                 rd: rd_val,
                 nlri,
             };
@@ -3193,7 +3216,27 @@ pub fn route_ipv4_withdraw(
     // last candidate just disappeared and we should withdraw from
     // the kernel; non-empty means a replacement path is now best
     // and a fresh Ipv4Add carries the new attrs.
-    if rd.is_none() {
+    if let Some(rd) = rd {
+        // VPNv4 transit (Option B): the prefix is fully gone → release
+        // its local label and tear down the swap ILM; a surviving winner
+        // keeps the same per-(RD,prefix) label, whose ILM is reconciled
+        // for the (possibly new) winner's received label / transport.
+        if selected.is_empty() {
+            if let Some(local) = bgp
+                .lu_labels
+                .as_mut()
+                .and_then(|ll| ll.free_vpn_v4(rd, nlri.prefix))
+            {
+                ilm_swap_remove(bgp.rib_client, local);
+            }
+        } else {
+            reconcile_swap_ilm(
+                bgp.rib_client,
+                bgp.nexthop_cache.as_deref(),
+                selected.first(),
+            );
+        }
+    } else {
         fib_install_v4(bgp, nlri.prefix, &selected);
     }
 
@@ -5896,6 +5939,22 @@ pub fn stale_route_withdraw(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMa
     }
 }
 
+/// Service label to advertise for a VPNv4 NLRI. A transit ASBR that
+/// rewrites the next-hop to self — eBGP, or iBGP with `next-hop-self`
+/// (Inter-AS Option B) — advertises its own allocated local label, so a
+/// peer's VPN traffic arrives on a label we hold a swap ILM for (`local →
+/// received` + transport). Otherwise (next-hop preserved, or a
+/// self-originated VRF FEC with no local label) the route's own label
+/// passes through unchanged. Mirrors the Labeled-Unicast rule in
+/// [`route_update_labelv4`].
+fn vpnv4_service_label(peer: &Peer, rib: &BgpRib) -> Label {
+    let rewrites_nh = peer.is_ebgp() || peer.next_hop_self(Afi::Ip, Safi::MplsVpn);
+    match (rewrites_nh, rib.local_label) {
+        (true, Some(l)) => Label::new(l, 0, true),
+        _ => rib.label.unwrap_or_default(),
+    }
+}
+
 pub fn route_update_ipv4(
     peer: &mut Peer,
     prefix: &Ipv4Net,
@@ -5942,7 +6001,15 @@ pub fn route_update_ipv4(
     // NEXT_HOP attribute and read the LL from MP_REACH per RFC 8950
     // §4) and necessary for non-ENHE peers (they're the ones who
     // can't decode an MP_REACH with a v6 next-hop in the first place).
-    let needs_v4_rewrite = peer.is_ebgp() || rib.is_originated() || rib.egress_ifindex_v6.is_some();
+    // VPN rows (`rib.nexthop.is_some()`) additionally honor a per-neighbor
+    // `afi-safi vpnv4 next-hop-self` — an Inter-AS Option B ASBR sets it on
+    // the iBGP session to its PE so a re-advertised eBGP-VPNv4 route carries
+    // the ASBR (a resolvable next-hop) instead of the unreachable foreign
+    // PE. eBGP and self-originated routes rewrite unconditionally as before.
+    let needs_v4_rewrite = peer.is_ebgp()
+        || rib.is_originated()
+        || rib.egress_ifindex_v6.is_some()
+        || (rib.nexthop.is_some() && peer.next_hop_self(Afi::Ip, Safi::MplsVpn));
     if needs_v4_rewrite {
         let nexthop = if let Some(ref local_addr) = peer.param.local_addr
             && let IpAddr::V4(local_addr) = local_addr.ip()
@@ -7370,7 +7437,7 @@ pub fn route_sync_vpnv4(peer: &mut Peer, bgp: &mut BgpTop) {
             // Register to AdjOut.
             rib.attr = bgp.attr_store.intern(attr);
             let arc_attr = rib.attr.clone();
-            let label = rib.label.unwrap_or_default();
+            let label = vpnv4_service_label(peer, &rib);
             peer.adj_out.add(Some(rd), nlri.prefix, rib);
 
             let vpnv4_nlri = Vpnv4Nlri { label, rd, nlri };

--- a/zebra-rs/src/fib/netlink/handle.rs
+++ b/zebra-rs/src/fib/netlink/handle.rs
@@ -1934,15 +1934,27 @@ impl FibHandle {
                     msg.attributes.push(attr);
                 }
 
-                for &label in uni.mpls_label.iter() {
-                    let label = MplsLabel {
-                        label,
-                        traffic_class: 0,
-                        bottom_of_stack: true,
-                        ttl: 0,
-                    };
-                    let attr = RouteAttribute::NewDestination(vec![label]);
-                    msg.attributes.push(attr);
+                // The outgoing label stack rides a single RTA_NEWDST:
+                // one attribute carrying every label (outermost first),
+                // BoS set only on the bottom label. Emitting one
+                // NewDestination per label would leave the kernel with
+                // just the last (duplicate RTA_NEWDST overwrites), which
+                // drops the transport label under a swap-and-push — e.g.
+                // an Inter-AS Option B VPNv4 transit `local → [SR, VPN]`.
+                if !uni.mpls_label.is_empty() {
+                    let last = uni.mpls_label.len() - 1;
+                    let stack: Vec<MplsLabel> = uni
+                        .mpls_label
+                        .iter()
+                        .enumerate()
+                        .map(|(i, &label)| MplsLabel {
+                            label,
+                            traffic_class: 0,
+                            bottom_of_stack: i == last,
+                            ttl: 0,
+                        })
+                        .collect();
+                    msg.attributes.push(RouteAttribute::NewDestination(stack));
                 }
             }
             Nexthop::Multi(ref multi) => {
@@ -1961,15 +1973,21 @@ impl FibHandle {
                         nhop.attributes.push(attr);
                     }
 
-                    for &label in uni.mpls_label.iter() {
-                        let label = MplsLabel {
-                            label,
-                            traffic_class: 0,
-                            bottom_of_stack: true,
-                            ttl: 0,
-                        };
-                        let attr = RouteAttribute::NewDestination(vec![label]);
-                        nhop.attributes.push(attr);
+                    // Full label stack in one RTA_NEWDST (see the Uni arm).
+                    if !uni.mpls_label.is_empty() {
+                        let last = uni.mpls_label.len() - 1;
+                        let stack: Vec<MplsLabel> = uni
+                            .mpls_label
+                            .iter()
+                            .enumerate()
+                            .map(|(i, &label)| MplsLabel {
+                                label,
+                                traffic_class: 0,
+                                bottom_of_stack: i == last,
+                                ttl: 0,
+                            })
+                            .collect();
+                        nhop.attributes.push(RouteAttribute::NewDestination(stack));
                     }
 
                     mpath.push(nhop);

--- a/zebra-rs/yang/ietf-bgp-neighbor@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp-neighbor@2023-07-05.yang
@@ -231,11 +231,12 @@ submodule ietf-bgp-neighbor {
            routes too.
 
            Required on the iBGP IPv4/IPv6 Labeled-Unicast session an
-           Inter-AS MPLS/VPN Option C ASBR runs toward its PE: the PE must
-           resolve the ASBR's loopback (reachable via the IGP) and push
-           the ASBR's swap label, not the unreachable foreign-AS next-hop
-           carried across the inter-AS eBGP-LU link. Currently honored on
-           the Labeled-Unicast (SAFI 4) advertise paths.";
+           Inter-AS MPLS/VPN Option C ASBR runs toward its PE, and on the
+           iBGP VPNv4 session an Inter-AS Option B ASBR runs toward its PE:
+           the PE must resolve the ASBR's loopback (reachable via the IGP)
+           and push the ASBR's swap label, not the unreachable foreign-AS
+           next-hop carried across the inter-AS eBGP link. Honored on the
+           Labeled-Unicast (SAFI 4) and VPNv4 (SAFI 128) advertise paths.";
       }
     }
   }


### PR DESCRIPTION
## Summary

Implements **Inter-AS MPLS/VPN Option B** (RFC 4364 §10b — VPNv4 between
ASBRs), with an SR-MPLS transport inside each AS. The two ASBRs run a
single-hop **MP-eBGP VPNv4** session directly with each other and exchange
the VPN routes themselves. An Option B ASBR holds **no VRF** — every VPN
route lives in its global VPNv4 Loc-RIB and is re-advertised onward,
label-swapped across the boundary. Each AS is an ordinary intra-AS L3VPN
(PE↔ASBR VPNv4 over the SR-MPLS core); the inter-AS link sits in the
global table and carries labelled VPNv4.

The VPNv4 transit (no-VRF) path had never been exercised; four pieces
were missing:

| Area | Fix |
|---|---|
| `bgp/route.rs` | Honour per-neighbour `afi-safi vpnv4 next-hop-self` on the VPNv4 advertise path (the Option C knob was Labeled-Unicast only), so an ASBR re-advertises a route from the other AS to its PE with its own IGP-reachable loopback. |
| `bgp/route.rs`, `bgp/peer.rs`, `bgp/inst.rs` | Allocate a per-`(RD,prefix)` local VPN label for each received VPNv4 route and install a swap ILM (`our label → received label`, toward the original next-hop's transport); advertise the local label when the next-hop is rewritten to self. Reconciled on receive / NHT resolution / transport-reroute, freed on withdraw. Mirrors the Labeled-Unicast transit swap. |
| `bgp/config.rs` | Request the dynamic label block when a `vpnv4`/`vpnv6` family is enabled, not only for Labeled-Unicast — a transit ASBR has no VRF to trigger it. |
| `fib/netlink/handle.rs` | **General FIB fix:** pack a swap ILM's outgoing label stack into a single `RTA_NEWDST` with the bottom-of-stack bit on the innermost label. The encoder emitted one `RTA_NEWDST` per label, so the duplicate overwrote the earlier one and only the last label survived — a swap-and-push (`local → [SR-transport, VPN]`) lost its transport label and the packet was dropped at the next P router. Required for any multi-label swap ILM, not just Option B. |

Adds the `@bgp_interas_option_b` BDD feature and a book section. The
inter-AS forwarding crosses the boundary as a single labelled MPLS packet
that each ASBR label-swaps.

## Test plan

- `make -C bdd bgp_interas_option_b` — **6/6 scenarios, 77/77 steps**,
  including the end-to-end CE1→CE2 / CE2→CE1 pings (VPN-labelled PE→ASBR
  over SR, single-label swap across the inter-AS link, re-labelled
  ASBR→PE in the far AS).
- `make -C bdd bgp_interas_option_a` (6/6) and `bgp_interas_option_c`
  (7/7) — still green; the FIB encoder fix touches every ILM install.
- `cargo test --workspace --exclude bdd` — **1456 passed, 0 failed**.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- `mdbook build` (book/) — clean, no broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
