### PR TITLE
bgp: list unnumbered neighbors in summaries + neighbor completion/by-name lookups

### DIFF
--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -259,7 +259,14 @@ async fn set_namespace_interface_state(
     );
 }
 
+// Keyword-agnostic on purpose: cucumber-rs binds a step to its
+// attribute keyword, and an `And` inherits the preceding `Given`/
+// `When`/`Then` — a `when`-only utility step silently SKIPS (along
+// with every step after it in the scenario) when it follows a `Then`.
+// That exact pattern hid the bgp_unnumbered_neighbor route assertions.
+#[given(expr = "I wait {int} seconds")]
 #[when(expr = "I wait {int} seconds")]
+#[then(expr = "I wait {int} seconds")]
 async fn wait_seconds(_world: &mut World, seconds: u64) {
     tokio::time::sleep(tokio::time::Duration::from_secs(seconds)).await;
 }

--- a/bdd/tests/features/bgp_unnumbered_neighbor.feature
+++ b/bdd/tests/features/bgp_unnumbered_neighbor.feature
@@ -61,11 +61,23 @@ Feature: BGP IPv6 unnumbered neighbor discovered via Router Advertisements
     And BGP route in "z2" has "10.0.0.1/32"
     And BGP route in "z1" has "10.0.0.2/32"
 
+  Scenario: The unnumbered peer is listed in summaries and addressable by interface name
+    Given the test topology exists
+    # The summary identifies an interface-keyed peer by its interface
+    # name (the trailing space pins the fixed-width Neighbor column),
+    # and `show ip bgp neighbors <ifname>` resolves the peer the
+    # dynamic completion offers, rendering the FRR-style
+    # `BGP neighbor on <ifname>: <link-local>` identity.
+    Then show command "show bgp summary" in namespace "z1" should contain "i1 "
+    And show command "show bgp ipv4 summary" in namespace "z1" should contain "i1 "
+    And show command "show ip bgp neighbors i1" in namespace "z1" should contain "BGP neighbor on i1: fe80::"
+
   Scenario: Removing the interface-neighbor tears the session down
     Given the test topology exists
     When I apply config "z1-base.yaml" to namespace "z1"
     Then BGP session in namespace "z1" should eventually not be "Established"
     And BGP session in namespace "z2" should eventually not be "Established"
+    And show command "show bgp summary" in namespace "z1" should not contain "i1 "
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1478,10 +1478,16 @@ impl Bgp {
         self.dynamic_peer_count = self.dynamic_peer_count.saturating_sub(1);
     }
 
+    /// Candidates for the `bgp:neighbor` dynamic completion (`show ip
+    /// bgp neighbors <X>`, `clear bgp <afi> neighbor <X>`): every
+    /// address-keyed peer plus the configured `interface-neighbor`
+    /// names — interface-keyed (unnumbered) peers have no typeable
+    /// address, the interface name IS their CLI identity.
     pub fn peer_comps(&self) -> Vec<String> {
         self.peers
             .keys()
-            .map(|addr| addr.to_string().clone())
+            .map(|addr| addr.to_string())
+            .chain(self.interface_neighbors.keys().cloned())
             .collect()
     }
 

--- a/zebra-rs/src/bgp/interface_neighbor.rs
+++ b/zebra-rs/src/bgp/interface_neighbor.rs
@@ -114,6 +114,10 @@ pub fn materialize_peer(
     );
     peer.tracing_instance = bgp.tracing.clone();
     peer.origin = PeerOrigin::Interface { ifindex };
