### PR TITLE
bgp: withdraw every AFI/SAFI on session down, not just v4/VPNv4/EVPN/LU

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -138,6 +138,10 @@ ospfv3_nssa:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv3_nssa"
 
+bgp_peer_down_cleanup:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_peer_down_cleanup"
+
 ospfv2_tilfa:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv2_tilfa"
@@ -213,4 +217,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community bgp_neighbor_group bgp_unnumbered_neighbor bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community bgp_neighbor_group bgp_unnumbered_neighbor bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE

--- a/bdd/tests/configs/bgp_peer_down_cleanup/z1.yaml
+++ b/bdd/tests/configs/bgp_peer_down_cleanup/z1.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv4:
+    address: 192.168.0.1/30
+  ipv6:
+    address: 2001:db8:12::1/64
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      remote-as: 65002
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: null
+    - name: ipv6
+      redistribute:
+        connected: null

--- a/bdd/tests/configs/bgp_peer_down_cleanup/z2.yaml
+++ b/bdd/tests/configs/bgp_peer_down_cleanup/z2.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv4:
+    address: 192.168.0.2/30
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.0.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: null
+    - name: ipv6
+      redistribute:
+        connected: null

--- a/bdd/tests/features/bgp_peer_down_cleanup.feature
+++ b/bdd/tests/features/bgp_peer_down_cleanup.feature
@@ -1,0 +1,69 @@
+@serial
+@bgp_peer_down_cleanup
+Feature: BGP session loss withdraws every AFI/SAFI the peer contributed
+  As a network operator
+  I want a BGP session that leaves Established to take all of that
+  neighbour's routes with it — across every negotiated AFI/SAFI — so
+  that traffic never follows a route whose only source is a dead peer.
+
+  Regression guard: `route_clean` (the leaving-Established hook) used
+  to cover IPv4 unicast, VPNv4, EVPN and labeled-unicast but skipped
+  IPv6 unicast entirely — a session drop left the peer's IPv6 routes
+  best-path-selected forever, while the same peer's IPv4 routes were
+  correctly withdrawn. The fix also swept the same gap for VPNv6,
+  Flowspec, BGP-LS and SR Policy; this feature pins the dual-stack
+  unicast behaviour end to end.
+
+  Topology: one dual-stack point-to-point link, eBGP over the IPv4
+  addresses with both ipv4 and ipv6 afi-safi negotiated, both sides
+  redistributing connected (loopbacks 10.0.0.X/32 + 2001:db8::X/128).
+
+  Scenario: Establish the dual-stack session and learn both AFIs
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 10 seconds
+    Then show command "show bgp summary" in namespace "z1" should contain "Established"
+    # z2's loopbacks arrived over both AFIs.
+    And show command "show bgp" in namespace "z1" should contain "10.0.0.2/32"
+    And show command "show bgp ipv6" in namespace "z1" should contain "2001:db8::2/128"
+    # And the IPv4 route made it into the main RIB.
+    And show command "show ip route" in namespace "z1" should contain "10.0.0.2/32"
+
+  Scenario: Killing the peer withdraws IPv4 AND IPv6 routes
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z2"
+    And I wait 5 seconds
+    # The session left Established...
+    Then show command "show bgp summary" in namespace "z1" should not contain "Established"
+    # ...and BOTH address families are gone. The IPv6 assertion is the
+    # regression: it used to stay best-path-selected forever.
+    And show command "show bgp" in namespace "z1" should not contain "10.0.0.2/32"
+    And show command "show bgp ipv6" in namespace "z1" should not contain "2001:db8::2/128"
+    And show command "show ip route" in namespace "z1" should not contain "10.0.0.2/32"
+
+  Scenario: The session re-establishes and both AFIs are re-learned
+    Given the test topology exists
+    When I start zebra-rs in namespace "z2"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 15 seconds
+    Then show command "show bgp summary" in namespace "z1" should contain "Established"
+    # Both directions re-learn both AFIs — z1's adj-out was cleared on
+    # the drop, so z2 receives a full re-advertisement too.
+    And show command "show bgp" in namespace "z1" should contain "10.0.0.2/32"
+    And show command "show bgp ipv6" in namespace "z1" should contain "2001:db8::2/128"
+    And show command "show bgp" in namespace "z2" should contain "10.0.0.1/32"
+    And show command "show bgp ipv6" in namespace "z2" should contain "2001:db8::1/128"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -5664,6 +5664,32 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
     peer.adj_out.v4.0.clear();
 
     peer.cache_vpnv4.clear();
