### PR TITLE
book: refresh router-id coverage across protocol chapters

### DIFF
--- a/book/src/ch-02-00-what-is-bgp.md
+++ b/book/src/ch-02-00-what-is-bgp.md
@@ -1,1 +1,39 @@
-# BGP - Boarder Gateway Protocol
+# BGP - Border Gateway Protocol
+
+BGP (RFC 4271) is the path-vector routing protocol that connects
+autonomous systems. zebra-rs implements BGP-4 with the standard
+multiprotocol extensions: IPv4/IPv6 unicast, L3VPN (VPNv4/VPNv6),
+EVPN, labeled unicast, route-target constraint, link-state and more —
+each covered by its own chapter in this section.
+
+## Minimal configuration
+
+A BGP instance needs its autonomous system number; everything else
+has workable defaults. The canonical two-line start plus one
+neighbor:
+
+```
+set router bgp global as 65000
+set router bgp global router-id 10.0.0.1
+set router bgp neighbor 10.0.0.2 remote-as 65001
+commit
+```
+
+`global router-id` sets the BGP Identifier carried in OPEN messages.
+It is optional: when not configured, the RIB-distributed router-id
+(the system-wide selection, or the configured top-level `router-id`)
+is used, and deleting the BGP-local value falls back to it. See
+[Selection of the Router-ID](ch-00-02-router-id.md) for the full
+selection and precedence model. Earlier releases named this leaf
+`identifier`, following the IETF BGP YANG model; it was renamed for
+consistency with the rest of the configuration tree.
+
+A neighbor whose `remote-as` differs from the local AS forms an eBGP
+session; a matching AS forms iBGP. Session state is visible with:
+
+```
+> show bgp ipv4 summary
+IPv4 Unicast Summary:
+BGP router identifier 10.0.0.1, local AS number 65000 VRF default vrf-id 0
+...
+```

--- a/book/src/ch-02-02-tcp-authentication.md
+++ b/book/src/ch-02-02-tcp-authentication.md
@@ -109,7 +109,7 @@ router:
       router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
-      peer-as: 65002
+      remote-as: 65002
       enabled: true
       afi-safi:
       - name: ipv4
@@ -148,7 +148,7 @@ router:
       router-id: 192.168.0.1
     neighbor:
     - remote-address: 192.168.0.2
-      peer-as: 65002
+      remote-as: 65002
       enabled: true
       afi-safi:
       - name: ipv4

--- a/book/src/ch-06-02-show-config-commands.md
+++ b/book/src/ch-06-02-show-config-commands.md
@@ -42,15 +42,18 @@ default when you don't specify a serialization.
 ```
 host(config)# show candidate-config
 system {
-    hostname r1
+  hostname r1;
 }
 router {
-    bgp 65000 {
-        router-id 10.0.0.1
-        neighbor 10.0.0.2 {
-            peer-as 65001
-        }
+  bgp {
+    global {
+      as 65000;
+      router-id 10.0.0.1;
     }
+    neighbor 10.0.0.2 {
+      remote-as 65001;
+    }
+  }
 }
 ```
 
@@ -62,8 +65,9 @@ line, suitable for `load` to replay or for diffing in plain text.
 ```
 host(config)# show candidate-config formal
 set system hostname r1
-set router bgp 65000 router-id 10.0.0.1
-set router bgp 65000 neighbor 10.0.0.2 peer-as 65001
+set router bgp global as 65000
+set router bgp global router-id 10.0.0.1
+set router bgp neighbor 10.0.0.2 remote-as 65001
 ```
 
 ### `json`
@@ -77,12 +81,18 @@ internal `preserve_order` flag.
     "hostname": "r1"
   },
   "router": {
-    "bgp": [
-      {
+    "bgp": {
+      "global": {
         "as": 65000,
         "router-id": "10.0.0.1"
-      }
-    ]
+      },
+      "neighbor": [
+        {
+          "remote-address": "10.0.0.2",
+          "remote-as": 65001
+        }
+      ]
+    }
   }
 }
 ```
@@ -96,8 +106,12 @@ system:
   hostname: r1
 router:
   bgp:
-    - as: 65000
+    global:
+      as: 65000
       router-id: 10.0.0.1
+    neighbor:
+    - remote-address: 10.0.0.2
+      remote-as: 65001
 ```
 
 ## Editing helpers

