### PR TITLE
bgp: fix permanent session wedge after TCP reset (collision promotion)

### DIFF
--- a/crates/bgp-packet/src/notification.rs
+++ b/crates/bgp-packet/src/notification.rs
@@ -312,6 +312,25 @@ pub enum CeaseError {
     Unknown(u8),
 }
 
+impl From<CeaseError> for u8 {
+    fn from(error: CeaseError) -> Self {
+        use CeaseError::*;
+        match error {
+            MaximumNumberOfPrefixReached => 1,
+            AdministrativeShutdown => 2,
+            PeerDeConfigured => 3,
+            AdministrativeReset => 4,
+            ConnectionRejected => 5,
+            OtherConfigChange => 6,
+            ConnectionCollisionResolution => 7,
+            OutOfResources => 8,
+            HardReset => 9,
+            BfdDown => 10,
+            Unknown(v) => v,
+        }
+    }
+}
+
 impl From<u8> for CeaseError {
     fn from(sub_code: u8) -> Self {
         use CeaseError::*;
@@ -411,5 +430,22 @@ impl NotificationPacket {
             .saturating_sub(2);
         let (input, _data) = take(len as usize).parse(input)?;
         Ok((input, packet))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CeaseError;
+
+    /// Every Cease sub-code round-trips u8 → CeaseError → u8, including
+    /// the Unknown passthrough.
+    #[test]
+    fn cease_error_subcode_round_trip() {
+        for raw in [1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 42, 255] {
+            let err = CeaseError::from(raw);
+            assert_eq!(u8::from(err), raw);
+        }
+        assert_eq!(u8::from(CeaseError::ConnectionRejected), 5);
+        assert_eq!(u8::from(CeaseError::ConnectionCollisionResolution), 7);
     }
 }

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -1725,16 +1725,29 @@ pub fn fsm_conn_fail(peer: &mut Peer, conn: ConnTag) -> State {
         }
         return peer.state;
     }
-    // Primary conn failed. If a collision conn is waiting, promote it
-    // — there is no §6.8 decision to make yet (we haven't seen an
-    // OPEN on either) but the surviving TCP is the only one we have.
+    // Primary conn failed. A parked collision conn must NOT be
+    // promoted here: its reader/writer tasks were spawned with
+    // `ConnTag::Collision` baked into every event they emit, so after
+    // a promotion the connection's own failure is misrouted into the
+    // collision arm above (the state silently stays OpenSent with no
+    // socket and no retry timer — a permanent wedge), its KEEPALIVEs
+    // are ignored by `fsm_bgp_keepalive`, and its OPEN hits the §6.8
+    // arms with an empty collision slot. Reproduced by resetting the
+    // TCP session of an Established peer: both ends raced to
+    // reconnect, the parked conn was promoted, and the session never
+    // recovered. Close the parked conn alongside the failed primary
+    // and restart from Active — losing a pre-OPEN conn costs one
+    // reconnect round-trip.
     peer.task.writer = None;
     peer.task.reader = None;
     peer.packet_tx = None;
     peer.primary_role = None;
     if let Some(collision) = peer.collision.take() {
-        promote_collision_to_primary(peer, collision);
-        return State::OpenSent;
+        close_collision(
+            collision,
+            NotifyCode::Cease,
+            CeaseError::ConnectionRejected.into(),
+        );
     }
     peer.timer.connect_retry = Some(timer::start_connect_retry_timer(peer));
     State::Active


### PR DESCRIPTION
## Summary

Investigating the "VPNv4 table durably empty after a session flap" observation from the #1310 verification led to a deterministic reproduction and a worse finding: **a single TCP-level reset of an Established session could permanently kill it.**

**Repro** (Inter-AS Option B topology, PE↔ASBR VPNv4 session): `ip netns exec <pe1-ns> ss -K dst 1.1.1.3`. Both ends race to reconnect; one connection parks in `peer.collision`; when the primary fails, `fsm_conn_fail` promoted the parked conn and returned `OpenSent`. Observed result: peer stuck in `OpenSent` with **zero TCP sockets, no connect-retry timer, and no reconnect attempts for 5+ minutes**, with every route that traversed the session durably gone from both ends.

**Root cause**: `promote_collision_to_primary` moves the socket handles, but the parked connection's reader/writer tasks were spawned with `ConnTag::Collision` baked into every event they emit — a promotion cannot re-tag a running task. After promotion:
- the connection's own `ConnFail` is misrouted into the "drop the collision slot" arm → state silently stays `OpenSent` with no socket and no retry (the wedge);
- its KEEPALIVEs are discarded by `fsm_bgp_keepalive`'s collision guard, so even a healthy promoted conn can never complete the handshake or refresh hold;
- its OPEN lands in the §6.8 arms with an empty collision slot.

**Fix**: never promote in `fsm_conn_fail`. Close the parked conn alongside the failed primary (NOTIFICATION Cease/ConnectionRejected — `close_collision` also cancels its tasks) and restart from `Active` with connect-retry armed. A pre-OPEN parked conn isn't worth saving; losing it costs one reconnect round-trip. The OPEN-time §6.8 collision resolution is untouched. Includes the missing `From<CeaseError> for u8` plus a sub-code round-trip test.

## Testing

- **Live validation**: rebuilt topology on the fixed binary (`/usr/bin/zebra-rs` hash-verified), repeated the exact `ss -K` kill → peer goes `Active`, connect-retry fires, session re-establishes at the ~2-minute mark (default retry interval), and **both VPNv4 tables refill completely**. Before the fix the same kill wedged the session indefinitely.
- BDD `@bgp_interas_option_b`: 6/6 on the fixed binary.
- 1484 workspace tests pass; `cargo clippy --workspace --all-targets -- -D warnings` clean.

Related findings recorded for follow-up (memory + investigation notes): `clear bgp ipv4 <peer>` hard clear is a silent no-op (separate bug, uninvestigated), and the original incident's additional symptom (VRF-export Originated row lost under a link-down storm) was not reproduced by the `ss -K` flavor and may be resolved by this fix — needs a link-down-flavored reproduction to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)