### PR TITLE
refactor(bgp): move neighbor summary to show bgp summary with per-AFI forms

### DIFF
--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -67,12 +67,14 @@ pub async fn process_vrf_show(vrf: &BgpVrf, msg: DisplayRequest) {
     let (path, args) = path_from_command(&msg.paths);
     let out = match path.as_str() {
         "/show/ip/bgp" => show_bgp(vrf, args, msg.json),
-        "/show/ip/bgp/summary" => show_bgp_summary(vrf, args, msg.json),
+        "/show/ip/bgp/summary" | "/show/bgp/summary" => show_bgp_summary(vrf, args, msg.json),
         "/show/ip/bgp/neighbors" => show_bgp_neighbor(vrf, args, msg.json),
         // `show bgp vrf <name> [ipv4|ipv6] [<addr>|<prefix> [longer-prefix]]`
         // — the manager strips the `vrf <name>` selector, so a per-VRF
         // task sees the same `/show/bgp/…` paths as the default VRF and
-        // renders against its own Loc-RIB via [`BgpShowView`].
+        // renders against its own Loc-RIB via [`BgpShowView`]. The
+        // `summary` key-union arm rides along (`show bgp vrf X ipv4
+        // summary` → `/show/bgp/ipv4` with a "summary" arg).
         "/show/bgp" | "/show/bgp/ipv4" => show_bgp_ipv4(vrf, args, msg.json),
         "/show/bgp/ipv4/longer-prefix" => show_bgp_ipv4_longer(vrf, args, msg.json),
         "/show/bgp/ipv6" => show_bgp_ipv6(vrf, args, msg.json),
@@ -84,7 +86,7 @@ pub async fn process_vrf_show(vrf: &BgpVrf, msg: DisplayRequest) {
 }
 
 /// Human-readable label for an (AFI, SAFI) pair, used as the "<label>
-/// Summary:" header in `show ip bgp summary`.
+/// Summary:" header in `show bgp summary`.
 fn afi_safi_summary_label(afi: Afi, safi: Safi) -> &'static str {
     match (afi, safi) {
         (Afi::Ip, Safi::Unicast) => "IPv4 Unicast",
@@ -98,6 +100,7 @@ fn afi_safi_summary_label(afi: Afi, safi: Safi) -> &'static str {
         (Afi::L2vpn, Safi::Evpn) => "L2VPN EVPN",
         (Afi::Ip, Safi::Flowspec) => "IPv4 Flowspec",
         (Afi::Ip6, Safi::Flowspec) => "IPv6 Flowspec",
+        (Afi::LinkState, Safi::LinkState) => "Link-State",
         _ => "Unknown AFI/SAFI",
     }
 }
@@ -213,18 +216,22 @@ fn write_summary_section<V: BgpShowView>(
     afi_safi: AfiSafi,
 ) -> std::fmt::Result {
     let label = afi_safi_summary_label(afi_safi.afi, afi_safi.safi);
-    let router_id = if bgp.router_id().is_unspecified() {
-        "Not Configured".to_string()
-    } else {
-        bgp.router_id().to_string()
-    };
+    let router_id = summary_router_id(bgp);
     let asn = if bgp.asn() == 0 {
         "Not Configured".to_string()
     } else {
         bgp.asn().to_string()
     };
     let rib_entries = rib_entries_count(bgp, &afi_safi);
-    let peer_count = bgp.peers().iter().count();
+    // Only the neighbors with this AFI/SAFI enabled appear in the
+    // section, so `show bgp summary` reads as the concatenation of
+    // the per-AFI commands (`show bgp ipv4 summary`, …).
+    let peers: Vec<&Peer> = bgp
+        .peers()
+        .iter()
+        .filter(|(_, peer)| peer.config.mp.has(&afi_safi))
+        .map(|(_, peer)| peer)
+        .collect();
 
     writeln!(buf, "{} Summary:", label)?;
     writeln!(
@@ -233,16 +240,21 @@ fn write_summary_section<V: BgpShowView>(
         router_id, asn
     )?;
     writeln!(buf, "RIB entries {}", rib_entries)?;
-    writeln!(buf, "Peers {}", peer_count)?;
+    writeln!(buf, "Peers {}", peers.len())?;
     writeln!(buf)?;
 
+    if peers.is_empty() {
+        writeln!(buf, "No {} neighbor is configured", label)?;
+        return Ok(());
+    }
+
     write_summary_header_row(buf)?;
-    for (_, peer) in bgp.peers().iter() {
+    for peer in peers.iter() {
         write_summary_peer_row(buf, peer, afi_safi.afi, afi_safi.safi)?;
     }
 
     writeln!(buf)?;
-    writeln!(buf, "Total number of neighbors {}", peer_count)?;
+    writeln!(buf, "Total number of neighbors {}", peers.len())?;
     Ok(())
 }
 
@@ -352,6 +364,15 @@ fn srv6_behavior_name(behavior: u16) -> String {
 struct BgpSummaryJson {
     router_id: String,
     local_as: u32,
+    afi_safis: Vec<BgpAfiSafiSummaryJson>,
+}
+
+/// One AFI/SAFI section of `show bgp summary --json`, mirroring the
+/// text output: only the neighbors with the AFI/SAFI enabled, with
+/// the prefix counters taken from that family's Adj-RIBs.
+#[derive(Serialize)]
+struct BgpAfiSafiSummaryJson {
+    afi_safi: String,
     peers: Vec<BgpPeerSummaryJson>,
 }
 
@@ -577,10 +598,11 @@ fn show_labeled_row(
     )
 }
 
-/// `show bgp vpnv4 [A.B.C.D | A.B.C.D/M]` — VPNv4 (SAFI 128) Loc-RIB.
-/// No value dumps every RD's table; an address shows the longest match
-/// inside each RD (the routes that contain it); a prefix shows that
-/// exact entry. Mirrors [`show_bgp_ipv4`] on the unicast tree.
+/// `show bgp vpnv4 [A.B.C.D | A.B.C.D/M | summary]` — VPNv4 (SAFI
+/// 128) Loc-RIB. No value dumps every RD's table; an address shows the
+/// longest match inside each RD (the routes that contain it); a prefix
+/// shows that exact entry; `summary` shows the VPNv4-enabled
+/// neighbors. Mirrors [`show_bgp_ipv4`] on the unicast tree.
 fn show_bgp_vpnv4(
     bgp: &Bgp,
     mut args: Args,
@@ -588,6 +610,9 @@ fn show_bgp_vpnv4(
 ) -> std::result::Result<String, std::fmt::Error> {
     match args.string() {
         None => show_bgp_vpnv4_table(bgp, json),
+        Some(tok) if tok == "summary" => {
+            show_bgp_summary_one(bgp, AfiSafi::new(Afi::Ip, Safi::MplsVpn), json)
+        }
         Some(tok) => show_bgp_vpnv4_entry(bgp, &tok),
     }
 }
@@ -1282,6 +1307,11 @@ fn show_bgp_ipv4<V: BgpShowView>(
     let Some(tok) = args.string() else {
         return render_unicast_table(&bgp.local_rib().v4.0, json);
     };
+    // `summary` arrives as the list-key value (an enum arm of the key
+    // union — see exec.yang), not as a separate path element.
+    if tok == "summary" {
+        return show_bgp_summary_one(bgp, AfiSafi::new(Afi::Ip, Safi::Unicast), json);
+    }
     let mut out = String::new();
     if tok.contains('/') {
         match tok.parse::<Ipv4Net>() {
@@ -1344,6 +1374,9 @@ fn show_bgp_ipv6<V: BgpShowView>(
     let Some(tok) = args.string() else {
         return render_unicast_table(&bgp.local_rib().v6.0, json);
     };
+    if tok == "summary" {
+        return show_bgp_summary_one(bgp, AfiSafi::new(Afi::Ip6, Safi::Unicast), json);
+    }
     let mut out = String::new();
     if tok.contains('/') {
         match tok.parse::<Ipv6Net>() {
@@ -1542,66 +1575,84 @@ fn show_bgp_received(
     show_adj_rib_routes(&peer.adj_in.v4.0, bgp.router_id, json)
 }
 
+/// The "BGP router identifier" field of the summary headers.
+fn summary_router_id<V: BgpShowView>(bgp: &V) -> String {
+    if bgp.router_id().is_unspecified() {
+        "Not Configured".to_string()
+    } else {
+        bgp.router_id().to_string()
+    }
+}
+
+fn summary_peer_row_json(peer: &Peer, afi: Afi, safi: Safi) -> BgpPeerSummaryJson {
+    let mut msg_sent: u64 = 0;
+    let mut msg_rcvd: u64 = 0;
+    for counter in peer.counter.iter() {
+        msg_sent += counter.sent;
+        msg_rcvd += counter.rcvd;
+    }
+
+    let pfx_rcvd = peer.adj_in.count(afi, safi) as u64;
+    let pfx_sent = peer.adj_out.count(afi, safi) as u64;
+
+    // FRR-style State/PfxRcd column: an Established session shows its
+    // received-prefix count in place of the state word.
+    let state = if peer.state != State::Established {
+        peer.state.to_str().to_string()
+    } else {
+        pfx_rcvd.to_string()
+    };
+
+    BgpPeerSummaryJson {
+        neighbor: peer.address.to_string(),
+        remote_as: peer.remote_as,
+        msg_rcvd,
+        msg_sent,
+        up_down: uptime(&peer.instant),
+        state,
+        pfx_rcvd,
+        pfx_sent,
+    }
+}
+
+fn summary_section_json<V: BgpShowView>(bgp: &V, afi_safi: AfiSafi) -> BgpAfiSafiSummaryJson {
+    BgpAfiSafiSummaryJson {
+        afi_safi: afi_safi_summary_label(afi_safi.afi, afi_safi.safi).to_string(),
+        peers: bgp
+            .peers()
+            .iter()
+            .filter(|(_, peer)| peer.config.mp.has(&afi_safi))
+            .map(|(_, peer)| summary_peer_row_json(peer, afi_safi.afi, afi_safi.safi))
+            .collect(),
+    }
+}
+
+fn summary_json_render(summary: &BgpSummaryJson) -> String {
+    serde_json::to_string_pretty(summary)
+        .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize summary: {}\"}}", e))
+}
+
 fn show_bgp_summary<V: BgpShowView>(
     bgp: &V,
     _args: Args,
     json: bool,
 ) -> std::result::Result<String, std::fmt::Error> {
     if json {
-        let router_id = if bgp.router_id().is_unspecified() {
-            "Not Configured".to_string()
-        } else {
-            bgp.router_id().to_string()
-        };
-
-        let mut peers = Vec::new();
-        for (_, peer) in bgp.peers().iter() {
-            let mut msg_sent: u64 = 0;
-            let mut msg_rcvd: u64 = 0;
-            for counter in peer.counter.iter() {
-                msg_sent += counter.sent;
-                msg_rcvd += counter.rcvd;
-            }
-
-            let pfx_rcvd = peer.adj_in.count(Afi::Ip, Safi::MplsVpn) as u64;
-            let pfx_sent = peer.adj_out.count(Afi::Ip, Safi::MplsVpn) as u64;
-
-            let state = if peer.state != State::Established {
-                peer.state.to_str().to_string()
-            } else {
-                pfx_rcvd.to_string()
-            };
-
-            peers.push(BgpPeerSummaryJson {
-                neighbor: peer.address.to_string(),
-                remote_as: peer.remote_as,
-                msg_rcvd,
-                msg_sent,
-                up_down: uptime(&peer.instant),
-                state,
-                pfx_rcvd,
-                pfx_sent,
-            });
-        }
-
         let summary = BgpSummaryJson {
-            router_id,
+            router_id: summary_router_id(bgp),
             local_as: bgp.asn(),
-            peers,
+            afi_safis: configured_afi_safis(bgp)
+                .into_iter()
+                .map(|afi_safi| summary_section_json(bgp, afi_safi))
+                .collect(),
         };
-
-        return Ok(serde_json::to_string_pretty(&summary)
-            .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize summary: {}\"}}", e)));
+        return Ok(summary_json_render(&summary));
     }
 
     let mut buf = String::new();
 
     if bgp.peers().is_empty() {
-        let router_id = if bgp.router_id().is_unspecified() {
-            "Not Configured".to_string()
-        } else {
-            bgp.router_id().to_string()
-        };
+        let router_id = summary_router_id(bgp);
         let asn = if bgp.asn() == 0 {
             "Not Configured".to_string()
         } else {
@@ -1628,6 +1679,36 @@ fn show_bgp_summary<V: BgpShowView>(
     }
 
     Ok(buf)
+}
+
+/// One-section summary for a single AFI/SAFI — `show bgp
+/// {ipv4,ipv6,vpnv4,evpn} summary`. Lists only the neighbors that
+/// have that AFI/SAFI enabled.
+fn show_bgp_summary_one<V: BgpShowView>(
+    bgp: &V,
+    afi_safi: AfiSafi,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    if json {
+        let summary = BgpSummaryJson {
+            router_id: summary_router_id(bgp),
+            local_as: bgp.asn(),
+            afi_safis: vec![summary_section_json(bgp, afi_safi)],
+        };
+        return Ok(summary_json_render(&summary));
+    }
+    let mut buf = String::new();
+    write_summary_section(&mut buf, bgp, afi_safi)?;
+    Ok(buf)
+}
+
+/// `show bgp evpn summary` — the L2VPN/EVPN section only.
+fn show_bgp_evpn_summary(
+    bgp: &Bgp,
+    _args: Args,
+    json: bool,
+) -> std::result::Result<String, std::fmt::Error> {
+    show_bgp_summary_one(bgp, AfiSafi::new(Afi::L2vpn, Safi::Evpn), json)
 }
 
 #[derive(Serialize, Debug)]
@@ -3595,7 +3676,6 @@ impl Bgp {
         self.show_add("/show/ip/bgp", show_bgp::<Bgp>);
         self.show_add("/show/ip/bgp/labeled-unicast", show_bgp_labeled);
         self.show_add("/show/ip/bgp/route", show_bgp_route_entry);
-        self.show_add("/show/ip/bgp/summary", show_bgp_summary::<Bgp>);
         self.show_add("/show/ip/bgp/neighbors", show_bgp_neighbor::<Bgp>);
         self.show_add(
             "/show/ip/bgp/neighbors/advertised-routes",
@@ -3652,6 +3732,14 @@ impl Bgp {
         // `show bgp vpnv4 [<addr>|<prefix>]` and `show bgp evpn`.
         self.show_add("/show/bgp/vpnv4", show_bgp_vpnv4);
         self.show_add("/show/bgp/evpn", show_bgp_evpn);
+        // Neighbor summaries, moved here from the legacy `show ip bgp
+        // summary`: the bare form sections every configured AFI/SAFI;
+        // ipv4/ipv6/vpnv4 reach their one-section form through the
+        // key-union `summary` arm handled inside the RIB handlers
+        // above; EVPN has its own path (the `evpn` node is a presence
+        // container, not a keyed list).
+        self.show_add("/show/bgp/summary", show_bgp_summary::<Bgp>);
+        self.show_add("/show/bgp/evpn/summary", show_bgp_evpn_summary);
 
         // `show bgp vrf <name> …` is normally intercepted by the manager
         // and redirected into the per-VRF task (see `process_vrf_show`).
@@ -3660,6 +3748,7 @@ impl Bgp {
         // and a named-but-not-running VRF reports the miss instead of
         // leaving the request unanswered.
         self.show_add("/show/bgp/vrf", show_bgp_vrf);
+        self.show_add("/show/bgp/vrf/summary", show_bgp_vrf_not_running);
         self.show_add("/show/bgp/vrf/ipv4", show_bgp_vrf_not_running);
         self.show_add("/show/bgp/vrf/ipv4/longer-prefix", show_bgp_vrf_not_running);
         self.show_add("/show/bgp/vrf/ipv6", show_bgp_vrf_not_running);

--- a/zebra-rs/src/config/comps.rs
+++ b/zebra-rs/src/config/comps.rs
@@ -191,8 +191,39 @@ fn comps_as_leaf(comps: &mut Vec<Completion>, entry: &Rc<Entry>) {
             }
             return;
         }
+        if node.kind == YangType::Union {
+            // One hint per arm, mirroring how the matcher dispatches:
+            // enum arms surface their keywords (`show bgp ipv4 ?` ->
+            // `summary`), scalar arms their type hints (`<A.B.C.D>`),
+            // instead of an opaque `<value:union>`.
+            for n in node.union.iter() {
+                comps_push_arm(comps, n);
+            }
+            return;
+        }
     }
     comps.push(comps_as_key(entry));
+}
+
+/// Push the completion hint(s) for one union arm: an enumeration arm
+/// contributes its keywords, anything else its type hint. Skips names
+/// already present so a keyword that also exists as a sibling node
+/// (e.g. the `summary` leaf next to the `ipv4` default-child whose key
+/// has a `summary` enum arm) is listed once.
+fn comps_push_arm(comps: &mut Vec<Completion>, arm: &TypeNode) {
+    let mut push_unique = |name: &str| {
+        if !comps.iter().any(|c| c.name == name) {
+            comps.push(Completion::new_name(name));
+        }
+    };
+    if arm.kind == YangType::Enumeration {
+        for e in arm.enum_stmt.iter() {
+            push_unique(&e.name);
+        }
+    } else {
+        let kind = ytype_from_typedef(&arm.typedef).unwrap_or(arm.kind);
+        push_unique(ytype_str(&kind));
+    }
 }
 
 /// Emit the positional completion hints contributed by a container's
@@ -220,12 +251,10 @@ fn comps_default_child_key(comps: &mut Vec<Completion>, parent: &Rc<Entry>) {
     };
     if node.kind == YangType::Union {
         for n in node.union.iter() {
-            let kind = ytype_from_typedef(&n.typedef).unwrap_or(n.kind);
-            comps.push(Completion::new_name(ytype_str(&kind)));
+            comps_push_arm(comps, n);
         }
     } else {
-        let kind = ytype_from_typedef(&node.typedef).unwrap_or(node.kind);
-        comps.push(Completion::new_name(ytype_str(&kind)));
+        comps_push_arm(comps, node);
     }
 }
 

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -511,9 +511,21 @@ pub fn ymatch_complete(ymatch: YangMatch, list_presence: bool, is_delete: bool) 
 }
 
 fn matched_enumeration(mx: &Match) -> Option<String> {
-    if let Some(type_node) = &mx.matched_entry.type_node
-        && type_node.kind == YangType::Enumeration
-        && let Some(last_match) = &mx.last_match
+    let type_node = mx.matched_entry.type_node.as_ref()?;
+    let last_match = mx.last_match.as_ref()?;
+    if type_node.kind == YangType::Enumeration {
+        return Some(last_match.clone());
+    }
+    // A union with an inline enumeration arm (e.g. the `show bgp ipv4`
+    // key: address | prefix | `summary`). The winner was the enum
+    // keyword iff `last_match` names one of the arm's enums — the
+    // scalar arms record type hints like `<A.B.C.D>` instead — and
+    // returning the canonical name here is what lets an abbreviated
+    // keyword (`show bgp ipv4 summ`) reach the handler as `summary`.
+    if type_node.kind == YangType::Union
+        && type_node.union.iter().any(|arm| {
+            arm.kind == YangType::Enumeration && arm.enum_stmt.iter().any(|e| &e.name == last_match)
+        })
     {
         return Some(last_match.clone());
     }
@@ -958,6 +970,80 @@ mod tests {
         }
     }
 
+    /// The neighbor summary moved from `show ip bgp summary` to `show
+    /// bgp summary`, and grew per-AFI forms. ipv4/ipv6/vpnv4 carry
+    /// `summary` as an enum arm of the key union, so it arrives as an
+    /// arg of the RIB path; the EVPN form is a child path of the
+    /// `evpn` presence container; the VRF forms ride the existing
+    /// redirect. An abbreviated keyword canonicalizes (`summ` ->
+    /// `summary`) via the union-aware `matched_enumeration`.
+    #[test]
+    fn show_bgp_summary_grammar() {
+        use crate::config::path_from_command;
+        let entry = exec_entry();
+
+        let cases: Vec<(&str, &str, Vec<&str>)> = vec![
+            ("show bgp summary", "/show/bgp/summary", vec![]),
+            ("show bgp ipv4 summary", "/show/bgp/ipv4", vec!["summary"]),
+            ("show bgp ipv4 summ", "/show/bgp/ipv4", vec!["summary"]),
+            ("show bgp ipv6 summary", "/show/bgp/ipv6", vec!["summary"]),
+            ("show bgp vpnv4 summary", "/show/bgp/vpnv4", vec!["summary"]),
+            ("show bgp evpn summary", "/show/bgp/evpn/summary", vec![]),
+            (
+                "show bgp vrf blue summary",
+                "/show/bgp/vrf/summary",
+                vec!["blue"],
+            ),
+            (
+                "show bgp vrf blue ipv4 summary",
+                "/show/bgp/vrf/ipv4",
+                vec!["blue", "summary"],
+            ),
+        ];
+
+        for &(cmd, want_path, ref want_args) in &cases {
+            let (code, _comps, state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "parse `{cmd}`");
+            let (path, args) = path_from_command(&state.paths);
+            assert_eq!(path, want_path, "path for `{cmd}`");
+            let got: Vec<&str> = args.0.iter().map(|s| s.as_str()).collect();
+            assert_eq!(&got, want_args, "args for `{cmd}`");
+        }
+
+        // The legacy spelling is gone; the legacy per-VRF leaf stays.
+        let (code, _comps, _state) =
+            parse("show ip bgp summary", entry.clone(), None, State::new());
+        assert_ne!(
+            code,
+            ExecCode::Success,
+            "`show ip bgp summary` must not be a command"
+        );
+        let (code, _comps, _state) = parse(
+            "show ip bgp vrf v1 summary",
+            entry.clone(),
+            None,
+            State::new(),
+        );
+        assert_eq!(
+            code,
+            ExecCode::Success,
+            "`show ip bgp vrf v1 summary` must parse"
+        );
+    }
+
+    /// `show bgp ipv4 <tab>` surfaces the union arms of the key —
+    /// the value hints and the `summary` keyword — instead of an
+    /// opaque `<value:union>` hint.
+    #[test]
+    fn show_bgp_ipv4_completion_offers_union_arms() {
+        let entry = exec_entry();
+        let (_code, comps, _state) = parse("show bgp ipv4 ", entry, None, State::new());
+        let names: Vec<&str> = comps.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"<A.B.C.D>"), "comps: {names:?}");
+        assert!(names.contains(&"<A.B.C.D/M>"), "comps: {names:?}");
+        assert!(names.contains(&"summary"), "comps: {names:?}");
+    }
+
     /// The positional shortcut is IPv4-only (`ext:default-child
     /// "ipv4"`): a bare IPv6 literal after `show bgp` is not a command —
     /// IPv6 must be reached through the explicit `ipv6` keyword.
@@ -971,7 +1057,9 @@ mod tests {
     }
 
     /// `show bgp <tab>` advertises both the AFI keywords and the
-    /// positional value hints contributed by `ext:default-child`.
+    /// positional value hints contributed by `ext:default-child`. The
+    /// `summary` keyword exists twice in the schema (the leaf and the
+    /// ipv4 key's enum arm) but must be listed once.
     #[test]
     fn show_bgp_completion_offers_positional_hint() {
         let entry = exec_entry();
@@ -981,6 +1069,11 @@ mod tests {
         assert!(names.contains(&"ipv6"), "comps: {names:?}");
         assert!(names.contains(&"<A.B.C.D>"), "comps: {names:?}");
         assert!(names.contains(&"<A.B.C.D/M>"), "comps: {names:?}");
+        assert_eq!(
+            names.iter().filter(|n| **n == "summary").count(),
+            1,
+            "comps: {names:?}"
+        );
     }
 
     /// `show bgp vrf <name> …` mirrors the default-VRF tree: the `vrf`
@@ -1070,6 +1163,12 @@ mod tests {
                 "show bgp vrf blue ipv6 2001:db8::/48 longer-prefix",
                 "/show/bgp/ipv6/longer-prefix",
                 vec!["2001:db8::/48"],
+            ),
+            ("show bgp vrf blue summary", "/show/bgp/summary", vec![]),
+            (
+                "show bgp vrf blue ipv4 summary",
+                "/show/bgp/ipv4",
+                vec!["summary"],
             ),
         ];
 

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -49,13 +49,20 @@ module exec {
       ext:presence "BGP IPv4 unicast RIB (all prefixes)";
       key value;
       leaf value {
-        ext:help "Address (routes containing it) or prefix (exact match)";
+        ext:help "Address (routes containing it), prefix (exact match) or summary";
         // A bare address does a longest-match lookup (routes that
         // contain it); a prefix matches exactly. The handler tells
-        // them apart by the presence of `/M`.
+        // them apart by the presence of `/M`. `summary` rides the key
+        // union as an inline enumeration arm because the parser's
+        // list position only matches the key — an enum arm is how a
+        // keyword lives at the key position (`show bgp ipv4
+        // summary`); the handler dispatches on the literal value.
         type union {
           type inet:ipv4-address;
           type inet:ipv4-prefix;
+          type enumeration {
+            enum summary;
+          }
         }
       }
       leaf longer-prefix {
@@ -68,10 +75,13 @@ module exec {
       ext:presence "BGP IPv6 unicast RIB (all prefixes)";
       key value;
       leaf value {
-        ext:help "Address (routes containing it) or prefix (exact match)";
+        ext:help "Address (routes containing it), prefix (exact match) or summary";
         type union {
           type inet:ipv6-address;
           type inet:ipv6-prefix;
+          type enumeration {
+            enum summary;
+          }
         }
       }
       leaf longer-prefix {
@@ -208,6 +218,14 @@ module exec {
       // routed into `ipv4` by the matcher via `ext:default-child`.
       ext:default-child "ipv4";
       presence "BGP IPv4 unicast RIB (same as `show bgp ipv4`)";
+      // Neighbor summary, one section per AFI/SAFI configured on at
+      // least one neighbor. The per-AFI forms (`show bgp ipv4
+      // summary`, `show bgp vpnv4 summary`, …) render one section
+      // with only the neighbors that have that AFI/SAFI enabled.
+      leaf summary {
+        ext:help "Summary of BGP neighbor status per AFI/SAFI";
+        type empty;
+      }
       uses bgp-show-afi-rib;
       // VPNv4 (SAFI 128) Loc-RIB across every route distinguisher.
       // Mirrors the `ipv4` list above: a bare address after `vpnv4`
@@ -218,16 +236,23 @@ module exec {
         ext:presence "BGP VPNv4 RIB (all route distinguishers)";
         key value;
         leaf value {
-          ext:help "Address (routes containing it) or prefix (exact match)";
+          ext:help "Address (routes containing it), prefix (exact match) or summary";
           type union {
             type inet:ipv4-address;
             type inet:ipv4-prefix;
+            type enumeration {
+              enum summary;
+            }
           }
         }
       }
-      leaf evpn {
+      container evpn {
         ext:help "BGP EVPN RIB";
-        type empty;
+        presence "BGP EVPN RIB";
+        leaf summary {
+          ext:help "Summary of EVPN-enabled neighbors";
+          type empty;
+        }
       }
       list update-group {
         ext:help "BGP update-groups (IOS-XR style)";
@@ -253,6 +278,10 @@ module exec {
           ext:help "VRF name";
           ext:dynamic "rib:vrf";
           type string;
+        }
+        leaf summary {
+          ext:help "Summary of this VRF's BGP neighbor status";
+          type empty;
         }
         uses bgp-show-afi-rib;
       }
@@ -319,10 +348,6 @@ module exec {
             ext:help "BGP IPv6 SR Policy (SAFI 73) RIB";
             type empty;
           }
-        }
-        leaf summary {
-          ext:help "BGP summary information";
-          type empty;
         }
         list neighbors {
           ext:help "BGP neighbor information";


### PR DESCRIPTION
## Summary

Continues the `show ip bgp` → `show bgp` migration (#1303) for the neighbor summary:

- `show bgp summary` (moved from `show ip bgp summary`) — one section per AFI/SAFI configured on at least one neighbor; each section lists **only the neighbors with that AFI/SAFI enabled**
- `show bgp ipv4 summary` — IPv4-unicast-enabled neighbors only
- `show bgp ipv6 summary` — IPv6-unicast-enabled neighbors only
- `show bgp vpnv4 summary` — VPNv4-enabled neighbors only
- `show bgp evpn summary` — EVPN-enabled neighbors only
- `show bgp vrf X summary` / `show bgp vrf X {ipv4,ipv6} summary` ride the existing per-VRF redirect (legacy `show ip bgp vrf X summary` stays)

JSON mirrors the text sections (`afi_safis` array) instead of the old flat peer list whose prefix counters were hardwired to VPNv4.

## Grammar approach

The parser's list position only matches the key, so `ipv4`/`ipv6`/`vpnv4` carry `summary` as an **inline enumeration arm of the key union**; handlers dispatch on the literal value. Supporting parser/completion changes:

- `matched_enumeration` canonicalizes a union's enum-arm match, so abbreviated `show bgp ipv4 summ` reaches the handler as `summary` (also improves existing union+enum leaves like `remote-as external`)
- Completions surface union arms (`<A.B.C.D>`, `<A.B.C.D/M>`, `summary`) instead of an opaque `<value:union>`, deduplicating keywords that also exist as sibling nodes
- `evpn` becomes a presence container (bare RIB view unchanged) with a `summary` child

## Testing

- New parse tests pin the five commands, VRF forms, abbreviation canonicalization, completion dedup, and that `show ip bgp summary` no longer parses
- `cargo test --workspace --exclude bdd` green (35 suites), workspace clippy clean, fmt clean
- Validated live against the rebuilt daemon: three neighbors with mixed AFI/SAFI sets render correctly filtered sections for all five commands, abbreviations, JSON, and the VRF not-running fall-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)