### PR TITLE
bgp: Inter-AS MPLS/VPN Option AB (single VPNv4 session, per-VRF forwarding)

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -178,6 +178,10 @@ bgp_interas_option_b:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_interas_option_b"
 
+bgp_interas_option_ab:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_interas_option_ab"
+
 generate:
 	rm -rf allure-report
 	allure generate
@@ -197,4 +201,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv3_nssa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise bgp_neighbor_group bgp_unnumbered_neighbor bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv3_nssa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community_no_export_advertise bgp_neighbor_group bgp_unnumbered_neighbor bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE

--- a/bdd/tests/configs/bgp_interas_option_ab/asbr1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_ab/asbr1.yaml
@@ -1,0 +1,80 @@
+# ASBR1 (AS 65000 border — Inter-AS MPLS/VPN Option AB, RFC 4364 hybrid).
+#  - Holds vrf-cust (like Option A) but with NO interface and NO CE: it is
+#    a pure transit VRF whose only job is per-VRF forwarding (the VPN label
+#    terminates here → VRF lookup → re-impose) and per-VRF RT policy.
+#  - A SINGLE MP-eBGP VPNv4 session to ASBR2 (172.16.0.2) carries every
+#    VPN (like Option B); the inter-AS link is in the GLOBAL table.
+#  - VPNv4 iBGP to PE1 (1.1.1.1) over the IS-IS/SR core.
+#  - `inter-as-hybrid true` makes vrf-cust re-export the VPNv4 routes it
+#    imports, so AS 65001's prefixes (learned over the eBGP session and
+#    imported into vrf-cust) are relayed to PE1, and PE1's prefixes
+#    (imported from the iBGP session) are relayed to ASBR2. The re-export
+#    is Originated, so next-hop-self is automatic on both legs; the
+#    re-import loop is broken by the import fan-out's skip-self + eBGP
+#    AS-path. The VRF's per-VRF label + its DecapVrf ILM give the
+#    pop→VRF-lookup→re-impose data path; MPLS input is auto-enabled on
+#    every link.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.3/32
+- if-name: p1
+  ipv4:
+    address: 10.0.0.6/30
+- if-name: asbr2
+  ipv4:
+    address: 172.16.0.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0003.00
+    hostname: asbr1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 3
+    - if-name: p1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      identifier: 1.1.1.3
+    # Lower the MRAI so the VPNv4 route crosses the eBGP boundary (default
+    # 30s) and is relayed to PE1 promptly (same rationale as Option B).
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 1.1.1.1          # PE1, intra-AS VPNv4 iBGP
+      remote-as: 65000
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    - remote-address: 172.16.0.2       # ASBR2, single-hop inter-AS eBGP VPNv4
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:2
+      inter-as-hybrid: true

--- a/bdd/tests/configs/bgp_interas_option_ab/asbr2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_ab/asbr2.yaml
@@ -1,0 +1,66 @@
+# ASBR2 (AS 65001 border — Inter-AS Option AB). Mirror of ASBR1.
+#  - Transit vrf-cust (no interface, no CE) with `inter-as-hybrid true`.
+#  - Single MP-eBGP VPNv4 session to ASBR1 (172.16.0.1) in the global
+#    table; VPNv4 iBGP to PE2 (2.2.2.1) over the IS-IS/SR core.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.3/32
+- if-name: asbr1
+  ipv4:
+    address: 172.16.0.2/30
+- if-name: p2
+  ipv4:
+    address: 10.0.1.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0006.00
+    hostname: asbr2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.3
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 6
+    - if-name: p2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65001
+      identifier: 2.2.2.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 2.2.2.1          # PE2, intra-AS VPNv4 iBGP
+      remote-as: 65001
+      update-source: 2.2.2.3
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    - remote-address: 172.16.0.1       # ASBR1, single-hop inter-AS eBGP VPNv4
+      remote-as: 65000
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65001:2
+      inter-as-hybrid: true

--- a/bdd/tests/configs/bgp_interas_option_ab/ce1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_ab/ce1.yaml
@@ -1,0 +1,14 @@
+# CE1 (AS 65000 customer site). A plain host: one link to PE1 and a
+# default route pointing at PE1's VRF interface. No IGP/BGP — the CE is
+# the traffic source/sink for the end-to-end L3VPN ping (CE1 -> CE2).
+interface:
+- if-name: pe1
+  ipv4:
+    address: 10.1.0.2/30
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 0.0.0.0/0
+        nexthop:
+        - address: 10.1.0.1

--- a/bdd/tests/configs/bgp_interas_option_ab/ce2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_ab/ce2.yaml
@@ -1,0 +1,12 @@
+# CE2 (AS 65001 customer site). Plain host, default route to PE2.
+interface:
+- if-name: pe2
+  ipv4:
+    address: 10.2.0.2/30
+router:
+  static:
+    ipv4:
+      route:
+      - prefix: 0.0.0.0/0
+        nexthop:
+        - address: 10.2.0.1

--- a/bdd/tests/configs/bgp_interas_option_ab/p1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_ab/p1.yaml
@@ -1,0 +1,37 @@
+# P1 (AS 65000 core / transit LSR). Pure IS-IS + SR-MPLS, no BGP. Sits
+# between PE1 and ASBR1 so the intra-AS transport LSP performs a real SR
+# label swap (and PHP toward the loopbacks) rather than collapsing to a
+# single hop.
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.2/32
+- if-name: pe1
+  ipv4:
+    address: 10.0.0.2/30
+- if-name: asbr1
+  ipv4:
+    address: 10.0.0.5/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0002.00
+    hostname: p1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 2
+    - if-name: pe1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: asbr1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/bgp_interas_option_ab/p2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_ab/p2.yaml
@@ -1,0 +1,34 @@
+# P2 (AS 65001 core / transit LSR). Pure IS-IS + SR-MPLS, no BGP.
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.2/32
+- if-name: asbr2
+  ipv4:
+    address: 10.0.1.2/30
+- if-name: pe2
+  ipv4:
+    address: 10.0.1.5/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0005.00
+    hostname: p2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.2
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 5
+    - if-name: asbr2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+    - if-name: pe2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true

