### PR TITLE
docs(bdd): add inter-as option B/AB and bgp_port docs, refresh three more

### DIFF
--- a/bdd/docs/bgp_interas_option_ab.md
+++ b/bdd/docs/bgp_interas_option_ab.md
@@ -1,0 +1,46 @@
+# Inter-AS MPLS/VPN Option AB over SR-MPLS (RFC 4364 hybrid)
+
+## Overview
+
+As a service provider running L3VPN across two autonomous systems
+I want Inter-AS Option AB: the ASBRs keep a per-VPN VRF and forward
+through it (the VPN label terminates at the ASBR → VRF lookup →
+re-impose, like Option A), but exchange every VPN over a single MP-eBGP
+VPNv4 session on one labelled link (like Option B). Each ASBR's
+`inter-as-hybrid` VRF re-exports the VPNv4 routes it imports, relaying
+the remote AS's prefixes to its own PEs.
+
+## Test Topology
+
+```
+            AS 65000                                AS 65001
+   ce1 ── pe1 ──── p1 ──── asbr1 ════════ asbr2 ──── p2 ──── pe2 ── ce2
+          lo        lo       lo  172.16.0.0/30 lo      lo      lo
+       1.1.1.1   1.1.1.2  1.1.1.3  (global)   2.2.2.3 2.2.2.2 2.2.2.1
+   └ vrf-cust ┘        └ vrf-cust ┘        └ vrf-cust ┘    └ vrf-cust ┘
+    10.1.0.0/30        (transit, no CE)   (transit, no CE)  10.2.0.0/30
+```
+
+## Notes
+
+- Intra-AS: IS-IS L2 + segment-routing mpls; VPNv4 iBGP PE↔ASBR over
+  the SR-MPLS core.
+- Inter-AS (asbr1↔asbr2, 172.16.0.0/30): a single-hop **MP-eBGP VPNv4**
+  session over a link in the GLOBAL table. Each ASBR holds vrf-cust (no
+  interface, no CE) with `inter-as-hybrid`, so it imports the VPNv4 it
+  receives into the VRF (for per-VRF forwarding) AND re-exports it onward.
+- A CE→CE packet is VPN-labelled PE→ASBR over the SR core; at each ASBR
+  the label terminates (DecapVrf → VRF lookup) and a new label is
+  imposed — toward the peer ASBR (single label on the inter-AS link) or
+  toward the egress PE over its SR core.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the Inter-AS Option AB topology and bring up every session | |
+| SR-MPLS transport LSPs are installed on the core P routers | |
+| Each ASBR holds every VPN prefix in its per-VPN VRF (the "A" half) | |
+| Each PE imports the remote-AS customer prefix into its VRF | |
+| End-to-end customer forwarding across the AS boundary (per-VRF label swap) | |
+| Teardown topology | |