+    // The operator-facing identity for show/clear output and lookups
+    // (`show bgp summary`, `show ip bgp neighbors i1`, …) — the
+    // link-local in `address` is not something the operator can name.
+    peer.ifname = Some(name.to_string());
     // Required for the kernel connect(2) to a fe80:: target —
     // SocketAddrV6 without a scope_id returns EINVAL. The connect
     // path in `peer_start_connection` reads this back out and

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -623,6 +623,14 @@ pub struct Peer {
     /// for address-keyed peers — `connect(2)` treats the v4/v6 global
     /// case fine without it.
     pub scope_id: Option<u32>,
+    /// Interface name for an interface-keyed (IPv6 unnumbered) peer —
+    /// the operator-typed `interface-neighbor` list key, captured at
+    /// materialization. It is the peer's operator-facing identity in
+    /// `show`/`clear` output and lookups: the remote link-local in
+    /// `address` is kernel-assigned and can change between RAs, so it
+    /// is not something the operator can name. `None` for
+    /// address-keyed peers.
+    pub ifname: Option<String>,
     pub router_id: Ipv4Addr,
     pub local_identifier: Option<Ipv4Addr>,
     pub remote_id: Ipv4Addr,
@@ -782,6 +790,7 @@ impl Peer {
             ctx,
             origin: PeerOrigin::Static,
             scope_id: None,
+            ifname: None,
             active: false,
             // Fail open until the instance computes connectedness from
             // interface-address events (see `shared_network`).
@@ -850,6 +859,17 @@ impl Peer {
 
     pub fn is_passive(&self) -> bool {
         self.config.transport.passive
+    }
+
+    /// Operator-facing identity for `show`/`clear`: the interface name
+    /// for an unnumbered (interface-keyed) peer, the remote address
+    /// otherwise. FRR renders unnumbered peers the same way in
+    /// `show bgp summary`.
+    pub fn display_name(&self) -> String {
+        match &self.ifname {
+            Some(name) => name.clone(),
+            None => self.address.to_string(),
+        }
     }
 
     // ---- effective (instance ∪ per-neighbor) tracing checks --------
@@ -2523,15 +2543,25 @@ pub fn clear_bgp_action(
         return Ok("%% EVPN soft-in is not yet implemented".to_string());
     }
 
-    let targets: Vec<IpAddr> = if target == "all" {
+    // Resolve to peer idents, not addresses: interface-keyed (IPv6
+    // unnumbered) peers are not reachable via the address map — their
+    // CLI identity is the `interface-neighbor` name, and `all` must
+    // cover them too (hence `iter_all`).
+    let targets: Vec<usize> = if target == "all" {
         bgp.peers
-            .iter()
-            .filter_map(|(_, p)| p.is_afi_safi(afi, safi).then_some(p.address))
+            .iter_all()
+            .filter_map(|(_, p)| p.is_afi_safi(afi, safi).then_some(p.ident))
             .collect()
     } else {
         match target.parse::<IpAddr>() {
-            Ok(addr) => vec![addr],
-            Err(_) => return Ok(format!("invalid peer or 'all': {}", target)),
+            Ok(addr) => bgp.peers.get(&addr).map(|p| p.ident).into_iter().collect(),
+            Err(_) => bgp
+                .peers
+                .iter_all()
+                .filter_map(|(_, p)| {
+                    (p.ifname.as_deref() == Some(target.as_str())).then_some(p.ident)
+                })
+                .collect(),
         }
     };
 
@@ -2539,10 +2569,7 @@ pub fn clear_bgp_action(
         return Ok("%% no matching peers".to_string());
     }
 
-    for addr in &targets {
-        let Some(peer_idx) = bgp.peers.get(addr).map(|p| p.ident) else {
-            continue;
-        };
+    for &peer_idx in &targets {
         match op {
             BgpClearOp::Hard => {
                 let _ = bgp.tx.try_send(Message::Event(peer_idx, Event::Stop));

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -108,9 +108,11 @@ fn afi_safi_summary_label(afi: Afi, safi: Safi) -> &'static str {
 /// Collect the set of AFI/SAFIs that are configured on at least one peer,
 /// sorted deterministically by `(afi, safi)` ascending. Falls back to
 /// `[IPv4 Unicast]` when no peer has explicitly configured an AFI/SAFI.
+/// `iter_all` so interface-keyed (IPv6 unnumbered) peers contribute
+/// their families too — every peer is born with IPv4 unicast enabled.
 fn configured_afi_safis<V: BgpShowView>(bgp: &V) -> Vec<AfiSafi> {
     let mut set: std::collections::BTreeSet<AfiSafi> = std::collections::BTreeSet::new();
-    for (_, peer) in bgp.peers().iter() {
+    for (_, peer) in bgp.peers().iter_all() {
         for (afi_safi, _) in peer.config.mp.0.iter() {
             set.insert(*afi_safi);
         }
@@ -195,7 +197,9 @@ fn write_summary_peer_row(buf: &mut String, peer: &Peer, afi: Afi, safi: Safi) -
     writeln!(
         buf,
         "{:16}{:>1}{:>11}{:>10}{:>10}{:>9}{:>5}{:>5}{:>9} {:<11} {:>10} {}",
-        peer.address.to_string(),
+        // Interface name for unnumbered peers (FRR-style), remote
+        // address otherwise.
+        peer.display_name(),
         "4",
         peer.remote_as,
         msg_rcvd,
@@ -225,10 +229,12 @@ fn write_summary_section<V: BgpShowView>(
     let rib_entries = rib_entries_count(bgp, &afi_safi);
     // Only the neighbors with this AFI/SAFI enabled appear in the
     // section, so `show bgp summary` reads as the concatenation of
-    // the per-AFI commands (`show bgp ipv4 summary`, …).
+    // the per-AFI commands (`show bgp ipv4 summary`, …). `iter_all`
+    // so interface-keyed (IPv6 unnumbered) peers are listed too —
+    // the address-keyed `iter` would hide them entirely.
     let peers: Vec<&Peer> = bgp
         .peers()
-        .iter()
+        .iter_all()
         .filter(|(_, peer)| peer.config.mp.has(&afi_safi))
         .map(|(_, peer)| peer)
         .collect();
@@ -378,7 +384,13 @@ struct BgpAfiSafiSummaryJson {
 
 #[derive(Serialize)]
 struct BgpPeerSummaryJson {
+    /// Operator-facing identity: the remote address, or the interface
+    /// name for an unnumbered peer (matching the text renderer).
     neighbor: String,
+    /// Set (to the interface name) only for interface-keyed (IPv6
+    /// unnumbered) peers — its presence marks the row as unnumbered.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    interface: Option<String>,
     remote_as: u32,
     msg_rcvd: u64,
     msg_sent: u64,
@@ -1604,7 +1616,8 @@ fn summary_peer_row_json(peer: &Peer, afi: Afi, safi: Safi) -> BgpPeerSummaryJso
     };
 
     BgpPeerSummaryJson {
-        neighbor: peer.address.to_string(),
+        neighbor: peer.display_name(),
+        interface: peer.ifname.clone(),
         remote_as: peer.remote_as,
         msg_rcvd,
         msg_sent,
@@ -1618,9 +1631,11 @@ fn summary_peer_row_json(peer: &Peer, afi: Afi, safi: Safi) -> BgpPeerSummaryJso
 fn summary_section_json<V: BgpShowView>(bgp: &V, afi_safi: AfiSafi) -> BgpAfiSafiSummaryJson {
     BgpAfiSafiSummaryJson {
         afi_safi: afi_safi_summary_label(afi_safi.afi, afi_safi.safi).to_string(),
+        // `iter_all` for the same reason as the text renderer:
+        // interface-keyed (unnumbered) peers must be listed.
         peers: bgp
             .peers()
-            .iter()
+            .iter_all()
             .filter(|(_, peer)| peer.config.mp.has(&afi_safi))
             .map(|(_, peer)| summary_peer_row_json(peer, afi_safi.afi, afi_safi.safi))
             .collect(),
@@ -1714,6 +1729,12 @@ fn show_bgp_evpn_summary(
 #[derive(Serialize, Debug)]
 struct Neighbor<'a> {
     address: IpAddr,
+    /// Interface name for an interface-keyed (IPv6 unnumbered) peer.
+    /// Drives the FRR-style `BGP neighbor on <ifname>: <link-local>`
+    /// header form; serialized so JSON consumers can tell an
+    /// unnumbered peer from an address-configured one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    interface: Option<&'a str>,
     peer_type: &'a str,
     local_as: u32,
     remote_as: u32,
@@ -1913,6 +1934,7 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
 
     let mut n = Neighbor {
         address: peer.address,
+        interface: peer.ifname.as_deref(),
         remote_as: peer.remote_as,
         local_as: peer.local_as,
         peer_type: peer.peer_type.to_str(),
@@ -2002,16 +2024,23 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
         );
     }
 
+    // FRR-style identity line: an unnumbered peer is named by its
+    // interface, with the RA-learned link-local alongside.
+    let identity = match neighbor.interface {
+        Some(ifname) => format!("on {}: {}", ifname, neighbor.address),
+        None => format!("is {}", neighbor.address),
+    };
+
     writeln!(
         out,
-        r#"BGP neighbor is {}, remote AS {}, local AS {}, {} link
+        r#"BGP neighbor {}, remote AS {}, local AS {}, {} link
 {}  BGP version 4, remote router ID {}, local router ID {}
   BGP state = {}, up for {}
   Last read 00:00:00, Last write 00:00:00
   Hold time {} seconds, keepalive {} seconds
   Sent Hold time {} seconds, sent keepalive {} seconds
   Recv Hold time {} seconds, Recieved keepalive {} seconds"#,
-        neighbor.address,
+        identity,
         neighbor.remote_as,
         neighbor.local_as,
         neighbor.peer_type,
@@ -2559,26 +2588,37 @@ fn show_bgp_neighbor<V: BgpShowView>(
             render(&mut out, neighbor)?;
         }
     } else {
-        if let Some(addr) = args.addr() {
-            if let Some(peer) = bgp.peers().get(&addr) {
-                let neighbor = fetch(peer);
-                if json {
-                    return Ok(serde_json::to_string_pretty(&neighbor).unwrap_or_else(|e| {
-                        format!("{{\"error\": \"Failed to serialize: {}\"}}", e)
-                    }));
-                }
-                render(&mut out, &neighbor)?;
-            } else {
-                if json {
-                    return Ok(format!("{{\"error\": \"No such neighbor: {}\"}}", addr));
-                }
-                writeln!(out, "% No such neighbor: {}", addr)?;
-            }
-        } else {
+        let Some(target) = args.string() else {
             if json {
                 return Ok(String::from("{\"error\": \"Invalid address specified\"}"));
             }
             writeln!(out, "% Invalid address specified")?;
+            return Ok(out);
+        };
+        // An address selects an address-keyed peer; anything else is
+        // taken as an `interface-neighbor` name (IPv6 unnumbered) —
+        // those peers are keyed by ifindex and their link-local isn't
+        // an identity the operator can type.
+        let peer = match target.parse::<IpAddr>() {
+            Ok(addr) => bgp.peers().get(&addr),
+            Err(_) => bgp
+                .peers()
+                .iter_all()
+                .map(|(_, peer)| peer)
+                .find(|peer| peer.ifname.as_deref() == Some(target.as_str())),
+        };
+        if let Some(peer) = peer {
+            let neighbor = fetch(peer);
+            if json {
+                return Ok(serde_json::to_string_pretty(&neighbor)
+                    .unwrap_or_else(|e| format!("{{\"error\": \"Failed to serialize: {}\"}}", e)));
+            }
+            render(&mut out, &neighbor)?;
+        } else {
+            if json {
+                return Ok(format!("{{\"error\": \"No such neighbor: {}\"}}", target));
+            }
+            writeln!(out, "% No such neighbor: {}", target)?;
         }
     }
     Ok(out)
@@ -3108,6 +3148,153 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
         assert_eq!(
             afi_safi_summary_label(Afi::Ip, Safi::MplsVpn),
             "VPNv4 Unicast"
+        );
+    }
+
+    use std::collections::VecDeque;
+
+    use super::super::peer_key::{PeerKey, PeerOrigin};
+
+    struct TestView {
+        rib: LocalRib,
+        peers: PeerMap,
+    }
+    impl BgpShowView for TestView {
+        fn local_rib(&self) -> &LocalRib {
+            &self.rib
+        }
+        fn peers(&self) -> &PeerMap {
+            &self.peers
+        }
+        fn router_id(&self) -> Ipv4Addr {
+            Ipv4Addr::new(1, 1, 1, 1)
+        }
+        fn asn(&self) -> u32 {
+            65001
+        }
+    }
+
+    fn make_peer(addr: IpAddr) -> Peer {
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        // The renderers never touch sockets; a parked ProtoContext over
+        // a leaked inbound channel is enough (same as the PeerMap tests).
+        let (inbound_tx, inbound_rx) = tokio::sync::mpsc::unbounded_channel();
+        Box::leak(Box::new(inbound_rx));
+        let rib = crate::rib::client::RibClient::new(
+            inbound_tx,
+            crate::rib::client::ProtoId::from_raw(0),
+        );
+        let ctx = crate::context::ProtoContext::default_table(rib);
+        Peer::new(
+            0,
+            65001,
+            Ipv4Addr::new(1, 1, 1, 1),
+            65002,
+            addr,
+            None,
+            tx,
+            ctx,
+        )
+    }
+
+    /// One address-keyed peer (10.0.0.9) and one interface-keyed
+    /// (unnumbered, `i1`) peer whose remote address is an RA-learned
+    /// link-local.
+    fn view_with_unnumbered_peer() -> TestView {
+        let mut peers = PeerMap::new();
+        let addr: IpAddr = Ipv4Addr::new(10, 0, 0, 9).into();
+        peers.insert(addr, make_peer(addr));
+
+        let link_local: IpAddr = "fe80::2".parse().unwrap();
+        let mut iface_peer = make_peer(link_local);
+        iface_peer.origin = PeerOrigin::Interface { ifindex: 7 };
+        iface_peer.ifname = Some("i1".to_string());
+        peers.insert_with_key(PeerKey::Interface(7), iface_peer);
+
+        TestView {
+            rib: LocalRib::default(),
+            peers,
+        }
+    }
+
+    /// Interface-keyed (IPv6 unnumbered) peers were invisible to every
+    /// summary: the renderers iterated the address-keyed `iter()`. They
+    /// must be listed — identified by interface name, FRR-style — and
+    /// counted.
+    #[test]
+    fn summary_lists_interface_keyed_peer() {
+        let view = view_with_unnumbered_peer();
+        let out = show_bgp_summary(&view, Args(VecDeque::new()), false).unwrap();
+
+        assert!(
+            out.lines().any(|l| l.starts_with("i1 ")),
+            "unnumbered peer must appear under its interface name:\n{out}"
+        );
+        assert!(
+            out.lines().any(|l| l.starts_with("10.0.0.9 ")),
+            "address-keyed peer row must be unaffected:\n{out}"
+        );
+        assert!(out.contains("Peers 2"), "both peers counted:\n{out}");
+        assert!(
+            out.contains("Total number of neighbors 2"),
+            "trailer counts both peers:\n{out}"
+        );
+    }
+
+    /// JSON summary: the unnumbered row is identified by the interface
+    /// name and carries an `interface` field marking its provenance;
+    /// address-keyed rows must not grow one.
+    #[test]
+    fn summary_json_marks_unnumbered_peer() {
+        let view = view_with_unnumbered_peer();
+        let out = show_bgp_summary(&view, Args(VecDeque::new()), true).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+
+        let peers = v["afi_safis"][0]["peers"]
+            .as_array()
+            .expect("ipv4-unicast section with peers");
+        assert_eq!(peers.len(), 2, "both peers listed: {out}");
+
+        let iface = peers
+            .iter()
+            .find(|p| p["neighbor"] == "i1")
+            .expect("unnumbered peer keyed by interface name");
+        assert_eq!(iface["interface"], "i1");
+
+        let addr = peers
+            .iter()
+            .find(|p| p["neighbor"] == "10.0.0.9")
+            .expect("address-keyed peer");
+        assert!(addr.get("interface").is_none());
+    }
+
+    /// `show ip bgp neighbors <name>` resolves an `interface-neighbor`
+    /// name (the completion offers them) and renders the FRR-style
+    /// `BGP neighbor on <ifname>: <link-local>` identity; address
+    /// lookups and the no-match error keep their existing forms.
+    #[test]
+    fn neighbor_show_accepts_interface_name() {
+        let view = view_with_unnumbered_peer();
+
+        let out =
+            show_bgp_neighbor(&view, Args(VecDeque::from(["i1".to_string()])), false).unwrap();
+        assert!(
+            out.contains("BGP neighbor on i1: fe80::2"),
+            "interface identity line:\n{out}"
+        );
+
+        let out = show_bgp_neighbor(&view, Args(VecDeque::from(["10.0.0.9".to_string()])), false)
+            .unwrap();
+        assert!(
+            out.contains("BGP neighbor is 10.0.0.9"),
+            "address identity line unchanged:\n{out}"
+        );
+
+        let out =
+            show_bgp_neighbor(&view, Args(VecDeque::from(["nope".to_string()])), false).unwrap();
+        assert!(
+            out.contains("% No such neighbor: nope"),
+            "unknown name reports cleanly:\n{out}"
         );
     }
 }

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -371,11 +371,36 @@ fn entry_match_type(entry: &Rc<Entry>, input: &str, m: &mut Match, s: &mut State
 
     if let Some(node) = &entry.type_node {
         if node.kind == YangType::Union {
+            // Match every arm into a side `Match`, then fold the best
+            // result into `m` as a single candidate. Arms of one union
+            // leaf are alternative spellings of the same command
+            // position, so two arms accepting the same token must not
+            // read as an ambiguous command — an address input matches
+            // both its address arm and a catch-all `string` arm (both
+            // Partial; the scalar matchers never return Exact), which
+            // per-arm counting would reject as Ambiguous. `last_match`
+            // carries the winning arm's comp name so an enum arm still
+            // canonicalizes abbreviations via `matched_enumeration`,
+            // and every matching arm's completion hint is kept for
+            // interactive display.
+            let mut um = Match::default();
             for n in node.union.iter() {
                 let kind = ytype_from_typedef(&n.typedef).unwrap_or(n.kind);
                 if let Some(f) = matcher.get(&kind) {
-                    f(m, entry, input, n);
+                    f(&mut um, entry, input, n);
                 }
+            }
+            if um.matched_type > MatchType::None {
+                if um.matched_type > m.matched_type {
+                    m.count = 1;
+                    m.pos = um.pos;
+                    m.matched_type = um.matched_type;
+                    m.matched_entry = entry.clone();
+                    m.last_match = um.last_match.clone();
+                } else if um.matched_type == m.matched_type {
+                    m.count += 1;
+                }
+                m.comps.append(&mut um.comps);
             }
         } else {
             let kind = ytype_from_typedef(&node.typedef).unwrap_or(node.kind);
@@ -972,6 +997,21 @@ mod tests {
                 "/clear/bgp/evpn/neighbor",
                 vec!["all"],
             ),
+            // Interface-neighbor names (IPv6 unnumbered peers have no
+            // typeable address). The pattern-less string arm of
+            // `peer-id-or-all` must word-match a single token, so the
+            // walk continues into `soft out`; `all` and address
+            // spellings above pin that the new arm doesn't shadow them.
+            (
+                "clear bgp ipv4 neighbor i1",
+                "/clear/bgp/ipv4/neighbor",
+                vec!["i1"],
+            ),
+            (
+                "clear bgp ipv4 i1 soft out",
+                "/clear/bgp/ipv4/neighbor/soft/out",
+                vec!["i1"],
+            ),
         ];
 
         for &(cmd, want_path, ref want_args) in &cases {
@@ -1065,6 +1105,54 @@ mod tests {
         ] {
             let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
             assert_eq!(code, ExecCode::Success, "`{cmd}` must parse");
+        }
+    }
+
+    /// `show ip bgp neighbors <X>` accepts an `interface-neighbor` name
+    /// — IPv6 unnumbered peers are keyed by interface, and the
+    /// `bgp:neighbor` dynamic completion offers those names, so the
+    /// execute path (which never sees dynamic candidates) must parse
+    /// them through the key's string arm. The arm is pattern-less so it
+    /// word-matches one token: trailing keywords like
+    /// `advertised-routes` must keep parsing. Address spellings keep
+    /// resolving because the union folds its arms into a single match
+    /// candidate — an address tying the catch-all string arm (both
+    /// Partial) is one leaf match, not an ambiguous command.
+    #[test]
+    fn show_ip_bgp_neighbors_interface_name() {
+        use crate::config::path_from_command;
+        let entry = exec_entry();
+
+        let cases: Vec<(&str, &str, Vec<&str>)> = vec![
+            (
+                "show ip bgp neighbors i1",
+                "/show/ip/bgp/neighbors",
+                vec!["i1"],
+            ),
+            (
+                "show ip bgp neighbors i1 advertised-routes",
+                "/show/ip/bgp/neighbors/advertised-routes",
+                vec!["i1"],
+            ),
+            (
+                "show ip bgp neighbors 10.0.0.1",
+                "/show/ip/bgp/neighbors",
+                vec!["10.0.0.1"],
+            ),
+            (
+                "show ip bgp neighbors 2001:db8::1",
+                "/show/ip/bgp/neighbors",
+                vec!["2001:db8::1"],
+            ),
+        ];
+
+        for &(cmd, want_path, ref want_args) in &cases {
+            let (code, _comps, state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(code, ExecCode::Success, "parse `{cmd}`");
+            let (path, args) = path_from_command(&state.paths);
+            assert_eq!(path, want_path, "path for `{cmd}`");
+            let got: Vec<&str> = args.0.iter().map(|s| s.as_str()).collect();
+            assert_eq!(&got, want_args, "args for `{cmd}`");
         }
     }
 

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -359,10 +359,21 @@ module exec {
           key name;
           leaf name {
             ext:dynamic "bgp:neighbor";
-            // Accept either family — peers are keyed by `IpAddr`.
+            // Accept either address family (peers are keyed by
+            // `IpAddr`) or an `interface-neighbor` name — IPv6
+            // unnumbered peers are keyed by interface, so the name is
+            // their only typeable identity. The string arm is
+            // pattern-less on purpose: a bare string word-matches one
+            // token (a pattern would full-match the remaining LINE and
+            // break `neighbors i1 advertised-routes`). Address inputs
+            // tie the string arm (both Partial), which is safe: the
+            // parser folds a union's arms into a single match
+            // candidate, and the consumed token is the same either
+            // way.
             type union {
               type inet:ipv4-address;
               type inet:ipv6-address;
+              type string;
             }
           }
           leaf rtcv4 {

--- a/zebra-rs/yang/zebra-bgp-clear.yang
+++ b/zebra-rs/yang/zebra-bgp-clear.yang
@@ -33,8 +33,9 @@ module zebra-bgp-clear {
        /clear/bgp/<afi>/neighbor/soft/in          soft, inbound only
        /clear/bgp/<afi>/neighbor/soft/out         soft, outbound only
 
-     The list key on `neighbor` is a `peer-id-or-all` — either the peer's
-     IP literal, or the keyword `all` to target every peer at that AFI.";
+     The list key on `neighbor` is a `peer-id-or-all` — the peer's IP
+     literal, an `interface-neighbor` name (IPv6 unnumbered), or the
+     keyword `all` to target every peer at that AFI.";
 
   /* =========================================================
    * Types
@@ -42,7 +43,9 @@ module zebra-bgp-clear {
 
   typedef peer-id-or-all {
     description
-      "BGP peer address (IPv4 or IPv6), or the literal `all` meaning
+      "BGP peer address (IPv4 or IPv6), an `interface-neighbor` name
+       (IPv6 unnumbered peers are keyed by interface — the name is
+       their only typeable identity), or the literal `all` meaning
        every peer at the enclosing AFI/SAFI. The same typedef is used
        across all four AFI containers — under vpnv4 the runtime only
        resolves IPv4 transports (and reports `peer not found` for IPv6
@@ -59,6 +62,12 @@ module zebra-bgp-clear {
       type enumeration {
         enum all;
       }
+      // Interface-neighbor names. Pattern-less so it word-matches a
+      // single token (`clear bgp ipv4 neighbor i1 soft out` keeps
+      // walking into `soft`); addresses and the full `all` keyword
+      // still win over it via Exact-over-Partial. Listed last so the
+      // typed arms get first shot.
+      type string;
     }
   }
 


### PR DESCRIPTION
## Problem

Interface-keyed (IPv6 unnumbered) BGP peers never appeared in any `show bgp summary` flavor — the renderers iterate the address-keyed `PeerMap::iter()`, which deliberately skips `PeerKey::Interface`. They were also missing from the `bgp:neighbor` dynamic completion, and there was no way to name them in `show ip bgp neighbors <X>` / `clear bgp <afi> neighbor <X>` (their remote link-local is kernel-assigned and not something an operator can type).

## What changed

**Summary visibility (text + JSON, all-AFI and per-AFI):**
- `Peer` grows `ifname`, captured at `interface-neighbor` materialization.
- `configured_afi_safis`, `write_summary_section`, and `summary_section_json` switch to `iter_all()`.
- The Neighbor column renders the interface name for unnumbered peers (FRR-style); JSON rows gain an `interface` field marking unnumbered provenance. Unnumbered peers appear under **IPv4 Unicast** (every peer is born with IPv4-unicast enabled, carried over the v6 link-local session via ENHE).
- `show ip bgp neighbors` renders `BGP neighbor on <ifname>: <link-local>` for unnumbered peers and serializes `interface` in JSON.

**Completion + by-name lookups:**
- `peer_comps()` chains the configured `interface-neighbor` names into the `bgp:neighbor` completion.
- The `neighbors` key in exec.yang and the `peer-id-or-all` typedef in zebra-bgp-clear.yang gain a pattern-less `string` union arm so completed names parse at execute time (the execute path never sees dynamic candidates). Pattern-less is load-bearing: a pattern arm full-matches the remaining LINE and would break `neighbors i1 advertised-routes` / `i1 soft out`.
- The parser now folds a union's arms into a **single match candidate**: an address input tying the catch-all string arm (both `Partial` — the scalar matchers never return `Exact`) is one leaf match, not an ambiguous command. Enum canonicalization (`summ` → `summary`, `all`) is preserved via `last_match`.
- `clear_bgp_action` resolves targets to peer idents: interface names work, `all` now covers interface-keyed peers, and the cleared-count reflects peers actually resolved.

**BDD (plus two latent harness traps this exposed):**
- New scenario asserts summary visibility and by-name show against the live daemon, and that the row disappears when the interface-neighbor is removed.
- `show command` step strings must contain the literal `show` (vtyctl sends the quoted command verbatim as the exec line; the old form returned empty output — which also made negative assertions pass vacuously).
- `wait_seconds` now stacks `#[given]/#[when]/#[then]`: cucumber-rs binds steps to their attribute keyword, so `And I wait 5 seconds` after a `Then` silently skipped — along with **everything after it in the scenario**. This resurrects the feature's two route-exchange assertions, which had never actually run. They pass.

## Testing

- `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude bdd` all green.
- New unit tests: summary text/JSON listing + ifname identity (`summary_tests`), grammar pins for `show ip bgp neighbors i1` (incl. trailing keyword + address regressions) and `clear bgp ipv4 [neighbor] i1 [soft out]` (incl. `all`/address regressions).
- `make bgp_unnumbered_neighbor` green end-to-end: 5 scenarios, 36 steps, all passed (binary md5 verified unchanged across the run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)