### PR TITLE
ospfv2: TI-LFA BDD + port the v3 SR fixes (disable gate, AddrAdd race)

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -138,6 +138,10 @@ ospfv3_nssa:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv3_nssa"
 
+ospfv2_tilfa:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv2_tilfa"
+
 ospfv3_tilfa:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv3_tilfa"
@@ -209,4 +213,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv3_nssa ospfv3_tilfa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community bgp_neighbor_group bgp_unnumbered_neighbor bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community bgp_neighbor_group bgp_unnumbered_neighbor bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE

--- a/bdd/tests/configs/ospfv2_tilfa/d.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/d.yaml
@@ -1,0 +1,34 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.5/32
+- if-name: d-n3
+  ipv4:
+    address: 192.168.4.2/30
+- if-name: d-s
+  ipv4:
+    address: 192.168.5.1/30
+router:
+  ospf:
+    router-id: 10.0.0.5
+    segment-routing:
+      mpls: null
+    fast-reroute:
+      ti-lfa: null
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 500
+      - if-name: d-n3
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 54
+      - if-name: d-s
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 51

--- a/bdd/tests/configs/ospfv2_tilfa/n1.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/n1.yaml
@@ -1,0 +1,34 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+- if-name: n1-s
+  ipv4:
+    address: 192.168.1.2/30
+- if-name: n1-n2
+  ipv4:
+    address: 192.168.2.1/30
+router:
+  ospf:
+    router-id: 10.0.0.2
+    segment-routing:
+      mpls: null
+    fast-reroute:
+      ti-lfa: null
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 200
+      - if-name: n1-s
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 21
+      - if-name: n1-n2
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 23

--- a/bdd/tests/configs/ospfv2_tilfa/n2.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/n2.yaml
@@ -1,0 +1,34 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.3/32
+- if-name: n2-n1
+  ipv4:
+    address: 192.168.2.2/30
+- if-name: n2-n3
+  ipv4:
+    address: 192.168.3.1/30
+router:
+  ospf:
+    router-id: 10.0.0.3
+    segment-routing:
+      mpls: null
+    fast-reroute:
+      ti-lfa: null
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 300
+      - if-name: n2-n1
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 32
+      - if-name: n2-n3
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 34

--- a/bdd/tests/configs/ospfv2_tilfa/n3.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/n3.yaml
@@ -1,0 +1,34 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.4/32
+- if-name: n3-n2
+  ipv4:
+    address: 192.168.3.2/30
+- if-name: n3-d
+  ipv4:
+    address: 192.168.4.1/30
+router:
+  ospf:
+    router-id: 10.0.0.4
+    segment-routing:
+      mpls: null
+    fast-reroute:
+      ti-lfa: null
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 400
+      - if-name: n3-n2
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 43
+      - if-name: n3-d
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 45

--- a/bdd/tests/configs/ospfv2_tilfa/s-nofrr.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/s-nofrr.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: s-n1
+  ipv4:
+    address: 192.168.1.1/30
+- if-name: s-d
+  ipv4:
+    address: 192.168.5.2/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    segment-routing:
+      mpls: null
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 100
+      - if-name: s-n1
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 12
+      - if-name: s-d
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 15

--- a/bdd/tests/configs/ospfv2_tilfa/s-nosr.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/s-nosr.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: s-n1
+  ipv4:
+    address: 192.168.1.1/30
+- if-name: s-d
+  ipv4:
+    address: 192.168.5.2/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    fast-reroute:
+      ti-lfa: null
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 100
+      - if-name: s-n1
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 12
+      - if-name: s-d
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 15

--- a/bdd/tests/configs/ospfv2_tilfa/s.yaml
+++ b/bdd/tests/configs/ospfv2_tilfa/s.yaml
@@ -1,0 +1,34 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+- if-name: s-n1
+  ipv4:
+    address: 192.168.1.1/30
+- if-name: s-d
+  ipv4:
+    address: 192.168.5.2/30
+router:
+  ospf:
+    router-id: 10.0.0.1
+    segment-routing:
+      mpls: null
+    fast-reroute:
+      ti-lfa: null
+    area:
+    - area-id: 0.0.0.0
+      interface:
+      - if-name: lo
+        enable: true
+        prefix-sid:
+          index: 100
+      - if-name: s-n1
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 12
+      - if-name: s-d
+        enable: true
+        network-type: point-to-point
+        adjacency-sid:
+          index: 15

