### PR TITLE
fix(bdd): run namespace daemons with --daemon so BDD_KEEP survives

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -332,6 +332,12 @@ async fn start_zebra_rs(world: &mut World, namespace: String) {
         &[("ZEBRA_XDP_BFD_ECHO_MODE", "skb")],
         "zebra-rs",
         &[
+            // --daemon double-forks + setsid so the daemon leaves the cargo-test
+            // session. Without it the daemon runs in the harness's session and is
+            // reaped by the end-of-run hangup, which killed BDD_KEEP=1 daemons a
+            // couple of minutes after the run finished. The pid file is written
+            // post-fork, so it holds the real daemonized pid for kill_pidfile.
+            "--daemon",
             "--log-output=file",
             &format!("--log-file={}", log_file),
             &format!("--pid-file={}", pid_file),


### PR DESCRIPTION
## Summary

`BDD_KEEP=1` is meant to leave namespaces and daemons up after a run for
inspection, but the daemons were dying a couple of minutes after the run
finished. The harness spawned `zebra-rs` in the foreground inside the
cargo-test session; skipping teardown (what `BDD_KEEP` does) left the
daemons in that session, so the end-of-run session hangup reaped them.

This passes `--daemon` when starting each namespace daemon. zebra-rs's
built-in daemonize (double-fork + `setsid`) moves it into its own session,
fully detached from the harness, so the hangup can't reach it. `--pid-file`
is written post-fork, so it still holds the real daemonized pid for
`kill_pidfile` / teardown, and `--log-file` logging is unaffected.

## Test plan

- `cargo test -p bdd --no-run` — harness compiles clean.
- Live: a `BDD_KEEP=1` run of `@bgp_interas_option_a` stayed green
  (6 scenarios), and all 8 daemons remained alive 200s past harness exit
  (previously reaped within a couple of minutes); pids unchanged, then
  cleaned up.

Generated with [Claude Code](https://claude.com/claude-code)