### PR TITLE
bdd: rewire the clear-neighbor step to the real soft-out grammar

### DIFF
--- a/bdd/docs/bgp_route_map_match.md
+++ b/bdd/docs/bgp_route_map_match.md
@@ -11,6 +11,15 @@ by swapping z2's input policy and asserting which advertised prefixes
 appear in z2's RIB. z1 attaches an outbound policy that stamps MED=100
 on every advertised route so MED match scenarios have something
 deterministic to compare against.
+Re-evaluation relies entirely on the policy-change trigger
+(PolicyRx -> soft-in): applying a config whose policy content changed
+re-runs the inbound policy over the Adj-RIB-In. Deliberately NO
+`I clear namespace ... neighbor` steps here — that step is a real
+egress soft-clear since the clear grammar was wired (PR #1318), and
+an operator `clear ... soft [in]` after additively-merged same-name
+policy edits currently diverges from the trigger path on the MED
+scenarios (open daemon bug — soft-in replay re-admits trigger-denied
+routes). Historically the step was a silent no-op here anyway.
 
 ## Test Topology
 

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -452,16 +452,36 @@ async fn wait_for_bgp(_world: &mut World, seconds: u64) {
     println!("✓ Waited {} seconds for BGP to operate", seconds);
 }
 
+/// Soft-clear OUTBOUND toward a BGP neighbor: re-run the egress
+/// policy over the Loc-RIB and re-advertise (with diff-withdraws),
+/// WITHOUT bouncing the session. Every feature uses this step to
+/// "force an immediate re-flood" after a config change, with waits as
+/// short as 5 s — a hard reset (bounce + reconnect) would overrun
+/// those. For a hard reset, use the generic run step with
+/// `clear bgp ipv4 <peer>` instead.
+///
+/// Deliberately NOT `soft` (both directions): the soft-IN replay can
+/// re-admit routes the policy-change trigger just denied when the
+/// additively-merged policy state diverges (observed live on
+/// bgp_route_map_match's med-eq scenarios) — a daemon-side issue
+/// tracked separately; the re-flood intent only needs OUT.
+///
+/// History: this step used to issue the legacy `clear ip bgp
+/// neighbors <X>` grammar, which was never wired into
+/// zebra-bgp-clear.yang and silently no-op'd (the clear surface is
+/// garbage-tolerant). The spelling below is pinned by the
+/// `clear_bgp_grammar` parse test in zebra-rs/src/config/parse.rs, so
+/// grammar rot now fails unit tests instead of silently no-opping.
 #[when(expr = "I clear namespace {string} neighbor {string}")]
 async fn clear_bgp_neighbor(world: &mut World, namespace: String, neighbor: String) {
     let scoped = world.ns(&namespace);
-    let cmd = format!("clear ip bgp neighbors {}", neighbor);
+    let cmd = format!("clear bgp ipv4 {} soft out", neighbor);
     netns::exec_in_netns(&scoped, "vtyctl", &["clear", &cmd])
         .await
         .expect("Failed to clear BGP neighbor");
 
     println!(
-        "✓ Cleared BGP neighbor {} in namespace {}",
+        "✓ Soft-cleared (out) BGP neighbor {} in namespace {}",
         neighbor, scoped
     );
 }

--- a/bdd/tests/features/bgp_route_map_match.feature
+++ b/bdd/tests/features/bgp_route_map_match.feature
@@ -12,6 +12,16 @@ Feature: BGP route-map match clauses
   on every advertised route so MED match scenarios have something
   deterministic to compare against.
 
+  Re-evaluation relies entirely on the policy-change trigger
+  (PolicyRx -> soft-in): applying a config whose policy content changed
+  re-runs the inbound policy over the Adj-RIB-In. Deliberately NO
+  `I clear namespace ... neighbor` steps here — that step is a real
+  egress soft-clear since the clear grammar was wired (PR #1318), and
+  an operator `clear ... soft [in]` after additively-merged same-name
+  policy edits currently diverges from the trigger path on the MED
+  scenarios (open daemon bug — soft-in replay re-admits trigger-denied
+  routes). Historically the step was a silent no-op here anyway.
+
   Test Topology:
   ```
   ┌─────────────────────────────────────────┐
@@ -69,7 +79,6 @@ Feature: BGP route-map match clauses
   Scenario: match as-path-set accepts routes whose AS_PATH matches the regex
     Given the test topology exists
     When I apply config "z2-aspath-pass.yaml" to namespace "z2"
-    And I clear namespace "z2" neighbor "192.168.0.1"
     And I wait 5 seconds for BGP to operate
     Then BGP route in "z2" has "10.0.0.1/32"
     And BGP route in "z2" has "10.0.0.2/32"
@@ -77,7 +86,6 @@ Feature: BGP route-map match clauses
   Scenario: match as-path-set rejects routes whose AS_PATH does not match
     Given the test topology exists
     When I apply config "z2-aspath-fail.yaml" to namespace "z2"
-    And I clear namespace "z2" neighbor "192.168.0.1"
     And I wait 5 seconds for BGP to operate
     Then BGP route in "z2" does not have "10.0.0.1/32"
     And BGP route in "z2" does not have "10.0.0.2/32"
@@ -85,7 +93,6 @@ Feature: BGP route-map match clauses
   Scenario: match origin igp accepts network-originated routes
     Given the test topology exists
     When I apply config "z2-origin-igp.yaml" to namespace "z2"
-    And I clear namespace "z2" neighbor "192.168.0.1"
     And I wait 5 seconds for BGP to operate
     Then BGP route in "z2" has "10.0.0.1/32"
     And BGP route in "z2" has "10.0.0.2/32"
@@ -93,7 +100,6 @@ Feature: BGP route-map match clauses
   Scenario: match origin egp rejects network-originated (igp) routes
     Given the test topology exists
     When I apply config "z2-origin-egp.yaml" to namespace "z2"
-    And I clear namespace "z2" neighbor "192.168.0.1"
     And I wait 5 seconds for BGP to operate
     Then BGP route in "z2" does not have "10.0.0.1/32"
     And BGP route in "z2" does not have "10.0.0.2/32"
@@ -101,7 +107,6 @@ Feature: BGP route-map match clauses
   Scenario: match med-eq accepts routes with the exact MED value
     Given the test topology exists
     When I apply config "z2-med-eq-pass.yaml" to namespace "z2"
-    And I clear namespace "z2" neighbor "192.168.0.1"
     And I wait 5 seconds for BGP to operate
     Then BGP route in "z2" has "10.0.0.1/32"
     And BGP route in "z2" has "10.0.0.2/32"
@@ -109,7 +114,6 @@ Feature: BGP route-map match clauses
   Scenario: match med-eq rejects routes with a different MED value
     Given the test topology exists
     When I apply config "z2-med-eq-fail.yaml" to namespace "z2"
-    And I clear namespace "z2" neighbor "192.168.0.1"
     And I wait 5 seconds for BGP to operate
     Then BGP route in "z2" does not have "10.0.0.1/32"
     And BGP route in "z2" does not have "10.0.0.2/32"
@@ -117,7 +121,6 @@ Feature: BGP route-map match clauses
   Scenario: match med-ge and med-le accept routes inside the range
     Given the test topology exists
     When I apply config "z2-med-range-pass.yaml" to namespace "z2"
-    And I clear namespace "z2" neighbor "192.168.0.1"
     And I wait 5 seconds for BGP to operate
     Then BGP route in "z2" has "10.0.0.1/32"
     And BGP route in "z2" has "10.0.0.2/32"
@@ -125,7 +128,6 @@ Feature: BGP route-map match clauses
   Scenario: match med-ge rejects routes below the floor
     Given the test topology exists
     When I apply config "z2-med-range-fail.yaml" to namespace "z2"
-    And I clear namespace "z2" neighbor "192.168.0.1"
     And I wait 5 seconds for BGP to operate
     Then BGP route in "z2" does not have "10.0.0.1/32"
     And BGP route in "z2" does not have "10.0.0.2/32"
@@ -133,7 +135,6 @@ Feature: BGP route-map match clauses
   Scenario: match next-hop-set accepts routes whose nexthop is in the prefix-set
     Given the test topology exists
     When I apply config "z2-nh-pass.yaml" to namespace "z2"
-    And I clear namespace "z2" neighbor "192.168.0.1"
     And I wait 5 seconds for BGP to operate
     Then BGP route in "z2" has "10.0.0.1/32"
     And BGP route in "z2" has "10.0.0.2/32"
@@ -141,7 +142,6 @@ Feature: BGP route-map match clauses
   Scenario: match next-hop-set rejects routes whose nexthop is outside the prefix-set
     Given the test topology exists
     When I apply config "z2-nh-fail.yaml" to namespace "z2"
-    And I clear namespace "z2" neighbor "192.168.0.1"
     And I wait 5 seconds for BGP to operate
     Then BGP route in "z2" does not have "10.0.0.1/32"
     And BGP route in "z2" does not have "10.0.0.2/32"

--- a/bdd/tests/features/bgp_ttl_security.feature
+++ b/bdd/tests/features/bgp_ttl_security.feature
@@ -60,10 +60,10 @@ Feature: BGP TTL Security / GTSM (RFC 5082)
     # Hard-reset both ends so each tears down cleanly and reconnects with
     # GTSM, rather than waiting out a multi-minute hold timer.
     #
-    # Use `clear bgp ipv4 neighbor <X>` (the real clear grammar) via the
-    # generic run step — NOT `I clear namespace ... neighbor`, whose
-    # `clear ip bgp neighbors <X>` does not match the grammar and is a
-    # silent no-op (see PR #1264). A clean GTSM reconnect reaches
+    # Use the hard-reset grammar via the generic run step — NOT
+    # `I clear namespace ... neighbor`, which is a SOFT clear (policy
+    # re-run + re-advertise, no session bounce) and would leave the
+    # stale pre-GTSM connection up. A clean GTSM reconnect reaches
     # Established in ~6s once collision-teardown packets carry TTL 255
     # (peer.rs handle_peer_connection); 15s is margin for CI.
     And I run "clear bgp ipv4 neighbor 192.168.0.2" in namespace "z1"


### PR DESCRIPTION
## Summary

`I clear namespace <ns> neighbor <peer>` issued the legacy `clear ip bgp neighbors <X>` grammar — never wired into `zebra-bgp-clear.yang`, so the garbage-tolerant clear surface made it a **silent no-op** in every feature using it (bgp_community ×3, bgp_basic_ebgp/ibgp, bgp_route_map_match ×10). The step now issues `clear bgp ipv4 <peer> soft out` — egress soft-clear (re-run outbound policy + re-advertise with diff-withdraws, no session bounce), matching the "force an immediate re-flood" intent everywhere the step appears and the features' 5–65 s waits. The spelling is pinned by the `clear_bgp_grammar` parse test from #1318.

**Why not `soft` (both directions)**: live validation exposed a daemon-side divergence — the soft-IN replay re-admits routes the policy-change trigger just denied (bgp_route_map_match med scenarios, additively-merged same-name policies). That bug **predates this change**: pristine main fails the same med deny scenarios with the original no-op step. Tracked separately with a repro recipe.

**bgp_route_map_match** drops its clear steps entirely (header note explains): it exercises the PolicyRx apply-trigger; the step was a no-op when its scenarios were written; a real clear adds nothing there while the med daemon bug is open. **bgp_ttl_security**'s comment is refreshed (its hard resets keep the generic run step).

## Testing

Live, binary md5-guarded before/after each run:
- `bgp_basic_ebgp` 9/9, `bgp_basic_ibgp` 9/9, `bgp_community` 6/6 — all with the step doing a real soft-out.
- `bgp_route_map_match`: the med deny failures reproduce identically on **pristine main** (3 steps fail there with the no-op step) — pre-existing daemon bug, not a regression of this PR; with the vestigial steps removed the feature is functionally unchanged from what it actually tested before.
- A/B bisect of `soft in` / `soft` / `soft out` on the live topology isolated the soft-in divergence; recorded for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)