### PR TITLE
ospfv3: TI-LFA BDD + four SR/adjacency fixes the new feature exposed

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -138,6 +138,10 @@ ospfv3_nssa:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv3_nssa"
 
+ospfv3_tilfa:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv3_tilfa"
+
 bgp_evpn_capability:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_evpn_capability"
@@ -205,4 +209,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv3_nssa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community bgp_neighbor_group bgp_unnumbered_neighbor bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv3_nssa ospfv3_tilfa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community bgp_neighbor_group bgp_unnumbered_neighbor bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE

--- a/bdd/tests/configs/ospfv3_tilfa/d.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/d.yaml
@@ -1,0 +1,34 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::5/128
+- if-name: d-n3
+  ipv6:
+    address: 2001:db8:4::2/64
+- if-name: d-s
+  ipv6:
+    address: 2001:db8:5::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.5
+    segment-routing:
+      mpls: null
+    fast-reroute:
+      ti-lfa: null
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 500
+      - if-name: d-n3
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 54
+      - if-name: d-s
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 51

--- a/bdd/tests/configs/ospfv3_tilfa/n1.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/n1.yaml
@@ -1,0 +1,34 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: n1-s
+  ipv6:
+    address: 2001:db8:1::2/64
+- if-name: n1-n2
+  ipv6:
+    address: 2001:db8:2::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.2
+    segment-routing:
+      mpls: null
+    fast-reroute:
+      ti-lfa: null
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 200
+      - if-name: n1-s
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 21
+      - if-name: n1-n2
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 23

--- a/bdd/tests/configs/ospfv3_tilfa/n2.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/n2.yaml
@@ -1,0 +1,34 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::3/128
+- if-name: n2-n1
+  ipv6:
+    address: 2001:db8:2::2/64
+- if-name: n2-n3
+  ipv6:
+    address: 2001:db8:3::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.3
+    segment-routing:
+      mpls: null
+    fast-reroute:
+      ti-lfa: null
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 300
+      - if-name: n2-n1
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 32
+      - if-name: n2-n3
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 34

--- a/bdd/tests/configs/ospfv3_tilfa/n3.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/n3.yaml
@@ -1,0 +1,34 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::4/128
+- if-name: n3-n2
+  ipv6:
+    address: 2001:db8:3::2/64
+- if-name: n3-d
+  ipv6:
+    address: 2001:db8:4::1/64
+router:
+  ospfv3:
+    router-id: 10.0.0.4
+    segment-routing:
+      mpls: null
+    fast-reroute:
+      ti-lfa: null
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 400
+      - if-name: n3-n2
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 43
+      - if-name: n3-d
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 45

--- a/bdd/tests/configs/ospfv3_tilfa/s-nofrr.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/s-nofrr.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: s-n1
+  ipv6:
+    address: 2001:db8:1::1/64
+- if-name: s-d
+  ipv6:
+    address: 2001:db8:5::2/64
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    segment-routing:
+      mpls: null
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 100
+      - if-name: s-n1
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 12
+      - if-name: s-d
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 15

--- a/bdd/tests/configs/ospfv3_tilfa/s-nosr.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/s-nosr.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: s-n1
+  ipv6:
+    address: 2001:db8:1::1/64
+- if-name: s-d
+  ipv6:
+    address: 2001:db8:5::2/64
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    fast-reroute:
+      ti-lfa: null
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 100
+      - if-name: s-n1
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 12
+      - if-name: s-d
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 15

--- a/bdd/tests/configs/ospfv3_tilfa/s.yaml
+++ b/bdd/tests/configs/ospfv3_tilfa/s.yaml
@@ -1,0 +1,34 @@
+interface:
+- if-name: lo
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: s-n1
+  ipv6:
+    address: 2001:db8:1::1/64
+- if-name: s-d
+  ipv6:
+    address: 2001:db8:5::2/64
+router:
+  ospfv3:
+    router-id: 10.0.0.1
+    segment-routing:
+      mpls: null
+    fast-reroute:
+      ti-lfa: null
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 100
+      - if-name: s-n1
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 12
+      - if-name: s-d
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 15

