### PR TITLE
docs: rewrite install instructions to match the CI build workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,43 +2,109 @@
 
 zebra-rs is a BGP, OSPF, and IS‑IS routing stack with SRv6, SR-MPLS, L3VPN, and EVPN extensions, written from scratch in Rust. Memory‑safe, async to the core, idempotent by design — and the first routing daemon to ship with a native MCP server for AI agents. Project Home Page <http://zebra.rs/>.
 
-## Install Instruction
+## Installation
 
-To build the project, we need protocol buffer's `protoc` compiler.
+### Prebuilt Nightly Packages
 
-On Linux,
+The nightly CI workflow publishes ready-to-install `.deb` packages to the
+[nightly release](https://github.com/zebra-rs/zebra-rs/releases/tag/nightly)
+for Ubuntu 22.04 (jammy), 24.04 (noble), and 26.04 (resolute), on both
+x86_64 and ARM64:
 
 ``` shell
-sudo apt install -y protobuf-compiler
+curl -LO https://github.com/zebra-rs/zebra-rs/releases/download/nightly/<filename>.deb
+sudo apt install ./<filename>.deb
 ```
 
-will be necessary.
+If you only want to run zebra-rs, this is the quickest path. The rest of this
+section describes building from source; the steps mirror the CI build scripts
+under `.github/workflows/` (`ci.yaml`, `build-amd64.yaml`, `build-arm64.yaml`,
+`nightly.yaml`).
 
-After that,
+### Build Requirements
+
+#### Rust toolchain
+
+Install the stable Rust toolchain with [rustup](https://rustup.rs/):
+
+``` shell
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+#### System packages
+
+On Ubuntu/Debian:
+
+``` shell
+sudo apt update
+sudo apt install -y build-essential pkg-config curl \
+    protobuf-compiler libpam0g-dev libnanomsg-dev bison xxd
+```
+
+| Package | Needed for |
+|---|---|
+| `build-essential`, `pkg-config`, `curl` | C toolchain for the `vty` shell — GNU bash 5.3 is downloaded and compiled from source |
+| `protobuf-compiler` | `protoc`, which generates the gRPC/protobuf management API code |
+| `libpam0g-dev` | the `vtypam` PAM authentication helper |
+| `libnanomsg-dev` | the vtysh hooks built into the `vty` shell |
+| `bison` | bash's grammar, regenerated during the `vty` build |
+| `xxd` | embeds `vty.sh` into the `vty` binary during the build |
+
+Building or testing only the Rust workspace (`cargo build`, `cargo test`)
+needs just `protobuf-compiler` and `libpam0g-dev` — that is all `ci.yaml`
+installs. The remaining packages are used by the `vty` build and packaging.
+
+#### XDP/eBPF toolchain: LLVM and bpf-linker
+
+The XDP BFD Echo helper (`offload/xdp-bfd-echo`) offloads BFD Echo
+reflection to XDP. It is compiled for the `bpfel-unknown-none` target, which
+requires a nightly Rust toolchain with `rust-src`, LLVM 18, and
+[`bpf-linker`](https://github.com/aya-rs/bpf-linker) (which links against
+LLVM). The validated combination is bpf-linker 0.10.3 with LLVM 18.1:
+
+``` shell
+# Nightly Rust + rust-src for the BPF target
+rustup toolchain install nightly --component rust-src
+
+# LLVM 18 from apt.llvm.org
+wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+chmod +x /tmp/llvm.sh
+sudo /tmp/llvm.sh 18
+export PATH="/usr/lib/llvm-18/bin:$PATH"
+
+# bpf-linker, linked against the LLVM installed above
+cargo install bpf-linker --version 0.10.3 --locked
+```
+
+This toolchain is **not** required for `make all`. It is required for
+`make xdp-bfd-echo` and for building the Debian package, which bundles the
+helper.
+
+### Build and Install from Source
 
 ``` shell
 make all
+```
+
+builds the release binaries of the Rust workspace (`zebra-rs`, `vtyctl`,
+`vtyhelper`, `vtypam`) and the `vty` shell.
+
+``` shell
 make install
 ```
 
-will install `zebra`, `vty`, and `vtyctl` under the `${HOME}/.zebra/bin` directory.
-Please add
-
-``` shell
-export PATH="${PATH}:${HOME}/.zebra/bin"
-```
-
-to your `.bashrc`, `.zshrc`, or any other shell profile.
+installs `zebra-rs`, `vtyctl`, and `vtyhelper` into `/usr/bin` (via `sudo`,
+granting `zebra-rs` the necessary network capabilities with `setcap`) and
+copies the YANG schemas to `/etc/zebra-rs/yang`. Keep the schemas in lockstep
+with the binary: a stale schema directory silently rejects newly added
+configuration even when the binary supports it.
 
 ## Debian Package
 
-``` shell
-sudo apt update -y
-sudo apt upgrade -y
-sudo apt install -y protobuf-compiler bison libpam0g-dev
-```
-
-To build a Debian package, we use the [`nfpm`](https://github.com/goreleaser/nfpm) package builder. Install nfpm as follows:
+Building the `.deb` package needs all of the build requirements above —
+including the XDP/eBPF toolchain (LLVM + bpf-linker), because the package
+bundles the `xdp-bfd-echo` helper — plus the
+[`nfpm`](https://github.com/goreleaser/nfpm) package builder:
 
 ``` shell
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
@@ -53,7 +119,10 @@ cd packaging
 make amd64   # or: make arm64
 ```
 
-This produces a `.deb` package for the selected architecture.
+This builds the `vty` shell and the Rust workspace if needed, compiles the
+`xdp-bfd-echo` XDP helper, and produces a `.deb` package for the selected
+architecture — the same steps `build-amd64.yaml` and `build-arm64.yaml` run
+in CI.
 
 ``` shell
 sudo dpkg -i zebra-rs_26.5.1_arm64.deb


### PR DESCRIPTION
## Summary

The README install section predated most of the build pipeline: it listed only `protobuf-compiler`, claimed `make install` puts binaries under `~/.zebra/bin` (it installs to `/usr/bin` + `/etc/zebra-rs/yang` with setcap), and didn't mention that the Debian package build needs the XDP/eBPF toolchain. Rewrite it to mirror the CI build scripts under `.github/workflows/` (`ci.yaml`, `build-amd64.yaml`, `build-arm64.yaml`, `nightly.yaml`):

- **Prebuilt Nightly Packages**: point at the `nightly` GitHub release (jammy/noble/resolute × amd64/arm64) as the quickest install path
- **System packages**: one apt line plus a table explaining what each package is for — `protobuf-compiler` (gRPC codegen), `libpam0g-dev` (vtypam), `libnanomsg-dev` (vtysh hooks), `bison` + `xxd` + `build-essential`/`pkg-config`/`curl` (the vty bash-5.3 build); note that `cargo build`/`cargo test` alone need only protobuf + libpam, exactly what `ci.yaml` installs
- **XDP/eBPF toolchain**: nightly Rust + `rust-src`, LLVM 18 via apt.llvm.org, `bpf-linker 0.10.3 --locked` (the validated combo from the workflows); not needed for `make all`, required for `make xdp-bfd-echo` and the `.deb` build
- **Build and Install from Source**: describe what `make all` / `make install` actually build and install, including the stale-YANG-schema warning
- **Debian Package**: needs everything above plus nfpm, since `packaging/Makefile` bundles the `xdp-bfd-echo` helper; same steps as `build-amd64.yaml`/`build-arm64.yaml`

## Test plan

- Docs-only change (README.md); no code touched
- Cross-checked every package and command against `.github/workflows/*.yaml`, the top-level/`packaging/`/`vty/` Makefiles, and the vty bash patch (`xxd -i vty.sh`)
- CI (fmt/clippy/test) unaffected

Generated with [Claude Code](https://claude.com/claude-code)