### PR TITLE
bgp: honor NO_EXPORT / NO_ADVERTISE well-known communities on egress

### DIFF
--- a/bdd/docs/bgp_community.md
+++ b/bdd/docs/bgp_community.md
@@ -5,23 +5,33 @@
 As a network operator
 I want to verify that the well-known communities NO_EXPORT and
 NO_ADVERTISE are honoured when re-advertising routes across eBGP
-and iBGP sessions, using a three-router topology.
+and iBGP sessions, using a four-router topology.
 
 ## Test Topology
 
 ```
-  ┌──────────────────────────────────────────────────────────┐
-  │                          br0                             │
-  └─────────┬──────────────────┬──────────────────┬──────────┘
-            │                  │                  │
-       ┌────┴────┐        ┌────┴────┐        ┌────┴────┐
-       │   z1    │  eBGP  │   z2    │  iBGP  │   z3    │
-       │  (A)    │◀──────▶│  (B)    │◀──────▶│  (C)    │
-       │ AS65001 │        │ AS65002 │        │ AS65002 │
-       │192.168. │        │192.168. │        │192.168. │
-       │  0.1/24 │        │  0.2/24 │        │  0.3/24 │
-       └─────────┘        └─────────┘        └─────────┘
+  ┌────────────────────────────────────────────────────────────────────────┐
+  │                                  br0                                   │
+  └────────┬──────────────────┬──────────────────┬──────────────────┬─────┘
+           │                  │                  │                  │
+      ┌────┴────┐        ┌────┴────┐        ┌────┴────┐        ┌────┴────┐
+      │   z1    │  eBGP  │   z2    │  iBGP  │   z3    │        │   z4    │
+      │  (A)    │◀──────▶│  (B)    │◀──────▶│  (C)    │        │  (D)    │
+      │ AS65001 │        │ AS65002 │        │ AS65002 │        │ AS65003 │
+      │192.168. │        │192.168. │        │192.168. │        │192.168. │
+      │  0.1/24 │        │  0.2/24 │        │  0.3/24 │        │  0.4/24 │
+      └─────────┘        └────┬────┘        └─────────┘        └────┬────┘
+                              │                eBGP                 │
+                              └─────────────────────────────────────┘
 ```
+
+## Notes
+
+B has an iBGP peer (C, same AS) and an eBGP peer (D, AS65003), so a
+route from A exercises both re-advertisement edges:
+- NO_EXPORT: B keeps advertising to C (iBGP) but must NOT export to
+  D (eBGP) — RFC 1997.
+- NO_ADVERTISE: B must advertise to neither C nor D.
 
 ## Config Files
 
@@ -29,11 +39,14 @@ and iBGP sessions, using a three-router topology.
 - z1-2.yaml: A advertises 1.1.1.1/32 with no community attribute.
 - z1-3.yaml: A advertises 1.1.1.1/32 with community "no-export".
 - z1-4.yaml: A advertises 1.1.1.1/32 with community "no-advertise".
-- z2-1.yaml: B — eBGP to A, iBGP to C.
+- z1-5.yaml: A advertises 1.1.1.1/32 through a permit-all policy
+- z2-1.yaml: B — eBGP to A, iBGP to C, eBGP to D.
 - z3-1.yaml: C — iBGP to B only.
+- z4-1.yaml: D — eBGP to B only.
 - eBGP MinRouteAdvertisementInterval = 30 s
 - iBGP MinRouteAdvertisementInterval =  5 s
 - End-to-end A → B → C propagation: up to 30 + 5 = 35 s.
+- End-to-end A → B → D propagation: up to 30 + 30 = 60 s.
 - Each scenario that triggers a fresh advertisement on A waits
 
 Convergence wait-time rationale:
@@ -43,8 +56,8 @@ Convergence wait-time rationale:
 | Scenario | Result |
 |----------|--------|
 | Setup topology and establish BGP sessions | |