+    peer.cache_vpnv6.clear();
+
+    // IPv6 unicast. Same shape as the IPv4 block above — withdraw
+    // every prefix the peer gave us from the Loc-RIB (which fans out
+    // MP_UNREACH to other peers and removes any main-RIB install),
+    // then drop the Adj-RIB tables. Was missing entirely: a session
+    // leaving Established kept its v6 routes selected forever.
+    let withdrawn_v6 = {
+        let mut withdrawn: Vec<Ipv6Nlri> = vec![];
+        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+        for (prefix, ribs) in peer.adj_in.v6.0.iter() {
+            for rib in ribs.iter() {
+                withdrawn.push(Ipv6Nlri {
+                    id: rib.remote_id,
+                    prefix: *prefix,
+                });
+            }
+        }
+        withdrawn
+    };
+    for withdraw in withdrawn_v6.iter() {
+        route_ipv6_withdraw(peer_id, withdraw, None, bgp, peers, true);
+    }
+    let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+    peer.adj_in.v6.0.clear();
+    peer.adj_out.v6.0.clear();
 
     // IPv4 VPN.
     let afi_safi = AfiSafi::new(Afi::Ip, Safi::MplsVpn);
@@ -5817,6 +5843,142 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
 
     let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
     peer.adj_out.v4vpn.clear();
+
+    // IPv6 VPN. Same two-branch shape as the VPNv4 block above:
+    // LLGR-negotiated sessions retain the adj-in entries stale-marked
+    // (LLGR_STALE community attached, stale timer armed); otherwise
+    // withdraw everything. Was missing entirely alongside the v6
+    // unicast block.
+    let afi_safi = AfiSafi::new(Afi::Ip6, Safi::MplsVpn);
+    if peer.cap_send.llgr.contains_key(&afi_safi)
+        && let Some(llgr) = peer.cap_recv.llgr.get(&afi_safi)
+    {
+        peer.timer.stale_timer.insert(
+            afi_safi,
+            start_stale_timer(peer, afi_safi, llgr.stale_time()),
+        );
+
+        // RFC 9494 §4.2: NO_LLGR routes are not retained — remove and
+        // withdraw them; only the rest go stale.
+        let no_llgr: Vec<Vpnv6Nlri> = {
+            let mut out = Vec::new();
+            for (rd, table) in peer.adj_in.v6vpn.iter_mut() {
+                for (prefix, ribs) in table.0.iter_mut() {
+                    ribs.retain(|rib| {
+                        let refuse = attr_refuses_llgr(&rib.attr);
+                        if refuse {
+                            out.push(Vpnv6Nlri {
+                                label: rib.label.unwrap_or_default(),
+                                rd: *rd,
+                                nlri: Ipv6Nlri {
+                                    id: rib.remote_id,
+                                    prefix: *prefix,
+                                },
+                            });
+                        }
+                        !refuse
+                    });
+                }
+            }
+            out
+        };
+        for withdraw in no_llgr.iter() {
+            route_ipv6_withdraw(peer_id, &withdraw.nlri, Some(withdraw.rd), bgp, peers, true);
+        }
+        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+
+        for (_rd, table) in peer.adj_in.v6vpn.iter_mut() {
+            for (_prefix, ribs) in table.0.iter_mut() {
+                for rib in ribs.iter_mut() {
+                    rib.stale = true;
+                    let mut new_attr = (*rib.attr).clone();
+                    match &mut new_attr.com {
+                        Some(com) => {
+                            com.insert(CommunityValue::LLGR_STALE.value());
+                        }
+                        None => {
+                            let mut com = Community::new();
+                            com.insert(CommunityValue::LLGR_STALE.value());
+                            new_attr.com = Some(com);
+                        }
+                    }
+                    rib.attr = bgp.attr_store.intern(new_attr);
+                }
+            }
+        }
+
+        // Re-import the now-stale entries into the Loc-RIB so best
+        // path selection still sees them (with the stale community).
+        let stale_updates: Vec<(
+            RouteDistinguisher,
+            Ipv6Nlri,
+            Option<Label>,
+            BgpAttr,
+            Option<VpnNexthop>,
+        )> = {
+            let mut updates = Vec::new();
+            for (rd, table) in peer.adj_in.v6vpn.iter() {
+                for (prefix, ribs) in table.0.iter() {
+                    for rib in ribs.iter() {
+                        let nlri = Ipv6Nlri {
+                            id: rib.remote_id,
+                            prefix: *prefix,
+                        };
+                        updates.push((
+                            *rd,
+                            nlri,
+                            rib.label,
+                            (*rib.attr).clone(),
+                            rib.nexthop.clone(),
+                        ));
+                    }
+                }
+            }
+            updates
+        };
+        for (rd, nlri, label, attr, nexthop) in stale_updates {
+            route_ipv6_update(
+                peer_id,
+                &nlri,
+                Some(rd),
+                label,
+                &attr,
+                nexthop,
+                bgp,
+                peers,
+                true,
+            );
+        }
+    } else {
+        let withdrawn = {
+            let mut withdrawn: Vec<Vpnv6Nlri> = vec![];
+            let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+
+            for (rd, table) in peer.adj_in.v6vpn.iter() {
+                for (prefix, ribs) in table.0.iter() {
+                    for rib in ribs.iter() {
+                        withdrawn.push(Vpnv6Nlri {
+                            label: rib.label.unwrap_or_default(),
+                            rd: *rd,
+                            nlri: Ipv6Nlri {
+                                id: rib.remote_id,
+                                prefix: *prefix,
+                            },
+                        });
+                    }
+                }
+            }
+            withdrawn
+        };
+        for withdraw in withdrawn.iter() {
+            route_ipv6_withdraw(peer_id, &withdraw.nlri, Some(withdraw.rd), bgp, peers, true);
+        }
+        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+        peer.adj_in.v6vpn.clear();
+    }
+
+    let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+    peer.adj_out.v6vpn.clear();
 
     // EVPN. Same shape as the VPNv4 block above:
     //   * If both ends advertised LLGR for L2VPN/EVPN, retain the