--- a/bdd/tests/features/ospfv3_tilfa.feature
+++ b/bdd/tests/features/ospfv3_tilfa.feature
@@ -1,0 +1,157 @@
+@serial
+@ospfv3_tilfa
+Feature: OSPFv3 TI-LFA fast-reroute over SR-MPLS
+  As a network operator
+  I want five zebra-rs instances running OSPFv3 with SR-MPLS (RFC 8666)
+  and TI-LFA (RFC 9490) to pre-compute a topology-independent loop-free
+  repair for the source's primary path, so that when the primary link
+  fails the source still reaches the destination over the SR repair /
+  post-convergence path.
+
+  All links are point-to-point veth pairs at the default interface cost
+  (OSPFv3 has no per-interface cost knob yet, so the topology — not the
+  metrics — must rule a plain LFA out). Every router enables
+  `segment-routing mpls` and `fast-reroute ti-lfa`; loopback Prefix-SIDs
+  index 100..500 resolve against the RIB's default SRGB (base 16000), so
+  node s's SID is label 16100, d's is 16500, etc. Each ring interface
+  also carries a configured Adjacency-SID (index = <from><to> digit
+  pair) — the OSPFv3 repair encodes its last hop as an Adj-SID segment,
+  which only resolves when the penultimate repair node advertises one.
+
+  The topology is a uniform-cost five-node ring — the textbook
+  no-plain-LFA case: for any destination two hops away, the source's
+  alternate neighbour reaches it through the source itself, so the
+  pre-computed repair must tunnel (Node-SID + Adj-SID segments) to a
+  node beyond the failure before plain forwarding can resume. OSPFv3
+  TI-LFA excludes the primary first-hop *vertex* (node protection), so
+  repairs exist exactly for the non-adjacent destinations n2 and n3.
+
+  Test Topology (loopback 2001:db8::X / SID X00 / router-id 10.0.0.X):
+  ```
+        s (::1) ────────── d (::5)        s-d:   2001:db8:5::/64
+         │                  │             s-n1:  2001:db8:1::/64
+        n1 (::2)           n3 (::4)       n1-n2: 2001:db8:2::/64
+         │                  │             n2-n3: 2001:db8:3::/64
+        n2 (::3) ───────────┘             n3-d:  2001:db8:4::/64
+  ```
+  s reaches n3 (2001:db8::4) via s-d (cost 20); protecting that
+  first hop, the repair tunnels via n1 with [Node-SID(n2) 16300,
+  Adj-SID(n2->n3)] and is installed as the route's backup nexthop.
+
+  Scenario: Build the TI-LFA ring and confirm adjacencies + routes
+    Given a clean test environment
+    When I create namespace "s"
+    And I create namespace "n1"
+    And I create namespace "n2"
+    And I create namespace "n3"
+    And I create namespace "d"
+    And I connect namespace "s" interface "s-n1" to namespace "n1" interface "n1-s"
+    And I connect namespace "n1" interface "n1-n2" to namespace "n2" interface "n2-n1"
+    And I connect namespace "n2" interface "n2-n3" to namespace "n3" interface "n3-n2"
+    And I connect namespace "n3" interface "n3-d" to namespace "d" interface "d-n3"
+    And I connect namespace "d" interface "d-s" to namespace "s" interface "s-d"
+    And I start zebra-rs in namespace "s"
+    And I start zebra-rs in namespace "n1"
+    And I start zebra-rs in namespace "n2"
+    And I start zebra-rs in namespace "n3"
+    And I start zebra-rs in namespace "d"
+    And I apply config "s.yaml" to namespace "s"
+    And I apply config "n1.yaml" to namespace "n1"
+    And I apply config "n2.yaml" to namespace "n2"
+    And I apply config "n3.yaml" to namespace "n3"
+    And I apply config "d.yaml" to namespace "d"
+    And I wait 30 seconds
+    # Directly-connected adjacency over s-n1, then a multi-hop loopback
+    # (n2, two hops away) over the converged v3 RIB.
+    Then ping from "s" to "2001:db8:1::2" should succeed
+    And ping from "s" to "2001:db8::3" should succeed
+
+  Scenario: SR-MPLS labels and a TI-LFA repair are installed on the source
+    Given the test topology exists
+    # Remote node-SIDs resolved into the LFIB. OSPFv3 originates its
+    # Prefix-SIDs with the NP (no-PHP) flag (RFC 8666 §5), so even the
+    # SID owner's direct neighbour swaps (label kept all the way; the
+    # owner pops via its own ILM entry) — unlike IS-IS's PHP default.
+    Then mpls ilm in namespace "s" should contain label 16300
+    And mpls ilm in namespace "s" should contain label 16500
+    And mpls ilm outgoing label for label 16100 in namespace "s" should be "Pop"
+    And mpls ilm outgoing label for label 16300 in namespace "s" should be "16300"
+    And mpls ilm outgoing label for label 16500 in namespace "s" should be "16500"
+    # The graph-level TI-LFA computation found repairs that need an SR
+    # tunnel: a Node-SID to reach past the failure, then an Adj-SID for
+    # the final hop.
+    And show command "show ipv6 ospf ti-lfa" in namespace "s" should contain "OSPFv3 TI-LFA repair paths:"
+    And show command "show ipv6 ospf ti-lfa" in namespace "s" should contain "Node-SID"
+    And show command "show ipv6 ospf ti-lfa" in namespace "s" should contain "Adj-SID"
+    # And the repairs are installed against the non-adjacent loopbacks:
+    # n2's (protected against s-n1 loss) and n3's (protected against
+    # s-d loss, tunnelling via n1 with n2's node-SID label 16300).
+    And show command "show ipv6 ospf repair-list" in namespace "s" should contain "2001:db8::3/128"
+    And show command "show ipv6 ospf repair-list" in namespace "s" should contain "2001:db8::4/128"
+    And show command "show ipv6 ospf repair-list" in namespace "s" should contain "16300"
+    And show command "show ipv6 ospf repair-list detail" in namespace "s" should contain "sr-mpls"
+
+  Scenario: Source reaches the destination over the primary path
+    Given the test topology exists
+    # s -> d primary is the direct s-d link (one hop); s -> n3 rides
+    # the same link one hop further.
+    Then ping from "s" to "2001:db8::5" should succeed
+    And ping from "s" to "2001:db8::4" should succeed
+    And ping from "d" to "2001:db8::1" should succeed
+
+  Scenario: Fast-reroute survives the primary link failure (s-d)
+    Given the test topology exists
+    Then ping from "s" to "2001:db8::4" should succeed
+    When I make namespace "s" interface "s-d" down
+    And I wait 5 seconds
+    # n3's loopback was TI-LFA-protected (backup via n1 pre-installed);
+    # d's loopback is the failed first hop itself (no repair exists for
+    # an adjacent destination) and recovers via reconvergence. Both end
+    # up on the long way around (s-n1-n2-n3[-d]), out a different
+    # interface than the failed s-d.
+    Then ping from "s" to "2001:db8::4" should succeed
+    And ping from "s" to "2001:db8::5" should succeed
+    When I make namespace "s" interface "s-d" up
+    And I wait 30 seconds
+    # Primary restored once the adjacency re-forms.
+    Then ping from "s" to "2001:db8::5" should succeed
+
+  Scenario: Disabling fast-reroute clears the repair-list
+    Given the test topology exists
+    # s still holds TI-LFA backups from the previous scenarios.
+    Then show command "show ipv6 ospf repair-list" in namespace "s" should contain "16300"
+    # Re-apply s without `fast-reroute ti-lfa` (SR-MPLS stays on).
+    When I apply config "s-nofrr.yaml" to namespace "s"
+    And I wait 5 seconds
+    # The toggle re-runs SPF without the TI-LFA pass: no graph repairs,
+    # no installed backups — while the SR labels stay in the LFIB.
+    Then show command "show ipv6 ospf ti-lfa" in namespace "s" should contain "(no TI-LFA repair paths computed)"
+    And show command "show ipv6 ospf repair-list" in namespace "s" should contain "(no TI-LFA repair-list entries)"
+    And mpls ilm in namespace "s" should contain label 16300
+
+  Scenario: Deleting segment-routing mpls clears all MPLS ILM entries
+    Given the test topology exists
+    # s still has remote node-SID labels installed (n2 SID 300 -> 16300,
+    # d SID 500 -> 16500).
+    Then mpls ilm in namespace "s" should contain label 16300
+    And mpls ilm in namespace "s" should contain label 16500
+    # Remove `segment-routing mpls` from s entirely.
+    When I apply config "s-nosr.yaml" to namespace "s"
+    And I wait 5 seconds
+    # Disabling SR-MPLS must withdraw every MPLS ILM entry, leaving the
+    # LFIB completely empty.
+    Then mpls ilm in namespace "s" should be empty
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "s"
+    And I stop zebra-rs in namespace "n1"
+    And I stop zebra-rs in namespace "n2"
+    And I stop zebra-rs in namespace "n3"
+    And I stop zebra-rs in namespace "d"
+    And I delete namespace "s"
+    And I delete namespace "n1"
+    And I delete namespace "n2"
+    And I delete namespace "n3"
+    And I delete namespace "d"
+    Then the test environment should be clean