-| A advertises 1.1.1.1/32 with no community — C receives it | |
-| A re-advertises 1.1.1.1/32 with community no-export — C still receives it | |
-| A re-advertises 1.1.1.1/32 with community no-advertise — C does NOT receive it | |
-| A reverts to plain advertisement — C receives it again | |
+| A advertises 1.1.1.1/32 with no community — C and D receive it | |
+| A re-advertises 1.1.1.1/32 with community no-export — C still receives it, D does NOT | |
+| A re-advertises 1.1.1.1/32 with community no-advertise — neither C nor D receives it | |
+| A reverts to a community-free advertisement — C and D receive it again | |
 | Teardown topology | |

--- a/bdd/tests/configs/bgp_community/z1-5.yaml
+++ b/bdd/tests/configs/bgp_community/z1-5.yaml
@@ -1,0 +1,23 @@
+policy:
+- name: pass-all
+  entry:
+  - number: 10
+    action: permit
+router:
+  bgp:
+    global:
+      as: 65001
+      identifier: 192.168.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      policy:
+        out: pass-all
+      enabled: true
+      remote-as: 65002
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 1.1.1.1/32

--- a/bdd/tests/configs/bgp_community/z2-1.yaml
+++ b/bdd/tests/configs/bgp_community/z2-1.yaml
@@ -16,3 +16,9 @@ router:
         enabled: true
       enabled: true
       remote-as: 65002
+    - remote-address: 192.168.0.4
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65003

--- a/bdd/tests/configs/bgp_community/z4-1.yaml
+++ b/bdd/tests/configs/bgp_community/z4-1.yaml
@@ -1,0 +1,12 @@
+router:
+  bgp:
+    global:
+      as: 65003
+      identifier: 192.168.0.4
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65002

--- a/bdd/tests/features/bgp_community.feature
+++ b/bdd/tests/features/bgp_community.feature
@@ -4,30 +4,42 @@ Feature: BGP well-known community handling (no-export, no-advertise)
   As a network operator
   I want to verify that the well-known communities NO_EXPORT and
   NO_ADVERTISE are honoured when re-advertising routes across eBGP
-  and iBGP sessions, using a three-router topology.
+  and iBGP sessions, using a four-router topology.
 
   Test Topology:
   ```
-  ┌──────────────────────────────────────────────────────────┐
-  │                          br0                             │
-  └─────────┬──────────────────┬──────────────────┬──────────┘
-            │                  │                  │
-       ┌────┴────┐        ┌────┴────┐        ┌────┴────┐
-       │   z1    │  eBGP  │   z2    │  iBGP  │   z3    │
-       │  (A)    │◀──────▶│  (B)    │◀──────▶│  (C)    │
-       │ AS65001 │        │ AS65002 │        │ AS65002 │
-       │192.168. │        │192.168. │        │192.168. │
-       │  0.1/24 │        │  0.2/24 │        │  0.3/24 │
-       └─────────┘        └─────────┘        └─────────┘
+  ┌────────────────────────────────────────────────────────────────────────┐
+  │                                  br0                                   │
+  └────────┬──────────────────┬──────────────────┬──────────────────┬─────┘
+           │                  │                  │                  │
+      ┌────┴────┐        ┌────┴────┐        ┌────┴────┐        ┌────┴────┐
+      │   z1    │  eBGP  │   z2    │  iBGP  │   z3    │        │   z4    │
+      │  (A)    │◀──────▶│  (B)    │◀──────▶│  (C)    │        │  (D)    │
+      │ AS65001 │        │ AS65002 │        │ AS65002 │        │ AS65003 │
+      │192.168. │        │192.168. │        │192.168. │        │192.168. │
+      │  0.1/24 │        │  0.2/24 │        │  0.3/24 │        │  0.4/24 │
+      └─────────┘        └────┬────┘        └─────────┘        └────┬────┘
+                              │                eBGP                 │
+                              └─────────────────────────────────────┘
   ```
+  B has an iBGP peer (C, same AS) and an eBGP peer (D, AS65003), so a
+  route from A exercises both re-advertisement edges:
+  - NO_EXPORT: B keeps advertising to C (iBGP) but must NOT export to
+    D (eBGP) — RFC 1997.
+  - NO_ADVERTISE: B must advertise to neither C nor D.
 
   Config files:
   - z1-1.yaml: A baseline — eBGP peer to B, no network advertised.
   - z1-2.yaml: A advertises 1.1.1.1/32 with no community attribute.
   - z1-3.yaml: A advertises 1.1.1.1/32 with community "no-export".
   - z1-4.yaml: A advertises 1.1.1.1/32 with community "no-advertise".
