### PR TITLE
bgp: source a real v6 next-hop for v6 NLRI over v4-addressed sessions

### DIFF
--- a/bdd/Makefile
+++ b/bdd/Makefile
@@ -142,6 +142,10 @@ bgp_peer_down_cleanup:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_peer_down_cleanup"
 
+bgp_ipv6_over_v4_session:
+	mkdir -p allure-results
+	cargo test --test cucumber -- --concurrency=1 --tags "@bgp_ipv6_over_v4_session"
+
 ospfv2_tilfa:
 	mkdir -p allure-results
 	cargo test --test cucumber -- --concurrency=1 --tags "@ospfv2_tilfa"
@@ -217,4 +221,4 @@ docs/%.md: tests/features/%.feature docs/feature2md.sh FORCE
 
 FORCE:
 
-.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community bgp_neighbor_group bgp_unnumbered_neighbor bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE
+.PHONY: all run ibgp ebgp rr rib_static_ipv6 isis_ipv6 isis_srv6 isis_fragmentation_ipv6 isis_fragmentation_ipv4 isis_l1p2p isis_tilfa isis_l1l2 isis_redist isis_hello_auth_keychain isis_passive isis_afi_enable isis_endx_ipv6 isis_bfd_ipv6_p2p isis_bfd_ipv6_p2p_echo isis_bfd_ipv6_lan isis_bfd_ipv6_lan_echo isis_bfd_ipv4_p2p isis_bfd_ipv4_p2p_echo isis_bfd_ipv4_lan isis_bfd_ipv4_lan_echo ospf_clear_neighbor ospfv2_nssa ospfv2_stub ospfv2_tilfa ospfv3_nssa ospfv3_tilfa bgp_peer_down_cleanup bgp_ipv6_over_v4_session bgp_evpn_capability bgp_vrf_evpn_type5 bgp_route_map_match bgp_policy_dynamic_update bgp_community bgp_neighbor_group bgp_unnumbered_neighbor bgp_interas_option_c bgp_interas_option_a bgp_interas_option_b bgp_interas_option_ab generate open docs FORCE

--- a/bdd/tests/configs/bgp_ipv6_over_v4_session/z1.yaml
+++ b/bdd/tests/configs/bgp_ipv6_over_v4_session/z1.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.1/32
+  ipv6:
+    address: 2001:db8::1/128
+- if-name: z1-z2
+  ipv4:
+    address: 192.168.0.1/30
+  ipv6:
+    address: 2001:db8:12::1/64
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    neighbor:
+    - remote-address: 192.168.0.2
+      remote-as: 65002
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: null
+    - name: ipv6
+      redistribute:
+        connected: null

--- a/bdd/tests/configs/bgp_ipv6_over_v4_session/z2.yaml
+++ b/bdd/tests/configs/bgp_ipv6_over_v4_session/z2.yaml
@@ -1,0 +1,32 @@
+interface:
+- if-name: lo
+  ipv4:
+    address: 10.0.0.2/32
+  ipv6:
+    address: 2001:db8::2/128
+- if-name: z2-z1
+  ipv4:
+    address: 192.168.0.2/30
+  ipv6:
+    address: 2001:db8:12::2/64
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 10.0.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      remote-as: 65001
+      enabled: true
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: ipv6
+        enabled: true
+    afi-safi:
+    - name: ipv4
+      redistribute:
+        connected: null
+    - name: ipv6
+      redistribute:
+        connected: null

