### PR TITLE
isis: re-originate LSP when te-router-id changes

### DIFF
--- a/zebra-rs/src/isis/config.rs
+++ b/zebra-rs/src/isis/config.rs
@@ -1783,11 +1783,35 @@ fn config_redistribute_ospf_match_type(isis: &mut Isis, args: Args, op: ConfigOp
 fn config_te_router_id(isis: &mut Isis, mut args: Args, op: ConfigOp) -> Option<()> {
     let te_router_id = args.v4addr()?;
 
+    // The LSP carries the EFFECTIVE router-id — configured
+    // te-router-id first, RIB-derived second (TLV 134 and the
+    // Router Capability TLV both resolve `te_router_id.or(
+    // rib_router_id)` at build time). Compare that, not the raw
+    // leaf, so configuring the value the RIB already supplies (or
+    // deleting an override that matches it) doesn't churn the LSP.
+    let prev = isis.config.te_router_id.or(isis.config.rib_router_id);
     if op == ConfigOp::Set {
         isis.config.te_router_id = Some(te_router_id);
     } else {
         isis.config.te_router_id = None;
     }
+    let curr = isis.config.te_router_id.or(isis.config.rib_router_id);
+
+    if prev == curr {
+        return Some(());
+    }
+
+    // Re-originate self LSP at any level that has one so the new
+    // router-id (or its fallback) propagates without waiting for the
+    // refresh timer — same pattern as `config_hostname`. Levels with
+    // no self LSP yet pick the value up naturally on first emission.
+    let key = IsisLspId::new(isis.config.net.sys_id(), 0, 0);
+    for level in [Level::L1, Level::L2] {
+        if isis.lsdb.get(&level).get(&key).is_some() {
+            let _ = isis.tx.send(Message::LspOriginate(level, None));
+        }
+    }
+
     Some(())
 }
 


### PR DESCRIPTION
## Summary

`config_te_router_id` only mutated config, so a `te-router-id` set or delete sat invisible until the next LSP refresh (~15 min): both the TE Router ID TLV (134) and the Router Capability router-id resolve `te_router_id.or(rib_router_id)` at LSP build time, and nothing scheduled a rebuild.

Adopt the `config_hostname` pattern: compare the **effective** router-id (configured first, RIB-derived fallback) before and after the edit and, when it moved, re-originate the self LSP at every level that has one. Comparing effective values keeps no-op edits quiet — configuring the value the RIB already supplies, or deleting an override that matches it, doesn't churn the LSP. Levels with no self LSP yet pick the value up naturally on first emission.

Follow-up to #1312/#1314 in the router-id series.

## Test plan

- `cargo test --workspace --exclude bdd` all green (35 binaries); workspace clippy clean; `cargo fmt` applied.
- Live-validated on a single SR-enabled node (L1+L2): `set router isis te-router-id 4.4.4.4` flipped both the TE Router ID TLV and the Router Capability router-id to 4.4.4.4 within the 5 s LSP-gen backoff; delete fell back to the RIB-derived 10.0.0.1 just as fast. The same sequence previously required waiting out the refresh timer.

Generated with [Claude Code](https://claude.com/claude-code)