-  - z2-1.yaml: B — eBGP to A, iBGP to C.
+  - z1-5.yaml: A advertises 1.1.1.1/32 through a permit-all policy
+    (config apply is additive, so reverting means OVERWRITING the
+    neighbor's `policy out` leaf with a community-free policy — the
+    no-community z1-2.yaml cannot remove an already-set leaf).
+  - z2-1.yaml: B — eBGP to A, iBGP to C, eBGP to D.
   - z3-1.yaml: C — iBGP to B only.
+  - z4-1.yaml: D — eBGP to B only.
 
   Convergence wait-time rationale:
   - eBGP MinRouteAdvertisementInterval = 30 s
@@ -35,9 +47,11 @@ Feature: BGP well-known community handling (no-export, no-advertise)
   - iBGP MinRouteAdvertisementInterval =  5 s
     (ADV_TIMER_IBGP_SECS in zebra-rs/src/bgp/update_group.rs)
   - End-to-end A → B → C propagation: up to 30 + 5 = 35 s.
+  - End-to-end A → B → D propagation: up to 30 + 30 = 60 s.
   - Each scenario that triggers a fresh advertisement on A waits
-    35 seconds; a session clear before the wait forces an immediate
-    re-flood instead of relying on incremental triggers.
+    65 seconds (the slowest path plus margin); a session clear before
+    the wait forces an immediate re-flood instead of relying on
+    incremental triggers.
 
   Scenario: Setup topology and establish BGP sessions
     Given a clean test environment
@@ -45,56 +59,67 @@ Feature: BGP well-known community handling (no-export, no-advertise)
     And I create namespace "z1" with IP "192.168.0.1/24" on bridge "br0"
     And I create namespace "z2" with IP "192.168.0.2/24" on bridge "br0"
     And I create namespace "z3" with IP "192.168.0.3/24" on bridge "br0"
+    And I create namespace "z4" with IP "192.168.0.4/24" on bridge "br0"
     And I start zebra-rs in namespace "z1"
     And I start zebra-rs in namespace "z2"
     And I start zebra-rs in namespace "z3"
+    And I start zebra-rs in namespace "z4"
     And I apply config "z1-1.yaml" to namespace "z1"
     And I apply config "z2-1.yaml" to namespace "z2"
     And I apply config "z3-1.yaml" to namespace "z3"
+    And I apply config "z4-1.yaml" to namespace "z4"
     And I wait 5 seconds for BGP to operate
     Then BGP session in "z1" to "192.168.0.2" should be "Established"
     And BGP session in "z2" to "192.168.0.1" should be "Established"
     And BGP session in "z2" to "192.168.0.3" should be "Established"
     And BGP session in "z3" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.4" should be "Established"
+    And BGP session in "z4" to "192.168.0.2" should be "Established"
 
-  Scenario: A advertises 1.1.1.1/32 with no community — C receives it
+  Scenario: A advertises 1.1.1.1/32 with no community — C and D receive it
     Given the test topology exists
     When I apply config "z1-2.yaml" to namespace "z1"
-    And I wait 35 seconds for BGP to operate
+    And I wait 65 seconds for BGP to operate
     Then BGP route in "z2" has "1.1.1.1/32"
     And BGP route in "z3" has "1.1.1.1/32"
+    And BGP route in "z4" has "1.1.1.1/32"
 
-  Scenario: A re-advertises 1.1.1.1/32 with community no-export — C still receives it
+  Scenario: A re-advertises 1.1.1.1/32 with community no-export — C still receives it, D does NOT
     Given the test topology exists
     When I apply config "z1-3.yaml" to namespace "z1"
     And I clear namespace "z1" neighbor "192.168.0.2"
-    And I wait 35 seconds for BGP to operate
+    And I wait 65 seconds for BGP to operate
     Then BGP route in "z2" has "1.1.1.1/32"
     And BGP route in "z3" has "1.1.1.1/32"
+    And BGP route in "z4" does not have "1.1.1.1/32"
 
