### PR TITLE
fix(bgp): show real MPLS label in "show ip bgp vpnv4"

### DIFF
--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -624,7 +624,7 @@ fn show_bgp_vpnv4(
                         },
                         path_id: rib.remote_id,
                         local_path_id: rib.local_id,
-                        label: 0, // TODO: Get actual label from rib.label
+                        label: rib.label.map(|l| l.label).unwrap_or(0),
                     });
                 }
             }
@@ -678,7 +678,8 @@ fn show_bgp_vpnv4(
                     origin,
                 )?;
                 let ecom = show_ecom(&rib.attr);
-                writeln!(buf, "     {} label=0, {}", ecom, com)?;
+                let label = rib.label.map(|l| l.label).unwrap_or(0);
+                writeln!(buf, "     {} label={}, {}", ecom, label, com)?;
             }
         }
     }
@@ -732,7 +733,7 @@ fn show_adj_rib_routes_vpnv4<D: RibDirection>(
                         },
                         path_id: rib.remote_id,
                         local_path_id: rib.local_id,
-                        label: 0, // TODO: Get actual label from rib.label
+                        label: rib.label.map(|l| l.label).unwrap_or(0),
                     });
                 }
             }
@@ -786,7 +787,8 @@ fn show_adj_rib_routes_vpnv4<D: RibDirection>(
                     origin,
                 )?;
                 let ecom = show_ecom(&rib.attr);
-                writeln!(buf, "     {} label=0, {}", ecom, com)?;
+                let label = rib.label.map(|l| l.label).unwrap_or(0);
+                writeln!(buf, "     {} label={}, {}", ecom, label, com)?;
             }
         }
     }


### PR DESCRIPTION
## Summary
`show ip bgp vpnv4` (and the per-peer Adj-RIB-In/Out VPNv4 views) always printed `label=0`. The renderer hard-coded the label at four sites in `bgp/show.rs` — text `label=0` and JSON `label: 0`, each with a `// TODO: Get actual label from rib.label` marker — instead of reading the value off the RIB entry.

The real label is already stored on `BgpRib.label` for:
- **received** VPNv4 routes — decoded from the VPNv4 NLRI (`route.rs:5317` → `BgpRib::new`), and
- **locally-originated** VRF exports — the per-VRF label block (`inst.rs:2954`).

This reads `rib.label` at all four render sites, mirroring the existing labeled-unicast helper (`show.rs:561`):
```rust
let label = rib.label.map(|l| l.label).unwrap_or(0);
```

## Test plan
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rs` — 964 passed, 0 failed
- No existing test asserted on the old `label=0` string.
- After the fix, received VPNv4 rows show the peer's advertised label and locally-originated rows show their per-VRF label.

Generated with [Claude Code](https://claude.com/claude-code)