--- a/bdd/tests/features/ospfv2_tilfa.feature
+++ b/bdd/tests/features/ospfv2_tilfa.feature
@@ -1,0 +1,155 @@
+@serial
+@ospfv2_tilfa
+Feature: OSPFv2 TI-LFA fast-reroute over SR-MPLS
+  As a network operator
+  I want five zebra-rs instances running OSPFv2 with SR-MPLS (RFC 8665)
+  and TI-LFA (RFC 9490) to pre-compute a topology-independent loop-free
+  repair for the source's primary path, so that when the primary link
+  fails the source still reaches the destination over the SR repair /
+  post-convergence path.
+
+  IPv4 sibling of `ospfv3_tilfa.feature` — same five-node ring, same
+  SID plan, the v2 SR machinery (Extended-Prefix / Extended-Link
+  Opaque LSAs instead of RFC 8362 E-LSAs). All links run at the
+  default interface cost so the ring topology — not metrics — rules a
+  plain LFA out. Every router enables `segment-routing mpls` and
+  `fast-reroute ti-lfa`; loopback Prefix-SIDs index 100..500 resolve
+  against the default SRGB (base 16000), and each ring interface
+  carries an Adjacency-SID (index = <from><to> digit pair) — the
+  repair encodes its last hop as an Adj-SID segment, which only
+  resolves when the penultimate repair node advertises one.
+
+  OSPFv2 TI-LFA excludes the primary first-hop *vertex* (node
+  protection), so repairs exist exactly for the non-adjacent
+  destinations n2 and n3.
+
+  Test Topology (loopback 10.0.0.X / SID X00 / router-id 10.0.0.X):
+  ```
+        s (.1) ────────── d (.5)         s-d:   192.168.5.0/30
+         │                 │             s-n1:  192.168.1.0/30
+        n1 (.2)           n3 (.4)        n1-n2: 192.168.2.0/30
+         │                 │             n2-n3: 192.168.3.0/30
+        n2 (.3) ───────────┘             n3-d:  192.168.4.0/30
+  ```
+  s reaches n3 (10.0.0.4) via s-d (cost 20); protecting that first
+  hop, the repair tunnels via n1 with [Node-SID(n2) 16300,
+  Adj-SID(n2->n3)] and is installed as the route's backup nexthop.
+
+  Scenario: Build the TI-LFA ring and confirm adjacencies + routes
+    Given a clean test environment
+    When I create namespace "s"
+    And I create namespace "n1"
+    And I create namespace "n2"
+    And I create namespace "n3"
+    And I create namespace "d"
+    And I connect namespace "s" interface "s-n1" to namespace "n1" interface "n1-s"
+    And I connect namespace "n1" interface "n1-n2" to namespace "n2" interface "n2-n1"
+    And I connect namespace "n2" interface "n2-n3" to namespace "n3" interface "n3-n2"
+    And I connect namespace "n3" interface "n3-d" to namespace "d" interface "d-n3"
+    And I connect namespace "d" interface "d-s" to namespace "s" interface "s-d"
+    And I start zebra-rs in namespace "s"
+    And I start zebra-rs in namespace "n1"
+    And I start zebra-rs in namespace "n2"
+    And I start zebra-rs in namespace "n3"
+    And I start zebra-rs in namespace "d"
+    And I apply config "s.yaml" to namespace "s"
+    And I apply config "n1.yaml" to namespace "n1"
+    And I apply config "n2.yaml" to namespace "n2"
+    And I apply config "n3.yaml" to namespace "n3"
+    And I apply config "d.yaml" to namespace "d"
+    And I wait 30 seconds
+    # Directly-connected adjacency over s-n1, then a multi-hop loopback
+    # (n2, two hops away) over the converged RIB.
+    Then ping from "s" to "192.168.1.2" should succeed
+    And ping from "s" to "10.0.0.3" should succeed
+
+  Scenario: SR-MPLS labels and a TI-LFA repair are installed on the source
+    Given the test topology exists
+    # Remote node-SIDs resolved into the LFIB. Multi-hop destinations
+    # swap (label kept toward the owner); a directly-adjacent owner's
+    # SID renders as an implicit-null Pop — v2 marks adjacency
+    # nexthops and applies the PHP optimisation there (unlike v3,
+    # which pushes the explicit label all the way per its NP flag).
+    Then mpls ilm in namespace "s" should contain label 16300
+    And mpls ilm in namespace "s" should contain label 16500
+    And mpls ilm outgoing label for label 16100 in namespace "s" should be "Pop"
+    And mpls ilm outgoing label for label 16300 in namespace "s" should be "16300"
+    And mpls ilm outgoing label for label 16500 in namespace "s" should be "Pop"
+    # The graph-level TI-LFA computation found repairs that need an SR
+    # tunnel: a Node-SID to reach past the failure, then an Adj-SID for
+    # the final hop.
+    And show command "show ip ospf ti-lfa" in namespace "s" should contain "OSPF TI-LFA repair paths:"
+    And show command "show ip ospf ti-lfa" in namespace "s" should contain "Node-SID"
+    And show command "show ip ospf ti-lfa" in namespace "s" should contain "Adj-SID"
+    # And the repairs are installed against the non-adjacent loopbacks:
+    # n2's (protected against s-n1 loss) and n3's (protected against
+    # s-d loss, tunnelling via n1 with n2's node-SID label 16300).
+    And show command "show ip ospf repair-list" in namespace "s" should contain "10.0.0.3/32"
+    And show command "show ip ospf repair-list" in namespace "s" should contain "10.0.0.4/32"
+    And show command "show ip ospf repair-list" in namespace "s" should contain "16300"
+    And show command "show ip ospf repair-list detail" in namespace "s" should contain "sr-mpls"
+
+  Scenario: Source reaches the destination over the primary path
+    Given the test topology exists
+    # s -> d primary is the direct s-d link (one hop); s -> n3 rides
+    # the same link one hop further.
+    Then ping from "s" to "10.0.0.5" should succeed
+    And ping from "s" to "10.0.0.4" should succeed
+    And ping from "d" to "10.0.0.1" should succeed
+
+  Scenario: Fast-reroute survives the primary link failure (s-d)
+    Given the test topology exists
+    Then ping from "s" to "10.0.0.4" should succeed
+    When I make namespace "s" interface "s-d" down
+    And I wait 5 seconds
+    # n3's loopback was TI-LFA-protected (backup via n1 pre-installed);
+    # d's loopback is the failed first hop itself (no repair exists for
+    # an adjacent destination) and recovers via reconvergence. Both end
+    # up on the long way around (s-n1-n2-n3[-d]), out a different
+    # interface than the failed s-d.
+    Then ping from "s" to "10.0.0.4" should succeed
+    And ping from "s" to "10.0.0.5" should succeed
+    When I make namespace "s" interface "s-d" up
+    And I wait 30 seconds
+    # Primary restored once the adjacency re-forms.
+    Then ping from "s" to "10.0.0.5" should succeed
+
+  Scenario: Disabling fast-reroute clears the repair-list
+    Given the test topology exists
+    # s still holds TI-LFA backups from the previous scenarios.
+    Then show command "show ip ospf repair-list" in namespace "s" should contain "16300"
+    # Re-apply s without `fast-reroute ti-lfa` (SR-MPLS stays on).
+    When I apply config "s-nofrr.yaml" to namespace "s"
+    And I wait 5 seconds
+    # The toggle re-runs SPF without the TI-LFA pass: no graph repairs,
+    # no installed backups — while the SR labels stay in the LFIB.
+    Then show command "show ip ospf ti-lfa" in namespace "s" should contain "(no TI-LFA repair paths computed)"
+    And show command "show ip ospf repair-list" in namespace "s" should contain "(no TI-LFA repair-list entries)"
+    And mpls ilm in namespace "s" should contain label 16300
+
+  Scenario: Deleting segment-routing mpls clears all MPLS ILM entries
+    Given the test topology exists
+    # s still has remote node-SID labels installed (n2 SID 300 -> 16300,
+    # d SID 500 -> 16500).
+    Then mpls ilm in namespace "s" should contain label 16300
+    And mpls ilm in namespace "s" should contain label 16500
+    # Remove `segment-routing mpls` from s entirely.
+    When I apply config "s-nosr.yaml" to namespace "s"
+    And I wait 5 seconds
+    # Disabling SR-MPLS must withdraw every MPLS ILM entry, leaving the
+    # LFIB completely empty.
+    Then mpls ilm in namespace "s" should be empty
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "s"
+    And I stop zebra-rs in namespace "n1"
+    And I stop zebra-rs in namespace "n2"
+    And I stop zebra-rs in namespace "n3"
+    And I stop zebra-rs in namespace "d"
+    And I delete namespace "s"
+    And I delete namespace "n1"
+    And I delete namespace "n2"
+    And I delete namespace "n3"
+    And I delete namespace "d"
+    Then the test environment should be clean

