### PR TITLE
bgp: inherit the full per-neighbor knob set through neighbor-group

### DIFF
--- a/bdd/tests/configs/bgp_neighbor_group/z1-3.yaml
+++ b/bdd/tests/configs/bgp_neighbor_group/z1-3.yaml
@@ -1,0 +1,22 @@
+# Full restatement of z1-1.yaml plus GTSM on the GROUP: the member
+# peer 192.168.0.2 carries no per-neighbor ttl-security statement, so
+# its GTSM comes entirely from the `neighbor-group RR` opinion. The
+# far end (z2-2.yaml) enables ttl-security per-neighbor; GTSM only
+# establishes when BOTH ends send TTL 255, so the session coming up
+# proves the inherited knob reached the wire.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 192.168.0.1
+    neighbor-group:
+    - name: RR
+      remote-as: 65002
+      ttl-security: null
+    neighbor:
+    - remote-address: 192.168.0.2
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      neighbor-group: RR

--- a/bdd/tests/configs/bgp_neighbor_group/z2-2.yaml
+++ b/bdd/tests/configs/bgp_neighbor_group/z2-2.yaml
@@ -1,0 +1,16 @@
+# Full restatement of z2-1.yaml plus per-neighbor ttl-security — the
+# conventional spelling on the far end, against z1's group-inherited
+# GTSM (see z1-3.yaml).
+router:
+  bgp:
+    global:
+      as: 65002
+      router-id: 192.168.0.2
+    neighbor:
+    - remote-address: 192.168.0.1
+      afi-safi:
+      - name: ipv4
+        enabled: true
+      enabled: true
+      remote-as: 65001
+      ttl-security: null

--- a/bdd/tests/features/bgp_neighbor_group.feature
+++ b/bdd/tests/features/bgp_neighbor_group.feature
@@ -32,6 +32,10 @@ Feature: BGP neighbor-group inheritance end-to-end
   - z1-2.yaml: same shape, but RR's remote-as is 65099 (wrong) —
     used to verify the reactive sweep tears the session down.
   - z2-1.yaml: plain AS 65002 peer to 192.168.0.1 remote-as 65001.
+  - z1-3.yaml / z2-2.yaml: GTSM round — z1 inherits ttl-security
+    from the GROUP while z2 enables it per-neighbor. GTSM needs both
+    ends at TTL 255, so re-establishment proves the inherited knob
+    is live on the wire, not just stored.
 
   Scenario: Setup topology
     Given a clean test environment
@@ -61,6 +65,21 @@ Feature: BGP neighbor-group inheritance end-to-end
     And I wait 30 seconds for BGP to operate
     Then BGP session in "z1" to "192.168.0.2" should be "Established"
     And BGP session in "z2" to "192.168.0.1" should be "Established"
+
+  Scenario: Inherited ttl-security — group GTSM interoperates with a per-neighbor GTSM far end
+    Given the test topology exists
+    # z1's member gets GTSM only through the group opinion; z2 turns
+    # it on per-neighbor. Both flips bounce their live session (same
+    # ritual as the per-neighbor knob), and GTSM only re-establishes
+    # when BOTH ends send TTL 255 — so Established below is proof the
+    # group-inherited knob reached z1's socket.
+    When I apply config "z1-3.yaml" to namespace "z1"
+    And I apply config "z2-2.yaml" to namespace "z2"
+    And I wait 30 seconds for BGP to operate
+    Then BGP session in "z1" to "192.168.0.2" should be "Established"
+    And BGP session in "z2" to "192.168.0.1" should be "Established"
+    And show command "show ip bgp neighbors 192.168.0.2" in namespace "z1" should contain "TTL security (GTSM) enabled"
+    And show command "show ip bgp neighbors 192.168.0.2" in namespace "z1" should contain "Neighbor-group: RR"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/book/src/ch-02-01-dynamic-neighbors.md
+++ b/book/src/ch-02-01-dynamic-neighbors.md
@@ -36,9 +36,12 @@ Key properties:
   are dropped at accept time. Setting it to `0` disables the ranges
   without removing them. A dynamic peer whose session ends is removed
   again (and frees its slot) rather than lingering in Idle.
-- **Group-driven.** The peer inherits `remote-as` and the `afi-safi`
-  set from the referenced group, with the usual precedence rules —
-  see [Neighbor Groups](ch-02-26-bgp-neighbor-group.md).
+- **Group-driven.** The peer inherits the group's entire attribute
+  set — `remote-as`, the `afi-safi` families, and the whole-session
+  knobs (`password`, `ttl-security`, policies, …) — with the usual
+  precedence rules; see
+  [Neighbor Groups](ch-02-26-bgp-neighbor-group.md). The group's
+  `passive` opinion is moot here: dynamic peers are always passive.
 
 ## Configuration
 

--- a/book/src/ch-02-02-tcp-authentication.md
+++ b/book/src/ch-02-02-tcp-authentication.md
@@ -123,6 +123,12 @@ router:
 obfuscated form). Maximum password length is 80 bytes, matching the
 kernel's `TCP_MD5SIG_MAXKEYLEN`.
 
+Like the other per-neighbor transport knobs, `password` can also be set
+on a [neighbor-group](ch-02-26-bgp-neighbor-group.md) and inherited by
+every member; a statement on the neighbor itself wins. A group password
+re-keys each member's listener entry; sessions already established keep
+their key until they reconnect.
+
 ### TCP-AO
 
 A key chain (RFC 8177) carries one or more keys; the BGP neighbor

--- a/book/src/ch-02-09-bgp-route-reflector.md
+++ b/book/src/ch-02-09-bgp-route-reflector.md
@@ -35,6 +35,11 @@ reflector client (eBGP peers always receive it). Plain
 iBGP→iBGP advertisement between non-clients is suppressed, which is
 what removes the need for a full mesh.
 
+`route-reflector client` can also be set on a
+[neighbor-group](ch-02-26-bgp-neighbor-group.md) and inherited by every
+member; a statement on the neighbor itself wins. Setting it on the group
+marks every member as a client — iBGP members only, as ever.
+
 ## Keeping reflected routes out of the FIB
 
 A dedicated route reflector usually sits *outside* the data path: it

--- a/book/src/ch-02-11-bgp-ttl-security.md
+++ b/book/src/ch-02-11-bgp-ttl-security.md
@@ -146,6 +146,11 @@ CLI form is the same path:
 set router bgp neighbor 192.168.0.2 ttl-security
 ```
 
+Both `ttl-security` and `ebgp-multihop` can also be set on a
+[neighbor-group](ch-02-26-bgp-neighbor-group.md) and inherited by every
+member; a statement on the neighbor itself wins. A group change bounces
+every live member session, exactly like the per-neighbor command.
+
 Toggling either `ttl-security` or `ebgp-multihop` on a session that is
 already up bounces it (the same teardown `clear bgp <peer>` performs),
 so the new TTL policy takes effect on the reconnect rather than waiting

--- a/book/src/ch-02-12-bgp-as-override.md
+++ b/book/src/ch-02-12-bgp-as-override.md
@@ -96,6 +96,10 @@ session so the provider re-advertises with the new AS_PATH:
 clear bgp ipv4 neighbor 192.168.1.3
 ```
 
+Like the other per-neighbor knobs, `as-override` can also be set on a
+[neighbor-group](ch-02-26-bgp-neighbor-group.md) and inherited by
+every member; a statement on the neighbor itself wins.
+
 ## Verification
 
 `show ip bgp neighbor <addr>` reports whether the knob is active:

--- a/book/src/ch-02-13-bgp-allowas-in.md
+++ b/book/src/ch-02-13-bgp-allowas-in.md
@@ -123,6 +123,10 @@ clear bgp ipv4 neighbor 192.168.1.2
 This is the key operational difference from an ordinary inbound policy
 change, which re-evaluates the routes already held in the Adj-RIB-In.
 
+Like the other per-neighbor knobs, `allowas-in` can also be set on a
+[neighbor-group](ch-02-26-bgp-neighbor-group.md) and inherited by
+every member; a statement on the neighbor itself wins.
+
 ## Verification
 
 `show ip bgp neighbors` reports the active setting for the session:

--- a/book/src/ch-02-14-bgp-remove-private-as.md
+++ b/book/src/ch-02-14-bgp-remove-private-as.md
@@ -137,6 +137,10 @@ the session so the provider re-advertises with the stripped AS_PATH:
 clear bgp ipv4 neighbor 192.168.1.3
 ```
 
+Like the other per-neighbor knobs, `remove-private-as` can also be set
+on a [neighbor-group](ch-02-26-bgp-neighbor-group.md) and inherited by
+every member; a statement on the neighbor itself wins.
+
 ## Verification
 
 `show ip bgp neighbor <addr>` reports the configured form:

--- a/book/src/ch-02-14-bgp-tcp-mss.md
+++ b/book/src/ch-02-14-bgp-tcp-mss.md
@@ -36,6 +36,12 @@ The FRR / IOS-style CLI form is the same path:
 set router bgp neighbor 192.168.0.2 tcp-mss 500
 ```
 
+Like the other per-neighbor transport knobs, `tcp-mss` can also be set
+on a [neighbor-group](ch-02-26-bgp-neighbor-group.md) and inherited by
+every member; a statement on the neighbor itself wins. The listener
+clamp is re-derived across all members when the group value changes;
+live sessions pick the new clamp up at their next connect.
+
 ## How it is applied
 
 TCP negotiates the MSS once, in the SYN / SYN-ACK exchange of the

--- a/book/src/ch-02-15-bgp-enforce-first-as.md
+++ b/book/src/ch-02-15-bgp-enforce-first-as.md
@@ -90,6 +90,10 @@ session so the routes are re-received and re-checked under the new policy:
 clear bgp ipv4 neighbor 192.168.0.1
 ```
 
+Like the other per-neighbor knobs, `enforce-first-as` can also be set on
+a [neighbor-group](ch-02-26-bgp-neighbor-group.md) and inherited by
+every member; a statement on the neighbor itself wins.
+
 ## Verification
 
 `show ip bgp neighbor <addr>` reports whether the knob is active:

--- a/book/src/ch-02-16-bgp-disable-connected-check.md
+++ b/book/src/ch-02-16-bgp-disable-connected-check.md
@@ -105,6 +105,10 @@ it (the same teardown `clear bgp <peer>` performs): enabling it lets a held
 neighbor connect, and disabling it resets a session that only came up
 because of the override.
 
+Like the other per-neighbor knobs, `disable-connected-check` can also be
+set on a [neighbor-group](ch-02-26-bgp-neighbor-group.md) and inherited
+by every member; a statement on the neighbor itself wins.
+
 ## Verification
 
 `show ip bgp neighbor <addr>` reports the active policy:

--- a/book/src/ch-02-23-bgp-port.md
+++ b/book/src/ch-02-23-bgp-port.md
@@ -77,6 +77,12 @@ set router bgp port 1790
 set router bgp port 0
 ```
 
+The per-neighbor `port` knob (the dial-side destination port) can also be
+set on a [neighbor-group](ch-02-26-bgp-neighbor-group.md) and inherited
+by every member; a statement on the neighbor itself wins. The instance
+listen port (`router bgp port`) is not inheritable — it is an
+instance-level setting, not a per-neighbor knob.
+
 ## How it is applied
 
 **Neighbor port (dial side).** The configured port is used when the

--- a/book/src/ch-02-26-bgp-neighbor-group.md
+++ b/book/src/ch-02-26-bgp-neighbor-group.md
@@ -20,16 +20,31 @@ Three kinds of peer can reference a group:
 
 ## Attributes and precedence
 
-A group currently carries two things:
+A group carries the full set of per-neighbor knobs. The complete list,
+grouped by function:
 
-- **`remote-as <asn>`** — the AS number a member peers with.
-- **`afi-safi <family> enabled <true|false>`** — per-family toggles,
-  using the same family names as the per-neighbor `afi-safi` list
-  (`ipv4`, `ipv6`, `vpnv4`, `label-v4`, `evpn`, …).
+**Transport**
+`remote-as`, `passive`, `update-source`, `port`, `ttl-security`,
+`ebgp-multihop`, `tcp-mss`, `password`, `disable-connected-check`
 
-The rule for both is: **anything set explicitly on the neighbor wins;
-otherwise the neighbor inherits from the group.** For address families
-there are three layers, lowest precedence first:
+**Per-family (afi-safi)**
+`afi-safi <name> enabled`, `afi-safi <name> next-hop-self`
+
+**Filtering and policy**
+`policy in`, `policy out`, `prefix-set in`, `prefix-set out`
+
+**AS-path handling**
+`allowas-in [count <1–10>|origin]`, `as-override`,
+`remove-private-as [all] [replace-as]`, `enforce-first-as`
+
+**Route reflection**
+`route-reflector client`
+
+The precedence rule is the same for every one of them: **anything set
+explicitly on the neighbor wins; otherwise the neighbor inherits from
+the group.**
+
+For address families there are three layers, lowest precedence first:
 
 1. the built-in default — every peer starts with **IPv4 unicast
    enabled**;
@@ -44,27 +59,56 @@ So a group with `afi-safi ipv4 enabled false` disables IPv4 unicast
 for its members — except a member that itself carries
 `afi-safi ipv4 enabled true`, which keeps it.
 
+Several knobs are **presence-style** — they can only be stated "on",
+matching the expressiveness of the per-neighbor command: `ttl-security`,
+`as-override`, `remove-private-as`, `enforce-first-as`,
+`disable-connected-check`, and `allowas-in`. Setting one in the group
+enables it for every member that does not suppress it with an explicit
+per-neighbor override.
+
 ## How changes propagate
 
-The two attributes apply on different schedules, matching what they
-mean on the wire:
+Each knob propagates with the same ritual the equivalent per-neighbor
+command uses:
 
 - **`remote-as` changes are immediate.** Setting or changing the
   group's `remote-as` propagates to every member that inherited it
   (members with their own `remote-as` are untouched). A member whose
   AS actually changed is bounced so the FSM renegotiates; deleting the
   group's `remote-as` (or the group) tears inherited members down.
+- **Session-bouncing knobs** — `port`, `ttl-security`, `ebgp-multihop`,
+  `disable-connected-check` — propagate immediately and bounce every
+  live member session so the change takes effect on the wire.
+- **Reconnect-time knobs** — `tcp-mss` and `password` — re-key or
+  clamp the listener and apply to new connections; existing sessions
+  pick them up at the next reconnect.
+- **Policy and prefix-set changes** re-resolve the filter chain and
+  soft-replay routes for every affected member (the equivalent of
+  `clear bgp ipv4 neighbor <X> soft in/out`).
+- **No-bounce knobs** — `passive`, `allowas-in`, `as-override`,
+  `remove-private-as`, `enforce-first-as`, `route-reflector client`,
+  `next-hop-self` — apply without bouncing established sessions. The
+  egress-signature ones (`route-reflector client`, `next-hop-self`,
+  `as-override`, …) take effect on routes and sessions going forward.
 - **`afi-safi` changes apply at the next capability negotiation.**
   Like the per-neighbor `afi-safi <family> enabled` knob, flipping a
   family in the group does *not* bounce established sessions — BGP
   capabilities are exchanged only in the OPEN message. Issue
   `clear bgp ipv4 neighbor <X>` when you want a live session to
   renegotiate with the new family set.
+- **`update-source`** propagates to inherited members, but skips
+  members whose address family does not match the configured source
+  address (e.g. an IPv4 source is not applied to an IPv6-only session).
+- **Dynamic (listen-range) members** are always passive regardless of
+  the group's `passive` setting — an inbound caller materializes the
+  peer and drives the connection.
 
 ## Configuration
 
 A route-reflector-style example: two clients share the group `RR`,
-which supplies the remote AS and enables IPv4 and IPv6 unicast.
+which supplies the remote AS, enables IPv4 and IPv6 unicast with
+next-hop-self on IPv4, enforces a TTL-security hop count, and marks
+members as route-reflector clients.
 
 ```yaml
 router:
@@ -75,9 +119,13 @@ router:
     neighbor-group:
     - name: RR
       remote-as: 65002
+      ttl-security: null
+      route-reflector:
+        client: true
       afi-safi:
       - name: ipv4
         enabled: true
+        next-hop-self: true
       - name: ipv6
         enabled: true
     neighbor:
@@ -89,13 +137,16 @@ router:
       neighbor-group: RR
 ```
 
-Neither neighbor needs its own `remote-as` or `afi-safi` list — both
-come from the group. The equivalent CLI forms:
+Neither neighbor needs its own `remote-as`, `afi-safi`, or policy
+knobs — all come from the group. The equivalent CLI forms:
 
 ```
 set router bgp neighbor-group RR
 set router bgp neighbor-group RR remote-as 65002
+set router bgp neighbor-group RR ttl-security
+set router bgp neighbor-group RR route-reflector client true
 set router bgp neighbor-group RR afi-safi ipv4 enabled true
+set router bgp neighbor-group RR afi-safi ipv4 next-hop-self true
 set router bgp neighbor-group RR afi-safi ipv6 enabled true
 set router bgp neighbor 192.168.0.2 neighbor-group RR
 ```
@@ -110,7 +161,8 @@ until the group definition lands.
 ## Verification
 
 `show ip bgp neighbor-group` lists every group with a member count;
-the detail form shows the attribute set and which peers reference it:
+the detail form shows every configured knob and which peers reference
+it:
 
 ```
 show ip bgp neighbor-group
@@ -122,7 +174,9 @@ RR                            65002        2
 show ip bgp neighbor-group RR
 BGP neighbor-group: RR
   Remote-AS: 65002
-  Afi-Safi:  ipv4 enabled, ipv6 enabled
+  Afi-Safi:  ipv4 enabled nhs, ipv6 enabled
+  TTL-security: enabled
+  Route-reflector-client: true
   Members (2):
     192.168.0.2              remote-as 65002 (inherited) state Established
     192.168.0.3              remote-as 65002 (inherited) state Established

--- a/book/src/ch-02-26-bgp-neighbor-group.md
+++ b/book/src/ch-02-26-bgp-neighbor-group.md
@@ -105,10 +105,12 @@ command uses:
 
 ## Configuration
 
-A route-reflector-style example: two clients share the group `RR`,
-which supplies the remote AS, enables IPv4 and IPv6 unicast with
-next-hop-self on IPv4, enforces a TTL-security hop count, and marks
-members as route-reflector clients.
+A route-reflector example: two clients share the group `RR`, which
+supplies the remote AS (the local AS — reflection is an iBGP
+mechanism, so the clients must be internal peers), enables IPv4 and
+IPv6 unicast with next-hop-self on IPv4, turns on GTSM
+(`ttl-security` — directly-connected clients only, fixed TTL 255),
+and marks members as route-reflector clients.
 
 ```yaml
 router:
@@ -118,7 +120,7 @@ router:
       router-id: 192.168.0.1
     neighbor-group:
     - name: RR
-      remote-as: 65002
+      remote-as: 65001
       ttl-security: null
       route-reflector:
         client: true
@@ -142,7 +144,7 @@ knobs — all come from the group. The equivalent CLI forms:
 
 ```
 set router bgp neighbor-group RR
-set router bgp neighbor-group RR remote-as 65002
+set router bgp neighbor-group RR remote-as 65001
 set router bgp neighbor-group RR ttl-security
 set router bgp neighbor-group RR route-reflector client true
 set router bgp neighbor-group RR afi-safi ipv4 enabled true
@@ -167,19 +169,19 @@ it:
 ```
 show ip bgp neighbor-group
 Name                      Remote-AS  Members
