### PR TITLE
nd: drain RIB's initial dump to EoR before serving the event loop

### DIFF
--- a/zebra-rs/src/nd/inst.rs
+++ b/zebra-rs/src/nd/inst.rs
@@ -133,16 +133,22 @@ impl Nd {
     }
 
     async fn event_loop(&mut self) {
-        // We will use this after "link name" -> "RIB link" bug is fixed.
-        // loop {
-        //     match self.rib_rx.recv().await {
-        //         Some(RibRx::EoR) => {
-        //             break;
-        //         }
-        //         Some(msg) => self.process_rib_msg(msg),
-        //         None => break,
-        //     }
-        // }
+        // Drain RIB's initial dump up to `EoR` before selecting on
+        // the other channels. `commit_config` enqueues ConfigRequests
+        // synchronously in the same call that spawned us, while the
+        // link dump makes a round trip through the RIB task — so
+        // without this barrier a `send-advertisements` callback can
+        // run before the LinkAdds that feed name → ifindex
+        // resolution. The engine's name-keyed pending config covers
+        // links that appear later (and would absorb this race too);
+        // the barrier makes the cold-start ordering deterministic so
+        // config applies on the spot instead of waiting for a replay.
+        while let Some(msg) = self.rib_rx.recv().await {
+            if matches!(msg, RibRx::EoR) {
+                break;
+            }
+            self.process_rib_msg(msg);
+        }
         loop {
             let wakeup = self.engine.next_wakeup();
             tokio::select! {


### PR DESCRIPTION
## Summary

Follow-up to #1339. `Nd::event_loop` now consumes RIB's initial dump up to the `EoR` sentinel before entering its `tokio::select!` loop.

`commit_config` enqueues `ConfigRequest`s synchronously in the same call that spawned ND, while the link dump makes a round trip through the RIB task — so without a barrier, a `send-advertisements` callback can run before the `LinkAdd`s that feed name→ifindex resolution. The name-keyed pending config from #1339 already absorbs that race by replaying when the `LinkAdd` arrives; this barrier makes the cold-start ordering deterministic so config applies on the spot instead of waiting for the replay. If RIB closes the channel without an `EoR`, the drain falls through to the normal loop rather than wedging.

## Test plan

- `cargo test --workspace --exclude bdd` green locally (35 suites, no failures).
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Live-verified together with #1339: RA config committed before the link dump now starts the RFC 4861 initial burst immediately on cold start.

Generated with [Claude Code](https://claude.com/claude-code)