-  Scenario: A re-advertises 1.1.1.1/32 with community no-advertise — C does NOT receive it
+  Scenario: A re-advertises 1.1.1.1/32 with community no-advertise — neither C nor D receives it
     Given the test topology exists
     When I apply config "z1-4.yaml" to namespace "z1"
     And I clear namespace "z1" neighbor "192.168.0.2"
-    And I wait 35 seconds for BGP to operate
+    And I wait 65 seconds for BGP to operate
     Then BGP route in "z2" has "1.1.1.1/32"
     And BGP route in "z3" does not have "1.1.1.1/32"
+    And BGP route in "z4" does not have "1.1.1.1/32"
 
-  Scenario: A reverts to plain advertisement — C receives it again
+  Scenario: A reverts to a community-free advertisement — C and D receive it again
     Given the test topology exists
-    When I apply config "z1-2.yaml" to namespace "z1"
+    When I apply config "z1-5.yaml" to namespace "z1"
     And I clear namespace "z1" neighbor "192.168.0.2"
-    And I wait 35 seconds for BGP to operate
+    And I wait 65 seconds for BGP to operate
     Then BGP route in "z2" has "1.1.1.1/32"
     And BGP route in "z3" has "1.1.1.1/32"
+    And BGP route in "z4" has "1.1.1.1/32"
 
   Scenario: Teardown topology
     Given the test topology exists
     When I stop zebra-rs in namespace "z1"
     And I stop zebra-rs in namespace "z2"
     And I stop zebra-rs in namespace "z3"
+    And I stop zebra-rs in namespace "z4"
     And I delete namespace "z1"
     And I delete namespace "z2"
     And I delete namespace "z3"
+    And I delete namespace "z4"
     And I delete bridge "br0"
     Then the test environment should be clean

--- a/docs/design/bgp-well-known-communities.md
+++ b/docs/design/bgp-well-known-communities.md
@@ -1,0 +1,45 @@
+# BGP well-known communities — implementation status
+
+Audit of every well-known community constant defined in
+`crates/bgp-packet/src/attrs/com.rs` (`CommunityValue`) against the
+behavior its RFC prescribes. Last reviewed 2026-06-09, alongside the
+change that added RFC 1997 egress suppression to the unicast / VPN /
+EVPN outbound paths (`community_suppresses_advertisement` in
+`zebra-rs/src/bgp/route.rs`).
+
+| Community | Value | RFC | Status |
+|---|---|---|---|
+| NO_EXPORT | 0xFFFFFF01 | 1997 | **Enforced**: suppressed toward eBGP peers on IPv4/IPv6 unicast, VPNv4/VPNv6, labeled-unicast, and EVPN egress. SR Policy (SAFI 73) has its own RFC 9830 handling in `sr_policy.rs`. |
+| NO_ADVERTISE | 0xFFFFFF02 | 1997 | **Enforced**: suppressed toward every peer on the same paths as NO_EXPORT. |
+| NO_EXPORT_SUBCONFED (local-AS) | 0xFFFFFF03 | 1997 | **Enforced** as an alias of NO_EXPORT — BGP confederations are not implemented, so "do not advertise outside the member-AS" degenerates to "do not advertise to eBGP" (FRR behaves the same without confederations). |
+| LLGR_STALE | 0xFFFF0006 | 9494 | **Partial**: attached when stale-marking routes of an LLGR-negotiated session, and locally-marked stale routes are least-preferred in best-path. Gaps (follow-up): stale routes are not blocked from advertisement to peers that did not advertise the LLGR capability (per-peer capability — the check must bypass the per-group advertise memo, since capabilities are not part of `UpdateGroupSig`); routes *received* with LLGR_STALE are not depreferenced; labeled-unicast has no LLGR handling. |
+| NO_LLGR | 0xFFFF0007 | 9494 | **Gap** (follow-up): ignored — routes carrying it must not be retained long-lived when the session goes down. |
+| GRACEFUL_SHUTDOWN | 0xFFFF0000 | 8326 | Constant only. Future work: a `graceful-shutdown` knob that attaches the community + LOCAL_PREF 0 on egress, and lowers LOCAL_PREF on tagged ingress routes. Until then operators can match it in inbound policy. |
+| ACCEPT_OWN | 0xFFFF0001 | 7611 | Constant only. Niche RR/VPN feature (accept routes carrying our own ORIGINATOR_ID across VRFs); unimplemented. |
+| ACCEPT_OWN_NEXTHOP | 0xFFFF0008 | draft | Constant only; unimplemented. |
+| BLACKHOLE | 0xFFFF029A | 7999 | Constant only. RFC 7999 handling (install discard route) is operator policy; a dedicated knob may come later. Matchable in policy today. |
+| NO_PEER | 0xFFFFFF04 | 3765 | **Intentionally not enforced**: the community is advisory and "bilateral peer vs transit" cannot be determined automatically by the router; FRR does not enforce it either. Available to policy. |
+| ROUTE_FILTER_TRANSLATED_V4 / ROUTE_FILTER_V4 / ROUTE_FILTER_TRANSLATED_V6 / ROUTE_FILTER_V6 | 0xFFFF0002-5 | — | Reserved constants (IANA registry); no standardized router behavior to implement. |
+
+## Enforcement design notes
+
+- The RFC 1997 gate runs in the shared outbound builders
+  (`route_update_ipv4` / `route_update_ipv6` / `route_update_evpn`),
+  **before** the per-peer outbound policy. A community the outbound
+  policy itself attaches toward a peer therefore does not suppress that
+  advertisement — only communities already on the route (received, or
+  set at origination/ingress) do. FRR orders these the same way.
+- The decision depends only on the peer *type* (iBGP/eBGP), which is
+  part of `UpdateGroupSig`, so the result is uniform across an
+  update-group and safe under the per-group advertise memo. Any future
+  per-peer community rule (e.g. the LLGR capability gate) must be
+  checked per-peer, outside that memo.
+- IPv4 unicast / VPNv4 / EVPN get withdraw-on-transition for free: a
+  suppressed route flows into `AdvertiseOutcome::Withdraw`, which is
+  gated on the per-peer Adj-RIB-Out. The IPv6 egress has no Adj-RIB-Out
+  yet, so v6 filtering is steady-state only (same pre-existing
+  limitation as the deferred v6 outbound policy).
+- BDD coverage: `bdd/tests/features/bgp_community.feature` — B has both
+  an iBGP peer (C) and an eBGP peer (D), so NO_EXPORT (C yes / D no)
+  and NO_ADVERTISE (neither) are each observable, including the
+  withdraw and re-advertise transitions.

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -2592,6 +2592,11 @@ pub fn route_update_evpn(
         return None;
     }
 
