### PR TITLE
feat(bgp): neighbor port and runtime-changeable listen port

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -182,6 +182,10 @@ bgp_interas_option_ab:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_interas_option_ab"
 
+bgp_port:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_port"
+
 generate:
 	rm -rf allure-report
 	allure generate

--- a/bdd/tests/configs/bgp_port/z1.yaml
+++ b/bdd/tests/configs/bgp_port/z1.yaml
@@ -1,0 +1,31 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.1/24
+router:
+  bgp:
+    # Do not listen at all: z2's dials toward z1:179 are refused, so
+    # the z1-z2 session can only be the one z1 opens toward z2:1790 —
+    # and an outbound dial works fine without any listener.
+    port: 0
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      # Dial this neighbor on TCP 1790 (z2's non-default listener)
+      # instead of the IANA default 179.
+      port: 1790
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.10.0.1/32

--- a/bdd/tests/configs/bgp_port/z2.yaml
+++ b/bdd/tests/configs/bgp_port/z2.yaml
@@ -1,0 +1,36 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.0.2/24
+- if-name: i2
+  ipv4:
+    address: 192.168.1.2/24
+router:
+  bgp:
+    # Listen for inbound BGP on TCP 1790 instead of the default 179.
+    port: 1790
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      # Passive: never dial z1, so the z1-z2 session is always the one
+      # z1 actively opened toward port 1790 — making the Foreign/Local
+      # port assertions deterministic.
+      transport:
+        passive-mode: true
+    - remote-address: 192.168.1.3
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003

--- a/bdd/tests/configs/bgp_port/z3-listen.yaml
+++ b/bdd/tests/configs/bgp_port/z3-listen.yaml
@@ -1,0 +1,26 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.1.3/24
+router:
+  bgp:
+    # Reopen the listener on the default port: 0 -> 179 closes nothing
+    # (there was no listener) and binds a fresh server socket, after
+    # which z2's connect retry can establish the session.
+    port: 179
+    global:
+      as: 65003
+      identifier: 192.168.1.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.1.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      transport:
+        passive-mode: true

--- a/bdd/tests/configs/bgp_port/z3.yaml
+++ b/bdd/tests/configs/bgp_port/z3.yaml
@@ -1,0 +1,27 @@
+interface:
+- if-name: i1
+  ipv4:
+    address: 192.168.1.3/24
+router:
+  bgp:
+    # 0 = close the BGP server socket and do not listen at all.
+    port: 0
+    global:
+      as: 65003
+      identifier: 192.168.1.3
+    timer:
+      adv-interval:
+        ibgp: 1
+        ebgp: 1
+    neighbor:
+    - remote-address: 192.168.1.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002
+      # Passive: z3 never dials, and with port 0 it never accepts —
+      # the session must stay down until the listener is reopened
+      # (z3-listen.yaml).
+      transport:
+        passive-mode: true

