### PR TITLE
config: share the show Builder, roll it out to every daemon

### DIFF
--- a/zebra-rs/src/bfd/show.rs
+++ b/zebra-rs/src/bfd/show.rs
@@ -21,20 +21,21 @@ use std::time::{Duration, Instant};
 use bfd_packet::{Diag, State};
 use serde::Serialize;
 
-use crate::config::Args;
+use crate::config::{Args, Builder};
 
 use super::inst::{Bfd, ShowCallback};
 use super::session::{Session, SessionKey};
 
 impl Bfd {
-    fn show_add(&mut self, path: &str, cb: ShowCallback) {
-        self.show_cb.insert(path.to_string(), cb);
-    }
-
     pub fn show_build(&mut self) {
-        self.show_add("/show/bfd", show_bfd);
-        self.show_add("/show/bfd/peers", show_bfd_peers);
-        self.show_add("/show/bfd/counters", show_bfd_counters);
+        self.show_cb = Builder::<ShowCallback>::default()
+            .path("/show/bfd")
+            .set(show_bfd)
+            .path("/show/bfd/peers")
+            .set(show_bfd_peers)
+            .path("/show/bfd/counters")
+            .set(show_bfd_counters)
+            .map();
     }
 }
 

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -18,7 +18,7 @@ use super::peer_map::PeerMap;
 use super::route::LocalRib;
 use super::vrf::inst::BgpVrf;
 use crate::bgp::{AdjRibEvpnTable, AdjRibTable, BgpRib, BgpRibType, RibDirection};
-use crate::config::Args;
+use crate::config::{Args, Builder};
 use crate::config::{DisplayRequest, path_from_command};
 
 /// Read-only view of the per-instance BGP state the `show bgp …`
@@ -4116,31 +4116,9 @@ fn show_bgp_neighbor_group_detail(
     Ok(buf)
 }
 
