### PR TITLE
config: move the global router-id under the system container

### DIFF
--- a/book/src/ch-00-02-router-id.md
+++ b/book/src/ch-00-02-router-id.md
@@ -22,16 +22,16 @@ Once a router-id has been selected it is *sticky*: if the address it was derived
 
 ## Configuring the global Router-ID
 
-The automatic pick can be overridden with the top-level `router-id` command:
+The automatic pick can be overridden with the `system router-id` command:
 
 ```
-set router-id 10.255.0.1
+set system router-id 10.255.0.1
 ```
 
 The configured value always wins over the automatic pick. Deleting it falls back to the automatic selection again:
 
 ```
-delete router-id 10.255.0.1
+delete system router-id 10.255.0.1
 ```
 
 The effective value and its origin are visible with `show router-id`:
@@ -39,7 +39,7 @@ The effective value and its origin are visible with `show router-id`:
 ```
 > show router-id
 Router ID: 10.255.0.1 (configured)
-> delete router-id 10.255.0.1
+> delete system router-id 10.255.0.1
 > show router-id
 Router ID: 192.0.2.200 (automatic)
 ```

--- a/book/src/ch-02-00-what-is-bgp.md
+++ b/book/src/ch-02-00-what-is-bgp.md
@@ -21,7 +21,7 @@ commit
 
 `global router-id` sets the BGP Identifier carried in OPEN messages.
 It is optional: when not configured, the RIB-distributed router-id
-(the system-wide selection, or the configured top-level `router-id`)
+(the system-wide selection, or the configured `system router-id`)
 is used, and deleting the BGP-local value falls back to it. See
 [Selection of the Router-ID](ch-00-02-router-id.md) for the full
 selection and precedence model. Earlier releases named this leaf