--- a/bdd/tests/features/bgp_port.feature
+++ b/bdd/tests/features/bgp_port.feature
@@ -1,0 +1,113 @@
+@serial
+@bgp_port
+Feature: BGP on a non-default TCP port
+  As a network operator
+  I want `router bgp port <0-65535>` and `neighbor X port <1-65535>`
+  So sessions can run on a non-179 port, and a router can refuse all
+  inbound BGP by closing its listener (`port 0`).
+
+  Test Topology (a line):
+  ```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐  192.168.1.0/24  ┌─────────┐
+   │   z1    │ i1────────────i1 │   z2    │ i2────────────i1 │   z3    │
+   │ AS65001 │                  │ AS65002 │                  │ AS65003 │
+   │  .0.1   │                  │.0.2 .1.2│                  │  .1.3   │
+   └─────────┘                  └─────────┘                  └─────────┘
+  ```
+
+  z1—z2 exercises the two port knobs together: z2 listens on TCP 1790
+  (`port: 1790`) and z1 dials it (`neighbor 192.168.0.2 port 1790`).
+  Both ends pin the connection direction so the assertion on the ports
+  is deterministic: z1 runs `port: 0` (its dial works fine without any
+  listener, and z2's racing dial toward z1:179 is refused) and z2 is
+  passive toward z1. The only session that can exist is the one z1
+  opened toward 1790. z1 originates 10.10.0.1/32 to prove routes flow
+  over it.
+
+  z2—z3 exercises `port 0` on the accept side: z3 starts with
+  `port: 0` (no listener) and is passive toward z2, so z2's dials to
+  z3:179 are refused and the session must stay down. Re-configuring z3
+  to `port: 179` reopens the listener at runtime; a `clear` on z2 then
+  redials immediately (a refused connect otherwise parks the peer on
+  the 120s connect-retry timer) and the session establishes — the
+  close-and-reopen path of a runtime port change.
+
+  Config application order matters once: z3's `port: 0` is applied
+  before z2's config exists, so z2 never catches the small window
+  between z3's daemon start (default listener on 179) and the apply.
+
+  Config files:
+  - z1.yaml: `port: 0`; neighbor z2 with `port: 1790`; originates
+    10.10.0.1/32
+  - z2.yaml: `port: 1790` listener; passive toward z1; active toward z3
+  - z3.yaml: `port: 0` (no listener); passive toward z2
+  - z3-listen.yaml: same as z3.yaml with `port: 179` (reopen listener)
+
+  Scenario: Setup line topology with custom ports
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I create namespace "z3"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I connect namespace "z2" interface "i2" to namespace "z3" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I start zebra-rs in namespace "z3"
+    And I apply config "z3.yaml" to namespace "z3"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    # Let both ends settle (z2's passive peer must be out of Idle —
+    # Idle refuses inbound connections), then hard-reset z1 so its
+    # dial happens with z2's listener and peer guaranteed ready. z1's
+    # own first dial may have fired into the apply gap and parked on
+    # the 120s connect-retry timer; the clear redials within seconds.
+    And I wait 10 seconds
+    And I run "clear bgp ipv4 neighbor 192.168.0.2" in namespace "z1"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+
+  Scenario: Session between z1 and z2 runs on TCP 1790
+    Given the test topology exists
+    # z1 dialed z2 on the configured neighbor port (z1 cannot have
+    # accepted anything: its listener is closed with port 0)...
+    Then show command "show ip bgp neighbors" in namespace "z1" should contain "Foreign port: 1790"
+    # ...and z2 accepted it on its non-default listener.
+    And show command "show ip bgp neighbors" in namespace "z2" should contain "Local port: 1790"
+    # Routes flow over the non-179 session.
+    And BGP route in "z2" has "10.10.0.1/32"
+
+  Scenario: port 0 closes the listener so the z2-z3 session stays down
+    Given the test topology exists
+    # z3 neither listens (port 0) nor dials (passive): z2's dials to
+    # z3:179 are refused, so the session cannot leave Active/Connect.
+    Then BGP session in "z2" to "192.168.1.3" should not be "Established"
+    And BGP session in "z3" to "192.168.1.2" should not be "Established"
+
+  Scenario: Changing the port reopens the listener and the session comes up
+    Given the test topology exists
+    # port 0 -> 179 closes nothing but opens a fresh listener.
+    When I apply config "z3-listen.yaml" to namespace "z3"
+    # z2's last dial was refused, which parks the peer on the 120s
+    # connect-retry timer — clear it so it redials now.
+    And I run "clear bgp ipv4 neighbor 192.168.1.3" in namespace "z2"
+    And I wait 20 seconds for BGP to operate
+    Then BGP session in "z2" to "192.168.1.3" should be "Established"
+    And BGP session in "z3" to "192.168.1.2" should be "Established"
+    # z3 accepted the session on the reopened default listener.
+    And show command "show ip bgp neighbors" in namespace "z3" should contain "Local port: 179"
+    # End-to-end: z1's route crossed both custom-port sessions.
+    And BGP route in "z3" has "10.10.0.1/32"
+
+  # Pure P2P topology (no bridge): deleting each namespace destroys the
+  # veth pair ends it holds, so only the daemons and namespaces need
+  # teardown.
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I stop zebra-rs in namespace "z3"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    And I delete namespace "z3"
+    Then the test environment should be clean

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -18,6 +18,7 @@
   - [Session Authentication (TCP MD5 / TCP-AO)](ch-02-02-tcp-authentication.md)
   - [TTL: eBGP Multihop & Security (GTSM)](ch-02-11-bgp-ttl-security.md)
   - [TCP MSS](ch-02-14-bgp-tcp-mss.md)
+  - [TCP Port (listen & per-neighbor)](ch-02-23-bgp-port.md)
   - [AS Override](ch-02-12-bgp-as-override.md)
   - [allowas-in (Inbound AS_PATH Loop Relaxation)](ch-02-13-bgp-allowas-in.md)
   - [Remove Private AS](ch-02-14-bgp-remove-private-as.md)

--- a/book/src/ch-02-23-bgp-port.md
+++ b/book/src/ch-02-23-bgp-port.md
@@ -1,0 +1,169 @@
+# BGP TCP Port (`port`)
+
+A BGP session is a TCP connection to the IANA well-known port **179**.
+Two knobs let a session run somewhere else:
+
+- **`router bgp port <0-65535>`** — the port this router's BGP
+  **listener** binds, for sessions *other* routers open toward it. The
+  special value `0` closes the server socket entirely: the router
+  refuses every inbound BGP connection and can only have sessions it
+  dials itself.
+- **`neighbor X port <1-65535>`** — the destination port this router
+  **dials** when it actively opens the session toward neighbor X.
+
+The two are a pair: point `neighbor X port <N>` at a router whose
+`router bgp port` is `<N>`. Typical uses are lab setups where several
+daemons share one network namespace, environments where 179 is filtered
+or reserved, and (`port 0`) route servers or strict dial-out designs
+that must never accept a connection.
+
+Deleting either leaf returns to the default 179.
+
+```
+delete router bgp port
+delete router bgp neighbor 192.168.0.2 port
+```
+
+FRR offers the same pair, with one difference: FRR's listen port is the
+`-p/--bgp_port` *startup option* of bgpd (0 likewise meaning
+do-not-listen) and cannot change at runtime, while in zebra-rs it is
+ordinary configuration — a change closes the listeners and reopens them
+on the new port on the spot.
+
+## Configuration
+
+The dialing side sets the port on the neighbor:
+
+```yaml
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      remote-as: 65002
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      port: 1790            # dial z2 on TCP 1790 instead of 179
+```
+
+The listening side moves its server socket (both the IPv4 and IPv6
+listeners) with the instance-level leaf, directly under `router bgp`:
+
+```yaml
+router:
+  bgp:
+    port: 1790              # listen on TCP 1790; 0 = do not listen
+    global:
+      as: 65002
+      identifier: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+```
+
+The CLI forms share the same paths:
+
+```
+set router bgp neighbor 192.168.0.2 port 1790
+set router bgp port 1790
+set router bgp port 0
+```
+
+## How it is applied
+
+**Neighbor port (dial side).** The configured port is used when the
+connect task is spawned, replacing 179 as the TCP destination. Only the
+active connection is affected: an inbound connection is matched to its
+neighbor by **source address alone, never by port** (same as FRR), so
+this leaf does not change what the local listener accepts. Changing or
+deleting the value on a session that is already up bounces it — the
+same hard teardown `clear bgp <peer>` performs — so the session
+re-establishes on the new port immediately (FRR resets the peer on this
+flag too). A neighbor still Idle simply picks the port up on its first
+connect.
+
+**Listen port (server side).** A change closes the current IPv4 and
+IPv6 listeners and binds fresh ones on the new port; with `0` it stops
+after the close. Per-peer options that live on the listening socket —
+TCP MD5 keys, TCP-AO keys, the listener's TCP MSS clamp — are
+re-installed on the new socket automatically.
+
+Two things deliberately survive a listen-port change:
+
+- **Established sessions.** Closing a listening socket does not touch
+  connections already accepted from it. Only *future* inbound
+  connections are affected; an existing session keeps running on the
+  old port until something else resets it. (This also means `port 0`
+  does not tear down sessions that are already up — it stops new ones
+  from being accepted.)
+- **Outgoing connections.** Dials toward neighbors are unaffected: they
+  go to each neighbor's default or configured `port`, from an ephemeral
+  local source port, whether or not this router listens anywhere.
+
+Scope is the default-VRF instance's listener; per-VRF BGP instances
+keep their own default-port listeners.
+
+## Verification
+
+`show ip bgp neighbors` reports the actual TCP endpoints of the live
+session, FRR-style. On the router that dialed a custom port, the
+**foreign** port is the configured one:
+
+```
+> show ip bgp neighbors
+BGP neighbor is 192.168.0.2, remote AS 65002, local AS 65001, external link
+  Local host: 192.168.0.1, Local port: 38766
+  Foreign host: 192.168.0.2, Foreign port: 1790
+  BGP state = Established, up for 00:01:12
+  ...
+```
+
+On the router that accepted it, the **local** port is its listen port
+and the foreign port is the peer's ephemeral source port:
+
+```
+> show ip bgp neighbors
+BGP neighbor is 192.168.0.1, remote AS 65001, local AS 65002, external link
+  Local host: 192.168.0.2, Local port: 1790
+  Foreign host: 192.168.0.1, Foreign port: 38766
+  BGP state = Established, up for 00:01:12
+  ...
+```
+
+To confirm the listener itself, look at the sockets:
+
+```
+# ss -tlnp | grep zebra-rs
+LISTEN 0 1024  0.0.0.0:1790  0.0.0.0:*  users:(("zebra-rs",...))
+LISTEN 0 1024     [::]:1790     [::]:*  users:(("zebra-rs",...))
+```
+
+With `port 0` the two LISTEN rows are gone, and a peer dialing this
+router is refused (RST) by the kernel.
+
+## Troubleshooting
+
+- **Session stays in Active/Connect after setting `neighbor X port`.**
+  The far end is not listening on that port — check its
+  `router bgp port` (and that its listener actually rebound: `ss -tln`).
+  Remember both directions dial by default; if the *other* router's
+  dial toward your unchanged listener establishes first, the session
+  may come up on 179 even though your custom-port dial is broken. Make
+  the far end passive (`transport: { passive-mode: true }`) when you
+  need to prove the custom-port direction works.
+- **Set `port 0` but an old session is still Established.** Expected —
+  the change only closes the listener. Reset the session
+  (`clear bgp <peer>`) to drop it; with no listener and no active dial
+  from this side it will not come back.
+- **A peer still connects to 179 after you moved the listener.** It
+  cannot — new connections to the old port are refused the moment the
+  rebind happens. If you see an Established session "on 179" it
+  predates the change (see above).

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -16,7 +16,7 @@ use super::auth::AoConfig;
 use super::peer::{AfiSafiEncapType, BgpTop};
 use super::route_clean;
 use super::{
-    Bgp,
+    BGP_PORT, Bgp,
     inst::Callback,
     peer::{
         ALLOWAS_IN_DEFAULT_COUNT, AllowAsIn, PasswordEncoding, Peer, PeerType, RemovePrivateAs,
@@ -1616,6 +1616,21 @@ fn config_transport_passive(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
         } else {
             peer.config.transport.passive = false;
         }
+        // Make the flag effective now, not at the next idle-hold tick.
+        // A started peer parked in Idle has an idle-hold timer armed
+        // toward its first dial (commonly because `remote-as` in the
+        // same commit fired `start()` a moment before this leaf):
+        // re-running the timer reconciler flips it straight to Active
+        // — listening, never dialing. Without this, an inbound
+        // connection landing in that ≤5s Idle window is dropped by
+        // `handle_peer_connection` (Idle refuses connections) and the
+        // remote parks on its 120s connect-retry timer.
+        if peer.config.transport.passive
+            && peer.active
+            && matches!(peer.state, super::peer::State::Idle)
+        {
+            timer::update_timers(peer);
+        }
     }
 
     Some(())
@@ -1817,6 +1832,63 @@ pub(super) fn apply_tcp_mss_refresh_all(bgp: &mut Bgp) {
     }
 }
 
+/// `[no] router bgp neighbor <addr> port <1-65535>` — TCP destination
+/// port used when this router actively dials the neighbor; deleting the
+/// leaf returns to the IANA default 179 ([`BGP_PORT`]). The value is
+/// read by `peer_start_connection` when the connect task is spawned.
+/// Inbound connections are matched by source address only, so the
+/// local listener is unaffected (that side moves with the
+/// instance-level `router bgp port`). Like FRR (`PEER_FLAG_PORT` is a
+/// `peer_change_reset` flag), a change on a live session bounces it
+/// (`Event::Stop`, the `clear bgp ... hard` teardown) so the session
+/// re-establishes on the new port immediately; an Idle peer just picks
+/// the port up on its first connect.
+fn config_peer_port(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let addr = args.addr()?;
+    // On delete the echoed value (if any) is irrelevant — back to 179.
+    let want = if op.is_set() { Some(args.u16()?) } else { None };
+    let (ident, bounce) = {
+        let peer = bgp.peers.get_mut(&addr)?;
+        if peer.config.transport.port == want {
+            // No actual change — don't disturb a live session.
+            return Some(());
+        }
+        peer.config.transport.port = want;
+        peer.start();
+        // Only an established / in-progress session needs an explicit
+        // bounce; bouncing an Idle peer here could race the idle-hold
+        // timer `start()` just armed and strand it.
+        (peer.ident, !matches!(peer.state, super::peer::State::Idle))
+    };
+    if bounce {
+        let _ = bgp
+            .tx
+            .try_send(super::inst::Message::Event(ident, super::peer::Event::Stop));
+    }
+    Some(())
+}
+
+/// `[no] router bgp port <0-65535>` — TCP port the BGP listener binds;
+/// 0 disables listening entirely and deleting the leaf returns to the
+/// IANA default 179 ([`BGP_PORT`]). The bind itself is async while
+/// config callbacks are sync, so the callback only records the value
+/// and queues [`super::inst::Message::Relisten`]; the event loop then
+/// closes the current listeners and reopens them on the new port (or
+/// leaves them closed for 0) in [`Bgp::relisten`]. Established
+/// sessions are not touched — only the server socket cycles. FRR
+/// exposes this as the `-p/--bgp_port` startup option only; here it
+/// is runtime-changeable.
+fn config_global_port(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let want = if op.is_set() { args.u16()? } else { BGP_PORT };
+    if bgp.port == want {
+        // No actual change — don't cycle a healthy listener.
+        return Some(());
+    }
+    bgp.port = want;
+    let _ = bgp.tx.try_send(super::inst::Message::Relisten);
+    Some(())
+}
+
 /// `[no] router bgp neighbor <addr> disable-connected-check` — exempt a
 /// single-hop eBGP neighbor from the directly-connected-network check, so
 /// a session toward a non-connected address (typically a loopback one L2
@@ -1925,6 +1997,15 @@ fn apply_md5_refresh_for(bgp: &mut Bgp, addr: IpAddr) {
             }
         }
         Err(e) => {
+            // Removing a key that was never on this socket is a no-op,
+            // not a failure: the kernel answers ENOENT. It happens for
+            // every password-less peer when the post-(re)bind sweep
+            // (`listen()` / `relisten()`) reconciles a fresh listener,
+            // so only a failed install — or a failed removal of a key
+            // that could really be present — deserves the warning.
+            if password_bytes.is_empty() && e.kind() == std::io::ErrorKind::NotFound {
+                return;
+            }
             tracing::warn!(
                 peer = %addr,
                 error = %e,
@@ -2153,6 +2234,9 @@ impl Bgp {
             "/router/bgp/global/no-fib-install",
             config_global_no_fib_install,
         );
+        // `router bgp port <0-65535>` (zebra-bgp-transport.yang): the
+        // listener port; 0 disables listening.
+        self.callback_add("/router/bgp/port", config_global_port);
         self.callback_add(
             "/router/bgp/segment-routing/srv6/locator",
             config_srv6_locator,
@@ -2344,6 +2428,10 @@ impl Bgp {
         // by Peer::session_ttl and applied at connect / fsm_connected.
         self.callback_peer("/ebgp-multihop", config_ebgp_multihop);
         self.callback_peer("/tcp-mss", config_tcp_mss);
+        // FRR-style `neighbor X port <1-65535>` from
+        // zebra-bgp-transport.yang: TCP destination port used when
+        // dialing this neighbor (default 179).
+        self.callback_peer("/port", config_peer_port);
         // FRR-style `neighbor X disable-connected-check` from
         // zebra-bgp-transport.yang. Exempts a single-hop eBGP neighbor from
         // the directly-connected-network check (Peer::connected_check_ok).
@@ -3407,6 +3495,151 @@ mod neighbor_group_wiring_tests {
             1,
             "disabling on a live session must bounce it",
         );
+    }
+
+    /// `neighbor X port <1-65535>`: Set stores the destination port and
+    /// bounces a live session (FRR `peer_change_reset`); a no-op Set
+    /// does not bounce; Delete clears back to the default (179) and
+    /// bounces again so the session redials on 179.
+    #[tokio::test]
+    async fn peer_port_set_and_delete_bounce_live_session() {
+        use crate::bgp::peer::State;
+        let mut bgp = fresh_bgp();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_remote_as(&mut bgp, arg_words(&["10.0.0.1", "65001"]), ConfigOp::Set).unwrap();
+        let _ = drain_stop_events(&mut bgp);
+        bgp.peers.get_mut(&peer_addr()).unwrap().state = State::Established;
+
+        config_peer_port(&mut bgp, arg_words(&["10.0.0.1", "1790"]), ConfigOp::Set).unwrap();
+        assert_eq!(
+            bgp.peers.get(&peer_addr()).unwrap().config.transport.port,
+            Some(1790),
+            "set must store the configured destination port",
+        );
+        assert_eq!(
+            drain_stop_events(&mut bgp).len(),
+            1,
+            "changing the port on a live session must bounce it",
+        );
+
+        config_peer_port(&mut bgp, arg_words(&["10.0.0.1", "1790"]), ConfigOp::Set).unwrap();
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "a no-op set must not bounce the session",
+        );
+
+        config_peer_port(&mut bgp, arg_words(&["10.0.0.1", "1790"]), ConfigOp::Delete).unwrap();
+        assert_eq!(
+            bgp.peers.get(&peer_addr()).unwrap().config.transport.port,
+            None,
+            "delete must return to the default port (179)",
+        );
+        assert_eq!(
+            drain_stop_events(&mut bgp).len(),
+            1,
+            "removing the port on a live session must bounce it",
+        );
+    }
+
+    /// A port change on an Idle peer is stored but never bounced — the
+    /// next connect picks it up (same policy as the TTL knobs).
+    #[tokio::test]
+    async fn peer_port_on_idle_peer_does_not_bounce() {
+        let mut bgp = fresh_bgp();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_remote_as(&mut bgp, arg_words(&["10.0.0.1", "65001"]), ConfigOp::Set).unwrap();
+        let _ = drain_stop_events(&mut bgp);
+
+        config_peer_port(&mut bgp, arg_words(&["10.0.0.1", "1790"]), ConfigOp::Set).unwrap();
+        assert_eq!(
+            bgp.peers.get(&peer_addr()).unwrap().config.transport.port,
+            Some(1790),
+            "value must still be stored on an Idle peer",
+        );
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "an Idle peer must not be bounced",
+        );
+    }
+
+    /// Setting `transport passive-mode true` on a started peer that is
+    /// still parked in Idle must flip it to Active immediately —
+    /// listening, never dialing. Idle refuses inbound connections, so
+    /// leaving the peer there until the idle-hold tick would drop a
+    /// remote's connect landing in that window (and park the remote on
+    /// its 120s connect-retry timer).
+    #[tokio::test]
+    async fn passive_mode_on_idle_started_peer_goes_active_immediately() {
+        use crate::bgp::peer::State;
+        let mut bgp = fresh_bgp();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_remote_as(&mut bgp, arg_words(&["10.0.0.1", "65001"]), ConfigOp::Set).unwrap();
+        let _ = drain_stop_events(&mut bgp);
+        assert_eq!(
+            bgp.peers.get(&peer_addr()).unwrap().state,
+            State::Idle,
+            "started peer waits out its idle-hold in Idle",
+        );
+
+        config_transport_passive(&mut bgp, arg_words(&["10.0.0.1", "true"]), ConfigOp::Set)
+            .unwrap();
+        let peer = bgp.peers.get(&peer_addr()).unwrap();
+        assert!(peer.config.transport.passive);
+        assert_eq!(
+            peer.state,
+            State::Active,
+            "passive peer must accept inbound connections right away",
+        );
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "the flip must not bounce anything",
+        );
+    }
+
+    /// Drain `bgp.rx`, counting queued `Message::Relisten`s.
+    fn drain_relisten(bgp: &mut Bgp) -> usize {
+        use crate::bgp::inst::Message;
+        let mut count = 0;
+        while let Ok(msg) = bgp.rx.try_recv() {
+            if matches!(msg, Message::Relisten) {
+                count += 1;
+            }
+        }
+        count
+    }
+
+    /// `router bgp port <0-65535>`: Set records the listener port and
+    /// queues a Relisten (the event loop does the async rebind); a
+    /// no-op Set queues nothing; port 0 is accepted (listener
+    /// disabled); Delete restores the default 179 and queues another
+    /// Relisten.
+    #[tokio::test]
+    async fn global_port_records_value_and_queues_relisten() {
+        let mut bgp = fresh_bgp();
+        assert_eq!(bgp.port, BGP_PORT, "fresh instance defaults to 179");
+
+        config_global_port(&mut bgp, arg_words(&["1790"]), ConfigOp::Set).unwrap();
+        assert_eq!(bgp.port, 1790);
+        assert_eq!(
+            drain_relisten(&mut bgp),
+            1,
+            "a port change must queue exactly one Relisten",
+        );
+
+        config_global_port(&mut bgp, arg_words(&["1790"]), ConfigOp::Set).unwrap();
+        assert_eq!(
+            drain_relisten(&mut bgp),
+            0,
+            "a no-op set must not cycle a healthy listener",
+        );
+
+        config_global_port(&mut bgp, arg_words(&["0"]), ConfigOp::Set).unwrap();
+        assert_eq!(bgp.port, 0, "port 0 (listener disabled) is accepted");
+        assert_eq!(drain_relisten(&mut bgp), 1);
+
+        config_global_port(&mut bgp, arg_words(&["0"]), ConfigOp::Delete).unwrap();
+        assert_eq!(bgp.port, BGP_PORT, "delete must restore the default 179");
+        assert_eq!(drain_relisten(&mut bgp), 1);
     }
 
     /// A single-hop eBGP peer whose address is not on a connected subnet

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1,7 +1,7 @@
-use super::BgpAttrStore;
 use super::peer::{BgpTop, Event, PeerBfdConfig, fsm};
 use super::peer_map::PeerMap;
 use super::route::LocalRib;
