### PR TITLE
rib: per-VRF router-id + ospfv3 RouterIdUpdate arm

### DIFF
--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -61,8 +61,7 @@ pub type ShowCallback<V = Ospfv2> = fn(&Ospf<V>, Args, bool) -> Result<String, s
 
 /// Constructor-default Router ID, used until a configured or
 /// RIB-derived value arrives (and as the fallback when a configured
-/// one is deleted on an instance that never received a RIB value,
-/// i.e. OSPFv3 today).
+/// one is deleted on an instance that never received a RIB value).
 pub const DEFAULT_ROUTER_ID: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 1);
 
 /// OSPF protocol instance.
@@ -104,9 +103,7 @@ pub struct Ospf<V: OspfVersion = Ospfv2> {
     pub router_id_config: Option<Ipv4Addr>,
     /// Last RIB-derived router-id (`RibRx::RouterIdUpdate`), kept
     /// while a configured router-id overrides it so a later delete
-    /// can fall back immediately. Always `None` on OSPFv3 today —
-    /// its `process_rib_msg` has no `RouterIdUpdate` arm yet — so v3
-    /// falls back to [`DEFAULT_ROUTER_ID`] instead.
+    /// can fall back immediately.
     pub rib_router_id: Option<Ipv4Addr>,
     pub lsdb_as: Lsdb<V>,
     pub lsp_map: LspMap,
@@ -5122,6 +5119,18 @@ impl Ospf<Ospfv3> {
     /// router-LSA re-origination) is a follow-up PR.
     fn process_rib_msg(&mut self, msg: RibRx) {
         match msg {
+            // RIB-derived router-id (top-level `router-id` config or
+            // the automatic pick from interface IPv4 addresses).
+            // Mirrors the v2 arm: store and refresh, so a configured
+            // `router ospfv3 router-id` keeps winning and a config
+            // delete falls back to this value. Before this arm every
+            // unconfigured v3 instance kept the constructor default
+            // 10.0.0.1 — two such routers shared one Router-ID and
+            // could never form an adjacency.
+            RibRx::RouterIdUpdate(router_id) => {
+                self.rib_router_id = (!router_id.is_unspecified()).then_some(router_id);
+                self.refresh_router_id();
+            }
             RibRx::LinkAdd(link) => self.link_add(link),
             RibRx::LinkUp(ifindex) => self.link_up(ifindex),
             RibRx::LinkDown(ifindex) => self.link_down(ifindex),
@@ -5216,10 +5225,8 @@ impl Ospf<Ospfv3> {
     }
 
     /// v3 sibling of the v2 `refresh_router_id`: configured value
-    /// wins, then RIB-derived, then the constructor default. v3's
-    /// `process_rib_msg` has no `RouterIdUpdate` arm yet, so
-    /// `rib_router_id` is always `None` here and a config delete
-    /// falls back to [`DEFAULT_ROUTER_ID`].
+    /// wins, then the RIB-derived value (v3's `process_rib_msg`
+    /// `RouterIdUpdate` arm), then the constructor default.
     pub(super) fn refresh_router_id(&mut self) {
         let effective = self
             .router_id_config

--- a/zebra-rs/src/rib/api.rs
+++ b/zebra-rs/src/rib/api.rs
@@ -332,12 +332,12 @@ impl Rib {
         }
     }
 
-    /// Router id is daemon-global today (one IPv4 address per
-    /// instance), so this push always targets default-VRF
-    /// subscribers. Per-VRF router-id arrives with the BGP-per-VRF
-    /// config and will gain its own emit path.
-    pub fn api_router_id_update(&self, router_id: Ipv4Addr) {
-        for (_, sub) in self.client_registry.iter_vrf(0) {
+    /// Push a Router-ID change to one VRF's subscriber set — `0` for
+    /// the default VRF (global effective value), a kernel `table_id`
+    /// for a named VRF (its per-VRF effective value). Emitted by
+    /// `Rib::router_id_update`, which owns the derivation.
+    pub fn api_router_id_update(&self, vrf_id: u32, router_id: Ipv4Addr) {
+        for (_, sub) in self.client_registry.iter_vrf(vrf_id) {
             let _ = sub.rib_rx_tx.send(RibRx::RouterIdUpdate(router_id));
         }
     }

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -189,6 +189,14 @@ pub enum Message {
         ipv6_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
         ipv6_export_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,
     },
+    /// Configured `vrf <name> router-id` snapshot from the VRF config
+    /// builder, sent on commit after `VrfAdd` (same ordering contract
+    /// as `VrfRouteTargets`). `None` means the leaf is absent —
+    /// fall back to the derived per-VRF pick.
+    VrfRouterId {
+        name: String,
+        router_id: Option<Ipv4Addr>,
+    },
     /// Bind / unbind an interface to a VRF master device.
     /// `vrf == Some(name)` enslaves; `vrf == None` clears the binding
     /// (sets IFLA_MASTER = 0). The handler tolerates the interface or
@@ -1163,8 +1171,23 @@ impl Rib {
                 let _ = tx.send(RibRx::FdbAdd(entry));
             }
         }
-        if !self.router_id.is_unspecified() {
-            let msg = RibRx::RouterIdUpdate(self.router_id);
+        // Router-id replay: default-VRF subscribers get the global
+        // effective value; per-VRF subscribers (registered under
+        // their kernel `table_id`) get their VRF's effective value —
+        // configured `vrf <name> router-id`, else derived from the
+        // VRF's member interfaces, else the global value (see
+        // `router_id_update`).
+        let replay_router_id = if vrf_id == 0 {
+            self.router_id
+        } else {
+            self.vrfs
+                .values()
+                .find(|v| v.table_id == vrf_id)
+                .map(|v| v.router_id)
+                .unwrap_or(self.router_id)
+        };
+        if !replay_router_id.is_unspecified() {
+            let msg = RibRx::RouterIdUpdate(replay_router_id);
             if tx.send(msg).is_err() {
                 return;
             }
@@ -1661,6 +1684,12 @@ impl Rib {
                         name: name.clone(),
                         table_id,
                         ifindex,
+                        // Router-id config arrives separately via
+                        // `Message::VrfRouterId`; the effective value
+                        // is computed by `router_id_update` below once
+                        // the row exists.
+                        router_id: Ipv4Addr::UNSPECIFIED,
+                        router_id_config: None,
                         owned,
                         // RT sets arrive separately via
                         // `Message::VrfRouteTargets` once the VRF
@@ -1701,6 +1730,12 @@ impl Rib {
                 for (ifname, vrf) in to_replay {
                     let _ = self.tx.send(Message::LinkVrfBind { ifname, vrf });
                 }
+                // Compute the new VRF's effective router-id (members
+                // may already be enslaved when adopting a pre-existing
+                // kernel VRF) — and re-evaluate the global pick, which
+                // excludes VRF-enslaved links and may change now that
+                // this master is known.
+                self.router_id_update();
             }
             Message::VrfDel { name } => {
                 let Some(vrf) = self.vrfs.remove(&name) else {
@@ -1746,6 +1781,22 @@ impl Rib {
                     tracing::debug!(
                         vrf = %name,
                         "rib: VrfRouteTargets for unknown VRF; dropping",
+                    );
+                }
+            }
+            Message::VrfRouterId { name, router_id } => {
+                // Same ordering contract as `VrfRouteTargets`: the
+                // YANG commit emits `VrfAdd` first, so an unknown name
+                // here is an out-of-order self-send — drop it.
+                if let Some(vrf) = self.vrfs.get_mut(&name) {
+                    vrf.router_id_config = router_id;
+                    // Recompute + emit (configured wins; delete falls
+                    // back to the derived pick / global value).
+                    self.router_id_update();
+                } else {
+                    tracing::debug!(
+                        vrf = %name,
+                        "rib: VrfRouterId for unknown VRF; dropping",
                     );
                 }
             }

--- a/zebra-rs/src/rib/link.rs
+++ b/zebra-rs/src/rib/link.rs
@@ -631,6 +631,11 @@ impl Rib {
                 for addr in link.addr4.iter().chain(link.addr6.iter()) {
                     self.api_addr_add_vrf(addr, now_vrf_id);
                 }
+                // The interface's addresses changed scope: both the
+                // VRF it left and the one it joined (and the global
+                // pick, which excludes VRF members) may now derive a
+                // different Router-ID.
+                self.router_id_update();
             }
         }
 

--- a/zebra-rs/src/rib/router_id.rs
+++ b/zebra-rs/src/rib/router_id.rs
@@ -1,15 +1,24 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::Ipv4Addr;
 
 use crate::config::{Args, ConfigOp};
 
 use super::{Link, Rib};
 
-fn auto_router_id(links: &BTreeMap<u32, Link>) -> Option<Ipv4Addr> {
-    fn find_router_id(links: &BTreeMap<u32, Link>, loopback: bool) -> Option<Ipv4Addr> {
+/// First non-localhost IPv4 among the links accepted by `in_scope` —
+/// loopback-flagged links first, then the rest.
+fn pick_router_id(
+    links: &BTreeMap<u32, Link>,
+    in_scope: impl Fn(&Link) -> bool,
+) -> Option<Ipv4Addr> {
+    fn find(
+        links: &BTreeMap<u32, Link>,
+        in_scope: &impl Fn(&Link) -> bool,
+        loopback: bool,
+    ) -> Option<Ipv4Addr> {
         links
             .values()
-            .filter(|link| link.is_loopback() == loopback)
+            .filter(|link| in_scope(link) && link.is_loopback() == loopback)
             .flat_map(|link| &link.addr4)
             .filter_map(|laddr| match laddr.addr {
                 ipnet::IpNet::V4(v4net) => Some(v4net.addr()),
@@ -18,25 +27,76 @@ fn auto_router_id(links: &BTreeMap<u32, Link>) -> Option<Ipv4Addr> {
             .find(|&addr| addr != Ipv4Addr::LOCALHOST)
     }
 
-    // Try to find a router ID from up loopback interfaces first, then fallback
-    // to non-loopback interfaces.
-    find_router_id(links, true).or_else(|| find_router_id(links, false))
+    find(links, &in_scope, true).or_else(|| find(links, &in_scope, false))
 }
 
-/// Configured global `router-id` wins; otherwise fall back to the
-/// automatic pick from interface addresses. `None` when neither
-/// exists yet (no config, no usable address).
-fn effective_router_id(config: Option<Ipv4Addr>, links: &BTreeMap<u32, Link>) -> Option<Ipv4Addr> {
-    config.or_else(|| auto_router_id(links))
+/// Automatic pick for the default VRF: links not enslaved to any VRF
+/// master. (A bridge master is not a VRF master — its slaves stay in
+/// the default routing table and remain candidates.)
+fn auto_router_id(links: &BTreeMap<u32, Link>, vrf_masters: &BTreeSet<u32>) -> Option<Ipv4Addr> {
+    pick_router_id(links, |link| {
+        !link.master.is_some_and(|m| vrf_masters.contains(&m))
+    })
+}
+
+/// Automatic pick for one VRF: links enslaved to its master device.
+fn auto_router_id_vrf(links: &BTreeMap<u32, Link>, vrf_ifindex: u32) -> Option<Ipv4Addr> {
+    pick_router_id(links, |link| link.master == Some(vrf_ifindex))
+}
+
+/// Configured value wins; otherwise the automatic pick; otherwise
+/// `fallback` (`None` for the global instance — its stickiness is
+/// handled by the caller — and the global effective value for a VRF).
+fn effective_router_id(
+    config: Option<Ipv4Addr>,
+    auto: Option<Ipv4Addr>,
+    fallback: Option<Ipv4Addr>,
+) -> Option<Ipv4Addr> {
+    config.or(auto).or(fallback)
 }
 
 impl Rib {
+    /// Recompute the global and every VRF's effective Router ID and
+    /// push `RouterIdUpdate` to the affected subscriber sets when a
+    /// value moved. Call sites: address add/delete, VRF add, a link
+    /// crossing a VRF boundary, and the `router-id` /
+    /// `vrf <name> router-id` config handlers.
     pub fn router_id_update(&mut self) {
-        if let Some(router_id) = effective_router_id(self.router_id_config, &self.links)
-            && self.router_id != router_id
+        let vrf_masters: BTreeSet<u32> = self.vrfs.values().map(|v| v.ifindex).collect();
+
+        // Global first, so VRFs falling back to it see the fresh value.
+        // Sticky: when no source yields a value, keep the old one.
+        if let Some(router_id) = effective_router_id(
+            self.router_id_config,
+            auto_router_id(&self.links, &vrf_masters),
+            None,
+        ) && self.router_id != router_id
         {
             self.router_id = router_id;
-            self.api_router_id_update(router_id);
+            self.api_router_id_update(0, router_id);
+        }
+
+        // Per-VRF: configured > derived-from-members > global
+        // effective. The global fallback keeps the historical behavior
+        // where per-VRF subscribers inherited the global value, while
+        // letting a VRF-local address or an explicit
+        // `vrf <name> router-id` take precedence. Collect emits first —
+        // `api_router_id_update` borrows `&self`.
+        let global = (!self.router_id.is_unspecified()).then_some(self.router_id);
+        let mut emits: Vec<(u32, Ipv4Addr)> = Vec::new();
+        for vrf in self.vrfs.values_mut() {
+            if let Some(router_id) = effective_router_id(
+                vrf.router_id_config,
+                auto_router_id_vrf(&self.links, vrf.ifindex),
+                global,
+            ) && vrf.router_id != router_id
+            {
+                vrf.router_id = router_id;
+                emits.push((vrf.table_id, router_id));
+            }
+        }
+        for (vrf_id, router_id) in emits {
+            self.api_router_id_update(vrf_id, router_id);
         }
     }
 
@@ -63,7 +123,7 @@ mod tests {
     use ipnet::{IpNet, Ipv4Net};
     use netlink_packet_route::link::LinkFlags;
 
-    fn test_link(index: u32, loopback: bool, addrs: &[Ipv4Addr]) -> Link {
+    fn test_link(index: u32, loopback: bool, master: Option<u32>, addrs: &[Ipv4Addr]) -> Link {
         Link {
             index,
             name: format!("test{index}"),
@@ -89,7 +149,7 @@ mod tests {
                 })
                 .collect(),
             addr6: Vec::new(),
-            master: None,
+            master,
             vni: None,
             vxlan_local: None,
             mtu_error: None,
@@ -103,36 +163,60 @@ mod tests {
     #[test]
     fn auto_pick_prefers_loopback_and_skips_localhost() {
         let mut links = BTreeMap::new();
-        links.insert(1, test_link(1, true, &[addr("127.0.0.1")]));
-        links.insert(2, test_link(2, false, &[addr("192.0.2.1")]));
-        links.insert(3, test_link(3, true, &[addr("10.255.0.1")]));
+        links.insert(1, test_link(1, true, None, &[addr("127.0.0.1")]));
+        links.insert(2, test_link(2, false, None, &[addr("192.0.2.1")]));
+        links.insert(3, test_link(3, true, None, &[addr("10.255.0.1")]));
         assert!(links.get(&1).unwrap().flags.is_loopback());
+        let no_vrfs = BTreeSet::new();
 
         // Loopback wins over the (lower-ifindex) non-loopback; the
         // 127.0.0.1 loopback address is never a candidate.
-        assert_eq!(auto_router_id(&links), Some(addr("10.255.0.1")));
+        assert_eq!(auto_router_id(&links, &no_vrfs), Some(addr("10.255.0.1")));
 
         // Without any loopback candidate, fall back to non-loopback.
         links.remove(&3);
-        assert_eq!(auto_router_id(&links), Some(addr("192.0.2.1")));
+        assert_eq!(auto_router_id(&links, &no_vrfs), Some(addr("192.0.2.1")));
 
         // Only 127.0.0.1 left -> no candidate at all.
         links.remove(&2);
-        assert_eq!(auto_router_id(&links), None);
+        assert_eq!(auto_router_id(&links, &no_vrfs), None);
     }
 
     #[test]
-    fn configured_router_id_wins_over_auto_pick() {
+    fn global_pick_excludes_vrf_enslaved_links_but_not_bridge_slaves() {
+        const VRF_IF: u32 = 100;
+        const BRIDGE_IF: u32 = 200;
         let mut links = BTreeMap::new();
-        links.insert(1, test_link(1, true, &[addr("10.255.0.1")]));
+        // VRF member with the lowest ifindex — must NOT win the
+        // global pick.
+        links.insert(1, test_link(1, false, Some(VRF_IF), &[addr("10.99.0.1")]));
+        // Bridge slave — its master is not a VRF, so it stays a
+        // global candidate.
+        links.insert(
+            2,
+            test_link(2, false, Some(BRIDGE_IF), &[addr("192.0.2.1")]),
+        );
+        let vrf_masters = BTreeSet::from([VRF_IF]);
 
         assert_eq!(
-            effective_router_id(Some(addr("192.0.2.255")), &links),
-            Some(addr("192.0.2.255"))
+            auto_router_id(&links, &vrf_masters),
+            Some(addr("192.0.2.1"))
         );
-        // Delete of the override falls back to the automatic pick.
-        assert_eq!(effective_router_id(None, &links), Some(addr("10.255.0.1")));
-        // No config and no usable address -> undecided.
-        assert_eq!(effective_router_id(None, &BTreeMap::new()), None);
+        // The VRF-scoped pick selects exactly the member the global
+        // pick skipped.
+        assert_eq!(auto_router_id_vrf(&links, VRF_IF), Some(addr("10.99.0.1")));
+        assert_eq!(auto_router_id_vrf(&links, 999), None);
+    }
+
+    #[test]
+    fn effective_chain_config_then_auto_then_fallback() {
+        let cfg = Some(addr("192.0.2.255"));
+        let auto = Some(addr("10.255.0.1"));
+        let global = Some(addr("9.9.9.9"));
+
+        assert_eq!(effective_router_id(cfg, auto, global), cfg);
+        assert_eq!(effective_router_id(None, auto, global), auto);
+        assert_eq!(effective_router_id(None, None, global), global);
+        assert_eq!(effective_router_id(None, None, None), None);
     }
 }

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -1717,8 +1717,13 @@ pub fn hostname_show(_rib: &Rib, _args: Args, _json: bool) -> String {
 
 pub fn vrf_show(rib: &Rib, _args: Args, _json: bool) -> String {
     let mut buf = String::new();
-    writeln!(buf, " {:<24}{:>10}  Members", "Name", "Table-ID").unwrap();
-    writeln!(buf, " {:-<24}  {:-<10}  {:-<32}", "", "", "").unwrap();
+    writeln!(
+        buf,
+        " {:<24}{:>10}  {:<17}Members",
+        "Name", "Table-ID", "Router-ID"
+    )
+    .unwrap();
+    writeln!(buf, " {:-<24}  {:-<10}  {:-<15}  {:-<32}", "", "", "", "").unwrap();
     for vrf in rib.vrfs.values() {
         let members: Vec<&str> = rib
             .links
@@ -1726,11 +1731,17 @@ pub fn vrf_show(rib: &Rib, _args: Args, _json: bool) -> String {
             .filter(|l| l.master == Some(vrf.ifindex))
             .map(|l| l.name.as_str())
             .collect();
+        let router_id = if vrf.router_id.is_unspecified() {
+            "-".to_string()
+        } else {
+            vrf.router_id.to_string()
+        };
         writeln!(
             buf,
-            " {:<24}{:>10}  {}",
+            " {:<24}{:>10}  {:<17}{}",
             vrf.name,
             vrf.table_id,
+            router_id,
             members.join(", ")
         )
         .unwrap();

--- a/zebra-rs/src/rib/vrf/builder.rs
+++ b/zebra-rs/src/rib/vrf/builder.rs
@@ -59,15 +59,20 @@ impl VrfBuilder {
                 let ipv4_export_rts = config.ipv4_export_rts.clone();
                 let ipv6_import_rts = config.ipv6_import_rts.clone();
                 let ipv6_export_rts = config.ipv6_export_rts.clone();
+                let router_id = config.router_id;
                 self.config.insert(name.clone(), config);
                 let _ = tx.send(Message::VrfAdd { name: name.clone() });
                 let _ = tx.send(Message::VrfRouteTargets {
-                    name,
+                    name: name.clone(),
                     ipv4_import_rts,
                     ipv4_export_rts,
                     ipv6_import_rts,
                     ipv6_export_rts,
                 });
+                // Router-id snapshot follows the same VrfAdd-first
+                // ordering contract as the RT message; `None` (leaf
+                // absent or deleted this commit) clears the override.
+                let _ = tx.send(Message::VrfRouterId { name, router_id });
             }
         }
     }
@@ -123,6 +128,7 @@ impl ConfigBuilder {
         const RT_ERR: &str = "missing route-target argument";
         const RT_PARSE_ERR: &str =
             "route-target must parse as ASN:value, IPv4:value, or 4byteASN:value";
+        const ROUTER_ID_ERR: &str = "missing or invalid router-id argument";
 
         ConfigBuilder::default()
             .path("")
@@ -138,6 +144,23 @@ impl ConfigBuilder {
                     s.delete = true;
                     cache.insert(name.clone(), s);
                 }
+                Ok(())
+            })
+            // /vrf/<name>/router-id — per-VRF Router-ID override.
+            // Delete clears the leaf; the RIB then falls back to the
+            // derived per-VRF pick (or the global effective value).
+            .path("/router-id")
+            .set(|config, cache, name, args| {
+                let router_id = args.v4addr().context(ROUTER_ID_ERR)?;
+                cache_get(config, cache, name)
+                    .context(CONFIG_ERR)?
+                    .router_id = Some(router_id);
+                Ok(())
+            })
+            .del(|config, cache, name, _args| {
+                cache_get(config, cache, name)
+                    .context(CONFIG_ERR)?
+                    .router_id = None;
                 Ok(())
             })
             // /vrf/<name>/ipv4/route-target/import — leaf-list, one
@@ -317,7 +340,63 @@ mod tests {
         assert!(ipv4_export_rts.contains(&exp));
         assert!(ipv6_import_rts.is_empty());
         assert!(ipv6_export_rts.is_empty());
-        assert!(rx.try_recv().is_err(), "no third message expected");
+
+        // The router-id snapshot always trails the RT message — `None`
+        // here because the operator never set `vrf v1 router-id`.
+        let third = rx.try_recv().expect("VrfRouterId present");
+        let Message::VrfRouterId { name, router_id } = third else {
+            panic!("third message is not VrfRouterId");
+        };
+        assert_eq!(name, "v1");
+        assert_eq!(router_id, None);
+        assert!(rx.try_recv().is_err(), "no fourth message expected");
+    }
+
+    #[test]
+    fn commit_carries_configured_router_id_and_delete_clears_it() {
+        let mut builder = VrfBuilder::new();
+        builder
+            .exec("/vrf".into(), args(&["v1"]), ConfigOp::Set)
+            .expect("create vrf");
+        builder
+            .exec(
+                "/vrf/router-id".into(),
+                args(&["v1", "11.11.11.11"]),
+                ConfigOp::Set,
+            )
+            .expect("set router-id");
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        builder.commit(tx);
+        let mut router_ids = Vec::new();
+        while let Ok(msg) = rx.try_recv() {
+            if let Message::VrfRouterId { name, router_id } = msg {
+                assert_eq!(name, "v1");
+                router_ids.push(router_id);
+            }
+        }
+        assert_eq!(router_ids, vec![Some("11.11.11.11".parse().unwrap())]);
+
+        // Delete the leaf in a second commit batch — the staged edit
+        // starts from the committed config, so the snapshot reports
+        // the cleared override.
+        builder
+            .exec(
+                "/vrf/router-id".into(),
+                args(&["v1", "11.11.11.11"]),
+                ConfigOp::Delete,
+            )
+            .expect("delete router-id");
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        builder.commit(tx);
+        let mut router_ids = Vec::new();
+        while let Ok(msg) = rx.try_recv() {
+            if let Message::VrfRouterId { name, router_id } = msg {
+                assert_eq!(name, "v1");
+                router_ids.push(router_id);
+            }
+        }
+        assert_eq!(router_ids, vec![None]);
     }
 
     #[test]

--- a/zebra-rs/src/rib/vrf/config.rs
+++ b/zebra-rs/src/rib/vrf/config.rs
@@ -15,6 +15,10 @@
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct VrfConfig {
     pub delete: bool,
+    /// Per-VRF Router-ID override — `set vrf X router-id A.B.C.D`.
+    /// `None` lets the RIB derive one from the VRF's member
+    /// interfaces (falling back to the global effective value).
+    pub router_id: Option<std::net::Ipv4Addr>,
     /// IPv4-unicast RT import set —
     /// `set vrf X ipv4 route-target import …`.
     pub ipv4_import_rts: std::collections::BTreeSet<bgp_packet::RouteDistinguisher>,

--- a/zebra-rs/src/rib/vrf/inst.rs
+++ b/zebra-rs/src/rib/vrf/inst.rs
@@ -20,6 +20,18 @@ pub struct Vrf {
     pub name: String,
     pub table_id: u32,
     pub ifindex: u32,
+    /// Effective per-VRF Router ID — what this VRF's subscribers
+    /// receive via `RibRx::RouterIdUpdate` and what the
+    /// subscribe-time replay sends them. Derived by
+    /// `Rib::router_id_update`: configured `vrf <name> router-id`
+    /// first, then the automatic pick from this VRF's member
+    /// interfaces, then the global effective Router ID. Sticky once
+    /// set, like the global one.
+    pub router_id: std::net::Ipv4Addr,
+    /// Operator-configured `vrf <name> router-id`, delivered via
+    /// `Message::VrfRouterId`. Wins over the derived values; `None`
+    /// falls back.
+    pub router_id_config: Option<std::net::Ipv4Addr>,
     /// `true` when this process created the kernel VRF master device,
     /// `false` when it adopted a pre-existing one (operator-created, or
     /// a leftover from a prior run). The shutdown path only deletes the

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -2605,6 +2605,16 @@ module config {
            The numeric VRF / kernel routing-table ID is assigned
            internally by zebra-rs and is not user-configurable.";
       }
+      leaf router-id {
+        ext:help "Router identifier for this VRF";
+        description
+          "Per-VRF Router ID override. When absent, zebra-rs derives
+           one from the VRF's member interfaces (loopback-flagged
+           members first), falling back to the global effective
+           Router ID. Pushed to this VRF's protocol subscribers via
+           RouterIdUpdate, like the top-level `router-id`.";
+        type inet:ipv4-address;
+      }
       container ipv4 {
         description
           "IPv4 unicast (VPNv4 / RFC 4364) route policy for this VRF.";


### PR DESCRIPTION
## Summary

Two commits closing the last gaps in the router-id series (#1312/#1314/#1315/#1317):

**1. `ospfv3: consume RIB RouterIdUpdate like v2`** — OSPFv3's `process_rib_msg` had no `RouterIdUpdate` arm, so every unconfigured v3 instance kept the constructor default 10.0.0.1 (two such routers could never form an adjacency), and `delete router ospfv3 router-id` could only fall back to that default. The arm mirrors v2: store in `rib_router_id`, `refresh_router_id` resolves precedence (configured wins). Every ospfv3 BDD config sets router-id explicitly, so nothing depended on the old default.

**2. `rib: per-VRF router-id — derive from members, config leaf, VRF emit`** — the RIB derived one daemon-global Router ID and emitted it to default-VRF subscribers only; per-VRF instances saw the global value once at subscribe-replay. Now:

- Each VRF row carries an effective router-id: configured `vrf <name> router-id` > automatic pick from the VRF's member interfaces (loopbacks first) > global effective value (preserves the old inherit-the-global behavior).
- New `vrf <name> router-id A.B.C.D` config leaf; the builder snapshots it on commit as `Message::VrfRouterId` (VrfAdd-first ordering, like VrfRouteTargets); delete falls back.
- `api_router_id_update` takes the target vrf_id; the subscribe-time replay sends the VRF-scoped value. Per-VRF OSPFv2/v3 and IS-IS children consume it through their existing arms (v3's thanks to commit 1). Per-VRF BGP still uses its spawn-time snapshot — the acknowledged follow-up in `spawn_bgp_vrf`.
- The global automatic pick now excludes VRF-enslaved links (a VRF member's address could previously win the global pick); bridge slaves remain candidates.
- Recompute hooks: address add/delete, VrfAdd, VrfRouterId config, link crossing a VRF boundary. `show vrf` grows a Router-ID column.

## Test plan

- Unit tests: pick scoping (global excludes VRF members but not bridge slaves; per-VRF selects exactly its members), the config>auto>fallback chain, and the builder's VrfRouterId emission incl. delete-clears-it.
- `cargo test --workspace --exclude bdd` all green (35 binaries); YANG load tests pass; workspace clippy clean; `cargo fmt` applied.
- Live-validated in one commit on a fresh daemon: global configured 9.9.9.9; `vrf blue` shows its configured 11.11.11.11; `vrf red` derives 10.99.0.1 from member d0; a per-VRF OSPFv2 child adopts 10.99.0.1 (previously inherited the global). Runtime `set vrf red router-id 12.12.12.12` propagates live into the running child; delete falls back to 10.99.0.1; deleting the global router-id re-picks 10.0.0.1 from non-VRF links. OSPFv3 default instance: adopts a broadcast 9.9.9.9 when unconfigured, configured 3.3.3.3 survives a RIB change, delete falls back to the RIB value.

Generated with [Claude Code](https://claude.com/claude-code)