### PR TITLE
bgp: flatten neighbor-group config level and add per-group afi-safi toggles

### DIFF
--- a/bdd/tests/configs/bgp_neighbor_group/z1-1.yaml
+++ b/bdd/tests/configs/bgp_neighbor_group/z1-1.yaml
@@ -3,10 +3,9 @@ router:
     global:
       as: 65001
       router-id: 192.168.0.1
-    neighbor-groups:
-      neighbor-group:
-      - name: RR
-        remote-as: 65002
+    neighbor-group:
+    - name: RR
+      remote-as: 65002
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_neighbor_group/z1-2.yaml
+++ b/bdd/tests/configs/bgp_neighbor_group/z1-2.yaml
@@ -3,10 +3,9 @@ router:
     global:
       as: 65001
       router-id: 192.168.0.1
-    neighbor-groups:
-      neighbor-group:
-      - name: RR
-        remote-as: 65099
+    neighbor-group:
+    - name: RR
+      remote-as: 65099
     neighbor:
     - remote-address: 192.168.0.2
       afi-safi:

--- a/bdd/tests/configs/bgp_unnumbered_afi_safi/z1-base.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_afi_safi/z1-base.yaml
@@ -1,0 +1,11 @@
+# Phase 1 of the two-step bring-up (same rationale as
+# bgp_unnumbered_neighbor): a bare `router bgp` block with no
+# neighbors. Applying this first spawns the ND subsystem so it learns
+# interface i1 BEFORE the next commit enables RA on it — the
+# per-interface `send-advertisements` callback silently drops if ND
+# hasn't yet learned the link.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 1.1.1.1

--- a/bdd/tests/configs/bgp_unnumbered_afi_safi/z1-full.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_afi_safi/z1-full.yaml
@@ -1,0 +1,47 @@
+# Phase 2: enable RA on i1 and declare the IPv6-unnumbered iBGP
+# session entirely through a neighbor-group — the user-facing shape
+# this feature exercises:
+#
+#   router bgp {
+#     neighbor-group dynamic {
+#       afi-safi ipv4 { enabled true; }
+#       afi-safi ipv6 { enabled true; }
+#     }
+#     interface-neighbor i1 {
+#       neighbor-group dynamic;
+#       remote-as internal;
+#     }
+#   }
+#
+# `remote-as internal` (iBGP, both ends AS 65001) comes from the
+# interface-neighbor itself; the afi-safi set is inherited from the
+# group. One IPv4 /32 (carried via RFC 8950 ENHE over the link-local
+# session) and one IPv6 /128 are originated per router.
+interface:
+- if-name: i1
+  ipv6:
+    router-advertisements:
+      send-advertisements: true
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 1.1.1.1
+    neighbor-group:
+    - name: dynamic
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: ipv6
+        enabled: true
+    interface-neighbor:
+    - interface: i1
+      neighbor-group: dynamic
+      remote-as: internal
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32
+    - name: ipv6
+      network:
+      - prefix: 2001:db8:1::1/128

--- a/bdd/tests/configs/bgp_unnumbered_afi_safi/z1-v4off.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_afi_safi/z1-v4off.yaml
@@ -1,0 +1,40 @@
+# Phase 3: identical to z1-full.yaml except the group's IPv4 opinion
+# flips to `enabled: false`. `vtyctl apply -f` is a declarative
+# whole-config replace (the candidate is cleared and rebuilt from this
+# file), so the file must restate the FULL config — the commit diff
+# against the running config is then exactly one leaf:
+#
+#   set router bgp neighbor-group dynamic afi-safi ipv4 enabled false
+#
+# Deliberately NO session bounce from that change — like the
+# per-neighbor `afi-safi <name> enabled` knob, the new family set is
+# advertised when capabilities are next negotiated; the scenario
+# issues `clear bgp ipv4 neighbor i1` to apply it.
+interface:
+- if-name: i1
+  ipv6:
+    router-advertisements:
+      send-advertisements: true
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 1.1.1.1
+    neighbor-group:
+    - name: dynamic
+      afi-safi:
+      - name: ipv4
+        enabled: false
+      - name: ipv6
+        enabled: true
+    interface-neighbor:
+    - interface: i1
+      neighbor-group: dynamic
+      remote-as: internal
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32
+    - name: ipv6
+      network:
+      - prefix: 2001:db8:1::1/128

--- a/bdd/tests/configs/bgp_unnumbered_afi_safi/z2-base.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_afi_safi/z2-base.yaml
@@ -1,0 +1,7 @@
+# Phase 1 for z2 — mirror of z1-base.yaml; same AS (iBGP via
+# `remote-as internal` in phase 2), different router-id.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 2.2.2.2

--- a/bdd/tests/configs/bgp_unnumbered_afi_safi/z2-full.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_afi_safi/z2-full.yaml
@@ -1,0 +1,30 @@
+# Phase 2 for z2 — mirror of z1-full.yaml (same AS, own router-id and
+# originated prefixes).
+interface:
+- if-name: i1
+  ipv6:
+    router-advertisements:
+      send-advertisements: true
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 2.2.2.2
+    neighbor-group:
+    - name: dynamic
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: ipv6
+        enabled: true
+    interface-neighbor:
+    - interface: i1
+      neighbor-group: dynamic
+      remote-as: internal
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.2/32
+    - name: ipv6
+      network:
+      - prefix: 2001:db8:1::2/128

--- a/bdd/tests/configs/bgp_unnumbered_afi_safi/z2-v4off.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_afi_safi/z2-v4off.yaml
@@ -1,0 +1,31 @@
+# Phase 3 for z2 — mirror of z1-v4off.yaml (full-config restatement
+# with the group's ipv4 opinion flipped to false; see z1-v4off.yaml
+# for why partial files don't work with `vtyctl apply -f`).
+interface:
+- if-name: i1
+  ipv6:
+    router-advertisements:
+      send-advertisements: true
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 2.2.2.2
+    neighbor-group:
+    - name: dynamic
+      afi-safi:
+      - name: ipv4
+        enabled: false
+      - name: ipv6
+        enabled: true
+    interface-neighbor:
+    - interface: i1
+      neighbor-group: dynamic
+      remote-as: internal
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.2/32
+    - name: ipv6
+      network:
+      - prefix: 2001:db8:1::2/128

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -424,10 +424,12 @@ async fn apply_config(world: &mut World, config_file: String, namespace: String)
 }
 
 /// Apply raw config lines (`set …` / `delete …`, `\n`-separated) and commit —