+use super::{BGP_PORT, BgpAttrStore};
 use crate::bgp::peer::accept;
 use crate::bgp::tracing::{Direction, PacketKind};
 use crate::bgp::{InOut, peer};
@@ -74,6 +74,13 @@ pub enum Message {
         add: Vec<(bgp_packet::BgpLsNlri, bgp_packet::BgpLsAttr)>,
         withdraw: Vec<bgp_packet::BgpLsNlri>,
     },
+    /// `router bgp port <0-65535>` changed: close the BGP listen
+    /// sockets and reopen them on the (new) configured port — or leave
+    /// them closed when the port is 0. Sent by the config callback
+    /// because the rebind is async (`Bgp::listen`) while callbacks are
+    /// sync; handled directly in [`Bgp::event_loop`], which awaits
+    /// [`Bgp::relisten`].
+    Relisten,
 }
 
 pub type Callback = fn(&mut Bgp, Args, ConfigOp) -> Option<()>;
@@ -415,6 +422,14 @@ pub struct Bgp {
     pub pcallbacks: HashMap<String, PCallback>,
     /// BGP Local RIB (Loc-RIB) for best path selection
     pub local_rib: LocalRib,
+    /// `router bgp port <0-65535>`: TCP port the BGP listener binds
+    /// (IPv4 and IPv6 both), default [`BGP_PORT`] (179). 0 disables
+    /// listening entirely — no server socket is open, so every session
+    /// must be dialed by this router. A config change closes and
+    /// reopens the listeners via [`Message::Relisten`] →
+    /// [`Bgp::relisten`]; established sessions are not touched. Scope
+    /// is this instance's listener (per-VRF tasks keep the default).
+    pub port: u16,
     pub listen_task: Option<Task<()>>,
     pub listen_task6: Option<Task<()>>,
     pub listen_err: Option<anyhow::Error>,
@@ -733,6 +748,7 @@ impl Bgp {
             manager_tx,
             callbacks: HashMap::new(),
             pcallbacks: HashMap::new(),
+            port: BGP_PORT,
             listen_task: None,
             listen_task6: None,
             listen_err: None,
@@ -1375,6 +1391,11 @@ impl Bgp {
                     );
                 }
             }