--- a/book/src/ch-07-00-isis.md
+++ b/book/src/ch-07-00-isis.md
@@ -36,7 +36,7 @@ set router isis te-router-id 1.1.1.1
 ```
 
 When `te-router-id` is not configured, the RIB-distributed router-id
-(the system-wide selection, or the configured top-level `router-id`)
+(the system-wide selection, or the configured `system router-id`)
 is advertised instead. Setting or deleting `te-router-id`
 re-originates the self LSP immediately, so the change propagates
 without waiting for the refresh timer. A per-VRF instance accepts

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1985,7 +1985,7 @@ impl Bgp {
                 self.refresh_connected();
             }
             RibRx::RouterIdUpdate(router_id) => {
-                // RIB-derived router-id (top-level `router-id` config
+                // RIB-derived router-id (`system router-id` config
                 // or the automatic pick from interface addresses).
                 // Without this arm BGP emitted OPEN with 0.0.0.0 in
                 // the BGP Identifier whenever the operator hadn't

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1380,6 +1380,48 @@ mod yang_load_tests {
         );
     }
 
+    /// The global Router-ID override moved from the top level
+    /// (`router-id A.B.C.D`) under the `system` container
+    /// (`system router-id A.B.C.D`); the RIB dispatch in
+    /// `rib/inst.rs` matches the literal `/system/router-id` path.
+    /// Pin both directions at the grammar level: the new spelling
+    /// parses, the old top-level one no longer does.
+    #[test]
+    fn global_router_id_moved_under_system() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        let (code, _comps, _state) = parse(
+            "set system router-id 10.255.0.1",
+            entry.clone(),
+            None,
+            State::new(),
+        );
+        assert_eq!(
+            code,
+            ExecCode::Success,
+            "`set system router-id <ipv4>` must be a settable path",
+        );
+
+        let (code, _comps, _state) = parse("set router-id 10.255.0.1", entry, None, State::new());
+        assert_ne!(
+            code,
+            ExecCode::Success,
+            "the pre-move top-level `router-id` spelling must no longer parse",
+        );
+    }
+
     /// A new BGP-neighbor YANG knob must be a *settable* path, not just a
     /// loadable module. Naming it the same as a leaf already present via
     /// `uses ietf-bgp:bgp` makes the augment silently dropped (RFC 7950

--- a/zebra-rs/src/ospf/inst.rs
+++ b/zebra-rs/src/ospf/inst.rs
@@ -5135,7 +5135,7 @@ impl Ospf<Ospfv3> {
     /// router-LSA re-origination) is a follow-up PR.
     fn process_rib_msg(&mut self, msg: RibRx) {
         match msg {
-            // RIB-derived router-id (top-level `router-id` config or
+            // RIB-derived router-id (`system router-id` config or
             // the automatic pick from interface IPv4 addresses).
             // Mirrors the v2 arm: store and refresh, so a configured
             // `router ospfv3 router-id` keeps winning and a config

--- a/zebra-rs/src/rib/inst.rs
+++ b/zebra-rs/src/rib/inst.rs
@@ -2240,7 +2240,7 @@ impl Rib {
             }
             ConfigOp::Set | ConfigOp::Delete => {
                 let (path, args) = path_from_command(&msg.paths);
-                if path.as_str() == "/router-id" {
+                if path.as_str() == "/system/router-id" {
                     let _ = self.router_id_config_exec(args, msg.op);
                 } else if path.as_str().starts_with("/router/static/ipv4/route") {
                     let _ = self.static_v4.exec(path, args, msg.op);

--- a/zebra-rs/src/rib/router_id.rs
+++ b/zebra-rs/src/rib/router_id.rs
@@ -62,7 +62,7 @@ impl Rib {
     /// Recompute the global and every VRF's effective Router ID and
     /// push `RouterIdUpdate` to the affected subscriber sets when a
     /// value moved. Call sites: address add/delete, VRF add, a link
-    /// crossing a VRF boundary, and the `router-id` /
+    /// crossing a VRF boundary, and the `system router-id` /
     /// `vrf <name> router-id` config handlers.
     pub fn router_id_update(&mut self) {
         let vrf_masters: BTreeSet<u32> = self.vrfs.values().map(|v| v.ifindex).collect();
@@ -103,7 +103,7 @@ impl Rib {
         }
     }
 
-    /// Top-level `router-id A.B.C.D` config handler. Set stores the
+    /// `system router-id A.B.C.D` config handler. Set stores the
     /// override, delete clears it back to the automatic pick; either
     /// way the effective value is recomputed and, when it moved,
     /// broadcast to subscribers.

--- a/zebra-rs/yang/config.yang
+++ b/zebra-rs/yang/config.yang
@@ -325,6 +325,18 @@ module config {
           "The name of the host. This name can be a single domain label or the
            fully qualified domain name of the host.";
       }
+      // Global Router ID, `system router-id A.B.C.D` (the equivalent
+      // of FRR/zebra's top-level `router-id`). When set it overrides
+      // the automatic pick (first non-localhost IPv4, loopbacks
+      // preferred — see `rib/router_id.rs`) and is pushed to protocol
+      // subscribers via `RibRx::RouterIdUpdate`; deleting it falls
+      // back to the automatic pick. Protocol-local identifiers
+      // (`router bgp global router-id`, `router ospf router-id`, …)
+      // still apply on their own instances.
+      leaf router-id {
+        ext:help "Global router identifier";
+        type inet:ipv4-address;
+      }
       container dhcp {
         uses "dhcp:dhcp";
       }
@@ -422,18 +434,6 @@ module config {
              aliases) or accidentally collide.";
         }
       }
-    }
-
-    // Global Router ID, FRR/zebra-style `router-id A.B.C.D`. When
-    // set it overrides the automatic pick (first non-localhost IPv4,
-    // loopbacks preferred — see `rib/router_id.rs`) and is pushed to
-    // protocol subscribers via `RibRx::RouterIdUpdate`; deleting it
-    // falls back to the automatic pick. Protocol-local identifiers
-    // (`router bgp global identifier`, `router ospf router-id`, …)
-    // still apply on their own instances.
-    leaf router-id {
-      ext:help "Global router identifier";
-      type inet:ipv4-address;
     }
 
     container router {
@@ -2612,7 +2612,7 @@ module config {
            one from the VRF's member interfaces (loopback-flagged
            members first), falling back to the global effective
            Router ID. Pushed to this VRF's protocol subscribers via
-           RouterIdUpdate, like the top-level `router-id`.";
+           RouterIdUpdate, like the global `system router-id`.";
         type inet:ipv4-address;
       }
       container ipv4 {

--- a/zebra-rs/yang/ietf-bgp@2023-07-05.yang
+++ b/zebra-rs/yang/ietf-bgp@2023-07-05.yang
@@ -304,7 +304,7 @@ module ietf-bgp {
         // zebra-rs divergence from the IETF model: this leaf is named
         // `identifier` upstream. Renamed to `router-id` so the BGP
         // surface matches every other router-id knob in zebra-rs
-        // (top-level `router-id`, `vrf <name> router-id`,
+        // (`system router-id`, `vrf <name> router-id`,
         // `router ospf{,v3} router-id`, `router bgp vrf <n> router-id`).
         leaf router-id {
           type inet:ipv4-address;


### PR DESCRIPTION
## Summary

The global Router-ID override moves from the top level (`router-id A.B.C.D`) into the existing `system` container:

```
set system router-id 10.255.0.1
delete system router-id 10.255.0.1
```

YAML form: `system: {router-id: A.B.C.D}`. Semantics are unchanged — set overrides the automatic pick, delete falls back to it, the effective value is broadcast via `RouterIdUpdate`. `show router-id`, the per-VRF `vrf <name> router-id`, and the protocol-local knobs (`router bgp global router-id`, `router ospf{,v3} router-id`, `router isis te-router-id`) are untouched.

## Changes

- `yang/config.yang` — the `router-id` leaf moves into `container system` (after `hostname`); comments updated.
- `rib/inst.rs` — the RIB config dispatch matches the literal `/system/router-id` path.
- `config/manager.rs` — new `global_router_id_moved_under_system` parse() test pins both directions: the new spelling parses, the old top-level one no longer does (the RIB's string match is invisible to `yang_load_tests`).
- Book chapters (`ch-00-02-router-id`, `ch-02-00-what-is-bgp`, `ch-07-00-isis`) and code/YANG comments referencing the old spelling updated.

## Testing

- `cargo test --workspace --exclude bdd` — green (35 suites, 0 failures).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (changed files touched to defeat the stale lint cache).
- Live smoke test against a debug daemon over a private vty socket:
  - `set system router-id 10.255.0.1` → `show router-id` reports `10.255.0.1 (configured)`
  - `delete system router-id 10.255.0.1` → falls back to `(automatic)`
  - YAML apply with `system: {router-id: 10.99.99.1}` → `(configured)`
  - old `set router-id 1.2.3.4` → parse error; old flat YAML `router-id:` key → loud `unknown key` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)