--- a/bdd/tests/configs/bgp_interas_option_ab/pe1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_ab/pe1.yaml
@@ -1,0 +1,61 @@
+# PE1 (AS 65000 provider edge). Inter-AS Option AB (VPNv4 between ASBRs,
+# per-VRF forwarding). A normal intra-AS L3VPN PE: VPNv4 iBGP to ASBR1
+# over the IS-IS/SR-MPLS core (loopback next-hop resolved by the IGP).
+# vrf-cust holds the CE1 link and originates the customer prefix; PE1 is
+# unaware of the AS boundary — ASBR1 relays AS 65001's prefixes to it.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 1.1.1.1/32
+- if-name: p1
+  ipv4:
+    address: 10.0.0.1/30
+- if-name: ce1
+  vrf: vrf-cust
+  ipv4:
+    address: 10.1.0.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0001.00
+    hostname: pe1
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 1.1.1.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 1
+    - if-name: p1
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65000
+      identifier: 1.1.1.1
+    neighbor:
+    - remote-address: 1.1.1.3
+      remote-as: 65000
+      update-source: 1.1.1.1
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65000:1
+      afi-safi:
+        ipv4:
+          network:
+          - prefix: 10.1.0.0/30

--- a/bdd/tests/configs/bgp_interas_option_ab/pe2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_ab/pe2.yaml
@@ -1,0 +1,58 @@
+# PE2 (AS 65001 provider edge). Inter-AS Option AB, mirror of PE1: VPNv4
+# iBGP to ASBR2 over the IS-IS/SR core; vrf-cust holds the CE2 link.
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import:
+      - 65000:100
+      export:
+      - 65000:100
+interface:
+- if-name: lo
+  ipv4:
+    address: 2.2.2.1/32
+- if-name: p2
+  ipv4:
+    address: 10.0.1.6/30
+- if-name: ce2
+  vrf: vrf-cust
+  ipv4:
+    address: 10.2.0.1/30
+router:
+  isis:
+    net: 49.0000.0000.0000.0004.00
+    hostname: pe2
+    is-type: level-2-only
+    segment-routing: mpls
+    te-router-id: 2.2.2.1
+    interface:
+    - if-name: lo
+      ipv4:
+        enable: true
+        prefix-sid:
+          index: 4
+    - if-name: p2
+      network-type: point-to-point
+      metric: 10
+      ipv4:
+        enable: true
+  bgp:
+    global:
+      as: 65001
+      identifier: 2.2.2.1
+    neighbor:
+    - remote-address: 2.2.2.3
+      remote-as: 65001
+      update-source: 2.2.2.1
+      enabled: true
+      afi-safi:
+      - name: vpnv4
+        enabled: true
+    vrf:
+    - name: vrf-cust
+      rd: 65001:1
+      afi-safi:
+        ipv4:
+          network:
+          - prefix: 10.2.0.0/30

--- a/bdd/tests/features/bgp_interas_option_ab.feature
+++ b/bdd/tests/features/bgp_interas_option_ab.feature
@@ -1,0 +1,125 @@
+@serial
+@bgp_interas_option_ab
+Feature: Inter-AS MPLS/VPN Option AB over SR-MPLS (RFC 4364 hybrid)
+  As a service provider running L3VPN across two autonomous systems
+  I want Inter-AS Option AB: the ASBRs keep a per-VPN VRF and forward
+  through it (the VPN label terminates at the ASBR → VRF lookup →
+  re-impose, like Option A), but exchange every VPN over a single MP-eBGP
+  VPNv4 session on one labelled link (like Option B). Each ASBR's
+  `inter-as-hybrid` VRF re-exports the VPNv4 routes it imports, relaying
+  the remote AS's prefixes to its own PEs.
+
+  Test Topology (8 namespaces):
+  ```
+            AS 65000                                AS 65001
+   ce1 ── pe1 ──── p1 ──── asbr1 ════════ asbr2 ──── p2 ──── pe2 ── ce2
+          lo        lo       lo  172.16.0.0/30 lo      lo      lo
+       1.1.1.1   1.1.1.2  1.1.1.3  (global)   2.2.2.3 2.2.2.2 2.2.2.1
+   └ vrf-cust ┘        └ vrf-cust ┘        └ vrf-cust ┘    └ vrf-cust ┘
+    10.1.0.0/30        (transit, no CE)   (transit, no CE)  10.2.0.0/30
+  ```
+  - Intra-AS: IS-IS L2 + segment-routing mpls; VPNv4 iBGP PE↔ASBR over
+    the SR-MPLS core.
+  - Inter-AS (asbr1↔asbr2, 172.16.0.0/30): a single-hop **MP-eBGP VPNv4**
+    session over a link in the GLOBAL table. Each ASBR holds vrf-cust (no
+    interface, no CE) with `inter-as-hybrid`, so it imports the VPNv4 it
+    receives into the VRF (for per-VRF forwarding) AND re-exports it onward.
+  - A CE→CE packet is VPN-labelled PE→ASBR over the SR core; at each ASBR
+    the label terminates (DecapVrf → VRF lookup) and a new label is
+    imposed — toward the peer ASBR (single label on the inter-AS link) or
+    toward the egress PE over its SR core.
+
+  Scenario: Build the Inter-AS Option AB topology and bring up every session
+    Given a clean test environment
+    When I create namespace "ce1"
+    And I create namespace "pe1"
+    And I create namespace "p1"
+    And I create namespace "asbr1"
+    And I create namespace "asbr2"
+    And I create namespace "p2"
+    And I create namespace "pe2"
+    And I create namespace "ce2"
+    And I connect namespace "ce1" interface "pe1" to namespace "pe1" interface "ce1"
+    And I connect namespace "pe1" interface "p1" to namespace "p1" interface "pe1"
+    And I connect namespace "p1" interface "asbr1" to namespace "asbr1" interface "p1"
+    And I connect namespace "asbr1" interface "asbr2" to namespace "asbr2" interface "asbr1"
+    And I connect namespace "asbr2" interface "p2" to namespace "p2" interface "asbr2"
+    And I connect namespace "p2" interface "pe2" to namespace "pe2" interface "p2"
+    And I connect namespace "pe2" interface "ce2" to namespace "ce2" interface "pe2"
+    And I start zebra-rs in namespace "ce1"
+    And I start zebra-rs in namespace "pe1"
+    And I start zebra-rs in namespace "p1"
+    And I start zebra-rs in namespace "asbr1"
+    And I start zebra-rs in namespace "asbr2"
+    And I start zebra-rs in namespace "p2"
+    And I start zebra-rs in namespace "pe2"
+    And I start zebra-rs in namespace "ce2"
+    And I apply config "ce1.yaml" to namespace "ce1"
+    And I apply config "pe1.yaml" to namespace "pe1"
+    And I apply config "p1.yaml" to namespace "p1"
+    And I apply config "asbr1.yaml" to namespace "asbr1"
+    And I apply config "asbr2.yaml" to namespace "asbr2"
+    And I apply config "p2.yaml" to namespace "p2"
+    And I apply config "pe2.yaml" to namespace "pe2"
+    And I apply config "ce2.yaml" to namespace "ce2"
+    And I wait 35 seconds for BGP to operate
+    # IS-IS SR adjacencies form the intra-AS transport.
+    Then isis neighbor in namespace "pe1" at level 2 on interface "p1" should be up
+    And isis neighbor in namespace "asbr1" at level 2 on interface "p1" should be up
+    And isis neighbor in namespace "pe2" at level 2 on interface "p2" should be up
+    And isis neighbor in namespace "asbr2" at level 2 on interface "p2" should be up
+    # Intra-AS VPNv4 iBGP PE↔ASBR in each AS.
+    And BGP session in "pe1" to "1.1.1.3" should be "Established"
+    And BGP session in "asbr1" to "1.1.1.1" should be "Established"
+    And BGP session in "pe2" to "2.2.2.3" should be "Established"
+    And BGP session in "asbr2" to "2.2.2.1" should be "Established"
+    # Inter-AS single-hop MP-eBGP VPNv4 between the ASBRs.
+    And BGP session in "asbr1" to "172.16.0.2" should be "Established"
+    And BGP session in "asbr2" to "172.16.0.1" should be "Established"
+
+  Scenario: SR-MPLS transport LSPs are installed on the core P routers
+    Given the test topology exists
+    Then mpls ilm in namespace "p1" should contain label 16001
+    And mpls ilm in namespace "p1" should contain label 16003
+    And mpls ilm in namespace "p2" should contain label 16004
+    And mpls ilm in namespace "p2" should contain label 16006
+
+  Scenario: Each ASBR holds every VPN prefix in its per-VPN VRF (the "A" half)
+    Given the test topology exists
+    # Unlike Option B (routes in the global VPNv4 table), an Option AB ASBR
+    # imports both prefixes into vrf-cust: the local-AS one from its PE, the
+    # remote-AS one from the single inter-AS eBGP VPNv4 session.
+    Then show command "show ip route vrf vrf-cust" in namespace "asbr1" should contain "10.1.0.0/30"
+    And show command "show ip route vrf vrf-cust" in namespace "asbr1" should contain "10.2.0.0/30"
+    And show command "show ip route vrf vrf-cust" in namespace "asbr2" should contain "10.1.0.0/30"
+    And show command "show ip route vrf vrf-cust" in namespace "asbr2" should contain "10.2.0.0/30"
+
+  Scenario: Each PE imports the remote-AS customer prefix into its VRF
+    Given the test topology exists
+    Then show command "show ip route vrf vrf-cust" in namespace "pe1" should contain "10.2.0.0/30"
+    And show command "show ip route vrf vrf-cust" in namespace "pe2" should contain "10.1.0.0/30"
+
+  Scenario: End-to-end customer forwarding across the AS boundary (per-VRF label swap)
+    Given the test topology exists
+    Then ping from "ce1" to "10.2.0.2" should succeed
+    And ping from "ce2" to "10.1.0.2" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "ce1"
+    And I stop zebra-rs in namespace "pe1"
+    And I stop zebra-rs in namespace "p1"
+    And I stop zebra-rs in namespace "asbr1"
+    And I stop zebra-rs in namespace "asbr2"
+    And I stop zebra-rs in namespace "p2"
+    And I stop zebra-rs in namespace "pe2"
+    And I stop zebra-rs in namespace "ce2"
+    And I delete namespace "ce1"
+    And I delete namespace "pe1"
+    And I delete namespace "p1"
+    And I delete namespace "asbr1"
+    And I delete namespace "asbr2"
+    And I delete namespace "p2"
+    And I delete namespace "pe2"
+    And I delete namespace "ce2"
+    Then the test environment should be clean

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -33,6 +33,7 @@
     - [Option A (back-to-back VRFs)](ch-02-20-bgp-interas-option-a.md)
     - [Option B (VPNv4 between ASBRs)](ch-02-21-bgp-interas-option-b.md)
     - [Option C over SR-MPLS](ch-02-19-bgp-interas-option-c.md)
