### PR TITLE
ospfv3,isis: per-VRF router-id YANG + fix same-commit vrf spawn race

### DIFF
--- a/zebra-rs/src/isis/inst.rs
+++ b/zebra-rs/src/isis/inst.rs
@@ -876,7 +876,50 @@ impl Isis {
         if let Some(handle) = self.vrf_registry.get(&name) {
             let _ = handle.cm_tx.send(ConfigRequest::new(rewritten.clone(), op));
         }
-        self.vrf_log.entry(name).or_default().push((rewritten, op));
+        self.vrf_log
+            .entry(name.clone())
+            .or_default()
+            .push((rewritten, op));
+        // The kernel VrfAdd may already have been processed BEFORE this
+        // intent line: in a same-commit `vrf X` + `router isis vrf X ...`
+        // apply, the netlink-acked VrfAdd and the config lines race on
+        // separate channels, and `vrf_add` alone only spawns when intent
+        // landed first. Spawn here too (no-op while either half is still
+        // missing) instead of waiting for a VrfDel/VrfAdd flap.
+        self.vrf_spawn_if_ready(&name);
+    }
+
+    /// Spawn the per-VRF child once BOTH halves exist — kernel info
+    /// (`rib_known_vrfs`, from `VrfAdd`) and active config intent
+    /// (`vrf_log`). Called from `vrf_add` (kernel half arriving) and
+    /// `vrf_config_record` (intent half arriving); whichever lands
+    /// second performs the spawn.
+    fn vrf_spawn_if_ready(&mut self, name: &str) {
+        if self.vrf_registry.contains_key(name) {
+            return;
+        }
+        let Some(&(table_id, _)) = self.rib_known_vrfs.get(name) else {
+            return;
+        };
+        let has_intent = self
+            .vrf_log
+            .get(name)
+            .is_some_and(|log| super::vrf::vrf_log_active(log));
+        if !has_intent {
+            return;
+        }
+        // Clone the replay log so the spawn borrow doesn't overlap the
+        // `vrf_registry` insert below.
+        let log = self.vrf_log.get(name).cloned().unwrap_or_default();
+        let handle = super::vrf::spawn_isis_vrf(
+            name,
+            table_id,
+            &self.rib_subscriber,
+            &self.config_tx,
+            &self.policy_tx,
+            &log,
+        );
+        self.vrf_registry.insert(name.to_string(), handle);
     }
 
     /// CommitEnd fan-out for the default instance: tear down per-VRF
