### PR TITLE
docs(bdd): add generated feature docs and update bgp_vrf_show

### DIFF
--- a/bdd/docs/bgp_allowas_in.md
+++ b/bdd/docs/bgp_allowas_in.md
@@ -1,0 +1,41 @@
+# BGP allowas-in relaxes the inbound AS_PATH loop check
+
+## Overview
+
+As a network operator
+I want `neighbor X allowas-in [count <1-10>|origin]`
+So a neighbor can accept routes whose AS_PATH already contains my AS.
+
+## Test Topology
+
+```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐  192.168.1.0/24  ┌─────────┐
+   │   z1    │ i1────────────i1 │   z2    │ i2────────────i1 │   z3    │
+   │ AS65001 │                  │ AS65002 │                  │ AS65001 │
+   │ .0.1    │                  │.0.2 .1.2│                  │ .1.3    │
+   └─────────┘                  └─────────┘                  └─────────┘
+```
+
+## Notes
+
+z1 originates 10.0.0.1/32. It reaches z2 with AS_PATH "65001", and z2
+re-advertises it to z3 with AS_PATH "65002 65001". Because z3 is also
+AS 65001, the RFC 4271 inbound loop check drops it — unless z3 has
+`allowas-in` configured on the session toward z2.
+
+## Config Files
+
+- z1.yaml / z2.yaml: static line topology, z1 originates 10.0.0.1/32
+- z3-base.yaml:    z3 without allowas-in (strict loop check)
+- z3-allowas.yaml: z3 with bare `allowas-in` (default count 3)
+- z3-origin.yaml:  z3 with `allowas-in origin`
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup line topology and establish all sessions | |
+| Default RFC 4271 loop check drops the route at z3 | |
+| allowas-in lets z3 accept the looped route | |
+| allowas-in origin mode accepts the route and shows in neighbor output | |
+| Teardown topology | |

--- a/bdd/docs/bgp_as_override.md
+++ b/bdd/docs/bgp_as_override.md
@@ -1,0 +1,43 @@
+# BGP as-override rewrites the peer AS on egress so a shared-AS neighbor accepts the route
+
+## Overview
+
+As a network operator
+I want `neighbor X as-override`
+So a neighbor that reuses an AS already in the AS_PATH still accepts my routes.
+
+## Test Topology
+
+```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐  192.168.1.0/24  ┌─────────┐
+   │   z1    │ i1────────────i1 │   z2    │ i2────────────i1 │   z3    │
+   │ AS65001 │                  │ AS65002 │                  │ AS65001 │
+   │ .0.1    │                  │.0.2 .1.2│                  │ .1.3    │
+   └─────────┘                  └─────────┘                  └─────────┘
+```
+
+## Notes
+
+z1 originates 10.0.0.1/32. It reaches z2 with AS_PATH "65001". When z2
+re-advertises it to z3 it would normally prepend its own AS, giving
+"65002 65001"; because z3 is also AS 65001 the RFC 4271 loop check
+drops it. With `as-override` on z2's session toward z3, z2 first
+rewrites z3's AS (65001) in the path to its own (65002), so z3 sees
+"65002 65002" and accepts the route. This is the send-side counterpart
+to `allowas-in`.
+
+## Config Files
+
+- z1.yaml:           z1 originates 10.0.0.1/32
+- z3.yaml:           z3 plain (strict loop check, no allowas-in)
+- z2-base.yaml:      z2 without as-override
+- z2-override.yaml:  z2 with `as-override` toward 192.168.1.3
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup line topology and establish all sessions | |
+| Without as-override the RFC 4271 loop check drops the route at z3 | |
+| as-override rewrites z3's AS on egress so z3 accepts the route | |
+| Teardown topology | |

--- a/bdd/docs/bgp_disable_connected_check.md
+++ b/bdd/docs/bgp_disable_connected_check.md
@@ -1,0 +1,47 @@
+# BGP disable-connected-check (eBGP connected-network check)
+
+## Overview
+
+As a network operator
+I want a single-hop eBGP session over loopback addresses to be held down
+by default (the neighbor is not on a directly-connected subnet) and to
+come up once `disable-connected-check` is set, confirming both the check
+and its override end-to-end.
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65002 │
+           │ 10.0.0. │     │ 10.0.0. │
+           │  1/24   │     │  2/24   │
+           │ lo .255 │     │ lo .255 │
+           │  .0.1/32│     │  .0.2/32│
+           └─────────┘     └─────────┘
+```
+
+## Notes
+
+z1 and z2 are directly connected at layer 2 over br0 (10.0.0.0/24), but
+peer eBGP using their loopbacks (10.255.0.1 ↔ 10.255.0.2), each reachable
+only via a static route — so neither peering address is on a connected
+subnet. A TTL-1 packet still reaches the L2-adjacent peer, so the only
+thing standing between the two routers is the connected check.
+
+## Config Files
+
+- z{1,2}-base.yaml: loopback peering, no disable-connected-check.
+- z{1,2}-disable.yaml: same, plus `disable-connected-check`.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| The connected check holds a loopback eBGP session down | |
+| disable-connected-check brings the loopback eBGP session up | |
+| Teardown topology | |

--- a/bdd/docs/bgp_ebgp_multihop.md
+++ b/bdd/docs/bgp_ebgp_multihop.md
@@ -1,0 +1,44 @@
+# BGP eBGP multihop TTL (RFC 4271)
+
+## Overview
+
+As a network operator
+I want to configure `ebgp-multihop` on an eBGP neighbor so that a peer
+more than one hop away can be reached, and confirm the option is
+accepted end-to-end and does not break a session.
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+```
+
+## Config Files
+
+- z1-1.yaml: AS 65001, neighbor 192.168.0.2 with `ebgp-multihop 5`.
+- z2-1.yaml: AS 65002, neighbor 192.168.0.1 with `ebgp-multihop 5`.
+
+Scope note: a genuine multi-hop test (peer behind a router, where the
+default eBGP TTL of 1 would be dropped and `ebgp-multihop` is required)
+needs a forwarding middle node, which the bridge-based harness cannot
+build. This scenario validates the YANG/dispatch path (`ebgp-multihop:
+5` is parsed and applied) and that raising the egress TTL to 5 does not
+break a directly-connected session. The default-TTL-1 directly-
+connected case is covered by @bgp_basic_ebgp, and the egress-TTL
+resolution itself is unit-tested (`session_ttl`).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| A directly-connected eBGP session establishes with ebgp-multihop set | |
+| Teardown topology | |