-#[derive(Default)]
-struct Builder {
-    path: String,
-    map: HashMap<String, ShowCallback>,
-}
-
-impl Builder {
-    fn path(mut self, path: &str) -> Self {
-        self.path = path.into();
-        self
-    }
-
-    fn set(mut self, cb: ShowCallback) -> Self {
-        self.map.insert(self.path.clone(), cb);
-        self
-    }
-
-    fn map(self) -> HashMap<String, ShowCallback> {
-        self.map
-    }
-}
-
 impl Bgp {
     pub fn show_build(&mut self) {
-        self.show_cb = Builder::default()
+        self.show_cb = Builder::<ShowCallback>::default()
             .path("/show/ip/bgp")
             .set(show_bgp::<Bgp>)
             .path("/show/ip/bgp/labeled-unicast")

--- a/zebra-rs/src/config/mod.rs
+++ b/zebra-rs/src/config/mod.rs
@@ -29,6 +29,9 @@ mod paths;
 pub use paths::path_from_command;
 pub use paths::vrf_redirect_split;
 
+mod show_builder;
+pub use show_builder::Builder;
+
 mod api;
 pub use api::{ConfigChannel, ConfigOp, ConfigRequest, DisplayRequest, Message, ShowChannel};
 

--- a/zebra-rs/src/config/show_builder.rs
+++ b/zebra-rs/src/config/show_builder.rs
@@ -1,0 +1,44 @@
+use std::collections::HashMap;
+
+/// Chained registration of show-command paths to render callbacks.
+/// Generic over the per-daemon callback type (each daemon's
+/// `ShowCallback` takes its own state struct), so every module
+/// builds its dispatch map through the same builder:
+///
+/// ```ignore
+/// self.show_cb = Builder::<ShowCallback>::default()
+///     .path("/show/foo")
+///     .set(show_foo)
+///     .map();
+/// ```
+pub struct Builder<T> {
+    path: String,
+    map: HashMap<String, T>,
+}
+
+// Derived `Default` would require `T: Default`, which fn pointers
+// don't implement.
+impl<T> Default for Builder<T> {
+    fn default() -> Self {
+        Self {
+            path: String::new(),
+            map: HashMap::new(),
+        }
+    }
+}
+
+impl<T> Builder<T> {
+    pub fn path(mut self, path: &str) -> Self {
+        self.path = path.into();
+        self
+    }
+
+    pub fn set(mut self, cb: T) -> Self {
+        self.map.insert(self.path.clone(), cb);
+        self
+    }
+
+    pub fn map(self) -> HashMap<String, T> {
+        self.map
+    }
+}

--- a/zebra-rs/src/isis/show.rs
+++ b/zebra-rs/src/isis/show.rs
@@ -12,7 +12,7 @@ use super::rib::{IsisRibFamily, SpfNexthop, SpfRoute, V4, V6};
 use super::tilfa::{RepairPathMpls, RepairPathSrv6};
 use super::{Isis, inst::ShowCallback};
 
-use crate::config::Args;
+use crate::config::{Args, Builder};
 use crate::isis::link::Afi;
 use crate::isis::{Level, hostname, link, neigh};
 use crate::rib;
@@ -20,50 +20,63 @@ use crate::rib;
 use crate::spf;
 
 impl Isis {
-    fn show_add(&mut self, path: &str, cb: ShowCallback) {
-        self.show_cb.insert(path.to_string(), cb);
-    }
-
     pub fn show_build(&mut self) {
-        self.show_add("/show/isis", show_isis);
-        self.show_add("/show/isis/summary", show_isis_summary);
-        self.show_add("/show/isis/route", show_isis_route);
-        self.show_add("/show/isis/route/detail", show_isis_route_detail);
-        self.show_add(
-            "/show/isis/fast-reroute/summary",
-            show_isis_fast_reroute_summary,
-        );
-        self.show_add(
-            "/show/isis/fast-reroute/prefix/detail",
-            show_isis_fast_reroute_prefix_detail,
-        );
-        self.show_add("/show/isis/interface", link::show);
-        self.show_add("/show/isis/interface/detail", link::show_detail);
-        self.show_add("/show/isis/dis/statistics", link::show_dis_statistics);
-        self.show_add("/show/isis/dis/history", link::show_dis_history);
-        self.show_add("/show/isis/neighbor", neigh::show);
-        self.show_add("/show/isis/neighbor/detail", neigh::show_detail);
-        self.show_add("/show/isis/graceful-restart", show_isis_graceful_restart);
-        self.show_add("/show/isis/checkpoint", show_isis_checkpoint);
-        self.show_add("/show/isis/database", show_isis_database);
-        self.show_add("/show/isis/database/detail", show_isis_database_detail);
-        self.show_add("/show/isis/hostname", hostname::show);
-        self.show_add("/show/isis/graph", show_isis_graph);
-        self.show_add("/show/isis/spf", show_isis_spf);
-        self.show_add("/show/isis/spf/detail", show_isis_spf_detail);
-        self.show_add("/show/isis/repair-list", show_isis_repair_list);
-        self.show_add(
-            "/show/isis/repair-list/detail",
-            show_isis_repair_list_detail,
-        );
-        self.show_add("/show/isis/topology", show_isis_topology);
-        self.show_add("/show/isis/ti-lfa", show_isis_tilfa);
-        self.show_add("/show/isis/flex-algo", show_isis_flex_algo);
-        self.show_add("/show/isis/flex-algo/route", show_isis_flex_algo_route);
-        self.show_add(
-            "/show/isis/flex-algo/route/algorithm",
-            show_isis_flex_algo_route_algo,
-        );
+        self.show_cb = Builder::<ShowCallback>::default()
+            .path("/show/isis")
+            .set(show_isis)
+            .path("/show/isis/summary")
+            .set(show_isis_summary)
+            .path("/show/isis/route")
+            .set(show_isis_route)
+            .path("/show/isis/route/detail")
+            .set(show_isis_route_detail)
+            .path("/show/isis/fast-reroute/summary")
+            .set(show_isis_fast_reroute_summary)
+            .path("/show/isis/fast-reroute/prefix/detail")
+            .set(show_isis_fast_reroute_prefix_detail)
+            .path("/show/isis/interface")
+            .set(link::show)
+            .path("/show/isis/interface/detail")
+            .set(link::show_detail)
+            .path("/show/isis/dis/statistics")
+            .set(link::show_dis_statistics)
+            .path("/show/isis/dis/history")
+            .set(link::show_dis_history)
+            .path("/show/isis/neighbor")
+            .set(neigh::show)
+            .path("/show/isis/neighbor/detail")
+            .set(neigh::show_detail)
+            .path("/show/isis/graceful-restart")
+            .set(show_isis_graceful_restart)
+            .path("/show/isis/checkpoint")
+            .set(show_isis_checkpoint)
+            .path("/show/isis/database")
+            .set(show_isis_database)
+            .path("/show/isis/database/detail")
+            .set(show_isis_database_detail)
+            .path("/show/isis/hostname")
+            .set(hostname::show)
+            .path("/show/isis/graph")
+            .set(show_isis_graph)
+            .path("/show/isis/spf")
+            .set(show_isis_spf)
+            .path("/show/isis/spf/detail")
+            .set(show_isis_spf_detail)
+            .path("/show/isis/repair-list")
+            .set(show_isis_repair_list)
+            .path("/show/isis/repair-list/detail")
+            .set(show_isis_repair_list_detail)
+            .path("/show/isis/topology")
+            .set(show_isis_topology)
+            .path("/show/isis/ti-lfa")
+            .set(show_isis_tilfa)
+            .path("/show/isis/flex-algo")
+            .set(show_isis_flex_algo)
+            .path("/show/isis/flex-algo/route")
+            .set(show_isis_flex_algo_route)
+            .path("/show/isis/flex-algo/route/algorithm")
+            .set(show_isis_flex_algo_route_algo)
+            .map();
     }
 }
 

--- a/zebra-rs/src/ospf/show.rs
+++ b/zebra-rs/src/ospf/show.rs
@@ -6,7 +6,7 @@ use netlink_packet_route::link::LinkFlags;
 use ospf_packet::*;
 use serde::Serialize;
 
-use crate::config::Args;
+use crate::config::{Args, Builder};
 use crate::rib::LinkFlagsExt;
 use crate::spf;
 
@@ -166,30 +166,41 @@ struct OspfNetworkLsaDetailJson {
 }
 
 impl Ospf {
-    fn show_add(&mut self, path: &str, cb: ShowCallback) {
-        self.show_cb.insert(path.to_string(), cb);
-    }
-
     pub fn show_build(&mut self) {
-        self.show_add("/show/ip/ospf", show_ospf);
-        self.show_add("/show/ip/ospf/interface", show_ospf_interface);
-        self.show_add("/show/ip/ospf/neighbor", show_ospf_neighbor);
-        self.show_add("/show/ip/ospf/neighbor/detail", show_ospf_neighbor_detail);
-        self.show_add("/show/ip/ospf/database", show_ospf_database);
-        self.show_add("/show/ip/ospf/database/detail", show_ospf_database_detail);
-        self.show_add("/show/ip/ospf/route", show_ospf_route);
-        self.show_add("/show/ip/ospf/spf", show_ospf_spf);
-        self.show_add("/show/ip/ospf/flex-algo", show_ospf_flex_algo);
-        self.show_add("/show/ip/ospf/graph", show_ospf_graph);
-        self.show_add("/show/ip/ospf/ti-lfa", show_ospf_tilfa);
-        self.show_add("/show/ip/ospf/repair-list", show_ospf_repair_list);
-        self.show_add(
-            "/show/ip/ospf/repair-list/detail",
-            show_ospf_repair_list_detail,
-        );
-        self.show_add("/show/ip/ospf/segment-routing", show_ospf_segment_routing);
-        self.show_add("/show/ip/ospf/graceful-restart", show_ospf_graceful_restart);
-        self.show_add("/show/ip/ospf/checkpoint", show_ospf_checkpoint);
+        self.show_cb = Builder::<ShowCallback>::default()
+            .path("/show/ip/ospf")
+            .set(show_ospf)
+            .path("/show/ip/ospf/interface")
+            .set(show_ospf_interface)
+            .path("/show/ip/ospf/neighbor")
+            .set(show_ospf_neighbor)
+            .path("/show/ip/ospf/neighbor/detail")
+            .set(show_ospf_neighbor_detail)
+            .path("/show/ip/ospf/database")
+            .set(show_ospf_database)
+            .path("/show/ip/ospf/database/detail")
+            .set(show_ospf_database_detail)
+            .path("/show/ip/ospf/route")
+            .set(show_ospf_route)
+            .path("/show/ip/ospf/spf")
+            .set(show_ospf_spf)
+            .path("/show/ip/ospf/flex-algo")
+            .set(show_ospf_flex_algo)
+            .path("/show/ip/ospf/graph")
+            .set(show_ospf_graph)
+            .path("/show/ip/ospf/ti-lfa")
+            .set(show_ospf_tilfa)
+            .path("/show/ip/ospf/repair-list")
+            .set(show_ospf_repair_list)
+            .path("/show/ip/ospf/repair-list/detail")
+            .set(show_ospf_repair_list_detail)
+            .path("/show/ip/ospf/segment-routing")
+            .set(show_ospf_segment_routing)
+            .path("/show/ip/ospf/graceful-restart")
+            .set(show_ospf_graceful_restart)
+            .path("/show/ip/ospf/checkpoint")
+            .set(show_ospf_checkpoint)
+            .map();
     }
 }
 

--- a/zebra-rs/src/ospf/show_v3.rs
+++ b/zebra-rs/src/ospf/show_v3.rs
@@ -25,34 +25,42 @@ use super::lsdb::{Lsa, OSPF_MAX_AGE};
 use super::version::Ospfv3;
 use super::{Ospf, ShowCallback};
 
-use crate::config::Args;
-
-const SHOW_OSPFV3: &str = "/show/ipv6/ospf";
+use crate::config::{Args, Builder};
 
 impl Ospf<Ospfv3> {
     /// Register the v3 show-path dispatch table. Mirrors v2's
     /// `show_build` shape and command set.
     pub fn show_build(&mut self) {
-        let prefix = SHOW_OSPFV3;
-        let entries: &[(&str, ShowCallback<Ospfv3>)] = &[
-            ("", show_ospfv3_summary),
-            ("/interface", show_ospfv3_interface),
-            ("/neighbor", show_ospfv3_neighbor),
-            ("/neighbor/detail", show_ospfv3_neighbor_detail),
-            ("/database", show_ospfv3_database),
-            ("/database/detail", show_ospfv3_database_detail),
-            ("/route", show_ospfv3_route),
-            ("/spf", show_ospfv3_spf),
-            ("/graph", show_ospfv3_graph),
-            ("/ti-lfa", show_ospfv3_tilfa),
-            ("/repair-list", show_ospfv3_repair_list),
-            ("/repair-list/detail", show_ospfv3_repair_list_detail),
-            ("/segment-routing", show_ospfv3_segment_routing),
-            ("/flex-algo", show_ospfv3_flex_algo),
-        ];
-        for (path, cb) in entries {
-            self.show_cb.insert(format!("{}{}", prefix, path), *cb);
-        }
+        self.show_cb = Builder::<ShowCallback<Ospfv3>>::default()
+            .path("/show/ipv6/ospf")
+            .set(show_ospfv3_summary)
+            .path("/show/ipv6/ospf/interface")
+            .set(show_ospfv3_interface)
+            .path("/show/ipv6/ospf/neighbor")
+            .set(show_ospfv3_neighbor)
+            .path("/show/ipv6/ospf/neighbor/detail")
+            .set(show_ospfv3_neighbor_detail)
+            .path("/show/ipv6/ospf/database")
+            .set(show_ospfv3_database)
+            .path("/show/ipv6/ospf/database/detail")
+            .set(show_ospfv3_database_detail)
+            .path("/show/ipv6/ospf/route")
+            .set(show_ospfv3_route)
+            .path("/show/ipv6/ospf/spf")
+            .set(show_ospfv3_spf)
+            .path("/show/ipv6/ospf/graph")
+            .set(show_ospfv3_graph)
+            .path("/show/ipv6/ospf/ti-lfa")
+            .set(show_ospfv3_tilfa)
+            .path("/show/ipv6/ospf/repair-list")
+            .set(show_ospfv3_repair_list)
+            .path("/show/ipv6/ospf/repair-list/detail")
+            .set(show_ospfv3_repair_list_detail)
+            .path("/show/ipv6/ospf/segment-routing")
+            .set(show_ospfv3_segment_routing)
+            .path("/show/ipv6/ospf/flex-algo")
+            .set(show_ospfv3_flex_algo)
+            .map();
     }
 }
 

--- a/zebra-rs/src/policy/show.rs
+++ b/zebra-rs/src/policy/show.rs
@@ -1,3 +1,4 @@
+use crate::config::Builder;
 use crate::policy::Policy;
 use crate::policy::inst::ShowCallback;
 
@@ -10,38 +11,34 @@ use super::policy_list;
 use super::prefix;
 
 impl Policy {
-    fn show_add(&mut self, path: &str, cb: ShowCallback) {
-        self.show_cb.insert(path.to_string(), cb);
-    }
-
     pub fn show_build(&mut self) {
-        self.show_add("/show/policy", policy_list::show);
-        self.show_add("/show/prefix-set", prefix::show::prefix_set);
-        self.show_add("/show/prefix-set/name", prefix::show::prefix_set_name);
-        self.show_add("/show/community-set", community::show::community_set);
-        self.show_add(
-            "/show/community-set/name",
-            community::show::community_set_name,
-        );
-        self.show_add(
-            "/show/ext-community-set",
-            ext_community::show::ext_community_set,
-        );
-        self.show_add(
-            "/show/ext-community-set/name",
-            ext_community::show::ext_community_set_name,
-        );
-        self.show_add(
-            "/show/large-community-set",
-            large_community::show::large_community_set,
-        );
-        self.show_add(
-            "/show/large-community-set/name",
-            large_community::show::large_community_set_name,
-        );
-        self.show_add("/show/as-path-set", aspath::show::as_path_set);
-        self.show_add("/show/as-path-set/name", aspath::show::as_path_set_name);
-        self.show_add("/show/key-chains", keychain::show::key_chains);
-        self.show_add("/show/key-chains/name", keychain::show::key_chain_name);
+        self.show_cb = Builder::<ShowCallback>::default()
+            .path("/show/policy")
+            .set(policy_list::show)
+            .path("/show/prefix-set")
+            .set(prefix::show::prefix_set)
+            .path("/show/prefix-set/name")
+            .set(prefix::show::prefix_set_name)
+            .path("/show/community-set")
+            .set(community::show::community_set)
+            .path("/show/community-set/name")
+            .set(community::show::community_set_name)
+            .path("/show/ext-community-set")
+            .set(ext_community::show::ext_community_set)
+            .path("/show/ext-community-set/name")
+            .set(ext_community::show::ext_community_set_name)
+            .path("/show/large-community-set")
+            .set(large_community::show::large_community_set)
+            .path("/show/large-community-set/name")
+            .set(large_community::show::large_community_set_name)
+            .path("/show/as-path-set")
+            .set(aspath::show::as_path_set)
+            .path("/show/as-path-set/name")
+            .set(aspath::show::as_path_set_name)
+            .path("/show/key-chains")
+            .set(keychain::show::key_chains)
+            .path("/show/key-chains/name")
+            .set(keychain::show::key_chain_name)
+            .map();
     }
 }

--- a/zebra-rs/src/rib/show.rs
+++ b/zebra-rs/src/rib/show.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::{
-    config::Args,
+    config::{Args, Builder},
     rib::{Label, Nexthop, nexthop::NexthopList, nexthop::NexthopMember, nexthop::NexthopUni},
 };
 
@@ -1653,32 +1653,51 @@ fn format_mac_flags(flags: u8) -> String {
 }
 
 impl Rib {
-    fn show_add(&mut self, path: &str, cb: ShowCallback) {
-        self.show_cb.insert(path.to_string(), cb);
-    }
-
     pub fn show_build(&mut self) {
-        self.show_add("/show/interface", link_show);
-        self.show_add("/show/ip/route", rib_show);
-        self.show_add("/show/ip/route/detail", rib_show_detail);
-        self.show_add("/show/ip/route/prefix", rib_show_prefix);
-        self.show_add("/show/ip/route/prefix/detail", rib_show_prefix_detail);
-        self.show_add("/show/ip/route/vrf", rib_show_vrf);
-        self.show_add("/show/ip/route/vrf/detail", rib_show_vrf_detail);
-        self.show_add("/show/ipv6/route", rib6_show);
-        self.show_add("/show/ipv6/route/detail", rib6_show_detail);
-        self.show_add("/show/ipv6/route/prefix", rib6_show_prefix);
-        self.show_add("/show/ipv6/route/prefix/detail", rib6_show_prefix_detail);
-        self.show_add("/show/ipv6/route/vrf", rib6_show_vrf);
-        self.show_add("/show/ipv6/route/vrf/detail", rib6_show_vrf_detail);
-        self.show_add("/show/nexthop", nexthop_show);
-        self.show_add("/show/mpls/ilm", ilm_show);
-        self.show_add("/show/l2/mac/table", mac_show);
-        self.show_add("/show/l2/neighbor", l2_neighbor_show);
-        self.show_add("/show/segment-routing/srv6/sid", sid_show);
-        self.show_add("/show/vrf", vrf_show);
-        self.show_add("/show/hostname", hostname_show);
-        self.show_add("/show/router-id", router_id_show);
+        self.show_cb = Builder::<ShowCallback>::default()
+            .path("/show/interface")
+            .set(link_show)
+            .path("/show/ip/route")
+            .set(rib_show)
+            .path("/show/ip/route/detail")
+            .set(rib_show_detail)
+            .path("/show/ip/route/prefix")
+            .set(rib_show_prefix)
+            .path("/show/ip/route/prefix/detail")
+            .set(rib_show_prefix_detail)
+            .path("/show/ip/route/vrf")
+            .set(rib_show_vrf)
+            .path("/show/ip/route/vrf/detail")
+            .set(rib_show_vrf_detail)
+            .path("/show/ipv6/route")
+            .set(rib6_show)
+            .path("/show/ipv6/route/detail")
+            .set(rib6_show_detail)
+            .path("/show/ipv6/route/prefix")
+            .set(rib6_show_prefix)
+            .path("/show/ipv6/route/prefix/detail")
+            .set(rib6_show_prefix_detail)
+            .path("/show/ipv6/route/vrf")
+            .set(rib6_show_vrf)
+            .path("/show/ipv6/route/vrf/detail")
+            .set(rib6_show_vrf_detail)
+            .path("/show/nexthop")
+            .set(nexthop_show)
+            .path("/show/mpls/ilm")
+            .set(ilm_show)
+            .path("/show/l2/mac/table")
+            .set(mac_show)
+            .path("/show/l2/neighbor")
+            .set(l2_neighbor_show)
+            .path("/show/segment-routing/srv6/sid")
+            .set(sid_show)
+            .path("/show/vrf")
+            .set(vrf_show)
+            .path("/show/hostname")
+            .set(hostname_show)
+            .path("/show/router-id")
+            .set(router_id_show)
+            .map();
     }
 }
 


### PR DESCRIPTION
## Summary
- Hoist the show-command registration `Builder` from `bgp/show.rs` into `crate::config` (new `config/show_builder.rs`, exported alongside `Args`), generic over each daemon's `ShowCallback` type since the callback signatures differ per daemon (and RIB returns a bare `String`).
- Convert OSPF v2/v3, IS-IS, policy, BFD, and RIB `show_build()` to the same `path()`/`set()` chain; drop the per-module `show_add()` helpers.
- OSPFv3 loses its `SHOW_OSPFV3` prefix + suffix-table loop: every show path is now a single greppable literal, which helps grammar-move sweeps.
- No behavior change: all seven registration path sets diff identical against `main` (v3 verified by reconstructing the prefix+suffix concatenations).

## Test plan
- `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace --exclude bdd`: all suites ok (zebra-rs: 1048 passed, 0 failed, 2 ignored)

Generated with [Claude Code](https://claude.com/claude-code)