@@ -1510,28 +1553,7 @@ impl Isis {
     fn vrf_add(&mut self, name: String, table_id: u32, ifindex: u32) {
         self.rib_known_vrfs
             .insert(name.clone(), (table_id, ifindex));
-        if self.vrf_registry.contains_key(&name) {
-            return;
-        }
-        let has_intent = self
-            .vrf_log
-            .get(&name)
-            .is_some_and(|log| super::vrf::vrf_log_active(log));
-        if !has_intent {
-            return;
-        }
-        // Clone the replay log so the spawn borrow doesn't overlap the
-        // `vrf_registry` insert below.
-        let log = self.vrf_log.get(&name).cloned().unwrap_or_default();
-        let handle = super::vrf::spawn_isis_vrf(
-            &name,
-            table_id,
-            &self.rib_subscriber,
-            &self.config_tx,
-            &self.policy_tx,
-            &log,
-        );
-        self.vrf_registry.insert(name, handle);
+        self.vrf_spawn_if_ready(&name);
     }
 
     /// Kernel VRF master removed. Despawn the child but KEEP its config

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -652,7 +652,50 @@ impl<V: OspfVersion> Ospf<V> {
         if let Some(handle) = self.vrf_registry.get(&name) {
             let _ = handle.cm_tx.send(ConfigRequest::new(rewritten.clone(), op));
         }
-        self.vrf_log.entry(name).or_default().push((rewritten, op));
+        self.vrf_log
+            .entry(name.clone())
+            .or_default()
+            .push((rewritten, op));
+        // The kernel VrfAdd may already have been processed BEFORE this
+        // intent line: in a same-commit `vrf X` + `router ... vrf X ...`
+        // apply, the netlink-acked VrfAdd and the config lines race on
+        // separate channels, and `vrf_add` alone only spawns when intent
+        // landed first. Spawn here too (no-op while either half is still
+        // missing) instead of waiting for a VrfDel/VrfAdd flap.
+        self.vrf_spawn_if_ready(&name);
+    }
+
+    /// Spawn the per-VRF child once BOTH halves exist — kernel info
+    /// (`rib_known_vrfs`, from `VrfAdd`) and active config intent
+    /// (`vrf_log`). Called from `vrf_add` (kernel half arriving) and
+    /// `vrf_config_record` (intent half arriving); whichever lands
+    /// second performs the spawn.
+    pub(crate) fn vrf_spawn_if_ready(&mut self, name: &str) {
+        if self.vrf_registry.contains_key(name) {
+            return;
+        }
+        let Some(&(table_id, _)) = self.rib_known_vrfs.get(name) else {
+            return;
+        };
+        let has_intent = self
+            .vrf_log
+            .get(name)
+            .is_some_and(|log| super::vrf::vrf_log_active(log));
+        if !has_intent {
+            return;
+        }
+        // Clone the replay log so the spawn borrow doesn't overlap the
+        // `vrf_registry` insert below.
+        let log = self.vrf_log.get(name).cloned().unwrap_or_default();
+        let handle = V::spawn_vrf(
+            name,
+            table_id,
+            &self.rib_subscriber,
+            &self.config_tx,
+            &self.policy_tx,
+            &log,
+        );
+        self.vrf_registry.insert(name.to_string(), handle);
     }
 
     /// `CommitEnd` fan-out for the default instance: tear down per-VRF
@@ -694,28 +737,7 @@ impl<V: OspfVersion> Ospf<V> {
     pub(crate) fn vrf_add(&mut self, name: String, table_id: u32, ifindex: u32) {
         self.rib_known_vrfs
             .insert(name.clone(), (table_id, ifindex));
-        if self.vrf_registry.contains_key(&name) {
-            return;
-        }
-        let has_intent = self
-            .vrf_log
-            .get(&name)
-            .is_some_and(|log| super::vrf::vrf_log_active(log));
-        if !has_intent {
-            return;
-        }
-        // Clone the replay log so the spawn borrow doesn't overlap the
-        // `vrf_registry` insert below.
-        let log = self.vrf_log.get(&name).cloned().unwrap_or_default();
-        let handle = V::spawn_vrf(
-            &name,
-            table_id,
-            &self.rib_subscriber,
-            &self.config_tx,
-            &self.policy_tx,
-            &log,
-        );
-        self.vrf_registry.insert(name, handle);
+        self.vrf_spawn_if_ready(&name);
     }
 
     /// Kernel VRF master removed. Despawn the child but KEEP its config

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -1228,13 +1228,18 @@ module config {
           // Per-VRF OSPFv3 instance. See `container ospf`'s `vrf`
           // list for the forwarding model. Exposes the per-interface
           // knobs the v3 instance handles (enable / network-type /
-          // priority / timers). `router-id` and `redistribute` are
-          // omitted — the v3 instance has no config handler for them
-          // today (so a forwarded line would be a no-op).
+          // priority / timers) plus `router-id` (the forwarded line
+          // hits the same `/router/ospfv3/router-id` callback on the
+          // child). `redistribute` stays omitted — the v3 instance
+          // has no config handler for it today (a forwarded line
+          // would be a no-op).
           key "name";
           leaf name {
             ext:dynamic "rib:vrf";
             type string;
+          }
+          leaf router-id {
+            type inet:ipv4-address;
           }
           list area {
             key "area-id";
@@ -2150,6 +2155,17 @@ module config {
               enum level-1-2;
               enum level-2-only;
             }
+          }
+          leaf te-router-id {
+            ext:help "Traffic-engineering stable Router ID";
+            // Forwarded to the child's `/router/isis/te-router-id`
+            // callback and stored per-VRF. NOTE: the TLVs that carry
+            // it (TE Router ID 134, Router Capability router-id) are
+            // gated on `sr_enabled()` at LSP build time, and the
+            // per-VRF surface doesn't expose `segment-routing` yet —
+            // so the value stages today and goes on the wire once
+            // per-VRF SR lands.
+            type inet:ipv4-address;
           }
           container timers {
             // `hold-time` (hyphen) matches the callback path


### PR DESCRIPTION
## Summary

Widen the per-VRF config surface for the router-id series (#1312/#1314/#1315):

- **`router ospfv3 vrf <name> router-id`** — the leaf was omitted with a comment claiming the v3 instance has no handler; that's been stale since the adjacency-formation fix added `config_ospfv3_router_id`. The forwarded line hits the same `/router/ospfv3/router-id` callback on the per-VRF child, so set / delete / fallback behave exactly like the default instance (delete falls back to the 10.0.0.1 default — v3 has no `RouterIdUpdate` arm yet).
- **`router isis vrf <name> te-router-id`** — stored per-VRF via the forwarded `/router/isis/te-router-id` callback. The TLVs that carry it (TE Router ID 134, Router Capability) are gated on `sr_enabled()` and the per-VRF surface doesn't expose segment-routing yet, so the value stages today and goes on the wire once per-VRF SR lands (noted in the YANG comment).

**Plus a pre-existing spawn-race fix the validation exposed**, shared by IS-IS and OSPF\<V\>: a per-VRF child spawned only when `VrfAdd` (kernel half) found config intent already recorded. In a single-commit `vrf X` + `router <proto> vrf X ...` apply the two halves race on separate channels; when `VrfAdd` won, the child never spawned until a VrfDel/VrfAdd flap. Observed live: in the same commit, the IS-IS child lost the race while the OSPFv3 child won it. Fix: extract the spawn gate into `vrf_spawn_if_ready` and call it from BOTH arrival paths — whichever half lands second performs the spawn.

## Test plan

- `cargo test --workspace --exclude bdd` all green (35 binaries); YANG load tests pass; workspace clippy clean; `cargo fmt` applied.
- Live-validated on a fresh daemon with a single-commit apply (`vrf red` + `interface d0 vrf red` + both per-VRF protocol blocks): both per-VRF children now spawn (~64 ms apart; previously IS-IS required a flap); `show ipv6 ospf vrf red` shows the configured Router ID 7.7.7.7; runtime `set`/`delete` work and delete falls back to 10.0.0.1.

Generated with [Claude Code](https://claude.com/claude-code)