### PR TITLE
config: reject unknown YAML keys; fix med BDD configs; safe vtyctl -c

### DIFF
--- a/bdd/docs/bgp_route_map_match.md
+++ b/bdd/docs/bgp_route_map_match.md
@@ -14,12 +14,15 @@ deterministic to compare against.
 Re-evaluation relies entirely on the policy-change trigger
 (PolicyRx -> soft-in): applying a config whose policy content changed
 re-runs the inbound policy over the Adj-RIB-In. Deliberately NO
-`I clear namespace ... neighbor` steps here — that step is a real
-egress soft-clear since the clear grammar was wired (PR #1318), and
-an operator `clear ... soft [in]` after additively-merged same-name
-policy edits currently diverges from the trigger path on the MED
-scenarios (open daemon bug — soft-in replay re-admits trigger-denied
-routes). Historically the step was a silent no-op here anyway.
+`I clear namespace ... neighbor` steps here — that step is an egress
+soft-clear (since PR #1318/#1320) and adds nothing to an inbound
+policy test; the apply trigger is the path under test.
+History: the MED scenarios were broken from the start — the configs
+used flat `med-eq:`/`med-ge:`/`med-le:` keys that do not exist in
+the schema (the YANG models a one-of `med: { eq | le | ge }`
+choice), and the YAML apply silently dropped unknown keys, leaving
+IN-MED permit-all. The configs now use the nested shape, and apply
+rejects unknown document keys loudly.
 
 ## Test Topology
 
@@ -44,10 +47,10 @@ routes). Historically the step was a silent no-op here anyway.
 - z2-aspath-fail.yaml: input policy `match as-path-set FROM-65999`
 - z2-origin-igp.yaml: input policy `match origin igp` — matches
 - z2-origin-egp.yaml: input policy `match origin egp` — no route
-- z2-med-eq-pass.yaml: input policy `match med-eq 100` — matches.
-- z2-med-eq-fail.yaml: input policy `match med-eq 999` — no match.
-- z2-med-range-pass.yaml: input policy `match med-ge 50, med-le 200`
-- z2-med-range-fail.yaml: input policy `match med-ge 200` — MED=100
+- z2-med-eq-pass.yaml: input policy `match med eq 100` — matches.
+- z2-med-eq-fail.yaml: input policy `match med eq 999` — no match.
+- z2-med-range-pass.yaml: input policy `match med le 200` —
+- z2-med-range-fail.yaml: input policy `match med ge 200` — MED=100
 - z2-nh-pass.yaml: input policy `match next-hop-set PEER-SUBNET`
 - z2-nh-fail.yaml: input policy `match next-hop-set WRONG-SUBNET`
 
@@ -60,10 +63,10 @@ routes). Historically the step was a silent no-op here anyway.
 | match as-path-set rejects routes whose AS_PATH does not match | |
 | match origin igp accepts network-originated routes | |
 | match origin egp rejects network-originated (igp) routes | |
-| match med-eq accepts routes with the exact MED value | |
-| match med-eq rejects routes with a different MED value | |
-| match med-ge and med-le accept routes inside the range | |
-| match med-ge rejects routes below the floor | |
+| match med eq accepts routes with the exact MED value | |
+| match med eq rejects routes with a different MED value | |
+| match med le accepts routes at or below the ceiling | |
+| match med ge rejects routes below the floor | |
 | match next-hop-set accepts routes whose nexthop is in the prefix-set | |
 | match next-hop-set rejects routes whose nexthop is outside the prefix-set | |
 | Teardown topology | |

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-eq-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-eq-fail.yaml
@@ -4,7 +4,8 @@ policy:
   - number: 10
     action: permit
     match:
-      med-eq: 999
+      med:
+        eq: 999
 router:
   bgp:
     global:

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-eq-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-eq-pass.yaml
@@ -4,7 +4,8 @@ policy:
   - number: 10
     action: permit
     match:
-      med-eq: 100
+      med:
+        eq: 100
 router:
   bgp:
     global:

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-range-fail.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-range-fail.yaml
@@ -4,7 +4,8 @@ policy:
   - number: 10
     action: permit
     match:
-      med-ge: 200
+      med:
+        ge: 200
 router:
   bgp:
     global:

--- a/bdd/tests/configs/bgp_route_map_match/z2-med-range-pass.yaml
+++ b/bdd/tests/configs/bgp_route_map_match/z2-med-range-pass.yaml
@@ -4,8 +4,8 @@ policy:
   - number: 10
     action: permit
     match:
-      med-ge: 50
-      med-le: 200
+      med:
+        le: 200
 router:
   bgp:
     global:

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -460,11 +460,10 @@ async fn wait_for_bgp(_world: &mut World, seconds: u64) {
 /// those. For a hard reset, use the generic run step with
 /// `clear bgp ipv4 <peer>` instead.
 ///
-/// Deliberately NOT `soft` (both directions): the soft-IN replay can
-/// re-admit routes the policy-change trigger just denied when the
-/// additively-merged policy state diverges (observed live on
-/// bgp_route_map_match's med-eq scenarios) — a daemon-side issue
-/// tracked separately; the re-flood intent only needs OUT.
+/// Deliberately `soft out` (not `soft`): every feature uses this step
+/// for its egress re-flood effect; inbound re-evaluation already runs
+/// automatically when an inbound policy changes, so the IN leg adds
+/// nothing here.
 ///
 /// History: this step used to issue the legacy `clear ip bgp
 /// neighbors <X>` grammar, which was never wired into

--- a/bdd/tests/features/bgp_route_map_match.feature
+++ b/bdd/tests/features/bgp_route_map_match.feature
@@ -15,12 +15,16 @@ Feature: BGP route-map match clauses
   Re-evaluation relies entirely on the policy-change trigger
   (PolicyRx -> soft-in): applying a config whose policy content changed
   re-runs the inbound policy over the Adj-RIB-In. Deliberately NO
-  `I clear namespace ... neighbor` steps here — that step is a real
-  egress soft-clear since the clear grammar was wired (PR #1318), and
-  an operator `clear ... soft [in]` after additively-merged same-name
-  policy edits currently diverges from the trigger path on the MED
-  scenarios (open daemon bug — soft-in replay re-admits trigger-denied
-  routes). Historically the step was a silent no-op here anyway.
+  `I clear namespace ... neighbor` steps here — that step is an egress
+  soft-clear (since PR #1318/#1320) and adds nothing to an inbound
+  policy test; the apply trigger is the path under test.
+
+  History: the MED scenarios were broken from the start — the configs
+  used flat `med-eq:`/`med-ge:`/`med-le:` keys that do not exist in
+  the schema (the YANG models a one-of `med: { eq | le | ge }`
+  choice), and the YAML apply silently dropped unknown keys, leaving
+  IN-MED permit-all. The configs now use the nested shape, and apply
+  rejects unknown document keys loudly.
 
   Test Topology:
   ```
@@ -49,11 +53,13 @@ Feature: BGP route-map match clauses
     network-originated routes.
   - z2-origin-egp.yaml: input policy `match origin egp` — no route
     matches.
-  - z2-med-eq-pass.yaml: input policy `match med-eq 100` — matches.
-  - z2-med-eq-fail.yaml: input policy `match med-eq 999` — no match.
-  - z2-med-range-pass.yaml: input policy `match med-ge 50, med-le 200`
-    — matches MED=100.
-  - z2-med-range-fail.yaml: input policy `match med-ge 200` — MED=100
+  - z2-med-eq-pass.yaml: input policy `match med eq 100` — matches.
+  - z2-med-eq-fail.yaml: input policy `match med eq 999` — no match.
+  - z2-med-range-pass.yaml: input policy `match med le 200` —
+    MED=100 is at or below the ceiling, matches. (`match med` is a
+    one-of eq|le|ge choice, so a two-sided range needs two entries;
+    the le and ge bounds are exercised separately.)
+  - z2-med-range-fail.yaml: input policy `match med ge 200` — MED=100
     is below the floor, no match.
   - z2-nh-pass.yaml: input policy `match next-hop-set PEER-SUBNET`
     where the prefix-set is 192.168.0.0/24 — matches z1's nexthop
@@ -104,28 +110,28 @@ Feature: BGP route-map match clauses
     Then BGP route in "z2" does not have "10.0.0.1/32"
     And BGP route in "z2" does not have "10.0.0.2/32"
 
-  Scenario: match med-eq accepts routes with the exact MED value
+  Scenario: match med eq accepts routes with the exact MED value
     Given the test topology exists
     When I apply config "z2-med-eq-pass.yaml" to namespace "z2"
     And I wait 5 seconds for BGP to operate
     Then BGP route in "z2" has "10.0.0.1/32"
     And BGP route in "z2" has "10.0.0.2/32"
 
-  Scenario: match med-eq rejects routes with a different MED value
+  Scenario: match med eq rejects routes with a different MED value
     Given the test topology exists
     When I apply config "z2-med-eq-fail.yaml" to namespace "z2"
     And I wait 5 seconds for BGP to operate
     Then BGP route in "z2" does not have "10.0.0.1/32"
     And BGP route in "z2" does not have "10.0.0.2/32"
 
-  Scenario: match med-ge and med-le accept routes inside the range
+  Scenario: match med le accepts routes at or below the ceiling
     Given the test topology exists
     When I apply config "z2-med-range-pass.yaml" to namespace "z2"
     And I wait 5 seconds for BGP to operate
     Then BGP route in "z2" has "10.0.0.1/32"
     And BGP route in "z2" has "10.0.0.2/32"
 
-  Scenario: match med-ge rejects routes below the floor
+  Scenario: match med ge rejects routes below the floor
     Given the test topology exists
     When I apply config "z2-med-range-fail.yaml" to namespace "z2"
     And I wait 5 seconds for BGP to operate

--- a/book/src/ch-02-25-bgp-clear.md
+++ b/book/src/ch-02-25-bgp-clear.md
@@ -66,13 +66,11 @@ Soft clears re-run policy without touching the TCP session:
 EVPN `soft in` is not implemented yet; the command reports
 `%% EVPN soft-in is not yet implemented` and leaves the session alone.
 
-> **Known issue:** after several *additive* edits to a policy under
-> the same name (re-`apply`ing config variants that overlay entries),
-> a `soft in` replay can disagree with the automatic re-evaluation
-> that runs when policy content changes — re-admitting routes the
-> policy change had just denied. Until that is resolved, prefer
-> `soft out` for re-flooding and rely on the automatic trigger for
-> inbound policy changes.
+Note that a `soft in` is rarely *needed* after a config change:
+editing an inbound policy already triggers the same re-evaluation
+automatically. The explicit command exists for operational use —
+re-checking the table after out-of-band changes, or confirming what
+the current policy admits.
 
 ## Where the per-AFI forms apply
 

--- a/vtyctl/src/apply.rs
+++ b/vtyctl/src/apply.rs
@@ -30,10 +30,21 @@ pub async fn apply(host: &str, filename: &str, command: Option<&String>) -> Resu
         // when the input ends with one.
         let normalised = cmd.replace("\\n", "\n");
         for line in normalised.lines() {
+            // `-c` is the command surface: a bare line is a `set`
+            // line. Without the explicit prefix the server's format
+            // sniffer would classify the payload as a YAML *document*,
+            // clear the candidate, and REPLACE the entire running
+            // config with whatever that one line parses to.
+            let line = if line.trim().is_empty()
+                || line.starts_with("set ")
+                || line.starts_with("delete ")
+            {
+                line.to_string()
+            } else {
+                format!("set {}", line)
+            };
             println!("line:{}", line);
-            vec.push(ApplyRequest {
-                line: line.to_string() + "\n",
-            });
+            vec.push(ApplyRequest { line: line + "\n" });
         }
     } else if !filename.is_empty() {
         let path = Path::new(filename);

--- a/zebra-rs/src/config/json.rs
+++ b/zebra-rs/src/config/json.rs
@@ -2,14 +2,38 @@ use libyang::Entry;
 use serde_json::Value;
 use std::rc::Rc;
 
-pub fn json_read(e: Rc<Entry>, str: &str) -> Vec<String> {
-    let json: Value = serde_json::from_str(str).unwrap();
+/// Translate a JSON (or YAML-converted-to-JSON) config document into
+/// flat `set …` command lines by walking it against the YANG `set`
+/// subtree.
+///
+/// Returns the command lines plus a list of errors for every part of
+/// the document that does NOT correspond to the schema. Errors must
+/// reach the operator: this walk used to silently `return` on the
+/// first unknown key — dropping that key AND every remaining sibling —
+/// which let a misspelled key (e.g. `med-eq:` for the nested
+/// `med: { eq: … }`) produce a partial config that *applied* cleanly
+/// while testing nothing.
+pub fn json_read(e: Rc<Entry>, str: &str) -> (Vec<String>, Vec<String>) {
     let mut lines: Vec<String> = Vec::new();
-    json_to_list(e, Vec::new(), &json, &mut lines);
-    lines
+    let mut errors: Vec<String> = Vec::new();
+    match serde_json::from_str::<Value>(str) {
+        Ok(json) => {
+            json_to_list(e, Vec::new(), &json, &mut lines, &mut errors);
+        }
+        Err(err) => {
+            errors.push(format!("invalid document: {err}"));
+        }
+    }
+    (lines, errors)
 }
 
-pub fn json_to_list(entry: Rc<Entry>, p: Vec<String>, v: &Value, lines: &mut Vec<String>) {
+pub fn json_to_list(
+    entry: Rc<Entry>,
+    p: Vec<String>,
+    v: &Value,
+    lines: &mut Vec<String>,
+    errors: &mut Vec<String>,
+) {
     match v {
         Value::Null => {
             lines.push(format!("set {}", p.join(" ")));
@@ -26,7 +50,7 @@ pub fn json_to_list(entry: Rc<Entry>, p: Vec<String>, v: &Value, lines: &mut Vec
         Value::Array(vec) => {
             for v in vec.iter() {
                 let p = p.clone();
-                json_to_list(entry.clone(), p, v, lines);
+                json_to_list(entry.clone(), p, v, lines, errors);
             }
         }
         Value::Object(map) => {
@@ -36,6 +60,14 @@ pub fn json_to_list(entry: Rc<Entry>, p: Vec<String>, v: &Value, lines: &mut Vec
                     p.push(value_without_quotes(value));
                     lines.push(format!("set {}", p.join(" ")));
                 } else {
+                    // A list entry without its key field can't be
+                    // addressed at all — report it instead of silently
+                    // dropping the whole object.
+                    errors.push(format!(
+                        "{}: list entry is missing its key `{}`",
+                        display_path(&p, &entry.name),
+                        entry.key[0]
+                    ));
                     return;
                 }
             }
@@ -47,14 +79,31 @@ pub fn json_to_list(entry: Rc<Entry>, p: Vec<String>, v: &Value, lines: &mut Vec
                     Some(entry) => {
                         let mut p = p.clone();
                         p.push(key.clone());
-                        json_to_list(entry.clone(), p, value, lines);
+                        json_to_list(entry.clone(), p, value, lines, errors);
                     }
                     None => {
-                        return;
+                        // Unknown key: record it and KEEP walking the
+                        // remaining siblings — aborting here used to
+                        // drop everything after the first typo.
+                        errors.push(format!(
+                            "{}: unknown key `{}`",
+                            display_path(&p, &entry.name),
+                            key
+                        ));
                     }
                 }
             }
         }
+    }
+}
+
+/// Human-readable location for an error: the accumulated command path,
+/// or the schema node name when the error fires at the document root.
+fn display_path(p: &[String], entry_name: &str) -> String {
+    if p.is_empty() {
+        entry_name.to_string()
+    } else {
+        p.join(" ")
     }
 }
 
@@ -72,4 +121,80 @@ fn entry_dir(entry: Rc<Entry>, name: &String) -> Option<Rc<Entry>> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libyang::{YangStore, to_entry};
+
+    fn set_entry() -> Rc<Entry> {
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+        entry
+            .dir
+            .borrow()
+            .iter()
+            .find(|e| e.name == "set")
+            .cloned()
+            .expect("set subtree")
+    }
+
+    /// The nested `med: { eq: … }` shape (matching the YANG `choice`)
+    /// produces the expected flat command.
+    #[test]
+    fn med_nested_shape_emits_command() {
+        let doc = r#"{"policy":[{"name":"IN-MED","entry":[{"number":10,"action":"permit","match":{"med":{"eq":999}}}]}]}"#;
+        let (lines, errors) = json_read(set_entry(), doc);
+        assert!(errors.is_empty(), "errors: {errors:?}");
+        assert!(
+            lines
+                .iter()
+                .any(|l| l == "set policy IN-MED entry 10 match med eq 999"),
+            "lines: {lines:?}"
+        );
+    }
+
+    /// An unknown key is reported as an error AND does not abort the
+    /// remaining siblings: `action` (sorted after the bogus `a-bogus`
+    /// key) must still be emitted. This is the regression shape that
+    /// let the BDD's flat `med-eq:` spelling apply cleanly while
+    /// configuring nothing.
+    #[test]
+    fn unknown_key_is_reported_and_siblings_survive() {
+        let doc = r#"{"policy":[{"name":"IN-MED","entry":[{"number":10,"a-bogus":1,"action":"permit","match":{"med-eq":999}}]}]}"#;
+        let (lines, errors) = json_read(set_entry(), doc);
+        assert!(
+            errors.iter().any(|e| e.contains("unknown key `med-eq`")),
+            "errors: {errors:?}"
+        );
+        assert!(
+            errors.iter().any(|e| e.contains("unknown key `a-bogus`")),
+            "errors: {errors:?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|l| l == "set policy IN-MED entry 10 action permit"),
+            "siblings after the unknown key must still apply; lines: {lines:?}"
+        );
+    }
+
+    /// A list entry whose key field is absent is reported, not dropped.
+    #[test]
+    fn missing_list_key_is_reported() {
+        let doc = r#"{"policy":[{"entry":[{"number":10}]}]}"#;
+        let (_lines, errors) = json_read(set_entry(), doc);
+        assert!(
+            errors.iter().any(|e| e.contains("missing its key `name`")),
+            "errors: {errors:?}"
+        );
+    }
 }

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -821,20 +821,37 @@ impl ConfigManager {
                 let entry = entry.unwrap();
 
                 let format_type = config_format_type(&req.config);
-                let cmds = match format_type {
-                    ConfigFormat::Cli => load_config_file(req.config.clone()),
+                let (cmds, doc_errors) = match format_type {
+                    ConfigFormat::Cli => (load_config_file(req.config.clone()), Vec::new()),
                     ConfigFormat::Json => json_read(entry, req.config.as_str()),
                     ConfigFormat::Yaml => {
                         let config = yaml_parse(req.config.as_str());
                         json_read(entry, config.as_str())
                     }
-                    ConfigFormat::SetDelete => req
-                        .config
-                        .lines()
-                        .filter(|l| !l.trim().is_empty())
-                        .map(str::to_string)
-                        .collect(),
+                    ConfigFormat::SetDelete => (
+                        req.config
+                            .lines()
+                            .filter(|l| !l.trim().is_empty())
+                            .map(str::to_string)
+                            .collect(),
+                        Vec::new(),
+                    ),
                 };
+                // A document key that doesn't exist in the schema used
+                // to be dropped silently, applying a PARTIAL config
+                // with a clean "applied" reply (e.g. a misspelled
+                // policy match leaf that left the policy permit-all).
+                // Reject the document instead so the operator sees
+                // exactly which keys the schema refused.
+                if !doc_errors.is_empty() {
+                    let resp = DeployResponse {
+                        apply_code: ApplyCode::ParseError,
+                        exec_code: ExecCode::Nomatch,
+                        cmd: doc_errors.join("; "),
+                    };
+                    let _ = req.resp.send(resp);
+                    return;
+                }
 
                 if format_type != ConfigFormat::SetDelete {
                     self.store.candidate_clear();


### PR DESCRIPTION
## Summary

Closes the investigation of the suspected "soft-in replay divergence" from #1320. **Soft-in is exonerated** — the PolicyRx trigger, the commit diff, and the med matcher are all correct. The divergence was a phantom produced by three real defects, each fixed here:

1. **Silent partial apply** (`config/json.rs`): the JSON/YAML document walk `return`ed on the first unknown key, dropping that key *and every remaining sibling* — a single misspelled key produced a partial config with a clean `applied` reply. The walk now collects path-qualified errors, keeps applying siblings, and the Apply handler rejects the document: `error reply: policy IN-MED entry 10 match: unknown key \`med-eq\``. Missing list keys and unparseable documents are reported the same way (and the `from_str().unwrap()` is gone). Unit tests cover the regression shapes.

2. **bgp_route_map_match med configs were schema-less since birth**: they used flat `med-eq:`/`med-ge:`/`med-le:` keys, but the YANG models a one-of `med: { eq | le | ge }` choice — so all four med scenarios tested a permit-all policy, which is why the deny variants fail on pristine main. Configs now use the nested shape (range-pass exercises `le`, range-fail `ge`; a two-sided range isn't expressible on one entry). **The feature now passes 12/12 — its first genuine full pass.**

3. **`vtyctl apply -c <bare line>` replaced the entire config**: the server's format sniffer classified an unprefixed line as a YAML document → `candidate_clear()` → the commit diff deleted everything else. Bare `-c` lines are now prefixed with `set ` client-side so they always take the additive path. (This also invalidated several earlier investigation probes — the "evidence" for the soft-in theory was config-replacement artifacts.)

Also corrects the misdiagnosis trail from #1320/#1322: the feature header note, the BDD step doc comment, and the book's clear-command chapter no longer cite a soft-in bug.

## Testing

- New `json.rs` unit tests: nested med shape emits the right command; unknown keys are reported with paths while siblings survive; missing list keys are reported. 1492 workspace tests pass; clippy `-D warnings` clean.
- Live negative check: applying the old broken-shaped YAML now fails loudly with the exact unknown-key path.
- BDD (binary md5-guarded): `bgp_route_map_match` **12/12** (previously 3 failures on pristine main), `bgp_community` 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)