+    // RFC 1997 well-known communities: NO_ADVERTISE / NO_EXPORT.
+    if community_suppresses_advertisement(&rib.attr, peer.peer_type) {
+        return None;
+    }
+
     let id = if add_path { rib.local_id } else { 0 };
 
     let route = match prefix {
@@ -5985,6 +5990,35 @@ fn vpnv4_service_label(peer: &Peer, rib: &BgpRib) -> Label {
     }
 }
 
+/// RFC 1997 well-known community egress gate, shared by the IPv4 /
+/// IPv6 / EVPN outbound builders. NO_ADVERTISE suppresses
+/// advertisement to every peer; NO_EXPORT — and NO_EXPORT_SUBCONFED,
+/// which is equivalent while BGP confederations are unimplemented —
+/// suppresses advertisement to eBGP peers. SR Policy (SAFI 73) keeps
+/// its own RFC 9830 handling in `sr_policy.rs`.
+///
+/// Runs BEFORE the outbound policy, so a community the policy itself
+/// attaches toward a peer does not self-suppress (FRR behaves the
+/// same); only communities already on the route — received, or set at
+/// origination/ingress — suppress.
+///
+/// Depends only on the route's attr and the peer TYPE — `peer_type`
+/// is part of `UpdateGroupSig`, so the result is identical for every
+/// member of an update-group and safe under the per-group advertise
+/// memo in `route_advertise_to_peers`. Do not add per-peer state here
+/// without moving the check out of the memoized path.
+fn community_suppresses_advertisement(attr: &BgpAttr, peer_type: PeerType) -> bool {
+    let Some(com) = attr.com.as_ref() else {
+        return false;
+    };
+    if com.contains(&CommunityValue::NO_ADVERTISE.value()) {
+        return true;
+    }
+    peer_type == PeerType::EBGP
+        && (com.contains(&CommunityValue::NO_EXPORT.value())
+            || com.contains(&CommunityValue::NO_EXPORT_SUBCONFED.value()))
+}
+
 pub fn route_update_ipv4(
     peer: &mut Peer,
     prefix: &Ipv4Net,
@@ -6010,6 +6044,14 @@ pub fn route_update_ipv4(
         && rib.typ == BgpRibType::IBGP
         && !peer.is_reflector_client()
     {
+        return None;
+    }
+
+    // RFC 1997 well-known communities: NO_ADVERTISE / NO_EXPORT. A
+    // suppressed route flows into `AdvertiseOutcome::Withdraw`, so a
+    // previously-advertised route that gains one of these communities
+    // is withdrawn from the affected peers (adj-out gated).
+    if community_suppresses_advertisement(&rib.attr, peer.peer_type) {
         return None;
     }
 
@@ -6146,6 +6188,15 @@ pub fn route_update_ipv6(
     // Inter-AS Option AB: a VPNv6 route a hybrid VRF imports is relayed
     // only via that VRF's re-export, never transparently (see the v4 path).
     if rib.vrf_transit_only {
+        return None;
+    }
+    // RFC 1997 well-known communities: NO_ADVERTISE / NO_EXPORT. Unlike
+    // the v4 path there is no Adj-RIB-Out for v6 yet, so this filters
+    // steady-state advertisement only — a previously-advertised route
+    // that GAINS one of these communities is not withdrawn until the
+    // session resyncs (same pre-existing limitation as the deferred v6
+    // outbound policy).
+    if community_suppresses_advertisement(&rib.attr, peer.peer_type) {
         return None;
     }
     // iBGP→iBGP: don't re-advertise iBGP-learned routes to iBGP peers
@@ -11017,5 +11068,65 @@ mod enforce_first_as_tests {
         // A path whose left-most segment carries no AS ⇒ violation.
         let empty_seq = As4Path::from(vec![]);
         assert!(aspath_first_as_mismatch(Some(&empty_seq), PEER_AS));
+    }
+}
+
+/// `community_suppresses_advertisement` truth table: NO_ADVERTISE
+/// gates every peer type; NO_EXPORT and NO_EXPORT_SUBCONFED gate eBGP
+/// only (no confederation support, so SUBCONFED ≡ NO_EXPORT).
+#[cfg(test)]
+mod community_suppress_tests {
+    use bgp_packet::{BgpAttr, CommunityValue};
+
+    use super::PeerType;
+    use super::community_suppresses_advertisement;
+
+    fn attr_with_coms(coms: &[u32]) -> BgpAttr {
+        BgpAttr {
+            com: Some(coms.iter().copied().collect()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn no_communities_never_suppresses() {
+        let attr = BgpAttr::default();
+        assert!(!community_suppresses_advertisement(&attr, PeerType::IBGP));
+        assert!(!community_suppresses_advertisement(&attr, PeerType::EBGP));
+    }
+
+    #[test]
+    fn ordinary_communities_never_suppress() {
+        let attr = attr_with_coms(&[(100 << 16) | 1]);
+        assert!(!community_suppresses_advertisement(&attr, PeerType::IBGP));
+        assert!(!community_suppresses_advertisement(&attr, PeerType::EBGP));
+    }
+
+    #[test]
+    fn no_advertise_suppresses_all_peer_types() {
+        let attr = attr_with_coms(&[CommunityValue::NO_ADVERTISE.value()]);
+        assert!(community_suppresses_advertisement(&attr, PeerType::IBGP));
+        assert!(community_suppresses_advertisement(&attr, PeerType::EBGP));
+    }
+
+    #[test]
+    fn no_export_suppresses_ebgp_only() {
+        let attr = attr_with_coms(&[CommunityValue::NO_EXPORT.value()]);
+        assert!(!community_suppresses_advertisement(&attr, PeerType::IBGP));
+        assert!(community_suppresses_advertisement(&attr, PeerType::EBGP));
+    }
+
+    #[test]
+    fn no_export_subconfed_suppresses_ebgp_only() {
+        let attr = attr_with_coms(&[CommunityValue::NO_EXPORT_SUBCONFED.value()]);
+        assert!(!community_suppresses_advertisement(&attr, PeerType::IBGP));
+        assert!(community_suppresses_advertisement(&attr, PeerType::EBGP));
+    }
+
+    #[test]
+    fn well_known_mixed_with_ordinary_still_suppresses() {
+        let attr = attr_with_coms(&[(65000 << 16) | 7, CommunityValue::NO_EXPORT.value()]);
+        assert!(community_suppresses_advertisement(&attr, PeerType::EBGP));
+        assert!(!community_suppresses_advertisement(&attr, PeerType::IBGP));
     }
 }


### PR DESCRIPTION
## Summary

Closes the gap found while validating #1305: zebra-rs enforced the RFC 1997 well-known communities only for SR Policy (SAFI 73, RFC 9830). IPv4/IPv6 unicast, VPNv4/VPNv6, labeled-unicast, and EVPN egress ignored them, so a route tagged `no-advertise` was still re-advertised (the `@bgp_community` BDD scenario that covers this had never been able to run before #1305 fixed its config path).

**Implementation** — one gate (`community_suppresses_advertisement`) hooked into the three shared outbound builders (`route_update_ipv4` / `route_update_ipv6` / `route_update_evpn`):
- `NO_ADVERTISE` suppresses advertisement to every peer.
- `NO_EXPORT` — and `NO_EXPORT_SUBCONFED`, equivalent while confederations are unimplemented — suppress advertisement to eBGP peers.
- The check runs **before** the outbound policy, so a community the policy itself attaches toward a peer does not self-suppress (FRR orders these the same way). It depends only on peer type, which is part of `UpdateGroupSig`, so it is safe under the per-group advertise memo.
- On the v4 paths a suppressed route flows into `AdvertiseOutcome::Withdraw`, so previously-advertised routes that gain one of these communities are withdrawn (adj-out gated). The v6 path has no Adj-RIB-Out yet and filters steady-state only — same pre-existing limitation as the deferred v6 outbound policy.

**BDD** — `@bgp_community` now has a fourth router (D, AS65003, eBGP off B) so both behaviors are observable: no-export keeps flowing over iBGP to C while suppressed toward D; no-advertise reaches neither; a permit-all revert restores both (config apply is additive, so reverting means overwriting the `policy out` leaf — the scenario previously "reverted" by applying a config that could not remove the policy and only passed because the community was unenforced).

**Docs** — `docs/design/bgp-well-known-communities.md` records the full audit of every `CommunityValue` constant: what this PR enforces, and the per-community status of the rest.

## Well-known community audit (summary)

| Community | RFC | Status |
|---|---|---|
| NO_EXPORT / NO_ADVERTISE / NO_EXPORT_SUBCONFED | 1997 | **enforced by this PR** |
| LLGR_STALE / NO_LLGR | 9494 | partial / missing — follow-up PR: capability-gated egress of stale routes, depreference of *received* LLGR_STALE, NO_LLGR no-retain |
| GRACEFUL_SHUTDOWN | 8326 | constant only — future `graceful-shutdown` knob |
| ACCEPT_OWN(_NEXTHOP) | 7611 | constant only — niche RR/VPN feature |
| BLACKHOLE | 7999 | operator policy; optional knob later |
| NO_PEER | 3765 | intentionally not enforced (advisory; FRR does not enforce either) |
| ROUTE_FILTER_* | — | reserved constants, nothing to implement |

## Testing

- New unit tests: gate truth table across both peer types (1463 workspace tests pass, 0 failed).
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.
- BDD `@bgp_community`: **6/6 scenarios pass** against the rebuilt `/usr/bin/zebra-rs` (binary hash verified before and after the run) — including the previously-impossible no-advertise scenario and the new no-export eBGP-edge assertions.
- BDD `@bgp_interas_option_b` (VPNv4 egress regression guard): passes on this branch. Note: this feature's "ASBRs hold every VPN prefix" assert sits right at its convergence margin (35s wait vs a worst-case 30s eBGP MRAI chain) and flaked under heavy parallel host load during testing — it failed identically regardless of binary timing-wise, and passed cleanly on both this branch and its parent once load settled; the gate is provably inert for community-less attrs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)