### PR TITLE
rib: global router-id config + show router-id

### DIFF
--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -544,7 +544,16 @@ pub struct Rib {
     /// overlapping label blocks to protocols (BGP L3VPN today).
     pub label_manager: super::label_manager::LabelManager,
     pub nmap: NexthopMap,
+    /// Effective global Router ID — what subscribers receive via
+    /// `RibRx::RouterIdUpdate` and what the subscribe-time replay
+    /// sends. Either the configured override (`router_id_config`) or
+    /// the automatic pick from interface addresses; sticky once set
+    /// (never reverts to 0.0.0.0 while running).
     pub router_id: Ipv4Addr,
+    /// Operator-configured global Router ID (top-level
+    /// `router-id A.B.C.D`). Takes precedence over the automatic
+    /// pick; `None` falls back to it.
+    pub router_id_config: Option<Ipv4Addr>,
 
     /// Single-shot timer that fires Message::Resolve after a debounce when
     /// the FIB has changed. None when no resolve is pending. Set by
@@ -644,6 +653,7 @@ impl Rib {
             label_manager: super::label_manager::LabelManager::new(),
             nmap: NexthopMap::default(),
             router_id: Ipv4Addr::UNSPECIFIED,
+            router_id_config: None,
             rib_sync_timer: None,
             rib_sync_interval: DEFAULT_RIB_SYNC_INTERVAL_SEC,
             sr0_owned: false,
@@ -2179,7 +2189,9 @@ impl Rib {
             }
             ConfigOp::Set | ConfigOp::Delete => {
                 let (path, args) = path_from_command(&msg.paths);
-                if path.as_str().starts_with("/router/static/ipv4/route") {
+                if path.as_str() == "/router-id" {
+                    let _ = self.router_id_config_exec(args, msg.op);
+                } else if path.as_str().starts_with("/router/static/ipv4/route") {
                     let _ = self.static_v4.exec(path, args, msg.op);
                 } else if path.as_str().starts_with("/router/static/ipv6/route") {
                     let _ = self.static_v6.exec(path, args, msg.op);

--- a/zebra-rs/src/rib/router_id.rs
+++ b/zebra-rs/src/rib/router_id.rs
@@ -1,9 +1,11 @@
 use std::collections::BTreeMap;
 use std::net::Ipv4Addr;
 
+use crate::config::{Args, ConfigOp};
+
 use super::{Link, Rib};
 
-fn router_id(links: &BTreeMap<u32, Link>) -> Option<Ipv4Addr> {
+fn auto_router_id(links: &BTreeMap<u32, Link>) -> Option<Ipv4Addr> {
     fn find_router_id(links: &BTreeMap<u32, Link>, loopback: bool) -> Option<Ipv4Addr> {
         links
             .values()
@@ -21,13 +23,116 @@ fn router_id(links: &BTreeMap<u32, Link>) -> Option<Ipv4Addr> {
     find_router_id(links, true).or_else(|| find_router_id(links, false))
 }
 
+/// Configured global `router-id` wins; otherwise fall back to the
+/// automatic pick from interface addresses. `None` when neither
+/// exists yet (no config, no usable address).
+fn effective_router_id(config: Option<Ipv4Addr>, links: &BTreeMap<u32, Link>) -> Option<Ipv4Addr> {
+    config.or_else(|| auto_router_id(links))
+}
+
 impl Rib {
     pub fn router_id_update(&mut self) {
-        if let Some(router_id) = router_id(&self.links)
+        if let Some(router_id) = effective_router_id(self.router_id_config, &self.links)
             && self.router_id != router_id
         {
             self.router_id = router_id;
             self.api_router_id_update(router_id);
         }
+    }
+
+    /// Top-level `router-id A.B.C.D` config handler. Set stores the
+    /// override, delete clears it back to the automatic pick; either
+    /// way the effective value is recomputed and, when it moved,
+    /// broadcast to subscribers.
+    pub(crate) fn router_id_config_exec(&mut self, mut args: Args, op: ConfigOp) -> Option<()> {
+        if op.is_set() {
+            self.router_id_config = Some(args.v4addr()?);
+        } else {
+            self.router_id_config = None;
+        }
+        self.router_id_update();
+        Some(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::link::LinkAddr;
+    use super::super::{LinkType, link_ext::LinkFlagsExt as _};
+    use super::*;
+    use ipnet::{IpNet, Ipv4Net};
+    use netlink_packet_route::link::LinkFlags;
+
+    fn test_link(index: u32, loopback: bool, addrs: &[Ipv4Addr]) -> Link {
+        Link {
+            index,
+            name: format!("test{index}"),
+            mtu: 1500,
+            original_mtu: 1500,
+            metric: 1,
+            flags: if loopback {
+                LinkFlags::Loopback
+            } else {
+                LinkFlags::empty()
+            },
+            link_type: LinkType::Ethernet,
+            label: false,
+            mac: None,
+            addr4: addrs
+                .iter()
+                .map(|&addr| LinkAddr {
+                    addr: IpNet::V4(Ipv4Net::new(addr, 24).unwrap()),
+                    ifindex: index,
+                    secondary: false,
+                    config: false,
+                    fib: true,
+                })
+                .collect(),
+            addr6: Vec::new(),
+            master: None,
+            vni: None,
+            vxlan_local: None,
+            mtu_error: None,
+        }
+    }
+
+    fn addr(s: &str) -> Ipv4Addr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn auto_pick_prefers_loopback_and_skips_localhost() {
+        let mut links = BTreeMap::new();
+        links.insert(1, test_link(1, true, &[addr("127.0.0.1")]));
+        links.insert(2, test_link(2, false, &[addr("192.0.2.1")]));
+        links.insert(3, test_link(3, true, &[addr("10.255.0.1")]));
+        assert!(links.get(&1).unwrap().flags.is_loopback());
+
+        // Loopback wins over the (lower-ifindex) non-loopback; the
+        // 127.0.0.1 loopback address is never a candidate.
+        assert_eq!(auto_router_id(&links), Some(addr("10.255.0.1")));
+
+        // Without any loopback candidate, fall back to non-loopback.
+        links.remove(&3);
+        assert_eq!(auto_router_id(&links), Some(addr("192.0.2.1")));
+
+        // Only 127.0.0.1 left -> no candidate at all.
+        links.remove(&2);
+        assert_eq!(auto_router_id(&links), None);
+    }
+
+    #[test]
+    fn configured_router_id_wins_over_auto_pick() {
+        let mut links = BTreeMap::new();
+        links.insert(1, test_link(1, true, &[addr("10.255.0.1")]));
+
+        assert_eq!(
+            effective_router_id(Some(addr("192.0.2.255")), &links),
+            Some(addr("192.0.2.255"))
+        );
+        // Delete of the override falls back to the automatic pick.
+        assert_eq!(effective_router_id(None, &links), Some(addr("10.255.0.1")));
+        // No config and no usable address -> undecided.
+        assert_eq!(effective_router_id(None, &BTreeMap::new()), None);
     }
 }

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1678,7 +1678,32 @@ impl Rib {
         self.show_add("/show/segment-routing/srv6/sid", sid_show);
         self.show_add("/show/vrf", vrf_show);
         self.show_add("/show/hostname", hostname_show);
+        self.show_add("/show/router-id", router_id_show);
     }
+}
+
+pub fn router_id_show(rib: &Rib, _args: Args, json: bool) -> String {
+    let selected = !rib.router_id.is_unspecified();
+    let source = if rib.router_id_config.is_some() {
+        "configured"
+    } else {
+        "automatic"
+    };
+    if json {
+        let value = if selected {
+            serde_json::json!({
+                "routerId": rib.router_id.to_string(),
+                "source": source,
+            })
+        } else {
+            serde_json::json!({ "routerId": Value::Null })
+        };
+        return value.to_string();
+    }
+    if !selected {
+        return "Router ID is not yet selected\n".to_string();
+    }
+    format!("Router ID: {} ({})\n", rib.router_id, source)
 }
 
 pub fn hostname_show(_rib: &Rib, _args: Args, _json: bool) -> String {

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -424,6 +424,18 @@ module config {
       }
     }
 
+    // Global Router ID, FRR/zebra-style `router-id A.B.C.D`. When
+    // set it overrides the automatic pick (first non-localhost IPv4,
+    // loopbacks preferred — see `rib/router_id.rs`) and is pushed to
+    // protocol subscribers via `RibRx::RouterIdUpdate`; deleting it
+    // falls back to the automatic pick. Protocol-local identifiers
+    // (`router bgp global identifier`, `router ospf router-id`, …)
+    // still apply on their own instances.
+    leaf router-id {
+      ext:help "Global router identifier";
+      type inet:ipv4-address;
+    }
+
     container router {
       ext:help "Router configuration";
       uses "ietf-bgp:bgp";

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -98,6 +98,10 @@ module exec {
       ext:help "Show version";
       type empty;
     }
+    leaf router-id {
+      ext:help "Show the effective global router ID";
+      type empty;
+    }
     container candidate-config {
       ext:help "Show the candidate configuration (uncommitted edits)";
       presence "Show candidate config";


### PR DESCRIPTION
## Summary

Add the FRR/zebra-style top-level `router-id A.B.C.D` knob. The RIB already auto-derives a daemon-global Router ID (first non-localhost IPv4, loopbacks preferred) and broadcasts it to protocol subscribers via `RibRx::RouterIdUpdate`; until now there was no way to override the pick.

- `config.yang`: new top-level `leaf router-id` (sibling of `container router`) — `set router-id 1.2.3.4`
- `rib/router_id.rs`: configured value wins over the automatic pick; deleting it falls back; either transition re-broadcasts to subscribers when the effective value moves. Stickiness preserved (never reverts to 0.0.0.0 while running).
- `rib/inst.rs`: new `router_id_config` field; `Rib.router_id` keeps meaning "effective value", so the subscribe-time replay and the show path stay consistent without further changes.
- `exec.yang` + `rib/show.rs`: `show router-id` reports the effective value and its source (`configured` / `automatic`), JSON included.

Protocol-side precedence (BGP/OSPFv2 last-writer-wins between their own configured identifier and this broadcast) and the missing OSPFv3 `RouterIdUpdate` arm are intentionally untouched follow-ups.

## Test plan

- Unit tests: auto-pick prefers loopbacks and skips 127.0.0.1; configured override wins; delete falls back; no candidate -> undecided.
- `cargo test --workspace --exclude bdd`: all green; YANG load tests pass; workspace clippy clean; `cargo fmt` applied.
- Live-validated on a throwaway daemon: `set router-id 203.0.113.7` flipped `show router-id` to `(configured)` and a running BGP instance adopted the identifier in `show bgp ipv4 summary`; `delete router-id 203.0.113.7` fell back to `(automatic)`.

Generated with [Claude Code](https://claude.com/claude-code)