-/// the runtime-reconfiguration sibling of `I apply config`. `vtyctl apply`
-/// with a file is additive, so exercising a runtime *removal* needs an
-/// explicit `delete` line; this is how scenarios prove a knob can be turned
-/// off on a live session, not just left out at startup.
+/// the runtime-reconfiguration sibling of `I apply config`. NOTE the two
+/// steps differ in replace semantics: `vtyctl apply` with a FILE clears the
+/// candidate and rebuilds it from the file (declarative whole-config
+/// replace — a partial file deletes everything it omits), while `-c` lines
+/// are additive against the running config. Use this step for a surgical
+/// runtime `set`/`delete`; keep config files full restatements.
 #[when(expr = "I apply command {string} in namespace {string}")]
 async fn apply_config_command(world: &mut World, command: String, namespace: String) {
     let scoped = world.ns(&namespace);

--- a/bdd/tests/features/bgp_unnumbered_afi_safi.feature
+++ b/bdd/tests/features/bgp_unnumbered_afi_safi.feature
@@ -1,0 +1,105 @@
+@serial
+@bgp_unnumbered_afi_safi
+Feature: BGP neighbor-group afi-safi inheritance on an IPv6 unnumbered iBGP session
+  As a network operator
+  I want an interface-keyed (IPv6 unnumbered) neighbor to inherit its
+  enabled address families from a referenced neighbor-group, so that a
+  fleet of unnumbered peers shares one afi-safi definition — and a
+  later change to the group (disable IPv4) takes effect at the next
+  capability negotiation (`clear bgp`), exactly like the per-neighbor
+  `afi-safi <name> enabled` knob.
+
+  Configuration shape under test (flattened `neighbor-group` list —
+  no `neighbor-groups` container level):
+
+    router bgp {
+      neighbor-group dynamic {
+        afi-safi ipv4 { enabled true; }
+        afi-safi ipv6 { enabled true; }
+      }
+      interface-neighbor i1 {
+        neighbor-group dynamic;
+        remote-as internal;
+      }
+    }
+
+  Test Topology (point-to-point veth, link-local only — no global addrs,
+  both routers in AS 65001, `remote-as internal` = iBGP):
+  ```
+        (i1)                                   (i1)
+    ┌────┴────┐                            ┌────┴────┐
+    │   z1    │────────── P2P ─────────────│   z2    │
+    │ AS65001 │       fe80:: <-> fe80::    │ AS65001 │
+    │ id 1.1. │                            │ id 2.2. │
+    │   1.1   │                            │   2.2   │
+    └─────────┘                            └─────────┘
+  ```
+
+  Config files:
+  - z1-base.yaml / z2-base.yaml: bare `router bgp` block (two-step
+    bring-up so ND learns i1 before RA is enabled — see the files).
+  - z1-full.yaml / z2-full.yaml: RA on, `neighbor-group dynamic` with
+    afi-safi ipv4+ipv6 enabled, `interface-neighbor i1` referencing it
+    with `remote-as internal`, one originated IPv4 /32 and IPv6 /128.
+  - z1-v4off.yaml / z2-v4off.yaml: flip the group's ipv4 opinion to
+    `enabled false` (additive apply overwrites just that leaf).
+
+  Scenario: Setup topology
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I start zebra-rs in namespace "z2"
+    And I apply config "z1-base.yaml" to namespace "z1"
+    And I apply config "z2-base.yaml" to namespace "z2"
+    And I wait 2 seconds
+
+  Scenario: Group-inherited IPv4+IPv6 capabilities negotiate and both families exchange routes
+    Given the test topology exists
+    When I apply config "z1-full.yaml" to namespace "z1"
+    And I apply config "z2-full.yaml" to namespace "z2"
+    Then BGP session in namespace "z1" should eventually be "Established"
+    And BGP session in namespace "z2" should eventually be "Established"
+    And I wait 5 seconds
+    And show command "show ip bgp neighbors i1" in namespace "z1" should contain "IPv4 Unicast: advertised and received"
+    And show command "show ip bgp neighbors i1" in namespace "z1" should contain "IPv6 Unicast: advertised and received"
+    And show command "show ip bgp neighbor-group dynamic" in namespace "z1" should contain "ipv4 enabled, ipv6 enabled"
+    And BGP route in "z2" has "10.0.1.1/32"
+    And BGP route in "z1" has "10.0.1.2/32"
+    And show command "show bgp ipv6" in namespace "z2" should contain "2001:db8:1::1/128"
+    And show command "show bgp ipv6" in namespace "z1" should contain "2001:db8:1::2/128"
+
+  Scenario: Disabling IPv4 in the group applies on clear — IPv6-only session remains
+    Given the test topology exists
+    # The group flip alone must NOT bounce the session; `clear` makes
+    # the new family set negotiate. Clearing z1 is enough to bounce
+    # both ends (z2 sees the TCP close and resets its session state).
+    When I apply config "z1-v4off.yaml" to namespace "z1"
+    And I apply config "z2-v4off.yaml" to namespace "z2"
+    And I wait 2 seconds
+    And I run "clear bgp ipv4 neighbor i1" in namespace "z1"
+    And I wait 3 seconds
+    Then BGP session in namespace "z1" should eventually be "Established"
+    And BGP session in namespace "z2" should eventually be "Established"
+    And I wait 3 seconds
+    # Positive assert first so the not-contains below cannot pass
+    # vacuously on an empty/garbled show output.
+    And show command "show ip bgp neighbors i1" in namespace "z1" should contain "IPv6 Unicast: advertised and received"
+    And show command "show ip bgp neighbors i1" in namespace "z1" should not contain "IPv4 Unicast:"
+    And show command "show ip bgp neighbors i1" in namespace "z2" should not contain "IPv4 Unicast:"
+    And show command "show ip bgp neighbor-group dynamic" in namespace "z1" should contain "ipv4 disabled, ipv6 enabled"
+    # IPv4 routes from the old session were cleaned on the bounce and
+    # must not re-sync on the IPv6-only session; IPv6 routes must.
+    And BGP route in "z2" does not have "10.0.1.1/32"
+    And BGP route in "z1" does not have "10.0.1.2/32"
+    And show command "show bgp ipv6" in namespace "z2" should contain "2001:db8:1::1/128"
+    And show command "show bgp ipv6" in namespace "z1" should contain "2001:db8:1::2/128"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I stop zebra-rs in namespace "z2"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -14,7 +14,9 @@
 ## Routing Protocols
 
 - [BGP](ch-02-00-what-is-bgp.md)
+  - [Neighbor Groups](ch-02-26-bgp-neighbor-group.md)
   - [Dynamic Neighbors](ch-02-01-dynamic-neighbors.md)
+  - [IPv6 Unnumbered (interface-neighbor)](ch-02-27-bgp-unnumbered.md)
   - [Session Authentication (TCP MD5 / TCP-AO)](ch-02-02-tcp-authentication.md)
   - [TTL: eBGP Multihop & Security (GTSM)](ch-02-11-bgp-ttl-security.md)
   - [TCP MSS](ch-02-14-bgp-tcp-mss.md)

--- a/book/src/ch-02-01-dynamic-neighbors.d
+++ b/book/src/ch-02-01-dynamic-neighbors.d
@@ -1,1 +1,0 @@
-# Dyanamic Neighbors

--- a/book/src/ch-02-01-dynamic-neighbors.md
+++ b/book/src/ch-02-01-dynamic-neighbors.md
@@ -1,9 +1,117 @@
 # Dynamic Neighbors
 
-BGP dynamic neighbors, also known as BGP peer groups, allow you to simplify the
-configuration and management of a large number of BGP peers. Instead of
-configuring individual neighbors with their respective IP addresses, you can
-define a peer group with a set of common attributes and policies. Any new
-neighbor that matches the defined criteria will automatically inherit the
-group's configuration.
+A statically configured neighbor names its remote address up front.
+That breaks down when the set of peers is open-ended — a route server,
+a hub router, or a data-center fabric where new leaves appear without
+a config change on the hub. **Dynamic neighbors** invert the model:
+instead of enumerating peers, you authorize a **prefix range**, and any
+BGP speaker that connects *from* an address inside the range is
+accepted and materialized as a peer on the fly. This is the IOS-XR
+`bgp listen range` / FRR `bgp listen range` model.
 
+Because an unknown caller has no per-neighbor configuration of its
+own, every listen-range must name a
+[neighbor-group](ch-02-26-bgp-neighbor-group.md) — that group supplies
+the peer's `remote-as` and its enabled address families.
+
+```
+ ┌─────────┐                ┌─────────┐
+ │  hub    │ ◄───── SYN ─── │ spoke N │   spokes connect in from
+ │ AS65001 │                │ AS65002 │   anywhere in 10.1.0.0/24;
+ └─────────┘                └─────────┘   the hub configures no
+   listen-range 10.1.0.0/24                per-spoke neighbor
+```
+
+Key properties:
+
+- **Passive-only.** A dynamic peer is created when its TCP connection
+  arrives; the local speaker never dials into a listen-range. The
+  synthesized peer is marked passive for its lifetime.
+- **Longest-prefix match.** Ranges may overlap; the most specific
+  prefix that contains the source address wins, so a `/24` carve-out
+  can reference a different group than the surrounding `/8`. IPv4 and
+  IPv6 ranges are looked up per address family.
+- **Bounded.** `listen-limit` (default **100**) caps how many dynamic
+  peers may exist at once; past the cap, further matching connections
+  are dropped at accept time. Setting it to `0` disables the ranges
+  without removing them. A dynamic peer whose session ends is removed
+  again (and frees its slot) rather than lingering in Idle.
+- **Group-driven.** The peer inherits `remote-as` and the `afi-safi`
+  set from the referenced group, with the usual precedence rules —
+  see [Neighbor Groups](ch-02-26-bgp-neighbor-group.md).
+
+## Configuration
+
+The hub above, accepting any caller from `10.1.0.0/24` as an AS-65002
+peer with IPv4 and IPv6 unicast enabled:
+
+```yaml
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 10.0.0.1
+    neighbor-group:
+    - name: SPOKES
+      remote-as: 65002
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: ipv6
+        enabled: true
+    dynamic-neighbors:
+      listen-limit: 200
+      listen-range:
+      - prefix: 10.1.0.0/24
+        neighbor-group: SPOKES
+```
+
+The equivalent CLI forms:
+
+```
+set router bgp dynamic-neighbors listen-limit 200
+set router bgp dynamic-neighbors listen-range 10.1.0.0/24 neighbor-group SPOKES
+```
+
+`neighbor-group` is mandatory on each range. As elsewhere, the
+reference is a plain string: the range can be configured before the
+group exists, and connections simply keep being refused until the
+group (and its `remote-as`) lands.
+
+## Verification
+
+A spoke that has connected shows up like any other peer —
+`show bgp summary`, `show ip bgp neighbors` — identified by its source
+address, and `show ip bgp neighbors <addr>` reports the binding:
+
+```
+  Neighbor-group: SPOKES (remote-as inherited)
+```
+
+The group detail view counts the spokes that are currently
+materialized:
+
+```
+show ip bgp neighbor-group SPOKES
+BGP neighbor-group: SPOKES
+  Remote-AS: 65002
+  Afi-Safi:  ipv4 enabled, ipv6 enabled
+  Members (3):
+    10.1.0.11                remote-as 65002 (inherited) state Established
+    10.1.0.12                remote-as 65002 (inherited) state Established
+    10.1.0.13                remote-as 65002 (inherited) state Established
+```
+
+## Troubleshooting
+
+- **A caller inside the range is refused.** Check `listen-limit` — at
+  the cap, additional connections are silently dropped — and confirm
+  the referenced group exists *and* carries a `remote-as`; a range
+  pointing at an unresolved group accepts nothing.
+- **A caller matches the wrong group.** Overlapping ranges resolve by
+  longest prefix; verify which range actually contains the source
+  address.
+- **The spoke connects but the wrong families negotiate.** Family
+  enablement comes from the group's `afi-safi` list (IPv4 unicast on
+  by default); a change there applies to a live spoke only after the
+  session renegotiates — `clear bgp ipv4 neighbor <addr>`.

--- a/book/src/ch-02-25-bgp-clear.md
+++ b/book/src/ch-02-25-bgp-clear.md
@@ -6,7 +6,7 @@ under the `clear bgp …` tree and take effect immediately — there is no
 `commit`.
 
 ```
-clear bgp <ipv4|ipv6|vpnv4|evpn> <peer-address|all> [soft [in|out]]
+clear bgp <ipv4|ipv6|vpnv4|evpn> <peer-address|ifname|all> [soft [in|out]]
 ```
 
 The peer can be typed straight after the AFI (the FRR spelling), or
@@ -16,11 +16,15 @@ command:
 ```
 zebra# clear bgp ipv4 192.168.0.2
 zebra# clear bgp ipv4 neighbor 192.168.0.2      # same thing
+zebra# clear bgp ipv4 neighbor i1               # unnumbered peer, by interface
 zebra# clear bgp ipv4 all soft out
 ```
 
 `all` targets every established peer that negotiated the given
-AFI/SAFI.
+AFI/SAFI. An interface name selects an
+[IPv6 unnumbered](ch-02-27-bgp-unnumbered.md) peer — its kernel-assigned
+link-local is not something an operator can type, so the interface is
+its CLI identity.
 
 ## Hard clear — bounce the session
 

