### PR TITLE
nd: count ND packets and track sources in the engine

### DIFF
--- a/zebra-rs/src/nd/engine.rs
+++ b/zebra-rs/src/nd/engine.rs
@@ -17,10 +17,12 @@ use std::collections::BTreeMap;
 use std::net::Ipv6Addr;
 use std::time::Instant;
 
+use nd_packet::RaFlags;
+
 use crate::rib::link::Link;
 
 use super::send::{RaEvent, RaSendConfig, RaSender};
-use super::{NdRecv, NdSend};
+use super::{DropReason, NdRecv, NdSend};
 
 /// Lifecycle events emitted by [`NdEngine`] for downstream consumers.
 /// One subscriber today (BGP unnumbered will plug in here); a
@@ -33,6 +35,77 @@ pub enum NdEvent {
     /// debouncing repeats.
     NeighborDiscovered { ifindex: u32, src: Ipv6Addr },
 }
+
+/// Per-interface packet counters observed at the daemon's raw socket.
+///
+/// Note: kernel-originated NS/NA are invisible here because the host
+/// kernel owns the NDP cache and multicast loopback is disabled on the
+/// ND socket. Only packets received on the wire and our own RA
+/// transmissions are counted.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct NdIfCounters {
+    /// Unsolicited RAs we transmitted (periodic).
+    pub tx_ra_unsolicited: u64,
+    /// Solicited RAs we transmitted (in response to RS).
+    pub tx_ra_solicited: u64,
+    /// Router Advertisements received.
+    pub rx_ra: u64,
+    /// Router Solicitations received.
+    pub rx_rs: u64,
+    /// Neighbor Solicitations received.
+    pub rx_ns: u64,
+    /// Neighbor Advertisements received.
+    pub rx_na: u64,
+    /// Packets discarded because the IPv6 hop limit was not 255
+    /// (RFC 4861 §6.1.2 MUST silently discard).
+    pub rx_drop_hop_limit: u64,
+    /// Packets discarded due to a parse error (too short, non-zero
+    /// ICMPv6 code, malformed option, etc.).
+    pub rx_drop_malformed: u64,
+    /// Sources that arrived when the per-interface neighbor table was
+    /// full (see [`MAX_TRACKED_SOURCES`]). Counted per packet, not per
+    /// unique source.
+    pub untracked_sources: u64,
+}
+
+/// Snapshot of the most recently received Router Advertisement from a
+/// given source. Stored in [`NdNeighbor`] so the show command can
+/// render lifetime / flags without re-parsing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LastRa {
+    pub router_lifetime: u16,
+    pub cur_hop_limit: u8,
+    pub flags: RaFlags,
+}
+
+/// Per-source observation record in the neighbor table.
+///
+/// Keyed by the IPv6 source address of received ND messages. The
+/// source may be `::` for DAD (Duplicate Address Detection) probes
+/// — those get a table entry like any other source.
+#[derive(Debug, Clone)]
+pub struct NdNeighbor {
+    /// Wall-clock time the first packet from this source was seen.
+    pub first_seen: Instant,
+    /// Wall-clock time the most recent packet from this source was seen.
+    pub last_seen: Instant,
+    /// Router Advertisements received from this source.
+    pub rx_ra: u64,
+    /// Router Solicitations received from this source.
+    pub rx_rs: u64,
+    /// Neighbor Solicitations received from this source.
+    pub rx_ns: u64,
+    /// Neighbor Advertisements received from this source.
+    pub rx_na: u64,
+    /// Fields from the most recently received RA, if any.
+    pub last_ra: Option<LastRa>,
+}
+
+/// Per-interface neighbor-table cap. When the table is full, additional
+/// *new* sources are not inserted; instead `untracked_sources` on the
+/// interface counters is incremented. Existing sources continue to be
+/// updated even when the table is at capacity.
+pub const MAX_TRACKED_SOURCES: usize = 256;
 
 pub struct NdEngine {
     senders: BTreeMap<u32, RaSender>,
@@ -55,6 +128,13 @@ pub struct NdEngine {
     /// long after the commit — instead of silently dropping config
     /// that raced ahead of the dump.
     ra_config_by_name: BTreeMap<String, RaSendConfig>,
+    /// Per-interface packet counters. Independent of `senders` — NS/NA
+    /// arrive on interfaces with no RA sender configured and must still
+    /// be counted.
+    counters: BTreeMap<u32, NdIfCounters>,
+    /// Per-interface, per-source observation records. Independent of
+    /// `senders` for the same reason as `counters`.
+    neighbors: BTreeMap<u32, BTreeMap<Ipv6Addr, NdNeighbor>>,
 }
 
 impl NdEngine {
@@ -65,6 +145,8 @@ impl NdEngine {
             ifindex_by_name: BTreeMap::new(),
             name_by_ifindex: BTreeMap::new(),
             ra_config_by_name: BTreeMap::new(),
+            counters: BTreeMap::new(),
+            neighbors: BTreeMap::new(),
         }
     }
 
@@ -166,13 +248,57 @@ impl NdEngine {
         self.senders.values().map(|s| s.next_wakeup()).min()
     }
 
-    /// Handle an inbound ND frame: emit a [`NdEvent::NeighborDiscovered`]
-    /// for the RA case (the BGP unnumbered hand-off), and forward RS
-    /// events into the matching sender so a solicited reply gets
-    /// scheduled.
+    // ── Read accessors (used by the upcoming show command) ──────────────
+
+    /// All per-interface counters, keyed by ifindex.
+    pub fn counters(&self) -> &BTreeMap<u32, NdIfCounters> {
+        &self.counters
+    }
+
+    /// All per-interface neighbor tables, keyed by ifindex then source
+    /// address.
+    pub fn neighbors(&self) -> &BTreeMap<u32, BTreeMap<Ipv6Addr, NdNeighbor>> {
+        &self.neighbors
+    }
+
+    /// The [`RaSender`] for `ifindex`, if RA is enabled on that
+    /// interface.
+    pub fn sender(&self, ifindex: u32) -> Option<&RaSender> {
+        self.senders.get(&ifindex)
+    }
+
+    /// All active [`RaSender`]s, keyed by ifindex.
+    pub fn senders(&self) -> &BTreeMap<u32, RaSender> {
+        &self.senders
+    }
+
+    /// Handle an inbound ND frame: update counters, update the
+    /// neighbor table, emit [`NdEvent::NeighborDiscovered`] for RA
+    /// (the BGP unnumbered hand-off), and forward RS events into the
+    /// matching sender so a solicited reply gets scheduled.
     pub fn on_recv(&mut self, recv: NdRecv, now: Instant) {
         match recv {
-            NdRecv::RouterAdvert { ifindex, src, .. } => {
+            NdRecv::RouterAdvert { ifindex, src, ra } => {
+                // Update counters and neighbor table first using
+                // disjoint field borrows — doing this before the
+                // senders.get_mut call avoids a borrow-checker conflict.
+                self.counters.entry(ifindex).or_default().rx_ra += 1;
+                let last_ra = Some(LastRa {
+                    router_lifetime: ra.router_lifetime,
+                    cur_hop_limit: ra.cur_hop_limit,
+                    flags: ra.flags,
+                });
+                Self::record_neighbor(
+                    &mut self.neighbors,
+                    &mut self.counters,
+                    ifindex,
+                    src,
+                    now,
+                    |nb| {
+                        nb.rx_ra += 1;
+                        nb.last_ra = last_ra.clone();
+                    },
+                );
                 if let Some(tx) = &self.notifier {
                     // Ignore SendError — a closed subscriber just
                     // means nobody's listening, not a fatal state.
@@ -180,8 +306,46 @@ impl NdEngine {
                 }
             }
             NdRecv::RouterSolicit { ifindex, src, .. } => {
+                self.counters.entry(ifindex).or_default().rx_rs += 1;
+                Self::record_neighbor(
+                    &mut self.neighbors,
+                    &mut self.counters,
+                    ifindex,
+                    src,
+                    now,
+                    |nb| nb.rx_rs += 1,
+                );
                 if let Some(sender) = self.senders.get_mut(&ifindex) {
                     sender.on_router_solicit(src, now);
+                }
+            }
+            NdRecv::NeighborSolicit { ifindex, src, .. } => {
+                self.counters.entry(ifindex).or_default().rx_ns += 1;
+                Self::record_neighbor(
+                    &mut self.neighbors,
+                    &mut self.counters,
+                    ifindex,
+                    src,
+                    now,
+                    |nb| nb.rx_ns += 1,
+                );
+            }
+            NdRecv::NeighborAdvert { ifindex, src, .. } => {
+                self.counters.entry(ifindex).or_default().rx_na += 1;
+                Self::record_neighbor(
+                    &mut self.neighbors,
+                    &mut self.counters,
+                    ifindex,
+                    src,
+                    now,
+                    |nb| nb.rx_na += 1,
+                );
+            }
+            NdRecv::Dropped { ifindex, reason } => {
+                let c = self.counters.entry(ifindex).or_default();
+                match reason {
+                    DropReason::HopLimit => c.rx_drop_hop_limit += 1,
+                    DropReason::Malformed => c.rx_drop_malformed += 1,
                 }
             }
         }
@@ -195,20 +359,70 @@ impl NdEngine {
         for (&ifindex, sender) in self.senders.iter_mut() {
             for ev in sender.tick(now) {
                 match ev {
-                    RaEvent::SendUnsolicited { ra } => out.push(NdSend::RouterAdvert {
-                        ifindex,
-                        dst: ALL_NODES,
-                        ra,
-                    }),
-                    RaEvent::SendSolicited { ra } => out.push(NdSend::RouterAdvert {
-                        ifindex,
-                        dst: ALL_NODES,
-                        ra,
-                    }),
+                    RaEvent::SendUnsolicited { ra } => {
+                        // Disjoint field borrow: `senders` is mutably
+                        // borrowed by the iterator; `counters` is a
+                        // separate field so this compiles.
+                        self.counters.entry(ifindex).or_default().tx_ra_unsolicited += 1;
+                        out.push(NdSend::RouterAdvert {
+                            ifindex,
+                            dst: ALL_NODES,
+                            ra,
+                        });
+                    }
+                    RaEvent::SendSolicited { ra } => {
+                        self.counters.entry(ifindex).or_default().tx_ra_solicited += 1;
+                        out.push(NdSend::RouterAdvert {
+                            ifindex,
+                            dst: ALL_NODES,
+                            ra,
+                        });
+                    }
                 }
             }
         }
         out
+    }
+
+    /// Update (or insert) the per-source observation record for `src`
+    /// on `ifindex`. If the table is already at [`MAX_TRACKED_SOURCES`]
+    /// and `src` is a new entry, increment `untracked_sources` instead.
+    ///
+    /// `update` is a closure that bumps the appropriate per-type counter
+    /// and sets any additional fields (e.g. `last_ra`) on the record.
+    ///
+    /// Takes `neighbors` and `counters` as explicit parameters so the
+    /// borrow checker can see they are disjoint fields — this function
+    /// is called from `on_recv` while `self.senders` may also be
+    /// accessed.
+    fn record_neighbor(
+        neighbors: &mut BTreeMap<u32, BTreeMap<Ipv6Addr, NdNeighbor>>,
+        counters: &mut BTreeMap<u32, NdIfCounters>,
+        ifindex: u32,
+        src: Ipv6Addr,
+        now: Instant,
+        update: impl FnOnce(&mut NdNeighbor),
+    ) {
+        let table = neighbors.entry(ifindex).or_default();
+        if let Some(nb) = table.get_mut(&src) {
+            nb.last_seen = now;
+            update(nb);
+        } else if table.len() < MAX_TRACKED_SOURCES {
+            let mut nb = NdNeighbor {
+                first_seen: now,
+                last_seen: now,
+                rx_ra: 0,
+                rx_rs: 0,
+                rx_ns: 0,
+                rx_na: 0,
+                last_ra: None,
+            };
+            update(&mut nb);
+            table.insert(src, nb);
+        } else {
+            // Table full — count the overflow but don't insert.
+            counters.entry(ifindex).or_default().untracked_sources += 1;
+        }
     }
 }
 
@@ -229,7 +443,7 @@ mod tests {
     use super::*;
     use crate::nd::send::RaSendConfig;
     use crate::rib::link::{Link, LinkType};
-    use nd_packet::{RouterAdvert, RouterSolicit};
+    use nd_packet::{NaFlags, NeighborAdvert, NeighborSolicit, RouterAdvert, RouterSolicit};
     use netlink_packet_route::link::LinkFlags;
     use tokio::sync::mpsc;
 
@@ -260,6 +474,36 @@ mod tests {
             mtu_error: None,
         }
     }
+
+    fn make_ra() -> RouterAdvert {
+        RouterAdvert {
+            cur_hop_limit: 64,
+            flags: Default::default(),
+            router_lifetime: 1800,
+            reachable_time: 0,
+            retrans_timer: 0,
+            options: vec![],
+        }
+    }
+
+    fn make_ns() -> NeighborSolicit {
+        let target: Ipv6Addr = "fe80::ffff".parse().unwrap();
+        NeighborSolicit {
+            target,
+            options: vec![],
+        }
+    }
+
+    fn make_na() -> NeighborAdvert {
+        let target: Ipv6Addr = "fe80::ffff".parse().unwrap();
+        NeighborAdvert {
+            flags: NaFlags::empty(),
+            target,
+            options: vec![],
+        }
+    }
+
+    // ── Existing tests (unmodified) ──────────────────────────────────────
 
     #[test]
     fn no_interfaces_means_no_wakeup() {
@@ -301,14 +545,7 @@ mod tests {
             NdRecv::RouterAdvert {
                 ifindex: 5,
                 src: ll("fe80::1"),
-                ra: RouterAdvert {
-                    cur_hop_limit: 64,
-                    flags: Default::default(),
-                    router_lifetime: 1800,
-                    reachable_time: 0,
-                    retrans_timer: 0,
-                    options: vec![],
-                },
+                ra: make_ra(),
             },
             t0(),
         );
@@ -518,5 +755,397 @@ mod tests {
 
         eng.process_link_add(&link("swp1", 7), start);
         assert!(eng.is_enabled(7));
+    }
+
+    // ── New tests for PR 2 ───────────────────────────────────────────────
+
+    #[test]
+    fn rx_counters_increment_per_type() {
+        let start = t0();
+        let mut eng = NdEngine::new();
+
+        eng.on_recv(
+            NdRecv::RouterAdvert {
+                ifindex: 5,
+                src: ll("fe80::1"),
+                ra: make_ra(),
+            },
+            start,
+        );
+        eng.on_recv(
+            NdRecv::RouterSolicit {
+                ifindex: 5,
+                src: ll("fe80::2"),
+                rs: RouterSolicit::default(),
+            },
+            start,
+        );
+        eng.on_recv(
+            NdRecv::NeighborSolicit {
+                ifindex: 5,
+                src: ll("fe80::3"),
+                ns: make_ns(),
+            },
+            start,
+        );
+        eng.on_recv(
+            NdRecv::NeighborAdvert {
+                ifindex: 5,
+                src: ll("fe80::4"),
+                na: make_na(),
+            },
+            start,
+        );
+
+        let c = &eng.counters()[&5];
+        assert_eq!(c.rx_ra, 1);
+        assert_eq!(c.rx_rs, 1);
+        assert_eq!(c.rx_ns, 1);
+        assert_eq!(c.rx_na, 1);
+        assert_eq!(c.rx_drop_hop_limit, 0);
+        assert_eq!(c.rx_drop_malformed, 0);
+    }
+
+    #[test]
+    fn dropped_reasons_map_to_counters() {
+        let start = t0();
+        let mut eng = NdEngine::new();
+
+        eng.on_recv(
+            NdRecv::Dropped {
+                ifindex: 5,
+                reason: DropReason::HopLimit,
+            },
+            start,
+        );
+        eng.on_recv(
+            NdRecv::Dropped {
+                ifindex: 5,
+                reason: DropReason::HopLimit,
+            },
+            start,
+        );
+        eng.on_recv(
+            NdRecv::Dropped {
+                ifindex: 5,
+                reason: DropReason::Malformed,
+            },
+            start,
+        );
+
+        let c = &eng.counters()[&5];
+        assert_eq!(c.rx_drop_hop_limit, 2);
+        assert_eq!(c.rx_drop_malformed, 1);
+    }
+
+    #[test]
+    fn neighbor_table_records_per_source() {
+        use std::time::Duration;
+        let start = t0();
+        let later = start + Duration::from_secs(5);
+        let mut eng = NdEngine::new();
+
+        // Source A: one NS at start, one NA at start.
+        eng.on_recv(
+            NdRecv::NeighborSolicit {
+                ifindex: 5,
+                src: ll("fe80::a"),
+                ns: make_ns(),
+            },
+            start,
+        );
+        eng.on_recv(
+            NdRecv::NeighborAdvert {
+                ifindex: 5,
+                src: ll("fe80::a"),
+                na: make_na(),
+            },
+            start,
+        );
+
+        // Source B: one RA at later.
+        eng.on_recv(
+            NdRecv::RouterAdvert {
+                ifindex: 5,
+                src: ll("fe80::b"),
+                ra: make_ra(),
+            },
+            later,
+        );
+
+        let table = &eng.neighbors()[&5];
+        let a = &table[&ll("fe80::a")];
+        assert_eq!(a.rx_ns, 1);
+        assert_eq!(a.rx_na, 1);
+        assert_eq!(a.rx_ra, 0);
+        // both packets arrived at `start` so first_seen == last_seen
+        assert_eq!(a.first_seen, a.last_seen);
+
+        // Now send another packet from A at `later` — last_seen advances.
+        let mut eng2 = NdEngine::new();
+        eng2.on_recv(
+            NdRecv::NeighborSolicit {
+                ifindex: 5,
+                src: ll("fe80::a"),
+                ns: make_ns(),
+            },
+            start,
+        );
+        eng2.on_recv(
+            NdRecv::NeighborSolicit {
+                ifindex: 5,
+                src: ll("fe80::a"),
+                ns: make_ns(),
+            },
+            later,
+        );
+        let table2 = &eng2.neighbors()[&5];
+        let a2 = &table2[&ll("fe80::a")];
+        assert!(a2.first_seen < a2.last_seen);
+        assert_eq!(a2.rx_ns, 2);
+
+        let b = &table[&ll("fe80::b")];
+        assert_eq!(b.rx_ra, 1);
+    }
+
+    #[test]
+    fn last_ra_updates_on_each_ra() {
+        let start = t0();
+        let mut eng = NdEngine::new();
+        let src = ll("fe80::1:1");
+
+        eng.on_recv(
+            NdRecv::RouterAdvert {
+                ifindex: 5,
+                src,
+                ra: RouterAdvert {
+                    cur_hop_limit: 64,
+                    flags: nd_packet::RaFlags::empty(),
+                    router_lifetime: 1800,
+                    reachable_time: 0,
+                    retrans_timer: 0,
+                    options: vec![],
+                },
+            },
+            start,
+        );
+
+        // Second RA with lifetime=0 (router going away).
+        eng.on_recv(
+            NdRecv::RouterAdvert {
+                ifindex: 5,
+                src,
+                ra: RouterAdvert {
+                    cur_hop_limit: 64,
+                    flags: nd_packet::RaFlags::empty(),
+                    router_lifetime: 0,
+                    reachable_time: 0,
+                    retrans_timer: 0,
+                    options: vec![],
+                },
+            },
+            start,
+        );
+
+        let table = &eng.neighbors()[&5];
+        let nb = &table[&src];
+        assert_eq!(nb.rx_ra, 2);
+        let lr = nb.last_ra.as_ref().expect("last_ra should be set");
+        // Latest RA wins.
+        assert_eq!(lr.router_lifetime, 0);
+    }
+
+    #[test]
+    fn dad_unspecified_source_is_tracked() {
+        let start = t0();
+        let mut eng = NdEngine::new();
+        let unspec: Ipv6Addr = "::".parse().unwrap();
+
+        eng.on_recv(
+            NdRecv::NeighborSolicit {
+                ifindex: 5,
+                src: unspec,
+                ns: make_ns(),
+            },
+            start,
+        );
+
+        let table = &eng.neighbors()[&5];
+        assert!(
+            table.contains_key(&unspec),
+            "DAD probe from :: should create a table entry"
+        );
+        assert_eq!(table[&unspec].rx_ns, 1);
+    }
+
+    #[test]
+    fn source_cap_overflows_to_untracked() {
+        let start = t0();
+        let mut eng = NdEngine::new();
+
+        // Fill the table with MAX_TRACKED_SOURCES distinct sources.
+        for i in 0u32..MAX_TRACKED_SOURCES as u32 {
+            // Build fe80::0001, fe80::0002, … — unique per i.
+            let addr = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, (i + 1) as u16);
+            eng.on_recv(
+                NdRecv::NeighborSolicit {
+                    ifindex: 5,
+                    src: addr,
+                    ns: make_ns(),
+                },
+                start,
+            );
+        }
+
+        let table_len_before = eng.neighbors()[&5].len();
+        assert_eq!(table_len_before, MAX_TRACKED_SOURCES);
+
+        // One more NEW source — should be untracked.
+        let new_src = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0xdead, 0xbeef);
+        eng.on_recv(
+            NdRecv::NeighborSolicit {
+                ifindex: 5,
+                src: new_src,
+                ns: make_ns(),
+            },
+            start,
+        );
+
+        assert_eq!(eng.counters()[&5].untracked_sources, 1);
+        // Table didn't grow.
+        assert_eq!(eng.neighbors()[&5].len(), MAX_TRACKED_SOURCES);
+
+        // An EXISTING source must still update even when the table is full.
+        let existing = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+        let old_ns = eng.neighbors()[&5][&existing].rx_ns;
+        use std::time::Duration;
+        eng.on_recv(
+            NdRecv::NeighborSolicit {
+                ifindex: 5,
+                src: existing,
+                ns: make_ns(),
+            },
+            start + Duration::from_secs(1),
+        );
+        // Counter bumped, untracked_sources unchanged.
+        assert_eq!(
+            eng.neighbors()[&5][&existing].rx_ns,
+            old_ns + 1,
+            "existing source should still update when table is full"
+        );
+        assert_eq!(
+            eng.counters()[&5].untracked_sources,
+            1,
+            "untracked_sources should not grow for an existing source"
+        );
+    }
+
+    #[test]
+    fn counters_on_interface_without_sender() {
+        let start = t0();
+        let mut eng = NdEngine::new();
+
+        // ifindex 42 has no RA sender configured.
+        eng.on_recv(
+            NdRecv::NeighborSolicit {
+                ifindex: 42,
+                src: ll("fe80::1"),
+                ns: make_ns(),
+            },
+            start,
+        );
+
+        assert_eq!(eng.counters()[&42].rx_ns, 1);
+        assert!(eng.neighbors()[&42].contains_key(&ll("fe80::1")));
+        assert!(!eng.is_enabled(42), "no sender should have been created");
+    }
+
+    #[test]
+    fn tx_counters_split_unsolicited_solicited() {
+        use crate::nd::send::RaSendConfig;
+        use std::time::Duration;
+
+        // (a) Unsolicited: enable + tick at the scheduled wakeup.
+        {
+            let start = t0();
+            let mut eng = NdEngine::new();
+            eng.enable_interface(5, RaSendConfig::default(), start);
+            let wakeup = eng.next_wakeup().unwrap();
+            let frames = eng.tick(wakeup);
+            assert_eq!(frames.len(), 1);
+            assert_eq!(eng.counters()[&5].tx_ra_unsolicited, 1);
+            assert_eq!(eng.counters()[&5].tx_ra_solicited, 0);
+        }
+
+        // (b) Solicited: enable, send RS before any tick, tick at the
+        //     solicited wakeup → tx_ra_solicited == 1.
+        //
+        // We need a deterministic RNG so we know exactly when the
+        // solicited reply will fire. Use RaSender::with_rng with a
+        // FixedRng that returns a very long initial delay so the first
+        // tick we care about is the solicited one.
+        {
+            // We drive this sub-test entirely through NdEngine's public
+            // API. The trick: enable the interface with a large
+            // max_interval so the first unsolicited fires far in the
+            // future; then send an RS; the solicited wakeup is within
+            // MAX_RA_DELAY_TIME (500ms) of `start`.
+            use crate::nd::send::{MAX_RA_DELAY_TIME, MIN_DELAY_BETWEEN_RAS};
+
+            let start = t0();
+            let mut eng = NdEngine::new();
+            // Large intervals push the unsolicited RA far into the future.
+            let cfg = RaSendConfig {
+                min_interval: Duration::from_secs(3600),
+                max_interval: Duration::from_secs(7200),
+                ..RaSendConfig::default()
+            };
+            eng.enable_interface(5, cfg, start);
+            let initial_wakeup = eng.next_wakeup().unwrap();
+
+            // Receive an RS — this schedules a solicited reply.
+            eng.on_recv(
+                NdRecv::RouterSolicit {
+                    ifindex: 5,
+                    src: ll("fe80::c1"),
+                    rs: RouterSolicit::default(),
+                },
+                start,
+            );
+
+            let solicited_wakeup = eng.next_wakeup().unwrap();
+            assert!(
+                solicited_wakeup < initial_wakeup,
+                "solicited wakeup should be earlier than the unsolicited one"
+            );
+            // Solicited wakeup must be within MAX_RA_DELAY_TIME of start
+            // (plus MIN_DELAY_BETWEEN_RAS in case we just sent — but we
+            // haven't sent yet so the rate-limit doesn't apply).
+            assert!(
+                solicited_wakeup <= start + MAX_RA_DELAY_TIME + MIN_DELAY_BETWEEN_RAS,
+                "solicited wakeup should be within the delay window"
+            );
+
+            let frames = eng.tick(solicited_wakeup);
+            // The solicited RA should fire; the unsolicited one should not.
+            assert!(!frames.is_empty(), "expected at least one frame");
+            assert_eq!(
+                eng.counters()
+                    .get(&5)
+                    .map(|c| c.tx_ra_solicited)
+                    .unwrap_or(0),
+                1,
+                "tx_ra_solicited should be 1"
+            );
+            // Unsolicited counter must still be 0.
+            assert_eq!(
+                eng.counters()
+                    .get(&5)
+                    .map(|c| c.tx_ra_unsolicited)
+                    .unwrap_or(0),
+                0,
+                "tx_ra_unsolicited should remain 0"
+            );
+        }
     }
 }

--- a/zebra-rs/src/nd/mod.rs
+++ b/zebra-rs/src/nd/mod.rs
@@ -4,8 +4,11 @@
 //! This module is the runtime counterpart to the `nd-packet` crate: it
 //! brings up a raw `IPPROTO_ICMPV6` socket configured per RFC 4861
 //! §6.1 (hop limit = 255 on both send and receive, ICMP6_FILTER scoped
-//! to RS + RA only) and provides async read / write tasks that hand
-//! parsed packets to the rest of the daemon via channels.
+//! to RS + RA + NS + NA) and provides async read / write tasks that
+//! hand parsed packets to the rest of the daemon via channels.
+//!
+//! NS (135) and NA (136) are passively observed for counters and
+//! diagnostics; the host kernel still owns the NDP cache.
 //!
 //! Higher-level concerns (per-interface RA send state machine, RIB
 //! integration, BGP unnumbered hand-off) live in follow-up PRs. The
@@ -15,7 +18,7 @@
 
 use std::net::Ipv6Addr;
 
-use nd_packet::{RouterAdvert, RouterSolicit};
+use nd_packet::{NeighborAdvert, NeighborSolicit, RouterAdvert, RouterSolicit};
 
 pub mod config;
 pub mod engine;
@@ -37,6 +40,32 @@ pub enum NdRecv {
         src: Ipv6Addr,
         rs: RouterSolicit,
     },
+    NeighborSolicit {
+        ifindex: u32,
+        src: Ipv6Addr,
+        ns: NeighborSolicit,
+    },
+    NeighborAdvert {
+        ifindex: u32,
+        src: Ipv6Addr,
+        na: NeighborAdvert,
+    },
+    /// A packet failed RFC 4861 receive validation (hop-limit ≠ 255 or
+    /// malformed payload) and was dropped. Carried up so the engine can
+    /// count drops per interface without touching any atomics in the I/O
+    /// task.
+    Dropped { ifindex: u32, reason: DropReason },
+}
+
+/// Reason a received ICMPv6 ND packet was discarded before delivery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DropReason {
+    /// IPv6 hop limit was not 255 — RFC 4861 §6.1.2 MUST silently
+    /// discard.
+    HopLimit,
+    /// Packet was too short, had a non-zero ICMPv6 code, or an option
+    /// was malformed.
+    Malformed,
 }
 
 /// Outbound ND messages consumed by [`network::write_packet`].