--- a/zebra-rs/src/ospf/config_v3.rs
+++ b/zebra-rs/src/ospf/config_v3.rs
@@ -855,8 +855,16 @@ fn config_ospfv3_sr_mpls(ospf: &mut Ospf<Ospfv3>, _args: Args, op: ConfigOp) -> 
     // peers can decode the Index-form SIDs we advertise into
     // absolute labels.
     let area_ids: Vec<std::net::Ipv4Addr> = ospf.areas.iter().map(|(id, _)| *id).collect();
+    for area_id in area_ids.iter() {
+        ospf.e_router_v3_sr_info_lsa_originate(*area_id);
+    }
+
+    // Rebuild every area's v6 RIB + ILM under the new mode — same
+    // pattern as the ti-lfa toggle below. `add_prefix_sids_v3` gates
+    // on the mode, so a disable drops every label imposition and
+    // empties the LFIB instead of waiting for an unrelated SPF.
     for area_id in area_ids {
-        ospf.e_router_v3_sr_info_lsa_originate(area_id);
+        let _ = ospf.tx.send(Message::SpfCalc(area_id));
     }
 
     Some(())

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -5199,6 +5199,17 @@ impl Ospf<Ospfv3> {
                 .tx
                 .send(Message::Ifsm(addr.ifindex, IfsmEvent::InterfaceUp));
         }
