### PR TITLE
bgp: rename `global identifier` to `global router-id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Enter configure mode with `configure`, edit the candidate, then `commit`:
 ubuntu>configure
 ubuntu#set system hostname r1
 ubuntu#set router bgp global as 65001
-ubuntu#set router bgp global identifier 10.0.0.1
+ubuntu#set router bgp global router-id 10.0.0.1
 ubuntu#set router bgp neighbor 10.0.0.2 remote-as 65001
 ubuntu#commit
 r1#show running-config
@@ -97,7 +97,7 @@ router {
   bgp {
     global {
       as 65001;
-      identifier 10.0.0.1;
+      router-id 10.0.0.1;
     }
     neighbor 10.0.0.2 {
       remote-as 65001;

--- a/bdd/tests/configs/bgp_allowas_in/z1.yaml
+++ b/bdd/tests/configs/bgp_allowas_in/z1.yaml
@@ -6,7 +6,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_allowas_in/z2.yaml
+++ b/bdd/tests/configs/bgp_allowas_in/z2.yaml
@@ -9,7 +9,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_allowas_in/z3-allowas.yaml
+++ b/bdd/tests/configs/bgp_allowas_in/z3-allowas.yaml
@@ -6,7 +6,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.1.3
+      router-id: 192.168.1.3
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_allowas_in/z3-base.yaml
+++ b/bdd/tests/configs/bgp_allowas_in/z3-base.yaml
@@ -6,7 +6,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.1.3
+      router-id: 192.168.1.3
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_allowas_in/z3-origin.yaml
+++ b/bdd/tests/configs/bgp_allowas_in/z3-origin.yaml
@@ -6,7 +6,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.1.3
+      router-id: 192.168.1.3
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_as_override/z1.yaml
+++ b/bdd/tests/configs/bgp_as_override/z1.yaml
@@ -6,7 +6,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_as_override/z2-base.yaml
+++ b/bdd/tests/configs/bgp_as_override/z2-base.yaml
@@ -9,7 +9,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_as_override/z2-override.yaml
+++ b/bdd/tests/configs/bgp_as_override/z2-override.yaml
@@ -9,7 +9,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_as_override/z3.yaml
+++ b/bdd/tests/configs/bgp_as_override/z3.yaml
@@ -6,7 +6,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.1.3
+      router-id: 192.168.1.3
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_basic_ebgp/z1-1.yaml
+++ b/bdd/tests/configs/bgp_basic_ebgp/z1-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_basic_ebgp/z1-2.yaml
+++ b/bdd/tests/configs/bgp_basic_ebgp/z1-2.yaml
@@ -2,4 +2,4 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1

--- a/bdd/tests/configs/bgp_basic_ebgp/z1-3.yaml
+++ b/bdd/tests/configs/bgp_basic_ebgp/z1-3.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_basic_ebgp/z1-4.yaml
+++ b/bdd/tests/configs/bgp_basic_ebgp/z1-4.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_basic_ebgp/z1-5.yaml
+++ b/bdd/tests/configs/bgp_basic_ebgp/z1-5.yaml
@@ -13,7 +13,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_basic_ebgp/z2-1.yaml
+++ b/bdd/tests/configs/bgp_basic_ebgp/z2-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_basic_ibgp/z1-1.yaml
+++ b/bdd/tests/configs/bgp_basic_ibgp/z1-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_basic_ibgp/z1-2.yaml
+++ b/bdd/tests/configs/bgp_basic_ibgp/z1-2.yaml
@@ -2,4 +2,4 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1

--- a/bdd/tests/configs/bgp_basic_ibgp/z1-3.yaml
+++ b/bdd/tests/configs/bgp_basic_ibgp/z1-3.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_basic_ibgp/z1-4.yaml
+++ b/bdd/tests/configs/bgp_basic_ibgp/z1-4.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_basic_ibgp/z1-5.yaml
+++ b/bdd/tests/configs/bgp_basic_ibgp/z1-5.yaml
@@ -13,7 +13,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_basic_ibgp/z2-1.yaml
+++ b/bdd/tests/configs/bgp_basic_ibgp/z2-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_community/z1-1.yaml
+++ b/bdd/tests/configs/bgp_community/z1-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_community/z1-2.yaml
+++ b/bdd/tests/configs/bgp_community/z1-2.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_community/z1-3.yaml
+++ b/bdd/tests/configs/bgp_community/z1-3.yaml
@@ -20,7 +20,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_community/z1-4.yaml
+++ b/bdd/tests/configs/bgp_community/z1-4.yaml
@@ -20,7 +20,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_community/z1-5.yaml
+++ b/bdd/tests/configs/bgp_community/z1-5.yaml
@@ -7,7 +7,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_community/z2-1.yaml
+++ b/bdd/tests/configs/bgp_community/z2-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_community/z3-1.yaml
+++ b/bdd/tests/configs/bgp_community/z3-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.3
+      router-id: 192.168.0.3
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_community/z4-1.yaml
+++ b/bdd/tests/configs/bgp_community/z4-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65003
-      identifier: 192.168.0.4
+      router-id: 192.168.0.4
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_disable_connected_check/z1-base.yaml
+++ b/bdd/tests/configs/bgp_disable_connected_check/z1-base.yaml
@@ -18,7 +18,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 10.255.0.1
+      router-id: 10.255.0.1
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_disable_connected_check/z1-disable.yaml
+++ b/bdd/tests/configs/bgp_disable_connected_check/z1-disable.yaml
@@ -16,7 +16,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 10.255.0.1
+      router-id: 10.255.0.1
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_disable_connected_check/z2-base.yaml
+++ b/bdd/tests/configs/bgp_disable_connected_check/z2-base.yaml
@@ -14,7 +14,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 10.255.0.2
+      router-id: 10.255.0.2
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_disable_connected_check/z2-disable.yaml
+++ b/bdd/tests/configs/bgp_disable_connected_check/z2-disable.yaml
@@ -14,7 +14,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 10.255.0.2
+      router-id: 10.255.0.2
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_ebgp_multihop/z1-1.yaml
+++ b/bdd/tests/configs/bgp_ebgp_multihop/z1-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_ebgp_multihop/z2-1.yaml
+++ b/bdd/tests/configs/bgp_ebgp_multihop/z2-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_enforce_first_as/z1.yaml
+++ b/bdd/tests/configs/bgp_enforce_first_as/z1.yaml
@@ -27,7 +27,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_enforce_first_as/z2-base.yaml
+++ b/bdd/tests/configs/bgp_enforce_first_as/z2-base.yaml
@@ -6,7 +6,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_enforce_first_as/z2-enforce.yaml
+++ b/bdd/tests/configs/bgp_enforce_first_as/z2-enforce.yaml
@@ -6,7 +6,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_evpn_capability/z1-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_capability/z1-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       enabled: true

--- a/bdd/tests/configs/bgp_evpn_capability/z2-1.yaml
+++ b/bdd/tests/configs/bgp_evpn_capability/z2-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       enabled: true

--- a/bdd/tests/configs/bgp_gobgpd_rr/rr1.yaml
+++ b/bdd/tests/configs/bgp_gobgpd_rr/rr1.yaml
@@ -70,7 +70,7 @@ router:
   bgp:
     global:
       as: 64512
-      identifier: 198.18.39.94
+      router-id: 198.18.39.94
     neighbor:
     - remote-address: 198.18.37.17
       afi-safi:

--- a/bdd/tests/configs/bgp_interas_option_a/asbr1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_a/asbr1.yaml
@@ -46,7 +46,7 @@ router:
   bgp:
     global:
       as: 65000
-      identifier: 1.1.1.3
+      router-id: 1.1.1.3
     neighbor:
     - remote-address: 1.1.1.1
       remote-as: 65000

--- a/bdd/tests/configs/bgp_interas_option_a/asbr2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_a/asbr2.yaml
@@ -42,7 +42,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 2.2.2.3
+      router-id: 2.2.2.3
     neighbor:
     - remote-address: 2.2.2.1
       remote-as: 65001

--- a/bdd/tests/configs/bgp_interas_option_a/pe1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_a/pe1.yaml
@@ -42,7 +42,7 @@ router:
   bgp:
     global:
       as: 65000
-      identifier: 1.1.1.1
+      router-id: 1.1.1.1
     neighbor:
     - remote-address: 1.1.1.3
       remote-as: 65000

--- a/bdd/tests/configs/bgp_interas_option_a/pe2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_a/pe2.yaml
@@ -40,7 +40,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 2.2.2.1
+      router-id: 2.2.2.1
     neighbor:
     - remote-address: 2.2.2.3
       remote-as: 65001

--- a/bdd/tests/configs/bgp_interas_option_ab/asbr1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_ab/asbr1.yaml
@@ -53,7 +53,7 @@ router:
   bgp:
     global:
       as: 65000
-      identifier: 1.1.1.3
+      router-id: 1.1.1.3
     # Lower the MRAI so the VPNv4 route crosses the eBGP boundary (default
     # 30s) and is relayed to PE1 promptly (same rationale as Option B).
     timer:

--- a/bdd/tests/configs/bgp_interas_option_ab/asbr2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_ab/asbr2.yaml
@@ -41,7 +41,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 2.2.2.3
+      router-id: 2.2.2.3
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_interas_option_ab/pe1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_ab/pe1.yaml
@@ -43,7 +43,7 @@ router:
   bgp:
     global:
       as: 65000
-      identifier: 1.1.1.1
+      router-id: 1.1.1.1
     neighbor:
     - remote-address: 1.1.1.3
       remote-as: 65000

--- a/bdd/tests/configs/bgp_interas_option_ab/pe2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_ab/pe2.yaml
@@ -40,7 +40,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 2.2.2.1
+      router-id: 2.2.2.1
     neighbor:
     - remote-address: 2.2.2.3
       remote-as: 65001

--- a/bdd/tests/configs/bgp_interas_option_b/asbr1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_b/asbr1.yaml
@@ -42,7 +42,7 @@ router:
   bgp:
     global:
       as: 65000
-      identifier: 1.1.1.3
+      router-id: 1.1.1.3
     # Lower the MRAI so the transit VPNv4 route crosses the eBGP boundary
     # (default 30s) and is re-advertised to PE1 promptly — the four-hop
     # PE2->ASBR2->ASBR1->PE1 chain otherwise converges past the test wait.

--- a/bdd/tests/configs/bgp_interas_option_b/asbr2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_b/asbr2.yaml
@@ -36,7 +36,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 2.2.2.3
+      router-id: 2.2.2.3
     # Lower the MRAI so the transit VPNv4 route crosses the eBGP boundary
     # (default 30s) and is re-advertised to PE2 promptly (see ASBR1).
     timer:

--- a/bdd/tests/configs/bgp_interas_option_b/pe1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_b/pe1.yaml
@@ -45,7 +45,7 @@ router:
   bgp:
     global:
       as: 65000
-      identifier: 1.1.1.1
+      router-id: 1.1.1.1
     neighbor:
     - remote-address: 1.1.1.3
       remote-as: 65000

--- a/bdd/tests/configs/bgp_interas_option_b/pe2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_b/pe2.yaml
@@ -40,7 +40,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 2.2.2.1
+      router-id: 2.2.2.1
     neighbor:
     - remote-address: 2.2.2.3
       remote-as: 65001

--- a/bdd/tests/configs/bgp_interas_option_c/asbr1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_c/asbr1.yaml
@@ -38,7 +38,7 @@ router:
   bgp:
     global:
       as: 65000
-      identifier: 1.1.1.3
+      router-id: 1.1.1.3
     neighbor:
     - remote-address: 1.1.1.1
       remote-as: 65000

--- a/bdd/tests/configs/bgp_interas_option_c/asbr2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_c/asbr2.yaml
@@ -34,7 +34,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 2.2.2.3
+      router-id: 2.2.2.3
     neighbor:
     - remote-address: 2.2.2.1
       remote-as: 65001

--- a/bdd/tests/configs/bgp_interas_option_c/pe1.yaml
+++ b/bdd/tests/configs/bgp_interas_option_c/pe1.yaml
@@ -48,7 +48,7 @@ router:
   bgp:
     global:
       as: 65000
-      identifier: 1.1.1.1
+      router-id: 1.1.1.1
     neighbor:
     - remote-address: 1.1.1.3
       remote-as: 65000

--- a/bdd/tests/configs/bgp_interas_option_c/pe2.yaml
+++ b/bdd/tests/configs/bgp_interas_option_c/pe2.yaml
@@ -44,7 +44,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 2.2.2.1
+      router-id: 2.2.2.1
     neighbor:
     - remote-address: 2.2.2.3
       remote-as: 65001

--- a/bdd/tests/configs/bgp_neighbor_group/z1-1.yaml
+++ b/bdd/tests/configs/bgp_neighbor_group/z1-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor-groups:
       neighbor-group:
       - name: RR

--- a/bdd/tests/configs/bgp_neighbor_group/z1-2.yaml
+++ b/bdd/tests/configs/bgp_neighbor_group/z1-2.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor-groups:
       neighbor-group:
       - name: RR

--- a/bdd/tests/configs/bgp_neighbor_group/z2-1.yaml
+++ b/bdd/tests/configs/bgp_neighbor_group/z2-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z1.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-both.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-both.yaml
@@ -14,7 +14,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-initial.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-initial.yaml
@@ -13,7 +13,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_policy_dynamic_update/z2-other.yaml
+++ b/bdd/tests/configs/bgp_policy_dynamic_update/z2-other.yaml
@@ -13,7 +13,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_port/z1.yaml
+++ b/bdd/tests/configs/bgp_port/z1.yaml
@@ -10,7 +10,7 @@ router:
     port: 0
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_port/z2.yaml
+++ b/bdd/tests/configs/bgp_port/z2.yaml
@@ -11,7 +11,7 @@ router:
     port: 1790
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_port/z3-listen.yaml
+++ b/bdd/tests/configs/bgp_port/z3-listen.yaml
@@ -10,7 +10,7 @@ router:
     port: 179
     global:
       as: 65003
-      identifier: 192.168.1.3
+      router-id: 192.168.1.3
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_port/z3.yaml
+++ b/bdd/tests/configs/bgp_port/z3.yaml
@@ -8,7 +8,7 @@ router:
     port: 0
     global:
       as: 65003
-      identifier: 192.168.1.3
+      router-id: 192.168.1.3
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_remove_private_as/z1.yaml
+++ b/bdd/tests/configs/bgp_remove_private_as/z1.yaml
@@ -6,7 +6,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_remove_private_as/z2-base.yaml
+++ b/bdd/tests/configs/bgp_remove_private_as/z2-base.yaml
@@ -9,7 +9,7 @@ router:
   bgp:
     global:
       as: 100
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_remove_private_as/z2-remove.yaml
+++ b/bdd/tests/configs/bgp_remove_private_as/z2-remove.yaml
@@ -9,7 +9,7 @@ router:
   bgp:
     global:
       as: 100
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_remove_private_as/z3.yaml
+++ b/bdd/tests/configs/bgp_remove_private_as/z3.yaml
@@ -6,7 +6,7 @@ router:
   bgp:
     global:
       as: 200
-      identifier: 192.168.1.3
+      router-id: 192.168.1.3
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_route_map_match/z1.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z1.yaml
@@ -17,7 +17,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_route_map_match/z2-aspath-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-aspath-fail.yaml
@@ -13,7 +13,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_route_map_match/z2-aspath-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-aspath-pass.yaml
@@ -13,7 +13,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_route_map_match/z2-base.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-base.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-eq-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-eq-fail.yaml
@@ -9,7 +9,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-eq-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-eq-pass.yaml
@@ -9,7 +9,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-range-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-range-fail.yaml
@@ -9,7 +9,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-range-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-range-pass.yaml
@@ -10,7 +10,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_route_map_match/z2-nh-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-nh-fail.yaml
@@ -9,7 +9,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_route_map_match/z2-nh-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-nh-pass.yaml
@@ -9,7 +9,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_route_map_match/z2-origin-egp.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-origin-egp.yaml
@@ -9,7 +9,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_route_map_match/z2-origin-igp.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-origin-igp.yaml
@@ -9,7 +9,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_show/z1.yaml
+++ b/bdd/tests/configs/bgp_show/z1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_show/z2.yaml
+++ b/bdd/tests/configs/bgp_show/z2.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_srv6_redistribute/z1.yaml
+++ b/bdd/tests/configs/bgp_srv6_redistribute/z1.yaml
@@ -15,7 +15,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 10.0.0.1
+      router-id: 10.0.0.1
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_srv6_redistribute/z2.yaml
+++ b/bdd/tests/configs/bgp_srv6_redistribute/z2.yaml
@@ -20,7 +20,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 10.0.0.2
+      router-id: 10.0.0.2
     timer:
       adv-interval:
         ibgp: 1

--- a/bdd/tests/configs/bgp_tcp_ao_auth/z1-1.yaml
+++ b/bdd/tests/configs/bgp_tcp_ao_auth/z1-1.yaml
@@ -13,7 +13,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_tcp_ao_auth/z2-1.yaml
+++ b/bdd/tests/configs/bgp_tcp_ao_auth/z2-1.yaml
@@ -13,7 +13,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_tcp_md5_auth/z1-1.yaml
+++ b/bdd/tests/configs/bgp_tcp_md5_auth/z1-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_tcp_md5_auth/z2-1.yaml
+++ b/bdd/tests/configs/bgp_tcp_md5_auth/z2-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_tcp_md5_auth/z2-2.yaml
+++ b/bdd/tests/configs/bgp_tcp_md5_auth/z2-2.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_tcp_mss/z1-1.yaml
+++ b/bdd/tests/configs/bgp_tcp_mss/z1-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_tcp_mss/z2-1.yaml
+++ b/bdd/tests/configs/bgp_tcp_mss/z2-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_ttl_security/z1-1.yaml
+++ b/bdd/tests/configs/bgp_ttl_security/z1-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_ttl_security/z2-1.yaml
+++ b/bdd/tests/configs/bgp_ttl_security/z2-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_ttl_security/z2-2.yaml
+++ b/bdd/tests/configs/bgp_ttl_security/z2-2.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_unnumbered_neighbor/z1-base.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_neighbor/z1-base.yaml
@@ -10,4 +10,4 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 1.1.1.1
+      router-id: 1.1.1.1

--- a/bdd/tests/configs/bgp_unnumbered_neighbor/z1-full.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_neighbor/z1-full.yaml
@@ -15,7 +15,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 1.1.1.1
+      router-id: 1.1.1.1
     interface-neighbor:
     - interface: i1
       remote-as: 65002

--- a/bdd/tests/configs/bgp_unnumbered_neighbor/z2-base.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_neighbor/z2-base.yaml
@@ -3,4 +3,4 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 2.2.2.2
+      router-id: 2.2.2.2

--- a/bdd/tests/configs/bgp_unnumbered_neighbor/z2-full.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_neighbor/z2-full.yaml
@@ -8,7 +8,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 2.2.2.2
+      router-id: 2.2.2.2
     interface-neighbor:
     - interface: i1
       remote-as: 65001

--- a/bdd/tests/configs/bgp_update_group_ipv4/z1-1.yaml
+++ b/bdd/tests/configs/bgp_update_group_ipv4/z1-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_update_group_ipv4/z2-1.yaml
+++ b/bdd/tests/configs/bgp_update_group_ipv4/z2-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_update_group_ipv4/z3-1.yaml
+++ b/bdd/tests/configs/bgp_update_group_ipv4/z3-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65003
-      identifier: 192.168.0.3
+      router-id: 192.168.0.3
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_update_group_ipv4/z4-1.yaml
+++ b/bdd/tests/configs/bgp_update_group_ipv4/z4-1.yaml
@@ -2,7 +2,7 @@ router:
   bgp:
     global:
       as: 65004
-      identifier: 192.168.0.4
+      router-id: 192.168.0.4
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_vrf_evpn_type5/z1-1.yaml
+++ b/bdd/tests/configs/bgp_vrf_evpn_type5/z1-1.yaml
@@ -10,7 +10,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_vrf_evpn_type5/z2-1.yaml
+++ b/bdd/tests/configs/bgp_vrf_evpn_type5/z2-1.yaml
@@ -10,7 +10,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/bdd/tests/configs/bgp_vrf_show/z1-1.yaml
+++ b/bdd/tests/configs/bgp_vrf_show/z1-1.yaml
@@ -2,4 +2,4 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1

--- a/bdd/tests/configs/bgp_vrf_show/z1-2.yaml
+++ b/bdd/tests/configs/bgp_vrf_show/z1-2.yaml
@@ -10,7 +10,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     vrf:
     - name: vrf-blue
       rd: 65001:100

--- a/bdd/tests/configs/bgp_vrf_vpnv4_export/z1-1.yaml
+++ b/bdd/tests/configs/bgp_vrf_vpnv4_export/z1-1.yaml
@@ -10,7 +10,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_vrf_vpnv4_export/z2-1.yaml
+++ b/bdd/tests/configs/bgp_vrf_vpnv4_export/z2-1.yaml
@@ -10,7 +10,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       afi-safi:

--- a/book/src/ch-00-02-router-id.md
+++ b/book/src/ch-00-02-router-id.md
@@ -12,6 +12,88 @@ It is important to note that Cisco and Juniper differ in that one selects the hi
 
 To avoid confusion among operators who are familiar with existing router implementations, this implementation follows these rules:
 
-1. If one or more Loopback interfaces have an IP address configured, the highest among them is selected.
+1. If one or more Loopback interfaces have an IP address configured, the highest among them is selected (`127.0.0.1` is never a candidate).
 2. If not, then if one or more physical interfaces have an IP address configured, the highest among them is selected regardless of the interface's state.
 3. Otherwise, the router-id remains unset.
+
+Interfaces that are enslaved to a VRF are excluded from this default-instance selection — their addresses participate in the per-VRF selection instead (see below). Interfaces enslaved to a bridge remain candidates, since a bridge master does not move its ports out of the default routing table.
+
+Once a router-id has been selected it is *sticky*: if the address it was derived from later disappears and no other candidate exists, the previously selected value is retained rather than reverting to unset. This avoids churning every protocol session over a transient address removal.
+
+## Configuring the global Router-ID
+
+The automatic pick can be overridden with the top-level `router-id` command:
+
+```
+set router-id 10.255.0.1
+```
+
+The configured value always wins over the automatic pick. Deleting it falls back to the automatic selection again:
+
+```
+delete router-id 10.255.0.1
+```
+
+The effective value and its origin are visible with `show router-id`:
+
+```
+> show router-id
+Router ID: 10.255.0.1 (configured)
+> delete router-id 10.255.0.1
+> show router-id
+Router ID: 192.0.2.200 (automatic)
+```
+
+## Per-VRF Router-ID
+
+Each VRF has its own router-id, resolved independently of the default instance:
+
+1. The configured `vrf <name> router-id`, if present.
+2. Otherwise, the automatic pick among the VRF's member interfaces (the same loopback-first, highest-address rules as above).
+3. Otherwise, the global effective router-id.
+
+```yaml
+vrf:
+- name: cust-a
+  router-id: 11.11.11.11
+```
+
+The per-VRF values appear in `show vrf`:
+
+```
+> show vrf
+ Name                      Table-ID  Router-ID        Members
+ ------------------------  ----------  ---------------  ----------------
+ cust-a                           1  11.11.11.11      ce1
+ cust-b                           2  10.99.0.1        ce2
+```
+
+Here `cust-a` uses its configured override while `cust-b` derived `10.99.0.1` from its member interface. Deleting a per-VRF `router-id` falls back to the derived value, then to the global one.
+
+## Distribution to routing protocols
+
+The RIB pushes the effective router-id to every routing protocol: default-instance protocols receive the global value, per-VRF protocol instances receive their VRF's value. A change (an interface address appearing, an interface moving into a VRF, a configuration edit) is propagated to running instances immediately.
+
+Every protocol can still override the distributed value with its own configuration. The protocol-local value always wins; deleting it falls back to the RIB-distributed value. The knobs are deliberately named uniformly:
+
+| Protocol | Default instance | Per-VRF instance |
+|---|---|---|
+| BGP | `set router bgp global router-id A.B.C.D` | `set router bgp vrf <name> router-id A.B.C.D` |
+| OSPFv2 | `set router ospf router-id A.B.C.D` | `set router ospf vrf <name> router-id A.B.C.D` |
+| OSPFv3 | `set router ospfv3 router-id A.B.C.D` | `set router ospfv3 vrf <name> router-id A.B.C.D` |
+| IS-IS | `set router isis te-router-id A.B.C.D` | `set router isis vrf <name> te-router-id A.B.C.D` |
+
+Notes:
+
+* **BGP** — the knob was previously named `identifier`, following the IETF BGP YANG model; it has been renamed to `router-id` for consistency with every other knob in this table. It sets the BGP Identifier carried in OPEN messages. A per-neighbor `local-identifier` override also exists for individual sessions. A per-VRF BGP instance captures its router-id when it starts (the `vrf` value, falling back to the global one); later RIB updates are not yet applied to running per-VRF BGP instances.
+* **OSPFv2/v3** — the Router ID keys the router's LSAs. When neither a protocol-local nor a RIB-distributed value exists, OSPF instances fall back to the constructor default `10.0.0.1`; relying on that default is not recommended, since two routers sharing it can never form an adjacency.
+* **IS-IS** — IS-IS does not use an IPv4 router-id for its own identity (the NET supplies the system-id). `te-router-id` sets the stable Traffic Engineering Router ID advertised in TLV 134 and the Router Capability TLV; when it is not configured, the RIB-distributed router-id is advertised instead. Changing it re-originates the LSP immediately. (On a per-VRF instance the value is stored but only goes on the wire once per-VRF segment routing is available, since both TLVs are emitted by the SR machinery.)
+
+In summary, the value a protocol instance actually uses resolves through this chain, with configuration always beating derivation and every delete falling back to the next step:
+
+```
+protocol-local router-id
+  > VRF router-id            (configured, else derived from VRF members)
+  > global router-id         (configured, else derived from interfaces)
+  > protocol default         (e.g. 10.0.0.1 for OSPF)
+```

--- a/book/src/ch-02-02-tcp-authentication.md
+++ b/book/src/ch-02-02-tcp-authentication.md
@@ -106,7 +106,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       peer-as: 65002
@@ -145,7 +145,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       peer-as: 65002

--- a/book/src/ch-02-11-bgp-ttl-security.md
+++ b/book/src/ch-02-11-bgp-ttl-security.md
@@ -43,7 +43,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 10.0.0.1
+      router-id: 10.0.0.1
     neighbor:
     - remote-address: 10.0.0.2
       remote-as: 65002
@@ -126,7 +126,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       remote-as: 65002

--- a/book/src/ch-02-12-bgp-as-override.md
+++ b/book/src/ch-02-12-bgp-as-override.md
@@ -68,7 +68,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.1.3
       remote-as: 65001

--- a/book/src/ch-02-13-bgp-allowas-in.md
+++ b/book/src/ch-02-13-bgp-allowas-in.md
@@ -71,7 +71,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.1.3
+      router-id: 192.168.1.3
     neighbor:
     - remote-address: 192.168.1.2
       remote-as: 65002

--- a/book/src/ch-02-14-bgp-remove-private-as.md
+++ b/book/src/ch-02-14-bgp-remove-private-as.md
@@ -93,7 +93,7 @@ router:
   bgp:
     global:
       as: 100
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.1.3
       remote-as: 200

--- a/book/src/ch-02-14-bgp-tcp-mss.md
+++ b/book/src/ch-02-14-bgp-tcp-mss.md
@@ -19,7 +19,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       remote-as: 65002

--- a/book/src/ch-02-15-bgp-enforce-first-as.md
+++ b/book/src/ch-02-15-bgp-enforce-first-as.md
@@ -62,7 +62,7 @@ router:
   bgp:
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       remote-as: 65001

--- a/book/src/ch-02-16-bgp-disable-connected-check.md
+++ b/book/src/ch-02-16-bgp-disable-connected-check.md
@@ -76,7 +76,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 10.255.0.1
+      router-id: 10.255.0.1
     neighbor:
     - remote-address: 10.255.0.2
       remote-as: 65002

--- a/book/src/ch-02-17-bgp-srv6-encapsulation-type.md
+++ b/book/src/ch-02-17-bgp-srv6-encapsulation-type.md
@@ -55,7 +55,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 10.255.0.1
+      router-id: 10.255.0.1
     neighbor:
     - remote-address: 2001:db8::8
       remote-as: 65002

--- a/book/src/ch-02-19-bgp-interas-option-c.md
+++ b/book/src/ch-02-19-bgp-interas-option-c.md
@@ -82,7 +82,7 @@ router:
   bgp:
     global:
       as: 65000
-      identifier: 1.1.1.3
+      router-id: 1.1.1.3
     neighbor:
     - remote-address: 172.16.0.2   # ASBR2, over the inter-AS link
       remote-as: 65001

--- a/book/src/ch-02-20-bgp-interas-option-a.md
+++ b/book/src/ch-02-20-bgp-interas-option-a.md
@@ -74,7 +74,7 @@ interface:
   ipv4: { address: 10.1.0.1/30 }
 router:
   bgp:
-    global: { as: 65000, identifier: 1.1.1.1 }
+    global: { as: 65000, router-id: 1.1.1.1 }
     neighbor:
     - remote-address: 1.1.1.3        # ASBR1, intra-AS VPNv4
       remote-as: 65000
@@ -100,7 +100,7 @@ interface:
   ipv4: { address: 172.16.0.1/30 }   # inter-AS link, in the VRF
 router:
   bgp:
-    global: { as: 65000, identifier: 1.1.1.3 }
+    global: { as: 65000, router-id: 1.1.1.3 }
     neighbor:
     - remote-address: 1.1.1.1         # PE1, intra-AS VPNv4
       remote-as: 65000
@@ -119,7 +119,7 @@ router:
 
 A per-VRF neighbor needs no `afi-safi` block — it defaults to IPv4
 unicast, which is what a PE-CE session carries. The per-VRF BGP router-id
-defaults to the global identifier.
+defaults to the global `router-id` (see [Router ID](ch-00-02-router-id.md)).
 
 ## What makes the per-VRF session work
 

--- a/book/src/ch-02-21-bgp-interas-option-b.md
+++ b/book/src/ch-02-21-bgp-interas-option-b.md
@@ -80,7 +80,7 @@ interface:
   ipv4: { address: 10.1.0.1/30 }
 router:
   bgp:
-    global: { as: 65000, identifier: 1.1.1.1 }
+    global: { as: 65000, router-id: 1.1.1.1 }
     neighbor:
     - remote-address: 1.1.1.3        # ASBR1, intra-AS VPNv4
       remote-as: 65000
@@ -106,7 +106,7 @@ interface:
   ipv4: { address: 172.16.0.1/30 }   # inter-AS link, GLOBAL table
 router:
   bgp:
-    global: { as: 65000, identifier: 1.1.1.3 }
+    global: { as: 65000, router-id: 1.1.1.3 }
     neighbor:
     - remote-address: 1.1.1.1          # PE1, intra-AS VPNv4
       remote-as: 65000

--- a/book/src/ch-02-22-bgp-interas-option-ab.md
+++ b/book/src/ch-02-22-bgp-interas-option-ab.md
@@ -63,7 +63,7 @@ interface:
   ipv4: { address: 172.16.0.1/30 }   # inter-AS link, GLOBAL table
 router:
   bgp:
-    global: { as: 65000, identifier: 1.1.1.3 }
+    global: { as: 65000, router-id: 1.1.1.3 }
     neighbor:
     - remote-address: 1.1.1.1          # PE1, intra-AS VPNv4 iBGP
       remote-as: 65000

--- a/book/src/ch-02-23-bgp-port.md
+++ b/book/src/ch-02-23-bgp-port.md
@@ -39,7 +39,7 @@ router:
   bgp:
     global:
       as: 65001
-      identifier: 192.168.0.1
+      router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
       remote-as: 65002
@@ -59,7 +59,7 @@ router:
     port: 1790              # listen on TCP 1790; 0 = do not listen
     global:
       as: 65002
-      identifier: 192.168.0.2
+      router-id: 192.168.0.2
     neighbor:
     - remote-address: 192.168.0.1
       remote-as: 65001

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -32,7 +32,7 @@ fn config_global_asn(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> 
     Some(())
 }
 
-fn config_global_identifier(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+fn config_global_router_id(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     if op == ConfigOp::Set {
         bgp.router_id_config = Some(args.v4addr()?);
     } else {
@@ -2250,7 +2250,7 @@ impl Bgp {
 
     pub fn callback_build(&mut self) {
         self.callback_add("/router/bgp/global/as", config_global_asn);
-        self.callback_add("/router/bgp/global/identifier", config_global_identifier);
+        self.callback_add("/router/bgp/global/router-id", config_global_router_id);
         self.callback_add("/router/bgp/global/hostname", config_global_hostname);
         self.callback_add(
             "/router/bgp/global/no-fib-install",

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -343,18 +343,18 @@ pub struct RibKnownVrf {
 pub struct Bgp {
     pub asn: u32,
     /// Effective BGP Identifier — what OPENs, EVPN RDs and the show
-    /// paths use. Derived: configured `global identifier` wins, else
+    /// paths use. Derived: configured `global router-id` wins, else
     /// the RIB-derived value, else 0.0.0.0. Mutate via
     /// `refresh_router_id` (or `set_router_id` for the propagation
     /// side effects), never directly.
     pub router_id: Ipv4Addr,
-    /// Operator-configured `router bgp global identifier`. Wins over
+    /// Operator-configured `router bgp global router-id`. Wins over
     /// the RIB-derived value; deleting it falls back (same
     /// configured-vs-derived split IS-IS uses for te-router-id).
     pub router_id_config: Option<Ipv4Addr>,
     /// Last RIB-derived router-id (`RibRx::RouterIdUpdate`), kept
     /// even while a configured identifier overrides it so a later
-    /// `delete ... identifier` can fall back without waiting for the
+    /// `delete ... router-id` can fall back without waiting for the
     /// next RIB push.
     pub rib_router_id: Option<Ipv4Addr>,
     /// FRR-style `advertise-all-vni` knob under `router bgp afi-safi