+            Message::Relisten => {
+                // Intercepted in `event_loop` before this dispatcher
+                // (the rebind is async, this method is not). Nothing to
+                // do if one slips through another path.
+            }
         }
     }
 
@@ -1660,6 +1681,12 @@ impl Bgp {
     }
 
     pub async fn listen(&mut self) -> anyhow::Result<()> {
+        // `router bgp port 0` — do not open a server socket at all;
+        // sessions can only be dialed actively from this side.
+        if self.port == 0 {
+            return Ok(());
+        }
+
         let tx = self.tx.clone();
         let tx_clone = tx.clone();
 
@@ -1668,15 +1695,14 @@ impl Bgp {
         let mut ipv6_bound = false;
 
         // Check if we can bind to IPv4
-        match self.ctx.tcp_listen("0.0.0.0:179".parse().unwrap()).await {
+        let addr_v4: SocketAddr = format!("0.0.0.0:{}", self.port).parse().unwrap();
+        match self.ctx.tcp_listen(addr_v4).await {
             Ok(listener) => {
                 ipv4_bound = true;
-                // println!("Successfully bound to IPv4 0.0.0.0:179");
                 use std::os::fd::AsRawFd;
                 self.listen_fd_v4 = Some(listener.as_raw_fd());
                 let tx_ipv4 = tx.clone();
                 self.listen_task = Some(Task::spawn(async move {
-                    // println!("BGP listening on 0.0.0.0:179");
                     loop {
                         match listener.accept().await {
                             Ok((socket, sockaddr)) => {
@@ -1698,24 +1724,19 @@ impl Bgp {
                 }));
             }
             Err(e) => {
-                eprintln!("Failed to bind to IPv4 0.0.0.0:179: {}", e);
+                eprintln!("Failed to bind to IPv4 {}: {}", addr_v4, e);
             }
         }
 
         // Check if we can bind to IPv6 with IPv6-only socket
-        match self
-            .ctx
-            .tcp_listen_v6_only("[::]:179".parse().unwrap())
-            .await
-        {
+        let addr_v6: SocketAddr = format!("[::]:{}", self.port).parse().unwrap();
+        match self.ctx.tcp_listen_v6_only(addr_v6).await {
             Ok(listener) => {
                 ipv6_bound = true;
-                // println!("Successfully bound to IPv6 [::]:179");
                 use std::os::fd::AsRawFd;
                 self.listen_fd_v6 = Some(listener.as_raw_fd());
                 let tx_ipv6 = tx_clone;
                 self.listen_task6 = Some(Task::spawn(async move {
-                    // println!("BGP listening on [::]:179");
                     loop {
                         match listener.accept().await {
                             Ok((socket, sockaddr)) => {
@@ -1736,7 +1757,7 @@ impl Bgp {
                 }));
             }
             Err(e) => {
-                eprintln!("Failed to bind to IPv6 [::]:179: {}", e);
+                eprintln!("Failed to bind to IPv6 {}: {}", addr_v6, e);
             }
         }
 
@@ -1761,6 +1782,32 @@ impl Bgp {
         super::config::apply_tcp_mss_refresh_all(self);
 
         Ok(())
+    }
+
+    /// Close the BGP listen sockets and, unless the configured
+    /// [`Self::port`] is 0, reopen them on it. Dropping the accept
+    /// tasks aborts them, which drops the `TcpListener`s and closes
+    /// the fds; the cached raw fds (MD5 / TCP-AO / MSS install
+    /// targets) are cleared with them and re-captured — and the
+    /// per-peer options re-applied — by `listen()` on the new
+    /// sockets. Established sessions are left alone: only the
+    /// listener cycles. A `Message::Accept` already queued from an
+    /// old listener is still processed — that connection was
+    /// accepted while its port was live.
+    pub async fn relisten(&mut self) {
+        self.listen_task = None;
+        self.listen_task6 = None;
+        self.listen_fd_v4 = None;
+        self.listen_fd_v6 = None;
+        self.listen_err = None;
+        if self.port == 0 {
+            tracing::info!("bgp: listen port set to 0 — BGP listener disabled");
+            return;
+        }
+        tracing::info!(port = self.port, "bgp: reopening BGP listener");
+        if let Err(err) = self.listen().await {
+            self.listen_err = Some(err);
+        }
     }
 
     /// Recompute every peer's cached `shared_network` against the current
@@ -2808,7 +2855,14 @@ impl Bgp {
                     self.process_rib_msg(msg);
                 }
                 Some(msg) = self.rx.recv() => {
-                    self.process_msg(msg);
+                    // Relisten needs `.await` (async bind), which the
+                    // sync `process_msg` dispatcher cannot do — handle
+                    // it here at the loop level.
+                    if matches!(msg, Message::Relisten) {
+                        self.relisten().await;
+                    } else {
+                        self.process_msg(msg);
+                    }
                 }
                 Some(msg) = self.cm.rx.recv() => {
                     self.process_cm_msg(msg);

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -79,6 +79,13 @@ pub struct CollisionConn {
     pub reader: Task<()>,
     pub writer: Task<()>,
     pub role: Role,
+    /// Endpoint addresses of this collision conn, written into
+    /// `peer.param` if it wins §6.8 resolution and is promoted —
+    /// `show ip bgp neighbors`' Local/Foreign host lines must
+    /// describe the surviving connection, not the primary it
+    /// replaced.
+    pub local_addr: Option<SocketAddr>,
+    pub remote_addr: Option<SocketAddr>,
 }
 
 impl State {
@@ -172,6 +179,17 @@ pub enum PasswordEncoding {
 pub struct PeerTransportConfig {
     pub passive: bool,
     pub update_source: Option<IpAddr>,
+    /// `port <1-65535>` (FRR `neighbor X port`): TCP destination port
+    /// used when this router actively dials the neighbor. `None` is
+    /// the IANA default [`BGP_PORT`] (179); deleting the leaf returns
+    /// to it. Consulted only by [`peer_start_connection`] — inbound
+    /// connections are matched to their neighbor by source address,
+    /// never by port, so the listener side ignores this (move the
+    /// listener with the instance-level `router bgp port` instead).
+    /// A change bounces a live session (FRR `peer_change_reset`) so
+    /// the new port takes effect immediately. See
+    /// `zebra-bgp-transport.yang`.
+    pub port: Option<u16>,
     /// GTSM / `ttl-security` (RFC 5082, originally RFC 3682): when set,
     /// this neighbor is treated as directly connected. Every BGP packet
     /// leaves with IP TTL / IPv6 Hop Limit 255 and inbound packets are
@@ -515,6 +533,14 @@ pub struct PeerParam {
     pub hold_time: u16,
     pub keepalive: u16,
     pub local_addr: Option<SocketAddr>,
+    /// Remote endpoint of the session's TCP connection, captured with
+    /// [`Self::local_addr`] when the primary conn comes up (and
+    /// refreshed if a §6.8 collision conn is promoted). For a dialed
+    /// session the port is the neighbor's configured `port` (default
+    /// 179); for an accepted one it is the peer's ephemeral source
+    /// port. Rendered as `Foreign host/port` by `show ip bgp neighbors`,
+    /// mirroring FRR's `su_remote`.
+    pub remote_addr: Option<SocketAddr>,
 }
 
 #[derive(Debug, Default)]
@@ -1403,6 +1429,15 @@ fn promote_collision_to_primary(peer: &mut Peer, collision: CollisionConn) {
     peer.task.reader = Some(collision.reader);
     peer.task.writer = Some(collision.writer);
     peer.primary_role = Some(collision.role);
+    // Show the surviving connection's endpoints, not the dead
+    // primary's (the collision conn is always accepted, so its
+    // local port is the listen port and its remote port ephemeral).
+    if collision.local_addr.is_some() {
+        peer.param.local_addr = collision.local_addr;
+    }
+    if collision.remote_addr.is_some() {
+        peer.param.remote_addr = collision.remote_addr;
+    }
 }
 
 pub fn fsm_bgp_open(peer: &mut Peer, conn: ConnTag, packet: OpenPacket) -> State {
@@ -1630,6 +1665,9 @@ pub fn fsm_connected(peer: &mut Peer, role: Role, stream: TcpStream) -> State {
     if let Ok(local_addr) = stream.local_addr() {
         peer.param.local_addr = Some(local_addr);
     }
+    if let Ok(remote_addr) = stream.peer_addr() {
+        peer.param.remote_addr = Some(remote_addr);
+    }
     apply_session_ttl(peer, &stream);
     record_session_mss(peer, &stream);
     peer.task.connect = None;
@@ -1825,11 +1863,14 @@ pub fn peer_start_connection(peer: &mut Peer) -> Task<()> {
     // `tcp-mss <1-65535>`, likewise set before connect so our SYN
     // advertises the clamp and the kernel caches the reduced MSS.
     let tcp_mss = peer.config.transport.tcp_mss;
+    // `neighbor X port <1-65535>` — TCP destination port for the dial;
+    // the IANA 179 unless overridden.
+    let port = peer.config.transport.port.unwrap_or(BGP_PORT);
     let ctx = peer.ctx.clone();
     Task::spawn(async move {
         let tx = tx.clone();
         let remote: SocketAddr = match address {
-            IpAddr::V4(addr) => SocketAddr::new(IpAddr::V4(addr), BGP_PORT),
+            IpAddr::V4(addr) => SocketAddr::new(IpAddr::V4(addr), port),
             // Pass `scope_id` through `SocketAddrV6` so a link-local
             // target (fe80::/10) resolves to the right interface — the
             // kernel `connect(2)` returns EINVAL otherwise. For global
@@ -1838,7 +1879,7 @@ pub fn peer_start_connection(peer: &mut Peer) -> Task<()> {
             // by interface-neighbor.
             IpAddr::V6(addr) => SocketAddr::V6(std::net::SocketAddrV6::new(
                 addr,
-                BGP_PORT,
+                port,
                 0,
                 scope_id.unwrap_or(0),
             )),
@@ -2141,6 +2182,8 @@ fn start_collision_conn(peer: &mut Peer, stream: TcpStream) {
     // keeps the synced value correct whichever connection survives.
     apply_session_ttl(peer, &stream);
     record_session_mss(peer, &stream);
+    let local_addr = stream.local_addr().ok();
+    let remote_addr = stream.peer_addr().ok();
     let (packet_tx, packet_rx) = mpsc::unbounded_channel::<BytesMut>();
     let (read_half, write_half) = stream.into_split();
     let reader = peer_start_reader(peer, ConnTag::Collision, read_half);
@@ -2152,6 +2195,8 @@ fn start_collision_conn(peer: &mut Peer, stream: TcpStream) {
         reader,
         writer,
         role: Role::Passive,
+        local_addr,
+        remote_addr,
     });
     // Mirror peer_send_open but target the collision packet_tx.
     let bytes = build_open_packet(peer);

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1863,7 +1863,7 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
 }
 
 fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
-    let local_info = if let Some(local_addr) = &neighbor.timer.local_addr {
+    let mut host_info = if let Some(local_addr) = &neighbor.timer.local_addr {
         format!(
             "  Local host: {}, Local port: {}\n",
             local_addr.ip(),
@@ -1872,6 +1872,19 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
     } else {
         String::new()
     };
+    // FRR's "Foreign host" pair: the TCP remote endpoint of the
+    // session. For a dialed session the port is the neighbor's
+    // configured `port` (default 179); for an accepted one it is the
+    // peer's ephemeral source port.
+    if let Some(remote_addr) = &neighbor.timer.remote_addr {
+        use std::fmt::Write as _;
+        let _ = writeln!(
+            host_info,
+            "  Foreign host: {}, Foreign port: {}",
+            remote_addr.ip(),
+            remote_addr.port()
+        );
+    }
 
     writeln!(
         out,
@@ -1886,7 +1899,7 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
         neighbor.remote_as,
         neighbor.local_as,
         neighbor.peer_type,
-        local_info,
+        host_info,
         neighbor.remote_router_id,
         neighbor.local_router_id,
         neighbor.state,

--- a/zebra-rs/src/bgp/vrf/inst.rs
+++ b/zebra-rs/src/bgp/vrf/inst.rs
@@ -499,6 +499,11 @@ impl BgpVrf {
                 // BGP-LS (RFC 9552) is produced and stored only by the
                 // global BGP instance — per-VRF tasks never see it.
             }
+            Message::Relisten => {
+                // `router bgp port` is a global-instance knob; only the
+                // global event loop queues (and handles) Relisten.
+                // Per-VRF tasks keep their default-port listeners.
+            }
         }
     }
 

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1350,6 +1350,53 @@ mod yang_load_tests {
         );
     }
 
+    /// `neighbor X port <1-65535>` and the instance-level
+    /// `router bgp port <0-65535>` (zebra-bgp-transport.yang) must both
+    /// be settable paths. The neighbor leaf's range starts at 1, so
+    /// port 0 must be rejected there while the instance leaf accepts it
+    /// (0 = do not listen).
+    #[test]
+    fn bgp_port_paths_are_settable() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router bgp neighbor 10.0.0.1 port 1790",
+            "set router bgp port 1790",
+            "set router bgp port 0",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+
+        let (code, _comps, _state) = parse(
+            "set router bgp neighbor 10.0.0.1 port 0",
+            entry,
+            None,
+            State::new(),
+        );
+        assert_ne!(
+            code,
+            ExecCode::Success,
+            "neighbor port 0 is outside the 1..65535 range and must not parse",
+        );
+    }
+
     /// The per-neighbor `afi-safi ipv6 encapsulation-type` knob is a
     /// hand-added leaf on the vendored `ietf-bgp-neighbor` afi-safi list.
     /// `load_mode` proves the module loads but not that the concrete path

--- a/zebra-rs/yang/zebra-bgp-transport.yang
+++ b/zebra-rs/yang/zebra-bgp-transport.yang
@@ -52,6 +52,17 @@ module zebra-bgp-transport {
      site in `peer_connect`. Operators using the FRR vocabulary get
      the flat form without giving up the IETF tree.";
 
+  revision 2026-06-09 {
+    description
+      "Add per-neighbor `port <1-65535>` (TCP destination port used to
+       dial the neighbor, default 179) and instance-level
+       `port <0-65535>` (TCP port the BGP listener binds; 0 disables
+       listening entirely, default 179).";
+    reference
+      "FRR `neighbor X port (0-65535)`; FRR bgpd `-p/--bgp_port`
+       startup option (port 0 sets BGP_OPT_NO_LISTEN).";
+  }
+
   revision 2026-06-08 {
     description
       "Add `tcp-mss <1-65535>` per-neighbor leaf (TCP_MAXSEG clamp), and
@@ -178,6 +189,35 @@ module zebra-bgp-transport {
          RFC 4271: A Border Gateway Protocol 4 (BGP-4).";
     }
 
+    leaf port {
+      ext:help "TCP destination port used to connect to this neighbor (1-65535, default 179)";
+      type uint16 {
+        range "1..65535";
+      }
+      description
+        "TCP destination port this router dials when it actively opens
+         the BGP session toward this neighbor. When absent, the IANA
+         default of 179 is used; deleting the leaf returns to 179.
+
+         Only the active (outgoing) connection is affected: an inbound
+         connection is matched to its neighbor by source address alone,
+         never by port, so this leaf does not change what the local
+         listener accepts. To move the local listening side off 179,
+         set the instance-level `router bgp port` instead — the usual
+         pairing is `port <N>` on the instance of one router and
+         `neighbor X port <N>` on the router that dials it.
+
+         A change (set, change, or delete) on a session that is already
+         up bounces it — the same teardown `clear bgp ... hard` uses —
+         so the session re-establishes on the new port immediately
+         (FRR's `peer_change_reset` behaviour for this knob).
+
+         Equivalent to `neighbor X port` in FRR / Cisco IOS.";
+      reference
+        "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 8
+         (TCP port 179).";
+    }
+
     leaf disable-connected-check {
       ext:help "Allow a single-hop eBGP peer that is not on a connected subnet";
       type empty;
@@ -212,6 +252,46 @@ module zebra-bgp-transport {
     }
   }
 
+  grouping bgp-instance-transport-extension {
+    description
+      "FRR-style transport leaves on the BGP instance itself.";
+
+    leaf port {
+      ext:help "TCP port the BGP listener binds (0-65535; 0 disables listening, default 179)";
+      type uint16 {
+        range "0..65535";
+      }
+      description
+        "TCP port the BGP server socket listens on for inbound
+         sessions (IPv4 and IPv6 listeners both). When absent, the
+         IANA default of 179 is used; deleting the leaf returns to
+         179. The special value 0 disables listening entirely: the
+         server sockets are closed and no inbound BGP connection can
+         be accepted — every session must then be opened actively by
+         this router.
+
+         Changing the value closes the current listeners and reopens
+         them on the new port (or, for 0, just closes them). Sessions
+         that are already established are not touched — only the
+         listening socket cycles; a remote peer that later dials the
+         old port is refused by the kernel.
+
+         Outgoing connections are unaffected: they go to each
+         neighbor's default or configured `neighbor X port`, and the
+         local source port of a dialed session stays ephemeral.
+
+         Scope is this instance's listener (the default VRF task);
+         per-VRF instances keep the default port.
+
+         FRR exposes this only as the `-p/--bgp_port` startup option
+         (0 likewise meaning do-not-listen); here it is runtime
+         configuration.";
+      reference
+        "RFC 4271: A Border Gateway Protocol 4 (BGP-4), Section 8
+         (TCP port 179).";
+    }
+  }
+
   /* =========================================================
    * Augments into the zebra-rs configure tree
    * ========================================================= */
@@ -230,5 +310,21 @@ module zebra-bgp-transport {
       "Same attachment for the delete subtree so
        `delete router bgp neighbor X update-source` is path-valid.";
     uses bgp-neighbor-transport-extension;
+  }
+
+  augment "/configure:set/config:router"
+        + "/bgp:bgp" {
+    description
+      "Attach the instance-level transport leaves (listen `port`) in
+       the candidate-set subtree.";
+    uses bgp-instance-transport-extension;
+  }
+
+  augment "/configure:delete/config:router"
+        + "/bgp:bgp" {
+    description
+      "Same attachment for the delete subtree so
+       `delete router bgp port` is path-valid.";
+    uses bgp-instance-transport-extension;
   }
 }


### PR DESCRIPTION
## Summary

Implements BGP TCP port configuration (`zebra-bgp-transport.yang`):

- **`router bgp neighbor X port <1-65535>`** — TCP destination port used when actively dialing the neighbor. Default 179; deleting the leaf returns to it. Only the active connect path is affected — inbound connections are matched by source address, never by port (same as FRR). Like FRR's `PEER_FLAG_PORT` (a `peer_change_reset` flag), changing or deleting the value on a live session bounces it so the new port takes effect immediately; an Idle peer picks it up on its first connect.
- **`router bgp port <0-65535>`** — port the BGP listener binds (IPv4+IPv6). `0` closes the server socket entirely (no inbound BGP at all). A change closes the current listeners and reopens them on the new port at runtime (`Message::Relisten` → `Bgp::relisten`, because the bind is async while config callbacks are sync). Listener-side MD5 / TCP-AO / TCP-MSS options are re-installed on the fresh sockets by the existing refresh sweeps; established sessions are not touched. FRR exposes this only as the `-p/--bgp_port` startup option — here it is runtime configuration.

## Supporting changes

- `show ip bgp neighbors` now prints FRR's **`Foreign host: X, Foreign port: N`** pair (`PeerParam::remote_addr`, captured at `fsm_connected`). A §6.8 collision promotion now also refreshes Local/Foreign endpoints to describe the surviving connection (Local was previously left stale).
- The post-(re)bind MD5 listener sweep no longer warns `ENOENT` when it "removes" a key for a password-less peer from a fresh socket (exposed by relisten — previously the sweep only ever ran before any peer existed).
- Setting `transport passive-mode true` on a started peer still parked in Idle now flips it to Active immediately. Idle refuses inbound connections, so a remote dialing into that ≤5s window was dropped and parked on its 120s connect-retry timer.

## Testing

- Unit: handler tests (set/change/delete + bounce semantics, Relisten queueing, no-op guards, Idle no-bounce, passive Idle→Active flip) and parse-level YANG tests (`set router bgp port 0/1790`, `neighbor X port 1790` settable; `neighbor X port 0` rejected by the 1..65535 range).
- BDD `@bgp_port` (passes locally, 5 scenarios): 3-node line where z2 listens on 1790 and is passive toward z1, z1 dials `port 1790` while running `port 0` itself — the only session that can exist is the custom-port one, proven by `Foreign port: 1790`/`Local port: 1790` and a route flowing over it; `port 0` keeps the z2–z3 session down; changing z3 to `port 179` reopens the listener at runtime and the session establishes end-to-end. Explicit teardown scenario included.
- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude bdd` all clean.

## Docs

Book chapter `ch-02-23-bgp-port.md` (configuration, application semantics, verification with `ss`/show output, troubleshooting) linked from SUMMARY under the BGP transport knobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)