--- a/zebra-rs/src/nd/network.rs
+++ b/zebra-rs/src/nd/network.rs
@@ -4,11 +4,14 @@
 //! `crate::ospf::network` so the runtime wiring (channels, cmsg
 //! plumbing, `AsyncFd::async_io`) is familiar.
 //!
-//! Inbound packets are filtered to ICMPv6 RA + RS by the kernel
-//! (`ICMP6_FILTER` was set in [`super::socket::nd_socket`]); we add
-//! one more application-layer check here: drop anything whose
-//! IPv6 hop limit isn't 255, per RFC 4861 §6.1.2. The kernel can't
-//! enforce that on raw sockets, so it's our job.
+//! Inbound packets are filtered to ICMPv6 RS + RA + NS + NA by the
+//! kernel (`ICMP6_FILTER` was set in [`super::socket::nd_socket`]); we
+//! add one more application-layer check here: drop anything whose IPv6
+//! hop limit isn't 255, per RFC 4861 §6.1.2. The kernel can't enforce
+//! that on raw sockets, so it's our job.
+//!
+//! Drops are surfaced as [`NdRecv::Dropped`] so the engine (not the I/O
+//! task) is the single place where every counter increments.
 #![allow(dead_code)]
 
 use std::io::{ErrorKind, IoSlice, IoSliceMut};
