### PR TITLE
bgp: list interface-neighbor in show bgp summary before any session

### DIFF
--- a/bdd/tests/configs/bgp_unnumbered_summary/z1.yaml
+++ b/bdd/tests/configs/bgp_unnumbered_summary/z1.yaml
@@ -1,0 +1,14 @@
+# One-sided unnumbered bring-up: the remote namespace never runs
+# zebra-rs, so no RA ever arrives on i1 and no BGP session is ever
+# attempted. The configured interface-neighbor must nevertheless be
+# visible as a dormant Idle peer in `show bgp summary` (FRR parity) —
+# its Peer is materialized from config + link knowledge alone, with the
+# remote link-local left unspecified until a first RA upgrades it.
+router:
+  bgp:
+    global:
+      as: 65001
+      router-id: 1.1.1.1
+    interface-neighbor:
+    - interface: i1
+      remote-as: 65002

--- a/bdd/tests/features/bgp_unnumbered_summary.feature
+++ b/bdd/tests/features/bgp_unnumbered_summary.feature
@@ -1,0 +1,51 @@
+@serial
+@bgp_unnumbered_summary
+Feature: BGP unnumbered neighbor visible in summaries before any session
+  As a network operator bringing up BGP over IPv6-only point-to-point
+  links, I want a configured `interface-neighbor` to appear in
+  `show bgp summary` (as Idle) even when the remote node has never been
+  reachable, so that mis-cabled or not-yet-deployed neighbors are
+  diagnosable from the summary instead of silently absent.
+
+  Interface-keyed peers are normally materialized only when the
+  remote's Router Advertisement surfaces its link-local. This feature
+  pins the dormant-materialization path: config + link knowledge alone
+  must create the operator-visible peer (FRR behaves the same way).
+
+  Test Topology (point-to-point veth; z2 exists only to hold the other
+  veth end — it never runs zebra-rs, so z1 never sees an RA):
+  ```
+        (i1)                                   (i1)
+    ┌────┴────┐                            ┌─────────┐
+    │   z1    │────────── P2P ─────────────│   z2    │
+    │ AS65001 │      no RA, no session     │ (no     │
+    │ id 1.1. │                            │ daemon) │
+    │   1.1   │                            └─────────┘
+    └─────────┘
+  ```
+
+  Scenario: Setup topology
+    Given a clean test environment
+    When I create namespace "z1"
+    And I create namespace "z2"
+    And I connect namespace "z1" interface "i1" to namespace "z2" interface "i1"
+    And I start zebra-rs in namespace "z1"
+    And I apply config "z1.yaml" to namespace "z1"
+    And I wait 2 seconds
+
+  Scenario: A never-connected interface-neighbor is listed as a dormant Idle peer
+    Given the test topology exists
+    # The trailing space pins the fixed-width Neighbor column. The peer
+    # has no remote link-local yet, so its row must carry the Idle
+    # state, and the per-AFI summary must list it too.
+    Then show command "show bgp summary" in namespace "z1" should contain "i1 "
+    And show command "show bgp summary" in namespace "z1" should contain "Idle"
+    And show command "show bgp ipv4 summary" in namespace "z1" should contain "i1 "
+    And show command "show bgp neighbors i1" in namespace "z1" should contain "BGP neighbor on i1:"
+
+  Scenario: Teardown topology
+    Given the test topology exists
+    When I stop zebra-rs in namespace "z1"
+    And I delete namespace "z1"
+    And I delete namespace "z2"
+    Then the test environment should be clean

--- a/zebra-rs/src/bgp/config.rs
+++ b/zebra-rs/src/bgp/config.rs
@@ -4643,6 +4643,127 @@ mod neighbor_group_wiring_tests {
         );
     }
 