--- a/bdd/docs/bgp_enforce_first_as.md
+++ b/bdd/docs/bgp_enforce_first_as.md
@@ -1,0 +1,45 @@
+# BGP enforce-first-as drops inbound updates whose AS_PATH does not start with the peer AS
+
+## Overview
+
+As a network operator
+I want `neighbor X enforce-first-as`
+So a peer that forwards routes without prepending its own AS first is not trusted.
+
+## Test Topology
+
+```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐
+   │   z1    │ i1────────────i1 │   z2    │
+   │ AS65001 │                  │ AS65002 │
+   │  .0.1   │                  │  .0.2   │
+   └─────────┘                  └─────────┘
+   originates 10.0.0.1/32
+```
+
+## Notes
+
+z1 originates 10.0.0.1/32. It also runs an outbound route-map toward z2
+that prepends a *foreign* AS (65099). zebra-rs applies the mandatory
+eBGP local-AS prepend first ("65001"), then the route-map prepend lands
+65099 left-most, so z2 receives AS_PATH "65099 65001". The left-most AS
+is 65099, not z1's own AS 65001.
+Normally z2 accepts that route (AS 65002 is not in the path, so there is
+no loop). With `enforce-first-as` on z2's session toward z1, z2 instead
+requires the left-most AS to be the peer's own AS (65001) and discards
+the update because it starts with 65099.
+
+## Config Files
+
+- z1.yaml:          z1 originates 10.0.0.1/32, prepends foreign AS 65099 on egress
+- z2-base.yaml:     z2 without enforce-first-as (accepts the route)
+- z2-enforce.yaml:  z2 with `enforce-first-as` toward 192.168.0.1
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup the topology and establish the session | |
+| Without enforce-first-as z2 accepts the foreign-first-AS route | |
+| With enforce-first-as z2 drops the route | |
+| Teardown topology | |

--- a/bdd/docs/bgp_interas_option_a.md
+++ b/bdd/docs/bgp_interas_option_a.md
@@ -1,0 +1,45 @@
+# Inter-AS MPLS/VPN Option A over SR-MPLS (RFC 4364 §10a)
+
+## Overview
+
+As a service provider running L3VPN across two autonomous systems
+I want Inter-AS Option A: the ASBRs are back-to-back PEs joined by a
+per-VPN VRF interface, over which they run a PE-CE eBGP session inside
+the VRF. The VPN label terminates at each ASBR — the inter-AS link
+carries plain IP inside the VRF — and each AS runs an ordinary intra-AS
+L3VPN (PE↔ASBR VPNv4 over an SR-MPLS core).
+
+## Test Topology
+
+```
+            AS 65000                              AS 65001
+   ce1 ── pe1 ──── p1 ──── asbr1 ─── asbr2 ──── p2 ──── pe2 ── ce2
+          lo        lo       lo  172.16  lo      lo      lo
+       1.1.1.1   1.1.1.2  1.1.1.3 .0.0/30 2.2.2.3 2.2.2.2 2.2.2.1
+   └ vrf-cust ┘          └ vrf ┘ (in VRF) └ vrf ┘       └ vrf-cust ┘
+    10.1.0.0/30                                         10.2.0.0/30
+```
+
+## Notes
+
+- Intra-AS: IS-IS L2 + segment-routing mpls; VPNv4 iBGP PE↔ASBR over
+  the SR-MPLS core (the PE loopback next-hop is resolved by the IGP —
+  no BGP-LU). ASBR1 and PE1 are both PEs of AS 65000; likewise AS 65001.
+- Inter-AS (asbr1↔asbr2, 172.16.0.0/30): the link is in `vrf-cust` on
+  both ASBRs (NOT in the IGP). They run a **PE-CE eBGP session inside
+  vrf-cust**. Routes learned there are re-exported to VPNv4; imported
+  VPNv4 routes are advertised over it. Plain IP on the wire.
+- A CE→CE packet is VPN-labeled PE→ASBR, decapsulated to plain IP at
+  the ASBR, forwarded over the inter-AS VRF link, then re-labeled
+  ASBR→PE in the far AS.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the Inter-AS Option A topology and bring up every session | |
+| SR-MPLS transport LSPs are installed on the core P routers | |
+| The customer prefixes cross the AS boundary via the per-VRF PE-CE eBGP | |
+| Each PE imports the remote-AS customer prefix into its VRF | |
+| End-to-end customer forwarding across the AS boundary (VPN + back-to-back VRF) | |
+| Teardown topology | |

--- a/bdd/docs/bgp_interas_option_c.md
+++ b/bdd/docs/bgp_interas_option_c.md
@@ -1,0 +1,55 @@
+# Inter-AS MPLS/VPN Option C over SR-MPLS (RFC 4364 §10c)
+
+## Overview
+
+As a service provider running L3VPN across two autonomous systems
+I want Inter-AS Option C: the ASBRs exchange only labeled IPv4 (BGP-LU)
+for the PE loopbacks and hold no VPN state, while the PEs run a direct
+multihop MP-eBGP VPNv4 session whose next-hop (the remote PE loopback)
+is resolved across the AS boundary through the BGP-LU LSP, with SR-MPLS
+providing the intra-AS transport.
+This mirrors Cisco's "Configuration and Verification of L3 MPLS VPN
+Inter-AS Option C" (doc 200523), streamlined to one PE + one P + one
+ASBR per AS and a direct PE↔PE VPNv4 session (no route reflector — the
+originating PE's next-hop-self is already the correct egress, so no
+next-hop-unchanged is needed; the ASBR→PE iBGP-LU leg uses next-hop-self
+instead).
+
+## Test Topology
+
+```
+            AS 65000                              AS 65001
+   ce1 --- pe1 --- p1 --- asbr1 ===== asbr2 --- p2 --- pe2 --- ce2
+  10.1.0.2 lo       lo     lo   172.16  lo       lo     lo   10.2.0.2
+        1.1.1.1 1.1.1.2 1.1.1.3 .0.0/30 2.2.2.3 2.2.2.2 2.2.2.1
+        (sid 1) (sid 2) (sid 3)         (sid 6) (sid 5) (sid 4)
+   \__vrf-cust_/                                       \_vrf-cust__/
+     10.1.0.0/30                                         10.2.0.0/30
+```
+
+## Notes
+
+- Intra-AS: IS-IS L2 + segment-routing mpls; loopback Prefix-SIDs give
+  the transport LSP (SRGB base 16000 → labels 16001..16006). P routers
+  perform the real SR transit swap / PHP.
+- Inter-AS (asbr1↔asbr2, 172.16.0.0/30): eBGP labeled-unicast only —
+  PE loopback /32s exchanged with labels, no IGP, no VPN state.
+- ASBR↔PE (intra-AS): iBGP labeled-unicast with next-hop-self, so the
+  PE resolves the ASBR (via IS-IS) and pushes the ASBR's swap label.
+- PE↔PE: multihop eBGP VPNv4 between loopbacks. The session itself
+  rides the BGP-LU LSP, so "Established" already proves end-to-end
+  labeled forwarding works before any data packet is sent.
+- The CE↔CE ping exercises the full label stack: SR transport (outer)
+  + BGP-LU (AS crossing) + VPN (innermost).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the Inter-AS Option C topology and bring up every session | |
+| SR-MPLS transport LSPs are installed on the core P routers | |
+| ASBRs exchange PE loopbacks via BGP labeled-unicast, holding no VPN state | |
+| Each PE learns the remote PE loopback through the BGP-LU chain | |
+| VPNv4 customer routes are exchanged directly between the PEs | |
+| End-to-end customer forwarding across the AS boundary (SR + BGP-LU + VPN) | |
+| Teardown topology | |

