### PR TITLE
bgp,ospf: router-id delete falls back; configured wins over RIB push

### DIFF
--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -34,14 +34,20 @@ fn config_global_asn(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> 
 
 fn config_global_identifier(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     if op == ConfigOp::Set {
-        let router_id = args.v4addr()?;
-        // Go through `set_router_id` so the new value is also
-        // propagated to every existing peer's `router_id` snapshot
-        // — peers created before the operator typed this line would
-        // otherwise keep their stale (often 0.0.0.0) value and emit
-        // OPEN with the wrong BGP Identifier.
-        bgp.set_router_id(router_id);
+        bgp.router_id_config = Some(args.v4addr()?);
+    } else {
+        // Delete falls back to the RIB-derived value (or 0.0.0.0 if
+        // none was ever learned) instead of silently keeping the old
+        // identifier.
+        bgp.router_id_config = None;
     }
+    // `refresh_router_id` resolves configured-vs-RIB precedence and
+    // goes through `set_router_id`, so the result is also propagated
+    // to every existing peer's `router_id` snapshot — peers created
+    // before the operator typed this line would otherwise keep their
+    // stale (often 0.0.0.0) value and emit OPEN with the wrong BGP
+    // Identifier.
+    bgp.refresh_router_id();
     Some(())
 }
 
@@ -1595,19 +1601,23 @@ fn config_llgr_restart_time(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
 }
 
 fn config_local_identifier(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    if op == ConfigOp::Set {
-        let addr = if let Some(addr) = args.v4addr() {
-            IpAddr::V4(addr)
-        } else if let Some(addr) = args.v6addr() {
-            IpAddr::V6(addr)
-        } else {
-            return None;
-        };
-        let identifier: Ipv4Addr = args.v4addr()?;
-        if let Some(peer) = bgp.peers.get_mut(&addr) {
-            peer.local_identifier = Some(identifier);
-            peer.start();
-        }
+    let addr = if let Some(addr) = args.v4addr() {
+        IpAddr::V4(addr)
+    } else if let Some(addr) = args.v6addr() {
+        IpAddr::V6(addr)
+    } else {
+        return None;
+    };
+    let identifier = if op == ConfigOp::Set {
+        Some(args.v4addr()?)
+    } else {
+        // Delete reverts the peer to the instance identifier instead
+        // of keeping the per-peer override forever.
+        None
+    };
+    if let Some(peer) = bgp.peers.get_mut(&addr) {
+        peer.local_identifier = identifier;
+        peer.start();
     }
     Some(())
 }

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -342,7 +342,21 @@ pub struct RibKnownVrf {
 
 pub struct Bgp {
     pub asn: u32,
+    /// Effective BGP Identifier — what OPENs, EVPN RDs and the show
+    /// paths use. Derived: configured `global identifier` wins, else
+    /// the RIB-derived value, else 0.0.0.0. Mutate via
+    /// `refresh_router_id` (or `set_router_id` for the propagation
+    /// side effects), never directly.
     pub router_id: Ipv4Addr,
+    /// Operator-configured `router bgp global identifier`. Wins over
+    /// the RIB-derived value; deleting it falls back (same
+    /// configured-vs-derived split IS-IS uses for te-router-id).
+    pub router_id_config: Option<Ipv4Addr>,
+    /// Last RIB-derived router-id (`RibRx::RouterIdUpdate`), kept
+    /// even while a configured identifier overrides it so a later
+    /// `delete ... identifier` can fall back without waiting for the
+    /// next RIB push.
+    pub rib_router_id: Option<Ipv4Addr>,
     /// FRR-style `advertise-all-vni` knob under `router bgp afi-safi
     /// evpn`. When true, every locally-configured VXLAN VNI
     /// participates in EVPN advertisement: Type-2 (MAC/IP) routes
@@ -729,6 +743,8 @@ impl Bgp {
         let mut bgp = Self {
             asn: 0,
             router_id: Ipv4Addr::UNSPECIFIED,
+            router_id_config: None,
+            rib_router_id: None,
             advertise_all_vni: false,
             local_fdb: BTreeMap::new(),
             local_vxlans: BTreeMap::new(),
@@ -1153,13 +1169,11 @@ impl Bgp {
     /// before the router-id was known would emit OPEN messages with
     /// `0.0.0.0` in the BGP Identifier field forever.
     ///
-    /// Inputs:
-    ///   - operator config (`set router bgp global identifier <ip>`)
-    ///     via `config_global_identifier`.
-    ///   - RIB-derived auto-pick (`RibRx::RouterIdUpdate`) when no
-    ///     explicit identifier is configured. Same precedence Cisco /
-    ///     Junos use — last write wins for now; an explicit / auto
-    ///     priority pin is a follow-up.
+    /// Both inputs — operator config (`router bgp global identifier`)
+    /// and the RIB-derived auto-pick (`RibRx::RouterIdUpdate`) — land
+    /// here through `refresh_router_id`, which resolves their
+    /// precedence (configured wins). Don't call this with a raw input
+    /// value from either source; update the source field and refresh.
     ///
     /// Existing established sessions keep using the value they sent
     /// at OPEN; the next OPEN (after a reset) picks up the new one.
@@ -1226,6 +1240,30 @@ impl Bgp {
                 }
             }
         }
+    }
+
+    /// Recompute the effective BGP Identifier from its two sources —
+    /// configured `global identifier` wins, RIB-derived second — and
+    /// propagate it. Falls back to 0.0.0.0 only when neither exists
+    /// (pre-config cold start, or identifier deleted before any
+    /// interface address was learned).
+    pub fn refresh_router_id(&mut self) {
+        let effective = self
+            .router_id_config
+            .or(self.rib_router_id)
+            .unwrap_or(Ipv4Addr::UNSPECIFIED);
+        self.set_router_id(effective);
+    }
+
+    /// `RibRx::RouterIdUpdate` handler: remember the RIB-derived
+    /// value and refresh. A configured `global identifier` keeps
+    /// winning (the update is stored, not applied), so a later
+    /// identifier delete can still fall back to it — the IS-IS
+    /// `rib_router_id` pattern, replacing the old last-writer-wins
+    /// behavior where this push stomped the configured value.
+    pub fn rib_router_id_update(&mut self, router_id: Ipv4Addr) {
+        self.rib_router_id = (!router_id.is_unspecified()).then_some(router_id);
+        self.refresh_router_id();
     }
 
     pub fn pcallback_add(&mut self, path: &str, cb: PCallback) {
@@ -1941,13 +1979,12 @@ impl Bgp {
                 self.refresh_connected();
             }
             RibRx::RouterIdUpdate(router_id) => {
-                // RIB auto-derived a router-id from interface IPv4
-                // addresses (highest loopback, falling back to
-                // non-loopback). Without this arm BGP missed the
-                // notification and emitted OPEN with 0.0.0.0 in the
-                // BGP Identifier whenever the operator hadn't typed
-                // `set router bgp global identifier <ip>`.
-                self.set_router_id(router_id);
+                // RIB-derived router-id (top-level `router-id` config
+                // or the automatic pick from interface addresses).
+                // Without this arm BGP emitted OPEN with 0.0.0.0 in
+                // the BGP Identifier whenever the operator hadn't
+                // typed `set router bgp global identifier <ip>`.
+                self.rib_router_id_update(router_id);
             }
             RibRx::FdbAdd(entry) => {
                 // Cache durably so we can replay on `advertise_all_vni`

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -271,16 +271,21 @@ pub(super) fn apply_link_enable_transition<V: OspfVersion>(
 }
 
 fn config_ospf_router_id(ospf: &mut Ospf, mut args: Args, op: ConfigOp) -> Option<()> {
-    let router_id = args.v4addr()?;
     if op.is_set() {
-        // Apply the configured Router-ID to the instance, push it into
-        // every interface's `ident`, and re-originate. Previously this
-        // callback parsed the value and dropped it, so every OSPFv2
-        // instance kept the constructor default (10.0.0.1) — making all
-        // routers share one Router-ID, so each treated every neighbour's
-        // Hello as self-originated and no adjacency ever formed.
-        ospf.router_id_update(router_id);
+        // Store the configured Router-ID; `refresh_router_id` pushes
+        // it into the instance and every interface's `ident` and
+        // re-originates. Previously this callback parsed the value
+        // and dropped it, so every OSPFv2 instance kept the
+        // constructor default (10.0.0.1) — making all routers share
+        // one Router-ID, so each treated every neighbour's Hello as
+        // self-originated and no adjacency ever formed.
+        ospf.router_id_config = Some(args.v4addr()?);
+    } else {
+        // Delete falls back to the RIB-derived value (or the
+        // constructor default) instead of keeping the old Router-ID.
+        ospf.router_id_config = None;
     }
+    ospf.refresh_router_id();
     Some(())
 }
 

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -227,15 +227,19 @@ fn config_ospfv3_area_type(ospf: &mut Ospf<Ospfv3>, mut args: Args, op: ConfigOp
 }
 
 /// `router ospfv3 { router-id ... }`. Mirrors v2's
-/// `config_ospf_router_id`: apply the configured Router-ID to the
-/// instance (and every interface's `ident`) and re-originate.
-/// Previously OSPFv3 had no per-instance Router-ID callback at all,
-/// so every v3 instance kept the constructor default 10.0.0.1.
+/// `config_ospf_router_id`: store the configured Router-ID and
+/// refresh — the instance (and every interface's `ident`) picks it
+/// up and re-originates. Delete falls back instead of keeping the
+/// old value. Previously OSPFv3 had no per-instance Router-ID
+/// callback at all, so every v3 instance kept the constructor
+/// default 10.0.0.1.
 fn config_ospfv3_router_id(ospf: &mut Ospf<Ospfv3>, mut args: Args, op: ConfigOp) -> Option<()> {
-    let router_id = args.v4addr()?;
     if op.is_set() {
-        ospf.router_id_update(router_id);
+        ospf.router_id_config = Some(args.v4addr()?);
+    } else {
+        ospf.router_id_config = None;
     }
+    ospf.refresh_router_id();
     Some(())
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::net::Ipv4Addr;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -60,6 +59,12 @@ use crate::context::{Timer, TimerType};
 /// keep existing v2 callsites resolving unchanged.
 pub type ShowCallback<V = Ospfv2> = fn(&Ospf<V>, Args, bool) -> Result<String, std::fmt::Error>;
 
+/// Constructor-default Router ID, used until a configured or
+/// RIB-derived value arrives (and as the fallback when a configured
+/// one is deleted on an instance that never received a RIB value,
+/// i.e. OSPFv3 today).
+pub const DEFAULT_ROUTER_ID: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 1);
+
 /// OSPF protocol instance.
 ///
 /// Parameterized over `V: OspfVersion` (default `Ospfv2`) so the
@@ -88,7 +93,21 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     pub show: ShowChannel,
     pub show_cb: HashMap<String, ShowCallback<V>>,
     pub sock: Arc<AsyncFd<Socket>>,
+    /// Effective Router ID — what packets, LSAs and every link
+    /// `ident` carry. Derived: configured `router-id` wins, then the
+    /// RIB-derived value, then [`DEFAULT_ROUTER_ID`]. Mutate via
+    /// `refresh_router_id`, never directly.
     pub router_id: Ipv4Addr,
+    /// Operator-configured `router ospf{,v3} router-id`. Wins over
+    /// the RIB-derived value; deleting it falls back (the IS-IS
+    /// configured-vs-derived split).
+    pub router_id_config: Option<Ipv4Addr>,
+    /// Last RIB-derived router-id (`RibRx::RouterIdUpdate`), kept
+    /// while a configured router-id overrides it so a later delete
+    /// can fall back immediately. Always `None` on OSPFv3 today —
+    /// its `process_rib_msg` has no `RouterIdUpdate` arm yet — so v3
+    /// falls back to [`DEFAULT_ROUTER_ID`] instead.
+    pub rib_router_id: Option<Ipv4Addr>,
     pub lsdb_as: Lsdb<V>,
     pub lsp_map: LspMap,
     pub spf_result: Option<BTreeMap<usize, Path>>,
@@ -962,7 +981,9 @@ impl Ospf<Ospfv2> {
             areas: OspfAreaMap::new(),
             show: ShowChannel::new(),
             show_cb: HashMap::new(),
-            router_id: Ipv4Addr::from_str("10.0.0.1").unwrap(),
+            router_id: DEFAULT_ROUTER_ID,
+            router_id_config: None,
+            rib_router_id: None,
             lsdb_as: Lsdb::new(),
             lsp_map: LspMap::default(),
             spf_result: None,
@@ -4281,6 +4302,23 @@ impl Ospf<Ospfv2> {
         self.router_lsa_originate();
     }
 
+    /// Recompute the effective Router ID from its sources —
+    /// configured `router-id` wins, RIB-derived second, constructor
+    /// default last — and apply it (links + Router-LSA re-origination)
+    /// when it moved. Both the config callback and the
+    /// `RibRx::RouterIdUpdate` arm funnel through here, so a
+    /// configured value can't be stomped by a RIB push and a config
+    /// delete falls back instead of keeping the stale value.
+    pub(super) fn refresh_router_id(&mut self) {
+        let effective = self
+            .router_id_config
+            .or(self.rib_router_id)
+            .unwrap_or(DEFAULT_ROUTER_ID);
+        if self.router_id != effective {
+            self.router_id_update(effective);
+        }
+    }
+
     fn addr_add(&mut self, addr: LinkAddr) {
         // println!("OSPF: AddrAdd {} {}", addr.addr, addr.ifindex);
         let Some(link) = self.links.get_mut(&addr.ifindex) else {
@@ -4693,7 +4731,12 @@ impl Ospf<Ospfv2> {
     fn process_rib_msg(&mut self, msg: RibRx) {
         match msg {
             RibRx::RouterIdUpdate(router_id) => {
-                self.router_id_update(router_id);
+                // Remember the RIB-derived value and refresh: a
+                // configured `router-id` keeps winning (this push
+                // used to stomp it), and a later config delete falls
+                // back to the stored value.
+                self.rib_router_id = (!router_id.is_unspecified()).then_some(router_id);
+                self.refresh_router_id();
             }
             RibRx::LinkAdd(link) => {
                 self.link_add(link);
@@ -4899,7 +4942,9 @@ impl Ospf<Ospfv3> {
             areas: OspfAreaMap::new(),
             show: ShowChannel::new(),
             show_cb: HashMap::new(),
-            router_id: Ipv4Addr::from_str("10.0.0.1").unwrap(),
+            router_id: DEFAULT_ROUTER_ID,
+            router_id_config: None,
+            rib_router_id: None,
             lsdb_as: Lsdb::new(),
             lsp_map: LspMap::default(),
             spf_result: None,
@@ -5134,17 +5179,33 @@ impl Ospf<Ospfv3> {
         }
     }
 
-    /// Apply a configured Router-ID to this OSPFv3 instance. Mirror of
-    /// the v2 `router_id_update`; wired from `config_ospfv3_router_id`
-    /// so `router ospfv3 { router-id ... }` is honoured (previously
-    /// v3 had no per-instance Router-ID path at all and every instance
-    /// kept the constructor default 10.0.0.1).
+    /// Apply a Router-ID to this OSPFv3 instance. Mirror of the v2
+    /// `router_id_update`; reached via `refresh_router_id` from
+    /// `config_ospfv3_router_id` so `router ospfv3 { router-id ... }`
+    /// is honoured (previously v3 had no per-instance Router-ID path
+    /// at all and every instance kept the constructor default
+    /// 10.0.0.1).
     pub(super) fn router_id_update(&mut self, router_id: Ipv4Addr) {
         self.router_id = router_id;
         for (_, link) in self.links.iter_mut() {
             link.ident.router_id = router_id;
         }
         self.router_lsa_originate();
+    }
+
+    /// v3 sibling of the v2 `refresh_router_id`: configured value
+    /// wins, then RIB-derived, then the constructor default. v3's
+    /// `process_rib_msg` has no `RouterIdUpdate` arm yet, so
+    /// `rib_router_id` is always `None` here and a config delete
+    /// falls back to [`DEFAULT_ROUTER_ID`].
+    pub(super) fn refresh_router_id(&mut self) {
+        let effective = self
+            .router_id_config
+            .or(self.rib_router_id)
+            .unwrap_or(DEFAULT_ROUTER_ID);
+        if self.router_id != effective {
+            self.router_id_update(effective);
+        }
     }
 
     /// Remove an IPv6 address from the matching link's `addr` list


### PR DESCRIPTION
## Summary

Bring BGP and OSPF router-id handling in line with the IS-IS te-router-id pattern: store the operator-configured value and the RIB-derived value separately and derive the effective Router ID (configured first, RIB-derived second, then 0.0.0.0 for BGP / the 10.0.0.1 constructor default for OSPF). All mutation paths funnel through one `refresh_router_id` helper per protocol.

Fixes two defects in one move:

- **Delete was a no-op**: `delete router bgp global identifier` / `delete router ospf{,v3} router-id` parsed the op and kept the old value forever. Now they fall back to the RIB-derived value (or the default). The per-peer `local-identifier` delete had the same bug and now reverts the peer to the instance identifier.
- **Last-writer-wins stomp**: a RIB `RouterIdUpdate` (interface address change or top-level `router-id` edit, #1312) overwrote an explicitly configured BGP identifier / OSPFv2 router-id. Now the RIB value is stored, not applied, while a configured override exists.

OSPFv3 still has no `RouterIdUpdate` arm (its `rib_router_id` stays `None`, so delete falls back to the 10.0.0.1 default); wiring that arm is a follow-up that would also fix v3's unconfigured default.

## Test plan

- `cargo test --workspace --exclude bdd` all green; workspace clippy clean; `cargo fmt` applied.
- Live-validated end-to-end on a root daemon: configured BGP 1.1.1.1 / OSPFv2 2.2.2.2 / OSPFv3 3.3.3.3 all survived a `set router-id 9.9.9.9` broadcast (old code flipped BGP and OSPFv2 to 9.9.9.9); deleting each fell back to 9.9.9.9 / 9.9.9.9 / 10.0.0.1; deleting the global knob chained BGP+OSPFv2 down to the automatic pick.

Generated with [Claude Code](https://claude.com/claude-code)