+    // ---- interface-neighbor dormant materialization ---------------
+    // A configured `interface-neighbor` must exist as a Peer (and so
+    // be listed by `show bgp summary`) even when the remote node has
+    // never sent an RA — before dormant materialization the neighbor
+    // was invisible until the first NeighborDiscovered event.
+
+    /// Config alone (link already known to RIB) materializes a dormant
+    /// Idle peer; the first RA upgrades it in place — address learned,
+    /// FSM kicked — instead of re-creating it.
+    #[tokio::test]
+    async fn interface_neighbor_is_visible_before_first_ra() {
+        use super::super::interface_neighbor::{
+            config_interface_neighbor, config_interface_neighbor_remote_as, materialize_peer,
+        };
+        use super::super::peer_key::PeerKey;
+        use crate::bgp::peer::State;
+
+        let mut bgp = fresh_bgp();
+        // RIB announced the link; no RA has arrived.
+        bgp.link_index_by_name.insert("i1".to_string(), 7);
+        config_interface_neighbor(&mut bgp, arg_words(&["i1"]), ConfigOp::Set).unwrap();
+        config_interface_neighbor_remote_as(&mut bgp, arg_words(&["i1", "65002"]), ConfigOp::Set)
+            .unwrap();
+
+        let peer = bgp
+            .peers
+            .get_by_key(&PeerKey::Interface(7))
+            .expect("dormant peer must materialize from config alone");
+        assert_eq!(peer.ifname.as_deref(), Some("i1"));
+        assert_eq!(peer.remote_as, 65002);
+        assert_eq!(peer.state, State::Idle);
+        assert!(peer.address.is_unspecified(), "no RA yet — no address");
+        assert!(!peer.active, "FSM must not dial an unspecified address");
+        let ident = peer.ident;
+
+        let link_local: std::net::Ipv6Addr = "fe80::2".parse().unwrap();
+        materialize_peer(&mut bgp, "i1", 7, link_local).expect("RA upgrades the peer");
+        let peer = bgp.peers.get_by_key(&PeerKey::Interface(7)).unwrap();
+        assert_eq!(peer.ident, ident, "upgraded in place, not re-created");
+        assert_eq!(peer.address, IpAddr::from(link_local));
+        assert!(peer.active, "the first RA must kick the FSM");
+    }
+
+    /// Config typed before RIB announces the interface (startup config
+    /// replay races the link dump): the `RibRx::LinkAdd` arm must
+    /// materialize the dormant peer.
+    #[tokio::test]
+    async fn interface_neighbor_materializes_on_link_add() {
+        use super::super::interface_neighbor::{
+            config_interface_neighbor, config_interface_neighbor_remote_as,
+        };
+        use super::super::peer_key::PeerKey;
+
+        let mut bgp = fresh_bgp();
+        config_interface_neighbor(&mut bgp, arg_words(&["i1"]), ConfigOp::Set).unwrap();
+        config_interface_neighbor_remote_as(&mut bgp, arg_words(&["i1", "65002"]), ConfigOp::Set)
+            .unwrap();
+        assert!(
+            bgp.peers.get_by_key(&PeerKey::Interface(7)).is_none(),
+            "no link yet — nothing to key the peer by"
+        );
+
+        let link = crate::rib::Link {
+            index: 7,
+            name: "i1".to_string(),
+            mtu: 1500,
+            original_mtu: 1500,
+            metric: 1,
+            flags: Default::default(),
+            link_type: crate::rib::LinkType::Ethernet,
+            label: false,
+            mac: None,
+            addr4: Vec::new(),
+            addr6: Vec::new(),
+            master: None,
+            vni: None,
+            vxlan_local: None,
+            mtu_error: None,
+        };
+        bgp.process_rib_msg(crate::rib::api::RibRx::LinkAdd(link));
+
+        let peer = bgp
+            .peers
+            .get_by_key(&PeerKey::Interface(7))
+            .expect("LinkAdd must materialize the configured neighbor");
+        assert_eq!(peer.ifname.as_deref(), Some("i1"));
+        assert!(!peer.active, "still no RA — stays dormant");
+    }
+
+    /// The group supplies the remote-as after an interface-neighbor
+    /// referenced it: the group callback must surface the dormant
+    /// member — the remote-as sweep only reaches peers that already
+    /// exist.
+    #[tokio::test]
+    async fn group_remote_as_materializes_dormant_interface_member() {
+        use super::super::interface_neighbor::{
+            config_interface_neighbor, config_interface_neighbor_neighbor_group,
+        };
+        use super::super::peer_key::PeerKey;
+
+        let mut bgp = fresh_bgp();
+        bgp.link_index_by_name.insert("i1".to_string(), 7);
+        config_interface_neighbor(&mut bgp, arg_words(&["i1"]), ConfigOp::Set).unwrap();
+        config_interface_neighbor_neighbor_group(&mut bgp, arg_words(&["i1", "G"]), ConfigOp::Set)
+            .unwrap();
+        assert!(
+            bgp.peers.get_by_key(&PeerKey::Interface(7)).is_none(),
+            "no remote-as resolvable yet"
+        );
+
+        config_neighbor_group_remote_as(&mut bgp, arg_words(&["G", "65003"]), ConfigOp::Set)
+            .unwrap();
+        let peer = bgp
+            .peers
+            .get_by_key(&PeerKey::Interface(7))
+            .expect("the group's remote-as completes the config gates");
+        assert_eq!(peer.remote_as, 65003);
+        assert!(peer.config.remote_as_inherited);
+        assert!(!peer.active, "still no RA — stays dormant");
+    }
+
     // ---- whole-session knob inheritance (ttl-security exemplar) --
 
     use super::super::neighbor_group::config_neighbor_group_ttl_security;