--- a/book/src/ch-02-26-bgp-neighbor-group.md
+++ b/book/src/ch-02-26-bgp-neighbor-group.md
@@ -1,0 +1,153 @@
+# Neighbor Groups
+
+Configuring many BGP peers that share the same attributes — the same
+remote AS, the same enabled address families — gets repetitive and
+error-prone fast. A **neighbor-group** is a named bundle of those
+attributes, defined once under `router bgp` and referenced by any
+number of peers. It is modelled on the IOS-XR `neighbor-group`, with a
+deliberately focused attribute surface rather than a mirror of every
+per-neighbor leaf.
+
+Three kinds of peer can reference a group:
+
+- a **static neighbor** (`neighbor X neighbor-group G`),
+- an **interface-keyed unnumbered neighbor**
+  ([IPv6 Unnumbered](ch-02-27-bgp-unnumbered.md)),
+- a **dynamic peer** materialized from a listen-range
+  ([Dynamic Neighbors](ch-02-01-dynamic-neighbors.md)) — there the
+  group reference is mandatory, since an unknown caller has no
+  per-neighbor config of its own.
+
+## Attributes and precedence
+
+A group currently carries two things:
+
+- **`remote-as <asn>`** — the AS number a member peers with.
+- **`afi-safi <family> enabled <true|false>`** — per-family toggles,
+  using the same family names as the per-neighbor `afi-safi` list
+  (`ipv4`, `ipv6`, `vpnv4`, `label-v4`, `evpn`, …).
+
+The rule for both is: **anything set explicitly on the neighbor wins;
+otherwise the neighbor inherits from the group.** For address families
+there are three layers, lowest precedence first:
+
+1. the built-in default — every peer starts with **IPv4 unicast
+   enabled**;
+2. the group's `afi-safi` opinions — `enabled true` switches a family
+   on for members, `enabled false` switches it off (this is how a
+   group turns the IPv4-unicast default *off*), and a family the group
+   does not mention is left alone;
+3. an explicit `neighbor X afi-safi <family> enabled <bool>` statement
+   on the peer itself.
+
+So a group with `afi-safi ipv4 enabled false` disables IPv4 unicast
+for its members — except a member that itself carries
+`afi-safi ipv4 enabled true`, which keeps it.
+
+## How changes propagate
+
+The two attributes apply on different schedules, matching what they
+mean on the wire:
+
+- **`remote-as` changes are immediate.** Setting or changing the
+  group's `remote-as` propagates to every member that inherited it
+  (members with their own `remote-as` are untouched). A member whose
+  AS actually changed is bounced so the FSM renegotiates; deleting the
+  group's `remote-as` (or the group) tears inherited members down.
+- **`afi-safi` changes apply at the next capability negotiation.**
+  Like the per-neighbor `afi-safi <family> enabled` knob, flipping a
+  family in the group does *not* bounce established sessions — BGP
+  capabilities are exchanged only in the OPEN message. Issue
+  `clear bgp ipv4 neighbor <X>` when you want a live session to
+  renegotiate with the new family set.
+
+## Configuration
+
+A route-reflector-style example: two clients share the group `RR`,
+which supplies the remote AS and enables IPv4 and IPv6 unicast.
+
+```yaml
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    neighbor-group:
+    - name: RR
+      remote-as: 65002
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: ipv6
+        enabled: true
+    neighbor:
+    - remote-address: 192.168.0.2
+      enabled: true
+      neighbor-group: RR
+    - remote-address: 192.168.0.3
+      enabled: true
+      neighbor-group: RR
+```
+
+Neither neighbor needs its own `remote-as` or `afi-safi` list — both
+come from the group. The equivalent CLI forms:
+
+```
+set router bgp neighbor-group RR
+set router bgp neighbor-group RR remote-as 65002
+set router bgp neighbor-group RR afi-safi ipv4 enabled true
+set router bgp neighbor-group RR afi-safi ipv6 enabled true
+set router bgp neighbor 192.168.0.2 neighbor-group RR
+```
+
+The reference is an ordinary string, not a strict cross-reference —
+`neighbor X neighbor-group G` is accepted before `neighbor-group G`
+exists, so configuration can be staged in any order. A peer whose
+group reference is unresolved (group missing, or present but without a
+`remote-as` when the peer has none of its own) simply stays dormant
+until the group definition lands.
+
+## Verification
+
+`show ip bgp neighbor-group` lists every group with a member count;
+the detail form shows the attribute set and which peers reference it:
+
+```
+show ip bgp neighbor-group
+Name                      Remote-AS  Members
+RR                            65002        2
+```
+
+```
+show ip bgp neighbor-group RR
+BGP neighbor-group: RR
+  Remote-AS: 65002
+  Afi-Safi:  ipv4 enabled, ipv6 enabled
+  Members (2):
+    192.168.0.2              remote-as 65002 (inherited) state Established
+    192.168.0.3              remote-as 65002 (inherited) state Established
+```
+
+`(inherited)` marks members whose AS came from the group rather than a
+per-neighbor `remote-as`. Both commands also have `--json` forms; the
+JSON carries the same `afi_safi` map keyed by family name.
+
+On the member side, `show ip bgp neighbors` reports the binding:
+
+```
+  Neighbor-group: RR (remote-as inherited)
+```
+
+## Troubleshooting
+
+- **A member never leaves Idle.** The group reference is unresolved —
+  the group does not exist yet, or carries no `remote-as` and the peer
+  has none of its own. The daemon logs
+  `neighbor-group reference unresolved … peer stays dormant`.
+- **An afi-safi flip "did nothing".** Capability changes wait for the
+  next OPEN exchange by design. `clear bgp ipv4 neighbor <X>` the
+  member and re-check the `Neighbor Capabilities:` section of
+  `show ip bgp neighbors`.
+- **One member ignores the group's family setting.** That member has
+  its own `afi-safi <family> enabled` statement, which outranks the
+  group. Delete the per-neighbor leaf to fall back to inheritance.