@@ -17,14 +20,14 @@ use std::os::fd::AsRawFd;
 use std::sync::Arc;
 
 use bytes::BytesMut;
-use nd_packet::{Icmp6Type, RouterAdvert, RouterSolicit};
+use nd_packet::{Icmp6Type, NeighborAdvert, NeighborSolicit, RouterAdvert, RouterSolicit};
 use nix::sys::socket::{self, ControlMessageOwned, SockaddrIn6};
 use socket2::Socket;
 use tokio::io::Interest;
 use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
-use super::{NdRecv, NdSend};
+use super::{DropReason, NdRecv, NdSend};
 
 /// Hop limit required by RFC 4861 §6.1.2 — anything else is dropped.
 const REQUIRED_HOP_LIMIT: i32 = 255;
@@ -33,9 +36,9 @@ const REQUIRED_HOP_LIMIT: i32 = 255;
 const ALL_ROUTERS: Ipv6Addr = Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0x2);
 
 /// Read loop: parse ICMPv6 packets off the raw socket, deliver
-/// [`NdRecv`] messages on `tx`. Drops malformed packets and packets
-/// failing the hop-limit-255 check silently — both situations are
-/// "MUST silently discard" in RFC 4861.
+/// [`NdRecv`] messages on `tx`. Drops are surfaced as
+/// [`NdRecv::Dropped`] so the engine counts them; the read task never
+/// increments counters directly.
 pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<NdRecv>) {
     let mut buf = [0u8; 1500];
     let mut iov = [IoSliceMut::new(&mut buf)];
@@ -73,7 +76,13 @@ pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<NdRecv>
                     return Err(ErrorKind::InvalidData.into());
                 };
                 if hop_limit != REQUIRED_HOP_LIMIT {
-                    // RFC 4861 §6.1.2: silently drop.
+                    // RFC 4861 §6.1.2: MUST silently discard any ND
+                    // message with a hop limit other than 255. Surface
+                    // this as a Dropped message so the engine counts it.
+                    let _ = tx.send(NdRecv::Dropped {
+                        ifindex,
+                        reason: DropReason::HopLimit,
+                    });
                     return Ok(());
                 }
 