@@ -5976,6 +6138,69 @@ pub fn route_clean(peer_id: usize, bgp: &mut BgpTop, peers: &mut PeerMap) {
     peer.adj_out.v4lu.0.clear();
     peer.adj_out.v6lu.0.clear();
 
+    // Flowspec v4 / v6 (SAFI 133). Withdraw each rule the peer gave
+    // us — `route_flowspec_withdraw` removes adj-in + Loc-RIB entry
+    // and re-propagates — then drop the Adj-RIB tables.
+    let withdrawn_fs: Vec<(Afi, FlowspecNlri)> = {
+        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+        let mut out = Vec::new();
+        for nlri in peer.adj_in.flowspec_v4.0.keys() {
+            out.push((Afi::Ip, nlri.clone()));
+        }
+        for nlri in peer.adj_in.flowspec_v6.0.keys() {
+            out.push((Afi::Ip6, nlri.clone()));
+        }
+        out
+    };
+    for (afi, nlri) in withdrawn_fs.iter() {
+        route_flowspec_withdraw(peer_id, nlri, *afi, bgp, peers);
+    }
+    let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+    peer.adj_in.flowspec_v4.0.clear();
+    peer.adj_in.flowspec_v6.0.clear();
+    peer.adj_out.flowspec_v4.0.clear();
+    peer.adj_out.flowspec_v6.0.clear();
+
+    // BGP Link-State (SAFI 71). Withdraw each NLRI the peer gave us
+    // from the bgp_ls Loc-RIB, then drop the Adj-RIB tables.
+    let withdrawn_ls: Vec<BgpLsNlri> = {
+        let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+        peer.adj_in.bgp_ls.0.keys().cloned().collect()
+    };
+    for nlri in withdrawn_ls.iter() {
+        route_bgpls_withdraw(peer_id, nlri, bgp, peers);
+    }
+    let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
+    peer.adj_in.bgp_ls.0.clear();
+    peer.adj_out.bgp_ls.0.clear();
+
+    // SR Policy (SAFI 73). The candidate paths live in the headend
+    // database keyed by <color, endpoint, discriminator> with the
+    // contributing peer recorded per candidate — sweep this peer's
+    // candidates out through `route_srpolicy_withdraw`, which also
+    // tears down any installed Binding-SID / MPLS FIB state and
+    // reflects the withdraw to other SAFI-73 peers.
+    let withdrawn_srp: Vec<SrPolicyNlri> = {
+        let mut out = Vec::new();
+        for (key, policy) in bgp.local_rib.sr_policy.policies.iter() {
+            for (cp_key, cp) in policy.candidates.iter() {
+                if cp.peer == peer_id {
+                    out.push(SrPolicyNlri {
+                        id: 0,
+                        distinguisher: cp_key.discriminator,
+                        color: key.color,
+                        endpoint: key.endpoint,
+                    });
+                }
+            }
+        }
+        out
+    };
+    for nlri in withdrawn_srp.iter() {
+        route_srpolicy_withdraw(peer_id, nlri, bgp, peers);
+    }
+
+    let peer = peers.get_mut_by_idx(peer_id).expect("peer must exist");
     peer.cap_map = CapAfiMap::new();
     peer.cap_recv = BgpCap::default();
     peer.opt.clear();


### PR DESCRIPTION
## Summary

Fixes the reported critical bug: **a BGP neighbor leaving Established kept its IPv6 routes in the RIB forever** — and the audit it prompted found the same leak in four more AFI/SAFIs.

### Reproduction (the reported bug)

Dual-stack eBGP pair, both `ipv4` and `ipv6` afi-safi negotiated, redistribute connected. Kill the peer:

- `show bgp` — the peer's **IPv4 routes are withdrawn** ✓
- `show bgp ipv6` — the peer's **IPv6 routes survive, still best-path-selected** ✗ (and would sit in the main RIB wherever installed)

### Root cause

`route_clean` — the hook `fsm()` runs whenever a peer leaves Established — enumerated IPv4 unicast, VPNv4 (with LLGR), EVPN (with LLGR), and v4/v6 labeled-unicast, then stopped. Full audit of per-peer state vs. cleanup:

| AFI/SAFI | adj-in | Loc-RIB / dataplane on peer-down |
|---|---|---|
| IPv4 unicast | cleaned | withdrawn ✓ |
| VPNv4 | cleaned | LLGR-stale / withdrawn ✓ |
| EVPN | cleaned | LLGR-stale / withdrawn ✓ |
| v4/v6 labeled-unicast | cleaned | withdrawn ✓ |
| **IPv6 unicast** | **leaked** | **leaked** ← reported bug |
| **VPNv6** | **leaked** | **leaked** (no LLGR branch either) |
| **Flowspec v4/v6** | **leaked** | **leaked** |
| **BGP-LS** | **leaked** | **leaked** |
| **SR Policy** | n/a | **leaked — including installed Binding-SID / MPLS FIB state surviving a dead controller** |

### Fix

All in `route_clean`, mirroring the existing per-AFI shapes:

- **IPv6 unicast**: withdraw via `route_ipv6_withdraw` (Loc-RIB removal, MP_UNREACH fan-out, main-RIB uninstall), clear `adj_in.v6`/`adj_out.v6`, clear `cache_vpnv6`.
- **VPNv6**: full two-branch mirror of the VPNv4 block — RFC 9494 NO_LLGR withdraw + LLGR_STALE marking + stale re-import when LLGR is negotiated for the AFI/SAFI; plain withdraw + clear otherwise. (Closes part of the "stale coverage beyond VPNv4/EVPN" deferral from #1311.)
- **Flowspec v4/v6**: per-rule `route_flowspec_withdraw` sweep + table clears.
- **BGP-LS**: per-NLRI `route_bgpls_withdraw` sweep + table clears.
- **SR Policy**: sweep the headend DB for this peer's candidate paths per `<color, endpoint, discriminator>` via `route_srpolicy_withdraw` — tears down installed Binding-SID/MPLS FIB state and reflects the withdraw to other SAFI-73 peers.

Clearing the v6 adj-out alongside means a re-established session gets a clean full re-advertisement (pinned by the BDD's third scenario).

### Noted, separate issue (not addressed here)

During the repro: IPv6 unicast advertised over a v4-addressed session carries `::` as the MP_REACH nexthop, so those routes never install into the main RIB (RFC 2545 nexthop selection gap). Worth its own follow-up.

## Test plan

- New `@bgp_peer_down_cleanup` BDD: establish dual-stack session → learn both AFIs → kill peer → **both AFIs withdrawn** (the v6 assertion is the regression guard) → restart peer → both AFIs re-learned in both directions. **4/4 scenarios green**, binary md5-bracketed.
- Live repro verified fixed before the BDD (v6 table empties on session kill).
- `cargo test --workspace --exclude bdd` green; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)