--- a/bdd/docs/bgp_interas_option_b.md
+++ b/bdd/docs/bgp_interas_option_b.md
@@ -1,0 +1,47 @@
+# Inter-AS MPLS/VPN Option B over SR-MPLS (RFC 4364 §10b)
+
+## Overview
+
+As a service provider running L3VPN across two autonomous systems
+I want Inter-AS Option B: the ASBRs exchange VPNv4 routes directly over
+a single-hop MP-eBGP session and re-advertise them with next-hop-self,
+allocating a fresh local label and a swap ILM for each, so the VPN
+crosses the AS boundary as a label switch — the ASBRs hold every VPN
+route but no VRF, and the inter-AS link carries labelled VPNv4 packets.
+
+## Test Topology
+
+```
+            AS 65000                                AS 65001
+   ce1 ── pe1 ──── p1 ──── asbr1 ════════ asbr2 ──── p2 ──── pe2 ── ce2
+          lo        lo       lo  172.16.0.0/30 lo      lo      lo
+       1.1.1.1   1.1.1.2  1.1.1.3  (global)   2.2.2.3 2.2.2.2 2.2.2.1
+   └ vrf-cust ┘                                            └ vrf-cust ┘
+    10.1.0.0/30                                            10.2.0.0/30
+```
+
+## Notes
+
+- Intra-AS: IS-IS L2 + segment-routing mpls; VPNv4 iBGP PE↔ASBR over
+  the SR-MPLS core (the PE loopback next-hop is resolved by the IGP —
+  no BGP-LU).
+- Inter-AS (asbr1↔asbr2, 172.16.0.0/30): a single-hop **MP-eBGP VPNv4**
+  session over a link in the GLOBAL table (NOT the IGP). The ASBRs run
+  NO VRF: a received VPNv4 route sits in the global v4vpn RIB and is
+  re-advertised with next-hop-self, a freshly allocated local label and
+  a swap ILM (our label → received label, toward the original next-hop).
+- A CE→CE packet is VPN-labelled PE→ASBR over the SR core; the ASBR
+  swaps the VPN label and forwards a single labelled packet across the
+  inter-AS link; the far ASBR swaps again over its SR core to the egress
+  PE, which pops and delivers plain IP to the CE.
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Build the Inter-AS Option B topology and bring up every session | |
+| SR-MPLS transport LSPs are installed on the core P routers | |
+| The ASBRs hold every VPN prefix in the global VPNv4 table (no VRF) | |
+| Each PE imports the remote-AS customer prefix into its VRF | |
+| End-to-end customer forwarding across the AS boundary (VPNv4 label swap) | |
+| Teardown topology | |