+    - [Option AB (hybrid)](ch-02-22-bgp-interas-option-ab.md)
   - [BFD](ch-02-08-bgp-bfd.md)
   - [Route Reflector](ch-02-09-bgp-route-reflector.md)
   - [Conditional Tracing](ch-02-10-bgp-tracing.md)

--- a/book/src/ch-02-18-bgp-interas.md
+++ b/book/src/ch-02-18-bgp-interas.md
@@ -9,14 +9,15 @@ autonomous systems — two providers, or two regions of one provider that
 run separate IGPs — and the VPN must cross the AS boundary at the
 Autonomous System Boundary Routers (ASBRs).
 
-RFC 4364 §10 describes three ways to carry VPN routes across that
-boundary:
+RFC 4364 §10 describes three standard ways to carry VPN routes across
+that boundary, plus a widely-deployed vendor hybrid (**Option AB**):
 
 | Option | How VPN routes cross | VPN state on the ASBRs | Transport LSP |
 |---|---|---|---|
 | **A** (§10a) | back-to-back VRFs; one (sub)interface per VPN between the ASBRs | full — one VRF per VPN | terminates at each ASBR |
-| **B** (§10b) | MP-eBGP VPNv4/VPNv6 between the ASBRs | per-VPN-route (the ASBRs hold and re-advertise every VPN prefix) | terminates at each ASBR |
+| **B** (§10b) | MP-eBGP VPNv4/VPNv6 between the ASBRs | per-VPN-route (the ASBRs hold and re-advertise every VPN prefix) in the **global** table | terminates at each ASBR |
 | **C** (§10c) | MP-eBGP VPNv4/VPNv6 directly (multihop) between the PEs (or RRs); the ASBRs exchange only **labeled IPv4/IPv6** (BGP-LU) for the PE loopbacks | **none** — the ASBRs hold no VPN routes | a single end-to-end LSP from ingress PE to egress PE |
+| **AB** (hybrid) | a **single** MP-eBGP VPNv4/VPNv6 session between the ASBRs (as in B) | per-VPN — the ASBRs hold every VPN prefix in a **VRF** (as in A) and forward per-VRF | terminates at each ASBR |
 
 The options trade off ASBR scaling against operational coupling. Option
 A needs no MPLS on the inter-AS link but burns a (sub)interface and a
@@ -25,10 +26,15 @@ VPN data plane) but needs no per-VPN VRF — the ASBRs hold every VPN route
 in their global VPNv4 table and label-swap it across the boundary.
 **Option C** pushes both out: the ASBRs only need to make the remote PE
 loopbacks reachable — and labeled — so a single LSP runs end to end and