-RR                            65002        2
+RR                            65001        2
 ```
 
 ```
 show ip bgp neighbor-group RR
 BGP neighbor-group: RR
-  Remote-AS: 65002
+  Remote-AS: 65001
   Afi-Safi:  ipv4 enabled nhs, ipv6 enabled
   TTL-security: enabled
   Route-reflector-client: true
   Members (2):
-    192.168.0.2              remote-as 65002 (inherited) state Established
-    192.168.0.3              remote-as 65002 (inherited) state Established
+    192.168.0.2              remote-as 65001 (inherited) state Established
+    192.168.0.3              remote-as 65001 (inherited) state Established
 ```
 
 `(inherited)` marks members whose AS came from the group rather than a

--- a/book/src/ch-02-27-bgp-unnumbered.md
+++ b/book/src/ch-02-27-bgp-unnumbered.md
@@ -60,7 +60,12 @@ interface-neighbor itself always wins over the group's.
 `interface-neighbor` deliberately carries no per-peer `afi-safi` list.
 A bare entry negotiates the default — IPv4 unicast only. To run IPv6
 (or any other family) on an unnumbered session, reference a
-neighbor-group and set the families there:
+neighbor-group and set the families there. The full per-neighbor knob
+set — `ttl-security`, `password`, `policy`, `prefix-set`,
+`allowas-in`, and every other knob listed in
+[Neighbor Groups](ch-02-26-bgp-neighbor-group.md) — inherits through
+the group the same way, making the group the natural place to configure
+all shared policy for an unnumbered fabric.
 
 ```yaml
 interface:

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -232,21 +232,24 @@ fn config_peer_neighbor_group(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Op
     };
 
     // Stash what we need to act on outside the &mut peer borrow.
-    let (peer_ident, resolve_now, should_stop_inherited) = {
+    let (peer_ident, resolve_now, should_stop_inherited, outcome) = {
         let peer = bgp.peers.get_mut(&addr)?;
         peer.config.neighbor_group = new_ref.clone();
-        // Re-resolve the effective MP set against the new reference —
-        // Set adopts the group's afi-safi opinions underneath any
+        // Re-resolve everything the group supplies against the new
+        // reference — Set adopts the group's opinions underneath any
         // explicit per-peer statements; Delete falls back to
-        // default + explicit.
-        super::neighbor_group::recompute_peer_mp(&bgp.neighbor_groups, &mut peer.config);
+        // defaults + explicit. A knob whose effective value changed
+        // on a live session asks for a bounce; the listener/BFD jobs
+        // run after the peer borrow ends.
+        let outcome =
+            super::neighbor_group::apply_inherited(&bgp.neighbor_groups, &bgp.policy_tx, peer);
 
         match op {
             ConfigOp::Set => {
                 // Resolve only if the peer doesn't already carry an
                 // explicit per-peer remote-as.
                 let needs_resolve = peer.remote_as == 0 || peer.config.remote_as_inherited;
-                (peer.ident, needs_resolve, false)
+                (peer.ident, needs_resolve, false, outcome)
             }
             ConfigOp::Delete => {
                 // Tear down only when the peer was relying on the
@@ -257,9 +260,9 @@ fn config_peer_neighbor_group(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Op
                     peer.config.remote_as_inherited = false;
                     peer.active = false;
                 }
-                (peer.ident, false, was_inherited)
+                (peer.ident, false, was_inherited, outcome)
             }
-            _ => (peer.ident, false, false),
+            _ => (peer.ident, false, false, outcome),
         }
     };
 
@@ -290,12 +293,25 @@ fn config_peer_neighbor_group(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Op
         }
     }
 
-    if should_stop_inherited {
+    if should_stop_inherited || outcome.bounce {
         // FSM teardown — same mechanism `clear bgp ... hard` uses.
+        // Either the inherited remote-as went away or some inherited
+        // knob needs the session to reconnect under its new value.
         let _ = bgp.tx.try_send(super::inst::Message::Event(
             peer_ident,
             super::peer::Event::Stop,
         ));
+    }
+
+    // Cross-borrow jobs the inherited-knob pass asked for.
+    if outcome.mss_refresh {
+        apply_tcp_mss_refresh_all(bgp);
+    }
+    if outcome.md5_refresh {
+        apply_md5_refresh_for(bgp, addr);
+    }
+    if outcome.bfd_reapply {
+        let _ = bfd_apply(bgp, addr);
     }
 
     Some(())
@@ -378,6 +394,37 @@ fn policy_attach_msgs(
     }
 }
 
+/// Bind a resolved policy / prefix-set name to one direction slot on
+/// the peer and (un)register it with the policy actor. The actor's
+/// `PolicyRx` reply resolves the name into the actual object and
+/// soft-replays the direction — the same asynchronous ritual the
+/// per-neighbor callbacks use. Diff-gated inside
+/// [`policy_attach_msgs`] (prior == new sends nothing), so group
+/// sweeps may call this freely. Shared by the per-neighbor callbacks
+/// and the neighbor-group sweep.
+pub(super) fn apply_peer_policy_ref(
+    policy_tx: &tokio::sync::mpsc::UnboundedSender<policy::Message>,
+    peer: &mut Peer,
+    policy_type: policy::PolicyType,
+    want: Option<String>,
+) {
+    let ident = peer.ident;
+    let slot = match policy_type {
+        policy::PolicyType::PolicyListIn => &mut peer.policy_list.get_mut(&InOut::Input).name,
+        policy::PolicyType::PolicyListOut => &mut peer.policy_list.get_mut(&InOut::Output).name,
+        policy::PolicyType::PrefixSetIn => &mut peer.prefix_set.get_mut(&InOut::Input).name,
+        policy::PolicyType::PrefixSetOut => &mut peer.prefix_set.get_mut(&InOut::Output).name,
+        // Key-chain subscriptions ride a different registry and never
+        // reach this helper.
+        policy::PolicyType::KeyChain(_) => return,
+    };
+    let prior = match &want {
+        Some(n) => slot.replace(n.clone()),
+        None => slot.take(),
+    };
+    policy_attach_msgs(policy_tx, ident, policy_type, prior, want);
+}
+
 fn config_policy_in(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let new_name = if op.is_set() {
@@ -386,19 +433,11 @@ fn config_policy_in(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
         None
     };
     let peer = bgp.peers.get_mut(&addr)?;
-    let peer_ident = peer.ident;
-    let config = peer.policy_list.get_mut(&InOut::Input);
-    let prior = match &new_name {
-        Some(n) => config.name.replace(n.clone()),
-        None => config.name.take(),
-    };
-    policy_attach_msgs(
-        &bgp.policy_tx,
-        peer_ident,
-        policy::PolicyType::PolicyListIn,
-        prior,
-        new_name,
-    );
+    peer.config.knobs_explicit.policy_in = new_name;
+    let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
+        k.policy_in.clone()
+    });
+    apply_peer_policy_ref(&bgp.policy_tx, peer, policy::PolicyType::PolicyListIn, want);
     Some(())
 }
 
@@ -410,18 +449,15 @@ fn config_policy_out(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> 
         None
     };
     let peer = bgp.peers.get_mut(&addr)?;
-    let peer_ident = peer.ident;
-    let config = peer.policy_list.get_mut(&InOut::Output);
-    let prior = match &new_name {
-        Some(n) => config.name.replace(n.clone()),
-        None => config.name.take(),
-    };
-    policy_attach_msgs(
+    peer.config.knobs_explicit.policy_out = new_name;
+    let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
+        k.policy_out.clone()
+    });
+    apply_peer_policy_ref(
         &bgp.policy_tx,
-        peer_ident,
+        peer,
         policy::PolicyType::PolicyListOut,
-        prior,
-        new_name,
+        want,
     );
     Some(())
 }
@@ -434,19 +470,11 @@ fn config_prefix_in(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
         None
     };
     let peer = bgp.peers.get_mut(&addr)?;
-    let peer_ident = peer.ident;
-    let config = peer.prefix_set.get_mut(&InOut::Input);
-    let prior = match &new_name {
-        Some(n) => config.name.replace(n.clone()),
-        None => config.name.take(),
-    };
-    policy_attach_msgs(
-        &bgp.policy_tx,
-        peer_ident,
-        policy::PolicyType::PrefixSetIn,
-        prior,
-        new_name,
-    );
+    peer.config.knobs_explicit.prefix_set_in = new_name;
+    let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
+        k.prefix_set_in.clone()
+    });
+    apply_peer_policy_ref(&bgp.policy_tx, peer, policy::PolicyType::PrefixSetIn, want);
     Some(())
 }
 
@@ -458,19 +486,11 @@ fn config_prefix_out(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> 
         None
     };
     let peer = bgp.peers.get_mut(&addr)?;
-    let peer_ident = peer.ident;
-    let config = peer.prefix_set.get_mut(&InOut::Output);
-    let prior = match &new_name {
-        Some(n) => config.name.replace(n.clone()),
-        None => config.name.take(),
-    };
-    policy_attach_msgs(
-        &bgp.policy_tx,
-        peer_ident,
-        policy::PolicyType::PrefixSetOut,
-        prior,
-        new_name,
-    );
+    peer.config.knobs_explicit.prefix_set_out = new_name;
+    let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
+        k.prefix_set_out.clone()
+    });
+    apply_peer_policy_ref(&bgp.policy_tx, peer, policy::PolicyType::PrefixSetOut, want);
     Some(())
 }
 
@@ -480,8 +500,29 @@ fn config_route_reflector(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option
 
     let peer = bgp.peers.get_mut(&addr)?;
 
-    peer.reflector_client = op.is_set() && flag;
-    None
+    // Record the verbatim statement (the `client` boolean leaf): Set
+    // carries the value, Delete forgets the statement. Then resolve
+    // through the neighbor-group precedence: the explicit statement
+    // wins, a Delete falls back to the group's opinion (or the off
+    // default).
+    peer.config.knobs_explicit.route_reflector_client = op.is_set().then_some(flag);
+    let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
+        k.route_reflector_client
+    })
+    .unwrap_or(false);
+    apply_route_reflector_client(peer, want);
+    Some(())
+}
+
+/// Write a resolved `route-reflector client` value onto the peer.
+/// Note the field lives on [`Peer`] directly (`peer.reflector_client`),
+/// not on [`super::peer::PeerConfig`]. Storage-only effective state — no
+/// FSM ritual: like the per-neighbor knob the new role applies to route
+/// reflection performed after the change. Shared by the per-neighbor
+/// callback and the neighbor-group sweep.
+pub(super) fn apply_route_reflector_client(peer: &mut Peer, want: bool) -> bool {
+    peer.reflector_client = want;
+    false
 }
 
 fn config_soft_reconfig_in(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
@@ -520,14 +561,29 @@ fn config_allowas_in(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> 
     let addr = args.addr()?;
     let peer = bgp.peers.get_mut(&addr)?;
 
+    // The verbatim statement now rides `knobs_explicit`; the effective
+    // value (explicit-wins over the group opinion) is written below.
     if op.is_set() {
         peer.config
+            .knobs_explicit
             .allowas_in
             .get_or_insert(AllowAsIn::Count(ALLOWAS_IN_DEFAULT_COUNT));
     } else {
-        peer.config.allowas_in = None;
+        peer.config.knobs_explicit.allowas_in = None;
     }
+    let want =
+        super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| k.allowas_in);
+    apply_allowas_in(peer, want);
     Some(())
+}
+
+/// Write a resolved `allowas-in` value onto the peer. Storage-only
+/// effective state — no FSM ritual: like the per-neighbor knob the new
+/// budget applies to inbound UPDATEs processed after the change.
+/// Shared by the per-neighbor callbacks and the neighbor-group sweep.
+pub(super) fn apply_allowas_in(peer: &mut Peer, want: Option<AllowAsIn>) -> bool {
+    peer.config.allowas_in = want;
+    false
 }
 
 /// `set router bgp neighbor X allowas-in count <1-10>`. Deleting just
@@ -539,13 +595,21 @@ fn config_allowas_in_count(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
     if op.is_set() {
         let count = args.u8()?;
         let peer = bgp.peers.get_mut(&addr)?;
-        peer.config.allowas_in = Some(AllowAsIn::Count(count));
+        peer.config.knobs_explicit.allowas_in = Some(AllowAsIn::Count(count));
     } else {
         let peer = bgp.peers.get_mut(&addr)?;
-        if matches!(peer.config.allowas_in, Some(AllowAsIn::Count(_))) {
-            peer.config.allowas_in = Some(AllowAsIn::Count(ALLOWAS_IN_DEFAULT_COUNT));
+        if matches!(
+            peer.config.knobs_explicit.allowas_in,
+            Some(AllowAsIn::Count(_))
+        ) {
+            peer.config.knobs_explicit.allowas_in =
+                Some(AllowAsIn::Count(ALLOWAS_IN_DEFAULT_COUNT));
         }
     }
+    let peer = bgp.peers.get_mut(&addr)?;
+    let want =
+        super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| k.allowas_in);
+    apply_allowas_in(peer, want);
     Some(())
 }
 
@@ -557,10 +621,16 @@ fn config_allowas_in_origin(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
     let peer = bgp.peers.get_mut(&addr)?;
 
     if op.is_set() {
-        peer.config.allowas_in = Some(AllowAsIn::Origin);
-    } else if matches!(peer.config.allowas_in, Some(AllowAsIn::Origin)) {
-        peer.config.allowas_in = Some(AllowAsIn::Count(ALLOWAS_IN_DEFAULT_COUNT));
+        peer.config.knobs_explicit.allowas_in = Some(AllowAsIn::Origin);
+    } else if matches!(
+        peer.config.knobs_explicit.allowas_in,
+        Some(AllowAsIn::Origin)
+    ) {
+        peer.config.knobs_explicit.allowas_in = Some(AllowAsIn::Count(ALLOWAS_IN_DEFAULT_COUNT));
     }
+    let want =
+        super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| k.allowas_in);
+    apply_allowas_in(peer, want);
     Some(())
 }
 
@@ -572,8 +642,25 @@ fn config_allowas_in_origin(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
 fn config_as_override(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let peer = bgp.peers.get_mut(&addr)?;
-    peer.config.as_override = op.is_set();
+    // Record the verbatim statement (a presence container: presence
+    // means "on"), then resolve through the neighbor-group precedence:
+    // the explicit statement wins, a Delete falls back to the group's
+    // opinion (or the off default).
+    peer.config.knobs_explicit.as_override = op.is_set().then_some(true);
+    let want =
+        super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| k.as_override)
+            .unwrap_or(false);
+    apply_as_override(peer, want);
     Some(())
+}
+
+/// Write a resolved `as-override` value onto the peer. Storage-only
+/// effective state — no FSM ritual: like the per-neighbor knob the new
+/// value applies to UPDATEs advertised after the change. Shared by the
+/// per-neighbor callback and the neighbor-group sweep.
+pub(super) fn apply_as_override(peer: &mut Peer, want: bool) -> bool {
+    peer.config.as_override = want;
+    false
 }
 
 /// `set router bgp neighbor X remove-private-as` — the presence
@@ -591,14 +678,30 @@ fn config_remove_private_as(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opti
     let addr = args.addr()?;
     let peer = bgp.peers.get_mut(&addr)?;
 
+    // The verbatim statement now rides `knobs_explicit`; the effective
+    // value (explicit-wins over the group opinion) is written below.
     if op.is_set() {
         peer.config
+            .knobs_explicit
             .remove_private_as
             .get_or_insert_with(RemovePrivateAs::default);
     } else {
-        peer.config.remove_private_as = None;
+        peer.config.knobs_explicit.remove_private_as = None;
     }
+    let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
+        k.remove_private_as
+    });
+    apply_remove_private_as(peer, want);
     Some(())
+}
+
+/// Write a resolved `remove-private-as` value onto the peer.
+/// Storage-only effective state — no FSM ritual: like the per-neighbor
+/// knob the new policy applies to UPDATEs advertised after the change.
+/// Shared by the per-neighbor callbacks and the neighbor-group sweep.
+pub(super) fn apply_remove_private_as(peer: &mut Peer, want: Option<RemovePrivateAs>) -> bool {
+    peer.config.remove_private_as = want;
+    false
 }
 
 /// `set router bgp neighbor X remove-private-as all`. Act on a mixed
@@ -612,12 +715,17 @@ fn config_remove_private_as_all(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
 
     if op.is_set() {
         peer.config
+            .knobs_explicit
             .remove_private_as
             .get_or_insert_with(RemovePrivateAs::default)
             .all = true;
-    } else if let Some(rpa) = peer.config.remove_private_as.as_mut() {
+    } else if let Some(rpa) = peer.config.knobs_explicit.remove_private_as.as_mut() {
         rpa.all = false;
     }
+    let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
+        k.remove_private_as
+    });
+    apply_remove_private_as(peer, want);
     Some(())
 }
 
@@ -631,12 +739,17 @@ fn config_remove_private_as_replace_as(bgp: &mut Bgp, mut args: Args, op: Config
 
     if op.is_set() {
         peer.config
+            .knobs_explicit
             .remove_private_as
             .get_or_insert_with(RemovePrivateAs::default)
             .replace_as = true;
-    } else if let Some(rpa) = peer.config.remove_private_as.as_mut() {
+    } else if let Some(rpa) = peer.config.knobs_explicit.remove_private_as.as_mut() {
         rpa.replace_as = false;
     }
+    let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
+        k.remove_private_as
+    });
+    apply_remove_private_as(peer, want);
     Some(())
 }
 
@@ -648,8 +761,27 @@ fn config_remove_private_as_replace_as(bgp: &mut Bgp, mut args: Args, op: Config
 fn config_enforce_first_as(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
     let peer = bgp.peers.get_mut(&addr)?;
-    peer.config.enforce_first_as = op.is_set();
+    // Record the verbatim statement (a presence container: presence
+    // means "on"), then resolve through the neighbor-group precedence:
+    // the explicit statement wins, a Delete falls back to the group's
+    // opinion (or the off default).
+    peer.config.knobs_explicit.enforce_first_as = op.is_set().then_some(true);
+    let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
+        k.enforce_first_as
+    })
+    .unwrap_or(false);
+    apply_enforce_first_as(peer, want);
     Some(())
+}
+
+/// Write a resolved `enforce-first-as` value onto the peer.
+/// Storage-only effective state — no FSM ritual: like the per-neighbor
+/// knob the new check applies to inbound UPDATEs processed after the
+/// change. Shared by the per-neighbor callback and the neighbor-group
+/// sweep.
+pub(super) fn apply_enforce_first_as(peer: &mut Peer, want: bool) -> bool {
+    peer.config.enforce_first_as = want;
+    false
 }
 
 /// `set router bgp neighbor X bfd enable true|false` — flips the
