### PR TITLE
config: marshal presence containers as {} instead of null

### DIFF
--- a/zebra-rs/src/config/configs.rs
+++ b/zebra-rs/src/config/configs.rs
@@ -372,11 +372,17 @@ impl Config {
             self.marshal_configs(out);
 
             // A `type empty` leaf or a childless presence container has
-            // emitted only a dangling `"name":` so far. Close it with an
-            // explicit null: json_to_list() maps null back to the bare
-            // `set <path>` on load, whereas `{}` is silently dropped.
+            // emitted only a dangling `"name":` so far. A presence
+            // container closes as `{}` (it is a container in the YANG
+            // data tree); a `type empty` leaf closes as null. Both
+            // shapes round-trip: json_to_list() restores each as the
+            // bare `set <path>`.
             if !has_configs && self.value.borrow().is_empty() && self.list.borrow().is_empty() {
-                out.push_str("null");
+                if self.presence {
+                    out.push_str("{}");
+                } else {
+                    out.push_str("null");
+                }
             }
         }
     }
@@ -1156,11 +1162,11 @@ mod tests {
     }
 
     #[test]
-    fn test_presence_container_json_null() {
+    fn test_presence_container_json_empty_object() {
         // A childless presence container (e.g. `set router bgp
-        // segment-routing srv6 ipv6-unicast`) marshals as null, not `{}`:
-        // json_to_list() restores null as the bare `set <path>` but
-        // silently drops an empty object, losing the node on re-apply.
+        // segment-routing srv6 ipv6-unicast`) marshals as `{}`, not
+        // null — null is reserved for `type empty` leaves. json_to_list()
+        // restores an empty object as the bare `set <path>` on re-apply.
         let root = Rc::new(Config::new("".to_string(), None));
 
         let paths = vec![
@@ -1181,6 +1187,11 @@ mod tests {
         root.json(&mut json_output);
         let parsed: serde_json::Value =
             serde_json::from_str(&json_output).expect("JSON output should be valid");
-        assert_eq!(parsed["srv6"]["ipv6-unicast"], serde_json::Value::Null);
+        assert_eq!(parsed["srv6"]["ipv6-unicast"], serde_json::json!({}));
+
+        let mut yaml_output = String::new();
+        root.yaml(&mut yaml_output);
+        assert!(yaml_output.contains("ipv6-unicast: {}"));
+        assert!(!yaml_output.contains("% "));
     }
 }

--- a/zebra-rs/src/config/json.rs
+++ b/zebra-rs/src/config/json.rs
@@ -54,6 +54,14 @@ pub fn json_to_list(
             }
         }
         Value::Object(map) => {
+            // A childless presence container marshals as `{}`; restore
+            // it as the bare `set <path>` (a presence container exists
+            // on its own, unlike a plain container which only exists
+            // through its children — an empty `{}` there is a no-op).
+            if map.is_empty() && entry.presence {
+                lines.push(format!("set {}", p.join(" ")));
+                return;
+            }
             let mut p = p.clone();
             if !entry.key.is_empty() {
                 if let Some(value) = map.get(&entry.key[0]) {
@@ -184,6 +192,44 @@ mod tests {
                 .iter()
                 .any(|l| l == "set policy IN-MED entry 10 action permit"),
             "siblings after the unknown key must still apply; lines: {lines:?}"
+        );
+    }
+
+    /// A childless presence container dumps as `{}` — loading that
+    /// shape must restore the bare `set <path>` line, and the legacy
+    /// `null` shape (pre-`{}` dumps) must keep loading the same way.
+    /// An empty object on a plain (non-presence) container stays a
+    /// silent no-op: such a container has no independent existence.
+    #[test]
+    fn empty_object_restores_presence_container() {
+        let doc =
+            r#"{"router":{"bgp":{"neighbor":[{"remote-address":"10.0.0.1","as-override":{}}]}}}"#;
+        let (lines, errors) = json_read(set_entry(), doc);
+        assert!(errors.is_empty(), "errors: {errors:?}");
+        assert!(
+            lines
+                .iter()
+                .any(|l| l == "set router bgp neighbor 10.0.0.1 as-override"),
+            "lines: {lines:?}"
+        );
+
+        let doc =
+            r#"{"router":{"bgp":{"neighbor":[{"remote-address":"10.0.0.1","as-override":null}]}}}"#;
+        let (lines, errors) = json_read(set_entry(), doc);
+        assert!(errors.is_empty(), "errors: {errors:?}");
+        assert!(
+            lines
+                .iter()
+                .any(|l| l == "set router bgp neighbor 10.0.0.1 as-override"),
+            "legacy null shape must keep loading; lines: {lines:?}"
+        );
+
+        let doc = r#"{"router":{"bgp":{}}}"#;
+        let (lines, errors) = json_read(set_entry(), doc);
+        assert!(errors.is_empty(), "errors: {errors:?}");
+        assert!(
+            lines.is_empty(),
+            "non-presence `{{}}` must not emit a command; lines: {lines:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

A childless presence container (e.g. `set router bgp neighbor X as-override`) used to dump as `"node": null` in JSON/YAML — the same shape as a `type empty` leaf. It now renders as `"node": {}`, the natural JSON encoding of a container; `type empty` leaves keep `null`.

`null` was originally chosen (PR #1309) because `json_to_list()` silently dropped an empty object on load, losing the node on re-apply. This PR closes that half too:

- **Marshal** (`configs.rs`): childless node with `presence == true` → `{}`; `type empty` leaf → `null` (unchanged).
- **Load** (`json.rs`): empty `{}` on a presence entry restores the bare `set <path>` line. The legacy `null` shape still loads the same way, so existing dumps and the BDD config YAMLs keep working. An empty `{}` on a plain (non-presence) container stays a no-op — it has no independent existence in the data tree, and `set` ending at a plain `Dir` is not a complete command (`ymatch_complete`).

## Tests

- `test_presence_container_json_empty_object` (renamed): presence container marshals as `{}` in JSON and `node: {}` in YAML.
- `empty_object_restores_presence_container` (new, schema-backed): `{}` → `set router bgp neighbor 10.0.0.1 as-override`; legacy `null` shape still loads; `{}` on a non-presence container emits nothing and no error.
- Full workspace suite (excluding bdd) green; workspace clippy clean; fmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)