--- a/book/src/ch-02-27-bgp-unnumbered.md
+++ b/book/src/ch-02-27-bgp-unnumbered.md
@@ -1,0 +1,189 @@
+# IPv6 Unnumbered (interface-neighbor)
+
+On a point-to-point fabric link there is often nothing worth
+addressing: no IPv4 subnet, no global IPv6 — just two routers and a
+wire. **IPv6 unnumbered BGP** peers over the link-local addresses that
+every IPv6 interface already has, so a session needs zero address
+planning: you name the **interface**, not the neighbor's address.
+
+zebra-rs surfaces this as a separate `interface-neighbor` list under
+`router bgp` (the IOS-XR shape), rather than overloading `neighbor`
+with interface names:
+
+```
+      (i1)                                   (i1)
+  ┌────┴────┐                            ┌────┴────┐
+  │   z1    │────────── P2P ─────────────│   z2    │
+  │ AS65001 │       fe80:: ↔ fe80::      │ AS65001 │
+  └─────────┘   no IPv4, no global v6    └─────────┘
+```
+
+How a session comes up:
+
+1. Both ends enable **Router Advertisements** on the link. The ND
+   subsystem ingests the neighbor's RA and learns its link-local
+   address.
+2. When an RA arrives on an interface named by an
+   `interface-neighbor` entry, BGP **materializes a peer keyed by that
+   interface**, with the discovered link-local as its remote address.
+3. The session establishes over `fe80::%ifindex`. Both ends dial and
+   accept, so a connection collision is resolved normally (RFC 4271
+   §6.8).
+4. IPv4 routes are carried over the IPv6-only session via **RFC 8950
+   Extended Next Hop Encoding** (ENHE), which interface-keyed peers
+   advertise automatically — an IPv4 NLRI travels with an IPv6
+   link-local next hop. IPv6 routes use the session's link-local as
+   next hop directly.
+
+The discovered link-local is not something an operator can type, so
+the interface name is the peer's CLI identity throughout:
+`show ip bgp neighbors i1`, `clear bgp ipv4 neighbor i1`, and the
+`Neighbor` column of `show bgp summary` all use it.
+
+## remote-as forms
+
+`interface-neighbor <ifname> remote-as` accepts a numeric AS or the
+FRR-style shorthands:
+
+- **`internal`** — the peer is in the local AS (iBGP).
+- **`external`** — any AS other than the local one. Accepted by the
+  schema today, but the OPEN-side AS learning is not wired up yet, so
+  a peer configured this way stays dormant — use a numeric AS or
+  `internal` for now.
+
+Alternatively the AS can come from a referenced
+[neighbor-group](ch-02-26-bgp-neighbor-group.md); a `remote-as` on the
+interface-neighbor itself always wins over the group's.
+
+## Address families come from the group
+
+`interface-neighbor` deliberately carries no per-peer `afi-safi` list.
+A bare entry negotiates the default — IPv4 unicast only. To run IPv6
+(or any other family) on an unnumbered session, reference a
+neighbor-group and set the families there:
+
+```yaml
+interface:
+- if-name: i1
+  ipv6:
+    router-advertisements:
+      send-advertisements: true
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 1.1.1.1
+    neighbor-group:
+    - name: dynamic
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      - name: ipv6
+        enabled: true
+    interface-neighbor:
+    - interface: i1
+      neighbor-group: dynamic
+      remote-as: internal
+    afi-safi:
+    - name: ipv4
+      network:
+      - prefix: 10.0.1.1/32
+    - name: ipv6
+      network:
+      - prefix: 2001:db8:1::1/128
+```
+
+The mirror configuration runs on `z2` (same AS — `remote-as internal`
+makes this an iBGP session — its own router-id and prefixes). The
+equivalent CLI forms:
+
+```
+set interface i1 ipv6 router-advertisements send-advertisements true
+set router bgp neighbor-group dynamic afi-safi ipv4 enabled true
+set router bgp neighbor-group dynamic afi-safi ipv6 enabled true
+set router bgp interface-neighbor i1 neighbor-group dynamic
+set router bgp interface-neighbor i1 remote-as internal
+```
+
+RA send must be enabled on **both** ends — each side materializes its
+peer only when it hears the other side's RA. Routers advertise RAs on
+their own schedule, so allow up to ~16 seconds for first discovery.
+
+## Verification
+
+Once both ends have applied the configuration:
+
+```
+show ip bgp neighbors i1
+BGP neighbor on i1: fe80::8080:9fff:fef9:3fa, remote AS 65001, local AS 65001, internal link
+  Local host: fe80::c49d:fbff:fe08:b421, Local port: 35086
+  Foreign host: fe80::8080:9fff:fef9:3fa, Foreign port: 179
+  BGP version 4, remote router ID 2.2.2.2, local router ID 1.1.1.1
+  BGP state = Established, up for 00:00:03
+  ...
+  Neighbor-group: dynamic
+
+  Neighbor Capabilities:
+    4 Octet AS: advertised and received
+    IPv4 Unicast: advertised and received
+    IPv6 Unicast: advertised and received
+    ...
+```
+
+Both families negotiated, and both tables carry the neighbor's
+prefixes — `show ip bgp` holds `10.0.1.2/32` (learned via ENHE with a
+link-local next hop) and `show bgp ipv6` holds `2001:db8:1::2/128`.
+The unnumbered peer appears as `i1` in `show bgp summary`, and as a
+member in `show ip bgp neighbor-group dynamic`.
+
+## Changing the family set at runtime
+
+Capability changes apply at the next OPEN exchange, so reshaping a
+running fabric is a two-step: flip the group, then clear. To take the
+session above IPv6-only, change the group's IPv4 opinion on both ends:
+
+```
+set router bgp neighbor-group dynamic afi-safi ipv4 enabled false
+```
+
+The established session is deliberately left alone. Now bounce it by
+interface name (one end suffices — the other end sees the connection
+close and renegotiates too):
+
+```
+clear bgp ipv4 neighbor i1
+```
+
+The re-established session advertises only IPv6 unicast — the
+`IPv4 Unicast:` capability line is gone from
+`show ip bgp neighbors i1`, the IPv4 routes learned from the peer were
+withdrawn with the old session and do not return, and the IPv6 routes
+re-sync immediately:
+
+```
+show ip bgp neighbor-group dynamic
+BGP neighbor-group: dynamic
+  Remote-AS: (unset)
+  Afi-Safi:  ipv4 disabled, ipv6 enabled
+  Members (1):
+    i1                       remote-as 65001 state Established
+```
+
+## Troubleshooting
+
+- **No peer ever appears.** The peer is materialized from the
+  neighbor's RA, so check `send-advertisements true` on *both* ends,
+  and that the `interface-neighbor` name matches the actual interface.
+  First discovery can take ~16 seconds (RA timing).
+- **Peer exists but stays down with `remote-as external`.** Expected
+  for now — see [remote-as forms](#remote-as-forms); configure a
+  numeric AS or `internal`.
+- **IPv6 routes don't flow.** The session is IPv4-unicast-only by
+  default; IPv6 must be enabled through the referenced group's
+  `afi-safi ipv6 enabled true` (there is no per-interface-neighbor
+  afi-safi list), and a change only applies after
+  `clear bgp ipv4 neighbor <ifname>`.
+- **IPv4 routes still flow after disabling ipv4 in the group.** The
+  running session negotiated its capabilities at establishment;
+  capability changes wait for the next OPEN exchange. Clear the
+  session.

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -210,10 +210,11 @@ fn clear_peer_listener_auth(bgp: &mut Bgp, addr: &IpAddr) {
 
 /// `set router bgp neighbor <addr> neighbor-group <name>`.
 ///
-/// Stores the reference on the peer's `PeerConfig` and — if the peer
-/// has no explicit `remote-as` yet — pulls the group's `remote-as`
-/// in via [`super::neighbor_group::group_remote_as`] and kicks
-/// [`super::peer::Peer::start`]. An explicit per-peer `remote-as`
+/// Stores the reference on the peer's `PeerConfig`, re-resolves the
+/// effective MP family set against the group's afi-safi opinions, and
+/// — if the peer has no explicit `remote-as` yet — pulls the group's
+/// `remote-as` in via [`super::neighbor_group::group_remote_as`] and
+/// kicks [`super::peer::Peer::start`]. An explicit per-peer `remote-as`
 /// (signalled by `remote_as_inherited == false` and `remote_as != 0`)
 /// always wins; in that case the reference is recorded but the
 /// resolved value is left alone.
@@ -234,6 +235,11 @@ fn config_peer_neighbor_group(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Op
     let (peer_ident, resolve_now, should_stop_inherited) = {
         let peer = bgp.peers.get_mut(&addr)?;
         peer.config.neighbor_group = new_ref.clone();
+        // Re-resolve the effective MP set against the new reference —
+        // Set adopts the group's afi-safi opinions underneath any
+        // explicit per-peer statements; Delete falls back to
+        // default + explicit.
+        super::neighbor_group::recompute_peer_mp(&bgp.neighbor_groups, &mut peer.config);
 
         match op {
             ConfigOp::Set => {
@@ -918,33 +924,32 @@ fn unspecified_for(remote: &IpAddr) -> IpAddr {
 fn config_afi_safi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let key: AfiSafi = args.afi_safi()?;
-    let enabled: bool = args.boolean()?;
+    let enabled = args.boolean();
 
-    let ipv4_unicast = key.afi == Afi::Ip && key.safi == Safi::Unicast;
     // Enabling a Labeled-Unicast or VPN family means we may re-advertise
     // routes with next-hop-self and need per-prefix local labels (the
     // Inter-AS Option B/C transit case); request a dynamic label block
     // eagerly so one is granted before routes arrive. A PE with a VRF
     // already requests the block on VRF config — this also covers a
     // transit ASBR that runs VPNv4 with no VRF of its own.
-    let label_block_needed =
-        matches!(key.safi, Safi::MplsLabel | Safi::MplsVpn) && op.is_set() && enabled;
+    let label_block_needed = matches!(key.safi, Safi::MplsLabel | Safi::MplsVpn)
+        && op.is_set()
+        && enabled.unwrap_or(false);
 
     let peer = bgp.peers.get_mut(&addr)?;
 
+    // Record the verbatim statement, then re-resolve the effective MP
+    // set through the default < group < explicit precedence. A Delete
+    // simply forgets the statement: IPv4 unicast falls back to the
+    // built-in default (or the group's opinion), other families to
+    // off (or the group's opinion).
     if op.is_set() {
-        if enabled {
-            peer.config.mp.set(key, true);
-        } else {
-            peer.config.mp.remove(&key);
-        }
+        peer.config.mp_explicit.insert(key, enabled?);
     } else {
-        if ipv4_unicast {
-            peer.config.mp.set(key, true);
-        } else {
-            peer.config.mp.remove(&key);
-        }
+        peer.config.mp_explicit.remove(&key);
     }
+    super::neighbor_group::recompute_peer_mp(&bgp.neighbor_groups, &mut peer.config);
+
     if label_block_needed {
         bgp.request_label_block();
     }
@@ -2269,18 +2274,26 @@ impl Bgp {
         );
         self.callback_peer("", config_peer);
         self.callback_peer("/remote-as", config_remote_as);
-        // Per-peer reference to a `neighbor-group`. Storage only —
-        // resolution lands in the follow-up that adds field-level
-        // override semantics.
+        // Per-peer reference to a `neighbor-group`: stores the
+        // back-reference and resolves the inheritable attributes
+        // (remote-as, afi-safi).
         self.callback_peer("/neighbor-group", config_peer_neighbor_group);
-        // `set router bgp neighbor-groups neighbor-group <name> [...]`.
+        // `set router bgp neighbor-group <name> [...]`.
         self.callback_add(
-            "/router/bgp/neighbor-groups/neighbor-group",
+            "/router/bgp/neighbor-group",
             super::neighbor_group::config_neighbor_group,
         );
         self.callback_add(
-            "/router/bgp/neighbor-groups/neighbor-group/remote-as",
+            "/router/bgp/neighbor-group/remote-as",
             super::neighbor_group::config_neighbor_group_remote_as,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/afi-safi",
+            super::neighbor_group::config_neighbor_group_afi_safi,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/afi-safi/enabled",
+            super::neighbor_group::config_neighbor_group_afi_safi_enabled,
         );
         // `set router bgp dynamic-neighbors …`.
         self.callback_add(
@@ -4038,6 +4051,199 @@ mod neighbor_group_wiring_tests {
         assert!(
             drain_stop_events(&mut bgp).contains(&peer_ident),
             "Event::Stop must have been enqueued",
+        );
+    }
+
+    // ---- group afi-safi inheritance ------------------------------
+
+    use super::super::neighbor_group::{
+        config_neighbor_group_afi_safi, config_neighbor_group_afi_safi_enabled,
+    };
+
+    fn v4() -> AfiSafi {
+        AfiSafi::new(Afi::Ip, Safi::Unicast)
+    }
+
+    fn v6() -> AfiSafi {
+        AfiSafi::new(Afi::Ip6, Safi::Unicast)
+    }
+
+    fn peer_mp_families(bgp: &Bgp) -> Vec<AfiSafi> {
+        bgp.peers
+            .get(&peer_addr())
+            .expect("peer exists")
+            .config
+            .mp
+            .keys()
+            .copied()
+            .collect()
+    }
+
+    /// Group `afi-safi ipv6 enabled true` flows to a member peer's
+    /// effective MP set reactively (no session bounce — the change is
+    /// advertised at the next capability negotiation), and `enabled
+    /// false` on ipv4 overrides the built-in default.
+    #[tokio::test]
+    async fn group_afi_safi_propagates_to_member() {
+        let mut bgp = fresh_bgp();
+        config_neighbor_group_remote_as(&mut bgp, arg_words(&["G", "65000"]), ConfigOp::Set)
+            .unwrap();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_peer_neighbor_group(&mut bgp, arg_words(&["10.0.0.1", "G"]), ConfigOp::Set).unwrap();
+        let _ = drain_stop_events(&mut bgp);
+
+        config_neighbor_group_afi_safi_enabled(
+            &mut bgp,
+            arg_words(&["G", "ipv6", "true"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert_eq!(peer_mp_families(&bgp), vec![v4(), v6()]);
+
+        config_neighbor_group_afi_safi_enabled(
+            &mut bgp,
+            arg_words(&["G", "ipv4", "false"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert_eq!(peer_mp_families(&bgp), vec![v6()]);
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "afi-safi changes must not bounce the session",
+        );
+    }
+
+    /// An explicit per-peer `afi-safi <name> enabled` statement wins
+    /// over the group's opinion — in either order of arrival.
+    #[tokio::test]
+    async fn peer_explicit_afi_safi_wins_over_group() {
+        let mut bgp = fresh_bgp();
+        config_neighbor_group_remote_as(&mut bgp, arg_words(&["G", "65000"]), ConfigOp::Set)
+            .unwrap();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_peer_neighbor_group(&mut bgp, arg_words(&["10.0.0.1", "G"]), ConfigOp::Set).unwrap();
+
+        // Peer says ipv4 on; a later group opinion of ipv4 off must
+        // not override it.
+        config_afi_safi(
+            &mut bgp,
+            arg_words(&["10.0.0.1", "ipv4", "true"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        config_neighbor_group_afi_safi_enabled(
+            &mut bgp,
+            arg_words(&["G", "ipv4", "false"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert_eq!(peer_mp_families(&bgp), vec![v4()]);
+
+        // Removing the explicit statement lets the group opinion
+        // through.
+        config_afi_safi(
+            &mut bgp,
+            arg_words(&["10.0.0.1", "ipv4", "true"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        assert_eq!(peer_mp_families(&bgp), Vec::<AfiSafi>::new());
+    }
+
+    /// Deleting one group afi-safi entry (or the whole group) drops
+    /// its opinions and the member falls back to the built-in default
+    /// plus its own statements.
+    #[tokio::test]
+    async fn group_afi_safi_delete_restores_default() {
+        let mut bgp = fresh_bgp();
+        config_neighbor_group_remote_as(&mut bgp, arg_words(&["G", "65000"]), ConfigOp::Set)
+            .unwrap();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_peer_neighbor_group(&mut bgp, arg_words(&["10.0.0.1", "G"]), ConfigOp::Set).unwrap();
+        config_neighbor_group_afi_safi_enabled(
+            &mut bgp,
+            arg_words(&["G", "ipv4", "false"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        config_neighbor_group_afi_safi_enabled(
+            &mut bgp,
+            arg_words(&["G", "ipv6", "true"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert_eq!(peer_mp_families(&bgp), vec![v6()]);
+
+        // Whole-entry delete (the per-leaf delete may be skipped by
+        // the commit path — the entry callback must cope alone).
+        config_neighbor_group_afi_safi(&mut bgp, arg_words(&["G", "ipv4"]), ConfigOp::Delete)
+            .unwrap();
+        assert_eq!(peer_mp_families(&bgp), vec![v4(), v6()]);
+
+        // Group delete cascade: opinions gone entirely.
+        config_neighbor_group(&mut bgp, arg_words(&["G"]), ConfigOp::Delete).unwrap();
+        assert_eq!(peer_mp_families(&bgp), vec![v4()]);
+    }
+
+    /// Group afi-safi changes must reach interface-keyed (IPv6
+    /// unnumbered) members too. `PeerMap::iter_mut` silently skips
+    /// interface-keyed peers — sweeping with it left the unnumbered
+    /// peer's families frozen (caught by the
+    /// `@bgp_unnumbered_afi_safi` BDD, pinned here).
+    #[tokio::test]
+    async fn group_afi_safi_reaches_interface_keyed_member() {
+        use super::super::interface_neighbor::{
+            config_interface_neighbor, config_interface_neighbor_neighbor_group,
+            config_interface_neighbor_remote_as, materialize_peer,
+        };
+        use super::super::peer_key::PeerKey;
+
+        let mut bgp = fresh_bgp();
+        config_neighbor_group_afi_safi_enabled(
+            &mut bgp,
+            arg_words(&["G", "ipv6", "true"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        config_interface_neighbor(&mut bgp, arg_words(&["i1"]), ConfigOp::Set).unwrap();
+        config_interface_neighbor_neighbor_group(&mut bgp, arg_words(&["i1", "G"]), ConfigOp::Set)
+            .unwrap();
+        config_interface_neighbor_remote_as(
+            &mut bgp,
+            arg_words(&["i1", "internal"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+
+        let link_local: std::net::Ipv6Addr = "fe80::1".parse().unwrap();
+        materialize_peer(&mut bgp, "i1", 7, link_local).expect("peer materializes");
+
+        let families = |bgp: &Bgp| -> Vec<AfiSafi> {
+            bgp.peers
+                .get_by_key(&PeerKey::Interface(7))
+                .expect("interface peer exists")
+                .config
+                .mp
+                .keys()
+                .copied()
+                .collect()
+        };
+        assert_eq!(
+            families(&bgp),
+            vec![v4(), v6()],
+            "materialization inherits the group families",
+        );
+
+        config_neighbor_group_afi_safi_enabled(
+            &mut bgp,
+            arg_words(&["G", "ipv4", "false"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert_eq!(
+            families(&bgp),
+            vec![v6()],
+            "the sweep must reach the interface-keyed member",
         );
     }
 }

--- a/zebra-rs/src/bgp/interface_neighbor.rs
+++ b/zebra-rs/src/bgp/interface_neighbor.rs
@@ -123,13 +123,21 @@ pub fn materialize_peer(
     // path in `peer_start_connection` reads this back out and
     // builds the SocketAddrV6 accordingly.
     peer.scope_id = Some(ifindex);
-    // When the remote-as came off the group rather than the per-cfg
-    // spec, stamp the back-reference so the reactive sweep on
-    // `neighbor-group remote-as` changes can find this peer.
+    // Stamp the group back-reference whenever the cfg carries one —
+    // it drives every inheritable attribute (afi-safi today), not just
+    // remote-as, so the reactive sweeps on group changes can find this
+    // peer. `remote_as_inherited` still records which side supplied
+    // the ASN: the remote-as sweep must leave a per-cfg spec alone
+    // (it additionally consults the interface-neighbor cfg for the
+    // `external`-placeholder case — see `sweep_peers_for_group`).
+    peer.config.neighbor_group = cfg.neighbor_group.clone();
     if resolved.inherited_from_group {
-        peer.config.neighbor_group = cfg.neighbor_group.clone();
         peer.config.remote_as_inherited = true;
     }
+    // Resolve the group's afi-safi opinions (e.g. `afi-safi ipv6
+    // enabled true` for an unnumbered IPv6 session) into the effective
+    // MP set before the first OPEN is built.
+    super::neighbor_group::recompute_peer_mp(&bgp.neighbor_groups, &mut peer.config);
     bgp.peers.insert_with_key(PeerKey::Interface(ifindex), peer);
 
     // Kick the FSM. `peer.start()` arms the idle-hold timer which
@@ -172,11 +180,26 @@ pub fn config_interface_neighbor_neighbor_group(
     op: ConfigOp,
 ) -> Option<()> {
     let name = args.string()?;
-    let entry = bgp.interface_neighbors.entry(name).or_default();
-    match op {
-        ConfigOp::Set => entry.neighbor_group = Some(args.string()?),
-        ConfigOp::Delete => entry.neighbor_group = None,
-        _ => {}
+    let new_ref = match op {
+        ConfigOp::Set => Some(args.string()?),
+        ConfigOp::Delete => None,
+        _ => return Some(()),
+    };
+    bgp.interface_neighbors
+        .entry(name.clone())
+        .or_default()
+        .neighbor_group = new_ref.clone();
+
+    // Propagate the (re)binding to an already-materialized peer so the
+    // group-driven attributes re-resolve against the new reference.
+    // Scope: afi-safi only — the peer's remote-as keeps its
+    // materialization-time value, matching how a per-cfg `remote-as`
+    // change is also picked up only on the next materialization.
+    if let Some(&ifindex) = bgp.link_index_by_name.get(&name)
+        && let Some(peer) = bgp.peers.get_mut_by_key(&PeerKey::Interface(ifindex))
+    {
+        peer.config.neighbor_group = new_ref;
+        super::neighbor_group::recompute_peer_mp(&bgp.neighbor_groups, &mut peer.config);
     }
     Some(())
 }

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -3,15 +3,22 @@
 //! Storage + the resolver shared by every peer-materialization path
 //! that may inherit from a group: static peers (`config_peer_neighbor_group`),
 //! IPv6 unnumbered (`interface_neighbor::materialize_peer`), and dynamic
-//! peers (`peer::try_dynamic_accept`). The v1 surface inherits only
-//! `remote-as`; per-peer overrides win via the
-//! [`super::peer::PeerConfig::remote_as_inherited`] flag.
+//! peers (`peer::try_dynamic_accept`). The surface inherits `remote-as`
+//! and per-family `afi-safi <name> enabled` toggles; per-peer overrides
+//! win — via the [`super::peer::PeerConfig::remote_as_inherited`] flag
+//! for `remote-as`, and via the explicit-statement record
+//! [`super::peer::PeerConfig::mp_explicit`] for `afi-safi`.
 //!
-//! Group mutations are reactive: `config_neighbor_group_remote_as`
-//! mutates the stored value and then sweeps every peer with a matching
-//! `config.neighbor_group` reference to propagate the change (or tear
-//! the inherited peer down on Delete) — see
-//! [`config_neighbor_group_remote_as`].
+//! Group mutations are reactive, but the two attributes propagate
+//! differently:
+//! - `remote-as` changes sweep every peer with a matching
+//!   `config.neighbor_group` reference and bounce affected sessions
+//!   (the FSM must renegotiate with the new ASN) — see
+//!   [`config_neighbor_group_remote_as`].
+//! - `afi-safi` changes recompute the peers' effective MP set
+//!   ([`effective_mp`]) without touching the FSM: like the per-neighbor
+//!   `afi-safi <name> enabled` knob, the new set is advertised when
+//!   capabilities are next negotiated (`clear bgp …`).
 //!
 //! Naming-wise this sits alongside the existing
 //! `peer-groups/peer-group` schema, not on top of it: a peer can
@@ -21,21 +28,30 @@
 
 use std::collections::BTreeMap;
 
+use bgp_packet::{Afi, AfiSafi, AfiSafis, Safi};
+
 use super::Bgp;
 use super::inst::Message;
-use super::peer::{Event, PeerType};
+use super::peer::{Event, PeerConfig, PeerType};
+use super::peer_key::PeerOrigin;
 use crate::config::{Args, ConfigOp};
 
 #[derive(Debug, Default, Clone)]
 pub struct NeighborGroup {
     pub remote_as: Option<u32>,
+    /// Per-family `afi-safi <name> enabled <bool>` opinions. Tri-state
+    /// per family: `true` forces the family on for inheriting peers,
+    /// `false` forces it off (overriding the implicit IPv4-unicast
+    /// default), absent means "no opinion" (the peer's own default /
+    /// explicit setting stands).
+    pub afi_safi: BTreeMap<AfiSafi, bool>,
 }
 
-/// `set router bgp neighbor-groups neighbor-group <name>` — list-key
-/// callback. Creates the entry on `Set`; on `Delete` cascades through
-/// the sweep helper (so any peers that inherited from the group are
-/// torn down even when libyang's commit path skips the per-leaf
-/// delete callbacks) and then removes the entry.
+/// `set router bgp neighbor-group <name>` — list-key callback.
+/// Creates the entry on `Set`; on `Delete` cascades through the sweep
+/// helpers (so any peers that inherited from the group are torn down /
+/// reset even when libyang's commit path skips the per-leaf delete
+/// callbacks) and then removes the entry.
 pub fn config_neighbor_group(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let name = args.string()?;
     match op {
@@ -50,13 +66,18 @@ pub fn config_neighbor_group(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
             // false` and returns `SweepAction::Ignore`.
             sweep_peers_for_group(bgp, &name, None);
             bgp.neighbor_groups.remove(&name);
+            // With the group gone its afi-safi opinions are gone too:
+            // members fall back to default + their own explicit
+            // statements (the reference leaf on the peer still stands
+            // and re-resolves if the group is re-created).
+            sweep_group_afi_safi(bgp, &name);
         }
         _ => {}
     }
     Some(())
 }
 
-/// `set router bgp neighbor-groups neighbor-group <name> remote-as <asn>`.
+/// `set router bgp neighbor-group <name> remote-as <asn>`.
 ///
 /// Mutates the stored value and then reactively sweeps every peer that
 /// references the group with an inherited (or absent) `remote-as`:
@@ -81,6 +102,121 @@ pub fn config_neighbor_group_remote_as(bgp: &mut Bgp, mut args: Args, op: Config
 
     sweep_peers_for_group(bgp, &name, new_asn);
     Some(())
+}
+
+/// `set router bgp neighbor-group <name> afi-safi <family>` — list-key
+/// callback. `Set` just materializes the group entry (the meaningful
+/// state arrives with the mandatory `enabled` leaf); `Delete` drops the
+/// family opinion and re-resolves members — needed because a
+/// whole-entry delete skips the per-leaf delete callbacks (same
+/// libyang-commit behavior the group-level Delete works around).
+pub fn config_neighbor_group_afi_safi(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let family: AfiSafi = args.afi_safi()?;
+    match op {
+        ConfigOp::Set => {
+            bgp.neighbor_groups.entry(name).or_default();
+        }
+        ConfigOp::Delete => {
+            if let Some(group) = bgp.neighbor_groups.get_mut(&name) {
+                group.afi_safi.remove(&family);
+            }
+            sweep_group_afi_safi(bgp, &name);
+        }
+        _ => {}
+    }
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> afi-safi <family> enabled <bool>`.
+///
+/// Stores the opinion and recomputes the effective MP set of every
+/// member peer. Deliberately no FSM bounce: exactly like the
+/// per-neighbor `afi-safi <name> enabled` knob, the new family set is
+/// advertised when capabilities are next negotiated — the operator
+/// issues `clear bgp …` to apply it to an established session.
+pub fn config_neighbor_group_afi_safi_enabled(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let family: AfiSafi = args.afi_safi()?;
+    let group = bgp.neighbor_groups.entry(name.clone()).or_default();
+    match op {
+        ConfigOp::Set => {
+            let enabled = args.boolean()?;
+            group.afi_safi.insert(family, enabled);
+        }
+        ConfigOp::Delete => {
+            group.afi_safi.remove(&family);
+        }
+        _ => return Some(()),
+    }
+    sweep_group_afi_safi(bgp, &name);
+    Some(())
+}
+
+/// Compute a peer's effective MP (multiprotocol) family set from the
+/// three layers, lowest precedence first:
+///
+/// 1. the built-in default (IPv4 unicast on — every peer is born with
+///    it, see `Peer::new`),
+/// 2. the referenced neighbor-group's `afi-safi` opinions,
+/// 3. the per-peer explicit `afi-safi <name> enabled` statements
+///    ([`super::peer::PeerConfig::mp_explicit`]) — "any field set
+///    explicitly on the neighbor wins".
+///
+/// Presence in the returned set means enabled — the same invariant
+/// `PeerConfig::mp` always had.
+pub fn effective_mp(
+    group: Option<&BTreeMap<AfiSafi, bool>>,
+    explicit: &BTreeMap<AfiSafi, bool>,
+) -> AfiSafis<bool> {
+    let mut mp = AfiSafis::new();
+    mp.insert(AfiSafi::new(Afi::Ip, Safi::Unicast), true);
+    for (family, enabled) in group.into_iter().flatten() {
+        if *enabled {
+            mp.insert(*family, true);
+        } else {
+            mp.remove(family);
+        }
+    }
+    for (family, enabled) in explicit.iter() {
+        if *enabled {
+            mp.insert(*family, true);
+        } else {
+            mp.remove(family);
+        }
+    }
+    mp
+}
+
+/// Re-resolve one peer's `config.mp` from its group reference and
+/// explicit statements. Takes the group map (not `&Bgp`) so callers
+/// holding a `&mut` borrow into `bgp.peers` can still pass
+/// `&bgp.neighbor_groups` alongside.
+pub fn recompute_peer_mp(groups: &BTreeMap<String, NeighborGroup>, config: &mut PeerConfig) {
+    let opinions = config
+        .neighbor_group
+        .as_ref()
+        .and_then(|name| groups.get(name))
+        .map(|group| &group.afi_safi);
+    config.mp = effective_mp(opinions, &config.mp_explicit);
+}
+
+/// Recompute the effective MP set of every peer referencing `name`.
+/// Called after any change to the group's `afi-safi` opinions (and
+/// after group deletion, where the lookup misses and members fall back
+/// to default + explicit). `iter_mut_all` so interface-keyed (IPv6
+/// unnumbered) members are swept too — `iter_mut` silently skips them.
+fn sweep_group_afi_safi(bgp: &mut Bgp, name: &str) {
+    for (_, peer) in bgp.peers.iter_mut_all() {
+        if peer.config.neighbor_group.as_deref() != Some(name) {
+            continue;
+        }
+        recompute_peer_mp(&bgp.neighbor_groups, &mut peer.config);
+    }
 }
 
 /// Decide what to do with one peer that references the group whose
@@ -142,8 +278,33 @@ fn sweep_peers_for_group(bgp: &mut Bgp, name: &str, new_asn: Option<u32>) {
     let local_asn = bgp.asn;
     let mut stops: Vec<usize> = Vec::new();
 
-    for (_, peer) in bgp.peers.iter_mut() {
+    // Interface-keyed peers carry the group back-reference even when
+    // their remote-as came from the interface-neighbor cfg itself (the
+    // reference also drives afi-safi inheritance). The remote-as sweep
+    // must not adopt over such an explicit spec — `remote-as external`
+    // materializes as the 0 placeholder, which the zero-means-unset
+    // heuristic in [`sweep_action`] would otherwise treat as
+    // group-eligible.
+    let explicit_ifnames: std::collections::BTreeSet<&str> = bgp
+        .interface_neighbors
+        .iter()
+        .filter(|(_, cfg)| cfg.remote_as != super::interface_neighbor::RemoteAsSpec::Unset)
+        .map(|(ifname, _)| ifname.as_str())
+        .collect();
+
+    // `iter_mut_all` so interface-keyed (IPv6 unnumbered) members are
+    // swept too — `iter_mut` silently skips them, which left an
+    // unnumbered peer's inherited remote-as frozen across group edits.
+    for (_, peer) in bgp.peers.iter_mut_all() {
         if peer.config.neighbor_group.as_deref() != Some(name) {
+            continue;
+        }
+        if matches!(peer.origin, PeerOrigin::Interface { .. })
+            && peer
+                .ifname
+                .as_deref()
+                .is_some_and(|ifname| explicit_ifnames.contains(ifname))
+        {
             continue;
         }
         match sweep_action(
@@ -213,6 +374,7 @@ mod tests {
             "RR".into(),
             NeighborGroup {
                 remote_as: Some(65000),
+                ..Default::default()
             },
         );
         assert_eq!(map.get("RR").and_then(|g| g.remote_as), Some(65000));
@@ -227,7 +389,7 @@ mod tests {
     #[test]
     fn remote_as_absent_when_group_has_no_asn() {
         let mut map: BTreeMap<String, NeighborGroup> = BTreeMap::new();
-        map.insert("RR".into(), NeighborGroup { remote_as: None });
+        map.insert("RR".into(), NeighborGroup::default());
         assert_eq!(map.get("RR").and_then(|g| g.remote_as), None);
     }
 
@@ -296,5 +458,72 @@ mod tests {
         // Peer was never inherited and never got an explicit asn —
         // Delete on the group is a no-op from the sweep's perspective.
         assert_eq!(sweep_action(0, false, false, None), SweepAction::Ignore);
+    }
+
+    // [`effective_mp`] precedence matrix: built-in default (IPv4
+    // unicast on) < group opinions < per-peer explicit statements.
+
+    fn v4() -> AfiSafi {
+        AfiSafi::new(Afi::Ip, Safi::Unicast)
+    }
+
+    fn v6() -> AfiSafi {
+        AfiSafi::new(Afi::Ip6, Safi::Unicast)
+    }
+
+    fn families(mp: &AfiSafis<bool>) -> Vec<AfiSafi> {
+        mp.keys().copied().collect()
+    }
+
+    #[test]
+    fn effective_mp_default_is_ipv4_unicast_only() {
+        let mp = effective_mp(None, &BTreeMap::new());
+        assert_eq!(families(&mp), vec![v4()]);
+    }
+
+    #[test]
+    fn effective_mp_group_enables_extra_family() {
+        let group = BTreeMap::from([(v6(), true)]);
+        let mp = effective_mp(Some(&group), &BTreeMap::new());
+        assert_eq!(families(&mp), vec![v4(), v6()]);
+    }
+
+    #[test]
+    fn effective_mp_group_disables_the_ipv4_default() {
+        let group = BTreeMap::from([(v4(), false), (v6(), true)]);
+        let mp = effective_mp(Some(&group), &BTreeMap::new());
+        assert_eq!(families(&mp), vec![v6()]);
+    }
+
+    #[test]
+    fn effective_mp_explicit_wins_over_group() {
+        // Group switches v4 off, but the peer's own `afi-safi ipv4
+        // enabled true` stands; group's v6 opinion is unopposed.
+        let group = BTreeMap::from([(v4(), false), (v6(), true)]);
+        let explicit = BTreeMap::from([(v4(), true)]);
+        let mp = effective_mp(Some(&group), &explicit);
+        assert_eq!(families(&mp), vec![v4(), v6()]);
+
+        // ... and the mirror: group on, explicit off.
+        let group = BTreeMap::from([(v6(), true)]);
+        let explicit = BTreeMap::from([(v6(), false)]);
+        let mp = effective_mp(Some(&group), &explicit);
+        assert_eq!(families(&mp), vec![v4()]);
+    }
+
+    #[test]
+    fn effective_mp_explicit_without_group() {
+        let explicit = BTreeMap::from([(v4(), false), (v6(), true)]);
+        let mp = effective_mp(None, &explicit);
+        assert_eq!(families(&mp), vec![v6()]);
+    }
+
+    #[test]
+    fn effective_mp_group_gone_restores_default() {
+        // Same shape the group-delete cascade produces: reference
+        // still set on the peer, lookup misses → opinions = None.
+        let mp = effective_mp(None, &BTreeMap::new());
+        assert!(mp.has(&v4()));
+        assert!(!mp.has(&v6()));
     }
 }

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -382,7 +382,18 @@ pub struct PeerConfig {
     pub transport: PeerTransportConfig,
     pub four_octet: bool,
     pub extended_message: bool,
+    /// Effective multiprotocol family set — what the next OPEN
+    /// advertises. Presence means enabled. Recomputed by
+    /// [`super::neighbor_group::recompute_peer_mp`] as
+    /// default (IPv4 unicast) < group opinions < [`Self::mp_explicit`];
+    /// for a peer with no group reference it equals default + explicit.
     pub mp: AfiSafis<bool>,
+    /// Verbatim per-peer `afi-safi <name> enabled <bool>` statements.
+    /// Kept separately from the effective [`Self::mp`] so a referenced
+    /// neighbor-group's opinions can be merged underneath them ("any
+    /// field set explicitly on the neighbor wins") and re-merged when
+    /// the group changes.
+    pub mp_explicit: BTreeMap<AfiSafi, bool>,
     pub restart: AfiSafis<RestartValue>,
     pub llgr: AfiSafis<LlgrValue>,
     pub addpath: AfiSafis<AddPathValue>,
@@ -446,6 +457,7 @@ impl Default for PeerConfig {
             four_octet: Default::default(),
             extended_message: true,
             mp: Default::default(),
+            mp_explicit: BTreeMap::new(),
             restart: AfiSafis::new(),
             llgr: AfiSafis::new(),
             addpath: AfiSafis::new(),
@@ -2223,7 +2235,12 @@ fn build_open_packet(peer: &mut Peer) -> BytesMut {
     // session that has no IPv4 source address. Other AFIs / SAFIs
     // can be added once the operator has a knob, but the
     // single-tuple case covers every interface-neighbor deployment.
-    if matches!(peer.origin, PeerOrigin::Interface { .. }) {
+    // Skipped when IPv4 unicast itself is disabled on the peer (e.g.
+    // via the neighbor-group's `afi-safi ipv4 enabled false`) — ENHE
+    // qualifies an MP family we would not be advertising.
+    if matches!(peer.origin, PeerOrigin::Interface { .. })
+        && peer.config.mp.has(&AfiSafi::new(Afi::Ip, Safi::Unicast))
+    {
         bgp_cap.extended_nexthop = Some(CapExtendedNextHop::new(vec![ExtendedNextHopValue::new(
             Afi::Ip,
             Safi::Unicast,
@@ -2551,6 +2568,9 @@ fn try_dynamic_accept(bgp: &mut Bgp, peer_addr: IpAddr, stream: TcpStream) -> Op
     // sweep in `config_neighbor_group_remote_as` to consult.
     peer.config.neighbor_group = Some(group_name);
     peer.config.remote_as_inherited = true;
+    // Resolve the group's afi-safi opinions into the effective MP set
+    // before the OPEN for this very connection is built.
+    super::neighbor_group::recompute_peer_mp(&bgp.neighbor_groups, &mut peer.config);
 
     bgp.peers.insert(peer_addr, peer);
     bgp.dynamic_peer_count += 1;

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -3733,6 +3733,28 @@ fn show_bgp_vrf_detail(
 // `show ip bgp neighbor-group [NAME]`
 // ---------------------------------------------------------------------
 
+/// Map an [`AfiSafi`] to the zebra-rs config-layer token name used in
+/// `zebra-afi-safi.yang` and `Args::afi_safi`.
+fn afi_safi_config_name(afi_safi: &AfiSafi) -> &'static str {
+    match (afi_safi.afi, afi_safi.safi) {
+        (Afi::Ip, Safi::Unicast) => "ipv4",
+        (Afi::Ip6, Safi::Unicast) => "ipv6",
+        (Afi::Ip, Safi::MplsVpn) => "vpnv4",
+        (Afi::Ip6, Safi::MplsVpn) => "vpnv6",
+        (Afi::Ip, Safi::Rtc) => "rtcv4",
+        (Afi::Ip6, Safi::Rtc) => "rtcv6",
+        (Afi::L2vpn, Safi::Evpn) => "evpn",
+        (Afi::Ip, Safi::MplsLabel) => "label-v4",
+        (Afi::Ip6, Safi::MplsLabel) => "label-v6",
+        (Afi::Ip, Safi::Flowspec) => "flowspec-ipv4",
+        (Afi::Ip6, Safi::Flowspec) => "flowspec-ipv6",
+        (Afi::Ip, Safi::SrTePolicy) => "sr-policy-v4",
+        (Afi::Ip6, Safi::SrTePolicy) => "sr-policy-v6",
+        (Afi::LinkState, Safi::LinkState) => "link-state",
+        _ => "unknown",
+    }
+}
+
 /// One row of `show ip bgp neighbor-group` (list form). Captures the
 /// configured fields plus a member-peer count to make the list useful
 /// at a glance.
@@ -3741,6 +3763,7 @@ struct BgpNeighborGroupListRow {
     name: String,
     remote_as: Option<u32>,
     members: usize,
+    afi_safi: BTreeMap<String, bool>,
 }
 
 /// Detail view: configured fields plus the peer addresses that
@@ -3760,17 +3783,20 @@ struct BgpNeighborGroupMember {
 struct BgpNeighborGroupDetail {
     name: String,
     remote_as: Option<u32>,
+    afi_safi: BTreeMap<String, bool>,
     members: Vec<BgpNeighborGroupMember>,
 }
 
 fn neighbor_group_members(bgp: &Bgp, name: &str) -> Vec<BgpNeighborGroupMember> {
+    // `iter_all` so interface-keyed (IPv6 unnumbered) members appear;
+    // their operator-facing identity is the interface name.
     let mut members: Vec<BgpNeighborGroupMember> = bgp
         .peers
-        .iter()
+        .iter_all()
         .filter_map(|(_, peer)| {
             if peer.config.neighbor_group.as_deref() == Some(name) {
                 Some(BgpNeighborGroupMember {
-                    address: peer.address.to_string(),
+                    address: peer.display_name(),
                     remote_as: peer.remote_as,
                     inherited_remote_as: peer.config.remote_as_inherited,
                     state: peer.state.to_str().to_string(),
@@ -3825,6 +3851,11 @@ fn show_bgp_neighbor_group_list_json(bgp: &Bgp) -> std::result::Result<String, s
             name: name.clone(),
             remote_as: group.remote_as,
             members: neighbor_group_members(bgp, name).len(),
+            afi_safi: group
+                .afi_safi
+                .iter()
+                .map(|(k, v)| (afi_safi_config_name(k).to_string(), *v))
+                .collect(),
         })
         .collect();
     Ok(serde_json::to_string_pretty(&rows).unwrap_or_default())
@@ -3847,6 +3878,11 @@ fn show_bgp_neighbor_group_detail(
         let detail = BgpNeighborGroupDetail {
             name: name.to_string(),
             remote_as: group.remote_as,
+            afi_safi: group
+                .afi_safi
+                .iter()
+                .map(|(k, v)| (afi_safi_config_name(k).to_string(), *v))
+                .collect(),
             members,
         };
         return Ok(serde_json::to_string_pretty(&detail).unwrap_or_default());
@@ -3862,6 +3898,20 @@ fn show_bgp_neighbor_group_detail(
             .map(|a| a.to_string())
             .unwrap_or_else(|| "(unset)".into())
     )?;
+    if !group.afi_safi.is_empty() {
+        let families: Vec<String> = group
+            .afi_safi
+            .iter()
+            .map(|(k, v)| {
+                format!(
+                    "{} {}",
+                    afi_safi_config_name(k),
+                    if *v { "enabled" } else { "disabled" }
+                )
+            })
+            .collect();
+        writeln!(buf, "  Afi-Safi:  {}", families.join(", "))?;
+    }
     if members.is_empty() {
         writeln!(buf, "  Members:   (no peers reference this group)")?;
     } else {

--- a/zebra-rs/src/bgp/vrf_config.rs
+++ b/zebra-rs/src/bgp/vrf_config.rs
@@ -13,7 +13,7 @@
 //!   — the list-key handler typically arrives first, but staging
 //!   tolerates the leaf handler racing ahead.
 //! - The `peer-group` reference is a plain string (matching the
-//!   schema). Resolution against `neighbor-groups/neighbor-group/<X>`
+//!   schema). Resolution against `neighbor-group <X>`
 //!   happens when the per-VRF runtime materializes peers.
 //! - `BgpVrfNeighborConfig::enabled` defaults to `true` so a freshly
 //!   added neighbor row matches the YANG default without the user

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1380,6 +1380,56 @@ mod yang_load_tests {
         );
     }
 
+    /// The BGP `neighbor-group` list was flattened to sit directly
+    /// under `router bgp` (the wrapping `neighbor-groups` container is
+    /// gone) and gained per-family `afi-safi <name> enabled` toggles
+    /// (zebra-bgp-neighbor-group.yang). Pin the new spellings as
+    /// settable and the old container level as rejected.
+    #[test]
+    fn bgp_neighbor_group_flattened_with_afi_safi() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router bgp neighbor-group dynamic",
+            "set router bgp neighbor-group dynamic remote-as 65000",
+            "set router bgp neighbor-group dynamic afi-safi ipv4 enabled true",
+            "set router bgp neighbor-group dynamic afi-safi ipv6 enabled false",
+            "set router bgp neighbor 192.168.1.3 neighbor-group dynamic",
+            "set router bgp interface-neighbor eth0 neighbor-group dynamic",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+
+        let (code, _comps, _state) = parse(
+            "set router bgp neighbor-groups neighbor-group dynamic",
+            entry,
+            None,
+            State::new(),
+        );
+        assert_ne!(
+            code,
+            ExecCode::Success,
+            "the pre-flatten `neighbor-groups` container level must no longer parse",
+        );
+    }
+
     /// The global Router-ID override moved from the top level
     /// (`router-id A.B.C.D`) under the `system` container
     /// (`system router-id A.B.C.D`); the RIB dispatch in

--- a/zebra-rs/yang/zebra-bgp-neighbor-group.yang
+++ b/zebra-rs/yang/zebra-bgp-neighbor-group.yang
@@ -12,6 +12,10 @@ module zebra-bgp-neighbor-group {
     prefix bgp;
   }
 
+  import zebra-afi-safi {
+    prefix zas;
+  }
+
   import config {
     prefix config;
   }
@@ -37,25 +41,27 @@ module zebra-bgp-neighbor-group {
      'these N peers share these few attributes' case ergonomic,
      not to mirror every leaf of `neighbor-group-config`.
 
-     This first cut exposes only `remote-as`. The runtime currently
-     stores the group definition and per-neighbor reference but
-     does NOT yet resolve inheritance — that lands in a follow-up.
-     Field-level override semantics: any field set explicitly on
-     the neighbor wins; otherwise the neighbor inherits from the
-     referenced group.
+     The surface exposes `remote-as` and per-family `afi-safi
+     <name> enabled` toggles. Field-level override semantics: any
+     field set explicitly on the neighbor wins; otherwise the
+     neighbor inherits from the referenced group.
 
-     Resulting CLI / config shape (target):
+     Resulting CLI / config shape:
 
        router bgp {
-         neighbor-groups {
-           neighbor-group RR-CLIENTS {
-             remote-as 65000;
+         neighbor-group RR-CLIENTS {
+           remote-as 65000;
+           afi-safi ipv4 {
+             enabled true;
+           }
+           afi-safi ipv6 {
+             enabled true;
            }
          }
          neighbor 10.0.0.1 {
            neighbor-group RR-CLIENTS;
          }
-         neighbor 10.0.0.2 {
+         interface-neighbor eth0 {
            neighbor-group RR-CLIENTS;
          }
        }
@@ -65,26 +71,45 @@ module zebra-bgp-neighbor-group {
      before `neighbor-group G` has been declared — the same
      staging-friendly pattern other zebra-bgp-* augments use.";
 
-  grouping bgp-neighbor-groups-extension {
+  grouping bgp-neighbor-group-extension {
     description
-      "Top-level `neighbor-groups` container hung off `router bgp`.";
-    container neighbor-groups {
-      ext:help "BGP neighbor-groups (IOS-XR style)";
-      list neighbor-group {
+      "Top-level `neighbor-group` list hung off `router bgp`.";
+    list neighbor-group {
+      key "name";
+      ext:help "BGP neighbor-group (IOS-XR style)";
+      description
+        "List of BGP neighbor-groups configured on the local
+         system, uniquely identified by name.";
+      leaf name {
+        type string;
+        description
+          "Name of the neighbor-group.";
+      }
+      leaf remote-as {
+        type inet:as-number;
+        description
+          "AS number inherited by neighbors that reference this
+           group. A `remote-as` set on the neighbor itself wins.";
+      }
+      list afi-safi {
         key "name";
         description
-          "List of BGP neighbor-groups configured on the local
-           system, uniquely identified by name.";
-        leaf name {
-          type string;
+          "Per-family toggles inherited by neighbors that reference
+           this group. Tri-state per family: an entry with `enabled
+           true` switches the family on for inheriting peers, an
+           entry with `enabled false` switches it off (overriding
+           the implicit IPv4-unicast default), and no entry leaves
+           the peer's own setting (or the default) in effect. An
+           `afi-safi` set explicitly on the neighbor itself wins.
+           Like the per-neighbor knob, a change takes effect when
+           the session next negotiates capabilities (`clear bgp`).";
+        uses zas:afi-safi;
+        leaf enabled {
+          type boolean;
+          mandatory true;
           description
-            "Name of the neighbor-group.";
-        }
-        leaf remote-as {
-          type inet:as-number;
-          description
-            "AS number inherited by neighbors that reference this
-             group. A `remote-as` set on the neighbor itself wins.";
+            "Whether this AFI,SAFI is enabled for peers inheriting
+             from the group.";
         }
       }
     }
@@ -105,17 +130,16 @@ module zebra-bgp-neighbor-group {
 
   augment "/configure:set/config:router/bgp:bgp" {
     description
-      "Attach the `neighbor-groups` container to `router bgp` in
-       the candidate-set subtree.";
-    uses bgp-neighbor-groups-extension;
+      "Attach the `neighbor-group` list to `router bgp` in the
+       candidate-set subtree.";
+    uses bgp-neighbor-group-extension;
   }
 
   augment "/configure:delete/config:router/bgp:bgp" {
     description
       "Same attachment for the delete subtree so
-       `delete router bgp neighbor-groups neighbor-group X` is
-       path-valid.";
-    uses bgp-neighbor-groups-extension;
+       `delete router bgp neighbor-group X` is path-valid.";
+    uses bgp-neighbor-group-extension;
   }
 
   augment "/configure:set/config:router/bgp:bgp/bgp:neighbor" {


### PR DESCRIPTION
## Summary

Refines the IOS-XR-style BGP `neighbor-group` surface in three steps:

1. **Flatten one config level** — the wrapping `neighbor-groups` container is gone:
   `set router bgp neighbor-groups neighbor-group dynamic` → `set router bgp neighbor-group dynamic`.
2. **Per-group `afi-safi <name> enabled <bool>` toggles** (full zebra-afi-safi family set), inherited by every peer that references the group — static `neighbor`, `interface-neighbor` (IPv6 unnumbered), and dynamic listen-range peers alike.
3. **IPv6-unnumbered enablement** — an `interface-neighbor` bound to a group with `afi-safi ipv6 enabled true` negotiates the IPv6-unicast MP capability and carries IPv6 routes over the link-local session; flipping the group to `afi-safi ipv4 enabled false` + `clear bgp ipv4 neighbor <ifname>` renegotiates without the IPv4-unicast capability and the IPv4 routes stay gone.

```
router bgp {
  neighbor-group dynamic {
    afi-safi ipv4 { enabled false; }
    afi-safi ipv6 { enabled true; }
  }
  interface-neighbor eth0 {
    neighbor-group dynamic;
    remote-as internal;
  }
}
```

## Design notes

- **Precedence** is `built-in default (IPv4 unicast on) < group opinion < explicit per-peer statement` — "any field set explicitly on the neighbor wins", matching the documented remote-as semantics. `PeerConfig` now records the verbatim per-peer statements (`mp_explicit`) separately from the effective set (`mp`), and `neighbor_group::effective_mp` re-merges the three layers at every materialization/attach/group-change site. This also makes the result order-independent across config replay.
- **No session bounce on afi-safi changes** — exactly like the per-neighbor `afi-safi <name> enabled` knob, a group change only recomputes `config.mp`; the new family set is advertised when capabilities are next negotiated (`clear bgp …`). The per-session capability state reset on leaving Established (end of `route_clean`) is what makes the renegotiation clean.
- **Bug fix: `PeerMap::iter_mut()` silently skips interface-keyed peers.** Both the new afi-safi sweep and the pre-existing group remote-as sweep never reached unnumbered members (the BDD caught the session renegotiating with IPv4 still advertised while a static-neighbor unit test passed). Both sweeps now use `iter_mut_all()`, pinned by an interface-keyed wiring test; the `show ip bgp neighbor-group` member list had the same blind spot (now `iter_all` + `display_name`).
- **Group back-reference is now stamped unconditionally** on interface-peer materialization (previously only when remote-as was inherited), so afi-safi sweeps can find these peers. The remote-as sweep gained a guard so a per-cfg `remote-as` (including the `external` 0-placeholder) is never adopted over.
- **ENHE gate**: an interface-keyed peer no longer advertises the RFC 8950 extended-next-hop capability for IPv4-unicast when IPv4-unicast itself is disabled.
- `interface-neighbor X neighbor-group <G>` rebinding now propagates to an already-materialized peer (afi-safi only; remote-as keeps its materialization-time value, as before).
- `show ip bgp neighbor-group [NAME]` renders the group's afi-safi map (text + JSON).

## Testing

- `effective_mp` precedence matrix + group afi-safi wiring tests (propagation, explicit-wins, entry/group delete cascade, interface-keyed sweep) — `cargo test -p zebra-rs`: 1031 passed.
- Grammar pin in `yang_load_tests`: the new flattened paths parse; the pre-flatten `neighbor-groups` spelling is rejected.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test --workspace --exclude bdd` green.
- BDD `@bgp_neighbor_group` (existing inheritance feature, configs flattened) passes.
- New BDD `@bgp_unnumbered_afi_safi`: unnumbered iBGP (`remote-as internal`) via `neighbor-group dynamic` with ipv4+ipv6 enabled — asserts both MP capabilities and both address families' routes; then flips the group to `ipv4 enabled false`, `clear bgp ipv4 neighbor i1`, and asserts the re-established session has the IPv6-unicast capability but no IPv4-unicast capability, IPv4 routes gone, IPv6 routes intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