--- a/book/src/ch-07-00-isis.md
+++ b/book/src/ch-07-00-isis.md
@@ -16,3 +16,31 @@ paths (TI-LFA, RFC 9490).
 This section documents operational tuning surfaces. See `router isis`
 under `/router/isis` in the YANG schema for the full configuration
 tree.
+
+## Identity: NET and TE Router ID
+
+IS-IS does not use an IPv4 router-id for its own identity — the
+configured NET (Network Entity Title) supplies the system-id that
+names the router in the link-state database:
+
+```
+set router isis net 49.0000.0000.0000.0001.00
+```
+
+The IPv4-shaped identity IS-IS *does* advertise is the stable
+Traffic Engineering Router ID, carried in TLV 134 and in the Router
+Capability TLV (both emitted when segment routing is enabled):
+
+```
+set router isis te-router-id 1.1.1.1
+```
+
+When `te-router-id` is not configured, the RIB-distributed router-id
+(the system-wide selection, or the configured top-level `router-id`)
+is advertised instead. Setting or deleting `te-router-id`
+re-originates the self LSP immediately, so the change propagates
+without waiting for the refresh timer. A per-VRF instance accepts
+`set router isis vrf <name> te-router-id`, which is stored and goes
+on the wire once per-VRF segment routing is available. See
+[Selection of the Router-ID](ch-00-02-router-id.md) for the
+system-wide selection and precedence model.

--- a/book/src/ch-08-01-ospf-configuration.md
+++ b/book/src/ch-08-01-ospf-configuration.md
@@ -47,8 +47,18 @@ operator wrote it.
 
 | YANG leaf | Type | Notes |
 |---|---|---|
-| `/router/ospf/router-id` | `inet:ipv4-address` | Optional; falls back to the system-wide router-id selection rules. |
+| `/router/ospf/router-id` | `inet:ipv4-address` | Optional; wins over the RIB-distributed value. Deleting it falls back to the RIB-distributed router-id, then to the constructor default `10.0.0.1`. |
+| `/router/ospf/vrf/<name>/router-id` | `inet:ipv4-address` | Per-VRF instance override; same precedence against the VRF's RIB-distributed router-id. |
 | `/router/ospf/area/<id>/area-id` | `union { uint32; ipv4-address }` | List key — see above. |
+
+Two routers must not share a Router ID — a neighbor advertising our
+own ID looks like self-originated traffic and no adjacency forms — so
+either configure it explicitly per router (recommended) or ensure each
+router derives a unique value (e.g. a unique loopback address). The
+same `router-id` leaf exists on `router ospfv3` (and its `vrf` list)
+with identical semantics. See
+[Selection of the Router-ID](ch-00-02-router-id.md) for the full
+selection and precedence model.
 
 ## Per-interface knobs
 


### PR DESCRIPTION
## Summary

Follow-up to the router-id series (#1312–#1321) bringing the rest of the book in line with the model that ch. 0.2 now documents — plus stale-grammar fixes the survey turned up:

- **ch-02-00 (BGP)**: replace the one-line stub with a minimal-config introduction using the current grammar (`global as` / `global router-id` / `neighbor remote-as`), the RIB-fallback semantics of the BGP Identifier, a note about the rename from the IETF model's `identifier`, and the title typo fix (Boarder → Border).
- **ch-06-02 (Show Config Commands)**: the CLI / formal / json / yaml example blocks still showed a long-gone grammar (`bgp 65000 { router-id …; peer-as … }`); rewrite all four to the real tree (`bgp { global { as; router-id; } neighbor … }`, `remote-address` list key, `remote-as`).
- **ch-08-01 (OSPF Configuration)**: the router-id leaf row now states the precedence (configured wins over the RIB-distributed value, delete falls back, constructor default 10.0.0.1 last), adds the per-VRF leaf row, warns about duplicate Router IDs blocking adjacency, notes ospfv3 parity, and cross-links ch. 0.2.
- **ch-07-00 (IS-IS)**: new "Identity: NET and TE Router ID" section — NET supplies the system identity; `te-router-id` feeds TLV 134 and the Router Capability TLV with RIB-distributed fallback, immediate LSP re-origination on change, and the per-VRF staging caveat; cross-links ch. 0.2.
- **ch-02-02 (TCP Authentication)**: the two YAML examples used the nonexistent `peer-as` leaf; corrected to `remote-as`.

## Test plan

- `mdbook build book` passes with no broken-link warnings; both touched cross-links resolve.
- Documentation-only change — no code touched.

Generated with [Claude Code](https://claude.com/claude-code)