@@ -87,16 +96,49 @@ pub async fn read_packet(sock: Arc<AsyncFd<Socket>>, tx: UnboundedSender<NdRecv>
                 let parsed = match Icmp6Type::from_u8(payload[0]) {
                     Some(Icmp6Type::RouterAdvert) => match RouterAdvert::parse(payload, None) {
                         Ok(ra) => NdRecv::RouterAdvert { ifindex, src, ra },
-                        Err(_) => return Ok(()),
+                        Err(_) => {
+                            let _ = tx.send(NdRecv::Dropped {
+                                ifindex,
+                                reason: DropReason::Malformed,
+                            });
+                            return Ok(());
+                        }
                     },
                     Some(Icmp6Type::RouterSolicit) => match RouterSolicit::parse(payload, None) {
                         Ok(rs) => NdRecv::RouterSolicit { ifindex, src, rs },
-                        Err(_) => return Ok(()),
+                        Err(_) => {
+                            let _ = tx.send(NdRecv::Dropped {
+                                ifindex,
+                                reason: DropReason::Malformed,
+                            });
+                            return Ok(());
+                        }
                     },
-                    // NS/NA are filtered out at the socket (ICMP6_FILTER in
-                    // socket.rs) and will be handled when the ND engine grows
-                    // counters — for now drop, preserving current behaviour.
-                    Some(_) => return Ok(()),
+                    Some(Icmp6Type::NeighborSolicit) => {
+                        match NeighborSolicit::parse(payload, None) {
+                            Ok(ns) => NdRecv::NeighborSolicit { ifindex, src, ns },
+                            Err(_) => {
+                                let _ = tx.send(NdRecv::Dropped {
+                                    ifindex,
+                                    reason: DropReason::Malformed,
+                                });
+                                return Ok(());
+                            }
+                        }
+                    }
+                    Some(Icmp6Type::NeighborAdvert) => match NeighborAdvert::parse(payload, None) {
+                        Ok(na) => NdRecv::NeighborAdvert { ifindex, src, na },
+                        Err(_) => {
+                            let _ = tx.send(NdRecv::Dropped {
+                                ifindex,
+                                reason: DropReason::Malformed,
+                            });
+                            return Ok(());
+                        }
+                    },
+                    // Unknown numeric type — `from_u8` returns None for
+                    // anything outside 133-136. The ICMP6_FILTER in
+                    // socket.rs makes this path unreachable in production.
                     None => return Ok(()),
                 };
 

--- a/zebra-rs/src/nd/send.rs
+++ b/zebra-rs/src/nd/send.rs
@@ -147,6 +147,35 @@ impl<R: RngSource> RaSender<R> {
         }
     }
 
