### PR TITLE
bgp: show ND discovery state on interface neighbors

### DIFF
--- a/zebra-rs/src/bgp/interface_neighbor.rs
+++ b/zebra-rs/src/bgp/interface_neighbor.rs
@@ -6,6 +6,7 @@
 
 use std::collections::BTreeMap;
 use std::net::Ipv6Addr;
+use std::time::Instant;
 
 use super::Bgp;
 use super::peer::Peer;
@@ -125,6 +126,7 @@ fn materialize(
     if let Some(existing) = bgp.peers.get_mut_by_key(&PeerKey::Interface(ifindex)) {
         if let Some(link_local) = link_local {
             existing.address = link_local.into();
+            nd_mark_refreshed(existing, Instant::now());
             // No-op on a running peer (`start()` gates on `!active`);
             // a dormant one leaves Idle now that it can dial.
             existing.start();
@@ -157,6 +159,11 @@ fn materialize(
     // path in `peer_start_connection` reads this back out and
     // builds the SocketAddrV6 accordingly.
     peer.scope_id = Some(ifindex);
+    // Record the ND discovery timestamp only when an RA-learned
+    // link-local is being set (not for dormant pre-RA peers).
+    if link_local.is_some() {
+        nd_mark_discovered(&mut peer, Instant::now());
+    }
     // Stamp the group back-reference whenever the cfg carries one —
     // it drives every inheritable attribute (afi-safi today), not just
     // remote-as, so the reactive sweeps on group changes can find this
@@ -191,6 +198,34 @@ fn materialize(
     // (no RA yet — the RA path upgrades them in place).
     peer.start();
     Some(peer.ident)
+}
+
+/// Stamp the initial ND discovery fields on a freshly created
+/// interface-keyed peer. Called exactly once — on the create path
+/// when a link-local is available (`link_local.is_some()`).
+///
+/// Extracted so unit tests can exercise the field-update semantics
+/// on a plain `Peer` without constructing a full `Bgp`.
+fn nd_mark_discovered(peer: &mut super::peer::Peer, now: Instant) {
+    peer.nd_discovered_at = Some(now);
+    peer.nd_refreshed_at = Some(now);
+    peer.nd_event_count = 1;
+}
+
+/// Update the ND refresh timestamp on an already-materialized
+/// interface-keyed peer when a subsequent RA arrives with a
+/// (possibly new) link-local.
+///
+/// `nd_discovered_at` is intentionally left unchanged — it records
+/// the first event only.
+fn nd_mark_refreshed(peer: &mut super::peer::Peer, now: Instant) {
+    // If the peer was created dormant (no RA yet), treat this first
+    // RA as the discovery event so both timestamps are set.
+    if peer.nd_discovered_at.is_none() {
+        peer.nd_discovered_at = Some(now);
+    }
+    peer.nd_refreshed_at = Some(now);
+    peer.nd_event_count = peer.nd_event_count.saturating_add(1);
 }
 
 /// `set router bgp interface-neighbor <name>` — list-key callback.
@@ -321,5 +356,77 @@ mod tests {
     #[test]
     fn materialize_unset_returns_none() {
         assert_eq!(RemoteAsSpec::Unset.materialize(64512), None);
+    }
+
+    /// Build a minimal Peer suitable for testing nd_mark_* helpers.
+    /// Uses a parked channel and a no-RIB context — no sockets are
+    /// opened and no timers fire during these synchronous tests.
+    fn make_peer() -> super::super::peer::Peer {
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        Box::leak(Box::new(rx));
+        super::super::peer::Peer::new(
+            0,
+            65001,
+            "1.1.1.1".parse().unwrap(),
+            65002,
+            "fe80::1".parse::<std::net::IpAddr>().unwrap(),
+            None,
+            tx,
+            crate::context::ProtoContext::default_table_no_rib(),
+        )
+    }
+
+    /// After `nd_mark_discovered`: count == 1, both timestamps set
+    /// and equal.
+    #[test]
+    fn nd_mark_discovered_sets_all_three_fields() {
+        let mut peer = make_peer();
+        assert!(peer.nd_discovered_at.is_none());
+        assert_eq!(peer.nd_event_count, 0);
+
+        let t0 = Instant::now();
+        nd_mark_discovered(&mut peer, t0);
+
+        assert_eq!(peer.nd_event_count, 1);
+        assert_eq!(peer.nd_discovered_at, Some(t0));
+        assert_eq!(peer.nd_refreshed_at, Some(t0));
+    }
+
+    /// After a subsequent `nd_mark_refreshed`: count increments,
+    /// `nd_refreshed_at` advances, `nd_discovered_at` stays.
+    #[test]
+    fn nd_mark_refreshed_increments_count_and_updates_refresh_only() {
+        let mut peer = make_peer();
+        let t0 = Instant::now();
+        nd_mark_discovered(&mut peer, t0);
+
+        // Simulate a later RA arriving.
+        let t1 = t0 + std::time::Duration::from_secs(60);
+        nd_mark_refreshed(&mut peer, t1);
+
+        assert_eq!(peer.nd_event_count, 2);
+        // Discovery timestamp must not change.
+        assert_eq!(peer.nd_discovered_at, Some(t0));
+        // Refresh timestamp must advance.
+        assert_eq!(peer.nd_refreshed_at, Some(t1));
+    }
+
+    /// A dormant peer (created at config time, no RA yet) has all
+    /// three fields at their zero values. When its first RA arrives
+    /// via `nd_mark_refreshed`, both timestamps are set (treating
+    /// the first refresh as discovery).
+    #[test]
+    fn nd_mark_refreshed_on_dormant_peer_sets_discovered_at() {
+        let mut peer = make_peer();
+        // Dormant: no RA yet.
+        assert!(peer.nd_discovered_at.is_none());
+        assert_eq!(peer.nd_event_count, 0);
+
+        let t0 = Instant::now();
+        nd_mark_refreshed(&mut peer, t0);
+
+        assert_eq!(peer.nd_event_count, 1);
+        assert_eq!(peer.nd_discovered_at, Some(t0));
+        assert_eq!(peer.nd_refreshed_at, Some(t0));
     }
 }

--- a/zebra-rs/src/bgp/peer.rs
+++ b/zebra-rs/src/bgp/peer.rs
@@ -823,6 +823,22 @@ pub struct Peer {
     /// show path gates on state rather than clearing this on teardown.
     /// `None` until the first session comes up. See [`super::mss`].
     pub tcp_mss_synced: Option<u16>,
+
+    /// When the first `NdEvent::NeighborDiscovered` materialized this
+    /// interface-keyed peer. `None` for address-keyed peers and for
+    /// dormant peers created at config time before any RA has arrived.
+    pub nd_discovered_at: Option<Instant>,
+    /// Timestamp of the most recent `NdEvent::NeighborDiscovered` for
+    /// this peer. Updated on every RA that refreshes the remote
+    /// link-local; equal to `nd_discovered_at` right after the first
+    /// event.  `None` in the same cases as `nd_discovered_at`.
+    pub nd_refreshed_at: Option<Instant>,
+    /// Running total of `NdEvent::NeighborDiscovered` events applied to
+    /// this peer. 0 for address-keyed and dormant peers; 1 after the
+    /// first RA; incremented on every subsequent refresh. The render
+    /// path reports `nd_event_count.saturating_sub(1)` as the refresh
+    /// count (events after the initial discovery).
+    pub nd_event_count: u64,
 }
 
 impl Peer {
@@ -901,6 +917,9 @@ impl Peer {
             tracing: super::tracing::BgpTracing::default(),
             tracing_instance: super::tracing::BgpTracing::default(),
             tcp_mss_synced: None,
+            nd_discovered_at: None,
+            nd_refreshed_at: None,
+            nd_event_count: 0,
         };
         peer.config
             .mp

--- a/zebra-rs/src/bgp/show.rs
+++ b/zebra-rs/src/bgp/show.rs
@@ -1829,6 +1829,22 @@ struct Neighbor<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     neighbor_group: Option<String>,
     remote_as_inherited: bool,
+
+    /// Seconds elapsed since the first `NdEvent::NeighborDiscovered`
+    /// materialized this interface-keyed peer. `None` for
+    /// address-keyed peers and dormant peers that have never seen an
+    /// RA. Serialized in JSON for consumers that want the raw value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nd_discovered_secs_ago: Option<u64>,
+    /// Number of RA refresh events applied to this peer after the
+    /// initial discovery (`nd_event_count - 1`). `None` in the same
+    /// cases as `nd_discovered_secs_ago`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nd_refresh_count: Option<u64>,
+    /// Seconds elapsed since the most recent RA refresh. `None` in
+    /// the same cases as `nd_discovered_secs_ago`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nd_refreshed_secs_ago: Option<u64>,
 }
 
 const ONE_DAY_SECOND: u64 = 60 * 60 * 24;
@@ -1940,6 +1956,20 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         .unwrap_or_else(|| peer.config.timer.idle_hold_time());
     let connect_retry_timer_rem = peer.timer.connect_retry.as_ref().map(|t| t.rem_sec());
 
+    // Snapshot now once so all ND elapsed-time calculations are
+    // consistent within a single fetch call.
+    let now = Instant::now();
+    let nd_discovered_secs_ago = peer
+        .nd_discovered_at
+        .map(|t| now.saturating_duration_since(t).as_secs());
+    let nd_refresh_count = peer
+        .nd_event_count
+        .checked_sub(1)
+        .filter(|_| peer.nd_discovered_at.is_some());
+    let nd_refreshed_secs_ago = peer
+        .nd_refreshed_at
+        .map(|t| now.saturating_duration_since(t).as_secs());
+
     let mut n = Neighbor {
         address: peer.address,
         interface: peer.ifname.as_deref(),
@@ -1987,6 +2017,9 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
         disable_connected_check: peer.config.transport.disable_connected_check,
         neighbor_group: peer.config.neighbor_group.clone(),
         remote_as_inherited: peer.config.remote_as_inherited,
+        nd_discovered_secs_ago,
+        nd_refresh_count,
+        nd_refreshed_secs_ago,
     };
 
     // Timers.
@@ -2007,6 +2040,27 @@ fn fetch(peer: &Peer) -> Neighbor<'_> {
     };
     n.count.insert("total", total);
     n
+}
+
+/// Format a number of seconds as `NhNmNs` (or just `Ns` / `NmNs`
+/// depending on magnitude).  Used for the ND discovery / refresh
+/// elapsed-time lines in `show bgp neighbors`.
+///
+/// Examples:
+/// * 27 → `"27s"`
+/// * 331 → `"5m31s"`
+/// * 3661 → `"1h1m1s"`
+fn format_nd_elapsed(secs: u64) -> String {
+    let h = secs / 3600;
+    let m = (secs % 3600) / 60;
+    let s = secs % 60;
+    if h > 0 {
+        format!("{}h{}m{}s", h, m, s)
+    } else if m > 0 {
+        format!("{}m{}s", m, s)
+    } else {
+        format!("{}s", s)
+    }
 }
 
 fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
@@ -2065,6 +2119,34 @@ fn render(out: &mut String, neighbor: &Neighbor) -> std::fmt::Result {
         neighbor.timer_recv.hold_time,
         neighbor.timer_recv.keepalive,
     )?;
+
+    // ND discovery block — interface-keyed (unnumbered) peers only.
+    if let Some(discovered_secs) = neighbor.nd_discovered_secs_ago {
+        writeln!(
+            out,
+            "  Interface peer: link-local learned via IPv6 ND router advertisement"
+        )?;
+        let discovered_ago = format_nd_elapsed(discovered_secs);
+        match neighbor.nd_refresh_count {
+            Some(0) | None => {
+                writeln!(out, "  Discovered {} ago", discovered_ago)?;
+            }
+            Some(refreshes) => {
+                let refreshed_ago = neighbor
+                    .nd_refreshed_secs_ago
+                    .map(format_nd_elapsed)
+                    .unwrap_or_default();
+                writeln!(
+                    out,
+                    "  Discovered {} ago, refreshed {} time{} (last {} ago)",
+                    discovered_ago,
+                    refreshes,
+                    if refreshes == 1 { "" } else { "s" },
+                    refreshed_ago,
+                )?;
+            }
+        }
+    }
 
     // Display timer expiry information
     if let Some(keepalive_rem) = neighbor.keepalive_timer_rem {
@@ -3344,6 +3426,141 @@ Neighbor        V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down Sta
             "unknown name reports cleanly:\n{out}"
         );
     }
+
+    /// Build a `Neighbor` DTO directly (all-`None` ND fields) and
+    /// verify that `render` does NOT emit any ND block — address-keyed
+    /// peers must be unaffected.
+    #[test]
+    fn nd_block_absent_for_address_keyed_peer() {
+        let mut out = String::new();
+        let n = minimal_neighbor(None);
+        render(&mut out, &n).unwrap();
+        assert!(
+            !out.contains("Interface peer:"),
+            "address-keyed peer must not get ND block:\n{out}"
+        );
+    }
+
+    /// An interface-keyed peer with ND discovery data (no refreshes
+    /// yet) renders the "Discovered N ago" line but not the refresh
+    /// clause.
+    #[test]
+    fn nd_block_discovery_only_no_refresh() {
+        let mut out = String::new();
+        let mut n = minimal_neighbor(Some("enp0s5"));
+        // 331 seconds = 5m31s
+        n.nd_discovered_secs_ago = Some(331);
+        n.nd_refresh_count = Some(0);
+        n.nd_refreshed_secs_ago = Some(331);
+        render(&mut out, &n).unwrap();
+        assert!(
+            out.contains("Interface peer: link-local learned via IPv6 ND router advertisement"),
+            "ND header line missing:\n{out}"
+        );
+        assert!(
+            out.contains("Discovered 5m31s ago"),
+            "discovery line missing:\n{out}"
+        );
+        assert!(
+            !out.contains("refreshed"),
+            "no refresh clause when count is 0:\n{out}"
+        );
+    }
+
+    /// An interface-keyed peer with multiple refresh events renders
+    /// the full "Discovered … ago, refreshed N times (last … ago)" form.
+    #[test]
+    fn nd_block_with_refreshes() {
+        let mut out = String::new();
+        let mut n = minimal_neighbor(Some("enp0s5"));
+        n.nd_discovered_secs_ago = Some(331); // 5m31s
+        n.nd_refresh_count = Some(12);
+        n.nd_refreshed_secs_ago = Some(27); // 27s
+        render(&mut out, &n).unwrap();
+        assert!(
+            out.contains("Discovered 5m31s ago, refreshed 12 times (last 27s ago)"),
+            "full refresh line missing:\n{out}"
+        );
+    }
+
+    /// JSON output for an interface-keyed peer carries the three ND
+    /// fields; an address-keyed peer must not carry them.
+    #[test]
+    fn nd_fields_in_json_interface_peer_only() {
+        // Interface-keyed peer with ND data.
+        let mut n = minimal_neighbor(Some("enp0s5"));
+        n.nd_discovered_secs_ago = Some(331);
+        n.nd_refresh_count = Some(12);
+        n.nd_refreshed_secs_ago = Some(27);
+        let json_str = serde_json::to_string(&n).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(v["nd_discovered_secs_ago"], 331);
+        assert_eq!(v["nd_refresh_count"], 12);
+        assert_eq!(v["nd_refreshed_secs_ago"], 27);
+
+        // Address-keyed peer: ND fields must be absent.
+        let n2 = minimal_neighbor(None);
+        let json_str2 = serde_json::to_string(&n2).unwrap();
+        let v2: serde_json::Value = serde_json::from_str(&json_str2).unwrap();
+        assert!(
+            v2.get("nd_discovered_secs_ago").is_none(),
+            "address-keyed peer must not carry nd_discovered_secs_ago"
+        );
+        assert!(
+            v2.get("nd_refresh_count").is_none(),
+            "address-keyed peer must not carry nd_refresh_count"
+        );
+        assert!(
+            v2.get("nd_refreshed_secs_ago").is_none(),
+            "address-keyed peer must not carry nd_refreshed_secs_ago"
+        );
+    }
+
+    /// Helper: build a minimal `Neighbor<'static>` with placeholder
+    /// values — only the fields under test need to be non-default.
+    fn minimal_neighbor(interface: Option<&'static str>) -> Neighbor<'static> {
+        use std::collections::HashMap as HM;
+        Neighbor {
+            address: "10.0.0.1".parse().unwrap(),
+            interface,
+            peer_type: "internal",
+            local_as: 65001,
+            remote_as: 65002,
+            local_router_id: Ipv4Addr::UNSPECIFIED,
+            remote_router_id: Ipv4Addr::UNSPECIFIED,
+            state: "Idle",
+            uptime: String::from("never"),
+            timer: PeerParam::default(),
+            timer_sent: PeerParam::default(),
+            timer_recv: PeerParam::default(),
+            keepalive_timer_rem: None,
+            hold_timer_rem: None,
+            idle_hold_timer_rem: None,
+            idle_hold_timer_next: 0,
+            connect_retry_timer_rem: None,
+            cap_send: BgpCap::default(),
+            cap_recv: BgpCap::default(),
+            cap_map: CapAfiMap::new(),
+            count: HM::default(),
+            reflector_client: false,
+            soft_reconfig_in: false,
+            allowas_in: None,
+            as_override: false,
+            remove_private_as: None,
+            enforce_first_as: false,
+            encapsulation_type_ipv6: None,
+            ttl_security: false,
+            ebgp_multihop: None,
+            tcp_mss: None,
+            tcp_mss_synced: None,
+            disable_connected_check: false,
+            neighbor_group: None,
+            remote_as_inherited: false,
+            nd_discovered_secs_ago: None,
+            nd_refresh_count: None,
+            nd_refreshed_secs_ago: None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -4227,5 +4444,30 @@ impl Bgp {
             .path("/show/bgp/vrf/ipv6/longer-prefix")
             .set(show_bgp_vrf_not_running)
             .map();
+    }
+}
+
+#[cfg(test)]
+mod nd_elapsed_tests {
+    use super::format_nd_elapsed;
+
+    #[test]
+    fn seconds_only() {
+        assert_eq!(format_nd_elapsed(0), "0s");
+        assert_eq!(format_nd_elapsed(27), "27s");
+        assert_eq!(format_nd_elapsed(59), "59s");
+    }
+
+    #[test]
+    fn minutes_and_seconds() {
+        assert_eq!(format_nd_elapsed(60), "1m0s");
+        assert_eq!(format_nd_elapsed(331), "5m31s");
+        assert_eq!(format_nd_elapsed(3599), "59m59s");
+    }
+
+    #[test]
+    fn hours_minutes_seconds() {
+        assert_eq!(format_nd_elapsed(3600), "1h0m0s");
+        assert_eq!(format_nd_elapsed(3661), "1h1m1s");
     }
 }


### PR DESCRIPTION
## Summary

PR 4 of the IPv6 ND show-commands series (stacked on #1347; see `docs/design/nd-show-commands-plan.md` §2.4).

- `Peer` gains three display-only fields: `nd_discovered_at` (first `NeighborDiscovered` that materialized the peer), `nd_refreshed_at` (most recent), `nd_event_count`.
- `materialize_peer` stamps them via two pure helpers: the create path stamps discovery only when an RA-learned link-local is present; a dormant peer (configured before any RA arrived) is stamped by its first refresh instead.
- `show bgp neighbors` renders a block for interface-keyed peers, text + JSON:

  ```
  Interface peer: link-local learned via IPv6 ND router advertisement
  Discovered 5m31s ago, refreshed 12 times (last 27s ago)
  ```

  The refresh clause is omitted when no refresh has happened. Address-keyed peers are unaffected and carry none of the new JSON fields (`skip_serializing_if`, matching the view's convention).
- No session/update-group/PeerMap behavior changes — display-only plus three inert fields.

## Test plan

- 10 new unit tests: the `nd_mark_*` helper semantics (create / refresh / dormant-upgrade) on a hand-built `Peer`, the renderer (block absent for address-keyed, discovery-only form, full refresh form), JSON field presence/absence, and the elapsed-time formatter.
- `cargo test -p zebra-rs` → 1089 passed; full workspace suite green; clippy workspace clean; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)