--- a/bdd/tests/features/bgp_ipv6_over_v4_session.feature
+++ b/bdd/tests/features/bgp_ipv6_over_v4_session.feature
@@ -1,0 +1,57 @@
+@serial
+@bgp_ipv6_over_v4_session
+Feature: IPv6 NLRI over a v4-addressed BGP session carries a usable next-hop
+  As a network operator
+  I want IPv6 routes advertised across an IPv4-addressed BGP session to
+  carry a real IPv6 next-hop (RFC 2545 §2), so the receiver can resolve,
+  install and forward them — not just display them.
+
+  Regression guard: next-hop-self only fired when the session's local
+  end was itself IPv6, so v6 NLRI over v4 transport went out with `::`
+  as the MP_REACH next-hop. The receiver kept those routes best-path
+  selected but could never install them. The fix sources the next-hop
+  from the session interface's global IPv6 (the v4 local end's owning
+  interface), and skips the advertisement entirely when no usable v6
+  next-hop exists rather than emitting `::`.
+
+  Topology: one dual-stack point-to-point link, eBGP over the IPv4
+  addresses with both ipv4 and ipv6 afi-safi negotiated, both sides
+  redistributing connected (loopbacks 10.0.0.X/32 + 2001:db8::X/128,
+  link 192.168.0.0/30 + 2001:db8:12::/64).
+
+  Scenario: v6 routes arrive with the peer's interface global as next-hop
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "z1-z2" to namespace "z2" interface "z2-z1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I apply config "z2.yaml" to namespace "z2"
+    And I wait 10 seconds
+    Then show command "show bgp summary" in namespace "z1" should contain "Established"
+    # z2's loopback arrived over the v6 AFI with z2's interface global
+    # (2001:db8:12::2) as the next-hop — not `::`.
+    And show command "show bgp ipv6" in namespace "z1" should contain "2001:db8::2/128"
+    And show command "show bgp ipv6" in namespace "z1" should contain "2001:db8:12::2"
+    # Symmetric on z2.
+    And show command "show bgp ipv6" in namespace "z2" should contain "2001:db8::1/128"
+    And show command "show bgp ipv6" in namespace "z2" should contain "2001:db8:12::1"
+
+  Scenario: The v6 routes resolve, install into the RIB and forward
+    Given the test topology exists
+    # A resolvable next-hop means the route makes it past best-path
+    # into the main v6 RIB (it never did while the next-hop was `::`)...
+    Then show command "show ipv6 route" in namespace "z1" should contain "2001:db8::2/128"
+    And show command "show ipv6 route" in namespace "z2" should contain "2001:db8::1/128"
+    # ...and the dataplane forwards loopback-to-loopback both ways.
+    And ping from "z1" to "2001:db8::2" should succeed
+    And ping from "z2" to "2001:db8::1" should succeed
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/interface_addrs.rs
+++ b/zebra-rs/src/bgp/interface_addrs.rs
@@ -17,17 +17,22 @@
 //! peers see stable next-hops across daemon restarts and reorderings.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::net::Ipv6Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 use ipnet::IpNet;
 
 use crate::rib::link::LinkAddr;
 