@@ -1169,7 +1169,7 @@ impl Bgp {
     /// before the router-id was known would emit OPEN messages with
     /// `0.0.0.0` in the BGP Identifier field forever.
     ///
-    /// Both inputs — operator config (`router bgp global identifier`)
+    /// Both inputs — operator config (`router bgp global router-id`)
     /// and the RIB-derived auto-pick (`RibRx::RouterIdUpdate`) — land
     /// here through `refresh_router_id`, which resolves their
     /// precedence (configured wins). Don't call this with a raw input
@@ -1243,7 +1243,7 @@ impl Bgp {
     }
 
     /// Recompute the effective BGP Identifier from its two sources —
-    /// configured `global identifier` wins, RIB-derived second — and
+    /// configured `global router-id` wins, RIB-derived second — and
     /// propagate it. Falls back to 0.0.0.0 only when neither exists
     /// (pre-config cold start, or identifier deleted before any
     /// interface address was learned).
@@ -1256,7 +1256,7 @@ impl Bgp {
     }
 
     /// `RibRx::RouterIdUpdate` handler: remember the RIB-derived
-    /// value and refresh. A configured `global identifier` keeps
+    /// value and refresh. A configured `global router-id` keeps
     /// winning (the update is stored, not applied), so a later
     /// identifier delete can still fall back to it — the IS-IS
     /// `rib_router_id` pattern, replacing the old last-writer-wins
@@ -1983,7 +1983,7 @@ impl Bgp {
                 // or the automatic pick from interface addresses).
                 // Without this arm BGP emitted OPEN with 0.0.0.0 in
                 // the BGP Identifier whenever the operator hadn't
-                // typed `set router bgp global identifier <ip>`.
+                // typed `set router bgp global router-id <ip>`.
                 self.rib_router_id_update(router_id);
             }
             RibRx::FdbAdd(entry) => {

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -2040,7 +2040,7 @@ fn build_open_packet(peer: &mut Peer) -> BytesMut {
     if router_id.is_unspecified() {
         tracing::warn!(
             "peer {}: sending OPEN with router-id 0.0.0.0 — \
-             configure `router bgp global identifier <ipv4>` or wait \
+             configure `router bgp global router-id <ipv4>` or wait \
              for an interface address to seed the auto-derivation",
             peer.address
         );

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1315,6 +1315,54 @@ mod yang_load_tests {
         }
     }
 
+    /// `router bgp global router-id` is zebra-rs's rename of the IETF
+    /// model's `global/identifier` leaf (vendored ietf-bgp edit), so the
+    /// BGP surface matches every other router-id knob. The leaf lives in
+    /// a `uses ietf-bgp:bgp` grouping — exactly the class of change
+    /// `yang_load_tests` can't see — so pin both directions at the
+    /// grammar level: the new spelling parses, the old one no longer
+    /// does.
+    #[test]
+    fn bgp_global_router_id_renamed_from_identifier() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        let (code, _comps, _state) = parse(
+            "set router bgp global router-id 10.0.0.1",
+            entry.clone(),
+            None,
+            State::new(),
+        );
+        assert_eq!(
+            code,
+            ExecCode::Success,
+            "`set router bgp global router-id <ipv4>` must be a settable path",
+        );
+
+        let (code, _comps, _state) = parse(
+            "set router bgp global identifier 10.0.0.1",
+            entry,
+            None,
+            State::new(),
+        );
+        assert_ne!(
+            code,
+            ExecCode::Success,
+            "the pre-rename `identifier` spelling must no longer parse",
+        );
+    }
+
     /// A new BGP-neighbor YANG knob must be a *settable* path, not just a
     /// loadable module. Naming it the same as a leaf already present via
     /// `uses ietf-bgp:bgp` makes the augment silently dropped (RFC 7950

--- a/zebra-rs/src/rib/router_id.rs
+++ b/zebra-rs/src/rib/router_id.rs
@@ -5,8 +5,10 @@ use crate::config::{Args, ConfigOp};
 
 use super::{Link, Rib};
 
-/// First non-localhost IPv4 among the links accepted by `in_scope` —
-/// loopback-flagged links first, then the rest.
+/// Highest non-localhost IPv4 among the links accepted by `in_scope`
+/// — loopback-flagged links first, then the rest. "Highest" (not
+/// first-seen) is the rule the book documents (ch. 0.2), matching
+/// Cisco IOS selection so operators can predict the value.
 fn pick_router_id(
     links: &BTreeMap<u32, Link>,
     in_scope: impl Fn(&Link) -> bool,
@@ -24,7 +26,8 @@ fn pick_router_id(
                 ipnet::IpNet::V4(v4net) => Some(v4net.addr()),
                 _ => None,
             })
-            .find(|&addr| addr != Ipv4Addr::LOCALHOST)
+            .filter(|&addr| addr != Ipv4Addr::LOCALHOST)
+            .max()
     }
 
     find(links, &in_scope, true).or_else(|| find(links, &in_scope, false))
@@ -169,8 +172,9 @@ mod tests {
         assert!(links.get(&1).unwrap().flags.is_loopback());
         let no_vrfs = BTreeSet::new();
 
-        // Loopback wins over the (lower-ifindex) non-loopback; the
-        // 127.0.0.1 loopback address is never a candidate.
+        // Loopback wins over the non-loopback even though the
+        // non-loopback address is numerically higher; the 127.0.0.1
+        // loopback address is never a candidate.
         assert_eq!(auto_router_id(&links, &no_vrfs), Some(addr("10.255.0.1")));
 
         // Without any loopback candidate, fall back to non-loopback.
@@ -180,6 +184,27 @@ mod tests {
         // Only 127.0.0.1 left -> no candidate at all.
         links.remove(&2);
         assert_eq!(auto_router_id(&links, &no_vrfs), None);
+    }
+
+    #[test]
+    fn auto_pick_selects_highest_address_within_a_class() {
+        // The book's rule (ch. 0.2, Cisco-style): the HIGHEST address
+        // among loopbacks wins — not the first one encountered in
+        // ifindex order.
+        let mut links = BTreeMap::new();
+        links.insert(
+            1,
+            test_link(1, true, None, &[addr("10.2.2.2"), addr("10.1.1.1")]),
+        );
+        links.insert(2, test_link(2, true, None, &[addr("10.3.3.3")]));
+        let no_vrfs = BTreeSet::new();
+        assert_eq!(auto_router_id(&links, &no_vrfs), Some(addr("10.3.3.3")));
+
+        // Same rule on the non-loopback fallback.
+        let mut links = BTreeMap::new();
+        links.insert(5, test_link(5, false, None, &[addr("192.0.2.9")]));
+        links.insert(6, test_link(6, false, None, &[addr("192.0.2.200")]));
+        assert_eq!(auto_router_id(&links, &no_vrfs), Some(addr("192.0.2.200")));
     }
 
     #[test]

--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -301,7 +301,12 @@ module ietf-bgp {
             "Local autonomous system number of the router.  Uses
              the 32-bit as-number type from the model in RFC 6991.";
         }
-        leaf identifier {
+        // zebra-rs divergence from the IETF model: this leaf is named
+        // `identifier` upstream. Renamed to `router-id` so the BGP
+        // surface matches every other router-id knob in zebra-rs
+        // (top-level `router-id`, `vrf <name> router-id`,
+        // `router ospf{,v3} router-id`, `router bgp vrf <n> router-id`).
+        leaf router-id {
           type inet:ipv4-address;
           description
             "BGP Identifier of the router - an unsigned 32-bit,


### PR DESCRIPTION
## Summary

Rename the BGP Identifier knob from the IETF model's `router bgp global identifier` to `router bgp global router-id`, so the BGP surface matches every other router-id knob in zebra-rs (top-level `router-id`, `vrf <name> router-id`, `router ospf{,v3} [vrf <name>] router-id`, `router bgp vrf <name> router-id`). Final piece of the router-id series (#1312/#1314/#1315/#1317/#1319).

- **YANG**: rename the `global` container's `identifier` leaf in the vendored ietf-bgp model (divergence comment added); the confederation identifier and the per-neighbor state leaf keep their IETF names.
- **Rust**: callback path + handler renamed (`config_global_router_id`); peer.rs passive-accept hint text and doc comments follow.
- **BDD**: all 112 `identifier:` lines (verified uniformly under `router: bgp: global:`) renamed to `router-id:`; `cucumber.rs` and the feature files never referenced the old name.
- **Grammar regression test**: the leaf lives in a `uses ietf-bgp:bgp` grouping — the change class `yang_load_tests` can't see — so a parse-level test pins both directions: the new spelling is settable, the old one no longer parses.
- **Docs**: README quickstart + every book config example updated; the book's Router-ID chapter (ch. 0.2) extended into the full model reference (selection rules, sticky semantics, VRF-member exclusion, global/per-VRF config, `show router-id`/`show vrf`, RIB distribution, per-protocol override table, resolution chain).
- **Selection alignment**: the automatic pick now selects the HIGHEST candidate address per class (Cisco-style), as the book has always documented, instead of the first in ifindex order.

**Note for in-flight branches**: BGP BDD configs created before this commit use `identifier:` and must be renamed after rebasing.

## Test plan

- `cargo test --workspace --exclude bdd` all green (35 binaries, incl. the new grammar test and highest-address pick tests); YANG load tests pass; workspace clippy clean; `cargo fmt` applied.
- Live daemon: `set router bgp global router-id 5.5.5.5` applies and shows in `show bgp ipv4 summary`; the old `identifier` spelling is rejected; one of the actual renamed BDD config files applies via vtyctl and sets the identifier.
- A full local BDD feature run was deliberately skipped: a parallel worktree's BDD run was live on the shared `/usr/bin/zebra-rs` during validation, and installing the renamed YANG mid-run would have broken it. CI excludes BDD, so the renamed configs get harness exercise on the next local BDD run after `make install`.

Generated with [Claude Code](https://claude.com/claude-code)