--- a/bdd/docs/bgp_remove_private_as.md
+++ b/bdd/docs/bgp_remove_private_as.md
@@ -1,0 +1,45 @@
+# BGP remove-private-as strips private ASNs from the egress AS_PATH
+
+## Overview
+
+As a network operator
+I want `neighbor X remove-private-as`
+So a downstream eBGP peer never learns the private internal AS numbers
+of my network.
+
+## Test Topology
+
+```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐  192.168.1.0/24  ┌─────────┐
+   │   z1    │ i1────────────i1 │   z2    │ i2────────────i1 │   z3    │
+   │ AS65001 │                  │ AS 100  │                  │ AS 200  │
+   │ .0.1    │                  │.0.2 .1.2│                  │ .1.3    │
+   └─────────┘                  └─────────┘                  └─────────┘
+   private AS                    public AS                    public AS
+```
+
+## Notes
+
+z1 originates 10.0.0.1/32; z2 learns it with AS_PATH "65001". When z2
+re-advertises it to z3 it normally prepends its own AS, sending
+"100 65001" — leaking z1's private AS 65001 to z3. With
+`remove-private-as` on z2's session toward z3, z2 strips the private
+65001 before prepending, so z3 receives just "100". The neighbor's own
+AS (z3's 200) would always be kept for loop prevention, but here it is
+not in the path.
+
+## Config Files
+
+- z1.yaml:          z1 (private AS 65001) originates 10.0.0.1/32
+- z3.yaml:          z3 plain
+- z2-base.yaml:     z2 without remove-private-as
+- z2-remove.yaml:   z2 with `remove-private-as` toward 192.168.1.3
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup line topology and establish all sessions | |
+| Without remove-private-as the private AS leaks to z3 | |
+| remove-private-as strips the private AS on egress to z3 | |
+| Teardown topology | |

--- a/bdd/docs/bgp_show.md
+++ b/bdd/docs/bgp_show.md
@@ -1,0 +1,44 @@
+# BGP show command tree (show bgp ...)
+
+## Overview
+
+As a network operator
+I want the new `show bgp [ipv4|ipv6] [<addr>|<prefix> [longer-prefix]]`
+command tree to render the BGP RIB, including the IPv4 shortcut where
+an address or prefix is typed straight after `show bgp` (no AFI keyword).
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬────────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+```
+
+## Notes
+
+z1 originates a covering prefix (10.0.0.0/24), a more-specific
+(10.0.0.128/25), and a host route (10.0.0.1/32) so the longest-match
+and longer-prefix views have a real prefix hierarchy to display. z2 is
+the receiver where the `show bgp ...` output is checked.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup topology and establish BGP session | |
+| Routes propagate to z2 | |
+| "show bgp" defaults to the IPv4 unicast table | |
+| "show bgp ipv4" renders the same IPv4 unicast table | |
+| "show bgp A.B.C.D" shortcut shows the longest match | |
+| "show bgp A.B.C.D/M" shortcut shows the exact prefix | |
+| "longer-prefix" shows the prefix and every more-specific entry | |
+| "show bgp ipv6" dispatches to the IPv6 unicast table | |
+| Teardown topology | |

--- a/bdd/docs/bgp_srv6_redistribute.md
+++ b/bdd/docs/bgp_srv6_redistribute.md
@@ -1,0 +1,44 @@
+# BGP IPv6 redistribute connected with SRv6 End.DT6 origination
+
+## Overview
+
+As a network operator
+I want a connected IPv6 prefix redistributed into BGP on an
+SRv6-enabled speaker to carry an SRv6 End.DT6 service SID, so a peer
+configured for `encapsulation-type srv6` accepts it and the route
+reaches the peer's BGP table as an SRv6 service route.
+
+## Test Topology
+
+```
+  ┌────────┐  i1 ──────── i1  ┌────────┐
+  │   z1   │──────────────────│   z2   │
+  │ AS65001│  2001:db8:12::/64│ AS65002│
+  │ LOC1   │                  │ encap- │
+  │ fcbb:1 │                  │ srv6   │
+  └────────┘                  └────────┘
+   cust0: 2001:db8:cafe::1/64 (connected, redistributed)
+```
+
+## Notes
+
+- z1 advertises SRv6 locator `LOC1` (fcbb:bbbb:1::/48) and enables
+  `segment-routing srv6 ipv6-unicast`, so locally-originated IPv6
+  unicast routes carry an End.DT6 SID carved from the locator.
+- z1 redistributes connected; the dummy `cust0` prefix
+  `2001:db8:cafe::/64` is originated into BGP with the SID stamped at
+  origination (visible as a "Local SID" in `show bgp ipv6`).
+- z2 peers eBGP over IPv6 and sets `encapsulation-type srv6` on the
+  session, so it only accepts SID-bearing routes; the redistributed
+  prefix arrives carrying the SID (shown as a "Remote SID").
+
+## Config Files
+
+- z1.yaml, z2.yaml
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Redistributed connected IPv6 route carries an End.DT6 Prefix-SID | |
+| Teardown topology | |

--- a/bdd/docs/bgp_tcp_mss.md
+++ b/bdd/docs/bgp_tcp_mss.md
@@ -1,0 +1,42 @@
+# BGP TCP MSS (neighbor tcp-mss)
+
+## Overview
+
+As a network operator
+I want to cap the TCP Maximum Segment Size of a BGP session so the
+daemon stays under a path MTU smaller than the interface MTU (a tunnel,
+an MPLS core, a link that cannot carry full-size frames) instead of
+stalling on a black-holed large UPDATE.
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+```
+
+## Config Files
+
+- z1-1.yaml: AS 65001, neighbor 192.168.0.2 with `tcp-mss 500`.
+- z2-1.yaml: AS 65002, neighbor 192.168.0.1 with `tcp-mss 500`.
+
+socket and the listening socket, so the kernel negotiates the reduced
+MSS. `getsockopt(TCP_MAXSEG)` reads back the negotiated value (the
+the 12-byte TCP timestamp option, so a configured 500 syncs to 488.
+Both ends must advertise the clamp for both to read it back, which is
+why both neighbors set `tcp-mss 500`.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Session establishes and reports configured and synced tcp-mss | |
+| Teardown topology | |

--- a/bdd/docs/bgp_ttl_security.md
+++ b/bdd/docs/bgp_ttl_security.md
@@ -1,0 +1,43 @@
+# BGP TTL Security / GTSM (RFC 5082)
+
+## Overview
+
+As a network operator
+I want to protect a directly-connected eBGP session with the
+Generalized TTL Security Mechanism (GTSM) so that only a peer one hop
+away — whose packets arrive with TTL 255 — can keep the session up.
+
+## Test Topology
+
+```
+  ┌─────────────────────────────────────────┐
+  │                   br0                    │
+  └─────────────┬───────────────┬───────────┘
+                │               │
+           ┌────┴────┐     ┌────┴────┐
+           │   z1    │     │   z2    │
+           │ AS65001 │     │ AS65002 │
+           │192.168. │     │192.168. │
+           │  0.1/24 │     │  0.2/24 │
+           └─────────┘     └─────────┘
+```
+
+## Config Files
+
+- z1-1.yaml: AS 65001, neighbor 192.168.0.2 WITH `ttl-security`.
+- z2-1.yaml: AS 65002, neighbor 192.168.0.1 WITHOUT `ttl-security`
+- z2-2.yaml: AS 65002, neighbor 192.168.0.1 WITH `ttl-security`
+- Asymmetric: z2 still sends at the default TTL (64). z1's minimum-TTL
+- Symmetric: once z2 also pins egress to 255, z1 accepts its packets
+
+GTSM sends BGP at TTL 255 and the kernel drops any segment that
+arrives below 255 (IP_MINTTL). A Linux bridge does not decrement TTL,
+so the two scenarios isolate the two halves of the mechanism:
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Asymmetric ttl-security keeps the session down | |
+| Enabling ttl-security on both ends establishes the session | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_show.md
+++ b/bdd/docs/bgp_vrf_show.md
@@ -29,5 +29,6 @@ Route Distinguisher / Route Target / MPLS label.
 |----------|--------|
 | Setup topology | |
 | Configure vrf-blue and observe via show | |
+| Inspect vrf-blue via the `show bgp vrf` tree | |
 | Remove vrf-blue and observe row drops | |
 | Teardown topology | |

--- a/bdd/docs/isis_afi_enable.md
+++ b/bdd/docs/isis_afi_enable.md
@@ -1,0 +1,40 @@
+# IS-IS re-originates its LSP when an interface address-family is toggled
+
+## Overview
+
+As a network operator
+I want enabling (or disabling) an address-family on an IS-IS interface to
+immediately update the self-originated LSP, so a newly-enabled prefix is
+advertised without waiting for the periodic LSP refresh.
+Regression: enabling IPv6 on a loopback that already had IPv4 enabled used
+to leave the loopback's IPv6 prefix out of the LSP, because re-origination
+only fired on a 0<->non-zero *global* protocols-supported (NLPID)
+transition — and the global IPv6 count was already non-zero thanks to the
+dual-stack backbone link. The fix re-originates on any per-interface AFI
+flip.
+
+## Test Topology
+
+```
+   a1 ───────────── a2
+   i2  10.0.12.0/30  i1
+       2001:db8:12::/64
+   lo 10.0.0.1/32      lo 10.0.0.2/32
+      2001:db8::1/128     2001:db8::2/128
+```
+
+## Notes
+
+Both routers are level-2-only and the a1–a2 link is dual-stack, so the
+global IPv6 interface count on a1 is already non-zero. a1's loopback starts
+with **only IPv4** enabled in IS-IS; its IPv6 address exists on the kernel
+interface but is not advertised. A later scenario enables IPv6 on a1's
+loopback at runtime and proves a2 then learns 2001:db8::1/128.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the topology — the IPv4 loopback is advertised, the IPv6 loopback is not | |
+| Enabling IPv6 on the loopback re-originates the LSP and advertises the prefix | |
+| Teardown topology | |

--- a/bdd/docs/isis_bfd_ipv4_lan.md
+++ b/bdd/docs/isis_bfd_ipv4_lan.md
@@ -1,0 +1,41 @@
+# IS-IS BFD over an IPv4 LAN (broadcast) link
+
+## Overview
+
+As a network operator running IS-IS over IPv4 broadcast segments
+I want BFD to protect each LAN adjacency
+So that a forwarding failure tears the adjacency down well within the IS-IS
+hold time, and the adjacency stays down (RFC 5882 hold-down) until BFD
+recovers — even while IIHs keep arriving.
+Same intent as the point-to-point feature, but the two routers share a Linux
+bridge (broadcast network type, DIS election). Per-neighbour single-hop BFD
+sessions are built from each end's IPv4 interface address (TLV 132). Each
+scenario is self-contained so the Echo scenarios arm echo-mode before the
+session first comes up.
+BFD-down is induced by dropping inbound UDP/3784 in one namespace: the link
+stays up and IIHs (L2 ISO PDUs, not IP/UDP) keep flowing, so a fast teardown
+is provably BFD's doing — not carrier loss, not the ~30s IS-IS hold timer.
+
+## Test Topology
+
+```
+  ┌────────────────────────────────────────┐
+  │                  br0                    │
+  └────────────┬───────────────┬───────────┘
+               │               │
+          10.0.1.1/24     10.0.1.2/24
+            (vz1ns)            (vz2ns)
+          ┌────┴────┐     ┌────┴────┐
+          │   z1    │     │   z2    │
+          └─────────┘     └─────────┘
+       lo 10.255.0.1      lo 10.255.0.2
+              /32                  /32
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| BFD without Echo protects the LAN adjacency and tears it down on BFD failure | |
+| BFD with Echo in one direction (z1 transmit, z2 receive) | |
+| BFD with Echo in both directions | |

--- a/bdd/docs/isis_bfd_ipv4_p2p.md
+++ b/bdd/docs/isis_bfd_ipv4_p2p.md
@@ -1,0 +1,35 @@
+# IS-IS BFD over an IPv4 point-to-point link
+
+## Overview
+
+As a network operator running IS-IS over IPv4 links
+I want BFD to protect the point-to-point adjacency
+So that a forwarding failure tears the adjacency down well within the IS-IS
+hold time, and the adjacency stays down (RFC 5882 hold-down) until BFD
+recovers — even while IIHs keep arriving.
+The single-hop BFD session is built from the two ends' IPv4 interface
+addresses (learned via TLV 132). Each scenario is self-contained (own setup
+and teardown) so the Echo scenarios configure echo-mode before the session
+first comes up (echo is armed at session establishment, not retrofitted).
+BFD-down is induced by dropping inbound UDP/3784 in one namespace: the link
+stays up and IIHs (L2 ISO PDUs, not IP/UDP) keep flowing, so a fast teardown
+is provably BFD's doing — not carrier loss, not the ~30s IS-IS hold timer.
+
+## Test Topology
+
+```
+     10.0.1.1/24                             10.0.1.2/24
+        (i1)                                   (i1)
+    ┌────┴────┐                            ┌────┴────┐
+    │   z1    │────────── P2P ─────────────│   z2    │
+    └─────────┘                            └─────────┘
+   lo 10.255.0.1/32                       lo 10.255.0.2/32
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| BFD without Echo protects the adjacency and tears it down on BFD failure | |
+| BFD with Echo in one direction (z1 transmit, z2 receive) | |
+| BFD with Echo in both directions | |

--- a/bdd/docs/isis_bfd_ipv6_lan.md
+++ b/bdd/docs/isis_bfd_ipv6_lan.md
@@ -1,0 +1,41 @@
+# IS-IS BFD over an IPv6-only LAN (broadcast) link
+
+## Overview
+
+As a network operator running IS-IS over IPv6-only broadcast segments
+I want BFD to protect each LAN adjacency
+So that a forwarding failure tears the adjacency down well within the IS-IS
+hold time, and the adjacency stays down (RFC 5882 hold-down) until BFD
+recovers — even while IIHs keep arriving.
+Same intent as the point-to-point feature, but the two routers share a Linux
+bridge (broadcast network type, DIS election). Per-neighbour single-hop BFD
+sessions are built from each end's IPv6 link-local address (TLV 232). Each
+scenario is self-contained so the Echo scenarios arm echo-mode before the
+session first comes up.
+BFD-down is induced by dropping inbound UDP/3784 in one namespace: the link
+stays up and IIHs (L2 ISO PDUs, not IP/UDP) keep flowing, so a fast teardown
+is provably BFD's doing — not carrier loss, not the ~30s IS-IS hold timer.
+
+## Test Topology
+
+```
+  ┌────────────────────────────────────────┐
+  │                  br0                    │
+  └────────────┬───────────────┬───────────┘
+               │               │
+       2001:db8:1::1/64   2001:db8:1::2/64
+            (vz1ns)            (vz2ns)
+          ┌────┴────┐     ┌────┴────┐
+          │   z1    │     │   z2    │
+          └─────────┘     └─────────┘
+   lo 2001:db8:0:ffff::1   lo 2001:db8:0:ffff::2
+              /128                  /128
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| BFD without Echo protects the LAN adjacency and tears it down on BFD failure | |
+| BFD with Echo in one direction (z1 transmit, z2 receive) | |
+| BFD with Echo in both directions | |

--- a/bdd/docs/isis_bfd_ipv6_p2p.md
+++ b/bdd/docs/isis_bfd_ipv6_p2p.md
@@ -1,0 +1,35 @@
+# IS-IS BFD over an IPv6-only point-to-point link
+
+## Overview
+
+As a network operator running IS-IS over IPv6-only links
+I want BFD to protect the point-to-point adjacency
+So that a forwarding failure tears the adjacency down well within the IS-IS
+hold time, and the adjacency stays down (RFC 5882 hold-down) until BFD
+recovers — even while IIHs keep arriving.
+The single-hop BFD session is built from the two ends' IPv6 link-local
+addresses (learned via TLV 232). Each scenario is self-contained (own setup
+and teardown) so the Echo scenarios configure echo-mode before the session
+first comes up (echo is armed at session establishment, not retrofitted).
+BFD-down is induced by dropping inbound UDP/3784 in one namespace: the link
+stays up and IIHs (L2 ISO PDUs, not IP/UDP) keep flowing, so a fast teardown
+is provably BFD's doing — not carrier loss, not the ~30s IS-IS hold timer.
+
+## Test Topology
+
+```
+   2001:db8:1::1/64                       2001:db8:1::2/64
+        (i1)                                   (i1)
+    ┌────┴────┐                            ┌────┴────┐
+    │   z1    │────────── P2P ─────────────│   z2    │
+    └─────────┘                            └─────────┘
+  lo 2001:db8:0:ffff::1/128             lo 2001:db8:0:ffff::2/128
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| BFD without Echo protects the adjacency and tears it down on BFD failure | |
+| BFD with Echo in one direction (z1 transmit, z2 receive) | |
+| BFD with Echo in both directions | |

--- a/bdd/docs/isis_endx_ipv6.md
+++ b/bdd/docs/isis_endx_ipv6.md
@@ -1,0 +1,39 @@
+# IS-IS SRv6 End.X (adjacency) SID is gated on the neighbor's IPv6
+
+## Overview
+
+As a network operator
+I want an SRv6 End.X adjacency SID to be allocated only for a neighbor that
+can actually forward IPv6 — one that advertises the IPv6 NLPID in its
+Protocols Supported TLV AND gives us an IPv6 link-local nexthop — and I want
+that decision re-evaluated as the neighbor's capability changes, so enabling
+IPv6 on an already-Up adjacency starts advertising an End.X without a flap.
+
+## Test Topology
+
+```
+   x1 ───────────────── x2
+   i2  10.0.12.0/30      i1
+       2001:db8:12::/64
+   lo 10.0.0.1/32        lo 10.0.0.2/32
+   SRv6 locator LX1
+   (fcbb:1::/64)
+```
+
+## Notes
+
+x1 runs SRv6 with a classic locator, so it owns an End SID and would carve
+an End.X for each IPv6-capable adjacency. The x1–x2 IS-IS circuit starts
+IPv4-only (IS-IS `ipv4 enable` only), so x2 advertises no IPv6 and x1 must
+NOT allocate an End.X for it. A later scenario enables IPv6 on the circuit;
+x2 then advertises IPv6 and x1 allocates the End.X by re-evaluation.
+This also pins the `show segment-routing srv6 sid` column rename: the owner
+column is "Protocol" and the value is "isis" (no instance suffix).
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the topology — an IPv4-only neighbor gets no End.X SID | |
+| Enabling IPv6 on the neighbor re-evaluates and allocates the End.X SID | |
+| Teardown topology | |

--- a/bdd/docs/isis_flexalgo.md
+++ b/bdd/docs/isis_flexalgo.md
@@ -1,0 +1,33 @@
+# IS-IS Flexible Algorithm with affinity-based topology constraints
+
+## Overview
+
+As a network operator running a global backbone (inspired by the Graphiant
+backbone topology), I want IS-IS Flex-Algo (RFC 9350) to confine traffic to
+specific regional sub-topologies so that data-sovereignty and compliance
+policies (HIPAA, GDPR) are enforced at the routing layer.
+Five zebra-rs instances form a two-region backbone.  Each link is tagged
+with one or more affinity names from the global /affinity-map table.
+Two custom algorithms restrict the SPF graph by excluding non-compliant
+link colors:
+The FAD (Flex-Algorithm Definition) for both algorithms is originated by
+the Chicago (ch) router; every other router participates without
+advertising a FAD.
+Topology (all links point-to-point; default metric 10):
+Affinity map:
+Per-algo prefix-SIDs (SRGB base 16000):
+
+## Config Files
+
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the Flex-Algo topology and confirm IS-IS adjacencies | |
+| FAD advertisement is visible from the originating router | |
+| FAD floods to non-originating routers | |
+| Algo 128 (US-only) route table contains only US-region nodes | |
+| Algo 129 (EU-only) route table contains only EU-region nodes | |
+| Default algo-0 topology has full-mesh connectivity | |
+| Teardown Flex-Algo topology | |

--- a/bdd/docs/isis_passive.md
+++ b/bdd/docs/isis_passive.md
@@ -1,0 +1,47 @@
+# IS-IS passive interfaces and the self-sourced-Hello guard
+
+## Overview
+
+As a network operator
+I want IS-IS to advertise a loopback / stub prefix without running the
+Hello protocol on it, and I never want a router to form an adjacency with
+itself when its own Hellos loop back to it.
+Two independent guarantees are exercised here:
+1. A loopback is implicitly passive, and an explicitly `passive` interface
+2. The self-sourced-IIH guard: if an IIH arrives carrying this router's own
+
+## Test Topology
+
+```
+        z3 (IS-IS active, but ISOLATED — z1's side of the link is passive)
+        │
+        │ z3:i1 ── 10.0.13.2/30
+        │ z1:i3 ── 10.0.13.1/30   (PASSIVE on z1)
+        │
+   z2 ══════════════ z1                 z4
+   i1   10.0.12.0/30  i2           sa ─┐  (sa<->sb are one veth pair
+   .2                 .1           sb ─┘   inside z4: a self-loop)
+
+    loopbacks: zI -> 10.0.0.I/32  and  2001:db8::I/128
+```
+
+## Notes
+
+z1–z2 is an ordinary point-to-point Level-2 backbone link and forms an
+adjacency. z1–z3 has z1 configured `passive`, so even though z3 runs IS-IS
+actively it never hears a Hello and z3 stays isolated; z1 still advertises
+10.0.13.0/30 so z2 can reach it. z4 is wired to itself (sa and sb are the
+two ends of one veth pair in the same namespace) to force its own Hellos
+back at it, exercising the self-sourced-IIH guard. Every router also runs
+IS-IS on its loopback (network-type defaults to LAN, the configuration that
+used to make a router peer with itself over `lo`).
+All routers are level-2-only.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the topology — a real adjacency forms, no router self-peers | |
+| A passive interface forms no adjacency but still advertises its prefix | |
+| A self-looped circuit never peers with itself (self-sourced-IIH guard) | |
+| Teardown topology | |

--- a/bdd/docs/ospfv2_as_external.md
+++ b/bdd/docs/ospfv2_as_external.md
@@ -1,0 +1,37 @@
+# OSPFv2 AS-External (Type-5) LSA origination with E1 and E2 metric types
+
+## Overview
+
+As a network operator
+I want zebra-rs to act as an OSPFv2 ASBR — originating Type-5 AS-External
+LSAs from redistributed connected routes — so that routers in all areas
+install the external prefix, and the metric type (E1 vs E2) is correctly
+computed and varies by observer location for E1.
+Same six-router three-area topology as ospfv2_multi_area:
+Area 0: a (ABR), b (ASBR), c (ABR), d.
+Area 0.0.0.1: a (ABR), e (internal).
+Area 0.0.0.2: c (ABR), f (internal).
+Router b is the ASBR in backbone area 0.  A connected network
+(192.168.1.0/24) on a standalone dummy interface "cust0" is added to b
+after zebra-rs starts.  It is NOT on any OSPF-enabled interface, so it
+is a genuine external route — it enters the OSPF domain exclusively via
+`redistribute connected` as a Type-5 AS-External LSA.  (An address on
+an OSPF-enabled interface would instead be advertised as an intra-area
+stub and summarized as a Type-3, which would win over the Type-5 and
+mask the AS-External path being tested.)
+E2 metric (type 2): the installed metric equals the LSA's external metric
+(20) regardless of the observer's distance to the ASBR — the same [20]
+appears on a (backbone, 1 hop), e (area 1, 2 hops), and f (area 2, 2 hops).
+E1 metric (type 1): the installed metric equals SPF-cost-to-ASBR plus the
+external metric.  b is connected to a and c at cost 10, so backbone routers
+one hop away see [30] (10 + 20).  e reaches b via a (10) then via Type-4
+from a (10), total ASBR cost 20, so it sees [40] (20 + 20).
+Interface naming: on router X the interface toward router Y is "ethY".
+Loopbacks: 10.0.0.X/32.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| E2 metric — same external metric from all observers | |
+| E1 metric — external metric plus SPF cost to ASBR varies by location | |

--- a/bdd/docs/ospfv2_multi_area.md
+++ b/bdd/docs/ospfv2_multi_area.md
@@ -1,0 +1,59 @@
+# OSPFv2 multi-area routing across two Area Border Routers
+
+## Overview
+
+As a network operator
+I want zebra-rs to act as an OSPFv2 Area Border Router — originating a
+per-area Router-LSA and Type-3 Summary-LSAs — so that hosts in different
+non-backbone areas learn each other's prefixes through the backbone and
+are mutually reachable, with paths chosen by configured interface cost.
+Six routers in three areas. The backbone (area 0.0.0.0) holds a, b, c, d
+fully meshed-ish; a and c are the ABRs, each anchoring one non-backbone
+area. Area 0.0.0.1 hangs off a (internal router e); area 0.0.0.2 hangs
+off c (internal router f).
+
+## Test Topology
+
+```
+                 area 0.0.0.1                 area 0.0.0.2
+                  e (10.0.0.5)                 f (10.0.0.6)
+                     |                            |
+                10.0.15.0/30                 10.0.36.0/30
+                     | ethe                  ethf |
+        ____________ a (ABR, 10.0.0.1) ........  c (ABR, 10.0.0.3) ____
+       |   area 0   /|                            |\   area 0          |
+       |           / |                            | \                  |
+   10.0.12.0/30   /  10.0.14.0/30 (cost 20)       |  10.0.23.0/30      |
+   (cost 10)     /   |                            |  (cost 10)         |
+       |        /    | etha                  ethd | 10.0.34.0/30       |
+       b (10.0.0.2)  d (10.0.0.4) ________________/  (cost 20)         |
+       |  \________ 10.0.24.0/30 (cost 10) ________/                   |
+       |              (b - d)                                          |
+       \______________________________________________________________/
+
+    backbone links + cost:
+      a-b 10.0.12.0/30  cost 10      a-d 10.0.14.0/30  cost 20
+      b-c 10.0.23.0/30  cost 10      c-d 10.0.34.0/30  cost 20
+      b-d 10.0.24.0/30  cost 10
+    on router X the interface toward router Y is named "ethY".
+    loopbacks: a .1  b .2  c .3  d .4  e .5  f .6  (10.0.0.X/32).
+```
+
+## Notes
+
+The cost-20 a-d and c-d links are the only non-default metrics. They are
+always tied (20) with the two-hop alternative (a-b-d = c-b-d = 10+10), so
+the direct link only ever shows up as an equal-cost path at metric 20 —
+had cost stayed at the default 10 the direct link would win outright at
+10. That metric is the deterministic proof the configured cost took
+effect.
+Inter-area reachability between e (area 1) and f (area 2) is the headline:
+it can only work if a and c each originate Type-3 summaries — a's of
+area 1 into the backbone, c re-advertising them into area 2, and the
+mirror image for f — so the ABR producer is exercised end to end.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Two ABRs glue three areas; inter-area routes form and resolve by cost | |

--- a/bdd/docs/ospfv2_nssa.md
+++ b/bdd/docs/ospfv2_nssa.md
@@ -1,0 +1,61 @@
+# OSPFv2 NSSA (Not-So-Stubby Area) Type-7 origination and translation
+
+## Overview
+
+As a network operator
+I want zebra-rs to support OSPFv2 NSSA areas — N-bit adjacency
+negotiation, Type-7 (NSSA-AS-External) origination from an internal
+ASBR, intra-NSSA Type-7 route install, the ABR's RFC 3101
+Type-7->Type-5 translation into the rest of the OSPF domain, and a
+default Type-7 injected by the ABR — so that an external prefix born
+inside an NSSA is reachable both inside the area and across the
+backbone, while the area still refuses to carry Type-5 AS-External.
+Four routers, two areas. The backbone (0.0.0.0) holds the ABR a and
+a pure backbone router b. The NSSA (0.0.0.1) hangs off a as a
+hub-and-spoke: the ASBR c and the plain internal router d both peer
+only with a.
+
+## Test Topology
+
+```
+            area 0.0.0.0 (backbone)
+      b (10.0.0.2) ---- 10.0.12.0/30 ---- a (ABR, 10.0.0.1)
+                                          |  translator + default-originate
+                                  area 0.0.0.1 (NSSA)
+                       10.0.13.0/30 |        | 10.0.14.0/30
+                              etha  |        |  etha
+                         c (ASBR, 10.0.0.3)  d (10.0.0.4)
+                         redistribute        plain internal
+                         connected -> Type-7
+
+    on router X the interface toward router Y is named "ethY".
+    loopbacks: a .1  b .2  c .3  d .4  (10.0.0.X/32).
+```
+
+## Notes
+
+The external prefix is a connected network (192.168.1.0/24) on a
+standalone dummy interface "cust0" added to c AFTER zebra-rs starts.
+It is NOT on any OSPF-enabled interface, so it is a genuine external
+route — it enters OSPF only via c's per-area `redistribute connected`
+as a Type-7. (An address on an OSPF-enabled interface would instead be
+advertised as an intra-area stub and summarized as a Type-3, masking
+the Type-7 path entirely.) c is a pure ASBR (not an ABR), so it sets
+the Type-7 P-bit. The flood is area-scoped: d installs it directly,
+and the ABR a — the elected (sole-ABR, default `candidate` role)
+NSSA translator —
+re-originates it as a Type-5 AS-External into the backbone, where b
+installs it. b carries no NSSA link, so a Type-5 is the only way the
+prefix can reach it: its presence on b is the proof the translator ran.
+The metric is a flat [20] (E2 / type-2) everywhere — on d (Type-7)
+and on b (translated Type-5) alike — because E2 uses the LSA metric
+verbatim, independent of distance to the originator.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Internal ASBR Type-7 is installed in-area and translated to Type-5 on the backbone | |
+| Totally-NSSA suppresses Type-3 summaries but keeps the default and translation | |
+| Translator-role never keeps the Type-7 in-area and out of the backbone | |
+| E1 metric grows with SPF distance to the originating ASBR and the translator | |

--- a/bdd/docs/ospfv2_stub.md
+++ b/bdd/docs/ospfv2_stub.md
@@ -1,0 +1,41 @@
+# OSPFv2 stub area drops Type-5 AS-External while keeping inter-area routes
+
+## Overview
+
+As a network operator
+I want zebra-rs to support OSPFv2 stub areas — E-bit adjacency
+negotiation, AS-External (Type-5) LSAs excluded from the area, and
+inter-area Type-3 summaries still flooded in — so that a stub router
+learns inter-area destinations but is shielded from the external LSDB.
+Three routers, two areas. The backbone (0.0.0.0) holds the ABR a and
+the ASBR b; the stub (0.0.0.1) holds the internal router c hanging
+off a.
+
+## Test Topology
+
+```
+        area 0.0.0.0 (backbone)              area 0.0.0.1 (stub)
+    b (ASBR, 10.0.0.2) -- 10.0.12.0/30 -- a (ABR, 10.0.0.1) -- 10.0.13.0/30 -- c (10.0.0.3)
+    redistribute connected                                                      internal
+    -> Type-5
+
+    on router X the interface toward router Y is named "ethY".
+    loopbacks: a .1  b .2  c .3  (10.0.0.X/32).
+```
+
+## Notes
+
+b redistributes a connected network (192.168.1.0/24) on a standalone
+dummy interface "cust0" (NOT an OSPF interface, so it is a genuine
+external — not an intra-area stub that would summarize as a Type-3) as
+a Type-5 AS-External LSA. The backbone router a installs it, but
+`flood_lsa_through_as` skips stub areas, so the Type-5 never reaches c
+— and external prefixes are not re-advertised as Type-3 either. The
+backbone loopback 10.0.0.2/32, by contrast, IS summarized into the
+stub as a Type-3, so c reaches it across the area boundary.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Stub router learns inter-area Type-3 but never the Type-5 external | |

--- a/bdd/docs/ospfv3_adjacency.md
+++ b/bdd/docs/ospfv3_adjacency.md
@@ -1,0 +1,34 @@
+# OSPFv3 two-router adjacency forms over a point-to-point link
+
+## Overview
+
+As a network operator
+I want two zebra-rs OSPFv3 routers joined by a point-to-point link to
+progress all the way to Full and synchronise their databases, so the
+OSPFv3 control plane is exercised router-to-router (not only against
+an external implementation).
+This is the v3 counterpart of `ospf_clear_neighbor` and guards the
+OSPFv3 half of the adjacency-formation fixes (Router-ID config applied
+per instance, `addr_add` re-firing InterfaceUp, and the DB-exchange
+More-bit being cleared). Without those, two zebra-rs v3 routers share
+the default Router-ID 10.0.0.1 and/or stall in Exchange and never reach
+Full — a regression invisible to zebra-rs<->FRR validation and to CI
+(which does not run the BDD suite).
+Reaching Full in BOTH directions is the proof: it requires the master
+(higher Router-ID, o2) and the slave (o1) to complete ExStart ->
+Exchange -> Loading -> Full, which only happens when all three fixes
+hold.
+
+## Test Topology
+
+```
+    o1 (router-id 10.0.0.1) --- 2001:db8:12::/64 --- o2 (router-id 10.0.0.2)
+       eth1   point-to-point, area 0.0.0.0   eth2
+    loopbacks: 2001:db8::1/128 (o1)         2001:db8::2/128 (o2)
+```
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Two OSPFv3 routers reach Full over a point-to-point link | |

--- a/bdd/docs/ospfv3_nssa.md
+++ b/bdd/docs/ospfv3_nssa.md
@@ -1,0 +1,50 @@
+# OSPFv3 NSSA (Not-So-Stubby Area) Type-7 origination and translation
+
+## Overview
+
+As a network operator
+I want zebra-rs to support OSPFv3 NSSA areas — N-bit adjacency, Type-7
+(NSSA-LSA) origination from an internal ASBR via redistribute
+connected, intra-NSSA Type-7 route install, and the ABR's RFC 5340 /
+RFC 3101 Type-7->Type-5 translation into the backbone — so that an IPv6
+external prefix born inside an NSSA reaches both the area and the rest
+of the OSPFv3 domain.
+This is the IPv6 counterpart of @ospfv2_nssa. Four routers, two areas:
+the backbone (0.0.0.0) holds the ABR a and a pure backbone router b;
+the NSSA (0.0.0.1) hangs off a as a hub-and-spoke with the ASBR c and
+the plain internal router d.
+
+## Test Topology
+
+```
+            area 0.0.0.0 (backbone)
+      b (10.0.0.2) -- 2001:db8:12::/64 -- a (ABR, 10.0.0.1)
+                                          |  translator + default-originate
+                                  area 0.0.0.1 (NSSA)
+                     2001:db8:13::/64 |        | 2001:db8:14::/64
+                       c (ASBR, 10.0.0.3)      d (10.0.0.4)
+                       redistribute            plain internal
+                       connected -> Type-7
+
+    on router X the interface toward router Y is named "ethY".
+    loopbacks: 2001:db8::X/128 (X = router-id last octet).
+```
+
+## Notes
+
+The external prefix is a connected network (2001:db8:dead::/64) on a
+standalone dummy interface "cust0" on c — NOT on any OSPF-enabled
+interface, so it is a genuine external that enters OSPFv3 only via
+`redistribute connected` as a Type-7. c is a pure ASBR (not an ABR),
+so it sets the Type-7 P-bit in the prefix-options. d installs it
+directly (area-scoped flood); a — the elected (sole-ABR, default
+`candidate` role) translator — re-originates it as a Type-5
+AS-External into the backbone, where b installs it. b carries no NSSA
+link, so a translated Type-5 is the only way the prefix reaches it.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Internal ASBR Type-7 is installed in-area and translated to Type-5 on the backbone | |
+| Translator-role never keeps the Type-7 in-area and out of the backbone | |


### PR DESCRIPTION
## Summary
- Regenerate Markdown docs from the cucumber `.feature` files (via `bdd/docs/feature2md.sh`) for 26 BDD features that were missing their rendered docs — covering BGP, IS-IS, and OSPFv2/v3.
- Update `bdd/docs/bgp_vrf_show.md` to include the added "Inspect vrf-blue via the `show bgp vrf` tree" scenario.

## New docs
BGP: `allowas_in`, `as_override`, `disable_connected_check`, `ebgp_multihop`, `enforce_first_as`, `interas_option_a`, `interas_option_c`, `remove_private_as`, `show`, `srv6_redistribute`, `tcp_mss`, `ttl_security`
IS-IS: `afi_enable`, `bfd_ipv4_lan`, `bfd_ipv4_p2p`, `bfd_ipv6_lan`, `bfd_ipv6_p2p`, `endx_ipv6`, `flexalgo`, `passive`
OSPF: `ospfv2_as_external`, `ospfv2_multi_area`, `ospfv2_nssa`, `ospfv2_stub`, `ospfv3_adjacency`, `ospfv3_nssa`

Docs-only change; each new `.md` was verified to map to an existing `bdd/tests/features/<name>.feature`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)