+    // ── Read accessors for show ──────────────────────────────────────────
+
+    /// The current RA send configuration template.
+    pub fn cfg(&self) -> &RaSendConfig {
+        &self.cfg
+    }
+
+    /// Number of initial RAs still to send before switching to the
+    /// periodic schedule (counts down from
+    /// [`MAX_INITIAL_RTR_ADVERTISEMENTS`]).
+    pub fn initial_remaining(&self) -> u32 {
+        self.initial_remaining
+    }
+
+    /// Scheduled time for the next unsolicited RA.
+    pub fn next_unsolicited_at(&self) -> Instant {
+        self.next_unsolicited_at
+    }
+
+    /// Scheduled time for the pending solicited reply, if any.
+    pub fn pending_solicited_at(&self) -> Option<Instant> {
+        self.pending_solicited_at
+    }
+
+    /// Time of the most recent multicast RA we sent, if any.
+    pub fn last_multicast_at(&self) -> Option<Instant> {
+        self.last_multicast_at
+    }
+
     /// Update the template fields (router lifetime, options, etc.).
     /// Doesn't reschedule — operators tweaking timers don't expect a
     /// burst of RAs.

--- a/zebra-rs/src/nd/socket.rs
+++ b/zebra-rs/src/nd/socket.rs
@@ -8,9 +8,9 @@
 //!     same check on inbound packets.
 //!   * `IPV6_RECVPKTINFO` on so the receive side learns the
 //!     destination address and arriving ifindex.