--- a/zebra-rs/src/ospf/config.rs
+++ b/zebra-rs/src/ospf/config.rs
@@ -1474,6 +1474,15 @@ fn config_ospf_sr_mpls(ospf: &mut Ospf, _args: Args, op: ConfigOp) -> Option<()>
         ospf.ext_link_lsa_originate(ifindex);
     }
 
+    // Rebuild every area's RIB + ILM under the new mode — same
+    // pattern as the v3 toggle. `add_prefix_sids` gates on the mode,
+    // so a disable drops every label imposition and empties the LFIB
+    // instead of waiting for an unrelated SPF.
+    let area_ids: Vec<std::net::Ipv4Addr> = ospf.areas.iter().map(|(id, _)| *id).collect();
+    for area_id in area_ids {
+        let _ = ospf.tx.send(Message::SpfCalc(area_id));
+    }
+
     Some(())
 }
 

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -4363,6 +4363,17 @@ impl Ospf<Ospfv2> {
                 .tx
                 .send(Message::Ifsm(addr.ifindex, IfsmEvent::InterfaceUp));
         }
+
+        // The Prefix-SID's Extended-Prefix LSA advertises this link's
+        // first non-loopback address as a /32 host prefix. The config
+        // handler originates it at commit time, but the kernel's
+        // AddrAdd for an address configured in the same commit can
+        // land *after* that — origination then finds no usable
+        // address and bails without retry. Re-originate here so the
+        // LSA appears as soon as the address does (no-op on links
+        // without SR + a configured prefix-sid). Mirrors the v3
+        // `addr_add` fix.
+        self.ext_prefix_lsa_originate(addr.ifindex);
     }
 
     fn addr_del(&mut self, addr: LinkAddr) {
@@ -4377,6 +4388,11 @@ impl Ospf<Ospfv2> {
         // Re-evaluate enable state after address removal.
         let (next, next_id) = super::config::link_should_enable(link);
         super::config::apply_link_enable_transition(link, next, next_id);
+
+        // Mirror of the `addr_add` re-origination: the advertised
+        // host prefix may have just gone away or a different
+        // remaining address now wins.
+        self.ext_prefix_lsa_originate(addr.ifindex);
     }
 
     async fn process_recv(
@@ -9146,6 +9162,16 @@ fn build_rib_from_spf(
 /// here, and `SpfRoute.metric` / `SpfRoute.nhops` are left untouched.
 fn add_prefix_sids(top: &Ospf, area_id: Ipv4Addr, rib: &mut PrefixMap<Ipv4Net, SpfRoute>) {
     use crate::ospf::lsdb::OSPF_MAX_AGE;
+
+    // SR-MPLS participation is a local choice: with `segment-routing
+    // mpls` removed, no label may be imposed and no ILM derived, even
+    // though peers' Ext-Prefix LSAs stay in the LSDB. Same gate as
+    // `add_prefix_sids_v3` — without it a disable kept every remote
+    // node-SID swap entry in the LFIB while only the self pop entries
+    // went away with the flushed self LSAs.
+    if top.segment_routing != super::srmpls::SegmentRoutingMode::Mpls {
+        return;
+    }
 
     let Some(area) = top.areas.get(area_id) else {
         return;


### PR DESCRIPTION
## Summary

Adds `@ospfv2_tilfa` — the IPv4 sibling of `@ospfv3_tilfa` (PR #1326) — and ports the two OSPFv2 gaps that PR deferred. Both gaps reproduced on the new feature's very first run, confirming the deferral notes.

### The feature

Same five-router uniform-cost ring as the v3 test, with IPv4 addressing (loopbacks `10.0.0.X/32`, `/30` links), riding the v2 SR machinery: RFC 7684/8665 Extended-Prefix / Extended-Link Opaque LSAs instead of RFC 8362 E-LSAs. Loopback Prefix-SIDs 100..500, per-link Adjacency-SIDs (repairs encode their last hop as an Adj-SID segment). Scenarios mirror the v3 feature one-for-one: bring-up + routes, label install, `show ip ospf ti-lfa` / `repair-list` views, ping across an s-d link failure (n3 TI-LFA-protected, d via reconvergence), fast-reroute disable clears the repair-list, segment-routing disable empties the LFIB, teardown.

### Ported fixes

1. **`add_prefix_sids` SR-mode gate + SPF kick on toggle** (inst.rs / config.rs): deleting `segment-routing mpls` flushed self LSAs but kept every remote node-SID swap entry in the LFIB — the exact failure the first run produced (`[16200, 16300, 16400, 16500]` retained). Same shape as the v3 fix in #1326.

2. **`addr_add`/`addr_del` re-originate the Extended-Prefix LSA** (inst.rs): the config handler originates at commit time, but the kernel `AddrAdd` for an address configured in the same commit can land after that; origination then bails without retry and the Prefix-SID never appears. v2 already skipped loopback addresses, so unlike v3 it failed silent-empty rather than advertising a bogus `127.0.0.1` prefix.

### Pinned v2/v3 divergence

A directly-adjacent owner's node-SID renders as an implicit-null **Pop** on v2 (v2 marks adjacency nexthops and applies the PHP optimisation) while v3 pushes the explicit label per its NP flag; multi-hop SIDs swap on both. Both forward correctly — the two features pin their respective behaviors, and aligning them (if desired) is left as a follow-up.

## Test plan

- `@ospfv2_tilfa` BDD: **7/7 scenarios, 75/75 steps green**, binary md5-bracketed before/after (one earlier run was invalidated by a parallel-worktree binary stomp and rerun).
- `cargo test --workspace --exclude bdd`: green.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean; `cargo fmt --all` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)