### PR TITLE
docs(book): rename book title to "zebra-rs"

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -1,5 +1,5 @@
 [book]
-title = "zebra-rs Routing Software"
+title = "zebra-rs"
 authors = ["Kunihiro Ishiguro"]
 language = "en"
 src = "src"


### PR DESCRIPTION
## Summary
- Rename the mdbook title from `"zebra-rs Routing Software"` to `"zebra-rs"` in `book/book.toml`.

## Test plan
- Docs-only config change; `make book` renders with the shortened title. No code paths affected.

Generated with [Claude Code](https://claude.com/claude-code)