-/// Per-ifindex IPv6 address registry, split by kind.
+/// Per-ifindex IPv6 address registry, split by kind, plus an
+/// IPv4-address → owning-ifindex map so a v4-addressed BGP session
+/// can be tied back to its interface (and from there to that
+/// interface's global v6 — the RFC 2545 next-hop source for v6 NLRI
+/// carried over v4 transport).
 #[derive(Debug, Default)]
 pub struct InterfaceAddrs {
     link_local: BTreeMap<u32, BTreeSet<Ipv6Addr>>,
     global: BTreeMap<u32, BTreeSet<Ipv6Addr>>,
+    v4_owner: BTreeMap<Ipv4Addr, u32>,
 }
 
 impl InterfaceAddrs {
@@ -35,9 +40,10 @@ impl InterfaceAddrs {
         Self::default()
     }
 
-    /// Register an address with the table. IPv4, loopback, and the
-    /// unspecified address are ignored; link-locals and globals
-    /// (including ULA) are routed to their respective bucket.
+    /// Register an address with the table. Loopback and the
+    /// unspecified address are ignored; v6 link-locals and globals
+    /// (including ULA) are routed to their respective bucket, and v4
+    /// addresses record which ifindex owns them.
     pub fn record(&mut self, addr: &LinkAddr) {
         match classify(addr) {
             Some(V6Kind::LinkLocal(host)) => {
@@ -51,6 +57,12 @@ impl InterfaceAddrs {
             }
             None => {}
         }
+        if let IpNet::V4(net) = addr.addr {
+            let host = net.addr();
+            if !host.is_loopback() && !host.is_unspecified() {
+                self.v4_owner.insert(host, addr.ifindex);
+            }
+        }
     }
 
     /// Forget an address previously passed to [`Self::record`]. If the
@@ -62,6 +74,21 @@ impl InterfaceAddrs {
             Some(V6Kind::Global(host)) => drop_from(&mut self.global, addr.ifindex, host),
             None => {}
         }
+        if let IpNet::V4(net) = addr.addr {
+            // Guard against an out-of-order AddrDel for an address that
+            // has since been re-claimed by another interface.
+            if self.v4_owner.get(&net.addr()) == Some(&addr.ifindex) {
+                self.v4_owner.remove(&net.addr());
+            }
+        }
+    }
+
+    /// Which interface owns this local IPv4 address, if any. Used to
+    /// map a v4-addressed BGP session's local end back to its
+    /// interface so [`Self::global_for`] can supply the v6 next-hop
+    /// for v6 NLRI advertised over that session.
+    pub fn ifindex_for_v4(&self, addr: Ipv4Addr) -> Option<u32> {
+        self.v4_owner.get(&addr).copied()
     }
 
     /// Return the chosen link-local for `ifindex`, or `None` if none
@@ -170,6 +197,29 @@ mod tests {
         t.record(&v6("::1", 128, 7));
         assert_eq!(t.link_local_for(7), None);
         assert_eq!(t.global_for(7), None);
+    }
+
+    #[test]
+    fn v4_owner_maps_session_address_to_interface_v6_global() {
+        // The RFC 2545 fix: a v4-addressed session's local end resolves
+        // to its owning ifindex, whose global v6 becomes the MP_REACH
+        // next-hop for v6 NLRI carried over that session.
+        let mut t = InterfaceAddrs::new();
+        t.record(&v4("192.168.0.1", 30, 7));
+        t.record(&v6("2001:db8:12::1", 64, 7));
+        let ifindex = t.ifindex_for_v4("192.168.0.1".parse().unwrap());
+        assert_eq!(ifindex, Some(7));
+        assert_eq!(
+            ifindex.and_then(|i| t.global_for(i)),
+            Some("2001:db8:12::1".parse().unwrap())
+        );
+        // Forget drops the mapping; a stale AddrDel for an address
+        // re-claimed by another interface must not clobber it.
+        t.record(&v4("192.168.0.1", 30, 9));
+        t.forget(&v4("192.168.0.1", 30, 7));
+        assert_eq!(t.ifindex_for_v4("192.168.0.1".parse().unwrap()), Some(9));
+        t.forget(&v4("192.168.0.1", 30, 9));
+        assert_eq!(t.ifindex_for_v4("192.168.0.1".parse().unwrap()), None);
     }
 
     #[test]

--- a/zebra-rs/src/bgp/route.rs
+++ b/zebra-rs/src/bgp/route.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 
 use bgp_packet::*;
@@ -6581,33 +6581,55 @@ pub fn route_update_ipv6(
     // AS_PATH prepend for eBGP.
     ebgp_egress_aspath(peer, &mut attrs);
 
-    // NEXT_HOP: next-hop-self for eBGP / locally-originated routes. The
-    // address is the local end of this peer's (i)BGP session when it's
-    // IPv6; otherwise the route's existing v6 next-hop is preserved
-    // (next-hop-unchanged) — a v4-transport session can't carry a
-    // sensible v6 next-hop anyway.
+    // NEXT_HOP: next-hop-self for eBGP / locally-originated routes.
+    // RFC 2545 §2 requires the MP_REACH next-hop be one of OUR IPv6
+    // addresses regardless of the session's transport family:
+    //   - v6-transport session: the session's local end.
+    //   - v4-transport session: the session interface's global v6
+    //     (looked up via the v4 local end's owning ifindex). The old
+    //     code skipped next-hop-self entirely here, so an originated
+    //     route (whose stored next-hop is empty) went on the wire as
+    //     `::` — the peer kept it best-path-selected but could never
+    //     resolve or install it.
     let needs_self = peer.is_ebgp() || rib.is_originated();
-    if needs_self
-        && let Some(ref local_addr) = peer.param.local_addr
-        && let IpAddr::V6(local_v6) = local_addr.ip()
-    {
-        // VPNv6 rows carry a `VpnNexthop::V6` (the route's RD); emit a
-        // VPNv6-shaped next-hop so `flush_vpnv6` picks it up. Plain
-        // v6-unicast rows get a bare IPv6 next-hop.
-        attrs.nexthop = match rib.nexthop {
-            Some(VpnNexthop::V6(ref v6nh)) => Some(BgpNexthop::Vpnv6(Vpnv6Nexthop {
-                rd: v6nh.rd,
-                // SRv6 L3VPN: a VPNv6 route with an SRv6 L3 Service SID
-                // advertises the PE's locator (stored on the row) as the
-                // next-hop; MPLS-mode rows next-hop-self with local_v6.
-                nhop: if attrs.srv6_l3_sid().is_some() {
-                    v6nh.nhop
-                } else {
-                    local_v6
-                },
-            })),
-            _ => Some(BgpNexthop::Ipv6(local_v6)),
+    if needs_self {
+        let self_v6: Option<Ipv6Addr> = match peer.param.local_addr.as_ref().map(|a| a.ip()) {
+            Some(IpAddr::V6(v6)) => Some(v6),
+            Some(IpAddr::V4(v4)) => bgp
+                .interface_addrs
+                .ifindex_for_v4(v4)
+                .and_then(|ifindex| bgp.interface_addrs.global_for(ifindex)),
+            None => None,
         };
+        if let Some(local_v6) = self_v6 {
+            // VPNv6 rows carry a `VpnNexthop::V6` (the route's RD); emit a
+            // VPNv6-shaped next-hop so `flush_vpnv6` picks it up. Plain
+            // v6-unicast rows get a bare IPv6 next-hop.
+            attrs.nexthop = match rib.nexthop {
+                Some(VpnNexthop::V6(ref v6nh)) => Some(BgpNexthop::Vpnv6(Vpnv6Nexthop {
+                    rd: v6nh.rd,
+                    // SRv6 L3VPN: a VPNv6 route with an SRv6 L3 Service SID
+                    // advertises the PE's locator (stored on the row) as the
+                    // next-hop; MPLS-mode rows next-hop-self with local_v6.
+                    nhop: if attrs.srv6_l3_sid().is_some() {
+                        v6nh.nhop
+                    } else {
+                        local_v6
+                    },
+                })),
+                _ => Some(BgpNexthop::Ipv6(local_v6)),
+            };
+        } else if !matches!(
+            attrs.nexthop,
+            Some(BgpNexthop::Ipv6(_)) | Some(BgpNexthop::Vpnv6(_))
+        ) {
+            // No v6 self next-hop available (v4-transport session whose
+            // interface carries no global v6) and the route brings no
+            // usable v6 next-hop of its own. Emitting `::` is worse
+            // than not advertising — the peer would select a route it
+            // can never resolve — so skip it.
+            return None;
+        }
     }
 
     // LOCAL_PREF for iBGP.


### PR DESCRIPTION
## Summary

Investigates and fixes the quirk noted in #1329: **IPv6 NLRI advertised over an IPv4-addressed BGP session went on the wire with `::` as the MP_REACH next-hop**, so the receiver kept the routes best-path-selected (`*>` with `Next Hop ::` in `show bgp ipv6`) but could never resolve, install, or forward them.

### Root cause

RFC 2545 §2 requires the MP_REACH next-hop for v6 NLRI to be one of the speaker's IPv6 addresses — regardless of the session's transport family. `route_update_ipv6`'s next-hop-self only fired when the session's **local end was itself IPv6**:

```rust
if needs_self
    && let IpAddr::V6(local_v6) = local_addr.ip()   // v4 session → whole block skipped
```

Over v4 transport, originated/redistributed v6 routes (stored next-hop: empty) fell through untouched and the encoder emitted `::`.

### Fix

- **`interface_addrs.rs`**: the registry that already tracks per-ifindex v6 link-locals/globals (RFC 8950) now also records **which ifindex owns each local IPv4 address**, from the same `AddrAdd`/`AddrDel` feed. `ifindex_for_v4()` maps a v4-addressed session's local end back to its interface.
- **`route_update_ipv6`**: self next-hop resolution is now: session local v6 (v6 transport) → session **interface's global v6** (v4 transport) → and when neither exists and the route has no usable v6 next-hop of its own, **skip the advertisement** instead of emitting `::`. The VPNv6 arm (incl. the SRv6-locator override) inherits the same resolution.

### Out of scope, noted

The v6 **Labeled-Unicast** builder has its own family-blind pick (`local_addr` regardless of family) — same class of issue for LU over mismatched-family transport, left as a follow-up since all LU deployment paths (Inter-AS BDDs) run matched-family sessions.

## Test plan

- New `@bgp_ipv6_over_v4_session` BDD (dual-stack link, eBGP over v4, both AFIs): received v6 routes carry the **peer's interface global** (`2001:db8:12::2`) as next-hop, **install into the main v6 RIB**, and **forward** (loopback-to-loopback ping6 both directions). None of that worked before the fix. **3/3 scenarios green.**
- `@bgp_peer_down_cleanup` re-run **4/4 green** (regression cover — shares the egress path with #1329).
- Unit test for the v4-owner map incl. the stale-AddrDel-after-reclaim guard.
- `cargo test --workspace --exclude bdd` green; `cargo clippy --workspace --all-targets -- -D warnings` clean; binaries md5-bracketed through both BDD runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)