-the VPN routes pass over the top, transparent to the ASBRs.
+the VPN routes pass over the top, transparent to the ASBRs. **Option AB**
+splits the difference between A and B: a *single* MP-eBGP session carries
+every VPN (B's scaling), but the ASBRs still keep a per-VPN VRF and
+forward through it (A's per-VPN control and security), so it needs
+neither a per-VPN interface nor a transparent label swap.
 
-> **Implemented today:** all three —
+> **Implemented today:** all four —
 > [Option A](ch-02-20-bgp-interas-option-a.md) (back-to-back VRFs),
-> [Option B](ch-02-21-bgp-interas-option-b.md) (VPNv4 between ASBRs), and
-> [Option C](ch-02-19-bgp-interas-option-c.md) (BGP-LU between ASBRs) —
-> each with an SR-MPLS transport inside the AS.
+> [Option B](ch-02-21-bgp-interas-option-b.md) (VPNv4 between ASBRs),
+> [Option C](ch-02-19-bgp-interas-option-c.md) (BGP-LU between ASBRs), and
+> [Option AB](ch-02-22-bgp-interas-option-ab.md) (single VPNv4 session +
+> per-VRF forwarding) — each with an SR-MPLS transport inside the AS.

--- a/book/src/ch-02-22-bgp-interas-option-ab.md
+++ b/book/src/ch-02-22-bgp-interas-option-ab.md
@@ -1,0 +1,166 @@
+# Inter-AS Option AB (VPNv4 between ASBRs, per-VRF forwarding)
+
+Option AB is a vendor hybrid (not an RFC 4364 §10 sub-option) that
+combines the two trade-offs of Option A and Option B:
+
+- like **Option B**, a *single* MP-eBGP VPNv4/VPNv6 session between the
+  ASBRs carries every VPN over one labelled link — no per-VPN interface;
+- like **Option A**, each ASBR keeps a per-VPN **VRF** and forwards
+  through it (the VPN label terminates at the ASBR → VRF lookup →
+  re-impose), so per-VPN policy, filtering and accounting still apply.
+
+So Option AB gives the scaling of B with the per-VPN control of A. The
+ASBR imports the VPNv4 routes it receives into a VRF (for forwarding and
+RT policy) and **re-exports** them — relaying a remote AS's prefixes to
+its own PEs, and its PEs' prefixes to the other ASBR — all over the one
+session. In zebra-rs this is enabled per VRF with `inter-as-hybrid`.
+
+## Reference topology
+
+This is the topology exercised by the `@bgp_interas_option_ab` BDD
+feature (`bdd/tests/features/bgp_interas_option_ab.feature`):
+
+```
+          AS 65000                                  AS 65001
+ ce1 ── pe1 ──── p1 ──── asbr1 ════════ asbr2 ──── p2 ──── pe2 ── ce2
+        lo        lo       lo  172.16.0.0/30  lo     lo      lo
+     1.1.1.1   1.1.1.2  1.1.1.3  (global)    2.2.2.3 2.2.2.2 2.2.2.1
+  └ vrf-cust ┘      └ vrf-cust ┘        └ vrf-cust ┘    └ vrf-cust ┘
+   10.1.0.0/30      (transit, no CE)   (transit, no CE)  10.2.0.0/30
+```
+
+`pe1` exchanges VPNv4 with `asbr1` over the IS-IS / SR-MPLS core; likewise
+`pe2`/`asbr2`. The `asbr1`–`asbr2` link is in the **global** table and
+carries a single-hop MP-eBGP VPNv4 session. Each ASBR holds `vrf-cust`
+(with `inter-as-hybrid`) — but with **no interface and no CE**: it is a
+pure transit VRF, present only to provide per-VPN forwarding and policy.
+
+## How it differs from A and B
+
+| | Option A | Option B | **Option AB** |
+|---|---|---|---|
+| Inter-AS sessions | one eBGP **per VRF** (PE-CE in the VRF) | one eBGP VPNv4 (global) | one eBGP VPNv4 (global) |
+| ASBR VPN state | VRF per VPN | global VPNv4 table | **VRF per VPN** |
+| Inter-AS link carries | plain IP (in the VRF) | labelled VPNv4 | labelled VPNv4 |
+| ASBR data path | pop → VRF lookup → plain IP | label **swap** | pop → **VRF lookup** → re-impose |
+
+## Configuration
+
+PEs are ordinary intra-AS L3VPN PEs — identical to Options A/B and unaware
+of the boundary. The ASBR holds a transit VRF and a single eBGP VPNv4
+peer. The only Option-AB-specific knob is `inter-as-hybrid` on the VRF:
+
+```yaml
+# Top-level VRF: RT policy only (no interface — a pure transit VRF).
+vrf:
+- name: vrf-cust
+  ipv4:
+    route-target:
+      import: [65000:100]
+      export: [65000:100]
+interface:
+- if-name: asbr2
+  ipv4: { address: 172.16.0.1/30 }   # inter-AS link, GLOBAL table
+router:
+  bgp:
+    global: { as: 65000, identifier: 1.1.1.3 }
+    neighbor:
+    - remote-address: 1.1.1.1          # PE1, intra-AS VPNv4 iBGP
+      remote-as: 65000
+      update-source: 1.1.1.3
+      enabled: true
+      afi-safi:
+      - { name: vpnv4, enabled: true }
+    - remote-address: 172.16.0.2       # ASBR2, single-hop inter-AS eBGP VPNv4
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - { name: vpnv4, enabled: true }
+    vrf:
+    - name: vrf-cust
+      rd: 65000:2
+      inter-as-hybrid: true            # re-export imported VPNv4 routes
+```
+
+No `next-hop-self` knob is needed: re-exported routes are *originated*
+from the VRF, so the next-hop is rewritten to self automatically — to the
+inter-AS link address on the eBGP leg, and to the ASBR loopback on the
+iBGP leg (both resolvable by the receiver). MPLS input is auto-enabled on
+every link, so the global inter-AS link forwards labelled packets with no
+extra config.
+
+## Re-exporting imported routes
+
+An ordinary L3VPN VRF re-exports only the routes it *originates*
+(`network` / redistribute / CE-learned). Option AB additionally
+re-exports the routes it **imports** from VPNv4 — that is what lets an
+ASBR relay AS 65001's prefixes to its own PEs. zebra-rs gates this on the
+per-VRF `inter-as-hybrid` flag, so a normal VRF is unchanged.
+
+Crucially, the ASBR **re-originates** each route from the VRF (a new RD,
+the VRF's export RTs, next-hop-self) rather than *also* transparently
+relaying the one it received: a received VPNv4 route an `inter-as-hybrid`
+VRF imports is marked transit-only and is **not** advertised directly to
+peers. Otherwise the same prefix would reach the next node under two RDs
+(the relayed one and the re-originated one), and because a VRF's IP table
+is keyed by prefix, the two would collide and the import would thrash.
+Each node therefore sees the prefix under exactly one RD.
+
+The obvious risk — a route imported from VPNv4, re-exported as VPNv4, then
+re-imported into the same VRF — is already handled:
+
+- the VRF that originated an export is **excluded from its own import
+  fan-out** (the import dispatcher's skip-self), so a re-export never
+  loops back into the VRF it came from; and
+- the inter-AS leg is **eBGP**, so the AS-path loop check drops a route
+  that returns to the AS that emitted it.
+
+## Forwarding
+
+Every hop carries an MPLS label; at each ASBR the label terminates into
+the VRF and a new one is imposed. A packet from `ce1` to a host in `ce2`'s
+subnet (a route originated by `pe2`):
+
+| Hop | Action |
+|---|---|
+| `pe1` | VRF lookup → push `[SR→asbr1, ASBR1-VRF]`, send over the core |
+| `p1` | SR penultimate-hop pop → `[ASBR1-VRF]` |
+| `asbr1` | pop the VRF label → **vrf-cust lookup** → push `[ASBR2-VRF]`, send the **single** label to `asbr2` |
+| `asbr2` | pop the VRF label → **vrf-cust lookup** → push `[SR→pe2, PE2-VRF]` onto the AS 65001 core |
+| `p2` | SR penultimate-hop pop → `[PE2-VRF]` |
+| `pe2` | pop the VRF label → vrf-cust lookup → to `ce2` |
+
+Each ASBR uses one per-VRF label (one decap entry per VRF); the inner IP
+lookup in the VRF disambiguates the many prefixes that share it. The
+inter-AS link carries a single label (the ASBRs are directly connected,
+so no transport label is needed there); the intra-AS legs carry two.
+
+## Verification
+
+Unlike Option B (prefixes in the global VPNv4 table), an Option AB ASBR
+holds both prefixes in its **VRF** — the local-AS one from its PE, the
+remote-AS one from the single inter-AS session:
+
+```
+asbr1$ show ip route vrf vrf-cust
+B *> 10.1.0.0/30  via … p1            label <SR→pe1> <PE1-VRF>   # from PE1
+B *> 10.2.0.0/30  via 172.16.0.2, asbr2  label <ASBR2-VRF>      # from ASBR2 (eBGP)
+```
+
+The remote-AS prefix reaches the far PE's VRF, and CE-to-CE traffic
+forwards:
+
+```
+pe1$  show ip route vrf vrf-cust    # contains 10.2.0.0/30
+ce1$  ping <host in ce2's subnet>   # succeeds
+```
+
+## BDD coverage
+
+`bdd/tests/features/bgp_interas_option_ab.feature` builds the eight-
+namespace topology above and asserts the IS-IS SR adjacencies, the
+SR-MPLS ILM entries, the intra-AS VPNv4 sessions, the single-hop inter-AS
+eBGP VPNv4 sessions, **every VPN prefix in both ASBRs' `vrf-cust` tables**
+(the per-VRF state that distinguishes AB from B), the far-PE VRF import,
+and an end-to-end CE-to-CE ping in both directions. The ASBRs lower their
+MRAI so the inter-AS VPNv4 relay converges promptly.

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -2264,6 +2264,10 @@ impl Bgp {
             super::vrf_config::config_vrf_encapsulation,
         );
         self.callback_add(
+            "/router/bgp/vrf/inter-as-hybrid",
+            super::vrf_config::config_vrf_inter_as_hybrid,
+        );
+        self.callback_add(
             "/router/bgp/vrf/neighbor",
             super::vrf_config::config_vrf_neighbor,
         );

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -278,6 +278,36 @@ pub(crate) fn import_targets_v6(
         .collect()
 }
 
+/// Inter-AS Option AB: does the route's RT fall in the import set of any
+/// `inter-as-hybrid` VRF? Such a received route is propagated only by
+/// that VRF's re-export (an `Originated` row with next-hop-self), so the
+/// receive path marks it [`super::route::BgpRib::vrf_transit_only`] and
+/// the advertise path suppresses the transparent relay — otherwise the
+/// same prefix would reach a peer under several RDs and thrash the
+/// prefix-keyed VRF import.
+pub(crate) fn rt_imported_by_hybrid_vrf_v4(
+    vrf_index: &BTreeMap<String, RibKnownVrf>,
+    ecom: &Option<bgp_packet::ExtCommunity>,
+) -> bool {
+    let route_rts = route_rts_from_ecom(ecom);
+    !route_rts.is_empty()
+        && vrf_index
+            .values()
+            .any(|info| info.inter_as_hybrid && !info.import_rts_v4.is_disjoint(&route_rts))
+}
+
+/// VPNv6 counterpart of [`rt_imported_by_hybrid_vrf_v4`].
+pub(crate) fn rt_imported_by_hybrid_vrf_v6(
+    vrf_index: &BTreeMap<String, RibKnownVrf>,
+    ecom: &Option<bgp_packet::ExtCommunity>,
+) -> bool {
+    let route_rts = route_rts_from_ecom(ecom);
+    !route_rts.is_empty()
+        && vrf_index
+            .values()
+            .any(|info| info.inter_as_hybrid && !info.import_rts_v6.is_disjoint(&route_rts))
+}
+
 /// Kernel VRF master info as observed by `Bgp` via
 /// `RibRx::VrfAdd` and the matching RT sets observed via
 /// `RibRx::VrfRouteTargets`. Used by
@@ -294,6 +324,13 @@ pub struct RibKnownVrf {
     pub export_rts_v4: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
     pub import_rts_v6: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
     pub export_rts_v6: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
+    /// Inter-AS Option AB: copied from the VRF's BGP config
+    /// (`inter_as_hybrid`). Lets the shared VPNv4/VPNv6 receive path
+    /// (which only borrows `rib_known_vrfs`, not the config map) tell
+    /// whether a route's RT is imported by a hybrid VRF — and therefore
+    /// must be propagated only via that VRF's re-export, not transparently
+    /// relayed. See [`super::route::BgpRib::vrf_transit_only`].
+    pub inter_as_hybrid: bool,
 }
 
 pub struct Bgp {
@@ -1913,6 +1950,11 @@ impl Bgp {
                         .as_ref()
                         .map(|p| p.export_rts_v6.clone())
                         .unwrap_or_default(),
+                    inter_as_hybrid: self
+                        .vrfs
+                        .get(&name)
+                        .map(|c| c.inter_as_hybrid)
+                        .unwrap_or(false),
                 };
                 self.rib_known_vrfs.insert(name.clone(), entry);
                 // If the operator already committed `router bgp vrf
@@ -1946,12 +1988,18 @@ impl Bgp {
                 // them as separate messages and a slow
                 // `tokio::select!` could draw the RT message ahead
                 // of the VrfAdd).
+                let hybrid = self
+                    .vrfs
+                    .get(&name)
+                    .map(|c| c.inter_as_hybrid)
+                    .unwrap_or(false);
                 let entry = self.rib_known_vrfs.entry(name.clone()).or_default();
                 let export_v4_changed = entry.export_rts_v4 != ipv4_export_rts;
                 entry.import_rts_v4 = ipv4_import_rts;
                 entry.export_rts_v4 = ipv4_export_rts;
                 entry.import_rts_v6 = ipv6_import_rts;
                 entry.export_rts_v6 = ipv6_export_rts;
+                entry.inter_as_hybrid = hybrid;
                 // Close the export / RT-learning race: a per-VRF route can
                 // be exported into `v4vpn` before this RT policy lands (the
                 // export reads `rib_known_vrfs` at emit time), leaving the
@@ -2910,6 +2958,7 @@ impl Bgp {
                     egress_ifindex_v6: None,
                     stale: false,
                     esi: None,
+                    vrf_transit_only: false,
                 };
 
                 let (_, selected, _gen) = self.local_rib.update(Some(rd), prefix, rib);
@@ -3186,6 +3235,7 @@ impl Bgp {
                     egress_ifindex_v6: None,
                     stale: false,
                     esi: None,
+                    vrf_transit_only: false,
                 };
 
                 let (_, selected, _gen) = self.local_rib.update_v6vpn(rd, prefix, rib);
@@ -3672,6 +3722,7 @@ mod tests {
                 export_rts_v4: BTreeSet::new(),
                 import_rts_v6: BTreeSet::new(),
                 export_rts_v6: BTreeSet::new(),
+                inter_as_hybrid: false,
             }
         }
 
@@ -3687,6 +3738,7 @@ mod tests {
                 export_rts_v4: BTreeSet::new(),
                 import_rts_v6,
                 export_rts_v6: BTreeSet::new(),
+                inter_as_hybrid: false,
             }
         }
 

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -827,6 +827,14 @@ pub struct BgpRib {
     pub stale: bool,
     // EVPN ESI (Ethernet Segment Identifier) for multi-homing.
     pub esi: Option<[u8; 10]>,
+    /// Inter-AS Option AB: a received VPNv4/VPNv6 route whose RT is
+    /// imported by a local `inter-as-hybrid` VRF. Such a route is
+    /// propagated only by that VRF's re-export (an `Originated` row with
+    /// the VRF's RD + next-hop-self), never transparently relayed — so it
+    /// must NOT be advertised to peers directly. Set once at receive
+    /// (`route_ipv4_update` / `route_ipv6_update`); `route_update_ipv4` /
+    /// `…ipv6` suppress the advertise. Default `false` (ordinary route).
+    pub vrf_transit_only: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -891,6 +899,7 @@ impl BgpRib {
             egress_ifindex_v6: None,
             stale,
             esi: None,
+            vrf_transit_only: false,
         }
     }
 
@@ -2125,6 +2134,18 @@ pub fn route_ipv4_update(
             .lu_labels
             .as_mut()
             .and_then(|ll| ll.label_vpn_v4(rd, nlri.prefix));
+    }
+    // Inter-AS Option AB: a received VPNv4 route an `inter-as-hybrid` VRF
+    // imports is relayed only by that VRF's re-export (Originated,
+    // next-hop-self), never transparently — mark it so the advertise path
+    // suppresses it, otherwise the same prefix would reach a peer under
+    // several RDs and thrash the prefix-keyed VRF import.
+    if rd.is_some()
+        && !rib.is_originated()
+        && let Some(disp) = bgp.vrf_import
+        && super::inst::rt_imported_by_hybrid_vrf_v4(disp.rib_known_vrfs, &rib.attr.ecom)
+    {
+        rib.vrf_transit_only = true;
     }
     let (replaced, selected, next_id) = bgp.local_rib.update(rd, nlri.prefix, rib.clone());
     // If this update changed the path's next-hop, the displaced row's
@@ -3385,6 +3406,15 @@ pub fn route_ipv6_update(
     // Kept for the rd==Some import-dispatch withdraw branch (the rib
     // itself is moved into `update_v6vpn` below); cheap Arc bump.
     let import_attr = rib.attr.clone();
+    // Inter-AS Option AB (VPNv6): mark a route a hybrid VRF imports as
+    // transit-only — relayed only via the VRF re-export (see the v4 path).
+    if rd.is_some()
+        && !rib.is_originated()
+        && let Some(disp) = bgp.vrf_import
+        && super::inst::rt_imported_by_hybrid_vrf_v6(disp.rib_known_vrfs, &rib.attr.ecom)
+    {
+        rib.vrf_transit_only = true;
+    }
     let (replaced, selected, _next_id) = match rd {
         Some(rd) => bgp.local_rib.update_v6vpn(rd, nlri.prefix, rib),
         None => bgp.local_rib.update_v6(nlri.prefix, rib),
@@ -5967,6 +5997,13 @@ pub fn route_update_ipv4(
         return None;
     }
 
+    // Inter-AS Option AB: a received VPNv4 route an `inter-as-hybrid` VRF
+    // imports is relayed only by that VRF's re-export (an Originated row,
+    // built separately), never transparently — suppress the direct relay.
+    if rib.vrf_transit_only {
+        return None;
+    }
+
     // iBGP to iBGP: Don't advertise iBGP-learned routes except the peer is
     // route reflector client.
     if peer.peer_type == PeerType::IBGP
@@ -6104,6 +6141,11 @@ pub fn route_update_ipv6(
 ) -> Option<(Ipv6Nlri, BgpAttr)> {
     // Split-horizon: never send a route back to its source peer.
     if rib.ident == peer.ident {
+        return None;
+    }
+    // Inter-AS Option AB: a VPNv6 route a hybrid VRF imports is relayed
+    // only via that VRF's re-export, never transparently (see the v4 path).
+    if rib.vrf_transit_only {
         return None;
     }
     // iBGP→iBGP: don't re-advertise iBGP-learned routes to iBGP peers

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -80,6 +80,16 @@ pub struct BgpVrf {
     /// VRF; the matching AF_MPLS ILM pops this label and routes
     /// the inner packet into `vrf_tables[table_id]`.
     pub label: u32,
+    /// Inter-AS MPLS/VPN Option AB (`inter-as-hybrid`). When set, this
+    /// VRF re-exports the VPNv4 routes it *imports* (not just `network`/
+    /// CE-learned routes) back into the global VPNv4 table, so an ASBR
+    /// can relay a remote AS's VPN routes to its own PEs (and the other
+    /// ASBR) over a single MP-eBGP VPNv4 session while still forwarding
+    /// per-VRF (the VPN label terminates at the ASBR → VRF lookup). The
+    /// re-import loop is broken by `dispatch_import_v4`'s `skip_vrf` (the
+    /// originating VRF is excluded) and by eBGP AS-path. Off by default,
+    /// so non-hybrid VRF behaviour is unchanged.
+    pub inter_as_hybrid: bool,
     /// Dedup pool for `BgpAttr` instances seen by this VRF's
     /// peers. Every per-VRF runtime gets its own pool (cheaper
     /// than threading a shared lock across the `!Send` boundary,
@@ -144,6 +154,20 @@ pub struct VrfExporter {
 /// "no per-VRF label allocated" — the global handler treats it as
 /// "skip the per-route install" rather than emit an
 /// explicit-null label.
+/// Drop every Route-Target extended community (RFC 4360 sub-type 0x02)
+/// from a clone of `attr`. Used on the Inter-AS Option AB re-export path:
+/// a route imported into a hybrid VRF carries the RTs it matched on, but
+/// the re-originated route must carry only *this* VRF's export RTs (the
+/// global Export handler re-tags). Without the strip the same RT would
+/// accumulate one copy per inter-AS hop.
+fn attr_without_route_targets(attr: &bgp_packet::BgpAttr) -> bgp_packet::BgpAttr {
+    let mut a = attr.clone();
+    if let Some(ref mut ecom) = a.ecom {
+        ecom.0.retain(|v| v.low_type != 0x02);
+    }
+    a
+}
+
 pub fn vrf_emit_export(exporter: &VrfExporter, prefix: ipnet::Ipv4Net, attr: &bgp_packet::BgpAttr) {
     let _ = exporter.tx.send(BgpGlobalMsg::Export {
         vrf: exporter.name.clone(),
@@ -340,6 +364,8 @@ impl BgpVrf {
             rx,
             asn,
             label,
+            // Default off; `spawn_bgp_vrf` sets it from the VRF config.
+            inter_as_hybrid: false,
             attr_store: BgpAttrStore::new(),
             update_groups: super::super::update_group::empty_map(),
             interface_addrs: InterfaceAddrs::new(),
@@ -543,6 +569,7 @@ impl BgpVrf {
             egress_ifindex_v6: None,
             stale: false,
             esi: None,
+            vrf_transit_only: false,
         };
 
         let (_, selected, _gen) = self.local_rib.update(None, prefix, rib);
@@ -594,6 +621,28 @@ impl BgpVrf {
         // neither. The VRF-bound `ctx.rib` lands it in the VRF table;
         // a placeholder (no-kernel) context's parked client no-ops.
         super::super::route::fib_install_v4(&top, prefix, &selected);
+
+        // Inter-AS Option AB: relay this imported route back into the
+        // global VPNv4 table (toward our PEs and the peer ASBR over the
+        // single MP-eBGP session). Ordinary VRFs leave `inter_as_hybrid`
+        // off and never re-export an import — the explicit hook here is
+        // needed because the import path bypasses `route_update_ipv4`,
+        // where the normal VRF→global export fires. The re-import loop is
+        // broken by `dispatch_import_v4`'s `skip_vrf` (this VRF is
+        // excluded from its own export's fan-out) and by eBGP AS-path.
+        if self.inter_as_hybrid {
+            let exporter = VrfExporter {
+                name: self.name.clone(),
+                tx: self.global_tx.clone(),
+                label: self.label,
+            };
+            match selected.first() {
+                Some(winner) => {
+                    vrf_emit_export(&exporter, prefix, &attr_without_route_targets(&winner.attr))
+                }
+                None => vrf_emit_withdraw(&exporter, prefix),
+            }
+        }
 
         tracing::info!(
             vrf = %self.name,
@@ -655,6 +704,23 @@ impl BgpVrf {
         // no winner left, `fib_install_v4` emits the withdraw. (The old
         // code unconditionally deleted, dropping a now-winning CE route.)
         super::super::route::fib_install_v4(&top, prefix, &selected);
+
+        // Inter-AS Option AB: mirror `handle_import_v4` — re-export the
+        // replacement winner, or withdraw the global VPNv4 row when the
+        // last candidate is gone.
+        if self.inter_as_hybrid {
+            let exporter = VrfExporter {
+                name: self.name.clone(),
+                tx: self.global_tx.clone(),
+                label: self.label,
+            };
+            match selected.first() {
+                Some(winner) => {
+                    vrf_emit_export(&exporter, prefix, &attr_without_route_targets(&winner.attr))
+                }
+                None => vrf_emit_withdraw(&exporter, prefix),
+            }
+        }
 
         tracing::info!(
             vrf = %self.name,
@@ -721,6 +787,7 @@ impl BgpVrf {
             egress_ifindex_v6: None,
             stale: false,
             esi: None,
+            vrf_transit_only: false,
         };
 
         let (_, selected, _gen) = self.local_rib.update_v6(prefix, rib);
@@ -760,6 +827,22 @@ impl BgpVrf {
 
         // Single VRF FIB install path (see `handle_import_v4`).
         super::super::route::fib_install_v6(&top, prefix, &selected);
+
+        // Inter-AS Option AB (VPNv6): re-export the imported route — see
+        // `handle_import_v4`.
+        if self.inter_as_hybrid {
+            let exporter = VrfExporter {
+                name: self.name.clone(),
+                tx: self.global_tx.clone(),
+                label: self.label,
+            };
+            match selected.first() {
+                Some(winner) => {
+                    vrf_emit_export_v6(&exporter, prefix, &attr_without_route_targets(&winner.attr))
+                }
+                None => vrf_emit_withdraw_v6(&exporter, prefix),
+            }
+        }
 
         tracing::info!(
             vrf = %self.name,
@@ -813,6 +896,22 @@ impl BgpVrf {
 
         // Reconcile against the new best-path (see `handle_withdraw_import`).
         super::super::route::fib_install_v6(&top, prefix, &selected);
+
+        // Inter-AS Option AB (VPNv6): re-export the replacement winner or
+        // withdraw the global row — see `handle_withdraw_import`.
+        if self.inter_as_hybrid {
+            let exporter = VrfExporter {
+                name: self.name.clone(),
+                tx: self.global_tx.clone(),
+                label: self.label,
+            };
+            match selected.first() {
+                Some(winner) => {
+                    vrf_emit_export_v6(&exporter, prefix, &attr_without_route_targets(&winner.attr))
+                }
+                None => vrf_emit_withdraw_v6(&exporter, prefix),
+            }
+        }
 
         tracing::info!(
             vrf = %self.name,

--- a/zebra-rs/src/bgp/vrf/spawn.rs
+++ b/zebra-rs/src/bgp/vrf/spawn.rs
@@ -161,6 +161,9 @@ pub fn spawn_bgp_vrf(
         label,
         global_tx,
     );
+    // Inter-AS Option AB: re-export imported VPNv4 routes (see the field
+    // doc on `BgpVrf`). Carried from the staged VRF config.
+    vrf.inter_as_hybrid = cfg.inter_as_hybrid;
 
     // Materialise per-VRF peers from the BgpVrfConfig snapshot.
     // `peer.start()`'s timer events get logged at debug and
@@ -380,6 +383,7 @@ fn materialize_self_originated_networks(vrf: &mut BgpVrf, cfg: &BgpVrfConfig) ->
             egress_ifindex_v6: None,
             stale: false,
             esi: None,
+            vrf_transit_only: false,
         };
 
         let (_, selected, _) = vrf.local_rib.update(None, *prefix, rib);

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -137,6 +137,13 @@ pub struct BgpVrfConfig {
     pub evpn_advertise_v4: bool,
     /// Advertise this VRF's IPv6 routes as EVPN Type-5 (RFC 9136).
     pub evpn_advertise_v6: bool,
+    /// Inter-AS MPLS/VPN Option AB (RFC 4364 hybrid of §10a/§10b).
+    /// Mirrors `inter-as-hybrid` in zebra-bgp-vrf.yang. When set, the
+    /// VRF re-exports the VPNv4 routes it *imports* (not only `network`/
+    /// CE-learned ones), so an ASBR relays a remote AS's VPN routes to
+    /// its own PEs over a single MP-eBGP VPNv4 session while still
+    /// forwarding per-VRF. Default `false` (ordinary L3VPN VRF).
+    pub inter_as_hybrid: bool,
 }
 
 /// Borrow-or-create the per-VRF entry on `Bgp::vrfs`. Used by every
@@ -213,6 +220,20 @@ pub fn config_vrf_encapsulation(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
             cfg.encapsulation = BgpVrfEncapsulation::parse(&raw)?;
         }
         ConfigOp::Delete => cfg.encapsulation = BgpVrfEncapsulation::default(),
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp vrf <NAME> inter-as-hybrid <BOOL>` — RFC 4364
+/// Inter-AS Option AB. Enables re-export of imported VPNv4 routes for
+/// this VRF (see [`BgpVrfConfig::inter_as_hybrid`]).
+pub fn config_vrf_inter_as_hybrid(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let cfg = vrf_entry(bgp, name);
+    match op {
+        ConfigOp::Set => cfg.inter_as_hybrid = args.boolean()?,
+        ConfigOp::Delete => cfg.inter_as_hybrid = false,
         _ => {}
     }
     Some(())

--- a/zebra-rs/yang/zebra-bgp-vrf.yang
+++ b/zebra-rs/yang/zebra-bgp-vrf.yang
@@ -297,6 +297,22 @@ module zebra-bgp-vrf {
           "VPN data-plane encapsulation for routes originated from /
            imported into this VRF.";
       }
+      leaf inter-as-hybrid {
+        type boolean;
+        default "false";
+        description
+          "RFC 4364 Inter-AS MPLS/VPN Option AB. When true, this VRF
+           re-exports the VPNv4 routes it imports (not only `network`/
+           CE-learned routes) back into the global VPNv4 table. An ASBR
+           configured this way relays a remote AS's VPN routes to its own
+           PEs (and the peer ASBR) over a single MP-eBGP VPNv4 session,
+           while the VPN label still terminates at the ASBR and the
+           packet is forwarded per-VRF (combining the per-VPN control of
+           Option A with the single-session scale of Option B). The
+           re-import loop is broken by excluding the originating VRF from
+           the import fan-out and by eBGP AS-path. Default false leaves an
+           ordinary intra-AS L3VPN VRF unchanged.";
+      }
       container evpn {
         description
           "EVPN (RFC 9136 Type-5 / IP Prefix) service for this VRF.


### PR DESCRIPTION
## Summary

Implements **Inter-AS MPLS/VPN Option AB** — the Cisco hybrid of RFC 4364
§10a/§10b. The ASBRs keep a per-VPN **VRF** and forward through it (the
VPN label terminates at the ASBR → VRF lookup → re-impose, like Option A),
but exchange every VPN over a **single MP-eBGP VPNv4 session** on one
labelled link (like Option B). Enabled per VRF with `inter-as-hybrid`.

The data path reuses the existing per-VRF `DecapVrf` ILM + VRF FIB
install; VPNv4 re-origination and the loop guards (the import dispatcher's
skip-self and eBGP AS-path) already existed. New pieces — all gated on
`inter-as-hybrid`, so non-hybrid VRFs are byte-for-byte unchanged:

| Area | Change |
|---|---|
| `vrf_config.rs`, `vrf/inst.rs`, `vrf/spawn.rs`, YANG | Per-VRF `inter-as-hybrid` knob. When set, `handle_import_v4/v6` re-export the routes the VRF *imports* (not only `network`/CE-learned ones), so the ASBR relays a remote AS's prefixes to its PEs (and the peer ASBR) over the one session. |
| `bgp/route.rs`, `bgp/inst.rs` | **Suppress the transparent relay** of a received VPNv4/VPNv6 route a hybrid VRF imports (new `BgpRib.vrf_transit_only`, set at receive from `RibKnownVrf.inter_as_hybrid`, honoured in `route_update_ipv4/ipv6`). The ASBR re-originates from the VRF instead. Without this the prefix reaches the next node under two RDs; since a VRF IP table is prefix-keyed, they collide and the import thrashes. |
| `vrf/inst.rs` | Strip inherited Route-Targets on re-export so the re-originated route carries only the VRF's export RTs, not one copy per inter-AS hop. |

The ASBR's transit `vrf-cust` has no interface and no CE — the top-level
`vrf:` block alone creates the kernel VRF device, so `DecapVrf` installs.

## Test plan

- `make -C bdd bgp_interas_option_ab` — **6/6 scenarios, 77/77 steps**
  (repeatable), including the end-to-end CE1↔CE2 pings in both directions
  and both prefixes in each ASBR's `vrf-cust` (the per-VRF state that
  distinguishes AB from B).
- `make -C bdd bgp_interas_option_a` (6/6), `bgp_interas_option_b` (6/6),
  `bgp_interas_option_c` (7/7) — still green (the change touches the
  shared VPNv4 advertise/receive path but is gated on `inter-as-hybrid`).
- `cargo test --workspace --exclude bdd` — **1456 passed, 0 failed**.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- `mdbook build` (book/) — clean; adds a fourth row to the Inter-AS
  comparison table and a dedicated Option AB chapter.

Generated with [Claude Code](https://claude.com/claude-code)