+
+        // The Prefix-SID's E-Intra-Area-Prefix-LSA advertises this
+        // link's first routable global as a /128 host prefix. The
+        // config handler originates it at commit time, but the
+        // kernel's AddrAdd for an address configured in the same
+        // commit can land *after* that — origination then finds no
+        // usable address and stays flushed forever. Re-originate
+        // here so the LSA appears as soon as the address does (the
+        // builder gates on SR mode + a configured prefix-sid, so
+        // this is a no-op on links without one).
+        self.ext_intra_area_prefix_v3_lsa_originate(addr.ifindex);
     }
 
     /// Apply a Router-ID to this OSPFv3 instance. Mirror of the v2
@@ -5245,6 +5256,11 @@ impl Ospf<Ospfv3> {
 
         let (next, next_id) = super::config::link_should_enable(link);
         super::config::apply_link_enable_transition(link, next, next_id);
+
+        // Mirror of the `addr_add` re-origination: the advertised
+        // host prefix may have just gone away (the builder flushes)
+        // or a different remaining address now wins.
+        self.ext_intra_area_prefix_v3_lsa_originate(addr.ifindex);
     }
 
     /// Look up the v3 show-path handler for `msg.paths` and invoke
@@ -6469,6 +6485,55 @@ impl Ospf<Ospfv3> {
         ));
     }
 