--- a/bdd/docs/bgp_port.md
+++ b/bdd/docs/bgp_port.md
@@ -1,0 +1,56 @@
+# BGP on a non-default TCP port
+
+## Overview
+
+As a network operator
+I want `router bgp port <0-65535>` and `neighbor X port <1-65535>`
+So sessions can run on a non-179 port, and a router can refuse all
+inbound BGP by closing its listener (`port 0`).
+
+## Test Topology
+
+```
+   ┌─────────┐  192.168.0.0/24  ┌─────────┐  192.168.1.0/24  ┌─────────┐
+   │   z1    │ i1────────────i1 │   z2    │ i2────────────i1 │   z3    │
+   │ AS65001 │                  │ AS65002 │                  │ AS65003 │
+   │  .0.1   │                  │.0.2 .1.2│                  │  .1.3   │
+   └─────────┘                  └─────────┘                  └─────────┘
+```
+
+## Notes
+
+z1—z2 exercises the two port knobs together: z2 listens on TCP 1790
+(`port: 1790`) and z1 dials it (`neighbor 192.168.0.2 port 1790`).
+Both ends pin the connection direction so the assertion on the ports
+is deterministic: z1 runs `port: 0` (its dial works fine without any
+listener, and z2's racing dial toward z1:179 is refused) and z2 is
+passive toward z1. The only session that can exist is the one z1
+opened toward 1790. z1 originates 10.10.0.1/32 to prove routes flow
+over it.
+z2—z3 exercises `port 0` on the accept side: z3 starts with
+`port: 0` (no listener) and is passive toward z2, so z2's dials to
+z3:179 are refused and the session must stay down. Re-configuring z3
+to `port: 179` reopens the listener at runtime; a `clear` on z2 then
+redials immediately (a refused connect otherwise parks the peer on
+the 120s connect-retry timer) and the session establishes — the
+close-and-reopen path of a runtime port change.
+Config application order matters once: z3's `port: 0` is applied
+before z2's config exists, so z2 never catches the small window
+between z3's daemon start (default listener on 179) and the apply.
+
+## Config Files
+
+- z1.yaml: `port: 0`; neighbor z2 with `port: 1790`; originates
+- z2.yaml: `port: 1790` listener; passive toward z1; active toward z3
+- z3.yaml: `port: 0` (no listener); passive toward z2
+- z3-listen.yaml: same as z3.yaml with `port: 179` (reopen listener)
+
+## Test Scenarios
+
+| Scenario | Result |
+|----------|--------|
+| Setup line topology with custom ports | |
+| Session between z1 and z2 runs on TCP 1790 | |
+| port 0 closes the listener so the z2-z3 session stays down | |
+| Changing the port reopens the listener and the session comes up | |
+| Teardown topology | |

--- a/bdd/docs/bgp_vrf_show.md
+++ b/bdd/docs/bgp_vrf_show.md
@@ -6,7 +6,8 @@ As a network operator
 I want to inspect the per-VRF state of a running zebra-rs
 Using a single-namespace topology that drives the local config
 callbacks end-to-end so `show ip bgp vrf` reports the committed
-Route Distinguisher / Route Target / MPLS label.
+Route Distinguisher / MPLS label / task state, and the named forms
+redirect into the spawned per-VRF task.
 
 ## Test Topology
 
@@ -30,5 +31,5 @@ Route Distinguisher / Route Target / MPLS label.
 | Setup topology | |
 | Configure vrf-blue and observe via show | |
 | Inspect vrf-blue via the `show bgp vrf` tree | |
-| Remove vrf-blue and observe row drops | |
+| Remove the BGP VRF block and observe the RD clear | |
 | Teardown topology | |

--- a/bdd/docs/bgp_vrf_vpnv4_export.md
+++ b/bdd/docs/bgp_vrf_vpnv4_export.md
@@ -38,4 +38,5 @@ inside vrf-blue and z2 peers with z1 over VPNv4 only.
 | Setup topology | |
 | z1 advertises the self-originated network as VPNv4 | |
 | z2 receives the VPNv4 NLRI under the same RD | |
+| VPNv4 route detail by address and by exact prefix | |
 | Teardown topology | |

--- a/bdd/docs/isis_bfd_ipv4_p2p.md
+++ b/bdd/docs/isis_bfd_ipv4_p2p.md
@@ -9,8 +9,8 @@ hold time, and the adjacency stays down (RFC 5882 hold-down) until BFD
 recovers — even while IIHs keep arriving.
 The single-hop BFD session is built from the two ends' IPv4 interface
 addresses (learned via TLV 132). Each scenario is self-contained (own setup
-and teardown) so the Echo scenarios configure echo-mode before the session
-first comes up (echo is armed at session establishment, not retrofitted).
+and teardown). Echo params apply to live sessions too — the last scenario
+toggles echo-mode at runtime and the session must not be re-established.
 BFD-down is induced by dropping inbound UDP/3784 in one namespace: the link
 stays up and IIHs (L2 ISO PDUs, not IP/UDP) keep flowing, so a fast teardown
 is provably BFD's doing — not carrier loss, not the ~30s IS-IS hold timer.
@@ -32,4 +32,5 @@ is provably BFD's doing — not carrier loss, not the ~30s IS-IS hold timer.
 |----------|--------|
 | BFD without Echo protects the adjacency and tears it down on BFD failure | |
 | BFD with Echo in one direction (z1 transmit, z2 receive) | |
+| Echo transmit is toggled at runtime on the live session | |
 | BFD with Echo in both directions | |


### PR DESCRIPTION
## Summary
- Add generated feature docs for three features that had none: `bgp_interas_option_b`, `bgp_interas_option_ab`, `bgp_port`.
- Refresh three docs whose features gained scenarios recently:
  - `bgp_vrf_show` — named-form `show bgp vrf` redirect and the RD-clear scenario rename.
  - `bgp_vrf_vpnv4_export` — new VPNv4 route-detail (by address / exact prefix) scenario row.
  - `isis_bfd_ipv4_p2p` — runtime echo-mode toggle scenario (echo params now apply to live sessions).

## Test plan
Docs-only change (markdown under `bdd/docs/`); no code or feature files touched. CI fmt/clippy/test gates are unaffected but will run as usual.

Generated with [Claude Code](https://claude.com/claude-code)