### PR TITLE
bgp: move per-neighbor show commands to show bgp neighbors

### DIFF
--- a/bdd/docs/bgp_unnumbered_neighbor.md
+++ b/bdd/docs/bgp_unnumbered_neighbor.md
@@ -35,7 +35,7 @@ into a single Established session), and ENHE-carried IPv4 routes.
 Note: the interface-keyed peer's remote address is a kernel-assigned
 link-local that the scenario can't name, so the session is asserted
 with the address-agnostic "BGP session in namespace … should
-eventually be …" step (it reads `show ip bgp neighbors`, which lists
+eventually be …" step (it reads `show bgp neighbors`, which lists
 interface-keyed peers).
 
 ## Test Scenarios

--- a/bdd/src/main.rs
+++ b/bdd/src/main.rs
@@ -7,7 +7,7 @@ async fn main() {
     // if let Ok(output) = output {
     //     println!("{:?}", output);
     // }
-    let cmd = format!("show ip bgp neighbors {}", "192.168.0.2");
+    let cmd = format!("show bgp neighbors {}", "192.168.0.2");
     let binding = ["show", "-j", &cmd];
     let output = netns::exec_in_netns("z1", "vtyctl", &binding).await;
     if let Ok(output) = output {

--- a/bdd/tests/cucumber.rs
+++ b/bdd/tests/cucumber.rs
@@ -552,7 +552,7 @@ async fn verify_bgp_session(
     expected_state: String,
 ) {
     let scoped = world.ns(&namespace);
-    let cmd = format!("show ip bgp neighbors {}", neighbor);
+    let cmd = format!("show bgp neighbors {}", neighbor);
     let binding = ["show", "-j", &cmd];
     let output = netns::exec_in_netns(&scoped, "vtyctl", &binding)
         .await
@@ -586,7 +586,7 @@ async fn verify_bgp_session_not(
     unexpected_state: String,
 ) {
     let scoped = world.ns(&namespace);
-    let cmd = format!("show ip bgp neighbors {}", neighbor);
+    let cmd = format!("show bgp neighbors {}", neighbor);
     let binding = ["show", "-j", &cmd];
     let output = netns::exec_in_netns(&scoped, "vtyctl", &binding)
         .await
@@ -610,7 +610,7 @@ async fn verify_bgp_session_not(
     );
 }
 
-/// Poll `show ip bgp neighbors` (all peers, JSON) until some peer's
+/// Poll `show bgp neighbors` (all peers, JSON) until some peer's
 /// `state` matches `expected` (`want_match = true`) or no peer matches
 /// it (`want_match = false`). Returns `(satisfied, last_output)`.
 ///
@@ -629,7 +629,7 @@ async fn poll_unnumbered_session_state(
     const ATTEMPTS: u32 = 60;
     let mut last = String::new();
     for i in 0..ATTEMPTS {
-        last = netns::exec_in_netns(scoped, "vtyctl", &["show", "-j", "show ip bgp neighbors"])
+        last = netns::exec_in_netns(scoped, "vtyctl", &["show", "-j", "show bgp neighbors"])
             .await
             .expect("Failed to get BGP neighbors");
         let matched = serde_json::from_str::<Value>(&last)

--- a/bdd/tests/features/bgp_allowas_in.feature
+++ b/bdd/tests/features/bgp_allowas_in.feature
@@ -61,7 +61,7 @@ Feature: BGP allowas-in relaxes the inbound AS_PATH loop check
     And I wait 30 seconds for BGP to operate
     Then BGP session in "z3" to "192.168.1.2" should be "Established"
     And BGP route in "z3" has "10.0.0.1/32"
-    And show command "show ip bgp neighbors" in namespace "z3" should contain "Allowas-in: 3 occurrence(s)"
+    And show command "show bgp neighbors" in namespace "z3" should contain "Allowas-in: 3 occurrence(s)"
 
   Scenario: allowas-in origin mode accepts the route and shows in neighbor output
     Given the test topology exists
@@ -70,7 +70,7 @@ Feature: BGP allowas-in relaxes the inbound AS_PATH loop check
     And I wait 30 seconds for BGP to operate
     Then BGP session in "z3" to "192.168.1.2" should be "Established"
     And BGP route in "z3" has "10.0.0.1/32"
-    And show command "show ip bgp neighbors" in namespace "z3" should contain "Allowas-in: origin"
+    And show command "show bgp neighbors" in namespace "z3" should contain "Allowas-in: origin"
 
   # Pure P2P topology (no bridge): deleting each namespace destroys the veth
   # pair ends it holds, so only the daemons and namespaces need teardown.

--- a/bdd/tests/features/bgp_as_override.feature
+++ b/bdd/tests/features/bgp_as_override.feature
@@ -63,7 +63,7 @@ Feature: BGP as-override rewrites the peer AS on egress so a shared-AS neighbor 
     And I wait 30 seconds for BGP to operate
     Then BGP session in "z3" to "192.168.1.2" should be "Established"
     And BGP route in "z3" has "10.0.0.1/32"
-    And show command "show ip bgp neighbors" in namespace "z2" should contain "AS-Override"
+    And show command "show bgp neighbors" in namespace "z2" should contain "AS-Override"
 
   # Pure P2P topology (no bridge): deleting each namespace destroys the veth
   # pair ends it holds, so only the daemons and namespaces need teardown.

--- a/bdd/tests/features/bgp_enforce_first_as.feature
+++ b/bdd/tests/features/bgp_enforce_first_as.feature
@@ -59,7 +59,7 @@ Feature: BGP enforce-first-as drops inbound updates whose AS_PATH does not start
     And I wait 30 seconds for BGP to operate
     Then BGP session in "z2" to "192.168.0.1" should be "Established"
     And BGP route in "z2" does not have "10.0.0.1/32"
-    And show command "show ip bgp neighbors" in namespace "z2" should contain "Enforce-first-AS"
+    And show command "show bgp neighbors" in namespace "z2" should contain "Enforce-first-AS"
 
   # Pure P2P topology (no bridge): deleting each namespace destroys the veth
   # pair ends it holds, so only the daemons and namespaces need teardown.

--- a/bdd/tests/features/bgp_evpn_capability.feature
+++ b/bdd/tests/features/bgp_evpn_capability.feature
@@ -49,5 +49,5 @@ Feature: BGP L2VPN/EVPN capability negotiation
 
   Scenario: L2VPN/EVPN capability is advertised and received on both sides
     Given the test topology exists
-    Then show command "show ip bgp neighbors 192.168.0.2" in namespace "z1" should contain "L2VPN EVPN: advertised and received"
-    And show command "show ip bgp neighbors 192.168.0.1" in namespace "z2" should contain "L2VPN EVPN: advertised and received"
+    Then show command "show bgp neighbors 192.168.0.2" in namespace "z1" should contain "L2VPN EVPN: advertised and received"
+    And show command "show bgp neighbors 192.168.0.1" in namespace "z2" should contain "L2VPN EVPN: advertised and received"

--- a/bdd/tests/features/bgp_neighbor_group.feature
+++ b/bdd/tests/features/bgp_neighbor_group.feature
@@ -78,8 +78,8 @@ Feature: BGP neighbor-group inheritance end-to-end
     And I wait 30 seconds for BGP to operate
     Then BGP session in "z1" to "192.168.0.2" should be "Established"
     And BGP session in "z2" to "192.168.0.1" should be "Established"
-    And show command "show ip bgp neighbors 192.168.0.2" in namespace "z1" should contain "TTL security (GTSM) enabled"
-    And show command "show ip bgp neighbors 192.168.0.2" in namespace "z1" should contain "Neighbor-group: RR"
+    And show command "show bgp neighbors 192.168.0.2" in namespace "z1" should contain "TTL security (GTSM) enabled"
+    And show command "show bgp neighbors 192.168.0.2" in namespace "z1" should contain "Neighbor-group: RR"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/bgp_port.feature
+++ b/bdd/tests/features/bgp_port.feature
@@ -71,9 +71,9 @@ Feature: BGP on a non-default TCP port
     Given the test topology exists
     # z1 dialed z2 on the configured neighbor port (z1 cannot have
     # accepted anything: its listener is closed with port 0)...
-    Then show command "show ip bgp neighbors" in namespace "z1" should contain "Foreign port: 1790"
+    Then show command "show bgp neighbors" in namespace "z1" should contain "Foreign port: 1790"
     # ...and z2 accepted it on its non-default listener.
-    And show command "show ip bgp neighbors" in namespace "z2" should contain "Local port: 1790"
+    And show command "show bgp neighbors" in namespace "z2" should contain "Local port: 1790"
     # Routes flow over the non-179 session.
     And BGP route in "z2" has "10.10.0.1/32"
 
@@ -95,7 +95,7 @@ Feature: BGP on a non-default TCP port
     Then BGP session in "z2" to "192.168.1.3" should be "Established"
     And BGP session in "z3" to "192.168.1.2" should be "Established"
     # z3 accepted the session on the reopened default listener.
-    And show command "show ip bgp neighbors" in namespace "z3" should contain "Local port: 179"
+    And show command "show bgp neighbors" in namespace "z3" should contain "Local port: 179"
     # End-to-end: z1's route crossed both custom-port sessions.
     And BGP route in "z3" has "10.10.0.1/32"
 

--- a/bdd/tests/features/bgp_remove_private_as.feature
+++ b/bdd/tests/features/bgp_remove_private_as.feature
@@ -65,7 +65,7 @@ Feature: BGP remove-private-as strips private ASNs from the egress AS_PATH
     Then BGP session in "z3" to "192.168.1.2" should be "Established"
     And BGP route in "z3" has "10.0.0.1/32"
     And BGP route in "z3" has "10.0.0.1/32" with "as_path" value "100"
-    And show command "show ip bgp neighbors" in namespace "z2" should contain "Private AS removal"
+    And show command "show bgp neighbors" in namespace "z2" should contain "Private AS removal"
 
   # Pure P2P topology (no bridge): deleting each namespace destroys the veth
   # pair it holds, so only the daemons and namespaces need teardown.

--- a/bdd/tests/features/bgp_tcp_mss.feature
+++ b/bdd/tests/features/bgp_tcp_mss.feature
@@ -49,10 +49,10 @@ Feature: BGP TCP MSS (neighbor tcp-mss)
     And BGP session in "z2" to "192.168.0.1" should be "Established"
     # show bgp neighbor reports both the configured tcp-mss and the MSS
     # the kernel actually negotiated on the live socket.
-    And show command "show ip bgp neighbors 192.168.0.2" in namespace "z1" should contain "Configured tcp-mss is 500"
-    And show command "show ip bgp neighbors 192.168.0.2" in namespace "z1" should contain "synced tcp-mss is 488"
-    And show command "show ip bgp neighbors 192.168.0.1" in namespace "z2" should contain "Configured tcp-mss is 500"
-    And show command "show ip bgp neighbors 192.168.0.1" in namespace "z2" should contain "synced tcp-mss is 488"
+    And show command "show bgp neighbors 192.168.0.2" in namespace "z1" should contain "Configured tcp-mss is 500"
+    And show command "show bgp neighbors 192.168.0.2" in namespace "z1" should contain "synced tcp-mss is 488"
+    And show command "show bgp neighbors 192.168.0.1" in namespace "z2" should contain "Configured tcp-mss is 500"
+    And show command "show bgp neighbors 192.168.0.1" in namespace "z2" should contain "synced tcp-mss is 488"
 
   Scenario: Teardown topology
     Given the test topology exists

--- a/bdd/tests/features/bgp_unnumbered_afi_safi.feature
+++ b/bdd/tests/features/bgp_unnumbered_afi_safi.feature
@@ -62,8 +62,8 @@ Feature: BGP neighbor-group afi-safi inheritance on an IPv6 unnumbered iBGP sess
     Then BGP session in namespace "z1" should eventually be "Established"
     And BGP session in namespace "z2" should eventually be "Established"
     And I wait 5 seconds
-    And show command "show ip bgp neighbors i1" in namespace "z1" should contain "IPv4 Unicast: advertised and received"
-    And show command "show ip bgp neighbors i1" in namespace "z1" should contain "IPv6 Unicast: advertised and received"
+    And show command "show bgp neighbors i1" in namespace "z1" should contain "IPv4 Unicast: advertised and received"
+    And show command "show bgp neighbors i1" in namespace "z1" should contain "IPv6 Unicast: advertised and received"
     And show command "show ip bgp neighbor-group dynamic" in namespace "z1" should contain "ipv4 enabled, ipv6 enabled"
     And BGP route in "z2" has "10.0.1.1/32"
     And BGP route in "z1" has "10.0.1.2/32"
@@ -85,9 +85,9 @@ Feature: BGP neighbor-group afi-safi inheritance on an IPv6 unnumbered iBGP sess
     And I wait 3 seconds
     # Positive assert first so the not-contains below cannot pass
     # vacuously on an empty/garbled show output.
-    And show command "show ip bgp neighbors i1" in namespace "z1" should contain "IPv6 Unicast: advertised and received"
-    And show command "show ip bgp neighbors i1" in namespace "z1" should not contain "IPv4 Unicast:"
-    And show command "show ip bgp neighbors i1" in namespace "z2" should not contain "IPv4 Unicast:"
+    And show command "show bgp neighbors i1" in namespace "z1" should contain "IPv6 Unicast: advertised and received"
+    And show command "show bgp neighbors i1" in namespace "z1" should not contain "IPv4 Unicast:"
+    And show command "show bgp neighbors i1" in namespace "z2" should not contain "IPv4 Unicast:"
     And show command "show ip bgp neighbor-group dynamic" in namespace "z1" should contain "ipv4 disabled, ipv6 enabled"
     # IPv4 routes from the old session were cleaned on the bounce and
     # must not re-sync on the IPv6-only session; IPv6 routes must.

--- a/bdd/tests/features/bgp_unnumbered_neighbor.feature
+++ b/bdd/tests/features/bgp_unnumbered_neighbor.feature
@@ -37,7 +37,7 @@ Feature: BGP IPv6 unnumbered neighbor discovered via Router Advertisements
   Note: the interface-keyed peer's remote address is a kernel-assigned
   link-local that the scenario can't name, so the session is asserted
   with the address-agnostic "BGP session in namespace … should
-  eventually be …" step (it reads `show ip bgp neighbors`, which lists
+  eventually be …" step (it reads `show bgp neighbors`, which lists
   interface-keyed peers).
 
   Scenario: Setup topology
@@ -65,12 +65,12 @@ Feature: BGP IPv6 unnumbered neighbor discovered via Router Advertisements
     Given the test topology exists
     # The summary identifies an interface-keyed peer by its interface
     # name (the trailing space pins the fixed-width Neighbor column),
-    # and `show ip bgp neighbors <ifname>` resolves the peer the
+    # and `show bgp neighbors <ifname>` resolves the peer the
     # dynamic completion offers, rendering the FRR-style
     # `BGP neighbor on <ifname>: <link-local>` identity.
     Then show command "show bgp summary" in namespace "z1" should contain "i1 "
     And show command "show bgp ipv4 summary" in namespace "z1" should contain "i1 "
-    And show command "show ip bgp neighbors i1" in namespace "z1" should contain "BGP neighbor on i1: fe80::"
+    And show command "show bgp neighbors i1" in namespace "z1" should contain "BGP neighbor on i1: fe80::"
 
   Scenario: Removing the interface-neighbor tears the session down
     Given the test topology exists

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -4125,29 +4125,26 @@ impl Bgp {
         self.show_add("/show/ip/bgp", show_bgp::<Bgp>);
         self.show_add("/show/ip/bgp/labeled-unicast", show_bgp_labeled);
         self.show_add("/show/ip/bgp/route", show_bgp_route_entry);
-        self.show_add("/show/ip/bgp/neighbors", show_bgp_neighbor::<Bgp>);
+        self.show_add("/show/bgp/neighbors", show_bgp_neighbor::<Bgp>);
+        self.show_add("/show/bgp/neighbors/advertised-routes", show_bgp_advertised);
         self.show_add(
-            "/show/ip/bgp/neighbors/advertised-routes",
-            show_bgp_advertised,
-        );
-        self.show_add(
-            "/show/ip/bgp/neighbors/advertised-routes/vpnv4",
+            "/show/bgp/neighbors/advertised-routes/vpnv4",
             show_bgp_advertised_vpnv4,
         );
         self.show_add(
-            "/show/ip/bgp/neighbors/advertised-routes/evpn",
+            "/show/bgp/neighbors/advertised-routes/evpn",
             show_bgp_advertised_evpn,
         );
-        self.show_add("/show/ip/bgp/neighbors/received-routes", show_bgp_received);
+        self.show_add("/show/bgp/neighbors/received-routes", show_bgp_received);
         self.show_add(
-            "/show/ip/bgp/neighbors/received-routes/vpnv4",
+            "/show/bgp/neighbors/received-routes/vpnv4",
             show_bgp_received_vpnv4,
         );
         self.show_add(
-            "/show/ip/bgp/neighbors/received-routes/evpn",
+            "/show/bgp/neighbors/received-routes/evpn",
             show_bgp_received_evpn,
         );
-        self.show_add("/show/ip/bgp/neighbors/rtcv4", show_bgp_rtcv4);
+        self.show_add("/show/bgp/neighbors/rtcv4", show_bgp_rtcv4);
         self.show_add("/show/ip/bgp/flowspec", show_bgp_flowspec_v4);
         self.show_add("/show/ip/bgp/flowspec/ipv6", show_bgp_flowspec_v6);
         self.show_add("/show/ip/bgp/sr-policy", show_bgp_sr_policy_v4);

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -1126,6 +1126,9 @@ mod tests {
         let entry = exec_entry();
 
         let cases: Vec<(&str, &str, Vec<&str>)> = vec![
+            // The bare (all-peers) form rides on the list's
+            // `ext:presence`; the BDD session-state steps poll it.
+            ("show bgp neighbors", "/show/bgp/neighbors", vec![]),
             ("show bgp neighbors i1", "/show/bgp/neighbors", vec!["i1"]),
             (
                 "show bgp neighbors i1 advertised-routes",

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -1086,8 +1086,8 @@ mod tests {
 
     /// The VPNv4 / EVPN RIB views moved from the legacy `show ip bgp`
     /// tree to `show bgp …`; the old spellings must no longer parse.
-    /// The per-neighbor Adj-RIB filters under `show ip bgp neighbors`
-    /// keep their `vpnv4` / `evpn` keywords.
+    /// The per-neighbor views (and their `vpnv4` / `evpn` Adj-RIB
+    /// filters) moved the same way: `show bgp neighbors …`.
     #[test]
     fn show_ip_bgp_vpnv4_evpn_moved() {
         let entry = exec_entry();
@@ -1095,20 +1095,22 @@ mod tests {
             "show ip bgp vpnv4",
             "show ip bgp vpnv4 route 10.0.0.1",
             "show ip bgp evpn",
+            "show ip bgp neighbors 10.0.0.1",
+            "show ip bgp neighbors 10.0.0.1 advertised-routes vpnv4",
         ] {
             let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
             assert_ne!(code, ExecCode::Success, "`{cmd}` must not be a command");
         }
         for cmd in [
-            "show ip bgp neighbors 10.0.0.1 advertised-routes vpnv4",
-            "show ip bgp neighbors 10.0.0.1 received-routes evpn",
+            "show bgp neighbors 10.0.0.1 advertised-routes vpnv4",
+            "show bgp neighbors 10.0.0.1 received-routes evpn",
         ] {
             let (code, _comps, _state) = parse(cmd, entry.clone(), None, State::new());
             assert_eq!(code, ExecCode::Success, "`{cmd}` must parse");
         }
     }
 
-    /// `show ip bgp neighbors <X>` accepts an `interface-neighbor` name
+    /// `show bgp neighbors <X>` accepts an `interface-neighbor` name
     /// — IPv6 unnumbered peers are keyed by interface, and the
     /// `bgp:neighbor` dynamic completion offers those names, so the
     /// execute path (which never sees dynamic candidates) must parse
@@ -1119,29 +1121,25 @@ mod tests {
     /// candidate — an address tying the catch-all string arm (both
     /// Partial) is one leaf match, not an ambiguous command.
     #[test]
-    fn show_ip_bgp_neighbors_interface_name() {
+    fn show_bgp_neighbors_interface_name() {
         use crate::config::path_from_command;
         let entry = exec_entry();
 
         let cases: Vec<(&str, &str, Vec<&str>)> = vec![
+            ("show bgp neighbors i1", "/show/bgp/neighbors", vec!["i1"]),
             (
-                "show ip bgp neighbors i1",
-                "/show/ip/bgp/neighbors",
+                "show bgp neighbors i1 advertised-routes",
+                "/show/bgp/neighbors/advertised-routes",
                 vec!["i1"],
             ),
             (
-                "show ip bgp neighbors i1 advertised-routes",
-                "/show/ip/bgp/neighbors/advertised-routes",
-                vec!["i1"],
-            ),
-            (
-                "show ip bgp neighbors 10.0.0.1",
-                "/show/ip/bgp/neighbors",
+                "show bgp neighbors 10.0.0.1",
+                "/show/bgp/neighbors",
                 vec!["10.0.0.1"],
             ),
             (
-                "show ip bgp neighbors 2001:db8::1",
-                "/show/ip/bgp/neighbors",
+                "show bgp neighbors 2001:db8::1",
+                "/show/bgp/neighbors",
                 vec!["2001:db8::1"],
             ),
         ];

--- a/zebra-rs/yang/exec.yang
+++ b/zebra-rs/yang/exec.yang
@@ -230,6 +230,53 @@ module exec {
         ext:help "Summary of BGP neighbor status per AFI/SAFI";
         type empty;
       }
+      list neighbors {
+        ext:help "BGP neighbor information";
+        ext:presence "BGP all neighbor information";
+        key name;
+        leaf name {
+          ext:dynamic "bgp:neighbor";
+          // Accept either address family (peers are keyed by
+          // `IpAddr`) or an `interface-neighbor` name — IPv6
+          // unnumbered peers are keyed by interface, so the name is
+          // their only typeable identity. The string arm is
+          // pattern-less on purpose: a bare string word-matches one
+          // token (a pattern would full-match the remaining LINE and
+          // break `neighbors i1 advertised-routes`). Address inputs
+          // tie the string arm (both Partial), which is safe: the
+          // parser folds a union's arms into a single match
+          // candidate, and the consumed token is the same either
+          // way.
+          type union {
+            type inet:ipv4-address;
+            type inet:ipv6-address;
+            type string;
+          }
+        }
+        leaf rtcv4 {
+          type empty;
+        }
+        container advertised-routes {
+          presence "";
+          leaf vpnv4 {
+            type empty;
+          }
+          leaf evpn {
+            ext:help "EVPN Adj-RIB-Out";
+            type empty;
+          }
+        }
+        container received-routes {
+          presence "";
+          leaf vpnv4 {
+            type empty;
+          }
+          leaf evpn {
+            ext:help "EVPN Adj-RIB-In";
+            type empty;
+          }
+        }
+      }
       uses bgp-show-afi-rib;
       // VPNv4 (SAFI 128) Loc-RIB across every route distinguisher.
       // Mirrors the `ipv4` list above: a bare address after `vpnv4`
@@ -351,53 +398,6 @@ module exec {
           leaf ipv6 {
             ext:help "BGP IPv6 SR Policy (SAFI 73) RIB";
             type empty;
-          }
-        }
-        list neighbors {
-          ext:help "BGP neighbor information";
-          ext:presence "BGP all neighbor information";
-          key name;
-          leaf name {
-            ext:dynamic "bgp:neighbor";
-            // Accept either address family (peers are keyed by
-            // `IpAddr`) or an `interface-neighbor` name — IPv6
-            // unnumbered peers are keyed by interface, so the name is
-            // their only typeable identity. The string arm is
-            // pattern-less on purpose: a bare string word-matches one
-            // token (a pattern would full-match the remaining LINE and
-            // break `neighbors i1 advertised-routes`). Address inputs
-            // tie the string arm (both Partial), which is safe: the
-            // parser folds a union's arms into a single match
-            // candidate, and the consumed token is the same either
-            // way.
-            type union {
-              type inet:ipv4-address;
-              type inet:ipv6-address;
-              type string;
-            }
-          }
-          leaf rtcv4 {
-            type empty;
-          }
-          container advertised-routes {
-            presence "";
-            leaf vpnv4 {
-              type empty;
-            }
-            leaf evpn {
-              ext:help "EVPN Adj-RIB-Out";
-              type empty;
-            }
-          }
-          container received-routes {
-            presence "";
-            leaf vpnv4 {
-              type empty;
-            }
-            leaf evpn {
-              ext:help "EVPN Adj-RIB-In";
-              type empty;
-            }
           }
         }
         leaf attributes {


### PR DESCRIPTION
## Summary

- Relocate the per-neighbor show subtree (detail view, `rtcv4`, and the `advertised-routes` / `received-routes` Adj-RIB filters with their `vpnv4`/`evpn` arms) from the legacy `show ip bgp` tree to `show bgp`, matching the earlier move of the VPNv4/EVPN RIB views. Handler registrations follow the yang move; the per-VRF `show ip bgp vrf <name> neighbors` leaf is untouched.
- Update the grammar-pinning parse() tests to the new spellings, pin the old `show ip bgp neighbors` spelling as removed, and pin the bare all-peers form (which rides on the list's `ext:presence`).
- Sweep the BDD suite for the old spelling: the shared `BGP session … should [not] be` step definitions and the all-peers JSON poll in `cucumber.rs`, show-command assertions across nine features, the `bdd/src/main.rs` debug helper, and the bgp_unnumbered_neighbor doc. Without this the old spelling returns empty output — loud failures for the session steps, but **vacuous passes** for `should not contain` assertions.

## Test plan

- `cargo test -p zebra-rs` — 1048 passed.
- `make install` (md5-verified binary + yang), then:
  - `@bgp_tcp_mss` — passes (keyed-form `show bgp neighbors <addr>` JSON step + text assertions).
  - `@bgp_unnumbered_neighbor` — all 5 scenarios pass (bare-form poll, interface-keyed `show bgp neighbors i1`, removal scenario's `should not contain`, teardown).

Generated with [Claude Code](https://claude.com/claude-code)