+    /// v3 sibling of v2's `process_dd_retransmit` (RFC 2328 §10.8,
+    /// inherited by RFC 5340 §4.2.2): the master resends the DBD in
+    /// `nbr.dd.sent` while still in ExStart / Exchange. Without this
+    /// a single lost or crossed negotiation DBD wedges both ends in
+    /// ExStart forever — the NFSM only sends one DBD per state entry,
+    /// and the slave only echoes on duplicate receipt, so nobody ever
+    /// transmits again (the `Message::DdRetransmit` the timer fires
+    /// used to fall through v3's unhandled-variant arm).
+    fn process_dd_retransmit(&mut self, ifindex: u32, router_id: Ipv4Addr) {
+        let Some((oi, nbr)) = self.ospf_interface(ifindex, &router_id) else {
+            return;
+        };
+        if (nbr.state != NfsmState::ExStart && nbr.state != NfsmState::Exchange)
+            || !nbr.dd.flags.master()
+        {
+            nbr.timer.db_desc = None;
+            return;
+        }
+        tracing::info!(
+            "[v3 DBD:Retransmit] to {} seq={:#x}",
+            router_id,
+            nbr.dd.seqnum
+        );
+        super::packet_v3::ospfv3_db_desc_resend(&oi, nbr);
+    }
+
+    /// v3 sibling of v2's `process_ls_req_retransmit` (RFC 2328
+    /// §10.9): resend the pending LS Request while the neighbor sits
+    /// in Exchange / Loading. Same missing-arm story as
+    /// `process_dd_retransmit` — a lost LS Request (or its LS Update
+    /// reply) used to park the neighbor in Loading forever.
+    fn process_ls_req_retransmit(&mut self, ifindex: u32, router_id: Ipv4Addr) {
+        let Some((mut oi, nbr)) = self.ospf_interface(ifindex, &router_id) else {
+            return;
+        };
+        if nbr.state < NfsmState::Exchange || nbr.state >= NfsmState::Full || nbr.ls_req.is_empty()
+        {
+            nbr.timer.ls_req = None;
+            return;
+        }
+        let ident = *oi.ident;
+        tracing::info!(
+            "[v3 LSReq:Retransmit] to {} entries={}",
+            router_id,
+            nbr.ls_req.len()
+        );
+        super::packet_v3::ospfv3_ls_req_send(&mut oi, nbr, &ident);
+    }
+
     /// Dispatch one v3 instance-level message.
     ///
     /// Subset of v2's `process_msg` covering the IFSM-driver scope:
@@ -6705,6 +6770,12 @@ impl Ospf<Ospfv3> {
             }
             Message::Retransmit(ifindex, router_id) => {
                 self.process_retransmit(ifindex, router_id);
+            }
+            Message::DdRetransmit(ifindex, router_id) => {
+                self.process_dd_retransmit(ifindex, router_id);
+            }
+            Message::LsReqRetransmit(ifindex, router_id) => {
+                self.process_ls_req_retransmit(ifindex, router_id);
             }
             Message::Lsdb(ev, area_id, key) => {
                 ospf_event_trace!(
@@ -7069,11 +7140,18 @@ impl Ospf<Ospfv3> {
             && let Some(link) = self.links.get(&ifindex)
             && link.enabled
             && (link.config.prefix_sid.is_some() || !link.config.flex_algo_prefix_sids.is_empty())
-            && let Some(addr) = link
-                .addr
-                .iter()
-                .find(|a| a.prefix.addr().segments()[0] != 0xfe80)
-        {
+            && let Some(addr) = link.addr.iter().find(|a| {
+                // The SID's host prefix must be a routable global —
+                // skip fe80 (advertised via Link-LSAs) and ::1: the
+                // kernel auto-assigns ::1/128 to `lo` ahead of any
+                // configured loopback address, and a `find` keyed
+                // only on !fe80 made every router advertise its
+                // Prefix-SID for ::1/128. Receivers then stamped all
+                // remote SIDs onto their own ::1/128 route (last
+                // writer wins) instead of the advertised loopbacks.
+                let a = a.prefix.addr();
+                a.segments()[0] != 0xfe80 && !a.is_loopback() && !a.is_unspecified()
+            }) {
             let host = Ipv6Net::new(addr.prefix.addr(), 128).unwrap_or(addr.prefix);
             // Loopback parity with v2 / FRR / Junos: stamp 0 instead
             // of the link's output_cost so a /128 on `lo` doesn't add
@@ -10571,6 +10649,16 @@ fn add_prefix_sids_v3(
     };
 
     use crate::ospf::lsdb::OSPF_MAX_AGE;
+
+    // SR-MPLS participation is a local choice: with `segment-routing
+    // mpls` removed, no label may be imposed and no ILM derived, even
+    // though peers' E-LSAs stay in the LSDB. Without this gate a
+    // disable kept every remote node-SID swap entry in the LFIB
+    // (`build_ilm_from_rib6` reads `route.sid` stamped here) — only
+    // the self pop entries went away with the flushed self E-LSAs.
+    if top.segment_routing != super::srmpls::SegmentRoutingMode::Mpls {
+        return;
+    }
 
     let Some(area) = top.areas.get(area_id) else {
         return;

--- a/zebra-rs/src/ospf/nfsm.rs
+++ b/zebra-rs/src/ospf/nfsm.rs
@@ -407,7 +407,9 @@ pub fn ospfv3_populate_initial_db_summary(
     nbr: &mut Neighbor<Ospfv3>,
 ) {
     use ospf_packet::{
-        OSPFV3_AS_EXTERNAL_LSA_TYPE, OSPFV3_INTER_AREA_PREFIX_LSA_TYPE,
+        OSPFV3_AS_EXTERNAL_LSA_TYPE, OSPFV3_E_INTER_AREA_PREFIX_LSA_TYPE,
+        OSPFV3_E_INTER_AREA_ROUTER_LSA_TYPE, OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE,
+        OSPFV3_E_NETWORK_LSA_TYPE, OSPFV3_E_ROUTER_LSA_TYPE, OSPFV3_INTER_AREA_PREFIX_LSA_TYPE,
         OSPFV3_INTER_AREA_ROUTER_LSA_TYPE, OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE,
         OSPFV3_NETWORK_LSA_TYPE, OSPFV3_NSSA_LSA_TYPE, OSPFV3_ROUTER_LSA_TYPE,
     };
@@ -418,6 +420,19 @@ pub fn ospfv3_populate_initial_db_summary(
         OSPFV3_INTER_AREA_PREFIX_LSA_TYPE,
         OSPFV3_INTER_AREA_ROUTER_LSA_TYPE,
         OSPFV3_INTRA_AREA_PREFIX_LSA_TYPE,
+        // RFC 8362 E-LSAs share the area flooding scope (S=01) and are
+        // first-class LSDB members, so they belong in the initial DBD
+        // summary like any other area-scope type. Omitting them meant a
+        // neighbor that adjacencied AFTER our E-LSAs were originated
+        // (e.g. SR-MPLS configured before the link came up) never
+        // learned the E-Router-LSA / E-Intra-Area-Prefix-LSA carrying
+        // the RFC 8666 SR SIDs — remote Prefix-SIDs silently failed to
+        // resolve even though live flooding of the same LSAs worked.
+        OSPFV3_E_ROUTER_LSA_TYPE,
+        OSPFV3_E_NETWORK_LSA_TYPE,
+        OSPFV3_E_INTER_AREA_PREFIX_LSA_TYPE,
+        OSPFV3_E_INTER_AREA_ROUTER_LSA_TYPE,
+        OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE,
     ] {
         ospf_db_summary_add_table(nbr, oi.lsdb.iter_by_raw_type(ls_type).map(|(_, lsa)| lsa));
     }

--- a/zebra-rs/src/ospf/packet_v3.rs
+++ b/zebra-rs/src/ospf/packet_v3.rs
@@ -611,8 +611,9 @@ fn ospfv3_is_dd_dup(dd: &Ospfv3DbDesc, prev: &Ospfv3DbDesc) -> bool {
 
 /// Resend the DBD stored in `nbr.dd.sent`. Used by the slave on
 /// duplicate-DBD receipt (RFC 5340 §4.2.2 inheriting v2 §10.6) and
-/// by the master retransmit timer.
-fn ospfv3_db_desc_resend(oi: &OspfInterface<Ospfv3>, nbr: &Neighbor<Ospfv3>) {
+/// by the master retransmit timer (`process_dd_retransmit` in
+/// `inst.rs`, hence `pub(super)`).
+pub(super) fn ospfv3_db_desc_resend(oi: &OspfInterface<Ospfv3>, nbr: &Neighbor<Ospfv3>) {
     let Some(ref sent) = nbr.dd.sent else {
         return;
     };

--- a/zebra-rs/src/ospf/srmpls.rs
+++ b/zebra-rs/src/ospf/srmpls.rs
@@ -455,6 +455,55 @@ pub fn ext_intra_area_prefix_v3_lsa_build(
 mod tests {
     use super::*;
 
+    /// Wire roundtrip of the RFC 8666 §5 E-Intra-Area-Prefix-LSA: the
+    /// receiver must reconstruct the exact prefix bytes the originator
+    /// advertised. Guards the BDD-found bug where every received
+    /// Prefix-SID stamped onto a mangled prefix instead of the
+    /// advertised loopback.
+    #[test]
+    fn ext_intra_area_prefix_v3_lsa_roundtrip() {
+        use bytes::BytesMut;
+        use packet_utils::ParseBe;
+        use std::net::Ipv6Addr;
+
+        let prefix: Ipv6Net = "2001:db8::5/128".parse().unwrap();
+        let sid = PrefixSid::Index(500);
+        let lsa = ext_intra_area_prefix_v3_lsa_build(
+            Ipv4Addr::new(10, 0, 0, 5),
+            prefix,
+            Some(&sid),
+            &BTreeMap::new(),
+            1,
+            0,
+        );
+
+        let mut buf = BytesMut::new();
+        lsa.emit(&mut buf);
+        let (_, parsed) = Ospfv3Lsa::parse_be(&buf).expect("LSA must parse");
+
+        assert_eq!(parsed.h.ls_type, OSPFV3_E_INTRA_AREA_PREFIX_LSA_TYPE);
+        let Ospfv3LsBody::EIntraAreaPrefix(ref body) = parsed.body else {
+            panic!("expected EIntraAreaPrefix body, got {:?}", parsed.body);
+        };
+        let Ospfv3ExtTlv::IntraAreaPrefix(ref tlv) = body.tlvs[0] else {
+            panic!("expected IntraAreaPrefix TLV, got {:?}", body.tlvs[0]);
+        };
+        assert_eq!(tlv.prefix_length, 128);
+        let mut bytes = [0u8; 16];
+        bytes.copy_from_slice(&tlv.address_prefix[..16]);
+        assert_eq!(
+            Ipv6Addr::from(bytes),
+            "2001:db8::5".parse::<Ipv6Addr>().unwrap(),
+            "address_prefix must survive the wire roundtrip"
+        );
+        assert!(
+            tlv.subs.iter().any(
+                |s| matches!(s, Ospfv3SubTlv::PrefixSid(p) if p.sid == SidLabelTlv::Index(500))
+            ),
+            "Prefix-SID sub-TLV must survive the wire roundtrip"
+        );
+    }
+
     fn extract_caps(lsa: &OspfLsa) -> RouterCapability {
         let OspfLsp::OpaqueAreaRouterInfo(ref ri) = lsa.lsp else {
             panic!("expected OpaqueAreaRouterInfo, got {:?}", lsa.lsp);


### PR DESCRIPTION
## Summary

Adds the first OSPF TI-LFA BDD — `@ospfv3_tilfa` — modeled on `isis_tilfa.feature`, plus four OSPFv3 daemon fixes the new feature surfaced. All four were invisible to unit tests and to single-router validation; each one blocks SR-MPLS / TI-LFA from working across a real multi-router topology.

### The feature

Five zebra-rs routers in a **uniform-cost ring** (s—n1—n2—n3—d—s). OSPFv3 has no per-interface cost knob, so unlike the IS-IS test the topology itself rules a plain LFA out: for any 2-hops-away destination, the alternate neighbour's shortest path crosses the protected link, so the pre-computed repair must tunnel ([Node-SID, Adj-SID] stack) past the failure. Every router runs `segment-routing mpls` + `fast-reroute ti-lfa` with loopback Prefix-SIDs 100..500 and per-link Adjacency-SIDs.

Scenarios: bring-up + routes, label install (v3's NP/no-PHP semantics: remote node-SIDs swap, owner pops), `show ipv6 ospf ti-lfa` / `repair-list` views, ping across an s-d link failure (n3 is TI-LFA-protected, d recovers via reconvergence — v3 TI-LFA excludes the first-hop *vertex*, so adjacent destinations have no repair), `fast-reroute` disable clears the repair-list, `segment-routing` disable empties the LFIB, teardown.

### Fixes

1. **nfsm: E-LSAs missing from the initial DBD summary.** `ospfv3_populate_initial_db_summary` listed only classic LSA types, so a neighbor that adjacencied *after* SR config never learned remote SIDs via database sync (live flooding masked this when adjacency formed first — likely how PR #1111's validation passed).

2. **inst: `Message::DdRetransmit` / `Message::LsReqRetransmit` unhandled on v3.** Both fell into the v3 message loop's catch-all, so the master's negotiation DBD and the LS Request were sent exactly once. One lost/crossed packet wedged the adjacency in ExStart forever — observed live as a silent link with Hellos only, both ends stuck. Added the v3 siblings of the v2 handlers.

3. **inst: Prefix-SID advertised for `::1/128`.** The host-prefix pick only excluded fe80, so the kernel's `::1/128` on `lo` won and *every* router advertised its node SID for `::1/128`; receivers stamped all remote SIDs onto their own `::1/128` route (last writer wins → one broken via-`lo` ILM entry, all real labels missing). Now skips loopback/unspecified, and `addr_add`/`addr_del` re-originate the E-Intra-Area-Prefix-LSA — the configured loopback address can land after the config commit processed (AddrAdd race), which previously left the LSA flushed forever on whichever routers lost the race.

4. **inst/config_v3: SR disable kept remote labels.** Deleting `segment-routing mpls` flushed self E-LSAs but left every remote node-SID swap entry in the LFIB. `add_prefix_sids_v3` now gates on the local SR mode and the toggle kicks per-area SPF, so a disable empties the ILM deterministically (IS-IS-parity behavior).

`srmpls.rs` gains an emit→parse roundtrip test for the E-Intra-Area-Prefix LSA pinning the codec layer of (3).

### Notes / deferred

- The legacy Intra-Area-Prefix-LSA (and Link-LSA) still advertise `::1/128` from `lo`; masked there (self route at metric 0 wins) — candidate cleanup, kept out of scope.
- A transient netlink EINVAL retry (~5s, self-healing) installs the failed link's own /64 with an empty nexthop during the down-transition window; pre-existing, does not affect the test.
- OSPFv2 `add_prefix_sids` has the same missing SR-mode gate as (4); no v2 BDD pins it yet, left for a follow-up.

## Test plan

- `@ospfv3_tilfa` BDD: **7/7 scenarios, 75/75 steps green** (binary md5-verified before/after the run).
- `cargo test --workspace --exclude bdd`: all green (992 zebra-rs unit tests + crates).
- `cargo clippy --workspace --all-targets -- -D warnings`: clean; `cargo fmt --all` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)