### PR TITLE
bgp: add AFI-less clear bgp {A.B.C.D|X:X::X:X|IFNAME|all}

### DIFF
--- a/zebra-rs/src/bgp/inst.rs
+++ b/zebra-rs/src/bgp/inst.rs
@@ -28,23 +28,33 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 /// for larger fleets is a follow-up.
 const VRF_LABEL_BLOCK_SIZE: u32 = 1024;
 
-/// Map a `/clear/bgp/<afi>/neighbor[/soft[/in|out]]` path (from
-/// zebra-bgp-clear.yang) to the (AFI, SAFI, op) triple the BGP runtime
-/// understands. Returns None for unrecognised paths.
+/// Map a `/clear/bgp[/<afi>]/neighbor[/soft[/in|out]]` path (from
+/// zebra-bgp-clear.yang) to the (AFI/SAFI filter, op) pair the BGP
+/// runtime understands. The AFI segment is optional — the AFI-less
+/// `clear bgp <peer-or-all>` form returns `None` for the filter,
+/// meaning every AFI/SAFI. Returns None for unrecognised paths.
 fn parse_clear_bgp_path(
     path: &str,
-) -> Option<(bgp_packet::Afi, bgp_packet::Safi, peer::BgpClearOp)> {
+) -> Option<(
+    Option<(bgp_packet::Afi, bgp_packet::Safi)>,
+    peer::BgpClearOp,
+)> {
     use bgp_packet::{Afi, Safi};
     use peer::BgpClearOp;
 
     let rest = path.strip_prefix("/clear/bgp/")?;
-    let (afi_str, tail) = rest.split_once('/')?;
-    let (afi, safi) = match afi_str {
-        "ipv4" => (Afi::Ip, Safi::Unicast),
-        "ipv6" => (Afi::Ip6, Safi::Unicast),
-        "vpnv4" => (Afi::Ip, Safi::MplsVpn),
-        "evpn" => (Afi::L2vpn, Safi::Evpn),
-        _ => return None,
+    let (afi_safi, tail) = if rest == "neighbor" || rest.starts_with("neighbor/") {
+        (None, rest)
+    } else {
+        let (afi_str, tail) = rest.split_once('/')?;
+        let pair = match afi_str {
+            "ipv4" => (Afi::Ip, Safi::Unicast),
+            "ipv6" => (Afi::Ip6, Safi::Unicast),
+            "vpnv4" => (Afi::Ip, Safi::MplsVpn),
+            "evpn" => (Afi::L2vpn, Safi::Evpn),
+            _ => return None,
+        };
+        (Some(pair), tail)
     };
     let op = match tail {
         "neighbor" => BgpClearOp::Hard,
@@ -53,7 +63,7 @@ fn parse_clear_bgp_path(
         "neighbor/soft/out" => BgpClearOp::SoftOut,
         _ => return None,
     };
-    Some((afi, safi, op))
+    Some((afi_safi, op))
 }
 
 #[derive(Debug)]
@@ -1701,13 +1711,13 @@ impl Bgp {
                 msg.resp.unwrap().send(self.peer_comps()).unwrap();
             }
             ConfigOp::Clear => {
-                // FRR-style `clear bgp <afi> <peer-or-all> [soft [in|out]]`
-                // surface (zebra-bgp-clear.yang). The first segment after
-                // `/clear/bgp/` is the AFI; the remainder selects the
-                // operation.
+                // FRR-style `clear bgp [<afi>] <peer-or-all> [soft [in|out]]`
+                // surface (zebra-bgp-clear.yang). The optional segment after
+                // `/clear/bgp/` is the AFI (absent = every AFI/SAFI); the
+                // remainder selects the operation.
                 let (path, mut args) = path_from_command(&msg.paths);
-                if let Some((afi, safi, op)) = parse_clear_bgp_path(&path) {
-                    let _ = peer::clear_bgp_action(self, &mut args, afi, safi, op);
+                if let Some((afi_safi, op)) = parse_clear_bgp_path(&path) {
+                    let _ = peer::clear_bgp_action(self, &mut args, afi_safi, op);
                 }
             }
         }
@@ -3604,6 +3614,53 @@ mod tests {
 
     fn addr(s: &str) -> IpAddr {
         s.parse().unwrap()
+    }
+
+    /// `/clear/bgp/...` path → (AFI/SAFI filter, op) mapping, both the
+    /// per-AFI containers and the AFI-less form (filter = None, meaning
+    /// every AFI/SAFI). Pinned here because the vtyctl clear surface is
+    /// garbage-tolerant: an unmapped path silently no-ops.
+    #[test]
+    fn clear_bgp_path_mapping() {
+        use crate::bgp::peer::BgpClearOp;
+        use bgp_packet::{Afi, Safi};
+
+        let cases = [
+            (
+                "/clear/bgp/ipv4/neighbor",
+                Some((Some((Afi::Ip, Safi::Unicast)), BgpClearOp::Hard)),
+            ),
+            (
+                "/clear/bgp/ipv6/neighbor/soft",
+                Some((Some((Afi::Ip6, Safi::Unicast)), BgpClearOp::SoftBoth)),
+            ),
+            (
+                "/clear/bgp/vpnv4/neighbor/soft/in",
+                Some((Some((Afi::Ip, Safi::MplsVpn)), BgpClearOp::SoftIn)),
+            ),
+            (
+                "/clear/bgp/evpn/neighbor/soft/out",
+                Some((Some((Afi::L2vpn, Safi::Evpn)), BgpClearOp::SoftOut)),
+            ),
+            ("/clear/bgp/neighbor", Some((None, BgpClearOp::Hard))),
+            (
+                "/clear/bgp/neighbor/soft",
+                Some((None, BgpClearOp::SoftBoth)),
+            ),
+            (
+                "/clear/bgp/neighbor/soft/in",
+                Some((None, BgpClearOp::SoftIn)),
+            ),
+            (
+                "/clear/bgp/neighbor/soft/out",
+                Some((None, BgpClearOp::SoftOut)),
+            ),
+            ("/clear/bgp/bogus/neighbor", None),
+            ("/clear/bgp/neighbor/bogus", None),
+        ];
+        for (path, want) in cases {
+            assert_eq!(super::parse_clear_bgp_path(path), want, "path `{path}`");
+        }
     }
 
     #[test]

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -2700,28 +2700,30 @@ pub enum BgpClearOp {
     SoftOut,
 }
 
-/// Drive `clear bgp <afi> <peer-or-all> [soft [in|out]]` requests from
-/// the new YANG schema in zebra-bgp-clear.yang. The first arg is the
+/// Drive `clear bgp [<afi>] <peer-or-all> [soft [in|out]]` requests
+/// from the YANG schema in zebra-bgp-clear.yang. The first arg is the
 /// list key — either an IP literal or the keyword `all`.
 ///
-/// Filtering by `(afi, safi)` only matters when the key is `all`; for
-/// a concrete peer address we look it up directly and skip the filter
-/// (the caller asked for *that* peer specifically). EVPN soft-in is
-/// not yet wired into `route_soft_in_peer`, so a soft-in/soft-both on
-/// EVPN logs a "not yet implemented" notice and leaves the session
-/// alone.
+/// `afi_safi` is `Some` for the per-AFI containers and `None` for the
+/// AFI-less `clear bgp <peer-or-all>` form. Filtering by it only
+/// matters when the key is `all`; for a concrete peer address we look
+/// it up directly and skip the filter (the caller asked for *that*
+/// peer specifically). EVPN soft-in is not yet wired into
+/// `route_soft_in_peer`, so a soft-in/soft-both on EVPN logs a "not
+/// yet implemented" notice and leaves the session alone.
 pub fn clear_bgp_action(
     bgp: &mut Bgp,
     args: &mut Args,
-    afi: bgp_packet::Afi,
-    safi: bgp_packet::Safi,
+    afi_safi: Option<(bgp_packet::Afi, bgp_packet::Safi)>,
     op: BgpClearOp,
 ) -> std::result::Result<String, std::fmt::Error> {
     let Some(target) = args.string() else {
         return Ok("missing peer or 'all' argument".to_string());
     };
 
-    if matches!(op, BgpClearOp::SoftIn | BgpClearOp::SoftBoth) && safi == bgp_packet::Safi::Evpn {
+    if matches!(op, BgpClearOp::SoftIn | BgpClearOp::SoftBoth)
+        && afi_safi.map(|(_, safi)| safi) == Some(bgp_packet::Safi::Evpn)
+    {
         return Ok("%% EVPN soft-in is not yet implemented".to_string());
     }
 
@@ -2732,7 +2734,11 @@ pub fn clear_bgp_action(
     let targets: Vec<usize> = if target == "all" {
         bgp.peers
             .iter_all()
-            .filter_map(|(_, p)| p.is_afi_safi(afi, safi).then_some(p.ident))
+            .filter_map(|(_, p)| {
+                afi_safi
+                    .is_none_or(|(afi, safi)| p.is_afi_safi(afi, safi))
+                    .then_some(p.ident)
+            })
             .collect()
     } else {
         match target.parse::<IpAddr>() {
@@ -2975,6 +2981,47 @@ mod fsm_idle_hold_tests {
         peer.state = next;
         timer::update_timers(&mut peer);
         assert!(peer.timer.idle_hold_timer.is_none());
+    }
+
+    /// `clear bgp <peer>` hard reset (Event::Stop): the session drops
+    /// to Idle and the idle hold timer is armed — the pacer whose
+    /// Event::Start brings the session back up.
+    #[tokio::test]
+    async fn stop_lands_in_idle_and_arms_idle_hold_timer() {
+        let mut peer = test_peer(false);
+        peer.state = State::Established;
+
+        let next = fsm_stop(&mut peer);
+        assert_eq!(next, State::Idle);
+
+        peer.state = next;
+        timer::update_timers(&mut peer);
+        assert!(
+            peer.timer.idle_hold_timer.is_some(),
+            "a cleared peer must pace its restart with the idle hold timer"
+        );
+        assert!(peer.timer.connect_retry.is_none());
+    }
+
+    /// `clear bgp <peer>` on a passive neighbor: no idle hold, no
+    /// redial — `update_timers` flips the peer straight to Active
+    /// listening, waiting for the remote router to reconnect.
+    #[tokio::test]
+    async fn stop_passive_peer_returns_to_listening() {
+        let mut peer = test_peer(true);
+        peer.state = State::Established;
+
+        let next = fsm_stop(&mut peer);
+        assert_eq!(next, State::Idle);
+
+        peer.state = next;
+        timer::update_timers(&mut peer);
+        assert_eq!(peer.state, State::Active);
+        assert!(peer.timer.idle_hold_timer.is_none());
+        assert!(
+            peer.timer.connect_retry.is_none(),
+            "a passive peer must not arm the redial pacer"
+        );
     }
 
     /// The dial path arms the ConnectRetryTimer (RFC 4271: started on

--- a/zebra-rs/src/config/parse.rs
+++ b/zebra-rs/src/config/parse.rs
@@ -1012,6 +1012,43 @@ mod tests {
                 "/clear/bgp/ipv4/neighbor/soft/out",
                 vec!["i1"],
             ),
+            // AFI-less form — `clear bgp {<peer>|all} [soft [in|out]]`
+            // routes positionally into the `neighbor` list directly
+            // under /clear/bgp (no AFI/SAFI filter at runtime). The
+            // `clear bgp ipv4 …` cases above pin that the AFI keyword
+            // children still win over the positional key.
+            ("clear bgp all", "/clear/bgp/neighbor", vec!["all"]),
+            (
+                "clear bgp 192.168.0.1",
+                "/clear/bgp/neighbor",
+                vec!["192.168.0.1"],
+            ),
+            (
+                "clear bgp 2001:db8::1",
+                "/clear/bgp/neighbor",
+                vec!["2001:db8::1"],
+            ),
+            ("clear bgp i1", "/clear/bgp/neighbor", vec!["i1"]),
+            (
+                "clear bgp neighbor 192.168.0.1",
+                "/clear/bgp/neighbor",
+                vec!["192.168.0.1"],
+            ),
+            (
+                "clear bgp 192.168.0.1 soft",
+                "/clear/bgp/neighbor/soft",
+                vec!["192.168.0.1"],
+            ),
+            (
+                "clear bgp all soft out",
+                "/clear/bgp/neighbor/soft/out",
+                vec!["all"],
+            ),
+            (
+                "clear bgp i1 soft in",
+                "/clear/bgp/neighbor/soft/in",
+                vec!["i1"],
+            ),
         ];
 
         for &(cmd, want_path, ref want_args) in &cases {

--- a/zebra-rs/yang/zebra-bgp-clear.yang
+++ b/zebra-rs/yang/zebra-bgp-clear.yang
@@ -33,9 +33,15 @@ module zebra-bgp-clear {
        /clear/bgp/<afi>/neighbor/soft/in          soft, inbound only
        /clear/bgp/<afi>/neighbor/soft/out         soft, outbound only
 
+     plus an AFI-less form directly under /clear/bgp — same subtree,
+     no AFI/SAFI filter (`clear bgp <peer-or-all> [soft [in|out]]`):
+
+       /clear/bgp/neighbor[/soft[/in|/out]]
+
      The list key on `neighbor` is a `peer-id-or-all` — the peer's IP
      literal, an `interface-neighbor` name (IPv6 unnumbered), or the
-     keyword `all` to target every peer at that AFI.";
+     keyword `all` to target every peer at that AFI (every peer
+     outright in the AFI-less form).";
 
   /* =========================================================
    * Types
@@ -116,6 +122,16 @@ module zebra-bgp-clear {
        Each AFI container reuses the same neighbor/soft grouping.";
     container bgp {
       ext:help "BGP clear actions";
+      // AFI-less form: `clear bgp {<peer>|all} [soft [in|out]]` clears
+      // across every AFI/SAFI. The positional routing is safe next to
+      // the AFI keyword children because the matcher only takes the
+      // default-child descent on a *strictly better* match: `ipv4`
+      // etc. keyword-match Exact (or Partial when abbreviated) while
+      // the key's pattern-less string arm is only ever Partial — so
+      // any AFI spelling, including abbreviations, still wins and an
+      // IP literal / interface name / `all` falls through to the key.
+      ext:default-child "neighbor";
+      uses bgp-clear-neighbor-actions;
       // FRR-style positional form: a peer address (or `all`) typed
       // straight after the AFI (`clear bgp ipv4 10.0.0.1 [soft ...]`)
       // is routed into the `neighbor` list by the matcher via


### PR DESCRIPTION
## Summary

Adds the AFI-less `clear bgp` form so a neighbor can be reset by typing its identity straight after `clear bgp`:

- `clear bgp all` — every peer, every AFI/SAFI (interface-keyed peers included, via `iter_all`)
- `clear bgp {A.B.C.D|X:X::X:X|IFNAME} [soft [in|out]]` — one peer, all AFI/SAFIs
- the existing per-AFI forms (`clear bgp ipv4 ...` etc.) are untouched

**Grammar** (`zebra-bgp-clear.yang`): the same `neighbor [soft [in|out]]` grouping now also hangs directly under `/clear/bgp`, with `ext:default-child "neighbor"` on the `bgp` container. The positional routing is safe next to the AFI keyword children because the matcher only takes the default-child descent on a strictly better match: the AFI keywords match Exact (or Partial when abbreviated) while the key's pattern-less string arm is only ever Partial — so every AFI spelling, including abbreviations, still wins (`clear bgp ip` stays Ambiguous instead of being treated as a peer name).

**Dispatch**: `parse_clear_bgp_path` returns an `Option<(Afi, Safi)>` filter — `None` for the AFI-less form — and `clear_bgp_action`'s `all` sweep skips the AFI/SAFI filter when it is absent.

**Reset semantics** (pre-existing `Event::Stop` path, now pinned by tests): the hard clear drops the session to Idle and arms the idle hold timer to pace the restart; a passive neighbor instead flips straight to Active listening, waiting for the remote router to reconnect.

## Test plan

- `clear_bgp_grammar` parse() cases for the AFI-less spellings (positional peer/`all`/IFNAME, soft variants) — pinned with parse() tests because the vtyctl clear surface is garbage-tolerant
- `clear_bgp_path_mapping` unit test for the `/clear/bgp[/<afi>]/neighbor[/soft[/in|/out]]` → (filter, op) mapping
- `stop_lands_in_idle_and_arms_idle_hold_timer` + `stop_passive_peer_returns_to_listening` FSM tests
- Full workspace suite: 1555 passed, 0 failed; `cargo fmt` + workspace clippy clean

Generated with [Claude Code](https://claude.com/claude-code)