@@ -668,7 +800,7 @@ fn config_enforce_first_as(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
 /// `minimum-ttl` is not part of the key; changing it on an already-up
 /// session needs a bounce (BFD applies params only at session
 /// creation), consistent with how intervals / profile behave.
-fn bfd_apply(bgp: &mut Bgp, addr: IpAddr) -> Option<()> {
+pub(super) fn bfd_apply(bgp: &mut Bgp, addr: IpAddr) -> Option<()> {
     let (enable, desired_key, params) = {
         let peer = bgp.peers.get(&addr)?;
         // Effective enable + Echo = the per-neighbor `bfd {}` merged over the
@@ -1567,9 +1699,18 @@ fn config_next_hop_self(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<(
     let afi_safi: AfiSafi = args.afi_safi()?;
     let peer = bgp.peers.get_mut(&addr)?;
 
-    let value = if op.is_set() { args.boolean()? } else { false };
-    let config = peer.config.sub.entry(afi_safi).or_default();
-    config.next_hop_self = value;
+    // Record the verbatim statement, then resolve through the
+    // neighbor-group precedence — a Delete falls back to the group's
+    // per-family opinion (or the off default).
+    if op.is_set() {
+        let value = args.boolean()?;
+        peer.config.nhs_explicit.insert(afi_safi, value);
+    } else {
+        peer.config.nhs_explicit.remove(&afi_safi);
+    }
+    let value =
+        super::neighbor_group::resolve_next_hop_self(&bgp.neighbor_groups, &peer.config, afi_safi);
+    peer.config.sub.entry(afi_safi).or_default().next_hop_self = value;
     Some(())
 }
 
@@ -1628,39 +1769,61 @@ fn config_local_identifier(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Optio
 }
 
 fn config_transport_passive(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
-    let addr = if let Some(addr) = args.v4addr() {
-        IpAddr::V4(addr)
-    } else if let Some(addr) = args.v6addr() {
-        IpAddr::V6(addr)
+    let addr = args.addr()?;
+    // Per-neighbor `transport passive-mode` is a boolean leaf: Set
+    // carries the value, Delete forgets the statement.
+    let passive = if op.is_set() {
+        Some(args.boolean()?)
     } else {
-        return None;
+        None
     };
-    let passive = args.boolean()?;
 
     if let Some(peer) = bgp.peers.get_mut(&addr) {
-        if op == ConfigOp::Set {
-            peer.config.transport.passive = passive;
-        } else {
-            peer.config.transport.passive = false;
-        }
-        // Make the flag effective now, not at the next idle-hold tick.
-        // A started peer parked in Idle has an idle-hold timer armed
-        // toward its first dial (commonly because `remote-as` in the
-        // same commit fired `start()` a moment before this leaf):
-        // re-running the timer reconciler flips it straight to Active
-        // — listening, never dialing. Without this, an inbound
-        // connection landing in that ≤5s Idle window is dropped by
-        // `handle_peer_connection` (Idle refuses connections) and the
-        // remote parks on its 120s connect-retry timer.
-        if peer.config.transport.passive
-            && peer.active
-            && matches!(peer.state, super::peer::State::Idle)
-        {
-            timer::update_timers(peer);
-        }
+        // Record the verbatim statement, then resolve through the
+        // neighbor-group precedence: the explicit statement wins, a
+        // Delete falls back to the group's opinion (or the off
+        // default).
+        peer.config.knobs_explicit.passive = passive;
+        let want =
+            super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| k.passive)
+                .unwrap_or(false);
+        apply_passive(peer, want);
     }
 
     Some(())
+}
+
+/// Write a resolved `passive` value onto the peer, preserving the
+/// per-neighbor ritual. Never bounces (returns `false`): a passive
+/// flip changes only which side dials, applied live by re-running the
+/// timer reconciler. Shared by the per-neighbor callback and the
+/// neighbor-group sweep.
+///
+/// Dynamic (listen-range) members are ALWAYS passive — they only exist
+/// because an inbound connection matched a range and must never dial
+/// back out (see `try_dynamic_accept`, which forces it at
+/// materialization). The resolved opinion is clamped to `true` for such
+/// peers regardless of the group's value.
+///
+/// Make the flag effective now, not at the next idle-hold tick. A
+/// started peer parked in Idle has an idle-hold timer armed toward its
+/// first dial (commonly because `remote-as` in the same commit fired
+/// `start()` a moment before this leaf): re-running the timer
+/// reconciler flips it straight to Active — listening, never dialing.
+/// Without this, an inbound connection landing in that ≤5s Idle window
+/// is dropped by `handle_peer_connection` (Idle refuses connections)
+/// and the remote parks on its 120s connect-retry timer.
+pub(super) fn apply_passive(peer: &mut Peer, want: bool) -> bool {
+    // Dynamic listen-range peers are passive-only, no matter the group.
+    let want = want || matches!(peer.origin, super::peer_key::PeerOrigin::Dynamic { .. });
+    peer.config.transport.passive = want;
+    if peer.config.transport.passive
+        && peer.active
+        && matches!(peer.state, super::peer::State::Idle)
+    {
+        timer::update_timers(peer);
+    }
+    false
 }
 
 fn config_transport_local_address(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
@@ -1672,23 +1835,33 @@ fn config_transport_local_address(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -
         return None;
     };
 
-    let peer = bgp.peers.get_mut(&peer_addr)?;
+    {
+        let peer = bgp.peers.get_mut(&peer_addr)?;
 
-    if op == ConfigOp::Set {
-        let source = if let Some(addr) = args.v4addr() {
-            IpAddr::V4(addr)
-        } else if let Some(addr) = args.v6addr() {
-            IpAddr::V6(addr)
+        // Record the verbatim statement, then resolve through the
+        // neighbor-group precedence — a Delete falls back to the
+        // group's source (or none).
+        if op == ConfigOp::Set {
+            let source = if let Some(addr) = args.v4addr() {
+                IpAddr::V4(addr)
+            } else if let Some(addr) = args.v6addr() {
+                IpAddr::V6(addr)
+            } else {
+                return None;
+            };
+            // Address family of the source must match the peer; an
+            // invalid statement is refused outright (not recorded).
+            if source.is_ipv4() != peer_addr.is_ipv4() {
+                return None;
+            }
+            peer.config.knobs_explicit.update_source = Some(source);
         } else {
-            return None;
-        };
-        // Address family of the source must match the peer.
-        if source.is_ipv4() != peer_addr.is_ipv4() {
-            return None;
+            peer.config.knobs_explicit.update_source = None;
         }
-        peer.config.transport.update_source = Some(source);
-    } else {
-        peer.config.transport.update_source = None;
+        let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
+            k.update_source
+        });
+        apply_update_source(peer, want);
     }
 
     // IOS-XR semantics: an async BFD session inherits the neighbor's
@@ -1703,6 +1876,33 @@ fn config_transport_local_address(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -
     bfd_apply(bgp, peer_addr)
 }
 
+/// Write a resolved `update-source` onto the peer. The connect path
+/// reads it at dial time, so no bounce — parity with the per-neighbor
+/// callback, which has never bounced on a source change. A source
+/// whose address family doesn't match the peer is skipped with a
+/// warning: a group serves IPv4 and IPv6 members alike, so a v4
+/// `update-source` simply doesn't apply to a v6 member
+/// (interface-keyed link-local peers included). Returns `true` when
+/// the stored value changed — the caller owes a `bfd_apply`
+/// reconcile.
+pub(super) fn apply_update_source(peer: &mut Peer, want: Option<IpAddr>) -> bool {
+    if let Some(source) = want
+        && source.is_ipv4() != peer.address.is_ipv4()
+    {
+        tracing::warn!(
+            peer = %peer.display_name(),
+            source = %source,
+            "bgp: update-source address family does not match the peer; not applied to this member",
+        );
+        return false;
+    }
+    if peer.config.transport.update_source == want {
+        return false;
+    }
+    peer.config.transport.update_source = want;
+    true
+}
+
 /// `[no] router bgp neighbor <addr> ttl-security` — enable GTSM (RFC
 /// 5082) for a directly-connected peer. The leaf is `type empty`, so
 /// presence (Set) turns it on and Delete turns it off; no value is
@@ -1714,31 +1914,18 @@ fn config_transport_local_address(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -
 /// connect.
 fn config_ttl_security(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
-    let want = op.is_set();
     let (ident, bounce) = {
         let peer = bgp.peers.get_mut(&addr)?;
-        // Mutually exclusive with ebgp-multihop: GTSM pins the TTL to 255
-        // and filters the received TTL, while ebgp-multihop permits a
-        // decremented TTL. Refuse to enable GTSM on a peer that already
-        // has ebgp-multihop — the existing setting wins; the operator
-        // must remove ebgp-multihop first.
-        if want && peer.config.transport.ebgp_multihop.is_some() {
-            tracing::warn!(
-                peer = %addr,
-                "bgp: ttl-security and ebgp-multihop are mutually exclusive; ignoring ttl-security (remove ebgp-multihop on this neighbor first)",
-            );
-            return Some(());
-        }
-        if peer.config.transport.ttl_security == want {
-            // No actual change — don't disturb a live session.
-            return Some(());
-        }
-        peer.config.transport.ttl_security = want;
-        peer.start();
-        // Only an established / in-progress session needs an explicit
-        // bounce; bouncing an Idle peer here could race the idle-hold
-        // timer `start()` just armed and strand it.
-        (peer.ident, !matches!(peer.state, super::peer::State::Idle))
+        // Record the verbatim statement, then resolve through the
+        // neighbor-group precedence: the explicit statement wins, a
+        // Delete falls back to the group's opinion (or the off
+        // default).
+        peer.config.knobs_explicit.ttl_security = op.is_set().then_some(true);
+        let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
+            k.ttl_security
+        })
+        .unwrap_or(false);
+        (peer.ident, apply_ttl_security(peer, want))
     };
     if bounce {
         let _ = bgp
@@ -1746,6 +1933,36 @@ fn config_ttl_security(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()
             .try_send(super::inst::Message::Event(ident, super::peer::Event::Stop));
     }
     Some(())
+}
+
+/// Write a resolved `ttl-security` value onto the peer, preserving the
+/// per-neighbor ritual: the ebgp-multihop mutual-exclusion guard, the
+/// no-change diff-gate, `start()` for a dormant peer, and the
+/// bounce-if-live decision (returned to the caller, which owns the
+/// `Event::Stop` send — only an established / in-progress session
+/// needs the explicit bounce; bouncing an Idle peer here could race
+/// the idle-hold timer `start()` just armed and strand it). Shared by
+/// the per-neighbor callback and the neighbor-group sweep.
+///
+/// GTSM pins the TTL to 255 and filters the received TTL, while
+/// ebgp-multihop permits a decremented TTL — refusing to enable GTSM
+/// on a peer that already has ebgp-multihop keeps the existing
+/// setting; the operator must remove ebgp-multihop first.
+pub(super) fn apply_ttl_security(peer: &mut Peer, want: bool) -> bool {
+    if want && peer.config.transport.ebgp_multihop.is_some() {
+        tracing::warn!(
+            peer = %peer.display_name(),
+            "bgp: ttl-security and ebgp-multihop are mutually exclusive; ignoring ttl-security (remove ebgp-multihop on this neighbor first)",
+        );
+        return false;
+    }
+    if peer.config.transport.ttl_security == want {
+        // No actual change — don't disturb a live session.
+        return false;
+    }
+    peer.config.transport.ttl_security = want;
+    peer.start();
+    !matches!(peer.state, super::peer::State::Idle)
 }
 
 /// `[no] router bgp neighbor <addr> ebgp-multihop <1-255>` — raise the
@@ -1764,22 +1981,14 @@ fn config_ebgp_multihop(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<(
     let want = if op.is_set() { Some(args.u8()?) } else { None };
     let (ident, bounce) = {
         let peer = bgp.peers.get_mut(&addr)?;
-        // Mutually exclusive with ttl-security (see `config_ttl_security`).
-        // Refuse to set ebgp-multihop on a peer that already has GTSM —
-        // the existing setting wins; remove ttl-security first.
-        if want.is_some() && peer.config.transport.ttl_security {
-            tracing::warn!(
-                peer = %addr,
-                "bgp: ebgp-multihop and ttl-security are mutually exclusive; ignoring ebgp-multihop (remove ttl-security on this neighbor first)",
-            );
-            return Some(());
-        }
-        if peer.config.transport.ebgp_multihop == want {
-            return Some(());
-        }
-        peer.config.transport.ebgp_multihop = want;
-        peer.start();
-        (peer.ident, !matches!(peer.state, super::peer::State::Idle))
+        // Record the verbatim statement, then resolve through the
+        // neighbor-group precedence: the explicit statement wins, a
+        // Delete falls back to the group's opinion (or off — `None`).
+        peer.config.knobs_explicit.ebgp_multihop = want;
+        let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
+            k.ebgp_multihop
+        });
+        (peer.ident, apply_ebgp_multihop(peer, want))
     };
     if bounce {
         let _ = bgp
@@ -1787,6 +1996,35 @@ fn config_ebgp_multihop(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<(
             .try_send(super::inst::Message::Event(ident, super::peer::Event::Stop));
     }
     Some(())
+}
+
+/// Write a resolved `ebgp-multihop` value onto the peer, preserving the
+/// per-neighbor ritual: the ttl-security mutual-exclusion guard, the
+/// no-change diff-gate, `start()` for a dormant peer, and the
+/// bounce-if-live decision (returned to the caller, which owns the
+/// `Event::Stop` send — only an established / in-progress session needs
+/// the explicit bounce; bouncing an Idle peer here could race the
+/// idle-hold timer `start()` just armed and strand it). Shared by the
+/// per-neighbor callback and the neighbor-group sweep.
+///
+/// Mutually exclusive with ttl-security (GTSM pins the TTL to 255 while
+/// ebgp-multihop permits a decremented TTL): refusing to raise the TTL
+/// on a peer that already has GTSM keeps the existing setting; the
+/// operator must remove ttl-security first.
+pub(super) fn apply_ebgp_multihop(peer: &mut Peer, want: Option<u8>) -> bool {
+    if want.is_some() && peer.config.transport.ttl_security {
+        tracing::warn!(
+            peer = %peer.display_name(),
+            "bgp: ebgp-multihop and ttl-security are mutually exclusive; ignoring ebgp-multihop (remove ttl-security on this neighbor first)",
+        );
+        return false;
+    }
+    if peer.config.transport.ebgp_multihop == want {
+        return false;
+    }
+    peer.config.transport.ebgp_multihop = want;
+    peer.start();
+    !matches!(peer.state, super::peer::State::Idle)
 }
 
 /// `[no] router bgp neighbor <addr> tcp-mss <1-65535>` — cap the TCP
@@ -1805,19 +2043,37 @@ fn config_ebgp_multihop(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<(
 /// (a freshly created, still-Idle peer begins connecting).
 fn config_tcp_mss(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
-    // On delete the echoed value (if any) is irrelevant — clear it.
-    let want = if op.is_set() { Some(args.u16()?) } else { None };
-    {
+    let changed = {
         let peer = bgp.peers.get_mut(&addr)?;
-        if peer.config.transport.tcp_mss == want {
-            // No actual change — leave the live session and listener alone.
-            return Some(());
-        }
-        peer.config.transport.tcp_mss = want;
-        peer.start();
+        // Record the verbatim statement, then resolve through the
+        // neighbor-group precedence — a Delete falls back to the
+        // group's clamp (or none).
+        peer.config.knobs_explicit.tcp_mss = if op.is_set() { Some(args.u16()?) } else { None };
+        let want =
+            super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| k.tcp_mss);
+        apply_tcp_mss(peer, want)
+    };
+    if changed {
+        apply_tcp_mss_refresh_all(bgp);
     }
-    apply_tcp_mss_refresh_all(bgp);
     Some(())
+}
+
+/// Write a resolved `tcp-mss` onto the peer, preserving the
+/// per-neighbor ritual: the no-change diff-gate and `start()` for a
+/// dormant peer. Never bounces — the clamp is read at connect time;
+/// the operator clears the session for immediate effect. Returns
+/// `true` when the value changed, in which case the caller owes one
+/// [`apply_tcp_mss_refresh_all`] so the shared listener re-derives
+/// its per-AF minimum.
+pub(super) fn apply_tcp_mss(peer: &mut Peer, want: Option<u16>) -> bool {
+    if peer.config.transport.tcp_mss == want {
+        // No actual change — leave the live session and listener alone.
+        return false;
+    }
+    peer.config.transport.tcp_mss = want;
+    peer.start();
+    true
 }
 
 /// Reconcile the shared BGP listener's TCP MSS. A listening socket
@@ -1876,16 +2132,14 @@ fn config_peer_port(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let want = if op.is_set() { Some(args.u16()?) } else { None };
     let (ident, bounce) = {
         let peer = bgp.peers.get_mut(&addr)?;
-        if peer.config.transport.port == want {
-            // No actual change — don't disturb a live session.
-            return Some(());
-        }
-        peer.config.transport.port = want;
-        peer.start();
-        // Only an established / in-progress session needs an explicit
-        // bounce; bouncing an Idle peer here could race the idle-hold
-        // timer `start()` just armed and strand it.
-        (peer.ident, !matches!(peer.state, super::peer::State::Idle))
+        // Record the verbatim statement, then resolve through the
+        // neighbor-group precedence: the explicit statement wins, a
+        // Delete falls back to the group's opinion (or the 179
+        // default — `None`).
+        peer.config.knobs_explicit.port = want;
+        let want =
+            super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| k.port);
+        (peer.ident, apply_port(peer, want))
     };
     if bounce {
         let _ = bgp
@@ -1893,6 +2147,23 @@ fn config_peer_port(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
             .try_send(super::inst::Message::Event(ident, super::peer::Event::Stop));
     }
     Some(())
+}
+
+/// Write a resolved `port` onto the peer, preserving the per-neighbor
+/// ritual: the no-change diff-gate, `start()` for a dormant peer, and
+/// the bounce-if-live decision (returned to the caller, which owns the
+/// `Event::Stop` send — only an established / in-progress session needs
+/// the explicit bounce; bouncing an Idle peer here could race the
+/// idle-hold timer `start()` just armed and strand it). Shared by the
+/// per-neighbor callback and the neighbor-group sweep.
+pub(super) fn apply_port(peer: &mut Peer, want: Option<u16>) -> bool {
+    if peer.config.transport.port == want {
+        // No actual change — don't disturb a live session.
+        return false;
+    }
+    peer.config.transport.port = want;
+    peer.start();
+    !matches!(peer.state, super::peer::State::Idle)
 }
 
 /// `[no] router bgp port <0-65535>` — TCP port the BGP listener binds;
@@ -1929,21 +2200,18 @@ fn config_global_port(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()>
 /// `peer_change_reset`). An Idle peer just picks it up on its first connect.
 fn config_disable_connected_check(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
     let addr = args.addr()?;
-    let want = op.is_set();
     let (ident, bounce) = {
         let peer = bgp.peers.get_mut(&addr)?;
-        if peer.config.transport.disable_connected_check == want {
-            // No actual change — don't disturb a live session.
-            return Some(());
-        }
-        peer.config.transport.disable_connected_check = want;
-        peer.start();
-        // Only an established / in-progress session needs an explicit
-        // bounce; bouncing an Idle peer here could race the idle-hold
-        // timer `start()` just armed and strand it. A held (Active) peer
-        // is bounced too, so it leaves Active and re-dials on the next
-        // idle-hold rather than waiting out the connect-retry backstop.
-        (peer.ident, !matches!(peer.state, super::peer::State::Idle))
+        // Record the verbatim statement (a `type empty` flag: presence
+        // means "on"), then resolve through the neighbor-group
+        // precedence: the explicit statement wins, a Delete falls back
+        // to the group's opinion (or the off default).
+        peer.config.knobs_explicit.disable_connected_check = op.is_set().then_some(true);
+        let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
+            k.disable_connected_check
+        })
+        .unwrap_or(false);
+        (peer.ident, apply_disable_connected_check(peer, want))
     };
     if bounce {
         let _ = bgp
@@ -1951,6 +2219,26 @@ fn config_disable_connected_check(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -
             .try_send(super::inst::Message::Event(ident, super::peer::Event::Stop));
     }
     Some(())
+}
+
+/// Write a resolved `disable-connected-check` value onto the peer,
+/// preserving the per-neighbor ritual: the no-change diff-gate,
+/// `start()` for a dormant peer, and the bounce-if-live decision
+/// (returned to the caller, which owns the `Event::Stop` send — only an
+/// established / in-progress session needs the explicit bounce;
+/// bouncing an Idle peer here could race the idle-hold timer `start()`
+/// just armed and strand it. A held (Active) peer is bounced too, so it
+/// leaves Active and re-dials on the next idle-hold rather than waiting
+/// out the connect-retry backstop). Shared by the per-neighbor callback
+/// and the neighbor-group sweep.
+pub(super) fn apply_disable_connected_check(peer: &mut Peer, want: bool) -> bool {
+    if peer.config.transport.disable_connected_check == want {
+        // No actual change — don't disturb a live session.
+        return false;
+    }
+    peer.config.transport.disable_connected_check = want;
+    peer.start();
+    !matches!(peer.state, super::peer::State::Idle)
 }
 
 fn config_peer_tcp_md5_password(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
@@ -1962,20 +2250,26 @@ fn config_peer_tcp_md5_password(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
         return None;
     };
 
-    // Store the password on the peer if it exists. The peer may not
-    // be in the map yet if the per-leaf callbacks fire in deeper-first
+    // Record the verbatim statement on the peer if it exists, then
+    // resolve through the neighbor-group precedence — a Delete falls
+    // back to the group's password (or none). The peer may not be in
+    // the map yet if the per-leaf callbacks fire in deeper-first
     // order (`/password` before `/neighbor`); in that case we just
-    // skip the field-store — the peer will be created momentarily and
-    // a follow-up `apply_md5_refresh_all` will catch up. The earlier
+    // skip the record — the peer will be created momentarily and a
+    // follow-up `apply_md5_refresh_all` will catch up. The earlier
     // `?` short-circuit also skipped the listener install, which is
     // the actual bug that left passive peers unauthenticated.
-    if op == ConfigOp::Set {
-        let password = args.string()?;
-        if let Some(peer) = bgp.peers.get_mut(&addr) {
-            peer.config.transport.md5_password = Some(password);
-        }
-    } else if let Some(peer) = bgp.peers.get_mut(&addr) {
-        peer.config.transport.md5_password = None;
+    let explicit = if op == ConfigOp::Set {
+        Some(args.string()?)
+    } else {
+        None
+    };
+    if let Some(peer) = bgp.peers.get_mut(&addr) {
+        peer.config.knobs_explicit.password = explicit;
+        let want = super::neighbor_group::resolve_knob(&bgp.neighbor_groups, &peer.config, |k| {
+            k.password.clone()
+        });
+        apply_md5_password(peer, want);
     }
 
     // Reconcile the listener state for this peer regardless of
@@ -1988,12 +2282,26 @@ fn config_peer_tcp_md5_password(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> 
     Some(())
 }
 
+/// Write a resolved TCP MD5 password onto the peer. The active
+/// connect path reads it at dial time and the listener key is owned
+/// by [`apply_md5_refresh_for`] — no bounce, parity with the
+/// per-neighbor callback (the live session keeps its key until it
+/// resets). Returns `true` when the stored value changed — the
+/// caller owes a listener re-key for this peer's address.
+pub(super) fn apply_md5_password(peer: &mut Peer, want: Option<String>) -> bool {
+    if peer.config.transport.md5_password == want {
+        return false;
+    }
+    peer.config.transport.md5_password = want;
+    true
+}
+
 /// Reconcile the listener TCP MD5 key for a single peer. Reads
 /// `peer.config.transport.md5_password` and installs (or removes,
 /// with an empty key) on the appropriate listening socket. Silent
 /// when there is no listener fd yet — `apply_md5_refresh_all` from
 /// `listen()` will fill in once the bind completes.
-fn apply_md5_refresh_for(bgp: &mut Bgp, addr: IpAddr) {
+pub(super) fn apply_md5_refresh_for(bgp: &mut Bgp, addr: IpAddr) {
     let listen_fd = match addr {
         IpAddr::V4(_) => bgp.listen_fd_v4,
         IpAddr::V6(_) => bgp.listen_fd_v6,
@@ -2294,6 +2602,94 @@ impl Bgp {
         self.callback_add(
             "/router/bgp/neighbor-group/afi-safi/enabled",
             super::neighbor_group::config_neighbor_group_afi_safi_enabled,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/afi-safi/next-hop-self",
+            super::neighbor_group::config_neighbor_group_afi_safi_next_hop_self,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/ttl-security",
+            super::neighbor_group::config_neighbor_group_ttl_security,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/port",
+            super::neighbor_group::config_neighbor_group_port,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/ebgp-multihop",
+            super::neighbor_group::config_neighbor_group_ebgp_multihop,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/disable-connected-check",
+            super::neighbor_group::config_neighbor_group_disable_connected_check,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/passive",
+            super::neighbor_group::config_neighbor_group_passive,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/allowas-in",
+            super::neighbor_group::config_neighbor_group_allowas_in,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/allowas-in/count",
+            super::neighbor_group::config_neighbor_group_allowas_in_count,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/allowas-in/origin",
+            super::neighbor_group::config_neighbor_group_allowas_in_origin,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/as-override",
+            super::neighbor_group::config_neighbor_group_as_override,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/remove-private-as",
+            super::neighbor_group::config_neighbor_group_remove_private_as,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/remove-private-as/all",
+            super::neighbor_group::config_neighbor_group_remove_private_as_all,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/remove-private-as/replace-as",
+            super::neighbor_group::config_neighbor_group_remove_private_as_replace_as,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/enforce-first-as",
+            super::neighbor_group::config_neighbor_group_enforce_first_as,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/route-reflector/client",
+            super::neighbor_group::config_neighbor_group_route_reflector_client,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/update-source",
+            super::neighbor_group::config_neighbor_group_update_source,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/tcp-mss",
+            super::neighbor_group::config_neighbor_group_tcp_mss,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/password",
+            super::neighbor_group::config_neighbor_group_password,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/policy/in",
+            super::neighbor_group::config_neighbor_group_policy_in,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/policy/out",
+            super::neighbor_group::config_neighbor_group_policy_out,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/prefix-set/in",
+            super::neighbor_group::config_neighbor_group_prefix_set_in,
+        );
+        self.callback_add(
+            "/router/bgp/neighbor-group/prefix-set/out",
+            super::neighbor_group::config_neighbor_group_prefix_set_out,
         );
         // `set router bgp dynamic-neighbors …`.
         self.callback_add(
@@ -4245,6 +4641,764 @@ mod neighbor_group_wiring_tests {
             vec![v6()],
             "the sweep must reach the interface-keyed member",
         );
+    }
+
+    // ---- whole-session knob inheritance (ttl-security exemplar) --
+
+    use super::super::neighbor_group::config_neighbor_group_ttl_security;
+
+    fn member_ttl_security(bgp: &Bgp) -> bool {
+        bgp.peers
+            .get(&peer_addr())
+            .expect("peer exists")
+            .config
+            .transport
+            .ttl_security
+    }
+
+    /// Group ttl-security flows to a member with the same ritual as
+    /// the per-neighbor knob: applied on an Idle peer without a
+    /// bounce, bounced on a live session, and removed when the group
+    /// opinion goes away.
+    #[tokio::test]
+    async fn group_ttl_security_propagates_and_bounces_live_member() {
+        use crate::bgp::peer::State;
+        let mut bgp = fresh_bgp();
+        config_neighbor_group_remote_as(&mut bgp, arg_words(&["G", "65000"]), ConfigOp::Set)
+            .unwrap();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_peer_neighbor_group(&mut bgp, arg_words(&["10.0.0.1", "G"]), ConfigOp::Set).unwrap();
+        let _ = drain_stop_events(&mut bgp);
+
+        // Idle member: flag lands, no bounce.
+        config_neighbor_group_ttl_security(&mut bgp, arg_words(&["G"]), ConfigOp::Set).unwrap();
+        assert!(member_ttl_security(&bgp), "group opinion must apply");
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "an Idle member must not be bounced",
+        );
+
+        // Live member: a group flip bounces it, exactly like the
+        // per-neighbor callback would.
+        bgp.peers.get_mut(&peer_addr()).unwrap().state = State::Established;
+        config_neighbor_group_ttl_security(&mut bgp, arg_words(&["G"]), ConfigOp::Delete).unwrap();
+        assert!(!member_ttl_security(&bgp), "group delete must clear");
+        assert_eq!(
+            drain_stop_events(&mut bgp).len(),
+            1,
+            "a live member must bounce to drop GTSM",
+        );
+    }
+
+    /// Explicit per-neighbor ttl-security outlives group changes, and
+    /// deleting the explicit statement falls back to the group's
+    /// opinion instead of off.
+    #[tokio::test]
+    async fn peer_explicit_ttl_security_wins_and_falls_back() {
+        let mut bgp = fresh_bgp();
+        config_neighbor_group_remote_as(&mut bgp, arg_words(&["G", "65000"]), ConfigOp::Set)
+            .unwrap();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_peer_neighbor_group(&mut bgp, arg_words(&["10.0.0.1", "G"]), ConfigOp::Set).unwrap();
+
+        config_ttl_security(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_neighbor_group_ttl_security(&mut bgp, arg_words(&["G"]), ConfigOp::Set).unwrap();
+        assert!(member_ttl_security(&bgp));
+
+        // Deleting the explicit statement keeps GTSM via the group.
+        config_ttl_security(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Delete).unwrap();
+        assert!(
+            member_ttl_security(&bgp),
+            "delete of the explicit statement must fall back to the group opinion",
+        );
+
+        // Dropping the group opinion finally clears it.
+        config_neighbor_group_ttl_security(&mut bgp, arg_words(&["G"]), ConfigOp::Delete).unwrap();
+        assert!(!member_ttl_security(&bgp));
+    }
+
+    /// Per-family next-hop-self inherits through the group's afi-safi
+    /// entry with explicit-wins semantics.
+    #[tokio::test]
+    async fn group_next_hop_self_propagates_with_explicit_priority() {
+        use super::super::neighbor_group::config_neighbor_group_afi_safi_next_hop_self;
+
+        let mut bgp = fresh_bgp();
+        config_neighbor_group_remote_as(&mut bgp, arg_words(&["G", "65000"]), ConfigOp::Set)
+            .unwrap();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_peer_neighbor_group(&mut bgp, arg_words(&["10.0.0.1", "G"]), ConfigOp::Set).unwrap();
+
+        let nhs = |bgp: &Bgp| {
+            bgp.peers
+                .get(&peer_addr())
+                .unwrap()
+                .config
+                .sub
+                .get(&v4())
+                .map(|s| s.next_hop_self)
+                .unwrap_or(false)
+        };
+
+        config_neighbor_group_afi_safi_enabled(
+            &mut bgp,
+            arg_words(&["G", "ipv4", "true"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        config_neighbor_group_afi_safi_next_hop_self(
+            &mut bgp,
+            arg_words(&["G", "ipv4", "true"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert!(nhs(&bgp), "group next-hop-self must apply");
+
+        // Explicit per-neighbor false outranks the group's true.
+        config_next_hop_self(
+            &mut bgp,
+            arg_words(&["10.0.0.1", "ipv4", "false"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert!(!nhs(&bgp), "explicit statement must win");
+
+        // Removing the explicit statement falls back to the group.
+        config_next_hop_self(
+            &mut bgp,
+            arg_words(&["10.0.0.1", "ipv4", "false"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        assert!(nhs(&bgp), "fallback to group opinion");
+
+        // Dropping the family entry (enabled delete removes the whole
+        // entry, next-hop-self opinion included) clears it.
+        config_neighbor_group_afi_safi_enabled(
+            &mut bgp,
+            arg_words(&["G", "ipv4", "true"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        assert!(!nhs(&bgp), "entry delete clears the inherited value");
+    }
+
+    // ---- the nine additional inheritable whole-session knobs --------
+    //
+    // One focused test per knob. Bounce-family knobs (port,
+    // ebgp-multihop, disable-connected-check) mirror the ttl-security
+    // exemplar: value propagates, a live member bounces, explicit wins
+    // and falls back. Write-only knobs (passive, allowas-in,
+    // as-override, remove-private-as, enforce-first-as,
+    // route-reflector) additionally assert the sweep never bounces.
+
+    use super::super::neighbor_group::{
+        config_neighbor_group_allowas_in, config_neighbor_group_allowas_in_count,
+        config_neighbor_group_allowas_in_origin, config_neighbor_group_as_override,
+        config_neighbor_group_disable_connected_check, config_neighbor_group_ebgp_multihop,
+        config_neighbor_group_enforce_first_as, config_neighbor_group_passive,
+        config_neighbor_group_port, config_neighbor_group_remove_private_as,
+        config_neighbor_group_remove_private_as_all,
+        config_neighbor_group_remove_private_as_replace_as,
+        config_neighbor_group_route_reflector_client,
+    };
+
+    /// Attach `10.0.0.1` to group `G` (which has a remote-as so the
+    /// member can start), draining the setup events. Returns a `Bgp`
+    /// with the member parked Idle.
+    fn bgp_with_member() -> Bgp {
+        let mut bgp = fresh_bgp();
+        config_neighbor_group_remote_as(&mut bgp, arg_words(&["G", "65000"]), ConfigOp::Set)
+            .unwrap();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_peer_neighbor_group(&mut bgp, arg_words(&["10.0.0.1", "G"]), ConfigOp::Set).unwrap();
+        let _ = drain_stop_events(&mut bgp);
+        bgp
+    }
+
+    fn member(bgp: &Bgp) -> &Peer {
+        bgp.peers.get(&peer_addr()).expect("peer exists")
+    }
+
+    /// Group `port` flows to an Idle member without a bounce, bounces a
+    /// live member, and the explicit per-neighbor value wins and falls
+    /// back to the group on explicit-delete.
+    #[tokio::test]
+    async fn group_port_propagates_explicit_wins_and_bounces_live() {
+        use crate::bgp::peer::State;
+        let mut bgp = bgp_with_member();
+
+        // Idle member: value lands, no bounce.
+        config_neighbor_group_port(&mut bgp, arg_words(&["G", "1790"]), ConfigOp::Set).unwrap();
+        assert_eq!(member(&bgp).config.transport.port, Some(1790));
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "an Idle member must not be bounced",
+        );
+
+        // Explicit per-neighbor value wins over the group's.
+        config_peer_port(&mut bgp, arg_words(&["10.0.0.1", "1791"]), ConfigOp::Set).unwrap();
+        assert_eq!(member(&bgp).config.transport.port, Some(1791));
+        let _ = drain_stop_events(&mut bgp);
+
+        // Live member: a group flip bounces it (only matters once the
+        // explicit value is gone, so delete it first).
+        config_peer_port(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Delete).unwrap();
+        assert_eq!(
+            member(&bgp).config.transport.port,
+            Some(1790),
+            "explicit delete falls back to the group opinion",
+        );
+        let _ = drain_stop_events(&mut bgp);
+
+        bgp.peers.get_mut(&peer_addr()).unwrap().state = State::Established;
+        config_neighbor_group_port(&mut bgp, arg_words(&["G"]), ConfigOp::Delete).unwrap();
+        assert_eq!(
+            member(&bgp).config.transport.port,
+            None,
+            "group delete clears"
+        );
+        assert_eq!(
+            drain_stop_events(&mut bgp).len(),
+            1,
+            "a live member must bounce to re-dial on the new port",
+        );
+    }
+
+    /// Group `ebgp-multihop` propagates with explicit-wins / fallback
+    /// and bounces a live member.
+    #[tokio::test]
+    async fn group_ebgp_multihop_propagates_explicit_wins_and_bounces_live() {
+        use crate::bgp::peer::State;
+        let mut bgp = bgp_with_member();
+
+        config_neighbor_group_ebgp_multihop(&mut bgp, arg_words(&["G", "5"]), ConfigOp::Set)
+            .unwrap();
+        assert_eq!(member(&bgp).config.transport.ebgp_multihop, Some(5));
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "an Idle member must not be bounced",
+        );
+
+        config_ebgp_multihop(&mut bgp, arg_words(&["10.0.0.1", "10"]), ConfigOp::Set).unwrap();
+        assert_eq!(member(&bgp).config.transport.ebgp_multihop, Some(10));
+        let _ = drain_stop_events(&mut bgp);
+
+        config_ebgp_multihop(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Delete).unwrap();
+        assert_eq!(
+            member(&bgp).config.transport.ebgp_multihop,
+            Some(5),
+            "explicit delete falls back to the group opinion",
+        );
+        let _ = drain_stop_events(&mut bgp);
+
+        bgp.peers.get_mut(&peer_addr()).unwrap().state = State::Established;
+        config_neighbor_group_ebgp_multihop(&mut bgp, arg_words(&["G"]), ConfigOp::Delete).unwrap();
+        assert_eq!(member(&bgp).config.transport.ebgp_multihop, None);
+        assert_eq!(
+            drain_stop_events(&mut bgp).len(),
+            1,
+            "a live member must bounce to apply the new TTL",
+        );
+    }
+
+    /// Group `disable-connected-check` (a `type empty` flag)
+    /// propagates with explicit-wins / fallback and bounces a live
+    /// member.
+    #[tokio::test]
+    async fn group_disable_connected_check_propagates_and_bounces_live() {
+        use crate::bgp::peer::State;
+        let mut bgp = bgp_with_member();
+
+        config_neighbor_group_disable_connected_check(&mut bgp, arg_words(&["G"]), ConfigOp::Set)
+            .unwrap();
+        assert!(member(&bgp).config.transport.disable_connected_check);
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "an Idle member must not be bounced",
+        );
+
+        // Live member: dropping the group opinion bounces it.
+        bgp.peers.get_mut(&peer_addr()).unwrap().state = State::Established;
+        config_neighbor_group_disable_connected_check(
+            &mut bgp,
+            arg_words(&["G"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        assert!(
+            !member(&bgp).config.transport.disable_connected_check,
+            "group delete clears"
+        );
+        assert_eq!(
+            drain_stop_events(&mut bgp).len(),
+            1,
+            "a live member must bounce when the check is re-enabled",
+        );
+    }
+
+    /// Group `passive` flows to the member, the explicit per-neighbor
+    /// value wins and falls back, and the sweep never bounces.
+    #[tokio::test]
+    async fn group_passive_propagates_explicit_wins_no_bounce() {
+        use crate::bgp::peer::State;
+        let mut bgp = bgp_with_member();
+        bgp.peers.get_mut(&peer_addr()).unwrap().state = State::Established;
+
+        config_neighbor_group_passive(&mut bgp, arg_words(&["G", "true"]), ConfigOp::Set).unwrap();
+        assert!(
+            member(&bgp).config.transport.passive,
+            "group opinion must apply"
+        );
+
+        // Explicit per-neighbor false outranks the group's true.
+        config_transport_passive(&mut bgp, arg_words(&["10.0.0.1", "false"]), ConfigOp::Set)
+            .unwrap();
+        assert!(
+            !member(&bgp).config.transport.passive,
+            "explicit statement must win"
+        );
+
+        // Removing the explicit statement falls back to the group.
+        config_transport_passive(
+            &mut bgp,
+            arg_words(&["10.0.0.1", "false"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        assert!(
+            member(&bgp).config.transport.passive,
+            "fallback to group opinion"
+        );
+
+        // Dropping the group opinion clears it.
+        config_neighbor_group_passive(&mut bgp, arg_words(&["G"]), ConfigOp::Delete).unwrap();
+        assert!(
+            !member(&bgp).config.transport.passive,
+            "group delete clears"
+        );
+
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "passive changes must never bounce the session",
+        );
+    }
+
+    /// Group `allowas-in` (bare + count + origin) propagates with
+    /// explicit-wins / fallback and never bounces.
+    #[tokio::test]
+    async fn group_allowas_in_propagates_explicit_wins_no_bounce() {
+        use crate::bgp::peer::AllowAsIn;
+        use crate::bgp::peer::State;
+        let mut bgp = bgp_with_member();
+        bgp.peers.get_mut(&peer_addr()).unwrap().state = State::Established;
+
+        // Bare form → default count.
+        config_neighbor_group_allowas_in(&mut bgp, arg_words(&["G"]), ConfigOp::Set).unwrap();
+        assert_eq!(member(&bgp).config.allowas_in, Some(AllowAsIn::Count(3)));
+
+        // Group count then origin (order-independent cooperative leaves).
+        config_neighbor_group_allowas_in_count(&mut bgp, arg_words(&["G", "7"]), ConfigOp::Set)
+            .unwrap();
+        assert_eq!(member(&bgp).config.allowas_in, Some(AllowAsIn::Count(7)));
+        config_neighbor_group_allowas_in_origin(&mut bgp, arg_words(&["G"]), ConfigOp::Set)
+            .unwrap();
+        assert_eq!(member(&bgp).config.allowas_in, Some(AllowAsIn::Origin));
+
+        // Explicit per-neighbor count wins over the group's origin.
+        config_allowas_in_count(&mut bgp, arg_words(&["10.0.0.1", "5"]), ConfigOp::Set).unwrap();
+        assert_eq!(member(&bgp).config.allowas_in, Some(AllowAsIn::Count(5)));
+
+        // Removing the whole explicit container falls back to the group.
+        config_allowas_in(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Delete).unwrap();
+        assert_eq!(
+            member(&bgp).config.allowas_in,
+            Some(AllowAsIn::Origin),
+            "fallback to group opinion",
+        );
+
+        // Dropping the group container clears it.
+        config_neighbor_group_allowas_in(&mut bgp, arg_words(&["G"]), ConfigOp::Delete).unwrap();
+        assert_eq!(member(&bgp).config.allowas_in, None, "group delete clears");
+
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "allowas-in changes must never bounce the session",
+        );
+    }
+
+    /// Group `as-override` (presence) propagates with explicit-wins /
+    /// fallback and never bounces.
+    #[tokio::test]
+    async fn group_as_override_propagates_explicit_wins_no_bounce() {
+        use crate::bgp::peer::State;
+        let mut bgp = bgp_with_member();
+        bgp.peers.get_mut(&peer_addr()).unwrap().state = State::Established;
+
+        config_neighbor_group_as_override(&mut bgp, arg_words(&["G"]), ConfigOp::Set).unwrap();
+        assert!(member(&bgp).config.as_override, "group opinion must apply");
+
+        // Presence knob: explicit can only assert "on", so explicit-wins
+        // is exercised via the fallback path like the ttl-security
+        // exemplar — an explicit statement keeps the value through a
+        // group delete, then dropping the explicit one finally clears it.
+        config_as_override(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_neighbor_group_as_override(&mut bgp, arg_words(&["G"]), ConfigOp::Delete).unwrap();
+        assert!(
+            member(&bgp).config.as_override,
+            "explicit statement survives the group delete",
+        );
+        config_as_override(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Delete).unwrap();
+        assert!(!member(&bgp).config.as_override, "dropping both clears it");
+
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "as-override changes must never bounce the session",
+        );
+    }
+
+    /// Group `remove-private-as` (bare + all + replace-as) propagates
+    /// with explicit-wins / fallback and never bounces.
+    #[tokio::test]
+    async fn group_remove_private_as_propagates_explicit_wins_no_bounce() {
+        use crate::bgp::peer::State;
+        let mut bgp = bgp_with_member();
+        bgp.peers.get_mut(&peer_addr()).unwrap().state = State::Established;
+
+        config_neighbor_group_remove_private_as(&mut bgp, arg_words(&["G"]), ConfigOp::Set)
+            .unwrap();
+        let rpa = member(&bgp)
+            .config
+            .remove_private_as
+            .expect("group opinion applies");
+        assert!(!rpa.all && !rpa.replace_as, "bare form: both modifiers off");
+
+        config_neighbor_group_remove_private_as_all(&mut bgp, arg_words(&["G"]), ConfigOp::Set)
+            .unwrap();
+        config_neighbor_group_remove_private_as_replace_as(
+            &mut bgp,
+            arg_words(&["G"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        let rpa = member(&bgp)
+            .config
+            .remove_private_as
+            .expect("group opinion applies");
+        assert!(rpa.all && rpa.replace_as, "both modifiers on");
+
+        // Explicit per-neighbor bare form (both off) wins over the
+        // group's all+replace-as.
+        config_remove_private_as(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        let rpa = member(&bgp)
+            .config
+            .remove_private_as
+            .expect("explicit applies");
+        assert!(!rpa.all && !rpa.replace_as, "explicit statement must win");
+
+        // Removing the explicit container falls back to the group.
+        config_remove_private_as(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Delete).unwrap();
+        let rpa = member(&bgp)
+            .config
+            .remove_private_as
+            .expect("fallback to group");
+        assert!(rpa.all && rpa.replace_as, "fallback to group opinion");
+
+        // Dropping the group container clears it.
+        config_neighbor_group_remove_private_as(&mut bgp, arg_words(&["G"]), ConfigOp::Delete)
+            .unwrap();
+        assert_eq!(
+            member(&bgp).config.remove_private_as,
+            None,
+            "group delete clears"
+        );
+
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "remove-private-as changes must never bounce the session",
+        );
+    }
+
+    /// Group `enforce-first-as` (presence) propagates and never
+    /// bounces.
+    #[tokio::test]
+    async fn group_enforce_first_as_propagates_no_bounce() {
+        use crate::bgp::peer::State;
+        let mut bgp = bgp_with_member();
+        bgp.peers.get_mut(&peer_addr()).unwrap().state = State::Established;
+
+        config_neighbor_group_enforce_first_as(&mut bgp, arg_words(&["G"]), ConfigOp::Set).unwrap();
+        assert!(
+            member(&bgp).config.enforce_first_as,
+            "group opinion must apply"
+        );
+
+        // Presence knob: explicit-wins via the fallback path (see
+        // as-override test).
+        config_enforce_first_as(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_neighbor_group_enforce_first_as(&mut bgp, arg_words(&["G"]), ConfigOp::Delete)
+            .unwrap();
+        assert!(
+            member(&bgp).config.enforce_first_as,
+            "explicit statement survives the group delete",
+        );
+        config_enforce_first_as(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Delete).unwrap();
+        assert!(
+            !member(&bgp).config.enforce_first_as,
+            "dropping both clears it"
+        );
+
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "enforce-first-as changes must never bounce the session",
+        );
+    }
+
+    /// Group `route-reflector client` flows to the member's
+    /// `reflector_client` (a `Peer` field), explicit wins / falls back,
+    /// and the sweep never bounces.
+    #[tokio::test]
+    async fn group_route_reflector_client_propagates_explicit_wins_no_bounce() {
+        use crate::bgp::peer::State;
+        let mut bgp = bgp_with_member();
+        bgp.peers.get_mut(&peer_addr()).unwrap().state = State::Established;
+
+        config_neighbor_group_route_reflector_client(
+            &mut bgp,
+            arg_words(&["G", "true"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert!(member(&bgp).reflector_client, "group opinion must apply");
+
+        // Explicit per-neighbor false outranks the group's true.
+        config_route_reflector(&mut bgp, arg_words(&["10.0.0.1", "false"]), ConfigOp::Set).unwrap();
+        assert!(
+            !member(&bgp).reflector_client,
+            "explicit statement must win"
+        );
+
+        // Removing the explicit statement falls back to the group.
+        config_route_reflector(
+            &mut bgp,
+            arg_words(&["10.0.0.1", "false"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        assert!(member(&bgp).reflector_client, "fallback to group opinion");
+
+        // Dropping the group opinion clears it.
+        config_neighbor_group_route_reflector_client(&mut bgp, arg_words(&["G"]), ConfigOp::Delete)
+            .unwrap();
+        assert!(!member(&bgp).reflector_client, "group delete clears");
+
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "route-reflector changes must never bounce the session",
+        );
+    }
+
+    // ---- side-effectful knobs: tcp-mss / password / update-source /
+    // ---- policy refs ---------------------------------------------
+
+    /// Group tcp-mss flows to a member without a bounce; explicit
+    /// wins; explicit-delete falls back to the group clamp.
+    #[tokio::test]
+    async fn group_tcp_mss_propagates_with_explicit_priority() {
+        use super::super::neighbor_group::config_neighbor_group_tcp_mss;
+        let mut bgp = fresh_bgp();
+        config_neighbor_group_remote_as(&mut bgp, arg_words(&["G", "65000"]), ConfigOp::Set)
+            .unwrap();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_peer_neighbor_group(&mut bgp, arg_words(&["10.0.0.1", "G"]), ConfigOp::Set).unwrap();
+        let _ = drain_stop_events(&mut bgp);
+
+        let mss = |bgp: &Bgp| {
+            bgp.peers
+                .get(&peer_addr())
+                .unwrap()
+                .config
+                .transport
+                .tcp_mss
+        };
+
+        config_neighbor_group_tcp_mss(&mut bgp, arg_words(&["G", "1300"]), ConfigOp::Set).unwrap();
+        assert_eq!(mss(&bgp), Some(1300), "group clamp must apply");
+
+        config_tcp_mss(&mut bgp, arg_words(&["10.0.0.1", "1200"]), ConfigOp::Set).unwrap();
+        assert_eq!(mss(&bgp), Some(1200), "explicit statement must win");
+
+        config_tcp_mss(&mut bgp, arg_words(&["10.0.0.1", "1200"]), ConfigOp::Delete).unwrap();
+        assert_eq!(mss(&bgp), Some(1300), "fallback to group clamp");
+
+        config_neighbor_group_tcp_mss(&mut bgp, arg_words(&["G", "1300"]), ConfigOp::Delete)
+            .unwrap();
+        assert_eq!(mss(&bgp), None, "group delete clears");
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "tcp-mss changes must never bounce the session",
+        );
+    }
+
+    /// Group MD5 password flows to a member; explicit wins; fallback
+    /// on explicit-delete; never bounces.
+    #[tokio::test]
+    async fn group_password_propagates_with_explicit_priority() {
+        use super::super::neighbor_group::config_neighbor_group_password;
+        let mut bgp = fresh_bgp();
+        config_neighbor_group_remote_as(&mut bgp, arg_words(&["G", "65000"]), ConfigOp::Set)
+            .unwrap();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_peer_neighbor_group(&mut bgp, arg_words(&["10.0.0.1", "G"]), ConfigOp::Set).unwrap();
+        let _ = drain_stop_events(&mut bgp);
+
+        let pw = |bgp: &Bgp| {
+            bgp.peers
+                .get(&peer_addr())
+                .unwrap()
+                .config
+                .transport
+                .md5_password
+                .clone()
+        };
+
+        config_neighbor_group_password(&mut bgp, arg_words(&["G", "groupsecret"]), ConfigOp::Set)
+            .unwrap();
+        assert_eq!(pw(&bgp).as_deref(), Some("groupsecret"));
+
+        config_peer_tcp_md5_password(
+            &mut bgp,
+            arg_words(&["10.0.0.1", "mysecret"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+        assert_eq!(pw(&bgp).as_deref(), Some("mysecret"), "explicit wins");
+
+        config_peer_tcp_md5_password(
+            &mut bgp,
+            arg_words(&["10.0.0.1", "mysecret"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        assert_eq!(
+            pw(&bgp).as_deref(),
+            Some("groupsecret"),
+            "fallback to group password",
+        );
+
+        config_neighbor_group_password(
+            &mut bgp,
+            arg_words(&["G", "groupsecret"]),
+            ConfigOp::Delete,
+        )
+        .unwrap();
+        assert_eq!(pw(&bgp), None, "group delete clears");
+        assert!(
+            drain_stop_events(&mut bgp).is_empty(),
+            "password changes must never bounce the session",
+        );
+    }
+
+    /// A group update-source applies only to members whose address
+    /// family matches the source — a v4 source lands on the v4 member
+    /// and is skipped (with a warning) on the v6 member.
+    #[tokio::test]
+    async fn group_update_source_respects_address_family() {
+        use super::super::neighbor_group::config_neighbor_group_update_source;
+        let mut bgp = fresh_bgp();
+        config_neighbor_group_remote_as(&mut bgp, arg_words(&["G", "65000"]), ConfigOp::Set)
+            .unwrap();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_peer_neighbor_group(&mut bgp, arg_words(&["10.0.0.1", "G"]), ConfigOp::Set).unwrap();
+        config_peer(&mut bgp, arg_words(&["2001:db8::2"]), ConfigOp::Set).unwrap();
+        config_peer_neighbor_group(&mut bgp, arg_words(&["2001:db8::2", "G"]), ConfigOp::Set)
+            .unwrap();
+        let _ = drain_stop_events(&mut bgp);
+
+        config_neighbor_group_update_source(
+            &mut bgp,
+            arg_words(&["G", "192.0.2.10"]),
+            ConfigOp::Set,
+        )
+        .unwrap();
+
+        let src = |bgp: &Bgp, addr: &str| {
+            bgp.peers
+                .get(&addr.parse().unwrap())
+                .unwrap()
+                .config
+                .transport
+                .update_source
+        };
+        assert_eq!(
+            src(&bgp, "10.0.0.1"),
+            Some("192.0.2.10".parse().unwrap()),
+            "v4 member adopts the v4 source",
+        );
+        assert_eq!(
+            src(&bgp, "2001:db8::2"),
+            None,
+            "v6 member must skip the mismatched-family source",
+        );
+    }
+
+    /// Group policy/prefix-set references bind to the member's
+    /// direction slots with explicit-wins semantics.
+    #[tokio::test]
+    async fn group_policy_refs_bind_with_explicit_priority() {
+        use super::super::neighbor_group::{
+            config_neighbor_group_policy_out, config_neighbor_group_prefix_set_in,
+        };
+        use crate::bgp::InOut;
+
+        let mut bgp = fresh_bgp();
+        config_neighbor_group_remote_as(&mut bgp, arg_words(&["G", "65000"]), ConfigOp::Set)
+            .unwrap();
+        config_peer(&mut bgp, arg_words(&["10.0.0.1"]), ConfigOp::Set).unwrap();
+        config_peer_neighbor_group(&mut bgp, arg_words(&["10.0.0.1", "G"]), ConfigOp::Set).unwrap();
+
+        let pol_out = |bgp: &Bgp| {
+            bgp.peers
+                .get(&peer_addr())
+                .unwrap()
+                .policy_list
+                .get(&InOut::Output)
+                .name
+                .clone()
+        };
+        let pfx_in = |bgp: &Bgp| {
+            bgp.peers
+                .get(&peer_addr())
+                .unwrap()
+                .prefix_set
+                .get(&InOut::Input)
+                .name
+                .clone()
+        };
+
+        config_neighbor_group_policy_out(&mut bgp, arg_words(&["G", "EGRESS"]), ConfigOp::Set)
+            .unwrap();
+        config_neighbor_group_prefix_set_in(&mut bgp, arg_words(&["G", "INGRESS"]), ConfigOp::Set)
+            .unwrap();
+        assert_eq!(pol_out(&bgp).as_deref(), Some("EGRESS"));
+        assert_eq!(pfx_in(&bgp).as_deref(), Some("INGRESS"));
+
+        // Explicit per-neighbor name outranks the group's.
+        config_policy_out(&mut bgp, arg_words(&["10.0.0.1", "MINE"]), ConfigOp::Set).unwrap();
+        assert_eq!(pol_out(&bgp).as_deref(), Some("MINE"), "explicit wins");
+
+        // Removing the explicit statement falls back to the group's.
+        config_policy_out(&mut bgp, arg_words(&["10.0.0.1", "MINE"]), ConfigOp::Delete).unwrap();
+        assert_eq!(
+            pol_out(&bgp).as_deref(),
+            Some("EGRESS"),
+            "fallback to group reference",
+        );
+
+        // Dropping the group reference unbinds.
+        config_neighbor_group_policy_out(&mut bgp, arg_words(&["G", "EGRESS"]), ConfigOp::Delete)
+            .unwrap();
+        assert_eq!(pol_out(&bgp), None, "group delete unbinds");
     }
 }
 

--- a/zebra-rs/src/bgp/interface_neighbor.rs
+++ b/zebra-rs/src/bgp/interface_neighbor.rs
@@ -134,11 +134,16 @@ pub fn materialize_peer(
     if resolved.inherited_from_group {
         peer.config.remote_as_inherited = true;
     }
-    // Resolve the group's afi-safi opinions (e.g. `afi-safi ipv6
-    // enabled true` for an unnumbered IPv6 session) into the effective
-    // MP set before the first OPEN is built.
-    super::neighbor_group::recompute_peer_mp(&bgp.neighbor_groups, &mut peer.config);
     bgp.peers.insert_with_key(PeerKey::Interface(ifindex), peer);
+
+    // Resolve everything the group supplies (the MP family set for
+    // the first OPEN — e.g. `afi-safi ipv6 enabled true` for an
+    // unnumbered IPv6 session — plus the whole-session knobs). Runs
+    // AFTER insert because the apply ritual may arm timers that
+    // capture `peer.ident`; the bounce flag is irrelevant for a
+    // freshly materialized Idle peer.
+    let peer = bgp.peers.get_mut_by_key(&PeerKey::Interface(ifindex))?;
+    let _ = super::neighbor_group::apply_inherited(&bgp.neighbor_groups, &bgp.policy_tx, peer);
 
     // Kick the FSM. `peer.start()` arms the idle-hold timer which
     // fires Event::Start → fsm_start → peer_start_connection. The
@@ -148,7 +153,6 @@ pub fn materialize_peer(
     // External` (which yields 0 as a placeholder until OPEN backfill)
     // remain dormant — that case lands in a follow-up alongside the
     // OPEN-side validation.
-    let peer = bgp.peers.get_mut_by_key(&PeerKey::Interface(ifindex))?;
     peer.start();
     Some(peer.ident)
 }
@@ -192,14 +196,25 @@ pub fn config_interface_neighbor_neighbor_group(
 
     // Propagate the (re)binding to an already-materialized peer so the
     // group-driven attributes re-resolve against the new reference.
-    // Scope: afi-safi only — the peer's remote-as keeps its
-    // materialization-time value, matching how a per-cfg `remote-as`
-    // change is also picked up only on the next materialization.
+    // Scope: the inheritable attribute set only — the peer's remote-as
+    // keeps its materialization-time value, matching how a per-cfg
+    // `remote-as` change is also picked up only on the next
+    // materialization.
+    let mut stop: Option<usize> = None;
     if let Some(&ifindex) = bgp.link_index_by_name.get(&name)
         && let Some(peer) = bgp.peers.get_mut_by_key(&PeerKey::Interface(ifindex))
     {
         peer.config.neighbor_group = new_ref;
-        super::neighbor_group::recompute_peer_mp(&bgp.neighbor_groups, &mut peer.config);
+        let outcome =
+            super::neighbor_group::apply_inherited(&bgp.neighbor_groups, &bgp.policy_tx, peer);
+        if outcome.bounce {
+            stop = Some(peer.ident);
+        }
+    }
+    if let Some(ident) = stop {
+        let _ = bgp
+            .tx
+            .try_send(super::inst::Message::Event(ident, super::peer::Event::Stop));
     }
     Some(())
 }

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -27,24 +27,74 @@
 //! pass will pick one.
 
 use std::collections::BTreeMap;
+use std::net::IpAddr;
 
 use bgp_packet::{Afi, AfiSafi, AfiSafis, Safi};
 
 use super::Bgp;
 use super::inst::Message;
-use super::peer::{Event, PeerConfig, PeerType};
+use super::peer::{
+    ALLOWAS_IN_DEFAULT_COUNT, AllowAsIn, Event, Peer, PeerConfig, PeerType, RemovePrivateAs, State,
+};
 use super::peer_key::PeerOrigin;
 use crate::config::{Args, ConfigOp};
+
+/// The per-neighbor knobs a `neighbor-group` can supply. One struct
+/// serves both sides of the inheritance:
+///
+/// - [`NeighborGroup::knobs`] — the group's opinions,
+/// - [`super::peer::PeerConfig::knobs_explicit`] — the verbatim
+///   statements made on the neighbor itself.
+///
+/// Every field is `Option`: `None` means "no statement" (group: no
+/// opinion / peer: not explicitly configured). Resolution is
+/// field-wise `explicit.or(group)` via [`resolve_knob`]; when both are
+/// `None` the per-knob default applies. Presence-style knobs
+/// (`ttl-security`, `as-override`, `remove-private-as`,
+/// `enforce-first-as`, `disable-connected-check`, `allowas-in`) can
+/// only be stated "on" — exactly the expressiveness the per-neighbor
+/// YANG has.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct InheritableKnobs {
+    pub passive: Option<bool>,
+    pub update_source: Option<IpAddr>,
+    pub port: Option<u16>,
+    pub ttl_security: Option<bool>,
+    pub ebgp_multihop: Option<u8>,
+    pub tcp_mss: Option<u16>,
+    pub password: Option<String>,
+    pub disable_connected_check: Option<bool>,
+    pub policy_in: Option<String>,
+    pub policy_out: Option<String>,
+    pub prefix_set_in: Option<String>,
+    pub prefix_set_out: Option<String>,
+    pub allowas_in: Option<AllowAsIn>,
+    pub as_override: Option<bool>,
+    pub remove_private_as: Option<RemovePrivateAs>,
+    pub enforce_first_as: Option<bool>,
+    pub route_reflector_client: Option<bool>,
+}
+
+/// One group `afi-safi <family>` entry: the mandatory `enabled`
+/// toggle plus optional per-family opinions.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct GroupAfiSafi {
+    pub enabled: bool,
+    pub next_hop_self: Option<bool>,
+}
 
 #[derive(Debug, Default, Clone)]
 pub struct NeighborGroup {
     pub remote_as: Option<u32>,
-    /// Per-family `afi-safi <name> enabled <bool>` opinions. Tri-state
-    /// per family: `true` forces the family on for inheriting peers,
-    /// `false` forces it off (overriding the implicit IPv4-unicast
-    /// default), absent means "no opinion" (the peer's own default /
-    /// explicit setting stands).
-    pub afi_safi: BTreeMap<AfiSafi, bool>,
+    /// Per-family `afi-safi <name>` opinions. Tri-state per family:
+    /// an entry with `enabled true` forces the family on for
+    /// inheriting peers, `enabled false` forces it off (overriding
+    /// the implicit IPv4-unicast default), absent means "no opinion"
+    /// (the peer's own default / explicit setting stands). The entry
+    /// also carries the optional per-family `next-hop-self` opinion.
+    pub afi_safi: BTreeMap<AfiSafi, GroupAfiSafi>,
+    /// Whole-session knobs inheritable by members.
+    pub knobs: InheritableKnobs,
 }
 
 /// `set router bgp neighbor-group <name>` — list-key callback.
@@ -66,11 +116,11 @@ pub fn config_neighbor_group(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Opt
             // false` and returns `SweepAction::Ignore`.
             sweep_peers_for_group(bgp, &name, None);
             bgp.neighbor_groups.remove(&name);
-            // With the group gone its afi-safi opinions are gone too:
-            // members fall back to default + their own explicit
+            // With the group gone every opinion it carried is gone
+            // too: members fall back to defaults + their own explicit
             // statements (the reference leaf on the peer still stands
             // and re-resolves if the group is re-created).
-            sweep_group_afi_safi(bgp, &name);
+            sweep_members_inherit(bgp, &name);
         }
         _ => {}
     }
@@ -146,15 +196,580 @@ pub fn config_neighbor_group_afi_safi_enabled(
     match op {
         ConfigOp::Set => {
             let enabled = args.boolean()?;
-            group.afi_safi.insert(family, enabled);
+            group.afi_safi.entry(family).or_default().enabled = enabled;
         }
         ConfigOp::Delete => {
+            // `enabled` is the entry's mandatory core: dropping it
+            // drops the family opinion. A surviving `next-hop-self`
+            // opinion would be unreachable config (the schema requires
+            // `enabled` on the entry), so remove the whole entry.
             group.afi_safi.remove(&family);
         }
         _ => return Some(()),
     }
     sweep_group_afi_safi(bgp, &name);
     Some(())
+}
+
+/// `set router bgp neighbor-group <name> afi-safi <family> next-hop-self <bool>`.
+///
+/// Stores the per-family opinion and re-resolves every member's
+/// effective `next-hop-self` for that family. Like the per-neighbor
+/// leaf, no session bounce and no replay: the new value applies to
+/// routes advertised after the change.
+pub fn config_neighbor_group_afi_safi_next_hop_self(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let family: AfiSafi = args.afi_safi()?;
+    let group = bgp.neighbor_groups.entry(name.clone()).or_default();
+    match op {
+        ConfigOp::Set => {
+            let value = args.boolean()?;
+            group.afi_safi.entry(family).or_default().next_hop_self = Some(value);
+        }
+        ConfigOp::Delete => {
+            if let Some(entry) = group.afi_safi.get_mut(&family) {
+                entry.next_hop_self = None;
+            }
+        }
+        _ => return Some(()),
+    }
+    sweep_members(bgp, &name, |groups, peer| {
+        let value = resolve_next_hop_self(groups, &peer.config, family);
+        peer.config.sub.entry(family).or_default().next_hop_self = value;
+        false
+    });
+    Some(())
+}
+
+/// Resolve a member's effective per-family `next-hop-self`: the
+/// explicit per-neighbor statement wins, else the group's opinion,
+/// else the default (`false`).
+pub fn resolve_next_hop_self(
+    groups: &BTreeMap<String, NeighborGroup>,
+    config: &PeerConfig,
+    family: AfiSafi,
+) -> bool {
+    config
+        .nhs_explicit
+        .get(&family)
+        .copied()
+        .or_else(|| {
+            config
+                .neighbor_group
+                .as_deref()
+                .and_then(|name| groups.get(name))
+                .and_then(|group| group.afi_safi.get(&family))
+                .and_then(|entry| entry.next_hop_self)
+        })
+        .unwrap_or(false)
+}
+
+/// `set router bgp neighbor-group <name> ttl-security` (`type empty`).
+///
+/// Stores the opinion and re-resolves every member through the same
+/// apply ritual as the per-neighbor callback (mutual-exclusion guard,
+/// diff-gate, start, bounce-if-live).
+pub fn config_neighbor_group_ttl_security(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    bgp.neighbor_groups
+        .entry(name.clone())
+        .or_default()
+        .knobs
+        .ttl_security = op.is_set().then_some(true);
+    sweep_members(bgp, &name, |groups, peer| {
+        let want = resolve_knob(groups, &peer.config, |k| k.ttl_security).unwrap_or(false);
+        super::config::apply_ttl_security(peer, want)
+    });
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> port <1-65535>`.
+///
+/// Stores the opinion and re-resolves every member through the same
+/// apply ritual as the per-neighbor callback (diff-gate, start,
+/// bounce-if-live).
+pub fn config_neighbor_group_port(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let value = match op {
+        ConfigOp::Set => Some(args.u16()?),
+        ConfigOp::Delete => None,
+        _ => return Some(()),
+    };
+    bgp.neighbor_groups
+        .entry(name.clone())
+        .or_default()
+        .knobs
+        .port = value;
+    sweep_members(bgp, &name, |groups, peer| {
+        let want = resolve_knob(groups, &peer.config, |k| k.port);
+        super::config::apply_port(peer, want)
+    });
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> ebgp-multihop <1-255>`.
+///
+/// Stores the opinion and re-resolves every member through the same
+/// apply ritual as the per-neighbor callback (mutual-exclusion guard
+/// vs ttl-security, diff-gate, start, bounce-if-live).
+pub fn config_neighbor_group_ebgp_multihop(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let value = match op {
+        ConfigOp::Set => Some(args.u8()?),
+        ConfigOp::Delete => None,
+        _ => return Some(()),
+    };
+    bgp.neighbor_groups
+        .entry(name.clone())
+        .or_default()
+        .knobs
+        .ebgp_multihop = value;
+    sweep_members(bgp, &name, |groups, peer| {
+        let want = resolve_knob(groups, &peer.config, |k| k.ebgp_multihop);
+        super::config::apply_ebgp_multihop(peer, want)
+    });
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> disable-connected-check`
+/// (`type empty`).
+///
+/// Stores the opinion and re-resolves every member through the same
+/// apply ritual as the per-neighbor callback (diff-gate, start,
+/// bounce-if-live).
+pub fn config_neighbor_group_disable_connected_check(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    bgp.neighbor_groups
+        .entry(name.clone())
+        .or_default()
+        .knobs
+        .disable_connected_check = op.is_set().then_some(true);
+    sweep_members(bgp, &name, |groups, peer| {
+        let want =
+            resolve_knob(groups, &peer.config, |k| k.disable_connected_check).unwrap_or(false);
+        super::config::apply_disable_connected_check(peer, want)
+    });
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> passive <bool>` — the flat
+/// boolean spelling of the per-neighbor `transport passive-mode` leaf.
+///
+/// Stores the opinion and re-resolves every member through the same
+/// apply ritual as the per-neighbor callback (no bounce; dynamic
+/// members stay forced-passive inside the apply fn).
+pub fn config_neighbor_group_passive(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let value = match op {
+        ConfigOp::Set => Some(args.boolean()?),
+        ConfigOp::Delete => None,
+        _ => return Some(()),
+    };
+    bgp.neighbor_groups
+        .entry(name.clone())
+        .or_default()
+        .knobs
+        .passive = value;
+    sweep_members(bgp, &name, |groups, peer| {
+        let want = resolve_knob(groups, &peer.config, |k| k.passive).unwrap_or(false);
+        super::config::apply_passive(peer, want)
+    });
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> allowas-in` — the presence
+/// container. Mirrors the per-neighbor `config_allowas_in`
+/// `get_or_insert` logic onto the group's opinion, then re-resolves
+/// every member.
+pub fn config_neighbor_group_allowas_in(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let knobs = &mut bgp.neighbor_groups.entry(name.clone()).or_default().knobs;
+    if op.is_set() {
+        knobs
+            .allowas_in
+            .get_or_insert(AllowAsIn::Count(ALLOWAS_IN_DEFAULT_COUNT));
+    } else {
+        knobs.allowas_in = None;
+    }
+    sweep_members(bgp, &name, |groups, peer| {
+        let want = resolve_knob(groups, &peer.config, |k| k.allowas_in);
+        super::config::apply_allowas_in(peer, want)
+    });
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> allowas-in count <1-10>`.
+/// Mirrors the per-neighbor `config_allowas_in_count` logic onto the
+/// group's opinion.
+pub fn config_neighbor_group_allowas_in_count(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    if op.is_set() {
+        let count = args.u8()?;
+        let knobs = &mut bgp.neighbor_groups.entry(name.clone()).or_default().knobs;
+        knobs.allowas_in = Some(AllowAsIn::Count(count));
+    } else {
+        let knobs = &mut bgp.neighbor_groups.entry(name.clone()).or_default().knobs;
+        if matches!(knobs.allowas_in, Some(AllowAsIn::Count(_))) {
+            knobs.allowas_in = Some(AllowAsIn::Count(ALLOWAS_IN_DEFAULT_COUNT));
+        }
+    }
+    sweep_members(bgp, &name, |groups, peer| {
+        let want = resolve_knob(groups, &peer.config, |k| k.allowas_in);
+        super::config::apply_allowas_in(peer, want)
+    });
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> allowas-in origin`. Mirrors
+/// the per-neighbor `config_allowas_in_origin` logic onto the group's
+/// opinion.
+pub fn config_neighbor_group_allowas_in_origin(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let knobs = &mut bgp.neighbor_groups.entry(name.clone()).or_default().knobs;
+    if op.is_set() {
+        knobs.allowas_in = Some(AllowAsIn::Origin);
+    } else if matches!(knobs.allowas_in, Some(AllowAsIn::Origin)) {
+        knobs.allowas_in = Some(AllowAsIn::Count(ALLOWAS_IN_DEFAULT_COUNT));
+    }
+    sweep_members(bgp, &name, |groups, peer| {
+        let want = resolve_knob(groups, &peer.config, |k| k.allowas_in);
+        super::config::apply_allowas_in(peer, want)
+    });
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> as-override` — presence
+/// container. Stores the opinion and re-resolves every member.
+pub fn config_neighbor_group_as_override(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    bgp.neighbor_groups
+        .entry(name.clone())
+        .or_default()
+        .knobs
+        .as_override = op.is_set().then_some(true);
+    sweep_members(bgp, &name, |groups, peer| {
+        let want = resolve_knob(groups, &peer.config, |k| k.as_override).unwrap_or(false);
+        super::config::apply_as_override(peer, want)
+    });
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> remove-private-as` — presence
+/// container. Mirrors the per-neighbor `config_remove_private_as`
+/// `get_or_insert_with` logic onto the group's opinion, then
+/// re-resolves every member.
+pub fn config_neighbor_group_remove_private_as(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let knobs = &mut bgp.neighbor_groups.entry(name.clone()).or_default().knobs;
+    if op.is_set() {
+        knobs
+            .remove_private_as
+            .get_or_insert_with(RemovePrivateAs::default);
+    } else {
+        knobs.remove_private_as = None;
+    }
+    sweep_members(bgp, &name, |groups, peer| {
+        let want = resolve_knob(groups, &peer.config, |k| k.remove_private_as);
+        super::config::apply_remove_private_as(peer, want)
+    });
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> remove-private-as all`.
+/// Mirrors the per-neighbor `config_remove_private_as_all` logic onto
+/// the group's opinion.
+pub fn config_neighbor_group_remove_private_as_all(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let knobs = &mut bgp.neighbor_groups.entry(name.clone()).or_default().knobs;
+    if op.is_set() {
+        knobs
+            .remove_private_as
+            .get_or_insert_with(RemovePrivateAs::default)
+            .all = true;
+    } else if let Some(rpa) = knobs.remove_private_as.as_mut() {
+        rpa.all = false;
+    }
+    sweep_members(bgp, &name, |groups, peer| {
+        let want = resolve_knob(groups, &peer.config, |k| k.remove_private_as);
+        super::config::apply_remove_private_as(peer, want)
+    });
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> remove-private-as replace-as`.
+/// Mirrors the per-neighbor `config_remove_private_as_replace_as` logic
+/// onto the group's opinion.
+pub fn config_neighbor_group_remove_private_as_replace_as(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let knobs = &mut bgp.neighbor_groups.entry(name.clone()).or_default().knobs;
+    if op.is_set() {
+        knobs
+            .remove_private_as
+            .get_or_insert_with(RemovePrivateAs::default)
+            .replace_as = true;
+    } else if let Some(rpa) = knobs.remove_private_as.as_mut() {
+        rpa.replace_as = false;
+    }
+    sweep_members(bgp, &name, |groups, peer| {
+        let want = resolve_knob(groups, &peer.config, |k| k.remove_private_as);
+        super::config::apply_remove_private_as(peer, want)
+    });
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> enforce-first-as` — presence
+/// container. Stores the opinion and re-resolves every member.
+pub fn config_neighbor_group_enforce_first_as(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    bgp.neighbor_groups
+        .entry(name.clone())
+        .or_default()
+        .knobs
+        .enforce_first_as = op.is_set().then_some(true);
+    sweep_members(bgp, &name, |groups, peer| {
+        let want = resolve_knob(groups, &peer.config, |k| k.enforce_first_as).unwrap_or(false);
+        super::config::apply_enforce_first_as(peer, want)
+    });
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> route-reflector client <bool>`.
+///
+/// Stores the opinion and re-resolves every member. The effective
+/// value lands on `peer.reflector_client` (a `Peer` field, not
+/// `PeerConfig`); no session bounce.
+pub fn config_neighbor_group_route_reflector_client(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let value = match op {
+        ConfigOp::Set => Some(args.boolean()?),
+        ConfigOp::Delete => None,
+        _ => return Some(()),
+    };
+    bgp.neighbor_groups
+        .entry(name.clone())
+        .or_default()
+        .knobs
+        .route_reflector_client = value;
+    sweep_members(bgp, &name, |groups, peer| {
+        let want =
+            resolve_knob(groups, &peer.config, |k| k.route_reflector_client).unwrap_or(false);
+        super::config::apply_route_reflector_client(peer, want)
+    });
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> update-source <addr>`.
+///
+/// Like the per-neighbor knob: no bounce (the source is read at dial
+/// time) and a per-member address-family guard — a v4 source applies
+/// only to v4 members, a v6 source only to v6 members (the apply fn
+/// skips mismatches with a warning). Changed members get their BFD
+/// session re-keyed, mirroring the per-neighbor callback's
+/// `bfd_apply` reconcile.
+pub fn config_neighbor_group_update_source(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    let name = args.string()?;
+    let value = match op {
+        ConfigOp::Set => Some(args.addr()?),
+        ConfigOp::Delete => None,
+        _ => return Some(()),
+    };
+    bgp.neighbor_groups
+        .entry(name.clone())
+        .or_default()
+        .knobs
+        .update_source = value;
+    sweep_members_inherit(bgp, &name);
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> tcp-mss <1-65535>`.
+///
+/// Like the per-neighbor knob: no bounce (the clamp is read at
+/// connect time; `clear bgp` for immediate effect), and one listener
+/// reconcile after the sweep so the shared socket re-derives its
+/// per-AF minimum.
+pub fn config_neighbor_group_tcp_mss(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let value = match op {
+        ConfigOp::Set => Some(args.u16()?),
+        ConfigOp::Delete => None,
+        _ => return Some(()),
+    };
+    bgp.neighbor_groups
+        .entry(name.clone())
+        .or_default()
+        .knobs
+        .tcp_mss = value;
+    sweep_members_inherit(bgp, &name);
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> password <string>`.
+///
+/// Like the per-neighbor knob: no bounce (a live session keeps its
+/// key until it resets); every changed member's listener key is
+/// re-installed so passively-accepted reconnects authenticate under
+/// the inherited password.
+pub fn config_neighbor_group_password(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    let name = args.string()?;
+    let value = match op {
+        ConfigOp::Set => Some(args.string()?),
+        ConfigOp::Delete => None,
+        _ => return Some(()),
+    };
+    bgp.neighbor_groups
+        .entry(name.clone())
+        .or_default()
+        .knobs
+        .password = value;
+    sweep_members_inherit(bgp, &name);
+    Some(())
+}
+
+/// `set router bgp neighbor-group <name> policy {in|out} <name>` and
+/// `… prefix-set {in|out} <name>` — four callbacks sharing one shape.
+///
+/// Like the per-neighbor knobs: the member's direction slot is
+/// re-bound and the policy actor (un)registered; the actor's reply
+/// resolves the name and soft-replays the direction. No bounce.
+pub fn config_neighbor_group_policy_in(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    config_neighbor_group_policy_ref(bgp, args.string()?, args, op, |knobs| &mut knobs.policy_in)
+}
+
+pub fn config_neighbor_group_policy_out(bgp: &mut Bgp, mut args: Args, op: ConfigOp) -> Option<()> {
+    config_neighbor_group_policy_ref(bgp, args.string()?, args, op, |knobs| &mut knobs.policy_out)
+}
+
+pub fn config_neighbor_group_prefix_set_in(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    config_neighbor_group_policy_ref(bgp, args.string()?, args, op, |knobs| {
+        &mut knobs.prefix_set_in
+    })
+}
+
+pub fn config_neighbor_group_prefix_set_out(
+    bgp: &mut Bgp,
+    mut args: Args,
+    op: ConfigOp,
+) -> Option<()> {
+    config_neighbor_group_policy_ref(bgp, args.string()?, args, op, |knobs| {
+        &mut knobs.prefix_set_out
+    })
+}
+
+fn config_neighbor_group_policy_ref(
+    bgp: &mut Bgp,
+    name: String,
+    mut args: Args,
+    op: ConfigOp,
+    slot: impl Fn(&mut InheritableKnobs) -> &mut Option<String>,
+) -> Option<()> {
+    let value = match op {
+        ConfigOp::Set => Some(args.string()?),
+        ConfigOp::Delete => None,
+        _ => return Some(()),
+    };
+    *slot(&mut bgp.neighbor_groups.entry(name.clone()).or_default().knobs) = value;
+    sweep_members_inherit(bgp, &name);
+    Some(())
+}
+
+/// Resolve one whole-session inheritable knob for a peer: the explicit
+/// per-peer statement wins, else the referenced group's opinion, else
+/// `None` (the per-knob default applies). `pick` selects the field
+/// from either [`InheritableKnobs`] record.
+pub fn resolve_knob<T>(
+    groups: &BTreeMap<String, NeighborGroup>,
+    config: &PeerConfig,
+    pick: impl Fn(&InheritableKnobs) -> Option<T>,
+) -> Option<T> {
+    pick(&config.knobs_explicit).or_else(|| {
+        config
+            .neighbor_group
+            .as_deref()
+            .and_then(|name| groups.get(name))
+            .and_then(|group| pick(&group.knobs))
+    })
+}
+
+/// Run `apply` for every member of group `name`, then queue an FSM
+/// stop for each member whose apply asked for one (a knob whose new
+/// value needs a reconnect on a live session — the same `Event::Stop`
+/// ritual the per-neighbor callbacks use). `iter_mut_all` so
+/// interface-keyed (IPv6 unnumbered) and dynamic members are swept
+/// too.
+pub(super) fn sweep_members(
+    bgp: &mut Bgp,
+    name: &str,
+    mut apply: impl FnMut(&BTreeMap<String, NeighborGroup>, &mut Peer) -> bool,
+) {
+    let mut stops: Vec<usize> = Vec::new();
+    for (_, peer) in bgp.peers.iter_mut_all() {
+        if peer.config.neighbor_group.as_deref() != Some(name) {
+            continue;
+        }
+        if apply(&bgp.neighbor_groups, peer) && !matches!(peer.state, State::Idle) {
+            stops.push(peer.ident);
+        }
+    }
+    for ident in stops {
+        let _ = bgp.tx.try_send(Message::Event(ident, Event::Stop));
+    }
 }
 
 /// Compute a peer's effective MP (multiprotocol) family set from the
@@ -170,13 +785,13 @@ pub fn config_neighbor_group_afi_safi_enabled(
 /// Presence in the returned set means enabled — the same invariant
 /// `PeerConfig::mp` always had.
 pub fn effective_mp(
-    group: Option<&BTreeMap<AfiSafi, bool>>,
+    group: Option<&BTreeMap<AfiSafi, GroupAfiSafi>>,
     explicit: &BTreeMap<AfiSafi, bool>,
 ) -> AfiSafis<bool> {
     let mut mp = AfiSafis::new();
     mp.insert(AfiSafi::new(Afi::Ip, Safi::Unicast), true);
-    for (family, enabled) in group.into_iter().flatten() {
-        if *enabled {
+    for (family, entry) in group.into_iter().flatten() {
+        if entry.enabled {
             mp.insert(*family, true);
         } else {
             mp.remove(family);
@@ -205,17 +820,216 @@ pub fn recompute_peer_mp(groups: &BTreeMap<String, NeighborGroup>, config: &mut 
     config.mp = effective_mp(opinions, &config.mp_explicit);
 }
 
-/// Recompute the effective MP set of every peer referencing `name`.
-/// Called after any change to the group's `afi-safi` opinions (and
-/// after group deletion, where the lookup misses and members fall back
-/// to default + explicit). `iter_mut_all` so interface-keyed (IPv6
-/// unnumbered) members are swept too — `iter_mut` silently skips them.
+/// Recompute the per-family inherited state (MP set + next-hop-self)
+/// of every peer referencing `name`. Called after any change to the
+/// group's `afi-safi` opinions (and after group deletion, where the
+/// lookup misses and members fall back to default + explicit).
 fn sweep_group_afi_safi(bgp: &mut Bgp, name: &str) {
+    sweep_members(bgp, name, |groups, peer| {
+        recompute_peer_mp(groups, &mut peer.config);
+        recompute_peer_nhs(groups, peer);
+        false
+    });
+}
+
+/// Re-resolve the effective per-family `next-hop-self` of one peer for
+/// every family either side mentions. Families with no statement left
+/// on either side fall back to the off default — the union sweep is
+/// what clears a removed opinion.
+fn recompute_peer_nhs(groups: &BTreeMap<String, NeighborGroup>, peer: &mut Peer) {
+    let mut families: Vec<AfiSafi> = peer.config.sub.keys().copied().collect();
+    families.extend(peer.config.nhs_explicit.keys().copied());
+    if let Some(group) = peer
+        .config
+        .neighbor_group
+        .as_deref()
+        .and_then(|name| groups.get(name))
+    {
+        families.extend(group.afi_safi.keys().copied());
+    }
+    families.sort_unstable();
+    families.dedup();
+    for family in families {
+        let value = resolve_next_hop_self(groups, &peer.config, family);
+        peer.config.sub.entry(family).or_default().next_hop_self = value;
+    }
+}
+
+/// Re-resolve EVERYTHING a neighbor-group can supply for one peer: the
+/// MP family set, per-family next-hop-self, and the whole-session
+/// knobs — each through the same diff-gated apply ritual its
+/// per-neighbor callback uses. Returns `true` when a live session must
+/// bounce for some knob to take effect (the caller owns the
+/// `Event::Stop` send).
+///
+/// Used by every path where the peer↔group binding itself changes:
+/// peer materialization (static attach, interface RA, dynamic accept),
+/// `interface-neighbor … neighbor-group` rebinding, and the
+/// group-delete cascade.
+/// Cross-borrow side-effect jobs an [`apply_inherited`] pass asks its
+/// caller to run once the peer borrow ends. Each maps to the same
+/// bgp-level reconciler the corresponding per-neighbor callback uses.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(super) struct InheritOutcome {
+    /// A knob whose new value needs the session to reconnect — send
+    /// `Event::Stop` (skip for Idle peers; the apply fns already
+    /// account for that in their bounce decision).
+    pub bounce: bool,
+    /// `tcp-mss` changed — run `apply_tcp_mss_refresh_all` so the
+    /// shared listener re-derives its per-AF minimum clamp.
+    pub mss_refresh: bool,
+    /// The MD5 password changed — run `apply_md5_refresh_for` with
+    /// this peer's address to re-key the listener.
+    pub md5_refresh: bool,
+    /// `update-source` changed — run `bfd_apply` so an attached BFD
+    /// session re-keys to the new local address.
+    pub bfd_reapply: bool,
+}
+
+pub(super) fn apply_inherited(
+    groups: &BTreeMap<String, NeighborGroup>,
+    policy_tx: &tokio::sync::mpsc::UnboundedSender<crate::policy::Message>,
+    peer: &mut Peer,
+) -> InheritOutcome {
+    recompute_peer_mp(groups, &mut peer.config);
+    recompute_peer_nhs(groups, peer);
+
+    // Resolve every knob up front by constructing the full record —
+    // the struct literal names each field, so adding a knob to
+    // `InheritableKnobs` refuses to compile until this site decides
+    // how to apply it.
+    let resolved = InheritableKnobs {
+        passive: resolve_knob(groups, &peer.config, |k| k.passive),
+        update_source: resolve_knob(groups, &peer.config, |k| k.update_source),
+        port: resolve_knob(groups, &peer.config, |k| k.port),
+        ttl_security: resolve_knob(groups, &peer.config, |k| k.ttl_security),
+        ebgp_multihop: resolve_knob(groups, &peer.config, |k| k.ebgp_multihop),
+        tcp_mss: resolve_knob(groups, &peer.config, |k| k.tcp_mss),
+        password: resolve_knob(groups, &peer.config, |k| k.password.clone()),
+        disable_connected_check: resolve_knob(groups, &peer.config, |k| k.disable_connected_check),
+        policy_in: resolve_knob(groups, &peer.config, |k| k.policy_in.clone()),
+        policy_out: resolve_knob(groups, &peer.config, |k| k.policy_out.clone()),
+        prefix_set_in: resolve_knob(groups, &peer.config, |k| k.prefix_set_in.clone()),
+        prefix_set_out: resolve_knob(groups, &peer.config, |k| k.prefix_set_out.clone()),
+        allowas_in: resolve_knob(groups, &peer.config, |k| k.allowas_in),
+        as_override: resolve_knob(groups, &peer.config, |k| k.as_override),
+        remove_private_as: resolve_knob(groups, &peer.config, |k| k.remove_private_as),
+        enforce_first_as: resolve_knob(groups, &peer.config, |k| k.enforce_first_as),
+        route_reflector_client: resolve_knob(groups, &peer.config, |k| k.route_reflector_client),
+    };
+    // Destructure so an unapplied field is a compile error, not a
+    // silently-ignored knob. Fields whose apply lands in a follow-up
+    // batch are discarded explicitly below — remove the discard when
+    // wiring the knob.
+    let InheritableKnobs {
+        passive,
+        update_source,
+        port,
+        ttl_security,
+        ebgp_multihop,
+        tcp_mss,
+        password,
+        disable_connected_check,
+        policy_in,
+        policy_out,
+        prefix_set_in,
+        prefix_set_out,
+        allowas_in,
+        as_override,
+        remove_private_as,
+        enforce_first_as,
+        route_reflector_client,
+    } = resolved;
+
+    let mut outcome = InheritOutcome::default();
+    let mut bounce = false;
+    // ebgp-multihop before ttl-security: the two are mutually
+    // exclusive and each apply fn refuses to override the other, so
+    // applying ebgp-multihop first lets `apply_ttl_security`'s guard
+    // observe it — matching a per-neighbor commit where both leaves'
+    // callbacks fire and the guard keeps whichever landed first.
+    bounce |= super::config::apply_ebgp_multihop(peer, ebgp_multihop);
+    bounce |= super::config::apply_ttl_security(peer, ttl_security.unwrap_or(false));
+    bounce |= super::config::apply_port(peer, port);
+    bounce |= super::config::apply_disable_connected_check(
+        peer,
+        disable_connected_check.unwrap_or(false),
+    );
+    super::config::apply_passive(peer, passive.unwrap_or(false));
+    super::config::apply_allowas_in(peer, allowas_in);
+    super::config::apply_as_override(peer, as_override.unwrap_or(false));
+    super::config::apply_remove_private_as(peer, remove_private_as);
+    super::config::apply_enforce_first_as(peer, enforce_first_as.unwrap_or(false));
+    super::config::apply_route_reflector_client(peer, route_reflector_client.unwrap_or(false));
+    outcome.bfd_reapply = super::config::apply_update_source(peer, update_source);
+    outcome.mss_refresh = super::config::apply_tcp_mss(peer, tcp_mss);
+    outcome.md5_refresh = super::config::apply_md5_password(peer, password);
+    super::config::apply_peer_policy_ref(
+        policy_tx,
+        peer,
+        crate::policy::PolicyType::PolicyListIn,
+        policy_in,
+    );
+    super::config::apply_peer_policy_ref(
+        policy_tx,
+        peer,
+        crate::policy::PolicyType::PolicyListOut,
+        policy_out,
+    );
+    super::config::apply_peer_policy_ref(
+        policy_tx,
+        peer,
+        crate::policy::PolicyType::PrefixSetIn,
+        prefix_set_in,
+    );
+    super::config::apply_peer_policy_ref(
+        policy_tx,
+        peer,
+        crate::policy::PolicyType::PrefixSetOut,
+        prefix_set_out,
+    );
+    outcome.bounce = bounce;
+    outcome
+}
+
+/// Re-resolve the full inherited attribute set for every member of
+/// group `name` and run the cross-borrow jobs each apply asked for.
+/// The full-resolution sibling of [`sweep_members`], used by the
+/// knobs whose side effects need `&mut Bgp` (listener clamps, MD5
+/// re-keys, BFD reconciles) and by the group-delete cascade.
+pub(super) fn sweep_members_inherit(bgp: &mut Bgp, name: &str) {
+    let policy_tx = bgp.policy_tx.clone();
+    let mut stops: Vec<usize> = Vec::new();
+    let mut mss_refresh = false;
+    let mut md5_addrs: Vec<IpAddr> = Vec::new();
+    let mut bfd_addrs: Vec<IpAddr> = Vec::new();
     for (_, peer) in bgp.peers.iter_mut_all() {
         if peer.config.neighbor_group.as_deref() != Some(name) {
             continue;
         }
-        recompute_peer_mp(&bgp.neighbor_groups, &mut peer.config);
+        let outcome = apply_inherited(&bgp.neighbor_groups, &policy_tx, peer);
+        if outcome.bounce && !matches!(peer.state, State::Idle) {
+            stops.push(peer.ident);
+        }
+        mss_refresh |= outcome.mss_refresh;
+        if outcome.md5_refresh {
+            md5_addrs.push(peer.address);
+        }
+        if outcome.bfd_reapply {
+            bfd_addrs.push(peer.address);
+        }
+    }
+    for ident in stops {
+        let _ = bgp.tx.try_send(Message::Event(ident, Event::Stop));
+    }
+    if mss_refresh {
+        super::config::apply_tcp_mss_refresh_all(bgp);
+    }
+    for addr in md5_addrs {
+        super::config::apply_md5_refresh_for(bgp, addr);
+    }
+    for addr in bfd_addrs {
+        let _ = super::config::bfd_apply(bgp, addr);
     }
 }
 
@@ -475,6 +1289,14 @@ mod tests {
         mp.keys().copied().collect()
     }
 
+    /// Group `afi-safi <family> enabled <bool>` entry shorthand.
+    fn entry(enabled: bool) -> GroupAfiSafi {
+        GroupAfiSafi {
+            enabled,
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn effective_mp_default_is_ipv4_unicast_only() {
         let mp = effective_mp(None, &BTreeMap::new());
@@ -483,14 +1305,14 @@ mod tests {
 
     #[test]
     fn effective_mp_group_enables_extra_family() {
-        let group = BTreeMap::from([(v6(), true)]);
+        let group = BTreeMap::from([(v6(), entry(true))]);
         let mp = effective_mp(Some(&group), &BTreeMap::new());
         assert_eq!(families(&mp), vec![v4(), v6()]);
     }
 
     #[test]
     fn effective_mp_group_disables_the_ipv4_default() {
-        let group = BTreeMap::from([(v4(), false), (v6(), true)]);
+        let group = BTreeMap::from([(v4(), entry(false)), (v6(), entry(true))]);
         let mp = effective_mp(Some(&group), &BTreeMap::new());
         assert_eq!(families(&mp), vec![v6()]);
     }
@@ -499,13 +1321,13 @@ mod tests {
     fn effective_mp_explicit_wins_over_group() {
         // Group switches v4 off, but the peer's own `afi-safi ipv4
         // enabled true` stands; group's v6 opinion is unopposed.
-        let group = BTreeMap::from([(v4(), false), (v6(), true)]);
+        let group = BTreeMap::from([(v4(), entry(false)), (v6(), entry(true))]);
         let explicit = BTreeMap::from([(v4(), true)]);
         let mp = effective_mp(Some(&group), &explicit);
         assert_eq!(families(&mp), vec![v4(), v6()]);
 
         // ... and the mirror: group on, explicit off.
-        let group = BTreeMap::from([(v6(), true)]);
+        let group = BTreeMap::from([(v6(), entry(true))]);
         let explicit = BTreeMap::from([(v6(), false)]);
         let mp = effective_mp(Some(&group), &explicit);
         assert_eq!(families(&mp), vec![v4()]);

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -394,6 +394,20 @@ pub struct PeerConfig {
     /// field set explicitly on the neighbor wins") and re-merged when
     /// the group changes.
     pub mp_explicit: BTreeMap<AfiSafi, bool>,
+    /// Verbatim per-peer `afi-safi <name> next-hop-self <bool>`
+    /// statements — same explicit-vs-effective split as
+    /// [`Self::mp_explicit`]; the effective value lives in
+    /// [`Self::sub`].
+    pub nhs_explicit: BTreeMap<AfiSafi, bool>,
+    /// Verbatim per-peer statements for the whole-session knobs a
+    /// `neighbor-group` can supply (passive, update-source,
+    /// ttl-security, …). Same explicit-vs-effective split: the
+    /// effective values live in their usual homes
+    /// ([`Self::transport`], [`Self::allowas_in`], `Peer` fields, …),
+    /// re-resolved through
+    /// [`super::neighbor_group::resolve_knob`] whenever either side
+    /// changes.
+    pub knobs_explicit: super::neighbor_group::InheritableKnobs,
     pub restart: AfiSafis<RestartValue>,
     pub llgr: AfiSafis<LlgrValue>,
     pub addpath: AfiSafis<AddPathValue>,
@@ -458,6 +472,8 @@ impl Default for PeerConfig {
             extended_message: true,
             mp: Default::default(),
             mp_explicit: BTreeMap::new(),
+            nhs_explicit: BTreeMap::new(),
+            knobs_explicit: Default::default(),
             restart: AfiSafis::new(),
             llgr: AfiSafis::new(),
             addpath: AfiSafis::new(),
@@ -2568,12 +2584,19 @@ fn try_dynamic_accept(bgp: &mut Bgp, peer_addr: IpAddr, stream: TcpStream) -> Op
     // sweep in `config_neighbor_group_remote_as` to consult.
     peer.config.neighbor_group = Some(group_name);
     peer.config.remote_as_inherited = true;
-    // Resolve the group's afi-safi opinions into the effective MP set
-    // before the OPEN for this very connection is built.
-    super::neighbor_group::recompute_peer_mp(&bgp.neighbor_groups, &mut peer.config);
 
     bgp.peers.insert(peer_addr, peer);
     bgp.dynamic_peer_count += 1;
+
+    // Resolve everything the group supplies (the MP family set for
+    // the OPEN this very connection is about to exchange, plus the
+    // whole-session knobs) — after insert so any timer the apply
+    // ritual arms captures the real ident. Dynamic peers stay
+    // passive regardless of the group's `passive` opinion (forced
+    // above); the bounce flag is irrelevant for a fresh Idle peer.
+    if let Some(peer) = bgp.peers.get_mut(&peer_addr) {
+        let _ = super::neighbor_group::apply_inherited(&bgp.neighbor_groups, &bgp.policy_tx, peer);
+    }
 
     // Dynamic (listen-range) peers are always address-keyed, so no
     // interface scope is needed here.

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -10,6 +10,7 @@ use serde::Serialize;
 
 use super::cap::CapAfiMap;
 use super::inst::{Bgp, ShowCallback};
+use super::neighbor_group::InheritableKnobs;
 use super::peer::{
     AfiSafiEncapType, AllowAsIn, Peer, PeerCounter, PeerParam, RemovePrivateAs, State,
 };
@@ -3758,6 +3759,10 @@ fn afi_safi_config_name(afi_safi: &AfiSafi) -> &'static str {
 /// One row of `show ip bgp neighbor-group` (list form). Captures the
 /// configured fields plus a member-peer count to make the list useful
 /// at a glance.
+///
+/// Note: keeps `afi_safi` as `BTreeMap<String, bool>` (enabled-only) —
+/// the list view is a summary and the extra per-family detail (e.g.
+/// `next_hop_self`) belongs to the detail view only.
 #[derive(Serialize)]
 struct BgpNeighborGroupListRow {
     name: String,
@@ -3779,11 +3784,97 @@ struct BgpNeighborGroupMember {
     state: String,
 }
 
+/// Per-family entry in the detail JSON `afi_safi` map — richer than
+/// the list row's enabled-only bool because the detail view should
+/// expose per-family knobs such as `next_hop_self`.
+#[derive(Serialize)]
+struct GroupAfiSafiDetail {
+    enabled: bool,
+    /// `null` when not configured, `true`/`false` when explicitly set.
+    next_hop_self: Option<bool>,
+}
+
+/// JSON representation of the group's configured whole-session knobs.
+/// Only `Some(...)` knobs are emitted (the struct itself is always
+/// serialized — fields with `skip_serializing_if` are absent from the
+/// output when `None`). `password` is represented as a boolean presence
+/// flag so the secret is never echoed.
+#[derive(Serialize)]
+struct NeighborGroupKnobsJson {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    passive: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    update_source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ttl_security: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ebgp_multihop: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tcp_mss: Option<u16>,
+    /// `true` = a password is configured; never serializes the secret.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    password: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    disable_connected_check: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    policy_in: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    policy_out: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prefix_set_in: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prefix_set_out: Option<String>,
+    /// Serializes as `{"mode":"count","count":N}` or `{"mode":"origin"}`
+    /// (AllowAsIn's own Serialize derive).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    allowas_in: Option<AllowAsIn>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    as_override: Option<bool>,
+    /// Serializes as `{"all":bool,"replace_as":bool}`
+    /// (RemovePrivateAs's own Serialize derive).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remove_private_as: Option<RemovePrivateAs>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enforce_first_as: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    route_reflector_client: Option<bool>,
+}
+
+impl NeighborGroupKnobsJson {
+    fn from_knobs(k: &InheritableKnobs) -> Self {
+        Self {
+            passive: k.passive,
+            update_source: k.update_source.map(|a| a.to_string()),
+            port: k.port,
+            ttl_security: k.ttl_security,
+            ebgp_multihop: k.ebgp_multihop,
+            tcp_mss: k.tcp_mss,
+            password: k.password.as_ref().map(|_| true),
+            disable_connected_check: k.disable_connected_check,
+            policy_in: k.policy_in.clone(),
+            policy_out: k.policy_out.clone(),
+            prefix_set_in: k.prefix_set_in.clone(),
+            prefix_set_out: k.prefix_set_out.clone(),
+            allowas_in: k.allowas_in,
+            as_override: k.as_override,
+            remove_private_as: k.remove_private_as,
+            enforce_first_as: k.enforce_first_as,
+            route_reflector_client: k.route_reflector_client,
+        }
+    }
+}
+
 #[derive(Serialize)]
 struct BgpNeighborGroupDetail {
     name: String,
     remote_as: Option<u32>,
-    afi_safi: BTreeMap<String, bool>,
+    /// Per-family detail: `{"enabled": bool, "next_hop_self": bool|null}`.
+    /// The list-row view keeps a simpler `BTreeMap<String, bool>` for
+    /// backwards compatibility; here we use the richer type.
+    afi_safi: BTreeMap<String, GroupAfiSafiDetail>,
+    knobs: NeighborGroupKnobsJson,
     members: Vec<BgpNeighborGroupMember>,
 }
 
@@ -3854,7 +3945,7 @@ fn show_bgp_neighbor_group_list_json(bgp: &Bgp) -> std::result::Result<String, s
             afi_safi: group
                 .afi_safi
                 .iter()
-                .map(|(k, v)| (afi_safi_config_name(k).to_string(), *v))
+                .map(|(k, v)| (afi_safi_config_name(k).to_string(), v.enabled))
                 .collect(),
         })
         .collect();
@@ -3881,8 +3972,17 @@ fn show_bgp_neighbor_group_detail(
             afi_safi: group
                 .afi_safi
                 .iter()
-                .map(|(k, v)| (afi_safi_config_name(k).to_string(), *v))
+                .map(|(k, v)| {
+                    (
+                        afi_safi_config_name(k).to_string(),
+                        GroupAfiSafiDetail {
+                            enabled: v.enabled,
+                            next_hop_self: v.next_hop_self,
+                        },
+                    )
+                })
                 .collect(),
+            knobs: NeighborGroupKnobsJson::from_knobs(&group.knobs),
             members,
         };
         return Ok(serde_json::to_string_pretty(&detail).unwrap_or_default());
@@ -3903,15 +4003,99 @@ fn show_bgp_neighbor_group_detail(
             .afi_safi
             .iter()
             .map(|(k, v)| {
-                format!(
+                let mut s = format!(
                     "{} {}",
                     afi_safi_config_name(k),
-                    if *v { "enabled" } else { "disabled" }
-                )
+                    if v.enabled { "enabled" } else { "disabled" }
+                );
+                if v.next_hop_self == Some(true) {
+                    s.push_str(" nhs");
+                }
+                s
             })
             .collect();
         writeln!(buf, "  Afi-Safi:  {}", families.join(", "))?;
     }
+
+    // --- Configured knobs (one line per Some(...) field) ---
+    let k = &group.knobs;
+    if let Some(v) = k.passive {
+        writeln!(buf, "  Passive:   {v}")?;
+    }
+    if let Some(addr) = k.update_source {
+        writeln!(buf, "  Update-source: {addr}")?;
+    }
+    if let Some(p) = k.port {
+        writeln!(buf, "  Port:      {p}")?;
+    }
+    if k.ttl_security == Some(true) {
+        writeln!(buf, "  TTL-security: enabled")?;
+    }
+    if let Some(hops) = k.ebgp_multihop {
+        writeln!(buf, "  Ebgp-multihop: {hops}")?;
+    }
+    if let Some(mss) = k.tcp_mss {
+        writeln!(buf, "  TCP-MSS:   {mss}")?;
+    }
+    if k.password.is_some() {
+        writeln!(buf, "  Password:  (configured)")?;
+    }
+    if k.disable_connected_check == Some(true) {
+        writeln!(buf, "  Disable-connected-check: enabled")?;
+    }
+    // Policy: emit one combined line listing configured directions.
+    {
+        let mut parts: Vec<String> = Vec::new();
+        if let Some(ref n) = k.policy_in {
+            parts.push(format!("in {n}"));
+        }
+        if let Some(ref n) = k.policy_out {
+            parts.push(format!("out {n}"));
+        }
+        if !parts.is_empty() {
+            writeln!(buf, "  Policy:    {}", parts.join(", "))?;
+        }
+    }
+    // Prefix-set: same pattern.
+    {
+        let mut parts: Vec<String> = Vec::new();
+        if let Some(ref n) = k.prefix_set_in {
+            parts.push(format!("in {n}"));
+        }
+        if let Some(ref n) = k.prefix_set_out {
+            parts.push(format!("out {n}"));
+        }
+        if !parts.is_empty() {
+            writeln!(buf, "  Prefix-set: {}", parts.join(", "))?;
+        }
+    }
+    if let Some(aai) = k.allowas_in {
+        let desc = match aai {
+            AllowAsIn::Count(n) => format!("{n} occurrence(s)"),
+            AllowAsIn::Origin => "origin".to_string(),
+        };
+        writeln!(buf, "  Allowas-in: {desc}")?;
+    }
+    if k.as_override == Some(true) {
+        writeln!(buf, "  As-override: enabled")?;
+    }
+    if let Some(rpa) = k.remove_private_as {
+        let mut desc = "enabled".to_string();
+        if rpa.all {
+            desc.push_str(", all");
+        }
+        if rpa.replace_as {
+            desc.push_str(", replace-as");
+        }
+        writeln!(buf, "  Remove-private-as: {desc}")?;
+    }
+    if k.enforce_first_as == Some(true) {
+        writeln!(buf, "  Enforce-first-as: enabled")?;
+    }
+    if let Some(v) = k.route_reflector_client {
+        writeln!(buf, "  Route-reflector-client: {v}")?;
+    }
+
     if members.is_empty() {
         writeln!(buf, "  Members:   (no peers reference this group)")?;
     } else {

--- a/zebra-rs/src/config/manager.rs
+++ b/zebra-rs/src/config/manager.rs
@@ -1430,6 +1430,62 @@ mod yang_load_tests {
         );
     }
 
+    /// The `neighbor-group` list inherits the per-neighbor knob set
+    /// (zebra-bgp-neighbor-group.yang reuses the feature modules'
+    /// groupings via cross-module `uses`, plus inline mirrors for
+    /// policy / prefix-set / route-reflector / passive /
+    /// afi-safi next-hop-self). Pin every group spelling as settable
+    /// so a grouping rename or import slip in any feature module is
+    /// caught here, not at daemon startup.
+    #[test]
+    fn bgp_neighbor_group_inheritable_knobs_parse() {
+        use crate::config::ExecCode;
+        use crate::config::parse::{State, parse};
+        use libyang::to_entry;
+
+        let mut yang = YangStore::new();
+        yang.add_path(concat!(env!("CARGO_MANIFEST_DIR"), "/yang"));
+        yang.read_with_resolve("configure")
+            .expect("configure mode loads");
+        yang.identity_resolve();
+        let module = yang
+            .find_module("configure")
+            .expect("configure module present");
+        let entry = to_entry(&yang, module);
+
+        for cmd in [
+            "set router bgp neighbor-group G passive true",
+            "set router bgp neighbor-group G update-source 10.0.0.1",
+            "set router bgp neighbor-group G ttl-security",
+            "set router bgp neighbor-group G ebgp-multihop 5",
+            "set router bgp neighbor-group G tcp-mss 1400",
+            "set router bgp neighbor-group G port 1179",
+            "set router bgp neighbor-group G disable-connected-check",
+            "set router bgp neighbor-group G password secret",
+            "set router bgp neighbor-group G allowas-in",
+            "set router bgp neighbor-group G allowas-in count 5",
+            "set router bgp neighbor-group G allowas-in origin",
+            "set router bgp neighbor-group G as-override",
+            "set router bgp neighbor-group G remove-private-as",
+            "set router bgp neighbor-group G remove-private-as all",
+            "set router bgp neighbor-group G remove-private-as replace-as",
+            "set router bgp neighbor-group G enforce-first-as",
+            "set router bgp neighbor-group G policy in PL-IN",
+            "set router bgp neighbor-group G policy out PL-OUT",
+            "set router bgp neighbor-group G prefix-set in PS-IN",
+            "set router bgp neighbor-group G prefix-set out PS-OUT",
+            "set router bgp neighbor-group G route-reflector client true",
+            "set router bgp neighbor-group G afi-safi ipv4 next-hop-self true",
+        ] {
+            let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
+            assert_eq!(
+                code,
+                ExecCode::Success,
+                "should parse as a settable path: {cmd}"
+            );
+        }
+    }
+
     /// The global Router-ID override moved from the top level
     /// (`router-id A.B.C.D`) under the `system` container
     /// (`system router-id A.B.C.D`); the RIB dispatch in

--- a/zebra-rs/yang/zebra-bgp-neighbor-group.yang
+++ b/zebra-rs/yang/zebra-bgp-neighbor-group.yang
@@ -16,6 +16,30 @@ module zebra-bgp-neighbor-group {
     prefix zas;
   }
 
+  import zebra-bgp-transport {
+    prefix zbt;
+  }
+
+  import zebra-bgp-password {
+    prefix zbp;
+  }
+
+  import zebra-bgp-allowas-in {
+    prefix zbai;
+  }
+
+  import zebra-bgp-as-override {
+    prefix zbao;
+  }
+
+  import zebra-bgp-remove-private-as {
+    prefix zbrpa;
+  }
+
+  import zebra-bgp-enforce-first-as {
+    prefix zbef;
+  }
+
   import config {
     prefix config;
   }
@@ -91,6 +115,66 @@ module zebra-bgp-neighbor-group {
           "AS number inherited by neighbors that reference this
            group. A `remote-as` set on the neighbor itself wins.";
       }
+
+      /* Per-neighbor knobs inheritable through the group. The same
+       * explicit-wins rule applies to each: a statement on the
+       * neighbor itself outranks the group's; absence of both means
+       * the per-neighbor default. The transport / password /
+       * allowas-in / as-override / remove-private-as /
+       * enforce-first-as shapes are reused verbatim from the modules
+       * that attach them to `neighbor`, so the two surfaces cannot
+       * drift apart. */
+
+      leaf passive {
+        ext:help "Members only accept inbound sessions (never dial)";
+        type boolean;
+        description
+          "Inherited passive mode. The flat-group spelling of the
+           per-neighbor `transport passive-mode` leaf. Ignored by
+           dynamic (listen-range) members, which are always passive.";
+      }
+      uses zbt:bgp-neighbor-transport-extension;
+      uses zbp:bgp-neighbor-password-extension;
+      uses zbai:bgp-neighbor-allowas-in-extension;
+      uses zbao:bgp-neighbor-as-override-extension;
+      uses zbrpa:bgp-neighbor-remove-private-as-extension;
+      uses zbef:bgp-neighbor-enforce-first-as-extension;
+      container policy {
+        ext:help "Route policy inherited by group members";
+        description
+          "Per-direction route-policy references, mirroring the
+           per-neighbor `policy` container.";
+        leaf in {
+          type string;
+        }
+        leaf out {
+          type string;
+        }
+      }
+      container prefix-set {
+        ext:help "Prefix filter inherited by group members";
+        description
+          "Per-direction prefix-set references, mirroring the
+           per-neighbor `prefix-set` container.";
+        leaf in {
+          type string;
+        }
+        leaf out {
+          type string;
+        }
+      }
+      container route-reflector {
+        ext:help "Route reflector parameters inherited by group members";
+        description
+          "Mirror of the per-neighbor `route-reflector` container
+           (client leaf only — `cluster-id` stays per-neighbor).";
+        leaf client {
+          type boolean;
+          description
+            "Members are route-reflector clients.";
+        }
+      }
+
       list afi-safi {
         key "name";
         description
@@ -110,6 +194,14 @@ module zebra-bgp-neighbor-group {
           description
             "Whether this AFI,SAFI is enabled for peers inheriting
              from the group.";
+        }
+        leaf next-hop-self {
+          type boolean;
+          description
+            "Inherited per-family next-hop-self, mirroring the
+             per-neighbor `afi-safi <name> next-hop-self` leaf.
+             Applies to routes advertised after the change (no
+             session bounce).";
         }
       }
     }


### PR DESCRIPTION
## Summary

`neighbor-group` grows from `{remote-as, afi-safi enabled}` to the full inheritable per-neighbor knob set:

- **Transport**: `passive`, `update-source`, `port`, `ttl-security`, `ebgp-multihop`, `tcp-mss`, `password`, `disable-connected-check`
- **Filtering / policy**: `policy in|out`, `prefix-set in|out`
- **AS-path handling**: `allowas-in [count|origin]`, `as-override`, `remove-private-as [all] [replace-as]`, `enforce-first-as`
- **Route reflection**: `route-reflector client`
- **Per-family**: `afi-safi <name> next-hop-self` joins `enabled`

The same explicit-wins rule applies everywhere: a statement on the neighbor outranks the group's; deleting the per-neighbor statement falls back to the group instead of the default.

## Design

- **One record type, two roles.** `InheritableKnobs` (all-`Option` fields) is both the group's opinion set (`NeighborGroup::knobs`) and the per-peer verbatim-statement record (`PeerConfig::knobs_explicit`). Per-field resolution is `explicit.or(group)` via `resolve_knob`; per-family `next-hop-self` gets the same split (`nhs_explicit` vs the effective `sub` map).
- **Same apply ritual as the per-neighbor command.** Each per-neighbor callback's body was extracted into a shared `apply_<knob>` fn (diff-gate, mutual-exclusion guards, `start()`, bounce decision, listener/BFD side effects), and both the per-neighbor callback and the group sweep call it — so group changes behave byte-for-byte like the per-neighbor change: `port`/`ttl-security`/`ebgp-multihop`/`disable-connected-check` bounce live members; `tcp-mss`/`password` re-clamp/re-key the listener and apply at next connect; `policy`/`prefix-set` re-register with the policy actor and soft-replay; the rest apply in place without a bounce.
- **Lockstep guard.** `apply_inherited` (used by every peer↔group binding change: static attach, interface materialization/rebind, dynamic accept, group delete) resolves the full record through a struct-literal + destructure, so adding a field to `InheritableKnobs` refuses to compile until the apply site handles it.
- **Member-class guards.** A group `update-source` applies per-member only when the address family matches (a v4 source skips v6/link-local members with a warning); dynamic listen-range members stay passive regardless of the group's `passive`.
- **YANG with zero drift.** The group list reuses the per-neighbor feature modules' groupings (`zebra-bgp-transport`, `-password`, `-allowas-in`, `-as-override`, `-remove-private-as`, `-enforce-first-as`) via cross-module `uses`, plus inline mirrors for `policy`/`prefix-set`/`route-reflector`/`passive`. Grammar pins assert all 22 group spellings parse.
- `show ip bgp neighbor-group <NAME>` renders every configured knob (password as `(configured)`, never the secret) and `nhs` per family; JSON carries a `knobs` object.

## Testing

- 1048 unit tests green (`cargo test -p zebra-rs`), including a per-knob wiring matrix: group→member propagation, explicit-wins, fallback-on-explicit-delete, group-delete cascade, bounce-vs-no-bounce parity, interface-keyed member sweeps, update-source AF guard, policy-slot binding.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; full workspace suite green.
- BDD: new `@bgp_neighbor_group` scenario proves inheritance on the wire — z1's member gets GTSM only via the group while z2 enables `ttl-security` per-neighbor; GTSM establishes only if both ends send TTL 255, so Established ⇔ the inherited knob reached the socket. Regression runs: `@bgp_unnumbered_afi_safi`, `@bgp_ttl_security`, `@bgp_allowas_in`, `@bgp_basic_rr`, `@bgp_interas_option_c` (the per-neighbor callbacks these exercise were all refactored through the shared apply fns).
- Book chapters (`Neighbor Groups`, `IPv6 Unnumbered`) updated for the expanded surface and per-class propagation semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
