### PR TITLE
bdd+book: spell implicitly-null presence containers as {}

### DIFF
--- a/bdd/tests/configs/bgp_allowas_in/z3-allowas.yaml
+++ b/bdd/tests/configs/bgp_allowas_in/z3-allowas.yaml
@@ -19,5 +19,5 @@ router:
       enabled: true
       remote-as: 65002
       # Bare presence container → default occurrence budget of 3.
-      # (`allowas-in:` with a null value lowers to `set ... allowas-in`.)
-      allowas-in:
+      # (`allowas-in: {}` — a childless presence container — lowers to `set ... allowas-in`.)
+      allowas-in: {}

--- a/bdd/tests/configs/bgp_as_override/z2-override.yaml
+++ b/bdd/tests/configs/bgp_as_override/z2-override.yaml
@@ -31,4 +31,4 @@ router:
       # z3, replaces z3's AS (65001) in the AS_PATH with z2's AS (65002)
       # before the local-AS prepend, so z3's RFC 4271 loop check accepts
       # 10.0.0.1/32 (it sees "65002 65002" instead of "65002 65001").
-      as-override:
+      as-override: {}

--- a/bdd/tests/configs/bgp_enforce_first_as/z2-enforce.yaml
+++ b/bdd/tests/configs/bgp_enforce_first_as/z2-enforce.yaml
@@ -22,4 +22,4 @@ router:
       # session is bounced, z2 re-receives 10.0.0.1/32 with AS_PATH
       # "65099 65001"; the left-most AS (65099) is not z1's AS (65001), so
       # the inbound first-AS check drops the update.
-      enforce-first-as:
+      enforce-first-as: {}

--- a/bdd/tests/configs/bgp_remove_private_as/z2-remove.yaml
+++ b/bdd/tests/configs/bgp_remove_private_as/z2-remove.yaml
@@ -32,4 +32,4 @@ router:
       # private — so the bare form strips it before z2 prepends its own
       # AS 100. z3 receives AS_PATH "100" instead of "100 65001"; z1's
       # private AS 65001 is hidden from z3.
-      remove-private-as:
+      remove-private-as: {}

--- a/book/src/ch-02-13-bgp-allowas-in.md
+++ b/book/src/ch-02-13-bgp-allowas-in.md
@@ -79,11 +79,13 @@ router:
       afi-safi:
       - name: ipv4
         enabled: true
-      allowas-in:            # bare presence container → default count 3
+      allowas-in: {}         # bare presence container → default count 3
 ```
 
-`allowas-in:` with no value is the YAML spelling of a presence container;
-the loader turns it into `set router bgp neighbor 192.168.1.2 allowas-in`.
+`allowas-in: {}` is the YAML spelling of a childless presence container;
+the loader turns it into `set router bgp neighbor 192.168.1.2 allowas-in`
+(the legacy `allowas-in: null` / bare `allowas-in:` spellings still load
+the same way).
 To set an explicit budget, nest `count`; for origin-only mode, nest the
 `origin` flag:
 


### PR DESCRIPTION
## Summary

Follow-up to #1348: that sweep replaced explicit `: null` presence containers in the BDD configs but missed the *implicit* spelling — a bare `key:` with no value, which YAML also loads as null.

A YAML-aware walk over `bdd/tests/configs/` (parse every file, report None-valued keys) found six remaining sites. Four are childless presence containers and move to the canonical `{}`:

| file | key |
|---|---|
| `bgp_allowas_in/z3-allowas.yaml` | `allowas-in` |
| `bgp_as_override/z2-override.yaml` | `as-override` |
| `bgp_enforce_first_as/z2-enforce.yaml` | `enforce-first-as` |
| `bgp_remove_private_as/z2-remove.yaml` | `remove-private-as` |

The other two are genuine `type empty` leaves and correctly keep the null spelling: `allowas-in origin` (`z3-origin.yaml`) and `prefix-sid no-php` (`isis_tilfa/s-nophp.yaml`).

Also updates the allowas-in book chapter, which documented the bare `allowas-in:` form, to show `{}` (noting the legacy spellings still load).

## Test plan

- Data/docs-only change (BDD config YAMLs + one book page); no Rust code touched.
- Both spellings load identically today — the loader keeps the legacy null path — so this is canonicalization with no behavior change.
- Re-ran the YAML walk after the edit: only the two `type empty` leaves remain None-valued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)