--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -1973,6 +1973,14 @@ impl Bgp {
                 // covered by simple insert-replaces-on-collision.
                 self.link_index_by_name
                     .insert(link.name.clone(), link.index);
+                // An `interface-neighbor` typed before RIB announced
+                // this link (config replay at startup races the link
+                // dump) materializes its dormant peer now, so the
+                // neighbor is listed by `show bgp summary` without
+                // waiting for the remote's first RA.
+                if self.interface_neighbors.contains_key(&link.name) {
+                    super::interface_neighbor::materialize_dormant(self, &link.name);
+                }
             }
             RibRx::AddrAdd(addr) => {
                 self.interface_addrs.record(&addr);

--- a/zebra-rs/src/bgp/interface_neighbor.rs
+++ b/zebra-rs/src/bgp/interface_neighbor.rs
@@ -91,23 +91,57 @@ pub fn materialize_peer(
     ifindex: u32,
     link_local: Ipv6Addr,
 ) -> Option<usize> {
+    materialize(bgp, name, ifindex, Some(link_local))
+}
+
+/// Materialize a dormant Peer for `interface-neighbor IFNAME` before
+/// any RA has surfaced the remote link-local. The address stays
+/// unspecified and the FSM is left alone (`peer.start()` gates on a
+/// dialable address), so the peer is operator-visible state only:
+/// `show bgp summary` / `show bgp neighbors` list the configured
+/// neighbor as Idle even when the remote node has never been up,
+/// matching FRR. The RA path ([`materialize_peer`]) upgrades it in
+/// place. `None` when the interface is unknown to RIB yet or the
+/// config gates (resolvable remote-as) aren't satisfied — callers
+/// simply retry on the next config/link event.
+pub fn materialize_dormant(bgp: &mut Bgp, name: &str) -> Option<usize> {
+    let ifindex = *bgp.link_index_by_name.get(name)?;
+    materialize(bgp, name, ifindex, None)
+}
+
+fn materialize(
+    bgp: &mut Bgp,
+    name: &str,
+    ifindex: u32,
+    link_local: Option<Ipv6Addr>,
+) -> Option<usize> {
     let cfg = bgp.interface_neighbors.get(name)?.clone();
     let resolved = resolve_remote_as_with_source(bgp, &cfg)?;
 
     // Already materialized? Refresh address (the peer's link-local
     // can change if the kernel reassigns it) but otherwise leave the
-    // FSM alone.
+    // FSM alone — except a dormant peer (materialized at config time,
+    // address still unspecified), which gets its first kick here.
     if let Some(existing) = bgp.peers.get_mut_by_key(&PeerKey::Interface(ifindex)) {
-        existing.address = link_local.into();
+        if let Some(link_local) = link_local {
+            existing.address = link_local.into();
+            // No-op on a running peer (`start()` gates on `!active`);
+            // a dormant one leaves Idle now that it can dial.
+            existing.start();
+        }
         return Some(existing.ident);
     }
 
+    let address: std::net::IpAddr = match link_local {
+        Some(link_local) => link_local.into(),
+        None => Ipv6Addr::UNSPECIFIED.into(),
+    };
     let mut peer = Peer::new(
         0,
         bgp.asn,
         bgp.router_id,
         resolved.asn,
-        link_local.into(),
+        address,
         bgp.hostname(),
         bgp.tx.clone(),
         bgp.ctx.clone(),
@@ -148,11 +182,13 @@ pub fn materialize_peer(
     // Kick the FSM. `peer.start()` arms the idle-hold timer which
     // fires Event::Start → fsm_start → peer_start_connection. The
     // timer captures `peer.ident`, so it must run AFTER insert (which
-    // assigns the real ident). The gate inside start() also requires
-    // `remote_as != 0`, so peers materialized from a `RemoteAsSpec::
-    // External` (which yields 0 as a placeholder until OPEN backfill)
-    // remain dormant — that case lands in a follow-up alongside the
-    // OPEN-side validation.
+    // assigns the real ident). The gates inside start() also require
+    // `remote_as != 0` and a specified address, so two kinds of peer
+    // remain dormant in Idle here: ones materialized from a
+    // `RemoteAsSpec::External` (which yields 0 as a placeholder until
+    // OPEN backfill — that case lands in a follow-up alongside the
+    // OPEN-side validation) and ones materialized without a link-local
+    // (no RA yet — the RA path upgrades them in place).
     peer.start();
     Some(peer.ident)
 }
@@ -162,7 +198,12 @@ pub fn config_interface_neighbor(bgp: &mut Bgp, mut args: Args, op: ConfigOp) ->
     let name = args.string()?;
     match op {
         ConfigOp::Set => {
-            bgp.interface_neighbors.entry(name).or_default();
+            bgp.interface_neighbors.entry(name.clone()).or_default();
+            // Become operator-visible right away when the interface
+            // already exists and a remote-as resolves (via a group
+            // bound before this key arrived) — no RA required for the
+            // neighbor to appear in `show bgp summary`.
+            materialize_dormant(bgp, &name);
         }
         ConfigOp::Delete => {
             // Take the cfg out first so we can tear the peer (if any)
@@ -216,6 +257,11 @@ pub fn config_interface_neighbor_neighbor_group(
             .tx
             .try_send(super::inst::Message::Event(ident, super::peer::Event::Stop));
     }
+    // The (re)bound group may supply the remote-as this neighbor was
+    // missing — an unmaterialized cfg becomes a dormant peer now. A
+    // no-op when the peer above already exists or the gates still
+    // aren't satisfied.
+    materialize_dormant(bgp, &name);
     Some(())
 }
 
@@ -226,7 +272,7 @@ pub fn config_interface_neighbor_remote_as(
     op: ConfigOp,
 ) -> Option<()> {
     let name = args.string()?;
-    let entry = bgp.interface_neighbors.entry(name).or_default();
+    let entry = bgp.interface_neighbors.entry(name.clone()).or_default();
     match op {
         ConfigOp::Set => {
             let raw = args.string()?;
@@ -235,6 +281,10 @@ pub fn config_interface_neighbor_remote_as(
                 "internal" => RemoteAsSpec::Internal,
                 numeric => RemoteAsSpec::Asn(numeric.parse().ok()?),
             };
+            // remote-as usually completes the config (it arrives after
+            // the list-key callback in a commit) — surface the dormant
+            // peer so the neighbor shows up before any RA.
+            materialize_dormant(bgp, &name);
         }
         ConfigOp::Delete => entry.remote_as = RemoteAsSpec::Unset,
         _ => {}

--- a/zebra-rs/src/bgp/neighbor_group.rs
+++ b/zebra-rs/src/bgp/neighbor_group.rs
@@ -151,6 +151,23 @@ pub fn config_neighbor_group_remote_as(bgp: &mut Bgp, mut args: Args, op: Config
         .remote_as = new_asn;
 
     sweep_peers_for_group(bgp, &name, new_asn);
+
+    // The group's remote-as can be the missing gate for an
+    // interface-neighbor that references this group but has no peer
+    // yet (interface known, no RA, no per-cfg remote-as) — the sweep
+    // above only reaches already-materialized peers. Surface those
+    // members as dormant peers so `show bgp summary` lists them.
+    if new_asn.is_some() {
+        let members: Vec<String> = bgp
+            .interface_neighbors
+            .iter()
+            .filter(|(_, cfg)| cfg.neighbor_group.as_deref() == Some(name.as_str()))
+            .map(|(ifname, _)| ifname.clone())
+            .collect();
+        for ifname in members {
+            super::interface_neighbor::materialize_dormant(bgp, &ifname);
+        }
+    }
     Some(())
 }
 

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -3257,6 +3257,37 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
         );
     }
 
+    /// A dormant unnumbered peer — configured `interface-neighbor`
+    /// whose remote has never sent an RA, so its address is still
+    /// unspecified and the FSM was never kicked — must still be
+    /// listed (as Idle), exactly like FRR. Before dormant
+    /// materialization existed no Peer was created at all and the
+    /// configured neighbor was invisible to every summary.
+    #[test]
+    fn summary_lists_dormant_unnumbered_peer() {
+        let mut peers = PeerMap::new();
+        let unspecified: IpAddr = std::net::Ipv6Addr::UNSPECIFIED.into();
+        let mut iface_peer = make_peer(unspecified);
+        iface_peer.origin = PeerOrigin::Interface { ifindex: 7 };
+        iface_peer.ifname = Some("i1".to_string());
+        peers.insert_with_key(PeerKey::Interface(7), iface_peer);
+        let view = TestView {
+            rib: LocalRib::default(),
+            peers,
+        };
+
+        let out = show_bgp_summary(&view, Args(VecDeque::new()), false).unwrap();
+        let row = out
+            .lines()
+            .find(|l| l.starts_with("i1 "))
+            .unwrap_or_else(|| panic!("dormant unnumbered peer must be listed:\n{out}"));
+        assert!(row.contains("Idle"), "no session yet — Idle row:\n{row}");
+        assert!(
+            out.contains("Peers 1"),
+            "dormant peer must be counted:\n{out}"
+        );
+    }
+
     /// JSON summary: the unnumbered row is identified by the interface
     /// name and carries an `interface` field marking its provenance;
     /// address-keyed rows must not grow one.


### PR DESCRIPTION
## Problem

A configured `interface-neighbor IFNAME` only became a `Peer` when the remote's first Router Advertisement surfaced its link-local (`process_nd_event` → `materialize_peer`). If the remote node was never up, the neighbor existed only as config — `show bgp summary` and `show bgp neighbors` showed nothing, so a mis-cabled or not-yet-deployed neighbor was silently absent instead of diagnosable as Idle. FRR lists such a neighbor.

## Fix

Materialize a **dormant** peer as soon as the config gates (resolvable remote-as) and the ifindex are known:

- the address stays unspecified and the FSM is never kicked — `peer.start()` already gates on `remote_as != 0 && !address.is_unspecified() && !active`;
- the RA path upgrades the dormant peer in place: refresh the address and call `start()` (a no-op on an already-running peer);
- hooked at every site where the gates can become satisfied: the interface-neighbor key / `remote-as` / `neighbor-group` callbacks, `RibRx::LinkAdd` (config replayed before the link dump), and the group `remote-as` callback (the existing sweep only reaches peers that already exist).

Audited every `Event::Start` emitter so the dormant peer can never dial `::`: `refresh_connected` gates on `peer.active` + `connected_check_applies()`, the group sweep's `Adopt` goes through the gated `start()`, timers are only armed by `start()` or on an FSM state *transition* (`Event::Stop` on an Idle peer is a no-op), and the accept path drops an inbound stream for an Idle peer exactly like the previous no-peer-found path.

No show-side changes were needed — the summary/neighbors renderers already use `iter_all()`; the peer just has to exist.

## Tests

- `summary_lists_dormant_unnumbered_peer` — renderer pin: dormant shape (unspecified address) lists as Idle under its interface name.
- `interface_neighbor_is_visible_before_first_ra` — config alone materializes the dormant Idle peer; the first RA upgrades it in place (same ident, address learned, FSM kicked).
- `interface_neighbor_materializes_on_link_add` — config before the RIB link dump; the `LinkAdd` arm materializes.
- `group_remote_as_materializes_dormant_interface_member` — the group's remote-as completes the gates for an unmaterialized member.
- New `@bgp_unnumbered_summary` BDD: one-sided topology (remote namespace never runs a daemon) — neighbor appears as Idle in `show bgp summary` / `show bgp ipv4 summary` and resolves via `show bgp neighbors i1`. Passed locally, plus regression runs of `@bgp_unnumbered_neighbor` (5 scenarios) and `@bgp_unnumbered_afi_safi` (4 scenarios) since their materialization timing changed.
- Full workspace test suite green; workspace clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)