### PR TITLE
fix(daemon): use umask 0o022 when daemonizing so pid files stay readable

### DIFF
--- a/zebra-rs/src/main.rs
+++ b/zebra-rs/src/main.rs
@@ -106,6 +106,13 @@ fn daemonize() -> anyhow::Result<()> {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
     Daemonize::new()
         .working_directory(cwd)
+        // The daemonize crate defaults to umask 0o027, which makes a
+        // root daemon's pid file (and log files) mode 0640 — unreadable
+        // by unprivileged tooling. The BDD harness reads the pid file as
+        // the test user to stop the daemon at teardown, so 0o027 made
+        // every teardown silently skip the kill and leak the daemon.
+        // Use the conventional 0o022 to match foreground behavior.
+        .umask(0o022)
         .start()
         .map_err(|e| anyhow::anyhow!("Failed to daemonize: {}", e))
 }


### PR DESCRIPTION
## Problem
Since f11f502c started BDD namespace daemons with `--daemon`, **every BDD run silently leaks its root zebra-rs daemons**:

1. The `daemonize` crate defaults to umask `0o027`, so the root daemon's pid file is written mode **0640 root:root**.
2. The BDD harness's `read_pid` runs as the unprivileged test user → permission denied → `None`.
3. `kill_pidfile` therefore **skips the kill**, then `sudo rm -f` deletes the pid file — erasing the only handle to the daemon. Teardown scenarios stay green.
4. The leaked daemons also defeat the `pidfile_alive` concurrent-run guard, and the 0640 log files are unreadable for debugging.

Easy to confirm on main: run any feature, then `pgrep -x zebra-rs` — the namespace daemons survive teardown (namespaces deleted, daemons reparented).

## Fix
Set the conventional `umask(0o022)` in `daemonize()` so `--daemon` matches foreground behavior: pid files and logs are 0644 again, and the existing unprivileged-read + `sudo kill` teardown path works.

## Testing
- `cargo fmt` / clippy `-D warnings` / `cargo test --workspace --exclude bdd` green
- Live: a root `--daemon` instance in a scratch netns writes a 0644 pid file whose pid matches the daemonized process; the harness's read-then-kill path kills it (no survivor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)