-//!   * `ICMP6_FILTER` scoped to RS (133) + RA (134) so neighbor
-//!     solicitation / advertisement (135 / 136) and the kernel's NDP
-//!     cache are left alone.
+//!   * `ICMP6_FILTER` scoped to RS (133) + RA (134) + NS (135) + NA
+//!     (136) so the daemon can passively observe NS/NA for counters
+//!     and diagnostics while leaving the kernel's NDP cache alone.
 //!
 //! Note: there is no `IPV6_CHECKSUM` setsockopt here on purpose. Linux
 //! returns `EINVAL` for `IPV6_CHECKSUM` on raw `IPPROTO_ICMPV6`
@@ -87,7 +87,7 @@ pub fn nd_socket() -> Result<AsyncFd<Socket>, SocketError> {
     // Note: no `IPV6_CHECKSUM` here — Linux returns EINVAL for that
     // option on raw ICMPv6 sockets; the kernel does the checksum for
     // us. See module-level docs.
-    let filter = Icmp6Filter::pass_only(&[133, 134]);
+    let filter = Icmp6Filter::pass_only(&[133, 134, 135, 136]);
     apply_icmp6_filter(&socket, &filter).map_err(SocketError::Filter)?;
 
     AsyncFd::new(socket).map_err(SocketError::AsyncFd)
@@ -227,11 +227,12 @@ mod tests {
 
     #[test]
     fn filter_pass_only_passes_listed_types() {
-        let f = Icmp6Filter::pass_only(&[133, 134]);
+        // The production socket now passes all four ND types.
+        let f = Icmp6Filter::pass_only(&[133, 134, 135, 136]);
         assert!(f.will_pass(133));
         assert!(f.will_pass(134));
-        assert!(!f.will_pass(135));
-        assert!(!f.will_pass(136));
+        assert!(f.will_pass(135));
+        assert!(f.will_pass(136));
         assert!(!f.will_pass(128));
         assert!(!f.will_pass(0));
     }


### PR DESCRIPTION
## Summary

PR 2 of the IPv6 ND show-commands series (stacked on #1342; see `docs/design/nd-show-commands-plan.md`).

- Widen the socket's ICMP6 filter to also pass NS (135) / NA (136) — the daemon now **passively observes** them for counters/diagnostics; the kernel still owns the NDP cache (a raw socket only sees received copies, and multicast loopback stays off).
- All state lives in the pure `NdEngine`:
  - `NdIfCounters` per interface — rx RS/RA/NS/NA, tx RA split unsolicited/solicited, hop-limit and malformed drop counts.
  - A per-source neighbor table (`NdNeighbor`: first/last seen, per-type counts, last-RA snapshot), capped at `MAX_TRACKED_SOURCES = 256` per interface; overflow increments `untracked_sources` instead of growing the map. DAD probes from `::` are tracked like any source.
- The read task surfaces validation failures as `NdRecv::Dropped { reason }` channel messages rather than counting in the I/O task, keeping the engine the single counting point (and unit-testable without a socket).
- `RaSender` gains read accessors (`cfg`, `initial_remaining`, `next_unsolicited_at`, `pending_solicited_at`, `last_multicast_at`) for the upcoming `show ipv6 nd` command (PR 3).
- Existing behaviour unchanged: RA still notifies BGP unnumbered, RS still schedules a solicited reply.

## Test plan

- 8 new engine unit tests: per-type rx counters, drop-reason mapping, per-source table with advancing timestamps, last-RA replacement, DAD `::` tracking, cap overflow (+ existing-source update while full), counting on sender-less interfaces, tx unsolicited/solicited split.
- `cargo test --workspace --exclude bdd` — all green (zebra-rs 1056 passed)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)